### PR TITLE
fix(coding-agent): attribute tool-policy denies to the tool, not tools.approval

### DIFF
--- a/packages/coding-agent/src/extensibility/extensions/wrapper.ts
+++ b/packages/coding-agent/src/extensibility/extensions/wrapper.ts
@@ -12,7 +12,13 @@ import type { ComputerSafetyCheck, ImageContent, Static, TextContent, TSchema } 
 import { sanitizeText, untilAborted } from "@oh-my-pi/pi-utils";
 import type { Settings } from "../../config/settings";
 import type { Theme } from "../../modes/theme/theme";
-import { type ApprovalMode, formatApprovalPrompt, resolveApproval, truncateForPrompt } from "../../tools/approval";
+import {
+	type ApprovalMode,
+	denyError,
+	formatApprovalPrompt,
+	resolveApproval,
+	truncateForPrompt,
+} from "../../tools/approval";
 import { defaultLoadModeForToolName } from "../../tools/essential-tools";
 import { withFileMutationSession } from "../../tools/file-write-fallback";
 import { normalizeToolEventInput, resolveToolEventInput } from "../tool-event-input";
@@ -193,10 +199,7 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 		const userPolicies = (settings?.get("tools.approval") ?? {}) as Record<string, unknown>;
 		const preResolved = resolveApproval(this.tool, approvalArgs(params, context), approvalMode, userPolicies);
 		if (preResolved.policy === "deny") {
-			throw new Error(
-				`Tool "${preResolved.policyKey ?? this.tool.name}" is blocked by user policy.\n` +
-					`To allow: remove "tools.approval.${preResolved.policyKey ?? this.tool.name}: deny" from config.`,
-			);
+			throw denyError(preResolved, this.tool.name);
 		}
 
 		// 1. Emit tool_call event first - extensions can block execution or revise the input the tool
@@ -246,10 +249,7 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 		const resolved = resolveApproval(this.tool, resolvedArgs, approvalMode, userPolicies);
 		context?.xdevTierResolved?.(resolved.tier);
 		if (resolved.policy === "deny") {
-			throw new Error(
-				`Tool "${resolved.policyKey ?? this.tool.name}" is blocked by user policy.\n` +
-					`To allow: remove "tools.approval.${resolved.policyKey ?? this.tool.name}: deny" from config.`,
-			);
+			throw denyError(resolved, this.tool.name);
 		}
 		const pendingSafetyChecks = computerSafetyChecks(context);
 		// An xd:// device dispatch already cleared the write tool's outer gate at

--- a/packages/coding-agent/src/tools/approval.ts
+++ b/packages/coding-agent/src/tools/approval.ts
@@ -219,6 +219,20 @@ export function resolveApproval(
 }
 
 /**
+ * Error for a resolved deny. Distinguishes tool-owned policy from user config.
+ */
+export function denyError(resolved: ResolvedApproval, toolName: string): Error {
+	const { source, reason, policyKey } = resolved;
+	if (source === "tool") {
+		return new Error(`Tool "${toolName}" is blocked by tool policy.${reason ? `\nReason: ${reason}` : ""}`);
+	}
+	return new Error(
+		`Tool "${policyKey ?? toolName}" is blocked by user policy.\n` +
+			`To allow: remove "tools.approval.${policyKey ?? toolName}: deny" from config.`,
+	);
+}
+
+/**
  * Check if a tool call requires user approval.
  *
  * @throws Error if policy is 'deny'
@@ -230,16 +244,11 @@ export function requiresApproval(
 	mode: ApprovalMode,
 	userConfig: Record<string, unknown> = {},
 ): { required: boolean; reason?: string } {
-	const { policy, reason, source, policyKey } = resolveApproval(tool, args, mode, userConfig);
+	const resolved = resolveApproval(tool, args, mode, userConfig);
+	const { policy, reason } = resolved;
 
 	if (policy === "deny") {
-		if (source === "tool") {
-			throw new Error(`Tool "${tool.name}" is blocked by tool policy.${reason ? `\nReason: ${reason}` : ""}`);
-		}
-		throw new Error(
-			`Tool "${policyKey ?? tool.name}" is blocked by user policy.\n` +
-				`To allow: remove "tools.approval.${policyKey ?? tool.name}: deny" from config.`,
-		);
+		throw denyError(resolved, tool.name);
 	}
 
 	if (policy === "prompt") return { required: true, reason };

--- a/packages/coding-agent/test/tools/approval.test.ts
+++ b/packages/coding-agent/test/tools/approval.test.ts
@@ -3,6 +3,7 @@ import type { AgentTool, ToolApproval } from "@oh-my-pi/pi-agent-core";
 import { LSP_READONLY_ACTIONS } from "@oh-my-pi/pi-coding-agent/lsp";
 import {
 	type ApprovalMode,
+	denyError,
 	formatApprovalPrompt,
 	requiresApproval,
 	resolveApproval,
@@ -112,6 +113,30 @@ describe("resolveApproval override and user policy", () => {
 		expect(() => requiresApproval(blocked, {}, "write", { bash: "allow" })).toThrow(
 			'Tool "bash" is blocked by tool policy',
 		);
+	});
+
+	it("tool-sourced deny surfaces the reason and does not mention tools.approval", () => {
+		const blocked = tool("bash", {
+			tier: "exec",
+			override: true,
+			policy: "deny",
+			reason: "Blocked by bash pattern: rm -rf *",
+		});
+		const resolved = resolveApproval(blocked, {}, "yolo", { bash: "allow" });
+		expect(() => {
+			throw denyError(resolved, "bash");
+		}).toThrow('Tool "bash" is blocked by tool policy.\nReason: Blocked by bash pattern: rm -rf *');
+		expect(() => {
+			throw denyError(resolved, "bash");
+		}).not.toThrow(/tools\.approval/);
+	});
+
+	it("user-sourced deny keeps the original tools.approval message", () => {
+		const writeTool = tool("write", "write");
+		const resolved = resolveApproval(writeTool, {}, "yolo", { write: "deny" });
+		expect(() => {
+			throw denyError(resolved, "write");
+		}).toThrow('Tool "write" is blocked by user policy.\nTo allow: remove "tools.approval.write: deny" from config.');
 	});
 
 	it("valid user policy overrides mode and tier when no tool override is active", () => {


### PR DESCRIPTION
I reviewed the full diff. This change makes the wrapper use the same deny message as `requiresApproval`, so a tool-owned deny no longer pretends `tools.approval.bash` is the problem.

## Divergent call sites

`packages/coding-agent/src/tools/approval.ts` (`requiresApproval`) already branched on `source`:

- `source === "tool"`: `Tool "<name>" is blocked by tool policy.` plus optional `Reason: <reason>`
- otherwise: `Tool "<key>" is blocked by user policy.` plus `To allow: remove "tools.approval.<key>: deny" from config.`

`packages/coding-agent/src/extensibility/extensions/wrapper.ts` (`execute`) had two deny throws (pre-resolve before `tool_call`, and post-handler re-resolve). Both always used the user-policy text and dropped `source` / `reason`.

## Misleading vs corrected output

Reproduction: `bash.patterns` has `{ match: "rm -rf *", approval: "deny" }` and `tools.approval.bash` is `allow` (or unset).

Before (wrapper path):

```
Tool "bash" is blocked by user policy.
To allow: remove "tools.approval.bash: deny" from config.
```

After:

```
Tool "bash" is blocked by tool policy.
Reason: Blocked by bash pattern: rm -rf *
```

The old text points at a setting that is not denying the call.

## Why an extension cannot work around it

Both wrapper throws happen before `emitToolCall`. A `tool_call` handler never sees the denied call.

## What the helper prevents

`denyError(resolved, toolName)` is the single branch. `requiresApproval` and both wrapper sites call it. Message text for both branches is unchanged.

## Verification

- `bun run --cwd=packages/coding-agent check:types` passed
- `bun test test/tools/approval.test.ts` (after copying a matching 18.0.4 `pi_natives` addon; local natives build needs cmake): 45 pass
- Isolated `denyError` / `requiresApproval` script: PASS
