### PR TITLE
fix(coding-agent): keep embedded context usage visible

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -33,6 +33,9 @@
 ### Fixed
 
 - Fixed the `aarch64-linux` `nix build` output segfaulting in the dynamic loader before startup by repointing the stale `DT_VERDEF` that `patchelf` leaves behind when it grows `.dynamic`, and surfaced smoke-test signal deaths in the build log instead of masking them ([#9881](https://github.com/can1357/oh-my-pi/issues/9881)).
+### Fixed
+
+- Kept embedded context usage visible when long session names or paths fill the status line ([#9946](https://github.com/can1357/oh-my-pi/pull/9946) by [@641-git641](https://github.com/641-git641)).
 
 ## [18.0.7] - 2026-08-26
 

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -322,6 +322,11 @@ function removeContextSegments(parts: string[], segments: StatusLineSegmentId[])
 function formatEmbeddedContextPercent(percent: number): string {
 	return `${percent > 0 && percent < 1 ? percent.toFixed(1) : Math.round(percent)}%`;
 }
+
+function embeddedContextGaugeMinWidth(percent: number, contextWindow: number): number {
+	return formatEmbeddedContextPercent(percent).length + formatNumber(contextWindow).length + 4;
+}
+
 function hasGitSegment(segments: readonly StatusLineSegmentId[]): boolean {
 	return segments.includes("git");
 }
@@ -1934,7 +1939,15 @@ export class StatusLineComponent implements Component {
 
 		let leftWidth = groupWidth(left, leftCapWidth, leftSepWidth);
 		let rightWidth = groupWidth(right, rightCapWidth, rightSepWidth);
-		const totalWidth = () => leftWidth + rightWidth + (left.length > 0 && right.length > 0 ? 1 : 0);
+		// Embedded mode removes the standalone context segment before overflow
+		// handling, so the gauge must reserve enough room for both labels. Without
+		// this budget a long path/session title can leave a one-cell gap: the
+		// context segment is gone, and the gauge silently omits its labels too.
+		const embeddedContextWidth = embedContext
+			? embeddedContextGaugeMinWidth(ctx.contextPercent ?? 0, ctx.contextWindow)
+			: 0;
+		const minimumGapWidth = () => embeddedContextWidth || (left.length > 0 && right.length > 0 ? 1 : 0);
+		const totalWidth = () => leftWidth + rightWidth + minimumGapWidth();
 
 		if (topFillWidth > 0) {
 			// Truncate the session-name segment before dropping right segments —
@@ -2093,7 +2106,7 @@ export class StatusLineComponent implements Component {
 		if (embedContext) {
 			const candidatePercent = formatEmbeddedContextPercent(percentOverflow ? pct : clampedPct);
 			const candidateWindow = formatNumber(ctx.contextWindow);
-			if (gapWidth >= candidatePercent.length + candidateWindow.length + 4) {
+			if (gapWidth >= embeddedContextGaugeMinWidth(percentOverflow ? pct : clampedPct, ctx.contextWindow)) {
 				percentLabel = candidatePercent;
 				windowLabel = candidateWindow;
 				if (percentOverflow) {

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -1946,7 +1946,16 @@ export class StatusLineComponent implements Component {
 		const embeddedContextWidth = embedContext
 			? embeddedContextGaugeMinWidth(ctx.contextPercent ?? 0, ctx.contextWindow)
 			: 0;
-		const minimumGapWidth = () => embeddedContextWidth || (left.length > 0 && right.length > 0 ? 1 : 0);
+		const minimumGapWidth = (): number => {
+			if (!embeddedContextWidth) return left.length > 0 && right.length > 0 ? 1 : 0;
+			// If the labels cannot coexist with the last surviving segment, fall
+			// back to the original one-cell gauge instead of dropping the entire
+			// status line. At this width the labels cannot render either way.
+			if (left.length + right.length === 1 && leftWidth + rightWidth + embeddedContextWidth > topFillWidth) {
+				return 1;
+			}
+			return embeddedContextWidth;
+		};
 		const totalWidth = () => leftWidth + rightWidth + minimumGapWidth();
 
 		if (topFillWidth > 0) {

--- a/packages/coding-agent/test/status-line-context-cache.test.ts
+++ b/packages/coding-agent/test/status-line-context-cache.test.ts
@@ -420,6 +420,25 @@ describe("StatusLineComponent context breakdown", () => {
 		expect(plain).toContain("200K");
 	});
 
+	it("preserves a status segment when embedded context labels cannot fit", () => {
+		const { session } = makeSession({
+			messages: [userMessage("hi"), assistantMessage("done")],
+			usage: { tokens: 50_000, contextWindow: 200_000, percent: 25 },
+		});
+		const comp = new StatusLineComponent(session);
+		comp.updateSettings({
+			preset: "custom",
+			leftSegments: ["pi", "context_pct"],
+			rightSegments: [],
+			separator: "powerline-thin",
+			contextLine: "embedded",
+		});
+
+		const border = comp.getTopBorder(8);
+		expect(border.content).not.toBe("");
+		expect(border.width).toBe(8);
+	});
+
 	it("embedded overflow (>100%) breaks the raw percent past the window label in error color", () => {
 		const { session } = makeSession({
 			messages: [userMessage("hi"), assistantMessage("done")],

--- a/packages/coding-agent/test/status-line-context-cache.test.ts
+++ b/packages/coding-agent/test/status-line-context-cache.test.ts
@@ -396,6 +396,30 @@ describe("StatusLineComponent context breakdown", () => {
 			settings.clearOverride("statusLine.preset");
 		}
 	});
+
+	it("reserves embedded context labels when a long session title consumes the status line", () => {
+		const { session } = makeSession({
+			messages: [userMessage("hi"), assistantMessage("done")],
+			usage: { tokens: 50_000, contextWindow: 200_000, percent: 25 },
+			sessionName: "28大学生AI赋能司法行政创新挑战 law agent",
+		});
+		const comp = new StatusLineComponent(session);
+		comp.updateSettings({
+			preset: "custom",
+			leftSegments: ["pi", "model", "path", "context_pct"],
+			rightSegments: ["session_name"],
+			separator: "powerline-thin",
+			sessionAccent: false,
+			contextLine: "embedded",
+		});
+
+		const border = comp.getTopBorder(48);
+		const plain = border.content.replaceAll(/\x1b\[[0-9;]*m/g, "");
+		expect(border.width).toBe(48);
+		expect(plain).toContain("25%");
+		expect(plain).toContain("200K");
+	});
+
 	it("embedded overflow (>100%) breaks the raw percent past the window label in error color", () => {
 		const { session } = makeSession({
 			messages: [userMessage("hi"), assistantMessage("done")],


### PR DESCRIPTION
## What

- Reserve enough status-line gauge width for the embedded context percentage and window labels.
- Allow long session titles, paths, and lower-priority segments to yield space during overflow handling.
- Add a regression test covering a long CJK session title in a narrow status line.

## Why

Embedded mode removes the standalone context segment before allocating status-line width. When a long session title or path consumed the available space, the remaining gauge was too narrow to render its labels, causing context usage to disappear entirely.

I reproduced this with a long project/session name and reviewed the complete diff.

## Testing

- `bun test packages/coding-agent/test/status-line-context-cache.test.ts`
- `bun --cwd=packages/coding-agent run check`
- Manually reproduced with a long project/session name in a narrow terminal
