### PR TITLE
fix(ai): surface in-band completions stream errors

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed OpenAI-compatible streaming error events being treated as successful empty completions, so queue admission failures now trigger retry and model fallback.
+
 ## [18.0.6] - 2026-08-26
 
 ### Added

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -587,6 +587,45 @@ const OPENAI_COMPLETIONS_FIRST_EVENT_TIMEOUT_MESSAGE =
 // converts the already-successful response into a timeout error.
 const OPENAI_COMPLETIONS_POST_FINISH_GRACE_MS = 2_500;
 
+const OPENAI_COMPLETIONS_ERROR_STATUS_BY_TYPE: Readonly<Record<string, number>> = {
+	SERVICE_UNAVAILABLE: 503,
+	TOO_MANY_REQUESTS: 429,
+	REQUEST_TIMEOUT: 408,
+};
+
+function parseOpenAICompletionsErrorStatus(value: unknown): number | undefined {
+	const status =
+		typeof value === "number"
+			? value
+			: typeof value === "string" && /^\d{3}$/.test(value.trim())
+				? Number(value)
+				: undefined;
+	return status !== undefined && Number.isInteger(status) && status >= 400 && status <= 599 ? status : undefined;
+}
+
+function createOpenAICompletionsStreamError(chunk: unknown, provider: string): Error | undefined {
+	if (!chunk || typeof chunk !== "object") return undefined;
+	const error = Reflect.get(chunk, "error");
+	if (!error || typeof error !== "object") return undefined;
+
+	const messageValue = Reflect.get(error, "message");
+	const typeValue = Reflect.get(error, "type");
+	const codeValue = Reflect.get(error, "code");
+	const type = typeof typeValue === "string" ? typeValue.trim() : undefined;
+	const status =
+		parseOpenAICompletionsErrorStatus(codeValue) ??
+		(type ? OPENAI_COMPLETIONS_ERROR_STATUS_BY_TYPE[type.toUpperCase()] : undefined);
+	const detail =
+		typeof messageValue === "string" && messageValue.length > 0
+			? messageValue
+			: "Provider returned an in-band OpenAI completions stream error";
+	if (status === undefined) {
+		return new AIError.ProviderResponseError(detail, { provider, kind: "runtime" });
+	}
+	const code = type || (typeof codeValue === "string" ? codeValue : undefined);
+	return new AIError.ProviderHttpError(`${status} ${detail}`, status, { code });
+}
+
 const streamOpenAICompletionsOnce = (
 	model: Model<"openai-completions">,
 	context: Context,
@@ -1060,6 +1099,8 @@ const streamOpenAICompletionsOnce = (
 			});
 			for await (const chunk of terminalAwareStream) {
 				if (!chunk || typeof chunk !== "object") continue;
+				const streamError = createOpenAICompletionsStreamError(chunk, model.provider);
+				if (streamError) throw streamError;
 
 				// OpenAI documents ChatCompletionChunk.id as the unique chat completion identifier,
 				// and each chunk in a streamed completion carries the same id.

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -606,24 +606,26 @@ function parseOpenAICompletionsErrorStatus(value: unknown): number | undefined {
 function createOpenAICompletionsStreamError(chunk: unknown, provider: string): Error | undefined {
 	if (!chunk || typeof chunk !== "object") return undefined;
 	const error = Reflect.get(chunk, "error");
-	if (!error || typeof error !== "object") return undefined;
+	const flatMessage = Reflect.get(chunk, "message");
+	const structuredError = error !== null && typeof error === "object";
+	if (!structuredError && typeof error !== "string" && typeof flatMessage !== "string") return undefined;
 
-	const messageValue = Reflect.get(error, "message");
+	const parsed = AIError.OpenAIHttpError.parseEnvelope(chunk, undefined);
+	const detail = parsed.detail ?? "Provider returned an in-band OpenAI completions stream error";
+	if (!structuredError) {
+		return new AIError.ProviderResponseError(detail, { provider, kind: "runtime" });
+	}
+
 	const typeValue = Reflect.get(error, "type");
 	const codeValue = Reflect.get(error, "code");
 	const type = typeof typeValue === "string" ? typeValue.trim() : undefined;
 	const status =
 		parseOpenAICompletionsErrorStatus(codeValue) ??
 		(type ? OPENAI_COMPLETIONS_ERROR_STATUS_BY_TYPE[type.toUpperCase()] : undefined);
-	const detail =
-		typeof messageValue === "string" && messageValue.length > 0
-			? messageValue
-			: "Provider returned an in-band OpenAI completions stream error";
 	if (status === undefined) {
 		return new AIError.ProviderResponseError(detail, { provider, kind: "runtime" });
 	}
-	const code = type || (typeof codeValue === "string" ? codeValue : undefined);
-	return new AIError.ProviderHttpError(`${status} ${detail}`, status, { code });
+	return new AIError.ProviderHttpError(`${status} ${detail}`, status, { code: parsed.code });
 }
 
 const streamOpenAICompletionsOnce = (

--- a/packages/ai/test/openai-completions-error-finish-reason.test.ts
+++ b/packages/ai/test/openai-completions-error-finish-reason.test.ts
@@ -108,6 +108,60 @@ describe("finish_reason: error", () => {
 	}, 10_000);
 });
 
+describe("in-band SSE error envelope", () => {
+	it("surfaces a queue-full error carried inside a successful HTTP stream", async () => {
+		const fetchMock = createSseFetch([
+			{
+				error: {
+					object: "error",
+					message: "The request queue is full.",
+					type: "SERVICE_UNAVAILABLE",
+					param: null,
+					code: 503,
+				},
+			},
+			"[DONE]",
+		]);
+
+		const result = await streamOpenAICompletions(completionsModel, baseContext(), {
+			apiKey: "test-key",
+			fetch: fetchMock,
+		}).result();
+
+		expect(result.stopReason).toBe("error");
+		expect(result.errorStatus).toBe(503);
+		expect(result.errorMessage).toContain("The request queue is full.");
+	}, 10_000);
+
+	it("does not replay after content precedes an in-band error", async () => {
+		let attempts = 0;
+		const baseFetch = createSseFetch([
+			completionChunk({ choices: [{ index: 0, delta: { role: "assistant", content: "Partial" } }] }),
+			{
+				error: {
+					message: "Request timed out in the queue.",
+					type: "REQUEST_TIMEOUT",
+				},
+			},
+			"[DONE]",
+		]);
+		const fetchMock: FetchImpl = async (input, init) => {
+			attempts++;
+			return baseFetch(input, init);
+		};
+
+		const result = await streamOpenAICompletions(completionsModel, baseContext(), {
+			apiKey: "test-key",
+			fetch: fetchMock,
+		}).result();
+
+		expect(attempts).toBe(1);
+		expect(result.stopReason).toBe("error");
+		expect(result.errorStatus).toBe(408);
+		expect(result.content).toEqual([{ type: "text", text: "Partial" }]);
+	}, 10_000);
+});
+
 describe("finish_reason: insufficient_system_resource", () => {
 	// DeepSeek interrupts the generation mid-stream when its inference system
 	// runs out of resources; the terminal chunk carries

--- a/packages/ai/test/openai-completions-error-finish-reason.test.ts
+++ b/packages/ai/test/openai-completions-error-finish-reason.test.ts
@@ -133,6 +133,30 @@ describe("in-band SSE error envelope", () => {
 		expect(result.errorMessage).toContain("The request queue is full.");
 	}, 10_000);
 
+	it("surfaces a flat error string carried inside a successful HTTP stream", async () => {
+		const fetchMock = createSseFetch([{ error: "rate limit exceeded" }, "[DONE]"]);
+
+		const result = await streamOpenAICompletions(completionsModel, baseContext(), {
+			apiKey: "test-key",
+			fetch: fetchMock,
+		}).result();
+
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toContain("rate limit exceeded");
+	}, 10_000);
+
+	it("surfaces a flat message-only error carried inside a successful HTTP stream", async () => {
+		const fetchMock = createSseFetch([{ message: "provider temporarily unavailable" }, "[DONE]"]);
+
+		const result = await streamOpenAICompletions(completionsModel, baseContext(), {
+			apiKey: "test-key",
+			fetch: fetchMock,
+		}).result();
+
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toContain("provider temporarily unavailable");
+	}, 10_000);
+
 	it("does not replay after content precedes an in-band error", async () => {
 		let attempts = 0;
 		const baseFetch = createSseFetch([


### PR DESCRIPTION
## Repro
A mocked `200 text/event-stream` response carrying `data: {"error":{"message":"The request queue is full.","type":"SERVICE_UNAVAILABLE","code":503}}` followed by `[DONE]` finalized with `stopReason: "stop"`. `bun test packages/ai/test/openai-completions-error-finish-reason.test.ts` reproduced both the pre-content queue rejection and a content-then-error variant as two failing assertions.

## Cause
`streamOpenAICompletionsOnce` in `packages/ai/src/providers/openai-completions.ts` treated every decoded SSE object as a `ChatCompletionChunk`; an error envelope had no `choices`, so the loop skipped it, and the following `[DONE]` sentinel finalized the turn as a clean empty stop.

## Fix
- Detect OpenAI-compatible in-band error envelopes before reading completion fields.
- Preserve numeric 4xx/5xx `error.code` values and map `SERVICE_UNAVAILABLE`, `TOO_MANY_REQUESTS`, and `REQUEST_TIMEOUT` types to structured provider HTTP statuses.
- Cover pre-content 503 classification and replay-unsafe content-then-error handling.
- Document the corrected retry/model-fallback behavior in the AI changelog.

## Verification
`bun test packages/ai/test/openai-completions-error-finish-reason.test.ts` passes 10/10 tests. `bun test packages/coding-agent/test/agent-session-retry-fallback.test.ts -t "advances through a role-keyed fallback chain across retries"` passes the existing 503-to-`retry_fallback_applied` recovery contract. The pre-publish `bun check` gate passed.

Fixes #9812