### PR TITLE
fix(coding-agent): finalize retry lifecycle after recovery

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed prompts hanging when a successful automatic retry ended through an early terminal path such as `yield`.
+
 ## [18.0.7] - 2026-08-26
 
 ### Added

--- a/packages/coding-agent/src/session/turn-recovery.ts
+++ b/packages/coding-agent/src/session/turn-recovery.ts
@@ -382,6 +382,7 @@ export class TurnRecovery {
 		});
 		this.#clearPendingRetryErrors();
 		this.#retryAttempt = 0;
+		this.resolveRetry();
 	}
 
 	/** Closes a failed retry saga when no compaction continuation took ownership. */

--- a/packages/coding-agent/test/agent-session-auto-compaction-queue.test.ts
+++ b/packages/coding-agent/test/agent-session-auto-compaction-queue.test.ts
@@ -729,12 +729,11 @@ describe("AgentSession auto-compaction queue resume", () => {
 		expect(getRuntimeSignals()).toContain("compaction:start:threshold");
 	});
 
-	it("resolves a pending retry before active-goal compaction continuation returns", async () => {
-		// Codex review on #3175: a retry can succeed with a non-empty text stop
-		// that is already over the active-goal compaction threshold. If the
-		// compaction pre-empt schedules its own continuation before the normal
-		// bottom-of-handler `#resolveRetry()` call runs, the session stays
-		// `isRetrying` and later prompt/idle gates remain blocked.
+	it("settles a successful retry before active-goal compaction continuation starts", async () => {
+		// A retry can succeed with a non-empty text stop that is already over the
+		// active-goal compaction threshold. The successful message itself must
+		// close the retry lifecycle before agent_end routes into compaction, so
+		// early terminal routes cannot leave prompt/idle gates blocked.
 		vi.useRealTimers();
 		const now = Date.now();
 		session.setGoalModeState({
@@ -819,7 +818,7 @@ describe("AgentSession auto-compaction queue resume", () => {
 		};
 		session.agent.emitExternalEvent({ type: "message_end", message: recoveredOverThreshold });
 		await withTimeout(retryEnded, 1000, "Retry end timed out");
-		expect(session.isRetrying).toBe(true);
+		expect(session.isRetrying).toBe(false);
 
 		session.agent.emitExternalEvent({ type: "agent_end", messages: [recoveredOverThreshold] });
 

--- a/packages/coding-agent/test/agent-session-yield-empty-stop-suppression.test.ts
+++ b/packages/coding-agent/test/agent-session-yield-empty-stop-suppression.test.ts
@@ -8,6 +8,7 @@
  * (see issues #3389 and #4963).
  */
 import { afterAll, afterEach, describe, expect, it, vi } from "bun:test";
+import { scheduler } from "node:timers/promises";
 import { type } from "@oh-my-pi/omptype";
 import { Agent, type AgentMessage, type AgentTool } from "@oh-my-pi/pi-agent-core";
 import { createMockModel, type MockModel, type MockResponse } from "@oh-my-pi/pi-ai/providers/mock";
@@ -82,14 +83,21 @@ function emptyStop(): MockResponse {
 	};
 }
 
-async function createHarness(responses: MockResponse[]): Promise<Harness & { mock: MockModel }> {
+async function createHarness(
+	responses: MockResponse[],
+	options?: { retryEnabled?: boolean },
+): Promise<Harness & { mock: MockModel }> {
 	const tempDir = TempDir.createSync("@pi-yield-empty-stop-");
 
 	const mock = createMockModel({ responses });
 	const modelRegistry = sharedModelRegistry;
 	const settings = Settings.isolated({
 		"compaction.enabled": false,
-		"retry.enabled": false,
+		"retry.enabled": options?.retryEnabled ?? false,
+		"retry.baseDelayMs": 5,
+		"retry.maxDelayMs": 100,
+		"retry.maxRetries": 1,
+		"retry.modelFallback": false,
 		"todo.enabled": false,
 		"todo.eager": "default",
 		"todo.reminders": false,
@@ -150,6 +158,35 @@ afterEach(async () => {
 });
 
 describe("AgentSession yield empty-stop suppression", () => {
+	it("settles a successful retry that ends in a terminal yield", async () => {
+		vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+		const { session, mock } = await createHarness(
+			[{ throw: "503 service unavailable: overloaded_error" }, yieldCall("recovered", "call-yield-after-retry")],
+			{ retryEnabled: true },
+		);
+		const retryEvents: Array<"auto_retry_start" | "auto_retry_end"> = [];
+		session.subscribe(event => {
+			if (event.type === "auto_retry_start" || event.type === "auto_retry_end") {
+				retryEvents.push(event.type);
+			}
+		});
+
+		const prompt = session.prompt("retry once then yield");
+		const outcome = await Promise.race([
+			prompt.then(() => "completed" as const),
+			Bun.sleep(1_000).then(() => "stuck" as const),
+		]);
+		if (outcome === "stuck") {
+			session.abortRetry();
+			await prompt;
+		}
+
+		expect(outcome).toBe("completed");
+		expect(mock.calls).toHaveLength(2);
+		expect(retryEvents).toEqual(["auto_retry_start", "auto_retry_end"]);
+		expect(session.isRetrying).toBe(false);
+	});
+
 	it("does not continue to a trailing empty assistant stop after a successful yield", async () => {
 		const { session, mock } = await createHarness([yieldCall("done", "call-yield-done")]);
 


### PR DESCRIPTION
## What

Finalize the retry lifecycle when a retried assistant turn succeeds, including terminal `yield` paths.

- Resolve the pending retry promise at the successful recovery boundary.
- Add a regression test covering retry followed by terminal yield.
- Update the compaction test to require `isRetrying === false` after successful recovery.

## Why

A successful retry emitted `auto_retry_end` and reset the attempt counter, but left the retry promise pending. Early terminal paths could therefore leave `session.prompt()` blocked indefinitely.

## Testing

- Confirmed the new regression test fails with `"stuck"` before the fix.
- Confirmed the same test passes after the fix.
- Passed 149 related retry, fallback, compaction, empty-stop, and thinking-loop tests.
- `bun run check`
- Runtime CI passed 29/30 chunks; the remaining unrelated failure was `sdk-context-file-refresh.test.ts`.