### PR TITLE
fix(cli): repair stale Windows update launchers

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Expanded git TUI navigation and file-management shortcuts, including refresh, stage/unstage, directory operations, hunk and file navigation, pane movement, diff-view selection, commit-form access, and paging.
 
 ### Fixed
+- Fixed `omp update` leaving standalone Windows binaries on the old version when stale Bun launcher metadata was present.
 
 - Fixed race condition where tunnel startup was incorrectly reported as failure on quick process exit
 - Fixed Obsidian theme task instructions and usage-limit text becoming unreadable against dark backgrounds.

--- a/packages/coding-agent/src/cli/update-cli.ts
+++ b/packages/coding-agent/src/cli/update-cli.ts
@@ -1119,16 +1119,25 @@ function resolveOmpPath(): string | undefined {
 }
 
 /**
+ * Parse the version a launcher reports from `omp --version` output
+ * (`omp/X.Y.Z`, or a prerelease such as `omp/X.Y.Z-canary.1`).
+ *
+ * The prerelease suffix is preserved so a correctly installed canary build
+ * verifies as up to date instead of appearing to report a stale `X.Y.Z` and
+ * being mistaken for an unreplaced launcher.
+ */
+export function parseReportedVersion(output: string): string | undefined {
+	return output.match(/\/(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)/)?.[1];
+}
+
+/**
  * Run a specific binary and check if it reports the expected version.
  */
 async function verifyBinaryAtPath(binaryPath: string, expectedVersion: string): Promise<InstalledVersionVerification> {
 	try {
 		const result = await $`${binaryPath} --version`.quiet().nothrow();
 		if (result.exitCode !== 0) return { ok: false, path: binaryPath };
-		const output = result.text().trim();
-		// Output format: "omp/X.Y.Z"
-		const match = output.match(/\/(\d+\.\d+\.\d+)/);
-		const actual = match?.[1];
+		const actual = parseReportedVersion(result.text().trim());
 		return { ok: actual === expectedVersion, actual, path: binaryPath };
 	} catch {
 		return { ok: false, path: binaryPath };

--- a/packages/coding-agent/src/cli/update-cli.ts
+++ b/packages/coding-agent/src/cli/update-cli.ts
@@ -181,11 +181,17 @@ export function shouldForceBinaryUpdate(
 
 /**
  * Select and validate the binary asset from GitHub release metadata.
+ *
+ * Draft releases are always rejected. Prereleases are rejected unless
+ * `options.allowPrerelease` is set, which the canary channel passes: canary
+ * GitHub releases are published as prereleases, and the exact-tag match below
+ * still pins the download to the specific requested version.
  */
 export function resolveReleaseBinaryAsset(
 	release: unknown,
 	expectedTag: string,
 	binaryName: string,
+	options: { allowPrerelease?: boolean } = {},
 ): ReleaseBinaryAsset {
 	if (!isRecord(release)) {
 		throw new Error("Invalid GitHub release metadata");
@@ -193,8 +199,11 @@ export function resolveReleaseBinaryAsset(
 	if (release.tag_name !== expectedTag) {
 		throw new Error(`GitHub release tag mismatch: expected ${expectedTag}`);
 	}
-	if (release.draft !== false || release.prerelease !== false) {
-		throw new Error(`GitHub release ${expectedTag} is not a published stable release`);
+	if (release.draft !== false) {
+		throw new Error(`GitHub release ${expectedTag} is a draft, not a published release`);
+	}
+	if (release.prerelease !== false && !options.allowPrerelease) {
+		throw new Error(`GitHub release ${expectedTag} is a prerelease; only canary updates install prerelease assets`);
 	}
 	if (!Array.isArray(release.assets)) {
 		throw new Error(`GitHub release ${expectedTag} has no asset list`);
@@ -237,6 +246,7 @@ async function getReleaseBinaryAsset(
 	binaryName: string,
 	fetchImpl: Fetch = fetch,
 	githubToken: string | undefined = $env.GITHUB_TOKEN || $env.GH_TOKEN,
+	allowPrerelease = false,
 ): Promise<ReleaseBinaryAsset> {
 	const tag = `v${expectedVersion}`;
 	const headers: Record<string, string> = {
@@ -267,7 +277,7 @@ async function getReleaseBinaryAsset(
 		throw new Error(`Failed to fetch GitHub release metadata: ${response.statusText}`);
 	}
 
-	return resolveReleaseBinaryAsset(await response.json(), tag, binaryName);
+	return resolveReleaseBinaryAsset(await response.json(), tag, binaryName, { allowPrerelease });
 }
 
 export interface VerifiedBinaryDownloadOptions {
@@ -1558,7 +1568,11 @@ export interface ManagerUpdateSteps {
 }
 
 /** Production {@link ManagerUpdateSteps}: a bun/npm global install plus an in-place binary takeover. */
-function packageManagerUpdateSteps(manager: "bun" | "npm", release: ReleaseInfo): ManagerUpdateSteps {
+function packageManagerUpdateSteps(
+	manager: "bun" | "npm",
+	release: ReleaseInfo,
+	allowPrerelease: boolean,
+): ManagerUpdateSteps {
 	return {
 		manager,
 		install: () => (manager === "bun" ? updateViaBun(release) : updateViaNpm(release)),
@@ -1566,8 +1580,11 @@ function packageManagerUpdateSteps(manager: "bun" | "npm", release: ReleaseInfo)
 		repair: async launcherPath => {
 			// npm's script shims outrank `.exe` in PowerShell and Git Bash, so
 			// they must be retired rather than merely shadowed.
-			if (isWindowsScriptLauncherPath(launcherPath)) await updateViaShimTakeover(launcherPath, release.version);
-			else await updateViaBinaryAt(launcherPath, release.version);
+			if (isWindowsScriptLauncherPath(launcherPath)) {
+				await updateViaShimTakeover(launcherPath, release.version, { allowPrerelease });
+			} else {
+				await updateViaBinaryAt(launcherPath, release.version, { allowPrerelease });
+			}
 		},
 	};
 }
@@ -1683,6 +1700,7 @@ export async function updateViaBinaryAt(
 		binaryName?: string;
 		fetchImpl?: Fetch;
 		githubToken?: string;
+		allowPrerelease?: boolean;
 		verifyInstalledVersion?: typeof verifyInstalledVersion;
 	} = {},
 ): Promise<void> {
@@ -1699,7 +1717,13 @@ export async function updateViaBinaryAt(
 	const attempt = `${Date.now()}.${process.pid}.${updateAttemptSeq++}`;
 	const tempPath = `${targetPath}.${attempt}.new`;
 	const backupPath = `${targetPath}.${attempt}.bak`;
-	const asset = await getReleaseBinaryAsset(expectedVersion, binaryName, options.fetchImpl, options.githubToken);
+	const asset = await getReleaseBinaryAsset(
+		expectedVersion,
+		binaryName,
+		options.fetchImpl,
+		options.githubToken,
+		options.allowPrerelease,
+	);
 	console.log(chalk.dim(`Downloading ${binaryName}…`));
 	await downloadVerifiedBinary({
 		url: asset.url,
@@ -1776,6 +1800,7 @@ export async function updateViaShimTakeover(
 		binaryName?: string;
 		fetchImpl?: Fetch;
 		githubToken?: string;
+		allowPrerelease?: boolean;
 		verifyBinary?: typeof verifyBinaryAtPath;
 	} = {},
 ): Promise<void> {
@@ -1784,7 +1809,13 @@ export async function updateViaShimTakeover(
 	const exePath = path.join(launcherDir, `${APP_NAME}.exe`);
 	const attempt = `${Date.now()}.${process.pid}.${updateAttemptSeq++}`;
 	const tempPath = `${exePath}.${attempt}.new`;
-	const asset = await getReleaseBinaryAsset(expectedVersion, binaryName, options.fetchImpl, options.githubToken);
+	const asset = await getReleaseBinaryAsset(
+		expectedVersion,
+		binaryName,
+		options.fetchImpl,
+		options.githubToken,
+		options.allowPrerelease,
+	);
 	console.log(chalk.dim(`Downloading ${binaryName}…`));
 	await downloadVerifiedBinary({
 		url: asset.url,
@@ -1959,6 +1990,7 @@ export async function runUpdateCommand(opts: {
 	// same PATH entry live.
 	try {
 		const forceBinary = shouldForceBinaryUpdate(release);
+		const allowPrerelease = channel === "canary";
 		const target = await resolveUpdateTarget({ allowPackageManagers: !forceBinary });
 		if (channel === "canary" && (target.method === "nix" || target.method === "brew" || target.method === "mise")) {
 			console.log(chalk.yellow("Canary updates are only supported for bun, npm, or binary installs."));
@@ -1979,20 +2011,24 @@ export async function runUpdateCommand(opts: {
 				// skipped), so the launcher path is always known.
 				if (!target.path) throw new Error(`Could not resolve ${APP_NAME} launcher path in PATH`);
 				console.log(chalk.dim("This release ships as a standalone binary; replacing the script launcher."));
-				await updateViaShimTakeover(target.path, release.version);
+				await updateViaShimTakeover(target.path, release.version, { allowPrerelease });
 				console.log(
 					chalk.yellow(
 						`This install is no longer managed by ${target.method}. Removing the old global package may delete this launcher; if it does, reinstall with: ${installerHint()}`,
 					),
 				);
 			} else {
-				await updateViaManager(release, target.path, packageManagerUpdateSteps(target.method, release));
+				await updateViaManager(
+					release,
+					target.path,
+					packageManagerUpdateSteps(target.method, release, allowPrerelease),
+				);
 			}
 		} else {
 			if (forceBinary && target.replacesSymlink) {
 				console.log(chalk.dim("Replacing the package-manager launcher with the standalone binary."));
 			}
-			await updateViaBinaryAt(target.path, release.version);
+			await updateViaBinaryAt(target.path, release.version, { allowPrerelease });
 			if (forceBinary && target.replacesSymlink) {
 				console.log(
 					chalk.yellow(

--- a/packages/coding-agent/src/cli/update-cli.ts
+++ b/packages/coding-agent/src/cli/update-cli.ts
@@ -1565,22 +1565,19 @@ function packageManagerUpdateSteps(manager: "bun" | "npm", release: ReleaseInfo)
 
 /**
  * Run a package-manager self-update, repairing the launcher when the manager
- * leaves this install without a working `omp`.
+ * succeeds without updating it or leaves no working launcher behind.
  *
  * A global reinstall has to replace files the running process still holds open.
  * On Windows that is unavoidable — the launcher image, the loaded native addon,
- * and the package tree being executed are all locked — and either manager can
- * end the attempt with no usable launcher: npm moves the global bin shims aside
- * before unpacking and restores them only if its own rollback succeeds, and bun
- * aborts the whole install on the first file it cannot overwrite, which leaves
- * a half-replaced package the launcher can no longer run.
+ * and the package tree being executed are all locked. Bun writes the new
+ * `.bunx` metadata before ignoring EBUSY from the launcher replacement, while
+ * npm can retire its shims before an install fails.
  *
- * Only a launcher that is gone from PATH, or that can no longer report a
- * version, is repaired — by taking its path over with the standalone release
- * binary. A launcher that still reports the old version means the install did
- * not land (usually a transient registry failure): the previous version keeps
- * working, so that case surfaces the error and leaves the managed install
- * alone instead of migrating a healthy install off its manager.
+ * A successful install whose PATH launcher still reports the previous version
+ * means the manager no longer controls that launcher, so it is taken over with
+ * the standalone binary. If the install itself failed, a launcher that still
+ * reports a version is preserved and the manager error is surfaced; only a
+ * missing or unusable launcher is repaired.
  */
 export async function updateViaManager(
 	release: ReleaseInfo,
@@ -1597,8 +1594,9 @@ export async function updateViaManager(
 		installError = err;
 	}
 	const result = verification ?? (await steps.verify());
-	const launcherBroken = !result.ok && (result.path === undefined || result.actual === undefined);
-	if (!launcherBroken) {
+	const launcherNeedsRepair =
+		!result.ok && (installError === undefined || result.path === undefined || result.actual === undefined);
+	if (!launcherNeedsRepair) {
 		if (installError) throw installError;
 		printVerificationResult(result, release.version);
 		return;
@@ -1608,13 +1606,13 @@ export async function updateViaManager(
 	}
 	console.log(
 		chalk.yellow(
-			`\n${steps.manager} left no working ${APP_NAME} launcher (${formatVerificationFailure(result, release.version)}); installing the standalone binary at ${launcherPath}.`,
+			`\n${steps.manager} did not install a working ${APP_NAME} ${release.version} launcher (${formatVerificationFailure(result, release.version)}); installing the standalone binary at ${launcherPath}.`,
 		),
 	);
 	try {
 		await steps.repair(launcherPath);
 	} catch (err) {
-		throw new Error(`${steps.manager} install failed and the launcher could not be repaired: ${err}`, {
+		throw new Error(`${steps.manager} update did not produce a working launcher and binary repair failed: ${err}`, {
 			cause: installError ?? err,
 		});
 	}

--- a/packages/coding-agent/src/cli/update-cli.ts
+++ b/packages/coding-agent/src/cli/update-cli.ts
@@ -1599,11 +1599,12 @@ function packageManagerUpdateSteps(
  * `.bunx` metadata before ignoring EBUSY from the launcher replacement, while
  * npm can retire its shims before an install fails.
  *
- * A successful install whose PATH launcher still reports the previous version
+ * A successful install whose PATH launcher still reports an older version
  * means the manager no longer controls that launcher, so it is taken over with
- * the standalone binary. If the install itself failed, a launcher that still
- * reports a version is preserved and the manager error is surfaced; only a
- * missing or unusable launcher is repaired.
+ * the standalone binary. A newer launcher may have been installed by a
+ * concurrent update and is left untouched. If the install itself failed, a
+ * launcher that still reports a version is preserved and the manager error is
+ * surfaced; only a missing or unusable launcher is repaired.
  */
 export async function updateViaManager(
 	release: ReleaseInfo,
@@ -1620,8 +1621,10 @@ export async function updateViaManager(
 		installError = err;
 	}
 	const result = verification ?? (await steps.verify());
-	const launcherNeedsRepair =
-		!result.ok && (installError === undefined || result.path === undefined || result.actual === undefined);
+	const launcherIsBroken = result.path === undefined || result.actual === undefined;
+	const launcherIsOlder =
+		installError === undefined && result.actual !== undefined && compareVersions(result.actual, release.version) < 0;
+	const launcherNeedsRepair = !result.ok && (launcherIsBroken || launcherIsOlder);
 	if (!launcherNeedsRepair) {
 		if (installError) throw installError;
 		printVerificationResult(result, release.version);

--- a/packages/coding-agent/test/update-cli.test.ts
+++ b/packages/coding-agent/test/update-cli.test.ts
@@ -1513,13 +1513,13 @@ describe("update-cli manager update recovery", () => {
 		expect(calls).toEqual(["install", `repair:${launcherPath}`]);
 	});
 
-	it("leaves a working managed install on its manager when the new version did not land", async () => {
+	it("takes the launcher over when the manager succeeds but the previous version remains", async () => {
 		vi.spyOn(console, "log").mockImplementation(() => {});
 		const { steps, calls } = scriptedSteps({ install: { ok: false, path: launcherPath, actual: "17.4.2" } });
 
 		await updateViaManager(release, launcherPath, steps);
 
-		expect(calls).toEqual(["install"]);
+		expect(calls).toEqual(["install", `repair:${launcherPath}`]);
 	});
 
 	it("surfaces the install failure without a takeover when the previous launcher still runs", async () => {
@@ -1559,7 +1559,7 @@ describe("update-cli manager update recovery", () => {
 		});
 
 		await expect(updateViaManager(release, launcherPath, steps)).rejects.toThrow(
-			"launcher could not be repaired: Error: no binary asset",
+			"update did not produce a working launcher and binary repair failed: Error: no binary asset",
 		);
 	});
 });

--- a/packages/coding-agent/test/update-cli.test.ts
+++ b/packages/coding-agent/test/update-cli.test.ts
@@ -1576,6 +1576,15 @@ describe("update-cli manager update recovery", () => {
 		expect(calls).toEqual(["install", `repair:${launcherPath}`]);
 	});
 
+	it("leaves a concurrently installed newer launcher untouched", async () => {
+		vi.spyOn(console, "log").mockImplementation(() => {});
+		const { steps, calls } = scriptedSteps({ install: { ok: false, path: launcherPath, actual: "18.0.2" } });
+
+		await updateViaManager(release, launcherPath, steps);
+
+		expect(calls).toEqual(["install"]);
+	});
+
 	it("surfaces the install failure without a takeover when the previous launcher still runs", async () => {
 		vi.spyOn(console, "log").mockImplementation(() => {});
 		const { steps, calls } = scriptedSteps({

--- a/packages/coding-agent/test/update-cli.test.ts
+++ b/packages/coding-agent/test/update-cli.test.ts
@@ -18,6 +18,7 @@ import {
 	isMuslLinuxForTest,
 	type ManagerUpdateSteps,
 	migrateRenamedInstall,
+	parseReportedVersion,
 	parseUpdateArgs,
 	pruneBunInstallCache,
 	type ReleaseInfo,
@@ -118,6 +119,17 @@ describe("parseUpdateArgs", () => {
 		expect(() => parseUpdateArgs(["update", "--canary", "--stable"])).toThrow(
 			"--canary and --stable are mutually exclusive",
 		);
+	});
+});
+
+describe("parseReportedVersion", () => {
+	it("preserves the prerelease suffix so a canary launcher verifies as up to date", () => {
+		// Regression: dropping `-canary.1` made a correctly installed canary
+		// build look like a stale `X.Y.Z` launcher, triggering a binary repair
+		// that rejects the prerelease GitHub release.
+		expect(parseReportedVersion("omp/18.0.6-canary.1")).toBe("18.0.6-canary.1");
+		expect(parseReportedVersion("omp/18.0.5")).toBe("18.0.5");
+		expect(parseReportedVersion("not a version")).toBeUndefined();
 	});
 });
 

--- a/packages/coding-agent/test/update-cli.test.ts
+++ b/packages/coding-agent/test/update-cli.test.ts
@@ -811,9 +811,12 @@ describe("update-cli release binary integrity", () => {
 		);
 	});
 
-	it("rejects release metadata that does not identify one exact stable asset", () => {
+	it("rejects a draft, a stable-channel prerelease, and metadata without one exact asset", () => {
+		expect(() => resolveReleaseBinaryAsset({ ...releaseAsset(), draft: true }, tag, binaryName)).toThrow(
+			"is a draft",
+		);
 		expect(() => resolveReleaseBinaryAsset({ ...releaseAsset(), prerelease: true }, tag, binaryName)).toThrow(
-			"is not a published stable release",
+			"is a prerelease",
 		);
 		expect(() => resolveReleaseBinaryAsset({ ...releaseAsset(), assets: [] }, tag, binaryName)).toThrow(
 			`has 0 assets named ${binaryName}`,
@@ -832,6 +835,18 @@ describe("update-cli release binary integrity", () => {
 				binaryName,
 			),
 		).toThrow("has an unexpected download URL");
+	});
+
+	it("installs a prerelease asset only when a canary update permits it", () => {
+		// Canary GitHub releases are marked prerelease; a canary update passes
+		// allowPrerelease so its exact-tag asset installs, while a draft stays
+		// rejected even then.
+		expect(
+			resolveReleaseBinaryAsset({ ...releaseAsset(), prerelease: true }, tag, binaryName, { allowPrerelease: true }),
+		).toEqual({ url, size: Buffer.byteLength(content), digest });
+		expect(() =>
+			resolveReleaseBinaryAsset({ ...releaseAsset(), draft: true }, tag, binaryName, { allowPrerelease: true }),
+		).toThrow("is a draft");
 	});
 
 	it("writes a download only after its size and digest match", async () => {
@@ -1184,7 +1199,7 @@ describe("update-cli script-shim takeover", () => {
 	const binaryName = "omp-windows-x64.exe";
 	const url = `https://github.com/can1357/oh-my-pi/releases/download/v${version}/${binaryName}`;
 
-	function makeFetch(content: string): (input: string | URL | Request) => Promise<Response> {
+	function makeFetch(content: string, prerelease = false): (input: string | URL | Request) => Promise<Response> {
 		const digest = `sha256:${createHash("sha256").update(content).digest("hex")}`;
 		return async (input: string | URL | Request): Promise<Response> => {
 			const requestUrl = String(input);
@@ -1193,7 +1208,7 @@ describe("update-cli script-shim takeover", () => {
 					JSON.stringify({
 						tag_name: `v${version}`,
 						draft: false,
-						prerelease: false,
+						prerelease,
 						assets: [
 							{
 								name: binaryName,
@@ -1243,6 +1258,33 @@ describe("update-cli script-shim takeover", () => {
 		}
 		const residue = (await fs.readdir(dir)).filter(name => name.endsWith(".bak") || name.endsWith(".new"));
 		expect(residue).toEqual([]);
+	});
+
+	it("installs a canary prerelease binary only when the caller opts in", async () => {
+		const dir = await makeTempDir();
+		await writeShims(dir);
+		const exe = `#!/bin/sh\necho omp/${version}\n`;
+
+		// A canary release is published as a prerelease: without opt-in the
+		// takeover refuses the asset and leaves the shims intact.
+		await expect(
+			updateViaShimTakeover(path.join(dir, "omp.cmd"), version, {
+				binaryName,
+				fetchImpl: makeFetch(exe, true),
+				githubToken: "test-token",
+			}),
+		).rejects.toThrow("is a prerelease");
+		expect(await Bun.file(path.join(dir, "omp.exe")).exists()).toBe(false);
+
+		// allowPrerelease threads through to the asset resolver, so the canary
+		// exe installs and the shims are retired.
+		await updateViaShimTakeover(path.join(dir, "omp.cmd"), version, {
+			binaryName,
+			fetchImpl: makeFetch(exe, true),
+			allowPrerelease: true,
+			githubToken: "test-token",
+		});
+		expect(await Bun.file(path.join(dir, "omp.exe")).text()).toBe(exe);
 	});
 
 	it("drops bun's launcher metadata when the standalone binary takes the .exe over", async () => {


### PR DESCRIPTION
## Repro
A regular `C:/Users/User/.bun/bin/omp.exe` with a stale adjacent `omp.bunx` resolves to the Bun update path. Running a resolver probe with `bun -e` returned `bun`; after the exact-version Bun install succeeded, the launcher still reported 18.0.4 instead of 18.0.5 and the updater previously stopped at a warning.

## Cause
`updateViaManager` in `packages/coding-agent/src/cli/update-cli.ts` treated any launcher that could still report a version as healthy, even after the package manager successfully installed the requested version. On Windows, Bun writes fresh `.bunx` metadata before tolerating EBUSY while replacing the running `.exe`, so stale metadata can misclassify a standalone executable and leave it pinned.

## Fix
- Repair a stale PATH launcher with the standalone release binary when the exact-version package-manager install succeeds but verification does not.
- Preserve the previous working launcher and surface the manager error when the install itself fails.
- Update the recovery regression test and user-facing changelog.

## Verification
`bun test packages/coding-agent/test/update-cli.test.ts` passed 84 tests. `bun run check:types` passed in `packages/coding-agent`. A manual `updateViaManager` probe for successful Bun installation plus a stale 18.0.4 launcher invoked binary repair at the original `omp.exe` path.

Fixes #9806