### PR TITLE
fix(coding-agent): defer default-model discovery without blocking startup

### DIFF
--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -1747,6 +1747,7 @@ export async function runRootCommand(
 		sessionOptions.authStorage = authStorage;
 		sessionOptions.modelRegistry = modelRegistry;
 		sessionOptions.hasUI = isInteractive || mode === "rpc-ui";
+		sessionOptions.awaitDeferredModel = !isInteractive && mode !== "acp";
 		sessionOptions.settings = settingsInstance;
 
 		// OTEL: register global OTLP exporters when an endpoint is configured via

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -1746,8 +1746,13 @@ export async function runRootCommand(
 		);
 		sessionOptions.authStorage = authStorage;
 		sessionOptions.modelRegistry = modelRegistry;
-		sessionOptions.hasUI = isInteractive || mode === "rpc-ui";
-		sessionOptions.awaitDeferredModel = !isInteractive && mode !== "acp";
+		const hasInitialPrompt =
+			parsedArgs.messages.length > 0 ||
+			parsedArgs.fileArgs.length > 0 ||
+			parsedArgs.print ||
+			parsedArgs.mode === "rpc" ||
+			parsedArgs.mode === "rpc-ui";
+		sessionOptions.awaitDeferredModel = !isInteractive || hasInitialPrompt;
 		sessionOptions.settings = settingsInstance;
 
 		// OTEL: register global OTLP exporters when an endpoint is configured via

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -575,6 +575,8 @@ export interface CreateAgentSessionOptions {
 
 	/** Whether UI is available (enables interactive tools like ask). Default: false */
 	hasUI?: boolean;
+	/** Wait for deferred discovery before returning to headless callers. */
+	awaitDeferredModel?: boolean;
 	/**
 	 * A human can answer synchronous prompts even without a terminal UI (e.g. an
 	 * ACP client rendering elicitation forms). Enables `ask` without enabling
@@ -1476,7 +1478,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 		}),
 	);
 	let model = options.model;
-	let deferredModelResolution: Promise<Model | undefined> | undefined;
+	let deferredModelResolution: Promise<{ model: Model; thinkingLevel?: ConfiguredThinkingLevel } | undefined> | undefined;
 	let modelFallbackMessage: string | undefined;
 	let initialRetryFallback: InitialRetryFallbackState | undefined;
 	// Identify session model strings to restore in fallback order. We do an
@@ -2575,13 +2577,13 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 						.then(async () => {
 							if (model || hasExplicitModel) return undefined;
 							const resolved = await tryResolveDefaultRole();
-							return resolved ? model : pick;
+							return resolved ? { model: model!, thinkingLevel } : pick ? { model: pick } : undefined;
 						})
 						.catch(error => {
 							logger.warn("background model discovery failed", {
 								error: error instanceof Error ? error.message : String(error),
 							});
-							return pick;
+							return pick ? { model: pick } : undefined;
 						});
 				} else if (pick) {
 					model = pick;
@@ -2597,6 +2599,14 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 					patterns && patterns.length > 0
 						? `No model available matching enabledModels (${patterns.join(", ")}) with usable credentials. Configure auth for an allowed provider or adjust enabledModels.`
 						: "No models available. Use /login or set an API key environment variable. Then use /model to select a model.";
+			}
+		}
+		if (deferredModelResolution && options.awaitDeferredModel) {
+			const deferredModel = await deferredModelResolution;
+			if (deferredModel) {
+				model = deferredModel.model;
+				thinkingLevel = deferredModel.thinkingLevel ?? thinkingLevel;
+				modelFallbackMessage = undefined;
 			}
 		}
 
@@ -4080,22 +4090,15 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 		// `auto` matching the model's `code_mode_only` flag): the Agent above was
 		// handed the unrestricted `initialTools`, so without this the first and all
 		// subsequent turns would expose the full direct tool surface and omit
-		// `tool_namespaces_info` until an unrelated model/setting/tool-selection
-		// change reconciled.
-		try {
-			await session.initializeCodeMode();
-		} catch (error) {
-			logger.warn("Code Mode initialization at session startup failed", { error: String(error) });
-		}
-
 		void deferredModelResolution?.then(discovered => {
 			if (!discovered || session.model) return;
-			void session.setModelTemporary(discovered).catch(error => {
+			void session.setModelTemporary(discovered.model, discovered.thinkingLevel).catch(error => {
 				logger.warn("background model discovery model activation failed", {
 					error: error instanceof Error ? error.message : String(error),
 				});
 			});
 		});
+
 
 		return {
 			session,

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -4090,6 +4090,12 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 		// `auto` matching the model's `code_mode_only` flag): the Agent above was
 		// handed the unrestricted `initialTools`, so without this the first and all
 		// subsequent turns would expose the full direct tool surface and omit
+		try {
+			await session.initializeCodeMode();
+		} catch (error) {
+			logger.warn("Code Mode initialization at session startup failed", { error: String(error) });
+		}
+
 		void deferredModelResolution?.then(discovered => {
 			if (!discovered || session.model) return;
 			void session.setModelTemporary(discovered.model, discovered.thinkingLevel).catch(error => {

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -2573,8 +2573,8 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 						.refresh("online-if-uncached")
 						.then(async () => {
 							if (model || hasExplicitModel) return;
-							await tryResolveDefaultRole();
-							if (!model && pick) model = pick;
+							const resolved = await tryResolveDefaultRole();
+							if (!resolved && pick) model = pick;
 						})
 						.catch(error => {
 							logger.warn("background model discovery failed", {

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -2564,20 +2564,25 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 				const fallbackCandidates = await resolveAllowedModels(modelRegistry, settings, modelMatchPreferences);
 				const pick = pickDefaultAvailableModel(fallbackCandidates.filter(hasModelAuth));
 				const defaultRoleConfigured = Boolean(settings.getModelRole("default"));
-				// Never block session creation on remote model discovery. Static
-				// and cached catalogs are sufficient to start; background refresh
-				// updates the registry after startup and the first request reports
-				// an invalid explicitly configured model normally.
+				// Do not block startup on remote discovery. When a configured default
+				// is discovery-only, keep the session unselected rather than replacing
+				// the requested role with an unrelated provider fallback.
 				if (
 					!hasExplicitModel &&
 					(defaultRoleConfigured || !pick) &&
 					modelRegistry.getDiscoverableProviders().length > 0
 				) {
-					void modelRegistry.refresh("online-if-uncached").catch(error => {
-						logger.warn("background model discovery failed", {
-							error: error instanceof Error ? error.message : String(error),
+					void modelRegistry
+						.refresh("online-if-uncached")
+						.then(async () => {
+							if (model || hasExplicitModel) return;
+							await tryResolveDefaultRole();
+						})
+						.catch(error => {
+							logger.warn("background model discovery failed", {
+								error: error instanceof Error ? error.message : String(error),
+							});
 						});
-					});
 				}
 
 				if (!model && pick) {

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1476,6 +1476,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 		}),
 	);
 	let model = options.model;
+	let deferredModelResolution: Promise<Model | undefined> | undefined;
 	let modelFallbackMessage: string | undefined;
 	let initialRetryFallback: InitialRetryFallbackState | undefined;
 	// Identify session model strings to restore in fallback order. We do an
@@ -2569,17 +2570,18 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 					(defaultRoleConfigured || !pick) &&
 					modelRegistry.getDiscoverableProviders().length > 0;
 				if (canDiscoverDefault) {
-					void modelRegistry
+					deferredModelResolution = modelRegistry
 						.refresh("online-if-uncached")
 						.then(async () => {
-							if (model || hasExplicitModel) return;
+							if (model || hasExplicitModel) return undefined;
 							const resolved = await tryResolveDefaultRole();
-							if (!resolved && pick) model = pick;
+							return resolved ? model : pick;
 						})
 						.catch(error => {
 							logger.warn("background model discovery failed", {
 								error: error instanceof Error ? error.message : String(error),
 							});
+							return pick;
 						});
 				} else if (pick) {
 					model = pick;
@@ -4085,6 +4087,15 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 		} catch (error) {
 			logger.warn("Code Mode initialization at session startup failed", { error: String(error) });
 		}
+
+		void deferredModelResolution?.then(discovered => {
+			if (!discovered || session.model) return;
+			void session.setModelTemporary(discovered).catch(error => {
+				logger.warn("background model discovery model activation failed", {
+					error: error instanceof Error ? error.message : String(error),
+				});
+			});
+		});
 
 		return {
 			session,

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -2564,28 +2564,24 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 				const fallbackCandidates = await resolveAllowedModels(modelRegistry, settings, modelMatchPreferences);
 				const pick = pickDefaultAvailableModel(fallbackCandidates.filter(hasModelAuth));
 				const defaultRoleConfigured = Boolean(settings.getModelRole("default"));
-				// Do not block startup on remote discovery. When a configured default
-				// is discovery-only, keep the session unselected rather than replacing
-				// the requested role with an unrelated provider fallback.
-				if (
+				const canDiscoverDefault =
 					!hasExplicitModel &&
 					(defaultRoleConfigured || !pick) &&
-					modelRegistry.getDiscoverableProviders().length > 0
-				) {
+					modelRegistry.getDiscoverableProviders().length > 0;
+				if (canDiscoverDefault) {
 					void modelRegistry
 						.refresh("online-if-uncached")
 						.then(async () => {
 							if (model || hasExplicitModel) return;
 							await tryResolveDefaultRole();
+							if (!model && pick) model = pick;
 						})
 						.catch(error => {
 							logger.warn("background model discovery failed", {
 								error: error instanceof Error ? error.message : String(error),
 							});
 						});
-				}
-
-				if (!model && pick) {
+				} else if (pick) {
 					model = pick;
 				}
 			}

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -2562,36 +2562,22 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 
 			if (!model) {
 				const fallbackCandidates = await resolveAllowedModels(modelRegistry, settings, modelMatchPreferences);
-				let pick = pickDefaultAvailableModel(fallbackCandidates.filter(hasModelAuth));
-
-				// Cold-cache discovery race (issues #6114, #6162): a discovery
-				// provider (models.yml `openai-models-list`, LM Studio/Ollama/
-				// llama.cpp, or an openai-compat proxy) ships no static models, so
-				// the static+cached catalog resolved nothing above. Background
-				// discovery in main.ts fires only AFTER createAgentSession returns,
-				// so on a cache-cold boot the configured default stays unresolved
-				// and `pick` silently degrades to an unrelated authed provider's
-				// default (#6162) or "No models available" (#6114) — even though
-				// `omp models` (which awaits discovery) lists the model. Await one
-				// cache-aware discovery pass and retry when a default role is
-				// configured (must win over `pick`) or nothing resolved at all.
-				// The common path — role already resolved, or a `pick` with no
-				// configured default — never pays for it.
+				const pick = pickDefaultAvailableModel(fallbackCandidates.filter(hasModelAuth));
 				const defaultRoleConfigured = Boolean(settings.getModelRole("default"));
+				// Never block session creation on remote model discovery. Static
+				// and cached catalogs are sufficient to start; background refresh
+				// updates the registry after startup and the first request reports
+				// an invalid explicitly configured model normally.
 				if (
 					!hasExplicitModel &&
 					(defaultRoleConfigured || !pick) &&
 					modelRegistry.getDiscoverableProviders().length > 0
 				) {
-					await logger.time("resolveModelDiscoveryFallback", () => modelRegistry.refresh("online-if-uncached"));
-					if (!(await tryResolveDefaultRole()) && !model) {
-						const refreshedCandidates = await resolveAllowedModels(
-							modelRegistry,
-							settings,
-							modelMatchPreferences,
-						);
-						pick = pickDefaultAvailableModel(refreshedCandidates.filter(hasModelAuth));
-					}
+					void modelRegistry.refresh("online-if-uncached").catch(error => {
+						logger.warn("background model discovery failed", {
+							error: error instanceof Error ? error.message : String(error),
+						});
+					});
 				}
 
 				if (!model && pick) {

--- a/packages/coding-agent/test/sdk-model-selection.test.ts
+++ b/packages/coding-agent/test/sdk-model-selection.test.ts
@@ -1673,7 +1673,7 @@ describe("nonblocking default model discovery", () => {
 		const startedAt = performance.now();
 		const refresh = vi.spyOn(modelRegistry, "refresh").mockImplementation(() => new Promise<void>(() => {}));
 		try {
-			const { session, modelFallbackMessage } = await createAgentSession({
+			const { session } = await createAgentSession({
 				cwd,
 				agentDir: cwd,
 				authStorage,
@@ -1694,7 +1694,7 @@ describe("nonblocking default model discovery", () => {
 			});
 			try {
 				expect(performance.now() - startedAt).toBeLessThan(2_000);
-				expect(session.model).toBeDefined();
+				expect(session.model).toBeUndefined();
 				expect(refresh).toHaveBeenCalled();
 			} finally {
 				await session.dispose();
@@ -1704,4 +1704,46 @@ describe("nonblocking default model discovery", () => {
 			authStorage.close();
 		}
 	});
+});
+
+test("does not accept an unrelated fallback before discovery resolves the configured default", async () => {
+	const fallback = getBundledModel("anthropic", "claude-sonnet-4-5");
+	if (!fallback) return;
+	const authStorage = createInMemoryAuthStorage();
+	authStorage.setRuntimeApiKey(fallback.provider, "test-key");
+	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "omp-default-discovery-race-"));
+	const settings = Settings.isolated();
+	settings.setModelRole("default", "runtime-provider/discovery-model");
+	const modelRegistry = new ModelRegistry(authStorage, path.join(cwd, "models.yml"));
+	const release = Promise.withResolvers<void>();
+	const refresh = vi.spyOn(modelRegistry, "refresh").mockImplementation(async () => release.promise);
+	try {
+		const { session } = await createAgentSession({
+			cwd,
+			agentDir: cwd,
+			authStorage,
+			modelRegistry,
+			settings,
+			sessionManager: SessionManager.inMemory(),
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+			skipPythonPreflight: true,
+			rules: [],
+			preloadedCustomToolPaths: [],
+			toolNames: ["read"],
+		});
+		expect(refresh).toHaveBeenCalled();
+		expect(session.model?.provider).not.toBe(fallback.provider);
+		await session.dispose();
+	} finally {
+		release.resolve();
+		refresh.mockRestore();
+		authStorage.close();
+		fs.rmSync(cwd, { recursive: true, force: true });
+	}
 });

--- a/packages/coding-agent/test/sdk-model-selection.test.ts
+++ b/packages/coding-agent/test/sdk-model-selection.test.ts
@@ -1671,7 +1671,8 @@ describe("nonblocking default model discovery", () => {
 		const settings = Settings.isolated();
 		settings.setModelRole("default", "missing-provider/missing-model");
 		const startedAt = performance.now();
-		const refresh = vi.spyOn(modelRegistry, "refresh").mockImplementation(() => new Promise<void>(() => {}));
+		const refreshPending = Promise.withResolvers<void>();
+		const refresh = vi.spyOn(modelRegistry, "refresh").mockImplementation(() => refreshPending.promise);
 		try {
 			const { session } = await createAgentSession({
 				cwd,
@@ -1701,7 +1702,9 @@ describe("nonblocking default model discovery", () => {
 			}
 		} finally {
 			refresh.mockRestore();
+			refreshPending.resolve();
 			authStorage.close();
+			fs.rmSync(cwd, { recursive: true, force: true });
 		}
 	});
 });

--- a/packages/coding-agent/test/sdk-model-selection.test.ts
+++ b/packages/coding-agent/test/sdk-model-selection.test.ts
@@ -1662,3 +1662,46 @@ describe("createAgentSession deferred model pattern resolution", () => {
 		expect(cliOptions.model?.id).toBe(scopedTarget.id);
 	});
 });
+
+describe("nonblocking default model discovery", () => {
+	test("does not await remote discovery before creating a session", async () => {
+		const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "omp-nonblocking-discovery-"));
+		const authStorage = createInMemoryAuthStorage();
+		const modelRegistry = new ModelRegistry(authStorage, path.join(cwd, "models.yml"));
+		const settings = Settings.isolated();
+		settings.setModelRole("default", "missing-provider/missing-model");
+		const startedAt = performance.now();
+		const refresh = vi.spyOn(modelRegistry, "refresh").mockImplementation(() => new Promise<void>(() => {}));
+		try {
+			const { session, modelFallbackMessage } = await createAgentSession({
+				cwd,
+				agentDir: cwd,
+				authStorage,
+				modelRegistry,
+				settings,
+				sessionManager: SessionManager.inMemory(),
+				disableExtensionDiscovery: true,
+				skills: [],
+				contextFiles: [],
+				promptTemplates: [],
+				slashCommands: [],
+				enableMCP: false,
+				enableLsp: false,
+				skipPythonPreflight: true,
+				rules: [],
+				preloadedCustomToolPaths: [],
+				toolNames: ["read"],
+			});
+			try {
+				expect(performance.now() - startedAt).toBeLessThan(2_000);
+				expect(session.model).toBeDefined();
+				expect(refresh).toHaveBeenCalled();
+			} finally {
+				await session.dispose();
+			}
+		} finally {
+			refresh.mockRestore();
+			authStorage.close();
+		}
+	});
+});


### PR DESCRIPTION
## Summary

Keep startup responsive when the configured default model belongs to a discovery-only provider. The session retains the configured default as eligible, refreshes the catalog in the background, retries the configured default first, and only accepts an unrelated authenticated fallback when that retry cannot resolve a model.

## Scope

- Defer online discovery from the interactive startup path.
- Preserve explicit model selection and fallback precedence.
- Await deferred resolution for headless callers that require a concrete model before returning.
- Activate a model discovered after startup without mutating the initial UI path unsafely.
- Add focused SDK model-selection regression coverage.

This is intentionally separate from the modern ESM extension-loader change.