### PR TITLE
fix(agent): preserve images during shake elision

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `/shake elide` deleting images from mixed tool results and over-reporting token savings; it now offloads only the text while preserving every image block for normal replay.
+
 ## [18.0.7] - 2026-08-26
 
 ### Fixed

--- a/packages/agent/src/compaction/shake.ts
+++ b/packages/agent/src/compaction/shake.ts
@@ -1,9 +1,10 @@
 /**
  * Context-reducing surgical compaction ("shake").
  *
- * `shake` drops heavy content out of the live context mechanically: whole
- * tool-call results and large fenced/XML blocks are replaced with short
- * placeholders. This module is the pure layer — region detection and in-place
+ * `shake` drops heavy content out of the live context mechanically:
+ * tool-result text and large fenced/XML blocks are replaced with short
+ * placeholders while non-text tool-result content is preserved. This module
+ * is the pure layer — region detection and in-place
  * mutation only. Artifact offload, persistence, and provider-session teardown
  * are orchestrated by the caller (`AgentSession.shake`).
  *
@@ -80,6 +81,7 @@ const PLACEHOLDER_TOKEN_ESTIMATE = 16;
 export interface ToolResultShakeRegion {
 	kind: "toolResult";
 	entry: SessionMessageEntry;
+	/** Estimated tokens in the removable text only; retained images are excluded. */
 	tokens: number;
 	originalText: string;
 	/** Human label for the offload doc (tool name). */
@@ -114,11 +116,19 @@ function getToolResultMessage(entry: SessionEntry): ToolResultMessage | undefine
 	return message as ToolResultMessage;
 }
 
-function toolResultText(message: ToolResultMessage): string {
-	return message.content
-		.filter((block): block is TextContent => block.type === "text")
-		.map(block => block.text)
-		.join("\n");
+function toolResultText(
+	message: ToolResultMessage,
+	tokenizer: Tokenizer,
+): { originalText: string; tokens: number } | undefined {
+	const fragments: string[] = [];
+	for (const block of message.content) {
+		if (block.type === "text" && block.text.length > 0) fragments.push(block.text);
+	}
+	if (fragments.length === 0) return undefined;
+	return {
+		originalText: fragments.join("\n"),
+		tokens: tokenizer.countTokens(fragments),
+	};
 }
 
 /** Estimate the token contribution of an entry for the protect-recent window. */
@@ -292,10 +302,11 @@ function scanContentBlocks(
  * Pure detection: locate every eligible shake region on a branch.
  *
  * Walks the protect-recent window (most recent `protectTokens` of context is
- * kept intact), collects whole tool-result messages (honoring `protectedTools`
- * and skipping already-pruned results) and large fenced/XML blocks inside
- * user/developer/assistant/custom messages. Tool results flagged contextually
- * useless by their tool bypass the protect window — there is nothing recent
+ * kept intact), collects the text from eligible tool-result messages
+ * (honoring `protectedTools` and skipping already-pruned results) and large
+ * fenced/XML blocks inside user/developer/assistant/custom messages.
+ * Contextually useless tool results bypass the protect window — there is
+ * nothing recent
  * worth keeping in them. Returns regions in document order.
  *
  * `toolCall` blocks are never touched (tool-call/result pairing is preserved)
@@ -339,13 +350,13 @@ export function collectShakeRegions(entries: SessionEntry[], tokenizer: Tokenize
 			if (toolResult.prunedAt !== undefined) continue;
 			if (isProtectedToolResult(toolResult, toolCallsById.get(toolResult.toolCallId), config.protectedTools))
 				continue;
-			const text = toolResultText(toolResult);
-			if (text.length === 0) continue;
+			const text = toolResultText(toolResult, tokenizer);
+			if (!text) continue;
 			regions.push({
 				kind: "toolResult",
 				entry: entry as SessionMessageEntry,
-				tokens: tokenizer.countMessage(toolResult as AgentMessage),
-				originalText: text,
+				tokens: text.tokens,
+				originalText: text.originalText,
 				label: toolResult.toolName,
 			});
 			continue;
@@ -414,8 +425,9 @@ function getBlockTextSlot(entry: SessionMessageEntry | CustomMessageEntry, block
 /**
  * Pure mutation: replace a single region's content in place.
  *
- * Tool-result: replaces the message content with the placeholder text and
- * stamps `prunedAt`. Block: splices `replacement` over `[start, end)` of the
+ * Tool-result: replaces its first non-empty text block with the placeholder,
+ * removes its other text blocks, preserves every non-text block, and stamps
+ * `prunedAt`. Block: splices `replacement` over `[start, end)` of the
  * target text block. When several block regions share one text block they MUST
  * be applied highest-start-first so earlier offsets stay valid — use
  * {@link applyShakeRegions}, which orders them correctly.
@@ -423,7 +435,15 @@ function getBlockTextSlot(entry: SessionMessageEntry | CustomMessageEntry, block
 export function applyShakeRegion(region: ShakeRegion, replacement: string): void {
 	if (region.kind === "toolResult") {
 		const message = region.entry.message as ToolResultMessage;
-		message.content = [{ type: "text", text: replacement }];
+		const replacementIndex = message.content.findIndex(block => block.type === "text" && block.text.length > 0);
+		if (replacementIndex < 0) return;
+		const kept: typeof message.content = [];
+		for (let index = 0; index < message.content.length; index++) {
+			const block = message.content[index];
+			if (block.type !== "text") kept.push(block);
+			else if (index === replacementIndex) kept.push({ type: "text", text: replacement });
+		}
+		message.content = kept;
 		message.prunedAt = Date.now();
 		invalidateMessageCache(message as AgentMessage);
 		return;

--- a/packages/coding-agent/test/shake.test.ts
+++ b/packages/coding-agent/test/shake.test.ts
@@ -131,6 +131,79 @@ describe("AgentSession shake", () => {
 			expect(text).toContain("shaken");
 		});
 
+		it("preserves mixed tool-result images while eliding only recoverable text", async () => {
+			const largeText = "mixed tool output ".repeat(2_000);
+			const image: ImageContent = {
+				type: "image",
+				data: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB",
+				mimeType: "image/png",
+				detail: "original",
+				providerFile: { provider: "openai", id: "file_shake_image" },
+				url: "https://images.example.invalid/shake.png",
+			};
+			const imageSnapshot = structuredClone(image);
+			seedHeavyToolResult(largeText);
+			const [mixedResult] = branchToolResults();
+			mixedResult.content = [{ type: "text", text: largeText }, image];
+			const tailBefore = recentProtectedTail("newer context");
+			appendRecentProtectedTail();
+
+			const result = await session.shake("elide");
+
+			expect(result.toolResultsDropped).toBe(1);
+			expect(result.imagesDropped).toBeUndefined();
+			expect(result.artifactId).toBeDefined();
+			const placeholder = mixedResult.content[0];
+			expect(placeholder?.type).toBe("text");
+			if (placeholder?.type !== "text") throw new Error("Expected shake placeholder text");
+			expect(placeholder.text).toContain("shaken");
+			expect(placeholder.text).toContain(`artifact://${result.artifactId}`);
+			expect(mixedResult.content[1]).toBe(image);
+			expect(mixedResult.content[1]).toEqual(imageSnapshot);
+
+			const tokenizer = new Tokenizer();
+			const expectedFreed = tokenizer.countTokens(largeText) - tokenizer.countTokens(placeholder.text);
+			expect(result.tokensFreed).toBe(expectedFreed);
+			expect(result.tokensFreed).toBeGreaterThan(0);
+
+			if (!result.artifactId) throw new Error("Expected shake artifact");
+			const artifactPath = await sessionManager.getArtifactPath(result.artifactId);
+			if (!artifactPath) throw new Error("Expected persisted shake artifact");
+			expect(await Bun.file(artifactPath).text()).toContain(largeText);
+
+			const latestUser = sessionManager
+				.getBranch()
+				.findLast(entry => entry.type === "message" && entry.message.role === "user");
+			expect(latestUser?.type === "message" ? latestUser.message.content : undefined).toEqual([
+				{ type: "text", text: tailBefore },
+			]);
+
+			const sessionFile = sessionManager.getSessionFile();
+			if (!sessionFile) throw new Error("Expected persisted shake session");
+			const persisted = await SessionManager.open(sessionFile, tempDir.path());
+			try {
+				const persistedResult = persisted
+					.getBranch()
+					.find(
+						entry =>
+							entry.type === "message" &&
+							entry.message.role === "toolResult" &&
+							entry.message.toolCallId === mixedResult.toolCallId,
+					);
+				const persistedImage =
+					persistedResult?.type === "message" && persistedResult.message.role === "toolResult"
+						? persistedResult.message.content.find(block => block.type === "image")
+						: undefined;
+				expect(persistedImage).toEqual(imageSnapshot);
+			} finally {
+				await persisted.close();
+			}
+
+			const imageResult = await session.shake("images");
+			expect(imageResult.imagesDropped).toBe(1);
+			expect(mixedResult.content.some(block => block.type === "image")).toBe(false);
+		});
+
 		it("updates provider-anchored context usage immediately after rewriting prompt history", async () => {
 			seedHeavyToolResult("X".repeat(20_000));
 			sessionManager.appendMessage({


### PR DESCRIPTION
User report that triggered this investigation: “I’m fairly certain `/shake images` drops snapcompaction, which is not the intended use/behavior, especially when we are using it to compact tool/system prompts and parameters.”

The trace separated two behaviors:

- `/shake images` intentionally calls `dropImages()` and remains unchanged by this PR.
- `/shake elide` had a real data-loss bug: a mixed tool result was eligible based on its joined text, but applying the region replaced the *entire* `message.content` array with one text placeholder. Any sibling image blocks disappeared, and `tokensFreed` implicitly treated the whole result as gone.

## Fix

Elision now operates on text content only:

- the first non-empty text block becomes the artifact-backed recovery placeholder;
- remaining text blocks are removed;
- every non-text block is preserved by reference and in original relative order;
- token savings are calculated from removed text minus placeholder cost, never from retained images.

For a normal `[text, image]` result, output is `[placeholder, image]`. The explicit destructive `/shake images` command is unchanged.

## Behavioral coverage

The new session-level test uses an old mixed tool result with image fields `data`, `mimeType`, `detail`, `providerFile`, and `url`, plus a protected recent tail. It asserts:

- artifact contains the original elided text;
- placeholder carries the recovery link;
- the full image block survives with the same in-memory identity and fields;
- persisted history still contains the image;
- protected tail is unchanged;
- savings equal text-only savings;
- a subsequent `/shake images` still deletes the image.

Mutation proof: final test against the unfixed source fails exactly on mixed-image preservation (18 pass / 1 fail); fixed source passes 19 / 0 with 84 assertions. `packages/agent` typechecks clean.
