### PR TITLE
fix(session): seed enabled tool set from the construction slate

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed a startup race that left a new session with almost no tools and an empty skill inventory. An early reconcile could commit a small live tool set as the permanent enabled set. The enabled set is now seeded from the construction-time tool slate, and `reconcileCodeMode` samples it inside the registry mutation lock.
+
 ## [18.0.7] - 2026-08-26
 
 ### Added

--- a/packages/coding-agent/src/session/session-tools.ts
+++ b/packages/coding-agent/src/session/session-tools.ts
@@ -306,6 +306,14 @@ export class SessionTools {
 		this.#skillWarnings = options.skillWarnings ?? [];
 		this.#skillsSettings = options.skillsSettings;
 		this.#skillsReloadable = options.skillsReloadable ?? true;
+		// Seed from the construction slate (top-level tools plus xd:// mounts).
+		// Left empty, getEnabledToolNames() falls back to live agent.state.tools,
+		// so an early reconcile (think/inspect_image/Code Mode after the startup
+		// model resolution) landing while the live set is transiently narrow
+		// commits that narrow set as the sticky slate — the session keeps almost
+		// no tools and the prompt rebuild without `read` empties the skill list.
+		for (const tool of host.agent.state.tools) this.#enabledToolNames.add(tool.name);
+		for (const name of this.#xdev?.mountedNames ?? []) this.#enabledToolNames.add(name);
 		this.#promptModelKey = this.#currentPromptModelKey();
 	}
 
@@ -389,10 +397,12 @@ export class SessionTools {
 	}
 	/** Enabled top-level, `xd://`, and Code Mode bridge tool names. */
 	getEnabledToolNames(): string[] {
-		if (this.#enabledToolNames.size > 0) return [...this.#enabledToolNames];
+		// Union live xd:// mounts so devices mounted out-of-band (plugins writing
+		// to xdev state directly) survive the next apply.
 		const mountedNames = this.#xdev?.mountedNames;
-		if (!mountedNames || mountedNames.size === 0) return this.getActiveToolNames();
-		return [...this.getActiveToolNames(), ...mountedNames];
+		const base = this.#enabledToolNames.size > 0 ? [...this.#enabledToolNames] : this.getActiveToolNames();
+		if (!mountedNames || mountedNames.size === 0) return base;
+		return [...new Set([...base, ...mountedNames])];
 	}
 
 	/** Names currently presented as `xd://` devices. */
@@ -708,7 +718,11 @@ export class SessionTools {
 
 	/** Reapplies the enabled set after model or Code Mode setting changes. */
 	reconcileCodeMode(): Promise<void> {
-		return this.applyActiveToolsByName(this.getEnabledToolNames());
+		// Sample inside the lock: an unlocked sample can race a queued apply and
+		// re-commit a stale slate.
+		return this.runToolRegistryMutation(async () => {
+			await this.#applyActiveToolsByName(this.getEnabledToolNames());
+		});
 	}
 
 	/** Enabled MCP tools in their current presentation partition. */

--- a/packages/coding-agent/test/session-code-mode.test.ts
+++ b/packages/coding-agent/test/session-code-mode.test.ts
@@ -373,6 +373,18 @@ describe("Code Mode session reconciliation", () => {
 		expect(session.codeModeNamespacesInfo).toBeUndefined();
 	});
 
+	test("startup reconcile survives a transiently narrow live tool set", async () => {
+		const { session } = createSession(Settings.isolated({ "providers.openai-codex.codeMode": "auto" }));
+		// Before the first apply, a startup-time mutation can shrink the live
+		// agent tools. A reconcile landing in that window must reapply the
+		// construction slate, not commit the shrunken set as sticky.
+		session.agent.setTools([]);
+		await session.initializeCodeMode();
+
+		expect(session.getEnabledToolNames()).toEqual(["eval", "read"]);
+		expect(session.getActiveToolNames()).toEqual(["eval"]);
+	});
+
 	test("an eval replacement that cannot state transport support keeps the direct surface", async () => {
 		const { session } = createSession(
 			Settings.isolated({ "providers.openai-codex.codeMode": "auto" }),


### PR DESCRIPTION
## Summary

New sessions no longer start with almost no tools and an empty skill inventory. Before this change, a session sometimes came up where the model saw only the `think` tool. The system prompt in that state also listed no skills, because the prompt builder removes the skill inventory when the tool list does not contain `read`.

The cause is a startup race in `SessionTools`. The enabled set starts empty, and `getEnabledToolNames()` reads the live `agent.state.tools` as a fallback until the first apply fills the set. Several reconciles run in the startup window, for example the think, inspect_image, and Code Mode reconciles after the initial model resolution. If one of them samples the fallback while the live tool list is small for a short time, the apply commits that small list as the permanent enabled set. Later MCP and extension refreshes only add to the committed set, so the session stays broken.

Three changes close the window:

- The `SessionTools` constructor seeds the enabled set from the construction slate, the top-level agent tools plus the `xd://` mounts. The fallback no longer decides the permanent set.
- `getEnabledToolNames()` adds the live `xd://` mounts in all cases, so devices that plugins mount out-of-band stay enabled after the next apply.
- `reconcileCodeMode` samples the enabled set inside `runToolRegistryMutation`. The unlocked sample could race a queued apply and commit a stale set.

## Tests

The new regression test "startup reconcile survives a transiently narrow live tool set" is not successful on the code before this change and passes with it. The session-code-mode, sdk-tool-activation, agent-session-tool-rebuild-skip, and sdk-computer-tool-toggle suites pass (132 tests).