### PR TITLE
fix(settings): prevent sidebar clicks from toggling options

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed clicks on the active Settings section sidebar toggling its first option ([#9795](https://github.com/can1357/oh-my-pi/issues/9795)).
+
 ## [18.0.5] - 2026-08-25
 
 ### Added

--- a/packages/coding-agent/src/modes/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/components/settings-selector.ts
@@ -798,12 +798,13 @@ export class SettingsSelectorComponent implements Component {
 			return true;
 		}
 		if (overContent && list) {
-			const id = list.hitTest(contentLine, innerCol);
+			const itemId = list.hoverTest(contentLine, innerCol);
+			const id = itemId ?? list.hitTest(contentLine, innerCol);
 			if (id !== undefined) {
 				const wasSelected = list.getSelectedItem()?.id === id;
 				list.selectItem(id);
-				// Click-again activates: toggle booleans, open submenus.
-				if (wasSelected) list.handleInput("\n");
+				// Only repeated setting-row clicks activate. Sidebar section clicks navigate.
+				if (wasSelected && itemId !== undefined) list.handleInput("\n");
 			}
 		}
 		return true;

--- a/packages/coding-agent/test/modes/components/settings-multiselect.test.ts
+++ b/packages/coding-agent/test/modes/components/settings-multiselect.test.ts
@@ -212,3 +212,17 @@ describe("multiselect settings (array-of-enum)", () => {
 		expect(settings.get("providers.webSearchOrder")).toEqual([secondChoice!.value, firstChoice!.value]);
 	});
 });
+
+describe("settings section sidebar", () => {
+	it("does not toggle the selected section's first setting", () => {
+		const comp = createSelector();
+		for (let i = 0; i < 7; i++) comp.handleInput("\x1b[C");
+		expect(settings.get("dev.autoqa")).toBe(true);
+
+		clickOption(comp, "Developer");
+		expect(settings.get("dev.autoqa")).toBe(true);
+
+		clickOption(comp, "Developer");
+		expect(settings.get("dev.autoqa")).toBe(true);
+	});
+});


### PR DESCRIPTION
## Repro
At 120 columns, open `/settings`, switch to Tools, click `Developer` to select Auto QA, then click `Developer` again. `bun test packages/coding-agent/test/modes/components/settings-multiselect.test.ts` reproduces the regression on the old selector because the second navigation click changes `dev.autoqa` from `true` to `false`.

## Cause
`SettingsSelectorComponent.#routeMouseEvent()` in `packages/coding-agent/src/modes/components/settings-selector.ts` used `SettingsList.hitTest()` for both setting rows and section-sidebar entries. A section entry resolves to its first setting ID, so clicking the active section satisfied the selected-row activation check and toggled that setting.

## Fix
- Distinguish pane-item hits with `SettingsList.hoverTest()` before allowing repeated-click activation.
- Keep section-sidebar hits as selection-only navigation.
- Add regression coverage for repeated `Developer` sidebar clicks with Auto QA selected.
- Document the user-visible fix in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/modes/components/settings-multiselect.test.ts` passes: 9 tests, 0 failures. The minimal mouse harness now reports `{"before":true,"afterSelect":true,"afterRepeatedClick":true}`. The pre-publish `bun check` gate passed.

Fixes #9795