### PR TITLE
fix(ai): handle incomplete Z.AI quota meters

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Z.AI quota ranking when usage responses contain multiple meters or omit absolute credit values.
+
 ## [18.0.9] - 2026-08-28
 
 ### Fixed

--- a/packages/ai/src/usage/zai.ts
+++ b/packages/ai/src/usage/zai.ts
@@ -1,15 +1,16 @@
 import { toNumber } from "@oh-my-pi/pi-catalog/utils";
 import { USER_AGENT } from "@oh-my-pi/pi-utils";
-import type {
-	CredentialRankingStrategy,
-	UsageAmount,
-	UsageFetchContext,
-	UsageFetchParams,
-	UsageLimit,
-	UsageProvider,
-	UsageReport,
-	UsageStatus,
-	UsageWindow,
+import {
+	type CredentialRankingStrategy,
+	resolveUsedFraction,
+	type UsageAmount,
+	type UsageFetchContext,
+	type UsageFetchParams,
+	type UsageLimit,
+	type UsageProvider,
+	type UsageReport,
+	type UsageStatus,
+	type UsageWindow,
 } from "../usage";
 import { isRecord } from "../utils";
 import { DAY_MS, HOUR_MS, WEEK_MS } from "./shared";
@@ -204,7 +205,7 @@ function getZaiCredentialLimits(report: UsageReport): UsageLimit[] {
 }
 
 function zaiLimitPressure(limit: UsageLimit): number {
-	const fraction = limit.amount.usedFraction;
+	const fraction = resolveUsedFraction(limit);
 	return typeof fraction === "number" && Number.isFinite(fraction) ? fraction : -1;
 }
 
@@ -215,11 +216,11 @@ function rankZaiRequestLimits(report: UsageReport): UsageLimit[] {
 	// Mixed-meter payloads (tokens + credits on the same plan) can repeat a
 	// window; keep the most-binding limit per window so a second 5h row never
 	// displaces the weekly window when primary/secondary are picked positionally.
-	const byWindow = new Map<number, UsageLimit>();
+	const byWindow = new Map<string, UsageLimit>();
 	for (const limit of limits) {
-		const durationMs = limit.window?.durationMs ?? Number.POSITIVE_INFINITY;
-		const current = byWindow.get(durationMs);
-		if (!current || zaiLimitPressure(limit) > zaiLimitPressure(current)) byWindow.set(durationMs, limit);
+		const windowKey = limit.window?.id ?? limit.scope.windowId ?? limit.id;
+		const current = byWindow.get(windowKey);
+		if (!current || zaiLimitPressure(limit) > zaiLimitPressure(current)) byWindow.set(windowKey, limit);
 	}
 	const ranked = [...byWindow.values()];
 	ranked.sort((left, right) => {
@@ -327,16 +328,17 @@ async function fetchZaiUsage(params: UsageFetchParams, ctx: UsageFetchContext): 
 		if (parsed.type === "CREDIT_LIMIT") {
 			// GLM Coding Plan windows (e.g. 12k credits / 5h + 60k credits / week):
 			// `usage` is the plan's credit allotment, `currentValue` the spend.
-			// `percentage` is a server-rounded integer (11 for 1438/12000 ≈ 11.98%),
-			// so prefer the exact ratio and fall back to it only without absolutes.
+			// Prefer the exact ratio when both absolute meter values exist. Keep an
+			// absolute remaining value in credits and use percentages only by themselves.
 			const window = buildZaiWindow(parsed);
 			const hasAbsoluteMeter = parsed.currentValue !== undefined && parsed.usage !== undefined && parsed.usage > 0;
+			const usePercentUnit = !hasAbsoluteMeter && parsed.remaining === undefined && parsed.percentage !== undefined;
 			const amount = buildUsageAmount({
 				used: parsed.currentValue,
 				limit: parsed.usage,
 				remaining: parsed.remaining,
 				percentage: hasAbsoluteMeter ? undefined : parsed.percentage,
-				unit: "credits",
+				unit: usePercentUnit ? "percent" : "credits",
 			});
 			limits.push({
 				id: `zai:credits:${window.id}`,

--- a/packages/ai/src/usage/zai.ts
+++ b/packages/ai/src/usage/zai.ts
@@ -331,7 +331,6 @@ async function fetchZaiUsage(params: UsageFetchParams, ctx: UsageFetchContext): 
 			// Prefer the exact ratio when both absolute meter values exist. Keep an
 			// absolute remaining value in credits and use percentages only by themselves.
 			const window = buildZaiWindow(parsed);
-			const hasAbsoluteMeter = parsed.currentValue !== undefined && parsed.usage !== undefined && parsed.usage > 0;
 			const usePercentUnit =
 				parsed.currentValue === undefined &&
 				parsed.usage === undefined &&
@@ -341,7 +340,7 @@ async function fetchZaiUsage(params: UsageFetchParams, ctx: UsageFetchContext): 
 				used: parsed.currentValue,
 				limit: parsed.usage,
 				remaining: parsed.remaining,
-				percentage: hasAbsoluteMeter ? undefined : parsed.percentage,
+				percentage: usePercentUnit ? parsed.percentage : undefined,
 				unit: usePercentUnit ? "percent" : "credits",
 			});
 			limits.push({

--- a/packages/ai/src/usage/zai.ts
+++ b/packages/ai/src/usage/zai.ts
@@ -332,7 +332,11 @@ async function fetchZaiUsage(params: UsageFetchParams, ctx: UsageFetchContext): 
 			// absolute remaining value in credits and use percentages only by themselves.
 			const window = buildZaiWindow(parsed);
 			const hasAbsoluteMeter = parsed.currentValue !== undefined && parsed.usage !== undefined && parsed.usage > 0;
-			const usePercentUnit = !hasAbsoluteMeter && parsed.remaining === undefined && parsed.percentage !== undefined;
+			const usePercentUnit =
+				parsed.currentValue === undefined &&
+				parsed.usage === undefined &&
+				parsed.remaining === undefined &&
+				parsed.percentage !== undefined;
 			const amount = buildUsageAmount({
 				used: parsed.currentValue,
 				limit: parsed.usage,

--- a/packages/ai/test/zai-usage.test.ts
+++ b/packages/ai/test/zai-usage.test.ts
@@ -105,6 +105,26 @@ describe("zai usage provider", () => {
 		]);
 	});
 
+	it("keeps distinct Z.AI quota windows without known durations", async () => {
+		const report = await zaiUsageProvider.fetchUsage!(
+			{ provider: "zai", credential: makeCredential(), signal: undefined },
+			makeCtx({
+				success: true,
+				data: {
+					limits: [
+						{ type: "TOKENS_LIMIT", percentage: 30, unit: 7, number: 1 },
+						{ type: "TOKENS_LIMIT", percentage: 40, unit: 8, number: 1 },
+					],
+				},
+			}),
+		);
+
+		expect(report).not.toBeNull();
+		const ranked = zaiRankingStrategy.findWindowLimits(report!);
+		expect(ranked.primary?.id).toBe("zai:tokens:1u7");
+		expect(ranked.secondary?.id).toBe("zai:tokens:1u8");
+	});
+
 	it("supports both api-key and oauth credentials, rejecting oauth rows with no access token", () => {
 		expect(zaiUsageProvider.supports!({ provider: "zai", credential: makeCredential(), signal: undefined })).toBe(
 			true,
@@ -208,12 +228,30 @@ describe("zai usage provider", () => {
 
 		expect(report).not.toBeNull();
 		const limit = report!.limits[0]!;
+		expect(limit.amount.unit).toBe("percent");
 		expect(limit.id).toBe("zai:credits:5h");
 		expect(limit.amount.used).toBeUndefined();
 		expect(limit.amount.usedFraction).toBeCloseTo(0.97, 5);
 		expect(limit.status).toBe("warning");
 	});
 
+	it("keeps credit units when only remaining is available", async () => {
+		const report = await zaiUsageProvider.fetchUsage!(
+			{ provider: "zai", credential: makeCredential(), signal: undefined },
+			makeCtx({
+				success: true,
+				data: {
+					limits: [{ type: "CREDIT_LIMIT", remaining: 1234, unit: 3, number: 5 }],
+				},
+			}),
+		);
+
+		expect(report).not.toBeNull();
+		const limit = report!.limits[0]!;
+		expect(limit.amount.unit).toBe("credits");
+		expect(limit.amount.remaining).toBe(1234);
+		expect(limit.amount.usedFraction).toBeUndefined();
+	});
 	it("keeps one ranked limit per window when tokens and credits meters coexist", async () => {
 		const report = await zaiUsageProvider.fetchUsage!(
 			{ provider: "zai", credential: makeCredential(), signal: undefined },

--- a/packages/ai/test/zai-usage.test.ts
+++ b/packages/ai/test/zai-usage.test.ts
@@ -252,6 +252,25 @@ describe("zai usage provider", () => {
 		expect(limit.amount.remaining).toBe(1234);
 		expect(limit.amount.usedFraction).toBeUndefined();
 	});
+	it("keeps credit units for partial absolute meters", async () => {
+		const report = await zaiUsageProvider.fetchUsage!(
+			{ provider: "zai", credential: makeCredential(), signal: undefined },
+			makeCtx({
+				success: true,
+				data: {
+					limits: [
+						{ type: "CREDIT_LIMIT", currentValue: 1200, percentage: 12, unit: 3, number: 5 },
+						{ type: "CREDIT_LIMIT", usage: 10000, percentage: 12, unit: 6, number: 1 },
+					],
+				},
+			}),
+		);
+
+		expect(report).not.toBeNull();
+		expect(report!.limits.map(limit => limit.amount.unit)).toEqual(["credits", "credits"]);
+		expect(report!.limits.map(limit => limit.amount.used)).toEqual([1200, undefined]);
+		expect(report!.limits.map(limit => limit.amount.limit)).toEqual([undefined, 10000]);
+	});
 	it("keeps one ranked limit per window when tokens and credits meters coexist", async () => {
 		const report = await zaiUsageProvider.fetchUsage!(
 			{ provider: "zai", credential: makeCredential(), signal: undefined },

--- a/packages/ai/test/zai-usage.test.ts
+++ b/packages/ai/test/zai-usage.test.ts
@@ -261,15 +261,18 @@ describe("zai usage provider", () => {
 					limits: [
 						{ type: "CREDIT_LIMIT", currentValue: 1200, percentage: 12, unit: 3, number: 5 },
 						{ type: "CREDIT_LIMIT", usage: 10000, percentage: 12, unit: 6, number: 1 },
+						{ type: "CREDIT_LIMIT", remaining: 1234, percentage: 42, unit: 3, number: 5 },
 					],
 				},
 			}),
 		);
 
 		expect(report).not.toBeNull();
-		expect(report!.limits.map(limit => limit.amount.unit)).toEqual(["credits", "credits"]);
-		expect(report!.limits.map(limit => limit.amount.used)).toEqual([1200, undefined]);
-		expect(report!.limits.map(limit => limit.amount.limit)).toEqual([undefined, 10000]);
+		expect(report!.limits.map(limit => limit.amount.unit)).toEqual(["credits", "credits", "credits"]);
+		expect(report!.limits.map(limit => limit.amount.used)).toEqual([1200, undefined, undefined]);
+		expect(report!.limits.map(limit => limit.amount.limit)).toEqual([undefined, 10000, undefined]);
+		expect(report!.limits.map(limit => limit.amount.remaining)).toEqual([undefined, undefined, 1234]);
+		expect(report!.limits.map(limit => limit.amount.usedFraction)).toEqual([undefined, undefined, undefined]);
 	});
 	it("keeps one ranked limit per window when tokens and credits meters coexist", async () => {
 		const report = await zaiUsageProvider.fetchUsage!(

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `omp usage` percentage rendering for Z.AI credit quotas that omit absolute values.
+
 ## [18.0.9] - 2026-08-28
 
 ### Breaking Changes

--- a/packages/coding-agent/test/usage-cli.test.ts
+++ b/packages/coding-agent/test/usage-cli.test.ts
@@ -331,6 +331,53 @@ describe("formatUsageBreakdown", () => {
 		expect(text).not.toContain("%");
 		expect(text).not.toContain("resets");
 	});
+	it("renders absolute credit quotas with their unit", () => {
+		const creditReport = makeReport("zai", "credits@example.test", [
+			{
+				id: "zai:credits:5h",
+				label: "ZAI 5 Hours Credit Quota",
+				scope: { provider: "zai", windowId: "5h" },
+				window: { id: "5h", label: "5 Hours" },
+				amount: { used: 2000, limit: 2000, unit: "credits", usedFraction: 1 },
+				status: "exhausted",
+			},
+		]);
+		const text = stripVTControlCharacters(formatUsageBreakdown([creditReport], [], Date.now()));
+		expect(text).toContain("2K / 2K credits");
+		expect(text).not.toContain("2Kundefined");
+	});
+
+	it("renders remaining credit quotas with their unit", () => {
+		const remainingReport = makeReport("zai", "remaining@example.test", [
+			{
+				id: "zai:credits:5h",
+				label: "ZAI 5 Hours Credit Quota",
+				scope: { provider: "zai", windowId: "5h" },
+				window: { id: "5h", label: "5 Hours" },
+				amount: { remaining: 2000, unit: "credits" },
+				status: "ok",
+			},
+		]);
+		const text = stripVTControlCharacters(formatUsageBreakdown([remainingReport], [], Date.now()));
+		expect(text).toContain("2K credits left");
+		expect(text).not.toContain("no data");
+	});
+	it("renders percentage-only credit quotas without claiming a credit count", () => {
+		const fallbackReport = makeReport("zai", "percentage@example.test", [
+			{
+				id: "zai:credits:5h",
+				label: "ZAI 5 Hours Credit Quota",
+				scope: { provider: "zai", windowId: "5h" },
+				window: { id: "5h", label: "5 Hours" },
+				amount: { unit: "percent", usedFraction: 0.42, remainingFraction: 0.58 },
+				status: "ok",
+			},
+		]);
+		const text = stripVTControlCharacters(formatUsageBreakdown([fallbackReport], [], Date.now()));
+		expect(text).toContain("42.0% used");
+		expect(text).not.toContain("credits");
+	});
+
 	it("renders every account: reported ones with limits, credential-only ones as no-data rows", () => {
 		const text = stripVTControlCharacters(formatUsageBreakdown(reports, accounts, Date.now()));
 		expect(text).toContain("dummy.primary@example.test");


### PR DESCRIPTION
## Summary

Keep Z.AI quota windows distinct and render incomplete credit meters safely in usage views and credential ranking.

## Changes

- Rank one most-binding token or credit meter per stable Z.AI quota-window identity, including windows without a known duration.
- Resolve ranking pressure from normalized usage amount fields.
- Preserve the `credits` unit when only an absolute remaining value is available.
- Render percentage-only credit quotas as percentages instead of attaching a misleading credit unit.

## Validation

- `bun test packages/ai/test/zai-usage.test.ts packages/ai/test/auth-broker-wire-schema-contract.test.ts packages/coding-agent/test/usage-cli.test.ts packages/ai/test/auth-broker-wire.test.ts` (68 pass, 0 fail, 355 expect calls)
- `bun --cwd=packages/ai run check`
- `bun --cwd=packages/coding-agent run check`
- `git diff --check`
- GitHub CI run `33150088393`: all test and validation jobs passed; release and publish jobs were skipped as expected.