### PR TITLE
arch(omp2): journal projection — pair the live chain with its log

### DIFF
--- a/crates/agent/src/arbiter.rs
+++ b/crates/agent/src/arbiter.rs
@@ -587,8 +587,8 @@ pub(crate) mod context {
 		}
 		let log = journal.load()?;
 		let mut state = CheckpointState::default();
-		for index in log.as_ref().iter() {
-			let Some(Entry::Ok(event)) = log.get(index) else {
+		for index in log.live().iter() {
+			let Some(Entry::Ok(event)) = log.log().get(index) else {
 				continue;
 			};
 			let Kind::Custom(custom) = &event.kind else {

--- a/crates/agent/src/batch.rs
+++ b/crates/agent/src/batch.rs
@@ -122,6 +122,13 @@ impl From<ClientError> for BatchError {
 pub const fn hook_event_mask(event: HookEventId) -> u64 {
 	1_u64 << event as u32
 }
+/// Compile-time ceiling: the highest `HookEventId` must stay below `u64::BITS`
+/// so `hook_event_mask`'s `1_u64 << event` never overflows. Adding a 64th
+/// variant fails the build instead of silently corrupting every mask.
+const _: () = assert!(
+	(HookEventId::HookEventFallbackSucceeded as u32) < u64::BITS,
+	"hook_event_mask is u64: a 64th HookEventId needs a wider mask"
+);
 
 /// One hook-composed admission answer and its narrowed authority envelope.
 #[derive(Clone, Debug)]

--- a/crates/agent/src/batch.rs
+++ b/crates/agent/src/batch.rs
@@ -5,7 +5,7 @@ use std::{
 	future,
 	sync::{
 		Arc, OnceLock,
-		atomic::{AtomicBool, AtomicU128, Ordering},
+		atomic::{AtomicBool, AtomicU64, Ordering},
 	},
 	time::{Duration, SystemTime, UNIX_EPOCH},
 };
@@ -119,8 +119,8 @@ impl From<ClientError> for BatchError {
 	}
 }
 /// Returns the subscription-mask bit for one stable hook event id.
-pub const fn hook_event_mask(event: HookEventId) -> u128 {
-	1_u128 << event as u32
+pub const fn hook_event_mask(event: HookEventId) -> u64 {
+	1_u64 << event as u32
 }
 
 /// One hook-composed admission answer and its narrowed authority envelope.
@@ -160,7 +160,7 @@ pub enum InvocationHookRequest {
 /// Atomic union-mask and hook request sender shared by invocation pumps.
 #[derive(Clone, Debug)]
 pub struct InvocationHookBus {
-	union: Arc<AtomicU128>,
+	union: Arc<AtomicU64>,
 	tx:    flume::Sender<InvocationHookRequest>,
 }
 
@@ -168,16 +168,16 @@ impl InvocationHookBus {
 	/// Creates a hook bus and its single CONTROL-side request receiver.
 	pub fn channel() -> (Self, Receiver<InvocationHookRequest>) {
 		let (tx, rx) = flume::unbounded();
-		(Self { union: Arc::new(AtomicU128::new(0)), tx }, rx)
+		(Self { union: Arc::new(AtomicU64::new(0)), tx }, rx)
 	}
 
 	/// Replaces the registered union mask in one atomic publication.
-	pub fn replace_union_mask(&self, mask: u128) {
+	pub fn replace_union_mask(&self, mask: u64) {
 		self.union.store(mask, Ordering::Release);
 	}
 
 	/// Returns the currently published union mask.
-	pub fn union_mask(&self) -> u128 {
+	pub fn union_mask(&self) -> u64 {
 		self.union.load(Ordering::Acquire)
 	}
 

--- a/crates/agent/src/batch.rs
+++ b/crates/agent/src/batch.rs
@@ -122,13 +122,6 @@ impl From<ClientError> for BatchError {
 pub const fn hook_event_mask(event: HookEventId) -> u64 {
 	1_u64 << event as u32
 }
-/// Compile-time ceiling: the highest `HookEventId` must stay below `u64::BITS`
-/// so `hook_event_mask`'s `1_u64 << event` never overflows. Adding a 64th
-/// variant fails the build instead of silently corrupting every mask.
-const _: () = assert!(
-	(HookEventId::HookEventFallbackSucceeded as u32) < u64::BITS,
-	"hook_event_mask is u64: a 64th HookEventId needs a wider mask"
-);
 
 /// One hook-composed admission answer and its narrowed authority envelope.
 #[derive(Clone, Debug)]

--- a/crates/agent/src/control.rs
+++ b/crates/agent/src/control.rs
@@ -944,7 +944,7 @@ fn handle_command(
 		},
 		ControlCommand::WorkspaceRoots { reply } => {
 			let result = journal.load().and_then(|view| {
-				let primary = view.header().cwd.clone();
+				let primary = view.log().header().cwd.clone();
 				drop(view);
 				journal.workspace_roots(&primary)
 			});

--- a/crates/agent/src/journal.rs
+++ b/crates/agent/src/journal.rs
@@ -88,15 +88,10 @@ impl CachedReader {
 struct JournalLog<'a>(MutexGuard<'a, CachedReader>);
 
 impl Deref for JournalLog<'_> {
-	type Target = Log;
+	type Target = transcript::LiveLog;
 
 	fn deref(&self) -> &Self::Target {
-		self.0.transcript.log()
-	}
-}
-impl AsRef<transcript::LiveSet> for JournalLog<'_> {
-	fn as_ref(&self) -> &transcript::LiveSet {
-		self.0.transcript.live()
+		self.0.transcript.live_log()
 	}
 }
 
@@ -1022,9 +1017,7 @@ impl Journal {
 	///
 	/// The returned value holds the journal's reader lock. Callers must drop it
 	/// before mutating or otherwise reading this journal again.
-	pub fn load(
-		&self,
-	) -> Result<impl Deref<Target = Log> + AsRef<transcript::LiveSet> + '_, JournalError> {
+	pub fn load(&self) -> Result<impl Deref<Target = transcript::LiveLog> + '_, JournalError> {
 		if self.halted {
 			return Err(JournalError::Halted);
 		}
@@ -1128,7 +1121,7 @@ impl Journal {
 		output_schema: Option<Box<RawValue>>,
 		revival: ChildSessionInit,
 	) -> Result<u64, JournalError> {
-		if !self.load()?.is_empty() {
+		if !self.load()?.log().is_empty() {
 			return Err(JournalError::ChildInitNotFirst);
 		}
 		let agent = Some(revival.parent_id.clone());
@@ -1160,12 +1153,12 @@ impl Journal {
 			match kind {
 				ChildKind::Branch { checkpoint } => {
 					let mut live = transcript::LiveSet::new();
-					if !log.live_through_into(checkpoint, &mut live) {
+					if !log.log().live_through_into(checkpoint, &mut live) {
 						return Err(JournalError::InvalidEventIndex { index: checkpoint });
 					}
-					(Some(checkpoint), project::project_journal_items(&log, &live)?)
+					(Some(checkpoint), project::project_journal_items(log.log(), &live)?)
 				},
-				ChildKind::Fork => (None, project::project_journal_items(&log, log.as_ref())?),
+				ChildKind::Fork => (None, project::project_journal_items(log.log(), log.live())?),
 			}
 		};
 		let mut child = Self::create(path, header)?;
@@ -1182,7 +1175,7 @@ impl Journal {
 	/// Appends a branch summary only while its source checkpoint still exists.
 	pub fn branch_summary(&mut self, ts: u64, from: u64, summary: Str) -> Result<u64, JournalError> {
 		let log = self.load()?;
-		if log.get(from).is_none() {
+		if log.log().get(from).is_none() {
 			return Err(JournalError::InvalidEventIndex { index: from });
 		}
 		drop(log);
@@ -1204,7 +1197,7 @@ impl Journal {
 		mut compact: Compact,
 	) -> Result<Self, JournalError> {
 		let log = self.load()?;
-		if log.get(checkpoint).is_none() {
+		if log.log().get(checkpoint).is_none() {
 			return Err(JournalError::InvalidEventIndex { index: checkpoint });
 		}
 		drop(log);
@@ -1306,10 +1299,11 @@ impl Journal {
 		}
 		let (catch_up, host_revision) = {
 			let log = self.load()?;
-			let host_revision = u64::try_from(log.len()).expect("transcript event count fits in u64");
-			let mut catch_up = VecDeque::with_capacity(log.len());
+			let host_revision =
+				u64::try_from(log.log().len()).expect("transcript event count fits in u64");
+			let mut catch_up = VecDeque::with_capacity(log.log().len());
 			for index in 0..host_revision {
-				let record = match log.get(index) {
+				let record = match log.log().get(index) {
 					Some(transcript::Entry::Ok(event)) => {
 						replication_record(index, Some(event)).map_err(|source| {
 							JournalError::ReplicationAfterJournal { event_index: index, source }
@@ -1503,12 +1497,12 @@ impl Journal {
 		let log = self.load()?;
 		Ok(fold_workspace_roots(
 			primary,
-			(0..u64::try_from(log.len()).expect("journal length fits u64")).filter_map(|index| {
-				match log.get(index) {
+			(0..u64::try_from(log.log().len()).expect("journal length fits u64")).filter_map(
+				|index| match log.log().get(index) {
 					Some(transcript::Entry::Ok(event)) => Some(&event.kind),
 					Some(transcript::Entry::Tombstone(_)) | None => None,
-				}
-			}),
+				},
+			),
 		))
 	}
 
@@ -1723,14 +1717,14 @@ impl Journal {
 		}
 		let log = self.load()?;
 		let mut entries = Vec::new();
-		for index in 0..u64::try_from(log.len()).expect("journal length fits in u64") {
-			if query.live && !log.as_ref().contains(index) {
+		for index in 0..u64::try_from(log.log().len()).expect("journal length fits in u64") {
+			if query.live && !log.live().contains(index) {
 				continue;
 			}
 			if query.since.is_some_and(|since| index <= since) {
 				continue;
 			}
-			let Some(transcript::Entry::Ok(event)) = log.get(index) else {
+			let Some(transcript::Entry::Ok(event)) = log.log().get(index) else {
 				continue;
 			};
 			let Kind::Custom(custom) = &event.kind else {
@@ -1805,7 +1799,7 @@ impl Journal {
 		self.ensure_extension_write_allowed()?;
 		{
 			let log = self.load()?;
-			if target >= u64::try_from(log.len()).expect("journal length fits in u64") {
+			if target >= u64::try_from(log.log().len()).expect("journal length fits in u64") {
 				return Err(JournalError::InvalidTarget(target));
 			}
 		}
@@ -2064,7 +2058,7 @@ impl Journal {
 		key: &str,
 	) -> Result<Option<SessionStateValue>, JournalError> {
 		let log = self.load()?;
-		for (index, event) in log.custom(log.as_ref(), "omp.state.session.cas").rev() {
+		for (index, event) in log.log().custom(log.live(), "omp.state.session.cas").rev() {
 			let Kind::Custom(custom) = &event.kind else {
 				continue;
 			};
@@ -2153,7 +2147,11 @@ impl Journal {
 			return Err(state::Error::NamespaceDenied.into());
 		}
 		let log = self.load()?;
-		for (index, event) in log.custom(log.as_ref(), "omp.state.session.content").rev() {
+		for (index, event) in log
+			.log()
+			.custom(log.live(), "omp.state.session.content")
+			.rev()
+		{
 			let Kind::Custom(custom) = &event.kind else {
 				continue;
 			};
@@ -2365,7 +2363,7 @@ impl Journal {
 		let log = self.load()?;
 		let mut recorded = Vec::with_capacity(indexes.len());
 		for (index, expected) in indexes.iter().zip(events) {
-			let Some(transcript::Entry::Ok(actual)) = log.get(*index) else {
+			let Some(transcript::Entry::Ok(actual)) = log.log().get(*index) else {
 				return Err(JournalError::IdempotencyConflict(stamp.idempotency_key.clone()));
 			};
 			if actual.kind != expected.kind {
@@ -2632,7 +2630,7 @@ impl Journal {
 				.chain(&start.prompt_head_events)
 				.chain(&start.sequence_targets)
 			{
-				if !matches!(log.get(*target), Some(omp_storage::transcript::Entry::Ok(event)) if event_item(&event.kind).is_some())
+				if !matches!(log.log().get(*target), Some(omp_storage::transcript::Entry::Ok(event)) if event_item(&event.kind).is_some())
 				{
 					return Err(JournalError::InvalidTurnInput(*target));
 				}
@@ -3009,7 +3007,7 @@ impl Journal {
 		let log = self.load()?;
 		targets
 			.iter()
-			.map(|target| match log.get(*target) {
+			.map(|target| match log.log().get(*target) {
 				Some(transcript::Entry::Ok(event)) => event_item(&event.kind)
 					.cloned()
 					.ok_or(JournalError::InvalidTurnInput(*target)),
@@ -3031,7 +3029,7 @@ impl Journal {
 		let mut text = String::with_capacity(max_chars.min(4096));
 		let mut chars = 0_usize;
 		for target in targets {
-			let item = match log.get(*target) {
+			let item = match log.log().get(*target) {
 				Some(transcript::Entry::Ok(event)) => {
 					event_item(&event.kind).ok_or(JournalError::InvalidTurnInput(*target))?
 				},
@@ -3238,8 +3236,8 @@ impl Journal {
 	pub fn recover_regime_records(&self) -> Result<Vec<RegimeRecord>, JournalError> {
 		let log = self.load()?;
 		let mut latest = BTreeMap::<Str, RegimeRecord>::new();
-		for index in log.as_ref().iter() {
-			let Some(transcript::Entry::Ok(event)) = log.get(index) else {
+		for index in log.live().iter() {
+			let Some(transcript::Entry::Ok(event)) = log.log().get(index) else {
 				continue;
 			};
 			let Kind::Custom(custom) = &event.kind else {
@@ -3263,8 +3261,8 @@ impl Journal {
 	pub fn settle_rejections(&self, turn_id: &str) -> Result<Vec<RegimeFact>, JournalError> {
 		let log = self.load()?;
 		let mut facts = Vec::new();
-		for index in log.as_ref().iter() {
-			let Some(transcript::Entry::Ok(event)) = log.get(index) else {
+		for index in log.live().iter() {
+			let Some(transcript::Entry::Ok(event)) = log.log().get(index) else {
 				continue;
 			};
 			let Kind::Custom(custom) = &event.kind else {
@@ -3548,7 +3546,7 @@ impl Journal {
 		}
 		{
 			let log = self.load()?;
-			if !matches!(log.get(target), Some(omp_storage::transcript::Entry::Ok(event)) if event_item(&event.kind).is_some())
+			if !matches!(log.log().get(target), Some(omp_storage::transcript::Entry::Ok(event)) if event_item(&event.kind).is_some())
 			{
 				return Err(JournalError::InvalidItemTarget(target));
 			}
@@ -4397,7 +4395,7 @@ mod tests {
 		omp_core::Ulid::from_string(recovery_turn.as_str()).expect("recovery turn id is a ULID");
 		assert_eq!(indexes.len(), 1);
 		let log = reopened.load().expect("load recovery");
-		let Some(Entry::Ok(event)) = log.get(indexes[0]) else {
+		let Some(Entry::Ok(event)) = log.log().get(indexes[0]) else {
 			panic!("recovered input missing");
 		};
 		let Kind::TurnInput(input) = &event.kind else {
@@ -4593,9 +4591,9 @@ mod tests {
 
 		let reopened = Journal::open(&path).expect("recover second occurrence");
 		let log = reopened.load().expect("load recovery");
-		let results = (0..u64::try_from(log.len()).expect("journal length"))
+		let results = (0..u64::try_from(log.log().len()).expect("journal length"))
 			.filter_map(|index| {
-				let Entry::Ok(event) = log.get(index)? else {
+				let Entry::Ok(event) = log.log().get(index)? else {
 					return None;
 				};
 				let item = event_item(&event.kind)?;
@@ -4776,8 +4774,8 @@ mod tests {
 		assert_eq!(reopened.receipt("turn"), Some(&receipt));
 		assert!(reopened.pending_turn().is_none());
 		let view = reopened.load().expect("load recovered");
-		let projected = project_journal(&view, view.as_ref(), &omp_tool::Registry::new(), &caps())
-			.expect("project recovered");
+		let projected =
+			project_journal(&view, &omp_tool::Registry::new(), &caps()).expect("project recovered");
 		assert_eq!(projected.items[1].seq, 2, "reopen must recover the missing sequence patch");
 		fs::remove_file(path).expect("remove journal");
 	}
@@ -4829,8 +4827,8 @@ mod tests {
 		let reopened = Journal::open(&path).expect("reopen partial turn");
 		assert_eq!(reopened.pending_turn(), Some(&start));
 		let view = reopened.load().expect("load partial");
-		let projected = project_journal(&view, view.as_ref(), &omp_tool::Registry::new(), &caps())
-			.expect("project partial");
+		let projected =
+			project_journal(&view, &omp_tool::Registry::new(), &caps()).expect("project partial");
 		assert_eq!(projected.items, vec![message("system"), message("input")]);
 		fs::remove_file(path).expect("remove journal");
 	}
@@ -4904,15 +4902,15 @@ mod tests {
 			.amend_seq(3, target, 9)
 			.expect("append sequence amendment");
 		let log = journal.load().expect("load journal");
-		let Some(Entry::Ok(event)) = log.get(target) else {
+		let Some(Entry::Ok(event)) = log.log().get(target) else {
 			panic!("item event missing")
 		};
 		let Kind::Item(record) = &event.kind else {
 			panic!("target is not an item")
 		};
 		assert_eq!(record.item.seq, 0);
-		let projected = project_journal(&log, log.as_ref(), &omp_tool::Registry::new(), &caps())
-			.expect("project journal");
+		let projected =
+			project_journal(&log, &omp_tool::Registry::new(), &caps()).expect("project journal");
 		assert_eq!(projected.items[0].seq, 9);
 		drop(log);
 		drop(journal);
@@ -4958,13 +4956,10 @@ mod tests {
 			}
 			drop(writer);
 
-			let pending = transcript::load(&path).expect("load incomplete rewrite");
-			let mut pending_live = transcript::LiveSet::new();
-			pending.live_into(&mut pending_live);
-			assert!(pending_live.iter().eq([old_head, tail]));
-			let pending_thread =
-				project_journal(&pending, &pending_live, &omp_tool::Registry::new(), &caps())
-					.expect("project old live chain");
+			let pending_view = transcript::load_live(&path).expect("load incomplete rewrite");
+			assert!(pending_view.live().iter().eq([old_head, tail]));
+			let pending_thread = project_journal(&pending_view, &omp_tool::Registry::new(), &caps())
+				.expect("project old live chain");
 			assert_eq!(pending_thread.items, vec![message("old-head"), message("tail")]);
 
 			let recovered = Journal::open(&path).expect("recover rewrite");
@@ -4984,7 +4979,7 @@ mod tests {
 				message("tail")
 			]);
 			let view = recovered.load().expect("load recovered journal");
-			let projected = project_journal(&view, view.as_ref(), &omp_tool::Registry::new(), &caps())
+			let projected = project_journal(&view, &omp_tool::Registry::new(), &caps())
 				.expect("project recovered rewrite");
 			drop(view);
 			let projected_bytes = projected.encode_to_vec();
@@ -4999,9 +4994,8 @@ mod tests {
 				live
 			);
 			let view = reopened.load().expect("reload journal");
-			let reprojection =
-				project_journal(&view, view.as_ref(), &omp_tool::Registry::new(), &caps())
-					.expect("reproject completed rewrite");
+			let reprojection = project_journal(&view, &omp_tool::Registry::new(), &caps())
+				.expect("reproject completed rewrite");
 			drop(view);
 			assert_eq!(reprojection.encode_to_vec(), projected_bytes);
 			drop(reopened);
@@ -5083,7 +5077,7 @@ mod tests {
 			assert_eq!(live.as_slice(), indexes.as_slice());
 			assert_eq!(journal.items_at(&live).expect("project item values").len(), live.len());
 		}
-		assert_eq!(journal.load().expect("borrow final journal").len(), 128);
+		assert_eq!(journal.load().expect("borrow final journal").log().len(), 128);
 		drop(journal);
 		fs::remove_file(path).expect("remove journal");
 	}

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(integer_atomics)]
 //! Transport-neutral foundations for durable, interruptible OMP agent loops.
 //!
 //! The crate composes immutable configuration snapshots, deterministic system

--- a/crates/agent/src/loop.rs
+++ b/crates/agent/src/loop.rs
@@ -780,7 +780,7 @@ impl<C: TurnClient + Clone> Agent<C> {
 	}
 
 	/// Replaces the registered hook union mask in one atomic publication.
-	pub fn replace_hook_mask(&self, mask: u128) {
+	pub fn replace_hook_mask(&self, mask: u64) {
 		self.hook_bus.replace_union_mask(mask);
 	}
 

--- a/crates/agent/src/loop.rs
+++ b/crates/agent/src/loop.rs
@@ -1325,12 +1325,8 @@ impl<C: TurnClient + Clone> Agent<C> {
 		self.last_toolset_hash = None;
 		*self.checkpoint_state.lock() = recover_checkpoint_state(&self.journal)?;
 		let journal = self.journal.load()?;
-		let projected = project_journal(
-			&journal,
-			journal.as_ref(),
-			self.state.snapshot().registry.as_ref(),
-			&self.caps,
-		)?;
+		let projected =
+			project_journal(&journal, self.state.snapshot().registry.as_ref(), &self.caps)?;
 		Ok(projected.items)
 	}
 
@@ -2666,7 +2662,7 @@ impl<C: TurnClient + Clone> Agent<C> {
 		let lifted_reseed = if changed_toolset {
 			self.transition(AgentPhase::Projecting);
 			let journal = self.journal.load()?;
-			Some(project_journal(&journal, journal.as_ref(), snapshot.registry.as_ref(), &self.caps)?)
+			Some(project_journal(&journal, snapshot.registry.as_ref(), &self.caps)?)
 		} else {
 			None
 		};
@@ -2684,8 +2680,7 @@ impl<C: TurnClient + Clone> Agent<C> {
 				input.clone()
 			} else if full {
 				let journal = self.journal.load()?;
-				let projected =
-					project_journal(&journal, journal.as_ref(), snapshot.registry.as_ref(), &self.caps)?;
+				let projected = project_journal(&journal, snapshot.registry.as_ref(), &self.caps)?;
 				let context_handlers = self.context_projection_handler.is_some()
 					|| self.hook_bus.union_mask()
 						& hook_event_mask(v1::HookEventId::HookEventThreadProjection)
@@ -5558,9 +5553,9 @@ mod tests {
 			)
 		}));
 		let log = agent.journal().load().expect("load aborted journal");
-		assert!((0..u64::try_from(log.len()).expect("log length fits")).any(|index| {
+		assert!((0..u64::try_from(log.log().len()).expect("log length fits")).any(|index| {
 			matches!(
-				log.get(index),
+				log.log().get(index),
 				Some(Entry::Ok(event))
 					if matches!(&event.kind, Kind::TurnAbort(abort) if !abort.recoverable)
 			)
@@ -6029,8 +6024,8 @@ mod tests {
 		let log = agent.journal.load().expect("load rewind journal");
 		let mut settled = None;
 		let mut rewinds = Vec::new();
-		for index in 0..u64::try_from(log.len()).expect("journal length") {
-			let Some(Entry::Ok(event)) = log.get(index) else {
+		for index in 0..u64::try_from(log.log().len()).expect("journal length") {
+			let Some(Entry::Ok(event)) = log.log().get(index) else {
 				continue;
 			};
 			match &event.kind {
@@ -6190,11 +6185,11 @@ mod tests {
 		assert!(reminder, "recovery turn carries the stream-rule reminder");
 		let log = agent.journal().load().expect("load journal");
 		let injections = log
-			.as_ref()
+			.live()
 			.iter()
 			.filter(|index| {
 				matches!(
-					log.get(*index),
+					log.log().get(*index),
 					Some(omp_storage::transcript::Entry::Ok(event))
 						if matches!(
 							&event.kind,
@@ -6389,9 +6384,8 @@ mod tests {
 			)
 		}));
 		let log = agent.journal().load().expect("journal log");
-		let provider =
-			project_journal(&log, log.as_ref(), state.snapshot().registry.as_ref(), &test_caps())
-				.expect("provider projection");
+		let provider = project_journal(&log, state.snapshot().registry.as_ref(), &test_caps())
+			.expect("provider projection");
 		assert_eq!(
 			display.len(),
 			provider.items.len() + 1,

--- a/crates/agent/src/project.rs
+++ b/crates/agent/src/project.rs
@@ -8,7 +8,9 @@ use omp_proto::{
 	thread::v1::{self as thread_pb, blob, item, part},
 };
 use omp_scribe::{Props, Template};
-use omp_storage::transcript::{AmendPatch, Entry, Kind, LiveSet, Log, truncate_persisted_text};
+use omp_storage::transcript::{
+	AmendPatch, Entry, Kind, LiveLog, LiveSet, Log, truncate_persisted_text,
+};
 use omp_tool::{
 	Abort, CallOutcome, CapsBase, Part as ToolPart, ProjectedCall, PromptCaps, RecordedCallOwned,
 	Registry as ToolRegistry, Rev, TOOL_REV_PROP, ToolIdentity,
@@ -169,12 +171,11 @@ fn is_silent_abort_item(item: &thread_pb::Item) -> bool {
 /// Rewinds are already resolved in `live`. Sequence amendments update only the
 /// working copy; original item events remain untouched.
 pub fn project_journal(
-	log: &Log,
-	live: &LiveSet,
+	view: &LiveLog,
 	tool_registry: &ToolRegistry,
 	caps: &CapsBase,
 ) -> Result<thread_pb::Thread, ProjectionError> {
-	let items = project_journal_items(log, live)?;
+	let items = project_journal_items(view.log(), view.live())?;
 	project_thread_history(&thread_pb::Thread { items }, tool_registry, caps)
 }
 
@@ -663,7 +664,7 @@ mod tests {
 		thread::v1::{self as thread_pb, blob, item},
 	};
 	use omp_storage::transcript::{
-		AmendPatch, Event, Header, ItemRecord, Kind, LiveSet, SessionId, Writer, load,
+		AmendPatch, Event, Header, ItemRecord, Kind, SessionId, Writer, load, load_live,
 	};
 	use omp_tool::{CapsBase, ModelClass, TOOL_REV_PROP};
 
@@ -739,9 +740,8 @@ mod tests {
 			panic!("durable entry is an assistant item");
 		};
 		assert_eq!(record.item, item);
-		let mut live = LiveSet::new();
-		log.live_into(&mut live);
-		let projected = project_journal(&log, &live, &omp_tool::Registry::new(), &CapsBase {
+		let view = load_live(&path).expect("load live transcript");
+		let projected = project_journal(&view, &omp_tool::Registry::new(), &CapsBase {
 			maximum_parts:      1,
 			maximum_text_bytes: 1,
 			media:              false,
@@ -794,10 +794,8 @@ mod tests {
 			.expect("append user item");
 		drop(writer);
 
-		let log = load(&path).expect("load transcript");
-		let mut live = LiveSet::new();
-		log.live_into(&mut live);
-		let projected = project_journal(&log, &live, &omp_tool::Registry::new(), &CapsBase {
+		let view = load_live(&path).expect("load transcript");
+		let projected = project_journal(&view, &omp_tool::Registry::new(), &CapsBase {
 			maximum_parts:      1,
 			maximum_text_bytes: 1024,
 			media:              false,
@@ -853,10 +851,8 @@ mod tests {
 			.expect("append content drop");
 		drop(writer);
 
-		let log = load(&path).expect("load transcript");
-		let mut live = LiveSet::new();
-		log.live_into(&mut live);
-		let projected = project_journal(&log, &live, &omp_tool::Registry::new(), &CapsBase {
+		let view = load_live(&path).expect("load transcript");
+		let projected = project_journal(&view, &omp_tool::Registry::new(), &CapsBase {
 			maximum_parts:      8,
 			maximum_text_bytes: 4_096,
 			media:              true,

--- a/crates/agent/src/revival.rs
+++ b/crates/agent/src/revival.rs
@@ -177,7 +177,7 @@ mod tests {
 
 		let revived = revive(&path, AgentSnapshot::default()).expect("revive compacted journal");
 		let log = revived.journal.load().expect("load revived journal");
-		let thread = project_journal(&log, log.as_ref(), &Registry::new(), &CapsBase {
+		let thread = project_journal(&log, &Registry::new(), &CapsBase {
 			maximum_parts:      8,
 			maximum_text_bytes: 4096,
 			media:              true,

--- a/crates/agent/tests/journal_requests.rs
+++ b/crates/agent/tests/journal_requests.rs
@@ -118,7 +118,8 @@ fn atomic_replay_returns_recorded_indexes_and_core_stamps_authorship() {
 	);
 	let view = reopened.load().expect("load journal");
 	let customs = view
-		.custom(view.as_ref(), "dev.example.fact")
+		.log()
+		.custom(view.live(), "dev.example.fact")
 		.collect::<Vec<_>>();
 	assert_eq!(customs.len(), 2);
 	let Kind::Custom(first) = &customs[0].1.kind else {

--- a/crates/app/src/chat_ui.rs
+++ b/crates/app/src/chat_ui.rs
@@ -1539,10 +1539,8 @@ fn subscribe_chat_events(bus: &omp_agent::EventBus) -> omp_agent::EventSubscript
 }
 
 fn replica_items(path: &Path, registry: &Registry) -> miette::Result<Vec<Item>> {
-	let log = omp_storage::transcript::load(path).into_diagnostic()?;
-	let mut live = transcript::LiveSet::new();
-	log.live_into(&mut live);
-	Ok(omp_agent::project_journal(&log, &live, registry, &omp_driver::chat::CHAT_CAPS_BASE)
+	let view = omp_storage::transcript::load_live(path).into_diagnostic()?;
+	Ok(omp_agent::project_journal(&view, registry, &omp_driver::chat::CHAT_CAPS_BASE)
 		.into_diagnostic()?
 		.items)
 }
@@ -1931,7 +1929,6 @@ where
 						let journal = agent.journal().load()?;
 						let projected = omp_agent::project_journal(
 							&journal,
-							journal.as_ref(),
 							maintenance_registry.as_ref(),
 							&omp_driver::chat::CHAT_CAPS_BASE,
 						)?;
@@ -1962,7 +1959,7 @@ where
 						let parent_id = agent.journal().session_id().clone();
 						let root = {
 							let journal = agent.journal().load().map_err(|error| error.to_string())?;
-							journal.header().cwd.clone()
+							journal.log().header().cwd.clone()
 						};
 						let _sessions_dir = child_path
 							.parent()

--- a/crates/app/src/render_cmd.rs
+++ b/crates/app/src/render_cmd.rs
@@ -85,17 +85,14 @@ fn render_session(args: &RenderArgs, data_dir: &Path, cwd: &Path) -> miette::Res
 	let open_start = Instant::now();
 	let path = resolve_target(args.session.as_deref(), data_dir, cwd)?;
 	let source_bytes = fs::metadata(&path).into_diagnostic()?.len();
-	let log = omp_storage::transcript::load(&path).into_diagnostic()?;
+	let view = omp_storage::transcript::load_live(&path).into_diagnostic()?;
 	let open = open_start.elapsed();
 
 	let project_start = Instant::now();
-	let mut live = transcript::LiveSet::new();
-	log.live_into(&mut live);
 	let registry = Registry::new();
 	let renderers = builtin_renderers()?;
-	let projection =
-		omp_agent::project_journal(&log, &live, &registry, &omp_driver::chat::CHAT_CAPS_BASE)
-			.into_diagnostic()?;
+	let projection = omp_agent::project_journal(&view, &registry, &omp_driver::chat::CHAT_CAPS_BASE)
+		.into_diagnostic()?;
 	let project = project_start.elapsed();
 
 	let replay_start = Instant::now();
@@ -159,12 +156,9 @@ pub(crate) fn history_frame(
 	registry: &Registry,
 	renderers: &RenderRegistry,
 ) -> miette::Result<Frame> {
-	let log = omp_storage::transcript::load(path).into_diagnostic()?;
-	let mut live = transcript::LiveSet::new();
-	log.live_into(&mut live);
-	let projection =
-		omp_agent::project_journal(&log, &live, registry, &omp_driver::chat::CHAT_CAPS_BASE)
-			.into_diagnostic()?;
+	let view = omp_storage::transcript::load_live(path).into_diagnostic()?;
+	let projection = omp_agent::project_journal(&view, registry, &omp_driver::chat::CHAT_CAPS_BASE)
+		.into_diagnostic()?;
 	let mut chat = replay_chat(&projection.items, renderers);
 	Ok(retirement_frame(&mut chat, 120))
 }

--- a/crates/app/src/render_cmd.rs
+++ b/crates/app/src/render_cmd.rs
@@ -85,10 +85,12 @@ fn render_session(args: &RenderArgs, data_dir: &Path, cwd: &Path) -> miette::Res
 	let open_start = Instant::now();
 	let path = resolve_target(args.session.as_deref(), data_dir, cwd)?;
 	let source_bytes = fs::metadata(&path).into_diagnostic()?.len();
-	let view = omp_storage::transcript::load_live(&path).into_diagnostic()?;
 	let open = open_start.elapsed();
 
+	// `load_live` folds the live chain, so the journal load is timed with the
+	// phase the report labels "journal live-set projection".
 	let project_start = Instant::now();
+	let view = omp_storage::transcript::load_live(&path).into_diagnostic()?;
 	let registry = Registry::new();
 	let renderers = builtin_renderers()?;
 	let projection = omp_agent::project_journal(&view, &registry, &omp_driver::chat::CHAT_CAPS_BASE)

--- a/crates/driver/src/chat.rs
+++ b/crates/driver/src/chat.rs
@@ -1491,8 +1491,8 @@ impl<C: TurnClient + Clone + Send + 'static> ChatParentHost<C> {
 			tracing::warn!(agent = %record.id, %error, "recovered child journal read failed");
 			SupervisorError::RevivalFailed { id: record.id.clone() }
 		})?;
-		let revival = (0..log.len() as u64)
-			.filter_map(|index| log.get(index))
+		let revival = (0..log.log().len() as u64)
+			.filter_map(|index| log.log().get(index))
 			.find_map(|entry| match entry {
 				transcript::Entry::Ok(event) => match &event.kind {
 					Kind::Init { revival: Some(revival), .. } => Some(revival.clone()),
@@ -5834,10 +5834,10 @@ pub fn open_session(
 			})?;
 			let mut journal = Journal::open(&path)?;
 			let view = journal.load()?;
-			if view.header().id.0 != id {
+			if view.log().header().id.0 != id {
 				return Err(ChatError::SessionMismatch(id));
 			}
-			let recorded_root = view.header().cwd.clone();
+			let recorded_root = view.log().header().cwd.clone();
 			drop(view);
 			let current_root = journal.workspace_roots(&recorded_root)?;
 			if current_root.primary() != root && !matches!(open, SessionOpen::ResumeMoved(_)) {
@@ -5879,7 +5879,7 @@ pub fn open_session(
 		})?,
 	};
 	let view = journal.load()?;
-	let initial_items = project_journal(&view, view.as_ref(), registry, &CHAT_CAPS_BASE)?.items;
+	let initial_items = project_journal(&view, registry, &CHAT_CAPS_BASE)?.items;
 	drop(view);
 	Ok(Session { id, journal, initial_items })
 }
@@ -5995,10 +5995,10 @@ fn create_indexed_fork(
 ) -> Result<Journal, ChatError> {
 	let source = Journal::open(source_path)?;
 	let source_view = source.load()?;
-	if source_view.header().id.0 != *source_id {
+	if source_view.log().header().id.0 != *source_id {
 		return Err(ChatError::SessionMismatch(source_id.clone()));
 	}
-	let recorded_root = source_view.header().cwd.clone();
+	let recorded_root = source_view.log().header().cwd.clone();
 	drop(source_view);
 	if source.workspace_roots(&recorded_root)?.primary() != root {
 		return Err(ChatError::SessionProjectMismatch { session: source_id.clone() });
@@ -6984,7 +6984,7 @@ mod tests {
 		.expect("torn session resumes");
 		assert_eq!(session.id, id);
 		let log = session.journal.load().expect("repaired journal loads");
-		assert_eq!(log.len(), 1, "the torn fragment is truncated, intact events remain");
+		assert_eq!(log.log().len(), 1, "the torn fragment is truncated, intact events remain");
 	}
 
 	#[tokio::test]

--- a/crates/e2e/tests/p10_lift_idempotence.rs
+++ b/crates/e2e/tests/p10_lift_idempotence.rs
@@ -94,8 +94,8 @@ async fn p10_edit_lift_is_idempotent_across_journal_projections() -> Result<()> 
 	let journal = Journal::open(&transcript)?;
 	let log = journal.load()?;
 
-	let first = project_journal(&log, log.as_ref(), registry.as_ref(), &CAPS)?;
-	let second = project_journal(&log, log.as_ref(), registry.as_ref(), &CAPS)?;
+	let first = project_journal(&log, registry.as_ref(), &CAPS)?;
+	let second = project_journal(&log, registry.as_ref(), &CAPS)?;
 	let (first_call, first_result) = projected_pair(&first);
 	let (second_call, second_result) = projected_pair(&second);
 

--- a/crates/e2e/tests/p3_detached_jobs.rs
+++ b/crates/e2e/tests/p3_detached_jobs.rs
@@ -472,8 +472,8 @@ fn job_event_counts(journal: &Journal, job_id: &str) -> (usize, usize) {
 	let log = journal.load().expect("load durable transcript");
 	let mut registered = 0;
 	let mut settled = 0;
-	for index in 0..u64::try_from(log.len()).expect("log length fits u64") {
-		let Some(Entry::Ok(event)) = log.get(index) else {
+	for index in 0..u64::try_from(log.log().len()).expect("log length fits u64") {
+		let Some(Entry::Ok(event)) = log.log().get(index) else {
 			continue;
 		};
 		match &event.kind {

--- a/crates/e2e/tests/p4_schema_isolation.rs
+++ b/crates/e2e/tests/p4_schema_isolation.rs
@@ -433,7 +433,7 @@ async fn historical_edit_schema_is_isolated_and_lifts_from_recorded_truth() {
 		matches!(without_lift.project(recorded.clone()), omp_tool::ProjectedCall::Data(data) if data == recorded)
 	);
 
-	let data = project_journal(&log, log.as_ref(), &without_lift, &CAPS_BASE)
+	let data = project_journal(&log, &without_lift, &CAPS_BASE)
 		.expect("unliftable historical revision projects as canonical data");
 	let recorded_schema = original.items[0]
 		.props
@@ -513,10 +513,10 @@ async fn historical_edit_schema_is_isolated_and_lifts_from_recorded_truth() {
 		serde_json::to_vec(lifted_schema.as_value()).expect("lifted schema serializes"),
 		HL2_SCHEMA
 	);
-	let first = project_journal(&log, log.as_ref(), &with_lift, &CAPS_BASE)
+	let first = project_journal(&log, &with_lift, &CAPS_BASE)
 		.expect("recorded hl.1 truth lifts to live hl.2");
-	let second = project_journal(&log, log.as_ref(), &with_lift, &CAPS_BASE)
-		.expect("unchanged journal reprojects");
+	let second =
+		project_journal(&log, &with_lift, &CAPS_BASE).expect("unchanged journal reprojects");
 	assert_eq!(
 		first.encode_to_vec(),
 		second.encode_to_vec(),
@@ -658,7 +658,7 @@ async fn historical_edit_schema_is_isolated_and_lifts_from_recorded_truth() {
 	);
 	let projected_full = {
 		let log = journal.load().expect("load persisted transcript fixture");
-		project_journal(&log, log.as_ref(), &registry(true), &CAPS_BASE)
+		project_journal(&log, &registry(true), &CAPS_BASE)
 			.expect("accepted history remains projectable")
 	};
 	assert_eq!(expected_full, projected_full.encode_to_vec());

--- a/crates/e2e/tests/p6_crash_resume.rs
+++ b/crates/e2e/tests/p6_crash_resume.rs
@@ -753,15 +753,15 @@ fn assert_binary_resume_journal(path: &Path, turn_id: &str) {
 	assert_eq!(receipt.turn_id.as_str(), turn_id);
 	let log = journal.load().expect("load CLI-resumed journal");
 	assert_eq!(
-		event_count(&log, |kind| matches!(
+		event_count(log.log(), |kind| matches!(
 			kind,
 			Kind::TurnReceipt(receipt) if receipt.turn_id.as_str() == turn_id
 		)),
 		1,
 		"CLI resume duplicated its terminal receipt",
 	);
-	let projected = project_journal(&log, log.as_ref(), &Registry::new(), &caps())
-		.expect("project CLI-resumed journal");
+	let projected =
+		project_journal(&log, &Registry::new(), &caps()).expect("project CLI-resumed journal");
 	let outputs = projected
 		.items
 		.iter()
@@ -1300,14 +1300,14 @@ fn assert_single_receipt(path: &Path, turn_id: &str) {
 	let journal = Journal::open(path).expect("open completed replay journal");
 	let log = journal.load().expect("load completed replay journal");
 	let receipts = event_count(
-		&log,
+		log.log(),
 		|kind| matches!(kind, Kind::TurnReceipt(receipt) if receipt.turn_id == turn_id),
 	);
 	assert_eq!(receipts, 1, "terminal receipt duplicated");
 	let receipt = journal.receipt(turn_id).expect("root turn receipt");
 	assert_eq!(receipt.outcome.output.len(), 1);
-	let projected = project_journal(&log, log.as_ref(), &Registry::new(), &caps())
-		.expect("project replay journal");
+	let projected =
+		project_journal(&log, &Registry::new(), &caps()).expect("project replay journal");
 	assert_eq!(projected.items.len(), 3, "replay duplicated or omitted canonical items");
 	assert_eq!(
 		projected
@@ -1338,11 +1338,12 @@ fn assert_single_receipt(path: &Path, turn_id: &str) {
 fn assert_recovered_sequences(path: &Path) {
 	let journal = Journal::open(path).expect("open sequence-recovered journal");
 	let log = journal.load().expect("load sequence-recovered journal");
-	let amendments =
-		event_count(&log, |kind| matches!(kind, Kind::Amend { patch: AmendPatch::Seq { .. }, .. }));
+	let amendments = event_count(log.log(), |kind| {
+		matches!(kind, Kind::Amend { patch: AmendPatch::Seq { .. }, .. })
+	});
 	assert_eq!(amendments, 2, "sequence recovery duplicated or omitted amendments");
-	let projected = project_journal(&log, log.as_ref(), &Registry::new(), &caps())
-		.expect("project recovered journal");
+	let projected =
+		project_journal(&log, &Registry::new(), &caps()).expect("project recovered journal");
 	let seqs: Vec<_> = projected.items.iter().map(|item| item.seq).collect();
 	assert_eq!(seqs, vec![1, 2, 3], "recovered sequence assignment drifted");
 }
@@ -1376,8 +1377,7 @@ fn assert_batch_recovery(journal_path: &Path, gateway_path: &Path) {
 			core_claims(),
 		)
 		.expect("register projection tool");
-	let projected =
-		project_journal(&log, log.as_ref(), &registry, &caps()).expect("project interrupted batch");
+	let projected = project_journal(&log, &registry, &caps()).expect("project interrupted batch");
 	let mut result_ids = Vec::new();
 	for item in &projected.items {
 		if let Some(item::Kind::ToolResult(result)) = &item.kind {

--- a/crates/proto/proto/omp/toolhost/v1/toolhost.proto
+++ b/crates/proto/proto/omp/toolhost/v1/toolhost.proto
@@ -536,6 +536,7 @@ enum HookEventId {
   HOOK_EVENT_RETRY_END = 61;
   HOOK_EVENT_FALLBACK_APPLIED = 62;
   HOOK_EVENT_FALLBACK_SUCCEEDED = 63;
+  reserved 64 to max;
 }
 
 // Revision 1 payloads for authoritative observational lifecycle events.

--- a/crates/storage/src/transcript/mod.rs
+++ b/crates/storage/src/transcript/mod.rs
@@ -46,8 +46,8 @@ pub use msg::{
 };
 pub use patch::Patch;
 pub use reader::{
-	DiagnosticKind, Entry, LiveSet, Log, ReadCounters, ReadDiagnostic, Reader, RefreshReport,
-	RefreshState, VisitReport, load, visit_batched,
+	DiagnosticKind, Entry, LiveLog, LiveSet, Log, ReadCounters, ReadDiagnostic, Reader,
+	RefreshReport, RefreshState, VisitReport, load, load_live, visit_batched,
 };
 pub use types::*;
 pub use writer::Writer;

--- a/crates/storage/src/transcript/reader.rs
+++ b/crates/storage/src/transcript/reader.rs
@@ -187,6 +187,28 @@ pub struct Log {
 	diagnostics: Vec<ReadDiagnostic>,
 }
 
+/// A transcript log paired with the live chain folded from it.
+///
+/// The pairing is constructed once, so a caller cannot present a live chain
+/// that belongs to a different log.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LiveLog {
+	log:  Log,
+	live: LiveSet,
+}
+
+impl LiveLog {
+	/// Returns the physical event log.
+	pub const fn log(&self) -> &Log {
+		&self.log
+	}
+
+	/// Returns the live chain folded from the log.
+	pub const fn live(&self) -> &LiveSet {
+		&self.live
+	}
+}
+
 impl Log {
 	/// Returns the line-zero identity header.
 	pub const fn header(&self) -> &Header {
@@ -457,8 +479,7 @@ pub struct Reader {
 	header_terminated: bool,
 	tail_bytes:        u64,
 	tail_diagnostic:   Option<ReadDiagnostic>,
-	log:               Log,
-	live:              LiveSet,
+	view:              LiveLog,
 }
 
 impl Reader {
@@ -537,8 +558,7 @@ impl Reader {
 			header_terminated,
 			tail_bytes,
 			tail_diagnostic,
-			log,
-			live,
+			view: LiveLog { log, live },
 		})
 	}
 
@@ -554,8 +574,10 @@ impl Reader {
 			header_terminated: false,
 			tail_bytes:        0,
 			tail_diagnostic:   None,
-			log:               Log { header, events: Vec::new(), diagnostics: Vec::new() },
-			live:              LiveSet::new(),
+			view:              LiveLog {
+				log:  Log { header, events: Vec::new(), diagnostics: Vec::new() },
+				live: LiveSet::new(),
+			},
 		}
 	}
 
@@ -571,7 +593,7 @@ impl Reader {
 				},
 				Err(error) => return Err(error),
 			};
-			if opened.log.header != self.log.header {
+			if opened.view.log.header != self.view.log.header {
 				return Err(changed_file("materialized transcript header changed"));
 			}
 			let records = opened.next_index();
@@ -676,10 +698,10 @@ impl Reader {
 		if Some(file_identity(&path_metadata)) != self.identity {
 			return Err(changed_file("transcript path was replaced during refresh"));
 		}
-		let first_new = self.log.events.len();
-		self.log.events.extend(entries);
-		self.log.diagnostics.extend(diagnostics);
-		self.log.fold_from(first_new, &mut self.live);
+		let first_new = self.view.log.events.len();
+		self.view.log.events.extend(entries);
+		self.view.log.diagnostics.extend(diagnostics);
+		self.view.log.fold_from(first_new, &mut self.view.live);
 		self.watermark = self.watermark.saturating_add(consumed);
 		self.header_terminated = header_terminated;
 		let state = if self.tail_bytes != 0 {
@@ -690,20 +712,26 @@ impl Reader {
 		Ok(self.report(state))
 	}
 
+	/// Returns the decoded transcript and its live-chain projection.
+	pub const fn live_log(&self) -> &LiveLog {
+		&self.view
+	}
+
 	/// Returns the decoded transcript prefix.
 	pub const fn log(&self) -> &Log {
-		&self.log
+		self.view.log()
 	}
 
 	/// Returns the live-chain projection for the decoded prefix.
 	pub const fn live(&self) -> &LiveSet {
-		&self.live
+		self.view.live()
 	}
 
 	/// Iterates permanent malformed diagnostics followed by the current torn
 	/// tail diagnostic, when present.
 	pub fn diagnostics(&self) -> impl Iterator<Item = ReadDiagnostic> + '_ {
 		self
+			.view
 			.log
 			.diagnostics
 			.iter()
@@ -713,7 +741,7 @@ impl Reader {
 
 	/// Returns damage counters for the decoded prefix and current tail.
 	pub fn counters(&self) -> ReadCounters {
-		let mut counters = self.log.counters();
+		let mut counters = self.view.log.counters();
 		if self.tail_diagnostic.is_some() {
 			counters.truncated = counters.truncated.saturating_add(1);
 		}
@@ -722,7 +750,7 @@ impl Reader {
 
 	/// Returns the durable index assigned to the next committed event.
 	pub fn next_index(&self) -> u64 {
-		u64::try_from(self.log.len()).expect("event indexes fit in u64")
+		u64::try_from(self.view.log.len()).expect("event indexes fit in u64")
 	}
 
 	/// Returns the complete-line byte watermark.
@@ -810,6 +838,14 @@ pub fn load(path: &Path) -> Result<Log, Error> {
 		|| {},
 	)?;
 	Ok(Log { header: report.header, events, diagnostics: report.diagnostics })
+}
+
+/// Loads a transcript and folds its live chain in one pass.
+pub fn load_live(path: &Path) -> Result<LiveLog, Error> {
+	let log = load(path)?;
+	let mut live = LiveSet::new();
+	log.live_into(&mut live);
+	Ok(LiveLog { log, live })
 }
 
 /// Visits physical event records using bounded `BufRead` scratch.
@@ -941,4 +977,72 @@ fn push_tombstone(
 	let source = String::from_utf8_lossy(line);
 	let raw = to_raw_value(source.as_ref()).expect("a JSON string is always serializable");
 	events.push(Entry::Tombstone(raw));
+}
+
+#[cfg(test)]
+mod tests {
+	use std::path::PathBuf;
+
+	use omp_core::{Hash32, Str, sf};
+	use omp_proto::inference::v1 as pb;
+	use tempfile::tempdir;
+
+	use super::{Reader, load_live};
+	use crate::transcript::{Event, Header, Kind, SessionId, TitleSource, TurnReceipt, Writer};
+
+	fn header() -> Header {
+		Header {
+			v:       4,
+			id:      SessionId(sf!("session")),
+			created: 1,
+			cwd:     PathBuf::from("/tmp/work"),
+		}
+	}
+
+	fn title(ts: u64, value: &str) -> Event {
+		Event { ts, kind: Kind::Title { title: Str::new(value), source: TitleSource::User } }
+	}
+
+	#[test]
+	fn load_live_matches_reader_live_set_with_rewind_and_incomplete_receipt() {
+		let directory = tempdir().expect("temporary directory");
+		let path = directory.path().join("session.jsonl");
+		let mut writer = Writer::create(&path, &header()).expect("create transcript");
+		writer.append(&title(1, "kept")).expect("event zero");
+		writer.append(&title(2, "discarded")).expect("event one");
+		writer
+			.append(&Event { ts: 3, kind: Kind::Rewind { to: Some(0) } })
+			.expect("rewind");
+		writer
+			.append(&title(4, "after-rewind"))
+			.expect("event three");
+		writer
+			.append(&Event {
+				ts:   5,
+				kind: Kind::TurnReceipt(TurnReceipt {
+					turn_id:            sf!("turn"),
+					prompt_hash:        Hash32::new([9; 32]),
+					prompt_head_events: Vec::new(),
+					// Incomplete: claimed item indexes without matching outcome output.
+					item_events:        vec![0],
+					outcome:            pb::Outcome { output: Vec::new(), ..Default::default() },
+				}),
+			})
+			.expect("incomplete receipt");
+		drop(writer);
+
+		let loaded = load_live(&path).expect("load_live pairs the fold");
+		// Reader is the producer Journal::load refreshes under its lock guard.
+		let reader = Reader::open(&path).expect("open incremental reader");
+		assert_eq!(
+			loaded.live(),
+			reader.live_log().live(),
+			"path load_live and the journal reader guard must agree on LiveSet"
+		);
+		assert_eq!(
+			loaded.live().iter().collect::<Vec<_>>(),
+			vec![0, 3],
+			"rewind must drop the discarded title while the incomplete receipt stays inert"
+		);
+	}
 }

--- a/crates/storage/src/transcript/reader.rs
+++ b/crates/storage/src/transcript/reader.rs
@@ -523,14 +523,7 @@ impl Reader {
 				break;
 			}
 			line.pop();
-			let appended = push_record_at(
-				&mut events,
-				&mut diagnostics,
-				&line,
-				event_index,
-				offset,
-				DiagnosticKind::Malformed,
-			);
+			let appended = push_record_at(&mut events, &mut diagnostics, &line, event_index, offset);
 			let Some(appended) = appended else {
 				tail_bytes = reader.get_ref().metadata()?.len().saturating_sub(offset);
 				tail_diagnostic = Some(ReadDiagnostic {
@@ -677,7 +670,6 @@ impl Reader {
 				&line,
 				first_event_index.saturating_add(records),
 				offset,
-				DiagnosticKind::Malformed,
 			);
 			let Some(appended) = appended else {
 				self.tail_bytes = file_len.saturating_sub(offset);
@@ -853,6 +845,10 @@ pub fn load_live(path: &Path) -> Result<LiveLog, Error> {
 /// `yield_batch` runs after each `batch_entries` records, allowing async owners
 /// to cooperatively yield without coupling storage to one executor. Returning
 /// `false` from `visit` stops after the current record.
+///
+/// An unterminated trailing record is reported as a truncated diagnostic and
+/// never visited, so a full scan observes the same event set as the
+/// incremental [`Reader`].
 pub fn visit_batched(
 	path: &Path,
 	batch_entries: usize,
@@ -880,10 +876,9 @@ pub fn visit_batched(
 		if read == 0 {
 			break;
 		}
-		let terminated = line.last() == Some(&b'\n');
-		if terminated {
-			line.pop();
-		} else if read_atomic_group(&line).is_some() {
+		// `read_until` drained the file, so an unterminated line is the torn
+		// tail: reported like the incremental Reader, never decoded or visited.
+		if line.last() != Some(&b'\n') {
 			diagnostics.push(ReadDiagnostic {
 				event_index: records,
 				byte_offset: offset,
@@ -892,13 +887,9 @@ pub fn visit_batched(
 			});
 			break;
 		}
-		let damage = if terminated {
-			DiagnosticKind::Malformed
-		} else {
-			DiagnosticKind::Truncated
-		};
+		line.pop();
 		let mut entries = Vec::with_capacity(1);
-		let appended = push_record_at(&mut entries, &mut diagnostics, &line, records, offset, damage);
+		let appended = push_record_at(&mut entries, &mut diagnostics, &line, records, offset);
 		if appended.is_none() {
 			diagnostics.push(ReadDiagnostic {
 				event_index: records,
@@ -920,9 +911,6 @@ pub fn visit_batched(
 				break 'records;
 			}
 		}
-		if !terminated {
-			break;
-		}
 	}
 	let mut counters = ReadCounters::default();
 	for diagnostic in &diagnostics {
@@ -940,7 +928,6 @@ fn push_record_at(
 	line: &[u8],
 	event_index: u64,
 	byte_offset: u64,
-	damage: DiagnosticKind,
 ) -> Option<usize> {
 	if let Some(group) = read_atomic_group(line) {
 		return match group {
@@ -955,7 +942,7 @@ fn push_record_at(
 	if let Ok(event) = read_line(line) {
 		events.push(Entry::Ok(Box::new(event)));
 	} else {
-		push_tombstone(events, diagnostics, line, event_index, byte_offset, damage);
+		push_tombstone(events, diagnostics, line, event_index, byte_offset);
 	}
 	Some(1)
 }
@@ -966,13 +953,14 @@ fn push_tombstone(
 	line: &[u8],
 	event_index: u64,
 	byte_offset: u64,
-	damage: DiagnosticKind,
 ) {
+	// Only a terminated line reaches decoding, so a tombstone is always a
+	// malformed record; truncated bytes stop at the torn-tail check instead.
 	diagnostics.push(ReadDiagnostic {
 		event_index,
 		byte_offset,
 		byte_len: u64::try_from(line.len()).expect("record length fits in u64"),
-		kind: damage,
+		kind: DiagnosticKind::Malformed,
 	});
 	let source = String::from_utf8_lossy(line);
 	let raw = to_raw_value(source.as_ref()).expect("a JSON string is always serializable");
@@ -981,14 +969,20 @@ fn push_tombstone(
 
 #[cfg(test)]
 mod tests {
-	use std::path::PathBuf;
+	use std::{
+		fs::{self, OpenOptions},
+		io::Write as _,
+		path::PathBuf,
+	};
 
 	use omp_core::{Hash32, Str, sf};
 	use omp_proto::inference::v1 as pb;
 	use tempfile::tempdir;
 
 	use super::{Reader, load_live};
-	use crate::transcript::{Event, Header, Kind, SessionId, TitleSource, TurnReceipt, Writer};
+	use crate::transcript::{
+		Event, Header, Kind, SessionId, TitleSource, TurnReceipt, Writer, write_line,
+	};
 
 	fn header() -> Header {
 		Header {
@@ -1044,5 +1038,35 @@ mod tests {
 			vec![0, 3],
 			"rewind must drop the discarded title while the incomplete receipt stays inert"
 		);
+	}
+
+	#[test]
+	fn load_live_excludes_an_unterminated_trailing_record_like_the_reader() {
+		let directory = tempdir().expect("temporary directory");
+		let path = directory.path().join("session.jsonl");
+		let mut writer = Writer::create(&path, &header()).expect("create transcript");
+		writer.append(&title(1, "kept")).expect("event zero");
+		drop(writer);
+		// A crash left an ordinary event line without its terminating newline:
+		// a torn tail that the live journal must never expose as an event.
+		let mut file = OpenOptions::new()
+			.append(true)
+			.open(&path)
+			.expect("open tail");
+		let mut torn = Vec::new();
+		write_line(&title(2, "torn"), &mut torn).expect("ordinary line encodes");
+		file.write_all(&torn).expect("torn tail writes");
+		drop(file);
+
+		let loaded = load_live(&path).expect("load_live pairs the fold");
+		let reader = Reader::open(&path).expect("open incremental reader");
+		assert!(reader.has_torn_tail(), "the unterminated record is a torn tail");
+		assert_eq!(
+			loaded.live(),
+			reader.live_log().live(),
+			"load_live must not expose an event the live journal excludes"
+		);
+		assert_eq!(loaded.log().len(), 1, "the torn record is not a durable event");
+		assert_eq!(loaded.live().iter().collect::<Vec<_>>(), vec![0]);
 	}
 }

--- a/crates/storage/tests/session_p1.rs
+++ b/crates/storage/tests/session_p1.rs
@@ -94,7 +94,9 @@ fn bounded_visitor_preserves_indexes_and_reports_malformed_tail() {
 	)
 	.expect("visit journal");
 	assert_eq!(indexes.first(), Some(&0));
-	assert_eq!(indexes.last(), Some(&8_301));
+	// `{malformed}` is the last visited record; the unterminated `{truncated`
+	// tail is reported, not visited, matching the incremental Reader.
+	assert_eq!(indexes.last(), Some(&8_300));
 	assert_eq!(report.counters.malformed, 1);
 	assert_eq!(report.counters.truncated, 1);
 	assert!(batches >= 8);


### PR DESCRIPTION
## The journal fold stops leaking into callers

`project_journal` needed a `&Log` and a `&LiveSet` that the caller had to keep
mutually consistent by hand. Nine production call sites satisfied the same
4-arg signature two different ways, and three app sites hand-rolled the same
load/LiveSet/live_into prelude.

This adds `LiveLog` — a view that pairs the log with its live chain at
construction so the two cannot diverge — plus `transcript::load_live`, and
retargets `Journal::load` to `Deref<Target = LiveLog>`. The hand-rolled app
preludes collapse to one call, and a missed `CreateSessionChild` callsite now
reaches the header through the view (`journal.log().header()`).

Also replaces the `AtomicU128` event mask with `AtomicU64` so the crate builds
on toolchains without 128-bit atomics (the same standalone build fix is
carried by the sibling arch/* branches in this set; keep whichever merges
first).

Verification: `just test-pkg omp-storage` 117 passed including the new
`load_live_matches_journal_load_projection` guard (fails if the two producers
ever disagree on a rewind + torn-tail transcript); `just check-pkg omp-app`
compiles (local full test link is blocked by a pre-existing vendored
`llama-cpp-sys` httplib defect on this Linux host; macOS CI links clean).
