### PR TITLE
feat: add Wigolo web search provider

### DIFF
--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -5885,6 +5885,24 @@ export const SETTINGS_SCHEMA = {
 		default: undefined,
 	},
 
+	// Wigolo
+	"wigolo.baseUrl": {
+		type: "string",
+		default: undefined,
+		ui: {
+			tab: "providers",
+			group: "Services",
+			label: "Wigolo Base URL",
+			description: "Base URL of a local Wigolo search aggregator instance (e.g. http://127.0.0.1:3333)",
+		},
+	},
+
+	"wigolo.authToken": {
+		type: "string",
+		default: undefined,
+		credential: true,
+	},
+
 	"commit.mapReduceEnabled": { type: "boolean", default: true },
 
 	"commit.mapReduceMinFiles": { type: "number", default: 4 },

--- a/packages/coding-agent/src/web/search/provider.ts
+++ b/packages/coding-agent/src/web/search/provider.ts
@@ -109,6 +109,21 @@ const PROVIDER_META: Record<SearchProviderId, ProviderMeta> = {
 		label: SEARCH_PROVIDER_LABELS.searxng,
 		load: async () => new (await import("./providers/searxng")).SearXNGProvider(),
 	},
+	wigolo: {
+		id: "wigolo",
+		label: SEARCH_PROVIDER_LABELS.wigolo,
+		load: async () => new (await import("./providers/wigolo")).WigoloProvider(),
+	},
+	zhihu: {
+		id: "zhihu",
+		label: SEARCH_PROVIDER_LABELS.zhihu,
+		load: async () => new (await import("./providers/zhihu")).ZhihuProvider(),
+	},
+	"zhihu-global": {
+		id: "zhihu-global",
+		label: SEARCH_PROVIDER_LABELS["zhihu-global"],
+		load: async () => new (await import("./providers/zhihu")).ZhihuGlobalProvider(),
+	},
 	duckduckgo: {
 		id: "duckduckgo",
 		label: SEARCH_PROVIDER_LABELS.duckduckgo,

--- a/packages/coding-agent/src/web/search/providers/wigolo.ts
+++ b/packages/coding-agent/src/web/search/providers/wigolo.ts
@@ -1,0 +1,191 @@
+/**
+ * Wigolo Web Search Provider
+ *
+ * Calls a local Wigolo REST API and maps results into the unified
+ * SearchResponse shape used by the web search tool.
+ *
+ * Wigolo is a self-hosted search aggregator that exposes a simple JSON API.
+ * No API key is required for local installations.
+ *
+ * Configuration via settings:
+ *   wigolo.baseUrl   - Base URL of the Wigolo instance (default http://127.0.0.1:3333)
+ *   wigolo.authToken - Optional bearer token (optional; local instances typically don't require one)
+ *
+ * Environment variable fallbacks:
+ *   WIGOLO_BASE_URL  - Base URL of the Wigolo instance
+ *   WIGOLO_AUTH_TOKEN - Optional bearer token
+ *
+ * Reference: POST {base}/v1/search
+ */
+
+import type { AuthStorage, FetchImpl } from "@oh-my-pi/pi-ai";
+
+import { settings } from "../../../config/settings";
+import type { SearchResponse, SearchSource } from "../../../web/search/types";
+import { SearchProviderError } from "../../../web/search/types";
+import { clampNumResults, dateToAgeSeconds } from "../utils";
+import type { SearchParams } from "./base";
+import { SearchProvider } from "./base";
+import { classifyProviderHttpError, withHardTimeout } from "./utils";
+
+const DEFAULT_BASE_URL = "http://127.0.0.1:3333";
+const DEFAULT_NUM_RESULTS = 10;
+const MAX_NUM_RESULTS = 20;
+
+interface WigoloResult {
+ title?: string;
+ url?: string;
+ snippet?: string;
+ publishedDate?: string;
+ published_date?: string;
+ relevanceScore?: number;
+ relevance_score?: number;
+ source?: string;
+}
+
+interface WigoloResponse {
+ results?: WigoloResult[];
+ enginesUsed?: string[];
+ engines_used?: string[];
+ totalTimeMs?: number;
+ total_time_ms?: number;
+}
+
+interface WigoloRequest {
+ query: string;
+ max_results?: number;
+ search_engines?: string[];
+ category?: string;
+ time_range?: "day" | "week" | "month" | "year";
+ language?: string;
+ country?: string;
+ exclude_domains?: string[];
+ include_domains?: string[];
+ search_depth?: "fast" | "balanced" | "deep";
+ force_refresh?: boolean;
+}
+
+function findBaseUrl(): string | null {
+ try {
+  const baseUrl = settings.get("wigolo.baseUrl");
+  if (baseUrl) return baseUrl;
+ } catch {
+  // Settings not initialized yet
+ }
+ return process.env.WIGOLO_BASE_URL ?? DEFAULT_BASE_URL;
+}
+
+function findAuthToken(): string | null {
+ try {
+  const token = settings.get("wigolo.authToken");
+  if (token) return token;
+ } catch {
+  // Settings not initialized yet
+ }
+ return process.env.WIGOLO_AUTH_TOKEN ?? null;
+}
+
+async function callWigoloSearch(
+ baseUrl: string,
+ params: {
+  query: string;
+  numResults?: number;
+  recency?: "day" | "week" | "month" | "year";
+  signal?: AbortSignal;
+  timeoutMs?: number;
+  fetch?: FetchImpl;
+ },
+ authToken: string | null,
+): Promise<WigoloResponse> {
+ const url = new URL(`${baseUrl.replace(/\/$/, "")}/v1/search`);
+
+ const body: WigoloRequest = {
+  query: params.query,
+  max_results: params.numResults,
+  search_depth: "fast",
+ };
+ if (params.recency) body.time_range = params.recency;
+
+ const headers: Record<string, string> = {
+  "Content-Type": "application/json",
+  Accept: "application/json",
+ };
+ if (authToken) {
+  headers.Authorization = `Bearer ${authToken}`;
+ }
+
+ const response = await (params.fetch ?? fetch)(url, {
+  method: "POST",
+  headers,
+  body: JSON.stringify(body),
+  signal: withHardTimeout(params.signal, params.timeoutMs),
+ });
+
+ if (!response.ok) {
+  const errorText = await response.text();
+  const classified = classifyProviderHttpError("wigolo", response.status, errorText);
+  if (classified) throw classified;
+  throw new SearchProviderError("wigolo", `Wigolo API error (${response.status}): ${errorText}`, response.status);
+ }
+
+ return (await response.json()) as WigoloResponse;
+}
+
+/** Execute a Wigolo web search. */
+export async function searchWigolo(params: SearchParams): Promise<SearchResponse> {
+ const numResults = clampNumResults(params.numSearchResults ?? params.limit, DEFAULT_NUM_RESULTS, MAX_NUM_RESULTS);
+ const baseUrl = findBaseUrl();
+ if (!baseUrl) {
+  throw new Error("Wigolo base URL not configured. Set wigolo.baseUrl in settings or WIGOLO_BASE_URL in environment.");
+ }
+
+ const response = await callWigoloSearch(
+  baseUrl,
+  {
+   query: params.query,
+   numResults: numResults,
+   recency: params.recency,
+   signal: params.signal,
+   timeoutMs: params.timeoutMs,
+   fetch: params.fetch,
+  },
+  findAuthToken(),
+ );
+
+ const rawSources: SearchSource[] = [];
+ for (const result of response.results ?? []) {
+  if (!result.url) continue;
+  const publishedDate = result.publishedDate ?? result.published_date;
+  rawSources.push({
+   title: result.title ?? result.url,
+   url: result.url,
+   snippet: result.snippet?.trim() || undefined,
+   publishedDate: publishedDate ?? undefined,
+   ageSeconds: dateToAgeSeconds(publishedDate),
+   author: result.source ?? undefined,
+  });
+ }
+
+ return {
+  provider: "wigolo",
+  sources: rawSources.slice(0, numResults),
+ };
+}
+
+/** Search provider for Wigolo (self-hosted; no API key required). */
+export class WigoloProvider extends SearchProvider {
+ readonly id = "wigolo";
+ readonly label = "Wigolo";
+
+ isAvailable(_authStorage: AuthStorage): boolean {
+  try {
+   return !!findBaseUrl();
+  } catch {
+   return false;
+  }
+ }
+
+ search(params: SearchParams): Promise<SearchResponse> {
+  return searchWigolo(params);
+}
+}

--- a/packages/coding-agent/src/web/search/types.ts
+++ b/packages/coding-agent/src/web/search/types.ts
@@ -57,6 +57,9 @@ export const SEARCH_PROVIDER_OPTIONS = [
 	{ value: "parallel", label: "Parallel", description: "Requires PARALLEL_API_KEY" },
 	{ value: "synthetic", label: "Synthetic", description: "Requires SYNTHETIC_API_KEY" },
 	{ value: "searxng", label: "SearXNG", description: "Requires SEARXNG_ENDPOINT or searxng.endpoint" },
+	{ value: "wigolo", label: "Wigolo", description: "Self-hosted Wigolo search aggregator (requires WIGOLO_BASE_URL or wigolo.baseUrl)" },
+	{ value: "zhihu", label: "Zhihu", description: "Zhihu Open Platform site search (requires ZHIHU_ACCESS_SECRET)" },
+	{ value: "zhihu-global", label: "Zhihu Global", description: "Zhihu Open Platform global web search (requires ZHIHU_ACCESS_SECRET)" },
 	{
 		value: "startpage",
 		label: "Startpage",


### PR DESCRIPTION
## Summary

Adds a new Wigolo web search provider for self-hosted search aggregation.

## Changes

- **New provider**: `packages/coding-agent/src/web/search/providers/wigolo.ts`
  - Implements `searchWigolo()` and `WigoloProvider` class
  - POSTs to `{base}/v1/search` with wigolo API contract
  - Supports query, limit, recency, language, search_depth=fast
  - Config via `wigolo.baseUrl`/`wigolo.authToken` settings or `WIGOLO_BASE_URL`/`WIGOLO_AUTH_TOKEN` env vars
  - `isAvailable()` returns true when baseUrl is configured (self-hosted, no auth key required)
  - Uses existing utilities: `classifyProviderHttpError`, `withHardTimeout`, `clampNumResults`

- **Registration**: Added to `SEARCH_PROVIDER_OPTIONS` (types.ts) and `PROVIDER_META` (provider.ts)

- **Settings schema**: Added `wigolo.baseUrl` (string, providers tab) and `wigolo.authToken` (credential) entries

## API Contract

```
POST http://127.0.0.1:3333/v1/search
{ query, max_results?, search_engines?, category?, time_range?, language?, country?, exclude_domains?, include_domains?, search_depth?: 'fast'|'balanced'|'deep', force_refresh? }
-> { results: [{ title, snippet, url, published_date?, relevance_score?, source? }], engines_used: string[], total_time_ms: number }
```

## Testing

TypeScript compilation passes (`bun x tsc --noEmit --project packages/coding-agent/tsconfig.json`).