### PR TITLE
fix(ai): correct Codex Spark quota isolation

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Codex OAuth selection to keep chat and Spark quotas independent, preserve legacy shared blocks from older brokers, and avoid treating incomplete usage reports as uncapped.
+
 ## [18.0.6] - 2026-08-26
 
 ### Added

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -1269,6 +1269,7 @@ type UsageRankedCandidate<T extends AuthCredential> = UsageCandidate<T> & {
 	blocked: boolean;
 	blockedUntil?: number;
 	hasPriorityBoost: boolean;
+	usageMeasured: boolean;
 	planPriority: number;
 	secondaryUsed: number;
 	secondaryRequiredDrain: number;
@@ -2165,13 +2166,16 @@ export class AuthStorage {
 			const windows = usage ? strategy.findWindowLimits(usage, args.rankingContext) : undefined;
 			const primary = windows?.primary;
 			const secondary = windows?.secondary;
+			const usageMeasured = primary !== undefined || secondary !== undefined;
+			const primaryUncapped = primary === undefined && secondary !== undefined;
 			ranked.push({
 				selection,
 				usage,
 				usageChecked,
 				blocked,
 				blockedUntil,
-				hasPriorityBoost: strategy.hasPriorityBoost?.(primary) ?? false,
+				usageMeasured,
+				hasPriorityBoost: strategy.hasPriorityBoost?.(primary, primaryUncapped) ?? false,
 				planPriority: 0,
 				secondaryUsed: this.#normalizeUsageFraction(secondary),
 				secondaryRequiredDrain: this.#computeWindowRequiredDrain(
@@ -4624,8 +4628,8 @@ export class AuthStorage {
 		// scores are only comparable between measured windows, and the
 		// clockless headroom fallback (0..1) must not let an account whose
 		// usage fetch failed shadow a measured sibling.
-		const leftMeasured = left.usage !== null;
-		const rightMeasured = right.usage !== null;
+		const leftMeasured = left.usageMeasured;
+		const rightMeasured = right.usageMeasured;
 		if (leftMeasured !== rightMeasured) return leftMeasured ? -1 : 1;
 		// Required drain, descending: the account whose remaining quota must
 		// burn fastest to avoid expiring unused at its reset comes first, so
@@ -4760,13 +4764,16 @@ export class AuthStorage {
 			const windows = usage ? strategy.findWindowLimits(usage, args.rankingContext) : undefined;
 			const primary = windows?.primary;
 			const secondary = windows?.secondary;
+			const usageMeasured = primary !== undefined || secondary !== undefined;
+			const primaryUncapped = primary === undefined && secondary !== undefined;
 			ranked.push({
 				selection,
 				usage,
 				usageChecked,
 				blocked,
 				blockedUntil,
-				hasPriorityBoost: strategy.hasPriorityBoost?.(primary) ?? false,
+				usageMeasured,
+				hasPriorityBoost: strategy.hasPriorityBoost?.(primary, primaryUncapped) ?? false,
 				planPriority: getOpenAICodexPlanPriority(usage, args.planRequirement),
 				secondaryUsed: this.#normalizeUsageFraction(secondary),
 				secondaryRequiredDrain: this.#computeWindowRequiredDrain(

--- a/packages/ai/src/usage.ts
+++ b/packages/ai/src/usage.ts
@@ -396,6 +396,10 @@ export interface CredentialRankingStrategy {
 		primaryMs: number;
 		secondaryMs: number;
 	};
-	/** Optional: priority boost for specific credential states (e.g., fresh 5h ticker start). */
-	hasPriorityBoost?(primary: UsageLimit | undefined): boolean;
+	/**
+	 * Optional: priority boost for specific credential states (e.g., fresh 5h
+	 * ticker start). `primaryUncapped` is true only when the fetched report has
+	 * an applicable secondary window but no applicable primary window.
+	 */
+	hasPriorityBoost?(primary: UsageLimit | undefined, primaryUncapped?: boolean): boolean;
 }

--- a/packages/ai/src/usage/openai-codex.ts
+++ b/packages/ai/src/usage/openai-codex.ts
@@ -611,8 +611,11 @@ export const codexRankingStrategy: CredentialRankingStrategy = {
 		return { primary: findLimit("primary"), secondary: findLimit("secondary") };
 	},
 	windowDefaults: { primaryMs: 60 * 60 * 1000, secondaryMs: 7 * 24 * 60 * 60 * 1000 },
-	hasPriorityBoost(primary) {
-		if (!primary) return false;
+	hasPriorityBoost(primary, primaryUncapped = false) {
+		// A missing primary window is only an uncapped signal when the same
+		// request scope still reports its secondary window. Empty or
+		// differently-scoped reports remain unmeasured.
+		if (!primary) return primaryUncapped;
 		const windowId = primary.scope.windowId?.toLowerCase();
 		const durationMs = primary.window?.durationMs;
 		const isFiveHourWindow =

--- a/packages/ai/test/auth-storage-codex-selection.test.ts
+++ b/packages/ai/test/auth-storage-codex-selection.test.ts
@@ -217,10 +217,15 @@ async function countApiKeySelections(
 	provider: string,
 	sessionPrefix: string,
 	samples = 150,
+	modelId?: string,
 ): Promise<Map<string, number>> {
 	const counts = new Map<string, number>();
 	for (let index = 0; index < samples; index += 1) {
-		const apiKey = await authStorage.getApiKey(provider, `${sessionPrefix}-${index}`);
+		const apiKey = await authStorage.getApiKey(
+			provider,
+			`${sessionPrefix}-${index}`,
+			modelId === undefined ? undefined : { modelId },
+		);
 		if (!apiKey) continue;
 		counts.set(apiKey, (counts.get(apiKey) ?? 0) + 1);
 	}
@@ -389,6 +394,95 @@ describe("AuthStorage codex oauth ranking", () => {
 		const counts = await countApiKeySelections(authStorage, "openai-codex", "weighted-codex-zero");
 		expectExclusivePreference(counts, "api-acct-zero", "api-acct-progress");
 	});
+	test("preserves the uncapped-Pro priority signal when only the secondary window is reported", async () => {
+		if (!authStorage) throw new Error("test setup failed");
+
+		await authStorage.set("openai-codex", [
+			{ type: "oauth", ...createCredential("acct-uncapped-pro", "uncapped-pro@example.com") },
+			{ type: "oauth", ...createCredential("acct-capped", "capped@example.com") },
+		]);
+
+		const uncapped = createCodexUsageReport({
+			accountId: "acct-uncapped-pro",
+			primary: { usedFraction: 0, resetInMs: FIVE_HOUR_MS },
+			secondary: { usedFraction: 0.9, resetInMs: WEEK_MS },
+			metadata: { planType: "pro", allowed: true, limitReached: false },
+		});
+		uncapped.limits = uncapped.limits.filter(limit => limit.id !== "openai-codex:primary");
+		usageByAccount.set("acct-uncapped-pro", uncapped);
+		usageByAccount.set(
+			"acct-capped",
+			createCodexUsageReport({
+				accountId: "acct-capped",
+				primary: { usedFraction: 0, resetInMs: HOUR_MS },
+				secondary: { usedFraction: 0.5, resetInMs: WEEK_MS },
+			}),
+		);
+
+		const counts = await countApiKeySelections(authStorage, "openai-codex", "uncapped-pro");
+		expectExclusivePreference(counts, "api-acct-uncapped-pro", "api-acct-capped");
+	});
+
+	test("does not boost incomplete or differently-scoped Codex usage over measured quota", async () => {
+		if (!authStorage) throw new Error("test setup failed");
+
+		await authStorage.set("openai-codex", [
+			{ type: "oauth", ...createCredential("acct-status", "status@example.com") },
+			{ type: "oauth", ...createCredential("acct-chat", "chat@example.com") },
+			{ type: "oauth", ...createCredential("acct-chat-only", "chat-only@example.com") },
+			{ type: "oauth", ...createCredential("acct-spark", "spark@example.com") },
+		]);
+
+		usageByAccount.set("acct-status", {
+			provider: "openai-codex",
+			fetchedAt: Date.now(),
+			limits: [],
+			metadata: { accountId: "acct-status", allowed: true, limitReached: false },
+		});
+		usageByAccount.set(
+			"acct-chat",
+			createCodexUsageReport({
+				accountId: "acct-chat",
+				primary: { usedFraction: 0.2, resetInMs: HOUR_MS },
+				secondary: { usedFraction: 0.2, resetInMs: WEEK_MS },
+			}),
+		);
+		const sparkOnlyReport = addSparkUsage(
+			createCodexUsageReport({
+				accountId: "acct-spark",
+				primary: { usedFraction: 0.1, resetInMs: HOUR_MS },
+				secondary: { usedFraction: 0.1, resetInMs: WEEK_MS },
+			}),
+			0.1,
+			0.1,
+		);
+		sparkOnlyReport.limits = sparkOnlyReport.limits.filter(limit => limit.id.includes(":spark:"));
+		usageByAccount.set("acct-spark", sparkOnlyReport);
+		const otherMeterReport = addSparkUsage(
+			createCodexUsageReport({
+				accountId: "acct-chat-only",
+				primary: { usedFraction: 0.9, resetInMs: HOUR_MS },
+				secondary: { usedFraction: 0.9, resetInMs: WEEK_MS },
+			}),
+			0.9,
+			0.9,
+		);
+		otherMeterReport.limits = otherMeterReport.limits.filter(limit => limit.id.includes(":spark:"));
+		usageByAccount.set("acct-chat-only", otherMeterReport);
+
+		const chatCounts = await countApiKeySelections(authStorage, "openai-codex", "incomplete-chat");
+		expectExclusivePreference(chatCounts, "api-acct-chat", "api-acct-status");
+
+		const sparkCounts = await countApiKeySelections(
+			authStorage,
+			"openai-codex",
+			"incomplete-spark",
+			150,
+			"gpt-5.3-codex-spark",
+		);
+		expectExclusivePreference(sparkCounts, "api-acct-spark", "api-acct-chat-only");
+	});
+
 	test("skips exhausted weekly account even when reset is near", async () => {
 		if (!authStorage) throw new Error("test setup failed");
 

--- a/packages/ai/test/remote-auth-store.test.ts
+++ b/packages/ai/test/remote-auth-store.test.ts
@@ -834,6 +834,47 @@ describe("RemoteAuthCredentialStore + AuthStorage integration", () => {
 			remoteStore.close();
 		}
 	});
+	test("retains the legacy Codex shared block from an older broker snapshot", () => {
+		const blockedUntilMs = Date.now() + 60_000;
+		const remoteStore = new RemoteAuthCredentialStore({
+			client: new AuthBrokerClient({ url: "http://127.0.0.1:9", token: "unused" }),
+			streamSnapshots: false,
+			initialSnapshot: {
+				generation: 1,
+				generatedAt: Date.now(),
+				serverNowMs: Date.now(),
+				refresher: { enabled: false, intervalMs: 0, skewMs: 0, nextSweepInMs: Number.MAX_SAFE_INTEGER },
+				credentials: [
+					{
+						id: 7,
+						provider: "openai-codex",
+						credential: {
+							type: "oauth",
+							access: "remote-codex-access",
+							refresh: REMOTE_REFRESH_SENTINEL,
+							expires: blockedUntilMs,
+							accountId: "remote-codex-account",
+							email: "remote-codex@example.com",
+						},
+						identityKey: "email:remote-codex@example.com",
+						rotatesInMs: null,
+						blocks: [
+							{
+								providerKey: "openai-codex:oauth",
+								blockScope: "shared",
+								blockedUntilMs,
+							},
+						],
+					},
+				],
+			},
+		});
+		try {
+			expect(remoteStore.getCredentialBlock(7, "openai-codex:oauth", "shared")).toBe(blockedUntilMs);
+		} finally {
+			remoteStore.close();
+		}
+	});
 
 	test("ingestUsageReport overlays only the matching Anthropic report and getUsageReport returns the overlaid Fable row", async () => {
 		const brokerClient = new AuthBrokerClient({ url: handle!.url, token });

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `omp usage` capacity stats to report Codex chat and Spark meters separately when they share a window duration.
+
 ## [18.0.6] - 2026-08-26
 
 ### Added

--- a/packages/coding-agent/src/cli/usage-cli.ts
+++ b/packages/coding-agent/src/cli/usage-cli.ts
@@ -479,32 +479,43 @@ export interface ProviderWindowStat {
 	/** Compact window label, e.g. "5h", "7d". */
 	window: string;
 	durationMs?: number;
+	/** Meter identity when a provider keeps independent meters in one window. */
+	meter?: string;
 	/** Accounts reporting a limit in this window. */
 	accounts: number;
-	/** Sum of each account's binding used fraction — accounts' worth of quota burned. */
+	/** Sum of each account's binding used fraction - accounts' worth of quota burned. */
 	usedAccounts: number;
 	/** Accounts' worth of quota still available across reporting accounts. */
 	remainingAccounts: number;
+}
+
+function meterForLimit(report: UsageReport, limit: UsageLimit): string | undefined {
+	if (report.provider !== "openai-codex") return undefined;
+	const tier = limit.scope.tier?.trim().toLowerCase();
+	if (tier) return tier;
+	const slug = limit.id.toLowerCase().split(":")[1];
+	return slug && slug !== "primary" && slug !== "secondary" ? slug : "chat";
 }
 
 /**
  * Aggregate one provider's reports into per-window quota capacity stats.
  *
  * Limits are bucketed by window duration (5h, 7d, ...). Within a bucket each
- * account contributes its single highest used fraction — when an account has
- * several meters on the same window (tiered/metered limits), the most-burned
- * one is what binds.
+ * account contributes its single highest used fraction. Codex keeps each meter
+ * in its own bucket because chat and Spark can share a window duration.
  */
 export function computeProviderWindowStats(reports: UsageReport[]): ProviderWindowStat[] {
-	const buckets = new Map<string, { window: string; durationMs?: number; fractions: number[] }>();
+	const buckets = new Map<string, { window: string; durationMs?: number; meter?: string; fractions: number[] }>();
 	for (const report of reports) {
 		const accountMax = new Map<string, number>();
 		for (const limit of report.limits) {
 			const fraction = resolveUsedFraction(limit);
 			if (fraction === undefined) continue;
 			const durationMs = limit.window?.durationMs;
-			const key =
+			const windowKey =
 				durationMs !== undefined ? `d:${durationMs}` : (limit.scope.windowId ?? limit.window?.label ?? limit.label);
+			const meter = meterForLimit(report, limit);
+			const key = meter === undefined ? windowKey : `m:${meter}\0${windowKey}`;
 			const previous = accountMax.get(key);
 			if (previous === undefined || fraction > previous) accountMax.set(key, fraction);
 			if (!buckets.has(key)) {
@@ -512,18 +523,22 @@ export function computeProviderWindowStats(reports: UsageReport[]): ProviderWind
 					durationMs !== undefined
 						? formatDuration(durationMs)
 						: (limit.window?.label ?? limit.scope.windowId ?? limit.label);
-				buckets.set(key, { window, durationMs, fractions: [] });
+				buckets.set(key, { window, durationMs, meter, fractions: [] });
 			}
 		}
 		for (const [key, fraction] of accountMax) buckets.get(key)!.fractions.push(fraction);
 	}
 	return [...buckets.values()]
-		.sort((a, b) => (a.durationMs ?? Number.POSITIVE_INFINITY) - (b.durationMs ?? Number.POSITIVE_INFINITY))
+		.sort((a, b) => {
+			const duration = (a.durationMs ?? Number.POSITIVE_INFINITY) - (b.durationMs ?? Number.POSITIVE_INFINITY);
+			return duration !== 0 ? duration : (a.meter ?? "").localeCompare(b.meter ?? "");
+		})
 		.map(bucket => {
 			const usedAccounts = bucket.fractions.reduce((sum, fraction) => sum + fraction, 0);
 			return {
 				window: bucket.window,
 				durationMs: bucket.durationMs,
+				...(bucket.meter === undefined ? {} : { meter: bucket.meter }),
 				accounts: bucket.fractions.length,
 				usedAccounts,
 				remainingAccounts: Math.max(0, bucket.fractions.length - usedAccounts),
@@ -705,10 +720,10 @@ export function formatUsageBreakdown(
 
 		const stats = computeProviderWindowStats(providerReports);
 		if (stats.length > 0) {
-			const parts = stats.map(
-				stat =>
-					`${stat.window} → ${stat.usedAccounts.toFixed(2)}/${stat.accounts} ${stat.accounts === 1 ? "account" : "accounts"} used (${stat.remainingAccounts.toFixed(2)}× quota left)`,
-			);
+			const parts = stats.map(stat => {
+				const meterLabel = stat.meter ? ` (${stat.meter.charAt(0).toUpperCase()}${stat.meter.slice(1)})` : "";
+				return `${stat.window}${meterLabel} → ${stat.usedAccounts.toFixed(2)}/${stat.accounts} ${stat.accounts === 1 ? "account" : "accounts"} used (${stat.remainingAccounts.toFixed(2)}× quota left)`;
+			});
 			lines.push(`  ${chalk.dim(`capacity: ${parts.join(" · ")}`)}`);
 		}
 	}

--- a/packages/coding-agent/test/usage-cli.test.ts
+++ b/packages/coding-agent/test/usage-cli.test.ts
@@ -21,13 +21,14 @@ function makeLimit(opts: {
 	windowId?: string;
 	tier?: string;
 	accountId?: string;
+	provider?: string;
 	notes?: string[];
 }): UsageReport["limits"][number] {
 	return {
 		id: opts.id,
 		label: opts.id,
 		scope: {
-			provider: "anthropic",
+			provider: opts.provider ?? "anthropic",
 			windowId: opts.windowId,
 			tier: opts.tier,
 			accountId: opts.accountId,
@@ -100,6 +101,81 @@ describe("computeProviderWindowStats", () => {
 		expect(sevenDay.window).toBe("7d");
 		expect(sevenDay.usedAccounts).toBeCloseTo(0.6); // 0.4 (opus binds) + 0.2
 		expect(sevenDay.remainingAccounts).toBeCloseTo(1.4);
+	});
+
+	it("reports Spark-only capacity instead of dropping the meter", () => {
+		const report = makeReport("openai-codex", "spark@example.test", [
+			makeLimit({
+				id: "openai-codex:spark:primary",
+				provider: "openai-codex",
+				tier: "spark",
+				usedFraction: 0.75,
+				durationMs: FIVE_HOURS,
+				windowId: "5h",
+			}),
+			makeLimit({
+				id: "openai-codex:spark:secondary",
+				provider: "openai-codex",
+				tier: "spark",
+				usedFraction: 0.25,
+				durationMs: SEVEN_DAYS,
+				windowId: "7d",
+			}),
+		]);
+		const stats = computeProviderWindowStats([report]);
+		expect(stats.map(stat => [stat.window, stat.meter])).toEqual([
+			["5h", "spark"],
+			["7d", "spark"],
+		]);
+		expect(stats[0]).toMatchObject({ accounts: 1, usedAccounts: 0.75, remainingAccounts: 0.25 });
+	});
+
+	it("keeps mixed Codex meters separate when they share a window duration", () => {
+		const report = makeReport("openai-codex", "mixed@example.test", [
+			makeLimit({
+				id: "openai-codex:primary",
+				provider: "openai-codex",
+				usedFraction: 0.2,
+				durationMs: FIVE_HOURS,
+				windowId: "5h",
+			}),
+			makeLimit({
+				id: "openai-codex:secondary",
+				provider: "openai-codex",
+				usedFraction: 0.4,
+				durationMs: SEVEN_DAYS,
+				windowId: "7d",
+			}),
+			makeLimit({
+				id: "openai-codex:spark:primary",
+				provider: "openai-codex",
+				tier: "spark",
+				usedFraction: 0.8,
+				durationMs: FIVE_HOURS,
+				windowId: "5h",
+			}),
+			makeLimit({
+				id: "openai-codex:spark:secondary",
+				provider: "openai-codex",
+				tier: "spark",
+				usedFraction: 0.1,
+				durationMs: SEVEN_DAYS,
+				windowId: "7d",
+			}),
+		]);
+		const stats = computeProviderWindowStats([report]);
+		expect(stats.map(stat => [stat.window, stat.meter])).toEqual([
+			["5h", "chat"],
+			["5h", "spark"],
+			["7d", "chat"],
+			["7d", "spark"],
+		]);
+		expect(stats.find(stat => stat.window === "5h" && stat.meter === "chat")?.usedAccounts).toBe(0.2);
+		expect(stats.find(stat => stat.window === "5h" && stat.meter === "spark")?.usedAccounts).toBe(0.8);
+
+		const text = stripVTControlCharacters(formatUsageBreakdown([report], [], Date.now()));
+		expect(text).toContain("5h (Chat) → 0.20/1");
+		expect(text).toContain("5h (Spark) → 0.80/1");
 	});
 
 	it("ignores limits without a resolvable fraction", () => {


### PR DESCRIPTION
## Summary
- Keep Codex Spark quota accounting separate from the chat quota.

## Validation
- Focused Codex quota tests passed in the integrated repair worktree.