### PR TITLE
fix(tui): surface skills for leading bare-name slash prefixes

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed leading bare-name skill prefixes such as `/batch` returning no autocomplete suggestions.
+
 ## [18.0.6] - 2026-08-26
 
 ### Added

--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -393,21 +393,26 @@ export const SKILL_NAMESPACE = "skill:";
 
 /**
  * Collapse `skill:*` commands into a single `/skill:` namespace row while the
- * typed prefix has not committed to the namespace. Until the prefix starts
- * with `skill:`, individual skills never list — a lone group entry (shown only
- * while the prefix is still a prefix of `skill:`) keeps the `/` popup
- * readable. Accepting the group inserts `/skill:` without a trailing space so
- * the reopened popup expands to the individual skills.
+ * typed prefix is empty or still approaches the namespace. Bare skill-name
+ * prefixes retain matching skills (`/hum` → `skill:humanizer`), while the
+ * group entry keeps the `/` popup readable. Accepting the group inserts
+ * `/skill:` without a trailing space so the reopened popup expands to the
+ * individual skills.
  */
 function collapseSkillNamespace(commands: CommandEntry[], lowerPrefix: string): CommandEntry[] {
 	if (lowerPrefix.startsWith(SKILL_NAMESPACE)) return commands;
 	let skillCount = 0;
 	let skillIcon: string | undefined;
 	const rest = commands.filter(cmd => {
-		if (!getCommandName(cmd)?.startsWith(SKILL_NAMESPACE)) return true;
+		const name = getCommandName(cmd);
+		if (!name?.startsWith(SKILL_NAMESPACE)) return true;
 		skillCount += 1;
 		skillIcon ??= cmd.icon;
-		return false;
+		return (
+			lowerPrefix.length > 0 &&
+			!SKILL_NAMESPACE.startsWith(lowerPrefix) &&
+			name.slice(SKILL_NAMESPACE.length).toLowerCase().startsWith(lowerPrefix)
+		);
 	});
 	if (skillCount === 0) return commands;
 	if (!SKILL_NAMESPACE.startsWith(lowerPrefix)) return rest;

--- a/packages/tui/test/autocomplete.test.ts
+++ b/packages/tui/test/autocomplete.test.ts
@@ -178,17 +178,19 @@ describe("CombinedAutocompleteProvider", () => {
 			expect(result?.items.map(item => item.value)).toEqual(["skill:"]);
 		});
 
-		it("does not surface skills for a leading prefix unrelated to the namespace", async () => {
+		it("surfaces skills for a leading bare-name prefix", async () => {
 			const provider = new CombinedAutocompleteProvider(
-				[{ name: "skill:humanizer", description: "Remove signs of AI writing" }],
+				[
+					{ name: "skill:batch", description: "Run batch workflows" },
+					{ name: "skill:reviewer", description: "Code review" },
+				],
 				"/tmp",
 			);
 
-			// Bare-name and description fuzzy matches are reserved for the
-			// mid-prompt skill popup; at prompt start only `/skill:…` lists skills.
-			const result = await provider.getSuggestions(["/hum"], 0, "/hum".length);
+			const result = await provider.getSuggestions(["/batch"], 0, "/batch".length);
 
-			expect(result).toBeNull();
+			expect(result?.prefix).toBe("/batch");
+			expect(result?.items.map(item => item.value)).toEqual(["skill:batch"]);
 		});
 
 		it("expands individual skills once the leading prefix enters the namespace", async () => {


### PR DESCRIPTION
## Repro
Type `/batch` at the start of the prompt. The popup lists only fuzzy-matched builtin commands such as `autoresearch` and `loop`; the `skill:batch-pr-review` and `skill:batch` skills are missing. Typing `/skill:batch` shows them, so the skills are loaded; only the leading bare-name prefix path hides them. The same holds for any skill by its bare name (`/hum` → `skill:humanizer` at prompt start).

## Was the hiding intentional?
The evidence cuts both ways.

- `2794f85b` (feat(tui): added collapsed skill namespace to autocomplete) introduced the collapse, and its doc comment does say "Until the prefix starts with `skill:`, individual skills never list", so the state was written down.
- The same commit also regressed prior behavior without mention: before it, `buildSlashCommandCompletions` fuzzy-scored skill commands by name for non-empty prefixes, so `/hum` matched `skill:humanizer` at prompt start. The commit message bullets (grouping, bare-`/skill:` submit prevention, chaining) and the 18.0.1 changelog entries never mention hiding bare-name matches.
- Mid-prompt bare-name matching (`polish this /hum` → `skill:humanizer`) is deliberately supported, documented on `matchesSkillToken`, and tested (`1eab12e2`). The leading-position exclusion had no tests and no stated rationale, so it reads as an over-broad simplification rather than a design goal.

If maintainers do want "namespace or nothing" at prompt start, a recorded decision, a test, and a changelog line would codify that; this PR takes the other reading.

## Cause
`collapseSkillNamespace()` (`packages/tui/src/autocomplete.ts`) folds every `skill:*` command into the single `/skill:` namespace row whenever the prefix doesn't start with `skill:`. But the group row is only inserted while the prefix is still a prefix of `skill:` (`/`, `/s`, `/sk`). For any other prefix the skills are filtered out and nothing replaces them, so the popup dead-ends. Mid-prompt tokens already had bare-name matching via `matchesSkillToken()`; the leading-position path lost it in `2794f85b`.

## Fix
In `collapseSkillNamespace()`, keep a `skill:*` entry in the collapsed list when the prefix is non-empty, is not approaching the namespace, and is a prefix of the skill's bare name (`/batch` → `skill:batch`). The namespace collapse itself is unchanged: bare `/` still shows one `skill:` row, `/sk` still shows only the group entry, and `/skill:` still expands the full list.

## Verification
- `bun test packages/tui/test/autocomplete.test.ts` — 68 pass (regression test strengthened to the exact repro, `/batch` → `["skill:batch"]`; it was red before the fix)
- `bun test packages/coding-agent/test/prompt-action-autocomplete.test.ts` — 10 pass
- `bun --cwd=packages/tui run check` — biome + tsgo clean
- Live TUI: `/bat` and `/batch` list `skill:batch-pr-review` + `skill:batch`; Tab accepts to `/skill:batch-pr-review`
- Full tui suite: 1297 pass; the 3 kitty-keyboard failures also reproduce on pristine `v18.0.4` (environment-only, unrelated)

Changelog entry added under `packages/tui/CHANGELOG.md` `[Unreleased]`.
