### PR TITLE
feat(slash-commands): multi-path /add-dir and /remove-dir, Enter submits slash command args

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Added
+
+- `/add-dir` and `/remove-dir` now accept multiple space-separated paths (e.g. `/add-dir ../sibling-a ../sibling-b`), and both commands have Tab-completion for directory arguments.
+
+### Fixed
+
+- Pressing Enter while the autocomplete popup shows file-path suggestions for a slash command argument (e.g. `/add-dir ../p`) now submits the command instead of accepting the first file suggestion; Tab remains the way to accept a completion.
+
 ## [18.0.6] - 2026-08-26
 
 ### Added

--- a/packages/coding-agent/src/slash-commands/builtin-lifecycle.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-lifecycle.ts
@@ -11,6 +11,7 @@ import { resolveResumableSession } from "../session/session-listing";
 import { toggleSessionPin } from "../session/session-pins";
 import { formatShakeSummary, type ShakeMode } from "../session/shake-types";
 import { resolveToCwd } from "../tools/path-utils";
+import { parseCommandArgs } from "../utils/command-args";
 import { commandConsumed, errorMessage, usage } from "./helpers/parse";
 import { handleSshAcp } from "./helpers/ssh";
 import type {
@@ -593,61 +594,98 @@ export const BUILTIN_LIFECYCLE_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> =
 	{
 		name: "add-dir",
 		icon: "folderPlus",
-		description: "Add a workspace directory to this session (multi-root)",
+		description: "Add a workspace directory to this session (multi-root, space-separated paths)",
 		acpDescription: "Add a workspace directory to this session",
-		inlineHint: "<path>",
+		inlineHint: "<path> [<path> ...]",
 		allowArgs: true,
 		handle: async (command, runtime) => {
 			if (runtime.session.isStreaming) return usage("Cannot add a directory while streaming.", runtime);
-			if (!command.args) return usage(formatWorkspaceDirectories(runtime, "Usage: /add-dir <path>"), runtime);
-			const resolved = resolveToCwd(command.args, runtime.cwd);
-			try {
-				const stat = await fs.stat(resolved);
-				if (!stat.isDirectory()) return usage(`Not a directory: ${resolved}`, runtime);
-			} catch {
-				return usage(`Directory does not exist: ${resolved}`, runtime);
+			if (!command.args)
+				return usage(formatWorkspaceDirectories(runtime, "Usage: /add-dir <path> [<path> ...]"), runtime);
+			const rawPaths = parseCommandArgs(command.args);
+			const resolvedPaths: string[] = [];
+			for (const raw of rawPaths) {
+				const resolved = resolveToCwd(raw, runtime.cwd);
+				try {
+					const stat = await fs.stat(resolved);
+					if (!stat.isDirectory()) return usage(`Not a directory: ${resolved}`, runtime);
+				} catch {
+					return usage(`Directory does not exist: ${resolved}`, runtime);
+				}
+				resolvedPaths.push(resolved);
 			}
-			let added: string | null;
-			try {
-				added = await runtime.sessionManager.addWorkspaceDirectory(resolved);
-			} catch (err) {
-				return usage(errorMessage(err), runtime);
-			}
-			if (added === null) {
-				await runtime.output(`Already in the workspace: ${resolved}`);
-				return commandConsumed();
+			const added: string[] = [];
+			const skipped: string[] = [];
+			for (const resolved of resolvedPaths) {
+				try {
+					const result = await runtime.sessionManager.addWorkspaceDirectory(resolved);
+					if (result !== null) added.push(result);
+					else skipped.push(resolved);
+				} catch (err) {
+					return usage(errorMessage(err), runtime);
+				}
 			}
 			await runtime.session.refreshBaseSystemPrompt();
-			await runtime.output(formatWorkspaceDirectories(runtime, `Added ${added}.`));
+			const parts: string[] = [];
+			if (added.length > 0)
+				parts.push(
+					added.length === 1 ? `Added ${added[0]}.` : `Added ${added.length} directories: ${added.join(", ")}.`,
+				);
+			if (skipped.length > 0)
+				parts.push(
+					skipped.length === 1
+						? `Already in the workspace: ${skipped[0]}`
+						: `Already in the workspace: ${skipped.join(", ")}`,
+				);
+			await runtime.output(formatWorkspaceDirectories(runtime, parts.join("\n")));
 			return commandConsumed();
 		},
 	},
 	{
 		name: "remove-dir",
 		icon: "folderMinus",
-		description: "Remove a workspace directory from this session",
+		description: "Remove a workspace directory from this session (space-separated paths)",
 		acpDescription: "Remove a workspace directory from this session",
-		inlineHint: "<path>",
+		inlineHint: "<path> [<path> ...]",
 		allowArgs: true,
 		handle: async (command, runtime) => {
 			if (runtime.session.isStreaming) return usage("Cannot remove a directory while streaming.", runtime);
-			if (!command.args) return usage("Usage: /remove-dir <path>", runtime);
-			const resolved = resolveToCwd(command.args, runtime.cwd);
-			if (resolved === path.resolve(runtime.cwd)) {
-				return usage("Cannot remove the working directory; use /move to change it.", runtime);
+			if (!command.args) return usage("Usage: /remove-dir <path> [<path> ...]", runtime);
+			const rawPaths = parseCommandArgs(command.args);
+			const resolvedPaths: string[] = [];
+			for (const raw of rawPaths) {
+				const resolved = resolveToCwd(raw, runtime.cwd);
+				if (resolved === path.resolve(runtime.cwd)) {
+					return usage("Cannot remove the working directory; use /move to change it.", runtime);
+				}
+				resolvedPaths.push(resolved);
 			}
-			let removed: string | null;
-			try {
-				removed = await runtime.sessionManager.removeWorkspaceDirectory(resolved);
-			} catch (err) {
-				return usage(errorMessage(err), runtime);
-			}
-			if (removed === null) {
-				await runtime.output(`Not a workspace directory: ${resolved}`);
-				return commandConsumed();
+			const removed: string[] = [];
+			const skipped: string[] = [];
+			for (const resolved of resolvedPaths) {
+				try {
+					const result = await runtime.sessionManager.removeWorkspaceDirectory(resolved);
+					if (result !== null) removed.push(result);
+					else skipped.push(resolved);
+				} catch (err) {
+					return usage(errorMessage(err), runtime);
+				}
 			}
 			await runtime.session.refreshBaseSystemPrompt();
-			await runtime.output(formatWorkspaceDirectories(runtime, `Removed ${removed}.`));
+			const parts: string[] = [];
+			if (removed.length > 0)
+				parts.push(
+					removed.length === 1
+						? `Removed ${removed[0]}.`
+						: `Removed ${removed.length} directories: ${removed.join(", ")}.`,
+				);
+			if (skipped.length > 0)
+				parts.push(
+					skipped.length === 1
+						? `Not a workspace directory: ${skipped[0]}`
+						: `Not workspace directories: ${skipped.join(", ")}`,
+				);
+			await runtime.output(formatWorkspaceDirectories(runtime, parts.join("\n")));
 			return commandConsumed();
 		},
 	},

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -78,7 +78,7 @@ function materializeTuiBuiltinSlashCommand(
 				? buildMcpArgumentCompletions(cmd.subcommands, runtime)
 				: buildArgumentCompletions(cmd.subcommands);
 		materialized.getInlineHint = buildSubcommandInlineHint(cmd.subcommands);
-	} else if (cmd.name === "move") {
+	} else if (cmd.name === "move" || cmd.name === "add-dir" || cmd.name === "remove-dir") {
 		materialized.getArgumentCompletions = buildDirectoryArgumentCompletions();
 		if (cmd.inlineHint) materialized.getInlineHint = buildStaticInlineHint(cmd.inlineHint);
 	} else if (cmd.inlineHint) {

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Pressing Enter while the autocomplete popup shows file-path suggestions for a slash command argument (e.g. `/add-dir ../p`) now submits the command instead of accepting the first file suggestion; Tab remains the way to accept a completion.
+
+
 ## [18.0.6] - 2026-08-26
 
 ### Added

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -1484,7 +1484,13 @@ export class Editor implements Component, Focusable {
 					// Don't return - fall through to submission logic
 				}
 				// Otherwise, apply the completion without submitting the surrounding draft.
-				else if (kb.matchesCanonical(canonical, "tui.input.submit") || data === "\n") {
+				// When the popup is a file-path completion whose prefix is just the argument
+				// tail of a submitted slash command (e.g. `/add-dir ../p`), Enter should
+				// submit the command rather than accept the file selection — Tab handles that.
+				else if (this.#isInSubmittedSlashCommandContext() && this.#cursorIsInSlashCommandArgument()) {
+					this.#cancelAutocomplete();
+					// Fall through to normal submission logic below.
+				} else if (kb.matchesCanonical(canonical, "tui.input.submit") || data === "\n") {
 					const selected = this.#autocompleteList.getSelectedItem();
 					// Check for stale autocomplete state due to buffer edits since last refresh.
 					const currentLine = this.#state.lines[this.#state.cursorLine] ?? "";
@@ -3250,6 +3256,14 @@ export class Editor implements Component, Focusable {
 		const currentLine = this.#state.lines[this.#state.cursorLine] || "";
 		const beforeCursor = currentLine.slice(0, this.#state.cursorCol);
 		return this.#hasOnlyWhitespaceBeforeCursorLine() && beforeCursor.trimStart().startsWith("/");
+	}
+
+	/** Whether the cursor sits past the first whitespace inside a submitted slash
+	 *  command (i.e. in the argument region, not the command-name token). */
+	#cursorIsInSlashCommandArgument(): boolean {
+		const currentLine = this.#state.lines[this.#state.cursorLine] || "";
+		const beforeCursor = currentLine.slice(0, this.#state.cursorCol).trimStart();
+		return beforeCursor.startsWith("/") && beforeCursor.includes(" ");
 	}
 
 	#isInMidPromptSkillSlashContext(): boolean {


### PR DESCRIPTION
## Summary

- `/add-dir` and `/remove-dir` now accept multiple space-separated paths (e.g. `/add-dir ../sibling-a ../sibling-b`), parsed via the existing `parseCommandArgs` utility which also supports quoted paths with spaces
- Tab completion added for both commands using `buildDirectoryArgumentCompletions` (same as `/move`)
- **Editor fix**: pressing Enter while the autocomplete popup shows file-path suggestions for a slash command argument (e.g. `/add-dir ../p`) now submits the command instead of accepting the first file suggestion; Tab remains the way to accept a completion

## Changed files

| File | Change |
|---|---|
| `packages/coding-agent/src/slash-commands/builtin-lifecycle.ts` | Multi-path handlers for `/add-dir` and `/remove-dir` using `parseCommandArgs` |
| `packages/coding-agent/src/slash-commands/builtin-registry.ts` | Wire `buildDirectoryArgumentCompletions` for `add-dir` and `remove-dir` |
| `packages/tui/src/components/editor.ts` | New `#cursorIsInSlashCommandArgument()` guard — Enter cancels popup and falls through to submit when in slash command argument region |
| `packages/coding-agent/CHANGELOG.md` | Changelog entries |
| `packages/tui/CHANGELOG.md` | Changelog entry |

## Test plan

- [ ] `/add-dir /tmp /etc` adds both directories
- [ ] `/add-dir "my dir with spaces"` adds a single quoted path
- [ ] `/remove-dir /tmp /etc` removes both
- [ ] `/add-dir /tm` + Tab shows directory completions
- [ ] With autocomplete popup visible for a slash command argument, Enter submits the command (does not accept first file)
- [ ] Tab still accepts the autocomplete selection
- [ ] Existing tests pass (`bun test packages/tui/test/editor-autocomplete-actions.test.ts`)
