### PR TITLE
fix(collab): rebuild guest context after host compaction

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed a joined collab guest diverging from the host after the host compacted: the guest now collapses its replicated context behind the compaction summary instead of keeping the stale pre-compaction transcript ([#9781](https://github.com/can1357/oh-my-pi/issues/9781)).
+
 ## [18.0.5] - 2026-08-25
 
 ### Added

--- a/packages/coding-agent/src/collab/guest.ts
+++ b/packages/coding-agent/src/collab/guest.ts
@@ -504,6 +504,14 @@ export class CollabGuestLink {
 				this.#ctx.sessionManager.ingestReplicatedEntry(frame.entry);
 				if (frame.entry.type === "message") {
 					this.#ctx.session.agent.replaceMessages([...this.#ctx.session.messages, frame.entry.message]);
+				} else if (frame.entry.type === "compaction" || frame.entry.type === "branch_summary") {
+					// Compaction/branch entries rewrite the host's model context: the
+					// pre-boundary transcript collapses behind a summary. Appending
+					// the entry alone leaves the replica holding the stale full
+					// history, so rebuild the message array from the ingested entries
+					// exactly as the host does after appendCompaction/branchWithSummary
+					// (session-maintenance.ts, agent-session.ts).
+					this.#ctx.session.agent.replaceMessages(this.#ctx.session.buildDisplaySessionContext().messages);
 				}
 				break;
 			}

--- a/packages/coding-agent/test/collab/host-compaction-guest-sync.test.ts
+++ b/packages/coding-agent/test/collab/host-compaction-guest-sync.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Contract: after the host compacts, a joined guest's replicated model context
+ * must collapse behind the compaction summary exactly as the host's does —
+ * appending the compaction entry alone leaves the guest holding the stale
+ * pre-compaction transcript (issue #9781).
+ *
+ * A real host `SessionManager` broadcasts live entries through `CollabHost`; a
+ * real guest `CollabGuestLink` (backed by a real `AgentSession`) applies them.
+ * The in-memory relay (see ./helpers/in-memory-relay) runs the real socket,
+ * host, and guest unchanged, so the full welcome → snapshot → live-entry path
+ * is exercised.
+ */
+import { afterAll, afterEach, beforeAll, describe, expect, it, type Mock, spyOn } from "bun:test";
+import * as os from "node:os";
+import { Agent } from "@oh-my-pi/pi-agent-core";
+import type { Model } from "@oh-my-pi/pi-ai";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { CollabGuestLink } from "@oh-my-pi/pi-coding-agent/collab/guest";
+import { CollabHost } from "@oh-my-pi/pi-coding-agent/collab/host";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import type { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { refreshDirsFromEnv, TempDir } from "@oh-my-pi/pi-utils";
+import { createAssistantMessage, createInMemoryAuthStorage } from "../helpers/agent-session-setup";
+import { installInMemoryRelay, uninstallInMemoryRelay } from "./helpers/in-memory-relay";
+
+/** Minimal host `InteractiveModeContext`: only the members `CollabHost` reads. */
+function makeHostContext(manager: SessionManager): InteractiveModeContext {
+	return {
+		settings: { get: () => "" },
+		sessionManager: manager,
+		session: {
+			isStreaming: false,
+			isAborting: false,
+			queuedMessageCount: 0,
+			sessionName: "host session",
+			model: undefined,
+			thinkingLevel: undefined,
+			subscribe: () => () => {},
+			emitNotice: () => {},
+			promptCustomMessage: () => Promise.resolve(),
+			abort: () => Promise.resolve(),
+		},
+		eventBus: undefined,
+		statusLine: {
+			setCollabStatus: () => {},
+			invalidate: () => {},
+			getCachedContextBreakdown: () => ({ usedTokens: 0, contextWindow: 0 }),
+		},
+		ui: { requestRender: () => {} },
+		showStatus: () => {},
+		collabHost: undefined,
+	} as unknown as InteractiveModeContext;
+}
+
+interface GuestHarness {
+	guest: CollabGuestLink;
+	session: AgentSession;
+	dispose: () => Promise<void>;
+}
+
+/**
+ * Real guest: a live `AgentSession` + `SessionManager` behind a `CollabGuestLink`.
+ * Every UI touchpoint the join/finalize/apply path calls is a no-op double; the
+ * session and manager are real so `session.messages` reflects the replicated
+ * (and rebuilt-on-compaction) model context.
+ */
+function makeGuestHarness(model: Model, modelRegistry: ModelRegistry): GuestHarness {
+	const tempDir = TempDir.createSync("@pi-collab-guest-sync-");
+	const manager = SessionManager.create(tempDir.path(), tempDir.path());
+	const agent = new Agent({
+		initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] },
+	});
+	const session = new AgentSession({ agent, sessionManager: manager, settings: Settings.isolated(), modelRegistry });
+
+	const ctx = {
+		settings: { get: () => "" },
+		sessionManager: manager,
+		session,
+		statusContainer: { clear: () => {}, disposeChildren: () => {} },
+		pendingMessagesContainer: { clear: () => {} },
+		compactionQueuedMessages: [],
+		streamingComponent: undefined,
+		streamingMessage: undefined,
+		pendingTools: new Map(),
+		loadingAnimation: undefined,
+		autoCompactionLoader: undefined,
+		retryLoader: undefined,
+		ensureLoadingAnimation: () => {},
+		statusLine: {
+			setCollabStatus: () => {},
+			invalidate: () => {},
+			markActivityStart: () => {},
+			markActivityEnd: () => {},
+			getCachedContextBreakdown: () => ({ usedTokens: 0, contextWindow: 0 }),
+			resetActiveTime: () => {},
+		},
+		ui: { requestRender: () => {} },
+		chatContainer: { clear: () => {}, disposeChildren: () => {} },
+		resetObserverRegistry: () => {},
+		syncRunningSubagentBadge: () => {},
+		renderInitialMessages: () => Promise.resolve(),
+		reloadTodos: () => Promise.resolve(),
+		showStatus: () => {},
+		showError: () => {},
+		eventController: { handleEvent: () => Promise.resolve() },
+		eventBus: undefined,
+		collabGuest: undefined,
+		handleResumeSession: () => Promise.resolve(),
+	} as unknown as InteractiveModeContext;
+
+	const guest = new CollabGuestLink(ctx);
+	return {
+		guest,
+		session,
+		dispose: async () => {
+			await guest.leave("test cleanup").catch(() => {});
+			await session.dispose().catch(() => {});
+			await tempDir.remove().catch(() => {});
+		},
+	};
+}
+
+// Frames traverse the real CollabSocket, whose AES-GCM seal/open run on
+// WebCrypto — genuine async that resolves on the event loop, not on a clock
+// this test controls, so fake timers cannot drive it. Poll event-loop ticks
+// (zero-delay yields, not a wall-clock guess) until the awaited state lands.
+async function settleFrames(predicate: () => boolean, maxTicks = 500): Promise<void> {
+	for (let i = 0; i < maxTicks; i++) {
+		if (predicate()) return;
+		await new Promise<void>(resolve => setTimeout(resolve, 0));
+	}
+	if (!predicate()) throw new Error("condition not met while settling collab frames");
+}
+
+// The guest writes its replica under getConfigRootDir(); redirect the config
+// root to a temp HOME so the test never touches the real ~/.omp.
+let homedirSpy: Mock<typeof os.homedir> | undefined;
+let homeDir: TempDir | undefined;
+let authStorage: AuthStorage;
+let modelRegistry: ModelRegistry;
+let model: Model;
+
+beforeAll(() => {
+	homeDir = TempDir.createSync("@pi-collab-guest-home-");
+	homedirSpy = spyOn(os, "homedir").mockReturnValue(homeDir.path());
+	refreshDirsFromEnv();
+	installInMemoryRelay();
+	authStorage = createInMemoryAuthStorage();
+	authStorage.setRuntimeApiKey("anthropic", "test-key");
+	modelRegistry = new ModelRegistry(authStorage);
+	const bundled = getBundledModel("anthropic", "claude-sonnet-4-5");
+	if (!bundled) throw new Error("expected bundled anthropic model");
+	model = bundled;
+});
+
+afterAll(async () => {
+	uninstallInMemoryRelay();
+	authStorage.close();
+	homedirSpy?.mockRestore();
+	refreshDirsFromEnv();
+	await homeDir?.remove().catch(() => {});
+});
+
+const cleanups: (() => Promise<void>)[] = [];
+afterEach(async () => {
+	for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+});
+
+describe("collab host compaction → guest sync (#9781)", () => {
+	it("collapses the guest's model context behind the summary after the host compacts", async () => {
+		const hostManager = SessionManager.inMemory();
+		hostManager.appendMessage({ role: "user", content: "first", timestamp: Date.now() });
+		hostManager.appendMessage(createAssistantMessage("reply"));
+		const keptId = hostManager.appendMessage({ role: "user", content: "keep", timestamp: Date.now() });
+
+		const host = new CollabHost(makeHostContext(hostManager));
+		await host.start("ws://localhost:8788");
+		cleanups.push(() => host.stop("test done"));
+
+		const harness = makeGuestHarness(model, modelRegistry);
+		cleanups.push(harness.dispose);
+
+		await harness.guest.join(host.link);
+
+		// Snapshot replicated the full pre-compaction transcript.
+		await settleFrames(() => harness.session.messages.length === 3);
+		expect(
+			harness.session.messages.map(m => ("content" in m && typeof m.content === "string" ? m.content : m.role)),
+		).toEqual(["first", "assistant", "keep"]);
+
+		// Host compacts: everything before `keptId` collapses behind the summary.
+		hostManager.appendCompaction("SUMMARY", undefined, keptId, 100);
+
+		await settleFrames(() => harness.session.messages[0]?.role === "compactionSummary");
+		const compacted = harness.session.messages;
+		expect(compacted).toHaveLength(2);
+		expect(compacted[0]).toMatchObject({ role: "compactionSummary", summary: "SUMMARY" });
+		expect(compacted[1]).toMatchObject({ role: "user", content: "keep" });
+		// The stale pre-compaction turns are gone.
+		expect(compacted.some(m => "content" in m && (m.content === "first" || m.content === "reply"))).toBe(false);
+
+		// A live message after compaction builds on the compacted base, not the
+		// stale full history.
+		hostManager.appendMessage({ role: "user", content: "after", timestamp: Date.now() });
+		await settleFrames(() => harness.session.messages.length === 3);
+		const withFollowup = harness.session.messages;
+		expect(withFollowup[0]?.role).toBe("compactionSummary");
+		expect(withFollowup.at(-1)).toMatchObject({ role: "user", content: "after" });
+	});
+});

--- a/packages/coding-agent/test/collab/host-compaction-guest-sync.test.ts
+++ b/packages/coding-agent/test/collab/host-compaction-guest-sync.test.ts
@@ -131,7 +131,7 @@ function makeGuestHarness(model: Model, modelRegistry: ModelRegistry): GuestHarn
 async function settleFrames(predicate: () => boolean, maxTicks = 500): Promise<void> {
 	for (let i = 0; i < maxTicks; i++) {
 		if (predicate()) return;
-		await new Promise<void>(resolve => setTimeout(resolve, 0));
+		await Bun.sleep(0);
 	}
 	if (!predicate()) throw new Error("condition not met while settling collab frames");
 }


### PR DESCRIPTION
## Repro
When a collab host compacts its context during a live session, a joined guest diverges: the guest keeps the full pre-compaction transcript while the host holds the compacted view. A new E2E test (`packages/coding-agent/test/collab/host-compaction-guest-sync.test.ts`) drives a real `CollabHost` and real `CollabGuestLink` (backed by a real `AgentSession`) over the in-memory relay; run it against the pre-fix guest with `bun test test/collab/host-compaction-guest-sync.test.ts` and the guest's `session.messages` stays `[user, assistant, user]` instead of collapsing to `[compactionSummary, user]`. Auto-compaction is on by default (`compaction.enabled`), so any sufficiently long collab session hits this.

## Cause
`CollabGuestLink.#applyFrame` (`packages/coding-agent/src/collab/guest.ts`) only rebuilt the guest's agent message array for `entry.type === "message"` (it appends `frame.entry.message`). Compaction rewrites host history: `session-maintenance.ts` calls `SessionManager.appendCompaction()` then `buildDisplaySessionContext()` + `agent.replaceMessages()`, collapsing the pre-boundary transcript behind a summary. The host broadcasts the `compaction` entry (`WIRE_SESSION_ENTRY_TYPES` includes `compaction`), but the guest only called `ingestReplicatedEntry` for it and never rebuilt its message array, so it retained the stale full transcript and every subsequently appended message stacked on that stale base. `branch_summary` shares the identical rewrite shape.

## Fix
- In `CollabGuestLink.#applyFrame`'s `entry` case, after ingesting a `compaction` or `branch_summary` entry, rebuild the guest message array from the ingested entries via `session.buildDisplaySessionContext()` + `agent.replaceMessages()` — mirroring exactly what the host does after `appendCompaction`/`branchWithSummary`.
- Added `packages/coding-agent/test/collab/host-compaction-guest-sync.test.ts`: a real host/guest E2E over the in-memory relay asserting the guest collapses behind the summary and that post-compaction live messages build on the compacted base.
- Changelog entry under `[Unreleased]`.

## Verification
`bun test test/collab/host-compaction-guest-sync.test.ts` — 1 pass (fails on the pre-fix guest, confirming the regression is caught). `bun test test/collab/` — 75 pass / 0 fail. `bun run check:types` (pi-coding-agent) clean. The pre-publish `bun check` gate passed on push.

Fixes #9781