### PR TITLE
fix(oauth): fall back gracefully when window.close() is blocked

### DIFF
--- a/packages/ai/src/registry/oauth/oauth.html
+++ b/packages/ai/src/registry/oauth/oauth.html
@@ -279,7 +279,7 @@
 
 			<h1 id="title">Authentication</h1>
 			<p id="message"></p>
-			<button onclick="window.close()" class="btn">Close Window</button>
+			<button id="close-btn" class="btn">Close Window</button>
 		</div>
 
 		<script id="server-state" type="application/json">
@@ -302,16 +302,30 @@
 			const title = document.getElementById("title");
 			const message = document.getElementById("message");
 
+			// window.close() is a no-op unless the tab was opened by script, and OAuth
+			// tabs are opened via the system browser. The message already tells the user
+			// they can close the tab, so on failure just hide the now-useless button.
+			function tryCloseTab(delay) {
+				setTimeout(() => {
+					window.close();
+					setTimeout(() => {
+						if (!window.closed) document.getElementById("close-btn").remove();
+					}, 150);
+				}, delay);
+			}
+
 			if (serverState.ok) {
 				app.classList.add("success", "countdown");
 				title.textContent = "Authentication Successful";
 				message.innerHTML = "You have successfully logged in.<br>You can now close this tab.";
-				setTimeout(() => window.close(), 3000);
+				tryCloseTab(3000);
 			} else {
 				app.classList.add("error");
 				title.textContent = "Authentication Failed";
 				message.textContent = serverState.error || "An error occurred";
 			}
+
+			document.getElementById("close-btn").addEventListener("click", () => tryCloseTab(0));
 		</script>
 	</body>
 </html>


### PR DESCRIPTION
Fixes #9964.

## Problem

`window.close()` is silently ignored on tabs not opened by script (spec: [WHATWG window.close](https://html.spec.whatwg.org/multipage/window-object.html#dom-window-close)). OAuth tabs are opened via the system browser, so **both** close attempts on the callback page did nothing:

- the **Close Window** button (`onclick="window.close()"`)
- the 3 s success auto-close (`setTimeout(() => window.close(), 3000)`)

## Fix

Single `tryCloseTab(delay)` helper in the same script block, used by both the click handler and the success auto-close: attempt `window.close()`, then after 150 ms hide the button if the tab is still open. No extra message text — the success path already tells the user they can close the tab.

## Verification

Standalone page with stubbed `__OAUTH_STATE__`, headless Chromium:

```json
{"successClick":{"btn":false,"closed":false}}
{"afterAuto":{"btn":false,"msg":"You have successfully logged in.You can now close this tab."}}
{"err":{"title":"Authentication Failed","msg":"boom"},"errAfter":{"btn":false}}
```

All three paths (success click, 3 s auto-close failure, error-path click): button hides, messages render, no console errors. On script-opened tabs the close succeeds before the fallback fires.