### PR TITLE
docs: document BigModel balance-key setup

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -320,6 +320,25 @@ providers:
         maxTokens: 8192
 ```
 
+### Zhipu BigModel account-balance keys
+
+`/login zai` targets the global Z.AI Coding Plan endpoint, and `/login zhipu-coding-plan` targets the domestic Zhipu Coding Plan endpoint. Neither flow configures the general pay-as-you-go BigModel endpoint at `https://open.bigmodel.cn/api/paas/v4`.
+
+Use a custom provider for an API key issued from a standard BigModel account balance:
+
+```yaml
+providers:
+  bigmodel:
+    baseUrl: https://open.bigmodel.cn/api/paas/v4
+    api: openai-completions
+    apiKey: BIGMODEL_API_KEY
+    models:
+      - id: glm-4.6
+        name: GLM-4.6 (BigModel)
+```
+
+Set `BIGMODEL_API_KEY` to the `<id>.<secret>` key before starting `omp`, then select `bigmodel/glm-4.6`. The key does not use an `sk-` prefix.
+
 Keyless local provider (no credentials required):
 
 ```yaml


### PR DESCRIPTION
## Repro
Current `main` exposes only Z.AI Coding Plan and `zhipu-coding-plan` login entries for Zhipu-family services. Running `bun -e 'import { getOAuthProviders } from "./packages/ai/src/registry/oauth/index.ts"; console.log(JSON.stringify(getOAuthProviders().filter(({ id, name }) => /zhipu|zai/i.test(`${id} ${name}`)), null, 2))'` lists those Coding Plan flows, while `docs/providers.md` has no `open.bigmodel.cn/api/paas/v4` guidance for standard account-balance keys.

## Cause
`packages/ai/src/registry/zai.ts` and `packages/ai/src/registry/zhipu-coding-plan.ts` correctly define distinct Coding Plan login endpoints, but `docs/providers.md` documented custom providers only generically and did not map mainland BigModel balance-key users to the required pay-as-you-go endpoint and credential format.

## Fix
- Documented the endpoint distinction between Z.AI, Zhipu Coding Plan, and standard BigModel account-balance access.
- Added a minimal `bigmodel` custom-provider example using `BIGMODEL_API_KEY` and `https://open.bigmodel.cn/api/paas/v4`.
- Documented the `<id>.<secret>` key format and `bigmodel/glm-4.6` selector.

## Verification
Loaded the exact YAML example through `ModelRegistry` and confirmed it resolves `bigmodel/glm-4.6` with the documented base URL and `openai-completions` API. The pre-publish gate also completed successfully. Fixes #9947