### PR TITLE
fix(coding-agent): preserve dynamic providers with static fallbacks

### DIFF
--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -2388,7 +2388,7 @@ export class ModelRegistry {
 				} else {
 					this.#invalidateProviderModelCache(providerName);
 				}
-				return;
+				if (!config.fetchDynamicModels) return;
 			}
 
 			// Update the unprojected snapshot, then rerun every whole-catalog
@@ -2409,7 +2409,7 @@ export class ModelRegistry {
 
 			this.#models = this.#applyRuntimeModelModifiers(this.#unprojectedModels);
 			this.#invalidateProviderModelCache(providerName);
-			return;
+			if (!config.fetchDynamicModels) return;
 		}
 
 		if (config.fetchDynamicModels) {


### PR DESCRIPTION
## Summary

Preserve dynamically discovered providers when static fallback models are also configured during registry refresh.

## Scope

This is intentionally isolated from the extension loader, deferred default-model discovery, and model-hub refresh changes. Please review the changed refresh-path precedence independently, with focused regression coverage added before merge.