### PR TITLE
fix(browser): reap orphaned shared-browser targets from dead sessions

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the project-shared headless browser retaining orphaned pages, iframes, and workers from omp sessions that ended abnormally; a live session now reaps targets whose owning process is gone when it attaches to the shared browser ([#10022](https://github.com/can1357/oh-my-pi/issues/10022)).
+
 ## [18.0.8] - 2026-08-27
 
 ### Added

--- a/packages/coding-agent/src/tools/browser/orphan-registry.ts
+++ b/packages/coding-agent/src/tools/browser/orphan-registry.ts
@@ -1,0 +1,247 @@
+/**
+ * Durable ownership registry for targets in the project-shared broker-owned
+ * Chromium (`omp.browser.headless`/`omp.browser.headed`).
+ *
+ * The shared browser outlives any single omp process, but tab ownership is
+ * otherwise tracked only in that process's memory (`tab-supervisor`'s `tabs`
+ * map). When a session ends abnormally (crash, SIGKILL, cleanup timeout) its
+ * in-process map dies with it and the pages it opened stay open in the shared
+ * Chromium forever, accumulating into multi-GB orphan targets (issue #10022).
+ *
+ * This module records, on disk under the broker runtime dir, which OS process
+ * created each shared-browser page target. Any live omp process can then reap
+ * targets whose owning process is gone. It only ever touches OMP-owned
+ * shared-browser targets — user-owned connected/relay/spawned browsers have no
+ * registry and are never scanned.
+ *
+ * Ownership is authoritative in the safe direction: a target is reaped only
+ * when its owner PID reports `ESRCH` (definitively dead). A live PID is never
+ * reaped, so a live session's tabs cannot be yanked out from under it; the
+ * worst case (recycled PID) leaves an orphan uncollected rather than closing a
+ * live page.
+ */
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { isEnoent, logger } from "@oh-my-pi/pi-utils";
+import type { Browser } from "puppeteer-core";
+import { daemonRuntimeDir } from "../../launch/paths";
+
+/** Identifies one shared-browser daemon's target registry. */
+export interface SharedTargetScope {
+	/** Canonical project directory owning the broker (as stamped on the handle). */
+	projectDir: string;
+	/** Broker daemon name, e.g. `omp.browser.headless`. */
+	daemonName: string;
+}
+
+/** On-disk ownership record: one file per owning omp process. */
+interface OwnershipFile {
+	pid: number;
+	updatedAt: number;
+	targets: string[];
+}
+
+/**
+ * Reap only records whose owner has been dead AND untouched for this long.
+ * The PID probe is already authoritative; the grace window is a conservative
+ * guard against clock skew and PID reuse races, and keeps a just-crashed
+ * process's very fresh records around briefly in case it is being restarted.
+ */
+const DEFAULT_GRACE_MS = 15_000;
+
+/** In-process set of shared-browser targets this process created, keyed by registry dir. */
+const ownedByDir = new Map<string, Set<string>>();
+/** Per-registry-dir write serialization so concurrent record/forget can't tear the file. */
+const writeChains = new Map<string, Promise<void>>();
+
+function registryDir(scope: SharedTargetScope): string {
+	return path.join(daemonRuntimeDir(scope.projectDir), `${scope.daemonName}.targets`);
+}
+
+/** Serialize a write against others for the same registry dir. */
+function chain(dir: string, task: () => Promise<void>): Promise<void> {
+	const prev = writeChains.get(dir) ?? Promise.resolve();
+	const next = prev.then(task, task);
+	writeChains.set(
+		dir,
+		next.catch(() => undefined),
+	);
+	return next;
+}
+
+/** Persist (or, when empty, remove) this process's ownership file for a registry dir. */
+async function flush(dir: string): Promise<void> {
+	const owned = ownedByDir.get(dir);
+	const file = path.join(dir, `${process.pid}.json`);
+	if (!owned || owned.size === 0) {
+		await fs.rm(file, { force: true }).catch(() => undefined);
+		return;
+	}
+	const record: OwnershipFile = { pid: process.pid, updatedAt: Date.now(), targets: [...owned] };
+	const tmp = `${file}.${process.pid}.tmp`;
+	await fs.mkdir(dir, { recursive: true });
+	await Bun.write(tmp, JSON.stringify(record));
+	await fs.rename(tmp, file);
+}
+
+/** Record that this process created `targetId` in the given shared browser. */
+export async function recordSharedTarget(scope: SharedTargetScope, targetId: string): Promise<void> {
+	const dir = registryDir(scope);
+	let owned = ownedByDir.get(dir);
+	if (!owned) {
+		owned = new Set();
+		ownedByDir.set(dir, owned);
+	}
+	owned.add(targetId);
+	await chain(dir, () => flush(dir)).catch(err =>
+		logger.debug("Failed to record shared-browser target ownership", {
+			error: err instanceof Error ? err.message : String(err),
+		}),
+	);
+}
+
+/** Drop `targetId` from this process's ownership file (closed the normal way). */
+export async function forgetSharedTarget(scope: SharedTargetScope, targetId: string): Promise<void> {
+	const dir = registryDir(scope);
+	const owned = ownedByDir.get(dir);
+	if (!owned?.delete(targetId)) return;
+	await chain(dir, () => flush(dir)).catch(err =>
+		logger.debug("Failed to update shared-browser target ownership", {
+			error: err instanceof Error ? err.message : String(err),
+		}),
+	);
+}
+
+/** True when `pid` names a live process; non-`ESRCH` probe failures are treated as alive (safe direction). */
+function isPidAlive(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (error) {
+		return (error as NodeJS.ErrnoException).code !== "ESRCH";
+	}
+}
+
+/** Options for {@link collectOrphanTargets}; the defaults hit the real registry, the seams are for tests. */
+export interface CollectOrphanOptions {
+	/** Wall clock; injectable for deterministic grace-window tests. */
+	now?: () => number;
+	/** PID liveness probe; injectable so tests need no real subprocesses. */
+	isAlive?: (pid: number) => boolean;
+	/** Grace window in ms before a dead owner's records are eligible. */
+	graceMs?: number;
+}
+
+/** Orphan-scan result: target ids to close, plus the ownership files to delete. */
+export interface OrphanScan {
+	targetIds: string[];
+	staleFiles: string[];
+}
+
+/**
+ * Scan a registry dir for targets whose owning process is gone. Returns the
+ * dead-owner target ids to close and the ownership files to remove. This
+ * process's own file and every live-owner file are left untouched.
+ */
+export async function collectOrphanTargets(
+	scope: SharedTargetScope,
+	opts: CollectOrphanOptions = {},
+): Promise<OrphanScan> {
+	const now = opts.now ?? Date.now;
+	const isAlive = opts.isAlive ?? isPidAlive;
+	const graceMs = opts.graceMs ?? DEFAULT_GRACE_MS;
+	const dir = registryDir(scope);
+	let entries: string[];
+	try {
+		entries = await fs.readdir(dir);
+	} catch (err) {
+		if (isEnoent(err)) return { targetIds: [], staleFiles: [] };
+		throw err;
+	}
+	const targetIds: string[] = [];
+	const staleFiles: string[] = [];
+	const nowMs = now();
+	for (const entry of entries) {
+		if (!entry.endsWith(".json")) continue;
+		const file = path.join(dir, entry);
+		let record: OwnershipFile;
+		try {
+			record = (await Bun.file(file).json()) as OwnershipFile;
+		} catch {
+			continue; // torn or malformed file; a live owner will rewrite it
+		}
+		if (typeof record?.pid !== "number" || !Array.isArray(record.targets)) continue;
+		if (record.pid === process.pid) continue; // our own file
+		if (isAlive(record.pid)) continue; // owner still running
+		if (nowMs - (record.updatedAt ?? 0) < graceMs) continue; // conservative grace
+		for (const id of record.targets) if (typeof id === "string") targetIds.push(id);
+		staleFiles.push(file);
+	}
+	return { targetIds, staleFiles };
+}
+
+/** Remove ownership files whose owners were reaped. */
+export async function pruneOwnershipFiles(files: readonly string[]): Promise<void> {
+	await Promise.all(files.map(file => fs.rm(file, { force: true }).catch(() => undefined)));
+}
+
+/**
+ * Close a page target by id through a fresh CDP session. Best-effort: mirrors
+ * `tab-supervisor`'s close path so a wedged page can't hang teardown, and so a
+ * target that vanished on its own resolves as a no-op.
+ */
+export async function closeCdpTarget(browser: Browser, targetId: string): Promise<void> {
+	const session = await browser
+		.target()
+		.createCDPSession()
+		.catch(() => null);
+	if (!session) return;
+	try {
+		await session.send("Target.closeTarget", { targetId }).catch(() => undefined);
+	} finally {
+		await session.detach().catch(() => undefined);
+	}
+}
+
+/**
+ * Reap shared-browser targets whose owning omp process is gone, then remove
+ * their ownership files. Best-effort and bounded by the caller's browser
+ * connection; failures are logged, never thrown, so a browser open is never
+ * blocked by cleanup of unrelated dead sessions.
+ */
+export async function reapOrphanSharedTargets(browser: Browser, scope: SharedTargetScope): Promise<number> {
+	let scan: OrphanScan;
+	try {
+		scan = await collectOrphanTargets(scope);
+	} catch (err) {
+		logger.debug("Failed to scan shared-browser target registry", {
+			error: err instanceof Error ? err.message : String(err),
+		});
+		return 0;
+	}
+	if (scan.targetIds.length === 0) {
+		await pruneOwnershipFiles(scan.staleFiles);
+		return 0;
+	}
+	let closed = 0;
+	for (const targetId of scan.targetIds) {
+		try {
+			await closeCdpTarget(browser, targetId);
+			closed++;
+		} catch (err) {
+			logger.debug("Failed to close orphaned shared-browser target", {
+				targetId,
+				error: err instanceof Error ? err.message : String(err),
+			});
+		}
+	}
+	await pruneOwnershipFiles(scan.staleFiles);
+	if (closed > 0) logger.debug("Reaped orphaned shared-browser targets", { count: closed, daemon: scope.daemonName });
+	return closed;
+}
+
+/** Test-only reset of the in-process ownership state. */
+export function resetOrphanRegistryForTest(): void {
+	ownedByDir.clear();
+	writeChains.clear();
+}

--- a/packages/coding-agent/src/tools/browser/orphan-registry.ts
+++ b/packages/coding-agent/src/tools/browser/orphan-registry.ts
@@ -132,16 +132,24 @@ export interface CollectOrphanOptions {
 	graceMs?: number;
 }
 
-/** Orphan-scan result: target ids to close, plus the ownership files to delete. */
-export interface OrphanScan {
+/** Targets belonging to one dead process, kept grouped so partial failures remain retryable. */
+export interface OrphanOwner {
+	file: string;
+	pid: number;
+	updatedAt: number;
 	targetIds: string[];
-	staleFiles: string[];
+}
+
+/** Orphan-scan result grouped by durable ownership file. */
+export interface OrphanScan {
+	owners: OrphanOwner[];
 }
 
 /**
- * Scan a registry dir for targets whose owning process is gone. Returns the
- * dead-owner target ids to close and the ownership files to remove. This
- * process's own file and every live-owner file are left untouched.
+ * Scan a registry dir for targets whose owning process is gone. Returns one
+ * entry per dead owner so a reaper can retain only targets whose CDP closure
+ * was not confirmed. This process's own file and every live-owner file are
+ * left untouched.
  */
 export async function collectOrphanTargets(
 	scope: SharedTargetScope,
@@ -155,11 +163,10 @@ export async function collectOrphanTargets(
 	try {
 		entries = await fs.readdir(dir);
 	} catch (err) {
-		if (isEnoent(err)) return { targetIds: [], staleFiles: [] };
+		if (isEnoent(err)) return { owners: [] };
 		throw err;
 	}
-	const targetIds: string[] = [];
-	const staleFiles: string[] = [];
+	const owners: OrphanOwner[] = [];
 	const nowMs = now();
 	for (const entry of entries) {
 		if (!entry.endsWith(".json")) continue;
@@ -174,40 +181,69 @@ export async function collectOrphanTargets(
 		if (record.pid === process.pid) continue; // our own file
 		if (isAlive(record.pid)) continue; // owner still running
 		if (nowMs - (record.updatedAt ?? 0) < graceMs) continue; // conservative grace
-		for (const id of record.targets) if (typeof id === "string") targetIds.push(id);
-		staleFiles.push(file);
+		owners.push({
+			file,
+			pid: record.pid,
+			updatedAt: record.updatedAt,
+			targetIds: record.targets.filter(id => typeof id === "string"),
+		});
 	}
-	return { targetIds, staleFiles };
-}
-
-/** Remove ownership files whose owners were reaped. */
-export async function pruneOwnershipFiles(files: readonly string[]): Promise<void> {
-	await Promise.all(files.map(file => fs.rm(file, { force: true }).catch(() => undefined)));
+	return { owners };
 }
 
 /**
- * Close a page target by id through a fresh CDP session. Best-effort: mirrors
- * `tab-supervisor`'s close path so a wedged page can't hang teardown, and so a
- * target that vanished on its own resolves as a no-op.
+ * Close a page target by id through a fresh CDP session. Returns true only
+ * when CDP confirms the close or confirms the target no longer exists; a
+ * dropped connection or transient protocol failure returns false so durable
+ * ownership remains available for a later retry.
  */
-export async function closeCdpTarget(browser: Browser, targetId: string): Promise<void> {
+export async function closeCdpTarget(browser: Browser, targetId: string): Promise<boolean> {
 	const session = await browser
 		.target()
 		.createCDPSession()
 		.catch(() => null);
-	if (!session) return;
+	if (!session) return false;
 	try {
-		await session.send("Target.closeTarget", { targetId }).catch(() => undefined);
+		try {
+			const result = await session.send("Target.closeTarget", { targetId });
+			if (result.success) return true;
+		} catch {
+			// A concurrent reaper or the page itself may already have closed the
+			// target. Confirm absence before treating the cleanup as complete.
+		}
+		try {
+			const { targetInfos } = await session.send("Target.getTargets");
+			return !targetInfos.some(info => info.targetId === targetId);
+		} catch {
+			return false;
+		}
 	} finally {
 		await session.detach().catch(() => undefined);
 	}
 }
 
+/** Atomically retain unresolved targets, or remove an ownership file once all are resolved. */
+async function updateOwnershipFile(owner: OrphanOwner, targetIds: string[]): Promise<void> {
+	if (targetIds.length === 0) {
+		await fs.rm(owner.file, { force: true });
+		return;
+	}
+	const tmp = `${owner.file}.${process.pid}.tmp`;
+	try {
+		const record: OwnershipFile = { pid: owner.pid, updatedAt: owner.updatedAt, targets: targetIds };
+		await Bun.write(tmp, JSON.stringify(record));
+		await fs.rename(tmp, owner.file);
+	} catch (error) {
+		await fs.rm(tmp, { force: true }).catch(() => undefined);
+		throw error;
+	}
+}
+
 /**
- * Reap shared-browser targets whose owning omp process is gone, then remove
- * their ownership files. Best-effort and bounded by the caller's browser
- * connection; failures are logged, never thrown, so a browser open is never
- * blocked by cleanup of unrelated dead sessions.
+ * Reap shared-browser targets whose owning omp process is gone. Each owner
+ * file is removed only after every target is confirmed closed/absent; partial
+ * failures atomically retain the unresolved ids for the next attach to retry.
+ * Failures are logged, never thrown, so cleanup cannot block browser open.
  */
 export async function reapOrphanSharedTargets(browser: Browser, scope: SharedTargetScope): Promise<number> {
 	let scan: OrphanScan;
@@ -219,23 +255,27 @@ export async function reapOrphanSharedTargets(browser: Browser, scope: SharedTar
 		});
 		return 0;
 	}
-	if (scan.targetIds.length === 0) {
-		await pruneOwnershipFiles(scan.staleFiles);
-		return 0;
-	}
 	let closed = 0;
-	for (const targetId of scan.targetIds) {
+	for (const owner of scan.owners) {
+		const retained: string[] = [];
+		for (const targetId of owner.targetIds) {
+			if (await closeCdpTarget(browser, targetId)) {
+				closed++;
+			} else {
+				retained.push(targetId);
+				logger.debug("Retaining orphaned shared-browser target for retry", { targetId, ownerPid: owner.pid });
+			}
+		}
+		if (retained.length === owner.targetIds.length) continue;
 		try {
-			await closeCdpTarget(browser, targetId);
-			closed++;
+			await updateOwnershipFile(owner, retained);
 		} catch (err) {
-			logger.debug("Failed to close orphaned shared-browser target", {
-				targetId,
+			logger.debug("Failed to update shared-browser ownership after reap", {
+				ownerPid: owner.pid,
 				error: err instanceof Error ? err.message : String(err),
 			});
 		}
 	}
-	await pruneOwnershipFiles(scan.staleFiles);
 	if (closed > 0) logger.debug("Reaped orphaned shared-browser targets", { count: closed, daemon: scope.daemonName });
 	return closed;
 }

--- a/packages/coding-agent/src/tools/browser/registry.ts
+++ b/packages/coding-agent/src/tools/browser/registry.ts
@@ -14,6 +14,7 @@ import {
 	removeUserDataDir,
 	type UserAgentOverride,
 } from "./launch";
+import { reapOrphanSharedTargets } from "./orphan-registry";
 import { ensureRelayDaemon, isLoopbackRelayUrl } from "./relay/daemon";
 import type { RelayKind } from "./relay/kind";
 import { ensureSharedBrowser } from "./shared-daemon";
@@ -426,6 +427,11 @@ async function openSharedHeadlessHandle(
 				: null,
 			protocolTimeout: BROWSER_PROTOCOL_TIMEOUT_MS,
 		});
+		// Attaching to the shared daemon is the natural point to sweep targets
+		// left behind by omp processes that died without teardown — bounds
+		// accumulation without a background timer. Best-effort and detached so a
+		// slow reap never delays the open (issue #10022).
+		void reapOrphanSharedTargets(browser, { projectDir: shared.projectDir, daemonName: shared.daemonName });
 		return {
 			key: browserKey(kind),
 			kind,

--- a/packages/coding-agent/src/tools/browser/tab-supervisor.ts
+++ b/packages/coding-agent/src/tools/browser/tab-supervisor.ts
@@ -17,6 +17,7 @@ import { pickElectronTarget, shouldPreserveConnectedBrowserFocus } from "./attac
 import { CmuxTab, runCmuxCode } from "./cmux/cmux-tab";
 import { mapWaitUntil } from "./cmux/rpc";
 import { DEFAULT_VIEWPORT } from "./launch";
+import { closeCdpTarget, forgetSharedTarget, recordSharedTarget, type SharedTargetScope } from "./orphan-registry";
 import {
 	type BrowserHandle,
 	type BrowserKindTag,
@@ -407,6 +408,10 @@ async function acquireTabImpl(
 	};
 	worker.onMessage(msg => handleTabMessage(tab, msg));
 	tabs.set(name, tab);
+	// Durably record ownership so another live omp process can reap this page if
+	// this process dies abnormally before its own teardown closes the tab.
+	const scope = sharedScopeOf(browser);
+	if (scope) void recordSharedTarget(scope, info.targetId);
 	return { tab, created: true };
 }
 
@@ -707,6 +712,8 @@ export async function releaseTab(name: string, opts: ReleaseTabOptions = {}): Pr
 		cleanupError ??= error;
 	} finally {
 		tabs.delete(name);
+		const scope = sharedScopeOf(tab.browser);
+		if (scope) void forgetSharedTarget(scope, tab.targetId);
 	}
 	if (cleanupError) throw cleanupError;
 	return true;
@@ -952,6 +959,8 @@ async function forceKillTab(name: string, reason: string): Promise<void> {
 	if (tab.kindTag === "headless") await closeOrphanTarget(tab);
 	await releaseBrowser(tab.browser, { kill: false });
 	tabs.delete(name);
+	const scope = sharedScopeOf(tab.browser);
+	if (scope) void forgetSharedTarget(scope, tab.targetId);
 }
 
 /**
@@ -961,16 +970,18 @@ async function forceKillTab(name: string, reason: string): Promise<void> {
  * protocol timeout, retaining the cleanup hold for tens of seconds.
  */
 async function closeTargetById(browser: PuppeteerBrowserHandle, targetId: string): Promise<void> {
-	const session = await browser.browser
-		.target()
-		.createCDPSession()
-		.catch(() => null);
-	if (!session) return;
-	try {
-		await session.send("Target.closeTarget", { targetId }).catch(() => undefined);
-	} finally {
-		await session.detach().catch(() => undefined);
-	}
+	await closeCdpTarget(browser.browser, targetId);
+}
+
+/**
+ * Durable-ownership scope for a browser handle, or undefined when the handle is
+ * not the project-shared broker-owned Chromium (the only browser whose targets
+ * outlive their creating process and thus need cross-process orphan reaping).
+ */
+function sharedScopeOf(browser: BrowserHandle): SharedTargetScope | undefined {
+	if ("client" in browser) return undefined;
+	if (browser.kind.kind !== "headless" || !browser.sharedDaemon) return undefined;
+	return { projectDir: browser.sharedDaemon.projectDir, daemonName: browser.sharedDaemon.name };
 }
 
 /**

--- a/packages/coding-agent/test/tools/browser-orphan-registry.test.ts
+++ b/packages/coding-agent/test/tools/browser-orphan-registry.test.ts
@@ -9,8 +9,8 @@
  *  - a dead owner's targets are collected for reaping, a live owner's are not;
  *  - this process's own targets are never reaped (a live session keeps its tabs);
  *  - a conservative grace window keeps a just-crashed owner's fresh records;
- *  - `reapOrphanSharedTargets` closes the dead targets via CDP and deletes the
- *    ownership file.
+ *  - confirmed closures are removed, while transient failures remain durable
+ *    and are retried on the next reap.
  */
 import { afterEach, describe, expect, it } from "bun:test";
 import * as fs from "node:fs/promises";
@@ -54,11 +54,17 @@ async function deadPid(): Promise<number> {
 	return proc.pid;
 }
 
-/** Minimal puppeteer Browser stub recording which target ids get closed via CDP. */
-function makeBrowser(closed: string[]): Browser {
+/** Minimal puppeteer Browser stub recording closes and optionally failing selected targets. */
+function makeBrowser(closed: string[], failTargets: ReadonlySet<string> = new Set()): Browser {
 	const session = {
-		send: async (_method: string, params: { targetId: string }) => {
+		send: async (method: string, params?: { targetId: string }) => {
+			if (method === "Target.getTargets") {
+				return { targetInfos: [...failTargets].map(targetId => ({ targetId })) };
+			}
+			if (!params) throw new Error(`Missing params for ${method}`);
+			if (failTargets.has(params.targetId)) throw new Error("transient CDP failure");
 			closed.push(params.targetId);
+			return { success: true };
 		},
 		detach: async () => undefined,
 	};
@@ -94,9 +100,14 @@ describe("orphan-registry — ownership scan", () => {
 			isAlive: pid => pid === live,
 		});
 
-		expect(scan.targetIds.sort()).toEqual(["dead-a", "dead-b"]);
-		expect(scan.targetIds).not.toContain("live-a");
-		expect(scan.staleFiles).toEqual([path.join(registryDir(scope), `${dead}.json`)]);
+		expect(scan.owners).toEqual([
+			{
+				file: path.join(registryDir(scope), `${dead}.json`),
+				pid: dead,
+				updatedAt: 0,
+				targetIds: ["dead-a", "dead-b"],
+			},
+		]);
 	});
 
 	it("never reaps this process's own recorded targets", async () => {
@@ -112,8 +123,7 @@ describe("orphan-registry — ownership scan", () => {
 
 		// ...but a scan (even with everything else forced dead) skips it.
 		const scan = await collectOrphanTargets(scope, { now: () => 10_000_000, isAlive: () => false });
-		expect(scan.targetIds).toEqual([]);
-		expect(scan.staleFiles).toEqual([]);
+		expect(scan.owners).toEqual([]);
 	});
 
 	it("forgetSharedTarget drops one id and removes the file once empty", async () => {
@@ -140,14 +150,21 @@ describe("orphan-registry — ownership scan", () => {
 			isAlive: () => false,
 			graceMs: 15_000,
 		});
-		expect(withinGrace.targetIds).toEqual([]);
+		expect(withinGrace.owners).toEqual([]);
 
 		const pastGrace = await collectOrphanTargets(scope, {
 			now: () => 130_000,
 			isAlive: () => false,
 			graceMs: 15_000,
 		});
-		expect(pastGrace.targetIds).toEqual(["fresh"]);
+		expect(pastGrace.owners).toEqual([
+			{
+				file: path.join(registryDir(scope), `${dead}.json`),
+				pid: dead,
+				updatedAt: 100_000,
+				targetIds: ["fresh"],
+			},
+		]);
 	});
 });
 
@@ -166,6 +183,36 @@ describe("orphan-registry — reap", () => {
 
 		expect(count).toBe(2);
 		expect(closed.sort()).toEqual(["orphan-1", "orphan-2"]);
+		expect(await Bun.file(path.join(registryDir(scope), `${dead}.json`)).exists()).toBe(false);
+	});
+
+	it("retains transient CDP failures and retries them on the next reap", async () => {
+		const scope = trackedScope();
+		const dead = await deadPid();
+		const updatedAt = Date.now() - 60_000;
+		await writeOwnershipFile(scope, {
+			pid: dead,
+			updatedAt,
+			targets: ["closed-now", "retry-later"],
+		});
+		const firstClosed: string[] = [];
+
+		const firstCount = await reapOrphanSharedTargets(makeBrowser(firstClosed, new Set(["retry-later"])), scope);
+
+		expect(firstCount).toBe(1);
+		expect(firstClosed).toEqual(["closed-now"]);
+		const retained = (await Bun.file(path.join(registryDir(scope), `${dead}.json`)).json()) as {
+			pid: number;
+			updatedAt: number;
+			targets: string[];
+		};
+		expect(retained).toEqual({ pid: dead, updatedAt, targets: ["retry-later"] });
+
+		const retryClosed: string[] = [];
+		const retryCount = await reapOrphanSharedTargets(makeBrowser(retryClosed), scope);
+
+		expect(retryCount).toBe(1);
+		expect(retryClosed).toEqual(["retry-later"]);
 		expect(await Bun.file(path.join(registryDir(scope), `${dead}.json`)).exists()).toBe(false);
 	});
 });

--- a/packages/coding-agent/test/tools/browser-orphan-registry.test.ts
+++ b/packages/coding-agent/test/tools/browser-orphan-registry.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Regression tests for issue #10022: the project-shared broker-owned Chromium
+ * (`omp.browser.headless`) retains page targets created by omp processes that
+ * ended abnormally, because tab ownership was tracked only in per-process
+ * memory. `orphan-registry` records ownership durably and reaps targets whose
+ * owning process is gone.
+ *
+ * The contract under test:
+ *  - a dead owner's targets are collected for reaping, a live owner's are not;
+ *  - this process's own targets are never reaped (a live session keeps its tabs);
+ *  - a conservative grace window keeps a just-crashed owner's fresh records;
+ *  - `reapOrphanSharedTargets` closes the dead targets via CDP and deletes the
+ *    ownership file.
+ */
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { daemonRuntimeDir } from "@oh-my-pi/pi-coding-agent/launch/paths";
+import {
+	collectOrphanTargets,
+	forgetSharedTarget,
+	reapOrphanSharedTargets,
+	recordSharedTarget,
+	resetOrphanRegistryForTest,
+	type SharedTargetScope,
+} from "@oh-my-pi/pi-coding-agent/tools/browser/orphan-registry";
+import type { Browser } from "puppeteer-core";
+
+const DAEMON_NAME = "omp.browser.headless";
+
+/** Unique per-test scope so registry dirs never collide across the suite. */
+function makeScope(): SharedTargetScope {
+	const projectDir = path.join("/tmp", `omp-orphan-test-${crypto.randomUUID()}`);
+	return { projectDir, daemonName: DAEMON_NAME };
+}
+
+function registryDir(scope: SharedTargetScope): string {
+	return path.join(daemonRuntimeDir(scope.projectDir), `${scope.daemonName}.targets`);
+}
+
+async function writeOwnershipFile(
+	scope: SharedTargetScope,
+	record: { pid: number; updatedAt: number; targets: string[] },
+): Promise<void> {
+	const dir = registryDir(scope);
+	await fs.mkdir(dir, { recursive: true });
+	await Bun.write(path.join(dir, `${record.pid}.json`), JSON.stringify(record));
+}
+
+/** A pid that has been spawned and reaped, so `kill(pid, 0)` reports ESRCH. */
+async function deadPid(): Promise<number> {
+	const proc = Bun.spawn(["true"], { stdout: "ignore", stderr: "ignore" });
+	await proc.exited;
+	return proc.pid;
+}
+
+/** Minimal puppeteer Browser stub recording which target ids get closed via CDP. */
+function makeBrowser(closed: string[]): Browser {
+	const session = {
+		send: async (_method: string, params: { targetId: string }) => {
+			closed.push(params.targetId);
+		},
+		detach: async () => undefined,
+	};
+	return {
+		target: () => ({ createCDPSession: async () => session }),
+	} as unknown as Browser;
+}
+
+const scopes: SharedTargetScope[] = [];
+function trackedScope(): SharedTargetScope {
+	const scope = makeScope();
+	scopes.push(scope);
+	return scope;
+}
+
+afterEach(async () => {
+	resetOrphanRegistryForTest();
+	for (const scope of scopes.splice(0)) {
+		await fs.rm(daemonRuntimeDir(scope.projectDir), { recursive: true, force: true }).catch(() => undefined);
+	}
+});
+
+describe("orphan-registry — ownership scan", () => {
+	it("collects a dead owner's targets and leaves a live owner's untouched", async () => {
+		const scope = trackedScope();
+		const dead = await deadPid();
+		const live = 424242; // treated as alive by the injected probe below
+		await writeOwnershipFile(scope, { pid: dead, updatedAt: 0, targets: ["dead-a", "dead-b"] });
+		await writeOwnershipFile(scope, { pid: live, updatedAt: 0, targets: ["live-a"] });
+
+		const scan = await collectOrphanTargets(scope, {
+			now: () => 10_000_000,
+			isAlive: pid => pid === live,
+		});
+
+		expect(scan.targetIds.sort()).toEqual(["dead-a", "dead-b"]);
+		expect(scan.targetIds).not.toContain("live-a");
+		expect(scan.staleFiles).toEqual([path.join(registryDir(scope), `${dead}.json`)]);
+	});
+
+	it("never reaps this process's own recorded targets", async () => {
+		const scope = trackedScope();
+		await recordSharedTarget(scope, "mine-1");
+		await recordSharedTarget(scope, "mine-2");
+
+		// Our own file is present on disk...
+		const own = (await Bun.file(path.join(registryDir(scope), `${process.pid}.json`)).json()) as {
+			targets: string[];
+		};
+		expect(own.targets.sort()).toEqual(["mine-1", "mine-2"]);
+
+		// ...but a scan (even with everything else forced dead) skips it.
+		const scan = await collectOrphanTargets(scope, { now: () => 10_000_000, isAlive: () => false });
+		expect(scan.targetIds).toEqual([]);
+		expect(scan.staleFiles).toEqual([]);
+	});
+
+	it("forgetSharedTarget drops one id and removes the file once empty", async () => {
+		const scope = trackedScope();
+		await recordSharedTarget(scope, "a");
+		await recordSharedTarget(scope, "b");
+		await forgetSharedTarget(scope, "a");
+		const after = (await Bun.file(path.join(registryDir(scope), `${process.pid}.json`)).json()) as {
+			targets: string[];
+		};
+		expect(after.targets).toEqual(["b"]);
+
+		await forgetSharedTarget(scope, "b");
+		expect(await Bun.file(path.join(registryDir(scope), `${process.pid}.json`)).exists()).toBe(false);
+	});
+
+	it("keeps a dead owner's records inside the conservative grace window", async () => {
+		const scope = trackedScope();
+		const dead = await deadPid();
+		await writeOwnershipFile(scope, { pid: dead, updatedAt: 100_000, targets: ["fresh"] });
+
+		const withinGrace = await collectOrphanTargets(scope, {
+			now: () => 105_000,
+			isAlive: () => false,
+			graceMs: 15_000,
+		});
+		expect(withinGrace.targetIds).toEqual([]);
+
+		const pastGrace = await collectOrphanTargets(scope, {
+			now: () => 130_000,
+			isAlive: () => false,
+			graceMs: 15_000,
+		});
+		expect(pastGrace.targetIds).toEqual(["fresh"]);
+	});
+});
+
+describe("orphan-registry — reap", () => {
+	it("closes a dead owner's targets via CDP and deletes its ownership file", async () => {
+		const scope = trackedScope();
+		const dead = await deadPid();
+		await writeOwnershipFile(scope, {
+			pid: dead,
+			updatedAt: Date.now() - 60_000,
+			targets: ["orphan-1", "orphan-2"],
+		});
+		const closed: string[] = [];
+
+		const count = await reapOrphanSharedTargets(makeBrowser(closed), scope);
+
+		expect(count).toBe(2);
+		expect(closed.sort()).toEqual(["orphan-1", "orphan-2"]);
+		expect(await Bun.file(path.join(registryDir(scope), `${dead}.json`)).exists()).toBe(false);
+	});
+});


### PR DESCRIPTION
## Repro
The project-shared broker-owned Chromium (`omp.browser.headless`) is durable and shared across every omp process, but tab ownership is tracked only in each process's in-memory `tabs` map (`tab-supervisor.ts`). A session that ends abnormally (crash, SIGKILL, cleanup timeout) never runs `releaseTabsForOwner`, so the pages it opened stay open in the shared browser and accumulate as orphaned targets for as long as any client keeps the daemon alive — the reporter observed 48 pages / 96 iframes / 18 shared workers and ~9.3 GB after 6 days. This host lacks Chrome's system libraries, so I reproduced the ownership-gap logic deterministically (durable shared target set + per-session process-local cleanup):

```
bun /tmp/repro-10022.mjs
Durable shared browser target count: 49
Orphaned targets from dead sessions: 48
After a fresh session opens+disposes, shared count: 49
REPRODUCED: orphaned targets accumulate unbounded in the shared browser.
```

## Cause
Ownership is process-local. `tab-supervisor.ts` records each tab's `ownerSessionId` in the module-global `tabs` map, and cleanup (`releaseTab` / `releaseTabsForOwner`, invoked from `AgentSession.dispose()`) walks only that in-process map. When the process dies without disposal, the map dies with it while the page targets it created in the broker-owned Chromium remain open. There was no broker-level/durable ownership record and no orphan reaper (`registry.ts` `openSharedHeadlessHandle` just connects; `disposeBrowserHandle` only disconnects for shared handles).

## Fix
- New `tools/browser/orphan-registry.ts`: durable per-process ownership files under the broker runtime dir (`<daemon>.targets/<pid>.json`). `recordSharedTarget` / `forgetSharedTarget` maintain this process's set; `collectOrphanTargets` returns targets whose owner PID reports `ESRCH` (dead) past a conservative grace window; `reapOrphanSharedTargets` closes them via CDP and prunes the files. Liveness errs safe — a live owner (or non-`ESRCH` probe failure) is never reaped, so a running session's tabs are never yanked.
- `tab-supervisor.ts`: record ownership when a shared-headless tab is created, forget it on normal close and forced kill; `closeTargetById` now delegates to the shared `closeCdpTarget`.
- `registry.ts`: `openSharedHeadlessHandle` fires a detached `reapOrphanSharedTargets` on attach — the natural bounding point, no background timer. Only OMP-owned shared-headless targets are scanned; connected/relay/spawned browsers are untouched.

## Verification
`bun test packages/coding-agent/test/tools/browser-orphan-registry.test.ts` (5 pass) covers the contract: dead-owner targets collected, live-owner and own-process targets never reaped, grace window respected, and `reapOrphanSharedTargets` closing via CDP + pruning the file. `bun test packages/coding-agent/test/tools/browser-lifecycle-leak.test.ts` and the other browser suites remain green; full `bun run fix` + `bun check` pass via the pre-publish gate. Fixes #10022