### PR TITLE
fix(coding-agent): refresh model hub from the online catalog

### DIFF
--- a/packages/coding-agent/src/modes/components/model-hub.ts
+++ b/packages/coding-agent/src/modes/components/model-hub.ts
@@ -277,7 +277,7 @@ export class ModelHubComponent implements Component {
 		// the synchronous hydration above.
 		if (this.#scopedModels.length === 0) {
 			this.#registry
-				.refresh("offline")
+				.refresh("online-if-uncached")
 				.then(() => this.#syncFromRegistryState())
 				.then(() => this.#reprobeHiddenOptionalProviders())
 				.catch(error => {

--- a/packages/coding-agent/src/modes/components/model-hub.ts
+++ b/packages/coding-agent/src/modes/components/model-hub.ts
@@ -277,7 +277,7 @@ export class ModelHubComponent implements Component {
 		// the synchronous hydration above.
 		if (this.#scopedModels.length === 0) {
 			this.#registry
-				.refresh("online-if-uncached")
+				.refresh("online")
 				.then(() => this.#syncFromRegistryState())
 				.then(() => this.#reprobeHiddenOptionalProviders())
 				.catch(error => {


### PR DESCRIPTION
## Summary

Refresh the model hub from the online catalog when it opens so newly discovered provider models are available in the interactive picker.

## Scope

This is intentionally separate from extension loading and deferred default-model discovery. The change is limited to the model-hub refresh mode and should be reviewed independently, including the hidden-provider re-probe behavior and associated rationale.