### PR TITLE
fix(coding-agent): export registry subpaths to compiled extensions

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed compiled-binary extensions failing to import `@oh-my-pi/pi-coding-agent/registry/*` modules.
+
 ## [18.0.5] - 2026-08-25
 
 ### Added

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -500,6 +500,10 @@
       "import": "./src/plan-mode/*.ts"
     },
     "./prompts/*": "./src/prompts/*.md",
+    "./registry/*": {
+      "types": "./src/registry/*.ts",
+      "import": "./src/registry/*.ts"
+    },
     "./secrets": {
       "types": "./src/secrets/index.ts",
       "import": "./src/secrets/index.ts"

--- a/packages/coding-agent/test/extensibility/legacy-pi-bundled-subpath-overrides.test.ts
+++ b/packages/coding-agent/test/extensibility/legacy-pi-bundled-subpath-overrides.test.ts
@@ -139,6 +139,13 @@ export const observed = [
 		}
 	});
 
+	it("serves coding-agent registry wildcard exports in compiled mode", () => {
+		const key = "@oh-my-pi/pi-coding-agent/registry/agent-registry";
+		const overrides = __buildLegacyPiPackageRootOverrides(true, bundledModuleKeys);
+		expect(bundledModuleKeys.has(key)).toBe(true);
+		expect(overrides[key]).toBe(`omp-legacy-pi-bundled:${key}`);
+	});
+
 	it("does not enumerate root catch-all wildcards (./* / ./*.js)", () => {
 		// Root `./*` / `./*.js` patterns would static-import top-level files
 		// like the package's own `cli.ts` and explode the bundle through the


### PR DESCRIPTION
## Problem
OMP's Bun-compiled binary serves host modules requested by runtime-loaded extensions through a build-time bundled-module registry. The package export map's root `./*` wildcard works in source installs but does not populate that compiled registry, producing a dev-vs-compiled contract divergence:

```ts
import("@oh-my-pi/pi-coding-agent/task/executor"); // resolves
import("@oh-my-pi/pi-coding-agent/registry/agent-registry"); // Cannot find package
```

Extension authors needing `AgentRegistry` therefore have to reach it indirectly through the `modes/running-subagent-badge` UI helper. As related context, when the extension-source rewrite encounters an unmapped specifier, it currently fails file-scoped and can misattribute the error to whichever import executes first; changing that behavior is outside this PR.

## Cause
The compiled registry intentionally excludes root catch-all exports to avoid retaining CLI entrypoints and other unsafe surfaces. `packages/coding-agent/package.json` had explicit named wildcard exports for `./task/*`, `./modes/*`, `./session/*`, and similar surfaces, but not `./registry/*`.

## Fix
- Add the explicit `./registry/*` package export.
- Keep the key list auto-derived: `packages/coding-agent/scripts/legacy-pi-virtual-module.ts:135-170` expands every named wildcard export by scanning its source targets and emits each concrete module key. No manual registry entry is needed.
- Add regression coverage proving `registry/agent-registry` enters the compiled override map, plus the coding-agent changelog entry.

`./sdk` is unchanged.

## Verification
- `bunx bun@1.4.0 test test/extensibility/legacy-pi-bundled-subpath-overrides.test.ts` — 13 pass
- `bunx bun@1.4.0 check` — clean