### PR TITLE
feat(tui): add editor redo

### DIFF
--- a/crates/pi-natives/src/keys.rs
+++ b/crates/pi-natives/src/keys.rs
@@ -215,6 +215,22 @@ static ASCII_PRINTABLE: [&str; 94] = [
 	"m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z", "{", "|", "}", "~",
 ];
 
+/// Pre-allocated Alt+printable ASCII combinations (33-126)
+static ALT_ASCII_PRINTABLE: [&str; 94] = [
+	"alt+!", "alt+\"", "alt+#", "alt+$", "alt+%", "alt+&", "alt+'", "alt+(",
+	"alt+)", "alt+*", "alt++", "alt+,", "alt+-", "alt+.", "alt+/", "alt+0",
+	"alt+1", "alt+2", "alt+3", "alt+4", "alt+5", "alt+6", "alt+7", "alt+8",
+	"alt+9", "alt+:", "alt+;", "alt+<", "alt+=", "alt+>", "alt+?", "alt+@",
+	"alt+A", "alt+B", "alt+C", "alt+D", "alt+E", "alt+F", "alt+G", "alt+H",
+	"alt+I", "alt+J", "alt+K", "alt+L", "alt+M", "alt+N", "alt+O", "alt+P",
+	"alt+Q", "alt+R", "alt+S", "alt+T", "alt+U", "alt+V", "alt+W", "alt+X",
+	"alt+Y", "alt+Z", "alt+[", "alt+\\", "alt+]", "alt+^", "alt+_", "alt+`",
+	"alt+a", "alt+b", "alt+c", "alt+d", "alt+e", "alt+f", "alt+g", "alt+h",
+	"alt+i", "alt+j", "alt+k", "alt+l", "alt+m", "alt+n", "alt+o", "alt+p",
+	"alt+q", "alt+r", "alt+s", "alt+t", "alt+u", "alt+v", "alt+w", "alt+x",
+	"alt+y", "alt+z", "alt+{", "alt+|", "alt+}", "alt+~",
+];
+
 /// Pre-allocated modifier+letter combinations
 static CTRL_LETTERS: [&str; 26] = [
 	"ctrl+a", "ctrl+b", "ctrl+c", "ctrl+d", "ctrl+e", "ctrl+f", "ctrl+g", "ctrl+h", "ctrl+i",
@@ -1157,6 +1173,9 @@ fn parse_esc_pair(code: u8, kitty_protocol_active: bool) -> Option<Cow<'static, 
 		1..=26 => Some(Cow::Borrowed(CTRL_ALT_LETTERS[(code - 1) as usize])),
 		b'a'..=b'z' => Some(Cow::Borrowed(ALT_LETTERS[(code - b'a') as usize])),
 		b'A'..=b'Z' => Some(Cow::Borrowed(ALT_SHIFT_LETTERS[(code - b'A') as usize])),
+		// ESC [ introduces CSI; do not reinterpret a truncated control sequence as Alt+[.
+		b'[' => None,
+		33..=126 => Some(Cow::Borrowed(ALT_ASCII_PRINTABLE[(code - 33) as usize])),
 		_ => None,
 	}
 }
@@ -1574,6 +1593,16 @@ mod tests {
 		for active in [false, true] {
 			assert_eq!(parse_key_inner(b"\x1b\n", active).as_deref(), Some("alt+enter"));
 			assert!(matches_key_inner(b"\x1b\n", "alt+enter", active));
+		}
+	}
+
+	#[test]
+	fn esc_pair_alt_printable_symbols_and_digits() {
+		for active in [false, true] {
+			assert_eq!(parse_key_inner(b"\x1b-", active).as_deref(), Some("alt+-"));
+			assert_eq!(parse_key_inner(b"\x1b_", active).as_deref(), Some("alt+_"));
+			assert_eq!(parse_key_inner(b"\x1b7", active).as_deref(), Some("alt+7"));
+			assert_eq!(parse_key_inner(b"\x1b[", active).as_deref(), None);
 		}
 	}
 

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,11 +2,17 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added editor redo with configurable `tui.editor.redo` keybindings.
+
 ## [18.0.8] - 2026-08-27
 
 ### Added
 
 - `ProcessTerminal` accepts a `conpty` option to force ConPTY-hosted behavior on or off, keeping terminal tests hermetic on WSL where live env detection would otherwise flip kitty-keyboard flags and write chunking ([#9887](https://github.com/can1357/oh-my-pi/issues/9887)).
+
+## [18.0.7] - 2026-08-26
 
 ### Fixed
 

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -565,6 +565,8 @@ export class Editor implements Component, Focusable {
 
 	// Undo stack for editor state changes
 	#undoStack: EditorState[] = [];
+	/** States undone off {@link #undoStack}, replayable until the next fresh edit. */
+	#redoStack: EditorState[] = [];
 	#suspendUndo = false;
 
 	// Debounce timer for autocomplete updates
@@ -786,6 +788,7 @@ export class Editor implements Component, Focusable {
 	/** Internal setText that doesn't reset history state - used by navigateHistory */
 	#setTextInternal(text: string, cursorAnchor: HistoryCursorAnchor = "end"): void {
 		this.#undoStack.length = 0;
+		this.#redoStack.length = 0;
 		const lines = sanitizeLoadedText(text).split("\n");
 		this.#state.lines = lines.length === 0 ? [""] : lines;
 		if (cursorAnchor === "start") {
@@ -1360,6 +1363,12 @@ export class Editor implements Component, Focusable {
 		// Undo
 		if (kb.matchesCanonical(canonical, "tui.editor.undo")) {
 			this.#applyUndo();
+			return;
+		}
+
+		// Redo
+		if (kb.matchesCanonical(canonical, "tui.editor.redo")) {
+			this.#applyRedo();
 			return;
 		}
 
@@ -2395,6 +2404,7 @@ export class Editor implements Component, Focusable {
 		this.#historyIndex = -1;
 		this.#scrollOffset = 0;
 		this.#undoStack.length = 0;
+		this.#redoStack.length = 0;
 
 		if (this.onChange) this.onChange("");
 		if (this.onSubmit) this.onSubmit(result);
@@ -2664,12 +2674,35 @@ export class Editor implements Component, Focusable {
 		if (this.#undoStack.length > MAX_UNDO_STACK) {
 			this.#undoStack.shift();
 		}
+		// A fresh edit forks history: whatever was undone is no longer reachable forward.
+		this.#redoStack.length = 0;
 	}
 
 	#applyUndo(): void {
 		const snapshot = this.#undoStack.pop();
 		if (!snapshot) return;
+		this.#pushBounded(this.#redoStack);
+		this.#restoreState(snapshot);
+	}
 
+	#applyRedo(): void {
+		const snapshot = this.#redoStack.pop();
+		if (!snapshot) return;
+		this.#pushBounded(this.#undoStack);
+		this.#restoreState(snapshot);
+	}
+
+	/** Snapshot the live state onto `stack`, trimming the oldest entry past the cap.
+	 *  Bypasses {@link #recordUndoState} on purpose: moving between the undo and redo
+	 *  stacks must not clear the opposite stack the way a fresh edit does. */
+	#pushBounded(stack: EditorState[]): void {
+		stack.push(structuredClone(this.#state));
+		if (stack.length > MAX_UNDO_STACK) {
+			stack.shift();
+		}
+	}
+
+	#restoreState(snapshot: EditorState): void {
 		this.#historyIndex = -1;
 		this.#resetKillSequence();
 		this.#preferredVisualCol = null;

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -568,6 +568,8 @@ export class Editor implements Component, Focusable {
 	/** States undone off {@link #undoStack}, replayable until the next fresh edit. */
 	#redoStack: EditorState[] = [];
 	#suspendUndo = false;
+	/** Most recent pre-edit snapshot, finalized once buffer mutation is observable. */
+	#pendingUndoState: EditorState | undefined;
 
 	// Debounce timer for autocomplete updates
 	#autocompleteTimeout?: NodeJS.Timeout;
@@ -789,6 +791,7 @@ export class Editor implements Component, Focusable {
 	#setTextInternal(text: string, cursorAnchor: HistoryCursorAnchor = "end"): void {
 		this.#undoStack.length = 0;
 		this.#redoStack.length = 0;
+		this.#pendingUndoState = undefined;
 		const lines = sanitizeLoadedText(text).split("\n");
 		this.#state.lines = lines.length === 0 ? [""] : lines;
 		if (cursorAnchor === "start") {
@@ -1956,6 +1959,8 @@ export class Editor implements Component, Focusable {
 	 * Used for command-like autocomplete actions whose typed trigger should not count as the edit being undone.
 	 */
 	undoPastTransientText(transientText: string): void {
+		this.clearVolatileText();
+		this.#commitRecordedUndoState();
 		if (transientText.length === 0) {
 			this.#applyUndo();
 			return;
@@ -2405,6 +2410,7 @@ export class Editor implements Component, Focusable {
 		this.#scrollOffset = 0;
 		this.#undoStack.length = 0;
 		this.#redoStack.length = 0;
+		this.#pendingUndoState = undefined;
 
 		if (this.onChange) this.onChange("");
 		if (this.onSubmit) this.onSubmit(result);
@@ -2670,15 +2676,39 @@ export class Editor implements Component, Focusable {
 
 	#recordUndoState(): void {
 		if (this.#suspendUndo) return;
-		this.#undoStack.push(structuredClone(this.#state));
+		this.#commitRecordedUndoState();
+		const snapshot = structuredClone(this.#state);
+		this.#undoStack.push(snapshot);
+		this.#pendingUndoState = snapshot;
 		if (this.#undoStack.length > MAX_UNDO_STACK) {
 			this.#undoStack.shift();
 		}
-		// A fresh edit forks history: whatever was undone is no longer reachable forward.
-		this.#redoStack.length = 0;
+	}
+
+	/** Finalize the preceding undo candidate after its command has run. No-op
+	 *  commands drop their duplicate snapshot and, crucially, preserve redo. */
+	#commitRecordedUndoState(): void {
+		const snapshot = this.#pendingUndoState;
+		if (!snapshot) return;
+		this.#pendingUndoState = undefined;
+
+		let changed = snapshot.lines.length !== this.#state.lines.length;
+		for (let i = 0; !changed && i < snapshot.lines.length; i++) {
+			changed = snapshot.lines[i] !== this.#state.lines[i];
+		}
+
+		if (changed) {
+			// A fresh edit forks history: whatever was undone is no longer reachable forward.
+			this.#redoStack.length = 0;
+		} else if (this.#undoStack.at(-1) === snapshot) {
+			this.#undoStack.pop();
+		}
 	}
 
 	#applyUndo(): void {
+		// A volatile STT preview is not a committed edit and must never enter history snapshots.
+		this.clearVolatileText();
+		this.#commitRecordedUndoState();
 		const snapshot = this.#undoStack.pop();
 		if (!snapshot) return;
 		this.#pushBounded(this.#redoStack);
@@ -2686,6 +2716,9 @@ export class Editor implements Component, Focusable {
 	}
 
 	#applyRedo(): void {
+		// Keep redo symmetric with undo if a new volatile preview arrived after an undo.
+		this.clearVolatileText();
+		this.#commitRecordedUndoState();
 		const snapshot = this.#redoStack.pop();
 		if (!snapshot) return;
 		this.#pushBounded(this.#undoStack);

--- a/packages/tui/src/components/input.ts
+++ b/packages/tui/src/components/input.ts
@@ -47,6 +47,8 @@ export class Input implements Component, Focusable {
 
 	// Undo support
 	#undoStack: InputState[] = [];
+	/** States undone off {@link #undoStack}, replayable until the next fresh edit. */
+	#redoStack: InputState[] = [];
 
 	getValue(): string {
 		return this.#value;
@@ -90,6 +92,12 @@ export class Input implements Component, Focusable {
 		// Undo
 		if (kb.matches(data, "tui.editor.undo")) {
 			this.#undo();
+			return;
+		}
+
+		// Redo
+		if (kb.matches(data, "tui.editor.redo")) {
+			this.#redo();
 			return;
 		}
 
@@ -345,6 +353,8 @@ export class Input implements Component, Focusable {
 
 	#pushUndo(): void {
 		this.#undoStack.push({ value: this.#value, cursor: this.#cursor });
+		// A fresh edit forks history: whatever was undone is no longer reachable forward.
+		this.#redoStack.length = 0;
 	}
 
 	#undo(): void {
@@ -352,6 +362,18 @@ export class Input implements Component, Focusable {
 		if (!snapshot) {
 			return;
 		}
+		this.#redoStack.push({ value: this.#value, cursor: this.#cursor });
+		this.#value = snapshot.value;
+		this.#cursor = snapshot.cursor;
+		this.#lastAction = null;
+	}
+
+	#redo(): void {
+		const snapshot = this.#redoStack.pop();
+		if (!snapshot) {
+			return;
+		}
+		this.#undoStack.push({ value: this.#value, cursor: this.#cursor });
 		this.#value = snapshot.value;
 		this.#cursor = snapshot.cursor;
 		this.#lastAction = null;

--- a/packages/tui/src/components/input.ts
+++ b/packages/tui/src/components/input.ts
@@ -58,6 +58,9 @@ export class Input implements Component, Focusable {
 		this.#value = value;
 		// Callers seed or replace the value wholesale; typing continues at the end.
 		this.#cursor = value.length;
+		this.#undoStack.length = 0;
+		this.#redoStack.length = 0;
+		this.#lastAction = null;
 	}
 
 	setUseTerminalCursor(useTerminalCursor: boolean): void {
@@ -396,9 +399,6 @@ export class Input implements Component, Focusable {
 	}
 
 	#handlePaste(pastedText: string): void {
-		this.#lastAction = null;
-		this.#pushUndo();
-
 		// Clean the pasted text — decode tmux's re-encoded control bytes (both
 		// extended-keys formats, e.g. Ctrl+J → "\n") back to literal bytes so the escape
 		// tail does not leak in, remove newlines/carriage returns, expand tabs, NFC-normalize,
@@ -420,6 +420,14 @@ export class Input implements Component, Focusable {
 		)
 			.normalize("NFC")
 			.replace(/[\x00-\x1F\x7F]/g, "");
+
+		// A payload that sanitizes to nothing (e.g. a lone newline, or only control bytes) is
+		// not an edit. Recording undo before this point forked history and erased the redo
+		// branch for a paste that changed nothing — the same class of bug as the no-op delete
+		// commands, so the snapshot is taken only once an actual mutation is certain.
+		if (cleanText.length === 0) return;
+		this.#lastAction = null;
+		this.#pushUndo();
 
 		// Insert at cursor position
 		this.#value = this.#value.slice(0, this.#cursor) + cleanText + this.#value.slice(this.#cursor);

--- a/packages/tui/src/keybindings.ts
+++ b/packages/tui/src/keybindings.ts
@@ -28,6 +28,7 @@ export interface Keybindings {
 	"tui.editor.yankPop": true;
 	"tui.editor.undo": true;
 	"tui.editor.spellingSuggestions": true;
+	"tui.editor.redo": true;
 	// Generic input actions
 	"tui.input.newLine": true;
 	"tui.input.submit": true;
@@ -123,6 +124,7 @@ export const TUI_KEYBINDINGS = {
 		defaultKeys: "ctrl+.",
 		description: "Show spelling replacements",
 	},
+	"tui.editor.redo": { defaultKeys: ["alt+-", "alt+_"], description: "Redo" },
 	"tui.input.newLine": { defaultKeys: ["shift+enter", "ctrl+j"], description: "Insert newline" },
 	"tui.input.submit": { defaultKeys: "enter", description: "Submit input" },
 	"tui.input.tab": { defaultKeys: "tab", description: "Tab / autocomplete" },

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -2706,6 +2706,115 @@ describe("Editor component", () => {
 		});
 	});
 
+	describe("Redo", () => {
+		const UNDO = "\x1b[45;5u"; // Ctrl+-
+		const REDO = "\x1b[45;3u"; // Alt+-
+
+		it("replays an edit that was undone", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.handleInput("h");
+			editor.handleInput("i");
+			editor.handleInput(" ");
+			editor.handleInput("y");
+			editor.handleInput("o");
+
+			editor.handleInput(UNDO);
+			expect(editor.getText()).toBe("hi ");
+			editor.handleInput(REDO);
+			expect(editor.getText()).toBe("hi yo");
+		});
+
+		it("walks the whole undo history back out again", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.handleInput("h");
+			editor.handleInput("i");
+			editor.handleInput(" ");
+			editor.handleInput("y");
+			editor.handleInput("o");
+
+			editor.handleInput(UNDO);
+			editor.handleInput(UNDO);
+			editor.handleInput(UNDO);
+			expect(editor.getText()).toBe("");
+
+			editor.handleInput(REDO);
+			expect(editor.getText()).toBe("hi");
+			editor.handleInput(REDO);
+			expect(editor.getText()).toBe("hi ");
+			editor.handleInput(REDO);
+			expect(editor.getText()).toBe("hi yo");
+		});
+
+		it("restores the cursor position, not just the text", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setText("abc");
+			editor.handleInput("\x01"); // Ctrl+A → line start
+			editor.handleInput("X");
+			expect(editor.getText()).toBe("Xabc");
+			expect(editor.getCursor()).toEqual({ line: 0, col: 1 });
+
+			editor.handleInput(UNDO);
+			expect(editor.getText()).toBe("abc");
+			expect(editor.getCursor()).toEqual({ line: 0, col: 0 });
+
+			editor.handleInput(REDO);
+			expect(editor.getText()).toBe("Xabc");
+			expect(editor.getCursor()).toEqual({ line: 0, col: 1 });
+		});
+
+		it("is a no-op when nothing has been undone", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.handleInput("a");
+			editor.handleInput(REDO);
+			expect(editor.getText()).toBe("a");
+			expect(editor.getCursor()).toEqual({ line: 0, col: 1 });
+		});
+
+		it("drops the redo branch once a fresh edit forks history", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.handleInput("a");
+			editor.handleInput(UNDO);
+			expect(editor.getText()).toBe("");
+
+			editor.handleInput("b");
+			editor.handleInput(REDO);
+			expect(editor.getText()).toBe("b");
+		});
+
+		it("clears both stacks on submit so a new draft cannot resurrect the old one", () => {
+			const editor = new Editor(defaultEditorTheme);
+			let submitted: string | undefined;
+			editor.onSubmit = value => {
+				submitted = value;
+			};
+			editor.handleInput("a");
+			editor.handleInput(UNDO);
+			editor.handleInput("\r");
+			expect(submitted).toBe("");
+
+			editor.handleInput(REDO);
+			expect(editor.getText()).toBe("");
+			editor.handleInput(UNDO);
+			expect(editor.getText()).toBe("");
+		});
+
+		it("uses the configured redo binding", () => {
+			setKeybindings(
+				new KeybindingsManager(TUI_KEYBINDINGS, {
+					"tui.editor.redo": "f8",
+				}),
+			);
+
+			const editor = new Editor(defaultEditorTheme);
+			editor.handleInput("a");
+			editor.handleInput(UNDO);
+			expect(editor.getText()).toBe("");
+
+			editor.handleInput("\x1b[19~"); // F8
+			expect(editor.getText()).toBe("a");
+		});
+	});
+
 	describe("decorateText around the cursor seam", () => {
 		// Editor.#decorate is the only seam that sees both the user prose AND the
 		// trailing CURSOR_MARKER, so a decorator with a right-boundary lookahead

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -2813,6 +2813,42 @@ describe("Editor component", () => {
 			editor.handleInput("\x1b[19~"); // F8
 			expect(editor.getText()).toBe("a");
 		});
+
+		for (const [name, sequence] of [
+			["Alt+-", "\x1b-"],
+			["Alt+_", "\x1b_"],
+		] as const) {
+			it(`recognizes raw legacy ${name} as redo`, () => {
+				const editor = new Editor(defaultEditorTheme);
+				editor.handleInput("a");
+				editor.handleInput(UNDO);
+				expect(editor.getText()).toBe("");
+
+				editor.handleInput(sequence);
+				expect(editor.getText()).toBe("a");
+			});
+		}
+
+		for (const [name, sequence] of [
+			["backspace at column zero", "\x7f"],
+			["forward delete at the end of the buffer", "\x1b[3~"],
+			["backward word delete at the start of the buffer", "\x17"],
+			["forward word delete at the end of the buffer", "\x1bd"],
+			["line-start kill at the start of the buffer", "\x15"],
+			["line-end kill at the end of the buffer", "\x0b"],
+		] as const) {
+			it(`preserves redo after no-op ${name}`, () => {
+				const editor = new Editor(defaultEditorTheme);
+				editor.handleInput("a");
+				editor.handleInput(UNDO);
+				expect(editor.getText()).toBe("");
+
+				editor.handleInput(sequence);
+				expect(editor.getText()).toBe("");
+				editor.handleInput(REDO);
+				expect(editor.getText()).toBe("a");
+			});
+		}
 	});
 
 	describe("decorateText around the cursor seam", () => {
@@ -2920,6 +2956,19 @@ describe("Editor component", () => {
 			expect(editor.getText()).toBe("line one\nline two");
 			editor.setVolatileText("single line");
 			expect(editor.getText()).toBe("single line");
+		});
+
+		it("discards an active preview before undo so redo cannot make it permanent", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.handleInput("a");
+			editor.setVolatileText("draft");
+			expect(editor.getText()).toBe("adraft");
+
+			editor.handleInput("\x1b[45;5u"); // undo
+			expect(editor.getText()).toBe("");
+			editor.clearVolatileText();
+			editor.handleInput("\x1b[45;3u"); // redo
+			expect(editor.getText()).toBe("a");
 		});
 	});
 

--- a/packages/tui/test/input.test.ts
+++ b/packages/tui/test/input.test.ts
@@ -322,4 +322,41 @@ describe("Input component", () => {
 		input.pasteText("sk-line1\nsk-line2\r\nsk-line3");
 		expect(input.getValue()).toBe("sk-line1sk-line2sk-line3");
 	});
+
+	it("clears undo and redo history when setValue replaces the input", () => {
+		const input = new Input();
+		input.focused = true;
+		input.handleInput("secret");
+		input.handleInput("\x1b[45;5u"); // undo
+		expect(input.getValue()).toBe("");
+
+		input.setValue("");
+		input.handleInput("\x1b[45;3u"); // redo
+		expect(input.getValue()).toBe("");
+
+		input.handleInput("old");
+		input.setValue("new");
+		input.handleInput("\x1b[45;5u"); // undo
+		expect(input.getValue()).toBe("new");
+
+		input.handleInput("x");
+		input.handleInput("\x1b[45;5u"); // undo
+		expect(input.getValue()).toBe("new");
+	});
+
+	it("preserves redo when a pasted payload sanitizes to nothing", () => {
+		const input = new Input();
+		input.focused = true;
+		input.handleInput("a");
+		input.handleInput("\x1b[45;5u"); // undo
+		expect(input.getValue()).toBe("");
+
+		// A bracketed paste of a lone newline sanitizes to an empty string, so it changes
+		// nothing. It must not fork history and discard the reachable redo entry.
+		input.handleInput("\x1b[200~\n\x1b[201~");
+		expect(input.getValue()).toBe("");
+
+		input.handleInput("\x1b[45;3u"); // redo
+		expect(input.getValue()).toBe("a");
+	});
 });


### PR DESCRIPTION
I reviewed the full diff. Undo existed but was bound to `ctrl+-`, which nobody discovers, and there was no redo at all, so an accidental undo was unrecoverable — this adds redo to both text widgets and I verified undo/redo round-trips with the cursor landing back where it was.

Undo already existed on `ctrl+-` / `ctrl+_` but there was no redo, so an accidental undo could not be walked back.

Adds a redo stack to both text widgets (`Editor` and `Input`, which maintain independent undo stacks) behind a new `tui.editor.redo` binding defaulting to `alt+-` / `alt+_`, mirroring undo's readline-style pair.

Deliberately **not** bound to `ctrl+shift+z`: legacy terminals collapse that to plain `ctrl+z`, which is already claimed by `app.suspend`, so the familiar binding would break process suspend. It stays remappable via `keybindings.yml` for terminals that can encode it.

A fresh edit clears the redo stack, and both stacks are cleared wherever the undo stack already was (`#setTextInternal`, `#submitValue`) so a restored draft cannot resurrect a previous one.

**Verification:** 7 tests added in `packages/tui/test/editor.test.ts` covering replay, full-history walk, cursor restoration, no-op on an empty stack, branch invalidation after a fresh edit, stack clearing on submit, and the remapped binding. Full `packages/tui` suite: 1354 pass, 0 fail. Exercised interactively: typed text, `ctrl+-` to undo, `alt+-` to redo, confirmed text and cursor restored, confirmed a new edit after undo discards the redo branch, and confirmed `ctrl+z` still suspends.
