### PR TITLE
fix(tui): prevent duplicated and interleaved text in tmux scrollback

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Fixed unfinished live viewport rows entering tmux pane history and duplicating streamed output ([#9780](https://github.com/can1357/oh-my-pi/issues/9780)).
 - Fixed image previews displaying as garbled characters in Paseo terminals.
 - Fixed graceful shutdown so finalized output is correctly retired before handing control back to the shell.
 - Fixed terminal resizing from duplicating committed history in native scrollback.

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -2361,7 +2361,16 @@ export class TUI extends Container {
 			// committed rows and blanks, never an unfinished frame.
 			const pushed = Math.max(0, startTop + preparedHistory.length + rows - height);
 			if (pushed > this.#providerViewportTop && this.#providerWindow.length > 0) {
-				buffer += `\x1b[${this.#providerViewportTop + 1};1H\x1b[J`;
+				const eraseTop = this.#providerViewportTop;
+				if (eraseTop > 0) {
+					// Below existing history: ED0 here never spans the whole screen.
+					buffer += `\x1b[${eraseTop + 1};1H\x1b[J`;
+				} else {
+					// Full-screen erase makes tmux preserve the live rows (#9780);
+					// EL2 the first row + ED0 the rest clears the same cells, no full clear.
+					buffer += "\x1b[1;1H\x1b[2K";
+					if (height > 1) buffer += "\x1b[2;1H\x1b[J";
+				}
 			}
 			buffer += `\x1b[${startTop + 1};1H`;
 			let screenRow = startTop;

--- a/packages/tui/test/history-frame-plan.test.ts
+++ b/packages/tui/test/history-frame-plan.test.ts
@@ -172,6 +172,22 @@ class FlushProvider implements TerminalFrameProvider {
 function plainBuffer(terminal: VirtualTerminal): string[] {
 	return terminal.getScrollBuffer().map(row => Bun.stripANSI(row).trimEnd());
 }
+/** Models tmux's preserved clear: a full-screen ED0/ED2 scrolls the live
+ *  screen into pane history before blanking, unlike xterm-family discard. */
+class TmuxPreservedClearTerminal extends VirtualTerminal {
+	override write(data: string): void {
+		const fullScreenClear = /\x1b\[1;1H\x1b\[J|\x1b\[2J/g;
+		let translated = "";
+		let last = 0;
+		for (let match = fullScreenClear.exec(data); match; match = fullScreenClear.exec(data)) {
+			translated += data.slice(last, match.index);
+			translated += `\x1b[${this.rows};1H${"\n".repeat(this.rows)}${match[0]}`;
+			last = match.index + match[0].length;
+		}
+		translated += data.slice(last);
+		super.write(translated);
+	}
+}
 
 describe("terminal frame plans", () => {
 	it("appends finalized history once and leaves the requested mutable viewport intact", () => {
@@ -186,6 +202,28 @@ describe("terminal frame plans", () => {
 		expect(provider.acknowledged).toEqual([1]);
 		expect(terminal.getBufferPosition().baseY).toBe(1);
 		expect(terminal.getViewport().map(row => row.trimEnd())).toEqual(["history two", "editor", "status"]);
+		tui.stop();
+	});
+	it("keeps live viewport rows out of tmux-style preserved-clear scrollback on a scrolling append", () => {
+		// Viewport at row 0 fills the screen: the protective erase is emitted
+		// full-screen, which tmux would archive as the #9780 duplication.
+		const terminal = new TmuxPreservedClearTerminal(20, 4);
+		const provider = new Provider({ viewport: ["live-1", "live-2", "live-3", "editor"] });
+		const tui = new TUI(terminal, undefined, { renderScheduler: scheduler });
+		tui.setFrameProvider(provider);
+		expect(terminal.getBufferPosition().baseY).toBe(0);
+
+		provider.plan = {
+			history: { id: 1, rows: ["hist-1", "hist-2"] },
+			viewport: ["live-2", "live-3", "live-4", "editor"],
+		};
+		tui.requestRender(true);
+
+		expect(provider.acknowledged).toEqual([1]);
+		const scrollback = plainBuffer(terminal).slice(0, terminal.getBufferPosition().baseY);
+		expect(scrollback.some(row => row.includes("live-") || row.includes("editor"))).toBe(false);
+		expect(scrollback.filter(Boolean)).toEqual(["hist-1", "hist-2"]);
+		expect(terminal.getViewport().map(row => row.trimEnd())).toEqual(["live-2", "live-3", "live-4", "editor"]);
 		tui.stop();
 	});
 	it("bottom-splits a complete replay and serializes it in one terminal write", () => {


### PR DESCRIPTION
Refs #9780

I live in tmux, either SSH'd into my server or locally on my laptop, and I keep the reasoning visible so I can interrupt a model when it goes off track. Some models are really verbose after the reasoning too — I can't always keep up with the stream, or I'm AFK — so I scroll back through the history, and that's where I kept hitting cut-off or duplicated text in the transcript. Annoying enough that, like the reporter of #9780, I nearly dropped omp over it. I tracked it down to the tmux erase semantics below, fixed it, verified in my own Ghostty+tmux sessions that scrolling mid-stream is now clean, and I'm sharing the fix.

#9780 was labeled wontfix as the known #8831 limitation — "rows already in scrollback can't be repaired". That's not what happens here. The duplicated rows are the still-streaming bottom of the screen, spinner and composer included, which is never supposed to enter scrollback at all. Under tmux, the escape sequence omp uses to clear that area doesn't clear it — it archives it into scrollback.

```text
┌──────────────────────────────┐
│ scrollback                   │ ← finalized rows, written once, never repainted
├──────────────────────────────┤
│ live region (screen bottom)  │ ← repainted every frame: the streaming reply,
│ ⠴ Working…  ╭─ composer ─╮   │   the spinner, the composer
└──────────────────────────────┘
```

**How the duplicated rows are created:**

1. Appending finalized rows to scrollback scrolls the screen.
2. Before scrolling, omp clears the live region so the unfinished reply, spinner and composer cannot be pushed into scrollback.
3. During a long reply, the live region grows until it fills the whole screen — so "clear the live region" becomes "clear the whole screen".
4. When tmux receives a full-screen clear, it saves the current screen into pane history before clearing it.
5. tmux therefore saves one unfinished copy of the reply, including the spinner and composer.
6. When omp later writes the finalized reply to scrollback, the unfinished screen snapshot saved by tmux is still there above it. Scrollback now contains both:
   - an accidental snapshot of the unfinished reply, spinner and composer included;
   - the intended final reply written by omp.

   This is why text appears twice and old UI appears between answer rows in #9780.

**The root cause is tmux's clear behavior, reproducible without omp.**

The strings below are standard ANSI/VT-style CSI terminal escape sequences:

- CUP (*Cursor Position*) moves the cursor: `\033[row;columnH`;
- ED0 (*Erase in Display, mode 0*) clears from the cursor to the bottom: `\033[J`;
- ED2 (*Erase in Display, mode 2*) clears the whole screen: `\033[2J`;
- EL2 (*Erase in Line, mode 2*) clears the whole current row: `\033[2K`.

Copy-paste probe:

```bash
probe_clear() {
  local name="$1"
  local sequence="$2"

  tmux -L omp-clear-probe kill-server >/dev/null 2>&1 || true
  tmux -L omp-clear-probe -f /dev/null new-session -d -x 80 -y 24 \
    "for i in \$(seq 1 23); do echo LIVE-\$i; done; sleep 1; printf '$sequence'; sleep 5"

  sleep 3
  local saved
  saved=$(tmux -L omp-clear-probe capture-pane -p -S - -E -1 | grep -c 'LIVE-')
  printf '%-30s %s rows saved into tmux history\n' "$name" "$saved"
  tmux -L omp-clear-probe kill-server
}

# CUP row 1, column 1 + ED0 from the cursor to the bottom.
# Because ED0 starts at the first cell, this clears the whole screen.
old_omp_clear='\033[1;1H\033[J'

# ED2: explicit full-screen clear.
standard_ed2='\033[2J'

# CUP row 1 + EL2 (clear the whole first row),
# then CUP row 2 + ED0 (clear rows 2 to the bottom).
# The same cells are cleared, but no command clears the whole screen.
split_clear='\033[1;1H\033[2K\033[2;1H\033[J'

probe_clear "old omp clear: ED0" "$old_omp_clear"
probe_clear "standard screen-clear: ED2" "$standard_ed2"
probe_clear "PR fix: EL2 + ED0" "$split_clear"
```

Expected output:

```text
old omp clear: ED0            23 rows saved into tmux history
standard screen-clear: ED2    23 rows saved into tmux history
PR fix: EL2 + ED0              0 rows saved into tmux history
```

The first two sequences are full-screen clears. tmux saves the current screen into pane history before clearing it. The replacement sequence clears the same cells — the first row, then the rest from the second row down — without sending a full-screen clear, so tmux saves nothing.

The history must stay empty because there are two writers into the same pane history:

1. **omp is the intended writer.** It deliberately appends finalized rows, one at a time. For omp, pane history is an append-only ledger where it chooses every entry.
2. **tmux's full-screen clear becomes an accidental writer.** When omp asks it to clear the live screen, tmux inserts a snapshot of rows omp never chose to publish.

Those cleared rows are unfinished drafts — partial reply, spinner and composer included. omp appends the finished version later. If tmux saves the draft too, pane history contains both copies, which creates the duplicated text and interleaved UI seen in #9780.

**Why split the erase**

tmux's preserved-clear behavior is triggered when one command clears the whole screen.

Before this fix, omp placed the cursor at the first row and column, then sent ED0:

```text
cursor here
↓
row 1  ───────────────┐
row 2                 │ ED0 clears from the cursor
row 3                 │ to the bottom
...                   │
last row ─────────────┘
```

Because ED0 starts at the first cell, it clears the whole screen in one command. tmux saves that screen into pane history before clearing it.

The fix splits the same erase into two commands:

```text
row 1          ← EL2 clears this row only

row 2  ───────────────┐
row 3                 │ ED0 starts at row 2
...                   │ and clears to the bottom
last row ─────────────┘
```

- EL2 clears the whole current row.
- ED0 clears from the cursor to the bottom.

Together they clear the same cells, but neither command clears the whole screen by itself, so tmux does not trigger its preserved clear. Sending EL2 for every row would also work, but this keeps the fix to two erase commands.

**Why this is safe on every terminal**

1. EL2 and ED0 are standard terminal sequences; every terminal receives the same replacement — there is no tmux detection.
2. Both versions clear exactly the same cells.
3. `#emitPlanFrame` moves the cursor back to the repaint position immediately afterward, so the temporary cursor position on the second row is not observable.
4. On a one-row screen, the code sends only EL2 because the second row does not exist.
5. Every other erase path is unchanged, including the intentional destructive reset (Ctrl+L), which follows its full-screen clear with ED3 that also wipes tmux's preserved copy.

**End-to-end reproduction**

I also reran the original #9780 capture method against a deterministic local provider: a fixed 80x24 tmux pane, no resize, and a streamed reply containing 120 numbered markers (`UNICODE-STRESS-1` … `UNICODE-STRESS-120`). Each marker should appear exactly once and in order in the final pane history.

| build | rendered markers | unique markers | duplicated IDs | order | live UI saved |
|---|---:|---:|---:|---|---:|
| main (`40f095f8fd`) | 136–137 | 120 | 16–17 | broken | 2 screen snapshots |
| patched | 120 | 120 | 0 | correct | 0 |

The main captures contain unfinished reply rows, spinner and composer between finalized answer rows. The patched captures contain the 120 expected markers once each, in order, with no live UI in pane history.

**Regression test**

`history-frame-plan.test.ts` models tmux's preserved-clear behavior on top of `VirtualTerminal`. It fills the live viewport, appends a finalized history batch and checks what reached pane history:

- on main, unfinished live rows and the editor leak into history;
- with the patch, pane history contains only the finalized batch.

The test fails on main and passes with the patch.

**Validation**

- `bun run check`
- `bun test test/history-frame-plan.test.ts` — 12 passed
- full pi-tui suite — 1374 passed
- manual Ghostty + tmux verification while scrolling during a streamed reply

**Scope**

This PR only fixes unintended live-screen snapshots entering tmux pane history. It does not change when streamed assistant prose becomes final or eligible for scrollback.
