### PR TITLE
fix(discovery): load config.yml extension roots for sub-discovery

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed extension packages configured via `extensions:` in `.omp/config.yml` not wiring their bundled `skills/`, `hooks/`, `tools/`, `commands/`, `rules/`, `prompts/`, and `.mcp.json` into discovery ([#9768](https://github.com/can1357/oh-my-pi/issues/9768)).
+
 ## [18.0.5] - 2026-08-25
 
 ### Added

--- a/packages/coding-agent/src/capability/index.ts
+++ b/packages/coding-agent/src/capability/index.ts
@@ -265,10 +265,7 @@ export async function loadCapability<T>(
 	const cwd = options.cwd ?? getProjectDir();
 	const home = os.homedir();
 	const repoRoot = await findRepoRoot(cwd);
-	const configuredExtensionPaths = settings?.get("extensions");
-	const ctx: LoadContext = configuredExtensionPaths
-		? { cwd, home, repoRoot, configuredExtensionPaths }
-		: { cwd, home, repoRoot };
+	const ctx: LoadContext = { cwd, home, repoRoot };
 	const providers = filterProviders(capability, options);
 
 	return await loadImpl(capability, providers, ctx, options);

--- a/packages/coding-agent/src/capability/index.ts
+++ b/packages/coding-agent/src/capability/index.ts
@@ -265,7 +265,10 @@ export async function loadCapability<T>(
 	const cwd = options.cwd ?? getProjectDir();
 	const home = os.homedir();
 	const repoRoot = await findRepoRoot(cwd);
-	const ctx: LoadContext = { cwd, home, repoRoot };
+	const configuredExtensionPaths = settings?.get("extensions");
+	const ctx: LoadContext = configuredExtensionPaths
+		? { cwd, home, repoRoot, configuredExtensionPaths }
+		: { cwd, home, repoRoot };
 	const providers = filterProviders(capability, options);
 
 	return await loadImpl(capability, providers, ctx, options);

--- a/packages/coding-agent/src/capability/index.ts
+++ b/packages/coding-agent/src/capability/index.ts
@@ -265,10 +265,9 @@ export async function loadCapability<T>(
 	const cwd = options.cwd ?? getProjectDir();
 	const home = os.homedir();
 	const repoRoot = await findRepoRoot(cwd);
-	const ctx: LoadContext =
-		options.configuredExtensionPaths !== undefined
-			? { cwd, home, repoRoot, configuredExtensionPaths: options.configuredExtensionPaths }
-			: { cwd, home, repoRoot };
+	const ctx: LoadContext = { cwd, home, repoRoot };
+	if (options.configuredExtensionPaths !== undefined) ctx.configuredExtensionPaths = options.configuredExtensionPaths;
+	if (options.extensionRootMode !== undefined) ctx.extensionRootMode = options.extensionRootMode;
 	const providers = filterProviders(capability, options);
 
 	return await loadImpl(capability, providers, ctx, options);

--- a/packages/coding-agent/src/capability/index.ts
+++ b/packages/coding-agent/src/capability/index.ts
@@ -265,7 +265,10 @@ export async function loadCapability<T>(
 	const cwd = options.cwd ?? getProjectDir();
 	const home = os.homedir();
 	const repoRoot = await findRepoRoot(cwd);
-	const ctx: LoadContext = { cwd, home, repoRoot };
+	const ctx: LoadContext =
+		options.configuredExtensionPaths !== undefined
+			? { cwd, home, repoRoot, configuredExtensionPaths: options.configuredExtensionPaths }
+			: { cwd, home, repoRoot };
 	const providers = filterProviders(capability, options);
 
 	return await loadImpl(capability, providers, ctx, options);

--- a/packages/coding-agent/src/capability/index.ts
+++ b/packages/coding-agent/src/capability/index.ts
@@ -266,8 +266,7 @@ export async function loadCapability<T>(
 	const home = os.homedir();
 	const repoRoot = await findRepoRoot(cwd);
 	const ctx: LoadContext = { cwd, home, repoRoot };
-	if (options.configuredExtensionPaths !== undefined) ctx.configuredExtensionPaths = options.configuredExtensionPaths;
-	if (options.extensionRootMode !== undefined) ctx.extensionRootMode = options.extensionRootMode;
+	if (options.extensionRoots !== undefined) ctx.extensionRoots = options.extensionRoots;
 	const providers = filterProviders(capability, options);
 
 	return await loadImpl(capability, providers, ctx, options);

--- a/packages/coding-agent/src/capability/types.ts
+++ b/packages/coding-agent/src/capability/types.ts
@@ -82,6 +82,13 @@ export interface LoadOptions<T = unknown> {
 	/** Explicit disabled extension IDs to apply instead of settings. */
 	disabledExtensions?: string[];
 	/**
+	 * Effective `extensions` setting for this load, forwarded to
+	 * {@link LoadContext.configuredExtensionPaths}. Post-startup reloads (e.g.
+	 * `refreshSkills`) MUST pass their live session value so overlay/override
+	 * extensions survive outside the construction-time invocation scope.
+	 */
+	configuredExtensionPaths?: readonly string[];
+	/**
 	 * Drop items before deduplication as if they never existed (e.g. scope
 	 * exclusions). A dropped item neither survives nor claims its dedupe key,
 	 * so it cannot shadow anything. Receives the item with its attached

--- a/packages/coding-agent/src/capability/types.ts
+++ b/packages/coding-agent/src/capability/types.ts
@@ -14,13 +14,16 @@ export type ExtensionRootMode = "merge" | "explicit-only";
  * so no dimension is lost between the construction-time invocation scope and
  * post-startup reloads. `explicit` are the SDK `additionalExtensionPaths` / CLI
  * `--extension` roots (always active, user-level); `configured` is the live
- * `extensions:` setting (ambient, only in `merge` mode, provenance resolved
- * against the persisted config); `mode` gates the ambient/installed sources.
+ * `extensions:` setting (ambient, only in `merge` mode); `configuredLevel` is
+ * its provenance as resolved by `Settings` (the authority — includes foreign
+ * project providers like `.claude/settings.json`, never re-derived from `.omp`
+ * on disk); `mode` gates the ambient/installed sources.
  */
 export interface EffectiveExtensionRoots {
 	explicit: readonly string[];
 	mode: ExtensionRootMode;
 	configured: readonly string[];
+	configuredLevel: "user" | "project";
 }
 
 /**

--- a/packages/coding-agent/src/capability/types.ts
+++ b/packages/coding-agent/src/capability/types.ts
@@ -25,6 +25,13 @@ export interface LoadContext {
 	 * the invocation scope so concurrent sessions stay isolated.
 	 */
 	configuredExtensionPaths?: readonly string[];
+	/**
+	 * Extension discovery mode for this load. `explicit-only` (from an SDK
+	 * `disableExtensionDiscovery` session) restricts sub-discovery to
+	 * {@link configuredExtensionPaths} — no ambient `extensions:`, installed
+	 * plugins, or disk config. Defaults to `merge` when unset.
+	 */
+	extensionRootMode?: "merge" | "explicit-only";
 }
 
 /**
@@ -88,6 +95,8 @@ export interface LoadOptions<T = unknown> {
 	 * extensions survive outside the construction-time invocation scope.
 	 */
 	configuredExtensionPaths?: readonly string[];
+	/** Extension discovery mode, forwarded to {@link LoadContext.extensionRootMode}. */
+	extensionRootMode?: "merge" | "explicit-only";
 	/**
 	 * Drop items before deduplication as if they never existed (e.g. scope
 	 * exclusions). A dropped item neither survives nor claims its dedupe key,

--- a/packages/coding-agent/src/capability/types.ts
+++ b/packages/coding-agent/src/capability/types.ts
@@ -6,6 +6,23 @@
  * a unified array of MCP servers.
  */
 
+/** Extension sub-discovery mode; `explicit-only` suppresses ambient sources. */
+export type ExtensionRootMode = "merge" | "explicit-only";
+
+/**
+ * Session-local extension-root inputs for sub-discovery, threaded as one value
+ * so no dimension is lost between the construction-time invocation scope and
+ * post-startup reloads. `explicit` are the SDK `additionalExtensionPaths` / CLI
+ * `--extension` roots (always active, user-level); `configured` is the live
+ * `extensions:` setting (ambient, only in `merge` mode, provenance resolved
+ * against the persisted config); `mode` gates the ambient/installed sources.
+ */
+export interface EffectiveExtensionRoots {
+	explicit: readonly string[];
+	mode: ExtensionRootMode;
+	configured: readonly string[];
+}
+
 /**
  * Context passed to every provider loader.
  */
@@ -17,21 +34,13 @@ export interface LoadContext {
 	/** Git repository root (directory containing .git), or null if not in a repo */
 	repoRoot: string | null;
 	/**
-	 * Effective `extensions` setting supplied explicitly by a direct caller
-	 * (e.g. {@link ../task/discovery.discoverAgents}) that already holds its own
-	 * session's `Settings`. When set, extension sub-discovery uses it instead of
-	 * the invocation-scoped snapshot or the persisted config on disk. Left unset
-	 * by {@link loadCapability}; SDK sessions route their effective value through
-	 * the invocation scope so concurrent sessions stay isolated.
+	 * Session-local extension roots for sub-discovery. When set, extension
+	 * discovery uses these lanes instead of the invocation-scoped snapshot or
+	 * the process defaults, so post-startup reloads stay byte-identical to the
+	 * construction-time scoped load. Left unset by {@link loadCapability}; SDK
+	 * sessions carry their value explicitly (or via the invocation scope).
 	 */
-	configuredExtensionPaths?: readonly string[];
-	/**
-	 * Extension discovery mode for this load. `explicit-only` (from an SDK
-	 * `disableExtensionDiscovery` session) restricts sub-discovery to
-	 * {@link configuredExtensionPaths} — no ambient `extensions:`, installed
-	 * plugins, or disk config. Defaults to `merge` when unset.
-	 */
-	extensionRootMode?: "merge" | "explicit-only";
+	extensionRoots?: EffectiveExtensionRoots;
 }
 
 /**
@@ -89,14 +98,12 @@ export interface LoadOptions<T = unknown> {
 	/** Explicit disabled extension IDs to apply instead of settings. */
 	disabledExtensions?: string[];
 	/**
-	 * Effective `extensions` setting for this load, forwarded to
-	 * {@link LoadContext.configuredExtensionPaths}. Post-startup reloads (e.g.
-	 * `refreshSkills`) MUST pass their live session value so overlay/override
-	 * extensions survive outside the construction-time invocation scope.
+	 * Session-local extension roots for this load, forwarded to
+	 * {@link LoadContext.extensionRoots}. Post-startup reloads MUST pass their
+	 * live session value so explicit roots, discovery mode, and configured
+	 * extensions all survive outside the construction-time invocation scope.
 	 */
-	configuredExtensionPaths?: readonly string[];
-	/** Extension discovery mode, forwarded to {@link LoadContext.extensionRootMode}. */
-	extensionRootMode?: "merge" | "explicit-only";
+	extensionRoots?: EffectiveExtensionRoots;
 	/**
 	 * Drop items before deduplication as if they never existed (e.g. scope
 	 * exclusions). A dropped item neither survives nor claims its dedupe key,

--- a/packages/coding-agent/src/capability/types.ts
+++ b/packages/coding-agent/src/capability/types.ts
@@ -17,9 +17,12 @@ export interface LoadContext {
 	/** Git repository root (directory containing .git), or null if not in a repo */
 	repoRoot: string | null;
 	/**
-	 * Effective `extensions` setting for this capability load. When present,
-	 * extension sub-discovery MUST use it instead of reconstructing settings
-	 * layers from disk.
+	 * Effective `extensions` setting supplied explicitly by a direct caller
+	 * (e.g. {@link ../task/discovery.discoverAgents}) that already holds its own
+	 * session's `Settings`. When set, extension sub-discovery uses it instead of
+	 * the invocation-scoped snapshot or the persisted config on disk. Left unset
+	 * by {@link loadCapability}; SDK sessions route their effective value through
+	 * the invocation scope so concurrent sessions stay isolated.
 	 */
 	configuredExtensionPaths?: readonly string[];
 }

--- a/packages/coding-agent/src/capability/types.ts
+++ b/packages/coding-agent/src/capability/types.ts
@@ -16,6 +16,12 @@ export interface LoadContext {
 	home: string;
 	/** Git repository root (directory containing .git), or null if not in a repo */
 	repoRoot: string | null;
+	/**
+	 * Effective `extensions` setting for this capability load. When present,
+	 * extension sub-discovery MUST use it instead of reconstructing settings
+	 * layers from disk.
+	 */
+	configuredExtensionPaths?: readonly string[];
 }
 
 /**

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -852,6 +852,22 @@ export class Settings {
 	}
 
 	/**
+	 * Provenance of the effective `extensions` array for extension-root
+	 * sub-discovery. `"project"` only when a project settings provider owns it
+	 * (any of `.omp/config.yml`, `.omp/settings.json`, `.claude/settings.json`,
+	 * … — all merged into the project layer) and no higher user-level layer (a
+	 * `--config` overlay or a runtime override) replaces it; otherwise `"user"`.
+	 * Callers pass this into {@link EffectiveExtensionRoots.configuredLevel} so
+	 * discovery labels roots by the authority that produced them rather than
+	 * re-deriving provenance from a partial disk scan.
+	 */
+	extensionsSourceLevel(): "user" | "project" {
+		if (Object.hasOwn(this.#overrides, "extensions")) return "user";
+		if (Object.hasOwn(this.#configOverlay, "extensions")) return "user";
+		return Object.hasOwn(this.#project, "extensions") ? "project" : "user";
+	}
+
+	/**
 	 * Get all settings in a group with full type safety.
 	 */
 	getGroup<G extends GroupPrefix>(prefix: G): GroupTypeMap[G] {

--- a/packages/coding-agent/src/discovery/omp-extension-roots.ts
+++ b/packages/coding-agent/src/discovery/omp-extension-roots.ts
@@ -58,6 +58,8 @@ interface InvocationRootScope {
 	 * to reading the persisted config from disk.
 	 */
 	configuredExtensions?: readonly string[];
+	/** Provenance of {@link configuredExtensions}, from `Settings`. Defaults to `user` when unset. */
+	configuredLevel?: "user" | "project";
 }
 
 const invocationRootScope = new AsyncLocalStorage<InvocationRootScope>();
@@ -91,15 +93,18 @@ export function withOmpExtensionRootScope<T>(
 }
 
 /**
- * Record the owning session's effective `extensions` setting on the active
- * invocation scope so sub-discovery honors overlays and runtime overrides
- * without reading the process-global settings singleton (which the most
- * recently initialized session would otherwise clobber). No-op outside a
- * {@link withOmpExtensionRootScope} callback.
+ * Record the owning session's effective `extensions` setting (and its
+ * `Settings`-resolved provenance) on the active invocation scope so
+ * sub-discovery honors overlays/runtime overrides and foreign project
+ * providers without reading the process-global settings singleton. No-op
+ * outside a {@link withOmpExtensionRootScope} callback.
  */
-export function setInvocationConfiguredExtensions(paths: readonly string[]): void {
+export function setInvocationConfiguredExtensions(paths: readonly string[], level: "user" | "project" = "user"): void {
 	const scope = invocationRootScope.getStore();
-	if (scope) scope.configuredExtensions = [...paths];
+	if (scope) {
+		scope.configuredExtensions = [...paths];
+		scope.configuredLevel = level;
+	}
 }
 
 /**
@@ -259,9 +264,11 @@ async function isDirectory(p: string): Promise<boolean> {
  * 1. Explicit lane — `explicit` roots (SDK `additionalExtensionPaths` / CLI
  *    `--extension`). Always active, always user-level.
  * 2. Configured lane — the effective `extensions:` setting, added only in
- *    `merge` mode. Its provenance is resolved against the persisted config, so
- *    a project-configured package is labeled `project` (kept separate from the
- *    explicit lane precisely so this comparison is not polluted).
+ *    `merge` mode. Its provenance (`configuredLevel`) is carried from
+ *    `Settings` (the authority that merges every project provider, incl.
+ *    `.claude/settings.json`, and honors overlays/overrides), never re-derived
+ *    from a partial `.omp` disk scan; scopeless callers read the persisted
+ *    `.omp` config, which supplies its own level.
  * 3. Installed npm/link plugins under `<plugins>/node_modules/`, added only in
  *    `merge` mode. Marketplace installs load via the `claude-plugins` provider.
  *
@@ -287,24 +294,22 @@ export async function listOmpExtensionRoots(ctx: LoadContext): Promise<OmpExtens
 	const rootMode: OmpExtensionRootMode = ctx.extensionRoots?.mode ?? scopedRoots?.mode ?? injectedCliRootMode;
 	let candidates: InjectedRoot[] = explicitSeed;
 	if (rootMode === "merge") {
-		const [persisted, installedPlugins] = await Promise.all([
-			readConfiguredExtensions(ctx),
-			listInstalledPluginRoots(ctx),
-		]);
-		// Configured lane: caller value, else the invocation-scoped snapshot,
-		// else the persisted config on disk. Compared unpolluted against the
-		// persisted array so project provenance survives.
+		const installedPlugins = await listInstalledPluginRoots(ctx);
+		// Configured lane. When a session supplies the effective value (reload
+		// struct or invocation-scoped snapshot), its provenance came from
+		// `Settings` — the authority that merges every project provider (incl.
+		// `.claude/settings.json`) and honors overlays/overrides — so trust the
+		// carried `configuredLevel` verbatim. When no session value is present,
+		// read the persisted `.omp` config on disk, which is the authoritative
+		// source (and its own provenance) in that scopeless path.
 		const configuredEntries = ctx.extensionRoots?.configured ?? scopedRoots?.configuredExtensions;
 		const configured =
 			configuredEntries !== undefined
 				? {
 						entries: [...configuredEntries],
-						level:
-							persisted && Bun.deepEquals(configuredEntries, persisted.entries)
-								? persisted.level
-								: ("user" as const),
+						level: ctx.extensionRoots?.configuredLevel ?? scopedRoots?.configuredLevel ?? ("user" as const),
 					}
-				: persisted;
+				: await readConfiguredExtensions(ctx);
 		candidates = [
 			...candidates,
 			...(configured?.entries.map(

--- a/packages/coding-agent/src/discovery/omp-extension-roots.ts
+++ b/packages/coding-agent/src/discovery/omp-extension-roots.ts
@@ -270,7 +270,10 @@ async function isDirectory(p: string): Promise<boolean> {
  */
 export async function listOmpExtensionRoots(ctx: LoadContext): Promise<OmpExtensionRoot[]> {
 	const scopedRoots = invocationRootScope.getStore();
-	const rootMode = scopedRoots?.mode ?? injectedCliRootMode;
+	// Post-startup reloads run outside `withOmpExtensionRootScope`; the caller
+	// carries the session's discovery mode on the LoadContext so an
+	// `explicit-only` session never re-merges ambient/installed roots on refresh.
+	const rootMode = ctx.extensionRootMode ?? scopedRoots?.mode ?? injectedCliRootMode;
 	let candidates: InjectedRoot[] = scopedRoots
 		? scopedRoots.paths.map(raw => ({ path: resolveAgainst(raw, ctx), level: "user" }))
 		: injectedCliRoots.map(root =>
@@ -299,6 +302,15 @@ export async function listOmpExtensionRoots(ctx: LoadContext): Promise<OmpExtens
 				(raw): InjectedRoot => ({ path: resolveAgainst(raw, ctx), level: configured.level }),
 			) ?? []),
 			...installedPlugins,
+		];
+	} else if (ctx.configuredExtensionPaths !== undefined) {
+		// `explicit-only` reload outside the scope: honor exactly the caller's
+		// roots — no ambient `extensions:`, installed plugins, or disk config.
+		candidates = [
+			...candidates,
+			...ctx.configuredExtensionPaths.map(
+				(raw): InjectedRoot => ({ path: resolveAgainst(raw, ctx), level: "user" }),
+			),
 		];
 	}
 

--- a/packages/coding-agent/src/discovery/omp-extension-roots.ts
+++ b/packages/coding-agent/src/discovery/omp-extension-roots.ts
@@ -21,7 +21,7 @@ import * as path from "node:path";
 import { getAgentDir, isEnoent, logger, MAIN_CONFIG_FILENAMES, tryParseJson } from "@oh-my-pi/pi-utils";
 import { YAML } from "bun";
 import { readDirEntries, readFile } from "../capability/fs";
-import type { LoadContext } from "../capability/types";
+import type { ExtensionRootMode, LoadContext } from "../capability/types";
 import { getEnabledPlugins } from "../extensibility/plugins/loader";
 import { expandTilde } from "../tools/path-utils";
 import { listClaudePluginRoots } from "./helpers";
@@ -43,7 +43,8 @@ interface InjectedRoot {
 	level: "user" | "project";
 }
 
-export type OmpExtensionRootMode = "merge" | "explicit-only";
+/** Extension sub-discovery mode; re-exported alias of {@link ExtensionRootMode}. */
+export type OmpExtensionRootMode = ExtensionRootMode;
 
 interface InvocationRootScope {
 	/** Raw SDK spellings, resolved against the LoadContext that performs discovery. */
@@ -250,50 +251,58 @@ async function isDirectory(p: string): Promise<boolean> {
 /**
  * Resolve every configured extension package directory for the given context.
  *
- * Sources, in order of precedence:
+ * Sources are threaded as one `EffectiveExtensionRoots` value — from
+ * `ctx.extensionRoots` (a post-startup reload), else the invocation scope
+ * (a construction-time load), else the process defaults (CLI injection + disk).
+ * The three lanes stay separate so no dimension is lost:
  *
- * 1. Invocation-scoped SDK roots, when present; otherwise CLI roots injected
- *    via {@link injectOmpExtensionCliRoots}
- * 2. The effective configured `extensions` array. SDK sessions record their
- *    live `Settings` value on the invocation scope via
- *    {@link setInvocationConfiguredExtensions} (honoring overlays and runtime
- *    overrides); scopeless callers fall back to persisted array-replacement
- *    precedence read from disk.
- * 3. Enabled npm/link plugins installed under `<plugins>/node_modules/` (for
- *    `omp install <pkg>` / `omp plugin install` / `omp plugin link`). Marketplace
- *    installs are loaded by the `claude-plugins` provider and are excluded here.
+ * 1. Explicit lane — `explicit` roots (SDK `additionalExtensionPaths` / CLI
+ *    `--extension`). Always active, always user-level.
+ * 2. Configured lane — the effective `extensions:` setting, added only in
+ *    `merge` mode. Its provenance is resolved against the persisted config, so
+ *    a project-configured package is labeled `project` (kept separate from the
+ *    explicit lane precisely so this comparison is not polluted).
+ * 3. Installed npm/link plugins under `<plugins>/node_modules/`, added only in
+ *    `merge` mode. Marketplace installs load via the `claude-plugins` provider.
+ *
+ * `explicit-only` mode (an SDK `disableExtensionDiscovery` session) contributes
+ * the explicit lane alone — no ambient `extensions:`, installed plugins, or
+ * disk config — identically inside and outside the construction scope.
+ *
  * Only entries that resolve to a directory on disk are returned; file
  * entrypoints contribute zero sub-discovery surface and are filtered out.
- * Installed-plugin enumeration failures (missing lockfile, unreadable
- * `package.json`, etc.) are logged at `debug` and degrade gracefully — the
- * other sources still surface.
+ * Installed-plugin enumeration failures degrade gracefully at `debug`.
  */
 export async function listOmpExtensionRoots(ctx: LoadContext): Promise<OmpExtensionRoot[]> {
 	const scopedRoots = invocationRootScope.getStore();
-	// Post-startup reloads run outside `withOmpExtensionRootScope`; the caller
-	// carries the session's discovery mode on the LoadContext so an
-	// `explicit-only` session never re-merges ambient/installed roots on refresh.
-	const rootMode = ctx.extensionRootMode ?? scopedRoots?.mode ?? injectedCliRootMode;
-	let candidates: InjectedRoot[] = scopedRoots
-		? scopedRoots.paths.map(raw => ({ path: resolveAgainst(raw, ctx), level: "user" }))
-		: injectedCliRoots.map(root =>
-				root.relativePath ? { ...root, path: path.resolve(ctx.cwd, root.relativePath) } : root,
-			);
+	// Explicit lane, in precedence order: caller-provided reload value, then the
+	// construction-time invocation scope, then process-level CLI injection.
+	const explicitSeed: InjectedRoot[] = ctx.extensionRoots
+		? ctx.extensionRoots.explicit.map(raw => ({ path: resolveAgainst(raw, ctx), level: "user" }))
+		: scopedRoots
+			? scopedRoots.paths.map(raw => ({ path: resolveAgainst(raw, ctx), level: "user" }))
+			: injectedCliRoots.map(root =>
+					root.relativePath ? { ...root, path: path.resolve(ctx.cwd, root.relativePath) } : root,
+				);
+	const rootMode: OmpExtensionRootMode = ctx.extensionRoots?.mode ?? scopedRoots?.mode ?? injectedCliRootMode;
+	let candidates: InjectedRoot[] = explicitSeed;
 	if (rootMode === "merge") {
 		const [persisted, installedPlugins] = await Promise.all([
 			readConfiguredExtensions(ctx),
 			listInstalledPluginRoots(ctx),
 		]);
-		// Prefer the session's effective `extensions` (explicit ctx value, else
-		// the invocation-scoped snapshot) so overlays and runtime overrides win;
-		// scopeless callers fall back to the persisted config read from disk.
-		const effective = ctx.configuredExtensionPaths ?? scopedRoots?.configuredExtensions;
+		// Configured lane: caller value, else the invocation-scoped snapshot,
+		// else the persisted config on disk. Compared unpolluted against the
+		// persisted array so project provenance survives.
+		const configuredEntries = ctx.extensionRoots?.configured ?? scopedRoots?.configuredExtensions;
 		const configured =
-			effective !== undefined
+			configuredEntries !== undefined
 				? {
-						entries: [...effective],
+						entries: [...configuredEntries],
 						level:
-							persisted && Bun.deepEquals(effective, persisted.entries) ? persisted.level : ("user" as const),
+							persisted && Bun.deepEquals(configuredEntries, persisted.entries)
+								? persisted.level
+								: ("user" as const),
 					}
 				: persisted;
 		candidates = [
@@ -302,15 +311,6 @@ export async function listOmpExtensionRoots(ctx: LoadContext): Promise<OmpExtens
 				(raw): InjectedRoot => ({ path: resolveAgainst(raw, ctx), level: configured.level }),
 			) ?? []),
 			...installedPlugins,
-		];
-	} else if (ctx.configuredExtensionPaths !== undefined) {
-		// `explicit-only` reload outside the scope: honor exactly the caller's
-		// roots — no ambient `extensions:`, installed plugins, or disk config.
-		candidates = [
-			...candidates,
-			...ctx.configuredExtensionPaths.map(
-				(raw): InjectedRoot => ({ path: resolveAgainst(raw, ctx), level: "user" }),
-			),
 		];
 	}
 

--- a/packages/coding-agent/src/discovery/omp-extension-roots.ts
+++ b/packages/coding-agent/src/discovery/omp-extension-roots.ts
@@ -8,10 +8,9 @@
  * `prompts/`, `.mcp.json`) are wired into discovery by `omp-plugins.ts`.
  *
  * CLI-provided paths are injected via {@link injectOmpExtensionCliRoots}
- * before discovery runs; settings paths are read lazily in
- * {@link listOmpExtensionRoots} from each scope's canonical `config.yml`
- * (`config.yaml` at user scope) *and* legacy `settings.json`, mirroring the
- * merged `extensions:` that `loadExtensionModules` loads via `settings.get`.
+ * before discovery runs. Capability loads supply the effective `extensions`
+ * setting; direct callers reconstruct its array-replacement precedence from
+ * canonical YAML config and legacy `settings.json`.
  *
  * @see ./omp-plugins.ts
  * @see ./builtin.ts `loadExtensionModules`
@@ -139,24 +138,31 @@ function scopeDirs(ctx: LoadContext): ScopeDirs {
 	};
 }
 
-async function readSettingsExtensions(settingsPath: string): Promise<string[]> {
-	const content = await readFile(settingsPath);
-	if (!content) return [];
-	const parsed = tryParseJson<{ extensions?: unknown }>(content);
-	const raw = parsed?.extensions;
-	if (!Array.isArray(raw)) return [];
+function readExtensionsArray(raw: unknown): string[] | null {
+	if (!Array.isArray(raw)) return null;
 	return raw.filter((entry): entry is string => typeof entry === "string" && entry.length > 0);
+}
+
+async function readSettingsExtensions(settingsPath: string): Promise<string[] | null> {
+	const content = await readFile(settingsPath);
+	if (!content) return null;
+	const parsed = tryParseJson<{ extensions?: unknown }>(content);
+	return readExtensionsArray(parsed?.extensions);
 }
 
 /** Project native config filename; matches the single `.omp/config.yml` the settings loader reads. */
 const PROJECT_CONFIG_FILENAMES = ["config.yml"] as const;
 
+interface YamlExtensions {
+	exists: boolean;
+	entries: string[] | null;
+}
+
 /**
- * Read the `extensions:` array from a scope's canonical YAML config. The first
- * present filename wins (mirroring the settings loader), and a present-but-
- * malformed file yields no entries rather than throwing.
+ * Read the first present YAML config filename, matching the settings loader's
+ * `config.yml` before `config.yaml` selection.
  */
-async function readYamlExtensions(scopeDir: string, filenames: readonly string[]): Promise<string[]> {
+async function readYamlExtensions(scopeDir: string, filenames: readonly string[]): Promise<YamlExtensions> {
 	for (const filename of filenames) {
 		const content = await readFile(path.join(scopeDir, filename));
 		if (content === null) continue;
@@ -164,30 +170,42 @@ async function readYamlExtensions(scopeDir: string, filenames: readonly string[]
 		try {
 			parsed = YAML.parse(content);
 		} catch {
-			return [];
+			return { exists: true, entries: null };
 		}
-		if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) return [];
-		if (!("extensions" in parsed)) return [];
-		const raw = parsed.extensions;
-		if (!Array.isArray(raw)) return [];
-		return raw.filter((entry): entry is string => typeof entry === "string" && entry.length > 0);
+		if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+			return { exists: true, entries: null };
+		}
+		const raw = "extensions" in parsed ? parsed.extensions : undefined;
+		return { exists: true, entries: readExtensionsArray(raw) };
 	}
-	return [];
+	return { exists: false, entries: null };
+}
+
+interface ConfiguredExtensions {
+	entries: string[];
+	level: "user" | "project";
 }
 
 /**
- * Merge a scope's configured extension paths from both surfaces that feed
- * `settings.get("extensions")`: the canonical `config.yml`/`config.yaml` and
- * the legacy `settings.json`. Reading only the latter left `config.yml`-only
- * extensions loading their module while their `skills/`, `hooks/`, etc. never
- * reached discovery (#9768). Duplicate paths are dropped downstream.
+ * Select the persisted `extensions` array with the same array-replacement
+ * precedence as `Settings`: project YAML, project legacy settings, user YAML,
+ * then user legacy settings. A present user YAML config suppresses its legacy
+ * migration source even when it omits `extensions`.
  */
-async function readScopeExtensions(scopeDir: string, configFilenames: readonly string[]): Promise<string[]> {
-	const [fromConfig, fromSettings] = await Promise.all([
-		readYamlExtensions(scopeDir, configFilenames),
-		readSettingsExtensions(path.join(scopeDir, "settings.json")),
+async function readConfiguredExtensions(ctx: LoadContext): Promise<ConfiguredExtensions | null> {
+	const { project, user } = scopeDirs(ctx);
+	const [projectYaml, projectSettings, userYaml, userSettings] = await Promise.all([
+		readYamlExtensions(project, PROJECT_CONFIG_FILENAMES),
+		readSettingsExtensions(path.join(project, "settings.json")),
+		readYamlExtensions(user, MAIN_CONFIG_FILENAMES),
+		readSettingsExtensions(path.join(user, "settings.json")),
 	]);
-	return [...fromConfig, ...fromSettings];
+	if (projectYaml.entries !== null) return { entries: projectYaml.entries, level: "project" };
+	if (projectSettings !== null) return { entries: projectSettings, level: "project" };
+	if (userYaml.entries !== null) return { entries: userYaml.entries, level: "user" };
+	if (userYaml.exists) return null;
+	if (userSettings !== null) return { entries: userSettings, level: "user" };
+	return null;
 }
 
 function resolveAgainst(raw: string, ctx: LoadContext): string {
@@ -212,14 +230,14 @@ async function isDirectory(p: string): Promise<boolean> {
 /**
  * Resolve every configured extension package directory for the given context.
  *
- * Sources, in order of precedence (later entries with the same absolute path
- * are dropped):
+ * Sources, in order of precedence:
  *
  * 1. Invocation-scoped SDK roots, when present; otherwise CLI roots injected
  *    via {@link injectOmpExtensionCliRoots}
- * 2. Project `<cwd>/.omp/config.yml#extensions`, then `.omp/settings.json#extensions`
- * 3. User `~/.omp/agent/config.{yml,yaml}#extensions`, then `settings.json#extensions`
- * 4. Enabled npm/link plugins installed under `<plugins>/node_modules/` (for
+ * 2. The effective configured `extensions` array. Capability loads pass the
+ *    active `Settings` value (including overlays and runtime overrides);
+ *    direct callers fall back to persisted array-replacement precedence.
+ * 3. Enabled npm/link plugins installed under `<plugins>/node_modules/` (for
  *    `omp install <pkg>` / `omp plugin install` / `omp plugin link`). Marketplace
  *    installs are loaded by the `claude-plugins` provider and are excluded here.
  * Only entries that resolve to a directory on disk are returned; file
@@ -237,21 +255,30 @@ export async function listOmpExtensionRoots(ctx: LoadContext): Promise<OmpExtens
 				root.relativePath ? { ...root, path: path.resolve(ctx.cwd, root.relativePath) } : root,
 			);
 	if (rootMode === "merge") {
-		const { project, user } = scopeDirs(ctx);
-		const [projectExtensions, userExtensions, installedPlugins] = await Promise.all([
-			readScopeExtensions(project, PROJECT_CONFIG_FILENAMES),
-			readScopeExtensions(user, MAIN_CONFIG_FILENAMES),
+		const [persisted, installedPlugins] = await Promise.all([
+			readConfiguredExtensions(ctx),
 			listInstalledPluginRoots(ctx),
 		]);
+		const configured =
+			ctx.configuredExtensionPaths !== undefined
+				? {
+						entries: [...ctx.configuredExtensionPaths],
+						level:
+							persisted && Bun.deepEquals(ctx.configuredExtensionPaths, persisted.entries)
+								? persisted.level
+								: ("user" as const),
+					}
+				: persisted;
 		candidates = [
 			...candidates,
-			...projectExtensions.map((raw): InjectedRoot => ({ path: resolveAgainst(raw, ctx), level: "project" })),
-			...userExtensions.map((raw): InjectedRoot => ({ path: resolveAgainst(raw, ctx), level: "user" })),
+			...(configured?.entries.map(
+				(raw): InjectedRoot => ({ path: resolveAgainst(raw, ctx), level: configured.level }),
+			) ?? []),
 			...installedPlugins,
 		];
 	}
 
-	// First-seen-wins dedup preserves invocation/CLI > project-settings > user-settings > installed precedence.
+	// First-seen-wins dedup preserves invocation/CLI > configured settings > installed precedence.
 	const seen = new Set<string>();
 	const unique: InjectedRoot[] = [];
 	for (const candidate of candidates) {

--- a/packages/coding-agent/src/discovery/omp-extension-roots.ts
+++ b/packages/coding-agent/src/discovery/omp-extension-roots.ts
@@ -8,9 +8,10 @@
  * `prompts/`, `.mcp.json`) are wired into discovery by `omp-plugins.ts`.
  *
  * CLI-provided paths are injected via {@link injectOmpExtensionCliRoots}
- * before discovery runs; settings paths are read lazily from
- * `<scope>/settings.json` in {@link listOmpExtensionRoots} to mirror what
- * `loadExtensionModules` already does.
+ * before discovery runs; settings paths are read lazily in
+ * {@link listOmpExtensionRoots} from each scope's canonical `config.yml`
+ * (`config.yaml` at user scope) *and* legacy `settings.json`, mirroring the
+ * merged `extensions:` that `loadExtensionModules` loads via `settings.get`.
  *
  * @see ./omp-plugins.ts
  * @see ./builtin.ts `loadExtensionModules`
@@ -18,7 +19,8 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import { getAgentDir, isEnoent, logger, tryParseJson } from "@oh-my-pi/pi-utils";
+import { getAgentDir, isEnoent, logger, MAIN_CONFIG_FILENAMES, tryParseJson } from "@oh-my-pi/pi-utils";
+import { YAML } from "bun";
 import { readDirEntries, readFile } from "../capability/fs";
 import type { LoadContext } from "../capability/types";
 import { getEnabledPlugins } from "../extensibility/plugins/loader";
@@ -146,6 +148,48 @@ async function readSettingsExtensions(settingsPath: string): Promise<string[]> {
 	return raw.filter((entry): entry is string => typeof entry === "string" && entry.length > 0);
 }
 
+/** Project native config filename; matches the single `.omp/config.yml` the settings loader reads. */
+const PROJECT_CONFIG_FILENAMES = ["config.yml"] as const;
+
+/**
+ * Read the `extensions:` array from a scope's canonical YAML config. The first
+ * present filename wins (mirroring the settings loader), and a present-but-
+ * malformed file yields no entries rather than throwing.
+ */
+async function readYamlExtensions(scopeDir: string, filenames: readonly string[]): Promise<string[]> {
+	for (const filename of filenames) {
+		const content = await readFile(path.join(scopeDir, filename));
+		if (content === null) continue;
+		let parsed: unknown;
+		try {
+			parsed = YAML.parse(content);
+		} catch {
+			return [];
+		}
+		if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) return [];
+		if (!("extensions" in parsed)) return [];
+		const raw = parsed.extensions;
+		if (!Array.isArray(raw)) return [];
+		return raw.filter((entry): entry is string => typeof entry === "string" && entry.length > 0);
+	}
+	return [];
+}
+
+/**
+ * Merge a scope's configured extension paths from both surfaces that feed
+ * `settings.get("extensions")`: the canonical `config.yml`/`config.yaml` and
+ * the legacy `settings.json`. Reading only the latter left `config.yml`-only
+ * extensions loading their module while their `skills/`, `hooks/`, etc. never
+ * reached discovery (#9768). Duplicate paths are dropped downstream.
+ */
+async function readScopeExtensions(scopeDir: string, configFilenames: readonly string[]): Promise<string[]> {
+	const [fromConfig, fromSettings] = await Promise.all([
+		readYamlExtensions(scopeDir, configFilenames),
+		readSettingsExtensions(path.join(scopeDir, "settings.json")),
+	]);
+	return [...fromConfig, ...fromSettings];
+}
+
 function resolveAgainst(raw: string, ctx: LoadContext): string {
 	const tilde = expandTilde(raw, ctx.home);
 	return path.isAbsolute(tilde) ? tilde : path.resolve(ctx.cwd, tilde);
@@ -173,8 +217,8 @@ async function isDirectory(p: string): Promise<boolean> {
  *
  * 1. Invocation-scoped SDK roots, when present; otherwise CLI roots injected
  *    via {@link injectOmpExtensionCliRoots}
- * 2. Project `<cwd>/.omp/settings.json#extensions`
- * 3. User `~/.omp/agent/settings.json#extensions`
+ * 2. Project `<cwd>/.omp/config.yml#extensions`, then `.omp/settings.json#extensions`
+ * 3. User `~/.omp/agent/config.{yml,yaml}#extensions`, then `settings.json#extensions`
  * 4. Enabled npm/link plugins installed under `<plugins>/node_modules/` (for
  *    `omp install <pkg>` / `omp plugin install` / `omp plugin link`). Marketplace
  *    installs are loaded by the `claude-plugins` provider and are excluded here.
@@ -195,8 +239,8 @@ export async function listOmpExtensionRoots(ctx: LoadContext): Promise<OmpExtens
 	if (rootMode === "merge") {
 		const { project, user } = scopeDirs(ctx);
 		const [projectExtensions, userExtensions, installedPlugins] = await Promise.all([
-			readSettingsExtensions(path.join(project, "settings.json")),
-			readSettingsExtensions(path.join(user, "settings.json")),
+			readScopeExtensions(project, PROJECT_CONFIG_FILENAMES),
+			readScopeExtensions(user, MAIN_CONFIG_FILENAMES),
 			listInstalledPluginRoots(ctx),
 		]);
 		candidates = [

--- a/packages/coding-agent/src/discovery/omp-extension-roots.ts
+++ b/packages/coding-agent/src/discovery/omp-extension-roots.ts
@@ -49,6 +49,14 @@ interface InvocationRootScope {
 	/** Raw SDK spellings, resolved against the LoadContext that performs discovery. */
 	paths: readonly string[];
 	mode: OmpExtensionRootMode;
+	/**
+	 * Effective `extensions` setting for the owning session, captured once its
+	 * `Settings` instance is loaded. Session-local so concurrent SDK sessions
+	 * never observe each other's configured roots. `undefined` until
+	 * {@link setInvocationConfiguredExtensions} runs; discovery then falls back
+	 * to reading the persisted config from disk.
+	 */
+	configuredExtensions?: readonly string[];
 }
 
 const invocationRootScope = new AsyncLocalStorage<InvocationRootScope>();
@@ -79,6 +87,18 @@ export function withOmpExtensionRootScope<T>(
 	callback: () => T,
 ): T {
 	return invocationRootScope.run({ paths: [...paths], mode }, callback);
+}
+
+/**
+ * Record the owning session's effective `extensions` setting on the active
+ * invocation scope so sub-discovery honors overlays and runtime overrides
+ * without reading the process-global settings singleton (which the most
+ * recently initialized session would otherwise clobber). No-op outside a
+ * {@link withOmpExtensionRootScope} callback.
+ */
+export function setInvocationConfiguredExtensions(paths: readonly string[]): void {
+	const scope = invocationRootScope.getStore();
+	if (scope) scope.configuredExtensions = [...paths];
 }
 
 /**
@@ -234,9 +254,11 @@ async function isDirectory(p: string): Promise<boolean> {
  *
  * 1. Invocation-scoped SDK roots, when present; otherwise CLI roots injected
  *    via {@link injectOmpExtensionCliRoots}
- * 2. The effective configured `extensions` array. Capability loads pass the
- *    active `Settings` value (including overlays and runtime overrides);
- *    direct callers fall back to persisted array-replacement precedence.
+ * 2. The effective configured `extensions` array. SDK sessions record their
+ *    live `Settings` value on the invocation scope via
+ *    {@link setInvocationConfiguredExtensions} (honoring overlays and runtime
+ *    overrides); scopeless callers fall back to persisted array-replacement
+ *    precedence read from disk.
  * 3. Enabled npm/link plugins installed under `<plugins>/node_modules/` (for
  *    `omp install <pkg>` / `omp plugin install` / `omp plugin link`). Marketplace
  *    installs are loaded by the `claude-plugins` provider and are excluded here.
@@ -259,14 +281,16 @@ export async function listOmpExtensionRoots(ctx: LoadContext): Promise<OmpExtens
 			readConfiguredExtensions(ctx),
 			listInstalledPluginRoots(ctx),
 		]);
+		// Prefer the session's effective `extensions` (explicit ctx value, else
+		// the invocation-scoped snapshot) so overlays and runtime overrides win;
+		// scopeless callers fall back to the persisted config read from disk.
+		const effective = ctx.configuredExtensionPaths ?? scopedRoots?.configuredExtensions;
 		const configured =
-			ctx.configuredExtensionPaths !== undefined
+			effective !== undefined
 				? {
-						entries: [...ctx.configuredExtensionPaths],
+						entries: [...effective],
 						level:
-							persisted && Bun.deepEquals(ctx.configuredExtensionPaths, persisted.entries)
-								? persisted.level
-								: ("user" as const),
+							persisted && Bun.deepEquals(effective, persisted.entries) ? persisted.level : ("user" as const),
 					}
 				: persisted;
 		candidates = [

--- a/packages/coding-agent/src/extensibility/skills.ts
+++ b/packages/coding-agent/src/extensibility/skills.ts
@@ -120,6 +120,12 @@ export async function loadSkillsFromDir(options: LoadSkillsFromDirOptions): Prom
 export interface LoadSkillsOptions extends SkillsSettings {
 	/** Working directory for project-local skills. Default: getProjectDir() */
 	cwd?: string;
+	/**
+	 * Effective `extensions` setting. Post-startup reloads pass their live
+	 * session value so overlay/override extension skills survive outside the
+	 * construction-time invocation scope.
+	 */
+	configuredExtensionPaths?: readonly string[];
 }
 
 /**
@@ -141,6 +147,7 @@ export async function loadSkills(options: LoadSkillsOptions = {}): Promise<LoadS
 		ignoredSkills = [],
 		includeSkills = [],
 		disabledExtensions = [],
+		configuredExtensionPaths,
 	} = options;
 
 	// Early return if skills are disabled
@@ -175,7 +182,11 @@ export async function loadSkills(options: LoadSkillsOptions = {}): Promise<LoadS
 	}
 
 	// Use capability API to load all skills
-	const result = await loadCapability<CapabilitySkill>(skillCapability.id, { cwd, disabledExtensions });
+	const result = await loadCapability<CapabilitySkill>(skillCapability.id, {
+		cwd,
+		disabledExtensions,
+		configuredExtensionPaths,
+	});
 
 	const skillMap = new Map<string, Skill>();
 	const realPathSet = new Set<string>();

--- a/packages/coding-agent/src/extensibility/skills.ts
+++ b/packages/coding-agent/src/extensibility/skills.ts
@@ -7,7 +7,7 @@ import {
 	sanitizeManagedDescription,
 } from "../autolearn/managed-skills";
 import { skillCapability } from "../capability/skill";
-import type { SourceMeta } from "../capability/types";
+import type { EffectiveExtensionRoots, SourceMeta } from "../capability/types";
 import type { SkillsSettings } from "../config/settings";
 import { type Skill as CapabilitySkill, loadCapability } from "../discovery";
 import { compareSkillOrder, scanSkillsFromDir } from "../discovery/helpers";
@@ -121,13 +121,11 @@ export interface LoadSkillsOptions extends SkillsSettings {
 	/** Working directory for project-local skills. Default: getProjectDir() */
 	cwd?: string;
 	/**
-	 * Effective `extensions` setting. Post-startup reloads pass their live
-	 * session value so overlay/override extension skills survive outside the
-	 * construction-time invocation scope.
+	 * Session-local extension roots. Post-startup reloads pass their live
+	 * session value so explicit roots, discovery mode, and configured
+	 * extensions all survive outside the construction-time invocation scope.
 	 */
-	configuredExtensionPaths?: readonly string[];
-	/** Discovery mode paired with {@link configuredExtensionPaths}. */
-	extensionRootMode?: "merge" | "explicit-only";
+	extensionRoots?: EffectiveExtensionRoots;
 }
 
 /**
@@ -149,8 +147,7 @@ export async function loadSkills(options: LoadSkillsOptions = {}): Promise<LoadS
 		ignoredSkills = [],
 		includeSkills = [],
 		disabledExtensions = [],
-		configuredExtensionPaths,
-		extensionRootMode,
+		extensionRoots,
 	} = options;
 
 	// Early return if skills are disabled
@@ -188,8 +185,7 @@ export async function loadSkills(options: LoadSkillsOptions = {}): Promise<LoadS
 	const result = await loadCapability<CapabilitySkill>(skillCapability.id, {
 		cwd,
 		disabledExtensions,
-		configuredExtensionPaths,
-		extensionRootMode,
+		extensionRoots,
 	});
 
 	const skillMap = new Map<string, Skill>();

--- a/packages/coding-agent/src/extensibility/skills.ts
+++ b/packages/coding-agent/src/extensibility/skills.ts
@@ -126,6 +126,8 @@ export interface LoadSkillsOptions extends SkillsSettings {
 	 * construction-time invocation scope.
 	 */
 	configuredExtensionPaths?: readonly string[];
+	/** Discovery mode paired with {@link configuredExtensionPaths}. */
+	extensionRootMode?: "merge" | "explicit-only";
 }
 
 /**
@@ -148,6 +150,7 @@ export async function loadSkills(options: LoadSkillsOptions = {}): Promise<LoadS
 		includeSkills = [],
 		disabledExtensions = [],
 		configuredExtensionPaths,
+		extensionRootMode,
 	} = options;
 
 	// Early return if skills are disabled
@@ -186,6 +189,7 @@ export async function loadSkills(options: LoadSkillsOptions = {}): Promise<LoadS
 		cwd,
 		disabledExtensions,
 		configuredExtensionPaths,
+		extensionRootMode,
 	});
 
 	const skillMap = new Map<string, Skill>();

--- a/packages/coding-agent/src/extensibility/slash-commands.ts
+++ b/packages/coding-agent/src/extensibility/slash-commands.ts
@@ -63,6 +63,8 @@ export interface LoadSlashCommandsOptions {
 	 * construction-time invocation scope.
 	 */
 	configuredExtensionPaths?: readonly string[];
+	/** Discovery mode paired with {@link configuredExtensionPaths}. */
+	extensionRootMode?: "merge" | "explicit-only";
 }
 
 /**
@@ -73,6 +75,7 @@ export async function loadSlashCommands(options: LoadSlashCommandsOptions = {}):
 	const result = await loadCapability<SlashCommand>(slashCommandCapability.id, {
 		cwd: options.cwd,
 		configuredExtensionPaths: options.configuredExtensionPaths,
+		extensionRootMode: options.extensionRootMode,
 	});
 
 	const fileCommands: FileSlashCommand[] = result.items.map(cmd => {

--- a/packages/coding-agent/src/extensibility/slash-commands.ts
+++ b/packages/coding-agent/src/extensibility/slash-commands.ts
@@ -1,5 +1,6 @@
 import { parseFrontmatter, prompt } from "@oh-my-pi/pi-utils";
 import { slashCommandCapability } from "../capability/slash-command";
+import type { EffectiveExtensionRoots } from "../capability/types";
 import { appendInlineArgsFallback, templateUsesInlineArgPlaceholders } from "../config/prompt-templates";
 import type { SlashCommand } from "../discovery";
 import { loadCapability } from "../discovery";
@@ -57,14 +58,8 @@ function parseCommandTemplate(
 export interface LoadSlashCommandsOptions {
 	/** Working directory for project-local commands. Default: getProjectDir() */
 	cwd?: string;
-	/**
-	 * Effective `extensions` setting. Post-startup reloads pass their live
-	 * session value so overlay/override extension commands survive outside the
-	 * construction-time invocation scope.
-	 */
-	configuredExtensionPaths?: readonly string[];
-	/** Discovery mode paired with {@link configuredExtensionPaths}. */
-	extensionRootMode?: "merge" | "explicit-only";
+	/** Session-local extension roots for post-startup reloads (explicit + mode + configured). */
+	extensionRoots?: EffectiveExtensionRoots;
 }
 
 /**
@@ -74,8 +69,7 @@ export interface LoadSlashCommandsOptions {
 export async function loadSlashCommands(options: LoadSlashCommandsOptions = {}): Promise<FileSlashCommand[]> {
 	const result = await loadCapability<SlashCommand>(slashCommandCapability.id, {
 		cwd: options.cwd,
-		configuredExtensionPaths: options.configuredExtensionPaths,
-		extensionRootMode: options.extensionRootMode,
+		extensionRoots: options.extensionRoots,
 	});
 
 	const fileCommands: FileSlashCommand[] = result.items.map(cmd => {

--- a/packages/coding-agent/src/extensibility/slash-commands.ts
+++ b/packages/coding-agent/src/extensibility/slash-commands.ts
@@ -57,6 +57,12 @@ function parseCommandTemplate(
 export interface LoadSlashCommandsOptions {
 	/** Working directory for project-local commands. Default: getProjectDir() */
 	cwd?: string;
+	/**
+	 * Effective `extensions` setting. Post-startup reloads pass their live
+	 * session value so overlay/override extension commands survive outside the
+	 * construction-time invocation scope.
+	 */
+	configuredExtensionPaths?: readonly string[];
 }
 
 /**
@@ -64,7 +70,10 @@ export interface LoadSlashCommandsOptions {
  * Loads from all registered providers (builtin, user, project).
  */
 export async function loadSlashCommands(options: LoadSlashCommandsOptions = {}): Promise<FileSlashCommand[]> {
-	const result = await loadCapability<SlashCommand>(slashCommandCapability.id, { cwd: options.cwd });
+	const result = await loadCapability<SlashCommand>(slashCommandCapability.id, {
+		cwd: options.cwd,
+		configuredExtensionPaths: options.configuredExtensionPaths,
+	});
 
 	const fileCommands: FileSlashCommand[] = result.items.map(cmd => {
 		const { description, body } = parseCommandTemplate(cmd.content, {

--- a/packages/coding-agent/src/mcp/config.ts
+++ b/packages/coding-agent/src/mcp/config.ts
@@ -6,7 +6,7 @@
 
 import { getMCPConfigPath } from "@oh-my-pi/pi-utils";
 import { mcpCapability } from "../capability/mcp";
-import type { SourceMeta } from "../capability/types";
+import type { EffectiveExtensionRoots, SourceMeta } from "../capability/types";
 import type { MCPServer } from "../discovery";
 import { loadCapability } from "../discovery";
 import { readDisabledServers, readEnabledServers } from "./config-writer";
@@ -20,10 +20,8 @@ export interface LoadMCPConfigsOptions {
 	filterExa?: boolean;
 	/** Whether to filter out browser MCP servers when builtin browser tool is enabled (default: false) */
 	filterBrowser?: boolean;
-	/** Effective extension roots for session-scoped post-startup rediscovery. */
-	configuredExtensionPaths?: readonly string[];
-	/** Discovery mode paired with {@link configuredExtensionPaths}. */
-	extensionRootMode?: "merge" | "explicit-only";
+	/** Session-local extension roots for post-startup rediscovery (explicit + mode + configured). */
+	extensionRoots?: EffectiveExtensionRoots;
 }
 
 /** Result of loading MCP configs */
@@ -131,8 +129,7 @@ export async function loadAllMCPConfigs(cwd: string, options?: LoadMCPConfigsOpt
 
 	const result = await loadCapability<MCPServer>(mcpCapability.id, {
 		cwd,
-		configuredExtensionPaths: options?.configuredExtensionPaths,
-		extensionRootMode: options?.extensionRootMode,
+		extensionRoots: options?.extensionRoots,
 		filter: includeServer,
 		suppress: suppressServer,
 	});

--- a/packages/coding-agent/src/mcp/config.ts
+++ b/packages/coding-agent/src/mcp/config.ts
@@ -22,6 +22,8 @@ export interface LoadMCPConfigsOptions {
 	filterBrowser?: boolean;
 	/** Effective extension roots for session-scoped post-startup rediscovery. */
 	configuredExtensionPaths?: readonly string[];
+	/** Discovery mode paired with {@link configuredExtensionPaths}. */
+	extensionRootMode?: "merge" | "explicit-only";
 }
 
 /** Result of loading MCP configs */
@@ -130,6 +132,7 @@ export async function loadAllMCPConfigs(cwd: string, options?: LoadMCPConfigsOpt
 	const result = await loadCapability<MCPServer>(mcpCapability.id, {
 		cwd,
 		configuredExtensionPaths: options?.configuredExtensionPaths,
+		extensionRootMode: options?.extensionRootMode,
 		filter: includeServer,
 		suppress: suppressServer,
 	});

--- a/packages/coding-agent/src/mcp/config.ts
+++ b/packages/coding-agent/src/mcp/config.ts
@@ -20,6 +20,8 @@ export interface LoadMCPConfigsOptions {
 	filterExa?: boolean;
 	/** Whether to filter out browser MCP servers when builtin browser tool is enabled (default: false) */
 	filterBrowser?: boolean;
+	/** Effective extension roots for session-scoped post-startup rediscovery. */
+	configuredExtensionPaths?: readonly string[];
 }
 
 /** Result of loading MCP configs */
@@ -127,6 +129,7 @@ export async function loadAllMCPConfigs(cwd: string, options?: LoadMCPConfigsOpt
 
 	const result = await loadCapability<MCPServer>(mcpCapability.id, {
 		cwd,
+		configuredExtensionPaths: options?.configuredExtensionPaths,
 		filter: includeServer,
 		suppress: suppressServer,
 	});

--- a/packages/coding-agent/src/mcp/manager.ts
+++ b/packages/coding-agent/src/mcp/manager.ts
@@ -177,6 +177,8 @@ export interface MCPDiscoverOptions {
 	filterExa?: boolean;
 	/** Whether to filter out browser MCP servers when builtin browser tool is enabled (default: false) */
 	filterBrowser?: boolean;
+	/** Effective extension roots for session-scoped post-startup rediscovery. */
+	configuredExtensionPaths?: readonly string[];
 	/** Called when MCP server connection state changes. */
 	onStatus?: (event: McpConnectionStatusEvent) => void;
 }
@@ -461,6 +463,7 @@ export class MCPManager {
 				enableProjectConfig: options?.enableProjectConfig,
 				filterExa: options?.filterExa,
 				filterBrowser: options?.filterBrowser,
+				configuredExtensionPaths: options?.configuredExtensionPaths,
 			});
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);

--- a/packages/coding-agent/src/mcp/manager.ts
+++ b/packages/coding-agent/src/mcp/manager.ts
@@ -9,7 +9,7 @@ import * as url from "node:url";
 import { isDefinitiveOAuthFailure, type TSchema } from "@oh-my-pi/pi-ai";
 import type { OAuthCredentials } from "@oh-my-pi/pi-ai/oauth/types";
 import { logger } from "@oh-my-pi/pi-utils";
-import type { SourceMeta } from "../capability/types";
+import type { EffectiveExtensionRoots, SourceMeta } from "../capability/types";
 import { resolveConfigValue } from "../config/resolve-config-value";
 import type { CustomTool } from "../extensibility/custom-tools/types";
 import { type AuthStorage, REMOTE_REFRESH_SENTINEL } from "../session/auth-storage";
@@ -177,10 +177,8 @@ export interface MCPDiscoverOptions {
 	filterExa?: boolean;
 	/** Whether to filter out browser MCP servers when builtin browser tool is enabled (default: false) */
 	filterBrowser?: boolean;
-	/** Effective extension roots for session-scoped post-startup rediscovery. */
-	configuredExtensionPaths?: readonly string[];
-	/** Discovery mode paired with {@link configuredExtensionPaths}. */
-	extensionRootMode?: "merge" | "explicit-only";
+	/** Session-local extension roots for post-startup rediscovery (explicit + mode + configured). */
+	extensionRoots?: EffectiveExtensionRoots;
 	/** Called when MCP server connection state changes. */
 	onStatus?: (event: McpConnectionStatusEvent) => void;
 }
@@ -465,8 +463,7 @@ export class MCPManager {
 				enableProjectConfig: options?.enableProjectConfig,
 				filterExa: options?.filterExa,
 				filterBrowser: options?.filterBrowser,
-				configuredExtensionPaths: options?.configuredExtensionPaths,
-				extensionRootMode: options?.extensionRootMode,
+				extensionRoots: options?.extensionRoots,
 			});
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);

--- a/packages/coding-agent/src/mcp/manager.ts
+++ b/packages/coding-agent/src/mcp/manager.ts
@@ -179,6 +179,8 @@ export interface MCPDiscoverOptions {
 	filterBrowser?: boolean;
 	/** Effective extension roots for session-scoped post-startup rediscovery. */
 	configuredExtensionPaths?: readonly string[];
+	/** Discovery mode paired with {@link configuredExtensionPaths}. */
+	extensionRootMode?: "merge" | "explicit-only";
 	/** Called when MCP server connection state changes. */
 	onStatus?: (event: McpConnectionStatusEvent) => void;
 }
@@ -464,6 +466,7 @@ export class MCPManager {
 				filterExa: options?.filterExa,
 				filterBrowser: options?.filterBrowser,
 				configuredExtensionPaths: options?.configuredExtensionPaths,
+				extensionRootMode: options?.extensionRootMode,
 			});
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -2117,17 +2117,12 @@ export class AcpAgent implements Agent {
 		const cwd = record.session.sessionManager.getCwd();
 		const projectPath = await resolveActiveProjectRegistryPath(cwd);
 		clearPluginRootsAndCaches(projectPath ? [projectPath] : undefined);
-		await refreshAgentDiscovery(
-			cwd,
-			record.session.settings.get("extensions") ?? [],
-			record.session.extensionRootMode,
-		);
+		await refreshAgentDiscovery(cwd, record.session.effectiveExtensionRoots);
 		resetCapabilities();
 		await record.session.refreshSkills();
 		const fileCommands = await loadSlashCommands({
 			cwd,
-			configuredExtensionPaths: record.session.configuredExtensionPaths,
-			extensionRootMode: record.session.extensionRootMode,
+			extensionRoots: record.session.effectiveExtensionRoots,
 		});
 		record.session.setSlashCommands(fileCommands);
 		await this.#emitAvailableCommandsUpdate(record);

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -2117,7 +2117,7 @@ export class AcpAgent implements Agent {
 		const cwd = record.session.sessionManager.getCwd();
 		const projectPath = await resolveActiveProjectRegistryPath(cwd);
 		clearPluginRootsAndCaches(projectPath ? [projectPath] : undefined);
-		await refreshAgentDiscovery(cwd, record.session.configuredExtensionPaths);
+		await refreshAgentDiscovery(cwd, record.session.settings.get("extensions") ?? []);
 		resetCapabilities();
 		await record.session.refreshSkills();
 		const fileCommands = await loadSlashCommands({

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -2117,10 +2117,13 @@ export class AcpAgent implements Agent {
 		const cwd = record.session.sessionManager.getCwd();
 		const projectPath = await resolveActiveProjectRegistryPath(cwd);
 		clearPluginRootsAndCaches(projectPath ? [projectPath] : undefined);
-		await refreshAgentDiscovery(cwd);
+		await refreshAgentDiscovery(cwd, record.session.configuredExtensionPaths);
 		resetCapabilities();
 		await record.session.refreshSkills();
-		const fileCommands = await loadSlashCommands({ cwd });
+		const fileCommands = await loadSlashCommands({
+			cwd,
+			configuredExtensionPaths: record.session.configuredExtensionPaths,
+		});
 		record.session.setSlashCommands(fileCommands);
 		await this.#emitAvailableCommandsUpdate(record);
 	}

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -2117,12 +2117,17 @@ export class AcpAgent implements Agent {
 		const cwd = record.session.sessionManager.getCwd();
 		const projectPath = await resolveActiveProjectRegistryPath(cwd);
 		clearPluginRootsAndCaches(projectPath ? [projectPath] : undefined);
-		await refreshAgentDiscovery(cwd, record.session.settings.get("extensions") ?? []);
+		await refreshAgentDiscovery(
+			cwd,
+			record.session.settings.get("extensions") ?? [],
+			record.session.extensionRootMode,
+		);
 		resetCapabilities();
 		await record.session.refreshSkills();
 		const fileCommands = await loadSlashCommands({
 			cwd,
 			configuredExtensionPaths: record.session.configuredExtensionPaths,
+			extensionRootMode: record.session.extensionRootMode,
 		});
 		record.session.setSlashCommands(fileCommands);
 		await this.#emitAvailableCommandsUpdate(record);

--- a/packages/coding-agent/src/modes/components/agents-hub.ts
+++ b/packages/coding-agent/src/modes/components/agents-hub.ts
@@ -288,7 +288,7 @@ export class AgentsHubComponent implements Component {
 		this.#loadError = null;
 		try {
 			const selectedName = this.#selectedAgent()?.name;
-			const { agents } = await discoverAgents(this.#cwd);
+			const { agents } = await discoverAgents(this.#cwd, undefined, this.#settings.get("extensions"));
 			const disabled = new Set(this.#settings.get("task.disabledAgents") ?? []);
 			const overrides = this.#settings.get("task.agentModelOverrides") ?? {};
 			const prewalkOverrides = this.#settings.get("task.agentPrewalk") ?? {};

--- a/packages/coding-agent/src/modes/components/agents-hub.ts
+++ b/packages/coding-agent/src/modes/components/agents-hub.ts
@@ -29,6 +29,7 @@ import {
 } from "@oh-my-pi/pi-tui";
 import { isEnoent, prompt } from "@oh-my-pi/pi-utils";
 import { YAML } from "bun";
+import type { EffectiveExtensionRoots } from "../../capability/types";
 import { getConfigDirs } from "../../config";
 import type { ModelRegistry } from "../../config/model-registry";
 import {
@@ -122,6 +123,13 @@ export interface AgentsHubModelContext {
 	modelRegistry?: ModelRegistry;
 	activeModelPattern?: string;
 	defaultModelPattern?: string;
+	/**
+	 * Live provider for the owning session's extension roots (explicit + mode +
+	 * configured). Supplied so `/agents` lists exactly the agents the session
+	 * can spawn — including `--extension` roots and honoring `explicit-only`.
+	 * Falls back to a settings-only merge struct when absent.
+	 */
+	extensionRoots?: () => EffectiveExtensionRoots;
 }
 
 export interface AgentsHubCallbacks {
@@ -280,6 +288,17 @@ export class AgentsHubComponent implements Component {
 	dispose(): void {}
 	invalidate(): void {}
 
+	/** Live extension roots for the owning session; settings-only merge fallback when no provider. */
+	#extensionRoots(): EffectiveExtensionRoots {
+		return (
+			this.#modelContext.extensionRoots?.() ?? {
+				explicit: [],
+				mode: "merge",
+				configured: this.#settings.get("extensions") ?? [],
+			}
+		);
+	}
+
 	// ═══════════════════════════════════════════════════════════════════════
 	// Data pipeline
 	// ═══════════════════════════════════════════════════════════════════════
@@ -288,11 +307,7 @@ export class AgentsHubComponent implements Component {
 		this.#loadError = null;
 		try {
 			const selectedName = this.#selectedAgent()?.name;
-			const { agents } = await discoverAgents(this.#cwd, undefined, {
-				explicit: [],
-				mode: "merge",
-				configured: this.#settings.get("extensions") ?? [],
-			});
+			const { agents } = await discoverAgents(this.#cwd, undefined, this.#extensionRoots());
 			const disabled = new Set(this.#settings.get("task.disabledAgents") ?? []);
 			const overrides = this.#settings.get("task.agentModelOverrides") ?? {};
 			const prewalkOverrides = this.#settings.get("task.agentPrewalk") ?? {};
@@ -809,11 +824,7 @@ export class AgentsHubComponent implements Component {
 		const frontmatter = YAML.stringify({ name: spec.identifier, description: spec.whenToUse }, null, 2).trimEnd();
 		const content = `---\n${frontmatter}\n---\n\n${spec.systemPrompt.trim()}\n`;
 		await Bun.write(filePath, content);
-		await refreshAgentDiscovery(this.#cwd, {
-			explicit: [],
-			mode: "merge",
-			configured: this.#settings.get("extensions") ?? [],
-		});
+		await refreshAgentDiscovery(this.#cwd, this.#extensionRoots());
 		this.#clearCreateFlow();
 		this.#notice = `Created agent ${spec.identifier} at ${shortenPath(filePath)}`;
 		await this.#reload();

--- a/packages/coding-agent/src/modes/components/agents-hub.ts
+++ b/packages/coding-agent/src/modes/components/agents-hub.ts
@@ -288,7 +288,11 @@ export class AgentsHubComponent implements Component {
 		this.#loadError = null;
 		try {
 			const selectedName = this.#selectedAgent()?.name;
-			const { agents } = await discoverAgents(this.#cwd, undefined, this.#settings.get("extensions"));
+			const { agents } = await discoverAgents(this.#cwd, undefined, {
+				explicit: [],
+				mode: "merge",
+				configured: this.#settings.get("extensions") ?? [],
+			});
 			const disabled = new Set(this.#settings.get("task.disabledAgents") ?? []);
 			const overrides = this.#settings.get("task.agentModelOverrides") ?? {};
 			const prewalkOverrides = this.#settings.get("task.agentPrewalk") ?? {};
@@ -805,7 +809,11 @@ export class AgentsHubComponent implements Component {
 		const frontmatter = YAML.stringify({ name: spec.identifier, description: spec.whenToUse }, null, 2).trimEnd();
 		const content = `---\n${frontmatter}\n---\n\n${spec.systemPrompt.trim()}\n`;
 		await Bun.write(filePath, content);
-		await refreshAgentDiscovery(this.#cwd, this.#settings.get("extensions"));
+		await refreshAgentDiscovery(this.#cwd, {
+			explicit: [],
+			mode: "merge",
+			configured: this.#settings.get("extensions") ?? [],
+		});
 		this.#clearCreateFlow();
 		this.#notice = `Created agent ${spec.identifier} at ${shortenPath(filePath)}`;
 		await this.#reload();

--- a/packages/coding-agent/src/modes/components/agents-hub.ts
+++ b/packages/coding-agent/src/modes/components/agents-hub.ts
@@ -295,6 +295,7 @@ export class AgentsHubComponent implements Component {
 				explicit: [],
 				mode: "merge",
 				configured: this.#settings.get("extensions") ?? [],
+				configuredLevel: this.#settings.extensionsSourceLevel(),
 			}
 		);
 	}

--- a/packages/coding-agent/src/modes/components/agents-hub.ts
+++ b/packages/coding-agent/src/modes/components/agents-hub.ts
@@ -805,7 +805,7 @@ export class AgentsHubComponent implements Component {
 		const frontmatter = YAML.stringify({ name: spec.identifier, description: spec.whenToUse }, null, 2).trimEnd();
 		const content = `---\n${frontmatter}\n---\n\n${spec.systemPrompt.trim()}\n`;
 		await Bun.write(filePath, content);
-		await refreshAgentDiscovery(this.#cwd);
+		await refreshAgentDiscovery(this.#cwd, this.#settings.get("extensions"));
 		this.#clearCreateFlow();
 		this.#notice = `Created agent ${spec.identifier} at ${shortenPath(filePath)}`;
 		await this.#reload();

--- a/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
@@ -2123,8 +2123,7 @@ export class MCPCommandController {
 		}
 
 		const { configs, sources } = await loadAllMCPConfigs(getProjectDir(), {
-			configuredExtensionPaths: this.ctx.session.configuredExtensionPaths,
-			extensionRootMode: this.ctx.session.extensionRootMode,
+			extensionRoots: this.ctx.session.effectiveExtensionRoots,
 		});
 		const config = configs[name];
 		if (!config) {
@@ -2183,8 +2182,7 @@ export class MCPCommandController {
 			enableProjectConfig: this.ctx.settings.get("mcp.enableProjectConfig") ?? true,
 			filterExa: true,
 			filterBrowser: this.ctx.settings.get("browser.enabled") ?? false,
-			configuredExtensionPaths: this.ctx.session.configuredExtensionPaths,
-			extensionRootMode: this.ctx.session.extensionRootMode,
+			extensionRoots: this.ctx.session.effectiveExtensionRoots,
 		});
 		await this.ctx.session.refreshMCPTools(this.ctx.mcpManager.getTools());
 

--- a/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
@@ -2124,6 +2124,7 @@ export class MCPCommandController {
 
 		const { configs, sources } = await loadAllMCPConfigs(getProjectDir(), {
 			configuredExtensionPaths: this.ctx.session.configuredExtensionPaths,
+			extensionRootMode: this.ctx.session.extensionRootMode,
 		});
 		const config = configs[name];
 		if (!config) {
@@ -2183,6 +2184,7 @@ export class MCPCommandController {
 			filterExa: true,
 			filterBrowser: this.ctx.settings.get("browser.enabled") ?? false,
 			configuredExtensionPaths: this.ctx.session.configuredExtensionPaths,
+			extensionRootMode: this.ctx.session.extensionRootMode,
 		});
 		await this.ctx.session.refreshMCPTools(this.ctx.mcpManager.getTools());
 

--- a/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
@@ -2122,7 +2122,9 @@ export class MCPCommandController {
 			return;
 		}
 
-		const { configs, sources } = await loadAllMCPConfigs(getProjectDir());
+		const { configs, sources } = await loadAllMCPConfigs(getProjectDir(), {
+			configuredExtensionPaths: this.ctx.session.configuredExtensionPaths,
+		});
 		const config = configs[name];
 		if (!config) {
 			await this.ctx.session.refreshMCPTools(this.ctx.mcpManager.getTools());
@@ -2180,6 +2182,7 @@ export class MCPCommandController {
 			enableProjectConfig: this.ctx.settings.get("mcp.enableProjectConfig") ?? true,
 			filterExa: true,
 			filterBrowser: this.ctx.settings.get("browser.enabled") ?? false,
+			configuredExtensionPaths: this.ctx.session.configuredExtensionPaths,
 		});
 		await this.ctx.session.refreshMCPTools(this.ctx.mcpManager.getTools());
 

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -449,6 +449,7 @@ export class SelectorController {
 				modelRegistry: this.ctx.session.modelRegistry,
 				activeModelPattern,
 				defaultModelPattern,
+				extensionRoots: () => this.ctx.session.effectiveExtensionRoots,
 			},
 			{ onCancel: () => done() },
 		);

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -1455,7 +1455,12 @@ export class InteractiveMode implements InteractiveModeContext {
 		const basePath = cwd ?? this.sessionManager.getCwd();
 		// Session construction already ran slash-command discovery for this cwd;
 		// init passes that result through instead of re-walking the providers.
-		const fileCommands = preloaded ? [...preloaded] : await loadSlashCommands({ cwd: basePath });
+		const fileCommands = preloaded
+			? [...preloaded]
+			: await loadSlashCommands({
+					cwd: basePath,
+					configuredExtensionPaths: this.session.configuredExtensionPaths,
+				});
 		this.fileSlashCommands = new Set(fileCommands.map(cmd => cmd.name));
 		const promptIcon = getSlashCommandTypeIcon("prompt");
 		const fileSlashCommands: SlashCommand[] = fileCommands.map(cmd => ({

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -1459,8 +1459,7 @@ export class InteractiveMode implements InteractiveModeContext {
 			? [...preloaded]
 			: await loadSlashCommands({
 					cwd: basePath,
-					configuredExtensionPaths: this.session.configuredExtensionPaths,
-					extensionRootMode: this.session.extensionRootMode,
+					extensionRoots: this.session.effectiveExtensionRoots,
 				});
 		this.fileSlashCommands = new Set(fileCommands.map(cmd => cmd.name));
 		const promptIcon = getSlashCommandTypeIcon("prompt");

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -1460,6 +1460,7 @@ export class InteractiveMode implements InteractiveModeContext {
 			: await loadSlashCommands({
 					cwd: basePath,
 					configuredExtensionPaths: this.session.configuredExtensionPaths,
+					extensionRootMode: this.session.extensionRootMode,
 				});
 		this.fileSlashCommands = new Set(fileCommands.map(cmd => cmd.name));
 		const promptIcon = getSlashCommandTypeIcon("prompt");

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -989,8 +989,7 @@ export async function runRpcMode(
 		session.setSlashCommands(
 			await loadSlashCommands({
 				cwd,
-				configuredExtensionPaths: session.configuredExtensionPaths,
-				extensionRootMode: session.extensionRootMode,
+				extensionRoots: session.effectiveExtensionRoots,
 			}),
 		);
 		await emitAvailableCommandsUpdate();

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -987,7 +987,11 @@ export async function runRpcMode(
 		resetCapabilities();
 		await session.refreshSkills();
 		session.setSlashCommands(
-			await loadSlashCommands({ cwd, configuredExtensionPaths: session.configuredExtensionPaths }),
+			await loadSlashCommands({
+				cwd,
+				configuredExtensionPaths: session.configuredExtensionPaths,
+				extensionRootMode: session.extensionRootMode,
+			}),
 		);
 		await emitAvailableCommandsUpdate();
 	};

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -986,7 +986,9 @@ export async function runRpcMode(
 		clearPluginRootsAndCaches(projectPath ? [projectPath] : undefined);
 		resetCapabilities();
 		await session.refreshSkills();
-		session.setSlashCommands(await loadSlashCommands({ cwd }));
+		session.setSlashCommands(
+			await loadSlashCommands({ cwd, configuredExtensionPaths: session.configuredExtensionPaths }),
+		);
 		await emitAvailableCommandsUpdate();
 	};
 	const emitAvailableCommandsUpdate = async () => {

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1913,6 +1913,9 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			// Filter browser MCP servers when builtin browser tool is active
 			filterBrowser: settings.get("browser.enabled") ?? false,
 			configuredExtensionPaths: settings.get("extensions") ?? [],
+			extensionRootMode: (options.disableExtensionDiscovery ? "explicit-only" : "merge") as
+				| "merge"
+				| "explicit-only",
 		};
 		if (enableMCP && !mcpManager) {
 			if (deferMCPDiscoveryForUI) {
@@ -2092,6 +2095,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 		// Forward the source-path list (NOT the loaded instances) so subagents
 		// rebuild their own session-scoped extensions.
 		toolSession.extensionPaths = extensionPaths;
+		toolSession.extensionRootMode = options.disableExtensionDiscovery ? "explicit-only" : "merge";
 
 		// Load inline extensions from factories
 		if (inlineExtensions.length > 0) {

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -53,6 +53,7 @@ import { createAutoresearchExtension } from "./autoresearch";
 import { loadCapability } from "./capability";
 import { type Rule, ruleCapability, setActiveRules } from "./capability/rule";
 import { bucketRules } from "./capability/rule-buckets";
+import type { EffectiveExtensionRoots } from "./capability/types";
 import { shouldEnableAppendOnlyContext } from "./config/append-only-context-mode";
 import { shouldInlineToolDescriptors } from "./config/inline-tool-descriptors-mode";
 import { isAuthenticated, kNoAuth, ModelRegistry } from "./config/model-registry";
@@ -1905,6 +1906,11 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			if (event.type === "connecting" && event.serverNames.length === 0) return;
 			eventBus.emit(MCP_CONNECTION_STATUS_EVENT_CHANNEL, event);
 		};
+		const sessionExtensionRoots: EffectiveExtensionRoots = {
+			explicit: options.additionalExtensionPaths ?? [],
+			mode: options.disableExtensionDiscovery ? "explicit-only" : "merge",
+			configured: settings.get("extensions") ?? [],
+		};
 		const mcpDiscoverOptions = {
 			onStatus: onMCPStatus,
 			enableProjectConfig: settings.get("mcp.enableProjectConfig") ?? true,
@@ -1912,10 +1918,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			filterExa: true,
 			// Filter browser MCP servers when builtin browser tool is active
 			filterBrowser: settings.get("browser.enabled") ?? false,
-			configuredExtensionPaths: settings.get("extensions") ?? [],
-			extensionRootMode: (options.disableExtensionDiscovery ? "explicit-only" : "merge") as
-				| "merge"
-				| "explicit-only",
+			extensionRoots: sessionExtensionRoots,
 		};
 		if (enableMCP && !mcpManager) {
 			if (deferMCPDiscoveryForUI) {
@@ -2095,7 +2098,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 		// Forward the source-path list (NOT the loaded instances) so subagents
 		// rebuild their own session-scoped extensions.
 		toolSession.extensionPaths = extensionPaths;
-		toolSession.extensionRootMode = options.disableExtensionDiscovery ? "explicit-only" : "merge";
+		toolSession.effectiveExtensionRoots = sessionExtensionRoots;
 
 		// Load inline extensions from factories
 		if (inlineExtensions.length > 0) {

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -79,7 +79,7 @@ import "./discovery";
 import { createImageUrlServiceFromSettings } from "./blob-broker/service";
 import { wrapStreamFnWithBlobUrlFallback } from "./blob-broker/stream-fallback";
 import { initializeWithSettings } from "./discovery";
-import { withOmpExtensionRootScope } from "./discovery/omp-extension-roots";
+import { setInvocationConfiguredExtensions, withOmpExtensionRootScope } from "./discovery/omp-extension-roots";
 import { disposeAllJuliaKernelSessions, disposeJuliaKernelSessionsByOwner } from "./eval/jl/executor";
 import { disposeVmContextsByOwner } from "./eval/js/context-manager";
 import { disposeAllKernelSessions, disposeKernelSessionsByOwner } from "./eval/py/executor";
@@ -1268,6 +1268,10 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 		options.settingsManager ??
 		logger.time("settings", Settings.init, { cwd, agentDir }));
 	logger.time("initializeWithSettings", initializeWithSettings, settings);
+	// Snapshot this session's effective `extensions` onto its invocation scope so
+	// extension sub-discovery stays isolated from other concurrent sessions'
+	// Settings instances (never the process-global singleton).
+	setInvocationConfiguredExtensions(settings.get("extensions") ?? []);
 
 	// Pin authStorage to modelRegistry.authStorage: ModelRegistry.getApiKey() routes refresh
 	// failures through that instance, so any divergent storage handed to the bridge / mcpManager

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -3550,6 +3550,8 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			serviceTierByFamily: initialServiceTierByFamily,
 			sessionManager,
 			settings,
+			additionalExtensionPaths: options.additionalExtensionPaths,
+			disableExtensionDiscovery: options.disableExtensionDiscovery,
 			autoApprove: options.autoApprove,
 			scoutAllowedBySpawnPolicy: isScoutSpawnable(undefined, options.spawns ?? "*"),
 			evalKernelOwnerId,

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1906,11 +1906,14 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			if (event.type === "connecting" && event.serverNames.length === 0) return;
 			eventBus.emit(MCP_CONNECTION_STATUS_EVENT_CHANNEL, event);
 		};
-		const sessionExtensionRoots: EffectiveExtensionRoots = {
+		// Provider, never a stored value: materialized per discovery call so a
+		// runtime override or settings reload is reflected. `explicit`/`mode` are
+		// construction-time constants; only `configured` is read live.
+		const buildSessionExtensionRoots = (): EffectiveExtensionRoots => ({
 			explicit: options.additionalExtensionPaths ?? [],
 			mode: options.disableExtensionDiscovery ? "explicit-only" : "merge",
 			configured: settings.get("extensions") ?? [],
-		};
+		});
 		const mcpDiscoverOptions = {
 			onStatus: onMCPStatus,
 			enableProjectConfig: settings.get("mcp.enableProjectConfig") ?? true,
@@ -1918,7 +1921,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			filterExa: true,
 			// Filter browser MCP servers when builtin browser tool is active
 			filterBrowser: settings.get("browser.enabled") ?? false,
-			extensionRoots: sessionExtensionRoots,
+			extensionRoots: buildSessionExtensionRoots(),
 		};
 		if (enableMCP && !mcpManager) {
 			if (deferMCPDiscoveryForUI) {
@@ -2098,7 +2101,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 		// Forward the source-path list (NOT the loaded instances) so subagents
 		// rebuild their own session-scoped extensions.
 		toolSession.extensionPaths = extensionPaths;
-		toolSession.effectiveExtensionRoots = sessionExtensionRoots;
+		toolSession.effectiveExtensionRoots = buildSessionExtensionRoots;
 
 		// Load inline extensions from factories
 		if (inlineExtensions.length > 0) {

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -441,6 +441,14 @@ export interface CreateAgentSessionOptions {
 	/** Disable extension discovery (explicit paths still load). */
 	disableExtensionDiscovery?: boolean;
 	/**
+	 * Live extension-root policy inherited by a child session. Keeps recursive
+	 * sub-discovery aligned with the parent while `preloadedExtensionPaths` only
+	 * optimizes extension-module loading.
+	 *
+	 * @internal
+	 */
+	extensionRoots?: () => EffectiveExtensionRoots;
+	/**
 	 * Pre-loaded extensions (skips file discovery and the per-session factory
 	 * call). Used by the CLI when extensions are loaded early to parse custom
 	 * flags — the same process owns the returned instances, so reusing them is
@@ -1251,10 +1259,10 @@ export function createAutoLearnCaptureRunner(
  * ```
  */
 export async function createAgentSession(options: CreateAgentSessionOptions = {}): Promise<CreateAgentSessionResult> {
-	const rootMode = options.disableExtensionDiscovery ? "explicit-only" : "merge";
-	return await withOmpExtensionRootScope(options.additionalExtensionPaths ?? [], rootMode, () =>
-		createAgentSessionScoped(options),
-	);
+	const extensionRoots = options.extensionRoots?.();
+	const explicit = extensionRoots?.explicit ?? options.additionalExtensionPaths ?? [];
+	const mode = extensionRoots?.mode ?? (options.disableExtensionDiscovery ? "explicit-only" : "merge");
+	return await withOmpExtensionRootScope(explicit, mode, () => createAgentSessionScoped(options));
 }
 
 async function createAgentSessionScoped(options: CreateAgentSessionOptions): Promise<CreateAgentSessionResult> {
@@ -1269,10 +1277,14 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 		options.settingsManager ??
 		logger.time("settings", Settings.init, { cwd, agentDir }));
 	logger.time("initializeWithSettings", initializeWithSettings, settings);
-	// Snapshot this session's effective `extensions` onto its invocation scope so
-	// extension sub-discovery stays isolated from other concurrent sessions'
-	// Settings instances (never the process-global singleton).
-	setInvocationConfiguredExtensions(settings.get("extensions") ?? [], settings.extensionsSourceLevel());
+	// Snapshot this session's effective configured lane onto its invocation scope
+	// so startup sub-discovery sees the same complete policy that post-startup
+	// reloads and recursively spawned children consume.
+	const extensionRoots = options.extensionRoots?.();
+	setInvocationConfiguredExtensions(
+		extensionRoots?.configured ?? settings.get("extensions") ?? [],
+		extensionRoots?.configuredLevel ?? settings.extensionsSourceLevel(),
+	);
 
 	// Pin authStorage to modelRegistry.authStorage: ModelRegistry.getApiKey() routes refresh
 	// failures through that instance, so any divergent storage handed to the bridge / mcpManager
@@ -1906,15 +1918,17 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			if (event.type === "connecting" && event.serverNames.length === 0) return;
 			eventBus.emit(MCP_CONNECTION_STATUS_EVENT_CHANNEL, event);
 		};
-		// Provider, never a stored value: materialized per discovery call so a
-		// runtime override or settings reload is reflected. `explicit`/`mode` are
-		// construction-time constants; only `configured` is read live.
-		const buildSessionExtensionRoots = (): EffectiveExtensionRoots => ({
-			explicit: options.additionalExtensionPaths ?? [],
-			mode: options.disableExtensionDiscovery ? "explicit-only" : "merge",
-			configured: settings.get("extensions") ?? [],
-			configuredLevel: settings.extensionsSourceLevel(),
-		});
+		// Provider, never a stored value: inherited child policy remains linked to
+		// the owning session, while top-level sessions materialize their own live
+		// settings on every discovery call.
+		const buildSessionExtensionRoots =
+			options.extensionRoots ??
+			((): EffectiveExtensionRoots => ({
+				explicit: options.additionalExtensionPaths ?? [],
+				mode: options.disableExtensionDiscovery ? "explicit-only" : "merge",
+				configured: settings.get("extensions") ?? [],
+				configuredLevel: settings.extensionsSourceLevel(),
+			}));
 		const mcpDiscoverOptions = {
 			onStatus: onMCPStatus,
 			enableProjectConfig: settings.get("mcp.enableProjectConfig") ?? true,
@@ -3562,6 +3576,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			sessionManager,
 			settings,
 			additionalExtensionPaths: options.additionalExtensionPaths,
+			extensionRoots: buildSessionExtensionRoots,
 			disableExtensionDiscovery: options.disableExtensionDiscovery,
 			autoApprove: options.autoApprove,
 			scoutAllowedBySpawnPolicy: isScoutSpawnable(undefined, options.spawns ?? "*"),

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1912,6 +1912,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			filterExa: true,
 			// Filter browser MCP servers when builtin browser tool is active
 			filterBrowser: settings.get("browser.enabled") ?? false,
+			configuredExtensionPaths: settings.get("extensions") ?? [],
 		};
 		if (enableMCP && !mcpManager) {
 			if (deferMCPDiscoveryForUI) {

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1272,7 +1272,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 	// Snapshot this session's effective `extensions` onto its invocation scope so
 	// extension sub-discovery stays isolated from other concurrent sessions'
 	// Settings instances (never the process-global singleton).
-	setInvocationConfiguredExtensions(settings.get("extensions") ?? []);
+	setInvocationConfiguredExtensions(settings.get("extensions") ?? [], settings.extensionsSourceLevel());
 
 	// Pin authStorage to modelRegistry.authStorage: ModelRegistry.getApiKey() routes refresh
 	// failures through that instance, so any divergent storage handed to the bridge / mcpManager
@@ -1913,6 +1913,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			explicit: options.additionalExtensionPaths ?? [],
 			mode: options.disableExtensionDiscovery ? "explicit-only" : "merge",
 			configured: settings.get("extensions") ?? [],
+			configuredLevel: settings.extensionsSourceLevel(),
 		});
 		const mcpDiscoverOptions = {
 			onStatus: onMCPStatus,

--- a/packages/coding-agent/src/session/agent-session-types.ts
+++ b/packages/coding-agent/src/session/agent-session-types.ts
@@ -125,6 +125,14 @@ export interface AgentSessionConfig {
 	codeModeState?: { namespacesInfo?: unknown };
 	sessionManager: SessionManager;
 	settings: Settings;
+	/**
+	 * Raw SDK `additionalExtensionPaths`. Retained so post-startup capability
+	 * reloads rediscover explicitly-supplied packages, which live only in the
+	 * construction-time invocation scope otherwise.
+	 */
+	additionalExtensionPaths?: readonly string[];
+	/** Mirror of `disableExtensionDiscovery`: reloads then use only explicit roots. */
+	disableExtensionDiscovery?: boolean;
 	/** Whether the session spawn policy permits the read-only `scout` subagent. Defaults to true. */
 	scoutAllowedBySpawnPolicy?: boolean;
 	/** Whether the caller explicitly requested yolo/auto-approve behavior for this session. */

--- a/packages/coding-agent/src/session/agent-session-types.ts
+++ b/packages/coding-agent/src/session/agent-session-types.ts
@@ -21,6 +21,7 @@ import type {
 import type { postmortem } from "@oh-my-pi/pi-utils";
 import type { AdvisorConfig } from "../advisor";
 import type { AsyncJob, AsyncJobDeliveryState, AsyncJobManager } from "../async";
+import type { EffectiveExtensionRoots } from "../capability/types";
 import type { ModelRegistry } from "../config/model-registry";
 import type { PromptTemplate } from "../config/prompt-templates";
 import type { Settings, SkillsSettings } from "../config/settings";
@@ -126,12 +127,14 @@ export interface AgentSessionConfig {
 	sessionManager: SessionManager;
 	settings: Settings;
 	/**
-	 * Raw SDK `additionalExtensionPaths`. Retained so post-startup capability
-	 * reloads rediscover explicitly-supplied packages, which live only in the
-	 * construction-time invocation scope otherwise.
+	 * Live extension-root policy inherited from the owning session. Subagents use
+	 * this provider so explicit roots, discovery mode, configured roots, and
+	 * provenance survive recursive task discovery.
 	 */
+	extensionRoots?: () => EffectiveExtensionRoots;
+	/** Raw SDK `additionalExtensionPaths`; used when no inherited root provider exists. */
 	additionalExtensionPaths?: readonly string[];
-	/** Mirror of `disableExtensionDiscovery`: reloads then use only explicit roots. */
+	/** Mirror of `disableExtensionDiscovery`; used when no inherited root provider exists. */
 	disableExtensionDiscovery?: boolean;
 	/** Whether the session spawn policy permits the read-only `scout` subagent. Defaults to true. */
 	scoutAllowedBySpawnPolicy?: boolean;

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -101,6 +101,7 @@ import {
 import { type AdvisorConfig, type AdvisorRuntimeStatus, loadAdvisorTranscriptCosts } from "../advisor";
 import { ASYNC_JOB_MANAGER_SHUTDOWN_REASON, type AsyncJob, AsyncJobManager } from "../async";
 import { reset as resetCapabilities } from "../capability";
+import type { EffectiveExtensionRoots } from "../capability/types";
 import { shouldEnableAppendOnlyContext } from "../config/append-only-context-mode";
 import type { ModelRegistry } from "../config/model-registry";
 import type { ResolvedModelRoleValue } from "../config/model-resolver";
@@ -486,29 +487,20 @@ export class AgentSession {
 	readonly #disableExtensionDiscovery: boolean;
 
 	/**
-	 * Effective extension roots for this session: the SDK's explicit
-	 * `additionalExtensionPaths` plus (unless discovery is disabled) the live
-	 * `extensions` setting, read from its own {@link settings} so post-startup
-	 * reloads honor overlays/runtime overrides and survive settings reloads.
-	 * Session-local — never the process-global singleton — so concurrent
-	 * sessions stay isolated, and explicit roots outlive the construction-time
-	 * invocation scope.
+	 * Session-local extension roots for this session, read live from its own
+	 * {@link settings}. Threaded whole (explicit lane + mode + configured lane)
+	 * so post-startup reloads — `refreshSkills`, slash-command/agent/MCP
+	 * rediscovery — stay byte-identical to the construction-time scoped load and
+	 * never lose the explicit `additionalExtensionPaths`, the `explicit-only`
+	 * mode, or project provenance. Session-local, never the process-global
+	 * singleton, so concurrent sessions stay isolated.
 	 */
-	get configuredExtensionPaths(): readonly string[] {
-		const explicit = this.#additionalExtensionPaths;
-		if (this.#disableExtensionDiscovery) return explicit;
-		const configured = this.settings.get("extensions") ?? [];
-		return explicit.length > 0 ? [...explicit, ...configured] : configured;
-	}
-
-	/**
-	 * Discovery mode paired with {@link configuredExtensionPaths}. A
-	 * `disableExtensionDiscovery` session stays `explicit-only` across
-	 * post-startup reloads so refreshes never re-merge ambient or installed
-	 * roots the caller opted out of.
-	 */
-	get extensionRootMode(): "merge" | "explicit-only" {
-		return this.#disableExtensionDiscovery ? "explicit-only" : "merge";
+	get effectiveExtensionRoots(): EffectiveExtensionRoots {
+		return {
+			explicit: this.#additionalExtensionPaths,
+			mode: this.#disableExtensionDiscovery ? "explicit-only" : "merge",
+			configured: this.settings.get("extensions") ?? [],
+		};
 	}
 
 	#powerAssertion: MacOSPowerAssertion | undefined;
@@ -1348,8 +1340,7 @@ export class AgentSession {
 			agent: this.agent,
 			sessionManager: this.sessionManager,
 			settings: this.settings,
-			configuredExtensionPaths: () => this.configuredExtensionPaths,
-			extensionRootMode: () => this.extensionRootMode,
+			effectiveExtensionRoots: () => this.effectiveExtensionRoots,
 			modelRegistry: this.#modelRegistry,
 			extensionRunner: () => this.#extensionRunner,
 			clientBridge: () => this.#clientBridge,

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -500,6 +500,7 @@ export class AgentSession {
 			explicit: this.#additionalExtensionPaths,
 			mode: this.#disableExtensionDiscovery ? "explicit-only" : "merge",
 			configured: this.settings.get("extensions") ?? [],
+			configuredLevel: this.settings.extensionsSourceLevel(),
 		};
 	}
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -481,27 +481,16 @@ export class AgentSession {
 	/** Per-session `CUT`/`PASTE` clipboard register shared across edit calls. */
 	editClipboard?: Clipboard;
 
-	/** Raw SDK `additionalExtensionPaths`, resolved lazily by `listOmpExtensionRoots`. */
-	readonly #additionalExtensionPaths: readonly string[];
-	/** When true, reloads expose only the explicit roots (no ambient `extensions:`). */
-	readonly #disableExtensionDiscovery: boolean;
+	/** Materializes this session's live extension-root policy per discovery call. */
+	readonly #extensionRoots: () => EffectiveExtensionRoots;
 
 	/**
-	 * Session-local extension roots for this session, read live from its own
-	 * {@link settings}. Threaded whole (explicit lane + mode + configured lane)
-	 * so post-startup reloads — `refreshSkills`, slash-command/agent/MCP
-	 * rediscovery — stay byte-identical to the construction-time scoped load and
-	 * never lose the explicit `additionalExtensionPaths`, the `explicit-only`
-	 * mode, or project provenance. Session-local, never the process-global
-	 * singleton, so concurrent sessions stay isolated.
+	 * Session-local extension roots for post-startup rediscovery. Subagents may
+	 * inherit the owning session's provider so recursive task discovery preserves
+	 * explicit roots, mode, configured roots, and provenance.
 	 */
 	get effectiveExtensionRoots(): EffectiveExtensionRoots {
-		return {
-			explicit: this.#additionalExtensionPaths,
-			mode: this.#disableExtensionDiscovery ? "explicit-only" : "merge",
-			configured: this.settings.get("extensions") ?? [],
-			configuredLevel: this.settings.extensionsSourceLevel(),
-		};
+		return this.#extensionRoots();
 	}
 
 	#powerAssertion: MacOSPowerAssertion | undefined;
@@ -1022,8 +1011,14 @@ export class AgentSession {
 		this.sessionManager = config.sessionManager;
 		this.settings = config.settings;
 		this.#modelRegistry = config.modelRegistry;
-		this.#additionalExtensionPaths = config.additionalExtensionPaths ?? [];
-		this.#disableExtensionDiscovery = config.disableExtensionDiscovery ?? false;
+		this.#extensionRoots =
+			config.extensionRoots ??
+			(() => ({
+				explicit: config.additionalExtensionPaths ?? [],
+				mode: config.disableExtensionDiscovery ? "explicit-only" : "merge",
+				configured: this.settings.get("extensions") ?? [],
+				configuredLevel: this.settings.extensionsSourceLevel(),
+			}));
 		this.#codexResetCoordinator = config.codexResetCoordinator ?? defaultCodexAutoRedeemCoordinator;
 		const bashHost: BashRunnerHost = {
 			agent: this.agent,

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -501,6 +501,16 @@ export class AgentSession {
 		return explicit.length > 0 ? [...explicit, ...configured] : configured;
 	}
 
+	/**
+	 * Discovery mode paired with {@link configuredExtensionPaths}. A
+	 * `disableExtensionDiscovery` session stays `explicit-only` across
+	 * post-startup reloads so refreshes never re-merge ambient or installed
+	 * roots the caller opted out of.
+	 */
+	get extensionRootMode(): "merge" | "explicit-only" {
+		return this.#disableExtensionDiscovery ? "explicit-only" : "merge";
+	}
+
 	#powerAssertion: MacOSPowerAssertion | undefined;
 
 	readonly configWarnings: string[] = [];
@@ -1339,6 +1349,7 @@ export class AgentSession {
 			sessionManager: this.sessionManager,
 			settings: this.settings,
 			configuredExtensionPaths: () => this.configuredExtensionPaths,
+			extensionRootMode: () => this.extensionRootMode,
 			modelRegistry: this.#modelRegistry,
 			extensionRunner: () => this.#extensionRunner,
 			clientBridge: () => this.#clientBridge,

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -480,6 +480,16 @@ export class AgentSession {
 	/** Per-session `CUT`/`PASTE` clipboard register shared across edit calls. */
 	editClipboard?: Clipboard;
 
+	/**
+	 * Effective `extensions` setting for this session, read live from its own
+	 * {@link settings} so post-startup capability reloads honor overlays and
+	 * runtime overrides (and survive settings reloads). Session-local — never
+	 * the process-global singleton — so concurrent sessions stay isolated.
+	 */
+	get configuredExtensionPaths(): readonly string[] {
+		return this.settings.get("extensions") ?? [];
+	}
+
 	#powerAssertion: MacOSPowerAssertion | undefined;
 
 	readonly configWarnings: string[] = [];

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -480,14 +480,25 @@ export class AgentSession {
 	/** Per-session `CUT`/`PASTE` clipboard register shared across edit calls. */
 	editClipboard?: Clipboard;
 
+	/** Raw SDK `additionalExtensionPaths`, resolved lazily by `listOmpExtensionRoots`. */
+	readonly #additionalExtensionPaths: readonly string[];
+	/** When true, reloads expose only the explicit roots (no ambient `extensions:`). */
+	readonly #disableExtensionDiscovery: boolean;
+
 	/**
-	 * Effective `extensions` setting for this session, read live from its own
-	 * {@link settings} so post-startup capability reloads honor overlays and
-	 * runtime overrides (and survive settings reloads). Session-local — never
-	 * the process-global singleton — so concurrent sessions stay isolated.
+	 * Effective extension roots for this session: the SDK's explicit
+	 * `additionalExtensionPaths` plus (unless discovery is disabled) the live
+	 * `extensions` setting, read from its own {@link settings} so post-startup
+	 * reloads honor overlays/runtime overrides and survive settings reloads.
+	 * Session-local — never the process-global singleton — so concurrent
+	 * sessions stay isolated, and explicit roots outlive the construction-time
+	 * invocation scope.
 	 */
 	get configuredExtensionPaths(): readonly string[] {
-		return this.settings.get("extensions") ?? [];
+		const explicit = this.#additionalExtensionPaths;
+		if (this.#disableExtensionDiscovery) return explicit;
+		const configured = this.settings.get("extensions") ?? [];
+		return explicit.length > 0 ? [...explicit, ...configured] : configured;
 	}
 
 	#powerAssertion: MacOSPowerAssertion | undefined;
@@ -1008,6 +1019,8 @@ export class AgentSession {
 		this.sessionManager = config.sessionManager;
 		this.settings = config.settings;
 		this.#modelRegistry = config.modelRegistry;
+		this.#additionalExtensionPaths = config.additionalExtensionPaths ?? [];
+		this.#disableExtensionDiscovery = config.disableExtensionDiscovery ?? false;
 		this.#codexResetCoordinator = config.codexResetCoordinator ?? defaultCodexAutoRedeemCoordinator;
 		const bashHost: BashRunnerHost = {
 			agent: this.agent,
@@ -1325,6 +1338,7 @@ export class AgentSession {
 			agent: this.agent,
 			sessionManager: this.sessionManager,
 			settings: this.settings,
+			configuredExtensionPaths: () => this.configuredExtensionPaths,
 			modelRegistry: this.#modelRegistry,
 			extensionRunner: () => this.#extensionRunner,
 			clientBridge: () => this.#clientBridge,

--- a/packages/coding-agent/src/session/session-tools.ts
+++ b/packages/coding-agent/src/session/session-tools.ts
@@ -3,6 +3,7 @@ import type { Agent, AgentTool } from "@oh-my-pi/pi-agent-core";
 import type { Model } from "@oh-my-pi/pi-ai";
 import { isRecord, logger, prompt, stringProperty, untilAborted } from "@oh-my-pi/pi-utils";
 import { reset as resetCapabilities } from "../capability";
+import type { EffectiveExtensionRoots } from "../capability/types";
 import type { ModelRegistry } from "../config/model-registry";
 import { formatModelString } from "../config/model-resolver";
 import type { Settings, SkillsSettings } from "../config/settings";
@@ -44,10 +45,8 @@ export interface SessionToolsHost {
 	agent: Agent;
 	sessionManager: SessionManager;
 	settings: Settings;
-	/** Effective extension roots (explicit SDK paths + live `extensions:`) for post-startup reloads. */
-	configuredExtensionPaths(): readonly string[];
-	/** Discovery mode paired with {@link configuredExtensionPaths}. */
-	extensionRootMode(): "merge" | "explicit-only";
+	/** Session-local extension roots (explicit + mode + configured) for post-startup reloads. */
+	effectiveExtensionRoots(): EffectiveExtensionRoots;
 	modelRegistry: ModelRegistry;
 	extensionRunner(): ExtensionRunner | undefined;
 	clientBridge(): ClientBridge | undefined;
@@ -1187,8 +1186,7 @@ export class SessionTools {
 				...skillsSettings,
 				cwd: this.#host.sessionManager.getCwd(),
 				disabledExtensions: this.#host.settings.get("disabledExtensions") ?? [],
-				configuredExtensionPaths: this.#host.configuredExtensionPaths(),
-				extensionRootMode: this.#host.extensionRootMode(),
+				extensionRoots: this.#host.effectiveExtensionRoots(),
 			});
 			this.#skills = discovered.skills;
 			this.#skillWarnings = discovered.warnings;

--- a/packages/coding-agent/src/session/session-tools.ts
+++ b/packages/coding-agent/src/session/session-tools.ts
@@ -46,6 +46,8 @@ export interface SessionToolsHost {
 	settings: Settings;
 	/** Effective extension roots (explicit SDK paths + live `extensions:`) for post-startup reloads. */
 	configuredExtensionPaths(): readonly string[];
+	/** Discovery mode paired with {@link configuredExtensionPaths}. */
+	extensionRootMode(): "merge" | "explicit-only";
 	modelRegistry: ModelRegistry;
 	extensionRunner(): ExtensionRunner | undefined;
 	clientBridge(): ClientBridge | undefined;
@@ -1186,6 +1188,7 @@ export class SessionTools {
 				cwd: this.#host.sessionManager.getCwd(),
 				disabledExtensions: this.#host.settings.get("disabledExtensions") ?? [],
 				configuredExtensionPaths: this.#host.configuredExtensionPaths(),
+				extensionRootMode: this.#host.extensionRootMode(),
 			});
 			this.#skills = discovered.skills;
 			this.#skillWarnings = discovered.warnings;

--- a/packages/coding-agent/src/session/session-tools.ts
+++ b/packages/coding-agent/src/session/session-tools.ts
@@ -1183,6 +1183,7 @@ export class SessionTools {
 				...skillsSettings,
 				cwd: this.#host.sessionManager.getCwd(),
 				disabledExtensions: this.#host.settings.get("disabledExtensions") ?? [],
+				configuredExtensionPaths: this.#host.settings.get("extensions") ?? [],
 			});
 			this.#skills = discovered.skills;
 			this.#skillWarnings = discovered.warnings;

--- a/packages/coding-agent/src/session/session-tools.ts
+++ b/packages/coding-agent/src/session/session-tools.ts
@@ -44,6 +44,8 @@ export interface SessionToolsHost {
 	agent: Agent;
 	sessionManager: SessionManager;
 	settings: Settings;
+	/** Effective extension roots (explicit SDK paths + live `extensions:`) for post-startup reloads. */
+	configuredExtensionPaths(): readonly string[];
 	modelRegistry: ModelRegistry;
 	extensionRunner(): ExtensionRunner | undefined;
 	clientBridge(): ClientBridge | undefined;
@@ -1183,7 +1185,7 @@ export class SessionTools {
 				...skillsSettings,
 				cwd: this.#host.sessionManager.getCwd(),
 				disabledExtensions: this.#host.settings.get("disabledExtensions") ?? [],
-				configuredExtensionPaths: this.#host.settings.get("extensions") ?? [],
+				configuredExtensionPaths: this.#host.configuredExtensionPaths(),
 			});
 			this.#skills = discovered.skills;
 			this.#skillWarnings = discovered.warnings;

--- a/packages/coding-agent/src/slash-commands/available-commands.ts
+++ b/packages/coding-agent/src/slash-commands/available-commands.ts
@@ -1,4 +1,5 @@
 import type { AvailableCommand } from "@oh-my-pi/pi-utils/acp";
+import type { EffectiveExtensionRoots } from "../capability/types";
 import type { SkillsSettings } from "../config/settings";
 import type { LoadedCustomCommand } from "../extensibility/custom-commands";
 import type { ExtensionRunner } from "../extensibility/extensions";
@@ -24,8 +25,7 @@ export interface AvailableCommandsSession {
 	readonly mcpPromptCommands?: ReadonlyArray<LoadedCustomCommand>;
 	readonly skills: ReadonlyArray<Skill>;
 	readonly skillsSettings?: SkillsSettings;
-	readonly configuredExtensionPaths?: readonly string[];
-	readonly extensionRootMode?: "merge" | "explicit-only";
+	readonly effectiveExtensionRoots?: EffectiveExtensionRoots;
 	setSlashCommands(slashCommands: FileSlashCommand[]): void;
 	sessionManager: { getCwd(): string };
 }
@@ -33,11 +33,7 @@ export interface AvailableCommandsSession {
 export async function buildAvailableSlashCommands(
 	session: AvailableCommandsSession,
 	loadFileCommands: (cwd: string) => Promise<FileSlashCommand[]> = cwd =>
-		loadSlashCommands({
-			cwd,
-			configuredExtensionPaths: session.configuredExtensionPaths,
-			extensionRootMode: session.extensionRootMode,
-		}),
+		loadSlashCommands({ cwd, extensionRoots: session.effectiveExtensionRoots }),
 ): Promise<InternalAvailableSlashCommand[]> {
 	const commands: InternalAvailableSlashCommand[] = [];
 	const seenNames = new Set<string>();

--- a/packages/coding-agent/src/slash-commands/available-commands.ts
+++ b/packages/coding-agent/src/slash-commands/available-commands.ts
@@ -25,6 +25,7 @@ export interface AvailableCommandsSession {
 	readonly skills: ReadonlyArray<Skill>;
 	readonly skillsSettings?: SkillsSettings;
 	readonly configuredExtensionPaths?: readonly string[];
+	readonly extensionRootMode?: "merge" | "explicit-only";
 	setSlashCommands(slashCommands: FileSlashCommand[]): void;
 	sessionManager: { getCwd(): string };
 }
@@ -32,7 +33,11 @@ export interface AvailableCommandsSession {
 export async function buildAvailableSlashCommands(
 	session: AvailableCommandsSession,
 	loadFileCommands: (cwd: string) => Promise<FileSlashCommand[]> = cwd =>
-		loadSlashCommands({ cwd, configuredExtensionPaths: session.configuredExtensionPaths }),
+		loadSlashCommands({
+			cwd,
+			configuredExtensionPaths: session.configuredExtensionPaths,
+			extensionRootMode: session.extensionRootMode,
+		}),
 ): Promise<InternalAvailableSlashCommand[]> {
 	const commands: InternalAvailableSlashCommand[] = [];
 	const seenNames = new Set<string>();

--- a/packages/coding-agent/src/slash-commands/available-commands.ts
+++ b/packages/coding-agent/src/slash-commands/available-commands.ts
@@ -24,13 +24,15 @@ export interface AvailableCommandsSession {
 	readonly mcpPromptCommands?: ReadonlyArray<LoadedCustomCommand>;
 	readonly skills: ReadonlyArray<Skill>;
 	readonly skillsSettings?: SkillsSettings;
+	readonly configuredExtensionPaths?: readonly string[];
 	setSlashCommands(slashCommands: FileSlashCommand[]): void;
 	sessionManager: { getCwd(): string };
 }
 
 export async function buildAvailableSlashCommands(
 	session: AvailableCommandsSession,
-	loadFileCommands: (cwd: string) => Promise<FileSlashCommand[]> = cwd => loadSlashCommands({ cwd }),
+	loadFileCommands: (cwd: string) => Promise<FileSlashCommand[]> = cwd =>
+		loadSlashCommands({ cwd, configuredExtensionPaths: session.configuredExtensionPaths }),
 ): Promise<InternalAvailableSlashCommand[]> {
 	const commands: InternalAvailableSlashCommand[] = [];
 	const seenNames = new Set<string>();

--- a/packages/coding-agent/src/slash-commands/builtin-marketplace.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-marketplace.ts
@@ -30,7 +30,7 @@ import type { SlashCommandSpec } from "./types";
 export async function reloadTuiPluginState(ctx: InteractiveModeContext): Promise<void> {
 	const projectPath = await resolveActiveProjectRegistryPath(ctx.sessionManager.getCwd());
 	clearPluginRootsAndCaches(projectPath ? [projectPath] : undefined);
-	await refreshAgentDiscovery(ctx.sessionManager.getCwd());
+	await refreshAgentDiscovery(ctx.sessionManager.getCwd(), ctx.session.configuredExtensionPaths);
 	await ctx.refreshSkillState();
 	await ctx.refreshSlashCommandState();
 	resetCapabilities();

--- a/packages/coding-agent/src/slash-commands/builtin-marketplace.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-marketplace.ts
@@ -30,7 +30,7 @@ import type { SlashCommandSpec } from "./types";
 export async function reloadTuiPluginState(ctx: InteractiveModeContext): Promise<void> {
 	const projectPath = await resolveActiveProjectRegistryPath(ctx.sessionManager.getCwd());
 	clearPluginRootsAndCaches(projectPath ? [projectPath] : undefined);
-	await refreshAgentDiscovery(ctx.sessionManager.getCwd(), ctx.session.configuredExtensionPaths);
+	await refreshAgentDiscovery(ctx.sessionManager.getCwd(), ctx.settings.get("extensions") ?? []);
 	await ctx.refreshSkillState();
 	await ctx.refreshSlashCommandState();
 	resetCapabilities();

--- a/packages/coding-agent/src/slash-commands/builtin-marketplace.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-marketplace.ts
@@ -30,11 +30,7 @@ import type { SlashCommandSpec } from "./types";
 export async function reloadTuiPluginState(ctx: InteractiveModeContext): Promise<void> {
 	const projectPath = await resolveActiveProjectRegistryPath(ctx.sessionManager.getCwd());
 	clearPluginRootsAndCaches(projectPath ? [projectPath] : undefined);
-	await refreshAgentDiscovery(
-		ctx.sessionManager.getCwd(),
-		ctx.settings.get("extensions") ?? [],
-		ctx.session.extensionRootMode,
-	);
+	await refreshAgentDiscovery(ctx.sessionManager.getCwd(), ctx.session.effectiveExtensionRoots);
 	await ctx.refreshSkillState();
 	await ctx.refreshSlashCommandState();
 	resetCapabilities();

--- a/packages/coding-agent/src/slash-commands/builtin-marketplace.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-marketplace.ts
@@ -30,7 +30,11 @@ import type { SlashCommandSpec } from "./types";
 export async function reloadTuiPluginState(ctx: InteractiveModeContext): Promise<void> {
 	const projectPath = await resolveActiveProjectRegistryPath(ctx.sessionManager.getCwd());
 	clearPluginRootsAndCaches(projectPath ? [projectPath] : undefined);
-	await refreshAgentDiscovery(ctx.sessionManager.getCwd(), ctx.settings.get("extensions") ?? []);
+	await refreshAgentDiscovery(
+		ctx.sessionManager.getCwd(),
+		ctx.settings.get("extensions") ?? [],
+		ctx.session.extensionRootMode,
+	);
 	await ctx.refreshSkillState();
 	await ctx.refreshSlashCommandState();
 	resetCapabilities();

--- a/packages/coding-agent/src/task/discovery.ts
+++ b/packages/coding-agent/src/task/discovery.ts
@@ -67,11 +67,13 @@ async function loadAgentsFromDir(dir: string, source: AgentSource): Promise<Agen
  * @param cwd - Current working directory for project agent discovery
  * @param home - Home directory for user and marketplace discovery
  * @param configuredExtensionPaths - Effective `extensions` setting, including runtime overrides
+ * @param extensionRootMode - Discovery mode paired with `configuredExtensionPaths`
  */
 export async function discoverAgents(
 	cwd: string,
 	home: string = os.homedir(),
 	configuredExtensionPaths?: readonly string[],
+	extensionRootMode?: "merge" | "explicit-only",
 ): Promise<DiscoveryResult> {
 	const resolvedCwd = path.resolve(cwd);
 
@@ -104,6 +106,7 @@ export async function discoverAgents(
 				home,
 				repoRoot: null,
 				configuredExtensionPaths,
+				extensionRootMode,
 			})
 		: [];
 	for (const root of extensionRoots) {

--- a/packages/coding-agent/src/task/discovery.ts
+++ b/packages/coding-agent/src/task/discovery.ts
@@ -61,13 +61,18 @@ async function loadAgentsFromDir(dir: string, source: AgentSource): Promise<Agen
 /**
  * Discover agents from filesystem and merge with bundled agents.
  * Precedence (highest wins): project `.omp/agents`, user `.omp/agents`,
- * OMP extension-package agents in `listOmpExtensionRoots` source order
- * (CLI roots > project `extensions:` settings > user `extensions:` settings >
- * installed npm/link plugins), Claude marketplace plugin agents (project
- * scope before user), then bundled.
+ * OMP extension-package agents from the effective `extensions` setting,
+ * installed npm/link plugins, Claude marketplace plugin agents (project scope
+ * before user), then bundled.
  * @param cwd - Current working directory for project agent discovery
+ * @param home - Home directory for user and marketplace discovery
+ * @param configuredExtensionPaths - Effective `extensions` setting, including runtime overrides
  */
-export async function discoverAgents(cwd: string, home: string = os.homedir()): Promise<DiscoveryResult> {
+export async function discoverAgents(
+	cwd: string,
+	home: string = os.homedir(),
+	configuredExtensionPaths?: readonly string[],
+): Promise<DiscoveryResult> {
 	const resolvedCwd = path.resolve(cwd);
 
 	const userDirs = getConfigDirs("agents", { project: false })
@@ -90,15 +95,16 @@ export async function discoverAgents(cwd: string, home: string = os.homedir()): 
 	const user = userDirs[0];
 	if (user) orderedDirs.push({ dir: user.path, source: "user" });
 
-	// OMP extension-package agents/ dirs. `listOmpExtensionRoots` returns roots in
-	// source-precedence order (CLI > project `extensions:` settings > user
-	// `extensions:` settings > installed npm/link plugins, with marketplace
-	// installs already excluded by realpath) — consume that order verbatim so the
-	// `task` agent surface dedups identically to the sibling skills/hooks/tools
-	// surface in `discovery/omp-plugins.ts`. Gate on `omp-plugins` so
-	// disabledProviders suppresses the whole extension-package surface.
+	// Extension-package agents use the same effective root set as sibling
+	// skills/hooks/tools. Callers with a live Settings instance pass its merged
+	// value so overlays and runtime overrides replace persisted arrays.
 	const extensionRoots = isProviderEnabled("omp-plugins")
-		? await listOmpExtensionRoots({ cwd: resolvedCwd, home, repoRoot: null })
+		? await listOmpExtensionRoots({
+				cwd: resolvedCwd,
+				home,
+				repoRoot: null,
+				configuredExtensionPaths,
+			})
 		: [];
 	for (const root of extensionRoots) {
 		orderedDirs.push({ dir: path.join(root.path, "agents"), source: root.level });

--- a/packages/coding-agent/src/task/discovery.ts
+++ b/packages/coding-agent/src/task/discovery.ts
@@ -22,6 +22,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { logger } from "@oh-my-pi/pi-utils";
 import { isProviderEnabled } from "../capability";
+import type { EffectiveExtensionRoots } from "../capability/types";
 import { findAllNearestProjectConfigDirs, getConfigDirs } from "../config";
 import { listClaudePluginRoots } from "../discovery/helpers";
 import { listOmpExtensionRoots } from "../discovery/omp-extension-roots";
@@ -66,14 +67,12 @@ async function loadAgentsFromDir(dir: string, source: AgentSource): Promise<Agen
  * before user), then bundled.
  * @param cwd - Current working directory for project agent discovery
  * @param home - Home directory for user and marketplace discovery
- * @param configuredExtensionPaths - Effective `extensions` setting, including runtime overrides
- * @param extensionRootMode - Discovery mode paired with `configuredExtensionPaths`
+ * @param extensionRoots - Session-local extension roots (explicit + mode + configured)
  */
 export async function discoverAgents(
 	cwd: string,
 	home: string = os.homedir(),
-	configuredExtensionPaths?: readonly string[],
-	extensionRootMode?: "merge" | "explicit-only",
+	extensionRoots?: EffectiveExtensionRoots,
 ): Promise<DiscoveryResult> {
 	const resolvedCwd = path.resolve(cwd);
 
@@ -98,18 +97,11 @@ export async function discoverAgents(
 	if (user) orderedDirs.push({ dir: user.path, source: "user" });
 
 	// Extension-package agents use the same effective root set as sibling
-	// skills/hooks/tools. Callers with a live Settings instance pass its merged
-	// value so overlays and runtime overrides replace persisted arrays.
-	const extensionRoots = isProviderEnabled("omp-plugins")
-		? await listOmpExtensionRoots({
-				cwd: resolvedCwd,
-				home,
-				repoRoot: null,
-				configuredExtensionPaths,
-				extensionRootMode,
-			})
+	// skills/hooks/tools, threaded whole so explicit roots and mode survive.
+	const packageRoots = isProviderEnabled("omp-plugins")
+		? await listOmpExtensionRoots({ cwd: resolvedCwd, home, repoRoot: null, extensionRoots })
 		: [];
-	for (const root of extensionRoots) {
+	for (const root of packageRoots) {
 		orderedDirs.push({ dir: path.join(root.path, "agents"), source: root.level });
 	}
 

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -11,6 +11,7 @@ import type { Api, Model, ServiceTierByFamily, Usage } from "@oh-my-pi/pi-ai";
 import { logger, popLoopPhase, prompt, pushLoopPhase, untilAborted } from "@oh-my-pi/pi-utils";
 import { ASYNC_JOB_MANAGER_SHUTDOWN_REASON, AsyncJobManager } from "../async";
 import type { Rule } from "../capability/rule";
+import type { EffectiveExtensionRoots } from "../capability/types";
 import { ModelRegistry } from "../config/model-registry";
 import {
 	formatModelSelectorValue,
@@ -456,6 +457,11 @@ export interface ExecutorOptions {
 	workspaceTree?: WorkspaceTree;
 	/** Parent-discovered rules, forwarded to skip rule discovery in the subagent. */
 	rules?: Rule[];
+	/**
+	 * Parent session's live extension-root policy. Forwarded separately from
+	 * `preloadedExtensionPaths`, which only controls extension module loading.
+	 */
+	extensionRoots?: () => EffectiveExtensionRoots;
 	/**
 	 * Parent's discovered extension source paths. Forwarded to skip the
 	 * extension FS scan in the subagent; the subagent then re-binds each
@@ -3148,6 +3154,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				promptTemplates: options.promptTemplates,
 				workspaceTree: options.workspaceTree,
 				rules: options.rules,
+				extensionRoots: options.extensionRoots,
 				preloadedExtensionPaths: restrictToolNames ? [] : options.preloadedExtensionPaths,
 				preloadedCustomToolPaths: restrictToolNames ? [] : options.preloadedCustomToolPaths,
 				systemPrompt: defaultPrompt => {

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -442,19 +442,24 @@ class TaskJobError extends Error {}
 
 /**
  * Process-level create-time discovery memo and published reload snapshots,
- * keyed by resolved cwd.
+ * keyed by resolved cwd plus the exact effective `extensions` array.
  *
- * `TaskTool.create` runs for every (sub)agent session in this process and the
- * walk-up + plugin-registry scan in `discoverAgents` is identical for a given
- * cwd, so repeat creations reuse the first scan. Explicit plugin reloads
- * replace the matching snapshot so already-created tools advertise the latest
- * definitions. Execution-time discovery (`#runSpawn`) intentionally stays
- * fresh. The memo also tracks the live `discoverAgents` binding: test spies
- * swap that binding, which invalidates both caches automatically.
+ * `TaskTool.create` runs for every (sub)agent session in this process. Sessions
+ * may share a cwd while carrying different overlay/runtime extension settings,
+ * so cwd alone is not an isolation boundary. Explicit plugin reloads replace
+ * only the matching cwd+extensions snapshot. Execution-time discovery
+ * (`#runSpawn`) intentionally stays fresh. The memo also tracks the live
+ * `discoverAgents` binding: test spies swap that binding, which invalidates
+ * both caches automatically.
  */
 const discoveryMemo = new Map<string, Promise<DiscoveryResult>>();
 const discoverySnapshots = new Map<string, AgentDefinition[]>();
 let discoveryMemoFn: typeof discoverAgents | undefined;
+
+/** Stable cache identity for the filesystem root and ordered effective extension paths. */
+function discoveryCacheKey(cwd: string, configuredExtensionPaths?: readonly string[]): string {
+	return `${path.resolve(cwd)}\0${JSON.stringify(configuredExtensionPaths ?? null)}`;
+}
 
 function discoverAgentsForCreate(cwd: string, configuredExtensionPaths?: readonly string[]): Promise<DiscoveryResult> {
 	const fn = discoverAgents;
@@ -463,7 +468,7 @@ function discoverAgentsForCreate(cwd: string, configuredExtensionPaths?: readonl
 		discoveryMemo.clear();
 		discoverySnapshots.clear();
 	}
-	const key = path.resolve(cwd);
+	const key = discoveryCacheKey(cwd, configuredExtensionPaths);
 	let pending = discoveryMemo.get(key);
 	if (!pending) {
 		pending = fn(cwd, undefined, configuredExtensionPaths);
@@ -477,7 +482,7 @@ function discoverAgentsForCreate(cwd: string, configuredExtensionPaths?: readonl
 
 /** Rescan one cwd and publish its definitions to existing and future task tools. */
 export async function refreshAgentDiscovery(cwd: string, configuredExtensionPaths?: readonly string[]): Promise<void> {
-	const key = path.resolve(cwd);
+	const key = discoveryCacheKey(cwd, configuredExtensionPaths);
 	discoveryMemo.delete(key);
 	const pending = discoverAgentsForCreate(cwd, configuredExtensionPaths);
 	const { agents } = await pending;
@@ -602,7 +607,10 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		const planMode = this.session.getPlanModeState?.()?.enabled === true;
 		const isolationMode = this.session.settings.get("task.isolation.mode");
 		return renderDescription({
-			agents: discoverySnapshots.get(path.resolve(this.session.cwd)) ?? this.#discoveredAgents,
+			agents:
+				discoverySnapshots.get(
+					discoveryCacheKey(this.session.cwd, this.session.settings.get("extensions") ?? []),
+				) ?? this.#discoveredAgents,
 			isolationEnabled: !planMode && isolationMode !== "none",
 			applyIsolatedChanges: this.session.settings.get("task.isolation.apply"),
 			disabledAgents,

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -18,6 +18,7 @@ import type { AgentTool, AgentToolResult, AgentToolUpdateCallback } from "@oh-my
 import type { Usage } from "@oh-my-pi/pi-ai";
 import { $env, logger, prompt } from "@oh-my-pi/pi-utils";
 import type { ToolSession } from "..";
+import type { EffectiveExtensionRoots } from "../capability/types";
 import type { Theme } from "../modes/theme/theme";
 import subagentUserPromptTemplate from "../prompts/system/subagent-user-prompt.md" with { type: "text" };
 import taskDescriptionTemplate from "../prompts/tools/task.md" with { type: "text" };
@@ -456,30 +457,22 @@ const discoveryMemo = new Map<string, Promise<DiscoveryResult>>();
 const discoverySnapshots = new Map<string, AgentDefinition[]>();
 let discoveryMemoFn: typeof discoverAgents | undefined;
 
-/** Stable cache identity for the filesystem root, ordered effective extension paths, and discovery mode. */
-function discoveryCacheKey(
-	cwd: string,
-	configuredExtensionPaths?: readonly string[],
-	extensionRootMode?: "merge" | "explicit-only",
-): string {
-	return `${path.resolve(cwd)}\0${JSON.stringify(configuredExtensionPaths ?? null)}\0${extensionRootMode ?? "merge"}`;
+/** Stable cache identity for the filesystem root and the full effective extension-root struct. */
+function discoveryCacheKey(cwd: string, extensionRoots?: EffectiveExtensionRoots): string {
+	return `${path.resolve(cwd)}\0${JSON.stringify(extensionRoots ?? null)}`;
 }
 
-function discoverAgentsForCreate(
-	cwd: string,
-	configuredExtensionPaths?: readonly string[],
-	extensionRootMode?: "merge" | "explicit-only",
-): Promise<DiscoveryResult> {
+function discoverAgentsForCreate(cwd: string, extensionRoots?: EffectiveExtensionRoots): Promise<DiscoveryResult> {
 	const fn = discoverAgents;
 	if (discoveryMemoFn !== fn) {
 		discoveryMemoFn = fn;
 		discoveryMemo.clear();
 		discoverySnapshots.clear();
 	}
-	const key = discoveryCacheKey(cwd, configuredExtensionPaths, extensionRootMode);
+	const key = discoveryCacheKey(cwd, extensionRoots);
 	let pending = discoveryMemo.get(key);
 	if (!pending) {
-		pending = fn(cwd, undefined, configuredExtensionPaths, extensionRootMode);
+		pending = fn(cwd, undefined, extensionRoots);
 		discoveryMemo.set(key, pending);
 		pending.catch(() => {
 			if (discoveryMemo.get(key) === pending) discoveryMemo.delete(key);
@@ -489,14 +482,10 @@ function discoverAgentsForCreate(
 }
 
 /** Rescan one cwd and publish its definitions to existing and future task tools. */
-export async function refreshAgentDiscovery(
-	cwd: string,
-	configuredExtensionPaths?: readonly string[],
-	extensionRootMode?: "merge" | "explicit-only",
-): Promise<void> {
-	const key = discoveryCacheKey(cwd, configuredExtensionPaths, extensionRootMode);
+export async function refreshAgentDiscovery(cwd: string, extensionRoots?: EffectiveExtensionRoots): Promise<void> {
+	const key = discoveryCacheKey(cwd, extensionRoots);
 	discoveryMemo.delete(key);
-	const pending = discoverAgentsForCreate(cwd, configuredExtensionPaths, extensionRootMode);
+	const pending = discoverAgentsForCreate(cwd, extensionRoots);
 	const { agents } = await pending;
 	if (discoveryMemo.get(key) === pending) {
 		discoverySnapshots.set(key, agents);
@@ -620,13 +609,8 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		const isolationMode = this.session.settings.get("task.isolation.mode");
 		return renderDescription({
 			agents:
-				discoverySnapshots.get(
-					discoveryCacheKey(
-						this.session.cwd,
-						this.session.settings.get("extensions") ?? [],
-						this.session.extensionRootMode,
-					),
-				) ?? this.#discoveredAgents,
+				discoverySnapshots.get(discoveryCacheKey(this.session.cwd, this.session.effectiveExtensionRoots)) ??
+				this.#discoveredAgents,
 			isolationEnabled: !planMode && isolationMode !== "none",
 			applyIsolatedChanges: this.session.settings.get("task.isolation.apply"),
 			disabledAgents,
@@ -691,11 +675,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 	 * Create a TaskTool instance with async agent discovery.
 	 */
 	static async create(session: ToolSession): Promise<TaskTool> {
-		const { agents } = await discoverAgentsForCreate(
-			session.cwd,
-			session.settings.get("extensions") ?? [],
-			session.extensionRootMode,
-		);
+		const { agents } = await discoverAgentsForCreate(session.cwd, session.effectiveExtensionRoots);
 		return new TaskTool(session, agents);
 	}
 

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -609,7 +609,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		const isolationMode = this.session.settings.get("task.isolation.mode");
 		return renderDescription({
 			agents:
-				discoverySnapshots.get(discoveryCacheKey(this.session.cwd, this.session.effectiveExtensionRoots)) ??
+				discoverySnapshots.get(discoveryCacheKey(this.session.cwd, this.session.effectiveExtensionRoots?.())) ??
 				this.#discoveredAgents,
 			isolationEnabled: !planMode && isolationMode !== "none",
 			applyIsolatedChanges: this.session.settings.get("task.isolation.apply"),
@@ -675,7 +675,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 	 * Create a TaskTool instance with async agent discovery.
 	 */
 	static async create(session: ToolSession): Promise<TaskTool> {
-		const { agents } = await discoverAgentsForCreate(session.cwd, session.effectiveExtensionRoots);
+		const { agents } = await discoverAgentsForCreate(session.cwd, session.effectiveExtensionRoots?.());
 		return new TaskTool(session, agents);
 	}
 

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -456,7 +456,7 @@ const discoveryMemo = new Map<string, Promise<DiscoveryResult>>();
 const discoverySnapshots = new Map<string, AgentDefinition[]>();
 let discoveryMemoFn: typeof discoverAgents | undefined;
 
-function discoverAgentsForCreate(cwd: string): Promise<DiscoveryResult> {
+function discoverAgentsForCreate(cwd: string, configuredExtensionPaths?: readonly string[]): Promise<DiscoveryResult> {
 	const fn = discoverAgents;
 	if (discoveryMemoFn !== fn) {
 		discoveryMemoFn = fn;
@@ -466,7 +466,7 @@ function discoverAgentsForCreate(cwd: string): Promise<DiscoveryResult> {
 	const key = path.resolve(cwd);
 	let pending = discoveryMemo.get(key);
 	if (!pending) {
-		pending = fn(cwd);
+		pending = fn(cwd, undefined, configuredExtensionPaths);
 		discoveryMemo.set(key, pending);
 		pending.catch(() => {
 			if (discoveryMemo.get(key) === pending) discoveryMemo.delete(key);
@@ -476,10 +476,10 @@ function discoverAgentsForCreate(cwd: string): Promise<DiscoveryResult> {
 }
 
 /** Rescan one cwd and publish its definitions to existing and future task tools. */
-export async function refreshAgentDiscovery(cwd: string): Promise<void> {
+export async function refreshAgentDiscovery(cwd: string, configuredExtensionPaths?: readonly string[]): Promise<void> {
 	const key = path.resolve(cwd);
 	discoveryMemo.delete(key);
-	const pending = discoverAgentsForCreate(cwd);
+	const pending = discoverAgentsForCreate(cwd, configuredExtensionPaths);
 	const { agents } = await pending;
 	if (discoveryMemo.get(key) === pending) {
 		discoverySnapshots.set(key, agents);
@@ -667,7 +667,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 	 * Create a TaskTool instance with async agent discovery.
 	 */
 	static async create(session: ToolSession): Promise<TaskTool> {
-		const { agents } = await discoverAgentsForCreate(session.cwd);
+		const { agents } = await discoverAgentsForCreate(session.cwd, session.settings.get("extensions") ?? []);
 		return new TaskTool(session, agents);
 	}
 

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -456,22 +456,30 @@ const discoveryMemo = new Map<string, Promise<DiscoveryResult>>();
 const discoverySnapshots = new Map<string, AgentDefinition[]>();
 let discoveryMemoFn: typeof discoverAgents | undefined;
 
-/** Stable cache identity for the filesystem root and ordered effective extension paths. */
-function discoveryCacheKey(cwd: string, configuredExtensionPaths?: readonly string[]): string {
-	return `${path.resolve(cwd)}\0${JSON.stringify(configuredExtensionPaths ?? null)}`;
+/** Stable cache identity for the filesystem root, ordered effective extension paths, and discovery mode. */
+function discoveryCacheKey(
+	cwd: string,
+	configuredExtensionPaths?: readonly string[],
+	extensionRootMode?: "merge" | "explicit-only",
+): string {
+	return `${path.resolve(cwd)}\0${JSON.stringify(configuredExtensionPaths ?? null)}\0${extensionRootMode ?? "merge"}`;
 }
 
-function discoverAgentsForCreate(cwd: string, configuredExtensionPaths?: readonly string[]): Promise<DiscoveryResult> {
+function discoverAgentsForCreate(
+	cwd: string,
+	configuredExtensionPaths?: readonly string[],
+	extensionRootMode?: "merge" | "explicit-only",
+): Promise<DiscoveryResult> {
 	const fn = discoverAgents;
 	if (discoveryMemoFn !== fn) {
 		discoveryMemoFn = fn;
 		discoveryMemo.clear();
 		discoverySnapshots.clear();
 	}
-	const key = discoveryCacheKey(cwd, configuredExtensionPaths);
+	const key = discoveryCacheKey(cwd, configuredExtensionPaths, extensionRootMode);
 	let pending = discoveryMemo.get(key);
 	if (!pending) {
-		pending = fn(cwd, undefined, configuredExtensionPaths);
+		pending = fn(cwd, undefined, configuredExtensionPaths, extensionRootMode);
 		discoveryMemo.set(key, pending);
 		pending.catch(() => {
 			if (discoveryMemo.get(key) === pending) discoveryMemo.delete(key);
@@ -481,10 +489,14 @@ function discoverAgentsForCreate(cwd: string, configuredExtensionPaths?: readonl
 }
 
 /** Rescan one cwd and publish its definitions to existing and future task tools. */
-export async function refreshAgentDiscovery(cwd: string, configuredExtensionPaths?: readonly string[]): Promise<void> {
-	const key = discoveryCacheKey(cwd, configuredExtensionPaths);
+export async function refreshAgentDiscovery(
+	cwd: string,
+	configuredExtensionPaths?: readonly string[],
+	extensionRootMode?: "merge" | "explicit-only",
+): Promise<void> {
+	const key = discoveryCacheKey(cwd, configuredExtensionPaths, extensionRootMode);
 	discoveryMemo.delete(key);
-	const pending = discoverAgentsForCreate(cwd, configuredExtensionPaths);
+	const pending = discoverAgentsForCreate(cwd, configuredExtensionPaths, extensionRootMode);
 	const { agents } = await pending;
 	if (discoveryMemo.get(key) === pending) {
 		discoverySnapshots.set(key, agents);
@@ -609,7 +621,11 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		return renderDescription({
 			agents:
 				discoverySnapshots.get(
-					discoveryCacheKey(this.session.cwd, this.session.settings.get("extensions") ?? []),
+					discoveryCacheKey(
+						this.session.cwd,
+						this.session.settings.get("extensions") ?? [],
+						this.session.extensionRootMode,
+					),
 				) ?? this.#discoveredAgents,
 			isolationEnabled: !planMode && isolationMode !== "none",
 			applyIsolatedChanges: this.session.settings.get("task.isolation.apply"),
@@ -675,7 +691,11 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 	 * Create a TaskTool instance with async agent discovery.
 	 */
 	static async create(session: ToolSession): Promise<TaskTool> {
-		const { agents } = await discoverAgentsForCreate(session.cwd, session.settings.get("extensions") ?? []);
+		const { agents } = await discoverAgentsForCreate(
+			session.cwd,
+			session.settings.get("extensions") ?? [],
+			session.extensionRootMode,
+		);
 		return new TaskTool(session, agents);
 	}
 

--- a/packages/coding-agent/src/task/structured-subagent.ts
+++ b/packages/coding-agent/src/task/structured-subagent.ts
@@ -252,7 +252,7 @@ export async function resolveEffectiveSubagentPolicy(
 	assertPlanControlsAllowed(request, planMode);
 	assertDepthAndSpawnAllowed(request, agentName);
 
-	const discovery = await discoverAgents(request.session.cwd);
+	const discovery = await discoverAgents(request.session.cwd, undefined, request.session.settings.get("extensions"));
 	const agent = getAgent(discovery.agents, agentName);
 	if (!agent) {
 		const available = discovery.agents.map(candidate => candidate.name).join(", ") || "none";

--- a/packages/coding-agent/src/task/structured-subagent.ts
+++ b/packages/coding-agent/src/task/structured-subagent.ts
@@ -439,13 +439,10 @@ function buildExecutorOptions(
 		workspaceTree: session.workspaceTree,
 		promptTemplates: session.promptTemplates,
 		rules: session.rules,
-		// Subagents inherit the parent's already-resolved extension module paths.
-		// The parent's raw SDK `additionalExtensionPaths` are intentionally not
-		// re-threaded: child sessions carry no `additionalExtensionPaths`, so
-		// their `effectiveExtensionRoots.explicit` is empty and extension-package
-		// agents/skills reach them only through inherited paths — not a fresh
-		// scoped sub-discovery. Revisit if subagents ever need explicit-root
-		// agents the parent did not itself preload.
+		// Root policy and module paths have separate jobs: the live policy drives
+		// recursive sub-discovery; preloaded paths only avoid re-scanning/reusing
+		// parent-bound extension instances while constructing the child.
+		extensionRoots: session.effectiveExtensionRoots?.bind(session),
 		preloadedExtensionPaths: restrictToolNames ? [] : session.extensionPaths,
 		preloadedCustomToolPaths: restrictToolNames ? [] : session.customToolPaths,
 		localProtocolOptions,

--- a/packages/coding-agent/src/task/structured-subagent.ts
+++ b/packages/coding-agent/src/task/structured-subagent.ts
@@ -252,12 +252,7 @@ export async function resolveEffectiveSubagentPolicy(
 	assertPlanControlsAllowed(request, planMode);
 	assertDepthAndSpawnAllowed(request, agentName);
 
-	const discovery = await discoverAgents(
-		request.session.cwd,
-		undefined,
-		request.session.settings.get("extensions"),
-		request.session.extensionRootMode,
-	);
+	const discovery = await discoverAgents(request.session.cwd, undefined, request.session.effectiveExtensionRoots);
 	const agent = getAgent(discovery.agents, agentName);
 	if (!agent) {
 		const available = discovery.agents.map(candidate => candidate.name).join(", ") || "none";
@@ -444,6 +439,13 @@ function buildExecutorOptions(
 		workspaceTree: session.workspaceTree,
 		promptTemplates: session.promptTemplates,
 		rules: session.rules,
+		// Subagents inherit the parent's already-resolved extension module paths.
+		// The parent's raw SDK `additionalExtensionPaths` are intentionally not
+		// re-threaded: child sessions carry no `additionalExtensionPaths`, so
+		// their `effectiveExtensionRoots.explicit` is empty and extension-package
+		// agents/skills reach them only through inherited paths — not a fresh
+		// scoped sub-discovery. Revisit if subagents ever need explicit-root
+		// agents the parent did not itself preload.
 		preloadedExtensionPaths: restrictToolNames ? [] : session.extensionPaths,
 		preloadedCustomToolPaths: restrictToolNames ? [] : session.customToolPaths,
 		localProtocolOptions,

--- a/packages/coding-agent/src/task/structured-subagent.ts
+++ b/packages/coding-agent/src/task/structured-subagent.ts
@@ -252,7 +252,12 @@ export async function resolveEffectiveSubagentPolicy(
 	assertPlanControlsAllowed(request, planMode);
 	assertDepthAndSpawnAllowed(request, agentName);
 
-	const discovery = await discoverAgents(request.session.cwd, undefined, request.session.settings.get("extensions"));
+	const discovery = await discoverAgents(
+		request.session.cwd,
+		undefined,
+		request.session.settings.get("extensions"),
+		request.session.extensionRootMode,
+	);
 	const agent = getAgent(discovery.agents, agentName);
 	if (!agent) {
 		const available = discovery.agents.map(candidate => candidate.name).join(", ") || "none";

--- a/packages/coding-agent/src/task/structured-subagent.ts
+++ b/packages/coding-agent/src/task/structured-subagent.ts
@@ -252,7 +252,7 @@ export async function resolveEffectiveSubagentPolicy(
 	assertPlanControlsAllowed(request, planMode);
 	assertDepthAndSpawnAllowed(request, agentName);
 
-	const discovery = await discoverAgents(request.session.cwd, undefined, request.session.effectiveExtensionRoots);
+	const discovery = await discoverAgents(request.session.cwd, undefined, request.session.effectiveExtensionRoots?.());
 	const agent = getAgent(discovery.agents, agentName);
 	if (!agent) {
 		const available = discovery.agents.map(candidate => candidate.name).join(", ") || "none";

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -200,11 +200,12 @@ export interface ToolSession {
 	extensionPaths?: string[];
 	/**
 	 * Session-local extension roots for post-startup sub-discovery: explicit SDK
-	 * roots, discovery mode, and configured `extensions:`. Threaded whole so the
-	 * task surface (`TaskTool.create`, preflight, refresh) stays byte-identical
-	 * to the construction-time scoped load.
+	 * roots, discovery mode, and configured `extensions:`. A provider (not a
+	 * stored value) so it is materialized live per discovery call — a runtime
+	 * override or settings reload is reflected, never a construction-time
+	 * snapshot. Keeps the task surface byte-identical to the scoped load.
 	 */
-	effectiveExtensionRoots?: EffectiveExtensionRoots;
+	effectiveExtensionRoots?(): EffectiveExtensionRoots;
 	/**
 	 * Pre-discovered custom-tool source paths from `.omp/tools/`, `.claude/tools/`,
 	 * plugins, etc. Forwarded to subagents so they skip the FS scan but still

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -4,6 +4,7 @@ import type { FetchImpl, ImageContent, Model, ServiceTierByFamily, ToolChoice } 
 import { logger } from "@oh-my-pi/pi-utils";
 import type { AsyncJobManager } from "../async/job-manager";
 import type { Rule } from "../capability/rule";
+import type { EffectiveExtensionRoots } from "../capability/types";
 import type { PromptTemplate } from "../config/prompt-templates";
 import type { Settings } from "../config/settings";
 import { EditTool } from "../edit";
@@ -198,11 +199,12 @@ export interface ToolSession {
 	 */
 	extensionPaths?: string[];
 	/**
-	 * Extension discovery mode for post-startup sub-discovery. `explicit-only`
-	 * (an SDK `disableExtensionDiscovery` session) restricts reloads to the
-	 * session's explicit roots. Defaults to `merge` when unset.
+	 * Session-local extension roots for post-startup sub-discovery: explicit SDK
+	 * roots, discovery mode, and configured `extensions:`. Threaded whole so the
+	 * task surface (`TaskTool.create`, preflight, refresh) stays byte-identical
+	 * to the construction-time scoped load.
 	 */
-	extensionRootMode?: "merge" | "explicit-only";
+	effectiveExtensionRoots?: EffectiveExtensionRoots;
 	/**
 	 * Pre-discovered custom-tool source paths from `.omp/tools/`, `.claude/tools/`,
 	 * plugins, etc. Forwarded to subagents so they skip the FS scan but still

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -198,6 +198,12 @@ export interface ToolSession {
 	 */
 	extensionPaths?: string[];
 	/**
+	 * Extension discovery mode for post-startup sub-discovery. `explicit-only`
+	 * (an SDK `disableExtensionDiscovery` session) restricts reloads to the
+	 * session's explicit roots. Defaults to `merge` when unset.
+	 */
+	extensionRootMode?: "merge" | "explicit-only";
+	/**
 	 * Pre-discovered custom-tool source paths from `.omp/tools/`, `.claude/tools/`,
 	 * plugins, etc. Forwarded to subagents so they skip the FS scan but still
 	 * re-bind tools to their own session-scoped `CustomToolAPI`.

--- a/packages/coding-agent/test/agent-session-configured-extensions.test.ts
+++ b/packages/coding-agent/test/agent-session-configured-extensions.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Regression (#9769 review): `AgentSession.configuredExtensionPaths` must retain
+ * the SDK's explicit `additionalExtensionPaths` for post-startup reloads. Those
+ * roots live only in the construction-time invocation scope, so a getter that
+ * returned just `settings.extensions` dropped them from `refreshSkills`,
+ * `/reload-plugins`, and MCP rediscovery, silently removing the explicitly
+ * supplied packages' skills, commands, agents, and servers.
+ */
+import { afterEach, describe, expect, it } from "bun:test";
+import { Agent } from "@oh-my-pi/pi-agent-core";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { convertToLlm } from "@oh-my-pi/pi-coding-agent/session/messages";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+
+interface SessionInputs {
+	additionalExtensionPaths?: readonly string[];
+	disableExtensionDiscovery?: boolean;
+	extensions?: string[];
+}
+
+describe("AgentSession.configuredExtensionPaths", () => {
+	const sessions: AgentSession[] = [];
+	const authStorages: AuthStorage[] = [];
+
+	afterEach(async () => {
+		for (const session of sessions.splice(0)) await session.dispose();
+		for (const authStorage of authStorages.splice(0)) authStorage.close();
+	});
+
+	async function makeSession(inputs: SessionInputs): Promise<AgentSession> {
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5")!;
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model, systemPrompt: ["Test"], tools: [] },
+			convertToLlm,
+		});
+		const authStorage = await AuthStorage.create(":memory:");
+		authStorages.push(authStorage);
+		const session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({ extensions: inputs.extensions ?? [] }),
+			modelRegistry: new ModelRegistry(authStorage),
+			additionalExtensionPaths: inputs.additionalExtensionPaths,
+			disableExtensionDiscovery: inputs.disableExtensionDiscovery,
+		});
+		sessions.push(session);
+		return session;
+	}
+
+	it("keeps explicit SDK roots when the extensions setting is empty", async () => {
+		const session = await makeSession({ additionalExtensionPaths: ["/ext/explicit"] });
+		expect(session.configuredExtensionPaths).toEqual(["/ext/explicit"]);
+	});
+
+	it("merges explicit roots ahead of the configured extensions setting", async () => {
+		const session = await makeSession({
+			additionalExtensionPaths: ["/ext/explicit"],
+			extensions: ["/ext/configured"],
+		});
+		expect(session.configuredExtensionPaths).toEqual(["/ext/explicit", "/ext/configured"]);
+	});
+
+	it("exposes only explicit roots when discovery is disabled", async () => {
+		const session = await makeSession({
+			additionalExtensionPaths: ["/ext/explicit"],
+			extensions: ["/ext/configured"],
+			disableExtensionDiscovery: true,
+		});
+		expect(session.configuredExtensionPaths).toEqual(["/ext/explicit"]);
+	});
+});

--- a/packages/coding-agent/test/agent-session-configured-extensions.test.ts
+++ b/packages/coding-agent/test/agent-session-configured-extensions.test.ts
@@ -1,19 +1,27 @@
 /**
- * Regression (#9769 review): `AgentSession.effectiveExtensionRoots` must thread
- * the SDK's explicit `additionalExtensionPaths`, the discovery mode, and the
- * live configured `extensions` as three separate lanes for post-startup
- * reloads. Flattening them dropped explicit roots and the `explicit-only` mode
- * from `refreshSkills`, `/reload-plugins`, and MCP rediscovery.
+ * Regression (#9769 review): a session's extension roots must survive
+ * post-startup discovery. Exercised through the real `AgentSession.refreshSkills`
+ * path against on-disk extension packages, so it defends the user-visible
+ * contract — explicit `additionalExtensionPaths` skills still resolve after a
+ * reload, and an `explicit-only` (`disableExtensionDiscovery`) session drops the
+ * ambient `extensions:` configured lane — not merely that the getter echoes its
+ * constructor inputs.
  */
-import { afterEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 import { Agent } from "@oh-my-pi/pi-agent-core";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import "@oh-my-pi/pi-coding-agent/discovery";
+import { setActiveSkills } from "@oh-my-pi/pi-coding-agent/extensibility/skills";
 import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { convertToLlm } from "@oh-my-pi/pi-coding-agent/session/messages";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { removeSyncWithRetries } from "@oh-my-pi/pi-utils";
 
 interface SessionInputs {
 	additionalExtensionPaths?: readonly string[];
@@ -21,13 +29,29 @@ interface SessionInputs {
 	extensions?: string[];
 }
 
-describe("AgentSession.effectiveExtensionRoots", () => {
+/** Write a minimal extension package exposing a single named skill. */
+function buildSkillPackage(dir: string, skillName: string): void {
+	fs.mkdirSync(path.join(dir, "skills", skillName), { recursive: true });
+	fs.writeFileSync(
+		path.join(dir, "skills", skillName, "SKILL.md"),
+		`---\nname: ${skillName}\ndescription: ${skillName} fixture\n---\nbody\n`,
+	);
+}
+
+describe("AgentSession extension-root discovery (post-startup)", () => {
 	const sessions: AgentSession[] = [];
 	const authStorages: AuthStorage[] = [];
+	let tempDir: string;
+
+	beforeEach(() => {
+		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "omp-session-ext-"));
+	});
 
 	afterEach(async () => {
 		for (const session of sessions.splice(0)) await session.dispose();
 		for (const authStorage of authStorages.splice(0)) authStorage.close();
+		setActiveSkills([]);
+		removeSyncWithRetries(tempDir);
 	});
 
 	async function makeSession(inputs: SessionInputs): Promise<AgentSession> {
@@ -46,40 +70,56 @@ describe("AgentSession.effectiveExtensionRoots", () => {
 			modelRegistry: new ModelRegistry(authStorage),
 			additionalExtensionPaths: inputs.additionalExtensionPaths,
 			disableExtensionDiscovery: inputs.disableExtensionDiscovery,
+			skillsReloadable: true,
 		});
 		sessions.push(session);
 		return session;
 	}
 
-	it("keeps explicit SDK roots and merge mode when the extensions setting is empty", async () => {
-		const session = await makeSession({ additionalExtensionPaths: ["/ext/explicit"] });
-		expect(session.effectiveExtensionRoots).toEqual({
-			explicit: ["/ext/explicit"],
-			mode: "merge",
-			configured: [],
-			configuredLevel: "user",
-		});
+	it("surfaces an additionalExtensionPaths package's skills through refreshSkills", async () => {
+		const ext = path.join(tempDir, "explicit-pkg");
+		buildSkillPackage(ext, "explicit-skill");
+		// Empty settings.extensions: the only source is the explicit SDK root,
+		// which lives solely in the construction-time scope. A stale/flattened
+		// getter would drop it on this post-startup reload.
+		const session = await makeSession({ additionalExtensionPaths: [ext] });
+
+		await session.refreshSkills();
+
+		expect(session.skills.map(skill => skill.name)).toContain("explicit-skill");
 	});
 
-	it("keeps explicit and configured in separate lanes under merge mode", async () => {
+	it("drops the ambient configured lane for an explicit-only session on refresh", async () => {
+		const explicitExt = path.join(tempDir, "explicit-pkg");
+		const configuredExt = path.join(tempDir, "configured-pkg");
+		buildSkillPackage(explicitExt, "explicit-skill");
+		buildSkillPackage(configuredExt, "configured-skill");
+		// disableExtensionDiscovery ⇒ explicit-only: the explicit root is honored,
+		// the ambient `extensions:` (configured) root is suppressed on reload.
 		const session = await makeSession({
-			additionalExtensionPaths: ["/ext/explicit"],
-			extensions: ["/ext/configured"],
-		});
-		expect(session.effectiveExtensionRoots).toEqual({
-			explicit: ["/ext/explicit"],
-			mode: "merge",
-			configured: ["/ext/configured"],
-			configuredLevel: "user",
-		});
-	});
-
-	it("reports explicit-only mode when discovery is disabled", async () => {
-		const session = await makeSession({
-			additionalExtensionPaths: ["/ext/explicit"],
-			extensions: ["/ext/configured"],
+			additionalExtensionPaths: [explicitExt],
+			extensions: [configuredExt],
 			disableExtensionDiscovery: true,
 		});
-		expect(session.effectiveExtensionRoots).toMatchObject({ explicit: ["/ext/explicit"], mode: "explicit-only" });
+
+		await session.refreshSkills();
+
+		const names = session.skills.map(skill => skill.name);
+		expect(names).toContain("explicit-skill");
+		expect(names).not.toContain("configured-skill");
+	});
+
+	it("reflects a runtime extensions override on the next refresh", async () => {
+		const configuredExt = path.join(tempDir, "configured-pkg");
+		buildSkillPackage(configuredExt, "configured-skill");
+		const session = await makeSession({});
+
+		await session.refreshSkills();
+		expect(session.skills.map(skill => skill.name)).not.toContain("configured-skill");
+
+		// The live getter reads settings per call, so the override lands on refresh.
+		session.settings.override("extensions", [configuredExt]);
+		await session.refreshSkills();
+		expect(session.skills.map(skill => skill.name)).toContain("configured-skill");
 	});
 });

--- a/packages/coding-agent/test/agent-session-configured-extensions.test.ts
+++ b/packages/coding-agent/test/agent-session-configured-extensions.test.ts
@@ -53,7 +53,12 @@ describe("AgentSession.effectiveExtensionRoots", () => {
 
 	it("keeps explicit SDK roots and merge mode when the extensions setting is empty", async () => {
 		const session = await makeSession({ additionalExtensionPaths: ["/ext/explicit"] });
-		expect(session.effectiveExtensionRoots).toEqual({ explicit: ["/ext/explicit"], mode: "merge", configured: [] });
+		expect(session.effectiveExtensionRoots).toEqual({
+			explicit: ["/ext/explicit"],
+			mode: "merge",
+			configured: [],
+			configuredLevel: "user",
+		});
 	});
 
 	it("keeps explicit and configured in separate lanes under merge mode", async () => {
@@ -65,6 +70,7 @@ describe("AgentSession.effectiveExtensionRoots", () => {
 			explicit: ["/ext/explicit"],
 			mode: "merge",
 			configured: ["/ext/configured"],
+			configuredLevel: "user",
 		});
 	});
 

--- a/packages/coding-agent/test/agent-session-configured-extensions.test.ts
+++ b/packages/coding-agent/test/agent-session-configured-extensions.test.ts
@@ -55,8 +55,8 @@ describe("AgentSession.configuredExtensionPaths", () => {
 	it("keeps explicit SDK roots when the extensions setting is empty", async () => {
 		const session = await makeSession({ additionalExtensionPaths: ["/ext/explicit"] });
 		expect(session.configuredExtensionPaths).toEqual(["/ext/explicit"]);
+		expect(session.extensionRootMode).toBe("merge");
 	});
-
 	it("merges explicit roots ahead of the configured extensions setting", async () => {
 		const session = await makeSession({
 			additionalExtensionPaths: ["/ext/explicit"],
@@ -65,12 +65,13 @@ describe("AgentSession.configuredExtensionPaths", () => {
 		expect(session.configuredExtensionPaths).toEqual(["/ext/explicit", "/ext/configured"]);
 	});
 
-	it("exposes only explicit roots when discovery is disabled", async () => {
+	it("exposes only explicit roots in explicit-only mode when discovery is disabled", async () => {
 		const session = await makeSession({
 			additionalExtensionPaths: ["/ext/explicit"],
 			extensions: ["/ext/configured"],
 			disableExtensionDiscovery: true,
 		});
 		expect(session.configuredExtensionPaths).toEqual(["/ext/explicit"]);
+		expect(session.extensionRootMode).toBe("explicit-only");
 	});
 });

--- a/packages/coding-agent/test/agent-session-configured-extensions.test.ts
+++ b/packages/coding-agent/test/agent-session-configured-extensions.test.ts
@@ -13,6 +13,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { Agent } from "@oh-my-pi/pi-agent-core";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import type { EffectiveExtensionRoots } from "@oh-my-pi/pi-coding-agent/capability/types";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import "@oh-my-pi/pi-coding-agent/discovery";
@@ -21,11 +22,13 @@ import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { convertToLlm } from "@oh-my-pi/pi-coding-agent/session/messages";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { discoverAgents } from "@oh-my-pi/pi-coding-agent/task/discovery";
 import { removeSyncWithRetries } from "@oh-my-pi/pi-utils";
 
 interface SessionInputs {
 	additionalExtensionPaths?: readonly string[];
 	disableExtensionDiscovery?: boolean;
+	extensionRoots?: () => EffectiveExtensionRoots;
 	extensions?: string[];
 }
 
@@ -35,6 +38,15 @@ function buildSkillPackage(dir: string, skillName: string): void {
 	fs.writeFileSync(
 		path.join(dir, "skills", skillName, "SKILL.md"),
 		`---\nname: ${skillName}\ndescription: ${skillName} fixture\n---\nbody\n`,
+	);
+}
+
+/** Write a minimal extension package exposing a single task agent. */
+function buildAgentPackage(dir: string, agentName: string): void {
+	fs.mkdirSync(path.join(dir, "agents"), { recursive: true });
+	fs.writeFileSync(
+		path.join(dir, "agents", `${agentName}.md`),
+		`---\nname: ${agentName}\ndescription: ${agentName} fixture\n---\nHandle the assigned task.\n`,
 	);
 }
 
@@ -70,6 +82,7 @@ describe("AgentSession extension-root discovery (post-startup)", () => {
 			modelRegistry: new ModelRegistry(authStorage),
 			additionalExtensionPaths: inputs.additionalExtensionPaths,
 			disableExtensionDiscovery: inputs.disableExtensionDiscovery,
+			extensionRoots: inputs.extensionRoots,
 			skillsReloadable: true,
 		});
 		sessions.push(session);
@@ -107,6 +120,29 @@ describe("AgentSession extension-root discovery (post-startup)", () => {
 		const names = session.skills.map(skill => skill.name);
 		expect(names).toContain("explicit-skill");
 		expect(names).not.toContain("configured-skill");
+	});
+
+	it("discovers sibling task agents from an inherited explicit-only root policy", async () => {
+		const explicitExt = path.join(tempDir, "explicit-pkg");
+		const configuredExt = path.join(tempDir, "configured-pkg");
+		buildAgentPackage(explicitExt, "explicit-sibling");
+		buildAgentPackage(configuredExt, "configured-sibling");
+		const extensionRoots = (): EffectiveExtensionRoots => ({
+			explicit: [explicitExt],
+			mode: "explicit-only",
+			configured: [configuredExt],
+			configuredLevel: "project",
+		});
+		const session = await makeSession({
+			extensions: [configuredExt],
+			extensionRoots,
+		});
+
+		const { agents } = await discoverAgents(tempDir, tempDir, session.effectiveExtensionRoots);
+		const names = agents.map(agent => agent.name);
+
+		expect(names).toContain("explicit-sibling");
+		expect(names).not.toContain("configured-sibling");
 	});
 
 	it("reflects a runtime extensions override on the next refresh", async () => {

--- a/packages/coding-agent/test/agent-session-configured-extensions.test.ts
+++ b/packages/coding-agent/test/agent-session-configured-extensions.test.ts
@@ -1,10 +1,9 @@
 /**
- * Regression (#9769 review): `AgentSession.configuredExtensionPaths` must retain
- * the SDK's explicit `additionalExtensionPaths` for post-startup reloads. Those
- * roots live only in the construction-time invocation scope, so a getter that
- * returned just `settings.extensions` dropped them from `refreshSkills`,
- * `/reload-plugins`, and MCP rediscovery, silently removing the explicitly
- * supplied packages' skills, commands, agents, and servers.
+ * Regression (#9769 review): `AgentSession.effectiveExtensionRoots` must thread
+ * the SDK's explicit `additionalExtensionPaths`, the discovery mode, and the
+ * live configured `extensions` as three separate lanes for post-startup
+ * reloads. Flattening them dropped explicit roots and the `explicit-only` mode
+ * from `refreshSkills`, `/reload-plugins`, and MCP rediscovery.
  */
 import { afterEach, describe, expect, it } from "bun:test";
 import { Agent } from "@oh-my-pi/pi-agent-core";
@@ -22,7 +21,7 @@ interface SessionInputs {
 	extensions?: string[];
 }
 
-describe("AgentSession.configuredExtensionPaths", () => {
+describe("AgentSession.effectiveExtensionRoots", () => {
 	const sessions: AgentSession[] = [];
 	const authStorages: AuthStorage[] = [];
 
@@ -52,26 +51,29 @@ describe("AgentSession.configuredExtensionPaths", () => {
 		return session;
 	}
 
-	it("keeps explicit SDK roots when the extensions setting is empty", async () => {
+	it("keeps explicit SDK roots and merge mode when the extensions setting is empty", async () => {
 		const session = await makeSession({ additionalExtensionPaths: ["/ext/explicit"] });
-		expect(session.configuredExtensionPaths).toEqual(["/ext/explicit"]);
-		expect(session.extensionRootMode).toBe("merge");
+		expect(session.effectiveExtensionRoots).toEqual({ explicit: ["/ext/explicit"], mode: "merge", configured: [] });
 	});
-	it("merges explicit roots ahead of the configured extensions setting", async () => {
+
+	it("keeps explicit and configured in separate lanes under merge mode", async () => {
 		const session = await makeSession({
 			additionalExtensionPaths: ["/ext/explicit"],
 			extensions: ["/ext/configured"],
 		});
-		expect(session.configuredExtensionPaths).toEqual(["/ext/explicit", "/ext/configured"]);
+		expect(session.effectiveExtensionRoots).toEqual({
+			explicit: ["/ext/explicit"],
+			mode: "merge",
+			configured: ["/ext/configured"],
+		});
 	});
 
-	it("exposes only explicit roots in explicit-only mode when discovery is disabled", async () => {
+	it("reports explicit-only mode when discovery is disabled", async () => {
 		const session = await makeSession({
 			additionalExtensionPaths: ["/ext/explicit"],
 			extensions: ["/ext/configured"],
 			disableExtensionDiscovery: true,
 		});
-		expect(session.configuredExtensionPaths).toEqual(["/ext/explicit"]);
-		expect(session.extensionRootMode).toBe("explicit-only");
+		expect(session.effectiveExtensionRoots).toMatchObject({ explicit: ["/ext/explicit"], mode: "explicit-only" });
 	});
 });

--- a/packages/coding-agent/test/discovery/omp-plugins.test.ts
+++ b/packages/coding-agent/test/discovery/omp-plugins.test.ts
@@ -359,13 +359,16 @@ test("concurrent scopes snapshot their own effective extensions (no cross-sessio
 	expect(secondRoots.map(root => root.path)).toEqual([secondExt]);
 });
 
-test("explicit-only ctx mode excludes ambient/installed roots on scopeless reload (#9769)", async () => {
-	// A disableExtensionDiscovery session reloads outside the invocation scope.
-	// Its LoadContext must carry explicit-only so the refresh honors only the
-	// explicit roots — never installed plugins the caller opted out of.
+test("explicit-only mode drops the configured lane and installed roots (#9769)", async () => {
+	// A disableExtensionDiscovery / `--no-extensions` session must honor only its
+	// explicit roots on reload — never the ambient `extensions:` (configured
+	// lane) or installed plugins the caller opted out of, even when the struct
+	// still carries a nonempty configured array (round-8 leak).
 	const explicitExt = path.join(tempDir, "explicit-extension");
+	const configuredExt = path.join(tempDir, "configured-extension");
 	const installed = path.join(home, ".omp", "plugins", "node_modules", "installed-extension");
 	buildExtensionPackage(explicitExt, "explicit-skill");
+	buildExtensionPackage(configuredExt, "configured-skill");
 	buildExtensionPackage(installed, "installed-skill");
 	writeFile(
 		path.join(home, ".omp", "plugins", "package.json"),
@@ -374,15 +377,15 @@ test("explicit-only ctx mode excludes ambient/installed roots on scopeless reloa
 
 	const mergeRoots = await listOmpExtensionRoots({
 		...ctx(),
-		extensionRoots: { explicit: [explicitExt], mode: "merge", configured: [] },
+		extensionRoots: { explicit: [explicitExt], mode: "merge", configured: [configuredExt] },
 	});
 	expect(mergeRoots.map(root => path.basename(root.path))).toEqual(
-		expect.arrayContaining(["explicit-extension", "installed-extension"]),
+		expect.arrayContaining(["explicit-extension", "configured-extension", "installed-extension"]),
 	);
 
 	const explicitOnlyRoots = await listOmpExtensionRoots({
 		...ctx(),
-		extensionRoots: { explicit: [explicitExt], mode: "explicit-only", configured: [] },
+		extensionRoots: { explicit: [explicitExt], mode: "explicit-only", configured: [configuredExt] },
 	});
 	expect(explicitOnlyRoots.map(root => root.path)).toEqual([explicitExt]);
 });

--- a/packages/coding-agent/test/discovery/omp-plugins.test.ts
+++ b/packages/coding-agent/test/discovery/omp-plugins.test.ts
@@ -32,6 +32,7 @@ import {
 	clearOmpExtensionCliRoots,
 	injectOmpExtensionCliRoots,
 	listOmpExtensionRoots,
+	setInvocationConfiguredExtensions,
 	withOmpExtensionRootScope,
 } from "@oh-my-pi/pi-coding-agent/discovery/omp-extension-roots";
 import { discoverExtensionPaths } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/loader";
@@ -323,6 +324,36 @@ test("invocation scopes isolate concurrent SDK roots and merge ambient roots onl
 	const mergedRoots = await withOmpExtensionRootScope([ext], "merge", () => listOmpExtensionRoots(ctx()));
 	expect(mergedRoots.map(root => root.path)).toEqual(expect.arrayContaining([ext, projectExt, installed]));
 	expect(mergedRoots.map(root => root.path)).not.toContain(staleCli);
+});
+
+test("concurrent scopes snapshot their own effective extensions (no cross-session leak)", async () => {
+	// Reproduces the P1 concurrency hazard: two SDK sessions with different
+	// effective `extensions` must each discover only their own roots, even when
+	// their capability loads interleave during startup.
+	const firstExt = path.join(tempDir, "first-session-extension");
+	const secondExt = path.join(tempDir, "second-session-extension");
+	buildExtensionPackage(firstExt, "first-session-skill");
+	buildExtensionPackage(secondExt, "second-session-skill");
+
+	const firstEntered = Promise.withResolvers<void>();
+	const secondEntered = Promise.withResolvers<void>();
+	const [firstRoots, secondRoots] = await Promise.all([
+		withOmpExtensionRootScope([], "merge", async () => {
+			setInvocationConfiguredExtensions([firstExt]);
+			firstEntered.resolve();
+			await secondEntered.promise;
+			return listOmpExtensionRoots(ctx());
+		}),
+		withOmpExtensionRootScope([], "merge", async () => {
+			setInvocationConfiguredExtensions([secondExt]);
+			secondEntered.resolve();
+			await firstEntered.promise;
+			return listOmpExtensionRoots(ctx());
+		}),
+	]);
+
+	expect(firstRoots.map(root => root.path)).toEqual([firstExt]);
+	expect(secondRoots.map(root => root.path)).toEqual([secondExt]);
 });
 
 test("file-extension entrypoints contribute zero sub-surface (the file has no siblings to scan)", async () => {

--- a/packages/coding-agent/test/discovery/omp-plugins.test.ts
+++ b/packages/coding-agent/test/discovery/omp-plugins.test.ts
@@ -119,17 +119,15 @@ function ctx(): LoadContext {
 	return { cwd: project, home, repoRoot: project };
 }
 
-test("project settings.json#extensions surfaces every sub-directory", async () => {
-	writeFile(path.join(project, ".omp", "settings.json"), JSON.stringify({ extensions: [ext] }));
-
+async function expectExtensionSubDirectoriesLoaded(context: LoadContext): Promise<void> {
 	const [skills, commands, rules, prompts, hooks, tools, mcps] = await Promise.all([
-		loadFromPlugin<{ name: string }>(skillCapability.id, ctx()),
-		loadFromPlugin<{ name: string }>(slashCommandCapability.id, ctx()),
-		loadFromPlugin<{ name: string }>(ruleCapability.id, ctx()),
-		loadFromPlugin<{ name: string }>(promptCapability.id, ctx()),
-		loadFromPlugin<{ name: string; type: "pre" | "post" }>(hookCapability.id, ctx()),
-		loadFromPlugin<{ name: string }>(toolCapability.id, ctx()),
-		loadFromPlugin<{ name: string; command?: string }>(mcpCapability.id, ctx()),
+		loadFromPlugin<{ name: string }>(skillCapability.id, context),
+		loadFromPlugin<{ name: string }>(slashCommandCapability.id, context),
+		loadFromPlugin<{ name: string }>(ruleCapability.id, context),
+		loadFromPlugin<{ name: string }>(promptCapability.id, context),
+		loadFromPlugin<{ name: string; type: "pre" | "post" }>(hookCapability.id, context),
+		loadFromPlugin<{ name: string }>(toolCapability.id, context),
+		loadFromPlugin<{ name: string; command?: string }>(mcpCapability.id, context),
 	]);
 
 	expect(skills.map(s => s.name)).toContain("my-skill");
@@ -140,6 +138,11 @@ test("project settings.json#extensions surfaces every sub-directory", async () =
 	expect(hooks.some(h => h.name === "edit.sh" && h.type === "post")).toBe(true);
 	expect(tools.map(t => t.name)).toEqual(expect.arrayContaining(["wcount", "deep-tool"]));
 	expect(mcps.find(m => m.name === "lsp")?.command).toBe("lsp-server");
+}
+
+test("project settings.json#extensions surfaces every sub-directory", async () => {
+	writeFile(path.join(project, ".omp", "settings.json"), JSON.stringify({ extensions: [ext] }));
+	await expectExtensionSubDirectoriesLoaded(ctx());
 });
 
 test("user settings.json#extensions also feeds sub-discovery", async () => {
@@ -150,29 +153,8 @@ test("user settings.json#extensions also feeds sub-discovery", async () => {
 });
 
 test("project config.yml#extensions surfaces every sub-directory (#9768)", async () => {
-	// config.yml is the canonical settings store; settings.json is a legacy
-	// migration source. Before the fix, listOmpExtensionRoots read only
-	// settings.json, so a config.yml-declared extension loaded its module but
-	// never sub-discovered its skills/hooks/etc.
 	writeFile(path.join(project, ".omp", "config.yml"), `extensions:\n  - "${ext}"\n`);
-
-	const [skills, commands, rules, prompts, hooks, tools, mcps] = await Promise.all([
-		loadFromPlugin<{ name: string }>(skillCapability.id, ctx()),
-		loadFromPlugin<{ name: string }>(slashCommandCapability.id, ctx()),
-		loadFromPlugin<{ name: string }>(ruleCapability.id, ctx()),
-		loadFromPlugin<{ name: string }>(promptCapability.id, ctx()),
-		loadFromPlugin<{ name: string; type: "pre" | "post" }>(hookCapability.id, ctx()),
-		loadFromPlugin<{ name: string }>(toolCapability.id, ctx()),
-		loadFromPlugin<{ name: string; command?: string }>(mcpCapability.id, ctx()),
-	]);
-
-	expect(skills.map(s => s.name)).toContain("my-skill");
-	expect(commands.map(c => c.name)).toContain("greet");
-	expect(rules.map(r => r.name)).toContain("style");
-	expect(prompts.map(p => p.name)).toContain("review");
-	expect(hooks.some(h => h.name === "bash.sh" && h.type === "pre")).toBe(true);
-	expect(tools.map(t => t.name)).toEqual(expect.arrayContaining(["wcount", "deep-tool"]));
-	expect(mcps.find(m => m.name === "lsp")?.command).toBe("lsp-server");
+	await expectExtensionSubDirectoriesLoaded(ctx());
 });
 
 test("user config.yaml#extensions feeds sub-discovery", async () => {
@@ -183,14 +165,60 @@ test("user config.yaml#extensions feeds sub-discovery", async () => {
 	expect(skills.map(s => s.name)).toContain("my-skill");
 });
 
-test("config.yml and settings.json naming the same package dedup to one root", async () => {
-	// Both surfaces feed the module loader; keeping two spellings would
-	// otherwise double-count the package. First-seen-wins dedup collapses them.
-	writeFile(path.join(project, ".omp", "config.yml"), `extensions:\n  - "${ext}"\n`);
-	writeFile(path.join(project, ".omp", "settings.json"), JSON.stringify({ extensions: [ext] }));
+test("project config.yml#extensions replaces lower-precedence configured roots", async () => {
+	const userExt = path.join(tempDir, "user-extension");
+	const projectSettingsExt = path.join(tempDir, "project-settings-extension");
+	const projectConfigExt = path.join(tempDir, "project-config-extension");
+	buildExtensionPackage(userExt, "user-skill");
+	buildExtensionPackage(projectSettingsExt, "project-settings-skill");
+	buildExtensionPackage(projectConfigExt, "project-config-skill");
+	writeFile(path.join(home, ".omp", "agent", "config.yml"), `extensions:\n  - "${userExt}"\n`);
+	writeFile(path.join(project, ".omp", "settings.json"), JSON.stringify({ extensions: [projectSettingsExt] }));
+	writeFile(path.join(project, ".omp", "config.yml"), `extensions:\n  - "${projectConfigExt}"\n`);
 
-	const roots = await listOmpExtensionRoots(ctx());
-	expect(roots.map(r => r.path)).toEqual([ext]);
+	const skills = await loadFromPlugin<{ name: string }>(skillCapability.id, ctx());
+	const names = skills.map(skill => skill.name);
+	expect(names).toContain("project-config-skill");
+	expect(names).not.toContain("project-settings-skill");
+	expect(names).not.toContain("user-skill");
+});
+
+test("effective extensions replace persisted roots for overlays and runtime overrides", async () => {
+	const persistedExt = path.join(tempDir, "persisted-extension");
+	const overrideExt = path.join(tempDir, "override-extension");
+	buildExtensionPackage(persistedExt, "persisted-skill");
+	buildExtensionPackage(overrideExt, "override-skill");
+	writeFile(path.join(project, ".omp", "config.yml"), `extensions:\n  - "${persistedExt}"\n`);
+
+	const context: LoadContext = { ...ctx(), configuredExtensionPaths: [overrideExt] };
+	const skills = await loadFromPlugin<{ name: string }>(skillCapability.id, context);
+	const names = skills.map(skill => skill.name);
+	expect(names).toContain("override-skill");
+	expect(names).not.toContain("persisted-skill");
+
+	const emptyOverride: LoadContext = { ...ctx(), configuredExtensionPaths: [] };
+	const emptySkills = await loadFromPlugin<{ name: string }>(skillCapability.id, emptyOverride);
+	expect(emptySkills.map(skill => skill.name)).not.toContain("persisted-skill");
+});
+
+test("empty project config.yml#extensions suppresses user roots", async () => {
+	const userExt = path.join(tempDir, "user-extension");
+	buildExtensionPackage(userExt, "user-skill");
+	writeFile(path.join(home, ".omp", "agent", "config.yml"), `extensions:\n  - "${userExt}"\n`);
+	writeFile(path.join(project, ".omp", "config.yml"), "extensions: []\n");
+
+	const skills = await loadFromPlugin<{ name: string }>(skillCapability.id, ctx());
+	expect(skills.map(skill => skill.name)).not.toContain("user-skill");
+});
+
+test("user YAML config suppresses its legacy settings.json migration source", async () => {
+	const legacyExt = path.join(tempDir, "legacy-extension");
+	buildExtensionPackage(legacyExt, "legacy-skill");
+	writeFile(path.join(home, ".omp", "agent", "settings.json"), JSON.stringify({ extensions: [legacyExt] }));
+	writeFile(path.join(home, ".omp", "agent", "config.yml"), "theme:\n  dark: default\n");
+
+	const skills = await loadFromPlugin<{ name: string }>(skillCapability.id, ctx());
+	expect(skills.map(skill => skill.name)).not.toContain("legacy-skill");
 });
 
 test("`--extension` CLI injection is wired through the same provider", async () => {

--- a/packages/coding-agent/test/discovery/omp-plugins.test.ts
+++ b/packages/coding-agent/test/discovery/omp-plugins.test.ts
@@ -193,14 +193,17 @@ test("effective extensions replace persisted roots for overlays and runtime over
 
 	const context: LoadContext = {
 		...ctx(),
-		extensionRoots: { explicit: [], mode: "merge", configured: [overrideExt] },
+		extensionRoots: { explicit: [], mode: "merge", configured: [overrideExt], configuredLevel: "user" },
 	};
 	const skills = await loadFromPlugin<{ name: string }>(skillCapability.id, context);
 	const names = skills.map(skill => skill.name);
 	expect(names).toContain("override-skill");
 	expect(names).not.toContain("persisted-skill");
 
-	const emptyOverride: LoadContext = { ...ctx(), extensionRoots: { explicit: [], mode: "merge", configured: [] } };
+	const emptyOverride: LoadContext = {
+		...ctx(),
+		extensionRoots: { explicit: [], mode: "merge", configured: [], configuredLevel: "user" },
+	};
 	const emptySkills = await loadFromPlugin<{ name: string }>(skillCapability.id, emptyOverride);
 	expect(emptySkills.map(skill => skill.name)).not.toContain("persisted-skill");
 });
@@ -377,7 +380,12 @@ test("explicit-only mode drops the configured lane and installed roots (#9769)",
 
 	const mergeRoots = await listOmpExtensionRoots({
 		...ctx(),
-		extensionRoots: { explicit: [explicitExt], mode: "merge", configured: [configuredExt] },
+		extensionRoots: {
+			explicit: [explicitExt],
+			mode: "merge",
+			configured: [configuredExt],
+			configuredLevel: "project",
+		},
 	});
 	expect(mergeRoots.map(root => path.basename(root.path))).toEqual(
 		expect.arrayContaining(["explicit-extension", "configured-extension", "installed-extension"]),
@@ -385,9 +393,35 @@ test("explicit-only mode drops the configured lane and installed roots (#9769)",
 
 	const explicitOnlyRoots = await listOmpExtensionRoots({
 		...ctx(),
-		extensionRoots: { explicit: [explicitExt], mode: "explicit-only", configured: [configuredExt] },
+		extensionRoots: {
+			explicit: [explicitExt],
+			mode: "explicit-only",
+			configured: [configuredExt],
+			configuredLevel: "project",
+		},
 	});
 	expect(explicitOnlyRoots.map(root => root.path)).toEqual([explicitExt]);
+});
+
+test("configured lane takes its level from the authority's configuredLevel, not the disk scan (#9769)", async () => {
+	// A project provider Settings can't see on the `.omp` disk scan (e.g.
+	// `.claude/settings.json`) still yields a project-level root because the
+	// session carries the Settings-resolved provenance in the struct.
+	const configuredExt = path.join(tempDir, "provenance-extension");
+	buildExtensionPackage(configuredExt, "provenance-skill");
+	// Nothing on `.omp` disk configures it — the old deepEquals scan would label it `user`.
+
+	const asProject = await listOmpExtensionRoots({
+		...ctx(),
+		extensionRoots: { explicit: [], mode: "merge", configured: [configuredExt], configuredLevel: "project" },
+	});
+	expect(asProject.find(root => root.path === configuredExt)?.level).toBe("project");
+
+	const asUser = await listOmpExtensionRoots({
+		...ctx(),
+		extensionRoots: { explicit: [], mode: "merge", configured: [configuredExt], configuredLevel: "user" },
+	});
+	expect(asUser.find(root => root.path === configuredExt)?.level).toBe("user");
 });
 
 test("scopeless reload with session roots equals the construction-time scoped load (#9769 invariant)", async () => {
@@ -411,13 +445,15 @@ test("scopeless reload with session roots equals the construction-time scoped lo
 
 	for (const mode of ["merge", "explicit-only"] as const) {
 		for (const configured of [[configuredExt], []]) {
-			const roots = { explicit: [explicitExt], mode, configured };
-			const scoped = await withOmpExtensionRootScope(roots.explicit, roots.mode, () => {
-				setInvocationConfiguredExtensions(roots.configured);
-				return listOmpExtensionRoots(ctx());
-			});
-			const reloaded = await listOmpExtensionRoots({ ...ctx(), extensionRoots: roots });
-			expect(reloaded).toEqual(scoped);
+			for (const configuredLevel of ["user", "project"] as const) {
+				const roots = { explicit: [explicitExt], mode, configured, configuredLevel };
+				const scoped = await withOmpExtensionRootScope(roots.explicit, roots.mode, () => {
+					setInvocationConfiguredExtensions(roots.configured, roots.configuredLevel);
+					return listOmpExtensionRoots(ctx());
+				});
+				const reloaded = await listOmpExtensionRoots({ ...ctx(), extensionRoots: roots });
+				expect(reloaded).toEqual(scoped);
+			}
 		}
 	}
 });
@@ -431,7 +467,7 @@ test("loadCapability extensionRoots surfaces override extensions outside any sco
 
 	const withOption = await loadCapability<{ name: string }>(skillCapability.id, {
 		cwd: project,
-		extensionRoots: { explicit: [], mode: "merge", configured: [overrideExt] },
+		extensionRoots: { explicit: [], mode: "merge", configured: [overrideExt], configuredLevel: "user" },
 	});
 	expect(withOption.items.map(skill => skill.name)).toContain("runtime-override-skill");
 

--- a/packages/coding-agent/test/discovery/omp-plugins.test.ts
+++ b/packages/coding-agent/test/discovery/omp-plugins.test.ts
@@ -356,6 +356,36 @@ test("concurrent scopes snapshot their own effective extensions (no cross-sessio
 	expect(secondRoots.map(root => root.path)).toEqual([secondExt]);
 });
 
+test("explicit-only ctx mode excludes ambient/installed roots on scopeless reload (#9769)", async () => {
+	// A disableExtensionDiscovery session reloads outside the invocation scope.
+	// Its LoadContext must carry explicit-only so the refresh honors only the
+	// explicit roots — never installed plugins the caller opted out of.
+	const explicitExt = path.join(tempDir, "explicit-extension");
+	const installed = path.join(home, ".omp", "plugins", "node_modules", "installed-extension");
+	buildExtensionPackage(explicitExt, "explicit-skill");
+	buildExtensionPackage(installed, "installed-skill");
+	writeFile(
+		path.join(home, ".omp", "plugins", "package.json"),
+		JSON.stringify({ name: "omp-plugins", dependencies: { "installed-extension": "1.0.0" } }),
+	);
+
+	const mergeRoots = await listOmpExtensionRoots({
+		...ctx(),
+		configuredExtensionPaths: [explicitExt],
+		extensionRootMode: "merge",
+	});
+	expect(mergeRoots.map(root => path.basename(root.path))).toEqual(
+		expect.arrayContaining(["explicit-extension", "installed-extension"]),
+	);
+
+	const explicitOnlyRoots = await listOmpExtensionRoots({
+		...ctx(),
+		configuredExtensionPaths: [explicitExt],
+		extensionRootMode: "explicit-only",
+	});
+	expect(explicitOnlyRoots.map(root => root.path)).toEqual([explicitExt]);
+});
+
 test("loadCapability configuredExtensionPaths surfaces override extensions outside any scope (#9769)", async () => {
 	// refreshSkills / slash-command reloads run outside the construction-time
 	// invocation scope. The effective extensions must arrive via the explicit

--- a/packages/coding-agent/test/discovery/omp-plugins.test.ts
+++ b/packages/coding-agent/test/discovery/omp-plugins.test.ts
@@ -149,6 +149,50 @@ test("user settings.json#extensions also feeds sub-discovery", async () => {
 	expect(skills.map(s => s.name)).toContain("my-skill");
 });
 
+test("project config.yml#extensions surfaces every sub-directory (#9768)", async () => {
+	// config.yml is the canonical settings store; settings.json is a legacy
+	// migration source. Before the fix, listOmpExtensionRoots read only
+	// settings.json, so a config.yml-declared extension loaded its module but
+	// never sub-discovered its skills/hooks/etc.
+	writeFile(path.join(project, ".omp", "config.yml"), `extensions:\n  - "${ext}"\n`);
+
+	const [skills, commands, rules, prompts, hooks, tools, mcps] = await Promise.all([
+		loadFromPlugin<{ name: string }>(skillCapability.id, ctx()),
+		loadFromPlugin<{ name: string }>(slashCommandCapability.id, ctx()),
+		loadFromPlugin<{ name: string }>(ruleCapability.id, ctx()),
+		loadFromPlugin<{ name: string }>(promptCapability.id, ctx()),
+		loadFromPlugin<{ name: string; type: "pre" | "post" }>(hookCapability.id, ctx()),
+		loadFromPlugin<{ name: string }>(toolCapability.id, ctx()),
+		loadFromPlugin<{ name: string; command?: string }>(mcpCapability.id, ctx()),
+	]);
+
+	expect(skills.map(s => s.name)).toContain("my-skill");
+	expect(commands.map(c => c.name)).toContain("greet");
+	expect(rules.map(r => r.name)).toContain("style");
+	expect(prompts.map(p => p.name)).toContain("review");
+	expect(hooks.some(h => h.name === "bash.sh" && h.type === "pre")).toBe(true);
+	expect(tools.map(t => t.name)).toEqual(expect.arrayContaining(["wcount", "deep-tool"]));
+	expect(mcps.find(m => m.name === "lsp")?.command).toBe("lsp-server");
+});
+
+test("user config.yaml#extensions feeds sub-discovery", async () => {
+	// User scope also honors the legacy-compatible `config.yaml` filename.
+	writeFile(path.join(home, ".omp", "agent", "config.yaml"), `extensions:\n  - "${ext}"\n`);
+
+	const skills = await loadFromPlugin<{ name: string }>(skillCapability.id, ctx());
+	expect(skills.map(s => s.name)).toContain("my-skill");
+});
+
+test("config.yml and settings.json naming the same package dedup to one root", async () => {
+	// Both surfaces feed the module loader; keeping two spellings would
+	// otherwise double-count the package. First-seen-wins dedup collapses them.
+	writeFile(path.join(project, ".omp", "config.yml"), `extensions:\n  - "${ext}"\n`);
+	writeFile(path.join(project, ".omp", "settings.json"), JSON.stringify({ extensions: [ext] }));
+
+	const roots = await listOmpExtensionRoots(ctx());
+	expect(roots.map(r => r.path)).toEqual([ext]);
+});
+
 test("`--extension` CLI injection is wired through the same provider", async () => {
 	// Empty settings on disk; rely purely on CLI injection.
 	injectOmpExtensionCliRoots([ext], home, project);

--- a/packages/coding-agent/test/discovery/omp-plugins.test.ts
+++ b/packages/coding-agent/test/discovery/omp-plugins.test.ts
@@ -16,7 +16,7 @@ import { afterEach, beforeEach, expect, test } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { getCapability } from "@oh-my-pi/pi-coding-agent/capability";
+import { getCapability, loadCapability } from "@oh-my-pi/pi-coding-agent/capability";
 import { clearCache } from "@oh-my-pi/pi-coding-agent/capability/fs";
 import { hookCapability } from "@oh-my-pi/pi-coding-agent/capability/hook";
 import { mcpCapability } from "@oh-my-pi/pi-coding-agent/capability/mcp";
@@ -354,6 +354,24 @@ test("concurrent scopes snapshot their own effective extensions (no cross-sessio
 
 	expect(firstRoots.map(root => root.path)).toEqual([firstExt]);
 	expect(secondRoots.map(root => root.path)).toEqual([secondExt]);
+});
+
+test("loadCapability configuredExtensionPaths surfaces override extensions outside any scope (#9769)", async () => {
+	// refreshSkills / slash-command reloads run outside the construction-time
+	// invocation scope. The effective extensions must arrive via the explicit
+	// option so overlay/override extensions survive; omitting it falls back to
+	// the (empty) persisted config on disk.
+	const overrideExt = path.join(tempDir, "runtime-override-extension");
+	buildExtensionPackage(overrideExt, "runtime-override-skill");
+
+	const withOption = await loadCapability<{ name: string }>(skillCapability.id, {
+		cwd: project,
+		configuredExtensionPaths: [overrideExt],
+	});
+	expect(withOption.items.map(skill => skill.name)).toContain("runtime-override-skill");
+
+	const withoutOption = await loadCapability<{ name: string }>(skillCapability.id, { cwd: project });
+	expect(withoutOption.items.map(skill => skill.name)).not.toContain("runtime-override-skill");
 });
 
 test("file-extension entrypoints contribute zero sub-surface (the file has no siblings to scan)", async () => {

--- a/packages/coding-agent/test/discovery/omp-plugins.test.ts
+++ b/packages/coding-agent/test/discovery/omp-plugins.test.ts
@@ -191,13 +191,16 @@ test("effective extensions replace persisted roots for overlays and runtime over
 	buildExtensionPackage(overrideExt, "override-skill");
 	writeFile(path.join(project, ".omp", "config.yml"), `extensions:\n  - "${persistedExt}"\n`);
 
-	const context: LoadContext = { ...ctx(), configuredExtensionPaths: [overrideExt] };
+	const context: LoadContext = {
+		...ctx(),
+		extensionRoots: { explicit: [], mode: "merge", configured: [overrideExt] },
+	};
 	const skills = await loadFromPlugin<{ name: string }>(skillCapability.id, context);
 	const names = skills.map(skill => skill.name);
 	expect(names).toContain("override-skill");
 	expect(names).not.toContain("persisted-skill");
 
-	const emptyOverride: LoadContext = { ...ctx(), configuredExtensionPaths: [] };
+	const emptyOverride: LoadContext = { ...ctx(), extensionRoots: { explicit: [], mode: "merge", configured: [] } };
 	const emptySkills = await loadFromPlugin<{ name: string }>(skillCapability.id, emptyOverride);
 	expect(emptySkills.map(skill => skill.name)).not.toContain("persisted-skill");
 });
@@ -371,8 +374,7 @@ test("explicit-only ctx mode excludes ambient/installed roots on scopeless reloa
 
 	const mergeRoots = await listOmpExtensionRoots({
 		...ctx(),
-		configuredExtensionPaths: [explicitExt],
-		extensionRootMode: "merge",
+		extensionRoots: { explicit: [explicitExt], mode: "merge", configured: [] },
 	});
 	expect(mergeRoots.map(root => path.basename(root.path))).toEqual(
 		expect.arrayContaining(["explicit-extension", "installed-extension"]),
@@ -380,23 +382,53 @@ test("explicit-only ctx mode excludes ambient/installed roots on scopeless reloa
 
 	const explicitOnlyRoots = await listOmpExtensionRoots({
 		...ctx(),
-		configuredExtensionPaths: [explicitExt],
-		extensionRootMode: "explicit-only",
+		extensionRoots: { explicit: [explicitExt], mode: "explicit-only", configured: [] },
 	});
 	expect(explicitOnlyRoots.map(root => root.path)).toEqual([explicitExt]);
 });
 
-test("loadCapability configuredExtensionPaths surfaces override extensions outside any scope (#9769)", async () => {
+test("scopeless reload with session roots equals the construction-time scoped load (#9769 invariant)", async () => {
+	// The single invariant that retires the per-surface regressions: for any
+	// session, listOmpExtensionRoots outside the construction scope with
+	// session.effectiveExtensionRoots returns byte-identical roots (paths,
+	// levels, order) to the construction-time scoped call — across the whole
+	// 2×2 grid of explicit-only × has-configured.
+	const explicitExt = path.join(tempDir, "invariant-explicit");
+	const configuredExt = path.join(tempDir, "invariant-configured");
+	const installed = path.join(home, ".omp", "plugins", "node_modules", "invariant-installed");
+	buildExtensionPackage(explicitExt, "invariant-explicit-skill");
+	buildExtensionPackage(configuredExt, "invariant-configured-skill");
+	buildExtensionPackage(installed, "invariant-installed-skill");
+	// Persist the configured lane at project scope so its provenance resolves to `project`.
+	writeFile(path.join(project, ".omp", "config.yml"), `extensions:\n  - "${configuredExt}"\n`);
+	writeFile(
+		path.join(home, ".omp", "plugins", "package.json"),
+		JSON.stringify({ name: "omp-plugins", dependencies: { "invariant-installed": "1.0.0" } }),
+	);
+
+	for (const mode of ["merge", "explicit-only"] as const) {
+		for (const configured of [[configuredExt], []]) {
+			const roots = { explicit: [explicitExt], mode, configured };
+			const scoped = await withOmpExtensionRootScope(roots.explicit, roots.mode, () => {
+				setInvocationConfiguredExtensions(roots.configured);
+				return listOmpExtensionRoots(ctx());
+			});
+			const reloaded = await listOmpExtensionRoots({ ...ctx(), extensionRoots: roots });
+			expect(reloaded).toEqual(scoped);
+		}
+	}
+});
+
+test("loadCapability extensionRoots surfaces override extensions outside any scope (#9769)", async () => {
 	// refreshSkills / slash-command reloads run outside the construction-time
-	// invocation scope. The effective extensions must arrive via the explicit
-	// option so overlay/override extensions survive; omitting it falls back to
-	// the (empty) persisted config on disk.
+	// invocation scope. The effective roots must arrive via the explicit option
+	// so overlay/override extensions survive; omitting it falls back to disk.
 	const overrideExt = path.join(tempDir, "runtime-override-extension");
 	buildExtensionPackage(overrideExt, "runtime-override-skill");
 
 	const withOption = await loadCapability<{ name: string }>(skillCapability.id, {
 		cwd: project,
-		configuredExtensionPaths: [overrideExt],
+		extensionRoots: { explicit: [], mode: "merge", configured: [overrideExt] },
 	});
 	expect(withOption.items.map(skill => skill.name)).toContain("runtime-override-skill");
 

--- a/packages/coding-agent/test/mcp-config-scope-dedup.test.ts
+++ b/packages/coding-agent/test/mcp-config-scope-dedup.test.ts
@@ -117,7 +117,7 @@ describe("MCP scope filtering precedes connection-equivalence deduplication", ()
 
 			const withEffectiveRoots = await loadAllMCPConfigs(projectDir, {
 				filterExa: false,
-				extensionRoots: { explicit: [extensionDir], mode: "merge", configured: [] },
+				extensionRoots: { explicit: [extensionDir], mode: "merge", configured: [], configuredLevel: "user" },
 			});
 			expect(withEffectiveRoots.configs.extensionserver).toMatchObject({ command: "extension-mcp" });
 

--- a/packages/coding-agent/test/mcp-config-scope-dedup.test.ts
+++ b/packages/coding-agent/test/mcp-config-scope-dedup.test.ts
@@ -17,7 +17,7 @@ import * as path from "node:path";
 import { clearCache as clearFsCache } from "@oh-my-pi/pi-coding-agent/capability/fs";
 import { loadAllMCPConfigs } from "@oh-my-pi/pi-coding-agent/mcp/config";
 import { getConfigRootDir, removeWithRetries, setAgentDir } from "@oh-my-pi/pi-utils";
-import "@oh-my-pi/pi-coding-agent/discovery/builtin";
+import "@oh-my-pi/pi-coding-agent/discovery";
 
 const originalAgentDirEnv = process.env.PI_CODING_AGENT_DIR;
 const fallbackAgentDir = path.join(getConfigRootDir(), "agent");
@@ -105,5 +105,26 @@ describe("MCP scope filtering precedes connection-equivalence deduplication", ()
 		const result = await loadAllMCPConfigs(projectDir, { enableProjectConfig: false, filterExa: false });
 		expect(Object.keys(result.configs)).toEqual(["shared"]);
 		expect(result.sources.shared?.level).toBe("user");
+	});
+
+	test("effective extension roots survive scopeless MCP rediscovery", async () => {
+		const extensionDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-mcp-extension-"));
+		try {
+			await fs.writeFile(
+				path.join(extensionDir, ".mcp.json"),
+				JSON.stringify({ mcpServers: { extensionserver: { command: "extension-mcp" } } }),
+			);
+
+			const withEffectiveRoots = await loadAllMCPConfigs(projectDir, {
+				filterExa: false,
+				configuredExtensionPaths: [extensionDir],
+			});
+			expect(withEffectiveRoots.configs.extensionserver).toMatchObject({ command: "extension-mcp" });
+
+			const diskOnly = await loadAllMCPConfigs(projectDir, { filterExa: false });
+			expect(diskOnly.configs.extensionserver).toBeUndefined();
+		} finally {
+			await removeWithRetries(extensionDir);
+		}
 	});
 });

--- a/packages/coding-agent/test/mcp-config-scope-dedup.test.ts
+++ b/packages/coding-agent/test/mcp-config-scope-dedup.test.ts
@@ -117,7 +117,7 @@ describe("MCP scope filtering precedes connection-equivalence deduplication", ()
 
 			const withEffectiveRoots = await loadAllMCPConfigs(projectDir, {
 				filterExa: false,
-				configuredExtensionPaths: [extensionDir],
+				extensionRoots: { explicit: [extensionDir], mode: "merge", configured: [] },
 			});
 			expect(withEffectiveRoots.configs.extensionserver).toMatchObject({ command: "extension-mcp" });
 

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -1613,4 +1613,25 @@ describe("Settings", () => {
 			});
 		});
 	});
+
+	describe("extensionsSourceLevel", () => {
+		it("reports project when a foreign project provider (.claude/settings.json) supplies extensions", async () => {
+			const claudeSettings = path.join(projectDir, ".claude", "settings.json");
+			fs.mkdirSync(path.dirname(claudeSettings), { recursive: true });
+			fs.writeFileSync(claudeSettings, JSON.stringify({ extensions: ["../claude-ext"] }));
+
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			expect(settings.get("extensions")).toContain("../claude-ext");
+			expect(settings.extensionsSourceLevel()).toBe("project");
+		});
+
+		it("reports user for a user-only setting and for runtime overrides", async () => {
+			await writeSettings({ extensions: ["../user-ext"] });
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			expect(settings.extensionsSourceLevel()).toBe("user");
+
+			settings.override("extensions", ["../override-ext"]);
+			expect(settings.extensionsSourceLevel()).toBe("user");
+		});
+	});
 });

--- a/packages/coding-agent/test/task/create-memo.test.ts
+++ b/packages/coding-agent/test/task/create-memo.test.ts
@@ -27,6 +27,7 @@ function createSession(cwd: string, extensions: readonly string[] = []): ToolSes
 		cwd,
 		hasUI: false,
 		settings: Settings.isolated({ extensions: [...extensions] }),
+		effectiveExtensionRoots: { explicit: [], mode: "merge", configured: [...extensions] },
 		getSessionFile: () => null,
 		getSessionSpawns: () => "*",
 	} as unknown as ToolSession;
@@ -96,7 +97,7 @@ describe("TaskTool.create discovery memo", () => {
 		const existing = await TaskTool.create(session);
 
 		expect(existing.description).toContain("General-purpose task agent");
-		await refreshAgentDiscovery(session.cwd, session.settings.get("extensions"));
+		await refreshAgentDiscovery(session.cwd, session.effectiveExtensionRoots);
 
 		expect(existing.description).toContain("Refreshed task agent");
 		expect(existing.description).not.toContain("General-purpose task agent");

--- a/packages/coding-agent/test/task/create-memo.test.ts
+++ b/packages/coding-agent/test/task/create-memo.test.ts
@@ -27,7 +27,12 @@ function createSession(cwd: string, extensions: readonly string[] = []): ToolSes
 		cwd,
 		hasUI: false,
 		settings: Settings.isolated({ extensions: [...extensions] }),
-		effectiveExtensionRoots: () => ({ explicit: [], mode: "merge", configured: [...extensions] }),
+		effectiveExtensionRoots: () => ({
+			explicit: [],
+			mode: "merge",
+			configured: [...extensions],
+			configuredLevel: "user",
+		}),
 		getSessionFile: () => null,
 		getSessionSpawns: () => "*",
 	} as unknown as ToolSession;
@@ -103,6 +108,7 @@ describe("TaskTool.create discovery memo", () => {
 				explicit: [],
 				mode: "merge" as const,
 				configured: settings.get("extensions") ?? [],
+				configuredLevel: "user" as const,
 			}),
 			getSessionFile: () => null,
 			getSessionSpawns: () => "*",

--- a/packages/coding-agent/test/task/create-memo.test.ts
+++ b/packages/coding-agent/test/task/create-memo.test.ts
@@ -27,7 +27,7 @@ function createSession(cwd: string, extensions: readonly string[] = []): ToolSes
 		cwd,
 		hasUI: false,
 		settings: Settings.isolated({ extensions: [...extensions] }),
-		effectiveExtensionRoots: { explicit: [], mode: "merge", configured: [...extensions] },
+		effectiveExtensionRoots: () => ({ explicit: [], mode: "merge", configured: [...extensions] }),
 		getSessionFile: () => null,
 		getSessionSpawns: () => "*",
 	} as unknown as ToolSession;
@@ -88,6 +88,35 @@ describe("TaskTool.create discovery memo", () => {
 		expect(spy).toHaveBeenCalledTimes(2);
 	});
 
+	it("reflects a runtime settings override through the live provider (no stale snapshot)", async () => {
+		const spy = vi
+			.spyOn(discoveryModule, "discoverAgents")
+			.mockResolvedValueOnce({ agents: TEST_AGENTS, projectAgentsDir: null })
+			.mockResolvedValueOnce({ agents: REFRESHED_AGENTS, projectAgentsDir: null });
+		const settings = Settings.isolated({ extensions: [] });
+		const session = {
+			cwd: "/tmp/omp-memo-live",
+			hasUI: false,
+			settings,
+			// Provider reads settings live — a stored snapshot would freeze the key.
+			effectiveExtensionRoots: () => ({
+				explicit: [],
+				mode: "merge" as const,
+				configured: settings.get("extensions") ?? [],
+			}),
+			getSessionFile: () => null,
+			getSessionSpawns: () => "*",
+		} as unknown as ToolSession;
+
+		const before = await TaskTool.create(session);
+		expect(before.description).toContain("General-purpose task agent");
+
+		settings.override("extensions", ["/extensions/live"]);
+		const after = await TaskTool.create(session);
+		expect(after.description).toContain("Refreshed task agent");
+		expect(spy).toHaveBeenCalledTimes(2);
+	});
+
 	it("publishes refreshed definitions to existing and future tools", async () => {
 		const spy = vi
 			.spyOn(discoveryModule, "discoverAgents")
@@ -97,7 +126,7 @@ describe("TaskTool.create discovery memo", () => {
 		const existing = await TaskTool.create(session);
 
 		expect(existing.description).toContain("General-purpose task agent");
-		await refreshAgentDiscovery(session.cwd, session.effectiveExtensionRoots);
+		await refreshAgentDiscovery(session.cwd, session.effectiveExtensionRoots?.());
 
 		expect(existing.description).toContain("Refreshed task agent");
 		expect(existing.description).not.toContain("General-purpose task agent");

--- a/packages/coding-agent/test/task/create-memo.test.ts
+++ b/packages/coding-agent/test/task/create-memo.test.ts
@@ -22,11 +22,11 @@ const REFRESHED_AGENTS = [
 	},
 ];
 
-function createSession(cwd: string): ToolSession {
+function createSession(cwd: string, extensions: readonly string[] = []): ToolSession {
 	return {
 		cwd,
 		hasUI: false,
-		settings: Settings.isolated({}),
+		settings: Settings.isolated({ extensions: [...extensions] }),
 		getSessionFile: () => null,
 		getSessionSpawns: () => "*",
 	} as unknown as ToolSession;
@@ -60,6 +60,20 @@ describe("TaskTool.create discovery memo", () => {
 		expect(spy).toHaveBeenCalledTimes(2);
 	});
 
+	it("isolates sessions sharing a cwd when effective extensions differ", async () => {
+		const spy = vi
+			.spyOn(discoveryModule, "discoverAgents")
+			.mockResolvedValueOnce({ agents: TEST_AGENTS, projectAgentsDir: null })
+			.mockResolvedValueOnce({ agents: REFRESHED_AGENTS, projectAgentsDir: null });
+
+		const first = await TaskTool.create(createSession("/tmp/omp-memo-shared", ["/extensions/first"]));
+		const second = await TaskTool.create(createSession("/tmp/omp-memo-shared", ["/extensions/second"]));
+
+		expect(spy).toHaveBeenCalledTimes(2);
+		expect(first.description).toContain("General-purpose task agent");
+		expect(second.description).toContain("Refreshed task agent");
+	});
+
 	it("does not cache a rejected discovery", async () => {
 		const spy = vi
 			.spyOn(discoveryModule, "discoverAgents")
@@ -82,7 +96,7 @@ describe("TaskTool.create discovery memo", () => {
 		const existing = await TaskTool.create(session);
 
 		expect(existing.description).toContain("General-purpose task agent");
-		await refreshAgentDiscovery(session.cwd);
+		await refreshAgentDiscovery(session.cwd, session.settings.get("extensions"));
 
 		expect(existing.description).toContain("Refreshed task agent");
 		expect(existing.description).not.toContain("General-purpose task agent");

--- a/packages/coding-agent/test/task/executor-pass-through.test.ts
+++ b/packages/coding-agent/test/task/executor-pass-through.test.ts
@@ -113,7 +113,7 @@ describe("runSubprocess parent-discovery pass-through (issue #2190)", () => {
 		vi.restoreAllMocks();
 	});
 
-	it("forwards rules, preloadedExtensionPaths, and preloadedCustomToolPaths to createAgentSession", async () => {
+	it("forwards rules, extension-root policy, and preloaded source paths to createAgentSession", async () => {
 		const session = yieldEmittingSession();
 		const spy = vi.spyOn(sdkModule, "createAgentSession").mockResolvedValue(createSessionResult(session));
 
@@ -122,10 +122,17 @@ describe("runSubprocess parent-discovery pass-through (issue #2190)", () => {
 		const preloadedCustomToolPaths: ToolPathWithSource[] = [
 			{ path: "tools/x.ts", source: { provider: "config", providerName: "Config", level: "project" } },
 		];
+		const extensionRoots = () => ({
+			explicit: ["/abs/parent/explicit-extension"],
+			mode: "explicit-only" as const,
+			configured: ["/abs/parent/configured-extension"],
+			configuredLevel: "project" as const,
+		});
 
 		const result = await runSubprocess({
 			...baseOptions,
 			rules,
+			extensionRoots,
 			preloadedExtensionPaths,
 			preloadedCustomToolPaths,
 		});
@@ -135,6 +142,7 @@ describe("runSubprocess parent-discovery pass-through (issue #2190)", () => {
 		const forwarded = spy.mock.calls[0]?.[0];
 		// Identity, not equality: passing a clone would defeat the perf fix.
 		expect(forwarded?.rules).toBe(rules);
+		expect(forwarded?.extensionRoots).toBe(extensionRoots);
 		expect(forwarded?.preloadedExtensionPaths).toBe(preloadedExtensionPaths);
 		expect(forwarded?.preloadedCustomToolPaths).toBe(preloadedCustomToolPaths);
 	});

--- a/packages/coding-agent/test/task/structured-subagent.test.ts
+++ b/packages/coding-agent/test/task/structured-subagent.test.ts
@@ -468,7 +468,19 @@ describe("structured subagent primitive", () => {
 		const planSession = session({ planMode: true });
 		Object.assign(planSession, { mcpManager, extensionPaths, customToolPaths });
 		const nonPlanSession = session();
-		Object.assign(nonPlanSession, { mcpManager, extensionPaths, customToolPaths });
+		let explicitRoot = "/plugins/explicit";
+		const extensionRoots = () => ({
+			explicit: [explicitRoot],
+			mode: "explicit-only" as const,
+			configured: ["/plugins/configured"],
+			configuredLevel: "project" as const,
+		});
+		Object.assign(nonPlanSession, {
+			mcpManager,
+			extensionPaths,
+			customToolPaths,
+			effectiveExtensionRoots: extensionRoots,
+		});
 		const mcpDisabledSession = session();
 		mcpDisabledSession.enableMCP = false;
 		const restrictedSession = session();
@@ -507,6 +519,9 @@ describe("structured subagent primitive", () => {
 			preloadedCustomToolPaths: customToolPaths,
 		});
 		expect(options[1]?.restrictToolNames).toBe(false);
+		expect(options[1]?.extensionRoots?.()).toEqual(extensionRoots());
+		explicitRoot = "/plugins/explicit-after-spawn";
+		expect(options[1]?.extensionRoots?.().explicit).toEqual([explicitRoot]);
 		expect(options[2]).toMatchObject({ enableMCP: false });
 		expect(options[2]?.mcpManager).toBeUndefined();
 		expect(options[3]).toMatchObject({


### PR DESCRIPTION
## Repro
A project with `.omp/config.yml` → `extensions: [../my-ext]` and `my-ext/skills/demo/SKILL.md` loads the extension module (factory, tools, commands, hooks all register) but its bundled `skills/` never enter discovery — `skill://demo` returns `Unknown skill`. Moving the identical entry to `.omp/settings.json` wires everything. Reproduced on current main by loading the `omp-plugins` skill discovery provider against both spellings:

```
config.yml extensions -> discovered skills: []
settings.json extensions -> discovered skills: [ "demo" ]
```

## Cause
`listOmpExtensionRoots` in `packages/coding-agent/src/discovery/omp-extension-roots.ts` sourced configured extension paths solely from `<scope>/settings.json` via `readSettingsExtensions()` (literal `JSON.parse`). Extension *module* loading, however, uses `settings.get("extensions")` (`sdk.ts` `discoverSessionExtensionPaths`), which merges the canonical `config.yml`. The two subsystems disagreed about what was configured, so a `config.yml`-only extension ran its factory while its sibling `skills/`, `hooks/`, `tools/`, `commands/`, `rules/`, `prompts/`, and `.mcp.json` never reached the sub-discovery surfaces. The file's own header called the `settings.json` read a mirror of "what `loadExtensionModules` already does" — the mirror was incomplete. This is the still-relevant re-report of #1557, whose fix (#1558) was closed unmerged.

## Fix
- Add `readYamlExtensions()` to parse `extensions:` from a scope's canonical YAML config (`Bun.YAML`), first-present-filename-wins, malformed file yields no entries rather than throwing.
- Add `readScopeExtensions()` to merge each scope's `config.yml`/`config.yaml` with the legacy `settings.json` — both surfaces that feed `settings.get("extensions")`.
- Wire it into `listOmpExtensionRoots`: project reads `.omp/config.yml`, user reads `config.{yml,yaml}` (`MAIN_CONFIG_FILENAMES`); existing first-seen-wins dedup collapses a package named in both surfaces to one root.
- Update the file header and precedence doc to reflect the config.yml source.
- Add regression tests in `test/discovery/omp-plugins.test.ts` (project config.yml surfaces every sub-directory; user config.yaml feeds sub-discovery; config.yml + settings.json dedup to a single root) and a changelog entry.

## Verification
`bun test test/discovery/omp-plugins.test.ts` → 19 pass; `bun test test/task/discovery.test.ts test/marketplace/manager.test.ts` (other `listOmpExtensionRoots` consumers) → 55 pass; `bun check` clean. Manually confirmed the repro flips from `[]` to `[ "demo" ]` for `config.yml` after the fix. Fixes #9768