### PR TITLE
fix(coding-agent): diff user-shell env hook against the child shell's base environment

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed `!` user-shell commands losing extension-provided environment variables (e.g. the secretsd session token) when the extension also mirrors them into the omp process environment: the shell-env hook now diffs against the child shell's actual base environment instead of `process.env`.
+- Fixed the user-shell environment hook sharing the cached shell config object with extension hooks: a hook that mutates its environment context in place could permanently poison later commands' environment diffing.
 
 ## [18.0.5] - 2026-08-25
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `!` user-shell commands losing extension-provided environment variables (e.g. the secretsd session token) when the extension also mirrors them into the omp process environment: the shell-env hook now diffs against the child shell's actual base environment instead of `process.env`.
+
 ## [18.0.5] - 2026-08-25
 
 ### Added
@@ -67,7 +71,6 @@
 - Fixed completed assistant replies disappearing from the live transcript under viewport pressure.
 - Accelerated SHA-2 and SHA-3 checksums on supported ARM64 hardware.
 - Fixed large MCP tool payloads being stored redundantly on disk.
-
 ## [18.0.4] - 2026-08-24
 
 ### Added

--- a/packages/coding-agent/src/session/bash-runner.ts
+++ b/packages/coding-agent/src/session/bash-runner.ts
@@ -91,9 +91,17 @@ export class BashRunner {
 				}
 			}
 
+			// The hook's adapter forwards only entries that differ from the baseline
+			// it is handed, and the child shell starts from the (cached, filtered)
+			// spawn env — NOT from live process.env. Diffing against process.env
+			// cancels out any variable an extension both mirrors into process.env
+			// and injects via its hook (e.g. the secretsd session token file), so
+			// hand the hook the env the child will actually receive.
 			const shellEnv =
 				options?.useUserShell === true
-					? extensionRunner?.getRegisteredTool("bash")?.definition.shellEnv?.({ command, cwd, env: process.env })
+					? extensionRunner
+							?.getRegisteredTool("bash")
+							?.definition.shellEnv?.({ command, cwd, env: this.#host.settings.getShellConfig().env })
 					: undefined;
 
 			const abortController = new AbortController();

--- a/packages/coding-agent/src/session/bash-runner.ts
+++ b/packages/coding-agent/src/session/bash-runner.ts
@@ -96,12 +96,15 @@ export class BashRunner {
 			// spawn env — NOT from live process.env. Diffing against process.env
 			// cancels out any variable an extension both mirrors into process.env
 			// and injects via its hook (e.g. the secretsd session token file), so
-			// hand the hook the env the child will actually receive.
+			// hand the hook the env the child will actually receive. Pass a copy:
+			// this.#host.settings.getShellConfig().env is a cached, shared object,
+			// and a legacy hook that mutates its context.env in place (a supported
+			// pattern) would otherwise poison that cache for every later command.
 			const shellEnv =
 				options?.useUserShell === true
 					? extensionRunner
 							?.getRegisteredTool("bash")
-							?.definition.shellEnv?.({ command, cwd, env: this.#host.settings.getShellConfig().env })
+							?.definition.shellEnv?.({ command, cwd, env: { ...this.#host.settings.getShellConfig().env } })
 					: undefined;
 
 			const abortController = new AbortController();

--- a/packages/coding-agent/test/agent-session-bash-session-ownership.test.ts
+++ b/packages/coding-agent/test/agent-session-bash-session-ownership.test.ts
@@ -197,6 +197,48 @@ describe("AgentSession bash session ownership", () => {
 		}
 	});
 
+	it("does not poison the cached shell env when a hook mutates its context in place", async () => {
+		// Regression: `Settings#getShellConfig().env` is a cached, shared object
+		// (procmgr's module-level cache). A legacy hook that mutates its
+		// `context.env` in place — a supported pattern, see "forwards changes
+		// when the hook mutates its environment in place" below — must not be
+		// handed that shared object directly: doing so writes the injected
+		// variable straight into the cache, poisoning the diff baseline for
+		// every later command. On the next call the hook injects the same
+		// value again, it now looks unchanged against the poisoned baseline,
+		// and the adapter silently drops it from the forwarded env.
+		const shell = process.platform === "win32" ? (Bun.env.ComSpec ?? "cmd.exe") : "/bin/sh";
+		Settings.instance.set("shellPath", shell);
+		const cachedShellConfig = {
+			shell,
+			args: process.platform === "win32" ? ["/c"] : ["-c"],
+			env: { PATH: Bun.env.PATH ?? "", HOME: tempDir.path(), SHELL: shell },
+			prefix: undefined,
+		};
+		vi.spyOn(Settings.prototype, "getShellConfig").mockReturnValue(cachedShellConfig);
+		const spawnHook = vi.fn(context => {
+			context.env.OMP_INJECTED_TOKEN = "injected-value";
+			return context;
+		});
+		const definition = createBashTool(tempDir.path(), { spawnHook });
+		const extensionRunner = {
+			hasHandlers: vi.fn(() => false),
+			getRegisteredTool: vi.fn((name: string) => (name === "bash" ? { definition } : undefined)),
+			emit: vi.fn().mockResolvedValue(undefined),
+			emitBeforeAgentStart: vi.fn().mockResolvedValue(undefined),
+		} as unknown as ExtensionRunner;
+		createSession(undefined, extensionRunner);
+		const executeBashSpy = vi.spyOn(bashExecutor, "executeBash").mockResolvedValue(bashResult);
+
+		await session.executeBash("true", undefined, { useUserShell: true });
+		await session.executeBash("true", undefined, { useUserShell: true });
+
+		expect(executeBashSpy).toHaveBeenCalledTimes(2);
+		expect(executeBashSpy.mock.calls[0]?.[1]?.env).toEqual({ OMP_INJECTED_TOKEN: "injected-value" });
+		expect(executeBashSpy.mock.calls[1]?.[1]?.env).toEqual({ OMP_INJECTED_TOKEN: "injected-value" });
+		expect(cachedShellConfig.env).not.toHaveProperty("OMP_INJECTED_TOKEN");
+	});
+
 	it("does not run the shell environment hook when a user_bash handler replaces the result", async () => {
 		const spawnHook = vi.fn(() => {
 			throw new Error("shell env hook must not run when user_bash supplies a replacement result");

--- a/packages/coding-agent/test/agent-session-bash-session-ownership.test.ts
+++ b/packages/coding-agent/test/agent-session-bash-session-ownership.test.ts
@@ -154,6 +154,49 @@ describe("AgentSession bash session ownership", () => {
 		);
 	});
 
+	it("forwards a hook-injected variable even when process.env already mirrors its value", async () => {
+		// Regression: an extension may both mirror a variable into process.env (so
+		// MCP servers and workers inherit it) and inject it via its spawnHook. The
+		// hook adapter forwards only entries differing from the baseline it is
+		// handed; diffing against process.env made the mirrored value look
+		// unchanged and dropped it, while the child shell's real base env (the
+		// filtered spawn env) never contained it — so user shells lost the
+		// variable entirely (the secretsd session-token incident).
+		const shell = process.platform === "win32" ? (Bun.env.ComSpec ?? "cmd.exe") : "/bin/sh";
+		Settings.instance.set("shellPath", shell);
+		vi.spyOn(Settings.prototype, "getShellConfig").mockReturnValue({
+			shell,
+			args: process.platform === "win32" ? ["/c"] : ["-c"],
+			env: { PATH: Bun.env.PATH ?? "", HOME: tempDir.path(), SHELL: shell },
+			prefix: undefined,
+		});
+		const previousMirror = process.env.OMP_USER_SHELL_MIRROR;
+		process.env.OMP_USER_SHELL_MIRROR = "mirrored-value";
+		try {
+			const spawnHook = vi.fn(spawn => ({
+				...spawn,
+				env: { ...spawn.env, OMP_USER_SHELL_MIRROR: "mirrored-value" },
+			}));
+			const definition = createBashTool(tempDir.path(), { spawnHook });
+			const extensionRunner = {
+				hasHandlers: vi.fn(() => false),
+				getRegisteredTool: vi.fn((name: string) => (name === "bash" ? { definition } : undefined)),
+				emit: vi.fn().mockResolvedValue(undefined),
+				emitBeforeAgentStart: vi.fn().mockResolvedValue(undefined),
+			} as unknown as ExtensionRunner;
+			createSession(undefined, extensionRunner);
+
+			const result = await session.executeBash('printf "%s" "$OMP_USER_SHELL_MIRROR"', undefined, {
+				useUserShell: true,
+			});
+
+			expect(result.output).toBe("mirrored-value");
+		} finally {
+			if (previousMirror === undefined) delete process.env.OMP_USER_SHELL_MIRROR;
+			else process.env.OMP_USER_SHELL_MIRROR = previousMirror;
+		}
+	});
+
 	it("does not run the shell environment hook when a user_bash handler replaces the result", async () => {
 		const spawnHook = vi.fn(() => {
 			throw new Error("shell env hook must not run when user_bash supplies a replacement result");


### PR DESCRIPTION
## What

Fixes `!` user-shell commands losing environment variables that an extension injects through the `shellEnv` hook whenever the extension *also* mirrors those variables into the omp process environment.

## Why

The `shellEnv` adapter (`legacy-pi-coding-agent-shim.ts`) forwards only entries that differ from the baseline it is handed — by design, so the spread of `context.env` isn't re-injected wholesale. But `bash-runner.ts` handed the hook `process.env` as that baseline, while the spawned user shell actually starts from the cached, filtered spawn env (`settings.getShellConfig().env` → `buildSpawnEnv`), which is not the same environment.

An extension that both mirrors a variable into `process.env` (e.g. so MCP stdio servers and workers inherit it) and injects it via its spawn hook gets the injection silently cancelled: the hook's output matches the `process.env` baseline, the diff is empty, and the child shell — whose real base env never had the variable — doesn't receive it.

## Fix

Hand the hook the env the child will actually start from: `this.#host.settings.getShellConfig().env` instead of `process.env`. One line plus a comment; `Settings.getShellConfig()` is already on the runner's host surface.

## Tests

New regression case in `test/agent-session-bash-session-ownership.test.ts`: "forwards a hook-injected variable even when process.env already mirrors its value" — sets the variable in `process.env`, injects the same value via the hook, and asserts the user shell receives it (with env save/restore in `finally`).

Mutation-verified: reverting the baseline to `process.env` fails exactly this test (13 pass / 1 fail); with the fix, 14 pass / 0 fail. `bun check` clean.

## Base

Rebased onto `eab72e88` (v18.0.5). Complements `afc435ad` (baseline snapshot before hook mutation) — that fix hardened the adapter's diff arithmetic; this one fixes which environment the diff is computed against.
