### PR TITLE
Show status message when toggling tool output expansion

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -34,6 +34,8 @@
 
 - Fixed the `aarch64-linux` `nix build` output segfaulting in the dynamic loader before startup by repointing the stale `DT_VERDEF` that `patchelf` leaves behind when it grows `.dynamic`, and surfaced smoke-test signal deaths in the build log instead of masking them ([#9881](https://github.com/can1357/oh-my-pi/issues/9881)).
 
+- Fixed `CTRL-O` now shows a status message ("Tool output expansion: enabled/disabled") after toggling, consistent with CTRL-T and CTRL-SHIFT-O.
+
 ## [18.0.7] - 2026-08-26
 
 ### Added

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -2051,6 +2051,7 @@ export class InputController {
 			return;
 		}
 		this.setToolsExpanded(!this.ctx.toolOutputExpanded);
+		this.ctx.showStatus(`Tool output expansion: ${this.ctx.toolOutputExpanded ? "enabled" : "disabled"}`);
 	}
 
 	toggleToolActivityVisibility(): void {

--- a/packages/coding-agent/test/modes/controllers/input-controller-tool-expansion.test.ts
+++ b/packages/coding-agent/test/modes/controllers/input-controller-tool-expansion.test.ts
@@ -8,10 +8,12 @@ describe("InputController tool output expansion", () => {
 		const expandable = { setExpanded: vi.fn() };
 		const inert = { render: vi.fn(() => []) };
 		const requestRender = vi.fn();
+		const showStatus = vi.fn();
 		const ctx = {
 			toolOutputExpanded: false,
 			chatContainer: { children: [expandable, inert] },
 			ui: { requestRender },
+			showStatus,
 		} as unknown as InteractiveModeContext;
 
 		new InputController(ctx).toggleToolOutputExpansion();
@@ -22,6 +24,7 @@ describe("InputController tool output expansion", () => {
 		// at their new heights in the same frame.
 		expect(requestRender).toHaveBeenCalledTimes(1);
 		expect(requestRender).toHaveBeenCalledWith(true);
+		expect(showStatus).toHaveBeenCalledWith("Tool output expansion: enabled");
 	});
 
 	it("does not expand hidden tool activity and explains why", () => {


### PR DESCRIPTION
Fixes #9919

[  ### Problem
  Pressing CTRL-O to toggle tool output expansion gave no visual feedback. Pressing CTRL-T (thinking blocks) and CTRL-SHIFT-O (tool activity visibility) both show a status message confirming the action — CTRL-O was inconsistent and silent.

  ### Fix
  Added a showStatus call in toggleToolOutputExpansion() after the expansion state is updated, matching the pattern used by the other two toggles:

  • CTRL-O → Tool output expansion: enabled / Tool output expansion: disabled
  • CTRL-SHIFT-O → Tool activity: hidden / Tool activity: visible (unchanged, already worked)
  • CTRL-T → Thinking blocks: hidden / Thinking blocks: visible (unchanged, already worked)

  ### Changes
  • src/modes/controllers/input-controller.ts — added  showStatus call at the end of toggleToolOutputExpansion()
  • test/modes/controllers/input-controller-tool-expansion.test.ts — added showStatus mock and assertion to the expansion test

  ### Testing
  bun test packages/coding-agent/test/modes/controllers/input-controller-tool-expansion.test.ts

  Fixes #[issue-number]
  │ Replace #[issue-number] with the actual GitHub
  │ issue number before submitting.](url)