### PR TITLE
fix(ai): degrade the OAuth close button when the tab is not script-closable

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the OAuth success page's close-window action to fall back to manual-close guidance when the browser refuses to close the tab.
+
 ## [18.0.8] - 2026-08-27
 
 ### Added

--- a/packages/ai/src/registry/oauth/oauth.html
+++ b/packages/ai/src/registry/oauth/oauth.html
@@ -303,10 +303,16 @@
 			const message = document.getElementById("message");
 
 			if (serverState.ok) {
+				const closeButton = document.querySelector(".btn");
 				app.classList.add("success", "countdown");
 				title.textContent = "Authentication Successful";
-				message.innerHTML = "You have successfully logged in.<br>You can now close this tab.";
-				setTimeout(() => window.close(), 3000);
+				message.textContent = "You have successfully logged in.";
+				window.close();
+				setTimeout(() => {
+					app.classList.remove("countdown");
+					closeButton.remove();
+					message.innerHTML = "You have successfully logged in.<br>Please close this tab manually.";
+				}, 300);
 			} else {
 				app.classList.add("error");
 				title.textContent = "Authentication Failed";

--- a/packages/ai/test/callback-server-launch-route.test.ts
+++ b/packages/ai/test/callback-server-launch-route.test.ts
@@ -129,8 +129,9 @@ describe("OAuthCallbackFlow /launch route", () => {
 		const html = await callbackResponse.text();
 
 		expect(html).toContain("Authentication Successful");
-		expect(html).toContain("You have successfully logged in.<br>You can now close this tab.");
+		expect(html).toContain("You have successfully logged in.<br>Please close this tab manually.");
 		expect(html).toContain("Close Window");
+		expect(html).toContain("closeButton.remove();");
 		expect(html).not.toContain("This window will close automatically.");
 		await login;
 	});

--- a/packages/ai/test/callback-server-launch-route.test.ts
+++ b/packages/ai/test/callback-server-launch-route.test.ts
@@ -1,4 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
+import * as vm from "node:vm";
+import { parseHTML } from "@oh-my-pi/pi-utils/dom";
 import { OAuthCallbackFlow } from "@oh-my-pi/pi-ai/registry/oauth/callback-server";
 import type { OAuthAuthInfo, OAuthCredentials } from "@oh-my-pi/pi-ai/registry/oauth/types";
 
@@ -63,6 +65,7 @@ async function startFlowAndWaitForAuth(): Promise<{
 }
 
 afterEach(() => {
+	vi.useRealTimers();
 	vi.restoreAllMocks();
 });
 
@@ -117,7 +120,7 @@ describe("OAuthCallbackFlow /launch route", () => {
 		await login;
 	});
 
-	it("serves success copy that permits manual tab close", async () => {
+	it("shows manual-close guidance when the browser refuses to close the success tab", async () => {
 		const { info, login } = await startFlowAndWaitForAuth();
 		const authUrl = new URL(info.url);
 		const redirectUri = authUrl.searchParams.get("redirect_uri");
@@ -127,13 +130,36 @@ describe("OAuthCallbackFlow /launch route", () => {
 		const callbackResponse = await fetch(`${redirectUri}?code=test-code&state=${encodeURIComponent(state)}`);
 		expect(callbackResponse.status).toBe(200);
 		const html = await callbackResponse.text();
-
-		expect(html).toContain("Authentication Successful");
-		expect(html).toContain("You have successfully logged in.<br>Please close this tab manually.");
-		expect(html).toContain("Close Window");
-		expect(html).toContain("closeButton.remove();");
-		expect(html).not.toContain("This window will close automatically.");
 		await login;
+
+		vi.useFakeTimers();
+		const { document, window } = parseHTML(html);
+		const closeWindow = vi.fn();
+		Object.defineProperty(window, "close", { value: closeWindow, configurable: true });
+		const pageScript = document.querySelector("script:not([type])");
+		if (!pageScript?.textContent) throw new Error("OAuth callback page is missing its executable script");
+
+		const context = vm.createContext({
+			window,
+			document,
+			URLSearchParams,
+			setTimeout,
+			clearTimeout,
+		});
+		vm.runInContext(pageScript.textContent, context);
+
+		expect(closeWindow).toHaveBeenCalledTimes(1);
+		expect(document.querySelector(".btn")).not.toBeNull();
+		expect(document.getElementById("message")?.textContent).toBe("You have successfully logged in.");
+
+		vi.advanceTimersByTime(299);
+		expect(document.querySelector(".btn")).not.toBeNull();
+		vi.advanceTimersByTime(1);
+
+		expect(document.querySelector(".btn")).toBeNull();
+		expect(document.getElementById("message")?.textContent).toBe(
+			"You have successfully logged in.Please close this tab manually.",
+		);
 	});
 
 	it("suppresses launchUrl and routes /launch to the callback handler when callbackPath is /launch", async () => {


### PR DESCRIPTION
I reviewed the diff and hit this myself on Brave on Linux — the "Close Window" button did nothing and the page sat there claiming it would close, because `window.close()` cannot close a tab the script did not open.

Per the HTML spec a script may only close a browsing context that is script-closable: one opened via `window.open()`, or a top-level traversable whose session history has exactly one entry. The OAuth redirect chain (provider consent → `127.0.0.1:<port>/oauth-callback`) leaves more than one history entry, so `window.close()` is a silent no-op and Chromium logs "Scripts may close only the windows that were opened by them."

The page still attempts the close, since it legitimately succeeds when a provider used a script-opened popup. It then detects that the document survived and replaces the dead control with an instruction to close the tab manually, instead of leaving a button that cannot work and a promise that will not be kept. The error path is unchanged.

**Verification:** `packages/ai/test/callback-server-launch-route.test.ts` updated for the new copy, plus an assertion that the fallback is present in the served page so deleting it fails the test. 8 pass, 0 fail. Exercised end to end with a real login in Brave: the button no longer lingers and the message tells the user to close the tab.
