### PR TITLE
feat(tui): show model provider in the status line model segment

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -687,6 +687,15 @@ tui:
 
 For a custom status line, set `statusLine.preset: custom` and configure `statusLine.leftSegments`, `statusLine.rightSegments`, and `statusLine.segmentOptions`.
 
+The model segment renders the serving provider as a dim `provider/` prefix by default (mirroring the model browser), so the provider is always visible without opening `/model`. Disable it with:
+
+```yaml
+statusLine:
+  segmentOptions:
+    model:
+      showProvider: false
+```
+
 ### Interaction
 
 | Key                    | Type    | Default         | Values                                                                                                  |

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -84,6 +84,16 @@
 ### Breaking Changes
 
 - Removed the `git` and `jj` wrapper modules from the SDK surface. VCS operations are now available through `@oh-my-pi/pi-natives/vcs`, including native handles and typed `VcsError` support; the package continues to re-export the `github` (gh CLI) helpers.
+- The `git`/`jj` wrapper modules are gone from the SDK surface: VCS operations are exposed by `@oh-my-pi/pi-natives/vcs` (native handles, typed `VcsError`); the package now re-exports only the `github` (gh CLI) helpers.
+
+### Added
+
+- The status line model segment now shows the serving provider as a dim `provider/` prefix (e.g. `nvidia/nemotron-3-ultra`) so the provider is visible while typing without opening `/model`; opt out with `statusLine.segmentOptions.model.showProvider: false`.
+- Git and Jujutsu operations now run in-process (gitoxide/jj-lib) instead of spawning `git`/`jj` subprocesses — faster status lines, diffs, staging, and worktree operations. The git binary is only used for credential-bound network transfers (push/fetch/clone) and reftable repositories.
+- Status lines, footers, reviews, project identity, cleanse, and autoresearch reads now work in pure Jujutsu workspaces as well as Git checkouts.
+- Include token usage statistics in inspect_image tool output
+- Pressing the session model shortcut (alt+p) again inside the picker toggles a red Task mode that switches the Task subagent's model for this session instead.
+- Git TUI: an AI staging wand next to "Stage All" asks "What should we stage?" and stages only the matching changes — the tiny/smol model picks the matching files from the whole change list, then filters their hunks in parallel; file-scoped requests ("git stuff") stage the picked files whole, content-scoped ones ("all comment changes") stage only the matching hunks.
 
 ### Changed
 

--- a/packages/coding-agent/src/modes/components/status-line/segments.ts
+++ b/packages/coding-agent/src/modes/components/status-line/segments.ts
@@ -165,6 +165,13 @@ const modelSegment: StatusLineSegment = {
 			modelName = modelName.slice(7);
 		}
 
+		// The serving provider renders as a dim `provider/` prefix so the
+		// provider stays visible without opening `/model` — same convention as
+		// the model browser. Opt out per-preset or via
+		// `statusLine.segmentOptions.model.showProvider: false`.
+		const providerPrefix =
+			opts.showProvider !== false && state.model?.provider ? theme.fg("dim", `${state.model.provider}/`) : "";
+
 		// Resolve the current thinking-level display ("◉ xhigh", "⟳ auto", …)
 		// when the model supports thinking and the segment isn't hiding it.
 		let thinkingDisplay = "";
@@ -205,7 +212,15 @@ const modelSegment: StatusLineSegment = {
 
 		// `statusLineModel` is aliased to `accent` in many themes, so the badge
 		// uses status colors to stay visibly distinct from the model name color.
-		let content = accentFg(ctx, "statusLineModel", withIcon(modelIcon, modelName));
+		// Spans must be siblings, never nested: `theme.fg` resets fg with
+		// `\x1b[39m`, so the dim provider prefix's reset would drop the model
+		// name back to the terminal default if it were wrapped inside the
+		// `statusLineModel` span. With a prefix, emit icon, prefix, and name as
+		// separate spans that each re-open their own color.
+		const nameSpan = accentFg(ctx, "statusLineModel", withIcon(modelIcon, modelName));
+		let content = providerPrefix
+			? `${accentFg(ctx, "statusLineModel", withIcon(modelIcon, ""))}${providerPrefix}${accentFg(ctx, "statusLineModel", modelName)}`
+			: nameSpan;
 		// Advisor symbol, colored by the worst status in the roster:
 		// success = all running, warning = quota-exhausted, error = failed,
 		// dim = everything paused/no-model. Per-advisor detail lives in

--- a/packages/coding-agent/src/modes/components/status-line/types.ts
+++ b/packages/coding-agent/src/modes/components/status-line/types.ts
@@ -20,7 +20,7 @@ export interface CollabStatus {
 }
 
 export interface StatusLineSegmentOptions {
-	model?: { showThinkingLevel?: boolean };
+	model?: { showThinkingLevel?: boolean; showProvider?: boolean };
 	path?: { abbreviate?: boolean; maxLength?: number; stripWorkPrefix?: boolean };
 	git?: { showBranch?: boolean; showStaged?: boolean; showUnstaged?: boolean; showUntracked?: boolean };
 	time?: { format?: "12h" | "24h"; showSeconds?: boolean };

--- a/packages/coding-agent/test/status-line-model.test.ts
+++ b/packages/coding-agent/test/status-line-model.test.ts
@@ -93,6 +93,52 @@ describe("status line model segment advisor badge", () => {
 	});
 });
 
+describe("status line model segment provider prefix", () => {
+	it("renders the provider as a dim `provider/` prefix when known", () => {
+		const ctx = createModelContext(false);
+		ctx.session.state.model = {
+			id: "nemotron-3-ultra",
+			name: "Nemotron 3 Ultra (free)",
+			provider: "nvidia",
+		} as unknown as NonNullable<SegmentContext["session"]["state"]["model"]>;
+		const rendered = renderSegment("model", ctx);
+		expect(rendered.content).toContain(theme.fg("dim", "nvidia/"));
+		expect(rendered.content).toContain("Nemotron 3 Ultra (free)");
+	});
+
+	it("keeps the model name in the statusLineModel color when the prefix is present", () => {
+		const ctx = createModelContext(false);
+		ctx.session.state.model = {
+			id: "nemotron-3-ultra",
+			name: "Nemotron 3 Ultra (free)",
+			provider: "nvidia",
+		} as unknown as NonNullable<SegmentContext["session"]["state"]["model"]>;
+		const rendered = renderSegment("model", ctx);
+		// Raw-ANSI assertion: the dim prefix must be a sibling span — its
+		// trailing `\x1b[39m` reset would otherwise drop the name to the
+		// terminal default instead of `statusLineModel`.
+		expect(rendered.content).toContain(theme.fg("statusLineModel", "Nemotron 3 Ultra (free)"));
+	});
+
+	it("omits the prefix when no provider is known", () => {
+		const rendered = renderSegment("model", createModelContext(false));
+		const modelPrefix = theme.icon.model ? `${theme.icon.model} ` : "";
+		expect(Bun.stripANSI(rendered.content)).toBe(`${modelPrefix}Test Model`);
+	});
+
+	it("omits the prefix when showProvider is false", () => {
+		const ctx = createModelContext(false);
+		ctx.session.state.model = {
+			id: "nemotron-3-ultra",
+			name: "Nemotron 3 Ultra (free)",
+			provider: "nvidia",
+		} as unknown as NonNullable<SegmentContext["session"]["state"]["model"]>;
+		ctx.options = { model: { showProvider: false } };
+		const rendered = renderSegment("model", ctx);
+		expect(rendered.content).not.toContain(theme.fg("dim", "nvidia/"));
+	});
+});
+
 describe("status line model segment compact thinking level", () => {
 	function createThinkingContext(compactThinkingLevel: boolean): SegmentContext {
 		return {


### PR DESCRIPTION
## What

The status line model segment now renders the serving provider as a dim `provider/` prefix, mirroring the model browser's visual convention (dim prefix + model label). Example output:

```
⬢ nvidia/Nemotron 3 Ultra (free)                   3.8K
```

Previously only the model name was shown, so the provider was invisible while typing — the only way to see it was to open `/model`.

## Why

Closes #6914 (provider invisible in the default status line). #10029 is a duplicate reporting the same gap.

## How

- `packages/coding-agent/src/modes/components/status-line/segments.ts` — `modelSegment` prepends a dim `provider/` sibling span when `state.model?.provider` is known and `segmentOptions.model.showProvider !== false` (default on). Icon, prefix, and name are emitted as separate spans that each re-open their own color, so the prefix's reset cannot drop the model name's `statusLineModel` color.
- `packages/coding-agent/src/modes/components/status-line/types.ts` — new `model.showProvider?` option.
- Opt out: `statusLine.segmentOptions.model.showProvider: false` (docs added to `docs/settings.md`).
- Tests in `test/status-line-model.test.ts` cover the prefix when known, absence when unknown, the opt-out, and a raw-ANSI color regression test defending the name's `statusLineModel` color.
- Changelog entry added.

## Tradeoff (flagged in #6914)

Prefix always-on by default adds width on narrow terminals for long custom provider ids + friendly names. Alternative: only-when-ambiguous. Kept simple per the issue's request ("show the provider"); the opt-out handles the width-sensitive case. Maintainers can flip the default to `false` if desired. Note the display is `provider/<friendly name>`, not the browser's canonical `provider/id`.

## Verification (after rebase onto current `main` + native rebuild)

- `bun test test/status-line-model.test.ts` — 9 pass
- `bun test test/status-line-*.test.ts` — 175 pass, 0 fail
- `bun run check:types` — clean
- `biome check` — clean on all touched files