### PR TITLE
fix(coding-agent): compact mixed-image tool results

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed inline Snapcompact skipping all text compaction for tool results that also contain source images; mixed results now compact their text while preserving every original image block.
+
 ## [18.0.8] - 2026-08-27
 
 ### Added

--- a/packages/coding-agent/src/session/snapcompact-inline.ts
+++ b/packages/coding-agent/src/session/snapcompact-inline.ts
@@ -56,21 +56,19 @@ const MIN_TOOL_RESULT_TOKENS = 3000;
 /** Render only if imageTokens <= textTokens * SAVINGS_MARGIN. */
 const SAVINGS_MARGIN = 0.9;
 
-/** Count image blocks already present across all message contents. */
-function countContextImages(context: Context): number {
+/** Loose block-array view shared by live contexts and session-history estimates. */
+type BlockViews = ReadonlyArray<{ type?: unknown; text?: unknown }>;
+
+/** Count image blocks already present across message contents. */
+function countMessageImages(messages: readonly { content?: unknown }[]): number {
 	let count = 0;
-	for (const message of context.messages) {
-		const content = message.content;
-		if (typeof content === "string") continue;
-		for (const block of content) {
+	for (const message of messages) {
+		if (!Array.isArray(message.content)) continue;
+		for (const block of message.content as BlockViews) {
 			if (block.type === "image") count++;
 		}
 	}
 	return count;
-}
-
-function isTextContent(block: TextContent | ImageContent): block is TextContent {
-	return block.type === "text";
 }
 
 /** Image tokens must undercut text tokens by the margin to be worth rendering. */
@@ -137,12 +135,10 @@ function selectSystemPromptImageTarget(
 export interface InlineToolResultCandidate {
 	/** Stable identifier for rendering cache key and applying the swap. */
 	id: string;
-	/** Token count of the joined text blocks (0 for empty or image-carrying). */
+	/** Token count of all joined text blocks, including text beside images. */
 	textTokens: number;
-	/** Frames needed to render the text (0 = empty, below floor, image-carrying, or error). */
+	/** Frames needed to render the joined text (0 = empty or below floor). */
 	frames: number;
-	/** Already carries an image (screenshot etc.) — never re-imaged. */
-	hasImage: boolean;
 	/** Error tool results must stay text-only for provider API validation. */
 	isError?: boolean;
 }
@@ -186,7 +182,6 @@ export function planInlineSwaps(input: InlinePlanInput): InlineSwapPlan {
 		// remaining budget is skipped, not a stop — later smaller ones may fit.
 		for (let k = 0; k < input.toolResults.length - 1 && budget > 0; k++) {
 			const candidate = input.toolResults[k];
-			if (candidate.hasImage) continue;
 			if (candidate.isError) continue;
 			if (candidate.textTokens < MIN_TOOL_RESULT_TOKENS) continue;
 			if (candidate.frames === 0 || candidate.frames > budget) continue;
@@ -229,6 +224,41 @@ export interface InlineMessageView {
 	isError?: boolean;
 }
 
+interface BuiltInlineToolResultCandidate {
+	candidate: InlineToolResultCandidate;
+	text: string;
+}
+
+/**
+ * Build the exact same text payload and planning candidate for estimation and
+ * live transformation. Image blocks do not suppress co-resident text.
+ */
+function buildInlineToolResultCandidate(
+	toolCallId: string,
+	content: unknown,
+	messageIsError: boolean | undefined,
+	tokenizer: Tokenizer,
+	shape: snapcompact.Shape,
+): BuiltInlineToolResultCandidate {
+	const blocks: BlockViews = Array.isArray(content) ? (content as BlockViews) : [];
+	const textBlocks: string[] = [];
+	for (const block of blocks) {
+		if (block.type === "text" && typeof block.text === "string") textBlocks.push(block.text);
+	}
+	const text = textBlocks.join("\n");
+	const textTokens = text.length > 0 ? tokenizer.countTokens(text) : 0;
+	const isError = messageIsError === true;
+	return {
+		candidate: {
+			id: toolCallId,
+			textTokens,
+			frames: !isError && textTokens >= MIN_TOOL_RESULT_TOKENS ? snapcompact.frames(text, { shape }) : 0,
+			isError,
+		},
+		text,
+	};
+}
+
 export interface SnapcompactSavingsEstimate {
 	/** Frames only ship on models that accept image input. */
 	visionCapable: boolean;
@@ -259,9 +289,6 @@ export interface SnapcompactSavingsEstimate {
 	savedTokens: number;
 }
 
-/** Loose block-array view of unknown message content. */
-type BlockViews = ReadonlyArray<{ type?: unknown; text?: unknown }>;
-
 /**
  * Estimate what `SnapcompactInlineTransformer.transform` would save on the
  * NEXT request, given the session's live system prompt and message history.
@@ -284,35 +311,21 @@ export function estimateInlineSavings(input: {
 
 	const shape = snapcompact.resolveShape(model, options.shape);
 	const tokenizer = new Tokenizer(model);
-	let existingImages = 0;
-	for (const message of input.messages) {
-		if (!Array.isArray(message.content)) continue;
-		for (const block of message.content as BlockViews) {
-			if (block.type === "image") existingImages++;
-		}
-	}
+	const existingImages = countMessageImages(input.messages);
 	const budget = snapcompact.providerImageBudget(model.provider) - existingImages;
 
 	const candidates: InlineToolResultCandidate[] = [];
 	if (options.renderToolResults) {
 		for (const message of input.messages) {
 			if (message.role !== "toolResult" || typeof message.toolCallId !== "string") continue;
-			if (message.isError) continue;
-			const blocks: BlockViews = Array.isArray(message.content) ? (message.content as BlockViews) : [];
-			const hasImage = blocks.some(block => block.type === "image");
-			const text = hasImage
-				? ""
-				: blocks
-						.filter(block => block.type === "text" && typeof block.text === "string")
-						.map(block => block.text as string)
-						.join("\n");
-			const textTokens = text.length > 0 ? tokenizer.countTokens(text) : 0;
-			candidates.push({
-				id: message.toolCallId,
-				textTokens,
-				frames: textTokens >= MIN_TOOL_RESULT_TOKENS ? snapcompact.frames(text, { shape }) : 0,
-				hasImage,
-			});
+			const built = buildInlineToolResultCandidate(
+				message.toolCallId,
+				message.content,
+				message.isError,
+				tokenizer,
+				shape,
+			);
+			candidates.push(built.candidate);
 		}
 	}
 
@@ -424,8 +437,7 @@ export class SnapcompactInlineTransformer {
 
 		const shape = snapcompact.resolveShape(model, this.options.shape);
 		const tokenizer = new Tokenizer(model);
-		const budget = snapcompact.providerImageBudget(model.provider) - countContextImages(context);
-		if (budget <= 0) return context;
+		const budget = snapcompact.providerImageBudget(model.provider) - countMessageImages(context.messages);
 
 		const messages = [...context.messages];
 
@@ -439,23 +451,15 @@ export class SnapcompactInlineTransformer {
 				const message = messages[i];
 				if (message.role !== "toolResult") continue;
 				liveToolCallIds.add(message.toolCallId);
-				// Don't re-image results that already carry images (screenshots etc.).
-				const hasImage = message.content.some(block => block.type === "image");
-				if (message.isError) continue;
-				const text = hasImage
-					? ""
-					: message.content
-							.filter(isTextContent)
-							.map(block => block.text)
-							.join("\n");
-				const textTokens = text.length > 0 ? tokenizer.countTokens(text) : 0;
-				candidates.push({
-					id: message.toolCallId,
-					textTokens,
-					frames: textTokens >= MIN_TOOL_RESULT_TOKENS ? snapcompact.frames(text, { shape }) : 0,
-					hasImage,
-				});
-				targets.set(message.toolCallId, { index: i, message, text });
+				const built = buildInlineToolResultCandidate(
+					message.toolCallId,
+					message.content,
+					message.isError,
+					tokenizer,
+					shape,
+				);
+				candidates.push(built.candidate);
+				targets.set(message.toolCallId, { index: i, message, text: built.text });
 			}
 		}
 
@@ -487,7 +491,13 @@ export class SnapcompactInlineTransformer {
 			const target = targets.get(swap.id);
 			if (!target) continue;
 			const frames = await this.#framesFor(this.#toolCache, swap.id, target.text, shape);
-			messages[target.index] = { ...target.message, content: [{ type: "text", text: toolResultNote }, ...frames] };
+			const content: (TextContent | ImageContent)[] = [{ type: "text", text: toolResultNote }, ...frames];
+			// Keep the note adjacent to its generated frames, then retain
+			// source images in their original relative order and identity.
+			for (const block of target.message.content) {
+				if (block.type === "image") content.push(block);
+			}
+			messages[target.index] = { ...target.message, content };
 			changed = true;
 			savings.push({
 				toolCallId: swap.id,

--- a/packages/coding-agent/test/snapcompact-inline.test.ts
+++ b/packages/coding-agent/test/snapcompact-inline.test.ts
@@ -208,23 +208,79 @@ describe("SnapcompactInlineTransformer", () => {
 		expect((context.messages[0] as { content: string }).content).toBe("first user prompt");
 	});
 
-	it("leaves tool results that already carry images untouched", async () => {
-		const transformer = new SnapcompactInlineTransformer(
-			withTestShape({ renderSystemPrompt: "none", renderToolResults: true }),
-		);
-		const withImage: ToolResultMessage = {
-			...toolResult("call_img", LARGE),
-			content: [
-				{ type: "text", text: LARGE },
-				{ type: "image", data: "aGk=", mimeType: "image/png" },
-			],
+	it("compacts text in mixed tool results while preserving every source image and the input context", async () => {
+		const options = withTestShape({ renderSystemPrompt: "all", renderToolResults: true });
+		const transformer = new SnapcompactInlineTransformer(options);
+		const toolImage: ImageContent = {
+			type: "image",
+			data: "dG9vbC1pbWFnZS1ieXRlcw==",
+			mimeType: "image/webp",
+			detail: "original",
+			providerFile: { provider: "anthropic", id: "file_tool_source" },
+			url: "https://images.example.invalid/tool-source.webp",
+		};
+		const userImage: ImageContent = {
+			type: "image",
+			data: "dXNlci1pbWFnZS1ieXRlcw==",
+			mimeType: "image/png",
+		};
+		const userContent: (TextContent | ImageContent)[] = [{ type: "text", text: "inspect both images" }, userImage];
+		const firstUserMessage: Message = { role: "user", content: userContent, timestamp: 0 };
+		const mixedContent: (TextContent | ImageContent)[] = [
+			{ type: "text", text: LARGE },
+			toolImage,
+			{ type: "text", text: "mixed result text tail" },
+		];
+		const mixedResult: ToolResultMessage = {
+			...toolResult("call_mixed", LARGE),
+			content: mixedContent,
 		};
 		const context: Context = {
-			messages: [userMessage("hi"), withImage, toolResult("call_tail", LARGE)],
+			systemPrompt: [LARGE],
+			messages: [firstUserMessage, mixedResult, toolResult("call_newest", LARGE)],
 		};
-		const result = await transformer.transform(context, makeModel());
-		expect(result.messages[1]).toBe(withImage);
+		const pristine = structuredClone(context);
+		const toolImageSnapshot = structuredClone(toolImage);
+		const userImageSnapshot = structuredClone(userImage);
+		const originalMessages = context.messages;
+		const originalSystemPrompt = context.systemPrompt;
+		const model = makeModel();
+
+		const estimate = estimateInlineSavings({
+			options,
+			model,
+			systemPrompt: context.systemPrompt!,
+			messages: context.messages,
+		});
+		const result = await transformer.transform(context, model);
+
+		expect(estimate.toolResults?.swapped).toBe(1);
+		expect(estimate.systemPrompt?.applied).toBe(true);
+		const swapped = result.messages[1] as ToolResultMessage;
+		const toolImageIndex = swapped.content.indexOf(toolImage);
+		expect(swapped.content[0].type).toBe("text");
+		expect(toolImageIndex).toBe(swapped.content.length - 1);
+		expect(swapped.content.slice(1, toolImageIndex).every(block => block.type === "image")).toBe(true);
+		expect(swapped.content.slice(1, toolImageIndex)).toHaveLength(estimate.toolResults!.frames);
+		expect(swapped.content[toolImageIndex]).toBe(toolImage);
+		expect(swapped.content[toolImageIndex]).toEqual(toolImageSnapshot);
+		expect(result.messages[2]).toBe(context.messages[2]);
+
+		const carrier = result.messages[0] as { content: (TextContent | ImageContent)[] };
+		const systemFrames = carrier.content.slice(1, carrier.content.length - userContent.length);
+		expect(systemFrames).toHaveLength(estimate.systemPrompt!.frames);
+		expect(systemFrames.every(block => block.type === "image")).toBe(true);
+		expect(carrier.content[carrier.content.length - 1]).toBe(userImage);
+		expect(carrier.content[carrier.content.length - 1]).toEqual(userImageSnapshot);
+		expect(result.systemPrompt).not.toBe(context.systemPrompt);
+
+		expect(context).toEqual(pristine);
+		expect(context.messages).toBe(originalMessages);
+		expect(context.systemPrompt).toBe(originalSystemPrompt);
+		expect(firstUserMessage.content).toBe(userContent);
+		expect((context.messages[1] as ToolResultMessage).content).toBe(mixedContent);
 	});
+
 	it("leaves error tool results text-only even when they are large", async () => {
 		const transformer = new SnapcompactInlineTransformer(
 			withTestShape({ renderSystemPrompt: "none", renderToolResults: true }),
@@ -339,6 +395,48 @@ describe("SnapcompactInlineTransformer", () => {
 		expect(result.messages[4]).toBe(context.messages[4]);
 	});
 
+	it("truthfully skips swaps when source images consume the provider budget", async () => {
+		const options = withTestShape({ renderSystemPrompt: "all", renderToolResults: true });
+		const sourceImages: ImageContent[] = Array.from({ length: 5 }, (_, index) => ({
+			type: "image",
+			data: String(index).repeat(4),
+			mimeType: "image/png",
+		}));
+		const mixedResult: ToolResultMessage = {
+			...toolResult("call_mixed", LARGE),
+			content: [{ type: "text", text: LARGE }, ...sourceImages.slice(1)],
+		};
+		const context: Context = {
+			systemPrompt: [LARGE],
+			messages: [
+				{
+					role: "user",
+					content: [{ type: "text", text: "go" }, sourceImages[0]],
+					timestamp: 0,
+				},
+				mixedResult,
+				toolResult("call_newest", LARGE),
+			],
+		};
+		const model = makeModel({ provider: "groq" });
+		const estimate = estimateInlineSavings({
+			options,
+			model,
+			systemPrompt: context.systemPrompt!,
+			messages: context.messages,
+		});
+		const result = await new SnapcompactInlineTransformer(options).transform(context, model);
+
+		expect(estimate.toolResults?.total).toBe(2);
+		expect(estimate.toolResults?.swapped).toBe(0);
+		expect(estimate.toolResults?.savedTokens).toBe(0);
+		expect(estimate.systemPrompt?.applied).toBe(false);
+		expect(estimate.systemPrompt?.reason).toBe("budget");
+		expect(estimate.savedTokens).toBe(0);
+		expect(result).toBe(context);
+		expect(result.messages[1]).toBe(mixedResult);
+	});
+
 	it("caches renders across turns: identical input does not re-rasterize", async () => {
 		const spy = spyOn(snapcompact, "renderMany");
 		try {
@@ -378,8 +476,8 @@ describe("planInlineSwaps", () => {
 			shape,
 			budget: 90,
 			toolResults: [
-				{ id: "a", textTokens: 10000, frames: 2, hasImage: false },
-				{ id: "z", textTokens: 10000, frames: 2, hasImage: false },
+				{ id: "a", textTokens: 10000, frames: 2 },
+				{ id: "z", textTokens: 10000, frames: 2 },
 			],
 			systemPrompt: undefined,
 			hasUserMessage: true,
@@ -387,19 +485,19 @@ describe("planInlineSwaps", () => {
 		expect(plan.toolResults.map(swap => swap.id)).toEqual(["a"]);
 	});
 
-	it("skips error, image-carrying, below-floor, and below-margin candidates", () => {
+	it("skips error, empty, below-floor, and below-margin candidates", () => {
 		const plan = planInlineSwaps({
 			options: toolOnly,
 			shape,
 			budget: 90,
 			toolResults: [
-				{ id: "img", textTokens: 0, frames: 0, hasImage: true },
-				{ id: "small", textTokens: 2999, frames: 1, hasImage: false },
+				{ id: "empty", textTokens: 0, frames: 0 },
+				{ id: "small", textTokens: 2999, frames: 1 },
 				// 2 frames ≈ 6600 image tokens > 7000 * 0.9 — margin gate rejects.
-				{ id: "margin", textTokens: 7000, frames: 2, hasImage: false },
-				{ id: "err", textTokens: 10000, frames: 2, hasImage: false, isError: true },
-				{ id: "ok", textTokens: 10000, frames: 2, hasImage: false },
-				{ id: "last", textTokens: 10000, frames: 2, hasImage: false },
+				{ id: "margin", textTokens: 7000, frames: 2 },
+				{ id: "err", textTokens: 10000, frames: 2, isError: true },
+				{ id: "ok", textTokens: 10000, frames: 2 },
+				{ id: "last", textTokens: 10000, frames: 2 },
 			],
 			systemPrompt: undefined,
 			hasUserMessage: true,
@@ -413,10 +511,10 @@ describe("planInlineSwaps", () => {
 			shape,
 			budget: 3,
 			toolResults: [
-				{ id: "a", textTokens: 10000, frames: 2, hasImage: false },
-				{ id: "b", textTokens: 10000, frames: 2, hasImage: false },
-				{ id: "c", textTokens: 5000, frames: 1, hasImage: false },
-				{ id: "last", textTokens: 10000, frames: 2, hasImage: false },
+				{ id: "a", textTokens: 10000, frames: 2 },
+				{ id: "b", textTokens: 10000, frames: 2 },
+				{ id: "c", textTokens: 5000, frames: 1 },
+				{ id: "last", textTokens: 10000, frames: 2 },
 			],
 			systemPrompt: undefined,
 			hasUserMessage: true,
@@ -430,8 +528,8 @@ describe("planInlineSwaps", () => {
 			shape,
 			budget: 2,
 			toolResults: [
-				{ id: "a", textTokens: 10000, frames: 2, hasImage: false },
-				{ id: "last", textTokens: 10000, frames: 2, hasImage: false },
+				{ id: "a", textTokens: 10000, frames: 2 },
+				{ id: "last", textTokens: 10000, frames: 2 },
 			],
 			systemPrompt: { textTokens: 10000, frames: 2 },
 			hasUserMessage: true,


### PR DESCRIPTION
The intended behavior from the user report is: “We are using it to compact tool/system prompts and parameters,” so one screenshot should not disable compaction of all co-resident text.

## Root cause

Inline Snapcompact marked a historical tool result `hasImage` if *any* content block was an image, set its candidate text to `""`, then skipped `candidate.hasImage` in `planInlineSwaps`. A large `[text, image]` result was therefore left entirely untouched even when its text cleared the token and savings gates.

The checked-in test explicitly codified that all-or-nothing skip.

## Fix

- Candidate construction always joins text blocks; source images are opaque attachments, not a reason to discard text eligibility.
- Estimator and runtime now share the same candidate/image-budget builder, so `/context` cannot disagree with the real transform.
- Applying a selected mixed swap emits the explanatory note, generated Snapcompact frames, then carries every original image block unchanged and in original relative order.
- Existing source images remain reserved through `countContextImages(context)` before frame planning, so generated frames cannot exceed the provider image-count budget.
- Error results and the newest result remain protected.
- Input context/message arrays remain immutable.

## Behavioral coverage

The replacement test includes:

- a large mixed historical tool result;
- image fields `data`, `mimeType`, `detail`, `providerFile`, and `url`;
- a large system prompt;
- a first-user image;
- a newer protected tool result.

It proves the mixed text is compacted, source images survive with same object identity, system-prompt imaging still runs, the first-user image survives, estimator/runtime agree, newest/error protections remain, and input objects are unchanged. A second test proves five existing source images leave no slots and produce a truthful zero-savings/zero-swap result.

Mutation proof: tests against unfixed source fail on the mixed-image contract (23 pass / 1 fail); fixed source passes 24 / 0 with 118 assertions. `packages/coding-agent` typechecks clean.
