### PR TITLE
fix(cli): refresh local MCP OAuth tokens

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 
+- Fixed `omp token` refreshing local MCP OAuth credentials through the MCP grant path without temporarily blocking or losing rotating refresh tokens ([#9953](https://github.com/can1357/oh-my-pi/issues/9953)).
 - Fixed corrupt session headers silently overwriting recoverable transcripts during resume ([#9915](https://github.com/can1357/oh-my-pi/issues/9915)).
 - Fixed a startup race that left a new session with almost no tools and an empty skill inventory. An early reconcile could commit a small live tool set as the permanent enabled set. The enabled set is now seeded from the construction-time tool slate, and `reconcileCodeMode` samples it inside the registry mutation lock.
 - Fixed `snapcompact` compaction frames larger than the persistence limit being truncated into invalid image base64 on session resume, which made the provider reject every subsequent request with HTTP 400; already-corrupted archives now resume from their retained source text instead ([#9901](https://github.com/can1357/oh-my-pi/issues/9901)).

--- a/packages/coding-agent/src/commands/token.ts
+++ b/packages/coding-agent/src/commands/token.ts
@@ -7,8 +7,40 @@ import chalk from "@oh-my-pi/pi-utils/chalk";
 import { Args, Command, Flags } from "@oh-my-pi/pi-utils/cli";
 import { tokenHelp as commandHelp } from "../cli/command-help";
 import { isAuthenticated, ModelRegistry } from "../config/model-registry";
+import { refreshStoredManagedMcpOAuthCredential } from "../mcp/oauth-credentials";
+import { isManagedMCPOAuthCredentialId } from "../mcp/oauth-flow";
 import { discoverAuthStorage } from "../sdk";
+import type { AuthStorage } from "../session/auth-storage";
 import { getAvailableAuthMethods } from "../web/search/providers/perplexity-auth";
+
+async function resolveManagedMcpOAuthToken(
+	authStorage: AuthStorage,
+	provider: string,
+	options: { credentialId?: number; forceRefresh?: boolean } = {},
+): Promise<string | undefined> {
+	const row = authStorage
+		.listStoredCredentials(provider)
+		.find(
+			entry =>
+				entry.credential.type === "oauth" &&
+				(options.credentialId === undefined || entry.id === options.credentialId),
+		);
+	if (row?.credential.type !== "oauth") return undefined;
+	const before = row.credential;
+	const result = await refreshStoredManagedMcpOAuthCredential(authStorage, provider, options);
+	const credential = result.credential;
+	if (!credential || Date.now() >= credential.expires) return undefined;
+	if (
+		options.forceRefresh &&
+		!result.refreshed &&
+		credential.access === before.access &&
+		credential.refresh === before.refresh &&
+		credential.expires === before.expires
+	) {
+		return undefined;
+	}
+	return credential.access;
+}
 
 export default class Token extends Command {
 	static description = commandHelp.description;
@@ -50,7 +82,8 @@ export default class Token extends Command {
 	async run(): Promise<void> {
 		const { args, flags } = await this.parse(Token);
 		const providerName = args.provider ?? "";
-		const provider = providerName.toLowerCase();
+		const managedMcpOAuth = isManagedMCPOAuthCredentialId(args.provider);
+		const provider = managedMcpOAuth ? providerName : providerName.toLowerCase();
 
 		const authStorage = await discoverAuthStorage();
 		try {
@@ -84,9 +117,18 @@ export default class Token extends Command {
 					process.exitCode = 1;
 					return;
 				}
-				const resolution = await authStorage.getOAuthAccessAt(provider, n - 1, {
-					forceRefresh: flags["force-refresh"],
-				});
+				const resolution = managedMcpOAuth
+					? await resolveManagedMcpOAuthToken(authStorage, provider, {
+							credentialId: accounts[n - 1]?.credentialId,
+							forceRefresh: flags["force-refresh"],
+						})
+					: await authStorage.getOAuthAccessAt(provider, n - 1, {
+							forceRefresh: flags["force-refresh"],
+						});
+				if (typeof resolution === "string") {
+					process.stdout.write(`${resolution}\n`);
+					return;
+				}
 				if (!resolution?.ok) {
 					const reason = resolution && !resolution.ok ? resolution.error : "no OAuth credential available";
 					process.stderr.write(
@@ -114,7 +156,11 @@ export default class Token extends Command {
 				}
 			}
 
-			if (!apiKey) {
+			if (!apiKey && managedMcpOAuth) {
+				apiKey = await resolveManagedMcpOAuthToken(authStorage, provider, {
+					forceRefresh: flags["force-refresh"],
+				});
+			} else if (!apiKey) {
 				apiKey = await modelRegistry.getApiKeyForProvider(provider, undefined, {
 					forceRefresh: flags["force-refresh"],
 				});

--- a/packages/coding-agent/src/commands/token.ts
+++ b/packages/coding-agent/src/commands/token.ts
@@ -27,7 +27,10 @@ async function resolveManagedMcpOAuthToken(
 		);
 	if (row?.credential.type !== "oauth") return undefined;
 	const before = row.credential;
-	const result = await refreshStoredManagedMcpOAuthCredential(authStorage, provider, options);
+	const result = await refreshStoredManagedMcpOAuthCredential(authStorage, provider, {
+		...options,
+		recoverServerUrlFromCredentialId: true,
+	});
 	const credential = result.credential;
 	if (!credential || Date.now() >= credential.expires) return undefined;
 	if (

--- a/packages/coding-agent/src/commands/token.ts
+++ b/packages/coding-agent/src/commands/token.ts
@@ -5,10 +5,11 @@
 import { PROVIDER_REGISTRY } from "@oh-my-pi/pi-ai";
 import chalk from "@oh-my-pi/pi-utils/chalk";
 import { Args, Command, Flags } from "@oh-my-pi/pi-utils/cli";
+import { getActiveProfile } from "@oh-my-pi/pi-utils/dirs";
 import { tokenHelp as commandHelp } from "../cli/command-help";
 import { isAuthenticated, ModelRegistry } from "../config/model-registry";
 import { refreshStoredManagedMcpOAuthCredential } from "../mcp/oauth-credentials";
-import { isManagedMCPOAuthCredentialId } from "../mcp/oauth-flow";
+import { isManagedMCPOAuthCredentialId, mcpOAuthCredentialProfile } from "../mcp/oauth-flow";
 import { discoverAuthStorage } from "../sdk";
 import type { AuthStorage } from "../session/auth-storage";
 import { getAvailableAuthMethods } from "../web/search/providers/perplexity-auth";
@@ -87,6 +88,20 @@ export default class Token extends Command {
 		const providerName = args.provider ?? "";
 		const managedMcpOAuth = isManagedMCPOAuthCredentialId(args.provider);
 		const provider = managedMcpOAuth ? providerName : providerName.toLowerCase();
+		// Profile-scoped managed ids stay isolated per profile: a shared broker
+		// snapshot carries `mcp_oauth:profile:*` rows for every profile, so refuse
+		// to read/refresh another profile's row from this one (mirrors
+		// removeManagedMcpOAuthCredential). Legacy unscoped ids have no profile.
+		if (managedMcpOAuth) {
+			const scopedProfile = mcpOAuthCredentialProfile(provider);
+			if (scopedProfile !== undefined && scopedProfile !== (getActiveProfile() ?? "default")) {
+				process.stderr.write(
+					`${chalk.red(`Managed MCP credential "${providerName}" belongs to profile "${scopedProfile}", not the active profile.`)}\n`,
+				);
+				process.exitCode = 1;
+				return;
+			}
+		}
 
 		const authStorage = await discoverAuthStorage();
 		try {

--- a/packages/coding-agent/src/mcp/manager.ts
+++ b/packages/coding-agent/src/mcp/manager.ts
@@ -6,13 +6,12 @@
  */
 import * as path from "node:path";
 import * as url from "node:url";
-import { isDefinitiveOAuthFailure, type TSchema } from "@oh-my-pi/pi-ai";
-import type { OAuthCredentials } from "@oh-my-pi/pi-ai/oauth/types";
+import type { TSchema } from "@oh-my-pi/pi-ai";
 import { logger } from "@oh-my-pi/pi-utils";
 import type { EffectiveExtensionRoots, SourceMeta } from "../capability/types";
 import { resolveConfigValue } from "../config/resolve-config-value";
 import type { CustomTool } from "../extensibility/custom-tools/types";
-import { type AuthStorage, REMOTE_REFRESH_SENTINEL } from "../session/auth-storage";
+import type { AuthStorage } from "../session/auth-storage";
 import {
 	connectToServer,
 	disconnectServer,
@@ -31,8 +30,7 @@ import { type LoadMCPConfigsResult, loadAllMCPConfigs, validateServerConfig } fr
 import {
 	lookupMcpOAuthCredential,
 	type MCPOAuthCredentialLookup,
-	refreshManagedMcpOAuthCredential,
-	selectMcpOAuthRefreshMaterial,
+	refreshStoredManagedMcpOAuthCredential,
 } from "./oauth-credentials";
 import type { MCPStoredOAuthCredential } from "./oauth-flow";
 import type { McpConnectionStatusEvent } from "./startup-events";
@@ -1482,36 +1480,6 @@ export class MCPManager {
 	}
 
 	/**
-	 * Refresh a broker-redacted MCP OAuth credential through the auth-broker.
-	 *
-	 * When running in broker mode the client only ever holds the redacted
-	 * refresh sentinel; the real refresh token lives on the broker. Delegating
-	 * to {@link AuthStorage.forceRefreshCredentialById} makes the broker run the
-	 * `refresh_token` grant and return a fresh access token, which the client
-	 * uses while keeping {@link REMOTE_REFRESH_SENTINEL} in the refresh slot.
-	 */
-	async #refreshBrokeredMcpCredential(credentialId: string, signal?: AbortSignal): Promise<OAuthCredentials> {
-		const storage = this.#authStorage;
-		if (!storage) throw new Error("MCP OAuth broker refresh requires an auth storage");
-		const row = storage.listStoredCredentials(credentialId).find(entry => entry.credential.type === "oauth");
-		if (!row) throw new Error(`No broker credential row for ${credentialId}`);
-		const entry = await storage.forceRefreshCredentialById(row.id, signal);
-		if (entry.credential.type !== "oauth") {
-			throw new Error(`Broker returned non-OAuth credential for ${credentialId}`);
-		}
-		const refreshed = entry.credential;
-		return {
-			access: refreshed.access,
-			refresh: REMOTE_REFRESH_SENTINEL,
-			expires: refreshed.expires,
-			accountId: refreshed.accountId,
-			email: refreshed.email,
-			projectId: refreshed.projectId,
-			enterpriseUrl: refreshed.enterpriseUrl,
-		};
-	}
-
-	/**
 	 * Resolve OAuth credentials and shell commands in config.
 	 * `oauth: false` skips credential injection (reauth's unauthenticated probe);
 	 * `forceRefresh` bypasses the expiry buffer (401/403 auth-error hook).
@@ -1529,64 +1497,18 @@ export class MCPManager {
 			const { credentialId } = lookup;
 			try {
 				let credential: MCPStoredOAuthCredential | undefined = lookup.credential;
-				const REFRESH_BUFFER_MS = 5 * 60_000;
-				const refreshResult = await this.#authStorage.refreshStoredOAuthCredential<MCPStoredOAuthCredential>(
-					credentialId,
-					{
-						observedCredential: credential,
-						credentialFromRow: row => row,
-						forceRefresh: opts?.forceRefresh,
-						refreshSkewMs: REFRESH_BUFFER_MS,
-						canRefresh: current => {
-							const material = selectMcpOAuthRefreshMaterial(current, auth);
-							return Boolean(current.refresh && material?.tokenUrl);
-						},
-						refresh: (current, signal) => {
-							// Broker-backed credentials redact the refresh token
-							// (REMOTE_REFRESH_SENTINEL); the broker holds the real one, so
-							// route the refresh through it instead of failing locally.
-							if (current.refresh === REMOTE_REFRESH_SENTINEL) {
-								return this.#refreshBrokeredMcpCredential(credentialId, signal);
-							}
-							return refreshManagedMcpOAuthCredential(current, {
-								serverUrl: config.type === "http" || config.type === "sse" ? config.url : undefined,
-								auth,
-								signal,
-							});
-						},
-						mergeRefreshedCredential: (current, refreshed) => {
-							const material = selectMcpOAuthRefreshMaterial(current, auth);
-							const tokenUrl = material?.tokenUrl;
-							const clientId = material?.clientId;
-							const clientSecret = material?.clientSecret;
-							const authorizationUrl =
-								material && "authorizationUrl" in material ? material.authorizationUrl : undefined;
-							const resourceIsFallback =
-								!material?.resource && (config.type === "http" || config.type === "sse") && Boolean(config.url);
-							const resource = material?.resource ?? (resourceIsFallback ? config.url : undefined);
-							return {
-								...current,
-								...refreshed,
-								tokenUrl,
-								clientId,
-								clientSecret,
-								resource: resourceIsFallback ? undefined : resource,
-								authorizationUrl,
-							};
-						},
-						isDefinitiveFailure: error =>
-							isDefinitiveOAuthFailure(error instanceof Error ? error.message : String(error)),
-						disabledCause: error =>
-							`oauth refresh failed: ${error instanceof Error ? error.message : String(error)}`,
-						keepCredentialOnRefreshFailure: true,
-						onRefreshFailure: refreshError => {
-							logger.warn("MCP OAuth refresh failed, using existing token", {
-								credentialId,
-								error: refreshError,
-							});
-						},
+				const refreshResult = await refreshStoredManagedMcpOAuthCredential(this.#authStorage, credentialId, {
+					serverUrl: config.type === "http" || config.type === "sse" ? config.url : undefined,
+					auth,
+					forceRefresh: opts?.forceRefresh,
+					keepCredentialOnRefreshFailure: true,
+					onRefreshFailure: refreshError => {
+						logger.warn("MCP OAuth refresh failed, using existing token", {
+							credentialId,
+							error: refreshError,
+						});
 					},
-				);
+				});
 				if (refreshResult.removed) {
 					logger.warn("MCP OAuth refresh failed definitively; cleared credential", { credentialId });
 				}

--- a/packages/coding-agent/src/mcp/oauth-credentials.ts
+++ b/packages/coding-agent/src/mcp/oauth-credentials.ts
@@ -1,3 +1,4 @@
+import { isDefinitiveOAuthFailure, REMOTE_REFRESH_SENTINEL, type StoredOAuthRefreshResult } from "@oh-my-pi/pi-ai";
 import type { OAuthCredentials } from "@oh-my-pi/pi-ai/oauth/types";
 import { getActiveProfile } from "@oh-my-pi/pi-utils/dirs";
 import { expandEnvVarsDeep } from "../discovery/helpers";
@@ -7,6 +8,7 @@ import {
 	type MCPStoredOAuthCredential,
 	mcpOAuthCredentialId,
 	mcpOAuthCredentialProfile,
+	mcpOAuthServerUrlFromCredentialId,
 	refreshMCPOAuthToken,
 } from "./oauth-flow";
 import type { MCPAuthConfig, MCPServerConfig } from "./types";
@@ -115,6 +117,96 @@ export function refreshManagedMcpOAuthCredential(
 		authorizationUrl,
 		stripSameOriginResource: resourceIsFallback,
 		signal: opts.signal,
+	});
+}
+
+async function refreshBrokeredMcpOAuthCredential(
+	authStorage: AuthStorage,
+	credentialId: number,
+	provider: string,
+	signal?: AbortSignal,
+): Promise<OAuthCredentials> {
+	const entry = await authStorage.forceRefreshCredentialById(credentialId, signal);
+	if (entry.credential.type !== "oauth") {
+		throw new Error(`Broker returned non-OAuth credential for ${provider}`);
+	}
+	const refreshed = entry.credential;
+	return {
+		access: refreshed.access,
+		refresh: REMOTE_REFRESH_SENTINEL,
+		expires: refreshed.expires,
+		accountId: refreshed.accountId,
+		email: refreshed.email,
+		projectId: refreshed.projectId,
+		enterpriseUrl: refreshed.enterpriseUrl,
+	};
+}
+
+/**
+ * Resolve and refresh one stored MCP OAuth row through the durable credential owner.
+ *
+ * Local rows use their embedded OAuth metadata; broker-redacted rows delegate the
+ * grant to the broker. The MCP manager and standalone credential consumers share
+ * this path so rotating refresh tokens are persisted before callers receive them.
+ */
+export async function refreshStoredManagedMcpOAuthCredential(
+	authStorage: AuthStorage,
+	provider: string,
+	opts: {
+		credentialId?: number;
+		serverUrl?: string;
+		auth?: MCPAuthConfig;
+		forceRefresh?: boolean;
+		keepCredentialOnRefreshFailure?: boolean;
+		onRefreshFailure?: (error: unknown) => void;
+	} = {},
+): Promise<StoredOAuthRefreshResult<MCPStoredOAuthCredential>> {
+	const row = authStorage
+		.listStoredCredentials(provider)
+		.find(
+			entry =>
+				entry.credential.type === "oauth" && (opts.credentialId === undefined || entry.id === opts.credentialId),
+		);
+	if (row?.credential.type !== "oauth") {
+		return { credential: undefined, refreshed: false, removed: false };
+	}
+	const observedCredential: MCPStoredOAuthCredential = row.credential;
+	const serverUrl = opts.serverUrl ?? mcpOAuthServerUrlFromCredentialId(provider);
+	return authStorage.refreshStoredOAuthCredential<MCPStoredOAuthCredential>(provider, {
+		credentialId: row.id,
+		observedCredential,
+		credentialFromRow: credential => credential,
+		forceRefresh: opts.forceRefresh,
+		refreshSkewMs: 5 * 60_000,
+		canRefresh: current => {
+			const material = selectMcpOAuthRefreshMaterial(current, opts.auth);
+			return Boolean(current.refresh && material?.tokenUrl);
+		},
+		refresh: (current, signal) =>
+			current.refresh === REMOTE_REFRESH_SENTINEL
+				? refreshBrokeredMcpOAuthCredential(authStorage, row.id, provider, signal)
+				: refreshManagedMcpOAuthCredential(current, {
+						serverUrl,
+						auth: opts.auth,
+						signal,
+					}),
+		mergeRefreshedCredential: (current, refreshed) => {
+			const material = selectMcpOAuthRefreshMaterial(current, opts.auth);
+			const resourceIsFallback = !material?.resource && Boolean(serverUrl);
+			return {
+				...current,
+				...refreshed,
+				tokenUrl: material?.tokenUrl,
+				clientId: material?.clientId,
+				clientSecret: material?.clientSecret,
+				resource: resourceIsFallback ? undefined : material?.resource,
+				authorizationUrl: material && "authorizationUrl" in material ? material.authorizationUrl : undefined,
+			};
+		},
+		isDefinitiveFailure: error => isDefinitiveOAuthFailure(error instanceof Error ? error.message : String(error)),
+		disabledCause: error => `oauth refresh failed: ${error instanceof Error ? error.message : String(error)}`,
+		keepCredentialOnRefreshFailure: opts.keepCredentialOnRefreshFailure ?? true,
+		onRefreshFailure: opts.onRefreshFailure,
 	});
 }
 

--- a/packages/coding-agent/src/mcp/oauth-credentials.ts
+++ b/packages/coding-agent/src/mcp/oauth-credentials.ts
@@ -148,6 +148,12 @@ async function refreshBrokeredMcpOAuthCredential(
  * Local rows use their embedded OAuth metadata; broker-redacted rows delegate the
  * grant to the broker. The MCP manager and standalone credential consumers share
  * this path so rotating refresh tokens are persisted before callers receive them.
+ *
+ * `serverUrl` supplies the RFC 8707 fallback resource indicator; the manager passes
+ * the configured server URL for http/sse servers and `undefined` for stdio servers,
+ * whose refresh must NOT advertise a resource. Standalone consumers that hold only
+ * the credential id (`omp token`) set `recoverServerUrlFromCredentialId` to derive
+ * the same fallback resource the http/sse client would use.
  */
 export async function refreshStoredManagedMcpOAuthCredential(
 	authStorage: AuthStorage,
@@ -155,6 +161,7 @@ export async function refreshStoredManagedMcpOAuthCredential(
 	opts: {
 		credentialId?: number;
 		serverUrl?: string;
+		recoverServerUrlFromCredentialId?: boolean;
 		auth?: MCPAuthConfig;
 		forceRefresh?: boolean;
 		keepCredentialOnRefreshFailure?: boolean;
@@ -171,7 +178,9 @@ export async function refreshStoredManagedMcpOAuthCredential(
 		return { credential: undefined, refreshed: false, removed: false };
 	}
 	const observedCredential: MCPStoredOAuthCredential = row.credential;
-	const serverUrl = opts.serverUrl ?? mcpOAuthServerUrlFromCredentialId(provider);
+	const serverUrl =
+		opts.serverUrl ??
+		(opts.recoverServerUrlFromCredentialId ? mcpOAuthServerUrlFromCredentialId(provider) : undefined);
 	return authStorage.refreshStoredOAuthCredential<MCPStoredOAuthCredential>(provider, {
 		credentialId: row.id,
 		observedCredential,

--- a/packages/coding-agent/test/token-mcp-oauth-refresh.test.ts
+++ b/packages/coding-agent/test/token-mcp-oauth-refresh.test.ts
@@ -2,8 +2,60 @@ import { Database } from "bun:sqlite";
 import { expect, test } from "bun:test";
 import * as path from "node:path";
 import { AuthStorage, SqliteAuthCredentialStore } from "@oh-my-pi/pi-ai";
+import { refreshStoredManagedMcpOAuthCredential } from "@oh-my-pi/pi-coding-agent/mcp/oauth-credentials";
 import type { MCPStoredOAuthCredential } from "@oh-my-pi/pi-coding-agent/mcp/oauth-flow";
 import { TempDir } from "@oh-my-pi/pi-utils";
+
+/** Capture the `resource` form field of the single refresh_token grant a helper call makes. */
+async function captureRefreshResource(
+	recoverServerUrlFromCredentialId: boolean,
+): Promise<{ resources: (string | null)[]; access: string | undefined }> {
+	// Credential id embeds a DIFFERENT origin than the token endpoint, so a
+	// recovered fallback resource survives same-origin filtering and is observable.
+	const provider = "mcp_oauth:profile:default:https://remote.example.test/mcp";
+	const resources: (string | null)[] = [];
+	const tokenServer = Bun.serve({
+		hostname: "127.0.0.1",
+		port: 0,
+		async fetch(request) {
+			const body = new URLSearchParams(await request.text());
+			resources.push(body.get("resource"));
+			return Response.json({ access_token: "access-1", refresh_token: "refresh-1", expires_in: 3600 });
+		},
+	});
+	try {
+		const storage = new AuthStorage(new SqliteAuthCredentialStore(new Database(":memory:")));
+		await storage.reload();
+		const credential: MCPStoredOAuthCredential = {
+			type: "oauth",
+			access: "access-0",
+			refresh: "refresh-0",
+			expires: Date.now() - 60_000,
+			tokenUrl: `http://127.0.0.1:${tokenServer.port}/token`,
+		};
+		await storage.set(provider, credential);
+		const result = await refreshStoredManagedMcpOAuthCredential(storage, provider, {
+			forceRefresh: true,
+			recoverServerUrlFromCredentialId,
+		});
+		storage.close();
+		return { resources, access: result.credential?.access };
+	} finally {
+		tokenServer.stop(true);
+	}
+}
+
+test("standalone refresh recovers the fallback resource from the credential id", async () => {
+	const { resources, access } = await captureRefreshResource(true);
+	expect(access).toBe("access-1");
+	expect(resources).toEqual(["https://remote.example.test/mcp"]);
+});
+
+test("refresh without server-url recovery advertises no resource", async () => {
+	const { resources, access } = await captureRefreshResource(false);
+	expect(access).toBe("access-1");
+	expect(resources).toEqual([null]);
+});
 
 const cliEntry = path.join(import.meta.dir, "..", "src", "cli.ts");
 

--- a/packages/coding-agent/test/token-mcp-oauth-refresh.test.ts
+++ b/packages/coding-agent/test/token-mcp-oauth-refresh.test.ts
@@ -133,3 +133,44 @@ test("token refreshes and persists a rotating local MCP OAuth grant", async () =
 		tokenServer.stop(true);
 	}
 }, 30_000);
+
+test("token refuses a managed MCP id scoped to another profile", async () => {
+	using tempDir = TempDir.createSync("@omp-token-mcp-oauth-xprofile-");
+	// A non-expired row that the fall-through resolver WOULD hand back verbatim.
+	const foreignProvider = "mcp_oauth:profile:work:https://mcp.example.test/mcp";
+	const dbPath = tempDir.join("agent.db");
+	const store = await SqliteAuthCredentialStore.open(dbPath);
+	const authStorage = new AuthStorage(store);
+	await authStorage.reload();
+	await authStorage.set(foreignProvider, {
+		type: "oauth",
+		access: "work-access",
+		refresh: "work-refresh",
+		expires: Date.now() + 3_600_000,
+	});
+	authStorage.close();
+
+	const proc = Bun.spawn([process.execPath, cliEntry, "token", foreignProvider], {
+		cwd: path.resolve(import.meta.dir, "../../.."),
+		env: {
+			...process.env,
+			NO_COLOR: "1",
+			OMP_AUTH_BROKER_TOKEN: undefined,
+			OMP_AUTH_BROKER_URL: undefined,
+			OMP_PROFILE: undefined,
+			PI_PROFILE: undefined,
+			PI_CODING_AGENT_DIR: tempDir.path(),
+		},
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	const [exitCode, stdout, stderr] = await Promise.all([
+		proc.exited,
+		new Response(proc.stdout).text(),
+		new Response(proc.stderr).text(),
+	]);
+
+	expect(exitCode).toBe(1);
+	expect(stdout).not.toContain("work-access");
+	expect(stderr).toContain('profile "work"');
+}, 30_000);

--- a/packages/coding-agent/test/token-mcp-oauth-refresh.test.ts
+++ b/packages/coding-agent/test/token-mcp-oauth-refresh.test.ts
@@ -1,0 +1,83 @@
+import { Database } from "bun:sqlite";
+import { expect, test } from "bun:test";
+import * as path from "node:path";
+import { AuthStorage, SqliteAuthCredentialStore } from "@oh-my-pi/pi-ai";
+import type { MCPStoredOAuthCredential } from "@oh-my-pi/pi-coding-agent/mcp/oauth-flow";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+const cliEntry = path.join(import.meta.dir, "..", "src", "cli.ts");
+
+test("token refreshes and persists a rotating local MCP OAuth grant", async () => {
+	using tempDir = TempDir.createSync("@omp-token-mcp-oauth-");
+	const provider = "mcp_oauth:profile:default:https://mcp.example.test/MCP";
+	const dbPath = tempDir.join("agent.db");
+	const refreshTokens: string[] = [];
+	const tokenServer = Bun.serve({
+		hostname: "127.0.0.1",
+		port: 0,
+		async fetch(request) {
+			const body = new URLSearchParams(await request.text());
+			refreshTokens.push(body.get("refresh_token") ?? "");
+			return Response.json({
+				access_token: "access-1",
+				refresh_token: "refresh-1",
+				expires_in: 3600,
+			});
+		},
+	});
+
+	try {
+		const store = await SqliteAuthCredentialStore.open(dbPath);
+		const authStorage = new AuthStorage(store);
+		await authStorage.reload();
+		const credential: MCPStoredOAuthCredential = {
+			type: "oauth",
+			access: "access-0",
+			refresh: "refresh-0",
+			expires: Date.now() - 60_000,
+			tokenUrl: `http://127.0.0.1:${tokenServer.port}/token`,
+		};
+		await authStorage.set(provider, credential);
+		authStorage.close();
+
+		const proc = Bun.spawn([process.execPath, cliEntry, "token", provider, "--force-refresh"], {
+			cwd: path.resolve(import.meta.dir, "../../.."),
+			env: {
+				...process.env,
+				NO_COLOR: "1",
+				OMP_AUTH_BROKER_TOKEN: undefined,
+				OMP_AUTH_BROKER_URL: undefined,
+				PI_CODING_AGENT_DIR: tempDir.path(),
+			},
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		const [exitCode, stdout, stderr] = await Promise.all([
+			proc.exited,
+			new Response(proc.stdout).text(),
+			new Response(proc.stderr).text(),
+		]);
+
+		expect(exitCode, stderr).toBe(0);
+		expect(stdout).toBe("access-1\n");
+		expect(refreshTokens).toEqual(["refresh-0"]);
+
+		const persistedStore = await SqliteAuthCredentialStore.open(dbPath);
+		const persistedStorage = new AuthStorage(persistedStore);
+		await persistedStorage.reload();
+		const persisted = persistedStorage.get(provider);
+		expect(persisted?.type).toBe("oauth");
+		if (persisted?.type === "oauth") {
+			expect(persisted.access).toBe("access-1");
+			expect(persisted.refresh).toBe("refresh-1");
+		}
+		persistedStorage.close();
+
+		const db = new Database(dbPath, { readonly: true });
+		const blockCount = db.query<{ count: number }, []>("SELECT count(*) AS count FROM auth_credential_blocks").get();
+		db.close();
+		expect(blockCount?.count).toBe(0);
+	} finally {
+		tokenServer.stop(true);
+	}
+}, 30_000);


### PR DESCRIPTION
## Repro
With an expired self-describing `mcp_oauth:profile:default:<url>` row in the local SQLite credential store, run `omp token "mcp_oauth:profile:default:<url>" --force-refresh`. Before this change the command returned `No active credential found`, made no request to the embedded token endpoint, and inserted a five-minute `auth_credential_blocks` row. The recorded repro used `bun /tmp/repro-9953.ts` with an in-memory store and rotating local token endpoint.

## Cause
`packages/coding-agent/src/commands/token.ts` routed every provider through `ModelRegistry.getApiKeyForProvider`, which sent managed MCP provider IDs into `AuthStorage`’s built-in OAuth-provider dispatcher. That dispatcher intentionally has no `mcp_oauth:*` provider definition, while the correct self-describing grant and durable rotation logic lived only in `MCPManager.#resolveAuthConfig` in `packages/coding-agent/src/mcp/manager.ts`. The command also lowercased the full provider string, including the URL-keyed credential ID.

## Fix
- Extract the MCP manager’s durable local/broker refresh flow into `refreshStoredManagedMcpOAuthCredential` in `packages/coding-agent/src/mcp/oauth-credentials.ts`.
- Route managed MCP credentials from `omp token` through that shared path, preserving exact URL-keyed IDs and rejecting unchanged stale results without writing credential blocks.
- Cover the real CLI command with a rotating token endpoint and assert the new access token, rotated refresh-token persistence, exact mixed-case URL lookup, and absence of block rows.
- Document the user-visible fix in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/mcp-manager-oauth-refresh.test.ts packages/coding-agent/test/mcp-broker-oauth-refresh.test.ts packages/coding-agent/test/token-mcp-oauth-refresh.test.ts` — 10 passed, 0 failed. `bun run check:types` in `packages/coding-agent` passed. The pre-publish `bun run fix` and `bun check` gate passed while pushing. Fixes #9953