### PR TITLE
fix(install): anchor tag_name extraction for minified JSON

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -243,7 +243,7 @@ install_binary() {
     if [ -n "$REF" ]; then
         echo "Fetching release $REF..."
         if RELEASE_JSON=$(curl -fsSL --connect-timeout 10 --max-time 60 "https://api.github.com/repos/${REPO}/releases/tags/${REF}"); then
-            LATEST=$(echo "$RELEASE_JSON" | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/')
+            LATEST=$(echo "$RELEASE_JSON" | grep '"tag_name"' | sed -E 's/.*"tag_name"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/')
         else
             echo "Release tag not found: $REF"
             echo "For branch/commit installs, use --source with --ref."
@@ -252,7 +252,7 @@ install_binary() {
     else
         echo "Fetching latest release..."
         RELEASE_JSON=$(curl -fsSL --connect-timeout 10 --max-time 60 "https://api.github.com/repos/${REPO}/releases/latest")
-        LATEST=$(echo "$RELEASE_JSON" | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/')
+        LATEST=$(echo "$RELEASE_JSON" | grep '"tag_name"' | sed -E 's/.*"tag_name"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/')
     fi
 
     if [ -z "$LATEST" ]; then


### PR DESCRIPTION
## Problem

`curl -fsSL https://omp.sh/install | sh` (the default binary install) fails with a 404:

```
Fetching latest release...
Using version: mentions_count
Downloading omp-linux-x64...
curl: (22) The requested URL returned error: 404
```

## Root cause

`scripts/install.sh` extracts the release tag with:

```sh
LATEST=$(echo "$RELEASE_JSON" | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/')
```

`GET /repos/can1357/oh-my-pi/releases/latest` returns single-line (minified) JSON, so `grep` matches the entire document and the greedy `.*"([^"]+)".*` captures the **last** quoted token on the line — `"mentions_count"` (a field GitHub added to release objects; its value is an unquoted number, so the key itself is the last quoted string). The download URL becomes `…/releases/download/mentions_count/omp-linux-x64`, which 404s.

The `--ref <tag>` path is unaffected in practice because `releases/tags/{tag}` returns pretty-printed JSON, so `grep` isolates the `"tag_name"` line — but it relies on the same fragile pattern.

## Fix

Anchor the regex to the `tag_name` key so it can't match an unrelated trailing field:

```sh
LATEST=$(echo "$RELEASE_JSON" | grep '"tag_name"' | sed -E 's/.*"tag_name"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/')
```

Verified against both live endpoints:
- minified `releases/latest` → `v18.0.5`
- pretty-printed `releases/tags/v18.0.5` → `v18.0.5`
