### PR TITLE
fix(session): externalize snapcompact frames to blob store on persist

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `snapcompact` compaction frames larger than the persistence limit being truncated into invalid image base64 on session resume, which made the provider reject every subsequent request with HTTP 400 ([#9901](https://github.com/can1357/oh-my-pi/issues/9901)).
+
 ## [18.0.7] - 2026-08-26
 
 ### Added

--- a/packages/coding-agent/src/session/session-loader.ts
+++ b/packages/coding-agent/src/session/session-loader.ts
@@ -4,7 +4,7 @@ import { BlobStore, isBlobRef, resolveImageData, resolveImageDataUrl } from "./b
 import { buildSessionContext } from "./session-context";
 import type { FileEntry, RawFileEntry, SessionEntry, SessionHeader } from "./session-entries";
 import { migrateToCurrentVersion } from "./session-migrations";
-import { isImageBlock, isImageDataPayload } from "./session-persistence";
+import { isExternalizableImagePosition } from "./session-persistence";
 import { FileSessionStorage, type SessionStorage } from "./session-storage";
 import {
 	parseTitleSlotFromContent,
@@ -318,13 +318,8 @@ function hasImageUrl(value: unknown): value is { image_url: string } {
 	return typeof value === "object" && value !== null && "image_url" in value && typeof value.image_url === "string";
 }
 
-function shouldResolveImagePayload(value: unknown, key: string | undefined): value is { data: string } {
-	if (!isImageDataPayload(value) || !isBlobRef(value.data)) return false;
-	return (key === "content" && isImageBlock(value)) || key === "images";
-}
-
 async function resolvePersistedBlobRefs(value: unknown, blobStore: BlobStore, key?: string): Promise<void> {
-	if (shouldResolveImagePayload(value, key)) {
+	if (isExternalizableImagePosition(value, key) && isBlobRef(value.data)) {
 		value.data = await resolveImageData(blobStore, value.data);
 		return;
 	}

--- a/packages/coding-agent/src/session/session-persistence.ts
+++ b/packages/coding-agent/src/session/session-persistence.ts
@@ -13,6 +13,12 @@ const TRUNCATION_NOTICE = "\n\n[Session persistence truncated large content]";
 /** Minimum base64 length to externalize to blob store (skip tiny inline images) */
 const BLOB_EXTERNALIZE_THRESHOLD = 1024;
 const TEXT_CONTENT_KEY = "content";
+/** Parent key under which snapcompact persists its base64 PNG frame archive
+ *  (`preserveData.snapcompact.frames[]`). Frame objects are image payloads, so
+ *  their base64 must externalize to the blob store rather than fall through to
+ *  generic string truncation, which appends {@link TRUNCATION_NOTICE} and
+ *  corrupts the base64 the provider decodes on resume. */
+const SNAPCOMPACT_FRAMES_KEY = "frames";
 
 function truncateString(value: string, maxLength: number): string {
 	if (value.length <= maxLength) return value;
@@ -51,13 +57,29 @@ export function isImageDataPayload(value: unknown): value is { data: string; mim
 	);
 }
 
-function shouldExternalizeImagePayload(
+/**
+ * True when an image payload sits in a persistence position whose base64 is
+ * externalized to the blob store instead of truncated as a generic string: a
+ * `content` image block, an `images[]` entry, or a snapcompact frame under
+ * `frames[]`. Shared by the persist path ({@link shouldExternalizeImagePayload})
+ * and the load path (`shouldResolveImagePayload`) so the two never drift and
+ * strand a payload externalized on write but not resolved on read.
+ */
+export function isExternalizableImagePosition(
 	value: unknown,
 	key: string | undefined,
 ): value is { data: string; mimeType?: string } {
 	if (!isImageDataPayload(value)) return false;
+	return (key === TEXT_CONTENT_KEY && isImageBlock(value)) || key === "images" || key === SNAPCOMPACT_FRAMES_KEY;
+}
+
+function shouldExternalizeImagePayload(
+	value: unknown,
+	key: string | undefined,
+): value is { data: string; mimeType?: string } {
+	if (!isExternalizableImagePosition(value, key)) return false;
 	if (isBlobRef(value.data) || value.data.length < BLOB_EXTERNALIZE_THRESHOLD) return false;
-	return (key === TEXT_CONTENT_KEY && isImageBlock(value)) || key === "images";
+	return true;
 }
 
 /** True for a non-empty string — marks signature/encrypted fields whose block must persist verbatim. */

--- a/packages/coding-agent/test/session-persistence-images.test.ts
+++ b/packages/coding-agent/test/session-persistence-images.test.ts
@@ -2,10 +2,16 @@ import { describe, expect, it } from "bun:test";
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
 import type { ImageContent, TextContent } from "@oh-my-pi/pi-ai";
 import { BlobStore, isBlobRef } from "@oh-my-pi/pi-coding-agent/session/blob-store";
-import type { FileEntry, SessionMessageEntry } from "@oh-my-pi/pi-coding-agent/session/session-entries";
+import type {
+	CompactionEntry,
+	FileEntry,
+	SessionMessageEntry,
+} from "@oh-my-pi/pi-coding-agent/session/session-entries";
 import { resolveBlobRefsInEntries } from "@oh-my-pi/pi-coding-agent/session/session-loader";
 import { prepareEntryForPersistence } from "@oh-my-pi/pi-coding-agent/session/session-persistence";
 import { TempDir } from "@oh-my-pi/pi-utils";
+import type { Archive } from "@oh-my-pi/snapcompact";
+import * as snapcompact from "@oh-my-pi/snapcompact";
 
 type ImagePayload = { data: string; mimeType: string; type?: "image" };
 type ToolResultMessage = Extract<AgentMessage, { role: "toolResult" }>;
@@ -166,5 +172,58 @@ describe("session image persistence", () => {
 		const resolved = loaded[loaded.length - 1] as ToolResultEntry;
 		const resolvedImage = resolved.message.content.find((block): block is ImageContent => block.type === "image");
 		expect(resolvedImage?.data).toBe(imageData);
+	});
+});
+
+/** Strict base64 the way a provider's decoder validates it: only the base64
+ *  alphabet, canonical padding, length a multiple of 4. Buffer.from is lenient
+ *  and would silently accept the corrupted payload this test guards against. */
+function isStrictBase64(data: string): boolean {
+	return /^[A-Za-z0-9+/]*={0,2}$/.test(data) && data.length % 4 === 0;
+}
+
+describe("snapcompact frame persistence", () => {
+	it("externalizes oversized frame base64 to the blob store instead of truncating it", async () => {
+		using tempDir = TempDir.createSync("@snapcompact-frame-persistence-");
+		const blobStore = new BlobStore(tempDir.path());
+		// 400k bytes -> ~533k base64 chars, comfortably past the 500k persist cap
+		// that previously truncated the frame and appended the notice.
+		const frameData = Buffer.alloc(400_000, 7).toString("base64");
+		expect(isStrictBase64(frameData)).toBe(true);
+		expect(frameData.length).toBeGreaterThan(500_000);
+
+		const archive: Archive = {
+			frames: [{ data: frameData, mimeType: "image/png", cols: 100, rows: 100, chars: 5000 }],
+			totalChars: 5000,
+			truncatedChars: 0,
+			text: "archived source text",
+		};
+		const entry: CompactionEntry = {
+			type: "compaction",
+			id: "compaction-1",
+			parentId: null,
+			timestamp: new Date(0).toISOString(),
+			summary: "summary",
+			firstKeptEntryId: "entry-1",
+			tokensBefore: 5000,
+			preserveData: { [snapcompact.PRESERVE_KEY]: archive },
+		};
+
+		const persisted = prepareEntryForPersistence(entry, blobStore) as CompactionEntry;
+		const persistedArchive = persisted.preserveData![snapcompact.PRESERVE_KEY] as Archive;
+		expect(isBlobRef(persistedArchive.frames[0]!.data)).toBe(true);
+		expect(persistedArchive.frames[0]!.data).not.toContain("[Session persistence truncated large content]");
+
+		const loaded: CompactionEntry[] = [structuredClone(persisted)];
+		await resolveBlobRefsInEntries(loaded, blobStore);
+		const loadedArchive = snapcompact.getPreservedArchive(loaded[0]!.preserveData)!;
+		expect(loadedArchive.frames[0]!.data).toBe(frameData);
+
+		const blocks = snapcompact.historyBlocks(loadedArchive, {
+			maxFrameDataBytes: snapcompact.FRAME_DATA_BYTES_BUDGET,
+		});
+		const imageBlocks = blocks.filter((block): block is ImageContent => block.type === "image");
+		expect(imageBlocks).toHaveLength(1);
+		expect(imageBlocks.every(block => isStrictBase64(block.data))).toBe(true);
 	});
 });


### PR DESCRIPTION
## Repro
A long session using `compaction.strategy: snapcompact` produces PNG frames whose base64 `data` exceeds 500,000 chars. After stopping and resuming, the next provider request fails with `400 invalid base64 data`. Reproduced on `main` with a compaction entry carrying one 533,336-char frame: `prepareEntryForPersistence` truncated the frame to 500,000 chars and appended `[Session persistence truncated large content]`, and the reloaded `historyBlocks()` image block failed strict base64 validation (`ROUND-TRIP VALID: false`).

## Cause
Snapcompact frame archives live under `preserveData.snapcompact.frames[]`, so `truncateForPersistence()` in `packages/coding-agent/src/session/session-persistence.ts` reaches each frame's base64 with parent key `frames`. `shouldExternalizeImagePayload()` only externalized image payloads under keys `content`/`images`, so frames fell through to the generic string branch, which appends `TRUNCATION_NOTICE` past `MAX_PERSIST_CHARS` and corrupts the base64. The load path (`resolvePersistedBlobRefs()` in `session-loader.ts`) had the same key restriction, so the two never externalized frames. `packages/snapcompact/src/snapcompact.ts` maps `archive.frames[].data` straight back into image content on resume.

## Fix
- Add exported `isExternalizableImagePosition()` in `session-persistence.ts` that recognizes the three externalizable image positions — `content` image block, `images[]`, and now snapcompact `frames[]`.
- Rebuild `shouldExternalizeImagePayload()` on top of it (persist path externalizes frame base64 to the blob store instead of truncating).
- Reuse the same predicate in `session-loader.ts` `resolvePersistedBlobRefs()` so persist and load stay symmetric and a frame externalized on write is always resolved on read.
- Add a changelog entry.

## Verification
`bun test test/session-persistence-images.test.ts` (added `snapcompact frame persistence` round-trip: persist a 533,336-char frame, assert it becomes a blob ref with no truncation notice, reload, assert the frame data is byte-identical to the original, and strict-base64-validate every `historyBlocks()` image block). Result: 4 pass, 0 fail. Also ran `session-loader-stream` and typechecked the package (`bun --filter '@oh-my-pi/pi-coding-agent' check:types`, exit 0).

Fixes #9901