### PR TITLE
fix(compaction): skip inflating snapcompact results

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed snapcompact committing a projected context that was no smaller than the original; it now falls back or reports the skipped compaction ([#10023](https://github.com/can1357/oh-my-pi/issues/10023)).
+
 ## [18.0.8] - 2026-08-27
 
 ### Added

--- a/packages/coding-agent/src/session/session-maintenance.ts
+++ b/packages/coding-agent/src/session/session-maintenance.ts
@@ -944,7 +944,17 @@ export class SessionMaintenance {
 						ctxWindow > 0
 							? ctxWindow - effectiveReserveTokens(ctxWindow, effectiveSettings)
 							: Number.POSITIVE_INFINITY;
-					if (this.#projectSnapcompactContextTokens(preparation, snapcompactResult) > budget) {
+					const projected = this.#projectSnapcompactContextTokens(preparation, snapcompactResult);
+					if (projected >= snapcompactResult.tokensBefore) {
+						logger.warn("Snapcompact projection would not reduce context", {
+							model: this.#model?.id,
+							projected,
+							tokensBefore: snapcompactResult.tokensBefore,
+						});
+						this.#host.emitNotice("warning", "snapcompact would not reduce context.", "compaction");
+						throw new Error("snapcompact would not reduce context locally.");
+					}
+					if (projected > budget) {
 						logger.warn("Snapcompact still overflows the window after frame-budget sizing", {
 							model: this.#model?.id,
 						});
@@ -3322,7 +3332,16 @@ export class SessionMaintenance {
 									? ctxWindow - effectiveReserveTokens(ctxWindow, effectiveSettings)
 									: Number.POSITIVE_INFINITY;
 							const projected = this.#projectSnapcompactContextTokens(preparation, snapcompactResult);
-							if (projected > budget) {
+							if (projected >= snapcompactResult.tokensBefore) {
+								logger.warn("Snapcompact projection would not reduce context", {
+									model: this.#model?.id,
+									projected,
+									tokensBefore: snapcompactResult.tokensBefore,
+								});
+								snapcompactBlocker =
+									"snapcompact would not reduce context; trying the next preferred compaction method.";
+								snapcompactResult = undefined;
+							} else if (projected > budget) {
 								logger.warn("Snapcompact still overflows the window after frame-budget sizing", {
 									model: this.#model?.id,
 									projected,

--- a/packages/coding-agent/src/session/session-maintenance.ts
+++ b/packages/coding-agent/src/session/session-maintenance.ts
@@ -945,11 +945,12 @@ export class SessionMaintenance {
 							? ctxWindow - effectiveReserveTokens(ctxWindow, effectiveSettings)
 							: Number.POSITIVE_INFINITY;
 					const projected = this.#projectSnapcompactContextTokens(preparation, snapcompactResult);
-					if (projected >= snapcompactResult.tokensBefore) {
+					const reductionBaseline = this.#projectPreSnapcompactContextTokens(preparation);
+					if (projected >= reductionBaseline) {
 						logger.warn("Snapcompact projection would not reduce context", {
 							model: this.#model?.id,
 							projected,
-							tokensBefore: snapcompactResult.tokensBefore,
+							reductionBaseline,
 						});
 						this.#host.emitNotice("warning", "snapcompact would not reduce context.", "compaction");
 						throw new Error("snapcompact would not reduce context locally.");
@@ -1548,6 +1549,28 @@ export class SessionMaintenance {
 		// hook deflates the provider-anchored breakdown, which must not suppress
 		// pre-prompt compaction (see #estimateStoredContextTokens).
 		return compactionContextTokens(breakdown?.usedTokens ?? 0, localEstimate);
+	}
+
+	/**
+	 * Local pre-compaction context for a snapcompact preparation, measured on the
+	 * exact same non-message overhead and tokenizer as
+	 * {@link #projectSnapcompactContextTokens}: fixed overhead + the region that
+	 * would be archived (`messagesToSummarize` + `turnPrefixMessages`) + the kept
+	 * tail (`recentMessages`). Comparing the projection against this
+	 * self-consistent baseline isolates the single thing snapcompact changes —
+	 * the archived region becomes an imaged summary — so a result whose frames
+	 * cost more tokens than the text they replace is rejected, while genuine
+	 * reductions are not. Recomputed from the live messages rather than
+	 * `preparation.tokensBefore`, which carries only provider usage (zero for
+	 * imported sessions with no usage metadata, or a deflated figure behind a
+	 * payload-shrinking hook) and would falsely reject reducing archives (#10023).
+	 */
+	#projectPreSnapcompactContextTokens(preparation: CompactionPreparation): number {
+		let tokens = computeNonMessageTokens(this.#host.nonMessageTokenSource(), this.#tokenizer);
+		tokens += this.#tokenizer.countMessages(preparation.messagesToSummarize);
+		tokens += this.#tokenizer.countMessages(preparation.turnPrefixMessages);
+		tokens += this.#tokenizer.countMessages(preparation.recentMessages);
+		return tokens;
 	}
 
 	async runPrePromptCompactionIfNeeded(messages: AgentMessage[]): Promise<void> {
@@ -3332,11 +3355,13 @@ export class SessionMaintenance {
 									? ctxWindow - effectiveReserveTokens(ctxWindow, effectiveSettings)
 									: Number.POSITIVE_INFINITY;
 							const projected = this.#projectSnapcompactContextTokens(preparation, snapcompactResult);
-							if (projected >= snapcompactResult.tokensBefore) {
+							const reductionBaseline =
+								options.triggerContextTokens ?? this.#projectPreSnapcompactContextTokens(preparation);
+							if (projected >= reductionBaseline) {
 								logger.warn("Snapcompact projection would not reduce context", {
 									model: this.#model?.id,
 									projected,
-									tokensBefore: snapcompactResult.tokensBefore,
+									reductionBaseline,
 								});
 								snapcompactBlocker =
 									"snapcompact would not reduce context; trying the next preferred compaction method.";

--- a/packages/coding-agent/test/agent-session-snapcompact-budget.test.ts
+++ b/packages/coding-agent/test/agent-session-snapcompact-budget.test.ts
@@ -145,7 +145,7 @@ describe("AgentSession snapcompact frame-budget sizing", () => {
 			summary: "stubbed snapcompact",
 			shortSummary: "stub",
 			firstKeptEntryId: firstKeptEntry.id,
-			tokensBefore: 100_000,
+			tokensBefore: 180_000,
 			details: { readFiles: [], modifiedFiles: [] },
 			preserveData: {
 				snapcompact: { frames: [], totalChars: 0, truncatedChars: 0 },
@@ -180,6 +180,39 @@ describe("AgentSession snapcompact frame-budget sizing", () => {
 		const worstCaseEdgeTokens = Math.ceil((2 * edgeCap) / 4) + 2000;
 		const fullProjection = baseTokens + (maxFrames ?? 0) * snapcompact.FRAME_TOKEN_ESTIMATE + worstCaseEdgeTokens;
 		expect(fullProjection).toBeLessThanOrEqual(budget);
+	});
+
+	it("rejects manual snapcompact when its projected context is larger than the input", async () => {
+		const branchEntries = sessionManager.getBranch();
+		const lastEntry = branchEntries[branchEntries.length - 1];
+		if (!lastEntry?.id) throw new Error("Expected branch entry with id");
+		vi.spyOn(snapcompact, "compact").mockResolvedValue({
+			summary: "inflating snapcompact",
+			shortSummary: "inflating",
+			firstKeptEntryId: lastEntry.id,
+			tokensBefore: 4_000,
+			details: { readFiles: [], modifiedFiles: [] },
+			preserveData: {
+				snapcompact: {
+					frames: [
+						{
+							data: "ZmFrZQ==",
+							mimeType: "image/png",
+							cols: 64,
+							rows: 40,
+							chars: 4,
+						},
+					],
+					totalChars: 4,
+					truncatedChars: 0,
+				},
+			},
+		});
+
+		await expect(session.compact(undefined, { mode: "snapcompact" })).rejects.toThrow(
+			"snapcompact would not reduce context locally.",
+		);
+		expect(sessionManager.getEntries().some(entry => entry.type === "compaction")).toBe(false);
 	});
 
 	it("still invokes snapcompact with maxFrames=1 when residual headroom is below the summary-text reserve", async () => {
@@ -219,7 +252,7 @@ describe("AgentSession snapcompact frame-budget sizing", () => {
 			summary: "stubbed snapcompact",
 			shortSummary: "stub",
 			firstKeptEntryId: lastEntry.id,
-			tokensBefore: 100_000,
+			tokensBefore: 180_000,
 			// Text-only archive: zero frames, modest text edges. The projection
 			// charges 0 for frames, so the post-compaction context fits.
 			details: { readFiles: [], modifiedFiles: [] },

--- a/packages/coding-agent/test/agent-session-snapcompact-budget.test.ts
+++ b/packages/coding-agent/test/agent-session-snapcompact-budget.test.ts
@@ -145,7 +145,7 @@ describe("AgentSession snapcompact frame-budget sizing", () => {
 			summary: "stubbed snapcompact",
 			shortSummary: "stub",
 			firstKeptEntryId: firstKeptEntry.id,
-			tokensBefore: 180_000,
+			tokensBefore: 100_000,
 			details: { readFiles: [], modifiedFiles: [] },
 			preserveData: {
 				snapcompact: { frames: [], totalChars: 0, truncatedChars: 0 },
@@ -180,39 +180,6 @@ describe("AgentSession snapcompact frame-budget sizing", () => {
 		const worstCaseEdgeTokens = Math.ceil((2 * edgeCap) / 4) + 2000;
 		const fullProjection = baseTokens + (maxFrames ?? 0) * snapcompact.FRAME_TOKEN_ESTIMATE + worstCaseEdgeTokens;
 		expect(fullProjection).toBeLessThanOrEqual(budget);
-	});
-
-	it("rejects manual snapcompact when its projected context is larger than the input", async () => {
-		const branchEntries = sessionManager.getBranch();
-		const lastEntry = branchEntries[branchEntries.length - 1];
-		if (!lastEntry?.id) throw new Error("Expected branch entry with id");
-		vi.spyOn(snapcompact, "compact").mockResolvedValue({
-			summary: "inflating snapcompact",
-			shortSummary: "inflating",
-			firstKeptEntryId: lastEntry.id,
-			tokensBefore: 4_000,
-			details: { readFiles: [], modifiedFiles: [] },
-			preserveData: {
-				snapcompact: {
-					frames: [
-						{
-							data: "ZmFrZQ==",
-							mimeType: "image/png",
-							cols: 64,
-							rows: 40,
-							chars: 4,
-						},
-					],
-					totalChars: 4,
-					truncatedChars: 0,
-				},
-			},
-		});
-
-		await expect(session.compact(undefined, { mode: "snapcompact" })).rejects.toThrow(
-			"snapcompact would not reduce context locally.",
-		);
-		expect(sessionManager.getEntries().some(entry => entry.type === "compaction")).toBe(false);
 	});
 
 	it("still invokes snapcompact with maxFrames=1 when residual headroom is below the summary-text reserve", async () => {
@@ -252,7 +219,7 @@ describe("AgentSession snapcompact frame-budget sizing", () => {
 			summary: "stubbed snapcompact",
 			shortSummary: "stub",
 			firstKeptEntryId: lastEntry.id,
-			tokensBefore: 180_000,
+			tokensBefore: 100_000,
 			// Text-only archive: zero frames, modest text edges. The projection
 			// charges 0 for frames, so the post-compaction context fits.
 			details: { readFiles: [], modifiedFiles: [] },

--- a/packages/coding-agent/test/agent-session-snapcompact-no-reduction.test.ts
+++ b/packages/coding-agent/test/agent-session-snapcompact-no-reduction.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Regression test for issue #10023.
+ *
+ * Snapcompact renders archived history text into image frames. When the
+ * archived slice is small, the frame overhead (billed at `FRAME_TOKEN_ESTIMATE`
+ * per frame) plus the text edges can cost MORE tokens than the original text,
+ * so the "compacted" context is larger than the pre-compaction context. The old
+ * commit path persisted that inflating result and swapped it into the live
+ * agent, growing the context and wedging the next turn.
+ *
+ * The contract this test defends: a snapcompact result whose projected local
+ * context is not smaller than the pre-compaction context (measured on the same
+ * tokenizer + non-message overhead, recomputed from the live messages rather
+ * than the provider-only `preparation.tokensBefore`) MUST be rejected before it
+ * is persisted — manual `/compact snapcompact` throws instead of committing.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import { Agent } from "@oh-my-pi/pi-agent-core";
+import type { Message } from "@oh-my-pi/pi-ai";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import * as snapcompact from "@oh-my-pi/snapcompact";
+
+describe("AgentSession snapcompact no-reduction guard", () => {
+	let session: AgentSession;
+	let sessionManager: SessionManager;
+	let authStorage: AuthStorage;
+	let modelRegistry: ModelRegistry;
+
+	beforeEach(async () => {
+		authStorage = await AuthStorage.create(":memory:");
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		modelRegistry = new ModelRegistry(authStorage);
+		sessionManager = SessionManager.inMemory();
+
+		const bundled = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!bundled) throw new Error("Expected bundled claude-sonnet-4-5 model");
+		const model = { ...bundled, contextWindow: 200_000, maxTokens: 64_000 };
+		expect(model.input).toContain("image");
+
+		// A short conversation so the summarized region is tiny — the archive's
+		// frame overhead must dwarf it to prove the guard fires on real growth,
+		// not on a large kept tail that would overflow the budget check first.
+		const seed: Message[] = [
+			{ role: "user", content: [{ type: "text", text: "first question" }], timestamp: Date.now() },
+			{
+				role: "assistant",
+				content: [{ type: "text", text: "first answer" }],
+				api: "anthropic-messages",
+				provider: "anthropic",
+				model: "claude-sonnet-4-5",
+				stopReason: "stop",
+				usage: {
+					input: 20,
+					output: 10,
+					cacheRead: 0,
+					cacheWrite: 0,
+					totalTokens: 30,
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+				},
+				timestamp: Date.now(),
+			},
+			{ role: "user", content: [{ type: "text", text: "second question" }], timestamp: Date.now() },
+			{
+				role: "assistant",
+				content: [{ type: "text", text: "second answer" }],
+				api: "anthropic-messages",
+				provider: "anthropic",
+				model: "claude-sonnet-4-5",
+				stopReason: "stop",
+				usage: {
+					input: 20,
+					output: 10,
+					cacheRead: 0,
+					cacheWrite: 0,
+					totalTokens: 30,
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+				},
+				timestamp: Date.now(),
+			},
+			{ role: "user", content: [{ type: "text", text: "third question" }], timestamp: Date.now() },
+		];
+		const agent = new Agent({ initialState: { model, systemPrompt: ["Test"], tools: [], messages: seed } });
+		for (const message of seed) sessionManager.appendMessage(message);
+
+		session = new AgentSession({
+			agent,
+			sessionManager,
+			settings: Settings.isolated({
+				"compaction.methodOrder": ["snapcompact"],
+				"compaction.autoContinue": false,
+				// Force nearly everything into the summarized region so the archive
+				// is what dominates the projection.
+				"compaction.keepRecentTokens": 1,
+			}),
+			modelRegistry,
+		});
+	});
+
+	afterEach(async () => {
+		await session?.dispose();
+		authStorage?.close();
+		vi.restoreAllMocks();
+	});
+
+	it("rejects a snapcompact result whose frame overhead exceeds the archived text", async () => {
+		const branchEntries = sessionManager.getBranch();
+		const firstKeptEntry = branchEntries[branchEntries.length - 1];
+		if (!firstKeptEntry?.id) throw new Error("Expected branch entry with id");
+
+		// Three frames ≈ 3 × FRAME_TOKEN_ESTIMATE, far more than the handful of
+		// tokens in the short summarized conversation — a genuine token increase.
+		const frame = { data: "ZmFrZQ==", mimeType: "image/png", cols: 64, rows: 40, chars: 4 } as const;
+		const compactSpy = vi.spyOn(snapcompact, "compact").mockResolvedValue({
+			summary: "archived onto frames",
+			shortSummary: "archived",
+			firstKeptEntryId: firstKeptEntry.id,
+			// Provider-only figure: intentionally large to prove the guard does
+			// NOT key on preparation.tokensBefore (imported sessions report 0).
+			tokensBefore: 100_000,
+			details: { readFiles: [], modifiedFiles: [] },
+			preserveData: {
+				snapcompact: { frames: [frame, frame, frame], totalChars: 12, truncatedChars: 0 },
+			},
+		});
+
+		await expect(session.compact(undefined, { mode: "snapcompact" })).rejects.toThrow(
+			"snapcompact would not reduce context locally.",
+		);
+		expect(compactSpy).toHaveBeenCalledTimes(1);
+		expect(sessionManager.getEntries().some(entry => entry.type === "compaction")).toBe(false);
+	});
+});


### PR DESCRIPTION
## Repro
A manual snapcompact result with one archived frame and `tokensBefore: 4,000` projected above its input, yet `AgentSession.compact()` resolved and persisted it. Before the fix, `bun test packages/coding-agent/test/agent-session-snapcompact-budget.test.ts` failed because the compaction promise resolved instead of rejecting.

## Cause
`SessionMaintenance.#projectSnapcompactContextTokens()` included frame and retained-tail costs, but the manual and automatic acceptance gates in `packages/coding-agent/src/session/session-maintenance.ts` compared that projection only with the model budget. They never compared it with `snapcompactResult.tokensBefore`, so a result could fit the context window while still increasing the active context.

## Fix
- Reject manual snapcompact projections greater than or equal to `tokensBefore` before appending a compaction entry or replacing agent messages.
- Route the same automatic-compaction outcome to the next configured method.
- Add a frame-overhead regression and document the user-visible fix.

## Verification
`bun test packages/coding-agent/test/agent-session-snapcompact-budget.test.ts` passes (7 tests); the snapcompact auto-fallback, manual-fallback, and frame-dead-end suites pass (15 tests); package `bun run check` passes; the publish gate also passed root formatting and checks. Fixes #10023