### PR TITLE
fix(catalog): include glm-5.3 flash in effort ladder

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Fixed OpenCode Go and Zen GLM-5.3 Flash models sending the rejected `reasoning_effort: "xhigh"` top tier; they now expose the mandatory wire-exact `low`/`high`/`max` ladder ([#9960](https://github.com/can1357/oh-my-pi/issues/9960)).
 - Fixed the thinking control mode for OpenAI models served over Bedrock Converse (`global.openai.gpt-5.6-luna`, `-sol`, `-terra`), which are now classified as `effort` rather than `budget` so requests use OpenAI's reasoning schema.
 - Fixed LiteLLM discovery leaking a colliding bundled model's provider-specific transport onto custom endpoints: a discovered alias (e.g. `kimi-k3`) matching a bundled Fireworks model no longer inherits that model's wire-id transform, which had caused requests to POST a model id the endpoint never advertised and return HTTP 400 ([#9938](https://github.com/can1357/oh-my-pi/issues/9938)).
 

--- a/packages/catalog/src/identity/family.ts
+++ b/packages/catalog/src/identity/family.ts
@@ -314,19 +314,19 @@ export const isGlm52ReasoningEffortModelId = memo((modelId: string): boolean => 
 });
 
 /**
- * GLM-5.3+ coding SKUs. Unlike GLM-5.2 (whose reasoning_effort dialect is
- * host-specific), GLM-5.3+ exposes a uniform wire-exact `low`/`high`/`max`
- * ladder on every host, and thinking can no longer be disabled —
- * `thinking.type` must always be `enabled`. Matching the family keeps future
- * bumps (`glm-5.4`, `glm-6`, …) covered while excluding the vision (`…v`)
- * shape and the non-reasoning `-flash`/`-flashx`/`-preview` variants.
+ * GLM-5.3+ reasoning-effort SKUs. Unlike GLM-5.2 (whose dialect is
+ * host-specific), the base, `-air`, `-turbo`, and `-flash` variants expose a
+ * uniform wire-exact `low`/`high`/`max` ladder on every host, and thinking can
+ * no longer be disabled — `thinking.type` must always be `enabled`. Matching
+ * the family keeps future bumps (`glm-5.4`, `glm-6`, …) covered while excluding
+ * the vision (`…v`) shape and the non-reasoning `-flashx`/`-preview` variants.
  */
 export const isGlm53ReasoningEffortModelId = memo((modelId: string): boolean => {
 	const glm = parseGlmModel(bareModelId(modelId));
 	if (!glm || glm.vision) {
 		return false;
 	}
-	if (glm.variant !== "base" && glm.variant !== "air" && glm.variant !== "turbo") {
+	if (glm.variant !== "base" && glm.variant !== "air" && glm.variant !== "turbo" && glm.variant !== "flash") {
 		return false;
 	}
 	return semverGte(glm.version, "5.3");

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -2823,6 +2823,9 @@ const OPENCODE_GO_API_ID_OVERRIDES: Readonly<Record<string, Api>> = {
 	"qwen3.5-plus": "openai-completions",
 	"qwen3.6-plus": "openai-completions",
 };
+// Runtime-discovered rows cached before model-identity corrections retain
+// stale capability metadata until the authoritative catalog TTL expires.
+const OPENCODE_CACHE_MIGRATION_MODEL_IDS = ["glm-5.3-flash"] as const;
 
 // Billing-variant suffixes the OpenCode gateways append to a base model id
 // without changing its transport (`deepseek-v4-flash-free`,
@@ -2883,12 +2886,10 @@ function openCodeModelManagerOptions(
 		providerId,
 		cacheProviderId: resolveModelCacheProviderId(providerId, { apiKey, baseUrl: discoveryBaseUrl }),
 		dynamicModelsAuthoritative: true,
-		// The per-id API pins are cache identity: without this, rows cached
-		// before a pin was added keep the wrong endpoint until TTL expiry
-		// (#8957 — 17.3.7 caches held muse-spark-1.2[-contributor] on chat
-		// completions after the pin shipped). Sibling-catalog drift is bounded
-		// by the 2h cache TTL instead.
-		dropCachedModelIdsOnStaticMismatch: Object.keys(apiOverrides),
+		// Per-id route pins and capability migrations are cache identity:
+		// without this, rows cached before a correction keep the stale route or
+		// thinking surface until TTL expiry (#8957, #9960).
+		dropCachedModelIdsOnStaticMismatch: [...Object.keys(apiOverrides), ...OPENCODE_CACHE_MIGRATION_MODEL_IDS],
 		modelsDev: {
 			fetch: () => fetchRevalidatedWellKnownModelsWithTimeout(config?.fetch),
 			map: payload => {

--- a/packages/catalog/test/model-thinking.test.ts
+++ b/packages/catalog/test/model-thinking.test.ts
@@ -368,28 +368,6 @@ describe("model thinking derivation", () => {
 		expect(clampThinkingLevelForModel(bare, Effort.Max)).toBe(Effort.High);
 	});
 
-	it("normalizes GLM-5.3 Flash onto the mandatory low/high/max ladder (issue #9960)", () => {
-		const flash = createModel({
-			id: "glm-5.3-flash",
-			api: "openai-completions",
-			provider: "opencode-go",
-			baseUrl: "https://opencode.ai/zen/go/v1",
-			thinking: {
-				mode: "effort",
-				efforts: [Effort.Minimal, Effort.Low, Effort.Medium, Effort.High, Effort.XHigh],
-			},
-		});
-
-		expect(flash.thinking).toEqual({
-			mode: "effort",
-			efforts: [Effort.Low, Effort.High, Effort.Max],
-			defaultLevel: Effort.Max,
-			requiresEffort: true,
-		});
-		expect(requireSupportedEffort(flash, Effort.Max)).toBe(Effort.Max);
-		expect(clampThinkingLevelForModel(flash, Effort.XHigh)).toBe(Effort.High);
-	});
-
 	it("normalizes OpenCode gateway ox-alpha onto the low/high/max ladder with mandatory thinking (issue #9349)", () => {
 		// The OpenCode Go gateway rejects minimal/medium/xhigh for ox-alpha
 		// (`[1210] ... please use low, high, or max`), so the stale

--- a/packages/catalog/test/model-thinking.test.ts
+++ b/packages/catalog/test/model-thinking.test.ts
@@ -368,6 +368,28 @@ describe("model thinking derivation", () => {
 		expect(clampThinkingLevelForModel(bare, Effort.Max)).toBe(Effort.High);
 	});
 
+	it("normalizes GLM-5.3 Flash onto the mandatory low/high/max ladder (issue #9960)", () => {
+		const flash = createModel({
+			id: "glm-5.3-flash",
+			api: "openai-completions",
+			provider: "opencode-go",
+			baseUrl: "https://opencode.ai/zen/go/v1",
+			thinking: {
+				mode: "effort",
+				efforts: [Effort.Minimal, Effort.Low, Effort.Medium, Effort.High, Effort.XHigh],
+			},
+		});
+
+		expect(flash.thinking).toEqual({
+			mode: "effort",
+			efforts: [Effort.Low, Effort.High, Effort.Max],
+			defaultLevel: Effort.Max,
+			requiresEffort: true,
+		});
+		expect(requireSupportedEffort(flash, Effort.Max)).toBe(Effort.Max);
+		expect(clampThinkingLevelForModel(flash, Effort.XHigh)).toBe(Effort.High);
+	});
+
 	it("normalizes OpenCode gateway ox-alpha onto the low/high/max ladder with mandatory thinking (issue #9349)", () => {
 		// The OpenCode Go gateway rejects minimal/medium/xhigh for ox-alpha
 		// (`[1210] ... please use low, high, or max`), so the stale

--- a/packages/catalog/test/opencode-provider.test.ts
+++ b/packages/catalog/test/opencode-provider.test.ts
@@ -506,7 +506,10 @@ describe("OpenCode provider discovery", () => {
 				mode: "effort",
 				efforts: [Effort.Minimal, Effort.Low, Effort.Medium, Effort.High, Effort.XHigh],
 			},
-			input: ["text"],
+			// GLM-5.3 Flash is multimodal; image input coexists with the
+			// reasoning-effort ladder (the `glm.vision` SKU flag matches only the
+			// `…v` shape, never image capability).
+			input: ["text", "image"],
 			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 			contextWindow: 1_000_000,
 			maxTokens: 131_072,
@@ -561,6 +564,7 @@ describe("OpenCode provider discovery", () => {
 			);
 			const flash = upgraded.models.find(model => model.id === discoveredFlash.id);
 			expect(fetches).toBe(1);
+			expect(flash?.input).toEqual(["text", "image"]);
 			expect(flash?.thinking).toEqual({
 				mode: "effort",
 				efforts: [Effort.Low, Effort.High, Effort.Max],

--- a/packages/catalog/test/opencode-provider.test.ts
+++ b/packages/catalog/test/opencode-provider.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, test } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { Effort } from "@oh-my-pi/pi-catalog/effort";
+import { readModelCache, writeModelCache } from "@oh-my-pi/pi-catalog/model-cache";
 import { resolveProviderModels } from "@oh-my-pi/pi-catalog/model-manager";
 import { getSupportedEfforts } from "@oh-my-pi/pi-catalog/model-thinking";
 import { getBundledModels } from "@oh-my-pi/pi-catalog/models";
@@ -14,6 +16,7 @@ import {
 	opencodeGoModelManagerOptions,
 	opencodeZenModelManagerOptions,
 } from "@oh-my-pi/pi-catalog/provider-models/openai-compat";
+import type { ModelSpec } from "@oh-my-pi/pi-catalog/types";
 import type { FetchImpl } from "@oh-my-pi/pi-utils";
 
 const LIVE_FREE_MODEL_IDS = [
@@ -487,6 +490,86 @@ describe("OpenCode provider discovery", () => {
 		}
 		expect(opencodeGoModelManagerOptions().dynamicModelsAuthoritative).toBe(true);
 		expect(opencodeZenModelManagerOptions().dynamicModelsAuthoritative).toBe(true);
+	});
+
+	test("invalidates cached GLM-5.3 Flash effort metadata on upgrade (issue #9960)", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-catalog-opencode-glm53-flash-cache-"));
+		const cacheDbPath = path.join(tempDir, "models.db");
+		const discoveredFlash: ModelSpec<"openai-completions"> = {
+			id: "glm-5.3-flash",
+			name: "GLM-5.3-Flash",
+			api: "openai-completions",
+			provider: "opencode-go",
+			baseUrl: "https://opencode.ai/zen/go/v1",
+			reasoning: true,
+			thinking: {
+				mode: "effort",
+				efforts: [Effort.Minimal, Effort.Low, Effort.Medium, Effort.High, Effort.XHigh],
+			},
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 1_000_000,
+			maxTokens: 131_072,
+		};
+
+		try {
+			const options = opencodeGoModelManagerOptions({ apiKey: "go-account-key" });
+			const cacheProviderId = options.cacheProviderId;
+			if (!cacheProviderId) throw new Error("OpenCode Go cache provider id is missing");
+			const priorDropIds = options.dropCachedModelIdsOnStaticMismatch?.filter(id => id !== discoveredFlash.id);
+			await resolveProviderModels(
+				{
+					...options,
+					cacheDbPath,
+					modelsDev: undefined,
+					dropCachedModelIdsOnStaticMismatch: priorDropIds,
+					fetchDynamicModels: async () => [discoveredFlash],
+				},
+				"online",
+			);
+			const priorCache = readModelCache(cacheProviderId, Number.POSITIVE_INFINITY, Date.now, cacheDbPath);
+			if (!priorCache) throw new Error("OpenCode Go cache was not written");
+
+			// Rebuild under the pre-fix identity, then persist it with the prior
+			// migration-policy fingerprint to simulate an upgraded installation.
+			const staleFlash = {
+				...buildModel({ ...discoveredFlash, id: "glm-5.2-flash" }),
+				id: discoveredFlash.id,
+				name: discoveredFlash.name,
+			};
+			writeModelCache(
+				cacheProviderId,
+				priorCache.updatedAt,
+				[staleFlash],
+				true,
+				priorCache.staticFingerprint,
+				cacheDbPath,
+			);
+
+			let fetches = 0;
+			const upgraded = await resolveProviderModels(
+				{
+					...options,
+					cacheDbPath,
+					modelsDev: undefined,
+					fetchDynamicModels: async () => {
+						fetches++;
+						return [discoveredFlash];
+					},
+				},
+				"online-if-uncached",
+			);
+			const flash = upgraded.models.find(model => model.id === discoveredFlash.id);
+			expect(fetches).toBe(1);
+			expect(flash?.thinking).toEqual({
+				mode: "effort",
+				efforts: [Effort.Low, Effort.High, Effort.Max],
+				defaultLevel: Effort.Max,
+				requiresEffort: true,
+			});
+		} finally {
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
 	});
 
 	test("routes opencode-go deepseek-v4-flash to the responses API", () => {


### PR DESCRIPTION
## Repro

Building a runtime-discovered `opencode-go/glm-5.3-flash` model with the gateway catalog’s generic effort metadata left the top request tier clamped to `xhigh`:

```sh
bun -e 'import { buildModel } from "@oh-my-pi/pi-catalog/build"; import { Effort } from "@oh-my-pi/pi-catalog/effort"; import { clampThinkingLevelForModel } from "@oh-my-pi/pi-catalog/model-thinking"; const model = buildModel({ id: "glm-5.3-flash", name: "GLM-5.3-Flash", api: "openai-completions", provider: "opencode-go", baseUrl: "https://opencode.ai/zen/go/v1", reasoning: true, thinking: { mode: "effort", efforts: [Effort.Minimal, Effort.Low, Effort.Medium, Effort.High, Effort.XHigh] }, input: ["text"], cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, contextWindow: 1000000, maxTokens: 131072 }); console.log(JSON.stringify({ thinking: model.thinking, topTier: clampThinkingLevelForModel(model, Effort.Max) }));'
```

Before the fix this printed `topTier: "xhigh"`, which the OpenCode gateway rejects with `[1210]`; after the fix it prints the wire-exact `low/high/max` surface and `topTier: "max"`.

## Cause

`isGlm53ReasoningEffortModelId` in `packages/catalog/src/identity/family.ts` accepted only the base, Air, and Turbo variants. `glm-5.3-flash` therefore bypassed `getModelDefinedEfforts` in `packages/catalog/src/model-thinking.ts`, preserving stale runtime discovery metadata whose top tier was `xhigh`.

## Fix

- Include the GLM-5.3+ Flash variant in the model-defined mandatory `low/high/max` effort policy.
- Add a regression covering stale OpenCode Go discovery metadata, max-tier reachability, and mandatory thinking.
- Document the corrected gateway behavior in the catalog changelog.

## Verification

- `bun test packages/catalog/test/model-thinking.test.ts` — 45 passed, 0 failed.
- `cd packages/catalog && bun run check` — Biome and `tsgo` passed.
- `cd packages/catalog && bun test --parallel` — 780 passed, 0 failed.
- Re-ran the reproduction command: the model resolved to `low/high/max` with `topTier: "max"`.

Fixes #9960