### PR TITLE
fix(acp): surface session-busy as a typed JSON-RPC error instead of -32603

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- ACP clients prompting while the agent is mid-turn now receive a typed JSON-RPC error (code -32003, `data.reason: "session_busy"`) instead of an opaque -32603 "Internal error", so prompts no longer appear to vanish when the session is busy.
+
 ## [18.0.6] - 2026-08-26
 
 ### Added

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -1,6 +1,6 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import type { AgentToolResult } from "@oh-my-pi/pi-agent-core";
+import { AgentBusyError, type AgentToolResult } from "@oh-my-pi/pi-agent-core";
 import type { AssistantMessage, Model } from "@oh-my-pi/pi-ai";
 import { getBlobsDir, isEnoent, logger, type postmortem, VERSION } from "@oh-my-pi/pi-utils";
 import {
@@ -30,6 +30,7 @@ import {
 	PROTOCOL_VERSION,
 	type PromptRequest,
 	type PromptResponse,
+	RequestError,
 	type ResumeSessionRequest,
 	type ResumeSessionResponse,
 	type SessionConfigOption,
@@ -161,6 +162,15 @@ type PromptTurnState = {
 function isPromptTurnInFlight(turn: PromptTurnState | undefined): turn is PromptTurnState {
 	return turn !== undefined && (!turn.settled || turn.cleanup !== undefined);
 }
+
+/**
+ * JSON-RPC server-range application code (-32000..-32099) identifying a busy
+ * session on the ACP prompt path. Sibling application codes live on the
+ * `RequestError` factories (-32000 authRequired, -32002 resourceNotFound); the
+ * data payload carries `reason: "session_busy"` so clients can react instead
+ * of decoding an opaque -32603 "Internal error".
+ */
+const ACP_SESSION_BUSY_ERROR_CODE = -32003;
 
 type ManagedSessionRecord = {
 	session: AgentSession;
@@ -869,8 +879,21 @@ export class AcpAgent implements Agent {
 				this.#trackPromptEvent(record, event);
 			});
 
+			// Autonomous turns stream without an owning promptTurn, so the implicit-cancel
+			// guard above cannot fire and a client prompt lands on AgentSession's busy
+			// guard. Type that failure for the wire instead of letting transport.ts wrap
+			// it as a generic -32603 internal error.
 			this.#runPromptOrCommand(record, converted.text, converted.images).catch((error: unknown) => {
-				this.#finishPrompt(record, undefined, error);
+				this.#finishPrompt(
+					record,
+					undefined,
+					error instanceof AgentBusyError
+						? new RequestError(ACP_SESSION_BUSY_ERROR_CODE, error.message, {
+								reason: "session_busy",
+								hint: "steer|followUp|wait",
+							})
+						: error,
+				);
 			});
 
 			return await pendingPrompt.promise;

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -163,15 +163,6 @@ function isPromptTurnInFlight(turn: PromptTurnState | undefined): turn is Prompt
 	return turn !== undefined && (!turn.settled || turn.cleanup !== undefined);
 }
 
-/**
- * JSON-RPC server-range application code (-32000..-32099) identifying a busy
- * session on the ACP prompt path. Sibling application codes live on the
- * `RequestError` factories (-32000 authRequired, -32002 resourceNotFound); the
- * data payload carries `reason: "session_busy"` so clients can react instead
- * of decoding an opaque -32603 "Internal error".
- */
-const ACP_SESSION_BUSY_ERROR_CODE = -32003;
-
 type ManagedSessionRecord = {
 	session: AgentSession;
 	setToolUIContext: ((uiContext: ExtensionUIContext, hasUI: boolean) => void) | undefined;
@@ -888,7 +879,7 @@ export class AcpAgent implements Agent {
 					record,
 					undefined,
 					error instanceof AgentBusyError
-						? new RequestError(ACP_SESSION_BUSY_ERROR_CODE, error.message, {
+						? RequestError.sessionBusy(error.message, {
 								reason: "session_busy",
 								hint: "steer|followUp|wait",
 							})

--- a/packages/coding-agent/test/acp-agent.test.ts
+++ b/packages/coding-agent/test/acp-agent.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, spyOn, vi } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { AgentBusyError } from "@oh-my-pi/pi-agent-core";
 import type { Model } from "@oh-my-pi/pi-ai";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
@@ -40,6 +41,7 @@ import type {
 	Validator,
 } from "@oh-my-pi/pi-utils/acp";
 import {
+	RequestError,
 	zForkSessionResponse,
 	zLoadSessionResponse,
 	zNewSessionResponse,
@@ -2459,6 +2461,33 @@ describe("ACP agent", () => {
 		finishPrompt();
 		harness.abortController.abort();
 		await Bun.sleep(0);
+	});
+
+	it("maps agent-busy rejections to a typed session_busy error instead of internalError", async () => {
+		const harness = await createHarness();
+		const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });
+		const session = harness.findSession(created.sessionId)!;
+		// Autonomous turns stream without an owning ACP promptTurn, so prompt()'s
+		// implicit-cancel guard never fires. Mirror AgentSession's contract: a
+		// bare prompt while streaming throws AgentBusyError.
+		session.isStreaming = true;
+		session.prompt = async (): Promise<boolean> => {
+			if (session.isStreaming) throw new AgentBusyError();
+			return true;
+		};
+
+		const error = await harness.agent
+			.prompt({
+				sessionId: created.sessionId,
+				prompt: [{ type: "text", text: "ping during autonomous turn" }],
+			} as PromptRequest)
+			.catch((reason: unknown) => reason);
+
+		expect(error).toBeInstanceOf(RequestError);
+		const requestError = error as RequestError;
+		expect(requestError.code).toBe(-32003);
+		expect(requestError.message).toContain("already processing");
+		expect(requestError.data).toEqual({ reason: "session_busy", hint: "steer|followUp|wait" });
 	});
 
 	it("keeps closeSession gated while cancel cleanup is pending", async () => {

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `RequestError.sessionBusy(message, data)` for the ACP session-busy application error (`-32003`) on the shared JSON-RPC transport.
+
 ## [18.0.6] - 2026-08-26
 
 ### Added

--- a/packages/utils/src/acp/transport.ts
+++ b/packages/utils/src/acp/transport.ts
@@ -77,6 +77,15 @@ export class RequestError extends Error {
 			uri === undefined ? undefined : { uri },
 		);
 	}
+	/**
+	 * Creates a session-busy error: the agent/session is already processing, so the
+	 * request can be retried once idle (steer/follow-up/wait) instead of treating it
+	 * as a fault. `message` carries the caller's user-facing wording; `data` should
+	 * keep the stable discriminator shape (`reason: "session_busy"`).
+	 */
+	static sessionBusy(message: string, data?: unknown): RequestError {
+		return new RequestError(-32003, message, data);
+	}
 	/** Converts this error into a JSON-RPC result. */
 	toResult(): { error: ErrorResponse } {
 		return { error: this.toErrorResponse() };

--- a/packages/utils/test/acp.test.ts
+++ b/packages/utils/test/acp.test.ts
@@ -113,6 +113,7 @@ describe("ACP JSON-RPC transport", () => {
 			RequestError.requestCancelled().toErrorResponse(),
 			RequestError.authRequired().toErrorResponse(),
 			RequestError.resourceNotFound("file:///missing").toErrorResponse(),
+			RequestError.sessionBusy("Agent is already processing.", { reason: "session_busy" }).toErrorResponse(),
 		]).toEqual([
 			{ code: -32700, message: "Parse error" },
 			{ code: -32600, message: "Invalid request" },
@@ -122,6 +123,7 @@ describe("ACP JSON-RPC transport", () => {
 			{ code: -32800, message: "Request cancelled" },
 			{ code: -32000, message: "Authentication required" },
 			{ code: -32002, message: "Resource not found: file:///missing", data: { uri: "file:///missing" } },
+			{ code: -32003, message: "Agent is already processing.", data: { reason: "session_busy" } },
 		]);
 	});
 });


### PR DESCRIPTION
## Problem

When an ACP client sends session/prompt while the agent is mid-turn, omp currently fails the request with a generic -32603 'Internal error'. The client cannot distinguish 'busy' from 'broken', so user prompts appear to vanish. This maps the existing AgentBusyError onto a typed JSON-RPC error with a stable data payload so clients can react (steer, queue, or wait).

## Root cause

- `AgentBusyError` (`packages/agent/src/agent.ts:90-97`, thrown at `:1155`/`:1217` when the agent is already streaming) carries only a human message.

- On the ACP path, turns started outside `session/prompt` (steer/follow-up continuations, scheduled messages, async job follow-ups) stream **without an owning `promptTurn`**. The implicit-cancel guard at the top of `AcpAgent.prompt()` (`packages/coding-agent/src/modes/acp/acp-agent.ts:832-850`) keys on `record.promptTurn`, so it never fires for these; control falls into the queued closure and `#runPromptOrCommand`, where `record.session.prompt(...)` (`acp-agent.ts:1039`) rejects with the raw `AgentBusyError`.

- `RpcConnection.#handle` (`packages/utils/src/acp/transport.ts:205-211`) wraps any non-`RequestError` into `RequestError.internalError({ details })`, so the client receives:

```json
{ "code": -32603, "message": "Internal error", "data": { "details": "Agent is already processing. Use steer() or followUp() to queue messages, or wait for completion." } }
```

(The message does survive in `data.details`, but the code is indistinguishable from any other server fault.)

## The change

Two pieces, wire shape identical throughout:

- `RequestError.sessionBusy(message, data)` factory on the shared transport utility (`packages/utils/src/acp/transport.ts`), so the third ACP application code (`-32003`) lives beside the existing `-32000` authRequired / `-32002` resourceNotFound factories instead of a local constant (per the repo's central-utilities rule).
- The single prompt-path choke point — the `.catch` that settles the ACP turn (`packages/coding-agent/src/modes/acp/acp-agent.ts:873-889`) — maps `instanceof AgentBusyError` through that factory:

```json
{ "code": -32003, "message": "Agent is already processing. Use steer() or followUp() to queue messages, or wait for completion.", "data": { "reason": "session_busy", "hint": "steer|followUp|wait" } }
```

Semantics: `session_busy` is **transient** — clients may retry once the session goes idle; `data.reason` is the stable machine discriminator, `message`/`hint` are display text kept identical to `AgentBusyError`'s own wording so ACP clients and the TUI agree.

Everything else (cancel cleanup failures, closed-session errors, provider faults) still falls through to the generic internal-error envelope; this PR deliberately changes one concern.

## Verification

Wire-level regression test in `packages/coding-agent/test/acp-agent.test.ts` (FakeAgentSession mirroring `AgentSession`'s bare-prompt-throws-busy contract): busy session + `session/prompt` → rejects with `RequestError`, `code === -32003`, `data.reason === "session_busy"`, message preserved. Suite: 76 pass / 0 fail.

Also green after the factory follow-up (`761ef10c0c`): `packages/utils/test/acp.test.ts` SDK-fixture enumeration extended for `-32003` (7 files touched suites: 127 pass / 0 fail), `tsgo` + biome clean on both touched packages.

Manual repro against `omp --mode acp` (project-local extension schedules `pi.sendUserMessage()` on an idle session → autonomous turn with no owning `promptTurn`; second `session/prompt` captured on the wire mid-turn):

Before:

```json
{"code":-32603,"message":"Internal error","data":{"details":"Agent is already processing. Use steer() or followUp() to queue messages, or wait for completion."}}
```

After:

```json
{"code":-32003,"message":"Agent is already processing. Use steer() or followUp() to queue messages, or wait for completion.","data":{"reason":"session_busy","hint":"steer|followUp|wait"}}
```

## References

- Prior art and ask: [#9157 (comment)](https://github.com/can1357/oh-my-pi/issues/9157#issuecomment-5392684053) — typed busy-error request, endorsed by @bradhallett ("Endorsing the earlier ask from the Tx Code side"). Two ACP clients hit this in practice: Tx Code and get-bb ([get-bb/bb#2461](https://github.com/get-bb/bb/issues/2461) resumes parked async deliveries with a synthetic `session/prompt` and needs to branch on the typed error).
- Composition, not overlap: this makes busy **detectable**; the signal for when the busy turn *ends* is the wake/lifecycle half of #9157. Client story = detect (`-32003` + `reason`) → wait for wake → resume.
