### PR TITLE
feat(lsp): Add native TypeScript 7 server

### DIFF
--- a/docs/lsp-config.md
+++ b/docs/lsp-config.md
@@ -17,7 +17,7 @@ When no config file contributes a server override, OMP auto-detects built-in ser
 
 Root-marker detection at startup is cwd-only; it does not search parent directories. Wildcard markers such as `*.cabal` match entries directly inside the cwd and do not recurse. No configuration is required for common setups; see [`defaults.json`](../packages/coding-agent/src/lsp/defaults.json) for the full built-in set.
 
-The `tsc` entry provides the native TypeScript 7 server. OMP runs `tsc --lsp --stdio` and discovers a user-installed `tsc` in supported project-local bin directories before `$PATH`. The config key and command are both `tsc`.
+The `tsc` entry provides the native TypeScript 7 server. OMP discovers a user-installed `tsc` in supported project-local bin directories before `$PATH`, then registers it only when the executable is launchable and reports TypeScript 7 or newer. Older or unusable `tsc` installations are skipped, so `typescript-language-server` remains eligible. The registered server runs `tsc --lsp --stdio`; the config key and command are both `tsc`.
 
 For TypeScript and JavaScript files, OMP prefers `tsc` when both servers are available. `typescript-language-server` remains an independent fallback. Configure or disable either server by its own key without changing the other.
 Operations such as diagnostics and synchronization may query both matching servers when both are available.

--- a/docs/lsp-config.md
+++ b/docs/lsp-config.md
@@ -17,6 +17,11 @@ When no config file contributes a server override, OMP auto-detects built-in ser
 
 Root-marker detection at startup is cwd-only; it does not search parent directories. Wildcard markers such as `*.cabal` match entries directly inside the cwd and do not recurse. No configuration is required for common setups; see [`defaults.json`](../packages/coding-agent/src/lsp/defaults.json) for the full built-in set.
 
+The `tsc` entry provides the native TypeScript 7 server. OMP runs `tsc --lsp --stdio` and discovers a user-installed `tsc` in supported project-local bin directories before `$PATH`. The config key and command are both `tsc`.
+
+For TypeScript and JavaScript files, OMP prefers `tsc` when both servers are available. `typescript-language-server` remains an independent fallback. Configure or disable either server by its own key without changing the other.
+Operations such as diagnostics and synchronization may query both matching servers when both are available.
+
 ## Config file locations
 
 OMP merges LSP config from multiple sources, lowest to highest precedence:
@@ -219,6 +224,7 @@ The following servers ship in `defaults.json` and are eligible for auto-detectio
 | `clangd`                      | C, C++, ObjC                  | `clangd`                          |
 | `zls`                         | Zig                           | `zls`                             |
 | `gopls`                       | Go                            | `gopls`                           |
+| `tsc`                        | TypeScript, JavaScript (native TypeScript 7) | `tsc`                            |
 | `typescript-language-server`  | TypeScript, JavaScript        | `typescript-language-server`      |
 | `denols`                      | TypeScript, JavaScript (Deno) | `deno`                            |
 | `biome`                       | TS/JS/JSON (linter)           | `biome`                           |

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -13,6 +13,8 @@
 - The status line now displays the thinking level as a compact icon alongside the model name by default; set `statusLine.compactThinkingLevel` to `false` to restore the previous display.
 
 ### Fixed
+### Added
+- Added native TypeScript 7 LSP autodetection via `tsc --lsp --stdio`, preferred over `typescript-language-server` when both are available.
 
 - Fixed MCP OAuth discovery for shared API gateways and authorization servers with nested paths, including Keycloak realms, so authentication targets the correct resource issuer and supports endpoint and dynamic client-registration discovery.
 - Fixed credential rotation for HTTP 402 payment-required responses so sibling credentials are tried before model fallback without misclassifying informative non-quota errors.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -301,6 +301,7 @@
 - Fixed completed assistant replies disappearing from the live transcript under viewport pressure.
 - Accelerated SHA-2 and SHA-3 checksums on supported ARM64 hardware.
 - Fixed large MCP tool payloads being stored redundantly on disk.
+- Fixed native TypeScript LSP autodetection skipping pre-7 or unlaunchable `tsc` binaries so the classic server remains available ([#9986](https://github.com/can1357/oh-my-pi/pull/9986) by [@christian-auguste](https://github.com/christian-auguste)).
 
 ## [18.0.4] - 2026-08-24
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Added
+- Added native TypeScript 7 LSP autodetection via `tsc --lsp --stdio`, preferred over `typescript-language-server` when both are available ([#9986](https://github.com/can1357/oh-my-pi/pull/9986) by [@christian-auguste](https://github.com/christian-auguste)).
+
+### Fixed
+- Fixed native TypeScript LSP autodetection skipping pre-7 or unlaunchable `tsc` binaries so the classic server remains available ([#9986](https://github.com/can1357/oh-my-pi/pull/9986) by [@christian-auguste](https://github.com/christian-auguste)).
+
 ## [18.0.11] - 2026-08-29
 
 ### Added
@@ -13,8 +19,6 @@
 - The status line now displays the thinking level as a compact icon alongside the model name by default; set `statusLine.compactThinkingLevel` to `false` to restore the previous display.
 
 ### Fixed
-### Added
-- Added native TypeScript 7 LSP autodetection via `tsc --lsp --stdio`, preferred over `typescript-language-server` when both are available ([#9986](https://github.com/can1357/oh-my-pi/pull/9986) by [@christian-auguste](https://github.com/christian-auguste)).
 
 - Fixed MCP OAuth discovery for shared API gateways and authorization servers with nested paths, including Keycloak realms, so authentication targets the correct resource issuer and supports endpoint and dynamic client-registration discovery.
 - Fixed credential rotation for HTTP 402 payment-required responses so sibling credentials are tried before model fallback without misclassifying informative non-quota errors.
@@ -86,11 +90,7 @@
 - Kept embedded context usage visible in the status line when long session names or paths consume available space.
 - Added a status message when `CTRL-O` toggles tool-output expansion.
 - Fixed `omp usage` to report Codex Chat and Spark capacity meters separately when they share a usage window.
-### Added
-- Added native TypeScript 7 LSP autodetection via `tsc --lsp --stdio`, preferred over `typescript-language-server` when both are available ([#9986](https://github.com/can1357/oh-my-pi/pull/9986) by [@christian-auguste](https://github.com/christian-auguste)).
 
-### Fixed
-- Fixed native TypeScript LSP autodetection skipping pre-7 or unlaunchable `tsc` binaries so the classic server remains available ([#9986](https://github.com/can1357/oh-my-pi/pull/9986) by [@christian-auguste](https://github.com/christian-auguste)).
 
 ## [18.0.8] - 2026-08-27
 
@@ -306,7 +306,6 @@
 - Fixed completed assistant replies disappearing from the live transcript under viewport pressure.
 - Accelerated SHA-2 and SHA-3 checksums on supported ARM64 hardware.
 - Fixed large MCP tool payloads being stored redundantly on disk.
-- Fixed native TypeScript LSP autodetection skipping pre-7 or unlaunchable `tsc` binaries so the classic server remains available ([#9986](https://github.com/can1357/oh-my-pi/pull/9986) by [@christian-auguste](https://github.com/christian-auguste)).
 
 ## [18.0.4] - 2026-08-24
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -86,6 +86,11 @@
 - Kept embedded context usage visible in the status line when long session names or paths consume available space.
 - Added a status message when `CTRL-O` toggles tool-output expansion.
 - Fixed `omp usage` to report Codex Chat and Spark capacity meters separately when they share a usage window.
+### Added
+- Added native TypeScript 7 LSP autodetection via `tsc --lsp --stdio`, preferred over `typescript-language-server` when both are available ([#9986](https://github.com/can1357/oh-my-pi/pull/9986) by [@christian-auguste](https://github.com/christian-auguste)).
+
+### Fixed
+- Fixed native TypeScript LSP autodetection skipping pre-7 or unlaunchable `tsc` binaries so the classic server remains available ([#9986](https://github.com/can1357/oh-my-pi/pull/9986) by [@christian-auguste](https://github.com/christian-auguste)).
 
 ## [18.0.8] - 2026-08-27
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ### Fixed
 ### Added
-- Added native TypeScript 7 LSP autodetection via `tsc --lsp --stdio`, preferred over `typescript-language-server` when both are available.
+- Added native TypeScript 7 LSP autodetection via `tsc --lsp --stdio`, preferred over `typescript-language-server` when both are available ([#9986](https://github.com/can1357/oh-my-pi/pull/9986) by [@christian-auguste](https://github.com/christian-auguste)).
 
 - Fixed MCP OAuth discovery for shared API gateways and authorization servers with nested paths, including Keycloak realms, so authentication targets the correct resource issuer and supports endpoint and dynamic client-registration discovery.
 - Fixed credential rotation for HTTP 402 payment-required responses so sibling credentials are tried before model fallback without misclassifying informative non-quota errors.

--- a/packages/coding-agent/src/lsp/config.ts
+++ b/packages/coding-agent/src/lsp/config.ts
@@ -308,7 +308,25 @@ export function resolveCommand(command: string, cwd: string, options?: ResolveCo
 	if (!options) return $which(command);
 	return $which(command, { cache: options.cache, PATH: options.PATH });
 }
+const TSC_PROBE_TIMEOUT_MS = 500;
 
+function hasSupportedTypeScriptVersion(command: string, cwd: string): boolean {
+	try {
+		const result = Bun.spawnSync([command, "--version"], {
+			cwd,
+			stdout: "pipe",
+			stderr: "ignore",
+			timeout: TSC_PROBE_TIMEOUT_MS,
+			killSignal: "SIGKILL",
+		});
+		if (result.exitCode !== 0 || result.exitedDueToTimeout) return false;
+		const output = result.stdout.toString("utf-8").trim();
+		const match = /^Version\s+(\d+)(?:\.\d+){0,2}(?:[-+][\w.-]+)?$/.exec(output);
+		return match !== null && Number(match[1]) >= 7;
+	} catch {
+		return false;
+	}
+}
 interface ConfigSource {
 	read(): NormalizedConfig | null;
 }
@@ -466,6 +484,7 @@ export function loadConfig(cwd: string): LspConfig {
 			// Check if the language server binary is available (local or $PATH)
 			const resolved = resolveCommand(config.command, cwd);
 			if (!resolved) continue;
+			if (name === "tsc" && !hasSupportedTypeScriptVersion(resolved, cwd)) continue;
 
 			detected[name] = { ...config, resolvedCommand: resolved };
 		}
@@ -482,6 +501,7 @@ export function loadConfig(cwd: string): LspConfig {
 		if (!hasRootMarkers(cwd, config.rootMarkers)) continue;
 		const resolved = resolveCommand(config.command, cwd);
 		if (!resolved) continue;
+		if (name === "tsc" && !hasSupportedTypeScriptVersion(resolved, cwd)) continue;
 		available[name] = { ...config, resolvedCommand: resolved };
 	}
 

--- a/packages/coding-agent/src/lsp/defaults.json
+++ b/packages/coding-agent/src/lsp/defaults.json
@@ -52,6 +52,12 @@
 			}
 		}
 	},
+	"tsc": {
+		"command": "tsc",
+		"args": ["--lsp", "--stdio"],
+		"fileTypes": [".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs"],
+		"rootMarkers": ["package.json", "tsconfig.json", "jsconfig.json"]
+	},
 	"typescript-language-server": {
 		"command": "typescript-language-server",
 		"args": ["--stdio"],

--- a/packages/coding-agent/test/tools/lsp-regressions.test.ts
+++ b/packages/coding-agent/test/tools/lsp-regressions.test.ts
@@ -10,8 +10,12 @@ import { preloadPluginRoots } from "@oh-my-pi/pi-coding-agent/discovery/helpers"
 import { LspTool } from "@oh-my-pi/pi-coding-agent/lsp";
 import * as lspClient from "@oh-my-pi/pi-coding-agent/lsp/client";
 import * as lspConfig from "@oh-my-pi/pi-coding-agent/lsp/config";
+<<<<<<< HEAD
 import { getServersForFile, type LspConfig, loadConfig } from "@oh-my-pi/pi-coding-agent/lsp/config";
 import { waitForDiagnostics } from "@oh-my-pi/pi-coding-agent/lsp/diagnostics";
+=======
+import { getServerForFile, getServersForFile, type LspConfig, loadConfig } from "@oh-my-pi/pi-coding-agent/lsp/config";
+>>>>>>> 88ddc93035 (feat(lsp): Add native TypeScript 7 server)
 import {
 	applyTextEditsToString,
 	applyWorkspaceEdit,
@@ -5031,6 +5035,91 @@ describe("ty python lsp", () => {
 			expect(config.servers.ty?.resolvedCommand).toBe(resolvedTy);
 			expect(config.servers.ty?.command).toBe("ty");
 			expect(config.servers.ty?.args).toEqual(["server"]);
+		} finally {
+			tempDir.removeSync();
+		}
+	});
+});
+describe("native tsc lsp", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("routes TypeScript files to tsc before typescript-language-server", () => {
+		const config = { servers: DEFAULTS as unknown as Record<string, ServerConfig> };
+		const names = getServersForFile(config, "app.ts").map(([name]) => name);
+		expect(names).toContain("tsc");
+		expect(names).toContain("typescript-language-server");
+		expect(names.indexOf("tsc")).toBeLessThan(names.indexOf("typescript-language-server"));
+		expect(getServerForFile(config, "app.ts")?.[0]).toBe("tsc");
+	});
+
+	it("defines tsc with the native LSP command and all supported TypeScript extensions", () => {
+		const config = { servers: DEFAULTS as unknown as Record<string, ServerConfig> };
+		expect(config.servers.tsc).toMatchObject({
+			command: "tsc",
+			args: ["--lsp", "--stdio"],
+			fileTypes: [".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs"],
+			rootMarkers: ["package.json", "tsconfig.json", "jsconfig.json"],
+		});
+		for (const extension of [".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs"]) {
+			expect(getServersForFile(config, `app${extension}`).map(([name]) => name)).toContain("tsc");
+		}
+	});
+
+	it("auto-detects tsc when a TypeScript project marker and binary are present", async () => {
+		const tempDir = TempDir.createSync("@omp-lsp-tsc-detect-");
+		const resolvedTsc = path.join(tempDir.path(), "bin", "tsc");
+		const whichSpy = vi
+			.spyOn(piUtils, "$which")
+			.mockImplementation(command => (command === "tsc" ? resolvedTsc : null));
+		try {
+			await Bun.write(path.join(tempDir.path(), "package.json"), "{}\n");
+			const config = loadConfig(tempDir.path());
+			expect(config.servers.tsc?.resolvedCommand).toBe(resolvedTsc);
+			expect(config.servers.tsc?.command).toBe("tsc");
+			expect(config.servers.tsc?.args).toEqual(["--lsp", "--stdio"]);
+			expect(whichSpy).toHaveBeenCalledWith("tsc");
+		} finally {
+			tempDir.removeSync();
+		}
+	});
+
+	it("falls back to typescript-language-server when tsc is unavailable", async () => {
+		const tempDir = TempDir.createSync("@omp-lsp-tsc-fallback-");
+		const resolvedClassic = path.join(tempDir.path(), "bin", "typescript-language-server");
+		vi.spyOn(piUtils, "$which").mockImplementation(command =>
+			command === "typescript-language-server" ? resolvedClassic : null,
+		);
+		try {
+			await Bun.write(path.join(tempDir.path(), "package.json"), "{}\n");
+			const config = loadConfig(tempDir.path());
+			expect(config.servers.tsc).toBeUndefined();
+			expect(config.servers["typescript-language-server"]?.resolvedCommand).toBe(resolvedClassic);
+			expect(getServersForFile(config, path.join(tempDir.path(), "app.ts")).map(([name]) => name)).toEqual([
+				"typescript-language-server",
+			]);
+		} finally {
+			tempDir.removeSync();
+		}
+	});
+
+	it("prefers tsc while retaining typescript-language-server when both are available", async () => {
+		const tempDir = TempDir.createSync("@omp-lsp-tsc-both-");
+		const resolvedTsc = path.join(tempDir.path(), "bin", "tsc");
+		const resolvedClassic = path.join(tempDir.path(), "bin", "typescript-language-server");
+		vi.spyOn(piUtils, "$which").mockImplementation(command =>
+			command === "tsc" ? resolvedTsc : command === "typescript-language-server" ? resolvedClassic : null,
+		);
+		try {
+			await Bun.write(path.join(tempDir.path(), "package.json"), "{}\n");
+			const config = loadConfig(tempDir.path());
+			expect(config.servers.tsc?.resolvedCommand).toBe(resolvedTsc);
+			expect(config.servers["typescript-language-server"]?.resolvedCommand).toBe(resolvedClassic);
+			expect(getServersForFile(config, path.join(tempDir.path(), "app.ts")).map(([name]) => name)).toEqual([
+				"tsc",
+				"typescript-language-server",
+			]);
 		} finally {
 			tempDir.removeSync();
 		}

--- a/packages/coding-agent/test/tools/lsp-regressions.test.ts
+++ b/packages/coding-agent/test/tools/lsp-regressions.test.ts
@@ -5070,6 +5070,13 @@ describe("native tsc lsp", () => {
 	it("auto-detects tsc when a TypeScript project marker and binary are present", async () => {
 		const tempDir = TempDir.createSync("@omp-lsp-tsc-detect-");
 		const resolvedTsc = path.join(tempDir.path(), "bin", "tsc");
+		const valid7Result = {
+			...Bun.spawnSync([process.execPath, "--version"], { stdout: "pipe", stderr: "pipe" }),
+			exitCode: 0,
+			stdout: Buffer.from("Version 7.0.2\n"),
+			stderr: Buffer.from(""),
+		} satisfies Bun.ReadableSyncSubprocess;
+		vi.spyOn(Bun, "spawnSync").mockReturnValue(valid7Result);
 		const whichSpy = vi
 			.spyOn(piUtils, "$which")
 			.mockImplementation(command => (command === "tsc" ? resolvedTsc : null));
@@ -5108,6 +5115,13 @@ describe("native tsc lsp", () => {
 		const tempDir = TempDir.createSync("@omp-lsp-tsc-both-");
 		const resolvedTsc = path.join(tempDir.path(), "bin", "tsc");
 		const resolvedClassic = path.join(tempDir.path(), "bin", "typescript-language-server");
+		const valid7Result = {
+			...Bun.spawnSync([process.execPath, "--version"], { stdout: "pipe", stderr: "pipe" }),
+			exitCode: 0,
+			stdout: Buffer.from("Version 7.0.2\n"),
+			stderr: Buffer.from(""),
+		} satisfies Bun.ReadableSyncSubprocess;
+		vi.spyOn(Bun, "spawnSync").mockReturnValue(valid7Result);
 		vi.spyOn(piUtils, "$which").mockImplementation(command =>
 			command === "tsc" ? resolvedTsc : command === "typescript-language-server" ? resolvedClassic : null,
 		);
@@ -5120,6 +5134,58 @@ describe("native tsc lsp", () => {
 				"tsc",
 				"typescript-language-server",
 			]);
+		} finally {
+			tempDir.removeSync();
+		}
+	});
+	it("falls back to typescript-language-server when native tsc reports a pre-7 version", async () => {
+		const tempDir = TempDir.createSync("@omp-lsp-tsc-pre7-");
+		const resolvedTsc = path.join(tempDir.path(), "bin", "tsc");
+		const resolvedClassic = path.join(tempDir.path(), "bin", "typescript-language-server");
+		const pre7Result = {
+			...Bun.spawnSync([process.execPath, "--version"], { stdout: "pipe", stderr: "pipe" }),
+			exitCode: 0,
+			stdout: Buffer.from("Version 6.0.3\n"),
+			stderr: Buffer.from(""),
+		} satisfies Bun.ReadableSyncSubprocess;
+		const spawnSyncSpy = vi.spyOn(Bun, "spawnSync").mockReturnValue(pre7Result);
+		const whichSpy = vi
+			.spyOn(piUtils, "$which")
+			.mockImplementation(command =>
+				command === "tsc" ? resolvedTsc : command === "typescript-language-server" ? resolvedClassic : null,
+			);
+		try {
+			await Bun.write(path.join(tempDir.path(), "package.json"), "{}\n");
+			const config = loadConfig(tempDir.path());
+			expect(config.servers.tsc).toBeUndefined();
+			expect(config.servers["typescript-language-server"]?.resolvedCommand).toBe(resolvedClassic);
+			expect(getServerForFile(config, path.join(tempDir.path(), "app.ts"))?.[0]).toBe("typescript-language-server");
+			expect(whichSpy).toHaveBeenCalledWith("tsc");
+			expect(whichSpy).toHaveBeenCalledWith("typescript-language-server");
+			expect(spawnSyncSpy).toHaveBeenCalled();
+		} finally {
+			tempDir.removeSync();
+		}
+	});
+
+	it("falls back to typescript-language-server when native tsc cannot be launched", async () => {
+		const tempDir = TempDir.createSync("@omp-lsp-tsc-unlaunchable-");
+		const resolvedTsc = path.join(tempDir.path(), "bin", "tsc");
+		const resolvedClassic = path.join(tempDir.path(), "bin", "typescript-language-server");
+		const whichSpy = vi
+			.spyOn(piUtils, "$which")
+			.mockImplementation(command =>
+				command === "tsc" ? resolvedTsc : command === "typescript-language-server" ? resolvedClassic : null,
+			);
+		try {
+			await Bun.write(resolvedTsc, "#!/bin/sh\nexit 1\n");
+			await Bun.write(path.join(tempDir.path(), "package.json"), "{}\n");
+			const config = loadConfig(tempDir.path());
+			expect(config.servers.tsc).toBeUndefined();
+			expect(config.servers["typescript-language-server"]?.resolvedCommand).toBe(resolvedClassic);
+			expect(getServerForFile(config, path.join(tempDir.path(), "app.ts"))?.[0]).toBe("typescript-language-server");
+			expect(whichSpy).toHaveBeenCalledWith("tsc");
+			expect(whichSpy).toHaveBeenCalledWith("typescript-language-server");
 		} finally {
 			tempDir.removeSync();
 		}

--- a/packages/coding-agent/test/tools/lsp-regressions.test.ts
+++ b/packages/coding-agent/test/tools/lsp-regressions.test.ts
@@ -10,12 +10,8 @@ import { preloadPluginRoots } from "@oh-my-pi/pi-coding-agent/discovery/helpers"
 import { LspTool } from "@oh-my-pi/pi-coding-agent/lsp";
 import * as lspClient from "@oh-my-pi/pi-coding-agent/lsp/client";
 import * as lspConfig from "@oh-my-pi/pi-coding-agent/lsp/config";
-<<<<<<< HEAD
-import { getServersForFile, type LspConfig, loadConfig } from "@oh-my-pi/pi-coding-agent/lsp/config";
-import { waitForDiagnostics } from "@oh-my-pi/pi-coding-agent/lsp/diagnostics";
-=======
 import { getServerForFile, getServersForFile, type LspConfig, loadConfig } from "@oh-my-pi/pi-coding-agent/lsp/config";
->>>>>>> 88ddc93035 (feat(lsp): Add native TypeScript 7 server)
+import { waitForDiagnostics } from "@oh-my-pi/pi-coding-agent/lsp/diagnostics";
 import {
 	applyTextEditsToString,
 	applyWorkspaceEdit,

--- a/packages/coding-agent/test/tools/lsp-regressions.test.ts
+++ b/packages/coding-agent/test/tools/lsp-regressions.test.ts
@@ -5052,18 +5052,42 @@ describe("native tsc lsp", () => {
 		expect(names).toContain("typescript-language-server");
 		expect(names.indexOf("tsc")).toBeLessThan(names.indexOf("typescript-language-server"));
 		expect(getServerForFile(config, "app.ts")?.[0]).toBe("tsc");
-	});
-
-	it("defines tsc with the native LSP command and all supported TypeScript extensions", () => {
-		const config = { servers: DEFAULTS as unknown as Record<string, ServerConfig> };
-		expect(config.servers.tsc).toMatchObject({
-			command: "tsc",
-			args: ["--lsp", "--stdio"],
-			fileTypes: [".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs"],
-			rootMarkers: ["package.json", "tsconfig.json", "jsconfig.json"],
-		});
 		for (const extension of [".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs"]) {
 			expect(getServersForFile(config, `app${extension}`).map(([name]) => name)).toContain("tsc");
+		}
+	});
+
+	it("launches native tsc with LSP arguments and completes initialization", async () => {
+		const tempDir = TempDir.createSync("@omp-lsp-tsc-launch-");
+		const resolvedTsc = path.join(tempDir.path(), "bin", "tsc");
+		const valid7Result = {
+			...Bun.spawnSync([process.execPath, "--version"], { stdout: "pipe", stderr: "pipe" }),
+			exitCode: 0,
+			stdout: Buffer.from("Version 7.0.2\n"),
+			stderr: Buffer.from(""),
+		} satisfies Bun.ReadableSyncSubprocess;
+		vi.spyOn(Bun, "spawnSync").mockReturnValue(valid7Result);
+		vi.spyOn(piUtils, "$which").mockImplementation(command => (command === "tsc" ? resolvedTsc : null));
+		try {
+			await Bun.write(path.join(tempDir.path(), "package.json"), "{}\n");
+			const config = loadConfig(tempDir.path());
+			const tscConfig = config.servers.tsc;
+			if (!tscConfig) throw new Error("native tsc was not detected");
+			const server = installHandshakeLsp();
+
+			const client = await lspClient.getOrCreateClient(tscConfig, tempDir.path(), 1_000);
+
+			expect(piUtils.ptree.spawn).toHaveBeenCalledWith(
+				[resolvedTsc, "--lsp", "--stdio"],
+				expect.objectContaining({ cwd: tempDir.path(), stdin: "pipe" }),
+			);
+			const initialize = await server.waitFor(message => message.method === "initialize");
+			expect(initialize.params).toMatchObject({ rootPath: tempDir.path() });
+			await server.waitFor(message => message.method === "initialized");
+			expect(client.status).toBe("ready");
+		} finally {
+			await lspClient.shutdownAll();
+			tempDir.removeSync();
 		}
 	});
 


### PR DESCRIPTION
## Problem

Registering every resolvable `tsc` as the native TypeScript 7 LSP selected TypeScript 6 binaries and unlaunchable Node-shebang wrappers ahead of `typescript-language-server`. Native operations then failed without trying the classic server.

## Change

- Keep the native `tsc --lsp --stdio` default.
- Probe the resolved `tsc --version` before registering it.
- Accept TypeScript 7 and newer only.
- Skip pre-7, nonzero, timed-out, malformed, and unlaunchable `tsc` executables.
- Preserve `typescript-language-server` as the fallback.
- Add regressions for pre-7 and unlaunchable binaries.
- Document the eligibility and fallback behavior.

I reviewed the full diff and verified that the fix stays limited to LSP configuration, regression coverage, documentation, and the Unreleased changelog.

## Verification

- `bun test packages/coding-agent/test/tools/lsp-regressions.test.ts` (104 passed)
- `bun run check` (passed)
- LSP diagnostics on `config.ts` (OK)
- LSP diagnostics on `lsp-regressions.test.ts` (no errors; 19 existing hints)
- `git diff --check` (passed)