### PR TITLE
fix(acp): group model select options by provider

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the ACP model picker (Zed) showing every configured provider's models as one flat, unlabeled list — models are now grouped under provider headers when the client supports it, so same-named models from different providers (e.g. multiple "free" tiers) are distinguishable.
+
 ## [18.0.6] - 2026-08-26
 
 ### Added

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -33,6 +33,8 @@ import {
 	type ResumeSessionRequest,
 	type ResumeSessionResponse,
 	type SessionConfigOption,
+	type SessionConfigSelectGroup,
+	type SessionConfigSelectOption,
 	type SessionInfo,
 	type SessionModeState,
 	type SessionNotification,
@@ -1747,11 +1749,7 @@ export class AcpAgent implements Agent {
 				category: "model",
 				type: "select",
 				currentValue: currentModel ? this.#toModelId(currentModel) : this.#toModelId(models[0]),
-				options: models.map(model => ({
-					value: this.#toModelId(model),
-					name: model.name,
-					description: `${model.provider}/${model.id}`,
-				})),
+				options: this.#buildModelSelectOptions(models),
 			});
 		}
 
@@ -1768,6 +1766,32 @@ export class AcpAgent implements Agent {
 		return configOptions;
 	}
 
+	#buildModelSelectOptions(models: Model[]): SessionConfigSelectOption[] | SessionConfigSelectGroup[] {
+		const providers: string[] = [];
+		const byProvider = new Map<string, Model[]>();
+		for (const model of models) {
+			let group = byProvider.get(model.provider);
+			if (!group) {
+				group = [];
+				byProvider.set(model.provider, group);
+				providers.push(model.provider);
+			}
+			group.push(model);
+		}
+		const toOption = (model: Model): SessionConfigSelectOption => ({
+			value: this.#toModelId(model),
+			name: model.name,
+			description: `${model.provider}/${model.id}`,
+		});
+		if (providers.length <= 1) {
+			return models.map(toOption);
+		}
+		return providers.map(provider => ({
+			group: provider,
+			name: provider,
+			options: (byProvider.get(provider) ?? []).map(toOption),
+		}));
+	}
 	#buildThinkingOptions(session: AgentSession): Array<{ value: string; name: string; description?: string }> {
 		return [
 			{ value: THINKING_OFF, name: "Off" },

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -18,6 +18,7 @@ import {
 	type ElicitationPropertySchema,
 	type ForkSessionRequest,
 	type ForkSessionResponse,
+	type Implementation,
 	type InitializeRequest,
 	type InitializeResponse,
 	type ListSessionsRequest,
@@ -616,6 +617,7 @@ export class AcpAgent implements Agent {
 	#disposePromise: Promise<void> | undefined;
 	#cleanupRegistered = false;
 	#clientCapabilities: ClientCapabilities | undefined;
+	#clientInfo: Implementation | undefined | null;
 	#cancelCleanupTimeoutMs = ACP_CANCEL_CLEANUP_TIMEOUT_MS;
 	#blobs = new BlobStore(getBlobsDir());
 
@@ -632,6 +634,7 @@ export class AcpAgent implements Agent {
 	async initialize(params: InitializeRequest): Promise<InitializeResponse> {
 		this.#registerConnectionCleanup();
 		this.#clientCapabilities = params.clientCapabilities;
+		this.#clientInfo = params.clientInfo;
 		const authMethods: AuthMethod[] = [
 			{
 				id: "agent",
@@ -1766,7 +1769,25 @@ export class AcpAgent implements Agent {
 		return configOptions;
 	}
 
+	/**
+	 * Clients that only understand the flat `SessionConfigSelectOption[]` shape would see
+	 * `options[].value === undefined` for a `Grouped` group header and either drop the model
+	 * list or fail to render it. ACP has no negotiated capability flag for this (it's a
+	 * hand-maintained protocol superset here), so only opt in known-compatible clients.
+	 */
+	#clientSupportsGroupedSelectOptions(): boolean {
+		return this.#clientInfo?.name === "zed";
+	}
+
 	#buildModelSelectOptions(models: Model[]): SessionConfigSelectOption[] | SessionConfigSelectGroup[] {
+		const toOption = (model: Model): SessionConfigSelectOption => ({
+			value: this.#toModelId(model),
+			name: model.name,
+			description: `${model.provider}/${model.id}`,
+		});
+		if (!this.#clientSupportsGroupedSelectOptions()) {
+			return models.map(toOption);
+		}
 		const providers: string[] = [];
 		const byProvider = new Map<string, Model[]>();
 		for (const model of models) {
@@ -1778,11 +1799,6 @@ export class AcpAgent implements Agent {
 			}
 			group.push(model);
 		}
-		const toOption = (model: Model): SessionConfigSelectOption => ({
-			value: this.#toModelId(model),
-			name: model.name,
-			description: `${model.provider}/${model.id}`,
-		});
 		if (providers.length <= 1) {
 			return models.map(toOption);
 		}

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added a `SessionConfigSelectGroup` type and widened `SessionConfigOption`'s select variant to accept grouped options, matching the ACP schema's `Grouped` select shape.
+
 ## [18.0.6] - 2026-08-26
 
 ### Added

--- a/packages/utils/src/acp/protocol.ts
+++ b/packages/utils/src/acp/protocol.ts
@@ -225,9 +225,15 @@ export interface SessionConfigSelectOption extends Meta {
 	name: string;
 	description?: string | null;
 }
+/** A group of options under a header, for grouped select configuration values. */
+export interface SessionConfigSelectGroup extends Meta {
+	group: string;
+	name: string;
+	options: SessionConfigSelectOption[];
+}
 /** Session configuration option. */
 export type SessionConfigOption = (
-	| { type: "select"; currentValue: string; options: SessionConfigSelectOption[] }
+	| { type: "select"; currentValue: string; options: SessionConfigSelectOption[] | SessionConfigSelectGroup[] }
 	| { type: "boolean"; currentValue: boolean }
 ) & { id: string; name: string; description?: string | null; category?: string | null } & Meta;
 /** Shared fields for creating or restoring a session. */


### PR DESCRIPTION
## Why I'm submitting this

I added multiple providers in Zed and got stuck immediately because I couldn't tell which provider I was actually using. Coming from opencode it was so intuitive, but not in omp — even the omp TUI feels clunky, which is why I moved to using omp through Zed in the first place, and Zed shows different integrations for opencode, Zed, Vercel AI Gateway, etc. without that grouping this didn't carry over. I felt this was a small yet critical fix, since picking the wrong model means burning tokens against the wrong provider/profile without realizing it.

## Summary
- `AcpAgent#buildConfigOptions` always sent the `model` session config option as a flat, ungrouped list, even though `SessionConfigSelectOptions` (per the ACP schema) supports a `Grouped` variant with `group`/`name`/`options` headers, and Zed already renders those headers in its model picker.
- With multiple providers configured (e.g. `anthropic`, `openrouter`, `opencode-zen`), same-named "free" models across providers were indistinguishable in Zed's picker — no way to tell which provider a given entry came from.
- Added `#buildModelSelectOptions`, which groups `getAvailableModels()` by `model.provider` and emits the `Grouped` shape (`{ group, name, options }` per provider) whenever more than one provider is present; falls back to the existing flat list when there's only one, so single-provider setups are unaffected.
- Extended the local `SessionConfigOption`/`SessionConfigSelectGroup` types in `packages/utils/src/acp/protocol.ts` to allow the union, matching the field name (`group`, not `groupId`) used by the schema version (v1.5.0 of `agent-client-protocol-schema`) that Zed currently vendors.

## Test plan
- [x] Ran the patched build directly via `bun run src/cli.ts acp`, sent raw `initialize` + `session/new` JSON-RPC over stdio, and confirmed the `model` config option's `options` field now returns 3 provider groups (`anthropic`, `openrouter`, `opencode-zen`) instead of one flat list of ~548 models.
- [x] Verified against Zed (custom ACP agent pointed at this build): the model picker now shows provider headers (e.g. "openrouter", "opencode-zen") above each group's models, and picking/cycling models still works.
- [x] `biome check` on both changed files passes with no issues.
