### PR TITLE
fix(ai): pin the Composer operating prefix on Cursor prompts

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fixed multimodal tool results in OpenAI Responses requests so inline, remote, and OpenAI file-backed images are preserved correctly.
 - Fixed resumed and forked Cursor sessions failing when their history came from a Responses-based provider such as Codex ([#9754](https://github.com/can1357/oh-my-pi/issues/9754)).
 - Fixed Cursor `composer-2.5` selections using the Fast variant instead of the Standard tier ([#9012](https://github.com/can1357/oh-my-pi/issues/9012)).
+- Fixed Cursor Composer models calling tools that do not exist on this surface, which surfaced as tool-calling errors in longer sessions.
 
 ## [18.0.6] - 2026-08-26
 

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -241,6 +241,7 @@ import {
 	piReadPathHasRange,
 	piTimeout,
 } from "./cursor/exec-modern";
+import { CURSOR_COMPOSER_PROMPT, isCursorComposerModel } from "./cursor/composer-prompt";
 import { handleInteractionQuery } from "./cursor/interaction-query";
 
 export const CURSOR_API_URL = "https://api2.cursor.sh";
@@ -703,7 +704,7 @@ function streamCursorWithWireMode(
 			serializedFallbackWireModelId = builtRequest.fallbackWireModelId;
 			conversationStateCache.set(conversationId, conversationState);
 			const requestContextTools = buildMcpToolDefinitions(context.tools);
-			const requestContextRules = buildCursorRequestContextRules(context.systemPrompt);
+			const requestContextRules = buildCursorRequestContextRules(context.systemPrompt, model.id);
 
 			const baseUrl = model.baseUrl || CURSOR_API_URL;
 			const requestPath = "/agent.v1.AgentService/Run";
@@ -4572,8 +4573,29 @@ function readCursorBlob(blobStore: Map<string, Uint8Array>, blobId: Uint8Array):
  * OMP system-prompt entry to a global CursorRule so always-apply rules survive
  * that reconstruction.
  */
-export function buildCursorRequestContextRules(systemPrompt: readonly string[] | undefined): CursorRule[] {
-	return normalizeSystemPrompts(systemPrompt).map((content, index) =>
+export function buildCursorRequestContextRules(
+	systemPrompt: readonly string[] | undefined,
+	modelId?: string,
+): CursorRule[] {
+	// Composer models are Cursor-harness-trained and otherwise reach for the
+	// native tool vocabulary of that harness (StrReplace-style editors) which
+	// this client never executes. The operating prefix leads the reconstructed
+	// prompt so the trained habits are overwritten before the host rules run.
+	const composerPrefix =
+		modelId !== undefined && isCursorComposerModel(modelId)
+			? create(CursorRuleSchema, {
+					fullPath: "/omp/system-prompt/composer.mdc",
+					content: CURSOR_COMPOSER_PROMPT,
+					source: CursorRuleSource.USER,
+					type: create(CursorRuleTypeSchema, {
+						type: {
+							case: "global",
+							value: create(CursorRuleTypeGlobalSchema, {}),
+						},
+					}),
+				})
+			: undefined;
+	const hostRules = normalizeSystemPrompts(systemPrompt).map((content, index) =>
 		create(CursorRuleSchema, {
 			fullPath: `/omp/system-prompt/${index}.mdc`,
 			content,
@@ -4586,6 +4608,7 @@ export function buildCursorRequestContextRules(systemPrompt: readonly string[] |
 			}),
 		}),
 	);
+	return composerPrefix ? [composerPrefix, ...hostRules] : hostRules;
 }
 
 /**
@@ -4836,12 +4859,24 @@ function findLastUserMessageIndex(messages: Message[]): number {
  * When no system prompts are provided, returns a single default greeting so we never emit
  * an empty `rootPromptMessagesJson` head.
  */
-export function buildCursorSystemPromptJsons(systemPrompt: readonly string[] | undefined): string[] {
+export function buildCursorSystemPromptJsons(
+	systemPrompt: readonly string[] | undefined,
+	modelId?: string,
+): string[] {
 	const systemPrompts = normalizeSystemPrompts(systemPrompt);
+	// Composer models get their operating prefix as its own leading blob
+	// rather than concatenated into the host prompt, so Cursor's per-blob
+	// prompt cache keeps the prefix stable while the host prompt changes
+	// underneath it.
+	const prefixJson =
+		modelId !== undefined && isCursorComposerModel(modelId)
+			? [JSON.stringify({ role: "system", content: CURSOR_COMPOSER_PROMPT })]
+			: [];
 	if (systemPrompts.length === 0) {
+		if (prefixJson.length > 0) return prefixJson;
 		return [JSON.stringify({ role: "system", content: "You are a helpful assistant." })];
 	}
-	return systemPrompts.map(content => JSON.stringify({ role: "system", content }));
+	return [...prefixJson, ...systemPrompts.map(content => JSON.stringify({ role: "system", content }))];
 }
 
 function buildRootPromptMessagesJson(
@@ -5237,7 +5272,7 @@ async function buildGrpcRequestForWireMode(
 ): Promise<CursorTransportRequest> {
 	const blobStore = state.blobStore;
 
-	const systemPromptIds = buildCursorSystemPromptJsons(context.systemPrompt).map(json =>
+	const systemPromptIds = buildCursorSystemPromptJsons(context.systemPrompt, model.id).map(json =>
 		storeCursorBlob(blobStore, new TextEncoder().encode(json)),
 	);
 

--- a/packages/ai/src/providers/cursor/composer-prompt.ts
+++ b/packages/ai/src/providers/cursor/composer-prompt.ts
@@ -1,0 +1,55 @@
+/**
+ * Cursor Composer operating prefix.
+ *
+ * Composer 2 and 2.5 are Cursor's continued pretraining plus large-scale
+ * agentic RL on top of Moonshot's Kimi K2.5 checkpoint, and Cursor trains them
+ * inside essentially the same agent harness it serves them from
+ * (arXiv:2603.24477; cursor.com/blog/composer-2-5). The policy is therefore
+ * shaped around Cursor's own tool surface, and Cursor reports that a model
+ * given an unfamiliar tool or edit format still works but spends more reasoning
+ * tokens and makes more mistakes.
+ *
+ * Driving Composer through this client is exactly that off-distribution case,
+ * so the prefix supplies only what the host prompt cannot know: which tools
+ * this wire surface actually exposes, and the operating rules for the habits
+ * Cursor documents as trained-in. Everything the host prompt already covers
+ * (verification depth, output style, commit policy) is deliberately absent:
+ * K2-family models follow instructions strictly enough that restating an
+ * existing rule buys nothing and dilutes the rules that are new.
+ *
+ * The wording is positive and procedural rather than a stack of prohibitions.
+ * A prohibition invites this family to spend reasoning deciding whether the
+ * current case is the prohibited one, while a named tool and a terminal
+ * condition install the behavior directly.
+ */
+export const CURSOR_COMPOSER_PROMPT = `You are running in this client, not in Cursor. Your tools on this surface are read, ls, grep, write, delete, diagnostics, and shell. Tool names from other harnesses are unavailable here.
+
+Reach for repository files through the native tools: read for file contents, ls for directory entries, grep for content and filename search, write to create or modify, delete to remove, diagnostics for a file's current errors. These carry line anchors and result metadata that shell output does not.
+
+Keep shell for terminal work: tests, builds, package scripts, git, and process control. Put only the command in the command string.
+
+Tool arguments are the schema object the tool declares. Keep explanation and markdown in your message text, where it belongs.
+
+Read a file before you edit it, and read it again after any write before relying on its contents. Copy line anchors from the most recent tool output rather than computing or adjusting them; when an anchor is rejected, re-read and use the anchors that come back.
+
+Run independent searches and reads together in one batch. Keep dependent steps in sequence, and let a step that needs the previous result wait for it.
+
+A task is finished when the requested behavior is in place and you have watched it work: the relevant test, build, or command run, and its output read. Until you have that, keep going. If something remains unproven or broken, say which part and why.
+
+When asked a question, answer it from the code and stop there. Edit when a change was requested or when a fix is confirmed.`;
+
+/**
+ * Composer ids on this provider, e.g. `composer-2.5`, `composer-2.6-thinking-max`,
+ * `composer-2.6-lite-medium-fast`. The match is name-based and version-agnostic
+ * because the trained-in harness habits belong to the family rather than to any
+ * one release, and Cursor serves ids ahead of its public docs.
+ *
+ * Cursor also resells first-party Kimi models (`kimi-k2.7-code`, `kimi-k3-*`).
+ * Those are ordinary hosted models rather than Cursor-harness-trained policies,
+ * so keying on the Composer name keeps them out.
+ */
+const COMPOSER_MODEL_ID_PATTERN = /(?:^|[/:._-])composer(?:[/:._-]|\d|$)/i;
+
+export function isCursorComposerModel(modelId: string): boolean {
+	return COMPOSER_MODEL_ID_PATTERN.test(modelId);
+}

--- a/packages/ai/test/cursor-exec-handlers.test.ts
+++ b/packages/ai/test/cursor-exec-handlers.test.ts
@@ -14,6 +14,7 @@ import {
 import { streamCursor as lazyStreamCursor, setCursorProviderModule } from "@oh-my-pi/pi-ai/providers/register-builtins";
 import type { AssistantMessage, Context, CursorExecHandlers, Model, ToolResultMessage } from "@oh-my-pi/pi-ai/types";
 import { kCursorExecResolved } from "@oh-my-pi/pi-ai/utils/block-symbols";
+import { CURSOR_COMPOSER_PROMPT, isCursorComposerModel } from "@oh-my-pi/pi-ai/providers/cursor/composer-prompt";
 import { AssistantMessageEventStream } from "@oh-my-pi/pi-ai/utils/event-stream";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import type { McpResult, ReadResult } from "@oh-my-pi/pi-catalog/discovery/cursor-proto";
@@ -468,6 +469,43 @@ describe("Cursor system prompt encoding", () => {
 		expect(rules[1]?.content).toContain(canary);
 		expect(rules[0]?.source).toBe(CursorRuleSource.USER);
 		expect(rules[1]?.type?.type.case).toBe("global");
+	});
+
+	it("detects Composer family ids and excludes Cursor-resold Kimi and grok ids", () => {
+		expect(isCursorComposerModel("composer-2.5")).toBe(true);
+		expect(isCursorComposerModel("cursor/composer-2.6-thinking-max")).toBe(true);
+		expect(isCursorComposerModel("composer-2.6-lite-medium-fast")).toBe(true);
+		expect(isCursorComposerModel("kimi-k2.7-code")).toBe(false);
+		expect(isCursorComposerModel("cursor-grok-4.6")).toBe(false);
+		expect(isCursorComposerModel("claude-sonnet-5")).toBe(false);
+	});
+
+	it("prepends the Composer operating prefix as its own leading blob for Composer models", () => {
+		const jsons = buildCursorSystemPromptJsons(["Primary instructions."], "cursor/composer-2.6");
+		expect(jsons).toHaveLength(2);
+		expect(JSON.parse(jsons[0])).toEqual({ role: "system", content: CURSOR_COMPOSER_PROMPT });
+		expect(JSON.parse(jsons[1])).toEqual({ role: "system", content: "Primary instructions." });
+	});
+
+	it("leaves non-Composer and unspecified model prompts unchanged", () => {
+		expect(buildCursorSystemPromptJsons(["Primary instructions."], "cursor/claude-sonnet-5")).toHaveLength(1);
+		expect(buildCursorSystemPromptJsons(["Primary instructions."], "kimi-k3")).toHaveLength(1);
+	});
+
+	it("leads the reconstructed rule prompt with the Composer prefix for Composer models", () => {
+		const rules = buildCursorRequestContextRules(["prefix"], "composer-2.5");
+		expect(rules).toHaveLength(2);
+		expect(rules[0]?.fullPath).toBe("/omp/system-prompt/composer.mdc");
+		expect(rules[0]?.content).toBe(CURSOR_COMPOSER_PROMPT);
+		expect(rules[0]?.source).toBe(CursorRuleSource.USER);
+		expect(rules[1]?.fullPath).toBe("/omp/system-prompt/0.mdc");
+		expect(rules[1]?.content).toBe("prefix");
+	});
+
+	it("leaves rules unchanged for non-Composer models", () => {
+		const rules = buildCursorRequestContextRules(["prefix"], "cursor-grok-4.6");
+		expect(rules).toHaveLength(1);
+		expect(rules[0]?.fullPath).toBe("/omp/system-prompt/0.mdc");
 	});
 });
 


### PR DESCRIPTION
Cursor Composer models are trained inside Cursor's own agent harness, so mid-session they reach for that harness's native tool vocabulary. This client never exposes those tools, which is what the reported tool-calling errors in longer Cursor sessions actually are: `agent.proto` declares no StrReplace, ApplyPatch, MultiEdit, or SearchReplace frame at all, so the attempt fails before it can reach the exec dispatch. Thanks to @korri123 for naming the cause.

The fix is an operating prefix that declares this surface's real tool vocabulary and prohibits other-harness tool names. It is ported from a working implementation, prompt text unchanged.

The prefix rides both paths that reach the model prompt, because the client cannot observe which one the server rebuilds from:

- a leading `rootPromptMessagesJson` system blob, kept as its own blob so per-blob prompt caching stays stable while the host prompt changes underneath it;
- the first `requestContext` rule, `/omp/system-prompt/composer.mdc`, ahead of the host rules.

Gated by `isCursorComposerModel`, a version-agnostic family match, so only Composer ids are affected. Cursor's first-party Kimi resales and the grok ids are excluded.

This is deliberately separate from #9852: that PR hardens the transport, which cannot influence a server-side prompt. Both are worth having, and they fix different bugs.

Tests: five gating tests (family detection, blob prepend, blob unchanged for non-Composer, rule leads, rules unchanged) fail without the provider change. 299 Cursor tests pass on this base.
