### PR TITLE
perf(pi-shell): avoid duplicate Windows Git discovery

### DIFF
--- a/crates/pi-shell/src/windows.rs
+++ b/crates/pi-shell/src/windows.rs
@@ -115,18 +115,17 @@ where
 	let mut seen_paths = HashSet::new();
 
 	for install_path in [registry_path, where_path].into_iter().flatten() {
-		let root = PathBuf::from(&install_path);
-		let normalized_root = normalize_path(&root);
-		if normalized_root.is_empty() || !seen_roots.insert(normalized_root) {
-			continue;
-		}
-		install_roots.push(root);
-
 		for path in git_paths_for_install_root(&install_path) {
 			let normalized_path = normalize_path(Path::new(&path));
 			if !normalized_path.is_empty() && seen_paths.insert(normalized_path) {
 				paths.push(path);
 			}
+		}
+
+		let root = PathBuf::from(&install_path);
+		let normalized_root = normalize_path(&root);
+		if !normalized_root.is_empty() && seen_roots.insert(normalized_root) {
+			install_roots.push(root);
 		}
 	}
 
@@ -373,6 +372,26 @@ mod tests {
 		let discovery = discover_git_with(|| Some(registry_path), || Some(where_path));
 
 		assert_eq!(discovery.install_roots, vec![root.path().to_path_buf()]);
+		assert_eq!(discovery.paths, vec![
+			root.path().join("cmd").to_string_lossy().into_owned(),
+			root.path().join("bin").to_string_lossy().into_owned(),
+			root
+				.path()
+				.join("usr")
+				.join("bin")
+				.to_string_lossy()
+				.into_owned(),
+		]);
+	}
+
+	#[test]
+	fn git_discovery_keeps_valid_candidates_when_duplicate_root_spellings_differ() {
+		let root = git_install_fixture();
+		let clean_path = root.path().to_string_lossy().into_owned();
+		let decorated_path = format!("  \"{clean_path}\"  ");
+
+		let discovery = discover_git_with(|| Some(decorated_path), || Some(clean_path));
+
 		assert_eq!(discovery.paths, vec![
 			root.path().join("cmd").to_string_lossy().into_owned(),
 			root.path().join("bin").to_string_lossy().into_owned(),

--- a/crates/pi-shell/src/windows.rs
+++ b/crates/pi-shell/src/windows.rs
@@ -10,8 +10,7 @@ use brush_core::{Shell as BrushShell, ShellValue, ShellVariable};
 use winreg::{RegKey, enums::HKEY_LOCAL_MACHINE};
 
 pub fn configure_windows_path(shell: &mut BrushShell) -> Result<()> {
-	let install_roots = find_git_install_roots();
-	let git_paths = find_git_paths();
+	let GitDiscovery { install_roots, paths: git_paths } = discover_git();
 	if install_roots.is_empty() && git_paths.is_empty() {
 		return Ok(());
 	}
@@ -94,26 +93,44 @@ fn normalize_path(path: &Path) -> String {
 	normalized.to_string_lossy().into_owned()
 }
 
-fn find_git_paths() -> Vec<String> {
-	let mut paths = Vec::new();
-	let mut seen = HashSet::new();
+struct GitDiscovery {
+	install_roots: Vec<PathBuf>,
+	paths:         Vec<String>,
+}
 
-	for install_path in [query_git_install_path_from_registry(), query_git_install_path_from_where()]
-		.into_iter()
-		.flatten()
-	{
+fn discover_git() -> GitDiscovery {
+	discover_git_with(query_git_install_path_from_registry, query_git_install_path_from_where)
+}
+
+fn discover_git_with<R, W>(registry_query: R, where_query: W) -> GitDiscovery
+where
+	R: FnOnce() -> Option<String>,
+	W: FnOnce() -> Option<String>,
+{
+	let registry_path = registry_query();
+	let where_path = where_query();
+	let mut install_roots = Vec::new();
+	let mut paths = Vec::new();
+	let mut seen_roots = HashSet::new();
+	let mut seen_paths = HashSet::new();
+
+	for install_path in [registry_path, where_path].into_iter().flatten() {
+		let root = PathBuf::from(&install_path);
+		let normalized_root = normalize_path(&root);
+		if normalized_root.is_empty() || !seen_roots.insert(normalized_root) {
+			continue;
+		}
+		install_roots.push(root);
+
 		for path in git_paths_for_install_root(&install_path) {
-			let normalized = normalize_path(Path::new(&path));
-			if normalized.is_empty() {
-				continue;
-			}
-			if seen.insert(normalized) {
+			let normalized_path = normalize_path(Path::new(&path));
+			if !normalized_path.is_empty() && seen_paths.insert(normalized_path) {
 				paths.push(path);
 			}
 		}
 	}
 
-	paths
+	GitDiscovery { install_roots, paths }
 }
 
 fn query_git_install_path_from_registry() -> Option<String> {
@@ -206,25 +223,6 @@ fn has_git_command(dir: &Path) -> bool {
 		.any(|name| dir.join(name).is_file())
 }
 
-fn find_git_install_roots() -> Vec<PathBuf> {
-	let mut roots = Vec::new();
-	let mut seen = HashSet::new();
-	for install_path in [query_git_install_path_from_registry(), query_git_install_path_from_where()]
-		.into_iter()
-		.flatten()
-	{
-		let path = PathBuf::from(install_path);
-		let normalized = normalize_path(&path);
-		if normalized.is_empty() {
-			continue;
-		}
-		if seen.insert(normalized) {
-			roots.push(path);
-		}
-	}
-	roots
-}
-
 /// Translate an MSYS2/Git Bash style path entry (e.g. `/usr/bin`,
 /// `/mingw64/bin`, `/c/Users/foo`) into a Windows-native path so that
 /// `std::path` based executable lookups in brush-core can resolve binaries
@@ -283,7 +281,109 @@ fn is_windows_style_path(value: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
+	use std::{cell::Cell, fs};
+
 	use super::*;
+
+	fn git_install_fixture() -> tempfile::TempDir {
+		let root = tempfile::tempdir().expect("Git installation fixture");
+		let cmd = root.path().join("cmd");
+		let bin = root.path().join("bin");
+		let usr_bin = root.path().join("usr").join("bin");
+		for path in [&cmd, &bin, &usr_bin] {
+			fs::create_dir_all(path).expect("Git path fixture");
+		}
+		fs::write(cmd.join("git.exe"), []).expect("cmd Git fixture");
+		fs::write(bin.join("git.exe"), []).expect("bin Git fixture");
+		fs::write(usr_bin.join("ls.exe"), []).expect("usr/bin fixture");
+		root
+	}
+
+	#[test]
+	fn git_discovery_queries_each_source_once_per_invocation_and_remains_fresh() {
+		let registry_calls = Cell::new(0);
+		let where_calls = Cell::new(0);
+
+		for _ in 0..2 {
+			let discovery = discover_git_with(
+				|| {
+					registry_calls.set(registry_calls.get() + 1);
+					None
+				},
+				|| {
+					where_calls.set(where_calls.get() + 1);
+					None
+				},
+			);
+			assert!(discovery.install_roots.is_empty());
+			assert!(discovery.paths.is_empty());
+		}
+
+		assert_eq!(registry_calls.get(), 2);
+		assert_eq!(where_calls.get(), 2);
+	}
+
+	#[test]
+	fn git_discovery_preserves_provider_and_candidate_order() {
+		let registry_root = git_install_fixture();
+		let where_root = git_install_fixture();
+		let registry_path = registry_root.path().to_string_lossy().into_owned();
+		let where_path = where_root.path().to_string_lossy().into_owned();
+
+		let discovery = discover_git_with(|| Some(registry_path), || Some(where_path));
+
+		assert_eq!(discovery.install_roots, vec![
+			registry_root.path().to_path_buf(),
+			where_root.path().to_path_buf()
+		]);
+		assert_eq!(discovery.paths, vec![
+			registry_root
+				.path()
+				.join("cmd")
+				.to_string_lossy()
+				.into_owned(),
+			registry_root
+				.path()
+				.join("bin")
+				.to_string_lossy()
+				.into_owned(),
+			registry_root
+				.path()
+				.join("usr")
+				.join("bin")
+				.to_string_lossy()
+				.into_owned(),
+			where_root.path().join("cmd").to_string_lossy().into_owned(),
+			where_root.path().join("bin").to_string_lossy().into_owned(),
+			where_root
+				.path()
+				.join("usr")
+				.join("bin")
+				.to_string_lossy()
+				.into_owned(),
+		]);
+	}
+
+	#[test]
+	fn git_discovery_deduplicates_the_same_installation_from_both_sources() {
+		let root = git_install_fixture();
+		let registry_path = root.path().to_string_lossy().into_owned();
+		let where_path = registry_path.clone();
+
+		let discovery = discover_git_with(|| Some(registry_path), || Some(where_path));
+
+		assert_eq!(discovery.install_roots, vec![root.path().to_path_buf()]);
+		assert_eq!(discovery.paths, vec![
+			root.path().join("cmd").to_string_lossy().into_owned(),
+			root.path().join("bin").to_string_lossy().into_owned(),
+			root
+				.path()
+				.join("usr")
+				.join("bin")
+				.to_string_lossy()
+				.into_owned(),
+		]);
+	}
 
 	#[test]
 	fn drive_letter_segments_translate_to_windows_paths() {


### PR DESCRIPTION
## What

- Replaces the separate Git-root and Git-path probes with one invocation-local discovery pass.
- Preserves registry-before-`where git` ordering, candidate ordering, duplicate suppression, and fresh discovery on later shell setups.
- Adds Windows regression coverage for provider call counts, ordering, duplicate installations, and differently spelled duplicate roots.

## Why

I reviewed the full diff. This change avoids discovering Git twice on Windows, reducing redundant shell setup work without changing path behavior.

Fixes #7430

## Testing

- `windows::tests`: 7 passed, covering once-per-source discovery, fresh subsequent discovery, ordering, duplicate suppression, differently spelled duplicate roots, and existing MSYS path translation.
- Rust formatting passed.
- Focused `pi-shell` Clippy passed after allowing the unrelated current-main `process.rs:1877` `missing_const_for_fn` warning.
- The full `bun run test:rs` is currently blocked on Windows by six unresolved `tempdir()` calls in `crates/pi-builtins/src/stat.rs` on `main`.
- The full `bun run check:rs` is currently blocked on Windows by eight unrelated Clippy errors in `crates/pi-walker/src/lib.rs` on `main`.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing) — not user-facing, so no entry was needed