### PR TITLE
feat(coding-agent): add /continue command to resume an interrupted turn

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+
+- `Agent.continue()` and `agentLoopContinue()` now accept a trailing assistant message with `stopReason: "aborted"`, replaying it as prefill so an interrupted turn can resume without a new user message.
 
 ## [18.0.7] - 2026-08-26
 

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -191,7 +191,9 @@ await agent.prompt("What's in this image?", [{ type: "image", data: base64Data, 
 // AgentMessage directly
 await agent.prompt({ role: "user", content: "Hello", timestamp: Date.now() });
 
-// Continue from current context (last message must be user or toolResult)
+// Continue from current context (last message must be user or toolResult).
+// A trailing assistant message with `stopReason: "aborted"` (a user-interrupted
+// partial turn) is replayed as assistant prefill so the model resumes it.
 await agent.continue();
 ```
 

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -556,11 +556,12 @@ export function agentLoop(
 
 /**
  * Continue an agent loop from the current context without adding a new message.
- * Used for retries - context already has user message or tool results.
+ * Used for retries and resuming queued messages.
  *
  * **Important:** The last message in context must convert to a `user` or `toolResult` message
- * via `convertToLlm`. If it doesn't, the LLM provider will reject the request.
- * This cannot be validated here since `convertToLlm` is only called once per turn.
+ * via `convertToLlm`. The one exception is a trailing assistant message with
+ * `stopReason: "aborted"` (a user-interrupted partial turn): it is replayed as
+ * assistant prefill so the model continues where the stream was cut off.
  */
 export function agentLoopContinue(
 	context: AgentContext,
@@ -572,8 +573,11 @@ export function agentLoopContinue(
 		throw new Error("Cannot continue: no messages in context");
 	}
 
-	if (context.messages[context.messages.length - 1].role === "assistant") {
-		throw new Error("Cannot continue from message role: assistant");
+	if (context.messages[context.messages.length - 1]?.role === "assistant") {
+		const tail = context.messages[context.messages.length - 1] as AssistantMessage;
+		if (tail.stopReason !== "aborted") {
+			throw new Error("Cannot continue from message role: assistant");
+		}
 	}
 
 	const stream = createAgentStream();

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -1248,7 +1248,16 @@ export class Agent {
 				}
 				throw new Error("No messages to continue from");
 			}
-			if (messages[messages.length - 1].role === "assistant") {
+			const lastMessage = messages[messages.length - 1] as AssistantMessage | undefined;
+			if (lastMessage?.role === "assistant" && !this.hasQueuedMessages() && lastMessage.stopReason === "aborted") {
+				// An aborted (user-interrupted) partial assistant turn is the one
+				// resumable assistant tail: runLoop replays it as prefill so the
+				// model continues where the stream was cut off. Any other assistant
+				// tail still requires queued messages or throws below.
+				await this.#runLoop(undefined, undefined, signal, true);
+				return;
+			}
+			if (lastMessage?.role === "assistant") {
 				const queuedSteering = await this.#dequeueSteeringMessagesAfterHooks(dequeueSignal);
 				if (queuedSteering.length > 0) {
 					await this.#runLoop(queuedSteering, { skipInitialSteeringPoll: true }, signal, true);

--- a/packages/agent/test/continue-aborted-tail.test.ts
+++ b/packages/agent/test/continue-aborted-tail.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "bun:test";
+import { Agent } from "@oh-my-pi/pi-agent-core";
+import { createMockModel } from "@oh-my-pi/pi-ai/providers/mock";
+import { createAssistantMessage, createUserMessage } from "./helpers";
+
+/**
+ * Regression coverage for the public continuation branch added with `/continue`:
+ * a trailing assistant message with `stopReason: "aborted"` (a user-interrupted
+ * partial turn) is the one resumable assistant tail — `Agent.continue()` replays
+ * it as assistant prefill so the model continues where the stream cut off,
+ * without injecting a new message. Any other assistant tail keeps its existing
+ * contract: throw when nothing is queued, drain the queue when it is.
+ *
+ * These tests drive `Agent.continue()` and assert the provider context carries
+ * the original `[user, assistant]` history (no new agent message on the wire),
+ * plus the settled-assistant rejection and queued-message precedence that a
+ * later role/queue change could silently remove.
+ */
+describe("Agent.continue() on an aborted assistant tail", () => {
+	it("replays the aborted assistant tail as prefill without injecting a new message", async () => {
+		const mock = createMockModel({ responses: [{ content: ["ready"] }] });
+		const agent = new Agent({ streamFn: mock.stream });
+
+		agent.replaceMessages([
+			createUserMessage("Hello"),
+			createAssistantMessage([{ type: "text", text: "partial response" }], "aborted"),
+		]);
+
+		await expect(agent.continue()).resolves.toBeUndefined();
+
+		expect(mock.calls).toHaveLength(1);
+		const wireMessages = mock.calls[0]!.context.messages;
+		expect(wireMessages.map(message => message.role)).toEqual(["user", "assistant"]);
+		// No new agent message was injected by our side — the aborted tail is
+		// replayed verbatim as the last (assistant-prefill) message.
+		expect(wireMessages[wireMessages.length - 1]?.role).toBe("assistant");
+		expect(agent.state.messages[agent.state.messages.length - 1]?.role).toBe("assistant");
+	});
+
+	it("still throws on a settled (non-aborted) assistant tail with nothing queued", async () => {
+		const mock = createMockModel({ responses: [{ content: ["ready"] }] });
+		const agent = new Agent({ streamFn: mock.stream });
+
+		agent.replaceMessages([createUserMessage("Hello"), createAssistantMessage([{ type: "text", text: "complete" }])]);
+
+		await expect(agent.continue()).rejects.toThrow("Cannot continue from message role: assistant");
+		expect(mock.calls).toHaveLength(0);
+	});
+
+	it("still drains a queued follow-up after a settled assistant tail", async () => {
+		const mock = createMockModel({ responses: [{ content: ["Processed"] }] });
+		const agent = new Agent({ streamFn: mock.stream });
+
+		agent.replaceMessages([createUserMessage("Hello"), createAssistantMessage([{ type: "text", text: "complete" }])]);
+		agent.followUp(createUserMessage("Queued follow-up"));
+
+		await expect(agent.continue()).resolves.toBeUndefined();
+
+		expect(mock.calls).toHaveLength(1);
+		expect(agent.hasQueuedMessages()).toBe(false);
+		expect(agent.state.messages[agent.state.messages.length - 1]?.role).toBe("assistant");
+	});
+});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+
+- `/continue` command resumes a response you interrupted with Esc — the model picks up exactly where it stopped, with no extra message added to the conversation.
 
 ## [18.0.7] - 2026-08-26
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -7806,6 +7806,20 @@ export class AgentSession {
 		return this.#recovery.retry();
 	}
 
+	/**
+	 * Resume a user-interrupted (aborted) assistant turn without appending any
+	 * user-visible message. Returns false when there is no aborted assistant
+	 * tail to resume or the session is busy.
+	 */
+	continueInterrupted(): boolean {
+		if (this.isStreaming || this.isCompacting || this.#recovery.isRetrying) return false;
+		const messages = this.agent.state.messages;
+		const tail = messages[messages.length - 1] as AssistantMessage | undefined;
+		if (tail?.role !== "assistant" || tail.stopReason !== "aborted") return false;
+		this.#scheduleAgentContinue();
+		return true;
+	}
+
 	// =========================================================================
 	// Bash Execution
 	// =========================================================================

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -7814,8 +7814,23 @@ export class AgentSession {
 	 */
 	continueInterrupted(): boolean {
 		if (this.isStreaming || this.isCompacting || this.#recovery.isRetrying) return false;
-		const tail = findResumableAbortedAssistant(this.agent.state.messages);
+		const messages = this.agent.state.messages;
+		const tail = findResumableAbortedAssistant(messages);
 		if (!tail) return false;
+		// `findResumableAbortedAssistant` walks back over the sanctioned trailing
+		// continuity records the session appends after an Esc abort (the hidden
+		// `interrupted-thinking` note and synthetic tool-result placeholders).
+		// `Agent.continue()` only enters its assistant-prefill branch when the
+		// aborted assistant is the literal last message, so drop those records
+		// here — otherwise the provider request tail would be the continuity note
+		// / failed tool result instead of the partial assistant the user is
+		// actually resuming. Preserve tool-result placeholders when the assistant
+		// tail is itself a tool call: removing them would leave a dangling
+		// tool_call the provider rejects.
+		const tailIndex = messages.indexOf(tail);
+		if (tailIndex < messages.length - 1 && tail.content[tail.content.length - 1]?.type !== "toolCall") {
+			this.agent.replaceMessages(messages.slice(0, tailIndex + 1));
+		}
 		this.#scheduleAgentContinue();
 		return true;
 	}

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -305,6 +305,7 @@ import {
 	demoteInterruptedThinking,
 	didSessionMessagesChange,
 	type FileMentionMessage,
+	findResumableAbortedAssistant,
 	type HookMessage,
 	INTERRUPTED_THINKING_MESSAGE_TYPE,
 	type InterruptedThinkingDetails,
@@ -7813,9 +7814,8 @@ export class AgentSession {
 	 */
 	continueInterrupted(): boolean {
 		if (this.isStreaming || this.isCompacting || this.#recovery.isRetrying) return false;
-		const messages = this.agent.state.messages;
-		const tail = messages[messages.length - 1] as AssistantMessage | undefined;
-		if (tail?.role !== "assistant" || tail.stopReason !== "aborted") return false;
+		const tail = findResumableAbortedAssistant(this.agent.state.messages);
+		if (!tail) return false;
 		this.#scheduleAgentContinue();
 		return true;
 	}

--- a/packages/coding-agent/src/session/messages.ts
+++ b/packages/coding-agent/src/session/messages.ts
@@ -4,7 +4,7 @@
  * Extends the base AgentMessage type with coding-agent specific message types,
  * and provides a transformer to convert them to LLM-compatible messages.
  */
-import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
+import { type AgentMessage, isSyntheticToolResultMessage } from "@oh-my-pi/pi-agent-core";
 import {
 	invalidateMessageCache,
 	registerMessageCacheInvalidator,
@@ -474,6 +474,46 @@ export function isUserInterruptAbort(message: Pick<AssistantMessage, "errorId" |
 
 export function shouldRenderAbortReason(message: Pick<AssistantMessage, "errorId" | "errorMessage">): boolean {
 	return !isSilentAbort(message) && !isUserInterruptAbort(message);
+}
+
+/**
+ * Find the user-interrupted assistant turn at the tail of `messages` that
+ * `/continue` can resume as assistant prefill.
+ *
+ * After an Esc abort the session appends sanctioned internal continuity records
+ * *after* the aborted assistant, so the literal tail is not always the assistant:
+ * - a hidden {@link INTERRUPTED_THINKING_MESSAGE_TYPE} continuity note when a
+ *   meaningful unsigned thinking run was demoted, and
+ * - one synthetic `tool_result` placeholder per tool call the abort interrupted
+ *   (see {@link createAbortedToolResult}).
+ *
+ * This helper walks back over those records and returns the aborted assistant
+ * only when it is a genuine user interrupt (`stopReason === "aborted"` AND
+ * {@link isUserInterruptAbort}). Internal/lifecycle aborts (plan-mode
+ * compaction, streaming-edit, TTSR `SilentAbort`) are deliberately excluded so
+ * `/continue` never advertises or replays a turn the runtime ended on its own.
+ *
+ * Returns `undefined` when the tail is not a resumable user-interrupt.
+ */
+export function findResumableAbortedAssistant(messages: readonly AgentMessage[]): AssistantMessage | undefined {
+	let index = messages.length - 1;
+	while (index >= 0) {
+		const candidate = messages[index];
+		if (candidate?.role === "custom" && candidate.customType === INTERRUPTED_THINKING_MESSAGE_TYPE) {
+			index--;
+			continue;
+		}
+		if (isSyntheticToolResultMessage(candidate)) {
+			index--;
+			continue;
+		}
+		break;
+	}
+	const tail = messages[index] as AssistantMessage | undefined;
+	if (tail?.role !== "assistant") return undefined;
+	if (tail.stopReason !== "aborted") return undefined;
+	if (!isUserInterruptAbort(tail)) return undefined;
+	return tail;
 }
 
 /** A provider-rejection turn carrying nothing but the error flag: stopReason

--- a/packages/coding-agent/src/slash-commands/builtin-lifecycle.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-lifecycle.ts
@@ -1,13 +1,12 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { CompactionCancelledError } from "@oh-my-pi/pi-agent-core/compaction";
-import type { AssistantMessage } from "@oh-my-pi/pi-ai";
 import { logger, setProjectDir } from "@oh-my-pi/pi-utils";
 import { applyProviderGlobalsFromSettings } from "../config/provider-globals";
 import { memoryStatsUnavailableMessage, resolveMemoryBackend } from "../memory-backend";
 import type { FreshSessionResult, HandoffResult } from "../session/agent-session";
 import { COMPACT_MODES, parseCompactArgs } from "../session/compact-modes";
-import { USER_INTERRUPT_LABEL } from "../session/messages";
+import { findResumableAbortedAssistant, USER_INTERRUPT_LABEL } from "../session/messages";
 import { resolveResumableSession } from "../session/session-listing";
 import { toggleSessionPin } from "../session/session-pins";
 import { formatShakeSummary, type ShakeMode } from "../session/shake-types";
@@ -440,11 +439,8 @@ export const BUILTIN_LIFECYCLE_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> =
 		icon: "redo",
 		description: "Continue an interrupted response (no message sent)",
 		getTuiAutocompleteDescription: runtime => {
-			const tail = runtime.ctx.session.messages[runtime.ctx.session.messages.length - 1] as
-				| AssistantMessage
-				| undefined;
-			if (tail?.role !== "assistant") return undefined;
-			return tail.stopReason === "aborted" ? "Continue: resumable interrupted turn" : "Continue: nothing to resume";
+			const tail = findResumableAbortedAssistant(runtime.ctx.session.messages);
+			return tail ? "Continue: resumable interrupted turn" : "Continue: nothing to resume";
 		},
 		handle: async (_command, runtime) => {
 			if (runtime.session.isStreaming) {
@@ -462,6 +458,10 @@ export const BUILTIN_LIFECYCLE_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> =
 		},
 		handleTui: async (_command, runtime) => {
 			runtime.ctx.editor.setText("");
+			if (runtime.ctx.session.isStreaming) {
+				runtime.ctx.showStatus("Busy — wait for the current response to finish or abort it first.");
+				return;
+			}
 			if (!runtime.ctx.session.continueInterrupted()) {
 				runtime.ctx.showStatus("Nothing to continue");
 			}

--- a/packages/coding-agent/src/slash-commands/builtin-lifecycle.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-lifecycle.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { CompactionCancelledError } from "@oh-my-pi/pi-agent-core/compaction";
+import type { AssistantMessage } from "@oh-my-pi/pi-ai";
 import { logger, setProjectDir } from "@oh-my-pi/pi-utils";
 import { applyProviderGlobalsFromSettings } from "../config/provider-globals";
 import { memoryStatsUnavailableMessage, resolveMemoryBackend } from "../memory-backend";
@@ -432,6 +433,38 @@ export const BUILTIN_LIFECYCLE_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> =
 				runtime.ctx.showStatus("Nothing to retry");
 			}
 			runtime.ctx.editor.setText("");
+		},
+	},
+	{
+		name: "continue",
+		icon: "redo",
+		description: "Continue an interrupted response (no message sent)",
+		getTuiAutocompleteDescription: runtime => {
+			const tail = runtime.ctx.session.messages[runtime.ctx.session.messages.length - 1] as
+				| AssistantMessage
+				| undefined;
+			if (tail?.role !== "assistant") return undefined;
+			return tail.stopReason === "aborted" ? "Continue: resumable interrupted turn" : "Continue: nothing to resume";
+		},
+		handle: async (_command, runtime) => {
+			if (runtime.session.isStreaming) {
+				return usage("Wait for the current response to finish or abort it before continuing.", runtime);
+			}
+			if (!runtime.session.continueInterrupted()) {
+				return usage("Nothing to continue — no interrupted turn.", runtime);
+			}
+			await runtime.output("Continuing the interrupted turn.");
+			// Same post-prompt continuation contract as /retry: the continuation is
+			// only scheduled, so ACP hosts must keep their prompt turn open across
+			// it or its output would stream into an already-unsubscribed turn.
+			await runtime.keepTurnOpenUntilIdle?.();
+			return commandConsumed({ agentInvoked: true });
+		},
+		handleTui: async (_command, runtime) => {
+			runtime.ctx.editor.setText("");
+			if (!runtime.ctx.session.continueInterrupted()) {
+				runtime.ctx.showStatus("Nothing to continue");
+			}
 		},
 	},
 	{

--- a/packages/coding-agent/test/continue-interrupted-predicate.test.ts
+++ b/packages/coding-agent/test/continue-interrupted-predicate.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "bun:test";
+import { createSyntheticToolResultMessage } from "@oh-my-pi/pi-agent-core";
+import type { AssistantMessage, Model, UserMessage } from "@oh-my-pi/pi-ai";
+import {
+	findResumableAbortedAssistant,
+	INTERRUPTED_THINKING_MESSAGE_TYPE,
+	USER_INTERRUPT_LABEL,
+} from "@oh-my-pi/pi-coding-agent/session/messages";
+
+function userMessage(text: string): UserMessage {
+	return { role: "user", content: text, timestamp: Date.now() };
+}
+
+function emptyUsage(): AssistantMessage["usage"] {
+	return {
+		input: 0,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: 0,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+	};
+}
+
+function assistant(
+	model: Model,
+	content: AssistantMessage["content"],
+	additions?: Partial<AssistantMessage>,
+): AssistantMessage {
+	return {
+		role: "assistant",
+		content,
+		api: model.api,
+		provider: model.provider,
+		model: model.id,
+		usage: emptyUsage(),
+		stopReason: "aborted",
+		timestamp: Date.now(),
+		...additions,
+	};
+}
+
+const model = {
+	api: "mock",
+	provider: "mock",
+	id: "mock-model",
+} as unknown as Model;
+
+const interruptedThinking = {
+	role: "custom",
+	customType: INTERRUPTED_THINKING_MESSAGE_TYPE,
+	content: "continuity quote",
+	display: false,
+	timestamp: Date.now(),
+} as const;
+
+describe("findResumableAbortedAssistant", () => {
+	it("returns the literal aborted user-interrupt assistant tail", () => {
+		const messages = [
+			userMessage("hello"),
+			assistant(model, [{ type: "text", text: "partial" }], { errorMessage: USER_INTERRUPT_LABEL }),
+		];
+		expect(findResumableAbortedAssistant(messages)?.stopReason).toBe("aborted");
+	});
+
+	it("walks past a trailing interrupted-thinking continuity note", () => {
+		const aborted = assistant(model, [{ type: "text", text: "partial" }], {
+			errorMessage: USER_INTERRUPT_LABEL,
+		});
+		const messages = [userMessage("hello"), aborted, interruptedThinking];
+		const found = findResumableAbortedAssistant(messages);
+		expect(found).toBe(aborted);
+	});
+
+	it("walks past trailing synthetic tool_result placeholders", () => {
+		const toolCall = { type: "toolCall" as const, id: "tool-1", name: "alpha", arguments: {} };
+		const aborted = assistant(model, [toolCall], { errorMessage: USER_INTERRUPT_LABEL });
+		const synthetic = createSyntheticToolResultMessage(toolCall, "aborted", USER_INTERRUPT_LABEL);
+		const messages = [userMessage("hello"), aborted, interruptedThinking, synthetic];
+		const found = findResumableAbortedAssistant(messages);
+		expect(found).toBe(aborted);
+	});
+
+	it("rejects a settled assistant (non-aborted) tail", () => {
+		const messages = [
+			userMessage("hello"),
+			assistant(model, [{ type: "text", text: "complete" }], { stopReason: "stop" }),
+		];
+		expect(findResumableAbortedAssistant(messages)).toBeUndefined();
+	});
+
+	it("rejects a silent abort (not a user interrupt)", () => {
+		const messages = [
+			userMessage("hello"),
+			assistant(model, [{ type: "text", text: "partial" }], {
+				errorMessage: "__omp.silent_abort__",
+			}),
+		];
+		expect(findResumableAbortedAssistant(messages)).toBeUndefined();
+	});
+
+	it("rejects a bare lifecycle abort with no user-interrupt marker", () => {
+		const messages = [
+			userMessage("hello"),
+			assistant(model, [{ type: "text", text: "partial" }], {
+				errorMessage: "Request was aborted",
+				stopReason: "aborted",
+			}),
+		];
+		expect(findResumableAbortedAssistant(messages)).toBeUndefined();
+	});
+
+	it("returns undefined when the tail is not an assistant", () => {
+		const messages = [userMessage("hello")];
+		expect(findResumableAbortedAssistant(messages)).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## Problem

Aborting generation with Esc leaves a trailing assistant message (`stopReason: "aborted"`, partial content preserved). The only way to resume was typing "continue" as a user message, which pollutes the transcript with a redundant user turn and re-anchors the conversation on the interruption itself.

## Solution

`/continue` resumes the interrupted response as **assistant prefill**: the model continues exactly where the stream stopped, and no message is appended to the conversation.

### agent core (`packages/agent`)

- `Agent.continue()` / `agentLoopContinue()` now accept a trailing assistant message with `stopReason: "aborted"` as the one resumable tail. It is replayed through `runLoop(undefined)` like any continuation.
- Placement matters: the aborted-tail branch sits *after* the queued-steer/follow-up dequeue in `Agent.continue()`, so settled assistant tails keep their existing contract exactly — throw without queued messages, drain when queued.
- Providers already handle trailing-assistant contexts (the Anthropic converter pads a neutral `Continue.` user turn inside the request; that pad is request-scoped and never persisted). Aborted turns never carry unpaired tool calls (placeholders pair them at abort time), so prefill replay cannot trip tool_use validators.

### coding-agent

- `AgentSession.continueInterrupted()` validates idle state (not streaming/compacting/auto-retrying) and reuses `#scheduleAgentContinue`, inheriting fallback-model restore, pre-prompt compaction, usage-aware preflight, and in-flight bookkeeping.
- `/continue` builtin beside `/retry`:
  - ACP handler follows the same keep-turn-open contract as `/retry`, so the scheduled continuation streams into the still-open prompt turn.
  - TUI handler clears the editor and shows "Nothing to continue" when there is no resumable abort tail; busy sessions get the usual wait-for-idle guidance.
  - Autocomplete description reflects live resumability ("resumable interrupted turn" vs "nothing to resume").

Interrupted-thinking handling is unchanged by this PR: incomplete trailing thinking runs remain demoted via the existing continuity-message path (unsafe unsigned blocks are stripped from wire replay regardless of how the next turn starts).

## Testing

- Wire-level probe driving `Agent.continue()` against a mock streamFn: provider context arrives as `[user, assistant]` with no user-text injection from our side; aborted tail proceeds into the loop; settled tail still throws `Cannot continue from message role: assistant`; settled tail + queued follow-up still drains.
- `bun test packages/coding-agent/test/slash-commands/ packages/agent/test/continue-empty-transcript.test.ts packages/agent/test/agent.test.ts` — 199 pass.
- Biome clean on all touched files; package type-checks pass (pre-existing unrelated failures on clean `main`: `kitty-vt-wasm`, `@sinclair/typebox`).
- No prior issue/PR for this feature found (closest: #9635 markdown list continuation, #3695 auto-continue on unexpected stops).