### PR TITLE
feat(ai): forward session and cache-affinity identifiers

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Preserved Anthropic thinking now survives side requests, tool-description drift, turn-scoped reminders, and recoverable prefix mismatches without corrupting the conversation prefix.
+- OpenAI-compatible Chat Completions requests now forward supported agent sessions as `metadata.session_id` for tracing, while LiteLLM and compatible opt-in gateways receive the stable prompt-cache identity as `x-context-id` for cache affinity. Caller headers and cache-disabled behavior remain unchanged.
 
 ## [18.1.2] - 2026-09-01
 
@@ -54,7 +55,6 @@
 - Fixed Perplexity email sign-in for accounts protected by authenticator-based two-factor authentication.
 - Fixed Qianfan API-key login validation for keys that cannot access the validation model.
 - Fixed Z.AI browser sign-in to report an occupied callback port before opening the browser.
-- Chat Completions requests now forward the agent session id as `metadata.session_id`, letting OpenAI-compatible gateways associate provider requests with the agent conversation that produced them. Forwarded by default on hosts known to accept the field (first-party OpenAI, Azure OpenAI, and the `litellm` gateway provider); every other endpoint opts in via `compat.supportsMetadata`.
 
 ## [18.0.9] - 2026-08-28
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -54,6 +54,7 @@
 - Fixed Perplexity email sign-in for accounts protected by authenticator-based two-factor authentication.
 - Fixed Qianfan API-key login validation for keys that cannot access the validation model.
 - Fixed Z.AI browser sign-in to report an occupied callback port before opening the browser.
+- Chat Completions requests now forward the agent session id as `metadata.session_id`, letting OpenAI-compatible gateways associate provider requests with the agent conversation that produced them. Forwarded by default on hosts known to accept the field (first-party OpenAI, Azure OpenAI, and the `litellm` gateway provider); every other endpoint opts in via `compat.supportsMetadata`.
 
 ## [18.0.9] - 2026-08-28
 

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -1640,6 +1640,11 @@ function applyOpenAIChatCompletionsPromptCachePolicy(
 		markLatestStableChatCompletionsCacheBreakpoint(params.messages);
 }
 
+/** OpenAI chat-completions `metadata` accepts at most 16 string key/value pairs. */
+const OPENAI_METADATA_MAX_ENTRIES = 16;
+const OPENAI_METADATA_MAX_KEY_LENGTH = 64;
+const OPENAI_METADATA_MAX_VALUE_LENGTH = 512;
+
 function buildParams(
 	model: Model<"openai-completions">,
 	context: Context,
@@ -1660,6 +1665,30 @@ function buildParams(
 		messages: [],
 		stream: true,
 	};
+	const sessionId = options?.sessionId;
+	if (
+		sessionId !== undefined &&
+		sessionId.length <= OPENAI_METADATA_MAX_VALUE_LENGTH &&
+		initialCompat.supportsMetadata === true
+	) {
+		const callerMetadata: Record<string, string> = {};
+		let copied = 0;
+		for (const [key, value] of Object.entries(options?.metadata ?? {})) {
+			if (
+				typeof value !== "string" ||
+				key === "session_id" ||
+				key.length > OPENAI_METADATA_MAX_KEY_LENGTH ||
+				value.length > OPENAI_METADATA_MAX_VALUE_LENGTH
+			) {
+				continue;
+			}
+			if (copied >= OPENAI_METADATA_MAX_ENTRIES - 1) break;
+			callerMetadata[key] = value;
+			copied++;
+		}
+		callerMetadata.session_id = sessionId;
+		params.metadata = callerMetadata;
+	}
 	let toolStrictMode: AppliedToolStrictMode = "none";
 	let strictToolsApplied = false;
 

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -484,7 +484,8 @@ export interface StreamOptions {
 	/**
 	 * Optional prompt-cache identity. OpenAI-family providers use this for
 	 * `prompt_cache_key` payloads and cache-affinity headers such as
-	 * `x-grok-conv-id`; when omitted, they fall back to `sessionId`.
+	 * `x-context-id` and `x-grok-conv-id`; when omitted, they fall back to
+	 * `sessionId`.
 	 */
 	promptCacheKey?: string;
 	/**

--- a/packages/ai/test/openai-completions-cache-affinity.test.ts
+++ b/packages/ai/test/openai-completions-cache-affinity.test.ts
@@ -25,6 +25,18 @@ const openAI56CompletionsModel: Model<"openai-completions"> = {
 		api: "openai-completions",
 	}).compat,
 };
+const litellmCompletionsModel: Model<"openai-completions"> = {
+	...openAI56CompletionsSpec,
+	api: "openai-completions",
+	provider: "litellm",
+	baseUrl: "https://litellm.example.com/v1",
+	compat: resolveModelPolicy({
+		...openAI56CompletionsSpec,
+		api: "openai-completions",
+		provider: "litellm",
+		baseUrl: "https://litellm.example.com/v1",
+	}).compat,
+};
 
 const emptyUsage: Usage = {
 	input: 0,
@@ -100,6 +112,51 @@ async function captureSimpleRequest(
 	if (!requestHeaders || !body) throw new Error("Expected a serialized Chat Completions request");
 	return { headers: requestHeaders, body };
 }
+
+describe("OpenAI Chat Completions cache affinity header", () => {
+	const cases: Array<{
+		name: string;
+		options: OpenAICompletionsOptions;
+		expectedHeader: string | null;
+	}> = [
+		{
+			name: "uses sessionId when no prompt cache key is provided",
+			options: { sessionId: "session-fallback" },
+			expectedHeader: "session-fallback",
+		},
+		{
+			name: "keeps the prompt cache key stable across a distinct side-channel session",
+			options: { promptCacheKey: "stable-cache-key", sessionId: "side-channel-session" },
+			expectedHeader: "stable-cache-key",
+		},
+		{
+			name: "omits automatic affinity when caching is disabled",
+			options: {
+				promptCacheKey: "disabled-cache-key",
+				sessionId: "disabled-session",
+				cacheRetention: "none",
+			},
+			expectedHeader: null,
+		},
+		{
+			name: "preserves a caller-provided mixed-case affinity header",
+			options: {
+				promptCacheKey: "automatic-cache-key",
+				sessionId: "automatic-session",
+				headers: { "X-Context-ID": "caller-affinity" },
+			},
+			expectedHeader: "caller-affinity",
+		},
+	];
+
+	for (const { name, options, expectedHeader } of cases) {
+		it(name, async () => {
+			const { headers } = await captureRequest(options, litellmCompletionsModel);
+
+			expect(headers.get("x-context-id")).toBe(expectedHeader);
+		});
+	}
+});
 
 describe("OpenAI Chat Completions explicit prompt cache policy", () => {
 	const historicalContext: Context = {

--- a/packages/ai/test/openai-completions-cache-affinity.test.ts
+++ b/packages/ai/test/openai-completions-cache-affinity.test.ts
@@ -183,3 +183,80 @@ describe("OpenAI Chat Completions explicit prompt cache policy", () => {
 		}
 	});
 });
+
+describe("session id metadata forwarding", () => {
+	it("forwards sessionId as metadata.session_id", async () => {
+		const { body } = await captureRequest({ sessionId: "sess-01a03f57" });
+
+		expect(body.metadata).toEqual({ session_id: "sess-01a03f57" });
+	});
+
+	it("preserves caller metadata alongside session_id", async () => {
+		const { body } = await captureRequest({
+			sessionId: "sess-01a03f57",
+			metadata: { source: "test" },
+		});
+
+		expect(body.metadata).toEqual({ source: "test", session_id: "sess-01a03f57" });
+	});
+
+	it("omits metadata entirely when sessionId is absent", async () => {
+		const { body } = await captureRequest({ metadata: { source: "test" } });
+
+		expect(body.metadata).toBeUndefined();
+	});
+
+	it("drops non-string caller metadata values", async () => {
+		const { body } = await captureRequest({
+			sessionId: "sess-01a03f57",
+			metadata: { source: "test", count: 3, flag: null, nested: { a: 1 } },
+		});
+
+		expect(body.metadata).toEqual({ source: "test", session_id: "sess-01a03f57" });
+	});
+
+	it("omits metadata for endpoints whose compat rejects it", async () => {
+		const strictModel: Model<"openai-completions"> = {
+			...openAI56CompletionsModel,
+			compat: { ...openAI56CompletionsModel.compat, supportsMetadata: false },
+		};
+		const { body } = await captureRequest({ sessionId: "sess-01a03f57" }, strictModel);
+
+		expect(body.metadata).toBeUndefined();
+	});
+
+	it("omits metadata for endpoints that have not opted in", async () => {
+		const unknownModel: Model<"openai-completions"> = {
+			...openAI56CompletionsModel,
+			compat: { ...openAI56CompletionsModel.compat, supportsMetadata: undefined },
+		};
+		const { body } = await captureRequest({ sessionId: "sess-01a03f57" }, unknownModel);
+
+		expect(body.metadata).toBeUndefined();
+	});
+
+	it("reserves a metadata slot for session_id within the wire limit", async () => {
+		const callerEntries = Object.fromEntries(Array.from({ length: 16 }, (_, i) => [`key${i}`, `value${i}`]));
+		const { body } = await captureRequest({ sessionId: "sess-01a03f57", metadata: callerEntries });
+
+		const metadata = body.metadata as Record<string, string>;
+		expect(Object.keys(metadata)).toHaveLength(16);
+		expect(metadata.session_id).toBe("sess-01a03f57");
+		expect(metadata.key15).toBeUndefined();
+	});
+
+	it("drops caller metadata entries exceeding wire key and value limits", async () => {
+		const { body } = await captureRequest({
+			sessionId: "sess-01a03f57",
+			metadata: { ok: "fine", ["k".repeat(65)]: "v", longValue: "v".repeat(513) },
+		});
+
+		expect(body.metadata).toEqual({ ok: "fine", session_id: "sess-01a03f57" });
+	});
+
+	it("omits metadata entirely when the session id exceeds the wire value limit", async () => {
+		const { body } = await captureRequest({ sessionId: "s".repeat(513), metadata: { ok: "fine" } });
+
+		expect(body.metadata).toBeUndefined();
+	});
+});

--- a/packages/catalog/src/compat/axes.ts
+++ b/packages/catalog/src/compat/axes.ts
@@ -94,7 +94,7 @@ export const AXES: Readonly<Record<string, AxisDef>> = {
 	"native-kimi-k3-reasoning": wire("nativeKimiK3Reasoning", ["openai"]),
 	"omit-reasoning-effort": wire("omitReasoningEffort", OAI),
 	"prompt-cache-breakpoint-ttl": wire("promptCacheBreakpointTtl", OAI, "scalar", ["30m"]),
-	"prompt-cache-session-header": wire("promptCacheSessionHeader", OAI, "scalar", ["x-grok-conv-id"]),
+	"prompt-cache-session-header": wire("promptCacheSessionHeader", OAI, "scalar", ["x-context-id", "x-grok-conv-id"]),
 	"qwen-preserve-thinking": wire("qwenPreserveThinking", ["openai"]),
 	"reject-root-object-union": wire("rejectRootObjectUnion", OAI),
 	"retry-without-strict-on-grammar-error": wire("retryWithoutStrictOnGrammarError", OAI),

--- a/packages/catalog/src/compat/resolve.ts
+++ b/packages/catalog/src/compat/resolve.ts
@@ -561,7 +561,8 @@ function detectOpenAICompat(
 		reasoningDeltasMayBeCumulative: false,
 		emptyLengthFinishIsContextError: false,
 		usesOpenAIToolCallIdLimit: false,
-		promptCacheSessionHeader: hostMatchesUrl(baseUrl, "xai") ? "x-grok-conv-id" : undefined,
+		promptCacheSessionHeader:
+			provider === "litellm" ? "x-context-id" : hostMatchesUrl(baseUrl, "xai") ? "x-grok-conv-id" : undefined,
 		dropThinkingWhenReasoningEffort: false,
 		nativeKimiK3Reasoning: false,
 		zaiReasoningEffortDialect: false,
@@ -769,7 +770,8 @@ function resolveOpenAIResponsesPolicy(
 		reasoningDeltasMayBeCumulative: false,
 		emptyLengthFinishIsContextError: false,
 		usesOpenAIToolCallIdLimit: false,
-		promptCacheSessionHeader: hostMatchesUrl(baseUrl, "xai") ? "x-grok-conv-id" : undefined,
+		promptCacheSessionHeader:
+			provider === "litellm" ? "x-context-id" : hostMatchesUrl(baseUrl, "xai") ? "x-grok-conv-id" : undefined,
 		streamFirstEventTimeoutMs: isLocalServingBackend ? 0 : spec.compat?.streamFirstEventTimeoutMs,
 		streamIdleTimeoutMs: isLocalServingBackend
 			? LOCAL_OPENAI_COMPAT_STREAM_IDLE_TIMEOUT_MS

--- a/packages/catalog/src/compat/resolve.ts
+++ b/packages/catalog/src/compat/resolve.ts
@@ -469,6 +469,12 @@ function detectOpenAICompat(
 
 	return {
 		supportsStore: !isNonStandard,
+		// `metadata` is a standard OpenAI chat-completions field, but the wider
+		// OpenAI-compatible ecosystem predates it, and strict request schemas
+		// reject unknown top-level fields (NVIDIA NIM and Venice 400 under
+		// `additionalProperties: false`, see #2299). Default to hosts known to
+		// accept it; everything else opts in via the `supportsMetadata` override.
+		supportsMetadata: isOpenAIHost || isAzureHost || provider === "litellm",
 		supportsDeveloperRole: isOpenAIHost || isAzureHost,
 		supportsMultipleSystemMessages: supportsMultipleSystemMessagesDefault,
 		supportsReasoningEffort: !isGrok && !d.isXiaomiMimo && (!(d.isZai || d.isZhipu) || supportsZaiReasoningEffort),

--- a/packages/catalog/src/types.ts
+++ b/packages/catalog/src/types.ts
@@ -349,7 +349,7 @@ export interface OpenAICompat {
 	/** Extra fields to include in request body (e.g. gateway routing hints for OpenClaw-style proxies). */
 	extraBody?: Record<string, unknown>;
 	/** Request-session header that should mirror the normalized prompt-cache key. Default: unset. */
-	promptCacheSessionHeader?: "x-grok-conv-id";
+	promptCacheSessionHeader?: "x-context-id" | "x-grok-conv-id";
 	/** Whether chat-completions payloads should include provider-specific prompt-cache markers. */
 	cacheControlFormat?: "anthropic" | undefined;
 	/**

--- a/packages/catalog/src/types.ts
+++ b/packages/catalog/src/types.ts
@@ -195,6 +195,13 @@ export type OpenAIStreamMarkupHealingPattern = "kimi" | "dsml" | "qwen" | "think
 export interface OpenAICompat {
 	/** Whether the provider supports the `store` field. Default: auto-detected from URL. */
 	supportsStore?: boolean;
+	/**
+	 * Whether the provider's chat-completions endpoint accepts the OpenAI
+	 * `metadata` field (string-valued key/value pairs). Hosts with strict
+	 * request schemas reject unknown top-level fields and 400 on it.
+	 * Default: auto-detected from URL.
+	 */
+	supportsMetadata?: boolean;
 	/** Whether the provider supports the `developer` role (vs `system`). Default: auto-detected from URL. */
 	supportsDeveloperRole?: boolean;
 	/**
@@ -707,6 +714,12 @@ export interface ResolvedOpenAISharedCompat {
 	promptCacheBreakpointTtl?: "30m";
 	/** The model sits behind OpenRouter (routing prefs and max-token omission apply). */
 	isOpenRouterHost: boolean;
+	/**
+	 * Whether this endpoint accepts the OpenAI `metadata` field on chat
+	 * completions. Built catalog models always materialize this value;
+	 * optionality preserves hand-authored resolved compat fixtures.
+	 */
+	supportsMetadata?: boolean;
 	/** Whether this endpoint needs a max-token field even when caller did not set one. */
 	alwaysSendMaxTokens: boolean;
 	openRouterRouting?: OpenAICompat["openRouterRouting"];
@@ -774,6 +787,7 @@ export type ResolvedOpenAICompat = ResolvedOpenAISharedCompat &
 			| "promptCacheBreakpointTtl"
 			| "openRouterRouting"
 			| "isOpenRouterHost"
+			| "supportsMetadata"
 			| "supportsStrictMode"
 			| "supportsLongPromptCacheRetention"
 			| "alwaysSendMaxTokens"

--- a/packages/catalog/test/build.test.ts
+++ b/packages/catalog/test/build.test.ts
@@ -603,6 +603,16 @@ describe("openai-completions wire-quirk compat detection", () => {
 		expect(resolveModelPolicy(completionsSpec()).compat.dropThinkingWhenReasoningEffort).toBe(false);
 	});
 
+	it("declares the LiteLLM cache-affinity header without changing unknown providers", () => {
+		const litellm = resolveModelPolicy(
+			completionsSpec({ provider: "litellm", baseUrl: "https://litellm.example.com/v1" }),
+		).compat;
+		const custom = resolveModelPolicy(completionsSpec()).compat;
+
+		expect(litellm.promptCacheSessionHeader).toBe("x-context-id");
+		expect(custom.promptCacheSessionHeader).toBeUndefined();
+	});
+
 	it("floors the stream timeout for a loopback litellm proxy without enabling reasoning replay (#4786)", () => {
 		// A litellm proxy on a loopback baseUrl fronts a local llama-server whose
 		// prefill can exceed the 100s default first-event budget on large prompts.


### PR DESCRIPTION
## What

Chat Completions requests now carry two complementary session identifiers:

- `metadata.session_id` forwards the agent conversation ID for tracing, observability, and per-session accounting. Caller metadata is filtered to the OpenAI string/length/count limits, with one of 16 entries reserved for `session_id`.
- `x-context-id` forwards the normalized prompt-cache identity for backend cache affinity. An explicit `promptCacheKey` wins over `sessionId`, `cacheRetention: "none"` disables the automatic header, and a caller-provided header is preserved.

Both behaviors are compatibility-scoped. Request-body metadata defaults on only for first-party OpenAI, Azure OpenAI, and the `litellm` provider; other endpoints opt in with `supportsMetadata`. The existing `promptCacheSessionHeader` axis now supports `x-context-id`, which LiteLLM receives by default while custom gateways can opt in.

## Why

The two fields solve different problems. `metadata.session_id` identifies the OMP conversation to tracing callbacks. Cache routing needs the prompt-cache identity instead, so forks and side-channel requests can share the parent cache even when their provider session IDs differ.

LiteLLM also keeps ordinary OpenAI request-body `metadata` separate from the internal `litellm_metadata` passed to routing plugins. A router therefore cannot reliably use body `metadata.session_id`; `x-context-id` provides the explicit affinity contract without adding an unknown top-level field to strict OpenAI-compatible request schemas (#2299).

## Testing

- `bun test packages/ai/test/openai-completions-cache-affinity.test.ts packages/catalog/test/build.test.ts` — 71 passed.
- Full `bun run check` passed in `packages/ai` and `packages/catalog`.
- Repository-wide `bun check` passed.
- Live public LiteLLM verification with the dual-field request shape returned 3/3 HTTP 200 and routed all three requests to the same Baker backend (Webster delta 0, Baker delta 3).

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated
