### PR TITLE
Fix Bedrock Guardrails with AIPs

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `providers.amazon-bedrock` guardrail, transport, and header settings being dropped for models referenced by an inference-profile ARN.
+
 ## [18.0.6] - 2026-08-26
 
 ### Added

--- a/packages/coding-agent/src/config/model-resolver.ts
+++ b/packages/coding-agent/src/config/model-resolver.ts
@@ -329,6 +329,11 @@ function resolveBedrockInferenceProfileModelId(
 		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 		contextWindow: null,
 		maxTokens: null,
+		...(template.headers ? { headers: template.headers } : {}),
+		...(template.transport !== undefined ? { transport: template.transport } : {}),
+		...(template.guardrailIdentifier !== undefined ? { guardrailIdentifier: template.guardrailIdentifier } : {}),
+		...(template.guardrailVersion !== undefined ? { guardrailVersion: template.guardrailVersion } : {}),
+		...(template.guardrailTrace !== undefined ? { guardrailTrace: template.guardrailTrace } : {}),
 	});
 }
 

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -1850,6 +1850,44 @@ describe("ModelRegistry", () => {
 				expect(model.guardrailTrace).toBeUndefined();
 			}
 		});
+
+		test("guardrail provider config applies to a synthesized inference-profile ARN model", () => {
+			const profileArn = "arn:aws:bedrock:us-east-2:123456789012:application-inference-profile/company-opus-48";
+			const model = guardrailOverride.find("amazon-bedrock", profileArn);
+			expect(model).toBeDefined();
+			expect(model?.id).toBe(profileArn);
+			expect(model?.api).toBe("bedrock-converse-stream");
+			expect(model?.guardrailIdentifier).toBe("arn:aws:bedrock:eu-west-2:123456789012:guardrail/abcd1234");
+			expect(model?.guardrailVersion).toBe("1");
+			expect(model?.guardrailTrace).toBe("enabled");
+		});
+
+		test("guardrail fields are absent on a synthesized ARN model without override", () => {
+			const profileArn = "arn:aws:bedrock:us-east-2:123456789012:application-inference-profile/company-opus-48";
+			const model = sharedBuiltin.find("amazon-bedrock", profileArn);
+			expect(model).toBeDefined();
+			expect(model?.guardrailIdentifier).toBeUndefined();
+			expect(model?.guardrailVersion).toBeUndefined();
+			expect(model?.guardrailTrace).toBeUndefined();
+		});
+
+		test("transport and header overrides apply to a synthesized ARN model", () => {
+			const transportOverride = readonlyRegistry({
+				providers: {
+					"amazon-bedrock": {
+						transport: "pi-native",
+						headers: { "X-Custom-Header": "custom-value" },
+						guardrailIdentifier: "arn:aws:bedrock:eu-west-2:123456789012:guardrail/abcd1234",
+					},
+				},
+			});
+			const profileArn = "arn:aws:bedrock:us-east-2:123456789012:application-inference-profile/company-opus-48";
+			const model = transportOverride.find("amazon-bedrock", profileArn);
+			expect(model).toBeDefined();
+			expect(model?.transport).toBe("pi-native");
+			expect(model?.headers).toEqual({ "X-Custom-Header": "custom-value" });
+			expect(model?.guardrailIdentifier).toBe("arn:aws:bedrock:eu-west-2:123456789012:guardrail/abcd1234");
+		});
 	});
 
 	describe("provider auth: oauth", () => {

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { type Api, Effort, type Model } from "@oh-my-pi/pi-ai";
+import { type Api, Effort, type Model, type ModelSpec } from "@oh-my-pi/pi-ai";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { DEFAULT_MODEL_PER_PROVIDER } from "@oh-my-pi/pi-catalog/provider-models";
@@ -327,7 +327,9 @@ const openaiGpt55Models: Model<Api>[] = [
 	}),
 ];
 
-function createBedrockDefaultModel(): Model<"bedrock-converse-stream"> {
+function createBedrockDefaultModel(
+	overrides?: Partial<ModelSpec<"bedrock-converse-stream">>,
+): Model<"bedrock-converse-stream"> {
 	return buildModel({
 		id: "us.anthropic.claude-opus-4-8",
 		name: "Claude Opus 4.8 (US)",
@@ -339,6 +341,7 @@ function createBedrockDefaultModel(): Model<"bedrock-converse-stream"> {
 		cost: { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
 		contextWindow: 1000000,
 		maxTokens: 128000,
+		...overrides,
 	});
 }
 
@@ -1584,6 +1587,36 @@ describe("resolveCliModel", () => {
 		expect(offResult.error).toBeUndefined();
 		expect(offResult.model?.id).toBe(profileArn);
 		expect(offResult.thinkingLevel).toBe("off");
+	});
+
+	test("inherits provider-scoped guardrail, transport, and header overrides onto an ARN model, but not the template's prompt-cache checkpoints", () => {
+		const templateModel = createBedrockDefaultModel({
+			transport: "pi-native",
+			headers: { "X-Custom-Header": "custom-value" },
+			guardrailIdentifier: "arn:aws:bedrock:eu-west-2:123456789012:guardrail/abcd1234",
+			guardrailVersion: "1",
+			guardrailTrace: "enabled",
+		});
+		const profileArn = "arn:aws:bedrock:us-east-2:1234567890:application-inference-profile/company-opus-48";
+
+		const result = resolveCliModel({
+			cliProvider: "amazon-bedrock",
+			cliModel: profileArn,
+			modelRegistry: { getAll: () => [templateModel], getAvailable: () => [templateModel] },
+		});
+
+		expect(result.error).toBeUndefined();
+		expect(result.model?.id).toBe(profileArn);
+		expect(result.model?.transport).toBe("pi-native");
+		expect(result.model?.headers).toEqual({ "X-Custom-Header": "custom-value" });
+		expect(result.model?.guardrailIdentifier).toBe("arn:aws:bedrock:eu-west-2:123456789012:guardrail/abcd1234");
+		expect(result.model?.guardrailVersion).toBe("1");
+		expect(result.model?.guardrailTrace).toBe("enabled");
+
+		// The template's Opus-4.8 id derives explicit prompt-cache checkpoints;
+		// the synthesized ARN model must not borrow that checkpoint policy.
+		expect((templateModel.compat as { promptCacheMode?: string }).promptCacheMode).toBe("explicit");
+		expect((result.model?.compat as { promptCacheMode?: string } | undefined)?.promptCacheMode).toBe("none");
 	});
 
 	test("returns a clear error when there are no models", () => {


### PR DESCRIPTION
## What

- Fixed provider-scoped Amazon Bedrock settings being dropped for models referenced by inference-profile ARNs.
 - Synthesized ARN models now inherit guardrailIdentifier, guardrailVersion, guardrailTrace, transport, and headers from the configured Bedrock provider.
 - Preserved ARN-specific compatibility metadata generation so prompt-cache checkpoints from the template model are not incorrectly reused.
 - Added regression coverage for resolver and registry paths, including configured overrides and the no-override case.
 - Updated the coding-agent changelog.

## Why

Closes #9862

## Testing

Two regression tests added (`packages/coding-agent/test/model-registry.test.ts` and `packages/coding-agent/test/model-resolver.test.ts`)

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
