### PR TITLE
feat(coding-agent): expose Agent Hub roster and kill/revive/steer over RPC

### DIFF
--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -132,6 +132,10 @@ Important edge behavior from runtime:
 - `{ id?, type: "set_subagent_subscription", level: "off" | "progress" | "events" }`
 - `{ id?, type: "get_subagents" }`
 - `{ id?, type: "get_subagent_messages", subagentId?: string, sessionFile?: string, fromByte?: number }`
+- `{ id?, type: "list_agents" }`
+- `{ id?, type: "send_agent_message", agentId: string, message: string }`
+- `{ id?, type: "revive_agent", agentId: string }`
+- `{ id?, type: "kill_agent", agentId: string }`
 
 ### Model
 
@@ -535,6 +539,29 @@ Subagent forwarding defaults to `"off"`. `set_subagent_subscription` selects:
 `fromByte`, `nextByte`, `reset`, raw transcript `entries`, and converted
 `messages`. If `fromByte` exceeds the current file size, reading restarts at
 byte zero and reports `reset: true`.
+
+### Agent Hub control
+
+These commands operate on the process-global Agent Hub roster (`AgentRegistry`),
+including nested subagents (`parentId`) and parked/aborted rows. They are
+distinct from `get_subagents`, which only tracks first-level task-tool children
+on the session event bus.
+
+- `list_agents` returns `{ agents }` for every registered agent except Main,
+  sorted running → idle → parked → aborted, then recency.
+- `send_agent_message` revives a parked agent if needed, then prompts it with
+  `streamingBehavior: "steer"` (same path as collab Hub chat). Empty messages,
+  advisors, Main, and unknown ids fail with a machine-readable `code`.
+- `revive_agent` brings a parked agent back to a live session.
+- `kill_agent` aborts a running session and tombstones the roster row as `aborted`.
+
+Advisor transcripts are listed but rejected for send/revive/kill
+(`code: "advisor_readonly"`). Other failures use `unknown_agent`,
+`main_forbidden`, `empty_message`, `invalid_agent_id`, and
+`agent_control_failed`.
+
+Live `subagent_*` frames for nested (depth ≥ 2) task children still require
+`set_subagent_subscription`; nested *roster* rows are already in `list_agents`.
 
 ## Prompt/Queue Concurrency and Ordering
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- RPC clients can list Agent Hub agents (including nested children) and steer, revive, or kill them via `list_agents`, `send_agent_message`, `revive_agent`, and `kill_agent` (by [@Giardi77](https://github.com/Giardi77)).
+
 ## [18.0.8] - 2026-08-27
 
 ### Added

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- RPC clients can list Agent Hub agents (including nested children) and steer, revive, or kill them via `list_agents`, `send_agent_message`, `revive_agent`, and `kill_agent` (by [@Giardi77](https://github.com/Giardi77)).
+- RPC clients can list Agent Hub agents (including nested children) and steer, revive, or kill them via `list_agents`, `send_agent_message`, `revive_agent`, and `kill_agent` ([#10021](https://github.com/can1357/oh-my-pi/pull/10021) by [@Giardi77](https://github.com/Giardi77)).
 
 ## [18.0.8] - 2026-08-27
 

--- a/packages/coding-agent/src/modes/rpc/rpc-agent-hub.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-agent-hub.ts
@@ -1,0 +1,173 @@
+/**
+ * Agent Hub control over RPC.
+ *
+ * Mirrors the TUI Hub / collab guest remote: roster from AgentRegistry,
+ * steer/revive/kill through AgentLifecycleManager. Nested subagents are
+ * visible because they register with `parentId` on the same process-global
+ * roster — this is not the task-tool event-bus snapshot (`get_subagents`).
+ */
+import { AgentLifecycleManager } from "../../registry/agent-lifecycle";
+import {
+	type AgentHistorySummary,
+	type AgentRef,
+	AgentRegistry,
+	type AgentStatus,
+	MAIN_AGENT_ID,
+} from "../../registry/agent-registry";
+import { USER_INTERRUPT_LABEL } from "../../session/messages";
+import type { RpcAgentSnapshot } from "./rpc-types";
+
+export type AgentHubRpcCode =
+	| "unknown_agent"
+	| "advisor_readonly"
+	| "main_forbidden"
+	| "empty_message"
+	| "invalid_agent_id"
+	| "agent_control_failed";
+
+export type AgentHubRpcFailure = { ok: false; error: string; code: AgentHubRpcCode };
+export type AgentHubRpcOk<T> = { ok: true } & T;
+export type AgentHubRpcResult<T> = AgentHubRpcOk<T> | AgentHubRpcFailure;
+
+export interface AgentHubRpcDeps {
+	registry: AgentRegistry;
+	lifecycle: AgentLifecycleManager;
+}
+
+const AGENT_STATUS_ORDER: Record<AgentStatus, number> = {
+	running: 0,
+	idle: 1,
+	parked: 2,
+	aborted: 3,
+};
+
+function fail(error: string, code: AgentHubRpcCode): AgentHubRpcFailure {
+	return { ok: false, error, code };
+}
+
+function defaultDeps(): AgentHubRpcDeps {
+	return { registry: AgentRegistry.global(), lifecycle: AgentLifecycleManager.global() };
+}
+
+function asHistory(history: AgentHistorySummary | undefined): AgentHistorySummary | undefined {
+	if (!history) return undefined;
+	return { ...history, metrics: history.metrics ? { ...history.metrics } : undefined };
+}
+
+export function snapshotAgent(ref: AgentRef): RpcAgentSnapshot {
+	return {
+		id: ref.id,
+		displayName: ref.displayName,
+		kind: ref.kind,
+		parentId: ref.parentId,
+		status: ref.status,
+		sessionFile: ref.sessionFile,
+		createdAt: ref.createdAt,
+		lastActivity: ref.lastActivity,
+		activity: ref.activity,
+		history: asHistory(ref.history),
+		live: ref.session !== null,
+	};
+}
+
+function sortHubRoster(a: AgentRef, b: AgentRef): number {
+	return (
+		AGENT_STATUS_ORDER[a.status] - AGENT_STATUS_ORDER[b.status] ||
+		b.lastActivity - a.lastActivity ||
+		a.id.localeCompare(b.id)
+	);
+}
+
+export function listAgents(deps: AgentHubRpcDeps = defaultDeps()): RpcAgentSnapshot[] {
+	return deps.registry
+		.list()
+		.filter(ref => ref.id !== MAIN_AGENT_ID)
+		.sort(sortHubRoster)
+		.map(snapshotAgent);
+}
+
+function requireControllableAgent(
+	agentId: string | undefined,
+	deps: AgentHubRpcDeps,
+): AgentHubRpcResult<{ ref: AgentRef }> {
+	const id = agentId?.trim();
+	if (!id) return fail("agentId is required", "invalid_agent_id");
+	if (id === MAIN_AGENT_ID) {
+		return fail("The main RPC session is not controllable through Agent Hub commands", "main_forbidden");
+	}
+	const ref = deps.registry.get(id);
+	if (!ref) {
+		return fail(
+			`Unknown agent "${id}" — it was never registered or has been released. If a transcript exists, read history://${id}.`,
+			"unknown_agent",
+		);
+	}
+	if (ref.kind === "advisor") {
+		return fail(`Agent "${id}" is a read-only advisor transcript`, "advisor_readonly");
+	}
+	return { ok: true, ref };
+}
+
+export async function sendAgentMessage(
+	agentId: string | undefined,
+	message: string | undefined,
+	deps: AgentHubRpcDeps = defaultDeps(),
+): Promise<AgentHubRpcResult<{ agent: RpcAgentSnapshot }>> {
+	const resolved = requireControllableAgent(agentId, deps);
+	if (!resolved.ok) return resolved;
+	const trimmed = message?.trim();
+	if (!trimmed) return fail("message is required", "empty_message");
+	try {
+		const session = await deps.lifecycle.ensureLive(resolved.ref.id);
+		await session.prompt(trimmed, { streamingBehavior: "steer" });
+	} catch (error) {
+		return fail(error instanceof Error ? error.message : String(error), "agent_control_failed");
+	}
+	const live = deps.registry.get(resolved.ref.id) ?? resolved.ref;
+	return { ok: true, agent: snapshotAgent(live) };
+}
+
+export async function reviveAgent(
+	agentId: string | undefined,
+	deps: AgentHubRpcDeps = defaultDeps(),
+): Promise<AgentHubRpcResult<{ agent: RpcAgentSnapshot }>> {
+	const resolved = requireControllableAgent(agentId, deps);
+	if (!resolved.ok) return resolved;
+	try {
+		await deps.lifecycle.ensureLive(resolved.ref.id);
+	} catch (error) {
+		return fail(error instanceof Error ? error.message : String(error), "agent_control_failed");
+	}
+	const live = deps.registry.get(resolved.ref.id) ?? resolved.ref;
+	return { ok: true, agent: snapshotAgent(live) };
+}
+
+export async function killAgent(
+	agentId: string | undefined,
+	deps: AgentHubRpcDeps = defaultDeps(),
+): Promise<AgentHubRpcResult<{ agent: RpcAgentSnapshot }>> {
+	const resolved = requireControllableAgent(agentId, deps);
+	if (!resolved.ok) return resolved;
+	const ref = resolved.ref;
+	try {
+		if (ref.status === "running" && ref.session) {
+			await ref.session.abort({ reason: USER_INTERRUPT_LABEL });
+		}
+		await deps.lifecycle.release(ref.id, ref, { tombstone: true });
+	} catch (error) {
+		return fail(error instanceof Error ? error.message : String(error), "agent_control_failed");
+	}
+	const killed = deps.registry.get(ref.id);
+	if (!killed) {
+		return {
+			ok: true,
+			agent: snapshotAgent({
+				...ref,
+				status: "aborted",
+				session: null,
+				activity: undefined,
+			}),
+		};
+	}
+	return { ok: true, agent: snapshotAgent(killed) };
+}

--- a/packages/coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client.ts
@@ -20,6 +20,7 @@ import {
 	type RpcMessagesPageOptions,
 } from "./rpc-messages";
 import type {
+	RpcAgentSnapshot,
 	RpcAvailableCommandsUpdateFrame,
 	RpcAvailableSlashCommand,
 	RpcCommand,
@@ -669,6 +670,41 @@ export class RpcClient {
 			fromByte: selector.fromByte,
 		});
 		return this.#getData<RpcSubagentMessagesResult>(response);
+	}
+
+	/**
+	 * Agent Hub roster: every registered agent except Main, including nested
+	 * children (`parentId`), parked, aborted, and advisors. Distinct from
+	 * `getSubagents()`, which only tracks first-level task-tool event-bus rows.
+	 */
+	async listAgents(): Promise<RpcAgentSnapshot[]> {
+		const response = await this.#send({ type: "list_agents" });
+		return this.#getData<{ agents: RpcAgentSnapshot[] }>(response).agents;
+	}
+
+	/**
+	 * Steer a Hub agent: revive if parked, then prompt with streamingBehavior "steer".
+	 * Advisors and Main are rejected.
+	 */
+	async sendAgentMessage(agentId: string, message: string): Promise<RpcAgentSnapshot> {
+		const response = await this.#send({ type: "send_agent_message", agentId, message });
+		return this.#getData<{ agent: RpcAgentSnapshot }>(response).agent;
+	}
+
+	/**
+	 * Revive a parked Hub agent. Idle/running agents return their live snapshot.
+	 */
+	async reviveAgent(agentId: string): Promise<RpcAgentSnapshot> {
+		const response = await this.#send({ type: "revive_agent", agentId });
+		return this.#getData<{ agent: RpcAgentSnapshot }>(response).agent;
+	}
+
+	/**
+	 * Kill a Hub agent (abort if running, then tombstone). Advisors and Main are rejected.
+	 */
+	async killAgent(agentId: string): Promise<RpcAgentSnapshot> {
+		const response = await this.#send({ type: "kill_agent", agentId });
+		return this.#getData<{ agent: RpcAgentSnapshot }>(response).agent;
 	}
 
 	/**

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -36,6 +36,7 @@ import { calculateTokensPerSecond } from "../../utils/token-rate";
 import { initializeExtensions } from "../runtime-init";
 import { isRpcHostToolResult, isRpcHostToolUpdate, RpcHostToolBridge } from "./host-tools";
 import { isRpcHostUriResult, RpcHostUriBridge } from "./host-uris";
+import { killAgent, listAgents, reviveAgent, sendAgentMessage } from "./rpc-agent-hub";
 import { MAX_RPC_FRAME_BYTES, MAX_RPC_REASSEMBLED_BYTES, RpcFrameEncoder } from "./rpc-frame";
 import { claimRpcInput, readRpcInputFrames } from "./rpc-input";
 import { pageRpcMessages, RPC_MESSAGES_PAGE_BUSY_ERROR, RpcMessagesPageError } from "./rpc-messages";
@@ -1211,6 +1212,28 @@ export async function runRpcMode(
 				} catch (err) {
 					return error(id, "get_subagent_messages", err instanceof Error ? err.message : String(err));
 				}
+			}
+
+			case "list_agents": {
+				return success(id, "list_agents", { agents: listAgents() });
+			}
+
+			case "send_agent_message": {
+				const result = await sendAgentMessage(command.agentId, command.message);
+				if (!result.ok) return error(id, "send_agent_message", result.error, result.code);
+				return success(id, "send_agent_message", { agent: result.agent });
+			}
+
+			case "revive_agent": {
+				const result = await reviveAgent(command.agentId);
+				if (!result.ok) return error(id, "revive_agent", result.error, result.code);
+				return success(id, "revive_agent", { agent: result.agent });
+			}
+
+			case "kill_agent": {
+				const result = await killAgent(command.agentId);
+				if (!result.ok) return error(id, "kill_agent", result.error, result.code);
+				return success(id, "kill_agent", { agent: result.agent });
 			}
 
 			// =================================================================

--- a/packages/coding-agent/src/modes/rpc/rpc-types.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-types.ts
@@ -9,6 +9,7 @@ import type { CompactionResult } from "@oh-my-pi/pi-agent-core/compaction";
 import type { Effort, ImageContent, Model, ToolExample } from "@oh-my-pi/pi-ai";
 import type { BashResult } from "../../exec/bash-executor";
 import type { ContextUsage } from "../../extensibility/extensions/types";
+import type { AgentHistorySummary, AgentKind, AgentStatus } from "../../registry/agent-registry";
 import type { AgentSessionEvent, SessionStats } from "../../session/agent-session";
 import type { FileEntry } from "../../session/session-entries";
 import type { AvailableSlashCommandSource } from "../../slash-commands/available-commands";
@@ -47,6 +48,10 @@ export type RpcCommand =
 	| { id?: string; type: "set_subagent_subscription"; level: RpcSubagentSubscriptionLevel }
 	| { id?: string; type: "get_subagents" }
 	| { id?: string; type: "get_subagent_messages"; subagentId?: string; sessionFile?: string; fromByte?: number }
+	| { id?: string; type: "list_agents" }
+	| { id?: string; type: "send_agent_message"; agentId: string; message: string }
+	| { id?: string; type: "revive_agent"; agentId: string }
+	| { id?: string; type: "kill_agent"; agentId: string }
 
 	// Model
 	| { id?: string; type: "set_model"; provider: string; modelId: string }
@@ -188,6 +193,21 @@ export interface RpcSubagentMessagesResult {
 	messages: AgentMessage[];
 }
 
+/** Agent Hub roster row. Nested agents carry `parentId`; `live` is true when a session is attached. */
+export interface RpcAgentSnapshot {
+	id: string;
+	displayName: string;
+	kind: AgentKind;
+	parentId?: string;
+	status: AgentStatus;
+	sessionFile: string | null;
+	createdAt: number;
+	lastActivity: number;
+	activity?: string;
+	history?: AgentHistorySummary;
+	live: boolean;
+}
+
 // ============================================================================
 // RPC Responses (stdout)
 // ============================================================================
@@ -250,6 +270,34 @@ export type RpcResponse =
 			command: "get_subagent_messages";
 			success: true;
 			data: RpcSubagentMessagesResult;
+	  }
+	| {
+			id?: string;
+			type: "response";
+			command: "list_agents";
+			success: true;
+			data: { agents: RpcAgentSnapshot[] };
+	  }
+	| {
+			id?: string;
+			type: "response";
+			command: "send_agent_message";
+			success: true;
+			data: { agent: RpcAgentSnapshot };
+	  }
+	| {
+			id?: string;
+			type: "response";
+			command: "revive_agent";
+			success: true;
+			data: { agent: RpcAgentSnapshot };
+	  }
+	| {
+			id?: string;
+			type: "response";
+			command: "kill_agent";
+			success: true;
+			data: { agent: RpcAgentSnapshot };
 	  }
 
 	// Model

--- a/packages/coding-agent/test/rpc-agent-hub.test.ts
+++ b/packages/coding-agent/test/rpc-agent-hub.test.ts
@@ -1,0 +1,203 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as path from "node:path";
+import {
+	killAgent,
+	listAgents,
+	reviveAgent,
+	sendAgentMessage,
+} from "@oh-my-pi/pi-coding-agent/modes/rpc/rpc-agent-hub";
+import { AgentLifecycleManager } from "@oh-my-pi/pi-coding-agent/registry/agent-lifecycle";
+import {
+	type AgentKind,
+	AgentRegistry,
+	type AgentStatus,
+	getAgentTombstonePath,
+	MAIN_AGENT_ID,
+	type RegisterInput,
+} from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
+import type { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { USER_INTERRUPT_LABEL } from "@oh-my-pi/pi-coding-agent/session/messages";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+interface SessionStub {
+	session: AgentSession;
+	prompts: Array<{ text: string; options: unknown }>;
+	aborts: Array<{ reason?: string } | undefined>;
+}
+
+function makeSessionStub(): SessionStub {
+	const prompts: Array<{ text: string; options: unknown }> = [];
+	const aborts: Array<{ reason?: string } | undefined> = [];
+	const stub = {
+		prompt: async (text: string, options?: unknown) => {
+			prompts.push({ text, options });
+		},
+		abort: async (options?: { reason?: string }) => {
+			aborts.push(options);
+		},
+		dispose: async () => {},
+	};
+	return { session: stub as unknown as AgentSession, prompts, aborts };
+}
+
+describe("RPC Agent Hub control", () => {
+	let registry: AgentRegistry;
+	let lifecycle: AgentLifecycleManager;
+	let deps: { registry: AgentRegistry; lifecycle: AgentLifecycleManager };
+
+	beforeEach(() => {
+		AgentRegistry.resetGlobalForTests();
+		AgentLifecycleManager.resetGlobalForTests();
+		registry = AgentRegistry.global();
+		lifecycle = AgentLifecycleManager.global();
+		deps = { registry, lifecycle };
+	});
+
+	afterEach(() => {
+		AgentLifecycleManager.resetGlobalForTests();
+		AgentRegistry.resetGlobalForTests();
+	});
+
+	function register(input: {
+		id: string;
+		kind?: AgentKind;
+		parentId?: string;
+		status?: AgentStatus;
+		session?: AgentSession | null;
+		sessionFile?: string | null;
+		lastActivity?: number;
+		displayName?: string;
+	}) {
+		const payload: RegisterInput = {
+			id: input.id,
+			displayName: input.displayName ?? input.id,
+			kind: input.kind ?? "sub",
+			parentId: input.parentId,
+			status: input.status ?? "idle",
+			session: input.session === undefined ? makeSessionStub().session : input.session,
+			sessionFile: input.sessionFile,
+			lastActivity: input.lastActivity,
+		};
+		return registry.register(payload);
+	}
+
+	test("listAgents hides Main and includes nested children plus advisors", () => {
+		register({ id: MAIN_AGENT_ID, kind: "main", displayName: "Main" });
+		register({ id: "worker", lastActivity: 20 });
+		register({ id: "nested", parentId: "worker", lastActivity: 10 });
+		register({ id: "review", kind: "advisor", lastActivity: 5 });
+		register({ id: "parked-child", parentId: "worker", status: "parked", session: null, lastActivity: 1 });
+
+		const agents = listAgents(deps);
+		expect(agents.map(agent => agent.id)).toEqual(["worker", "nested", "review", "parked-child"]);
+		expect(agents.find(agent => agent.id === "nested")?.parentId).toBe("worker");
+		expect(agents.find(agent => agent.id === "review")).toMatchObject({
+			kind: "advisor",
+			live: true,
+		});
+		expect(agents.find(agent => agent.id === "parked-child")).toMatchObject({
+			parentId: "worker",
+			status: "parked",
+			live: false,
+		});
+	});
+
+	test("listAgents sorts by Hub status then recency", () => {
+		register({ id: "aborted-old", status: "aborted", session: null, lastActivity: 400 });
+		register({ id: "parked-new", status: "parked", session: null, lastActivity: 300 });
+		register({ id: "idle-new", status: "idle", lastActivity: 200 });
+		register({ id: "running-old", status: "running", lastActivity: 50 });
+		register({ id: "running-new", status: "running", lastActivity: 100 });
+
+		expect(listAgents(deps).map(agent => agent.id)).toEqual([
+			"running-new",
+			"running-old",
+			"idle-new",
+			"parked-new",
+			"aborted-old",
+		]);
+	});
+
+	test("sendAgentMessage steers a live agent without parking it", async () => {
+		const stub = makeSessionStub();
+		register({ id: "worker", session: stub.session, status: "idle" });
+
+		const result = await sendAgentMessage("worker", "  keep going  ", deps);
+		expect(result).toMatchObject({ ok: true, agent: { id: "worker", live: true } });
+		expect(stub.prompts).toEqual([{ text: "keep going", options: { streamingBehavior: "steer" } }]);
+		expect(stub.aborts).toEqual([]);
+	});
+
+	test("sendAgentMessage revives a parked agent then steers it", async () => {
+		const revived = makeSessionStub();
+		register({ id: "worker", status: "parked", session: null, sessionFile: "/tmp/worker.jsonl" });
+		lifecycle.adopt("worker", { idleTtlMs: 0, revive: async () => revived.session });
+
+		const result = await sendAgentMessage("worker", "resume", deps);
+		expect(result).toMatchObject({ ok: true, agent: { id: "worker", status: "idle", live: true } });
+		expect(revived.prompts).toEqual([{ text: "resume", options: { streamingBehavior: "steer" } }]);
+	});
+
+	test("control commands reject Main, advisors, unknown ids, and empty steer text", async () => {
+		register({ id: MAIN_AGENT_ID, kind: "main" });
+		register({ id: "advisor-1", kind: "advisor" });
+		register({ id: "worker" });
+
+		await expect(sendAgentMessage(MAIN_AGENT_ID, "hi", deps)).resolves.toMatchObject({
+			ok: false,
+			code: "main_forbidden",
+		});
+		await expect(killAgent(MAIN_AGENT_ID, deps)).resolves.toMatchObject({ ok: false, code: "main_forbidden" });
+		await expect(sendAgentMessage("advisor-1", "hi", deps)).resolves.toMatchObject({
+			ok: false,
+			code: "advisor_readonly",
+		});
+		await expect(reviveAgent("advisor-1", deps)).resolves.toMatchObject({ ok: false, code: "advisor_readonly" });
+		await expect(killAgent("missing", deps)).resolves.toMatchObject({ ok: false, code: "unknown_agent" });
+		await expect(sendAgentMessage("worker", "   ", deps)).resolves.toMatchObject({
+			ok: false,
+			code: "empty_message",
+		});
+		await expect(sendAgentMessage("", "hi", deps)).resolves.toMatchObject({ ok: false, code: "invalid_agent_id" });
+	});
+
+	test("reviveAgent restores a parked agent through its reviver", async () => {
+		const revived = makeSessionStub();
+		register({ id: "worker", status: "parked", session: null, sessionFile: "/tmp/worker.jsonl" });
+		lifecycle.adopt("worker", { idleTtlMs: 0, revive: async () => revived.session });
+
+		const result = await reviveAgent("worker", deps);
+		expect(result).toMatchObject({ ok: true, agent: { id: "worker", status: "idle", live: true } });
+		expect(registry.get("worker")?.session).toBe(revived.session);
+		expect(revived.prompts).toEqual([]);
+	});
+
+	test("killAgent aborts a running session and writes a tombstone", async () => {
+		using dir = TempDir.createSync("@omp-rpc-agent-hub-kill-");
+		const sessionFile = path.join(dir.path(), "worker.jsonl");
+		await Bun.write(sessionFile, "{}\n");
+		const stub = makeSessionStub();
+		register({ id: "worker", status: "running", session: stub.session, sessionFile });
+
+		const result = await killAgent("worker", deps);
+		expect(result).toMatchObject({
+			ok: true,
+			agent: { id: "worker", status: "aborted", live: false, sessionFile },
+		});
+		expect(stub.aborts).toEqual([{ reason: USER_INTERRUPT_LABEL }]);
+		expect(await Bun.file(getAgentTombstonePath(sessionFile)).exists()).toBe(true);
+		expect(registry.get("worker")?.status).toBe("aborted");
+		expect(registry.get("worker")?.session).toBeNull();
+	});
+
+	test("killAgent tombstones a parked agent without aborting a session", async () => {
+		using dir = TempDir.createSync("@omp-rpc-agent-hub-parked-kill-");
+		const sessionFile = path.join(dir.path(), "worker.jsonl");
+		await Bun.write(sessionFile, "{}\n");
+		register({ id: "worker", status: "parked", session: null, sessionFile });
+
+		const result = await killAgent("worker", deps);
+		expect(result).toMatchObject({ ok: true, agent: { id: "worker", status: "aborted", live: false } });
+		expect(await Bun.file(getAgentTombstonePath(sessionFile)).exists()).toBe(true);
+	});
+});


### PR DESCRIPTION
## Summary

RPC clients can now use the Agent Hub roster the TUI already has: list every registered agent except Main, steer one, revive a parked one, or kill one. Nested children show up through `parentId` on the process-global `AgentRegistry`.

This is the headless equivalent of opening the Hub overlay (`Alt+A`) and using chat / `r` revive / `x` kill. It follows the same path as collab guest `agent-cmd` (chat/kill/revive), not the task-tool event-bus snapshot.

## Commands

| Command | Effect |
| --- | --- |
| `list_agents` | Hub roster (nested via `parentId`, including parked/aborted/advisors) |
| `send_agent_message` | `ensureLive` + `prompt(..., { streamingBehavior: "steer" })` |
| `revive_agent` | `ensureLive` |
| `kill_agent` | abort if running, then tombstone as `aborted` |

Advisors are listed but rejected for send/revive/kill (`advisor_readonly`). Main is not controllable through these commands. Failures also use `unknown_agent`, `main_forbidden`, `empty_message`, `invalid_agent_id`, and `agent_control_failed`.

`get_subagents` / `set_subagent_subscription` are unchanged (default remains `"off"`). Live `subagent_*` frames for nested (depth ≥ 2) task children are still #9952; this PR only adds nested *roster* visibility.

## Why a small PR

#2214 added observation. Drafts #7439 / #7532 stack a much larger RPC control surface. This is the focused Hub remote: roster + kill/revive/steer + nested `parentId`.

## Test plan

- [x] `packages/coding-agent/test/rpc-agent-hub.test.ts` — list excludes Main and includes nested `parentId`; steer; revive parked; kill abort+tombstone; reject advisor/Main/empty/unknown
- [ ] `bun test packages/coding-agent/test/rpc-agent-hub.test.ts` in CI (local checkout has no `pi_natives` addon)