### PR TITLE
feat(collab-web): render LaTeX in transcripts

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -118,6 +118,7 @@
       "dependencies": {
         "@oh-my-pi/pi-utils": "catalog:",
         "@oh-my-pi/pi-wire": "catalog:",
+        "katex": "catalog:",
         "lucide-react": "catalog:",
         "react": "catalog:",
         "react-dom": "catalog:",
@@ -384,6 +385,7 @@
     "chart.js": "^4.5.1",
     "diff": "^9.0.0",
     "fastembed": "2.1.0",
+    "katex": "^0.18.4",
     "kitty-vt-wasm": "^0.2.0",
     "lint-staged": "^17.0.8",
     "lucide-react": "^1.24.0",
@@ -1023,6 +1025,8 @@
 
     "colorette": ["colorette@2.0.20", "", {}, "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="],
 
+    "commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
+
     "content-type": ["content-type@3.0.0", "", {}, "sha512-AIi5H6p0xk5uknXcN3/rmhP8jgp69OfSe/JuKiQAFprJ7UGw7mwj7m4XcmDzlrnJDG+cGpphAINGdU3g3g7kDw=="],
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
@@ -1156,6 +1160,8 @@
     "jsonparse": ["jsonparse@1.3.1", "", {}, "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg=="],
 
     "jsonstream-next": ["jsonstream-next@3.0.0", "", { "dependencies": { "jsonparse": "^1.2.0", "through2": "^4.0.2" }, "bin": { "jsonstream-next": "bin.js" } }, "sha512-aAi6oPhdt7BKyQn1SrIIGZBt0ukKuOUE1qV6kJ3GgioSOYzsRc8z9Hfr1BVmacA/jLe9nARfmgMGgn68BqIAgg=="],
+
+    "katex": ["katex@0.18.4", "", { "dependencies": { "commander": "^8.3.0" }, "bin": { "katex": "cli.js" } }, "sha512-IMPntbRLOU+eu88XDiFKqQ8Akhr9Tv7jDMXqPhjG9SI1JMA4DIgXk4x9k4skJz2NZJXBRbC+2pYBLj9olqcZow=="],
 
     "kitty-vt-wasm": ["kitty-vt-wasm@0.2.0", "", {}, "sha512-RJNzy9r5ql8CKkocjkg0FKC1MZoWM0R8leb2VB5hsgrP/4HHlumeODHriOw4Jk2dDsCOmPxWuwFQyqDiy0m8Kw=="],
 

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
       "chart.js": "^4.5.1",
       "diff": "^9.0.0",
       "fastembed": "2.1.0",
+      "katex": "^0.18.4",
       "kitty-vt-wasm": "^0.2.0",
       "lint-staged": "^17.0.8",
       "lucide-react": "^1.24.0",

--- a/packages/collab-web/CHANGELOG.md
+++ b/packages/collab-web/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added KaTeX rendering for inline and display math in collab transcripts, supporting `$…$`, `$$…$$`, `\(…\)`, and `\[…\]` delimiters.
+
+### Fixed
+
+- Bounded explicit KaTeX dimensions and preserved unfinished bracket-delimited math while transcripts stream.
+
 ## [17.3.8] - 2026-08-19
 
 ### Fixed

--- a/packages/collab-web/package.json
+++ b/packages/collab-web/package.json
@@ -40,6 +40,7 @@
     "@oh-my-pi/pi-utils": "catalog:",
     "@oh-my-pi/pi-wire": "catalog:",
     "lucide-react": "catalog:",
+    "katex": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:"
   },

--- a/packages/collab-web/src/components/transcript/Markdown.tsx
+++ b/packages/collab-web/src/components/transcript/Markdown.tsx
@@ -1,6 +1,7 @@
 import { Marked } from "@oh-my-pi/pi-utils/marked";
 import type { ReactNode } from "react";
 import { memo, useMemo } from "react";
+import { mathExtension } from "./math";
 
 function escapeHtml(s: string): string {
 	return s
@@ -73,6 +74,7 @@ const md = new Marked({
 	},
 	breaks: true,
 });
+md.use(mathExtension);
 
 export const Markdown = memo(function Markdown({ text }: { text: string }): ReactNode {
 	const html = useMemo(() => {

--- a/packages/collab-web/src/components/transcript/math.ts
+++ b/packages/collab-web/src/components/transcript/math.ts
@@ -1,0 +1,63 @@
+import type { MarkedExtension, Tokens } from "@oh-my-pi/pi-utils/marked";
+import {
+	type MathSpan,
+	mathBlockStartIndex,
+	mathStartIndex,
+	tokenizeMathBlock,
+	tokenizeMathSpan,
+} from "@oh-my-pi/pi-utils/math-delimiters";
+import { renderToString } from "katex";
+
+// Bound explicit TeX dimensions to about 260 px at the transcript's 13 px base size.
+const MAX_KATEX_SIZE_EM = 20;
+
+interface MathToken extends Tokens.Generic {
+	type: "math";
+	text: string;
+	display: boolean;
+}
+
+function toMarkedToken(span: MathSpan): MathToken | Tokens.Text {
+	if (!span.complete) return { type: "text", raw: span.raw, text: span.raw };
+	return { type: "math", raw: span.raw, text: span.text, display: span.display };
+}
+
+function isMathToken(token: Tokens.Generic): token is MathToken {
+	return token.type === "math" && typeof token.text === "string" && typeof token.display === "boolean";
+}
+
+function renderMath(token: Tokens.Generic): string | false {
+	if (!isMathToken(token)) return false;
+	return renderToString(token.text, {
+		displayMode: token.display,
+		maxSize: MAX_KATEX_SIZE_EM,
+		throwOnError: false,
+		trust: false,
+	});
+}
+
+/** Tokenizes and renders inline and display math in collab transcript Markdown. */
+export const mathExtension: MarkedExtension = {
+	extensions: [
+		{
+			name: "math",
+			level: "block",
+			start: mathBlockStartIndex,
+			tokenizer(source) {
+				const span = tokenizeMathBlock(source);
+				return span ? toMarkedToken(span) : undefined;
+			},
+			renderer: renderMath,
+		},
+		{
+			name: "math",
+			level: "inline",
+			start: mathStartIndex,
+			tokenizer(source) {
+				const span = tokenizeMathSpan(source);
+				return span ? toMarkedToken(span) : undefined;
+			},
+			renderer: renderMath,
+		},
+	],
+};

--- a/packages/collab-web/src/components/transcript/transcript.css
+++ b/packages/collab-web/src/components/transcript/transcript.css
@@ -232,6 +232,10 @@
 	word-break: keep-all;
 }
 
+.tr-md .katex-display {
+	overflow-x: auto;
+}
+
 .tr-md > :first-child {
 	margin-top: 0;
 }

--- a/packages/collab-web/src/main.tsx
+++ b/packages/collab-web/src/main.tsx
@@ -1,4 +1,5 @@
 import { createRoot } from "react-dom/client";
+import "katex/dist/katex.min.css";
 import { App } from "./app";
 import "./styles/tokens.css";
 import "./styles/base.css";

--- a/packages/collab-web/test/markdown.test.tsx
+++ b/packages/collab-web/test/markdown.test.tsx
@@ -51,4 +51,67 @@ describe("Transcript Markdown", () => {
 		expect(html).not.toContain("&lt;/advisory&gt;");
 	});
 
+	it("renders dollar and bracket math delimiters through KaTeX", () => {
+		const html = renderMarkdown("Inline $x^2$ and \\(y^2\\).\n\n$$\na^2\n$$\n\n\\[\nb^2\n\\]");
+
+		expect(html).toContain('<annotation encoding="application/x-tex">x^2</annotation>');
+		expect(html).toContain('<annotation encoding="application/x-tex">y^2</annotation>');
+		expect(html).toContain('<annotation encoding="application/x-tex">a^2</annotation>');
+		expect(html).toContain('<annotation encoding="application/x-tex">b^2</annotation>');
+		expect(html.match(/class="katex-display"/g)).toHaveLength(2);
+	});
+
+	it("renders a multiline matrix product as one display equation", () => {
+		const html = renderMarkdown(
+			"A matrix product:\n$$\n\\begin{pmatrix} a & b \\\\ c & d \\end{pmatrix}\n\\begin{pmatrix} x \\\\ y \\end{pmatrix}\n=\n\\begin{pmatrix} ax + by \\\\ cx + dy \\end{pmatrix}\n$$",
+		);
+
+		expect(html).toContain('class="katex-display"');
+		expect(html).toContain("\\begin{pmatrix} ax + by");
+		expect(html).not.toContain("<p>$$");
+	});
+
+	it("leaves currency, escaped dollars, code, and unfinished math literal", () => {
+		const html = renderMarkdown(
+			"Prices are $20 and $30. Escaped: \\$5. Code: `$x$`. Streaming: $x. Paren: \\(x. Bracket: \\[y.",
+		);
+
+		expect(html).toContain("Prices are $20 and $30.");
+		expect(html).toContain("Escaped: $5.");
+		expect(html).toContain("Code: <code>$x$</code>.");
+		expect(html).toContain("Streaming: $x");
+		expect(html).toContain("Paren: \\(x");
+		expect(html).toContain("Bracket: \\[y");
+		expect(html).not.toContain('class="katex"');
+	});
+
+	it("renders valid dollar math after rejected dollar openers", () => {
+		const html = renderMarkdown("Cost $20; formula $x^2$. Streaming $unfinished then $y^2$.");
+
+		expect(html).toContain('<annotation encoding="application/x-tex">x^2</annotation>');
+		expect(html).toContain('<annotation encoding="application/x-tex">y^2</annotation>');
+		expect(html.match(/class="katex"/g)).toHaveLength(2);
+	});
+
+	it("keeps a false-positive display opener in one paragraph", () => {
+		const html = renderMarkdown("before\n\\[\nx");
+
+		expect(html.match(/<p>/g)).toHaveLength(1);
+		expect(html).toContain("before<br>\\[<br>x");
+	});
+
+	it("bounds user-controlled KaTeX dimensions", () => {
+		const html = renderMarkdown("$\\rule{1em}{1000000em}$");
+
+		expect(html).toContain("height:20em");
+		expect(html).not.toContain("height:1000000em");
+	});
+
+	it("does not grant KaTeX trusted-link commands", () => {
+		const html = renderMarkdown("$\\href{javascript:alert(1)}{click}$");
+
+		expect(html).toContain('class="katex"');
+		expect(html).not.toContain('href="javascript:');
+	});
+
 });

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Preserved unfinished `\(` and `\[` math delimiters while Markdown content streams.
+
 ## [18.0.5] - 2026-08-25
 
 ### Breaking Changes

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -7,8 +7,14 @@ import {
 	type TokenizerAndRendererExtension,
 	type Tokens,
 } from "@oh-my-pi/pi-utils/marked";
+import {
+	mathBlockStartIndex,
+	mathStartIndex,
+	tokenizeMathBlock,
+	tokenizeMathSpan,
+} from "@oh-my-pi/pi-utils/math-delimiters";
 import { latexToBlock } from "../latex-block";
-import { inlineMathSpanEnd, isBareMathEnvironment, latexToUnicode } from "../latex-to-unicode";
+import { isBareMathEnvironment, latexToUnicode } from "../latex-to-unicode";
 import type { SymbolTheme } from "../symbols";
 import { TERMINAL } from "../terminal-capabilities";
 import type { Component } from "../tui";
@@ -582,78 +588,34 @@ const customHrExtension: TokenizerAndRendererExtension = {
 	},
 };
 
-// Leftmost-match scan replacing /\$|\\\(|\\\[/ in mathExtension.start —
-// marked calls start() on the remaining source at every inline position, so
-// the regex alternation showed up in CPU profiles (part of a ~4.3% start()
-// tail). Three indexOf scans yield the identical leftmost index.
-/** @internal exported for tests — must stay index-identical to the old regex scan. */
-export function mathStartIndex(src: string): number | undefined {
-	let best = src.indexOf("$");
-	const paren = src.indexOf("\\(");
-	if (paren !== -1 && (best === -1 || paren < best)) best = paren;
-	const bracket = src.indexOf("\\[");
-	if (bracket !== -1 && (best === -1 || bracket < best)) best = bracket;
-	return best === -1 ? undefined : best;
-}
-
+// Shared delimiter tokenization keeps the TUI and collab-web renderers aligned
+// on dollar/bracket syntax, currency, escapes, and incomplete streaming input.
 const mathExtension: TokenizerAndRendererExtension = {
 	name: "math",
 	level: "inline",
-	start(src) {
-		return mathStartIndex(src);
-	},
+	start: mathStartIndex,
 	tokenizer(src) {
-		if (src.startsWith("$$")) {
-			const end = src.indexOf("$$", 2);
-			if (end !== -1 && src.slice(2, end).trim().length > 0) {
-				return { type: "math", raw: src.slice(0, end + 2), text: src.slice(2, end), display: true };
-			}
-			return undefined;
-		}
-		if (src.startsWith("\\[")) {
-			const end = src.indexOf("\\]", 2);
-			if (end !== -1) return { type: "math", raw: src.slice(0, end + 2), text: src.slice(2, end), display: true };
-			return undefined;
-		}
-		if (src.startsWith("\\(")) {
-			const end = src.indexOf("\\)", 2);
-			if (end !== -1) return { type: "math", raw: src.slice(0, end + 2), text: src.slice(2, end), display: false };
-			return undefined;
-		}
-		if (src.charCodeAt(0) === 0x24 /* $ */) {
-			const end = inlineMathSpanEnd(src, 0);
-			if (end !== -1) return { type: "math", raw: src.slice(0, end + 1), text: src.slice(1, end), display: false };
-		}
-		return undefined;
+		const span = tokenizeMathSpan(src);
+		if (!span) return undefined;
+		if (!span.complete) return { type: "text", raw: span.raw, text: span.raw };
+		return { type: "math", raw: span.raw, text: span.text, display: span.display };
 	},
 	renderer(token) {
-		return (token as { text?: string }).text ?? "";
+		return typeof token.text === "string" ? token.text : "";
 	},
 };
 
-// Display math blocks: opening `$$` / `\[` and closing `$$` / `\]` each alone on
-// their own line (≤3 leading spaces). Matched at the block level — before
-// paragraph/list parsing — so a multi-line equation (e.g. a matrix with `\\`
-// row breaks) renders across several lines instead of being collapsed onto one,
-// and blank lines inside the block don't split it. The own-line requirement
-// keeps inline `$$…$$` inside prose for the inline tokenizer above.
-const MATH_BLOCK_DOLLAR = /^ {0,3}\$\$[ \t]*\n([\s\S]+?)\n {0,3}\$\$[ \t]*(?:\n|$)/;
-const MATH_BLOCK_BRACKET = /^ {0,3}\\\[[ \t]*\n([\s\S]+?)\n {0,3}\\\][ \t]*(?:\n|$)/;
-const MATH_BLOCK_START = /(?:^|\n) {0,3}(?:\$\$|\\\[)[ \t]*\n/;
 const mathBlockExtension: TokenizerAndRendererExtension = {
 	name: "mathBlock",
 	level: "block",
-	start(src) {
-		const m = MATH_BLOCK_START.exec(src);
-		return m ? m.index : undefined;
-	},
+	start: mathBlockStartIndex,
 	tokenizer(src) {
-		const m = MATH_BLOCK_DOLLAR.exec(src) ?? MATH_BLOCK_BRACKET.exec(src);
-		if (!m || m[1].trim().length === 0) return undefined;
-		return { type: "math", raw: m[0], text: m[1], display: true };
+		const span = tokenizeMathBlock(src);
+		if (!span) return undefined;
+		return { type: "math", raw: span.raw, text: span.text, display: true };
 	},
 	renderer(token) {
-		return (token as { text?: string }).text ?? "";
+		return typeof token.text === "string" ? token.text : "";
 	},
 };
 

--- a/packages/tui/src/latex-to-unicode.ts
+++ b/packages/tui/src/latex-to-unicode.ts
@@ -1,4 +1,7 @@
+import { inlineMathSpanEnd, tokenizeMathSpan } from "@oh-my-pi/pi-utils/math-delimiters";
 import { TERMINAL } from "./terminal-capabilities";
+
+export { inlineMathSpanEnd };
 
 // LaTeX → Unicode/ANSI converter.
 //
@@ -1923,95 +1926,25 @@ export function renderMathInText(text: string): string {
 	const conv = (inner: string): string => latexToUnicode(inner).replace(NEWLINES, " ");
 	let out = "";
 	let i = 0;
-	const n = text.length;
-	while (i < n) {
-		const c = text[i];
-		if (c === "\\") {
-			const d = text[i + 1];
-			if (d === "\\") {
-				// Escaped backslash: emit verbatim so a following `(`/`[` is plain text.
-				out += "\\\\";
-				i += 2;
-				continue;
-			}
-			if (d === "(") {
-				const close = text.indexOf("\\)", i + 2);
-				if (close !== -1) {
-					out += conv(text.slice(i + 2, close));
-					i = close + 2;
-					continue;
-				}
-			} else if (d === "[") {
-				const close = text.indexOf("\\]", i + 2);
-				if (close !== -1) {
-					out += conv(text.slice(i + 2, close));
-					i = close + 2;
-					continue;
-				}
-			} else if (d === "$") {
-				out += "$";
-				i += 2;
-				continue;
-			}
-			out += c;
-			i++;
+	while (i < text.length) {
+		const span = tokenizeMathSpan(text.slice(i));
+		if (span) {
+			out += span.complete ? conv(span.text) : span.raw;
+			i += span.raw.length;
 			continue;
 		}
-		if (c === "$") {
-			if (text[i + 1] === "$") {
-				const close = text.indexOf("$$", i + 2);
-				if (close !== -1 && text.slice(i + 2, close).trim().length > 0) {
-					out += conv(text.slice(i + 2, close));
-					i = close + 2;
-					continue;
-				}
-				out += "$$";
-				i += 2;
-				continue;
-			}
-			const close = inlineMathSpanEnd(text, i);
-			if (close !== -1) {
-				out += conv(text.slice(i + 1, close));
-				i = close + 1;
-				continue;
-			}
+		if (text[i] === "\\" && text[i + 1] === "$") {
 			out += "$";
-			i++;
+			i += 2;
 			continue;
 		}
-		out += c;
+		if (text[i] === "\\" && text[i + 1] === "\\") {
+			out += "\\\\";
+			i += 2;
+			continue;
+		}
+		out += text[i];
 		i++;
 	}
 	return renderBareMathInText(out);
-}
-
-/**
- * Index of the `$` that closes an inline math span opened at `open` (the index
- * of the opening `$`), or -1 when the run is not inline math. Applies pandoc's
- * anti-currency heuristics: the opener must not be followed by whitespace, the
- * closer must not be preceded by whitespace nor followed by a digit, `\$` is a
- * literal dollar, and the span may not span a newline. Shared by
- * `renderMathInText` and the markdown math tokenizer so the rule has one home.
- */
-export function inlineMathSpanEnd(text: string, open: number): number {
-	const after = text[open + 1];
-	if (after === undefined || after === " " || after === "\t" || after === "\n" || after === "$") {
-		return -1;
-	}
-	for (let j = open + 1; j < text.length; j++) {
-		const ch = text[j];
-		if (ch === "\\") {
-			j++;
-			continue;
-		}
-		if (ch === "\n") return -1;
-		if (ch === "$") {
-			const prev = text[j - 1];
-			if (prev === " " || prev === "\t") return -1;
-			const next = text[j + 1];
-			if (next !== undefined && next >= "0" && next <= "9") continue; // currency: keep scanning
-			return text.slice(open + 1, j).trim().length > 0 ? j : -1;
-		}
-	}
-	return -1;
 }

--- a/packages/tui/test/latex-to-unicode.test.ts
+++ b/packages/tui/test/latex-to-unicode.test.ts
@@ -89,6 +89,13 @@ describe("latexToUnicode symbol fixes", () => {
 	});
 });
 
+describe("renderMathInText delimited math", () => {
+	it("ignores escaped bracket closers inside a span", () => {
+		const inner = String.raw`a \\) b`;
+		expect(renderMathInText(String.raw`\(a \\) b\)`)).toBe(latexToUnicode(inner).replace(/\r?\n/g, " "));
+	});
+});
+
 describe("renderMathInText bare-environment handling", () => {
 	it("converts a bare math environment without $$ delimiters", () => {
 		const out = renderMathInText("\\begin{align}\na &= b + c \\\\\nx &= y\n\\end{align}");

--- a/packages/tui/test/markdown-math.test.ts
+++ b/packages/tui/test/markdown-math.test.ts
@@ -75,6 +75,11 @@ describe("Markdown math rendering", () => {
 		expect(line).toBe("it costs $5 and $10 total");
 	});
 
+	it("preserves unfinished bracket math while streaming", () => {
+		const [line] = renderLines("Streaming: \\(x and \\[y");
+		expect(line).toBe("Streaming: \\(x and \\[y");
+	});
+
 	it("renderInlineMarkdown converts inline math", () => {
 		const out = stripVTControlCharacters(renderInlineMarkdown("energy $E=mc^2$ here", defaultMarkdownTheme));
 		expect(out).toBe("energy E=mc² here");

--- a/packages/tui/test/markdown.test.ts
+++ b/packages/tui/test/markdown.test.ts
@@ -4,7 +4,6 @@ import {
 	autolinkSchemeScanIndex,
 	clearRenderCache,
 	Markdown,
-	mathStartIndex,
 	renderInlineMarkdown,
 	urlTokenPossible,
 } from "@oh-my-pi/pi-tui/components/markdown";
@@ -12,6 +11,7 @@ import { setTerminalTextSizing, TERMINAL } from "@oh-my-pi/pi-tui/terminal-capab
 import { type Component, TUI } from "@oh-my-pi/pi-tui/tui";
 import { visibleWidth } from "@oh-my-pi/pi-tui/utils";
 import { Chalk } from "@oh-my-pi/pi-utils/chalk";
+import { mathStartIndex } from "@oh-my-pi/pi-utils/math-delimiters";
 import { defaultMarkdownTheme } from "./test-themes.js";
 import { VirtualTerminal } from "./virtual-terminal.js";
 

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added parsing utilities for dollar- and bracket-delimited Markdown math.
+
+### Fixed
+
+- Block tokenizer extension `start` hints now interrupt paragraphs and rejoin false-positive clips, matching Marked extension behavior.
+
 ## [18.0.5] - 2026-08-25
 
 ### Added

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -15,6 +15,7 @@ Shared utilities for [oh-my-pi](https://github.com/can1357/oh-my-pi) packages. Z
 | `which` | `$which()` binary lookup with caching |
 | `fetch-retry` | `fetch` with retry/backoff policies |
 | `fs-error` | Errno guards (`isEnoent` and friends) |
+| `math-delimiters` | Shared Markdown math tokenization for dollar and bracket delimiters |
 | `env` / `worker-host` | Environment plumbing and side-effect-free worker-host entry contract (`workerHostEntry`) |
 | `abortable` / `async` | AbortSignal-aware stream/promise helpers |
 | `peek-file` | Read the first N bytes of a file with pooled buffers |

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -14,6 +14,7 @@ export * from "./json";
 export * from "./json-parse";
 export * as logger from "./logger";
 export * from "./loop-phase";
+export * from "./math-delimiters";
 export * from "./mermaid-ascii";
 export * from "./mime";
 export * from "./path";

--- a/packages/utils/src/marked/core.ts
+++ b/packages/utils/src/marked/core.ts
@@ -895,6 +895,7 @@ function parseList(lines: string[], index: number, lexer: Lexer): { token: Token
 function blockTokens(src: string, lexer: Lexer, output: Token[]): Token[] {
 	const lines = lineArray(src);
 	let i = 0;
+	let lastParagraphClipped = false;
 	while (i < lines.length) {
 		const remaining = lines.slice(i).join("");
 		let custom: Tokens.Generic | undefined;
@@ -906,8 +907,14 @@ function blockTokens(src: string, lexer: Lexer, output: Token[]): Token[] {
 			output.push(custom);
 			let consumed = custom.raw.length;
 			while (i < lines.length && consumed > 0) {
-				consumed -= lines[i]!.length;
-				i++;
+				const current = lines[i]!;
+				if (consumed < current.length) {
+					lines[i] = current.slice(consumed);
+					consumed = 0;
+				} else {
+					consumed -= current.length;
+					i++;
+				}
 			}
 			continue;
 		}
@@ -1069,8 +1076,13 @@ function blockTokens(src: string, lexer: Lexer, output: Token[]): Token[] {
 				continue;
 			}
 		}
-		let raw = line;
-		i++;
+		let extensionStart = remaining.length;
+		const afterFirstCharacter = remaining.slice(1);
+		for (const extension of lexer.extensions.block) {
+			const at = extension.start?.call({ lexer }, afterFirstCharacter);
+			if (typeof at === "number" && at >= 0 && at + 1 < extensionStart) extensionStart = at + 1;
+		}
+		let raw = "";
 		// An indented code block cannot interrupt a paragraph (CommonMark lazy
 		// continuation): a line indented by at least 4 spaces directly attached to
 		// paragraph text stays inside the paragraph, bypassing every block-start
@@ -1078,18 +1090,41 @@ function blockTokens(src: string, lexer: Lexer, output: Token[]): Token[] {
 		// blank line the indent is no longer attached, so it still opens an
 		// indented code block.
 		let prevBlankish = false;
+		let paragraphClipped = false;
 		while (i < lines.length) {
+			if (raw.length >= extensionStart) {
+				paragraphClipped = true;
+				break;
+			}
 			const next = lines[i]!;
-			const indented = next.trim() !== "" && /^ {4}/.test(next);
-			if (indented ? prevBlankish : isBlockStart(lines, i)) break;
+			if (raw.length > 0) {
+				const indented = next.trim() !== "" && /^ {4}/.test(next);
+				if (indented ? prevBlankish : isBlockStart(lines, i)) break;
+			}
+			const available = extensionStart - raw.length;
+			if (next.length > available) {
+				raw += next.slice(0, available);
+				lines[i] = next.slice(available);
+				paragraphClipped = true;
+				break;
+			}
 			prevBlankish = next.trim() === "";
 			raw += next;
 			i++;
 		}
 		const text = stripFinalNewline(raw);
-		const tokens: Token[] = [];
-		lexer.inline(text, tokens);
-		output.push({ type: "paragraph", raw, text, tokens });
+		const previous = output.at(-1);
+		if (lastParagraphClipped && previous?.type === "paragraph") {
+			previous.raw += (previous.raw.endsWith("\n") ? "" : "\n") + raw;
+			previous.text += `\n${text}`;
+			previous.tokens = [];
+			lexer.inline(previous.text, previous.tokens);
+		} else {
+			const tokens: Token[] = [];
+			lexer.inline(text, tokens);
+			output.push({ type: "paragraph", raw, text, tokens });
+		}
+		lastParagraphClipped = paragraphClipped;
 	}
 	return output;
 }

--- a/packages/utils/src/math-delimiters.ts
+++ b/packages/utils/src/math-delimiters.ts
@@ -1,0 +1,123 @@
+export interface CompleteMathSpan {
+	complete: true;
+	raw: string;
+	text: string;
+	display: boolean;
+}
+
+export interface IncompleteMathSpan {
+	complete: false;
+	raw: string;
+	display: boolean;
+}
+
+export type MathSpan = CompleteMathSpan | IncompleteMathSpan;
+
+interface MathDelimiter {
+	open: string;
+	close: string;
+	display: boolean;
+}
+
+const DELIMITERS: readonly MathDelimiter[] = [
+	{ open: "$$", close: "$$", display: true },
+	{ open: "\\[", close: "\\]", display: true },
+	{ open: "\\(", close: "\\)", display: false },
+	{ open: "$", close: "$", display: false },
+];
+const MATH_BLOCK_DOLLAR = /^ {0,3}\$\$[ \t]*\n([\s\S]+?)\n {0,3}\$\$[ \t]*(?:\n|$)/;
+const MATH_BLOCK_BRACKET = /^ {0,3}\\\[[ \t]*\n([\s\S]+?)\n {0,3}\\\][ \t]*(?:\n|$)/;
+const MATH_BLOCK_START = /(?:^|\n) {0,3}(?:\$\$|\\\[)[ \t]*\n/;
+
+function isEscaped(source: string, index: number): boolean {
+	let slashCount = 0;
+	for (let i = index - 1; i >= 0 && source[i] === "\\"; i--) slashCount++;
+	return slashCount % 2 === 1;
+}
+
+export function mathStartIndex(source: string): number | undefined {
+	let next = source.indexOf("$");
+	const paren = source.indexOf("\\(");
+	if (paren !== -1 && (next === -1 || paren < next)) next = paren;
+	const bracket = source.indexOf("\\[");
+	if (bracket !== -1 && (next === -1 || bracket < next)) next = bracket;
+	return next === -1 ? undefined : next;
+}
+
+/**
+ * Index of the `$` that closes an inline math span opened at `open`, or -1.
+ * Uses Pandoc's anti-currency rules and never crosses a newline.
+ */
+export function inlineMathSpanEnd(source: string, open: number): number {
+	const after = source[open + 1];
+	if (after === undefined || after === " " || after === "\t" || after === "\n" || after === "$") return -1;
+	for (let at = open + 1; at < source.length; at++) {
+		const char = source[at];
+		if (char === "\\") {
+			at++;
+			continue;
+		}
+		if (char === "\n") return -1;
+		if (char !== "$") continue;
+		const before = source[at - 1];
+		if (before === " " || before === "\t") return -1;
+		const next = source[at + 1];
+		if (next !== undefined && next >= "0" && next <= "9") continue;
+		return source.slice(open + 1, at).trim().length > 0 ? at : -1;
+	}
+	return -1;
+}
+
+function closingDelimiterIndex(source: string, { open, close, display }: MathDelimiter): number {
+	for (let at = source.indexOf(close, open.length); at !== -1; at = source.indexOf(close, at + 1)) {
+		const touchesDollar = close.startsWith("$") && (source[at - 1] === "$" || source[at + close.length] === "$");
+		if (isEscaped(source, at) || touchesDollar) continue;
+		return !display && source.slice(open.length, at).includes("\n") ? -1 : at;
+	}
+	return -1;
+}
+
+/** Tokenize one math span at the start of source. */
+export function tokenizeMathSpan(source: string): MathSpan | undefined {
+	for (const delimiter of DELIMITERS) {
+		if (!source.startsWith(delimiter.open)) continue;
+		if (delimiter.open === "$") {
+			const closeAt = inlineMathSpanEnd(source, 0);
+			if (closeAt === -1) return { complete: false, raw: "$", display: false };
+			const text = source.slice(1, closeAt);
+			if (text.includes("`")) return { complete: false, raw: "$", display: false };
+			return { complete: true, raw: source.slice(0, closeAt + 1), text, display: false };
+		}
+		if (delimiter.open.startsWith("$") && source[delimiter.open.length] === "$") return undefined;
+
+		const closeAt = closingDelimiterIndex(source, delimiter);
+		if (closeAt === -1) {
+			if (delimiter.open.startsWith("\\"))
+				return { complete: false, raw: delimiter.open, display: delimiter.display };
+			return undefined;
+		}
+		const text = source.slice(delimiter.open.length, closeAt);
+		if (text.trim() === "" || text.includes("`")) return undefined;
+		return {
+			complete: true,
+			raw: source.slice(0, closeAt + delimiter.close.length),
+			text: text.trim(),
+			display: delimiter.display,
+		};
+	}
+	return undefined;
+}
+
+/** Character index of the next own-line display-math opener. */
+export function mathBlockStartIndex(source: string): number | undefined {
+	const match = MATH_BLOCK_START.exec(source);
+	if (!match) return undefined;
+	return match.index === 0 ? 0 : match.index + 1;
+}
+
+/** Tokenize an own-line display-math block at the start of source. */
+export function tokenizeMathBlock(source: string): CompleteMathSpan | undefined {
+	const match = MATH_BLOCK_DOLLAR.exec(source) ?? MATH_BLOCK_BRACKET.exec(source);
+	if (!match || match[1].trim().length === 0) return undefined;
+	return { complete: true, raw: match[0], text: match[1], display: true };
+}

--- a/packages/utils/test/marked.test.ts
+++ b/packages/utils/test/marked.test.ts
@@ -173,5 +173,49 @@ describe("marked compatibility", () => {
 			{ type: "latexBlock", raw: "$$\ny^2\n$$\n", text: "y^2" },
 		]);
 		expect(marked.parse("before $x_i$\n\n$$\ny^2\n$$\n")).toBe("<p>before <i>x_i</i></p>\n<math>y^2</math>\n");
+		expect(marked.parse("before $x_i$\n$$\ny^2\n$$\n")).toBe("<p>before <i>x_i</i></p>\n<math>y^2</math>\n");
+		expect(marked.parse("before\n$$\nunclosed")).toBe("<p>before\n$$\nunclosed</p>\n");
+	});
+
+	test("clips paragraphs at exact block extension start offsets", () => {
+		const inlineBlock: TokenizerAndRendererExtension = {
+			name: "inlineBlock",
+			level: "block",
+			start(src) {
+				const index = src.indexOf("@@");
+				return index === -1 ? undefined : index;
+			},
+			tokenizer(src) {
+				return src.startsWith("@@") ? { type: "inlineBlock", raw: "@@" } : undefined;
+			},
+			renderer() {
+				return "<block></block>\n";
+			},
+		};
+		const marked = new Marked().use({ extensions: [inlineBlock] });
+
+		expect(marked.parse("before @@ after")).toBe("<p>before </p>\n<block></block>\n<p> after</p>\n");
+	});
+
+	test("rejoins paragraphs after a false-positive bracket-math start hint", () => {
+		const bracketBlock: TokenizerAndRendererExtension = {
+			name: "bracketBlock",
+			level: "block",
+			start(src) {
+				const index = src.indexOf("\\[\n");
+				return index === -1 ? undefined : index;
+			},
+			tokenizer() {
+				return undefined;
+			},
+			renderer() {
+				return "";
+			},
+		};
+		const marked = new Marked().use({ extensions: [bracketBlock] });
+
+		expect([...marked.lexer("before\n\\[\nx")].map(token => [token.type, token.raw])).toEqual([
+			["paragraph", "before\n\\[\nx"],
+		]);
 	});
 });

--- a/packages/utils/test/math-delimiters.test.ts
+++ b/packages/utils/test/math-delimiters.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test";
+import {
+	inlineMathSpanEnd,
+	mathBlockStartIndex,
+	mathStartIndex,
+	tokenizeMathBlock,
+	tokenizeMathSpan,
+} from "../src/math-delimiters";
+
+describe("math delimiters", () => {
+	test("tokenizes dollar and bracket math spans", () => {
+		expect(tokenizeMathSpan("$x^2$ tail")).toEqual({
+			complete: true,
+			raw: "$x^2$",
+			text: "x^2",
+			display: false,
+		});
+		expect(tokenizeMathSpan("$$x^2$$ tail")).toEqual({
+			complete: true,
+			raw: "$$x^2$$",
+			text: "x^2",
+			display: true,
+		});
+		expect(tokenizeMathSpan("\\(x^2\\) tail")).toEqual({
+			complete: true,
+			raw: "\\(x^2\\)",
+			text: "x^2",
+			display: false,
+		});
+		expect(tokenizeMathSpan("\\[x^2\\] tail")).toEqual({
+			complete: true,
+			raw: "\\[x^2\\]",
+			text: "x^2",
+			display: true,
+		});
+	});
+
+	test("returns rejected dollar openers as literal spans so later math remains discoverable", () => {
+		expect(tokenizeMathSpan("$20 and $30")).toEqual({ complete: false, raw: "$", display: false });
+		expect(tokenizeMathSpan("$unfinished")).toEqual({ complete: false, raw: "$", display: false });
+		expect(tokenizeMathSpan("$x `code` y$")).toEqual({ complete: false, raw: "$", display: false });
+		expect(inlineMathSpanEnd("$cost = \\$20$", 0)).toBe(12);
+		expect(mathStartIndex("cost \\$20 and \\(x\\)")).toBe(6);
+	});
+
+	test("preserves unfinished bracket openers", () => {
+		expect(tokenizeMathSpan("\\(x")).toEqual({ complete: false, raw: "\\(", display: false });
+		expect(tokenizeMathSpan("\\[x")).toEqual({ complete: false, raw: "\\[", display: true });
+	});
+
+	test("tokenizes own-line display blocks with up to three leading spaces", () => {
+		const source = "  $$\n\\begin{pmatrix}a & b \\\\ c & d\\end{pmatrix}\n  $$\nnext";
+		const token = tokenizeMathBlock(source);
+		expect(token).toEqual({
+			complete: true,
+			raw: "  $$\n\\begin{pmatrix}a & b \\\\ c & d\\end{pmatrix}\n  $$\n",
+			text: "\\begin{pmatrix}a & b \\\\ c & d\\end{pmatrix}",
+			display: true,
+		});
+		expect(mathBlockStartIndex(`prose\n${source}`)).toBe(6);
+	});
+});


### PR DESCRIPTION
## Summary

I added KaTeX rendering to the collab web transcript. The extra code handles Markdown cases that KaTeX does not handle, such as `$20 and $30`.

The Marked extension supports these forms:

- `$…$` for inline math
- `\(…\)` for inline math
- `$$…$$` for display math
- `\[…\]` for display math

KaTeX renders the math. A shared `pi-utils` tokenizer finds math delimiters for both the TUI and collab web. It keeps normal Markdown text unchanged, including money, escaped dollar signs, code spans, and incomplete math from a streaming response. Rejected dollar openers are consumed as literal text so valid math later in the same line can still render.

The shared Marked parser now uses block-extension `start` hints at exact character offsets. It also rejoins a clipped paragraph when an extension declines a possible block. Display math can therefore start on the line after normal text without changing literal unfinished blocks.

KaTeX uses a finite `maxSize` so explicit dimensions in guest or agent content cannot create an unbounded transcript layout. Long display equations scroll horizontally instead of being cut off.

This change was discussed and approved in Discord.

## Architecture decision

The TUI already contained the production rules for dollar and bracket math delimiters, including the anti-currency rule used by `inlineMathSpanEnd`. Duplicating those rules in collab web would let the two renderers drift.

This change moves the reusable delimiter interface and implementation to `@oh-my-pi/pi-utils/math-delimiters`. The TUI and collab web now use the same tokenizer and keep only renderer-specific adapters: Unicode layout in the TUI and KaTeX HTML in collab web. `renderMathInText()` also iterates through the shared tokenizer instead of parsing delimiters independently. The TUI continues to export `inlineMathSpanEnd` from its existing public module, so current consumers keep the same interface while the implementation has one shared home.

## Verification

I tested the change in a real `/collab` session with the local collab web. I confirmed that all four math forms render, currency and code stay unchanged, unfinished bracket delimiters stay visible while streaming, and a matrix directly after prose renders as one display equation. I also confirmed in the live transcript that valid `$x^2$` and `$y^2$` spans render after rejected currency and unfinished dollar openers.

I also tested `$\rule{1em}{1000000em}$` in the live collab web. The rendered transcript row stayed bounded at about 320 px high.

Automated checks:

- 87 collab-web tests passed
- 808 utils tests passed; 2 skipped
- 1,366 TUI tests passed
- package checks passed in all three affected packages
- the production collab-web build passed