### PR TITLE
fix(catalog): fold gemini-3.7-flash-tiered into gemini-3.7-flash

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `google-antigravity/gemini-3.7-flash-tiered` sending `thinkingLevel: MINIMAL` at `:off`/`:minimal`, which Cloud Code Assist rejects with HTTP 400; the discovery alias now collapses into `gemini-3.7-flash` and routes those tiers to the `-low` SKU like the 3.6 family ([#10016](https://github.com/can1357/oh-my-pi/issues/10016)).
+
 ## [18.0.8] - 2026-08-27
 
 ### Fixed

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -64887,38 +64887,6 @@
 			"requiresGlyphTokenization": false,
 			"supportsComputerUse": false
 		},
-		"gemini-3.7-flash-tiered": {
-			"id": "gemini-3.7-flash-tiered",
-			"name": "gemini-3.7-flash-tiered",
-			"api": "google-gemini-cli",
-			"provider": "google-antigravity",
-			"baseUrl": "https://daily-cloudcode-pa.googleapis.com",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1048576,
-			"maxTokens": 65536,
-			"thinking": {
-				"mode": "google-level",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				],
-				"requiresEffort": true
-			},
-			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false
-		},
 		"gpt-oss-120b": {
 			"id": "gpt-oss-120b",
 			"name": "GPT OSS 120B",

--- a/packages/catalog/src/variant-collapse.ts
+++ b/packages/catalog/src/variant-collapse.ts
@@ -307,7 +307,7 @@ function geminiLevelFlashFamily(version: "3.6" | "3.7", ...additionalMembers: st
 }
 
 const GEMINI_36_FLASH_FAMILY = geminiLevelFlashFamily("3.6", "gemini-3.6-flash-tiered");
-const GEMINI_37_FLASH_FAMILY = geminiLevelFlashFamily("3.7");
+const GEMINI_37_FLASH_FAMILY = geminiLevelFlashFamily("3.7", "gemini-3.7-flash-tiered");
 
 function geminiProFamily(mode: "budget" | "google-level"): EffortVariantFamily {
 	const budget = mode === "budget";

--- a/packages/catalog/test/variant-collapse.test.ts
+++ b/packages/catalog/test/variant-collapse.test.ts
@@ -10,7 +10,11 @@ import {
 import { Effort } from "@oh-my-pi/pi-catalog/effort";
 import { stripThinkingVariantToken } from "@oh-my-pi/pi-catalog/identity/family";
 import { resolveProviderModels } from "@oh-my-pi/pi-catalog/model-manager";
-import { defaultSupportedEffort, resolveWireModelId } from "@oh-my-pi/pi-catalog/model-thinking";
+import {
+	defaultSupportedEffort,
+	mapEffortToGoogleThinkingLevel,
+	resolveWireModelId,
+} from "@oh-my-pi/pi-catalog/model-thinking";
 import { googleGeminiCliModelManagerOptions } from "@oh-my-pi/pi-catalog/provider-models/google";
 import type { ModelSpec } from "@oh-my-pi/pi-catalog/types";
 import {
@@ -160,6 +164,67 @@ describe("collapseEffortVariants", () => {
 		expect(resolveWireModelId(model, Effort.Low)).toBe("gemini-3.6-flash-low");
 		expect(resolveWireModelId(model, Effort.Medium)).toBe("gemini-3.6-flash-medium");
 		expect(resolveWireModelId(model, Effort.High)).toBe("gemini-3.6-flash-high");
+	});
+
+	it("folds the gemini-3.7-flash-tiered alias into gemini-3.7-flash so :minimal sends LOW not MINIMAL (#10016)", () => {
+		const out = collapseEffortVariants(
+			[
+				memberSpec("gemini-3.7-flash-high"),
+				memberSpec("gemini-3.7-flash-low"),
+				memberSpec("gemini-3.7-flash-medium"),
+				memberSpec("gemini-3.7-flash-tiered"),
+			],
+			ANTIGRAVITY_VARIANT_COLLAPSE_TABLE,
+		);
+
+		expect(out).toHaveLength(1);
+		const flash = out[0];
+		expect(flash?.id).toBe("gemini-3.7-flash");
+		expect(flash?.thinking?.effortRouting).toEqual({
+			minimal: "gemini-3.7-flash-low",
+			low: "gemini-3.7-flash-low",
+			medium: "gemini-3.7-flash-medium",
+			high: "gemini-3.7-flash-high",
+		});
+
+		// The actual regression: Cloud Code Assist rejects thinkingLevel MINIMAL on
+		// this SKU with HTTP 400, so the collapsed routing must downgrade both :off
+		// (floored to minimal by requiresEffort) and :minimal to LOW on the wire.
+		const model = buildModel(flash as ModelSpec<"google-gemini-cli">);
+		expect(mapEffortToGoogleThinkingLevel(Effort.Minimal, model)).toBe("LOW");
+		expect(mapEffortToGoogleThinkingLevel(Effort.Low, model)).toBe("LOW");
+		expect(resolveWireModelId(model, Effort.Minimal)).toBe("gemini-3.7-flash-low");
+	});
+
+	it("dedupes a stale standalone gemini-3.7-flash-tiered snapshot into the collapsed gemini-3.7-flash (#10016)", () => {
+		// Mirrors the bundled catalog snapshot: the already-collapsed logical id
+		// plus a raw -tiered alias that older snapshots emitted as its own
+		// MINIMAL-sending model. Runtime collapse must fold the alias away.
+		const collapsedFlash = memberSpec("gemini-3.7-flash", {
+			requestModelId: "gemini-3.7-flash-low",
+			thinking: {
+				mode: "google-level",
+				efforts: [Effort.Minimal, Effort.Low, Effort.Medium, Effort.High],
+				requiresEffort: true,
+				effortRouting: {
+					minimal: "gemini-3.7-flash-low",
+					low: "gemini-3.7-flash-low",
+					medium: "gemini-3.7-flash-medium",
+					high: "gemini-3.7-flash-high",
+				},
+			},
+		});
+		const staleTiered = memberSpec("gemini-3.7-flash-tiered", {
+			thinking: {
+				mode: "google-level",
+				efforts: [Effort.Minimal, Effort.Low, Effort.Medium, Effort.High],
+				requiresEffort: true,
+			},
+		});
+
+		const out = collapseEffortVariants([collapsedFlash, staleTiered], ANTIGRAVITY_VARIANT_COLLAPSE_TABLE);
+		expect(out.map(m => m.id)).toEqual(["gemini-3.7-flash"]);
+		expect(out[0]?.thinking?.effortRouting?.minimal).toBe("gemini-3.7-flash-low");
 	});
 
 	it("drops routes whose target member is absent", () => {

--- a/packages/catalog/test/variant-collapse.test.ts
+++ b/packages/catalog/test/variant-collapse.test.ts
@@ -15,6 +15,7 @@ import {
 	mapEffortToGoogleThinkingLevel,
 	resolveWireModelId,
 } from "@oh-my-pi/pi-catalog/model-thinking";
+import { getBundledModel, getBundledModels } from "@oh-my-pi/pi-catalog/models";
 import { googleGeminiCliModelManagerOptions } from "@oh-my-pi/pi-catalog/provider-models/google";
 import type { ModelSpec } from "@oh-my-pi/pi-catalog/types";
 import {
@@ -225,6 +226,15 @@ describe("collapseEffortVariants", () => {
 		const out = collapseEffortVariants([collapsedFlash, staleTiered], ANTIGRAVITY_VARIANT_COLLAPSE_TABLE);
 		expect(out.map(m => m.id)).toEqual(["gemini-3.7-flash"]);
 		expect(out[0]?.thinking?.effortRouting?.minimal).toBe("gemini-3.7-flash-low");
+	});
+
+	it("bundles only the routed gemini-3.7-flash model after generation (#10016)", () => {
+		const models = getBundledModels("google-antigravity");
+		expect(models.some(model => model.id === "gemini-3.7-flash-tiered")).toBe(false);
+
+		const flash = getBundledModel("google-antigravity", "gemini-3.7-flash");
+		expect(flash?.thinking?.effortRouting?.minimal).toBe("gemini-3.7-flash-low");
+		expect(flash ? mapEffortToGoogleThinkingLevel(Effort.Minimal, flash) : undefined).toBe("LOW");
 	});
 
 	it("drops routes whose target member is absent", () => {


### PR DESCRIPTION
## Repro
`google-antigravity/gemini-3.7-flash-tiered` accepts `:off` and `:minimal` but both resolve to `thinkingLevel: MINIMAL`, which Cloud Code Assist rejects with HTTP 400 (`Thinking level MINIMAL is not supported for this model`); `:low` works. Reproduced in-process against the bundled catalog (no network needed) by resolving the wire `thinkingLevel` per effort:

```
gemini-3.7-flash-tiered   effortRouting=undefined   :off/:minimal -> MINIMAL (400)   :low -> LOW
gemini-3.7-flash          effortRouting={minimal:gemini-3.7-flash-low,...}  :off/:minimal -> LOW
```

## Cause
`mapEffortToGoogleThinkingLevel` (`packages/catalog/src/model-thinking.ts`) only downgrades `minimal`→`LOW` when the model's `thinking.effortRouting` folds `minimal` onto the same wire id as `low`. The canonical `gemini-3.7-flash` gets that routing from `geminiLevelFlashFamily("3.7")` in `packages/catalog/src/variant-collapse.ts`, but the 3.7 family omitted the `gemini-3.7-flash-tiered` discovery alias that the 3.6 family folds in (`geminiLevelFlashFamily("3.6", "gemini-3.6-flash-tiered")`). So `-tiered` survived as a standalone `google-level` model with no routing and emitted raw `MINIMAL` — the same class PR #8871 fixed for the canonical SKUs but missed for this alias.

## Fix
- `packages/catalog/src/variant-collapse.ts`: pass `"gemini-3.7-flash-tiered"` to `geminiLevelFlashFamily("3.7", ...)` so the alias is a family member. It now collapses into `gemini-3.7-flash` (routing `minimal`/`off`→`gemini-3.7-flash-low`, i.e. `thinkingLevel: LOW`) at every collapse site — discovery, the generator, and the model-manager merge that runs on the bundled snapshot — while `gemini-3.7-flash-tiered` remains a resolvable alias.
- `packages/catalog/test/variant-collapse.test.ts`: added two regression tests — a fresh-discovery collapse asserting the built model emits `LOW` (not `MINIMAL`) for `minimal`/`low` and routes to `gemini-3.7-flash-low`, and a stale-bundled-snapshot dedupe (standalone `-tiered` + already-collapsed `gemini-3.7-flash` → one entry).
- `packages/catalog/CHANGELOG.md`: entry under `[Unreleased]`.

The bundled `models.json` still carries the pre-fix standalone `gemini-3.7-flash-tiered` row; it is not hand-edited (generated file) and is neutralized at runtime by `collapseBuiltModelVariants` in the model manager, which now folds it. It will drop from the snapshot on the next `bun run gen:models` (deferred — regeneration needs live Antigravity discovery credentials).

## Verification
`bun test packages/catalog/test/variant-collapse.test.ts` → 59 pass / 0 fail. `bun check` → all packages exit 0. Manually confirmed against the workspace source that `gemini-3.7-flash-tiered` now collapses into `gemini-3.7-flash`, emits `thinkingLevel: LOW` at `:off`/`:minimal`, and still resolves as an alias. Fixes #10016