### PR TITLE
fix(coding-agent): hydrate benchmark model caches

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `omp bench` and `omp if-bench` failing to resolve credential-scoped dynamic models already listed by `omp models`.
+
 ## [18.0.5] - 2026-08-25
 
 ### Added

--- a/packages/coding-agent/src/cli/bench-runtime.ts
+++ b/packages/coding-agent/src/cli/bench-runtime.ts
@@ -63,6 +63,7 @@ export async function createDefaultBenchRuntime(): Promise<BenchRuntime> {
 		const cwd = getProjectDir();
 		const settings = await Settings.init({ cwd });
 		const modelRegistry = new ModelRegistry(authStorage);
+		await modelRegistry.hydrateCredentialScopedModelCaches();
 		await loadCliExtensionProviders(modelRegistry, settings, cwd);
 		return {
 			modelRegistry,

--- a/packages/coding-agent/test/bash-executor.test.ts
+++ b/packages/coding-agent/test/bash-executor.test.ts
@@ -900,25 +900,28 @@ exit 64
 		if (process.platform === "win32") return;
 
 		const sessionKey = "parallel-overlap";
+		const started = path.join(tempDir, "parallel-overlap.started");
+		const release = path.join(tempDir, "parallel-overlap.release");
 		const order: string[] = [];
-		const slow = executeBash('sleep 0.15 && echo "A-done"', { cwd: tempDir, timeout: 5000, sessionKey }).then(
-			result => {
-				order.push("slow");
-				return result;
-			},
-		);
-		const fast = executeBash('echo "B-done"', { cwd: tempDir, timeout: 5000, sessionKey }).then(result => {
-			order.push("fast");
+		const slow = executeBash(
+			`touch ${shellQuote(started)}; while [ ! -f ${shellQuote(release)} ]; do sleep 0.02; done; echo "A-done"`,
+			{ cwd: tempDir, timeout: 5000, sessionKey },
+		).then(result => {
+			order.push("slow");
 			return result;
 		});
+		await pollUntil(() => fs.existsSync(started), Date.now() + 4000);
+		expect(fs.existsSync(started)).toBe(true);
 
-		const [slowResult, fastResult] = await Promise.all([slow, fast]);
+		const fastResult = await executeBash('echo "B-done"', { cwd: tempDir, timeout: 5000, sessionKey });
+		order.push("fast");
+		fs.writeFileSync(release, "");
+		const slowResult = await slow;
+
 		expect(slowResult.exitCode).toBe(0);
 		expect(slowResult.output).toContain("A-done");
 		expect(fastResult.exitCode).toBe(0);
 		expect(fastResult.output).toContain("B-done");
-		// If the second call had queued behind the persistent session it could
-		// not finish before the 150ms sleep of the first.
 		expect(order).toEqual(["fast", "slow"]);
 	});
 

--- a/packages/coding-agent/test/bench-auth-fallback.test.ts
+++ b/packages/coding-agent/test/bench-auth-fallback.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
 import type {
 	Api,
 	ApiKeyResolver,
@@ -8,9 +10,13 @@ import type {
 	Model,
 	SimpleStreamOptions,
 } from "@oh-my-pi/pi-ai";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import { writeModelCache } from "@oh-my-pi/pi-catalog/model-cache";
+import { resolveModelCacheProviderId } from "@oh-my-pi/pi-catalog/provider-models";
 import { type BenchSummary, runBenchCommand } from "@oh-my-pi/pi-coding-agent/cli/bench-cli";
 import type { BenchModelRegistry } from "@oh-my-pi/pi-coding-agent/cli/bench-runtime";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { getModelDbPath, TempDir } from "@oh-my-pi/pi-utils";
 
 function fakeModel(provider: string, id: string): Model<Api> {
 	return {
@@ -95,6 +101,75 @@ async function runBench(
 	);
 	return { summary, stderr: stderr.join("") };
 }
+describe("default bench runtime", () => {
+	it("hydrates credential-scoped model caches before selector resolution", async () => {
+		const tempDir = TempDir.createSync("@omp-bench-runtime-");
+		const apiKey = "bench-cache-test-key";
+		const modelId = "cached-bench-model";
+		const cacheDbPath = getModelDbPath(tempDir.path());
+		await fs.mkdir(path.dirname(cacheDbPath), { recursive: true });
+		try {
+			writeModelCache(
+				resolveModelCacheProviderId("opencode-go", { apiKey }),
+				Date.now(),
+				[
+					buildModel({
+						id: modelId,
+						name: "Cached Bench Model",
+						provider: "opencode-go",
+						api: "openai-completions",
+						baseUrl: "https://opencode.ai/zen/go/v1",
+						reasoning: false,
+						input: ["text"],
+						cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+						contextWindow: 128_000,
+						maxTokens: 4096,
+					}),
+				],
+				true,
+				"",
+				cacheDbPath,
+			);
+			const script = `
+				import { createDefaultBenchRuntime, resolveBenchTargets } from "./packages/coding-agent/src/cli/bench-runtime.ts";
+				const runtime = await createDefaultBenchRuntime();
+				try {
+					const [target] = resolveBenchTargets(
+						["opencode-go/${modelId}"],
+						runtime.modelRegistry,
+						runtime.settings,
+						() => {},
+					);
+					console.log(target.model.provider + "/" + target.model.id);
+				} finally {
+					runtime.close?.();
+				}
+			`;
+			const child = Bun.spawn([process.execPath, "-e", script], {
+				cwd: path.resolve(import.meta.dir, "../../.."),
+				env: {
+					...process.env,
+					NO_COLOR: "1",
+					OPENCODE_API_KEY: apiKey,
+					PI_CODING_AGENT_DIR: tempDir.path(),
+				},
+				stdout: "pipe",
+				stderr: "pipe",
+			});
+			const [stdout, stderr, exitCode] = await Promise.all([
+				new Response(child.stdout).text(),
+				new Response(child.stderr).text(),
+				child.exited,
+			]);
+
+			expect(exitCode).toBe(0);
+			expect(stderr).toBe("");
+			expect(stdout.trim()).toBe(`opencode-go/${modelId}`);
+		} finally {
+			await tempDir.remove();
+		}
+	});
+});
 
 describe("bench credential-aware provider selection", () => {
 	it("redirects an ambiguous shared-id selector to an authenticated provider", async () => {


### PR DESCRIPTION
## Summary

- hydrate credential-scoped model caches before benchmark selector resolution
- cover cached OpenCode Go model resolution in the default benchmark runtime
- document the user-visible fix
- stabilize the pre-existing bash overlap test with explicit session-owner synchronization

## CI follow-up

The initial CI failure was unrelated to the benchmark change and was not a GitHub Actions infrastructure failure. The existing bash overlap test started its slow and fast commands without first ensuring the slow command owned the persistent session, so CI scheduling could reverse the expected completion order. The test now waits for an explicit start marker and uses a release marker instead of relying on a 150 ms timing assumption.

## Verification

- `bun test packages/coding-agent/test/bench-auth-fallback.test.ts packages/coding-agent/test/if-bench.test.ts`
- `bun test packages/coding-agent/test/bash-executor.test.ts --test-name-pattern "runs overlapping calls" --rerun-each 20`
- `bun run check` in `packages/coding-agent`
- resolved `opencode-go/longcat-2.0` through `createDefaultBenchRuntime`
- all required PR checks pass