### PR TITLE
fix(catalog): stop litellm discovery leaking cross-provider wire transport

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed LiteLLM discovery leaking a colliding bundled model's provider-specific transport onto custom endpoints: a discovered alias (e.g. `kimi-k3`) matching a bundled Fireworks model no longer inherits that model's wire-id transform, which had caused requests to POST a model id the endpoint never advertised and return HTTP 400 ([#9938](https://github.com/can1357/oh-my-pi/issues/9938)).
+
 ## [18.0.7] - 2026-08-26
 
 ### Added

--- a/packages/catalog/src/provider-models/cache-provider-id.ts
+++ b/packages/catalog/src/provider-models/cache-provider-id.ts
@@ -60,7 +60,10 @@ export function resolveModelCacheProviderId(providerId: string, options: ModelCa
 			return "cursor:default-effort-v4";
 		case "litellm": {
 			const baseUrl = options.baseUrl ?? getDefaultModelDiscoveryBaseUrl(providerId)!;
-			return `litellm:rich-v7:${Bun.hash(baseUrl).toString(36)}`;
+			// rich-v8 invalidates rows whose `compatConfig` retained a colliding
+			// bundled model's provider-specific transport (e.g. Fireworks
+			// `wireModelIdMode`) before that leak was fixed (issue #9938).
+			return `litellm:rich-v8:${Bun.hash(baseUrl).toString(36)}`;
 		}
 		case "opencode-go":
 		case "opencode-zen": {

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -5645,12 +5645,14 @@ export function litellmModelManagerOptions(config?: LiteLLMModelManagerConfig): 
 	const baseUrl = config?.baseUrl ?? getDefaultModelDiscoveryBaseUrl("litellm")!;
 	return {
 		providerId: "litellm",
-		// rich-v7 invalidates rows cached before discovery continued past endpoints
-		// that omitted cache pricing. Earlier versions added bundled reference fallback,
-		// moved OpenAI models to Responses, continued past incomplete vision and API
-		// metadata, stripped reseller usage suffixes, filtered placeholder rows, and
-		// mapped rich pricing. Bump the version whenever these mappers change, or warm
-		// authoritative caches keep serving pre-change rows for the full TTL.
+		// rich-v8 invalidates rows whose `compatConfig` retained a colliding
+		// bundled model's provider-specific transport (e.g. Fireworks
+		// `wireModelIdMode`) before that leak was fixed. Earlier versions added
+		// bundled reference fallback, moved OpenAI models to Responses, continued
+		// past incomplete vision/API metadata and endpoints omitting cache
+		// pricing, stripped reseller usage suffixes, filtered placeholder rows,
+		// and mapped rich pricing. Bump the version whenever these mappers change,
+		// or warm authoritative caches keep serving pre-change rows for the full TTL.
 		cacheProviderId: resolveModelCacheProviderId("litellm", { baseUrl }),
 		// litellm is a local-only proxy and is never bundled in models.json (that
 		// would leak the machine's localhost catalog). Prefer the proxy's richer

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -5397,12 +5397,28 @@ function mapLiteLLMRichEntry<TApi extends Api>(
 							["tools", "tool_choice", "functions", "function_call"].includes(param),
 						)
 					: reference?.supportsTools;
+	// Enrich from the bundled reference with provider-INDEPENDENT reasoning
+	// hints only. The reference is resolved against the global bundled catalog,
+	// so a custom endpoint exposing an alias that collides with a bundled model
+	// (a LiteLLM proxy serving `kimi-k3`, which matches Fireworks' bundled
+	// `kimi-k3`) must not inherit that provider's transport compat. Spreading
+	// the resolved `reference.compat` wholesale leaked `wireModelIdMode`,
+	// `toolSchemaFlavor`, `thinkingFormat`, etc. across the provider boundary —
+	// rewriting the wire id to `accounts/fireworks/models/kimi-k3` for a
+	// non-Fireworks endpoint (issue #9938). `buildModel` re-derives every
+	// transport field from the discovered provider and model id, so only the
+	// effort vocabulary flows through here. Mirrors `discoverOpenAIModelsList`.
+	const referenceCompat = reference?.compat as OpenAICompat | undefined;
 	const compat: OpenAICompat = {
-		...(reference?.compat ?? {}),
 		supportsStore: false,
 		supportsDeveloperRole: false,
-		...(supportedOpenAIParams !== undefined
-			? { supportsReasoningEffort: supportedOpenAIParams.includes("reasoning_effort") }
+		supportsReasoningEffort:
+			supportedOpenAIParams !== undefined
+				? supportedOpenAIParams.includes("reasoning_effort")
+				: (referenceCompat?.supportsReasoningEffort ?? false),
+		...(referenceCompat?.reasoningEffortMap ? { reasoningEffortMap: referenceCompat.reasoningEffortMap } : {}),
+		...(referenceCompat?.omitReasoningEffort !== undefined
+			? { omitReasoningEffort: referenceCompat.omitReasoningEffort }
 			: {}),
 	};
 	return {

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -5412,10 +5412,11 @@ function mapLiteLLMRichEntry<TApi extends Api>(
 	const compat: OpenAICompat = {
 		supportsStore: false,
 		supportsDeveloperRole: false,
-		supportsReasoningEffort:
-			supportedOpenAIParams !== undefined
-				? supportedOpenAIParams.includes("reasoning_effort")
-				: (referenceCompat?.supportsReasoningEffort ?? false),
+		...(supportedOpenAIParams !== undefined
+			? { supportsReasoningEffort: supportedOpenAIParams.includes("reasoning_effort") }
+			: referenceCompat?.supportsReasoningEffort !== undefined
+				? { supportsReasoningEffort: referenceCompat.supportsReasoningEffort }
+				: {}),
 		...(referenceCompat?.reasoningEffortMap ? { reasoningEffortMap: referenceCompat.reasoningEffortMap } : {}),
 		...(referenceCompat?.omitReasoningEffort !== undefined
 			? { omitReasoningEffort: referenceCompat.omitReasoningEffort }

--- a/packages/catalog/test/litellm-provider.test.ts
+++ b/packages/catalog/test/litellm-provider.test.ts
@@ -131,7 +131,7 @@ describe("LiteLLM provider discovery", () => {
 		const models = await options.fetchDynamicModels?.();
 
 		expect(options.cacheProviderId).toBe(
-			`litellm:rich-v7:${Bun.hash("http://litellm.example:4100/v1").toString(36)}`,
+			`litellm:rich-v8:${Bun.hash("http://litellm.example:4100/v1").toString(36)}`,
 		);
 		expect(fetchMock).toHaveBeenCalledTimes(6);
 		expect(models).toHaveLength(1);
@@ -155,7 +155,7 @@ describe("LiteLLM provider discovery", () => {
 		const models = await options.fetchDynamicModels?.();
 
 		expect(options.cacheProviderId).toBe(
-			`litellm:rich-v7:${Bun.hash("http://litellm-config.example:4200/v1/").toString(36)}`,
+			`litellm:rich-v8:${Bun.hash("http://litellm-config.example:4200/v1/").toString(36)}`,
 		);
 		expect(fetchMock).toHaveBeenCalledTimes(6);
 		expect(models).toHaveLength(1);

--- a/packages/catalog/test/litellm-provider.test.ts
+++ b/packages/catalog/test/litellm-provider.test.ts
@@ -267,6 +267,37 @@ describe("LiteLLM provider discovery", () => {
 		expect(buildModel(spec as ModelSpec<"openai-completions">).compat.wireModelIdMode).toBe("raw");
 	});
 
+	test("preserves generic effort support when rich metadata and references omit it", async () => {
+		const fetchMock = vi.fn(async (input: string | URL | Request) => {
+			const url = inputUrl(input);
+			if (url === "http://primary:4000/model_group/info") {
+				return Response.json({
+					data: [
+						{
+							model_group: "private-reasoner",
+							supports_vision: false,
+							supports_reasoning: true,
+						},
+					],
+				});
+			}
+			return new Response("{}", { status: 404 });
+		}) as FetchImpl;
+
+		const specs = await fetchLiteLLMRichModels<"openai-completions">({
+			api: "openai-completions",
+			provider: "private-litellm",
+			baseUrl: "http://primary:4000/v1",
+			fetch: fetchMock,
+		});
+
+		expect(specs).toHaveLength(1);
+		const spec = specs?.[0];
+		if (!spec) throw new Error("expected exactly one discovered model");
+		expect(spec.compat).not.toHaveProperty("supportsReasoningEffort");
+		expect(buildModel(spec).compat.supportsReasoningEffort).toBe(true);
+	});
+
 	test("routes only OpenAI-backed rich models through Responses", async () => {
 		const fetchMock = vi.fn(async (input: string | URL | Request) => {
 			const url = inputUrl(input);

--- a/packages/catalog/test/litellm-provider.test.ts
+++ b/packages/catalog/test/litellm-provider.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, describe, expect, test, vi } from "bun:test";
-import { fetchLiteLLMRichModels, litellmModelManagerOptions } from "@oh-my-pi/pi-catalog/provider-models/openai-compat";
-import type { FetchImpl } from "@oh-my-pi/pi-catalog/types";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import {
+	fetchLiteLLMRichModels,
+	litellmModelManagerOptions,
+	resolveLiteLLMApi,
+} from "@oh-my-pi/pi-catalog/provider-models/openai-compat";
+import type { Api, FetchImpl, ModelSpec } from "@oh-my-pi/pi-catalog/types";
 import * as logger from "@oh-my-pi/pi-utils/logger";
 
 const ORIGINAL_LITELLM_BASE_URL = Bun.env.LITELLM_BASE_URL;
@@ -181,6 +186,85 @@ describe("LiteLLM provider discovery", () => {
 				output: 2,
 			},
 		});
+	});
+
+	test("does not inherit a colliding bundled model's provider-specific wire transport (#9938)", async () => {
+		// The coding-agent discovery path resolves discovered aliases against the
+		// *resolved* bundled reference index, so a custom endpoint exposing
+		// `kimi-k3` (which collides with the bundled Fireworks `kimi-k3`) would
+		// otherwise inherit Fireworks' resolved `wireModelIdMode: "fireworks"` and
+		// POST `accounts/fireworks/models/kimi-k3` — an id the endpoint never
+		// advertised, which the proxy rejects with HTTP 400. Only provider-
+		// independent reasoning hints may cross the provider boundary; every
+		// transport field must be re-derived from the discovered provider.
+		const fetchMock = vi.fn(async (input: string | URL | Request) => {
+			const url = inputUrl(input);
+			if (url === "http://primary:4000/model_group/info") {
+				return Response.json({
+					data: [
+						{
+							model_group: "kimi-k3",
+							model_info: {
+								max_input_tokens: 200_000,
+								max_output_tokens: 32_000,
+								supports_function_calling: true,
+							},
+						},
+					],
+				});
+			}
+			return new Response("{}", { status: 404 });
+		}) as FetchImpl;
+
+		// Mimic getBundledModelReferenceIndex: a reference carrying fully-resolved,
+		// provider-specific compat (wire-id transform, tool-schema flavor) plus
+		// provider-independent reasoning metadata.
+		const referenceResolver = (id: string): ModelSpec<Api> | undefined =>
+			id === "kimi-k3"
+				? ({
+						id: "kimi-k3",
+						name: "Kimi K3",
+						api: "openai-completions",
+						provider: "fireworks",
+						baseUrl: "https://api.fireworks.ai/inference/v1",
+						reasoning: true,
+						input: ["text"],
+						cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+						contextWindow: 1_048_576,
+						maxTokens: 131_072,
+						compat: {
+							wireModelIdMode: "fireworks",
+							toolSchemaFlavor: "moonshot-mfjs",
+							supportsReasoningEffort: true,
+							reasoningEffortMap: { max: "max" },
+						},
+					} as unknown as ModelSpec<Api>)
+				: undefined;
+
+		const specs = await fetchLiteLLMRichModels<Api>({
+			api: "openai-completions",
+			provider: "e-infra",
+			baseUrl: "http://primary:4000/v1",
+			fetch: fetchMock,
+			referenceResolver,
+			resolveApi: (entry, id) => resolveLiteLLMApi(entry, id, "openai-completions"),
+		});
+
+		expect(specs).toHaveLength(1);
+		const spec = specs?.[0];
+		if (!spec) throw new Error("expected exactly one discovered model");
+		expect(spec.provider).toBe("e-infra");
+		// Provider-specific transport must NOT cross the boundary.
+		expect(spec.compat).not.toHaveProperty("wireModelIdMode");
+		expect(spec.compat).not.toHaveProperty("toolSchemaFlavor");
+		// Provider-independent reasoning hints still enrich the discovered model.
+		expect(spec.compat).toMatchObject({
+			supportsReasoningEffort: true,
+			reasoningEffortMap: { max: "max" },
+		});
+		// buildModel re-derives the wire-id transform from the discovered
+		// provider (`e-infra`, not Fireworks), so the alias serializes verbatim.
+		expect(buildModel(spec as ModelSpec<"openai-completions">).compat.wireModelIdMode).toBe("raw");
 	});
 
 	test("routes only OpenAI-backed rich models through Responses", async () => {

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -1474,10 +1474,12 @@ export class ModelRegistry {
 			return `${providerConfig.provider}:openai-models-list-context-v3`;
 		}
 		if (providerConfig.discovery.type === "litellm") {
-			// rich-v3 invalidates rows cached before per-model Responses routing;
-			// keep in lockstep with the catalog package's `litellm:rich-vN`
-			// namespace whenever LiteLLM mapping behavior changes.
-			return `${providerConfig.provider}:litellm-rich-v3`;
+			// rich-v4 invalidates rows whose `compatConfig` retained a colliding
+			// bundled model's provider-specific transport (e.g. Fireworks
+			// `wireModelIdMode`) before that leak was fixed (issue #9938); keep in
+			// lockstep with the catalog package's `litellm:rich-vN` namespace
+			// whenever LiteLLM mapping behavior changes.
+			return `${providerConfig.provider}:litellm-rich-v4`;
 		}
 		return providerConfig.provider;
 	}

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -2308,11 +2308,12 @@ describe("ModelRegistry", () => {
 					maxTokens: 16_384,
 				});
 			litellmStaleNamespaceCache = readonlyRegistry(litellmProxyConfig(), {
-				// Rows cached before per-model Responses routing must be orphaned
-				// instead of keeping OpenAI-backed groups on Chat Completions.
+				// Rows cached under the retired namespace whose `compatConfig`
+				// retained a colliding bundled model's provider-specific transport
+				// (issue #9938) must be orphaned instead of served.
 				seedCache: dbPath =>
 					writeModelCache(
-						"litellm-proxy:litellm-rich-v2",
+						"litellm-proxy:litellm-rich-v3",
 						Date.now(),
 						[litellmCachedModel("MiniMax-M3 (3x usage)")],
 						true,
@@ -2323,7 +2324,7 @@ describe("ModelRegistry", () => {
 			litellmCurrentNamespaceCache = readonlyRegistry(litellmProxyConfig(), {
 				seedCache: dbPath =>
 					writeModelCache(
-						"litellm-proxy:litellm-rich-v3",
+						"litellm-proxy:litellm-rich-v4",
 						Date.now(),
 						[litellmCachedModel("MiniMax-M3")],
 						true,
@@ -2409,13 +2410,13 @@ describe("ModelRegistry", () => {
 			});
 		});
 
-		test("ignores litellm discovery rows cached under the retired rich-v2 namespace", () => {
-			// Warm rich-v2 rows carry the pre-change provider-wide API and must not load.
+		test("ignores litellm discovery rows cached under the retired rich-v3 namespace", () => {
+			// Warm rich-v3 rows carry the leaked provider-specific compat and must not load.
 			expect(litellmStaleNamespaceCache.find("litellm-proxy", "minimax/minimax-m3")).toBeUndefined();
 			expect(getModelsForProvider(litellmStaleNamespaceCache, "litellm-proxy")).toHaveLength(0);
 		});
 
-		test("loads litellm discovery rows cached under the rich-v3 namespace", () => {
+		test("loads litellm discovery rows cached under the rich-v4 namespace", () => {
 			const model = litellmCurrentNamespaceCache.find("litellm-proxy", "minimax/minimax-m3");
 			expect(model?.name).toBe("MiniMax-M3");
 			expect(model?.provider).toBe("litellm-proxy");


### PR DESCRIPTION
## Repro
A custom provider using `discovery.type: litellm` whose endpoint advertises the public alias `kimi-k3` (which collides with the bundled Fireworks `kimi-k3`) selects the discovered model with `--model <provider>/kimi-k3`, but OMP POSTs `{"model":"accounts/fireworks/models/kimi-k3"}` — an id the endpoint never advertised — and the endpoint returns HTTP 400 `Invalid model name passed in`. Reproduced on v18.0.7 by replicating the coding-agent `discoverLiteLLMModels` path (`getBundledModelReferenceIndex()` + `resolveModelReference('kimi-k3')` as the reference resolver → `fetchLiteLLMRichModels` → `buildModel`): the built model resolves `compat.wireModelIdMode: "fireworks"` and serializes `accounts/fireworks/models/kimi-k3`.

## Cause
`discoverLiteLLMModels` in `packages/coding-agent/src/config/model-discovery.ts` resolves discovered aliases against the **fully-resolved** bundled reference index (`getBundledModelReferenceIndex()` / `resolveModelReference()`), so `reference.compat` is the resolved `ResolvedOpenAICompat` of a bundled model, not the sparse `compatConfig`. `mapLiteLLMRichEntry()` in `packages/catalog/src/provider-models/openai-compat.ts` built the discovered model's compat with `...(reference?.compat ?? {})`, spreading provider-specific transport (`wireModelIdMode: "fireworks"`, `toolSchemaFlavor`, `thinkingFormat`, …) across the provider boundary. `buildModel` then applied the Fireworks wire-id transform even though the discovered provider is unrelated.

## Fix
- `mapLiteLLMRichEntry()` no longer spreads the reference's resolved compat. It now cherry-picks only provider-independent reasoning hints — `supportsReasoningEffort`, `reasoningEffortMap`, `omitReasoningEffort` — mirroring `discoverOpenAIModelsList()`, which already handled the same collision correctly.
- `buildModel` re-derives every transport field (`wireModelIdMode`, `toolSchemaFlavor`, `thinkingFormat`, …) from the discovered provider and model id, so id-derived kimi compat still resolves while provider-specific transforms stay local to their real provider.
- Added a regression test in `packages/catalog/test/litellm-provider.test.ts` that feeds a resolved Fireworks-style reference and asserts the discovered spec drops `wireModelIdMode`/`toolSchemaFlavor`, keeps the reasoning-effort metadata, and resolves `wireModelIdMode: "raw"` after `buildModel`.
- Changelog entry under `## [Unreleased]`.

## Verification
`bun test packages/catalog/test/litellm-provider.test.ts` → 28 pass. Full `bun test packages/catalog/test/` → 777 pass, 0 fail. `bun run check:ts` clean for `@oh-my-pi/pi-catalog`. Manually verified via the coding-agent resolver replay that `e-infra/kimi-k3` now resolves `wireModelIdMode: "raw"` and serializes `kimi-k3` on the wire, while context window, reasoning, effort map, and id-derived `toolSchemaFlavor: moonshot-mfjs` are preserved.

Fixes #9938