### PR TITLE
fix(tui): apply full-frame cost to loader backpressure

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed pending-work animations repeatedly composing expensive frames without applying their full render cost to CPU backpressure.
+
 ## [18.0.7] - 2026-08-26
 
 ### Fixed

--- a/packages/tui/src/components/loader.ts
+++ b/packages/tui/src/components/loader.ts
@@ -139,12 +139,13 @@ export class Loader extends Text {
 				this.#requestPaint();
 			}
 
-			const frameCostMs = performance.now() - startedAt;
+			const completedFrameCostMs = this.#ui?.lastFrameCostMs ?? 0;
+			const requestCostMs = performance.now() - startedAt;
 			if (this.#intervalId !== timer) return;
-			const cadenceDelayMs = Math.max(0, intervalMs - frameCostMs);
-			// Idle for nine times the paint cost to keep animation at or below
-			// 10% CPU, even when a slow ConPTY write exceeds the normal cadence.
-			const backpressureDelayMs = frameCostMs * RENDER_BACKPRESSURE_MULTIPLIER;
+			const cadenceDelayMs = Math.max(0, intervalMs - requestCostMs);
+			// Idle for nine times the full frame cost to keep animation at or
+			// below 10% CPU even though requestComponentRender() only enqueues.
+			const backpressureDelayMs = Math.max(completedFrameCostMs, requestCostMs) * RENDER_BACKPRESSURE_MULTIPLIER;
 			this.#scheduleTick(intervalMs, Math.max(cadenceDelayMs, backpressureDelayMs));
 		}, delayMs);
 		this.#intervalId = timer;

--- a/packages/tui/src/components/loader.ts
+++ b/packages/tui/src/components/loader.ts
@@ -5,6 +5,7 @@ import { Text } from "./text";
 const RENDER_INTERVAL_MS = 1000 / 30;
 const SPINNER_ADVANCE_MS = 80;
 const RENDER_BACKPRESSURE_MULTIPLIER = 9;
+const MAX_BACKPRESSURE_FRAME_COST_MS = 200;
 
 type ColorFn = (str: string) => string;
 
@@ -145,7 +146,11 @@ export class Loader extends Text {
 			const cadenceDelayMs = Math.max(0, intervalMs - requestCostMs);
 			// Idle for nine times the full frame cost to keep animation at or
 			// below 10% CPU even though requestComponentRender() only enqueues.
-			const backpressureDelayMs = Math.max(completedFrameCostMs, requestCostMs) * RENDER_BACKPRESSURE_MULTIPLIER;
+			const boundedFrameCostMs = Math.min(
+				MAX_BACKPRESSURE_FRAME_COST_MS,
+				Math.max(completedFrameCostMs, requestCostMs),
+			);
+			const backpressureDelayMs = boundedFrameCostMs * RENDER_BACKPRESSURE_MULTIPLIER;
 			this.#scheduleTick(intervalMs, Math.max(cadenceDelayMs, backpressureDelayMs));
 		}, delayMs);
 		this.#intervalId = timer;

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -901,6 +901,16 @@ export class TUI extends Container {
 		return this.#synchronizedOutputEnabled;
 	}
 
+	/**
+	 * Cost in milliseconds of the most recently completed frame.
+	 *
+	 * Animation components use this to apply proportional backpressure after
+	 * their render request is asynchronously composed and written.
+	 */
+	get lastFrameCostMs(): number {
+		return this.#lastFrameCostMs;
+	}
+
 	setFocus(component: Component | null): void {
 		const topVisibleOverlay = this.#getTopmostVisibleOverlay();
 		if (topVisibleOverlay && !isOverlayFocusTarget(topVisibleOverlay.component, component)) {

--- a/packages/tui/test/loader.test.ts
+++ b/packages/tui/test/loader.test.ts
@@ -153,6 +153,37 @@ describe("Loader component", () => {
 		loader.stop();
 	});
 
+	it("backs off from the completed TUI frame cost when render requests are asynchronous", () => {
+		vi.useFakeTimers();
+		let lastFrameCostMs = 0;
+		const ui = {
+			synchronizedOutput: true,
+			get lastFrameCostMs() {
+				return lastFrameCostMs;
+			},
+			requestComponentRender: vi.fn(),
+		};
+		const loader = new Loader(
+			ui as unknown as TUI,
+			text => text,
+			text => text,
+			"Checking",
+			["0", "1"],
+		);
+
+		expect(ui.requestComponentRender).toHaveBeenCalledTimes(1);
+		lastFrameCostMs = 40;
+		vi.advanceTimersByTime(80);
+		expect(ui.requestComponentRender).toHaveBeenCalledTimes(2);
+
+		vi.advanceTimersByTime(359);
+		expect(ui.requestComponentRender).toHaveBeenCalledTimes(2);
+		vi.advanceTimersByTime(1);
+		expect(ui.requestComponentRender).toHaveBeenCalledTimes(3);
+
+		loader.stop();
+	});
+
 	it("reuses text layout when only animated ANSI styling changes", () => {
 		vi.useFakeTimers();
 		let colorFrame = 0;

--- a/packages/tui/test/loader.test.ts
+++ b/packages/tui/test/loader.test.ts
@@ -184,6 +184,33 @@ describe("Loader component", () => {
 		loader.stop();
 	});
 
+	it("caps backpressure after a pathological one-off frame", () => {
+		vi.useFakeTimers();
+		const ui = {
+			synchronizedOutput: true,
+			lastFrameCostMs: 5_000,
+			requestComponentRender: vi.fn(),
+		};
+		const loader = new Loader(
+			ui as unknown as TUI,
+			text => text,
+			text => text,
+			"Checking",
+			["0", "1"],
+		);
+
+		expect(ui.requestComponentRender).toHaveBeenCalledTimes(1);
+		vi.advanceTimersByTime(80);
+		expect(ui.requestComponentRender).toHaveBeenCalledTimes(2);
+
+		vi.advanceTimersByTime(1_799);
+		expect(ui.requestComponentRender).toHaveBeenCalledTimes(2);
+		vi.advanceTimersByTime(1);
+		expect(ui.requestComponentRender).toHaveBeenCalledTimes(3);
+
+		loader.stop();
+	});
+
 	it("reuses text layout when only animated ANSI styling changes", () => {
 		vi.useFakeTimers();
 		let colorFrame = 0;


### PR DESCRIPTION
## Repro
A pending-work `Loader` queues full TUI frames asynchronously. The regression test reproduces the failure with `bun test packages/tui/test/loader.test.ts --test-name-pattern 'completed TUI frame cost'`: after a 40 ms frame, six render requests arrived inside the 359 ms proportional backpressure window instead of none.

## Cause
`Loader.#scheduleTick` in `packages/tui/src/components/loader.ts` measured only the synchronous duration of `TUI.requestComponentRender()`. Since `requestComponentRender()` now enqueues full frame composition in `packages/tui/src/tui.ts`, the measured cost was approximately zero and the loader continued waking the entire frame every spinner interval, repeatedly rebuilding the unchanged status line.

## Fix
- Expose the cost of the most recently completed TUI frame.
- Pace loader animation from the larger of enqueue cost and completed full-frame cost, restoring the documented 10% proportional backpressure.
- Cover asynchronous full-frame requests with a loader regression test and record the user-visible fix in the TUI changelog.

## Verification
`bun test packages/tui/test/loader.test.ts packages/tui/test/adaptive-render-backpressure.test.ts packages/tui/test/input-render-scheduling.test.ts` passed: 20 tests, 69 assertions. `bun check` passed in `packages/tui`; the publish gate also passed repository formatting and checks. Fixes #9890