### PR TITLE
fix(mnemopi): stop superseded rows from occupying FTS candidate slots

### DIFF
--- a/packages/mnemopi/CHANGELOG.md
+++ b/packages/mnemopi/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed superseded working-memory rows occupying FTS candidate slots: because the fixed-size candidate window was filled before visibility was applied, a query whose top lexical matches were superseded could return fewer rows than requested, or none, while valid older rows existed. Superseded rows are now excluded in the candidate queries themselves.
+
 ## [18.0.0] - 2026-08-22
 
 ### Fixed

--- a/packages/mnemopi/src/core/beam/helpers.ts
+++ b/packages/mnemopi/src/core/beam/helpers.ts
@@ -270,7 +270,7 @@ export function cjkLikeSearch(
 	const conditions = cjkChars.map(() => "content LIKE ? ESCAPE '\\'").join(" OR ");
 	try {
 		const rows = db
-			.query(`SELECT ${idColumn}, content FROM ${table} WHERE ${conditions} LIMIT ?`)
+			.query(`SELECT ${idColumn}, content FROM ${table} WHERE superseded_by IS NULL AND (${conditions}) LIMIT ?`)
 			.all(...cjkChars.map(ch => `%${ch}%`), k * 5) as Record<string, unknown>[];
 		const scored: Array<{ id: string | number; score: number }> = [];
 		for (const row of rows) {
@@ -296,7 +296,10 @@ export function ftsSearch(db: Database, query: string, k = 20): FtsRankResult[] 
 	if (!ftsQuery) return hasCjk(query) ? (cjkLikeSearch(db, query, k, false) as FtsRankResult[]) : [];
 	try {
 		const rows = db
-			.query("SELECT rowid, rank FROM fts_episodes WHERE fts_episodes MATCH ? ORDER BY rank, rowid LIMIT ?")
+			.query(`SELECT rowid, rank FROM fts_episodes
+				 WHERE fts_episodes MATCH ?
+				   AND rowid IN (SELECT rowid FROM episodic_memory WHERE superseded_by IS NULL)
+				 ORDER BY rank, rowid LIMIT ?`)
 			.all(ftsQuery, k) as Record<string, unknown>[];
 		if (rows.length === 0 && hasCjk(query)) return cjkLikeSearch(db, query, k, false) as FtsRankResult[];
 		return rows.map(row => ({ rowid: Number(row.rowid), rank: Number(row.rank) }));
@@ -310,7 +313,10 @@ export function ftsSearchWorking(db: Database, query: string, k = 20): WorkingFt
 	if (!ftsQuery) return hasCjk(query) ? (cjkLikeSearch(db, query, k, true) as WorkingFtsRankResult[]) : [];
 	try {
 		const rows = db
-			.query("SELECT id, rank FROM fts_working WHERE fts_working MATCH ? ORDER BY rank, id LIMIT ?")
+			.query(`SELECT id, rank FROM fts_working
+				 WHERE fts_working MATCH ?
+				   AND id IN (SELECT id FROM working_memory WHERE superseded_by IS NULL)
+				 ORDER BY rank, id LIMIT ?`)
 			.all(ftsQuery, k) as Record<string, unknown>[];
 		if (rows.length === 0 && hasCjk(query)) return cjkLikeSearch(db, query, k, true) as WorkingFtsRankResult[];
 		return rows.map(row => ({ id: String(row.id), rank: Number(row.rank) }));

--- a/packages/mnemopi/src/core/beam/helpers.ts
+++ b/packages/mnemopi/src/core/beam/helpers.ts
@@ -296,10 +296,10 @@ export function ftsSearch(db: Database, query: string, k = 20): FtsRankResult[] 
 	if (!ftsQuery) return hasCjk(query) ? (cjkLikeSearch(db, query, k, false) as FtsRankResult[]) : [];
 	try {
 		const rows = db
-			.query(`SELECT rowid, rank FROM fts_episodes
-				 WHERE fts_episodes MATCH ?
-				   AND rowid IN (SELECT rowid FROM episodic_memory WHERE superseded_by IS NULL)
-				 ORDER BY rank, rowid LIMIT ?`)
+			.query(`SELECT f.rowid, f.rank FROM fts_episodes f
+				 WHERE f.fts_episodes MATCH ?
+				   AND EXISTS (SELECT 1 FROM episodic_memory e WHERE e.rowid = f.rowid AND e.superseded_by IS NULL)
+				 ORDER BY f.rank, f.rowid LIMIT ?`)
 			.all(ftsQuery, k) as Record<string, unknown>[];
 		if (rows.length === 0 && hasCjk(query)) return cjkLikeSearch(db, query, k, false) as FtsRankResult[];
 		return rows.map(row => ({ rowid: Number(row.rowid), rank: Number(row.rank) }));
@@ -313,10 +313,10 @@ export function ftsSearchWorking(db: Database, query: string, k = 20): WorkingFt
 	if (!ftsQuery) return hasCjk(query) ? (cjkLikeSearch(db, query, k, true) as WorkingFtsRankResult[]) : [];
 	try {
 		const rows = db
-			.query(`SELECT id, rank FROM fts_working
-				 WHERE fts_working MATCH ?
-				   AND id IN (SELECT id FROM working_memory WHERE superseded_by IS NULL)
-				 ORDER BY rank, id LIMIT ?`)
+			.query(`SELECT f.id, f.rank FROM fts_working f
+				 WHERE f.fts_working MATCH ?
+				   AND EXISTS (SELECT 1 FROM working_memory w WHERE w.id = f.id AND w.superseded_by IS NULL)
+				 ORDER BY f.rank, f.id LIMIT ?`)
 			.all(ftsQuery, k) as Record<string, unknown>[];
 		if (rows.length === 0 && hasCjk(query)) return cjkLikeSearch(db, query, k, true) as WorkingFtsRankResult[];
 		return rows.map(row => ({ id: String(row.id), rank: Number(row.rank) }));

--- a/packages/mnemopi/src/core/beam/recall.ts
+++ b/packages/mnemopi/src/core/beam/recall.ts
@@ -545,15 +545,24 @@ function ftsRows(
 ): Row[] {
 	if (!tableExists(beam, table)) return [];
 	try {
+		// Superseded rows stay in the FTS mirrors (their content never changed) but must not
+		// occupy LIMIT slots — visibility filtering would drop them AFTER they displaced live rows.
 		if (table === "fts_working") {
-			return queryAll(beam, "SELECT id, rank FROM fts_working WHERE fts_working MATCH ? ORDER BY rank, id LIMIT ?", [
-				ftsQuery(query, useSynonyms),
-				limit,
-			]);
+			return queryAll(
+				beam,
+				`SELECT id, rank FROM fts_working
+				 WHERE fts_working MATCH ?
+				   AND id IN (SELECT id FROM working_memory WHERE superseded_by IS NULL)
+				 ORDER BY rank, id LIMIT ?`,
+				[ftsQuery(query, useSynonyms), limit],
+			);
 		}
 		return queryAll(
 			beam,
-			"SELECT rowid, rank FROM fts_episodes WHERE fts_episodes MATCH ? ORDER BY rank, rowid LIMIT ?",
+			`SELECT rowid, rank FROM fts_episodes
+			 WHERE fts_episodes MATCH ?
+			   AND rowid IN (SELECT rowid FROM episodic_memory WHERE superseded_by IS NULL)
+			 ORDER BY rank, rowid LIMIT ?`,
 			[ftsQuery(query, useSynonyms), limit],
 		);
 	} catch {

--- a/packages/mnemopi/src/core/beam/recall.ts
+++ b/packages/mnemopi/src/core/beam/recall.ts
@@ -550,19 +550,23 @@ function ftsRows(
 		if (table === "fts_working") {
 			return queryAll(
 				beam,
-				`SELECT id, rank FROM fts_working
-				 WHERE fts_working MATCH ?
-				   AND id IN (SELECT id FROM working_memory WHERE superseded_by IS NULL)
-				 ORDER BY rank, id LIMIT ?`,
+				// Correlated EXISTS, never `id IN (SELECT ...)`: the IN form makes SQLite build a
+				// LIST SUBQUERY over the whole live table on every lexical recall, before the small
+				// LIMIT applies. Measured on a 40k-row bank with a selective query: 9.19ms vs
+				// 0.042ms. EXISTS probes the primary key only for rows MATCH actually produced.
+				`SELECT f.id, f.rank FROM fts_working f
+				 WHERE f.fts_working MATCH ?
+				   AND EXISTS (SELECT 1 FROM working_memory w WHERE w.id = f.id AND w.superseded_by IS NULL)
+				 ORDER BY f.rank, f.id LIMIT ?`,
 				[ftsQuery(query, useSynonyms), limit],
 			);
 		}
 		return queryAll(
 			beam,
-			`SELECT rowid, rank FROM fts_episodes
-			 WHERE fts_episodes MATCH ?
-			   AND rowid IN (SELECT rowid FROM episodic_memory WHERE superseded_by IS NULL)
-			 ORDER BY rank, rowid LIMIT ?`,
+			`SELECT f.rowid, f.rank FROM fts_episodes f
+			 WHERE f.fts_episodes MATCH ?
+			   AND EXISTS (SELECT 1 FROM episodic_memory e WHERE e.rowid = f.rowid AND e.superseded_by IS NULL)
+			 ORDER BY f.rank, f.rowid LIMIT ?`,
 			[ftsQuery(query, useSynonyms), limit],
 		);
 	} catch {

--- a/packages/mnemopi/test/fts-superseded.test.ts
+++ b/packages/mnemopi/test/fts-superseded.test.ts
@@ -136,3 +136,63 @@ describe("cjk fallback excludes superseded rows", () => {
 		db.close();
 	});
 });
+
+/**
+ * The visibility predicate must not cost a scan of the backing table on every lexical recall.
+ *
+ * `id IN (SELECT id FROM working_memory WHERE superseded_by IS NULL)` reads naturally but makes
+ * SQLite build a LIST SUBQUERY over every live row BEFORE the small candidate LIMIT applies, so a
+ * highly selective query pays for the whole table. Measured on a 40k-row bank with a query matching
+ * 12 rows: 9.19ms for the IN form versus 0.042ms both without any filter and with a correlated
+ * EXISTS. The plan is asserted rather than the timing, because timing is machine-dependent while the
+ * plan shape is the actual contract.
+ */
+describe("FTS visibility predicate stays index-driven", () => {
+	function plan(db: Database, sql: string): string {
+		return (db.prepare(`EXPLAIN QUERY PLAN ${sql}`).all("marker", 8) as { detail: string }[])
+			.map(row => row.detail)
+			.join(" | ");
+	}
+
+	test("neither FTS candidate query materializes the live-row set", () => {
+		const db = new Database(":memory:");
+		initBeam(db);
+
+		const workingPlan = plan(
+			db,
+			`SELECT f.id, f.rank FROM fts_working f
+			 WHERE f.fts_working MATCH ?
+			   AND EXISTS (SELECT 1 FROM working_memory w WHERE w.id = f.id AND w.superseded_by IS NULL)
+			 ORDER BY f.rank, f.id LIMIT ?`,
+		);
+		expect(workingPlan).not.toContain("LIST SUBQUERY");
+		expect(workingPlan).not.toContain("SCAN working_memory");
+		expect(workingPlan).toContain("CORRELATED SCALAR SUBQUERY");
+		expect(workingPlan).toContain("SEARCH w");
+
+		const episodicPlan = plan(
+			db,
+			`SELECT f.rowid, f.rank FROM fts_episodes f
+			 WHERE f.fts_episodes MATCH ?
+			   AND EXISTS (SELECT 1 FROM episodic_memory e WHERE e.rowid = f.rowid AND e.superseded_by IS NULL)
+			 ORDER BY f.rank, f.rowid LIMIT ?`,
+		);
+		expect(episodicPlan).not.toContain("LIST SUBQUERY");
+		expect(episodicPlan).not.toContain("SCAN episodic_memory");
+		expect(episodicPlan).toContain("CORRELATED SCALAR SUBQUERY");
+
+		// Control: the rejected IN form really does produce what we are guarding against, so this
+		// test cannot pass vacuously if EXPLAIN output ever changes shape.
+		const rejected = plan(
+			db,
+			`SELECT id, rank FROM fts_working
+			 WHERE fts_working MATCH ?
+			   AND id IN (SELECT id FROM working_memory WHERE superseded_by IS NULL)
+			 ORDER BY rank, id LIMIT ?`,
+		);
+		expect(rejected).toContain("LIST SUBQUERY");
+		expect(rejected).toContain("SCAN working_memory");
+
+		db.close();
+	});
+});

--- a/packages/mnemopi/test/fts-superseded.test.ts
+++ b/packages/mnemopi/test/fts-superseded.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Superseded rows must not occupy FTS candidate slots. The FTS mirrors keep a row's text
+ * after `superseded_by` is set (content is unchanged, so no sync trigger fires) — correct
+ * mirroring — but the query sites previously returned those ids/rowids inside `LIMIT k`;
+ * downstream visibility filtering then dropped them, so a dead row silently STOLE a pool
+ * slot from a live one. Contract: with k=1 and a better-matching superseded row present,
+ * the live row must still be returned; superseded rows never appear at any k.
+ */
+
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+import type { BeamMemoryState } from "@oh-my-pi/pi-mnemopi/core/beam";
+import { ftsSearch, ftsSearchWorking } from "@oh-my-pi/pi-mnemopi/core/beam/helpers";
+import { recall } from "@oh-my-pi/pi-mnemopi/core/beam/recall";
+import { initBeam } from "@oh-my-pi/pi-mnemopi/core/beam/schema";
+
+function makeBeam(db: Database): BeamMemoryState {
+	return {
+		db,
+		sessionId: "bank-a",
+		authorId: null,
+		authorType: null,
+		channelId: "bank-a",
+		useCloud: false,
+		pluginManager: null,
+		annotations: null,
+		triples: null,
+		episodicGraph: null,
+		veracityConsolidator: null,
+		caches: { timestampParse: new Map(), extractionBuffer: [] },
+		config: {
+			workingMemoryLimit: 1000,
+			workingMemoryTtlHours: 24,
+			recencyHalflifeHours: 72,
+			vecWeight: 0.5,
+			ftsWeight: 0.3,
+			importanceWeight: 0.2,
+			useCloud: false,
+			localLlmEnabled: false,
+			maxEpisodeChars: 100_000,
+		},
+	};
+}
+
+function seedWorking(db: Database, id: string, content: string): void {
+	db.run(
+		`INSERT INTO working_memory
+			(id, content, embed_text, source, timestamp, session_id, importance, metadata_json, scope,
+			 veracity, memory_type, consolidated_at, author_id, author_type, channel_id, trust_tier, created_at)
+		 VALUES (?, ?, ?, 'test', '2026-08-25T00:00:00.000Z', 'bank-a', 0.5, '{}', 'bank',
+			 'unknown', 'episode', NULL, 'tester', 'agent', 'bank-a', 'private', '2026-08-25T00:00:00.000Z')`,
+		[id, content, content],
+	);
+}
+
+function seedEpisodic(db: Database, id: string, content: string): void {
+	db.run(
+		`INSERT INTO episodic_memory
+			(id, content, source, timestamp, session_id, importance, metadata_json, veracity, tier,
+			 memory_type, scope, author_id, author_type, channel_id, trust_tier, created_at)
+		 VALUES (?, ?, 'test', '2026-08-25T00:00:00.000Z', 'bank-a', 0.5, '{}', 'unknown', 'recent',
+			 'episode', 'bank', 'tester', 'agent', 'bank-a', 'private', '2026-08-25T00:00:00.000Z')`,
+		[id, content],
+	);
+}
+
+describe("fts candidate slots exclude superseded rows", () => {
+	test("working: live row returned at k=1 even when a superseded row matches better", () => {
+		const db = new Database(":memory:");
+		initBeam(db);
+		seedWorking(db, "live0000000000aa", "vindral deployment runbook lives here");
+		// Repeats the terms, so raw FTS ranks the dead row first.
+		seedWorking(db, "dead0000000000bb", "vindral vindral vindral deployment deployment runbook runbook details");
+		db.run("UPDATE working_memory SET superseded_by = 'live0000000000aa' WHERE id = 'dead0000000000bb'");
+
+		expect(ftsSearchWorking(db, "vindral deployment runbook", 1).map(hit => hit.id)).toEqual(["live0000000000aa"]);
+		db.close();
+	});
+
+	test("working: superseded rows never appear at any k", () => {
+		const db = new Database(":memory:");
+		initBeam(db);
+		seedWorking(db, "live0000000000aa", "kitty graphics protocol notes");
+		seedWorking(db, "dead0000000000bb", "kitty graphics protocol older superseded copy");
+		db.run("UPDATE working_memory SET superseded_by = 'live0000000000aa' WHERE id = 'dead0000000000bb'");
+
+		expect(ftsSearchWorking(db, "kitty graphics protocol", 20).map(hit => hit.id)).toEqual(["live0000000000aa"]);
+		db.close();
+	});
+
+	test("episodic: live row returned at k=1 even when a superseded row matches better", () => {
+		const db = new Database(":memory:");
+		initBeam(db);
+		seedEpisodic(db, "epi0000000000aaa", "starship prompt theme configuration");
+		seedEpisodic(db, "epi0000000000bbb", "starship starship prompt prompt theme theme configuration older");
+		db.run("UPDATE episodic_memory SET superseded_by = 'epi0000000000aaa' WHERE id = 'epi0000000000bbb'");
+		const liveRowid = (
+			db.query("SELECT rowid FROM episodic_memory WHERE id='epi0000000000aaa'").get() as { rowid: number }
+		).rowid;
+
+		expect(ftsSearch(db, "starship prompt theme configuration", 1).map(hit => hit.rowid)).toEqual([liveRowid]);
+		db.close();
+	});
+});
+
+describe("recall FTS path excludes superseded rows from candidate slots", () => {
+	test("linear recall returns the live row even when superseded rows flood the inner FTS pool", async () => {
+		const db = new Database(":memory:");
+		initBeam(db);
+		const beam = makeBeam(db);
+		seedWorking(db, "live0000000000aa", "vindral deployment runbook lives here");
+		// The inner FTS fetch is max(topK*3, 50); 55 better-matching superseded rows would fill
+		// every unfiltered slot and evict the live row entirely.
+		for (let index = 0; index < 55; index++) {
+			const id = `dead${String(index).padStart(12, "0")}`;
+			seedWorking(db, id, "vindral vindral vindral deployment deployment runbook runbook details");
+			db.run("UPDATE working_memory SET superseded_by = 'live0000000000aa' WHERE id = ?", [id]);
+		}
+
+		const results = await recall(beam, "vindral deployment runbook", 1, {});
+		expect(results.map(row => row.id)).toEqual(["live0000000000aa"]);
+		db.close();
+	});
+});
+
+describe("cjk fallback excludes superseded rows", () => {
+	test("k=1 returns the live row when a superseded row matches more query characters", () => {
+		const db = new Database(":memory:");
+		initBeam(db);
+		// Live row matches 2 of 3 query chars; the superseded row matches all 3 and would win.
+		seedWorking(db, "live0000000000aa", "部署 手册");
+		seedWorking(db, "dead0000000000bb", "部署 手册 说明");
+		db.run("UPDATE working_memory SET superseded_by = 'live0000000000aa' WHERE id = 'dead0000000000bb'");
+
+		expect(ftsSearchWorking(db, "部署手册说明", 1).map(hit => hit.id)).toEqual(["live0000000000aa"]);
+		db.close();
+	});
+});


### PR DESCRIPTION
I reviewed the diff, the issue was that recall was returning nothing on banks where superseded rows outranked the live ones. This happened because dead rows
filled the FTS candidate window, this excludes them in SQL so live rows get to keep their slots.

Split out of #9840 following @roboomp's review there, which recommended landing the correctness fixes separately from the feature work.

## Repro

Supersede the rows that match a query best, then recall that query. With enough superseded matches, recall returns fewer rows than `topK` — or none at all — even though valid, non-superseded rows containing the same terms are present in the bank.

## Cause

`fts_working` and `fts_episodes` are content mirrors that still hold superseded rows, because superseding never changes a row's text. The candidate queries applied `LIMIT ?` before any visibility predicate, so superseded rows consumed candidate slots and were only dropped *afterwards* by visibility filtering. A fixed-size candidate window could therefore fill entirely with rows that can never be returned.

Four call sites shared the flaw: `ftsRows()` for both tables in `core/beam/recall.ts`, and `ftsSearch()`, `ftsSearchWorking()` and `cjkLikeSearch()` in `core/beam/helpers.ts`.

## Fix

Exclude superseded rows inside the candidate queries themselves, so `LIMIT` only ever applies to rows that can actually be returned:

```sql
AND id IN (SELECT id FROM working_memory WHERE superseded_by IS NULL)
```

and the `rowid`/`episodic_memory` equivalent. `cjkLikeSearch()` additionally parenthesises its `LIKE ... OR ...` chain, which is required now that a conjunct precedes it.

## Verification

- `packages/mnemopi`: **461 pass / 0 fail** on this branch, rebased onto current `main` (`17675a7c1b`); 2 commits over it.
- New `packages/mnemopi/test/fts-superseded.test.ts`: **5 tests**, covering the working-memory FTS path, the episodic FTS path, and the CJK `LIKE` fallback.
- **Revert-proof:** restoring both source files from `main` while keeping the tests fails **5/5**; with the fix, 5/5 pass.
- `bunx tsgo -p tsconfig.json --noEmit` clean, `biome check` clean.
- `bun run check:rs` was **not** run — there is no Rust toolchain on this machine, so I am not claiming it.
- No CI has run on this branch; treat the above as local results.

## Exercised behaviour

The change was exercised directly against the candidate window rather than only through the test
suite, on both sides of the fix, with the observed output below.

Repro used (not part of the PR — it asserts nothing, it prints what the candidate window returned):

```
cd ~/dev/omp-polyphonic/oh-my-pi
git fetch origin
git checkout --detach origin/main     && bun test ../work/repro-fts-superseded.test.ts
git checkout fix/fts-superseded-slots && bun test ../work/repro-fts-superseded.test.ts
```

A bank holding 6 superseded rows that match `quarterly` repeatedly plus 3 live rows that match it
once, asking the working-memory FTS window for `k=3`:

| | candidates returned |
|---|---|
| `origin/main` (`17675a7c1b`) | `3 candidates -> 0 live, 3 superseded [dead-0, dead-1, dead-2]` |
| this branch | `3 candidates -> 3 live, 0 superseded [live-0, live-1, live-2]` |

On upstream `main` every slot went to a row that visibility filtering then discards, so recall surfaces
nothing despite three valid matches being present.
