### PR TITLE
fix(bedrock): send reasoning.effort to OpenAI-schema models

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Amazon Bedrock requests to OpenAI-schema models (the `gpt-5.x` SKUs) failing with HTTP 400 `unknown_parameter: 'thinking'` when reasoning was enabled, by sending `reasoning.effort` instead of Anthropic's `thinking` budget block for models the catalog marks as effort-controlled.
+
 ## [18.0.7] - 2026-08-26
 
 ### Added

--- a/packages/ai/src/providers/amazon-bedrock.ts
+++ b/packages/ai/src/providers/amazon-bedrock.ts
@@ -1089,6 +1089,15 @@ function buildAdditionalModelRequestFields(
 		};
 	}
 
+	if (mode === "effort") {
+		// OpenAI-schema models on Bedrock (the GPT-5.x SKUs) reject the
+		// Anthropic budget block with `unknown_parameter: 'thinking'` and take
+		// `reasoning.effort` instead — same effort vocabulary the catalog
+		// already bakes (low/medium/high/xhigh/max).
+		const level = requireSupportedEffort(model, reasoning);
+		return { reasoning: { effort: model.thinking?.effortMap?.[level] ?? level } };
+	}
+
 	const level = requireSupportedEffort(model, reasoning);
 	const defaultBudgets: Record<Effort, number> = {
 		minimal: 1024,

--- a/packages/ai/test/bedrock-openai-reasoning.test.ts
+++ b/packages/ai/test/bedrock-openai-reasoning.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "bun:test";
+import { streamBedrock } from "@oh-my-pi/pi-ai/providers/amazon-bedrock";
+import type { Context, Model } from "@oh-my-pi/pi-ai/types";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import { Effort } from "@oh-my-pi/pi-catalog/effort";
+
+// Bedrock hosts the GPT-5.x SKUs behind OpenAI's own request schema. It rejects
+// the Anthropic budget block with HTTP 400 `unknown_parameter: 'thinking'` and
+// takes `reasoning.effort` instead, so the Converse provider has to switch wire
+// shapes on the catalog's thinking mode rather than assuming Anthropic.
+
+const OPENAI_LADDER = [Effort.Low, Effort.Medium, Effort.High, Effort.XHigh, Effort.Max] as const;
+
+function bedrockModel(id: string, thinking: Model<"bedrock-converse-stream">["thinking"]) {
+	return buildModel({
+		id,
+		name: id,
+		api: "bedrock-converse-stream",
+		provider: "amazon-bedrock",
+		baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 1_050_000,
+		maxTokens: 128_000,
+		thinking,
+	});
+}
+
+function payloadFor(model: Model<"bedrock-converse-stream">, reasoning: Effort): Promise<unknown> {
+	const context: Context = { messages: [{ role: "user", content: "hi", timestamp: 0 }] };
+	const controller = new AbortController();
+	controller.abort();
+	const { promise, resolve } = Promise.withResolvers<unknown>();
+	void streamBedrock(model, context, {
+		bearerToken: "test-token",
+		signal: controller.signal,
+		reasoning,
+		maxTokens: 16,
+		onPayload: payload => resolve(payload),
+	});
+	return promise;
+}
+
+describe("Bedrock OpenAI-schema reasoning", () => {
+	test("sends reasoning.effort and never the Anthropic thinking block", async () => {
+		const model = bedrockModel("global.openai.gpt-5.6-luna", { mode: "effort", efforts: OPENAI_LADDER });
+		const payload = (await payloadFor(model, Effort.Max)) as {
+			additionalModelRequestFields?: Record<string, unknown>;
+		};
+
+		expect(payload.additionalModelRequestFields).toEqual({ reasoning: { effort: "max" } });
+		expect(payload.additionalModelRequestFields).not.toHaveProperty("thinking");
+	});
+
+	test("keeps the budget block for Anthropic models on the same API", async () => {
+		const model = bedrockModel("us.anthropic.claude-sonnet-4-5-20250929", {
+			mode: "budget",
+			efforts: [Effort.Low, Effort.Medium, Effort.High],
+		});
+		const payload = (await payloadFor(model, Effort.High)) as {
+			additionalModelRequestFields?: Record<string, unknown>;
+		};
+
+		expect(payload.additionalModelRequestFields).toMatchObject({
+			thinking: { type: "enabled", budget_tokens: 16384 },
+		});
+	});
+});

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the thinking control mode for OpenAI models served over Bedrock Converse (`global.openai.gpt-5.6-luna`, `-sol`, `-terra`), which are now classified as `effort` rather than `budget` so requests use OpenAI's reasoning schema.
+
 ## [18.0.7] - 2026-08-26
 
 ### Fixed

--- a/packages/catalog/src/model-thinking.ts
+++ b/packages/catalog/src/model-thinking.ts
@@ -777,6 +777,14 @@ function inferThinkingControlMode<TApi extends Api>(
 					return "anthropic-budget-effort";
 				}
 			}
+			// Bedrock serves the GPT-5.x models through OpenAI's own request
+			// schema, which rejects Anthropic's budget block outright:
+			// `unknown_parameter: 'thinking'`. It takes `reasoning.effort`
+			// instead. gpt-oss parses as `unknown` (no `gpt-<digits>`), so it
+			// keeps the budget path it ships with today.
+			if (parsedModel.family === "openai") {
+				return "effort";
+			}
 			return "budget";
 
 		default:

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -28688,7 +28688,7 @@
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
 			"thinking": {
-				"mode": "budget",
+				"mode": "effort",
 				"efforts": [
 					"low",
 					"medium",
@@ -28727,7 +28727,7 @@
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
 			"thinking": {
-				"mode": "budget",
+				"mode": "effort",
 				"efforts": [
 					"low",
 					"medium",
@@ -28766,7 +28766,7 @@
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
 			"thinking": {
-				"mode": "budget",
+				"mode": "effort",
 				"efforts": [
 					"low",
 					"medium",

--- a/packages/catalog/test/model-thinking.test.ts
+++ b/packages/catalog/test/model-thinking.test.ts
@@ -707,6 +707,23 @@ describe("model thinking derivation", () => {
 		expect(sonnet5Bedrock.thinking?.supportsDisplay).toBe(true);
 	});
 
+	it("classifies OpenAI-schema Bedrock models as effort, leaving gpt-oss on budget", () => {
+		// Bedrock serves the GPT-5.x SKUs through OpenAI's own request schema,
+		// which rejects Anthropic's budget block: `unknown_parameter: 'thinking'`.
+		for (const id of ["global.openai.gpt-5.6-luna", "global.openai.gpt-5.6-sol", "openai.gpt-5.6-terra"]) {
+			expect(createModel({ id, api: "bedrock-converse-stream", provider: "amazon-bedrock" }).thinking?.mode).toBe(
+				"effort",
+			);
+		}
+
+		// gpt-oss is not a `gpt-<digits>` id, so it stays unclassified and keeps
+		// the budget path it ships with today.
+		expect(
+			createModel({ id: "openai.gpt-oss-120b", api: "bedrock-converse-stream", provider: "amazon-bedrock" }).thinking
+				?.mode,
+		).toBe("budget");
+	});
+
 	it("backfills wire facts onto explicit thinking, explicit values winning", () => {
 		// Authored partial ladders on wire-exact models normalize to the
 		// model-defined ladder, and the wire map is re-derived alongside:


### PR DESCRIPTION
lets omp use 1M context luna from bedrock

## What

Bedrock Converse serves the GPT-5.x SKUs (`global.openai.gpt-5.6-luna`, `-sol`, `-terra`) behind OpenAI's own
request schema, but `buildAdditionalModelRequestFields` sent Anthropic's `thinking` budget block to every model
whose thinking mode is not `anthropic-adaptive`. Any request to those models with reasoning enabled failed with:

```
HTTP 400 {"error":{"code":"unknown_parameter", ... 'thinking' ...}}
```

Two changes:

- `packages/catalog/src/model-thinking.ts` — on `bedrock-converse-stream`, models whose parsed family is `openai`
  are classified as thinking mode `effort` instead of `budget`. `openai.gpt-oss-120b` does not parse as an OpenAI
  family (no `gpt-<digits>`), so it keeps the budget path it ships with today.
- `packages/ai/src/providers/amazon-bedrock.ts` — mode `effort` emits `{"reasoning":{"effort":<level>}}`, using the
  same effort vocabulary the catalog already bakes.

`packages/catalog/src/models.json` changes 3 lines: the baked `thinking.mode` for those three entries.

## Why

Today the only reachable GPT-5.6 Luna is the `bedrock-mantle` one, which caps context at 272K. The
`amazon-bedrock` entry advertises 1,050,000 — and is unusable with thinking on, which is the default for these
models. The wire shape was verified directly against `global.openai.gpt-5.6-luna` in `us-east-1`: Bedrock's own
error text enumerates the accepted efforts as `none, low, medium, high, xhigh, max`, and rejects
`reasoning_effort`, `effort`, `output_config`, and `thinking`.

## Testing

- New `packages/ai/test/bedrock-openai-reasoning.test.ts` captures the exact Converse payload via `onPayload` with
  a pre-aborted signal (no network). It asserts `additionalModelRequestFields` is `{reasoning:{effort:"max"}}` for
  Luna and still the `thinking` budget block for an Anthropic model on the same API.
- Confirmed the test reproduces the bug: with the two source changes stashed it fails with exactly
  `- "reasoning": {"effort": "max"}` / `+ "thinking": {"budget_tokens": 32768, "display": "summarized", "type": "enabled"}`.
- New catalog test asserts the three GPT-5.6 Bedrock ids classify as `effort` and `openai.gpt-oss-120b` stays `budget`.
- `bun test packages/ai/test/bedrock-openai-reasoning.test.ts packages/catalog/test/model-thinking.test.ts` — 46 pass, 0 fail.
- `bun check` passes (`check:rs` skips: no Rust-affecting changes).
- Exercised end to end against real Bedrock by applying the equivalent patch to an installed 18.0.5 bundle: before,
  every Luna request at thinking `max` returned HTTP 400 `unknown_parameter: 'thinking'`; after, the same prompt
  completed normally on the 1.05M-context `amazon-bedrock` model.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
