### PR TITLE
fix(lsp): surface workspace symbol server failures

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed workspace symbol searches reporting success when every configured language server failed; partial failures now remain visible alongside successful results ([#8387](https://github.com/can1357/oh-my-pi/issues/8387)).
+
 ## [18.0.7] - 2026-08-26
 
 ### Added

--- a/packages/coding-agent/src/lsp/tool.ts
+++ b/packages/coding-agent/src/lsp/tool.ts
@@ -992,6 +992,7 @@ export class LspTool implements AgentTool<typeof lspSchema, LspToolDetails, Them
 			}
 			const aggregatedSymbols: SymbolInformation[] = [];
 			const respondingServers = new Set<string>();
+			const serverFailures: string[] = [];
 			for (const [workspaceServerName, workspaceServerConfig] of servers) {
 				throwIfAborted(signal);
 				try {
@@ -1007,21 +1008,40 @@ export class LspTool implements AgentTool<typeof lspSchema, LspToolDetails, Them
 						{ query: normalizedQuery },
 						signal,
 					)) as SymbolInformation[] | null;
-					if (!workspaceResult || workspaceResult.length === 0) {
-						continue;
-					}
 					respondingServers.add(workspaceServerName);
-					aggregatedSymbols.push(...filterWorkspaceSymbols(workspaceResult, normalizedQuery));
+					if (workspaceResult && workspaceResult.length > 0) {
+						aggregatedSymbols.push(...filterWorkspaceSymbols(workspaceResult, normalizedQuery));
+					}
 				} catch (err) {
 					if (err instanceof ToolAbortError || signal?.aborted) {
 						throw err;
 					}
+					const message = replaceTabs(err instanceof Error ? err.message : String(err));
+					serverFailures.push(`  ${workspaceServerName}: ${message}`);
 				}
+			}
+			const serverFailureSection =
+				serverFailures.length > 0 ? `\nServer failures:\n${serverFailures.join("\n")}` : "";
+			if (respondingServers.size === 0) {
+				return {
+					content: [
+						{
+							type: "text",
+							text: `Workspace symbol search failed: all language servers failed${serverFailureSection}`,
+						},
+					],
+					details: { action, serverName: "", success: false, request: params },
+				};
 			}
 			const dedupedSymbols = dedupeWorkspaceSymbols(aggregatedSymbols);
 			if (dedupedSymbols.length === 0) {
 				return {
-					content: [{ type: "text", text: `No symbols matching "${normalizedQuery}"` }],
+					content: [
+						{
+							type: "text",
+							text: `No symbols matching "${normalizedQuery}"${serverFailureSection}`,
+						},
+					],
 					details: {
 						action,
 						serverName: Array.from(respondingServers).join(", "),
@@ -1040,7 +1060,15 @@ export class LspTool implements AgentTool<typeof lspSchema, LspToolDetails, Them
 				content: [
 					{
 						type: "text",
-						text: `Found ${dedupedSymbols.length} symbol(s) matching "${normalizedQuery}":\n${lines.map(l => `  ${l}`).join("\n")}${truncationLine}`,
+						text:
+							"Found " +
+							dedupedSymbols.length +
+							' symbol(s) matching "' +
+							normalizedQuery +
+							'":\n' +
+							lines.map(line => `  ${line}`).join("\n") +
+							truncationLine +
+							serverFailureSection,
 					},
 				],
 				details: {

--- a/packages/coding-agent/test/tools/lsp-regressions.test.ts
+++ b/packages/coding-agent/test/tools/lsp-regressions.test.ts
@@ -1793,6 +1793,108 @@ describe("lsp regressions", () => {
 		}
 	});
 
+	it("reports failure when every workspace-symbol server fails (#8387)", async () => {
+		const tempDir = TempDir.createSync("@omp-lsp-workspace-symbol-all-fail-");
+		try {
+			const firstConfig: ServerConfig = { command: "broken-first", fileTypes: ["ts"], rootMarkers: [] };
+			const secondConfig: ServerConfig = { command: "broken-second", fileTypes: ["ts"], rootMarkers: [] };
+			vi.spyOn(lspConfig, "loadConfig").mockReturnValue({
+				servers: { first: firstConfig, second: secondConfig },
+				idleTimeoutMs: undefined,
+			});
+			vi.spyOn(lspClient, "getOrCreateClient").mockImplementation(async config => {
+				throw new Error(`${config.command} exited`);
+			});
+
+			const result = await new LspTool(makeLspSession(tempDir.path())).execute("workspace-symbol-all-fail", {
+				action: "symbols",
+				file: "*",
+				query: "Target",
+			});
+
+			expect(result.details?.success).toBe(false);
+			const output = textResult(result);
+			expect(output).toContain("all language servers failed");
+			expect(output).toContain("first");
+			expect(output).toContain("second");
+			expect(output).not.toContain('No symbols matching "Target"');
+		} finally {
+			vi.restoreAllMocks();
+			tempDir.removeSync();
+		}
+	});
+
+	it("treats an empty workspace-symbol response as a successful search (#8387)", async () => {
+		const tempDir = TempDir.createSync("@omp-lsp-workspace-symbol-empty-");
+		try {
+			const serverConfig: ServerConfig = { command: "empty-lsp", fileTypes: ["ts"], rootMarkers: [] };
+			vi.spyOn(lspConfig, "loadConfig").mockReturnValue({
+				servers: { empty: serverConfig },
+				idleTimeoutMs: undefined,
+			});
+			vi.spyOn(lspClient, "getOrCreateClient").mockResolvedValue({} as LspClient);
+			vi.spyOn(lspClient, "sendRequest").mockResolvedValue([]);
+
+			const result = await new LspTool(makeLspSession(tempDir.path())).execute("workspace-symbol-empty", {
+				action: "symbols",
+				file: "*",
+				query: "Missing",
+			});
+
+			expect(result.details?.success).toBe(true);
+			expect(result.details?.serverName).toBe("empty");
+			expect(textResult(result)).toBe('No symbols matching "Missing"');
+		} finally {
+			vi.restoreAllMocks();
+			tempDir.removeSync();
+		}
+	});
+
+	it("keeps workspace-symbol results and reports partial server failures (#8387)", async () => {
+		const tempDir = TempDir.createSync("@omp-lsp-workspace-symbol-partial-");
+		try {
+			const brokenConfig: ServerConfig = { command: "broken-lsp", fileTypes: ["ts"], rootMarkers: [] };
+			const healthyConfig: ServerConfig = { command: "healthy-lsp", fileTypes: ["ts"], rootMarkers: [] };
+			vi.spyOn(lspConfig, "loadConfig").mockReturnValue({
+				servers: { broken: brokenConfig, healthy: healthyConfig },
+				idleTimeoutMs: undefined,
+			});
+			vi.spyOn(lspClient, "getOrCreateClient").mockImplementation(async config => {
+				if (config.command === "broken-lsp") throw new Error("server exited with code 7");
+				return {} as LspClient;
+			});
+			vi.spyOn(lspClient, "sendRequest").mockResolvedValue([
+				{
+					name: "TargetSymbol",
+					kind: 12,
+					location: {
+						uri: fileToUri(path.join(tempDir.path(), "target.ts")),
+						range: {
+							start: { line: 0, character: 0 },
+							end: { line: 0, character: 12 },
+						},
+					},
+				},
+			]);
+
+			const result = await new LspTool(makeLspSession(tempDir.path())).execute("workspace-symbol-partial", {
+				action: "symbols",
+				file: "*",
+				query: "Target",
+			});
+
+			expect(result.details?.success).toBe(true);
+			expect(result.details?.serverName).toBe("healthy");
+			const output = textResult(result);
+			expect(output).toContain("TargetSymbol");
+			expect(output).toContain("Server failures:");
+			expect(output).toContain("broken: server exited with code 7");
+		} finally {
+			vi.restoreAllMocks();
+			tempDir.removeSync();
+		}
+	});
+
 	it("treats a go.work-only root as a Go workspace for workspace diagnostics", async () => {
 		const tempDir = TempDir.createSync("@omp-lsp-go-work-only-");
 		const spawnCalls: BunSpawnCall[] = [];


### PR DESCRIPTION
Fixes #8387.

## Problem

Workspace-wide symbol search only recorded a server after it returned a non-empty result. Successful empty responses were therefore indistinguishable from failures, while request errors were discarded. If every server failed, the tool still returned success: true with ‘No symbols matching …’.

## Fix

- Count every completed workspace/symbol response, including null and [], as a responding server.
- Return success: false when zero servers respond successfully.
- Preserve per-server errors in successful partial and empty results.
- Keep abort propagation unchanged.

## Tests

Added contract-level regressions for:

1. every workspace-symbol server failing;
2. one successful empty response;
3. successful symbols alongside a failed server.

Verification:

- bun test test/tools/lsp-regressions.test.ts -t workspace-symbol: 3 pass, 0 fail
- bun run check in packages/coding-agent: Biome and tsgo clean
- Negative control on unpatched source: all 3 regressions fail on the reported branches