### PR TITLE
fix(tui): add conpty seam so terminal tests stay platform-hermetic

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- `ProcessTerminal` accepts a `conpty` option to force ConPTY-hosted behavior on or off, keeping terminal tests hermetic on WSL where live env detection would otherwise flip kitty-keyboard flags and write chunking ([#9887](https://github.com/can1357/oh-my-pi/issues/9887)).
+
 ## [18.0.7] - 2026-08-26
 
 ### Fixed

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -581,6 +581,17 @@ function isPrivateModeSupported(status: string): boolean {
 	return status !== "0" && status !== "4";
 }
 
+/** Construction-time overrides for {@link ProcessTerminal}. */
+export interface ProcessTerminalOptions {
+	/**
+	 * Force ConPTY-hosted behavior on or off. Defaults to live detection via
+	 * {@link isConPTYHosted}. Tests set this so the kitty-flag and write-chunking
+	 * paths stay hermetic regardless of the ambient WSL env (`WSL_DISTRO_NAME` /
+	 * `WSL_INTEROP`) — the suite must behave identically on WSL and on CI.
+	 */
+	conpty?: boolean;
+}
+
 /**
  * Real terminal using process.stdin/stdout
  */
@@ -619,6 +630,11 @@ export class ProcessTerminal implements Terminal {
 	// terminal side effect (writes, probes, raw mode, SIGWINCH, timers) is
 	// suppressed. Defaults on under `bun test` — see isTerminalHeadless().
 	#headless = isTerminalHeadless();
+	// Captured once at construction: whether stdout flows through a ConPTY
+	// pseudo-console. Gates the kitty-flag choice (#1216) and large-write
+	// chunking (#safeWrite). Live-detected by default; tests inject a fixed
+	// value so WSL env does not change behavior. See {@link ProcessTerminalOptions}.
+	readonly #conpty: boolean;
 	#writeLogPath = $env.PI_TUI_WRITE_LOG || "";
 	#stdoutErrorCleanup?: () => void;
 	#stdoutErrorHandler = (err: Error) => {
@@ -673,6 +689,10 @@ export class ProcessTerminal implements Terminal {
 	#mode2031DebounceTimer?: Timer;
 	#windowsTerminalAppearancePollTimer?: Timer;
 	#progressTimer?: Timer;
+
+	constructor(options?: ProcessTerminalOptions) {
+		this.#conpty = options?.conpty ?? isConPTYHosted();
+	}
 
 	get kittyProtocolActive(): boolean {
 		return this.#kittyProtocolActive;
@@ -1213,7 +1233,7 @@ export class ProcessTerminal implements Terminal {
 				const reportedFlags = parseInt(match[1]!, 10);
 				this.#kittyProtocolActive = true;
 				setKittyProtocolActive(true);
-				if (isConPTYHosted()) {
+				if (this.#conpty) {
 					// ConPTY (native Windows and WSL) drops Shift+letter keypresses
 					// entirely when flag 4 (report alternate keys) is set. Use flag 1
 					// (disambiguate only), preserving flag 2 if already active.
@@ -1863,7 +1883,7 @@ export class ProcessTerminal implements Terminal {
 			// threshold. See #2034 and #2095.
 			const bytes = Buffer.byteLength(data, "utf8");
 			let accepted: boolean;
-			if (isConPTYHosted() && bytes > MAX_CONPTY_WRITE_CHUNK_BYTES) {
+			if (this.#conpty && bytes > MAX_CONPTY_WRITE_CHUNK_BYTES) {
 				accepted = true;
 				for (const chunk of chunkForConPTY(data, MAX_CONPTY_WRITE_CHUNK_BYTES)) {
 					if (this.#dead) break;

--- a/packages/tui/test/emergency-restore-altscreen.test.ts
+++ b/packages/tui/test/emergency-restore-altscreen.test.ts
@@ -45,7 +45,8 @@ function startCapturedTerminal() {
 		return true;
 	});
 
-	const terminal = new ProcessTerminal();
+	// conpty: false keeps kitty flags at >5u regardless of ambient WSL env.
+	const terminal = new ProcessTerminal({ conpty: false });
 	terminal.start(
 		() => {},
 		() => {},

--- a/packages/tui/test/output-backlog-guard.test.ts
+++ b/packages/tui/test/output-backlog-guard.test.ts
@@ -66,7 +66,9 @@ it("stops writing when the real terminal path crosses the backlog cap", () => {
 
 	try {
 		Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true });
-		const terminal = new ProcessTerminal();
+		// conpty: false keeps the single-write path so the 64 MiB cap trips at the
+		// 65th frame; ConPTY would chunk each frame and skew the write count.
+		const terminal = new ProcessTerminal({ conpty: false });
 		const frame = "x".repeat(1024 * 1024);
 		for (let i = 0; i < 70; i++) terminal.write(frame);
 

--- a/packages/tui/test/process-terminal-render-harness.ts
+++ b/packages/tui/test/process-terminal-render-harness.ts
@@ -103,7 +103,10 @@ export function createProcessTerminalRenderHarness(
 		}),
 	];
 
-	const terminal = new ProcessTerminal();
+	// Force non-ConPTY behavior so kitty-flag and write-chunking assertions are
+	// hermetic: the ambient WSL env (WSL_DISTRO_NAME / WSL_INTEROP) must not
+	// change what the suite observes. See ProcessTerminalOptions.
+	const terminal = new ProcessTerminal({ conpty: false });
 	const tui = new TUI(terminal);
 	const probe = new WidthProbe();
 	tui.addChild(probe);

--- a/packages/tui/test/terminal-appearance.test.ts
+++ b/packages/tui/test/terminal-appearance.test.ts
@@ -65,7 +65,10 @@ describe("ProcessTerminal OSC 11 appearance detection", () => {
 		restoreEnv("TMUX", originalTmux);
 	});
 
-	function setupTerminal() {
+	// conpty defaults false so kitty-flag assertions stay hermetic under WSL,
+	// where isConPTYHosted() would otherwise read the live WSL_* env. The two
+	// ConPTY cases opt in explicitly.
+	function setupTerminal({ conpty = false }: { conpty?: boolean } = {}) {
 		const writes: string[] = [];
 		const received: string[] = [];
 		vi.spyOn(process, "kill").mockReturnValue(true);
@@ -77,7 +80,7 @@ describe("ProcessTerminal OSC 11 appearance detection", () => {
 			return true;
 		});
 
-		const terminal = new ProcessTerminal();
+		const terminal = new ProcessTerminal({ conpty });
 		terminal.start(
 			data => received.push(data),
 			() => {},
@@ -653,10 +656,7 @@ describe("ProcessTerminal OSC 11 appearance detection", () => {
 	});
 
 	it("uses disambiguation-only keyboard reporting on ConPTY", () => {
-		Object.defineProperty(process, "platform", { value: "linux", configurable: true });
-		Bun.env.WSL_DISTRO_NAME = "Ubuntu";
-
-		const { terminal, writes } = setupTerminal();
+		const { terminal, writes } = setupTerminal({ conpty: true });
 		writes.length = 0;
 		process.stdin.emit("data", "\x1b[?0u");
 
@@ -666,10 +666,7 @@ describe("ProcessTerminal OSC 11 appearance detection", () => {
 	});
 
 	it("avoids alternate-key reporting on ConPTY while preserving parent event reporting", () => {
-		Object.defineProperty(process, "platform", { value: "linux", configurable: true });
-		Bun.env.WSL_INTEROP = "/run/WSL/1_interop";
-
-		const { terminal, writes } = setupTerminal();
+		const { terminal, writes } = setupTerminal({ conpty: true });
 		writes.length = 0;
 		process.stdin.emit("data", "\x1b[?3u");
 


### PR DESCRIPTION
## Repro
On WSL2 (`WSL_DISTRO_NAME`/`WSL_INTEROP` present in the test process env), 8 `packages/tui` terminal tests fail deterministically while the same SHA is green in CI (no WSL env). A default `ProcessTerminal` fed a kitty reply pushes `\x1b[>1u` where the non-ConPTY assertions expect `\x1b[>5u`:

```
WSL_DISTRO_NAME=Ubuntu WSL_INTEROP=/run/WSL/8_interop bun test
expect(writes).toContain("\x1b[>5u")  ->  received ["\x1b[>1u", ...]
```

## Cause
`isConPTYHosted()` (`packages/tui/src/terminal.ts`) reads live `WSL_DISTRO_NAME`/`WSL_INTEROP`, and `ProcessTerminal` called it directly at two sites — the kitty-keyboard flag choice (`>1u`/`>3u` under ConPTY vs `>5u`/`>7u` otherwise) and the `#safeWrite` large-write chunking. There was no injectable seam, so on WSL the kitty-flag assertions (`kitty-keyboard-da1-ordering`, `terminal-appearance`, `emergency-restore-altscreen`) and the write-count assertion (`output-backlog-guard`) diverged from CI. `terminal-appearance` already cleared `TMUX` in `beforeEach` for the same hermeticity reason but never cleared the WSL vars.

## Fix
- `terminal.ts`: add a `ProcessTerminalOptions` interface with a `conpty?: boolean`, captured once in the constructor as `#conpty` (`options?.conpty ?? isConPTYHosted()`), and use `this.#conpty` at both call sites (kitty flags, `#safeWrite` chunking). Default behavior is unchanged (live detection).
- `process-terminal-render-harness.ts`: construct `new ProcessTerminal({ conpty: false })`.
- `emergency-restore-altscreen.test.ts`, `output-backlog-guard.test.ts`: pin `{ conpty: false }` at construction.
- `terminal-appearance.test.ts`: `setupTerminal` takes `{ conpty = false }`; the two ConPTY cases opt in via `setupTerminal({ conpty: true })` and drop their `process.platform`/`Bun.env` mutation.
- Changelog entry under `[Unreleased]`.

## Verification
`bun test` in `packages/tui` with `WSL_DISTRO_NAME=Ubuntu WSL_INTEROP=/run/WSL/8_interop` injected: 1373 pass, 0 fail (was 8 failing). Same suite green without the WSL env — parity confirmed. Repo-wide `bun check` passes. Fixes #9887