### PR TITLE
fix(tui): display Antigravity daily usage in status line

### DIFF
--- a/packages/ai/src/usage/google-antigravity.ts
+++ b/packages/ai/src/usage/google-antigravity.ts
@@ -426,12 +426,13 @@ export const antigravityUsageProvider: UsageProvider = {
 	supports: params => params.provider === "google-antigravity",
 };
 
-function getAntigravityCounterKeyForModel(context: CredentialRankingContext | undefined): string | undefined {
-	const modelId = context?.modelId?.toLowerCase();
-	if (!modelId) return undefined;
-	if (modelId.startsWith("claude-")) return "anthropic";
-	if (modelId.startsWith("gemini-") || modelId.startsWith("gemma-")) return "google";
-	if (modelId.startsWith("gpt-") || modelId.startsWith("openai/")) return "openai";
+/** Map an Antigravity model id to its backend quota-counter key. */
+export function getAntigravityCounterKeyForModel(modelId: string | undefined): string | undefined {
+	const normalizedModelId = modelId?.toLowerCase();
+	if (!normalizedModelId) return undefined;
+	if (normalizedModelId.startsWith("claude-")) return "anthropic";
+	if (normalizedModelId.startsWith("gemini-") || normalizedModelId.startsWith("gemma-")) return "google";
+	if (normalizedModelId.startsWith("gpt-") || normalizedModelId.startsWith("openai/")) return "openai";
 	return undefined;
 }
 
@@ -447,7 +448,7 @@ function scopeAntigravityLimitsForModel(
 	report: UsageReport,
 	context: CredentialRankingContext | undefined,
 ): UsageLimit[] {
-	const counterKey = getAntigravityCounterKeyForModel(context);
+	const counterKey = getAntigravityCounterKeyForModel(context?.modelId);
 	if (!counterKey) return [];
 	const backendLimits = getAntigravityCounterLimits(report, counterKey);
 	if (backendLimits.length > 0) return backendLimits;
@@ -455,7 +456,7 @@ function scopeAntigravityLimitsForModel(
 }
 
 function rankAntigravityLimits(report: UsageReport, context: CredentialRankingContext | undefined): UsageLimit[] {
-	const counterKey = getAntigravityCounterKeyForModel(context);
+	const counterKey = getAntigravityCounterKeyForModel(context?.modelId);
 	if (!counterKey) return report.limits;
 	return scopeAntigravityLimitsForModel(report, context);
 }
@@ -480,7 +481,7 @@ export const antigravityRankingStrategy: CredentialRankingStrategy = {
 	// Always return a scope for Antigravity so missing/unknown model context
 	// cannot fall through to AuthStorage's provider-wide block bucket.
 	blockScope(context) {
-		const counterKey = getAntigravityCounterKeyForModel(context);
+		const counterKey = getAntigravityCounterKeyForModel(context?.modelId);
 		return `counter:${counterKey ?? "unknown"}`;
 	},
 	// Antigravity windows carry `durationMs` when the response identifies them

--- a/packages/ai/src/usage/google-antigravity.ts
+++ b/packages/ai/src/usage/google-antigravity.ts
@@ -441,10 +441,15 @@ function getAntigravityCounterLimits(report: UsageReport, counterKey: string): U
 	return report.limits.filter(limit => limit.id.toLowerCase().startsWith(prefix));
 }
 
-// Exhaustion checks are only safe with a concrete backend counter. A no-model
-// Antigravity credential lookup (for example image-provider discovery) must
-// not turn one exhausted family into a provider-wide block.
-function scopeAntigravityLimitsForModel(
+/**
+ * Scope an Antigravity report to the active model's backend counter, falling
+ * back to legacy default counters only when that backend has no limits.
+ *
+ * Exhaustion checks are only safe with a concrete backend counter. A no-model
+ * credential lookup (for example image-provider discovery) must not turn one
+ * exhausted family into a provider-wide block.
+ */
+export function scopeAntigravityLimitsForModel(
 	report: UsageReport,
 	context: CredentialRankingContext | undefined,
 ): UsageLimit[] {

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Google Antigravity daily quota usage now appears in the status-line usage segment ([#9999](https://github.com/can1357/oh-my-pi/issues/9999)).
+
 ## [18.0.8] - 2026-08-27
 
 ### Added

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -1,7 +1,7 @@
 import * as path from "node:path";
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
 import type { AssistantMessage, UsageLimit, UsageReport } from "@oh-my-pi/pi-ai";
-import { parseKnownModel } from "@oh-my-pi/pi-catalog/identity";
+import { getAntigravityCounterKeyForModel } from "@oh-my-pi/pi-ai/usage/google-antigravity";
 import {
 	type Component,
 	type ComposerStyle,
@@ -64,28 +64,6 @@ function normalizeUsageScopeValue(value: unknown): string | undefined {
 
 /** Antigravity backend counters the status line can scope to a model family. */
 const ANTIGRAVITY_KNOWN_COUNTERS: Record<string, true> = { google: true, anthropic: true, openai: true };
-
-/**
- * Antigravity account reports keep Google, Anthropic, and OpenAI backend
- * counters separate and sort limits by remaining fraction, so a Claude session
- * could otherwise display the more-exhausted Gemini quota (or vice versa). Map
- * the active model id to the counter key encoded in the Antigravity limit id
- * (`google-antigravity:<counter>:<tier>:<window>`). Returns undefined when the
- * family is unknown (e.g. `gpt-oss-*`), so filtering falls back to first-match.
- */
-function antigravityCounterForModel(modelId: string | undefined): string | undefined {
-	if (!modelId) return undefined;
-	switch (parseKnownModel(modelId).family) {
-		case "gemini":
-			return "google";
-		case "anthropic":
-			return "anthropic";
-		case "openai":
-			return "openai";
-		default:
-			return undefined;
-	}
-}
 
 /** Backend counter segment of an Antigravity limit id, or undefined. */
 function antigravityCounterFromLimitId(id: string | undefined): string | undefined {
@@ -1497,7 +1475,7 @@ export class StatusLineComponent implements Component {
 		const now = Date.now();
 		const activeModelId = normalizeUsageScopeValue(context.modelId);
 		const activeAntigravityCounter =
-			context.provider === "google-antigravity" ? antigravityCounterForModel(context.modelId) : undefined;
+			context.provider === "google-antigravity" ? getAntigravityCounterKeyForModel(context.modelId) : undefined;
 		const scopeGroups = new Map<string, UsageScopeGroup>();
 		for (const report of reports) {
 			if (!report || typeof report !== "object") continue;

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -1,6 +1,7 @@
 import * as path from "node:path";
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
 import type { AssistantMessage, UsageLimit, UsageReport } from "@oh-my-pi/pi-ai";
+import { parseKnownModel } from "@oh-my-pi/pi-catalog/identity";
 import {
 	type Component,
 	type ComposerStyle,
@@ -59,6 +60,38 @@ interface UsageScopeGroup {
 
 function normalizeUsageScopeValue(value: unknown): string | undefined {
 	return typeof value === "string" && value.trim() ? value.trim().toLowerCase() : undefined;
+}
+
+/** Antigravity backend counters the status line can scope to a model family. */
+const ANTIGRAVITY_KNOWN_COUNTERS: Record<string, true> = { google: true, anthropic: true, openai: true };
+
+/**
+ * Antigravity account reports keep Google, Anthropic, and OpenAI backend
+ * counters separate and sort limits by remaining fraction, so a Claude session
+ * could otherwise display the more-exhausted Gemini quota (or vice versa). Map
+ * the active model id to the counter key encoded in the Antigravity limit id
+ * (`google-antigravity:<counter>:<tier>:<window>`). Returns undefined when the
+ * family is unknown (e.g. `gpt-oss-*`), so filtering falls back to first-match.
+ */
+function antigravityCounterForModel(modelId: string | undefined): string | undefined {
+	if (!modelId) return undefined;
+	switch (parseKnownModel(modelId).family) {
+		case "gemini":
+			return "google";
+		case "anthropic":
+			return "anthropic";
+		case "openai":
+			return "openai";
+		default:
+			return undefined;
+	}
+}
+
+/** Backend counter segment of an Antigravity limit id, or undefined. */
+function antigravityCounterFromLimitId(id: string | undefined): string | undefined {
+	if (!id) return undefined;
+	const parts = id.split(":");
+	return parts.length >= 2 ? parts[1] : undefined;
 }
 
 /**
@@ -1463,6 +1496,8 @@ export class StatusLineComponent implements Component {
 		if (!Array.isArray(reports)) return null;
 		const now = Date.now();
 		const activeModelId = normalizeUsageScopeValue(context.modelId);
+		const activeAntigravityCounter =
+			context.provider === "google-antigravity" ? antigravityCounterForModel(context.modelId) : undefined;
 		const scopeGroups = new Map<string, UsageScopeGroup>();
 		for (const report of reports) {
 			if (!report || typeof report !== "object") continue;
@@ -1535,6 +1570,15 @@ export class StatusLineComponent implements Component {
 				// specificity, untiered limits preserve the historical preference.
 				const priority = modelId ? (normalizedTier ? 1 : 0) : normalizedTier ? 3 : 2;
 				const id = "id" in limit && typeof limit.id === "string" ? limit.id : undefined;
+				// Antigravity keeps per-family counters in one untiered group; keep
+				// only the counter matching the active model's family. Unknown
+				// families and unclassified counters fall through to first-match.
+				if (activeAntigravityCounter) {
+					const counter = antigravityCounterFromLimitId(id);
+					if (counter && counter !== activeAntigravityCounter && ANTIGRAVITY_KNOWN_COUNTERS[counter]) {
+						continue;
+					}
+				}
 				const resetValue = window && "resetsAt" in window ? window.resetsAt : undefined;
 				const displayCandidate: UsageWindowCandidate = {
 					id,

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -45,7 +45,7 @@ const WATCHER_FAILURE_POLL_TTL_MS = 5000;
 /** A displayable limit after provider, account, model, and window filtering. */
 interface UsageWindowCandidate {
 	id?: string;
-	windowClass: "5h" | "7d" | "monthly";
+	windowClass: "5h" | "daily" | "7d" | "monthly";
 	fraction: number;
 	resetsAt?: number;
 }
@@ -452,6 +452,7 @@ export class StatusLineComponent implements Component {
 	#cachedUsage: {
 		tier?: string;
 		fiveHour?: { percent: number; resetMinutes?: number };
+		daily?: { percent: number; resetMinutes?: number };
 		sevenDay?: { percent: number; resetHours?: number };
 		monthly?: { percent: number; resetHours?: number };
 	} | null = null;
@@ -1455,6 +1456,7 @@ export class StatusLineComponent implements Component {
 	): {
 		tier?: string;
 		fiveHour?: { percent: number; resetMinutes?: number };
+		daily?: { percent: number; resetMinutes?: number };
 		sevenDay?: { percent: number; resetHours?: number };
 		monthly?: { percent: number; resetHours?: number };
 	} | null {
@@ -1501,11 +1503,15 @@ export class StatusLineComponent implements Component {
 				const subscriptionWindow =
 					windowId === "5h" || windowId === "7d"
 						? windowId
-						: durationMs !== undefined && Math.abs(durationMs - 5 * 3_600_000) <= 60_000
-							? "5h"
-							: durationMs !== undefined && Math.abs(durationMs - 7 * 86_400_000) <= 60_000
-								? "7d"
-								: undefined;
+						: windowId === "daily" || windowId === "24h" || windowId === "1d"
+							? "daily"
+							: durationMs !== undefined && Math.abs(durationMs - 5 * 3_600_000) <= 60_000
+								? "5h"
+								: durationMs !== undefined && Math.abs(durationMs - 86_400_000) <= 60_000
+									? "daily"
+									: durationMs !== undefined && Math.abs(durationMs - 7 * 86_400_000) <= 60_000
+										? "7d"
+										: undefined;
 				const windowClass =
 					subscriptionWindow ??
 					((context.provider === "cursor" || context.provider === "opencode-go") &&
@@ -1552,6 +1558,7 @@ export class StatusLineComponent implements Component {
 		if (!selectedGroup) return null;
 
 		let fiveHour: { percent: number; resetMinutes?: number } | undefined;
+		let daily: { percent: number; resetMinutes?: number } | undefined;
 		let sevenDay: { percent: number; resetHours?: number } | undefined;
 		let monthly: { percent: number; resetHours?: number } | undefined;
 		let monthlyPriority = Number.POSITIVE_INFINITY;
@@ -1566,6 +1573,15 @@ export class StatusLineComponent implements Component {
 		for (const candidate of selectedGroup.candidates) {
 			if (candidate.windowClass === "5h" && !fiveHour) {
 				fiveHour = {
+					percent: candidate.fraction * 100,
+					resetMinutes:
+						typeof candidate.resetsAt === "number"
+							? Math.max(0, Math.round((candidate.resetsAt - now) / 60_000))
+							: undefined,
+				};
+			}
+			if (candidate.windowClass === "daily" && !daily) {
+				daily = {
 					percent: candidate.fraction * 100,
 					resetMinutes:
 						typeof candidate.resetsAt === "number"
@@ -1596,8 +1612,8 @@ export class StatusLineComponent implements Component {
 				}
 			}
 		}
-		if (!fiveHour && !sevenDay && !monthly) return null;
-		return { tier: selectedGroup.tier, fiveHour, sevenDay, monthly };
+		if (!fiveHour && !daily && !sevenDay && !monthly) return null;
+		return { tier: selectedGroup.tier, fiveHour, daily, sevenDay, monthly };
 	}
 
 	/**

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -1,7 +1,10 @@
 import * as path from "node:path";
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
 import type { AssistantMessage, UsageLimit, UsageReport } from "@oh-my-pi/pi-ai";
-import { getAntigravityCounterKeyForModel } from "@oh-my-pi/pi-ai/usage/google-antigravity";
+import {
+	getAntigravityCounterKeyForModel,
+	scopeAntigravityLimitsForModel,
+} from "@oh-my-pi/pi-ai/usage/google-antigravity";
 import {
 	type Component,
 	type ComposerStyle,
@@ -60,16 +63,6 @@ interface UsageScopeGroup {
 
 function normalizeUsageScopeValue(value: unknown): string | undefined {
 	return typeof value === "string" && value.trim() ? value.trim().toLowerCase() : undefined;
-}
-
-/** Antigravity backend counters the status line can scope to a model family. */
-const ANTIGRAVITY_KNOWN_COUNTERS: Record<string, true> = { google: true, anthropic: true, openai: true };
-
-/** Backend counter segment of an Antigravity limit id, or undefined. */
-function antigravityCounterFromLimitId(id: string | undefined): string | undefined {
-	if (!id) return undefined;
-	const parts = id.split(":");
-	return parts.length >= 2 ? parts[1] : undefined;
 }
 
 /**
@@ -1481,11 +1474,15 @@ export class StatusLineComponent implements Component {
 			if (!report || typeof report !== "object") continue;
 			const provider = "provider" in report ? report.provider : undefined;
 			if (context.provider && provider !== context.provider) continue;
-			const limits = "limits" in report ? report.limits : undefined;
-			if (!Array.isArray(limits)) continue;
+			const reportLimits = "limits" in report ? report.limits : undefined;
+			if (!Array.isArray(reportLimits)) continue;
 			// fetchUsageReports supplies normalized rows; the guards above protect
 			// the unknown session boundary before the account matcher reads metadata.
 			const usageReport = report as UsageReport;
+			const limits =
+				provider === "google-antigravity" && activeAntigravityCounter
+					? scopeAntigravityLimitsForModel(usageReport, context)
+					: reportLimits;
 			for (const limit of limits) {
 				if (
 					!limit ||
@@ -1548,15 +1545,6 @@ export class StatusLineComponent implements Component {
 				// specificity, untiered limits preserve the historical preference.
 				const priority = modelId ? (normalizedTier ? 1 : 0) : normalizedTier ? 3 : 2;
 				const id = "id" in limit && typeof limit.id === "string" ? limit.id : undefined;
-				// Antigravity keeps per-family counters in one untiered group; keep
-				// only the counter matching the active model's family. Unknown
-				// families and unclassified counters fall through to first-match.
-				if (activeAntigravityCounter) {
-					const counter = antigravityCounterFromLimitId(id);
-					if (counter && counter !== activeAntigravityCounter && ANTIGRAVITY_KNOWN_COUNTERS[counter]) {
-						continue;
-					}
-				}
 				const resetValue = window && "resetsAt" in window ? window.resetsAt : undefined;
 				const displayCandidate: UsageWindowCandidate = {
 					id,

--- a/packages/coding-agent/src/modes/components/status-line/segments.ts
+++ b/packages/coding-agent/src/modes/components/status-line/segments.ts
@@ -664,7 +664,7 @@ function pickUsageColor(percent: number): "muted" | "warning" | "error" {
 
 function formatUsageReset(value: number, unit: "m" | "h"): string {
 	if (unit === "m") {
-		// total minutes (5h window: max 300)
+		// Short-window reset timers retain minute precision.
 		if (value < 60) return `${value}m`;
 		const hours = Math.floor(value / 60);
 		const mins = value % 60;
@@ -681,7 +681,7 @@ const usageSegment: StatusLineSegment = {
 	id: "usage",
 	render(ctx) {
 		const u = ctx.usage;
-		if (!u || (!u.fiveHour && !u.sevenDay && !u.monthly)) {
+		if (!u || (!u.fiveHour && !u.daily && !u.sevenDay && !u.monthly)) {
 			return { content: "", visible: false };
 		}
 		const parts: string[] = [];
@@ -697,6 +697,15 @@ const usageSegment: StatusLineSegment = {
 					? theme.fg("muted", ` (${formatUsageReset(u.fiveHour.resetMinutes, "m")})`)
 					: "";
 			parts.push(`5h ${pctText}${reset}`);
+		}
+		if (u.daily) {
+			const pct = u.daily.percent;
+			const pctText = theme.fg(pickUsageColor(pct), `${Math.round(pct)}%`);
+			const reset =
+				u.daily.resetMinutes !== undefined
+					? theme.fg("muted", ` (${formatUsageReset(u.daily.resetMinutes, "m")})`)
+					: "";
+			parts.push(`1d ${pctText}${reset}`);
 		}
 		if (u.sevenDay) {
 			const pct = u.sevenDay.percent;

--- a/packages/coding-agent/src/modes/components/status-line/types.ts
+++ b/packages/coding-agent/src/modes/components/status-line/types.ts
@@ -136,6 +136,7 @@ export interface SegmentContext {
 	usage: {
 		tier?: string;
 		fiveHour?: { percent: number; resetMinutes?: number };
+		daily?: { percent: number; resetMinutes?: number };
 		sevenDay?: { percent: number; resetHours?: number };
 		monthly?: { percent: number; resetHours?: number };
 	} | null;

--- a/packages/coding-agent/test/status-line-usage.test.ts
+++ b/packages/coding-agent/test/status-line-usage.test.ts
@@ -658,6 +658,34 @@ describe("usage status-line segment", () => {
 		expect(content).toContain("8%");
 	});
 
+	it("renders Google Antigravity daily usage", async () => {
+		const now = Date.now();
+		const component = makeComponent(
+			[
+				{
+					provider: "google-antigravity",
+					limits: [
+						{
+							label: "Usage (Google)",
+							scope: { provider: "google-antigravity", windowId: "daily" },
+							window: { id: "daily", label: "Daily", durationMs: 86_400_000, resetsAt: now + 11 * 60_000 },
+							amount: { usedFraction: 0.054 },
+						},
+					],
+				},
+			],
+			{ provider: "google-antigravity" },
+		);
+
+		component.refreshUsageInBackground();
+		await flushUsageRefresh();
+		const content = stripVTControlCharacters(component.getTopBorder(200).content);
+
+		expect(content).toContain("1d");
+		expect(content).toContain("5%");
+		expect(content).toContain("11m");
+	});
+
 	it("ignores non-canonical windows without a reported span", async () => {
 		const component = makeComponent([
 			{

--- a/packages/coding-agent/test/status-line-usage.test.ts
+++ b/packages/coding-agent/test/status-line-usage.test.ts
@@ -686,6 +686,47 @@ describe("usage status-line segment", () => {
 		expect(content).toContain("11m");
 	});
 
+	it("scopes Antigravity usage to the active model's backend counter", async () => {
+		const now = Date.now();
+		const reports = [
+			{
+				provider: "google-antigravity",
+				limits: [
+					{
+						id: "google-antigravity:google:default:daily",
+						label: "Usage (Google)",
+						scope: { provider: "google-antigravity", windowId: "daily" },
+						window: { id: "daily", label: "Daily", durationMs: 86_400_000, resetsAt: now + 11 * 60_000 },
+						amount: { usedFraction: 0.91 },
+					},
+					{
+						id: "google-antigravity:anthropic:default:daily",
+						label: "Usage (Anthropic)",
+						scope: { provider: "google-antigravity", windowId: "daily" },
+						window: { id: "daily", label: "Daily", durationMs: 86_400_000, resetsAt: now + 40 * 60_000 },
+						amount: { usedFraction: 0.24 },
+					},
+				],
+			},
+		];
+
+		const claude = makeComponent(reports, { provider: "google-antigravity", modelId: "claude-opus-4-6" });
+		claude.refreshUsageInBackground();
+		await flushUsageRefresh();
+		const claudeContent = stripVTControlCharacters(claude.getTopBorder(200).content);
+		expect(claudeContent).toContain("1d");
+		expect(claudeContent).toContain("24%");
+		expect(claudeContent).not.toContain("91%");
+
+		const gemini = makeComponent(reports, { provider: "google-antigravity", modelId: "gemini-3-pro" });
+		gemini.refreshUsageInBackground();
+		await flushUsageRefresh();
+		const geminiContent = stripVTControlCharacters(gemini.getTopBorder(200).content);
+		expect(geminiContent).toContain("1d");
+		expect(geminiContent).toContain("91%");
+		expect(geminiContent).not.toContain("24%");
+	});
+
 	it("ignores non-canonical windows without a reported span", async () => {
 		const component = makeComponent([
 			{

--- a/packages/coding-agent/test/status-line-usage.test.ts
+++ b/packages/coding-agent/test/status-line-usage.test.ts
@@ -706,6 +706,13 @@ describe("usage status-line segment", () => {
 						window: { id: "daily", label: "Daily", durationMs: 86_400_000, resetsAt: now + 40 * 60_000 },
 						amount: { usedFraction: 0.24 },
 					},
+					{
+						id: "google-antigravity:openai:default:daily",
+						label: "Usage (OpenAI)",
+						scope: { provider: "google-antigravity", windowId: "daily" },
+						window: { id: "daily", label: "Daily", durationMs: 86_400_000, resetsAt: now + 25 * 60_000 },
+						amount: { usedFraction: 0.63 },
+					},
 				],
 			},
 		];
@@ -725,6 +732,14 @@ describe("usage status-line segment", () => {
 		expect(geminiContent).toContain("1d");
 		expect(geminiContent).toContain("91%");
 		expect(geminiContent).not.toContain("24%");
+
+		const gptOss = makeComponent(reports, { provider: "google-antigravity", modelId: "gpt-oss-120b" });
+		gptOss.refreshUsageInBackground();
+		await flushUsageRefresh();
+		const gptOssContent = stripVTControlCharacters(gptOss.getTopBorder(200).content);
+		expect(gptOssContent).toContain("1d");
+		expect(gptOssContent).toContain("63%");
+		expect(gptOssContent).not.toContain("91%");
 	});
 
 	it("ignores non-canonical windows without a reported span", async () => {

--- a/packages/coding-agent/test/status-line-usage.test.ts
+++ b/packages/coding-agent/test/status-line-usage.test.ts
@@ -693,6 +693,13 @@ describe("usage status-line segment", () => {
 				provider: "google-antigravity",
 				limits: [
 					{
+						id: "google-antigravity:default:default:daily",
+						label: "Usage",
+						scope: { provider: "google-antigravity", windowId: "daily" },
+						window: { id: "daily", label: "Daily", durationMs: 86_400_000, resetsAt: now + 5 * 60_000 },
+						amount: { usedFraction: 0.99 },
+					},
+					{
 						id: "google-antigravity:google:default:daily",
 						label: "Usage (Google)",
 						scope: { provider: "google-antigravity", windowId: "daily" },
@@ -724,6 +731,7 @@ describe("usage status-line segment", () => {
 		expect(claudeContent).toContain("1d");
 		expect(claudeContent).toContain("24%");
 		expect(claudeContent).not.toContain("91%");
+		expect(claudeContent).not.toContain("99%");
 
 		const gemini = makeComponent(reports, { provider: "google-antigravity", modelId: "gemini-3-pro" });
 		gemini.refreshUsageInBackground();
@@ -732,6 +740,7 @@ describe("usage status-line segment", () => {
 		expect(geminiContent).toContain("1d");
 		expect(geminiContent).toContain("91%");
 		expect(geminiContent).not.toContain("24%");
+		expect(geminiContent).not.toContain("99%");
 
 		const gptOss = makeComponent(reports, { provider: "google-antigravity", modelId: "gpt-oss-120b" });
 		gptOss.refreshUsageInBackground();
@@ -740,6 +749,33 @@ describe("usage status-line segment", () => {
 		expect(gptOssContent).toContain("1d");
 		expect(gptOssContent).toContain("63%");
 		expect(gptOssContent).not.toContain("91%");
+		expect(gptOssContent).not.toContain("99%");
+	});
+
+	it("falls back to legacy default Antigravity usage when the model counter is absent", async () => {
+		const component = makeComponent(
+			[
+				{
+					provider: "google-antigravity",
+					limits: [
+						{
+							id: "google-antigravity:default:default:daily",
+							label: "Usage",
+							scope: { provider: "google-antigravity", windowId: "daily" },
+							window: { id: "daily", label: "Daily", durationMs: 86_400_000 },
+							amount: { usedFraction: 0.42 },
+						},
+					],
+				},
+			],
+			{ provider: "google-antigravity", modelId: "claude-opus-4-6" },
+		);
+
+		component.refreshUsageInBackground();
+		await flushUsageRefresh();
+		const content = stripVTControlCharacters(component.getTopBorder(200).content);
+		expect(content).toContain("1d");
+		expect(content).toContain("42%");
 	});
 
 	it("ignores non-canonical windows without a reported span", async () => {


### PR DESCRIPTION
## Repro
With the status-line `usage` segment enabled, feed an active `google-antigravity` report containing the provider’s canonical `daily` window; the segment renders empty. Reproduced with `bun test packages/coding-agent/test/status-line-usage.test.ts --test-name-pattern "renders Google Antigravity daily usage"`.

## Cause
`StatusLineComponent.#normalizeUsageReports()` in `packages/coding-agent/src/modes/components/status-line/component.ts` recognized only 5-hour, 7-day, and provider-gated monthly windows. Antigravity normalizes its short quota window to `daily` with a 24-hour duration, so the normalizer discarded the available report before `usageSegment` could render it.

## Fix
- Recognize canonical `daily`, `24h`, and `1d` IDs plus 24-hour durations as daily usage windows.
- Render daily usage as `1d` with minute-precision reset timing.
- Cover the Antigravity report shape and update the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/status-line-usage.test.ts` — 24 passed, 0 failed. `bun check` — passed.

Fixes #9999