### PR TITLE
fix(catalog,coding-agent): strip OpenRouter route suffixes in bareModelId

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
-
+- Fixed family identity for OpenRouter route-suffixed ids (`z-ai/glm-5.3:nitro`, `deepseek/deepseek-v4-pro-0813:nitro`): `bareModelId` now strips the request-time routing suffix (`:nitro`, `:floor`, `:online`, `:exacto`, `:extended`) alongside the provider namespace, so GLM-5.3 keeps its wire-exact `low`/`high`/`max` effort ladder and dated DeepSeek SKUs no longer collapse to the `high`-only ladder when selected through a routing variant.
 - Fixed the thinking control mode for OpenAI models served over Bedrock Converse (`global.openai.gpt-5.6-luna`, `-sol`, `-terra`), which are now classified as `effort` rather than `budget` so requests use OpenAI's reasoning schema.
 - Fixed LiteLLM discovery leaking a colliding bundled model's provider-specific transport onto custom endpoints: a discovered alias (e.g. `kimi-k3`) matching a bundled Fireworks model no longer inherits that model's wire-id transform, which had caused requests to POST a model id the endpoint never advertised and return HTTP 400 ([#9938](https://github.com/can1357/oh-my-pi/issues/9938)).
 

--- a/packages/catalog/src/identity/classify.ts
+++ b/packages/catalog/src/identity/classify.ts
@@ -50,14 +50,27 @@ export interface UnknownModel {
 
 export type ParsedModel = GeminiModel | AnthropicModel | OpenAIModel | UnknownModel;
 
-/** Strip a provider namespace prefix (`openai/gpt-5.4` → `gpt-5.4`). */
+/**
+ * Strip a provider namespace prefix (`openai/gpt-5.4` → `gpt-5.4`) and any
+ * trailing OpenRouter route suffix (`glm-5.3-flash:nitro` → `glm-5.3-flash`),
+ * so identity parsers see the canonical id behind an aggregator variant.
+ */
 // Cache keyed by model id (a bounded set of bundled/aggregator ids), so no eviction is needed.
 const bareModelIdCache = new Map<string, string>();
 export function bareModelId(modelId: string): string {
 	const cached = bareModelIdCache.get(modelId);
 	if (cached !== undefined) return cached;
-	const p = modelId.lastIndexOf("/");
-	const result = p !== -1 ? modelId.slice(p + 1) : modelId;
+	const slash = modelId.lastIndexOf("/");
+	let result = slash !== -1 ? modelId.slice(slash + 1) : modelId;
+	// OpenRouter route suffixes (`:nitro`, `:floor`, `:exacto`, …) are request-time
+	// routing shortcuts, never part of a real family id. Thinking-level suffixes
+	// (`:high`, `:max`) share the shape; parsers called on bare ids treat them as
+	// unknown words either way, so stripping uniformly is safe and keeps e.g.
+	// `isGlm53ReasoningEffortModelId` working for `...:nitro` selectors.
+	const colon = result.lastIndexOf(":");
+	if (colon !== -1) {
+		result = result.slice(0, colon);
+	}
 	bareModelIdCache.set(modelId, result);
 	return result;
 }

--- a/packages/catalog/test/identity-family.test.ts
+++ b/packages/catalog/test/identity-family.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import {
+	bareModelId,
 	hasOpus47ApiRestrictions,
 	isClaudeModelId,
 	isGeminiModelId,
+	isGlm53ReasoningEffortModelId,
 	isGlmVisionModelId,
 	isGrokModelId,
 	isGrokMultiAgentModelId,
@@ -313,6 +315,15 @@ describe("isReasoningGlmModelId", () => {
 	});
 });
 
+describe("family matchers on OpenRouter route-suffixed ids", () => {
+	test("isGlm53ReasoningEffortModelId sees through :nitro route suffixes", () => {
+		expect(isGlm53ReasoningEffortModelId("z-ai/glm-5.3:nitro")).toBe(true);
+		expect(isGlm53ReasoningEffortModelId("z-ai/glm-5.3-air:nitro")).toBe(true);
+		// Flash/preview variants stay excluded with or without a route suffix.
+		expect(isGlm53ReasoningEffortModelId("z-ai/glm-5.3-flash")).toBe(false);
+		expect(isGlm53ReasoningEffortModelId("z-ai/glm-5.3-flash:nitro")).toBe(false);
+	});
+});
 describe("isGlmVisionModelId", () => {
 	test("matches the `v` vision shape across versions and variants", () => {
 		expect(isGlmVisionModelId("glm-4v")).toBe(true);
@@ -437,5 +448,19 @@ describe("isGrokXHighEffortCapable", () => {
 		expect(isGrokXHighEffortCapable("grok-3-mini")).toBe(false);
 		expect(isGrokXHighEffortCapable("grok-build")).toBe(false);
 		expect(isGrokXHighEffortCapable("")).toBe(false);
+	});
+});
+
+describe("bareModelId", () => {
+	test("strips OpenRouter route suffixes alongside the provider namespace", () => {
+		expect(bareModelId("z-ai/glm-5.3-flash:nitro")).toBe("glm-5.3-flash");
+		expect(bareModelId("deepseek/deepseek-v4-pro-0813:nitro")).toBe("deepseek-v4-pro-0813");
+		expect(bareModelId("openai/gpt-4o:extended")).toBe("gpt-4o");
+	});
+
+	test("keeps ids without a colon suffix untouched", () => {
+		expect(bareModelId("anthropic/claude-opus-5")).toBe("claude-opus-5");
+		expect(bareModelId("gpt-5.6-luna")).toBe("gpt-5.6-luna");
+		expect(bareModelId("")).toBe("");
 	});
 });

--- a/packages/coding-agent/src/config/model-resolver.ts
+++ b/packages/coding-agent/src/config/model-resolver.ts
@@ -448,6 +448,11 @@ export function resolveProviderModelReference(
 		return undefined;
 	}
 
+	// OpenRouter route suffixes (`:nitro`, `:floor`, `:online`, `:exacto`, `:extended`)
+	// are request-time routing shortcuts that never appear in any catalog or discovery
+	// listing, so the exact lookup above cannot see them. Fall back through the
+	// suffix/date-stripped candidate chain to the base catalog model and clone it with
+	// the requested id, preserving route semantics on the wire.
 	for (const fallbackId of getOpenRouterFallbackModelIds(modelId).slice(1)) {
 		const fallback = index.get(`${normalizedProvider}\u0000${fallbackId.toLowerCase()}`);
 		if (fallback === null) {

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -649,6 +649,27 @@ describe("parseModelPattern", () => {
 			expect(result.warning).toBeUndefined();
 		});
 
+		test("supports route suffixes on undated ids when only the base is registered", () => {
+			// `openrouter/z-ai/glm-4.7:nitro` has no dated snapshot to strip; the fallback
+			// chain must still reach base `z-ai/glm-4.7` (also covers `:floor`, `:online`,
+			// `:exacto`, `:extended` — none appear in any catalog listing).
+			const result = parseModelPattern("openrouter/z-ai/glm-4.7:nitro", allModels);
+			expect(result.model?.provider).toBe("openrouter");
+			expect(result.model?.id).toBe("z-ai/glm-4.7:nitro");
+			expect(result.thinkingLevel).toBeUndefined();
+			expect(result.explicitThinkingLevel).toBe(false);
+			expect(result.warning).toBeUndefined();
+		});
+
+		test("supports route suffixes on undated ids with an appended thinking level", () => {
+			const result = parseModelPattern("openrouter/z-ai/glm-4.7:nitro:max", allModels);
+			expect(result.model?.provider).toBe("openrouter");
+			expect(result.model?.id).toBe("z-ai/glm-4.7:nitro");
+			expect(result.thinkingLevel).toBe(Effort.Max);
+			expect(result.explicitThinkingLevel).toBe(true);
+			expect(result.warning).toBeUndefined();
+		});
+
 		test("openrouter/<id>:max applies max through the exact-selector path, not an OpenRouter route", () => {
 			// `max` is a thinking-level suffix, never an OpenRouter route suffix: the request
 			// must resolve the base model and carry max, not clone a literal `z-ai/glm-4.7:max`.


### PR DESCRIPTION
## What

`bareModelId()` now strips OpenRouter routing-variant suffixes (`:nitro`, `:floor`, `:online`, `:exacto`, `:extended`) after the provider namespace, so every downstream identity parser (`parseGlmModel`, `parseAnthropicModel`, `parseOpenAIModel`, family matchers, `getModelDefinedEfforts`) sees the canonical base id behind an aggregator variant selector.

## Why

Route suffixes are request-time shortcuts that never appear in any catalog or discovery listing, but selectors can carry them (`openrouter/z-ai/glm-5.3:nitro`). Upstream, `bareModelId` kept the suffix, which produced wrong family metadata in two reproducible ways:

- `isGlm53ReasoningEffortModelId("z-ai/glm-5.3:nitro")` returned `false` while the bare id returns `true`, so GLM-5.3's wire-exact `low/high/max` ladder silently degraded to the generic inference ladder (`minimal..high`).
- `deepseek/deepseek-v4-pro-0813:nitro` missed the strict dated-SKU equality in `getModelDefinedEfforts` and collapsed to the `HIGH_ONLY` ladder instead of `low/high/max` (verified: upstream `{"efforts":["high"]}` → patched `{"efforts":["low","high","max"]}`).

The fix composes with the existing request-time append (`applyOpenRouterRoutingVariant` already skips ids containing a colon after the last slash), so a selector suffix and the `providers.openrouterVariant` global never double-append or conflict: the selector wins, the flag fills the gap.

## Testing

- `bun run check` (biome + tsgo) in `packages/catalog` and `packages/coding-agent`
- `bun test` in `packages/catalog`: 782 pass
- `bun test packages/coding-agent/test/model-resolver.test.ts`: 161 pass (adds 2: undated route-suffix selectors, with and without an appended thinking level)
- Identity regression tests in `packages/catalog/test/identity-family.test.ts`: matchers see through `:nitro`, `bareModelId` stripping table
- Live: selector `openrouter/z-ai/glm-5.3-flash:nitro` against the bundled catalog resolves to a clone of the base row with intact thinking metadata and wire id carrying the suffix

## Related

- [#9725](https://github.com/can1357/oh-my-pi/pull/9725) (`@preset/` selectors) is orthogonal — presets suppress routing variants rather than resolve them
- Related to the selector-resolution gap discussed in [#3273](https://github.com/can1357/oh-my-pi/issues/3273)

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (user-facing: `packages/catalog/CHANGELOG.md`)