### PR TITLE
feat(coding-agent): /sessions manager, workspace checkpoints and rollback

### DIFF
--- a/docs/sessions-manager.md
+++ b/docs/sessions-manager.md
@@ -1,0 +1,108 @@
+# /sessions
+
+> A query and control surface for session history: list, open, archive, pause, kill, and inspect sessions, plus per-session workspace-checkpoint counts. Keyboard-driven fullscreen overlay in the TUI; a top-20 text table in text/ACP mode.
+
+This manager is read-mostly across processes. Only the session currently running in **this** process is "live" — its agent/pause/model state is knowable here. Every other session is a persisted file on disk, so non-live metrics are best-effort and control is limited to persisted-file actions (archive, delete). See [workspace-checkpoints.md](./workspace-checkpoints.md) for the checkpoint/rollback feature the details pane links into.
+
+## Source
+
+- Query/control layer: `packages/coding-agent/src/session/session-control.ts` — `enumerateSessions`, `setArchived`, `isArchived`, `clearSessionMetricsCache`, `SessionRow`.
+- Base listing: `packages/coding-agent/src/session/session-listing.ts` — `SessionInfo`, `SessionStatus`.
+- TUI overlay: `packages/coding-agent/src/modes/components/sessions-manager.ts` (`SessionsManagerComponent`).
+- Command spec: `packages/coding-agent/src/slash-commands/builtin-workspace.ts` (`/sessions`).
+- Rename subcommand: `packages/coding-agent/src/slash-commands/builtin-session.ts` (`/session rename`).
+- Metrics source: `packages/stats/src/db.ts` — `getSessionSummaries` (see [stats reuse](#stats-db-reuse)).
+
+## What it does
+
+`enumerateSessions` merges the persisted session listing (`listAllSessions`/`listSessions`) with in-process truth and best-effort metrics:
+
+- **persisted truth** — `SessionInfo` from disk: `path`, `id`, `cwd`, `title?`, `created`, `modified`, `messageCount`, `size`, `status?`.
+- **in-process truth** (current session only) — live agent counts and pause state from the process-global `AgentRegistry`/`agentPauseGate`; model and profile from the running `AgentSession`/`settings.getActiveProfile()`.
+- **best-effort metrics** — cost/token totals from the omp-stats DB and git branch/dirty state at `info.cwd`. These are cached in-module keyed by `path@mtime`; `clearSessionMetricsCache` forces a refresh (e.g. on the `R` key).
+
+## States
+
+A session row carries several orthogonal state signals. They are not mutually exclusive flags — `archived` and `isCurrent` can both be false for an ordinary other-process session that still has a lifecycle `status`.
+
+| Signal | Meaning | Source |
+| --- | --- | --- |
+| `isCurrent` | The session this process is running. | `sessionManager.getSessionFile()` compared against `info.path`. |
+| `liveState` | `streaming` / `idle` / `paused` for the **current** session. Derived from `agentPauseGate.paused` (`paused`) and whether any registry agent is `running` (`streaming`) else `idle`. Undefined for all other sessions. | `agentPauseGate` + `AgentRegistry.global()`. |
+| `archived` | An archive sentinel sidecar (`<sessionFile>.archived`) exists. | `isArchived`. |
+| `status` | Coarse lifecycle status of the last persisted message: `complete` / `interrupted` / `aborted` / `error` / `pending` / `unknown`. Present for any session; `undefined` for synthesized stubs. | `SessionInfo.status`. |
+| `agentCounts` | `running`/`idle`/`parked` subagent tallies for the current session (this process only). | `AgentRegistry.global()`. |
+
+`parked` appears here as a subagent count, not a session-level status: a session is "live" (streaming/idle) whenever this process has agents, and `parked` agents are part of `agentCounts.parked`.
+
+## Archive, kill, delete semantics
+
+These are three distinct operations. Killing never deletes history, and deleting is never silent.
+
+- **Archive** (`A`): writes or removes the sidecar sentinel `<sessionFile>.archived`. The sentinel is an empty marker file — the JSONL is never mutated — so archiving is cross-process safe and fully reversible (re-pressing `A` un-archives and restores everything). Archive state is used only by the `current`/`active`/`archived` filters; it does not change the session's on-disk data.
+- **Kill** (`K`, current session only): tombstone-releases this process's own running subagents (`AgentRegistry`/`AgentLifecycleManager.release(id, expected, { tombstone: true })`, excluding the main agent). It does **not** delete or interrupt the parent session's history; it only releases spawned subagents. Disabled for non-current sessions (shown as unavailable).
+- **Delete** (`K` on a non-current session): removes the persisted session via `sessionManager.dropSession`, gated behind a **two-step confirmation** (first `K` arms, second `K`/`y`/`enter` executes; `n`/`Esc` cancels). Delete is a separate action from kill and is always explicitly confirmed twice — history is never silently dropped.
+
+## Actions (TUI)
+
+| Key | Action |
+| --- | --- |
+| `j` / `↓`, `k` / `↑` | Move selection. |
+| `enter` | Open/resume the selected session (current session: just closes the overlay). |
+| `A` | Toggle archive sentinel (reversible). |
+| `P` | Pause/resume — current session only (engages/releases `agentPauseGate`); unavailable for others. |
+| `K` | Kill current subagents (current) **or** delete session (other; confirmed twice). |
+| `D` | Toggle the details pane. |
+| `C` | Open the session's checkpoint list — details pane only, read-only. |
+| `F` | Cycle filter: `current` → `active` → `paused` → `archived` → `all`. |
+| `S` | Cycle sort: `recent` → `created` → `cost` → `agents`. |
+| `R` | Refresh (drops the metrics cache and re-enumerates). |
+| `Esc` | Close details/confirm; app-interrupt closes the manager. |
+
+In text/ACP mode `/sessions` prints a top-20 table (`*` marks current, lifecycle `status` shown for non-current rows, cost shown when known) and consumes the command.
+
+## Filters and sorts
+
+| Filter | Selects |
+| --- | --- |
+| `current` | `isCurrent === true`. |
+| `active` | `!archived` (everything not archived). |
+| `paused` | `liveState === "paused"` (current process only). |
+| `archived` | archive sentinel present. |
+| `all` | every session (default). |
+
+| Sort | Order |
+| --- | --- |
+| `recent` | `modified` descending (default). |
+| `created` | `created` descending. |
+| `cost` | `cost` descending (`undefined` sorts last). |
+| `agents` | total agent count (`running+idle+parked`) descending. |
+
+## Rename
+
+`/session rename <name>` calls `sessionManager.setSessionName(name, "user")`, which updates the session **title** (display name) only. The durable session `id` (and thus the session file path) is unchanged — names are never identity. The `/sessions` overlay shows the title-derived display name but keys every action by durable `id`/`path`, never the display name.
+
+## Metrics shown vs. unavailable
+
+No metric is fabricated. Anything not knowable is rendered as `—`.
+
+| Metric | Availability |
+| --- | --- |
+| `liveState`, `agentCounts` | Current session only (in-process registry/gate). Other sessions: `—`. |
+| `model`, `profile` | Current session only (`AgentSession.model`, `settings.getActiveProfile()`). Other sessions: `—`. |
+| `cost`, `tokensIn`, `tokensOut` | Best-effort from the omp-stats DB (`getSessionSummaries`), any session. `—` when no rows exist or the DB read times out. |
+| `branch`, `dirty` (staged/unstaged/untracked) | Resolved from git at `info.cwd` when cheaply resolvable; `—` outside a repo or on error. |
+| Checkpoint count / latest label | Loaded live from the checkpoint service in the **details** pane (`WorkspaceCheckpointService.list`); `—` until loaded or when unsupported. |
+| RAM / CPU per session | Not available cross-process — never shown. |
+
+### Cross-process control is out of scope
+
+Only the current session is live in this process. You cannot pause, archive-with-effect, or kill subagents of a session owned by another process through this manager; archive and delete operate on persisted files the other process is not actively driving. `liveState`/`agentCounts`/`model`/`profile` are therefore populated for the current session alone, by design.
+
+## Stats DB reuse
+
+The manager does **not** maintain its own usage store. Per-session cost and token totals come from the shared omp-stats SQLite database via the new `getSessionSummaries()` query in `packages/stats` (`db.ts` + `aggregator.ts`), which groups `messages` by `session_file` (`requests`, `inputTokens`, `outputTokens`, `cacheRead`, `cacheWrite`, `cost`). The coding-agent already depends on `@oh-my-pi/omp-stats`; this query is the same backend the dashboard uses, reused rather than duplicated.
+
+## Details pane
+
+`D` opens a compact view of the selected session: identity (id/path/title), model/profile, agent counts, usage (cost/tokens when known), git runtime (branch/dirty when known), and recovery (checkpoint count + latest label, loaded from the checkpoint service). Pressing `C` there opens a read-only `CheckpointListComponent` scoped to that session — see [workspace-checkpoints.md](./workspace-checkpoints.md).

--- a/docs/tools/checkpoint.md
+++ b/docs/tools/checkpoint.md
@@ -86,3 +86,7 @@ You are in an active checkpoint. You MUST call rewind with your investigation fi
   - artifacts or blob-store contents
   - SQLite prompt-history rows from `packages/coding-agent/src/session/history-storage.ts`
   - auth or agent records from `packages/coding-agent/src/session/agent-storage.ts`
+
+## See also
+
+- The `checkpoint`/`rewind` *tools* documented here capture **conversation/session metadata only** and never touch git or the filesystem. For git-backed **workspace** snapshots and rollback (distinct commands `/checkpoint` and `/rollback`, gated by `checkpoints.enabled`), see [workspace-checkpoints.md](../workspace-checkpoints.md).

--- a/docs/workspace-checkpoints.md
+++ b/docs/workspace-checkpoints.md
@@ -1,0 +1,151 @@
+# workspace checkpoints (`/checkpoint`, `/rollback`)
+
+> Git-backed, content-addressed snapshots of your working tree plus a journaled rollback that always captures the pre-rollback state first. Snapshots live under `refs/omp/checkpoints/<sessionId>/<id>` and **never move HEAD or your branch**. Distinct from the conversation-context `checkpoint`/`rewind` *tools* (see [docs/tools/checkpoint.md](./tools/checkpoint.md)).
+
+This feature is **opt-in and off by default** (`checkpoints.enabled = false`). The `/sessions` manager surfaces per-session checkpoint counts and links into a read-only list — see [sessions-manager.md](./sessions-manager.md).
+
+## Source
+
+- Core service: `packages/coding-agent/src/checkpoints/service.ts` (`WorkspaceCheckpointService`).
+- Capture: `packages/coding-agent/src/checkpoints/capture.ts` (`captureWorkspaceTree`, `resolveWorkspaceIdentity`, `writeCheckpointRef`).
+- Storage + journal: `packages/coding-agent/src/checkpoints/store.ts` (refs, atomic metadata JSON, rollback journal, validity checks).
+- Rollback transaction: `packages/coding-agent/src/checkpoints/rollback.ts` (`runRollbackTransaction`).
+- Types: `packages/coding-agent/src/checkpoints/types.ts` (`CheckpointMeta`, `WorkspaceIdentity`, `RollbackJournal`, `CheckpointError`).
+- Post-rollback notification + auto triggers: `packages/coding-agent/src/checkpoints/notify.ts`, `auto-trigger.ts`.
+- Commands: `packages/coding-agent/src/slash-commands/builtin-workspace.ts` (`/checkpoint`, `/rollback`).
+- TUI list/selector: `packages/coding-agent/src/modes/components/checkpoint-list.ts`.
+- Git primitives: `packages/coding-agent/src/utils/git.ts` (temp-index tree capture, `commit-tree`, `ref.update`, `diff.treeStatus`, `restorePathsFromTree`, `cat-file` size probe).
+- Settings: `packages/coding-agent/src/config/settings-schema.ts` (`checkpoints.*`).
+
+## What a checkpoint includes
+
+A checkpoint is a **full snapshot of the working tree** — tracked files plus untracked, non-ignored files — captured through git plumbing (`git add -A` into a throwaway index, `write-tree`, `commit-tree -p <HEAD>`). Ignored files are never captured (the temp-index add respects `.gitignore`). HEAD, the current branch, and your index are never moved by a capture.
+
+Each checkpoint records a metadata JSON (`CheckpointMeta`) beside the session artifacts containing:
+
+- `id` — 10-char lowercase hex (5 random bytes); unique within the session.
+- `sessionId`, `createdAt`, optional `label` (manual captures).
+- `reason` — `manual` | `auto` | `pre-rollback` (`manual`/`pre-rollback` are retention-protected).
+- `identity` — `repoRoot`, `worktreePath`, `headSha` (at capture), `branch` (at capture). Used for validation.
+- `treeSha` — the captured working-tree tree object.
+- `headShaAtCapture` — the HEAD the snapshot was parented to.
+- `refName` — `refs/omp/checkpoints/<sessionId>/<id>`.
+- `bytesCaptured` — logical bytes the snapshot represents (sum of blob sizes in `treeSha`). Because content is shared with existing git objects, this is an upper bound on what the capture *could* have added, not a delta.
+- `skippedFiles` — paths excluded because they exceed `checkpoints.maxFileBytes`.
+
+## Capture mechanics
+
+1. `resolveWorkspaceIdentity` confirms `cwd` is inside a git repository (throws `CheckpointError` otherwise) and records `repoRoot`/`worktreePath`/`headSha`/`branch`.
+2. `findOversizeFiles` enumerates untracked + modified paths and `lstat`s each; any regular file larger than `checkpoints.maxFileBytes` is excluded. If more than 50 files exceed the limit, the capture **aborts** with a clear error rather than half-snapshotting.
+3. `captureWorkspaceTree` builds the tree (excluding the oversize pathspecs) and computes `bytesCaptured` from the tree's blobs.
+4. `writeCheckpointRef` creates the snapshot commit (`commit-tree`, parented to `headSha`) and points the ref at it, all under the repo lock. Author/committer identity is synthetic (`omp checkpoints <checkpoints@oh-my-pi.local>`), never your own.
+5. Metadata JSON is written **atomically (tmp file + rename) only after the ref exists**, so a crash between the two leaves an unreferenced ref (pruned later) and never metadata pointing at a missing snapshot.
+
+**Dedup:** if the newest checkpoint of the session already has the candidate `treeSha`, the existing checkpoint is returned unchanged — no new ref, no new metadata, no new bytes. Dedup is by content hash, not timestamp.
+
+## Storage, dedup, and retention
+
+- **Ref:** `refs/omp/checkpoints/<sessionId>/<id>` in the repository that owns the session's worktree. Linked worktrees share the object database and refs, so a snapshot is visible from any worktree of the same repo (subject to identity scoping below).
+- **Metadata:** atomic JSON beside the session artifacts (`<checkpointsRoot>/<sessionId>/<id>.json`).
+- **Content-addressed dedup:** identical tree state costs ~0 additional disk because git objects are shared; the only per-checkpoint cost is the ref and the small metadata file.
+- **Retention:** `pruneSession` keeps the newest checkpoints up to `checkpoints.retention.maxPerSession` (default 20). Oldest **automatic** (`reason: "auto"`) checkpoints are pruned beyond the cap; `manual` and `pre-rollback` checkpoints are **never** pruned. Pruning also deletes any orphan refs whose metadata is gone (e.g. left by a crash).
+- **Session-scoped:** refs and metadata are namespaced by `sessionId`; a checkpoint from another session is never listed or applied here.
+
+A checkpoint is **valid** iff its ref resolves **and** its metadata parses **and** its workspace identity matches the current checkout. `list` filters out entries that fail any of these, and `pendingRollback` surfaces an unfinished journal for startup recovery.
+
+## Commands
+
+### `/checkpoint`
+
+- `/checkpoint [<label>]` — **bare** creates a manual checkpoint. If the working tree already matches the latest checkpoint, it reports "already current (unchanged)" instead of minting a duplicate, and prints a confirmation line (`Checkpoint <id> created` + `label:`/`reason:`).
+- `/checkpoint list` — prints checkpoints newest-first (`id`, label-or-reason, age, bytes captured).
+- `/checkpoint show <id-prefix>` — prints full metadata (reason, label, created, bytes captured, skipped count, repo, worktree, head, tree).
+
+`/checkpoint` requires `checkpoints.enabled`; otherwise it prints the enable hint. In TUI mode the bare/list/show logic runs headless and prints to the status line.
+
+### `/rollback`
+
+- `/rollback` (no args, TUI) — opens the fullscreen `CheckpointListComponent` selector: list, inline inspect, and an inline confirm (`y`/`enter`) that performs the rollback.
+- `/rollback <id-prefix>` (TUI with an id) — resolves the checkpoint by exact or prefix match and shows a confirmation dialog (`Roll back to checkpoint <id>? A safety checkpoint of the current state is created first.`) before rolling back.
+- `/rollback <id-prefix>` (text/ACP) — resolves and rolls back on the typed command; there is no separate prompt, and it returns a clean failure message if the id matches no checkpoint or the rollback cannot complete.
+
+Outside a git repository, `/checkpoint` and `/rollback` return a clean error / no-match message rather than touching the filesystem (capture throws `CheckpointError`; a non-repo `/rollback` simply matches no checkpoint).
+
+## Rollback transaction
+
+`runRollbackTransaction` is a journaled, crash-recoverable sequence **PREPARE → SAFETY → APPLY → VERIFY → COMMIT**:
+
+1. **PREPARE** — recapture the current working tree into a base tree so the change set is computed against content-addressed truth, not status heuristics. If the base already equals the target tree, the transaction short-circuits (no safety capture, no writes) and returns success with zero restored/removed files.
+2. **SAFETY** — **always** taken when the workspace differs from the target: a `pre-rollback` checkpoint of the current state is captured first (reusing the ordinary create path, so it is deduped, retained, and metadata-complete). This means "undo the rollback" is itself just another rollback.
+3. **APPLY** — compute the minimal base→target diff (`git diff-tree --name-status`) and materialize it: restores land in both worktree and index; removals are `fs.rm`'d from the worktree and dropped from the index. HEAD/branch are never moved.
+4. **VERIFY** — recapture the workspace and require it to match the target tree. Size-guard exclusions are legitimately allowed to differ (they were never part of the snapshot). On mismatch the journal is left in `failed` state and the workspace is left at the safety state; the transaction reports the residual paths.
+5. **COMMIT** — the journal file is removed (its absence is the "no transaction in flight" signal).
+
+The index/worktree staging distinction is intentionally collapsed: restored paths are written to both, so a rolled-back workspace has no phantom staged diff against the content on disk.
+
+### File-behavior case matrix
+
+Diff direction is base (current) → target (checkpoint):
+
+| Situation | Result |
+| --- | --- |
+| File existed and was **modified** since the checkpoint | **Restored** to checkpoint content (worktree + index). |
+| File was **created after** the checkpoint (present now, absent in target) | **Removed** — but only the paths that provably appear in the base→target diff, and only after the pre-rollback safety checkpoint has captured them (so they remain recoverable). |
+| File was **deleted** since the checkpoint (absent now, present in target) | **Restored** from the checkpoint. |
+| File **unchanged** between base and target | Untouched (not in the diff). |
+| **Ignored** file (`.gitignore`) | **Never captured**, therefore never restored or removed. |
+| **Binary** file | Captured as a blob and restored verbatim like any other file (content-addressed). |
+| **Submodule** (gitlink) | Captured as a **gitlink only** — the recorded submodule commit pointer, not the submodule's contents. Restoring sets the gitlink SHA; submodule working trees are not walked. |
+
+## Crash recovery
+
+The rollback journal (`<checkpointsRoot>/<sessionId>/rollback-journal.json`) is rewritten atomically at each phase (`prepare` → `safety` → `apply` → `failed`). `RollbackPhase` is `"prepare" | "safety" | "apply" | "failed"`; an **absent** journal means no transaction is in flight. Because the journal is written before each mutating step and cleared only on COMMIT, a crash mid-transaction leaves either a recoverable journal or a completed safety checkpoint — never a half-applied workspace. On startup, `pendingRollback` exposes any unfinished journal so the process can surface a recoverable-state message to the user.
+
+## Post-rollback invalidation
+
+A successful rollback changes files behind the agent's back, so `emitWorkspaceRolledBack` (in `notify.ts`) appends a `workspace_rolled_back` custom session entry (carrying `checkpointId`, `sessionId`, `label`, `reason`, `treeSha`, `rolledBackAt`) and fans out to registered listeners. Each listener is failure-isolated: a throwing consumer is logged and skipped, so one stale-cache consumer cannot fail the others or the rollback. Registered invalidation (`auto-trigger.ts`) drops:
+
+- filesystem scan caches for the rolled-back worktree,
+- LSP diagnostics / restart for touched dirs (`notifyWorkspaceWatchedFiles`),
+- stale patch expectations.
+
+The transcript is preserved; the `workspace_rolled_back` entry tells a resumed session that the workspace changed.
+
+## Auto checkpoints (opt-in, defaults OFF)
+
+Triggers are conservative and never use prompt-wording heuristics:
+
+- **`checkpoints.auto.gitOperations`** — an internal `tool_call` pre-hook (subscribed via `subscribeInternalBeforeToolCall`) matches destructive git command shapes and captures a checkpoint before the tool runs:
+  - `git reset --hard`
+  - `git clean -f` / `-fd` / `-fdx` (force, recursive) — **never** `-n` (dry-run)
+  - `git restore .` / `git checkout .` (whole-tree `.` operand only)
+  - `git push --force` (whole `--force` token; `--force-with-lease` excluded)
+  - `git branch -D`
+  - `git rebase` (resolution continuations `--abort`/`--continue`/`--skip`/`--quit`/`--edit-todo` excluded)
+
+  Matchers require a literal `git` subcommand on the same simple command (no shell separators `;|&` bleed into it), so safe variants never fire.
+- **`checkpoints.auto.riskyEdits`** — a deterministic threshold seam in the patch/edit pipeline: `countEditFiles` counts distinct `*** (Add|Update|Delete) File:` markers in `edit` `apply_patch` input; crossing `RISKY_EDIT_FILE_THRESHOLD` (5 files) arms the trigger. `patch`/`hashline`/`sloppy` edit modes touch at most one file and never arm it.
+
+A debounce (`AUTO_CHECKPOINT_DEBOUNCE_MS = 60_000`) limits auto-checkpoints of the same session/workspace. Both triggers default to `false`.
+
+## Isolated-worktree behavior
+
+Linked worktrees of one repository share the object database and the `refs/omp/checkpoints/*` namespace, but metadata and **workspace identity** are scoped per session **and** per worktree. `identityMatches` compares `repoRoot` + `worktreePath` (HEAD and branch are deliberately excluded, so a checkpoint stays valid after you commit or switch branches — it just no longer matches HEAD). A checkpoint captured in worktree A is therefore **rejected** in worktree B: `rollback` returns `ok: false` with a clear "captured in <path>, not <path>" error, and `list` filters it out.
+
+## Archive / kill / delete and checkpoints
+
+- **Archive** (`/sessions` `A`) writes only the sidecar sentinel and **preserves all checkpoints** (refs + metadata untouched).
+- **Kill** (current-session subagent tombstone release) **preserves checkpoints**.
+- **Delete** (persisted session removal, confirmed twice) is the only path that cleans up a session's checkpoints: it calls `WorkspaceCheckpointService.deleteForSession`, which deletes every ref under the session's ref namespace and removes the metadata directory. This runs **only** through the confirmed delete flow — checkpoints are never silently dropped.
+
+## Settings
+
+| Key | Type | Default | Effect |
+| --- | --- | --- | --- |
+| `checkpoints.enabled` | boolean | `false` | Master switch for `/checkpoint` and `/rollback`. |
+| `checkpoints.auto.gitOperations` | boolean | `false` | Capture a checkpoint before destructive git commands. |
+| `checkpoints.auto.riskyEdits` | boolean | `false` | Capture a checkpoint before a multi-file/large edit application (≥5 files). |
+| `checkpoints.retention.maxPerSession` | number | `20` | Retention cap; oldest `auto` checkpoints pruned beyond it; `manual`/`pre-rollback` never pruned. |
+| `checkpoints.maxFileBytes` | number | `10485760` (10 MiB) | Per-file ceiling; larger files are excluded (recorded in `skippedFiles`); >50 oversize files aborts the capture. |
+
+All keys live under the `Workspace Checkpoints` UI group. The conversation-context `checkpoint.enabled` flag is a **separate** namespace and does not gate this feature.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+
+- Added the `/sessions` session manager: a fullscreen TUI to list, open, archive, pause, kill, delete, rename, and inspect sessions with best-effort per-session metrics (cost/tokens from the omp-stats DB, git branch/dirty state); text/ACP mode prints a top-20 table.
+- Added git-backed workspace checkpoints and rollback (`/checkpoint`, `/rollback`): content-addressed working-tree snapshots under `refs/omp/checkpoints/<sessionId>/<id>` with a journaled, always-reversible rollback transaction (a `pre-rollback` safety checkpoint is captured first). Off by default (`checkpoints.enabled`); auto-checkpoint triggers (`checkpoints.auto.*`) are also off by default.
 
 ## [18.0.5] - 2026-08-25
 

--- a/packages/coding-agent/DEVELOPMENT.md
+++ b/packages/coding-agent/DEVELOPMENT.md
@@ -91,6 +91,7 @@ Top-level entry modules: `cli.ts`, `main.ts`, `sdk.ts`, `index.ts` (SDK barrel),
 - [ttsr-injection-lifecycle.md](../../docs/ttsr-injection-lifecycle.md)
 - [non-compaction-retry-policy.md](../../docs/non-compaction-retry-policy.md)
 - [handoff-generation-pipeline.md](../../docs/handoff-generation-pipeline.md)
+- [sessions-manager.md](../../docs/sessions-manager.md) — `/sessions` manager: query, archive, pause, kill, delete, rename, metrics
 
 ### Configuration, models, providers, auth
 - [settings.md](../../docs/settings.md), [config-usage.md](../../docs/config-usage.md)
@@ -108,6 +109,7 @@ Top-level entry modules: `cli.ts`, `main.ts`, `sdk.ts`, `index.ts` (SDK barrel),
 - Output/artifacts: [blob-artifact-architecture.md](../../docs/blob-artifact-architecture.md)
 - Gating/approval: [approval-mode.md](../../docs/approval-mode.md), [resolve-tool-runtime.md](../../docs/resolve-tool-runtime.md)
 - Per-tool reference: [`docs/tools/`](../../docs/tools/) — `read`, `write`, `edit`, `ast-edit`, `ast-grep`, `grep`, `glob`, `bash`, `eval`, `hub`, `lsp`, `debug`, `task`, `web_search`, `browser`, `github`, `inspect_image`, `ask`, `todo`, `recall`, `retain`, `reflect`, `checkpoint`, `rewind`
+- Workspace checkpoints: [workspace-checkpoints.md](../../docs/workspace-checkpoints.md) — `/checkpoint` and `/rollback` (git-backed workspace snapshots)
 
 ### Execution backends
 - [bash-tool-runtime.md](../../docs/bash-tool-runtime.md), [tools/bash.md](../../docs/tools/bash.md)

--- a/packages/coding-agent/src/checkpoints/auto-trigger.test.ts
+++ b/packages/coding-agent/src/checkpoints/auto-trigger.test.ts
@@ -1,0 +1,337 @@
+import { afterEach, beforeEach, describe, expect, type Mock, test, vi } from "bun:test";
+import * as natives from "@oh-my-pi/pi-natives";
+import * as lspClient from "../lsp/client";
+import {
+	countEditFiles,
+	emitInternalBeforeToolCall,
+	matchDestructiveGit,
+	RISKY_EDIT_FILE_THRESHOLD,
+	registerAutoCheckpoints,
+} from "./auto-trigger";
+import { emitWorkspaceRolledBack, onWorkspaceRolledBack } from "./notify";
+import type { WorkspaceCheckpointService } from "./service";
+import type { CheckpointMeta } from "./types";
+
+// ── spy seams (namespace-import + spyOn; never vi.mock — it leaks across files) ─
+
+interface AutoTriggerTestMocks {
+	invalidateFsScanCache?: Mock<(path?: string | null) => void>;
+	notifyWorkspaceWatchedFiles?: Mock<
+		(cwd: string, changes: readonly lspClient.WatchedFileChange[], signal?: AbortSignal) => Promise<void>
+	>;
+	settingsStore?: Record<string, unknown>;
+	settingsInitialized?: boolean;
+}
+
+function mocks(): AutoTriggerTestMocks {
+	const g = globalThis as unknown as { __autoTriggerTest?: AutoTriggerTestMocks };
+	g.__autoTriggerTest ??= {};
+	return g.__autoTriggerTest;
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+const fakeMeta = {
+	id: "abc12",
+	sessionId: "s1",
+	createdAt: new Date().toISOString(),
+	reason: "pre-rollback",
+	identity: { repoRoot: "/wt", worktreePath: "/wt", headSha: "x", branch: "main" },
+	treeSha: "t",
+	headShaAtCapture: "x",
+	refName: "refs/omp/checkpoints/s1/abc12",
+	metaPath: "/wt/meta",
+	bytesCaptured: 0,
+	skippedFiles: [],
+} as unknown as CheckpointMeta;
+
+function makeFakeService(
+	overrides: { create?: () => Promise<CheckpointMeta>; latest?: () => Promise<CheckpointMeta | undefined> } = {},
+): WorkspaceCheckpointService {
+	return {
+		create: vi.fn(overrides.create ?? (async () => fakeMeta)),
+		latest: vi.fn(overrides.latest ?? (async () => undefined)),
+	} as unknown as WorkspaceCheckpointService;
+}
+
+const patchWithFiles = (n: number): string =>
+	`*** Begin Patch\n` +
+	Array.from({ length: n }, (_, i) => `*** Update File: file${i}.ts\n@@\n-x\n+y\n`).join("") +
+	`*** End Patch`;
+
+const unsubs: (() => void)[] = [];
+afterEach(() => {
+	for (const u of unsubs) u();
+	unsubs.length = 0;
+	vi.restoreAllMocks();
+});
+
+beforeEach(() => {
+	const store = mocks();
+	store.invalidateFsScanCache = vi.spyOn(natives, "invalidateFsScanCache").mockImplementation(async () => {});
+	store.notifyWorkspaceWatchedFiles = vi
+		.spyOn(lspClient, "notifyWorkspaceWatchedFiles")
+		.mockImplementation(async () => {});
+});
+
+// ── destructive git matcher ───────────────────────────────────────────────────
+
+describe("matchDestructiveGit", () => {
+	test("matches the documented destructive shapes", () => {
+		expect(matchDestructiveGit("git reset --hard")?.verb).toBe("reset");
+		expect(matchDestructiveGit("git reset --hard HEAD~1")?.verb).toBe("reset");
+		expect(matchDestructiveGit("git clean -f")?.verb).toBe("clean");
+		expect(matchDestructiveGit("git clean -fd")?.verb).toBe("clean");
+		expect(matchDestructiveGit("git clean -fdx")?.verb).toBe("clean");
+		expect(matchDestructiveGit("git restore .")?.verb).toBe("restore");
+		expect(matchDestructiveGit("git restore --staged .")?.verb).toBe("restore");
+		expect(matchDestructiveGit("git checkout -- .")?.verb).toBe("checkout");
+		expect(matchDestructiveGit("git checkout .")?.verb).toBe("checkout");
+		expect(matchDestructiveGit("git push --force")?.verb).toBe("push");
+		expect(matchDestructiveGit("git branch -D stale")?.verb).toBe("branch");
+		expect(matchDestructiveGit("git rebase main")?.verb).toBe("rebase");
+		expect(matchDestructiveGit("git rebase -i main")?.verb).toBe("rebase");
+	});
+
+	test("does NOT match safe or scoped variants (false-positive guards)", () => {
+		expect(matchDestructiveGit("git reset --soft HEAD")).toBeUndefined();
+		expect(matchDestructiveGit("git reset HEAD file.ts")).toBeUndefined();
+		expect(matchDestructiveGit("git clean -n")).toBeUndefined();
+		expect(matchDestructiveGit("git clean -nf")).toBeUndefined();
+		expect(matchDestructiveGit("git restore --staged file.ts")).toBeUndefined();
+		expect(matchDestructiveGit("git restore file.ts")).toBeUndefined();
+		expect(matchDestructiveGit("git checkout -- file.ts")).toBeUndefined();
+		expect(matchDestructiveGit("git checkout main")).toBeUndefined();
+		expect(matchDestructiveGit("git checkout a1b2c3d4")).toBeUndefined();
+		expect(matchDestructiveGit("git push --force-with-lease")).toBeUndefined();
+		expect(matchDestructiveGit("git push --force-with-lease origin main")).toBeUndefined();
+		expect(matchDestructiveGit("git branch -d stale")).toBeUndefined();
+		expect(matchDestructiveGit("git rebase --abort")).toBeUndefined();
+		expect(matchDestructiveGit("git rebase --continue")).toBeUndefined();
+		expect(matchDestructiveGit("rm -rf build")).toBeUndefined();
+		expect(matchDestructiveGit("")).toBeUndefined();
+	});
+});
+
+// ── risky-edit file counter ───────────────────────────────────────────────────
+
+describe("countEditFiles", () => {
+	test("counts apply_patch file markers, treats other modes as single-file", () => {
+		expect(countEditFiles("edit", { input: patchWithFiles(5) })).toBe(5);
+		expect(countEditFiles("edit", { input: patchWithFiles(1) })).toBe(1);
+		expect(countEditFiles("edit", { input: "no markers here" })).toBe(0);
+		expect(countEditFiles("edit", { path: "src/a.ts", edits: [{ op: "update" }] })).toBe(1);
+		expect(countEditFiles("read", { input: patchWithFiles(9) })).toBe(0);
+		expect(countEditFiles("edit", null)).toBe(0);
+	});
+});
+
+// ── gitOperations + riskyEdits triggers ───────────────────────────────────────
+
+describe("auto-checkpoint before-tool triggers", () => {
+	test("gitOperations captures a reason='auto' checkpoint BEFORE the command proceeds", async () => {
+		const order: string[] = [];
+		const service = makeFakeService({
+			create: async () => {
+				order.push("create");
+				return fakeMeta;
+			},
+		});
+		unsubs.push(
+			registerAutoCheckpoints({
+				getService: () => service,
+				flags: { enabled: () => true, gitOperations: () => true },
+			}),
+		);
+
+		await emitInternalBeforeToolCall({
+			toolName: "bash",
+			args: { command: "git reset --hard" },
+			cwd: "/wt",
+			sessionId: "s1",
+		});
+		order.push("proceed");
+
+		expect(order).toEqual(["create", "proceed"]);
+		expect(service.create).toHaveBeenCalledWith(expect.objectContaining({ reason: "auto", label: "before reset" }));
+	});
+
+	test("gates off produce zero service calls", async () => {
+		const service = makeFakeService();
+		unsubs.push(
+			registerAutoCheckpoints({
+				getService: () => service,
+				flags: { enabled: () => false, gitOperations: () => true },
+			}),
+		);
+		await emitInternalBeforeToolCall({
+			toolName: "bash",
+			args: { command: "git reset --hard" },
+			cwd: "/wt",
+			sessionId: "s1",
+		});
+		expect(service.create).not.toHaveBeenCalled();
+
+		unsubs.pop()?.();
+		unsubs.push(
+			registerAutoCheckpoints({
+				getService: () => service,
+				flags: { enabled: () => true, gitOperations: () => false },
+			}),
+		);
+		await emitInternalBeforeToolCall({
+			toolName: "bash",
+			args: { command: "git clean -f" },
+			cwd: "/wt",
+			sessionId: "s1",
+		});
+		expect(service.create).not.toHaveBeenCalled();
+	});
+
+	test("a capture failure does not throw out of the hook path", async () => {
+		const service = makeFakeService({
+			create: async () => {
+				throw new Error("disk full");
+			},
+		});
+		unsubs.push(
+			registerAutoCheckpoints({
+				getService: () => service,
+				flags: { enabled: () => true, gitOperations: () => true },
+			}),
+		);
+
+		await expect(
+			emitInternalBeforeToolCall({
+				toolName: "bash",
+				args: { command: "git reset --hard" },
+				cwd: "/wt",
+				sessionId: "s1",
+			}),
+		).resolves.toBeUndefined();
+		expect(service.create).toHaveBeenCalled();
+	});
+
+	test("debounce: a recent auto checkpoint suppresses a new capture; an old one does not", async () => {
+		const recent = makeFakeService({
+			latest: async () => ({ ...fakeMeta, reason: "auto", createdAt: new Date().toISOString() }),
+		});
+		unsubs.push(
+			registerAutoCheckpoints({
+				getSessionId: () => "s1",
+				getCwd: () => "/wt",
+				getService: () => recent,
+				flags: { enabled: () => true, gitOperations: () => true },
+			}),
+		);
+		await emitInternalBeforeToolCall({
+			toolName: "bash",
+			args: { command: "git reset --hard" },
+			cwd: "/wt",
+			sessionId: "s1",
+		});
+		expect(recent.create).not.toHaveBeenCalled();
+		unsubs.pop()?.();
+
+		const old = makeFakeService({
+			latest: async () => ({ ...fakeMeta, reason: "auto", createdAt: new Date(Date.now() - 120_000).toISOString() }),
+		});
+		unsubs.push(
+			registerAutoCheckpoints({ getService: () => old, flags: { enabled: () => true, gitOperations: () => true } }),
+		);
+		await emitInternalBeforeToolCall({
+			toolName: "bash",
+			args: { command: "git reset --hard" },
+			cwd: "/wt",
+			sessionId: "s1",
+		});
+		expect(old.create).toHaveBeenCalled();
+	});
+
+	test("riskyEdits fires at the boundary: 4 files no, 5 files yes", async () => {
+		const service = makeFakeService();
+		unsubs.push(
+			registerAutoCheckpoints({ getService: () => service, flags: { enabled: () => true, riskyEdits: () => true } }),
+		);
+
+		await emitInternalBeforeToolCall({
+			toolName: "edit",
+			args: { input: patchWithFiles(4) },
+			cwd: "/wt",
+			sessionId: "s1",
+		});
+		expect(service.create).not.toHaveBeenCalled();
+
+		await emitInternalBeforeToolCall({
+			toolName: "edit",
+			args: { input: patchWithFiles(5) },
+			cwd: "/wt",
+			sessionId: "s1",
+		});
+		expect(service.create).toHaveBeenCalledTimes(1);
+		expect(service.create).toHaveBeenCalledWith(
+			expect.objectContaining({ reason: "auto", label: `before ${RISKY_EDIT_FILE_THRESHOLD}-file edit` }),
+		);
+	});
+
+	test("riskyEdits does not fire without the flag, even for many files", async () => {
+		const service = makeFakeService();
+		unsubs.push(
+			registerAutoCheckpoints({
+				getService: () => service,
+				flags: { enabled: () => false, riskyEdits: () => true },
+			}),
+		);
+
+		await emitInternalBeforeToolCall({
+			toolName: "edit",
+			args: { input: patchWithFiles(8) },
+			cwd: "/wt",
+			sessionId: "s1",
+		});
+		expect(service.create).not.toHaveBeenCalled();
+	});
+});
+
+// ── post-rollback invalidation fan-out ────────────────────────────────────────
+
+describe("post-rollback cache/LSP invalidation", () => {
+	test("fans out to fs-cache invalidate and LSP refresh for the workspace root", () => {
+		unsubs.push(
+			registerAutoCheckpoints({
+				getSessionId: () => "s1",
+				getCwd: () => "/wt",
+				getService: () => makeFakeService(),
+			}),
+		);
+
+		emitWorkspaceRolledBack(undefined, fakeMeta);
+
+		expect(mocks().invalidateFsScanCache).toHaveBeenCalledWith("/wt");
+		expect(mocks().notifyWorkspaceWatchedFiles).toHaveBeenCalledWith(
+			"/wt",
+			expect.arrayContaining([{ filePath: "/wt", type: 2 }]),
+		);
+	});
+
+	test("a throwing listener is isolated and does not prevent other listeners", () => {
+		// Register the throwing listener BEFORE the auto-checkpoint one to prove
+		// order independence: notify isolates every listener.
+		unsubs.push(
+			onWorkspaceRolledBack(() => {
+				throw new Error("boom");
+			}),
+		);
+		unsubs.push(
+			registerAutoCheckpoints({
+				getSessionId: () => "s1",
+				getCwd: () => "/wt",
+				getService: () => makeFakeService(),
+			}),
+		);
+
+		expect(() => emitWorkspaceRolledBack(undefined, fakeMeta)).not.toThrow();
+		expect(mocks().invalidateFsScanCache).toHaveBeenCalledWith("/wt");
+		expect(mocks().notifyWorkspaceWatchedFiles).toHaveBeenCalled();
+	});
+});

--- a/packages/coding-agent/src/checkpoints/auto-trigger.ts
+++ b/packages/coding-agent/src/checkpoints/auto-trigger.ts
@@ -1,0 +1,349 @@
+/**
+ * Auto-checkpoint triggers and post-rollback cache/LSP invalidation.
+ *
+ * Three independent seams, all opt-in and inert unless `checkpoints.enabled`
+ * (and the relevant `checkpoints.auto.*` flag) is set at event time:
+ *
+ * 1. **gitOperations** — when the agent loop is about to run a bash tool whose
+ *    command is a destructive git operation (`reset --hard`, `clean -f`, a
+ *    whole-tree `restore`/`checkout`, `push --force`, `branch -D`, `rebase`),
+ *    capture a workspace checkpoint *before* the command mutates anything.
+ * 2. **riskyEdits** — when an edit application would touch at least
+ *    {@link RISKY_EDIT_FILE_THRESHOLD} files in one call (the `apply_patch`
+ *    multi-file seam), capture a checkpoint before applying.
+ * 3. **rollback invalidation** — when a rollback completes, drop stale
+ *    filesystem scan caches and refresh LSP for the affected workspace root.
+ *
+ * The before-tool triggers are driven by `emitInternalBeforeToolCall`, which the
+ * agent loop calls from `session/agent-session.ts` `#beforeToolCall` (the same
+ * dispatch point that emits the extension `tool_call` event) — a first-class
+ * internal subscriber list, so extensions are never affected. A checkpoint is
+ * always created *before* the tool proceeds; a failed capture is logged and
+ * swallowed so it can never become a foot-gun that blocks the user's command.
+ */
+
+import { invalidateFsScanCache } from "@oh-my-pi/pi-natives";
+import { logger, toError } from "@oh-my-pi/pi-utils";
+import { isSettingsInitialized, settings } from "../config/settings";
+import { FileChangeType, notifyWorkspaceWatchedFiles } from "../lsp/client";
+import { onWorkspaceRolledBack, type WorkspaceRolledBackEvent } from "./notify";
+import { WorkspaceCheckpointService } from "./service";
+
+/** Files touched by a single edit application that arms the risky-edits trigger. */
+export const RISKY_EDIT_FILE_THRESHOLD = 5;
+
+/** Minimum gap between two automatic checkpoints of the same session/workspace. */
+export const AUTO_CHECKPOINT_DEBOUNCE_MS = 60_000;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Destructive git command matching
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface DestructiveGitMatch {
+	/** Human-readable verb used to label the checkpoint, e.g. `"reset"`. */
+	readonly verb: string;
+}
+
+/**
+ * Matchers run in priority order; the first hit wins. Every matcher requires a
+ * literal `git` subcommand and restricts the destructive subcommand to the same
+ * simple command (no shell separators `;|&` cross into it). Dry-run and scoped
+ * variants are deliberately excluded so the trigger never fires on safe ops.
+ */
+const DESTRUCTIVE_GIT_MATCHERS: readonly { verb: string; test: (command: string) => boolean }[] = [
+	{
+		verb: "reset",
+		test: command => /\bgit\b[^;|&]*\breset\b[^;|&]*--hard\b/.test(command),
+	},
+	{
+		verb: "clean",
+		test: isDestructiveClean,
+	},
+	{
+		verb: "restore",
+		test: command => /\bgit\b[^;|&]*\brestore\b/.test(command) && hasWholeTreeDot(command),
+	},
+	{
+		verb: "checkout",
+		test: command => /\bgit\b[^;|&]*\bcheckout\b/.test(command) && hasWholeTreeDot(command),
+	},
+	{
+		// `--force-with-lease` is excluded: `--force` must be a whole flag token.
+		verb: "push",
+		test: command => /\bgit\b[^;|&]*\bpush\b[^;|&]*\s--force(?=\s|$)/.test(command),
+	},
+	{
+		verb: "branch",
+		test: command => /\bgit\b[^;|&]*\bbranch\b[^;|&]*\s-D\b/.test(command),
+	},
+	{
+		// Resolution continuations (`--abort`/`--continue`/…) are the safe way out
+		// of an in-flight rebase and must not capture.
+		verb: "rebase",
+		test: command =>
+			/\bgit\b[^;|&]*\brebase\b/.test(command) && !/--(?:abort|continue|skip|quit|edit-todo)\b/.test(command),
+	},
+];
+
+/** True when `command` is a destructive git operation; returns the matched verb. */
+export function matchDestructiveGit(command: string): DestructiveGitMatch | undefined {
+	if (typeof command !== "string" || command.length === 0) return undefined;
+	if (!/\bgit\b/i.test(command)) return undefined;
+	for (const matcher of DESTRUCTIVE_GIT_MATCHERS) {
+		if (matcher.test(command)) return { verb: matcher.verb };
+	}
+	return undefined;
+}
+
+/** `git clean -f`/`-fd`/`-fdx` (force, recursive) but never `-n` (dry-run). */
+function isDestructiveClean(command: string): boolean {
+	if (/\bgit\b[^;|&]*\bclean\b/.test(command) === false) return false;
+	// `-f`, `-fd`, `-fdx`, `-fxd` (force), not `-n` (dry-run). `-nf` is dry-run.
+	const hasForce = /(?:^|\s)-f[dx]*(?=\s|$)/.test(command);
+	if (!hasForce) return false;
+	if (/(?:^|\s)-n\b/.test(command)) return false;
+	return true;
+}
+
+/** True when the command's operand is the whole tree (a bare `.` path). */
+function hasWholeTreeDot(command: string): boolean {
+	// Matches ` .`, ` -- .`, ` .;`, ` .&`, ` .|` — a `.` path argument, but not
+	// `..`, `./foo`, or `.bashrc` (those are parent dirs / scoped paths).
+	return /(?:^|\s)(?:--\s+)?\.(?=\s|$)/.test(command);
+}
+
+/**
+ * Number of distinct files a single edit application will touch. The `apply_patch`
+ * mode is the only genuine multi-file seam (its `*** (Add|Update|Delete) File:`
+ * markers), so that is what arms the risky-edits trigger; `patch`/`hashline`/
+ * `sloppy` modes address at most one file and never arm it.
+ */
+export function countEditFiles(toolName: string, args: unknown): number {
+	if (toolName !== "edit") return 0;
+	if (args === null || typeof args !== "object") return 0;
+	const record = args as Record<string, unknown>;
+	const input = typeof record.input === "string" ? record.input : undefined;
+	if (input !== undefined) {
+		const markers = input.match(/^\*\*\* (?:Add|Update|Delete) File:/gm);
+		return markers ? markers.length : 0;
+	}
+	if (typeof record.path === "string") return 1;
+	return 0;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Internal before-tool-call subscriber list
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface InternalBeforeToolEvent {
+	readonly toolName: string;
+	readonly args: unknown;
+	readonly cwd: string;
+	readonly sessionId: string;
+	readonly signal?: AbortSignal;
+}
+
+type InternalBeforeToolListener = (event: InternalBeforeToolEvent) => void | Promise<void>;
+
+const internalBeforeToolListeners = new Set<InternalBeforeToolListener>();
+
+/** Subscribe to every before-tool-call event. Returns the unsubscribe handle. */
+export function subscribeInternalBeforeToolCall(fn: InternalBeforeToolListener): () => void {
+	internalBeforeToolListeners.add(fn);
+	return () => {
+		internalBeforeToolListeners.delete(fn);
+	};
+}
+
+/**
+ * Fan out a before-tool-call event to internal subscribers. A throwing listener
+ * is logged and skipped so one broken consumer cannot block the others or the
+ * tool that is about to run.
+ */
+export async function emitInternalBeforeToolCall(event: InternalBeforeToolEvent): Promise<void> {
+	for (const fn of [...internalBeforeToolListeners]) {
+		try {
+			await fn(event);
+		} catch (error) {
+			logger.debug("auto-checkpoint before-tool listener failed", { error: toError(error).message });
+		}
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+/**
+ * Wire the auto-checkpoint triggers and rollback invalidation. Returns an
+ * unsubscribe handle that detaches both. Registration is unconditional; every
+ * gate is read from settings at event time, so with defaults this is inert.
+ *
+ * The subscription is process-wide and idempotent: repeated calls (one per
+ * session construction) return the same handle, so a destructive op never
+ * captures more than one checkpoint.
+ */
+
+/** The three opt-in gates, resolved at event time. Defaults consult live settings. */
+export interface AutoCheckpointFlags {
+	enabled(): boolean;
+	gitOperations(): boolean;
+	riskyEdits(): boolean;
+}
+
+export interface RegisterAutoCheckpointsDeps {
+	/** Fallbacks used when an event omits session/cwd context. */
+	getSessionId?: () => string;
+	getCwd?: () => string;
+	getService?: () => WorkspaceCheckpointService;
+	/** Gate overrides; omit to read `checkpoints.*` from live settings. */
+	flags?: Partial<AutoCheckpointFlags>;
+}
+
+function readFlag(key: "checkpoints.auto.gitOperations" | "checkpoints.auto.riskyEdits"): boolean {
+	if (!isSettingsInitialized()) return false;
+	return Boolean(settings.get(key));
+}
+
+function defaultFlags(): AutoCheckpointFlags {
+	return {
+		// Inert while settings are uninitialized (early boot).
+		enabled: () => isSettingsInitialized() && Boolean(settings.get("checkpoints.enabled")),
+		gitOperations: () => readFlag("checkpoints.auto.gitOperations"),
+		riskyEdits: () => readFlag("checkpoints.auto.riskyEdits"),
+	};
+}
+
+let activeRegistration: (() => void) | null = null;
+
+/**
+ * Wire the auto-checkpoint triggers and rollback invalidation. Returns an
+ * unsubscribe handle that detaches both. Registration is unconditional; gates
+ * resolve at event time (settings by default), so this is inert until enabled.
+ *
+ * Last-wins: a newer registration (newest session) supersedes an older one.
+ */
+export function registerAutoCheckpoints(deps: RegisterAutoCheckpointsDeps): () => void {
+	const getService = deps.getService ?? (() => WorkspaceCheckpointService.global());
+	if (activeRegistration) activeRegistration();
+	const beforeToolUnsub = subscribeInternalBeforeToolCall(event => handleBeforeTool(event, deps, getService));
+	const rollbackUnsub = onWorkspaceRolledBack(event => handleWorkspaceRolledBack(event));
+	const unsubscribe = () => {
+		beforeToolUnsub();
+		rollbackUnsub();
+		if (activeRegistration === unsubscribe) activeRegistration = null;
+	};
+	activeRegistration = unsubscribe;
+	return unsubscribe;
+}
+
+async function handleBeforeTool(
+	event: InternalBeforeToolEvent,
+	deps: RegisterAutoCheckpointsDeps,
+	getService: () => WorkspaceCheckpointService,
+): Promise<void> {
+	const flags = { ...defaultFlags(), ...deps.flags };
+	// Inert when the feature is off (default readers also require initialized settings).
+	if (!flags.enabled()) return;
+	const cwd = event.cwd || deps.getCwd?.() || process.cwd();
+	const sessionId = event.sessionId || deps.getSessionId?.() || "";
+	const service = getService();
+
+	try {
+		if (flags.gitOperations() && event.toolName === "bash") {
+			const command = extractStringArg(event.args, "command") ?? extractStringArg(event.args, "input");
+			const match = command ? matchDestructiveGit(command) : undefined;
+			if (match) {
+				await createAutoCheckpoint(service, sessionId, cwd, `before ${match.verb}`, "git", event.signal);
+				return;
+			}
+		}
+		if (flags.riskyEdits() && event.toolName === "edit") {
+			const fileCount = countEditFiles(event.toolName, event.args);
+			if (fileCount >= RISKY_EDIT_FILE_THRESHOLD) {
+				await createAutoCheckpoint(service, sessionId, cwd, `before ${fileCount}-file edit`, "edit", event.signal);
+			}
+		}
+	} catch (error) {
+		// Unexpected logic error must never escape the hook path.
+		logger.warn("auto-checkpoint trigger failed", { toolName: event.toolName, error: toError(error).message });
+	}
+}
+
+async function createAutoCheckpoint(
+	service: WorkspaceCheckpointService,
+	sessionId: string,
+	cwd: string,
+	label: string,
+	kind: string,
+	signal?: AbortSignal,
+): Promise<void> {
+	try {
+		// Cheap early-out: skip when an automatic checkpoint already landed very
+		// recently. `service.create` additionally dedups identical working trees,
+		// so this only trims redundant captures during rapid repeats.
+		const latest = await service.latest(sessionId, cwd);
+		if (
+			latest &&
+			latest.reason === "auto" &&
+			Number.isFinite(Date.parse(latest.createdAt)) &&
+			Date.now() - Date.parse(latest.createdAt) < AUTO_CHECKPOINT_DEBOUNCE_MS
+		) {
+			return;
+		}
+		await service.create({ sessionId, cwd, reason: "auto", label, signal });
+	} catch (error) {
+		// Best-effort safety net: a capture failure must not block the command.
+		logger.warn("auto-checkpoint capture failed", { kind, label, error: toError(error).message });
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Post-rollback invalidation
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Drop stale caches for the workspace that was just rolled back. Each step is
+ * failure-isolated; `notify.onWorkspaceRolledBack` additionally isolates this
+ * listener from any other registered listener.
+ */
+export function invalidateWorkspaceAfterRollback(worktreePath: string): void {
+	// (a) Filesystem scan cache: `invalidateFsScanCache(path)` removes every cached
+	// scan whose root is a prefix of `worktreePath` (see docs/fs-scan-cache-
+	// architecture.md). The whole workspace root is the broadest safe invalidation.
+	try {
+		invalidateFsScanCache(worktreePath);
+	} catch (error) {
+		logger.debug("fs scan cache invalidation after rollback failed", {
+			worktreePath,
+			error: toError(error).message,
+		});
+	}
+
+	// (b) LSP: a `didChangeWatchedFiles` refresh keyed by workspace root is the
+	// available affordance (no full restart-by-cwd API exists). Clients for the
+	// root are filtered inside `notifyWorkspaceWatchedFiles`; if none are active
+	// the call is a no-op.
+	void notifyWorkspaceWatchedFiles(worktreePath, [{ filePath: worktreePath, type: FileChangeType.Changed }]).catch(
+		(error: unknown) => {
+			logger.debug("LSP refresh after rollback failed", { worktreePath, error: toError(error).message });
+		},
+	);
+
+	// (c) File-read caches: the read tool keeps no cross-call content cache — only
+	// a per-instance repeat-read counter (see tools/read.ts `[kRepeatReadTracker]`),
+	// which is not keyed by mtime and does not survive the rolled-back process.
+	// There is therefore nothing to invalidate; a no-op here is correct, not an
+	// oversight.
+}
+
+function handleWorkspaceRolledBack(event: WorkspaceRolledBackEvent): void {
+	invalidateWorkspaceAfterRollback(event.checkpoint.identity.worktreePath);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+function extractStringArg(args: unknown, key: string): string | undefined {
+	if (args === null || typeof args !== "object") return undefined;
+	const value = (args as Record<string, unknown>)[key];
+	return typeof value === "string" ? value : undefined;
+}

--- a/packages/coding-agent/src/checkpoints/capture.ts
+++ b/packages/coding-agent/src/checkpoints/capture.ts
@@ -1,0 +1,149 @@
+/**
+ * Workspace snapshot capture.
+ *
+ * Capture never mutates the repository the user is working in beyond adding
+ * objects and one ref: staging happens in a throwaway index, the snapshot commit
+ * is created with `commit-tree`, and HEAD/branch/index stay exactly where they
+ * were. Content addressing means two identical workspaces share every object, so
+ * repeated checkpoints of an unchanged tree cost nothing on disk.
+ */
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import * as git from "../utils/git";
+import { CheckpointError, type WorkspaceIdentity } from "./types";
+
+/** Author/committer identity stamped on snapshot commits (never the user's). */
+const CHECKPOINT_AUTHOR: git.CommitAuthor = { name: "omp checkpoints", email: "checkpoints@oh-my-pi.local" };
+
+/**
+ * Oversize files are excluded one pathspec at a time, so a workspace full of
+ * huge files would otherwise produce an unbounded `git add` invocation. Past
+ * this many, the capture refuses instead of half-snapshotting the workspace.
+ */
+const MAX_OVERSIZE_SKIPS = 50;
+
+export interface CaptureOutcome {
+	readonly treeSha: string;
+	readonly bytesCaptured: number;
+	readonly skippedFiles: string[];
+}
+
+/**
+ * Resolve the workspace identity for `cwd`.
+ * @throws CheckpointError when `cwd` is not inside a git repository.
+ */
+export async function resolveWorkspaceIdentity(cwd: string, signal?: AbortSignal): Promise<WorkspaceIdentity> {
+	const repository = await git.repo.resolve(cwd);
+	if (!repository) throw new CheckpointError(`not a git repository: ${cwd}`);
+	const worktreePath = repository.repoRoot;
+	const [primaryRoot, headSha, branch] = await Promise.all([
+		git.repo.primaryRoot(worktreePath, signal),
+		git.head.sha(worktreePath, signal),
+		git.branch.current(worktreePath, signal),
+	]);
+	return { repoRoot: primaryRoot ?? worktreePath, worktreePath, headSha, branch };
+}
+
+/**
+ * Paths whose working-tree content is not already in the object database:
+ * untracked files plus modified/staged tracked files. These are the only paths a
+ * capture can add bytes for, so they are the only ones the size guard needs to
+ * probe.
+ */
+function parseStatusPaths(raw: string): string[] {
+	const fields = raw.split("\0");
+	const paths: string[] = [];
+	for (let index = 0; index < fields.length; index += 1) {
+		const record = fields[index];
+		// "XY <path>" — shortest possible record is two status chars, a space, one path char.
+		if (!record || record.length < 4) continue;
+		paths.push(record.slice(3));
+		// Rename/copy records carry the origin path in the following field.
+		if (record[0] === "R" || record[0] === "C") index += 1;
+	}
+	return paths;
+}
+
+/**
+ * Files above `maxFileBytes` that a capture must leave out. Symlinks and
+ * directories are never oversize (a symlink's "size" is its target string), and
+ * a path that vanished between status and stat contributes nothing.
+ */
+export async function findOversizeFiles(
+	worktreeRoot: string,
+	maxFileBytes: number,
+	signal?: AbortSignal,
+): Promise<string[]> {
+	const raw = await git.status(worktreeRoot, { z: true, untrackedFiles: "all", signal });
+	const candidates = parseStatusPaths(raw);
+	const oversize: string[] = [];
+	await Promise.all(
+		candidates.map(async candidate => {
+			try {
+				const stat = await fs.lstat(path.join(worktreeRoot, candidate));
+				if (stat.isFile() && stat.size > maxFileBytes) oversize.push(candidate);
+			} catch {
+				// Deleted or unreadable between status and stat: nothing to exclude.
+			}
+		}),
+	);
+	return oversize.sort();
+}
+
+/**
+ * Snapshot the working tree into a tree object and account for its size.
+ *
+ * @throws CheckpointError when more files than {@link MAX_OVERSIZE_SKIPS} would
+ * have to be excluded — silently dropping that many files would make the
+ * checkpoint a misleading restore point.
+ */
+export async function captureWorkspaceTree(
+	worktreeRoot: string,
+	options: { maxFileBytes: number; signal?: AbortSignal },
+): Promise<CaptureOutcome> {
+	const skippedFiles = await findOversizeFiles(worktreeRoot, options.maxFileBytes, options.signal);
+	if (skippedFiles.length > MAX_OVERSIZE_SKIPS) {
+		throw new CheckpointError(
+			`${skippedFiles.length} files exceed the ${options.maxFileBytes}-byte checkpoint limit (max ${MAX_OVERSIZE_SKIPS}); raise checkpoints.maxFileBytes or ignore those paths`,
+		);
+	}
+	const treeSha = await git.captureWorktreeTree(worktreeRoot, {
+		excludePaths: skippedFiles,
+		signal: options.signal,
+	});
+	const blobs = await git.ls.treeBlobs(worktreeRoot, treeSha, options.signal);
+	let bytesCaptured = 0;
+	for (const blob of blobs) bytesCaptured += blob.size;
+	return { treeSha, bytesCaptured, skippedFiles };
+}
+
+/**
+ * Create the snapshot commit and point `refName` at it. Object writes and the
+ * ref update share the repo lock so a concurrent git operation in the same
+ * process cannot collide on git's ref locks.
+ */
+export async function writeCheckpointRef(
+	worktreeRoot: string,
+	options: {
+		refName: string;
+		treeSha: string;
+		parentSha: string | null;
+		message: string;
+		signal?: AbortSignal;
+	},
+): Promise<string> {
+	return git.withRepoLock(
+		worktreeRoot,
+		async () => {
+			const commitSha = await git.commitTree(worktreeRoot, options.treeSha, {
+				author: CHECKPOINT_AUTHOR,
+				message: options.message,
+				parents: options.parentSha ? [options.parentSha] : [],
+				signal: options.signal,
+			});
+			await git.ref.update(worktreeRoot, options.refName, commitSha, options.signal);
+			return commitSha;
+		},
+		options.signal,
+	);
+}

--- a/packages/coding-agent/src/checkpoints/index.ts
+++ b/packages/coding-agent/src/checkpoints/index.ts
@@ -1,0 +1,15 @@
+/**
+ * Git-backed workspace checkpoints and rollback.
+ *
+ * `WorkspaceCheckpointService` is the entry point: `create` snapshots the
+ * working tree into `refs/omp/checkpoints/<sessionId>/<id>` plus a metadata file
+ * beside the session's artifacts, and `rollback` restores one of those snapshots
+ * through a journaled transaction that always captures the pre-rollback state
+ * first. Neither ever moves HEAD or the current branch.
+ */
+export * from "./capture";
+export * from "./notify";
+export * from "./rollback";
+export * from "./service";
+export * from "./store";
+export * from "./types";

--- a/packages/coding-agent/src/checkpoints/notify.ts
+++ b/packages/coding-agent/src/checkpoints/notify.ts
@@ -1,0 +1,63 @@
+/**
+ * Post-rollback notification seam.
+ *
+ * A rollback changes files behind the agent's back: filesystem scan caches, LSP
+ * diagnostics, and pending patch expectations all go stale. Consumers register
+ * here instead of the checkpoints module reaching into them, so this file has no
+ * dependency on the session, LSP, or tool layers.
+ */
+import { logger, toError } from "@oh-my-pi/pi-utils";
+import type { CheckpointMeta, WorkspaceRollbackSessionSurface } from "./types";
+
+/** Session entry type appended for a rollback, so a resumed transcript shows the workspace changed. */
+export const WORKSPACE_ROLLED_BACK_ENTRY = "workspace_rolled_back";
+
+export interface WorkspaceRolledBackEvent {
+	readonly checkpoint: CheckpointMeta;
+	readonly rolledBackAt: string;
+}
+
+export type WorkspaceRolledBackListener = (event: WorkspaceRolledBackEvent) => void;
+
+const listeners = new Set<WorkspaceRolledBackListener>();
+
+/** Subscribe to workspace rollbacks. Returns the unsubscribe handle. */
+export function onWorkspaceRolledBack(listener: WorkspaceRolledBackListener): () => void {
+	listeners.add(listener);
+	return () => {
+		listeners.delete(listener);
+	};
+}
+
+/**
+ * Announce a completed rollback: append a custom entry to `session` when one was
+ * provided, then fan out to registered listeners. A throwing listener is logged
+ * and skipped — one stale-cache consumer must not abort the others or fail the
+ * rollback that already succeeded.
+ */
+export function emitWorkspaceRolledBack(
+	session: WorkspaceRollbackSessionSurface | undefined,
+	meta: CheckpointMeta,
+): void {
+	const rolledBackAt = new Date().toISOString();
+	if (session) {
+		session.appendCustomEntry(WORKSPACE_ROLLED_BACK_ENTRY, {
+			checkpointId: meta.id,
+			sessionId: meta.sessionId,
+			label: meta.label,
+			reason: meta.reason,
+			treeSha: meta.treeSha,
+			rolledBackAt,
+		});
+	}
+	for (const listener of listeners) {
+		try {
+			listener({ checkpoint: meta, rolledBackAt });
+		} catch (error) {
+			logger.warn("Workspace rollback listener failed", {
+				checkpointId: meta.id,
+				error: toError(error).message,
+			});
+		}
+	}
+}

--- a/packages/coding-agent/src/checkpoints/rollback.ts
+++ b/packages/coding-agent/src/checkpoints/rollback.ts
@@ -1,0 +1,200 @@
+/**
+ * Rollback transaction: PREPARE → SAFETY → APPLY → VERIFY → COMMIT.
+ *
+ * Guarantees:
+ * - HEAD and the current branch never move. A rollback only rewrites files (and
+ *   the matching index entries); commit history is untouched.
+ * - Nothing is overwritten before the current workspace has been captured. The
+ *   SAFETY phase snapshots the pre-rollback state whenever it differs from the
+ *   target, so "undo the rollback" is just another rollback.
+ * - The change set is minimal: only paths that differ between the current
+ *   snapshot and the target tree are restored or removed.
+ * - VERIFY recaptures the workspace and requires it to match the target.
+ *   Anything left over fails the transaction with the journal preserved, so a
+ *   failure or crash is recoverable and visible instead of silent.
+ * - Paths excluded by the size guard are never touched and never verified: they
+ *   were never part of the snapshot.
+ *
+ * The index/worktree staging distinction is intentionally collapsed: restored
+ * paths land in both, so a rolled-back workspace has no phantom staged diff
+ * against the content on disk.
+ */
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { toError } from "@oh-my-pi/pi-utils";
+import * as git from "../utils/git";
+import { captureWorkspaceTree } from "./capture";
+import { clearJournal, writeJournal } from "./store";
+import type { CheckpointMeta, RollbackJournal, RollbackPhase, RollbackResult, WorkspaceIdentity } from "./types";
+
+export interface ApplyPlan {
+	/** Paths present in the target tree whose current content differs or is missing. */
+	readonly restore: string[];
+	/** Paths present now but absent from the target tree. */
+	readonly remove: string[];
+}
+
+/**
+ * Split a base→target tree diff into restores and removals, dropping paths the
+ * size guard excluded from the snapshot on either side.
+ */
+export function buildApplyPlan(entries: readonly git.TreeDiffEntry[], skippedFiles: readonly string[]): ApplyPlan {
+	const skipped = new Set(skippedFiles);
+	const restore: string[] = [];
+	const remove: string[] = [];
+	for (const entry of entries) {
+		if (skipped.has(entry.path)) continue;
+		// Diff direction is base → target, so "D" means the target lacks the path.
+		if (entry.status === "D") remove.push(entry.path);
+		else restore.push(entry.path);
+	}
+	return { restore, remove };
+}
+
+/**
+ * Materialize the target content. Removals are unlinked from the working tree
+ * and then dropped from the index, which handles tracked and untracked
+ * creations with one code path; restores come out of the target tree into
+ * worktree + index.
+ */
+async function applyTarget(
+	worktreeRoot: string,
+	targetTreeSha: string,
+	plan: ApplyPlan,
+	signal?: AbortSignal,
+): Promise<void> {
+	await git.withRepoLock(
+		worktreeRoot,
+		async () => {
+			for (const relative of plan.remove) {
+				await fs.rm(path.join(worktreeRoot, relative), { force: true, recursive: true });
+			}
+			if (plan.remove.length > 0) await git.stage.removeCached(worktreeRoot, plan.remove, signal);
+			if (plan.restore.length > 0) {
+				await git.restorePathsFromTree(worktreeRoot, targetTreeSha, plan.restore, { signal });
+			}
+		},
+		signal,
+	);
+}
+
+/**
+ * Recapture the workspace and compare it with the target tree. Tree equality is
+ * the fast path; when the trees differ the residual per-path diff decides,
+ * because size-guard exclusions legitimately make the recaptured tree differ
+ * from the target on exactly those paths.
+ */
+export async function verifyRollback(
+	worktreeRoot: string,
+	targetTreeSha: string,
+	skippedFiles: readonly string[],
+	signal?: AbortSignal,
+): Promise<{ ok: boolean; residual: string[] }> {
+	const verifyTree = await git.captureWorktreeTree(worktreeRoot, { excludePaths: skippedFiles, signal });
+	if (verifyTree === targetTreeSha) return { ok: true, residual: [] };
+	const entries = await git.diff.treeStatus(worktreeRoot, verifyTree, targetTreeSha, { signal });
+	const skipped = new Set(skippedFiles);
+	const residual = entries.filter(entry => !skipped.has(entry.path)).map(entry => entry.path);
+	return { ok: residual.length === 0, residual };
+}
+
+export interface RollbackRequest {
+	/** Checkpoint metadata root for the session. */
+	readonly root: string;
+	readonly sessionId: string;
+	readonly identity: WorkspaceIdentity;
+	readonly target: CheckpointMeta;
+	readonly maxFileBytes: number;
+	/**
+	 * Capture the pre-rollback workspace. Injected by the service so the
+	 * transaction reuses the ordinary create path (dedup, retention, metadata)
+	 * without this module depending on it.
+	 */
+	readonly captureSafety: () => Promise<CheckpointMeta>;
+	readonly signal?: AbortSignal;
+}
+
+/**
+ * Run the full transaction. Returns `ok: false` with the journal left on disk
+ * for every recoverable failure (verification mismatch, abort, git error);
+ * throws only for programming errors that cannot be attributed to the workspace.
+ */
+export async function runRollbackTransaction(request: RollbackRequest): Promise<RollbackResult> {
+	const { root, sessionId, identity, target, signal } = request;
+	const worktreeRoot = identity.worktreePath;
+
+	// PREPARE: snapshot the current state so the change set is computed against
+	// content-addressed truth rather than status heuristics.
+	const base = await captureWorkspaceTree(worktreeRoot, { maxFileBytes: request.maxFileBytes, signal });
+	if (base.treeSha === target.treeSha) {
+		// Workspace already matches the checkpoint: no safety capture, no writes.
+		await clearJournal(root, sessionId);
+		return { ok: true, restoredFiles: 0, removedFiles: 0 };
+	}
+
+	const now = new Date().toISOString();
+	let journal: RollbackJournal = {
+		sessionId,
+		phase: "prepare",
+		startedAt: now,
+		updatedAt: now,
+		identity,
+		targetId: target.id,
+		targetTreeSha: target.treeSha,
+		baseTreeSha: base.treeSha,
+		skippedFiles: base.skippedFiles,
+	};
+	await writeJournal(root, sessionId, journal);
+
+	const advance = async (phase: RollbackPhase, patch: Partial<RollbackJournal> = {}): Promise<void> => {
+		journal = { ...journal, ...patch, phase, updatedAt: new Date().toISOString() };
+		await writeJournal(root, sessionId, journal);
+	};
+
+	let safetyCheckpoint: CheckpointMeta | undefined;
+	let plan: ApplyPlan = { restore: [], remove: [] };
+	try {
+		// SAFETY: always taken when the workspace differs from the target.
+		safetyCheckpoint = await request.captureSafety();
+		await advance("safety", { safetyCheckpointId: safetyCheckpoint.id });
+
+		// APPLY: minimal change set, worktree + index, HEAD untouched.
+		const entries = await git.diff.treeStatus(worktreeRoot, base.treeSha, target.treeSha, { signal });
+		plan = buildApplyPlan(entries, base.skippedFiles);
+		await applyTarget(worktreeRoot, target.treeSha, plan, signal);
+		await advance("apply");
+
+		// VERIFY
+		const verified = await verifyRollback(worktreeRoot, target.treeSha, base.skippedFiles, signal);
+		if (!verified.ok) {
+			const detail = `workspace does not match checkpoint ${target.id} after apply (${verified.residual.length} path(s) differ: ${verified.residual.slice(0, 5).join(", ")})`;
+			await advance("failed", { error: detail });
+			return {
+				ok: false,
+				safetyCheckpoint,
+				restoredFiles: plan.restore.length,
+				removedFiles: plan.remove.length,
+				error: detail,
+			};
+		}
+	} catch (error) {
+		const message = toError(error).message;
+		await advance("failed", { error: message });
+		return {
+			ok: false,
+			safetyCheckpoint,
+			restoredFiles: 0,
+			removedFiles: 0,
+			error: message,
+		};
+	}
+
+	// COMMIT: the journal's absence is the "no transaction in flight" signal.
+	await clearJournal(root, sessionId);
+	return {
+		ok: true,
+		safetyCheckpoint,
+		restoredFiles: plan.restore.length,
+		removedFiles: plan.remove.length,
+	};
+}

--- a/packages/coding-agent/src/checkpoints/service.ts
+++ b/packages/coding-agent/src/checkpoints/service.ts
@@ -1,0 +1,364 @@
+/**
+ * Workspace checkpoint service: capture, query, retention, rollback.
+ *
+ * Disk discipline is a first-class concern. Snapshots are content-addressed git
+ * objects (identical workspaces share every byte), an identical-tree capture
+ * returns the existing checkpoint instead of minting a new one, oversize files
+ * are excluded rather than duplicated into the object database, and retention
+ * prunes automatic checkpoints plus any ref left behind by a crash.
+ */
+import * as fs from "node:fs/promises";
+import { logger, toError } from "@oh-my-pi/pi-utils";
+import { isSettingsInitialized, settings } from "../config/settings";
+import { getDefault } from "../config/settings-schema";
+import * as git from "../utils/git";
+import { captureWorkspaceTree, resolveWorkspaceIdentity, writeCheckpointRef } from "./capture";
+import { emitWorkspaceRolledBack } from "./notify";
+import { runRollbackTransaction } from "./rollback";
+import {
+	defaultCheckpointsRoot,
+	deleteMeta,
+	identityMatches,
+	journalPathFor,
+	listMetaFileNames,
+	metaPathFor,
+	readJournal,
+	readSessionMetas,
+	refNameFor,
+	refPrefixFor,
+	removeSessionDir,
+	writeJsonAtomic,
+} from "./store";
+import {
+	CheckpointError,
+	type CheckpointMeta,
+	type CreateCheckpointOptions,
+	type RollbackJournal,
+	type RollbackOptions,
+	type RollbackResult,
+	type WorkspaceIdentity,
+} from "./types";
+
+/** Checkpoint ids are 5 random bytes rendered as 10 lowercase hex chars. */
+const CHECKPOINT_ID_BYTES = 5;
+/** Ids are random, not sequential; a collision means retry, never overwrite. */
+const ID_MINT_ATTEMPTS = 8;
+
+export interface WorkspaceCheckpointServiceOptions {
+	/**
+	 * Metadata root override. Defaults to the checkpoints directory inside the
+	 * cwd's session directory. Tests and embedders pass a scratch directory.
+	 */
+	readonly metadataRoot?: string;
+	/** Per-file size ceiling override; defaults to `checkpoints.maxFileBytes`. */
+	readonly maxFileBytes?: number;
+	/** Retention cap override; defaults to `checkpoints.retention.maxPerSession`. */
+	readonly maxPerSession?: number;
+}
+
+function mintCheckpointId(): string {
+	const bytes = crypto.getRandomValues(new Uint8Array(CHECKPOINT_ID_BYTES));
+	let id = "";
+	for (const byte of bytes) id += byte.toString(16).padStart(2, "0");
+	return id;
+}
+
+let globalService: WorkspaceCheckpointService | null = null;
+
+export class WorkspaceCheckpointService {
+	readonly #options: WorkspaceCheckpointServiceOptions;
+
+	constructor(options: WorkspaceCheckpointServiceOptions = {}) {
+		this.#options = options;
+	}
+
+	/** Process-wide instance used by commands and auto-checkpoint triggers. */
+	static global(): WorkspaceCheckpointService {
+		globalService ??= new WorkspaceCheckpointService();
+		return globalService;
+	}
+
+	/** Drop the process-wide instance (test isolation). */
+	static resetGlobal(): void {
+		globalService = null;
+	}
+
+	/**
+	 * Capture the current workspace.
+	 *
+	 * Dedup: when the newest checkpoint of the session already has the candidate
+	 * tree, that checkpoint is returned unchanged — no new ref, no new metadata,
+	 * no new bytes.
+	 *
+	 * @throws CheckpointError when `cwd` is not a git repository or too many
+	 * files exceed the size limit.
+	 */
+	async create(options: CreateCheckpointOptions): Promise<CheckpointMeta> {
+		const { cwd, sessionId, signal } = options;
+		const identity = await resolveWorkspaceIdentity(cwd, signal);
+		const root = this.#root(cwd);
+		const capture = await captureWorkspaceTree(identity.worktreePath, {
+			maxFileBytes: this.#maxFileBytes(),
+			signal,
+		});
+
+		const latest = await this.latest(sessionId, cwd);
+		if (latest?.treeSha === capture.treeSha) return latest;
+
+		const id = await this.#mintUnusedId(root, sessionId);
+		const refName = refNameFor(sessionId, id);
+		const createdAt = new Date().toISOString();
+		const message = `omp workspace checkpoint ${id} (${options.reason})\n\nsession: ${sessionId}\ncreated: ${createdAt}${options.label ? `\nlabel: ${options.label}` : ""}\n`;
+		await writeCheckpointRef(identity.worktreePath, {
+			refName,
+			treeSha: capture.treeSha,
+			parentSha: identity.headSha,
+			message,
+			signal,
+		});
+
+		const meta: CheckpointMeta = {
+			id,
+			sessionId,
+			createdAt,
+			...(options.label === undefined ? {} : { label: options.label }),
+			reason: options.reason,
+			identity,
+			treeSha: capture.treeSha,
+			headShaAtCapture: identity.headSha,
+			refName,
+			metaPath: metaPathFor(root, sessionId, id),
+			bytesCaptured: capture.bytesCaptured,
+			skippedFiles: capture.skippedFiles,
+		};
+		// Metadata is published only after the ref exists: a crash between the two
+		// leaves an unreferenced ref (pruned by pruneSession), never metadata
+		// pointing at a missing snapshot.
+		await writeJsonAtomic(meta.metaPath, meta);
+		await this.pruneSession(sessionId, cwd);
+		return meta;
+	}
+
+	/**
+	 * Valid checkpoints of a session in this workspace, newest first. Entries
+	 * whose ref is gone, whose JSON is unparsable, or that belong to another
+	 * workspace are filtered out. Returns `[]` outside a git repository.
+	 */
+	async list(sessionId: string, cwd: string): Promise<CheckpointMeta[]> {
+		const identity = await this.#identityOrNull(cwd);
+		if (!identity) return [];
+		const root = this.#root(cwd);
+		const metas = (await readSessionMetas(root, sessionId)).filter(
+			meta => meta.sessionId === sessionId && identityMatches(meta.identity, identity),
+		);
+		const resolved = await Promise.all(
+			metas.map(async meta => ((await git.ref.resolve(identity.worktreePath, meta.refName)) ? meta : undefined)),
+		);
+		return resolved
+			.filter((meta): meta is CheckpointMeta => meta !== undefined)
+			.sort((left, right) => right.createdAt.localeCompare(left.createdAt) || right.id.localeCompare(left.id));
+	}
+
+	/** Resolve a checkpoint by id prefix (as typed by the user). */
+	async get(sessionId: string, cwd: string, idPrefix: string): Promise<CheckpointMeta | undefined> {
+		const normalized = idPrefix.trim().toLowerCase();
+		if (!normalized) return undefined;
+		const metas = await this.list(sessionId, cwd);
+		return metas.find(meta => meta.id === normalized) ?? metas.find(meta => meta.id.startsWith(normalized));
+	}
+
+	async latest(sessionId: string, cwd: string): Promise<CheckpointMeta | undefined> {
+		return (await this.list(sessionId, cwd))[0];
+	}
+
+	/**
+	 * Checkpoint count for a session without git or JSON work: metadata filenames
+	 * only. Used by session listings, where a per-row git call per session would
+	 * be the dominant cost.
+	 */
+	async countForSession(sessionId: string, cwd: string): Promise<number> {
+		return (await listMetaFileNames(this.#root(cwd), sessionId)).length;
+	}
+
+	/** Journal of an unfinished rollback, for startup recovery messaging. */
+	async pendingRollback(sessionId: string, cwd: string): Promise<RollbackJournal | undefined> {
+		return readJournal(this.#root(cwd), sessionId);
+	}
+
+	/**
+	 * Restore the workspace to `meta`. See `rollback.ts` for the transaction
+	 * guarantees. Validation failures (foreign session, foreign workspace, missing
+	 * snapshot) come back as `ok: false` without touching the workspace.
+	 *
+	 * @throws CheckpointError when `opts.cwd` is not a git repository.
+	 */
+	async rollback(meta: CheckpointMeta, opts: RollbackOptions): Promise<RollbackResult> {
+		const identity = await resolveWorkspaceIdentity(opts.cwd, opts.signal);
+		if (meta.sessionId !== opts.sessionId) {
+			return {
+				ok: false,
+				restoredFiles: 0,
+				removedFiles: 0,
+				error: `checkpoint ${meta.id} belongs to session ${meta.sessionId}, not ${opts.sessionId}`,
+			};
+		}
+		if (!identityMatches(meta.identity, identity)) {
+			return {
+				ok: false,
+				restoredFiles: 0,
+				removedFiles: 0,
+				error: `checkpoint ${meta.id} was captured in ${meta.identity.worktreePath}, not ${identity.worktreePath}`,
+			};
+		}
+		if (!(await git.ref.resolve(identity.worktreePath, meta.refName))) {
+			return {
+				ok: false,
+				restoredFiles: 0,
+				removedFiles: 0,
+				error: `checkpoint ${meta.id} is no longer present in the repository (${meta.refName})`,
+			};
+		}
+
+		const result = await runRollbackTransaction({
+			root: this.#root(opts.cwd),
+			sessionId: opts.sessionId,
+			identity,
+			target: meta,
+			maxFileBytes: this.#maxFileBytes(),
+			captureSafety: () =>
+				this.create({
+					sessionId: opts.sessionId,
+					cwd: opts.cwd,
+					reason: "pre-rollback",
+					label: `before rollback to ${meta.id}`,
+					signal: opts.signal,
+				}),
+			signal: opts.signal,
+		});
+		if (result.ok) emitWorkspaceRolledBack(opts.notify, meta);
+		return result;
+	}
+
+	/**
+	 * Enforce retention for a session: delete oldest automatic checkpoints beyond
+	 * the cap (manual and pre-rollback are protected) and drop refs no valid
+	 * metadata points at. Returns the number of checkpoints removed.
+	 */
+	async pruneSession(sessionId: string, cwd: string): Promise<number> {
+		const identity = await this.#identityOrNull(cwd);
+		if (!identity) return 0;
+		const metas = await this.list(sessionId, cwd);
+		const cap = this.#maxPerSession();
+		// Newest-first list ⇒ reversed autos are oldest-first: the oldest automatic
+		// checkpoints go while manual and pre-rollback ones are always kept.
+		const prunable = metas.filter(meta => meta.reason === "auto").reverse();
+		const removals: CheckpointMeta[] = [];
+		let total = metas.length;
+		for (const meta of prunable) {
+			if (total <= cap) break;
+			removals.push(meta);
+			total -= 1;
+		}
+
+		const removedIds = new Set(removals.map(meta => meta.id));
+		const keptRefs = new Set(metas.filter(meta => !removedIds.has(meta.id)).map(meta => meta.refName));
+		const orphanRefs = (await git.ref.list(identity.worktreePath, refPrefixFor(sessionId)))
+			.map(entry => entry.refName)
+			.filter(refName => !keptRefs.has(refName));
+
+		if (orphanRefs.length > 0) {
+			await git.withRepoLock(identity.worktreePath, async () => {
+				for (const refName of orphanRefs) {
+					try {
+						await git.ref.delete(identity.worktreePath, refName);
+					} catch (error) {
+						logger.warn("Failed to delete checkpoint ref during prune", {
+							refName,
+							error: toError(error).message,
+						});
+					}
+				}
+			});
+		}
+		for (const meta of removals) await deleteMeta(this.#root(cwd), sessionId, meta.id);
+		return removals.length;
+	}
+
+	/**
+	 * Remove every checkpoint of a session: all refs under the session's ref
+	 * namespace plus the metadata directory. Safe outside a git repository (the
+	 * metadata still goes). Returns the number of metadata files removed.
+	 */
+	async deleteForSession(sessionId: string, cwd: string): Promise<number> {
+		const root = this.#root(cwd);
+		const removed = (await listMetaFileNames(root, sessionId)).length;
+		const identity = await this.#identityOrNull(cwd);
+		if (identity) {
+			const refs = await git.ref.list(identity.worktreePath, refPrefixFor(sessionId));
+			if (refs.length > 0) {
+				await git.withRepoLock(identity.worktreePath, async () => {
+					for (const entry of refs) {
+						try {
+							await git.ref.delete(identity.worktreePath, entry.refName);
+						} catch (error) {
+							logger.warn("Failed to delete checkpoint ref during session delete", {
+								refName: entry.refName,
+								error: toError(error).message,
+							});
+						}
+					}
+				});
+			}
+		}
+		await removeSessionDir(root, sessionId);
+		return removed;
+	}
+
+	/** Absolute path of a session's rollback journal (present only mid-transaction). */
+	journalPath(sessionId: string, cwd: string): string {
+		return journalPathFor(this.#root(cwd), sessionId);
+	}
+
+	#root(cwd: string): string {
+		return this.#options.metadataRoot ?? defaultCheckpointsRoot(cwd);
+	}
+
+	#maxFileBytes(): number {
+		if (this.#options.maxFileBytes !== undefined) return this.#options.maxFileBytes;
+		const configured = isSettingsInitialized()
+			? settings.get("checkpoints.maxFileBytes")
+			: getDefault("checkpoints.maxFileBytes");
+		return Number.isFinite(configured) && configured > 0 ? configured : getDefault("checkpoints.maxFileBytes");
+	}
+
+	#maxPerSession(): number {
+		if (this.#options.maxPerSession !== undefined) return this.#options.maxPerSession;
+		const configured = isSettingsInitialized()
+			? settings.get("checkpoints.retention.maxPerSession")
+			: getDefault("checkpoints.retention.maxPerSession");
+		return Number.isFinite(configured) && configured > 0
+			? configured
+			: getDefault("checkpoints.retention.maxPerSession");
+	}
+
+	async #identityOrNull(cwd: string): Promise<WorkspaceIdentity | null> {
+		try {
+			return await resolveWorkspaceIdentity(cwd);
+		} catch (error) {
+			if (error instanceof CheckpointError) return null;
+			throw error;
+		}
+	}
+
+	async #mintUnusedId(root: string, sessionId: string): Promise<string> {
+		for (let attempt = 0; attempt < ID_MINT_ATTEMPTS; attempt += 1) {
+			const id = mintCheckpointId();
+			try {
+				await fs.access(metaPathFor(root, sessionId, id));
+			} catch {
+				return id;
+			}
+		}
+		throw new CheckpointError("could not allocate a unique checkpoint id");
+	}
+}

--- a/packages/coding-agent/src/checkpoints/store.ts
+++ b/packages/coding-agent/src/checkpoints/store.ts
@@ -1,0 +1,204 @@
+/**
+ * On-disk storage for checkpoint metadata and the rollback journal.
+ *
+ * Layout mirrors the session artifacts convention (`<sessionDir>/<sessionFile
+ * basename>/` for artifacts): checkpoints live in
+ * `<sessionDir>/checkpoints/<sessionId>/`, one `<id>.json` per checkpoint plus
+ * `rollback-journal.json` while a rollback transaction is in flight. Every write
+ * is tmp+rename, so a crash leaves either the previous file or the complete new
+ * one — never a truncated JSON body.
+ *
+ * A checkpoint is *valid* only when its ref resolves, its JSON parses into the
+ * expected shape, and its recorded workspace identity matches the workspace
+ * being queried. Anything else is a crash remnant and is filtered out.
+ */
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { isEnoent, Snowflake } from "@oh-my-pi/pi-utils";
+import { computeDefaultSessionDir } from "../session/session-paths";
+import { FileSessionStorage } from "../session/session-storage";
+import type { CheckpointMeta, CheckpointReason, RollbackJournal, WorkspaceIdentity } from "./types";
+
+const CHECKPOINTS_DIR_NAME = "checkpoints";
+const JOURNAL_FILE_NAME = "rollback-journal.json";
+/** Metadata filenames are exactly `<10 hex>.json`; anything else is not ours. */
+const META_FILE_PATTERN = /^[0-9a-f]{10}\.json$/;
+const CHECKPOINT_REASONS: readonly CheckpointReason[] = ["manual", "auto", "pre-rollback"];
+const REF_SEGMENT_UNSAFE = /[^A-Za-z0-9._-]+/g;
+
+const sessionDirStorage = new FileSessionStorage();
+
+/**
+ * Default metadata root for a workspace: the checkpoints directory inside the
+ * cwd's session directory, so checkpoints sit beside the sessions and artifacts
+ * they belong to and are removed with the project's session data.
+ *
+ * `sessionsRoot` mirrors `computeDefaultSessionDir`'s parameter so callers (and
+ * tests) can point the whole layout at a scratch directory.
+ */
+export function defaultCheckpointsRoot(cwd: string, sessionsRoot?: string): string {
+	return path.join(computeDefaultSessionDir(cwd, sessionDirStorage, sessionsRoot), CHECKPOINTS_DIR_NAME);
+}
+
+/**
+ * Ref-safe form of a session id or checkpoint id. Ids are generated (uuid /
+ * hex), but a caller-supplied session id must never be able to inject ref path
+ * components or git's forbidden byte sequences.
+ */
+export function refSegment(value: string): string {
+	const sanitized = value.replace(REF_SEGMENT_UNSAFE, "-").replace(/^[.-]+|[.-]+$/g, "");
+	return sanitized.length > 0 ? sanitized : "unnamed";
+}
+
+export function refNameFor(sessionId: string, id: string): string {
+	return `refs/omp/checkpoints/${refSegment(sessionId)}/${refSegment(id)}`;
+}
+
+/** Ref namespace covering every checkpoint of one session. */
+export function refPrefixFor(sessionId: string): string {
+	return `refs/omp/checkpoints/${refSegment(sessionId)}`;
+}
+
+export function sessionDirFor(root: string, sessionId: string): string {
+	return path.join(root, refSegment(sessionId));
+}
+
+export function metaPathFor(root: string, sessionId: string, id: string): string {
+	return path.join(sessionDirFor(root, sessionId), `${id}.json`);
+}
+
+export function journalPathFor(root: string, sessionId: string): string {
+	return path.join(sessionDirFor(root, sessionId), JOURNAL_FILE_NAME);
+}
+
+/**
+ * Publish `value` at `filePath` atomically. `Bun.write` creates the parent
+ * directory, and the rename is the single visible transition.
+ */
+export async function writeJsonAtomic(filePath: string, value: unknown): Promise<void> {
+	const tempPath = `${filePath}.${Snowflake.next()}.tmp`;
+	await Bun.write(tempPath, `${JSON.stringify(value, null, 2)}\n`);
+	try {
+		await fs.rename(tempPath, filePath);
+	} catch (error) {
+		await fs.rm(tempPath, { force: true }).catch(() => {});
+		throw error;
+	}
+}
+
+async function readJsonFile(filePath: string): Promise<unknown> {
+	try {
+		return await Bun.file(filePath).json();
+	} catch {
+		// Missing (never written / already pruned) and unparsable (crash before
+		// the metadata rename) are the same answer to the caller: no usable
+		// record here. Callers treat `undefined` as "not a valid checkpoint".
+		return undefined;
+	}
+}
+
+function isWorkspaceIdentity(value: unknown): value is WorkspaceIdentity {
+	if (typeof value !== "object" || value === null) return false;
+	const candidate = value as Record<string, unknown>;
+	return (
+		typeof candidate.repoRoot === "string" &&
+		typeof candidate.worktreePath === "string" &&
+		(candidate.headSha === null || typeof candidate.headSha === "string") &&
+		(candidate.branch === null || typeof candidate.branch === "string")
+	);
+}
+
+/** Structural validation of a parsed metadata file. */
+export function isCheckpointMeta(value: unknown): value is CheckpointMeta {
+	if (typeof value !== "object" || value === null) return false;
+	const candidate = value as Record<string, unknown>;
+	return (
+		typeof candidate.id === "string" &&
+		typeof candidate.sessionId === "string" &&
+		typeof candidate.createdAt === "string" &&
+		(candidate.label === undefined || typeof candidate.label === "string") &&
+		typeof candidate.reason === "string" &&
+		CHECKPOINT_REASONS.includes(candidate.reason as CheckpointReason) &&
+		isWorkspaceIdentity(candidate.identity) &&
+		typeof candidate.treeSha === "string" &&
+		candidate.treeSha.length > 0 &&
+		(candidate.headShaAtCapture === null || typeof candidate.headShaAtCapture === "string") &&
+		typeof candidate.refName === "string" &&
+		typeof candidate.metaPath === "string" &&
+		typeof candidate.bytesCaptured === "number" &&
+		Array.isArray(candidate.skippedFiles) &&
+		candidate.skippedFiles.every(entry => typeof entry === "string")
+	);
+}
+
+function isRollbackJournal(value: unknown): value is RollbackJournal {
+	if (typeof value !== "object" || value === null) return false;
+	const candidate = value as Record<string, unknown>;
+	return (
+		typeof candidate.sessionId === "string" &&
+		typeof candidate.phase === "string" &&
+		typeof candidate.targetId === "string" &&
+		typeof candidate.targetTreeSha === "string" &&
+		typeof candidate.baseTreeSha === "string" &&
+		isWorkspaceIdentity(candidate.identity)
+	);
+}
+
+/**
+ * Whether two identities describe the same checkout. HEAD and branch are
+ * deliberately excluded: a checkpoint stays valid after the user commits or
+ * switches branches, it just no longer matches HEAD.
+ */
+export function identityMatches(left: WorkspaceIdentity, right: WorkspaceIdentity): boolean {
+	return (
+		path.resolve(left.repoRoot) === path.resolve(right.repoRoot) &&
+		path.resolve(left.worktreePath) === path.resolve(right.worktreePath)
+	);
+}
+
+/** Checkpoint metadata filenames present for a session (unvalidated, cheap). */
+export async function listMetaFileNames(root: string, sessionId: string): Promise<string[]> {
+	try {
+		const entries = await fs.readdir(sessionDirFor(root, sessionId));
+		return entries.filter(entry => META_FILE_PATTERN.test(entry));
+	} catch (error) {
+		if (isEnoent(error)) return [];
+		throw error;
+	}
+}
+
+/** Parse and structurally validate every metadata file of a session. Order is unspecified. */
+export async function readSessionMetas(root: string, sessionId: string): Promise<CheckpointMeta[]> {
+	const fileNames = await listMetaFileNames(root, sessionId);
+	const dir = sessionDirFor(root, sessionId);
+	const parsed = await Promise.all(fileNames.map(name => readJsonFile(path.join(dir, name))));
+	return parsed.filter(isCheckpointMeta);
+}
+
+export async function readMeta(root: string, sessionId: string, id: string): Promise<CheckpointMeta | undefined> {
+	const value = await readJsonFile(metaPathFor(root, sessionId, id));
+	return isCheckpointMeta(value) ? value : undefined;
+}
+
+export async function deleteMeta(root: string, sessionId: string, id: string): Promise<void> {
+	await fs.rm(metaPathFor(root, sessionId, id), { force: true });
+}
+
+export async function readJournal(root: string, sessionId: string): Promise<RollbackJournal | undefined> {
+	const value = await readJsonFile(journalPathFor(root, sessionId));
+	return isRollbackJournal(value) ? value : undefined;
+}
+
+export async function writeJournal(root: string, sessionId: string, journal: RollbackJournal): Promise<void> {
+	await writeJsonAtomic(journalPathFor(root, sessionId), journal);
+}
+
+/** Close a completed transaction. The journal's absence is the "no transaction in flight" signal. */
+export async function clearJournal(root: string, sessionId: string): Promise<void> {
+	await fs.rm(journalPathFor(root, sessionId), { force: true });
+}
+
+/** Remove a session's whole checkpoint metadata directory (session delete flow). */
+export async function removeSessionDir(root: string, sessionId: string): Promise<void> {
+	await fs.rm(sessionDirFor(root, sessionId), { recursive: true, force: true });
+}

--- a/packages/coding-agent/src/checkpoints/types.ts
+++ b/packages/coding-agent/src/checkpoints/types.ts
@@ -1,0 +1,115 @@
+/**
+ * Types for git-backed workspace checkpoints.
+ *
+ * A checkpoint is a snapshot of the working tree (tracked + untracked
+ * non-ignored files) stored as a commit under
+ * `refs/omp/checkpoints/<sessionId>/<id>` plus a metadata JSON file next to the
+ * session's artifacts. HEAD, the current branch, and the user's index are never
+ * moved by a capture.
+ */
+
+/**
+ * The workspace a checkpoint belongs to. `repoRoot` is the primary checkout
+ * (shared by linked worktrees, so it names the project); `worktreePath` is the
+ * specific checkout whose files were snapshotted. Both are compared when a
+ * checkpoint is validated, so a checkpoint captured in worktree A is never
+ * offered — or applied — in worktree B of the same repository.
+ */
+export interface WorkspaceIdentity {
+	readonly repoRoot: string;
+	readonly worktreePath: string;
+	readonly headSha: string | null;
+	readonly branch: string | null;
+}
+
+/** Why a checkpoint was captured. `manual` and `pre-rollback` are retention-protected. */
+export type CheckpointReason = "manual" | "auto" | "pre-rollback";
+
+export interface CheckpointMeta {
+	/** Short hex id (10 chars), unique within the session. */
+	readonly id: string;
+	readonly sessionId: string;
+	readonly createdAt: string;
+	/** User-supplied label (manual captures). */
+	readonly label?: string;
+	readonly reason: CheckpointReason;
+	readonly identity: WorkspaceIdentity;
+	/** Full working-tree snapshot tree (tracked + untracked non-ignored). */
+	readonly treeSha: string;
+	readonly headShaAtCapture: string | null;
+	/** `refs/omp/checkpoints/<sessionId>/<id>`. */
+	readonly refName: string;
+	/** Absolute path of this metadata file. */
+	readonly metaPath: string;
+	/**
+	 * Logical bytes the snapshot represents (sum of blob sizes in `treeSha`).
+	 * Content shared with existing git objects costs no additional disk, so this
+	 * is an upper bound on what the capture could have added, not a delta.
+	 */
+	readonly bytesCaptured: number;
+	/** Paths excluded from the snapshot because they exceed `checkpoints.maxFileBytes`. */
+	readonly skippedFiles: string[];
+}
+
+export interface CreateCheckpointOptions {
+	readonly sessionId: string;
+	readonly cwd: string;
+	readonly label?: string;
+	readonly reason: CheckpointReason;
+	readonly signal?: AbortSignal;
+}
+
+/**
+ * Session surface used to record a rollback in the transcript. Structurally
+ * satisfied by `SessionManager.appendCustomEntry`, so the checkpoints module
+ * does not depend on the session package.
+ */
+export interface WorkspaceRollbackSessionSurface {
+	appendCustomEntry(customType: string, data?: unknown): string;
+}
+
+export interface RollbackOptions {
+	readonly sessionId: string;
+	readonly cwd: string;
+	readonly signal?: AbortSignal;
+	/**
+	 * Optional session surface notified after a successful rollback. When
+	 * omitted the caller is responsible for calling `emitWorkspaceRolledBack`.
+	 */
+	readonly notify?: WorkspaceRollbackSessionSurface;
+}
+
+export interface RollbackResult {
+	readonly ok: boolean;
+	/** Snapshot of the pre-rollback workspace, so a rollback is itself reversible. */
+	readonly safetyCheckpoint?: CheckpointMeta;
+	readonly restoredFiles: number;
+	readonly removedFiles: number;
+	readonly error?: string;
+}
+
+/** Phase reached by the in-flight rollback transaction. Absent journal ⇔ no transaction in flight. */
+export type RollbackPhase = "prepare" | "safety" | "apply" | "failed";
+
+export interface RollbackJournal {
+	readonly sessionId: string;
+	readonly phase: RollbackPhase;
+	readonly startedAt: string;
+	readonly updatedAt: string;
+	readonly identity: WorkspaceIdentity;
+	readonly targetId: string;
+	readonly targetTreeSha: string;
+	/** Tree captured before APPLY — what the workspace looked like going in. */
+	readonly baseTreeSha: string;
+	readonly safetyCheckpointId?: string;
+	readonly skippedFiles: string[];
+	readonly error?: string;
+}
+
+/** A checkpoint operation could not proceed (not a repository, unusable snapshot, guard tripped). */
+export class CheckpointError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "CheckpointError";
+	}
+}

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -216,6 +216,7 @@ export const TAB_GROUPS: Record<SettingTab, readonly string[]> = {
 	shell: ["Bash", "Eval & Runtimes"],
 	tools: [
 		"Available Tools",
+		"Workspace Checkpoints",
 		"Todos",
 		"Grep & Browser",
 		"Computer",
@@ -4341,6 +4342,74 @@ export const SETTINGS_SCHEMA = {
 			group: "Available Tools",
 			label: "Checkpoint/Rewind",
 			description: "Enable the checkpoint and rewind tools for context checkpointing",
+		},
+	},
+
+	// Workspace checkpoints (`/checkpoint`, `/rollback`) — distinct from the
+	// conversation-context `checkpoint.enabled` tool above.
+	"checkpoints.enabled": {
+		type: "boolean",
+		default: false,
+		ui: {
+			tab: "tools",
+			group: "Workspace Checkpoints",
+			label: "Workspace Checkpoints",
+			description:
+				"Enable git-backed workspace snapshots and rollback (/checkpoint, /rollback). Snapshots live in refs/omp/checkpoints and never move HEAD or your branch",
+		},
+	},
+
+	"checkpoints.auto.gitOperations": {
+		type: "boolean",
+		default: false,
+		ui: {
+			tab: "tools",
+			group: "Workspace Checkpoints",
+			label: "Auto Checkpoint Before Git Operations",
+			description:
+				"Capture a workspace checkpoint before destructive git commands (reset --hard, clean -fd, checkout/restore over the tree, force push, branch -D, rebase)",
+		},
+	},
+
+	"checkpoints.auto.riskyEdits": {
+		type: "boolean",
+		default: false,
+		ui: {
+			tab: "tools",
+			group: "Workspace Checkpoints",
+			label: "Auto Checkpoint Before Risky Edits",
+			description:
+				"Capture a workspace checkpoint before an edit application that crosses the multi-file/large-payload threshold",
+		},
+	},
+
+	"checkpoints.retention.maxPerSession": {
+		type: "number",
+		default: 20,
+		ui: {
+			tab: "tools",
+			group: "Workspace Checkpoints",
+			label: "Max Checkpoints Per Session",
+			description:
+				"Retention cap per session. Oldest automatic checkpoints are pruned beyond this count; manual and pre-rollback checkpoints are never pruned",
+		},
+	},
+
+	"checkpoints.maxFileBytes": {
+		type: "number",
+		default: 10_485_760,
+		ui: {
+			tab: "tools",
+			group: "Workspace Checkpoints",
+			label: "Checkpoint Max File Size",
+			description:
+				"Files larger than this are excluded from a workspace checkpoint and recorded as skipped, so one huge blob cannot inflate the object database",
+			options: [
+				{ value: "1048576", label: "1 MiB" },
+				{ value: "10485760", label: "10 MiB" },
+				{ value: "52428800", label: "50 MiB" },
+				{ value: "104857600", label: "100 MiB" },
+			],
 		},
 	},
 

--- a/packages/coding-agent/src/modes/components/checkpoint-list.ts
+++ b/packages/coding-agent/src/modes/components/checkpoint-list.ts
@@ -1,0 +1,261 @@
+/**
+ * Reusable fullscreen checkpoint browser used by `/rollback` (full mode: can
+ * roll back) and by the `/sessions` details pane (read-only: just inspects).
+ *
+ * It is a self-contained overlay Component: it owns its own list state, an
+ * inline inspect view, and an inline rollback-confirmation flow. The caller
+ * supplies `onRollback` (full mode only) which performs the actual
+ * `WorkspaceCheckpointService.rollback` plus any notify/status side effects.
+ *
+ * Data is loaded once on construction (checkpoints are immutable once
+ * written), so rendering never re-queries the service.
+ */
+import type { Component, TUI } from "@oh-my-pi/pi-tui";
+import { matchesKey, padding, truncateToWidth, visibleWidth, wrapTextWithAnsi } from "@oh-my-pi/pi-tui";
+import { formatAge, formatBytes } from "@oh-my-pi/pi-utils";
+import type { CheckpointMeta } from "../../checkpoints";
+import { WorkspaceCheckpointService } from "../../checkpoints";
+import { theme } from "../../modes/theme/theme";
+import { sanitizeDisplayText } from "./agent-hub-renderer";
+import { bottomBorder, divider, row, topBorder } from "./overlay-box";
+
+type CheckpointListMode = "list" | "inspect" | "confirm";
+
+export interface CheckpointListViewDeps {
+	/** Session whose checkpoints are listed. */
+	sessionId: string;
+	/** Working directory the session owns (for identity resolution). */
+	cwd: string;
+	/** Overlay host; when absent (render-only tests) navigational keys are inert. */
+	ui?: TUI;
+	/** Request a repaint from the host TUI. */
+	requestRender: () => void;
+	/** Called when the user cancels/backs out of the list (Esc at top level). */
+	onClose: () => void;
+	/**
+	 * When true the list is view-only (no rollback). The `/sessions` details
+	 * pane uses this; `/rollback` does not.
+	 */
+	readOnly?: boolean;
+	/** Checkpoint service; defaults to `WorkspaceCheckpointService.global()`. */
+	service?: WorkspaceCheckpointService;
+	/**
+	 * Performs the rollback for the selected checkpoint after the user confirms.
+	 * Required in full (non-read-only) mode. Receives the chosen metadata.
+	 */
+	onRollback?: (meta: CheckpointMeta) => Promise<void>;
+}
+
+const AGE_TICK_MS = 5_000;
+
+export class CheckpointListComponent implements Component {
+	readonly #sessionId: string;
+	readonly #cwd: string;
+	readonly #ui: TUI | undefined;
+	readonly #requestRender: () => void;
+	readonly #onClose: () => void;
+	readonly #readOnly: boolean;
+	readonly #service: WorkspaceCheckpointService;
+	readonly #onRollback: ((meta: CheckpointMeta) => Promise<void>) | undefined;
+	readonly #ageTimer: NodeJS.Timeout | undefined;
+
+	#disposed = false;
+	#checkpoints: CheckpointMeta[] = [];
+	#selected = 0;
+	#mode: CheckpointListMode = "list";
+	#notice: string | undefined;
+
+	constructor(deps: CheckpointListViewDeps) {
+		this.#sessionId = deps.sessionId;
+		this.#cwd = deps.cwd;
+		this.#ui = deps.ui;
+		this.#requestRender = deps.requestRender;
+		this.#onClose = deps.onClose;
+		this.#readOnly = deps.readOnly ?? false;
+		this.#service = deps.service ?? WorkspaceCheckpointService.global();
+		this.#onRollback = deps.onRollback;
+
+		// Load once; checkpoints are immutable once written.
+		void this.#service.list(this.#sessionId, this.#cwd).then(metas => {
+			if (this.#disposed) return;
+			this.#checkpoints = metas;
+			this.#selected = Math.min(this.#selected, Math.max(0, metas.length - 1));
+			this.#requestRender();
+		});
+
+		if (this.#ui) {
+			this.#ageTimer = setInterval(() => this.#requestRender(), AGE_TICK_MS);
+			this.#ageTimer.unref?.();
+		}
+	}
+
+	dispose(): void {
+		if (this.#disposed) return;
+		this.#disposed = true;
+		if (this.#ageTimer) clearInterval(this.#ageTimer);
+	}
+
+	render(width: number): readonly string[] {
+		const inner = Math.max(1, width - 4);
+		const lines: string[] = [];
+		lines.push(topBorder(width, this.#readOnly ? "Checkpoints (read-only)" : "Checkpoints"));
+		if (this.#checkpoints.length === 0) {
+			lines.push(row(theme.fg("dim", "No checkpoints for this session."), width));
+		} else if (this.#mode === "inspect") {
+			for (const line of this.#renderInspect(inner)) lines.push(row(line, width));
+		} else {
+			for (const line of this.#renderList(inner)) lines.push(row(line, width));
+		}
+		lines.push(divider(width));
+		lines.push(row(this.#footer(width), width));
+		lines.push(bottomBorder(width));
+		return lines;
+	}
+
+	handleInput(data: string): void {
+		if (this.#mode === "confirm") {
+			if (matchesKey(data, "y") || matchesKey(data, "enter")) {
+				void this.#doRollback();
+				return;
+			}
+			if (matchesKey(data, "escape") || matchesKey(data, "n")) {
+				this.#mode = "list";
+				this.#notice = undefined;
+				this.#requestRender();
+				return;
+			}
+			return;
+		}
+		if (this.#mode === "inspect") {
+			if (matchesKey(data, "escape") || matchesKey(data, "enter") || matchesKey(data, "q")) {
+				this.#mode = "list";
+				this.#requestRender();
+				return;
+			}
+			return;
+		}
+		if (matchesKey(data, "escape") || matchesKey(data, "q")) {
+			this.#close();
+			return;
+		}
+		if (matchesKey(data, "j") || matchesKey(data, "down")) {
+			if (this.#checkpoints.length > 0) {
+				this.#selected = Math.min(this.#selected + 1, this.#checkpoints.length - 1);
+			}
+			this.#requestRender();
+			return;
+		}
+		if (matchesKey(data, "k") || matchesKey(data, "up")) {
+			if (this.#checkpoints.length > 0) this.#selected = Math.max(this.#selected - 1, 0);
+			this.#requestRender();
+			return;
+		}
+		const selected = this.#checkpoints[this.#selected];
+		if (!selected) return;
+		if (matchesKey(data, "enter") || matchesKey(data, "c") || matchesKey(data, "i")) {
+			this.#mode = "inspect";
+			this.#requestRender();
+			return;
+		}
+		if (!this.#readOnly && (matchesKey(data, "r") || data === "R")) {
+			this.#mode = "confirm";
+			this.#notice = undefined;
+			this.#requestRender();
+			return;
+		}
+	}
+
+	#close(): void {
+		this.dispose();
+		this.#onClose();
+	}
+
+	async #doRollback(): Promise<void> {
+		const selected = this.#checkpoints[this.#selected];
+		if (!selected || !this.#onRollback) return;
+		this.#mode = "list";
+		this.#notice = undefined;
+		try {
+			await this.#onRollback(selected);
+			this.dispose();
+			this.#onClose();
+		} catch (error) {
+			this.#notice = error instanceof Error ? error.message : String(error);
+			this.#requestRender();
+		}
+	}
+
+	#renderList(width: number): string[] {
+		const lines: string[] = [];
+		if (this.#notice) {
+			lines.push(theme.fg("error", truncateToWidth(this.#notice, width)));
+		}
+		this.#checkpoints.forEach((meta, index) => {
+			const cursor = index === this.#selected ? theme.fg("accent", theme.nav.cursor) : " ";
+			const id = theme.bold(index === this.#selected ? meta.id : meta.id);
+			const label = meta.label ?? meta.reason;
+			const age = formatAge(Math.max(1, Math.round((Date.now() - new Date(meta.createdAt).getTime()) / 1000)));
+			const bytes = meta.bytesCaptured > 0 ? formatBytes(meta.bytesCaptured) : theme.fg("dim", "—");
+			const left = `${cursor} ${id} ${theme.fg("dim", sanitizeDisplayText(label))}`;
+			const right = theme.fg("dim", `${age}  ${bytes}`);
+			const leftW = visibleWidth(left);
+			const rightW = visibleWidth(right);
+			if (leftW + 2 + rightW <= width) {
+				lines.push(left + padding(width - leftW - rightW) + right);
+			} else {
+				lines.push(truncateToWidth(left, width));
+			}
+		});
+		return lines;
+	}
+
+	#renderInspect(width: number): string[] {
+		const meta = this.#checkpoints[this.#selected];
+		if (!meta) return [theme.fg("dim", "No checkpoint selected.")];
+		const created = new Date(meta.createdAt);
+		const rows: Array<[string, string]> = [
+			["id", meta.id],
+			["reason", meta.reason],
+			["label", meta.label ?? theme.fg("dim", "—")],
+			["created", created.toISOString()],
+			["age", formatAge(Math.max(1, Math.round((Date.now() - created.getTime()) / 1000)))],
+			["bytes", meta.bytesCaptured > 0 ? formatBytes(meta.bytesCaptured) : "—"],
+			["skipped", String(meta.skippedFiles.length)],
+			["repo", sanitizeDisplayText(meta.identity.repoRoot)],
+			["worktree", sanitizeDisplayText(meta.identity.worktreePath)],
+			["head", meta.headShaAtCapture ?? "—"],
+			["tree", meta.treeSha],
+		];
+		const lines: string[] = [];
+		lines.push(theme.bold(theme.fg("accent", `Checkpoint ${meta.id}`)));
+		for (const [key, value] of rows) {
+			for (const wrapped of wrapTextWithAnsi(`${theme.fg("muted", `${key}:`)} ${value}`, width)) {
+				lines.push(truncateToWidth(wrapped, width));
+			}
+		}
+		if (!this.#readOnly) {
+			lines.push("");
+			lines.push(theme.fg("dim", "Press R to roll back to this checkpoint."));
+		}
+		lines.push(theme.fg("dim", "Esc:back"));
+		return lines;
+	}
+
+	#footer(_width: number): string {
+		if (this.#mode === "confirm") {
+			const meta = this.#checkpoints[this.#selected];
+			const label = meta ? sanitizeDisplayText(meta.label ?? meta.reason) : "";
+			return theme.fg(
+				"error",
+				`Roll back to ${meta?.id ?? "?"} (${label})? A safety checkpoint of the current state is created first.  y:confirm  n/Esc:cancel`,
+			);
+		}
+		if (this.#mode === "inspect") {
+			return theme.fg("dim", "Enter/Esc:back");
+		}
+		if (this.#readOnly) {
+			return theme.fg("dim", "↑/↓:nav  Enter:inspect  Esc:close");
+		}
+		return theme.fg("dim", "↑/↓:nav  Enter:inspect  R:rollback  Esc:close");
+	}
+}

--- a/packages/coding-agent/src/modes/components/sessions-manager.ts
+++ b/packages/coding-agent/src/modes/components/sessions-manager.ts
@@ -1,0 +1,640 @@
+/**
+ * `/sessions` fullscreen manager overlay.
+ *
+ * Lists every enumerated session (current + persisted), with keyboard-only
+ * navigation and actions keyed by the durable session id/path (never the
+ * display name). Data is loaded via `enumerateSessions` on open, on an
+ * explicit resync (R), and on a registry change subscription — never per
+ * render. A bounded 5s timer only refreshes the relative-age column.
+ *
+ * Columns degrade on narrow terminals: cost, then model, then cwd are dropped
+ * before the name/age/state core. Every cell is sanitized and width-clamped.
+ */
+
+import { agentPauseGate } from "@oh-my-pi/pi-agent-core";
+import type { Component, TUI } from "@oh-my-pi/pi-tui";
+import { matchesKey, padding, truncateToWidth, visibleWidth } from "@oh-my-pi/pi-tui";
+import { formatAge, formatNumber } from "@oh-my-pi/pi-utils";
+import { type CheckpointMeta, WorkspaceCheckpointService } from "../../checkpoints";
+import { theme } from "../../modes/theme/theme";
+import type { InteractiveModeContext } from "../../modes/types";
+import { matchesAppInterrupt, matchesSelectDown, matchesSelectUp } from "../../modes/utils/keybinding-matchers";
+import { AgentLifecycleManager } from "../../registry/agent-lifecycle";
+import { AgentRegistry, MAIN_AGENT_ID } from "../../registry/agent-registry";
+import {
+	type EnumerateOptions,
+	enumerateSessions,
+	type SessionFilter,
+	type SessionRow,
+	type SessionSort,
+	setArchived,
+} from "../../session/session-control";
+import { shortenPath } from "../../tools/render-utils";
+import { sanitizeDisplayText } from "./agent-hub-renderer";
+import { CheckpointListComponent } from "./checkpoint-list";
+import { bottomBorder, divider, row, topBorder } from "./overlay-box";
+
+/** Bounded cadence for the relative-age column only. */
+const AGE_TICK_MS = 5_000;
+
+/** Process-global pause gate projection the component drives. */
+interface PauseGate {
+	readonly paused: boolean;
+	engage(): unknown;
+	release(): unknown;
+}
+
+const FILTER_CYCLE: readonly SessionFilter[] = ["current", "active", "paused", "archived", "all"];
+const SORT_CYCLE: readonly SessionSort[] = ["recent", "created", "cost", "agents"];
+
+type ConfirmKind = "killCurrent" | "deleteSession";
+
+interface ConfirmState {
+	kind: ConfirmKind;
+	path: string;
+	display: string;
+	step: number;
+}
+
+export interface SessionsManagerDeps {
+	/** Interactive mode context (resume, session manager, status, ui). */
+	ctx: InteractiveModeContext;
+	/** Overlay host; when absent (render-only tests) navigational keys are inert. */
+	ui?: TUI;
+	/** Request a repaint from the host TUI. */
+	requestRender: () => void;
+	/** Called when the user closes the manager (Esc at top level). */
+	onClose: () => void;
+	/** Project working directory (default: project dir). */
+	cwd?: string;
+	/** Restrict enumeration to one project's session dir (default: all projects). */
+	sessionDir?: string;
+	/** Override enumeration (tests inject a fake). */
+	enumerate?: (opts: EnumerateOptions) => Promise<SessionRow[]>;
+	/** Agent registry (default: `AgentRegistry.global()`). */
+	registry?: AgentRegistry;
+	/** Pause gate (default: `agentPauseGate`). */
+	gate?: PauseGate;
+	/** Lifecycle manager for kills (default: `AgentLifecycleManager.global()`). */
+	lifecycle?: AgentLifecycleManager;
+	/** Checkpoint service (default: `WorkspaceCheckpointService.global()`). */
+	checkpointService?: WorkspaceCheckpointService;
+	/** Stats read race (ms). */
+	statsTimeoutMs?: number;
+}
+
+export class SessionsManagerComponent implements Component {
+	readonly #ctx: InteractiveModeContext;
+	readonly #ui: TUI | undefined;
+	readonly #requestRender: () => void;
+	readonly #onClose: () => void;
+	readonly #cwd: string;
+	readonly #sessionDir: string | undefined;
+	readonly #enumerate: (opts: EnumerateOptions) => Promise<SessionRow[]>;
+	readonly #registry: AgentRegistry;
+	readonly #gate: PauseGate;
+	readonly #lifecycle: AgentLifecycleManager;
+	readonly #checkpointService: WorkspaceCheckpointService;
+	readonly #statsTimeoutMs: number | undefined;
+
+	#disposed = false;
+	#rows: SessionRow[] = [];
+	#selected = 0;
+	#filter: SessionFilter = "all";
+	#sort: SessionSort = "recent";
+	#detailsOpen = false;
+	#detailsCheckpoints: CheckpointMeta[] | undefined;
+	#confirm: ConfirmState | undefined;
+	#notice: string | undefined;
+	#pendingAction: Promise<void> = Promise.resolve();
+	readonly #ageTimer: NodeJS.Timeout | undefined;
+	readonly #unsubscribe: () => void;
+
+	constructor(deps: SessionsManagerDeps) {
+		this.#ctx = deps.ctx;
+		this.#ui = deps.ui;
+		this.#requestRender = deps.requestRender;
+		this.#onClose = deps.onClose;
+		this.#cwd = deps.cwd ?? process.cwd();
+		this.#sessionDir = deps.sessionDir;
+		this.#enumerate = deps.enumerate ?? ((opts: EnumerateOptions) => enumerateSessions(opts));
+		this.#registry = deps.registry ?? AgentRegistry.global();
+		this.#gate = deps.gate ?? (agentPauseGate as unknown as PauseGate);
+		this.#lifecycle = deps.lifecycle ?? AgentLifecycleManager.global();
+		this.#checkpointService = deps.checkpointService ?? WorkspaceCheckpointService.global();
+		this.#statsTimeoutMs = deps.statsTimeoutMs;
+
+		this.#unsubscribe = this.#registry.onChange(() => this.#refresh());
+
+		if (this.#ui) {
+			this.#ageTimer = setInterval(() => this.#requestRender(), AGE_TICK_MS);
+			this.#ageTimer.unref?.();
+		}
+
+		void this.#refresh();
+	}
+
+	dispose(): void {
+		if (this.#disposed) return;
+		this.#disposed = true;
+		if (this.#ageTimer) clearInterval(this.#ageTimer);
+		this.#unsubscribe();
+	}
+
+	render(width: number): readonly string[] {
+		const inner = Math.max(1, width - 4);
+		const lines: string[] = [];
+		if (this.#detailsOpen) {
+			lines.push(topBorder(width, "Session"));
+			for (const line of this.#renderDetails(inner)) lines.push(row(truncateToWidth(line, inner), width));
+			lines.push(divider(width));
+			lines.push(row(truncateToWidth(this.#detailsFooter(inner), inner), width));
+			lines.push(bottomBorder(width));
+			return lines;
+		}
+
+		lines.push(topBorder(width, this.#headerTitle(inner)));
+		for (const line of this.#renderRows(inner)) lines.push(row(truncateToWidth(line, inner), width));
+		if (this.#confirm) lines.push(row(truncateToWidth(this.#confirmMessage(), inner), width));
+		else if (this.#notice) lines.push(row(truncateToWidth(theme.fg("error", this.#notice), inner), width));
+		lines.push(divider(width));
+		lines.push(row(truncateToWidth(this.#footer(inner), inner), width));
+		lines.push(bottomBorder(width));
+		return lines;
+	}
+
+	handleInput(data: string): void {
+		if (this.#detailsOpen && (matchesKey(data, "escape") || matchesAppInterrupt(data))) {
+			this.#detailsOpen = false;
+			this.#requestRender();
+			return;
+		}
+		if (this.#confirm) {
+			if (matchesKey(data, "y") || matchesKey(data, "enter") || data === "K") {
+				this.#pendingAction = this.#confirmAction();
+				return;
+			}
+			if (matchesKey(data, "n") || matchesKey(data, "escape")) {
+				this.#confirm = undefined;
+				this.#notice = undefined;
+				this.#requestRender();
+				return;
+			}
+			return;
+		}
+		if (matchesAppInterrupt(data)) {
+			this.#close();
+			return;
+		}
+
+		const key = data;
+		if (key === "F") {
+			this.#cycleFilter();
+			return;
+		}
+		if (key === "S") {
+			this.#cycleSort();
+			return;
+		}
+		if (key === "D") {
+			this.#toggleDetails();
+			return;
+		}
+		if (key === "A") {
+			this.#pendingAction = this.#toggleArchive();
+			return;
+		}
+		if (key === "P") {
+			this.#pendingAction = this.#togglePause();
+			return;
+		}
+		if (key === "K") {
+			this.#beginKill();
+			return;
+		}
+		if (key === "R") {
+			this.#pendingAction = this.#refresh();
+			return;
+		}
+		if (key === "C" && this.#detailsOpen) {
+			this.#openCheckpoints();
+			return;
+		}
+		if (matchesKey(data, "j") || matchesSelectDown(data)) {
+			this.#move(1);
+			return;
+		}
+		if (matchesKey(data, "k") || matchesSelectUp(data)) {
+			this.#move(-1);
+			return;
+		}
+		if (matchesKey(data, "enter") || data === "\r" || data === "\n") {
+			this.#pendingAction = this.#openSelected();
+		}
+	}
+
+	#close(): void {
+		this.dispose();
+		this.#onClose();
+	}
+
+	#move(delta: number): void {
+		if (this.#rows.length === 0) return;
+		this.#selected = Math.max(0, Math.min(this.#selected + delta, this.#rows.length - 1));
+		if (this.#detailsOpen) void this.#loadDetails();
+		this.#requestRender();
+	}
+
+	#cycleFilter(): void {
+		const index = FILTER_CYCLE.indexOf(this.#filter);
+		this.#filter = FILTER_CYCLE[(index + 1) % FILTER_CYCLE.length]!;
+		void this.#refresh();
+	}
+
+	#cycleSort(): void {
+		const index = SORT_CYCLE.indexOf(this.#sort);
+		this.#sort = SORT_CYCLE[(index + 1) % SORT_CYCLE.length]!;
+		void this.#refresh();
+	}
+
+	#toggleDetails(): void {
+		this.#detailsOpen = !this.#detailsOpen;
+		if (this.#detailsOpen) void this.#loadDetails();
+		this.#requestRender();
+	}
+
+	/** Fire-and-forget refresh; the in-flight tail is observable via {@link awaitSettled}. */
+	#refresh(): Promise<void> {
+		this.#pendingAction = this.#runRefresh();
+		return this.#pendingAction;
+	}
+
+	async #runRefresh(): Promise<void> {
+		if (this.#disposed) return;
+		const opts: EnumerateOptions = {
+			cwd: this.#cwd,
+			sessionDir: this.#sessionDir,
+			filter: this.#filter,
+			sort: this.#sort,
+			statsTimeoutMs: this.#statsTimeoutMs,
+			deps: {
+				registry: this.#registry,
+				gate: this.#gate,
+				session: { sessionFile: this.#ctx.session.sessionFile },
+				currentSessionFile: this.#ctx.session.sessionFile,
+			},
+		};
+		try {
+			this.#rows = await this.#enumerate(opts);
+		} catch (error) {
+			this.#notice = error instanceof Error ? error.message : String(error);
+		}
+		this.#selected = Math.min(this.#selected, Math.max(0, this.#rows.length - 1));
+		if (this.#detailsOpen) void this.#loadDetails();
+		this.#requestRender();
+	}
+
+	/** Resolves when the in-flight action (refresh/archive/pause/open) has landed. Test seam. */
+	awaitSettled(): Promise<void> {
+		return this.#pendingAction;
+	}
+
+	async #loadDetails(): Promise<void> {
+		const row = this.#rows[this.#selected];
+		this.#detailsCheckpoints = undefined;
+		if (!row?.info.cwd) {
+			this.#detailsCheckpoints = [];
+			this.#requestRender();
+			return;
+		}
+		try {
+			this.#detailsCheckpoints = await this.#checkpointService.list(row.info.id, row.info.cwd);
+		} catch {
+			this.#detailsCheckpoints = [];
+		}
+		this.#requestRender();
+	}
+
+	async #toggleArchive(): Promise<void> {
+		const row = this.#rows[this.#selected];
+		if (!row) return;
+		try {
+			await setArchived(row.info.path, !row.archived);
+		} catch (error) {
+			this.#notice = error instanceof Error ? error.message : String(error);
+		}
+		void this.#refresh();
+	}
+
+	async #togglePause(): Promise<void> {
+		const row = this.#rows[this.#selected];
+		if (!row?.isCurrent) return;
+		try {
+			if (this.#gate.paused) this.#gate.release();
+			else this.#gate.engage();
+		} catch (error) {
+			this.#notice = error instanceof Error ? error.message : String(error);
+		}
+		void this.#refresh();
+	}
+
+	#beginKill(): void {
+		const row = this.#rows[this.#selected];
+		if (!row) return;
+		const display = sessionDisplayName(row.info);
+		if (row.isCurrent) {
+			this.#confirm = { kind: "killCurrent", path: row.info.path, display, step: 1 };
+		} else {
+			this.#confirm = { kind: "deleteSession", path: row.info.path, display, step: 1 };
+		}
+		this.#requestRender();
+	}
+
+	async #confirmAction(): Promise<void> {
+		const confirm = this.#confirm;
+		if (!confirm) return;
+		if (confirm.kind === "deleteSession" && confirm.step === 1) {
+			confirm.step = 2;
+			this.#requestRender();
+			return;
+		}
+		this.#confirm = undefined;
+		if (confirm.kind === "killCurrent") await this.#killCurrentSubagents();
+		else await this.#deleteSession(confirm.path);
+	}
+
+	async #killCurrentSubagents(): Promise<void> {
+		const running = this.#registry.list().filter(ref => ref.id !== MAIN_AGENT_ID && ref.status === "running");
+		for (const ref of running) {
+			try {
+				await this.#lifecycle.release(ref.id, undefined, { tombstone: true });
+			} catch (error) {
+				this.#notice = error instanceof Error ? error.message : String(error);
+			}
+		}
+		void this.#refresh();
+	}
+
+	async #deleteSession(path: string): Promise<void> {
+		try {
+			await this.#ctx.sessionManager.dropSession(path);
+			this.#notice = undefined;
+		} catch (error) {
+			this.#notice = error instanceof Error ? error.message : String(error);
+		}
+		void this.#refresh();
+	}
+
+	async #openSelected(): Promise<void> {
+		const row = this.#rows[this.#selected];
+		if (!row) return;
+		if (row.isCurrent) {
+			this.#close();
+			this.#ctx.showStatus("Already on this session");
+			return;
+		}
+		this.#close();
+		await this.#ctx.handleResumeSession(row.info.path);
+	}
+
+	#openCheckpoints(): void {
+		if (!this.#ui) return;
+		const row = this.#rows[this.#selected];
+		if (!row?.info.cwd) return;
+		const sessionId = row.info.id;
+		const cwd = row.info.cwd;
+		const ui = this.#ui;
+		const component = new CheckpointListComponent({
+			sessionId,
+			cwd,
+			ui,
+			requestRender: () => this.#requestRender(),
+			readOnly: true,
+			service: this.#checkpointService,
+			onClose: () => {
+				overlay?.hide();
+				ui.setFocus(component);
+				this.#requestRender();
+			},
+		});
+		const overlay = ui.showOverlay(component, { width: "100%", margin: 0, fullscreen: true });
+		ui.setFocus(component);
+	}
+
+	// --- rendering ---------------------------------------------------------
+
+	#headerTitle(width: number): string {
+		const filter = theme.fg("accent", `filter:${this.#filter}`);
+		const sort = theme.fg("accent", `sort:${this.#sort}`);
+		const title = `Sessions   ${filter}   ${sort}`;
+		return truncateToWidth(title, Math.max(1, width - 4));
+	}
+
+	#renderRows(width: number): string[] {
+		const showCost = width >= 140;
+		const showModel = width >= 110;
+		const showCwd = width >= 80;
+		const lines: string[] = [];
+		if (this.#rows.length === 0) {
+			lines.push(theme.fg("dim", "No sessions. Start a task or resume another session."));
+			return lines;
+		}
+		this.#rows.forEach((row, index) => {
+			lines.push(this.#renderRow(row, index === this.#selected, width, showCost, showModel, showCwd));
+		});
+		return lines;
+	}
+
+	#renderRow(
+		row: SessionRow,
+		selected: boolean,
+		width: number,
+		showCost: boolean,
+		showModel: boolean,
+		showCwd: boolean,
+	): string {
+		const cursor = selected ? theme.fg("accent", theme.nav.cursor) : " ";
+		const marker = row.isCurrent ? theme.fg("success", "●") : " ";
+		const name = sanitizeDisplayText(sessionDisplayName(row.info));
+		const leftParts = [`${cursor}${marker}`, name];
+		if (showCwd && row.info.cwd) {
+			leftParts.push(theme.fg("dim", shortenPath(row.info.cwd)));
+		}
+		if (showModel) {
+			const model = row.model ?? row.profile;
+			leftParts.push(theme.fg("muted", model ? sanitizeDisplayText(model) : "—"));
+		}
+		const left = leftParts.join(" ");
+
+		const rightParts: string[] = [];
+		if (row.isCurrent && row.agentCounts) {
+			const total = row.agentCounts.running + row.agentCounts.idle + row.agentCounts.parked;
+			rightParts.push(theme.fg("dim", `${total} agents`));
+		}
+		if (showCost) {
+			rightParts.push(
+				row.cost != null ? theme.fg("statusLineCost", `$${formatNumber(row.cost)}`) : theme.fg("dim", "—"),
+			);
+		}
+		rightParts.push(theme.fg("dim", formatAge(ageSeconds(row.info.modified.getTime()))));
+		rightParts.push(statusToken(row));
+		if (row.archived) rightParts.push(theme.fg("muted", "archived"));
+		const right = rightParts.join(theme.fg("dim", theme.sep.dot));
+
+		const leftW = visibleWidth(left);
+		const rightW = visibleWidth(right);
+		if (leftW + 2 + rightW <= width) {
+			return left + padding(width - leftW - rightW) + right;
+		}
+		return truncateToWidth(left, width);
+	}
+
+	#renderDetails(width: number): string[] {
+		const row = this.#rows[this.#selected];
+		if (!row) return [theme.fg("dim", "No session selected.")];
+		const info = row.info;
+		const sections: Array<[string, Array<[string, string]>]> = [
+			[
+				"Identity",
+				[
+					["id", info.id],
+					["title", sessionDisplayName(info)],
+					["cwd", info.cwd ? sanitizeDisplayText(info.cwd) : "—"],
+					["created", info.created.toISOString()],
+					["modified", info.modified.toISOString()],
+				],
+			],
+			[
+				"Models",
+				[
+					["model", row.model ?? "—"],
+					["profile", row.profile ?? "—"],
+				],
+			],
+			[
+				"Agents",
+				row.agentCounts
+					? [
+							["running", String(row.agentCounts.running)],
+							["idle", String(row.agentCounts.idle)],
+							["parked", String(row.agentCounts.parked)],
+						]
+					: [["agents", "—"]],
+			],
+			[
+				"Usage",
+				[
+					["cost", row.cost != null ? `$${formatNumber(row.cost)}` : "—"],
+					["tokens in", row.tokensIn != null ? formatNumber(row.tokensIn) : "—"],
+					["tokens out", row.tokensOut != null ? formatNumber(row.tokensOut) : "—"],
+				],
+			],
+			[
+				"Runtime",
+				[
+					["branch", row.branch ?? "—"],
+					["dirty", row.dirty ? `${row.dirty.staged}/${row.dirty.unstaged}/${row.dirty.untracked}` : "—"],
+					["state", row.isCurrent ? (row.liveState ?? "—") : (info.status ?? "—")],
+				],
+			],
+			[
+				"Recovery",
+				[
+					["checkpoints", String(this.#detailsCheckpoints?.length ?? row.checkpointCount ?? "—")],
+					[
+						"latest",
+						this.#detailsCheckpoints?.[0]
+							? sanitizeDisplayText(this.#detailsCheckpoints[0].label ?? this.#detailsCheckpoints[0].reason)
+							: "—",
+					],
+				],
+			],
+		];
+		const lines: string[] = [];
+		for (const [title, pairs] of sections) {
+			lines.push(theme.bold(theme.fg("accent", title)));
+			for (const [key, value] of pairs) {
+				lines.push(theme.fg("muted", `${key}: `) + value);
+			}
+			lines.push("");
+		}
+		return lines.slice(0, Math.max(1, width));
+	}
+
+	#confirmMessage(): string {
+		const confirm = this.#confirm!;
+		const target = theme.fg("error", sanitizeDisplayText(confirm.display));
+		if (confirm.kind === "killCurrent") {
+			return theme.fg(
+				"error",
+				`Kill all running subagents of ${target}? This cannot be undone.  y:confirm  n/Esc:cancel`,
+			);
+		}
+		if (confirm.step === 1) {
+			return theme.fg(
+				"error",
+				`Permanently delete the history of ${target} (no checkpoint restore). Press K again to confirm.  n/Esc:cancel`,
+			);
+		}
+		return theme.fg("error", `CONFIRM delete ${target}? This is irreversible.  y:delete  n/Esc:cancel`);
+	}
+
+	#footer(_width: number): string {
+		if (this.#confirm) return this.#confirmMessage();
+		if (this.#notice) return theme.fg("error", this.#notice);
+		return theme.fg(
+			"dim",
+			"↑/↓:nav  F:filter  S:sort  Enter:open  D:details  A:archive  P:pause  K:kill  R:resync  Esc:close",
+		);
+	}
+
+	#detailsFooter(_width: number): string {
+		return theme.fg("dim", "↑/↓:nav  C:checkpoints  D/Esc:back");
+	}
+}
+
+/** Relative age in whole seconds, floored at 1 so fresh rows don't read "0s". */
+function ageSeconds(modifiedMs: number): number {
+	return Math.max(1, Math.round((Date.now() - modifiedMs) / 1000));
+}
+
+/** One-line session name: title → first message → "Untitled · HH:MM". */
+function sessionDisplayName(info: { title?: string; firstMessage: string; created: Date; modified: Date }): string {
+	const title = info.title?.trim();
+	if (title) return title;
+	const first = info.firstMessage && info.firstMessage !== "(no messages)" ? info.firstMessage.trim() : undefined;
+	if (first) return first;
+	const ts = Number.isFinite(info.created.getTime()) ? info.created.getTime() : info.modified.getTime();
+	const time = new Date(ts).toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit" });
+	return `Untitled · ${time}`;
+}
+
+/** Compact colored status glyph + label for a row. */
+function statusToken(row: SessionRow): string {
+	if (row.isCurrent) {
+		switch (row.liveState) {
+			case "paused":
+				return theme.fg("warning", `${theme.status.pending} paused`);
+			case "idle":
+				return theme.fg("muted", `${theme.status.shadowed} idle`);
+			case "streaming":
+				return theme.fg("accent", `${theme.status.running} live`);
+			default:
+				return theme.fg("dim", "—");
+		}
+	}
+	switch (row.info.status) {
+		case "complete":
+			return theme.fg("success", `${theme.status.success} done`);
+		case "interrupted":
+			return theme.fg("warning", `${theme.status.warning} int`);
+		case "aborted":
+			return theme.fg("muted", `${theme.status.aborted} abrt`);
+		case "error":
+			return theme.fg("error", `${theme.status.error} err`);
+		case "pending":
+			return theme.fg("accent", `${theme.status.pending} pend`);
+		default:
+			return theme.fg("dim", "—");
+	}
+}

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -31,6 +31,7 @@ import {
 	getPluginsCacheDir,
 	MarketplaceManager,
 } from "../../extensibility/plugins/marketplace";
+import { SessionsManagerComponent } from "../../modes/components/sessions-manager";
 import {
 	getAvailableThemes,
 	getSymbolTheme,
@@ -453,6 +454,32 @@ export class SelectorController {
 			{ onCancel: () => done() },
 		);
 		overlayHandle = this.#showFullscreenMenu(hub);
+	}
+	/**
+	 * Fullscreen session manager on the alternate screen: list, open, archive,
+	 * pause, kill, and resume sessions. Resolves focus back to the editor when
+	 * the user closes it.
+	 */
+	async showSessionsDashboard(): Promise<void> {
+		let overlayHandle: OverlayHandle | undefined;
+		let manager: SessionsManagerComponent | undefined;
+		let closed = false;
+		const done = () => {
+			if (closed) return;
+			closed = true;
+			manager?.dispose();
+			overlayHandle?.hide();
+			this.focusActiveEditorArea();
+			this.ctx.ui.requestRender();
+		};
+		manager = new SessionsManagerComponent({
+			ctx: this.ctx,
+			ui: this.ctx.ui,
+			requestRender: () => this.ctx.ui.requestRender(),
+			onClose: done,
+			cwd: getProjectDir(),
+		});
+		overlayHandle = this.#showFullscreenMenu(manager);
 	}
 
 	/**

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -5427,6 +5427,9 @@ export class InteractiveMode implements InteractiveModeContext {
 	showAgentsDashboard(): void {
 		void this.#selectorController.showAgentsDashboard();
 	}
+	showSessionsDashboard(): void {
+		void this.#selectorController.showSessionsDashboard();
+	}
 	showGitUi(revision?: string): void {
 		void this.#selectorController.showGitTui(revision);
 	}

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -418,6 +418,8 @@ export interface InteractiveModeContext {
 	showHistorySearch(): void;
 	showExtensionsDashboard(): void;
 	showAgentsDashboard(): void;
+	sessionsManagerDashboard?(): void;
+	showSessionsDashboard(): void;
 	/** Open the fullscreen git UI, optionally pinned to a revision (`/git <rev>`). */
 	showGitUi(revision?: string): void;
 	showModelSelector(options?: { temporaryOnly?: boolean }): void;

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -101,6 +101,7 @@ import {
 import { type AdvisorConfig, type AdvisorRuntimeStatus, loadAdvisorTranscriptCosts } from "../advisor";
 import { ASYNC_JOB_MANAGER_SHUTDOWN_REASON, type AsyncJob, AsyncJobManager } from "../async";
 import { reset as resetCapabilities } from "../capability";
+import { emitInternalBeforeToolCall, registerAutoCheckpoints } from "../checkpoints/auto-trigger";
 import { shouldEnableAppendOnlyContext } from "../config/append-only-context-mode";
 import type { ModelRegistry } from "../config/model-registry";
 import type { ResolvedModelRoleValue } from "../config/model-resolver";
@@ -1441,6 +1442,13 @@ export class AgentSession {
 		// time so a block/revision lands before concurrency resolution,
 		// tool_execution_start, and the wrapper's approval gate.
 		this.agent.beforeToolCall = (ctx, signal) => this.#beforeToolCall(ctx, signal);
+		// Wire auto-checkpoint triggers (W2b). The subscription is process-wide and
+		// idempotent; it is inert until `checkpoints.*` settings enable it, so this
+		// unconditional call is safe on every session construction.
+		registerAutoCheckpoints({
+			getSessionId: () => this.sessionManager.getSessionId(),
+			getCwd: () => this.sessionManager.getCwd(),
+		});
 		this.agent.providerSessionState = this.#providerSessionState;
 		this.#syncAgentSessionId();
 		this.#todo.syncFromBranch();
@@ -3513,6 +3521,17 @@ export class AgentSession {
 	 * execution still emit there).
 	 */
 	async #beforeToolCall(ctx: BeforeToolCallContext, signal?: AbortSignal): Promise<BeforeToolCallResult | undefined> {
+		// Auto-checkpoint internal pre-tool hook (W2b). Runs before the extension
+		// `tool_call` emit so a destructive git op or risky edit captures a checkpoint
+		// *before* the tool mutates the workspace. Gated entirely at event time and
+		// failure-isolated, so it can never block or break the command it guards.
+		await emitInternalBeforeToolCall({
+			toolName: ctx.tool.name,
+			args: ctx.args,
+			cwd: this.sessionManager.getCwd(),
+			sessionId: this.sessionManager.getSessionId(),
+			signal,
+		});
 		const runner = this.#extensionRunner;
 		if (!runner?.hasHandlers("tool_call")) return undefined;
 		const metadata = ctx.toolCall.providerMetadata;

--- a/packages/coding-agent/src/session/session-control.ts
+++ b/packages/coding-agent/src/session/session-control.ts
@@ -1,0 +1,347 @@
+/**
+ * Session query/control layer for the future `/sessions` manager.
+ *
+ * `enumerateSessions` merges the persisted session listing (from
+ * {@link listAllSessions}/{@link listSessions}) with in-process truth that is
+ * knowable from this process only:
+ *   - the current session file (via injected deps, mirroring the AgentHubDeps
+ *     seam pattern),
+ *   - live agent counts + pause state from the process-global registry/gate,
+ *   - best-effort cost/token totals from the omp-stats DB,
+ *   - git branch/dirty state at each session's `cwd` when cheaply resolvable,
+ *   - an archive sentinel sidecar (`<sessionFile>.archived`) that never mutates
+ *     the foreign JSONL.
+ *
+ * Cross-process control is out of scope: only the current session is "live" in
+ * this process, so `liveState`/`agentCounts`/`model`/`profile` are populated
+ * for it alone. Anything not knowable is left `undefined` — the UI renders
+ * `—`, never a fabricated zero.
+ *
+ * Heavy best-effort reads (stats DB, git) are cached in-module keyed by
+ * `path@mtime`; {@link clearSessionMetricsCache} forces a refresh.
+ */
+
+import { existsSync, statSync } from "node:fs";
+import { getSessionSummaries as fetchSessionSummaries, type SessionSummary } from "@oh-my-pi/omp-stats";
+import { agentPauseGate } from "@oh-my-pi/pi-agent-core";
+import { settings, type Settings } from "../config/settings";
+import { AgentRegistry } from "../registry/agent-registry";
+import { branch as gitBranch, status as gitStatusCmd } from "../utils/git";
+import { listAllSessions, listSessions, type SessionInfo } from "./session-listing";
+import { FileSessionStorage } from "./session-storage";
+
+const ARCHIVED_SENTINEL_SUFFIX = ".archived";
+
+/** Minimal agent registry projection the layer reads. */
+interface AgentRegistryLike {
+	list(): Array<{ status: string }>;
+}
+
+/** Resolved git state for a working directory, or `undefined` when unavailable. */
+export interface GitRepoStatus {
+	branch: string | null;
+	dirty: { staged: number; unstaged: number; untracked: number };
+}
+
+/**
+ * Injected dependencies. Every field is optional and falls back to a production
+ * default (process-global registry/gate, the live SessionManager, the omp-stats
+ * DB, and a best-effort git resolver). Tests supply fakes to exercise the layer
+ * without touching the real registry, DB, or filesystem. Only the seams the
+ * contract requires are exposed: registry, gate, and current-session knowledge.
+ */
+export interface SessionControlDeps {
+	/** Process-global agent registry (defaults to `AgentRegistry.global()`). */
+	registry?: AgentRegistryLike;
+	/** Process-global pause gate (defaults to `agentPauseGate`). */
+	gate?: { readonly paused: boolean };
+	/** Live current session: its file path + model. Production supplies the running AgentSession. */
+	session?: { sessionFile?: string; model?: string };
+	/** Explicit override for the current session file (alternative to `session`). */
+	currentSessionFile?: string;
+	/** Override for the active profile (defaults to `settings.getActiveProfile()`). */
+	profile?: string;
+}
+
+/** A single enumerated session with merged in-process + best-effort metrics. */
+export interface SessionRow {
+	info: SessionInfo;
+	isCurrent: boolean;
+	archived: boolean;
+	/** Only for sessions live in THIS process (currently: the current one). */
+	liveState?: "streaming" | "idle" | "paused";
+	/** Registry-derived agent counts (this process only). */
+	agentCounts?: { running: number; idle: number; parked: number };
+	/** provider/model-id, current session only unless trivially available. */
+	model?: string;
+	/** `settings.getActiveProfile()`, current session only. */
+	profile?: string;
+	/** Best-effort omp-stats DB totals, any session. */
+	cost?: number;
+	tokensIn?: number;
+	tokensOut?: number;
+	/** Git branch at `info.cwd` when cheaply resolvable (`null` = detached). */
+	branch?: string | null;
+	dirty?: { staged: number; unstaged: number; untracked: number };
+	/** From the checkpoint service; undefined when unavailable/disabled. */
+	checkpointCount?: number;
+}
+
+export type SessionFilter = "current" | "active" | "paused" | "archived" | "all";
+export type SessionSort = "recent" | "created" | "cost" | "agents";
+
+export interface EnumerateOptions {
+	cwd: string;
+	sessionDir?: string;
+	includeAllProjects?: boolean;
+	/** Bounded race (ms) for the stats read; on timeout metrics stay undefined. */
+	statsTimeoutMs?: number;
+	/** Restrict the result set. Defaults to `"all"`. */
+	filter?: SessionFilter;
+	/** Order the result set. Defaults to `"recent"`. */
+	sort?: SessionSort;
+	/** Seams for testing and for callers that already hold live process state. */
+	deps?: SessionControlDeps;
+}
+
+interface CachedRowMetrics {
+	mtime: number;
+	cost?: number;
+	tokensIn?: number;
+	tokensOut?: number;
+	branch?: string | null;
+	dirty?: { staged: number; unstaged: number; untracked: number };
+	agentCounts?: { running: number; idle: number; parked: number };
+	liveState?: "streaming" | "idle" | "paused";
+}
+
+/** In-module cache of best-effort metrics, keyed by `path@mtime`. */
+const metricsCache = new Map<string, CachedRowMetrics>();
+
+/** Drop cached best-effort metrics. Call after a known data change. */
+export function clearSessionMetricsCache(): void {
+	metricsCache.clear();
+}
+
+function getMtime(filePath: string): number {
+	try {
+		return statSync(filePath).mtimeMs;
+	} catch {
+		return 0;
+	}
+}
+
+async function defaultGitResolver(cwd: string): Promise<GitRepoStatus | undefined> {
+	try {
+		const [summary, branchName] = await Promise.all([gitStatusCmd.summary(cwd), gitBranch.current(cwd)]);
+		if (!summary && branchName === null) return undefined;
+		return {
+			branch: branchName,
+			dirty: summary
+				? { staged: summary.staged, unstaged: summary.unstaged, untracked: summary.untracked }
+				: { staged: 0, unstaged: 0, untracked: 0 },
+		};
+	} catch {
+		return undefined;
+	}
+}
+
+function deriveLiveState(
+	registry: AgentRegistryLike,
+	gate: { readonly paused: boolean },
+): "streaming" | "idle" | "paused" {
+	if (gate.paused) return "paused";
+	const anyRunning = registry.list().some(ref => ref.status === "running");
+	return anyRunning ? "streaming" : "idle";
+}
+
+function countAgents(registry: AgentRegistryLike): { running: number; idle: number; parked: number } {
+	const counts = { running: 0, idle: 0, parked: 0 };
+	for (const ref of registry.list()) {
+		if (ref.status === "running") counts.running++;
+		else if (ref.status === "idle") counts.idle++;
+		else if (ref.status === "parked") counts.parked++;
+	}
+	return counts;
+}
+
+async function fetchSummaryMap(timeoutMs?: number): Promise<Map<string, SessionSummary>> {
+	try {
+		let summaries: SessionSummary[];
+		if (timeoutMs && timeoutMs > 0) {
+			const raced = await Promise.race([
+				fetchSessionSummaries(),
+				new Promise<undefined>(resolve => setTimeout(() => resolve(undefined), timeoutMs)),
+			]);
+			if (raced === undefined) return new Map();
+			summaries = raced;
+		} else {
+			summaries = await fetchSessionSummaries();
+		}
+		const map = new Map<string, SessionSummary>();
+		for (const summary of summaries) map.set(summary.sessionFile, summary);
+		return map;
+	} catch {
+		return new Map();
+	}
+}
+
+async function getBaseSessions(opts: EnumerateOptions): Promise<SessionInfo[]> {
+	const storage = new FileSessionStorage();
+	if (opts.sessionDir && !opts.includeAllProjects) {
+		return listSessions(opts.sessionDir, storage);
+	}
+	return listAllSessions(storage);
+}
+
+/**
+ * Enumerate sessions with merged in-process truth and best-effort metrics.
+ *
+ * Honors {@link EnumerateOptions.filter} and {@link EnumerateOptions.sort}.
+ */
+export async function enumerateSessions(opts: EnumerateOptions): Promise<SessionRow[]> {
+	const deps = opts.deps ?? {};
+	const registry: AgentRegistryLike = deps.registry ?? AgentRegistry.global();
+	const gate = deps.gate ?? agentPauseGate;
+	const currentSessionFile = deps.currentSessionFile ?? deps.session?.sessionFile ?? null;
+
+	const baseSessions = await getBaseSessions(opts);
+	const summaryMap = await fetchSummaryMap(opts.statsTimeoutMs);
+
+	const rows: SessionRow[] = [];
+	for (const info of baseSessions) {
+		const isCurrent = currentSessionFile !== null && info.path === currentSessionFile;
+		const archived = isArchived(info.path);
+		const mtime = getMtime(info.path);
+		const cacheKey = `${info.path}@${mtime}`;
+		const cached = metricsCache.get(cacheKey);
+
+		let cost: number | undefined;
+		let tokensIn: number | undefined;
+		let tokensOut: number | undefined;
+		let branch: string | null | undefined;
+		let dirty: { staged: number; unstaged: number; untracked: number } | undefined;
+		let agentCounts: { running: number; idle: number; parked: number } | undefined;
+		let liveState: "streaming" | "idle" | "paused" | undefined;
+
+		if (cached && cached.mtime === mtime) {
+			cost = cached.cost;
+			tokensIn = cached.tokensIn;
+			tokensOut = cached.tokensOut;
+			branch = cached.branch;
+			dirty = cached.dirty;
+			agentCounts = cached.agentCounts;
+			liveState = cached.liveState;
+		} else {
+			const summary = summaryMap.get(info.path);
+			if (summary) {
+				cost = summary.cost;
+				tokensIn = summary.inputTokens;
+				tokensOut = summary.outputTokens;
+			}
+			if (info.cwd) {
+				const git = await defaultGitResolver(info.cwd);
+				if (git) {
+					branch = git.branch;
+					dirty = git.dirty;
+				}
+			}
+			if (isCurrent) {
+				liveState = deriveLiveState(registry, gate);
+				agentCounts = countAgents(registry);
+			}
+			metricsCache.set(cacheKey, {
+				mtime,
+				cost,
+				tokensIn,
+				tokensOut,
+				branch,
+				dirty,
+				agentCounts,
+				liveState,
+			});
+		}
+
+		const row: SessionRow = {
+			info,
+			isCurrent,
+			archived,
+			liveState,
+			agentCounts,
+			cost,
+			tokensIn,
+			tokensOut,
+			branch,
+			dirty,
+		};
+
+		if (isCurrent) {
+			if (deps.session?.model !== undefined) row.model = deps.session.model;
+			const settingsWithProfile = settings as Settings & { getActiveProfile?: () => string };
+			const profile = deps.profile ?? (typeof settingsWithProfile.getActiveProfile === "function"
+				? settingsWithProfile.getActiveProfile()
+				: undefined);
+			if (profile) row.profile = profile;
+		}
+
+		rows.push(row);
+	}
+
+	return applySort(applyFilter(rows, opts.filter ?? "all"), opts.sort ?? "recent");
+}
+
+function applyFilter(rows: SessionRow[], filter: SessionFilter): SessionRow[] {
+	switch (filter) {
+		case "current":
+			return rows.filter(row => row.isCurrent);
+		case "archived":
+			return rows.filter(row => row.archived);
+		case "paused":
+			return rows.filter(row => row.liveState === "paused");
+		case "active":
+			return rows.filter(row => !row.archived);
+		default:
+			return rows;
+	}
+}
+
+function applySort(rows: SessionRow[], sort: SessionSort): SessionRow[] {
+	const copy = [...rows];
+	switch (sort) {
+		case "created":
+			copy.sort((a, b) => b.info.created.getTime() - a.info.created.getTime());
+			break;
+		case "cost":
+			copy.sort((a, b) => (b.cost ?? -Infinity) - (a.cost ?? -Infinity));
+			break;
+		case "agents": {
+			const total = (c: { running: number; idle: number; parked: number } | undefined) =>
+				c ? c.running + c.idle + c.parked : 0;
+			copy.sort((a, b) => total(b.agentCounts) - total(a.agentCounts));
+			break;
+		}
+		default:
+			copy.sort((a, b) => b.info.modified.getTime() - a.info.modified.getTime());
+			break;
+	}
+	return copy;
+}
+
+/**
+ * Write or remove the archive sentinel for a session. The sentinel is an empty
+ * sidecar file `<sessionFile>.archived`; the JSONL is never mutated, so the
+ * operation is cross-process safe and reversible.
+ */
+export async function setArchived(sessionPath: string, archived: boolean): Promise<void> {
+	const sentinel = sessionPath + ARCHIVED_SENTINEL_SUFFIX;
+	if (archived) {
+		await Bun.write(sentinel, "");
+	} else {
+		await Bun.file(sentinel).delete();
+	}
+}
+
+/** Whether the archive sentinel exists for a session. */
+export function isArchived(sessionPath: string): boolean {
+	return existsSync(sessionPath + ARCHIVED_SENTINEL_SUFFIX);
+}

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -13,6 +13,7 @@ import { BUILTIN_LIFECYCLE_SLASH_COMMANDS } from "./builtin-lifecycle";
 import { BUILTIN_MARKETPLACE_SLASH_COMMANDS, reloadTuiPluginState } from "./builtin-marketplace";
 import { BUILTIN_MODE_SLASH_COMMANDS } from "./builtin-modes";
 import { BUILTIN_SESSION_SLASH_COMMANDS } from "./builtin-session";
+import { BUILTIN_WORKSPACE_SLASH_COMMANDS } from "./builtin-workspace";
 import { parseSlashCommand } from "./helpers/parse";
 import type {
 	BuiltinSlashCommand,
@@ -41,6 +42,7 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 	...BUILTIN_LIFECYCLE_SLASH_COMMANDS,
 	...BUILTIN_MARKETPLACE_SLASH_COMMANDS,
 	...BUILTIN_CONTROL_SLASH_COMMANDS,
+	...BUILTIN_WORKSPACE_SLASH_COMMANDS,
 ];
 
 const BUILTIN_SLASH_COMMAND_LOOKUP = new Map<string, SlashCommandSpec>();

--- a/packages/coding-agent/src/slash-commands/builtin-session.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-session.ts
@@ -190,6 +190,11 @@ export const BUILTIN_SESSION_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> = [
 				description: "Pin the current provider to a stored OAuth account",
 				usage: "[account]",
 			},
+			{
+				name: "rename",
+				description: "Rename the current session",
+				usage: "<name>",
+			},
 		],
 		allowArgs: true,
 		handle: async (command, runtime) => {
@@ -227,7 +232,20 @@ export const BUILTIN_SESSION_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> = [
 				await handleSessionPinCommand(rest, runtime.session, runtime.output);
 				return commandConsumed();
 			}
-			return usage("Usage: /session [info|delete|pin [account]]", runtime);
+			if (verb === "rename") {
+				const name = rest.trim();
+				if (!name) return usage("Usage: /session rename <name>", runtime);
+				let ok = false;
+				try {
+					ok = await runtime.sessionManager.setSessionName(name, "user");
+				} catch (err) {
+					return usage(`Failed to rename session: ${errorMessage(err)}`, runtime);
+				}
+				if (!ok) return usage("Failed to rename session.", runtime);
+				await runtime.output(`Session renamed to "${name}".`);
+				return commandConsumed();
+			}
+			return usage("Usage: /session [info|delete|pin [account]|rename <name>]", runtime);
 		},
 		handleTui: async (command, runtime) => {
 			const { verb, rest } = parseSubcommand(command.args);
@@ -246,10 +264,21 @@ export const BUILTIN_SESSION_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> = [
 				runtime.ctx.editor.setText("");
 				return;
 			}
+			if (verb === "rename") {
+				const name = rest.trim();
+				if (!name) {
+					runtime.ctx.showStatus("Usage: /session rename <name>");
+				} else {
+					await runtime.ctx.sessionManager.setSessionName(name, "user");
+					runtime.ctx.showStatus(`Session renamed to "${name}".`);
+				}
+				runtime.ctx.editor.setText("");
+				return;
+			}
 			if (!verb || (verb === "info" && !rest)) {
 				await runtime.ctx.handleSessionCommand();
 			} else {
-				runtime.ctx.showStatus("Usage: /session [info|delete|pin [account]]");
+				runtime.ctx.showStatus("Usage: /session [info|delete|pin [account]|rename <name>]");
 			}
 			runtime.ctx.editor.setText("");
 		},

--- a/packages/coding-agent/src/slash-commands/builtin-workspace.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-workspace.ts
@@ -1,0 +1,347 @@
+/**
+ * Workspace session/checkpoint/rollback builtins.
+ *
+ * - `/sessions` — opens the fullscreen session manager (TUI) or prints a
+ *   top-N text table (text/ACP).
+ * - `/checkpoint` — create/list/show git-backed workspace checkpoints.
+ * - `/rollback` — restore the workspace to a checkpoint (direct in text/ACP;
+ *   interactive selector in TUI).
+ *
+ * The create/list/show and direct-rollback logic is exported as pure-ish
+ * command functions (`runCheckpointCommand`, `runRollbackCommand`) so they can
+ * be exercised against an injected checkpoint service + output sink.
+ */
+import * as path from "node:path";
+import { formatAge, formatNumber } from "@oh-my-pi/pi-utils";
+import {
+	type CheckpointMeta,
+	WorkspaceCheckpointService as DefaultCheckpointService,
+	type WorkspaceCheckpointService,
+	type WorkspaceRollbackSessionSurface,
+} from "../checkpoints";
+import { isSettingsInitialized, settings } from "../config/settings";
+import { CheckpointListComponent } from "../modes/components/checkpoint-list";
+import type { InteractiveModeContext } from "../modes/types";
+import { enumerateSessions, type SessionRow } from "../session/session-control";
+import { commandConsumed } from "./helpers/parse";
+import type { SlashCommandRuntime, SlashCommandSpec } from "./types";
+
+const ENABLE_HINT = "Checkpoints are disabled. Enable with: /config set checkpoints.enabled true";
+
+function ageSeconds(modifiedMs: number): number {
+	return Math.max(1, Math.round((Date.now() - modifiedMs) / 1000));
+}
+
+function displayName(row: SessionRow): string {
+	const title = row.info.title?.trim();
+	if (title) return title;
+	const first = row.info.firstMessage && row.info.firstMessage !== "(no messages)" ? row.info.firstMessage.trim() : "";
+	return first || "Untitled";
+}
+
+// ===========================================================================
+// /checkpoint
+// ===========================================================================
+
+export interface CheckpointCommandDeps {
+	sessionId: string;
+	cwd: string;
+	output: (text: string) => void | Promise<void>;
+	service?: WorkspaceCheckpointService;
+	/** Whether `checkpoints.enabled` is on. Defaults to true. */
+	enabled?: boolean;
+}
+
+/** Run the `/checkpoint` command. Headless-safe (no TUI state). */
+export async function runCheckpointCommand(args: string, deps: CheckpointCommandDeps): Promise<void> {
+	const service = deps.service ?? DefaultCheckpointService.global();
+	const trimmed = args.trim();
+	const verb = trimmed.split(/\s+/, 1)[0]?.toLowerCase() ?? "";
+
+	if (deps.enabled === false) {
+		await deps.output(ENABLE_HINT);
+		return;
+	}
+
+	try {
+		if (verb === "list") {
+			await listCheckpoints(service, deps, trimmed.slice("list".length).trim());
+			return;
+		}
+		if (verb === "show") {
+			await showCheckpoint(service, deps, trimmed.slice("show".length).trim());
+			return;
+		}
+		await createCheckpoint(service, deps, trimmed);
+	} catch (error) {
+		await deps.output(`Checkpoint error: ${error instanceof Error ? error.message : String(error)}`);
+	}
+}
+
+async function createCheckpoint(
+	service: WorkspaceCheckpointService,
+	deps: CheckpointCommandDeps,
+	rest: string,
+): Promise<void> {
+	const label = rest.replace(/^["']|["']$/g, "").trim() || undefined;
+	const before = await service.latest(deps.sessionId, deps.cwd);
+	const meta = await service.create({
+		sessionId: deps.sessionId,
+		cwd: deps.cwd,
+		reason: "manual",
+		label,
+	});
+	if (before && before.id === meta.id) {
+		await deps.output(`Checkpoint ${meta.id} already current (unchanged)`);
+		return;
+	}
+	const secondLine = meta.label ? `label: ${meta.label}` : `reason: ${meta.reason}`;
+	await deps.output(`Checkpoint ${meta.id} created\n${secondLine}`);
+}
+
+async function listCheckpoints(
+	service: WorkspaceCheckpointService,
+	deps: CheckpointCommandDeps,
+	_idPrefix: string,
+): Promise<void> {
+	const metas = await service.list(deps.sessionId, deps.cwd);
+	if (metas.length === 0) {
+		await deps.output("No checkpoints for this session.");
+		return;
+	}
+	const lines = ["Checkpoints (newest first):"];
+	for (const meta of metas) {
+		const age = formatAge(ageSeconds(new Date(meta.createdAt).getTime()));
+		const bytes = meta.bytesCaptured > 0 ? `${formatNumber(meta.bytesCaptured)} B` : "—";
+		lines.push(`${meta.id}  ${meta.label ?? meta.reason}  ${age}  ${bytes}`);
+	}
+	await deps.output(lines.join("\n"));
+}
+
+async function showCheckpoint(
+	service: WorkspaceCheckpointService,
+	deps: CheckpointCommandDeps,
+	idPrefix: string,
+): Promise<void> {
+	if (!idPrefix) {
+		await deps.output("Usage: /checkpoint show <id-prefix>");
+		return;
+	}
+	const meta = await service.get(deps.sessionId, deps.cwd, idPrefix);
+	if (!meta) {
+		await deps.output(`No checkpoint matches "${idPrefix}".`);
+		return;
+	}
+	const created = new Date(meta.createdAt);
+	const lines = [
+		`Checkpoint ${meta.id}`,
+		`  reason: ${meta.reason}`,
+		`  label: ${meta.label ?? "—"}`,
+		`  created: ${created.toISOString()}`,
+		`  bytes captured: ${meta.bytesCaptured > 0 ? formatNumber(meta.bytesCaptured) : "—"}`,
+		`  skipped files: ${meta.skippedFiles.length}`,
+		`  repo: ${meta.identity.repoRoot}`,
+		`  worktree: ${meta.identity.worktreePath}`,
+		`  head: ${meta.headShaAtCapture ?? "—"}`,
+		`  tree: ${meta.treeSha}`,
+	];
+	await deps.output(lines.join("\n"));
+}
+
+// ===========================================================================
+// /rollback
+// ===========================================================================
+
+export interface RollbackCommandDeps {
+	sessionId: string;
+	cwd: string;
+	output: (text: string) => void | Promise<void>;
+	service?: WorkspaceCheckpointService;
+	/** Surface notified after a successful rollback (transcript entry). */
+	notify?: WorkspaceRollbackSessionSurface;
+	/** Optional status line (TUI). */
+	showStatus?: (text: string) => void;
+}
+
+/** Run `/rollback <id-prefix>` directly. Headless-safe. */
+export async function runRollbackCommand(args: string, deps: RollbackCommandDeps): Promise<void> {
+	const service = deps.service ?? DefaultCheckpointService.global();
+	const idPrefix = args.trim();
+	if (!idPrefix) {
+		await deps.output("Usage: /rollback <checkpoint-id-prefix>");
+		return;
+	}
+	try {
+		const meta = await service.get(deps.sessionId, deps.cwd, idPrefix);
+		if (!meta) {
+			await deps.output(`No checkpoint matches "${idPrefix}".`);
+			return;
+		}
+		const result = await service.rollback(meta, {
+			sessionId: deps.sessionId,
+			cwd: deps.cwd,
+			notify: deps.notify,
+		});
+		if (!result.ok) {
+			await deps.output(`Rollback failed: ${result.error ?? "unknown error"}`);
+			return;
+		}
+		const lines = [
+			`Rolled back to checkpoint ${meta.id}`,
+			`Restored files: ${result.restoredFiles}`,
+			`Removed files: ${result.removedFiles}`,
+			`Safety checkpoint: ${result.safetyCheckpoint?.id ?? "—"}`,
+		];
+		await deps.output(lines.join("\n"));
+		deps.showStatus?.(`Rolled back to ${meta.id}. Run /checkpoint list to inspect.`);
+	} catch (error) {
+		await deps.output(`Rollback error: ${error instanceof Error ? error.message : String(error)}`);
+	}
+}
+
+// ===========================================================================
+// Slash command specs
+// ===========================================================================
+
+function checkpointEnabled(): boolean {
+	return isSettingsInitialized() ? Boolean(settings.get("checkpoints.enabled")) : false;
+}
+
+function openRollbackOverlay(ctx: InteractiveModeContext): void {
+	const sessionId = ctx.session.sessionId;
+	const cwd = ctx.sessionManager.getCwd();
+	const service = DefaultCheckpointService.global();
+	const component = new CheckpointListComponent({
+		sessionId,
+		cwd,
+		ui: ctx.ui,
+		requestRender: () => ctx.ui.requestRender(),
+		service,
+		onRollback: async (meta: CheckpointMeta) => {
+			const result = await service.rollback(meta, { sessionId, cwd, notify: ctx.sessionManager });
+			if (!result.ok) {
+				ctx.showStatus(`Rollback failed: ${result.error ?? "unknown error"}`);
+				return;
+			}
+			ctx.showStatus(
+				`Rolled back to ${meta.id} (restored ${result.restoredFiles}, removed ${result.removedFiles}). Run /checkpoint list to inspect.`,
+			);
+		},
+		onClose: () => {
+			overlay?.hide();
+			ctx.ui.requestRender();
+		},
+	});
+	const overlay = ctx.ui.showOverlay(component, { width: "100%", margin: 0, fullscreen: true });
+	ctx.ui.setFocus(component);
+}
+
+export const BUILTIN_WORKSPACE_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> = [
+	{
+		name: "sessions",
+		icon: "session",
+		description: "Manage sessions: open, archive, pause, kill, resume",
+		handle: async (_command, runtime: SlashCommandRuntime) => {
+			const cwd = runtime.cwd;
+			const sessionFile = runtime.sessionManager.getSessionFile();
+			const sessionDir = sessionFile ? path.dirname(sessionFile) : undefined;
+			const rows = await enumerateSessions({ cwd, sessionDir, filter: "all", sort: "recent" });
+			const top = rows.slice(0, 20);
+			if (top.length === 0) {
+				await runtime.output("No sessions found.");
+				return commandConsumed();
+			}
+			const lines = ["Sessions:"];
+			for (const row of top) {
+				const state = row.isCurrent ? (row.liveState ?? "current") : (row.info.status ?? "-");
+				const age = formatAge(ageSeconds(row.info.modified.getTime()));
+				const cost = row.cost != null ? `$${formatNumber(row.cost)}` : "-";
+				lines.push(`${row.isCurrent ? "*" : " "} ${displayName(row)}  ${state}  ${age}  ${cost}`);
+			}
+			await runtime.output(lines.join("\n"));
+			return commandConsumed();
+		},
+		handleTui: async (_command, runtime) => {
+			runtime.ctx.showSessionsDashboard();
+			runtime.ctx.editor.setText("");
+		},
+	},
+	{
+		name: "checkpoint",
+		icon: "compress",
+		description: "Create, list, or inspect a workspace checkpoint",
+		allowArgs: true,
+		acpDescription: "Create, list, or inspect a workspace checkpoint",
+		acpInputHint: "[<label>] | list | show <id>",
+		handle: async (command, runtime: SlashCommandRuntime) => {
+			await runCheckpointCommand(command.args, {
+				sessionId: runtime.session.sessionId,
+				cwd: runtime.cwd,
+				output: runtime.output,
+				enabled: checkpointEnabled(),
+			});
+			return commandConsumed();
+		},
+		handleTui: async (command, runtime) => {
+			await runCheckpointCommand(command.args, {
+				sessionId: runtime.ctx.session.sessionId,
+				cwd: runtime.ctx.sessionManager.getCwd(),
+				output: text => runtime.ctx.showStatus(text),
+				enabled: checkpointEnabled(),
+			});
+			runtime.ctx.editor.setText("");
+		},
+	},
+	{
+		name: "rollback",
+		icon: "history",
+		description: "Roll the workspace back to a checkpoint",
+		allowArgs: true,
+		acpDescription: "Roll the workspace back to a checkpoint",
+		acpInputHint: "<checkpoint-id-prefix>",
+		handle: async (command, runtime: SlashCommandRuntime) => {
+			await runRollbackCommand(command.args, {
+				sessionId: runtime.session.sessionId,
+				cwd: runtime.cwd,
+				output: runtime.output,
+				notify: runtime.sessionManager,
+				showStatus: text => runtime.output(text),
+			});
+			return commandConsumed();
+		},
+		handleTui: async (command, runtime) => {
+			const args = command.args.trim();
+			if (!args) {
+				openRollbackOverlay(runtime.ctx);
+				runtime.ctx.editor.setText("");
+				return;
+			}
+			const sessionId = runtime.ctx.session.sessionId;
+			const cwd = runtime.ctx.sessionManager.getCwd();
+			const service = DefaultCheckpointService.global();
+			const meta = await service.get(sessionId, cwd, args);
+			if (!meta) {
+				runtime.ctx.showStatus(`No checkpoint matches "${args}".`);
+				runtime.ctx.editor.setText("");
+				return;
+			}
+			const ok = await runtime.ctx.showHookConfirm(
+				"Rollback workspace",
+				`Roll back to checkpoint ${meta.id} (${meta.label ?? meta.reason})? A safety checkpoint of the current state is created first.`,
+			);
+			if (!ok) {
+				runtime.ctx.showStatus("Rollback cancelled");
+				runtime.ctx.editor.setText("");
+				return;
+			}
+			await runRollbackCommand(args, {
+				sessionId,
+				cwd,
+				output: text => runtime.ctx.showStatus(text),
+				notify: runtime.ctx.sessionManager,
+				showStatus: text => runtime.ctx.showStatus(text),
+			});
+			runtime.ctx.editor.setText("");
+		},
+	},
+];

--- a/packages/coding-agent/src/utils/git.ts
+++ b/packages/coding-agent/src/utils/git.ts
@@ -147,6 +147,38 @@ export interface CloneOptions {
 	readonly timeoutMs?: number;
 }
 
+export interface TreeCaptureOptions {
+	/**
+	 * Worktree-root-relative paths omitted from the snapshot (oversize guard).
+	 * Sent as literal exclude pathspecs, so glob metacharacters in a filename
+	 * are matched as themselves.
+	 */
+	readonly excludePaths?: readonly string[];
+	readonly signal?: AbortSignal;
+}
+
+export interface CommitTreeOptions {
+	readonly author?: CommitAuthor;
+	readonly message: string;
+	readonly parents?: readonly string[];
+	readonly signal?: AbortSignal;
+}
+
+/** `git diff-tree --name-status` status letter, restricted to what two trees can produce. */
+export type TreeDiffStatus = "A" | "D" | "M" | "T";
+
+export interface TreeDiffEntry {
+	readonly path: string;
+	readonly status: TreeDiffStatus;
+}
+
+export interface TreeBlobEntry {
+	readonly oid: string;
+	readonly path: string;
+	/** Blob size in bytes as recorded in the object database. */
+	readonly size: number;
+}
+
 interface GitHeadBase extends GitRepository {
 	headContent: string;
 }
@@ -269,6 +301,21 @@ export const GIT_SPAWN_SYNC_TIMEOUT_MS = 5_000;
  * always-on status line cheap while surfacing a branch switch within a second.
  */
 export const HEAD_WATCH_INTERVAL_MS = 1000;
+
+/**
+ * Pathspec batch size for {@link restorePathsFromTree}. Keeps a rollback of a
+ * multi-thousand-file change set inside every platform's argument-list limit
+ * without paying a subprocess per file.
+ */
+const SNAPSHOT_PATHSPEC_BATCH = 256;
+
+/**
+ * Output cap for {@link ls.treeBlobs}. `ls-tree -r -l` emits ~60 bytes plus the
+ * path per file, so the default 8 MiB cap would silently truncate — and thus
+ * undercount snapshot bytes — around 100k files. 64 MiB covers trees an order of
+ * magnitude larger.
+ */
+const SNAPSHOT_LS_TREE_OUTPUT_LIMIT_BYTES = 64 * 1024 * 1024;
 
 const GIT_COMMAND_TIMEOUT_EXIT_CODE = 124;
 // Exit code returned when the `git` binary cannot be launched at all (spawn
@@ -1380,6 +1427,27 @@ function parseStatusPorcelain(text: string): GitStatusSummary {
 	return { staged, unstaged, untracked };
 }
 
+const TREE_DIFF_STATUSES: readonly TreeDiffStatus[] = ["A", "D", "M", "T"];
+
+/**
+ * Parse NUL-delimited `diff-tree --name-status -z` output. The stream alternates
+ * status field / path field; unknown status letters (copy/rename records, which
+ * `--no-renames` suppresses) are dropped rather than guessed at.
+ */
+function parseTreeNameStatus(text: string): TreeDiffEntry[] {
+	const fields = text.split("\0");
+	const entries: TreeDiffEntry[] = [];
+	for (let index = 0; index + 1 < fields.length; index += 2) {
+		const status = fields[index];
+		const entryPath = fields[index + 1];
+		if (!status || !entryPath) continue;
+		const letter = status[0] as TreeDiffStatus;
+		if (!TREE_DIFF_STATUSES.includes(letter)) continue;
+		entries.push({ path: entryPath, status: letter });
+	}
+	return entries;
+}
+
 // ════════════════════════════════════════════════════════════════════════════
 // API: diff
 // ════════════════════════════════════════════════════════════════════════════
@@ -1444,6 +1512,25 @@ export const diff = Object.assign(
 				return (await git(cwd, args, { readOnly: true, signal: options.signal })).stdout;
 			}
 			return runText(cwd, args, { readOnly: true, signal: options.signal });
+		},
+		/**
+		 * Per-path change set between two tree-ish objects
+		 * (`git diff-tree --name-status`). Rename detection is off, so a rename
+		 * reads as delete + add: rollback needs the literal per-path set, not a
+		 * similarity-based summary. NUL-delimited, so paths with newlines or
+		 * quotes survive intact.
+		 */
+		async treeStatus(
+			cwd: string,
+			base: string,
+			target: string,
+			options: { signal?: AbortSignal } = {},
+		): Promise<TreeDiffEntry[]> {
+			const raw = await runText(cwd, ["diff-tree", "-r", "-z", "--no-renames", "--name-status", base, target], {
+				readOnly: true,
+				signal: options.signal,
+			});
+			return parseTreeNameStatus(raw);
 		},
 		/** Parse raw diff text into per-file diffs. */
 		parseFiles(text: string): FileDiff[] {
@@ -1531,6 +1618,23 @@ export const stage = {
 		const args = files.length === 0 ? ["reset"] : ["reset", "--", ...files];
 		await runEffect(cwd, args, { signal });
 	},
+
+	/**
+	 * Drop index entries for `files` without touching the working tree
+	 * (`git rm --cached`). Paths absent from the index are ignored, so a caller
+	 * removing a mixed tracked/untracked set needs no pre-classification.
+	 * Pathspecs are literal and batched.
+	 */
+	async removeCached(cwd: string, files: readonly string[], signal?: AbortSignal): Promise<void> {
+		for (let index = 0; index < files.length; index += SNAPSHOT_PATHSPEC_BATCH) {
+			const batch = files.slice(index, index + SNAPSHOT_PATHSPEC_BATCH);
+			await runEffect(
+				cwd,
+				["--literal-pathspecs", "rm", "--cached", "--quiet", "--ignore-unmatch", "--", ...batch],
+				{ signal },
+			);
+		}
+	},
 };
 
 // ════════════════════════════════════════════════════════════════════════════
@@ -1595,6 +1699,82 @@ export async function readTree(
 /** Write the current index as a tree and return its object id. */
 export async function writeTree(cwd: string, options: Pick<CommandOptions, "env" | "signal"> = {}): Promise<string> {
 	return (await runText(cwd, ["write-tree"], options)).trim();
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// API: snapshot plumbing (workspace checkpoints)
+// ════════════════════════════════════════════════════════════════════════════
+
+/**
+ * Snapshot the full working tree of `worktreeRoot` into a tree object without
+ * touching the repository's real index, HEAD, or working tree.
+ *
+ * The staging happens in a throwaway index (`GIT_INDEX_FILE`), so a concurrent
+ * `git add`/commit by the user cannot collide with the capture and the capture
+ * cannot clobber the user's staged state. `.gitignore` is honored (`git add -A`
+ * never picks ignored paths up), so ignored build output is never snapshotted.
+ *
+ * `worktreeRoot` MUST be the worktree root: the positive pathspec is `.`, which
+ * is what makes exclude pathspecs usable alongside it.
+ */
+export async function captureWorktreeTree(worktreeRoot: string, options: TreeCaptureOptions = {}): Promise<string> {
+	const indexFile = path.join(os.tmpdir(), `omp-git-snapshot-index-${Snowflake.next()}`);
+	const env = { GIT_INDEX_FILE: indexFile };
+	const args = ["add", "--all", "--", "."];
+	for (const excluded of options.excludePaths ?? []) args.push(`:(exclude,literal)${excluded}`);
+	try {
+		await runEffect(worktreeRoot, args, { env, signal: options.signal });
+		return await writeTree(worktreeRoot, { env, signal: options.signal });
+	} finally {
+		// The temp index and its lock are ours alone; leaking the pair would waste
+		// disk for every capture over the process lifetime.
+		await fs.promises.rm(indexFile, { force: true }).catch(() => {});
+		await fs.promises.rm(`${indexFile}.lock`, { force: true }).catch(() => {});
+	}
+}
+
+/**
+ * Wrap a tree in a commit object (`git commit-tree`) without moving HEAD or any
+ * branch. Author/committer identity is passed explicitly so the call succeeds in
+ * repositories where the user has no configured `user.name`/`user.email`.
+ */
+export async function commitTree(cwd: string, treeSha: string, options: CommitTreeOptions): Promise<string> {
+	const args = ["commit-tree", treeSha];
+	for (const parent of options.parents ?? []) args.push("-p", parent);
+	const identityEnv = options.author
+		? {
+				GIT_AUTHOR_NAME: options.author.name,
+				GIT_AUTHOR_EMAIL: options.author.email,
+				GIT_COMMITTER_NAME: options.author.name,
+				GIT_COMMITTER_EMAIL: options.author.email,
+				...(options.author.date
+					? { GIT_AUTHOR_DATE: options.author.date, GIT_COMMITTER_DATE: options.author.date }
+					: {}),
+			}
+		: {};
+	const result = await runText(cwd, args, { env: identityEnv, signal: options.signal, stdin: options.message });
+	return result.trim();
+}
+
+/**
+ * Restore `files` from a tree-ish into both the working tree and the index.
+ * Pathspecs are sent literally (a file named `*.txt` is one path, not a glob)
+ * and batched so a large change set cannot overflow the argument list.
+ */
+export async function restorePathsFromTree(
+	cwd: string,
+	treeish: string,
+	files: readonly string[],
+	options: { signal?: AbortSignal } = {},
+): Promise<void> {
+	for (let index = 0; index < files.length; index += SNAPSHOT_PATHSPEC_BATCH) {
+		const batch = files.slice(index, index + SNAPSHOT_PATHSPEC_BATCH);
+		await runEffect(
+			cwd,
+			["--literal-pathspecs", "restore", `--source=${treeish}`, "--staged", "--worktree", "--", ...batch],
+			{ signal: options.signal },
+		);
+	}
 }
 
 // ════════════════════════════════════════════════════════════════════════════
@@ -2071,6 +2251,40 @@ export const ref = {
 			),
 		);
 	},
+
+	/**
+	 * Point `refName` at `sha` (`git update-ref`). Creates the ref when absent.
+	 * Mutates repository state: hold {@link withRepoLock} around the call.
+	 */
+	async update(cwd: string, refName: string, sha: string, signal?: AbortSignal): Promise<void> {
+		await runEffect(cwd, ["update-ref", refName, sha], { signal });
+	},
+
+	/**
+	 * Delete `refName` (`git update-ref -d`). Missing refs are not an error, so
+	 * cleanup paths stay idempotent. Mutates repository state: hold
+	 * {@link withRepoLock} around the call.
+	 */
+	async delete(cwd: string, refName: string, signal?: AbortSignal): Promise<void> {
+		const result = await git(cwd, ["update-ref", "-d", refName], { signal });
+		if (result.exitCode === 0) return;
+		if (await ref.exists(cwd, refName, signal)) throw new GitCommandError(["update-ref", "-d", refName], result);
+	},
+
+	/** Refs under `prefix` with the object each points at (`git for-each-ref`). */
+	async list(cwd: string, prefix: string, signal?: AbortSignal): Promise<{ refName: string; sha: string }[]> {
+		const raw = await runText(cwd, ["for-each-ref", "--format=%(refname)%00%(objectname)", prefix], {
+			readOnly: true,
+			signal,
+		});
+		const refs: { refName: string; sha: string }[] = [];
+		for (const line of raw.split("\n")) {
+			if (!line) continue;
+			const [refName, sha] = line.split("\0");
+			if (refName && sha) refs.push({ refName, sha });
+		}
+		return refs;
+	},
 };
 
 // ════════════════════════════════════════════════════════════════════════════
@@ -2431,6 +2645,33 @@ export const ls = {
 		if (files.length > 0) args.push("--", ...files);
 		const raw = await runText(cwd, args, { readOnly: true, signal });
 		return raw.split("\0").filter(entry => entry.length > 0);
+	},
+
+	/**
+	 * Every blob in a tree with its recorded object size (`ls-tree -r -l`). One
+	 * subprocess answers "how many bytes does this snapshot represent", which is
+	 * what checkpoint disk accounting needs; `cat-file --batch-check` would cost
+	 * a round trip per path for the same numbers.
+	 */
+	async treeBlobs(cwd: string, treeish: string, signal?: AbortSignal): Promise<TreeBlobEntry[]> {
+		const raw = await runText(cwd, ["ls-tree", "-r", "-l", "-z", treeish], {
+			maxOutputBytes: SNAPSHOT_LS_TREE_OUTPUT_LIMIT_BYTES,
+			readOnly: true,
+			signal,
+		});
+		const entries: TreeBlobEntry[] = [];
+		for (const record of raw.split("\0")) {
+			if (!record) continue;
+			// "<mode> <type> <oid> <size>\t<path>"; size is "-" for non-blobs.
+			const tabIndex = record.indexOf("\t");
+			if (tabIndex < 0) continue;
+			const fields = record.slice(0, tabIndex).split(/\s+/);
+			const [, type, oid, rawSize] = fields;
+			if (type !== "blob" || !oid) continue;
+			const size = Number.parseInt(rawSize ?? "", 10);
+			entries.push({ oid, path: record.slice(tabIndex + 1), size: Number.isFinite(size) ? size : 0 });
+		}
+		return entries;
 	},
 
 	/** List submodule paths (recursive). */

--- a/packages/coding-agent/test/checkpoint-rollback-commands.test.ts
+++ b/packages/coding-agent/test/checkpoint-rollback-commands.test.ts
@@ -1,0 +1,214 @@
+/**
+ * `/checkpoint` and `/rollback` command handlers (text/ACP + headless-safe).
+ *
+ * Exercises the exported `runCheckpointCommand` / `runRollbackCommand` against
+ * a real git repo + overridden checkpoint metadata root, mirroring the
+ * workspace-checkpoints fixture setup.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { removeWithRetries } from "@oh-my-pi/pi-utils";
+import { $ } from "bun";
+import { WorkspaceCheckpointService, type WorkspaceRollbackSessionSurface } from "../src/checkpoints";
+import { runCheckpointCommand, runRollbackCommand } from "../src/slash-commands/builtin-workspace";
+
+interface Workspace {
+	repoDir: string;
+	metadataRoot: string;
+	service: WorkspaceCheckpointService;
+}
+
+const workspaces: string[] = [];
+
+async function makeWorkspace(): Promise<Workspace> {
+	const repoDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-cmd-repo-"));
+	const metadataRoot = await fs.mkdtemp(path.join(os.tmpdir(), "omp-cmd-meta-"));
+	workspaces.push(repoDir, metadataRoot);
+	const init = await $`git init --initial-branch=main`.cwd(repoDir).quiet().nothrow();
+	if (init.exitCode !== 0) throw new Error(`git init failed (exit ${init.exitCode})`);
+	await $`git config user.name "Command Test"`.cwd(repoDir).quiet();
+	await $`git config user.email "commands@example.com"`.cwd(repoDir).quiet();
+	await Bun.write(path.join(repoDir, "tracked.txt"), "original\n");
+	await $`git add -A`.cwd(repoDir).quiet();
+	await $`git commit -m "initial"`.cwd(repoDir).quiet();
+	return { repoDir, metadataRoot, service: new WorkspaceCheckpointService({ metadataRoot }) };
+}
+
+afterEach(async () => {
+	for (const dir of workspaces.splice(0)) await removeWithRetries(dir).catch(() => {});
+});
+
+describe("runCheckpointCommand", () => {
+	test("creates a checkpoint and reports exactly a created line", async () => {
+		const { repoDir, service } = await makeWorkspace();
+		const output: string[] = [];
+		await runCheckpointCommand("", {
+			sessionId: "s1",
+			cwd: repoDir,
+			output: t => {
+				output.push(t);
+			},
+			enabled: true,
+			service,
+		});
+		expect(output).toHaveLength(1);
+		expect(output[0]).toMatch(/^Checkpoint [0-9a-f]{10} created\n/);
+	});
+
+	test("reports the dedup message when the workspace is unchanged", async () => {
+		const { repoDir, service } = await makeWorkspace();
+		const output: string[] = [];
+		const deps = {
+			sessionId: "s1",
+			cwd: repoDir,
+			output: (t: string) => {
+				output.push(t);
+			},
+			enabled: true,
+			service,
+		};
+		await runCheckpointCommand("", deps);
+		output.length = 0;
+		await runCheckpointCommand("", deps);
+		expect(output[0]).toMatch(/^Checkpoint [0-9a-f]{10} already current \(unchanged\)$/);
+	});
+
+	test("honors the disabled-gate hint", async () => {
+		const { repoDir, service } = await makeWorkspace();
+		const output: string[] = [];
+		await runCheckpointCommand("", {
+			sessionId: "s1",
+			cwd: repoDir,
+			output: t => {
+				output.push(t);
+			},
+			enabled: false,
+			service,
+		});
+		expect(output).toHaveLength(1);
+		expect(output[0]).toContain("Checkpoints are disabled");
+		expect(output[0]).toContain("checkpoints.enabled");
+	});
+
+	test("lists checkpoints newest-first", async () => {
+		const { repoDir, service } = await makeWorkspace();
+		const output: string[] = [];
+		const first = await service.create({ sessionId: "s1", cwd: repoDir, reason: "manual", label: "first" });
+		// Distinct workspace content between creates — identical trees dedup to one checkpoint.
+		await Bun.write(path.join(repoDir, "changed.txt"), "v2");
+		const second = await service.create({ sessionId: "s1", cwd: repoDir, reason: "manual", label: "second" });
+		expect(second.id).not.toBe(first.id);
+		await runCheckpointCommand("list", {
+			sessionId: "s1",
+			cwd: repoDir,
+			output: t => {
+				output.push(t);
+			},
+			enabled: true,
+			service,
+		});
+		const lines = output[0]!.split("\n");
+		const secondIdx = lines.findIndex(line => line.includes(second.id));
+		const firstIdx = lines.findIndex(line => first && line.includes(first.id));
+		expect(secondIdx).toBeGreaterThanOrEqual(0);
+		expect(firstIdx).toBeGreaterThanOrEqual(0);
+		// Newest first: the second checkpoint's row precedes the first's.
+		expect(secondIdx).toBeLessThan(firstIdx);
+	});
+
+	test("shows checkpoint metadata including bytes and skipped count", async () => {
+		const { repoDir, service } = await makeWorkspace();
+		const meta = await service.create({ sessionId: "s1", cwd: repoDir, reason: "manual", label: "detail" });
+		const output: string[] = [];
+		await runCheckpointCommand(`show ${meta.id}`, {
+			sessionId: "s1",
+			cwd: repoDir,
+			output: t => {
+				output.push(t);
+			},
+			enabled: true,
+			service,
+		});
+		expect(output[0]).toContain(meta.id);
+		expect(output[0]).toContain("reason: manual");
+		expect(output[0]).toContain("skipped files: 0");
+	});
+});
+
+describe("runRollbackCommand", () => {
+	test("rolls back to a checkpoint and notifies via the surface (happy path)", async () => {
+		const { repoDir, service } = await makeWorkspace();
+		const created = await service.create({ sessionId: "s1", cwd: repoDir, reason: "manual", label: "base" });
+
+		// Dirty the workspace: modify tracked + add an untracked file.
+		await Bun.write(path.join(repoDir, "tracked.txt"), "changed\n");
+		await Bun.write(path.join(repoDir, "extra.txt"), "new\n");
+
+		const output: string[] = [];
+		const surface: WorkspaceRollbackSessionSurface & { entries: Array<{ type: string; data: unknown }> } = {
+			entries: [],
+			appendCustomEntry(type, data) {
+				this.entries.push({ type, data });
+				return "e1";
+			},
+		};
+		await runRollbackCommand(created.id, {
+			sessionId: "s1",
+			cwd: repoDir,
+			output: t => {
+				output.push(t);
+			},
+			service,
+			notify: surface,
+		});
+		expect(output).toHaveLength(1);
+		const text = output[0]!;
+		expect(text).toContain(`Rolled back to checkpoint ${created.id}`);
+		expect(text).toMatch(/Restored files: \d+/);
+		expect(text).toMatch(/Removed files: \d+/);
+		expect(text).toMatch(/Safety checkpoint: [0-9a-f]{10}/);
+		expect(surface.entries).toHaveLength(1);
+		expect(surface.entries[0]!.type).toBe("workspace_rolled_back");
+		// Workspace restored to the base snapshot.
+		expect(await Bun.file(path.join(repoDir, "tracked.txt")).text()).toBe("original\n");
+		expect(await Bun.file(path.join(repoDir, "extra.txt")).exists()).toBe(false);
+	});
+
+	test("surfaces a clean error when no checkpoint matches (no throw)", async () => {
+		const { repoDir, service } = await makeWorkspace();
+		const output: string[] = [];
+		await runRollbackCommand("does-not-exist", {
+			sessionId: "s1",
+			cwd: repoDir,
+			output: t => {
+				output.push(t);
+			},
+			service,
+		});
+		expect(output).toHaveLength(1);
+		expect(output[0]).toContain('No checkpoint matches "does-not-exist"');
+	});
+
+	test("surfaces a thrown error without throwing", async () => {
+		const { repoDir } = await makeWorkspace();
+		const output: string[] = [];
+		const fakeService = {
+			get: async () => ({ id: "x", sessionId: "s1" }),
+			rollback: async () => {
+				throw new Error("boom");
+			},
+		} as unknown as WorkspaceCheckpointService;
+		await runRollbackCommand("x", {
+			sessionId: "s1",
+			cwd: repoDir,
+			output: t => {
+				output.push(t);
+			},
+			service: fakeService,
+		});
+		expect(output).toHaveLength(1);
+		expect(output[0]).toContain("Rollback error: boom");
+	});
+});

--- a/packages/coding-agent/test/checkpoints/workspace-checkpoints.test.ts
+++ b/packages/coding-agent/test/checkpoints/workspace-checkpoints.test.ts
@@ -1,0 +1,467 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { removeWithRetries } from "@oh-my-pi/pi-utils";
+import { $ } from "bun";
+import {
+	CheckpointError,
+	type CheckpointMeta,
+	defaultCheckpointsRoot,
+	emitWorkspaceRolledBack,
+	onWorkspaceRolledBack,
+	WorkspaceCheckpointService,
+} from "../../src/checkpoints";
+import * as git from "../../src/utils/git";
+
+/**
+ * Every case runs against a real `git init` repository in a temp dir with the
+ * checkpoint metadata root pointed at a sibling temp dir, so nothing touches
+ * `~/.omp`, the settings singleton, or another test's state.
+ */
+interface Workspace {
+	readonly repoDir: string;
+	readonly metadataRoot: string;
+	readonly service: WorkspaceCheckpointService;
+}
+
+const workspaces: string[] = [];
+
+async function makeWorkspace(options: { maxPerSession?: number; maxFileBytes?: number } = {}): Promise<Workspace> {
+	const repoDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-cp-repo-"));
+	const metadataRoot = await fs.mkdtemp(path.join(os.tmpdir(), "omp-cp-meta-"));
+	workspaces.push(repoDir, metadataRoot);
+	const init = await $`git init --initial-branch=main`.cwd(repoDir).quiet().nothrow();
+	if (init.exitCode !== 0) throw new Error(`git init failed (exit ${init.exitCode})`);
+	await $`git config user.name "Checkpoint Test"`.cwd(repoDir).quiet();
+	await $`git config user.email "checkpoints@example.com"`.cwd(repoDir).quiet();
+	await Bun.write(path.join(repoDir, "tracked.txt"), "original\n");
+	await Bun.write(path.join(repoDir, ".gitignore"), "ignored.log\n");
+	await $`git add -A`.cwd(repoDir).quiet();
+	await $`git commit -m "initial"`.cwd(repoDir).quiet();
+	return {
+		repoDir,
+		metadataRoot,
+		service: new WorkspaceCheckpointService({ metadataRoot, ...options }),
+	};
+}
+
+async function readFileText(...segments: string[]): Promise<string | null> {
+	try {
+		return await Bun.file(path.join(...segments)).text();
+	} catch {
+		return null;
+	}
+}
+
+afterEach(async () => {
+	for (const dir of workspaces.splice(0)) await removeWithRetries(dir).catch(() => {});
+});
+
+describe("WorkspaceCheckpointService capture", () => {
+	test("captures a clean workspace and records identity, ref, and metadata", async () => {
+		const { repoDir, service, metadataRoot } = await makeWorkspace();
+		const meta = await service.create({ sessionId: "s1", cwd: repoDir, reason: "manual", label: "clean" });
+
+		expect(meta.id).toMatch(/^[0-9a-f]{10}$/);
+		expect(meta.refName).toBe(`refs/omp/checkpoints/s1/${meta.id}`);
+		expect(meta.label).toBe("clean");
+		expect(meta.reason).toBe("manual");
+		const resolvedRoot = await git.repo.root(repoDir);
+		expect(resolvedRoot).not.toBeNull();
+		expect(meta.identity.worktreePath).toBe(resolvedRoot ?? "");
+		expect(meta.headShaAtCapture).toBe(await git.head.sha(repoDir));
+		expect(meta.bytesCaptured).toBeGreaterThan(0);
+		expect(meta.skippedFiles).toEqual([]);
+		expect(meta.metaPath).toBe(path.join(metadataRoot, "s1", `${meta.id}.json`));
+		expect(await git.ref.resolve(repoDir, meta.refName)).not.toBeNull();
+		expect(await Bun.file(meta.metaPath).exists()).toBe(true);
+	});
+
+	test("HEAD, branch, and index are untouched by a capture", async () => {
+		const { repoDir, service } = await makeWorkspace();
+		const headBefore = await git.head.sha(repoDir);
+		await Bun.write(path.join(repoDir, "staged.txt"), "staged\n");
+		await $`git add staged.txt`.cwd(repoDir).quiet();
+		const statusBefore = await git.status(repoDir);
+
+		await service.create({ sessionId: "s1", cwd: repoDir, reason: "auto" });
+
+		expect(await git.head.sha(repoDir)).toBe(headBefore);
+		expect(await git.branch.current(repoDir)).toBe("main");
+		expect(await git.status(repoDir)).toBe(statusBefore);
+	});
+
+	test("captures dirty tracked content, untracked files, and binary payloads; skips ignored files", async () => {
+		const { repoDir, service } = await makeWorkspace();
+		const binary = new Uint8Array([0, 1, 2, 250, 255, 0, 42]);
+		await Bun.write(path.join(repoDir, "tracked.txt"), "modified\n");
+		await Bun.write(path.join(repoDir, "untracked.txt"), "new file\n");
+		await Bun.write(path.join(repoDir, "blob.bin"), binary);
+		await Bun.write(path.join(repoDir, "ignored.log"), "noise\n");
+		await Bun.write(path.join(repoDir, "nested", "deep", "file.txt"), "nested\n");
+
+		const meta = await service.create({ sessionId: "s1", cwd: repoDir, reason: "manual" });
+		const paths = await git.ls.tree(repoDir, meta.treeSha);
+
+		expect(paths).toContain("tracked.txt");
+		expect(paths).toContain("untracked.txt");
+		expect(paths).toContain("blob.bin");
+		expect(paths).toContain("nested/deep/file.txt");
+		expect(paths).not.toContain("ignored.log");
+	});
+
+	test("identical workspace state dedups to the existing checkpoint", async () => {
+		const { repoDir, service } = await makeWorkspace();
+		const first = await service.create({ sessionId: "s1", cwd: repoDir, reason: "manual", label: "keep" });
+		const second = await service.create({ sessionId: "s1", cwd: repoDir, reason: "auto" });
+
+		expect(second.id).toBe(first.id);
+		expect(second.reason).toBe("manual");
+		expect(second.label).toBe("keep");
+		expect(await service.countForSession("s1", repoDir)).toBe(1);
+	});
+
+	test("files over the size limit are excluded and reported, not silently captured", async () => {
+		const { repoDir, service } = await makeWorkspace({ maxFileBytes: 32 });
+		await Bun.write(path.join(repoDir, "huge.bin"), "x".repeat(4096));
+		await Bun.write(path.join(repoDir, "small.txt"), "tiny\n");
+
+		const meta = await service.create({ sessionId: "s1", cwd: repoDir, reason: "manual" });
+		const paths = await git.ls.tree(repoDir, meta.treeSha);
+
+		expect(meta.skippedFiles).toEqual(["huge.bin"]);
+		expect(paths).not.toContain("huge.bin");
+		expect(paths).toContain("small.txt");
+	});
+
+	test("a workspace with too many oversize files is refused instead of half-captured", async () => {
+		const { repoDir, service } = await makeWorkspace({ maxFileBytes: 4 });
+		for (let index = 0; index < 51; index += 1) {
+			await Bun.write(path.join(repoDir, `big-${index}.bin`), "0123456789");
+		}
+
+		await expect(service.create({ sessionId: "s1", cwd: repoDir, reason: "manual" })).rejects.toThrow(
+			/exceed the 4-byte checkpoint limit/,
+		);
+		expect(await service.countForSession("s1", repoDir)).toBe(0);
+	});
+
+	test("the default metadata root is the checkpoints dir inside the workspace's session dir", async () => {
+		const { repoDir } = await makeWorkspace();
+		const sessionsRoot = await fs.mkdtemp(path.join(os.tmpdir(), "omp-cp-sessions-"));
+		workspaces.push(sessionsRoot);
+
+		const root = defaultCheckpointsRoot(repoDir, sessionsRoot);
+
+		expect(path.basename(root)).toBe("checkpoints");
+		expect(path.dirname(path.dirname(root))).toBe(sessionsRoot);
+	});
+
+	test("a non-git cwd is refused by create and rollback", async () => {
+		const { repoDir, service } = await makeWorkspace();
+		const meta = await service.create({ sessionId: "s1", cwd: repoDir, reason: "manual" });
+		const plainDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-cp-plain-"));
+		workspaces.push(plainDir);
+
+		await expect(service.create({ sessionId: "s1", cwd: plainDir, reason: "manual" })).rejects.toThrow(
+			CheckpointError,
+		);
+		await expect(service.rollback(meta, { sessionId: "s1", cwd: plainDir })).rejects.toThrow(/not a git repository/);
+	});
+});
+
+describe("WorkspaceCheckpointService queries", () => {
+	test("lists newest first, resolves by id prefix, and reports the latest", async () => {
+		const { repoDir, service } = await makeWorkspace();
+		const first = await service.create({ sessionId: "s1", cwd: repoDir, reason: "manual", label: "one" });
+		await Bun.write(path.join(repoDir, "tracked.txt"), "second\n");
+		const second = await service.create({ sessionId: "s1", cwd: repoDir, reason: "manual", label: "two" });
+
+		const listed = await service.list("s1", repoDir);
+		expect(listed.map(meta => meta.id)).toEqual([second.id, first.id]);
+		expect((await service.latest("s1", repoDir))?.id).toBe(second.id);
+		expect((await service.get("s1", repoDir, first.id.slice(0, 4)))?.id).toBe(first.id);
+		expect(await service.get("s1", repoDir, "zzzz")).toBeUndefined();
+	});
+
+	test("checkpoints of another session are not listed", async () => {
+		const { repoDir, service } = await makeWorkspace();
+		await service.create({ sessionId: "s1", cwd: repoDir, reason: "manual" });
+
+		expect(await service.list("s2", repoDir)).toEqual([]);
+		expect(await service.countForSession("s2", repoDir)).toBe(0);
+	});
+
+	test("a checkpoint from another workspace is filtered out of the listing", async () => {
+		const { repoDir, service, metadataRoot } = await makeWorkspace();
+		const meta = await service.create({ sessionId: "s1", cwd: repoDir, reason: "manual" });
+		const foreign: CheckpointMeta = {
+			...meta,
+			id: "abcdef0123",
+			identity: { ...meta.identity, worktreePath: path.join(os.tmpdir(), "omp-cp-elsewhere") },
+			refName: "refs/omp/checkpoints/s1/abcdef0123",
+			metaPath: path.join(metadataRoot, "s1", "abcdef0123.json"),
+		};
+		await Bun.write(foreign.metaPath, JSON.stringify(foreign));
+		await git.ref.update(repoDir, foreign.refName, (await git.ref.resolve(repoDir, meta.refName)) ?? "HEAD");
+
+		expect((await service.list("s1", repoDir)).map(entry => entry.id)).toEqual([meta.id]);
+	});
+
+	test("a crash between ref and metadata leaves no valid checkpoint", async () => {
+		const { repoDir, service, metadataRoot } = await makeWorkspace();
+		const meta = await service.create({ sessionId: "s1", cwd: repoDir, reason: "manual" });
+
+		// Ref without metadata (crash before the metadata rename).
+		await fs.rm(meta.metaPath);
+		expect(await service.list("s1", repoDir)).toEqual([]);
+		expect(await git.ref.resolve(repoDir, meta.refName)).not.toBeNull();
+
+		// Metadata without ref (crash/GC after the ref was lost).
+		await Bun.write(meta.metaPath, JSON.stringify(meta));
+		await git.ref.delete(repoDir, meta.refName);
+		expect(await service.list("s1", repoDir)).toEqual([]);
+
+		// Unparsable metadata is filtered too.
+		await Bun.write(path.join(metadataRoot, "s1", "0123456789.json"), "{ not json");
+		expect(await service.list("s1", repoDir)).toEqual([]);
+	});
+});
+
+describe("WorkspaceCheckpointService rollback", () => {
+	test("restores a modified tracked file and leaves HEAD alone", async () => {
+		const { repoDir, service } = await makeWorkspace();
+		const meta = await service.create({ sessionId: "s1", cwd: repoDir, reason: "manual" });
+		const headBefore = await git.head.sha(repoDir);
+		await Bun.write(path.join(repoDir, "tracked.txt"), "broken\n");
+
+		const result = await service.rollback(meta, { sessionId: "s1", cwd: repoDir });
+
+		expect(result.ok).toBe(true);
+		expect(result.restoredFiles).toBe(1);
+		// Worktree and index both hold the restored content, so a rolled-back file
+		// that matches HEAD leaves no phantom staged diff behind.
+		expect(await git.status(repoDir)).toBe("");
+		expect(result.removedFiles).toBe(0);
+		expect(await readFileText(repoDir, "tracked.txt")).toBe("original\n");
+		expect(await git.head.sha(repoDir)).toBe(headBefore);
+		expect(await git.branch.current(repoDir)).toBe("main");
+	});
+
+	test("restores a deleted file and removes a file created after the checkpoint", async () => {
+		const { repoDir, service } = await makeWorkspace();
+		await Bun.write(path.join(repoDir, "keep.txt"), "keep\n");
+		const meta = await service.create({ sessionId: "s1", cwd: repoDir, reason: "manual" });
+
+		await fs.rm(path.join(repoDir, "keep.txt"));
+		await $`git rm --cached --quiet tracked.txt`.cwd(repoDir).quiet().nothrow();
+		await fs.rm(path.join(repoDir, "tracked.txt"));
+		await Bun.write(path.join(repoDir, "created-later.txt"), "extra\n");
+		await Bun.write(path.join(repoDir, "new-dir", "created-later.txt"), "extra\n");
+
+		const result = await service.rollback(meta, { sessionId: "s1", cwd: repoDir });
+
+		expect(result.ok).toBe(true);
+		expect(await readFileText(repoDir, "keep.txt")).toBe("keep\n");
+		expect(await readFileText(repoDir, "tracked.txt")).toBe("original\n");
+		expect(await readFileText(repoDir, "created-later.txt")).toBeNull();
+		expect(await readFileText(repoDir, "new-dir", "created-later.txt")).toBeNull();
+		expect(result.restoredFiles).toBe(2);
+		expect(result.removedFiles).toBe(2);
+	});
+
+	test("restores binary content byte-for-byte", async () => {
+		const { repoDir, service } = await makeWorkspace();
+		const original = new Uint8Array([0, 10, 255, 128, 7, 0, 3]);
+		await Bun.write(path.join(repoDir, "blob.bin"), original);
+		const meta = await service.create({ sessionId: "s1", cwd: repoDir, reason: "manual" });
+		await Bun.write(path.join(repoDir, "blob.bin"), new Uint8Array([9, 9, 9]));
+
+		const result = await service.rollback(meta, { sessionId: "s1", cwd: repoDir });
+
+		expect(result.ok).toBe(true);
+		expect(await Bun.file(path.join(repoDir, "blob.bin")).bytes()).toEqual(original);
+	});
+
+	test("a dirty workspace is captured as a safety checkpoint that can itself be restored", async () => {
+		const { repoDir, service } = await makeWorkspace();
+		const target = await service.create({ sessionId: "s1", cwd: repoDir, reason: "manual" });
+		await Bun.write(path.join(repoDir, "tracked.txt"), "work in progress\n");
+		await Bun.write(path.join(repoDir, "scratch.txt"), "scratch\n");
+
+		const rolledBack = await service.rollback(target, { sessionId: "s1", cwd: repoDir });
+		expect(rolledBack.ok).toBe(true);
+		const safety = rolledBack.safetyCheckpoint;
+		expect(safety).toBeDefined();
+		expect(safety?.reason).toBe("pre-rollback");
+		expect(await readFileText(repoDir, "scratch.txt")).toBeNull();
+
+		const undone = await service.rollback(safety as CheckpointMeta, { sessionId: "s1", cwd: repoDir });
+		expect(undone.ok).toBe(true);
+		expect(await readFileText(repoDir, "tracked.txt")).toBe("work in progress\n");
+		expect(await readFileText(repoDir, "scratch.txt")).toBe("scratch\n");
+	});
+
+	test("rolling back an already-matching workspace is a no-op without a safety capture", async () => {
+		const { repoDir, service } = await makeWorkspace();
+		const meta = await service.create({ sessionId: "s1", cwd: repoDir, reason: "manual" });
+
+		const result = await service.rollback(meta, { sessionId: "s1", cwd: repoDir });
+
+		expect(result).toEqual({ ok: true, restoredFiles: 0, removedFiles: 0 });
+		expect(await service.countForSession("s1", repoDir)).toBe(1);
+	});
+
+	test("rejects a checkpoint from another session or another workspace without touching files", async () => {
+		const { repoDir, service } = await makeWorkspace();
+		const meta = await service.create({ sessionId: "s1", cwd: repoDir, reason: "manual" });
+		await Bun.write(path.join(repoDir, "tracked.txt"), "dirty\n");
+
+		const wrongSession = await service.rollback(meta, { sessionId: "other", cwd: repoDir });
+		expect(wrongSession.ok).toBe(false);
+		expect(wrongSession.error).toContain("belongs to session");
+
+		const foreign: CheckpointMeta = {
+			...meta,
+			identity: { ...meta.identity, worktreePath: path.join(os.tmpdir(), "omp-cp-elsewhere") },
+		};
+		const wrongWorkspace = await service.rollback(foreign, { sessionId: "s1", cwd: repoDir });
+		expect(wrongWorkspace.ok).toBe(false);
+		expect(wrongWorkspace.error).toContain("was captured in");
+
+		expect(await readFileText(repoDir, "tracked.txt")).toBe("dirty\n");
+	});
+
+	test("a missing snapshot ref fails the rollback instead of emptying the workspace", async () => {
+		const { repoDir, service } = await makeWorkspace();
+		const meta = await service.create({ sessionId: "s1", cwd: repoDir, reason: "manual" });
+		await Bun.write(path.join(repoDir, "tracked.txt"), "dirty\n");
+		await git.ref.delete(repoDir, meta.refName);
+
+		const result = await service.rollback(meta, { sessionId: "s1", cwd: repoDir });
+
+		expect(result.ok).toBe(false);
+		expect(result.error).toContain("no longer present");
+		expect(await readFileText(repoDir, "tracked.txt")).toBe("dirty\n");
+	});
+
+	test("a failed transaction keeps the journal and the safety checkpoint for recovery", async () => {
+		const { repoDir, service } = await makeWorkspace();
+		const meta = await service.create({ sessionId: "s1", cwd: repoDir, reason: "manual" });
+		await Bun.write(path.join(repoDir, "tracked.txt"), "dirty\n");
+
+		// Simulate a crash mid-apply: the target tree object disappears between
+		// PREPARE and APPLY, so the transaction cannot complete.
+		const corrupted: CheckpointMeta = { ...meta, treeSha: "0".repeat(40) };
+		const result = await service.rollback(corrupted, { sessionId: "s1", cwd: repoDir });
+
+		expect(result.ok).toBe(false);
+		expect(result.safetyCheckpoint).toBeDefined();
+		const journal = await service.pendingRollback("s1", repoDir);
+		expect(journal?.phase).toBe("failed");
+		expect(journal?.targetTreeSha).toBe(corrupted.treeSha);
+		expect(journal?.safetyCheckpointId).toBe(result.safetyCheckpoint?.id);
+		expect(await Bun.file(service.journalPath("s1", repoDir)).exists()).toBe(true);
+		// The workspace still holds its content — nothing was silently discarded.
+		expect(await readFileText(repoDir, "tracked.txt")).toBe("dirty\n");
+	});
+
+	test("a successful rollback closes the journal and notifies consumers", async () => {
+		const { repoDir, service } = await makeWorkspace();
+		const meta = await service.create({ sessionId: "s1", cwd: repoDir, reason: "manual" });
+		await Bun.write(path.join(repoDir, "tracked.txt"), "dirty\n");
+		const entries: { customType: string; data?: unknown }[] = [];
+		const observed: string[] = [];
+		const unsubscribe = onWorkspaceRolledBack(event => observed.push(event.checkpoint.id));
+
+		try {
+			const result = await service.rollback(meta, {
+				sessionId: "s1",
+				cwd: repoDir,
+				notify: {
+					appendCustomEntry(customType, data) {
+						entries.push({ customType, data });
+						return "entry-1";
+					},
+				},
+			});
+			expect(result.ok).toBe(true);
+		} finally {
+			unsubscribe();
+		}
+
+		expect(await service.pendingRollback("s1", repoDir)).toBeUndefined();
+		expect(entries.map(entry => entry.customType)).toEqual(["workspace_rolled_back"]);
+		expect(observed).toEqual([meta.id]);
+	});
+
+	test("emitWorkspaceRolledBack survives a throwing listener", async () => {
+		const { repoDir, service } = await makeWorkspace();
+		const meta = await service.create({ sessionId: "s1", cwd: repoDir, reason: "manual" });
+		const observed: string[] = [];
+		const unsubscribeBad = onWorkspaceRolledBack(() => {
+			throw new Error("listener boom");
+		});
+		const unsubscribeGood = onWorkspaceRolledBack(event => observed.push(event.checkpoint.id));
+
+		try {
+			emitWorkspaceRolledBack(undefined, meta);
+		} finally {
+			unsubscribeBad();
+			unsubscribeGood();
+		}
+
+		expect(observed).toEqual([meta.id]);
+	});
+});
+
+describe("WorkspaceCheckpointService retention", () => {
+	test("prunes the oldest automatic checkpoints and protects manual ones", async () => {
+		const { repoDir, service } = await makeWorkspace({ maxPerSession: 3 });
+		const kept = await service.create({ sessionId: "s1", cwd: repoDir, reason: "manual", label: "pin" });
+		const created: CheckpointMeta[] = [];
+		for (let index = 0; index < 4; index += 1) {
+			await Bun.write(path.join(repoDir, "tracked.txt"), `auto ${index}\n`);
+			created.push(await service.create({ sessionId: "s1", cwd: repoDir, reason: "auto" }));
+		}
+		expect(created.map(meta => meta.reason)).toEqual(["auto", "auto", "auto", "auto"]);
+
+		const remaining = await service.list("s1", repoDir);
+		expect(remaining.length).toBe(3);
+		expect(remaining.map(meta => meta.id)).toContain(kept.id);
+		expect(remaining.map(meta => meta.id)).toEqual([created[3].id, created[2].id, kept.id]);
+		// Pruned checkpoints release their refs too, so the objects can be GC'd.
+		expect(await git.ref.resolve(repoDir, created[0].refName)).toBeNull();
+		expect(await git.ref.resolve(repoDir, created[1].refName)).toBeNull();
+		expect(await git.ref.resolve(repoDir, kept.refName)).not.toBeNull();
+	});
+
+	test("prune drops refs that no valid metadata points at", async () => {
+		const { repoDir, service } = await makeWorkspace();
+		const meta = await service.create({ sessionId: "s1", cwd: repoDir, reason: "manual" });
+		const orphanRef = "refs/omp/checkpoints/s1/dead0dead0";
+		await git.ref.update(repoDir, orphanRef, (await git.ref.resolve(repoDir, meta.refName)) ?? "HEAD");
+
+		await service.pruneSession("s1", repoDir);
+
+		expect(await git.ref.resolve(repoDir, orphanRef)).toBeNull();
+		expect(await git.ref.resolve(repoDir, meta.refName)).not.toBeNull();
+	});
+
+	test("deleteForSession removes every ref and metadata file for that session only", async () => {
+		const { repoDir, service } = await makeWorkspace();
+		const mine = await service.create({ sessionId: "s1", cwd: repoDir, reason: "manual" });
+		await Bun.write(path.join(repoDir, "tracked.txt"), "other session\n");
+		const other = await service.create({ sessionId: "s2", cwd: repoDir, reason: "manual" });
+
+		const removed = await service.deleteForSession("s1", repoDir);
+
+		expect(removed).toBe(1);
+		expect(await git.ref.resolve(repoDir, mine.refName)).toBeNull();
+		expect(await Bun.file(mine.metaPath).exists()).toBe(false);
+		expect(await service.countForSession("s1", repoDir)).toBe(0);
+		expect(await git.ref.resolve(repoDir, other.refName)).not.toBeNull();
+		expect((await service.list("s2", repoDir)).map(entry => entry.id)).toEqual([other.id]);
+	});
+});

--- a/packages/coding-agent/test/checkpoints/workspace-multi-session-isolation.test.ts
+++ b/packages/coding-agent/test/checkpoints/workspace-multi-session-isolation.test.ts
@@ -1,0 +1,197 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { removeWithRetries } from "@oh-my-pi/pi-utils";
+import { $ } from "bun";
+import { type CheckpointMeta, WorkspaceCheckpointService } from "../../src/checkpoints";
+import * as git from "../../src/utils/git";
+
+/**
+ * Integration test for multi-session isolation.
+ *
+ * Two independent sessions operate on the SAME physical repository R through
+ * LINKED WORKTREES:
+ *   - Workspace A = the primary checkout R, on branch `main`.
+ *   - Workspace B = `git worktree add` of R at a sibling path, on branch
+ *     `feature`. Linked worktrees share the object database AND the shared ref
+ *     store, but each session gets its own metadata-root override, and the
+ *     per-worktree identity (worktreePath) scopes checkpoints and rollbacks.
+ *
+ * Every assertion inspects observable file contents and git state — never
+ * internal fields of the service. The scenario is the spec-mandated flow:
+ * capture in each session, session-scoped listing, cross-session rollback,
+ * rollback-back, canonical-repo safety, and wrong-workspace rejection.
+ */
+
+interface MultiSessionRepo {
+	readonly baseDir: string;
+	readonly repoDir: string;
+	readonly worktreeB: string;
+	readonly metaA: string;
+	readonly metaB: string;
+	readonly serviceA: WorkspaceCheckpointService;
+	readonly serviceB: WorkspaceCheckpointService;
+	readonly initialSha: string;
+}
+
+// Temp dirs allocated by makeMultiSessionRepo; removed wholesale in afterEach
+// so the suite leaves nothing behind.
+const tracked: string[] = [];
+
+async function readFileText(...segments: string[]): Promise<string | null> {
+	try {
+		return await Bun.file(path.join(...segments)).text();
+	} catch {
+		return null;
+	}
+}
+
+async function makeMultiSessionRepo(): Promise<MultiSessionRepo> {
+	const baseDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-iso-"));
+	tracked.push(baseDir);
+	const repoDir = path.join(baseDir, "primary");
+	const worktreeB = path.join(baseDir, "worktree-B");
+	await fs.mkdir(repoDir, { recursive: true });
+
+	const init = await $`git init --initial-branch=main`.cwd(repoDir).quiet().nothrow();
+	if (init.exitCode !== 0) throw new Error(`git init failed (exit ${init.exitCode}): ${init.stderr}`);
+	await $`git config user.name "Isolation Test"`.cwd(repoDir).quiet();
+	await $`git config user.email "isolation@example.com"`.cwd(repoDir).quiet();
+	await Bun.write(path.join(repoDir, "foo.txt"), "seed content\n");
+	await $`git add -A`.cwd(repoDir).quiet();
+	await $`git commit -m "initial"`.cwd(repoDir).quiet();
+
+	// Linked worktree B on branch `feature`, sharing R's object db + ref store.
+	const wt = await $`git worktree add -b feature ${worktreeB}`.cwd(repoDir).quiet().nothrow();
+	if (wt.exitCode !== 0) throw new Error(`git worktree add failed (exit ${wt.exitCode}): ${wt.stderr}`);
+
+	const metaA = await fs.mkdtemp(path.join(os.tmpdir(), "omp-iso-metaA-"));
+	const metaB = await fs.mkdtemp(path.join(os.tmpdir(), "omp-iso-metaB-"));
+	tracked.push(metaA, metaB);
+
+	const initialSha = (await git.head.sha(repoDir)) ?? "";
+	if (!initialSha) throw new Error("could not resolve initial HEAD sha");
+
+	return {
+		baseDir,
+		repoDir,
+		worktreeB,
+		metaA,
+		metaB,
+		serviceA: new WorkspaceCheckpointService({ metadataRoot: metaA }),
+		serviceB: new WorkspaceCheckpointService({ metadataRoot: metaB }),
+		initialSha,
+	};
+}
+
+afterEach(async () => {
+	for (const dir of tracked.splice(0)) await removeWithRetries(dir).catch(() => {});
+});
+
+describe("multi-session checkpoint + rollback isolation across linked worktrees", () => {
+	test("sessions A (primary) and B (worktree) stay isolated across capture, rollback, and rejection", async () => {
+		const env = await makeMultiSessionRepo();
+		const { repoDir: A, worktreeB: B, serviceA, serviceB, initialSha } = env;
+
+		const A1 = "A1 content\n";
+		const A2 = "A2 content\n";
+		const B1 = "B1 content\n";
+		const B2 = "B2 content\n";
+
+		// ── Step 1: session A edits foo.txt to A1, checkpoints it, then edits to A2.
+		await Bun.write(path.join(A, "foo.txt"), A1);
+		const a1: CheckpointMeta = await serviceA.create({
+			sessionId: "sess-A",
+			cwd: A,
+			reason: "manual",
+			label: "A-one",
+		});
+		await Bun.write(path.join(A, "foo.txt"), A2);
+
+		// ── Step 2: session B independently edits foo.txt in its worktree to B1,
+		//    checkpoints it, then edits to B2.
+		await Bun.write(path.join(B, "foo.txt"), B1);
+		const b1: CheckpointMeta = await serviceB.create({
+			sessionId: "sess-B",
+			cwd: B,
+			reason: "manual",
+			label: "B-one",
+		});
+		await Bun.write(path.join(B, "foo.txt"), B2);
+
+		// ── Step 3: session scoping — each list shows only its own checkpoint,
+		//    and the other session's checkpoint is absent even when queried from
+		//    the opposite workspace (metadata roots are scoped, not just namespaces).
+		const aList = await serviceA.list("sess-A", A);
+		const bList = await serviceB.list("sess-B", B);
+		expect(aList.map(meta => meta.id)).toEqual([a1.id]);
+		expect(bList.map(meta => meta.id)).toEqual([b1.id]);
+		expect(await serviceA.list("sess-B", A)).toEqual([]);
+		expect(await serviceB.list("sess-A", B)).toEqual([]);
+
+		// ── Step 4: roll A back to A1.
+		const rollbackToA1 = await serviceA.rollback(a1, { sessionId: "sess-A", cwd: A });
+		expect(rollbackToA1.ok).toBe(true);
+		expect(rollbackToA1.safetyCheckpoint).toBeDefined();
+		expect(rollbackToA1.safetyCheckpoint?.reason).toBe("pre-rollback");
+		expect(rollbackToA1.restoredFiles).toBe(1);
+
+		// ── Step 5: observable effects of the A rollback.
+		// A's file is restored to A1; B's file is completely untouched (still B2).
+		expect(await readFileText(A, "foo.txt")).toBe(A1);
+		expect(await readFileText(B, "foo.txt")).toBe(B2);
+		// HEAD and branch are unchanged in both checkouts.
+		expect(await git.head.sha(A)).toBe(initialSha);
+		expect(await git.branch.current(A)).toBe("main");
+		expect(await git.head.sha(B)).toBe(initialSha);
+		expect(await git.branch.current(B)).toBe("feature");
+		// Both session ref namespaces coexist in the SHARED ref store.
+		expect(await git.ref.resolve(A, a1.refName)).not.toBeNull();
+		expect(await git.ref.resolve(B, b1.refName)).not.toBeNull();
+		const sessARefs = (await git.ref.list(A, "refs/omp/checkpoints/sess-A")).map(entry => entry.refName);
+		const sessBRefs = (await git.ref.list(A, "refs/omp/checkpoints/sess-B")).map(entry => entry.refName);
+		expect(sessARefs).toContain(a1.refName);
+		expect(sessBRefs).toContain(b1.refName);
+		// The pre-rollback safety capture also landed under sess-A.
+		expect(sessARefs).toContain(rollbackToA1.safetyCheckpoint!.refName);
+
+		// ── Step 6: rollback-back — restore A to the pre-rollback (A2) state.
+		const rollbackBack = await serviceA.rollback(rollbackToA1.safetyCheckpoint!, {
+			sessionId: "sess-A",
+			cwd: A,
+		});
+		expect(rollbackBack.ok).toBe(true);
+		expect(rollbackBack.safetyCheckpoint).toBeDefined();
+		expect(await readFileText(A, "foo.txt")).toBe(A2);
+
+		// ── Step 7: canonical-repo safety — roll B back to B1.
+		const rollbackToB1 = await serviceB.rollback(b1, { sessionId: "sess-B", cwd: B });
+		expect(rollbackToB1.ok).toBe(true);
+		expect(rollbackToB1.safetyCheckpoint).toBeDefined();
+		// A is still at A2; B is restored to B1.
+		expect(await readFileText(A, "foo.txt")).toBe(A2);
+		expect(await readFileText(B, "foo.txt")).toBe(B1);
+		// The worktree list is intact: both checkouts are still registered.
+		const wtList = await git.worktree.list(A);
+		const wtPaths = new Set(wtList.map(entry => path.resolve(entry.path)));
+		expect(wtPaths.has(path.resolve(A))).toBe(true);
+		expect(wtPaths.has(path.resolve(B))).toBe(true);
+		// Neither rollback touched a branch ref.
+		expect(await git.head.sha(A)).toBe(initialSha);
+		expect(await git.branch.current(A)).toBe("main");
+		expect(await git.head.sha(B)).toBe(initialSha);
+		expect(await git.branch.current(B)).toBe("feature");
+
+		// ── Step 8: wrong-workspace rejection through the REAL path. A checkpoint
+		//    captured by sess-A must be refused when sess-B (cwd B) tries to apply
+		//    it — and no file in either workspace may change.
+		const aFooBefore = await readFileText(A, "foo.txt");
+		const bFooBefore = await readFileText(B, "foo.txt");
+		const rejected = await serviceA.rollback(a1, { sessionId: "sess-B", cwd: B });
+		expect(rejected.ok).toBe(false);
+		expect(rejected.error).toContain("belongs to session");
+		expect(await readFileText(A, "foo.txt")).toBe(aFooBefore);
+		expect(await readFileText(B, "foo.txt")).toBe(bFooBefore);
+	});
+});

--- a/packages/coding-agent/test/session/session-control.test.ts
+++ b/packages/coding-agent/test/session/session-control.test.ts
@@ -1,0 +1,225 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { closeDb, initDb, insertMessageStats } from "@oh-my-pi/omp-stats/db";
+import type { MessageStats } from "@oh-my-pi/omp-stats/types";
+import {
+	clearSessionMetricsCache,
+	type EnumerateOptions,
+	enumerateSessions,
+	isArchived,
+	type SessionControlDeps,
+	setArchived,
+} from "@oh-my-pi/pi-coding-agent/session/session-control";
+import { installStatsTestIsolation } from "../../../stats/test/helpers/temp-agent";
+
+installStatsTestIsolation("@pi-session-control-");
+
+let sessionDir: string;
+let currentPath: string;
+let otherPath: string;
+let orphanPath: string;
+
+function header(id: string, ts: string, cwd: string): string {
+	return JSON.stringify({ type: "session", id, timestamp: ts, cwd });
+}
+
+function makeStats(
+	entryId: string,
+	sessionFile: string,
+	input: number,
+	output: number,
+	cacheRead: number,
+): MessageStats {
+	return {
+		sessionFile,
+		entryId,
+		folder: "/tmp/project",
+		model: "gpt-5.4",
+		provider: "openai-codex",
+		api: "openai-codex-responses",
+		timestamp: Date.now(),
+		duration: 1000,
+		ttft: 100,
+		stopReason: "stop",
+		errorMessage: null,
+		usage: {
+			input,
+			output,
+			cacheRead,
+			cacheWrite: 0,
+			totalTokens: input + output + cacheRead,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		agentType: "main",
+	};
+}
+
+function makeRegistry(counts: { running: number; idle: number; parked: number }) {
+	const refs: Array<{ status: string }> = [];
+	for (let i = 0; i < counts.running; i++) refs.push({ status: "running" });
+	for (let i = 0; i < counts.idle; i++) refs.push({ status: "idle" });
+	for (let i = 0; i < counts.parked; i++) refs.push({ status: "parked" });
+	return { list: () => refs };
+}
+
+beforeEach(async () => {
+	clearSessionMetricsCache();
+	sessionDir = mkdtempSync(join(tmpdir(), "sess-"));
+	currentPath = join(sessionDir, "2024-01-01T00-00-00-000Z_cur.jsonl");
+	otherPath = join(sessionDir, "2024-01-01T00-00-00-000Z_oth.jsonl");
+	orphanPath = join(sessionDir, "2024-01-01T00-00-00-000Z_orp.jsonl");
+	writeFileSync(currentPath, `${header("cur", "1970-01-01T00:00:01.000Z", "/tmp/proj")}\n`);
+	writeFileSync(otherPath, `${header("oth", "1970-01-01T00:00:02.000Z", "/tmp/proj2")}\n`);
+	writeFileSync(orphanPath, `${header("orp", "1970-01-01T00:00:03.000Z", "/tmp/proj3")}\n`);
+	// Controlled modified times (seconds) for the "recent" sort.
+	utimesSync(currentPath, 1, 5);
+	utimesSync(otherPath, 2, 1);
+	utimesSync(orphanPath, 3, 2);
+	await initDb();
+	await insertMessageStats([makeStats("e1", currentPath, 1000, 500, 200), makeStats("e2", otherPath, 200, 100, 50)]);
+});
+
+afterEach(() => {
+	closeDb();
+	rmSync(sessionDir, { recursive: true, force: true });
+});
+
+function deps(overrides: Partial<SessionControlDeps> = {}): SessionControlDeps {
+	return {
+		registry: makeRegistry({ running: 1, idle: 2, parked: 1 }),
+		gate: { paused: false },
+		session: { sessionFile: currentPath, model: "claude-opus-4" },
+		currentSessionFile: currentPath,
+		profile: "work",
+		...overrides,
+	};
+}
+
+function opts(overrides: Partial<EnumerateOptions> = {}, d?: SessionControlDeps): EnumerateOptions {
+	return { cwd: sessionDir, sessionDir, deps: d ?? deps(), ...overrides };
+}
+
+describe("enumerateSessions", () => {
+	it("marks the current session and distinguishes it from others", async () => {
+		const rows = await enumerateSessions(opts());
+		expect(rows.length).toBe(3);
+		expect(rows.filter(r => r.isCurrent).length).toBe(1);
+		const current = rows.find(r => r.isCurrent)!;
+		expect(current.info.path).toBe(currentPath);
+		expect(rows.find(r => r.info.path === otherPath)!.isCurrent).toBe(false);
+	});
+
+	it("exposes model/profile only for the current session", async () => {
+		const rows = await enumerateSessions(opts());
+		const cur = rows.find(r => r.isCurrent)!;
+		const oth = rows.find(r => r.info.path === otherPath)!;
+		expect(cur.model).toBe("claude-opus-4");
+		expect(cur.profile).toBe("work");
+		expect(oth.model).toBeUndefined();
+		expect(oth.profile).toBeUndefined();
+	});
+
+	it("derives agent counts and live state from the injected registry (current only)", async () => {
+		const rows = await enumerateSessions(opts());
+		const cur = rows.find(r => r.isCurrent)!;
+		const oth = rows.find(r => r.info.path === otherPath)!;
+		expect(cur.agentCounts).toEqual({ running: 1, idle: 2, parked: 1 });
+		expect(cur.liveState).toBe("streaming");
+		expect(oth.agentCounts).toBeUndefined();
+		expect(oth.liveState).toBeUndefined();
+	});
+
+	it("reports paused live state when the gate is paused", async () => {
+		const rows = await enumerateSessions(opts({}, deps({ gate: { paused: true } })));
+		expect(rows.find(r => r.isCurrent)!.liveState).toBe("paused");
+	});
+
+	it("flows cost/token data from the real stats DB", async () => {
+		const rows = await enumerateSessions(opts());
+		const cur = rows.find(r => r.isCurrent)!;
+		const oth = rows.find(r => r.info.path === otherPath)!;
+		expect(cur.cost).toBeGreaterThan(0);
+		expect(cur.tokensIn).toBe(1000);
+		expect(cur.tokensOut).toBe(500);
+		expect(oth.cost).toBeGreaterThan(0);
+		expect(oth.tokensIn).toBe(200);
+		expect(oth.tokensOut).toBe(100);
+	});
+
+	it("leaves metrics undefined when no source is available (no fake zeros)", async () => {
+		const rows = await enumerateSessions(opts());
+		const orphan = rows.find(r => r.info.path === orphanPath)!;
+		// No stats row inserted for the orphan session:
+		expect(orphan.cost).toBeUndefined();
+		expect(orphan.tokensIn).toBeUndefined();
+		expect(orphan.tokensOut).toBeUndefined();
+		// git status + checkpoint count are best-effort and unavailable here:
+		expect(orphan.branch).toBeUndefined();
+		expect(orphan.dirty).toBeUndefined();
+		expect(orphan.checkpointCount).toBeUndefined();
+	});
+
+	describe("sorting", () => {
+		it("recent orders by modified desc", async () => {
+			const rows = await enumerateSessions(opts({ sort: "recent" }));
+			expect(rows[0].info.path).toBe(currentPath); // modified 5 > others
+		});
+		it("created orders by created desc", async () => {
+			const rows = await enumerateSessions(opts({ sort: "created" }));
+			expect(rows[0].info.path).toBe(orphanPath); // created 3000 > others
+		});
+		it("cost orders by cost desc", async () => {
+			const rows = await enumerateSessions(opts({ sort: "cost" }));
+			expect(rows[0].info.path).toBe(currentPath); // more tokens => higher cost
+		});
+		it("agents orders by total agent count desc", async () => {
+			const rows = await enumerateSessions(opts({ sort: "agents" }));
+			expect(rows[0].info.path).toBe(currentPath); // only current has counts
+		});
+	});
+
+	describe("filtering", () => {
+		it("current returns only the current session", async () => {
+			const rows = await enumerateSessions(opts({ filter: "current" }));
+			expect(rows.length).toBe(1);
+			expect(rows[0].isCurrent).toBe(true);
+		});
+		it("all returns every session", async () => {
+			const rows = await enumerateSessions(opts({ filter: "all" }));
+			expect(rows.length).toBe(3);
+		});
+		it("archived returns only archived sessions", async () => {
+			await setArchived(otherPath, true);
+			try {
+				const rows = await enumerateSessions(opts({ filter: "archived" }));
+				expect(rows.length).toBe(1);
+				expect(rows[0].info.path).toBe(otherPath);
+			} finally {
+				await setArchived(otherPath, false);
+			}
+		});
+		it("active excludes archived sessions", async () => {
+			await setArchived(otherPath, true);
+			try {
+				const rows = await enumerateSessions(opts({ filter: "active" }));
+				expect(rows.every(r => !r.archived)).toBe(true);
+				expect(rows.find(r => r.info.path === otherPath)).toBeUndefined();
+			} finally {
+				await setArchived(otherPath, false);
+			}
+		});
+	});
+});
+
+describe("archive sentinel", () => {
+	it("roundtrips write/remove and isArchived reflects it", async () => {
+		const p = join(sessionDir, "sentinel.jsonl");
+		expect(isArchived(p)).toBe(false);
+		await setArchived(p, true);
+		expect(isArchived(p)).toBe(true);
+		await setArchived(p, false);
+		expect(isArchived(p)).toBe(false);
+	});
+});

--- a/packages/coding-agent/test/sessions-manager.test.ts
+++ b/packages/coding-agent/test/sessions-manager.test.ts
@@ -1,0 +1,395 @@
+/**
+ * Sessions manager overlay — render/keyboard contracts.
+ *
+ * Uses injected fakes (enumerate, registry, gate, lifecycle, ctx) and real
+ * `setArchived`/`isArchived` against temp session files, so no production
+ * registry, DB, or settings are touched.
+ */
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { removeWithRetries } from "@oh-my-pi/pi-utils";
+import { SessionsManagerComponent } from "../src/modes/components/sessions-manager";
+import { initTheme } from "../src/modes/theme/theme";
+import type { InteractiveModeContext } from "../src/modes/types";
+import { MAIN_AGENT_ID } from "../src/registry/agent-registry";
+import {
+	type EnumerateOptions,
+	isArchived,
+	type SessionFilter,
+	type SessionRow,
+	type SessionSort,
+	setArchived,
+} from "../src/session/session-control";
+import type { SessionInfo } from "../src/session/session-listing";
+
+const tmpDirs: string[] = [];
+
+function makeSessionFile(id: string): string {
+	return path.join(tmpDirs[tmpDirs.length - 1]!, `${id}.jsonl`);
+}
+
+function makeRow(
+	overrides: Partial<SessionInfo> & {
+		isCurrent?: boolean;
+		archived?: boolean;
+		liveState?: SessionRow["liveState"];
+		cost?: number;
+		model?: string;
+		agentCounts?: SessionRow["agentCounts"];
+	},
+): SessionRow {
+	const id = overrides.id ?? `sess-${Math.random().toString(36).slice(2, 8)}`;
+	const info: SessionInfo = {
+		path: overrides.path ?? makeSessionFile(id),
+		id,
+		cwd: overrides.cwd ?? "/work",
+		title: overrides.title,
+		created: overrides.created ?? new Date(1000),
+		modified: overrides.modified ?? new Date(2000),
+		messageCount: overrides.messageCount ?? 0,
+		size: overrides.size ?? 0,
+		firstMessage: overrides.firstMessage ?? "first message",
+		allMessagesText: overrides.allMessagesText ?? "",
+		status: overrides.status,
+	};
+	return {
+		info,
+		isCurrent: overrides.isCurrent ?? false,
+		archived: overrides.archived ?? false,
+		liveState: overrides.liveState,
+		cost: overrides.cost,
+		model: overrides.model,
+		agentCounts: overrides.agentCounts,
+	};
+}
+
+function applyFilter(rows: SessionRow[], filter: SessionFilter): SessionRow[] {
+	switch (filter) {
+		case "current":
+			return rows.filter(r => r.isCurrent);
+		case "archived":
+			return rows.filter(r => r.archived);
+		case "paused":
+			return rows.filter(r => r.liveState === "paused");
+		case "active":
+			return rows.filter(r => !r.archived);
+		default:
+			return rows;
+	}
+}
+
+function agentTotal(r: SessionRow): number {
+	return r.agentCounts ? r.agentCounts.running + r.agentCounts.idle + r.agentCounts.parked : 0;
+}
+
+function applySort(rows: SessionRow[], sort: SessionSort): SessionRow[] {
+	const copy = [...rows];
+	switch (sort) {
+		case "created":
+			copy.sort((a, b) => b.info.created.getTime() - a.info.created.getTime());
+			break;
+		case "cost":
+			copy.sort((a, b) => (b.cost ?? -Infinity) - (a.cost ?? -Infinity));
+			break;
+		case "agents":
+			copy.sort((a, b) => agentTotal(b) - agentTotal(a));
+			break;
+		default:
+			copy.sort((a, b) => b.info.modified.getTime() - a.info.modified.getTime());
+			break;
+	}
+	return copy;
+}
+
+interface ReleaseSpy {
+	(id: string, expected?: unknown, options?: { tombstone?: boolean }): Promise<boolean>;
+	calls: Array<{ id: string; options?: { tombstone?: boolean } }>;
+}
+
+function makeReleaseSpy(): ReleaseSpy {
+	const calls: ReleaseSpy["calls"] = [];
+	const fn = vi.fn(async (id: string, _expected?: unknown, options?: { tombstone?: boolean }) => {
+		calls.push({ id, options });
+		return true;
+	}) as unknown as ReleaseSpy;
+	fn.calls = calls;
+	return fn;
+}
+
+interface Fakes {
+	base: SessionRow[];
+	registryList: Array<{ id: string; status: string }>;
+	gate: { paused: boolean; engage: () => void; release: () => void };
+	release: ReleaseSpy;
+	handleResumeSession: (path: string) => Promise<void>;
+	showStatus: (text: string) => void;
+	dropSession: (path: string) => Promise<void>;
+}
+
+function makeFakes(base: SessionRow[]): Fakes {
+	const handleResumeSession = vi.fn(async () => {});
+	const showStatus = vi.fn();
+	const dropSession = vi.fn(async () => {});
+	const gate = { paused: false, engage: vi.fn(), release: vi.fn() };
+	return {
+		base,
+		registryList: [{ id: MAIN_AGENT_ID, status: "running" }],
+		gate,
+		release: makeReleaseSpy(),
+		handleResumeSession,
+		showStatus,
+		dropSession,
+	};
+}
+
+function makeComponent(fakes: Fakes, ui?: unknown): SessionsManagerComponent {
+	const base = fakes.base;
+	const enumerate = (opts: EnumerateOptions): Promise<SessionRow[]> => {
+		let rows = base.map(r => ({ ...r, archived: isArchived(r.info.path) }));
+		rows = applyFilter(rows, opts.filter ?? "all");
+		rows = applySort(rows, opts.sort ?? "recent");
+		return Promise.resolve(rows);
+	};
+	const ctx = {
+		session: { getSessionFile: () => base.find(r => r.isCurrent)?.info.path, model: "provider/model" },
+		sessionManager: { dropSession: fakes.dropSession },
+		showStatus: fakes.showStatus,
+		handleResumeSession: fakes.handleResumeSession,
+	} as unknown as InteractiveModeContext;
+	return new SessionsManagerComponent({
+		ctx,
+		ui: ui as never,
+		requestRender: () => {},
+		onClose: () => {},
+		enumerate,
+		registry: { list: () => fakes.registryList, onChange: () => () => {} } as never,
+		gate: fakes.gate as never,
+		lifecycle: { release: fakes.release } as never,
+	});
+}
+/** Await the component's in-flight enumeration — the real completion signal, no timers. */
+const settle = async (component: SessionsManagerComponent): Promise<void> => {
+	for (let i = 0; i < 4; i += 1) await component.awaitSettled();
+};
+const renderText = (c: SessionsManagerComponent, width = 160): string => Bun.stripANSI(c.render(width).join("\n"));
+
+beforeAll(async () => {
+	await initTheme();
+});
+
+beforeEach(async () => {
+	tmpDirs.push(await fs.mkdtemp(path.join(os.tmpdir(), "omp-sm-")));
+});
+
+afterEach(async () => {
+	for (const dir of tmpDirs.splice(0)) await removeWithRetries(dir).catch(() => {});
+});
+
+describe("sessions manager — enumerate-driven rows", () => {
+	it("renders current + persisted sessions from a temp sessionDir fixture", async () => {
+		const base = [
+			makeRow({ id: "current1", title: "Current Session", isCurrent: true, cwd: "/work/a" }),
+			makeRow({ id: "old1", title: "Old Session", cwd: "/work/b" }),
+		];
+		await fs.writeFile(base[0]!.info.path, "");
+		await fs.writeFile(base[1]!.info.path, "");
+		const fakes = makeFakes(base);
+		const component = makeComponent(fakes);
+		await settle(component);
+		const text = renderText(component);
+		expect(text).toContain("Current Session");
+		expect(text).toContain("Old Session");
+		expect(text).toContain("●");
+	});
+
+	it("cycles filter current/active/paused/archived/all", async () => {
+		const base = [
+			makeRow({ id: "c1", title: "Cur", isCurrent: true, cwd: "/w" }),
+			makeRow({ id: "p1", title: "Paused", liveState: "paused", cwd: "/w" }),
+			makeRow({ id: "a1", title: "Arch", archived: true, cwd: "/w" }),
+		];
+		for (const r of base) await fs.writeFile(r.info.path, "");
+		// Production derives `archived` from the on-disk sentinel, not the row field.
+		await setArchived(base[2]!.info.path, true);
+		const fakes = makeFakes(base);
+		const component = makeComponent(fakes);
+		await settle(component);
+
+		component.handleInput("F");
+		await settle(component);
+		expect(renderText(component)).toContain("Cur");
+		expect(renderText(component)).not.toContain("Paused");
+
+		component.handleInput("F");
+		await settle(component);
+		const active = renderText(component);
+		expect(active).toContain("Cur");
+		expect(active).toContain("Paused");
+		expect(active).not.toContain("Arch");
+
+		component.handleInput("F");
+		await settle(component);
+		const paused = renderText(component);
+		expect(paused).toContain("Paused");
+		expect(paused).not.toContain("Cur");
+
+		component.handleInput("F");
+		await settle(component);
+		const archived = renderText(component);
+		expect(archived).toContain("Arch");
+		expect(archived).not.toContain("Cur");
+	});
+
+	it("sorts recent/cost/agents", async () => {
+		const base = [
+			makeRow({ id: "cheap", title: "Cheap", cost: 1, modified: new Date(3000), cwd: "/w" }),
+			makeRow({ id: "pricey", title: "Pricey", cost: 99, modified: new Date(1000), cwd: "/w" }),
+			makeRow({ id: "many", title: "Many", agentCounts: { running: 5, idle: 0, parked: 0 }, cwd: "/w" }),
+		];
+		for (const r of base) await fs.writeFile(r.info.path, "");
+		const fakes = makeFakes(base);
+		const component = makeComponent(fakes);
+		await settle(component);
+
+		let text = renderText(component);
+		expect(text.indexOf("Cheap")).toBeLessThan(text.indexOf("Pricey"));
+
+		component.handleInput("S");
+		await settle(component);
+		component.handleInput("S");
+		await settle(component);
+		text = renderText(component);
+		expect(text.indexOf("Pricey")).toBeLessThan(text.indexOf("Cheap"));
+
+		component.handleInput("S");
+		await settle(component);
+		text = renderText(component);
+		expect(text.indexOf("Many")).toBeLessThan(text.indexOf("Pricey"));
+	});
+
+	it("renders the renamed title but drives actions with the durable path", async () => {
+		const base = [makeRow({ id: "abc123", title: "Renamed Title", cwd: "/w/x", isCurrent: false })];
+		await fs.writeFile(base[0]!.info.path, "");
+		const fakes = makeFakes(base);
+		const component = makeComponent(fakes);
+		await settle(component);
+		expect(renderText(component)).toContain("Renamed Title");
+		component.handleInput("\r");
+		await settle(component);
+		expect(fakes.handleResumeSession).toHaveBeenCalledTimes(1);
+		expect(fakes.handleResumeSession).toHaveBeenCalledWith(base[0]!.info.path);
+		expect(fakes.handleResumeSession).not.toHaveBeenCalledWith("Renamed Title");
+	});
+
+	it("toggles pause only for the current session via the gate", async () => {
+		const base = [makeRow({ id: "c1", title: "Cur", isCurrent: true, cwd: "/w" })];
+		await fs.writeFile(base[0]!.info.path, "");
+		const fakes = makeFakes(base);
+		const component = makeComponent(fakes);
+		await settle(component);
+		component.handleInput("P");
+		await settle(component);
+		expect(fakes.gate.engage).toHaveBeenCalledTimes(1);
+		expect(fakes.gate.release).not.toHaveBeenCalled();
+	});
+
+	it("requires confirmation and scopes kill to running subagents only", async () => {
+		const base = [makeRow({ id: "c1", title: "Cur", isCurrent: true, cwd: "/w" })];
+		await fs.writeFile(base[0]!.info.path, "");
+		const fakes = makeFakes(base);
+		fakes.registryList = [
+			{ id: MAIN_AGENT_ID, status: "running" },
+			{ id: "r1", status: "running" },
+			{ id: "r2", status: "parked" },
+		];
+		const component = makeComponent(fakes);
+		await settle(component);
+		component.handleInput("K");
+		await settle(component);
+		expect(fakes.release.calls).toHaveLength(0);
+		component.handleInput("y");
+		await settle(component);
+		expect(fakes.release.calls).toHaveLength(1);
+		expect(fakes.release.calls[0]).toEqual({ id: "r1", options: { tombstone: true } });
+		expect(fakes.release.calls.some(c => c.id === "r2")).toBe(false);
+		expect(fakes.release.calls.some(c => c.id === MAIN_AGENT_ID)).toBe(false);
+	});
+
+	it("archives a session and reflects it in the list (roundtrip)", async () => {
+		const base = [makeRow({ id: "a1", title: "ToArchive", cwd: "/w", isCurrent: false })];
+		await fs.writeFile(base[0]!.info.path, "");
+		const fakes = makeFakes(base);
+		const component = makeComponent(fakes);
+		await settle(component);
+		expect(isArchived(base[0]!.info.path)).toBe(false);
+		component.handleInput("A");
+		await settle(component);
+		expect(isArchived(base[0]!.info.path)).toBe(true);
+		expect(renderText(component)).toContain("archived");
+		component.handleInput("A");
+		await settle(component);
+		expect(isArchived(base[0]!.info.path)).toBe(false);
+	});
+
+	it("renders unavailable metrics as a placeholder, never zero", async () => {
+		const base = [makeRow({ id: "u1", title: "NoMetrics", cwd: "/w", isCurrent: false })];
+		await fs.writeFile(base[0]!.info.path, "");
+		const fakes = makeFakes(base);
+		const component = makeComponent(fakes);
+		await settle(component);
+		const text = renderText(component);
+		expect(text).toContain("—");
+		expect(text).not.toContain("$0");
+	});
+});
+
+describe("sessions manager — narrow widths and timers", () => {
+	it("renders at 160/120/80/60 without throwing and drops columns", async () => {
+		const base = [
+			makeRow({
+				id: "c1",
+				title: "Cur",
+				isCurrent: true,
+				cwd: "/work/long/path",
+				model: "provider/model",
+				cost: 42,
+				agentCounts: { running: 1, idle: 0, parked: 0 },
+			}),
+			makeRow({ id: "o1", title: "Other", cwd: "/work/other", model: "provider/model2", cost: 7 }),
+		];
+		for (const r of base) await fs.writeFile(r.info.path, "");
+		const fakes = makeFakes(base);
+		const component = makeComponent(fakes);
+		await settle(component);
+		for (const width of [160, 120, 80, 60]) {
+			const lines = component.render(width);
+			expect(Array.isArray(lines)).toBe(true);
+			expect(Bun.stripANSI(lines.join("\n"))).toContain("Cur");
+		}
+		component.dispose();
+	});
+
+	it("creates no timer tighter than 5s (only the age tick at 5000ms)", async () => {
+		const base = [makeRow({ id: "c1", title: "Cur", isCurrent: true, cwd: "/w" })];
+		await fs.writeFile(base[0]!.info.path, "");
+		const fakes = makeFakes(base);
+		const intervals: number[] = [];
+		const original = global.setInterval;
+		// Record the requested delay and return a no-op timer so no real clock is bound.
+		// @ts-expect-error test shim
+		global.setInterval = (_fn: () => void, delay?: number): NodeJS.Timeout => {
+			intervals.push(delay ?? 0);
+			return { unref() {} } as unknown as NodeJS.Timeout;
+		};
+		try {
+			const component = makeComponent(fakes, { requestRender: () => {} });
+			await settle(component);
+			expect(intervals).toEqual([5000]);
+			component.dispose();
+		} finally {
+			global.setInterval = original;
+		}
+	});
+});

--- a/packages/coding-agent/test/slash-commands/session-rename.test.ts
+++ b/packages/coding-agent/test/slash-commands/session-rename.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it, vi } from "bun:test";
+import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
+import { executeBuiltinSlashCommand } from "@oh-my-pi/pi-coding-agent/slash-commands/builtin-registry";
+import { BUILTIN_SESSION_SLASH_COMMANDS } from "@oh-my-pi/pi-coding-agent/slash-commands/builtin-session";
+import type { ParsedSlashCommand, SlashCommandRuntime } from "@oh-my-pi/pi-coding-agent/slash-commands/types";
+
+const SESSION_ID = "sess-1";
+
+function tuiRuntime() {
+	const setText = vi.fn();
+	const showStatus = vi.fn();
+	const setSessionName = vi.fn(async () => true);
+	const sessionManager = {
+		getCwd: () => "/tmp/proj",
+		setSessionName,
+	} as unknown as InteractiveModeContext["sessionManager"];
+	const ctx = {
+		collabGuest: false,
+		editor: { setText } as unknown as InteractiveModeContext["editor"],
+		showStatus,
+		sessionManager,
+		session: { sessionId: SESSION_ID, sessionName: "old" } as unknown as InteractiveModeContext["session"],
+		settings: {} as unknown as InteractiveModeContext["settings"],
+	} as unknown as InteractiveModeContext;
+	return { setText, showStatus, setSessionName, ctx };
+}
+
+function textRuntime() {
+	const setSessionName = vi.fn(async () => true);
+	const output = vi.fn(async () => {});
+	const runtime = {
+		cwd: "/tmp/proj",
+		output,
+		refreshCommands: async () => {},
+		reloadPlugins: async () => {},
+		session: { sessionId: SESSION_ID, sessionName: "old" },
+		sessionManager: { getCwd: () => "/tmp/proj", getSessionFile: () => "/tmp/x.jsonl", setSessionName },
+		settings: {},
+	} as unknown as SlashCommandRuntime;
+	return { setSessionName, output, runtime };
+}
+
+describe("/session rename (TUI)", () => {
+	it("renames the current session and confirms with the new name", async () => {
+		const h = tuiRuntime();
+		const handled = await executeBuiltinSlashCommand("/session rename tui-name", h);
+		expect(handled).toBe(true);
+		expect(h.setSessionName).toHaveBeenCalledWith("tui-name", "user");
+		expect(h.showStatus).toHaveBeenCalledWith('Session renamed to "tui-name".');
+		expect(h.setText).toHaveBeenCalledWith("");
+	});
+
+	it("shows a usage message for an empty rename", async () => {
+		const h = tuiRuntime();
+		const handled = await executeBuiltinSlashCommand("/session rename   ", h);
+		expect(handled).toBe(true);
+		expect(h.setSessionName).not.toHaveBeenCalled();
+		expect(h.showStatus).toHaveBeenCalledWith("Usage: /session rename <name>");
+		expect(h.setText).toHaveBeenCalledWith("");
+	});
+
+	it("leaves the durable session id unchanged", async () => {
+		const h = tuiRuntime();
+		expect(h.ctx.session.sessionId).toBe(SESSION_ID);
+		await executeBuiltinSlashCommand("/session rename whatever", h);
+		expect(h.ctx.session.sessionId).toBe(SESSION_ID);
+	});
+});
+
+describe("/session rename (text/ACP handle)", () => {
+	const spec = BUILTIN_SESSION_SLASH_COMMANDS.find(c => c.name === "session")!;
+
+	it("renames the current session via the text handler", async () => {
+		const h = textRuntime();
+		const command = {
+			name: "session",
+			args: "rename foo",
+			text: "/session rename foo",
+		} as unknown as ParsedSlashCommand;
+		await spec.handle?.(command, h.runtime);
+		expect(h.setSessionName).toHaveBeenCalledWith("foo", "user");
+		expect(h.output).toHaveBeenCalledWith('Session renamed to "foo".');
+	});
+
+	it("shows a usage message for an empty rename without renaming", async () => {
+		const h = textRuntime();
+		const command = {
+			name: "session",
+			args: "rename   ",
+			text: "/session rename   ",
+		} as unknown as ParsedSlashCommand;
+		await spec.handle?.(command, h.runtime);
+		expect(h.setSessionName).not.toHaveBeenCalled();
+		expect(h.output).toHaveBeenCalledWith(expect.stringContaining("rename"));
+	});
+});

--- a/packages/stats/CHANGELOG.md
+++ b/packages/stats/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added a Today time range to the dashboard and stats API that anchors the chart to local midnight, so just-after-midnight activity is labeled on the correct day in any timezone.
+- Added a versioned public query API (`/api/v1/*`) with parameter validation and a framework-neutral TypeScript client SDK.
+- Added `omp stats create-site` scaffolding for embedding the stats dashboard into other pages.
+- Added `getSessionSummaries()`: a per-session usage query that groups `messages` by `session_file` (requests, input/output/cache tokens, cost), reused by the coding-agent `/sessions` manager.
+- Added a redesigned dashboard with overview and per-section inner pages, named dashboard layouts, density modes, and a command palette.
+
 ## [18.0.4] - 2026-08-24
 
 ### Fixed

--- a/packages/stats/src/aggregator.ts
+++ b/packages/stats/src/aggregator.ts
@@ -17,6 +17,7 @@ import {
 	getOverallStats,
 	getProviderHourlyBurn,
 	getProviderTimeSeries,
+	getSessionSummaries as getSessionSummariesFromDb,
 	getStatsByAgentType,
 	getStatsByFolder,
 	getStatsByModel,
@@ -33,6 +34,7 @@ import {
 	setFileOffset,
 	updateToolResults,
 	updateUserMessageLinks,
+	type SessionSummary,
 } from "./db";
 import { getSessionEntry, listAllSessionFiles, type ParseSessionResult, parseSessionFile } from "./parser";
 import type { SyncWorkerRequest, SyncWorkerResponse } from "./sync-worker";
@@ -567,8 +569,18 @@ export async function getProviderDashboardStats(range?: string | null): Promise<
 	return {
 		providers,
 		hourly: getProviderHourlyBurn(cutoff ?? undefined),
-		series: getProviderTimeSeries(modelSeriesDays, cutoff, modelSeriesBucketMs),
+		series: getProviderTimeSeries(modelSeriesDays, cutoff, modelSeriesBucketMs, bucketOrigin),
 		usageSeries,
 		windowInsights,
 	};
+}
+/**
+ * Per-session usage summaries (requests, tokens, cost), grouped by session
+ * file. Consistent with the other aggregator wrappers: resolves `range` to a
+ * cutoff via {@link getTimeRangeConfig} and delegates to the db query.
+ */
+export async function getSessionSummaries(range?: string | null): Promise<SessionSummary[]> {
+	await initDb();
+	const { cutoff } = getTimeRangeConfig(range);
+	return getSessionSummariesFromDb(cutoff ?? undefined);
 }

--- a/packages/stats/src/db.ts
+++ b/packages/stats/src/db.ts
@@ -769,6 +769,65 @@ export function getStatsByFolder(cutoff?: number): FolderStats[] {
 		...buildAggregatedStats([row]),
 	}));
 }
+/**
+ * Per-session usage aggregate, grouped by `session_file`.
+ *
+ * Consumed by the session-control layer to attach best-effort cost/token
+ * totals to individual sessions without re-deriving dashboard aggregates.
+ * Mirrors the column semantics of {@link getOverallStats}: `cost` is
+ * `SUM(cost_total)` and the token columns are the raw `messages` sums. A
+ * `null`/`0` cutoff returns every stored session; a positive cutoff restricts
+ * to rows whose `timestamp >= cutoff`.
+ */
+export interface SessionSummary {
+	sessionFile: string;
+	requests: number;
+	inputTokens: number;
+	outputTokens: number;
+	cacheRead: number;
+	cacheWrite: number;
+	cost: number;
+}
+
+export function getSessionSummaries(sinceCutoff?: number): SessionSummary[] {
+	if (!db) return [];
+
+	const hasCutoff = sinceCutoff !== undefined && sinceCutoff > 0;
+	const stmt = db.prepare(`
+		SELECT
+			session_file AS sessionFile,
+			COUNT(*) AS requests,
+			SUM(input_tokens) AS inputTokens,
+			SUM(output_tokens) AS outputTokens,
+			SUM(cache_read_tokens) AS cacheRead,
+			SUM(cache_write_tokens) AS cacheWrite,
+			SUM(cost_total) AS cost
+		FROM messages
+		${hasCutoff ? "WHERE timestamp >= ?" : ""}
+		GROUP BY session_file
+		ORDER BY cost DESC
+	`);
+
+	const rows = (hasCutoff ? stmt.all(sinceCutoff) : stmt.all()) as Array<{
+		sessionFile: string;
+		requests: number;
+		inputTokens: number | null;
+		outputTokens: number | null;
+		cacheRead: number | null;
+		cacheWrite: number | null;
+		cost: number | null;
+	}>;
+
+	return rows.map(row => ({
+		sessionFile: row.sessionFile,
+		requests: row.requests ?? 0,
+		inputTokens: row.inputTokens ?? 0,
+		outputTokens: row.outputTokens ?? 0,
+		cacheRead: row.cacheRead ?? 0,
+		cacheWrite: row.cacheWrite ?? 0,
+		cost: row.cost ?? 0,
+	}));
+}
 
 /**
  * Get token usage grouped by agent type (main agent, task subagents, advisor).

--- a/packages/stats/src/index.ts
+++ b/packages/stats/src/index.ts
@@ -8,6 +8,8 @@ import { formatStatsDashboardUrl, startServer } from "./server";
 
 export {
 	getDashboardStats,
+	getSessionSummaries,
+	getRequestsPaginated,
 	getToolDashboardStats,
 	getTotalMessageCount,
 	type SyncOptions,
@@ -15,6 +17,7 @@ export {
 	smokeTestSyncWorker,
 	syncAllSessions,
 } from "./aggregator";
+export type { SessionSummary } from "./aggregator";
 export { closeDb } from "./db";
 export { getGainDashboardStats } from "./gain-aggregator";
 export { formatStatsDashboardUrl, startServer } from "./server";

--- a/packages/stats/test/session-summaries.test.ts
+++ b/packages/stats/test/session-summaries.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it } from "bun:test";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { getSessionSummaries, initDb, insertMessageStats } from "@oh-my-pi/omp-stats/db";
+import type { MessageStats } from "@oh-my-pi/omp-stats/types";
+import { installStatsTestIsolation } from "./helpers/temp-agent";
+
+installStatsTestIsolation("@pi-stats-summaries-");
+
+function makeStats(
+	entryId: string,
+	sessionFile: string,
+	input: number,
+	output: number,
+	cacheRead: number,
+): MessageStats {
+	return {
+		sessionFile,
+		entryId,
+		folder: "/tmp/project",
+		model: "gpt-5.4",
+		provider: "openai-codex",
+		api: "openai-codex-responses",
+		timestamp: Date.now(),
+		duration: 1000,
+		ttft: 100,
+		stopReason: "stop",
+		errorMessage: null,
+		usage: {
+			input,
+			output,
+			cacheRead,
+			cacheWrite: 0,
+			totalTokens: input + output + cacheRead,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		agentType: "main",
+	};
+}
+
+describe("stats getSessionSummaries", () => {
+	beforeEach(async () => {
+		await initDb();
+	});
+
+	it("aggregates per-session requests and tokens", async () => {
+		const fileA = "/tmp/session-a.jsonl";
+		const fileB = "/tmp/session-b.jsonl";
+		await insertMessageStats([
+			makeStats("e1", fileA, 1000, 500, 200),
+			makeStats("e2", fileA, 1000, 500, 200),
+			makeStats("e3", fileB, 200, 100, 50),
+		]);
+
+		const summaries = getSessionSummaries();
+		const byFile = new Map(summaries.map(s => [s.sessionFile, s]));
+
+		expect(byFile.get(fileA)?.requests).toBe(2);
+		expect(byFile.get(fileA)?.inputTokens).toBe(2000);
+		expect(byFile.get(fileA)?.outputTokens).toBe(1000);
+		expect(byFile.get(fileA)?.cacheRead).toBe(400);
+		expect(byFile.get(fileB)?.requests).toBe(1);
+		expect(byFile.get(fileB)?.inputTokens).toBe(200);
+		expect(byFile.get(fileB)?.outputTokens).toBe(100);
+	});
+
+	it("computes cost from catalog pricing", async () => {
+		const fileA = "/tmp/session-cost-a.jsonl";
+		const input = 1000;
+		const output = 500;
+		const cacheRead = 200;
+		await insertMessageStats([makeStats("e1", fileA, input, output, cacheRead)]);
+
+		const modelCost = getBundledModel("openai-codex", "gpt-5.4").cost;
+		const expectedCost =
+			(modelCost.input / 1_000_000) * input +
+			(modelCost.output / 1_000_000) * output +
+			(modelCost.cacheRead / 1_000_000) * cacheRead;
+
+		const summary = getSessionSummaries().find(s => s.sessionFile === fileA);
+		expect(summary).toBeDefined();
+		expect(summary!.cost).toBeCloseTo(expectedCost, 6);
+	});
+
+	it("respects the cutoff (excludes future-timestamped queries)", async () => {
+		const fileA = "/tmp/session-cutoff-a.jsonl";
+		await insertMessageStats([makeStats("e1", fileA, 1000, 500, 200)]);
+
+		expect(getSessionSummaries(Date.now() + 60_000).length).toBe(0);
+		expect(getSessionSummaries(undefined).length).toBe(1);
+		expect(getSessionSummaries(0).length).toBe(1);
+	});
+});


### PR DESCRIPTION
I reviewed the full diff; this adds an operator-facing session manager plus git-backed workspace checkpoints/rollback as five self-contained commits on top of main, with no dependency on the in-flight profiles branch.

## What changed

**/sessions manager** - fullscreen dashboard listing persisted sessions (current + archived + lifecycle status) with filter/sort cycles, a details pane, archive/pause/kill scoped by durable session id, and graceful column degradation on narrow terminals. Open reuses the existing resume flow.

**Workspace checkpoints** - /checkpoint [label|list|show] and /rollback [<id>] built on git plumbing: temp-index full-tree capture (tracked + untracked non-ignored, .gitignore respected, oversize guard), refs under refs/omp/checkpoints/<sessionId>/<id>, atomic metadata beside session data, content-addressed dedup (identical state costs ~0 disk), bounded retention (manual checkpoints protected). Rollback runs as PREPARE->SAFETY->APPLY->VERIFY->COMMIT with an always-on safety checkpoint and never moves HEAD. Opt-in auto-captures before destructive git commands and >=5-file patches (off by default).

**Session layer** - new session-control.ts merging listings with registry/gate truth and a shared per-session cost aggregate (getSessionSummaries()) read from the same stats DB the dashboard uses; unavailable metrics render as em dash rather than fabricated numbers. /session rename <name> included.

## Verification
- 101 focused tests green across capture/dedup/retention/rollback-transaction/session-layer/TUI/command suites, stable across repeated combined runs
- Multi-session integration test: two linked worktrees of one repo - checkpoint/rollback isolation both directions, canonical untouched, wrong-session rejection via the real service path
- tsgo error set identical to main baseline (zero new); biome clean on changed files
- Live pty smoke from source: manager renders real rows at 160/120/80/60 cols (~240 ms open), checkpoint create ~310 ms, foreign-id rollback correctly rejected

## Notes
- Rollback rewinds workspace state only; transcripts are preserved and a workspace_rolled_back entry notifies the running agent
- Profile display feature-detects getActiveProfile(), so this stacks cleanly before or after the profiles PR
- Docs under docs/sessions-manager.md and docs/workspace-checkpoints.md