### PR TITLE
fix(session): reject corrupt headers before resume

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed corrupt session headers silently overwriting recoverable transcripts during resume ([#9915](https://github.com/can1357/oh-my-pi/issues/9915)).
+
 ## [18.0.7] - 2026-08-26
 
 ### Added

--- a/packages/coding-agent/src/session/session-loader.ts
+++ b/packages/coding-agent/src/session/session-loader.ts
@@ -37,6 +37,8 @@ export interface SessionLoadResult {
 	entries: FileEntry[];
 	titleSlot: SessionTitleUpdate | undefined;
 	malformedRecords: number;
+	/** Whether non-empty session data was found without a valid leading session header. */
+	invalidHeader: boolean;
 }
 
 function splitTitleSlot(content: string): { body: string; slot: SessionTitleUpdate | undefined } {
@@ -74,7 +76,12 @@ export function parseSessionContent(content: string): SessionLoadResult {
 		},
 	}) as FileEntry[];
 	applyTitleSlot(entries[0], slot);
-	return { entries, titleSlot: slot, malformedRecords };
+	return {
+		entries,
+		titleSlot: slot,
+		malformedRecords,
+		invalidHeader: entries.length > 0 ? !isValidSessionHeader(entries[0]) : malformedRecords > 0,
+	};
 }
 
 /** Parse session JSONL and visit each entry without retaining prior entries. */
@@ -243,7 +250,12 @@ export async function loadEntriesFromFileStream(filePath: string): Promise<Sessi
 			},
 		},
 	);
-	return { entries, titleSlot, malformedRecords };
+	return {
+		entries,
+		titleSlot,
+		malformedRecords,
+		invalidHeader: entries.length > 0 ? !isValidSessionHeader(entries[0]) : malformedRecords > 0,
+	};
 }
 
 /** Exported for compaction.test.ts */
@@ -259,7 +271,7 @@ async function loadWithKnownSize(filePath: string, storage: SessionStorage, size
 	const loaded = shouldStreamEntries(storage, size)
 		? await loadEntriesFromFileStream(filePath)
 		: parseSessionContent(await storage.readText(filePath));
-	return isValidSessionHeader(loaded.entries[0]) ? loaded : { ...loaded, entries: [] };
+	return loaded.invalidHeader ? { ...loaded, entries: [] } : loaded;
 }
 
 /** Load and validate a session while retaining malformed-record diagnostics. */
@@ -270,7 +282,7 @@ export async function loadSessionFile(
 	try {
 		return await loadWithKnownSize(filePath, storage, storage.statSync(filePath).size);
 	} catch (err) {
-		if (isEnoent(err)) return { entries: [], titleSlot: undefined, malformedRecords: 0 };
+		if (isEnoent(err)) return { entries: [], titleSlot: undefined, malformedRecords: 0, invalidHeader: false };
 		throw err;
 	}
 }

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -1357,10 +1357,16 @@ export class SessionManager {
 		this.#draftOnlySessionCleanupArmed = false;
 
 		const resolvedSessionFile = path.resolve(sessionFile);
+		const loaded = loadedSession ?? (await loadSessionFile(resolvedSessionFile, this.#storage));
+		if (loaded.invalidHeader) {
+			throw new Error(
+				`Cannot resume session "${resolvedSessionFile}": the session header is missing or malformed. The file was not modified.`,
+			);
+		}
+
 		this.#sessionFile = resolvedSessionFile;
 		this.#rememberBreadcrumb(this.#cwd, resolvedSessionFile);
 
-		const loaded = loadedSession ?? (await loadSessionFile(resolvedSessionFile, this.#storage));
 		const { entries: fileEntries, titleSlot } = loaded;
 		if (fileEntries.length === 0) {
 			// Explicit but empty/missing path (e.g. --session flag): start fresh but

--- a/packages/coding-agent/test/session-manager-immediate-persist.test.ts
+++ b/packages/coding-agent/test/session-manager-immediate-persist.test.ts
@@ -216,6 +216,29 @@ describe("SessionManager JSONL software-crash durability", () => {
 		await resumed.close();
 	});
 
+	it("rejects a corrupt session header without overwriting recoverable transcript bytes", async () => {
+		const cwd = makeTempDir("@pi-corrupt-header-cwd-");
+		const sessionFile = path.join(cwd, "corrupt-session.jsonl");
+		const original = [
+			"{broken header",
+			JSON.stringify({
+				type: "message",
+				id: "m1",
+				parentId: null,
+				timestamp: "2026-08-27T00:00:00.000Z",
+				message: { role: "user", content: "recover me", timestamp: 0 },
+			}),
+			"",
+		].join("\n");
+		fs.writeFileSync(sessionFile, original);
+		const originalBytes = fs.readFileSync(sessionFile);
+
+		await expect(SessionManager.open(sessionFile, undefined, undefined, { initialCwd: cwd })).rejects.toThrow(
+			"session header is missing or malformed",
+		);
+		expect(fs.readFileSync(sessionFile)).toEqual(originalBytes);
+	});
+
 	it("keeps pre-assistant sessions out of history during shutdown", async () => {
 		const cwd = makeTempDir("@pi-empty-session-cwd-");
 		const sessionDir = path.join(cwd, "sessions");


### PR DESCRIPTION
## Repro

From the repository root, run `bun -e "import * as fs from 'node:fs/promises'; import * as os from 'node:os'; import * as path from 'node:path'; import { SessionManager } from './packages/coding-agent/src/session/session-manager.ts'; const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'omp-corrupt-header-repro-')); const file = path.join(dir, 'session.jsonl'); const original = '{broken header\n' + JSON.stringify({ type: 'message', id: 'm1', parentId: null, timestamp: '2026-08-27T00:00:00.000Z', message: { role: 'user', content: 'recover me', timestamp: 0 } }) + '\n'; await Bun.write(file, original); await SessionManager.open(file, dir, undefined, { initialCwd: dir }); const after = await Bun.file(file).text(); console.log({ overwritten: after !== original, transcriptPreserved: after.includes('recover me') });"`. Before the fix, resume printed `{ overwritten: true, transcriptPreserved: false }` and replaced the recoverable message with a fresh session header.

## Cause

`loadWithKnownSize` in `packages/coding-agent/src/session/session-loader.ts` converted every invalid-header parse to an empty `entries` array. `SessionManager.#setSessionFile` in `packages/coding-agent/src/session/session-manager.ts` interpreted that result as an empty or missing file and immediately called `#rewriteAtomically` at the same path.

## Fix

- Retain explicit invalid-header metadata across both buffered and streaming session loaders.
- Reject invalid-header resumes before mutating manager path state or entering the empty-session rewrite branch.
- Cover a malformed first line followed by a recoverable transcript record, asserting the original bytes remain unchanged.
- Document the user-visible data-loss fix in the coding-agent changelog.

## Verification

`bun test packages/coding-agent/test/session-manager-immediate-persist.test.ts` passed 10 tests; `bun test packages/coding-agent/test/session-loader-stream.test.ts` passed 9 tests. Re-running the reproduction returned `{ rejected: true, bytesUnchanged: true, transcriptPreserved: true }`. The publish gate also completed `bun run fix` and `bun check`.

Fixes #9915