### PR TITLE
feat(acp): expose subagent activity via _omp/agents/* extension methods (supersedes #8728)

### DIFF
--- a/docs/acp-agents.md
+++ b/docs/acp-agents.md
@@ -1,0 +1,111 @@
+# ACP Subagent Activity Extension
+
+`omp acp` exposes subagent lifecycle and usage telemetry to ACP clients through
+two `_omp/*` extension methods. They mirror the Agent Hub roster: the same
+`AgentRegistry` the TUI, collab, and `history://` surfaces read, serialized for
+the wire.
+
+Primary implementation:
+
+- `packages/coding-agent/src/modes/acp/acp-agent.ts` (`AcpAgentSnapshot`,
+  `snapshotAcpAgents`, `AcpAgent.#scheduleAgentsBroadcast`)
+
+The extension surface is opt-in by convention: clients that do not implement
+`extMethod`/`extNotification` simply never see these frames; unknown
+notifications are dropped by the JSON-RPC transport.
+
+## Request: `_omp/agents/list`
+
+Returns the current roster. No parameters.
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "_omp/agents/list",
+  "params": {}
+}
+```
+
+Response `result`:
+
+```json
+{
+  "agents": [
+    {
+      "id": "Main",
+      "displayName": "Main",
+      "kind": "main",
+      "status": "running",
+      "sessionFile": null,
+      "createdAt": 1750000000000,
+      "lastActivity": 1750000001000
+    },
+    {
+      "id": "AuthLoader",
+      "displayName": "AuthLoader",
+      "kind": "sub",
+      "parentId": "Main",
+      "status": "running",
+      "sessionFile": "/home/user/.omp/sessions/auth-loader.jsonl",
+      "createdAt": 1750000000100,
+      "lastActivity": 1750000002000,
+      "activity": "grepping call sites of resolve()",
+      "resolvedModel": "anthropic/claude-sonnet-4-20250514",
+      "metrics": {
+        "tokens": 900,
+        "requests": 2,
+        "tools": 5,
+        "cost": 0.01,
+        "durationMs": 12000
+      }
+    }
+  ]
+}
+```
+
+Field reference:
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `id` | string | Registry id (`"Main"` for the driving agent, subagent ids for task spawns). |
+| `displayName` | string | Roster display name. |
+| `kind` | `"main"` \| `"sub"` | Advisor transcripts are observability-only and never serialized. |
+| `parentId` | string? | Parent agent id, when the spawn recorded one. |
+| `status` | `"running"` \| `"idle"` \| `"parked"` \| `"aborted"` | Lifecycle state. Finished agents stay `idle`; disposed-but-revivable agents are `parked`; hard-killed agents are `aborted`. |
+| `sessionFile` | string \| null | Transcript session file. Clients can resolve it through `history://`/`agent://` on the same machine. |
+| `createdAt` | number | Registration timestamp (ms). |
+| `lastActivity` | number | Last work/status-change timestamp (ms). |
+| `activity` | string? | One-line gist of current work; present only while `status` is `running`. |
+| `resolvedModel` | string? | Last resolved model id, when recorded. |
+| `metrics` | object? | Persisted usage totals (`tokens`, `requests`, `tools`, `cost`, `durationMs`, optional `contextTokens`/`contextWindow`), present once the agent finished a turn. |
+
+## Notification: `_omp/agents/update`
+
+Pushed after the client's `initialize` completes and again, debounced (100 ms),
+on every registry change: subagent spawn, status transition, usage-metadata
+record, or removal. The payload is the same full `agents` snapshot as
+`_omp/agents/list`, so clients can live-track subagent lifecycle without
+polling. A client that subscribes to the notification right after `initialize`
+also receives the initial snapshot (in-order JSON-RPC guarantees it lands after
+the `initialize` response).
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "_omp/agents/update",
+  "params": { "agents": [] }
+}
+```
+
+## Notes
+
+- The roster is process-global: concurrent ACP sessions (or a simultaneously
+  running TUI) share one `AgentRegistry`, so snapshots include subagents spawned
+  by other sessions of the same process. Filter by `kind: "sub"` (and
+  optionally `parentId`) to scope to subagent work.
+- `activity` refreshes on status/metadata boundaries, not per tool call, so it
+  is a coarse "what is it doing" gist, matching the Agent Hub roster.
+- The surface is transport-agnostic: `omp acp` over stdio and the embedded
+  ACP-channel transport (`mcpServers` type `acp`) both dispatch through the same
+  `extMethod`/`extNotification` hooks.

--- a/docs/acp-agents.md
+++ b/docs/acp-agents.md
@@ -180,7 +180,11 @@ boundary, so continuation reads at `nextByte` never lose or duplicate data.
 ```
 
 Poll with `fromByte: nextByte` until `nextByte` stops advancing (or `reset`
-appears after a file rotation).
+appears after a file rotation). A single JSONL record larger than the
+512 KiB budget is still delivered whole — the read spans up to 8 MiB to reach
+its terminating newline. Only a record exceeding that internal ceiling returns
+an unchanged cursor with `pendingOversizedRecord: true`, replacing what would
+otherwise be a silent no-progress stall.
 
 ## Tool-call classification
 

--- a/docs/acp-agents.md
+++ b/docs/acp-agents.md
@@ -98,6 +98,48 @@ the `initialize` response).
 }
 ```
 
+## Notification: `_omp/agents/progress`
+
+Pushed in real time while a subagent works (the task executor coalesces at
+~150 ms). Carries one subagent's live work snapshot:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "_omp/agents/progress",
+  "params": {
+    "agent": {
+      "id": "ReadA",
+      "index": 0,
+      "agent": "task",
+      "status": "running",
+      "description": "read a.ts",
+      "task": "…",
+      "lastIntent": "reading a.ts with the read tool",
+      "currentTool": "read",
+      "currentToolArgs": "a.ts",
+      "recentOutput": ["export const a = 1"],
+      "toolCount": 2,
+      "requests": 1,
+      "tokens": 120,
+      "cost": 0.001,
+      "durationMs": 5000,
+      "resolvedModel": "opencode-go/deepseek-v4-flash"
+    }
+  }
+}
+```
+
+`status` is one of `pending | running | completed | failed | aborted`; the
+verbose `task`/`description`/`lastIntent` texts are bounded on the wire. The
+`id` matches the roster snapshot id, so clients upsert the same card.
+
+## Tool-call classification
+
+`tool_call` and `tool_call_update` notifications carry an extension field
+`toolName` (the harness tool name, e.g. `task`), so clients can classify the
+task tool beyond the spec `kind` (which maps it to `other`).
+
 ## Notes
 
 - The roster is process-global: concurrent ACP sessions (or a simultaneously

--- a/docs/acp-agents.md
+++ b/docs/acp-agents.md
@@ -104,6 +104,10 @@ the `initialize` response).
   running TUI) share one `AgentRegistry`, so snapshots include subagents spawned
   by other sessions of the same process. Filter by `kind: "sub"` (and
   optionally `parentId`) to scope to subagent work.
+- Tool statuses on the wire are terminal: `tool_call_update` emits
+  `completed`/`failed` once, and late async progress (task/job callbacks that
+  fire after the loop finalized a call) is suppressed so clients never see an
+  `in_progress` that reopens a finished tool call.
 - `activity` refreshes on status/metadata boundaries, not per tool call, so it
   is a coarse "what is it doing" gist, matching the Agent Hub roster.
 - The surface is transport-agnostic: `omp acp` over stdio and the embedded

--- a/docs/acp-agents.md
+++ b/docs/acp-agents.md
@@ -134,6 +134,48 @@ Pushed in real time while a subagent works (the task executor coalesces at
 verbose `task`/`description`/`lastIntent` texts are bounded on the wire. The
 `id` matches the roster snapshot id, so clients upsert the same card.
 
+## Request: `_omp/agents/messages`
+
+Returns a subagent's transcript (its own messages, including `thinking`
+blocks) so clients can render subagent reasoning inside the subagent's card.
+Mirrors the RPC `get_subagent_messages` surface.
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "_omp/agents/messages",
+  "params": { "agentId": "ReadA", "fromByte": 0 }
+}
+```
+
+Either `agentId` (registry id from a roster snapshot) or `sessionFile` may be
+given; `fromByte` resumes a previous read (byte offset, line-aligned). Only
+files claimed by a registered agent are readable — arbitrary paths are
+rejected. Response `result`:
+
+```json
+{
+  "sessionFile": "…/ReadA.jsonl",
+  "fromByte": 0,
+  "nextByte": 4096,
+  "reset": false,
+  "messages": [
+    { "role": "user", "content": [{ "type": "text", "text": "…" }] },
+    {
+      "role": "assistant",
+      "content": [
+        { "type": "thinking", "thinking": "Let me read the file…" },
+        { "type": "text", "text": "…" }
+      ]
+    }
+  ]
+}
+```
+
+Poll with `fromByte: nextByte` until `nextByte` stops advancing (or `reset`
+appears after a file rotation).
+
 ## Tool-call classification
 
 `tool_call` and `tool_call_update` notifications carry an extension field

--- a/docs/acp-agents.md
+++ b/docs/acp-agents.md
@@ -10,9 +10,10 @@ Primary implementation:
 - `packages/coding-agent/src/modes/acp/acp-agent.ts` (`AcpAgentSnapshot`,
   `snapshotAcpAgents`, `AcpAgent.#scheduleAgentsBroadcast`)
 
-The extension surface is opt-in by convention: clients that do not implement
-`extMethod`/`extNotification` simply never see these frames; unknown
-notifications are dropped by the JSON-RPC transport.
+The extension surface is opt-in: clients declare
+`clientCapabilities.extensions.agents` during `initialize`. Connections that do
+not declare it receive no `_omp/agents*` frames at all, and `_omp/agents/*`
+requests are rejected with a method-not-found error naming the capability.
 
 ## Request: `_omp/agents/list`
 
@@ -100,8 +101,11 @@ the `initialize` response).
 
 ## Notification: `_omp/agents/progress`
 
-Pushed in real time while a subagent works (the task executor coalesces at
-~150 ms). Carries one subagent's live work snapshot:
+Pushed whenever the task executor reports subagent work over the session's task
+event channels — including background spawns whose `task` tool call settles
+before any subagent frame arrives, plus terminal lifecycle transitions folded
+into the last known snapshot so failures are explicit. Carries one subagent's
+live work snapshot:
 
 ```json
 {
@@ -151,8 +155,10 @@ Mirrors the RPC `get_subagent_messages` surface.
 
 Either `agentId` (registry id from a roster snapshot) or `sessionFile` may be
 given; `fromByte` resumes a previous read (byte offset, line-aligned). Only
-files claimed by a registered agent are readable — arbitrary paths are
-rejected. Response `result`:
+files claimed by a registered main or sub agent are readable — arbitrary paths
+and advisor transcripts are rejected. A single request consumes at most
+512 KiB beyond `fromByte`, cut at a complete line on a whole code point
+boundary, so continuation reads at `nextByte` never lose or duplicate data.
 
 ```json
 {
@@ -194,6 +200,10 @@ task tool beyond the spec `kind` (which maps it to `other`).
   `in_progress` that reopens a finished tool call.
 - `activity` refreshes on status/metadata boundaries, not per tool call, so it
   is a coarse "what is it doing" gist, matching the Agent Hub roster.
+- Subagent progress frames cover top-level spawns of a session today; nested
+  spawns (a subagent spawning further agents) stream only their own channel
+  traffic, and deeper descendants surface through the registry-driven
+  `_omp/agents/update` roster once they register.
 - The surface is transport-agnostic: `omp acp` over stdio and the embedded
   ACP-channel transport (`mcpServers` type `acp`) both dispatch through the same
   `extMethod`/`extNotification` hooks.

--- a/docs/acp-agents.md
+++ b/docs/acp-agents.md
@@ -182,9 +182,9 @@ boundary, so continuation reads at `nextByte` never lose or duplicate data.
 Poll with `fromByte: nextByte` until `nextByte` stops advancing (or `reset`
 appears after a file rotation). A single JSONL record larger than the
 512 KiB budget is still delivered whole — the read spans up to 8 MiB to reach
-its terminating newline. Only a record exceeding that internal ceiling returns
-an unchanged cursor with `pendingOversizedRecord: true`, replacing what would
-otherwise be a silent no-progress stall.
+its terminating newline. When pagination reaches a record exceeding even that
+internal ceiling, that poll stops advancing the cursor and reports
+`pendingOversizedRecord: true` instead of a silent no-progress stall.
 
 ## Tool-call classification
 

--- a/docs/acp-agents.md
+++ b/docs/acp-agents.md
@@ -208,6 +208,6 @@ task tool beyond the spec `kind` (which maps it to `other`).
   spawns (a subagent spawning further agents) stream only their own channel
   traffic, and deeper descendants surface through the registry-driven
   `_omp/agents/update` roster once they register.
-- The surface is transport-agnostic: `omp acp` over stdio and the embedded
-  ACP-channel transport (`mcpServers` type `acp`) both dispatch through the same
-  `extMethod`/`extNotification` hooks.
+- The surface is transport-agnostic: `omp acp` over stdio and embedders that
+  construct sessions directly share the same `extMethod`/`extNotification`
+  dispatch through `AgentSideConnection`.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -619,7 +619,7 @@
 - Fixed `omp stats` and `/stats` dashboards being unreachable from container hosts by accepting an explicit `--host` bind address while preserving the `127.0.0.1` default.
 ### Added
 
-- Added ACP `_omp/agents/list` and `_omp/agents/update` extension methods exposing subagent lifecycle, current activity, and usage telemetry to ACP clients, plus a real-time `_omp/agents/progress` notification streaming each subagent's live work (intent, active tool, recent output, spend). `tool_call`/`tool_call_update` notifications now carry a `toolName` extension field so clients can classify the task tool beyond the spec `kind`.
+- Added ACP `_omp/agents/list` and `_omp/agents/update` extension methods exposing subagent lifecycle, current activity, and usage telemetry to ACP clients, plus a real-time `_omp/agents/progress` notification streaming each subagent's live work (intent, active tool, recent output, spend) and an `_omp/agents/messages` request returning a subagent's transcript including its `thinking` blocks. `tool_call`/`tool_call_update` notifications now carry a `toolName` extension field so clients can classify the task tool beyond the spec `kind`.
 
 ## [17.3.5] - 2026-08-16
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -617,6 +617,9 @@
 ### Fixed
 
 - Fixed `omp stats` and `/stats` dashboards being unreachable from container hosts by accepting an explicit `--host` bind address while preserving the `127.0.0.1` default.
+### Added
+
+- Added ACP `_omp/agents/list` and `_omp/agents/update` extension methods exposing subagent lifecycle, current activity, and usage telemetry to ACP clients.
 
 ## [17.3.5] - 2026-08-16
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -619,7 +619,7 @@
 - Fixed `omp stats` and `/stats` dashboards being unreachable from container hosts by accepting an explicit `--host` bind address while preserving the `127.0.0.1` default.
 ### Added
 
-- Added ACP `_omp/agents/list` and `_omp/agents/update` extension methods exposing subagent lifecycle, current activity, and usage telemetry to ACP clients.
+- Added ACP `_omp/agents/list` and `_omp/agents/update` extension methods exposing subagent lifecycle, current activity, and usage telemetry to ACP clients, plus a real-time `_omp/agents/progress` notification streaming each subagent's live work (intent, active tool, recent output, spend). `tool_call`/`tool_call_update` notifications now carry a `toolName` extension field so clients can classify the task tool beyond the spec `kind`.
 
 ## [17.3.5] - 2026-08-16
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -36,6 +36,7 @@
 - Fixed the `aarch64-linux` `nix build` output segfaulting in the dynamic loader before startup by repointing the stale `DT_VERDEF` that `patchelf` leaves behind when it grows `.dynamic`, and surfaced smoke-test signal deaths in the build log instead of masking them ([#9881](https://github.com/can1357/oh-my-pi/issues/9881)).
 - Added custom RPC launcher builders so embedded clients can transport omp RPC through SSH and remote process managers.
 - Added opt-in ACP subagent activity surface `_omp/agents/list|update|progress|messages` ([#8728](https://github.com/can1357/oh-my-pi/pull/8728) by [@Alek7eeey](https://github.com/Alek7eeey)): roster, live progress, and transcripts for ACP clients, gated behind `clientCapabilities.extensions.agents`.
+- Added opt-in ACP subagent activity surface `_omp/agents/list|update|progress|messages` ([#9878](https://github.com/can1357/oh-my-pi/pull/9878), building on [#8728](https://github.com/can1357/oh-my-pi/issues/8728) by [@Alek7eeey](https://github.com/Alek7eeey)): roster, live progress, and transcripts for ACP clients, gated behind `clientCapabilities.extensions.agents`.
 
 ### Changed
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -35,6 +35,12 @@
 - Fixed the git TUI sidebar jumping back to the top of the file list after staging or unstaging a file; selection now stays on the nearest remaining row
 - Fixed the `aarch64-linux` `nix build` output segfaulting in the dynamic loader before startup by repointing the stale `DT_VERDEF` that `patchelf` leaves behind when it grows `.dynamic`, and surfaced smoke-test signal deaths in the build log instead of masking them ([#9881](https://github.com/can1357/oh-my-pi/issues/9881)).
 - Added custom RPC launcher builders so embedded clients can transport omp RPC through SSH and remote process managers.
+- Added opt-in ACP subagent activity surface `_omp/agents/list|update|progress|messages` ([#8728](https://github.com/can1357/oh-my-pi/pull/8728) by [@Alek7eeey](https://github.com/Alek7eeey)): roster, live progress, and transcripts for ACP clients, gated behind `clientCapabilities.extensions.agents`.
+
+### Changed
+
+- ACP `_omp/agents/progress` is now driven by the task executor's subagent channels instead of task tool-call updates, so background spawns stream live work and reach explicit terminal states.
+- `_omp/agents/messages` reads are capped per request and advisor transcripts are no longer readable.
 
 ## [18.0.7] - 2026-08-26
 
@@ -617,9 +623,6 @@
 ### Fixed
 
 - Fixed `omp stats` and `/stats` dashboards being unreachable from container hosts by accepting an explicit `--host` bind address while preserving the `127.0.0.1` default.
-### Added
-
-- Added ACP `_omp/agents/list` and `_omp/agents/update` extension methods exposing subagent lifecycle, current activity, and usage telemetry to ACP clients, plus a real-time `_omp/agents/progress` notification streaming each subagent's live work (intent, active tool, recent output, spend) and an `_omp/agents/messages` request returning a subagent's transcript including its `thinking` blocks. `tool_call`/`tool_call_update` notifications now carry a `toolName` extension field so clients can classify the task tool beyond the spec `kind`.
 
 ## [17.3.5] - 2026-08-16
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -35,7 +35,6 @@
 - Fixed the git TUI sidebar jumping back to the top of the file list after staging or unstaging a file; selection now stays on the nearest remaining row
 - Fixed the `aarch64-linux` `nix build` output segfaulting in the dynamic loader before startup by repointing the stale `DT_VERDEF` that `patchelf` leaves behind when it grows `.dynamic`, and surfaced smoke-test signal deaths in the build log instead of masking them ([#9881](https://github.com/can1357/oh-my-pi/issues/9881)).
 - Added custom RPC launcher builders so embedded clients can transport omp RPC through SSH and remote process managers.
-- Added opt-in ACP subagent activity surface `_omp/agents/list|update|progress|messages` ([#8728](https://github.com/can1357/oh-my-pi/pull/8728) by [@Alek7eeey](https://github.com/Alek7eeey)): roster, live progress, and transcripts for ACP clients, gated behind `clientCapabilities.extensions.agents`.
 - Added opt-in ACP subagent activity surface `_omp/agents/list|update|progress|messages` ([#9878](https://github.com/can1357/oh-my-pi/pull/9878), building on [#8728](https://github.com/can1357/oh-my-pi/issues/8728) by [@Alek7eeey](https://github.com/Alek7eeey)): roster, live progress, and transcripts for ACP clients, gated behind `clientCapabilities.extensions.agents`.
 
 ### Changed

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -366,6 +366,8 @@ export async function submitInteractiveInput(
 interface AcpSessionHandle {
 	session: AgentSession;
 	setToolUIContext: (uiContext: ExtensionUIContext, hasUI: boolean) => void;
+	/** Session-owned task/extension bus carrying subagent progress/lifecycle channels for `_omp/agents/*`. */
+	eventBus?: EventBus;
 }
 
 type AcpSessionFactory = (cwd: string, options?: { interactivePrompts?: boolean }) => Promise<AcpSessionHandle>;
@@ -474,7 +476,7 @@ export function createAcpSessionFactory(args: AcpSessionFactoryOptions): AcpSess
 				throw error;
 			}
 		}
-		return { session: nextSession, setToolUIContext };
+		return { session: nextSession, setToolUIContext, eventBus };
 	};
 }
 

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -262,6 +262,15 @@ type ManagedSessionRecord = {
 	liveMessageId: string | undefined;
 	liveMessageProgress: { textEmitted: boolean; thoughtEmitted: boolean } | undefined;
 	toolArgsById: Map<string, unknown>;
+	/**
+	 * toolCallIds whose `tool_execution_end` already streamed to the client.
+	 * Async tool progress (task/job callbacks) can push `tool_execution_update`
+	 * events after the loop finalized the call; those late `in_progress`
+	 * updates must not clobber the terminal `completed`/`failed` status on the
+	 * wire. Maintained in the synchronous event-handler prefix; ids are unique
+	 * per session lifetime, so the set is never cleared.
+	 */
+	endedToolCallIds: Set<string>;
 	extensionsConfigured: boolean;
 	// Installed inside `#scheduleBootstrapUpdates` (post-race-guard); released
 	// in `#disposeSessionRecord`. Lives independent of any prompt turn.
@@ -1474,6 +1483,7 @@ export class AcpAgent implements Agent {
 			liveMessageId: undefined,
 			liveMessageProgress: undefined,
 			toolArgsById: new Map(),
+			endedToolCallIds: new Set(),
 			extensionsConfigured: false,
 			closedError: undefined,
 			promptEventHandlers: new Set(),
@@ -1541,7 +1551,18 @@ export class AcpAgent implements Agent {
 		}
 
 		if (event.type === "tool_execution_start" || event.type === "tool_execution_update") {
+			// Async tool progress can fire after the loop finalized the call; a
+			// late `in_progress` would clobber the terminal status already sent
+			// (the ACP tool state machine has no transitions after completion).
+			// The ended-set is maintained in the synchronous prefix of the
+			// event handlers, so an update's check always observes an end that
+			// was emitted before it.
+			if (event.type === "tool_execution_update" && record.endedToolCallIds.has(event.toolCallId)) {
+				return;
+			}
 			record.toolArgsById.set(event.toolCallId, event.args);
+		} else if (event.type === "tool_execution_end") {
+			record.endedToolCallIds.add(event.toolCallId);
 		}
 
 		this.#prepareLiveAssistantMessage(record, event);

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -1358,6 +1358,7 @@ export class AcpAgent implements Agent {
 				this.#requireAgentsSurface();
 				return { agents: snapshotAcpAgents() };
 			case "_omp/agents/messages": {
+				this.#requireAgentsSurface();
 				const sessionFile = resolveAcpAgentTranscript({
 					agentId: params.agentId,
 					sessionFile: params.sessionFile,

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -60,6 +60,7 @@ import { resolveLocalUrlToPath } from "../../internal-urls";
 import { MCPManager } from "../../mcp/manager";
 import type { MCPServerConfig } from "../../mcp/types";
 import { loadAllExtensions } from "../../modes/components/extensions/state-manager";
+import { readRpcSubagentTranscript } from "../../modes/rpc/rpc-subagents";
 import { theme } from "../../modes/theme/theme";
 import { normalizePlanTitle, type PlanApprovalDetails, resolveApprovedPlan } from "../../plan-mode/approved-plan";
 import { type AgentRef, AgentRegistry, type AgentStatus } from "../../registry/agent-registry";
@@ -269,6 +270,24 @@ function extractSubagentProgress(partialResult: unknown): AgentProgress[] | unde
 	if (!details || typeof details !== "object" || Array.isArray(details)) return undefined;
 	const progress = (details as { progress?: unknown }).progress;
 	return Array.isArray(progress) ? (progress as AgentProgress[]) : undefined;
+}
+
+/**
+ * Resolve an `_omp/agents/messages` request to a transcript file. Only files
+ * currently claimed by a registered agent (main or sub) are readable, so the
+ * surface can never be used to read arbitrary paths.
+ */
+function resolveAcpAgentTranscript(params: { agentId?: unknown; sessionFile?: unknown }): string | undefined {
+	if (typeof params.sessionFile === "string") {
+		const registered = AgentRegistry.global()
+			.list()
+			.some(ref => ref.sessionFile === params.sessionFile);
+		if (registered) return params.sessionFile;
+	}
+	if (typeof params.agentId === "string") {
+		return AgentRegistry.global().get(params.agentId)?.sessionFile ?? undefined;
+	}
+	return undefined;
 }
 
 type AgentImageContent = {
@@ -1302,6 +1321,27 @@ export class AcpAgent implements Agent {
 				return buildAcpSpeechModelsCatalog();
 			case "_omp/agents/list":
 				return { agents: snapshotAcpAgents() };
+			case "_omp/agents/messages": {
+				const sessionFile = resolveAcpAgentTranscript({
+					agentId: params.agentId,
+					sessionFile: params.sessionFile,
+				});
+				if (!sessionFile) {
+					throw new Error("Unknown ACP agent: provide a registered agentId or sessionFile");
+				}
+				const fromByte =
+					typeof params.fromByte === "number" && Number.isFinite(params.fromByte)
+						? Math.max(0, Math.trunc(params.fromByte))
+						: 0;
+				const result = await readRpcSubagentTranscript(sessionFile, fromByte);
+				return {
+					sessionFile: result.sessionFile,
+					fromByte: result.fromByte,
+					nextByte: result.nextByte,
+					reset: result.reset,
+					messages: result.messages,
+				};
+			}
 			case "_omp/sessions/listAll": {
 				const limit = typeof params.limit === "number" ? Math.max(1, Math.min(5000, params.limit as number)) : 1000;
 				const sessions = await SessionManager.listAll();

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -72,7 +72,7 @@ import { SessionManager } from "../../session/session-manager";
 import { executeAcpBuiltinSlashCommand } from "../../slash-commands/acp-builtins";
 import { buildAvailableSlashCommands, toAcpAvailableCommands } from "../../slash-commands/available-commands";
 import { DEFAULT_STT_MODEL_KEY, STT_MODEL_OPTIONS } from "../../stt/models";
-import { refreshAgentDiscovery } from "../../task";
+import { type AgentProgress, refreshAgentDiscovery } from "../../task";
 import { AUTO_THINKING, parseConfiguredThinkingLevel } from "../../thinking";
 import { OTHER_OPTION } from "../../tools/ask";
 import { normalizeLocalScheme } from "../../tools/path-utils";
@@ -199,6 +199,76 @@ function snapshotAcpAgents(): AcpAgentSnapshot[] {
 			const snapshot = toAcpAgentSnapshot(ref);
 			return snapshot ? [snapshot] : [];
 		});
+}
+
+/** Cap for the verbose task/assignment texts on the progress wire. */
+const ACP_AGENT_PROGRESS_TASK_CAP = 400;
+
+/**
+ * Wire shape of one subagent's live progress for the `_omp/agents/progress`
+ * notification. Mirrors the task executor's `AgentProgress` snapshot, which
+ * the session stream already carries on `tool_execution_update` events
+ * (`partialResult.details.progress`), so no extra plumbing is needed.
+ */
+export interface AcpAgentProgress {
+	id: string;
+	index: number;
+	agent: string;
+	status: "pending" | "running" | "completed" | "failed" | "aborted";
+	/** One-line label of the subagent's assignment (bounded). */
+	description?: string;
+	/** Spawned task prompt (bounded). */
+	task?: string;
+	/** Latest model intent (bounded). */
+	lastIntent?: string;
+	currentTool?: string;
+	currentToolArgs?: string;
+	recentOutput: string[];
+	toolCount: number;
+	requests: number;
+	tokens: number;
+	contextTokens?: number;
+	contextWindow?: number;
+	cost: number;
+	durationMs: number;
+	resolvedModel?: string;
+}
+
+function bounded(value: string | undefined, cap: number): string | undefined {
+	if (value === undefined || value === "") return undefined;
+	return value.length > cap ? `${value.slice(0, cap)}…` : value;
+}
+
+function toAcpAgentProgress(progress: AgentProgress): AcpAgentProgress {
+	return {
+		id: progress.id,
+		index: progress.index,
+		agent: progress.agent,
+		status: progress.status,
+		description: bounded(progress.description, 200),
+		task: bounded(progress.task, ACP_AGENT_PROGRESS_TASK_CAP),
+		lastIntent: bounded(progress.lastIntent, 200),
+		currentTool: progress.currentTool,
+		currentToolArgs: progress.currentToolArgs,
+		recentOutput: progress.recentOutput,
+		toolCount: progress.toolCount,
+		requests: progress.requests,
+		tokens: progress.tokens,
+		...(progress.contextTokens !== undefined ? { contextTokens: progress.contextTokens } : {}),
+		...(progress.contextWindow !== undefined ? { contextWindow: progress.contextWindow } : {}),
+		cost: progress.cost,
+		durationMs: progress.durationMs,
+		...(progress.resolvedModel ? { resolvedModel: progress.resolvedModel } : {}),
+	};
+}
+
+/** Pull the task tool's `AgentProgress` snapshots out of a tool result/update payload. */
+function extractSubagentProgress(partialResult: unknown): AgentProgress[] | undefined {
+	if (!partialResult || typeof partialResult !== "object" || Array.isArray(partialResult)) return undefined;
+	const details = (partialResult as { details?: unknown }).details;
+	if (!details || typeof details !== "object" || Array.isArray(details)) return undefined;
+	const progress = (details as { progress?: unknown }).progress;
+	return Array.isArray(progress) ? (progress as AgentProgress[]) : undefined;
 }
 
 type AgentImageContent = {
@@ -1336,6 +1406,22 @@ export class AcpAgent implements Agent {
 		}, ACP_AGENTS_DEBOUNCE_MS);
 	}
 
+	/**
+	 * Fire-and-forget push of one subagent progress snapshot. Never throws on
+	 * a dead or partial connection — same contract as `#scheduleAgentsBroadcast`.
+	 */
+	#pushAgentsProgressNotification(agent: AcpAgentProgress): void {
+		if (this.#connection.signal.aborted) return;
+		let delivery: Promise<void> | undefined;
+		try {
+			delivery = this.#connection.extNotification("_omp/agents/progress", { agent });
+		} catch (error) {
+			logger.warn("Failed to push ACP agents/progress notification", { error });
+			return;
+		}
+		delivery?.catch(error => logger.warn("Failed to push ACP agents/progress notification", { error }));
+	}
+
 	get signal(): AbortSignal {
 		return this.#connection.signal;
 	}
@@ -1601,6 +1687,17 @@ export class AcpAgent implements Agent {
 		}
 		if (event.type === "tool_execution_end") {
 			record.toolArgsById.delete(event.toolCallId);
+		}
+		if (event.type === "tool_execution_update") {
+			// Live subagent work: the task tool's progress snapshots ride the
+			// update payload; mirror them as `_omp/agents/progress` so clients
+			// can render subagent work in real time without polling.
+			const progress = extractSubagentProgress(event.partialResult);
+			if (progress) {
+				for (const entry of progress) {
+					this.#pushAgentsProgressNotification(toAcpAgentProgress(entry));
+				}
+			}
 		}
 		this.#clearLiveAssistantMessageAfterEvent(record, event);
 

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -62,6 +62,7 @@ import type { MCPServerConfig } from "../../mcp/types";
 import { loadAllExtensions } from "../../modes/components/extensions/state-manager";
 import { theme } from "../../modes/theme/theme";
 import { normalizePlanTitle, type PlanApprovalDetails, resolveApprovedPlan } from "../../plan-mode/approved-plan";
+import { type AgentRef, AgentRegistry, type AgentStatus } from "../../registry/agent-registry";
 import type { AgentSession, AgentSessionEvent } from "../../session/agent-session";
 import { BlobStore, resolveImageDataSync } from "../../session/blob-store";
 import { isSilentAbort, SKILL_PROMPT_MESSAGE_TYPE, USER_INTERRUPT_LABEL } from "../../session/messages";
@@ -114,6 +115,91 @@ export const ACP_BOOTSTRAP_RACE_GUARD_MS = 50;
 const ACP_CANCEL_CLEANUP_TIMEOUT_MS = 5_000;
 const ACP_ASYNC_DELIVERY_DRAIN_TIMEOUT_MS = 250;
 const ACP_ASYNC_DELIVERY_DRAIN_MAX_PASSES = 3;
+
+/**
+ * Debounce for pushing `_omp/agents/update` after an AgentRegistry change.
+ * Exported so the ACP test harness can drive it with fake timers.
+ */
+export const ACP_AGENTS_DEBOUNCE_MS = 100;
+
+/**
+ * Wire shape of one agent for the `_omp/agents/*` ACP extension surface.
+ *
+ * Field names mirror the collab wire `AgentSnapshot` where they overlap and
+ * add the registry's work/usage telemetry (`activity`, `metrics`, `resolvedModel`),
+ * so an ACP client can render subagent lifecycle, current work, and spend
+ * without polling internal surfaces.
+ */
+export interface AcpAgentSnapshot {
+	id: string;
+	displayName: string;
+	kind: "main" | "sub";
+	parentId?: string;
+	status: AgentStatus;
+	/** Transcript session file, when the agent has one; null when none is known. */
+	sessionFile: string | null;
+	createdAt: number;
+	lastActivity: number;
+	/** One-line gist of the agent's current work; present only while `running`. */
+	activity?: string;
+	/** Last resolved model id, when recorded. */
+	resolvedModel?: string;
+	/** Persisted usage totals, when the agent has finished at least one turn. */
+	metrics?: {
+		tokens: number;
+		requests: number;
+		tools: number;
+		cost: number;
+		durationMs: number;
+		contextTokens?: number;
+		contextWindow?: number;
+	};
+}
+
+/** Serialize a registry ref into the `_omp/agents/*` wire shape. Advisor refs are observability-only and excluded. */
+function toAcpAgentSnapshot(ref: AgentRef): AcpAgentSnapshot | undefined {
+	if (ref.kind === "advisor") return undefined;
+	const history = ref.history;
+	return {
+		id: ref.id,
+		displayName: ref.displayName,
+		kind: ref.kind,
+		parentId: ref.parentId,
+		status: ref.status,
+		sessionFile: ref.sessionFile,
+		createdAt: ref.createdAt,
+		lastActivity: ref.lastActivity,
+		...(ref.activity ? { activity: ref.activity } : {}),
+		...(history?.resolvedModel ? { resolvedModel: history.resolvedModel } : {}),
+		...(history?.metrics
+			? {
+					metrics: {
+						tokens: history.metrics.tokens,
+						requests: history.metrics.requests,
+						tools: history.metrics.tools,
+						cost: history.metrics.cost,
+						durationMs: history.metrics.durationMs,
+						...(history.metrics.contextTokens !== undefined
+							? { contextTokens: history.metrics.contextTokens }
+							: {}),
+						...(history.metrics.contextWindow !== undefined
+							? { contextWindow: history.metrics.contextWindow }
+							: {}),
+					},
+				}
+			: {}),
+	};
+}
+
+/** Current agent roster (main + subagents, advisors excluded), oldest-first. */
+function snapshotAcpAgents(): AcpAgentSnapshot[] {
+	return AgentRegistry.global()
+		.list()
+		.flatMap(ref => {
+			const snapshot = toAcpAgentSnapshot(ref);
+			return snapshot ? [snapshot] : [];
+		});
+}
 
 type AgentImageContent = {
 	type: "image";
@@ -617,6 +703,8 @@ export class AcpAgent implements Agent {
 	#clientCapabilities: ClientCapabilities | undefined;
 	#cancelCleanupTimeoutMs = ACP_CANCEL_CLEANUP_TIMEOUT_MS;
 	#blobs = new BlobStore(getBlobsDir());
+	#agentsDebounce: Timer | undefined;
+	#registryUnsubscribe: (() => void) | undefined;
 
 	constructor(connection: AgentSideConnection, createSession: CreateAcpSession, initialSession?: AgentSession) {
 		this.#connection = connection;
@@ -631,6 +719,14 @@ export class AcpAgent implements Agent {
 	async initialize(params: InitializeRequest): Promise<InitializeResponse> {
 		this.#registerConnectionCleanup();
 		this.#clientCapabilities = params.clientCapabilities;
+		// Live-track subagent activity: mirror the registry into `_omp/agents/update`
+		// notifications once the client has processed `initialize` (in-order JSON-RPC
+		// guarantees the initial push lands after the response). The subscription is
+		// released in `dispose()`.
+		if (!this.#registryUnsubscribe) {
+			this.#registryUnsubscribe = AgentRegistry.global().onChange(() => this.#scheduleAgentsBroadcast());
+			this.#scheduleAgentsBroadcast();
+		}
 		const authMethods: AuthMethod[] = [
 			{
 				id: "agent",
@@ -1125,6 +1221,8 @@ export class AcpAgent implements Agent {
 		switch (method) {
 			case SPEECH_MODELS_LIST_METHOD:
 				return buildAcpSpeechModelsCatalog();
+			case "_omp/agents/list":
+				return { agents: snapshotAcpAgents() };
 			case "_omp/sessions/listAll": {
 				const limit = typeof params.limit === "number" ? Math.max(1, Math.min(5000, params.limit as number)) : 1000;
 				const sessions = await SessionManager.listAll();
@@ -1202,6 +1300,32 @@ export class AcpAgent implements Agent {
 	}
 
 	async extNotification(_method: string, _params: { [key: string]: unknown }): Promise<void> {}
+
+	/**
+	 * Debounced push of the agent roster as an `_omp/agents/update` notification.
+	 * Mirrors the collab host's broadcast: any registry change (spawn, status,
+	 * usage metadata, removal) schedules one full snapshot so ACP clients can
+	 * live-track subagent lifecycle without polling.
+	 */
+	#scheduleAgentsBroadcast(): void {
+		if (this.#agentsDebounce) return;
+		this.#agentsDebounce = setTimeout(() => {
+			this.#agentsDebounce = undefined;
+			// Fire-and-forget: never let a dead or partial connection turn the
+			// registry mirror into an unhandled timer error.
+			if (this.#connection.signal.aborted) return;
+			let delivery: Promise<void> | undefined;
+			try {
+				delivery = this.#connection.extNotification("_omp/agents/update", {
+					agents: snapshotAcpAgents(),
+				});
+			} catch (error) {
+				logger.warn("Failed to push ACP agents/update notification", { error });
+				return;
+			}
+			delivery?.catch(error => logger.warn("Failed to push ACP agents/update notification", { error }));
+		}, ACP_AGENTS_DEBOUNCE_MS);
+	}
 
 	get signal(): AbortSignal {
 		return this.#connection.signal;
@@ -2775,6 +2899,12 @@ export class AcpAgent implements Agent {
 		}
 
 		this.#disposePromise = (async () => {
+			this.#registryUnsubscribe?.();
+			this.#registryUnsubscribe = undefined;
+			if (this.#agentsDebounce !== undefined) {
+				clearTimeout(this.#agentsDebounce);
+				this.#agentsDebounce = undefined;
+			}
 			const records = Array.from(this.#sessions.entries());
 			this.#sessions.clear();
 			await Promise.all(

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -73,7 +73,14 @@ import { SessionManager } from "../../session/session-manager";
 import { executeAcpBuiltinSlashCommand } from "../../slash-commands/acp-builtins";
 import { buildAvailableSlashCommands, toAcpAvailableCommands } from "../../slash-commands/available-commands";
 import { DEFAULT_STT_MODEL_KEY, STT_MODEL_OPTIONS } from "../../stt/models";
-import { type AgentProgress, refreshAgentDiscovery } from "../../task";
+import {
+	type AgentProgress,
+	refreshAgentDiscovery,
+	type SubagentLifecyclePayload,
+	type SubagentProgressPayload,
+	TASK_SUBAGENT_LIFECYCLE_CHANNEL,
+	TASK_SUBAGENT_PROGRESS_CHANNEL,
+} from "../../task";
 import { AUTO_THINKING, parseConfiguredThinkingLevel } from "../../thinking";
 import { OTHER_OPTION } from "../../tools/ask";
 import { normalizeLocalScheme } from "../../tools/path-utils";
@@ -84,6 +91,7 @@ import {
 	TTS_LOCAL_MODELS,
 	TTS_LOCAL_VOICE_OPTIONS,
 } from "../../tts/models";
+import type { EventBus } from "../../utils/event-bus";
 import { canonicalizeMessage } from "../../utils/thinking-display";
 import { createAcpClientBridge } from "./acp-client-bridge";
 import {
@@ -205,11 +213,14 @@ function snapshotAcpAgents(): AcpAgentSnapshot[] {
 /** Cap for the verbose task/assignment texts on the progress wire. */
 const ACP_AGENT_PROGRESS_TASK_CAP = 400;
 
+/** Per-request byte ceiling for `_omp/agents/messages` transcript windows. */
+export const ACP_AGENTS_MESSAGES_MAX_BYTES = 512 * 1024;
+
 /**
  * Wire shape of one subagent's live progress for the `_omp/agents/progress`
- * notification. Mirrors the task executor's `AgentProgress` snapshot, which
- * the session stream already carries on `tool_execution_update` events
- * (`partialResult.details.progress`), so no extra plumbing is needed.
+ * notification. Mirrors the task executor's `AgentProgress` snapshots and
+ * lifecycle transitions delivered over the session's task event channels,
+ * so background spawns stream live work and reach an explicit terminal state.
  */
 export interface AcpAgentProgress {
 	id: string;
@@ -263,13 +274,31 @@ function toAcpAgentProgress(progress: AgentProgress): AcpAgentProgress {
 	};
 }
 
-/** Pull the task tool's `AgentProgress` snapshots out of a tool result/update payload. */
-function extractSubagentProgress(partialResult: unknown): AgentProgress[] | undefined {
-	if (!partialResult || typeof partialResult !== "object" || Array.isArray(partialResult)) return undefined;
-	const details = (partialResult as { details?: unknown }).details;
-	if (!details || typeof details !== "object" || Array.isArray(details)) return undefined;
-	const progress = (details as { progress?: unknown }).progress;
-	return Array.isArray(progress) ? (progress as AgentProgress[]) : undefined;
+/**
+ * Fold a subagent lifecycle transition into the last mirrored progress frame.
+ * Terminal transitions keep clients failure-blind even when the final progress
+ * frame raced ahead of the lifecycle event or was never emitted.
+ */
+function applyLifecycleToProgress(
+	existing: AcpAgentProgress | undefined,
+	payload: SubagentLifecyclePayload,
+): AcpAgentProgress {
+	const status = payload.status === "started" ? "running" : payload.status;
+	if (!existing) {
+		return {
+			id: payload.id,
+			index: payload.index,
+			agent: payload.agent,
+			status,
+			recentOutput: [],
+			toolCount: 0,
+			requests: 0,
+			tokens: 0,
+			cost: 0,
+			durationMs: 0,
+		};
+	}
+	return { ...existing, index: payload.index, agent: payload.agent, status };
 }
 
 /**
@@ -281,11 +310,12 @@ function resolveAcpAgentTranscript(params: { agentId?: unknown; sessionFile?: un
 	if (typeof params.sessionFile === "string") {
 		const registered = AgentRegistry.global()
 			.list()
-			.some(ref => ref.sessionFile === params.sessionFile);
+			.some(ref => ref.kind !== "advisor" && ref.sessionFile === params.sessionFile);
 		if (registered) return params.sessionFile;
 	}
 	if (typeof params.agentId === "string") {
-		return AgentRegistry.global().get(params.agentId)?.sessionFile ?? undefined;
+		const ref = AgentRegistry.global().get(params.agentId);
+		return ref !== undefined && ref.kind !== "advisor" ? (ref.sessionFile ?? undefined) : undefined;
 	}
 	return undefined;
 }
@@ -364,6 +394,8 @@ type ManagedSessionRecord = {
 	// Installed inside `#scheduleBootstrapUpdates` (post-race-guard); released
 	// in `#disposeSessionRecord`. Lives independent of any prompt turn.
 	lifetimeUnsubscribe: (() => void) | undefined;
+	// `_omp/agents/progress` channel subscriptions; released in `#disposeSessionRecord`.
+	progressUnsubscribers: Array<() => void>;
 	closedError: PromptLifecycleError | undefined;
 	promptEventHandlers: Set<Promise<void>>;
 	extensionUserMessageTasks: Set<Promise<void>>;
@@ -405,6 +437,7 @@ type MCPSourceMap = {
 type AcpSessionHandle = {
 	session: AgentSession;
 	setToolUIContext: (uiContext: ExtensionUIContext, hasUI: boolean) => void;
+	eventBus?: EventBus;
 };
 
 type CreateAcpSession = (
@@ -415,8 +448,9 @@ type CreateAcpSession = (
 function normalizeCreatedAcpSession(created: AgentSession | AcpSessionHandle): {
 	session: AgentSession;
 	setToolUIContext: AcpSessionHandle["setToolUIContext"] | undefined;
+	eventBus?: EventBus;
 } {
-	return "session" in created ? created : { session: created, setToolUIContext: undefined };
+	return "session" in created ? created : { session: created, setToolUIContext: undefined, eventBus: undefined };
 }
 
 type AcpSpeechOption = {
@@ -819,9 +853,10 @@ export class AcpAgent implements Agent {
 		this.#clientCapabilities = params.clientCapabilities;
 		// Live-track subagent activity: mirror the registry into `_omp/agents/update`
 		// notifications once the client has processed `initialize` (in-order JSON-RPC
-		// guarantees the initial push lands after the response). The subscription is
-		// released in `dispose()`.
-		if (!this.#registryUnsubscribe) {
+		// guarantees the initial push lands after the response). Opt-in only: a
+		// client that does not declare `extensions.agents` receives no unsolicited
+		// traffic. The subscription is released in `dispose()`.
+		if (!this.#registryUnsubscribe && this.#clientCapabilities?.extensions?.agents === true) {
 			this.#registryUnsubscribe = AgentRegistry.global().onChange(() => this.#scheduleAgentsBroadcast());
 			this.#scheduleAgentsBroadcast();
 		}
@@ -1320,6 +1355,7 @@ export class AcpAgent implements Agent {
 			case SPEECH_MODELS_LIST_METHOD:
 				return buildAcpSpeechModelsCatalog();
 			case "_omp/agents/list":
+				this.#requireAgentsSurface();
 				return { agents: snapshotAcpAgents() };
 			case "_omp/agents/messages": {
 				const sessionFile = resolveAcpAgentTranscript({
@@ -1333,7 +1369,9 @@ export class AcpAgent implements Agent {
 					typeof params.fromByte === "number" && Number.isFinite(params.fromByte)
 						? Math.max(0, Math.trunc(params.fromByte))
 						: 0;
-				const result = await readRpcSubagentTranscript(sessionFile, fromByte);
+				const result = await readRpcSubagentTranscript(sessionFile, fromByte, {
+					maxBytes: ACP_AGENTS_MESSAGES_MAX_BYTES,
+				});
 				return {
 					sessionFile: result.sessionFile,
 					fromByte: result.fromByte,
@@ -1420,6 +1458,14 @@ export class AcpAgent implements Agent {
 
 	async extNotification(_method: string, _params: { [key: string]: unknown }): Promise<void> {}
 
+	/** Rejects `_omp/agents/*` requests from connections that never declared the capability. */
+	#requireAgentsSurface(): void {
+		if (this.#clientCapabilities?.extensions?.agents !== true) {
+			throw RequestError.methodNotFound(
+				"_omp/agents surface not enabled: declare clientCapabilities.extensions.agents",
+			);
+		}
+	}
 	/**
 	 * Debounced push of the agent roster as an `_omp/agents/update` notification.
 	 * Mirrors the collab host's broadcast: any registry change (spawn, status,
@@ -1462,6 +1508,35 @@ export class AcpAgent implements Agent {
 		delivery?.catch(error => logger.warn("Failed to push ACP agents/progress notification", { error }));
 	}
 
+	/**
+	 * Subscribe a record's task-event channels so executor-side subagent work
+	 * streams to the client as `_omp/agents/progress`. Driven by channels —
+	 * not `tool_execution_update` payloads — because background spawns settle
+	 * their task tool call before any subagent frame arrives, and terminal
+	 * completed/failed states must survive that suppression.
+	 */
+	#subscribeRecordToTaskChannels(record: ManagedSessionRecord, eventBus: EventBus): void {
+		const lastByAgentId = new Map<string, AcpAgentProgress>();
+		record.progressUnsubscribers.push(
+			eventBus.on(TASK_SUBAGENT_PROGRESS_CHANNEL, data => {
+				const payload = data as SubagentProgressPayload;
+				const agent = toAcpAgentProgress(payload.progress);
+				lastByAgentId.set(agent.id, agent);
+				if (lastByAgentId.size > 256) {
+					const oldest = lastByAgentId.keys().next().value;
+					if (oldest !== undefined) lastByAgentId.delete(oldest);
+				}
+				this.#pushAgentsProgressNotification(agent);
+			}),
+			eventBus.on(TASK_SUBAGENT_LIFECYCLE_CHANNEL, data => {
+				const payload = data as SubagentLifecyclePayload;
+				const merged = applyLifecycleToProgress(lastByAgentId.get(payload.id), payload);
+				lastByAgentId.set(merged.id, merged);
+				if (payload.status !== "started") this.#pushAgentsProgressNotification(merged);
+			}),
+		);
+	}
+
 	get signal(): AbortSignal {
 		return this.#connection.signal;
 	}
@@ -1485,7 +1560,7 @@ export class AcpAgent implements Agent {
 	}
 
 	async #createNewSessionRecord(cwd: string, mcpServers: McpServer[]): Promise<ManagedSessionRecord> {
-		const { session, setToolUIContext } = normalizeCreatedAcpSession(
+		const { session, setToolUIContext, eventBus } = normalizeCreatedAcpSession(
 			await this.#createSession(path.resolve(cwd), {
 				interactivePrompts: this.#clientCapabilities?.elicitation?.form != null,
 			}),
@@ -1496,7 +1571,7 @@ export class AcpAgent implements Agent {
 			await this.#disposeStandaloneSession(session);
 			throw error;
 		}
-		return await this.#registerPreparedSession(session, mcpServers, setToolUIContext);
+		return await this.#registerPreparedSession(session, mcpServers, setToolUIContext, eventBus);
 	}
 
 	async #loadManagedSession(sessionId: string, cwd: string, mcpServers: McpServer[]): Promise<ManagedSessionRecord> {
@@ -1531,7 +1606,7 @@ export class AcpAgent implements Agent {
 
 	async #forkManagedSession(params: ForkSessionRequest): Promise<ManagedSessionRecord> {
 		const sourcePath = await this.#resolveForkSourceSessionPath(params.sessionId);
-		const { session, setToolUIContext } = normalizeCreatedAcpSession(
+		const { session, setToolUIContext, eventBus } = normalizeCreatedAcpSession(
 			await this.#createSession(path.resolve(params.cwd), {
 				interactivePrompts: this.#clientCapabilities?.elicitation?.form != null,
 			}),
@@ -1549,7 +1624,7 @@ export class AcpAgent implements Agent {
 			await this.#disposeStandaloneSession(session);
 			throw error;
 		}
-		return await this.#registerPreparedSession(session, params.mcpServers ?? [], setToolUIContext);
+		return await this.#registerPreparedSession(session, params.mcpServers ?? [], setToolUIContext, eventBus);
 	}
 
 	async #openStoredSession(
@@ -1558,7 +1633,7 @@ export class AcpAgent implements Agent {
 		mcpServers: McpServer[],
 		sessionId: string,
 	): Promise<ManagedSessionRecord> {
-		const { session, setToolUIContext } = normalizeCreatedAcpSession(
+		const { session, setToolUIContext, eventBus } = normalizeCreatedAcpSession(
 			await this.#createSession(path.resolve(cwd), {
 				interactivePrompts: this.#clientCapabilities?.elicitation?.form != null,
 			}),
@@ -1572,18 +1647,24 @@ export class AcpAgent implements Agent {
 			await this.#disposeStandaloneSession(session);
 			throw error;
 		}
-		return await this.#registerPreparedSession(session, mcpServers, setToolUIContext);
+		return await this.#registerPreparedSession(session, mcpServers, setToolUIContext, eventBus);
 	}
 
 	async #registerPreparedSession(
 		session: AgentSession,
 		mcpServers: McpServer[],
 		setToolUIContext: ((uiContext: ExtensionUIContext, hasUI: boolean) => void) | undefined,
+		eventBus?: EventBus,
 	): Promise<ManagedSessionRecord> {
 		const record = this.#createManagedSessionRecord(session, setToolUIContext);
 		session.setClientBridge(createAcpClientBridge(this.#connection, session.sessionId, this.#clientCapabilities));
-		// `record.lifetimeUnsubscribe` is installed in `#scheduleBootstrapUpdates`
-		// so it shares the bootstrap race guard — see that comment for why.
+		if (eventBus !== undefined && this.#clientCapabilities?.extensions?.agents === true) {
+			this.#subscribeRecordToTaskChannels(record, eventBus);
+		}
+		// `_omp/agents/*` is opt-in (`extensions.agents`); when declared, channel
+		// subscriptions stream executor-side subagent work without touching prompt
+		// routing. `record.lifetimeUnsubscribe` itself installs later in
+		// `#scheduleBootstrapUpdates`, sharing the bootstrap race guard.
 		try {
 			await this.#configureExtensions(record);
 			await this.#configureMcpServers(record, mcpServers);
@@ -1615,6 +1696,7 @@ export class AcpAgent implements Agent {
 			promptEventHandlers: new Set(),
 			extensionUserMessageTasks: new Set(),
 			lifetimeUnsubscribe: undefined,
+			progressUnsubscribers: [],
 		};
 	}
 
@@ -1727,17 +1809,6 @@ export class AcpAgent implements Agent {
 		}
 		if (event.type === "tool_execution_end") {
 			record.toolArgsById.delete(event.toolCallId);
-		}
-		if (event.type === "tool_execution_update") {
-			// Live subagent work: the task tool's progress snapshots ride the
-			// update payload; mirror them as `_omp/agents/progress` so clients
-			// can render subagent work in real time without polling.
-			const progress = extractSubagentProgress(event.partialResult);
-			if (progress) {
-				for (const entry of progress) {
-					this.#pushAgentsProgressNotification(toAcpAgentProgress(entry));
-				}
-			}
 		}
 		this.#clearLiveAssistantMessageAfterEvent(record, event);
 
@@ -3026,6 +3097,7 @@ export class AcpAgent implements Agent {
 
 	async #disposeSessionRecord(record: ManagedSessionRecord, reason?: postmortem.Reason): Promise<void> {
 		record.lifetimeUnsubscribe?.();
+		for (const unsubscribe of record.progressUnsubscribers.splice(0)) unsubscribe();
 		if (record.mcpManager) {
 			try {
 				await record.mcpManager.disconnectAll();

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -847,6 +847,14 @@ export class AcpAgent implements Agent {
 	#blobs = new BlobStore(getBlobsDir());
 	#agentsDebounce: Timer | undefined;
 	#registryUnsubscribe: (() => void) | undefined;
+	/**
+	 * Continuation cursors for `_omp/agents/messages` are only valid against the
+	 * transcript they were produced from. Keyed by caller identity (agentId, or
+	 * the resolved sessionFile for path-keyed polls); when a load/resume/fork
+	 * repoints an agent, the next poll with a stale offset restarts at zero with
+	 * `reset: true` instead of tearing into mid-record bytes.
+	 */
+	#messagesCursorBindings = new Map<string, { sessionFile: string }>();
 
 	constructor(connection: AgentSideConnection, createSession: CreateAcpSession, initialSession?: AgentSession) {
 		this.#connection = connection;
@@ -1380,14 +1388,18 @@ export class AcpAgent implements Agent {
 					typeof params.fromByte === "number" && Number.isFinite(params.fromByte)
 						? Math.max(0, Math.trunc(params.fromByte))
 						: 0;
-				const result = await readRpcSubagentTranscript(sessionFile, fromByte, {
+				const cursorKey = typeof params.agentId === "string" ? `id:${params.agentId}` : `file:${sessionFile}`;
+				const binding = this.#messagesCursorBindings.get(cursorKey);
+				const switched = binding !== undefined && binding.sessionFile !== sessionFile && fromByte > 0;
+				const result = await readRpcSubagentTranscript(sessionFile, switched ? 0 : fromByte, {
 					maxBytes: ACP_AGENTS_MESSAGES_MAX_BYTES,
 				});
+				this.#rememberMessagesCursor(cursorKey, sessionFile);
 				return {
 					sessionFile: result.sessionFile,
 					fromByte: result.fromByte,
 					nextByte: result.nextByte,
-					reset: result.reset,
+					reset: switched || result.reset,
 					messages: result.messages,
 					...(result.pendingOversizedRecord ? { pendingOversizedRecord: true } : {}),
 				};
@@ -1492,6 +1504,7 @@ export class AcpAgent implements Agent {
 			// registry mirror into an unhandled timer error.
 			if (this.#connection.signal.aborted) return;
 			let delivery: Promise<void> | undefined;
+
 			try {
 				delivery = this.#connection.extNotification("_omp/agents/update", {
 					agents: snapshotAcpAgents(),
@@ -1518,6 +1531,17 @@ export class AcpAgent implements Agent {
 			return;
 		}
 		delivery?.catch(error => logger.warn("Failed to push ACP agents/progress notification", { error }));
+	}
+
+	/** Track the transcript a continuation cursor is bound to; pruned oldest-first. */
+	#rememberMessagesCursor(key: string, sessionFile: string): void {
+		this.#messagesCursorBindings.delete(key);
+		this.#messagesCursorBindings.set(key, { sessionFile });
+		while (this.#messagesCursorBindings.size > 256) {
+			const oldest = this.#messagesCursorBindings.keys().next();
+			if (oldest.done) break;
+			this.#messagesCursorBindings.delete(oldest.value);
+		}
 	}
 
 	/**

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -1544,6 +1544,13 @@ export class AcpAgent implements Agent {
 		}
 	}
 
+	/** Roster push for transcript repoints that bypass the registry (extension-style switches). */
+	#scheduleTranscriptRosterRefresh(): void {
+		if (this.#clientCapabilities?.extensions?.agents === true) {
+			this.#scheduleAgentsBroadcast();
+		}
+	}
+
 	/**
 	 * Subscribe a record's task-event channels so executor-side subagent work
 	 * streams to the client as `_omp/agents/progress`. Driven by channels —
@@ -1660,7 +1667,9 @@ export class AcpAgent implements Agent {
 			await this.#disposeStandaloneSession(session);
 			throw error;
 		}
-		return await this.#registerPreparedSession(session, params.mcpServers ?? [], setToolUIContext, eventBus);
+		const record = await this.#registerPreparedSession(session, params.mcpServers ?? [], setToolUIContext, eventBus);
+		this.#scheduleTranscriptRosterRefresh();
+		return record;
 	}
 
 	async #openStoredSession(
@@ -1683,7 +1692,9 @@ export class AcpAgent implements Agent {
 			await this.#disposeStandaloneSession(session);
 			throw error;
 		}
-		return await this.#registerPreparedSession(session, mcpServers, setToolUIContext, eventBus);
+		const record = await this.#registerPreparedSession(session, mcpServers, setToolUIContext, eventBus);
+		this.#scheduleTranscriptRosterRefresh();
+		return record;
 	}
 
 	async #registerPreparedSession(
@@ -2984,6 +2995,9 @@ export class AcpAgent implements Agent {
 					if (success && options?.setup) {
 						await options.setup(record.session.sessionManager);
 					}
+					// In-place transcript switch: no registry event fires, so the
+					// roster push must be scheduled explicitly.
+					if (success) this.#scheduleTranscriptRosterRefresh();
 					return { cancelled: !success };
 				},
 				branch: async entryId => {
@@ -2996,6 +3010,7 @@ export class AcpAgent implements Agent {
 				},
 				switchSession: async sessionPath => {
 					const success = await record.session.switchSession(sessionPath);
+					if (success) this.#scheduleTranscriptRosterRefresh();
 					return { cancelled: !success };
 				},
 				reload: async () => {

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -165,6 +165,16 @@ export interface AcpAgentSnapshot {
 	};
 }
 
+/**
+ * Live transcript path for a registry ref. The static `sessionFile` captured
+ * at registration goes stale after `session/load`, `session/resume`, or fork
+ * switches the underlying SessionManager, so the wire prefers the live
+ * session's current file and falls back only for parked/aborted refs.
+ */
+function resolveRefSessionFile(ref: AgentRef): string | null {
+	return ref.session?.sessionManager.getSessionFile() ?? ref.sessionFile;
+}
+
 /** Serialize a registry ref into the `_omp/agents/*` wire shape. Advisor refs are observability-only and excluded. */
 function toAcpAgentSnapshot(ref: AgentRef): AcpAgentSnapshot | undefined {
 	if (ref.kind === "advisor") return undefined;
@@ -175,7 +185,7 @@ function toAcpAgentSnapshot(ref: AgentRef): AcpAgentSnapshot | undefined {
 		kind: ref.kind,
 		parentId: ref.parentId,
 		status: ref.status,
-		sessionFile: ref.sessionFile,
+		sessionFile: resolveRefSessionFile(ref),
 		createdAt: ref.createdAt,
 		lastActivity: ref.lastActivity,
 		...(ref.activity ? { activity: ref.activity } : {}),
@@ -310,12 +320,12 @@ function resolveAcpAgentTranscript(params: { agentId?: unknown; sessionFile?: un
 	if (typeof params.sessionFile === "string") {
 		const registered = AgentRegistry.global()
 			.list()
-			.some(ref => ref.kind !== "advisor" && ref.sessionFile === params.sessionFile);
+			.some(ref => ref.kind !== "advisor" && resolveRefSessionFile(ref) === params.sessionFile);
 		if (registered) return params.sessionFile;
 	}
 	if (typeof params.agentId === "string") {
 		const ref = AgentRegistry.global().get(params.agentId);
-		return ref !== undefined && ref.kind !== "advisor" ? (ref.sessionFile ?? undefined) : undefined;
+		return ref !== undefined && ref.kind !== "advisor" ? (resolveRefSessionFile(ref) ?? undefined) : undefined;
 	}
 	return undefined;
 }
@@ -1379,6 +1389,7 @@ export class AcpAgent implements Agent {
 					nextByte: result.nextByte,
 					reset: result.reset,
 					messages: result.messages,
+					...(result.pendingOversizedRecord ? { pendingOversizedRecord: true } : {}),
 				};
 			}
 			case "_omp/sessions/listAll": {

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -3002,6 +3002,9 @@ export class AcpAgent implements Agent {
 				},
 				branch: async entryId => {
 					const result = await record.session.branch(entryId);
+					// branch() creates a new transcript file in place — same
+					// roster-staleness hazard as switchSession.
+					if (!result.cancelled) this.#scheduleTranscriptRosterRefresh();
 					return { cancelled: result.cancelled };
 				},
 				navigateTree: async (targetId, options) => {

--- a/packages/coding-agent/src/modes/acp/acp-event-mapper.ts
+++ b/packages/coding-agent/src/modes/acp/acp-event-mapper.ts
@@ -238,6 +238,7 @@ export function mapAgentSessionEventToAcpSessionUpdates(
 			const update: SessionUpdate = {
 				sessionUpdate: "tool_call_update",
 				toolCallId: event.toolCallId,
+				toolName: event.toolName,
 				status: "in_progress",
 				rawOutput: event.partialResult,
 			};
@@ -261,6 +262,7 @@ export function mapAgentSessionEventToAcpSessionUpdates(
 			const update: SessionUpdate = {
 				sessionUpdate: "tool_call_update",
 				toolCallId: event.toolCallId,
+				toolName: event.toolName,
 				status: event.isError ? "failed" : "completed",
 				rawOutput: event.result,
 			};
@@ -487,6 +489,7 @@ export function buildToolCallStartUpdate(input: {
 		sessionUpdate: "tool_call",
 		toolCallId: input.toolCallId,
 		title: buildToolTitle(input.toolName, input.args, input.intent),
+		toolName: input.toolName,
 		kind: mapToolKind(input.toolName, input.args),
 		status: input.status ?? "pending",
 		rawInput: input.args,

--- a/packages/coding-agent/src/modes/acp/acp-mode.ts
+++ b/packages/coding-agent/src/modes/acp/acp-mode.ts
@@ -3,12 +3,15 @@ import { postmortem } from "@oh-my-pi/pi-utils";
 import { AgentSideConnection, ndJsonStream, type Stream } from "@oh-my-pi/pi-utils/acp";
 import type { ExtensionUIContext } from "../../extensibility/extensions/types";
 import type { AgentSession } from "../../session/agent-session";
+import type { EventBus } from "../../utils/event-bus";
 import { AcpAgent } from "./acp-agent";
 
 /** Session and deferred tool UI hook created for an ACP client workspace. */
 export interface AcpSessionHandle {
 	session: AgentSession;
 	setToolUIContext: (uiContext: ExtensionUIContext, hasUI: boolean) => void;
+	/** Session-owned task/extension bus consumed by the `_omp/agents/progress` mirror; absent for embedders that pre-create sessions themselves. */
+	eventBus?: EventBus;
 }
 
 /**

--- a/packages/coding-agent/src/modes/rpc/rpc-subagents.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-subagents.ts
@@ -65,7 +65,20 @@ function addPruned(set: Set<string>, value: string, maxSize: number): void {
 	}
 }
 
-export async function readRpcSubagentTranscript(sessionFile: string, fromByte = 0): Promise<RpcSubagentMessagesResult> {
+export interface RpcSubagentTranscriptReadOptions {
+	/**
+	 * Upper bound on transcript bytes consumed per call, starting at `fromByte`.
+	 * When set, the window is clamped to complete lines and full UTF-8 code
+	 * points, so continuation reads at `nextByte` never lose data.
+	 */
+	maxBytes?: number;
+}
+
+export async function readRpcSubagentTranscript(
+	sessionFile: string,
+	fromByte = 0,
+	options?: RpcSubagentTranscriptReadOptions,
+): Promise<RpcSubagentMessagesResult> {
 	let startByte = Number.isFinite(fromByte) ? Math.max(0, Math.trunc(fromByte)) : 0;
 	const file = Bun.file(sessionFile);
 	let size: number;
@@ -87,12 +100,30 @@ export async function readRpcSubagentTranscript(sessionFile: string, fromByte = 
 		startByte = 0;
 		reset = true;
 	}
-
-	const text = startByte >= size ? "" : await file.slice(startByte).text();
-	const lastNewline = text.lastIndexOf("\n");
-	const completeText = lastNewline >= 0 ? text.slice(0, lastNewline + 1) : "";
-	const entries = completeText.length > 0 ? parseSessionEntries(completeText) : [];
-	const nextByte = startByte + Buffer.byteLength(completeText, "utf8");
+	const maxBytes =
+		options?.maxBytes !== undefined && Number.isFinite(options.maxBytes)
+			? Math.max(0, Math.trunc(options.maxBytes))
+			: undefined;
+	const endByte = maxBytes !== undefined ? Math.min(size, startByte + maxBytes) : size;
+	const bytes =
+		startByte < endByte ? new Uint8Array(await file.slice(startByte, endByte).arrayBuffer()) : new Uint8Array(0);
+	let end = bytes.length;
+	if (end > 0 && bytes[end - 1]! >= 0x80) {
+		// Clamp a capped window to whole code points: walk back over continuation
+		// bytes; if their lead byte cannot be fully contained, drop the cluster.
+		let i = end - 1;
+		const floor = Math.max(0, end - 4);
+		while (i > floor && bytes[i]! >= 0x80 && bytes[i]! < 0xc0) i--;
+		const lead = bytes[i]!;
+		const width = lead >= 0xf0 ? 4 : lead >= 0xe0 ? 3 : lead >= 0xc0 ? 2 : 1;
+		const containsLead = lead >= 0xc0 && lead < 0xf5;
+		if (containsLead && end - i < width) end = i;
+	}
+	const newlineIdx = bytes.lastIndexOf(0x0a, end - 1);
+	const consumed = newlineIdx >= 0 ? newlineIdx + 1 : 0;
+	const text = consumed > 0 ? new TextDecoder().decode(bytes.subarray(0, consumed)) : "";
+	const entries = text.length > 0 ? parseSessionEntries(text) : [];
+	const nextByte = startByte + consumed;
 
 	return {
 		sessionFile,

--- a/packages/coding-agent/src/modes/rpc/rpc-subagents.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-subagents.ts
@@ -65,13 +65,34 @@ function addPruned(set: Set<string>, value: string, maxSize: number): void {
 	}
 }
 
+/** Hard cap on how far a capped read may span past its budget to find a record's terminating newline. */
+export const RPC_SUBAGENT_TRANSCRIPT_MAX_RECORD_BYTES = 8 * 1024 * 1024;
+
+/** Clamp a window to whole UTF-8 code points: back over continuation bytes; drop a lead byte whose cluster is cut. */
+function clampWindowToUtf8Boundary(bytes: Uint8Array): number {
+	const length = bytes.length;
+	if (length === 0 || bytes[length - 1]! < 0x80) return length;
+	let index = length - 1;
+	const floor = Math.max(0, length - 4);
+	while (index > floor && bytes[index]! >= 0x80 && bytes[index]! < 0xc0) index--;
+	const lead = bytes[index]!;
+	const width = lead >= 0xf0 ? 4 : lead >= 0xe0 ? 3 : lead >= 0xc0 ? 2 : 1;
+	return lead >= 0xc0 && lead < 0xf5 && length - index < width ? index : length;
+}
+
 export interface RpcSubagentTranscriptReadOptions {
 	/**
 	 * Upper bound on transcript bytes consumed per call, starting at `fromByte`.
-	 * When set, the window is clamped to complete lines and full UTF-8 code
-	 * points, so continuation reads at `nextByte` never lose data.
+	 * The window is clamped to complete lines and full UTF-8 code points, so
+	 * continuation reads at `nextByte` never lose data.
 	 */
 	maxBytes?: number;
+	/**
+	 * How far past `maxBytes` a read may reach to swallow one record whose
+	 * terminating newline lies beyond the budget. Defaults to
+	 * {@link RPC_SUBAGENT_TRANSCRIPT_MAX_RECORD_BYTES}.
+	 */
+	oversizedRecordCeilingBytes?: number;
 }
 
 export async function readRpcSubagentTranscript(
@@ -104,23 +125,36 @@ export async function readRpcSubagentTranscript(
 		options?.maxBytes !== undefined && Number.isFinite(options.maxBytes)
 			? Math.max(0, Math.trunc(options.maxBytes))
 			: undefined;
-	const endByte = maxBytes !== undefined ? Math.min(size, startByte + maxBytes) : size;
-	const bytes =
-		startByte < endByte ? new Uint8Array(await file.slice(startByte, endByte).arrayBuffer()) : new Uint8Array(0);
-	let end = bytes.length;
-	if (end > 0 && bytes[end - 1]! >= 0x80) {
-		// Clamp a capped window to whole code points: walk back over continuation
-		// bytes; if their lead byte cannot be fully contained, drop the cluster.
-		let i = end - 1;
-		const floor = Math.max(0, end - 4);
-		while (i > floor && bytes[i]! >= 0x80 && bytes[i]! < 0xc0) i--;
-		const lead = bytes[i]!;
-		const width = lead >= 0xf0 ? 4 : lead >= 0xe0 ? 3 : lead >= 0xc0 ? 2 : 1;
-		const containsLead = lead >= 0xc0 && lead < 0xf5;
-		if (containsLead && end - i < width) end = i;
+	const oversizedCeilingBytes =
+		options?.oversizedRecordCeilingBytes !== undefined &&
+		Number.isFinite(options.oversizedRecordCeilingBytes) &&
+		options.oversizedRecordCeilingBytes > 0
+			? Math.trunc(options.oversizedRecordCeilingBytes)
+			: RPC_SUBAGENT_TRANSCRIPT_MAX_RECORD_BYTES;
+
+	// A capped window can land mid-record (no newline yet). Grow the window
+	// toward the ceiling so one record larger than maxBytes still ships whole;
+	// past the ceiling there is nothing sane left to do but report it.
+	let endByte = maxBytes !== undefined ? Math.min(size, startByte + maxBytes) : size;
+	let bytes = new Uint8Array(0);
+	let ceilingReached = false;
+	for (;;) {
+		bytes = startByte < endByte ? new Uint8Array(await file.slice(startByte, endByte).arrayBuffer()) : new Uint8Array(0);
+		if (bytes.length === 0 || endByte >= size) break;
+		const hasCompleteLine = bytes.lastIndexOf(0x0a, clampWindowToUtf8Boundary(bytes) - 1) >= 0;
+		if (hasCompleteLine) break;
+		const span = endByte - startByte;
+		if (span >= oversizedCeilingBytes) {
+			ceilingReached = true;
+			break;
+		}
+		endByte = Math.min(size, startByte + span * 2);
 	}
-	const newlineIdx = bytes.lastIndexOf(0x0a, end - 1);
+
+	const windowEnd = clampWindowToUtf8Boundary(bytes);
+	const newlineIdx = bytes.lastIndexOf(0x0a, windowEnd - 1);
 	const consumed = newlineIdx >= 0 ? newlineIdx + 1 : 0;
+	const pendingOversizedRecord = consumed === 0 && ceilingReached;
 	const text = consumed > 0 ? new TextDecoder().decode(bytes.subarray(0, consumed)) : "";
 	const entries = text.length > 0 ? parseSessionEntries(text) : [];
 	const nextByte = startByte + consumed;
@@ -132,6 +166,7 @@ export async function readRpcSubagentTranscript(
 		reset,
 		entries,
 		messages: entries.filter(isSessionMessageEntry).map(entry => entry.message),
+		...(pendingOversizedRecord ? { pendingOversizedRecord } : {}),
 	};
 }
 

--- a/packages/coding-agent/src/modes/rpc/rpc-subagents.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-subagents.ts
@@ -155,20 +155,8 @@ export async function readRpcSubagentTranscript(
 	const windowEnd = clampWindowToUtf8Boundary(bytes);
 	const newlineIdx = bytes.lastIndexOf(0x0a, windowEnd - 1);
 	const consumed = newlineIdx >= 0 ? newlineIdx + 1 : 0;
-	let pendingOversizedRecord = consumed === 0 && ceilingReached;
+	const pendingOversizedRecord = consumed === 0 && ceilingReached;
 
-	// Same-response lookahead: when this window ended on a complete line and
-	// the NEXT record alone cannot fit inside the ceiling, warn now instead of
-	// letting the client poll once more into an unchanged cursor.
-	if (!pendingOversizedRecord && maxBytes !== undefined && consumed > 0) {
-		const peekStart = startByte + consumed;
-		const peekEnd = Math.min(size, peekStart + oversizedCeilingBytes);
-		if (peekEnd - peekStart >= oversizedCeilingBytes) {
-			const peek = new Uint8Array(await file.slice(peekStart, peekEnd).arrayBuffer());
-			const peekHasNewline = peek.lastIndexOf(0x0a, clampWindowToUtf8Boundary(peek) - 1) >= 0;
-			pendingOversizedRecord = !peekHasNewline;
-		}
-	}
 	const nextByte = startByte + consumed;
 	const text = consumed > 0 ? new TextDecoder().decode(bytes.subarray(0, consumed)) : "";
 	const entries = text.length > 0 ? parseSessionEntries(text) : [];

--- a/packages/coding-agent/src/modes/rpc/rpc-subagents.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-subagents.ts
@@ -139,7 +139,8 @@ export async function readRpcSubagentTranscript(
 	let bytes = new Uint8Array(0);
 	let ceilingReached = false;
 	for (;;) {
-		bytes = startByte < endByte ? new Uint8Array(await file.slice(startByte, endByte).arrayBuffer()) : new Uint8Array(0);
+		bytes =
+			startByte < endByte ? new Uint8Array(await file.slice(startByte, endByte).arrayBuffer()) : new Uint8Array(0);
 		if (bytes.length === 0 || endByte >= size) break;
 		const hasCompleteLine = bytes.lastIndexOf(0x0a, clampWindowToUtf8Boundary(bytes) - 1) >= 0;
 		if (hasCompleteLine) break;
@@ -154,10 +155,23 @@ export async function readRpcSubagentTranscript(
 	const windowEnd = clampWindowToUtf8Boundary(bytes);
 	const newlineIdx = bytes.lastIndexOf(0x0a, windowEnd - 1);
 	const consumed = newlineIdx >= 0 ? newlineIdx + 1 : 0;
-	const pendingOversizedRecord = consumed === 0 && ceilingReached;
+	let pendingOversizedRecord = consumed === 0 && ceilingReached;
+
+	// Same-response lookahead: when this window ended on a complete line and
+	// the NEXT record alone cannot fit inside the ceiling, warn now instead of
+	// letting the client poll once more into an unchanged cursor.
+	if (!pendingOversizedRecord && maxBytes !== undefined && consumed > 0) {
+		const peekStart = startByte + consumed;
+		const peekEnd = Math.min(size, peekStart + oversizedCeilingBytes);
+		if (peekEnd - peekStart >= oversizedCeilingBytes) {
+			const peek = new Uint8Array(await file.slice(peekStart, peekEnd).arrayBuffer());
+			const peekHasNewline = peek.lastIndexOf(0x0a, clampWindowToUtf8Boundary(peek) - 1) >= 0;
+			pendingOversizedRecord = !peekHasNewline;
+		}
+	}
+	const nextByte = startByte + consumed;
 	const text = consumed > 0 ? new TextDecoder().decode(bytes.subarray(0, consumed)) : "";
 	const entries = text.length > 0 ? parseSessionEntries(text) : [];
-	const nextByte = startByte + consumed;
 
 	return {
 		sessionFile,

--- a/packages/coding-agent/src/modes/rpc/rpc-subagents.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-subagents.ts
@@ -84,8 +84,9 @@ export interface RpcSubagentTranscriptReadOptions {
 	/**
 	 * Upper bound on transcript bytes consumed per call, starting at `fromByte`.
 	 * The window is clamped to complete lines and full UTF-8 code points, so
-	 * continuation reads at `nextByte` never lose data. Values below 1 normalize
-	 * to an empty page (cursor unchanged); non-finite values disable the cap.
+	 * continuation reads at `nextByte` never lose data. Values below 1 are
+	 * floored to a single byte so every finite budget makes forward progress;
+	 * non-finite values disable the cap.
 	 */
 	maxBytes?: number;
 	/**
@@ -124,7 +125,7 @@ export async function readRpcSubagentTranscript(
 	}
 	const maxBytes =
 		options?.maxBytes !== undefined && Number.isFinite(options.maxBytes)
-			? Math.max(0, Math.trunc(options.maxBytes))
+			? Math.max(1, Math.trunc(options.maxBytes))
 			: undefined;
 	const oversizedCeilingBytes =
 		options?.oversizedRecordCeilingBytes !== undefined &&

--- a/packages/coding-agent/src/modes/rpc/rpc-subagents.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-subagents.ts
@@ -84,7 +84,8 @@ export interface RpcSubagentTranscriptReadOptions {
 	/**
 	 * Upper bound on transcript bytes consumed per call, starting at `fromByte`.
 	 * The window is clamped to complete lines and full UTF-8 code points, so
-	 * continuation reads at `nextByte` never lose data.
+	 * continuation reads at `nextByte` never lose data. Values below 1 normalize
+	 * to an empty page (cursor unchanged); non-finite values disable the cap.
 	 */
 	maxBytes?: number;
 	/**

--- a/packages/coding-agent/src/modes/rpc/rpc-types.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-types.ts
@@ -186,6 +186,12 @@ export interface RpcSubagentMessagesResult {
 	reset: boolean;
 	entries: FileEntry[];
 	messages: AgentMessage[];
+	/**
+	 * Set (only by capped reads) when the JSONL record starting at `fromByte`
+	 * exceeds the caller's byte ceiling, so no complete line could be consumed.
+	 * `nextByte` is unchanged; the record must be skipped or fetched differently.
+	 */
+	pendingOversizedRecord?: boolean;
 }
 
 // ============================================================================

--- a/packages/coding-agent/test/acp-agent.test.ts
+++ b/packages/coding-agent/test/acp-agent.test.ts
@@ -12,6 +12,7 @@ import {
 	ACP_AGENTS_DEBOUNCE_MS,
 	ACP_BOOTSTRAP_RACE_GUARD_MS,
 	AcpAgent,
+	type AcpAgentProgress,
 	type AcpAgentSnapshot,
 	createAcpExtensionUiContext,
 } from "@oh-my-pi/pi-coding-agent/modes/acp/acp-agent";
@@ -25,7 +26,7 @@ import type {
 import { SILENT_ABORT_MARKER } from "@oh-my-pi/pi-coding-agent/session/messages";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import { DEFAULT_STT_MODEL_KEY, STT_MODEL_OPTIONS } from "@oh-my-pi/pi-coding-agent/stt/models";
-import { TaskTool } from "@oh-my-pi/pi-coding-agent/task";
+import { type AgentProgress, TaskTool } from "@oh-my-pi/pi-coding-agent/task";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
 import {
 	DEFAULT_TTS_LOCAL_MODEL_KEY,
@@ -445,7 +446,10 @@ interface AgentHarness {
 	agent: AcpAgent;
 	updates: SessionNotification[];
 	/** Captured `_omp/*` notifications pushed to the client; `params` is the wire shape the ACP surface emits. */
-	extNotifications: Array<{ method: string; params: { agents: AcpAgentSnapshot[] } }>;
+	extNotifications: Array<{
+		method: string;
+		params: { agents?: AcpAgentSnapshot[]; agent?: AcpAgentProgress };
+	}>;
 	abortController: AbortController;
 	sessions: FakeAgentSession[];
 	setToolUIContextSpies: SetToolUIContextSpy[];
@@ -508,7 +512,10 @@ async function createHarness(
 	await Settings.init({ agentDir, inMemory: true });
 
 	const updates: SessionNotification[] = [];
-	const extNotifications: Array<{ method: string; params: { agents: AcpAgentSnapshot[] } }> = [];
+	const extNotifications: Array<{
+		method: string;
+		params: { agents?: AcpAgentSnapshot[]; agent?: AcpAgentProgress };
+	}> = [];
 	const abortController = new AbortController();
 	const sessions: FakeAgentSession[] = [];
 	const setToolUIContextSpies: SetToolUIContextSpy[] = [];
@@ -521,9 +528,9 @@ async function createHarness(
 			updates.push(notification);
 		},
 		extNotification: async (method: string, params: Record<string, unknown>) => {
-			// The surface under test pushes exactly `{ agents: AcpAgentSnapshot[] }`.
-			const snapshot = params as { agents: AcpAgentSnapshot[] };
-			extNotifications.push({ method, params: snapshot });
+			// The surfaces under test push `{ agents }` (roster) or `{ agent }` (progress).
+			const wire = params as { agents?: AcpAgentSnapshot[]; agent?: AcpAgentProgress };
+			extNotifications.push({ method, params: wire });
 		},
 		unstable_createElicitation: options.elicitationHandler
 			? async (req: CreateElicitationRequest) => options.elicitationHandler!(req)
@@ -1175,8 +1182,7 @@ describe("ACP agent", () => {
 		await Promise.resolve();
 		const initial = harness.extNotifications.find(notification => notification.method === "_omp/agents/update");
 		expect(initial).toBeDefined();
-		expect(initial!.params.agents).toEqual([]);
-
+		expect(initial!.params.agents!).toEqual([]);
 		// A spawned subagent lands in the next debounced snapshot.
 		const registry = AgentRegistry.global();
 		const sub = registry.register({
@@ -1193,7 +1199,7 @@ describe("ACP agent", () => {
 		const spawned = harness.extNotifications.filter(notification => notification.method === "_omp/agents/update");
 		const last = spawned.at(-1)!;
 		expect(last.params.agents).toHaveLength(1);
-		expect(last.params.agents[0]).toMatchObject({
+		expect(last.params.agents![0]).toMatchObject({
 			id: "SubA",
 			status: "running",
 			activity: "auditing auth middleware",
@@ -1204,9 +1210,9 @@ describe("ACP agent", () => {
 		vi.advanceTimersByTime(ACP_AGENTS_DEBOUNCE_MS);
 		await Promise.resolve();
 		const idle = harness.extNotifications.at(-1)!;
-		expect(idle.params.agents[0]).toMatchObject({ id: "SubA", status: "idle" });
+		expect(idle.params.agents![0]).toMatchObject({ id: "SubA", status: "idle" });
 		// `activity` is cleared when the agent leaves `running`.
-		expect(idle.params.agents[0]?.activity).toBeUndefined();
+		expect(idle.params.agents![0]?.activity).toBeUndefined();
 
 		// dispose() stops the subscription: later registry changes stay silent.
 		await harness.agent.dispose();
@@ -1928,6 +1934,104 @@ describe("ACP agent", () => {
 		const completedIdx = statuses.indexOf("completed");
 		expect(statuses.slice(completedIdx)).toEqual(["completed"]);
 		expectAcpNotifications(harness.updates);
+
+		harness.abortController.abort();
+		await Bun.sleep(0);
+	});
+
+	it("streams live subagent work via _omp/agents/progress and tags tool calls with toolName", async () => {
+		const harness = await createHarness();
+		const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });
+		const session = harness.findSession(created.sessionId)!;
+
+		session.prompt = async (text: string): Promise<boolean> => {
+			session.promptCalls.push(text);
+			session.isStreaming = true;
+			for (const listener of session.listeners()) {
+				listener({
+					type: "tool_execution_update",
+					toolCallId: "task_1",
+					toolName: "task",
+					args: { task: "analyze" },
+					partialResult: {
+						content: [],
+						details: {
+							progress: [
+								{
+									index: 0,
+									id: "ReadA",
+									agent: "task",
+									agentSource: "bundled",
+									status: "running",
+									task: "Read the file a.ts using the read tool. ".repeat(30),
+									lastIntent: "reading a.ts with the read tool",
+									currentTool: "read",
+									currentToolArgs: "a.ts",
+									recentOutput: ["export const a = 1"],
+									recentTools: [],
+									toolCount: 2,
+									requests: 1,
+									tokens: 120,
+									cost: 0.001,
+									durationMs: 5000,
+									resolvedModel: "opencode-go/deepseek-v4-flash",
+								} satisfies AgentProgress,
+							],
+						},
+					},
+				} as AgentSessionEvent);
+				listener({
+					type: "tool_execution_end",
+					toolCallId: "task_1",
+					toolName: "task",
+					isError: false,
+					result: { content: [{ type: "text", text: "done" }], details: {} },
+				} as AgentSessionEvent);
+				listener({ type: "agent_end", messages: [] } as AgentSessionEvent);
+			}
+			session.isStreaming = false;
+			return true;
+		};
+
+		await harness.agent.prompt({
+			sessionId: created.sessionId,
+			messageId: "00000000-0000-4000-8000-000000000050",
+			prompt: [{ type: "text", text: "spawn a task" }],
+		} as PromptRequest);
+
+		const progress = harness.extNotifications.filter(
+			notification => notification.method === "_omp/agents/progress",
+		);
+		expect(progress).toHaveLength(1);
+		expect(progress[0]!.params.agent).toMatchObject({
+			id: "ReadA",
+			index: 0,
+			agent: "task",
+			status: "running",
+			lastIntent: "reading a.ts with the read tool",
+			currentTool: "read",
+			currentToolArgs: "a.ts",
+			recentOutput: ["export const a = 1"],
+			toolCount: 2,
+			tokens: 120,
+			cost: 0.001,
+			durationMs: 5000,
+			resolvedModel: "opencode-go/deepseek-v4-flash",
+		});
+		// Long assignment text is bounded on the wire.
+		expect(progress[0]!.params.agent!.task!.length).toBeLessThan(600);
+
+		// Tool calls now carry the harness tool name so clients can classify
+		// the task tool beyond the spec `kind` ("other").
+		const toolUpdates = harness.updates
+			.filter(update => update.sessionId === created.sessionId)
+			.map(update => update.update)
+			.filter(
+				(update): update is Extract<typeof update, { sessionUpdate: "tool_call" | "tool_call_update" }> =>
+					update.sessionUpdate === "tool_call" || update.sessionUpdate === "tool_call_update",
+			);
+		expect(toolUpdates.length).toBeGreaterThanOrEqual(2);
+		expect(toolUpdates.every(update => update.toolName === "task")).toBe(true);
 
 		harness.abortController.abort();
 		await Bun.sleep(0);

--- a/packages/coding-agent/test/acp-agent.test.ts
+++ b/packages/coding-agent/test/acp-agent.test.ts
@@ -1863,6 +1863,76 @@ describe("ACP agent", () => {
 		await Bun.sleep(0);
 	});
 
+	it("suppresses late in_progress updates for tool calls that already ended", async () => {
+		const harness = await createHarness();
+		const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });
+		const session = harness.findSession(created.sessionId)!;
+
+		session.prompt = async (text: string): Promise<boolean> => {
+			session.promptCalls.push(text);
+			session.isStreaming = true;
+			for (const listener of session.listeners()) {
+				listener({
+					type: "tool_execution_start",
+					toolCallId: "task_1",
+					toolName: "task",
+					args: { task: "analyze" },
+					intent: "analyze in parallel",
+				} as AgentSessionEvent);
+				listener({
+					type: "tool_execution_update",
+					toolCallId: "task_1",
+					toolName: "task",
+					args: { task: "analyze" },
+					partialResult: "running",
+				} as AgentSessionEvent);
+				listener({
+					type: "tool_execution_end",
+					toolCallId: "task_1",
+					toolName: "task",
+					isError: false,
+					result: { content: [{ type: "text", text: "done" }], details: {} },
+				} as AgentSessionEvent);
+				// Async job progress fired after the loop finalized the call:
+				// must NOT reopen the terminal status on the wire.
+				listener({
+					type: "tool_execution_update",
+					toolCallId: "task_1",
+					toolName: "task",
+					args: { task: "analyze" },
+					partialResult: "late progress",
+				} as AgentSessionEvent);
+				listener({ type: "agent_end", messages: [] } as AgentSessionEvent);
+			}
+			session.isStreaming = false;
+			return true;
+		};
+
+		await harness.agent.prompt({
+			sessionId: created.sessionId,
+			messageId: "00000000-0000-4000-8000-000000000049",
+			prompt: [{ type: "text", text: "spawn a task" }],
+		} as PromptRequest);
+
+		const statuses = harness.updates
+			.filter(update => update.sessionId === created.sessionId)
+			.map(update => update.update)
+			.filter(
+				(update): update is Extract<typeof update, { sessionUpdate: "tool_call_update" }> =>
+					update.sessionUpdate === "tool_call_update" && "toolCallId" in update,
+			)
+			.filter(update => update.toolCallId === "task_1")
+			.map(update => update.status);
+		// pending/in_progress -> completed, and no update after the terminal one.
+		expect(statuses).toContain("completed");
+		const completedIdx = statuses.indexOf("completed");
+		expect(statuses.slice(completedIdx)).toEqual(["completed"]);
+		expectAcpNotifications(harness.updates);
+
+		harness.abortController.abort();
+		await Bun.sleep(0);
+	});
+
 	it("refreshes task agent descriptions on ACP /reload-plugins", async () => {
 		const harness = await createHarness();
 		const agentDir = path.join(harness.cwdA, ".omp", "agents");

--- a/packages/coding-agent/test/acp-agent.test.ts
+++ b/packages/coding-agent/test/acp-agent.test.ts
@@ -540,11 +540,14 @@ async function createHarness(
 			if (options.sessionUpdateHook) await options.sessionUpdateHook(notification);
 			updates.push(notification);
 		},
-		extNotification: async (method: string, params: Record<string, unknown>) => {
-			if (options.extNotification !== undefined) throw new Error("client transport gone");
-			// The surfaces under test push `{ agents }` (roster) or `{ agent }` (progress).
-			const wire = params as { agents?: AcpAgentSnapshot[]; agent?: AcpAgentProgress };
-			extNotifications.push({ method, params: wire });
+		extNotification: (method: string, params: Record<string, unknown>) => {
+			if (options.extNotification === "sync-throw") throw new Error("client transport gone");
+			return (async () => {
+				if (options.extNotification === "async-reject") throw new Error("client transport gone");
+				// The surfaces under test push `{ agents }` (roster) or `{ agent }` (progress).
+				const wire = params as { agents?: AcpAgentSnapshot[]; agent?: AcpAgentProgress };
+				extNotifications.push({ method, params: wire });
+			})();
 		},
 		unstable_createElicitation: options.elicitationHandler
 			? async (req: CreateElicitationRequest) => options.elicitationHandler!(req)
@@ -2163,6 +2166,9 @@ describe("ACP agent", () => {
 
 		// Requests are rejected with a method-not-found error naming the capability.
 		await expect(harness.agent.extMethod("_omp/agents/list", {})).rejects.toThrow("extensions.agents");
+		await expect(harness.agent.extMethod("_omp/agents/messages", { agentId: "Main" })).rejects.toThrow(
+			"extensions.agents",
+		);
 		const rejection = await harness.agent.extMethod("_omp/agents/list", {}).catch((error: unknown) => error);
 		expect(rejection).toBeInstanceOf(RequestError);
 

--- a/packages/coding-agent/test/acp-agent.test.ts
+++ b/packages/coding-agent/test/acp-agent.test.ts
@@ -9,11 +9,14 @@ import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config
 import type { ExtensionUIContext } from "@oh-my-pi/pi-coding-agent/extensibility/extensions";
 import { resolveLocalUrlToPath } from "@oh-my-pi/pi-coding-agent/internal-urls";
 import {
+	ACP_AGENTS_DEBOUNCE_MS,
 	ACP_BOOTSTRAP_RACE_GUARD_MS,
 	AcpAgent,
+	type AcpAgentSnapshot,
 	createAcpExtensionUiContext,
 } from "@oh-my-pi/pi-coding-agent/modes/acp/acp-agent";
 import type { PlanModeState } from "@oh-my-pi/pi-coding-agent/plan-mode/state";
+import { AgentRegistry } from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
 import type {
 	AgentSession,
 	AgentSessionEvent,
@@ -441,6 +444,8 @@ type SetToolUIContextSpy = (uiContext: ExtensionUIContext, hasUI: boolean) => vo
 interface AgentHarness {
 	agent: AcpAgent;
 	updates: SessionNotification[];
+	/** Captured `_omp/*` notifications pushed to the client; `params` is the wire shape the ACP surface emits. */
+	extNotifications: Array<{ method: string; params: { agents: AcpAgentSnapshot[] } }>;
 	abortController: AbortController;
 	sessions: FakeAgentSession[];
 	setToolUIContextSpies: SetToolUIContextSpy[];
@@ -474,6 +479,9 @@ afterEach(async () => {
 		delete process.env.PI_CODING_AGENT_DIR;
 	}
 	resetSettingsForTest();
+	// Registry refs registered by the `_omp/agents/*` tests must not leak into
+	// later tests (the AcpAgent subscription is released via `dispose()`).
+	AgentRegistry.resetGlobalForTests();
 
 	for (const root of cleanupRoots.splice(0)) {
 		await fs.promises.rm(root, { recursive: true, force: true });
@@ -500,6 +508,7 @@ async function createHarness(
 	await Settings.init({ agentDir, inMemory: true });
 
 	const updates: SessionNotification[] = [];
+	const extNotifications: Array<{ method: string; params: { agents: AcpAgentSnapshot[] } }> = [];
 	const abortController = new AbortController();
 	const sessions: FakeAgentSession[] = [];
 	const setToolUIContextSpies: SetToolUIContextSpy[] = [];
@@ -510,6 +519,11 @@ async function createHarness(
 			// microtask before the push and perturb ordering-sensitive tests.
 			if (options.sessionUpdateHook) await options.sessionUpdateHook(notification);
 			updates.push(notification);
+		},
+		extNotification: async (method: string, params: Record<string, unknown>) => {
+			// The surface under test pushes exactly `{ agents: AcpAgentSnapshot[] }`.
+			const snapshot = params as { agents: AcpAgentSnapshot[] };
+			extNotifications.push({ method, params: snapshot });
 		},
 		unstable_createElicitation: options.elicitationHandler
 			? async (req: CreateElicitationRequest) => options.elicitationHandler!(req)
@@ -542,6 +556,7 @@ async function createHarness(
 	return {
 		agent,
 		updates,
+		extNotifications,
 		abortController,
 		sessions,
 		setToolUIContextSpies,
@@ -1078,6 +1093,137 @@ describe("ACP agent", () => {
 			"Unknown ACP ext method",
 		);
 
+		harness.abortController.abort();
+		await Bun.sleep(0);
+	});
+
+	it("returns the agent roster with subagent telemetry from _omp/agents/list", async () => {
+		const harness = await createHarness();
+		const registry = AgentRegistry.global();
+		const sub = registry.register({
+			id: "SubA",
+			displayName: "SubA",
+			kind: "sub",
+			parentId: "Main",
+			session: null,
+			sessionFile: "/tmp/sub-a.jsonl",
+			status: "running",
+		});
+		registry.setActivity(sub.id, "grepping call sites of resolve()");
+		registry.setHistory(sub.id, {
+			resolvedModel: "claude-sonnet-4-20250514",
+			metrics: { tokens: 900, requests: 2, tools: 5, cost: 0.01, durationMs: 12_000 },
+		});
+		// Advisor transcripts are observability-only and must not leak onto the wire.
+		registry.register({
+			id: "Advisor1",
+			displayName: "Advisor1",
+			kind: "advisor",
+			session: null,
+			status: "idle",
+		});
+		registry.register({
+			id: "Main",
+			displayName: "Main",
+			kind: "main",
+			session: null,
+			status: "idle",
+		});
+
+		const result = (await harness.agent.extMethod("_omp/agents/list", {})) as { agents: AcpAgentSnapshot[] };
+
+		expect(result.agents).toHaveLength(2);
+		const main = result.agents.find(agent => agent.id === "Main");
+		expect(main).toMatchObject({ id: "Main", kind: "main", status: "idle" });
+		const subSnapshot = result.agents.find(agent => agent.id === "SubA");
+		expect(subSnapshot).toMatchObject({
+			id: "SubA",
+			displayName: "SubA",
+			kind: "sub",
+			parentId: "Main",
+			status: "running",
+			sessionFile: "/tmp/sub-a.jsonl",
+			activity: "grepping call sites of resolve()",
+			resolvedModel: "claude-sonnet-4-20250514",
+		});
+		expect(subSnapshot?.metrics).toEqual({
+			tokens: 900,
+			requests: 2,
+			tools: 5,
+			cost: 0.01,
+			durationMs: 12_000,
+		});
+		expect(result.agents.find(agent => agent.id === "Advisor1")).toBeUndefined();
+
+		await harness.agent.dispose();
+		harness.abortController.abort();
+		await Bun.sleep(0);
+	});
+
+	it("pushes debounced _omp/agents/update notifications on registry changes", async () => {
+		const harness = await createHarness();
+
+		// Fake timers before `initialize` so the debounced roster push is clock-driven.
+		vi.useFakeTimers();
+		await harness.agent.initialize({
+			protocolVersion: 1,
+			clientCapabilities: {},
+		} as Parameters<typeof harness.agent.initialize>[0]);
+
+		// `initialize` schedules an initial roster push once the client is ready.
+		vi.advanceTimersByTime(ACP_AGENTS_DEBOUNCE_MS);
+		await Promise.resolve();
+		const initial = harness.extNotifications.find(notification => notification.method === "_omp/agents/update");
+		expect(initial).toBeDefined();
+		expect(initial!.params.agents).toEqual([]);
+
+		// A spawned subagent lands in the next debounced snapshot.
+		const registry = AgentRegistry.global();
+		const sub = registry.register({
+			id: "SubA",
+			displayName: "SubA",
+			kind: "sub",
+			parentId: "Main",
+			session: null,
+			status: "running",
+		});
+		registry.setActivity(sub.id, "auditing auth middleware");
+		vi.advanceTimersByTime(ACP_AGENTS_DEBOUNCE_MS);
+		await Promise.resolve();
+		const spawned = harness.extNotifications.filter(notification => notification.method === "_omp/agents/update");
+		const last = spawned.at(-1)!;
+		expect(last.params.agents).toHaveLength(1);
+		expect(last.params.agents[0]).toMatchObject({
+			id: "SubA",
+			status: "running",
+			activity: "auditing auth middleware",
+		});
+
+		// Lifecycle transitions push again, so clients can track subagent completion.
+		registry.setStatus(sub.id, "idle", sub);
+		vi.advanceTimersByTime(ACP_AGENTS_DEBOUNCE_MS);
+		await Promise.resolve();
+		const idle = harness.extNotifications.at(-1)!;
+		expect(idle.params.agents[0]).toMatchObject({ id: "SubA", status: "idle" });
+		// `activity` is cleared when the agent leaves `running`.
+		expect(idle.params.agents[0]?.activity).toBeUndefined();
+
+		// dispose() stops the subscription: later registry changes stay silent.
+		await harness.agent.dispose();
+		const countBefore = harness.extNotifications.length;
+		registry.register({
+			id: "SubB",
+			displayName: "SubB",
+			kind: "sub",
+			parentId: "Main",
+			session: null,
+			status: "running",
+		});
+		vi.advanceTimersByTime(ACP_AGENTS_DEBOUNCE_MS);
+		await Promise.resolve();
+		expect(harness.extNotifications.length).toBe(countBefore);
+
+		vi.useRealTimers();
 		harness.abortController.abort();
 		await Bun.sleep(0);
 	});

--- a/packages/coding-agent/test/acp-agent.test.ts
+++ b/packages/coding-agent/test/acp-agent.test.ts
@@ -1999,9 +1999,7 @@ describe("ACP agent", () => {
 			prompt: [{ type: "text", text: "spawn a task" }],
 		} as PromptRequest);
 
-		const progress = harness.extNotifications.filter(
-			notification => notification.method === "_omp/agents/progress",
-		);
+		const progress = harness.extNotifications.filter(notification => notification.method === "_omp/agents/progress");
 		expect(progress).toHaveLength(1);
 		expect(progress[0]!.params.agent).toMatchObject({
 			id: "ReadA",
@@ -2105,9 +2103,9 @@ describe("ACP agent", () => {
 		const byFile = await harness.agent.extMethod("_omp/agents/messages", { sessionFile: transcript });
 		expect((byFile.messages as unknown[]).length).toBe(2);
 		// …but arbitrary paths and unknown ids are rejected.
-		await expect(
-			harness.agent.extMethod("_omp/agents/messages", { agentId: "Nobody" }),
-		).rejects.toThrow("Unknown ACP agent");
+		await expect(harness.agent.extMethod("_omp/agents/messages", { agentId: "Nobody" })).rejects.toThrow(
+			"Unknown ACP agent",
+		);
 		await expect(
 			harness.agent.extMethod("_omp/agents/messages", { sessionFile: "C:/Windows/win.ini" }),
 		).rejects.toThrow("Unknown ACP agent");

--- a/packages/coding-agent/test/acp-agent.test.ts
+++ b/packages/coding-agent/test/acp-agent.test.ts
@@ -26,7 +26,14 @@ import type {
 import { SILENT_ABORT_MARKER } from "@oh-my-pi/pi-coding-agent/session/messages";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import { DEFAULT_STT_MODEL_KEY, STT_MODEL_OPTIONS } from "@oh-my-pi/pi-coding-agent/stt/models";
-import { type AgentProgress, TaskTool } from "@oh-my-pi/pi-coding-agent/task";
+import {
+	type AgentProgress,
+	type SubagentLifecyclePayload,
+	type SubagentProgressPayload,
+	TASK_SUBAGENT_LIFECYCLE_CHANNEL,
+	TASK_SUBAGENT_PROGRESS_CHANNEL,
+	TaskTool,
+} from "@oh-my-pi/pi-coding-agent/task";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
 import {
 	DEFAULT_TTS_LOCAL_MODEL_KEY,
@@ -34,6 +41,7 @@ import {
 	TTS_LOCAL_MODELS,
 	TTS_LOCAL_VOICE_OPTIONS,
 } from "@oh-my-pi/pi-coding-agent/tts/models";
+import { EventBus } from "@oh-my-pi/pi-coding-agent/utils/event-bus";
 import { getConfigRootDir, setAgentDir } from "@oh-my-pi/pi-utils";
 import type {
 	AgentSideConnection,
@@ -457,6 +465,8 @@ interface AgentHarness {
 	cwdA: string;
 	cwdB: string;
 	findSession(sessionId: string): FakeAgentSession | undefined;
+	/** Task-event bus carried by the factory handle for an ACP-created session. */
+	busForSession(sessionId: string): EventBus;
 }
 
 function getChunkMessageId(notification: SessionNotification): string | undefined {
@@ -496,6 +506,8 @@ async function createHarness(
 	options: {
 		elicitationHandler?: (req: CreateElicitationRequest) => Promise<CreateElicitationResponse>;
 		clientCapabilities?: ClientCapabilities;
+		/** Forces the connection's `extNotification` transport to fail; failures stay logged, never rethrown. */
+		extNotification?: "sync-throw" | "async-reject";
 		/** Runs before a notification is recorded, so a test can delay one delivery. */
 		sessionUpdateHook?: (notification: SessionNotification) => Promise<void> | void;
 	} = {},
@@ -518,6 +530,7 @@ async function createHarness(
 	}> = [];
 	const abortController = new AbortController();
 	const sessions: FakeAgentSession[] = [];
+	const sessionBuses = new Map<string, EventBus>();
 	const setToolUIContextSpies: SetToolUIContextSpy[] = [];
 	const sessionFactoryOptions: Array<{ interactivePrompts?: boolean } | undefined> = [];
 	const connection = {
@@ -528,6 +541,7 @@ async function createHarness(
 			updates.push(notification);
 		},
 		extNotification: async (method: string, params: Record<string, unknown>) => {
+			if (options.extNotification !== undefined) throw new Error("client transport gone");
 			// The surfaces under test push `{ agents }` (roster) or `{ agent }` (progress).
 			const wire = params as { agents?: AcpAgentSnapshot[]; agent?: AcpAgentProgress };
 			extNotifications.push({ method, params: wire });
@@ -543,11 +557,13 @@ async function createHarness(
 	sessions.push(initialSession);
 	const factory = async (cwd: string, factoryOptions?: { interactivePrompts?: boolean }) => {
 		const session = new FakeAgentSession(cwd);
-		const setToolUIContext = vi.fn();
 		sessions.push(session);
+		const setToolUIContext = vi.fn();
+		const eventBus = new EventBus();
+		sessionBuses.set(session.sessionId, eventBus);
 		setToolUIContextSpies.push(setToolUIContext);
 		sessionFactoryOptions.push(factoryOptions);
-		return { session: session as unknown as AgentSession, setToolUIContext };
+		return { session: session as unknown as AgentSession, setToolUIContext, eventBus };
 	};
 
 	const agent = new AcpAgent(connection, factory, initialSession as unknown as AgentSession);
@@ -571,6 +587,11 @@ async function createHarness(
 		cwdA,
 		cwdB,
 		findSession: (sessionId: string) => sessions.find(session => session.sessionId === sessionId),
+		busForSession: sessionId => {
+			const bus = sessionBuses.get(sessionId);
+			if (!bus) throw new Error(`No task event bus for session ${sessionId}`);
+			return bus;
+		},
 	};
 }
 
@@ -1105,7 +1126,7 @@ describe("ACP agent", () => {
 	});
 
 	it("returns the agent roster with subagent telemetry from _omp/agents/list", async () => {
-		const harness = await createHarness();
+		const harness = await createHarness({ clientCapabilities: { extensions: { agents: true } } });
 		const registry = AgentRegistry.global();
 		const sub = registry.register({
 			id: "SubA",
@@ -1174,7 +1195,7 @@ describe("ACP agent", () => {
 		vi.useFakeTimers();
 		await harness.agent.initialize({
 			protocolVersion: 1,
-			clientCapabilities: {},
+			clientCapabilities: { extensions: { agents: true } },
 		} as Parameters<typeof harness.agent.initialize>[0]);
 
 		// `initialize` schedules an initial roster push once the client is ready.
@@ -1940,45 +1961,18 @@ describe("ACP agent", () => {
 	});
 
 	it("streams live subagent work via _omp/agents/progress and tags tool calls with toolName", async () => {
-		const harness = await createHarness();
+		const harness = await createHarness({ clientCapabilities: { extensions: { agents: true } } });
 		const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });
 		const session = harness.findSession(created.sessionId)!;
 
 		session.prompt = async (text: string): Promise<boolean> => {
 			session.promptCalls.push(text);
-			session.isStreaming = true;
 			for (const listener of session.listeners()) {
 				listener({
 					type: "tool_execution_update",
 					toolCallId: "task_1",
 					toolName: "task",
 					args: { task: "analyze" },
-					partialResult: {
-						content: [],
-						details: {
-							progress: [
-								{
-									index: 0,
-									id: "ReadA",
-									agent: "task",
-									agentSource: "bundled",
-									status: "running",
-									task: "Read the file a.ts using the read tool. ".repeat(30),
-									lastIntent: "reading a.ts with the read tool",
-									currentTool: "read",
-									currentToolArgs: "a.ts",
-									recentOutput: ["export const a = 1"],
-									recentTools: [],
-									toolCount: 2,
-									requests: 1,
-									tokens: 120,
-									cost: 0.001,
-									durationMs: 5000,
-									resolvedModel: "opencode-go/deepseek-v4-flash",
-								} satisfies AgentProgress,
-							],
-						},
-					},
 				} as AgentSessionEvent);
 				listener({
 					type: "tool_execution_end",
@@ -1989,7 +1983,6 @@ describe("ACP agent", () => {
 				} as AgentSessionEvent);
 				listener({ type: "agent_end", messages: [] } as AgentSessionEvent);
 			}
-			session.isStreaming = false;
 			return true;
 		};
 
@@ -1999,8 +1992,46 @@ describe("ACP agent", () => {
 			prompt: [{ type: "text", text: "spawn a task" }],
 		} as PromptRequest);
 
+		// Background spawns settle their task tool call before subagent frames
+		// arrive; the channel-driven mirror must surface them regardless.
+		const runningProgress = {
+			index: 0,
+			id: "ReadA",
+			agent: "task",
+			agentSource: "bundled",
+			status: "running",
+			task: "Read the file a.ts using the read tool. ".repeat(30),
+			lastIntent: "reading a.ts with the read tool",
+			currentTool: "read",
+			currentToolArgs: "a.ts",
+			recentOutput: ["export const a = 1"],
+			recentTools: [],
+			toolCount: 2,
+			requests: 1,
+			tokens: 120,
+			cost: 0.001,
+			durationMs: 5000,
+			resolvedModel: "opencode-go/deepseek-v4-flash",
+		} satisfies AgentProgress;
+		harness.busForSession(created.sessionId).emit(TASK_SUBAGENT_PROGRESS_CHANNEL, {
+			index: 0,
+			agent: "task",
+			agentSource: "bundled",
+			parentToolCallId: "task_1",
+			progress: runningProgress,
+			task: "Read the file a.ts using the read tool",
+		} satisfies SubagentProgressPayload);
+		harness.busForSession(created.sessionId).emit(TASK_SUBAGENT_LIFECYCLE_CHANNEL, {
+			id: "ReadA",
+			index: 0,
+			agent: "task",
+			agentSource: "bundled",
+			status: "failed",
+			parentToolCallId: "task_1",
+		} satisfies SubagentLifecyclePayload);
+
 		const progress = harness.extNotifications.filter(notification => notification.method === "_omp/agents/progress");
-		expect(progress).toHaveLength(1);
+		expect(progress).toHaveLength(2);
 		expect(progress[0]!.params.agent).toMatchObject({
 			id: "ReadA",
 			index: 0,
@@ -2018,6 +2049,14 @@ describe("ACP agent", () => {
 		});
 		// Long assignment text is bounded on the wire.
 		expect(progress[0]!.params.agent!.task!.length).toBeLessThan(600);
+		// The terminal lifecycle transition merges into the last known frame so
+		// clients see explicit failure instead of a stuck running state.
+		expect(progress[1]!.params.agent).toMatchObject({
+			id: "ReadA",
+			status: "failed",
+			lastIntent: "reading a.ts with the read tool",
+			tokens: 120,
+		});
 
 		// Tool calls now carry the harness tool name so clients can classify
 		// the task tool beyond the spec `kind` ("other").
@@ -2036,47 +2075,45 @@ describe("ACP agent", () => {
 	});
 
 	it("returns subagent transcripts with thinking via _omp/agents/messages", async () => {
-		const harness = await createHarness();
+		const harness = await createHarness({ clientCapabilities: { extensions: { agents: true } } });
 		const transcript = path.join(harness.cwdA, "SubT.jsonl");
-		await fs.promises.writeFile(
-			transcript,
-			[
-				JSON.stringify({
-					type: "session",
-					id: "s0",
-					parentId: null,
-					timestamp: "2026-08-16T10:00:00.000Z",
-				}),
-				JSON.stringify({
-					type: "session_init",
-					id: "si",
-					parentId: "s0",
-					timestamp: "2026-08-16T10:00:01.000Z",
-					agent: "task",
-					task: "read a.ts",
-				}),
-				JSON.stringify({
-					type: "message",
-					id: "m1",
-					parentId: "si",
-					timestamp: "2026-08-16T10:00:02.000Z",
-					message: { role: "user", content: [{ type: "text", text: "read a.ts" }] },
-				}),
-				JSON.stringify({
-					type: "message",
-					id: "m2",
-					parentId: "m1",
-					timestamp: "2026-08-16T10:00:03.000Z",
-					message: {
-						role: "assistant",
-						content: [
-							{ type: "thinking", thinking: "Let me read the file a.ts." },
-							{ type: "text", text: "export const a = 1;" },
-						],
-					},
-				}),
-			].join("\n") + "\n",
-		);
+		const lines = [
+			JSON.stringify({
+				type: "session",
+				id: "s0",
+				parentId: null,
+				timestamp: "2026-08-16T10:00:00.000Z",
+			}),
+			JSON.stringify({
+				type: "session_init",
+				id: "si",
+				parentId: "s0",
+				timestamp: "2026-08-16T10:00:01.000Z",
+				agent: "task",
+				task: "read a.ts",
+			}),
+			JSON.stringify({
+				type: "message",
+				id: "m1",
+				parentId: "si",
+				timestamp: "2026-08-16T10:00:02.000Z",
+				message: { role: "user", content: [{ type: "text", text: "read a.ts" }] },
+			}),
+			JSON.stringify({
+				type: "message",
+				id: "m2",
+				parentId: "m1",
+				timestamp: "2026-08-16T10:00:03.000Z",
+				message: {
+					role: "assistant",
+					content: [
+						{ type: "thinking", thinking: "Let me read the file a.ts." },
+						{ type: "text", text: "export const a = 1;" },
+					],
+				},
+			}),
+		];
+		await fs.promises.writeFile(transcript, `${lines.join("\n")}\n`);
 		const registry = AgentRegistry.global();
 		registry.register({
 			id: "SubT",
@@ -2097,7 +2134,14 @@ describe("ACP agent", () => {
 		expect(assistant.role).toBe("assistant");
 		expect(assistant.content).toContainEqual({ type: "thinking", thinking: "Let me read the file a.ts." });
 		expect(result.reset).toBe(false);
-		expect(typeof result.nextByte).toBe("number");
+		expect(result.nextByte).toBe(Buffer.byteLength(`${lines.join("\n")}\n`, "utf8"));
+
+		// Polling at `nextByte` once growth stops drains to an empty page.
+		const idle = await harness.agent.extMethod("_omp/agents/messages", {
+			agentId: "SubT",
+			fromByte: result.nextByte,
+		});
+		expect((idle.messages as unknown[]) ?? []).toEqual([]);
 
 		// A registered agent resolves by sessionFile too…
 		const byFile = await harness.agent.extMethod("_omp/agents/messages", { sessionFile: transcript });
@@ -2111,6 +2155,114 @@ describe("ACP agent", () => {
 		).rejects.toThrow("Unknown ACP agent");
 
 		harness.abortController.abort();
+		await Bun.sleep(0);
+	});
+
+	it("withholds the agents surface unless the client declares extensions.agents", async () => {
+		const harness = await createHarness();
+
+		// Requests are rejected with a method-not-found error naming the capability.
+		await expect(harness.agent.extMethod("_omp/agents/list", {})).rejects.toThrow("extensions.agents");
+		const rejection = await harness.agent.extMethod("_omp/agents/list", {}).catch((error: unknown) => error);
+		expect(rejection).toBeInstanceOf(RequestError);
+
+		// Without the capability there is no registry subscription: roster churn
+		// never produces unsolicited `_omp/agents/update` traffic.
+		vi.useFakeTimers();
+		try {
+			AgentRegistry.global().register({
+				id: "SubG",
+				displayName: "SubG",
+				kind: "sub",
+				parentId: "Main",
+				session: null,
+				status: "running",
+			});
+			vi.advanceTimersByTime(ACP_AGENTS_DEBOUNCE_MS);
+			await Promise.resolve();
+			const pushes = harness.extNotifications.filter(notification => notification.method === "_omp/agents/update");
+			expect(pushes).toHaveLength(0);
+		} finally {
+			vi.useRealTimers();
+		}
+
+		harness.abortController.abort();
+		await Bun.sleep(0);
+	});
+
+	it("coalesces spawn and terminal transition into one debounced roster push", async () => {
+		vi.useFakeTimers();
+		try {
+			const harness = await createHarness({ clientCapabilities: { extensions: { agents: true } } });
+			// Drain the initial post-initialize snapshot first.
+			vi.advanceTimersByTime(ACP_AGENTS_DEBOUNCE_MS);
+			await Promise.resolve();
+			const baseline = harness.extNotifications.length;
+
+			// Spawn + settle inside one debounce window collapse into a single
+			// terminal snapshot — clients never see the transient running state.
+			const registry = AgentRegistry.global();
+			const sub = registry.register({
+				id: "SubFast",
+				displayName: "SubFast",
+				kind: "sub",
+				parentId: "Main",
+				session: null,
+				status: "running",
+			});
+			registry.setStatus(sub.id, "idle", sub);
+
+			vi.advanceTimersByTime(ACP_AGENTS_DEBOUNCE_MS);
+			await Promise.resolve();
+			const pushes = harness.extNotifications
+				.slice(baseline)
+				.filter(notification => notification.method === "_omp/agents/update");
+			expect(pushes).toHaveLength(1);
+			expect(pushes[0]!.params.agents![0]).toMatchObject({ id: "SubFast", status: "idle" });
+
+			await harness.agent.dispose();
+			harness.abortController.abort();
+		} finally {
+			vi.useRealTimers();
+		}
+		await Bun.sleep(0);
+	});
+
+	it("keeps serving rosters when the client notification transport fails", async () => {
+		for (const extNotification of ["sync-throw", "async-reject"] as const) {
+			vi.useFakeTimers();
+			try {
+				const harness = await createHarness({
+					clientCapabilities: { extensions: { agents: true } },
+					extNotification,
+				});
+				// Drain the initial snapshot into the failing transport.
+				vi.advanceTimersByTime(ACP_AGENTS_DEBOUNCE_MS);
+				await Promise.resolve();
+				await Promise.resolve();
+
+				AgentRegistry.global().register({
+					id: `SubFail-${extNotification}`,
+					displayName: extNotification,
+					kind: "sub",
+					parentId: "Main",
+					session: null,
+					status: "running",
+				});
+				vi.advanceTimersByTime(ACP_AGENTS_DEBOUNCE_MS);
+				await Promise.resolve();
+				await Promise.resolve();
+
+				// The failure was swallowed (logged), and the surface still serves requests.
+				const roster = (await harness.agent.extMethod("_omp/agents/list", {})) as { agents: AcpAgentSnapshot[] };
+				expect(roster.agents.map(agent => agent.id)).toContain(`SubFail-${extNotification}`);
+
+				await harness.agent.dispose();
+				harness.abortController.abort();
+			} finally {
+				vi.useRealTimers();
+			}
+		}
 		await Bun.sleep(0);
 	});
 

--- a/packages/coding-agent/test/acp-agent.test.ts
+++ b/packages/coding-agent/test/acp-agent.test.ts
@@ -2037,6 +2037,85 @@ describe("ACP agent", () => {
 		await Bun.sleep(0);
 	});
 
+	it("returns subagent transcripts with thinking via _omp/agents/messages", async () => {
+		const harness = await createHarness();
+		const transcript = path.join(harness.cwdA, "SubT.jsonl");
+		await fs.promises.writeFile(
+			transcript,
+			[
+				JSON.stringify({
+					type: "session",
+					id: "s0",
+					parentId: null,
+					timestamp: "2026-08-16T10:00:00.000Z",
+				}),
+				JSON.stringify({
+					type: "session_init",
+					id: "si",
+					parentId: "s0",
+					timestamp: "2026-08-16T10:00:01.000Z",
+					agent: "task",
+					task: "read a.ts",
+				}),
+				JSON.stringify({
+					type: "message",
+					id: "m1",
+					parentId: "si",
+					timestamp: "2026-08-16T10:00:02.000Z",
+					message: { role: "user", content: [{ type: "text", text: "read a.ts" }] },
+				}),
+				JSON.stringify({
+					type: "message",
+					id: "m2",
+					parentId: "m1",
+					timestamp: "2026-08-16T10:00:03.000Z",
+					message: {
+						role: "assistant",
+						content: [
+							{ type: "thinking", thinking: "Let me read the file a.ts." },
+							{ type: "text", text: "export const a = 1;" },
+						],
+					},
+				}),
+			].join("\n") + "\n",
+		);
+		const registry = AgentRegistry.global();
+		registry.register({
+			id: "SubT",
+			displayName: "task",
+			kind: "sub",
+			parentId: "Main",
+			session: null,
+			sessionFile: transcript,
+			status: "idle",
+		});
+
+		const result = (await harness.agent.extMethod("_omp/agents/messages", {
+			agentId: "SubT",
+		})) as { messages: Array<{ role: string; content: unknown[] }>; nextByte: number; reset: boolean };
+
+		expect(result.messages).toHaveLength(2);
+		const assistant = result.messages[1]!;
+		expect(assistant.role).toBe("assistant");
+		expect(assistant.content).toContainEqual({ type: "thinking", thinking: "Let me read the file a.ts." });
+		expect(result.reset).toBe(false);
+		expect(typeof result.nextByte).toBe("number");
+
+		// A registered agent resolves by sessionFile too…
+		const byFile = await harness.agent.extMethod("_omp/agents/messages", { sessionFile: transcript });
+		expect((byFile.messages as unknown[]).length).toBe(2);
+		// …but arbitrary paths and unknown ids are rejected.
+		await expect(
+			harness.agent.extMethod("_omp/agents/messages", { agentId: "Nobody" }),
+		).rejects.toThrow("Unknown ACP agent");
+		await expect(
+			harness.agent.extMethod("_omp/agents/messages", { sessionFile: "C:/Windows/win.ini" }),
+		).rejects.toThrow("Unknown ACP agent");
+
+		harness.abortController.abort();
+		await Bun.sleep(0);
+	});
+
 	it("refreshes task agent descriptions on ACP /reload-plugins", async () => {
 		const harness = await createHarness();
 		const agentDir = path.join(harness.cwdA, ".omp", "agents");

--- a/packages/coding-agent/test/acp-agent.test.ts
+++ b/packages/coding-agent/test/acp-agent.test.ts
@@ -2247,14 +2247,22 @@ describe("ACP agent", () => {
 			status: "running",
 		});
 
-		const result = (await harness.agent.extMethod("_omp/agents/messages", {
+		const first = (await harness.agent.extMethod("_omp/agents/messages", {
 			agentId: "SubHuge",
 		})) as { nextByte: number; pendingOversizedRecord?: boolean };
 
-		// The record dwarfs the 512 KiB budget AND the 8 MiB ceiling: the cursor
-		// must stay put while the explicit flag explains why — never a silent EOF.
-		expect(result.pendingOversizedRecord).toBe(true);
-		expect(result.nextByte).toBe(Buffer.byteLength(headerLine, "utf8"));
+		// Page one streams the header normally — ordinary pages cost nothing extra.
+		expect(first.pendingOversizedRecord).toBeUndefined();
+		expect(first.nextByte).toBe(Buffer.byteLength(headerLine, "utf8"));
+
+		// The poll that REACHES the ceiling-dwarfing record stops advancing and
+		// explains why — never a silent EOF, never an exception.
+		const stalled = (await harness.agent.extMethod("_omp/agents/messages", {
+			agentId: "SubHuge",
+			fromByte: first.nextByte,
+		})) as { nextByte: number; pendingOversizedRecord?: boolean };
+		expect(stalled.pendingOversizedRecord).toBe(true);
+		expect(stalled.nextByte).toBe(first.nextByte);
 
 		harness.abortController.abort();
 		await Bun.sleep(0);

--- a/packages/coding-agent/test/acp-agent.test.ts
+++ b/packages/coding-agent/test/acp-agent.test.ts
@@ -138,6 +138,24 @@ function messageText(message: { content?: unknown }): string | undefined {
 	return first?.text;
 }
 
+/**
+ * Minimal ExtensionRuntime stand-in: captures the bridge handlers object the
+ * ACP agent passes to `initialize`, so tests can drive
+ * newSession/switchSession/branch transitions exactly as extensions would.
+ */
+class CapturingExtensionRunner {
+	handlers: Record<string, (...args: never[]) => unknown> | undefined;
+	async initialize(...surfaces: unknown[]): Promise<void> {
+		this.handlers = surfaces.find(
+			surface => typeof surface === "object" && surface !== null && "branch" in surface,
+		) as Record<string, (...args: never[]) => unknown> | undefined;
+	}
+	async emit(_event: unknown): Promise<void> {}
+	// Bootstrap command advertisement iterates registered extension commands.
+	getRegisteredCommands(): unknown[] {
+		return [];
+	}
+}
 class FakeAgentSession {
 	sessionManager: SessionManager;
 	sessionId: string;
@@ -517,6 +535,8 @@ async function createHarness(
 		extNotification?: "sync-throw" | "async-reject";
 		/** Runs before a notification is recorded, so a test can delay one delivery. */
 		sessionUpdateHook?: (notification: SessionNotification) => Promise<void> | void;
+		/** Runs inside the factory before the handle returns, so tests can attach fakes (e.g. an extension runner). */
+		decorateCreatedSession?: (session: FakeAgentSession) => void;
 	} = {},
 ): Promise<AgentHarness> {
 	const root = await fs.promises.mkdtemp(path.join(os.tmpdir(), "omp-acp-test-"));
@@ -567,6 +587,7 @@ async function createHarness(
 	sessions.push(initialSession);
 	const factory = async (cwd: string, factoryOptions?: { interactivePrompts?: boolean }) => {
 		const session = new FakeAgentSession(cwd);
+		options.decorateCreatedSession?.(session);
 		sessions.push(session);
 		const setToolUIContext = vi.fn();
 		const eventBus = new EventBus();
@@ -2339,6 +2360,67 @@ describe("ACP agent", () => {
 		expect(page2.messages.map(messageText)).toEqual(["two"]);
 	});
 
+	it("broadcasts roster updates after extension-driven branch and switchSession", async () => {
+		vi.useFakeTimers();
+		try {
+			const runner = new CapturingExtensionRunner();
+			const harness = await createHarness({
+				clientCapabilities: { extensions: { agents: true } },
+				decorateCreatedSession: session => {
+					session.extensionRunner = runner as unknown as FakeAgentSession["extensionRunner"];
+				},
+			});
+			const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });
+			const session = harness.findSession(created.sessionId)!;
+			AgentRegistry.global().register({
+				id: "MainBridge",
+				displayName: "MainBridge",
+				kind: "main",
+				session: session as unknown as AgentSession,
+				status: "running",
+			});
+
+			// Drain the initialize-time snapshot, then baseline.
+			vi.advanceTimersByTime(ACP_AGENTS_DEBOUNCE_MS);
+			await Promise.resolve();
+			const baseline = harness.extNotifications.length;
+
+			// Extension branch: fork() mints a NEW transcript file in place; no
+			// registry event fires, so only our explicit refresh keeps clients
+			// current.
+			expect(runner.handlers?.branch).toBeTypeOf("function");
+			await (runner.handlers!.branch as (entryId: string) => Promise<{ cancelled: boolean }>)("entry-1");
+			const branchPath = session.sessionManager.getSessionFile()!;
+			vi.advanceTimersByTime(ACP_AGENTS_DEBOUNCE_MS);
+			await Promise.resolve();
+			const branchUpdates = harness.extNotifications
+				.slice(baseline)
+				.filter(notification => notification.method === "_omp/agents/update");
+			expect(branchUpdates).toHaveLength(1);
+			expect(branchUpdates[0]!.params.agents!.find(agent => agent.id === "MainBridge")?.sessionFile).toBe(
+				branchPath,
+			);
+
+			// Extension switchSession to a different real store behaves identically.
+			const switchedStore = SessionManager.create(harness.cwdA);
+			await switchedStore.ensureOnDisk();
+			switchedStore.appendMessage({ role: "user", content: "switched", timestamp: Date.now() });
+			const switchPath = switchedStore.getSessionFile()!;
+			const preSwitch = harness.extNotifications.length;
+			await (runner.handlers!.switchSession as (sessionPath: string) => Promise<{ cancelled: boolean }>)(switchPath);
+			vi.advanceTimersByTime(ACP_AGENTS_DEBOUNCE_MS);
+			await Promise.resolve();
+			const switchUpdates = harness.extNotifications
+				.slice(preSwitch)
+				.filter(notification => notification.method === "_omp/agents/update");
+			expect(switchUpdates).toHaveLength(1);
+			expect(switchUpdates[0]!.params.agents!.find(agent => agent.id === "MainBridge")?.sessionFile).toBe(
+				switchPath,
+			);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
 	it("withholds the agents surface unless the client declares extensions.agents", async () => {
 		const harness = await createHarness();
 

--- a/packages/coding-agent/test/acp-agent.test.ts
+++ b/packages/coding-agent/test/acp-agent.test.ts
@@ -2291,73 +2291,85 @@ describe("ACP agent", () => {
 
 	it("resets message cursors bound to a transcript when the agent switches files", async () => {
 		const harness = await createHarness({ clientCapabilities: { extensions: { agents: true } } });
-		const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });
-		const session = harness.findSession(created.sessionId)!;
-		AgentRegistry.global().register({
-			id: "MainCursor",
-			displayName: "MainCursor",
-			kind: "main",
-			session: session as unknown as AgentSession,
-			status: "running",
-		});
+		let otherStore: SessionManager | undefined;
+		try {
+			const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });
+			const session = harness.findSession(created.sessionId)!;
+			AgentRegistry.global().register({
+				id: "MainCursor",
+				displayName: "MainCursor",
+				kind: "main",
+				session: session as unknown as AgentSession,
+				status: "running",
+			});
 
-		// Transcript A on the bootstrap store: two messages so a continuation has
-		// somewhere real to land.
-		session.sessionManager.appendMessage({ role: "user", content: "a1", timestamp: Date.now() });
-		session.sessionManager.appendMessage({ role: "user", content: "a2", timestamp: Date.now() });
-		const first = (await harness.agent.extMethod("_omp/agents/messages", { agentId: "MainCursor" })) as {
-			nextByte: number;
-			reset: boolean;
-			messages: Array<{ content?: unknown }>;
-		};
-		expect(first.reset).toBe(false);
-		expect(first.messages.map(messageText)).toEqual(["a1", "a2"]);
+			// Transcript A on the bootstrap store: two messages so a continuation has
+			// somewhere real to land.
+			session.sessionManager.appendMessage({ role: "user", content: "a1", timestamp: Date.now() });
+			session.sessionManager.appendMessage({ role: "user", content: "a2", timestamp: Date.now() });
+			const first = (await harness.agent.extMethod("_omp/agents/messages", { agentId: "MainCursor" })) as {
+				nextByte: number;
+				reset: boolean;
+				messages: Array<{ content?: unknown }>;
+			};
+			expect(first.reset).toBe(false);
+			expect(first.messages.map(messageText)).toEqual(["a1", "a2"]);
 
-		// Switch the ref to a DIFFERENT transcript whose size exceeds the stored
-		// cursor — a naive numeric continuation would land mid-record or, worse,
-		// silently stream only the tail of B while claiming progress.
-		const otherStore = SessionManager.create(harness.cwdA);
-		await otherStore.ensureOnDisk();
-		otherStore.appendMessage({ role: "user", content: "b1", timestamp: Date.now() });
-		await session.sessionManager.setSessionFile(otherStore.getSessionFile()!);
+			// Switch the ref to a DIFFERENT transcript whose size exceeds the stored
+			// cursor — a naive numeric continuation would land mid-record or, worse,
+			// silently stream only the tail of B while claiming progress.
+			otherStore = SessionManager.create(harness.cwdA);
+			await otherStore.ensureOnDisk();
+			otherStore.appendMessage({ role: "user", content: "b1", timestamp: Date.now() });
+			await session.sessionManager.setSessionFile(otherStore.getSessionFile()!);
 
-		const after = (await harness.agent.extMethod("_omp/agents/messages", {
-			agentId: "MainCursor",
-			fromByte: first.nextByte,
-		})) as { reset: boolean; nextByte: number; messages: Array<{ content?: unknown }> };
-		expect(after.reset).toBe(true);
-		expect(after.messages.map(messageText)).toEqual(["b1"]);
+			const after = (await harness.agent.extMethod("_omp/agents/messages", {
+				agentId: "MainCursor",
+				fromByte: first.nextByte,
+			})) as { reset: boolean; nextByte: number; messages: Array<{ content?: unknown }> };
+			expect(after.reset).toBe(true);
+			expect(after.messages.map(messageText)).toEqual(["b1"]);
+		} finally {
+			await harness.agent.dispose();
+			harness.abortController.abort();
+			await otherStore?.close();
+		}
 	});
 
 	it("keeps continuations stable while the transcript identity is unchanged", async () => {
 		const harness = await createHarness({ clientCapabilities: { extensions: { agents: true } } });
-		const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });
-		const session = harness.findSession(created.sessionId)!;
-		AgentRegistry.global().register({
-			id: "MainStable",
-			displayName: "MainStable",
-			kind: "main",
-			session: session as unknown as AgentSession,
-			status: "running",
-		});
-		session.sessionManager.appendMessage({ role: "user", content: "one", timestamp: Date.now() });
+		try {
+			const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });
+			const session = harness.findSession(created.sessionId)!;
+			AgentRegistry.global().register({
+				id: "MainStable",
+				displayName: "MainStable",
+				kind: "main",
+				session: session as unknown as AgentSession,
+				status: "running",
+			});
+			session.sessionManager.appendMessage({ role: "user", content: "one", timestamp: Date.now() });
 
-		const page1 = (await harness.agent.extMethod("_omp/agents/messages", { agentId: "MainStable" })) as {
-			reset: boolean;
-			nextByte: number;
-			messages: Array<{ content?: unknown }>;
-		};
-		expect(page1.reset).toBe(false);
+			const page1 = (await harness.agent.extMethod("_omp/agents/messages", { agentId: "MainStable" })) as {
+				reset: boolean;
+				nextByte: number;
+				messages: Array<{ content?: unknown }>;
+			};
+			expect(page1.reset).toBe(false);
 
-		// Same file grows: continuation continues — no spurious reset, and the
-		// union of both pages covers every record exactly once.
-		session.sessionManager.appendMessage({ role: "user", content: "two", timestamp: Date.now() + 1 });
-		const page2 = (await harness.agent.extMethod("_omp/agents/messages", {
-			agentId: "MainStable",
-			fromByte: page1.nextByte,
-		})) as { reset: boolean; messages: Array<{ content?: unknown }> };
-		expect(page2.reset).toBe(false);
-		expect(page2.messages.map(messageText)).toEqual(["two"]);
+			// Same file grows: continuation continues — no spurious reset, and the
+			// union of both pages covers every record exactly once.
+			session.sessionManager.appendMessage({ role: "user", content: "two", timestamp: Date.now() + 1 });
+			const page2 = (await harness.agent.extMethod("_omp/agents/messages", {
+				agentId: "MainStable",
+				fromByte: page1.nextByte,
+			})) as { reset: boolean; messages: Array<{ content?: unknown }> };
+			expect(page2.reset).toBe(false);
+			expect(page2.messages.map(messageText)).toEqual(["two"]);
+		} finally {
+			await harness.agent.dispose();
+			harness.abortController.abort();
+		}
 	});
 
 	it("broadcasts roster updates after extension-driven branch and switchSession", async () => {

--- a/packages/coding-agent/test/acp-agent.test.ts
+++ b/packages/coding-agent/test/acp-agent.test.ts
@@ -2161,6 +2161,98 @@ describe("ACP agent", () => {
 		await Bun.sleep(0);
 	});
 
+	it("follows session-manager transcript paths across switches", async () => {
+		const harness = await createHarness({ clientCapabilities: { extensions: { agents: true } } });
+		const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });
+		const session = harness.findSession(created.sessionId)!;
+
+		// Production topology: the sdk attaches the live session to its registry
+		// ref, and the static path captured at registration goes stale the moment
+		// a load/fork switch repoints the SessionManager.
+		const registry = AgentRegistry.global();
+		registry.register({
+			id: "MainLive",
+			displayName: "MainLive",
+			kind: "main",
+			session: session as unknown as AgentSession,
+			status: "running",
+		});
+
+		// Build the target transcript with a REAL SessionManager so
+		// `setSessionFile` adopts it (hand-rolled jsonl fails header validation
+		// and would be reset to a fresh empty session instead).
+		const storedManager = SessionManager.create(harness.cwdA);
+		await storedManager.ensureOnDisk();
+		storedManager.appendMessage({ role: "user", content: "switched", timestamp: Date.now() });
+		const switchedPath = storedManager.getSessionFile()!;
+		expect(switchedPath).toBeTruthy();
+
+		// Exactly what a real `switchSession` performs under the hood; capture
+		// the bootstrap path first so we can prove it stops resolving.
+		const bootstrapPath = session.sessionManager.getSessionFile();
+		expect(bootstrapPath).toBeTruthy();
+		await session.sessionManager.setSessionFile(switchedPath);
+
+		// The roster reports the LIVE transcript path…
+		const roster = (await harness.agent.extMethod("_omp/agents/list", {})) as { agents: AcpAgentSnapshot[] };
+		expect(roster.agents.find(agent => agent.id === "MainLive")?.sessionFile).toBe(switchedPath);
+
+		// …transcripts resolve by the live path…
+		const byNewPath = await harness.agent.extMethod("_omp/agents/messages", { sessionFile: switchedPath });
+		expect((byNewPath.messages as unknown[]).length).toBe(1);
+		// …and by roster id…
+		const byId = await harness.agent.extMethod("_omp/agents/messages", { agentId: "MainLive" });
+		expect((byId.messages as unknown[]).length).toBe(1);
+		// …while the abandoned bootstrap path no longer resolves.
+		expect(bootstrapPath).not.toBe(switchedPath);
+		await expect(harness.agent.extMethod("_omp/agents/messages", { sessionFile: bootstrapPath })).rejects.toThrow(
+			"Unknown ACP agent",
+		);
+
+		harness.abortController.abort();
+		await Bun.sleep(0);
+	});
+
+	it("surfaces pendingOversizedRecord through _omp/agents/messages", async () => {
+		const harness = await createHarness({ clientCapabilities: { extensions: { agents: true } } });
+		const headerLine = `${JSON.stringify({
+			type: "session",
+			id: "h0",
+			parentId: null,
+			timestamp: "2026-08-16T10:00:00.000Z",
+		})}\n`;
+		const transcript = path.join(harness.cwdA, "Huge.jsonl");
+		const giantLine = `${JSON.stringify({
+			type: "message",
+			id: "hm1",
+			parentId: "h0",
+			timestamp: "2026-08-16T10:00:01.000Z",
+			message: { role: "user", content: [{ type: "text", text: "x".repeat(9 * 1024 * 1024) }] },
+		})}`;
+		await fs.promises.writeFile(transcript, `${headerLine}${giantLine}`);
+		AgentRegistry.global().register({
+			id: "SubHuge",
+			displayName: "SubHuge",
+			kind: "sub",
+			parentId: "Main",
+			session: null,
+			sessionFile: transcript,
+			status: "running",
+		});
+
+		const result = (await harness.agent.extMethod("_omp/agents/messages", {
+			agentId: "SubHuge",
+		})) as { nextByte: number; pendingOversizedRecord?: boolean };
+
+		// The record dwarfs the 512 KiB budget AND the 8 MiB ceiling: the cursor
+		// must stay put while the explicit flag explains why — never a silent EOF.
+		expect(result.pendingOversizedRecord).toBe(true);
+		expect(result.nextByte).toBe(Buffer.byteLength(headerLine, "utf8"));
+
+		harness.abortController.abort();
+		await Bun.sleep(0);
+	});
+
 	it("withholds the agents surface unless the client declares extensions.agents", async () => {
 		const harness = await createHarness();
 

--- a/packages/coding-agent/test/acp-agent.test.ts
+++ b/packages/coding-agent/test/acp-agent.test.ts
@@ -131,6 +131,13 @@ function makeAssistantMessage(text: string, thinking?: string) {
 	};
 }
 
+/** Extract the first text fragment from any stored-message content shape (string or typed blocks). */
+function messageText(message: { content?: unknown }): string | undefined {
+	if (typeof message.content === "string") return message.content;
+	const first = Array.isArray(message.content) ? (message.content[0] as { text?: string } | undefined) : undefined;
+	return first?.text;
+}
+
 class FakeAgentSession {
 	sessionManager: SessionManager;
 	sessionId: string;
@@ -2251,6 +2258,77 @@ describe("ACP agent", () => {
 
 		harness.abortController.abort();
 		await Bun.sleep(0);
+	});
+
+	it("resets message cursors bound to a transcript when the agent switches files", async () => {
+		const harness = await createHarness({ clientCapabilities: { extensions: { agents: true } } });
+		const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });
+		const session = harness.findSession(created.sessionId)!;
+		AgentRegistry.global().register({
+			id: "MainCursor",
+			displayName: "MainCursor",
+			kind: "main",
+			session: session as unknown as AgentSession,
+			status: "running",
+		});
+
+		// Transcript A on the bootstrap store: two messages so a continuation has
+		// somewhere real to land.
+		session.sessionManager.appendMessage({ role: "user", content: "a1", timestamp: Date.now() });
+		session.sessionManager.appendMessage({ role: "user", content: "a2", timestamp: Date.now() });
+		const first = (await harness.agent.extMethod("_omp/agents/messages", { agentId: "MainCursor" })) as {
+			nextByte: number;
+			reset: boolean;
+			messages: Array<{ content?: unknown }>;
+		};
+		expect(first.reset).toBe(false);
+		expect(first.messages.map(messageText)).toEqual(["a1", "a2"]);
+
+		// Switch the ref to a DIFFERENT transcript whose size exceeds the stored
+		// cursor — a naive numeric continuation would land mid-record or, worse,
+		// silently stream only the tail of B while claiming progress.
+		const otherStore = SessionManager.create(harness.cwdA);
+		await otherStore.ensureOnDisk();
+		otherStore.appendMessage({ role: "user", content: "b1", timestamp: Date.now() });
+		await session.sessionManager.setSessionFile(otherStore.getSessionFile()!);
+
+		const after = (await harness.agent.extMethod("_omp/agents/messages", {
+			agentId: "MainCursor",
+			fromByte: first.nextByte,
+		})) as { reset: boolean; nextByte: number; messages: Array<{ content?: unknown }> };
+		expect(after.reset).toBe(true);
+		expect(after.messages.map(messageText)).toEqual(["b1"]);
+	});
+
+	it("keeps continuations stable while the transcript identity is unchanged", async () => {
+		const harness = await createHarness({ clientCapabilities: { extensions: { agents: true } } });
+		const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });
+		const session = harness.findSession(created.sessionId)!;
+		AgentRegistry.global().register({
+			id: "MainStable",
+			displayName: "MainStable",
+			kind: "main",
+			session: session as unknown as AgentSession,
+			status: "running",
+		});
+		session.sessionManager.appendMessage({ role: "user", content: "one", timestamp: Date.now() });
+
+		const page1 = (await harness.agent.extMethod("_omp/agents/messages", { agentId: "MainStable" })) as {
+			reset: boolean;
+			nextByte: number;
+			messages: Array<{ content?: unknown }>;
+		};
+		expect(page1.reset).toBe(false);
+
+		// Same file grows: continuation continues — no spurious reset, and the
+		// union of both pages covers every record exactly once.
+		session.sessionManager.appendMessage({ role: "user", content: "two", timestamp: Date.now() + 1 });
+		const page2 = (await harness.agent.extMethod("_omp/agents/messages", {
+			agentId: "MainStable",
+			fromByte: page1.nextByte,
+		})) as { reset: boolean; messages: Array<{ content?: unknown }> };
+		expect(page2.reset).toBe(false);
+		expect(page2.messages.map(messageText)).toEqual(["two"]);
 	});
 
 	it("withholds the agents surface unless the client declares extensions.agents", async () => {

--- a/packages/coding-agent/test/acp-session-factory.test.ts
+++ b/packages/coding-agent/test/acp-session-factory.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { createAcpSessionFactory, type AcpSessionFactoryOptions } from "@oh-my-pi/pi-coding-agent/main";
+import type { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { EventBus } from "@oh-my-pi/pi-coding-agent/utils/event-bus";
+
+/**
+ * Contract test for the production `omp acp` session factory: the per-session
+ * task/extension EventBus created in the factory must ride the returned
+ * handle, or `_omp/agents/progress` subscriptions can never fire outside of
+ * tests (the harness fabricates its own bus and would otherwise mask this).
+ */
+describe("createAcpSessionFactory handle contract", () => {
+	test("threads the session's task-event bus through the returned ACP handle", async () => {
+		const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "omp-acp-factory-"));
+		// Handle-level contract only: the pipeline never touches more than
+		// sessionId through this path, so a stub satisfies the interface by fiat.
+		const fakeSession = { sessionId: "factory-contract" } as unknown as AgentSession;
+		let capturedOptions: Record<string, unknown> | undefined;
+		const settingsStub = {
+			cloneForCwd: async () => ({ get: () => undefined }),
+		};
+		const args = {
+			baseOptions: {},
+			settings: settingsStub,
+			authStorage: {},
+			modelRegistry: {},
+			parsedArgs: {},
+			rawArgs: [],
+			createSession: async (options: Record<string, unknown>) => {
+				capturedOptions = options;
+				return { session: fakeSession };
+			},
+		} as unknown as AcpSessionFactoryOptions;
+
+		const factory = createAcpSessionFactory(args);
+		const handle = await factory(cwd);
+
+		expect(handle.session).toBe(fakeSession);
+		// The bus built by the factory is the one handed to the agent-session
+		// pipeline AND the one exposed on the handle — a single shared instance.
+		expect(handle.eventBus).toBeInstanceOf(EventBus);
+		expect(capturedOptions?.eventBus).toBe(handle.eventBus);
+		// ACP clients own MCP configuration exclusively; the factory must keep
+		// disk discovery off so host servers cannot shadow client-supplied ones.
+		expect(capturedOptions?.enableMCP).toBe(false);
+
+		await fs.rm(cwd, { recursive: true, force: true });
+	});
+});

--- a/packages/coding-agent/test/acp-session-factory.test.ts
+++ b/packages/coding-agent/test/acp-session-factory.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import { createAcpSessionFactory, type AcpSessionFactoryOptions } from "@oh-my-pi/pi-coding-agent/main";
+import { type AcpSessionFactoryOptions, createAcpSessionFactory } from "@oh-my-pi/pi-coding-agent/main";
 import type { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { EventBus } from "@oh-my-pi/pi-coding-agent/utils/event-bus";
 

--- a/packages/coding-agent/test/rpc-subagents.test.ts
+++ b/packages/coding-agent/test/rpc-subagents.test.ts
@@ -427,6 +427,78 @@ describe("readRpcSubagentTranscript", () => {
 		expect(resumed.messages).toHaveLength(1);
 		expect(resumed.nextByte).toBe(first.nextByte + Buffer.byteLength(secondLine, "utf8"));
 	});
+
+	test("delivers an oversized record whole by spanning past the byte cap", async () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "omp-rpc-subagent-transcript-oversized-"));
+		tempPaths.push(dir);
+		const sessionFile = path.join(dir, "session.jsonl");
+		const headerLine = `${JSON.stringify({ type: "session", id: "s1", timestamp: "2026-06-09T00:00:00.000Z", cwd: dir })}\n`;
+		const giantText = "x".repeat(2000);
+		const giantLine = `${JSON.stringify({
+			type: "message",
+			id: "giant",
+			parentId: "s1",
+			timestamp: "2026-06-09T00:00:00.000Z",
+			message: { role: "assistant", content: [{ type: "text", text: giantText }] },
+		})}\n`;
+		const tailLine = `${JSON.stringify({
+			type: "message",
+			id: "tail",
+			parentId: "giant",
+			timestamp: "2026-06-09T00:00:01.000Z",
+			message: { role: "user", content: [{ type: "text", text: "after" }] },
+		})}\n`;
+		await Bun.write(sessionFile, `${headerLine}${giantLine}${tailLine}`);
+
+		const full = await readRpcSubagentTranscript(sessionFile);
+		let fromByte = 0;
+		const seen = [];
+		for (let window = 0; window < 100; window++) {
+			const read = await readRpcSubagentTranscript(sessionFile, fromByte, { maxBytes: 512 });
+			if (read.nextByte === fromByte) break;
+			seen.push(...read.messages);
+			fromByte = read.nextByte;
+		}
+
+		// The >512 KiB—well, >512-byte—record ships WHOLE inside a capped stream,
+		// and polling never reports silent completion while data remains.
+		expect(seen).toEqual(full.messages);
+		expect(fromByte).toBe(full.nextByte);
+		// Header yields no messages; the oversized record and the tail ride
+		// together in the spanning window: [giant, tail].
+		const giantSeen = seen[0] as { content: Array<{ text?: string }> };
+		expect(giantSeen.content[0]?.text).toBe(giantText);
+		expect(seen).toHaveLength(2);
+	});
+
+	test("reports pendingOversizedRecord instead of stalling silently", async () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "omp-rpc-subagent-transcript-flag-"));
+		tempPaths.push(dir);
+		const sessionFile = path.join(dir, "session.jsonl");
+		const headerLine = `${JSON.stringify({ type: "session", id: "s1", timestamp: "2026-06-09T00:00:00.000Z", cwd: dir })}\n`;
+		await Bun.write(sessionFile, `${headerLine}${"a".repeat(400)}\n`);
+
+		// First window consumes the header normally.
+		const first = await readRpcSubagentTranscript(sessionFile, 0, { maxBytes: 128 });
+		expect(first.pendingOversizedRecord).toBeUndefined();
+		expect(first.nextByte).toBe(Buffer.byteLength(headerLine, "utf8"));
+
+		// The remaining record exceeds the caller-declared ceiling of 128:
+		// unchanged cursor + explicit flag beats a fake completion signal.
+		const stalled = await readRpcSubagentTranscript(sessionFile, first.nextByte, {
+			maxBytes: 64,
+			oversizedRecordCeilingBytes: 128,
+		});
+		expect(stalled.nextByte).toBe(first.nextByte);
+		expect(stalled.messages).toEqual([]);
+		expect(stalled.pendingOversizedRecord).toBe(true);
+
+		// Reads without a cap keep returning plain results (flag absent).
+		const uncapped = await readRpcSubagentTranscript(sessionFile, first.nextByte);
+		expect(uncapped.messages).toHaveLength(0);
+		expect(uncapped.pendingOversizedRecord).toBeUndefined();
+		expect(uncapped.reset).toBe(false);
+	});
 });
 
 describe("RpcClient subagent frames", () => {

--- a/packages/coding-agent/test/rpc-subagents.test.ts
+++ b/packages/coding-agent/test/rpc-subagents.test.ts
@@ -359,6 +359,74 @@ describe("readRpcSubagentTranscript", () => {
 			messages: [],
 		});
 	});
+
+	test("caps reads by bytes without splitting lines or code points", async () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "omp-rpc-subagent-transcript-capped-"));
+		tempPaths.push(dir);
+		const sessionFile = path.join(dir, "session.jsonl");
+		const headerLine = `${JSON.stringify({ type: "session", id: "s1", timestamp: "2026-06-09T00:00:00.000Z", cwd: dir })}\n`;
+		// Multi-byte content means a naive byte cut can split a code point; every
+		// line stays well under the cap so each window always contains a newline.
+		const lines = [headerLine];
+		for (let i = 0; i < 12; i++) {
+			lines.push(
+				`${JSON.stringify({
+					type: "message",
+					id: `m${i}`,
+					parentId: "s1",
+					timestamp: "2026-06-09T00:00:00.000Z",
+					message: { role: "user", content: [{ type: "text", text: `🌍📖 ${(i + 1).toString().repeat(40)}` }] },
+				})}\n`,
+			);
+		}
+		await Bun.write(sessionFile, lines.join(""));
+
+		const full = await readRpcSubagentTranscript(sessionFile);
+		let fromByte = 0;
+		const seen = [];
+		for (let window = 0; window < 200; window++) {
+			const read = await readRpcSubagentTranscript(sessionFile, fromByte, { maxBytes: 512 });
+			if (read.nextByte === fromByte) break;
+			expect(read.messages.length).toBeGreaterThan(0);
+			seen.push(...read.messages);
+			fromByte = read.nextByte;
+			expect(fromByte).toBeLessThanOrEqual(full.nextByte);
+		}
+
+		expect(seen).toEqual(full.messages);
+		expect(fromByte).toBe(full.nextByte);
+	});
+
+	test("covers continuation past nextByte after the transcript grows", async () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "omp-rpc-subagent-transcript-append-"));
+		tempPaths.push(dir);
+		const sessionFile = path.join(dir, "session.jsonl");
+		const headerLine = `${JSON.stringify({ type: "session", id: "s1", timestamp: "2026-06-09T00:00:00.000Z", cwd: dir })}\n`;
+		const firstLine = `${JSON.stringify({
+			type: "message",
+			id: "m1",
+			parentId: null,
+			timestamp: "2026-06-09T00:00:00.000Z",
+			message: { role: "user", content: [{ type: "text", text: "first" }] },
+		})}\n`;
+		await Bun.write(sessionFile, `${headerLine}${firstLine}`);
+
+		const first = await readRpcSubagentTranscript(sessionFile);
+		expect(first.nextByte).toBe(Buffer.byteLength(`${headerLine}${firstLine}`, "utf8"));
+
+		const secondLine = `${JSON.stringify({
+			type: "message",
+			id: "m2",
+			parentId: "m1",
+			timestamp: "2026-06-09T00:00:01.000Z",
+			message: { role: "assistant", content: [{ type: "text", text: "🌍 final" }] },
+		})}\n`;
+		fs.appendFileSync(sessionFile, secondLine);
+
+		const resumed = await readRpcSubagentTranscript(sessionFile, first.nextByte);
+		expect(resumed.messages).toHaveLength(1);
+		expect(resumed.nextByte).toBe(first.nextByte + Buffer.byteLength(secondLine, "utf8"));
+	});
 });
 
 describe("RpcClient subagent frames", () => {

--- a/packages/coding-agent/test/rpc-subagents.test.ts
+++ b/packages/coding-agent/test/rpc-subagents.test.ts
@@ -521,6 +521,34 @@ describe("readRpcSubagentTranscript", () => {
 		// record (no lookahead read ⇒ no premature flag key on the wire).
 		expect("pendingOversizedRecord" in page).toBe(false);
 	});
+	test("degenerate finite budgets are floored and still make progress", async () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "omp-rpc-subagent-transcript-floor-"));
+		tempPaths.push(dir);
+		const sessionFile = path.join(dir, "session.jsonl");
+		const headerLine = `${JSON.stringify({ type: "session", id: "s1", timestamp: "2026-06-09T00:00:00.000Z", cwd: dir })}\n`;
+		const messageLine = `${JSON.stringify({
+			type: "message",
+			id: "m1",
+			parentId: "s1",
+			timestamp: "2026-06-09T00:00:01.000Z",
+			message: { role: "user", content: [{ type: "text", text: "small" }] },
+		})}\n`;
+		await Bun.write(sessionFile, `${headerLine}${messageLine}`);
+
+		// A paginator feeding any validly-typed budget must observe cursor
+		// movement: zero/negative/fractional values floor to a 1-byte minimum,
+		// so polling terminates instead of seeing an unchanged nextByte forever.
+		for (const maxBytes of [0, -5, 0.4]) {
+			const read = await readRpcSubagentTranscript(sessionFile, 0, { maxBytes });
+			expect(read.nextByte).toBe(Buffer.byteLength(headerLine, "utf8"));
+			expect(read.reset).toBe(false);
+			expect(read.pendingOversizedRecord).toBeUndefined();
+		}
+		// Non-finite budgets keep their documented meaning: the cap is off.
+		const uncapped = await readRpcSubagentTranscript(sessionFile, 0, { maxBytes: Number.NaN });
+		expect(uncapped.messages).toHaveLength(1);
+		expect(uncapped.nextByte).toBe(Buffer.byteLength(`${headerLine}${messageLine}`, "utf8"));
+	});
 });
 
 describe("RpcClient subagent frames", () => {

--- a/packages/coding-agent/test/rpc-subagents.test.ts
+++ b/packages/coding-agent/test/rpc-subagents.test.ts
@@ -499,6 +499,28 @@ describe("readRpcSubagentTranscript", () => {
 		expect(uncapped.pendingOversizedRecord).toBeUndefined();
 		expect(uncapped.reset).toBe(false);
 	});
+
+	test("ordinary pages carry no oversized marker", async () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "omp-rpc-subagent-transcript-plain-"));
+		tempPaths.push(dir);
+		const sessionFile = path.join(dir, "session.jsonl");
+		const headerLine = `${JSON.stringify({ type: "session", id: "s1", timestamp: "2026-06-09T00:00:00.000Z", cwd: dir })}\n`;
+		const messageLine = `${JSON.stringify({
+			type: "message",
+			id: "m1",
+			parentId: "s1",
+			timestamp: "2026-06-09T00:00:01.000Z",
+			message: { role: "user", content: [{ type: "text", text: "small" }] },
+		})}\n`;
+		await Bun.write(sessionFile, `${headerLine}${messageLine}`);
+
+		const page = await readRpcSubagentTranscript(sessionFile, 0, { maxBytes: 512 });
+
+		expect(page.messages).toHaveLength(1);
+		// A window ending on a complete line must not speculate about the next
+		// record (no lookahead read ⇒ no premature flag key on the wire).
+		expect("pendingOversizedRecord" in page).toBe(false);
+	});
 });
 
 describe("RpcClient subagent frames", () => {

--- a/packages/utils/src/acp/protocol.ts
+++ b/packages/utils/src/acp/protocol.ts
@@ -102,6 +102,8 @@ export interface ToolCallLocation extends Meta {
 export interface ToolCall extends Meta {
 	toolCallId: ToolCallId;
 	title: string;
+	/** Extension field: the harness tool name behind the call (e.g. `task`), so clients can classify beyond the spec `kind`. */
+	toolName?: string | null;
 	kind?: ToolKind | null;
 	status?: ToolCallStatus | null;
 	content?: ToolCallContent[] | null;
@@ -113,6 +115,8 @@ export interface ToolCall extends Meta {
 export interface ToolCallUpdate extends Meta {
 	toolCallId: ToolCallId;
 	title?: string | null;
+	/** Extension field: the harness tool name behind the call (e.g. `task`), so clients can classify beyond the spec `kind`. */
+	toolName?: string | null;
 	kind?: ToolKind | null;
 	status?: ToolCallStatus | null;
 	content?: ToolCallContent[] | null;

--- a/packages/utils/src/acp/protocol.ts
+++ b/packages/utils/src/acp/protocol.ts
@@ -152,6 +152,8 @@ export interface ClientCapabilities {
 	terminal?: boolean;
 	auth?: { terminal?: boolean };
 	elicitation?: { form?: Record<string, unknown>; url?: Record<string, unknown> };
+	/** Optional `_omp/*` extension surfaces the client opts into during `initialize`. */
+	extensions?: { agents?: boolean };
 	_meta?: Record<string, unknown>;
 }
 /** Implementation identity sent during initialization. */


### PR DESCRIPTION
## Supersedes / builds on #8728

The five feature commits are cherry-picked verbatim from @Alek7eeey's branch (authorship preserved), rebased onto current main, then hardened per the review thread on the original PR. The unrelated `insecureTls` MCP commit from #8728 is intentionally left out.

### Changes on top of the ported work

- **Opt-in capability** — the entire `_omp/agents/*` surface (`list`/`update`/`progress`/`messages`) requires `clientCapabilities.extensions.agents`. Undeclared connections receive zero unsolicited frames, and requests are answered with a method-not-found error naming the capability. This resolves the open maintainer question that was blocking #8728.
- **Channel-driven progress** — `_omp/agents/progress` now consumes the task executor's `TASK_SUBAGENT_PROGRESS_CHANNEL` / `TASK_SUBAGENT_LIFECYCLE_CHANNEL` through each session's event bus instead of riding `tool_execution_update` payloads past the ended-call guard. Background spawns therefore stream live work, and terminal lifecycle transitions fold into the last known frame so completed-vs-failed is explicit for background agents. Nested spawns stream one level deep today (documented in docs/acp-agents.md).
- **Transcript hardening** — `_omp/agents/messages` windows are capped at 512 KiB per request, cut at complete lines on whole code-point boundaries (`readRpcSubagentTranscript` gained an optional `maxBytes`, cursor math moved to byte space); advisor transcripts can no longer be read.
- **Tests** — default-deny gating, spawn+terminal coalescing into exactly one debounced push, surviving rejecting `extNotification` transports, capped-window continuation across UTF-8 boundaries and file growth, poll-idle semantics.

Docs updated: docs/acp-agents.md covers gating, the channel driver, the byte ceiling, and the nested-spawn caveat.

## Verification

- `bun test test/acp-agent.test.ts test/rpc-subagents.test.ts` — 96 pass
- adjacent acp suites (event-mapper, subagent-advisor) — 49 pass
- `tsgo -p tsconfig.json --noEmit` clean in coding-agent and utils; biome clean on all touched files