### PR TITLE
fix(tui): stop the resize pre-erase archiving the unfinished frame into scrollback

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Fixed pending-work animations repeatedly composing expensive frames without applying their full render cost to CPU backpressure.
 - Fixed unfinished live viewport rows entering tmux pane history and duplicating streamed output ([#9780](https://github.com/can1357/oh-my-pi/issues/9780)).
+- Fixed the resize pre-erase archiving the unfinished frame into scrollback on terminals that preserve a full-screen clear, including when a cursor-relative erase clamps onto the first row ([#9780](https://github.com/can1357/oh-my-pi/issues/9780)).
 
 ## [18.0.7] - 2026-08-26
 

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - Fixed pending-work animations repeatedly composing expensive frames without applying their full render cost to CPU backpressure.
 - Fixed unfinished live viewport rows entering tmux pane history and duplicating streamed output ([#9780](https://github.com/can1357/oh-my-pi/issues/9780)).
-- Fixed the resize pre-erase archiving the unfinished frame into scrollback on terminals that preserve a full-screen clear, including when a cursor-relative erase clamps onto the first row ([#9780](https://github.com/can1357/oh-my-pi/issues/9780)).
+- Fixed resizing a terminal copying the current screen into scrollback in tmux panes and Windows consoles, leaving a duplicate of the in-progress turn above the live one ([#9962](https://github.com/can1357/oh-my-pi/pull/9962) by [@nategriffin26](https://github.com/nategriffin26)).
 
 ## [18.0.7] - 2026-08-26
 

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -55,6 +55,17 @@ const SEGMENT_RESET = "\x1b[0m";
 const LINE_TERMINATOR = "\x1b[0m\x1b]8;;\x07";
 const ERASE_LINE = "\x1b[2K";
 const ERASE_TO_END_OF_LINE = "\x1b[K";
+// Erase the cursor's row and everything below it, cursor-relative, without ever
+// issuing a full-screen clear: tmux (`grid_view_clear_history()`) and Windows
+// conhost (#9597) archive a screen-wide erase into scrollback instead of
+// discarding it, so an erase that starts on the first cell preserves the very
+// live rows it exists to remove (#9780). EL2 clears the cursor's row, then ED0
+// from the next column clears the remainder, which leaves the cursor off the
+// first cell for the erase that spans the rest of the screen. The trailing CR
+// restores the column, so callers see the same cursor position as a plain
+// `\r\x1b[J`. Used where the resize path must stay cursor-relative because the
+// terminal reflowed the normal buffer and absolute rows are stale.
+const ERASE_BELOW_CURSOR_ROW = "\r\x1b[2K\x1b[C\x1b[J\r";
 // Keep the common short-row path out of native width/truncation. Longer rows
 // are fit by visible cells, not source code units, so zero-width-heavy prefixes
 // cannot hide visible suffix text that still belongs in the viewport.
@@ -1148,7 +1159,7 @@ export class TUI extends Container {
 						this.terminal.columns,
 					);
 					const top = Math.max(0, Math.min(this.#providerViewportTop, this.terminal.rows - staleRows));
-					erase = `\x1b[?25l\x1b[${top + 1};1H\x1b[J`;
+					erase = `\x1b[?25l${this.#eraseBelowRow(top, this.terminal.rows)}`;
 				} else {
 					const up = this.#reflowedRowCount(
 						this.#providerWindow,
@@ -1156,7 +1167,7 @@ export class TUI extends Container {
 						this.#parkedViewportOffset,
 						this.terminal.columns,
 					);
-					erase = `\x1b[?25l${up > 0 ? `\x1b[${up}A` : ""}\r\x1b[J`;
+					erase = `\x1b[?25l${up > 0 ? `\x1b[${up}A` : ""}${ERASE_BELOW_CURSOR_ROW}`;
 				}
 				// Both erase paths leave the cursor on the viewport's top row, so the
 				// parked offset no longer applies; carrying a stale nonzero offset
@@ -2264,6 +2275,23 @@ export class TUI extends Container {
 	}
 
 	/**
+	 * Erase `row` and everything below it, absolute-addressed, without ever
+	 * issuing a full-screen clear. tmux and Windows conhost (#9597) archive a
+	 * screen-wide erase into pane history instead of discarding it, so an erase
+	 * anchored on the first row would preserve the unfinished frame it exists to
+	 * remove (#9780). Below existing history a plain ED0 cannot span the screen;
+	 * on the first row, EL2 that row and ED0 from the second down touch the same
+	 * cells with no full-screen clear. `row` is clamped because a caller's
+	 * viewport top can predate a height shrink.
+	 */
+	#eraseBelowRow(row: number, height: number): string {
+		const top = Math.max(0, Math.min(row, Math.max(0, height - 1)));
+		if (top > 0) return `\x1b[${top + 1};1H\x1b[J`;
+		if (height <= 1) return `\x1b[1;1H${ERASE_LINE}`;
+		return `\x1b[1;1H${ERASE_LINE}\x1b[2;1H\x1b[J`;
+	}
+
+	/**
 	 * Physical write transaction: append an ordinary batch, or bottom-split one
 	 * complete replay into a history remainder and final viewport, then serialize
 	 * the whole result in one terminal write before acknowledgement.
@@ -2371,16 +2399,7 @@ export class TUI extends Container {
 			// committed rows and blanks, never an unfinished frame.
 			const pushed = Math.max(0, startTop + preparedHistory.length + rows - height);
 			if (pushed > this.#providerViewportTop && this.#providerWindow.length > 0) {
-				const eraseTop = this.#providerViewportTop;
-				if (eraseTop > 0) {
-					// Below existing history: ED0 here never spans the whole screen.
-					buffer += `\x1b[${eraseTop + 1};1H\x1b[J`;
-				} else {
-					// Full-screen erase makes tmux preserve the live rows (#9780);
-					// EL2 the first row + ED0 the rest clears the same cells, no full clear.
-					buffer += "\x1b[1;1H\x1b[2K";
-					if (height > 1) buffer += "\x1b[2;1H\x1b[J";
-				}
+				buffer += this.#eraseBelowRow(this.#providerViewportTop, height);
 			}
 			buffer += `\x1b[${startTop + 1};1H`;
 			let screenRow = startTop;

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -55,17 +55,6 @@ const SEGMENT_RESET = "\x1b[0m";
 const LINE_TERMINATOR = "\x1b[0m\x1b]8;;\x07";
 const ERASE_LINE = "\x1b[2K";
 const ERASE_TO_END_OF_LINE = "\x1b[K";
-// Erase the cursor's row and everything below it, cursor-relative, without ever
-// issuing a full-screen clear: tmux (`grid_view_clear_history()`) and Windows
-// conhost (#9597) archive a screen-wide erase into scrollback instead of
-// discarding it, so an erase that starts on the first cell preserves the very
-// live rows it exists to remove (#9780). EL2 clears the cursor's row, then ED0
-// from the next column clears the remainder, which leaves the cursor off the
-// first cell for the erase that spans the rest of the screen. The trailing CR
-// restores the column, so callers see the same cursor position as a plain
-// `\r\x1b[J`. Used where the resize path must stay cursor-relative because the
-// terminal reflowed the normal buffer and absolute rows are stale.
-const ERASE_BELOW_CURSOR_ROW = "\r\x1b[2K\x1b[C\x1b[J\r";
 // Keep the common short-row path out of native width/truncation. Longer rows
 // are fit by visible cells, not source code units, so zero-width-heavy prefixes
 // cannot hide visible suffix text that still belongs in the viewport.
@@ -1167,7 +1156,8 @@ export class TUI extends Container {
 						this.#parkedViewportOffset,
 						this.terminal.columns,
 					);
-					erase = `\x1b[?25l${up > 0 ? `\x1b[${up}A` : ""}${ERASE_BELOW_CURSOR_ROW}`;
+					const eraseBelow = this.#eraseBelowCursorRow(this.terminal.columns, this.terminal.rows);
+					erase = `\x1b[?25l${up > 0 ? `\x1b[${up}A` : ""}${eraseBelow}`;
 				}
 				// Both erase paths leave the cursor on the viewport's top row, so the
 				// parked offset no longer applies; carrying a stale nonzero offset
@@ -2289,6 +2279,29 @@ export class TUI extends Container {
 		if (top > 0) return `\x1b[${top + 1};1H\x1b[J`;
 		if (height <= 1) return `\x1b[1;1H${ERASE_LINE}`;
 		return `\x1b[1;1H${ERASE_LINE}\x1b[2;1H\x1b[J`;
+	}
+
+	/**
+	 * Erase the cursor's row and everything below it, cursor-relative, without
+	 * ever issuing a full-screen clear. Used where the resize path must stay
+	 * cursor-relative: the terminal reflowed the normal buffer, so absolute rows
+	 * are stale and only the parked cursor still tracks the viewport's logical
+	 * line. Every form leaves the cursor on column zero of that row, exactly
+	 * where a plain `\r\x1b[J` left it.
+	 *
+	 * The erase must never run from the first cell, which is what makes tmux and
+	 * Windows conhost (#9597) archive the screen instead of discarding it
+	 * (#9780), and a clamped CUU can put the cursor on the first row without
+	 * naming it. Stepping one column right is enough and needs no row movement,
+	 * but at one column CUF cannot leave the first cell, so step one row down
+	 * instead: from the first row that can only reach row 1, and DECSC/DECRC
+	 * restores the anchor even when CUD clamps at the last row. A one-row screen
+	 * has nothing below the cursor, so EL2 alone clears everything.
+	 */
+	#eraseBelowCursorRow(width: number, height: number): string {
+		if (height <= 1) return `\r${ERASE_LINE}`;
+		if (width > 1) return `\r${ERASE_LINE}\x1b[C\x1b[J\r`;
+		return `\r${ERASE_LINE}\x1b7\x1b[B\x1b[J\x1b8`;
 	}
 
 	/**

--- a/packages/tui/test/resize-preserved-clear.test.ts
+++ b/packages/tui/test/resize-preserved-clear.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import {
+	CURSOR_MARKER,
+	type TerminalFramePlan,
+	type TerminalFrameProvider,
+	TUI,
+	type ViewportSize,
+} from "@oh-my-pi/pi-tui";
+import { VirtualTerminal } from "./virtual-terminal";
+
+// Regression coverage for the SIGWINCH-side pre-erase archiving the unfinished
+// frame on terminals that preserve a full-screen clear (#9780).
+//
+// Before borrowing the alt buffer, the resize path erases the live viewport off
+// the normal screen so a reflow-driven scroll can only push committed rows into
+// scrollback. When that erase starts on the first row - the steady state once
+// the transcript fills the screen - it covers the whole screen, and a
+// preserving terminal archives the screen it is about to blank instead of
+// discarding it. The erase meant to keep live rows out of scrollback then puts
+// the whole unfinished frame (spinner, half-written cards, composer) there,
+// which is the same defect e72762e7d fixed for the history-append path.
+//
+// The grow branch addresses the erase cursor-relative, so the bytes alone do
+// not reveal the trigger: a CUU larger than the distance to the top clamps at
+// the first row, and `\r\x1b[J` there is screen-wide. The terminal below
+// therefore samples the cursor at each erase, exactly as tmux does.
+
+/**
+ * Models a terminal that preserves a full-screen clear, as tmux and Windows
+ * conhost (#9597) do: tmux's `screen_write_clearendofscreen()` routes through
+ * `grid_view_clear_history()` when the cursor sits on the first cell, and ED2
+ * always archives. Counts those clears and pushes the visible screen into
+ * scrollback before performing them.
+ */
+class PreservedClearTerminal extends VirtualTerminal {
+	archivedClears = 0;
+
+	override write(data: string): void {
+		const erase = /\x1b\[([0-2]?)J/g;
+		let cursor = 0;
+		for (let match = erase.exec(data); match; match = erase.exec(data)) {
+			super.write(data.slice(cursor, match.index));
+			cursor = match.index + match[0].length;
+			const mode = match[1] === "" ? "0" : match[1];
+			const position = this.getCursor();
+			if (mode === "2" || (mode === "0" && position.row === 0 && position.col === 0)) {
+				this.archivedClears++;
+				super.write(`\x1b[${this.rows};1H${"\n".repeat(this.rows)}`);
+			}
+			super.write(match[0]);
+		}
+		super.write(data.slice(cursor));
+	}
+}
+
+class FullFrameProvider implements TerminalFrameProvider {
+	history: { id: number; rows: string[] } | undefined;
+	markerRow: number | undefined;
+	liveRows = 12;
+
+	renderFrame(viewport: ViewportSize): TerminalFramePlan {
+		const rows = Array.from({ length: Math.min(this.liveRows, viewport.rows) }, (_, index) => `live-${index}`);
+		if (this.markerRow !== undefined && this.markerRow < rows.length) {
+			rows[this.markerRow] = `${rows[this.markerRow]}${CURSOR_MARKER}`;
+		}
+		return { history: this.history, viewport: rows };
+	}
+	renderResizeFrame(viewport: ViewportSize): readonly string[] {
+		return Array.from({ length: Math.min(this.liveRows, viewport.rows) }, (_, index) => `resize-${index}`);
+	}
+	acknowledgeHistory(): void {
+		this.history = undefined;
+	}
+}
+
+class ResizeScheduler {
+	#pending = new Set<() => void>();
+	t = 0;
+	now(): number {
+		return this.t;
+	}
+	scheduleImmediate(callback: () => void): void {
+		callback();
+	}
+	scheduleRender(callback: () => void, _delayMs?: number) {
+		this.#pending.add(callback);
+		return { cancel: () => this.#pending.delete(callback) };
+	}
+	settle(): void {
+		const pending = [...this.#pending];
+		this.#pending.clear();
+		for (const callback of pending) callback();
+	}
+}
+
+// Every signal isInsideTerminalMultiplexer() recognizes; the suite itself may
+// run under tmux, screen, Zellij, CMUX, or Herdr, and the SIGWINCH-side erase
+// only runs on direct terminals.
+const MUX_SIGNALS = [
+	"TMUX",
+	"STY",
+	"ZELLIJ",
+	"HERDR_ENV",
+	"CMUX_WORKSPACE_ID",
+	"CMUX_SURFACE_ID",
+	"CMUX_REMOTE_TRANSPORT",
+	"TERM",
+] as const;
+
+function startRig(markerRow?: number) {
+	const terminal = new PreservedClearTerminal(40, 12);
+	const provider = new FullFrameProvider();
+	provider.markerRow = markerRow;
+	const renderScheduler = new ResizeScheduler();
+	const tui = new TUI(terminal, undefined, { renderScheduler });
+	tui.setFrameProvider(provider);
+	tui.start();
+	terminal.archivedClears = 0;
+	return { terminal, tui, provider, renderScheduler };
+}
+
+describe("resize pre-erase on a preserved-clear terminal", () => {
+	let saved: Partial<Record<(typeof MUX_SIGNALS)[number], string | undefined>>;
+	beforeEach(() => {
+		saved = {};
+		for (const key of MUX_SIGNALS) {
+			saved[key] = Bun.env[key];
+			delete Bun.env[key];
+		}
+		Bun.env.TERM = "xterm-256color";
+	});
+	afterEach(() => {
+		for (const key of MUX_SIGNALS) {
+			if (saved[key] === undefined) delete Bun.env[key];
+			else Bun.env[key] = saved[key];
+		}
+	});
+
+	it("keeps live rows out of scrollback when a height grow erases a screen-filling viewport", () => {
+		// The parked cursor sits mid-frame, so the erase moves up by more rows
+		// than the screen has above it and clamps onto the first row.
+		const { terminal, tui, renderScheduler } = startRig(4);
+		expect(terminal.getViewport()[0]?.trimEnd()).toBe("live-0");
+
+		terminal.resize(40, 20);
+		renderScheduler.settle();
+
+		const buffer = terminal.getScrollBuffer();
+		const history = buffer.slice(0, Math.max(0, buffer.length - terminal.rows));
+		expect(history.map(row => Bun.stripANSI(row).trimEnd()).filter(row => row.startsWith("live-"))).toEqual([]);
+		expect(terminal.archivedClears).toBe(0);
+		tui.stop();
+	});
+
+	it("never issues a screen-wide clear when a height shrink erases a screen-filling viewport", () => {
+		// A height shrink pushes the screen's top rows into scrollback in the
+		// terminal itself, before the app is signalled, so scrollback content is
+		// not the discriminator here - the erase must simply never be screen-wide.
+		const { terminal, tui, renderScheduler } = startRig();
+		expect(terminal.getViewport()[0]?.trimEnd()).toBe("live-0");
+
+		terminal.resize(40, 6);
+		renderScheduler.settle();
+
+		expect(terminal.archivedClears).toBe(0);
+		tui.stop();
+	});
+});

--- a/packages/tui/test/resize-preserved-clear.test.ts
+++ b/packages/tui/test/resize-preserved-clear.test.ts
@@ -107,8 +107,8 @@ const MUX_SIGNALS = [
 	"TERM",
 ] as const;
 
-function startRig(markerRow?: number) {
-	const terminal = new PreservedClearTerminal(40, 12);
+function startRig(markerRow?: number, columns = 40, rows = 12) {
+	const terminal = new PreservedClearTerminal(columns, rows);
 	const provider = new FullFrameProvider();
 	provider.markerRow = markerRow;
 	const renderScheduler = new ResizeScheduler();
@@ -160,6 +160,19 @@ describe("resize pre-erase on a preserved-clear terminal", () => {
 		expect(terminal.getViewport()[0]?.trimEnd()).toBe("live-0");
 
 		terminal.resize(40, 6);
+		renderScheduler.settle();
+
+		expect(terminal.archivedClears).toBe(0);
+		tui.stop();
+	});
+
+	it("keeps the erase off the first cell at a one-column viewport, where CUF cannot move", () => {
+		// One column is a supported geometry, and there CUF clamps at the right
+		// margin: stepping one column right leaves the cursor on the first cell,
+		// so the erase has to step a row instead.
+		const { terminal, tui, renderScheduler } = startRig(2, 1, 4);
+
+		terminal.resize(1, 8);
 		renderScheduler.settle();
 
 		expect(terminal.archivedClears).toBe(0);


### PR DESCRIPTION
## What

I hit the #9780 duplication badly on a phone over tmux and dug into where the rows were actually coming from; e72762e7d fixed the append path, but the resize path still emits a full-screen erase, so I fixed that site the same way and added a test that catches the cursor-relative spelling too.

`#beginResizeAltPaint()` erases the live viewport off the normal screen before borrowing the alt buffer, so a reflow-driven scroll can only push committed rows into scrollback. Once the transcript fills the screen the viewport starts on the first row, and that erase then covers the whole screen. tmux and Windows conhost (#9597) *archive* a screen-wide erase into scrollback instead of discarding it, so the erase that exists to keep live rows out of history is what puts the entire unfinished frame — spinner, half-written tool card, composer, status line — there, one full screen per resize.

Both erase sites now clear the same cells without ever issuing a screen-wide erase:

- `#eraseBelowRow(row, height)` — absolute callers, shared with the append path. Below existing history a plain ED0 cannot span the screen; on the first row it is EL2 plus ED0 from the second row down. `row` is clamped, because a caller's viewport top can predate a height shrink.
- `#eraseBelowCursorRow(width, height)` — the resize caller, which must stay cursor-relative: the terminal reflowed the normal buffer, so absolute rows are stale and only the parked cursor still tracks the viewport's logical line. `width > 1` steps one column right (no row movement, so a clamped CUU cannot mis-target it); `width <= 1` steps one row down instead, where CUD from the first row can only reach row 1 and DECSC/DECRC restores the column-zero anchor even when CUD clamps at the last row; a one-row screen needs no ED0 at all. Every form leaves the cursor exactly where the previous `\r\x1b[J` left it.

No tmux detection, same behavior on every terminal.

## Why

The grow branch hides the bug: it addresses the erase cursor-relative on purpose, and a CUU larger than the distance to the top **clamps** onto the first row, so `\r\x1b[J` is screen-wide there without ever naming row 1. Captured from a real session at `1030dd3` with `PI_TUI_WRITE_LOG`, resizing an 88x24 pane to 50 columns:

```
\x1b[?25l\x1b[34A\r\x1b[J\x1b[?1049h...
         ^^^^^^^^ CUU 34 on a 24-row screen -> row 1 -> screen-wide ED0
```

tmux's trigger is positional, not textual: `screen_write_clearendofscreen()` routes through `grid_view_clear_history()` when the cursor sits on the first cell. That is why the bytes alone cannot classify the clamped case, and why the test samples the cursor instead of matching sequences.

Measured against tmux 3.6a — 88x41 pane, 41 rows of content, then the erase, counting what survived in `capture-pane -p -S -`:

|erase|rows archived|
|---|---|
|`CSI 1;1H` `CSI J`|41|
|`CSI H` `CSI J`|41|
|`CR` `CSI J` at row 1|41|
|`CSI 99A` `CR` `CSI J` (clamped)|41|
|`CSI 1;1H` `EL2` + `CSI 2;1H` `CSI J` (absolute form here)|1|
|`CR` `EL2` `CUF` `CSI J` `CR` (cursor-relative, width > 1)|1|

And in a 1x8 pane, where CUF cannot leave the first cell: the width-agnostic `CR EL2 CUF ED0 CR` leaves 17 rows of pane history (a screen archived), the `CR EL2 DECSC CUD ED0 DECRC` form leaves 10 (nothing archived).

It also lands on the path that fires most often in practice — a phone keyboard opening and closing, a dragged window, a pane split.

## Testing

- `packages/tui/test/resize-preserved-clear.test.ts` (new, 3 cases). The harness models a preserving terminal by sampling the cursor at each erase, so it catches the clamped cursor-relative form the bytes cannot classify. Each case fails on the code it guards:
  - height grow: on `1030dd3` the whole 12-row live frame is archived (`live-0` … `live-11`); passes here.
  - height shrink: asserts on the screen-wide-clear count rather than scrollback content, because a height shrink pushes the screen's top rows into history inside the terminal itself, before the app is signalled.
  - one column (`1x4` grown to `1x8`): fails on the width-agnostic CUF form, passes with the geometry-aware one.
- `bun test packages/tui/test`: 1377 pass, 3 fail — the 3 are the pre-existing `kitty-keyboard-da1-ordering` failures, identical with the change stashed.
- End to end from source in a real tmux pane (`TERM=xterm-256color`, `TMUX` unset so the direct-terminal branch runs): built up a screen-filling transcript, then resized 88x41 → 50x24 → 40x20 → 30x16 while capturing `PI_TUI_WRITE_LOG`. Before: the clamped `CSI 34A CR CSI J` above. After: the pre-erase is the split form and no live row reaches pane history. Same session also confirms the released v18.0.7 binary leaks 46 rows per `/context` submission at 88x41 against 8 (a legitimate retirement batch) at HEAD, which is how I located this site.

Refs #9780. Follow-up to e72762e7d, which fixed the append path only.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
