### PR TITLE
feat(catalog): add Z.AI GLM-5.3-Flash with native image input

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added Z.AI `glm-5.3-flash` to the bundled GLM Coding Plan catalog with its 1M
+  context window, 131,072-token output budget, native image input, and the
+  GLM-5.3 `low`/`high`/`max` mandatory-thinking ladder. The `zai` provider has
+  no live model discovery, so the SKU was unreachable in `/model` and
+  `omp models` even though the coding-plan endpoints already serve it. GLM-5.3-Flash
+  is also the first `-flash` SKU that reasons and the first GLM coding model
+  that accepts images without a `v` marker in its id, so the GLM family
+  classifiers now admit `-flash` from 5.3 on.
+
 ## [18.0.5] - 2026-08-25
 
 ### Added

--- a/packages/catalog/scripts/generate-models.ts
+++ b/packages/catalog/scripts/generate-models.ts
@@ -577,6 +577,27 @@ async function generateModels() {
 		contextWindow: 1_000_000,
 		maxTokens: 131_072,
 	} as ModelSpec<"anthropic-messages">);
+	// GLM-5.3-Flash ships on the same coding-plan endpoints and is likewise
+	// absent from `/v1/models`-derived upstream metadata. It is the first
+	// natively multimodal GLM coding SKU — its id carries no `v` marker, and
+	// base64 image blocks are accepted on `https://api.z.ai/api/anthropic` —
+	// so the seed declares image input directly instead of inheriting the
+	// text-only default. Cost is the currently billed launch price from
+	// https://docs.z.ai/guides/overview/pricing (50% off list 0.15/0.50/0.03
+	// through 2026-09-09); once upstream metadata carries the SKU its row wins
+	// dedup and supplies pricing.
+	allModels.push({
+		id: "glm-5.3-flash",
+		name: "GLM-5.3-Flash",
+		api: "anthropic-messages",
+		provider: "zai",
+		baseUrl: "https://api.z.ai/api/anthropic",
+		reasoning: true,
+		input: ["text", "image"],
+		cost: { input: 0.075, output: 0.25, cacheRead: 0.015, cacheWrite: 0 },
+		contextWindow: 1_000_000,
+		maxTokens: 131_072,
+	} as ModelSpec<"anthropic-messages">);
 	// Seed Meta's documented Muse model so first-run selection does not depend on
 	// credentials or live discovery.
 	allModels.push(...META_MUSE_STATIC_MODELS);

--- a/packages/catalog/scripts/generated-policies.ts
+++ b/packages/catalog/scripts/generated-policies.ts
@@ -382,13 +382,18 @@ function applyGeneratedModelPolicy(model: ModelSpec<Api>): void {
 
 	// GLM Coding Plan: the selectable 1M-context served ids; pin them so
 	// endpoint discovery or older bundled fallbacks cannot regress to 200k.
-	// GLM-5.3 succeeds GLM-5.2 with the same 1M context window.
+	// GLM-5.3 succeeds GLM-5.2 with the same 1M context window, and
+	// GLM-5.3-Flash shares the tier while adding native image input that
+	// upstream metadata still reports as text-only.
 	if (
 		(model.provider === "zai" || model.provider === "zhipu-coding-plan") &&
-		(model.id === "glm-5.2" || model.id === "glm-5.3")
+		(model.id === "glm-5.2" || model.id === "glm-5.3" || model.id === "glm-5.3-flash")
 	) {
 		model.contextWindow = 1_000_000;
 		model.maxTokens = 131_072;
+		if (model.id === "glm-5.3-flash") {
+			model.input = ["text", "image"];
+		}
 	}
 	// MiniMax-M3: 512K is the standard pricing tier boundary, not the
 	// model ceiling. Pin every long-context provider that serves the model

--- a/packages/catalog/src/identity/family.ts
+++ b/packages/catalog/src/identity/family.ts
@@ -9,6 +9,7 @@
 
 import {
 	bareModelId,
+	type GlmModel,
 	isAnthropicAdaptiveGenAtLeast,
 	isFableOrMythos,
 	parseAnthropicModel,
@@ -284,18 +285,34 @@ export const isOpenAISamplingRestrictedModelId = memo((modelId: string): boolean
 });
 
 /**
+ * GLM SKU shapes that carry the reasoning ladders. `base`/`air`/`turbo` have
+ * always been reasoning lines; `flash` joins at GLM-5.3-Flash, the first flash
+ * SKU whose thinking is mandatory (pre-5.3 `-flash` SKUs are non-reasoning).
+ * `flashx` and `preview` stay out.
+ */
+function isGlmReasoningVariant(glm: GlmModel): boolean {
+	switch (glm.variant) {
+		case "base":
+		case "air":
+		case "turbo":
+			return true;
+		case "flash":
+			return semverGte(glm.version, "5.3");
+		default:
+			return false;
+	}
+}
+
+/**
  * Reasoning-capable GLM coding SKUs: glm-4.5 and up on the base / `-air` /
- * `-turbo` lines. Excludes the vision (`…v`) shape, the non-reasoning
- * `-flash`/`-flashx`/`-preview` variants, and pre-4.5 ids. Matching the family
- * keeps newly-bumped integers (`glm-5.3`, `glm-6`, …) covered without a per-id
- * allowlist.
+ * `-turbo` lines, plus `-flash` from GLM-5.3-Flash on. Excludes the vision
+ * (`…v`) shape, the non-reasoning `-flashx`/`-preview` variants, and pre-4.5
+ * ids. Matching the family keeps newly-bumped integers (`glm-5.4`, `glm-6`, …)
+ * covered without a per-id allowlist.
  */
 export const isReasoningGlmModelId = memo((modelId: string): boolean => {
 	const glm = parseGlmModel(bareModelId(modelId));
-	if (!glm || glm.vision) {
-		return false;
-	}
-	if (glm.variant !== "base" && glm.variant !== "air" && glm.variant !== "turbo") {
+	if (!glm || glm.vision || !isGlmReasoningVariant(glm)) {
 		return false;
 	}
 	return semverGte(glm.version, "4.5");
@@ -304,10 +321,7 @@ export const isReasoningGlmModelId = memo((modelId: string): boolean => {
 /** GLM-5.2+ coding SKUs accept `reasoning_effort` in addition to binary thinking. */
 export const isGlm52ReasoningEffortModelId = memo((modelId: string): boolean => {
 	const glm = parseGlmModel(bareModelId(modelId));
-	if (!glm || glm.vision) {
-		return false;
-	}
-	if (glm.variant !== "base" && glm.variant !== "air" && glm.variant !== "turbo") {
+	if (!glm || glm.vision || !isGlmReasoningVariant(glm)) {
 		return false;
 	}
 	return semverGte(glm.version, "5.2");
@@ -319,22 +333,27 @@ export const isGlm52ReasoningEffortModelId = memo((modelId: string): boolean => 
  * ladder on every host, and thinking can no longer be disabled —
  * `thinking.type` must always be `enabled`. Matching the family keeps future
  * bumps (`glm-5.4`, `glm-6`, …) covered while excluding the vision (`…v`)
- * shape and the non-reasoning `-flash`/`-flashx`/`-preview` variants.
+ * shape and the non-reasoning `-flashx`/`-preview` variants.
  */
 export const isGlm53ReasoningEffortModelId = memo((modelId: string): boolean => {
 	const glm = parseGlmModel(bareModelId(modelId));
-	if (!glm || glm.vision) {
-		return false;
-	}
-	if (glm.variant !== "base" && glm.variant !== "air" && glm.variant !== "turbo") {
+	if (!glm || glm.vision || !isGlmReasoningVariant(glm)) {
 		return false;
 	}
 	return semverGte(glm.version, "5.3");
 });
 
-/** GLM vision SKUs — the `v` that attaches to the version (`glm-4v`, `glm-4.5v`). */
+/**
+ * GLM SKUs that accept image input: the `v` that attaches to the version
+ * (`glm-4v`, `glm-4.5v`) and the natively multimodal `-flash` line from
+ * GLM-5.3-Flash on, whose id carries no `v` marker.
+ */
 export const isGlmVisionModelId = memo((modelId: string): boolean => {
-	return parseGlmModel(bareModelId(modelId))?.vision === true;
+	const glm = parseGlmModel(bareModelId(modelId));
+	if (!glm) {
+		return false;
+	}
+	return glm.vision || (glm.variant === "flash" && semverGte(glm.version, "5.3"));
 });
 
 /**

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -294589,6 +294589,55 @@
 			},
 			"supportsComputerUseConfig": false
 		},
+		"glm-5.3-flash": {
+			"id": "glm-5.3-flash",
+			"name": "GLM-5.3-Flash",
+			"api": "anthropic-messages",
+			"provider": "zai",
+			"baseUrl": "https://api.z.ai/api/anthropic",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.075,
+				"output": 0.25,
+				"cacheRead": 0.015,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 131072,
+			"thinking": {
+				"mode": "anthropic-budget-effort",
+				"efforts": [
+					"low",
+					"high",
+					"max"
+				],
+				"defaultLevel": "max",
+				"requiresEffort": true
+			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "glm5",
+			"supportsComputerUse": false,
+			"compat": {
+				"officialEndpoint": false,
+				"signingEndpoint": false,
+				"disableStrictTools": false,
+				"disableAdaptiveThinking": false,
+				"allowAnthropicHeaderOverrides": false,
+				"supportsEagerToolInputStreaming": false,
+				"supportsLongCacheRetention": false,
+				"supportsMidConversationSystem": false,
+				"supportsForcedToolChoice": true,
+				"supportsSamplingParams": true,
+				"requiresToolResultId": true,
+				"requiresThinkingEnabled": false,
+				"replayUnsignedThinking": true,
+				"escapeBuiltinToolNames": false
+			}
+		},
 		"glm-5v-turbo": {
 			"id": "glm-5v-turbo",
 			"name": "GLM-5V-Turbo",

--- a/packages/catalog/test/generated-policies.test.ts
+++ b/packages/catalog/test/generated-policies.test.ts
@@ -344,6 +344,39 @@ describe("generated model policies", () => {
 		}
 	});
 
+	it("pins zai glm-5.3-flash to the 1M tier and restores its native image input", () => {
+		const models = [
+			createSpec({
+				id: "glm-5.3-flash",
+				api: "anthropic-messages",
+				provider: "zai",
+				contextWindow: 200_000,
+				maxTokens: 8192,
+			}),
+			createSpec({
+				id: "glm-5.3-flash",
+				api: "openai-completions",
+				provider: "zhipu-coding-plan",
+				contextWindow: 200_000,
+				maxTokens: 8192,
+			}),
+		];
+
+		applyGeneratedModelPolicies(models);
+
+		for (const model of models) {
+			expect(model.contextWindow).toBe(1_000_000);
+			expect(model.maxTokens).toBe(131_072);
+			// Natively multimodal despite the missing `v` marker; upstream
+			// metadata reports the flash SKU as text-only.
+			expect(model.input).toEqual(["text", "image"]);
+			// Same mandatory low/high/max ladder as the GLM-5.3 base line.
+			expect(model.thinking?.efforts).toEqual([Effort.Low, Effort.High, Effort.Max]);
+			expect(model.thinking?.requiresEffort).toBe(true);
+			expect(model.thinking?.defaultLevel).toBe(Effort.Max);
+		}
+	});
+
 	it("pins MiniMax-M3 long-context providers to 1M context", () => {
 		const models = [
 			createSpec({

--- a/packages/catalog/test/identity-family.test.ts
+++ b/packages/catalog/test/identity-family.test.ts
@@ -287,15 +287,18 @@ describe("isReasoningGlmModelId", () => {
 		// Family match is future-proof: new integers need no allowlist entry.
 		expect(isReasoningGlmModelId("glm-5.3")).toBe(true);
 		expect(isReasoningGlmModelId("glm-6")).toBe(true);
+		// GLM-5.3-Flash is the first `-flash` SKU with mandatory thinking.
+		expect(isReasoningGlmModelId("glm-5.3-flash")).toBe(true);
 		// Namespaced ids are stripped before classification.
 		expect(isReasoningGlmModelId("z-ai/glm-5-turbo")).toBe(true);
 	});
 
-	test("excludes pre-4.5, vision, flash, and preview SKUs", () => {
+	test("excludes pre-4.5, vision, pre-5.3 flash, flashx, and preview SKUs", () => {
 		expect(isReasoningGlmModelId("glm-4")).toBe(false);
 		expect(isReasoningGlmModelId("glm-4.4")).toBe(false);
 		expect(isReasoningGlmModelId("glm-5-preview")).toBe(false);
 		expect(isReasoningGlmModelId("glm-4.5-flash")).toBe(false);
+		expect(isReasoningGlmModelId("glm-4.7-flash")).toBe(false);
 		expect(isReasoningGlmModelId("glm-4.7-flashx")).toBe(false);
 		expect(isReasoningGlmModelId("glm-4.5v")).toBe(false);
 		expect(isReasoningGlmModelId("qwen3.5")).toBe(false);
@@ -318,6 +321,17 @@ describe("isGlmVisionModelId", () => {
 		expect(isGlmVisionModelId("glm-4v")).toBe(true);
 		expect(isGlmVisionModelId("glm-4.5v")).toBe(true);
 		expect(isGlmVisionModelId("glm-4v-plus")).toBe(true);
+	});
+
+	test("matches the natively multimodal flash line from GLM-5.3-Flash on", () => {
+		// GLM-5.3-Flash accepts image blocks without carrying a `v` marker.
+		expect(isGlmVisionModelId("glm-5.3-flash")).toBe(true);
+		expect(isGlmVisionModelId("zai-org/GLM-5.3-Flash")).toBe(true);
+		// Earlier flash SKUs stay text-only.
+		expect(isGlmVisionModelId("glm-4.5-flash")).toBe(false);
+		expect(isGlmVisionModelId("glm-4.7-flash")).toBe(false);
+		// The text-only base line is unaffected.
+		expect(isGlmVisionModelId("glm-5.3")).toBe(false);
 	});
 
 	test("excludes non-vision GLM ids (the old `includes('v')` false positives)", () => {

--- a/packages/catalog/test/zai-bundled-catalog.test.ts
+++ b/packages/catalog/test/zai-bundled-catalog.test.ts
@@ -7,6 +7,9 @@ interface BundledModel {
 	baseUrl: string;
 	contextWindow: number | null;
 	maxTokens: number | null;
+	input?: readonly string[];
+	reasoning?: boolean;
+	thinking?: { efforts?: readonly string[]; defaultLevel?: string; requiresEffort?: boolean };
 }
 
 describe("zai bundled catalog", () => {
@@ -21,5 +24,24 @@ describe("zai bundled catalog", () => {
 		expect(model.contextWindow).toBe(1_000_000);
 		expect(model.maxTokens).toBe(131_072);
 		expect(Object.keys(zaiModels)).not.toContain("glm-5.2[1m]");
+	});
+
+	it("bundles glm-5.3-flash with the 1M tier, native image input, and the GLM-5.3 ladder", () => {
+		const zaiModels = modelsJson.zai as Record<string, BundledModel>;
+		const model = zaiModels["glm-5.3-flash"];
+
+		expect(model).toBeDefined();
+		expect(model.api).toBe("anthropic-messages");
+		expect(model.baseUrl).toBe("https://api.z.ai/api/anthropic");
+		expect(model.contextWindow).toBe(1_000_000);
+		expect(model.maxTokens).toBe(131_072);
+		// Natively multimodal: the id carries no `v` marker, but the Anthropic
+		// endpoint accepts image blocks.
+		expect(model.input).toEqual(["text", "image"]);
+		expect(model.reasoning).toBe(true);
+		// Thinking cannot be disabled and defaults to `max`.
+		expect(model.thinking?.efforts).toEqual(["low", "high", "max"]);
+		expect(model.thinking?.requiresEffort).toBe(true);
+		expect(model.thinking?.defaultLevel).toBe("max");
 	});
 });

--- a/packages/catalog/test/zhipu-compat.test.ts
+++ b/packages/catalog/test/zhipu-compat.test.ts
@@ -175,4 +175,33 @@ describe("zhipu-coding-plan model discovery", () => {
 		expect(models?.[0]?.id).toBe("glm-5.1");
 		expect(models?.[0]?.baseUrl).toBe("https://open.bigmodel.cn/api/coding/paas/v4");
 	});
+
+	it("maps glm-5.3-flash as a reasoning model with native image input", async () => {
+		const mockFetch: FetchImpl = Object.assign(
+			async (): Promise<Response> =>
+				new Response(
+					JSON.stringify({
+						data: [
+							{ id: "glm-5.3-flash", name: "GLM-5.3-Flash" },
+							{ id: "glm-4.7-flash", name: "GLM-4.7-Flash" },
+						],
+					}),
+					{ headers: { "content-type": "application/json" } },
+				),
+			{ preconnect: fetch.preconnect },
+		);
+
+		const options = zhipuCodingPlanModelManagerOptions({ apiKey: "test-key", fetch: mockFetch });
+		const models = await options.fetchDynamicModels?.();
+		const flash53 = models?.find(model => model.id === "glm-5.3-flash");
+		const flash47 = models?.find(model => model.id === "glm-4.7-flash");
+
+		// GLM-5.3-Flash is the first natively multimodal, mandatory-thinking
+		// flash SKU; its id carries no `v` marker.
+		expect(flash53?.reasoning).toBe(true);
+		expect(flash53?.input).toEqual(["text", "image"]);
+		// Older flash SKUs stay non-reasoning and text-only.
+		expect(flash47?.reasoning).toBe(false);
+		expect(flash47?.input).toEqual(["text"]);
+	});
 });


### PR DESCRIPTION
I hit this on my own GLM Coding Plan account: `glm-5.3-flash` is served by
`api.z.ai` right now, but omp cannot offer it because the `zai` provider has no
live discovery, so this adds the SKU to the bundled catalog and makes the GLM
family classifiers treat the 5.3 flash line as reasoning-capable and
image-capable.

## Why it was missing

`zaiModelManagerOptions` (`packages/catalog/src/provider-models/special.ts`)
returns a bare `{ providerId: "zai" }` — there is no `fetchDynamicModels`. So
every `zai` model comes from upstream metadata plus the curated seeds in
`scripts/generate-models.ts`. GLM-5.3-Flash was released after the last
regeneration, so it was unreachable in `/model` and `omp models`, and
`omp models refresh` could not recover it (nothing to discover).

## What changed

- `scripts/generate-models.ts` — seeded `zai/glm-5.3-flash` next to the
  existing `glm-5.3` seed (1M context, 131,072 max output, `input: ["text",
  "image"]`, launch pricing 0.075/0.25/0.015 from
  https://docs.z.ai/guides/overview/pricing, which is 50% off list through
  2026-09-09; once upstream metadata carries the SKU its row wins dedup).
- `scripts/generated-policies.ts` — extended the existing GLM coding-plan pin
  to `glm-5.3-flash` (1M/131k) and restored its image input, which upstream
  metadata reports as text-only.
- `src/identity/family.ts` — the three GLM predicates shared one
  `base|air|turbo` variant gate. GLM-5.3-Flash is the first `-flash` SKU that
  reasons at all (its `thinking.type` only accepts `enabled`), so the gate now
  admits `flash` from 5.3 on via `isGlmReasoningVariant`, and
  `isGlmVisionModelId` recognises the natively multimodal flash line, whose id
  carries no `v` marker. `glm-4.5-flash` / `glm-4.7-flash` / `-flashx` /
  `-preview` are unchanged.
- `src/models.json` — added the bundled row so the SKU ships before the next
  regeneration. I produced it by running the repo's own `buildModel` +
  `applyGeneratedModelPolicies` over the new seed rather than hand-writing it,
  and the diff is insertion-only (49 lines).

## Verification

Endpoint behaviour, against a live GLM Coding Plan credential
(`POST https://api.z.ai/api/anthropic/v1/messages`, the wire the `zai`
provider uses):

| request | result |
|---|---|
| text turn | 200 |
| base64 PNG (1.3 KB hand-encoded, and 906 KB) + question | 200, answered `Red` for a solid-red fixture |
| base64 JPEG | 200, `Twilight sky glowing orange above dark horizon.` |
| base64 WebP | 200, `Rocky cliffs overlooking a winding fjord.` |

So no WebP pre-decode (`imageInputDecoder`) is needed. `GET /api/coding/paas/v4/models`
lists `glm-5.3-flash`, confirming the SKU is live on the plan.

End to end on this branch, with my local `~/.omp/agent/models.yml` override
moved aside so the bundled catalog was the only source:

```
$ bun src/cli.ts models zai
...
│ glm-5.3-flash  │      1M │    131K │ low,high,max                  │ yes    │

$ bun src/cli.ts -p --no-session --no-tools --model zai/glm-5.3-flash \
    "@omp-vision-halves.png" \
    "Answer in exactly two words: color of the left half, then color of the right half."
Blue green
```

The fixture is a 320x160 PNG, left half blue, right half green, so the answer
is only reachable by actually decoding the image.

Checks (`packages/catalog`):

- `bun test test/identity-family.test.ts test/generated-policies.test.ts test/zai-bundled-catalog.test.ts test/zhipu-compat.test.ts` — 79 pass, 0 fail
- `bun test` (full package) — 767 pass, 2 fail. Both failures are
  `test/issue-8867-repro.test.ts` (model-cache SQLite corruption self-heal) and
  they reproduce identically on unmodified `origin/main` in my Windows
  environment, so they are pre-existing and unrelated to this change.
- `bun run check:types` — clean
- `bunx biome check` on the touched files — clean

## Tests added

- `test/identity-family.test.ts` — `glm-5.3-flash` reasons; `glm-4.5-flash` /
  `glm-4.7-flash` / `-flashx` still do not; the vision predicate matches
  `glm-5.3-flash` (including the uppercase `zai-org/GLM-5.3-Flash` form) but
  not `glm-5.3` or older flash SKUs.
- `test/generated-policies.test.ts` — the 1M/131k pin, restored image input,
  and the mandatory low/high/max ladder on both `zai` and `zhipu-coding-plan`.
- `test/zai-bundled-catalog.test.ts` — the shipped `models.json` row.
- `test/zhipu-compat.test.ts` — `zhipu-coding-plan` discovery maps
  `glm-5.3-flash` to `reasoning: true` + `input: ["text", "image"]` while
  `glm-4.7-flash` stays non-reasoning and text-only.

## Notes

- Video and file inputs (`video_url` / `file_url` in Z.AI's API) are out of
  scope; omp has no matching content type.
- The diff was written with agent assistance; the endpoint probes, the
  end-to-end run, and the test results above are real runs on my machine
  against my own account.
