### PR TITLE
feat(coding-agent): add the ultracode magic keyword

### DIFF
--- a/.git-pr-body.md
+++ b/.git-pr-body.md
@@ -1,0 +1,33 @@
+# Add the `ultracode` magic keyword
+
+Closes #2159.
+
+## What this is
+
+A fourth magic keyword beside `ultrathink`, `orchestrate`, and `workflowz`: typing `ultracode` in a prompt pins that turn — and every subagent it spawns — to `xhigh` reasoning effort, and injects a hidden notice that makes eval-scripted multi-agent workflows the default for substantive tasks. It is the effort+orchestration fusion #2159 asked for, scoped to the turn rather than the session.
+
+## Why turn-scoped (a deliberate narrowing of #2159)
+
+#2159 proposes a session-wide `/effort ultracode`. This implementation borrows the level for the carrying turn and hands it back on the next user turn without the word: one maximal request does not silently re-bill every turn after it, and there is no mode to forget you are in. The plan-review path (below) covers the "arm a whole execution" case #2159 cares about. A session-persistent variant would be a small extension on top of this wiring if wanted (see also #7963's reasoning-vs-orchestration split — this PR keeps `ultrathink` reasoning-only and untouched).
+
+## Design decisions a reviewer will want to check
+
+- **Enforced, not advisory.** Unlike `orchestrate`/`workflowz` (notice-only), the effort contract is enforced at the single spawn chokepoint in `runSubprocess`, covering both the `task` tool and the eval `agent()` bridge. The pin overrides the agent definition's own level (scout pins `medium`), a caller `effort`, and a `task.maxEffort` ceiling below xhigh — the escorting ceiling is raised to the pinned level so it can never sit below the level it escorts. Both spawn entries are covered by tests, not inference.
+- **Clamp, don't throw.** The pin uses `clampAutoThinkingEffort`, not `resolveTaskEffortLevel`: the latter throws `RangeError` when a model's ladder sits entirely above the ceiling, which would have crashed spawns on `["max"]`-only ladders and blamed `task.maxEffort` for a ceiling ultracode supplied. Models with no effort surface run unchanged, and the notice says so honestly.
+- **Arm at turn start, not enqueue.** A prompt queued during streaming must not flip the pin under the in-flight turn; queued prompts carry their arm/disarm as a delivery effect that fires when the message commits into the live context.
+- **Escapable by construction.** Any explicit user thinking-level set (cycle, selector, RPC, ACP) clears the override and drops the pending handback; a session killed mid-turn hands the level back on restore instead of resuming stranded at xhigh. The override lives in the runtime settings layer and is never persisted.
+- **Plan review.** Plan approval dispatches a synthetic prompt, and synthetic turns never scan keywords, so a typed keyword cannot reach the execution turn. The plan review therefore gains "Approve and execute with ultracode" — shown and armed only while `magicKeywords.enabled` and `magicKeywords.ultracode` are on, and armed only after `#exitPlanMode` restores the pre-plan model (which would otherwise revert the pin).
+
+## Behavior change disclosed (affects all four keywords)
+
+Keyword notices now require **user-attributed** prompts. The existing doc comment already promised this ("User-authored prompts only — synthetic / agent-initiated turns never trigger them"), but the code gated only on `synthetic`, so agent-attributed prompts could fire keywords the user never typed. This PR makes the code match the documented intent. If you consider the old behavior load-bearing, this hunk is separable.
+
+## Provenance note
+
+`prompts/system/ultracode-notice.md` is structured after this repo's own `workflow-notice.md`, but several passages (the orchestration framing, barrier doctrine, the loop-until-dry example, the adjudication calibration) derive from — and in places closely follow — Anthropic's Claude Code ultracode prompt, adapted to this runtime's eval surface (helper signatures, pool bounds, budget API all verified against this codebase). Flagging explicitly so you can judge whether that provenance is acceptable; happy to rewrite passages in-house if not. This is also the first model-facing prompt in the repo to name Claude Code.
+
+## Testing
+
+99 new test cases; the six touched files run 185 total. Coverage includes: executor-seam proofs for both spawn entries; grandchild settings propagation; plan-approval arming order and settings gating (including a forged-choice negative); queued-message timing; every off-ramp; restore handback; keyword boundary/scan-scope cases (synthetic, agent-attributed, skill args); and controls proving the classifier-bypass assertions are not vacuous. Note on style: some notice tests pin exact contract-bearing phrases of the prompt (turn-scope wording, effort claims) — the consumer contract is model behavior, and phrase drift there has shipped real bugs; happy to restructure if you prefer looser assertions.
+
+`bun run check:types` clean; the six test files green on top of v18.0.5.

--- a/README.md
+++ b/README.md
@@ -313,11 +313,12 @@ Setting-gated, off by default: `github`, `security_scan`, `generate_image`, `tts
 
 ### Prompt controls
 
-Three standalone, lowercase words opt a turn into specialized agent behavior:
+Four standalone, lowercase words opt a turn into specialized agent behavior:
 
 - `ultrathink` — request careful multi-step reasoning and the highest supported automatic thinking effort.
 - `orchestrate` — run substantial independent work through parallel subagents and verify each phase.
 - `workflowz` — build a deterministic multi-subagent workflow with the active `task` tool.
+- `ultracode` — pin the turn and every subagent it spawns to maximum reasoning effort and make scripted multi-agent workflows the default for that turn (switch: `magicKeywords.ultracode`).
 
 They trigger only in prose, not inside code spans, fenced code blocks, XML/HTML sections, identifiers, or paths. See [Magic keywords](docs/magic-keywords.md) for exact matching rules and configuration.
 

--- a/docs/magic-keywords.md
+++ b/docs/magic-keywords.md
@@ -1,6 +1,6 @@
 # Magic keywords
 
-Magic keywords are standalone prose words in a user prompt that can add hidden, user-attributed instructions for that turn. Notice injection is enabled by default. The TUI highlights recognized words with animated gradients while editing and static gradients in sent messages; highlighting is a visual affordance and currently remains even when notice injection is disabled in settings.
+Magic keywords are standalone prose words in a user prompt that can add hidden, user-attributed instructions. Each one steers only the turn that carries it. Notice injection is enabled by default. The TUI highlights recognized words with animated gradients while editing and static gradients in sent messages; highlighting is a visual affordance and currently remains even when notice injection is disabled in settings.
 
 ## Keywords
 
@@ -9,6 +9,7 @@ Magic keywords are standalone prose words in a user prompt that can add hidden, 
 | `ultrathink`  | Adds a careful multi-step reasoning notice. When automatic thinking is active, it also selects the highest reasoning effort supported by the current model for that turn.                                                                                                                                                 |
 | `orchestrate` | Adds the multi-agent orchestration contract: scope the full task, delegate substantial independent work in parallel, verify each phase, and continue until the request is complete.                                                                                                                                       |
 | `workflowz`   | Adds a deterministic multi-subagent workflow contract centered on the persistent `eval` kernel's `agent()`, `parallel()`, `pipeline()`, and `completion()` helpers. It is intended for broad research, reviews, migrations, and adversarial coverage. The notice is injected only when both `eval` and `task` are active. |
+| `ultracode`   | Runs that turn at `xhigh` reasoning effort, for the turn and every subagent it spawns (overriding an agent's own pinned effort), and carries its own orchestration contract so the turn runs as a multi-subagent workflow. The effort is borrowed for the turn and handed back afterwards; nothing is persisted to disk.                                                  |
 
 Use the keyword anywhere in the prose of the prompt:
 
@@ -18,17 +19,35 @@ ultrathink about the failure modes before changing this API
 orchestrate the migration described in docs/plan.md
 
 workflowz an adversarial review of the authentication changes
+
+ultracode the scheduler rewrite, it needs a proper pass
 ```
+
+## Ultracode turns
+
+`ultracode` and `ultrathink` differ in reach, not just in height. Ultrathink only biases the difficulty classifier, so it does nothing at all when automatic thinking is off, and it leaves the level alone otherwise. Ultracode sets a concrete level for the turn, so it lands either way, and it covers every subagent the turn spawns. Stronger is not the same as higher: `xhigh` sits one tier below `max`, and on an ultracode turn the auto-thinking path resolves to `xhigh`, so a same-turn `ultrathink` no longer reaches `max` on a model that exposes it.
+
+On a turn carrying the keyword:
+
+- Reasoning effort is set to `xhigh`, clamped to the ladder the active model actually exposes. Automatic thinking is switched off for the turn, and if anything re-enables it the level resolves straight back to `xhigh` instead of letting the difficulty classifier walk it down mid-turn.
+- Every subagent that turn spawns is pinned the same way, clamped to the ladder that subagent's own model exposes, so a smaller model lands on its own highest supported level instead. The pin outranks a caller-supplied effort, an agent definition's own pinned level (the built-in `scout` pins `medium`), and a `task.maxEffort` ceiling below `xhigh`. It caps as well as raises: a `hi` spawn that would otherwise reach `max` lands on `xhigh`. A model with no controllable effort surface has nothing to pin, so the spawn falls back to the normal selectors, taking an explicit `:level` suffix on the resolved model pattern before the agent definition's own level. The pin rides with each spawn for that subagent's whole lifetime, even when the subagent outlives the turn.
+- The hidden `ultracode-notice` carries its own fuller orchestration contract, spelled out rather than referred to: the `eval` helper signatures, the workflow structure, the fan-out patterns, and the adjudication rules for adversarial verification. It is a separate notice, deliberately not the shorter one `workflowz` injects. Naming the contract without carrying it would tell the model to orchestrate while withholding the API it must orchestrate with.
+- That contract is gated on tool availability, because there is no way to fan out without it. When `eval` and `task` are both active the full API ships. When either is missing the notice is still injected, unlike `workflowz` which is skipped outright, because the effort still applies; it drops the fan-out API and states plainly that orchestration is unavailable, so the model does not describe subagents it cannot run.
+
+The borrowed effort is handed back on the next user turn that does not carry the word, restoring `auto` when that is what was running before. Repeat the word on any later message that wants the same treatment. Two things end the turn early: reaching for the effort control yourself (cycling the thinking level keeps your choice and drops the pending restore, rather than silently overwriting it), and a new session, which always starts clean.
+
+The `ultracode` boolean is turn state rather than a preference, so it is deliberately absent from the settings UI. It is written only to the runtime override layer, which never reaches disk, and a keyword-free turn writes it back to `false` so a stale persisted `true` cannot quietly run every turn at `xhigh`.
 
 ## Matching rules
 
 Matching is deliberate so source code and paths do not accidentally change agent behavior:
 
-- Use the exact lowercase spelling. `Ultrathink`, `Orchestrate`, and `Workflowz` do not trigger.
-- The keyword must be standalone prose. Sentence punctuation and quotes may touch it, but letters, digits, underscores, slashes, backslashes, hyphens, file extensions, symbol references, and call syntax do not match. For example, `orchestrate,` matches; `orchestrated`, `orchestrate.ts`, `foo::orchestrate`, and `orchestrate()` do not.
+- Use the exact lowercase spelling. `Ultrathink`, `Orchestrate`, `Workflowz`, and `Ultracode` do not trigger.
+- The keyword must be standalone prose. Sentence punctuation and quotes may touch it, but letters, digits, underscores, slashes, backslashes, hyphens, file extensions, symbol references, and call syntax do not match. For example, `orchestrate,` matches; `orchestrated`, `orchestrate.ts`, `foo::orchestrate`, `orchestrate()`, `ultracoded`, and `ultracode.ts` do not.
 - Fenced code blocks (backticks or tildes), inline code spans, HTML/XML comments/tags/elements, and their contents are ignored.
+- Keywords are scanned after slash-command and prompt-template expansion, so a command or template body — and skill arguments — can deliberately carry a keyword the user did not type that turn. Backticking the word in such a body keeps an innocent mention inert.
 - All enabled keywords in one prompt may add their own notice. The visible word remains in the user message; hidden notices are non-displayed custom messages attributed to the user.
-- The instruction applies only to the turn containing the keyword.
+- The instruction applies only to the turn containing the keyword. That includes `ultracode`: it steers the message that carries it and nothing after it.
 
 ## Configuration
 
@@ -42,6 +61,7 @@ omp config set magicKeywords.enabled false
 omp config set magicKeywords.ultrathink false
 omp config set magicKeywords.orchestrate false
 omp config set magicKeywords.workflow false
+omp config set magicKeywords.ultracode false
 ```
 
-The global switch and three per-keyword switches default to `true`. The global switch gates every hidden notice; a per-keyword switch gates only that notice (and ultrathink's maximum-auto-thinking override). These settings do not currently disable the editor/message gradient. Run `omp config list` to inspect every setting and its current value. See [Settings](./settings.md) for configuration scopes, precedence, and project-local overrides.
+The global switch and four per-keyword switches default to `true`. `workflowz` is gated by `magicKeywords.workflow`; every other switch is named after its keyword, including `magicKeywords.ultracode`. The global switch gates every hidden notice at the point a keyword fires; a per-keyword switch gates only that notice and the effort behavior attached to it (ultrathink's maximum-auto-thinking override, ultracode's `xhigh` level). Because both are read on the turn the keyword fires, switching one off takes effect on the very next message. These settings do not currently disable the editor/message gradient. Run `omp config list` to inspect every setting and its current value. See [Settings](./settings.md) for configuration scopes, precedence, and project-local overrides.

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -8,7 +8,7 @@ Settings are stored as plain YAML mappings. Every key, its type, default, and en
 - For custom model definitions in `models.yml`, see [Models](./models.md).
 - For instruction files discovered into the agent context (`AGENTS.md`, `.omp/`, etc.), see [Context files](./context-files.md).
 - For the full catalog of environment variables, see [Environment variables](./environment-variables.md).
-- For prompt words that activate specialized per-turn behavior, see [Magic keywords](./magic-keywords.md).
+- For prompt words that activate specialized per-turn behavior (`ultrathink`, `orchestrate`, `workflowz`, `ultracode`), see [Magic keywords](./magic-keywords.md).
 
 ## Where settings live
 
@@ -406,6 +406,8 @@ thinkingBudgets:
 | `thinkingBudgets.max`             | number  | `32768` | Token budget for `max`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
 | `providers.autoThinkingMaxEffort` | enum    | `xhigh` | Highest effort `defaultThinkingLevel: auto` may resolve. `xhigh` keeps the classifier one tier below the top, so only `ultrathink` reaches `max`; `max` lets the classifier bill the top tier on models that expose it. The local on-device classifier stays capped at `xhigh` either way. This governs what `auto` _resolves_: a model whose ladder offers nothing under the ceiling gets no auto level at all, and one whose metadata requires explicit effort still receives its lowest supported effort from the transport — on a `["max"]` ladder that is `max`, because the model accepts nothing else. |
 
+A turn that carries [`ultracode`](./magic-keywords.md) overrides this row: that turn is pinned at `xhigh` (clamped to the ladder the active model exposes), the difficulty classifier is bypassed, and a same-turn `ultrathink` no longer reaches `max`. The borrowed level is handed back on the next user turn that does not carry the word.
+
 ### Sampling
 
 A value of `-1` means "use the provider/model default" — `omp` does not send that parameter.
@@ -762,8 +764,8 @@ Every schema path not individually tabulated in this catalog is explicitly defer
 - Agent behavior and safety: `ask.*`, `eval.*`, `features.*`, `goal.*`, `loop.*`, `model.loopGuard.*`, `model.toolCallLoopGuard.*`, `prewalk.*`, `recap.*`, `tools.*`, and `vault.*`.
 - Execution and content: `commit.*`, `completion.*`, `edit.*`, `error.*`, `extensionHandlers.*`, `generate_image.*`, `git.*`, `images.*`, `live.*`, `paste.*`, `power.*`, `read.*`, `shellMinimizer.*`, `speech.*`, `terminal.*`, and `title.*`.
 - Interface and startup: `display.*`, `statusLine.*`, `startup.*`, `stt.*`, `tui.*`, and `ttsr.*`.
-- Integrations, storage, and discovery: `async.*`, `bashInterceptor.*`, `codexResets.*`, `collab.*`, `commands.*`, `dev.*`, `exa.*`, `gc.*`, `github.*`, `hindsight.*`, `magicKeywords.*`, `mcp.*`, `memories.*`, `mnemopi.*`, `providers.*`, `searxng.*`, `share.*`, `skills.*`, `task.*`, `todo.*`, `tts.*`, and `workspace.*`.
-- Ungrouped keys: `setupVersion`, `proseOnlyThinking`, `omitThinking`, `externalThinking`, `includeWorkspaceTree`, `autocompleteMaxVisible`, `emojiAutocomplete`, `extendedContext`, `disabledExtensions`, `inlineToolDescriptors`, and `treeFilterMode`.
+- Integrations, storage, and discovery: `async.*`, `bashInterceptor.*`, `codexResets.*`, `collab.*`, `commands.*`, `dev.*`, `exa.*`, `gc.*`, `github.*`, `hindsight.*`, `magicKeywords.*` (four per-keyword switches: `ultrathink`, `orchestrate`, `workflow`, `ultracode`), `mcp.*`, `memories.*`, `mnemopi.*`, `providers.*`, `searxng.*`, `share.*`, `skills.*`, `task.*`, `todo.*`, `tts.*`, and `workspace.*`.
+- Ungrouped keys: `setupVersion`, `proseOnlyThinking`, `omitThinking`, `externalThinking`, `includeWorkspaceTree`, `autocompleteMaxVisible`, `emojiAutocomplete`, `extendedContext`, `disabledExtensions`, `inlineToolDescriptors`, `treeFilterMode`, and the turn flag `ultracode` (set at runtime by the [ultracode keyword](./magic-keywords.md) for the turn that carries it, never persisted by it, and written back to `false` by the next user turn without the word).
 
 These settings follow the same schema-defined type and default rules shown above.
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added the `ultracode` magic keyword: pins the turn and every spawned subagent to maximum reasoning effort and makes scripted multi-agent workflows the default for that turn, with a matching "Approve and execute with ultracode" plan-review option ([#2159](https://github.com/can1357/oh-my-pi/issues/2159)).
+
 ## [18.0.6] - 2026-08-26
 
 ### Added

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -2196,7 +2196,7 @@ export const SETTINGS_SCHEMA = {
 			tab: "interaction",
 			group: "Magic Keywords",
 			label: "Magic Keywords",
-			description: "Enable hidden notices for standalone ultrathink, orchestrate, and workflowz keywords",
+			description: "Enable hidden notices for standalone ultrathink, orchestrate, workflowz, and ultracode keywords",
 		},
 	},
 
@@ -2231,6 +2231,28 @@ export const SETTINGS_SCHEMA = {
 			label: "Workflow Keyword",
 			description: "Let standalone workflowz append its hidden eval workflow notice",
 		},
+	},
+
+	"magicKeywords.ultracode": {
+		type: "boolean",
+		default: true,
+		ui: {
+			tab: "interaction",
+			group: "Magic Keywords",
+			label: "Ultracode Keyword",
+			description:
+				"Let standalone ultracode run that turn at xhigh effort with multi-subagent workflow orchestration",
+		},
+	},
+
+	// Turn state, not a preference, and deliberately absent from the settings UI:
+	// the ultracode keyword writes it through the runtime override layer
+	// (Settings.override), which never reaches disk, and the next user turn
+	// without the keyword writes it back to false. It exists so the task executor
+	// can see that this turn's spawns run at the ultracode floor.
+	ultracode: {
+		type: "boolean",
+		default: false,
 	},
 
 	// Notifications

--- a/packages/coding-agent/src/modes/components/tips.txt
+++ b/packages/coding-agent/src/modes/components/tips.txt
@@ -10,6 +10,7 @@ Did you know? Each kitty/tmux/cmux/zellij/wezterm split keeps its own session �
 Drop the word `ultrathink` in your message for harder multi-step reasoning — watch it glow rainbow as you type
 Say `orchestrate` in your message to drive a multi-phase task with parallel subagents — watch it glow as you type
 Say `workflowz` in your message to drive the task with parallel subagents in eval — watch it glow as you type
+Say `ultracode` in any message to run that turn and every subagent it spawns at xhigh — watch it glow as you type
 Log in to several accounts of the same provider — `/login` again — and omp load-balances across them automatically
 Run `omp auth-broker serve` once and every machine pulls live tokens over the wire — refresh keys never leave the host; `omp auth-gateway` fronts it as a drop-in proxy any OpenAI-compatible client can hit
 Press alt+p (or /switch) to switch provider, and ctrl+p to cycle role models smol -> slow -> etc

--- a/packages/coding-agent/src/modes/components/user-message.ts
+++ b/packages/coding-agent/src/modes/components/user-message.ts
@@ -45,8 +45,8 @@ export class UserMessageComponent extends Container {
 		// Markdown layout so wrapping and bubble padding are computed on the visible text.
 		text = collapseImageMarkers(text, Number.POSITIVE_INFINITY, () => {});
 		const bgColor = (value: string) => theme.bg("userMessageBg", value);
-		// Paint the magic keywords ("ultrathink"/"orchestrate"/"workflowz") inside the rendered
-		// bubble too — matching the live editor glow. The Markdown component routes code spans and
+		// Paint the magic keywords ("ultrathink"/"orchestrate"/"workflowz"/"ultracode") inside the
+		// rendered bubble too — matching the live editor glow. The Markdown component routes code spans and
 		// fenced blocks through its own code styling (never `color`), so those are already excluded;
 		// `highlightMagicKeywords` additionally restores the bubble's own foreground after each
 		// painted keyword so the gradient never bleeds into the rest of the line.

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -342,7 +342,18 @@ function formatHudNoteMarker(count: number): string {
 type GoalSubcommand = "set" | "show" | "pause" | "resume" | "drop" | "budget";
 
 const GOAL_SUBCOMMANDS = new Set<GoalSubcommand>(["set", "show", "pause", "resume", "drop", "budget"]);
-const PLAN_KEEP_CONTEXT_OPTION_INDEX = 2;
+/**
+ * Execute the approved plan as an ultracode turn.
+ *
+ * Plan approval dispatches a synthetic prompt, and synthetic turns never scan for
+ * magic keywords, so an `ultracode` typed into the PLANNING turn cannot reach the
+ * EXECUTION turn — the phase that actually spawns the subagents. This option is
+ * how the operator carries it across that boundary. It obeys the same
+ * per-keyword settings gate as the typed keyword (`magicKeywords.enabled` +
+ * `magicKeywords.ultracode`): a keyword the operator switched off must not
+ * resurface as a menu entry.
+ */
+const PLAN_EXECUTE_ULTRACODE_LABEL = "Approve and execute with ultracode";
 const PLAN_KEEP_CONTEXT_DISABLE_THRESHOLD_PERCENT = 95;
 const PLAN_SAVE_AND_QUIT_OPTION = "Save and quit";
 const PLAN_SAVE_TITLE_LINE_LIMIT = 6;
@@ -3636,6 +3647,8 @@ export class InteractiveMode implements InteractiveModeContext {
 			preserveContext?: boolean;
 			compactBeforeExecute?: boolean;
 			executionModel?: ResolvedRoleModel;
+			/** Run the execution turn as an ultracode turn (see PLAN_EXECUTE_ULTRACODE_LABEL). */
+			executionUltracode?: boolean;
 		},
 	): Promise<boolean> {
 		const previousTools = this.#planModePreviousTools ?? this.session.getEnabledToolNames();
@@ -3752,10 +3765,19 @@ export class InteractiveMode implements InteractiveModeContext {
 		// markPlanReferenceSent fires only on the dispatch path so the synthetic
 		// plan-approved prompt is the source of the reference injection.
 		this.session.markPlanReferenceSent();
-		const planModePrompt = prompt.render(planModeApprovedPrompt, {
+		const planModeDirective = prompt.render(planModeApprovedPrompt, {
 			planFilePath: options.planFilePath,
 			contextPreserved: options.preserveContext === true,
 		});
+		// Arm ultracode LAST, after #exitPlanMode and any executionModel application:
+		// #exitPlanMode restores the pre-plan model state, which would revert the
+		// pinned thinking level, exactly as documented for executionModel above. The
+		// notice rides on the synthetic directive because the synthetic path does not
+		// build keyword notices; the turn stays synthetic, so nothing disarms it, and
+		// the next keyword-free user turn hands the borrowed effort back.
+		const planModePrompt = options.executionUltracode
+			? `${this.session.armUltracodeTurn()}\n\n${planModeDirective}`
+			: planModeDirective;
 		// Close the review overlay only now — after the async title write and plan
 		// prompt are prepared, immediately before the execution turn is queued. The
 		// synthetic prompt below blocks in `session.prompt` for the whole run, so
@@ -4402,16 +4424,26 @@ export class InteractiveMode implements InteractiveModeContext {
 		let feedback = "";
 		const annotationStateKey = this.#resolvePlanFilePath(planFilePath);
 
+		// Same per-keyword settings check the keyword scan applies
+		// (AgentSession's #magicKeywordEnabled): with either switch off, the
+		// ultracode option is dropped from the menu AND ignored on the arming
+		// path below, so a disabled keyword cannot arm a turn through the menu.
+		const ultracodeEnabled =
+			this.session.settings.get("magicKeywords.enabled") && this.session.settings.get("magicKeywords.ultracode");
+		// The keep-context disable targets its live index: the list's shape
+		// depends on the ultracode gate above.
+		const planOptions = [
+			"Approve and execute",
+			...(ultracodeEnabled ? [PLAN_EXECUTE_ULTRACODE_LABEL] : []),
+			"Approve and compact context",
+			keepContextLabel,
+			"Refine plan",
+			PLAN_SAVE_AND_QUIT_OPTION,
+		];
 		const choice = await this.showPlanReview(
 			planContent,
 			"Plan mode - next step",
-			[
-				"Approve and execute",
-				"Approve and compact context",
-				keepContextLabel,
-				"Refine plan",
-				PLAN_SAVE_AND_QUIT_OPTION,
-			],
+			planOptions,
 			{
 				helpText,
 				onExternalEditor: () => void this.#openPlanInExternalEditor(planFilePath),
@@ -4427,7 +4459,7 @@ export class InteractiveMode implements InteractiveModeContext {
 					if (state.annotations.length > 0) this.#planReviewAnnotationState.set(annotationStateKey, state);
 					else this.#planReviewAnnotationState.delete(annotationStateKey);
 				},
-				disabledIndices: keepContextDisabled ? [PLAN_KEEP_CONTEXT_OPTION_INDEX] : undefined,
+				disabledIndices: keepContextDisabled ? [planOptions.indexOf(keepContextLabel)] : undefined,
 			},
 			{ slider },
 		);
@@ -4451,7 +4483,12 @@ export class InteractiveMode implements InteractiveModeContext {
 			return;
 		}
 
-		if (choice === "Approve and execute" || choice === "Approve and compact context" || choice === keepContextLabel) {
+		if (
+			choice === "Approve and execute" ||
+			choice === PLAN_EXECUTE_ULTRACODE_LABEL ||
+			choice === "Approve and compact context" ||
+			choice === keepContextLabel
+		) {
 			try {
 				// Prefer in-overlay edits (already in memory) over a disk re-read. The
 				// overlay mirrors edits as they happen, and approval awaits one final
@@ -4496,8 +4533,9 @@ export class InteractiveMode implements InteractiveModeContext {
 				const executionDispatched = await this.#approvePlan(latestPlanContent, {
 					planFilePath,
 					title: details.title,
-					preserveContext: choice !== "Approve and execute",
+					preserveContext: choice !== "Approve and execute" && choice !== PLAN_EXECUTE_ULTRACODE_LABEL,
 					compactBeforeExecute: choice === "Approve and compact context",
+					executionUltracode: ultracodeEnabled && choice === PLAN_EXECUTE_ULTRACODE_LABEL,
 					executionModel,
 				});
 				if (executionDispatched) this.#planReviewAnnotationState.delete(annotationStateKey);

--- a/packages/coding-agent/src/modes/magic-keywords.ts
+++ b/packages/coding-agent/src/modes/magic-keywords.ts
@@ -1,14 +1,16 @@
 import { containsOrchestrate, highlightOrchestrate } from "./orchestrate";
+import { containsUltracode, highlightUltracode } from "./ultracode";
 import { containsUltrathink, highlightUltrathink } from "./ultrathink";
 import { containsWorkflow, highlightWorkflow } from "./workflow";
 
 /**
  * Gradient-highlight every magic keyword ("ultrathink", "orchestrate",
- * "workflowz") that appears as standalone prose, skipping any occurrence inside a
- * code block, inline code span, or XML/HTML section. Each highlighter paints its
- * own keyword with its own gradient, so chaining is order-independent — the
- * earlier passes only inject zero-width SGR escapes (no backticks or angle
- * brackets), which never confuse the later passes' markdown masking.
+ * "workflowz", "ultracode") that appears as standalone prose, skipping any
+ * occurrence inside a code block, inline code span, or XML/HTML section. Each
+ * highlighter paints its own keyword with its own gradient, so chaining is
+ * order-independent — the earlier passes only inject zero-width SGR escapes
+ * (no backticks or angle brackets), which never confuse the later passes'
+ * markdown masking.
  *
  * `resetTo` is the SGR foreground sequence restored after each painted keyword;
  * pass the surrounding text color when decorating already-colored content (e.g.
@@ -21,8 +23,12 @@ import { containsWorkflow, highlightWorkflow } from "./workflow";
  * to keep the static gradient.
  */
 export function highlightMagicKeywords(text: string, resetTo?: string, phase?: number): string {
-	return highlightWorkflow(
-		highlightOrchestrate(highlightUltrathink(text, resetTo, phase), resetTo, phase),
+	return highlightUltracode(
+		highlightWorkflow(
+			highlightOrchestrate(highlightUltrathink(text, resetTo, phase), resetTo, phase),
+			resetTo,
+			phase,
+		),
 		resetTo,
 		phase,
 	);
@@ -31,12 +37,17 @@ export function highlightMagicKeywords(text: string, resetTo?: string, phase?: n
 /**
  * Cheap test for "does this text contain any magic keyword as standalone prose?".
  * Short-circuits on a substring probe before paying for the markdown-aware
- * prose check, so the common "no keyword in buffer" path is just three
+ * prose check, so the common "no keyword in buffer" path is just four
  * `String#indexOf`s. Used by the live editor to gate the shimmer timer.
  */
 export function hasMagicKeyword(text: string): boolean {
-	if (!text.includes("ultrathink") && !text.includes("orchestrate") && !text.includes("workflowz")) {
+	if (
+		!text.includes("ultrathink") &&
+		!text.includes("orchestrate") &&
+		!text.includes("workflowz") &&
+		!text.includes("ultracode")
+	) {
 		return false;
 	}
-	return containsUltrathink(text) || containsOrchestrate(text) || containsWorkflow(text);
+	return containsUltrathink(text) || containsOrchestrate(text) || containsWorkflow(text) || containsUltracode(text);
 }

--- a/packages/coding-agent/src/modes/markdown-prose.ts
+++ b/packages/coding-agent/src/modes/markdown-prose.ts
@@ -1,6 +1,6 @@
 /**
  * Markdown structure awareness for the magic-keyword affordances
- * ("ultrathink"/"orchestrate"/"workflowz").
+ * ("ultrathink"/"orchestrate"/"workflowz"/"ultracode").
  *
  * Keyword detection and editor/transcript highlighting must fire only on prose
  * the user is actually addressing to the model — never on a word that happens to

--- a/packages/coding-agent/src/modes/ultracode.ts
+++ b/packages/coding-agent/src/modes/ultracode.ts
@@ -1,0 +1,96 @@
+import { prompt } from "@oh-my-pi/pi-utils";
+import ultracodeNotice from "../prompts/system/ultracode-notice.md" with { type: "text" };
+import { normalizeConcurrencyLimit } from "../task/parallel";
+import { createGradientHighlighter, type KeywordHighlighter } from "./gradient-highlight";
+import { magicKeywordRegex } from "./magic-keyword-boundary";
+import { keywordInProse } from "./markdown-prose";
+
+/**
+ * "ultracode" keyword support.
+ *
+ * Typing the standalone word in the input editor paints it with a violet ->
+ * magenta -> gold ripple ({@link highlightUltracode}); submitting a message that
+ * mentions it runs THAT TURN at xhigh reasoning effort, for the turn and every
+ * subagent it spawns, under the workflow orchestration contract carried by
+ * {@link ULTRACODE_NOTICE}. The word must be repeated on any later message that
+ * wants the same treatment. Matching is
+ * prose-delimited and case-sensitive (lowercase only), so "ultracoded",
+ * "Ultracode", or "ultracode.ts" never trigger either behavior.
+ */
+
+// Detection: lowercase keyword flanked by prose punctuation, whitespace, or a string edge.
+const ULTRACODE_WORD = magicKeywordRegex("ultracode");
+
+/**
+ * Hidden system notice appended after a user message that mentions "ultracode".
+ *
+ * Carries the full workflow orchestration contract: the orchestration
+ * doctrine, the script API for this harness's `eval` helpers, the
+ * barrier rules, the quality patterns, and the three-verdict adjudication that
+ * keeps adversarial verification from destroying real findings. Deliberately
+ * NOT the `workflowz` notice: that one is shorter prose by design, and the
+ * point of ultracode is the fuller contract.
+ *
+ * Every claim the notice makes about the runtime is rendered from the live
+ * session, never hardcoded, because a notice that misdescribes the API is worse
+ * than no notice: the model writes code against it and the code fails.
+ * - `workflowAvailable` false: no `eval`/`task`, so no fan-out mechanism exists.
+ *   The notice says so and keeps only the effort layer.
+ * - `scoutAvailable` false: `scout` is disabled or outside the spawn policy, so
+ *   naming it would hand the model an agent type that throws at preflight.
+ * - `effortApplied` false: `externalThinking` has replaced native reasoning with
+ *   the think tool, and the transport honors that (`forceReasoningOff`), so the
+ *   xhigh pin never reaches the wire. The notice must not assert an effort the
+ *   request will not carry.
+ * - `maxConcurrency` is the live `task.maxConcurrency`; 0 means unbounded and
+ *   the cap sentence is omitted entirely, matching the system prompt.
+ */
+export function renderUltracodeNotice({
+	workflowAvailable,
+	scoutAvailable,
+	effortApplied,
+	maxConcurrency,
+	viaPlanApproval,
+}: {
+	workflowAvailable: boolean;
+	scoutAvailable?: boolean;
+	effortApplied?: boolean;
+	maxConcurrency?: number;
+	viaPlanApproval?: boolean;
+}): string {
+	return prompt
+		.render(ultracodeNotice, {
+			workflowAvailable,
+			scoutAvailable: scoutAvailable ?? true,
+			effortApplied: effortApplied ?? true,
+			MAX_CONCURRENCY: normalizeConcurrencyLimit(maxConcurrency ?? 0),
+			viaPlanApproval: viaPlanApproval ?? false,
+		})
+		.trim();
+}
+
+/** ULTRACODE_NOTICE is the default ultracode notice for sessions with workflow tooling live. */
+export const ULTRACODE_NOTICE: string = renderUltracodeNotice({ workflowAvailable: true });
+
+/**
+ * Whether `text` contains the standalone keyword "ultracode" (lowercase,
+ * prose-delimited) in prose — never inside a code block, inline code span,
+ * or XML/HTML section.
+ */
+export function containsUltracode(text: string): boolean {
+	return keywordInProse(text, ULTRACODE_WORD);
+}
+
+/**
+ * Highlight every standalone "ultracode" in `text` for editor display with a
+ * violet -> magenta -> gold ripple (hue 280..40, wrapping through 360), chosen
+ * to stay distinct from the other three keywords' palettes: ultrathink is a
+ * full-spectrum rainbow, orchestrate is hue 150..280 (teal -> violet), and
+ * workflowz is hue 30..150 (amber -> green).
+ */
+export const highlightUltracode: KeywordHighlighter = createGradientHighlighter({
+	probe: /ultracode/,
+	highlight: magicKeywordRegex("ultracode", "g"),
+	stops: 14,
+	hue: t => (280 + t * 120) % 360,
+});

--- a/packages/coding-agent/src/prompts/system/ultracode-notice.md
+++ b/packages/coding-agent/src/prompts/system/ultracode-notice.md
@@ -1,0 +1,145 @@
+<system-notice>
+{{#if viaPlanApproval}}You approved a plan for execution with **ultracode**, which applies to THIS TURN. The user chose it from the plan review rather than typing the word, so do not tell them to say it.{{else}}The user's message above contains the **ultracode** keyword, which applies to THIS TURN.{{/if}}
+
+<effort>
+{{#if effortApplied}}The harness has already pinned this turn and every subagent it spawns to xhigh reasoning effort, clamped to each model's own ladder: a model topping out at high pins to high, and one with no effort control runs unchanged. Do not try to lower it, do not budget around it, and do not comment on it in your output.{{else}}This turn's effort target is xhigh, but `externalThinking` is on: native reasoning is switched off at the transport and the `think` tool is your reasoning surface instead. So spend the effort deliberately through that tool rather than assuming a hidden reasoning pass happened. Do not comment on this in your output.{{/if}}
+</effort>
+{{#if workflowAvailable}}
+<orchestration>
+A workflow structures work across many agents: to be comprehensive (decompose and cover in parallel), to be confident (independent perspectives and adversarial checks before committing), or to take on scale one context cannot hold (migrations, audits, broad sweeps). The script is where you encode that structure: what fans out, what verifies, what synthesizes.
+
+Ultracode IS the opt-in. Author and run a workflow for this task. The goal is the most exhaustive, correct answer you can produce; token cost is not a constraint. Work solo only on a conversational turn: a question answerable from context, a one-line lookup, or a single obvious edit.
+
+The right move is often **hybrid**: scout inline first (list the files, find the call sites, scope the diff) to discover the work-list, then fan out over it. You do not need to know the shape before the *task*, only before the *orchestration step*.
+
+Common single-phase workflows, chainable across turns:
+- **Understand** - parallel readers over relevant subsystems → structured map
+- **Design** - judge panel of N independent approaches → scored synthesis
+- **Review** - dimensions → find → adversarially verify (example below)
+- **Research** - multi-modal sweep → deep-read → synthesize
+- **Migrate** - discover sites → transform each (isolated) → verify
+
+For multi-phase work (understand → design → implement → review), run several in sequence, one per phase, reading each result before deciding the next. You stay in the loop; each workflow is one well-scoped fan-out.
+</orchestration>
+
+<script>
+Write the orchestration as a script in the `eval` tool. Plain JavaScript or Python, running in an async context, so `await` directly.
+
+**Zero-token glue.** Sorting, filtering, deduping, routing and control flow are ORDINARY CODE, not agent calls. Only spawn an agent for work that genuinely needs a model. Deterministic glue costs no tokens and cannot hallucinate, so push as much of the structure into plain code as you can.
+
+Helpers available in the script body:
+- `agent(prompt, {agent, label, schema, schemaMode, isolated, apply, merge, handle})` - spawn a subagent with its own clean context. Without `schema` it returns final text as a string. With `schema` (a JSON Schema) the subagent is forced into structured output and you get the validated object back, no parsing. A subagent that dies, aborts, or hits a hard (`+Nk!`/Goal Mode) budget ceiling THROWS - it never returns null - so wrap the call in try/catch wherever you want partial results instead of a dead cell. `agent` selects the type{{#if scoutAvailable}} (`scout` for read-only research){{/if}}. JS takes ONE trailing object; Python takes keyword arguments and spells `schemaMode` as `schema_mode`.
+- `parallel(thunks)` - run zero-arg thunks concurrently, results in input order. BARRIER: every thunk settles before it returns. If ANY thunk throws, `parallel()` re-raises the lowest-index error and discards the entire results array - every successful sibling is lost with it. So put the try/catch INSIDE each risky thunk, never around the `parallel()` call.
+- `pipeline(items, stage1, stage2, …)` - map items left-to-right through one-arg stages. BARRIER PER STAGE: every item clears stage N before any item enters stage N+1. Same all-or-nothing error rule as `parallel()`.
+- `phase(title)` - start a new phase; following status lines appear under it in the progress display.
+- `log(message)` - emit a progress line to the user.
+- `budget` - the turn's token target, read live. JS: every member is async, so `await budget.total()`, `await budget.spent()`, `await budget.remaining()`. Python: `budget.total` is a property, `budget.spent()` and `budget.remaining()` are methods. The awaited total is null when no target is set, and remaining is then Infinity. A plain `+Nk` target is advisory - nothing enforces it, so self-limit via `budget.remaining()`; only a hard `+Nk!` or Goal-Mode ceiling makes `agent()` refuse to spawn once spent reaches it.
+
+Differences from Claude Code's Workflow tool, so you do not write against an API that is not here: there is no `export const meta` block, no `args` global, and no nested `workflow()` call. Phase state is a single global set only by `phase()`, so inside `pipeline`/`parallel` stages concurrent calls race; prefer distinct `label` values there.{{#when MAX_CONCURRENCY ">" 0}} `parallel()` and `pipeline()` run at most {{MAX_CONCURRENCY}} thunks at once and queue the rest; a bare `Promise.all` of `agent()` calls does NOT queue, so fan out through the helpers.{{/when}} There is no runId resume, but the eval kernel is PERSISTENT: results already assigned to variables survive into the next `eval` call, so on a partial failure continue from those variables in a new cell instead of re-running the whole fan-out.
+</script>
+
+<barriers>
+BOTH helpers barrier. `pipeline()` is NOT a streaming construct: it runs one bounded pool per stage, so every item must clear stage N before any item starts stage N+1, and one slow item in stage 1 holds up everyone's stage 2.
+
+To get genuinely independent per-item progress, put the WHOLE per-item chain in one thunk and hand those to `parallel()`. Item A then reaches the end of its chain while item B is still on its first step:
+
+```js
+await parallel(items.map(item => async () => {
+  const found = await agent(findPrompt(item), { schema: FINDINGS });
+  return parallel((found?.findings ?? []).map(f => () => agent(verifyPrompt(f), { schema: VERDICT })));
+}));
+```
+
+Reach for `pipeline()` when you actually WANT the barrier - when stage N needs cross-item context from ALL of stage N-1:
+- dedup or merge across the full result set before expensive downstream work
+- early-exit on the total count ("0 findings → skip verification entirely")
+- stage N's prompt references "the other findings" for comparison
+
+Barrier latency is real: if the slowest finder takes 3x the fastest, a staged barrier wastes two thirds of the fast finders' time. That is an argument for the one-thunk-per-item shape above, NOT for `pipeline()`.
+
+Do not add a stage boundary merely to flatten/map/filter between calls - do that with ordinary code inside the thunk.
+</barriers>
+
+<patterns>
+The canonical multi-stage shape: one self-contained chain per dimension, all chains racing, each verifying as soon as its own review lands. The try/catch is load-bearing - without it a single dead verifier discards every dimension's work:
+
+```js
+const DIMENSIONS = [{key: "bugs", prompt: "..."}, {key: "perf", prompt: "..."}];
+const results = await parallel(DIMENSIONS.map(d => async () => {
+  try {
+    const review = await agent(d.prompt, { label: `review:${d.key}`, schema: FINDINGS_SCHEMA });
+    return await parallel((review?.findings ?? []).map(f => () =>
+      agent(`Adversarially verify: ${f.title}`, { label: `verify:${f.file}`, schema: VERDICT_SCHEMA })
+        .then(v => ({ ...f, verdict: v }))
+        .catch(() => ({ ...f, verdict: null }))));   // unverified, not refuted
+  } catch (e) {
+    log(`dimension ${d.key} failed: ${e}`);
+    return [];
+  }
+}));
+const confirmed = results.flat().filter(f => f.verdict?.verdict !== "REFUTED");
+```
+
+Loop-until-dry, for unknown-size discovery. Dedup against everything SEEN, not against what survived, or judge-rejected findings reappear every round and it never converges. `tryAgent` is the whole trick: `.catch()` converts the throw into the `null` that `.filter(Boolean)` is looking for, so one flaky subagent costs one vote instead of the entire round:
+
+```js
+const seen = new Set(), confirmed = [];
+let dry = 0;
+const tryAgent = (p, o) => agent(p, o).catch(e => (log(`agent failed: ${e}`), null));
+while (dry < 2) {
+  const found = (await parallel(FINDERS.map(f => () => tryAgent(f.prompt, { schema: BUGS }))))
+    .filter(Boolean).flatMap(r => r.bugs ?? []);
+  const fresh = found.filter(b => !seen.has(key(b)));   // plain code, not an agent
+  if (!fresh.length) { dry++; continue; }
+  dry = 0; fresh.forEach(b => seen.add(key(b)));
+  const judged = await parallel(fresh.map(b => () =>
+    parallel(["correctness", "security", "repro"].map(lens => () =>
+      tryAgent(`Judge "${b.desc}" via the ${lens} lens. Real?`, { schema: VERDICT })))
+      .then(vs => ({ b, real: vs.filter(Boolean).filter(v => v.real).length >= 2 }))));
+  confirmed.push(...judged.filter(v => v.real).map(v => v.b));
+}
+```
+
+Scale depth to an explicit budget. Await every member, and test the awaited total so an unset target does not run to the cap:
+
+```js
+const target = await budget.total();
+while (target && (await budget.remaining()) > 50_000) { /* ... */ }
+```
+
+Quality patterns, composable; pick what fits:
+- **Adversarial verify** - spawn N independent skeptics per finding, each prompted to REFUTE. Kill on majority. Stops plausible-but-wrong findings surviving.
+- **Perspective-diverse verify** - when a finding can fail in more than one way, give each verifier a distinct lens (correctness, security, perf, does-it-reproduce) instead of N identical refuters. Diversity catches what redundancy cannot.
+- **Judge panel** - generate N independent attempts from different angles, score with parallel judges, synthesize from the winner while grafting the best ideas from the runners-up. Beats one-attempt-iterated when the solution space is wide.
+- **Multi-modal sweep** - parallel agents each searching a different way (by container, by content, by entity, by time). Each is blind to what the others surface.
+- **Completeness critic** - a final agent asking "what is missing: a modality not run, a claim unverified, a source unread?" What it finds becomes the next round.
+- **No silent caps** - if you bound coverage (top-N, sampling, no-retry), `log()` what you dropped. Silent truncation reads as "covered everything" when it did not.
+
+For a review sweep, give each finder a DISTINCT angle rather than N general reviewers: line-by-line hunk scan; removed-behavior auditor (for every deleted line, name the invariant it enforced and find where it is re-established); cross-file tracer (callers and callees of every changed function); language-pitfall specialist; wrapper and proxy correctness. Then verify per distinct location, not per finder.
+</patterns>
+
+<adjudication>
+This is what makes adversarial verification actually work, and getting it wrong is why naive refutation panels destroy real findings. Verifiers return one of three verdicts, never a boolean:
+
+- **CONFIRMED** - you can name the inputs or state that trigger it and the wrong output or crash. Quote the line.
+- **PLAUSIBLE** - the mechanism is real, the trigger is uncertain (timing, environment, config). State what would confirm it.
+- **REFUTED** - factually wrong (the code does not say that) or guarded elsewhere. Quote the line that proves it.
+
+**PLAUSIBLE by default.** Do NOT refute a candidate for being "speculative" or "depends on runtime state" when that state is realistic: concurrency races, nil or undefined on a rare but reachable path (error handler, cold cache, missing optional field), falsy-zero treated as missing, off-by-one on a boundary the code does not exclude, retry storms and partial failures, a regex or allowlist that lost an anchor. Those are PLAUSIBLE, not REFUTED.
+
+**REFUTED only when constructible from the code**: factually wrong (quote the actual line), provably impossible (show the type, constant or invariant), already handled (cite the guard), or pure style with no observable effect.
+
+Choose the vote rule deliberately and say which you used. Recall mode: a single non-REFUTED vote carries the finding, for sweeps where a miss costs more than a false positive. Precision mode: a majority must refute to kill it, for reports a human will act on directly. Keep CONFIRMED and PLAUSIBLE; drop REFUTED.
+
+When synthesizing, have the synthesizer return decisions BY INDEX and never re-emit finding text, so it cannot quietly rewrite or invent findings. Rank correctness above cleanup, and CONFIRMED above PLAUSIBLE. Then assemble under three invariants: no silent drops while there is room, the displayed entry is the synthesizer's chosen representative with duplicates merged into it, and the summary describes the report you actually return.
+
+Scale to what was asked. "find any bugs" means a few finders and a single-vote verify. "thoroughly audit this" means a larger finder pool, a 3 to 5 vote adversarial pass, and a synthesis stage. Lean thorough for research, review and audit; lean brief for quick checks.
+</adjudication>
+{{else}}
+<orchestration>
+Ultracode normally makes this turn run as a multi-subagent workflow, but the `eval` and `task` tools are not both active right now, so there is no fan-out mechanism available. Do not pretend to run workflows you cannot run and do not describe imaginary subagents.
+
+Work solo, and spend the raised effort on depth instead: enumerate rather than sample, verify your own findings adversarially before reporting them, and state plainly what you could not check.
+</orchestration>
+{{/if}}
+</system-notice>

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -158,6 +158,7 @@ import { getMnemopiSessionState, type MnemopiSessionState, setMnemopiSessionStat
 import { containsOrchestrate, renderOrchestrateNotice } from "../modes/orchestrate";
 import { theme } from "../modes/theme/theme";
 import { parseTurnBudget } from "../modes/turn-budget";
+import { containsUltracode, renderUltracodeNotice } from "../modes/ultracode";
 import { containsUltrathink, ULTRATHINK_NOTICE } from "../modes/ultrathink";
 import { computeNonMessageTokens } from "../modes/utils/context-usage";
 import { containsWorkflow, renderWorkflowNotice } from "../modes/workflow";
@@ -321,6 +322,7 @@ import {
 import { ModelControls, type ModelControlsHost } from "./model-controls";
 import { isPrewalkPlanNudge, PrewalkCoordinator, type PrewalkCoordinatorHost } from "./prewalk";
 import {
+	attachQueuedMessageDeliveryEffect,
 	isAdvisorCard,
 	isDisplayableQueuedMessage,
 	isHiddenUserCompanion,
@@ -1122,7 +1124,11 @@ export class AgentSession {
 			textOutputCommitted: () => this.#textOutputCommitted,
 			thinkingLevel: () => this.thinkingLevel,
 			configuredThinkingLevel: () => this.configuredThinkingLevel(),
-			setThinkingLevel: level => this.setThinkingLevel(level),
+			// Retry fallback is an automated recovery, not the user reaching for the
+			// effort control: bypass the session wrapper's ultracode off-ramp so a
+			// transient fallback mid-ultracode-turn cannot drop the pending handback
+			// or the subagent floor.
+			setThinkingLevel: level => this.#models.setThinkingLevel(level),
 			thinkingLevelCeiling: () => this.#models.thinkingLevelCeiling,
 			isDisposed: () => this.#isDisposed,
 			isStreaming: () => this.isStreaming,
@@ -5469,15 +5475,134 @@ export class AgentSession {
 		return this.#providerBoundary.normalizeAgentMessageImages(message);
 	}
 
-	#magicKeywordEnabled(keyword: "orchestrate" | "ultrathink" | "workflow"): boolean {
+	#magicKeywordEnabled(keyword: "orchestrate" | "ultracode" | "ultrathink" | "workflow"): boolean {
 		return this.settings.get("magicKeywords.enabled") && this.settings.get(`magicKeywords.${keyword}`);
 	}
 
-	#createMagicKeywordNotices(text: string): CustomMessage[] {
-		const timestamp = Date.now();
+	/**
+	 * Live session facts the ultracode notice renders from.
+	 *
+	 * Ultracode carries the whole workflow contract, not a pointer to it, so the
+	 * notice states concrete API facts. Every one is read from THIS session rather
+	 * than hardcoded, because a notice that promises an agent type, a concurrency
+	 * cap, or an effort level the session will not deliver is worse than no notice:
+	 * the model writes code against it and the code fails.
+	 */
+	#ultracodeNoticeFacts(): {
+		workflowAvailable: boolean;
+		scoutAvailable: boolean;
+		effortApplied: boolean;
+		maxConcurrency: number;
+	} {
+		const tools = this.getActiveToolNames();
+		return {
+			workflowAvailable: tools.includes("task") && tools.includes("eval"),
+			scoutAvailable: this.#isScoutAvailable(),
+			// `externalThinking` swaps native reasoning for the think tool, and the
+			// transport honors that via `forceReasoningOff`, so the xhigh pin never
+			// reaches the wire. Say so rather than asserting it was applied.
+			effortApplied: !(
+				this.settings.get("externalThinking") &&
+				this.getEnabledToolNames().includes("think") &&
+				supportsExternalThinking(this.agent.state.model)
+			),
+			maxConcurrency: this.settings.get("task.maxConcurrency"),
+		};
+	}
+
+	/**
+	 * Arm ultracode for a turn the user opted into WITHOUT typing the word, and
+	 * return the notice to carry on that turn.
+	 *
+	 * The only caller is the plan review's "Approve and execute with ultracode".
+	 * Plan approval dispatches a SYNTHETIC prompt, and synthetic turns never run
+	 * `#createMagicKeywordNotices`, so a typed keyword cannot reach the execution
+	 * turn: without this, approving an ultracode-planned task silently executes at
+	 * normal effort, which is the phase that actually spawns the subagents.
+	 *
+	 * Two ordering constraints, both load-bearing:
+	 * - Call AFTER any model restore. `#exitPlanMode` restores the pre-plan model
+	 *   state, which would revert the pinned level (the same hazard documented for
+	 *   `executionModel` in interactive-mode).
+	 * - The armed turn MUST be synthetic, so the disarm `else` branch never runs
+	 *   against it. The next keyword-free USER turn hands the borrowed effort back,
+	 *   exactly as it would for a typed `ultracode` turn.
+	 */
+	armUltracodeTurn(): string {
+		this.settings.override("ultracode", true);
+		this.#models.beginUltracodeTurn();
+		return renderUltracodeNotice({ ...this.#ultracodeNoticeFacts(), viaPlanApproval: true });
+	}
+
+	/**
+	 * Apply any turn budget directive (`+50k`, `+50k!`) carried by `text`.
+	 *
+	 * Separate from `#createMagicKeywordNotices` because the two have different
+	 * gates: a budget directive is honored on any non-synthetic turn, while the
+	 * keywords are restricted to genuinely user-authored ones. Both call sites of
+	 * the keyword builder must call this too, or a budget typed into skill args
+	 * silently stops applying.
+	 */
+	#beginTurnBudgetFrom(text: string): void {
 		const turnBudget = parseTurnBudget(text);
 		this.sessionManager.beginTurnBudget(turnBudget?.total ?? null, turnBudget?.hard ?? false);
+	}
+
+	/**
+	 * Arm or disarm the per-turn ultracode state for a user-authored turn
+	 * carrying `text`.
+	 *
+	 * MUST run when that turn actually STARTS, not when it is enqueued: flipping
+	 * the state from a message queued during streaming would raise or drop the
+	 * in-flight turn's effort pin and subagent floor before the message is even
+	 * delivered. Direct prompts apply it inline; queued steers/follow-ups defer
+	 * it to delivery via {@link attachQueuedMessageDeliveryEffect}.
+	 *
+	 * Callers MUST restrict this to genuinely user-authored turns. The
+	 * unconditional `else` disarms the keyword, so running it on an
+	 * agent-initiated prompt clears an inherited `ultracode: true` before the
+	 * subagent holding it can spawn anything.
+	 */
+	#applyUltracodeTurnState(text: string): void {
+		if (this.#magicKeywordEnabled("ultracode") && containsUltracode(text)) {
+			// Runtime override layer only, never written to settings.json. It is how
+			// the task executor learns this turn's spawns run at the ultracode floor.
+			this.settings.override("ultracode", true);
+			this.#models.beginUltracodeTurn();
+		} else {
+			// A user turn without the word ends any ultracode turn before it: hand the
+			// borrowed effort back and force the flag to false (not merely cleared), so
+			// a persisted `ultracode: true` cannot leak through the override layer and
+			// silently re-arm every turn. Guarded on the merged value: writing the
+			// override rebuilds the settings merge and seeds the override map, which
+			// the common keyword-free turn must not pay for when the flag is already
+			// off.
+			if (this.settings.get("ultracode")) this.settings.override("ultracode", false);
+			this.#models.endUltracodeTurn();
+		}
+	}
+
+	/**
+	 * Build the hidden steering notices for whichever magic keywords `text`
+	 * carries. Pure builder — the ultracode arm/disarm side effects live in
+	 * {@link #applyUltracodeTurnState}, which the caller runs at turn start.
+	 */
+	#createMagicKeywordNotices(text: string): CustomMessage[] {
+		const timestamp = Date.now();
 		const keywordNotices: CustomMessage[] = [];
+		// "ultracode" steers only the turn that carries it, like the other three
+		// keywords. Saying it once does not arm the session; the word has to be
+		// repeated on any later message that wants the same treatment.
+		if (this.#magicKeywordEnabled("ultracode") && containsUltracode(text)) {
+			keywordNotices.push({
+				role: "custom",
+				customType: "ultracode-notice",
+				content: renderUltracodeNotice(this.#ultracodeNoticeFacts()),
+				display: false,
+				attribution: "user",
+				timestamp,
+			});
+		}
 		if (this.#magicKeywordEnabled("ultrathink") && containsUltrathink(text)) {
 			keywordNotices.push({
 				role: "custom",
@@ -5576,10 +5701,21 @@ export class AgentSession {
 		// Expand file-based prompt templates if requested
 		const expandedText = expandPromptTemplates ? expandPromptTemplate(text, [...this.#promptTemplates]) : text;
 
-		// Magic keywords ("ultrathink", "orchestrate"): append hidden system notices after the
-		// user's message that steer this turn. User-authored prompts only — synthetic /
-		// agent-initiated turns never trigger them.
-		const keywordNotices = options?.synthetic ? [] : this.#createMagicKeywordNotices(expandedText);
+		// Turn budget directives (`+50k`, `+50k!`) are honored on every non-synthetic
+		// turn. They are not keywords and are deliberately outside the gate below.
+		if (!options?.synthetic) this.#beginTurnBudgetFrom(expandedText);
+
+		// Magic keywords ("ultracode", "ultrathink", "orchestrate", "workflowz"): append
+		// hidden system notices after the user's message that steer this turn.
+		// User-authored prompts only — and `synthetic` alone does not express that.
+		// Three agent-initiated callers reach prompt() with `attribution: "agent"` and
+		// no `synthetic` flag: a subagent's own task text (task/executor.ts), the
+		// agentic commit session, and the agent dashboard. Running keywords there arms
+		// a turn the user never marked, and runs ultracode's disarm `else` on a
+		// subagent that inherited `ultracode: true`, silently dropping the xhigh floor
+		// for everything it goes on to spawn.
+		const userAuthoredTurn = !options?.synthetic && options?.attribution !== "agent";
+		const keywordNotices = userAuthoredTurn ? this.#createMagicKeywordNotices(expandedText) : [];
 
 		// A user-initiated prompt (typed message or the `.`/`c` continue shortcut)
 		// re-enables advisor auto-resume that a prior user interrupt suppressed.
@@ -5603,13 +5739,28 @@ export class AgentSession {
 			for (const notice of keywordNotices) {
 				await this.#queueCustomMessage(notice, streamingBehavior);
 			}
+			// The ultracode arm/disarm belongs to the turn that DELIVERS this
+			// message, not to the enqueue: flipping it here would yank the effort
+			// pin and the subagent floor out from under the in-flight turn, and a
+			// message later dequeued or handed back to the editor would leave the
+			// flip behind with no turn. It rides the queued message instead and
+			// fires when the loop commits the message into the live context.
+			const applyKeywordTurnState = userAuthoredTurn
+				? () => this.#applyUltracodeTurnState(expandedText)
+				: undefined;
 			if (streamingBehavior === "followUp") {
-				await this.#queueUserMessage(expandedText, options?.images, "followUp");
+				await this.#queueUserMessage(expandedText, options?.images, "followUp", applyKeywordTurnState);
 			} else {
-				await this.#queueUserMessage(expandedText, options?.images, "steer");
+				await this.#queueUserMessage(expandedText, options?.images, "steer", applyKeywordTurnState);
 			}
 			return true;
 		}
+
+		// Enqueue IS turn start on the direct path: apply the keyword turn state
+		// before dispatch, so everything that reads it during turn setup
+		// (`applyAutoThinkingLevel`, the task executor's spawn floor) sees this
+		// turn's state.
+		if (userAuthoredTurn) this.#applyUltracodeTurnState(expandedText);
 
 		// Skip eager preludes when the user has already queued a directive
 		const hasPendingUserDirective = this.#toolChoiceQueue.inspect().includes("user-force");
@@ -5704,6 +5855,7 @@ export class AgentSession {
 						.join("");
 
 		let keywordNotices: CustomMessage[] = [];
+		let applyKeywordTurnState: (() => void) | undefined;
 		if (message.customType === SKILL_PROMPT_MESSAGE_TYPE && message.attribution === "user") {
 			const details = message.details;
 			let skillName: string | undefined;
@@ -5712,7 +5864,14 @@ export class AgentSession {
 				if ("name" in details && typeof details.name === "string") skillName = details.name;
 				if ("args" in details && typeof details.args === "string") skillArgs = details.args;
 			}
+			// This branch already restricts itself to user-attributed skill prompts,
+			// so it is a user-authored turn by construction.
+			this.#beginTurnBudgetFrom(skillArgs);
 			keywordNotices = this.#createMagicKeywordNotices(skillArgs);
+			// Same enqueue-vs-delivery split as prompt(): a queued skill prompt
+			// applies the ultracode turn state when it is delivered, a direct one
+			// right before dispatch.
+			applyKeywordTurnState = () => this.#applyUltracodeTurnState(skillArgs);
 			this.maybeStartTitleGeneration(
 				skillPromptTitleInput({
 					name: skillName,
@@ -5729,7 +5888,7 @@ export class AgentSession {
 			for (const notice of keywordNotices) {
 				await this.#queueCustomMessage(notice, streamingBehavior);
 			}
-			await this.#queueCustomMessage(message, streamingBehavior, options.queueChipText);
+			await this.#queueCustomMessage(message, streamingBehavior, options.queueChipText, applyKeywordTurnState);
 			return;
 		}
 		if (this.isStreaming) {
@@ -5739,9 +5898,11 @@ export class AgentSession {
 			for (const notice of keywordNotices) {
 				await this.#queueCustomMessage(notice, streamingBehavior);
 			}
-			await this.#queueCustomMessage(message, streamingBehavior, options?.queueChipText);
+			await this.#queueCustomMessage(message, streamingBehavior, options?.queueChipText, applyKeywordTurnState);
 			return;
 		}
+
+		applyKeywordTurnState?.();
 
 		const customMessage: CustomMessage<T> = {
 			role: "custom",
@@ -6241,6 +6402,7 @@ export class AgentSession {
 		text: string,
 		images: ImageContent[] | undefined,
 		mode: "steer" | "followUp",
+		onDeliver?: () => void,
 	): Promise<void> {
 		// A queued user message (RPC/SDK/collab steer or follow-up, or a typed message
 		// while streaming) is a deliberate resume; re-enable advisor auto-resume that
@@ -6257,23 +6419,19 @@ export class AgentSession {
 			? await this.#buildImageDescriptionNotice(normalizedImages)
 			: undefined;
 		this.#allowQueuedMessageDrainRetry();
+		const message: AgentMessage =
+			mode === "followUp"
+				? { role: "user", content, attribution: "user", timestamp: Date.now() }
+				: { role: "user", content, steering: true, attribution: "user", timestamp: Date.now() };
+		// Turn-start side effects (the ultracode arm/disarm) ride the message and
+		// fire when the loop commits it into the live context, never at enqueue.
+		if (onDeliver) attachQueuedMessageDeliveryEffect(message, onDeliver);
 		if (mode === "followUp") {
 			if (imageDescriptionNotice) this.agent.followUp(imageDescriptionNotice);
-			this.agent.followUp({
-				role: "user",
-				content,
-				attribution: "user",
-				timestamp: Date.now(),
-			});
+			this.agent.followUp(message);
 		} else {
 			if (imageDescriptionNotice) this.agent.steer(imageDescriptionNotice);
-			this.agent.steer({
-				role: "user",
-				content,
-				steering: true,
-				attribution: "user",
-				timestamp: Date.now(),
-			});
+			this.agent.steer(message);
 		}
 		this.#scheduleIdleQueueDrain();
 	}
@@ -6464,6 +6622,7 @@ export class AgentSession {
 		message: Pick<CustomMessage<T>, "customType" | "content" | "display" | "details" | "attribution">,
 		deliverAs: "steer" | "followUp",
 		queueChipText?: string,
+		onDeliver?: () => void,
 	): Promise<void> {
 		const details =
 			queueChipText !== undefined
@@ -6485,6 +6644,9 @@ export class AgentSession {
 			timestamp: Date.now(),
 		};
 		const normalizedAppMessage = await this.#normalizeAgentMessageImages(appMessage);
+		// Turn-start side effects (the ultracode arm/disarm for a queued skill
+		// prompt) ride the message and fire at delivery, never at enqueue.
+		if (onDeliver) attachQueuedMessageDeliveryEffect(normalizedAppMessage, onDeliver);
 		this.#allowQueuedMessageDrainRetry();
 		if (deliverAs === "followUp") {
 			this.agent.followUp(normalizedAppMessage);
@@ -7250,8 +7412,20 @@ export class AgentSession {
 		return this.#models.getAvailableModels();
 	}
 
-	/** Selects the session thinking level and optionally persists it as the default. */
+	/**
+	 * Selects the session thinking level and optionally persists it as the default.
+	 *
+	 * Every caller of this wrapper is an explicit user selection (model/settings
+	 * selector, RPC `set_thinking_level`, ACP, extension runtimes), so it takes
+	 * the same ultracode off-ramp as {@link cycleThinkingLevel}: drop the pending
+	 * restore so the end-of-turn handback cannot silently overwrite the level the
+	 * user just picked, and drop the subagent floor with it. Internal level
+	 * changes (retry fallback, begin/endUltracodeTurn, transcript restore) call
+	 * ModelControls directly and stay exempt.
+	 */
 	setThinkingLevel(level: ConfiguredThinkingLevel | undefined, persist: boolean = false): void {
+		this.#models.forgetUltracodeRestore();
+		if (this.settings.get("ultracode")) this.settings.override("ultracode", false);
 		this.#models.setThinkingLevel(level, persist);
 	}
 

--- a/packages/coding-agent/src/session/model-controls.ts
+++ b/packages/coding-agent/src/session/model-controls.ts
@@ -71,6 +71,11 @@ export class ModelControls {
 	readonly #thinkingLevelCeiling: Effort | undefined;
 	#autoThinking = false;
 	#autoResolvedLevel: Effort | undefined;
+	/**
+	 * Level to hand back once the ultracode turn ends, captured before the pin.
+	 * `undefined` means no ultracode turn is in flight, which is the common case.
+	 */
+	#levelBeforeUltracode: ConfiguredThinkingLevel | undefined;
 	#serviceTierByFamily: ServiceTierByFamily;
 
 	constructor(
@@ -501,8 +506,18 @@ export class ModelControls {
 	 * auto writes its provisional level plus `configured: "auto"` immediately,
 	 * giving external readers an authoritative selection receipt before the next
 	 * user turn. Later classifications persist only changed concrete resolutions.
+	 *
+	 * `configuredReceipt` overrides the `configured` value written to the session
+	 * record for a concrete level. {@link beginUltracodeTurn} passes the
+	 * borrowed-FROM level so the turn-scoped pin never becomes the session's own
+	 * configured level on disk: a process killed mid-ultracode-turn must resume
+	 * at the pre-ultracode level, not stranded at xhigh with no handback state.
 	 */
-	setThinkingLevel(level: ConfiguredThinkingLevel | undefined, persist: boolean = false): void {
+	setThinkingLevel(
+		level: ConfiguredThinkingLevel | undefined,
+		persist: boolean = false,
+		configuredReceipt?: ConfiguredThinkingLevel,
+	): void {
 		if (level === AUTO_THINKING) {
 			const provisional = clampThinkingLevelToCeiling(
 				this.#model,
@@ -546,7 +561,7 @@ export class ModelControls {
 
 		if (isChanging) {
 			this.#host.clearInheritedProviderPromptCacheKey();
-			this.#host.sessionManager.appendThinkingLevelChange(effectiveLevel, effectiveLevel);
+			this.#host.sessionManager.appendThinkingLevelChange(effectiveLevel, configuredReceipt ?? effectiveLevel);
 			if (persist && effectiveLevel !== undefined && effectiveLevel !== ThinkingLevel.Off) {
 				this.#host.settings.set("defaultThinkingLevel", effectiveLevel);
 			}
@@ -565,6 +580,14 @@ export class ModelControls {
 
 	/**
 	 * Cycle to next thinking level: off → auto → minimal..max → off.
+	 *
+	 * This is the user's own effort control, so it also takes precedence over an
+	 * ultracode turn in flight. {@link beginUltracodeTurn} borrows the level and
+	 * {@link endUltracodeTurn} hands it back on the next keyword-free turn, which
+	 * would silently discard a level the user picked in between. Reaching for this
+	 * control is an unambiguous "I want a different effort", so it drops the
+	 * pending restore and keeps the choice.
+	 *
 	 * @returns New selector, or undefined if model doesn't support thinking
 	 */
 	cycleThinkingLevel(): ConfiguredThinkingLevel | undefined {
@@ -582,8 +605,66 @@ export class ModelControls {
 		const nextLevel = levels[nextIndex];
 		if (!nextLevel) return undefined;
 
+		// Reaching for the effort control mid-ultracode-turn is an explicit choice:
+		// keep it, and drop the restore that would otherwise overwrite it when the
+		// turn ends.
+		this.forgetUltracodeRestore();
+		if (this.#host.settings.get("ultracode")) this.#host.settings.override("ultracode", false);
 		this.setThinkingLevel(nextLevel);
 		return nextLevel;
+	}
+
+	/**
+	 * Raise this TURN to the ultracode effort ({@link Effort.XHigh}), remembering
+	 * the level to hand back in {@link endUltracodeTurn}.
+	 *
+	 * Stronger than "ultrathink", which only biases the auto-thinking classifier
+	 * and therefore does nothing at all when auto-thinking is off. Ultracode sets
+	 * a concrete level, so it lands either way, and handing `setThinkingLevel` a
+	 * concrete effort clears `#autoThinking` on purpose: a classifier that still
+	 * runs is a classifier that can still lower the effort mid-turn.
+	 *
+	 * Turn-scoped, not session-scoped: the keyword steers the message that
+	 * carries it and nothing after it. `setThinkingLevel` is called without
+	 * `persist`, so `defaultThinkingLevel` is never rewritten, and the hard
+	 * `#thinkingLevelCeiling` still wins because that setter re-clamps to it.
+	 */
+	beginUltracodeTurn(): void {
+		const model = this.#model;
+		if (!model?.reasoning) return;
+		// Reasoning models with no controllable effort surface (devin-agent Cascade
+		// routes effort via sibling model ids) have nothing to pin.
+		if (getSupportedEfforts(model).length === 0) return;
+		// XHigh is the target, not an assumption: clamp it onto the ladder this model
+		// actually exposes, so one topping out at `high` pins to high.
+		const effort = clampAutoThinkingEffort(model, Effort.XHigh);
+		if (effort === undefined) return;
+		// Capture what to restore ONCE. Repeating the keyword on consecutive turns
+		// must not overwrite the saved level with xhigh and strand the session there.
+		if (this.#levelBeforeUltracode === undefined) {
+			this.#levelBeforeUltracode = this.configuredThinkingLevel() ?? ThinkingLevel.Off;
+		}
+		// The borrowed-from level is also the session record's `configured` receipt:
+		// the handback state lives in process memory only, so persisting the pin as
+		// the configured level would strand a killed-and-resumed session at xhigh.
+		this.setThinkingLevel(effort, false, this.#levelBeforeUltracode);
+	}
+
+	/**
+	 * Hand back the level {@link beginUltracodeTurn} borrowed, restoring `auto`
+	 * when that is what was running before. A no-op when the keyword never fired,
+	 * so ordinary turns cost nothing.
+	 */
+	endUltracodeTurn(): void {
+		const previous = this.#levelBeforeUltracode;
+		if (previous === undefined) return;
+		this.#levelBeforeUltracode = undefined;
+		this.setThinkingLevel(previous);
+	}
+
+	/** Forget the pending restore, leaving the current level alone. */
+	forgetUltracodeRestore(): void {
+		this.#levelBeforeUltracode = undefined;
 	}
 
 	/** Timeout (ms) for per-turn auto-thinking classification before falling back. */
@@ -604,7 +685,13 @@ export class ModelControls {
 		if (getSupportedEfforts(model).length === 0) return;
 
 		let resolved: Effort | undefined;
-		if (this.#host.magicKeywordEnabled("ultrathink") && containsUltrathink(promptText)) {
+		if (this.#host.settings.get("ultracode")) {
+			// This turn carries the ultracode keyword and beginUltracodeTurn already
+			// set the concrete level. If anything re-enabled auto since then, resolve
+			// straight back to that level instead of letting the difficulty classifier
+			// walk the effort down mid-turn.
+			resolved = clampAutoThinkingEffort(model, Effort.XHigh);
+		} else if (this.#host.magicKeywordEnabled("ultrathink") && containsUltrathink(promptText)) {
 			// The user explicitly asked for maximum thinking; bypass the classifier
 			// (and the `providers.autoThinkingMaxEffort` ceiling) and jump straight
 			// to the highest supported level for this model.

--- a/packages/coding-agent/src/session/queued-messages.ts
+++ b/packages/coding-agent/src/session/queued-messages.ts
@@ -1,4 +1,4 @@
-import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
+import { type AgentMessage, ASIDE_MESSAGE_COMMIT } from "@oh-my-pi/pi-agent-core";
 import type { AssistantMessage, ImageContent } from "@oh-my-pi/pi-ai";
 import type { RestoredQueuedMessage } from "./agent-session-types";
 import { type CustomMessage, readQueueChipText } from "./messages";
@@ -62,8 +62,18 @@ export function isUserQueuedMessage(message: AgentMessage): boolean {
 	return message.role === "custom" && message.attribution === "user" && message.display !== false;
 }
 
-/** Hidden magic-keyword notices queued alongside a user prompt. */
+/**
+ * Hidden magic-keyword notices queued alongside a user prompt.
+ *
+ * Every `customType` pushed by `#createMagicKeywordNotices` MUST appear here.
+ * A notice that is missing is invisible to both `isHiddenUserCompanion` and
+ * `isUserQueuedMessage` (which requires `display !== false`), so dequeue and
+ * clear walk straight past it: the user's prompt leaves the queue and the
+ * hidden notice stays behind, uncounted, to be delivered ahead of some later
+ * unrelated turn.
+ */
 export const MAGIC_KEYWORD_NOTICE_TYPES: Record<string, true> = {
+	"ultracode-notice": true,
 	"ultrathink-notice": true,
 	"orchestrate-notice": true,
 	"workflow-notice": true,
@@ -91,6 +101,20 @@ export function queueChipText(message: AgentMessage): string {
 	const text = queuedTextContent(message) ?? "";
 	if (text) return text;
 	return queuedImageContent(message) ? "[Image]" : "";
+}
+
+/**
+ * Attach a side effect that runs exactly once, when the queued message is
+ * committed into the live context (the agent loop's delivery point, before the
+ * provider call that first includes the message).
+ *
+ * This is for state that must flip at TURN START rather than at enqueue: the
+ * ultracode arm/disarm rides the queued user message so a steer/follow-up
+ * queued during streaming cannot flip the effort pin under the in-flight turn,
+ * and a message that is dequeued or handed back to the editor never fires it.
+ */
+export function attachQueuedMessageDeliveryEffect(message: AgentMessage, effect: () => void): void {
+	Object.defineProperty(message, ASIDE_MESSAGE_COMMIT, { configurable: true, value: effect });
 }
 
 /** Converts a queued user message to editor-restorable content. */

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -8,6 +8,7 @@ import path from "node:path";
 import type { AgentEvent, AgentIdentity, AgentMessage, AgentTelemetryConfig } from "@oh-my-pi/pi-agent-core";
 import { EventLoopKeepalive, recordHandoff, resolveTelemetry } from "@oh-my-pi/pi-agent-core";
 import type { Api, Model, ServiceTierByFamily, Usage } from "@oh-my-pi/pi-ai";
+import { Effort, THINKING_EFFORTS } from "@oh-my-pi/pi-ai";
 import { logger, popLoopPhase, prompt, pushLoopPhase, untilAborted } from "@oh-my-pi/pi-utils";
 import { ASYNC_JOB_MANAGER_SHUTDOWN_REASON, AsyncJobManager } from "../async";
 import type { Rule } from "../capability/rule";
@@ -50,7 +51,13 @@ import type { AuthStorage } from "../session/auth-storage";
 import { SKILL_PROMPT_MESSAGE_TYPE, USER_INTERRUPT_LABEL } from "../session/messages";
 import { SessionManager } from "../session/session-manager";
 import { truncateTail } from "../session/streaming-output";
-import { type ConfiguredThinkingLevel, prewalkWouldBeNoop, resolveTaskEffortLevel, type TaskEffort } from "../thinking";
+import {
+	type ConfiguredThinkingLevel,
+	clampAutoThinkingEffort,
+	prewalkWouldBeNoop,
+	resolveTaskEffortLevel,
+	type TaskEffort,
+} from "../thinking";
 import type { ContextFileEntry, ToolSession } from "../tools";
 import { resolveEvalBackends } from "../tools/eval-backends";
 import { isIrcEnabled } from "../tools/hub";
@@ -3011,11 +3018,47 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 			// through to the normal selectors below.
 			// The ceiling outlives initial resolution: it rides into the session so
 			// retry-fallback recovery can never clamp effort back up past it.
-			const spawnEffortCeiling = options.effort !== undefined ? settings.get("task.maxEffort") : undefined;
+			// Ultracode pins every spawn to xhigh while it is active, deliberately
+			// overriding the agent definition's own pinned effort (scout's `medium`,
+			// task's `auto`), any explicit `:level` suffix, and the caller's
+			// `effort`. The model is the only thing allowed to move it.
+			//
+			// `clampAutoThinkingEffort` is the same helper the session-side pin in
+			// `ModelControls.beginUltracodeTurn` uses, so a subagent and its parent
+			// resolve xhigh identically. It is used here INSTEAD of
+			// `resolveTaskEffortLevel(model, "hi", Effort.XHigh)`, which throws
+			// `RangeError` when a model's ladder sits entirely above the ceiling: a
+			// model exposing only `max` would have crashed the spawn outright, and
+			// the message would have blamed `task.maxEffort` for a ceiling ultracode
+			// supplied. Clamping instead lands that model on `max` and a model
+			// topping out at `high` on `high`, while a model with no controllable
+			// effort surface returns undefined and falls through to the normal
+			// selectors below.
+			//
+			// `task.maxEffort` must not drag the pin down either, so a ceiling below
+			// the pinned level is raised to exactly that level for the ride into the
+			// session. It is raised to `ultracodeEffortLevel` rather than to a
+			// hardcoded xhigh so the ceiling can never sit BELOW the level it is
+			// escorting: on a model whose ladder is entirely above xhigh (max only)
+			// the pin resolves to `max`, and a hardcoded xhigh ceiling would leave
+			// retry-fallback recovery re-clamping that spawn to a level the model
+			// does not expose. Non-ultracode spawns keep their exact previous
+			// ceiling behaviour.
+			const ultracodeEffortLevel = settings.get("ultracode")
+				? clampAutoThinkingEffort(model, Effort.XHigh)
+				: undefined;
+			const configuredEffortCeiling = options.effort !== undefined ? settings.get("task.maxEffort") : undefined;
+			const spawnEffortCeiling =
+				ultracodeEffortLevel !== undefined &&
+				configuredEffortCeiling !== undefined &&
+				THINKING_EFFORTS.indexOf(configuredEffortCeiling) < THINKING_EFFORTS.indexOf(ultracodeEffortLevel)
+					? ultracodeEffortLevel
+					: configuredEffortCeiling;
 			const effortLevel =
-				options.effort !== undefined
+				ultracodeEffortLevel ??
+				(options.effort !== undefined
 					? resolveTaskEffortLevel(model, options.effort, spawnEffortCeiling)
-					: undefined;
+					: undefined);
 			if (model) {
 				const displayLevel = effortLevel ?? (explicitThinkingLevel ? resolvedThinkingLevel : undefined);
 				progress.resolvedModel =
@@ -3023,9 +3066,9 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 						? formatModelSelectorValue(formatModelStringWithRouting(model), displayLevel)
 						: formatModelStringWithRouting(model);
 			}
-			// Precedence: caller `effort` > explicit `:level` suffix on the resolved
-			// model pattern > agent-definition default (e.g. task's `auto`) >
-			// pattern-derived level.
+			// Precedence: ultracode floor > caller `effort` > explicit `:level` suffix
+			// on the resolved model pattern > agent-definition default (e.g. task's
+			// `auto`) > pattern-derived level.
 			const effectiveThinkingLevel =
 				effortLevel ?? (explicitThinkingLevel ? resolvedThinkingLevel : (thinkingLevel ?? resolvedThinkingLevel));
 			resolvedAt = performance.now();

--- a/packages/coding-agent/test/agent-session-magic-keywords.test.ts
+++ b/packages/coding-agent/test/agent-session-magic-keywords.test.ts
@@ -3,7 +3,7 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { type } from "@oh-my-pi/omptype";
-import { Agent, type AgentTool } from "@oh-my-pi/pi-agent-core";
+import { Agent, type AgentMessage, type AgentTool } from "@oh-my-pi/pi-agent-core";
 import { Effort } from "@oh-my-pi/pi-ai";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import * as autoThinkingClassifier from "@oh-my-pi/pi-coding-agent/auto-thinking/classifier";
@@ -11,6 +11,12 @@ import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import {
+	type CustomMessage,
+	SKILL_PROMPT_MESSAGE_TYPE,
+	type SkillPromptDetails,
+} from "@oh-my-pi/pi-coding-agent/session/messages";
+import { isHiddenUserCompanion, MAGIC_KEYWORD_NOTICE_TYPES } from "@oh-my-pi/pi-coding-agent/session/queued-messages";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import { AUTO_THINKING } from "@oh-my-pi/pi-coding-agent/thinking";
 import { removeWithRetries } from "@oh-my-pi/pi-utils";
@@ -217,5 +223,346 @@ describe("AgentSession magic keyword settings", () => {
 		expect(noticeIdx).toBeGreaterThanOrEqual(0);
 		expect(userIdx).toBeGreaterThanOrEqual(0);
 		expect(noticeIdx).toBeLessThan(userIdx);
+	});
+
+	it("appends the ultracode notice and arms the ultracode turn flag", async () => {
+		const created = await createMagicKeywordSession(modelRegistry);
+		session = created.session;
+
+		expect(created.settings.get("ultracode")).toBe(false);
+		const promptSpy = vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined);
+
+		await session.prompt("please ultracode this refactor");
+
+		const promptMessages = promptSpy.mock.calls[0]![0] as unknown as Array<{
+			attribution?: string;
+			customType?: string;
+			display?: boolean;
+		}>;
+		expect(promptMessages.map(message => message.customType).filter(Boolean)).toEqual(["ultracode-notice"]);
+		const notice = promptMessages.find(message => message.customType === "ultracode-notice");
+		expect(notice?.display).toBe(false);
+		expect(notice?.attribution).toBe("user");
+		// The override is turn state, not a session preference: armed by the
+		// carrying turn, cleared by the next keyword-free user turn.
+		expect(created.settings.get("ultracode")).toBe(true);
+	});
+
+	it("ships the orchestration contract in the ultracode notice when the tools are live", async () => {
+		const created = await createMagicKeywordSession(modelRegistry);
+		session = created.session;
+
+		const promptSpy = vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined);
+
+		await session.prompt("please ultracode this refactor");
+
+		const promptMessages = promptSpy.mock.calls[0]![0] as unknown as Array<{
+			content?: string;
+			customType?: string;
+		}>;
+		const notice = promptMessages.find(message => message.customType === "ultracode-notice")?.content ?? "";
+		// The keyword promises a dynamic workflow, so the API to author one has to
+		// be in the notice; naming it without carrying it is the whole defect.
+		expect(notice).toContain("agent(");
+		expect(notice).toContain("parallel(");
+		expect(notice).toContain("THIS TURN");
+	});
+
+	it("keeps ultracode on but drops the fan-out contract when eval is inactive", async () => {
+		const created = await createMagicKeywordSession(modelRegistry, [mockTaskTool]);
+		session = created.session;
+
+		const promptSpy = vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined);
+
+		await session.prompt("please ultracode this refactor");
+
+		const promptMessages = promptSpy.mock.calls[0]![0] as unknown as Array<{
+			content?: string;
+			customType?: string;
+		}>;
+		// Unlike workflowz the notice is NOT skipped: the effort pin still applies.
+		expect(promptMessages.map(message => message.customType).filter(Boolean)).toEqual(["ultracode-notice"]);
+		const notice = promptMessages.find(message => message.customType === "ultracode-notice")?.content ?? "";
+		expect(notice).toContain("xhigh");
+		expect(notice).not.toContain("agent(");
+		expect(notice).not.toContain("parallel(");
+		expect(created.settings.get("ultracode")).toBe(true);
+	});
+
+	it("does not carry the ultracode notice into a later keyword-free turn", async () => {
+		const created = await createMagicKeywordSession(modelRegistry);
+		session = created.session;
+
+		const promptSpy = vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined);
+
+		await session.prompt("please ultracode this refactor");
+		await session.prompt("now do the next step");
+
+		// Per-turn: the word steers the message that carries it and nothing after.
+		const secondTurn = promptSpy.mock.calls[1]![0] as unknown as Array<{ customType?: string }>;
+		expect(secondTurn.map(message => message.customType).filter(Boolean)).toEqual([]);
+		expect(created.settings.get("ultracode")).toBe(false);
+	});
+
+	it("re-arms whenever the word comes back", async () => {
+		const created = await createMagicKeywordSession(modelRegistry);
+		session = created.session;
+
+		const promptSpy = vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined);
+
+		await session.prompt("please ultracode this refactor");
+		await session.prompt("now do the next step");
+		await session.prompt("ultracode the follow-up too");
+
+		const thirdTurn = promptSpy.mock.calls[2]![0] as unknown as Array<{ customType?: string }>;
+		expect(thirdTurn.map(message => message.customType).filter(Boolean)).toEqual(["ultracode-notice"]);
+		expect(created.settings.get("ultracode")).toBe(true);
+	});
+
+	it("refuses to let a persisted ultracode:true arm a keyword-free turn", async () => {
+		const created = await createMagicKeywordSession(modelRegistry);
+		session = created.session;
+
+		created.settings.set("ultracode", true);
+		const promptSpy = vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined);
+
+		await session.prompt("just a normal message");
+
+		// The flag is turn state, not a preference. A stale persisted true must not
+		// silently run every turn at xhigh with a workflow contract attached.
+		const promptMessages = promptSpy.mock.calls[0]![0] as unknown as Array<{ customType?: string }>;
+		expect(promptMessages.map(message => message.customType).filter(Boolean)).toEqual([]);
+		expect(created.settings.get("ultracode")).toBe(false);
+	});
+
+	it("appends a single ultracode notice when the keyword repeats while the flag is set", async () => {
+		const created = await createMagicKeywordSession(modelRegistry);
+		session = created.session;
+
+		created.settings.override("ultracode", true);
+		const promptSpy = vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined);
+
+		await session.prompt("ultracode this one too");
+
+		const promptMessages = promptSpy.mock.calls[0]![0] as unknown as Array<{ customType?: string }>;
+		expect(promptMessages.map(message => message.customType).filter(Boolean)).toEqual(["ultracode-notice"]);
+	});
+
+	it("honors the per-keyword ultracode toggle", async () => {
+		const created = await createMagicKeywordSession(modelRegistry);
+		session = created.session;
+
+		created.settings.set("magicKeywords.ultracode", false);
+		const promptSpy = vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined);
+
+		await session.prompt("please ultracode this refactor");
+
+		const promptMessages = promptSpy.mock.calls[0]![0] as unknown as Array<{ customType?: string }>;
+		expect(promptMessages.map(message => message.customType).filter(Boolean)).toEqual([]);
+		expect(created.settings.get("ultracode")).toBe(false);
+	});
+
+	it("does not turn ultracode on when magic keywords are disabled outright", async () => {
+		const created = await createMagicKeywordSession(modelRegistry);
+		session = created.session;
+
+		created.settings.set("magicKeywords.enabled", false);
+		const promptSpy = vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined);
+
+		await session.prompt("please ultracode this refactor");
+
+		const promptMessages = promptSpy.mock.calls[0]![0] as unknown as Array<{ customType?: string }>;
+		expect(promptMessages.map(message => message.customType).filter(Boolean)).toEqual([]);
+		expect(created.settings.get("ultracode")).toBe(false);
+	});
+
+	it("never lets a synthetic turn trigger the ultracode keyword", async () => {
+		const created = await createMagicKeywordSession(modelRegistry);
+		session = created.session;
+
+		const promptSpy = vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined);
+
+		await session.prompt("please ultracode this refactor", { synthetic: true });
+
+		const promptMessages = promptSpy.mock.calls[0]![0] as unknown as Array<{ customType?: string }>;
+		expect(promptMessages.map(message => message.customType).filter(Boolean)).toEqual([]);
+		expect(created.settings.get("ultracode")).toBe(false);
+	});
+
+	// `synthetic` alone is not the gate: three agent-initiated callers reach
+	// prompt() with `attribution: "agent"` and no synthetic flag — notably a
+	// subagent's own task text in task/executor.ts.
+	it("never lets an agent-authored turn trigger the ultracode keyword", async () => {
+		const created = await createMagicKeywordSession(modelRegistry);
+		session = created.session;
+
+		const promptSpy = vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined);
+
+		await session.prompt("please ultracode this refactor", { attribution: "agent" });
+
+		const promptMessages = promptSpy.mock.calls[0]![0] as unknown as Array<{ customType?: string }>;
+		expect(promptMessages.map(message => message.customType).filter(Boolean)).toEqual([]);
+		expect(created.settings.get("ultracode")).toBe(false);
+	});
+
+	// The depth-2 effort hazard: a subagent inherits `ultracode: true`, and its
+	// own task prompt (agent-authored, no keyword in the text) must not hit the
+	// disarm branch and clear the flag before the subagent can spawn anything —
+	// otherwise grandchild spawns silently drop off the xhigh floor the notice
+	// promises.
+	it("leaves an inherited ultracode flag alone on an agent-authored turn", async () => {
+		const created = await createMagicKeywordSession(modelRegistry);
+		session = created.session;
+
+		created.settings.override("ultracode", true);
+		const promptSpy = vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined);
+
+		await session.prompt("implement the thing described in the task brief", { attribution: "agent" });
+
+		expect(promptSpy).toHaveBeenCalled();
+		expect(created.settings.get("ultracode")).toBe(true);
+	});
+
+	// A keyword-free USER turn must still disarm, or the keyword would silently
+	// become session-scoped again.
+	it("still disarms ultracode on a keyword-free user turn", async () => {
+		const created = await createMagicKeywordSession(modelRegistry);
+		session = created.session;
+
+		created.settings.override("ultracode", true);
+		const promptSpy = vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined);
+
+		await session.prompt("just a normal follow-up question");
+
+		expect(promptSpy).toHaveBeenCalled();
+		expect(created.settings.get("ultracode")).toBe(false);
+	});
+
+	// A keyword typed as /skill ARGUMENTS fires through the same notice builder
+	// as a plain prompt: promptCustomMessage routes a user-attributed skill
+	// prompt's args into the keyword scan. Severing that callsite (or dropping
+	// ultracode from it) ships green through every plain-prompt test above —
+	// this is the only gated coverage of the skill-args firing path.
+	it("arms ultracode from user-attributed skill args", async () => {
+		const created = await createMagicKeywordSession(modelRegistry);
+		session = created.session;
+		const promptSpy = vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined);
+
+		const details: SkillPromptDetails = {
+			name: "deep-work",
+			path: "/skills/deep-work/SKILL.md",
+			args: "ultracode the refactor",
+			lineCount: 1,
+		};
+		await session.promptCustomMessage({
+			customType: SKILL_PROMPT_MESSAGE_TYPE,
+			content: `Skill body\n\nUser: ${details.args}`,
+			display: true,
+			details,
+			attribution: "user",
+		});
+
+		const promptMessages = promptSpy.mock.calls[0]![0] as unknown as Array<{ customType?: string }>;
+		// The notice precedes the skill body, exactly like a typed keyword's
+		// notice precedes the user message.
+		expect(promptMessages.map(message => message.customType).filter(Boolean)).toEqual([
+			"ultracode-notice",
+			SKILL_PROMPT_MESSAGE_TYPE,
+		]);
+		expect(created.settings.get("ultracode")).toBe(true);
+	});
+
+	// Skill prompts the harness injects itself (autoloads, subagent skill
+	// injection) carry `attribution: "agent"`. Their args are not user-authored
+	// text and must neither arm the keyword...
+	it("never lets an agent-attributed skill prompt's args trigger ultracode", async () => {
+		const created = await createMagicKeywordSession(modelRegistry);
+		session = created.session;
+		const promptSpy = vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined);
+
+		await session.promptCustomMessage({
+			customType: SKILL_PROMPT_MESSAGE_TYPE,
+			content: "Skill body",
+			display: false,
+			details: { name: "autoload", path: "/skills/autoload/SKILL.md", args: "ultracode the refactor" },
+			attribution: "agent",
+		});
+
+		const promptMessages = promptSpy.mock.calls[0]![0] as unknown as Array<{ customType?: string }>;
+		expect(promptMessages.map(message => message.customType).filter(Boolean)).toEqual([SKILL_PROMPT_MESSAGE_TYPE]);
+		expect(created.settings.get("ultracode")).toBe(false);
+	});
+
+	// ...nor run the keyword builder's disarm `else` against an armed inherited
+	// flag — the skill-prompt twin of the depth-2 effort hazard above. Loosening
+	// the user-attribution gate fails here.
+	it("leaves an inherited ultracode flag alone on an agent-attributed skill steer", async () => {
+		const created = await createMagicKeywordSession(modelRegistry);
+		session = created.session;
+
+		created.settings.override("ultracode", true);
+		const promptSpy = vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined);
+
+		await session.promptCustomMessage({
+			customType: SKILL_PROMPT_MESSAGE_TYPE,
+			content: "Skill body",
+			display: false,
+			details: { name: "autoload", path: "/skills/autoload/SKILL.md", args: "carry on with the brief" },
+			attribution: "agent",
+		});
+
+		expect(promptSpy).toHaveBeenCalled();
+		expect(created.settings.get("ultracode")).toBe(true);
+	});
+
+	// A keyword-free USER-attributed skill turn is still a user turn: it must
+	// hand the borrowed effort back, or firing a skill would silently extend an
+	// ultracode turn past the message that carried the word.
+	it("disarms ultracode on a keyword-free user-attributed skill prompt", async () => {
+		const created = await createMagicKeywordSession(modelRegistry);
+		session = created.session;
+
+		created.settings.override("ultracode", true);
+		const promptSpy = vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined);
+
+		await session.promptCustomMessage({
+			customType: SKILL_PROMPT_MESSAGE_TYPE,
+			content: "Skill body",
+			display: true,
+			details: { name: "deep-work", path: "/skills/deep-work/SKILL.md", args: "just do the next step" },
+			attribution: "user",
+		});
+
+		expect(promptSpy).toHaveBeenCalled();
+		expect(created.settings.get("ultracode")).toBe(false);
+	});
+
+	// Every notice the session queues MUST be a recognized hidden companion, or
+	// dequeue/clear walk past it: the user's prompt leaves and the hidden notice
+	// stays behind, uncounted, to be delivered ahead of a later unrelated turn.
+	// `ultracode-notice` was missing from that table while the other three were
+	// registered, so this enumerates from the session rather than hardcoding.
+	it("registers every queued keyword notice as a hidden user companion", async () => {
+		const created = await createMagicKeywordSession(modelRegistry);
+		session = created.session;
+
+		const promptSpy = vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined);
+
+		await session.prompt("ultracode and ultrathink and orchestrate and workflowz this");
+
+		const promptMessages = promptSpy.mock.calls[0]![0] as unknown as AgentMessage[];
+		const notices = promptMessages.filter(
+			(message): message is CustomMessage => message.role === "custom" && message.display === false,
+		);
+		expect(notices.map(notice => notice.customType).sort()).toEqual([
+			"orchestrate-notice",
+			"ultracode-notice",
+			"ultrathink-notice",
+			"workflow-notice",
+		]);
+		for (const notice of notices) {
+			expect(MAGIC_KEYWORD_NOTICE_TYPES[notice.customType]).toBe(true);
+			expect(isHiddenUserCompanion(notice)).toBe(true);
+		}
 	});
 });

--- a/packages/coding-agent/test/interactive-mode-plan-review.test.ts
+++ b/packages/coding-agent/test/interactive-mode-plan-review.test.ts
@@ -4,6 +4,7 @@ import * as path from "node:path";
 import { Agent, AgentBusyError, ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import type { AssistantMessage, Usage } from "@oh-my-pi/pi-ai";
 import * as AIError from "@oh-my-pi/pi-ai/error";
+import { Effort } from "@oh-my-pi/pi-catalog/effort";
 import { KeybindingsManager } from "@oh-my-pi/pi-coding-agent/config/keybindings";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
@@ -21,7 +22,7 @@ import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { SILENT_ABORT_MARKER, USER_INTERRUPT_LABEL } from "@oh-my-pi/pi-coding-agent/session/messages";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
-import { AUTO_THINKING } from "@oh-my-pi/pi-coding-agent/thinking";
+import { AUTO_THINKING, clampAutoThinkingEffort } from "@oh-my-pi/pi-coding-agent/thinking";
 import * as clipboard from "@oh-my-pi/pi-coding-agent/utils/clipboard";
 import { type OverlayHandle, type OverlayOptions, setKeybindings } from "@oh-my-pi/pi-tui";
 import { formatNumber, TempDir } from "@oh-my-pi/pi-utils";
@@ -37,6 +38,21 @@ const isPlanApprovedCall = (args: unknown[]): boolean =>
 	typeof args[1] === "object" &&
 	args[1] !== null &&
 	(args[1] as { synthetic?: boolean }).synthetic === true;
+
+/**
+ * Pick a plan-review option by label prefix.
+ *
+ * Selecting by index silently re-targets a different branch whenever the menu
+ * gains or loses an entry (the ultracode option comes and goes with its
+ * settings gate). Prefix, because the keep-context label carries a live token
+ * count.
+ */
+const pickPlanOption = (options: readonly string[], prefix: string): string => {
+	const match = options.find(option => option.startsWith(prefix));
+	if (!match)
+		throw new Error(`no plan-review option starting with ${JSON.stringify(prefix)} in ${JSON.stringify(options)}`);
+	return match;
+};
 
 function usageWithInput(input: number): Usage {
 	return {
@@ -740,6 +756,7 @@ describe("InteractiveMode plan review rendering", () => {
 			"Plan mode - next step",
 			[
 				"Approve and execute",
+				"Approve and execute with ultracode",
 				"Approve and compact context",
 				"Approve and keep context (~7.3k / 10k)",
 				"Refine plan",
@@ -748,6 +765,38 @@ describe("InteractiveMode plan review rendering", () => {
 			expect.any(Object),
 			expect.any(Object),
 		);
+	});
+
+	it("drops the ultracode approval option when the keyword is disabled in settings", async () => {
+		const planFilePath = "local://PLAN.md";
+		const resolvedPlanPath = resolveLocalUrlToPath(planFilePath, {
+			getArtifactsDir: () => session.sessionManager.getArtifactsDir(),
+			getSessionId: () => session.sessionManager.getSessionId(),
+		});
+		await Bun.write(resolvedPlanPath, "# Plan\n\nDo the thing.");
+
+		mode.planModeEnabled = true;
+		mode.planModePlanFilePath = planFilePath;
+		// The menu obeys the same per-keyword gate as the typed keyword: with
+		// magicKeywords.ultracode off, the option disappears and every later
+		// entry moves up one slot.
+		session.settings.set("magicKeywords.ultracode", false);
+		vi.spyOn(session, "getContextUsage").mockReturnValue({ tokens: 7320, contextWindow: 10000, percent: 73.2 });
+		const selector = vi.spyOn(mode, "showPlanReview").mockResolvedValue("Refine plan");
+
+		await mode.handlePlanApproval({
+			planFilePath,
+			planExists: true,
+			title: "PLAN",
+		});
+
+		expect(selector.mock.calls[0]?.[2]).toEqual([
+			"Approve and execute",
+			"Approve and compact context",
+			"Approve and keep context (~7.3k / 10k)",
+			"Refine plan",
+			"Save and quit",
+		]);
 	});
 
 	it("ignores aborted zero-usage assistant messages when estimating context usage", () => {
@@ -815,6 +864,7 @@ describe("InteractiveMode plan review rendering", () => {
 		expect(contextSpy).toHaveBeenCalledWith({ contextWindow: executionModel.contextWindow });
 		expect(selector.mock.calls[0]?.[2]).toEqual([
 			"Approve and execute",
+			"Approve and execute with ultracode",
 			"Approve and compact context",
 			`Approve and keep context (~${compactNumber(tokens)} / ${compactNumber(executionModel.contextWindow)})`,
 			"Refine plan",
@@ -841,9 +891,16 @@ describe("InteractiveMode plan review rendering", () => {
 			title: "PLAN",
 		});
 
-		expect(selector.mock.calls[0]?.[3]).toEqual(
+		// Assert the INVARIANT — the disabled entry is the keep-context option —
+		// rather than a literal index, which silently re-targets a different option
+		// whenever the menu gains an entry.
+		const call = selector.mock.calls[0];
+		const menu = call?.[2] ?? [];
+		const keepContextIndex = menu.findIndex(option => option.startsWith("Approve and keep context"));
+		expect(keepContextIndex).toBeGreaterThanOrEqual(0);
+		expect(call?.[3]).toEqual(
 			expect.objectContaining({
-				disabledIndices: [2],
+				disabledIndices: [keepContextIndex],
 			}),
 		);
 	});
@@ -899,6 +956,7 @@ describe("InteractiveMode plan review rendering", () => {
 			"Plan mode - next step",
 			[
 				"Approve and execute",
+				"Approve and execute with ultracode",
 				"Approve and compact context",
 				"Approve and keep context",
 				"Refine plan",
@@ -1023,12 +1081,12 @@ describe("InteractiveMode plan review rendering", () => {
 			return true;
 		});
 		const followUpSpy = vi.spyOn(session, "followUp").mockResolvedValue();
-		// Simulate a re-stream landing during the overlay, then pick keep-context
-		// (options[2]) — that branch skips clear/compact so `this.session` stays the
-		// instance the spies are on.
+		// Simulate a re-stream landing during the overlay, then pick keep-context —
+		// that branch skips clear/compact so `this.session` stays the instance the
+		// spies are on.
 		vi.spyOn(mode, "showPlanReview").mockImplementation(async (_plan, _title, options) => {
 			streaming = true;
-			return options[2];
+			return pickPlanOption(options, "Approve and keep context");
 		});
 		const errorSpy = vi.spyOn(mode, "showError");
 
@@ -1068,7 +1126,9 @@ describe("InteractiveMode plan review rendering", () => {
 			throw new AgentBusyError();
 		});
 		const followUpSpy = vi.spyOn(session, "followUp").mockResolvedValue();
-		vi.spyOn(mode, "showPlanReview").mockImplementation(async (_plan, _title, options) => options[2]);
+		vi.spyOn(mode, "showPlanReview").mockImplementation(async (_plan, _title, options) =>
+			pickPlanOption(options, "Approve and keep context"),
+		);
 		const errorSpy = vi.spyOn(mode, "showError");
 
 		await mode.handlePlanApproval({ planFilePath, planExists: true, title: "PLAN" });
@@ -1130,7 +1190,9 @@ describe("InteractiveMode plan review rendering", () => {
 			mode.queueCompactionMessage("queued message", "followUp");
 			return undefined as never;
 		});
-		vi.spyOn(mode, "showPlanReview").mockImplementation(async (_plan, _title, options) => options[1]);
+		vi.spyOn(mode, "showPlanReview").mockImplementation(async (_plan, _title, options) =>
+			pickPlanOption(options, "Approve and compact context"),
+		);
 		const errorSpy = vi.spyOn(mode, "showError");
 
 		await mode.handlePlanApproval({ planFilePath, planExists: true, title: "PLAN" });
@@ -1176,6 +1238,90 @@ describe("InteractiveMode plan review rendering", () => {
 		expect(prompt).toHaveBeenCalledWith(expect.any(String), {
 			synthetic: true,
 		});
+	});
+
+	// The execution turn is the phase that actually spawns subagents, and it is
+	// dispatched as a SYNTHETIC prompt — which never scans for magic keywords. So an
+	// `ultracode` typed into the planning turn cannot reach it; this option is the
+	// only way across that boundary.
+	it("arms ultracode for the execution turn when the operator picks it", async () => {
+		const planFilePath = "local://PLAN.md";
+		const resolvedPlanPath = resolveLocalUrlToPath(planFilePath, {
+			getArtifactsDir: () => session.sessionManager.getArtifactsDir(),
+			getSessionId: () => session.sessionManager.getSessionId(),
+		});
+		await Bun.write(resolvedPlanPath, "# Plan\n\nDo the work.");
+
+		mode.planModeEnabled = true;
+		mode.planModePlanFilePath = planFilePath;
+		vi.spyOn(mode, "showPlanReview").mockImplementation(async (_plan, _title, options) =>
+			pickPlanOption(options, "Approve and execute with ultracode"),
+		);
+		vi.spyOn(mode, "handleClearCommand").mockResolvedValue();
+		const prompt = vi.spyOn(session, "prompt").mockResolvedValue(undefined as never);
+
+		await mode.handlePlanApproval({ planFilePath, planExists: true, title: "PLAN" });
+
+		// This is the flag src/task/executor.ts reads to floor every spawn of this
+		// turn at xhigh. Without it the approved plan executes cold.
+		expect(session.settings.get("ultracode")).toBe(true);
+
+		const [text, opts] = prompt.mock.calls[0] ?? [];
+		expect(opts).toEqual({ synthetic: true });
+		// The notice must lead, so the model reads the contract before the directive.
+		expect(text?.startsWith("<system-notice>")).toBe(true);
+		// And it must not claim the user typed a word they picked from a menu.
+		expect(text).toContain("approved a plan");
+		expect(text).not.toContain("contains the **ultracode** keyword");
+	});
+
+	it("leaves ultracode off on the plain approve-and-execute path", async () => {
+		const planFilePath = "local://PLAN.md";
+		const resolvedPlanPath = resolveLocalUrlToPath(planFilePath, {
+			getArtifactsDir: () => session.sessionManager.getArtifactsDir(),
+			getSessionId: () => session.sessionManager.getSessionId(),
+		});
+		await Bun.write(resolvedPlanPath, "# Plan\n\nDo the work.");
+
+		mode.planModeEnabled = true;
+		mode.planModePlanFilePath = planFilePath;
+		vi.spyOn(mode, "showPlanReview").mockResolvedValue("Approve and execute");
+		vi.spyOn(mode, "handleClearCommand").mockResolvedValue();
+		const prompt = vi.spyOn(session, "prompt").mockResolvedValue(undefined as never);
+
+		await mode.handlePlanApproval({ planFilePath, planExists: true, title: "PLAN" });
+
+		expect(session.settings.get("ultracode")).toBe(false);
+		const [text] = prompt.mock.calls[0] ?? [];
+		expect(text?.startsWith("<system-notice>")).toBe(false);
+	});
+
+	it("never arms ultracode while the master keyword switch is off, even for a forged choice", async () => {
+		const planFilePath = "local://PLAN.md";
+		const resolvedPlanPath = resolveLocalUrlToPath(planFilePath, {
+			getArtifactsDir: () => session.sessionManager.getArtifactsDir(),
+			getSessionId: () => session.sessionManager.getSessionId(),
+		});
+		await Bun.write(resolvedPlanPath, "# Plan\n\nDo the work.");
+
+		mode.planModeEnabled = true;
+		mode.planModePlanFilePath = planFilePath;
+		session.settings.set("magicKeywords.enabled", false);
+		vi.spyOn(mode, "showPlanReview").mockImplementation(async (_plan, _title, options) => {
+			// The gated option must not be offered...
+			expect(options).not.toContain("Approve and execute with ultracode");
+			// ...and even a chooser that answers with the label anyway must not
+			// reach the arming path: the menu and the arm share one gate.
+			return "Approve and execute with ultracode";
+		});
+		vi.spyOn(mode, "handleClearCommand").mockResolvedValue();
+		const prompt = vi.spyOn(session, "prompt").mockResolvedValue(undefined as never);
+
+		await mode.handlePlanApproval({ planFilePath, planExists: true, title: "PLAN" });
+
+		expect(session.settings.get("ultracode")).toBe(false);
+		const [text] = prompt.mock.calls[0] ?? [];
+		expect(text?.startsWith("<system-notice>")).toBe(false);
 	});
 
 	it("executes on the slider-selected tier, surviving #exitPlanMode's model restore", async () => {
@@ -1236,6 +1382,84 @@ describe("InteractiveMode plan review rendering", () => {
 		// The load-bearing assertion: the approved plan executes on the operator's
 		// selected tier, not the restored default.
 		expect(session.model?.id).toBe(slow.id);
+	});
+
+	it("arms ultracode only after #exitPlanMode's restore and the executionModel application", async () => {
+		// The ordering constraint #approvePlan documents as load-bearing:
+		// `armUltracodeTurn()` must run LAST — after #exitPlanMode (which
+		// restores the pre-plan model state, thinking level included) and after
+		// #applyPlanExecutionModel (which applies the slider tier, thinking
+		// suffix included). Hoisting the arming above either call still leaves
+		// `settings.ultracode` true, the prompt synthetic, and the notice
+		// already rendered — every assertion in the arming test above passes —
+		// while the restore/application reverts the pinned LEVEL and the
+		// approved plan executes cold. Capturing the level AT DISPATCH makes
+		// either hoist fail here.
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		const slow = session.modelRegistry.find("anthropic", "claude-opus-4-5");
+		const def = session.modelRegistry.find("anthropic", "claude-sonnet-4-5");
+		if (!slow || !def) throw new Error("Expected sonnet + opus to exist in registry");
+
+		// plan === default === the session model, so plan-mode entry records the
+		// previous-model state #exitPlanMode restores. The slow tier carries an
+		// explicit `:low` suffix so #applyPlanExecutionModel also sets a
+		// concrete non-pin level — both reverters are live in this scenario.
+		session.settings.setModelRole("default", "anthropic/claude-sonnet-4-5");
+		session.settings.setModelRole("slow", "anthropic/claude-opus-4-5:low");
+		session.settings.setModelRole("plan", "anthropic/claude-sonnet-4-5");
+		// A concrete pre-plan level distinct from the pin: the restore target.
+		session.setThinkingLevel(ThinkingLevel.Low);
+
+		const planFilePath = "local://PLAN.md";
+		const resolvedPlanPath = resolveLocalUrlToPath(planFilePath, {
+			getArtifactsDir: () => session.sessionManager.getArtifactsDir(),
+			getSessionId: () => session.sessionManager.getSessionId(),
+		});
+		await Bun.write(resolvedPlanPath, "# Plan\n\nExecute at the ultracode floor.");
+
+		await mode.handlePlanModeCommand();
+		expect(session.getPlanModeState()?.enabled).toBe(true);
+		expect(session.model?.id).toBe(def.id);
+
+		vi.spyOn(session, "getContextUsage").mockReturnValue(undefined);
+		vi.spyOn(mode, "handleClearCommand").mockResolvedValue();
+
+		// The pin the arming applies on the final (slow-tier) model. Guard that
+		// the fixture can distinguish a reverted level from the pin at all.
+		const expectedPin = clampAutoThinkingEffort(slow, Effort.XHigh);
+		expect(expectedPin).toBeDefined();
+		expect(expectedPin).not.toBe(ThinkingLevel.Low);
+
+		let levelAtDispatch: ThinkingLevel | undefined;
+		vi.spyOn(session, "prompt").mockImplementation(async () => {
+			levelAtDispatch = session.thinkingLevel;
+			return true;
+		});
+
+		vi.spyOn(mode, "showPlanReview").mockImplementation(
+			async (_planContent, _title, options, _dialogOptions, extra?: { slider?: HookSelectorSlider }) => {
+				const slider = extra?.slider;
+				expect(slider).toBeDefined();
+				const slowIndex = slider!.segments.findIndex(segment => segment.label === "slow");
+				expect(slowIndex).toBeGreaterThanOrEqual(0);
+				// Slide to the slow tier AND pick the ultracode option: the
+				// execution turn must land on slow's model at the pinned effort.
+				slider!.onChange?.(slowIndex);
+				return pickPlanOption(options, "Approve and execute with ultracode");
+			},
+		);
+
+		await mode.handlePlanApproval({ planFilePath, planExists: true, title: "PLAN" });
+
+		// The tier survived the exit-plan-mode restore (as the executionModel
+		// test above already guarantees)...
+		expect(session.model?.id).toBe(slow.id);
+		// ...and the execution turn dispatched on the PIN — not the restored
+		// pre-plan `low` (arming hoisted above #exitPlanMode) and not the slow
+		// tier's explicit `:low` suffix (arming hoisted above
+		// #applyPlanExecutionModel).
+		expect(levelAtDispatch).toBe(expectedPin);
+		expect(session.settings.get("ultracode")).toBe(true);
 	});
 
 	it("retains the plan model when the slider selection matches the active plan tier", async () => {

--- a/packages/coding-agent/test/modes/magic-keywords.test.ts
+++ b/packages/coding-agent/test/modes/magic-keywords.test.ts
@@ -22,6 +22,28 @@ describe("highlightMagicKeywords", () => {
 		}
 	});
 
+	it("paints all four magic keywords in one pass, whatever order they appear in", () => {
+		const input = "ultracode then workflowz, orchestrate, and ultrathink";
+		const decorated = highlightMagicKeywords(input);
+		expect(decorated).not.toBe(input);
+		expect(Bun.stripANSI(decorated)).toBe(input);
+		// Each highlighter paints only its own keyword, so chaining them is
+		// order-independent: all four survive as visible text, none as a
+		// contiguous run in the decorated output.
+		for (const keyword of ["ultracode", "workflowz", "orchestrate", "ultrathink"]) {
+			expect(decorated).not.toContain(keyword);
+			expect(Bun.stripANSI(decorated)).toContain(keyword);
+		}
+	});
+
+	it("paints a standalone ultracode keyword", () => {
+		const input = "please ultracode this";
+		const decorated = highlightMagicKeywords(input);
+		expect(decorated).not.toBe(input);
+		expect(decorated).not.toContain("ultracode");
+		expect(Bun.stripANSI(decorated)).toBe(input);
+	});
+
 	it("paints punctuation-adjacent prose keywords without changing visible text", () => {
 		const input = 'first "ultrathink," then orchestrate. Finally workflowz!';
 		const decorated = highlightMagicKeywords(input);
@@ -122,5 +144,16 @@ describe("hasMagicKeyword", () => {
 	it("returns false for empty / keyword-free text", () => {
 		expect(hasMagicKeyword("")).toBe(false);
 		expect(hasMagicKeyword("plain message with no keywords")).toBe(false);
+	});
+
+	it("detects ultracode on the same prose boundaries as the other keywords", () => {
+		expect(hasMagicKeyword("ultracode this")).toBe(true);
+		expect(hasMagicKeyword('say "ultracode" now')).toBe(true);
+		expect(hasMagicKeyword("ultracoded")).toBe(false);
+		expect(hasMagicKeyword("Ultracode")).toBe(false);
+		expect(hasMagicKeyword("ultracode()")).toBe(false);
+		expect(hasMagicKeyword("foo::ultracode")).toBe(false);
+		expect(hasMagicKeyword("src/modes/ultracode.ts")).toBe(false);
+		expect(hasMagicKeyword("`ultracode`")).toBe(false);
 	});
 });

--- a/packages/coding-agent/test/modes/ultracode.test.ts
+++ b/packages/coding-agent/test/modes/ultracode.test.ts
@@ -1,0 +1,357 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import { containsOrchestrate, highlightOrchestrate } from "@oh-my-pi/pi-coding-agent/modes/orchestrate";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import {
+	containsUltracode,
+	highlightUltracode,
+	renderUltracodeNotice,
+	ULTRACODE_NOTICE,
+} from "@oh-my-pi/pi-coding-agent/modes/ultracode";
+import { WORKFLOW_NOTICE } from "@oh-my-pi/pi-coding-agent/modes/workflow";
+
+beforeAll(() => {
+	// highlightUltracode/highlightOrchestrate read the global theme's color mode.
+	initTheme();
+});
+
+/** First SGR escape emitted by a gradient highlighter, i.e. its opening color stop. */
+function firstEscape(decorated: string): string {
+	const start = decorated.indexOf("\x1b");
+	if (start < 0) return "";
+	return decorated.slice(start, decorated.indexOf("m", start) + 1);
+}
+
+describe("ultracode keyword detection", () => {
+	it("matches the lowercase word delimited by whitespace or a string edge", () => {
+		expect(containsUltracode("ultracode")).toBe(true);
+		expect(containsUltracode("please ultracode this refactor")).toBe(true);
+		expect(containsUltracode("ultracode the migration")).toBe(true);
+		// A newline is whitespace, and end-of-string is a valid right boundary.
+		expect(containsUltracode("do it now\nultracode")).toBe(true);
+	});
+
+	it("matches the lowercase word beside prose punctuation and quotes", () => {
+		for (const text of ["do it. ultracode.", "please ultracode, then report", 'say "ultracode" now']) {
+			expect(containsUltracode(text)).toBe(true);
+		}
+	});
+
+	it("ignores casing, inflections, and path-embedded forms", () => {
+		expect(containsUltracode("Ultracode")).toBe(false);
+		expect(containsUltracode("ULTRACODE")).toBe(false);
+		expect(containsUltracode("ultracoded the build")).toBe(false);
+		// A path/extension must not trigger even though sentence punctuation does.
+		expect(containsUltracode("packages/coding-agent/src/modes/ultracode.ts")).toBe(false);
+		expect(containsUltracode("nothing to see here")).toBe(false);
+	});
+
+	it("ignores the word bound into an identifier, symbol reference, or call", () => {
+		for (const text of ["foo::ultracode", "ultracode()", "my-ultracode", "ultracode_x"]) {
+			expect(containsUltracode(text)).toBe(false);
+		}
+	});
+
+	it("ignores keywords inside code spans, fenced blocks, and XML sections", () => {
+		expect(containsUltracode("use `ultracode` here")).toBe(false);
+		expect(containsUltracode("```\nultracode\n```")).toBe(false);
+		expect(containsUltracode("<note>ultracode</note>")).toBe(false);
+		expect(containsUltracode("<!-- ultracode -->")).toBe(false);
+		// A real prose request alongside code still triggers.
+		expect(containsUltracode("run `setup` then ultracode the migration")).toBe(true);
+	});
+});
+
+describe("ultracode keyword highlighting", () => {
+	it("decorates the keyword with zero-width escapes, preserving visible text", () => {
+		const input = "please ultracode this";
+		const decorated = highlightUltracode(input);
+		expect(decorated).not.toBe(input);
+		expect(decorated).toContain("\x1b");
+		expect(Bun.stripANSI(decorated)).toBe(input);
+	});
+
+	it("decorates punctuation-adjacent prose while preserving visible text", () => {
+		const input = 'please "ultracode," then continue';
+		const decorated = highlightUltracode(input);
+		expect(decorated).not.toBe(input);
+		expect(Bun.stripANSI(decorated)).toBe(input);
+	});
+
+	it("leaves text without the standalone keyword untouched", () => {
+		expect(highlightUltracode("nothing here")).toBe("nothing here");
+		// The probe hits the substring but token/path boundaries fail, so no decoration.
+		expect(highlightUltracode("ultracoded builds")).toBe("ultracoded builds");
+		expect(highlightUltracode("Ultracode this")).toBe("Ultracode this");
+		expect(highlightUltracode("ultracode_x")).toBe("ultracode_x");
+		const filePath = "packages/coding-agent/src/modes/ultracode.ts";
+		expect(highlightUltracode(filePath)).toBe(filePath);
+		// Code spans, fences, and XML sections stay literal.
+		expect(highlightUltracode("`ultracode`")).toBe("`ultracode`");
+		expect(highlightUltracode("```\nultracode\n```")).toBe("```\nultracode\n```");
+		expect(highlightUltracode("<note>ultracode</note>")).toBe("<note>ultracode</note>");
+	});
+
+	it("paints a gradient distinct from the orchestrate one", () => {
+		const ultracode = highlightUltracode("ultracode");
+		const orchestrate = highlightOrchestrate("orchestrate");
+		expect(firstEscape(ultracode)).not.toBe("");
+		expect(firstEscape(orchestrate)).not.toBe("");
+		// Both ripples open on their own hue, so the first color stop differs.
+		expect(firstEscape(ultracode)).not.toBe(firstEscape(orchestrate));
+	});
+
+	it("does not cross-trigger with the orchestrate highlighter", () => {
+		expect(highlightUltracode("orchestrate")).toBe("orchestrate");
+		expect(highlightOrchestrate("ultracode")).toBe("ultracode");
+		expect(containsOrchestrate("ultracode")).toBe(false);
+		expect(containsUltracode("orchestrate")).toBe(false);
+	});
+});
+
+describe("ultracode notice", () => {
+	it("is a self-contained system notice scoped to the turn that carries it", () => {
+		expect(ULTRACODE_NOTICE.startsWith("<system-notice>")).toBe(true);
+		expect(ULTRACODE_NOTICE.endsWith("</system-notice>")).toBe(true);
+		expect(ULTRACODE_NOTICE).toContain("xhigh");
+		// Turn-scoped, not a session opt-in: the word steers this message only.
+		expect(ULTRACODE_NOTICE).toContain("THIS TURN");
+		// The contract must not retain the slash-command input placeholder.
+		expect(ULTRACODE_NOTICE).not.toContain("$@");
+	});
+});
+
+describe("ultracode orchestration contract", () => {
+	// The whole point of the keyword is that the turn runs as a dynamic workflow.
+	// A notice that only NAMES the helpers tells the model to orchestrate while
+	// withholding the API it must orchestrate with, so these assert the contract
+	// travels with the instruction rather than being referred to.
+	const withTooling = renderUltracodeNotice({ workflowAvailable: true });
+	const withoutTooling = renderUltracodeNotice({ workflowAvailable: false });
+
+	it("carries the executable helper API, not a pointer to it", () => {
+		for (const helper of ["agent(", "parallel(", "pipeline(", "phase(", "log(", "budget.total"]) {
+			expect(withTooling).toContain(helper);
+		}
+		// Worked scripts, not a list of names: the model has to see the shape.
+		expect(withTooling).toContain("await parallel(");
+		expect(withTooling).toContain("```js");
+	});
+
+	it("describes both helpers as barriers, because both are", () => {
+		// Guards against the notice claiming pipeline() streams items
+		// independently. In THIS runtime pipeline() runs one bounded pool per
+		// stage (src/eval/js/shared/prelude.txt), and prelude.py says so outright:
+		// "Every item clears stage N before any item enters stage N+1". Telling the
+		// model to reach for pipeline() to AVOID a barrier buys the barrier.
+		expect(withTooling).toContain("BARRIER PER STAGE");
+		expect(withTooling).not.toContain("DEFAULT TO pipeline()");
+		expect(withTooling).not.toContain("NO barrier between stages");
+		// The shape that does give independent per-item progress.
+		expect(withTooling).toContain("put the WHOLE per-item chain in one thunk");
+	});
+
+	it("tells the truth about failure propagation, which decides whether a fan-out survives", () => {
+		// agent() throws a ToolError on every failure path (src/eval/agent-bridge.ts)
+		// and parallel() re-raises the lowest-index error, discarding every result
+		// that succeeded (prelude.txt __pool). A notice promising null returns plus
+		// `.filter(Boolean)` would describe a defence that can never fire.
+		expect(withTooling).toContain("it never returns null");
+		expect(withTooling).toContain("discards the entire results array");
+		expect(withTooling).toContain("put the try/catch INSIDE each risky thunk");
+		// The budget throw is gated on `turnBudget?.hard` (agent-bridge.ts): only a
+		// `+Nk!`/Goal-Mode ceiling refuses the spawn. Claiming ANY exhausted
+		// budget throws would invite the model to skip its own
+		// budget.remaining() gate under a soft +Nk that enforces nothing.
+		expect(withTooling).toContain("hits a hard (`+Nk!`/Goal Mode) budget ceiling THROWS");
+		expect(withTooling).not.toContain("exhausts the turn budget");
+	});
+
+	it("documents the budget members in their real, awaitable form", () => {
+		// Every JS budget member is async: `budget.total` is a function object
+		// (always truthy) and remaining() returns a Promise, so a guard like
+		// `while (budget.total && budget.remaining() > 50_000)` never loops once.
+		expect(withTooling).toContain("await budget.total()");
+		expect(withTooling).toContain("await budget.remaining()");
+		expect(withTooling).not.toContain("while (budget.total && budget.remaining()");
+		// The advisory/hard split must travel with the API: a plain +Nk is enforced
+		// by nobody, so the notice has to say self-limit rather than letting the
+		// model believe agent() polices it.
+		expect(withTooling).toContain("A plain `+Nk` target is advisory");
+		expect(withTooling).toContain("refuse to spawn");
+	});
+
+	it("describes phase() as a status line, not an agent-row grouper", () => {
+		// The renderer never nests agent rows under phases: eval-render.ts draws
+		// "phase" as one standalone line in a flat status list and EXCLUDES agent
+		// events from that stream entirely (they get their own flat tree).
+		// Promising that `agent()` calls group under the phase would describe a
+		// display behavior nothing implements.
+		expect(withTooling).toContain("following status lines appear under it");
+		expect(withTooling).not.toContain("`agent()` calls group under it");
+	});
+
+	it("spells the option name Python actually accepts", () => {
+		// prelude.py's agent() is keyword-only with no **kwargs, so schemaMode=...
+		// raises TypeError; the wire name is translated from schema_mode.
+		expect(withTooling).toContain("schema_mode");
+	});
+
+	it("carries the three-verdict adjudication, not a refute boolean", () => {
+		for (const verdict of ["CONFIRMED", "PLAUSIBLE", "REFUTED"]) {
+			expect(withTooling).toContain(verdict);
+		}
+		// The calibration IS the mechanism: a panel that refutes anything
+		// speculative deletes the real findings and reports a clean bill.
+		expect(withTooling).toContain("PLAUSIBLE by default");
+		expect(withTooling).toContain("REFUTED only when constructible from the code");
+	});
+
+	it("keeps deterministic glue out of the model", () => {
+		expect(withTooling).toContain("Zero-token glue");
+	});
+
+	it("is one notice block that names the keyword the user actually typed", () => {
+		expect(withTooling.split("<system-notice>")).toHaveLength(2);
+		expect(withTooling).toContain("**ultracode**");
+		expect(withTooling).not.toContain("**workflowz**");
+	});
+
+	it("scopes the contract to this turn and never claims the session", () => {
+		expect(withTooling).toContain("THIS TURN");
+		// The keyword is per-turn, so nothing in the notice may promise the
+		// contract outlives the turn as a session-wide standing default.
+		expect(withTooling).not.toContain("standing default for the session");
+		expect(withTooling).not.toContain("for the rest of the session");
+	});
+
+	it("prescribes no fan-out API when the tools to run it are inactive", () => {
+		for (const helper of ["agent(", "parallel(", "pipeline(", "phase("]) {
+			expect(withoutTooling).not.toContain(helper);
+		}
+		// Silence would read as "orchestrate anyway"; the notice must say why not.
+		expect(withoutTooling).toContain("not both active");
+		expect(withoutTooling).toContain("xhigh");
+	});
+
+	it("leaves the standalone workflowz notice unchanged", () => {
+		expect(WORKFLOW_NOTICE.startsWith("<system-notice>")).toBe(true);
+		expect(WORKFLOW_NOTICE.endsWith("</system-notice>")).toBe(true);
+		expect(WORKFLOW_NOTICE).toContain("**workflowz**");
+		// ultracode ships its own fuller contract. It must never splice in or
+		// re-render the workflowz notice: that announces a keyword the user did
+		// not type, and splicing would couple the ultracode contract to every
+		// future edit of workflow-notice.md.
+		expect(ULTRACODE_NOTICE).not.toContain(WORKFLOW_NOTICE);
+		expect(ULTRACODE_NOTICE).not.toContain("**workflowz**");
+	});
+
+	it("renders every template branch, leaving no handlebars behind", () => {
+		for (const notice of [withTooling, withoutTooling, ULTRACODE_NOTICE]) {
+			expect(notice).not.toContain("{{");
+		}
+	});
+});
+
+// A notice that misdescribes the runtime is worse than no notice: the model
+// writes code against it and the code fails. Everything the notice asserts
+// about this session has to come from this session.
+describe("ultracode notice renders live session facts", () => {
+	it("names scout only when scout can actually be spawned", () => {
+		expect(renderUltracodeNotice({ workflowAvailable: true, scoutAvailable: true })).toContain("`scout`");
+		// With task.disabledAgents: ["scout"] or a spawn policy that excludes it,
+		// naming scout hands the model an agent type that throws at preflight
+		// (src/task/structured-subagent.ts). Every sibling prompt gates it.
+		expect(renderUltracodeNotice({ workflowAvailable: true, scoutAvailable: false })).not.toContain("`scout`");
+	});
+
+	it("states the live concurrency cap instead of a hardcoded default", () => {
+		expect(renderUltracodeNotice({ workflowAvailable: true, maxConcurrency: 8 })).toContain(
+			"at most 8 thunks at once",
+		);
+		expect(renderUltracodeNotice({ workflowAvailable: true, maxConcurrency: 32 })).toContain(
+			"at most 32 thunks at once",
+		);
+		// 0 is "unlimited" for task.maxConcurrency, so any stated cap would be a
+		// lie — and the system prompt in the same context window omits it too.
+		expect(renderUltracodeNotice({ workflowAvailable: true, maxConcurrency: 0 })).not.toContain("at most");
+	});
+
+	it("stops asserting the effort pin when the transport will discard it", () => {
+		const applied = renderUltracodeNotice({ workflowAvailable: true, effortApplied: true });
+		expect(applied).toContain("The harness has already pinned");
+		// beginUltracodeTurn no-ops on non-reasoning models and reasoning models
+		// with no controllable effort surface, and on ladders without xhigh it pins
+		// the clamped level instead (model-controls.ts). The renderer cannot see
+		// which case it is, so the applied branch must carry the hedge in its own
+		// text rather than assert an unconditional, unclamped xhigh pin.
+		expect(applied).toContain("clamped to each model's own ladder");
+		expect(applied).toContain("one with no effort control runs unchanged");
+		// With externalThinking on, the transport's forceReasoningOff strips
+		// reasoning before the request leaves, so the pin never reaches the wire.
+		// Asserting it anyway makes the failure unobservable from inside the
+		// turn — the notice also forbids commenting on effort.
+		const suppressed = renderUltracodeNotice({ workflowAvailable: true, effortApplied: false });
+		expect(suppressed).not.toContain("The harness has already pinned");
+		expect(suppressed).toContain("externalThinking");
+		expect(suppressed).toContain("`think`");
+	});
+
+	it("leaves no handlebars behind in any combination of live facts", () => {
+		for (const scoutAvailable of [true, false])
+			for (const effortApplied of [true, false])
+				for (const maxConcurrency of [0, 8, 32])
+					for (const workflowAvailable of [true, false]) {
+						const notice = renderUltracodeNotice({
+							workflowAvailable,
+							scoutAvailable,
+							effortApplied,
+							maxConcurrency,
+						});
+						expect(notice).not.toContain("{{");
+						expect(notice).not.toContain("}}");
+					}
+	});
+});
+
+// Plan approval dispatches a SYNTHETIC prompt, and synthetic turns never scan for
+// keywords — so an `ultracode` typed into the planning turn cannot reach the
+// execution turn, which is the phase that actually spawns subagents. The plan
+// review's "Approve and execute with ultracode" carries it across that boundary.
+describe("ultracode notice for an approved plan", () => {
+	const typed = renderUltracodeNotice({ workflowAvailable: true });
+	const approved = renderUltracodeNotice({ workflowAvailable: true, viaPlanApproval: true });
+
+	it("does not claim the user typed a word they picked from a menu", () => {
+		expect(typed).toContain("contains the **ultracode** keyword");
+		expect(approved).not.toContain("contains the **ultracode** keyword");
+		expect(approved).toContain("approved a plan");
+	});
+
+	it("still scopes itself to this turn, and still names the keyword", () => {
+		// Both paths are per-turn. Neither may imply the session is armed.
+		for (const notice of [typed, approved]) {
+			expect(notice).toContain("THIS TURN");
+			expect(notice).toContain("**ultracode**");
+			expect(notice).not.toContain("for the rest of the session");
+		}
+	});
+
+	it("tells the model not to ask the user to type the word", () => {
+		// The operator already opted in; "say ultracode" advice would be nonsense.
+		expect(approved).toContain("do not tell them to say it");
+	});
+
+	it("carries the identical contract on both paths, differing only in the trigger line", () => {
+		// The orchestration contract must not silently diverge between entry points.
+		const body = (notice: string): string => notice.split("\n").slice(2).join("\n");
+		expect(body(approved)).toBe(body(typed));
+	});
+
+	it("leaves no handlebars behind on the approval path", () => {
+		for (const workflowAvailable of [true, false]) {
+			const notice = renderUltracodeNotice({ workflowAvailable, viaPlanApproval: true });
+			expect(notice).not.toContain("{{");
+			expect(notice).not.toContain("}}");
+		}
+	});
+});

--- a/packages/coding-agent/test/ultracode-subagent-effort.test.ts
+++ b/packages/coding-agent/test/ultracode-subagent-effort.test.ts
@@ -1,0 +1,436 @@
+/**
+ * Ultracode pins EVERY subagent spawn to xhigh while it is active.
+ *
+ * These drive the real `runSubprocess` and read the level it hands to
+ * `createAgentSession` — `thinkingLevel` (the pinned effort) and
+ * `thinkingLevelCeiling` (the ceiling that rides into the session so
+ * retry-fallback recovery cannot re-clamp below it). The agent loop itself is
+ * a mock that yields immediately, so nothing here talks to a model.
+ *
+ * The pin deliberately overrides the agent definition's own level (scout's
+ * `medium`, task's `auto`), the caller's coarse `effort`, and a `task.maxEffort`
+ * ceiling below xhigh. Only the model's own ladder is allowed to move it.
+ */
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
+import type { Model } from "@oh-my-pi/pi-ai";
+import { Effort } from "@oh-my-pi/pi-catalog/effort";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import type { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { runEvalAgent } from "@oh-my-pi/pi-coding-agent/eval/agent-bridge";
+import type { CreateAgentSessionResult } from "@oh-my-pi/pi-coding-agent/sdk";
+import * as sdkModule from "@oh-my-pi/pi-coding-agent/sdk";
+import type { AgentSession, AgentSessionEvent, PromptOptions } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import * as discoveryModule from "@oh-my-pi/pi-coding-agent/task/discovery";
+import { runSubprocess } from "@oh-my-pi/pi-coding-agent/task/executor";
+import { runStructuredSubagent } from "@oh-my-pi/pi-coding-agent/task/structured-subagent";
+import type { AgentDefinition } from "@oh-my-pi/pi-coding-agent/task/types";
+import { AUTO_THINKING, type ConfiguredThinkingLevel, type TaskEffort } from "@oh-my-pi/pi-coding-agent/thinking";
+import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+import { EventBus } from "@oh-my-pi/pi-coding-agent/utils/event-bus";
+
+function modelOrThrow(provider: Parameters<typeof getBundledModel>[0], id: string): Model {
+	const model = getBundledModel(provider, id);
+	if (!model) throw new Error(`Expected ${provider}/${id} to exist in the bundled catalog`);
+	return model as Model;
+}
+
+/** low → max, so an xhigh pin lands exactly on xhigh. */
+const FULL_LADDER = modelOrThrow("openai-codex", "gpt-5.6-sol");
+/** low → high: the model tops out below xhigh, so the pin must clamp down. */
+const CAPS_AT_HIGH = modelOrThrow("anthropic", "claude-sonnet-4-6");
+/** No `thinking` block at all: no controllable effort surface to pin. */
+const NO_EFFORT_SURFACE = modelOrThrow("openai", "gpt-4o");
+/**
+ * A ladder sitting entirely above xhigh. `resolveTaskEffortLevel` would throw
+ * `RangeError` here under a sub-xhigh `task.maxEffort`; the clamp the pin uses
+ * must land it on `max` instead.
+ */
+const MAX_ONLY = {
+	...FULL_LADDER,
+	provider: "mock",
+	id: "mock-max-only",
+	thinking: { mode: "effort", efforts: [Effort.Max] },
+} as Model;
+
+/** Yields on the first prompt so `runSubprocess` completes without a real loop. */
+function yieldEmittingSession(): AgentSession {
+	const listeners: Array<(event: AgentSessionEvent) => void> = [];
+	const session = {
+		state: { messages: [] },
+		agent: { state: { systemPrompt: ["test"] } },
+		model: undefined,
+		extensionRunner: undefined,
+		sessionManager: { appendSessionInit: () => {} },
+		getActiveToolNames: () => ["read", "yield"],
+		getEnabledToolNames: () => ["read", "yield"],
+		setActiveToolsByName: async (_toolNames: string[]) => {},
+		subscribe: (listener: (event: AgentSessionEvent) => void) => {
+			listeners.push(listener);
+			return () => {
+				const index = listeners.indexOf(listener);
+				if (index >= 0) listeners.splice(index, 1);
+			};
+		},
+		prompt: async (_text: string, _options?: PromptOptions) => {
+			for (const listener of listeners) {
+				listener({
+					type: "tool_execution_end",
+					toolCallId: "tool-ultracode-effort",
+					toolName: "yield",
+					result: {
+						content: [{ type: "text", text: "Result submitted." }],
+						details: { status: "success", data: { ok: true } },
+					},
+					isError: false,
+				});
+			}
+		},
+		waitForIdle: async () => {},
+		getLastAssistantMessage: () => undefined,
+		abort: async () => {},
+		dispose: async () => {},
+		setIrcWakeTurnObserver: () => {},
+		// v17.4.0 (`fix(hub): prevented stale agent refs from blocking wait`) made the agent
+		// registry mirror run-state on every spawn, so `runSubprocess` now calls this on the
+		// session it is handed. Returns an unsubscribe, matching the real signature.
+		subscribeRunState: (_listener: (state: "running" | "idle") => void) => () => {},
+		// v18.0.5 (2af99a67d2 `fix(agent): review subagent final yield in advisor`) drains
+		// the advisor's final-turn review before teardown, so `finalizeSubagentLifecycle`
+		// now calls both of these on every graceful (non-aborted) finish. No-op /
+		// instantly-caught-up, matching the real signatures.
+		prepareForHeadlessAdvisorDrain: () => {},
+		waitForAdvisorCatchup: async (_timeoutMs: number) => true,
+	};
+	return session as unknown as AgentSession;
+}
+
+function createSessionResult(session: AgentSession): CreateAgentSessionResult {
+	return {
+		session,
+		extensionsResult: {
+			extensions: [],
+			errors: [],
+			runtime: {} as unknown,
+		} as unknown as CreateAgentSessionResult["extensionsResult"],
+		setToolUIContext: () => {},
+		eventBus: new EventBus(),
+	};
+}
+
+function createModelRegistry(model: Model): ModelRegistry {
+	return {
+		authStorage: {},
+		refresh: async () => {},
+		getAvailable: () => [model],
+		getApiKey: async () => "test-key",
+	} as unknown as ModelRegistry;
+}
+
+const baseAgent: AgentDefinition = {
+	name: "task",
+	description: "test",
+	systemPrompt: "test",
+	source: "bundled",
+	model: ["@task"],
+};
+
+interface SpawnOptions {
+	id: string;
+	model: Model;
+	/** Flipped exactly the way the keyword flips it: the non-persisted runtime layer. */
+	ultracode?: boolean;
+	/** The agent definition's own pinned level (scout's `medium`, task's `auto`). */
+	thinkingLevel?: ConfiguredThinkingLevel;
+	/** The caller's coarse per-spawn effort. */
+	effort?: TaskEffort;
+	maxEffort?: Effort;
+}
+
+async function spawn(options: SpawnOptions) {
+	const settings = Settings.isolated(
+		options.maxEffort === undefined ? undefined : { "task.maxEffort": options.maxEffort },
+	);
+	if (options.ultracode) settings.override("ultracode", true);
+	settings.setModelRole("task", `${options.model.provider}/${options.model.id}`);
+	const spy = vi.spyOn(sdkModule, "createAgentSession").mockResolvedValue(createSessionResult(yieldEmittingSession()));
+
+	const result = await runSubprocess({
+		cwd: "/tmp",
+		agent: baseAgent,
+		task: "do work",
+		index: 0,
+		enableLsp: false,
+		id: options.id,
+		settings,
+		modelRegistry: createModelRegistry(options.model),
+		thinkingLevel: options.thinkingLevel,
+		effort: options.effort,
+	});
+
+	return { result, forwarded: spy.mock.calls[0]?.[0], spy };
+}
+
+describe("ultracode subagent effort pin", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("leaves a caller effort untouched while ultracode is off", async () => {
+		const { result, forwarded } = await spawn({
+			id: "ultracode-off-caller-effort",
+			model: FULL_LADDER,
+			effort: "lo",
+			maxEffort: Effort.Low,
+		});
+
+		expect(result.exitCode).toBe(0);
+		expect(forwarded?.thinkingLevel).toBe(ThinkingLevel.Low);
+		expect(forwarded?.thinkingLevelCeiling).toBe(Effort.Low);
+	});
+
+	it("leaves the agent definition's own level untouched while ultracode is off", async () => {
+		const { result, forwarded } = await spawn({
+			id: "ultracode-off-agent-level",
+			model: FULL_LADDER,
+			thinkingLevel: ThinkingLevel.Medium,
+		});
+
+		expect(result.exitCode).toBe(0);
+		expect(forwarded?.thinkingLevel).toBe(ThinkingLevel.Medium);
+		// No caller `effort` means no ceiling is computed at all — unchanged.
+		expect(forwarded?.thinkingLevelCeiling).toBeUndefined();
+	});
+
+	it("overrides an agent pinned to medium, the way scout is", async () => {
+		const { result, forwarded } = await spawn({
+			id: "ultracode-overrides-pinned-medium",
+			model: FULL_LADDER,
+			ultracode: true,
+			thinkingLevel: ThinkingLevel.Medium,
+		});
+
+		expect(result.exitCode).toBe(0);
+		expect(forwarded?.thinkingLevel).toBe(Effort.XHigh);
+	});
+
+	it("overrides an agent on auto, the way task is", async () => {
+		const { result, forwarded } = await spawn({
+			id: "ultracode-overrides-auto",
+			model: FULL_LADDER,
+			ultracode: true,
+			thinkingLevel: AUTO_THINKING,
+		});
+
+		expect(result.exitCode).toBe(0);
+		expect(forwarded?.thinkingLevel).toBe(Effort.XHigh);
+		expect(forwarded?.thinkingLevel).not.toBe(AUTO_THINKING);
+	});
+
+	it("overrides a caller-supplied effort of lo", async () => {
+		const { result, forwarded } = await spawn({
+			id: "ultracode-overrides-caller-effort",
+			model: FULL_LADDER,
+			ultracode: true,
+			effort: "lo",
+		});
+
+		expect(result.exitCode).toBe(0);
+		expect(forwarded?.thinkingLevel).toBe(Effort.XHigh);
+	});
+
+	it("is not capped by task.maxEffort, and raises the ceiling that rides into the session", async () => {
+		const { result, forwarded } = await spawn({
+			id: "ultracode-ignores-max-effort",
+			model: FULL_LADDER,
+			ultracode: true,
+			effort: "lo",
+			maxEffort: Effort.Low,
+		});
+
+		expect(result.exitCode).toBe(0);
+		expect(forwarded?.thinkingLevel).toBe(Effort.XHigh);
+		// The ceiling must be raised, not merely ignored: a stale `low` ceiling
+		// would let retry-fallback recovery clamp the child back down mid-run.
+		expect(forwarded?.thinkingLevelCeiling).toBe(Effort.XHigh);
+	});
+
+	it("clamps down to a model that tops out at high", async () => {
+		const { result, forwarded } = await spawn({
+			id: "ultracode-clamps-to-high",
+			model: CAPS_AT_HIGH,
+			ultracode: true,
+			thinkingLevel: AUTO_THINKING,
+		});
+
+		expect(result.exitCode).toBe(0);
+		expect(forwarded?.thinkingLevel).toBe(Effort.High);
+	});
+
+	it("resolves max for a model exposing only max instead of throwing", async () => {
+		const { result, forwarded } = await spawn({
+			id: "ultracode-max-only-model",
+			model: MAX_ONLY,
+			ultracode: true,
+			effort: "hi",
+			maxEffort: Effort.Low,
+		});
+
+		// `resolveTaskEffortLevel(model, "hi", Effort.Low)` would have thrown
+		// RangeError and killed the spawn outright.
+		expect(result.exitCode).toBe(0);
+		expect(result.stderr ?? "").not.toContain("no supported thinking effort");
+		expect(forwarded?.thinkingLevel).toBe(Effort.Max);
+	});
+
+	it("still fails that same spawn when ultracode is off, proving the clamp is what saves it", async () => {
+		const { result, spy } = await spawn({
+			id: "ultracode-off-max-only-model",
+			model: MAX_ONLY,
+			effort: "hi",
+			maxEffort: Effort.Low,
+		});
+
+		expect(result.exitCode).toBe(1);
+		expect(result.stderr).toContain(
+			"mock/mock-max-only has no supported thinking effort at or below task.maxEffort=low",
+		);
+		expect(spy).not.toHaveBeenCalled();
+	});
+
+	it("falls through to the normal selectors for a model with no controllable effort surface", async () => {
+		const { result, forwarded } = await spawn({
+			id: "ultracode-no-effort-surface",
+			model: NO_EFFORT_SURFACE,
+			ultracode: true,
+			thinkingLevel: ThinkingLevel.Low,
+		});
+
+		expect(result.exitCode).toBe(0);
+		// Forcing xhigh onto a model that cannot express it would be an invalid
+		// level downstream; the agent's own selector must survive instead.
+		expect(forwarded?.thinkingLevel).toBe(ThinkingLevel.Low);
+	});
+});
+
+/**
+ * The pin chokepoint (`runSubprocess`) is only as good as the plumbing above
+ * it: `buildExecutorOptions` in structured-subagent.ts hands the PARENT
+ * session's live settings — runtime override layer included — to the executor.
+ * The tests below enter at the two real frontends ABOVE that seam (the eval
+ * `agent()` bridge and a task-kind `runStructuredSubagent` call) instead of
+ * hand-building executor options the way `spawn` does, so a regression that
+ * gives those spawns derivative or clean settings (dropping the override)
+ * fails HERE even though every direct-`runSubprocess` test above stays green.
+ *
+ * Plain object, not a Proxy: only the members the structured-subagent seam and
+ * the executor actually read, each matching the real ToolSession signature.
+ */
+function frontendToolSession(options: { model: Model; ultracode?: boolean }): ToolSession {
+	const settings = Settings.isolated();
+	// Flipped exactly the way the keyword flips it: the non-persisted runtime layer.
+	if (options.ultracode) settings.override("ultracode", true);
+	settings.setModelRole("task", `${options.model.provider}/${options.model.id}`);
+	return {
+		cwd: "/tmp",
+		settings,
+		modelRegistry: createModelRegistry(options.model),
+		getSessionSpawns: () => "*",
+		getSessionFile: () => null,
+		enableLsp: false,
+		enableIrc: false,
+		enableMCP: false,
+	} as unknown as ToolSession;
+}
+
+function mockFrontendSpawnSeams() {
+	vi.spyOn(discoveryModule, "discoverAgents").mockResolvedValue({ agents: [baseAgent], projectAgentsDir: null });
+	return vi.spyOn(sdkModule, "createAgentSession").mockResolvedValue(createSessionResult(yieldEmittingSession()));
+}
+
+describe("ultracode pin through the real spawn frontends", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("pins an eval agent() spawn to xhigh end-to-end through the bridge", async () => {
+		const spy = mockFrontendSpawnSeams();
+		const session = frontendToolSession({ model: FULL_LADDER, ultracode: true });
+
+		await runEvalAgent({ prompt: "do work", agent: "task" }, { session });
+
+		expect(spy).toHaveBeenCalledTimes(1);
+		const forwarded = spy.mock.calls[0]?.[0];
+		// Fails if the bridge or buildExecutorOptions stops handing the parent's
+		// live settings through runStructuredSubagent (e.g. eval spawns given a
+		// derivative/clean Settings): the pin computation at the chokepoint then
+		// reads `ultracode: false` and this spawn dispatches cold.
+		expect(forwarded?.thinkingLevel).toBe(Effort.XHigh);
+		// The same severing also breaks inheritance: the child's settings
+		// snapshot is taken from what the frontend forwarded.
+		expect(forwarded?.settings?.get("ultracode")).toBe(true);
+	});
+
+	it("leaves an eval agent() spawn unpinned when ultracode is off", async () => {
+		const spy = mockFrontendSpawnSeams();
+		const session = frontendToolSession({ model: FULL_LADDER });
+
+		await runEvalAgent({ prompt: "do work", agent: "task" }, { session });
+
+		// The control: proves the pin above came from the parent's live flag,
+		// not from anything constant about the eval path.
+		const forwarded = spy.mock.calls[0]?.[0];
+		expect(forwarded?.thinkingLevel).toBeUndefined();
+		expect(forwarded?.settings?.get("ultracode")).toBe(false);
+	});
+
+	it("pins a task-kind structured-subagent spawn identically", async () => {
+		const spy = mockFrontendSpawnSeams();
+		const session = frontendToolSession({ model: FULL_LADDER, ultracode: true });
+
+		await runStructuredSubagent({ session, invocationKind: "task", assignment: "do work", agent: "task" });
+
+		// Fails if the task-kind settings plumbing above runSubprocess diverges
+		// from the eval kind — the "one seam covers both" claim, tested for both.
+		const forwarded = spy.mock.calls[0]?.[0];
+		expect(forwarded?.thinkingLevel).toBe(Effort.XHigh);
+		expect(forwarded?.settings?.get("ultracode")).toBe(true);
+	});
+});
+
+// The grandchild middle link. The pin tests above prove the parent's flag pins
+// the CHILD's level, and agent-session-magic-keywords proves an armed child
+// keeps an inherited flag through its agent-authored turn — but only the
+// whole-schema snapshot in createSubagentSettings connects the two. If that
+// seam force-cleared `ultracode` — a plausible edit, since the adjacent block
+// already force-sets "tools.approvalMode" and "advisor.enabled", and the
+// schema comment calls the flag turn state, not a preference — grandchildren
+// would silently lose the xhigh floor while every level assertion above
+// stayed green. These fail on exactly that severing.
+describe("ultracode override inheritance into child settings", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("carries the runtime ultracode override into the child settings snapshot", async () => {
+		const { result, forwarded } = await spawn({
+			id: "ultracode-inherits-into-child",
+			model: FULL_LADDER,
+			ultracode: true,
+		});
+
+		expect(result.exitCode).toBe(0);
+		expect(forwarded?.settings?.get("ultracode")).toBe(true);
+	});
+
+	it("spawns children with the flag off when the parent turn is not armed", async () => {
+		const { result, forwarded } = await spawn({
+			id: "ultracode-not-inherited-when-off",
+			model: FULL_LADDER,
+		});
+
+		expect(result.exitCode).toBe(0);
+		expect(forwarded?.settings?.get("ultracode")).toBe(false);
+	});
+});

--- a/packages/coding-agent/test/ultracode-turn-effort.test.ts
+++ b/packages/coding-agent/test/ultracode-turn-effort.test.ts
@@ -1,0 +1,588 @@
+/**
+ * Ultracode's per-turn effort pin.
+ *
+ * Keyword detection, highlighting and the notice are covered elsewhere
+ * (test/modes/ultracode.test.ts, test/modes/magic-keywords.test.ts). This file
+ * covers the thing the keyword exists for: `ModelControls.beginUltracodeTurn()`
+ * pinning the turn at xhigh, `endUltracodeTurn()` handing the borrowed level
+ * back on the next turn without the word, and the ultracode branch of
+ * `applyAutoThinkingLevel` refusing to let the difficulty classifier walk that
+ * pin back down.
+ *
+ * The pin is deliberately clamp-based rather than `resolveTaskEffortLevel`-based:
+ * a ladder that sits entirely above xhigh (`["max"]`) must resolve to max, not
+ * throw. See the "ladder entirely above xhigh" case.
+ */
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+	Agent,
+	type AgentMessage,
+	ASIDE_MESSAGE_COMMIT,
+	type CommittableAsideMessage,
+	ThinkingLevel,
+} from "@oh-my-pi/pi-agent-core";
+import type { Api, Model } from "@oh-my-pi/pi-ai";
+import { Effort } from "@oh-my-pi/pi-ai";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import type { AgentSessionEvent } from "@oh-my-pi/pi-coding-agent/session/agent-session-events";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { ModelControls, type ModelControlsHost } from "@oh-my-pi/pi-coding-agent/session/model-controls";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { AUTO_THINKING, type ConfiguredThinkingLevel } from "@oh-my-pi/pi-coding-agent/thinking";
+import { removeWithRetries } from "@oh-my-pi/pi-utils";
+
+function makeModel(id: string, thinking: Model<Api>["thinking"], reasoning = true): Model<Api> {
+	return {
+		id,
+		name: id,
+		api: "openai-responses",
+		provider: "test",
+		baseUrl: "https://example.test/v1",
+		reasoning,
+		input: ["text"],
+		cost: { input: 1, output: 1, cacheRead: 0, cacheWrite: 1 },
+		contextWindow: 200000,
+		maxTokens: 8192,
+		thinking,
+	} as Model<Api>;
+}
+
+/** Five-tier ladder with a genuine xhigh tier (GPT-5.6 / Sonnet 5 shape). */
+const HAS_XHIGH = makeModel("has-xhigh", {
+	mode: "effort",
+	efforts: [Effort.Low, Effort.Medium, Effort.High, Effort.XHigh, Effort.Max],
+});
+/** Tops out below xhigh (default reasoning scale, no xhigh tier). */
+const TOPS_AT_HIGH = makeModel("tops-at-high", {
+	mode: "effort",
+	efforts: [Effort.Minimal, Effort.Low, Effort.Medium, Effort.High],
+});
+/** Whole ladder sits ABOVE xhigh — the crash case for a resolve-based pin. */
+const MAX_ONLY = makeModel("max-only", { mode: "effort", efforts: [Effort.Max] });
+/** Reasoning, but effort is routed by sibling model id (devin-agent Cascade). */
+const NO_EFFORT_SURFACE = makeModel("no-effort-surface", undefined);
+const NON_REASONING = makeModel("non-reasoning", undefined, false);
+
+interface Harness {
+	controls: ModelControls;
+	settings: Settings;
+	/** Efforts handed to the agent, oldest first. The constructor contributes one. */
+	agentEfforts: Array<Effort | undefined>;
+	/** Every setting path read through the host, in order. */
+	settingReads: string[];
+	/** Times the host handed out its session id. Only the classifier's deps ask. */
+	sessionIdReads(): number;
+	events: AgentSessionEvent[];
+	entries: Array<{ thinkingLevel?: string; configured?: string }>;
+}
+
+/**
+ * `Settings` view that logs every `get` path. `classifyDifficulty` opens by
+ * reading `providers.autoThinkingModel`, so that path showing up in the log is
+ * direct evidence the difficulty classifier was entered.
+ */
+function recordSettingReads(settings: Settings, log: string[]): Settings {
+	return new Proxy(settings, {
+		get(target, prop) {
+			// Receiver is the real instance: Settings methods touch private fields.
+			const value = Reflect.get(target, prop, target);
+			if (typeof value !== "function") return value;
+			if (prop === "get") {
+				return (path: string) => {
+					log.push(path);
+					return (value as (p: string) => unknown).call(target, path);
+				};
+			}
+			return value.bind(target);
+		},
+	}) as Settings;
+}
+
+const GENERATION = 7;
+
+function createHarness(options: {
+	model: Model<Api> | undefined;
+	thinkingLevel?: ConfiguredThinkingLevel;
+	thinkingLevelCeiling?: Effort;
+	ultracode?: boolean;
+}): Harness {
+	const agentEfforts: Array<Effort | undefined> = [];
+	const settingReads: string[] = [];
+	const events: AgentSessionEvent[] = [];
+	const entries: Array<{ thinkingLevel?: string; configured?: string }> = [];
+	let sessionIdReads = 0;
+
+	const settings = Settings.isolated({ ultracode: options.ultracode ?? false });
+
+	const agent = {
+		setThinkingLevel: (effort: Effort | undefined) => {
+			agentEfforts.push(effort);
+		},
+		setDisableReasoning: () => {},
+		metadataForProvider: () => undefined,
+	} as unknown as Agent;
+
+	const host: ModelControlsHost = {
+		agent,
+		settings: recordSettingReads(settings, settingReads),
+		// Empty registry: if the classifier ever were entered it would fail to
+		// find a tiny/smol model and throw, so no test can reach the network.
+		modelRegistry: {
+			getAvailable: () => [],
+			getApiKey: async () => undefined,
+			getApiKeyForProvider: async () => undefined,
+			resolver: () => async () => undefined,
+		} as unknown as ModelRegistry,
+		sessionManager: {
+			appendThinkingLevelChange: (thinkingLevel?: string, configured?: string) => {
+				entries.push({ thinkingLevel, configured });
+				return "entry-id";
+			},
+		} as unknown as SessionManager,
+		providerSessionState: new Map(),
+		model: () => options.model,
+		sessionId: () => {
+			sessionIdReads++;
+			return "test-session";
+		},
+		promptGeneration: () => GENERATION,
+		resolveActiveEditMode: () => "hashline",
+		syncAfterModelChange: async () => {},
+		setModelWithProviderSessionReset: async () => {},
+		clearActiveRetryFallback: () => {},
+		clearInheritedProviderPromptCacheKey: () => {},
+		magicKeywordEnabled: () => true,
+		emit: event => {
+			events.push(event);
+		},
+		emitSessionEvent: async () => {},
+		emitNotice: () => {},
+	};
+
+	const controls = new ModelControls(host, {
+		thinkingLevel: options.thinkingLevel,
+		thinkingLevelCeiling: options.thinkingLevelCeiling,
+	});
+
+	return {
+		controls,
+		settings,
+		agentEfforts,
+		settingReads,
+		sessionIdReads: () => sessionIdReads,
+		events,
+		entries,
+	};
+}
+
+describe("beginUltracodeTurn", () => {
+	it("pins the turn at xhigh on a model whose ladder offers it", () => {
+		const h = createHarness({ model: HAS_XHIGH, thinkingLevel: Effort.Low });
+		h.controls.beginUltracodeTurn();
+
+		expect(h.controls.thinkingLevel).toBe(Effort.XHigh);
+		expect(h.agentEfforts.at(-1)).toBe(Effort.XHigh);
+		expect(h.events).toEqual([{ type: "thinking_level_changed", thinkingLevel: Effort.XHigh }]);
+	});
+
+	it("clamps down to the highest supported level when the ladder stops below xhigh", () => {
+		const h = createHarness({ model: TOPS_AT_HIGH, thinkingLevel: Effort.Minimal });
+		h.controls.beginUltracodeTurn();
+
+		expect(h.controls.thinkingLevel).toBe(Effort.High);
+		// The point of the clamp: never hand the provider an unsupported tier.
+		expect(h.agentEfforts).not.toContain(Effort.XHigh);
+	});
+
+	it("resolves up to max when the whole ladder sits above xhigh, without throwing", () => {
+		const h = createHarness({ model: MAX_ONLY });
+
+		// Regression: pinning through `resolveTaskEffortLevel` with an xhigh
+		// ceiling threw RangeError here, because no supported effort is at or
+		// below xhigh. The clamp has to snap to the nearest tier instead.
+		expect(() => h.controls.beginUltracodeTurn()).not.toThrow();
+		expect(h.controls.thinkingLevel).toBe(Effort.Max);
+		expect(h.agentEfforts.at(-1)).toBe(Effort.Max);
+	});
+
+	it("leaves a reasoning model with no controllable effort surface untouched", () => {
+		const h = createHarness({ model: NO_EFFORT_SURFACE, thinkingLevel: Effort.Medium });
+		const agentCallsBefore = h.agentEfforts.length;
+
+		expect(() => h.controls.beginUltracodeTurn()).not.toThrow();
+		// Untouched: still whatever the session was configured with.
+		expect(h.controls.thinkingLevel).toBe(Effort.Medium);
+		expect(h.agentEfforts.length).toBe(agentCallsBefore);
+		expect(h.events).toEqual([]);
+		expect(h.entries).toEqual([]);
+	});
+
+	it("leaves a non-reasoning model untouched", () => {
+		const h = createHarness({ model: NON_REASONING, thinkingLevel: Effort.Medium });
+		const agentCallsBefore = h.agentEfforts.length;
+
+		expect(() => h.controls.beginUltracodeTurn()).not.toThrow();
+		expect(h.controls.thinkingLevel).toBe(Effort.Medium);
+		expect(h.agentEfforts.length).toBe(agentCallsBefore);
+		expect(h.events).toEqual([]);
+	});
+
+	it("leaves auto behind so the difficulty classifier stops running", () => {
+		const h = createHarness({ model: HAS_XHIGH, thinkingLevel: AUTO_THINKING });
+		expect(h.controls.configuredThinkingLevel()).toBe(AUTO_THINKING);
+		expect(h.controls.isAutoThinking).toBe(true);
+
+		h.controls.beginUltracodeTurn();
+
+		// `AgentSession` only calls `applyAutoThinkingLevel` while `isAutoThinking`
+		// is true, so clearing it is what takes the classifier out of the turn.
+		expect(h.controls.isAutoThinking).toBe(false);
+		expect(h.controls.configuredThinkingLevel()).toBe(Effort.XHigh);
+		expect(h.controls.autoResolvedThinkingLevel).toBeUndefined();
+		// The pin's session receipt records the borrowed-FROM selector ("auto"
+		// here), never xhigh itself — see the "ultracode resume receipt" block.
+		expect(h.entries.at(-1)).toEqual({ thinkingLevel: Effort.XHigh, configured: AUTO_THINKING });
+	});
+
+	it("is turn-scoped: it never rewrites the persisted defaultThinkingLevel", () => {
+		const h = createHarness({ model: HAS_XHIGH, thinkingLevel: AUTO_THINKING });
+		h.settings.set("defaultThinkingLevel", Effort.Medium);
+
+		h.controls.beginUltracodeTurn();
+
+		expect(h.controls.thinkingLevel).toBe(Effort.XHigh);
+		expect(h.settings.get("defaultThinkingLevel")).toBe(Effort.Medium);
+	});
+
+	it("never exceeds a hard thinking-level ceiling", () => {
+		const h = createHarness({
+			model: HAS_XHIGH,
+			thinkingLevel: Effort.Low,
+			thinkingLevelCeiling: Effort.Medium,
+		});
+		h.controls.beginUltracodeTurn();
+
+		expect(h.controls.thinkingLevelCeiling).toBe(Effort.Medium);
+		expect(h.controls.thinkingLevel).toBe(Effort.Medium);
+		expect(h.agentEfforts).not.toContain(Effort.XHigh);
+	});
+
+	it("hands the borrowed level back when the turn ends", () => {
+		const h = createHarness({ model: HAS_XHIGH, thinkingLevel: Effort.Low });
+		h.controls.beginUltracodeTurn();
+		expect(h.controls.thinkingLevel).toBe(Effort.XHigh);
+
+		// The whole point of per-turn: the next keyword-free turn is back to normal.
+		h.controls.endUltracodeTurn();
+		expect(h.controls.configuredThinkingLevel()).toBe(Effort.Low);
+	});
+
+	it("restores auto, not a concrete level, when auto was running before", () => {
+		const h = createHarness({ model: HAS_XHIGH, thinkingLevel: AUTO_THINKING });
+		h.controls.beginUltracodeTurn();
+		expect(h.controls.isAutoThinking).toBe(false);
+
+		h.controls.endUltracodeTurn();
+		expect(h.controls.configuredThinkingLevel()).toBe(AUTO_THINKING);
+		expect(h.controls.isAutoThinking).toBe(true);
+	});
+
+	it("survives the keyword on consecutive turns without stranding the session at xhigh", () => {
+		const h = createHarness({ model: HAS_XHIGH, thinkingLevel: Effort.Low });
+		h.controls.beginUltracodeTurn();
+		// A second capture must not overwrite the saved level with xhigh itself.
+		h.controls.beginUltracodeTurn();
+		h.controls.endUltracodeTurn();
+
+		expect(h.controls.configuredThinkingLevel()).toBe(Effort.Low);
+	});
+
+	it("ending without a begin is a no-op, so ordinary turns cost nothing", () => {
+		const h = createHarness({ model: HAS_XHIGH, thinkingLevel: Effort.Medium });
+		const before = h.entries.length;
+		h.controls.endUltracodeTurn();
+
+		expect(h.controls.configuredThinkingLevel()).toBe(Effort.Medium);
+		expect(h.entries.length).toBe(before);
+	});
+
+	it("yields to the user's own effort control instead of overwriting their choice", () => {
+		const h = createHarness({ model: HAS_XHIGH, thinkingLevel: Effort.Low, ultracode: true });
+		h.controls.beginUltracodeTurn();
+		expect(h.controls.thinkingLevel).toBe(Effort.XHigh);
+
+		// Reaching for the effort control mid-turn is explicit. The pending restore
+		// must be dropped, or it would silently discard the level they just picked.
+		const picked = h.controls.cycleThinkingLevel();
+		h.controls.endUltracodeTurn();
+
+		expect(h.settings.get("ultracode")).toBe(false);
+		expect(h.controls.configuredThinkingLevel()).toBe(picked);
+		expect(h.controls.thinkingLevel).not.toBe(Effort.XHigh);
+	});
+
+	it("leaves the flag alone when cycling on a turn that never used the keyword", () => {
+		const h = createHarness({ model: HAS_XHIGH, thinkingLevel: Effort.Low });
+		h.controls.cycleThinkingLevel();
+		expect(h.settings.get("ultracode")).toBe(false);
+	});
+});
+
+describe("applyAutoThinkingLevel under ultracode", () => {
+	it("resolves straight to the clamped xhigh without invoking the classifier", async () => {
+		const h = createHarness({ model: HAS_XHIGH, thinkingLevel: AUTO_THINKING, ultracode: true });
+
+		await h.controls.applyAutoThinkingLevel("rename a local variable", GENERATION);
+
+		expect(h.controls.thinkingLevel).toBe(Effort.XHigh);
+		expect(h.controls.autoResolvedThinkingLevel).toBe(Effort.XHigh);
+		// The classifier was bypassed, not merely outvoted: its first read never
+		// happened and it was never handed a session id.
+		expect(h.settingReads).toContain("ultracode");
+		expect(h.settingReads).not.toContain("providers.autoThinkingModel");
+		expect(h.sessionIdReads()).toBe(0);
+	});
+
+	it("clamps the bypass to the model's ladder", async () => {
+		const h = createHarness({ model: TOPS_AT_HIGH, thinkingLevel: AUTO_THINKING, ultracode: true });
+
+		await h.controls.applyAutoThinkingLevel("rename a local variable", GENERATION);
+
+		expect(h.controls.thinkingLevel).toBe(Effort.High);
+		expect(h.settingReads).not.toContain("providers.autoThinkingModel");
+	});
+
+	it("still honors a hard ceiling below xhigh", async () => {
+		const h = createHarness({
+			model: HAS_XHIGH,
+			thinkingLevel: AUTO_THINKING,
+			thinkingLevelCeiling: Effort.Medium,
+			ultracode: true,
+		});
+
+		await h.controls.applyAutoThinkingLevel("rename a local variable", GENERATION);
+
+		expect(h.controls.thinkingLevel).toBe(Effort.Medium);
+	});
+
+	it("runs the classifier when ultracode is off", async () => {
+		// Counterpart to the bypass assertions above: without ultracode the same
+		// probes fire, so their absence there is meaningful rather than vacuous.
+		const h = createHarness({ model: HAS_XHIGH, thinkingLevel: AUTO_THINKING, ultracode: false });
+
+		await h.controls.applyAutoThinkingLevel("rename a local variable", GENERATION);
+
+		expect(h.settingReads).toContain("providers.autoThinkingModel");
+		expect(h.sessionIdReads()).toBe(1);
+		// The empty registry makes classification fail, so auto falls back to the
+		// provisional level — notably NOT xhigh.
+		expect(h.controls.thinkingLevel).toBe(Effort.High);
+		expect(h.controls.isAutoThinking).toBe(true);
+	});
+
+	it("does not clear auto, so a later turn re-pins xhigh", async () => {
+		const h = createHarness({ model: HAS_XHIGH, thinkingLevel: AUTO_THINKING, ultracode: true });
+
+		await h.controls.applyAutoThinkingLevel("first turn", GENERATION);
+		expect(h.controls.configuredThinkingLevel()).toBe(AUTO_THINKING);
+
+		h.controls.restoreThinkingLevel(ThinkingLevel.Low);
+		expect(h.controls.thinkingLevel).toBe(Effort.Low);
+		h.controls.restoreThinkingLevel(AUTO_THINKING);
+
+		await h.controls.applyAutoThinkingLevel("second turn", GENERATION);
+		expect(h.controls.thinkingLevel).toBe(Effort.XHigh);
+		expect(h.settingReads).not.toContain("providers.autoThinkingModel");
+	});
+});
+
+describe("ultracode resume receipt", () => {
+	// Invariant: the xhigh pin is turn state, never the session's own configured
+	// level on disk. The handback state (`#levelBeforeUltracode`) lives in process
+	// memory only, so the pin's `thinking_level_change` entry must carry the
+	// borrowed-FROM level as `configured` — the value session restore replays
+	// (session-context reads `entry.configured`, sdk feeds it through
+	// `parseConfiguredThinkingLevel`). A process killed mid-ultracode-turn
+	// therefore resumes at the pre-ultracode level instead of stranded at xhigh
+	// with no handback state left to run.
+	it("records the borrowed-from level, not xhigh, as the pin's configured receipt", () => {
+		const h = createHarness({ model: HAS_XHIGH, thinkingLevel: Effort.Low });
+		h.controls.beginUltracodeTurn();
+
+		expect(h.controls.thinkingLevel).toBe(Effort.XHigh);
+		expect(h.entries.at(-1)).toEqual({ thinkingLevel: Effort.XHigh, configured: Effort.Low });
+	});
+
+	it("writes the handed-back level as both fields once the turn ends", () => {
+		const h = createHarness({ model: HAS_XHIGH, thinkingLevel: Effort.Low });
+		h.controls.beginUltracodeTurn();
+		h.controls.endUltracodeTurn();
+
+		expect(h.entries.at(-1)).toEqual({ thinkingLevel: Effort.Low, configured: Effort.Low });
+	});
+
+	it("leaves ordinary level changes writing the level itself as the receipt", () => {
+		const h = createHarness({ model: HAS_XHIGH, thinkingLevel: Effort.Low });
+		h.controls.setThinkingLevel(Effort.Medium);
+
+		expect(h.entries.at(-1)).toEqual({ thinkingLevel: Effort.Medium, configured: Effort.Medium });
+	});
+});
+
+// The seam between AgentSession.prompt() and ModelControls is two one-line
+// calls (arm in the keyword branch, disarm in the keyword-free branch of the
+// turn-state applier). Each test below fails if its call is severed, which the
+// ModelControls-level blocks above cannot see.
+describe("AgentSession ultracode turn wiring", () => {
+	let session: AgentSession | undefined;
+	let authStorage: AuthStorage;
+	let authRoot: string;
+	let modelRegistry: ModelRegistry;
+
+	beforeAll(async () => {
+		authRoot = await fs.mkdtemp(path.join(os.tmpdir(), "omp-ultracode-turn-auth-"));
+		authStorage = await AuthStorage.create(path.join(authRoot, "auth.db"));
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		modelRegistry = new ModelRegistry(authStorage, path.join(authRoot, "models.yml"));
+	});
+
+	afterAll(async () => {
+		authStorage.close();
+		await removeWithRetries(authRoot);
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		if (session) await session.dispose();
+		session = undefined;
+	});
+
+	async function createSession(): Promise<{ session: AgentSession; settings: Settings }> {
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected bundled Claude Sonnet model");
+		const agent = new Agent({
+			initialState: {
+				model,
+				systemPrompt: ["Test"],
+				tools: [],
+				messages: [],
+				thinkingLevel: Effort.High,
+			},
+		});
+		const settings = Settings.isolated();
+		const created = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+		});
+		return { session: created, settings };
+	}
+
+	/** Forces the streaming queue path in prompt() without a live agent loop. */
+	function forceStreaming(target: AgentSession): void {
+		Object.defineProperty(target, "isStreaming", { configurable: true, get: () => true });
+	}
+
+	/**
+	 * Fires the queued message's delivery effect exactly as the agent loop does
+	 * when it commits the message into the live context. Fails when no effect is
+	 * attached — a severed hook would otherwise pass silently as a no-op.
+	 */
+	function deliverQueued(message: AgentMessage | undefined): void {
+		const hook = (message as CommittableAsideMessage | undefined)?.[ASIDE_MESSAGE_COMMIT];
+		expect(typeof hook).toBe("function");
+		hook?.();
+	}
+
+	it("pins the turn's thinking level through prompt(), not just through ModelControls", async () => {
+		const created = await createSession();
+		session = created.session;
+		session.setThinkingLevel(Effort.Low);
+		vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined);
+
+		await session.prompt("please ultracode this refactor");
+
+		expect(created.settings.get("ultracode")).toBe(true);
+		expect(session.thinkingLevel).toBe(Effort.XHigh);
+	});
+
+	it("hands the borrowed level back on the next keyword-free user turn through prompt()", async () => {
+		const created = await createSession();
+		session = created.session;
+		session.setThinkingLevel(Effort.Low);
+		vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined);
+
+		await session.prompt("please ultracode this refactor");
+		expect(session.thinkingLevel).toBe(Effort.XHigh);
+
+		await session.prompt("now the keyword-free follow-up");
+		expect(created.settings.get("ultracode")).toBe(false);
+		expect(session.thinkingLevel).toBe(Effort.Low);
+	});
+
+	it("does not disarm the in-flight ultracode turn when a keyword-free steer is enqueued", async () => {
+		const created = await createSession();
+		session = created.session;
+		session.setThinkingLevel(Effort.Low);
+		vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined);
+		await session.prompt("please ultracode this refactor");
+		expect(session.thinkingLevel).toBe(Effort.XHigh);
+
+		forceStreaming(session);
+		await session.prompt("also check the tests", { streamingBehavior: "steer" });
+
+		// Enqueue leaves the in-flight armed turn alone: the pin and the subagent
+		// floor stay up for everything the turn still spawns.
+		expect(created.settings.get("ultracode")).toBe(true);
+		expect(session.thinkingLevel).toBe(Effort.XHigh);
+
+		// The flip fires only when the loop delivers the queued message.
+		deliverQueued(session.agent.peekSteeringQueue().find(m => m.role === "user"));
+		expect(created.settings.get("ultracode")).toBe(false);
+		expect(session.thinkingLevel).toBe(Effort.Low);
+	});
+
+	it("arms a queued ultracode follow-up at delivery, not under the current turn", async () => {
+		const created = await createSession();
+		session = created.session;
+		session.setThinkingLevel(Effort.Low);
+		vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined);
+
+		forceStreaming(session);
+		await session.prompt("ultracode the next piece", { streamingBehavior: "followUp" });
+
+		// The tail of the CURRENT (keyword-free) turn must not borrow xhigh.
+		expect(created.settings.get("ultracode")).toBe(false);
+		expect(session.thinkingLevel).toBe(Effort.Low);
+
+		deliverQueued(session.agent.peekFollowUpQueue().find(m => m.role === "user"));
+		expect(created.settings.get("ultracode")).toBe(true);
+		expect(session.thinkingLevel).toBe(Effort.XHigh);
+	});
+
+	it("keeps the user's explicit selector pick instead of the stale ultracode handback", async () => {
+		const created = await createSession();
+		session = created.session;
+		session.setThinkingLevel(Effort.Low);
+		vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined);
+		await session.prompt("please ultracode this refactor");
+		expect(session.thinkingLevel).toBe(Effort.XHigh);
+
+		// The selector / RPC / ACP / extension path: an unambiguous "I want THIS
+		// effort". It drops the pending restore and the subagent floor with it.
+		session.setThinkingLevel(Effort.Medium);
+		expect(created.settings.get("ultracode")).toBe(false);
+		expect(session.thinkingLevel).toBe(Effort.Medium);
+
+		// The next keyword-free turn's handback must not overwrite the pick.
+		await session.prompt("keyword-free follow-up");
+		expect(session.thinkingLevel).toBe(Effort.Medium);
+	});
+});


### PR DESCRIPTION
# Add the `ultracode` magic keyword

Closes #2159.

## What this is

A fourth magic keyword beside `ultrathink`, `orchestrate`, and `workflowz`: typing `ultracode` in a prompt pins that turn — and every subagent it spawns — to `xhigh` reasoning effort, and injects a hidden notice that makes eval-scripted multi-agent workflows the default for substantive tasks. It is the effort+orchestration fusion #2159 asked for, scoped to the turn rather than the session.

## Why turn-scoped (a deliberate narrowing of #2159)

#2159 proposes a session-wide `/effort ultracode`. This implementation borrows the level for the carrying turn and hands it back on the next user turn without the word: one maximal request does not silently re-bill every turn after it, and there is no mode to forget you are in. The plan-review path (below) covers the "arm a whole execution" case #2159 cares about. A session-persistent variant would be a small extension on top of this wiring if wanted (see also #7963's reasoning-vs-orchestration split — this PR keeps `ultrathink` reasoning-only and untouched).

## Design decisions a reviewer will want to check

- **Enforced, not advisory.** Unlike `orchestrate`/`workflowz` (notice-only), the effort contract is enforced at the single spawn chokepoint in `runSubprocess`, covering both the `task` tool and the eval `agent()` bridge. The pin overrides the agent definition's own level (scout pins `medium`), a caller `effort`, and a `task.maxEffort` ceiling below xhigh — the escorting ceiling is raised to the pinned level so it can never sit below the level it escorts. Both spawn entries are covered by tests, not inference.
- **Clamp, don't throw.** The pin uses `clampAutoThinkingEffort`, not `resolveTaskEffortLevel`: the latter throws `RangeError` when a model's ladder sits entirely above the ceiling, which would have crashed spawns on `["max"]`-only ladders and blamed `task.maxEffort` for a ceiling ultracode supplied. Models with no effort surface run unchanged, and the notice says so honestly.
- **Arm at turn start, not enqueue.** A prompt queued during streaming must not flip the pin under the in-flight turn; queued prompts carry their arm/disarm as a delivery effect that fires when the message commits into the live context.
- **Escapable by construction.** Any explicit user thinking-level set (cycle, selector, RPC, ACP) clears the override and drops the pending handback; a session killed mid-turn hands the level back on restore instead of resuming stranded at xhigh. The override lives in the runtime settings layer and is never persisted.
- **Plan review.** Plan approval dispatches a synthetic prompt, and synthetic turns never scan keywords, so a typed keyword cannot reach the execution turn. The plan review therefore gains "Approve and execute with ultracode" — shown and armed only while `magicKeywords.enabled` and `magicKeywords.ultracode` are on, and armed only after `#exitPlanMode` restores the pre-plan model (which would otherwise revert the pin).

## Behavior change disclosed (affects all four keywords)

Keyword notices now require **user-attributed** prompts. The existing doc comment already promised this ("User-authored prompts only — synthetic / agent-initiated turns never trigger them"), but the code gated only on `synthetic`, so agent-attributed prompts could fire keywords the user never typed. This PR makes the code match the documented intent. If you consider the old behavior load-bearing, this hunk is separable.

## Provenance note

`prompts/system/ultracode-notice.md` is structured after this repo's own `workflow-notice.md`, but several passages (the orchestration framing, barrier doctrine, the loop-until-dry example, the adjudication calibration) derive from — and in places closely follow — Anthropic's Claude Code ultracode prompt, adapted to this runtime's eval surface (helper signatures, pool bounds, budget API all verified against this codebase). Flagging explicitly so you can judge whether that provenance is acceptable; happy to rewrite passages in-house if not. This is also the first model-facing prompt in the repo to name Claude Code.

## Testing

99 new test cases; the six touched files run 185 total. Coverage includes: executor-seam proofs for both spawn entries; grandchild settings propagation; plan-approval arming order and settings gating (including a forged-choice negative); queued-message timing; every off-ramp; restore handback; keyword boundary/scan-scope cases (synthetic, agent-attributed, skill args); and controls proving the classifier-bypass assertions are not vacuous. Note on style: some notice tests pin exact contract-bearing phrases of the prompt (turn-scope wording, effort claims) — the consumer contract is model behavior, and phrase drift there has shipped real bugs; happy to restructure if you prefer looser assertions.

`bun run check:types` clean; the six test files green on top of v18.0.5.