### PR TITLE
fix(cli): plugin uninstall no longer reports removing nothing

### DIFF
--- a/packages/coding-agent/src/cli/plugin-cli.ts
+++ b/packages/coding-agent/src/cli/plugin-cli.ts
@@ -476,9 +476,32 @@ async function handleUninstall(
 	// For uninstall, check the installed plugins registry directly.
 	// This works even if the marketplace entry was later removed from marketplaces.json.
 	const mktMgr = await makeMarketplaceManager();
-	const installedPlugins = new Set((await mktMgr.listInstalledPlugins()).map(p => p.id));
+	const installedIds = (await mktMgr.listInstalledPlugins()).map(p => p.id);
+	const installedPlugins = new Set(installedIds);
 
-	for (const name of packages) {
+	// Installed marketplace IDs are `name@marketplace`, so a bare name never matches one
+	// exactly. Resolve it when exactly one marketplace supplies that name: without this the
+	// bare form falls through to the npm path, where `bun uninstall` exits 0 for a package
+	// that was never a dependency and the command reports a removal that did not happen.
+	const marketplaceIdsFor = (name: string): string[] =>
+		installedIds.filter(id => id.slice(0, id.lastIndexOf("@")) === name);
+
+	for (const rawName of packages) {
+		let name = rawName;
+		if (!installedPlugins.has(name)) {
+			const candidates = marketplaceIdsFor(name);
+			if (candidates.length === 1) {
+				name = candidates[0] as string;
+			} else if (candidates.length > 1) {
+				console.error(
+					chalk.red(
+						`${theme.status.error} ${rawName} is installed from ${candidates.length} marketplaces. Qualify it: ${candidates.join(", ")}`,
+					),
+				);
+				process.exit(1);
+			}
+		}
+
 		const viaMarketplace = installedPlugins.has(name);
 
 		if (flags.dryRun) {
@@ -519,7 +542,14 @@ async function handleUninstall(
 			continue;
 		}
 
-		// npm path
+		// npm path. `bun uninstall` exits 0 for a package that is not a dependency, so an
+		// unknown name would otherwise print a success line having removed nothing.
+		const npmPlugins = await manager.list();
+		if (!npmPlugins.some(p => p.name === name)) {
+			console.error(chalk.red(`${theme.status.error} ${rawName} is not installed`));
+			process.exit(1);
+		}
+
 		try {
 			await manager.uninstall(name);
 			if (flags.json) {


### PR DESCRIPTION
## The bug

`omp plugin uninstall <name>` prints a success line and removes nothing when the caller
omits the marketplace qualifier.

Reproduced on 18.0.4 with two plugins installed from a marketplace named `subdir-probe`:

```
omp plugin uninstall probe-skilldir
Uninstalled probe-skilldir
```

That removed nothing. Immediately afterwards:

- `installed_plugins.json` still held 4 references
- both cache directories under `~/.omp/plugins/cache/plugins/` survived
- `omp plugin list` still listed both plugins

The qualified form `omp plugin uninstall probe-skilldir@subdir-probe` did remove them.

## Why

Two independent faults compose.

`listInstalledPlugins()` returns IDs shaped `name@marketplace`, so the exact membership
test at `plugin-cli.ts:482` never matches a bare name. The bare form therefore takes the
npm path.

On that path `PluginManager.uninstall` runs `bun uninstall`, which exits 0 for a package
that was never a dependency:

```
bun uninstall definitely-not-a-real-dep-9f3a; echo $?
bun remove v1.4.0
package.json doesn't have dependencies, there's nothing to remove!
0
```

Nothing throws, so the handler reports a removal that never happened.

## The change

When exactly one marketplace supplies a bare name, resolve it against the installed IDs.
When several do, fail and list the qualified candidates rather than guessing.

On the npm path, check `manager.list()` for the name before calling uninstall, so an unknown
name becomes an error instead of a false success. That check runs only on the non-dry-run
path, which leaves the `--dry-run` behavior from #8178 untouched.

## Test plan

- `bunx tsgo -p tsconfig.json --noEmit` in `packages/coding-agent`: zero errors.
- I measured the `bun uninstall` exit code quoted above. It is the fault this change fixes.

One gap, stated rather than skipped:

- `packages/coding-agent/test/plugin-uninstall-dry-run.test.ts` did not run here.
- It fails on a clean checkout at `packages/natives/native/index.js:17`, because the native
  bindings are absent, and `bun run build:native` also fails in this environment.
- The clean-tree control fails identically, so this change did not cause it.
- A maintainer with working native bindings should confirm that test still passes.
- A regression test covering the bare-name case would be worth adding.
