### PR TITLE
feat(catalog): add runtime shared-catalog refresh

### DIFF
--- a/docs/models.md
+++ b/docs/models.md
@@ -170,7 +170,7 @@ ModelRegistry pipeline (on refresh):
 5. Merge custom `models`:
    - same `provider + id` replaces existing
    - otherwise append
-6. Load cached/runtime-discovered models (Ollama, llama.cpp, LM Studio, plus built-in provider managers), then re-apply model overrides.
+6. Load cached and runtime-discovered models. This includes local servers, built-in provider managers, and the shared models.dev catalog for known providers. Re-apply model overrides after the merge.
 
 ### Provider-model cache and static fingerprint
 
@@ -182,6 +182,14 @@ catalog matches the cached one, the cached rows are returned verbatim —
 the static + dynamic merge is bypassed entirely. The fingerprint is
 memoized per process by tagging the static-models array with a symbol
 property, so repeated cold-start calls do not re-hash.
+
+### Shared catalog refresh
+
+The bundled catalog remains the startup and offline baseline. After startup loads bundled and cached rows synchronously, the existing background refresh lifecycle fetches the current shared models.dev catalog for known providers. New model IDs are merged additively into each provider's bundled slice, normalized through that provider's catalog descriptor, and persisted in the model-cache database. This allows newly published models to appear without waiting for a new OMP binary.
+
+Remote rows can supply current limits, pricing, modalities, and capability flags for newly added IDs, but they cannot introduce code, arbitrary headers, or an unregistered provider. A successful provider endpoint discovery remains authoritative for account availability. The shared catalog is not authoritative: it does not remove bundled models when a remote row disappears.
+
+Fresh cached snapshots avoid a network request. If refresh fails, OMP keeps the last usable cached snapshot and marks it stale; without a cache, it falls back to the bundled catalog. Provider discovery state records `source` (`bundled`, `models.dev`, `provider`, or `cache`) and `fetchedAt` so callers can distinguish current remote data from an offline fallback.
 
 ## Provider and model identity
 

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added cached background refresh from the shared models.dev catalog so newly published models for known providers can appear without a new OMP release, while bundled models remain the offline fallback.
+
 ## [18.0.7] - 2026-08-26
 
 ### Fixed

--- a/packages/catalog/scripts/generate-models.ts
+++ b/packages/catalog/scripts/generate-models.ts
@@ -30,6 +30,7 @@ import {
 	isCatalogDescriptor,
 } from "../src/provider-models/descriptor-types";
 import { PROVIDER_DESCRIPTORS } from "../src/provider-models/descriptors";
+import { filterModelsDevCatalogRows } from "../src/provider-models/models-dev-policies";
 import {
 	AIAND_STATIC_MODELS,
 	ALIBABA_TOKEN_PLAN_STATIC_MODELS,
@@ -64,8 +65,6 @@ import {
 	applyGeneratedModelPolicies,
 	applyOllamaCloudOutputCap,
 	CLOUDFLARE_FALLBACK_MODEL,
-	dropBedrockMantleOpenAIModels,
-	dropUnsupportedBedrockGeoIds,
 	hasBillableCost,
 	linkOpenAIPromotionTargets,
 } from "./generated-policies";
@@ -337,50 +336,6 @@ function applyFireworksDeepSeekReasoningShape(models: readonly ModelSpec[]): Mod
 		if (model.provider !== "fireworks" || model.api !== "openai-completions") return model;
 		// `.api` equality doesn't narrow the generic; the guard makes this cast sound.
 		return stripFireworksDeepSeekThinkingToggle(model as ModelSpec<"openai-completions">, model.id);
-	});
-}
-
-/**
- * Z.AI's `/v1/models` advertises context-tier variants with a `[1m]` suffix
- * (e.g. `glm-5.2[1m]`). That suffix is a Claude Code-side convention — Z.AI's
- * own docs instruct users to append `[1m]` to enable 1M context *inside Claude
- * Code* — but the inference endpoint rejects the bracketed id outright with
- * `[1211][Unknown Model, please check the model code.]`. The base id
- * (`glm-5.2`) already carries the full 1M context window (pinned by
- * {@link applyGeneratedModelPolicy}), so drop the unusable bracketed siblings
- * from the bundled catalog rather than ship a model that 400s on first use.
- */
-function dropUnusableZaiContextTierIds(models: readonly ModelSpec[]): ModelSpec[] {
-	return models.filter(model => !(model.provider === "zai" && model.id.endsWith("[1m]")));
-}
-
-/**
- * Fireworks discovery and prior snapshots can surface internal control-plane
- * resource ids (`accounts/fireworks/{models,routers}/...`) alongside the public
- * request ids (`kimi-k2.7-code`, `deepseek-v4-flash`, ...). The wire ids are an
- * implementation detail the request path reconstructs from the public id, so
- * drop them from the bundle outright.
- */
-function dropFireworksWireIds(models: readonly ModelSpec[]): ModelSpec[] {
-	return models.filter(
-		model =>
-			!(
-				(model.provider === "fireworks" || model.provider === "firepass") &&
-				model.id.startsWith("accounts/fireworks/")
-			),
-	);
-}
-
-/**
- * Xiaomi's `/v1/models` can advertise ASR/TTS ids alongside chat/completions
- * models. Runtime discovery filters them, but previous bundled snapshots can
- * still resurrect those stale ids via the fallback merge. Drop them here so the
- * committed catalog matches the runtime surface.
- */
-function dropXiaomiAudioOnlyIds(models: readonly ModelSpec[]): ModelSpec[] {
-	return models.filter(model => {
-		const isXiaomiProvider = model.provider === "xiaomi" || model.provider.startsWith("xiaomi-token-plan-");
-		return !isXiaomiProvider || (!model.id.includes("-tts") && !model.id.includes("-asr"));
 	});
 }
 
@@ -701,11 +656,7 @@ async function generateModels() {
 	allModels = applyAntigravityPricingFallback(allModels);
 	allModels = applyKimiMaxTokensCap(allModels);
 	allModels = applyFireworksDeepSeekReasoningShape(allModels);
-	allModels = dropFireworksWireIds(allModels);
-	allModels = dropUnusableZaiContextTierIds(allModels);
-	allModels = dropXiaomiAudioOnlyIds(allModels);
-	allModels = dropUnsupportedBedrockGeoIds(allModels);
-	allModels = dropBedrockMantleOpenAIModels(allModels);
+	allModels = filterModelsDevCatalogRows(allModels);
 	allModels = normalizeAntigravityEndpoint(allModels);
 	// Normalize display names: gateway author prefixes ("OpenAI: …"), alias
 	// markers ("(latest)"), provider attribution ("(Antigravity)"), and

--- a/packages/catalog/scripts/generated-policies.ts
+++ b/packages/catalog/scripts/generated-policies.ts
@@ -54,36 +54,6 @@ export const CLOUDFLARE_FALLBACK_MODEL: ModelSpec<"anthropic-messages"> = {
 	maxTokens: 64000,
 };
 
-/**
- * `stencil.so` currently lists `jp.anthropic.claude-opus-5`, but AWS's own
- * Bedrock model card documents only `anthropic.claude-opus-5` plus the `us.`,
- * `eu.`, `au.`, and `global.` Geo/Global inference-profile IDs under
- * Programmatic Access; Japan regions are marked unsupported for Geo inference
- * in the same card's regional-availability table. Bedrock rejects an
- * undocumented inference-profile ID outright, so drop this specific upstream
- * row rather than ship a selector that 4xxs on first use (PR #6591 review).
- * https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-opus-5.html
- */
-export function dropUnsupportedBedrockGeoIds(models: readonly ModelSpec[]): ModelSpec[] {
-	return models.filter(model => !(model.provider === "amazon-bedrock" && model.id === "jp.anthropic.claude-opus-5"));
-}
-
-const BEDROCK_MANTLE_OPENAI_MODEL_IDS: Record<string, true> = {
-	"openai.gpt-5.4": true,
-	"openai.gpt-5.5": true,
-	"openai.gpt-5.6-luna": true,
-	"openai.gpt-5.6-sol": true,
-	"openai.gpt-5.6-terra": true,
-};
-
-/**
- * models.dev exposes these Responses-only models under amazon-bedrock, whose
- * descriptor uses Converse. The working Mantle rows come from the static seed.
- */
-export function dropBedrockMantleOpenAIModels(models: readonly ModelSpec[]): ModelSpec[] {
-	return models.filter(model => !(model.provider === "amazon-bedrock" && BEDROCK_MANTLE_OPENAI_MODEL_IDS[model.id]));
-}
-
 /** True when any component of a model's per-million-token cost is nonzero. */
 export function hasBillableCost(cost: ModelSpec["cost"]): boolean {
 	return cost.input !== 0 || cost.output !== 0 || cost.cacheRead !== 0 || cost.cacheWrite !== 0;

--- a/packages/catalog/src/model-manager.ts
+++ b/packages/catalog/src/model-manager.ts
@@ -253,17 +253,18 @@ export async function resolveProviderModels<TApi extends Api = Api, TModelsDevPa
 		cacheFingerprintMatches &&
 		!cacheHasUnresolvedHeaders
 	) {
-		const cachedModels = additiveStaticModelIds
-			? mergeDynamicModels(
-					staticModels,
-					restoredCache.models.filter(model => !additiveStaticModelIds.has(model.id)),
-				)
+		const cacheContribution = additiveStaticModelIds
+			? restoredCache.models.filter(model => !additiveStaticModelIds.has(model.id))
 			: restoredCache.models;
+		const cachedModels = additiveStaticModelIds
+			? mergeDynamicModels(staticModels, cacheContribution)
+			: restoredCache.models;
+		const source: ModelResolutionSource = cacheContribution.length > 0 ? "cache" : "bundled";
 		return {
 			models: collapseBuiltModelVariants(cachedModels),
 			stale: false,
-			source: "cache",
-			updatedAt: cache.updatedAt,
+			source,
+			...(source === "cache" ? { updatedAt: cache.updatedAt } : {}),
 		};
 	}
 
@@ -368,18 +369,23 @@ export async function resolveProviderModels<TApi extends Api = Api, TModelsDevPa
 			);
 		}
 	}
+	const cacheContributed = cacheModels.length > 0;
 	const source: ModelResolutionSource = dynamicFetchSucceeded
 		? "provider"
 		: modelsDevFetchSucceeded
 			? "models.dev"
-			: cache
+			: cacheContributed
 				? "cache"
 				: "bundled";
 	return {
 		models,
 		stale: !resolutionAuthoritative,
 		source,
-		...(remoteUpdatedAt !== undefined ? { updatedAt: remoteUpdatedAt } : cache ? { updatedAt: cache.updatedAt } : {}),
+		...(remoteUpdatedAt !== undefined
+			? { updatedAt: remoteUpdatedAt }
+			: cacheContributed && cache
+				? { updatedAt: cache.updatedAt }
+				: {}),
 	};
 }
 

--- a/packages/catalog/src/model-manager.ts
+++ b/packages/catalog/src/model-manager.ts
@@ -181,9 +181,10 @@ function restoreCachedModelHeaders<TApi extends Api>(
 
 /**
  * Resolves provider models with source precedence:
- * static -> stencil.so -> cache -> dynamic.
+ * static -> cached fallback -> stencil.so -> dynamic.
  *
- * Later sources override earlier ones by model id.
+ * Later sources override earlier ones by model id. Cached rows participate only
+ * when at least one configured remote source did not refresh successfully.
  */
 export async function resolveProviderModels<TApi extends Api = Api, TModelsDevPayload = unknown>(
 	options: ModelManagerOptions<TApi, TModelsDevPayload>,
@@ -261,18 +262,22 @@ export async function resolveProviderModels<TApi extends Api = Api, TModelsDevPa
 		: [null, null];
 	const modelsDevFetchSucceeded = fetchedModelsDevModels !== null;
 	const normalizedModelsDevModels = normalizeModelList<TApi>(fetchedModelsDevModels ?? []);
-	let modelsDevModels = normalizedModelsDevModels;
-	if (options.modelsDev?.additiveOnly && normalizedModelsDevModels.length > 0 && staticModels.length > 0) {
-		const staticModelIds = new Set(staticModels.map(model => model.id));
-		modelsDevModels = normalizedModelsDevModels.filter(model => !staticModelIds.has(model.id));
-	}
+	const additiveStaticModelIds =
+		options.modelsDev?.additiveOnly && staticModels.length > 0
+			? new Set(staticModels.map(model => model.id))
+			: undefined;
+	const modelsDevModels = additiveStaticModelIds
+		? normalizedModelsDevModels.filter(model => !additiveStaticModelIds.has(model.id))
+		: normalizedModelsDevModels;
 	const shouldUseFreshCacheAsAuthoritative =
 		strategy === "online-if-uncached" && hasUsableFreshCache && hasAuthoritativeCache;
 	const dynamicFetchSucceeded = fetchedDynamicModels !== null;
-	// Endpoint discovery, when configured, decides whether this cycle is
-	// authoritative. Otherwise a successful shared-catalog fetch does.
-	const resolutionFetchSucceeded = hasDynamicFetcher ? dynamicFetchSucceeded : modelsDevFetchSucceeded;
-	const cacheModels = resolutionFetchSucceeded
+	const anyRemoteFetchSucceeded = modelsDevFetchSucceeded || dynamicFetchSucceeded;
+	const allConfiguredRemoteFetchesSucceeded =
+		(!hasModelsDevFetcher || modelsDevFetchSucceeded) && (!hasDynamicFetcher || dynamicFetchSucceeded);
+	const authoritativeDynamicFetchSucceeded = dynamicModelsAuthoritative && dynamicFetchSucceeded;
+	const remoteResolutionComplete = authoritativeDynamicFetchSucceeded || allConfiguredRemoteFetchesSucceeded;
+	const preparedCacheModels = remoteResolutionComplete
 		? []
 		: prepareCacheModelsForStaticMismatch(
 				usableCachedModels,
@@ -280,6 +285,11 @@ export async function resolveProviderModels<TApi extends Api = Api, TModelsDevPa
 				cacheFingerprintMatches,
 				options.dropCachedModelIdsOnStaticMismatch,
 			);
+	// Additive shared-catalog rows may only introduce IDs. Apply that boundary
+	// to cache fallback too, including snapshots written by an older binary.
+	const cacheModels = additiveStaticModelIds
+		? preparedCacheModels.filter(model => !additiveStaticModelIds.has(model.id))
+		: preparedCacheModels;
 	const dynamicModels = fetchedDynamicModels ?? [];
 	// A successful empty endpoint result stays authoritative for THIS cycle (so an
 	// intentional catalog emptying still prunes removed models downstream), but
@@ -287,25 +297,24 @@ export async function resolveProviderModels<TApi extends Api = Api, TModelsDevPa
 	// short retry that recovers a transient empty response (#6620). Shared
 	// models.dev snapshots may be empty for one provider and remain authoritative.
 	const cacheAuthoritative = hasDynamicFetcher
-		? dynamicFetchSucceeded && dynamicModels.length > 0
+		? dynamicFetchSucceeded &&
+			dynamicModels.length > 0 &&
+			(dynamicModelsAuthoritative || !hasModelsDevFetcher || modelsDevFetchSucceeded)
 		: modelsDevFetchSucceeded;
-	const mergedWithCache = mergeDynamicModels(mergeModelSources(staticModels, modelsDevModels), cacheModels);
-	const mergedModels = mergeDynamicModels(mergedWithCache, dynamicModels);
+	const mergedWithCache = mergeModelSources(staticModels, cacheModels);
+	const mergedWithModelsDev = mergeDynamicModels(mergedWithCache, modelsDevModels);
+	const mergedModels = mergeDynamicModels(mergedWithModelsDev, dynamicModels);
 	const models = collapseBuiltModelVariants(
-		dynamicModelsAuthoritative && dynamicFetchSucceeded ? retainModelIds(mergedModels, dynamicModels) : mergedModels,
+		authoritativeDynamicFetchSucceeded ? retainModelIds(mergedModels, dynamicModels) : mergedModels,
 	);
-	const resolutionAuthoritative = !hasRemoteFetcher || resolutionFetchSucceeded || shouldUseFreshCacheAsAuthoritative;
-	const remoteUpdatedAt = dynamicFetchSucceeded || modelsDevFetchSucceeded ? now() : undefined;
+	const resolutionAuthoritative = !hasRemoteFetcher || remoteResolutionComplete || shouldUseFreshCacheAsAuthoritative;
+	const remoteUpdatedAt = anyRemoteFetchSucceeded ? now() : undefined;
 	if (shouldFetchFromNetwork) {
-		if (resolutionFetchSucceeded) {
-			const mergedSnapshot = mergeDynamicModels(mergeModelSources(staticModels, modelsDevModels), dynamicModels);
-			const snapshotModels = dynamicModelsAuthoritative
-				? retainModelIds(mergedSnapshot, dynamicModels)
-				: mergedSnapshot;
+		if (anyRemoteFetchSucceeded) {
 			writeModelCache(
 				cacheProviderId,
 				remoteUpdatedAt!,
-				collapseBuiltModelVariants(snapshotModels),
+				models,
 				cacheAuthoritative,
 				staticFingerprint,
 				dbPath,
@@ -327,16 +336,17 @@ export async function resolveProviderModels<TApi extends Api = Api, TModelsDevPa
 			const latestUsableCacheModels = latestRestoredCache.models.filter(
 				model => !latestRestoredCache.unresolvedModelIds.has(model.id),
 			);
+			const preparedLatestCacheModels = prepareCacheModelsForStaticMismatch(
+				latestUsableCacheModels,
+				staticModels,
+				cacheFingerprintMatches,
+				options.dropCachedModelIdsOnStaticMismatch,
+			);
+			const latestCacheModels = additiveStaticModelIds
+				? preparedLatestCacheModels.filter(model => !additiveStaticModelIds.has(model.id))
+				: preparedLatestCacheModels;
 			const fallbackSnapshotModels = collapseBuiltModelVariants(
-				mergeDynamicModels(
-					mergeModelSources(staticModels, modelsDevModels),
-					prepareCacheModelsForStaticMismatch(
-						latestUsableCacheModels,
-						staticModels,
-						cacheFingerprintMatches,
-						options.dropCachedModelIdsOnStaticMismatch,
-					),
-				),
+				mergeDynamicModels(mergeModelSources(staticModels, latestCacheModels), modelsDevModels),
 			);
 			writeModelCache(
 				cacheProviderId,

--- a/packages/catalog/src/model-manager.ts
+++ b/packages/catalog/src/model-manager.ts
@@ -215,7 +215,7 @@ export async function resolveProviderModels<TApi extends Api = Api, TModelsDevPa
 	const cacheHasUnresolvedHeaders = restoredCache.unresolvedModelIds.size > 0;
 	const dynamicModelsAuthoritative = options.dynamicModelsAuthoritative ?? false;
 	const cacheDropIds = options.dropCachedModelIdsOnStaticMismatch;
-	const staticCatalogFingerprint = fingerprintStatic(staticModels, dynamicModelsAuthoritative);
+	const staticCatalogFingerprint = fingerprintStaticModels(staticModels, dynamicModelsAuthoritative);
 	// Endpoint-migration policy is cache identity: adding an id must invalidate
 	// matching-static-catalog caches written by the prior resolver.
 	const staticFingerprint =
@@ -494,22 +494,22 @@ function retainModelIds<TApi extends Api>(
 	return models.filter(model => retainedIds.has(model.id));
 }
 
-/**
- * Stable, low-collision fingerprint of a static catalog slice. Cached by
- * reference so repeat calls in the same process (e.g. multiple cold-start
- * arms calling `resolveProviderModels` with the same `staticModels` array)
- * skip the JSON+hash work after the first call.
- */
 const MODEL_CACHE_FINGERPRINT_VERSION = "merge-v3";
 const kStaticFingerprint = Symbol("model-manager.staticFingerprint");
 type ModelArrayWithFingerprint = readonly Model<Api>[] & { [kStaticFingerprint]?: string };
-function fingerprintStatic<TApi extends Api>(
+
+/**
+ * Return the versioned, low-collision model-cache identity for a static provider
+ * slice. Results are cached by array reference so repeat cold-start paths skip
+ * the JSON serialization and hash.
+ */
+export function fingerprintStaticModels<TApi extends Api>(
 	models: readonly Model<TApi>[],
 	dynamicModelsAuthoritative = false,
 ): string {
 	if (models.length === 0) return `${MODEL_CACHE_FINGERPRINT_VERSION}:empty`;
 	if (dynamicModelsAuthoritative)
-		return `${MODEL_CACHE_FINGERPRINT_VERSION}:authoritative:${fingerprintStatic(models)}`;
+		return `${MODEL_CACHE_FINGERPRINT_VERSION}:authoritative:${fingerprintStaticModels(models)}`;
 	const tagged = models as ModelArrayWithFingerprint;
 	const cached = tagged[kStaticFingerprint];
 	if (cached !== undefined) return cached;

--- a/packages/catalog/src/model-manager.ts
+++ b/packages/catalog/src/model-manager.ts
@@ -502,7 +502,7 @@ function retainModelIds<TApi extends Api>(
 
 const MODEL_CACHE_FINGERPRINT_VERSION = "merge-v3";
 const kStaticFingerprint = Symbol("model-manager.staticFingerprint");
-type ModelArrayWithFingerprint = readonly Model<Api>[] & { [kStaticFingerprint]?: string };
+type ModelArrayWithFingerprint = readonly (ModelSpec<Api> | Model<Api>)[] & { [kStaticFingerprint]?: string };
 
 /**
  * Return the versioned, low-collision model-cache identity for a static provider
@@ -510,7 +510,7 @@ type ModelArrayWithFingerprint = readonly Model<Api>[] & { [kStaticFingerprint]?
  * the JSON serialization and hash.
  */
 export function fingerprintStaticModels<TApi extends Api>(
-	models: readonly Model<TApi>[],
+	models: readonly (ModelSpec<TApi> | Model<TApi>)[],
 	dynamicModelsAuthoritative = false,
 ): string {
 	if (models.length === 0) return `${MODEL_CACHE_FINGERPRINT_VERSION}:empty`;

--- a/packages/catalog/src/model-manager.ts
+++ b/packages/catalog/src/model-manager.ts
@@ -198,6 +198,10 @@ export async function resolveProviderModels<TApi extends Api = Api, TModelsDevPa
 	const staticModels = options.staticModels
 		? passModelList<TApi>(options.staticModels)
 		: (getBundledModels(options.providerId as GeneratedProvider) as Model<TApi>[]);
+	const additiveStaticModelIds =
+		options.modelsDev?.additiveOnly && staticModels.length > 0
+			? new Set(staticModels.map(model => model.id))
+			: undefined;
 	const cache = readModelCache<TApi>(cacheProviderId, ttlMs, now, dbPath);
 	const restoredCache = restoreCachedModelHeaders(
 		cache?.models ?? [],
@@ -240,8 +244,8 @@ export async function resolveProviderModels<TApi extends Api = Api, TModelsDevPa
 	// Cold-start fast path: when a fresh, authoritative cache exists, the network
 	// fetch is skipped, AND the static catalog slice is byte-identical to what
 	// was merged in last time, the cache row IS the authoritative merge result.
-	// Re-running `mergeDynamicModels(static, cache)` would just rebuild the same
-	// objects (~800ms in the steady-state cold-start profile for `omp -p hi`).
+	// Additive caches still need same-id rows stripped because an older binary
+	// may have written the snapshot before additive semantics were enabled.
 	if (
 		!shouldFetchFromNetwork &&
 		cache?.fresh &&
@@ -249,8 +253,14 @@ export async function resolveProviderModels<TApi extends Api = Api, TModelsDevPa
 		cacheFingerprintMatches &&
 		!cacheHasUnresolvedHeaders
 	) {
+		const cachedModels = additiveStaticModelIds
+			? mergeDynamicModels(
+					staticModels,
+					restoredCache.models.filter(model => !additiveStaticModelIds.has(model.id)),
+				)
+			: restoredCache.models;
 		return {
-			models: collapseBuiltModelVariants(restoredCache.models),
+			models: collapseBuiltModelVariants(cachedModels),
 			stale: false,
 			source: "cache",
 			updatedAt: cache.updatedAt,
@@ -262,10 +272,6 @@ export async function resolveProviderModels<TApi extends Api = Api, TModelsDevPa
 		: [null, null];
 	const modelsDevFetchSucceeded = fetchedModelsDevModels !== null;
 	const normalizedModelsDevModels = normalizeModelList<TApi>(fetchedModelsDevModels ?? []);
-	const additiveStaticModelIds =
-		options.modelsDev?.additiveOnly && staticModels.length > 0
-			? new Set(staticModels.map(model => model.id))
-			: undefined;
 	const modelsDevModels = additiveStaticModelIds
 		? normalizedModelsDevModels.filter(model => !additiveStaticModelIds.has(model.id))
 		: normalizedModelsDevModels;

--- a/packages/catalog/src/model-manager.ts
+++ b/packages/catalog/src/model-manager.ts
@@ -21,6 +21,8 @@ export interface ModelsDevFallback<TApi extends Api = Api, TPayload = unknown> {
 	fetch(): Promise<TPayload>;
 	/** Maps payload into provider models. */
 	map(payload: TPayload, providerId: Provider): readonly ModelSpec<TApi>[];
+	/** When true, mapped rows can add model ids but cannot replace static metadata. */
+	additiveOnly?: boolean;
 }
 
 /**
@@ -58,17 +60,25 @@ export interface ModelManagerOptions<TApi extends Api = Api, TModelsDevPayload =
 }
 
 /**
+ * Catalog source that most recently refreshed the resolved provider snapshot.
+ */
+export type ModelResolutionSource = "bundled" | "cache" | "models.dev" | "provider";
+
+/**
  * Resolution result.
  *
  * `stale` is false when the resolved catalog is authoritative for the selected provider:
- * - a dynamic endpoint fetch succeeded in this call (an empty catalog is still
+ * - a provider endpoint fetch succeeded in this call (an empty catalog is still
  *   authoritative for the cycle, so downstream pruning of removed models runs),
+ * - a models.dev fetch succeeded for a provider without endpoint discovery,
  * - a still-fresh authoritative cache was reused in `online-if-uncached` mode, or
- * - the provider has no dynamic fetcher configured.
+ * - the provider has no remote fetcher configured.
  */
 export interface ModelResolutionResult<TApi extends Api = Api> {
 	models: Model<TApi>[];
 	stale: boolean;
+	source: ModelResolutionSource;
+	updatedAt?: number;
 }
 
 /**
@@ -219,14 +229,12 @@ export async function resolveProviderModels<TApi extends Api = Api, TModelsDevPa
 		(!dynamicModelsAuthoritative || cacheFingerprintMatches);
 	const dynamicFetcher = options.fetchDynamicModels;
 	const hasDynamicFetcher = typeof dynamicFetcher === "function";
-	const hasAuthoritativeCache = ((cache?.authoritative ?? false) && hasUsableFreshCache) || !hasDynamicFetcher;
+	const hasModelsDevFetcher = options.modelsDev !== undefined;
+	const hasRemoteFetcher = hasDynamicFetcher || hasModelsDevFetcher;
+	const hasAuthoritativeCache = ((cache?.authoritative ?? false) && hasUsableFreshCache) || !hasRemoteFetcher;
 	const cacheAgeMs = cache ? now() - cache.updatedAt : Number.POSITIVE_INFINITY;
-	const shouldFetchFromNetwork = shouldFetchRemoteSources(
-		strategy,
-		hasUsableFreshCache,
-		hasAuthoritativeCache,
-		cacheAgeMs,
-	);
+	const shouldFetchFromNetwork =
+		hasRemoteFetcher && shouldFetchRemoteSources(strategy, hasUsableFreshCache, hasAuthoritativeCache, cacheAgeMs);
 
 	// Cold-start fast path: when a fresh, authoritative cache exists, the network
 	// fetch is skipped, AND the static catalog slice is byte-identical to what
@@ -240,17 +248,31 @@ export async function resolveProviderModels<TApi extends Api = Api, TModelsDevPa
 		cacheFingerprintMatches &&
 		!cacheHasUnresolvedHeaders
 	) {
-		return { models: collapseBuiltModelVariants(restoredCache.models), stale: false };
+		return {
+			models: collapseBuiltModelVariants(restoredCache.models),
+			stale: false,
+			source: "cache",
+			updatedAt: cache.updatedAt,
+		};
 	}
 
 	const [fetchedModelsDevModels, fetchedDynamicModels] = shouldFetchFromNetwork
 		? await Promise.all([fetchModelsDev(options), dynamicFetcher ? fetchDynamicModels(dynamicFetcher) : null])
 		: [null, null];
-	const modelsDevModels = normalizeModelList<TApi>(fetchedModelsDevModels ?? []);
+	const modelsDevFetchSucceeded = fetchedModelsDevModels !== null;
+	const normalizedModelsDevModels = normalizeModelList<TApi>(fetchedModelsDevModels ?? []);
+	let modelsDevModels = normalizedModelsDevModels;
+	if (options.modelsDev?.additiveOnly && normalizedModelsDevModels.length > 0 && staticModels.length > 0) {
+		const staticModelIds = new Set(staticModels.map(model => model.id));
+		modelsDevModels = normalizedModelsDevModels.filter(model => !staticModelIds.has(model.id));
+	}
 	const shouldUseFreshCacheAsAuthoritative =
 		strategy === "online-if-uncached" && hasUsableFreshCache && hasAuthoritativeCache;
 	const dynamicFetchSucceeded = fetchedDynamicModels !== null;
-	const cacheModels = dynamicFetchSucceeded
+	// Endpoint discovery, when configured, decides whether this cycle is
+	// authoritative. Otherwise a successful shared-catalog fetch does.
+	const resolutionFetchSucceeded = hasDynamicFetcher ? dynamicFetchSucceeded : modelsDevFetchSucceeded;
+	const cacheModels = resolutionFetchSucceeded
 		? []
 		: prepareCacheModelsForStaticMismatch(
 				usableCachedModels,
@@ -259,36 +281,39 @@ export async function resolveProviderModels<TApi extends Api = Api, TModelsDevPa
 				options.dropCachedModelIdsOnStaticMismatch,
 			);
 	const dynamicModels = fetchedDynamicModels ?? [];
-	// A successful empty result stays authoritative for THIS cycle (so an
+	// A successful empty endpoint result stays authoritative for THIS cycle (so an
 	// intentional catalog emptying still prunes removed models downstream), but
 	// is NOT pinned into the cache as authoritative — that would suppress the
-	// short retry that recovers a transient empty response (#6620). The two
-	// concerns are deliberately separate: result authority vs. cache retry.
-	const dynamicCacheAuthoritative = dynamicFetchSucceeded && dynamicModels.length > 0;
+	// short retry that recovers a transient empty response (#6620). Shared
+	// models.dev snapshots may be empty for one provider and remain authoritative.
+	const cacheAuthoritative = hasDynamicFetcher
+		? dynamicFetchSucceeded && dynamicModels.length > 0
+		: modelsDevFetchSucceeded;
 	const mergedWithCache = mergeDynamicModels(mergeModelSources(staticModels, modelsDevModels), cacheModels);
 	const mergedModels = mergeDynamicModels(mergedWithCache, dynamicModels);
 	const models = collapseBuiltModelVariants(
 		dynamicModelsAuthoritative && dynamicFetchSucceeded ? retainModelIds(mergedModels, dynamicModels) : mergedModels,
 	);
-	const dynamicAuthoritative = !hasDynamicFetcher || dynamicFetchSucceeded || shouldUseFreshCacheAsAuthoritative;
+	const resolutionAuthoritative = !hasRemoteFetcher || resolutionFetchSucceeded || shouldUseFreshCacheAsAuthoritative;
+	const remoteUpdatedAt = dynamicFetchSucceeded || modelsDevFetchSucceeded ? now() : undefined;
 	if (shouldFetchFromNetwork) {
-		if (dynamicFetchSucceeded) {
+		if (resolutionFetchSucceeded) {
 			const mergedSnapshot = mergeDynamicModels(mergeModelSources(staticModels, modelsDevModels), dynamicModels);
 			const snapshotModels = dynamicModelsAuthoritative
 				? retainModelIds(mergedSnapshot, dynamicModels)
 				: mergedSnapshot;
 			writeModelCache(
 				cacheProviderId,
-				now(),
+				remoteUpdatedAt!,
 				collapseBuiltModelVariants(snapshotModels),
-				dynamicCacheAuthoritative,
+				cacheAuthoritative,
 				staticFingerprint,
 				dbPath,
 				staticModels,
 				restorableHeaderFallback,
 			);
 		} else {
-			// Dynamic fetch failed — update cache with a non-authoritative snapshot so
+			// Remote fetch failed — update cache with a non-authoritative snapshot so
 			// stale state remains visible while retry backoff still applies.
 			const latestCache = readModelCache<TApi>(cacheProviderId, ttlMs, now, dbPath);
 			const latestRestoredCache = restoreCachedModelHeaders(
@@ -325,9 +350,18 @@ export async function resolveProviderModels<TApi extends Api = Api, TModelsDevPa
 			);
 		}
 	}
+	const source: ModelResolutionSource = dynamicFetchSucceeded
+		? "provider"
+		: modelsDevFetchSucceeded
+			? "models.dev"
+			: cache
+				? "cache"
+				: "bundled";
 	return {
 		models,
-		stale: !dynamicAuthoritative,
+		stale: !resolutionAuthoritative,
+		source,
+		...(remoteUpdatedAt !== undefined ? { updatedAt: remoteUpdatedAt } : cache ? { updatedAt: cache.updatedAt } : {}),
 	};
 }
 

--- a/packages/catalog/src/model-manager.ts
+++ b/packages/catalog/src/model-manager.ts
@@ -274,7 +274,9 @@ export async function resolveProviderModels<TApi extends Api = Api, TModelsDevPa
 	const dynamicFetchSucceeded = fetchedDynamicModels !== null;
 	const anyRemoteFetchSucceeded = modelsDevFetchSucceeded || dynamicFetchSucceeded;
 	const allConfiguredRemoteFetchesSucceeded =
-		(!hasModelsDevFetcher || modelsDevFetchSucceeded) && (!hasDynamicFetcher || dynamicFetchSucceeded);
+		hasRemoteFetcher &&
+		(!hasModelsDevFetcher || modelsDevFetchSucceeded) &&
+		(!hasDynamicFetcher || dynamicFetchSucceeded);
 	const authoritativeDynamicFetchSucceeded = dynamicModelsAuthoritative && dynamicFetchSucceeded;
 	const remoteResolutionComplete = authoritativeDynamicFetchSucceeded || allConfiguredRemoteFetchesSucceeded;
 	const preparedCacheModels = remoteResolutionComplete
@@ -301,7 +303,7 @@ export async function resolveProviderModels<TApi extends Api = Api, TModelsDevPa
 			dynamicModels.length > 0 &&
 			(dynamicModelsAuthoritative || !hasModelsDevFetcher || modelsDevFetchSucceeded)
 		: modelsDevFetchSucceeded;
-	const mergedWithCache = mergeModelSources(staticModels, cacheModels);
+	const mergedWithCache = mergeDynamicModels(staticModels, cacheModels);
 	const mergedWithModelsDev = mergeDynamicModels(mergedWithCache, modelsDevModels);
 	const mergedModels = mergeDynamicModels(mergedWithModelsDev, dynamicModels);
 	const models = collapseBuiltModelVariants(
@@ -346,7 +348,7 @@ export async function resolveProviderModels<TApi extends Api = Api, TModelsDevPa
 				? preparedLatestCacheModels.filter(model => !additiveStaticModelIds.has(model.id))
 				: preparedLatestCacheModels;
 			const fallbackSnapshotModels = collapseBuiltModelVariants(
-				mergeDynamicModels(mergeModelSources(staticModels, latestCacheModels), modelsDevModels),
+				mergeDynamicModels(mergeDynamicModels(staticModels, latestCacheModels), modelsDevModels),
 			);
 			writeModelCache(
 				cacheProviderId,
@@ -451,23 +453,6 @@ function prepareCacheModelsForStaticMismatch<TApi extends Api>(
 		sanitizedModels.push(staticIds?.has(model.id) ? { ...model, contextWindow: null, maxTokens: null } : model);
 	}
 	return sanitizedModels;
-}
-
-function mergeModelSources<TApi extends Api>(...sources: readonly (readonly Model<TApi>[])[]): Model<TApi>[] {
-	// Strip out empty/missing sources up front. The hot path is `(static, [])`
-	// (modelsDev disabled / failed) — a single non-empty source means we can
-	// skip the Map churn entirely and just hand back the array.
-	const nonEmpty = sources.filter(source => source.length > 0);
-	if (nonEmpty.length === 0) return [];
-	if (nonEmpty.length === 1) return [...nonEmpty[0]];
-	const merged = new Map<string, Model<TApi>>();
-	for (const source of nonEmpty) {
-		for (const model of source) {
-			if (!model?.id) continue;
-			merged.set(model.id, model);
-		}
-	}
-	return Array.from(merged.values());
 }
 
 function mergeDynamicModels<TApi extends Api>(

--- a/packages/catalog/src/provider-models/models-dev-policies.ts
+++ b/packages/catalog/src/provider-models/models-dev-policies.ts
@@ -1,0 +1,38 @@
+import type { Api, ModelSpec } from "../types";
+
+const BEDROCK_MANTLE_OPENAI_MODEL_IDS: Readonly<Record<string, true>> = {
+	"openai.gpt-5.4": true,
+	"openai.gpt-5.5": true,
+	"openai.gpt-5.6-luna": true,
+	"openai.gpt-5.6-sol": true,
+	"openai.gpt-5.6-terra": true,
+};
+
+/**
+ * Remove models.dev rows that OMP cannot route successfully.
+ *
+ * Generation and runtime refresh share this policy so a live catalog cannot
+ * reintroduce selectors deliberately excluded from the bundled catalog.
+ */
+export function filterModelsDevCatalogRows<TApi extends Api>(models: readonly ModelSpec<TApi>[]): ModelSpec<TApi>[] {
+	return models.filter(model => {
+		if (model.provider === "amazon-bedrock") {
+			// AWS does not document the jp. Opus 5 profile, and the openai.gpt-5.x
+			// rows are Mantle-only ids that Bedrock rejects or misroutes.
+			return model.id !== "jp.anthropic.claude-opus-5" && !BEDROCK_MANTLE_OPENAI_MODEL_IDS[model.id];
+		}
+		if (model.provider === "zai") {
+			// [1m] is a Claude Code selector convention, not an inference id.
+			return !model.id.endsWith("[1m]");
+		}
+		if (model.provider === "fireworks" || model.provider === "firepass") {
+			// Control-plane resource ids are not accepted by the inference API.
+			return !model.id.startsWith("accounts/fireworks/");
+		}
+		if (model.provider === "xiaomi" || model.provider.startsWith("xiaomi-token-plan-")) {
+			// Text-chat transports cannot serve Xiaomi's audio-only models.
+			return !model.id.includes("-tts") && !model.id.includes("-asr");
+		}
+		return true;
+	});
+}

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -139,6 +139,17 @@ function getCatalogSession(fetchImpl: FetchImpl | undefined): CatalogSession {
 	return created;
 }
 
+function waitForCatalogRequest<T>(request: Promise<T>, signal?: AbortSignal): Promise<T> {
+	if (!signal) return request;
+	if (signal.aborted) return Promise.reject(signal.reason);
+	const aborted = Promise.withResolvers<never>();
+	const rejectAborted = () => aborted.reject(signal.reason);
+	signal.addEventListener("abort", rejectAborted, { once: true });
+	return Promise.race([request, aborted.promise]).finally(() => {
+		signal.removeEventListener("abort", rejectAborted);
+	});
+}
+
 const CATALOG_USER_AGENT = USER_AGENT;
 
 /**
@@ -148,9 +159,11 @@ const CATALOG_USER_AGENT = USER_AGENT;
  * responses (test stubs, fallback mirrors) parse identically.
  *
  * Fetched fully once per fetch context: concurrent callers sharing a fetch
- * implementation reuse the in-flight request, while repeat callers send a
- * conditional GET that the server answers with `304`. Transient failures reuse
- * the last in-memory payload for callers that only need best-effort metadata.
+ * implementation reuse one transport request, while repeat callers send a
+ * conditional GET that the server answers with `304`. Each subscriber may stop
+ * waiting independently; the shared transport retains its own hard deadline.
+ * Transient failures reuse the last in-memory payload for callers that only
+ * need best-effort metadata.
  */
 export function fetchWellKnownModels(fetchImpl?: FetchImpl, signal?: AbortSignal): Promise<unknown> {
 	const session = getCatalogSession(fetchImpl);
@@ -163,11 +176,13 @@ export function fetchWellKnownModels(fetchImpl?: FetchImpl, signal?: AbortSignal
 function fetchRevalidatedWellKnownModels(fetchImpl?: FetchImpl, signal?: AbortSignal): Promise<unknown> {
 	const session = getCatalogSession(fetchImpl);
 	if (!session.inflight) {
-		session.inflight = fetchCatalogPayload(fetchImpl ?? discoveryFetch(), session, signal).finally(() => {
+		session.inflight = withCatalogDiscoveryTimeout(DEFAULT_OPENAI_COMPATIBLE_DISCOVERY_TIMEOUT_MS, transportSignal =>
+			fetchCatalogPayload(fetchImpl ?? discoveryFetch(), session, transportSignal),
+		).finally(() => {
 			session.inflight = null;
 		});
 	}
-	return session.inflight;
+	return waitForCatalogRequest(session.inflight, signal);
 }
 
 function fetchRevalidatedWellKnownModelsWithTimeout(

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -47,6 +47,7 @@ import {
 import { createBundledReferenceMap, createReferenceResolver, toModelSpec } from "./bundled-references";
 import { getDefaultModelDiscoveryBaseUrl, resolveModelCacheProviderId } from "./cache-provider-id";
 import type { ModelManagerConfig } from "./descriptor-types";
+import { filterModelsDevCatalogRows } from "./models-dev-policies";
 
 const MODELS_DEV_URL = "https://catalog.stencil.so/models.json.zstd";
 
@@ -6843,6 +6844,6 @@ export function modelsDevCatalogFallback(
 	return {
 		additiveOnly: true,
 		fetch: () => withCatalogDiscoveryTimeout(timeoutMs, signal => fetchWellKnownModels(fetchImpl, signal)),
-		map: payload => (isRecord(payload) ? mapModelsDevToModels(payload, descriptors) : []),
+		map: payload => (isRecord(payload) ? filterModelsDevCatalogRows(mapModelsDevToModels(payload, descriptors)) : []),
 	};
 }

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -114,17 +114,29 @@ function toInputCapabilities(value: unknown): ("text" | "image")[] {
 }
 
 /**
- * Process-wide catalog session: the first call downloads the payload (the one
- * request the server logs); later calls revalidate with `If-None-Match` and
- * reuse the decoded payload on `304`. Failure after a successful load falls
- * back to the session copy.
+ * Catalog sessions are scoped to the fetch implementation that owns their
+ * network and authentication context. Callers sharing one fetch reuse the same
+ * conditional request state; isolated registries cannot observe each other's
+ * payloads, ETags, or in-flight requests.
  */
-const catalogSession: {
+interface CatalogSession {
 	inflight: Promise<unknown> | null;
 	payload: unknown;
 	etag: string | null;
 	hasPayload: boolean;
-} = { inflight: null, payload: undefined, etag: null, hasPayload: false };
+}
+
+const defaultCatalogSession: CatalogSession = { inflight: null, payload: undefined, etag: null, hasPayload: false };
+const catalogSessionsByFetch = new WeakMap<FetchImpl, CatalogSession>();
+
+function getCatalogSession(fetchImpl: FetchImpl | undefined): CatalogSession {
+	if (!fetchImpl) return defaultCatalogSession;
+	const existing = catalogSessionsByFetch.get(fetchImpl);
+	if (existing) return existing;
+	const created: CatalogSession = { inflight: null, payload: undefined, etag: null, hasPayload: false };
+	catalogSessionsByFetch.set(fetchImpl, created);
+	return created;
+}
 
 const CATALOG_USER_AGENT = USER_AGENT;
 
@@ -134,42 +146,47 @@ const CATALOG_USER_AGENT = USER_AGENT;
  * The frame magic is sniffed rather than trusting content-type so plain-JSON
  * responses (test stubs, fallback mirrors) parse identically.
  *
- * Fetched fully once per process: concurrent callers share the in-flight
- * request, repeat callers send a conditional GET that the server answers
- * (and deliberately does not log) with `304`.
+ * Fetched fully once per fetch context: concurrent callers sharing a fetch
+ * implementation reuse the in-flight request, while repeat callers send a
+ * conditional GET that the server answers with `304`.
  */
 export function fetchWellKnownModels(fetchImpl?: FetchImpl, signal?: AbortSignal): Promise<unknown> {
-	if (!catalogSession.inflight) {
-		catalogSession.inflight = fetchCatalogPayload(fetchImpl ?? discoveryFetch(), signal).finally(() => {
-			catalogSession.inflight = null;
+	const session = getCatalogSession(fetchImpl);
+	if (!session.inflight) {
+		session.inflight = fetchCatalogPayload(fetchImpl ?? discoveryFetch(), session, signal).finally(() => {
+			session.inflight = null;
 		});
 	}
-	return catalogSession.inflight;
+	return session.inflight;
 }
 
-async function fetchCatalogPayload(fetchImpl: FetchImpl, signal?: AbortSignal): Promise<unknown> {
+async function fetchCatalogPayload(
+	fetchImpl: FetchImpl,
+	session: CatalogSession,
+	signal?: AbortSignal,
+): Promise<unknown> {
 	const headers: Record<string, string> = {
 		Accept: "application/zstd, application/json",
 		"User-Agent": CATALOG_USER_AGENT,
 	};
-	if (catalogSession.hasPayload && catalogSession.etag) {
-		headers["If-None-Match"] = catalogSession.etag;
+	if (session.hasPayload && session.etag) {
+		headers["If-None-Match"] = session.etag;
 	}
 	let response: Response;
 	try {
 		response = await fetchImpl(MODELS_DEV_URL, { method: "GET", headers, signal });
 	} catch (error) {
-		if (catalogSession.hasPayload) {
-			return catalogSession.payload;
+		if (session.hasPayload) {
+			return session.payload;
 		}
 		throw error;
 	}
-	if (response.status === 304 && catalogSession.hasPayload) {
-		return catalogSession.payload;
+	if (response.status === 304 && session.hasPayload) {
+		return session.payload;
 	}
 	if (!response.ok) {
-		if (catalogSession.hasPayload) {
-			return catalogSession.payload;
+		if (session.hasPayload) {
+			return session.payload;
 		}
 		throw new Error(`models catalog fetch failed: ${response.status}`);
 	}
@@ -177,9 +194,9 @@ async function fetchCatalogPayload(fetchImpl: FetchImpl, signal?: AbortSignal): 
 	const isZstd = bytes.length >= 4 && new DataView(bytes.buffer, bytes.byteOffset).getUint32(0, true) === ZSTD_MAGIC;
 	const text = new TextDecoder().decode(isZstd ? await Bun.zstdDecompress(bytes) : bytes);
 	const payload: unknown = JSON.parse(text);
-	catalogSession.payload = payload;
-	catalogSession.etag = response.headers.get("etag");
-	catalogSession.hasPayload = true;
+	session.payload = payload;
+	session.etag = response.headers.get("etag");
+	session.hasPayload = true;
 	return payload;
 }
 
@@ -6809,19 +6826,23 @@ export const MODELS_DEV_CATALOG_PROVIDER_IDS: readonly string[] = Object.freeze(
 /**
  * Build the shared models.dev fallback for one known provider.
  *
- * Every provider-specific manager shares the process-wide conditional fetch in
- * `fetchWellKnownModels`; the model manager persists each mapped provider slice
- * independently so startup can restore it without parsing the full catalog.
+ * Provider managers sharing one fetch implementation reuse its conditional
+ * catalog session. Each mapped provider slice is persisted independently so
+ * startup can restore it without parsing the full catalog.
+ *
+ * `timeoutMs` bounds the catalog request. It is configurable for callers with a
+ * stricter startup budget and for deterministic timeout tests.
  */
 export function modelsDevCatalogFallback(
 	providerId: string,
 	fetchImpl?: FetchImpl,
+	timeoutMs = DEFAULT_OPENAI_COMPATIBLE_DISCOVERY_TIMEOUT_MS,
 ): ModelsDevFallback<Api> | undefined {
 	const descriptors = MODELS_DEV_DESCRIPTORS_BY_PROVIDER[providerId];
 	if (!descriptors) return undefined;
 	return {
 		additiveOnly: true,
-		fetch: () => fetchWellKnownModels(fetchImpl),
+		fetch: () => withCatalogDiscoveryTimeout(timeoutMs, signal => fetchWellKnownModels(fetchImpl, signal)),
 		map: payload => (isRecord(payload) ? mapModelsDevToModels(payload, descriptors) : []),
 	};
 }

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -149,9 +149,18 @@ const CATALOG_USER_AGENT = USER_AGENT;
  *
  * Fetched fully once per fetch context: concurrent callers sharing a fetch
  * implementation reuse the in-flight request, while repeat callers send a
- * conditional GET that the server answers with `304`.
+ * conditional GET that the server answers with `304`. Transient failures reuse
+ * the last in-memory payload for callers that only need best-effort metadata.
  */
 export function fetchWellKnownModels(fetchImpl?: FetchImpl, signal?: AbortSignal): Promise<unknown> {
+	const session = getCatalogSession(fetchImpl);
+	return fetchRevalidatedWellKnownModels(fetchImpl, signal).catch(error => {
+		if (session.hasPayload) return session.payload;
+		throw error;
+	});
+}
+
+function fetchRevalidatedWellKnownModels(fetchImpl?: FetchImpl, signal?: AbortSignal): Promise<unknown> {
 	const session = getCatalogSession(fetchImpl);
 	if (!session.inflight) {
 		session.inflight = fetchCatalogPayload(fetchImpl ?? discoveryFetch(), session, signal).finally(() => {
@@ -159,6 +168,13 @@ export function fetchWellKnownModels(fetchImpl?: FetchImpl, signal?: AbortSignal
 		});
 	}
 	return session.inflight;
+}
+
+function fetchRevalidatedWellKnownModelsWithTimeout(
+	fetchImpl?: FetchImpl,
+	timeoutMs = DEFAULT_OPENAI_COMPATIBLE_DISCOVERY_TIMEOUT_MS,
+): Promise<unknown> {
+	return withCatalogDiscoveryTimeout(timeoutMs, signal => fetchRevalidatedWellKnownModels(fetchImpl, signal));
 }
 
 async function fetchCatalogPayload(
@@ -173,22 +189,11 @@ async function fetchCatalogPayload(
 	if (session.hasPayload && session.etag) {
 		headers["If-None-Match"] = session.etag;
 	}
-	let response: Response;
-	try {
-		response = await fetchImpl(MODELS_DEV_URL, { method: "GET", headers, signal });
-	} catch (error) {
-		if (session.hasPayload) {
-			return session.payload;
-		}
-		throw error;
-	}
+	const response = await fetchImpl(MODELS_DEV_URL, { method: "GET", headers, signal });
 	if (response.status === 304 && session.hasPayload) {
 		return session.payload;
 	}
 	if (!response.ok) {
-		if (session.hasPayload) {
-			return session.payload;
-		}
 		throw new Error(`models catalog fetch failed: ${response.status}`);
 	}
 	const bytes = new Uint8Array(await response.arrayBuffer());
@@ -2870,7 +2875,7 @@ function openCodeModelManagerOptions(
 		// by the 2h cache TTL instead.
 		dropCachedModelIdsOnStaticMismatch: Object.keys(apiOverrides),
 		modelsDev: {
-			fetch: () => fetchWellKnownModels(config?.fetch),
+			fetch: () => fetchRevalidatedWellKnownModelsWithTimeout(config?.fetch),
 			map: payload => {
 				if (!isRecord(payload)) return [];
 				return mapModelsDevToModels(payload, OPENCODE_MODELS_DEV_DESCRIPTORS)
@@ -6136,7 +6141,7 @@ export function anthropicModelManagerOptions(
 	return {
 		providerId: "anthropic",
 		modelsDev: {
-			fetch: () => fetchWellKnownModels(config?.fetch),
+			fetch: () => fetchRevalidatedWellKnownModelsWithTimeout(config?.fetch),
 			map: payload => mapAnthropicModelsDev(payload, baseUrl),
 		},
 		...(apiKey && {
@@ -6843,7 +6848,7 @@ export function modelsDevCatalogFallback(
 	if (!descriptors) return undefined;
 	return {
 		additiveOnly: true,
-		fetch: () => withCatalogDiscoveryTimeout(timeoutMs, signal => fetchWellKnownModels(fetchImpl, signal)),
+		fetch: () => fetchRevalidatedWellKnownModelsWithTimeout(fetchImpl, timeoutMs),
 		map: payload => (isRecord(payload) ? filterModelsDevCatalogRows(mapModelsDevToModels(payload, descriptors)) : []),
 	};
 }

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -21,7 +21,7 @@ import {
 	isReasoningGlmModelId,
 } from "../identity/family";
 import { resolveModelReference } from "../identity/reference";
-import type { ModelManagerOptions } from "../model-manager";
+import type { ModelManagerOptions, ModelsDevFallback } from "../model-manager";
 import { type GeneratedProvider, getBundledModels } from "../models";
 import { OPENAI_GPT_56_CYBER_STANDARD_COST, OPENAI_GPT_56_SOL_STANDARD_COST } from "../openai-pricing";
 import type {
@@ -6790,3 +6790,38 @@ export const MODELS_DEV_PROVIDER_DESCRIPTORS: readonly ModelsDevProviderDescript
 	...MODELS_DEV_PROVIDER_DESCRIPTORS_CODING_PLANS,
 	...MODELS_DEV_PROVIDER_DESCRIPTORS_SPECIALIZED,
 ];
+
+const MODELS_DEV_DESCRIPTORS_BY_PROVIDER: Record<string, ModelsDevProviderDescriptor[]> = Object.create(null);
+for (const descriptor of MODELS_DEV_PROVIDER_DESCRIPTORS) {
+	const providerDescriptors = MODELS_DEV_DESCRIPTORS_BY_PROVIDER[descriptor.providerId];
+	if (providerDescriptors) {
+		providerDescriptors.push(descriptor);
+	} else {
+		MODELS_DEV_DESCRIPTORS_BY_PROVIDER[descriptor.providerId] = [descriptor];
+	}
+}
+
+/** Providers whose bundled catalog can receive additive models.dev updates at runtime. */
+export const MODELS_DEV_CATALOG_PROVIDER_IDS: readonly string[] = Object.freeze(
+	Object.keys(MODELS_DEV_DESCRIPTORS_BY_PROVIDER),
+);
+
+/**
+ * Build the shared models.dev fallback for one known provider.
+ *
+ * Every provider-specific manager shares the process-wide conditional fetch in
+ * `fetchWellKnownModels`; the model manager persists each mapped provider slice
+ * independently so startup can restore it without parsing the full catalog.
+ */
+export function modelsDevCatalogFallback(
+	providerId: string,
+	fetchImpl?: FetchImpl,
+): ModelsDevFallback<Api> | undefined {
+	const descriptors = MODELS_DEV_DESCRIPTORS_BY_PROVIDER[providerId];
+	if (!descriptors) return undefined;
+	return {
+		additiveOnly: true,
+		fetch: () => fetchWellKnownModels(fetchImpl),
+		map: payload => (isRecord(payload) ? mapModelsDevToModels(payload, descriptors) : []),
+	};
+}

--- a/packages/catalog/test/amazon-bedrock-openai.test.ts
+++ b/packages/catalog/test/amazon-bedrock-openai.test.ts
@@ -4,12 +4,12 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { resolveProviderModels } from "@oh-my-pi/pi-catalog/model-manager";
 import { DEFAULT_MODEL_PER_PROVIDER, PROVIDER_DESCRIPTORS } from "@oh-my-pi/pi-catalog/provider-models/descriptors";
+import { filterModelsDevCatalogRows } from "@oh-my-pi/pi-catalog/provider-models/models-dev-policies";
 import {
 	BEDROCK_MANTLE_STATIC_MODELS,
 	bedrockMantleModelManagerOptions,
 } from "@oh-my-pi/pi-catalog/provider-models/openai-compat";
 import type { FetchImpl, ModelSpec } from "@oh-my-pi/pi-catalog/types";
-import { dropBedrockMantleOpenAIModels } from "../scripts/generated-policies";
 
 const MANTLE_MODEL_IDS = [
 	"openai.gpt-5.4",
@@ -119,7 +119,7 @@ describe("Amazon Bedrock OpenAI routing", () => {
 			bedrockModel("bedrock-mantle", "openai.gpt-5.6-sol"),
 		];
 
-		expect(dropBedrockMantleOpenAIModels(input).map(model => `${model.provider}/${model.id}`)).toEqual([
+		expect(filterModelsDevCatalogRows(input).map(model => `${model.provider}/${model.id}`)).toEqual([
 			"amazon-bedrock/openai.gpt-oss-120b",
 			"bedrock-mantle/openai.gpt-5.6-sol",
 		]);

--- a/packages/catalog/test/amazon-bedrock-opus-5.test.ts
+++ b/packages/catalog/test/amazon-bedrock-opus-5.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import { buildBedrockCompat } from "@oh-my-pi/pi-catalog/compat/bedrock";
 import { MODELS_DEV_PROVIDER_DESCRIPTORS, mapModelsDevToModels } from "@oh-my-pi/pi-catalog/provider-models";
+import { filterModelsDevCatalogRows } from "@oh-my-pi/pi-catalog/provider-models/models-dev-policies";
 import type { ModelSpec } from "@oh-my-pi/pi-catalog/types";
-import { dropUnsupportedBedrockGeoIds } from "../scripts/generated-policies";
 
 // AWS's Bedrock model card for Claude Opus 5 lists these commercial/geo
 // Programmatic Access IDs — the bare model ID plus the us./eu./au. Geo and
@@ -81,7 +81,7 @@ describe("Amazon Bedrock Claude Opus 5", () => {
 		const mapped = allMapped.filter(
 			model => model.provider === "amazon-bedrock" && model.id.endsWith("anthropic.claude-opus-5"),
 		);
-		const opus5Ids = dropUnsupportedBedrockGeoIds(mapped).map(model => model.id);
+		const opus5Ids = filterModelsDevCatalogRows(mapped).map(model => model.id);
 
 		// Set semantics: the descriptor also derives `eu.` and `us-gov.` variants
 		// from the bare `anthropic.` row, so `eu.` legitimately arrives from both
@@ -116,7 +116,7 @@ describe("Amazon Bedrock Claude Opus 5", () => {
 			bareSpec("some-other-provider", "jp.anthropic.claude-opus-5"),
 		];
 
-		expect(dropUnsupportedBedrockGeoIds(input).map(model => model.id)).toEqual([
+		expect(filterModelsDevCatalogRows(input).map(model => model.id)).toEqual([
 			"us.anthropic.claude-opus-5",
 			"jp.anthropic.claude-opus-4-8",
 			"jp.anthropic.claude-opus-5",

--- a/packages/catalog/test/opencode-provider.test.ts
+++ b/packages/catalog/test/opencode-provider.test.ts
@@ -247,6 +247,8 @@ describe("Shared models.dev catalog fallback", () => {
 				contextWindow: staticV2.contextWindow,
 				maxTokens: staticV2.maxTokens,
 			});
+			expect(upgraded.source).toBe("bundled");
+			expect(upgraded.updatedAt).toBeUndefined();
 		} finally {
 			await fs.rm(tempDir, { recursive: true, force: true });
 		}
@@ -302,6 +304,8 @@ describe("Shared models.dev catalog fallback", () => {
 				contextWindow: bundledModel.contextWindow,
 				maxTokens: bundledModel.maxTokens,
 			});
+			expect(resolved.source).toBe("bundled");
+			expect(resolved.updatedAt).toBeUndefined();
 		} finally {
 			await fs.rm(tempDir, { recursive: true, force: true });
 		}

--- a/packages/catalog/test/opencode-provider.test.ts
+++ b/packages/catalog/test/opencode-provider.test.ts
@@ -5,9 +5,11 @@ import * as path from "node:path";
 import { Effort } from "@oh-my-pi/pi-catalog/effort";
 import { resolveProviderModels } from "@oh-my-pi/pi-catalog/model-manager";
 import { getSupportedEfforts } from "@oh-my-pi/pi-catalog/model-thinking";
+import { getBundledModels } from "@oh-my-pi/pi-catalog/models";
 import { PROVIDER_DESCRIPTORS } from "@oh-my-pi/pi-catalog/provider-models/descriptors";
 import {
 	MODELS_DEV_PROVIDER_DESCRIPTORS,
+	modelsDevCatalogFallback,
 	opencodeGoModelManagerOptions,
 	opencodeZenModelManagerOptions,
 } from "@oh-my-pi/pi-catalog/provider-models/openai-compat";
@@ -28,6 +30,104 @@ function modelListResponse(ids: readonly string[]): Response {
 		data: ids.map(id => ({ id, object: "model", owned_by: "opencode" })),
 	});
 }
+
+describe("Shared models.dev catalog fallback", () => {
+	test("adds newly published models for a bundled provider and reuses the cached snapshot", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-catalog-models-dev-fallback-"));
+		try {
+			const bundledModels = getBundledModels("zai");
+			const bundledModel = bundledModels[0];
+			if (!bundledModel) throw new Error("ZAI bundled catalog is empty");
+			const bundledModelId = bundledModel.id;
+			let fetches = 0;
+			const fallback = modelsDevCatalogFallback("zai");
+			if (!fallback) throw new Error("ZAI did not configure a models.dev fallback");
+			const modelsDev = {
+				...fallback,
+				fetch: async () => {
+					fetches++;
+					return {
+						zai: {
+							models: {
+								"glm-5.3-flash": {
+									id: "glm-5.3-flash",
+									name: "GLM-5.3-Flash",
+									tool_call: true,
+									reasoning: true,
+									limit: { context: 1_000_000, output: 131_072 },
+									modalities: { input: ["text", "image"], output: ["text"] },
+									provider: { npm: "@ai-sdk/anthropic" },
+								},
+								[bundledModelId]: {
+									id: bundledModelId,
+									name: "Untrusted remote override",
+									tool_call: false,
+									reasoning: false,
+									limit: { context: 1, output: 1 },
+									modalities: { input: ["text"], output: ["text"] },
+									provider: { npm: "@ai-sdk/anthropic" },
+								},
+							},
+						},
+					};
+				},
+			};
+			const options = {
+				providerId: "zai" as const,
+				cacheDbPath: path.join(tempDir, "models.db"),
+				staticModels: bundledModels,
+				modelsDev,
+			};
+
+			const online = await resolveProviderModels(options, "online");
+			expect(online.stale).toBe(false);
+			expect(online.source).toBe("models.dev");
+			expect(online.updatedAt).toBeNumber();
+			expect(online.models.find(model => model.id === bundledModelId)).toMatchObject({
+				name: bundledModel.name,
+				contextWindow: bundledModel.contextWindow,
+				maxTokens: bundledModel.maxTokens,
+				reasoning: bundledModel.reasoning,
+				input: bundledModel.input,
+			});
+			expect(online.models.find(model => model.id === "glm-5.3-flash")).toMatchObject({
+				api: "anthropic-messages",
+				baseUrl: "https://api.z.ai/api/anthropic",
+				contextWindow: 1_000_000,
+				maxTokens: 131_072,
+				reasoning: true,
+				input: ["text", "image"],
+			});
+
+			const cached = await resolveProviderModels(options, "online-if-uncached");
+			expect(cached.stale).toBe(false);
+			expect(cached.source).toBe("cache");
+			expect(cached.updatedAt).toBe(online.updatedAt);
+			expect(cached.models.some(model => model.id === "glm-5.3-flash")).toBe(true);
+
+			const staleFallback = await resolveProviderModels(
+				{
+					...options,
+					now: () => Date.now() + 3 * 60 * 60 * 1000,
+					modelsDev: {
+						...modelsDev,
+						fetch: async () => {
+							throw new Error("models.dev unavailable");
+						},
+					},
+				},
+				"online",
+			);
+			expect(staleFallback.stale).toBe(true);
+			expect(staleFallback.source).toBe("cache");
+			expect(staleFallback.updatedAt).toBe(online.updatedAt);
+			expect(staleFallback.models.some(model => model.id === "glm-5.3-flash")).toBe(true);
+			expect(fetches).toBe(1);
+		} finally {
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+	});
+});
 
 describe("OpenCode provider discovery", () => {
 	test("treats the OpenCode model endpoints as authoritative catalogs", () => {

--- a/packages/catalog/test/opencode-provider.test.ts
+++ b/packages/catalog/test/opencode-provider.test.ts
@@ -443,31 +443,39 @@ describe("Shared models.dev catalog fallback", () => {
 		}
 	});
 
-	test("aborts a stalled shared catalog request at the configured deadline", async () => {
+	test("applies subscriber deadlines without aborting a joined catalog request", async () => {
 		let aborted = false;
+		let fetches = 0;
+		const transport = Promise.withResolvers<Response>();
 		const stalledFetch: FetchImpl = (_input, init) => {
-			const { promise, reject } = Promise.withResolvers<Response>();
+			fetches++;
 			const signal = init?.signal;
-			if (!signal) {
-				reject(new Error("catalog fetch did not receive an abort signal"));
-				return promise;
-			}
+			if (!signal) throw new Error("catalog fetch did not receive an abort signal");
 			const rejectAborted = () => {
 				aborted = true;
-				reject(signal.reason);
+				transport.reject(signal.reason);
 			};
 			if (signal.aborted) {
 				rejectAborted();
 			} else {
 				signal.addEventListener("abort", rejectAborted, { once: true });
 			}
-			return promise;
+			return transport.promise;
 		};
-		const fallback = modelsDevCatalogFallback("zai", stalledFetch, 5);
-		if (!fallback) throw new Error("ZAI did not configure a models.dev fallback");
+		const shortFallback = modelsDevCatalogFallback("zai", stalledFetch, 5);
+		const longFallback = modelsDevCatalogFallback("zai", stalledFetch, 5_000);
+		if (!shortFallback || !longFallback) throw new Error("ZAI did not configure a models.dev fallback");
 
-		await expect(fallback.fetch()).rejects.toThrow(/timed out/i);
-		expect(aborted).toBe(true);
+		const shortRequest = shortFallback.fetch();
+		const longRequest = longFallback.fetch();
+		await expect(shortRequest).rejects.toThrow(/timed out/i);
+		expect(aborted).toBe(false);
+		expect(fetches).toBe(1);
+
+		const payload = { source: "shared-transport" };
+		transport.resolve(Response.json(payload));
+		expect(await longRequest).toEqual(payload);
+		expect(aborted).toBe(false);
 	});
 });
 

--- a/packages/catalog/test/opencode-provider.test.ts
+++ b/packages/catalog/test/opencode-provider.test.ts
@@ -385,6 +385,60 @@ describe("Shared models.dev catalog fallback", () => {
 		expect(secondFetches).toBe(1);
 	});
 
+	test("reports a stale cache when conditional catalog revalidation fails", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-catalog-revalidation-fallback-"));
+		try {
+			const bundledModels = getBundledModels("zai");
+			let catalogAvailable = true;
+			let fetches = 0;
+			const fetchImpl: FetchImpl = async () => {
+				fetches++;
+				if (!catalogAvailable) throw new Error("models.dev unavailable");
+				return Response.json(
+					{
+						zai: {
+							models: {
+								"shared-only": {
+									id: "shared-only",
+									name: "Shared Only",
+									tool_call: true,
+									reasoning: false,
+									limit: { context: 128_000, output: 8_192 },
+									modalities: { input: ["text"], output: ["text"] },
+									provider: { npm: "@ai-sdk/anthropic" },
+								},
+							},
+						},
+					},
+					{ headers: { etag: '"catalog-v1"' } },
+				);
+			};
+			const fallback = modelsDevCatalogFallback("zai", fetchImpl);
+			if (!fallback) throw new Error("ZAI did not configure a models.dev fallback");
+			const options = {
+				providerId: "zai" as const,
+				cacheDbPath: path.join(tempDir, "models.db"),
+				staticModels: bundledModels,
+				modelsDev: fallback,
+			};
+
+			const initial = await resolveProviderModels(options, "online");
+			expect(initial.source).toBe("models.dev");
+			expect(initial.stale).toBe(false);
+			expect(initial.models.some(model => model.id === "shared-only")).toBe(true);
+
+			catalogAvailable = false;
+			const failedRevalidation = await resolveProviderModels(options, "online");
+			expect(failedRevalidation.source).toBe("cache");
+			expect(failedRevalidation.stale).toBe(true);
+			expect(failedRevalidation.updatedAt).toBe(initial.updatedAt);
+			expect(failedRevalidation.models.some(model => model.id === "shared-only")).toBe(true);
+			expect(fetches).toBe(2);
+		} finally {
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+	});
+
 	test("aborts a stalled shared catalog request at the configured deadline", async () => {
 		let aborted = false;
 		const stalledFetch: FetchImpl = (_input, init) => {

--- a/packages/catalog/test/opencode-provider.test.ts
+++ b/packages/catalog/test/opencode-provider.test.ts
@@ -252,6 +252,61 @@ describe("Shared models.dev catalog fallback", () => {
 		}
 	});
 
+	test("sanitizes a fresh matching cache when additive mode is enabled", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-catalog-additive-fresh-cache-"));
+		try {
+			const bundledModel = getBundledModels("zai")[0];
+			if (!bundledModel) throw new Error("ZAI bundled catalog is empty");
+			const cachedOverride = {
+				...bundledModel,
+				name: "Untrusted cached override",
+				contextWindow: 1,
+				maxTokens: 1,
+			};
+			const cacheDbPath = path.join(tempDir, "models.db");
+			const legacyModelsDev = {
+				fetch: async () => [cachedOverride],
+				map: (payload: Array<typeof cachedOverride>) => payload,
+			};
+			await resolveProviderModels(
+				{
+					providerId: "zai" as const,
+					cacheDbPath,
+					staticModels: [bundledModel],
+					modelsDev: legacyModelsDev,
+				},
+				"online",
+			);
+
+			let additiveFetches = 0;
+			const resolved = await resolveProviderModels(
+				{
+					providerId: "zai" as const,
+					cacheDbPath,
+					staticModels: [bundledModel],
+					modelsDev: {
+						...legacyModelsDev,
+						additiveOnly: true,
+						fetch: async () => {
+							additiveFetches++;
+							return [];
+						},
+					},
+				},
+				"online-if-uncached",
+			);
+
+			expect(additiveFetches).toBe(0);
+			expect(resolved.models.find(model => model.id === bundledModel.id)).toMatchObject({
+				name: bundledModel.name,
+				contextWindow: bundledModel.contextWindow,
+				maxTokens: bundledModel.maxTokens,
+			});
+		} finally {
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+	});
+
 	test("retains one source's cached slice when the other source refreshes", async () => {
 		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-catalog-partial-source-refresh-"));
 		try {
@@ -332,23 +387,24 @@ describe("Shared models.dev catalog fallback", () => {
 
 	test("aborts a stalled shared catalog request at the configured deadline", async () => {
 		let aborted = false;
-		const stalledFetch: FetchImpl = (_input, init) =>
-			new Promise<Response>((_resolve, reject) => {
-				const signal = init?.signal;
-				if (!signal) {
-					reject(new Error("catalog fetch did not receive an abort signal"));
-					return;
-				}
-				const rejectAborted = () => {
-					aborted = true;
-					reject(signal.reason);
-				};
-				if (signal.aborted) {
-					rejectAborted();
-				} else {
-					signal.addEventListener("abort", rejectAborted, { once: true });
-				}
-			});
+		const stalledFetch: FetchImpl = (_input, init) => {
+			const { promise, reject } = Promise.withResolvers<Response>();
+			const signal = init?.signal;
+			if (!signal) {
+				reject(new Error("catalog fetch did not receive an abort signal"));
+				return promise;
+			}
+			const rejectAborted = () => {
+				aborted = true;
+				reject(signal.reason);
+			};
+			if (signal.aborted) {
+				rejectAborted();
+			} else {
+				signal.addEventListener("abort", rejectAborted, { once: true });
+			}
+			return promise;
+		};
 		const fallback = modelsDevCatalogFallback("zai", stalledFetch, 5);
 		if (!fallback) throw new Error("ZAI did not configure a models.dev fallback");
 

--- a/packages/catalog/test/opencode-provider.test.ts
+++ b/packages/catalog/test/opencode-provider.test.ts
@@ -130,6 +130,65 @@ describe("Shared models.dev catalog fallback", () => {
 		}
 	});
 
+	test("filters generation-rejected rows before runtime resolution and caching", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-catalog-runtime-policy-"));
+		const rawModel = (id: string, npm: string) => ({
+			id,
+			name: id,
+			tool_call: true,
+			reasoning: true,
+			limit: { context: 128_000, output: 32_000 },
+			modalities: { input: ["text"], output: ["text"] },
+			provider: { npm },
+		});
+		const cases = [
+			{
+				providerId: "zai",
+				invalidId: "glm-5.2[1m]",
+				validId: "glm-5.3-flash",
+				npm: "@ai-sdk/anthropic",
+			},
+			{
+				providerId: "amazon-bedrock",
+				invalidId: "openai.gpt-5.4",
+				validId: "openai.gpt-oss-120b",
+				npm: "@ai-sdk/openai-compatible",
+			},
+		] as const;
+		try {
+			for (const { providerId, invalidId, validId, npm } of cases) {
+				const fallback = modelsDevCatalogFallback(providerId);
+				if (!fallback) throw new Error(`${providerId} did not configure a models.dev fallback`);
+				const options = {
+					providerId,
+					cacheDbPath: path.join(tempDir, `${providerId}.db`),
+					staticModels: [],
+					modelsDev: {
+						...fallback,
+						fetch: async () => ({
+							[providerId]: {
+								models: {
+									[invalidId]: rawModel(invalidId, npm),
+									[validId]: rawModel(validId, npm),
+								},
+							},
+						}),
+					},
+				};
+
+				const online = await resolveProviderModels(options, "online");
+				expect(online.models.some(model => model.id === invalidId)).toBe(false);
+				expect(online.models.some(model => model.id === validId)).toBe(true);
+
+				const cached = await resolveProviderModels(options, "offline");
+				expect(cached.models.some(model => model.id === invalidId)).toBe(false);
+				expect(cached.models.some(model => model.id === validId)).toBe(true);
+			}
+		} finally {
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+	});
+
 	test("keeps upgraded bundled metadata authoritative over an older same-id cache row", async () => {
 		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-catalog-additive-cache-upgrade-"));
 		try {

--- a/packages/catalog/test/opencode-provider.test.ts
+++ b/packages/catalog/test/opencode-provider.test.ts
@@ -8,11 +8,13 @@ import { getSupportedEfforts } from "@oh-my-pi/pi-catalog/model-thinking";
 import { getBundledModels } from "@oh-my-pi/pi-catalog/models";
 import { PROVIDER_DESCRIPTORS } from "@oh-my-pi/pi-catalog/provider-models/descriptors";
 import {
+	fetchWellKnownModels,
 	MODELS_DEV_PROVIDER_DESCRIPTORS,
 	modelsDevCatalogFallback,
 	opencodeGoModelManagerOptions,
 	opencodeZenModelManagerOptions,
 } from "@oh-my-pi/pi-catalog/provider-models/openai-compat";
+import type { FetchImpl } from "@oh-my-pi/pi-utils";
 
 const LIVE_FREE_MODEL_IDS = [
 	"deepseek-v4-flash-free",
@@ -126,6 +128,173 @@ describe("Shared models.dev catalog fallback", () => {
 		} finally {
 			await fs.rm(tempDir, { recursive: true, force: true });
 		}
+	});
+
+	test("keeps upgraded bundled metadata authoritative over an older same-id cache row", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-catalog-additive-cache-upgrade-"));
+		try {
+			const bundledModel = getBundledModels("zai")[0];
+			if (!bundledModel) throw new Error("ZAI bundled catalog is empty");
+			const staticV1 = { ...bundledModel, name: "Bundled before upgrade" };
+			const cachedOverride = {
+				...staticV1,
+				name: "Untrusted cached override",
+				contextWindow: 1,
+				maxTokens: 1,
+			};
+			const cacheDbPath = path.join(tempDir, "models.db");
+			const legacyModelsDev = {
+				fetch: async () => [cachedOverride],
+				map: (payload: Array<typeof cachedOverride>) => payload,
+			};
+			const seeded = await resolveProviderModels(
+				{
+					providerId: "zai" as const,
+					cacheDbPath,
+					staticModels: [staticV1],
+					modelsDev: legacyModelsDev,
+				},
+				"online",
+			);
+			expect(seeded.models.find(model => model.id === bundledModel.id)).toMatchObject({
+				name: "Untrusted cached override",
+				contextWindow: 1,
+				maxTokens: 1,
+			});
+
+			const staticV2 = {
+				...bundledModel,
+				name: "Bundled after upgrade",
+				contextWindow: 1_000_001,
+				maxTokens: 131_073,
+			};
+			const upgraded = await resolveProviderModels(
+				{
+					providerId: "zai" as const,
+					cacheDbPath,
+					staticModels: [staticV2],
+					modelsDev: {
+						...legacyModelsDev,
+						additiveOnly: true,
+						fetch: async () => {
+							throw new Error("offline");
+						},
+					},
+				},
+				"offline",
+			);
+			expect(upgraded.models.find(model => model.id === bundledModel.id)).toMatchObject({
+				name: "Bundled after upgrade",
+				contextWindow: staticV2.contextWindow,
+				maxTokens: staticV2.maxTokens,
+			});
+		} finally {
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	test("retains one source's cached slice when the other source refreshes", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-catalog-partial-source-refresh-"));
+		try {
+			const existingModel = getBundledModels("zai")[0];
+			if (!existingModel) throw new Error("ZAI bundled catalog is empty");
+			const sharedModel = {
+				...existingModel,
+				id: "shared-only",
+				name: "Shared only",
+				requestModelId: undefined,
+			};
+			let endpointModel = {
+				...existingModel,
+				id: "endpoint-only",
+				name: "Endpoint v1",
+				requestModelId: undefined,
+			};
+			let sharedCatalogAvailable = true;
+			const modelsDev = {
+				additiveOnly: true,
+				fetch: async () => {
+					if (!sharedCatalogAvailable) throw new Error("models.dev unavailable");
+					return [sharedModel];
+				},
+				map: (payload: Array<typeof sharedModel>) => payload,
+			};
+			const options = {
+				providerId: "zai" as const,
+				cacheDbPath: path.join(tempDir, "models.db"),
+				staticModels: [existingModel],
+				modelsDev,
+				fetchDynamicModels: async () => [endpointModel],
+			};
+
+			const initial = await resolveProviderModels(options, "online");
+			expect(initial.models.map(model => model.id).sort()).toEqual(
+				[existingModel.id, "shared-only", "endpoint-only"].sort(),
+			);
+
+			sharedCatalogAvailable = false;
+			endpointModel = { ...endpointModel, name: "Endpoint v2" };
+			const partial = await resolveProviderModels(options, "online");
+			expect(partial.models.map(model => model.id).sort()).toEqual(
+				[existingModel.id, "shared-only", "endpoint-only"].sort(),
+			);
+			expect(partial.models.find(model => model.id === "endpoint-only")?.name).toBe("Endpoint v2");
+			expect(partial.source).toBe("provider");
+			expect(partial.stale).toBe(true);
+
+			const cached = await resolveProviderModels(options, "offline");
+			expect(cached.models.map(model => model.id).sort()).toEqual(
+				[existingModel.id, "shared-only", "endpoint-only"].sort(),
+			);
+			expect(cached.stale).toBe(true);
+		} finally {
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	test("isolates conditional catalog sessions by fetch context", async () => {
+		let firstFetches = 0;
+		let secondFetches = 0;
+		const firstFetch: FetchImpl = async () => {
+			firstFetches++;
+			return Response.json({ source: "first" }, { headers: { etag: '"first"' } });
+		};
+		const secondFetch: FetchImpl = async () => {
+			secondFetches++;
+			return Response.json({ source: "second" }, { headers: { etag: '"second"' } });
+		};
+
+		const [first, second] = await Promise.all([fetchWellKnownModels(firstFetch), fetchWellKnownModels(secondFetch)]);
+		expect(first).toEqual({ source: "first" });
+		expect(second).toEqual({ source: "second" });
+		expect(firstFetches).toBe(1);
+		expect(secondFetches).toBe(1);
+	});
+
+	test("aborts a stalled shared catalog request at the configured deadline", async () => {
+		let aborted = false;
+		const stalledFetch: FetchImpl = (_input, init) =>
+			new Promise<Response>((_resolve, reject) => {
+				const signal = init?.signal;
+				if (!signal) {
+					reject(new Error("catalog fetch did not receive an abort signal"));
+					return;
+				}
+				const rejectAborted = () => {
+					aborted = true;
+					reject(signal.reason);
+				};
+				if (signal.aborted) {
+					rejectAborted();
+				} else {
+					signal.addEventListener("abort", rejectAborted, { once: true });
+				}
+			});
+		const fallback = modelsDevCatalogFallback("zai", stalledFetch, 5);
+		if (!fallback) throw new Error("ZAI did not configure a models.dev fallback");
+
+		await expect(fallback.fetch()).rejects.toThrow(/timed out/i);
+		expect(aborted).toBe(true);
 	});
 });
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,9 +2,14 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added nonblocking shared model-catalog refresh with cached startup hydration and source freshness diagnostics, allowing newly published models for known providers to appear without a binary release.
+
 ## [18.0.7] - 2026-08-26
 
 ### Added
+
 
 - Added `omp usage clients` to report per-client token usage recorded by the auth broker, including the machine and application responsible for usage by provider. Supports `--days` and `--json` output.
 

--- a/packages/coding-agent/src/config/model-provider-discovery.ts
+++ b/packages/coding-agent/src/config/model-provider-discovery.ts
@@ -56,15 +56,15 @@ export function isDiscoveryBearerApiKey(apiKey: string | undefined | null): apiK
 }
 
 /**
- * Wraps an extension-provided fetchDynamicModels call with a hard timeout.
- * Uses a cancellable manual timer (not AbortSignal.timeout) so that a fast
- * successful path does not leave an armed timeout signal for concurrent GC.
- * The inner fetcher does not receive a signal (extension contract has none).
+ * Wraps a model-discovery operation with a hard timeout. Uses a cancellable
+ * manual timer (not AbortSignal.timeout) so that a fast successful path does
+ * not leave an armed timeout signal for concurrent GC. The inner operation
+ * does not receive a signal because not every discovery contract accepts one.
  */
-export async function withRuntimeDynamicModelsTimeout<T>(timeoutMs: number, run: () => Promise<T>): Promise<T> {
+export async function withModelDiscoveryTimeout<T>(timeoutMs: number, run: () => Promise<T>): Promise<T> {
 	const { promise: timeoutPromise, reject: timeoutReject } = Promise.withResolvers<never>();
 	const timer = setTimeout(() => {
-		timeoutReject(new Error(`fetchDynamicModels timed out after ${timeoutMs}ms`));
+		timeoutReject(new Error(`model discovery timed out after ${timeoutMs}ms`));
 	}, timeoutMs);
 	try {
 		return await Promise.race([run(), timeoutPromise]);

--- a/packages/coding-agent/src/config/model-provider-discovery.ts
+++ b/packages/coding-agent/src/config/model-provider-discovery.ts
@@ -7,6 +7,10 @@ import {
 } from "@oh-my-pi/pi-catalog/provider-models";
 import type { AuthStorage, OAuthCredential } from "../session/auth-storage";
 
+/**
+ * Built-in providers whose discovery requires provider-specific credentials
+ * or account expansion and therefore cannot use the standard descriptor path.
+ */
 export const SPECIAL_MODEL_MANAGER_PROVIDER_IDS: readonly string[] = [
 	"google-antigravity",
 	"google-gemini-cli",

--- a/packages/coding-agent/src/config/model-provider-discovery.ts
+++ b/packages/coding-agent/src/config/model-provider-discovery.ts
@@ -1,17 +1,28 @@
 import type { Api, Model } from "@oh-my-pi/pi-ai/types";
-import { type OpenAICodexAccount, PROVIDER_DESCRIPTORS } from "@oh-my-pi/pi-catalog/provider-models";
+import type { ModelResolutionSource } from "@oh-my-pi/pi-catalog/model-manager";
+import {
+	MODELS_DEV_CATALOG_PROVIDER_IDS,
+	type OpenAICodexAccount,
+	PROVIDER_DESCRIPTORS,
+} from "@oh-my-pi/pi-catalog/provider-models";
 import type { AuthStorage, OAuthCredential } from "../session/auth-storage";
 
-const SPECIAL_MODEL_MANAGER_PROVIDER_IDS: readonly string[] = [
+export const SPECIAL_MODEL_MANAGER_PROVIDER_IDS: readonly string[] = [
 	"google-antigravity",
 	"google-gemini-cli",
 	"openai-codex",
 ];
 
-export const STARTUP_MODEL_CACHE_PROVIDER_IDS: readonly string[] = [
+const STARTUP_MODEL_CACHE_PROVIDER_IDS_RECORD: Record<string, true> = Object.create(null);
+for (const providerId of [
 	...PROVIDER_DESCRIPTORS.map(descriptor => descriptor.providerId),
 	...SPECIAL_MODEL_MANAGER_PROVIDER_IDS,
-];
+	...MODELS_DEV_CATALOG_PROVIDER_IDS,
+]) {
+	STARTUP_MODEL_CACHE_PROVIDER_IDS_RECORD[providerId] = true;
+}
+
+export const STARTUP_MODEL_CACHE_PROVIDER_IDS: readonly string[] = Object.keys(STARTUP_MODEL_CACHE_PROVIDER_IDS_RECORD);
 
 // Sentinels for local-only OAuth tokens — declared inline to avoid loading
 // provider modules at startup. Must match packages/ai/src/registry/llama-cpp.ts,
@@ -71,6 +82,7 @@ export interface ProviderDiscoveryState {
 	optional: boolean;
 	stale: boolean;
 	fetchedAt?: number;
+	source?: ModelResolutionSource;
 	models: string[];
 	error?: string;
 }

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -1766,7 +1766,9 @@ export class ModelRegistry {
 					getProviderDefinition(descriptor.providerId)?.prepareModelDiscovery?.(discoveryConfig) ??
 					discoveryConfig;
 				const managerOptions = descriptor.createModelManagerOptions(preparedConfig);
-				const modelsDev = managerOptions.modelsDev ?? modelsDevCatalogFallback(descriptor.providerId, this.#fetch);
+				const modelsDev = managerOptions.modelsDev
+					? { ...managerOptions.modelsDev, additiveOnly: true }
+					: modelsDevCatalogFallback(descriptor.providerId, this.#fetch);
 				options.push(modelsDev ? { ...managerOptions, modelsDev } : managerOptions);
 			}
 		}

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -1712,6 +1712,7 @@ export class ModelRegistry {
 		const standardProviderDescriptors = PROVIDER_DESCRIPTORS.filter(descriptor => {
 			if (disabledProviders.has(descriptor.providerId)) return false;
 			if (configuredDiscoveryProviders.has(descriptor.providerId)) return false;
+			if (this.#runtimeModelManagers.has(descriptor.providerId)) return false;
 			return providerFilter ? providerFilter.has(descriptor.providerId) : true;
 		});
 		const enabledSpecialProviderDescriptors = specialProviderDescriptors.filter(descriptor => {

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -103,7 +103,7 @@ import {
 	resolveCodexDiscoveryAccounts,
 	SPECIAL_MODEL_MANAGER_PROVIDER_IDS,
 	STARTUP_MODEL_CACHE_PROVIDER_IDS,
-	withRuntimeDynamicModelsTimeout,
+	withModelDiscoveryTimeout,
 } from "./model-provider-discovery";
 
 export { mergeDiscoveredModel } from "./model-patch";
@@ -1843,7 +1843,9 @@ export class ModelRegistry {
 	): Promise<BuiltInDiscoveryResult> {
 		try {
 			const manager = createModelManager({ ...options, cacheDbPath: this.#cacheDbPath });
-			const result = await manager.refresh(strategy);
+			const result = await withModelDiscoveryTimeout(RUNTIME_DYNAMIC_MODEL_FETCH_TIMEOUT_MS, () =>
+				manager.refresh(strategy),
+			);
 			const models = result.models.map(model =>
 				model.provider === options.providerId ? model : { ...model, provider: options.providerId },
 			);
@@ -2587,7 +2589,7 @@ export class ModelRegistry {
 				fetchDynamicModels: async () => {
 					const apiKey = await this.#peekApiKeyForProvider(providerName);
 					const resolvedKey = isAuthenticated(apiKey) ? apiKey : undefined;
-					const modelDefs = await withRuntimeDynamicModelsTimeout(RUNTIME_DYNAMIC_MODEL_FETCH_TIMEOUT_MS, () =>
+					const modelDefs = await withModelDiscoveryTimeout(RUNTIME_DYNAMIC_MODEL_FETCH_TIMEOUT_MS, () =>
 						fetcher(resolvedKey),
 					);
 					const results: Model<Api>[] = [];

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -27,6 +27,8 @@ import {
 	googleAntigravityModelManagerOptions,
 	googleGeminiCliModelManagerOptions,
 	isCredentialScopedModelCacheProvider,
+	MODELS_DEV_CATALOG_PROVIDER_IDS,
+	modelsDevCatalogFallback,
 	openaiCodexModelManagerOptions,
 	PROVIDER_DESCRIPTORS,
 	resolveModelCacheProviderId,
@@ -98,6 +100,7 @@ import {
 	type ProviderDiscoveryState,
 	RUNTIME_DYNAMIC_MODEL_FETCH_TIMEOUT_MS,
 	resolveCodexDiscoveryAccounts,
+	SPECIAL_MODEL_MANAGER_PROVIDER_IDS,
 	STARTUP_MODEL_CACHE_PROVIDER_IDS,
 	withRuntimeDynamicModelsTimeout,
 } from "./model-provider-discovery";
@@ -117,6 +120,17 @@ import { type Settings, settings } from "./settings";
 // DeviceCheck attestation (`x-oai-attestation`) for ChatGPT-OAuth Codex
 // requests; the pi-ai provider resolves it just-in-time per request.
 setCodexAttestationProvider(generateCodexAttestation);
+
+const BUILT_IN_MODEL_MANAGER_PROVIDER_IDS: Readonly<Record<string, true>> = Object.freeze(
+	Object.fromEntries(
+		[...PROVIDER_DESCRIPTORS.map(descriptor => descriptor.providerId), ...SPECIAL_MODEL_MANAGER_PROVIDER_IDS].map(
+			providerId => [providerId, true as const],
+		),
+	),
+);
+const MODELS_DEV_CATALOG_PROVIDER_ID_LOOKUP: Readonly<Record<string, true>> = Object.freeze(
+	Object.fromEntries(MODELS_DEV_CATALOG_PROVIDER_IDS.map(providerId => [providerId, true as const])),
+);
 
 /**
  * Bedrock guardrail fields to spread onto a model spec, dropping keys that a
@@ -873,7 +887,18 @@ export class ModelRegistry {
 		for (const providerId of providerIds) {
 			const cacheProviderId = this.#resolveStartupModelCacheProviderId(providerId);
 			const cache = readModelCache<Api>(cacheProviderId, 24 * 60 * 60 * 1000, Date.now, this.#cacheDbPath);
+			const sharedCatalogProvider = MODELS_DEV_CATALOG_PROVIDER_ID_LOOKUP[providerId] === true;
 			if (!cache) {
+				if (sharedCatalogProvider) {
+					this.#providerDiscoveryStates.set(providerId, {
+						provider: providerId,
+						status: "idle",
+						optional: false,
+						stale: false,
+						source: "bundled",
+						models: [],
+					});
+				}
 				continue;
 			}
 			if (cache.fresh && cache.authoritative) {
@@ -929,7 +954,19 @@ export class ModelRegistry {
 					)
 				: withTransport.map(model => buildModel(model));
 			const resolved = this.#applyProviderModelOverrides(providerId, withCompat);
-			modelsByProvider.set(providerId, this.#applyHardcodedModelPolicies(resolved));
+			const cachedModels = this.#applyHardcodedModelPolicies(resolved);
+			modelsByProvider.set(providerId, cachedModels);
+			if (sharedCatalogProvider) {
+				this.#providerDiscoveryStates.set(providerId, {
+					provider: providerId,
+					status: "cached",
+					optional: false,
+					stale: !cache.fresh || !cache.authoritative,
+					fetchedAt: cache.updatedAt,
+					source: "cache",
+					models: cachedModels.map(model => model.id),
+				});
+			}
 		}
 		return { modelsByProvider, authoritativeFreshProviders };
 	}
@@ -1712,7 +1749,14 @@ export class ModelRegistry {
 				(this.#runtimeProviderOverrides.has(descriptor.providerId) ||
 					this.#providerOverrides.has(descriptor.providerId) ||
 					this.#keylessProviders.has(descriptor.providerId));
-			if (isAuthenticated(apiKey) || descriptor.allowUnauthenticated || hasExplicitVllmConfig) {
+			const supportsSharedCatalog = MODELS_DEV_CATALOG_PROVIDER_ID_LOOKUP[descriptor.providerId] === true;
+			const canUseSharedCatalogWithoutAuth = supportsSharedCatalog && !descriptor.dynamicModelsAuthoritative;
+			if (
+				isAuthenticated(apiKey) ||
+				descriptor.allowUnauthenticated ||
+				hasExplicitVllmConfig ||
+				canUseSharedCatalogWithoutAuth
+			) {
 				const discoveryConfig = {
 					apiKey: isDiscoveryBearerApiKey(apiKey) ? apiKey : undefined,
 					baseUrl: this.#descriptorBaseUrl(descriptor.providerId),
@@ -1721,7 +1765,9 @@ export class ModelRegistry {
 				const preparedConfig =
 					getProviderDefinition(descriptor.providerId)?.prepareModelDiscovery?.(discoveryConfig) ??
 					discoveryConfig;
-				options.push(descriptor.createModelManagerOptions(preparedConfig));
+				const managerOptions = descriptor.createModelManagerOptions(preparedConfig);
+				const modelsDev = managerOptions.modelsDev ?? modelsDevCatalogFallback(descriptor.providerId, this.#fetch);
+				options.push(modelsDev ? { ...managerOptions, modelsDev } : managerOptions);
 			}
 		}
 
@@ -1733,6 +1779,28 @@ export class ModelRegistry {
 			}
 			options.push(descriptor.createOptions(key, specialKeys[i]));
 		}
+
+		// Catalog-only providers have no endpoint manager. Give their bundled
+		// slices the same shared remote layer without requiring credentials.
+		const bundledProviderIds: Record<string, true> = Object.create(null);
+		for (const providerId of getBundledProviders()) bundledProviderIds[providerId] = true;
+		for (const providerId of MODELS_DEV_CATALOG_PROVIDER_IDS) {
+			if (BUILT_IN_MODEL_MANAGER_PROVIDER_IDS[providerId] === true) continue;
+			if (bundledProviderIds[providerId] !== true) continue;
+			if (disabledProviders.has(providerId) || configuredDiscoveryProviders.has(providerId)) continue;
+			if (providerFilter && !providerFilter.has(providerId)) continue;
+			if (this.#runtimeModelManagers.has(providerId)) continue;
+			const modelsDev = modelsDevCatalogFallback(providerId, this.#fetch);
+			if (!modelsDev) continue;
+			options.push({
+				providerId,
+				cacheProviderId: resolveModelCacheProviderId(providerId, {
+					baseUrl: this.#descriptorBaseUrl(providerId),
+				}),
+				modelsDev,
+			});
+		}
+
 		// Append runtime model managers registered by extensions via fetchDynamicModels.
 		for (const { options: managerOpts } of this.#runtimeModelManagers.values()) {
 			if (
@@ -1755,6 +1823,27 @@ export class ModelRegistry {
 			const models = result.models.map(model =>
 				model.provider === options.providerId ? model : { ...model, provider: options.providerId },
 			);
+			if (options.modelsDev) {
+				const status =
+					result.source === "cache"
+						? "cached"
+						: result.source === "bundled" && result.stale
+							? "unavailable"
+							: result.source === "bundled"
+								? "idle"
+								: result.models.length > 0
+									? "ok"
+									: "empty";
+				this.#providerDiscoveryStates.set(options.providerId, {
+					provider: options.providerId,
+					status,
+					optional: false,
+					stale: result.stale,
+					fetchedAt: result.updatedAt,
+					source: result.source,
+					models: models.map(model => model.id),
+				});
+			}
 			const authoritativeProviders = new Set<string>();
 			if (options.dynamicModelsAuthoritative && !result.stale) {
 				authoritativeProviders.add(options.providerId);

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -19,6 +19,7 @@ import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { readModelCache, writeModelCache } from "@oh-my-pi/pi-catalog/model-cache";
 import {
 	createModelManager,
+	fingerprintStaticModels,
 	type ModelManagerOptions,
 	type ModelRefreshStrategy,
 } from "@oh-my-pi/pi-catalog/model-manager";
@@ -130,6 +131,16 @@ const BUILT_IN_MODEL_MANAGER_PROVIDER_IDS: Readonly<Record<string, true>> = Obje
 );
 const MODELS_DEV_CATALOG_PROVIDER_ID_LOOKUP: Readonly<Record<string, true>> = Object.freeze(
 	Object.fromEntries(MODELS_DEV_CATALOG_PROVIDER_IDS.map(providerId => [providerId, true as const])),
+);
+const ADDITIVE_MODELS_DEV_CATALOG_PROVIDER_ID_LOOKUP: Readonly<Record<string, true>> = Object.freeze(
+	Object.fromEntries(
+		MODELS_DEV_CATALOG_PROVIDER_IDS.filter(
+			providerId =>
+				!PROVIDER_DESCRIPTORS.some(
+					descriptor => descriptor.providerId === providerId && descriptor.dynamicModelsAuthoritative,
+				),
+		).map(providerId => [providerId, true as const]),
+	),
 );
 
 /**
@@ -888,6 +899,7 @@ export class ModelRegistry {
 			const cacheProviderId = this.#resolveStartupModelCacheProviderId(providerId);
 			const cache = readModelCache<Api>(cacheProviderId, 24 * 60 * 60 * 1000, Date.now, this.#cacheDbPath);
 			const sharedCatalogProvider = MODELS_DEV_CATALOG_PROVIDER_ID_LOOKUP[providerId] === true;
+			const additiveSharedCatalogProvider = ADDITIVE_MODELS_DEV_CATALOG_PROVIDER_ID_LOOKUP[providerId] === true;
 			if (!cache) {
 				if (sharedCatalogProvider) {
 					this.#providerDiscoveryStates.set(providerId, {
@@ -911,17 +923,26 @@ export class ModelRegistry {
 			// model with required transport headers missing.
 			const omittedHeaderIds = new Set(cache.headerOmittedModelIds);
 			const unrestorableHeaderIds = new Set(cache.unrestorableHeaderModelIds);
-			const bundledById =
-				omittedHeaderIds.size > 0
-					? new Map(
-							(getBundledModels(providerId as Parameters<typeof getBundledModels>[0]) as Model<Api>[]).map(
-								bundledModel => [bundledModel.id, bundledModel],
-							),
-						)
+			const bundledModels =
+				omittedHeaderIds.size > 0 || additiveSharedCatalogProvider
+					? (getBundledModels(providerId as Parameters<typeof getBundledModels>[0]) as Model<Api>[])
 					: undefined;
+			const bundledFingerprint = bundledModels ? fingerprintStaticModels(bundledModels) : undefined;
+			// A matching cache may contain provider-endpoint overrides. Strip
+			// same-id rows only across a bundled-catalog upgrade, where the
+			// additive shared catalog must not replace the new bundled metadata.
+			const additiveCacheStaticMismatch =
+				additiveSharedCatalogProvider &&
+				bundledFingerprint !== undefined &&
+				cache.staticFingerprint !== bundledFingerprint &&
+				!cache.staticFingerprint.startsWith(`${bundledFingerprint}:drop:`);
+			const bundledById = bundledModels
+				? new Map(bundledModels.map(bundledModel => [bundledModel.id, bundledModel]))
+				: undefined;
 			const models: ModelSpec<Api>[] = [];
 			for (const cachedModel of cache.models) {
 				const spec = cachedModel.provider === providerId ? cachedModel : { ...cachedModel, provider: providerId };
+				if (additiveCacheStaticMismatch && bundledById?.has(spec.id)) continue;
 				if (!omittedHeaderIds.has(spec.id)) {
 					models.push(spec);
 					continue;

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -924,10 +924,12 @@ export class ModelRegistry {
 			const omittedHeaderIds = new Set(cache.headerOmittedModelIds);
 			const unrestorableHeaderIds = new Set(cache.unrestorableHeaderModelIds);
 			const bundledModels =
-				omittedHeaderIds.size > 0 || additiveSharedCatalogProvider
+				omittedHeaderIds.size > 0 || sharedCatalogProvider
 					? (getBundledModels(providerId as Parameters<typeof getBundledModels>[0]) as Model<Api>[])
 					: undefined;
-			const bundledFingerprint = bundledModels ? fingerprintStaticModels(bundledModels) : undefined;
+			const bundledFingerprint = bundledModels
+				? fingerprintStaticModels(bundledModels, sharedCatalogProvider && !additiveSharedCatalogProvider)
+				: undefined;
 			// A matching cache may contain provider-endpoint overrides. Strip
 			// same-id rows only across a bundled-catalog upgrade, where the
 			// additive shared catalog must not replace the new bundled metadata.
@@ -978,13 +980,24 @@ export class ModelRegistry {
 			const cachedModels = this.#applyHardcodedModelPolicies(resolved);
 			modelsByProvider.set(providerId, cachedModels);
 			if (sharedCatalogProvider) {
+				const cacheMatchesBundledFingerprint =
+					bundledFingerprint !== undefined &&
+					(cache.staticFingerprint === bundledFingerprint ||
+						cache.staticFingerprint.startsWith(`${bundledFingerprint}:drop:`));
+				const cachedSnapshotMatchesBundled =
+					bundledFingerprint !== undefined &&
+					fingerprintStaticModels(cache.models, !additiveSharedCatalogProvider) === bundledFingerprint;
+				const cacheContributed = additiveSharedCatalogProvider
+					? cachedModels.some(model => bundledById?.has(model.id) !== true)
+					: !(cacheMatchesBundledFingerprint && cachedSnapshotMatchesBundled);
+				const stale = !cache.fresh || !cache.authoritative;
 				this.#providerDiscoveryStates.set(providerId, {
 					provider: providerId,
-					status: "cached",
+					status: cacheContributed ? "cached" : stale ? "unavailable" : "idle",
 					optional: false,
-					stale: !cache.fresh || !cache.authoritative,
-					fetchedAt: cache.updatedAt,
-					source: "cache",
+					stale,
+					...(cacheContributed ? { fetchedAt: cache.updatedAt } : {}),
+					source: cacheContributed ? "cache" : "bundled",
 					models: cachedModels.map(model => model.id),
 				});
 			}

--- a/packages/coding-agent/test/model-registry-runtime-provider.test.ts
+++ b/packages/coding-agent/test/model-registry-runtime-provider.test.ts
@@ -402,6 +402,41 @@ describe("ModelRegistry runtime provider registration", () => {
 		]);
 	});
 
+	test("refreshProvider times out inherited shared-catalog fetches", async () => {
+		vi.useFakeTimers();
+		let catalogFetches = 0;
+		const stalledFetch: FetchImpl = () => {
+			catalogFetches++;
+			return Promise.withResolvers<Response>().promise;
+		};
+		const stalledRegistry = new ModelRegistry(authStorage, modelsJsonPath, { fetch: stalledFetch });
+
+		const baselineTimers = vi.getTimerCount();
+		let outcome: "resolved" | "rejected" | undefined;
+		const refresh = stalledRegistry.refreshProvider("anthropic", "online").then(
+			() => {
+				outcome = "resolved";
+			},
+			error => {
+				outcome = "rejected";
+				throw error;
+			},
+		);
+
+		await drainMicrotasksUntil(
+			() => vi.getTimerCount() > baselineTimers,
+			"shared-catalog timeout timer was not armed",
+		);
+		expect(outcome).toBeUndefined();
+		vi.advanceTimersByTime(14_999);
+		await Promise.resolve();
+		expect(outcome).toBeUndefined();
+		vi.advanceTimersByTime(1);
+		await refresh;
+		expect(outcome).toBe("resolved");
+		expect(catalogFetches).toBe(1);
+	});
+
 	test("refreshRuntimeProviders times out extension fetchDynamicModels that never resolves", async () => {
 		vi.useFakeTimers();
 		const hangingFetch = Promise.withResolvers<readonly NonNullable<ProviderConfigInput["models"]>[number][]>();

--- a/packages/coding-agent/test/model-registry-runtime-provider.test.ts
+++ b/packages/coding-agent/test/model-registry-runtime-provider.test.ts
@@ -402,39 +402,46 @@ describe("ModelRegistry runtime provider registration", () => {
 		]);
 	});
 
-	test("refreshProvider times out inherited shared-catalog fetches", async () => {
+	test("refreshProvider aborts and retries inherited shared-catalog fetches", async () => {
 		vi.useFakeTimers();
 		let catalogFetches = 0;
-		const stalledFetch: FetchImpl = () => {
+		let abortedFetches = 0;
+		const stalledFetch: FetchImpl = (_input, init) => {
 			catalogFetches++;
-			return Promise.withResolvers<Response>().promise;
+			const { promise, reject } = Promise.withResolvers<Response>();
+			const signal = init?.signal;
+			if (!signal) {
+				reject(new Error("catalog fetch did not receive an abort signal"));
+				return promise;
+			}
+			const rejectAborted = () => {
+				abortedFetches++;
+				reject(signal.reason);
+			};
+			if (signal.aborted) {
+				rejectAborted();
+			} else {
+				signal.addEventListener("abort", rejectAborted, { once: true });
+			}
+			return promise;
 		};
 		const stalledRegistry = new ModelRegistry(authStorage, modelsJsonPath, { fetch: stalledFetch });
 
-		const baselineTimers = vi.getTimerCount();
-		let outcome: "resolved" | "rejected" | undefined;
-		const refresh = stalledRegistry.refreshProvider("anthropic", "online").then(
-			() => {
-				outcome = "resolved";
-			},
-			error => {
-				outcome = "rejected";
-				throw error;
-			},
-		);
-
-		await drainMicrotasksUntil(
-			() => vi.getTimerCount() > baselineTimers,
-			"shared-catalog timeout timer was not armed",
-		);
-		expect(outcome).toBeUndefined();
-		vi.advanceTimersByTime(14_999);
+		const firstRefresh = stalledRegistry.refreshProvider("anthropic", "online");
+		await drainMicrotasksUntil(() => catalogFetches === 1, "first shared-catalog fetch did not start");
+		vi.advanceTimersByTime(9_999);
 		await Promise.resolve();
-		expect(outcome).toBeUndefined();
+		expect(abortedFetches).toBe(0);
 		vi.advanceTimersByTime(1);
-		await refresh;
-		expect(outcome).toBe("resolved");
-		expect(catalogFetches).toBe(1);
+		await firstRefresh;
+		expect(abortedFetches).toBe(1);
+
+		const secondRefresh = stalledRegistry.refreshProvider("anthropic", "online");
+		await drainMicrotasksUntil(() => catalogFetches === 2, "second shared-catalog fetch did not start");
+		vi.advanceTimersByTime(10_000);
+		await secondRefresh;
+		expect(abortedFetches).toBe(2);
+		expect(catalogFetches).toBe(2);
 	});
 
 	test("refreshRuntimeProviders times out extension fetchDynamicModels that never resolves", async () => {

--- a/packages/coding-agent/test/model-registry-runtime-provider.test.ts
+++ b/packages/coding-agent/test/model-registry-runtime-provider.test.ts
@@ -372,6 +372,36 @@ describe("ModelRegistry runtime provider registration", () => {
 		expect(configuredRegistry.find(providerName, "shared-runtime-model")?.contextWindow).toBe(32_768);
 	});
 
+	test("runtime provider manager supersedes the built-in shared catalog manager", async () => {
+		let catalogFetches = 0;
+		const catalogFetch: FetchImpl = async input => {
+			catalogFetches++;
+			throw new Error(`Unexpected built-in catalog fetch: ${String(input)}`);
+		};
+		const overrideRegistry = new ModelRegistry(authStorage, modelsJsonPath, { fetch: catalogFetch });
+		let runtimeFetches = 0;
+		overrideRegistry.registerProvider(
+			"anthropic",
+			{
+				baseUrl: "https://runtime.example.com/v1",
+				api: "anthropic-messages",
+				fetchDynamicModels: async () => {
+					runtimeFetches++;
+					return [{ ...baseModel, id: "runtime-anthropic-model" }];
+				},
+			},
+			"ext://runtime",
+		);
+
+		await overrideRegistry.refreshProvider("anthropic", "online");
+
+		expect(runtimeFetches).toBe(1);
+		expect(catalogFetches).toBe(0);
+		expect(getProviderModels(overrideRegistry, "anthropic").map(model => model.id)).toEqual([
+			"runtime-anthropic-model",
+		]);
+	});
+
 	test("refreshRuntimeProviders times out extension fetchDynamicModels that never resolves", async () => {
 		vi.useFakeTimers();
 		const hangingFetch = Promise.withResolvers<readonly NonNullable<ProviderConfigInput["models"]>[number][]>();

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -6,6 +6,7 @@ import * as path from "node:path";
 import { Effort, type FetchImpl, type Model, type OpenAICompat, type ThinkingConfig } from "@oh-my-pi/pi-ai";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { writeModelCache } from "@oh-my-pi/pi-catalog/model-cache";
+import { fingerprintStaticModels } from "@oh-my-pi/pi-catalog/model-manager";
 import { getBundledModels } from "@oh-my-pi/pi-catalog/models";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { resetSettingsForTest, Settings, settings } from "@oh-my-pi/pi-coding-agent/config/settings";
@@ -1993,11 +1994,20 @@ describe("ModelRegistry", () => {
 				{ providers: {} },
 				{
 					seedCache: dbPath => {
+						const bundledModels = getBundledModels("zai");
+						const bundledModel = bundledModels[0];
+						if (!bundledModel) throw new Error("ZAI bundled catalog is empty");
 						writeModelCache(
 							"zai",
 							Date.now(),
 							[
-								...getBundledModels("zai"),
+								{
+									...bundledModel,
+									name: "Stale cached name",
+									contextWindow: bundledModel.contextWindow === 1 ? 2 : 1,
+									maxTokens: bundledModel.maxTokens === 1 ? 2 : 1,
+								},
+								...bundledModels.slice(1),
 								buildModel({
 									id: "glm-5.3-flash",
 									name: "GLM-5.3-Flash",
@@ -2012,7 +2022,7 @@ describe("ModelRegistry", () => {
 								}),
 							],
 							true,
-							"",
+							"merge-v3:stale-bundle",
 							dbPath,
 						);
 					},
@@ -2098,7 +2108,7 @@ describe("ModelRegistry", () => {
 								}),
 							],
 							true,
-							"",
+							fingerprintStaticModels(getBundledModels("ollama-cloud")),
 							dbPath,
 						);
 					},
@@ -2448,7 +2458,14 @@ describe("ModelRegistry", () => {
 			expect(vertexModels.some(model => model.id.startsWith("gemini-"))).toBe(true);
 		});
 
-		test("hydrates cached shared-catalog additions without provider credentials", () => {
+		test("hydrates only shared-catalog additions from cache", () => {
+			const bundledModel = getBundledModels("zai")[0];
+			if (!bundledModel) throw new Error("ZAI bundled catalog is empty");
+			expect(sharedCatalogCache.find("zai", bundledModel.id)).toMatchObject({
+				name: bundledModel.name,
+				contextWindow: bundledModel.contextWindow,
+				maxTokens: bundledModel.maxTokens,
+			});
 			expect(sharedCatalogCache.find("zai", "glm-5.3-flash")).toMatchObject({
 				contextWindow: 1_000_000,
 				maxTokens: 131_072,

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -1974,6 +1974,7 @@ describe("ModelRegistry", () => {
 		let vertexStale: ModelRegistry;
 		let litellmStaleNamespaceCache: ModelRegistry;
 		let sharedCatalogCache: ModelRegistry;
+		let staticOnlySharedCatalogCache: ModelRegistry;
 		let litellmCurrentNamespaceCache: ModelRegistry;
 		let openaiModelsListStaleNamespaceCache: ModelRegistry;
 		const vertexProjectModel = () =>
@@ -2025,6 +2026,27 @@ describe("ModelRegistry", () => {
 							"merge-v3:stale-bundle",
 							dbPath,
 						);
+					},
+				},
+			);
+			staticOnlySharedCatalogCache = readonlyRegistry(
+				{ providers: {} },
+				{
+					seedCache: dbPath => {
+						for (const [providerId, dynamicModelsAuthoritative] of [
+							["zai", false],
+							["anthropic", true],
+						] as const) {
+							const bundledModels = getBundledModels(providerId);
+							writeModelCache(
+								providerId,
+								Date.now(),
+								bundledModels,
+								false,
+								fingerprintStaticModels(bundledModels, dynamicModelsAuthoritative),
+								dbPath,
+							);
+						}
 					},
 				},
 			);
@@ -2477,6 +2499,23 @@ describe("ModelRegistry", () => {
 				stale: false,
 				source: "cache",
 			});
+		});
+
+		test("reports static-only shared-catalog startup caches as bundled", () => {
+			for (const providerId of ["zai", "anthropic"] as const) {
+				const bundledModel = getBundledModels(providerId)[0];
+				if (!bundledModel) throw new Error(`${providerId} bundled catalog is empty`);
+				expect(staticOnlySharedCatalogCache.find(providerId, bundledModel.id)).toBeDefined();
+				const discovery = staticOnlySharedCatalogCache.getProviderDiscoveryState(providerId);
+				expect(discovery).toMatchObject({
+					provider: providerId,
+					status: "unavailable",
+					optional: false,
+					stale: true,
+					source: "bundled",
+				});
+				expect(discovery?.fetchedAt).toBeUndefined();
+			}
 		});
 	});
 

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -6,6 +6,7 @@ import * as path from "node:path";
 import { Effort, type FetchImpl, type Model, type OpenAICompat, type ThinkingConfig } from "@oh-my-pi/pi-ai";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { writeModelCache } from "@oh-my-pi/pi-catalog/model-cache";
+import { getBundledModels } from "@oh-my-pi/pi-catalog/models";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { resetSettingsForTest, Settings, settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
@@ -1971,6 +1972,7 @@ describe("ModelRegistry", () => {
 		let vertexNonAuthoritative: ModelRegistry;
 		let vertexStale: ModelRegistry;
 		let litellmStaleNamespaceCache: ModelRegistry;
+		let sharedCatalogCache: ModelRegistry;
 		let litellmCurrentNamespaceCache: ModelRegistry;
 		let openaiModelsListStaleNamespaceCache: ModelRegistry;
 		const vertexProjectModel = () =>
@@ -1987,6 +1989,35 @@ describe("ModelRegistry", () => {
 				maxTokens: 8_888,
 			});
 		beforeAll(() => {
+			sharedCatalogCache = readonlyRegistry(
+				{ providers: {} },
+				{
+					seedCache: dbPath => {
+						writeModelCache(
+							"zai",
+							Date.now(),
+							[
+								...getBundledModels("zai"),
+								buildModel({
+									id: "glm-5.3-flash",
+									name: "GLM-5.3-Flash",
+									api: "anthropic-messages",
+									provider: "zai",
+									baseUrl: "https://api.z.ai/api/anthropic",
+									reasoning: true,
+									input: ["text", "image"],
+									cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+									contextWindow: 1_000_000,
+									maxTokens: 131_072,
+								}),
+							],
+							true,
+							"",
+							dbPath,
+						);
+					},
+				},
+			);
 			legacySentinels = readonlyRegistry(
 				{
 					providers: {
@@ -2415,6 +2446,20 @@ describe("ModelRegistry", () => {
 			const vertexModels = getModelsForProvider(vertexStale, "google-vertex");
 			expect(vertexModels.some(model => model.id === "zai-org/glm-4.7-maas")).toBe(true);
 			expect(vertexModels.some(model => model.id.startsWith("gemini-"))).toBe(true);
+		});
+
+		test("hydrates cached shared-catalog additions without provider credentials", () => {
+			expect(sharedCatalogCache.find("zai", "glm-5.3-flash")).toMatchObject({
+				contextWindow: 1_000_000,
+				maxTokens: 131_072,
+			});
+			expect(sharedCatalogCache.getProviderDiscoveryState("zai")).toMatchObject({
+				provider: "zai",
+				status: "cached",
+				optional: false,
+				stale: false,
+				source: "cache",
+			});
 		});
 	});
 


### PR DESCRIPTION
## What

Contributor context, verbatim: “can you investigate if omp actually behaves like this? can we think of what the other alternative approaches would be and weigh the pros and cons”

- Add a cached runtime models.dev layer for providers with registered catalog descriptors.
- Hydrate provider slices from `models.db` during startup, then refresh them through the existing nonblocking background discovery lifecycle.
- Accept remote rows only for new model IDs. Bundled records remain authoritative for existing IDs, and remote omissions never remove bundled models.
- Expose `source` and `fetchedAt` in provider discovery state so callers can distinguish bundled, cached, shared-catalog, and provider-endpoint results.

## Why

OMP already supports provider-specific runtime discovery, but most providers still depend on the generated bundled catalog for newly released model IDs. This keeps deterministic startup and offline behavior while removing the binary release from the normal new-model path.

PR #9834 adds authenticated, authoritative Z.AI endpoint discovery. This draft covers the broader non-authoritative shared-catalog layer across known providers. The approaches overlap for Z.AI and should be reconciled before this draft is marked ready.

## Testing

- `cd packages/catalog && bun run check`
- `cd packages/coding-agent && bun run check`
- `cd packages/catalog && bun test test/opencode-provider.test.ts`
- `cd packages/coding-agent && bun test test/model-registry.test.ts`
- Live catalog smoke with a temporary cache returned `glm-5.3-flash` for Z.AI from `models.dev` with Anthropic-compatible routing, image input, a 1,000,000-token context window, and a 131,072-token output limit.
- The catalog test injects a conflicting remote row for an existing bundled ID and confirms bundled metadata is preserved.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
