### PR TITLE
fix(coding-agent): prefer concrete-auth provider for startup default model

### DIFF
--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -28,6 +28,7 @@ import type {
 	OAuthProvider,
 	OAuthProviderId,
 } from "./registry/oauth/types";
+import { AUTHENTICATED_SENTINEL } from "./registry/types";
 import { getEnvApiKey, getEnvApiKeyName } from "./stream";
 import type { Provider } from "./types";
 import type {
@@ -2746,6 +2747,26 @@ export class AuthStorage {
 		if (this.#hasDedicatedEnvAuth(provider)) return true;
 		if (this.#fallbackResolver?.(provider)) return true;
 		return false;
+	}
+
+	/**
+	 * Like {@link hasAuth} but excludes providers whose only credential is the
+	 * self-resolving {@link AUTHENTICATED_SENTINEL} — the marker AWS/Vertex
+	 * transports return when a credential *source* merely exists (a stray
+	 * `~/.aws` profile, an EC2 instance role, Application Default Credentials)
+	 * without a usable key resolved yet. Default-model auto-selection uses this
+	 * so an ambiently-available provider (e.g. `amazon-bedrock` via an unrelated
+	 * AWS profile) does not win the startup default over a provider the user
+	 * actually signed into and then 403 on the first turn. Explicit selection
+	 * and picker visibility still go through {@link hasAuth}. See issue #9967.
+	 */
+	hasConcreteAuth(provider: string): boolean {
+		if (this.#runtimeOverrides.has(provider)) return true;
+		if (this.#configOverrides.has(provider)) return true;
+		if (this.#getCredentialsForProvider(provider).length > 0) return true;
+		if (this.#hasDedicatedEnvAuth(provider) && getEnvApiKey(provider) !== AUTHENTICATED_SENTINEL) return true;
+		const fallback = this.#fallbackResolver?.(provider);
+		return fallback !== undefined && fallback !== AUTHENTICATED_SENTINEL;
 	}
 
 	/**

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Fixed fast tool completions leaving a permanent running summary that blocked transcript retirement and squeezed later tool output.
 - Fixed `omp git` hunk navigation (`alt+↓`/`alt+↑`) appearing to do nothing while the file sidebar had focus: the diff cursor band now stays visible (dimmed) when the pane is unfocused.
 - Fixed the git TUI sidebar jumping back to the top of the file list after staging or unstaging a file; selection now stays on the nearest remaining row
+- Fixed the startup default model resolving to an `amazon-bedrock/*` model — and failing every turn with a Bedrock 403 — when an ambient AWS credential source (a stray `~/.aws` profile, an EC2 instance role) made Bedrock look available; auto-selection now prefers a provider you actually signed into over one that only self-resolves AWS credentials ([#9967](https://github.com/can1357/oh-my-pi/issues/9967)).
 ### Fixed
 
 - Fixed the `aarch64-linux` `nix build` output segfaulting in the dynamic loader before startup by repointing the stale `DT_VERDEF` that `patchelf` leaves behind when it grows `.dynamic`, and surfaced smoke-test signal deaths in the build log instead of masking them ([#9881](https://github.com/can1357/oh-my-pi/issues/9881)).

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -2210,6 +2210,24 @@ export class ModelRegistry {
 	}
 
 	/**
+	 * Whether `provider` has a *concrete* credential — a stored login, a
+	 * command/config/runtime key, or a keyless local endpoint — as opposed to a
+	 * self-resolving AWS/Vertex sentinel that only signals an ambient credential
+	 * *source* exists. Default-model auto-selection prefers concretely-authed
+	 * providers so an ambiently-available Bedrock/Vertex provider never displaces
+	 * the provider the user actually signed into. See {@link AuthStorage.hasConcreteAuth}
+	 * and issue #9967.
+	 */
+	hasConcreteAuth(provider: string): boolean {
+		const keyConfig = this.#customProviderApiKeys.get(provider);
+		return (
+			isCommandConfigValue(keyConfig) ||
+			this.#keylessProviders.has(provider) ||
+			this.authStorage.hasConcreteAuth(provider)
+		);
+	}
+
+	/**
 	 * Whether the provider's configured API key is resolved from a command.
 	 *
 	 * Callers use this to distinguish the registry's command-first resolver

--- a/packages/coding-agent/src/config/model-resolver.ts
+++ b/packages/coding-agent/src/config/model-resolver.ts
@@ -54,18 +54,37 @@ function isKnownProvider(provider: string): provider is KnownProvider {
 /**
  * Pick the first provider-default model in availability order.
  *
+ * When `hasConcreteCredential` is supplied and at least one available model
+ * belongs to a provider with a concrete credential, the candidate pool is
+ * restricted to those providers first. This keeps a provider that is merely
+ * *ambiently* available — an `amazon-bedrock`/`google-vertex` transport that
+ * self-resolves credentials from a stray `~/.aws` profile or Application
+ * Default Credentials — from winning the startup default over the provider the
+ * user actually signed into (issue #9967). A provider that is the *only*
+ * credentialed option is still selected.
+ *
  * If multiple providers expose that same default id, rank only that shared-id
  * group by canonical provider priority so native/OAuth transports beat mirrors
  * without changing unrelated provider fallback precedence.
  */
-export function pickDefaultAvailableModel(availableModels: Model<Api>[]): Model<Api> | undefined {
-	const firstDefault = availableModels.find(
+export function pickDefaultAvailableModel(
+	availableModels: Model<Api>[],
+	hasConcreteCredential?: (provider: string) => boolean,
+): Model<Api> | undefined {
+	const models =
+		hasConcreteCredential === undefined
+			? availableModels
+			: (() => {
+					const concrete = availableModels.filter(model => hasConcreteCredential(model.provider));
+					return concrete.length > 0 ? concrete : availableModels;
+				})();
+	const firstDefault = models.find(
 		model => isKnownProvider(model.provider) && DEFAULT_MODEL_PER_PROVIDER[model.provider] === model.id,
 	);
-	if (!firstDefault) return availableModels[0];
+	if (!firstDefault) return models[0];
 
 	const providerPriority = buildModelProviderPriorityRank();
-	const sharedDefaultMatches = availableModels.filter(
+	const sharedDefaultMatches = models.filter(
 		model =>
 			model.id === firstDefault.id &&
 			isKnownProvider(model.provider) &&
@@ -75,7 +94,7 @@ export function pickDefaultAvailableModel(availableModels: Model<Api>[]): Model<
 		const aRank = providerPriority.get(a.provider.toLowerCase()) ?? Number.POSITIVE_INFINITY;
 		const bRank = providerPriority.get(b.provider.toLowerCase()) ?? Number.POSITIVE_INFINITY;
 		if (aRank !== bRank) return aRank - bRank;
-		return availableModels.indexOf(a) - availableModels.indexOf(b);
+		return models.indexOf(a) - models.indexOf(b);
 	})[0];
 }
 
@@ -472,8 +491,8 @@ export interface ModelMatchPreferences {
 
 export type ModelLookupRegistry = Pick<ModelRegistry, "getAvailable">;
 type CliModelRegistry = Pick<ModelRegistry, "getAll" | "getAvailable">;
-type InitialModelRegistry = Pick<ModelRegistry, "getAvailable" | "find">;
-type RestorableModelRegistry = Pick<ModelRegistry, "getAvailable" | "find" | "getApiKey">;
+type InitialModelRegistry = Pick<ModelRegistry, "getAvailable" | "find" | "hasConcreteAuth">;
+type RestorableModelRegistry = Pick<ModelRegistry, "getAvailable" | "find" | "getApiKey" | "hasConcreteAuth">;
 
 interface ModelPreferenceContext {
 	modelUsageRank: Map<string, number>;
@@ -2074,7 +2093,7 @@ export async function findInitialModel(options: {
 	// 4. Try first available model with valid API key
 	const availableModels = modelRegistry.getAvailable();
 
-	const fallback = pickDefaultAvailableModel(availableModels);
+	const fallback = pickDefaultAvailableModel(availableModels, provider => modelRegistry.hasConcreteAuth(provider));
 	if (fallback) {
 		return { model: fallback, thinkingLevel: undefined, fallbackMessage: undefined };
 	}
@@ -2126,7 +2145,9 @@ export async function restoreModelFromSession(
 	// Try to find any available model
 	const availableModels = modelRegistry.getAvailable();
 
-	const fallbackModel = pickDefaultAvailableModel(availableModels);
+	const fallbackModel = pickDefaultAvailableModel(availableModels, provider =>
+		modelRegistry.hasConcreteAuth(provider),
+	);
 	if (fallbackModel) {
 		if (shouldPrintMessages) {
 			console.log(chalk.dim(`Falling back to: ${fallbackModel.provider}/${fallbackModel.id}`));

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -2613,7 +2613,9 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 
 			if (!model) {
 				const fallbackCandidates = await resolveAllowedModels(modelRegistry, settings, modelMatchPreferences);
-				let pick = pickDefaultAvailableModel(fallbackCandidates.filter(hasModelAuth));
+				let pick = pickDefaultAvailableModel(fallbackCandidates.filter(hasModelAuth), provider =>
+					modelRegistry.hasConcreteAuth(provider),
+				);
 
 				// Cold-cache discovery race (issues #6114, #6162): a discovery
 				// provider (models.yml `openai-models-list`, LM Studio/Ollama/
@@ -2641,7 +2643,9 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 							settings,
 							modelMatchPreferences,
 						);
-						pick = pickDefaultAvailableModel(refreshedCandidates.filter(hasModelAuth));
+						pick = pickDefaultAvailableModel(refreshedCandidates.filter(hasModelAuth), provider =>
+							modelRegistry.hasConcreteAuth(provider),
+						);
 					}
 				}
 

--- a/packages/coding-agent/test/default-model-ambient-bedrock.test.ts
+++ b/packages/coding-agent/test/default-model-ambient-bedrock.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Regression: issue #9967.
+ *
+ * On a machine whose only real login is Anthropic OAuth but which also carries
+ * an ambient AWS credential *source* (a stray `~/.aws` profile, an EC2 instance
+ * role, static keys exported for unrelated tooling), `amazon-bedrock` passed the
+ * default-model availability gate via the self-resolving `AUTHENTICATED_SENTINEL`
+ * and — because its default model leads the bundled catalog order — won the
+ * startup default over the provider the user actually signed into. The session
+ * then 403'd on the first turn. The fix teaches auto-selection to prefer a
+ * provider with a *concrete* credential over a sentinel-only ambient one.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { DEFAULT_MODEL_PER_PROVIDER } from "@oh-my-pi/pi-catalog/provider-models";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { pickDefaultAvailableModel } from "@oh-my-pi/pi-coding-agent/config/model-resolver";
+import type { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { Snowflake } from "@oh-my-pi/pi-utils";
+import { createInMemoryAuthStorage } from "./helpers/agent-session-setup";
+
+describe("issue #9967 default model with ambient Bedrock credentials", () => {
+	let tempDir: string;
+	let authStorage: AuthStorage;
+	let registry: ModelRegistry;
+	let savedAccessKey: string | undefined;
+	let savedSecret: string | undefined;
+
+	beforeEach(async () => {
+		savedAccessKey = process.env.AWS_ACCESS_KEY_ID;
+		savedSecret = process.env.AWS_SECRET_ACCESS_KEY;
+		delete process.env.AWS_ACCESS_KEY_ID;
+		delete process.env.AWS_SECRET_ACCESS_KEY;
+		tempDir = path.join(os.tmpdir(), `pi-9967-${Snowflake.next()}`);
+		fs.mkdirSync(tempDir, { recursive: true });
+		authStorage = createInMemoryAuthStorage();
+		// The user's only real login: an Anthropic credential.
+		await authStorage.set("anthropic", [{ type: "api_key", key: "sk-test-anthropic" }]);
+		registry = new ModelRegistry(authStorage, path.join(tempDir, "models.yml"));
+	});
+
+	afterEach(() => {
+		authStorage.close();
+		if (savedAccessKey === undefined) delete process.env.AWS_ACCESS_KEY_ID;
+		else process.env.AWS_ACCESS_KEY_ID = savedAccessKey;
+		if (savedSecret === undefined) delete process.env.AWS_SECRET_ACCESS_KEY;
+		else process.env.AWS_SECRET_ACCESS_KEY = savedSecret;
+		fs.rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	test("prefers the concretely-authed provider over an ambient Bedrock default", () => {
+		// Without any AWS credentials, Bedrock is not available and Anthropic wins.
+		expect(authStorage.hasAuth("amazon-bedrock")).toBe(false);
+		const baseline = pickDefaultAvailableModel(registry.getAvailable(), provider =>
+			registry.hasConcreteAuth(provider),
+		);
+		expect(baseline?.provider).toBe("anthropic");
+
+		// Ambient AWS source with no usable Bedrock access (would 403 on request).
+		process.env.AWS_ACCESS_KEY_ID = "AKIAJUNKJUNKJUNKJUNK";
+		process.env.AWS_SECRET_ACCESS_KEY = "junksecretjunksecretjunksecretjunksecret";
+
+		// The ambient source makes Bedrock *available* but not *concretely* authed.
+		expect(authStorage.hasAuth("amazon-bedrock")).toBe(true);
+		expect(registry.hasConcreteAuth("amazon-bedrock")).toBe(false);
+		expect(registry.hasConcreteAuth("anthropic")).toBe(true);
+
+		const available = registry.getAvailable();
+		const bedrockIdx = available.findIndex(model => model.provider === "amazon-bedrock");
+		const anthropicIdx = available.findIndex(model => model.provider === "anthropic");
+		// Catalog order leads with Bedrock — the ordering that produced the bug.
+		expect(bedrockIdx).toBeGreaterThanOrEqual(0);
+		expect(bedrockIdx).toBeLessThan(anthropicIdx);
+
+		// Old behavior (no credential hint) regresses onto the unusable Bedrock default.
+		expect(pickDefaultAvailableModel(available)?.provider).toBe("amazon-bedrock");
+
+		// Fixed behavior: the provider the user signed into wins.
+		const picked = pickDefaultAvailableModel(available, provider => registry.hasConcreteAuth(provider));
+		expect(picked?.provider).toBe("anthropic");
+		expect(picked?.id).toBe(DEFAULT_MODEL_PER_PROVIDER.anthropic);
+	});
+});

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -452,6 +452,31 @@ describe("pickDefaultAvailableModel", () => {
 		expect(pickDefaultAvailableModel([paid, oauth])?.provider).toBe("xai-oauth");
 		expect(pickDefaultAvailableModel([paid])?.provider).toBe("xai");
 	});
+
+	test("prefers a concretely-authed provider over a sentinel-only ambient provider (issue #9967)", () => {
+		const bedrockDefault = createBedrockDefaultModel();
+		const anthropicDefault = createOpusModel("anthropic", DEFAULT_MODEL_PER_PROVIDER.anthropic, "Claude Opus");
+		// amazon-bedrock leads in catalog/availability order, exactly as
+		// `getAvailable()` returns it when a stray ~/.aws profile makes Bedrock
+		// ambiently "available" alongside a real Anthropic OAuth login.
+		const models = [bedrockDefault, anthropicDefault];
+
+		// Without the credential hint the ambient provider still wins by order —
+		// this is the reported bug (403 on the first turn).
+		expect(pickDefaultAvailableModel(models)?.provider).toBe("amazon-bedrock");
+
+		// With the hint, the provider the user actually signed into wins.
+		const picked = pickDefaultAvailableModel(models, provider => provider === "anthropic");
+		expect(picked?.provider).toBe("anthropic");
+		expect(picked?.id).toBe(DEFAULT_MODEL_PER_PROVIDER.anthropic);
+	});
+
+	test("keeps a sentinel-only provider when it is the only credentialed option", () => {
+		const bedrockDefault = createBedrockDefaultModel();
+		const picked = pickDefaultAvailableModel([bedrockDefault], () => false);
+		expect(picked?.provider).toBe("amazon-bedrock");
+		expect(picked?.id).toBe(DEFAULT_MODEL_PER_PROVIDER["amazon-bedrock"]);
+	});
 });
 
 describe("parseModelPattern", () => {


### PR DESCRIPTION
## Repro
On a machine whose only real login is Anthropic OAuth but which also carries an ambient AWS credential *source* (a stray `~/.aws` profile from unrelated `aws configure sso`, an EC2 instance role, or static keys exported for other tooling), a fresh `omp` session opens on `amazon-bedrock/us.anthropic.claude-opus-4-8` and every turn fails with `Bedrock HTTP 403: The security token included in the request is invalid.` Reproduced against a real `ModelRegistry` (Anthropic credential stored, then `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` set to any value that makes `hasAwsCredentialSource()` true): `getAvailable()` returns 176 models with `amazon-bedrock` at index 0 and `anthropic` at index 145, and `pickDefaultAvailableModel` selects `amazon-bedrock/us.anthropic.claude-opus-4-8` recorded as `resolvedModelIsFallback: false`.

## Cause
`amazon-bedrock`'s availability is gated on `authStorage.hasAuth("amazon-bedrock")`, whose env leg resolves `amazonBedrockProvider.envKeys()` → `resolveAwsRegistryApiKey({allowSkipAuth:true})` (`packages/ai/src/registry/aws.ts`). That returns `AUTHENTICATED_SENTINEL` for *any* `hasAwsCredentialSource()` signal — static keys, `AWS_BEARER_TOKEN_BEDROCK`, web-identity, ECS creds, an EC2 instance role, or a configured `~/.aws` profile (including SSO / `credential_process` profiles with no static keys). That is a credential-*source* presence check, not a usable-key check, so Bedrock passes availability with no signable credential. `pickDefaultAvailableModel` (`packages/coding-agent/src/config/model-resolver.ts`) then picks the first provider-default in catalog order, where `amazon-bedrock` (145 bundled models) leads `anthropic` — so the ambiently-available gateway beats the provider the user actually signed into, and the pick is recorded non-fallback (`session-manager.ts appendModelChange` defaults `resolvedModelIsFallback` to false).

## Fix
- Add `AuthStorage.hasConcreteAuth(provider)` (`packages/ai/src/auth-storage.ts`): mirrors `hasAuth` but a self-resolving `AUTHENTICATED_SENTINEL` env/fallback value does not count, so AWS/Vertex ambient sources are excluded while stored logins, real env keys, and config/runtime/command keys still qualify.
- Add `ModelRegistry.hasConcreteAuth(provider)` (`packages/coding-agent/src/config/model-registry.ts`): the registry-level wrapper (keyless local + command-backed keys + `authStorage.hasConcreteAuth`), parallel to `hasConfiguredAuth`.
- `pickDefaultAvailableModel` takes an optional `hasConcreteCredential` predicate: when supplied and at least one available model is concretely authed, the candidate pool is restricted to those providers before the existing first-default / shared-id-priority logic runs. A sentinel-only provider that is the *only* credentialed option is still selected, and `/model` picker visibility is unchanged.
- Wire the predicate through the four auto-default call sites: `findInitialModel`, `restoreModelFromSession`, and both `createAgentSession` startup fallbacks in `sdk.ts`.

## Verification
`cd packages/coding-agent && bun test test/default-model-ambient-bedrock.test.ts test/model-resolver.test.ts test/provider-default-selection.test.ts test/sdk-default-role-discovery-config-provider.test.ts test/sdk-default-role-discovery-local-provider.test.ts test/sdk-default-role-extension-provider.test.ts` → 166 pass, 0 fail. New `default-model-ambient-bedrock.test.ts` asserts that with an ambient AWS source `hasAuth("amazon-bedrock")` is true while `hasConcreteAuth` is false, that catalog order leads with Bedrock, and that auto-default now resolves to `anthropic` (documenting the pre-fix Bedrock pick alongside). New `pickDefaultAvailableModel` unit tests cover the concrete-vs-sentinel preference and the sentinel-only fallback. `bun check` passes clean.

Fixes #9967