### PR TITLE
fix(config): apply bedrock guardrail config to inference-profile ARNs

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Amazon Bedrock guardrail config (`guardrailIdentifier`/`guardrailVersion`/`guardrailTrace`) being dropped for cross-region inference-profile ARNs referenced directly from `model:`/`enabledModels:`/`modelRoles:`, which caused an IAM explicit-deny 403 on accounts gating `bedrock:InvokeModel*` on `bedrock:GuardrailIdentifier` ([#9862](https://github.com/can1357/oh-my-pi/issues/9862)).
+
 ## [18.0.6] - 2026-08-26
 
 ### Added

--- a/packages/coding-agent/src/config/model-resolver.ts
+++ b/packages/coding-agent/src/config/model-resolver.ts
@@ -329,6 +329,14 @@ function resolveBedrockInferenceProfileModelId(
 		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 		contextWindow: null,
 		maxTokens: null,
+		// Carry the provider's Bedrock guardrail config onto the synthetic model.
+		// Catalog ids get it via the registry's provider-guardrail overlay; a raw
+		// inference-profile ARN has no registered entry, so without this copy the
+		// Converse request drops `guardrailConfig` and IAM policies that gate
+		// `bedrock:InvokeModel*` on `bedrock:GuardrailIdentifier` return 403.
+		guardrailIdentifier: template.guardrailIdentifier,
+		guardrailVersion: template.guardrailVersion,
+		guardrailTrace: template.guardrailTrace,
 	});
 }
 

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -1586,6 +1586,37 @@ describe("resolveCliModel", () => {
 		expect(offResult.thinkingLevel).toBe("off");
 	});
 
+	test("carries provider guardrail config onto synthetic Bedrock inference-profile ARN models", () => {
+		const guardedBedrockModel = buildModel({
+			id: "us.anthropic.claude-opus-4-8",
+			name: "Claude Opus 4.8 (US)",
+			api: "bedrock-converse-stream",
+			provider: "amazon-bedrock",
+			baseUrl: "https://bedrock-runtime.eu-west-2.amazonaws.com",
+			reasoning: true,
+			input: ["text", "image"],
+			cost: { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
+			contextWindow: 1000000,
+			maxTokens: 128000,
+			guardrailIdentifier: "arn:aws:bedrock:eu-west-2:123456789012:guardrail/abcd1234",
+			guardrailVersion: "DRAFT",
+			guardrailTrace: "enabled",
+		});
+		const profileArn = "arn:aws:bedrock:eu-west-2:123456789012:application-inference-profile/example-profile";
+
+		const result = resolveCliModel({
+			cliProvider: "amazon-bedrock",
+			cliModel: profileArn,
+			modelRegistry: { getAll: () => [guardedBedrockModel], getAvailable: () => [guardedBedrockModel] },
+		});
+
+		expect(result.error).toBeUndefined();
+		expect(result.model?.id).toBe(profileArn);
+		expect(result.model?.guardrailIdentifier).toBe("arn:aws:bedrock:eu-west-2:123456789012:guardrail/abcd1234");
+		expect(result.model?.guardrailVersion).toBe("DRAFT");
+		expect(result.model?.guardrailTrace).toBe("enabled");
+	});
+
 	test("returns a clear error when there are no models", () => {
 		const registry = { getAll: () => [], getAvailable: () => [] } as unknown as Parameters<
 			typeof resolveCliModel


### PR DESCRIPTION
## Repro
With `providers.amazon-bedrock.guardrailIdentifier`/`guardrailVersion` set and a cross-region inference-profile ARN referenced directly from `modelRoles:`/`enabledModels:`/`model:` (e.g. `amazon-bedrock/arn:aws:bedrock:eu-west-2:…:application-inference-profile/example-profile`), the Converse request omits `guardrailConfig`. On accounts whose IAM policy denies `bedrock:InvokeModel*` unless the request carries a matching `bedrock:GuardrailIdentifier`, this yields an explicit-deny `403`. The identical provider config works for catalog ids (`anthropic.claude-3-5-haiku-20241022-v1:0`).

## Cause
`resolveBedrockInferenceProfileModelId` (`packages/coding-agent/src/config/model-resolver.ts`) synthesizes a `bedrock-converse-stream` model for raw inference-profile ARNs that have no registered catalog entry. It copied `baseUrl` from the provider template model but never the guardrail fields. Catalog ids instead flow through `ModelRegistry.#applyProviderGuardrailOverrides`, which is why they carried `guardrailIdentifier`/`guardrailVersion`/`guardrailTrace` and the ARN path did not.

## Fix
- In `resolveBedrockInferenceProfileModelId`, copy `guardrailIdentifier`, `guardrailVersion`, and `guardrailTrace` from the provider template model onto the synthetic model spec.
- Add a `model-resolver.test.ts` regression that resolves a guardrail-carrying provider template against an inference-profile ARN and asserts the resolved model carries all three guardrail fields.
- Changelog entry under `[Unreleased]`.

## Verification
`bun test model-resolver.test.ts` → 159 pass, 0 fail (new test `carries provider guardrail config onto synthetic Bedrock inference-profile ARN models` included). Fixes #9862