### PR TITLE
feat(coding-agent): add collab_start/collab_end extension events

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -253,6 +253,8 @@ Rejected, with measurements, so nobody re-litigates them: **sccache** (cannot ca
 
 ## Testing Guidance
 
+In a fresh clone/worktree, `bun test` in `packages/coding-agent` fails every test with a `pi_natives` native-addon load error until the addon is built: `bun --cwd=packages/natives run build` (see `packages/natives/README.md`). On macOS that build needs `cmake` and `ninja` on `PATH` (for the bundled Opus/audio bindings) in addition to Rust — `brew install cmake ninja` if missing.
+
 Test the contract the system exposes — not the easiest internal detail to assert.
 
 - Every new test must defend one **concrete, externally observable contract**: behavior, output shape, state transition, error mapping, or a regression-prone parsing boundary. If you cannot name the contract, do not add the test.

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -252,6 +252,15 @@ const contrasting = ctx.models
   .find((m) => current && ctx.models.family(m) !== ctx.models.family(current));
 ```
 
+### Collab state (`ctx.collab`)
+
+`ctx.collab` is a live, read-only snapshot of whether this session is currently hosting a `/collab` session:
+
+- `hosting` — `true` while a `/collab` host session is up.
+- `roomId` — the active room id, or `undefined` when not hosting.
+
+It never carries the room key or write token that make the collab link joinable — see the `collab_start`/`collab_end` events below for why. Combine it with those events when an extension needs to react to the transition rather than just poll the current state.
+
 ## 3) Command context (`ExtensionCommandContext`)
 
 Command handlers additionally get:
@@ -333,6 +342,22 @@ pi.on("mcp_notification", (event) => {
 ```
 
 The runtime handles the JSON-RPC transport and its own list/update refresh first; the handler runs afterwards and can inject a mid-turn steer via `pi.sendMessage` / `pi.sendUserMessage`.
+
+### Collab lifecycle
+
+- `collab_start` — fired once a `/collab` host session is live and broadcasting to guests. Payload: `{ roomId: string; relayUrl: string; webLink: string; hasWriteToken: boolean }`.
+- `collab_end` — fired when a `/collab` host session tears down (`/collab stop`, relay drop, or session switch). Same payload shape as `collab_start`.
+
+Both events deliberately exclude the room key and write token that make `CollabHost.link`/`CollabHost.webLink` joinable: extensions run trusted in-process — the same trust level as the terminal user who already sees the raw link — but there is no reason to widen the blast radius of a future extension bug (or a malicious extension) by handing every loaded extension the literal secret on every event fire. `webLink` is the collab web UI's base origin only, with no room-secret fragment attached; `roomId` plus `ctx.collab` (see above) is enough for an extension to know a session is live and which room it is.
+
+```ts
+pi.on("collab_start", (event) => {
+  pi.logger.info(`collab session live: room ${event.roomId} on ${event.relayUrl}`);
+});
+pi.on("collab_end", (event) => {
+  pi.logger.info(`collab session ended: room ${event.roomId}`);
+});
+```
 
 ### User command interception
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Include token usage statistics in inspect_image tool output
 - Pressing the session model shortcut (alt+p) again inside the picker toggles a red Task mode that switches the Task subagent's model for this session instead.
 - Git TUI: an AI staging wand next to "Stage All" asks "What should we stage?" and stages only the matching changes — the tiny/smol model picks the matching files from the whole change list, then filters their hunks in parallel; file-scoped requests ("git stuff") stage the picked files whole, content-scoped ones ("all comment changes") stage only the matching hunks.
+- Extensions can now observe `/collab` host sessions: new `collab_start`/`collab_end` events plus a live `ctx.collab` accessor (`hosting`, `roomId`).
 
 ### Changed
 

--- a/packages/coding-agent/src/collab/host.ts
+++ b/packages/coding-agent/src/collab/host.ts
@@ -21,6 +21,7 @@ import type {
 	AgentEvent as WireAgentEvent,
 	SessionEntry as WireSessionEntry,
 } from "@oh-my-pi/pi-wire";
+import type { CollabStartEvent } from "../extensibility/extensions/types";
 import type { InteractiveModeContext } from "../modes/types";
 import { AgentLifecycleManager } from "../registry/agent-lifecycle";
 import { type AgentRef, AgentRegistry } from "../registry/agent-registry";
@@ -41,6 +42,7 @@ import {
 	formatCollabLink,
 	formatCollabWebLink,
 	generateRoomId,
+	normalizeCollabWebBaseUrl,
 	parseCollabLink,
 } from "./protocol";
 import { CollabSocket } from "./relay-client";
@@ -120,6 +122,9 @@ const SNAPSHOT_CHUNK_BYTES = 512 * 1024;
  */
 export type CollabGuestUiResult = { kind: "answered"; value: CollabUiResponseValue } | { kind: "unavailable" };
 
+/** Shared shape of the `collab_start`/`collab_end` extension event payloads. */
+type CollabExtensionEventPayload = Omit<CollabStartEvent, "type">;
+
 export class CollabHost {
 	#ctx: InteractiveModeContext;
 	#socket: CollabSocket | null = null;
@@ -140,6 +145,8 @@ export class CollabHost {
 	#busUnsubscribers: (() => void)[] = [];
 	#registryUnsubscribe?: () => void;
 	#stopped = false;
+	/** Set once `start()` reaches a live socket; backs the `collab_end` event payload on teardown. */
+	#collabEventPayload: CollabExtensionEventPayload | null = null;
 
 	constructor(ctx: InteractiveModeContext) {
 		this.#ctx = ctx;
@@ -286,6 +293,16 @@ export class CollabHost {
 			this.#scheduleStateBroadcast();
 		};
 		this.#updateStatusSegment();
+
+		this.#collabEventPayload = {
+			roomId,
+			relayUrl,
+			webLink: normalizeCollabWebBaseUrl(relayUrl, webUrl),
+			hasWriteToken: true,
+		};
+		const runner = this.#ctx.session.extensionRunner;
+		runner?.setCollabState({ hosting: true, roomId });
+		void runner?.emit({ type: "collab_start", ...this.#collabEventPayload });
 	}
 
 	/** Broadcast a goodbye, detach all taps, and close the socket. */
@@ -298,6 +315,11 @@ export class CollabHost {
 	async #teardown(): Promise<void> {
 		if (this.#stopped) return;
 		this.#stopped = true;
+		const collabEventPayload = this.#collabEventPayload;
+		this.#collabEventPayload = null;
+		const runner = this.#ctx.session.extensionRunner;
+		runner?.setCollabState({ hosting: false, roomId: undefined });
+		if (collabEventPayload) void runner?.emit({ type: "collab_end", ...collabEventPayload });
 		this.#ctx.sessionManager.onEntryAppended = undefined;
 		this.#unsubscribe?.();
 		this.#unsubscribe = undefined;

--- a/packages/coding-agent/src/collab/protocol.ts
+++ b/packages/coding-agent/src/collab/protocol.ts
@@ -204,7 +204,14 @@ export function formatCollabLink(relayUrl: string, roomId: string, key: Uint8Arr
 	return `${compact}/r/${roomId}.${keyText}`;
 }
 
-function normalizeCollabWebBaseUrl(relayUrl: string, webUrl?: string): string {
+/**
+ * Base origin (+ path) of the collab web UI, with no room key or write token
+ * attached. Exported so callers that must not carry the room secret — e.g.
+ * the `collab_start`/`collab_end` extension events in
+ * `extensibility/extensions/types.ts`, which are deliberately kept
+ * secret-free — can still point at the web app.
+ */
+export function normalizeCollabWebBaseUrl(relayUrl: string, webUrl?: string): string {
 	const explicitWebUrl = webUrl?.trim();
 	if (!explicitWebUrl) {
 		const normalized = normalizeRelayOrigin(relayUrl);

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -37,6 +37,7 @@ import type {
 	ContextUsage,
 	Extension,
 	ExtensionActions,
+	ExtensionCollabState,
 	ExtensionCommandContext,
 	ExtensionCommandContextActions,
 	ExtensionContext,
@@ -554,6 +555,19 @@ export class ExtensionRunner {
 	/** Whether a native built-in of `name` is available to delegate to. */
 	hasNativeTool(name: string): boolean {
 		return this.#nativeToolResolver?.(name) !== undefined;
+	}
+
+	/**
+	 * Backing state for `ctx.collab`, kept live across every {@link createContext} call
+	 * (see the `get collab()` accessor there) rather than snapshotted at creation time, so
+	 * a handler that reads `ctx.collab` after `/collab stop` sees `hosting: false` even
+	 * though its own `ExtensionContext` was built before the session tore down.
+	 */
+	#collabState: ExtensionCollabState = { hosting: false, roomId: undefined };
+
+	/** Set by `CollabHost.start()`/`stop()` (interactive mode only) to back `ctx.collab`. */
+	setCollabState(state: ExtensionCollabState): void {
+		this.#collabState = state;
 	}
 
 	/**
@@ -1154,6 +1168,7 @@ export class ExtensionRunner {
 		},
 	): ExtensionContext {
 		const getModel = model ? () => model : this.#getModel;
+		const getCollabState = () => this.#collabState;
 		return {
 			ui: this.#uiContext,
 			mode: this.#mode,
@@ -1169,6 +1184,9 @@ export class ExtensionRunner {
 				return getModel();
 			},
 			models: createExtensionModelQuery(this.modelRegistry, this.settings, getModel),
+			get collab() {
+				return getCollabState();
+			},
 			isIdle: () => this.#isIdleFn(),
 			abort: () => this.#abortFn(),
 			hasPendingMessages: () => this.#hasPendingMessagesFn(),

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -477,6 +477,8 @@ export interface ExtensionContext {
 	model: Model | undefined;
 	/** Read-only model query facade: list / current / resolve / family. */
 	models: ExtensionModelQuery;
+	/** Live `/collab` host state for this session: whether it's hosting, and the active room id. */
+	collab: ExtensionCollabState;
 	/** Whether the agent is idle (not streaming) */
 	isIdle(): boolean;
 	/** Abort the current agent operation */
@@ -864,6 +866,53 @@ export interface McpNotificationEvent {
 }
 
 // ============================================================================
+// Collab Events
+// ============================================================================
+
+/**
+ * Fired once a `/collab` host session is live and broadcasting to guests, and
+ * again with `collab_end` when it tears down (user `/collab stop`, relay
+ * drop, or session switch).
+ *
+ * Deliberately excludes the room key and write token that make
+ * `CollabHost.link`/`CollabHost.webLink` joinable. Extensions run trusted
+ * in-process — the same trust level as the terminal user who already sees
+ * the raw link — but there is no reason to widen the blast radius of a
+ * future extension bug or a malicious extension by handing every loaded
+ * extension the literal secret on every event fire. `roomId` plus
+ * `ctx.collab` (see {@link ExtensionContext.collab}) is enough for an
+ * extension to know a session is live and which room it is.
+ */
+export interface CollabStartEvent {
+	type: "collab_start";
+	/** Room identifier guests join through. Not secret on its own: joining still requires the room key/write token. */
+	roomId: string;
+	/** Relay server hosting the room. */
+	relayUrl: string;
+	/** Base origin of the configured collab web UI, with no room key/write-token fragment attached. */
+	webLink: string;
+	/** Whether the host session carries a write-capable link (`CollabHost` always starts write-enabled). */
+	hasWriteToken: boolean;
+}
+
+/** Fired when a `/collab` host session tears down. See {@link CollabStartEvent}. */
+export interface CollabEndEvent {
+	type: "collab_end";
+	roomId: string;
+	relayUrl: string;
+	webLink: string;
+	hasWriteToken: boolean;
+}
+
+/** Live `ctx.collab` snapshot: whether this session is hosting a `/collab` session right now. */
+export interface ExtensionCollabState {
+	/** True while this session has an active `/collab` host session. */
+	hosting: boolean;
+	/** Room id of the active session, or `undefined` when not hosting. */
+	roomId: string | undefined;
+}
+
+// ============================================================================
 // User Bash Events
 // ============================================================================
 
@@ -1094,6 +1143,8 @@ export type ExtensionEvent =
 	| GoalUpdatedEvent
 	| CredentialDisabledEvent
 	| McpNotificationEvent
+	| CollabStartEvent
+	| CollabEndEvent
 	| UserBashEvent
 	| UserPythonEvent
 	| InputEvent
@@ -1282,6 +1333,8 @@ export interface ExtensionAPI {
 	on(event: "todo_reminder", handler: ExtensionHandler<TodoReminderEvent>): void;
 	on(event: "goal_updated", handler: ExtensionHandler<GoalUpdatedEvent>): void;
 	on(event: "credential_disabled", handler: ExtensionHandler<CredentialDisabledEvent>): void;
+	on(event: "collab_start", handler: ExtensionHandler<CollabStartEvent>): void;
+	on(event: "collab_end", handler: ExtensionHandler<CollabEndEvent>): void;
 	on(event: "input", handler: ExtensionHandler<InputEvent, InputEventResult>): void;
 	on(event: "tool_approval_requested", handler: ExtensionHandler<ToolApprovalRequestedEvent>): void;
 	on(event: "tool_approval_resolved", handler: ExtensionHandler<ToolApprovalResolvedEvent>): void;

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -6131,6 +6131,9 @@ export class AgentSession {
 
 			model: this.model ?? undefined,
 			models: createExtensionModelQuery(this.#modelRegistry, this.settings, () => this.model ?? undefined),
+			// No `CollabHost` reaches this runner-less fallback: it only exists without an
+			// ExtensionRunner (e.g. a subagent session), and collab hosting is interactive-only.
+			collab: { hosting: false, roomId: undefined },
 			isIdle: () => !this.isStreaming,
 			abort: () => {
 				void this.abort();

--- a/packages/coding-agent/test/collab/collab-extension-events.test.ts
+++ b/packages/coding-agent/test/collab/collab-extension-events.test.ts
@@ -1,0 +1,199 @@
+/**
+ * `/collab` host lifecycle fires `collab_start`/`collab_end` extension events
+ * and keeps `ctx.collab` (hosting/roomId) in sync, without ever handing a
+ * loaded extension the room key or write token that make the link joinable
+ * (see `CollabStartEvent` in extensibility/extensions/types.ts).
+ *
+ * Mirrors the `session_start` handler-dispatch convention used elsewhere in
+ * the extension test suite (extensions-runner.test.ts): a real extension
+ * module is written to disk, loaded through `loadExtensions`, and run by a
+ * real `ExtensionRunner`; handler observations are recorded to a marker file
+ * since the extension executes in its own module scope. `CollabHost` itself
+ * runs unchanged over the in-memory relay transport used by the rest of the
+ * collab suite (see ./helpers/in-memory-relay).
+ */
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { CollabHost } from "@oh-my-pi/pi-coding-agent/collab/host";
+import { parseCollabLink } from "@oh-my-pi/pi-coding-agent/collab/protocol";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { loadExtensions } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/loader";
+import { ExtensionRunner } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/runner";
+import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { getProjectAgentDir, TempDir } from "@oh-my-pi/pi-utils";
+import { installInMemoryRelay, uninstallInMemoryRelay } from "./helpers/in-memory-relay";
+
+interface RecordedEvent {
+	type: "collab_start" | "collab_end";
+	event: {
+		type: "collab_start" | "collab_end";
+		roomId: string;
+		relayUrl: string;
+		webLink: string;
+		hasWriteToken: boolean;
+	};
+	collab: { hosting: boolean; roomId: string | undefined };
+}
+
+const RELAY_URL = "ws://localhost:8787";
+
+describe("/collab host extension events", () => {
+	let tempDir: TempDir;
+	let markerPath: string;
+	let authStorage: AuthStorage;
+	let modelRegistry: ModelRegistry;
+	let runner: ExtensionRunner;
+
+	beforeEach(async () => {
+		tempDir = TempDir.createSync("@pi-collab-extension-events-");
+		markerPath = path.join(tempDir.path(), "events.jsonl");
+		const extensionsDir = path.join(getProjectAgentDir(tempDir.path()), "extensions");
+		fs.mkdirSync(extensionsDir, { recursive: true });
+		fs.writeFileSync(
+			path.join(extensionsDir, "record-collab-events.ts"),
+			`
+				import * as fs from "node:fs";
+
+				export default function(pi) {
+					const record = (type, event, ctx) => {
+						fs.appendFileSync(${JSON.stringify(markerPath)}, JSON.stringify({ type, event, collab: ctx.collab }) + "\\n");
+					};
+					pi.on("collab_start", (event, ctx) => record("collab_start", event, ctx));
+					pi.on("collab_end", (event, ctx) => record("collab_end", event, ctx));
+				}
+			`,
+		);
+
+		const discoveredPaths = fs
+			.readdirSync(extensionsDir, { withFileTypes: true })
+			.filter(entry => entry.isFile())
+			.map(entry => path.join(extensionsDir, entry.name));
+		const result = await loadExtensions(discoveredPaths, tempDir.path());
+
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "auth.db"));
+		modelRegistry = new ModelRegistry(authStorage);
+		const sessionManager = SessionManager.inMemory();
+		runner = new ExtensionRunner(result.extensions, result.runtime, tempDir.path(), sessionManager, modelRegistry);
+
+		installInMemoryRelay();
+	});
+
+	afterEach(() => {
+		uninstallInMemoryRelay();
+		authStorage.close();
+		tempDir.removeSync();
+	});
+
+	function makeHostContext(): InteractiveModeContext {
+		return {
+			settings: { get: () => "" },
+			sessionManager: {
+				getSessionId: () => "sess-1",
+				getCwd: () => "/tmp",
+				snapshotForReplication: () => ({
+					header: { type: "session", id: "sess-1", timestamp: new Date().toISOString(), cwd: "/tmp" },
+					entries: [],
+				}),
+				onEntryAppended: undefined,
+			},
+			session: {
+				isStreaming: false,
+				queuedMessageCount: 0,
+				sessionName: "test",
+				model: undefined,
+				thinkingLevel: undefined,
+				subscribe: () => () => {},
+				emitNotice: () => {},
+				promptCustomMessage: () => Promise.resolve(),
+				abort: () => Promise.resolve(),
+				extensionRunner: runner,
+			},
+			eventBus: undefined,
+			statusLine: {
+				setCollabStatus: () => {},
+				invalidate: () => {},
+				getCachedContextBreakdown: () => ({ usedTokens: 0, contextWindow: 0 }),
+			},
+			ui: { requestRender: () => {} },
+			showStatus: () => {},
+			collabHost: undefined,
+		} as unknown as InteractiveModeContext;
+	}
+
+	function readEvents(): RecordedEvent[] {
+		if (!fs.existsSync(markerPath)) return [];
+		return fs
+			.readFileSync(markerPath, "utf8")
+			.split("\n")
+			.filter(line => line.length > 0)
+			.map(line => JSON.parse(line) as RecordedEvent);
+	}
+
+	it("fires collab_start/collab_end with a secret-free payload and keeps ctx.collab in sync", async () => {
+		expect(runner.createContext().collab).toEqual({ hosting: false, roomId: undefined });
+
+		const ctx = makeHostContext();
+		const host = new CollabHost(ctx);
+		await host.start(RELAY_URL);
+
+		const parsedLink = parseCollabLink(host.link);
+		if ("error" in parsedLink) throw new Error(parsedLink.error);
+		const keyText = Buffer.from(parsedLink.key).toString("base64url");
+		const writeTokenText = parsedLink.writeToken ? Buffer.from(parsedLink.writeToken).toString("base64url") : "";
+
+		// `runner.emit` for collab_start/collab_end is fire-and-forget (`void`), so
+		// give its microtask a turn before reading the marker file back.
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(runner.createContext().collab).toEqual({ hosting: true, roomId: parsedLink.roomId });
+
+		let events = readEvents();
+		expect(events).toHaveLength(1);
+		const started = events[0];
+		if (!started) throw new Error("expected a recorded collab_start event");
+		expect(started.type).toBe("collab_start");
+		expect(started.event).toEqual({
+			type: "collab_start",
+			roomId: parsedLink.roomId,
+			relayUrl: RELAY_URL,
+			webLink: "http://localhost:8787",
+			hasWriteToken: true,
+		});
+		// The event must never carry the room key or write token embedded in
+		// `host.link`/`host.webLink` — only `roomId` (opaque, not by itself
+		// sufficient to join) is safe to broadcast to every loaded extension.
+		expect(started.event.webLink).not.toContain(keyText);
+		expect(started.event.webLink).not.toContain(writeTokenText);
+		expect(started.collab).toEqual({ hosting: true, roomId: parsedLink.roomId });
+
+		await host.stop("test done");
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(runner.createContext().collab).toEqual({ hosting: false, roomId: undefined });
+
+		events = readEvents();
+		expect(events).toHaveLength(2);
+		const ended = events[1];
+		if (!ended) throw new Error("expected a recorded collab_end event");
+		expect(ended.type).toBe("collab_end");
+		expect(ended.event).toEqual({ ...started.event, type: "collab_end" });
+		// By the time collab_end handlers run, the session has already torn down.
+		expect(ended.collab).toEqual({ hosting: false, roomId: undefined });
+	});
+
+	it("does not fire collab_start/collab_end for a host that never came up", async () => {
+		const ctx = makeHostContext();
+		const host = new CollabHost(ctx);
+		// Malformed relay URL: `start()` throws while formatting the link, before ever
+		// opening a socket, so neither event should fire and hosting stays false.
+		await expect(host.start("not a valid url")).rejects.toThrow();
+
+		expect(readEvents()).toHaveLength(0);
+		expect(runner.createContext().collab).toEqual({ hosting: false, roomId: undefined });
+	});
+});

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -159,6 +159,78 @@ describe("ExtensionRunner", () => {
 		expect(runner.createContext().mode).toBe("tui");
 	});
 
+	describe("collab state", () => {
+		it("defaults ctx.collab to not-hosting and reflects setCollabState() live", async () => {
+			const result = await loadTestExtensions();
+			const runner = new ExtensionRunner(
+				result.extensions,
+				result.runtime,
+				tempDir.path(),
+				sessionManager,
+				modelRegistry,
+			);
+
+			expect(runner.createContext().collab).toEqual({ hosting: false, roomId: undefined });
+
+			runner.setCollabState({ hosting: true, roomId: "room-123" });
+			expect(runner.createContext().collab).toEqual({ hosting: true, roomId: "room-123" });
+
+			// Same guarantee as the live `model` getter (see "reflects
+			// SessionManager.moveTo()" above): a context handed to an in-flight
+			// handler must observe a later state change, not a construction-time
+			// snapshot.
+			const liveCtx = runner.createContext();
+			runner.setCollabState({ hosting: false, roomId: undefined });
+			expect(liveCtx.collab).toEqual({ hosting: false, roomId: undefined });
+		});
+
+		it("dispatches collab_start/collab_end to subscribed extensions with the documented payload", async () => {
+			const markerPath = path.join(tempDir.path(), "collab-events.jsonl");
+			fs.writeFileSync(
+				path.join(extensionsDir, "collab-listener.ts"),
+				`
+					import * as fs from "node:fs";
+
+					export default function(pi) {
+						const record = (type, event) => {
+							fs.appendFileSync(${JSON.stringify(markerPath)}, JSON.stringify({ type, event }) + "\\n");
+						};
+						pi.on("collab_start", event => record("collab_start", event));
+						pi.on("collab_end", event => record("collab_end", event));
+					}
+				`,
+			);
+
+			const result = await loadTestExtensions();
+			const runner = new ExtensionRunner(
+				result.extensions,
+				result.runtime,
+				tempDir.path(),
+				sessionManager,
+				modelRegistry,
+			);
+
+			const payload = {
+				roomId: "room-abc",
+				relayUrl: "wss://relay.example",
+				webLink: "https://example.com",
+				hasWriteToken: true,
+			};
+			await runner.emit({ type: "collab_start", ...payload });
+			await runner.emit({ type: "collab_end", ...payload });
+
+			const recorded = fs
+				.readFileSync(markerPath, "utf8")
+				.split("\n")
+				.filter(line => line.length > 0)
+				.map(line => JSON.parse(line));
+			expect(recorded).toEqual([
+				{ type: "collab_start", event: { type: "collab_start", ...payload } },
+				{ type: "collab_end", event: { type: "collab_end", ...payload } },
+			]);
+		});
+	});
+
 	describe("shortcut conflicts", () => {
 		it("warns when extension shortcut conflicts with built-in", async () => {
 			const extCode = `

--- a/packages/natives/README.md
+++ b/packages/natives/README.md
@@ -48,7 +48,8 @@ console.log(pdf.markdown, pdf.pagesNeedingOcr);
 ## Building
 
 ```bash
-# Build native addon from workspace root (requires Rust)
+# Build native addon from workspace root (requires Rust, plus cmake and ninja
+# on PATH for the bundled Opus/audio bindings — e.g. `brew install cmake ninja` on macOS)
 bun run build
 
 # Type check


### PR DESCRIPTION
What

Adds `collab_start`/`collab_end` events to the extension system so a third-party extension can observe when a `/collab` session starts and stops, plus a live `ctx.collab` accessor.

- New `collab_start`/`collab_end` events in the `ExtensionEvent` union (`extensibility/extensions/types.ts`). Payload: `{ roomId, relayUrl, webLink, hasWriteToken }`.
- `CollabHost.start()` fires `collab_start` once the session is actually up (socket open, taps wired); its teardown path (`/collab stop`, relay drop without reconnect, or session switch) fires `collab_end`.
- New `ctx.collab: { hosting: boolean; roomId: string | undefined }` on `ExtensionContext`, wired through `ExtensionRunner.setCollabState()`/`createContext()`, so an extension can ask "is a collab session active right now" without caching event payloads across a session-long lifetime.
- `docs/extensions.md` gets a `### Collab state (ctx.collab)` and `### Collab lifecycle` section describing both.
- A drive-by fix: `packages/natives/README.md` and `AGENTS.md` now call out that a fresh checkout needs `cmake`/`ninja` on `PATH` in addition to Rust to build `pi_natives` — every `bun test` in `packages/coding-agent` fails with an opaque native-addon load error otherwise, and nothing documented that in the build instructions. Happy to drop this from the PR if you'd rather keep it separate.

Why

Today's extension `ExtensionEvent` union has no collaboration category at all, and `CollabHost`/`CollabGuestLink` live only on the TUI-only `InteractiveModeContext`, never reaching the separate `ExtensionContext` that extensions actually receive. There's no way for an extension to know a `/collab` session is live — e.g. to post a notification somewhere, adjust its own behavior while being observed by a guest, or log collab session boundaries for audit.

The event payload and `ctx.collab` deliberately exclude the room key and write token that make `CollabHost.link`/`webLink` joinable. Extensions run trusted in-process, at the same trust level as the terminal user who already sees the raw link, but there's no reason to widen the blast radius of a future extension bug (or a malicious extension) by handing every loaded extension the literal secret on every event fire. `roomId` plus `ctx.collab` is enough to know a session is live and which room it is; `webLink` in the payload is the web UI's base origin only (`normalizeCollabWebBaseUrl`), with no room-secret fragment attached.

Testing

- New `test/collab/collab-extension-events.test.ts`: an end-to-end test over the existing in-memory relay harness (`test/collab/helpers/in-memory-relay.ts`) — a real `CollabHost` + a real `ExtensionRunner` with a loaded extension file. Asserts `collab_start`/`collab_end` fire with the documented payload, that `webLink` never contains the room key or write token embedded in `host.link`, that `ctx.collab` flips `hosting`/`roomId` in sync with the host lifecycle, and that a host that never comes up (malformed relay URL) fires neither event.
- Extended `test/extensions-runner.test.ts` with a `collab state` block mirroring the existing `session_start` handler-dispatch tests: `ctx.collab` defaults to not-hosting, reflects `setCollabState()` live (same guarantee as the existing `model` getter), and `collab_start`/`collab_end` dispatch to subscribed extensions with the exact payload.
- `bun run check:types` (tsgo) passes with no errors.
- `bun test test/extensions-runner.test.ts test/collab/` — 164 pass, 0 fail.
- `biome check` clean on every changed file.

Happy to adjust naming, payload shape, or split the doc/env-note commit out if you'd prefer it separate.
