### PR TITLE
test(mnemopi): isolate local-llm Mnemopi instances on temp db paths

### DIFF
--- a/packages/mnemopi/test/local-llm.test.ts
+++ b/packages/mnemopi/test/local-llm.test.ts
@@ -1,7 +1,4 @@
 import { afterEach, describe, expect, it } from "bun:test";
-import { mkdtempSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
 import type { FetchImpl } from "@oh-my-pi/pi-ai";
 import { createMockModel, registerMockApi } from "@oh-my-pi/pi-ai/providers/mock";
 import {
@@ -22,18 +19,19 @@ import {
 } from "@oh-my-pi/pi-mnemopi/core/local-llm";
 import { Mnemopi } from "@oh-my-pi/pi-mnemopi/core/memory";
 import { withMnemopiRuntimeOptions } from "@oh-my-pi/pi-mnemopi/core/runtime-options";
+import { TempDir } from "@oh-my-pi/pi-utils";
 
 const OLD_ENV = { ...process.env };
 
-const tempRoots: string[] = [];
+const tempDirs: TempDir[] = [];
 
 // Per-test SQLite path so `new Mnemopi(...)` never touches the shared default
 // bank file. Full-workspace parallel runs otherwise contend on that single path
 // and throw SQLITE_BUSY at initBeam once busy_timeout is exceeded (#9886).
 function tempDbPath(): string {
-	const root = mkdtempSync(join(tmpdir(), "mnemopi-local-llm-"));
-	tempRoots.push(root);
-	return join(root, "mnemopi.db");
+	const tempDir = TempDir.createSync("@mnemopi-local-llm-");
+	tempDirs.push(tempDir);
+	return tempDir.join("mnemopi.db");
 }
 
 function restoreEnv(): void {
@@ -50,8 +48,8 @@ function restoreEnv(): void {
 afterEach(() => {
 	restoreEnv();
 	resetHostLlmBackendForTests();
-	while (tempRoots.length > 0) {
-		rmSync(tempRoots.pop() as string, { recursive: true, force: true });
+	for (const tempDir of tempDirs.splice(0)) {
+		tempDir.removeSync();
 	}
 });
 

--- a/packages/mnemopi/test/local-llm.test.ts
+++ b/packages/mnemopi/test/local-llm.test.ts
@@ -1,4 +1,7 @@
 import { afterEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { FetchImpl } from "@oh-my-pi/pi-ai";
 import { createMockModel, registerMockApi } from "@oh-my-pi/pi-ai/providers/mock";
 import {
@@ -22,6 +25,17 @@ import { withMnemopiRuntimeOptions } from "@oh-my-pi/pi-mnemopi/core/runtime-opt
 
 const OLD_ENV = { ...process.env };
 
+const tempRoots: string[] = [];
+
+// Per-test SQLite path so `new Mnemopi(...)` never touches the shared default
+// bank file. Full-workspace parallel runs otherwise contend on that single path
+// and throw SQLITE_BUSY at initBeam once busy_timeout is exceeded (#9886).
+function tempDbPath(): string {
+	const root = mkdtempSync(join(tmpdir(), "mnemopi-local-llm-"));
+	tempRoots.push(root);
+	return join(root, "mnemopi.db");
+}
+
 function restoreEnv(): void {
 	for (const key in process.env) {
 		if (!(key in OLD_ENV)) delete process.env[key];
@@ -36,6 +50,9 @@ function restoreEnv(): void {
 afterEach(() => {
 	restoreEnv();
 	resetHostLlmBackendForTests();
+	while (tempRoots.length > 0) {
+		rmSync(tempRoots.pop() as string, { recursive: true, force: true });
+	}
 });
 
 registerMockApi();
@@ -143,6 +160,7 @@ describe("local LLM TypeScript port", () => {
 			throw new Error("remote should not be called");
 		};
 		const memory = new Mnemopi({
+			dbPath: tempDbPath(),
 			llm: async (prompt, opts) => `fn:${prompt}:${opts?.maxTokens ?? 0}`,
 		});
 		try {
@@ -160,7 +178,7 @@ describe("local LLM TypeScript port", () => {
 		const model = createMockModel({
 			handler: () => ({ content: ["model summary"] }),
 		});
-		const memory = new Mnemopi({ llm: model });
+		const memory = new Mnemopi({ dbPath: tempDbPath(), llm: model });
 		try {
 			const text = await withMnemopiRuntimeOptions(memory.runtimeOptions, () => complete("hello"));
 			expect(text).toBe("model summary");
@@ -177,7 +195,7 @@ describe("local LLM TypeScript port", () => {
 			fetchCalls += 1;
 			throw new Error("remote should not be called");
 		};
-		const memory = new Mnemopi({ llm: false });
+		const memory = new Mnemopi({ dbPath: tempDbPath(), llm: false });
 		try {
 			const text = await withMnemopiRuntimeOptions(memory.runtimeOptions, () =>
 				complete("hello", 0.3, { fetch: fetchMock }),


### PR DESCRIPTION
## Repro
`packages/mnemopi/test/local-llm.test.ts` flakes with `SQLiteError: database is locked (SQLITE_BUSY)` at `initBeam` during full-workspace parallel runs (`bun scripts/ci-test-ts.ts all`, ~1 in 3). It passes in isolation because nothing else contends on the DB file. A minimal repro that pins the default path and holds a concurrent write lock on it reproduces the failure deterministically once `busy_timeout` (5s) is exceeded.

## Cause
The three `new Mnemopi({ llm })` constructions (`local-llm.test.ts:154`, `:176`, `:189`) passed neither `db` nor `dbPath`, so `resolveDbPath` (`packages/mnemopi/src/core/memory.ts:269`) returned `configuredDbPath()` — the single shared default bank file (`~/.hermes/mnemopi/data/mnemopi.db`). Concurrent package suites in the full-workspace run open and write that same file on init; WAL serializes writers, and when one holds the lock past `busy_timeout` the second open throws `SQLITE_BUSY`. PR #9364 blanked other default paths but not this test's.

## Fix
- Add a `tempDbPath()` helper (`mkdtempSync` under `tmpdir()`, matching `memory-facade.test.ts`) and pass its result as `dbPath` to all three `new Mnemopi` constructions, so each test owns an isolated SQLite file.
- Track the temp roots and `rmSync` them in `afterEach`.

## Verification
`bun test packages/mnemopi/test/local-llm.test.ts` → 10 pass, 0 fail. Each construction now resolves to a unique temp path, removing the shared-default contention. Fixes #9886