### PR TITLE
feat(git): optional OMP_GIT_MAX_CONCURRENCY concurrency limiter

### DIFF
--- a/packages/coding-agent/src/utils/git.ts
+++ b/packages/coding-agent/src/utils/git.ts
@@ -528,8 +528,51 @@ function formatCommandFailure(
 	return `git ${args.join(" ")} failed with exit code ${result.exitCode}`;
 }
 
+// ════════════════════════════════════════════════════════════════════════════
+// Concurrency limiter
+// ════════════════════════════════════════════════════════════════════════════
+//
+// A burst of parallel `git` launches — one per concurrent subagent plus any
+// always-on status pollers — can saturate CPU and filesystem I/O on
+// constrained or thermally-limited hosts. When `OMP_GIT_MAX_CONCURRENCY` is a
+// positive integer, git subprocess launches are queued so at most N run at
+// once; excess callers wait FIFO for a slot. Unset or non-positive => 0 =>
+// unlimited, preserving the previous behavior exactly.
+const GIT_MAX_CONCURRENCY_RAW = Number.parseInt(process.env.OMP_GIT_MAX_CONCURRENCY ?? "", 10);
+const GIT_MAX_CONCURRENCY = Number.isFinite(GIT_MAX_CONCURRENCY_RAW) && GIT_MAX_CONCURRENCY_RAW > 0 ? GIT_MAX_CONCURRENCY_RAW : 0;
+let gitActiveCount = 0;
+const gitSlotWaiters: Array<() => void> = [];
+
+/**
+ * Reserve a git-launch slot. Resolves with a release callback that MUST be
+ * invoked once (idempotent) after the child exits. A no-op when the limiter is
+ * disabled (`GIT_MAX_CONCURRENCY === 0`).
+ */
+function acquireGitSlot(): Promise<() => void> {
+	if (GIT_MAX_CONCURRENCY === 0) return Promise.resolve(() => {});
+	let released = false;
+	const release = (): void => {
+		if (released) return;
+		released = true;
+		gitActiveCount -= 1;
+		const next = gitSlotWaiters.shift();
+		if (next !== undefined) next();
+	};
+	if (gitActiveCount < GIT_MAX_CONCURRENCY) {
+		gitActiveCount += 1;
+		return Promise.resolve(release);
+	}
+	return new Promise<() => void>((resolve) => {
+		gitSlotWaiters.push(() => {
+			gitActiveCount += 1;
+			resolve(release);
+		});
+	});
+}
+
 async function git(cwd: string, args: readonly string[], options: CommandOptions = {}): Promise<GitCommandResult> {
 	const commandArgs = withShortLivedGitConfig(options.readOnly ? withNoOptionalLocks(args) : [...args]);
+	const releaseGitSlot = await acquireGitSlot();
 	let child: Subprocess;
 	try {
 		child = Bun.spawn(["git", ...commandArgs], {
@@ -542,6 +585,7 @@ async function git(cwd: string, args: readonly string[], options: CommandOptions
 			windowsHide: true,
 		});
 	} catch (err) {
+		releaseGitSlot();
 		if (isEnoent(err)) {
 			// A deleted/nonexistent cwd also surfaces as a spawn ENOENT; only blame
 			// the binary when the working directory actually exists.
@@ -551,7 +595,11 @@ async function git(cwd: string, args: readonly string[], options: CommandOptions
 		throw err;
 	}
 
-	return await collectSubprocessResult("git", commandArgs, child, options);
+	try {
+		return await collectSubprocessResult("git", commandArgs, child, options);
+	} finally {
+		releaseGitSlot();
+	}
 }
 
 function withNoOptionalLocks(args: readonly string[]): string[] {


### PR DESCRIPTION
## What

Adds an **opt-in** concurrency limiter around the async `git()` subprocess
launch path in `packages/coding-agent/src/utils/git.ts`, gated by a new env
var `OMP_GIT_MAX_CONCURRENCY`.

- **Unset / non-positive → `0` → unlimited** — behavior is byte-for-byte
  unchanged, so this is a no-op by default.
- **Positive `N`** → at most `N` git subprocesses run at once; excess callers
  wait **FIFO** for a slot and resume as slots free.

## Why

A burst of parallel `git` launches — one per concurrent subagent, plus
always-on status pollers — can saturate CPU and filesystem I/O. On a
constrained or thermally-limited host this is enough to cause instability.
A bounded queue flattens the spawn burst without changing any command's
semantics.

(Motivating case: a degrading Raptor Lake HX laptop where each git launch
boosts a P-core into the exact voltage regime that trips a hardware fault.
The real fix there is an RMA — but capping concurrent git launches is cheap,
reversible harm reduction that helps any resource-constrained host.)

## Design

- Small module-level FIFO semaphore: `acquireGitSlot()` returns an idempotent
  `release()`.
- `release()` runs in a `finally` after the child exits — including the
  spawn-`ENOENT` and timeout paths — so a slot can never leak.
- The synchronous render-path (`gitSpawnSyncText`) is **not** gated: it is
  blocking by nature and already deadline-bounded.
- The streaming path (`runByteStream`) is intentionally excluded: long-lived,
  few in number, not part of the launch burst.

## Test / verification notes

- Targeted typecheck of `utils/git.ts` under `tsgo`: **0 errors** in the
  changed file. (Full-workspace typecheck was run in a throwaway worktree with
  a junctioned `node_modules`, which produces unrelated cross-package
  `TS2307` resolution noise; CI runs the authoritative check.)
- Default path (`OMP_GIT_MAX_CONCURRENCY` unset) is a no-op: `acquireGitSlot`
  returns an immediately-resolved no-op release, so no scheduling change.

## Rollout

Ship default-off. Set `OMP_GIT_MAX_CONCURRENCY=2` (or `1`) to cap.
