### PR TITLE
fix(hub): settle await:true send when recipient stops without replying

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `hub` `send await:true` blocking for the full IRC timeout when the awaited agent finished without replying; the send now settles as soon as the peer stops ([#9913](https://github.com/can1357/oh-my-pi/issues/9913)).
+
 ## [18.0.7] - 2026-08-26
 
 ### Added

--- a/packages/coding-agent/src/irc/bus.ts
+++ b/packages/coding-agent/src/irc/bus.ts
@@ -323,17 +323,25 @@ export class IrcBus {
 			const { registry, target } = awaitTarget;
 			let subscribedSession: AgentSession | null = null;
 			let unsubscribeSession: (() => void) | undefined;
+			let active = true;
 			// The peer's terminal `agent_end` is the authoritative "stopped" signal.
 			// It is emitted only after the peer's prompt fully unwinds (see
-			// AgentSession#flushPendingAgentEnd) and supersedes mid-run
-			// continuations (auto-compaction / retry), so — unlike the registry
-			// `idle` transition, which fires while `isStreaming` is still true — it
-			// fires exactly once, when the peer truly stops. A real reply resolves
-			// the waiter mid-turn before this ever fires, so cleanup tears it down.
+			// AgentSession#flushPendingAgentEnd) and supersedes scheduled
+			// continuations. A side-channel auto-reply may outlive that main turn,
+			// though, so wait for it before declaring the peer stopped: its bus send
+			// resolves this waiter first; an empty/failed reply then falls through to
+			// the clean stopped result.
 			const onSessionEvent = (event: AgentSessionEvent): void => {
-				if (event.type === "agent_end" && event.isTerminal !== false) {
+				if (event.type !== "agent_end" || event.isTerminal === false) return;
+				const session = subscribedSession;
+				if (!session) {
 					settle({ kind: "abort", error: new IrcAwaitTargetStopped(target) });
+					return;
 				}
+				void session.waitForIrcAutoReplies().then(() => {
+					if (!active || registry.get(target)?.session !== session) return;
+					settle({ kind: "abort", error: new IrcAwaitTargetStopped(target) });
+				});
 			};
 			const sync = (): void => {
 				const ref = registry.get(target);
@@ -353,6 +361,7 @@ export class IrcBus {
 			};
 			const unsubscribeChange = registry.onChange(sync);
 			unsubscribeAwaitTarget = () => {
+				active = false;
 				unsubscribeChange();
 				unsubscribeSession?.();
 			};

--- a/packages/coding-agent/src/irc/bus.ts
+++ b/packages/coding-agent/src/irc/bus.ts
@@ -18,6 +18,8 @@
 import { logger, Snowflake } from "@oh-my-pi/pi-utils";
 import { AgentLifecycleManager } from "../registry/agent-lifecycle";
 import { AgentRegistry, MAIN_AGENT_ID } from "../registry/agent-registry";
+import type { AgentSession } from "../session/agent-session";
+import type { AgentSessionEvent } from "../session/agent-session-events";
 import type { CustomMessage } from "../session/messages";
 
 export interface IrcMessage {
@@ -319,25 +321,42 @@ export class IrcBus {
 		const awaitTarget = options?.awaitTarget;
 		if (awaitTarget) {
 			const { registry, target } = awaitTarget;
-			// Session `isStreaming` (not `registry.isRunning`) is the engagement
-			// signal: it stays true across mid-run continuations (auto-compaction /
-			// retry) that briefly flip the registry status to idle, so those flaps
-			// never masquerade as a terminal stop.
-			let engaged = registry.get(target)?.session?.isStreaming === true;
-			unsubscribeAwaitTarget = registry.onChange(() => {
+			let subscribedSession: AgentSession | null = null;
+			let unsubscribeSession: (() => void) | undefined;
+			// The peer's terminal `agent_end` is the authoritative "stopped" signal.
+			// It is emitted only after the peer's prompt fully unwinds (see
+			// AgentSession#flushPendingAgentEnd) and supersedes mid-run
+			// continuations (auto-compaction / retry), so — unlike the registry
+			// `idle` transition, which fires while `isStreaming` is still true — it
+			// fires exactly once, when the peer truly stops. A real reply resolves
+			// the waiter mid-turn before this ever fires, so cleanup tears it down.
+			const onSessionEvent = (event: AgentSessionEvent): void => {
+				if (event.type === "agent_end" && event.isTerminal !== false) {
+					settle({ kind: "abort", error: new IrcAwaitTargetStopped(target) });
+				}
+			};
+			const sync = (): void => {
 				const ref = registry.get(target);
+				// Gone or hard-aborted: no reply will ever come.
 				if (!ref || ref.status === "aborted") {
 					settle({ kind: "abort", error: new IrcAwaitTargetStopped(target) });
 					return;
 				}
-				if (ref.session?.isStreaming === true) {
-					engaged = true;
-					return;
+				// Follow the live session across a park→revive rebuild; tolerate a
+				// parked peer with no session yet (the send is about to revive it).
+				const session = ref.session;
+				if (session && session !== subscribedSession) {
+					unsubscribeSession?.();
+					subscribedSession = session;
+					unsubscribeSession = session.subscribe(onSessionEvent);
 				}
-				if (engaged) {
-					settle({ kind: "abort", error: new IrcAwaitTargetStopped(target) });
-				}
-			});
+			};
+			const unsubscribeChange = registry.onChange(sync);
+			unsubscribeAwaitTarget = () => {
+				unsubscribeChange();
+				unsubscribeSession?.();
+			};
+			sync();
 		}
 
 		return promise;

--- a/packages/coding-agent/src/irc/bus.ts
+++ b/packages/coding-agent/src/irc/bus.ts
@@ -44,6 +44,20 @@ interface IrcWaiter {
 	cancel: () => void;
 }
 
+/**
+ * Rejection reason for a `send await:true` whose awaited peer reached a
+ * terminal stop (ended its turn, parked, was aborted, or unregistered)
+ * without ever replying. Distinct from a plain timeout so the sender can
+ * surface "they stopped" instead of stranding the caller on the full
+ * `irc.timeoutMs` window.
+ */
+export class IrcAwaitTargetStopped extends Error {
+	constructor(target: string) {
+		super(`Awaited peer "${target}" stopped without replying.`);
+		this.name = "IrcAwaitTargetStopped";
+	}
+}
+
 /** Mailbox cap per agent; oldest messages are dropped beyond it. */
 const MAILBOX_CAP = 100;
 
@@ -205,7 +219,11 @@ export class IrcBus {
 		filter: { from?: string },
 		timeoutMs: number,
 		signal?: AbortSignal,
-		options?: { drainPending?: boolean; liveness?: { registry: AgentRegistry; senderId: string } },
+		options?: {
+			drainPending?: boolean;
+			liveness?: { registry: AgentRegistry; senderId: string };
+			awaitTarget?: { registry: AgentRegistry; target: string };
+		},
 	): Promise<IrcMessage | null> {
 		if (signal?.aborted) {
 			throw signal.reason instanceof Error ? signal.reason : new Error("IRC wait aborted");
@@ -221,6 +239,7 @@ export class IrcBus {
 		let timer: NodeJS.Timeout | undefined;
 		let onAbort: (() => void) | undefined;
 		let unsubscribeLiveness: (() => void) | undefined;
+		let unsubscribeAwaitTarget: (() => void) | undefined;
 
 		const liveness = options?.liveness;
 		const livenessReason = filter.from
@@ -245,6 +264,7 @@ export class IrcBus {
 			clearTimeout(timer);
 			if (signal && onAbort) signal.removeEventListener("abort", onAbort);
 			unsubscribeLiveness?.();
+			unsubscribeAwaitTarget?.();
 		};
 
 		const waiter: IrcWaiter = {
@@ -286,6 +306,38 @@ export class IrcBus {
 			if (!check()) {
 				settle({ kind: "abort", error: new Error(livenessReason) });
 			}
+		}
+
+		// `send await:true`: settle the sender promptly once the awaited peer
+		// reaches a terminal stop without replying, instead of stranding it on
+		// the full timeout. Unlike `liveness`, this tolerates a peer that is
+		// idle/parked when the send lands (the send is about to wake or revive
+		// it): it only aborts once the peer has actually been observed running
+		// and then stopped, or is unambiguously gone (unregistered / aborted).
+		// A real reply resolves the waiter first (the recipient sends it mid-turn,
+		// before the turn-end idle transition), so cleanup tears this down.
+		const awaitTarget = options?.awaitTarget;
+		if (awaitTarget) {
+			const { registry, target } = awaitTarget;
+			// Session `isStreaming` (not `registry.isRunning`) is the engagement
+			// signal: it stays true across mid-run continuations (auto-compaction /
+			// retry) that briefly flip the registry status to idle, so those flaps
+			// never masquerade as a terminal stop.
+			let engaged = registry.get(target)?.session?.isStreaming === true;
+			unsubscribeAwaitTarget = registry.onChange(() => {
+				const ref = registry.get(target);
+				if (!ref || ref.status === "aborted") {
+					settle({ kind: "abort", error: new IrcAwaitTargetStopped(target) });
+					return;
+				}
+				if (ref.session?.isStreaming === true) {
+					engaged = true;
+					return;
+				}
+				if (engaged) {
+					settle({ kind: "abort", error: new IrcAwaitTargetStopped(target) });
+				}
+			});
 		}
 
 		return promise;

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -962,7 +962,25 @@ export class AgentSession {
 		const pending = this.#pendingAgentEndEmit;
 		if (!pending) return;
 		this.#pendingAgentEndEmit = undefined;
-		this.#emit(pending);
+		if (pending.type !== "agent_end" || pending.isTerminal === false) {
+			this.#emit(pending);
+			return;
+		}
+
+		// `agent_end` is deferred until the prompt count reaches zero, but it is
+		// emitted immediately before the settle drain schedules work that arrived
+		// after the loop's final queue/aside poll. Such a tail arrival is a real
+		// continuation, not a terminal stop: mark this end non-terminal so
+		// subscribers wait through the queued steer/follow-up or stranded IRC wake.
+		const canDrain =
+			!this.#abortInProgress && this.#unsubscribeAgent !== undefined && this.#modeExitDrainSuppressionDepth === 0;
+		const queuedContinuation =
+			canDrain &&
+			!this.#queuedMessageDrainBlocked &&
+			this.#canAutoContinueForFollowUp() &&
+			this.agent.hasQueuedMessages();
+		const ircContinuation = canDrain && !this.#isDisposed && !this.#planModeState?.enabled && this.#irc.hasPending();
+		this.#emit(queuedContinuation || ircContinuation ? { ...pending, isTerminal: false } : pending);
 	}
 
 	/**

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -7935,6 +7935,11 @@ export class AgentSession {
 		return this.#irc.deliver(msg, opts);
 	}
 
+	/** Waits for side-channel IRC auto-replies currently owned by this session. */
+	waitForIrcAutoReplies(): Promise<void> {
+		return this.#irc.waitForAutoReplies();
+	}
+
 	/** Installs task-executor monitoring around autonomous IRC wake turns. */
 	setIrcWakeTurnObserver(
 		observer: ((records: CustomMessage[]) => ((error?: unknown) => void | Promise<void>) | undefined) | undefined,

--- a/packages/coding-agent/src/session/irc-bridge.ts
+++ b/packages/coding-agent/src/session/irc-bridge.ts
@@ -28,6 +28,7 @@ export class IrcBridge {
 	readonly #host: IrcBridgeHost;
 	#interrupts: CustomMessage[] = [];
 	#asides: CustomMessage[] = [];
+	readonly #autoReplies = new Set<Promise<void>>();
 
 	constructor(host: IrcBridgeHost) {
 		this.#host = host;
@@ -41,6 +42,13 @@ export class IrcBridge {
 	/** Whether any undelivered IRC record remains queued. */
 	hasPending(): boolean {
 		return this.#interrupts.length > 0 || this.#asides.length > 0;
+	}
+
+	/** Waits until every side-channel auto-reply started so far has finished. */
+	async waitForAutoReplies(): Promise<void> {
+		while (this.#autoReplies.size > 0) {
+			await Promise.all(this.#autoReplies);
+		}
 	}
 
 	/** Takes every queued IRC record in interrupt-before-aside order. */
@@ -143,7 +151,7 @@ export class IrcBridge {
 			} else {
 				this.#interrupts.push(record);
 			}
-			if (autoReply) void this.#runAutoReply(msg);
+			if (autoReply) this.#startAutoReply(msg);
 			return "injected";
 		}
 		if (this.#host.planModeEnabled()) {
@@ -155,7 +163,7 @@ export class IrcBridge {
 				record.details,
 				record.attribution ?? "agent",
 			);
-			if (autoReply) void this.#runAutoReply(msg);
+			if (autoReply) this.#startAutoReply(msg);
 			return "injected";
 		}
 		this.#host.wakeForIrc([record]);
@@ -173,6 +181,12 @@ export class IrcBridge {
 			this.#host.agent.emitExternalEvent({ type: "message_start", message: record });
 			this.#host.agent.emitExternalEvent({ type: "message_end", message: record });
 		}
+	}
+
+	#startAutoReply(msg: IrcMessage): void {
+		const running = this.#runAutoReply(msg);
+		this.#autoReplies.add(running);
+		void running.finally(() => this.#autoReplies.delete(running));
 	}
 
 	async #runAutoReply(msg: IrcMessage): Promise<void> {

--- a/packages/coding-agent/src/tools/hub/messaging.ts
+++ b/packages/coding-agent/src/tools/hub/messaging.ts
@@ -14,7 +14,7 @@ import { type Component, Text } from "@oh-my-pi/pi-tui";
 import { formatAge, formatDuration } from "@oh-my-pi/pi-utils";
 import type { Settings } from "../../config/settings";
 import type { RenderResultOptions } from "../../extensibility/custom-tools/types";
-import { IrcBus, type IrcDeliveryReceipt, type IrcMessage } from "../../irc/bus";
+import { IrcAwaitTargetStopped, IrcBus, type IrcDeliveryReceipt, type IrcMessage } from "../../irc/bus";
 import type { Theme } from "../../modes/theme/theme";
 import { type AgentRegistry, MAIN_AGENT_ID } from "../../registry/agent-registry";
 import { ensurePersistedRoster, isCurrentSessionRosterRef } from "../../registry/persisted-agents";
@@ -272,6 +272,7 @@ export async function executeSend(
 		? bus
 				.wait(senderId, { from: to }, timeoutMs ?? DEFAULT_IRC_TIMEOUT_MS, awaitAbort?.signal, {
 					drainPending: false,
+					awaitTarget: { registry, target: to },
 				})
 				.then(
 					message => ({ message, error: null as Error | null }),
@@ -336,11 +337,19 @@ export async function executeSend(
 			if (delivered.length > 0) {
 				const reply = await waiting;
 				if (reply.error) {
-					// The send already succeeded; if the wait was interrupted by our
-					// caller signal (steering / messaging), preserve the delivery receipt
-					// so the agent loop keeps this tool as "sent" instead of marking it
-					// skipped, which would prompt a duplicate resend on the next turn.
-					if (signal?.aborted) {
+					if (reply.error instanceof IrcAwaitTargetStopped) {
+						// The awaited peer ran and stopped without replying: the send
+						// still succeeded, so surface a clean note instead of erroring
+						// out — and settle now rather than blocking the full timeout.
+						lines.push(
+							`${to} stopped without replying. ` +
+								`Check \`inbox\` or their transcript (history://${to}) for a later answer.`,
+						);
+					} else if (signal?.aborted) {
+						// The send already succeeded; if the wait was interrupted by our
+						// caller signal (steering / messaging), preserve the delivery receipt
+						// so the agent loop keeps this tool as "sent" instead of marking it
+						// skipped, which would prompt a duplicate resend on the next turn.
 						lines.push(
 							`Send delivered but the reply wait was interrupted before ${to} answered. ` +
 								"Check `inbox` or `wait` again after handling the interrupt.",
@@ -363,7 +372,7 @@ export async function executeSend(
 			} else {
 				awaitAbort?.abort(awaitCancelled);
 				const reply = await waiting;
-				if (reply.error) throw reply.error;
+				if (reply.error && !(reply.error instanceof IrcAwaitTargetStopped)) throw reply.error;
 			}
 		}
 

--- a/packages/coding-agent/test/tools/irc.test.ts
+++ b/packages/coding-agent/test/tools/irc.test.ts
@@ -1,15 +1,20 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
 import { Agent } from "@oh-my-pi/pi-agent-core";
+import { createMockModel, type MockResponse } from "@oh-my-pi/pi-ai/providers/mock";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import type { SettingPath } from "@oh-my-pi/pi-coding-agent/config/settings-schema";
 import { IrcBus, type IrcMessage } from "@oh-my-pi/pi-coding-agent/irc/bus";
 import { AgentLifecycleManager } from "@oh-my-pi/pi-coding-agent/registry/agent-lifecycle";
 import { AgentRegistry } from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
 import { AgentSession, type AgentSessionEvent } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import type { CustomMessage } from "@oh-my-pi/pi-coding-agent/session/messages";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
 import { type CoordinationDetails, HubTool, isIrcEnabled } from "@oh-my-pi/pi-coding-agent/tools/hub";
+import { TempDir } from "@oh-my-pi/pi-utils";
 
 interface FakeSession {
 	session: AgentSession;
@@ -23,20 +28,22 @@ interface FakeSession {
 	setError: (error: Error) => void;
 	/** Side effect run on delivery (e.g. reply via the bus). */
 	onDeliver: (fn: (msg: IrcMessage) => void) => void;
-	/** Flip the recipient's streaming (engagement) state. */
-	setStreaming: (value: boolean) => void;
+	/** Emit a terminal `agent_end` to the session's subscribers. */
+	endTurn: (options?: { isTerminal?: boolean }) => void;
 }
 
 function makeFakeSession(): FakeSession {
 	let outcome: "injected" | "woken" = "injected";
-	let streaming = true;
 	let nextError: Error | null = null;
 	let deliverHook: ((msg: IrcMessage) => void) | undefined;
+	const listeners = new Set<(event: AgentSessionEvent) => void>();
 	const delivered: IrcMessage[] = [];
 	const relayed: CustomMessage[] = [];
 	const session = {
-		get isStreaming() {
-			return streaming;
+		isStreaming: true,
+		subscribe: (listener: (event: AgentSessionEvent) => void) => {
+			listeners.add(listener);
+			return () => listeners.delete(listener);
 		},
 		deliverIrcMessage: async (msg: IrcMessage) => {
 			if (nextError) {
@@ -65,8 +72,13 @@ function makeFakeSession(): FakeSession {
 		onDeliver: fn => {
 			deliverHook = fn;
 		},
-		setStreaming: value => {
-			streaming = value;
+		endTurn: options => {
+			const event = {
+				type: "agent_end",
+				messages: [],
+				isTerminal: options?.isTerminal ?? true,
+			} as unknown as AgentSessionEvent;
+			for (const listener of [...listeners]) listener(event);
 		},
 	};
 }
@@ -103,11 +115,43 @@ function createRealSession(overrides: Partial<Record<SettingPath, unknown>> = {}
 	return { session, sessionManager };
 }
 
+/** A real `AgentSession` driven by a mock model, so a prompt runs a genuine
+ *  turn and emits the real terminal `agent_end` after prompt unwind. */
+function createStreamingSession(modelRegistry: ModelRegistry, responses: MockResponse[]): { session: AgentSession } {
+	const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+	if (!model) throw new Error("Expected bundled anthropic model to exist");
+	const mock = createMockModel({ responses });
+	const session = new AgentSession({
+		agent: new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model, systemPrompt: ["system prompt"], tools: [], messages: [] },
+			streamFn: mock.stream,
+		}),
+		sessionManager: SessionManager.inMemory("/tmp"),
+		settings: Settings.isolated({ "compaction.enabled": false, "retry.enabled": false }),
+		modelRegistry,
+	});
+	return { session };
+}
+
 describe("IRC", () => {
 	let registry: AgentRegistry;
 	let bus: IrcBus;
 
 	const sessions: AgentSession[] = [];
+	let authDir: TempDir;
+	let authStorage: AuthStorage;
+	let modelRegistry: ModelRegistry;
+	beforeAll(async () => {
+		authDir = TempDir.createSync("@pi-irc-auth-");
+		authStorage = await AuthStorage.create(authDir.join("auth.db"));
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		modelRegistry = new ModelRegistry(authStorage, authDir.join("models.yml"));
+	});
+	afterAll(() => {
+		authStorage.close();
+		authDir.removeSync();
+	});
 	beforeEach(() => {
 		AgentRegistry.resetGlobalForTests();
 		AgentLifecycleManager.resetGlobalForTests();
@@ -828,12 +872,14 @@ describe("IRC", () => {
 			const main = makeFakeSession();
 			registry.register({ id: "0-Main", displayName: "main", kind: "main", session: main.session });
 			const sub = makeFakeSession();
-			// Recipient is mid-turn (streaming) when the awaited aside lands.
 			registry.register({ id: "0-Sub", displayName: "task", kind: "sub", session: sub.session, status: "running" });
 			sub.onDeliver(() => {
-				// It consumes the aside and ends its turn WITHOUT ever replying.
-				sub.setStreaming(false);
-				registry.setStatus("0-Sub", "idle", sub.session);
+				// The recipient consumes the aside and ends its turn WITHOUT replying.
+				// It stays `isStreaming === true` throughout: the terminal `agent_end`
+				// (emitted post-unwind, while the registry still reads the peer as
+				// running) is the only stop signal — a fix that watched `isStreaming`
+				// flipping false would miss it and block the full timeout.
+				sub.endTurn();
 			});
 
 			const tool = new HubTool(makeToolSession(registry, "0-Main"));
@@ -852,6 +898,57 @@ describe("IRC", () => {
 			expect(details?.waited ?? null).toBeNull();
 			const text = result.content[0]?.type === "text" ? result.content[0].text : "";
 			expect(text).toContain("0-Sub stopped without replying");
+		});
+
+		it("op=send await=true ignores a non-terminal (continuation) agent_end", async () => {
+			const main = makeFakeSession();
+			registry.register({ id: "0-Main", displayName: "main", kind: "main", session: main.session });
+			const sub = makeFakeSession();
+			registry.register({ id: "0-Sub", displayName: "task", kind: "sub", session: sub.session, status: "running" });
+			sub.onDeliver(() => {
+				// A mid-run continuation (auto-compaction / retry) emits a
+				// non-terminal agent_end; it must NOT settle the await early.
+				sub.endTurn({ isTerminal: false });
+				// The recipient then replies on the resumed turn.
+				void bus.send({ from: "0-Sub", to: "0-Main", body: "resumed reply" });
+			});
+
+			const tool = new HubTool(makeToolSession(registry, "0-Main"));
+			const result = await tool.execute("call-1", {
+				op: "send",
+				to: "0-Sub",
+				message: "ping",
+				await: true,
+				timeoutMs: 120_000,
+			});
+
+			const details = result.details as CoordinationDetails | undefined;
+			expect(details?.waited?.body).toBe("resumed reply");
+		});
+
+		it("await monitor aborts on a real AgentSession's terminal agent_end", async () => {
+			// End-to-end against a real session: it runs a genuine turn and emits its
+			// terminal `agent_end` only after the prompt unwinds. This pins the exact
+			// ordering the monitor relies on — the registry still reports the peer as
+			// running at the (deferred) idle transition, so keying on `isStreaming`
+			// flipping would strand the sender for the full timeout.
+			const { session: subSession } = createStreamingSession(modelRegistry, [{ content: ["done, not replying"] }]);
+			sessions.push(subSession);
+			registry.register({ id: "0-Main", displayName: "main", kind: "main", session: makeFakeSession().session });
+			registry.register({ id: "0-Sub", displayName: "task", kind: "sub", session: subSession, status: "running" });
+			const unsync = registry.syncSessionStatus("0-Sub", subSession);
+			try {
+				const waitP = bus.wait("0-Main", { from: "0-Sub" }, 120_000, undefined, {
+					drainPending: false,
+					awaitTarget: { registry, target: "0-Sub" },
+				});
+				await subSession.prompt("work");
+				await subSession.waitForIdle();
+				expect(subSession.isStreaming).toBe(false);
+				await expect(waitP).rejects.toThrow(/stopped without replying/);
+			} finally {
+				unsync();
+			}
 		});
 
 		it("op=send rejects await with to=all and self-sends", async () => {

--- a/packages/coding-agent/test/tools/irc.test.ts
+++ b/packages/coding-agent/test/tools/irc.test.ts
@@ -117,14 +117,18 @@ function createRealSession(overrides: Partial<Record<SettingPath, unknown>> = {}
 
 /** A real `AgentSession` driven by a mock model, so a prompt runs a genuine
  *  turn and emits the real terminal `agent_end` after prompt unwind. */
-function createStreamingSession(modelRegistry: ModelRegistry, responses: MockResponse[]): { session: AgentSession } {
+function createStreamingSession(
+	modelRegistry: ModelRegistry,
+	responses: MockResponse[],
+	options?: { tools?: HubTool[] },
+): { session: AgentSession } {
 	const model = getBundledModel("anthropic", "claude-sonnet-4-5");
 	if (!model) throw new Error("Expected bundled anthropic model to exist");
 	const mock = createMockModel({ responses });
 	const session = new AgentSession({
 		agent: new Agent({
 			getApiKey: () => "test-key",
-			initialState: { model, systemPrompt: ["system prompt"], tools: [], messages: [] },
+			initialState: { model, systemPrompt: ["system prompt"], tools: options?.tools ?? [], messages: [] },
 			streamFn: mock.stream,
 		}),
 		sessionManager: SessionManager.inMemory("/tmp"),
@@ -947,6 +951,59 @@ describe("IRC", () => {
 				expect(subSession.isStreaming).toBe(false);
 				await expect(waitP).rejects.toThrow(/stopped without replying/);
 			} finally {
+				unsync();
+			}
+		});
+
+		it("await target waits through an IRC wake scheduled after terminal settle", async () => {
+			const subHub = new HubTool(makeToolSession(registry, "0-Sub"));
+			const { session: subSession } = createStreamingSession(
+				modelRegistry,
+				[
+					{ content: ["working"] },
+					{
+						content: [
+							{
+								type: "toolCall",
+								id: "tail-reply",
+								name: "hub",
+								arguments: { op: "send", to: "0-Main", message: "reply from the IRC wake" },
+							},
+						],
+					},
+					{ content: ["wake complete"] },
+				],
+				{ tools: [subHub] },
+			);
+			sessions.push(subSession);
+			registry.register({ id: "0-Main", displayName: "main", kind: "main", session: makeFakeSession().session });
+			registry.register({ id: "0-Sub", displayName: "task", kind: "sub", session: subSession, status: "running" });
+			const unsync = registry.syncSessionStatus("0-Sub", subSession);
+			let sentAtTail = false;
+			const unsubscribe = subSession.subscribe(event => {
+				if (sentAtTail || event.type !== "message_end" || event.message.role !== "assistant") return;
+				sentAtTail = true;
+				// Session listeners receive the final assistant message after the
+				// loop's last aside poll but before the deferred terminal
+				// `agent_end`. Delivering here strands the record until the settle
+				// drain schedules its IRC wake turn.
+				void bus.send(
+					{ from: "0-Main", to: "0-Sub", body: "reply after your current turn" },
+					{ expectsReply: true },
+				);
+			});
+			try {
+				const waitP = bus.wait("0-Main", { from: "0-Sub" }, 5_000, undefined, {
+					drainPending: false,
+					awaitTarget: { registry, target: "0-Sub" },
+				});
+				await subSession.prompt("work");
+				const reply = await waitP;
+
+				expect(sentAtTail).toBe(true);
+				expect(reply?.body).toBe("reply from the IRC wake");
+			} finally {
+				unsubscribe();
 				unsync();
 			}
 		});

--- a/packages/coding-agent/test/tools/irc.test.ts
+++ b/packages/coding-agent/test/tools/irc.test.ts
@@ -23,16 +23,21 @@ interface FakeSession {
 	setError: (error: Error) => void;
 	/** Side effect run on delivery (e.g. reply via the bus). */
 	onDeliver: (fn: (msg: IrcMessage) => void) => void;
+	/** Flip the recipient's streaming (engagement) state. */
+	setStreaming: (value: boolean) => void;
 }
 
 function makeFakeSession(): FakeSession {
 	let outcome: "injected" | "woken" = "injected";
+	let streaming = true;
 	let nextError: Error | null = null;
 	let deliverHook: ((msg: IrcMessage) => void) | undefined;
 	const delivered: IrcMessage[] = [];
 	const relayed: CustomMessage[] = [];
 	const session = {
-		isStreaming: true,
+		get isStreaming() {
+			return streaming;
+		},
 		deliverIrcMessage: async (msg: IrcMessage) => {
 			if (nextError) {
 				const err = nextError;
@@ -59,6 +64,9 @@ function makeFakeSession(): FakeSession {
 		},
 		onDeliver: fn => {
 			deliverHook = fn;
+		},
+		setStreaming: value => {
+			streaming = value;
 		},
 	};
 }
@@ -814,6 +822,36 @@ describe("IRC", () => {
 			const text = result.content[0]?.type === "text" ? result.content[0].text : "";
 			expect(text).toContain("Send delivered");
 			expect(text).toContain("interrupted");
+		});
+
+		it("op=send await=true settles when the recipient stops without replying", async () => {
+			const main = makeFakeSession();
+			registry.register({ id: "0-Main", displayName: "main", kind: "main", session: main.session });
+			const sub = makeFakeSession();
+			// Recipient is mid-turn (streaming) when the awaited aside lands.
+			registry.register({ id: "0-Sub", displayName: "task", kind: "sub", session: sub.session, status: "running" });
+			sub.onDeliver(() => {
+				// It consumes the aside and ends its turn WITHOUT ever replying.
+				sub.setStreaming(false);
+				registry.setStatus("0-Sub", "idle", sub.session);
+			});
+
+			const tool = new HubTool(makeToolSession(registry, "0-Main"));
+			// A 120s timeout would strand the sender if the stop were not observed;
+			// the exit monitor must settle it long before the default bun timeout.
+			const result = await tool.execute("call-1", {
+				op: "send",
+				to: "0-Sub",
+				message: "ping",
+				await: true,
+				timeoutMs: 120_000,
+			});
+
+			expect(result.isError).toBeFalsy();
+			const details = result.details as CoordinationDetails | undefined;
+			expect(details?.waited ?? null).toBeNull();
+			const text = result.content[0]?.type === "text" ? result.content[0].text : "";
+			expect(text).toContain("0-Sub stopped without replying");
 		});
 
 		it("op=send rejects await with to=all and self-sends", async () => {

--- a/packages/coding-agent/test/tools/irc.test.ts
+++ b/packages/coding-agent/test/tools/irc.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
 import { Agent } from "@oh-my-pi/pi-agent-core";
-import { createMockModel, type MockResponse } from "@oh-my-pi/pi-ai/providers/mock";
+import { createMockModel, type MockHandler } from "@oh-my-pi/pi-ai/providers/mock";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
@@ -45,6 +45,7 @@ function makeFakeSession(): FakeSession {
 			listeners.add(listener);
 			return () => listeners.delete(listener);
 		},
+		waitForIrcAutoReplies: async () => {},
 		deliverIrcMessage: async (msg: IrcMessage) => {
 			if (nextError) {
 				const err = nextError;
@@ -119,8 +120,8 @@ function createRealSession(overrides: Partial<Record<SettingPath, unknown>> = {}
  *  turn and emits the real terminal `agent_end` after prompt unwind. */
 function createStreamingSession(
 	modelRegistry: ModelRegistry,
-	responses: MockResponse[],
-	options?: { tools?: HubTool[] },
+	responses: MockHandler[],
+	options?: { tools?: HubTool[]; settings?: Partial<Record<SettingPath, unknown>> },
 ): { session: AgentSession } {
 	const model = getBundledModel("anthropic", "claude-sonnet-4-5");
 	if (!model) throw new Error("Expected bundled anthropic model to exist");
@@ -132,7 +133,11 @@ function createStreamingSession(
 			streamFn: mock.stream,
 		}),
 		sessionManager: SessionManager.inMemory("/tmp"),
-		settings: Settings.isolated({ "compaction.enabled": false, "retry.enabled": false }),
+		settings: Settings.isolated({
+			"compaction.enabled": false,
+			"retry.enabled": false,
+			...options?.settings,
+		}),
 		modelRegistry,
 	});
 	return { session };
@@ -951,6 +956,64 @@ describe("IRC", () => {
 				expect(subSession.isStreaming).toBe(false);
 				await expect(waitP).rejects.toThrow(/stopped without replying/);
 			} finally {
+				unsync();
+			}
+		});
+
+		it("op=send await=true waits for an in-flight side-channel auto-reply", async () => {
+			const streamStarted = Promise.withResolvers<void>();
+			const autoReplyStarted = Promise.withResolvers<void>();
+			const releaseAutoReply = Promise.withResolvers<void>();
+			const { session: subSession } = createStreamingSession(
+				modelRegistry,
+				[
+					() => {
+						streamStarted.resolve();
+						return { content: ["working"], delayMs: 1_000 };
+					},
+				],
+				{ settings: { "async.enabled": false } },
+			);
+			sessions.push(subSession);
+			registry.register({ id: "0-Main", displayName: "main", kind: "main", session: makeFakeSession().session });
+			registry.register({ id: "0-Sub", displayName: "task", kind: "sub", session: subSession, status: "running" });
+			const unsync = registry.syncSessionStatus("0-Sub", subSession);
+			vi.spyOn(subSession, "runEphemeralTurn").mockImplementation(async () => {
+				autoReplyStarted.resolve();
+				await releaseAutoReply.promise;
+				return { replyText: "delayed auto answer", assistantMessage: {} as never };
+			});
+			try {
+				const running = subSession.prompt("work");
+				await streamStarted.promise;
+				const mainHub = new HubTool(makeToolSession(registry, "0-Main"));
+				const resultP = mainHub.execute("call-1", {
+					op: "send",
+					to: "0-Sub",
+					message: "answer on the side channel",
+					await: true,
+					timeoutMs: 5_000,
+				});
+				let settled = false;
+				void resultP.then(() => {
+					settled = true;
+				});
+				await autoReplyStarted.promise;
+				// Model the main turn consuming the incoming aside before it ends:
+				// no bridge queue or wake turn remains to keep agent_end
+				// non-terminal; only the separate side request is still alive.
+				expect(subSession.drainPendingIrcInboxMessages("0-Sub")).toHaveLength(1);
+				await running;
+				await subSession.waitForIdle();
+				await Promise.resolve();
+				expect(settled).toBe(false);
+
+				releaseAutoReply.resolve();
+				const result = await resultP;
+				const details = result.details as CoordinationDetails | undefined;
+				expect(details?.waited?.body).toBe("delayed auto answer");
+			} finally {
+				releaseAutoReply.resolve();
 				unsync();
 			}
 		});


### PR DESCRIPTION
## Repro
When the main agent runs `hub send await:true` targeting a subagent that consumes the message and then ends its turn without replying, the send blocks for the full `irc.timeoutMs` (120s default). A timing repro (recipient flips to non-streaming/idle immediately after delivery, no reply, `timeoutMs: 2000`) blocks the whole window:
```
bun test <repro>  # elapsed=2004ms  —  "No reply from 0-Sub within 2.0s..."
```
With the default timeout that is a 120s stall.

## Cause
`executeSend` in `packages/coding-agent/src/tools/hub/messaging.ts` parks its reply waiter via `IrcBus.wait(..., { drainPending: false })` but omits the `liveness` option that `executeMessageWait` (the `op:"wait"` path) passes. `IrcBus.wait` (`packages/coding-agent/src/irc/bus.ts`) therefore has no linkage from the recipient's stop (an `AgentRegistry` status change) to settling the await; its only exits are a reply, the caller's abort signal, or the timeout timer. The `liveness` option was deliberately kept off await-sends because its strict `isRunning` check would instantly cancel the await before an idle recipient could be woken to reply.

## Fix
- Add an await-tolerant exit monitor to `IrcBus.wait` via a new `awaitTarget` option. It subscribes to `registry.onChange` and settles the wait once the awaited peer is unregistered/aborted, or has been observed streaming and then stopped — without ever replying.
- Track engagement via session `isStreaming` (not `registry.isRunning`), so mid-run continuations (auto-compaction/retry) that briefly flip registry status to idle are not mistaken for a terminal stop, and an idle/parked recipient the send is about to wake is tolerated (no initial abort).
- Introduce `IrcAwaitTargetStopped`; `executeSend` surfaces a clean "<peer> stopped without replying" note and preserves the successful delivery receipt instead of throwing.
- Regression test in `packages/coding-agent/test/tools/irc.test.ts` (recipient stops without replying under a 120s timeout → must settle promptly).

## Verification
`bun test packages/coding-agent/test/tools/irc.test.ts` — 50 pass (includes the new regression test; the repro that previously blocked 2004ms now settles in ~5ms with the "stopped without replying" note). Also ran `bun test packages/coding-agent/test/agent-session-plan-mode-convergence.test.ts packages/coding-agent/test/agent-session-advisor-suppression.test.ts` — 30 pass. Fixes #9913