### PR TITLE
fix(mcp): preserve OpenCode OAuth config

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 
+- Preserved OpenCode MCP OAuth configuration during discovery.
 - Fixed corrupt session headers silently overwriting recoverable transcripts during resume ([#9915](https://github.com/can1357/oh-my-pi/issues/9915)).
 - Fixed a startup race that left a new session with almost no tools and an empty skill inventory. An early reconcile could commit a small live tool set as the permanent enabled set. The enabled set is now seeded from the construction-time tool slate, and `reconcileCodeMode` samples it inside the registry mutation lock.
 - Fixed `snapcompact` compaction frames larger than the persistence limit being truncated into invalid image base64 on session resume, which made the provider reject every subsequent request with HTTP 400; already-corrupted archives now resume from their retained source text instead ([#9901](https://github.com/can1357/oh-my-pi/issues/9901)).

--- a/packages/coding-agent/src/capability/mcp.ts
+++ b/packages/coding-agent/src/capability/mcp.ts
@@ -53,10 +53,11 @@ export interface MCPServer {
 		clientSecret?: string;
 		resource?: string;
 	};
-	/** OAuth configuration (clientId, clientSecret, redirectUri, callbackPort, callbackPath, prompt) for servers requiring explicit client credentials */
+	/** OAuth configuration for servers requiring explicit client credentials */
 	oauth?: {
 		clientId?: string;
 		clientSecret?: string;
+		scope?: string;
 		redirectUri?: string;
 		callbackPort?: number;
 		callbackPath?: string;

--- a/packages/coding-agent/src/config/mcp-schema.json
+++ b/packages/coding-agent/src/config/mcp-schema.json
@@ -88,6 +88,9 @@
         "clientSecret": {
           "type": "string"
         },
+        "scope": {
+          "type": "string"
+        },
         "redirectUri": {
           "type": "string"
         },

--- a/packages/coding-agent/src/discovery/opencode.ts
+++ b/packages/coding-agent/src/discovery/opencode.ts
@@ -196,6 +196,12 @@ interface OpenCodeMCPConfig {
 	headers?: Record<string, string>;
 	enabled?: boolean;
 	timeout?: number;
+	oauth?: {
+		clientId?: string;
+		clientSecret?: string;
+		scope?: string;
+		redirectUri?: string;
+	};
 }
 
 function stringArray(value: unknown): string[] | undefined {
@@ -215,6 +221,18 @@ function stringRecord(value: unknown): Record<string, string> | undefined {
 		record[key] = item;
 	}
 	return record;
+}
+
+function normalizeOAuth(value: unknown): MCPServer["oauth"] | undefined {
+	if (!isRecord(value)) return undefined;
+
+	const oauth = {
+		clientId: typeof value.clientId === "string" ? value.clientId : undefined,
+		clientSecret: typeof value.clientSecret === "string" ? value.clientSecret : undefined,
+		scope: typeof value.scope === "string" ? value.scope : undefined,
+		redirectUri: typeof value.redirectUri === "string" ? value.redirectUri : undefined,
+	};
+	return Object.values(oauth).some(item => item !== undefined) ? oauth : undefined;
 }
 
 function normalizeCommand(
@@ -313,6 +331,7 @@ function buildMCPServer(name: string, serverConfig: OpenCodeMCPConfig, source: O
 		headers: serverConfig.headers && typeof serverConfig.headers === "object" ? serverConfig.headers : undefined,
 		enabled: serverConfig.enabled,
 		timeout: typeof serverConfig.timeout === "number" ? serverConfig.timeout : undefined,
+		oauth: normalizeOAuth(serverConfig.oauth),
 		transport,
 		_source: createSourceMeta(PROVIDER_ID, source.path, source.level),
 	};

--- a/packages/coding-agent/src/mcp/oauth-flow.ts
+++ b/packages/coding-agent/src/mcp/oauth-flow.ts
@@ -210,7 +210,7 @@ function staticClientIdFromConfig(config: MCPOAuthConfig): string | undefined {
 	const fromConfig = config.clientId?.trim();
 	if (fromConfig) return fromConfig;
 	try {
-		return new URL(config.authorizationUrl).searchParams.get("client_id") ?? undefined;
+		return new URL(config.authorizationUrl).searchParams.get("client_id")?.trim() || undefined;
 	} catch {
 		return undefined;
 	}
@@ -422,8 +422,12 @@ export class MCPOAuthFlow extends OAuthCallbackFlow {
 			params.set("response_type", "code");
 		}
 		const existingClientId = params.get("client_id")?.trim();
-		if (this.#resolvedClientId && !existingClientId) {
+		if (this.#resolvedClientId) {
 			params.set("client_id", this.#resolvedClientId);
+		} else if (existingClientId) {
+			params.set("client_id", existingClientId);
+		} else {
+			params.delete("client_id");
 		}
 		if (this.config.scopes && !params.get("scope")) {
 			params.set("scope", this.config.scopes);
@@ -641,8 +645,9 @@ export class MCPOAuthFlow extends OAuthCallbackFlow {
 				client_secret?: string;
 			};
 
-			if (data.client_id && data.client_id.trim() !== "") {
-				this.#resolvedClientId = data.client_id;
+			const clientId = data.client_id?.trim();
+			if (clientId) {
+				this.#resolvedClientId = clientId;
 			}
 			if (data.client_secret && data.client_secret.trim() !== "") {
 				this.#registeredClientSecret = data.client_secret;
@@ -816,7 +821,8 @@ export async function refreshMCPOAuthToken(
 		grant_type: "refresh_token",
 		refresh_token: refreshToken,
 	});
-	if (clientId) params.set("client_id", clientId);
+	const normalizedClientId = clientId?.trim();
+	if (normalizedClientId) params.set("client_id", normalizedClientId);
 	// Drop redundant indicators so refresh stays consistent with the initial
 	// grant; see {@link filterResourceIndicator} for context.
 	const resolvedResource = filterResourceIndicator(resolveResourceUri(resource), filterAnchor, {

--- a/packages/coding-agent/src/mcp/types.ts
+++ b/packages/coding-agent/src/mcp/types.ts
@@ -86,6 +86,7 @@ interface MCPServerConfigBase {
 	oauth?: {
 		clientId?: string;
 		clientSecret?: string;
+		scope?: string;
 		redirectUri?: string;
 		callbackPort?: number;
 		callbackPath?: string;

--- a/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
@@ -858,7 +858,7 @@ export class MCPCommandController {
 			);
 		}
 
-		const resolvedClientId = clientId.trim() || parsedAuthUrl.searchParams.get("client_id") || undefined;
+		const resolvedClientId = clientId.trim() || parsedAuthUrl.searchParams.get("client_id")?.trim() || undefined;
 		const resolvedClientSecret = clientSecret.trim() || undefined;
 
 		const manualInput = this.ctx.oauthManualInput;
@@ -1001,7 +1001,7 @@ export class MCPCommandController {
 				type: "oauth",
 				...credentials,
 				tokenUrl,
-				clientId: flow.resolvedClientId ?? resolvedClientId,
+				clientId: flow.resolvedClientId?.trim() || resolvedClientId,
 				clientSecret: flow.registeredClientSecret ?? resolvedClientSecret,
 				resource: flow.resource,
 				authorizationUrl: flow.authorizationUrl,
@@ -1060,10 +1060,12 @@ export class MCPCommandController {
 			resource?: string;
 			stripSameOriginResource?: boolean;
 			clientId?: string;
+			persistOAuthClientId?: boolean;
 			userClientSecret?: string;
 		},
 	): MCPServerConfig {
-		const clientId = result.clientId ?? opts.clientId ?? config.oauth?.clientId;
+		const clientId = result.clientId?.trim() || opts.clientId?.trim() || config.oauth?.clientId?.trim();
+		const oauthClientId = opts.persistOAuthClientId === false ? undefined : clientId;
 		const resource =
 			result.resource ?? (opts.stripSameOriginResource ? undefined : opts.resource) ?? config.auth?.resource;
 		return {
@@ -1078,7 +1080,7 @@ export class MCPCommandController {
 			},
 			oauth: {
 				...config.oauth,
-				clientId,
+				clientId: oauthClientId,
 			},
 		};
 	}
@@ -1963,16 +1965,33 @@ export class MCPCommandController {
 			// DCR secrets are embedded in the stored credential and never echoed back
 			// into config files.
 			const runtimeAuth = currentAuth ? expandEnvVarsDeep(currentAuth) : undefined;
-			const configuredClientId = runtimeBaseConfig.oauth?.clientId ?? runtimeAuth?.clientId;
+			const configuredClientId = runtimeBaseConfig.oauth?.clientId?.trim() || undefined;
+			const configuredClientSecret = runtimeBaseConfig.oauth?.clientSecret;
 			const existingCredential = lookupMcpOAuthCredentialForServer(authStorage, currentAuth, serverUrl)?.credential;
-			const flowClientId = oauth.clientId ?? configuredClientId ?? existingCredential?.clientId ?? "";
-			const storedClientSecret =
-				existingCredential?.clientId === flowClientId ? existingCredential.clientSecret : undefined;
+			const persistedClientId = runtimeAuth?.clientId?.trim() || undefined;
+			const storedClientId = existingCredential?.clientId?.trim() || undefined;
+			const discoveredClientId = oauth.clientId?.trim() || undefined;
+			// A metadata-advertised client is only a fallback. Prefer DCR when the
+			// authorization server explicitly offers it, while retaining configured
+			// and previously registered client credentials above.
+			const flowClientId =
+				configuredClientId ??
+				persistedClientId ??
+				storedClientId ??
+				(oauth.registrationUrl ? undefined : discoveredClientId) ??
+				"";
+			const storedClientSecret = storedClientId === flowClientId ? existingCredential?.clientSecret : undefined;
 			const flowClientSecret =
-				runtimeBaseConfig.oauth?.clientSecret ?? runtimeAuth?.clientSecret ?? storedClientSecret ?? "";
+				(configuredClientId === flowClientId ? configuredClientSecret : undefined) ??
+				(persistedClientId === flowClientId ? runtimeAuth?.clientSecret : undefined) ??
+				storedClientSecret ??
+				"";
 			// Persisted separately below: keep the raw `${...}` placeholder in the file
 			// rather than writing the resolved secret back to (possibly shared) config.
-			const userClientSecret = found.config.oauth?.clientSecret ?? currentAuth?.clientSecret;
+			const userClientSecret =
+				(configuredClientId === flowClientId ? found.config.oauth?.clientSecret : undefined) ??
+				(persistedClientId === flowClientId ? currentAuth?.clientSecret : undefined);
+			const hasConfiguredOnlySecret = configuredClientId === undefined && configuredClientSecret !== undefined;
 
 			if (!options.silent) {
 				this.#showMessage(["", theme.fg("muted", `Reauthorizing "${name}"...`), ""].join("\n"));
@@ -2016,7 +2035,10 @@ export class MCPCommandController {
 			const updatedConfig = shouldPersist
 				? this.#persistOAuthResult(baseConfig, oauthResult, {
 						tokenUrl: oauth.tokenUrl,
+						// Do not turn a configured-only secret into a persisted oauth
+						// client pair by echoing the discovered client id.
 						clientId: oauth.clientId,
+						persistOAuthClientId: !hasConfiguredOnlySecret,
 						userClientSecret,
 						resource: oauthResource,
 						stripSameOriginResource: oauthResourceIsFallback,

--- a/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
@@ -1988,7 +1988,7 @@ export class MCPCommandController {
 				oauth.tokenUrl,
 				flowClientId,
 				flowClientSecret,
-				oauth.scopes ?? "",
+				oauth.scopes || runtimeBaseConfig.oauth?.scope || "",
 				{
 					callbackPort: found.config.oauth?.callbackPort,
 					callbackPath: found.config.oauth?.callbackPath,

--- a/packages/coding-agent/test/discovery/opencode.test.ts
+++ b/packages/coding-agent/test/discovery/opencode.test.ts
@@ -157,6 +157,38 @@ describe("OpenCode MCP discovery", () => {
 		expect(shared[0]).toMatchObject({ command: "project-jsonc-server", enabled: false });
 	});
 
+	test("preserves OAuth settings from remote OpenCode MCP servers", async () => {
+		await fs.writeFile(
+			path.join(tempDir, "opencode.json"),
+			JSON.stringify({
+				mcp: {
+					service: {
+						type: "remote",
+						url: "https://mcp.example.com/mcp",
+						oauth: {
+							clientId: "configured-client",
+							clientSecret: "configured-secret",
+							scope: "mcp:read mcp:write",
+							redirectUri: "http://127.0.0.1:53192/callback",
+						},
+					},
+				},
+			}),
+		);
+
+		const [server] = await loadOpenCodeMcpConfig(tempDir);
+
+		expect(server).toMatchObject({
+			name: "service",
+			oauth: {
+				clientId: "configured-client",
+				clientSecret: "configured-secret",
+				scope: "mcp:read mcp:write",
+				redirectUri: "http://127.0.0.1:53192/callback",
+			},
+		});
+	});
+
 	test("inherits lower-precedence fields on partial overrides", async () => {
 		const projectDir = path.join(tempDir, "project");
 		const userConfigDir = path.join(tempDir, ".config", "opencode");

--- a/packages/coding-agent/test/mcp-command-reauth.test.ts
+++ b/packages/coding-agent/test/mcp-command-reauth.test.ts
@@ -250,6 +250,18 @@ describe("/mcp auth commands", () => {
 	test("uses tool challenge resource metadata and scopes during reauth", async () => {
 		const authStorage = freshAuthStorage();
 		await authStorage.reload();
+		await Bun.write(
+			configPath,
+			JSON.stringify({
+				mcpServers: {
+					envserver: {
+						type: "http",
+						url: RAW_SERVER_URL,
+						oauth: { scope: "configured.read" },
+					},
+				},
+			}),
+		);
 		vi.spyOn(mcpClient, "connectToServer").mockRejectedValue(new Error("HTTP 401: Unauthorized"));
 
 		const resourceMetadataUrl = "https://gateway.example.com/.well-known/oauth-protected-resource";
@@ -398,6 +410,60 @@ describe("/mcp auth commands", () => {
 			access: "fresh-access",
 			tokenUrl: "https://auth.example.com/token",
 		});
+	});
+
+	test("uses configured OAuth scope when endpoint metadata omits scopes", async () => {
+		const authStorage = freshAuthStorage();
+		await authStorage.reload();
+		await Bun.write(
+			configPath,
+			JSON.stringify({
+				mcpServers: {
+					envserver: {
+						type: "http",
+						url: RAW_SERVER_URL,
+						oauth: { scope: "configured.read configured.write" },
+					},
+				},
+			}),
+		);
+		vi.spyOn(mcpClient, "connectToServer").mockResolvedValue({} as never);
+		vi.spyOn(mcpClient, "disconnectServer").mockResolvedValue(undefined as never);
+
+		const fetchMock = Object.assign(
+			async (input: string | URL | Request): Promise<Response> => {
+				if (String(input) === "https://mcp.example.com/.well-known/oauth-authorization-server") {
+					return new Response(
+						JSON.stringify({
+							authorization_endpoint: "https://auth.example.com/authorize",
+							token_endpoint: "https://auth.example.com/token",
+						}),
+						{ status: 200, headers: { "Content-Type": "application/json" } },
+					);
+				}
+				return new Response("not found", { status: 404 });
+			},
+			{ preconnect: globalThis.fetch.preconnect },
+		);
+		vi.spyOn(globalThis, "fetch").mockImplementation(fetchMock);
+
+		let authorizationUrl = "";
+		vi.spyOn(oauthFlow.MCPOAuthFlow.prototype, "login").mockImplementation(async function (
+			this: oauthFlow.MCPOAuthFlow,
+		) {
+			authorizationUrl = (await this.generateAuthUrl("state", "http://127.0.0.1:53192/callback")).url;
+			return {
+				access: "fresh-access",
+				refresh: "fresh-refresh",
+				expires: Date.now() + 3_600_000,
+			};
+		});
+
+		const { controller, showError } = createController(authStorage);
+		await controller.handle("/mcp reauth envserver");
+
+		expect(showError).not.toHaveBeenCalled();
+		expect(new URL(authorizationUrl).searchParams.get("scope")).toBe("configured.read configured.write");
 	});
 
 	test("reuses embedded DCR client secret during reauth token exchange", async () => {

--- a/packages/coding-agent/test/mcp-command-reauth.test.ts
+++ b/packages/coding-agent/test/mcp-command-reauth.test.ts
@@ -412,6 +412,116 @@ describe("/mcp auth commands", () => {
 		});
 	});
 
+	test("prefers dynamic registration over a metadata-advertised client", async () => {
+		const authStorage = freshAuthStorage();
+		await authStorage.reload();
+		vi.spyOn(mcpClient, "connectToServer").mockResolvedValue({} as never);
+		vi.spyOn(mcpClient, "disconnectServer").mockResolvedValue(undefined as never);
+
+		const registrationRequests: string[] = [];
+		let tokenRequest: URLSearchParams | undefined;
+		const fetchMock = Object.assign(
+			async (input: string | URL | Request, init?: RequestInit | BunFetchRequestInit): Promise<Response> => {
+				const url = String(input);
+				if (url === "https://mcp.example.com/.well-known/oauth-authorization-server") {
+					return new Response(
+						JSON.stringify({
+							authorization_endpoint: "https://auth.example.com/authorize",
+							token_endpoint: "https://auth.example.com/token",
+							registration_endpoint: "https://auth.example.com/register",
+							client_id: "advertised-client",
+						}),
+						{ status: 200, headers: { "Content-Type": "application/json" } },
+					);
+				}
+				if (url === "https://auth.example.com/register" && init?.method === "POST") {
+					registrationRequests.push(String(init.body ?? ""));
+					return new Response(JSON.stringify({ client_id: "dcr-client" }), {
+						status: 201,
+						headers: { "Content-Type": "application/json" },
+					});
+				}
+				if (url === "https://auth.example.com/token" && init?.method === "POST") {
+					tokenRequest = new URLSearchParams(String(init.body ?? ""));
+					return new Response(
+						JSON.stringify({ access_token: "fresh-access", refresh_token: "fresh-refresh", expires_in: 3600 }),
+						{ status: 200, headers: { "Content-Type": "application/json" } },
+					);
+				}
+				return new Response("not found", { status: 404 });
+			},
+			{ preconnect: globalThis.fetch.preconnect },
+		);
+		vi.spyOn(globalThis, "fetch").mockImplementation(fetchMock);
+
+		let authorizationUrl = "";
+		vi.spyOn(oauthFlow.MCPOAuthFlow.prototype, "login").mockImplementation(async function (
+			this: oauthFlow.MCPOAuthFlow,
+		) {
+			authorizationUrl = (await this.generateAuthUrl("state", "http://127.0.0.1/callback")).url;
+			return await this.exchangeToken("authorization-code", "state", "http://127.0.0.1/callback");
+		});
+
+		const { controller, showError } = createController(authStorage);
+		await controller.handle("/mcp reauth envserver");
+
+		expect(showError).not.toHaveBeenCalled();
+		expect(registrationRequests).toHaveLength(1);
+		expect(new URL(authorizationUrl).searchParams.get("client_id")).toBe("dcr-client");
+		expect(tokenRequest?.get("client_id")).toBe("dcr-client");
+		expect(authStorage.get(oauthFlow.mcpOAuthCredentialId(EXPANDED_SERVER_URL))).toMatchObject({
+			clientId: "dcr-client",
+		});
+	});
+
+	test("does not persist a whitespace-only embedded client id", async () => {
+		const authStorage = freshAuthStorage();
+		await authStorage.reload();
+		vi.spyOn(mcpClient, "connectToServer").mockRejectedValue(
+			new Error(
+				'HTTP 401: {"authorization_url":"https://auth.example.com/authorize?client_id=%20%09","token_url":"https://auth.example.com/token"}',
+			),
+		);
+
+		let tokenRequest: URLSearchParams | undefined;
+		const fetchMock = Object.assign(
+			async (input: string | URL | Request, init?: RequestInit | BunFetchRequestInit): Promise<Response> => {
+				if (String(input) === "https://auth.example.com/token" && init?.method === "POST") {
+					tokenRequest = new URLSearchParams(String(init.body ?? ""));
+					return new Response(
+						JSON.stringify({ access_token: "fresh-access", refresh_token: "fresh-refresh", expires_in: 3600 }),
+						{ status: 200, headers: { "Content-Type": "application/json" } },
+					);
+				}
+				return new Response("not found", { status: 404 });
+			},
+			{ preconnect: globalThis.fetch.preconnect },
+		);
+		vi.spyOn(globalThis, "fetch").mockImplementation(fetchMock);
+
+		let authorizationUrl = "";
+		vi.spyOn(oauthFlow.MCPOAuthFlow.prototype, "login").mockImplementation(async function (
+			this: oauthFlow.MCPOAuthFlow,
+		) {
+			authorizationUrl = (await this.generateAuthUrl("state", "http://127.0.0.1/callback")).url;
+			return await this.exchangeToken("authorization-code", "state", "http://127.0.0.1/callback");
+		});
+
+		const { controller, showError } = createController(authStorage);
+		await controller.handle("/mcp reauth envserver");
+
+		expect(showError).not.toHaveBeenCalled();
+		expect(new URL(authorizationUrl).searchParams.get("client_id")).toBeNull();
+		expect(tokenRequest?.has("client_id")).toBe(false);
+		const savedCredential = authStorage.get(oauthFlow.mcpOAuthCredentialId(EXPANDED_SERVER_URL)) as
+			| oauthFlow.MCPStoredOAuthCredential
+			| undefined;
+		expect(savedCredential).toMatchObject({ type: "oauth", access: "fresh-access" });
+		expect(savedCredential?.clientId).toBeUndefined();
+		const saved = JSON.parse(await Bun.file(configPath).text()) as TestConfigFile;
+		expect(saved.mcpServers?.envserver?.auth?.clientId).toBeUndefined();
+	});
+
 	test("uses configured OAuth scope when endpoint metadata omits scopes", async () => {
 		const authStorage = freshAuthStorage();
 		await authStorage.reload();
@@ -466,6 +576,170 @@ describe("/mcp auth commands", () => {
 		expect(new URL(authorizationUrl).searchParams.get("scope")).toBe("configured.read configured.write");
 	});
 
+	test("uses configured OAuth client credentials as a pair when discovery advertises another client", async () => {
+		const authStorage = freshAuthStorage();
+		await authStorage.reload();
+		await Bun.write(
+			configPath,
+			JSON.stringify({
+				mcpServers: {
+					envserver: {
+						type: "http",
+						url: RAW_SERVER_URL,
+						auth: { type: "oauth" },
+						oauth: { clientId: "configured-client", clientSecret: "configured-secret" },
+					},
+				},
+			}),
+		);
+		vi.spyOn(mcpClient, "connectToServer").mockResolvedValue({} as never);
+		vi.spyOn(mcpClient, "disconnectServer").mockResolvedValue(undefined as never);
+
+		let tokenRequest: URLSearchParams | undefined;
+		const fetchMock = Object.assign(
+			async (input: string | URL | Request, init?: RequestInit | BunFetchRequestInit): Promise<Response> => {
+				const url = String(input);
+				if (url === "https://mcp.example.com/.well-known/oauth-authorization-server") {
+					return new Response(
+						JSON.stringify({
+							authorization_endpoint: "https://auth.example.com/authorize?client_id=embedded-client",
+							token_endpoint: "https://auth.example.com/token",
+							client_id: "discovered-client",
+						}),
+						{ status: 200, headers: { "Content-Type": "application/json" } },
+					);
+				}
+				if (url === "https://auth.example.com/token" && init?.method === "POST") {
+					tokenRequest = new URLSearchParams(String(init.body ?? ""));
+					return new Response(
+						JSON.stringify({
+							access_token: "fresh-access",
+							refresh_token: "fresh-refresh",
+							expires_in: 3600,
+						}),
+						{ status: 200, headers: { "Content-Type": "application/json" } },
+					);
+				}
+				return new Response("not found", { status: 404 });
+			},
+			{ preconnect: globalThis.fetch.preconnect },
+		);
+		vi.spyOn(globalThis, "fetch").mockImplementation(fetchMock);
+
+		let authorizationUrl = "";
+		vi.spyOn(oauthFlow.MCPOAuthFlow.prototype, "login").mockImplementation(async function (
+			this: oauthFlow.MCPOAuthFlow,
+		) {
+			authorizationUrl = (await this.generateAuthUrl("state", "http://127.0.0.1/callback")).url;
+			return await this.exchangeToken("authorization-code", "state", "http://127.0.0.1/callback");
+		});
+
+		const { controller, showError } = createController(authStorage);
+		await controller.handle("/mcp reauth envserver");
+
+		expect(showError).not.toHaveBeenCalled();
+		expect(new URL(authorizationUrl).searchParams.get("client_id")).toBe("configured-client");
+		expect(tokenRequest?.get("client_id")).toBe("configured-client");
+		expect(tokenRequest?.get("client_secret")).toBe("configured-secret");
+		const saved = JSON.parse(await Bun.file(configPath).text()) as TestConfigFile;
+		expect(saved.mcpServers?.envserver?.auth).toEqual(
+			expect.objectContaining({ clientId: "configured-client", clientSecret: "configured-secret" }),
+		);
+		expect(saved.mcpServers?.envserver?.oauth).toEqual(
+			expect.objectContaining({ clientId: "configured-client", clientSecret: "configured-secret" }),
+		);
+	});
+
+	test("does not persist or reuse a configured-only OAuth secret", async () => {
+		const authStorage = freshAuthStorage();
+		await authStorage.reload();
+		await Bun.write(
+			configPath,
+			JSON.stringify({
+				mcpServers: {
+					envserver: {
+						type: "http",
+						url: RAW_SERVER_URL,
+						auth: { type: "oauth" },
+						oauth: { clientId: " \t ", clientSecret: "configured-secret" },
+					},
+				},
+			}),
+		);
+		vi.spyOn(mcpClient, "connectToServer").mockResolvedValue({} as never);
+		vi.spyOn(mcpClient, "disconnectServer").mockResolvedValue(undefined as never);
+
+		const tokenRequests: URLSearchParams[] = [];
+		const fetchMock = Object.assign(
+			async (input: string | URL | Request, init?: RequestInit | BunFetchRequestInit): Promise<Response> => {
+				const url = String(input);
+				if (url === "https://mcp.example.com/.well-known/oauth-authorization-server") {
+					return new Response(
+						JSON.stringify({
+							authorization_endpoint: "https://auth.example.com/authorize",
+							token_endpoint: "https://auth.example.com/token",
+							client_id: "discovered-client",
+						}),
+						{ status: 200, headers: { "Content-Type": "application/json" } },
+					);
+				}
+				if (url === "https://auth.example.com/token" && init?.method === "POST") {
+					tokenRequests.push(new URLSearchParams(String(init.body ?? "")));
+					return new Response(
+						JSON.stringify({
+							access_token: "fresh-access",
+							refresh_token: "fresh-refresh",
+							expires_in: 3600,
+						}),
+						{ status: 200, headers: { "Content-Type": "application/json" } },
+					);
+				}
+				return new Response("not found", { status: 404 });
+			},
+			{ preconnect: globalThis.fetch.preconnect },
+		);
+		vi.spyOn(globalThis, "fetch").mockImplementation(fetchMock);
+
+		const authorizationUrls: URL[] = [];
+		vi.spyOn(oauthFlow.MCPOAuthFlow.prototype, "login").mockImplementation(async function (
+			this: oauthFlow.MCPOAuthFlow,
+		) {
+			authorizationUrls.push(new URL((await this.generateAuthUrl("state", "http://127.0.0.1/callback")).url));
+			return await this.exchangeToken("authorization-code", "state", "http://127.0.0.1/callback");
+		});
+
+		const { controller, showError } = createController(authStorage);
+		await controller.handle("/mcp reauth envserver");
+
+		expect(showError).not.toHaveBeenCalled();
+		expect(authorizationUrls[0]?.searchParams.get("client_id")).toBe("discovered-client");
+		expect(tokenRequests[0]?.get("client_id")).toBe("discovered-client");
+		expect(tokenRequests[0]?.has("client_secret")).toBe(false);
+		const savedAfterFirstReauth = JSON.parse(await Bun.file(configPath).text()) as TestConfigFile;
+		const savedAuth = savedAfterFirstReauth.mcpServers?.envserver?.auth;
+		expect(savedAuth).toEqual(expect.objectContaining({ clientId: "discovered-client" }));
+		expect(savedAuth?.clientSecret).toBeUndefined();
+		expect(savedAfterFirstReauth.mcpServers?.envserver?.oauth?.clientId).toBeUndefined();
+
+		await controller.handle("/mcp reauth envserver");
+
+		expect(showError).not.toHaveBeenCalled();
+		expect(authorizationUrls[1]?.searchParams.get("client_id")).toBe("discovered-client");
+		expect(tokenRequests[1]?.get("client_id")).toBe("discovered-client");
+		expect(tokenRequests[1]?.has("client_secret")).toBe(false);
+		const savedAfterSecondReauth = JSON.parse(await Bun.file(configPath).text()) as TestConfigFile;
+		const savedAuthAfterSecondReauth = savedAfterSecondReauth.mcpServers?.envserver?.auth;
+		expect(savedAuthAfterSecondReauth).toEqual(expect.objectContaining({ clientId: "discovered-client" }));
+		expect(savedAuthAfterSecondReauth?.clientSecret).toBeUndefined();
+		expect(savedAfterSecondReauth.mcpServers?.envserver?.oauth?.clientId).toBeUndefined();
+		expect(savedAfterSecondReauth.mcpServers?.envserver?.oauth?.clientSecret).toBe("configured-secret");
+		const savedCredentialAfterSecond = authStorage.get(oauthFlow.mcpOAuthCredentialId(EXPANDED_SERVER_URL)) as
+			| oauthFlow.MCPStoredOAuthCredential
+			| undefined;
+		expect(savedCredentialAfterSecond).toMatchObject({ clientId: "discovered-client" });
+		expect(savedCredentialAfterSecond?.clientSecret).toBeUndefined();
+	});
+
 	test("reuses embedded DCR client secret during reauth token exchange", async () => {
 		const authStorage = freshAuthStorage();
 		await authStorage.reload();
@@ -479,27 +753,55 @@ describe("/mcp auth commands", () => {
 			clientSecret: "dcr-secret",
 			resource: EXPANDED_SERVER_URL,
 		} as oauthFlow.MCPStoredOAuthCredential);
-		const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
-			new Response(
-				JSON.stringify({
-					access_token: "fresh-access",
-					refresh_token: "fresh-refresh",
-					expires_in: 3600,
-					token_type: "Bearer",
-				}),
-				{ status: 200, headers: { "Content-Type": "application/json" } },
+		const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(
+			Object.assign(
+				async (input: string | URL | Request, init?: RequestInit | BunFetchRequestInit): Promise<Response> => {
+					const url = String(input);
+					if (url === "https://mcp.example.com/.well-known/oauth-authorization-server") {
+						return new Response(
+							JSON.stringify({
+								authorization_endpoint: "https://auth.example.com/authorize?client_id=discovered-client",
+								token_endpoint: "https://auth.example.com/token",
+								client_id: "discovered-client",
+							}),
+							{ status: 200, headers: { "Content-Type": "application/json" } },
+						);
+					}
+					if (url === "https://auth.example.com/token" && init?.method === "POST") {
+						return new Response(
+							JSON.stringify({
+								access_token: "fresh-access",
+								refresh_token: "fresh-refresh",
+								expires_in: 3600,
+								token_type: "Bearer",
+							}),
+							{ status: 200, headers: { "Content-Type": "application/json" } },
+						);
+					}
+					return new Response("not found", { status: 404 });
+				},
+				{ preconnect: globalThis.fetch.preconnect },
 			),
 		);
-		vi.spyOn(mcpClient, "connectToServer").mockRejectedValue(AUTH_ERROR);
-		vi.spyOn(oauthFlow.MCPOAuthFlow.prototype, "login").mockImplementation(function (this: oauthFlow.MCPOAuthFlow) {
-			return this.exchangeToken("authorization-code", "state", "http://127.0.0.1/callback");
+		vi.spyOn(mcpClient, "connectToServer").mockResolvedValue({} as never);
+		vi.spyOn(mcpClient, "disconnectServer").mockResolvedValue(undefined as never);
+		let authorizationUrl = "";
+		vi.spyOn(oauthFlow.MCPOAuthFlow.prototype, "login").mockImplementation(async function (
+			this: oauthFlow.MCPOAuthFlow,
+		) {
+			authorizationUrl = (await this.generateAuthUrl("state", "http://127.0.0.1/callback")).url;
+			return await this.exchangeToken("authorization-code", "state", "http://127.0.0.1/callback");
 		});
 		const { controller, showError } = createController(authStorage);
 
 		await controller.handle("/mcp reauth envserver");
 
 		expect(showError).not.toHaveBeenCalled();
-		const tokenRequestBody = String(fetchSpy.mock.calls[0]?.[1]?.body ?? "");
+		expect(new URL(authorizationUrl).searchParams.get("client_id")).toBe("dcr-client");
+		const tokenRequestCall = fetchSpy.mock.calls.find(
+			call => String(call[0]) === "https://auth.example.com/token" && call[1]?.method === "POST",
+		);
+		const tokenRequestBody = String(tokenRequestCall?.[1]?.body ?? "");
 		const tokenRequest = new URLSearchParams(tokenRequestBody);
 		expect(tokenRequest.get("client_id")).toBe("dcr-client");
 		expect(tokenRequest.get("client_secret")).toBe("dcr-secret");

--- a/packages/coding-agent/test/oauth-flow.test.ts
+++ b/packages/coding-agent/test/oauth-flow.test.ts
@@ -84,6 +84,21 @@ describe("mcp oauth flow", () => {
 		expect(authUrl.searchParams.get("state")).toBe("test-state");
 	});
 
+	it("removes a whitespace-only embedded client id before authorization", async () => {
+		const flow = new MCPOAuthFlow(
+			{
+				authorizationUrl: "https://provider.example/authorize?client_id=%20%09",
+				tokenUrl: "https://provider.example/token",
+				fetch: async () => new Response("not found", { status: 404 }),
+			},
+			{},
+		);
+
+		const { url } = await flow.generateAuthUrl("test-state", "http://127.0.0.1:53174/callback");
+
+		expect(new URL(url).searchParams.get("client_id")).toBeNull();
+	});
+
 	it("includes discovered scopes in dynamic client registration", async () => {
 		let registrationPayload: Record<string, unknown> | null = null;
 		const scopes = "openid profile email offline_access";
@@ -868,6 +883,17 @@ describe("mcp oauth flow", () => {
 
 		expect(tokenParams.get("grant_type")).toBe("refresh_token");
 		expect(tokenParams.get("resource")).toBeNull();
+	});
+	it("omits a whitespace-only client id from token refresh", async () => {
+		let tokenRequestBody = "";
+
+		await refreshMCPOAuthToken("https://provider.example/token", "refresh-token", " \t ", undefined, {
+			fetch: mockProviderTokenEndpoint(body => {
+				tokenRequestBody = body;
+			}),
+		});
+
+		expect(new URLSearchParams(tokenRequestBody).has("client_id")).toBe(false);
 	});
 	describe("RFC 8707 resource indicator", () => {
 		// Provider-advertised resource indicators are authoritative, including


### PR DESCRIPTION
## Summary

- Preserve OpenCode MCP OAuth client settings, scope, and redirect URI during discovery.
- Use configured OAuth scope during reauth only when discovery provides none.
- Add focused discovery and reauth regression coverage.

## Validation

- `bun test packages/coding-agent/test/discovery/opencode.test.ts packages/coding-agent/test/mcp-command-reauth.test.ts packages/coding-agent/test/oauth-discovery.test.ts`
- `bun --cwd=packages/coding-agent run check`

The focused suite passed 46 tests. The broader coding-agent suite passed the changed MCP/discovery chunks; unrelated existing failures remain in HTML template byte snapshots and process-exit tests returning 137.