### PR TITLE
docs(hooks): document plain status text

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Corrected the hook status API documentation and example to reflect that ANSI styling is stripped before display ([#9790](https://github.com/can1357/oh-my-pi/issues/9790)).
+
 ## [18.0.5] - 2026-08-25
 
 ### Added

--- a/packages/coding-agent/examples/hooks/README.md
+++ b/packages/coding-agent/examples/hooks/README.md
@@ -26,7 +26,7 @@ cp permission-gate.ts ~/.omp/agent/hooks/
 | `custom-compaction.ts`   | Custom compaction that summarizes entire conversation                          |
 | `qna.ts`                 | Extracts questions from last response into editor via `ctx.ui.setEditorText()` |
 | `snake.ts`               | Snake game with custom UI, keyboard handling, and session persistence          |
-| `status-line.ts`         | Shows turn progress in footer via `ctx.ui.setStatus()` with themed colors      |
+| `status-line.ts`         | Shows plain-text turn progress in the footer via `ctx.ui.setStatus()`          |
 | `handoff.ts`             | Transfer context to a new focused session via `/handoff <goal>`                |
 
 ## Writing Hooks

--- a/packages/coding-agent/examples/hooks/status-line.ts
+++ b/packages/coding-agent/examples/hooks/status-line.ts
@@ -2,7 +2,7 @@
  * Status Line Hook
  *
  * Demonstrates ctx.ui.setStatus() for displaying persistent status text in the footer.
- * Shows turn progress with themed colors.
+ * Shows plain-text turn progress across session and turn events.
  */
 import type { HookAPI } from "@oh-my-pi/pi-coding-agent";
 
@@ -10,30 +10,22 @@ export default function (pi: HookAPI) {
 	let turnCount = 0;
 
 	pi.on("session_start", async (_event, ctx) => {
-		const theme = ctx.ui.theme;
-		ctx.ui.setStatus("status-demo", theme.fg("dim", "Ready"));
+		ctx.ui.setStatus("status-demo", "Ready");
 	});
 
 	pi.on("turn_start", async (_event, ctx) => {
 		turnCount++;
-		const theme = ctx.ui.theme;
-		const spinner = theme.fg("accent", "●");
-		const text = theme.fg("dim", ` Turn ${turnCount}…`);
-		ctx.ui.setStatus("status-demo", spinner + text);
+		ctx.ui.setStatus("status-demo", `● Turn ${turnCount}…`);
 	});
 
 	pi.on("turn_end", async (_event, ctx) => {
-		const theme = ctx.ui.theme;
-		const check = theme.fg("success", "✓");
-		const text = theme.fg("dim", ` Turn ${turnCount} complete`);
-		ctx.ui.setStatus("status-demo", check + text);
+		ctx.ui.setStatus("status-demo", `✓ Turn ${turnCount} complete`);
 	});
 
 	pi.on("session_switch", async (event, ctx) => {
 		if (event.reason === "new") {
 			turnCount = 0;
-			const theme = ctx.ui.theme;
-			ctx.ui.setStatus("status-demo", theme.fg("dim", "Ready"));
+			ctx.ui.setStatus("status-demo", "Ready");
 		}
 	});
 }

--- a/packages/coding-agent/src/extensibility/hooks/types.ts
+++ b/packages/coding-agent/src/extensibility/hooks/types.ts
@@ -86,8 +86,8 @@ export interface HookUIContext {
 	/**
 	 * Set status text in the footer/status bar.
 	 * Pass undefined as text to clear the status for this key.
-	 * Text can include ANSI escape codes for styling.
-	 * Note: Newlines, tabs, and carriage returns are replaced with spaces.
+	 * ANSI/VT escape sequences are stripped, and control characters are replaced with spaces.
+	 * Repeated spaces are collapsed and surrounding whitespace is trimmed.
 	 * The combined status line is truncated to terminal width.
 	 * @param key - Unique key to identify this status (e.g., hook name)
 	 * @param text - Status text to display, or undefined to clear
@@ -156,12 +156,7 @@ export interface HookUIContext {
 	): Promise<string | undefined>;
 
 	/**
-	 * Get the current theme for styling text with ANSI codes.
-	 * Use theme.fg() and theme.bg() to style status text.
-	 *
-	 * @example
-	 * const theme = ctx.ui.theme;
-	 * ctx.ui.setStatus("my-hook", theme.fg("success", theme.status.success) + " Ready");
+	 * Get the current theme for styling custom components.
 	 */
 	readonly theme: Theme;
 }

--- a/packages/coding-agent/src/modes/components/footer.ts
+++ b/packages/coding-agent/src/modes/components/footer.ts
@@ -28,8 +28,8 @@ export class FooterComponent implements Component {
 
 	/**
 	 * Set extension status text to display in the footer.
-	 * Text is sanitized (newlines/tabs replaced with spaces) and truncated to terminal width.
-	 * ANSI escape codes for styling are preserved.
+	 * ANSI/VT escape sequences are stripped, control characters are mapped to spaces, and repeated spaces are collapsed.
+	 * The combined status line is trimmed and truncated to terminal width.
 	 * @param key - Unique key to identify this status
 	 * @param text - Status text, or undefined to clear
 	 */


### PR DESCRIPTION
## Repro
On current `main`, running `bun -e 'import { sanitizeStatusText } from "./packages/coding-agent/src/modes/shared.ts"; const styled = "\x1b[32mReady\x1b[39m"; console.log(JSON.stringify({ input: styled, rendered: sanitizeStatusText(styled) }));'` outputs `{"input":"\u001b[32mReady\u001b[39m","rendered":"Ready"}`, although the hook API declaration and shipped status-line example promise and use ANSI styling.

## Cause
`sanitizeStatusText` in `packages/coding-agent/src/modes/shared.ts` strips ANSI/VT sequences before both footer render paths display extension statuses, but `HookUIContext.setStatus` in `packages/coding-agent/src/extensibility/hooks/types.ts`, `Footer.setExtensionStatus` in `packages/coding-agent/src/modes/components/footer.ts`, and `packages/coding-agent/examples/hooks/status-line.ts` described a styled contract.

## Fix
- Document the exact plain-text sanitization contract in the hook declaration and footer API.
- Replace themed status values in the shipped hook example with plain strings and update its index description.
- Record the corrected public contract in the coding-agent changelog.

## Verification
The focused `bun -e` reproduction returned plain `Ready` from an ANSI-styled input as documented. The publish gate completed `bun run fix` and `bun check` successfully. Fixes #9790