### PR TITLE
feat(coding-agent): Support 'K' and 'M' suffixes for goal budgets

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- `/goal budget` now accepts `K`/`M` suffixes (e.g. `300K`, `1.5M`), in addition to plain integers.
+
 ## [18.0.8] - 2026-08-27
 
 ### Added

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -4062,9 +4062,11 @@ export class InteractiveMode implements InteractiveModeContext {
 		const trimmed = rawBudget.trim().toLowerCase();
 		let nextBudget: number | undefined;
 		if (trimmed !== "off") {
-			const parsed = Number.parseInt(trimmed, 10);
+			const match = /^(\d+(?:\.\d+)?)([km])?$/.exec(trimmed);
+			const multiplier = match?.[2] === "k" ? 1_000 : match?.[2] === "m" ? 1_000_000 : 1;
+			const parsed = match ? Math.round(Number.parseFloat(match[1]) * multiplier) : Number.NaN;
 			if (!Number.isInteger(parsed) || parsed <= 0) {
-				this.showError("Goal budget must be a positive integer or `off`.");
+				this.showError("Goal budget must be a positive integer (optionally with a K or M suffix) or `off`.");
 				return;
 			}
 			nextBudget = parsed;

--- a/packages/coding-agent/test/goals/goal-mode-integration.test.ts
+++ b/packages/coding-agent/test/goals/goal-mode-integration.test.ts
@@ -570,6 +570,26 @@ describe("InteractiveMode goal mode integration", () => {
 		expect(harness.session.getGoalModeState()?.goal.tokensUsed).toBe(42);
 	});
 
+	it("accepts K/M suffixes for /goal budget, case-insensitively", async () => {
+		await harness.mode.handleGoalModeCommand("Ship the release");
+
+		const cases: Array<[string, number]> = [
+			["300K", 300_000],
+			["800.5K", 800_500],
+			["1.5M", 1_500_000],
+			["3M", 3_000_000],
+			["300k", 300_000],
+			["800.5k", 800_500],
+			["1.5m", 1_500_000],
+			["3m", 3_000_000],
+		];
+
+		for (const [input, expected] of cases) {
+			await harness.mode.handleGoalModeCommand(`budget ${input}`);
+			expect(harness.session.getGoalModeState()?.goal.tokenBudget).toBe(expected);
+		}
+	});
+
 	it("refuses /goal budget while only a paused goal exists (fix #5)", async () => {
 		await harness.mode.handleGoalModeCommand("Ship the release");
 		vi.spyOn(harness.mode, "showHookSelector").mockResolvedValue("Pause");


### PR DESCRIPTION
## What

Allow specifying token budgets like "800k" or "2M".

## Why

I lose track of how many zeroes I've typed when I try to write "800000".

## Testing

Added the test, ran `bun run dev` and verified that the goal budget updates as expected.

---

- [X] `bun check` passes
- [X] Tested locally
- [X] CHANGELOG updated (if user-facing)
