### PR TITLE
feat(utils): honor absolute quota-reset moments in 429 bodies

### DIFF
--- a/packages/coding-agent/test/agent-session-quota-reset.test.ts
+++ b/packages/coding-agent/test/agent-session-quota-reset.test.ts
@@ -1,0 +1,210 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as path from "node:path";
+import { scheduler } from "node:timers/promises";
+import { Agent } from "@oh-my-pi/pi-agent-core";
+import type { AssistantMessage } from "@oh-my-pi/pi-ai";
+import { unregisterCustomApis } from "@oh-my-pi/pi-ai/api-registry";
+import { createMockModel } from "@oh-my-pi/pi-ai/providers/mock";
+import * as aiStream from "@oh-my-pi/pi-ai/stream";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { AgentSession, type AgentSessionEvent } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+type AutoRetryEndEvent = Extract<AgentSessionEvent, { type: "auto_retry_end" }>;
+type AutoRetryStartEvent = Extract<AgentSessionEvent, { type: "auto_retry_start" }>;
+
+const QUOTA_RESET_MOCK_API_SOURCE = "agent-session-quota-reset-test";
+
+// A fixed past date would fall through the hint sanity clamp (reset already
+// elapsed → undefined), so stamp the reset moment ~3h17m into the future as
+// Beijing wall-clock — the exact shape of Zhipu Coding Plan's 429 type=1308
+// body, whose timestamp carries no explicit zone marker.
+const RESET_AT_MS = Date.now() + (3 * 60 + 17) * 60 * 1000;
+const QUOTA_RESET_RETRY_BUFFER_MS = 3_000;
+
+function beijingWallClock(ms: number): string {
+	// Manual formatting: Intl "sv-SE" emits `21.51.10` (dotted time) in some ICU
+	// builds, which would not match the provider wording under test.
+	const parts = new Intl.DateTimeFormat("en-CA", {
+		timeZone: "Asia/Shanghai",
+		hour12: false,
+		year: "numeric",
+		month: "2-digit",
+		day: "2-digit",
+		hour: "2-digit",
+		minute: "2-digit",
+		second: "2-digit",
+	}).formatToParts(new Date(ms));
+	const get = (type: string) => parts.find(part => part.type === type)?.value ?? "00";
+	return `${get("year")}-${get("month")}-${get("day")} ${get("hour")}:${get("minute")}:${get("second")}`;
+}
+
+const ZHIPU_1308_ERROR = `429 已达到 5 小时的使用上限。您的限额将在 ${beijingWallClock(RESET_AT_MS)} 重置。 (type=1308)`;
+
+function lastAssistant(session: AgentSession): AssistantMessage {
+	const message = session.agent.state.messages.at(-1);
+	if (message?.role !== "assistant") {
+		throw new Error("Expected trailing assistant message");
+	}
+	return message as AssistantMessage;
+}
+
+/**
+ * Contract: a usage-limit error body stating an absolute reset timestamp is
+ * parsed into the exact wait-to-resume delay (stated moment +3s grace). The
+ * wait still honors `retry.maxDelayMs`: operators who want multi-hour
+ * auto-resume disable/raise the cap in their own config; with a tight cap the
+ * fail-fast behavior is unchanged — there is no per-hint code exemption.
+ */
+describe("AgentSession quota-reset auto-resume", () => {
+	let tempDir: TempDir;
+	let authStorage: AuthStorage;
+	let modelRegistry: ModelRegistry;
+	let session: AgentSession | undefined;
+
+	beforeAll(async () => {
+		tempDir = TempDir.createSync("@pi-quota-reset-");
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
+		modelRegistry = new ModelRegistry(authStorage, path.join(tempDir.path(), "models.yml"));
+	});
+
+	beforeEach(async () => {
+		vi.spyOn(aiStream, "getEnvApiKey").mockReturnValue(undefined);
+		await authStorage.remove("zhipu-coding-plan");
+		authStorage.removeRuntimeApiKey("zhipu-coding-plan");
+		authStorage.setRuntimeApiKey("zhipu-coding-plan", "zhipu-test-key");
+		modelRegistry.clearSuppressedSelectors();
+	});
+
+	afterEach(async () => {
+		if (session) {
+			await session.dispose();
+			session = undefined;
+		}
+		unregisterCustomApis(QUOTA_RESET_MOCK_API_SOURCE);
+		vi.restoreAllMocks();
+	});
+
+	afterAll(() => {
+		authStorage.close();
+		tempDir.removeSync();
+	});
+
+	it("sleeps until the stated reset time and resumes when retry.maxDelayMs is unlimited", async () => {
+		const model = getBundledModel("zhipu-coding-plan", "glm-4.7");
+		if (!model) {
+			throw new Error("Expected bundled zhipu-coding-plan test model to exist");
+		}
+
+		// Mock responses: the 1308 error, then the post-reset recovery turn.
+		const mock = createMockModel({
+			provider: model.provider,
+			responses: [
+				{ throw: ZHIPU_1308_ERROR },
+				{ content: [{ type: "text", text: "resumed after quota reset" }], stopReason: "stop" },
+			],
+		});
+		const agent = new Agent({
+			getApiKey: requestedModel => `${requestedModel.provider}-test-key`,
+			initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] },
+			streamFn: (requestedModel, context, options) => mock.stream(requestedModel, context, options),
+		});
+
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"retry.baseDelayMs": 5,
+			"retry.maxDelayMs": 0, // no cap: unattended auto-resume waits for the stated moment
+			"retry.maxRetries": 3,
+			"retry.modelFallback": false,
+		});
+		settings.setModelRole("default", `${model.provider}/${model.id}`);
+
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+		});
+
+		const waitSpy = vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+		const retryStartEvents: AutoRetryStartEvent[] = [];
+		const retryEndEvents: AutoRetryEndEvent[] = [];
+		session.subscribe(event => {
+			if (event.type === "auto_retry_start") retryStartEvents.push(event);
+			if (event.type === "auto_retry_end") retryEndEvents.push(event);
+		});
+
+		await session.prompt("Trigger zhipu quota exhaustion");
+		await session.waitForIdle();
+
+		// The stated reset moment (parsed as Beijing time) + 3s grace
+		// (RESET_AT_BUFFER_MS) — not the credential store's default 60s
+		// usage-limit block (AuthStorage.#defaultBackoffMs), and not a
+		// fail-fast terminal.
+		const delayMs = retryStartEvents[0].delayMs;
+		const expectedDelta = RESET_AT_MS - Date.now() + QUOTA_RESET_RETRY_BUFFER_MS;
+		// ±5s tolerance for when the turn ran relative to these assertions.
+		expect(Math.abs(delayMs - expectedDelta)).toBeLessThan(5_000);
+		expect(waitSpy.mock.calls.some(call => Math.abs((call[0] as number) - delayMs) < 5_000)).toBe(true);
+		expect(retryEndEvents).toHaveLength(1);
+		expect(retryEndEvents[0]).toMatchObject({ success: true, attempt: 1 });
+		expect(lastAssistant(session).content).toContainEqual({
+			type: "text",
+			text: "resumed after quota reset",
+		});
+		expect(session.isRetrying).toBe(false);
+	});
+
+	it("still fail-fasts on the same body when retry.maxDelayMs is tight", async () => {
+		const model = getBundledModel("zhipu-coding-plan", "glm-4.7");
+		if (!model) {
+			throw new Error("Expected bundled zhipu-coding-plan test model to exist");
+		}
+
+		const mock = createMockModel({ provider: model.provider, handler: () => ({ throw: ZHIPU_1308_ERROR }) });
+		const agent = new Agent({
+			getApiKey: requestedModel => `${requestedModel.provider}-test-key`,
+			initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] },
+			streamFn: (requestedModel, context, options) => mock.stream(requestedModel, context, options),
+		});
+
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"retry.baseDelayMs": 5,
+			"retry.maxDelayMs": 60_000,
+			"retry.maxRetries": 3,
+			"retry.modelFallback": false,
+		});
+		settings.setModelRole("default", `${model.provider}/${model.id}`);
+
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+		});
+
+		const waitSpy = vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+		const retryStartEvents: AutoRetryStartEvent[] = [];
+		const retryEndEvents: AutoRetryEndEvent[] = [];
+		session.subscribe(event => {
+			if (event.type === "auto_retry_start") retryStartEvents.push(event);
+			if (event.type === "auto_retry_end") retryEndEvents.push(event);
+		});
+
+		await session.prompt("Trigger quota reset error under a tight retry cap");
+		await session.waitForIdle();
+
+		expect(retryStartEvents).toHaveLength(0);
+		expect(retryEndEvents).toHaveLength(1);
+		expect(retryEndEvents[0].finalError).toContain("exceeds retry.maxDelayMs");
+		for (const call of waitSpy.mock.calls) {
+			expect(call[0]).toBeLessThanOrEqual(60_000);
+		}
+		expect(session.isRetrying).toBe(false);
+	});
+});

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Parsed absolute quota-reset moments named in GLM Coding Plan 429 error bodies (`您的限额将在 2026-08-17 11:17:40 重置`, codes 1308–1321; international Z.AI `Your limit will reset at 2026-02-06 05:34:34`) so `extractRetryHint` returns the real remaining wait (+3s grace), including monthly windows, instead of falling through to a generic hint.
+
 ## [18.0.5] - 2026-08-25
 
 ### Added

--- a/packages/utils/src/fetch-retry.ts
+++ b/packages/utils/src/fetch-retry.ts
@@ -12,6 +12,69 @@ const RETRY_DELAY_FIELD_PATTERN = /"retryDelay":\s*"([0-9.]+)(ms|s)"/i;
 const TRY_AGAIN_PATTERN = /try again in\s+~?\s*([0-9.]+)\s*(ms|sec|s|minutes?|mins?|m|hours?|hrs?|h)\b/i;
 // "Your limit will reset in 13 minutes" / "reset in 13 minutes" / "will reset in 2h"
 const WILL_RESET_IN_PATTERN = /(?:will\s+)?reset in\s+~?\s*([0-9.]+)\s*(ms|sec|s|minutes?|mins?|m|hours?|hrs?|h)\b/i;
+// Zhipu GLM Coding Plan 429s (docs.bigmodel.cn/cn/api/api-code,
+// docs.z.ai/api-reference/api-code, codes 1308–1321) state the reset as an
+// absolute wall-clock stamp, not a duration.
+const ZHIPU_RESET_AT_DATETIME = String.raw`\d{4}-\d{1,2}-\d{1,2} \d{1,2}:\d{2}(?::\d{2})?`;
+// Unattested in any body so far; honored if Zhipu starts stamping one.
+const ZHIPU_RESET_AT_ZONE = String.raw`(?:\s*(?:Z|UTC|GMT|[+-]\d{2}(?::?\d{2})?))?`;
+const ZHIPU_CN_RESET_AT_PATTERN = new RegExp(
+	String.raw`您的限额将在[^\S\n]*(${ZHIPU_RESET_AT_DATETIME}${ZHIPU_RESET_AT_ZONE})[^\S\n]*重置`,
+	"i",
+);
+// Only a body pairing a Zhipu code with its own documented message (regexes
+// below) earns the UTC+8 read.
+const ZHIPU_JSON_ERROR_ENVELOPE =
+	/\{\s*(?:"error"\s*:\s*\{\s*)?"code"\s*:\s*"(?<code>1308|1310|131[6-9]|132[01])"\s*,\s*"message"\s*:\s*"(?<message>[^"]*)"/;
+const ZHIPU_TYPE_CODE_PATTERN = /\btype=(?<code>1308|1310|131[6-9]|132[01])\b/;
+const ZHIPU_CODE_MESSAGES: Readonly<Record<string, RegExp>> = {
+	"1308": /已达到[^。]{0,16}的使用上限|usage limit reached for (?!the past)/i,
+	"1310": /每周\/每月使用上限|weekly\/monthly limit exhausted/i,
+	"1316":
+		/已达到\s*5\s*小时使用上限[，。][^。]{0,40}主账号余额不足|usage limit reached for the past 5 hours\.[^"]{0,80}insufficient balance/i,
+	"1317":
+		/已达到\s*7\s*天使用上限[，。][^。]{0,40}主账号余额不足|usage limit reached for the past 7 days\.[^"]{0,80}insufficient balance/i,
+	"1318":
+		/已达到\s*5\s*小时使用上限，且已达子账号月消费上限|usage limit reached for the past 5 hours\.[^"]{0,80}monthly spend limit/i,
+	"1319":
+		/已达到\s*7\s*天使用上限，且已达子账号月消费上限|usage limit reached for the past 7 days\.[^"]{0,80}monthly spend limit/i,
+	"1320":
+		/已达到\s*5\s*小时使用上限，且已达企业级月消费上限|usage limit reached for the past 5 hours\.[^"]{0,80}monthly spend limit/i,
+	"1321":
+		/已达到\s*7\s*天使用上限，且已达企业级月消费上限|usage limit reached for the past 7 days\.[^"]{0,80}monthly spend limit/i,
+};
+const ZHIPU_EN_RESET_AT_PATTERN = new RegExp(
+	String.raw`\b(?:will\s+reset|resets)\s+at\s+(${ZHIPU_RESET_AT_DATETIME}${ZHIPU_RESET_AT_ZONE})`,
+	"i",
+);
+const ZHIPU_RESET_AT_TOKEN =
+	/^(?<year>\d{4})-(?<month>\d{1,2})-(?<day>\d{1,2}) (?<hour>\d{1,2}):(?<minute>\d{2})(?::(?<second>\d{2}))?(?<zone>\s*(?:Z|UTC|GMT|[+-]\d{2}(?::?\d{2})?))?$/i;
+// Bare stamps are server wall clock; both platforms anchor UTC+8 (Beijing/Singapore).
+const ZHIPU_RESET_AT_ASSUMED_ZONE = "+08:00";
+const ZHIPU_RESET_AT_ZONE_SHIFT_MS = 8 * 3_600_000;
+// Grace past the stated boundary: reset jobs land seconds late and clocks skew ~1s;
+// waking early just buys another 429, and account windows run minutes+ — 3s is free.
+const RESET_AT_BUFFER_MS = 3_000;
+// Plausibility window for a past stamp in a fresh body: real staleness is
+// seconds, and 1min also absorbs client skew. A bare stamp staler than that
+// can't be a live UTC+8 boundary — the server likely stamped UTC (reread below).
+const ZHIPU_RESET_AT_STALE_MS = 60_000;
+// Horizon per code = its documented window; a stated reset further out is
+// garbage, not a wait target. 1308's `${number} ${unit}` interpolates any
+// unit → the widest window the docs name, the month (≤31d, shared with
+// 1310's weekly/monthly). Also bounds the implied sleep.
+const ZHIPU_RESET_AT_MAX_DELTA_MS: Readonly<Record<string, number>> = {
+	"1308": 31 * 24 * 60 * 60 * 1000,
+	"1310": 31 * 24 * 60 * 60 * 1000,
+	"1316": 5 * 60 * 60 * 1000,
+	"1317": 7 * 24 * 60 * 60 * 1000,
+	"1318": 5 * 60 * 60 * 1000,
+	"1319": 7 * 24 * 60 * 60 * 1000,
+	"1320": 5 * 60 * 60 * 1000,
+	"1321": 7 * 24 * 60 * 60 * 1000,
+};
+// Fallback for a code not yet mapped above; widest, since the horizon only rejects garbage.
+const ZHIPU_RESET_AT_MAX_DELTA_MS_DEFAULT = 31 * 24 * 60 * 60 * 1000;
 
 /**
  * Server-suggested retry delay extraction. Merges the patterns historically used
@@ -25,6 +88,9 @@ const WILL_RESET_IN_PATTERN = /(?:will\s+)?reset in\s+~?\s*([0-9.]+)\s*(ms|sec|s
  *  - `x-ratelimit-reset-after` (seconds)
  *
  * Body patterns:
+ *  - `您的限额将在 2026-08-17 11:17:40 重置` / `Your limit will reset at …`
+ *    (GLM Coding Plan 429, codes 1308–1321) — absolute reset moments; bare
+ *    stamps are server UTC+8, explicit zone markers honored, +3s grace
  *  - `Your quota will reset after 18h31m10s` / `10m15s` / `39s`
  *  - `Please retry in 250ms` / `Please retry in 12s`
  *  - `"retryDelay": "34.074824224s"` (JSON error detail field)
@@ -74,6 +140,10 @@ export function extractRetryHint(source: Response | Headers | null | undefined, 
 	}
 
 	if (!body) return undefined;
+	// Absolute reset moments are account windows → they outrank every relative
+	// hint below. Only the Zhipu family is registered today.
+	const zhipuResetWaitMs = extractZhipuResetWaitMs(body);
+	if (zhipuResetWaitMs !== undefined) return zhipuResetWaitMs;
 
 	const quotaMatch = QUOTA_RESET_PATTERN.exec(body);
 	if (quotaMatch) {
@@ -124,6 +194,61 @@ function unitToMs(unit: string): number | undefined {
 		default:
 			return undefined;
 	}
+}
+
+/**
+ * Zhipu stamp family: the wait implied by an absolute reset moment in the
+ * body. The reset-wording bracket keeps unrelated embedded dates out.
+ */
+
+function extractZhipuResetWaitMs(body: string): number | undefined {
+	const stamp = parseZhipuResetStamp(body);
+	if (!stamp) return undefined;
+	const maxDeltaMs = ZHIPU_RESET_AT_MAX_DELTA_MS[stamp.code] ?? ZHIPU_RESET_AT_MAX_DELTA_MS_DEFAULT;
+	const deltaMs = stamp.resetAtMs - Date.now();
+	// Future within the code's horizon → the wait.
+	if (deltaMs > 0 && deltaMs <= maxDeltaMs) return deltaMs + RESET_AT_BUFFER_MS;
+	// Bare + stale past the window → the UTC+8 assumption is likely wrong for
+	// this server; reread the same wall clock as UTC — Zhipu support's
+	// fallback advice. Zoned stamps have nothing to correct.
+	if (!stamp.explicitZone && deltaMs <= -ZHIPU_RESET_AT_STALE_MS) {
+		const utcDeltaMs = deltaMs + ZHIPU_RESET_AT_ZONE_SHIFT_MS;
+		if (utcDeltaMs > 0 && utcDeltaMs <= maxDeltaMs) return utcDeltaMs + RESET_AT_BUFFER_MS;
+	}
+	return undefined;
+}
+function parseZhipuResetStamp(body: string): { resetAtMs: number; code: string; explicitZone: boolean } | undefined {
+	// Code, wording, and stamp must come from one message — a code elsewhere
+	// in the body must not vouch for them.
+	const envelope = ZHIPU_JSON_ERROR_ENVELOPE.exec(body);
+	const code = envelope?.groups?.code ?? ZHIPU_TYPE_CODE_PATTERN.exec(body)?.groups?.code;
+	if (code === undefined) return undefined;
+	const text = envelope?.groups?.message ?? body;
+	if (!ZHIPU_CODE_MESSAGES[code]?.test(text)) return undefined;
+	for (const pattern of [ZHIPU_CN_RESET_AT_PATTERN, ZHIPU_EN_RESET_AT_PATTERN]) {
+		const token = ZHIPU_RESET_AT_TOKEN.exec(pattern.exec(text)?.[1] ?? "")?.groups;
+		if (!token) continue;
+		// Date.parse rolls an impossible day ("2026-02-30" → Mar 2); a server
+		// never states a rolled date → mismatch discards the stamp.
+		const day = Number(token.day);
+		if (new Date(Date.UTC(Number(token.year), Number(token.month) - 1, day)).getUTCDate() !== day) continue;
+		const pad2 = (value: string) => value.padStart(2, "0");
+		const iso =
+			`${token.year}-${pad2(token.month!)}-${pad2(token.day!)}` +
+			`T${token.hour!.padStart(2, "0")}:${token.minute}:${token.second ?? "00"}` +
+			zoneMarkerToIsoSuffix(token.zone);
+		const resetAtMs = Date.parse(iso);
+		if (!Number.isNaN(resetAtMs)) return { resetAtMs, code, explicitZone: token.zone !== undefined };
+	}
+	return undefined;
+}
+
+function zoneMarkerToIsoSuffix(zone: string | undefined): string {
+	if (zone === undefined) return ZHIPU_RESET_AT_ASSUMED_ZONE;
+	const marker = zone.trim().toUpperCase();
+	if (marker === "Z" || marker === "UTC" || marker === "GMT") return "Z";
+	const digits = marker.slice(1).replace(":", "");
+	return `${marker[0]!}${digits.slice(0, 2)}:${digits.slice(2) || "00"}`;
 }
 
 export interface FetchWithRetryOptions extends RequestInit {

--- a/packages/utils/test/fetch-retry.test.ts
+++ b/packages/utils/test/fetch-retry.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it, vi } from "bun:test";
 import { extractRetryHint, fetchWithRetry } from "@oh-my-pi/pi-utils/fetch-retry";
 
 describe("fetchWithRetry", () => {
@@ -133,5 +133,160 @@ describe("extractRetryHint", () => {
 	// blocked for the full stated window instead of the short generic retry.
 	it("prefers the account reset window over a shorter retry hint", () => {
 		expect(extractRetryHint(undefined, "Please retry in 5s. Your limit will reset in 13 minutes")).toBe(13 * 60_000);
+	});
+});
+
+describe("extractRetryHint — absolute reset timestamps", () => {
+	// Zhipu Coding Plan 429 type=1308; the bare stamp is server UTC+8 wall clock.
+	const ZHIPU_1308 = "429 已达到 5 小时的使用上限。您的限额将在 2026-08-17 11:17:40 重置。 (type=1308)";
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("converts the Zhipu 1308 reset stamp into a delta plus grace", () => {
+		vi.spyOn(Date, "now").mockReturnValue(Date.parse("2026-08-17T03:00:00Z")); // 08:00 Beijing
+		// 11:17:40 Beijing = 03:17:40Z → 17m40s + 3s grace.
+		expect(extractRetryHint(undefined, ZHIPU_1308)).toBe(17 * 60_000 + 40_000 + 3_000);
+	});
+
+	// International Z.AI 1308 JSON; the unmarked stamp is Singapore wall clock (UTC+8).
+	it("reads the unmarked Z.AI 1308 English stamp as UTC+8", () => {
+		vi.spyOn(Date, "now").mockReturnValue(Date.parse("2026-08-17T03:00:00Z"));
+		expect(
+			extractRetryHint(
+				undefined,
+				'{"code":"1308","message":"Usage limit reached for 5 hour. Your limit will reset at 2026-08-17 11:17:40"}',
+			),
+		).toBe(17 * 60_000 + 40_000 + 3_000);
+	});
+
+	it('reads the documented {"error":{code,message}} envelope as UTC+8', () => {
+		vi.spyOn(Date, "now").mockReturnValue(Date.parse("2026-08-17T03:00:00Z"));
+		expect(
+			extractRetryHint(
+				undefined,
+				'{"error":{"code":"1308","message":"Usage limit reached for 5 hour. Your limit will reset at 2026-08-17 11:17:40"}}',
+			),
+		).toBe(17 * 60_000 + 40_000 + 3_000);
+	});
+
+	it("keeps a quoted code that is not paired with its message key off the absolute path", () => {
+		vi.spyOn(Date, "now").mockReturnValue(Date.parse("2026-08-17T03:00:00Z"));
+		expect(
+			extractRetryHint(undefined, '{"code":"1308","detail":"Your limit will reset at 2026-08-17 11:17:40"}'),
+		).toBeUndefined();
+		expect(
+			extractRetryHint(undefined, '{"code":1308,"message":"Your limit will reset at 2026-08-17 11:17:40"}'),
+		).toBeUndefined();
+	});
+
+	it("rejects a code riding another code's documented message", () => {
+		vi.spyOn(Date, "now").mockReturnValue(Date.parse("2026-08-17T03:00:00Z"));
+		expect(
+			extractRetryHint(
+				undefined,
+				'{"code":"1308","message":"Usage limit reached for the past 5 hours. Insufficient balance for extra usage. Resets at 2026-08-17 11:17:40"}',
+			),
+		).toBeUndefined();
+		expect(
+			extractRetryHint(undefined, "已达到 5 小时的使用上限。您的限额将在 2026-08-17 11:17:40 重置。 (type=1310)"),
+		).toBeUndefined();
+	});
+
+	it("honors the documented 1316 and 1318 messages", () => {
+		vi.spyOn(Date, "now").mockReturnValue(Date.parse("2026-08-17T03:00:00Z"));
+		expect(
+			extractRetryHint(
+				undefined,
+				'{"code":"1316","message":"Usage limit reached for the past 5 hours. Insufficient balance for extra usage. Resets at 2026-08-17 11:17:40."}',
+			),
+		).toBe(17 * 60_000 + 40_000 + 3_000);
+		expect(
+			extractRetryHint(
+				undefined,
+				'{"code":"1318","message":"已达到 5 小时使用上限，且已达子账号月消费上限，无法使用超额按量付费。您的限额将在 2026-08-17 11:17:40 重置。"}',
+			),
+		).toBe(17 * 60_000 + 40_000 + 3_000);
+	});
+
+	it("keeps an ungated English stamp off the absolute path so relative hints apply", () => {
+		vi.spyOn(Date, "now").mockReturnValue(Date.parse("2026-08-17T03:00:00Z"));
+		expect(extractRetryHint(undefined, "Your limit will reset at 2026-08-17 11:17:40. Please retry in 5s")).toBe(
+			5_000,
+		);
+	});
+
+	// 1310 is weekly/monthly: a monthly reset can sit weeks past a single-week horizon.
+	it("honors a monthly reset stamp weeks out (code 1310)", () => {
+		vi.spyOn(Date, "now").mockReturnValue(Date.parse("2026-08-17T03:00:00Z"));
+		expect(
+			extractRetryHint(undefined, "您已达到每周/每月使用上限，您的限额将在 2026-09-06 11:00:00 重置 (type=1310)"),
+		).toBe(20 * 24 * 3_600_000 + 3_000);
+	});
+
+	// Past in both reads (~8h43m as UTC+8, ~42m reread as UTC) → garbage either way.
+	it("ignores a past stamp instead of inventing a wait", () => {
+		vi.spyOn(Date, "now").mockReturnValue(Date.parse("2026-08-17T12:00:00Z"));
+		expect(extractRetryHint(undefined, ZHIPU_1308)).toBeUndefined();
+	});
+
+	it("rereads a long-stale bare stamp as UTC", () => {
+		vi.spyOn(Date, "now").mockReturnValue(Date.parse("2026-08-17T06:30:00Z"));
+		// 11:17:40Z is 4h47m40s out; +3s grace.
+		expect(extractRetryHint(undefined, ZHIPU_1308)).toBe(4 * 3_600_000 + 47 * 60_000 + 40_000 + 3_000);
+	});
+
+	it("does not reread a stamp past the code's horizon as UTC", () => {
+		vi.spyOn(Date, "now").mockReturnValue(Date.parse("2026-10-01T00:00:00Z"));
+		expect(
+			extractRetryHint(undefined, "您已达到每周/每月使用上限，您的限额将在 2026-08-17 11:17:40 重置 (type=1310)"),
+		).toBeUndefined();
+	});
+
+	it("never rereads a zoned stamp", () => {
+		vi.spyOn(Date, "now").mockReturnValue(Date.parse("2026-08-17T12:00:00Z"));
+		expect(
+			extractRetryHint(undefined, "已达到 5 小时的使用上限。您的限额将在 2026-08-17 03:17:40Z 重置。 (type=1308)"),
+		).toBeUndefined();
+	});
+
+	it("ignores a reset stated beyond the 31-day horizon", () => {
+		vi.spyOn(Date, "now").mockReturnValue(Date.parse("2026-08-17T03:00:00Z"));
+		expect(
+			extractRetryHint(undefined, "您已达到每周/每月使用上限，您的限额将在 2026-12-31 11:17:40 重置 (type=1310)"),
+		).toBeUndefined();
+	});
+
+	it("honors an explicit zone marker over the assumed UTC+8", () => {
+		vi.spyOn(Date, "now").mockReturnValue(Date.parse("2026-08-17T03:00:00Z"));
+		expect(
+			extractRetryHint(
+				undefined,
+				"已达到 5 小时的使用上限。您的限额将在 2026-08-17 03:17:40+00:00 重置。 (type=1308)",
+			),
+		).toBe(17 * 60_000 + 40_000 + 3_000);
+		// Lowercase marker on a 1317 body so the wait sits inside its 7-day window.
+		expect(
+			extractRetryHint(
+				undefined,
+				'{"code":"1317","message":"Usage limit reached for the past 7 days. Insufficient balance for extra usage. Resets at 2026-08-17 11:17:40 z"}',
+			),
+		).toBe(8 * 3_600_000 + 17 * 60_000 + 40_000 + 3_000);
+	});
+
+	it("ignores an impossible day instead of letting it roll into the next month", () => {
+		expect(
+			extractRetryHint(undefined, "已达到 5 小时的使用上限。您的限额将在 2026-02-30 11:17:40 重置。 (type=1308)"),
+		).toBeUndefined();
+	});
+
+	it("ignores a datetime not bracketed by reset wording", () => {
+		expect(extractRetryHint(undefined, "订阅有效期至 2026-08-17 11:17:40")).toBeUndefined();
+	});
+
+	it("falls back to relative hints when the stamp yields no wait target", () => {
+		vi.spyOn(Date, "now").mockReturnValue(Date.parse("2026-08-17T12:00:00Z"));
+		expect(extractRetryHint(undefined, `${ZHIPU_1308} Please retry in 5s`)).toBe(5_000);
 	});
 });


### PR DESCRIPTION
Rework of #9633 (see the closing comment there): same goal, tightened recognition.

`extractRetryHint` now parses absolute reset stamps in GLM Coding Plan 429 bodies, so the session can sleep to the stated moment instead of retrying blind.

## What

- Parses `您的限额将在 2026-08-17 11:17:40 重置` (CN) and `Your limit will reset at …` / `Resets at …` (international Z.AI) into the remaining wait plus a small grace. Isolated under `extractZhipuResetWaitMs` / `ZHIPU_*` constants — wordings and policy are Zhipu-attested against the error-code references (docs.bigmodel.cn/cn/api/api-code, docs.z.ai/api-reference/api-code, codes 1308/1310/1316–1321); `extractRetryHint` keeps only the generic rule that an absolute reset moment outranks generic "retry in" hints.
- Strict code-message correspondence: a stamp joins the family only in a documented framing — the CN platform's `(type=1308)` suffix, or the JSON envelope with the code string paired to its message key (`{"error":{"code":…,"message":…}}` nested per the docs, flat as Z.AI emits) — carrying that code's own documented message, transcribed per code from both docs. This pins the family to Zhipu's exact API responses, so a foreign provider's lookalike body keeps its own hints (and therefore never receives the UTC+8 read).
- Zone fallback: an explicit zone marker is honored as-is → bare stamps read as UTC+8 (both platforms anchor there: Beijing / Singapore — same offset) → a bare stamp landing implausibly far in the past is reread as UTC (support's advice for that case). Out-of-calendar stamps (`2026-02-30`) are rejected instead of rolled over by `Date.parse`.
- Per-code horizon = the code's documented window: 1308's `${number} ${unit}` interpolation takes the widest documented window (the month, 31d, shared with 1310 weekly/monthly); the fixed 1316/1318/1320 are 5h and 1317/1319/1321 are 7d. Over-horizon stamps are garbage, not wait targets.
- Session-level test asserting the retry is scheduled at the stated moment; changelog entry under `[Unreleased]`.

## Why

My GLM Coding Plan 429 states the exact reset time in the body, but omp ignored it and kept retrying into the wall every ~1 minute until the retry budget ran out.

## Testing

- `bun test packages/utils/test/fetch-retry.test.ts` — 27 pass (CN/EN stamps per code, nested/flat envelopes, code-message cross-mismatch rejection, zone-marker override, stale→UTC reread, per-code horizons, unbracketed/impossible dates).
- `bun test packages/coding-agent/test/agent-session-quota-reset.test.ts` — 2 pass; fails before the fix (retry scheduled at the default 60s block).
- Verified end-to-end against a real 1308 wall: the session resumed at the stated reset moment. `bun check` passes.
