### PR TITLE
fix(utils): ignore async ERR_SOCKET_CLOSED from node:net internals

### DIFF
--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- OMP no longer exits when Bun 1.4 throws an asynchronous `ERR_SOCKET_CLOSED` from `node:net` internals during socket cleanup.
+
 ## [18.0.5] - 2026-08-25
 
 ### Added

--- a/packages/utils/src/postmortem.ts
+++ b/packages/utils/src/postmortem.ts
@@ -147,6 +147,29 @@ export function isIpcSendEpipe(err: Error): boolean {
 }
 
 /**
+ * Whether an uncaught error is Bun's asynchronous `ERR_SOCKET_CLOSED` thrown
+ * from inside `node:net` internals with no application frames on the stack.
+ *
+ * Bun ≥1.4 can fire the close callback of an already-closed `node:net` socket
+ * on a fresh stack; the throw bypasses every callsite try/catch and surfaces
+ * here as a process-level uncaughtException. Closing an already-closed socket
+ * is inherently a no-op — the socket owner's own `error`/`close` handlers
+ * still drive recovery — so tearing the session down for it is pure loss.
+ * Only frameless internal stacks qualify: an `ERR_SOCKET_CLOSED` raised
+ * through application code keeps the fatal path.
+ */
+export function isInternalSocketClosedError(err: Error): boolean {
+	if (!("code" in err) || err.code !== "ERR_SOCKET_CLOSED") return false;
+	const frames = (err.stack ?? "").split("\n").slice(1);
+	if (frames.length === 0) return false;
+	return frames.every(frame => {
+		const trimmed = frame.trim();
+		if (trimmed === "" || trimmed === "at unknown" || trimmed === "at native") return true;
+		return /\(node:[^)]*\)$/.test(trimmed) || /^at node:/.test(trimmed);
+	});
+}
+
+/**
  * Detect Bun's advanced-serialization (structured-clone) IPC decode failure.
  *
  * When a worker subprocess spawned with `serialization: "advanced"` sends a
@@ -355,6 +378,12 @@ if (isMainThread) {
 			if (isWorkerIpcDeserializeError(err)) {
 				logger.warn("Malformed worker IPC frame; faulting active worker subsystems", { err });
 				faultWorkerIpcChannels(err);
+				return;
+			}
+			if (isInternalSocketClosedError(err)) {
+				logger.warn("Ignoring async ERR_SOCKET_CLOSED from node:net internals; socket owner recovers itself", {
+					err,
+				});
 				return;
 			}
 			await exitAfterFatal("Uncaught Exception", "Uncaught exception", err, Reason.UNCAUGHT_EXCEPTION);

--- a/packages/utils/src/postmortem.ts
+++ b/packages/utils/src/postmortem.ts
@@ -162,11 +162,15 @@ export function isInternalSocketClosedError(err: Error): boolean {
 	if (!("code" in err) || err.code !== "ERR_SOCKET_CLOSED") return false;
 	const frames = (err.stack ?? "").split("\n").slice(1);
 	if (frames.length === 0) return false;
-	return frames.every(frame => {
+	let hasNetFrame = false;
+	const internal = frames.every(frame => {
 		const trimmed = frame.trim();
 		if (trimmed === "" || trimmed === "at unknown" || trimmed === "at native") return true;
-		return /\(node:[^)]*\)$/.test(trimmed) || /^at node:/.test(trimmed);
+		if (!/\(node:[^)]*\)$/.test(trimmed) && !/^at node:/.test(trimmed)) return false;
+		hasNetFrame ||= trimmed.includes("node:net:");
+		return true;
 	});
+	return internal && hasNetFrame;
 }
 
 /**

--- a/packages/utils/test/postmortem-epipe.test.ts
+++ b/packages/utils/test/postmortem-epipe.test.ts
@@ -123,4 +123,32 @@ describe("postmortem broken-pipe handling", () => {
 				.catch(() => {});
 		}
 	});
+
+	function makeSocketClosedErr(stack: string): Error {
+		const err = new Error("Socket is closed");
+		Object.assign(err, { code: "ERR_SOCKET_CLOSED" });
+		err.stack = stack;
+		return err;
+	}
+
+	it("classifies Bun's frameless node:net ERR_SOCKET_CLOSED as internal", () => {
+		// Verbatim stack from the Bun 1.4 async close-callback crash.
+		expect(
+			postmortem.isInternalSocketClosedError(
+				makeSocketClosedErr("Error: Socket is closed\n    at unknown\n    at close (node:net:686:67)"),
+			),
+		).toBe(true);
+	});
+
+	it("keeps ERR_SOCKET_CLOSED fatal when application frames are on the stack", () => {
+		expect(
+			postmortem.isInternalSocketClosedError(
+				makeSocketClosedErr(
+					"Error: Socket is closed\n    at send (/app/src/broker.ts:12:3)\n    at close (node:net:686:67)",
+				),
+			),
+		).toBe(false);
+		const other = Object.assign(new Error("Socket is closed"), { code: "EPIPE" });
+		expect(postmortem.isInternalSocketClosedError(other)).toBe(false);
+	});
 });

--- a/packages/utils/test/postmortem-epipe.test.ts
+++ b/packages/utils/test/postmortem-epipe.test.ts
@@ -4,6 +4,7 @@ import { postmortem } from "@oh-my-pi/pi-utils";
 
 const childFlag = "--stdio-epipe-child";
 const raceChildFlag = "--stdio-epipe-race-child";
+const socketClosedChildFlag = "--socket-closed-child";
 const childFlagIndex = process.argv.indexOf(childFlag);
 if (childFlagIndex >= 0) {
 	const marker = process.argv[childFlagIndex + 1];
@@ -35,10 +36,16 @@ if (childFlagIndex >= 0) {
 	});
 	void Promise.reject(Object.assign(new Error("broken pipe"), { code: "EPIPE", syscall: "write" }));
 	await new Promise<void>(() => {});
+} else if (process.argv.includes(socketClosedChildFlag)) {
+	const err = Object.assign(new Error("Socket is closed"), { code: "ERR_SOCKET_CLOSED" });
+	err.stack = "Error: Socket is closed\n    at unknown\n    at close (node:net:686:67)";
+	process.emit("uncaughtException", err);
+	process.stdout.write("survived\n");
 }
 
-describe("postmortem broken-pipe handling", () => {
-	function makeErr(props: { code?: string; syscall?: string; message?: string }): Error {
+if (!process.argv.includes(socketClosedChildFlag)) {
+	describe("postmortem broken-pipe handling", () => {
+		function makeErr(props: { code?: string; syscall?: string; message?: string }): Error {
 		const err = new Error(props.message ?? "broken pipe");
 		Object.assign(err, { code: props.code, syscall: props.syscall });
 		return err;
@@ -140,6 +147,19 @@ describe("postmortem broken-pipe handling", () => {
 		).toBe(true);
 	});
 
+	it("keeps the process alive for Bun's async node:net close error", async () => {
+		const child = Bun.spawn([process.execPath, "run", import.meta.path, socketClosedChildFlag], {
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		const [exitCode, stdout] = await Promise.all([
+			child.exited,
+			new Response(child.stdout).text(),
+		]);
+		expect(exitCode).toBe(0);
+		expect(stdout).toBe("survived\n");
+	});
+
 	it("keeps ERR_SOCKET_CLOSED fatal when application frames are on the stack", () => {
 		expect(
 			postmortem.isInternalSocketClosedError(
@@ -148,7 +168,16 @@ describe("postmortem broken-pipe handling", () => {
 				),
 			),
 		).toBe(false);
+		expect(postmortem.isInternalSocketClosedError(makeSocketClosedErr("Error: Socket is closed\n    at unknown"))).toBe(
+			false,
+		);
+		expect(
+			postmortem.isInternalSocketClosedError(
+				makeSocketClosedErr("Error: Socket is closed\n    at tick (node:timers:1:1)"),
+			),
+		).toBe(false);
 		const other = Object.assign(new Error("Socket is closed"), { code: "EPIPE" });
 		expect(postmortem.isInternalSocketClosedError(other)).toBe(false);
 	});
-});
+	});
+}


### PR DESCRIPTION
## What

Long Codex sessions no longer exit when Bun 1.4 throws an asynchronous `ERR_SOCKET_CLOSED` during socket cleanup.

## Why

Bun 1.4 can fire the close callback of a closed `node:net` socket on a fresh stack. The stack contains no application frames, only `at unknown` and `at close (node:net:686:67)`. No callsite try/catch can catch this error. It surfaces as a process-level `uncaughtException` and the postmortem handler stops the whole process. This is why sessions still crashed after #9641. That change guards only the synchronous `close()` call.

The postmortem handler now ignores an `ERR_SOCKET_CLOSED` whose stack contains only `node:net` internal frames. A close of a closed socket has no effect, and the socket owner's `error`/`close` handlers do the recovery. An `ERR_SOCKET_CLOSED` with application frames keeps the fatal path. This is the same containment pattern as the worker IPC EPIPE guard (#2997).

Related: #9641

## Testing

- `bun test packages/utils/test/postmortem-epipe.test.ts` passes, with a regression test that uses the verbatim crash stack from production logs
- Smoke test: a process with the postmortem handlers received the exact async crash. Without the guard the process exited with code 1. With the guard the process continued and exited normally.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)