### PR TITLE
fix(natives): prevent macOS Terminal output stalls

### DIFF
--- a/crates/pi-natives/src/tty_writer.rs
+++ b/crates/pi-natives/src/tty_writer.rs
@@ -48,23 +48,44 @@ struct Inner {
 	dead:    AtomicBool,
 }
 
+/// Keep each Unix PTY syscall small enough for terminal emulators to consume
+/// incrementally. In particular, Terminal.app can stop draining a PTY when a
+/// large normal-screen history replay arrives as one multi-hundred-KiB write,
+/// leaving the writer blocked and every later frame queued behind it.
+const MAX_TTY_WRITE_CHUNK_BYTES: usize = 16 * 1024;
+
 #[cfg(unix)]
-fn write_all(fd: i32, buf: &[u8]) -> std::io::Result<()> {
+fn write_all_with(
+	mut write: impl FnMut(&[u8]) -> std::io::Result<usize>,
+	buf: &[u8],
+) -> std::io::Result<()> {
 	let mut off = 0usize;
 	while off < buf.len() {
-		// SAFETY: `buf[off..]` is a valid initialized slice; `fd` is owned by
-		// the writer (dup'd at construction) and stays open until drop.
-		let rc = unsafe { libc::write(fd, buf[off..].as_ptr().cast(), buf.len() - off) };
-		if rc < 0 {
-			let err = std::io::Error::last_os_error();
-			if err.kind() == std::io::ErrorKind::Interrupted {
-				continue;
-			}
-			return Err(err);
+		let end = (off + MAX_TTY_WRITE_CHUNK_BYTES).min(buf.len());
+		match write(&buf[off..end]) {
+			Ok(0) => return Err(std::io::ErrorKind::WriteZero.into()),
+			Ok(written) => off += written,
+			Err(err) if err.kind() == std::io::ErrorKind::Interrupted => {},
+			Err(err) => return Err(err),
 		}
-		off += rc as usize;
 	}
 	Ok(())
+}
+
+#[cfg(unix)]
+fn write_all(fd: i32, buf: &[u8]) -> std::io::Result<()> {
+	write_all_with(
+		|chunk| {
+			// SAFETY: `chunk` is a valid initialized slice; `fd` is owned by
+			// the writer (dup'd at construction) and stays open until drop.
+			let rc = unsafe { libc::write(fd, chunk.as_ptr().cast(), chunk.len()) };
+			if rc < 0 {
+				return Err(std::io::Error::last_os_error());
+			}
+			Ok(rc as usize)
+		},
+		buf,
+	)
 }
 
 #[cfg(unix)]
@@ -268,6 +289,26 @@ impl Drop for TtyWriter {
 #[cfg(all(test, unix))]
 mod tests {
 	use super::*;
+
+	#[test]
+	fn large_frame_is_split_into_bounded_tty_writes() {
+		let frame = vec![b'x'; MAX_TTY_WRITE_CHUNK_BYTES * 2 + 7];
+		let mut requested = Vec::new();
+		let mut output = Vec::new();
+		write_all_with(
+			|chunk| {
+				requested.push(chunk.len());
+				output.extend_from_slice(chunk);
+				Ok(chunk.len())
+			},
+			&frame,
+		)
+		.unwrap();
+
+		assert_eq!(requested, [MAX_TTY_WRITE_CHUNK_BYTES, MAX_TTY_WRITE_CHUNK_BYTES, 7]);
+		assert_eq!(output, frame);
+	}
+
 	fn push(writer: &TtyWriter, data: &[u8]) {
 		writer.append(|back| {
 			back.extend_from_slice(data);

--- a/crates/pi-natives/src/tty_writer.rs
+++ b/crates/pi-natives/src/tty_writer.rs
@@ -52,6 +52,7 @@ struct Inner {
 /// incrementally. In particular, Terminal.app can stop draining a PTY when a
 /// large normal-screen history replay arrives as one multi-hundred-KiB write,
 /// leaving the writer blocked and every later frame queued behind it.
+#[cfg(unix)]
 const MAX_TTY_WRITE_CHUNK_BYTES: usize = 16 * 1024;
 
 #[cfg(unix)]

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Large session histories no longer leave macOS Terminal unresponsive during repaint.
+
 ## [18.0.6] - 2026-08-26
 
 ### Fixed


### PR DESCRIPTION
Fixes the issue where the macOS terminal would stall.

## What

Caps individual Unix TTY writes at 16 KiB and adds regression coverage for bounded writes and byte preservation.

## Why

Large session-history repaints could reach macOS Terminal as a single multi-hundred-kilobyte write. The native writer could remain blocked in `write(2)`, leaving subsequent repaints and input queued even though the session was still running and persisted correctly.

## Testing

- `bun run check`
- `bun run test:rs` — 2,352 tests passed
- Reproduced the issue with a large saved session in macOS Terminal and confirmed that the complete history rendered and the UI remained responsive

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated