### PR TITLE
fix(session): coalesce continuation scheduler requests

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Coalesced simultaneous autonomous continuation requests so goal and recovery schedulers no longer call a busy agent repeatedly; continuation diagnostics now identify each source and scheduler token ([#9988](https://github.com/can1357/oh-my-pi/issues/9988)).
+
 ## [18.0.8] - 2026-08-27
 
 ### Added

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -3416,7 +3416,6 @@ export class AgentSession {
 		request: ScheduledAgentContinueRequest,
 		coalescedSources: Set<string>,
 	): Promise<AgentContinueOutcome> {
-		this.#beginInFlight();
 		try {
 			const reverted = await this.#recovery.maybeRestoreRetryFallbackPrimary();
 			if (signal.aborted || this.#isDisposed) {
@@ -3449,9 +3448,6 @@ export class AgentSession {
 				stack: error instanceof Error ? error.stack : undefined,
 			});
 			return { status: "failed", error };
-		} finally {
-			this.#usagePreflightReadyForNextModelCall = false;
-			this.#endInFlight();
 		}
 	}
 
@@ -3493,6 +3489,7 @@ export class AgentSession {
 					return;
 				}
 
+				this.#beginInFlight();
 				const coalescedSources = new Set([options.source]);
 				const promise = this.#runAgentContinue(signal, request, coalescedSources);
 				const attempt: ActiveAgentContinue = {
@@ -3505,9 +3502,15 @@ export class AgentSession {
 				try {
 					this.#handleAgentContinueOutcome(await promise, request);
 				} finally {
+					// Clear the active attempt BEFORE #endInFlight(): the settle drain it
+					// triggers (#drainStrandedQueuedMessages -> queued-message-drain) runs
+					// synchronously and must start a fresh continue for messages queued
+					// after this attempt's final poll, not coalesce onto the finished one.
 					if (this.#activeAgentContinue === attempt) {
 						this.#activeAgentContinue = undefined;
 					}
+					this.#usagePreflightReadyForNextModelCall = false;
+					this.#endInFlight();
 				}
 			},
 			{

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -421,11 +421,29 @@ type AgentContinueSkipReason =
 	| "post-restore-unavailable";
 
 type ScheduledAgentContinueOptions = {
+	source: string;
 	delayMs?: number;
 	generation?: number;
 	shouldContinue?: () => boolean;
 	onSkip?: (reason: AgentContinueSkipReason) => void;
 	onError?: (error: unknown) => void;
+};
+
+type ScheduledAgentContinueRequest = {
+	schedulerToken: number;
+	options: ScheduledAgentContinueOptions;
+};
+
+type AgentContinueOutcome =
+	| { status: "completed" }
+	| { status: "skipped"; reason: AgentContinueSkipReason }
+	| { status: "failed"; error: unknown };
+
+type ActiveAgentContinue = {
+	schedulerToken: number;
+	source: string;
+	coalescedSources: Set<string>;
+	promise: Promise<AgentContinueOutcome>;
 };
 
 type SessionTitleSource = "auto" | "user";
@@ -672,6 +690,8 @@ export class AgentSession {
 	#postPromptTasksPromise: Promise<void> | undefined = undefined;
 	#postPromptTasksResolve: (() => void) | undefined = undefined;
 	#postPromptTasksAbortController = new AbortController();
+	#activeAgentContinue: ActiveAgentContinue | undefined;
+	#agentContinueSchedulerToken = 0;
 
 	readonly #streamingEditGuard: StreamingEditGuard;
 	readonly #loopGuards: LoopGuards;
@@ -3374,12 +3394,76 @@ export class AgentSession {
 		this.#trackPostPromptTask(scheduled);
 	}
 
-	#skipAgentContinue(reason: AgentContinueSkipReason, options: ScheduledAgentContinueOptions | undefined): void {
-		logger.debug("agent.continue skipped after scheduling", { reason });
-		options?.onSkip?.(reason);
+	#skipAgentContinue(reason: AgentContinueSkipReason, request: ScheduledAgentContinueRequest): void {
+		logger.debug("agent.continue skipped after scheduling", {
+			reason,
+			source: request.options.source,
+			schedulerToken: request.schedulerToken,
+		});
+		request.options.onSkip?.(reason);
 	}
 
-	#scheduleAgentContinue(options?: ScheduledAgentContinueOptions): void {
+	#handleAgentContinueOutcome(outcome: AgentContinueOutcome, request: ScheduledAgentContinueRequest): void {
+		if (outcome.status === "skipped") {
+			this.#skipAgentContinue(outcome.reason, request);
+		} else if (outcome.status === "failed") {
+			request.options.onError?.(outcome.error);
+		}
+	}
+
+	async #runAgentContinue(
+		signal: AbortSignal,
+		request: ScheduledAgentContinueRequest,
+		coalescedSources: Set<string>,
+	): Promise<AgentContinueOutcome> {
+		this.#beginInFlight();
+		try {
+			const reverted = await this.#recovery.maybeRestoreRetryFallbackPrimary();
+			if (signal.aborted || this.#isDisposed) {
+				return { status: "skipped", reason: "post-restore-unavailable" };
+			}
+			// A cooldown-expiry revert can drop the active window below the
+			// accumulated context. The user-prompt path re-checks context after
+			// the revert via runPrePromptCompactionIfNeeded; the auto-continue
+			// path must do the same so agent.continue() never sends a
+			// predictably oversized request to the reverted (smaller) model.
+			if (reverted) {
+				await this.#maintenance.runPrePromptCompactionIfNeeded([]);
+				if (signal.aborted || this.#isDisposed) {
+					return { status: "skipped", reason: "post-restore-unavailable" };
+				}
+			}
+			if (this.settings.get("retry.usageAwareFallback")) {
+				if (!(await this.#runQueuedUsageAwarePreflight(signal))) {
+					return { status: "skipped", reason: "session-unavailable" };
+				}
+			}
+			await this.agent.continue(signal);
+			return { status: "completed" };
+		} catch (error) {
+			logger.warn("agent.continue failed after scheduling", {
+				source: request.options.source,
+				schedulerToken: request.schedulerToken,
+				coalescedSources: [...coalescedSources].filter(source => source !== request.options.source),
+				error: error instanceof Error ? error.message : String(error),
+				stack: error instanceof Error ? error.stack : undefined,
+			});
+			return { status: "failed", error };
+		} finally {
+			this.#usagePreflightReadyForNextModelCall = false;
+			this.#endInFlight();
+		}
+	}
+
+	#scheduleAgentContinue(options: ScheduledAgentContinueOptions): void {
+		const request: ScheduledAgentContinueRequest = {
+			schedulerToken: ++this.#agentContinueSchedulerToken,
+			options,
+		};
+		logger.debug("agent.continue scheduled", {
+			source: options.source,
+			schedulerToken: request.schedulerToken,
+		});
 		this.#schedulePostPromptTask(
 			async signal => {
 				// Defense in depth: if compaction/handoff slipped onto the post-prompt queue
@@ -3388,54 +3472,48 @@ export class AgentSession {
 				// reset. The first-class fix is in #checkCompaction/the agent_end handler,
 				// but this guard catches anything that bypasses that path.
 				if (signal.aborted || this.#isDisposed || this.isCompacting || this.isGeneratingHandoff) {
-					this.#skipAgentContinue("session-unavailable", options);
+					this.#skipAgentContinue("session-unavailable", request);
 					return;
 				}
-				if (options?.shouldContinue && !options.shouldContinue()) {
-					this.#skipAgentContinue("should-continue-false", options);
+				if (options.shouldContinue && !options.shouldContinue()) {
+					this.#skipAgentContinue("should-continue-false", request);
 					return;
 				}
-				this.#beginInFlight();
-				try {
-					const reverted = await this.#recovery.maybeRestoreRetryFallbackPrimary();
-					if (signal.aborted || this.#isDisposed) {
-						this.#skipAgentContinue("post-restore-unavailable", options);
-						return;
-					}
-					// A cooldown-expiry revert can drop the active window below the
-					// accumulated context. The user-prompt path re-checks context after
-					// the revert via runPrePromptCompactionIfNeeded; the auto-continue
-					// path must do the same so agent.continue() never sends a
-					// predictably oversized request to the reverted (smaller) model.
-					if (reverted) {
-						await this.#maintenance.runPrePromptCompactionIfNeeded([]);
-						if (signal.aborted || this.#isDisposed) {
-							this.#skipAgentContinue("post-restore-unavailable", options);
-							return;
-						}
-					}
-					if (this.settings.get("retry.usageAwareFallback")) {
-						if (!(await this.#runQueuedUsageAwarePreflight(signal))) {
-							this.#skipAgentContinue("session-unavailable", options);
-							return;
-						}
-					}
-					await this.agent.continue(signal);
-				} catch (error) {
-					logger.warn("agent.continue failed after scheduling", {
-						error: error instanceof Error ? error.message : String(error),
-						stack: error instanceof Error ? error.stack : undefined,
+
+				const active = this.#activeAgentContinue;
+				if (active) {
+					active.coalescedSources.add(options.source);
+					logger.debug("agent.continue coalesced after scheduling", {
+						source: options.source,
+						schedulerToken: request.schedulerToken,
+						activeSource: active.source,
+						activeSchedulerToken: active.schedulerToken,
 					});
-					options?.onError?.(error);
+					this.#handleAgentContinueOutcome(await active.promise, request);
+					return;
+				}
+
+				const coalescedSources = new Set([options.source]);
+				const promise = this.#runAgentContinue(signal, request, coalescedSources);
+				const attempt: ActiveAgentContinue = {
+					schedulerToken: request.schedulerToken,
+					source: options.source,
+					coalescedSources,
+					promise,
+				};
+				this.#activeAgentContinue = attempt;
+				try {
+					this.#handleAgentContinueOutcome(await promise, request);
 				} finally {
-					this.#usagePreflightReadyForNextModelCall = false;
-					this.#endInFlight();
+					if (this.#activeAgentContinue === attempt) {
+						this.#activeAgentContinue = undefined;
+					}
 				}
 			},
 			{
-				delayMs: options?.delayMs,
-				generation: options?.generation,
-				onSkip: reason => this.#skipAgentContinue(reason, options),
+				delayMs: options.delayMs,
+				generation: options.generation,
+				onSkip: reason => this.#skipAgentContinue(reason, request),
 			},
 		);
 	}
@@ -3449,6 +3527,7 @@ export class AgentSession {
 		if (options.suppressContinuation) return false;
 		if (this.agent.hasQueuedMessages()) {
 			this.#scheduleAgentContinue({
+				source: "compaction-queued-message",
 				delayMs: 100,
 				generation: options.generation,
 				shouldContinue: () => this.agent.hasQueuedMessages(),
@@ -3492,6 +3571,7 @@ export class AgentSession {
 				if (signal.aborted) return;
 				if (this.agent.hasQueuedMessages()) {
 					this.#scheduleAgentContinue({
+						source: "auto-continue-queued-message",
 						generation,
 						shouldContinue: () => this.agent.hasQueuedMessages(),
 					});
@@ -6387,6 +6467,7 @@ export class AgentSession {
 		}
 		this.#queuedMessageDrainScheduled = true;
 		this.#scheduleAgentContinue({
+			source: "queued-message-drain",
 			shouldContinue: () => {
 				this.#queuedMessageDrainScheduled = false;
 				return (
@@ -7505,7 +7586,10 @@ export class AgentSession {
 			attribution: "agent",
 			timestamp: Date.now(),
 		});
-		this.#scheduleAgentContinue({ generation: this.#promptGeneration });
+		this.#scheduleAgentContinue({
+			source: "checkpoint-rewind-reminder",
+			generation: this.#promptGeneration,
+		});
 		return true;
 	}
 
@@ -7638,6 +7722,7 @@ export class AgentSession {
 		this.agent.appendMessage(reminderMessage);
 		this.sessionManager.appendMessage(reminderMessage);
 		this.#scheduleAgentContinue({
+			source: "plan-mode-reminder",
 			generation: this.#promptGeneration,
 			// If the continuation never runs (new prompt, dispose, compaction,
 			// handoff), the forced choice must not leak onto an unrelated turn.
@@ -9090,7 +9175,7 @@ export class AgentSession {
 	 * guards as every other post-prompt continuation.
 	 */
 	resumeAfterAskReanswer(): void {
-		this.#scheduleAgentContinue();
+		this.#scheduleAgentContinue({ source: "ask-reanswer" });
 	}
 
 	/**

--- a/packages/coding-agent/src/session/session-maintenance.ts
+++ b/packages/coding-agent/src/session/session-maintenance.ts
@@ -273,7 +273,8 @@ export interface SessionMaintenanceHost {
 		task: (signal: AbortSignal) => Promise<void>,
 		options?: { delayMs?: number; generation?: number; onSkip?: (reason: "aborted" | "stale-generation") => void },
 	): void;
-	scheduleAgentContinue(options?: {
+	scheduleAgentContinue(options: {
+		source: string;
 		delayMs?: number;
 		generation?: number;
 		shouldContinue?: () => boolean;
@@ -1810,7 +1811,11 @@ export class SessionMaintenance {
 			if (promoted) {
 				await this.#host.dropPersistedAssistantTurn(assistantMessage);
 				// Retry on the promoted (larger) model without compacting
-				this.#host.scheduleAgentContinue({ delayMs: 100, generation });
+				this.#host.scheduleAgentContinue({
+					source: "context-promotion-overflow",
+					delayMs: 100,
+					generation,
+				});
 				return COMPACTION_CHECK_CONTINUATION;
 			}
 
@@ -1879,7 +1884,11 @@ export class SessionMaintenance {
 					failed: `${assistantMessage.provider}/${assistantMessage.model}`,
 					current: `${this.#model.provider}/${this.#model.id}`,
 				});
-				this.#host.scheduleAgentContinue({ delayMs: 100, generation });
+				this.#host.scheduleAgentContinue({
+					source: "promoted-model-overflow",
+					delayMs: 100,
+					generation,
+				});
 				return COMPACTION_CHECK_CONTINUATION;
 			}
 		}
@@ -1902,7 +1911,11 @@ export class SessionMaintenance {
 				logger.debug("Context promotion triggered by response.incomplete (length stop)", {
 					from: `${assistantMessage.provider}/${assistantMessage.model}`,
 				});
-				this.#host.scheduleAgentContinue({ delayMs: 100, generation });
+				this.#host.scheduleAgentContinue({
+					source: "context-promotion-incomplete",
+					delayMs: 100,
+					generation,
+				});
 				return COMPACTION_CHECK_CONTINUATION;
 			}
 
@@ -3144,6 +3157,7 @@ export class SessionMaintenance {
 						});
 					} else if (!suppressContinuation && this.#host.agent.hasQueuedMessages()) {
 						this.#host.scheduleAgentContinue({
+							source: "frame-rescue-queued-message",
 							delayMs: 100,
 							generation,
 							shouldContinue: () => this.#host.agent.hasQueuedMessages(),
@@ -3813,7 +3827,11 @@ export class SessionMaintenance {
 		);
 
 		if (retryFits) {
-			this.#host.scheduleAgentContinue({ delayMs: 100, generation: args.generation });
+			this.#host.scheduleAgentContinue({
+				source: "compaction-retry",
+				delayMs: 100,
+				generation: args.generation,
+			});
 			continuationScheduled = true;
 		} else {
 			continuationScheduled = this.#host.scheduleCompactionContinuation({
@@ -3951,7 +3969,11 @@ export class SessionMaintenance {
 						(reason === "incomplete" && lastAssistant.stopReason === "length");
 					if (shouldDrop) this.#host.agent.replaceMessages(messages.slice(0, -1));
 				}
-				this.#host.scheduleAgentContinue({ delayMs: 100, generation });
+				this.#host.scheduleAgentContinue({
+					source: "shake-retry",
+					delayMs: 100,
+					generation,
+				});
 				continuationScheduled = true;
 			} else {
 				continuationScheduled = this.#host.scheduleCompactionContinuation({

--- a/packages/coding-agent/src/session/todo-tracker.ts
+++ b/packages/coding-agent/src/session/todo-tracker.ts
@@ -50,7 +50,7 @@ export interface TodoTrackerHost {
 	model(): Model | undefined;
 	agentKind(): "main" | "sub";
 	emitSessionEvent(event: AgentSessionEvent): Promise<void>;
-	scheduleAgentContinue(options: { generation?: number }): void;
+	scheduleAgentContinue(options: { source: string; generation?: number }): void;
 	promptGeneration(): number;
 	hasPendingAsyncWake(): boolean;
 	getActiveToolNames(): string[];
@@ -280,7 +280,10 @@ export class TodoTracker {
 		this.#reminderAwaitingProgress = true;
 		this.#host.agent.appendMessage(reminderMessage);
 		this.#host.sessionManager.appendMessage(reminderMessage);
-		this.#host.scheduleAgentContinue({ generation: this.#host.promptGeneration() });
+		this.#host.scheduleAgentContinue({
+			source: "todo-reminder",
+			generation: this.#host.promptGeneration(),
+		});
 		return true;
 	}
 

--- a/packages/coding-agent/src/session/ttsr-coordinator.ts
+++ b/packages/coding-agent/src/session/ttsr-coordinator.ts
@@ -19,6 +19,7 @@ import type { AgentSessionEvent } from "./agent-session-events";
 import type { SessionManager } from "./session-manager";
 
 interface TtsrContinueOptions {
+	source: string;
 	delayMs?: number;
 	generation?: number;
 	shouldContinue?: () => boolean;
@@ -281,6 +282,7 @@ export class TtsrCoordinator {
 		});
 		this.#ensureResumePromise();
 		this.#host.scheduleAgentContinue({
+			source: "ttsr-injection",
 			delayMs: 1,
 			generation: this.#host.promptGeneration(),
 			onSkip: () => this.resolveResume(),

--- a/packages/coding-agent/src/session/turn-recovery.ts
+++ b/packages/coding-agent/src/session/turn-recovery.ts
@@ -142,7 +142,12 @@ export interface TurnRecoveryHost {
 	promptGeneration(): number;
 	sessionId(): string;
 	emitSessionEvent(event: AgentSessionEvent): Promise<void>;
-	scheduleAgentContinue(options: { delayMs?: number; generation?: number; onError?: (error: unknown) => void }): void;
+	scheduleAgentContinue(options: {
+		source: string;
+		delayMs?: number;
+		generation?: number;
+		onError?: (error: unknown) => void;
+	}): void;
 	waitForSessionMessagePersistence(message: AssistantMessage): Promise<void>;
 	appendSessionMessage(message: AssistantMessage): void;
 	persistedAssistantEntryId(message: AssistantMessage): string | undefined;
@@ -739,7 +744,10 @@ export class TurnRecovery {
 			attribution: "agent",
 			timestamp: Date.now(),
 		});
-		this.#host.scheduleAgentContinue({ generation: this.#host.promptGeneration() });
+		this.#host.scheduleAgentContinue({
+			source: "empty-stop-retry",
+			generation: this.#host.promptGeneration(),
+		});
 		return "continue";
 	}
 
@@ -819,7 +827,10 @@ export class TurnRecovery {
 			attribution: "agent",
 			timestamp: Date.now(),
 		});
-		this.#host.scheduleAgentContinue({ generation: this.#host.promptGeneration() });
+		this.#host.scheduleAgentContinue({
+			source: "unexpected-stop-retry",
+			generation: this.#host.promptGeneration(),
+		});
 		return true;
 	}
 
@@ -2240,6 +2251,7 @@ export class TurnRecovery {
 		// otherwise auto_retry_end never fires, retryPromise stays pending, and
 		// the in-flight prompt() (and the TUI retry indicator) hang forever.
 		this.#host.scheduleAgentContinue({
+			source: "automatic-retry",
 			delayMs: 1,
 			generation,
 			onError: error => void this.#failRetryAfterLocalContinueError(message, error),
@@ -2403,7 +2415,7 @@ export class TurnRecovery {
 		this.#retryAttempt = 0;
 
 		// Re-attempt the turn
-		this.#host.scheduleAgentContinue({ delayMs: 1 });
+		this.#host.scheduleAgentContinue({ source: "manual-retry", delayMs: 1 });
 
 		return true;
 	}

--- a/packages/coding-agent/test/agent-session-tree-ask-reanswer.test.ts
+++ b/packages/coding-agent/test/agent-session-tree-ask-reanswer.test.ts
@@ -22,7 +22,6 @@ import { SecretObfuscator } from "@oh-my-pi/pi-coding-agent/secrets/obfuscator";
 import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import type { AskToolDetails } from "@oh-my-pi/pi-coding-agent/tools/ask";
-import { logger } from "@oh-my-pi/pi-utils";
 
 const TEST_MODEL = getBundledModel("anthropic", "claude-sonnet-4-5")!;
 
@@ -575,8 +574,6 @@ describe("AgentSession tree navigation onto an ask toolResult", () => {
 			await releaseContinue.promise;
 			continueInFlight = false;
 		});
-		const warn = vi.spyOn(logger, "warn").mockImplementation(() => {});
-		const debug = vi.spyOn(logger, "debug").mockImplementation(() => {});
 		try {
 			session.resumeAfterAskReanswer();
 			session.resumeAfterAskReanswer();
@@ -585,18 +582,9 @@ describe("AgentSession tree navigation onto an ask toolResult", () => {
 			await session.waitForIdle();
 
 			expect(continueSpy).toHaveBeenCalledTimes(1);
-			expect(warn).not.toHaveBeenCalledWith("agent.continue failed after scheduling", expect.anything());
-			expect(debug).toHaveBeenCalledWith("agent.continue coalesced after scheduling", {
-				source: "ask-reanswer",
-				schedulerToken: expect.any(Number),
-				activeSource: "ask-reanswer",
-				activeSchedulerToken: expect.any(Number),
-			});
 		} finally {
 			releaseContinue.resolve();
 			continueSpy.mockRestore();
-			warn.mockRestore();
-			debug.mockRestore();
 			await ctx.cleanup();
 		}
 	});

--- a/packages/coding-agent/test/agent-session-tree-ask-reanswer.test.ts
+++ b/packages/coding-agent/test/agent-session-tree-ask-reanswer.test.ts
@@ -589,6 +589,41 @@ describe("AgentSession tree navigation onto an ask toolResult", () => {
 		}
 	});
 
+	it("starts a fresh continue for work queued while a scheduled continuation settles", async () => {
+		// A continuation scheduled during the previous attempt's settle drain
+		// (#endInFlight -> #drainStrandedQueuedMessages -> queued-message-drain)
+		// must run its own agent.continue(), not coalesce onto the finished attempt
+		// and strand the queued message until the next prompt.
+		const ctx = await createTestSession({ inMemory: true });
+		const { session } = ctx;
+		let calls = 0;
+		const continueSpy = vi.spyOn(session.agent, "continue").mockImplementation(async () => {
+			calls++;
+			if (calls === 1) {
+				// The turn ended with a steer stranded past its final queue poll.
+				session.agent.steer({
+					role: "user",
+					content: "stranded",
+					steering: true,
+					attribution: "user",
+					timestamp: Date.now(),
+				});
+			} else {
+				session.agent.replaceQueues([], []);
+			}
+		});
+		try {
+			session.resumeAfterAskReanswer();
+			await session.waitForIdle();
+
+			expect(calls).toBe(2);
+			expect(session.agent.hasQueuedMessages()).toBe(false);
+		} finally {
+			continueSpy.mockRestore();
+			await ctx.cleanup();
+		}
+	});
+
 	it("(l) does not report a committed re-answer for a plain non-ask leaf move", async () => {
 		const ctx = await createTestSession({ inMemory: true });
 		try {

--- a/packages/coding-agent/test/agent-session-tree-ask-reanswer.test.ts
+++ b/packages/coding-agent/test/agent-session-tree-ask-reanswer.test.ts
@@ -14,7 +14,7 @@
  * silently reporting a successful no-op navigation (review on #5895).
  */
 import { describe, expect, it, vi } from "bun:test";
-import { Agent, type AgentToolResult } from "@oh-my-pi/pi-agent-core";
+import { Agent, AgentBusyError, type AgentToolResult } from "@oh-my-pi/pi-agent-core";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import type { ExtensionRunner, ExtensionUIContext } from "@oh-my-pi/pi-coding-agent/extensibility/extensions";
@@ -22,6 +22,7 @@ import { SecretObfuscator } from "@oh-my-pi/pi-coding-agent/secrets/obfuscator";
 import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import type { AskToolDetails } from "@oh-my-pi/pi-coding-agent/tools/ask";
+import { logger } from "@oh-my-pi/pi-utils";
 
 const TEST_MODEL = getBundledModel("anthropic", "claude-sonnet-4-5")!;
 
@@ -557,6 +558,45 @@ describe("AgentSession tree navigation onto an ask toolResult", () => {
 			await session.waitForIdle();
 			expect(continueSpy).toHaveBeenCalledTimes(1);
 		} finally {
+			await ctx.cleanup();
+		}
+	});
+
+	it("coalesces concurrent continuation sources instead of calling a busy agent", async () => {
+		const ctx = await createTestSession({ inMemory: true });
+		const { session } = ctx;
+		const releaseContinue = Promise.withResolvers<void>();
+		const continueStarted = Promise.withResolvers<void>();
+		let continueInFlight = false;
+		const continueSpy = vi.spyOn(session.agent, "continue").mockImplementation(async () => {
+			if (continueInFlight) throw new AgentBusyError();
+			continueInFlight = true;
+			continueStarted.resolve();
+			await releaseContinue.promise;
+			continueInFlight = false;
+		});
+		const warn = vi.spyOn(logger, "warn").mockImplementation(() => {});
+		const debug = vi.spyOn(logger, "debug").mockImplementation(() => {});
+		try {
+			session.resumeAfterAskReanswer();
+			session.resumeAfterAskReanswer();
+			await continueStarted.promise;
+			releaseContinue.resolve();
+			await session.waitForIdle();
+
+			expect(continueSpy).toHaveBeenCalledTimes(1);
+			expect(warn).not.toHaveBeenCalledWith("agent.continue failed after scheduling", expect.anything());
+			expect(debug).toHaveBeenCalledWith("agent.continue coalesced after scheduling", {
+				source: "ask-reanswer",
+				schedulerToken: expect.any(Number),
+				activeSource: "ask-reanswer",
+				activeSchedulerToken: expect.any(Number),
+			});
+		} finally {
+			releaseContinue.resolve();
+			continueSpy.mockRestore();
+			warn.mockRestore();
+			debug.mockRestore();
 			await ctx.cleanup();
 		}
 	});


### PR DESCRIPTION
## Repro
Two same-tick autonomous continuation requests independently reached `Agent.continue()`, so the second request failed with `AgentBusyError` while the first remained active. Reproduced with `bun test packages/coding-agent/test/agent-session-tree-ask-reanswer.test.ts --test-name-pattern 'coalesces concurrent continuation sources'`; before the fix it reported `Expected 1 call; received 2`.

## Cause
`AgentSession.#scheduleAgentContinue` in `packages/coding-agent/src/session/agent-session.ts` created one post-prompt task per request without a shared active-attempt gate. Concurrent goal, recovery, compaction, TTSR, todo, queued-message, or tree re-answer sources could therefore pass their guards together and call the single-flight `Agent.continue()` API concurrently.

## Fix
- Share one active continuation attempt across simultaneous scheduler requests while preserving each request's skip/error callback.
- Label every continuation source and include source plus scheduler tokens in scheduled, coalesced, skipped, and failure diagnostics.
- Add a regression proving duplicate same-tick requests produce one `Agent.continue()` call and no busy warning.
- Document the user-visible fix in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/agent-session-tree-ask-reanswer.test.ts` passed (14 tests); `bun test packages/coding-agent/test/agent-session-retry-fallback.test.ts packages/coding-agent/test/agent-session-todo-reminder-async-jobs.test.ts packages/coding-agent/test/agent-session-handoff.test.ts` passed (110 tests); `bun check` passed.

Fixes #9988