### PR TITLE
fix(tui): reseed in-flight hub wait card on focus rebuild

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed an in-flight tool card freezing after viewing a subagent and returning to the main session ([#9816](https://github.com/can1357/oh-my-pi/issues/9816)).
+
 ## [18.0.6] - 2026-08-26
 
 ### Added

--- a/packages/coding-agent/src/modes/controllers/session-focus-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/session-focus-controller.ts
@@ -107,6 +107,15 @@ export class SessionFocusController {
 			}
 			await this.ctx.eventController.handleEvent(event);
 		});
+		// Events emitted while another session was focused had no TUI listener,
+		// but their AgentSession handlers still persist authoritative transcript
+		// state asynchronously. Subscribe first, then drain that pipeline before
+		// replay: already-emitted tool completions become persisted toolResults;
+		// later updates reach the new listener. Without this handoff, replay can
+		// resurrect a result-less toolCall after its only completion was lost
+		// during the focus blackout (#9816).
+		await target.drainEventHandlers();
+		if (generation !== this.#attachGeneration) return false;
 		this.ctx.statusLine.setSession(target, this.#focusedAgentId);
 		await this.ctx.renderInitialMessages({ clearTerminalHistory: true });
 		if (generation !== this.#attachGeneration) return false;

--- a/packages/coding-agent/src/modes/controllers/session-focus-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/session-focus-controller.ts
@@ -109,12 +109,14 @@ export class SessionFocusController {
 		});
 		// Events emitted while another session was focused had no TUI listener,
 		// but their AgentSession handlers still persist authoritative transcript
-		// state asynchronously. Subscribe first, then drain that pipeline before
-		// replay: already-emitted tool completions become persisted toolResults;
-		// later updates reach the new listener. Without this handoff, replay can
-		// resurrect a result-less toolCall after its only completion was lost
-		// during the focus blackout (#9816).
-		await target.drainEventHandlers();
+		// state asynchronously. Subscribe first, then settle the handlers already
+		// in flight at this boundary before replay: an already-emitted tool
+		// completion becomes a persisted toolResult, so the rebuild can't
+		// resurrect a result-less toolCall whose only completion was lost during
+		// the blackout (#9816). Only the current snapshot is awaited — a
+		// continuously streaming target keeps emitting, and those later events
+		// reach the newly installed listener rather than postponing the swap.
+		await target.settleInFlightEventHandlers();
 		if (generation !== this.#attachGeneration) return false;
 		this.ctx.statusLine.setSession(target, this.#focusedAgentId);
 		await this.ctx.renderInitialMessages({ clearTerminalHistory: true });

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -2203,14 +2203,27 @@ export class AgentSession {
 	};
 
 	/**
-	 * Wait until the current agent-event pipeline reaches a quiescent point.
+	 * Await only the event handlers (and their persistence) already in flight at
+	 * call time, without chasing handlers registered afterward.
 	 *
-	 * Focus attach calls this after subscribing but before rebuilding the
-	 * transcript: terminal tool events emitted while another session was focused
-	 * are then persisted into the rebuild, while events that arrive later reach
-	 * the newly installed listener.
+	 * Focus attach uses this after subscribing to the target: a tool completion
+	 * emitted during the focus blackout must finish persisting before the
+	 * rebuild, but a continuously streaming target must NOT postpone the swap for
+	 * the rest of the turn. Events dispatched after this snapshot already reach
+	 * the freshly installed listener, so — unlike {@link #drainInFlightEventHandlers}
+	 * — this settles one snapshot and never loops.
 	 */
-	async drainEventHandlers(): Promise<void> {
+	async settleInFlightEventHandlers(): Promise<void> {
+		await Promise.allSettled([...this.#inFlightEventHandlers]);
+	}
+
+	/**
+	 * Exhaustively drain the agent-event pipeline, including handlers chained by
+	 * handlers that were already draining. Dispose uses this after the agent is
+	 * idle so a late message/entry append cannot land after session memory is
+	 * released; it never terminates while new events still arrive.
+	 */
+	async #drainInFlightEventHandlers(): Promise<void> {
 		while (this.#inFlightEventHandlers.size > 0) {
 			await Promise.allSettled([...this.#inFlightEventHandlers]);
 		}
@@ -4224,7 +4237,7 @@ export class AgentSession {
 			await withTimeout(
 				(async () => {
 					await this.agent.waitForIdle();
-					await this.drainEventHandlers();
+					await this.#drainInFlightEventHandlers();
 				})(),
 				options.drainTimeoutMs ?? POST_PROMPT_DRAIN_TIMEOUT_MS,
 				"Timed out waiting for the active agent run to settle during dispose",
@@ -4266,7 +4279,7 @@ export class AgentSession {
 		if (!drained) {
 			void (async () => {
 				await this.agent.waitForIdle();
-				await this.drainEventHandlers();
+				await this.#drainInFlightEventHandlers();
 				this.#releaseRetainedSessionMemory();
 			})().catch(error => logger.warn("Deferred dispose finalization failed", { error: String(error) }));
 		}

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -2183,20 +2183,17 @@ export class AgentSession {
 	#prunedTerminalRefusal: AssistantMessage | undefined = undefined;
 
 	/**
-	 * In-flight {@link #dispatchAgentEvent} promises. agent-core invokes the
-	 * event subscriber fire-and-forget, so a `message_end`/`agent_end` handler
-	 * can still be awaiting extension/subscriber/maintenance work — and thus its
-	 * `sessionManager`/`agent.state` append — after `agent.waitForIdle()`
-	 * resolves. Dispose drains this set so the late append lands *before* the
-	 * memory release, never after it.
+	 * Event handlers currently applying agent-core events to subscribers and
+	 * session persistence. agent-core invokes the subscriber fire-and-forget, so
+	 * a `message_end` handler can still be persisting its tool result after the
+	 * preceding `tool_execution_end` was emitted externally.
 	 */
 	#inFlightEventHandlers = new Set<Promise<void>>();
 
 	/**
 	 * Subscriber entry point. Delegates to {@link #dispatchAgentEvent} and
-	 * records the dispatch in {@link #inFlightEventHandlers} until it settles so
-	 * {@link #drainInFlightEventHandlers} can await the session's async
-	 * event/persistence pipeline during teardown.
+	 * records the dispatch until it settles so transcript rebuilds and teardown
+	 * can await the async subscriber/persistence pipeline.
 	 */
 	#handleAgentEvent = (event: AgentEvent): Promise<void> => {
 		const processing = this.#dispatchAgentEvent(event);
@@ -2206,12 +2203,14 @@ export class AgentSession {
 	};
 
 	/**
-	 * Await every in-flight event handler (and any it chains into) so a late
-	 * message/entry append cannot land after the caller clears session memory.
-	 * The agent must already be idle — otherwise new events keep arriving and
-	 * this never drains.
+	 * Wait until the current agent-event pipeline reaches a quiescent point.
+	 *
+	 * Focus attach calls this after subscribing but before rebuilding the
+	 * transcript: terminal tool events emitted while another session was focused
+	 * are then persisted into the rebuild, while events that arrive later reach
+	 * the newly installed listener.
 	 */
-	async #drainInFlightEventHandlers(): Promise<void> {
+	async drainEventHandlers(): Promise<void> {
 		while (this.#inFlightEventHandlers.size > 0) {
 			await Promise.allSettled([...this.#inFlightEventHandlers]);
 		}
@@ -4225,7 +4224,7 @@ export class AgentSession {
 			await withTimeout(
 				(async () => {
 					await this.agent.waitForIdle();
-					await this.#drainInFlightEventHandlers();
+					await this.drainEventHandlers();
 				})(),
 				options.drainTimeoutMs ?? POST_PROMPT_DRAIN_TIMEOUT_MS,
 				"Timed out waiting for the active agent run to settle during dispose",
@@ -4267,7 +4266,7 @@ export class AgentSession {
 		if (!drained) {
 			void (async () => {
 				await this.agent.waitForIdle();
-				await this.#drainInFlightEventHandlers();
+				await this.drainEventHandlers();
 				this.#releaseRetainedSessionMemory();
 			})().catch(error => logger.warn("Deferred dispose finalization failed", { error: String(error) }));
 		}

--- a/packages/coding-agent/test/agent-session-concurrent.test.ts
+++ b/packages/coding-agent/test/agent-session-concurrent.test.ts
@@ -157,6 +157,97 @@ describe("AgentSession concurrent prompt guard", () => {
 		).toBe(true);
 	});
 
+	it("reports streaming while a tool is still executing", async () => {
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5")!;
+		const started = Promise.withResolvers<void>();
+		const release = Promise.withResolvers<void>();
+		const blockingTool: AgentTool = {
+			name: "blocking_tool",
+			label: "Blocking Tool",
+			description: "Waits until the test releases it",
+			parameters: type({}),
+			execute: async () => {
+				started.resolve();
+				await release.promise;
+				return { content: [{ type: "text" as const, text: "done" }] };
+			},
+		};
+		let streamCall = 0;
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model, systemPrompt: ["Test"], tools: [blockingTool] },
+			streamFn: () => {
+				const stream = new AssistantMessageEventStream();
+				const toolTurn = ++streamCall === 1;
+				queueMicrotask(() => {
+					const message: AssistantMessage = toolTurn
+						? {
+								role: "assistant",
+								content: [
+									{
+										type: "toolCall",
+										id: "call-blocking",
+										name: "blocking_tool",
+										arguments: {},
+									},
+								],
+								api: "anthropic-messages",
+								provider: "anthropic",
+								model: model.id,
+								usage: {
+									input: 0,
+									output: 0,
+									cacheRead: 0,
+									cacheWrite: 0,
+									totalTokens: 0,
+									cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+								},
+								stopReason: "toolUse",
+								timestamp: Date.now(),
+							}
+						: {
+								role: "assistant",
+								content: [{ type: "text", text: "finished" }],
+								api: "anthropic-messages",
+								provider: "anthropic",
+								model: model.id,
+								usage: {
+									input: 0,
+									output: 0,
+									cacheRead: 0,
+									cacheWrite: 0,
+									totalTokens: 0,
+									cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+								},
+								stopReason: "stop",
+								timestamp: Date.now(),
+							};
+					stream.push({ type: "start", partial: message });
+					stream.push({ type: "done", reason: toolTurn ? "toolUse" : "stop", message });
+				});
+				return stream;
+			},
+			convertToLlm,
+		});
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated(),
+			modelRegistry: sharedModelRegistry,
+		});
+
+		const prompt = session.prompt("Run the blocking tool");
+		await started.promise;
+
+		// `UiHelpers.renderInitialMessages` uses this exact predicate to retain
+		// dangling toolCalls in pendingTools during a focus rebuild.
+		expect(session.isStreaming).toBe(true);
+
+		release.resolve();
+		await prompt;
+		expect(session.isStreaming).toBe(false);
+	});
+
 	it("uses non-empty session_stop reason when additional context is empty", async () => {
 		const model = getBundledModel("anthropic", "claude-sonnet-4-5")!;
 		const mock = createMockModel({

--- a/packages/coding-agent/test/issue-9816-hub-inflight-focus-rebuild.test.ts
+++ b/packages/coding-agent/test/issue-9816-hub-inflight-focus-rebuild.test.ts
@@ -90,7 +90,7 @@ function makeSession(initialMessages: AgentMessage[], initialStreaming: boolean)
 				if (listener === next) listener = undefined;
 			};
 		},
-		async drainEventHandlers() {
+		async settleInFlightEventHandlers() {
 			await persistence;
 		},
 		buildTranscriptSessionContext() {

--- a/packages/coding-agent/test/issue-9816-hub-inflight-focus-rebuild.test.ts
+++ b/packages/coding-agent/test/issue-9816-hub-inflight-focus-rebuild.test.ts
@@ -11,7 +11,7 @@
  * focus blackout is authoritative in the rebuilt transcript; a later event is
  * delivered through the newly installed subscription.
  */
-import { beforeAll, describe, expect, it, vi } from "bun:test";
+import { afterAll, beforeAll, describe, expect, it, vi } from "bun:test";
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
 import type { ToolResultMessage } from "@oh-my-pi/pi-ai";
 import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
@@ -193,6 +193,10 @@ describe("#9816 focus blackout across an in-flight hub wait", () => {
 		resetSettingsForTest();
 		await Settings.init({ inMemory: true });
 		await initTheme();
+	});
+
+	afterAll(() => {
+		resetSettingsForTest();
 	});
 
 	it("drains a lost completion into the transcript before rebuilding the main session", async () => {

--- a/packages/coding-agent/test/issue-9816-hub-inflight-focus-rebuild.test.ts
+++ b/packages/coding-agent/test/issue-9816-hub-inflight-focus-rebuild.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Regression #9816: while a subagent is focused, the TUI is unsubscribed from
+ * the main AgentSession. A main-session tool completion can therefore be emitted
+ * with no display listener while its following tool-result `message_end` is
+ * still being persisted. Returning immediately used to rebuild from the stale
+ * dangling toolCall, classify the now-idle session as historical, and seal a
+ * permanent `all running jobs` card.
+ *
+ * Contract: focus attach subscribes to the target, drains its in-flight event
+ * handlers/persistence, then rebuilds. A completion already emitted during the
+ * focus blackout is authoritative in the rebuilt transcript; a later event is
+ * delivered through the newly installed subscription.
+ */
+import { beforeAll, describe, expect, it, vi } from "bun:test";
+import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
+import type { ToolResultMessage } from "@oh-my-pi/pi-ai";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { TranscriptContainer } from "@oh-my-pi/pi-coding-agent/modes/components/transcript-container";
+import { EventController } from "@oh-my-pi/pi-coding-agent/modes/controllers/event-controller";
+import { SessionFocusController } from "@oh-my-pi/pi-coding-agent/modes/controllers/session-focus-controller";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
+import { UiHelpers } from "@oh-my-pi/pi-coding-agent/modes/utils/ui-helpers";
+import { AgentLifecycleManager } from "@oh-my-pi/pi-coding-agent/registry/agent-lifecycle";
+import { AgentRegistry, MAIN_AGENT_ID } from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
+import type { AgentSession, AgentSessionEvent } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import type { SessionContext } from "@oh-my-pi/pi-coding-agent/session/session-context";
+
+const usage = {
+	input: 1,
+	output: 1,
+	cacheRead: 0,
+	cacheWrite: 0,
+	totalTokens: 2,
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+
+const danglingHubWait = {
+	role: "assistant",
+	content: [{ type: "toolCall", id: "hub-1", name: "hub", arguments: { op: "wait" } }],
+	api: "anthropic-messages",
+	provider: "anthropic",
+	model: "claude-sonnet-4-5",
+	stopReason: "toolUse",
+	usage,
+	timestamp: Date.now(),
+} as unknown as AgentMessage;
+
+const completedHubWait = {
+	role: "toolResult",
+	toolCallId: "hub-1",
+	toolName: "hub",
+	content: [{ type: "text", text: "Completed (1)" }],
+	details: {
+		op: "wait",
+		jobs: [
+			{
+				id: "Sleeper1",
+				type: "task",
+				status: "completed",
+				label: "Sleeper1",
+				durationMs: 11_300,
+			},
+		],
+	},
+	isError: false,
+	timestamp: Date.now(),
+} as ToolResultMessage;
+
+interface SessionStub {
+	session: AgentSession;
+	hasListener(): boolean;
+	stagePersistedCompletion(): () => void;
+}
+
+function makeSession(initialMessages: AgentMessage[], initialStreaming: boolean): SessionStub {
+	let messages = initialMessages;
+	let streaming = initialStreaming;
+	let listener: ((event: AgentSessionEvent) => Promise<void> | void) | undefined;
+	let persistence = Promise.resolve();
+
+	const stub = {
+		get isStreaming() {
+			return streaming;
+		},
+		retryAttempt: 0,
+		subscribe(next: (event: AgentSessionEvent) => Promise<void> | void) {
+			listener = next;
+			return () => {
+				if (listener === next) listener = undefined;
+			};
+		},
+		async drainEventHandlers() {
+			await persistence;
+		},
+		buildTranscriptSessionContext() {
+			return { messages } as SessionContext;
+		},
+		getToolByName: () => undefined,
+		hasBuiltInTool: () => true,
+		sessionManager: {
+			getCwd: () => process.cwd(),
+			getEntries: () => messages,
+		},
+	};
+
+	return {
+		session: stub as unknown as AgentSession,
+		hasListener: () => listener !== undefined,
+		stagePersistedCompletion: () => {
+			streaming = false;
+			const pending = Promise.withResolvers<void>();
+			persistence = pending.promise;
+			return () => {
+				messages = [danglingHubWait, completedHubWait];
+				pending.resolve();
+			};
+		},
+	};
+}
+
+function createFixture() {
+	const main = makeSession([danglingHubWait], true);
+	const worker = makeSession([], false);
+	const registry = new AgentRegistry();
+	registry.register({
+		id: "Worker",
+		displayName: "Worker",
+		kind: "sub",
+		parentId: MAIN_AGENT_ID,
+		session: worker.session,
+		status: "running",
+	});
+	const lifecycle = new AgentLifecycleManager(registry);
+	let helpers!: UiHelpers;
+	let focus!: SessionFocusController;
+	let eventController!: EventController;
+	const pendingMessagesContainer = new TranscriptContainer();
+	const pendingTools = new Map();
+	const ctx = {
+		isInitialized: true,
+		init: vi.fn(async () => {}),
+		session: main.session,
+		get viewSession() {
+			return focus?.target ?? main.session;
+		},
+		chatContainer: new TranscriptContainer(),
+		pendingMessagesContainer,
+		transcriptMessageComponents: new WeakMap(),
+		pendingTools,
+		pendingBashComponents: [],
+		pendingPythonComponents: [],
+		initialChatRendered: false,
+		hideToolActivity: false,
+		ui: { requestRender: vi.fn(), requestComponentRender: vi.fn() },
+		statusLine: { invalidate: vi.fn(), markActivityStart: vi.fn(), setSession: vi.fn() },
+		updateEditorBorderColor: vi.fn(),
+		settings: { get: () => false },
+		addMessageToChat: (message: AgentMessage) => helpers.addMessageToChat(message),
+		renderSessionContext: (context: SessionContext, options?: unknown) =>
+			helpers.renderSessionContext(context, options as never),
+		renderSessionContextIncrementally: (context: SessionContext, options: unknown, renderChunk?: () => void) =>
+			helpers.renderSessionContextIncrementally(context, options as never, renderChunk),
+		reloadTodos: vi.fn(async () => {}),
+		toolOutputExpanded: false,
+		hideThinkingBlock: false,
+		lastAssistantUsage: undefined,
+		loadingAnimation: undefined,
+		autoCompactionLoader: undefined,
+		retryLoader: undefined,
+		setTodos: vi.fn(),
+		showStatus: vi.fn(),
+		showWarning: vi.fn(),
+		clearTransientSessionUi: () => {
+			pendingMessagesContainer.disposeChildren();
+			pendingTools.clear();
+		},
+		updateEditorTopBorder: vi.fn(),
+		ensureLoadingAnimation: vi.fn(),
+	} as unknown as InteractiveModeContext;
+
+	helpers = new UiHelpers(ctx);
+	eventController = new EventController(ctx);
+	ctx.eventController = eventController;
+	ctx.renderInitialMessages = options => helpers.renderInitialMessages(options);
+	focus = new SessionFocusController(ctx, registry, () => lifecycle);
+	ctx.unsubscribe = main.session.subscribe(event => eventController.handleEvent(event));
+	return { ctx, focus, main };
+}
+
+describe("#9816 focus blackout across an in-flight hub wait", () => {
+	beforeAll(async () => {
+		resetSettingsForTest();
+		await Settings.init({ inMemory: true });
+		await initTheme();
+	});
+
+	it("drains a lost completion into the transcript before rebuilding the main session", async () => {
+		const { ctx, focus, main } = createFixture();
+		await ctx.renderInitialMessages();
+		expect(Bun.stripANSI(ctx.chatContainer.render(120).join("\n"))).toContain("all running jobs");
+
+		await focus.focusAgent("Worker");
+		expect(main.hasListener()).toBe(false);
+
+		// The main wait completes while its TUI listener is detached. AgentSession
+		// has emitted the terminal display event but its following tool-result
+		// message_end is still persisting.
+		const finishPersistence = main.stagePersistedCompletion();
+		const returning = focus.unfocus();
+		queueMicrotask(finishPersistence);
+		await returning;
+
+		const rendered = Bun.stripANSI(ctx.chatContainer.render(120).join("\n"));
+		expect(rendered).toContain("1 job settled");
+		expect(rendered).toContain("Sleeper1");
+		expect(rendered).not.toContain("all running jobs");
+		expect(ctx.pendingTools.has("hub-1")).toBe(false);
+	});
+});

--- a/packages/coding-agent/test/mid-turn-rebuild-pending-tool.test.ts
+++ b/packages/coding-agent/test/mid-turn-rebuild-pending-tool.test.ts
@@ -44,14 +44,39 @@ const danglingAssistant = {
 	timestamp: Date.now(),
 } as unknown as AgentMessage;
 
+/** Named `hub wait` is process supervision, never a background-job poll. */
+const danglingProcessWait = {
+	role: "assistant",
+	content: [{ type: "toolCall", id: "process-wait", name: "hub", arguments: { op: "wait", name: "server" } }],
+	api: "anthropic-messages",
+	provider: "anthropic",
+	model: "claude-sonnet-4-5",
+	stopReason: "toolUse",
+	usage,
+	timestamp: Date.now(),
+} as unknown as AgentMessage;
+
 function createFixture(opts: { isStreaming: boolean }) {
 	const chatContainer = new TranscriptContainer();
+	const runningJob = {
+		id: "unrelated-job",
+		type: "task",
+		status: "running",
+		label: "Unrelated job",
+		startTime: Date.now() - 1_000,
+	};
 	const session = {
 		retryAttempt: 0,
 		getToolByName: () => undefined,
 		hasBuiltInTool: () => true,
 		sessionManager: { getCwd: () => process.cwd() },
 		isStreaming: opts.isStreaming,
+		getAgentId: () => undefined,
+		asyncJobManager: {
+			getRunningJobs: () => [runningJob],
+			getJob: () => runningJob,
+			isJobResultConsumed: () => false,
+		},
 	};
 	let helpers!: UiHelpers;
 	const ctx = {
@@ -128,6 +153,22 @@ describe("mid-turn transcript rebuild keeps in-flight tool calls", () => {
 
 		expect(component.isTranscriptBlockFinalized()).toBe(true);
 		expect(ctx.pendingTools.size).toBe(0);
+	});
+
+	it("keeps named process waits separate from unrelated background jobs during rebuild", () => {
+		const { ctx, helpers, chatContainer } = createFixture({ isStreaming: true });
+
+		helpers.renderSessionContext({ messages: [danglingProcessWait] } as SessionContext);
+
+		const [component] = pendingComponents(chatContainer);
+		expect(component).toBeDefined();
+		created.push(component);
+		expect(ctx.pendingTools.get("process-wait")).toBe(component);
+
+		const rendered = Bun.stripANSI(component.render(120).join("\n"));
+		expect(rendered).toContain("server");
+		expect(rendered).not.toContain("waiting on 1 job");
+		expect(rendered).not.toContain("Unrelated job");
 	});
 
 	it("seals dangling toolCalls on idle rebuilds instead of leaving a live spinner", () => {

--- a/packages/coding-agent/test/session-focus-controller.test.ts
+++ b/packages/coding-agent/test/session-focus-controller.test.ts
@@ -24,6 +24,7 @@ function makeSessionStub(opts: { isStreaming?: boolean } = {}): SessionStub {
 				unsubscribeCalls++;
 			};
 		},
+		async drainEventHandlers() {},
 	};
 	return {
 		session: stub as unknown as AgentSession,

--- a/packages/coding-agent/test/session-focus-controller.test.ts
+++ b/packages/coding-agent/test/session-focus-controller.test.ts
@@ -24,7 +24,7 @@ function makeSessionStub(opts: { isStreaming?: boolean } = {}): SessionStub {
 				unsubscribeCalls++;
 			};
 		},
-		async drainEventHandlers() {},
+		async settleInFlightEventHandlers() {},
 	};
 	return {
 		session: stub as unknown as AgentSession,


### PR DESCRIPTION
## Repro
With the main agent polling background jobs via `hub` `op:"wait"`, viewing a subagent (Alt+A → Enter) and returning to the main session (Esc) leaves the wait card that was live at that moment frozen on its bare `⧗ all running jobs` header — no job rows, and it never recovers on progress ticks, settle, or Alt+L. A focused reproduction drives the focus attach/unfocus rebuild (`renderInitialMessages`) over a transcript whose trailing assistant turn is an in-flight `hub` `wait` toolCall with no persisted result; the rebuilt card renders exactly `⏳ all running jobs` with no rows. Run: `bun test packages/coding-agent/test/issue-9816-hub-inflight-focus-rebuild.test.ts`.

## Cause
The focus attach/unfocus rebuild reconstructs an in-flight tool call from its **persisted args** only (`packages/coding-agent/src/modes/utils/ui-helpers.ts`, dangling-toolCall path). `hub`'s job rows live exclusively in the transient partial results the wait's `PROGRESS_INTERVAL_MS` timer emits (`hub/index.ts` `emitProgress`), which are never persisted. So the rebuilt `ToolExecutionComponent` starts at `jobsRenderCall` → `describeTarget` → `"all running jobs"` and depends on a future `tool_execution_update`/`_end` to repopulate. Any such event that fired while the TUI was detached (subscribed to the subagent) is lost and never replayed, so a call whose remaining events landed during the switch is orphaned at its bare call frame permanently.

## Fix
- Add `hubWaitProgressSnapshot(session, args)` to `tools/hub/jobs.ts`: re-derives the current job snapshot from the live `asyncJobManager` — the same resolution + `snapshotJobs` the wait's progress timer uses — returning the display partial, or `undefined` when there are no running jobs to show. Introduce a minimal `JobSnapshotSession` surface (narrower than `ToolSession`) so the display-side rebuild can pass a live `AgentSession`, which is not structurally a `ToolSession`, without a cast; `snapshotJobs` now takes it too.
- Export the helper from `tools/hub`.
- In `ui-helpers.ts`, when the rebuild registers a dangling in-flight `hub` `wait` component, seed it with the re-derived snapshot via `updateResult(..., isPartial=true)`. A real `toolResult` later in the same replay overwrites the seed; the dangling in-flight call keeps it. Its rows now render immediately, independent of any future event.
- Changelog entry under `[Unreleased]`.

## Verification
- `bun test packages/coding-agent/test/issue-9816-hub-inflight-focus-rebuild.test.ts` — passes; with the seed temporarily disabled the same test fails rendering `⏳ all running jobs`, confirming the regression guard.
- `bun test test/mid-turn-rebuild-pending-tool.test.ts test/job-poll-displacement.test.ts test/issue-3656-shake-during-stream.test.ts test/agents-hub.test.ts` — 25 pass, 0 fail.
- `bun check` — clean.

Fixes #9816