### PR TITLE
fix: decouple /branch from doubleEscapeAction setting

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- `/branch` now always opens the branch-from-message selector regardless of `doubleEscapeAction` setting ([#9818](https://github.com/can1357/oh-my-pi/pull/9818)).
+
 ## [18.0.6] - 2026-08-26
 
 ### Added

--- a/packages/coding-agent/src/slash-commands/builtin-session.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-session.ts
@@ -1,5 +1,4 @@
 import { getOAuthProviders } from "@oh-my-pi/pi-ai/oauth";
-import { settings } from "../config/settings";
 import type { AgentSession } from "../session/agent-session";
 import type { SessionOAuthAccountList } from "../session/agent-session-types";
 import {
@@ -477,11 +476,7 @@ export const BUILTIN_SESSION_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> = [
 		icon: "branch",
 		description: "Create a new branch from a previous message",
 		handleTui: (_command, runtime) => {
-			if (settings.get("doubleEscapeAction") === "tree") {
-				runtime.ctx.showTreeSelector();
-			} else {
-				runtime.ctx.showUserMessageSelector();
-			}
+			runtime.ctx.showUserMessageSelector();
 			runtime.ctx.editor.setText("");
 		},
 	},


### PR DESCRIPTION
The `/branch` command was hijacked to open the tree selector when `doubleEscapeAction` was set to `"tree"` (the default). This made `/branch` behave identically to `/tree`, contradicting its documented description: *"Create a new branch from a previous message"*.

The `doubleEscapeAction` setting should only control what double‑Esc does — not override the `/branch` command. The description of the setting is *"Action when pressing Escape twice with empty editor"*, with no mention of `/branch`.

**Fix**: removed the `settings.get("doubleEscapeAction") === "tree"` check from the `/branch` handler. Now `/branch` always calls `showUserMessageSelector()` regardless of the setting.

**No side effects**: `doubleEscapeAction` still controls double‑Esc (in `input-controller.ts`). `/tree` and `/fork` are unchanged.

Closes #... (no existing issue — this was discovered during investigation of the default behavior)