### PR TITLE
feat(ai): map vLLM created_cache_tokens to cacheWrite

### DIFF
--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -154,6 +154,7 @@ type OpenAICompletionsUsageLike = {
 type OpenAICompletionsPromptTokenDetails = {
 	cached_tokens?: unknown;
 	cache_write_tokens?: unknown;
+	created_cache_tokens?: unknown;
 };
 
 type OpenAICompletionsCompletionTokenDetails = {
@@ -1776,13 +1777,14 @@ export function parseChunkUsage(
 	const promptTokenCachedTokens = promptTokenDetails?.cached_tokens;
 	const completionReasoningTokens = completionTokenDetails?.reasoning_tokens;
 	const cacheWriteTokens = promptTokenDetails?.cache_write_tokens;
+	const createdCacheTokens = promptTokenDetails?.created_cache_tokens;
 	const outputTokens = typeof completionTokens === "number" ? completionTokens : 0;
 	const accounting = calculateOpenAIUsageAccounting({
 		promptTokens: typeof promptTokens === "number" ? promptTokens : 0,
 		outputTokens,
 		cachedTokens: firstPositiveNumber(cachedTokens, promptCacheHitTokens, promptTokenCachedTokens),
 		reasoningTokens: typeof completionReasoningTokens === "number" ? completionReasoningTokens : 0,
-		cacheWriteOpenRouter: typeof cacheWriteTokens === "number" ? cacheWriteTokens : undefined,
+		cacheWriteOpenRouter: firstPositiveNumber(cacheWriteTokens, createdCacheTokens) || undefined,
 		cacheWriteDeepSeek: typeof promptCacheMissTokens === "number" ? promptCacheMissTokens : undefined,
 		hasDeepSeekCacheHitAndMiss: typeof promptCacheHitTokens === "number" && typeof promptCacheMissTokens === "number",
 	});

--- a/packages/ai/test/usage-attribution.test.ts
+++ b/packages/ai/test/usage-attribution.test.ts
@@ -233,6 +233,44 @@ describe("openai-completions parseChunkUsage", () => {
 		expect(usage.cacheWrite).toBe(5_000);
 		expect(usage.totalTokens).toBe(6_250);
 	});
+
+	it("maps vLLM created_cache_tokens to cacheWrite on cold turn", () => {
+		// vLLM with --enable-prompt-tokens-details reports cache creation
+		// via prompt_tokens_details.created_cache_tokens (not cache_write_tokens).
+		// On the first (cold) turn: cached_tokens=0, created_cache_tokens=1920.
+		const usage = parseChunkUsage(
+			{
+				prompt_tokens: 3_026,
+				completion_tokens: 10,
+				prompt_tokens_details: { cached_tokens: 0, created_cache_tokens: 1_920 },
+			},
+			OPENAI_MODEL,
+			undefined,
+		);
+
+		expect(usage.input).toBe(1_106); // 3026 - 0 - 1920
+		expect(usage.cacheRead).toBe(0);
+		expect(usage.cacheWrite).toBe(1_920);
+		expect(usage.totalTokens).toBe(3_036); // 1106 + 10 + 0 + 1920
+	});
+
+	it("maps vLLM cached_tokens to cacheRead on warm turn", () => {
+		// On subsequent (warm) turns: cached_tokens=1920, created_cache_tokens=0.
+		const usage = parseChunkUsage(
+			{
+				prompt_tokens: 3_026,
+				completion_tokens: 10,
+				prompt_tokens_details: { cached_tokens: 1_920, created_cache_tokens: 0 },
+			},
+			OPENAI_MODEL,
+			undefined,
+		);
+
+		expect(usage.input).toBe(1_106); // 3026 - 1920 - 0
+		expect(usage.cacheRead).toBe(1_920);
+		expect(usage.cacheWrite).toBe(0);
+		expect(usage.totalTokens).toBe(3_036); // 1106 + 10 + 1920 + 0
+	});
 });
 
 describe("shared OpenAI usage accounting", () => {


### PR DESCRIPTION
## Summary

vLLM reports prefix cache creation via `prompt_tokens_details.created_cache_tokens` (requires `--enable-prompt-tokens-details` server flag). This field was not being read, so **Cache Write** in the context panel was always 0 for vLLM backends.

## Changes

### [`openai-completions.ts`](packages/ai/src/providers/openai-completions.ts)
- Added `created_cache_tokens` to `OpenAICompletionsPromptTokenDetails` type
- Extract `created_cache_tokens` from `prompt_tokens_details` alongside existing `cache_write_tokens`
- Use `firstPositiveNumber(cacheWriteTokens, createdCacheTokens)` so vLLM's field is used as fallback when OpenRouter's `cache_write_tokens` is absent

### [`usage-attribution.test.ts`](packages/ai/test/usage-attribution.test.ts)
- Added test: vLLM cold turn (`created_cache_tokens: 1920`) → `cacheWrite: 1920`
- Added test: vLLM warm turn (`cached_tokens: 1920`) → `cacheRead: 1920`

## vLLM Server Config

Requires `--enable-prompt-tokens-details` on the vLLM server (defaults to `false`). With the hybrid Mamba model (Qwen3.8-27B), the block size is 960 tokens, so prefix caching only kicks in for prompts exceeding that threshold.

## Backward Compatibility

- OpenRouter's `cache_write_tokens` takes priority via `firstPositiveNumber` ordering
- DeepSeek path is unaffected (uses separate `cacheWriteDeepSeek` field)
- When `prompt_tokens_details` is `null` (flag not enabled), both values remain 0