### PR TITLE
fix(nix): repair stale DT_VERDEF in aarch64-linux build output

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -228,10 +228,29 @@ stdenv.mkDerivation {
 
   disallowedReferences = [ bun ];
 
+  # patchelf leaves DT_VERDEF pointing at the pre-relocation `.gnu.version_d`
+  # address whenever it grows `.dynamic`: both the `--add-needed libstdc++.so.6`
+  # above and the autoPatchelfHook RPATH pass that follows it do. bun --compile
+  # output defines its own symbol versions (DT_VERDEFNUM), so glibc follows that
+  # stale pointer in `_dl_check_map_versions` and the binary SIGSEGVs in the
+  # loader before `main()` runs (issue #9881). Repoint DT_VERDEF at the current
+  # section address. preInstallCheck runs after every fixupPhase hook, including
+  # the autoPatchelfHook pass that follows postFixup, so it is the last point at
+  # which the field can be corrected; wrapProgram moved the real ELF to
+  # `.omp-wrapped`.
+  preInstallCheck = lib.optionalString stdenv.hostPlatform.isLinux ''
+    bun ${../scripts/fix-dt-verdef.ts} "$out/bin/.omp-wrapped"
+  '';
+
   doInstallCheck = true;
   installCheckPhase = ''
     runHook preInstallCheck
-    HOME="$TMPDIR" "$out/bin/omp" --smoke-test | grep -q "smoke-test: ok"
+    # Capture rather than pipe into grep: piping masks a signal death of omp
+    # under `set -o pipefail` (grep -q's exit status wins), which hid the
+    # loader SIGSEGV in issue #9881. With a variable, errexit surfaces omp's
+    # real exit status and stderr in the build log.
+    smokeOutput="$(HOME="$TMPDIR" "$out/bin/omp" --smoke-test)"
+    grep -q "smoke-test: ok" <<<"$smokeOutput"
     BUN_BE_BUN=1 "$out/bin/omp" -e \
       'if (Bun.version !== "${bun.version}" || typeof Bun.Image !== "function") process.exit(1)'
     ${lib.optionalString stdenv.hostPlatform.isLinux ''

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the `aarch64-linux` `nix build` output segfaulting in the dynamic loader before startup by repointing the stale `DT_VERDEF` that `patchelf` leaves behind when it grows `.dynamic`, and surfaced smoke-test signal deaths in the build log instead of masking them ([#9881](https://github.com/can1357/oh-my-pi/issues/9881)).
+
 ## [18.0.7] - 2026-08-26
 
 ### Added

--- a/scripts/fix-dt-verdef.ts
+++ b/scripts/fix-dt-verdef.ts
@@ -1,0 +1,108 @@
+/**
+ * Repoint `DT_VERDEF` at the current `.gnu.version_d` address in a compiled ELF.
+ *
+ * `bun build --compile` output defines its own symbol versions
+ * (`DT_VERDEFNUM 2`), so the dynamic loader reads `DT_VERDEF` at startup. When
+ * `patchelf` has to grow `.dynamic` — setting an RPATH or adding a `DT_NEEDED`,
+ * both of which omp's nix fixup chain does — it relocates the dynamic-section
+ * cluster and rewrites `DT_SYMTAB`, `DT_STRTAB`, `DT_VERSYM` and `DT_VERNEED`,
+ * but leaves `DT_VERDEF` holding the pre-relocation address. glibc follows the
+ * stale pointer in `_dl_check_map_versions` and the binary SIGSEGVs in the
+ * loader before `main()` runs (observed on aarch64-linux; see issue #9881).
+ *
+ * This restores the invariant after the fixup chain has finished patching, by
+ * pointing `DT_VERDEF` back at the section-header address of `.gnu.version_d`.
+ * ELF64 little-endian only — the only shape omp's Linux outputs take. Binaries
+ * without a `.gnu.version_d` (ordinary Rust/C objects) are a no-op.
+ */
+
+import * as fs from "node:fs";
+
+/** `d_tag` sentinel that terminates the `.dynamic` array. */
+const DT_NULL = 0n;
+/** `d_tag` for the `.gnu.version_d` (version-definition) table pointer. */
+const DT_VERDEF = 0x6ffffffcn;
+/** `sh_type` for `SHT_DYNAMIC`. */
+const SHT_DYNAMIC = 6;
+/** `sh_type` for `SHT_GNU_verdef` (`.gnu.version_d`). */
+const SHT_GNU_VERDEF = 0x6ffffffd;
+
+/** Location and extent of the `.dynamic` section within the file. */
+interface DynamicSection {
+	offset: number;
+	size: number;
+}
+
+/**
+ * Rewrite one file's `DT_VERDEF` in place so it matches `.gnu.version_d`.
+ *
+ * @throws if the file is not ELF64 little-endian, lacks `SHT_DYNAMIC`, or
+ * carries a `.gnu.version_d` with no corresponding `DT_VERDEF` entry — all of
+ * which indicate a malformed target rather than a benign skip.
+ */
+function repair(path: string): void {
+	const fd = fs.openSync(path, "r+");
+	try {
+		const header = Buffer.alloc(64);
+		fs.readSync(fd, header, 0, 64, 0);
+		if (header.toString("latin1", 0, 4) !== "\x7fELF") throw new Error(`${path}: not an ELF file`);
+		if (header[4] !== 2 || header[5] !== 1) throw new Error(`${path}: not ELF64 little-endian`);
+
+		const shoff = Number(header.readBigUInt64LE(40));
+		const shentsize = header.readUInt16LE(58);
+		const shnum = header.readUInt16LE(60);
+
+		const sections = Buffer.alloc(shentsize * shnum);
+		fs.readSync(fd, sections, 0, sections.length, shoff);
+
+		let verdefAddr: bigint | null = null;
+		let dynamic: DynamicSection | null = null;
+		for (let index = 0; index < shnum; index += 1) {
+			const base = index * shentsize;
+			const type = sections.readUInt32LE(base + 4);
+			if (type === SHT_GNU_VERDEF) verdefAddr = sections.readBigUInt64LE(base + 16);
+			else if (type === SHT_DYNAMIC) {
+				dynamic = {
+					offset: Number(sections.readBigUInt64LE(base + 24)),
+					size: Number(sections.readBigUInt64LE(base + 32)),
+				};
+			}
+		}
+
+		if (verdefAddr === null) {
+			console.log(`fix-dt-verdef: ${path}: no .gnu.version_d, nothing to do`);
+			return;
+		}
+		if (dynamic === null) throw new Error(`${path}: no SHT_DYNAMIC section`);
+
+		const dyn = Buffer.alloc(dynamic.size);
+		fs.readSync(fd, dyn, 0, dyn.length, dynamic.offset);
+		for (let cursor = 0; cursor + 16 <= dyn.length; cursor += 16) {
+			const tag = dyn.readBigUInt64LE(cursor);
+			if (tag === DT_NULL) break;
+			if (tag !== DT_VERDEF) continue;
+
+			const current = dyn.readBigUInt64LE(cursor + 8);
+			if (current === verdefAddr) {
+				console.log(`fix-dt-verdef: ${path}: DT_VERDEF already 0x${verdefAddr.toString(16)}`);
+				return;
+			}
+			const value = Buffer.alloc(8);
+			value.writeBigUInt64LE(verdefAddr);
+			fs.writeSync(fd, value, 0, 8, dynamic.offset + cursor + 8);
+			console.log(`fix-dt-verdef: ${path}: DT_VERDEF 0x${current.toString(16)} -> 0x${verdefAddr.toString(16)}`);
+			return;
+		}
+
+		throw new Error(`${path}: .gnu.version_d present but no DT_VERDEF entry`);
+	} finally {
+		fs.closeSync(fd);
+	}
+}
+
+const targets = process.argv.slice(2);
+if (targets.length === 0) {
+	console.error("usage: fix-dt-verdef.ts <elf>...");
+	process.exit(2);
+}
+for (const target of targets) repair(target);


### PR DESCRIPTION
## Repro
`nix build .#omp` on `aarch64-linux` produces an `omp` binary that SIGSEGVs in the dynamic loader before `main()` runs; the build itself fails in `installCheckPhase` with no visible error. I can't run an aarch64 nix build here (x86_64 host, no nix/patchelf), but the version-definition structure at fault is not aarch64-specific — a plain `bun build --compile` output carries `.gnu.version_d` + `DT_VERDEF`/`DT_VERDEFNUM 2` on x86_64 too. On a real compiled binary I reproduced the exact stale-pointer signature @epfister-cyncly documented: pristine `DT_VERDEF` equals the `.gnu.version_d` section address and `readelf -V` is clean; forcing `DT_VERDEF` to a stale address makes `readelf -V` flood `readelf: Error: Reading 20 bytes extends past end of file for version def`; the repair restores it (`DT_VERDEF 0x90206fe0 -> 0x20663c`) and `readelf -V` is clean again.

## Cause
`patchelf` relocates the dynamic-section cluster whenever it grows `.dynamic`, rewriting `DT_SYMTAB`/`DT_STRTAB`/`DT_VERSYM`/`DT_VERNEED` but leaving `DT_VERDEF` at the pre-relocation `.gnu.version_d` address. glibc follows the stale pointer in `_dl_check_map_versions` and dies. `bun build --compile` output defines its own symbol versions (`DT_VERDEFNUM 2`), so the loader reads `DT_VERDEF` at startup; ordinary Rust/C objects carry no `.gnu.version_d`, which is why nothing else in the closure breaks. `nix/package.nix` grows `.dynamic` twice on the `omp` ELF — `postFixup`'s `patchelf --add-needed libstdc++.so.6` and the `autoPatchelfHook` RPATH pass — either of which triggers the corruption. Separately, `installCheckPhase` piped `omp --smoke-test | grep -q ...`, so under `pipefail` grep's exit status masked the loader SIGSEGV, hiding the real failure in the build log.

## Fix
- Add `scripts/fix-dt-verdef.ts`: repoints `DT_VERDEF` at the current `.gnu.version_d` section-header address (ELF64 little-endian; no-op for binaries without `.gnu.version_d`; errors on a `.gnu.version_d` with no `DT_VERDEF` entry).
- Wire it into `nix/package.nix` via `preInstallCheck` (Linux-only), which runs after every `fixupPhase` hook — including the `autoPatchelfHook` pass that follows `postFixup` — so it is the last point at which the field can be corrected; it targets the `wrapProgram`-moved `.omp-wrapped` ELF.
- Replace the piped smoke-test assertion with a captured-output form so a signal death aborts the phase under `errexit` with omp's real exit status and stderr, instead of being swallowed by `grep -q` under `pipefail`.

## Verification
`bun check` passes. Behavioral checks on a real `bun --compile` ELF: staling `DT_VERDEF` reproduces the reporter's `readelf -V` out-of-bounds error; `bun scripts/fix-dt-verdef.ts` restores it and `readelf -V` is clean; re-running is idempotent (`DT_VERDEF already 0x...`); a binary without `.gnu.version_d` is a no-op; a non-ELF target errors with exit 1. The smoke-test bash logic was verified to exit 139 (not reach `grep`) when the checked binary dies by SIGSEGV. Full aarch64 nix-build verification was not possible in this environment (no nix/patchelf, x86_64 host); the corruption signature and the repair are reproduced and verified here. Fixes #9881