### PR TITLE
fix(stats): keep model colors consistent across views

### DIFF
--- a/packages/stats/CHANGELOG.md
+++ b/packages/stats/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed model colors so they now remain consistent between the Model Preference chart and Model Statistics table.
+
 ## [18.0.4] - 2026-08-24
 
 ### Fixed

--- a/packages/stats/src/client/components/chart-shared.tsx
+++ b/packages/stats/src/client/components/chart-shared.tsx
@@ -20,6 +20,22 @@ export const MODEL_COLORS = [
 	"#ff6b7d", // rose
 ];
 
+export function buildModelColorLookup(
+	records: readonly { model: string; provider: string; totalRequests: number }[],
+): Map<string, string> {
+	const rankedRecords = [...records].sort(
+		(a, b) =>
+			b.totalRequests - a.totalRequests || `${a.model}::${a.provider}`.localeCompare(`${b.model}::${b.provider}`),
+	);
+
+	return new Map(
+		rankedRecords.map((record, index) => [
+			`${record.model}::${record.provider}`,
+			MODEL_COLORS[index % MODEL_COLORS.length],
+		]),
+	);
+}
+
 export const CHART_THEMES = {
 	dark: {
 		legendLabel: "#a89fb3",

--- a/packages/stats/src/client/routes/ModelsRoute.tsx
+++ b/packages/stats/src/client/routes/ModelsRoute.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from "react";
 import { Line } from "react-chartjs-2";
 import { getModelDashboardStats } from "../api";
-import { CHART_THEMES, MODEL_COLORS } from "../components/chart-shared";
+import { buildModelColorLookup, CHART_THEMES, MODEL_COLORS } from "../components/chart-shared";
 import {
 	DetailChartEmpty,
 	detailChartPlugins,
@@ -40,17 +40,23 @@ export function ModelsRoute({ active, range, refreshTrigger }: ModelsRouteProps)
 		pollMs: 30000,
 		enabled: active,
 	});
+	const modelColorLookup = useMemo(() => buildModelColorLookup(modelStats?.byModel ?? []), [modelStats?.byModel]);
 
 	return (
 		<div className="stats-route-container space-y-6">
 			<AsyncBoundary loading={loading} error={error} data={modelStats}>
 				{modelStats && (
 					<>
-						<ModelShareChart modelSeries={modelStats.modelSeries} timeRange={range} />
+						<ModelShareChart
+							modelSeries={modelStats.modelSeries}
+							timeRange={range}
+							colorLookup={modelColorLookup}
+						/>
 						<ModelsTable
 							models={modelStats.byModel}
 							performanceSeries={modelStats.modelPerformanceSeries}
 							timeRange={range}
+							colorLookup={modelColorLookup}
 						/>
 					</>
 				)}
@@ -59,7 +65,15 @@ export function ModelsRoute({ active, range, refreshTrigger }: ModelsRouteProps)
 	);
 }
 
-function ModelShareChart({ modelSeries, timeRange }: { modelSeries: ModelTimeSeriesPoint[]; timeRange: TimeRange }) {
+function ModelShareChart({
+	modelSeries,
+	timeRange,
+	colorLookup,
+}: {
+	modelSeries: ModelTimeSeriesPoint[];
+	timeRange: TimeRange;
+	colorLookup: ReadonlyMap<string, string>;
+}) {
 	const theme = useSystemTheme();
 	const chartTheme = CHART_THEMES[theme];
 	const meta = rangeMeta(timeRange);
@@ -69,19 +83,25 @@ function ModelShareChart({ modelSeries, timeRange }: { modelSeries: ModelTimeSer
 	const data = useMemo(() => {
 		return {
 			labels: chartData.data.map(d => formatRangeTick(d.timestamp, timeRange)),
-			datasets: chartData.series.map((seriesName, index) => ({
-				label: seriesName,
-				data: chartData.data.map(d => d[seriesName] ?? 0),
-				borderColor: MODEL_COLORS[index % MODEL_COLORS.length],
-				backgroundColor: `${MODEL_COLORS[index % MODEL_COLORS.length]}20`,
-				fill: true,
-				tension: 0.4,
-				pointRadius: 0,
-				pointHoverRadius: 4,
-				borderWidth: 2,
-			})),
+			datasets: chartData.series.map((series, index) => {
+				const fallbackColor = MODEL_COLORS[index % MODEL_COLORS.length];
+				const color = series.key ? (colorLookup.get(series.key) ?? fallbackColor) : fallbackColor;
+				const dataKey = series.key ?? series.label;
+
+				return {
+					label: series.label,
+					data: chartData.data.map(d => d[dataKey] ?? 0),
+					borderColor: color,
+					backgroundColor: `${color}20`,
+					fill: true,
+					tension: 0.4,
+					pointRadius: 0,
+					pointHoverRadius: 4,
+					borderWidth: 2,
+				};
+			}),
 		};
-	}, [chartData, timeRange]);
+	}, [chartData, colorLookup, timeRange]);
 
 	const options = useMemo(() => {
 		return {
@@ -166,7 +186,7 @@ function buildModelPreferenceSeries(
 	topN = 5,
 ): {
 	data: Array<Record<string, number>>;
-	series: string[];
+	series: Array<{ key?: string; label: string }>;
 } {
 	if (points.length === 0) return { data: [], series: [] };
 
@@ -209,22 +229,26 @@ function buildModelPreferenceSeries(
 			total: 0,
 		};
 		bucket.total += point.requests;
-		const seriesLabel = topKeys.has(key) ? (labelByKey.get(key) ?? point.model) : "Other";
-		bucket[seriesLabel] = (bucket[seriesLabel] ?? 0) + point.requests;
+		const seriesKey = topKeys.has(key) ? key : "Other";
+		bucket[seriesKey] = (bucket[seriesKey] ?? 0) + point.requests;
 		dataMap.set(point.timestamp, bucket);
 	}
 
-	const series = topEntries.map(entry => labelByKey.get(entry.key) ?? entry.model);
+	const series: Array<{ key?: string; label: string }> = topEntries.map(entry => ({
+		key: entry.key,
+		label: labelByKey.get(entry.key) ?? entry.model,
+	}));
 	if ([...dataMap.values()].some(row => (row.Other ?? 0) > 0)) {
-		series.push("Other");
+		series.push({ label: "Other" });
 	}
 
 	const data = [...dataMap.values()]
 		.sort((a, b) => (a.timestamp ?? 0) - (b.timestamp ?? 0))
 		.map(row => {
 			const total = row.total ?? 0;
-			for (const key of series) {
-				row[key] = total > 0 ? ((row[key] ?? 0) / total) * 100 : 0;
+			for (const seriesItem of series) {
+				const seriesKey = seriesItem.key ?? seriesItem.label;
+				row[seriesKey] = total > 0 ? ((row[seriesKey] ?? 0) / total) * 100 : 0;
 			}
 			return row;
 		});
@@ -238,10 +262,12 @@ function ModelsTable({
 	models,
 	performanceSeries,
 	timeRange,
+	colorLookup,
 }: {
 	models: ModelStats[];
 	performanceSeries: ModelPerformancePoint[];
 	timeRange: TimeRange;
+	colorLookup: ReadonlyMap<string, string>;
 }) {
 	const [expandedKey, setExpandedKey] = useState<string | null>(null);
 	const meta = rangeMeta(timeRange);
@@ -280,7 +306,7 @@ function ModelsTable({
 					const key = `${model.model}::${model.provider}`;
 					const performance = performanceSeriesByKey.get(key);
 					const trendData = performance?.data ?? [];
-					const trendColor = MODEL_COLORS[index % MODEL_COLORS.length];
+					const trendColor = colorLookup.get(key) ?? MODEL_COLORS[index % MODEL_COLORS.length];
 					const isExpanded = expandedKey === key;
 					const errorRate = model.errorRate * 100;
 

--- a/packages/stats/test/model-color-consistency.test.ts
+++ b/packages/stats/test/model-color-consistency.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "bun:test";
+import { buildModelColorLookup, MODEL_COLORS } from "../src/client/components/chart-shared";
+
+type ModelRequestRecord = Readonly<{
+	model: string;
+	provider: string;
+	totalRequests: number;
+}>;
+
+describe("buildModelColorLookup", () => {
+	it("ranks by requests and keeps provider variants distinct", () => {
+		const records: readonly ModelRequestRecord[] = [
+			{ model: "Luna", provider: "provider-luna", totalRequests: 10_505 },
+			{ model: "Sol", provider: "provider-sol", totalRequests: 389 },
+			{ model: "Fable", provider: "provider-fable", totalRequests: 106 },
+			{ model: "Opus", provider: "provider-opus", totalRequests: 191 },
+			{ model: "Shared", provider: "provider-z", totalRequests: 5 },
+			{ model: "Shared", provider: "provider-a", totalRequests: 5 },
+		];
+		const originalRecords = records.map(record => ({ ...record }));
+
+		const lookup = buildModelColorLookup(records);
+
+		expect(lookup.get("Luna::provider-luna")).toBe(MODEL_COLORS[0]);
+		expect(lookup.get("Sol::provider-sol")).toBe(MODEL_COLORS[1]);
+		expect(lookup.get("Opus::provider-opus")).toBe(MODEL_COLORS[2]);
+		expect(lookup.get("Fable::provider-fable")).toBe(MODEL_COLORS[3]);
+		expect(lookup.get("Shared::provider-a")).toBe(MODEL_COLORS[4]);
+		expect(lookup.get("Shared::provider-z")).toBe(MODEL_COLORS[5]);
+		expect(lookup.get("Shared::provider-a")).not.toBe(lookup.get("Shared::provider-z"));
+		expect(records).toEqual(originalRecords);
+	});
+});


### PR DESCRIPTION
## What

- Build one deterministic model-provider color lookup ranked by request count.
- Reuse that lookup in the Model Preference chart, table sparklines, and expanded performance charts while preserving the table's token-based row order.
- Add regression coverage and a stats changelog entry.

## Why

I was recurrently running in this issue and it annoys me a bit, so I added this fix. Hope it helps!

The preference chart assigned palette positions by request rank, while the Model Statistics table assigned them by its independently token-ranked row position. Models whose request and token ranks differed therefore changed color between the two views.

### Before

![Model Preference and Model Statistics showing mismatched colors for the same models](https://raw.githubusercontent.com/rthiago/oh-my-pi/8ef4055061cd9efcfc0b35b812def162d861fd58/.github/pr-assets/stats-model-color-mismatch.webp)

## Testing

### Reproduction

In the supplied 24-hour Models view, `claude-fable-5` was green in Model Preference but cyan in its Model Statistics sparkline. `claude-opus-5` was cyan in Model Preference but green in its sparkline. Their request rank and token-based table rank were reversed, exposing the two independent positional color assignments.

### Result

Ran `bun --cwd=packages/coding-agent src/cli.ts stats --port 3848` against local session data with the same reversed Fable/Opus rankings and opened the 24-hour Models view. Fable rendered green in both sections, Opus rendered cyan in both sections, and the expanded performance chart retained the same assigned model color. The original reproduction no longer mismatched colors.

Automated verification:

- `bun test packages/stats/test/model-color-consistency.test.ts`
- `bun run --cwd packages/stats check`
- `bun run lint`
- `bun run check` (TypeScript and Rust checks completed successfully)
- `bun run test`

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)