### PR TITLE
fix(lsp): refresh discovery and complete Rust diagnostics

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -26,6 +26,13 @@
 - Kept embedded context usage visible in the status line when long session names or paths consume available space.
 - Added a status message when `CTRL-O` toggles tool-output expansion.
 - Fixed `omp usage` to report Codex Chat and Spark capacity meters separately when they share a usage window.
+- Fixed `lsp reload *` retaining cached executable misses, so language servers installed during a running session are discovered without restarting OMP.
+- Fixed Rust file diagnostics treating an early empty rust-analyzer pull as complete; diagnostics now wait for a fresh publication or report the timeout instead of returning false `OK`.
+- Fixed the VCS status line counting every file inside an untracked directory instead of collapsing it to one entry like `git status`.
+- Fixed git TUI sidebar wheel scrolling snapping back to the selected row after staging or collapsing entries; the list now follows the selection only when it actually changes.
+- Fixed `inspect_image` selecting a text-only vision/default role when an image-capable model was available on the active provider.
+- Improved unexpected-stop recovery for reasoning-only stalls by requiring the next concrete tool action instead of repeated analysis.
+- The edit tool now repairs a stray closing marker typed in place of the divider in a selection (`old⟫new` inside one selection instead of `old│new`) and applies the intended replacement with a note, instead of failing with an unmatched-marker error.
 
 ## [18.0.8] - 2026-08-27
 

--- a/packages/coding-agent/src/lsp/client.ts
+++ b/packages/coding-agent/src/lsp/client.ts
@@ -34,6 +34,8 @@ const clientLocks = new Map<string, PendingClient>();
 const invalidatedClientKeys = new Set<string>();
 const clientReloadBarriers = new Map<string, Promise<unknown>>();
 const fileOperationLocks = new Map<string, Promise<void>>();
+const rustAnalyzerFlycheckCompletions = new WeakMap<LspClient, number>();
+const RUST_ANALYZER_FLYCHECK_TOKEN_PREFIX = "rust-analyzer/flycheck/";
 
 /** Negative cache of recent init failures so a broken server fails fast instead of re-spawning per call. */
 const INIT_FAILURE_BACKOFF_MS = 3 * 60 * 1000;
@@ -396,6 +398,15 @@ async function startMessageReader(client: LspClient): Promise<void> {
 									client.activeProgressTokens.add(params.token);
 								} else if (params.value?.kind === "end") {
 									client.activeProgressTokens.delete(params.token);
+									if (
+										typeof params.token === "string" &&
+										params.token.startsWith(RUST_ANALYZER_FLYCHECK_TOKEN_PREFIX)
+									) {
+										rustAnalyzerFlycheckCompletions.set(
+											client,
+											(rustAnalyzerFlycheckCompletions.get(client) ?? 0) + 1,
+										);
+									}
 									if (client.activeProgressTokens.size === 0) {
 										client.resolveProjectLoaded();
 									}
@@ -784,6 +795,19 @@ export function isRustAnalyzerClient(client: LspClient): boolean {
 		commandBasename(client.config.command) === "rust-analyzer" ||
 		(client.config.resolvedCommand ? commandBasename(client.config.resolvedCommand) === "rust-analyzer" : false)
 	);
+}
+
+/** Monotonic count of completed rust-analyzer flycheck progress cycles. */
+export function getRustAnalyzerFlycheckCompletion(client: LspClient): number {
+	return rustAnalyzerFlycheckCompletions.get(client) ?? 0;
+}
+
+/** Whether rust-analyzer currently reports an active flycheck progress token. */
+export function isRustAnalyzerFlycheckActive(client: LspClient): boolean {
+	for (const token of client.activeProgressTokens) {
+		if (typeof token === "string" && token.startsWith(RUST_ANALYZER_FLYCHECK_TOKEN_PREFIX)) return true;
+	}
+	return false;
 }
 
 function isRustAnalyzerStatusTimeout(err: unknown): boolean {

--- a/packages/coding-agent/src/lsp/config.ts
+++ b/packages/coding-agent/src/lsp/config.ts
@@ -434,7 +434,7 @@ function getConfigSources(cwd: string): ConfigSource[] {
  * }
  * ```
  */
-export function loadConfig(cwd: string): LspConfig {
+export function loadConfig(cwd: string, resolveOptions?: ResolveCommandOptions): LspConfig {
 	let mergedServers = coerceServerConfigs(DEFAULTS);
 
 	const configSources = getConfigSources(cwd).reverse();
@@ -464,7 +464,7 @@ export function loadConfig(cwd: string): LspConfig {
 			if (!hasRootMarkers(cwd, config.rootMarkers)) continue;
 
 			// Check if the language server binary is available (local or $PATH)
-			const resolved = resolveCommand(config.command, cwd);
+			const resolved = resolveCommand(config.command, cwd, resolveOptions);
 			if (!resolved) continue;
 
 			detected[name] = { ...config, resolvedCommand: resolved };
@@ -480,7 +480,7 @@ export function loadConfig(cwd: string): LspConfig {
 	for (const [name, config] of Object.entries(mergedWithRuntime)) {
 		if (config.disabled) continue;
 		if (!hasRootMarkers(cwd, config.rootMarkers)) continue;
-		const resolved = resolveCommand(config.command, cwd);
+		const resolved = resolveCommand(config.command, cwd, resolveOptions);
 		if (!resolved) continue;
 		available[name] = { ...config, resolvedCommand: resolved };
 	}

--- a/packages/coding-agent/src/lsp/diagnostics.ts
+++ b/packages/coding-agent/src/lsp/diagnostics.ts
@@ -185,6 +185,10 @@ interface WaitForDiagnosticsOptions {
 	signal?: AbortSignal;
 	minVersion?: number;
 	expectedDocumentVersion?: number;
+	/** Treat an empty diagnostic pull as provisional until a fresh publish arrives. */
+	requirePublishForEmptyPull?: boolean;
+	/** Additional server-specific completion signal for an empty result. */
+	isComplete?: () => boolean;
 	/**
 	 * Quiescence window (ms). typescript-language-server never echoes the document
 	 * version (issue #983) and emits diagnostics from several sources at different
@@ -223,13 +227,22 @@ export async function waitForDiagnostics(
 	uri: string,
 	options: WaitForDiagnosticsOptions = {},
 ): Promise<Diagnostic[]> {
-	const { timeoutMs = 3000, signal, minVersion, expectedDocumentVersion, settleMs = DIAGNOSTICS_SETTLE_MS } = options;
+	const {
+		timeoutMs = 3000,
+		signal,
+		minVersion,
+		expectedDocumentVersion,
+		settleMs = DIAGNOSTICS_SETTLE_MS,
+		requirePublishForEmptyPull = false,
+		isComplete,
+	} = options;
 	const deadline = Date.now() + timeoutMs;
 	let pullAttempted = false;
 	let pullResultPromise: Promise<{ diagnostics: Diagnostic[] | undefined }> | undefined;
 	let pulled: Diagnostic[] | undefined;
 	let settledRef: PublishedDiagnostics | undefined;
 	let settledAt = 0;
+	let completionSettledAt = 0;
 	while (Date.now() < deadline) {
 		throwIfAborted(signal);
 		if (!pullAttempted && supportsDocumentDiagnostics(client)) {
@@ -255,6 +268,13 @@ export async function waitForDiagnostics(
 				return published.diagnostics;
 			}
 		}
+		if (isComplete?.()) {
+			if (completionSettledAt === 0) {
+				completionSettledAt = Date.now();
+			} else if (Date.now() - completionSettledAt >= settleMs) {
+				return pulled ?? [];
+			}
+		}
 
 		const pollMs = Math.min(DIAGNOSTICS_POLL_MS, Math.max(0, deadline - Date.now()));
 		if (!pullResultPromise) {
@@ -265,7 +285,7 @@ export async function waitForDiagnostics(
 		if (pullResult) {
 			pullResultPromise = undefined;
 			pulled = pullResult.diagnostics;
-			if (pulled !== undefined) break;
+			if (pulled !== undefined && (pulled.length > 0 || !requirePublishForEmptyPull)) break;
 		}
 	}
 
@@ -278,6 +298,10 @@ export async function waitForDiagnostics(
 		pulled = (await pullResultPromise).diagnostics;
 	}
 	throwIfAborted(signal);
+	if (isComplete?.()) return pulled ?? [];
+	if (requirePublishForEmptyPull && (pulled === undefined || pulled.length === 0)) {
+		throw new Error("Timed out waiting for the language server to publish complete diagnostics");
+	}
 	if (pulled === undefined) return [];
 	client.diagnostics.set(uri, {
 		diagnostics: pulled,

--- a/packages/coding-agent/src/lsp/servers.ts
+++ b/packages/coding-agent/src/lsp/servers.ts
@@ -1,4 +1,4 @@
-import { logger } from "@oh-my-pi/pi-utils";
+import { logger, WhichCachePolicy } from "@oh-my-pi/pi-utils";
 import { throwIfAborted } from "../tools/tool-errors";
 import {
 	getActiveClients,
@@ -200,6 +200,14 @@ export function getConfig(cwd: string): LspConfig {
 		config = loadConfig(cwd);
 		configCache.set(cwd, config);
 	}
+	setIdleTimeout(config.idleTimeoutMs);
+	return config;
+}
+
+/** Re-read LSP configuration and refresh executable lookup results for an explicit reload. */
+export function refreshConfig(cwd: string): LspConfig {
+	const config = loadConfig(cwd, { cache: WhichCachePolicy.Fresh, PATH: process.env.PATH });
+	configCache.set(cwd, config);
 	setIdleTimeout(config.idleTimeoutMs);
 	return config;
 }

--- a/packages/coding-agent/src/lsp/tool.ts
+++ b/packages/coding-agent/src/lsp/tool.ts
@@ -21,7 +21,9 @@ import {
 	clearInitializationFailure,
 	ensureFileOpen,
 	getActiveClients,
+	getRustAnalyzerFlycheckCompletion,
 	getOrCreateClient,
+	isRustAnalyzerFlycheckActive,
 	isRustAnalyzerClient,
 	type LspServerStatus,
 	refreshFile,
@@ -56,7 +58,6 @@ import {
 } from "./edits";
 import { detectLspmux } from "./lspmux";
 import {
-	configCache,
 	getConfig,
 	getLspServerForFile,
 	getLspServers,
@@ -64,6 +65,7 @@ import {
 	isMethodNotFoundError,
 	isProjectAwareLspServer,
 	LSP_READONLY_ACTIONS,
+	refreshConfig,
 	reloadServer,
 } from "./servers";
 import {
@@ -107,6 +109,26 @@ import {
 import { runWorkspaceDiagnostics } from "./workspace-diagnostics";
 
 const MAX_RENAME_PAIRS = 1000;
+const RUST_FLYCHECK_START_WAIT_MS = 3_000;
+const RUST_FLYCHECK_START_POLL_MS = 100;
+const RUST_FLYCHECK_START_ATTEMPTS = 3;
+
+async function triggerRustAnalyzerFlycheck(client: LspClient, uri: string, signal: AbortSignal): Promise<number> {
+	const completion = getRustAnalyzerFlycheckCompletion(client);
+	for (let attempt = 0; attempt < RUST_FLYCHECK_START_ATTEMPTS; attempt++) {
+		await sendNotification(client, "rust-analyzer/runFlycheck", { textDocument: { uri } }, signal);
+		const deadline = Date.now() + RUST_FLYCHECK_START_WAIT_MS;
+		while (
+			getRustAnalyzerFlycheckCompletion(client) === completion &&
+			!isRustAnalyzerFlycheckActive(client) &&
+			Date.now() < deadline
+		) {
+			await untilAborted(signal, () => Bun.sleep(RUST_FLYCHECK_START_POLL_MS));
+		}
+		if (getRustAnalyzerFlycheckCompletion(client) > completion || isRustAnalyzerFlycheckActive(client)) break;
+	}
+	return completion;
+}
 
 interface FileRenamePair {
 	oldUri: string;
@@ -355,12 +377,28 @@ export class LspTool implements AgentTool<typeof lspSchema, LspToolDetails, Them
 						const minVersion = client.diagnosticsVersion;
 						await refreshFile(client, resolved, signal);
 						const expectedDocumentVersion = client.openFiles.get(uri)?.version;
-						const diagnostics = await waitForDiagnostics(client, uri, {
-							timeoutMs: diagnosticsWaitTimeoutMs,
-							signal,
-							minVersion,
-							expectedDocumentVersion,
-						});
+						const rustAnalyzer = isRustAnalyzerClient(client);
+						const diagnostics = [
+							...(await waitForDiagnostics(client, uri, {
+								timeoutMs: diagnosticsWaitTimeoutMs,
+								signal,
+								minVersion,
+								expectedDocumentVersion,
+							})),
+						];
+						if (rustAnalyzer && !detailed) {
+							const flycheckDiagnosticsVersion = client.diagnosticsVersion;
+							const flycheckCompletion = await triggerRustAnalyzerFlycheck(client, uri, signal);
+							const flycheckDiagnostics = await waitForDiagnostics(client, uri, {
+								timeoutMs: timeoutSec * 1000,
+								signal,
+								minVersion: flycheckDiagnosticsVersion,
+								expectedDocumentVersion,
+								requirePublishForEmptyPull: true,
+								isComplete: () => getRustAnalyzerFlycheckCompletion(client) > flycheckCompletion,
+							});
+							diagnostics.push(...flycheckDiagnostics);
+						}
 						allDiagnostics.push(...diagnostics);
 						succeededServers++;
 						totalServerSuccesses++;
@@ -1081,13 +1119,9 @@ export class LspTool implements AgentTool<typeof lspSchema, LspToolDetails, Them
 		}
 
 		if (action === "reload" && (isWorkspace || !resolvedFile)) {
-			// `reload *` is the user's explicit request to re-read config from
-			// disk. Drop the per-cwd cache entry so `.omp/lsp.json`, root markers,
-			// and plugin configs added after the first LSP call become visible —
-			// otherwise `getConfig` returns the first observation for the rest of
-			// the process lifetime (#3546).
-			configCache.delete(this.session.cwd);
-			const refreshedConfig = getConfig(this.session.cwd);
+			// `reload *` is an explicit refresh: re-read config and force executable
+			// resolution to replace stale positive or negative process-wide cache entries.
+			const refreshedConfig = refreshConfig(this.session.cwd);
 			const servers = getLspServers(refreshedConfig);
 			// Identity-aware client keys make a changed server resolve to a fresh
 			// client below, but the process spawned from the superseded config


### PR DESCRIPTION
## Summary

- refresh executable resolution during explicit workspace LSP reloads
- make single-file Rust diagnostics run and await rust-analyzer flycheck completion

## Root causes and fixes

### Reload executable negative cache

`reload *` cleared only the per-cwd LSP config cache. The process-global `$which` cache retained `null` misses, so reloading after installing a server still filtered it out. Explicit refresh now loads config with `WhichCachePolicy.Fresh`, replacing stale positive or negative executable entries while normal discovery remains cached.

### Rust false-clean diagnostics

rust-analyzer can return an early empty document-diagnostic pull before Cargo flycheck completes; with `checkOnSave: false`, the explicit diagnostic path also had not triggered flycheck. Single-file Rust diagnostics now prime the document pull, trigger `rust-analyzer/runFlycheck`, observe the real `rust-analyzer/flycheck/*` progress lifecycle, and accept empty results only after flycheck completes. Caller timeout remains the hard bound; incomplete work is failure-shaped rather than `OK`.

## Real-probe evidence

- **Reload lifecycle:** cached a miss for an absent executable in a live source OMP process, created the executable in an existing PATH directory, ran `lsp reload *`, then observed `Reloaded live`, `live (ready)`, and a usable document-symbol response. A fresh process independently discovered the server.
- **Rust red/clear:** disposable Cargo workspace returned E0425 from `cargo check`; source OMP diagnostics returned the same `rustc` E0425. After restoring valid Rust, `cargo check` exited 0 and diagnostics returned `OK`.
- **Navigation:** real repository Rust document symbols, raw definition, and raw references requests remained functional.

## Checks

- `bun test packages/coding-agent/test/tools/lsp-regressions.test.ts packages/coding-agent/test/tools/lsp-diagnostics-freshness.test.ts` — 127 passed
- `git diff --check`

No new unit tests were added; validation uses the requested real lifecycle probes.