### PR TITLE
feat(coding-agent): expose session getTree and navigation tree over RPC

### DIFF
--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -180,8 +180,21 @@ correlate it via `id`. Ordering across concurrent commands is not guaranteed
 - `{ id?, type: "branch", entryId: string }`
 - `{ id?, type: "get_branch_messages" }`
 - `{ id?, type: "get_last_assistant_text" }`
+- `{ id?, type: "get_tree" }`
+- `{ id?, type: "get_navigation_tree", filter?: "default" | "no-tools" | "user-only" | "labeled-only" | "all", search?: string }`
 - `{ id?, type: "set_session_name", name: string }`
 - `{ id?, type: "handoff", customInstructions?: string }`
+
+`get_tree` returns the raw session tree: `leafId` plus the nested
+`SessionTreeNode` projection (`entry`, `children`, resolved `label`) from
+`SessionManager.getTree()`. `get_navigation_tree` returns the flattened rows
+the `/tree` selector renders for the same session: active branch first,
+connector geometry (`indent`, `showConnector`, `isLast`, `gutters`,
+`isVirtualRootChild`), `onActivePath` / `isLeaf` markers, and a `preview` of
+the same searchable text the selector indexes (capped at 200 chars). `filter`
+applies the selector's filter modes (default `"default"`) and `search` its
+tokenized fuzzy search; `totalNodes` reports the row count before filtering.
+An unknown `filter` fails the command with code `invalid_filter`.
 
 ### Messages
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- RPC clients can read the session tree via `get_tree` (raw `SessionManager.getTree()` snapshot) and `get_navigation_tree` (the flattened, filterable projection the `/tree` selector renders, with server-side filter modes and fuzzy search).
+
 ## [18.0.8] - 2026-08-27
 
 ### Added

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- RPC clients can read the session tree via `get_tree` (raw `SessionManager.getTree()` snapshot) and `get_navigation_tree` (the flattened, filterable projection the `/tree` selector renders, with server-side filter modes and fuzzy search).
+- RPC clients can read the session tree via `get_tree` (raw `SessionManager.getTree()` snapshot) and `get_navigation_tree` (the flattened, filterable projection the `/tree` selector renders, with server-side filter modes and fuzzy search) ([#10026](https://github.com/can1357/oh-my-pi/pull/10026) by [@Giardi77](https://github.com/Giardi77)).
 
 ## [18.0.8] - 2026-08-27
 

--- a/packages/coding-agent/src/modes/components/index.ts
+++ b/packages/coding-agent/src/modes/components/index.ts
@@ -34,6 +34,7 @@ export * from "./thinking-selector";
 export * from "./tiny-title-download-progress";
 export * from "./todo-reminder";
 export * from "./tool-execution";
+export * from "./tree-model";
 export * from "./tree-selector";
 export * from "./ttsr-notification";
 export * from "./user-message";

--- a/packages/coding-agent/src/modes/components/tree-model.ts
+++ b/packages/coding-agent/src/modes/components/tree-model.ts
@@ -1,0 +1,481 @@
+/**
+ * Pure session-tree navigation model: flattening, active-path resolution,
+ * filter modes, and searchable text. Shared by the interactive `/tree`
+ * selector (`tree-selector.ts`) and the RPC `get_navigation_tree` handler so
+ * remote clients see the same rows the TUI renders.
+ */
+import { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
+import { fuzzyMatch } from "@oh-my-pi/pi-tui";
+import { isRecord, sanitizeText } from "@oh-my-pi/pi-utils";
+import type { TreeFilterMode } from "../../config/settings-schema";
+import type { SessionEntry, SessionTreeNode } from "../../session/session-entries";
+import { canonicalizeMessage } from "../../utils/thinking-display";
+
+/** Gutter info: position (displayIndent where connector was) and whether to show │ */
+export interface GutterInfo {
+	position: number; // displayIndent level where the connector was shown
+	show: boolean; // true = show │, false = show spaces
+}
+
+/** Flattened tree node for navigation */
+export interface FlatNode {
+	node: SessionTreeNode;
+	/** Indentation level (each level = 3 chars) */
+	indent: number;
+	/** Whether to show connector (├─ or └─) - true if parent has multiple children */
+	showConnector: boolean;
+	/** If showConnector, true = last sibling (└─), false = not last (├─) */
+	isLast: boolean;
+	/** Gutter info for each ancestor branch point */
+	gutters: GutterInfo[];
+	/** True if this node is a root under a virtual branching root (multiple roots) */
+	isVirtualRootChild: boolean;
+}
+
+/** Tool call info for lookup */
+export interface ToolCallInfo {
+	name: string;
+	arguments: Record<string, unknown>;
+}
+
+/** Advisor note metadata surfaced on a single session-tree row. */
+export interface AdvisorTreeDisplay {
+	/** Non-default advisor names then severities, comma-joined (e.g. `sec, blocker`). */
+	qualifier: string;
+	/** Note bodies joined into one line. */
+	text: string;
+}
+
+/** Per-message cap on text folded into the tree search index. */
+export const SEARCH_TEXT_LIMIT = 200;
+
+/**
+ * Collapse a raw advisor field (a `WATCHDOG.yml`-supplied name or severity) to
+ * a single safe line: strip ANSI/control characters via the shared sanitizer,
+ * then fold the tab/newline it intentionally preserves into spaces so the value
+ * cannot split or misalign a session-tree row.
+ */
+function sanitizeAdvisorField(value: string): string {
+	return sanitizeText(value)
+		.replace(/[\n\t]/g, " ")
+		.trim();
+}
+
+/**
+ * Extract display metadata from an advisor custom-message's `details.notes`,
+ * ignoring the model-facing `<advisory>` wrapper stored in `content`. Collects
+ * distinct non-default advisor names and severities so the tree row can tag the
+ * note the way its transcript card does.
+ */
+export function advisorTreeDisplay(details: unknown): AdvisorTreeDisplay {
+	if (!isRecord(details) || !Array.isArray(details.notes)) return { qualifier: "", text: "" };
+	const notes: string[] = [];
+	const advisors: string[] = [];
+	const severities: string[] = [];
+	for (const note of details.notes) {
+		if (!isRecord(note)) continue;
+		if (typeof note.note === "string") notes.push(note.note);
+		if (typeof note.advisor === "string") {
+			const name = sanitizeAdvisorField(note.advisor);
+			if (name && name !== "default" && !advisors.includes(name)) advisors.push(name);
+		}
+		if (typeof note.severity === "string") {
+			const severity = sanitizeAdvisorField(note.severity);
+			if (severity && !severities.includes(severity)) severities.push(severity);
+		}
+	}
+	return { qualifier: [...advisors, ...severities].join(", "), text: notes.join(" ") };
+}
+
+/**
+ * Strip one model-facing `<system-*>` envelope from custom-message content.
+ * Nested system tags belong to the recorded payload and remain visible.
+ */
+export function stripSystemWrapperTags(content: string): string {
+	const trimmed = content.trim();
+	const opening = /^<(system-[\w-]+)/i.exec(trimmed);
+	if (!opening) return content;
+
+	const attributeStart = opening[0].length;
+	const firstAttributeCharacter = trimmed[attributeStart];
+	if (firstAttributeCharacter !== ">" && !/\s/.test(firstAttributeCharacter ?? "")) return content;
+
+	let quote: '"' | "'" | undefined;
+	let openingEnd = -1;
+	for (let index = attributeStart; index < trimmed.length; index++) {
+		const character = trimmed[index];
+		if (quote) {
+			if (character === quote) quote = undefined;
+		} else if (character === '"' || character === "'") {
+			quote = character;
+		} else if (character === "<") {
+			return content;
+		} else if (character === ">") {
+			openingEnd = index;
+			break;
+		}
+	}
+	if (openingEnd === -1 || quote) return content;
+
+	const closingTag = `</${opening[1]}>`;
+	const closingStart = trimmed.length - closingTag.length;
+	if (closingStart <= openingEnd || trimmed.slice(closingStart).toLowerCase() !== closingTag.toLowerCase()) {
+		return content;
+	}
+	return trimmed.slice(openingEnd + 1, closingStart).trim();
+}
+
+/** Concatenate every text block (or return a string as-is) with no length cap. */
+export function joinTextContent(content: unknown): string {
+	if (typeof content === "string") return content;
+	if (Array.isArray(content)) {
+		let result = "";
+		for (const c of content) {
+			if (
+				typeof c === "object" &&
+				c !== null &&
+				"type" in c &&
+				c.type === "text" &&
+				"text" in c &&
+				typeof c.text === "string"
+			) {
+				result += c.text;
+			}
+		}
+		return result;
+	}
+	return "";
+}
+
+export function extractContent(content: unknown): string {
+	return joinTextContent(content).slice(0, SEARCH_TEXT_LIMIT);
+}
+
+export function hasTextContent(content: unknown): boolean {
+	if (typeof content === "string") return Boolean(canonicalizeMessage(content));
+	if (Array.isArray(content)) {
+		for (const c of content) {
+			if (typeof c === "object" && c !== null && "type" in c && c.type === "text") {
+				const text = (c as { text?: string }).text;
+				if (text && canonicalizeMessage(text)) return true;
+			}
+		}
+	}
+	return false;
+}
+
+/**
+ * Flatten the session tree for navigation: active branch first, real branch
+ * points add one indentation level, and multiple roots nest under a virtual
+ * branching root. Also collects the tool-call lookup used to render toolResult
+ * rows. Pure projection — the session tree is not mutated.
+ */
+export function flattenSessionTree(
+	roots: SessionTreeNode[],
+	currentLeafId: string | null,
+): { flatNodes: FlatNode[]; toolCallMap: Map<string, ToolCallInfo> } {
+	const result: FlatNode[] = [];
+	const toolCallMap = new Map<string, ToolCallInfo>();
+
+	// A real branch point adds one indentation level. Linear conversation
+	// chains retain that level so their text stays aligned with the branch
+	// head instead of drifting right after every fork.
+
+	// Stack items: [node, indent, showConnector, isLast, gutters, isVirtualRootChild]
+	type StackItem = [SessionTreeNode, number, boolean, boolean, GutterInfo[], boolean];
+	const stack: StackItem[] = [];
+
+	// Determine which subtrees contain the active leaf (to sort current branch first)
+	// Use iterative post-order traversal to avoid stack overflow
+	const containsActive = new Map<SessionTreeNode, boolean>();
+	const leafId = currentLeafId;
+	{
+		// Build list in pre-order, then process in reverse for post-order effect
+		const allNodes: SessionTreeNode[] = [];
+		const preOrderStack: SessionTreeNode[] = [...roots];
+		while (preOrderStack.length > 0) {
+			const node = preOrderStack.pop()!;
+			allNodes.push(node);
+			// Push children in reverse so they're processed left-to-right
+			for (let i = node.children.length - 1; i >= 0; i--) {
+				preOrderStack.push(node.children[i]);
+			}
+		}
+		// Process in reverse (post-order): children before parents
+		for (let i = allNodes.length - 1; i >= 0; i--) {
+			const node = allNodes[i];
+			let has = leafId !== null && node.entry.id === leafId;
+			for (const child of node.children) {
+				if (containsActive.get(child)) {
+					has = true;
+				}
+			}
+			containsActive.set(node, has);
+		}
+	}
+
+	// Add roots in reverse order, prioritizing the one containing the active leaf
+	// If multiple roots, treat them as children of a virtual root that branches
+	const multipleRoots = roots.length > 1;
+	const orderedRoots = [...roots].sort((a, b) => Number(containsActive.get(b)) - Number(containsActive.get(a)));
+	for (let i = orderedRoots.length - 1; i >= 0; i--) {
+		const isLast = i === orderedRoots.length - 1;
+		stack.push([orderedRoots[i], multipleRoots ? 1 : 0, multipleRoots, isLast, [], multipleRoots]);
+	}
+
+	while (stack.length > 0) {
+		const [node, indent, showConnector, isLast, gutters, isVirtualRootChild] = stack.pop()!;
+
+		// Extract tool calls from assistant messages for later lookup
+		const entry = node.entry;
+		if (entry.type === "message" && entry.message.role === "assistant") {
+			const content = (entry.message as { content?: unknown }).content;
+			if (Array.isArray(content)) {
+				for (const block of content) {
+					if (typeof block === "object" && block !== null && "type" in block && block.type === "toolCall") {
+						const tc = block as { id: string; name: string; arguments: Record<string, unknown> };
+						toolCallMap.set(tc.id, { name: tc.name, arguments: tc.arguments });
+					}
+				}
+			}
+		}
+
+		result.push({ node, indent, showConnector, isLast, gutters, isVirtualRootChild });
+
+		const children = node.children;
+		const multipleChildren = children.length > 1;
+
+		// Order children so the branch containing the active leaf comes first
+		const orderedChildren = (() => {
+			const prioritized: SessionTreeNode[] = [];
+			const rest: SessionTreeNode[] = [];
+			for (const child of children) {
+				if (containsActive.get(child)) {
+					prioritized.push(child);
+				} else {
+					rest.push(child);
+				}
+			}
+			return [...prioritized, ...rest];
+		})();
+
+		// Real branch points add visual depth, and a virtual root's direct
+		// children (the session roots) nest one level under the shared column-0
+		// root. Linear continuations otherwise stay aligned with their head.
+		const childIndent = multipleChildren || isVirtualRootChild ? indent + 1 : indent;
+
+		// Build gutters for children
+		// If this node showed a connector, add a gutter entry for descendants
+		// Only add gutter if connector is actually displayed (not suppressed for virtual root children)
+		const connectorDisplayed = showConnector && !isVirtualRootChild;
+		// When connector is displayed, add a gutter entry at the connector's position
+		// Connector is at position (displayIndent - 1), so gutter should be there too
+		const currentDisplayIndent = multipleRoots ? Math.max(0, indent - 1) : indent;
+		const connectorPosition = Math.max(0, currentDisplayIndent - 1);
+		const childGutters: GutterInfo[] = connectorDisplayed
+			? [...gutters, { position: connectorPosition, show: !isLast }]
+			: gutters;
+
+		// Add children in reverse order
+		for (let i = orderedChildren.length - 1; i >= 0; i--) {
+			const childIsLast = i === orderedChildren.length - 1;
+			stack.push([orderedChildren[i], childIndent, multipleChildren, childIsLast, childGutters, false]);
+		}
+	}
+
+	return { flatNodes: result, toolCallMap };
+}
+
+/** Build the set of entry IDs on the path from root to current leaf. */
+export function buildActivePathIds(flatNodes: FlatNode[], currentLeafId: string | null): Set<string> {
+	const activePathIds = new Set<string>();
+	if (!currentLeafId) return activePathIds;
+
+	// Build a map of id -> entry for parent lookup
+	const entryMap = new Map<string, FlatNode>();
+	for (const flatNode of flatNodes) {
+		entryMap.set(flatNode.node.entry.id, flatNode);
+	}
+
+	// Walk from leaf to root
+	let currentId: string | null = currentLeafId;
+	while (currentId) {
+		activePathIds.add(currentId);
+		const node = entryMap.get(currentId);
+		if (!node) break;
+		currentId = node.node.entry.parentId ?? null;
+	}
+	return activePathIds;
+}
+
+/**
+ * Entry types hidden in default view (settings/bookkeeping). These carry
+ * no conversation content, so the tree only shows them in "all" mode.
+ */
+function isSettingsEntry(entry: SessionEntry): boolean {
+	return (
+		entry.type === "label" ||
+		entry.type === "custom" ||
+		entry.type === "model_change" ||
+		entry.type === "thinking_level_change" ||
+		entry.type === "service_tier_change" ||
+		entry.type === "title_change" ||
+		entry.type === "credential_pin" ||
+		entry.type === "session_init" ||
+		entry.type === "ttsr_injection" ||
+		entry.type === "mode_change" ||
+		entry.type === "reset_boundary"
+	);
+}
+
+/** Get searchable text content from a node */
+export function getSearchableText(node: SessionTreeNode): string {
+	const entry = node.entry;
+	const parts: string[] = [];
+
+	if (node.label) {
+		parts.push(node.label);
+	}
+
+	switch (entry.type) {
+		case "message": {
+			const msg = entry.message;
+			parts.push(msg.role);
+			if ("content" in msg && msg.content) {
+				parts.push(extractContent(msg.content));
+			}
+			if (msg.role === "bashExecution") {
+				const bashMsg = msg as { command?: string };
+				if (bashMsg.command) parts.push(bashMsg.command);
+			}
+			break;
+		}
+		case "custom_message": {
+			parts.push(entry.customType);
+			if (entry.customType === "advisor") {
+				const { qualifier, text } = advisorTreeDisplay(entry.details);
+				if (qualifier) parts.push(qualifier);
+				if (text) parts.push(text);
+			} else {
+				const content = stripSystemWrapperTags(joinTextContent(entry.content)).slice(0, SEARCH_TEXT_LIMIT);
+				if (content) parts.push(content);
+			}
+			break;
+		}
+		case "compaction":
+			parts.push("compaction");
+			break;
+		case "branch_summary":
+			parts.push("branch summary", entry.summary);
+			break;
+		case "model_change":
+			parts.push("model", entry.model);
+			break;
+		case "thinking_level_change":
+			parts.push("thinking", entry.thinkingLevel ?? ThinkingLevel.Off);
+			break;
+		case "custom":
+			parts.push("custom", entry.customType);
+			break;
+		case "label":
+			parts.push("label", entry.label ?? "");
+			break;
+		case "service_tier_change":
+			parts.push("service tier");
+			if (entry.serviceTier) {
+				const serviceTier = entry.serviceTier;
+				for (const family in serviceTier) {
+					const tier = serviceTier[family as keyof typeof serviceTier];
+					if (tier) parts.push(family, tier);
+				}
+			}
+			break;
+		case "title_change":
+			parts.push("title", entry.title);
+			break;
+		case "mode_change":
+			parts.push("mode", entry.mode);
+			break;
+		case "credential_pin":
+			parts.push("credential pin", entry.provider);
+			break;
+		case "ttsr_injection":
+			parts.push("ttsr injection", ...entry.injectedRules);
+			break;
+		case "reset_boundary":
+			parts.push("reset boundary");
+			break;
+		case "session_init":
+			parts.push("session init");
+			break;
+	}
+
+	return parts.join(" ");
+}
+
+/**
+ * Apply a filter mode and optional search query to flattened nodes, matching
+ * the `/tree` selector semantics: tool-only assistant messages are hidden
+ * unless errored/aborted or the current leaf, filter modes drop bookkeeping
+ * entry types, and search tokens must all fuzzy-match the searchable text.
+ */
+export function filterFlatNodes(
+	flatNodes: FlatNode[],
+	options: { mode: TreeFilterMode; searchQuery?: string; currentLeafId: string | null },
+): FlatNode[] {
+	const { mode, currentLeafId } = options;
+	const searchTokens = (options.searchQuery ?? "").toLowerCase().split(/\s+/).filter(Boolean);
+
+	return flatNodes.filter(flatNode => {
+		const entry = flatNode.node.entry;
+		const isCurrentLeaf = entry.id === currentLeafId;
+
+		// Skip assistant messages with only tool calls (no text) unless error/aborted
+		// Always show current leaf so active position is visible
+		if (entry.type === "message" && entry.message.role === "assistant" && !isCurrentLeaf) {
+			const msg = entry.message as { stopReason?: string; content?: unknown };
+			const hasText = hasTextContent(msg.content);
+			const isErrorOrAborted = msg.stopReason && msg.stopReason !== "stop" && msg.stopReason !== "toolUse";
+			// Only hide if no text AND not an error/aborted message
+			if (!hasText && !isErrorOrAborted) {
+				return false;
+			}
+		}
+
+		// Apply filter mode
+		let passesFilter = true;
+		switch (mode) {
+			case "user-only":
+				// Just user messages
+				passesFilter = entry.type === "message" && entry.message.role === "user";
+				break;
+			case "no-tools":
+				// Default minus tool results
+				passesFilter =
+					!isSettingsEntry(entry) && !(entry.type === "message" && entry.message.role === "toolResult");
+				break;
+			case "labeled-only":
+				// Just labeled entries
+				passesFilter = flatNode.node.label !== undefined;
+				break;
+			case "all":
+				// Show everything
+				passesFilter = true;
+				break;
+			default:
+				// Default mode: hide settings/bookkeeping entries
+				passesFilter = !isSettingsEntry(entry);
+				break;
+		}
+
+		if (!passesFilter) return false;
+
+		// Apply fuzzy search filter
+		if (searchTokens.length > 0) {
+			const nodeText = getSearchableText(flatNode.node);
+			return searchTokens.every(token => fuzzyMatch(token, nodeText).matches);
+		}
+
+		return true;
+	});
+}

--- a/packages/coding-agent/src/modes/components/tree-selector.ts
+++ b/packages/coding-agent/src/modes/components/tree-selector.ts
@@ -3,14 +3,12 @@ import {
 	type Component,
 	Container,
 	extractPrintableText,
-	fuzzyMatch,
 	Input,
 	matchesKey,
 	Spacer,
 	TruncatedText,
 	truncateToWidth,
 } from "@oh-my-pi/pi-tui";
-import { isRecord, sanitizeText } from "@oh-my-pi/pi-utils";
 import type { TreeFilterMode } from "../../config/settings-schema";
 import { theme } from "../../modes/theme/theme";
 import {
@@ -23,31 +21,20 @@ import {
 import type { SessionTreeNode } from "../../session/session-entries";
 import { toPathList } from "../../tools/path-utils";
 import { shortenPath } from "../../tools/render-utils";
-import { canonicalizeMessage } from "../../utils/thinking-display";
 import { resolveAssistantErrorPresentation } from "../utils/transcript-render-helpers";
 import { OverlayPanel, PanelDivider } from "./overlay-box";
 import { centeredWindow, contentRowWidth, renderScrollableList } from "./selector-helpers";
-
-/** Gutter info: position (displayIndent where connector was) and whether to show │ */
-interface GutterInfo {
-	position: number; // displayIndent level where the connector was shown
-	show: boolean; // true = show │, false = show spaces
-}
-
-/** Flattened tree node for navigation */
-interface FlatNode {
-	node: SessionTreeNode;
-	/** Indentation level (each level = 3 chars) */
-	indent: number;
-	/** Whether to show connector (├─ or └─) - true if parent has multiple children */
-	showConnector: boolean;
-	/** If showConnector, true = last sibling (└─), false = not last (├─) */
-	isLast: boolean;
-	/** Gutter info for each ancestor branch point */
-	gutters: GutterInfo[];
-	/** True if this node is a root under a virtual branching root (multiple roots) */
-	isVirtualRootChild: boolean;
-}
+import {
+	advisorTreeDisplay,
+	buildActivePathIds,
+	extractContent,
+	type FlatNode,
+	filterFlatNodes,
+	flattenSessionTree,
+	joinTextContent,
+	stripSystemWrapperTags,
+	type ToolCallInfo,
+} from "./tree-model";
 
 /** Filter mode for tree display */
 type FilterMode = TreeFilterMode;
@@ -55,99 +42,6 @@ type FilterMode = TreeFilterMode;
 /**
  * Tree list component with selection and ASCII art visualization
  */
-/** Tool call info for lookup */
-interface ToolCallInfo {
-	name: string;
-	arguments: Record<string, unknown>;
-}
-
-/** Advisor note metadata surfaced on a single session-tree row. */
-interface AdvisorTreeDisplay {
-	/** Non-default advisor names then severities, comma-joined (e.g. `sec, blocker`). */
-	qualifier: string;
-	/** Note bodies joined into one line. */
-	text: string;
-}
-
-/**
- * Collapse a raw advisor field (a `WATCHDOG.yml`-supplied name or severity) to
- * a single safe line: strip ANSI/control characters via the shared sanitizer,
- * then fold the tab/newline it intentionally preserves into spaces so the value
- * cannot split or misalign a session-tree row.
- */
-function sanitizeAdvisorField(value: string): string {
-	return sanitizeText(value)
-		.replace(/[\n\t]/g, " ")
-		.trim();
-}
-
-/**
- * Extract display metadata from an advisor custom-message's `details.notes`,
- * ignoring the model-facing `<advisory>` wrapper stored in `content`. Collects
- * distinct non-default advisor names and severities so the tree row can tag the
- * note the way its transcript card does.
- */
-function advisorTreeDisplay(details: unknown): AdvisorTreeDisplay {
-	if (!isRecord(details) || !Array.isArray(details.notes)) return { qualifier: "", text: "" };
-	const notes: string[] = [];
-	const advisors: string[] = [];
-	const severities: string[] = [];
-	for (const note of details.notes) {
-		if (!isRecord(note)) continue;
-		if (typeof note.note === "string") notes.push(note.note);
-		if (typeof note.advisor === "string") {
-			const name = sanitizeAdvisorField(note.advisor);
-			if (name && name !== "default" && !advisors.includes(name)) advisors.push(name);
-		}
-		if (typeof note.severity === "string") {
-			const severity = sanitizeAdvisorField(note.severity);
-			if (severity && !severities.includes(severity)) severities.push(severity);
-		}
-	}
-	return { qualifier: [...advisors, ...severities].join(", "), text: notes.join(" ") };
-}
-
-/**
- * Strip one model-facing `<system-*>` envelope from custom-message content.
- * Nested system tags belong to the recorded payload and remain visible.
- */
-function stripSystemWrapperTags(content: string): string {
-	const trimmed = content.trim();
-	const opening = /^<(system-[\w-]+)/i.exec(trimmed);
-	if (!opening) return content;
-
-	const attributeStart = opening[0].length;
-	const firstAttributeCharacter = trimmed[attributeStart];
-	if (firstAttributeCharacter !== ">" && !/\s/.test(firstAttributeCharacter ?? "")) return content;
-
-	let quote: '"' | "'" | undefined;
-	let openingEnd = -1;
-	for (let index = attributeStart; index < trimmed.length; index++) {
-		const character = trimmed[index];
-		if (quote) {
-			if (character === quote) quote = undefined;
-		} else if (character === '"' || character === "'") {
-			quote = character;
-		} else if (character === "<") {
-			return content;
-		} else if (character === ">") {
-			openingEnd = index;
-			break;
-		}
-	}
-	if (openingEnd === -1 || quote) return content;
-
-	const closingTag = `</${opening[1]}>`;
-	const closingStart = trimmed.length - closingTag.length;
-	if (closingStart <= openingEnd || trimmed.slice(closingStart).toLowerCase() !== closingTag.toLowerCase()) {
-		return content;
-	}
-	return trimmed.slice(openingEnd + 1, closingStart).trim();
-}
-
-/** Per-message cap on text folded into the tree search index. */
-const SEARCH_TEXT_LIMIT = 200;
-
 class TreeList implements Component {
 	#flatNodes: FlatNode[] = [];
 	#filteredNodes: FlatNode[] = [];
@@ -172,35 +66,16 @@ class TreeList implements Component {
 	) {
 		this.#filterMode = initialFilterMode;
 		this.#multipleRoots = tree.length > 1;
-		this.#flatNodes = this.#flattenTree(tree);
-		this.#buildActivePath();
+		const { flatNodes, toolCallMap } = flattenSessionTree(tree, this.currentLeafId);
+		this.#flatNodes = flatNodes;
+		this.#toolCallMap = toolCallMap;
+		this.#activePathIds = buildActivePathIds(this.#flatNodes, this.currentLeafId);
 		this.#applyFilter();
 
 		// Start with initialSelectedId if provided, otherwise current leaf
 		const targetId = initialSelectedId ?? currentLeafId;
 		this.#selectedIndex = this.#findNearestVisibleIndex(targetId);
 		this.#lastSelectedId = this.#filteredNodes[this.#selectedIndex]?.node.entry.id ?? null;
-	}
-
-	/** Build the set of entry IDs on the path from root to current leaf */
-	#buildActivePath(): void {
-		this.#activePathIds.clear();
-		if (!this.currentLeafId) return;
-
-		// Build a map of id -> entry for parent lookup
-		const entryMap = new Map<string, FlatNode>();
-		for (const flatNode of this.#flatNodes) {
-			entryMap.set(flatNode.node.entry.id, flatNode);
-		}
-
-		// Walk from leaf to root
-		let currentId: string | null = this.currentLeafId;
-		while (currentId) {
-			this.#activePathIds.add(currentId);
-			const node = entryMap.get(currentId);
-			if (!node) break;
-			currentId = node.node.entry.parentId ?? null;
-		}
 	}
 
 	/**
@@ -233,119 +108,6 @@ class TreeList implements Component {
 		return this.#filteredNodes.length - 1;
 	}
 
-	#flattenTree(roots: SessionTreeNode[]): FlatNode[] {
-		const result: FlatNode[] = [];
-		this.#toolCallMap.clear();
-
-		// A real branch point adds one indentation level. Linear conversation
-		// chains retain that level so their text stays aligned with the branch
-		// head instead of drifting right after every fork.
-
-		// Stack items: [node, indent, showConnector, isLast, gutters, isVirtualRootChild]
-		type StackItem = [SessionTreeNode, number, boolean, boolean, GutterInfo[], boolean];
-		const stack: StackItem[] = [];
-
-		// Determine which subtrees contain the active leaf (to sort current branch first)
-		// Use iterative post-order traversal to avoid stack overflow
-		const containsActive = new Map<SessionTreeNode, boolean>();
-		const leafId = this.currentLeafId;
-		{
-			// Build list in pre-order, then process in reverse for post-order effect
-			const allNodes: SessionTreeNode[] = [];
-			const preOrderStack: SessionTreeNode[] = [...roots];
-			while (preOrderStack.length > 0) {
-				const node = preOrderStack.pop()!;
-				allNodes.push(node);
-				// Push children in reverse so they're processed left-to-right
-				for (let i = node.children.length - 1; i >= 0; i--) {
-					preOrderStack.push(node.children[i]);
-				}
-			}
-			// Process in reverse (post-order): children before parents
-			for (let i = allNodes.length - 1; i >= 0; i--) {
-				const node = allNodes[i];
-				let has = leafId !== null && node.entry.id === leafId;
-				for (const child of node.children) {
-					if (containsActive.get(child)) {
-						has = true;
-					}
-				}
-				containsActive.set(node, has);
-			}
-		}
-
-		// Add roots in reverse order, prioritizing the one containing the active leaf
-		// If multiple roots, treat them as children of a virtual root that branches
-		const multipleRoots = roots.length > 1;
-		const orderedRoots = [...roots].sort((a, b) => Number(containsActive.get(b)) - Number(containsActive.get(a)));
-		for (let i = orderedRoots.length - 1; i >= 0; i--) {
-			const isLast = i === orderedRoots.length - 1;
-			stack.push([orderedRoots[i], multipleRoots ? 1 : 0, multipleRoots, isLast, [], multipleRoots]);
-		}
-
-		while (stack.length > 0) {
-			const [node, indent, showConnector, isLast, gutters, isVirtualRootChild] = stack.pop()!;
-
-			// Extract tool calls from assistant messages for later lookup
-			const entry = node.entry;
-			if (entry.type === "message" && entry.message.role === "assistant") {
-				const content = (entry.message as { content?: unknown }).content;
-				if (Array.isArray(content)) {
-					for (const block of content) {
-						if (typeof block === "object" && block !== null && "type" in block && block.type === "toolCall") {
-							const tc = block as { id: string; name: string; arguments: Record<string, unknown> };
-							this.#toolCallMap.set(tc.id, { name: tc.name, arguments: tc.arguments });
-						}
-					}
-				}
-			}
-
-			result.push({ node, indent, showConnector, isLast, gutters, isVirtualRootChild });
-
-			const children = node.children;
-			const multipleChildren = children.length > 1;
-
-			// Order children so the branch containing the active leaf comes first
-			const orderedChildren = (() => {
-				const prioritized: SessionTreeNode[] = [];
-				const rest: SessionTreeNode[] = [];
-				for (const child of children) {
-					if (containsActive.get(child)) {
-						prioritized.push(child);
-					} else {
-						rest.push(child);
-					}
-				}
-				return [...prioritized, ...rest];
-			})();
-
-			// Real branch points add visual depth, and a virtual root's direct
-			// children (the session roots) nest one level under the shared column-0
-			// root. Linear continuations otherwise stay aligned with their head.
-			const childIndent = multipleChildren || isVirtualRootChild ? indent + 1 : indent;
-
-			// Build gutters for children
-			// If this node showed a connector, add a gutter entry for descendants
-			// Only add gutter if connector is actually displayed (not suppressed for virtual root children)
-			const connectorDisplayed = showConnector && !isVirtualRootChild;
-			// When connector is displayed, add a gutter entry at the connector's position
-			// Connector is at position (displayIndent - 1), so gutter should be there too
-			const currentDisplayIndent = this.#multipleRoots ? Math.max(0, indent - 1) : indent;
-			const connectorPosition = Math.max(0, currentDisplayIndent - 1);
-			const childGutters: GutterInfo[] = connectorDisplayed
-				? [...gutters, { position: connectorPosition, show: !isLast }]
-				: gutters;
-
-			// Add children in reverse order
-			for (let i = orderedChildren.length - 1; i >= 0; i--) {
-				const childIsLast = i === orderedChildren.length - 1;
-				stack.push([orderedChildren[i], childIndent, multipleChildren, childIsLast, childGutters, false]);
-			}
-		}
-
-		return result;
-	}
-
 	#applyFilter(): void {
 		// Update lastSelectedId only when we have a valid selection (non-empty list)
 		// This preserves the selection when switching through empty filter results
@@ -353,73 +115,10 @@ class TreeList implements Component {
 			this.#lastSelectedId = this.#filteredNodes[this.#selectedIndex]?.node.entry.id ?? this.#lastSelectedId;
 		}
 
-		const searchTokens = this.#searchQuery.toLowerCase().split(/\s+/).filter(Boolean);
-
-		this.#filteredNodes = this.#flatNodes.filter(flatNode => {
-			const entry = flatNode.node.entry;
-			const isCurrentLeaf = entry.id === this.currentLeafId;
-
-			// Skip assistant messages with only tool calls (no text) unless error/aborted
-			// Always show current leaf so active position is visible
-			if (entry.type === "message" && entry.message.role === "assistant" && !isCurrentLeaf) {
-				const msg = entry.message as { stopReason?: string; content?: unknown };
-				const hasText = this.#hasTextContent(msg.content);
-				const isErrorOrAborted = msg.stopReason && msg.stopReason !== "stop" && msg.stopReason !== "toolUse";
-				// Only hide if no text AND not an error/aborted message
-				if (!hasText && !isErrorOrAborted) {
-					return false;
-				}
-			}
-
-			// Apply filter mode
-			let passesFilter = true;
-			// Entry types hidden in default view (settings/bookkeeping). These carry
-			// no conversation content, so the tree only shows them in "all" mode.
-			const isSettingsEntry =
-				entry.type === "label" ||
-				entry.type === "custom" ||
-				entry.type === "model_change" ||
-				entry.type === "thinking_level_change" ||
-				entry.type === "service_tier_change" ||
-				entry.type === "title_change" ||
-				entry.type === "credential_pin" ||
-				entry.type === "session_init" ||
-				entry.type === "ttsr_injection" ||
-				entry.type === "mode_change" ||
-				entry.type === "reset_boundary";
-
-			switch (this.#filterMode) {
-				case "user-only":
-					// Just user messages
-					passesFilter = entry.type === "message" && entry.message.role === "user";
-					break;
-				case "no-tools":
-					// Default minus tool results
-					passesFilter = !isSettingsEntry && !(entry.type === "message" && entry.message.role === "toolResult");
-					break;
-				case "labeled-only":
-					// Just labeled entries
-					passesFilter = flatNode.node.label !== undefined;
-					break;
-				case "all":
-					// Show everything
-					passesFilter = true;
-					break;
-				default:
-					// Default mode: hide settings/bookkeeping entries
-					passesFilter = !isSettingsEntry;
-					break;
-			}
-
-			if (!passesFilter) return false;
-
-			// Apply fuzzy search filter
-			if (searchTokens.length > 0) {
-				const nodeText = this.#getSearchableText(flatNode.node);
-				return searchTokens.every(token => fuzzyMatch(token, nodeText).matches);
-			}
-
-			return true;
+		this.#filteredNodes = filterFlatNodes(this.#flatNodes, {
+			mode: this.#filterMode,
+			searchQuery: this.#searchQuery,
+			currentLeafId: this.currentLeafId,
 		});
 
 		// Try to preserve cursor on the same node, or find nearest visible ancestor
@@ -434,91 +133,6 @@ class TreeList implements Component {
 		if (this.#filteredNodes.length > 0) {
 			this.#lastSelectedId = this.#filteredNodes[this.#selectedIndex]?.node.entry.id ?? this.#lastSelectedId;
 		}
-	}
-
-	/** Get searchable text content from a node */
-	#getSearchableText(node: SessionTreeNode): string {
-		const entry = node.entry;
-		const parts: string[] = [];
-
-		if (node.label) {
-			parts.push(node.label);
-		}
-
-		switch (entry.type) {
-			case "message": {
-				const msg = entry.message;
-				parts.push(msg.role);
-				if ("content" in msg && msg.content) {
-					parts.push(this.#extractContent(msg.content));
-				}
-				if (msg.role === "bashExecution") {
-					const bashMsg = msg as { command?: string };
-					if (bashMsg.command) parts.push(bashMsg.command);
-				}
-				break;
-			}
-			case "custom_message": {
-				parts.push(entry.customType);
-				if (entry.customType === "advisor") {
-					const { qualifier, text } = advisorTreeDisplay(entry.details);
-					if (qualifier) parts.push(qualifier);
-					if (text) parts.push(text);
-				} else {
-					const content = stripSystemWrapperTags(this.#joinTextContent(entry.content)).slice(0, SEARCH_TEXT_LIMIT);
-					if (content) parts.push(content);
-				}
-				break;
-			}
-			case "compaction":
-				parts.push("compaction");
-				break;
-			case "branch_summary":
-				parts.push("branch summary", entry.summary);
-				break;
-			case "model_change":
-				parts.push("model", entry.model);
-				break;
-			case "thinking_level_change":
-				parts.push("thinking", entry.thinkingLevel ?? ThinkingLevel.Off);
-				break;
-			case "custom":
-				parts.push("custom", entry.customType);
-				break;
-			case "label":
-				parts.push("label", entry.label ?? "");
-				break;
-			case "service_tier_change":
-				parts.push("service tier");
-				if (entry.serviceTier) {
-					const serviceTier = entry.serviceTier;
-					for (const family in serviceTier) {
-						const tier = serviceTier[family as keyof typeof serviceTier];
-						if (tier) parts.push(family, tier);
-					}
-				}
-				break;
-			case "title_change":
-				parts.push("title", entry.title);
-				break;
-			case "mode_change":
-				parts.push("mode", entry.mode);
-				break;
-			case "credential_pin":
-				parts.push("credential pin", entry.provider);
-				break;
-			case "ttsr_injection":
-				parts.push("ttsr injection", ...entry.injectedRules);
-				break;
-			case "reset_boundary":
-				parts.push("reset boundary");
-				break;
-			case "session_init":
-				parts.push("session init");
-				break;
-		}
-
-		return parts.join(" ");
 	}
 
 	invalidate(): void {}
@@ -713,11 +327,11 @@ class TreeList implements Component {
 				const role = msg.role;
 				if (role === "user") {
 					const msgWithContent = msg as { content?: unknown };
-					const content = normalize(this.#extractContent(msgWithContent.content));
+					const content = normalize(extractContent(msgWithContent.content));
 					result = theme.fg("accent", "user: ") + content;
 				} else if (role === "developer") {
 					const msgWithContent = msg as { content?: unknown };
-					const content = normalize(this.#extractContent(msgWithContent.content));
+					const content = normalize(extractContent(msgWithContent.content));
 					result = theme.fg("dim", "developer: ") + theme.fg("muted", content);
 				} else if (role === "assistant") {
 					const presentation = resolveAssistantErrorPresentation(msg);
@@ -726,7 +340,7 @@ class TreeList implements Component {
 						break;
 					}
 					const msgWithContent = msg as { content?: unknown; stopReason?: string; errorMessage?: string };
-					const textContent = normalize(this.#extractContent(msgWithContent.content));
+					const textContent = normalize(extractContent(msgWithContent.content));
 					if (textContent) {
 						result = theme.fg("success", "assistant: ") + textContent;
 					} else if (presentation.kind === "full") {
@@ -760,7 +374,7 @@ class TreeList implements Component {
 					result = theme.fg("customMessageLabel", label) + normalize(text);
 					break;
 				}
-				const content = stripSystemWrapperTags(this.#joinTextContent(entry.content));
+				const content = stripSystemWrapperTags(joinTextContent(entry.content));
 				result = theme.fg("customMessageLabel", `[${entry.customType}]: `) + normalize(content);
 				break;
 			}
@@ -812,45 +426,6 @@ class TreeList implements Component {
 		}
 
 		return isSelected ? theme.bold(result) : result;
-	}
-
-	#extractContent(content: unknown): string {
-		return this.#joinTextContent(content).slice(0, SEARCH_TEXT_LIMIT);
-	}
-
-	/** Concatenate every text block (or return a string as-is) with no length cap. */
-	#joinTextContent(content: unknown): string {
-		if (typeof content === "string") return content;
-		if (Array.isArray(content)) {
-			let result = "";
-			for (const c of content) {
-				if (
-					typeof c === "object" &&
-					c !== null &&
-					"type" in c &&
-					c.type === "text" &&
-					"text" in c &&
-					typeof c.text === "string"
-				) {
-					result += c.text;
-				}
-			}
-			return result;
-		}
-		return "";
-	}
-
-	#hasTextContent(content: unknown): boolean {
-		if (typeof content === "string") return Boolean(canonicalizeMessage(content));
-		if (Array.isArray(content)) {
-			for (const c of content) {
-				if (typeof c === "object" && c !== null && "type" in c && c.type === "text") {
-					const text = (c as { text?: string }).text;
-					if (text && canonicalizeMessage(text)) return true;
-				}
-			}
-		}
-		return false;
 	}
 
 	#formatToolCall(name: string, args: Record<string, unknown>): string {

--- a/packages/coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client.ts
@@ -31,14 +31,17 @@ import type {
 	RpcHostToolDefinition,
 	RpcHostToolResult,
 	RpcHostToolUpdate,
+	RpcNavigationTree,
 	RpcResponse,
 	RpcSessionState,
+	RpcSessionTree,
 	RpcSubagentEventFrame,
 	RpcSubagentLifecycleFrame,
 	RpcSubagentMessagesResult,
 	RpcSubagentProgressFrame,
 	RpcSubagentSnapshot,
 	RpcSubagentSubscriptionLevel,
+	RpcTreeFilterMode,
 } from "./rpc-types";
 
 /** Distributive Omit that works with union types */
@@ -836,6 +839,28 @@ export class RpcClient {
 	async getLastAssistantText(): Promise<string | null> {
 		const response = await this.#send({ type: "get_last_assistant_text" });
 		return this.#getData<{ text: string | null }>(response).text;
+	}
+
+	/**
+	 * Get the full session tree (`SessionManager.getTree()`): nested entry
+	 * nodes with resolved labels, plus the active leaf id.
+	 */
+	async getTree(): Promise<RpcSessionTree> {
+		const response = await this.#send({ type: "get_tree" });
+		return this.#getData<RpcSessionTree>(response);
+	}
+
+	/**
+	 * Get the flattened navigation tree the `/tree` selector renders: active
+	 * branch first, with filter modes and fuzzy search applied server-side.
+	 */
+	async getNavigationTree(options: { filter?: RpcTreeFilterMode; search?: string } = {}): Promise<RpcNavigationTree> {
+		const response = await this.#send({
+			type: "get_navigation_tree",
+			filter: options.filter,
+			search: options.search,
+		});
+		return this.#getData<RpcNavigationTree>(response);
 	}
 
 	/**

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -39,6 +39,7 @@ import { isRpcHostUriResult, RpcHostUriBridge } from "./host-uris";
 import { MAX_RPC_FRAME_BYTES, MAX_RPC_REASSEMBLED_BYTES, RpcFrameEncoder } from "./rpc-frame";
 import { claimRpcInput, readRpcInputFrames } from "./rpc-input";
 import { pageRpcMessages, RPC_MESSAGES_PAGE_BUSY_ERROR, RpcMessagesPageError } from "./rpc-messages";
+import { getNavigationTree, getSessionTree } from "./rpc-session-tree";
 import { RpcSubagentRegistry, readRpcSubagentTranscript } from "./rpc-subagents";
 import type {
 	RpcCommand,
@@ -1352,6 +1353,19 @@ export async function runRpcMode(
 			case "get_last_assistant_text": {
 				const text = session.getLastAssistantText();
 				return success(id, "get_last_assistant_text", { text });
+			}
+
+			case "get_tree": {
+				return success(id, "get_tree", getSessionTree(session.sessionManager));
+			}
+
+			case "get_navigation_tree": {
+				const result = getNavigationTree(session.sessionManager, {
+					filter: command.filter,
+					search: command.search,
+				});
+				if (!result.ok) return error(id, "get_navigation_tree", result.error, result.code);
+				return success(id, "get_navigation_tree", result.data);
 			}
 
 			case "set_session_name": {

--- a/packages/coding-agent/src/modes/rpc/rpc-session-tree.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-session-tree.ts
@@ -1,0 +1,89 @@
+/**
+ * Session tree over RPC.
+ *
+ * `get_tree` returns the raw `SessionManager.getTree()` snapshot;
+ * `get_navigation_tree` returns the flattened, filtered projection the `/tree`
+ * selector renders, so remote clients can mirror the same navigation UI.
+ */
+
+import type { SessionManager } from "../../session/session-manager";
+import {
+	buildActivePathIds,
+	type FlatNode,
+	filterFlatNodes,
+	flattenSessionTree,
+	getSearchableText,
+} from "../components/tree-model";
+import type { RpcNavigationTree, RpcNavigationTreeNode, RpcSessionTree, RpcTreeFilterMode } from "./rpc-types";
+
+const TREE_FILTER_MODES: readonly RpcTreeFilterMode[] = ["default", "no-tools", "user-only", "labeled-only", "all"];
+
+export function isRpcTreeFilterMode(value: unknown): value is RpcTreeFilterMode {
+	return typeof value === "string" && (TREE_FILTER_MODES as readonly string[]).includes(value);
+}
+
+/** Raw session tree: nested `SessionTreeNode[]` plus the active leaf. */
+export function getSessionTree(sessionManager: SessionManager): RpcSessionTree {
+	return { leafId: sessionManager.getLeafId(), tree: sessionManager.getTree() };
+}
+
+export type NavigationTreeRpcFailure = { ok: false; error: string; code: "invalid_filter" };
+export type NavigationTreeRpcResult = { ok: true; data: RpcNavigationTree } | NavigationTreeRpcFailure;
+
+/**
+ * Flattened navigation tree matching the `/tree` selector: active branch
+ * first, filter modes, and fuzzy search over the same searchable text.
+ */
+export function getNavigationTree(
+	sessionManager: SessionManager,
+	options: { filter?: unknown; search?: unknown } = {},
+): NavigationTreeRpcResult {
+	const filter = options.filter ?? "default";
+	if (!isRpcTreeFilterMode(filter)) {
+		return { ok: false, error: `Invalid tree filter mode: ${String(options.filter)}`, code: "invalid_filter" };
+	}
+	const search = typeof options.search === "string" ? options.search : "";
+
+	const leafId = sessionManager.getLeafId();
+	const tree = sessionManager.getTree();
+	const { flatNodes } = flattenSessionTree(tree, leafId);
+	const activePathIds = buildActivePathIds(flatNodes, leafId);
+	const visible = filterFlatNodes(flatNodes, { mode: filter, searchQuery: search, currentLeafId: leafId });
+
+	return {
+		ok: true,
+		data: {
+			leafId,
+			filter,
+			search,
+			multipleRoots: tree.length > 1,
+			totalNodes: flatNodes.length,
+			nodes: visible.map(flatNode => toRpcNavigationNode(flatNode, activePathIds, leafId)),
+		},
+	};
+}
+
+function toRpcNavigationNode(
+	flatNode: FlatNode,
+	activePathIds: Set<string>,
+	leafId: string | null,
+): RpcNavigationTreeNode {
+	const { entry, label } = flatNode.node;
+	const role = entry.type === "message" ? entry.message.role : undefined;
+	return {
+		entryId: entry.id,
+		parentId: entry.parentId,
+		entryType: entry.type,
+		...(role !== undefined ? { role } : {}),
+		timestamp: entry.timestamp,
+		...(label !== undefined ? { label } : {}),
+		preview: getSearchableText(flatNode.node),
+		indent: flatNode.indent,
+		showConnector: flatNode.showConnector,
+		isLast: flatNode.isLast,
+		isVirtualRootChild: flatNode.isVirtualRootChild,
+		gutters: flatNode.gutters.map(gutter => ({ position: gutter.position, show: gutter.show })),
+		onActivePath: activePathIds.has(entry.id),
+		isLeaf: entry.id === leafId,
+	};
+}

--- a/packages/coding-agent/src/modes/rpc/rpc-types.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-types.ts
@@ -10,7 +10,7 @@ import type { Effort, ImageContent, Model, ToolExample } from "@oh-my-pi/pi-ai";
 import type { BashResult } from "../../exec/bash-executor";
 import type { ContextUsage } from "../../extensibility/extensions/types";
 import type { AgentSessionEvent, SessionStats } from "../../session/agent-session";
-import type { FileEntry } from "../../session/session-entries";
+import type { FileEntry, SessionEntry, SessionTreeNode } from "../../session/session-entries";
 import type { AvailableSlashCommandSource } from "../../slash-commands/available-commands";
 import type {
 	AgentProgress,
@@ -81,6 +81,8 @@ export type RpcCommand =
 	| { id?: string; type: "branch"; entryId: string }
 	| { id?: string; type: "get_branch_messages" }
 	| { id?: string; type: "get_last_assistant_text" }
+	| { id?: string; type: "get_tree" }
+	| { id?: string; type: "get_navigation_tree"; filter?: RpcTreeFilterMode; search?: string }
 	| { id?: string; type: "set_session_name"; name: string }
 	| { id?: string; type: "handoff"; customInstructions?: string }
 
@@ -186,6 +188,58 @@ export interface RpcSubagentMessagesResult {
 	reset: boolean;
 	entries: FileEntry[];
 	messages: AgentMessage[];
+}
+
+// ============================================================================
+// Session Tree
+// ============================================================================
+
+/** Filter modes for `get_navigation_tree`, mirroring the `/tree` selector. */
+export type RpcTreeFilterMode = "default" | "no-tools" | "user-only" | "labeled-only" | "all";
+
+/** Full session tree snapshot: `SessionManager.getTree()` plus the active leaf. */
+export interface RpcSessionTree {
+	leafId: string | null;
+	tree: SessionTreeNode[];
+}
+
+/** One row of the flattened navigation tree (same projection as the `/tree` selector). */
+export interface RpcNavigationTreeNode {
+	entryId: string;
+	parentId: string | null;
+	entryType: SessionEntry["type"];
+	/** Message role for `message` entries. */
+	role?: string;
+	timestamp: string;
+	label?: string;
+	/** Searchable text for the row (label + type-specific content), capped at 200 chars. */
+	preview: string;
+	/** Indentation level (each level renders as 3 cells in the TUI). */
+	indent: number;
+	/** True when the parent has multiple children (connector shown unless virtual root child). */
+	showConnector: boolean;
+	/** True when this node is the last sibling under its parent. */
+	isLast: boolean;
+	/** True for roots nested under the virtual branching root (multiple roots). */
+	isVirtualRootChild: boolean;
+	/** Ancestor branch points: connector position and whether more siblings follow. */
+	gutters: Array<{ position: number; show: boolean }>;
+	/** True when the node lies on the path from root to the current leaf. */
+	onActivePath: boolean;
+	/** True when the node is the current leaf. */
+	isLeaf: boolean;
+}
+
+/** Flattened navigation tree: rows after filter/search, plus pre-filter totals. */
+export interface RpcNavigationTree {
+	leafId: string | null;
+	filter: RpcTreeFilterMode;
+	search: string;
+	/** True when the session has multiple roots (rows nest under a virtual root). */
+	multipleRoots: boolean;
+	/** Row count before filter/search were applied. */
+	totalNodes: number;
+	nodes: RpcNavigationTreeNode[];
 }
 
 // ============================================================================
@@ -307,6 +361,8 @@ export type RpcResponse =
 	| { id?: string; type: "response"; command: "export_html"; success: true; data: { path: string } }
 	| { id?: string; type: "response"; command: "switch_session"; success: true; data: { cancelled: boolean } }
 	| { id?: string; type: "response"; command: "branch"; success: true; data: { text: string; cancelled: boolean } }
+	| { id?: string; type: "response"; command: "get_tree"; success: true; data: RpcSessionTree }
+	| { id?: string; type: "response"; command: "get_navigation_tree"; success: true; data: RpcNavigationTree }
 	| {
 			id?: string;
 			type: "response";

--- a/packages/coding-agent/test/rpc-session-tree.test.ts
+++ b/packages/coding-agent/test/rpc-session-tree.test.ts
@@ -1,0 +1,271 @@
+import { describe, expect, it } from "bun:test";
+import {
+	getNavigationTree,
+	getSessionTree,
+	isRpcTreeFilterMode,
+} from "@oh-my-pi/pi-coding-agent/modes/rpc/rpc-session-tree";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+
+function appendUser(manager: SessionManager, text: string): string {
+	return manager.appendMessage({ role: "user", content: text, timestamp: Date.now() });
+}
+
+function appendAssistant(manager: SessionManager, text: string): string {
+	return manager.appendMessage({
+		role: "assistant",
+		content: [{ type: "text", text }],
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "claude-sonnet-4-20250514",
+		usage: {
+			input: 1,
+			output: 1,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 2,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: Date.now(),
+	});
+}
+
+function appendToolOnlyAssistant(manager: SessionManager): string {
+	return manager.appendMessage({
+		role: "assistant",
+		content: [{ type: "toolCall", id: "toolu_1", name: "bash", arguments: { command: "ls" } }],
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "claude-sonnet-4-20250514",
+		usage: {
+			input: 1,
+			output: 1,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 2,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "toolUse",
+		timestamp: Date.now(),
+	});
+}
+
+function appendToolResult(manager: SessionManager): string {
+	return manager.appendMessage({
+		role: "toolResult",
+		toolCallId: "toolu_1",
+		toolName: "bash",
+		content: [{ type: "text", text: "ok" }],
+		isError: false,
+		timestamp: Date.now(),
+	});
+}
+
+describe("RPC session tree", () => {
+	describe("isRpcTreeFilterMode", () => {
+		it("accepts the five /tree filter modes and rejects everything else", () => {
+			for (const mode of ["default", "no-tools", "user-only", "labeled-only", "all"]) {
+				expect(isRpcTreeFilterMode(mode)).toBe(true);
+			}
+			for (const bad of ["", "DEFAULT", "tools", "alll", 42, null, undefined, {}]) {
+				expect(isRpcTreeFilterMode(bad)).toBe(false);
+			}
+		});
+	});
+
+	describe("getSessionTree", () => {
+		it("returns the nested tree with the active leaf id", () => {
+			const manager = SessionManager.inMemory();
+			const userId = appendUser(manager, "hello");
+			const assistantId = appendAssistant(manager, "hi there");
+
+			const snapshot = getSessionTree(manager);
+			expect(snapshot.leafId).toBe(assistantId);
+			expect(snapshot.tree).toHaveLength(1);
+			const root = snapshot.tree[0];
+			expect(root.entry.id).toBe(userId);
+			expect(root.children.map(child => child.entry.id)).toEqual([assistantId]);
+		});
+
+		it("reflects branches as sibling children and resolves labels", () => {
+			const manager = SessionManager.inMemory();
+			const userId = appendUser(manager, "start");
+			const firstId = appendAssistant(manager, "approach A");
+			manager.branch(userId);
+			const secondId = appendAssistant(manager, "approach B");
+			// Appending the label moves the leaf onto the new label entry.
+			const labelId = manager.appendLabelChange(firstId, "checkpoint");
+
+			const snapshot = getSessionTree(manager);
+			expect(snapshot.leafId).toBe(labelId);
+			const root = snapshot.tree[0];
+			expect(root.children.map(child => child.entry.id)).toEqual([firstId, secondId]);
+			expect(root.children[0].label).toBe("checkpoint");
+			expect(root.children[1].label).toBeUndefined();
+		});
+	});
+
+	describe("getNavigationTree", () => {
+		it("flattens the linear conversation and marks the active path", () => {
+			const manager = SessionManager.inMemory();
+			const userId = appendUser(manager, "hello");
+			const assistantId = appendAssistant(manager, "hi there");
+
+			const result = getNavigationTree(manager);
+			expect(result.ok).toBe(true);
+			if (!result.ok) return;
+			expect(result.data.leafId).toBe(assistantId);
+			expect(result.data.multipleRoots).toBe(false);
+			expect(result.data.nodes.map(node => node.entryId)).toEqual([userId, assistantId]);
+			const [userRow, assistantRow] = result.data.nodes;
+			expect(userRow).toMatchObject({
+				parentId: null,
+				entryType: "message",
+				role: "user",
+				onActivePath: true,
+				isLeaf: false,
+			});
+			expect(assistantRow).toMatchObject({ role: "assistant", onActivePath: true, isLeaf: true });
+			expect(userRow.preview).toContain("hello");
+		});
+
+		it("orders the active branch first at a fork", () => {
+			const manager = SessionManager.inMemory();
+			const userId = appendUser(manager, "start");
+			const inactiveId = appendAssistant(manager, "approach A");
+			manager.branch(userId);
+			const activeId = appendAssistant(manager, "approach B");
+
+			const result = getNavigationTree(manager);
+			expect(result.ok).toBe(true);
+			if (!result.ok) return;
+			const childIds = result.data.nodes.filter(node => node.parentId === userId).map(node => node.entryId);
+			expect(childIds).toEqual([activeId, inactiveId]);
+			const activeRow = result.data.nodes.find(node => node.entryId === activeId);
+			const inactiveRow = result.data.nodes.find(node => node.entryId === inactiveId);
+			expect(activeRow?.onActivePath).toBe(true);
+			expect(inactiveRow?.onActivePath).toBe(false);
+			expect(activeRow?.isLast).toBe(false);
+			expect(inactiveRow?.isLast).toBe(true);
+		});
+
+		it("hides bookkeeping entries by default and shows them in all mode", () => {
+			const manager = SessionManager.inMemory();
+			const userId = appendUser(manager, "hello");
+			manager.appendLabelChange(userId, "checkpoint");
+			manager.appendModelChange("anthropic/claude-sonnet-4-5", "default");
+
+			const defaultResult = getNavigationTree(manager);
+			expect(defaultResult.ok).toBe(true);
+			if (!defaultResult.ok) return;
+			expect(defaultResult.data.nodes.every(node => node.entryType === "message")).toBe(true);
+			expect(defaultResult.data.totalNodes).toBeGreaterThan(defaultResult.data.nodes.length);
+
+			const allResult = getNavigationTree(manager, { filter: "all" });
+			expect(allResult.ok).toBe(true);
+			if (!allResult.ok) return;
+			const types = new Set(allResult.data.nodes.map(node => node.entryType));
+			expect(types.has("label")).toBe(true);
+			expect(types.has("model_change")).toBe(true);
+			expect(allResult.data.nodes.length).toBe(allResult.data.totalNodes);
+		});
+
+		it("user-only keeps only user messages; labeled-only keeps labeled entries", () => {
+			const manager = SessionManager.inMemory();
+			const userId = appendUser(manager, "hello");
+			appendAssistant(manager, "hi there");
+			manager.appendLabelChange(userId, "checkpoint");
+
+			const userOnly = getNavigationTree(manager, { filter: "user-only" });
+			expect(userOnly.ok).toBe(true);
+			if (!userOnly.ok) return;
+			expect(userOnly.data.nodes.map(node => node.entryId)).toEqual([userId]);
+
+			const labeledOnly = getNavigationTree(manager, { filter: "labeled-only" });
+			expect(labeledOnly.ok).toBe(true);
+			if (!labeledOnly.ok) return;
+			expect(labeledOnly.data.nodes.map(node => node.entryId)).toEqual([userId]);
+			expect(labeledOnly.data.nodes[0].label).toBe("checkpoint");
+		});
+
+		it("no-tools drops tool results but keeps conversation", () => {
+			const manager = SessionManager.inMemory();
+			const userId = appendUser(manager, "run ls");
+			const toolCallId = appendToolOnlyAssistant(manager);
+			const toolResultId = appendToolResult(manager);
+			const answerId = appendAssistant(manager, "done");
+
+			const result = getNavigationTree(manager, { filter: "no-tools" });
+			expect(result.ok).toBe(true);
+			if (!result.ok) return;
+			const ids = result.data.nodes.map(node => node.entryId);
+			expect(ids).toContain(userId);
+			expect(ids).toContain(answerId);
+			expect(ids).not.toContain(toolResultId);
+			// The tool-only assistant node is not the leaf, so it stays hidden.
+			expect(ids).not.toContain(toolCallId);
+		});
+
+		it("always keeps the current leaf visible, even a tool-only assistant node", () => {
+			const manager = SessionManager.inMemory();
+			appendUser(manager, "run ls");
+			const toolCallId = appendToolOnlyAssistant(manager);
+
+			const result = getNavigationTree(manager);
+			expect(result.ok).toBe(true);
+			if (!result.ok) return;
+			const leafRow = result.data.nodes.find(node => node.entryId === toolCallId);
+			expect(leafRow?.isLeaf).toBe(true);
+		});
+
+		it("applies fuzzy search over the same text the /tree selector indexes", () => {
+			const manager = SessionManager.inMemory();
+			appendUser(manager, "deploy the staging build");
+			appendAssistant(manager, "done, deployed");
+
+			const hit = getNavigationTree(manager, { search: "staging" });
+			expect(hit.ok).toBe(true);
+			if (!hit.ok) return;
+			expect(hit.data.nodes).toHaveLength(1);
+			expect(hit.data.nodes[0].preview).toContain("staging");
+
+			const miss = getNavigationTree(manager, { search: "nonexistent-token" });
+			expect(miss.ok).toBe(true);
+			if (!miss.ok) return;
+			expect(miss.data.nodes).toHaveLength(0);
+			expect(miss.data.totalNodes).toBeGreaterThan(0);
+		});
+
+		it("rejects an unknown filter mode with invalid_filter", () => {
+			const manager = SessionManager.inMemory();
+			appendUser(manager, "hello");
+
+			const result = getNavigationTree(manager, { filter: "bogus" });
+			expect(result.ok).toBe(false);
+			if (result.ok) return;
+			expect(result.code).toBe("invalid_filter");
+			expect(result.error).toContain("bogus");
+		});
+
+		it("nests multiple roots under a virtual branching root", () => {
+			const manager = SessionManager.inMemory();
+			const firstRoot = appendUser(manager, "first root");
+			manager.resetLeaf();
+			const secondRoot = appendUser(manager, "second root");
+
+			const result = getNavigationTree(manager);
+			expect(result.ok).toBe(true);
+			if (!result.ok) return;
+			expect(result.data.multipleRoots).toBe(true);
+			const roots = result.data.nodes.filter(node => node.parentId === null);
+			expect(roots.map(node => node.entryId)).toEqual([secondRoot, firstRoot]);
+			for (const root of roots) {
+				expect(root.isVirtualRootChild).toBe(true);
+				expect(root.indent).toBe(1);
+			}
+			// Active branch first: the second root holds the leaf.
+			expect(roots[0].onActivePath).toBe(true);
+			expect(roots[1].onActivePath).toBe(false);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

- Add two read-only session-tree commands to RPC mode:
  - `get_tree` — raw `SessionManager.getTree()` snapshot: nested `SessionTreeNode[]` with resolved labels plus the active `leafId`.
  - `get_navigation_tree` — the flattened rows the `/tree` selector renders: active branch first, connector geometry (`indent`, `showConnector`, `isLast`, `gutters`, `isVirtualRootChild`), `onActivePath`/`isLeaf` markers, and a 200-char `preview` of the same searchable text the selector indexes. Supports the selector's `filter` modes (`default`, `no-tools`, `user-only`, `labeled-only`, `all`) and tokenized fuzzy `search`, applied server-side; unknown filters fail with code `invalid_filter`.
- Extract the selector's flatten/filter/search logic into a pure `tree-model.ts` module shared by the TUI component and the RPC handler, so remote clients and `/tree` emit identical rows by construction.
- Add `RpcClient.getTree()` / `RpcClient.getNavigationTree()` convenience methods, protocol docs, and unit tests.

This lets remote/headless hosts (e.g. session surfers and collab-style UIs) render the session branch navigator without reimplementing — and drifting from — the TUI's tree semantics.

## Test plan

- [x] `bun run check:types` (tsgo, clean)
- [x] `biome check` on all touched files (clean)
- [x] `bun test test/rpc-session-tree.test.ts` — 12 new tests: tree shape, branch siblings, labels, active-branch-first ordering, all five filter modes, tool-only-assistant hiding (incl. current-leaf exception), fuzzy search, `invalid_filter`, virtual-root nesting
- [x] `bun test test/modes/components/ test/modes/controllers/ test/session-manager/ test/agent-session-tree-navigation.test.ts` — 938 pass / 0 fail, pinning the extraction as behavior-preserving for the `/tree` selector