### PR TITLE
docs(coding-agent): correct MCP approval key format

### DIFF
--- a/docs/approval-mode.md
+++ b/docs/approval-mode.md
@@ -33,8 +33,12 @@ tools:
   approval:
     bash: prompt
     read: allow
-    mcp__filesystem__delete: deny
+    mcp__filesystem_delete: deny
 ```
+
+For MCP tools, use the exact registered name: `mcp__<sanitized_server>_<sanitized_tool>`. A redundant
+`<server>_` prefix is removed from the tool name, so server `echo` tool `echo_it` is registered as
+`mcp__echo_it`. See [MCP tool naming](./mcp-server-tool-authoring.md#naming-and-collision-domain).
 
 Resolution per tool call:
 

--- a/docs/approval-mode.md
+++ b/docs/approval-mode.md
@@ -36,9 +36,11 @@ tools:
     mcp__filesystem_delete: deny
 ```
 
-For MCP tools, use the exact registered name: `mcp__<sanitized_server>_<sanitized_tool>`. A redundant
-`<server>_` prefix is removed from the tool name, so server `echo` tool `echo_it` is registered as
-`mcp__echo_it`. See [MCP tool naming](./mcp-server-tool-authoring.md#naming-and-collision-domain).
+For MCP tools, key the policy by the exact final registered name. The ordinary form is
+`mcp__<sanitized_server>_<sanitized_tool>`. A redundant `<server>_` prefix is removed from the tool name,
+so server `echo` tool `echo_it` is registered as `mcp__echo_it`. Names longer than 64 characters are
+capped with a deterministic hash suffix; use the final capped name rather than the uncapped pattern. See
+[MCP tool naming](./mcp-server-tool-authoring.md#naming-and-collision-domain).
 
 Resolution per tool call:
 

--- a/docs/mcp-server-tool-authoring.md
+++ b/docs/mcp-server-tool-authoring.md
@@ -146,6 +146,8 @@ Rules:
 - non-`[a-z_]` chars become `_`
 - repeated underscores collapse
 - redundant `<server>_` prefix in tool name is stripped once
+- names longer than 64 characters keep a readable prefix and append `_` plus the first eight base-36
+  characters of `Bun.hash()` over the full uncapped generated name
 
 Different raw names can still sanitize to the same identifier (for example
 `my-server` and `my.server` both sanitize similarly). Before registry

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Corrected the documented `tools.approval` key format for MCP tools so per-tool deny policies use the registered tool name ([#9830](https://github.com/can1357/oh-my-pi/issues/9830)).
+
 ## [18.0.6] - 2026-08-26
 
 ### Added


### PR DESCRIPTION
## Repro

On current `main`, `bun -e 'import { createMCPToolName } from "./packages/coding-agent/src/mcp/tool-bridge.ts"; import { resolveApproval } from "./packages/coding-agent/src/tools/approval.ts"; const name = createMCPToolName("echo", "echo_it"); const tool = { name, approval: "write" }; console.log(JSON.stringify({ name, documented: resolveApproval(tool, {}, "yolo", { mcp__echo__echo_it: "deny" }).policy, canonical: resolveApproval(tool, {}, "yolo", { [name]: "deny" }).policy }));'` prints `{"name":"mcp__echo_it","documented":"allow","canonical":"deny"}`: the documented key misses while the registered key denies.

## Cause

`docs/approval-mode.md` showed MCP names as `mcp__<server>__<tool>`, but `createMCPToolName()` in `packages/coding-agent/src/mcp/tool-bridge.ts` mints `mcp__<server>_<tool>` and removes a redundant `<server>_` prefix from the tool component. `resolveApproval()` correctly matches policies against that registered name.

## Fix

- Correct the MCP deny example to use the registered single-underscore separator.
- Document the canonical name format, redundant-prefix stripping, and link to the full MCP naming rules.
- Record the user-facing correction in the coding-agent changelog.

## Verification

The focused `bun -e` reproduction reports `allow` for the old documented key and `deny` for the corrected registered key. Re-read the corrected approval example and naming link; the pre-publish `bun run fix` and `bun check` gate passed.

Fixes #9830