### PR TITLE
fix(settings): preserve later external config edits

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed pending settings saves overwriting later external edits to `config.yml` ([#9789](https://github.com/can1357/oh-my-pi/issues/9789)).
+
 ## [18.0.5] - 2026-08-25
 
 ### Added

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -66,11 +66,62 @@ export interface RawSettings {
 	[key: string]: unknown;
 }
 
+type YamlContentGeneration = {
+	kind: "content";
+	source: string;
+	mtimeNs: bigint;
+	ctimeNs: bigint;
+	inode: bigint;
+	size: bigint;
+};
+
+type YamlGeneration = { kind: "missing" } | YamlContentGeneration | { kind: "unreadable" };
+
+type PendingYamlMutation = {
+	generation: YamlGeneration;
+	baseValue: unknown;
+};
+
 type YamlLoadResult =
 	| { kind: "missing" }
-	| { kind: "loaded"; settings: RawSettings }
-	| { kind: "invalid"; error: unknown; backupPath?: string }
+	| { kind: "loaded"; settings: RawSettings; generation: YamlContentGeneration }
+	| { kind: "invalid"; error: unknown; generation: YamlContentGeneration; backupPath?: string }
 	| { kind: "unreadable"; error: unknown };
+
+type LockedYamlLoadResult = {
+	settings: RawSettings | null;
+	generation: YamlGeneration;
+};
+
+function yamlGenerationFromLoadResult(result: YamlLoadResult): YamlGeneration {
+	switch (result.kind) {
+		case "missing":
+			return { kind: "missing" };
+		case "loaded":
+		case "invalid":
+			return result.generation;
+		case "unreadable":
+			return { kind: "unreadable" };
+	}
+}
+
+function yamlGenerationsMatch(left: YamlGeneration, right: YamlGeneration): boolean {
+	switch (left.kind) {
+		case "missing":
+			return right.kind === "missing";
+		case "content":
+			return (
+				right.kind === "content" &&
+				left.source === right.source &&
+				left.mtimeNs === right.mtimeNs &&
+				left.ctimeNs === right.ctimeNs &&
+				left.inode === right.inode &&
+				left.size === right.size
+			);
+		case "unreadable":
+			return false;
+	}
+}
 
 type MainYamlReadResult = {
 	settings: RawSettings | null;
@@ -415,6 +466,9 @@ export class Settings {
 	#modifiedProjectModelRoles = new Set<string>();
 	/** Individual global model roles modified during this session (for partial save) */
 	#modifiedGlobalModelRoles = new Set<string>();
+	/** On-disk generations and prior values observed before each pending global mutation. */
+	#modifiedPathMutations = new Map<string, PendingYamlMutation>();
+	#modifiedGlobalModelRoleMutations = new Map<string, PendingYamlMutation>();
 	/** Changes whenever a live API mutates a persisted layer. */
 	#persistedMutationGeneration = 0;
 	/**
@@ -568,6 +622,7 @@ export class Settings {
 	set<P extends SettingPath>(path: P, value: SettingValue<P>): void {
 		const prev = this.get(path);
 		const segments = path.split(".");
+		this.#captureGlobalMutation(path, this.#modifiedPathMutations, getByPath(this.#global, segments));
 		setByPath(this.#global, segments, value);
 		this.#persistedMutationGeneration++;
 		this.#modified.add(path);
@@ -1055,6 +1110,7 @@ export class Settings {
 	setModelRole(role: ModelRole | string, modelId: string | undefined): void {
 		const prev = this.get("modelRoles");
 		const current = this.#modelRolesFromLayer(this.#global);
+		this.#captureGlobalMutation(role, this.#modifiedGlobalModelRoleMutations, current[role]);
 		if (modelId === undefined) {
 			delete current[role];
 		} else {
@@ -1250,6 +1306,31 @@ export class Settings {
 		return this;
 	}
 
+	#readYamlGeneration(filePath: string): YamlGeneration {
+		try {
+			const source = fs.readFileSync(filePath, "utf8");
+			const stat = fs.statSync(filePath, { bigint: true });
+			return {
+				kind: "content",
+				source,
+				mtimeNs: stat.mtimeNs,
+				ctimeNs: stat.ctimeNs,
+				inode: stat.ino,
+				size: stat.size,
+			};
+		} catch (error) {
+			return isEnoent(error) ? { kind: "missing" } : { kind: "unreadable" };
+		}
+	}
+
+	#captureGlobalMutation(key: string, mutations: Map<string, PendingYamlMutation>, baseValue: unknown): void {
+		if (!this.#persist || !this.#configPath) return;
+		mutations.set(key, {
+			generation: this.#readYamlGeneration(this.#configPath),
+			baseValue: structuredClone(baseValue),
+		});
+	}
+
 	async #loadYaml(filePath: string): Promise<RawSettings> {
 		const loaded = await this.#loadYamlIfPresentForStartup(filePath);
 		return loaded ?? {};
@@ -1257,8 +1338,18 @@ export class Settings {
 
 	async #loadYamlIfPresent(filePath: string, captureLegacyChangelogVersion = true): Promise<YamlLoadResult> {
 		let content: string;
+		let generation: YamlContentGeneration;
 		try {
 			content = await fs.promises.readFile(filePath, "utf8");
+			const stat = await fs.promises.stat(filePath, { bigint: true });
+			generation = {
+				kind: "content",
+				source: content,
+				mtimeNs: stat.mtimeNs,
+				ctimeNs: stat.ctimeNs,
+				inode: stat.ino,
+				size: stat.size,
+			};
 		} catch (error) {
 			if (isEnoent(error)) return { kind: "missing" };
 			return { kind: "unreadable", error };
@@ -1268,20 +1359,22 @@ export class Settings {
 		try {
 			parsed = YAML.parse(content);
 		} catch (error) {
-			return { kind: "invalid", error };
+			return { kind: "invalid", error, generation };
 		}
 		if (parsed === null || parsed === undefined) {
-			return { kind: "loaded", settings: {} };
+			return { kind: "loaded", settings: {}, generation };
 		}
 		if (typeof parsed !== "object" || Array.isArray(parsed)) {
 			return {
 				kind: "invalid",
 				error: new Error("Settings YAML must contain a mapping at the document root"),
+				generation,
 			};
 		}
 		return {
 			kind: "loaded",
 			settings: this.#migrateRawSettings(parsed as RawSettings, captureLegacyChangelogVersion),
+			generation,
 		};
 	}
 
@@ -1319,9 +1412,10 @@ export class Settings {
 		if (result.kind !== "invalid" || !this.#persist) {
 			return this.#unwrapYamlLoadResult(filePath, result);
 		}
-		return await this.#withYamlWriteLock(filePath, async writePath =>
-			this.#loadYamlIfPresentForWriteLocked(filePath, writePath, true),
-		);
+		return await this.#withYamlWriteLock(filePath, async writePath => {
+			const loaded = await this.#loadYamlIfPresentForWriteLocked(filePath, writePath, true);
+			return loaded.settings;
+		});
 	}
 
 	/**
@@ -1333,8 +1427,9 @@ export class Settings {
 		filePath: string,
 		writePath: string,
 		rejectMissing = false,
-	): Promise<RawSettings | null> {
+	): Promise<LockedYamlLoadResult> {
 		let result = await this.#loadYamlIfPresent(writePath);
+		const generation = yamlGenerationFromLoadResult(result);
 		if (result.kind === "missing" && rejectMissing) {
 			throw new Error(
 				`Settings config was invalid before locking and is now missing: ${filePath}; another process may have moved it aside`,
@@ -1344,7 +1439,10 @@ export class Settings {
 			result = await this.#quarantineInvalidYamlLocked(writePath, result);
 			this.#quarantinedYamlTargets.set(filePath, writePath);
 		}
-		return this.#unwrapYamlLoadResult(filePath, result);
+		return {
+			settings: this.#unwrapYamlLoadResult(filePath, result),
+			generation,
+		};
 	}
 
 	async #quarantineInvalidYamlLocked(
@@ -2283,9 +2381,13 @@ export class Settings {
 		const configPath = this.#configPath;
 		const modifiedPaths = [...this.#modified];
 		const modifiedModelRoles = [...this.#modifiedGlobalModelRoles];
+		const modifiedPathMutations = new Map(this.#modifiedPathMutations);
+		const modifiedModelRoleMutations = new Map(this.#modifiedGlobalModelRoleMutations);
 		const globalRolesAtStart = this.#modelRolesFromLayer(this.#global);
 		this.#modified.clear();
 		this.#modifiedGlobalModelRoles.clear();
+		this.#modifiedPathMutations.clear();
+		this.#modifiedGlobalModelRoleMutations.clear();
 
 		try {
 			await this.#withYamlWriteLock(configPath, async writePath => {
@@ -2294,13 +2396,29 @@ export class Settings {
 				// rather than recreating the config from only the pending path.
 				const loaded = await this.#loadYamlIfPresentForWriteLocked(configPath, writePath);
 				const current =
-					loaded ?? (this.#quarantinedYamlTargets.has(configPath) ? structuredClone(this.#global) : {});
+					loaded.settings ?? (this.#quarantinedYamlTargets.has(configPath) ? structuredClone(this.#global) : {});
+				let shouldWrite = false;
 
-				// Apply only our modified whole-value paths
+				// Apply pending changes unless a newer file generation also
+				// changed that setting. Disjoint external edits still merge.
 				for (const modPath of modifiedPaths) {
 					const segments = modPath.split(".");
+					const mutation = modifiedPathMutations.get(modPath);
+					const canApply =
+						mutation !== undefined &&
+						mutation.generation.kind !== "unreadable" &&
+						(yamlGenerationsMatch(mutation.generation, loaded.generation) ||
+							Bun.deepEquals(getByPath(current, segments), mutation.baseValue));
+					if (!canApply) {
+						logger.warn("Settings: skipped stale change after external config edit", {
+							path: configPath,
+							setting: modPath,
+						});
+						continue;
+					}
 					const value = getByPath(this.#global, segments);
 					setByPath(current, segments, value);
+					shouldWrite = true;
 				}
 
 				// Merge only the model roles captured by this save. Then retain
@@ -2318,10 +2436,25 @@ export class Settings {
 						rolesToPreserve.add(role);
 					}
 				}
-				if (modifiedModelRoles.length > 0 || rolesToPreserve.size > 0) {
-					const currentRoles = getByPath(current, ["modelRoles"]);
-					const mergedRoles: Record<string, unknown> = isRecord(currentRoles) ? { ...currentRoles } : {};
-					for (const role of modifiedModelRoles) {
+				const currentRoles = getByPath(current, ["modelRoles"]);
+				const currentRoleValues: Record<string, unknown> = isRecord(currentRoles) ? currentRoles : {};
+				const rolesToApply = modifiedModelRoles.filter(role => {
+					const mutation = modifiedModelRoleMutations.get(role);
+					const canApply =
+						mutation !== undefined &&
+						mutation.generation.kind !== "unreadable" &&
+						(yamlGenerationsMatch(mutation.generation, loaded.generation) ||
+							Bun.deepEquals(currentRoleValues[role], mutation.baseValue));
+					if (canApply) return true;
+					logger.warn("Settings: skipped stale change after external config edit", {
+						path: configPath,
+						setting: `modelRoles.${role}`,
+					});
+					return false;
+				});
+				if (rolesToApply.length > 0 || rolesToPreserve.size > 0) {
+					const mergedRoles: Record<string, unknown> = { ...currentRoleValues };
+					for (const role of rolesToApply) {
 						if (Object.hasOwn(globalRolesAtStart, role)) {
 							mergedRoles[role] = globalRolesAtStart[role];
 						} else {
@@ -2336,11 +2469,14 @@ export class Settings {
 						}
 					}
 					setByPath(current, ["modelRoles"], mergedRoles);
+					shouldWrite = true;
 				}
 
-				// Update our global with any external changes we preserved
+				// Update our global with any external changes we preserved.
 				this.#global = current;
-				await this.#writeYamlAtomically(writePath, this.#global);
+				if (shouldWrite) {
+					await this.#writeYamlAtomically(writePath, this.#global);
+				}
 				this.#quarantinedYamlTargets.delete(configPath);
 				// These pending roles were included in this write. Remove each
 				// only if no newer local change arrived while the write was in flight.
@@ -2348,17 +2484,43 @@ export class Settings {
 				for (const role of rolesToPreserve) {
 					if (latestGlobalRoles[role] === globalRolesAfterWrite[role]) {
 						this.#modifiedGlobalModelRoles.delete(role);
+						this.#modifiedGlobalModelRoleMutations.delete(role);
 					}
 				}
 			});
 		} catch (error) {
 			logger.warn("Settings: save failed", { error: String(error) });
-			// Re-add failed paths for retry
+			// A quarantined file is now missing by our own action, not because
+			// another writer superseded the mutation. Retry against that state.
+			const retryGeneration = this.#quarantinedYamlTargets.has(configPath)
+				? this.#readYamlGeneration(configPath)
+				: undefined;
+			// Re-add failed paths for retry, retaining any newer mutation's generation.
 			for (const p of modifiedPaths) {
 				this.#modified.add(p);
+				if (!this.#modifiedPathMutations.has(p)) {
+					const mutation = modifiedPathMutations.get(p) ?? {
+						generation: { kind: "unreadable" },
+						baseValue: undefined,
+					};
+					this.#modifiedPathMutations.set(
+						p,
+						retryGeneration ? { ...mutation, generation: retryGeneration } : mutation,
+					);
+				}
 			}
 			for (const role of modifiedModelRoles) {
 				this.#modifiedGlobalModelRoles.add(role);
+				if (!this.#modifiedGlobalModelRoleMutations.has(role)) {
+					const mutation = modifiedModelRoleMutations.get(role) ?? {
+						generation: { kind: "unreadable" },
+						baseValue: undefined,
+					};
+					this.#modifiedGlobalModelRoleMutations.set(
+						role,
+						retryGeneration ? { ...mutation, generation: retryGeneration } : mutation,
+					);
+				}
 			}
 			this.#rebuildMerged();
 			throw error;
@@ -2398,7 +2560,7 @@ export class Settings {
 			await this.#withYamlWriteLock(projectConfigPath, async writePath => {
 				const loaded = await this.#loadYamlIfPresentForWriteLocked(projectConfigPath, writePath);
 				const projectSettings =
-					loaded ??
+					loaded.settings ??
 					(this.#quarantinedYamlTargets.has(projectConfigPath) ? structuredClone(this.#projectFileSettings) : {});
 
 				const projectRoles = getByPath(this.#project, ["modelRoles"]);

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -800,6 +800,42 @@ describe("Settings", () => {
 			const savedSettings = await readSettings();
 			expect(savedSettings.defaultThinkingLevel).toBe(Effort.High);
 		});
+
+		it("preserves a same-key external edit made after a local save was queued", async () => {
+			await writeSettings({
+				defaultThinkingLevel: Effort.Low,
+			});
+
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			settings.set("defaultThinkingLevel", Effort.High);
+
+			await writeSettings({
+				defaultThinkingLevel: Effort.Medium,
+			});
+			await settings.flush();
+
+			expect((await readSettings()).defaultThinkingLevel).toBe(Effort.Medium);
+			expect(settings.get("defaultThinkingLevel")).toBe(Effort.Medium);
+		});
+
+		it("merges a pending local change with a later disjoint external edit", async () => {
+			await writeSettings({
+				defaultThinkingLevel: Effort.Low,
+			});
+
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			settings.set("defaultThinkingLevel", Effort.High);
+
+			await writeSettings({
+				defaultThinkingLevel: Effort.Low,
+				enabledModels: ["openai/gpt-5.2-codex"],
+			});
+			await settings.flush();
+
+			const savedSettings = await readSettings();
+			expect(savedSettings.defaultThinkingLevel).toBe(Effort.High);
+			expect(savedSettings.enabledModels).toEqual(["openai/gpt-5.2-codex"]);
+		});
 	});
 
 	describe("model role overrides", () => {
@@ -823,6 +859,23 @@ describe("Settings", () => {
 			});
 			expect(settings.getModelRole("default")).toBe("openai/gpt-5.2-codex");
 			expect(settings.getModelRole("smol")).toBe("anthropic/claude-haiku-4-5");
+		});
+
+		it("preserves a same-role external edit made after a local save was queued", async () => {
+			await writeSettings({
+				modelRoles: { default: "anthropic/claude-sonnet-4-5" },
+			});
+
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			settings.setModelRole("default", "openai/gpt-5.2-codex");
+
+			await writeSettings({
+				modelRoles: { default: "moonshot/kimi-k3:max" },
+			});
+			await settings.flush();
+
+			expect((await readSettings()).modelRoles).toEqual({ default: "moonshot/kimi-k3:max" });
+			expect(settings.getModelRole("default")).toBe("moonshot/kimi-k3:max");
 		});
 
 		it("preserves concurrent external per-role edits when saving one global role", async () => {


### PR DESCRIPTION
## Repro
Load `config.yml` with `defaultThinkingLevel: low`, call `settings.set("defaultThinkingLevel", Effort.High)`, externally write `defaultThinkingLevel: medium`, then run `await settings.flush()`. Before the fix, the final file contained `high`; the same sequence is covered by `bun test packages/coding-agent/test/settings-manager.test.ts`.

## Cause
`Settings.#saveNow` in `packages/coding-agent/src/config/settings.ts` re-read the current YAML but unconditionally applied every dirty in-memory path. It had no generation or prior-value record to distinguish a later same-key external edit from a safe disjoint merge.

## Fix
- Capture the exact YAML content and filesystem generation plus the prior setting value when each global mutation is queued.
- Three-way merge pending paths and model roles: preserve later same-key disk edits while still applying disjoint local changes.
- Keep malformed-file quarantine retries safe and add user-visible conflict diagnostics.
- Add regression coverage for ordinary settings, model roles, disjoint external edits, and existing retry behavior.

## Verification
`bun test packages/coding-agent/test/settings-manager.test.ts` passed: 93 tests, 247 assertions. `bun check` passed across all packages. Manual repro now leaves `defaultThinkingLevel: medium` on disk.

Fixes #9789