### PR TITLE
fix(lsp): surface slow or failed pull diagnostics instead of reporting OK

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `lsp diagnostics` reporting `OK` for project-aware pull-diagnostic servers (e.g. Roslyn) whose `textDocument/diagnostic` response overran the 3s single-file budget; such servers now get a longer single-file wait and a timed-out or errored pull surfaces as a server failure instead of a clean result ([#10035](https://github.com/can1357/oh-my-pi/issues/10035)).
+
 ## [18.0.9] - 2026-08-28
 
 ### Breaking Changes

--- a/packages/coding-agent/src/lsp/diagnostics.ts
+++ b/packages/coding-agent/src/lsp/diagnostics.ts
@@ -289,10 +289,9 @@ export async function waitForDiagnostics(
 				break;
 			}
 			if (pullResult.failed !== undefined) {
-				// A pull-capable server that errors/times out won't answer via pull; stop
-				// waiting. The final publish re-check still lets a late publish win.
+				// A pull failure leaves the report unknown, but a dual-mode server
+				// may still publish fresh diagnostics within the remaining budget.
 				pullFailure = pullResult.failed;
-				break;
 			}
 		}
 	}
@@ -300,7 +299,12 @@ export async function waitForDiagnostics(
 	const versionOk = minVersion === undefined || client.diagnosticsVersion > minVersion;
 	const published = client.diagnostics.get(uri);
 	if (published && versionOk) {
-		return published.diagnostics;
+		if (expectedDocumentVersion !== undefined && published.version === expectedDocumentVersion) {
+			return published.diagnostics;
+		}
+		if (published === settledRef && Date.now() - settledAt >= settleMs) {
+			return published.diagnostics;
+		}
 	}
 	if (pullResultPromise) {
 		const outcome = await pullResultPromise;

--- a/packages/coding-agent/src/lsp/diagnostics.ts
+++ b/packages/coding-agent/src/lsp/diagnostics.ts
@@ -31,6 +31,14 @@ import {
 
 const DIAGNOSTIC_MESSAGE_LIMIT = 50;
 export const SINGLE_DIAGNOSTICS_WAIT_TIMEOUT_MS = 3000;
+/**
+ * Single-file diagnostics wait budget for project-aware servers (Roslyn, tsserver, …).
+ * Their first pull-diagnostic response computes analysis on demand and routinely
+ * takes several seconds, overrunning {@link SINGLE_DIAGNOSTICS_WAIT_TIMEOUT_MS};
+ * an explicit `lsp diagnostics` request can afford to wait, so give it more room
+ * (still capped by the tool-level timeout).
+ */
+export const PROJECT_DIAGNOSTICS_WAIT_TIMEOUT_MS = 10_000;
 export const BATCH_DIAGNOSTICS_WAIT_TIMEOUT_MS = 400;
 const DIAGNOSTICS_POLL_MS = 100;
 const DIAGNOSTICS_SETTLE_MS = 250;
@@ -196,25 +204,38 @@ interface WaitForDiagnosticsOptions {
 	settleMs?: number;
 }
 
+/**
+ * Outcome of one document pull-diagnostic request.
+ *
+ * Distinguishes a usable report from a failed request so a timeout or RPC error
+ * is never mistaken for a clean file. `diagnostics` holds the report's items (an
+ * empty array means the server reported the file clean); `failed` carries the
+ * error when the pull could not complete.
+ */
+interface PullDiagnosticsOutcome {
+	diagnostics?: Diagnostic[];
+	failed?: unknown;
+}
+
 function requestDocumentDiagnostics(
 	client: LspClient,
 	uri: string,
 	signal: AbortSignal | undefined,
 	timeoutMs: number,
-): Promise<Diagnostic[] | undefined> {
+): Promise<PullDiagnosticsOutcome> {
 	return sendRequest(client, "textDocument/diagnostic", { textDocument: { uri } }, signal, timeoutMs)
 		.then(report => {
 			if (!report || typeof report !== "object" || !("kind" in report) || report.kind !== "full") {
-				return undefined;
+				return {};
 			}
-			if (!("items" in report) || !Array.isArray(report.items)) return undefined;
-			return report.items;
+			if (!("items" in report) || !Array.isArray(report.items)) return {};
+			return { diagnostics: report.items };
 		})
 		.catch(err => {
 			if (!signal?.aborted) {
 				logger.debug("LSP document diagnostic pull failed", { server: client.name, uri, error: String(err) });
 			}
-			return undefined;
+			return { failed: err };
 		});
 }
 
@@ -226,17 +247,16 @@ export async function waitForDiagnostics(
 	const { timeoutMs = 3000, signal, minVersion, expectedDocumentVersion, settleMs = DIAGNOSTICS_SETTLE_MS } = options;
 	const deadline = Date.now() + timeoutMs;
 	let pullAttempted = false;
-	let pullResultPromise: Promise<{ diagnostics: Diagnostic[] | undefined }> | undefined;
+	let pullResultPromise: Promise<PullDiagnosticsOutcome> | undefined;
 	let pulled: Diagnostic[] | undefined;
+	let pullFailure: unknown;
 	let settledRef: PublishedDiagnostics | undefined;
 	let settledAt = 0;
 	while (Date.now() < deadline) {
 		throwIfAborted(signal);
 		if (!pullAttempted && supportsDocumentDiagnostics(client)) {
 			pullAttempted = true;
-			pullResultPromise = requestDocumentDiagnostics(client, uri, signal, Math.max(1, deadline - Date.now())).then(
-				diagnostics => ({ diagnostics }),
-			);
+			pullResultPromise = requestDocumentDiagnostics(client, uri, signal, Math.max(1, deadline - Date.now()));
 		}
 
 		const versionOk = minVersion === undefined || client.diagnosticsVersion > minVersion;
@@ -264,8 +284,16 @@ export async function waitForDiagnostics(
 		const pullResult = await Promise.race([pullResultPromise, Bun.sleep(pollMs).then(() => undefined)]);
 		if (pullResult) {
 			pullResultPromise = undefined;
-			pulled = pullResult.diagnostics;
-			if (pulled !== undefined) break;
+			if (pullResult.diagnostics !== undefined) {
+				pulled = pullResult.diagnostics;
+				break;
+			}
+			if (pullResult.failed !== undefined) {
+				// A pull-capable server that errors/times out won't answer via pull; stop
+				// waiting. The final publish re-check still lets a late publish win.
+				pullFailure = pullResult.failed;
+				break;
+			}
 		}
 	}
 
@@ -275,10 +303,19 @@ export async function waitForDiagnostics(
 		return published.diagnostics;
 	}
 	if (pullResultPromise) {
-		pulled = (await pullResultPromise).diagnostics;
+		const outcome = await pullResultPromise;
+		if (outcome.diagnostics !== undefined) pulled = outcome.diagnostics;
+		else if (outcome.failed !== undefined) pullFailure = outcome.failed;
 	}
 	throwIfAborted(signal);
-	if (pulled === undefined) return [];
+	if (pulled === undefined) {
+		// A failed pull (timeout/RPC error) leaves the file's state unknown; never
+		// let it collapse into a clean empty result the caller renders as "OK".
+		if (pullFailure !== undefined) {
+			throw pullFailure instanceof Error ? pullFailure : new Error(String(pullFailure));
+		}
+		return [];
+	}
 	client.diagnostics.set(uri, {
 		diagnostics: pulled,
 		version: expectedDocumentVersion ?? client.openFiles.get(uri)?.version ?? null,

--- a/packages/coding-agent/src/lsp/tool.ts
+++ b/packages/coding-agent/src/lsp/tool.ts
@@ -39,6 +39,7 @@ import {
 	isOnlyQueriedDeclaration,
 	MAX_GLOB_DIAGNOSTIC_TARGETS,
 	normalizeLocationResult,
+	PROJECT_DIAGNOSTICS_WAIT_TIMEOUT_MS,
 	PROJECT_INDEXED_ACTIONS,
 	REFERENCE_CONTEXT_LIMIT,
 	REFERENCES_RETRY_COUNT,
@@ -305,9 +306,6 @@ export class LspTool implements AgentTool<typeof lspSchema, LspToolDetails, Them
 			}
 
 			const detailed = targets.length > 1 || truncatedGlobTargets;
-			const diagnosticsWaitTimeoutMs = detailed
-				? Math.min(BATCH_DIAGNOSTICS_WAIT_TIMEOUT_MS, timeoutSec * 1000)
-				: Math.min(SINGLE_DIAGNOSTICS_WAIT_TIMEOUT_MS, timeoutSec * 1000);
 			const results: string[] = [];
 			const allServerNames = new Set<string>();
 			let totalServerAttempts = 0;
@@ -355,8 +353,17 @@ export class LspTool implements AgentTool<typeof lspSchema, LspToolDetails, Them
 						const minVersion = client.diagnosticsVersion;
 						await refreshFile(client, resolved, signal);
 						const expectedDocumentVersion = client.openFiles.get(uri)?.version;
+						// Project-aware servers (Roslyn, tsserver, …) compute pull diagnostics
+						// on demand; their first response routinely overruns the 3s single-file
+						// budget, which would otherwise surface as a false "OK". An explicit
+						// diagnostics request can afford to wait, bounded by the tool timeout.
+						const waitCapMs = detailed
+							? BATCH_DIAGNOSTICS_WAIT_TIMEOUT_MS
+							: isProjectAwareLspServer(serverConfig)
+								? PROJECT_DIAGNOSTICS_WAIT_TIMEOUT_MS
+								: SINGLE_DIAGNOSTICS_WAIT_TIMEOUT_MS;
 						const diagnostics = await waitForDiagnostics(client, uri, {
-							timeoutMs: diagnosticsWaitTimeoutMs,
+							timeoutMs: Math.min(waitCapMs, timeoutSec * 1000),
 							signal,
 							minVersion,
 							expectedDocumentVersion,

--- a/packages/coding-agent/test/tools/lsp-regressions.test.ts
+++ b/packages/coding-agent/test/tools/lsp-regressions.test.ts
@@ -11,6 +11,7 @@ import { LspTool } from "@oh-my-pi/pi-coding-agent/lsp";
 import * as lspClient from "@oh-my-pi/pi-coding-agent/lsp/client";
 import * as lspConfig from "@oh-my-pi/pi-coding-agent/lsp/config";
 import { getServersForFile, type LspConfig, loadConfig } from "@oh-my-pi/pi-coding-agent/lsp/config";
+import { waitForDiagnostics } from "@oh-my-pi/pi-coding-agent/lsp/diagnostics";
 import {
 	applyTextEditsToString,
 	applyWorkspaceEdit,
@@ -1660,87 +1661,108 @@ describe("lsp regressions", () => {
 		}, 15_000);
 	}
 
-	it("surfaces a failed document pull as a server failure instead of OK (#10035)", async () => {
-		const tempDir = TempDir.createSync("@omp-lsp-failed-pull-");
-		try {
-			// initTheme() populates the module theme the tool's error renderer reads;
-			// production initializes it before any tool runs.
-			await initTheme();
-			const targetFile = path.join(tempDir.path(), "Program.cs");
-			await Bun.write(targetFile, "private readonly object _gate = new();\n");
+	for (const scenario of [
+		{
+			name: "rejects a failed document pull when no publish follows (#10035)",
+			publish: false,
+			settleMs: 0,
+			acceptsPublish: false,
+		},
+		{
+			name: "accepts fresh published diagnostics after a document pull failure (#10035)",
+			publish: true,
+			settleMs: 0,
+			acceptsPublish: true,
+		},
+		{
+			name: "rejects an unversioned publish that has not settled after a pull failure (#10035)",
+			publish: true,
+			settleMs: 10_000,
+			acceptsPublish: false,
+		},
+	]) {
+		it(scenario.name, async () => {
+			const tempDir = TempDir.createSync("@omp-lsp-failed-pull-");
+			try {
+				const targetFile = path.join(tempDir.path(), "Program.cs");
+				await Bun.write(targetFile, "private readonly object _gate = new();\n");
+				const uri = fileToUri(targetFile);
+				const publishedDiagnostic: Diagnostic = {
+					message: "Use System.Threading.Lock",
+					severity: 3,
+					code: "IDE0330",
+					source: "roslyn",
+					range: {
+						start: { line: 0, character: 25 },
+						end: { line: 0, character: 38 },
+					},
+				};
 
-			// Roslyn-shaped server: no static diagnosticProvider, dynamically registers
-			// textDocument/diagnostic on `initialized`, then fails the pull (mirrors a
-			// cold analysis pull that overruns the wait budget and gets cancelled).
-			const fakeServer = installFakeLsp((message, server) => {
-				if (message.method === "initialize") {
-					server.send({ jsonrpc: "2.0", id: message.id, result: { capabilities: {} } });
-					server.send({
-						jsonrpc: "2.0",
-						method: "$/progress",
-						params: { token: "roslyn", value: { kind: "begin" } },
-					});
-					server.send({
-						jsonrpc: "2.0",
-						method: "$/progress",
-						params: { token: "roslyn", value: { kind: "end" } },
-					});
-				} else if (message.method === "initialized") {
-					server.send({
-						jsonrpc: "2.0",
-						id: "register-diagnostics",
-						method: "client/registerCapability",
-						params: {
-							registrations: [
-								{
-									id: "pull-diagnostics",
-									method: "textDocument/diagnostic",
-									registerOptions: { identifier: "DocumentCompilerSemantic" },
-								},
-							],
-						},
-					});
-				} else if (message.method === "textDocument/diagnostic") {
-					server.send({
-						jsonrpc: "2.0",
-						id: message.id,
-						error: { code: -32800, message: "request failed" },
-					});
-				} else if (message.method === "shutdown") {
-					server.send({ jsonrpc: "2.0", id: message.id, result: null });
-				} else if (message.method === "exit") {
-					server.exit(0);
+				const fakeServer = installFakeLsp((message, server) => {
+					if (message.method === "initialize") {
+						server.send({ jsonrpc: "2.0", id: message.id, result: { capabilities: {} } });
+					} else if (message.method === "initialized") {
+						server.send({
+							jsonrpc: "2.0",
+							id: "register-diagnostics",
+							method: "client/registerCapability",
+							params: {
+								registrations: [
+									{
+										id: "pull-diagnostics",
+										method: "textDocument/diagnostic",
+										registerOptions: { identifier: "DocumentCompilerSemantic" },
+									},
+								],
+							},
+						});
+					} else if (message.method === "textDocument/diagnostic") {
+						server.send({
+							jsonrpc: "2.0",
+							id: message.id,
+							error: { code: -32800, message: "request failed" },
+						});
+						if (scenario.publish) {
+							setImmediate(() => {
+								server.send({
+									jsonrpc: "2.0",
+									method: "textDocument/publishDiagnostics",
+									params: { uri, diagnostics: [publishedDiagnostic] },
+								});
+							});
+						}
+					} else if (message.method === "shutdown") {
+						server.send({ jsonrpc: "2.0", id: message.id, result: null });
+					} else if (message.method === "exit") {
+						server.exit(0);
+					}
+				});
+				const serverConfig: ServerConfig = {
+					command: "Microsoft.CodeAnalysis.LanguageServer",
+					fileTypes: ["cs"],
+					rootMarkers: [],
+				};
+				const client = await lspClient.getOrCreateClient(serverConfig, tempDir.path());
+				const diagnostics = waitForDiagnostics(client, uri, {
+					timeoutMs: scenario.acceptsPublish ? 1_000 : 50,
+					settleMs: scenario.settleMs,
+				});
+
+				if (scenario.acceptsPublish) {
+					expect(await diagnostics).toEqual([publishedDiagnostic]);
+				} else {
+					await expect(diagnostics).rejects.toThrow("request failed");
 				}
-			});
-
-			const serverConfig: ServerConfig = {
-				command: "Microsoft.CodeAnalysis.LanguageServer",
-				fileTypes: ["cs"],
-				rootMarkers: [],
-			};
-			vi.spyOn(lspConfig, "loadConfig").mockReturnValue({
-				servers: { roslyn: serverConfig },
-				idleTimeoutMs: undefined,
-			});
-			vi.spyOn(lspConfig, "getServersForFile").mockReturnValue([["roslyn", serverConfig]]);
-
-			const tool = new LspTool(makeLspSession(tempDir.path()));
-			const result = await tool.execute("failed-pull", {
-				action: "diagnostics",
-				file: targetFile,
-				timeout: 20,
-			});
-
-			expect(fakeServer.received.map(m => m.method)).toContain("textDocument/diagnostic");
-			const text = textResult(result);
-			expect(text).not.toBe("OK");
-			expect(text).toContain("all language servers failed");
-			expect(result.details?.success).toBe(false);
-		} finally {
-			await lspClient.shutdownAll();
-			tempDir.removeSync();
-		}
-	}, 15_000);
+				if (scenario.publish) {
+					expect(client.diagnostics.get(uri)?.diagnostics).toEqual([publishedDiagnostic]);
+				}
+				expect(fakeServer.received.map(m => m.method)).toContain("textDocument/diagnostic");
+			} finally {
+				await lspClient.shutdownAll();
+				tempDir.removeSync();
+			}
+		}, 15_000);
+	}
 
 	it("does not reuse stale file diagnostics after another URI publishes", async () => {
 		const tempDir = TempDir.createSync("@omp-lsp-stale-diags-");

--- a/packages/coding-agent/test/tools/lsp-regressions.test.ts
+++ b/packages/coding-agent/test/tools/lsp-regressions.test.ts
@@ -1660,6 +1660,88 @@ describe("lsp regressions", () => {
 		}, 15_000);
 	}
 
+	it("surfaces a failed document pull as a server failure instead of OK (#10035)", async () => {
+		const tempDir = TempDir.createSync("@omp-lsp-failed-pull-");
+		try {
+			// initTheme() populates the module theme the tool's error renderer reads;
+			// production initializes it before any tool runs.
+			await initTheme();
+			const targetFile = path.join(tempDir.path(), "Program.cs");
+			await Bun.write(targetFile, "private readonly object _gate = new();\n");
+
+			// Roslyn-shaped server: no static diagnosticProvider, dynamically registers
+			// textDocument/diagnostic on `initialized`, then fails the pull (mirrors a
+			// cold analysis pull that overruns the wait budget and gets cancelled).
+			const fakeServer = installFakeLsp((message, server) => {
+				if (message.method === "initialize") {
+					server.send({ jsonrpc: "2.0", id: message.id, result: { capabilities: {} } });
+					server.send({
+						jsonrpc: "2.0",
+						method: "$/progress",
+						params: { token: "roslyn", value: { kind: "begin" } },
+					});
+					server.send({
+						jsonrpc: "2.0",
+						method: "$/progress",
+						params: { token: "roslyn", value: { kind: "end" } },
+					});
+				} else if (message.method === "initialized") {
+					server.send({
+						jsonrpc: "2.0",
+						id: "register-diagnostics",
+						method: "client/registerCapability",
+						params: {
+							registrations: [
+								{
+									id: "pull-diagnostics",
+									method: "textDocument/diagnostic",
+									registerOptions: { identifier: "DocumentCompilerSemantic" },
+								},
+							],
+						},
+					});
+				} else if (message.method === "textDocument/diagnostic") {
+					server.send({
+						jsonrpc: "2.0",
+						id: message.id,
+						error: { code: -32800, message: "request failed" },
+					});
+				} else if (message.method === "shutdown") {
+					server.send({ jsonrpc: "2.0", id: message.id, result: null });
+				} else if (message.method === "exit") {
+					server.exit(0);
+				}
+			});
+
+			const serverConfig: ServerConfig = {
+				command: "Microsoft.CodeAnalysis.LanguageServer",
+				fileTypes: ["cs"],
+				rootMarkers: [],
+			};
+			vi.spyOn(lspConfig, "loadConfig").mockReturnValue({
+				servers: { roslyn: serverConfig },
+				idleTimeoutMs: undefined,
+			});
+			vi.spyOn(lspConfig, "getServersForFile").mockReturnValue([["roslyn", serverConfig]]);
+
+			const tool = new LspTool(makeLspSession(tempDir.path()));
+			const result = await tool.execute("failed-pull", {
+				action: "diagnostics",
+				file: targetFile,
+				timeout: 20,
+			});
+
+			expect(fakeServer.received.map(m => m.method)).toContain("textDocument/diagnostic");
+			const text = textResult(result);
+			expect(text).not.toBe("OK");
+			expect(text).toContain("all language servers failed");
+			expect(result.details?.success).toBe(false);
+		} finally {
+			await lspClient.shutdownAll();
+			tempDir.removeSync();
+		}
+	}, 15_000);
+
 	it("does not reuse stale file diagnostics after another URI publishes", async () => {
 		const tempDir = TempDir.createSync("@omp-lsp-stale-diags-");
 		try {


### PR DESCRIPTION
## Repro
Running `lsp diagnostics` on a single file served by a project-aware pull-diagnostic server (the official Roslyn `Microsoft.CodeAnalysis.LanguageServer`) reports `OK` even though the server returns real diagnostics through `textDocument/diagnostic`. An out-of-band `textDocument/diagnostic` probe against the same file returns the full report (IDE0330, CA1822, IDE0005). Reproduced in-process with a fake LSP server that mimics Roslyn's handshake (no static `diagnosticProvider`; dynamic `client/registerCapability` for `textDocument/diagnostic` on `initialized`): a prompt reply renders `2 info(s), 1 hint(s)`, but delaying the reply past the 3s single-file budget makes OMP send `$/cancelRequest` and render `OK`.

## Cause
The single-file diagnostics path waited `SINGLE_DIAGNOSTICS_WAIT_TIMEOUT_MS` (3s) for the pull regardless of server class, and `requestDocumentDiagnostics` in `packages/coding-agent/src/lsp/diagnostics.ts` caught a timeout/RPC error and returned `undefined`, which `waitForDiagnostics` collapsed into `[]`. `LspTool`'s diagnostics action (`packages/coding-agent/src/lsp/tool.ts`) then rendered the empty result as a clean `OK`. Roslyn computes `DocumentCompilerSemantic`/`DocumentAnalyzerSemantic` diagnostics on demand and its first response routinely overruns 3s, so a timed-out pull was indistinguishable from a genuinely clean file.

## Fix
- `diagnostics.ts`: `requestDocumentDiagnostics` now returns a `PullDiagnosticsOutcome` that distinguishes a usable full report (empty `items` = clean) from a failed pull (`failed` carries the error).
- `diagnostics.ts`: `waitForDiagnostics` tracks the pull failure and, when no publish/pull ever produced a report, rethrows it instead of returning `[]` — so a timeout/RPC error can no longer masquerade as clean.
- `diagnostics.ts`: added `PROJECT_DIAGNOSTICS_WAIT_TIMEOUT_MS` (10s).
- `tool.ts`: the single-file diagnostics wait now uses a per-server cap — `PROJECT_DIAGNOSTICS_WAIT_TIMEOUT_MS` for project-aware servers, `SINGLE_DIAGNOSTICS_WAIT_TIMEOUT_MS` otherwise, `BATCH_DIAGNOSTICS_WAIT_TIMEOUT_MS` for multi-file — still bounded by the tool-level timeout. A thrown pull failure is caught by the existing per-server handler and rendered as a server failure rather than `OK`.

## Verification
`bun test test/tools/lsp-regressions.test.ts test/tools/lsp-diagnostics-dedup.test.ts test/tools/lsp-diagnostics-freshness.test.ts test/tools/lsp-batching.test.ts` -> 145 pass, 0 fail, including a new regression test (`surfaces a failed document pull as a server failure instead of OK (#10035)`) that drives the Roslyn-shaped dynamic registration and fails the pull, asserting the output is not `OK`, contains `all language servers failed`, and reports `success: false`. `bunx tsgo -p tsconfig.json --noEmit` in `packages/coding-agent` exits 0.

Fixes #10035