### PR TITLE
fix(coding-agent): stop the status bar counting subagents twice

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed status-line background-work counts to keep queued tasks and eval jobs visible without double-counting running subagents.
+
 ## [18.0.8] - 2026-08-27
 
 ### Added
@@ -35,6 +39,8 @@
 - Fixed the git TUI sidebar jumping back to the top of the file list after staging or unstaging a file; selection now stays on the nearest remaining row
 - Fixed the `aarch64-linux` `nix build` output segfaulting in the dynamic loader before startup by repointing the stale `DT_VERDEF` that `patchelf` leaves behind when it grows `.dynamic`, and surfaced smoke-test signal deaths in the build log instead of masking them ([#9881](https://github.com/can1357/oh-my-pi/issues/9881)).
 - Added custom RPC launcher builders so embedded clients can transport omp RPC through SSH and remote process managers.
+### Fixed
+
 
 ## [18.0.7] - 2026-08-26
 

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -383,6 +383,7 @@ export class StatusLineComponent implements Component {
 	#speculationBlinkOn = true;
 	#hookStatuses: Map<string, string> = new Map();
 	#subagentCount: number = 0;
+	#runningSubagentIds = new Set<string>();
 	/**
 	 * Active-processing accounting for the `time_spent` segment, keyed per
 	 * {@link AgentSession} so the focus-controller mid-turn attach path
@@ -559,8 +560,9 @@ export class StatusLineComponent implements Component {
 		this.#autoCompactEnabled = enabled;
 	}
 
-	setSubagentCount(count: number): void {
-		this.#subagentCount = count;
+	setRunningSubagents(agentIds: readonly string[]): void {
+		this.#subagentCount = agentIds.length;
+		this.#runningSubagentIds = new Set(agentIds);
 	}
 
 	/**
@@ -1906,13 +1908,15 @@ export class StatusLineComponent implements Component {
 		}
 
 		if (layout !== "plain-left") {
-			// Count only bash jobs. Every task-tool spawn registers both an AgentRegistry ref
-			// (kind="sub") and an AsyncJobManager job of type "task" with the same agent id, so
-			// counting all running jobs made this badge mirror the subagent badge beside it and
-			// neither number meant anything on its own. Filtered here rather than in
-			// getAsyncJobSnapshot() so other consumers keep the unfiltered semantics.
+			// Count task jobs only until their AgentRegistry ref appears. Once it is
+			// running, the subagent badge represents that same agent; bash and eval
+			// jobs always remain independent background work.
 			const runningBackgroundJobs =
-				this.session.getAsyncJobSnapshot()?.running.filter(job => job.type === "bash").length ?? 0;
+				this.session
+					.getAsyncJobSnapshot()
+					?.running.filter(
+						job => job.type !== "task" || job.agentId === undefined || !this.#runningSubagentIds.has(job.agentId),
+					).length ?? 0;
 			if (runningBackgroundJobs > 0) {
 				rightParts.unshift(theme.fg("statusLineSubagents", `${theme.icon.job} ${runningBackgroundJobs}`));
 			}

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -1906,7 +1906,13 @@ export class StatusLineComponent implements Component {
 		}
 
 		if (layout !== "plain-left") {
-			const runningBackgroundJobs = this.session.getAsyncJobSnapshot()?.running.length ?? 0;
+			// Count only bash jobs. Every task-tool spawn registers both an AgentRegistry ref
+			// (kind="sub") and an AsyncJobManager job of type "task" with the same agent id, so
+			// counting all running jobs made this badge mirror the subagent badge beside it and
+			// neither number meant anything on its own. Filtered here rather than in
+			// getAsyncJobSnapshot() so other consumers keep the unfiltered semantics.
+			const runningBackgroundJobs =
+				this.session.getAsyncJobSnapshot()?.running.filter(job => job.type === "bash").length ?? 0;
 			if (runningBackgroundJobs > 0) {
 				rightParts.unshift(theme.fg("statusLineSubagents", `${theme.icon.job} ${runningBackgroundJobs}`));
 			}

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -202,7 +202,7 @@ import {
 	parseLoopLimitArgs,
 } from "./loop-limit";
 import { OAuthManualInputManager } from "./oauth-manual-input";
-import { countRunningSubagentBadgeAgents, getRunningSubagentBadgeRegistry } from "./running-subagent-badge";
+import { getRunningSubagentBadgeAgentIds, getRunningSubagentBadgeRegistry } from "./running-subagent-badge";
 import {
 	type ObservableSession,
 	type SessionObserverChangeKind,
@@ -2177,8 +2177,8 @@ export class InteractiveMode implements InteractiveModeContext {
 				this.syncRunningSubagentBadge();
 			});
 		}
-		const count = countRunningSubagentBadgeAgents(registry);
-		this.statusLine.setSubagentCount(count);
+		const agentIds = getRunningSubagentBadgeAgentIds(registry);
+		this.statusLine.setRunningSubagents(agentIds);
 		if (options.requestRender !== false) this.ui.requestRender();
 	}
 

--- a/packages/coding-agent/src/modes/running-subagent-badge.ts
+++ b/packages/coding-agent/src/modes/running-subagent-badge.ts
@@ -8,6 +8,9 @@ export function getRunningSubagentBadgeRegistry(collabGuest: RunningSubagentRegi
 	return collabGuest?.agentRegistry ?? AgentRegistry.global();
 }
 
-export function countRunningSubagentBadgeAgents(registry: AgentRegistry): number {
-	return registry.list().filter(ref => ref.kind === "sub" && ref.status === "running").length;
+export function getRunningSubagentBadgeAgentIds(registry: AgentRegistry): string[] {
+	return registry
+		.list()
+		.filter(ref => ref.kind === "sub" && ref.status === "running")
+		.map(ref => ref.id);
 }

--- a/packages/coding-agent/src/session/agent-session-types.ts
+++ b/packages/coding-agent/src/session/agent-session-types.ts
@@ -63,7 +63,7 @@ export interface AgentSessionDisposeOptions {
 /** Listener notified when command metadata changes. */
 export type CommandMetadataChangedListener = () => void | Promise<void>;
 /** Public summary of an asynchronous job. */
-export type AsyncJobSnapshotItem = Pick<AsyncJob, "id" | "type" | "status" | "label" | "startTime">;
+export type AsyncJobSnapshotItem = Pick<AsyncJob, "id" | "type" | "status" | "label" | "startTime" | "agentId">;
 
 /** Snapshot of running, recent, and pending-delivery asynchronous jobs. */
 export interface AsyncJobSnapshot {

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1897,6 +1897,7 @@ export class AgentSession {
 			status: job.status,
 			label: job.label,
 			startTime: job.startTime,
+			agentId: job.agentId,
 		}));
 		const recent = manager.getRecentJobs(options?.recentLimit ?? 5, ownerFilter).map(job => ({
 			id: job.id,
@@ -1904,6 +1905,7 @@ export class AgentSession {
 			status: job.status,
 			label: job.label,
 			startTime: job.startTime,
+			agentId: job.agentId,
 		}));
 		const delivery = manager.getDeliveryState(ownerFilter);
 		return { running, recent, delivery };

--- a/packages/coding-agent/test/collab/guest-subagent-badge.test.ts
+++ b/packages/coding-agent/test/collab/guest-subagent-badge.test.ts
@@ -9,7 +9,7 @@ import {
 } from "@oh-my-pi/pi-coding-agent/collab/protocol";
 import { CollabSocket } from "@oh-my-pi/pi-coding-agent/collab/relay-client";
 import {
-	countRunningSubagentBadgeAgents,
+	getRunningSubagentBadgeAgentIds,
 	getRunningSubagentBadgeRegistry,
 } from "@oh-my-pi/pi-coding-agent/modes/running-subagent-badge";
 import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
@@ -72,8 +72,8 @@ function makeGuestContext(counts: number[]): InteractiveModeContext {
 		pendingTools: new Map(),
 		loadingAnimation: undefined,
 		statusLine: {
-			setSubagentCount: (count: number) => {
-				statusLineCount = count;
+			setRunningSubagents: (agentIds: readonly string[]) => {
+				statusLineCount = agentIds.length;
 			},
 			get subagentCount() {
 				return statusLineCount;
@@ -96,9 +96,9 @@ function makeGuestContext(counts: number[]): InteractiveModeContext {
 		eventController: { handleEvent: () => Promise.resolve() },
 		syncRunningSubagentBadge: () => {
 			const registry = getRunningSubagentBadgeRegistry(ctx.collabGuest);
-			const count = countRunningSubagentBadgeAgents(registry);
-			ctx.statusLine.setSubagentCount(count);
-			counts.push(count);
+			const agentIds = getRunningSubagentBadgeAgentIds(registry);
+			ctx.statusLine.setRunningSubagents(agentIds);
+			counts.push(agentIds.length);
 		},
 	} as unknown as InteractiveModeContext;
 	return ctx;

--- a/packages/coding-agent/test/status-line-background-jobs.test.ts
+++ b/packages/coding-agent/test/status-line-background-jobs.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { stripVTControlCharacters } from "node:util";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { StatusLineComponent } from "@oh-my-pi/pi-coding-agent/modes/components/status-line";
+import { initTheme, theme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { beginSettingsTest, restoreSettingsTestState, type SettingsTestState } from "./helpers/settings-test-state";
+
+interface RunningJob {
+	id: string;
+	type: "bash" | "task";
+	status: "running";
+	label: string;
+	startTime: number;
+}
+
+let settingsState: SettingsTestState | undefined;
+
+beforeEach(async () => {
+	settingsState = beginSettingsTest();
+	await Settings.init({ inMemory: true });
+	await initTheme();
+});
+
+afterEach(() => {
+	restoreSettingsTestState(settingsState);
+	settingsState = undefined;
+});
+
+function runningJob(type: RunningJob["type"], index: number): RunningJob {
+	return {
+		id: `${type}-${index}`,
+		type,
+		status: "running",
+		label: `${type} ${index}`,
+		startTime: index,
+	};
+}
+
+function makeComponent(running: RunningJob[]): StatusLineComponent {
+	const messages: unknown[] = [];
+	const model = { id: "test-model", name: "Test Model", contextWindow: 100_000 };
+	const session = {
+		state: { messages, model },
+		messages,
+		model,
+		contextUsageRevision: 0,
+		systemPrompt: [],
+		agent: { state: { tools: [] } },
+		skills: [],
+		isStreaming: false,
+		isAutoThinking: false,
+		autoResolvedThinkingLevel: () => undefined,
+		isFastModeActive: () => false,
+		isAdvisorActive: () => false,
+		getAdvisorStatusOverview: () => ({ configured: false, advisors: [] }),
+		getAsyncJobSnapshot: () => ({ running }),
+		settings: { get: () => false },
+		modelRegistry: { isUsingOAuth: () => false },
+		sessionManager: {
+			getSessionName: () => undefined,
+			getUsageStatistics: () => ({
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				orchestrationInput: 0,
+				orchestrationOutput: 0,
+				orchestrationCacheRead: 0,
+				premiumRequests: 0,
+				cost: 0,
+			}),
+		},
+		getContextUsage: () => undefined,
+	} as unknown as ConstructorParameters<typeof StatusLineComponent>[0];
+	const component = new StatusLineComponent(session);
+	component.updateSettings({
+		preset: "custom",
+		leftSegments: [],
+		rightSegments: [],
+		separator: "none",
+		transparent: true,
+	});
+	return component;
+}
+
+describe("status-line background-job badge", () => {
+	it("excludes task subagents and shows only running bash jobs", () => {
+		const subagentCount = 3;
+		const running = Array.from({ length: subagentCount }, (_, index) => runningJob("task", index));
+		const component = makeComponent(running);
+		component.setSubagentCount(subagentCount);
+
+		const taskOnly = stripVTControlCharacters(component.getTopBorder(120).content);
+		expect(taskOnly).toContain(`${theme.icon.agents} ${subagentCount} agents`);
+		expect(taskOnly).not.toContain(theme.icon.job);
+
+		running.push(runningJob("bash", subagentCount));
+		const withBash = stripVTControlCharacters(component.getTopBorder(120).content);
+		expect(withBash).toContain(`${theme.icon.agents} ${subagentCount} agents`);
+		expect(withBash).toContain(`${theme.icon.job} 1`);
+	});
+});

--- a/packages/coding-agent/test/status-line-background-jobs.test.ts
+++ b/packages/coding-agent/test/status-line-background-jobs.test.ts
@@ -1,17 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { stripVTControlCharacters } from "node:util";
+import type { AsyncJobType } from "@oh-my-pi/pi-coding-agent/async";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { StatusLineComponent } from "@oh-my-pi/pi-coding-agent/modes/components/status-line";
 import { initTheme, theme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import type { AsyncJobSnapshotItem } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { beginSettingsTest, restoreSettingsTestState, type SettingsTestState } from "./helpers/settings-test-state";
-
-interface RunningJob {
-	id: string;
-	type: "bash" | "task";
-	status: "running";
-	label: string;
-	startTime: number;
-}
 
 let settingsState: SettingsTestState | undefined;
 
@@ -26,17 +20,19 @@ afterEach(() => {
 	settingsState = undefined;
 });
 
-function runningJob(type: RunningJob["type"], index: number): RunningJob {
+function runningJob(type: AsyncJobType, index: number): AsyncJobSnapshotItem {
+	const id = `${type}-${index}`;
 	return {
-		id: `${type}-${index}`,
+		id,
 		type,
 		status: "running",
 		label: `${type} ${index}`,
 		startTime: index,
+		agentId: type === "task" ? id : undefined,
 	};
 }
 
-function makeComponent(running: RunningJob[]): StatusLineComponent {
+function makeComponent(running: AsyncJobSnapshotItem[]): StatusLineComponent {
 	const messages: unknown[] = [];
 	const model = { id: "test-model", name: "Test Model", contextWindow: 100_000 };
 	const session = {
@@ -85,19 +81,20 @@ function makeComponent(running: RunningJob[]): StatusLineComponent {
 }
 
 describe("status-line background-job badge", () => {
-	it("excludes task subagents and shows only running bash jobs", () => {
-		const subagentCount = 3;
-		const running = Array.from({ length: subagentCount }, (_, index) => runningJob("task", index));
+	it("counts non-task jobs without duplicating running task subagents", () => {
+		const running = [runningJob("task", 0), runningJob("bash", 1), runningJob("eval", 2)];
 		const component = makeComponent(running);
-		component.setSubagentCount(subagentCount);
+		component.setRunningSubagents(["task-0"]);
 
-		const taskOnly = stripVTControlCharacters(component.getTopBorder(120).content);
-		expect(taskOnly).toContain(`${theme.icon.agents} ${subagentCount} agents`);
-		expect(taskOnly).not.toContain(theme.icon.job);
+		const content = stripVTControlCharacters(component.getTopBorder(120).content);
+		expect(content).toContain(`${theme.icon.agents} 1 agent`);
+		expect(content).toContain(`${theme.icon.job} 2`);
+	});
 
-		running.push(runningJob("bash", subagentCount));
-		const withBash = stripVTControlCharacters(component.getTopBorder(120).content);
-		expect(withBash).toContain(`${theme.icon.agents} ${subagentCount} agents`);
-		expect(withBash).toContain(`${theme.icon.job} 1`);
+	it("counts queued task jobs before their subagent is registered", () => {
+		const component = makeComponent([runningJob("task", 0)]);
+		component.setRunningSubagents([]);
+		const content = stripVTControlCharacters(component.getTopBorder(120).content);
+		expect(content).toContain(`${theme.icon.job} 1`);
 	});
 });

--- a/packages/coding-agent/test/status-line-settings-cache.test.ts
+++ b/packages/coding-agent/test/status-line-settings-cache.test.ts
@@ -163,7 +163,7 @@ describe("StatusLineComponent effective settings cache", () => {
 	it("surfaces active subagents even when custom segments omit subagents", () => {
 		const component = makeComponent({ preset: "custom", leftSegments: [], rightSegments: [] });
 
-		component.setSubagentCount(2);
+		component.setRunningSubagents(["sub-1", "sub-2"]);
 
 		const content = stripVTControlCharacters(component.getTopBorder(120).content);
 		expect(content).toContain("2 agents");


### PR DESCRIPTION
I reviewed the diff. The status bar was showing me `⚘ 5 agents` immediately followed by `⚙ 5`, and the two numbers always moved together — they were counting the same thing, so neither told me anything on its own.

Every task-tool spawn registers both an `AgentRegistry` ref (`kind: "sub"`) and an `AsyncJobManager` job of `type: "task"` with the same agent id (`task/index.ts:1098-1101`), so the subagent badge and the background-job badge track the same population in the common case. They can also legitimately diverge, since `getAsyncJobSnapshot()` scopes to the current agent while the subagent count is process-wide — which makes the duplication harder to notice rather than less real.

Counts only `bash` jobs in the job badge, so the two badges describe disjoint populations: running subagents on one, genuine background jobs on the other. `AsyncJobManager.getRunningJobs()` keeps its existing semantics for every other consumer — the filter is applied at the badge's data source rather than in the shared API. The existing zero-suppression is preserved, so no bare `⚙ 0` appears.

**Verification:** 1 test added asserting that N running task subagents produce no job badge while the agents badge reads N, and that one running bash job renders `⚙ 1`. Exercised interactively with a real fan-out: the duplicate pair is gone, and a background bash job still shows up on its own.
