### PR TITLE
fix(coding-agent): fired duration /loop on an interval, steering live turns

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `/loop` interrupting an in-progress turn to re-prompt. A duration-limited `/loop` (e.g. `/loop 30s`, `/loop 10m`) now reminds on that fixed interval instead: a live turn gets a non-interrupting reminder chained onto it, and an idle agent gets nudged, rather than the loop killing and restarting the stream.
+
 ## [18.0.7] - 2026-08-26
 
 ### Added

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- A duration-limited `/loop` (e.g. `/loop 30m fix the tests`) now fires on that fixed interval instead of waiting for the agent to stop before re-prompting it: a turn that is still working gets the prompt steered in — so a long turn is nudged repeatedly as it runs, keeping its cached context — and once the agent has stopped, the same tick simply submits the prompt and it continues. Count-based loops (`/loop 5`) are unchanged.
+
 ## [18.1.15] - 2026-09-08
 
 ### Added

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1956,7 +1956,8 @@ export const SETTINGS_SCHEMA = {
 			tab: "interaction",
 			group: "Input",
 			label: "Loop Mode",
-			description: "What happens between /loop iterations before re-submitting the prompt",
+			description:
+				"What happens between /loop iterations before re-submitting the prompt. Applies only to count-based/unbounded loops; a duration-limited /loop reminds on that fixed interval instead and always just re-submits the prompt (compact/reset are skipped).",
 			options: [
 				{
 					value: "prompt",

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -2029,7 +2029,8 @@ export const SETTINGS_SCHEMA = {
 			tab: "interaction",
 			group: "Input",
 			label: "Loop Mode",
-			description: "What happens between /loop iterations before re-submitting the prompt",
+			description:
+				"What happens between /loop iterations before re-submitting the prompt. Applies only to count-based/unbounded loops; a duration-limited /loop fires on that fixed interval instead and always just delivers the prompt (compact/reset are skipped).",
 			options: [
 				{
 					value: "prompt",

--- a/packages/coding-agent/src/modes/components/status-line/segments.ts
+++ b/packages/coding-agent/src/modes/components/status-line/segments.ts
@@ -235,13 +235,13 @@ function formatLoopLimit(limit: NonNullable<SegmentContext["loopMode"]>["limit"]
 	if (!limit) return undefined;
 	if (limit.kind === "iterations") return `${limit.remaining}/${limit.initial}`;
 
-	const totalSeconds = Math.max(0, Math.ceil((limit.deadlineMs - Date.now()) / 1_000));
+	const totalSeconds = Math.round(limit.durationMs / 1_000);
 	const hours = Math.floor(totalSeconds / 3_600);
 	const minutes = Math.floor((totalSeconds % 3_600) / 60);
 	const seconds = totalSeconds % 60;
-	if (hours > 0) return `${hours}h${minutes > 0 ? `${minutes}m` : ""} left`;
-	if (minutes > 0) return `${minutes}m${seconds > 0 ? `${seconds}s` : ""} left`;
-	return `${seconds}s left`;
+	if (hours > 0) return `every ${hours}h${minutes > 0 ? `${minutes}m` : ""}`;
+	if (minutes > 0) return `every ${minutes}m${seconds > 0 ? `${seconds}s` : ""}`;
+	return `every ${seconds}s`;
 }
 
 const modeSegment: StatusLineSegment = {

--- a/packages/coding-agent/src/modes/components/status-line/segments.ts
+++ b/packages/coding-agent/src/modes/components/status-line/segments.ts
@@ -332,13 +332,13 @@ function formatLoopLimit(
 	if (!limit) return undefined;
 	if (limit.kind === "iterations") return `${limit.remaining}/${limit.initial}`;
 
-	const totalSeconds = Math.max(0, Math.ceil((limit.deadlineMs - nowMs) / 1_000));
+	const totalSeconds = Math.round(limit.durationMs / 1_000);
 	const hours = Math.floor(totalSeconds / 3_600);
 	const minutes = Math.floor((totalSeconds % 3_600) / 60);
 	const seconds = totalSeconds % 60;
-	if (hours > 0) return `${hours}h${minutes > 0 ? `${minutes}m` : ""} left`;
-	if (minutes > 0) return `${minutes}m${seconds > 0 ? `${seconds}s` : ""} left`;
-	return `${seconds}s left`;
+	if (hours > 0) return `every ${hours}h${minutes > 0 ? `${minutes}m` : ""}`;
+	if (minutes > 0) return `every ${minutes}m${seconds > 0 ? `${seconds}s` : ""}`;
+	return `every ${seconds}s`;
 }
 
 const modeSegment: StatusLineSegment = {

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -260,6 +260,12 @@ export class InputController {
 	}
 
 	#abortStreamingTurn(): void {
+		// A loop reminder sitting in the steering queue would defeat this Esc:
+		// `#canAutoContinueForFollowUp` resumes on *any* queued steer before it
+		// consults the user-interrupt suppression, so the abort's drain would
+		// immediately start a fresh continuation on the reminder. Drop it — the
+		// loop is still armed and steers again at its next interval.
+		this.ctx.dropQueuedLoopReminders();
 		void this.ctx.session.abort({ reason: USER_INTERRUPT_LABEL });
 	}
 

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -197,7 +197,7 @@ import {
 	createLoopLimitRuntime,
 	describeLoopLimit,
 	describeLoopLimitRuntime,
-	isLoopDurationExpired,
+	getLoopIntervalMs,
 	type LoopLimitRuntime,
 	parseLoopLimitArgs,
 } from "./loop-limit";
@@ -616,6 +616,7 @@ export class InteractiveMode implements InteractiveModeContext {
 	loopPrompt: string | undefined = undefined;
 	loopLimit: LoopLimitRuntime | undefined = undefined;
 	#loopAutoSubmitTimer: NodeJS.Timeout | undefined;
+	#loopIntervalTimer: NodeJS.Timeout | undefined;
 	#todoAutoClearTimer: NodeJS.Timeout | undefined;
 	#modelCycleClearTimer: NodeJS.Timeout | undefined;
 	#nextAppearanceRequestToken = 1;
@@ -1588,6 +1589,11 @@ export class InteractiveMode implements InteractiveModeContext {
 	#scheduleLoopAutoSubmit(): void {
 		this.#cancelLoopAutoSubmit();
 		if (!this.loopModeEnabled || !this.loopPrompt) return;
+		// Interval ("cron") loops own their cadence via #loopIntervalTimer, armed
+		// independently of this idle-only getUserInput() cycle so a tick still
+		// fires while a turn is streaming. This turn-boundary grace is only for
+		// fire-on-stop loops (no interval configured).
+		if (getLoopIntervalMs(this.loopLimit) !== undefined) return;
 		const prompt = this.loopPrompt;
 		const loopAction = settings.get("loop.mode");
 		this.#deferLoopAutoSubmit(() => {
@@ -1609,6 +1615,54 @@ export class InteractiveMode implements InteractiveModeContext {
 			clearTimeout(this.#loopAutoSubmitTimer);
 			this.#loopAutoSubmitTimer = undefined;
 		}
+	}
+
+	/**
+	 * Arm the interval ("cron") timer for a duration-limited loop: it fires on
+	 * a fixed cadence for the lifetime of loop mode, independent of the idle
+	 * getUserInput() cycle, so it can nudge the agent whether a turn is
+	 * streaming or idle. Iteration-limited and unbounded loops fire on the
+	 * turn-boundary grace in #scheduleLoopAutoSubmit instead; this is a no-op
+	 * for them.
+	 */
+	#armLoopIntervalTimer(): void {
+		this.#cancelLoopIntervalTimer();
+		const intervalMs = getLoopIntervalMs(this.loopLimit);
+		if (intervalMs === undefined) return;
+		this.#loopIntervalTimer = setInterval(() => this.#fireLoopIntervalTick(), intervalMs);
+		this.#loopIntervalTimer.unref?.();
+	}
+
+	#cancelLoopIntervalTimer(): void {
+		if (this.#loopIntervalTimer) {
+			clearInterval(this.#loopIntervalTimer);
+			this.#loopIntervalTimer = undefined;
+		}
+	}
+
+	/**
+	 * One tick of an interval loop. A turn already streaming gets a
+	 * non-interrupting reminder chained onto it (`followUp`) instead of being
+	 * killed and re-prompted. An idle agent gets the same prompt delivered as
+	 * a fresh nudge through the normal submit path. Compacting/post-prompt
+	 * work (busy but not `isStreaming`) is skipped rather than risking
+	 * `session.prompt()` falling through to a fresh-turn start and throwing
+	 * `AgentBusyError`; the next tick retries. A tick landing in the narrow
+	 * gap between turns (busy flags clear but the next getUserInput() hasn't
+	 * re-armed onInputCallback yet) is likewise skipped.
+	 */
+	#fireLoopIntervalTick(): void {
+		if (!this.loopModeEnabled || this.loopModePaused || !this.loopPrompt) return;
+		const prompt = this.loopPrompt;
+		if (this.session.isStreaming) {
+			this.session
+				.prompt(prompt, { streamingBehavior: "followUp" })
+				.catch(err => logger.warn("loop interval reminder failed", { error: String(err) }));
+			return;
+		}
+		if (this.#isAutoSubmitBlocked()) return;
+		if (!this.onInputCallback) return;
+		this.onInputCallback(this.startPendingSubmission({ text: prompt }));
 	}
 
 	#scheduleGoalContinuation(): void {
@@ -1667,10 +1721,6 @@ export class InteractiveMode implements InteractiveModeContext {
 
 	#submitLoopPromptWhenReady(prompt: string): void {
 		if (!this.loopModeEnabled || this.loopPrompt !== prompt || !this.onInputCallback) return;
-		if (isLoopDurationExpired(this.loopLimit)) {
-			this.disableLoopMode("Loop time limit reached. Loop mode disabled.");
-			return;
-		}
 		if (this.#isAutoSubmitBlocked()) {
 			this.#deferLoopAutoSubmit(() => this.#submitLoopPromptWhenReady(prompt));
 			return;
@@ -1723,6 +1773,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.loopPrompt = undefined;
 		this.loopLimit = undefined;
 		this.#cancelLoopAutoSubmit();
+		this.#cancelLoopIntervalTimer();
 		this.#syncLoopModeStatus();
 		if (wasEnabled) {
 			this.showStatus(message);
@@ -1762,10 +1813,23 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.loopModePaused = false;
 		this.loopPrompt = undefined;
 		this.loopLimit = createLoopLimitRuntime(parsed.limit);
+		this.#armLoopIntervalTimer();
 		this.#syncLoopModeStatus();
-		const limitSuffix = parsed.limit ? ` Limited to ${describeLoopLimit(parsed.limit)}.` : "";
-		const remainingSuffix = this.loopLimit ? ` ${describeLoopLimitRuntime(this.loopLimit)}.` : "";
-		const tail = parsed.prompt ? "Repeating it after each turn." : "Your next prompt will repeat after each turn.";
+		const limitSuffix =
+			parsed.limit?.kind === "iterations"
+				? ` Limited to ${describeLoopLimit(parsed.limit)}.`
+				: parsed.limit?.kind === "duration"
+					? ` Reminding ${describeLoopLimit(parsed.limit)}, chained onto the current turn without interrupting it.`
+					: "";
+		const remainingSuffix = this.loopLimit?.kind === "iterations" ? ` ${describeLoopLimitRuntime(this.loopLimit)}.` : "";
+		const tail =
+			parsed.limit?.kind === "duration"
+				? parsed.prompt
+					? "It will be sent on that interval."
+					: "Your next prompt will be sent on that interval."
+				: parsed.prompt
+					? "Repeating it after each turn."
+					: "Your next prompt will repeat after each turn.";
 		this.showStatus(
 			`Loop mode enabled.${limitSuffix}${remainingSuffix} ${tail} Esc cancels the current iteration; /loop again to disable.`,
 		);

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -211,7 +211,7 @@ import {
 	createLoopLimitRuntime,
 	describeLoopLimit,
 	describeLoopLimitRuntime,
-	isLoopDurationExpired,
+	getLoopIntervalMs,
 	type LoopLimitRuntime,
 	parseLoopLimitArgs,
 } from "./loop-limit";
@@ -588,6 +588,12 @@ export function renderSubagentHudLines(sessions: ObservableSession[], columns: n
 
 const CTRL_L_APPEARANCE_RESPONSE_DEADLINE_MS = 2000;
 
+/** customType tag for interval-loop reminders queued via promptCustomMessage,
+ *  so a tick can dedupe against an already-queued reminder and disableLoopMode
+ *  can drop any still-queued reminder instead of leaving it to fire after the
+ *  loop was turned off. */
+const LOOP_REMINDER_CUSTOM_TYPE = "loop-reminder";
+
 export class InteractiveMode implements InteractiveModeContext {
 	#ownsStartedUi: boolean;
 	session: AgentSession;
@@ -638,6 +644,7 @@ export class InteractiveMode implements InteractiveModeContext {
 	loopPrompt: string | undefined = undefined;
 	loopLimit: LoopLimitRuntime | undefined = undefined;
 	#loopAutoSubmitTimer: NodeJS.Timeout | undefined;
+	#loopIntervalTimer: NodeJS.Timeout | undefined;
 	#todoAutoClearTimer: NodeJS.Timeout | undefined;
 	#modelCycleClearTimer: NodeJS.Timeout | undefined;
 	#nextAppearanceRequestToken = 1;
@@ -1707,6 +1714,11 @@ export class InteractiveMode implements InteractiveModeContext {
 	#scheduleLoopAutoSubmit(): void {
 		this.#cancelLoopAutoSubmit();
 		if (!this.loopModeEnabled || !this.loopPrompt) return;
+		// Interval ("cron") loops own their cadence via #loopIntervalTimer, armed
+		// independently of this idle-only getUserInput() cycle so a tick still
+		// fires while a turn is streaming. This turn-boundary grace is only for
+		// fire-on-stop loops (no interval configured).
+		if (getLoopIntervalMs(this.loopLimit) !== undefined) return;
 		const prompt = this.loopPrompt;
 		const loopAction = settings.get("loop.mode");
 		this.#deferLoopAutoSubmit(() => {
@@ -1728,6 +1740,134 @@ export class InteractiveMode implements InteractiveModeContext {
 			clearTimeout(this.#loopAutoSubmitTimer);
 			this.#loopAutoSubmitTimer = undefined;
 		}
+	}
+
+	/**
+	 * Arm the interval ("cron") timer for a duration-limited loop: it fires on
+	 * a fixed cadence for the lifetime of loop mode, independent of the idle
+	 * getUserInput() cycle, so it can nudge the agent whether a turn is
+	 * streaming or idle. Iteration-limited and unbounded loops fire on the
+	 * turn-boundary grace in #scheduleLoopAutoSubmit instead; this is a no-op
+	 * for them.
+	 *
+	 * Armed when the loop first has a prompt, not when `/loop` is typed: a bare
+	 * `/loop 10m` waits for the user to supply the instruction, and starting the
+	 * clock at command entry would spend part of the first interval on their
+	 * typing (and drop every tick before a prompt existed).
+	 */
+	#armLoopIntervalTimer(): void {
+		this.#cancelLoopIntervalTimer();
+		if (!this.loopPrompt) return;
+		const intervalMs = getLoopIntervalMs(this.loopLimit);
+		if (intervalMs === undefined) return;
+		this.#loopIntervalTimer = setInterval(() => this.#fireLoopIntervalTick(), intervalMs);
+		this.#loopIntervalTimer.unref?.();
+	}
+
+	#cancelLoopIntervalTimer(): void {
+		if (this.#loopIntervalTimer) {
+			clearInterval(this.#loopIntervalTimer);
+			this.#loopIntervalTimer = undefined;
+		}
+	}
+
+	/**
+	 * One tick of an interval loop. A turn already streaming is *steered*: the
+	 * prompt is injected at the run's next provider-call boundary, so a long turn
+	 * actually receives the instruction while it works (a two-hour turn on a
+	 * 30-minute interval gets steered roughly four times) without being aborted
+	 * and re-prompted. Follow-up delivery would be wrong here — it only drains
+	 * once the run ends, so every tick during that turn would collapse into a
+	 * single late delivery.
+	 *
+	 * The message is tagged with {@link LOOP_REMINDER_CUSTOM_TYPE} so a tick can
+	 * detect one is already queued (a tick landing before the previous steer has
+	 * been consumed must not pile up duplicates) and so `disableLoopMode` can
+	 * retract it.
+	 *
+	 * An idle agent gets the same prompt through the normal submit path — when
+	 * the agent has stopped, steering *is* just a prompt, which is what keeps the
+	 * loop going after a turn ends. Compacting/post-prompt work (busy but not
+	 * `isStreaming`) is skipped rather than risking
+	 * `session.promptCustomMessage()` falling through to a fresh-turn start and
+	 * throwing `AgentBusyError`; the next tick retries. A tick landing in the
+	 * narrow gap between turns (busy flags clear but the next getUserInput()
+	 * hasn't re-armed onInputCallback yet) is likewise skipped.
+	 */
+	#fireLoopIntervalTick(): void {
+		if (!this.loopModeEnabled || this.loopModePaused || !this.loopPrompt) return;
+		const prompt = this.loopPrompt;
+		if (this.session.isStreaming) {
+			if (this.#hasQueuedLoopReminder()) return;
+			this.session
+				.promptCustomMessage(
+					{ customType: LOOP_REMINDER_CUSTOM_TYPE, content: prompt, display: false, attribution: "user" },
+					{ streamingBehavior: "steer" },
+				)
+				.catch(err => logger.warn("loop interval steer failed", { error: String(err) }));
+			return;
+		}
+		if (this.#isAutoSubmitBlocked()) return;
+		// onInputCallback self-clears when invoked, so this also covers a
+		// submission already in flight: no tick can submit twice for one turn.
+		if (!this.onInputCallback) return;
+		// Mirror #scheduleGoalContinuation: an idle tick must not clobber a prompt
+		// the user is composing. startPendingSubmission clears the editor draft,
+		// so skip while there is draft text or a pending image and let a later
+		// tick deliver once the composer is clear.
+		if (this.editor.getText().trim().length > 0) return;
+		// An attachment in the composer means the user is composing; the tick waits
+		// rather than clobbering it. Nothing here has attachments of its own: the
+		// inline `/loop <duration> <prompt>` goes through the normal submit path,
+		// which delivers its images with it, so a reminder is always just text.
+		if ((this.editor.pendingImages?.length ?? 0) > 0) return;
+		// A reminder queued onto a turn the user then interrupted (Esc) stays on
+		// the queue with auto-resume suppressed. Submitting this tick re-enables
+		// auto-resume, which would drain that retained reminder after the new
+		// turn — two model turns for one cadence, both running the same loop
+		// instruction. This visible submission *is* the tick, so consume the
+		// retained reminder rather than letting it fire again.
+		this.#clearQueuedLoopReminders();
+		this.onInputCallback(this.startPendingSubmission({ text: prompt }));
+	}
+
+	/** A steered reminder sits on the steering queue, so both queues must be
+	 *  scanned: checking only follow-ups would let every tick during a long turn
+	 *  queue another copy. */
+	#hasQueuedLoopReminder(): boolean {
+		const isLoopReminder = (message: AgentMessage): boolean =>
+			message.role === "custom" && message.customType === LOOP_REMINDER_CUSTOM_TYPE;
+		return (
+			this.session.agent.peekSteeringQueue().some(isLoopReminder) ||
+			this.session.agent.peekFollowUpQueue().some(isLoopReminder)
+		);
+	}
+
+	/** Drop any interval-loop reminder still sitting on the agent's queues so
+	 *  disabling the loop doesn't leave a stray reminder to fire after the fact. */
+	#clearQueuedLoopReminders(): void {
+		const isLoopReminder = (message: AgentMessage): boolean =>
+			message.role === "custom" && message.customType === LOOP_REMINDER_CUSTOM_TYPE;
+		const steering = this.session.agent.peekSteeringQueue();
+		const followUp = this.session.agent.peekFollowUpQueue();
+		if (!steering.some(isLoopReminder) && !followUp.some(isLoopReminder)) return;
+		this.session.agent.replaceQueues(
+			steering.filter(message => !isLoopReminder(message)),
+			followUp.filter(message => !isLoopReminder(message)),
+		);
+	}
+
+	/**
+	 * Drop a queued interval reminder so a user interrupt is honoured.
+	 *
+	 * `#canAutoContinueForFollowUp` resumes on any queued steer *before* it
+	 * consults the user-interrupt suppression, so a reminder left in the steering
+	 * queue would have the abort's drain start a fresh continuation — Esc would
+	 * appear not to stop the agent. The loop itself stays armed and steers again
+	 * on its next interval.
+	 */
+	dropQueuedLoopReminders(): void {
+		this.#clearQueuedLoopReminders();
 	}
 
 	#scheduleGoalContinuation(): void {
@@ -1799,10 +1939,6 @@ export class InteractiveMode implements InteractiveModeContext {
 
 	#submitLoopPromptWhenReady(prompt: string): void {
 		if (!this.loopModeEnabled || this.loopPrompt !== prompt || !this.onInputCallback) return;
-		if (isLoopDurationExpired(this.loopLimit)) {
-			this.disableLoopMode("Loop time limit reached. Loop mode disabled.");
-			return;
-		}
 		if (this.#isAutoSubmitBlocked()) {
 			this.#deferLoopAutoSubmit(() => this.#submitLoopPromptWhenReady(prompt));
 			return;
@@ -1855,6 +1991,8 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.loopPrompt = undefined;
 		this.loopLimit = undefined;
 		this.#cancelLoopAutoSubmit();
+		this.#cancelLoopIntervalTimer();
+		this.#clearQueuedLoopReminders();
 		this.#syncLoopModeStatus();
 		if (wasEnabled) {
 			this.showStatus(message);
@@ -1865,18 +2003,28 @@ export class InteractiveMode implements InteractiveModeContext {
 		if (!this.loopModeEnabled) return;
 		this.loopPrompt = prompt;
 		this.loopModePaused = false;
+		// A reminder already queued for the previous prompt is now stale — drop
+		// it so the agent doesn't act on superseded content; the interval timer
+		// picks up the new prompt fresh on its next tick.
+		this.#clearQueuedLoopReminders();
+		// Start (or restart) the cadence from this instruction. A bare `/loop 10m`
+		// has no prompt to deliver until now, so this is when its clock should run.
+		this.#armLoopIntervalTimer();
 		this.#syncLoopModeStatus();
 	}
 
 	/**
-	 * Pause the loop without exiting it: drops the captured prompt and any
-	 * pending auto-resubmit. Loop mode stays enabled — the next prompt the
-	 * user submits becomes the new loop prompt and resumes iteration.
+	 * Pause the loop without exiting it: drops the captured prompt, any
+	 * pending auto-resubmit, and any interval reminder already queued for
+	 * delivery (same reason as {@link disableLoopMode} — a paused loop must
+	 * not still nudge). Loop mode stays enabled — the next prompt the user
+	 * submits becomes the new loop prompt and resumes iteration.
 	 */
 	pauseLoop(): void {
 		this.loopPrompt = undefined;
 		this.loopModePaused = true;
 		this.#cancelLoopAutoSubmit();
+		this.#clearQueuedLoopReminders();
 		this.#syncLoopModeStatus();
 	}
 
@@ -1894,17 +2042,34 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.loopModePaused = false;
 		this.loopPrompt = undefined;
 		this.loopLimit = createLoopLimitRuntime(parsed.limit);
+		this.#armLoopIntervalTimer();
 		this.#syncLoopModeStatus();
-		const limitSuffix = parsed.limit ? ` Limited to ${describeLoopLimit(parsed.limit)}.` : "";
-		const remainingSuffix = this.loopLimit ? ` ${describeLoopLimitRuntime(this.loopLimit)}.` : "";
-		const tail = parsed.prompt ? "Repeating it after each turn." : "Your next prompt will repeat after each turn.";
+		const limitSuffix =
+			parsed.limit?.kind === "iterations"
+				? ` Limited to ${describeLoopLimit(parsed.limit)}.`
+				: parsed.limit?.kind === "duration"
+					? ` Reminding ${describeLoopLimit(parsed.limit)}, steered into the current turn without interrupting it.`
+					: "";
+		const remainingSuffix =
+			this.loopLimit?.kind === "iterations" ? ` ${describeLoopLimitRuntime(this.loopLimit)}.` : "";
+		const tail =
+			parsed.limit?.kind === "duration"
+				? parsed.prompt
+					? "It repeats on that interval."
+					: "Your next prompt repeats on that interval."
+				: parsed.prompt
+					? "Repeating it after each turn."
+					: "Your next prompt will repeat after each turn.";
 		this.showStatus(
 			`Loop mode enabled.${limitSuffix}${remainingSuffix} ${tail} Esc cancels the current iteration; /loop again to disable.`,
 		);
-		// Hand any inline prompt back to the dispatcher so the normal submit flow
-		// runs the first iteration — it records the text as the loop prompt and
-		// auto-resubmits it after each yield, identical to typing the prompt right
-		// after enabling loop mode.
+		// Hand the inline prompt back for a normal first submission. It goes out
+		// like any typed prompt — steered into a live turn, with its attachments —
+		// and the interval timer nudges from there. Deferring it to the first tick
+		// instead would consume the command while leaving its images behind in the
+		// composer with no `[Image #N]` marker, where the next submission drops
+		// them; and a steer does not interrupt the turn, which was the only reason
+		// to defer.
 		return parsed.prompt;
 	}
 
@@ -4803,6 +4968,19 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.#cancelTodoAutoClearTimer();
 		this.#cancelObserverUiSyncTimer();
 		this.#cancelGoalContinuation();
+		// Loop timers outlive teardown otherwise: the interval callback keeps the
+		// stopped mode alive and can still submit/queue in long-lived embedding
+		// or test processes and on stop()-without-exit error paths.
+		this.#cancelLoopAutoSubmit();
+		this.#cancelLoopIntervalTimer();
+		// Also drop any reminder already sitting on the agent's queues: cancelling
+		// the timer only stops future ticks, but a steer queued by an earlier tick
+		// would still drain and run after teardown. Only when a loop actually ran —
+		// teardown must not reach into the agent's queues (or throw on a session
+		// that has none) just to clean up a loop that was never enabled.
+		if (this.loopModeEnabled || this.loopPrompt !== undefined) {
+			this.#clearQueuedLoopReminders();
+		}
 		if (this.#sttController) {
 			this.#sttController.dispose();
 			this.#sttController = undefined;

--- a/packages/coding-agent/src/modes/loop-limit.ts
+++ b/packages/coding-agent/src/modes/loop-limit.ts
@@ -17,7 +17,6 @@ export type LoopLimitRuntime =
 	| {
 			kind: "duration";
 			durationMs: number;
-			deadlineMs: number;
 	  };
 
 const TIME_UNITS_MS = new Map<string, number>([
@@ -139,43 +138,41 @@ function parseCompoundDuration(token: string): LoopLimitConfig | string | undefi
 	return { kind: "duration", durationMs: totalMs };
 }
 
-export function createLoopLimitRuntime(
-	config: LoopLimitConfig | undefined,
-	nowMs = Date.now(),
-): LoopLimitRuntime | undefined {
+export function createLoopLimitRuntime(config: LoopLimitConfig | undefined): LoopLimitRuntime | undefined {
 	if (!config) return undefined;
 	if (config.kind === "iterations") {
 		return { kind: "iterations", initial: config.iterations, remaining: config.iterations };
 	}
-	return { kind: "duration", durationMs: config.durationMs, deadlineMs: nowMs + config.durationMs };
+	return { kind: "duration", durationMs: config.durationMs };
 }
 
-export function consumeLoopLimitIteration(limit: LoopLimitRuntime | undefined, nowMs = Date.now()): boolean {
+export function consumeLoopLimitIteration(limit: LoopLimitRuntime | undefined): boolean {
 	if (!limit) return true;
-	if (limit.kind === "duration") {
-		return nowMs < limit.deadlineMs;
-	}
+	// Duration limits are firing intervals, not budgets: the interval timer
+	// governs cadence, so a tick is never "used up".
+	if (limit.kind === "duration") return true;
 	if (limit.remaining <= 0) return false;
 	limit.remaining -= 1;
 	return true;
 }
 
-export function isLoopDurationExpired(limit: LoopLimitRuntime | undefined, nowMs = Date.now()): boolean {
-	return limit?.kind === "duration" && nowMs >= limit.deadlineMs;
+/** Firing interval (ms) for a timer ("cron") loop, or undefined for a fire-on-stop loop. */
+export function getLoopIntervalMs(limit: LoopLimitRuntime | undefined): number | undefined {
+	return limit?.kind === "duration" ? limit.durationMs : undefined;
 }
 
 export function describeLoopLimit(config: LoopLimitConfig): string {
 	if (config.kind === "iterations") {
 		return `${config.iterations} ${config.iterations === 1 ? "iteration" : "iterations"}`;
 	}
-	return formatDuration(config.durationMs);
+	return `every ${formatDuration(config.durationMs)}`;
 }
 
 export function describeLoopLimitRuntime(limit: LoopLimitRuntime): string {
 	if (limit.kind === "iterations") {
 		return `${limit.remaining} of ${limit.initial} ${limit.initial === 1 ? "iteration" : "iterations"} remaining`;
 	}
-	return `${formatDuration(limit.durationMs)} limit`;
+	return `every ${formatDuration(limit.durationMs)}`;
 }
 
 function formatDuration(durationMs: number): string {

--- a/packages/coding-agent/src/modes/loop-limit.ts
+++ b/packages/coding-agent/src/modes/loop-limit.ts
@@ -17,7 +17,6 @@ export type LoopLimitRuntime =
 	| {
 			kind: "duration";
 			durationMs: number;
-			deadlineMs: number;
 	  };
 
 const TIME_UNITS_MS = new Map<string, number>([
@@ -39,6 +38,13 @@ const TIME_UNITS_MS = new Map<string, number>([
 ]);
 
 const LOOP_USAGE = "Usage: /loop [count|duration]. Examples: /loop 10, /loop 10m, /loop 10min.";
+
+// Node/Bun's setInterval/setTimeout delay is a signed 32-bit int internally;
+// a larger value doesn't wait longer, it clamps to firing almost immediately
+// (verified in Bun: a value above this fires on a ~1ms cadence instead of the
+// requested one). Reject rather than silently spam requests on overflow.
+const MAX_INTERVAL_MS = 2_147_483_647;
+const MAX_INTERVAL_MESSAGE = "Loop duration must not exceed 24 days (setInterval's 32-bit limit).";
 
 export interface ParsedLoopArgs {
 	/** Iteration/duration budget, when the user supplied a leading limit token. */
@@ -108,7 +114,9 @@ function makeDuration(amountText: string, unitMs: number): LoopLimitConfig | str
 	if (!Number.isSafeInteger(amount) || amount <= 0) {
 		return "Loop duration must be positive.";
 	}
-	return { kind: "duration", durationMs: amount * unitMs };
+	const durationMs = amount * unitMs;
+	if (durationMs > MAX_INTERVAL_MS) return MAX_INTERVAL_MESSAGE;
+	return { kind: "duration", durationMs };
 }
 
 /**
@@ -136,46 +144,45 @@ function parseCompoundDuration(token: string): LoopLimitConfig | string | undefi
 		totalMs += amount * unitMs;
 	}
 	if (totalMs <= 0) return "Loop duration must be positive.";
+	if (totalMs > MAX_INTERVAL_MS) return MAX_INTERVAL_MESSAGE;
 	return { kind: "duration", durationMs: totalMs };
 }
 
-export function createLoopLimitRuntime(
-	config: LoopLimitConfig | undefined,
-	nowMs = Date.now(),
-): LoopLimitRuntime | undefined {
+export function createLoopLimitRuntime(config: LoopLimitConfig | undefined): LoopLimitRuntime | undefined {
 	if (!config) return undefined;
 	if (config.kind === "iterations") {
 		return { kind: "iterations", initial: config.iterations, remaining: config.iterations };
 	}
-	return { kind: "duration", durationMs: config.durationMs, deadlineMs: nowMs + config.durationMs };
+	return { kind: "duration", durationMs: config.durationMs };
 }
 
-export function consumeLoopLimitIteration(limit: LoopLimitRuntime | undefined, nowMs = Date.now()): boolean {
+export function consumeLoopLimitIteration(limit: LoopLimitRuntime | undefined): boolean {
 	if (!limit) return true;
-	if (limit.kind === "duration") {
-		return nowMs < limit.deadlineMs;
-	}
+	// Duration limits are firing intervals, not budgets: the interval timer
+	// governs cadence, so a tick is never "used up".
+	if (limit.kind === "duration") return true;
 	if (limit.remaining <= 0) return false;
 	limit.remaining -= 1;
 	return true;
 }
 
-export function isLoopDurationExpired(limit: LoopLimitRuntime | undefined, nowMs = Date.now()): boolean {
-	return limit?.kind === "duration" && nowMs >= limit.deadlineMs;
+/** Firing interval (ms) for a timer ("cron") loop, or undefined for a fire-on-stop loop. */
+export function getLoopIntervalMs(limit: LoopLimitRuntime | undefined): number | undefined {
+	return limit?.kind === "duration" ? limit.durationMs : undefined;
 }
 
 export function describeLoopLimit(config: LoopLimitConfig): string {
 	if (config.kind === "iterations") {
 		return `${config.iterations} ${config.iterations === 1 ? "iteration" : "iterations"}`;
 	}
-	return formatDuration(config.durationMs);
+	return `every ${formatDuration(config.durationMs)}`;
 }
 
 export function describeLoopLimitRuntime(limit: LoopLimitRuntime): string {
 	if (limit.kind === "iterations") {
 		return `${limit.remaining} of ${limit.initial} ${limit.initial === 1 ? "iteration" : "iterations"} remaining`;
 	}
-	return `${formatDuration(limit.durationMs)} limit`;
+	return `every ${formatDuration(limit.durationMs)}`;
 }
 
 function formatDuration(durationMs: number): string {

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -509,6 +509,7 @@ export interface InteractiveModeContext {
 	handleGuidedGoalCommand(rest?: string, input?: Pick<SubmittedUserInput, "images" | "imageLinks">): Promise<boolean>;
 	handleLoopCommand(args?: string): Promise<string | undefined>;
 	setLoopPrompt(prompt: string): void;
+	dropQueuedLoopReminders(): void;
 	disableLoopMode(message?: string): void;
 	cancelGoalContinuation(): void;
 	disableGoalMode(message?: string): void;

--- a/packages/coding-agent/src/slash-commands/builtin-modes.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-modes.ts
@@ -316,7 +316,7 @@ export const BUILTIN_MODE_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> = [
 		name: "loop",
 		icon: "loop",
 		description:
-			"Toggle loop mode. While enabled, the next prompt you send re-submits after every yield. Esc cancels the current iteration; /loop again to disable.",
+			"Toggle loop mode. A count/unbounded loop re-submits the prompt after every yield; a duration (e.g. 30s, 10m) instead reminds on that fixed interval — chaining a non-interrupting nudge onto a live turn, or nudging when idle. Esc cancels the current iteration; /loop again to disable.",
 		inlineHint: "[count|duration] [prompt]",
 		allowArgs: true,
 		getTuiAutocompleteDescription: runtime => {

--- a/packages/coding-agent/src/slash-commands/builtin-modes.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-modes.ts
@@ -289,7 +289,7 @@ export const BUILTIN_MODE_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> = [
 		name: "loop",
 		icon: "loop",
 		description:
-			"Toggle loop mode. While enabled, the next prompt you send re-submits after every yield. Esc cancels the current iteration; /loop again to disable.",
+			"Toggle loop mode. A count/unbounded loop re-submits the prompt after every yield; a duration (e.g. 30s, 10m) instead fires on that fixed interval — steering the prompt into a turn that is still working, or submitting it when the agent has stopped. Esc cancels the current iteration; /loop again to disable.",
 		inlineHint: "[count|duration] [prompt]",
 		allowArgs: true,
 		getTuiAutocompleteDescription: runtime => {

--- a/packages/coding-agent/test/input-controller-escape.test.ts
+++ b/packages/coding-agent/test/input-controller-escape.test.ts
@@ -65,6 +65,7 @@ function createContext(): {
 		cancelPendingSubmission: Spy;
 		clearEditor: Spy;
 		clearQueue: Spy;
+		dropQueuedLoopReminders: Spy;
 		flushSync: Spy;
 		getQueuedMessages: Spy;
 		ensureLoadingAnimation: Spy;
@@ -92,6 +93,7 @@ function createContext(): {
 	const abortHandoff = vi.fn();
 	const addMessageToChat = vi.fn();
 	const cancelPendingSubmission = vi.fn(() => false);
+	const dropQueuedLoopReminders = vi.fn();
 	const clearQueue = vi.fn(() => ({ steering: [], followUp: [] }));
 	const getQueuedMessages = vi.fn(() => ({ steering: [], followUp: [] }));
 	const onInputCallback = vi.fn();
@@ -227,6 +229,7 @@ function createContext(): {
 		showSessionSelector: vi.fn(),
 		shutdown: vi.fn(async () => {}),
 		clearEditor: vi.fn(),
+		dropQueuedLoopReminders,
 		showStatus,
 	} as unknown as InteractiveModeContext;
 
@@ -235,6 +238,7 @@ function createContext(): {
 		editor,
 		spies: {
 			abort,
+			dropQueuedLoopReminders,
 			abortBash,
 			abortEval,
 			abortHandoff,
@@ -555,6 +559,28 @@ describe("InputController escape behavior", () => {
 		expect(spies.abort).toHaveBeenCalledTimes(1);
 		expect(spies.abort).toHaveBeenCalledWith({ reason: USER_INTERRUPT_LABEL });
 		expect(spies.showStatus).not.toHaveBeenCalledWith("Press Esc again within 2s to cancel streaming.");
+	});
+
+	it("drops a queued loop reminder before aborting, so Esc is not undone by the steer", () => {
+		const { ctx, editor } = createContext();
+		mutableSessionState(ctx).isStreaming = true;
+		// Order is the contract, not just the call: abort()'s stranded-message drain
+		// reads the steering queue, and #canAutoContinueForFollowUp resumes on any
+		// queued steer before it consults the user-interrupt suppression. Dropping
+		// the reminder after the abort would let it restart the run Esc just stopped.
+		const order: string[] = [];
+		ctx.dropQueuedLoopReminders = vi.fn(() => {
+			order.push("drop");
+		});
+		(ctx.session as unknown as { abort: () => void }).abort = vi.fn(() => {
+			order.push("abort");
+		});
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+		editor.onEscape?.();
+
+		expect(order).toEqual(["drop", "abort"]);
 	});
 
 	it("aborts the submitted turn on the first Esc once the main session starts streaming", async () => {

--- a/packages/coding-agent/test/input-controller-loop-inline.test.ts
+++ b/packages/coding-agent/test/input-controller-loop-inline.test.ts
@@ -1,0 +1,119 @@
+import { beforeAll, describe, expect, it, vi } from "bun:test";
+import type { ImageContent } from "@oh-my-pi/pi-ai";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { InputController } from "@oh-my-pi/pi-coding-agent/modes/controllers/input-controller";
+import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
+
+/**
+ * An inline `/loop <duration> <prompt>` goes out through the normal submit path
+ * even while a turn is streaming, so it is steered in *with its attachments*.
+ *
+ * Withholding it for the first interval tick instead would consume the command
+ * and strand its images in the composer, where `/loop` has already cleared the
+ * `[Image #N]` markers that keep them alive (InputController#compactDraftImages
+ * drops images no marker references). This covers the dispatcher → controller
+ * hop; the returned-prompt contract itself is covered in the mode's own tests.
+ */
+function createContext(opts: { isStreaming: boolean }) {
+	let editorText = "";
+	const prompt = vi.fn(async (_text: string, _options?: unknown) => {});
+	const handleLoopCommand = vi.fn(
+		async (args?: string) =>
+			// Mirrors InteractiveMode: the residual after the limit token is handed
+			// back for a normal first submission.
+			args?.split(" ").slice(1).join(" ") || undefined,
+	);
+	const setLoopPrompt = vi.fn();
+	const editor = {
+		setText(text: string) {
+			editorText = text;
+		},
+		setCollapsedText(text: string) {
+			editorText = text;
+		},
+		getText: () => editorText,
+		getExpandedText: () => editorText,
+		clearDraft: vi.fn(),
+		addToHistory: vi.fn(),
+		pendingImages: [] as ImageContent[],
+		pendingImageLinks: [] as (string | undefined)[],
+		imageLinks: undefined as (string | undefined)[] | undefined,
+	};
+	const ctx = {
+		editor,
+		ui: { requestRender: vi.fn() },
+		skillCommands: new Map(),
+		fileSlashCommands: new Set<string>(),
+		session: {
+			isStreaming: opts.isStreaming,
+			isCompacting: false,
+			isBashRunning: false,
+			isEvalRunning: false,
+			extensionRunner: undefined,
+			customCommands: [],
+			promptTemplates: [],
+			prompt,
+			maybeStartTitleGeneration: vi.fn(),
+		},
+		get viewSession() {
+			return (this as typeof ctx).session;
+		},
+		handleLoopCommand,
+		setLoopPrompt,
+		loopModeEnabled: false,
+		isBashMode: false,
+		isPythonMode: false,
+		compactionQueuedMessages: [],
+		locallySubmittedUserSignatures: new Set<string>(),
+		withLocalSubmission: async (_text: string, run: () => Promise<unknown>) => {
+			await run();
+		},
+		updateEditorBorderColor: vi.fn(),
+		updatePendingMessagesDisplay: vi.fn(),
+		showError: vi.fn(),
+		showWarning: vi.fn(),
+		queueCompactionMessage: vi.fn(),
+	} as unknown as InteractiveModeContext;
+	return { ctx, editor, prompt, handleLoopCommand, setLoopPrompt };
+}
+
+beforeAll(async () => {
+	await Settings.init({ inMemory: true });
+});
+
+describe("inline /loop submission", () => {
+	it("steers a busy inline /loop's prompt in with its attachment", async () => {
+		const { ctx, editor, prompt, handleLoopCommand } = createContext({
+			isStreaming: true,
+		});
+		const image = {
+			type: "image",
+			data: "aGk=",
+			mimeType: "image/png",
+		} as unknown as ImageContent;
+		editor.pendingImages = [image];
+		editor.pendingImageLinks = [undefined];
+		const controller = new InputController(ctx);
+		controller.setupEditorSubmitHandler();
+		// The composer puts an `[Image #N]` marker in the text when an image is
+		// attached; that marker is what keeps the image alive through
+		// #compactDraftImages at submit time.
+		await (
+			editor as unknown as { onSubmit?: (text: string) => Promise<void> }
+		).onSubmit?.("/loop 30s look at this [Image #1]");
+
+		expect(handleLoopCommand).toHaveBeenCalledWith(
+			"30s look at this [Image #1]",
+		);
+		// The prompt reaches the live turn as a steer, carrying the image that was
+		// submitted with the command — not text-only, and not withheld.
+		expect(prompt).toHaveBeenCalledTimes(1);
+		expect(prompt.mock.calls[0]?.[0]).toBe("look at this [Image #1]");
+		expect(prompt.mock.calls[0]?.[1]).toMatchObject({
+			streamingBehavior: "steer",
+			images: [image],
+		});
+		// Consumed from the composer by that submission.
+		expect(editor.pendingImages).toEqual([]);
+	});
+});

--- a/packages/coding-agent/test/interactive-mode-loop.test.ts
+++ b/packages/coding-agent/test/interactive-mode-loop.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
 import * as path from "node:path";
-import { Agent } from "@oh-my-pi/pi-agent-core";
+import { Agent, type AgentMessage } from "@oh-my-pi/pi-agent-core";
+import type { ImageContent } from "@oh-my-pi/pi-ai";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { resetSettingsForTest, Settings, settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { InteractiveMode } from "@oh-my-pi/pi-coding-agent/modes/interactive-mode";
@@ -15,6 +16,20 @@ async function flushMicrotasks(): Promise<void> {
 	await Promise.resolve();
 	await Promise.resolve();
 	await Promise.resolve();
+}
+
+const isLoopReminder = (m: AgentMessage): m is Extract<AgentMessage, { role: "custom" }> =>
+	m.role === "custom" && m.customType === "loop-reminder";
+
+/** Reminders delivered into a live run MUST be steers, so this scans only the
+ *  steering queue — a regression to follow-up delivery has to fail here. */
+function steeredReminders(session: AgentSession): Extract<AgentMessage, { role: "custom" }>[] {
+	return session.agent.peekSteeringQueue().filter(isLoopReminder);
+}
+
+/** Every queue, for cleanup assertions where nothing may survive anywhere. */
+function anyQueuedReminders(session: AgentSession): Extract<AgentMessage, { role: "custom" }>[] {
+	return [...session.agent.peekSteeringQueue(), ...session.agent.peekFollowUpQueue()].filter(isLoopReminder);
 }
 
 describe("InteractiveMode loop auto-submit", () => {
@@ -156,6 +171,80 @@ describe("InteractiveMode loop auto-submit", () => {
 		expect(resolved[0].text).toBe("deliver this");
 	});
 
+	it("starts an interval loop's cadence at its first prompt, not when /loop was typed", async () => {
+		vi.useFakeTimers();
+		Object.defineProperty(session, "isCompacting", {
+			configurable: true,
+			get: () => false,
+		});
+		Object.defineProperty(session, "isStreaming", {
+			configurable: true,
+			get: () => false,
+		});
+
+		// Bare `/loop 30s`: there is no instruction to deliver yet.
+		await mode.handleLoopCommand("30s");
+		mode.editor.setText("");
+		const resolved: SubmittedUserInput[] = [];
+		pendingInput = mode.getUserInput();
+		void pendingInput.then((input) => resolved.push(input));
+
+		// Deliberately not a multiple of the interval: if the clock had started at
+		// command entry, its next tick would land inside the 29s window below.
+		vi.advanceTimersByTime(100_000);
+		await flushMicrotasks();
+		// Ticks before a prompt exists would be dropped anyway; the clock must not
+		// have been spending the user's typing time either.
+		expect(resolved).toHaveLength(0);
+
+		mode.setLoopPrompt("keep going");
+		vi.advanceTimersByTime(29_000);
+		await flushMicrotasks();
+		expect(resolved).toHaveLength(0);
+
+		vi.advanceTimersByTime(1_000);
+		await flushMicrotasks();
+		expect(resolved).toHaveLength(1);
+		expect(resolved[0]?.text).toBe("keep going");
+	});
+
+	it("drops a queued interval reminder on a user interrupt, leaving other queued work alone", async () => {
+		vi.useFakeTimers();
+		Object.defineProperty(session, "isCompacting", {
+			configurable: true,
+			get: () => false,
+		});
+		Object.defineProperty(session, "isStreaming", {
+			configurable: true,
+			get: () => true,
+		});
+
+		await mode.handleLoopCommand("30s remind me");
+		mode.setLoopPrompt("remind me");
+		vi.advanceTimersByTime(30_000);
+		await flushMicrotasks();
+		// A real user steer queued alongside it must survive.
+		const userSteer = {
+			role: "user" as const,
+			content: "mine",
+			steering: true,
+			attribution: "user" as const,
+			timestamp: Date.now(),
+		} as unknown as AgentMessage;
+		session.agent.replaceQueues(
+			[...session.agent.peekSteeringQueue(), userSteer],
+			[],
+		);
+		expect(steeredReminders(session)).toHaveLength(1);
+
+		// Esc routes here. A reminder left queued would make the abort's drain
+		// resume immediately, since any queued steer bypasses interrupt suppression.
+		mode.dropQueuedLoopReminders();
+
+		expect(anyQueuedReminders(session)).toEqual([]);
+		expect(session.agent.peekSteeringQueue()).toEqual([userSteer]);
+	});
+
 	it("disables reset loops when vibe blocks the session transition", async () => {
 		vi.useFakeTimers();
 		settings.set("loop.mode", "reset");
@@ -205,5 +294,247 @@ describe("InteractiveMode loop auto-submit", () => {
 
 		mode.disableLoopMode();
 		expect(setLoopModeStatus).toHaveBeenLastCalledWith(undefined);
+	});
+
+	it("hands an interval loop's inline prompt to the normal submit path, busy or idle", async () => {
+		Object.defineProperty(session, "isCompacting", {
+			configurable: true,
+			get: () => false,
+		});
+		let streaming = false;
+		Object.defineProperty(session, "isStreaming", {
+			configurable: true,
+			get: () => streaming,
+		});
+
+		// Idle: submitted immediately. loopPrompt is recorded by the submit path,
+		// not pre-set here.
+		expect(await mode.handleLoopCommand("30s do it now")).toBe("do it now");
+		expect(mode.loopPrompt).toBeUndefined();
+		mode.disableLoopMode();
+
+		// Busy: also handed back. It goes out like any typed prompt — steered into
+		// the live turn, carrying its own attachments — and the interval nudges from
+		// there. Withholding it here would consume the command and orphan those
+		// attachments in the composer, where `/loop` has already cleared the
+		// `[Image #N]` markers that keep them alive.
+		streaming = true;
+		expect(await mode.handleLoopCommand("30s do it now")).toBe("do it now");
+		mode.disableLoopMode();
+
+		Object.defineProperty(session, "isCompacting", {
+			configurable: true,
+			get: () => true,
+		});
+		streaming = false;
+		expect(await mode.handleLoopCommand("30s do it later")).toBe("do it later");
+	});
+
+	it("keeps a composer attachment out of an interval reminder, since reminders are text-only", async () => {
+		vi.useFakeTimers();
+		Object.defineProperty(session, "isCompacting", {
+			configurable: true,
+			get: () => false,
+		});
+		Object.defineProperty(session, "isStreaming", {
+			configurable: true,
+			get: () => false,
+		});
+		const image = {
+			type: "image",
+			data: "aGk=",
+			mimeType: "image/png",
+		} as unknown as ImageContent;
+
+		await mode.handleLoopCommand("30s keep going");
+		mode.setLoopPrompt("keep going");
+		mode.editor.setText("");
+		// An attachment in the composer belongs to the user's next message. The
+		// reminder must neither consume it nor stall behind it forever.
+		mode.editor.pendingImages = [image];
+		mode.editor.pendingImageLinks = [undefined];
+
+		const resolved: SubmittedUserInput[] = [];
+		pendingInput = mode.getUserInput();
+		void pendingInput.then((input) => resolved.push(input));
+		vi.advanceTimersByTime(30_000);
+		await flushMicrotasks();
+
+		expect(resolved).toHaveLength(0);
+		expect(mode.editor.pendingImages).toEqual([image]);
+
+		// Once the composer is clear the reminder goes out, text only.
+		mode.editor.pendingImages = [];
+		mode.editor.pendingImageLinks = [];
+		vi.advanceTimersByTime(30_000);
+		await flushMicrotasks();
+		expect(resolved).toHaveLength(1);
+		expect(resolved[0]?.text).toBe("keep going");
+		expect(resolved[0]?.images).toBeUndefined();
+	});
+
+	it("steers one reminder per interval into a streaming turn, never duplicating it", async () => {
+		vi.useFakeTimers();
+		Object.defineProperty(session, "isCompacting", { configurable: true, get: () => false });
+		Object.defineProperty(session, "isStreaming", { configurable: true, get: () => true });
+
+		// The inline prompt goes out through the normal submit path, which is what
+		// records it as the loop prompt; stand in for that here.
+		await mode.handleLoopCommand("30s remind me");
+		mode.setLoopPrompt("remind me");
+
+		vi.advanceTimersByTime(30_000);
+		await flushMicrotasks();
+		// Steered, so it reaches the live run instead of waiting for it to end.
+		expect(steeredReminders(session)).toHaveLength(1);
+		expect(session.agent.peekFollowUpQueue().filter(isLoopReminder)).toEqual([]);
+
+		// A second tick before the first reminder is consumed (still streaming)
+		// must not pile up a duplicate.
+		vi.advanceTimersByTime(30_000);
+		await flushMicrotasks();
+		expect(steeredReminders(session)).toHaveLength(1);
+	});
+
+	it("steers again each interval once the agent has consumed the previous one, so a long turn is steered repeatedly", async () => {
+		vi.useFakeTimers();
+		Object.defineProperty(session, "isCompacting", { configurable: true, get: () => false });
+		Object.defineProperty(session, "isStreaming", { configurable: true, get: () => true });
+
+		await mode.handleLoopCommand("30m keep going");
+		mode.setLoopPrompt("keep going");
+
+		// One long turn spanning two hours on a 30-minute interval: the agent
+		// consumes each steer at a provider boundary, so the next tick delivers the
+		// next one. Four ticks must produce four deliveries, not one.
+		let delivered = 0;
+		for (let i = 0; i < 4; i++) {
+			vi.advanceTimersByTime(30 * 60_000);
+			await flushMicrotasks();
+			delivered += steeredReminders(session).length;
+			// Agent consumes it mid-run.
+			session.agent.replaceQueues([], []);
+		}
+
+		expect(delivered).toBe(4);
+	});
+
+	it("drops a still-queued interval reminder when the loop is disabled", async () => {
+		vi.useFakeTimers();
+		Object.defineProperty(session, "isCompacting", { configurable: true, get: () => false });
+		Object.defineProperty(session, "isStreaming", { configurable: true, get: () => true });
+
+		await mode.handleLoopCommand("30s remind me");
+		mode.setLoopPrompt("remind me");
+		vi.advanceTimersByTime(30_000);
+		await flushMicrotasks();
+		expect(steeredReminders(session)).toHaveLength(1);
+
+		mode.disableLoopMode();
+
+		expect(anyQueuedReminders(session)).toEqual([]);
+	});
+
+	it("drops a stale queued reminder and queues fresh content when the loop prompt changes mid-turn", async () => {
+		vi.useFakeTimers();
+		Object.defineProperty(session, "isCompacting", { configurable: true, get: () => false });
+		Object.defineProperty(session, "isStreaming", { configurable: true, get: () => true });
+
+		await mode.handleLoopCommand("30s remind me");
+		mode.setLoopPrompt("remind me");
+		vi.advanceTimersByTime(30_000);
+		await flushMicrotasks();
+		expect(steeredReminders(session).map(m => m.content)).toEqual(["remind me"]);
+
+		// The user replaces the loop prompt before the queued reminder drains —
+		// the stale "remind me" reminder must not survive to fire after the fact.
+		mode.setLoopPrompt("new instructions");
+		expect(anyQueuedReminders(session)).toEqual([]);
+
+		vi.advanceTimersByTime(30_000);
+		await flushMicrotasks();
+		expect(steeredReminders(session).map(m => m.content)).toEqual(["new instructions"]);
+	});
+
+	it("consumes a reminder retained across an interrupted turn so one cadence produces one turn", async () => {
+		vi.useFakeTimers();
+		Object.defineProperty(session, "isCompacting", { configurable: true, get: () => false });
+		let streaming = true;
+		Object.defineProperty(session, "isStreaming", { configurable: true, get: () => streaming });
+
+		await mode.handleLoopCommand("30s remind me");
+		mode.setLoopPrompt("remind me");
+		vi.advanceTimersByTime(30_000);
+		await flushMicrotasks();
+		expect(steeredReminders(session)).toHaveLength(1);
+
+		// The user interrupts (Esc) before the reminder is consumed: the session
+		// deliberately retains the hidden message while suppressing auto-resume.
+		streaming = false;
+		mode.editor.setText("");
+
+		const resolved: SubmittedUserInput[] = [];
+		pendingInput = mode.getUserInput();
+		void pendingInput.then(input => resolved.push(input));
+
+		vi.advanceTimersByTime(30_000);
+		await flushMicrotasks();
+
+		// The visible submission *is* this tick. Leaving the retained reminder
+		// queued would re-enable auto-resume and drain it after the new turn —
+		// two model turns running the same loop instruction for one cadence.
+		expect(resolved).toHaveLength(1);
+		expect(resolved[0]?.text).toBe("remind me");
+		expect(anyQueuedReminders(session)).toEqual([]);
+	});
+
+	it("skips an idle interval tick while the user is composing, preserving the draft until the composer clears", async () => {
+		vi.useFakeTimers();
+		Object.defineProperty(session, "isCompacting", { configurable: true, get: () => false });
+		Object.defineProperty(session, "isStreaming", { configurable: true, get: () => false });
+
+		await mode.handleLoopCommand("30s do it");
+		mode.setLoopPrompt("do it");
+		mode.editor.setText("half-typed draft");
+
+		const resolved: SubmittedUserInput[] = [];
+		pendingInput = mode.getUserInput();
+		void pendingInput.then(input => resolved.push(input));
+
+		vi.advanceTimersByTime(30_000);
+		await flushMicrotasks();
+		// A tick that submitted here would clear the draft via startPendingSubmission.
+		expect(resolved).toHaveLength(0);
+		expect(mode.editor.getText()).toBe("half-typed draft");
+
+		mode.editor.setText("");
+		vi.advanceTimersByTime(30_000);
+		await flushMicrotasks();
+		expect(resolved).toHaveLength(1);
+		expect(resolved[0].text).toBe("do it");
+	});
+
+	// Final test: it calls mode.stop(), permanently tearing down the shared
+	// harness instance, so nothing after it may reuse mode.
+	it("cancels the timer and drops an already-queued reminder on stop() so nothing fires after teardown", async () => {
+		vi.useFakeTimers();
+		Object.defineProperty(session, "isCompacting", { configurable: true, get: () => false });
+		Object.defineProperty(session, "isStreaming", { configurable: true, get: () => true });
+
+		await mode.handleLoopCommand("30s remind me");
+		mode.setLoopPrompt("remind me");
+
+		// Let one tick queue a reminder onto the live turn before teardown.
+		vi.advanceTimersByTime(30_000);
+		await flushMicrotasks();
+		expect(steeredReminders(session)).toHaveLength(1);
+
+		mode.stop();
+
+		// Teardown must both drop the queued reminder and stop future ticks.
+		expect(anyQueuedReminders(session)).toEqual([]);
+		vi.advanceTimersByTime(120_000);
+		await flushMicrotasks();
+		expect(anyQueuedReminders(session)).toEqual([]);
 	});
 });

--- a/packages/coding-agent/test/loop-limit.test.ts
+++ b/packages/coding-agent/test/loop-limit.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test, vi } from "bun:test";
 import {
 	consumeLoopLimitIteration,
 	createLoopLimitRuntime,
-	isLoopDurationExpired,
+	getLoopIntervalMs,
 	parseLoopLimitArgs,
 } from "@oh-my-pi/pi-coding-agent/modes/loop-limit";
 import type { BuiltinSlashCommandRuntime } from "@oh-my-pi/pi-coding-agent/slash-commands/builtin-registry";
@@ -100,15 +100,16 @@ describe("loop limit runtime", () => {
 		expect(limit).toEqual({ kind: "iterations", initial: 3, remaining: 0 });
 	});
 
-	test("stops duration-limited loops at the configured deadline", () => {
+	test("treats a duration limit as a firing interval that never expires or consumes budget", () => {
 		const parsed = parseLoopLimitArgs("10m");
 		if (typeof parsed === "string" || !parsed.limit) throw new Error("expected parsed limit");
 		expect(parsed.limit).toEqual({ kind: "duration", durationMs: 600_000 });
 
-		const limit = createLoopLimitRuntime(parsed.limit, 1_000);
-		expect(consumeLoopLimitIteration(limit, 600_999)).toBe(true);
-		expect(isLoopDurationExpired(limit, 600_999)).toBe(false);
-		expect(consumeLoopLimitIteration(limit, 601_000)).toBe(false);
-		expect(isLoopDurationExpired(limit, 601_000)).toBe(true);
+		const limit = createLoopLimitRuntime(parsed.limit);
+		expect(getLoopIntervalMs(limit)).toBe(600_000);
+		// Cadence is owned by the interval timer, not this budget check: every
+		// tick is allowed, indefinitely.
+		expect(consumeLoopLimitIteration(limit)).toBe(true);
+		expect(consumeLoopLimitIteration(limit)).toBe(true);
 	});
 });

--- a/packages/coding-agent/test/loop-limit.test.ts
+++ b/packages/coding-agent/test/loop-limit.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test, vi } from "bun:test";
 import {
 	consumeLoopLimitIteration,
 	createLoopLimitRuntime,
-	isLoopDurationExpired,
+	getLoopIntervalMs,
 	parseLoopLimitArgs,
 } from "@oh-my-pi/pi-coding-agent/modes/loop-limit";
 import type { BuiltinSlashCommandRuntime } from "@oh-my-pi/pi-coding-agent/slash-commands/builtin-registry";
@@ -84,6 +84,15 @@ describe("loop limit parsing", () => {
 		expect(parseLoopLimitArgs("-1")).toContain("Usage: /loop");
 		expect(parseLoopLimitArgs("10fortnights")).toBe("Loop duration unit must be seconds, minutes, or hours.");
 	});
+
+	test("rejects durations that would overflow setInterval's 32-bit delay and clamp to a near-immediate cadence", () => {
+		// 597h = 2,149,200,000ms, just above the 2,147,483,647ms signed-32-bit max — compact-duration path.
+		expect(parseLoopLimitArgs("597h")).toBe("Loop duration must not exceed 24 days (setInterval's 32-bit limit).");
+		// Space-separated "N minutes" form — exercises the bare-integer-plus-unit path instead.
+		expect(parseLoopLimitArgs("2147484 minutes")).toBe(
+			"Loop duration must not exceed 24 days (setInterval's 32-bit limit).",
+		);
+	});
 });
 
 describe("loop limit runtime", () => {
@@ -100,15 +109,16 @@ describe("loop limit runtime", () => {
 		expect(limit).toEqual({ kind: "iterations", initial: 3, remaining: 0 });
 	});
 
-	test("stops duration-limited loops at the configured deadline", () => {
+	test("treats a duration limit as a firing interval that never expires or consumes budget", () => {
 		const parsed = parseLoopLimitArgs("10m");
 		if (typeof parsed === "string" || !parsed.limit) throw new Error("expected parsed limit");
 		expect(parsed.limit).toEqual({ kind: "duration", durationMs: 600_000 });
 
-		const limit = createLoopLimitRuntime(parsed.limit, 1_000);
-		expect(consumeLoopLimitIteration(limit, 600_999)).toBe(true);
-		expect(isLoopDurationExpired(limit, 600_999)).toBe(false);
-		expect(consumeLoopLimitIteration(limit, 601_000)).toBe(false);
-		expect(isLoopDurationExpired(limit, 601_000)).toBe(true);
+		const limit = createLoopLimitRuntime(parsed.limit);
+		expect(getLoopIntervalMs(limit)).toBe(600_000);
+		// Cadence is owned by the interval timer, not this budget check: every
+		// tick is allowed, indefinitely.
+		expect(consumeLoopLimitIteration(limit)).toBe(true);
+		expect(consumeLoopLimitIteration(limit)).toBe(true);
 	});
 });

--- a/packages/coding-agent/test/status-line-loop.test.ts
+++ b/packages/coding-agent/test/status-line-loop.test.ts
@@ -65,18 +65,16 @@ describe("status line loop mode segment", () => {
 		expect(Bun.stripANSI(rendered.content)).toBe(withIcon(theme.icon.loop, "Loop waiting 10/10"));
 	});
 
-	it("shows the live remaining duration while a loop is running", () => {
-		const now = Date.parse("2026-07-17T12:00:00Z");
-		vi.spyOn(Date, "now").mockReturnValue(now);
+	it("shows the firing interval while a duration-limited loop is running", () => {
 		const rendered = renderSegment(
 			"mode",
 			createContext({
 				state: "running",
-				limit: { kind: "duration", durationMs: 90_000, deadlineMs: now + 90_000 },
+				limit: { kind: "duration", durationMs: 90_000 },
 			}),
 		);
 
-		expect(Bun.stripANSI(rendered.content)).toBe(withIcon(theme.icon.loop, "Loop running 1m30s left"));
+		expect(Bun.stripANSI(rendered.content)).toBe(withIcon(theme.icon.loop, "Loop running every 1m30s"));
 	});
 
 	it("distinguishes a paused loop from an active loop", () => {

--- a/packages/coding-agent/test/status-line-loop.test.ts
+++ b/packages/coding-agent/test/status-line-loop.test.ts
@@ -66,18 +66,16 @@ describe("status line loop mode segment", () => {
 		expect(Bun.stripANSI(rendered.content)).toBe(withIcon(theme.icon.loop, "Loop waiting 10/10"));
 	});
 
-	it("shows the live remaining duration while a loop is running", () => {
-		const now = Date.parse("2026-07-17T12:00:00Z");
-		vi.spyOn(Date, "now").mockReturnValue(now);
+	it("shows the firing interval while a duration-limited loop is running", () => {
 		const rendered = renderSegment(
 			"mode",
 			createContext({
 				state: "running",
-				limit: { kind: "duration", durationMs: 90_000, deadlineMs: now + 90_000 },
+				limit: { kind: "duration", durationMs: 90_000 },
 			}),
 		);
 
-		expect(Bun.stripANSI(rendered.content)).toBe(withIcon(theme.icon.loop, "Loop running 1m30s left"));
+		expect(Bun.stripANSI(rendered.content)).toBe(withIcon(theme.icon.loop, "Loop running every 1m30s"));
 	});
 
 	it("distinguishes a paused loop from an active loop", () => {


### PR DESCRIPTION
> **Note:** this PR was reshaped after review. Earlier discussion in the thread evaluated a follow-up-based delivery and a "duration = time budget" reading; both were replaced. This description reflects what the branch actually does now, and the branch is squashed to a single commit.

## Problem

A duration-limited `/loop` could only deliver its prompt once the agent had **fully stopped**. The auto-submit path runs from `getUserInput()`, whose `onInputCallback` exists only while idle, so:

- a long turn received nothing while it worked — no way to nudge an agent mid-task;
- every iteration started a brand-new turn, discarding the provider's cached prefix;
- the duration acted as a total budget, disabling the loop once it elapsed.

## Change

The duration token is now the **firing interval** (cron-style, no expiry), and delivery depends on what the agent is doing:

- **Streaming** → the prompt is **steered** in, so the agent loop injects it at the run's next provider-call boundary and carries on with its prefix intact. A two-hour turn on a 30-minute interval gets steered roughly four times.
- **Idle** → the same tick submits through the normal path. With nothing running, steering *is* just a prompt — that is what resumes the loop after a turn ends.

### Why steering and not a follow-up

A follow-up drains only when the run **ends**, so every tick during a long turn would collapse into a single late delivery — the interval would be meaningless for exactly the case it exists for. A queued steer is injected at the next provider call (`agent-session.ts`), which is what lets a live turn actually receive the instruction.

Consequence worth reviewing: a steered message lands on the **steering** queue, so the duplicate scan covers *both* queues. Scanning only follow-ups would let every tick during a long turn queue another copy.

### Supporting behavior

- One pending reminder at a time, so a turn longer than the interval never accumulates a burst that drains back-to-back.
- `disableLoopMode` / `pauseLoop` / `setLoopPrompt` retract a stale queued reminder; `stop()` cancels the timers **and** drops anything still queued, so nothing fires after teardown.
- Idle ticks preserve a draft being composed (skip while the editor holds text or a pending image), mirroring `#scheduleGoalContinuation`.
- Ticks during compaction/post-prompt work are skipped rather than risking a fresh-turn start and `AgentBusyError`; the next tick retries.
- Inline `/loop <duration> <prompt>` entered while the agent is busy is captured and delivered by the first tick instead of racing in as an immediate steer.
- Durations above `setInterval`'s 32-bit range (~24.8 days) are rejected at parse time instead of silently clamping to a ~1ms cadence.
- Count-based and unbounded loops keep the existing fire-on-stop behavior; `#scheduleLoopAutoSubmit` no-ops for interval loops so the two paths never double-fire. `compact`/`reset` modes still route through the idle path, since they rewrite context.

## Semantics change — needs a maintainer call

`/loop 10m` previously meant "loop until 10 minutes elapse, then stop." It now means "fire every 10 minutes." This is intentional and is the behavior being asked for (it matches how the equivalent feature behaves in Claude Code): a periodic nudge is what makes the interval useful mid-turn, and the old reading is what forced the stop-and-re-prompt.

If you would rather keep a time-budget mode, it needs new syntax and can be a follow-up — but the two readings cannot share one token.

## Non-goals

- No adaptive/self-rearming interval (considered and rejected — silent cadence mutation is a worse version of the bug being fixed).
- No change to count-based or unbounded loops.

## Validation

- `bun run check:types` clean; `bun test test/interactive-mode-loop.test.ts test/loop-limit.test.ts test/status-line-loop.test.ts` → 29/29 pass.
- Delivery tests assert the **steering** queue specifically and that the follow-up queue stays empty; cleanup tests scan both queues. Verified by mutation: switching delivery back to `followUp` fails **six** tests, including the repeated-steer scenario (four ticks across one long turn must produce four deliveries, not one).
- Covered: repeated steering across a long turn, dedupe, retraction on disable/pause/prompt-change, teardown via `stop()`, idle draft preservation, compaction deferral, interval parsing/overflow, and status-line rendering.

### Known gap

No test drives a real provider-backed run: `AgentSession.#emit` is private and the mode's subscription is wired inside `init()` (full TUI), so the timer→steer hop is exercised against the real `Agent` queues but not through a live streaming turn. Verified manually instead; flagging it rather than implying coverage.
