### PR TITLE
fix(rpc): nested subagent frames never reach RPC/observer surfaces (depth >= 2 invisible)

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 
+- Fixed RPC subagent subscriptions and the subagent HUD missing agents spawned by another subagent (depth >= 2): lifecycle, progress, and event frames are now published on a per-session observability bus inherited by every spawned agent in the session tree while per-session extension buses stay isolated, so nested agents appear in `get_subagents`, the `subagent_*` event stream, and `get_subagent_messages` ([#9952](https://github.com/can1357/oh-my-pi/pull/9952)).
 - Fixed corrupt session headers silently overwriting recoverable transcripts during resume ([#9915](https://github.com/can1357/oh-my-pi/issues/9915)).
 - Fixed a startup race that left a new session with almost no tools and an empty skill inventory. An early reconcile could commit a small live tool set as the permanent enabled set. The enabled set is now seeded from the construction-time tool slate, and `reconcileCodeMode` samples it inside the registry mutation lock.
 - Fixed `snapcompact` compaction frames larger than the persistence limit being truncated into invalid image base64 on session resume, which made the provider reject every subsequent request with HTTP 400; already-corrupted archives now resume from their retained source text instead ([#9901](https://github.com/can1357/oh-my-pi/issues/9901)).

--- a/packages/coding-agent/src/collab/guest.ts
+++ b/packages/coding-agent/src/collab/guest.ts
@@ -25,6 +25,7 @@ import { AgentRegistry } from "../registry/agent-registry";
 import type { AgentSessionEvent } from "../session/agent-session";
 import type { SessionEntry } from "../session/session-entries";
 import { shouldDisableReasoning, toReasoningEffort } from "../thinking";
+import { emitSubagentFrame } from "../utils/event-bus";
 import { setSessionTerminalTitle } from "../utils/title-generator";
 import { importRoomKey } from "./crypto";
 import { collabDisplayName } from "./display-name";
@@ -531,8 +532,9 @@ export class CollabGuestLink {
 			}
 			case "bus":
 				// Mirrored host EventBus traffic (task subagent lifecycle/progress)
-				// feeding the observer HUD and Agent Hub progress columns.
-				this.#ctx.eventBus?.emit(frame.channel, frame.data);
+				// feeding the observer HUD and Agent Hub progress columns. The
+				// observer registry listens on the shared observability bus.
+				emitSubagentFrame(this.#ctx.eventBus, this.#ctx.subagentEventBus, frame.channel, frame.data);
 				break;
 			case "agents":
 				this.#applyAgentSnapshots(frame.agents);

--- a/packages/coding-agent/src/collab/host.ts
+++ b/packages/coding-agent/src/collab/host.ts
@@ -272,10 +272,16 @@ export class CollabHost {
 			if (isWireAgentEvent(event)) this.#broadcast({ t: "event", event: shrinkForReplication(event) });
 			this.#onEventForState(event);
 		});
-		const bus = this.#ctx.eventBus;
-		if (bus) {
+		// Subagent frames publish on the session tree's observability bus at
+		// any spawn depth; mirroring from it is what lets nested agents reach
+		// guests at all. Embedders on the previous constructor signature only
+		// wire a session bus — fall back to it so depth-1 frames keep flowing.
+		const observabilityBus = this.#ctx.subagentEventBus ?? this.#ctx.eventBus;
+		if (observabilityBus) {
 			for (const channel of COLLAB_BUS_CHANNELS) {
-				this.#busUnsubscribers.push(bus.on(channel, data => this.#broadcast({ t: "bus", channel, data })));
+				this.#busUnsubscribers.push(
+					observabilityBus.on(channel, data => this.#broadcast({ t: "bus", channel, data })),
+				);
 			}
 		}
 		this.#registryUnsubscribe = AgentRegistry.global().onChange(() => this.#scheduleAgentsBroadcast());

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -114,7 +114,7 @@ type RunPrintMode = (session: AgentSession, options: PrintModeOptions) => Promis
 type RunRpcMode = (
 	session: AgentSession,
 	setToolUIContext?: (uiContext: ExtensionUIContext, hasUI: boolean) => void,
-	eventBus?: EventBus,
+	subagentEventBus?: EventBus,
 	input?: ReadableStream<Uint8Array>,
 ) => Promise<never>;
 
@@ -492,6 +492,7 @@ async function runInteractiveMode(
 	forceSetupWizard: boolean,
 	showStartupSplash: boolean,
 	eventBus?: EventBus,
+	subagentEventBus?: EventBus,
 	initialMessage?: string,
 	initialImages?: ImageContent[],
 	joinLink?: string,
@@ -509,6 +510,7 @@ async function runInteractiveMode(
 			mcpManager,
 			eventBus,
 			startupLease?.composer,
+			subagentEventBus,
 		);
 		startupLease?.adopt();
 	} catch (error) {
@@ -1877,6 +1879,7 @@ export async function runRootCommand(
 			}
 
 			const eventBus = new EventBus();
+			const subagentEventBus = new EventBus();
 			const extensionsResult = parsedArgs.trustedExtensions?.length
 				? await loadTrustedSessionExtensions(sessionOptions, cwd, eventBus)
 				: await loadSessionExtensions(sessionOptions, cwd, settingsInstance, eventBus);
@@ -1956,6 +1959,7 @@ export async function runRootCommand(
 			} = await createSession({
 				...sessionOptions,
 				eventBus,
+				subagentEventBus,
 				preloadedExtensions: extensionsResult,
 			});
 
@@ -1981,6 +1985,7 @@ export async function runRootCommand(
 					settings: settingsInstance,
 					enableLsp: sessionOptions.enableLsp ?? true,
 					eventBus,
+					subagentEventBus,
 				}),
 				Math.trunc(Number(settingsInstance.get("task.agentIdleTtlMs") ?? 420_000) || 0),
 			);
@@ -2029,7 +2034,7 @@ export async function runRootCommand(
 				// Branch-only protocol runner: keep RPC host code out of normal interactive startup.
 				const runRpcMode: RunRpcMode = (await import("./modes/rpc/rpc-mode")).runRpcMode;
 				stopStartupWatchdog();
-				await runRpcMode(session, mode === "rpc-ui" ? setToolUIContext : undefined, eventBus, rpcInput);
+				await runRpcMode(session, mode === "rpc-ui" ? setToolUIContext : undefined, subagentEventBus, rpcInput);
 			} else if (isInteractive) {
 				const versionCheckPromise = checkForNewVersion(VERSION).catch(() => undefined);
 				const startupChangelog = await startupChangelogPromise;
@@ -2069,6 +2074,7 @@ export async function runRootCommand(
 						deps.forceSetupWizard === true,
 						showStartupSplash,
 						eventBus,
+						subagentEventBus,
 						initialMessage,
 						initialImages,
 						parsedArgs.join,

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -822,6 +822,7 @@ export class InteractiveMode implements InteractiveModeContext {
 	#resizeHandler?: () => void;
 	#observerRegistry: SessionObserverRegistry;
 	#eventBus?: EventBus;
+	#subagentEventBus?: EventBus;
 	#eventBusUnsubscribers: Array<() => void> = [];
 	#observerUiSyncTimer?: NodeJS.Timeout;
 	#observerUiSyncNeedsTodoReconcile = false;
@@ -833,6 +834,11 @@ export class InteractiveMode implements InteractiveModeContext {
 	#mcpFailedServers = new Map<string, { error: string; sourcePath?: string }>();
 	readonly #chatHost: ChatBlockHost = { requestRender: () => this.ui.requestRender() };
 
+	/** Root-scoped bus carrying this session tree's `task:subagent:*` frames. */
+	get subagentEventBus(): EventBus | undefined {
+		return this.#subagentEventBus;
+	}
+
 	constructor(
 		session: AgentSession,
 		version: string,
@@ -842,6 +848,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		mcpManager?: MCPManager,
 		eventBus?: EventBus,
 		composer?: Composer,
+		subagentEventBus?: EventBus,
 	) {
 		this.session = session;
 		this.sessionManager = session.sessionManager;
@@ -892,6 +899,7 @@ export class InteractiveMode implements InteractiveModeContext {
 			new MCPCommandController(this).handleMCPAuthChallenge(serverName, challenge),
 		);
 		this.#eventBus = eventBus;
+		this.#subagentEventBus = subagentEventBus;
 		if (eventBus) {
 			this.#eventBusUnsubscribers.push(
 				eventBus.on(LSP_STARTUP_EVENT_CHANNEL, data => {
@@ -1212,7 +1220,7 @@ export class InteractiveMode implements InteractiveModeContext {
 
 		// Wire observer registry to EventBus
 		if (this.#eventBus) {
-			this.#observerRegistry.subscribeToEventBus(this.#eventBus);
+			this.#observerRegistry.subscribeToEventBus(this.#eventBus, this.#subagentEventBus ?? this.#eventBus);
 		}
 		this.#observerRegistry.setMainSession(this.sessionManager.getSessionFile() ?? undefined);
 		this.syncRunningSubagentBadge();

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -699,7 +699,7 @@ export function requestRpcDialog<T>(
 export async function runRpcMode(
 	session: AgentSession,
 	setToolUIContext?: (uiContext: ExtensionUIContext, hasUI: boolean) => void,
-	eventBus?: EventBus,
+	subagentEventBus?: EventBus,
 	input: ReadableStream<Uint8Array> = claimRpcInput(),
 ): Promise<never> {
 	// Signal to RPC clients that the server is ready to accept commands
@@ -760,7 +760,7 @@ export async function runRpcMode(
 	const pendingExtensionRequests = new RpcPendingExtensionRequests();
 	const hostToolBridge = new RpcHostToolBridge(output);
 	const hostUriBridge = new RpcHostUriBridge(output);
-	const subagentRegistry = eventBus ? new RpcSubagentRegistry(eventBus, output) : undefined;
+	const subagentRegistry = subagentEventBus ? new RpcSubagentRegistry(subagentEventBus, output) : undefined;
 
 	// Shutdown request flag (wrapped in object to allow mutation with const)
 	const shutdownState = { requested: false };

--- a/packages/coding-agent/src/modes/rpc/rpc-subagents.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-subagents.ts
@@ -112,16 +112,16 @@ export class RpcSubagentRegistry {
 	#output: RpcSubagentOutput;
 	#subscriptionLevel: RpcSubagentSubscriptionLevel = "off";
 
-	constructor(eventBus: EventBus, output: RpcSubagentOutput) {
+	constructor(observabilityBus: EventBus, output: RpcSubagentOutput) {
 		this.#output = output;
 		this.#unsubscribers.push(
-			eventBus.on(TASK_SUBAGENT_LIFECYCLE_CHANNEL, data => {
+			observabilityBus.on(TASK_SUBAGENT_LIFECYCLE_CHANNEL, data => {
 				this.handleLifecycle(data as SubagentLifecyclePayload);
 			}),
-			eventBus.on(TASK_SUBAGENT_PROGRESS_CHANNEL, data => {
+			observabilityBus.on(TASK_SUBAGENT_PROGRESS_CHANNEL, data => {
 				this.handleProgress(data as SubagentProgressPayload);
 			}),
-			eventBus.on(TASK_SUBAGENT_EVENT_CHANNEL, data => {
+			observabilityBus.on(TASK_SUBAGENT_EVENT_CHANNEL, data => {
 				this.handleEvent(data as SubagentEventPayload);
 			}),
 		);

--- a/packages/coding-agent/src/modes/session-observer-registry.ts
+++ b/packages/coding-agent/src/modes/session-observer-registry.ts
@@ -142,82 +142,106 @@ export class SessionObserverRegistry {
 		this.#listeners.clear();
 	}
 
-	subscribeToEventBus(eventBus: EventBus): void {
+	subscribeToEventBus(eventBus: EventBus, subagentEventBus: EventBus): void {
 		// Dispose previous EventBus subscriptions if called again
 		for (const unsub of this.#eventBusUnsubscribers) unsub();
 		this.#eventBusUnsubscribers = [];
 
-		this.#eventBusUnsubscribers.push(
-			eventBus.on(TASK_SUBAGENT_LIFECYCLE_CHANNEL, data => {
-				const payload = data as SubagentLifecyclePayload;
-				const status = STATUS_MAP[payload.status];
-				if (!status) return;
-
-				const sortOrder = this.#ensureSortOrder(payload.id);
-				this.#ensureParentSortOrder(payload.parentToolCallId, sortOrder);
-				const existing = this.#sessions.get(payload.id);
-				if (existing) {
-					existing.status = status;
-					existing.lastUpdate = Date.now();
-					existing.index = payload.index;
-					existing.parentToolCallId = payload.parentToolCallId ?? existing.parentToolCallId;
-					existing.detached = payload.detached ?? existing.detached;
-					if (payload.description) existing.description = payload.description;
-					if (payload.sessionFile) existing.sessionFile = payload.sessionFile;
-				} else {
-					this.#sessions.set(payload.id, {
-						id: payload.id,
-						kind: "subagent",
-						label: payload.description ?? `Subagent #${payload.index}`,
-						agent: payload.agent,
-						description: payload.description,
-						status,
-						sessionFile: payload.sessionFile,
-						parentToolCallId: payload.parentToolCallId,
-						detached: payload.detached,
-						index: payload.index,
-						lastUpdate: Date.now(),
-					});
+		// The task executor dual-publishes every frame on the spawning session's
+		// bus and on the session tree's observability bus. Subscribe to both so
+		// producers that only emit on the injected session bus still land —
+		// dual-published payloads share one object reference, so each is handled
+		// exactly once.
+		const seen = new WeakSet<object>();
+		const dedupe =
+			(handle: (data: unknown) => void) =>
+			(data: unknown): void => {
+				if (data !== null && typeof data === "object") {
+					if (seen.has(data as object)) return;
+					seen.add(data as object);
 				}
-				this.#notifyListeners("lifecycle");
-			}),
-		);
+				handle(data);
+			};
 
-		this.#eventBusUnsubscribers.push(
-			eventBus.on(TASK_SUBAGENT_PROGRESS_CHANNEL, data => {
-				const payload = data as SubagentProgressPayload;
-				const progress = payload.progress;
-				const id = progress.id;
-				const existing = this.#sessions.get(id);
+		for (const bus of [eventBus, subagentEventBus]) {
+			this.#eventBusUnsubscribers.push(
+				bus.on(
+					TASK_SUBAGENT_LIFECYCLE_CHANNEL,
+					dedupe(data => {
+						const payload = data as SubagentLifecyclePayload;
+						const status = STATUS_MAP[payload.status];
+						if (!status) return;
 
-				const sortOrder = this.#ensureSortOrder(id);
-				this.#ensureParentSortOrder(payload.parentToolCallId, sortOrder);
-				if (existing) {
-					existing.lastUpdate = Date.now();
-					existing.index = payload.index;
-					existing.parentToolCallId = payload.parentToolCallId ?? existing.parentToolCallId;
-					existing.detached = payload.detached ?? existing.detached;
-					existing.progress = progress;
-					if (progress.description) existing.description = progress.description;
-					if (payload.sessionFile) existing.sessionFile = payload.sessionFile;
-				} else {
-					this.#sessions.set(id, {
-						id,
-						kind: "subagent",
-						label: progress.description ?? `Subagent #${payload.index}`,
-						agent: payload.agent,
-						description: progress.description,
-						status: "active",
-						sessionFile: payload.sessionFile,
-						parentToolCallId: payload.parentToolCallId,
-						detached: payload.detached,
-						index: payload.index,
-						lastUpdate: Date.now(),
-						progress,
-					});
-				}
-				this.#notifyListeners("progress");
-			}),
-		);
+						const sortOrder = this.#ensureSortOrder(payload.id);
+						this.#ensureParentSortOrder(payload.parentToolCallId, sortOrder);
+						const existing = this.#sessions.get(payload.id);
+						if (existing) {
+							existing.status = status;
+							existing.lastUpdate = Date.now();
+							existing.index = payload.index;
+							existing.parentToolCallId = payload.parentToolCallId ?? existing.parentToolCallId;
+							existing.detached = payload.detached ?? existing.detached;
+							if (payload.description) existing.description = payload.description;
+							if (payload.sessionFile) existing.sessionFile = payload.sessionFile;
+						} else {
+							this.#sessions.set(payload.id, {
+								id: payload.id,
+								kind: "subagent",
+								label: payload.description ?? `Subagent #${payload.index}`,
+								agent: payload.agent,
+								description: payload.description,
+								status,
+								sessionFile: payload.sessionFile,
+								parentToolCallId: payload.parentToolCallId,
+								detached: payload.detached,
+								index: payload.index,
+								lastUpdate: Date.now(),
+							});
+						}
+						this.#notifyListeners("lifecycle");
+					}),
+				),
+			);
+
+			this.#eventBusUnsubscribers.push(
+				bus.on(
+					TASK_SUBAGENT_PROGRESS_CHANNEL,
+					dedupe(data => {
+						const payload = data as SubagentProgressPayload;
+						const progress = payload.progress;
+						const id = progress.id;
+						const existing = this.#sessions.get(id);
+
+						const sortOrder = this.#ensureSortOrder(id);
+						this.#ensureParentSortOrder(payload.parentToolCallId, sortOrder);
+						if (existing) {
+							existing.lastUpdate = Date.now();
+							existing.index = payload.index;
+							existing.parentToolCallId = payload.parentToolCallId ?? existing.parentToolCallId;
+							existing.detached = payload.detached ?? existing.detached;
+							existing.progress = progress;
+							if (progress.description) existing.description = progress.description;
+							if (payload.sessionFile) existing.sessionFile = payload.sessionFile;
+						} else {
+							this.#sessions.set(id, {
+								id,
+								kind: "subagent",
+								label: progress.description ?? `Subagent #${payload.index}`,
+								agent: payload.agent,
+								description: progress.description,
+								status: "active",
+								sessionFile: payload.sessionFile,
+								parentToolCallId: payload.parentToolCallId,
+								detached: payload.detached,
+								index: payload.index,
+								lastUpdate: Date.now(),
+								progress,
+							});
+						}
+						this.#notifyListeners("progress");
+					}),
+				),
+			);
+		}
 	}
 }

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -153,6 +153,8 @@ export interface InteractiveModeContext {
 	collabGuest?: CollabGuestLink;
 	eventController: EventController;
 	eventBus?: EventBus;
+	/** Root-scoped bus carrying this session tree's `task:subagent:*` frames. */
+	subagentEventBus?: EventBus;
 
 	// State
 	isInitialized: boolean;

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -496,6 +496,13 @@ export interface CreateAgentSessionOptions {
 	/** Shared event bus for tool/extension communication. Default: creates new bus. */
 	eventBus?: EventBus;
 
+	/**
+	 * Root-scoped bus carrying `task:subagent:*` observability frames for this
+	 * session and every subagent it spawns. Default: creates a new bus per
+	 * root session; `buildSubagentSessionOptions` inherits the spawner's.
+	 */
+	subagentEventBus?: EventBus;
+
 	/** Skills. Default: discovered from multiple locations */
 	skills?: Skill[];
 	/** Rules. Default: discovered from multiple locations */
@@ -646,6 +653,8 @@ export interface CreateAgentSessionResult {
 	startBackgroundModelDiscovery?: () => Promise<void>;
 	/** Shared event bus for tool/extension communication */
 	eventBus: EventBus;
+	/** Root-scoped bus carrying this session tree's `task:subagent:*` frames. */
+	subagentEventBus?: EventBus;
 }
 
 export type DialectFormat = "auto" | "native" | Dialect;
@@ -1277,6 +1286,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 	const cwd = options.cwd ?? getProjectDir();
 	const agentDir = options.agentDir ?? getAgentDir();
 	const eventBus = options.eventBus ?? new EventBus();
+	const subagentEventBus = options.subagentEventBus ?? new EventBus();
 
 	registerSshCleanup();
 	registerEvalCleanup();
@@ -1774,6 +1784,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			refreshSkills: () => session.refreshSkills(),
 			rules: allRules,
 			eventBus,
+			subagentEventBus,
 			outputSchema: options.outputSchema,
 			outputSchemaMode: options.outputSchemaMode,
 			requireYieldTool: options.requireYieldTool,
@@ -4188,6 +4199,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			lspServers,
 			startBackgroundModelDiscovery: startRuntimeDiscovery,
 			eventBus,
+			subagentEventBus,
 		};
 	} catch (error) {
 		// Release the subscription if the throw happened after install but before the

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -61,7 +61,7 @@ import { DEFAULT_HUB_LIST_LIMIT } from "../tools/hub/types";
 import { normalizeSchema } from "../tools/jtd-to-json-schema";
 import { buildOutputValidator, summarizeValidationFailure } from "../tools/output-schema-validator";
 import { ToolAbortError } from "../tools/tool-errors";
-import type { EventBus } from "../utils/event-bus";
+import { type EventBus, emitSubagentFrame } from "../utils/event-bus";
 import { trackLateCleanup } from "../utils/late-cleanup";
 import { buildNamedToolChoice } from "../utils/tool-choice";
 import type { WorkspaceTree } from "../workspace-tree";
@@ -473,6 +473,7 @@ export interface ExecutorOptions {
 	persistArtifacts?: boolean;
 	artifactsDir?: string;
 	eventBus?: EventBus;
+	subagentEventBus?: EventBus;
 	contextFiles?: ContextFileEntry[];
 	skills?: Skill[];
 	promptTemplates?: PromptTemplate[];
@@ -981,6 +982,7 @@ interface RunMonitorArgs {
 	signal?: AbortSignal;
 	onProgress?: (progress: AgentProgress) => void;
 	eventBus?: EventBus;
+	subagentEventBus?: EventBus;
 	parentToolCallId?: string;
 	detached?: boolean;
 	sessionFile?: string;
@@ -1316,19 +1318,18 @@ function createSubagentRunMonitor(args: RunMonitorArgs): SubagentRunMonitor {
 		const activityGist =
 			progress.lastIntent ?? (progress.currentTool ? `running ${progress.currentTool}` : undefined);
 		if (activityGist) AgentRegistry.global().setActivity(id, activityGist);
-		if (args.eventBus) {
-			args.eventBus.emit(TASK_SUBAGENT_PROGRESS_CHANNEL, {
-				index,
-				agent: agent.name,
-				agentSource: agent.source,
-				task,
-				parentToolCallId: args.parentToolCallId,
-				detached: args.detached,
-				assignment,
-				progress: { ...progress },
-				sessionFile: args.sessionFile,
-			});
-		}
+		const progressPayload = {
+			index,
+			agent: agent.name,
+			agentSource: agent.source,
+			task,
+			parentToolCallId: args.parentToolCallId,
+			detached: args.detached,
+			assignment,
+			progress: { ...progress },
+			sessionFile: args.sessionFile,
+		};
+		emitSubagentFrame(args.eventBus, args.subagentEventBus, TASK_SUBAGENT_PROGRESS_CHANNEL, progressPayload);
 		lastProgressEmitMs = Date.now();
 	};
 
@@ -1427,11 +1428,8 @@ function createSubagentRunMonitor(args: RunMonitorArgs): SubagentRunMonitor {
 	};
 
 	const emitSubagentEvent = (event: AgentSessionEvent) => {
-		if (!args.eventBus) return;
-		args.eventBus.emit(TASK_SUBAGENT_EVENT_CHANNEL, {
-			id,
-			event,
-		});
+		const payload = { id, event };
+		emitSubagentFrame(args.eventBus, args.subagentEventBus, TASK_SUBAGENT_EVENT_CHANNEL, payload);
 	};
 
 	const recordExtractedToolData = (toolName: string, data: unknown): void => {
@@ -2184,6 +2182,7 @@ interface FinalizeRunArgs {
 	signal?: AbortSignal;
 	artifactsDir?: string;
 	eventBus?: EventBus;
+	subagentEventBus?: EventBus;
 	parentToolCallId?: string;
 	detached?: boolean;
 	/**
@@ -2308,19 +2307,18 @@ async function finalizeRunResult(args: FinalizeRunArgs): Promise<SingleResult> {
 	monitor.scheduleProgress(true);
 
 	// Emit lifecycle end event after finalization so yield status is reflected
-	if (args.eventBus) {
-		args.eventBus.emit(TASK_SUBAGENT_LIFECYCLE_CHANNEL, {
-			id,
-			agent: agent.name,
-			parentToolCallId: args.parentToolCallId,
-			detached: args.detached,
-			agentSource: agent.source,
-			description: progress.description,
-			status: progress.status as "completed" | "failed" | "aborted",
-			sessionFile: args.sessionFile,
-			index,
-		});
-	}
+	const settledPayload = {
+		id,
+		agent: agent.name,
+		parentToolCallId: args.parentToolCallId,
+		detached: args.detached,
+		agentSource: agent.source,
+		description: progress.description,
+		status: progress.status as "completed" | "failed" | "aborted",
+		sessionFile: args.sessionFile,
+		index,
+	};
+	emitSubagentFrame(args.eventBus, args.subagentEventBus, TASK_SUBAGENT_LIFECYCLE_CHANNEL, settledPayload);
 
 	return {
 		index,
@@ -2367,6 +2365,7 @@ export interface IrcWakeTurnMonitorOptions {
 	/** Explicit pre-expansion model role alias selected for this run. */
 	modelRole?: string;
 	eventBus?: EventBus;
+	subagentEventBus?: EventBus;
 	parentToolCallId?: string;
 	/** Fallback session file when the registry ref carries none. */
 	sessionFile?: string;
@@ -2412,6 +2411,7 @@ export function attachIrcWakeTurnMonitor(session: AgentSession, options: IrcWake
 			modelOverride: options.modelOverride,
 			modelRole: options.modelRole,
 			eventBus: options.eventBus,
+			subagentEventBus: options.subagentEventBus,
 			parentToolCallId: options.parentToolCallId,
 			detached: true,
 			sessionFile,
@@ -2420,19 +2420,18 @@ export function attachIrcWakeTurnMonitor(session: AgentSession, options: IrcWake
 			maxRuntimeMs,
 		});
 
-		if (options.eventBus) {
-			options.eventBus.emit(TASK_SUBAGENT_LIFECYCLE_CHANNEL, {
-				id,
-				agent: agent.name,
-				parentToolCallId: options.parentToolCallId,
-				detached: true,
-				agentSource: agent.source,
-				description: options.description,
-				status: "started",
-				sessionFile,
-				index,
-			});
-		}
+		const startedPayload = {
+			id,
+			agent: agent.name,
+			parentToolCallId: options.parentToolCallId,
+			detached: true,
+			agentSource: agent.source,
+			description: options.description,
+			status: "started",
+			sessionFile,
+			index,
+		} as const;
+		emitSubagentFrame(options.eventBus, options.subagentEventBus, TASK_SUBAGENT_LIFECYCLE_CHANNEL, startedPayload);
 
 		turnMonitor.setActiveSession(session);
 		const unsubscribeTurn = turnMonitor.attach(session);
@@ -2474,6 +2473,7 @@ export function attachIrcWakeTurnMonitor(session: AgentSession, options: IrcWake
 					outputSchemaSource: options.outputSchemaSource,
 					artifactsDir: options.artifactsDir,
 					eventBus: options.eventBus,
+					subagentEventBus: options.subagentEventBus,
 					parentToolCallId: options.parentToolCallId,
 					detached: true,
 					followUpTurn: true,
@@ -2632,6 +2632,7 @@ export interface FollowUpTurnOptions {
 	signal?: AbortSignal;
 	onProgress?: (progress: AgentProgress) => void;
 	eventBus?: EventBus;
+	subagentEventBus?: EventBus;
 	parentToolCallId?: string;
 	/**
 	 * When set, a turn that produces a `yield` result (re)writes `<artifactsDir>/<id>.md`
@@ -2672,6 +2673,7 @@ export async function runSubagentFollowUpTurn(options: FollowUpTurnOptions): Pro
 		signal,
 		onProgress: options.onProgress,
 		eventBus: options.eventBus,
+		subagentEventBus: options.subagentEventBus,
 		parentToolCallId: options.parentToolCallId,
 		detached: true,
 		sessionFile,
@@ -2680,19 +2682,18 @@ export async function runSubagentFollowUpTurn(options: FollowUpTurnOptions): Pro
 		maxRuntimeMs: options.maxRuntimeMs ?? 0,
 	});
 
-	if (options.eventBus) {
-		options.eventBus.emit(TASK_SUBAGENT_LIFECYCLE_CHANNEL, {
-			id,
-			agent: agent.name,
-			parentToolCallId: options.parentToolCallId,
-			detached: true,
-			agentSource: agent.source,
-			description: options.description,
-			status: "started",
-			sessionFile,
-			index,
-		});
-	}
+	const startedPayload = {
+		id,
+		agent: agent.name,
+		parentToolCallId: options.parentToolCallId,
+		detached: true,
+		agentSource: agent.source,
+		description: options.description,
+		status: "started",
+		sessionFile,
+		index,
+	} as const;
+	emitSubagentFrame(options.eventBus, options.subagentEventBus, TASK_SUBAGENT_LIFECYCLE_CHANNEL, startedPayload);
 
 	monitor.setActiveSession(session);
 	const unsubscribe = monitor.attach(session);
@@ -2725,6 +2726,7 @@ export async function runSubagentFollowUpTurn(options: FollowUpTurnOptions): Pro
 		signal,
 		artifactsDir: options.artifactsDir,
 		eventBus: options.eventBus,
+		subagentEventBus: options.subagentEventBus,
 		parentToolCallId: options.parentToolCallId,
 		detached: true,
 		followUpTurn: true,
@@ -2886,6 +2888,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 		signal,
 		onProgress,
 		eventBus: options.eventBus,
+		subagentEventBus: options.subagentEventBus,
 		parentToolCallId: options.parentToolCallId,
 		detached: options.detached,
 		sessionFile: subtaskSessionFile,
@@ -2905,6 +2908,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 			modelOverride,
 			modelRole,
 			eventBus: options.eventBus,
+			subagentEventBus: options.subagentEventBus,
 			parentToolCallId: options.parentToolCallId,
 			sessionFile: subtaskSessionFile,
 			maxRuntimeMs,
@@ -3211,6 +3215,10 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				prewalk,
 				spawns: spawnsEnv,
 				taskDepth: childDepth,
+				// The whole spawn tree shares the root session's observability bus,
+				// so nested lifecycle/progress/event frames reach its surfaces
+				// without leaking into another root session's traffic.
+				subagentEventBus: options.subagentEventBus,
 				parentHindsightSessionState: options.parentHindsightSessionState,
 				parentMnemopiSessionState: options.parentMnemopiSessionState,
 				parentTaskPrefix: id,
@@ -3305,19 +3313,18 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 			}
 
 			// Emit lifecycle start event
-			if (options.eventBus) {
-				options.eventBus.emit(TASK_SUBAGENT_LIFECYCLE_CHANNEL, {
-					id,
-					agent: agent.name,
-					parentToolCallId: options.parentToolCallId,
-					detached: options.detached,
-					agentSource: agent.source,
-					description: options.description,
-					status: "started",
-					sessionFile: subtaskSessionFile,
-					index,
-				});
-			}
+			const startedPayload = {
+				id,
+				agent: agent.name,
+				parentToolCallId: options.parentToolCallId,
+				detached: options.detached,
+				agentSource: agent.source,
+				description: options.description,
+				status: "started" as const,
+				sessionFile: subtaskSessionFile,
+				index,
+			};
+			emitSubagentFrame(options.eventBus, options.subagentEventBus, TASK_SUBAGENT_LIFECYCLE_CHANNEL, startedPayload);
 
 			// Todos are parent-owned bookkeeping and stripped from subagents —
 			// except under prewalk, whose plan nudge + todo gate require the
@@ -3631,6 +3638,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 		signal,
 		artifactsDir: options.artifactsDir,
 		eventBus: options.eventBus,
+		subagentEventBus: options.subagentEventBus,
 		parentToolCallId: options.parentToolCallId,
 		detached: options.detached,
 		sessionFile: subtaskSessionFile,

--- a/packages/coding-agent/src/task/persisted-revive.ts
+++ b/packages/coding-agent/src/task/persisted-revive.ts
@@ -34,6 +34,8 @@ export interface PersistedSubagentReviveContext {
 	 * the same lifecycle/progress frames a live run does.
 	 */
 	eventBus?: EventBus;
+	/** Root-scoped observability bus the revived run's frames also publish to. */
+	subagentEventBus?: EventBus;
 }
 
 /**
@@ -123,6 +125,9 @@ export function createPersistedSubagentReviverFactory(
 			const { session } = await createAgentSession({
 				cwd: ctx.session.sessionManager.getCwd(),
 				authStorage: ctx.authStorage,
+				// Revived agents join the root session tree, so their observability
+				// frames ride the same bus the RPC/collab surfaces subscribed to.
+				subagentEventBus: ctx.subagentEventBus,
 				modelRegistry: ctx.modelRegistry,
 				...(persistedModelPattern ? { modelPattern: persistedModelPattern } : {}),
 				modelPatternAuthFallback: init.resolvedModel,
@@ -191,6 +196,7 @@ export function createPersistedSubagentReviverFactory(
 				id: ref.id,
 				agent: wakeAgent,
 				eventBus: ctx.eventBus,
+				subagentEventBus: ctx.subagentEventBus,
 				sessionFile,
 				outputSchema: init.outputSchema,
 				outputSchemaMode: init.outputSchemaMode,

--- a/packages/coding-agent/src/task/structured-subagent.ts
+++ b/packages/coding-agent/src/task/structured-subagent.ts
@@ -427,6 +427,7 @@ function buildExecutorOptions(
 		keepAlive: request.keepAlive,
 		signal: request.signal,
 		eventBus: session.eventBus,
+		subagentEventBus: session.subagentEventBus,
 		onProgress: request.onProgress,
 		authStorage: session.authStorage,
 		modelRegistry: session.modelRegistry,

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -230,6 +230,13 @@ export interface ToolSession {
 	hasEditTool?: boolean;
 	/** Event bus for tool/extension communication */
 	eventBus?: EventBus;
+	/**
+	 * Root-scoped bus for `task:subagent:*` observability frames. The root
+	 * session creates it; every spawned subagent session inherits it, so RPC
+	 * and HUD surfaces see spawns at any depth without crossing into another
+	 * root session's traffic.
+	 */
+	subagentEventBus?: EventBus;
 	/** Output schema for structured completion (subagents). */
 	outputSchema?: unknown;
 	/** Enforcement policy for {@link outputSchema}; defaults to legacy permissive behavior. */

--- a/packages/coding-agent/src/utils/event-bus.ts
+++ b/packages/coding-agent/src/utils/event-bus.ts
@@ -31,3 +31,20 @@ export class EventBus {
 		this.#listeners.clear();
 	}
 }
+
+/**
+ * Publishes a subagent frame on the session bus and the observability bus.
+ * SDK embedders may pass the same EventBus for both slots; the identity check
+ * skips the aliased re-emit so listeners never see duplicate frames.
+ */
+export function emitSubagentFrame(
+	eventBus: EventBus | undefined,
+	subagentEventBus: EventBus | undefined,
+	channel: string,
+	payload: unknown,
+): void {
+	eventBus?.emit(channel, payload);
+	if (subagentEventBus && subagentEventBus !== eventBus) {
+		subagentEventBus.emit(channel, payload);
+	}
+}

--- a/packages/coding-agent/src/vibe/runtime.ts
+++ b/packages/coding-agent/src/vibe/runtime.ts
@@ -1344,6 +1344,7 @@ export class VibeSessionRegistry {
 			enableLsp: (session.enableLsp ?? true) && session.settings.get("task.enableLsp"),
 			signal,
 			eventBus: session.eventBus,
+			subagentEventBus: session.subagentEventBus,
 			onProgress,
 			authStorage: session.authStorage,
 			modelRegistry: session.modelRegistry,
@@ -1432,6 +1433,7 @@ export class VibeSessionRegistry {
 								signal,
 								onProgress,
 								eventBus: session.eventBus,
+								subagentEventBus: session.subagentEventBus,
 								artifactsDir: session.getSessionFile()?.slice(0, -6),
 							});
 					return await this.#settleTurn(session, manager, record, turn, ownJobId, turnIndex, result);

--- a/packages/coding-agent/test/collab/guest-bus-mirror.test.ts
+++ b/packages/coding-agent/test/collab/guest-bus-mirror.test.ts
@@ -1,0 +1,157 @@
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
+import { generateRoomKey, importRoomKey } from "@oh-my-pi/pi-coding-agent/collab/crypto";
+import { CollabGuestLink } from "@oh-my-pi/pi-coding-agent/collab/guest";
+import { COLLAB_PROTO, type CollabFrame, formatCollabLink } from "@oh-my-pi/pi-coding-agent/collab/protocol";
+import { CollabSocket } from "@oh-my-pi/pi-coding-agent/collab/relay-client";
+import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
+import { AgentRegistry } from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
+import { TASK_SUBAGENT_LIFECYCLE_CHANNEL } from "@oh-my-pi/pi-coding-agent/task/types";
+import { EventBus } from "@oh-my-pi/pi-coding-agent/utils/event-bus";
+import { installInMemoryRelay, uninstallInMemoryRelay } from "./helpers/in-memory-relay";
+
+// The guest mirrors host EventBus traffic onto the local session and
+// observability buses. When an SDK embedder wires the SAME EventBus into both
+// slots, the mirror must emit each frame exactly once.
+
+function makeState(): Extract<CollabFrame, { t: "welcome" }>["state"] {
+	return {
+		isStreaming: false,
+		queuedMessageCount: 0,
+		sessionName: "host session",
+		cwd: "/tmp",
+		participants: [{ name: "Host", role: "host" }],
+	};
+}
+
+function makeGuestContext(eventBus: EventBus): InteractiveModeContext {
+	const ctx = {
+		collabGuest: undefined as CollabGuestLink | undefined,
+		settings: { get: () => "" },
+		sessionManager: {
+			getSessionFile: () => null,
+			getSessionName: () => "local session",
+			getCwd: () => "/local",
+		},
+		session: {
+			messages: [],
+			switchSession: () => Promise.resolve(),
+			newSession: () => Promise.resolve(),
+			agent: {
+				state: { model: undefined },
+				setModel: () => {},
+				setThinkingLevel: () => {},
+				setDisableReasoning: () => {},
+			},
+		},
+		statusContainer: { clear: () => {} },
+		pendingMessagesContainer: { clear: () => {} },
+		compactionQueuedMessages: [],
+		streamingComponent: undefined,
+		streamingMessage: undefined,
+		transcriptMessageComponents: new WeakMap(),
+		pendingTools: new Map(),
+		loadingAnimation: undefined,
+		statusLine: {
+			setSubagentCount: () => {},
+			get subagentCount() {
+				return 0;
+			},
+			setCollabStatus: () => {},
+			invalidate: () => {},
+			resetActiveTime: () => {},
+			markActivityStart: () => {},
+			markActivityEnd: () => {},
+		},
+		ui: { requestRender: () => {} },
+		chatContainer: { clear: () => {}, disposeChildren: () => {} },
+		resetObserverRegistry: () => {},
+		renderInitialMessages: () => {},
+		reloadTodos: () => Promise.resolve(),
+		showStatus: () => {},
+		showError: () => {},
+		updateEditorTopBorder: () => {},
+		updateEditorBorderColor: () => {},
+		eventController: { handleEvent: () => Promise.resolve() },
+		syncRunningSubagentBadge: () => {},
+		eventBus,
+		subagentEventBus: eventBus,
+	} as unknown as InteractiveModeContext;
+	return ctx;
+}
+
+beforeEach(() => {
+	AgentRegistry.resetGlobalForTests();
+	installInMemoryRelay();
+});
+
+afterEach(() => {
+	uninstallInMemoryRelay();
+	AgentRegistry.resetGlobalForTests();
+});
+
+describe("collab guest bus mirror", () => {
+	it("emits an aliased bus frame exactly once", async () => {
+		const writeSpy = spyOn(Bun, "write").mockResolvedValue(0);
+		const roomId = "bus-mirror-room-1";
+		const roomKey = generateRoomKey();
+		const cryptoKey = await importRoomKey(roomKey);
+		const link = formatCollabLink("ws://localhost:8788", roomId, roomKey);
+		const hostSocket = new CollabSocket({ wsUrl: `ws://localhost:8788/r/${roomId}`, role: "host", key: cryptoKey });
+		const hostOpen = Promise.withResolvers<void>();
+		hostSocket.onOpen = () => hostOpen.resolve();
+		hostSocket.onFrame = frame => {
+			if (frame.t === "hello") {
+				hostSocket.send({
+					t: "welcome",
+					proto: COLLAB_PROTO,
+					header: { type: "session", id: "remote-session", timestamp: "2026-06-26T00:00:00Z", cwd: "/tmp" },
+					state: makeState(),
+					agents: [],
+					entryCount: 0,
+				} as CollabFrame);
+			}
+		};
+		hostSocket.connect();
+		await hostOpen.promise;
+
+		const sharedBus = new EventBus();
+		const mirrored: Array<{ id?: string; status?: string }> = [];
+		const firstFrame = Promise.withResolvers<void>();
+		sharedBus.on(TASK_SUBAGENT_LIFECYCLE_CHANNEL, frame => {
+			const payload = frame as { id?: string; status?: string };
+			mirrored.push(payload);
+			if (mirrored.length === 1) firstFrame.resolve();
+		});
+
+		const ctx = makeGuestContext(sharedBus);
+		const guest = new CollabGuestLink(ctx);
+
+		try {
+			await guest.join(link);
+
+			hostSocket.send({
+				t: "bus",
+				channel: TASK_SUBAGENT_LIFECYCLE_CHANNEL,
+				data: {
+					id: "MirroredScout",
+					agent: "task",
+					agentSource: "bundled",
+					status: "started",
+					parentToolCallId: "call-mirror",
+					index: 1,
+				},
+			} as CollabFrame);
+			await firstFrame.promise;
+			// Give any duplicate emit a tick to land before counting.
+			await Bun.sleep(25);
+
+			expect(mirrored.length).toBe(1);
+			expect(mirrored[0]?.id).toBe("MirroredScout");
+			expect(mirrored[0]?.status).toBe("started");
+		} finally {
+			hostSocket.close();
+			writeSpy.mockRestore();
+			await guest.leave("test cleanup").catch(() => {});
+		}
+	});
+});

--- a/packages/coding-agent/test/collab/host-bus-fallback.test.ts
+++ b/packages/coding-agent/test/collab/host-bus-fallback.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { importRoomKey } from "@oh-my-pi/pi-coding-agent/collab/crypto";
+import { CollabHost } from "@oh-my-pi/pi-coding-agent/collab/host";
+import { COLLAB_PROTO, parseCollabLink } from "@oh-my-pi/pi-coding-agent/collab/protocol";
+import { CollabSocket } from "@oh-my-pi/pi-coding-agent/collab/relay-client";
+import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
+import { AgentRegistry } from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { TASK_SUBAGENT_LIFECYCLE_CHANNEL } from "@oh-my-pi/pi-coding-agent/task/types";
+import { EventBus } from "@oh-my-pi/pi-coding-agent/utils/event-bus";
+import { installInMemoryRelay, uninstallInMemoryRelay } from "./helpers/in-memory-relay";
+
+// Embedders on the previous InteractiveMode constructor signature wire only a
+// session `eventBus`; the host must fall back to it so depth-1 subagent
+// frames keep reaching collaboration guests.
+
+function makeHostContext(eventBus: EventBus): InteractiveModeContext {
+	return {
+		settings: { get: () => "" },
+		sessionManager: SessionManager.inMemory(),
+		session: {
+			isStreaming: false,
+			isAborting: false,
+			queuedMessageCount: 0,
+			sessionName: "host session",
+			model: undefined,
+			thinkingLevel: undefined,
+			subscribe: () => () => {},
+			emitNotice: () => {},
+			promptCustomMessage: () => Promise.resolve(),
+			abort: () => Promise.resolve(),
+		},
+		eventBus,
+		statusLine: {
+			setCollabStatus: () => {},
+			invalidate: () => {},
+			getCachedContextBreakdown: () => ({ usedTokens: 0, contextWindow: 0 }),
+		},
+		ui: { requestRender: () => {} },
+		showStatus: () => {},
+		collabHost: undefined,
+	} as unknown as InteractiveModeContext;
+}
+
+beforeEach(() => {
+	AgentRegistry.resetGlobalForTests();
+	installInMemoryRelay();
+});
+
+afterEach(() => {
+	uninstallInMemoryRelay();
+	AgentRegistry.resetGlobalForTests();
+});
+
+describe("collab host bus fallback", () => {
+	it("broadcasts subagent frames from a session-bus-only embedding", async () => {
+		const hostBus = new EventBus();
+		const host = new CollabHost(makeHostContext(hostBus));
+		await host.start("ws://localhost:8788");
+
+		const parsed = parseCollabLink(host.link);
+		if ("error" in parsed) throw new Error(parsed.error);
+		const guestKey = await importRoomKey(parsed.key);
+		const guestSocket = new CollabSocket({ wsUrl: parsed.wsUrl, role: "guest", key: guestKey });
+
+		const welcomed = Promise.withResolvers<void>();
+		const mirrored: Array<{ id?: string; status?: string }> = [];
+		guestSocket.onFrame = frame => {
+			if (frame.t === "welcome") welcomed.resolve();
+			if (frame.t === "bus" && frame.channel === TASK_SUBAGENT_LIFECYCLE_CHANNEL) {
+				mirrored.push(frame.data as { id?: string; status?: string });
+			}
+		};
+		guestSocket.onOpen = () => {
+			guestSocket.send({
+				t: "hello",
+				proto: COLLAB_PROTO,
+				name: "probe-guest",
+				writeToken: parsed.writeToken ? Buffer.from(parsed.writeToken).toString("base64url") : undefined,
+			});
+		};
+		guestSocket.connect();
+
+		try {
+			await welcomed.promise;
+
+			// Depth-1 frame on the session bus — the only bus this embedding has.
+			hostBus.emit(TASK_SUBAGENT_LIFECYCLE_CHANNEL, {
+				id: "FallbackScout",
+				agent: "task",
+				agentSource: "bundled",
+				status: "started",
+				parentToolCallId: "call-fallback",
+				index: 1,
+			});
+
+			const deadline = Date.now() + 5000;
+			while (Date.now() < deadline && mirrored.length === 0) {
+				await Bun.sleep(5);
+			}
+			// Give any duplicate emit a tick to land before counting.
+			await Bun.sleep(25);
+
+			expect(mirrored.length).toBe(1);
+			expect(mirrored[0]?.id).toBe("FallbackScout");
+			expect(mirrored[0]?.status).toBe("started");
+		} finally {
+			guestSocket.close();
+			await host.stop("test cleanup").catch(() => {});
+		}
+	}, 20000);
+});

--- a/packages/coding-agent/test/rpc-subagents.test.ts
+++ b/packages/coding-agent/test/rpc-subagents.test.ts
@@ -85,8 +85,8 @@ function createSessionChangeSession(options: SessionChangeStubOptions): RpcSessi
 
 describe("RPC subagent registry", () => {
 	test("defaults subagent frame emission to off while tracking snapshots", () => {
-		const eventBus = new EventBus();
 		const frames: RpcSubagentFrame[] = [];
+		const eventBus = new EventBus();
 		const registry = new RpcSubagentRegistry(eventBus, frame => frames.push(frame));
 		const lifecycle: SubagentLifecyclePayload = {
 			id: "SubagentA",
@@ -130,8 +130,8 @@ describe("RPC subagent registry", () => {
 	});
 
 	test("emits progress frames after explicit progress subscription and snapshots tracked subagents", () => {
-		const eventBus = new EventBus();
 		const frames: RpcSubagentFrame[] = [];
+		const eventBus = new EventBus();
 		const registry = new RpcSubagentRegistry(eventBus, frame => frames.push(frame));
 		registry.setSubscriptionLevel("progress");
 		const lifecycle: SubagentLifecyclePayload = {
@@ -300,8 +300,8 @@ describe("RPC subagent registry", () => {
 	});
 
 	test("gates raw subagent events behind the events subscription level", () => {
-		const eventBus = new EventBus();
 		const frames: RpcSubagentFrame[] = [];
+		const eventBus = new EventBus();
 		const registry = new RpcSubagentRegistry(eventBus, frame => frames.push(frame));
 		const eventPayload: SubagentEventPayload = {
 			id: "SubagentA",
@@ -445,5 +445,58 @@ function handle(frame) {
 		expect(progressTasks).toEqual(["Do work"]);
 		expect(rawEventTypes).toEqual(["agent_start"]);
 		expect(sessionEventTypes).toContain("notice");
+	});
+
+	test("forwards nested subagent frames published on the shared observability bus", () => {
+		const frames: RpcSubagentFrame[] = [];
+		const eventBus = new EventBus();
+		const registry = new RpcSubagentRegistry(eventBus, frame => frames.push(frame));
+		registry.setSubscriptionLevel("events");
+		eventBus.emit(TASK_SUBAGENT_LIFECYCLE_CHANNEL, {
+			id: "Kid",
+			agent: "task",
+			agentSource: "bundled",
+			status: "started",
+			parentToolCallId: "call-1",
+			index: 1,
+		} satisfies SubagentLifecyclePayload);
+		eventBus.emit(TASK_SUBAGENT_LIFECYCLE_CHANNEL, {
+			id: "Kid.Grandkid",
+			agent: "task",
+			agentSource: "bundled",
+			status: "started",
+			parentToolCallId: "call-2",
+			index: 2,
+		} satisfies SubagentLifecyclePayload);
+		eventBus.emit(TASK_SUBAGENT_EVENT_CHANNEL, {
+			id: "Kid.Grandkid",
+			event: { type: "agent_start" } as SubagentEventPayload["event"],
+		} satisfies SubagentEventPayload);
+		expect(frames.map(frame => frame.type)).toEqual(["subagent_lifecycle", "subagent_lifecycle", "subagent_event"]);
+		expect((frames[1] as { payload: SubagentLifecyclePayload }).payload.id).toBe("Kid.Grandkid");
+		expect((frames[2] as { payload: SubagentEventPayload }).payload.id).toBe("Kid.Grandkid");
+		registry.dispose();
+	});
+
+	test("scopes observability to each root session — another tree's bus stays invisible", () => {
+		const busA = new EventBus();
+		const busB = new EventBus();
+		const framesA: RpcSubagentFrame[] = [];
+		const framesB: RpcSubagentFrame[] = [];
+		const registryA = new RpcSubagentRegistry(busA, frame => framesA.push(frame));
+		const registryB = new RpcSubagentRegistry(busB, frame => framesB.push(frame));
+		registryA.setSubscriptionLevel("events");
+		registryB.setSubscriptionLevel("events");
+		busB.emit(TASK_SUBAGENT_LIFECYCLE_CHANNEL, {
+			id: "Kid",
+			agent: "task",
+			agentSource: "bundled",
+			status: "started",
+			index: 1,
+		} satisfies SubagentLifecyclePayload);
+		expect(framesA).toEqual([]);
+		expect(framesB).toHaveLength(1);
+		registryA.dispose();
+		registryB.dispose();
 	});
 });

--- a/packages/coding-agent/test/subagent-hud-render.test.ts
+++ b/packages/coding-agent/test/subagent-hud-render.test.ts
@@ -227,7 +227,7 @@ describe("subagent HUD lines", () => {
 	it("threads the detached flag from lifecycle and progress payloads", () => {
 		const eventBus = new EventBus();
 		const registry = new SessionObserverRegistry();
-		registry.subscribeToEventBus(eventBus);
+		registry.subscribeToEventBus(eventBus, eventBus);
 
 		eventBus.emit(TASK_SUBAGENT_LIFECYCLE_CHANNEL, makeLifecycle("Detached", 0, "background work", true));
 		eventBus.emit(TASK_SUBAGENT_LIFECYCLE_CHANNEL, makeLifecycle("Inline", 1, "sync work"));
@@ -248,10 +248,24 @@ describe("subagent HUD lines", () => {
 		}
 	});
 
+	it("dedupes frames dual-published on the session bus and the shared bus", () => {
+		const eventBus = new EventBus();
+		const registry = new SessionObserverRegistry();
+		registry.subscribeToEventBus(eventBus, eventBus);
+		const kinds: string[] = [];
+		registry.onChange(kind => kinds.push(kind));
+		const payload = makeLifecycle("DualPublished", 0, "dual-published frame");
+		eventBus.emit(TASK_SUBAGENT_LIFECYCLE_CHANNEL, payload);
+		eventBus.emit(TASK_SUBAGENT_LIFECYCLE_CHANNEL, payload);
+		expect(kinds).toEqual(["lifecycle"]);
+		expect(registry.getActiveSubagentCount()).toBe(1);
+		registry.dispose();
+	});
+
 	it("keeps subagent registry order stable while progress arrives out of order", () => {
 		const eventBus = new EventBus();
 		const registry = new SessionObserverRegistry();
-		registry.subscribeToEventBus(eventBus);
+		registry.subscribeToEventBus(eventBus, eventBus);
 		const activeIds = () =>
 			registry
 				.getSessions()

--- a/packages/coding-agent/test/task/executor-soft-budget.test.ts
+++ b/packages/coding-agent/test/task/executor-soft-budget.test.ts
@@ -15,6 +15,7 @@ import type { AgentSession, AgentSessionEvent, PromptOptions } from "@oh-my-pi/p
 import type { CustomMessage } from "@oh-my-pi/pi-coding-agent/session/messages";
 import { resolveSoftRequestBudget, runSubprocess } from "@oh-my-pi/pi-coding-agent/task/executor";
 import type { AgentDefinition } from "@oh-my-pi/pi-coding-agent/task/types";
+import { TASK_SUBAGENT_LIFECYCLE_CHANNEL } from "@oh-my-pi/pi-coding-agent/task/types";
 import { EventBus } from "@oh-my-pi/pi-coding-agent/utils/event-bus";
 import { TempDir } from "@oh-my-pi/pi-utils";
 
@@ -185,7 +186,7 @@ describe("runSubprocess soft request budget", () => {
 		tempDir[Symbol.dispose]();
 	});
 
-	function baseOptions(id: string, eventBus?: EventBus) {
+	function baseOptions(id: string, eventBus?: EventBus, subagentEventBus?: EventBus) {
 		return {
 			cwd: "/tmp",
 			agent: baseAgent,
@@ -197,6 +198,7 @@ describe("runSubprocess soft request budget", () => {
 			enableLsp: false,
 			artifactsDir: tempDir.path(),
 			eventBus,
+			subagentEventBus: subagentEventBus ?? eventBus,
 		};
 	}
 
@@ -457,6 +459,103 @@ describe("runSubprocess soft request budget", () => {
 		const restoredRegistry = new AgentRegistry();
 		await registerPersistedSubagents(restoredRegistry, rootSessionFile);
 		expect(restoredRegistry.get(id)?.status).toBe("parked");
+	});
+
+	it("a nested spawn reaches the root RPC surface through the inherited observability bus", async () => {
+		const id = "WiringScout";
+		// Separate session and observability buses, the way the CLI wires them.
+		const sessionBus = new EventBus();
+		const treeBus = new EventBus();
+		const frames: RpcSubagentFrame[] = [];
+		let resolveTerminalLatch: (() => void) | undefined;
+		const waitForTerminal = (): Promise<void> => {
+			const deferred = Promise.withResolvers<void>();
+			resolveTerminalLatch = deferred.resolve;
+			return deferred.promise;
+		};
+		const rpcRegistry = new RpcSubagentRegistry(treeBus, frame => {
+			frames.push(frame);
+			if (frame.type !== "subagent_lifecycle" || frame.payload.status === "started") return;
+			resolveTerminalLatch?.();
+			resolveTerminalLatch = undefined;
+		});
+		rpcRegistry.setSubscriptionLevel("events");
+		const handle = createMockSession(({ promptIndex, emit, pushMessage }) => {
+			if (promptIndex !== 1) return;
+			// The depth-2 executor publishes on the bus its spawner handed down —
+			// captured from the real spawn options, not the test's own bus.
+			capturedOptions?.subagentEventBus?.emit(TASK_SUBAGENT_LIFECYCLE_CHANNEL, {
+				id: `${id}.Grandkid`,
+				agent: "task",
+				agentSource: "bundled",
+				status: "started",
+				parentToolCallId: "call-grandkid",
+				index: 2,
+			});
+			const message = assistantText("settling");
+			pushMessage(message);
+			emit({ type: "message_end", message } as unknown as AgentSessionEvent);
+		});
+		let capturedOptions: { subagentEventBus?: EventBus } | undefined;
+		vi.spyOn(sdkModule, "createAgentSession").mockImplementation(async options => {
+			capturedOptions = options;
+			return {
+				session: handle.session,
+				extensionsResult: {} as unknown as LoadExtensionsResult,
+				setToolUIContext: () => {},
+				eventBus: new EventBus(),
+			} satisfies CreateAgentSessionResult;
+		});
+		registerRunning(id, handle.session);
+
+		const terminal = waitForTerminal();
+		await runSubprocess(baseOptions(id, sessionBus, treeBus));
+		await terminal;
+
+		// The spawn wiring inherited the tree bus into the nested session.
+		expect(capturedOptions?.subagentEventBus).toBe(treeBus);
+		// The root RPC surface observed the depth-1 run…
+		expect(frames.some(frame => frame.type === "subagent_lifecycle" && frame.payload.id === id)).toBe(true);
+		// …and the depth-2 frame published on the inherited bus.
+		expect(frames.some(frame => frame.type === "subagent_lifecycle" && frame.payload.id === `${id}.Grandkid`)).toBe(
+			true,
+		);
+	});
+
+	it("an aliased observability bus does not duplicate lifecycle frames", async () => {
+		const id = "AliasScout";
+		// An SDK caller wiring the same EventBus into both slots must not see
+		// every frame twice — the executor skips the aliased re-emit.
+		const sharedBus = new EventBus();
+		const settled: string[] = [];
+		const terminal = Promise.withResolvers<void>();
+		sharedBus.on(TASK_SUBAGENT_LIFECYCLE_CHANNEL, frame => {
+			const payload = frame as { id?: string; status?: string };
+			if (payload.id !== id) return;
+			if (payload.status === "started") return;
+			settled.push(payload.status ?? "");
+			terminal.resolve();
+		});
+		const handle = createMockSession(({ promptIndex, emit, pushMessage }) => {
+			if (promptIndex !== 1) return;
+			const message = assistantText("settling");
+			pushMessage(message);
+			emit({ type: "message_end", message } as unknown as AgentSessionEvent);
+		});
+		vi.spyOn(sdkModule, "createAgentSession").mockImplementation(async () => {
+			return {
+				session: handle.session,
+				extensionsResult: {} as unknown as LoadExtensionsResult,
+				setToolUIContext: () => {},
+				eventBus: new EventBus(),
+			} satisfies CreateAgentSessionResult;
+		});
+		registerRunning(id, handle.session);
+
+		await runSubprocess(baseOptions(id, sharedBus, sharedBus));
+		await terminal.promise;
+
+		expect(settled).toEqual(["completed"]);
 	});
 
 	it("a caller-signal abort stays terminal and irc names the aborted agent precisely", async () => {


### PR DESCRIPTION
### Summary

Subagents spawned by another subagent (depth >= 2) are invisible to every
surface that subscribes to `task:subagent:*` channels: the RPC
`set_subagent_subscription` stream, `get_subagents`, `get_subagent_messages`,
and the interactive subagent HUD. Their lifecycle/progress/event frames are
emitted on the parent session's private `EventBus`, while these surfaces only
ever subscribe to the root session's bus.

### Root cause

1. `packages/coding-agent/src/task/executor.ts` — `buildSubagentSessionOptions`
   does not pass `eventBus`, so `createAgentSessionScoped`
   (`packages/coding-agent/src/sdk.ts`) falls back to
   `options.eventBus ?? new EventBus()`: every subagent session gets a fresh,
   private bus.
2. A nested spawn (`task` inside a subagent) goes through
   `runStructuredSubagent`, which passes `eventBus: session.eventBus`
   (`packages/coding-agent/src/task/structured-subagent.ts:429`) — i.e. the
   *parent subagent's* private bus.
3. The lifecycle/progress/event emission sites in `executor.ts`
   (`TASK_SUBAGENT_LIFECYCLE_CHANNEL`, `TASK_SUBAGENT_PROGRESS_CHANNEL`,
   `TASK_SUBAGENT_EVENT_CHANNEL`) emit on `options.eventBus`, so nested frames
   land on the parent session's private bus.
4. `packages/coding-agent/src/modes/rpc/rpc-mode.ts` subscribes
   `RpcSubagentRegistry` to the RPC (root) session's bus only, and
   `session-observer-registry.ts#subscribeToEventBus` likewise subscribes to a
   single bus. Neither ever hears nested frames. `get_subagents` and
   `get_subagent_messages` resolve through the same root-bus-fed registry, so
   they also miss nested agents ("Unknown subagent").

### Reproduction

```sh
omp --mode rpc --yolo
# {"id":"1","type":"negotiate_protocol","protocolVersion":2}
# {"id":"2","type":"set_subagent_subscription","level":"events"}
# {"id":"3","type":"prompt","message":"use the task tool to spawn a child named Kid whose only job is to use the task tool once to spawn a grandchild named Grandkid that replies with one word; then relay its reply"}
```

Before the patch, the wire only carries `Kid` lifecycle/event frames. The
grandchild (`Kid.Grandkid`) produces nothing on the wire at all.

### Fix

One line (+comment): pass the spawning session's bus into the subagent
session options, so sessions at every depth share the bus their spawner (and
ultimately the RPC/observer surfaces) subscribed to.

```diff
--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@
 				spawns: spawnsEnv,
 				taskDepth: childDepth,
+				// Nested spawns must ride the spawning session's eventBus rather than
+				// a fresh per-session one: lifecycle/progress/event frames are the only
+				// channel RPC and observer surfaces subscribe to (the root session's
+				// bus), and a private bus makes depth >= 2 subagents invisible to them.
+				eventBus: options.eventBus,
 				parentHindsightSessionState: options.parentHindsightSessionState,
```

### Verification

Same reproduction against a build with the patch:

```
=== subagent_lifecycle frames: 4
  id=Kid status=started parentToolCallId=call_ac061b...|fc_b3eed11d... detached=True
  id=Kid.Grandkid status=started parentToolCallId=call_80654e...|fc_7051e0ea... detached=True
  id=Kid.Grandkid status=completed parentToolCallId=call_80654e...|fc_7051e0ea... detached=True
  id=Kid status=completed parentToolCallId=call_ac061b...|fc_b3eed11d... detached=True
=== subagent_event counts per id:
  Kid -> {agent_start, turn_start x3, message_start/end x7, message_update x221,
          tool_execution_start/end x3, turn_end x3, agent_end}
  Kid.Grandkid -> {agent_start, turn_start, message_start/end x3, message_update x45,
          tool_execution_start/end x1, turn_end, agent_end}
```

The nested lifecycle's `parentToolCallId` matches the child's own
`tool_execution_start.toolCallId` exactly, so RPC consumers can link nested
spawns back to the tool call that created them at any depth.

### Notes / alternatives considered

- With this change, a subagent session shares its spawner's bus for all bus
  traffic (extensions, LSP/MCP status events, etc.). Blast radius looks small:
  subagent sessions run `hasUI: false` with restricted extensions, and the
  channels in question are only emitted by the task executor.
- An alternative is to emit the three `task:subagent:*` channels on a shared
  process-global bus in addition to the session bus and subscribe RPC/observers
  to that; happy to implement that variant instead if you prefer stricter bus
  isolation.
- This also fixes the interactive subagent HUD for nested spawns, which has
  the same single-bus blind spot.

Verified against v18.0.6.