### PR TITLE
fix(coding-agent): preserve Ask custom input and notes

### DIFF
--- a/docs/tools/ask.md
+++ b/docs/tools/ask.md
@@ -44,21 +44,22 @@
 2. `execute()` also requires `context.hasUI` and `context.ui`; if missing it aborts the context and throws `ToolAbortError("Ask tool requires interactive mode")`.
 3. It reads `ask.timeout` from settings, converts seconds to milliseconds (`0` disables timeout), and disables timeout entirely while plan mode is enabled.
 4. If `ask.notify` is not `off`, it sends a terminal notification: `Waiting for input`. When `speech.enabled` is true, it also sends all question text to the vocalizer before opening the dialog.
-5. When the UI supplies `askDialog`, the tool opens one rich multi-question form. Rich options receive `header`, `description`, and `preview`; results may contain an answer note or choose the dialog's `Chat about this` redirect.
-6. Otherwise it uses the selector/editor fallback for each question:
+5. When the UI supplies `askDialog`, the tool opens one rich multi-question form. Rich options receive `header`, `description`, and `preview`; results may contain a question note or choose the dialog's `Chat about this` redirect.
+6. A rich-dialog custom answer is saved on the first editor submission and advances immediately. A question note remains visible in the dialog and review, is included even when the question is unanswered, and persists when the selected answer changes.
+7. Otherwise it uses the selector/editor fallback for each question:
    - single-select list plus `Other (type your own)`
    - multi-select checkbox loop plus `Done selecting` when applicable and `Other (type your own)`
-7. In fallback multi-question mode, left/right arrow handlers move backward/forward and preserve prior answers. The final question auto-advances on selection.
-8. If a timeout fires before an answer, the fallback auto-selects the valid recommended option, or the first option otherwise; result text gets ` (auto-selected after timeout)` and `details.timedOut` is set. The rich dialog reports its own `timedOut` answers.
-9. If the user cancels without timeout, `execute()` aborts the tool context and throws `ToolAbortError("Ask tool was cancelled by the user")`.
-10. On success it formats human-readable text plus structured `details`; the TUI renderer uses `details` for rich result display.
+8. In fallback multi-question mode, left/right arrow handlers move backward/forward and preserve prior answers. The final question auto-advances on selection.
+9. If a timeout fires before an answer, the fallback auto-selects the valid recommended option, or the first option otherwise; result text gets ` (auto-selected after timeout)` and `details.timedOut` is set. The rich dialog reports its own `timedOut` answers.
+10. If the user cancels without timeout, `execute()` aborts the tool context and throws `ToolAbortError("Ask tool was cancelled by the user")`.
+11. On success it formats human-readable text plus structured `details`; the TUI renderer uses `details` for rich result display.
 
 ## Modes / Variants
 - Single question: returns flattened `details` fields.
 - Multiple questions: returns `details.results[]`; the fallback permits arrow-key back/forward navigation, while a rich UI presents the complete form.
 - Single-select: one option or custom input.
 - Multi-select: toggled choices or custom input. In the fallback, `Done selecting` appears only when forward navigation is not active and at least one choice is selected.
-- Rich ask dialog: supports per-question headers, option previews, answer notes, and a `Chat about this` redirect.
+- Rich ask dialog: supports per-question headers, option previews, question notes, and a `Chat about this` redirect.
 - Selector/editor fallback: supports labels/descriptions but not headers, previews, notes, or chat redirect.
 
 ## Side Effects

--- a/docs/tools/ask.md
+++ b/docs/tools/ask.md
@@ -45,7 +45,7 @@
 3. It reads `ask.timeout` from settings, converts seconds to milliseconds (`0` disables timeout), and disables timeout entirely while plan mode is enabled.
 4. If `ask.notify` is not `off`, it sends a terminal notification: `Waiting for input`. When `speech.enabled` is true, it also sends all question text to the vocalizer before opening the dialog.
 5. When the UI supplies `askDialog`, the tool opens one rich multi-question form. Rich options receive `header`, `description`, and `preview`; results may contain a question note or choose the dialog's `Chat about this` redirect.
-6. A rich-dialog custom answer is saved on the first editor submission and advances immediately. A question note remains visible in the dialog and review, is included even when the question is unanswered, and persists when the selected answer changes. Submitting an empty or whitespace-only note clears it.
+6. A rich-dialog custom answer is saved on the first editor submission and advances immediately. A question note remains visible in the dialog and review, is included even when the question is unanswered, and persists when the selected answer changes. Adding a note to a single-select question exposes the Submit tab so note-only context can be reviewed and sent without choosing an option. Submitting an empty or whitespace-only note clears it.
 7. Otherwise it uses the selector/editor fallback for each question:
    - single-select list plus `Other (type your own)`
    - multi-select checkbox loop plus `Done selecting` when applicable and `Other (type your own)`

--- a/docs/tools/ask.md
+++ b/docs/tools/ask.md
@@ -45,7 +45,7 @@
 3. It reads `ask.timeout` from settings, converts seconds to milliseconds (`0` disables timeout), and disables timeout entirely while plan mode is enabled.
 4. If `ask.notify` is not `off`, it sends a terminal notification: `Waiting for input`. When `speech.enabled` is true, it also sends all question text to the vocalizer before opening the dialog.
 5. When the UI supplies `askDialog`, the tool opens one rich multi-question form. Rich options receive `header`, `description`, and `preview`; results may contain a question note or choose the dialog's `Chat about this` redirect.
-6. A rich-dialog custom answer is saved on the first editor submission and advances immediately. A question note remains visible in the dialog and review, is included even when the question is unanswered, and persists when the selected answer changes.
+6. A rich-dialog custom answer is saved on the first editor submission and advances immediately. A question note remains visible in the dialog and review, is included even when the question is unanswered, and persists when the selected answer changes. Submitting an empty or whitespace-only note clears it.
 7. Otherwise it uses the selector/editor fallback for each question:
    - single-select list plus `Other (type your own)`
    - multi-select checkbox loop plus `Done selecting` when applicable and `Other (type your own)`

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -61,6 +61,7 @@
 - Fixed ACP `read` tool-call locations so clients such as Zed Follow receive the resolved filesystem path rather than the OMP line-range selector.
 - Fixed `import numpy` (and other native-extension imports) hanging indefinitely in the Python eval tool on Windows, where the runner's always-on background stdin reader deadlocked native DLL loading; Windows now reads the control channel serially between requests while POSIX keeps concurrent request dispatch ([#7985](https://github.com/can1357/oh-my-pi/issues/7985)).
 - Ask dialog custom answers now advance on the first submission, and question notes remain visible and included when answers change or remain unanswered.
+- Ask dialog custom answers now advance on the first submission, and question notes remain visible and included when answers change or remain unanswered while empty notes clear cleanly.
 
 ## [18.0.9] - 2026-08-28
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -59,6 +59,8 @@
 - Fixed a macOS composer display issue where undercurl could remain attached to stale text after rapid typing.
 - Improved `xd://` MCP failure messages with actionable transport stages, failure categories, server and tool context, retryability, trace IDs, and redacted JSON-RPC details.
 - Fixed ACP `read` tool-call locations so clients such as Zed Follow receive the resolved filesystem path rather than the OMP line-range selector.
+- Fixed `import numpy` (and other native-extension imports) hanging indefinitely in the Python eval tool on Windows, where the runner's always-on background stdin reader deadlocked native DLL loading; Windows now reads the control channel serially between requests while POSIX keeps concurrent request dispatch ([#7985](https://github.com/can1357/oh-my-pi/issues/7985)).
+- Ask dialog custom answers now advance on the first submission, and question notes remain visible and included when answers change or remain unanswered.
 
 ## [18.0.9] - 2026-08-28
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -60,7 +60,6 @@
 - Improved `xd://` MCP failure messages with actionable transport stages, failure categories, server and tool context, retryability, trace IDs, and redacted JSON-RPC details.
 - Fixed ACP `read` tool-call locations so clients such as Zed Follow receive the resolved filesystem path rather than the OMP line-range selector.
 - Fixed `import numpy` (and other native-extension imports) hanging indefinitely in the Python eval tool on Windows, where the runner's always-on background stdin reader deadlocked native DLL loading; Windows now reads the control channel serially between requests while POSIX keeps concurrent request dispatch ([#7985](https://github.com/can1357/oh-my-pi/issues/7985)).
-- Ask dialog custom answers now advance on the first submission, and question notes remain visible and included when answers change or remain unanswered.
 - Ask dialog custom answers now advance on the first submission, and question notes remain visible and included when answers change or remain unanswered while empty notes clear cleanly.
 
 ## [18.0.9] - 2026-08-28

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -34,6 +34,9 @@
 - Fixed `lsp diagnostics` incorrectly reporting success for project-aware pull-diagnostic servers when diagnostics time out or fail.
 - Corrected labels under `Settings > Context > Compaction Token Limit`.
 - Fixed orphaned pages, iframes, and workers accumulating in the shared headless browser after abnormal OMP session termination.
+### Fixed
+
+- Ask dialog custom answers now advance on the first submission, and question notes remain visible and included when answers change or remain unanswered while empty notes clear cleanly.
 
 ## [18.0.10] - 2026-08-28
 
@@ -59,9 +62,6 @@
 - Fixed a macOS composer display issue where undercurl could remain attached to stale text after rapid typing.
 - Improved `xd://` MCP failure messages with actionable transport stages, failure categories, server and tool context, retryability, trace IDs, and redacted JSON-RPC details.
 - Fixed ACP `read` tool-call locations so clients such as Zed Follow receive the resolved filesystem path rather than the OMP line-range selector.
-- Fixed `import numpy` (and other native-extension imports) hanging indefinitely in the Python eval tool on Windows, where the runner's always-on background stdin reader deadlocked native DLL loading; Windows now reads the control channel serially between requests while POSIX keeps concurrent request dispatch ([#7985](https://github.com/can1357/oh-my-pi/issues/7985)).
-- Ask dialog custom answers now advance on the first submission, and question notes remain visible and included when answers change or remain unanswered while empty notes clear cleanly.
-
 ## [18.0.9] - 2026-08-28
 
 ### Breaking Changes
@@ -1236,9 +1236,7 @@
 - Fixed two remaining tool-card double renders: a superseded assistant turn no longer leaves its never-run cards above the re-run's fresh cards (a TTSR rewind retracts them immediately; an auto-retry removes the synthetic-settled failure cards when it supersedes the turn — while a genuinely terminal failure keeps its card visible), and a successful read whose persisted result wins a transcript-rebuild race no longer creates a fallback read group when its delayed live completion arrives ([#6879](https://github.com/can1357/oh-my-pi/issues/6879)).
 - Fixed a tool card rendering twice when the provider rewrites a streamed tool call's id mid-stream — GitHub Copilot's `call_id|id` transport, or any stream that delivers the tool name/arguments before the id — so the block appears first with an empty or partial id and is populated in a later delta. The transcript keyed the live card by that mutable id, so the changed id spawned a second card: the old-id card orphaned as a blue pending preview while the new-id card took the result. Streamed tool cards are now re-keyed in place when their id changes, using the block's position in the streaming message as a stable identity ([#6879](https://github.com/can1357/oh-my-pi/issues/6879)).
 - Withheld advisor nits and concerns while the primary turn is explicitly marked in progress, while still allowing blockers for unrecoverable active side effects.
-- Preserved explicit `-e`/`--extension` and `--hook` packages under
-  `--no-extensions` while excluding ambient extension factories and sibling
-  capabilities from settings or installed OMP packages.
+- Preserved explicit `-e`/`--extension` and `--hook` packages under `--no-extensions` while excluding ambient extension factories and sibling capabilities from settings or installed OMP packages.
 - Fixed explicit `thinking` metadata in `models.yml` custom definitions and `modelOverrides` being replaced by canonical catalog policy during model rebuilding. ([#7307](https://github.com/can1357/oh-my-pi/issues/7307))
 - Fixed the auto-titler installing a model's whole answer as the session title when the tiny title model ignored the titling task and answered the first user message instead. `normalizeGeneratedTitle` now rejects overlong output (>80 chars or >12 words) so the caller defers titling to the next user turn rather than accepting a full sentence ([#7303](https://github.com/can1357/oh-my-pi/issues/7303)).
 - Fixed the in-process `kill` builtin to validate signals, preserve negative PID operands, signal every process in pipeline jobs, continue after bad targets, and refuse non-probe signals aimed at the host process or process group.

--- a/packages/coding-agent/src/modes/components/ask-dialog.ts
+++ b/packages/coding-agent/src/modes/components/ask-dialog.ts
@@ -810,7 +810,17 @@ export class AskDialogComponent implements Component {
 		const { question, state } = active;
 		const rowItems = this.#questionRows(question);
 		state.cursorIndex = clamp(state.cursorIndex, 0, Math.max(0, rowItems.length - 1));
-		return this.#renderQuestionList(question, state, rowItems, width, maxRows);
+		const note = state.note?.trim() ? normalizedInlineInput(state.note) : undefined;
+		if (!note) return this.#renderQuestionList(question, state, rowItems, width, maxRows);
+		const noteLine = theme.fg(
+			"warning",
+			`✎ Note: ${truncateToWidth(note, Math.max(1, width - 8), Ellipsis.Unicode)}`,
+		);
+		if (maxRows <= 1) {
+			return { lines: maxRows === 1 ? [noteLine] : [], scrollOffset: state.scrollOffset, indicator: "" };
+		}
+		const list = this.#renderQuestionList(question, state, rowItems, width, maxRows - 1);
+		return { ...list, lines: [noteLine, ...list.lines] };
 	}
 
 	#renderQuestionList(
@@ -824,13 +834,6 @@ export class AskDialogComponent implements Component {
 		const renderRows = (contentWidth: number): { allLines: string[]; lineStartByRow: number[] } => {
 			const allLines: string[] = [];
 			const lineStartByRow: number[] = [];
-			if (state.note?.trim()) {
-				const note = normalizedInlineInput(state.note);
-				allLines.push(
-					theme.fg("muted", `Note: ${truncateToWidth(note, Math.max(1, contentWidth - 6), Ellipsis.Unicode)}`),
-					"",
-				);
-			}
 			for (let index = 0; index < rowItems.length; index++) {
 				lineStartByRow.push(allLines.length);
 				const rowItem = rowItems[index];
@@ -849,7 +852,7 @@ export class AskDialogComponent implements Component {
 			}
 			return { allLines, lineStartByRow };
 		};
-		const layoutKey = `${width}:${rows}:${state.customInput === undefined ? 0 : 1}:${state.note?.trim() ? 1 : 0}`;
+		const layoutKey = `${width}:${rows}:${state.customInput === undefined ? 0 : 1}`;
 		let overflowLayouts = this.#overflowLayouts.get(question);
 		const knownOverflow = overflowLayouts?.has(layoutKey) ?? false;
 		let renderedRows = renderRows(knownOverflow && width > 1 ? width - 1 : width);

--- a/packages/coding-agent/src/modes/components/ask-dialog.ts
+++ b/packages/coding-agent/src/modes/components/ask-dialog.ts
@@ -528,7 +528,8 @@ export class AskDialogComponent implements Component {
 	#measureHeight(width: number, termRows: number): number {
 		const maxHeight = Math.max(MIN_DIALOG_ROWS, Math.floor(termRows * DIALOG_HEIGHT_RATIO));
 		const chrome = 5; // topBorder + divider + divider + footer + bottomBorder
-		const tabBarRows = this.#hasSubmitTab() ? 1 : 0;
+		// Every question can gain a note-only Submit tab after the initial measurement.
+		const tabBarRows = this.#questions.length > 0 ? 1 : 0;
 		const mdTheme = getMarkdownTheme();
 		let needed = MIN_DIALOG_ROWS;
 		for (let index = 0; index < this.#questions.length; index++) {

--- a/packages/coding-agent/src/modes/components/ask-dialog.ts
+++ b/packages/coding-agent/src/modes/components/ask-dialog.ts
@@ -563,8 +563,14 @@ export class AskDialogComponent implements Component {
 
 	#hasSubmitTab(): boolean {
 		// Multi questions confirm on the Submit tab, so any multi question
-		// forces the tab even when there is only one question.
-		return this.#questions.length > 1 || this.#questions.some(question => question.multi);
+		// forces the tab even when there is only one question. A note on a
+		// single-select question also needs this path so it can be submitted
+		// without selecting an answer.
+		return (
+			this.#questions.length > 1 ||
+			this.#questions.some(question => question.multi) ||
+			this.#states.some(state => state.note !== undefined)
+		);
 	}
 
 	#submitTabIndex(): number {

--- a/packages/coding-agent/src/modes/components/ask-dialog.ts
+++ b/packages/coding-agent/src/modes/components/ask-dialog.ts
@@ -105,7 +105,6 @@ interface QuestionState {
 	selectedOptions: Set<string>;
 	customInput: string | undefined;
 	note: string | undefined;
-	noteRowKey: string | undefined;
 	cursorIndex: number;
 	scrollOffset: number;
 	manualScroll: boolean;
@@ -272,28 +271,6 @@ function renderAnswerSummary(question: ExtensionAskDialogQuestion, state: Questi
 	return selected[0] ?? theme.fg("warning", "unanswered");
 }
 
-function clearNote(state: QuestionState): void {
-	state.note = undefined;
-	state.noteRowKey = undefined;
-}
-
-function clearNoteIfRow(state: QuestionState, rowKey: string): void {
-	if (state.noteRowKey === rowKey) clearNote(state);
-}
-
-function clearNoteUnlessRow(state: QuestionState, rowKey: string): void {
-	if (state.noteRowKey !== undefined && state.noteRowKey !== rowKey) clearNote(state);
-}
-
-function noteForSubmittedAnswer(question: ExtensionAskDialogQuestion, state: QuestionState): string | undefined {
-	if (state.note === undefined || state.noteRowKey === undefined) return undefined;
-	if (state.noteRowKey === "other") return state.customInput !== undefined ? state.note : undefined;
-	const match = /^option:(\d+)$/.exec(state.noteRowKey);
-	const optionIndex = match?.[1] === undefined ? Number.NaN : Number.parseInt(match[1], 10);
-	const option = Number.isInteger(optionIndex) ? question.options[optionIndex] : undefined;
-	return option && state.selectedOptions.has(option.label) ? state.note : undefined;
-}
-
 function optionMarker(question: ExtensionAskDialogQuestion, checked: boolean): string {
 	if (question.multi) return checked ? theme.checkbox.checked : theme.checkbox.unchecked;
 	return checked ? theme.radio.selected : theme.radio.unselected;
@@ -317,16 +294,14 @@ function renderRowLabel(
 	const marker = `${theme.fg(checked ? "success" : "dim", optionMarker(question, checked))} `;
 	const cursor = selected ? theme.fg("accent", `${theme.nav.cursor} `) : "  ";
 	const label = renderInlineMarkdown(rowItem.label, mdTheme, t => theme.fg(color, t));
-	const noteMarker = state.note && state.noteRowKey === rowItem.key ? theme.fg("success", "  ✎ note") : "";
 	// `width` is already the inner content width consumed by row(); when a
 	// scrollbar is needed, renderRows() calls this again with one less column.
-	// Keep the cursor, option marker, first wrapped label line, and optional
-	// note marker within that budget so the outer fit() never truncates them.
-	const noteWidth = noteMarker ? visibleWidth(noteMarker) : 0;
-	const labelWidth = Math.max(1, width - visibleWidth(cursor) - visibleWidth(marker) - noteWidth);
+	// Keep the cursor, option marker, and first wrapped label line within that
+	// budget so the outer fit() never truncates them.
+	const labelWidth = Math.max(1, width - visibleWidth(cursor) - visibleWidth(marker));
 	const wrappedLabel = wrapTextWithAnsi(label, labelWidth);
 	const indent = padding(visibleWidth(cursor) + visibleWidth(marker));
-	const lines = [`${cursor}${marker}${wrappedLabel[0] ?? ""}${noteMarker}`];
+	const lines = [`${cursor}${marker}${wrappedLabel[0] ?? ""}`];
 	for (let i = 1; i < wrappedLabel.length; i++) {
 		lines.push(`${indent}${wrappedLabel[i] ?? ""}`);
 	}
@@ -423,7 +398,6 @@ export class AskDialogComponent implements Component {
 				selectedOptions: new Set<string>(),
 				customInput: undefined,
 				note: undefined,
-				noteRowKey: undefined,
 				cursorIndex: clamp(recommended ?? 0, 0, maxIndex),
 				scrollOffset: 0,
 				manualScroll: false,
@@ -589,9 +563,8 @@ export class AskDialogComponent implements Component {
 	}
 
 	#hasSubmitTab(): boolean {
-		// Multi questions confirm on the Submit tab (Enter toggles, never
-		// submits), so any multi question forces the tab even when there is
-		// only one question.
+		// Multi questions confirm on the Submit tab, so any multi question
+		// forces the tab even when there is only one question.
 		return this.#questions.length > 1 || this.#questions.some(question => question.multi);
 	}
 
@@ -657,13 +630,16 @@ export class AskDialogComponent implements Component {
 			return `Enter submit · ↑/↓ scroll ·${scroll} ${cancel}`;
 		}
 		const question = this.#questions[this.#currentQuestionIndex()];
+		const state = this.#states[this.#currentQuestionIndex()];
 		// Enter advances in multi-question dialogs and submits single-question ones.
 		const enterAction = this.#questions.length > 1 ? "next" : "submit";
-		const action = question?.multi ? `Space toggle · Enter ${enterAction}` : "Enter select · n note";
+		const noteAction = state?.note === undefined ? "n note" : "n edit note";
+		const baseAction = question?.multi ? `Space toggle · Enter ${enterAction}` : "Enter select";
+		const action = `${baseAction} · ${noteAction}`;
 		const tabs = this.#hasSubmitTab() ? " · Tab/←/→" : "";
 		const expand = this.#expandHint();
 		if (this.#questionCanPage && indicator) {
-			return `${action} · ↑/↓${tabs} · ${cancel}${expand} · ${pageKeysLabel()} ${indicator}`;
+			return `${baseAction} · ↑/↓${tabs} · ${cancel}${expand} · ${pageKeysLabel()} ${indicator}`;
 		}
 		const scroll = indicator ? ` ${indicator} scroll ·` : "";
 		return `${action} · ↑/↓ move${tabs} ·${scroll} ${cancel}${expand}`;
@@ -725,16 +701,14 @@ export class AskDialogComponent implements Component {
 		const rowItem = rows[state.cursorIndex];
 		if (!rowItem) return;
 		if (keyData === "n" || keyData === "N") {
-			if (rowItem.kind === "option" || rowItem.kind === "other") {
-				void this.#promptForNote(question, state, rowItem);
-			}
+			void this.#promptForNote(question, state);
 			return;
 		}
 		const isEnter = matchesKey(keyData, "enter") || matchesKey(keyData, "return") || keyData === "\n";
 		const isSpace = matchesKey(keyData, "space") || keyData === " ";
 		if (!isEnter && !(question.multi && isSpace)) return;
 		if (rowItem.kind === "other") {
-			void this.#promptForCustomInput(question, state, rowItem);
+			void this.#promptForCustomInput(question, state);
 			return;
 		}
 		const option = question.options[rowItem.optionIndex ?? -1];
@@ -750,7 +724,6 @@ export class AskDialogComponent implements Component {
 			}
 			if (state.selectedOptions.has(option.label)) {
 				state.selectedOptions.delete(option.label);
-				clearNoteIfRow(state, rowItem.key);
 			} else {
 				state.selectedOptions.add(option.label);
 			}
@@ -759,7 +732,6 @@ export class AskDialogComponent implements Component {
 		}
 		state.selectedOptions = new Set([option.label]);
 		state.customInput = undefined;
-		clearNoteUnlessRow(state, rowItem.key);
 		this.#advanceAfterQuestion();
 	}
 
@@ -796,11 +768,7 @@ export class AskDialogComponent implements Component {
 		this.#requestRender();
 	}
 
-	async #promptForCustomInput(
-		question: ExtensionAskDialogQuestion,
-		state: QuestionState,
-		rowItem: QuestionRow,
-	): Promise<void> {
+	async #promptForCustomInput(question: ExtensionAskDialogQuestion, state: QuestionState): Promise<void> {
 		this.#promptActive = true;
 		try {
 			const input = await this.callbacks.onPrompt(
@@ -811,15 +779,11 @@ export class AskDialogComponent implements Component {
 			if (input.trim() === "") {
 				// Submitting an empty value unselects the custom answer.
 				state.customInput = undefined;
-				clearNoteIfRow(state, rowItem.key);
 				return;
 			}
 			state.customInput = input;
-			if (!question.multi) {
-				state.selectedOptions.clear();
-				clearNoteUnlessRow(state, rowItem.key);
-				this.#advanceAfterQuestion();
-			}
+			if (!question.multi) state.selectedOptions.clear();
+			this.#advanceAfterQuestion();
 		} finally {
 			this.#promptActive = false;
 			this.#runDeferredTimeout();
@@ -827,20 +791,12 @@ export class AskDialogComponent implements Component {
 		}
 	}
 
-	async #promptForNote(
-		question: ExtensionAskDialogQuestion,
-		state: QuestionState,
-		rowItem: QuestionRow,
-	): Promise<void> {
+	async #promptForNote(question: ExtensionAskDialogQuestion, state: QuestionState): Promise<void> {
 		this.#promptActive = true;
 		try {
-			const input = await this.callbacks.onPrompt(
-				boundPromptTitle(`Note for ${rowItem.label}: `, question.question),
-				state.noteRowKey === rowItem.key ? state.note : undefined,
-			);
+			const input = await this.callbacks.onPrompt(boundPromptTitle("Note: ", question.question), state.note);
 			if (input === undefined || this.#closed) return;
 			state.note = input;
-			state.noteRowKey = rowItem.key;
 		} finally {
 			this.#promptActive = false;
 			this.#runDeferredTimeout();
@@ -868,6 +824,13 @@ export class AskDialogComponent implements Component {
 		const renderRows = (contentWidth: number): { allLines: string[]; lineStartByRow: number[] } => {
 			const allLines: string[] = [];
 			const lineStartByRow: number[] = [];
+			if (state.note?.trim()) {
+				const note = normalizedInlineInput(state.note);
+				allLines.push(
+					theme.fg("muted", `Note: ${truncateToWidth(note, Math.max(1, contentWidth - 6), Ellipsis.Unicode)}`),
+					"",
+				);
+			}
 			for (let index = 0; index < rowItems.length; index++) {
 				lineStartByRow.push(allLines.length);
 				const rowItem = rowItems[index];
@@ -886,7 +849,7 @@ export class AskDialogComponent implements Component {
 			}
 			return { allLines, lineStartByRow };
 		};
-		const layoutKey = `${width}:${rows}:${state.customInput === undefined ? 0 : 1}`;
+		const layoutKey = `${width}:${rows}:${state.customInput === undefined ? 0 : 1}:${state.note?.trim() ? 1 : 0}`;
 		let overflowLayouts = this.#overflowLayouts.get(question);
 		const knownOverflow = overflowLayouts?.has(layoutKey) ?? false;
 		let renderedRows = renderRows(knownOverflow && width > 1 ? width - 1 : width);
@@ -944,9 +907,8 @@ export class AskDialogComponent implements Component {
 			const label = questionTabLabel(question, index);
 			const answer = renderAnswerSummary(question, state);
 			allLines.push(`${theme.fg("dim", `${index + 1}. ${label}:`)} ${answer}`);
-			const submittedNote = noteForSubmittedAnswer(question, state);
-			if (submittedNote?.trim()) {
-				const note = normalizedInlineInput(submittedNote);
+			if (state.note?.trim()) {
+				const note = normalizedInlineInput(state.note);
 				allLines.push(
 					theme.fg("muted", `   Note: ${truncateToWidth(note, Math.max(1, width - 9), Ellipsis.Unicode)}`),
 				);
@@ -1024,12 +986,7 @@ export class AskDialogComponent implements Component {
 			const state = this.#states[index];
 			if (!question || !state) continue;
 			if (state.selectedOptions.size === 0 && state.customInput === undefined) {
-				const noteMatch = /^option:(\d+)$/.exec(state.noteRowKey ?? "");
-				const notedIndex = noteMatch ? Number.parseInt(noteMatch[1], 10) : Number.NaN;
-				const fallbackIndex =
-					Number.isInteger(notedIndex) && question.options[notedIndex]
-						? notedIndex
-						: clamp(question.recommended ?? 0, 0, Math.max(0, question.options.length - 1));
+				const fallbackIndex = clamp(question.recommended ?? 0, 0, Math.max(0, question.options.length - 1));
 				const fallback = question.options[fallbackIndex];
 				if (fallback) state.selectedOptions.add(fallback.label);
 				state.timedOut = true;
@@ -1074,7 +1031,7 @@ export class AskDialogComponent implements Component {
 				multi: question.multi ?? false,
 				selectedOptions,
 				customInput: state.customInput,
-				note: noteForSubmittedAnswer(question, state),
+				note: state.note,
 				timedOut: state.timedOut || undefined,
 			});
 		}

--- a/packages/coding-agent/src/modes/components/ask-dialog.ts
+++ b/packages/coding-agent/src/modes/components/ask-dialog.ts
@@ -115,7 +115,6 @@ type QuestionRowKind = "option" | "other";
 
 interface QuestionRow {
 	kind: QuestionRowKind;
-	key: string;
 	label: string;
 	optionIndex: number | undefined;
 }
@@ -648,11 +647,10 @@ export class AskDialogComponent implements Component {
 	#questionRows(question: ExtensionAskDialogQuestion): QuestionRow[] {
 		const rows: QuestionRow[] = question.options.map((option, index) => ({
 			kind: "option",
-			key: `option:${index}`,
 			label: this.#optionLabel(question, option.label, index),
 			optionIndex: index,
 		}));
-		rows.push({ kind: "other", key: "other", label: OTHER_OPTION, optionIndex: undefined });
+		rows.push({ kind: "other", label: OTHER_OPTION, optionIndex: undefined });
 		return rows;
 	}
 
@@ -796,7 +794,7 @@ export class AskDialogComponent implements Component {
 		try {
 			const input = await this.callbacks.onPrompt(boundPromptTitle("Note: ", question.question), state.note);
 			if (input === undefined || this.#closed) return;
-			state.note = input;
+			state.note = input.trim() ? input : undefined;
 		} finally {
 			this.#promptActive = false;
 			this.#runDeferredTimeout();

--- a/packages/coding-agent/src/tools/ask.ts
+++ b/packages/coding-agent/src/tools/ask.ts
@@ -716,6 +716,7 @@ function formatQuestionResult(result: QuestionResult): string {
 			? `${result.id}: [${result.selectedOptions.join(", ")}]${suffix}`
 			: `${result.id}: ${result.selectedOptions[0]}${suffix}`;
 	}
+	if (!result.multi && result.note) return `${result.id}: (unanswered)${noteSuffix}`;
 	return result.multi ? `${result.id}: []${noteSuffix}` : `${result.id}: (cancelled)${noteSuffix}`;
 }
 

--- a/packages/coding-agent/src/tools/ask.ts
+++ b/packages/coding-agent/src/tools/ask.ts
@@ -938,6 +938,7 @@ export class AskTool implements AgentTool<typeof askSchema, AskToolDetails> {
 					if (!question || !result || result.id !== question.id) {
 						throw new Error("Ask dialog returned results that do not match the requested question order");
 					}
+					const note = result.note?.trim() ? result.note : undefined;
 					results.push({
 						id: question.id,
 						question: question.question,
@@ -945,7 +946,7 @@ export class AskTool implements AgentTool<typeof askSchema, AskToolDetails> {
 						multi: question.multi ?? false,
 						selectedOptions: result.selectedOptions,
 						customInput: result.customInput,
-						note: result.note,
+						note,
 						timedOut: result.timedOut,
 					});
 				}
@@ -959,7 +960,8 @@ export class AskTool implements AgentTool<typeof askSchema, AskToolDetails> {
 						(!result.timedOut &&
 							!result.multi &&
 							result.selectedOptions.length === 0 &&
-							result.customInput === undefined)
+							result.customInput === undefined &&
+							result.note === undefined)
 					) {
 						context.abort();
 						throw new ToolAbortError("Ask tool was cancelled by the user");

--- a/packages/coding-agent/src/tools/ask.ts
+++ b/packages/coding-agent/src/tools/ask.ts
@@ -104,7 +104,7 @@ export interface QuestionResult {
 	multi: boolean;
 	selectedOptions: string[];
 	customInput?: string;
-	/** Optional note attached to the selected answer in the rich ask dialog. */
+	/** Optional note attached to the question in the rich ask dialog. */
 	note?: string;
 	/** True when the answer was auto-selected because the dialog timed out. */
 	timedOut?: boolean;
@@ -116,7 +116,7 @@ export interface AskToolDetails {
 	multi?: boolean;
 	selectedOptions?: string[];
 	customInput?: string;
-	/** Optional note attached to the selected answer in the rich ask dialog. */
+	/** Optional note attached to the question in the rich ask dialog. */
 	note?: string;
 	/** True when the answer was auto-selected because the dialog timed out. */
 	timedOut?: boolean;

--- a/packages/coding-agent/test/modes/components/ask-dialog.test.ts
+++ b/packages/coding-agent/test/modes/components/ask-dialog.test.ts
@@ -1605,6 +1605,30 @@ describe("AskDialogComponent", () => {
 		expect(component.render(80).length).toBe(questionTab.length);
 	});
 
+	it("reserves height when a note adds the Submit tab", async () => {
+		const onPrompt = vi.fn().mockReturnValue(Promise.resolve("Additional context"));
+		const component = new AskDialogComponent(
+			[
+				{
+					id: "q1",
+					question:
+						"Choose the primary environment for this focused regression test before continuing with the remaining verification steps.",
+					options: [{ label: "Option A" }],
+				},
+			],
+			{ onSubmit: vi.fn(), onCancel: vi.fn(), onPrompt },
+		);
+		const width = 28;
+		const initialRows = component.render(width).length;
+
+		component.handleInput("n");
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(onPrompt).toHaveBeenCalledTimes(1);
+		expect(component.render(width).length).toBe(initialRows);
+	});
+
 	it("clears the custom answer when the Other prompt is submitted empty", async () => {
 		const onPrompt = vi.fn();
 		const onSubmit = vi.fn();

--- a/packages/coding-agent/test/modes/components/ask-dialog.test.ts
+++ b/packages/coding-agent/test/modes/components/ask-dialog.test.ts
@@ -611,6 +611,39 @@ describe("AskDialogComponent", () => {
 		expect(onSubmit.mock.calls[0][0].results[0].note).toBe("Additional context");
 	});
 
+	it("shows Submit for a single-select note-only response", async () => {
+		const onPrompt = vi.fn().mockReturnValue(Promise.resolve("Additional context"));
+		const onSubmit = vi.fn();
+		const component = new AskDialogComponent(
+			[
+				{
+					id: "q1",
+					question: "Choose one?",
+					options: [{ label: "Option A" }, { label: "Option B" }],
+				},
+			],
+			{ onSubmit, onCancel: vi.fn(), onPrompt },
+		);
+
+		component.handleInput("n");
+		await Promise.resolve();
+		await Promise.resolve();
+
+		const question = render(component);
+		expect(question).toContain("Submit");
+		expect(question).toContain("Tab/←/→");
+
+		component.handleInput(TAB);
+		const review = render(component);
+		expect(review).toContain("unanswered");
+		expect(review).toContain("Note: Additional context");
+
+		component.handleInput(ENTER);
+		expect(onSubmit).toHaveBeenCalledTimes(1);
+		expect(onSubmit.mock.calls[0][0].results[0].selectedOptions).toEqual([]);
+		expect(onSubmit.mock.calls[0][0].results[0].note).toBe("Additional context");
+	});
+
 	it("advances after the first multi-select custom input and shows it on Submit", async () => {
 		const onPrompt = vi.fn().mockReturnValue(Promise.resolve("custom detail"));
 		const onSubmit = vi.fn();

--- a/packages/coding-agent/test/modes/components/ask-dialog.test.ts
+++ b/packages/coding-agent/test/modes/components/ask-dialog.test.ts
@@ -566,6 +566,8 @@ describe("AskDialogComponent", () => {
 		component.handleInput("n");
 		await Promise.resolve();
 		await Promise.resolve();
+		component.handleInput(DOWN);
+		expect(render(component)).toContain("✎ Note: Additional context");
 		component.handleInput(TAB);
 
 		const review = render(component);

--- a/packages/coding-agent/test/modes/components/ask-dialog.test.ts
+++ b/packages/coding-agent/test/modes/components/ask-dialog.test.ts
@@ -484,6 +484,38 @@ describe("AskDialogComponent", () => {
 		expect(onSubmit.mock.calls[0][0].results[0].note).toBe("Updated note");
 	});
 
+	it("clears a question note when the editor submits whitespace", async () => {
+		const onPrompt = vi
+			.fn()
+			.mockReturnValueOnce(Promise.resolve("Initial note"))
+			.mockReturnValueOnce(Promise.resolve("   "));
+		const onSubmit = vi.fn();
+		const component = new AskDialogComponent(
+			[
+				{
+					id: "q1",
+					question: "Choose one?",
+					options: [{ label: "Option A" }],
+				},
+			],
+			{ onSubmit, onCancel: vi.fn(), onPrompt },
+		);
+
+		component.handleInput("n");
+		await Promise.resolve();
+		await Promise.resolve();
+		expect(render(component)).toContain("✎ Note: Initial note");
+
+		component.handleInput("n");
+		await Promise.resolve();
+		await Promise.resolve();
+		expect(render(component)).not.toContain("✎ Note:");
+		expect(render(component)).toContain("n note");
+
+		component.handleInput(ENTER);
+		expect(onSubmit.mock.calls[0][0].results[0].note).toBeUndefined();
+	});
+
 	it("preserves a note when a single-select answer changes", async () => {
 		const onPrompt = vi.fn().mockReturnValue(Promise.resolve("Note for A"));
 		const onSubmit = vi.fn();

--- a/packages/coding-agent/test/modes/components/ask-dialog.test.ts
+++ b/packages/coding-agent/test/modes/components/ask-dialog.test.ts
@@ -435,7 +435,6 @@ describe("AskDialogComponent", () => {
 		await Promise.resolve();
 
 		expect(onPrompt).toHaveBeenCalledTimes(1);
-		expect(onPrompt.mock.calls[0][0]).toBe("Note: Choose one?");
 
 		// Verify note is saved by submitting
 		component.handleInput(ENTER);
@@ -467,7 +466,6 @@ describe("AskDialogComponent", () => {
 		await Promise.resolve();
 
 		expect(onPrompt).toHaveBeenCalledTimes(1);
-		expect(onPrompt.mock.calls[0][0]).toBe("Note: Choose one?");
 		expect(onPrompt.mock.calls[0][1]).toBeUndefined();
 
 		component.handleInput(DOWN);

--- a/packages/coding-agent/test/modes/components/ask-dialog.test.ts
+++ b/packages/coding-agent/test/modes/components/ask-dialog.test.ts
@@ -410,7 +410,7 @@ describe("AskDialogComponent", () => {
 		expect(onCancel).toHaveBeenCalledTimes(1);
 	});
 
-	it("n on an option calls onPrompt and stores note with marker", async () => {
+	it("n opens a question note and submits it with the answer", async () => {
 		const onPrompt = vi.fn().mockReturnValue(Promise.resolve("My Custom Note"));
 		const onSubmit = vi.fn();
 		const questions: ExtensionAskDialogQuestion[] = [
@@ -435,7 +435,7 @@ describe("AskDialogComponent", () => {
 		await Promise.resolve();
 
 		expect(onPrompt).toHaveBeenCalledTimes(1);
-		expect(onPrompt.mock.calls[0][0]).toBe("Note for Option A: Choose one?");
+		expect(onPrompt.mock.calls[0][0]).toBe("Note: Choose one?");
 
 		// Verify note is saved by submitting
 		component.handleInput(ENTER);
@@ -444,7 +444,7 @@ describe("AskDialogComponent", () => {
 		expect(onSubmit.mock.calls[0][0].results[0].note).toBe("My Custom Note");
 	});
 
-	it("note prefill is empty when editing a different row after noting another option", async () => {
+	it("reuses a question note after moving to a different answer", async () => {
 		const onPrompt = vi.fn();
 		const onSubmit = vi.fn();
 		const questions: ExtensionAskDialogQuestion[] = [
@@ -461,74 +461,30 @@ describe("AskDialogComponent", () => {
 			onPrompt,
 		});
 
-		// Cursor starts on Option A. Add a note for A.
-		onPrompt.mockReturnValueOnce(Promise.resolve("Note for A"));
+		onPrompt.mockReturnValueOnce(Promise.resolve("Initial note"));
 		component.handleInput("n");
 		await Promise.resolve();
 		await Promise.resolve();
 
 		expect(onPrompt).toHaveBeenCalledTimes(1);
-		expect(onPrompt.mock.calls[0][0]).toBe("Note for Option A: Choose one?");
-		// No prior note → prefill is undefined.
+		expect(onPrompt.mock.calls[0][0]).toBe("Note: Choose one?");
 		expect(onPrompt.mock.calls[0][1]).toBeUndefined();
 
-		// Move down to Option B and open its note.
 		component.handleInput(DOWN);
-		onPrompt.mockReturnValueOnce(Promise.resolve("Note for B"));
-		component.handleInput("n");
-		await Promise.resolve();
-		await Promise.resolve();
-
-		expect(onPrompt).toHaveBeenCalledTimes(2);
-		// Prefill for Option B must be undefined — not the note from Option A.
-		expect(onPrompt.mock.calls[1][1]).toBeUndefined();
-
-		// Move back up to Option A and re-open its note.
-		component.handleInput("\x1b[A"); // UP
-		onPrompt.mockReturnValueOnce(Promise.resolve("Updated note"));
-		component.handleInput("n");
-		await Promise.resolve();
-		await Promise.resolve();
-
-		expect(onPrompt).toHaveBeenCalledTimes(3);
-		// Note now belongs to Option B, so re-editing Option A starts empty.
-		expect(onPrompt.mock.calls[2][1]).toBeUndefined();
-	});
-
-	it("note prefill reuses the existing note when re-editing the same row", async () => {
-		const onPrompt = vi.fn();
-		const questions: ExtensionAskDialogQuestion[] = [
-			{
-				id: "q1",
-				question: "Choose one?",
-				options: [{ label: "Option A" }],
-			},
-		];
-
-		const component = new AskDialogComponent(questions, {
-			onSubmit: vi.fn(),
-			onCancel: vi.fn(),
-			onPrompt,
-		});
-
-		// Add a note on Option A.
-		onPrompt.mockReturnValueOnce(Promise.resolve("My note"));
-		component.handleInput("n");
-		await Promise.resolve();
-		await Promise.resolve();
-
-		// Re-open the note on the same row (cursor still on Option A).
 		onPrompt.mockReturnValueOnce(Promise.resolve("Updated note"));
 		component.handleInput("n");
 		await Promise.resolve();
 		await Promise.resolve();
 
 		expect(onPrompt).toHaveBeenCalledTimes(2);
-		// Same row → prefill reuses the existing note.
-		expect(onPrompt.mock.calls[1][1]).toBe("My note");
+		expect(onPrompt.mock.calls[1][1]).toBe("Initial note");
+
+		component.handleInput(ENTER);
+		expect(onSubmit.mock.calls[0][0].results[0].selectedOptions).toEqual(["Option B"]);
+		expect(onSubmit.mock.calls[0][0].results[0].note).toBe("Updated note");
 	});
 
-	it("omits a note when a single-select answer changes to a different option", async () => {
+	it("preserves a note when a single-select answer changes", async () => {
 		const onPrompt = vi.fn().mockReturnValue(Promise.resolve("Note for A"));
 		const onSubmit = vi.fn();
 		const questions: ExtensionAskDialogQuestion[] = [
@@ -554,10 +510,10 @@ describe("AskDialogComponent", () => {
 
 		expect(onSubmit).toHaveBeenCalledTimes(1);
 		expect(onSubmit.mock.calls[0][0].results[0].selectedOptions).toEqual(["Option B"]);
-		expect(onSubmit.mock.calls[0][0].results[0].note).toBeUndefined();
+		expect(onSubmit.mock.calls[0][0].results[0].note).toBe("Note for A");
 	});
 
-	it("clears the note when a noted multi-select option is toggled off", async () => {
+	it("preserves a note when a multi-select option is toggled off", async () => {
 		const onPrompt = vi.fn().mockReturnValue(Promise.resolve("Note for A"));
 		const onSubmit = vi.fn();
 		const questions: ExtensionAskDialogQuestion[] = [
@@ -581,10 +537,7 @@ describe("AskDialogComponent", () => {
 
 		component.handleInput(SPACE);
 		component.handleInput(SPACE);
-		expect(render(component)).not.toContain("✎ note");
 
-		// Select Option B and confirm from the Submit tab; the cleared note
-		// must not resurface.
 		component.handleInput(DOWN);
 		component.handleInput(SPACE);
 		component.handleInput(TAB);
@@ -592,10 +545,39 @@ describe("AskDialogComponent", () => {
 
 		expect(onSubmit).toHaveBeenCalledTimes(1);
 		expect(onSubmit.mock.calls[0][0].results[0].selectedOptions).toEqual(["Option B"]);
-		expect(onSubmit.mock.calls[0][0].results[0].note).toBeUndefined();
+		expect(onSubmit.mock.calls[0][0].results[0].note).toBe("Note for A");
 	});
 
-	it("shows selected multi-select options together with custom input on Submit", async () => {
+	it("shows and submits a question note even while the answer is unanswered", async () => {
+		const onPrompt = vi.fn().mockReturnValue(Promise.resolve("Additional context"));
+		const onSubmit = vi.fn();
+		const component = new AskDialogComponent(
+			[
+				{
+					id: "q1",
+					question: "Choose multiple?",
+					options: [{ label: "Option A" }, { label: "Option B" }],
+					multi: true,
+				},
+			],
+			{ onSubmit, onCancel: vi.fn(), onPrompt },
+		);
+
+		component.handleInput("n");
+		await Promise.resolve();
+		await Promise.resolve();
+		component.handleInput(TAB);
+
+		const review = render(component);
+		expect(review).toContain("unanswered");
+		expect(review).toContain("Note: Additional context");
+
+		component.handleInput(ENTER);
+		expect(onSubmit.mock.calls[0][0].results[0].selectedOptions).toEqual([]);
+		expect(onSubmit.mock.calls[0][0].results[0].note).toBe("Additional context");
+	});
+
+	it("advances after the first multi-select custom input and shows it on Submit", async () => {
 		const onPrompt = vi.fn().mockReturnValue(Promise.resolve("custom detail"));
 		const onSubmit = vi.fn();
 		const questions: ExtensionAskDialogQuestion[] = [
@@ -625,9 +607,9 @@ describe("AskDialogComponent", () => {
 		await Promise.resolve();
 		await Promise.resolve();
 
-		// Multi questions do not auto-advance after the Other prompt: still on
-		// q1, so Tab twice (q2, then Submit) to reach the review.
-		component.handleInput(TAB);
+		expect(onPrompt).toHaveBeenCalledTimes(1);
+		expect(render(component)).toContain("Second question?");
+
 		component.handleInput(TAB);
 		const review = render(component);
 		expect(review).toContain("Option A");
@@ -637,6 +619,32 @@ describe("AskDialogComponent", () => {
 
 		expect(onSubmit).toHaveBeenCalledTimes(1);
 		expect(onSubmit.mock.calls[0][0].results[0].selectedOptions).toEqual(["Option A"]);
+		expect(onSubmit.mock.calls[0][0].results[0].customInput).toBe("custom detail");
+	});
+
+	it("submits a single-select custom answer on the first prompt resolution", async () => {
+		const onPrompt = vi.fn().mockReturnValue(Promise.resolve("custom detail"));
+		const onSubmit = vi.fn();
+		const component = new AskDialogComponent(
+			[
+				{
+					id: "q1",
+					question: "Choose one?",
+					options: [{ label: "Option A" }, { label: "Option B" }],
+				},
+			],
+			{ onSubmit, onCancel: vi.fn(), onPrompt },
+		);
+
+		component.handleInput(DOWN);
+		component.handleInput(DOWN);
+		component.handleInput(ENTER);
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(onPrompt).toHaveBeenCalledTimes(1);
+		expect(onSubmit).toHaveBeenCalledTimes(1);
+		expect(onSubmit.mock.calls[0][0].results[0].selectedOptions).toEqual([]);
 		expect(onSubmit.mock.calls[0][0].results[0].customInput).toBe("custom detail");
 	});
 
@@ -798,7 +806,7 @@ describe("AskDialogComponent", () => {
 		expect(result.timedOut).toBeUndefined();
 	});
 
-	it("uses a noted non-recommended option as the timeout fallback", async () => {
+	it("keeps a question note without changing the timeout fallback", async () => {
 		vi.useFakeTimers();
 		const onPrompt = vi.fn().mockReturnValue(Promise.resolve("why B"));
 		const onSubmit = vi.fn();
@@ -828,12 +836,12 @@ describe("AskDialogComponent", () => {
 		expect(onTimeout).toHaveBeenCalledTimes(1);
 		expect(onSubmit).toHaveBeenCalledTimes(1);
 		const result = onSubmit.mock.calls[0][0].results[0];
-		expect(result.selectedOptions).toEqual(["Option B"]);
+		expect(result.selectedOptions).toEqual(["Option A"]);
 		expect(result.note).toBe("why B");
 		expect(result.timedOut).toBe(true);
 	});
 
-	it("preserves a pending note on a non-recommended option when deferred timeout submits", async () => {
+	it("preserves a pending question note when deferred timeout submits", async () => {
 		vi.useFakeTimers();
 		const deferred = Promise.withResolvers<string | undefined>();
 		const onPrompt = vi.fn().mockReturnValue(deferred.promise);
@@ -869,7 +877,7 @@ describe("AskDialogComponent", () => {
 		expect(onTimeout).toHaveBeenCalledTimes(1);
 		expect(onSubmit).toHaveBeenCalledTimes(1);
 		const result = onSubmit.mock.calls[0][0].results[0];
-		expect(result.selectedOptions).toEqual(["Option B"]);
+		expect(result.selectedOptions).toEqual(["Option A"]);
 		expect(result.note).toBe("why B");
 		expect(result.timedOut).toBe(true);
 	});
@@ -1008,7 +1016,7 @@ describe("AskDialogComponent", () => {
 		// Title must be bounded to at most MAX_PROMPT_TITLE_ROWS lines.
 		expect(lines.length).toBeLessThanOrEqual(3);
 		// The multi-line question must be flattened (no raw newlines expanding rows).
-		expect(stripVTControlCharacters(title)).toContain("Note for Option A:");
+		expect(stripVTControlCharacters(title)).toContain("Note:");
 	});
 
 	it("scrolls question rows when cursor moves below the viewport", () => {
@@ -1544,6 +1552,11 @@ describe("AskDialogComponent", () => {
 				options: [{ label: "Option A" }, { label: "Option B" }],
 				multi: true,
 			},
+			{
+				id: "q2",
+				question: "Second question?",
+				options: [{ label: "Option C" }],
+			},
 		];
 		const component = new AskDialogComponent(questions, {
 			onSubmit,
@@ -1558,10 +1571,11 @@ describe("AskDialogComponent", () => {
 		component.handleInput(ENTER);
 		await Promise.resolve();
 		await Promise.resolve();
+		expect(render(component)).toContain("Second question?");
+		component.handleInput(SHIFT_TAB);
 		expect(render(component)).toContain("my custom answer");
 
-		// Reopen Other (prefilled with the current answer) and submit an
-		// empty value: the custom answer is unselected.
+		// Reopen Other with the saved answer and clear it.
 		onPrompt.mockReturnValueOnce(Promise.resolve(""));
 		component.handleInput(ENTER);
 		await Promise.resolve();
@@ -1570,6 +1584,7 @@ describe("AskDialogComponent", () => {
 		expect(render(component)).not.toContain("my custom answer");
 
 		// Submitting confirms nothing was kept.
+		component.handleInput(TAB);
 		component.handleInput(TAB);
 		component.handleInput(ENTER);
 		expect(onSubmit).toHaveBeenCalledTimes(1);

--- a/packages/coding-agent/test/modes/components/ask-dialog.test.ts
+++ b/packages/coding-agent/test/modes/components/ask-dialog.test.ts
@@ -1080,8 +1080,6 @@ describe("AskDialogComponent", () => {
 		const lines = title.split("\n");
 		// Title must be bounded to at most MAX_PROMPT_TITLE_ROWS lines.
 		expect(lines.length).toBeLessThanOrEqual(3);
-		// The multi-line question must be flattened (no raw newlines expanding rows).
-		expect(stripVTControlCharacters(title)).toContain("Note:");
 	});
 
 	it("scrolls question rows when cursor moves below the viewport", () => {

--- a/packages/coding-agent/test/tools/ask.test.ts
+++ b/packages/coding-agent/test/tools/ask.test.ts
@@ -1620,6 +1620,50 @@ describe("AskTool rich ask dialog", () => {
 		expect(result.details?.note).toBe("Question context");
 	});
 
+	it("formats note-only single-select context as unanswered", async () => {
+		const tool = new AskTool(createSession());
+		const askDialog = vi.fn().mockResolvedValue({
+			kind: "submit",
+			results: [
+				{
+					id: "q1",
+					question: "Q1?",
+					options: ["Option A"],
+					multi: false,
+					selectedOptions: [],
+					note: "Question context",
+				},
+				{
+					id: "q2",
+					question: "Q2?",
+					options: ["Option B"],
+					multi: false,
+					selectedOptions: ["Option B"],
+				},
+			],
+		});
+
+		const result = await tool.execute(
+			"call-note-only-among-many",
+			{
+				questions: [
+					{ id: "q1", question: "Q1?", options: [{ label: "Option A" }] },
+					{ id: "q2", question: "Q2?", options: [{ label: "Option B" }] },
+				],
+			},
+			undefined,
+			undefined,
+			createContext({ askDialog }),
+		);
+
+		expect(result.content[0]?.type).toBe("text");
+		if (result.content[0]?.type === "text") {
+			expect(stripAnsi(result.content[0].text)).toBe(
+				"User answers:\nq1: (unanswered) (note: Question context)\nq2: Option B",
+			);
+		}
+	});
+
 	it("normalizes whitespace-only notes returned by askDialog", async () => {
 		const tool = new AskTool(createSession());
 		const askDialog = vi.fn().mockResolvedValue({

--- a/packages/coding-agent/test/tools/ask.test.ts
+++ b/packages/coding-agent/test/tools/ask.test.ts
@@ -1588,6 +1588,67 @@ describe("AskTool rich ask dialog", () => {
 		});
 	});
 
+	it("accepts a note-only single-select submission", async () => {
+		const tool = new AskTool(createSession());
+		const abort = vi.fn();
+		const askDialog = vi.fn().mockResolvedValue({
+			kind: "submit",
+			results: [
+				{
+					id: "q1",
+					question: "Q1?",
+					options: ["Option A"],
+					multi: false,
+					selectedOptions: [],
+					note: "Question context",
+				},
+			],
+		});
+
+		const result = await tool.execute(
+			"call-note-only",
+			{
+				questions: [{ id: "q1", question: "Q1?", options: [{ label: "Option A" }] }],
+			},
+			undefined,
+			undefined,
+			createContext({ askDialog, abort }),
+		);
+
+		expect(abort).not.toHaveBeenCalled();
+		expect(result.details?.selectedOptions).toEqual([]);
+		expect(result.details?.note).toBe("Question context");
+	});
+
+	it("normalizes whitespace-only notes returned by askDialog", async () => {
+		const tool = new AskTool(createSession());
+		const askDialog = vi.fn().mockResolvedValue({
+			kind: "submit",
+			results: [
+				{
+					id: "q1",
+					question: "Q1?",
+					options: ["Option A"],
+					multi: false,
+					selectedOptions: ["Option A"],
+					note: " \n\t ",
+				},
+			],
+		});
+
+		const result = await tool.execute(
+			"call-empty-note",
+			{
+				questions: [{ id: "q1", question: "Q1?", options: [{ label: "Option A" }] }],
+			},
+			undefined,
+			undefined,
+			createContext({ askDialog }),
+		);
+
+		expect(result.details?.note).toBeUndefined();
+	});
+
 	it("does not emit terminal notifications for non-terminal prompt surfaces", async () => {
 		const sendNotification = spyOn(TERMINAL, "sendNotification").mockImplementation(() => {});
 		const askDialog = vi.fn().mockResolvedValue({


### PR DESCRIPTION
## What

- Advance single-select and multi-select custom answers immediately after the first editor submission.
- Treat notes as question-level context that remains visible, survives answer changes, and is included for unanswered questions.
- Keep a fixed yellow question-note line above the independently scrolling answer options.
- Accept note-only single-select submissions and normalize empty notes at both rich-dialog boundaries.
- Update the Ask documentation, public result comments, changelog, and interaction regressions.

## Why

This fixes an issue with the Ask tool not accepting a custom answer the first time. It also makes notes per question instead of per answer, making it easier to select a different answer after a note has been filled in.

## Testing

- [x] `bun check`
- [x] `bun test packages/coding-agent/test/modes/components/ask-dialog.test.ts packages/coding-agent/test/tools/ask.test.ts` (101 passed)
- [x] `mdprose --check docs/tools/ask.md`
- [x] `git diff --check`
- [x] Manually entered a custom answer through Other, confirmed it once, and reached Submit with the custom value preserved
- [x] Manually added a question note, moved between answer options, and confirmed the yellow note line remained visible and the note remained on Submit
- [x] CHANGELOG updated

The full coding-agent suite was also attempted: 146 of 161 chunks passed. The remaining failures are outside this six-file diff and reproduce in Git fsmonitor, temporary repository discovery, loopback HTTP, and broker OAuth tests.
