### PR TITLE
test(ai): assert Anthropic OAuth fingerprint bytes as literals (follow-up to #9801)

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Anthropic Claude subscription OAuth requests being rejected by the upstream service ([#9801](https://github.com/can1357/oh-my-pi/pull/9801) by [@fanbaoyu1024](https://github.com/fanbaoyu1024)).
+
 ## [18.0.6] - 2026-08-26
 
 ### Added
@@ -11,9 +15,6 @@
 ### Fixed
 
 - Fixed auth-broker background activity keeping processes alive unnecessarily, so unused broker-backed auth storage now parks automatically and no longer prevents CLI exit.
-### Fixed
-
-- Fixed Anthropic Claude subscription OAuth requests being rejected by the upstream service ([#9801](https://github.com/can1357/oh-my-pi/pull/9801) by [@fanbaoyu1024](https://github.com/fanbaoyu1024)).
 
 ## [18.0.5] - 2026-08-25
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -13,7 +13,7 @@
 - Fixed auth-broker background activity keeping processes alive unnecessarily, so unused broker-backed auth storage now parks automatically and no longer prevents CLI exit.
 ### Fixed
 
-- Fixed Anthropic Claude subscription OAuth requests being rejected by the upstream service.
+- Fixed Anthropic Claude subscription OAuth requests being rejected by the upstream service ([#9801](https://github.com/can1357/oh-my-pi/pull/9801) by [@fanbaoyu1024](https://github.com/fanbaoyu1024)).
 
 ## [18.0.5] - 2026-08-25
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -11,6 +11,9 @@
 ### Fixed
 
 - Fixed auth-broker background activity keeping processes alive unnecessarily, so unused broker-backed auth storage now parks automatically and no longer prevents CLI exit.
+### Fixed
+
+- Fixed Anthropic Claude subscription OAuth requests being rejected by the upstream service.
 
 ## [18.0.5] - 2026-08-25
 

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -88,6 +88,7 @@ import {
 } from "./anthropic-wire";
 import {
 	CLAUDE_CODE_MAX_OUTPUT_TOKENS,
+	claudeCodeSdkVersion,
 	claudeCodeSystemInstruction,
 	claudeCodeVersion,
 	claudeToolPrefix,
@@ -154,13 +155,14 @@ function mergeAnthropicBetaHeader(callerHeaders: Record<string, string>, beta: s
 	}
 	return { "anthropic-beta": beta };
 }
-
+const oauthAuthBeta = "oauth-2025-04-20";
 const midConversationSystemBeta = "mid-conversation-system-2026-04-07";
 const contextManagementBeta = "context-management-2025-06-27";
 const structuredOutputsBeta = "structured-outputs-2025-12-15";
 const thinkingTokenCountBeta = "thinking-token-count-2026-05-13";
 const fallbackCreditBeta = "fallback-credit-2026-06-01";
 const coworkUtilityBetaDefaults = [
+	oauthAuthBeta,
 	"interleaved-thinking-2025-05-14",
 	thinkingTokenCountBeta,
 	contextManagementBeta,
@@ -169,6 +171,7 @@ const coworkUtilityBetaDefaults = [
 ] as const;
 const coworkAgentBetaDefaults = [
 	"claude-code-20250219",
+	oauthAuthBeta,
 	"interleaved-thinking-2025-05-14",
 	thinkingTokenCountBeta,
 	contextManagementBeta,
@@ -524,7 +527,7 @@ export const coworkHeaders = {
 	"X-Stainless-Arch": mapStainlessArch(process.arch),
 	"X-Stainless-Lang": "js",
 	"X-Stainless-OS": "Linux",
-	"X-Stainless-Package-Version": "0.94.0",
+	"X-Stainless-Package-Version": claudeCodeSdkVersion,
 	"X-Stainless-Retry-Count": "0",
 	"X-Stainless-Runtime": "node",
 	"X-Stainless-Runtime-Version": "v26.3.0",

--- a/packages/ai/src/providers/claude-code-fingerprint.ts
+++ b/packages/ai/src/providers/claude-code-fingerprint.ts
@@ -9,7 +9,9 @@
  */
 
 /** Claude runtime version bundled by the current Cowork desktop release. */
-export const claudeCodeVersion = "2.1.220";
+export const claudeCodeVersion = "2.1.246";
+/** `@anthropic-ai/sdk` version bundled by the current Cowork desktop release. */
+export const claudeCodeSdkVersion = "0.112.1";
 /** User-Agent emitted by Cowork's `claude-desktop` inference entrypoint. */
 export const coworkUserAgent = `claude-cli/${claudeCodeVersion} (external, claude-desktop)`;
 /** Prefix used to isolate custom Anthropic OAuth tools from built-in tools. */

--- a/packages/ai/src/registry/oauth/anthropic.ts
+++ b/packages/ai/src/registry/oauth/anthropic.ts
@@ -3,7 +3,7 @@
  */
 
 import * as AIError from "../../error";
-import { claudeCodeVersion } from "../../providers/claude-code-fingerprint";
+import { claudeCodeSdkVersion, claudeCodeVersion } from "../../providers/claude-code-fingerprint";
 import type { FetchImpl } from "../../types";
 import { OAuthCallbackFlow } from "./callback-server";
 import { generatePKCE } from "./pkce";
@@ -316,7 +316,7 @@ export async function refreshAnthropicToken(
 			{
 				// CC sends these on refresh but not on the initial code exchange
 				"anthropic-beta": "oauth-2025-04-20",
-				"User-Agent": "anthropic-sdk-typescript/0.94.0 userOAuthProvider",
+				"User-Agent": `anthropic-sdk-typescript/${claudeCodeSdkVersion} userOAuthProvider`,
 			},
 		);
 	} catch (error) {

--- a/packages/ai/test/anthropic-alignment.test.ts
+++ b/packages/ai/test/anthropic-alignment.test.ts
@@ -19,7 +19,7 @@ import {
 	stripClaudeToolPrefix,
 } from "@oh-my-pi/pi-ai/providers/anthropic";
 import type { MessageCreateParams } from "@oh-my-pi/pi-ai/providers/anthropic-wire";
-import { claudeCodeSdkVersion, claudeCodeVersion } from "@oh-my-pi/pi-ai/providers/claude-code-fingerprint";
+import { claudeCodeVersion } from "@oh-my-pi/pi-ai/providers/claude-code-fingerprint";
 import { getEnvApiKey, streamSimple } from "@oh-my-pi/pi-ai/stream";
 import type {
 	AssistantMessage,
@@ -178,7 +178,7 @@ describe("Anthropic request fingerprint alignment", () => {
 		expect(headers["X-Claude-Code-Session-Id"]).toBe(sessionId);
 		expect(headers["X-Stainless-Arch"]).toBe(mapStainlessArch(process.arch));
 		expect(headers["X-Stainless-OS"]).toBe("Linux");
-		expect(headers["X-Stainless-Package-Version"]).toBe(claudeCodeSdkVersion);
+		expect(headers["X-Stainless-Package-Version"]).toBe("0.112.1");
 		expect(headers["X-Stainless-Runtime-Version"]).toBe("v26.3.0");
 		expect(headers["X-Stainless-Timeout"]).toBe("600");
 		expect(headers["anthropic-client-platform"]).toBeUndefined();

--- a/packages/ai/test/anthropic-alignment.test.ts
+++ b/packages/ai/test/anthropic-alignment.test.ts
@@ -174,7 +174,9 @@ describe("Anthropic request fingerprint alignment", () => {
 		});
 
 		expect(headers.Accept).toBe("application/json");
-		expect(headers["User-Agent"]).toBe(`claude-cli/${claudeCodeVersion} (external, claude-desktop)`);
+		// Pinned literally (not via the imported constant) so a wrong version bump is caught
+		// on an observable wire header: this is the exact User-Agent the upstream expects.
+		expect(headers["User-Agent"]).toBe("claude-cli/2.1.246 (external, claude-desktop)");
 		expect(headers["X-Claude-Code-Session-Id"]).toBe(sessionId);
 		expect(headers["X-Stainless-Arch"]).toBe(mapStainlessArch(process.arch));
 		expect(headers["X-Stainless-OS"]).toBe("Linux");
@@ -234,6 +236,11 @@ describe("Anthropic request fingerprint alignment", () => {
 			thinkingDisplay: "omitted",
 		});
 		expect(hiddenUtility.defaultHeaders["anthropic-beta"]).not.toContain("redact-thinking-2026-02-12");
+		// Drift guard: the no-tools/no-thinking utility branch is a distinct code path
+		// (buildCoworkBetas utility defaults) from the agent branch asserted above. Its
+		// OAuth beta must be present verbatim — dropping `oauth-2025-04-20` there silently
+		// reintroduces the upstream 403 with no other test failing.
+		expect(hiddenUtility.defaultHeaders["anthropic-beta"]).toContain("oauth-2025-04-20");
 	});
 
 	it("never advertises context-1m on OAuth requests for million-token models (#7238)", () => {

--- a/packages/ai/test/anthropic-alignment.test.ts
+++ b/packages/ai/test/anthropic-alignment.test.ts
@@ -19,7 +19,7 @@ import {
 	stripClaudeToolPrefix,
 } from "@oh-my-pi/pi-ai/providers/anthropic";
 import type { MessageCreateParams } from "@oh-my-pi/pi-ai/providers/anthropic-wire";
-import { claudeCodeVersion } from "@oh-my-pi/pi-ai/providers/claude-code-fingerprint";
+import { claudeCodeSdkVersion, claudeCodeVersion } from "@oh-my-pi/pi-ai/providers/claude-code-fingerprint";
 import { getEnvApiKey, streamSimple } from "@oh-my-pi/pi-ai/stream";
 import type {
 	AssistantMessage,
@@ -178,6 +178,7 @@ describe("Anthropic request fingerprint alignment", () => {
 		expect(headers["X-Claude-Code-Session-Id"]).toBe(sessionId);
 		expect(headers["X-Stainless-Arch"]).toBe(mapStainlessArch(process.arch));
 		expect(headers["X-Stainless-OS"]).toBe("Linux");
+		expect(headers["X-Stainless-Package-Version"]).toBe(claudeCodeSdkVersion);
 		expect(headers["X-Stainless-Runtime-Version"]).toBe("v26.3.0");
 		expect(headers["X-Stainless-Timeout"]).toBe("600");
 		expect(headers["anthropic-client-platform"]).toBeUndefined();
@@ -205,7 +206,7 @@ describe("Anthropic request fingerprint alignment", () => {
 			"Accept-Encoding",
 		]);
 		expect(headers["anthropic-beta"]).toBe(
-			"claude-code-20250219,interleaved-thinking-2025-05-14,thinking-token-count-2026-05-13,context-management-2025-06-27,prompt-caching-scope-2026-01-05,mid-conversation-system-2026-04-07,advanced-tool-use-2025-11-20,effort-2025-11-24,fallback-credit-2026-06-01",
+			"claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14,thinking-token-count-2026-05-13,context-management-2025-06-27,prompt-caching-scope-2026-01-05,mid-conversation-system-2026-04-07,advanced-tool-use-2025-11-20,effort-2025-11-24,fallback-credit-2026-06-01",
 		);
 		expect(headers["x-client-request-id"]).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
 	});
@@ -255,7 +256,7 @@ describe("Anthropic request fingerprint alignment", () => {
 		});
 
 		expect(options.defaultHeaders["anthropic-beta"]).toBe(
-			"claude-code-20250219,interleaved-thinking-2025-05-14,thinking-token-count-2026-05-13,context-management-2025-06-27,prompt-caching-scope-2026-01-05,mid-conversation-system-2026-04-07,advanced-tool-use-2025-11-20,effort-2025-11-24,fallback-credit-2026-06-01",
+			"claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14,thinking-token-count-2026-05-13,context-management-2025-06-27,prompt-caching-scope-2026-01-05,mid-conversation-system-2026-04-07,advanced-tool-use-2025-11-20,effort-2025-11-24,fallback-credit-2026-06-01",
 		);
 		expect(options.defaultHeaders["anthropic-beta"]).not.toContain("context-1m-2025-08-07");
 	});

--- a/packages/ai/test/anthropic-oauth.test.ts
+++ b/packages/ai/test/anthropic-oauth.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
-import { claudeCodeSdkVersion, claudeCodeVersion } from "@oh-my-pi/pi-ai/providers/claude-code-fingerprint";
+import { claudeCodeVersion } from "@oh-my-pi/pi-ai/providers/claude-code-fingerprint";
 import { AnthropicOAuthFlow, refreshAnthropicToken } from "@oh-my-pi/pi-ai/registry/oauth/anthropic";
 import {
 	buildAnthropicAuthConfig,
@@ -125,7 +125,7 @@ describe("anthropic oauth alignment", () => {
 			expect(init?.method).toBe("POST");
 			const headers = init?.headers as Record<string, string> | undefined;
 			expect(headers?.["anthropic-beta"]).toBe("oauth-2025-04-20");
-			expect(headers?.["User-Agent"]).toBe(`anthropic-sdk-typescript/${claudeCodeSdkVersion} userOAuthProvider`);
+			expect(headers?.["User-Agent"]).toBe("anthropic-sdk-typescript/0.112.1 userOAuthProvider");
 			return new Response(
 				JSON.stringify({
 					access_token: "new-access-token",

--- a/packages/ai/test/anthropic-oauth.test.ts
+++ b/packages/ai/test/anthropic-oauth.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
-import { claudeCodeVersion } from "@oh-my-pi/pi-ai/providers/claude-code-fingerprint";
+import { claudeCodeSdkVersion, claudeCodeVersion } from "@oh-my-pi/pi-ai/providers/claude-code-fingerprint";
 import { AnthropicOAuthFlow, refreshAnthropicToken } from "@oh-my-pi/pi-ai/registry/oauth/anthropic";
 import {
 	buildAnthropicAuthConfig,
@@ -125,7 +125,7 @@ describe("anthropic oauth alignment", () => {
 			expect(init?.method).toBe("POST");
 			const headers = init?.headers as Record<string, string> | undefined;
 			expect(headers?.["anthropic-beta"]).toBe("oauth-2025-04-20");
-			expect(headers?.["User-Agent"]).toBe("anthropic-sdk-typescript/0.94.0 userOAuthProvider");
+			expect(headers?.["User-Agent"]).toBe(`anthropic-sdk-typescript/${claudeCodeSdkVersion} userOAuthProvider`);
 			return new Response(
 				JSON.stringify({
 					access_token: "new-access-token",


### PR DESCRIPTION
## Summary

Builds on #9801 (by @fanbaoyu1024), which restores Anthropic subscription OAuth compatibility by aligning the Cowork fingerprint to Claude Code 2.1.246 / Anthropic SDK 0.112.1 and sending the `oauth-2025-04-20` beta. This PR carries that work forward and resolves the two P1 review notes left on it, so it can land in a mergeable state.

## Changes on top of #9801

- **Assert the fingerprint bytes as literals** (the two P1 notes). The regression tests asserted `X-Stainless-Package-Version` and the refresh `User-Agent` against the same `claudeCodeSdkVersion` constant that production emits — so an incorrect change to that constant would move test and production together and pass silently. Since this exact wire value is what triggered the `403 Request not allowed` rejection, the tests now assert the required `0.112.1` bytes literally (`anthropic-sdk-typescript/0.112.1 userOAuthProvider` and `0.112.1`), so they can detect drift.
- **CHANGELOG attribution** — add the PR/author reference per `AGENTS.md`.

Production code is unchanged relative to #9801; only test assertions and the changelog line move. The literal values are exactly equal to the constant they replace, so behavior is identical while the tests gain real drift protection.

## Verification

- Static equivalence: the asserted literals (`0.112.1`) match `claudeCodeSdkVersion` in `claude-code-fingerprint.ts` and the values production sends in `anthropic.ts` / `registry/oauth/anthropic.ts`; `claudeCodeVersion` remains imported and used in both test files.
- I could not run `bun test` locally in this environment (bun runtime unavailable, release download blocked), so I'm relying on CI to run the suite. The change is a value-equal literal substitution over the already-green #9801 assertions.

Credit to @fanbaoyu1024 for the original fix.
