### PR TITLE
feat(mnemopi): add ggml GPU local-embedding backend via node-llama-cpp

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "omp",
       "dependencies": {
+        "node-llama-cpp": "3.20.0",
         "sherpa-onnx": "1.13.2",
         "sherpa-onnx-darwin-arm64": "1.13.3",
         "sherpa-onnx-node": "1.13.2",
@@ -179,14 +180,17 @@
       "devDependencies": {
         "@types/bun": "catalog:",
         "fastembed": "catalog:",
+        "node-llama-cpp": "3.20.0",
         "onnxruntime-node": "catalog:",
       },
       "peerDependencies": {
         "fastembed": "2.1.0",
+        "node-llama-cpp": "3.20.0",
         "onnxruntime-node": "1.21.0",
       },
       "optionalPeers": [
         "fastembed",
+        "node-llama-cpp",
         "onnxruntime-node",
       ],
     },
@@ -569,6 +573,10 @@
 
     "@kurkle/color": ["@kurkle/color@0.3.4", "", {}, "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w=="],
 
+    "@kwsites/file-exists": ["@kwsites/file-exists@1.1.1", "", { "dependencies": { "debug": "^4.1.1" } }, "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw=="],
+
+    "@kwsites/promise-deferred": ["@kwsites/promise-deferred@1.1.1", "", {}, "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw=="],
+
     "@napi-rs/cli": ["@napi-rs/cli@3.7.2", "", { "dependencies": { "@inquirer/prompts": "^8.5.2", "@napi-rs/cross-toolchain": "^1.0.3", "@napi-rs/wasm-tools": "^1.0.1", "@octokit/rest": "^22.0.1", "clipanion": "^4.0.0-rc.4", "colorette": "^2.0.20", "emnapi": "^1.11.1", "es-toolkit": "^1.47.0", "js-yaml": "^4.2.0", "obug": "^2.1.2", "semver": "^7.8.2", "typanion": "^3.14.0" }, "peerDependencies": { "@emnapi/runtime": "^1.7.1" }, "optionalPeers": ["@emnapi/runtime"], "bin": { "napi": "dist/cli.js", "napi-raw": "cli.mjs" } }, "sha512-shDW0Td/XZQpP04Yy+OsMt1ILMKGGkoLcy1zVAsSAK0fLfWm0Upgkmfs/NOV2ZhMQwkgpR3ZEdyHmTwgrUDQuA=="],
 
     "@napi-rs/cross-toolchain": ["@napi-rs/cross-toolchain@1.0.3", "", { "dependencies": { "@napi-rs/lzma": "^1.4.5", "@napi-rs/tar": "^1.1.0", "debug": "^4.4.1" }, "peerDependencies": { "@napi-rs/cross-toolchain-arm64-target-aarch64": "^1.0.3", "@napi-rs/cross-toolchain-arm64-target-armv7": "^1.0.3", "@napi-rs/cross-toolchain-arm64-target-ppc64le": "^1.0.3", "@napi-rs/cross-toolchain-arm64-target-s390x": "^1.0.3", "@napi-rs/cross-toolchain-arm64-target-x86_64": "^1.0.3", "@napi-rs/cross-toolchain-x64-target-aarch64": "^1.0.3", "@napi-rs/cross-toolchain-x64-target-armv7": "^1.0.3", "@napi-rs/cross-toolchain-x64-target-ppc64le": "^1.0.3", "@napi-rs/cross-toolchain-x64-target-s390x": "^1.0.3", "@napi-rs/cross-toolchain-x64-target-x86_64": "^1.0.3" }, "optionalPeers": ["@napi-rs/cross-toolchain-arm64-target-aarch64", "@napi-rs/cross-toolchain-arm64-target-armv7", "@napi-rs/cross-toolchain-arm64-target-ppc64le", "@napi-rs/cross-toolchain-arm64-target-s390x", "@napi-rs/cross-toolchain-arm64-target-x86_64", "@napi-rs/cross-toolchain-x64-target-aarch64", "@napi-rs/cross-toolchain-x64-target-armv7", "@napi-rs/cross-toolchain-x64-target-ppc64le", "@napi-rs/cross-toolchain-x64-target-s390x", "@napi-rs/cross-toolchain-x64-target-x86_64"] }, "sha512-ENPfLe4937bsKVTDA6zdABx4pq9w0tHqRrJHyaGxgaPq03a2Bd1unD5XSKjXJjebsABJ+MjAv1A2OvCgK9yehg=="],
@@ -672,6 +680,34 @@
     "@napi-rs/wasm-tools-win32-ia32-msvc": ["@napi-rs/wasm-tools-win32-ia32-msvc@1.1.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-mdD96QDEp70SX67rXFTY6c725nVYeqEEjyDqzzbNh6u1APj7CI7IMNpMmvE75XbCRl4C2MHZVU4U6AWdAzvyQQ=="],
 
     "@napi-rs/wasm-tools-win32-x64-msvc": ["@napi-rs/wasm-tools-win32-x64-msvc@1.1.0", "", { "os": "win32", "cpu": "x64" }, "sha512-bVVjuvhlyVX++3eJXfDR63cXdw1ay5QYac6iq0MKQw8wZARInTM+bXCtByDT4fzVFI3+7ZthYb/ERWRdBNIqgQ=="],
+
+    "@node-llama-cpp/linux-arm64": ["@node-llama-cpp/linux-arm64@3.20.0", "", { "os": "linux", "cpu": [ "x64", "arm64", ] }, "sha512-WFAffebfOLqBaZMfNsORns1G5vLMRVthxw/moDzON7TGYH6PTQN97h5YkLfRoSmZne/rtpHXH2LdYg0vFNAgnQ=="],
+
+    "@node-llama-cpp/linux-armv7l": ["@node-llama-cpp/linux-armv7l@3.20.0", "", { "os": "linux", "cpu": [ "arm", "x64", ] }, "sha512-VUWc9U8QzgfNVcAB2BoapxBJK3wQt8EnBkstRWITTxIb4PLQjARM8Lobuz0p8gMJja4W0yWJLCN0YzkLqn51Qw=="],
+
+    "@node-llama-cpp/linux-riscv64": ["@node-llama-cpp/linux-riscv64@3.20.0", "", { "os": "linux", "cpu": "none" }, "sha512-U5CV75ECl+RV8WhxKeucSyO3sjtrAudDJ3l8cBMc1V8G5CUWPpHHyS/7bL4a2l8mY+Y+LvI08VSNSiRW5GlXjw=="],
+
+    "@node-llama-cpp/linux-x64": ["@node-llama-cpp/linux-x64@3.20.0", "", { "os": "linux", "cpu": "x64" }, "sha512-zCSTd5m4MDrLWzgUvOvuGGzHm9DiEONZt+srgHYhV4Ppu/T5TL3kENj7lHY1cmQccKNgepABiyb9KcigjZbvSQ=="],
+
+    "@node-llama-cpp/linux-x64-cuda": ["@node-llama-cpp/linux-x64-cuda@3.20.0", "", { "os": "linux", "cpu": "x64" }, "sha512-XWGGj12nK82NWju5+H5r/b0AY5Fv/zFZHdBwqB+JEyLSyzeGEH7Hc8P6bXBhcxNbGdCWd6wEx/EdZ5PSJrn79Q=="],
+
+    "@node-llama-cpp/linux-x64-cuda-ext": ["@node-llama-cpp/linux-x64-cuda-ext@3.20.0", "", { "os": "linux", "cpu": "x64" }, "sha512-2XwxFr0K+bLnmhcmXHeR2xM+RZ3LCisrSTJN9LHFkkctCsuZ9mw292XLq5V5b4oJxa3d28UJm5G0WJjnvVd17Q=="],
+
+    "@node-llama-cpp/linux-x64-vulkan": ["@node-llama-cpp/linux-x64-vulkan@3.20.0", "", { "os": "linux", "cpu": "x64" }, "sha512-xTzv4cuTpsmmQgqvWWZvcvURHfPgUQdQzVXvYN1bwAEYq2DRVckEKrHPJ48824sFmdIRRJqDerniqEXiZlDPzA=="],
+
+    "@node-llama-cpp/mac-arm64-metal": ["@node-llama-cpp/mac-arm64-metal@3.20.0", "", { "os": "darwin", "cpu": [ "x64", "arm64", ] }, "sha512-QeFyyTZWicxKGzyoYwR1VtBGM8R1/oHjai9DC6KSg3T8WYpZd3mqATy24GPPVxgg20yEXUCbNl4xyKXZsLD0dQ=="],
+
+    "@node-llama-cpp/mac-x64": ["@node-llama-cpp/mac-x64@3.20.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-3/B1uT0dNkhGTVkjTpI6OlHdUsic9NWDeocO0GHeq134LmQan34rERpR7JJgyv50iXufah+mvumFD/VZvfUqqQ=="],
+
+    "@node-llama-cpp/win-arm64": ["@node-llama-cpp/win-arm64@3.20.0", "", { "os": "win32", "cpu": [ "x64", "arm64", ] }, "sha512-UDx5NBXVRtcLaoQsF1gZiYlgXQYfxLbFVb4j4sa7Jgq/b6oq2lTAjeos7sYsMPRKa+S/BB/rDFis6FsRDJur7w=="],
+
+    "@node-llama-cpp/win-x64": ["@node-llama-cpp/win-x64@3.20.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Mbh9n74DCB5zTw02cme7Kp9nVg9X5Wvf+SNMWkXx5o3rGLuiSijGqRIktPOO3aHQwshB/RXC4j6I34HCPsgdgg=="],
+
+    "@node-llama-cpp/win-x64-cuda": ["@node-llama-cpp/win-x64-cuda@3.20.0", "", { "os": "win32", "cpu": "x64" }, "sha512-VPV0Ayw3TP9gGiuwlyWD5x97dQSNMKcbWFXsREJ0KLVRxJXihZdZTrjRaudQX1T1d0lJUeLhDmQUGpDh/8jf1w=="],
+
+    "@node-llama-cpp/win-x64-cuda-ext": ["@node-llama-cpp/win-x64-cuda-ext@3.20.0", "", { "os": "win32", "cpu": "x64" }, "sha512-BTnHmJ7xTzrvv8CWGYnG+2eygjZ4xAvQujtvkfC8N187bRR1fmTA+R7dbrqC2b3fXKtOvyPwOB9NNl+d2FuCmQ=="],
+
+    "@node-llama-cpp/win-x64-vulkan": ["@node-llama-cpp/win-x64-vulkan@3.20.0", "", { "os": "win32", "cpu": "x64" }, "sha512-7V2SjNejon668+xmtlZ36u2FmtIT2fOfQbGjT5zJ6ydW1Xec53VsX1VwQdikx+79Y9/gEp7L2GtBcX6bc0LsCQ=="],
 
     "@octokit/auth-token": ["@octokit/auth-token@6.0.0", "", {}, "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w=="],
 
@@ -863,6 +899,24 @@
 
     "@puppeteer/browsers": ["@puppeteer/browsers@3.0.6", "", { "dependencies": { "modern-tar": "^0.7.6", "yargs": "^18.0.0" }, "peerDependencies": { "proxy-agent": ">=8.0.1", "yauzl": "^2.10.0 || ^3.4.0" }, "optionalPeers": ["proxy-agent", "yauzl"], "bin": { "browsers": "lib/main-cli.js" } }, "sha512-B/gKoqlFkzhvzsI6jo9K1cZz9o5ypviVv/xu8CwA4grZzyVwN+XfkT+tu8T1zrauuEXv6VhS2oGX+6NL95WcKA=="],
 
+    "@reflink/reflink": ["@reflink/reflink@0.1.19", "", { "optionalDependencies": { "@reflink/reflink-darwin-arm64": "0.1.19", "@reflink/reflink-darwin-x64": "0.1.19", "@reflink/reflink-linux-arm64-gnu": "0.1.19", "@reflink/reflink-linux-arm64-musl": "0.1.19", "@reflink/reflink-linux-x64-gnu": "0.1.19", "@reflink/reflink-linux-x64-musl": "0.1.19", "@reflink/reflink-win32-arm64-msvc": "0.1.19", "@reflink/reflink-win32-x64-msvc": "0.1.19" } }, "sha512-DmCG8GzysnCZ15bres3N5AHCmwBwYgp0As6xjhQ47rAUTUXxJiK+lLUxaGsX3hd/30qUpVElh05PbGuxRPgJwA=="],
+
+    "@reflink/reflink-darwin-arm64": ["@reflink/reflink-darwin-arm64@0.1.19", "", { "os": "darwin", "cpu": "arm64" }, "sha512-ruy44Lpepdk1FqDz38vExBY/PVUsjxZA+chd9wozjUH9JjuDT/HEaQYA6wYN9mf041l0yLVar6BCZuWABJvHSA=="],
+
+    "@reflink/reflink-darwin-x64": ["@reflink/reflink-darwin-x64@0.1.19", "", { "os": "darwin", "cpu": "x64" }, "sha512-By85MSWrMZa+c26TcnAy8SDk0sTUkYlNnwknSchkhHpGXOtjNDUOxJE9oByBnGbeuIE1PiQsxDG3Ud+IVV9yuA=="],
+
+    "@reflink/reflink-linux-arm64-gnu": ["@reflink/reflink-linux-arm64-gnu@0.1.19", "", { "os": "linux", "cpu": "arm64" }, "sha512-7P+er8+rP9iNeN+bfmccM4hTAaLP6PQJPKWSA4iSk2bNvo6KU6RyPgYeHxXmzNKzPVRcypZQTpFgstHam6maVg=="],
+
+    "@reflink/reflink-linux-arm64-musl": ["@reflink/reflink-linux-arm64-musl@0.1.19", "", { "os": "linux", "cpu": "arm64" }, "sha512-37iO/Dp6m5DDaC2sf3zPtx/hl9FV3Xze4xoYidrxxS9bgP3S8ALroxRK6xBG/1TtfXKTvolvp+IjrUU6ujIGmA=="],
+
+    "@reflink/reflink-linux-x64-gnu": ["@reflink/reflink-linux-x64-gnu@0.1.19", "", { "os": "linux", "cpu": "x64" }, "sha512-jbI8jvuYCaA3MVUdu8vLoLAFqC+iNMpiSuLbxlAgg7x3K5bsS8nOpTRnkLF7vISJ+rVR8W+7ThXlXlUQ93ulkw=="],
+
+    "@reflink/reflink-linux-x64-musl": ["@reflink/reflink-linux-x64-musl@0.1.19", "", { "os": "linux", "cpu": "x64" }, "sha512-e9FBWDe+lv7QKAwtKOt6A2W/fyy/aEEfr0g6j/hWzvQcrzHCsz07BNQYlNOjTfeytrtLU7k449H1PI95jA4OjQ=="],
+
+    "@reflink/reflink-win32-arm64-msvc": ["@reflink/reflink-win32-arm64-msvc@0.1.19", "", { "os": "win32", "cpu": "arm64" }, "sha512-09PxnVIQcd+UOn4WAW73WU6PXL7DwGS6wPlkMhMg2zlHHG65F3vHepOw06HFCq+N42qkaNAc8AKIabWvtk6cIQ=="],
+
+    "@reflink/reflink-win32-x64-msvc": ["@reflink/reflink-win32-x64-msvc@0.1.19", "", { "os": "win32", "cpu": "x64" }, "sha512-E//yT4ni2SyhwP8JRjVGWr3cbnhWDiPLgnQ66qqaanjjnMiu3O/2tjCPQXlcGc/DEYofpDc9fvhv6tALQsMV9w=="],
+
     "@rolldown/binding-android-arm-eabi": ["@rolldown/binding-android-arm-eabi@1.2.7", "", { "os": "android", "cpu": "arm" }, "sha512-EypzgnYCwyVY4NDHKzGmNJT5b+XaQEBniHxsMdeIQLB/tcCzZnhqrzHpZFbX9iaxx+5RiB8caATBtfvZP7zVxQ=="],
 
     "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.2.7", "", { "os": "android", "cpu": "arm64" }, "sha512-l17HE9EweWaqJZhuUuNBN/FzM62xw+DECVnJyvMsxn8vJFAGLy5QfLDoYAcronkAN8VxKZHezDpulHDPx95vFw=="],
@@ -894,6 +948,10 @@
     "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.2.7", "", { "os": "win32", "cpu": "x64" }, "sha512-W/jg5qoRSqjsEv0+dZi4e687mcHqmVuU0P4fK6qS/xjetW2Gmc1W8j//z5nAeNcC8Ttm0hV46IjcYeuVwYhuiw=="],
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.1", "", {}, "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw=="],
+
+    "@simple-git/args-pathspec": ["@simple-git/args-pathspec@1.0.3", "", {}, "sha512-ngJMaHlsWDTfjyq9F3VIQ8b7NXbBLq5j9i5bJ6XLYtD6qlDXT7fdKY2KscWWUF8t18xx052Y/PUO1K1TRc9yKA=="],
+
+    "@simple-git/argv-parser": ["@simple-git/argv-parser@1.1.1", "", { "dependencies": { "@simple-git/args-pathspec": "^1.0.3" } }, "sha512-Q9lBcfQ+VQCpQqGJFHe5yooOS5hGdLFFbJ5R+R5aDsnkPCahtn1hSkMcORX65J2Z5lxSkD0lQorMsncuBQxYUw=="],
 
     "@sinclair/typebox": ["@sinclair/typebox@0.34.52", "", {}, "sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw=="],
 
@@ -928,6 +986,8 @@
     "@tailwindcss/oxide-win32-x64-msvc": ["@tailwindcss/oxide-win32-x64-msvc@4.3.3", "", { "os": "win32", "cpu": "x64" }, "sha512-yJ0pwIVc/nYeGoV02WtsN8KYyLQv7kyI2wDnkezyJlGGjkd4QLwDGAwl47YpPJeuI0M0ObaXGSPjvWDPeTPggw=="],
 
     "@tailwindcss/vite": ["@tailwindcss/vite@4.3.3", "", { "dependencies": { "@tailwindcss/node": "4.3.3", "@tailwindcss/oxide": "4.3.3", "tailwindcss": "4.3.3" }, "peerDependencies": { "vite": "^5.2.0 || ^6 || ^7 || ^8" } }, "sha512-yYU8cogLeSh/ms2jh8Fj7jaba/EWa7Ja6GoUqYZaraEuCI5YS6ms6ObZgjjedm+jm6XZjdNRWBpPP6Z86oOxcw=="],
+
+    "@tinyhttp/content-disposition": ["@tinyhttp/content-disposition@2.2.4", "", {}, "sha512-5Kc5CM2Ysn3vTTArBs2vESUt0AQiWZA86yc1TI3B+lxXmtEq133C1nxXNOgnzhrivdPZIh3zLj5gDnZjoLL5GA=="],
 
     "@ts-morph/common": ["@ts-morph/common@0.29.0", "", { "dependencies": { "minimatch": "^10.0.1", "path-browserify": "^1.0.1", "tinyglobby": "^0.2.14" } }, "sha512-35oUmphHbJvQ/+UTwFNme/t2p3FoKiGJ5auTjjpNTop2dyREspirjMy82PLSC1pnDJ8ah1GU98hwpVt64YXQsg=="],
 
@@ -1019,6 +1079,8 @@
 
     "adm-zip": ["adm-zip@0.5.18", "", {}, "sha512-ufJnssQGbxzLNS1Ho9bCtX4rQKCCvoVuDLHoJyc3F9dOGDB4BkWs2Ci0kv53lqocAEQ/Cbi+I2XCsNYGqVYqng=="],
 
+    "ansi-escapes": ["ansi-escapes@6.2.1", "", {}, "sha512-4nJ3yixlEthEJ9Rk4vPcdBRkZvQZlYyu8j4/Mqz5sgIkddmEnH2Yj2ZrnP9S3tQOvSNRUIgVNF/1yPpRAGNRig=="],
+
     "ansi-regex": ["ansi-regex@6.3.0", "", {}, "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ=="],
 
     "ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
@@ -1028,6 +1090,8 @@
     "arkregex": ["arkregex@0.0.8", "", { "dependencies": { "@ark/util": "0.56.2" } }, "sha512-PJcx6G1kQTgLKPUbeYlYecDRaKq15AMSGVajlKFYWlPeJRQL+j3dKE6tyMs40HZ99djS1l9Vhl3ezAHy9JBIqQ=="],
 
     "arktype": ["arktype@2.2.3", "", { "dependencies": { "@ark/schema": "0.56.2", "@ark/util": "0.56.2", "arkregex": "0.0.8" } }, "sha512-7W+0RLTUNJiBFIIZXwOQxSR8Z273IAd6IvqBeG9+gHnQKFsIx2C0iOtGTmMrPnlX4qLXyc5+ll7A0BIj9WrbTg=="],
+
+    "async-retry": ["async-retry@1.3.3", "", { "dependencies": { "retry": "0.13.1" } }, "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw=="],
 
     "babel-plugin-jsx-dom-expressions": ["babel-plugin-jsx-dom-expressions@0.40.10", "", { "dependencies": { "@babel/helper-module-imports": "7.18.6", "@babel/plugin-syntax-jsx": "^7.18.6", "@babel/types": "^7.20.7", "html-entities": "2.3.3", "parse5": "^7.1.2" }, "peerDependencies": { "@babel/core": "^7.20.12" } }, "sha512-lxve6Y02YiZTldB7efKpnbf1BH00XCFZNYYW235jSGsYaJNFtHrYlKV6/O+miHbjqpIr9FTe5+0no4hofAMbfA=="],
 
@@ -1047,19 +1111,29 @@
 
     "bun-types": ["bun-types@1.4.2", "", { "dependencies": { "@types/node": "*" } }, "sha512-bxV1FgK7yBIzjRe5zBozIM4Bem11ZJcCXSrjWRG3YWLt8yFDePu4cLjpebO8OvPeIE9trbyPF4fuj3Cia4Fj3w=="],
 
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
     "caniuse-lite": ["caniuse-lite@1.0.30001810", "", {}, "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg=="],
 
-    "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+    "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
     "chardet": ["chardet@2.2.0", "", {}, "sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA=="],
 
     "chart.js": ["chart.js@4.5.1", "", { "dependencies": { "@kurkle/color": "^0.3.0" } }, "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw=="],
 
+    "chmodrp": ["chmodrp@1.0.2", "", {}, "sha512-TdngOlFV1FLTzU0o1w8MB6/BFywhtLC0SzRTGJU7T9lmdjlCWeMRt1iVo0Ki+ldwNk0BqNiKoc8xpLZEQ8mY1w=="],
+
     "chownr": ["chownr@2.0.0", "", {}, "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="],
 
     "chromium-bidi": ["chromium-bidi@16.0.1", "", { "dependencies": { "mitt": "^3.0.1", "zod": "^3.24.1" }, "peerDependencies": { "devtools-protocol": "*" } }, "sha512-J63PGu/9PpeCwLIcKYyzWP6yaVL5pxuBc0shlYCYM8BaAkmlwiQboXO1iNbOgSDbVklEyYFfNEcHD8oOAWacUA=="],
 
+    "ci-info": ["ci-info@4.4.0", "", {}, "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg=="],
+
+    "cli-cursor": ["cli-cursor@5.0.0", "", { "dependencies": { "restore-cursor": "^5.0.0" } }, "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw=="],
+
     "cli-progress": ["cli-progress@3.12.0", "", { "dependencies": { "string-width": "^4.2.3" } }, "sha512-tRkV3HJ1ASwm19THiiLIXLO7Im7wlTuKnvkYaTkyoAPefqjNg7W7DHKUlGRxy9vxDvbyCYQkQozvptuMkGCg8A=="],
+
+    "cli-spinners": ["cli-spinners@2.9.2", "", {}, "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg=="],
 
     "cli-truncate": ["cli-truncate@6.1.1", "", { "dependencies": { "slice-ansi": "^9.0.0", "string-width": "^8.2.0" } }, "sha512-06p9vyLahLa4zkGcgsGxU6iEkSOiuI4fhCH6Emhe2lPAcoUv73n72DnODsnHA+5wwXGnV0n9M9/qOQJSjYhFhw=="],
 
@@ -1067,9 +1141,11 @@
 
     "clipanion": ["clipanion@4.0.0-rc.4", "", { "dependencies": { "typanion": "^3.8.0" } }, "sha512-CXkMQxU6s9GklO/1f714dkKBMu1lopS1WFF0B8o4AxPykR1hpozxSiUZ5ZUeBjfPgCWqbcNOtZVFhB8Lkfp1+Q=="],
 
-    "cliui": ["cliui@9.0.1", "", { "dependencies": { "string-width": "^7.2.0", "strip-ansi": "^7.1.0", "wrap-ansi": "^9.0.0" } }, "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w=="],
+    "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
+
+    "cmake-js": ["cmake-js@8.0.0", "", { "dependencies": { "debug": "^4.4.3", "fs-extra": "^11.3.3", "node-api-headers": "^1.8.0", "rc": "1.2.8", "semver": "^7.7.3", "tar": "^7.5.6", "url-join": "^4.0.1", "which": "^6.0.0", "yargs": "^17.7.2" }, "bin": { "cmake-js": "bin/cmake-js" } }, "sha512-YbUP88RDwCvoQkZhRtGURYm9RIpWdtvZuhT87fKNoLjk8kIFIFeARpKfuZQGdwfH99GZpUmqSfcDrK62X7lTgg=="],
 
     "code-block-writer": ["code-block-writer@13.0.3", "", {}, "sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg=="],
 
@@ -1084,6 +1160,8 @@
     "content-type": ["content-type@3.0.0", "", {}, "sha512-AIi5H6p0xk5uknXcN3/rmhP8jgp69OfSe/JuKiQAFprJ7UGw7mwj7m4XcmDzlrnJDG+cGpphAINGdU3g3g7kDw=="],
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
@@ -1107,6 +1185,8 @@
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" }, "peerDependencies": { "supports-color": "*" }, "optionalPeers": ["supports-color"] }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
+    "deep-extend": ["deep-extend@0.6.0", "", {}, "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="],
+
     "define-data-property": ["define-data-property@1.1.4", "", { "dependencies": { "es-define-property": "^1.0.0", "es-errors": "^1.3.0", "gopd": "^1.0.1" } }, "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A=="],
 
     "define-properties": ["define-properties@1.2.1", "", { "dependencies": { "define-data-property": "^1.0.1", "has-property-descriptors": "^1.0.0", "object-keys": "^1.1.1" } }, "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg=="],
@@ -1123,11 +1203,13 @@
 
     "emnapi": ["emnapi@1.11.3", "", { "peerDependencies": { "node-addon-api": ">= 6.1.0" }, "optionalPeers": ["node-addon-api"] }, "sha512-+/ZS90YK/rYfVOHtGLHkGffVsnmD/MAKaBHio+Y4XAtg75RLr4cveV/w0jTkUdLM1CcAlaRgG76mpIemWAlk0A=="],
 
-    "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+    "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
     "enhanced-resolve": ["enhanced-resolve@5.24.5", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A=="],
 
     "entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+
+    "env-var": ["env-var@7.5.0", "", {}, "sha512-mKZOzLRN0ETzau2W2QXefbFjo5EF4yWq28OyKb9ICdeNhHJlOE/pHHnz4hdYJ9cNZXcJHo5xN4OT4pzuSHSNvA=="],
 
     "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
 
@@ -1141,6 +1223,8 @@
 
     "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 
+    "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
+
     "exit": ["exit@0.1.2", "", {}, "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ=="],
 
     "fast-string-truncated-width": ["fast-string-truncated-width@3.0.3", "", {}, "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g=="],
@@ -1153,9 +1237,15 @@
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
+    "filename-reserved-regex": ["filename-reserved-regex@3.0.0", "", {}, "sha512-hn4cQfU6GOT/7cFHXBqeBg2TbrMBgdD0kcjLhvSQYYwm3s4B6cjvBfb7nBALJLAXqmU5xajSa7X2NnUud/VCdw=="],
+
+    "filenamify": ["filenamify@6.0.0", "", { "dependencies": { "filename-reserved-regex": "^3.0.0" } }, "sha512-vqIlNogKeyD3yzrm0yhRMQg8hOVwYcYRfjEoODd49iCprMn4HL85gK3HcykQE53EPIpX3HcAbGA5ELQv216dAQ=="],
+
     "flatbuffers": ["flatbuffers@25.9.23", "", {}, "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ=="],
 
     "framer-motion": ["framer-motion@12.43.0", "", { "dependencies": { "motion-dom": "^12.43.0", "motion-utils": "^12.39.0", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-1eaL3RvR/kAlbG7UYcpMptEyzPoENO0c6w7ZnB3/hh2vSAz/6uGAFn6fdoqTBguNstf3MsFhJHsD/0DHiclG+g=="],
+
+    "fs-extra": ["fs-extra@11.4.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-EQsFzMUJkCKGr1ePqlYADkIUmHW1s3ZXr5Yqy6wbGrfUCphpl2maM/kyOIRA2HpP3AaFQTZXD4ldjek+nccddA=="],
 
     "fs-minipass": ["fs-minipass@2.1.0", "", { "dependencies": { "minipass": "^3.0.0" } }, "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg=="],
 
@@ -1189,13 +1279,25 @@
 
     "iconv-lite": ["iconv-lite@0.7.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ=="],
 
+    "ignore": ["ignore@7.0.8", "", {}, "sha512-YYNsSlXBjMk92SKnkwvB5LOVSa6OznlFUGcsvrFgNJbJCd0M1XKeFVRc8ZByeCqz32FivYNHJVooLmdqrmvp/Q=="],
+
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
 
     "internmap": ["internmap@2.0.3", "", {}, "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="],
 
+    "ipull": ["ipull@3.9.5", "", { "dependencies": { "@tinyhttp/content-disposition": "^2.2.0", "async-retry": "^1.3.3", "chalk": "^5.3.0", "ci-info": "^4.0.0", "cli-spinners": "^2.9.2", "commander": "^10.0.0", "eventemitter3": "^5.0.1", "filenamify": "^6.0.0", "fs-extra": "^11.1.1", "is-unicode-supported": "^2.0.0", "lifecycle-utils": "^2.0.1", "lodash.debounce": "^4.0.8", "lowdb": "^7.0.1", "pretty-bytes": "^6.1.0", "pretty-ms": "^8.0.0", "sleep-promise": "^9.1.0", "slice-ansi": "^7.1.0", "stdout-update": "^4.0.1", "strip-ansi": "^7.1.0" }, "optionalDependencies": { "@reflink/reflink": "^0.1.16" }, "bin": { "ipull": "dist/cli/cli.js" } }, "sha512-5w/yZB5lXmTfsvNawmvkCjYo4SJNuKQz/av8TC1UiOyfOHyaM+DReqbpU2XpWYfmY+NIUbRRH8PUAWsxaS+IfA=="],
+
     "is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
 
+    "is-interactive": ["is-interactive@2.0.0", "", {}, "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ=="],
+
+    "is-unicode-supported": ["is-unicode-supported@2.1.0", "", {}, "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ=="],
+
     "is-what": ["is-what@4.1.16", "", {}, "sha512-ZhMwEosbFJkA0YhFnNDgTM4ZxDRsS6HqTo7qsZM08fehyRYIYa0yHu5R6mgo1n/8MgaPBXiPimPD77baVFYg+A=="],
+
+    "isexe": ["isexe@4.0.0", "", {}, "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw=="],
 
     "jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
 
@@ -1211,6 +1313,8 @@
 
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
+    "jsonfile": ["jsonfile@6.2.1", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q=="],
+
     "jsonparse": ["jsonparse@1.3.1", "", {}, "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg=="],
 
     "jsonstream-next": ["jsonstream-next@3.0.0", "", { "dependencies": { "jsonparse": "^1.2.0", "through2": "^4.0.2" }, "bin": { "jsonstream-next": "bin.js" } }, "sha512-aAi6oPhdt7BKyQn1SrIIGZBt0ukKuOUE1qV6kJ3GgioSOYzsRc8z9Hfr1BVmacA/jLe9nARfmgMGgn68BqIAgg=="],
@@ -1218,6 +1322,8 @@
     "katex": ["katex@0.18.7", "", { "dependencies": { "commander": "^15.0.0" }, "bin": { "katex": "cli.js" } }, "sha512-h+UCwkZ+4Jz8WQ7MLGfj7UVFrRCizGb912fwF4luGdYsC5paYG1vx+jy+KRcC/XkpjGva/P7nAWuxNnPzRvzHw=="],
 
     "kitty-vt-wasm": ["kitty-vt-wasm@0.2.0", "", {}, "sha512-RJNzy9r5ql8CKkocjkg0FKC1MZoWM0R8leb2VB5hsgrP/4HHlumeODHriOw4Jk2dDsCOmPxWuwFQyqDiy0m8Kw=="],
+
+    "lifecycle-utils": ["lifecycle-utils@4.4.1", "", {}, "sha512-OISUWb0J8fBvF6u1SkegeKdohm7dNlNe4arVSYIOp5pPwRoO/H/eh/8FZVKPfzeswkAMin00/S7twWgSWN3tlw=="],
 
     "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
 
@@ -1245,7 +1351,13 @@
 
     "lint-staged": ["lint-staged@17.5.0", "", { "dependencies": { "picomatch": "^4.0.7", "string-argv": "^0.3.2", "tinyexec": "^1.3.1" }, "optionalDependencies": { "yaml": "^2.9.0" }, "bin": { "lint-staged": "bin/lint-staged.js" } }, "sha512-ah2qsNtvKP1+Ak4rAvEEIvcXDLjjbr/xmxCvlequxqEOFYk0qINcZcRxD3Ic8wRn7/oQ8+wC9s0DfDrdMVCRFg=="],
 
+    "lodash.debounce": ["lodash.debounce@4.0.8", "", {}, "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="],
+
+    "log-symbols": ["log-symbols@7.0.1", "", { "dependencies": { "is-unicode-supported": "^2.0.0", "yoctocolors": "^2.1.1" } }, "sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg=="],
+
     "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
+
+    "lowdb": ["lowdb@7.0.1", "", { "dependencies": { "steno": "^4.0.2" } }, "sha512-neJAj8GwF0e8EpycYIDFqEPcx9Qz4GUho20jWFR7YiFeXzF1YMLdxB36PypcTSPMA+4+LvgyMacYhlr18Zlymw=="],
 
     "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
@@ -1259,7 +1371,11 @@
 
     "merge-anything": ["merge-anything@5.1.7", "", { "dependencies": { "is-what": "^4.1.8" } }, "sha512-eRtbOb1N5iyH0tkQDAoQ4Ipsp/5qSR79Dzrz8hEPxRX10RWWR/iQXdoKmBSRCThY1Fh5EhISDtpSc93fpxUniQ=="],
 
+    "mimic-function": ["mimic-function@5.0.1", "", {}, "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA=="],
+
     "minimatch": ["minimatch@10.2.6", "", { "dependencies": { "brace-expansion": "^5.0.8" } }, "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A=="],
+
+    "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
 
     "minipass": ["minipass@5.0.0", "", {}, "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ=="],
 
@@ -1283,7 +1399,13 @@
 
     "mute-stream": ["mute-stream@3.0.0", "", {}, "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw=="],
 
-    "nanoid": ["nanoid@3.3.18", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w=="],
+    "nanoid": ["nanoid@5.1.16", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ=="],
+
+    "node-addon-api": ["node-addon-api@8.9.2", "", {}, "sha512-VijLXbi3UACN69I0JVXJsX4tjACjNoQDgv2gTF6sx2wWEi8tkSg2eX8p5gSIFi8z2+DL3oHmY6OyKce38SDolg=="],
+
+    "node-api-headers": ["node-api-headers@1.9.0", "", {}, "sha512-2oNILP4jXwRB4ywnYKjVk1YyJ96n2D4EOVJO6S3oYZ5PtbJrw3Yt9TpAuX3nBLMuzn74rnfGQrv13pS9vC+YiA=="],
+
+    "node-llama-cpp": ["node-llama-cpp@3.20.0", "", { "dependencies": { "@huggingface/jinja": "^0.5.9", "async-retry": "^1.3.3", "bytes": "^3.1.2", "chalk": "^5.6.2", "chmodrp": "^1.0.2", "cmake-js": "^8.0.0", "cross-spawn": "^7.0.6", "env-var": "^7.5.0", "filenamify": "^6.0.0", "fs-extra": "^11.3.4", "ignore": "^7.0.4", "ipull": "^3.9.5", "is-unicode-supported": "^2.1.0", "lifecycle-utils": "^4.0.1", "log-symbols": "^7.0.1", "nanoid": "^5.1.6", "node-addon-api": "^8.9.1", "ora": "^9.3.0", "pretty-ms": "^9.3.0", "proper-lockfile": "^4.1.2", "semver": "^7.7.1", "simple-git": "^3.36.0", "slice-ansi": "^8.0.0", "stdout-update": "^4.0.1", "strip-ansi": "^7.2.0", "validate-npm-package-name": "^7.0.2", "which": "^6.0.1", "yargs": "^17.7.2" }, "optionalDependencies": { "@node-llama-cpp/linux-arm64": "3.20.0", "@node-llama-cpp/linux-armv7l": "3.20.0", "@node-llama-cpp/linux-riscv64": "3.20.0", "@node-llama-cpp/linux-x64": "3.20.0", "@node-llama-cpp/linux-x64-cuda": "3.20.0", "@node-llama-cpp/linux-x64-cuda-ext": "3.20.0", "@node-llama-cpp/linux-x64-vulkan": "3.20.0", "@node-llama-cpp/mac-arm64-metal": "3.20.0", "@node-llama-cpp/mac-x64": "3.20.0", "@node-llama-cpp/win-arm64": "3.20.0", "@node-llama-cpp/win-x64": "3.20.0", "@node-llama-cpp/win-x64-cuda": "3.20.0", "@node-llama-cpp/win-x64-cuda-ext": "3.20.0", "@node-llama-cpp/win-x64-vulkan": "3.20.0" }, "peerDependencies": { "typescript": ">=5.0.0" }, "optionalPeers": ["typescript"], "bin": { "nlc": "dist/cli/cli.js", "node-llama-cpp": "dist/cli/cli.js" } }, "sha512-KnET3ttADYLCobjMnMTLkWkLt87rPRDhNzTZgGOCt8m8yTmdQW2sfLNmulGBA9laFvcyRIMOsgQST8lunPmMgw=="],
 
     "node-releases": ["node-releases@2.0.54", "", {}, "sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ=="],
 
@@ -1291,11 +1413,15 @@
 
     "obug": ["obug@2.1.4", "", {}, "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA=="],
 
+    "onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
+
     "onnxruntime-common": ["onnxruntime-common@1.26.0", "", {}, "sha512-qVyMR4lcWgbkc4getFV+GQijsTnbg/siteoqcDwa3sI/LxbrMSNw4ePyvCq/ymdQaRomCA7YuWmhzsswxvymdw=="],
 
     "onnxruntime-node": ["onnxruntime-node@1.26.0", "", { "dependencies": { "adm-zip": "^0.5.16", "global-agent": "^4.1.3", "onnxruntime-common": "1.26.0" }, "os": [ "linux", "win32", "darwin", ] }, "sha512-OHl6PiOEOqxaLHL0N9eFrbzS7IGmu3BtJNH3RTEnRAheCIkfc3gjcjl4sGcjp9C22ZC9YTquDOxSdT/stBQ6BQ=="],
 
     "onnxruntime-web": ["onnxruntime-web@1.26.0-dev.20260416-b7804b056c", "", { "dependencies": { "flatbuffers": "^25.1.24", "guid-typescript": "^1.0.9", "long": "^5.2.3", "onnxruntime-common": "1.24.0-dev.20251116-b39e144322", "platform": "^1.3.6", "protobufjs": "^7.2.4" } }, "sha512-MD6Ss4GSpQBo6zqoJzyT9LRbKYs7x/JVN23FT24EcEvlqF4VuzPOeH6X38orZPKHQDbprn7K+SBpu0/mj2CQiw=="],
+
+    "ora": ["ora@9.4.1", "", { "dependencies": { "chalk": "^5.6.2", "cli-cursor": "^5.0.0", "cli-spinners": "^3.2.0", "is-interactive": "^2.0.0", "is-unicode-supported": "^2.1.0", "log-symbols": "^7.0.1", "stdin-discarder": "^0.3.2", "string-width": "^8.1.0" } }, "sha512-6VlU9MLXbjVQD04AZCMX28hVtA5bUoadvUqO76MUCVA0ilwJbMiHsITRPfyVm6p/BC0Av/BXMujx39WCe1LEqw=="],
 
     "oxfmt": ["oxfmt@0.65.0", "", { "dependencies": { "tinypool": "2.1.0" }, "optionalDependencies": { "@oxfmt/binding-android-arm-eabi": "0.65.0", "@oxfmt/binding-android-arm64": "0.65.0", "@oxfmt/binding-darwin-arm64": "0.65.0", "@oxfmt/binding-darwin-x64": "0.65.0", "@oxfmt/binding-freebsd-x64": "0.65.0", "@oxfmt/binding-linux-arm-gnueabihf": "0.65.0", "@oxfmt/binding-linux-arm-musleabihf": "0.65.0", "@oxfmt/binding-linux-arm64-gnu": "0.65.0", "@oxfmt/binding-linux-arm64-musl": "0.65.0", "@oxfmt/binding-linux-ppc64-gnu": "0.65.0", "@oxfmt/binding-linux-riscv64-gnu": "0.65.0", "@oxfmt/binding-linux-riscv64-musl": "0.65.0", "@oxfmt/binding-linux-s390x-gnu": "0.65.0", "@oxfmt/binding-linux-x64-gnu": "0.65.0", "@oxfmt/binding-linux-x64-musl": "0.65.0", "@oxfmt/binding-openharmony-arm64": "0.65.0", "@oxfmt/binding-win32-arm64-msvc": "0.65.0", "@oxfmt/binding-win32-ia32-msvc": "0.65.0", "@oxfmt/binding-win32-x64-msvc": "0.65.0" }, "peerDependencies": { "svelte": "^5.0.0", "vite-plus": "*" }, "optionalPeers": ["svelte", "vite-plus"], "bin": { "oxfmt": "bin/oxfmt" } }, "sha512-SgS5VgnP42T0zl3zWD+xoH8FCqg1SAFnSRoOT/qeoa6gxcYIqrDMOmcXIg/EWSN92Du4ogB4riuKhKd6Y4CGhw=="],
 
@@ -1303,9 +1429,13 @@
 
     "p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
 
+    "parse-ms": ["parse-ms@4.0.0", "", {}, "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw=="],
+
     "parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
 
     "path-browserify": ["path-browserify@1.0.1", "", {}, "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
@@ -1317,11 +1447,19 @@
 
     "prettier": ["prettier@3.9.6", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g=="],
 
+    "pretty-bytes": ["pretty-bytes@6.1.1", "", {}, "sha512-mQUvGU6aUFQ+rNvTIAcZuWGRT9a6f6Yrg9bHs4ImKF+HZCEK+plBvnAZYSIQztknZF2qnzNtr6F8s0+IuptdlQ=="],
+
+    "pretty-ms": ["pretty-ms@9.3.1", "", { "dependencies": { "parse-ms": "^4.0.0" } }, "sha512-HzMy3Geq23nVALD/M2LliU+F+M+gVNsvkQWWqeBZ8HDiCgzo6YPJ/Omrmtq24EFrIsk0a3EkQGEd7bDOo+IhGA=="],
+
     "progress": ["progress@2.0.3", "", {}, "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="],
+
+    "proper-lockfile": ["proper-lockfile@4.1.2", "", { "dependencies": { "graceful-fs": "^4.2.4", "retry": "^0.12.0", "signal-exit": "^3.0.2" } }, "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA=="],
 
     "protobufjs": ["protobufjs@7.6.6", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.5", "@protobufjs/eventemitter": "^1.1.1", "@protobufjs/fetch": "^1.1.1", "@protobufjs/float": "^1.0.2", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.1", "@types/node": ">=13.7.0", "long": "^5.3.2" } }, "sha512-dYDWdjSl5RNb7SgPxGQcRU+GtvP7s2fpkrY0r432PcOIaZ0/rBcxEZnQN67iJhFuQiVw754JDoPruPCNdGsbjg=="],
 
     "puppeteer-core": ["puppeteer-core@25.3.0", "", { "dependencies": { "@puppeteer/browsers": "3.0.6", "chromium-bidi": "16.0.1", "devtools-protocol": "0.0.1638949", "typed-query-selector": "^2.12.2", "webdriver-bidi-protocol": "0.4.2", "ws": "^8.21.0" } }, "sha512-fm+wpUr2oigH1PXZvwgATrM2tYWHMDG8ASzTEe9uukCye4X5Ldx1K5BTHPFKITrIWvQQAQ256d1NpbEveBcKjA=="],
+
+    "rc": ["rc@1.2.8", "", { "dependencies": { "deep-extend": "^0.6.0", "ini": "~1.3.0", "minimist": "^1.2.0", "strip-json-comments": "~2.0.1" }, "bin": { "rc": "./cli.js" } }, "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw=="],
 
     "react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
 
@@ -1336,6 +1474,10 @@
     "regexp-tree": ["regexp-tree@0.1.27", "", { "bin": { "regexp-tree": "bin/regexp-tree" } }, "sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA=="],
 
     "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
+
+    "restore-cursor": ["restore-cursor@5.1.0", "", { "dependencies": { "onetime": "^7.0.0", "signal-exit": "^4.1.0" } }, "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA=="],
+
+    "retry": ["retry@0.13.1", "", {}, "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="],
 
     "roarr": ["roarr@2.15.4", "", { "dependencies": { "boolean": "^3.0.1", "detect-node": "^2.0.4", "globalthis": "^1.0.1", "json-stringify-safe": "^5.0.1", "semver-compare": "^1.0.0", "sprintf-js": "^1.1.2" } }, "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A=="],
 
@@ -1361,6 +1503,10 @@
 
     "sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
 
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
     "sherpa-onnx": ["sherpa-onnx@1.13.2", "", {}, "sha512-hheOLl4JlOzERco73u+1Q/LaNDdFChDe4r3+IlMYIO3wggBZrReHDSxWwRUIW+YLw3eLslyiXw/hfb75aOylEA=="],
 
     "sherpa-onnx-darwin-arm64": ["sherpa-onnx-darwin-arm64@1.13.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-9x86Cbf+BDFONdtCPM3cnjvtAW0ER8tMaHK5pVfz+SHPt8GeuwRXaiR/BzcByFBUyxCgmceO09/WMZOCi44P/g=="],
@@ -1377,7 +1523,11 @@
 
     "sherpa-onnx-win-x64": ["sherpa-onnx-win-x64@1.13.7", "", { "os": "win32", "cpu": "x64" }, "sha512-wBV1o+/zgsMrOjfCFIgGrH6S28xq6CqRCLSavCOjTZ6cqr80yGc07DUHxqsHFPZvfoJU+2JF5L2l3gyWFWoWdQ=="],
 
-    "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+    "signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
+
+    "simple-git": ["simple-git@3.36.0", "", { "dependencies": { "@kwsites/file-exists": "^1.1.1", "@kwsites/promise-deferred": "^1.1.1", "@simple-git/args-pathspec": "^1.0.3", "@simple-git/argv-parser": "^1.1.0", "debug": "^4.4.0" } }, "sha512-cGQjLjK8bxJw4QuYT7gxHw3/IouVESbhahSsHrX97MzCL1gu2u7oy38W6L2ZIGECEfIBG4BabsWDPjBxJENv9Q=="],
+
+    "sleep-promise": ["sleep-promise@9.1.0", "", {}, "sha512-UHYzVpz9Xn8b+jikYSD6bqvf754xL2uBUzDFwiU6NcdZeifPr6UfgU43xpkPu67VMS88+TI2PSI7Eohgqf2fKA=="],
 
     "slice-ansi": ["slice-ansi@9.0.0", "", { "dependencies": { "ansi-styles": "^6.2.3", "is-fullwidth-code-point": "^5.1.0" } }, "sha512-SO/3iYL5S3W57LLEniscOGPZgOqZUPCx6d3dB+52B80yJ0XstzsC/eV8gnA4tM3MHDrKz+OCFSLNjswdSC+/bA=="],
 
@@ -1391,6 +1541,12 @@
 
     "sprintf-js": ["sprintf-js@1.1.3", "", {}, "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="],
 
+    "stdin-discarder": ["stdin-discarder@0.3.2", "", {}, "sha512-eCPu1qRxPVkl5605OTWF8Wz40b4Mf45NY5LQmVPQ599knfs5QhASUm9GbJ5BDMDOXgrnh0wyEdvzmL//YMlw0A=="],
+
+    "stdout-update": ["stdout-update@4.0.1", "", { "dependencies": { "ansi-escapes": "^6.2.0", "ansi-styles": "^6.2.1", "string-width": "^7.1.0", "strip-ansi": "^7.1.0" } }, "sha512-wiS21Jthlvl1to+oorePvcyrIkiG/6M3D3VTmDUlJm7Cy6SbFhKkAvX+YBuHLxck/tO3mrdpC/cNesigQc3+UQ=="],
+
+    "steno": ["steno@4.0.2", "", {}, "sha512-yhPIQXjrlt1xv7dyPQg2P17URmXbuM5pdGkpiMB3RenprfiBlvK415Lctfe0eshk90oA7/tNq7WEiMK8RSP39A=="],
+
     "string-argv": ["string-argv@0.3.2", "", {}, "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q=="],
 
     "string-width": ["string-width@8.2.2", "", { "dependencies": { "get-east-asian-width": "^1.5.0", "strip-ansi": "^7.1.2" } }, "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg=="],
@@ -1398,6 +1554,8 @@
     "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
 
     "strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
+
+    "strip-json-comments": ["strip-json-comments@2.0.1", "", {}, "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="],
 
     "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
@@ -1435,9 +1593,15 @@
 
     "universal-user-agent": ["universal-user-agent@7.0.3", "", {}, "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A=="],
 
+    "universalify": ["universalify@2.0.1", "", {}, "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="],
+
     "update-browserslist-db": ["update-browserslist-db@1.3.2", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw=="],
 
+    "url-join": ["url-join@4.0.1", "", {}, "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA=="],
+
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
+
+    "validate-npm-package-name": ["validate-npm-package-name@7.0.2", "", {}, "sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A=="],
 
     "vite": ["vite@8.2.2", "", { "dependencies": { "lightningcss": "^1.33.0", "picomatch": "^4.0.5", "postcss": "^8.5.26", "rolldown": "~1.2.4", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.4.0 || ^0.5.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q=="],
 
@@ -1446,6 +1610,8 @@
     "vitefu": ["vitefu@1.1.3", "", { "peerDependencies": { "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["vite"] }, "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg=="],
 
     "webdriver-bidi-protocol": ["webdriver-bidi-protocol@0.4.2", "", {}, "sha512-VSV+fzfChirL3e7jay2yUC7B4HQCGtEWEg/MSSQbK+qWbqeGlRLlXTzPpYr3XGUvbpDHumWZBJxgesg4N7dbtA=="],
+
+    "which": ["which@6.0.1", "", { "dependencies": { "isexe": "^4.0.0" }, "bin": { "node-which": "bin/which.js" } }, "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg=="],
 
     "wrap-ansi": ["wrap-ansi@10.0.0", "", { "dependencies": { "ansi-styles": "^6.2.3", "string-width": "^8.2.0", "strip-ansi": "^7.1.2" } }, "sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ=="],
 
@@ -1457,11 +1623,13 @@
 
     "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
 
-    "yargs": ["yargs@18.1.0", "", { "dependencies": { "cliui": "^9.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "string-width": "^8.2.1", "y18n": "^5.0.5", "yargs-parser": "^22.0.0" } }, "sha512-2rAgRKu54VsHkqI0/tYkmluGXHD4KW7yZoycuqDQ15QOTnc2VVfy0nN/1eMhnQLO00A+dwtK20xuCnc1YGeUyg=="],
+    "yargs": ["yargs@17.7.3", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g=="],
 
-    "yargs-parser": ["yargs-parser@22.0.0", "", {}, "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw=="],
+    "yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
+
+    "yoctocolors": ["yoctocolors@2.2.0", "", {}, "sha512-xYqdZFUK/VYazNl/oCDYN+3WloWQwMfZxBoiNt6qNyk+xfOdi598muWE42rNZFp1kNOiqW936q5RhUdnpqElSg=="],
 
     "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
@@ -1472,6 +1640,8 @@
     "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "@huggingface/transformers/onnxruntime-node": ["onnxruntime-node@1.24.3", "", { "dependencies": { "adm-zip": "^0.5.16", "global-agent": "^3.0.0", "onnxruntime-common": "1.24.3" }, "os": [ "linux", "win32", "darwin", ] }, "sha512-JH7+czbc8ALA819vlTgcV+Q214/+VjGeBHDjX81+ZCD0PCVCIFGFNtT0V4sXG/1JXypKPgScQcB3ij/hk3YnTg=="],
+
+    "@inquirer/core/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
     "@isaacs/fs-minipass/minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
 
@@ -1517,6 +1687,8 @@
 
     "@opentelemetry/sdk-logs/@opentelemetry/resources": ["@opentelemetry/resources@2.9.0", "", { "dependencies": { "@opentelemetry/core": "2.9.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg=="],
 
+    "@puppeteer/browsers/yargs": ["yargs@18.1.0", "", { "dependencies": { "cliui": "^9.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "string-width": "^8.2.1", "y18n": "^5.0.5", "yargs-parser": "^22.0.0" } }, "sha512-2rAgRKu54VsHkqI0/tYkmluGXHD4KW7yZoycuqDQ15QOTnc2VVfy0nN/1eMhnQLO00A+dwtK20xuCnc1YGeUyg=="],
+
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.11.2", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" }, "bundled": true }, "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.11.2", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA=="],
@@ -1529,29 +1701,57 @@
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
+    "@typescript/analyze-trace/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
     "@typescript/analyze-trace/yargs": ["yargs@16.2.2", "", { "dependencies": { "cliui": "^7.0.2", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.0", "y18n": "^5.0.5", "yargs-parser": "^20.2.2" } }, "sha512-Nt9ZJjXTv5R8MHbqby/wXQ6Gi0Bb3TcYZkR1bzuL4yB2OxWPkXknz513gEF0GoA6tn00UpbPvERW8rzCuWCA6w=="],
 
     "babel-plugin-jsx-dom-expressions/@babel/helper-module-imports": ["@babel/helper-module-imports@7.18.6", "", { "dependencies": { "@babel/types": "^7.18.6" } }, "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA=="],
 
-    "chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
-
     "cli-progress/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
-    "cliui/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+    "cliui/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
-    "cliui/wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
+    "cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
+    "cmake-js/tar": ["tar@7.5.22", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA=="],
+
+    "cross-spawn/which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
     "fastembed/onnxruntime-node": ["onnxruntime-node@1.21.0", "", { "dependencies": { "global-agent": "^3.0.0", "onnxruntime-common": "1.21.0", "tar": "^7.0.1" }, "os": [ "linux", "win32", "darwin", ] }, "sha512-NeaCX6WW2L8cRCSqy3bInlo5ojjQqu2fD3D+9W5qb5irwxhEyWKXeH2vZ8W9r6VxaMPUan+4/7NDwZMtouZxEw=="],
 
     "fs-minipass/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
 
+    "ipull/commander": ["commander@10.0.1", "", {}, "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug=="],
+
+    "ipull/lifecycle-utils": ["lifecycle-utils@2.1.0", "", {}, "sha512-AnrXnE2/OF9PHCyFg0RSqsnQTzV991XaZA/buhFDoc58xU7rhSCDgCz/09Lqpsn4MpoPHt7TRAXV1kWZypFVsA=="],
+
+    "ipull/pretty-ms": ["pretty-ms@8.0.0", "", { "dependencies": { "parse-ms": "^3.0.0" } }, "sha512-ASJqOugUF1bbzI35STMBUpZqdfYKlJugy6JBziGi2EE+AL5JPJGSzvpeVXojxrr0ViUYoToUjb5kjSEGf7Y83Q=="],
+
+    "ipull/slice-ansi": ["slice-ansi@7.1.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w=="],
+
     "lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
     "minizlib/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
 
+    "node-llama-cpp/slice-ansi": ["slice-ansi@8.0.0", "", { "dependencies": { "ansi-styles": "^6.2.3", "is-fullwidth-code-point": "^5.1.0" } }, "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg=="],
+
     "onnxruntime-web/onnxruntime-common": ["onnxruntime-common@1.24.0-dev.20251116-b39e144322", "", {}, "sha512-BOoomdHYmNRL5r4iQ4bMvsl2t0/hzVQ3OM3PHD0gxeXu1PmggqBv3puZicEUVOA3AtHHYmqZtjMj9FOfGrATTw=="],
 
+    "ora/cli-spinners": ["cli-spinners@3.4.0", "", {}, "sha512-bXfOC4QcT1tKXGorxL3wbJm6XJPDqEnij2gQ2m7ESQuE+/z9YFIWnl/5RpTiKWbMq3EVKR4fRLJGn6DVfu0mpw=="],
+
+    "postcss/nanoid": ["nanoid@3.3.18", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w=="],
+
+    "proper-lockfile/retry": ["retry@0.12.0", "", {}, "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="],
+
+    "restore-cursor/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
+    "stdout-update/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+
     "vite/lightningcss": ["lightningcss@1.33.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.33.0", "lightningcss-darwin-arm64": "1.33.0", "lightningcss-darwin-x64": "1.33.0", "lightningcss-freebsd-x64": "1.33.0", "lightningcss-linux-arm-gnueabihf": "1.33.0", "lightningcss-linux-arm64-gnu": "1.33.0", "lightningcss-linux-arm64-musl": "1.33.0", "lightningcss-linux-x64-gnu": "1.33.0", "lightningcss-linux-x64-musl": "1.33.0", "lightningcss-win32-arm64-msvc": "1.33.0", "lightningcss-win32-x64-msvc": "1.33.0" } }, "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA=="],
+
+    "yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "@huggingface/transformers/onnxruntime-node/global-agent": ["global-agent@3.0.0", "", { "dependencies": { "boolean": "^3.0.1", "es6-error": "^4.1.1", "matcher": "^3.0.0", "roarr": "^2.15.3", "semver": "^7.3.2", "serialize-error": "^7.0.1" } }, "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q=="],
 
@@ -1565,23 +1765,49 @@
 
     "@octokit/plugin-rest-endpoint-methods/@octokit/types/@octokit/openapi-types": ["@octokit/openapi-types@27.0.0", "", {}, "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA=="],
 
+    "@puppeteer/browsers/yargs/cliui": ["cliui@9.0.1", "", { "dependencies": { "string-width": "^7.2.0", "strip-ansi": "^7.1.0", "wrap-ansi": "^9.0.0" } }, "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w=="],
+
+    "@puppeteer/browsers/yargs/yargs-parser": ["yargs-parser@22.0.0", "", {}, "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw=="],
+
+    "@typescript/analyze-trace/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
     "@typescript/analyze-trace/yargs/cliui": ["cliui@7.0.4", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.0", "wrap-ansi": "^7.0.0" } }, "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ=="],
 
     "@typescript/analyze-trace/yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "@typescript/analyze-trace/yargs/yargs-parser": ["yargs-parser@20.2.9", "", {}, "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="],
 
+    "cli-progress/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
     "cli-progress/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
 
     "cli-progress/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
-    "cliui/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+    "cliui/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "cliui/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "cmake-js/tar/chownr": ["chownr@3.0.0", "", {}, "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g=="],
+
+    "cmake-js/tar/minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
+
+    "cmake-js/tar/minizlib": ["minizlib@3.1.0", "", { "dependencies": { "minipass": "^7.1.2" } }, "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw=="],
+
+    "cmake-js/tar/yallist": ["yallist@5.0.0", "", {}, "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw=="],
+
+    "cross-spawn/which/isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
     "fastembed/onnxruntime-node/global-agent": ["global-agent@3.0.0", "", { "dependencies": { "boolean": "^3.0.1", "es6-error": "^4.1.1", "matcher": "^3.0.0", "roarr": "^2.15.3", "semver": "^7.3.2", "serialize-error": "^7.0.1" } }, "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q=="],
 
     "fastembed/onnxruntime-node/onnxruntime-common": ["onnxruntime-common@1.21.0", "", {}, "sha512-Q632iLLrtCAVOTO65dh2+mNbQir/QNTVBG3h/QdZBpns7mZ0RYbLRBgGABPbpU9351AgYy7SJf1WaeVwMrBFPQ=="],
 
     "fastembed/onnxruntime-node/tar": ["tar@7.5.22", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA=="],
+
+    "ipull/pretty-ms/parse-ms": ["parse-ms@3.0.0", "", {}, "sha512-Tpb8Z7r7XbbtBTrM9UhpkzzaMrqA2VXMT3YChzYltwV3P3pM6t8wl7TvpMnSTosz1aQAdVib7kdoys7vYOPerw=="],
 
     "vite/lightningcss/lightningcss-android-arm64": ["lightningcss-android-arm64@1.33.0", "", { "os": "android", "cpu": "arm64" }, "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg=="],
 
@@ -1605,13 +1831,25 @@
 
     "vite/lightningcss/lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.33.0", "", { "os": "win32", "cpu": "x64" }, "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA=="],
 
+    "yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "yargs/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "yargs/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
     "@huggingface/transformers/onnxruntime-node/global-agent/matcher": ["matcher@3.0.0", "", { "dependencies": { "escape-string-regexp": "^4.0.0" } }, "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng=="],
 
     "@huggingface/transformers/onnxruntime-node/global-agent/serialize-error": ["serialize-error@7.0.1", "", { "dependencies": { "type-fest": "^0.13.1" } }, "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw=="],
 
+    "@puppeteer/browsers/yargs/cliui/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+
+    "@puppeteer/browsers/yargs/cliui/wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
+
     "@typescript/analyze-trace/yargs/cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "@typescript/analyze-trace/yargs/cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
+    "@typescript/analyze-trace/yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "@typescript/analyze-trace/yargs/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
 
@@ -1630,6 +1868,8 @@
     "fastembed/onnxruntime-node/tar/minizlib": ["minizlib@3.1.0", "", { "dependencies": { "minipass": "^7.1.2" } }, "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw=="],
 
     "fastembed/onnxruntime-node/tar/yallist": ["yallist@5.0.0", "", {}, "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw=="],
+
+    "yargs/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "@huggingface/transformers/onnxruntime-node/global-agent/serialize-error/type-fest": ["type-fest@0.13.1", "", {}, "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg=="],
 

--- a/package.json
+++ b/package.json
@@ -169,6 +169,7 @@
 		"check-spoofed-versions": "bun scripts/check-spoofed-versions.ts"
 	},
 	"dependencies": {
+		"node-llama-cpp": "3.20.0",
 		"sherpa-onnx": "1.13.2",
 		"sherpa-onnx-darwin-arm64": "1.13.3",
 		"sherpa-onnx-node": "1.13.2"

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -501,6 +501,10 @@
 - Fixed a macOS composer display issue where undercurl could remain attached to stale text after rapid typing.
 - Improved `xd://` MCP failure messages with actionable transport stages, failure categories, server and tool context, retryability, trace IDs, and redacted JSON-RPC details.
 - Fixed ACP `read` tool-call locations so clients such as Zed Follow receive the resolved filesystem path rather than the OMP line-range selector.
+### Changed
+
+- The mnemopi embedding worker is now reaped after five idle minutes instead of living as long as the session: a session that stopped recalling releases the worker and its loaded model, and the next recall respawns it and reloads the model. Previously every concurrent session held its own worker for its entire life, measured at 0.6–1.7 GB on the CPU embedding path.
+
 ### Fixed
 
 - `bun run build` no longer fails when the ggml embedding backend is present, and compiled binaries can run it: node-llama-cpp is bundled while its per-platform prebuilt llama/ggml libraries stay on disk, found through build-time stand-ins for `@node-llama-cpp/*` and the release manifest the package reads at import time.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -501,6 +501,9 @@
 - Fixed a macOS composer display issue where undercurl could remain attached to stale text after rapid typing.
 - Improved `xd://` MCP failure messages with actionable transport stages, failure categories, server and tool context, retryability, trace IDs, and redacted JSON-RPC details.
 - Fixed ACP `read` tool-call locations so clients such as Zed Follow receive the resolved filesystem path rather than the OMP line-range selector.
+### Fixed
+
+- `bun run build` no longer fails when the ggml embedding backend is present, and compiled binaries can run it: node-llama-cpp is bundled while its per-platform prebuilt llama/ggml libraries stay on disk, found through build-time stand-ins for `@node-llama-cpp/*` and the release manifest the package reads at import time.
 
 ## [18.0.9] - 2026-08-28
 

--- a/packages/coding-agent/scripts/compile-binary.ts
+++ b/packages/coding-agent/scripts/compile-binary.ts
@@ -1,13 +1,138 @@
 // Deep import: the pi-utils barrel loads the host native addon, which is
 // absent on cross-compiling release runners.
 import { USER_AGENT } from "@oh-my-pi/pi-utils/dirs";
+import * as path from "node:path";
 import { buildDocsIndexPayload } from "./generate-docs-index";
 import { createLegacyPiVirtualModulePlugin } from "./legacy-pi-virtual-module";
 
 /** Native runtime dependencies always resolved from the on-demand install instead of embedded into compiled binaries. */
 export const COMPILED_EXTERNAL_DEPENDENCIES: readonly string[] = Object.freeze(["fastembed", "onnxruntime-node"]);
 
-/** Inputs shared by local and release coding-agent binary builds. */
+/** Module namespace for the generated `@node-llama-cpp/*` stand-ins. */
+const GGML_PLATFORM_NAMESPACE = "omp-ggml-platform-binaries";
+
+/** Module namespace for the generated stand-in replacing `getModuleVersion.js`. */
+const GGML_MODULE_VERSION_NAMESPACE = "omp-ggml-module-version";
+
+/** Module namespace for the generated stand-in replacing `binariesGithubRelease.js`. */
+const GGML_RELEASE_MANIFEST_NAMESPACE = "omp-ggml-release-manifest";
+
+/** Path of node-llama-cpp's pinned llama.cpp release manifest inside its package. */
+const RELEASE_MANIFEST_PATH = ["llama", "binariesGithubRelease.json"];
+
+/**
+ * Read node-llama-cpp's pinned llama.cpp release (`llama/binariesGithubRelease.json`)
+ * from the installed package at build time, so the compiled binary can answer
+ * the module that reads it instead of opening a path inside the bunfs.
+ */
+async function readPinnedLlamaCppRelease(repoRoot: string): Promise<string> {
+	const manifestPath = path.join(repoRoot, "node_modules", "node-llama-cpp", ...RELEASE_MANIFEST_PATH);
+	const manifest = (await Bun.file(manifestPath).json()) as { release?: unknown };
+	if (typeof manifest.release !== "string" || manifest.release === "") {
+		throw new Error(`node-llama-cpp release manifest at ${manifestPath} has no release string`);
+	}
+	return manifest.release;
+}
+
+/**
+ * `node-llama-cpp` finds its prebuilt llama/ggml libraries by importing
+ * `@node-llama-cpp/<platform>` and calling `getBinsDir()`, then comparing that
+ * package's version with `getModuleVersion()` (its own `package.json`). Both
+ * steps are impossible inside a compiled binary: the platform packages hold
+ * hundreds of MB of shared libraries (155 MB for CUDA alone) that must stay out
+ * of the bundle, bare specifiers resolve only against the embedded module graph
+ * (oven-sh/bun#1763), runtime `Bun.plugin` hooks never fire for them (Bun
+ * 1.3.14), and reading `package.json` through the embedded filesystem fails.
+ *
+ * This plugin bundles node-llama-cpp's JS (deps included) and replaces the two
+ * filesystem-dependent seams with generated modules that report the same
+ * contract from the install tree on disk, failing closed when the installed
+ * prebuilt is missing or comes from a different release.
+ */
+function ggmlPlatformBinariesPlugin(releaseVersion: string, pinnedRelease: string): Bun.BunPlugin {
+	return {
+		name: "omp-ggml-platform-binaries",
+		setup(build) {
+			build.onResolve({ filter: /^@node-llama-cpp\// }, args => ({
+				path: args.path,
+				namespace: GGML_PLATFORM_NAMESPACE,
+			}));
+			build.onLoad({ filter: /.*/, namespace: GGML_PLATFORM_NAMESPACE }, args => {
+				return {
+					loader: "js",
+					contents: [
+						`import * as path from "node:path";`,
+						`import { readPackageVersion, resolvePackageDirFromExecutable } from "@oh-my-pi/pi-utils";`,
+						`const PACKAGE = ${JSON.stringify(args.path)};`,
+						`const VERSION = ${JSON.stringify(releaseVersion)};`,
+						`/** Mirrors the platform package's getBinsDir(); an empty object means "unavailable". */`,
+						`export function getBinsDir() {`,
+						`	const packageDir = resolvePackageDirFromExecutable(PACKAGE);`,
+						`	if (packageDir === null || readPackageVersion(packageDir) !== VERSION) return {};`,
+						`	return { binsDir: path.join(packageDir, "bins"), packageVersion: VERSION };`,
+						`}`,
+					].join("\n"),
+				};
+			});
+			// `getModuleVersion()` resolves its own package.json relative to the
+			// module URL, which a compiled binary cannot read; serve the pinned
+			// release instead so node-llama-cpp's version comparison is meaningful.
+			build.onResolve({ filter: /getModuleVersion\.js$/ }, args =>
+				args.namespace === "file" ? { path: "version", namespace: GGML_MODULE_VERSION_NAMESPACE } : undefined,
+			);
+			build.onLoad({ filter: /.*/, namespace: GGML_MODULE_VERSION_NAMESPACE }, () => ({
+				loader: "js",
+				contents: [
+					`const VERSION = ${JSON.stringify(releaseVersion)};`,
+					`/** Bundled stand-in for node-llama-cpp's package.json version lookup. */`,
+					`export async function getModuleVersion() {`,
+					`	return VERSION;`,
+					`}`,
+				].join("\n"),
+			}));
+			// `binariesGithubRelease.js` reads `llama/binariesGithubRelease.json`
+			// from the package directory at module load (top-level await), a path
+			// that does not exist inside a compiled binary; serve the pinned
+			// release the build already knows.
+			build.onResolve({ filter: /binariesGithubRelease\.js$/ }, args =>
+				args.namespace === "file" ? { path: "release", namespace: GGML_RELEASE_MANIFEST_NAMESPACE } : undefined,
+			);
+			build.onLoad({ filter: /.*/, namespace: GGML_RELEASE_MANIFEST_NAMESPACE }, () => ({
+				loader: "js",
+				contents: [
+					`const RELEASE = ${JSON.stringify(pinnedRelease)};`,
+					`/** Pinned llama.cpp release baked at build time from the installed package. */`,
+					`export const builtinLlamaCppRelease = RELEASE;`,
+					`export const defaultLlamaCppRelease = RELEASE;`,
+					`export async function getBinariesGithubRelease() {`,
+					`	return RELEASE;`,
+					`}`,
+					`/** Only the update CLI writes this manifest; the binary never does. */`,
+					`export async function setBinariesGithubRelease() {}`,
+				].join("\n"),
+			}));
+		},
+	};
+}
+
+/**
+ * The pinned node-llama-cpp release whose prebuilt platform binaries the ggml
+ * embedding backend loads. `pi-mnemopi` declares it as an optional peer with an
+ * exact version so the compiled binary can compare a discovered prebuilt
+ * against a single known release.
+ */
+async function resolveNodeLlamaCppRelease(repoRoot: string): Promise<string> {
+	const manifest = (await Bun.file(path.join(repoRoot, "packages", "mnemopi", "package.json")).json()) as {
+		peerDependencies?: Record<string, string>;
+	};
+	const pinned = manifest.peerDependencies?.["node-llama-cpp"];
+	if (typeof pinned !== "string" || pinned === "") {
+		throw new Error("packages/mnemopi/package.json must pin an exact node-llama-cpp peer version");
+	}
+	return pinned;
+}
+
+/** Inputs shared for local and release coding-agent binary builds. */
 export interface CodingAgentCompileOptions {
 	/** Absolute repository root used for package resolution. */
 	readonly repoRoot: string;
@@ -50,7 +175,13 @@ export async function compileCodingAgent(options: CodingAgentCompileOptions): Pr
 				identifiers: options.minifyIdentifiers ?? false,
 				keepNames: true,
 			},
-			plugins: [await createLegacyPiVirtualModulePlugin()],
+			plugins: [
+				await createLegacyPiVirtualModulePlugin(),
+				ggmlPlatformBinariesPlugin(
+					await resolveNodeLlamaCppRelease(options.repoRoot),
+					await readPinnedLlamaCppRelease(options.repoRoot),
+				),
+			],
 			compile: {
 				// Bun's process-wide fetch User-Agent default. Any explicit
 				// provider fingerprint (Anthropic/Codex OAuth) still wins.

--- a/packages/coding-agent/src/mnemopi/embed-client.ts
+++ b/packages/coding-agent/src/mnemopi/embed-client.ts
@@ -97,6 +97,18 @@ export interface MnemopiSubprocessEmbeddingModel {
  */
 const EMBED_REQUEST_TIMEOUT_MS = 120_000;
 
+/**
+ * How long an idle worker is kept alive before it is reaped. A session that
+ * embedded once otherwise holds the worker — and its loaded model — for the
+ * rest of its life, and every concurrent session pays that cost again (the
+ * ONNX path measured 0.6–1.7 GB per worker on this box). The protocol is
+ * built for this: every `embed` carries the model + cache dir, so a reaped
+ * worker is respawned and lazily reloaded by the next request, at the cost of
+ * one model load. Kept well above a typical turn gap so interactive use does
+ * not reload per turn.
+ */
+const EMBED_WORKER_IDLE_TTL_MS = 300_000;
+
 /** Race marker for {@link MnemopiEmbedClient.#awaitRequest}. */
 const REQUEST_TIMED_OUT = Symbol("mnemopi.embed.timedOut");
 
@@ -108,13 +120,17 @@ export class MnemopiEmbedClient {
 	#nextRequestId = 0;
 	#spawnWorker: () => MnemopiEmbedWorkerHandle;
 	#requestTimeoutMs: number;
+	#idleTtlMs: number;
+	#idleReapTimer: Timer | null = null;
 
 	constructor(
 		spawnWorker: () => MnemopiEmbedWorkerHandle = spawnMnemopiEmbedWorker,
 		requestTimeoutMs: number = EMBED_REQUEST_TIMEOUT_MS,
+		idleTtlMs: number = EMBED_WORKER_IDLE_TTL_MS,
 	) {
 		this.#spawnWorker = spawnWorker;
 		this.#requestTimeoutMs = requestTimeoutMs;
+		this.#idleTtlMs = idleTtlMs;
 	}
 
 	/**
@@ -140,6 +156,7 @@ export class MnemopiEmbedClient {
 				if (!ok) return null;
 			} finally {
 				this.#pending.delete(id);
+				this.#armIdleReap();
 			}
 		} catch (error) {
 			logger.debug("mnemopi-embed: init failed", {
@@ -152,6 +169,7 @@ export class MnemopiEmbedClient {
 	}
 
 	async terminate(): Promise<void> {
+		this.#clearIdleReap();
 		const worker = this.#worker;
 		this.#worker = null;
 		this.#unsubscribeMessage?.();
@@ -192,7 +210,33 @@ export class MnemopiEmbedClient {
 			return result;
 		} finally {
 			this.#pending.delete(id);
+			this.#armIdleReap();
 		}
+	}
+
+	/**
+	 * Reap the worker once {@link EMBED_WORKER_IDLE_TTL_MS} pass without a
+	 * request. Respawning is the protocol's normal path (every `embed` carries
+	 * the model + cache dir), so this only trades one model load for releasing
+	 * the worker's address space in a session that stopped recalling.
+	 */
+	#armIdleReap(): void {
+		this.#clearIdleReap();
+		const timer = setTimeout(() => {
+			this.#idleReapTimer = null;
+			// A request that started after this timer was armed owns the worker.
+			if (this.#pending.size > 0) return;
+			logger.debug("mnemopi-embed: reaping idle worker", { idleMs: this.#idleTtlMs });
+			void this.terminate();
+		}, this.#idleTtlMs);
+		timer.unref();
+		this.#idleReapTimer = timer;
+	}
+
+	#clearIdleReap(): void {
+		if (this.#idleReapTimer === null) return;
+		clearTimeout(this.#idleReapTimer);
+		this.#idleReapTimer = null;
 	}
 
 	/**
@@ -236,6 +280,7 @@ export class MnemopiEmbedClient {
 	}
 
 	#ensureWorker(): MnemopiEmbedWorkerHandle {
+		this.#clearIdleReap();
 		if (this.#worker) return this.#worker;
 		const worker = this.#spawnWorker();
 		this.#worker = worker;

--- a/packages/coding-agent/src/mnemopi/embed-worker.ts
+++ b/packages/coding-agent/src/mnemopi/embed-worker.ts
@@ -19,7 +19,7 @@ import {
 import type { MnemopiEmbedModelId, MnemopiEmbedTransport, MnemopiEmbedWorkerInbound } from "./embed-protocol";
 
 /** Local embedding backend: ONNX fastembed (default) or ggml (llama.cpp GPU). */
-function selectedInitializer(): LocalModelInitializer {
+export function selectedInitializer(): LocalModelInitializer {
 	return embeddingBackend() === "ggml" ? ggmlLocalModelInitializer : defaultLocalModelInitializer;
 }
 

--- a/packages/coding-agent/src/mnemopi/embed-worker.ts
+++ b/packages/coding-agent/src/mnemopi/embed-worker.ts
@@ -9,8 +9,19 @@
  * in either process.
  */
 
-import { defaultLocalModelInitializer, type StandardEmbeddingModel } from "@oh-my-pi/pi-mnemopi/core";
+import {
+	defaultLocalModelInitializer,
+	embeddingBackend,
+	ggmlLocalModelInitializer,
+	type LocalModelInitializer,
+	type StandardEmbeddingModel,
+} from "@oh-my-pi/pi-mnemopi/core";
 import type { MnemopiEmbedModelId, MnemopiEmbedTransport, MnemopiEmbedWorkerInbound } from "./embed-protocol";
+
+/** Local embedding backend: ONNX fastembed (default) or ggml (llama.cpp GPU). */
+function selectedInitializer(): LocalModelInitializer {
+	return embeddingBackend() === "ggml" ? ggmlLocalModelInitializer : defaultLocalModelInitializer;
+}
 
 interface LoadedModel {
 	model: MnemopiEmbedModelId;
@@ -24,14 +35,14 @@ let loaded: Promise<LoadedModel> | null = null;
 let loadedKey = "";
 
 async function loadModel(model: MnemopiEmbedModelId, cacheDir: string | undefined): Promise<LoadedModel> {
-	// Route through mnemopi's shared initializer so the worker inherits BOTH
-	// cache heals (sidecar re-fetch AND corrupt-model quarantine/retry) —
-	// fastembed/onnxruntime still load only in this child address space, the
-	// initializer calls loadFastembed() itself.
+	// Route through the configured initializer so the worker inherits BOTH
+	// mnemopi's cache heals for fastembed (sidecar re-fetch AND corrupt-model
+	// quarantine/retry) and the ggml (llama.cpp) GPU path when selected. Both
+	// native runtimes stay inside this child address space.
 	// Cast: `model` arrives as a string from the parent (resolved by
 	// mnemopi's `fastembedModelName`); the parent only ever passes pre-vetted
 	// fast-* identifiers.
-	const instance = await defaultLocalModelInitializer({
+	const instance = await selectedInitializer()({
 		model: model as StandardEmbeddingModel,
 		cacheDir,
 		showDownloadProgress: false,

--- a/packages/coding-agent/test/embed-client-idle-reap.test.ts
+++ b/packages/coding-agent/test/embed-client-idle-reap.test.ts
@@ -1,0 +1,122 @@
+// The embed client owns the worker subprocess lifetime. A session that
+// embedded once used to hold that worker — and its loaded model — until the
+// session ended, so every concurrent session paid the model's address space
+// again. These tests pin the replacement contract: the worker is spawned on
+// demand, reaped after an idle window, and transparently respawned (with the
+// model/cacheDir replayed) by the next request.
+import { afterEach, beforeEach, describe, expect, test, vi } from "bun:test";
+import { MnemopiEmbedClient } from "../src/mnemopi/embed-client";
+
+interface FakeWorker {
+	sent: Array<{ type: string; id: string; model?: string; cacheDir?: string }>;
+	terminated: boolean;
+	handle: unknown;
+	reply(message: unknown): void;
+}
+
+/** Worker that answers every request after a microtask, like the real IPC round-trip. */
+function makeFakeWorker(): FakeWorker {
+	const worker = {
+		sent: [] as FakeWorker["sent"],
+		terminated: false,
+		handle: null as unknown,
+		reply: () => {},
+	};
+	const handlers = new Set<(message: unknown) => void>();
+	worker.handle = {
+		send(message: FakeWorker["sent"][number]) {
+			worker.sent.push(message);
+			queueMicrotask(() =>
+				worker.reply(
+					message.type === "init"
+						? { type: "ready", id: message.id }
+						: { type: "vectors", id: message.id, vectors: [[1, 2, 3]] },
+				),
+			);
+		},
+		onMessage(handler: (message: unknown) => void) {
+			handlers.add(handler);
+			return () => handlers.delete(handler);
+		},
+		onError() {
+			return () => {};
+		},
+		async terminate() {
+			worker.terminated = true;
+			handlers.clear();
+		},
+	};
+	worker.reply = (message: unknown) => {
+		for (const handler of handlers) handler(message);
+	};
+	return worker;
+}
+
+function spawnRecorder(spawned: FakeWorker[]): () => never {
+	return () => {
+		const worker = makeFakeWorker();
+		spawned.push(worker);
+		return worker.handle as never;
+	};
+}
+
+async function drain(iterable: AsyncIterable<number[][]>): Promise<number[][]> {
+	const rows: number[][] = [];
+	for await (const batch of iterable) rows.push(...batch);
+	return rows;
+}
+
+beforeEach(() => {
+	vi.useFakeTimers();
+});
+
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+describe("MnemopiEmbedClient worker lifetime", () => {
+	test("spawns no worker until the first request, then reaps it when idle", async () => {
+		const spawned: FakeWorker[] = [];
+		const client = new MnemopiEmbedClient(spawnRecorder(spawned), 5_000, 30);
+
+		expect(spawned).toHaveLength(0);
+
+		const model = await client.initialize("fast-bge-base-en-v1.5", "/tmp/cache");
+		expect(model).not.toBeNull();
+		expect(spawned).toHaveLength(1);
+		expect(await drain(model!.embed(["a"]))).toEqual([[1, 2, 3]]);
+		expect(spawned[0]!.terminated).toBe(false);
+
+		// Idle past the TTL: the worker (and its loaded model) is released.
+		vi.advanceTimersByTime(31);
+		expect(spawned[0]!.terminated).toBe(true);
+
+		// The next request respawns and replays model + cacheDir, so the fresh
+		// worker reloads without another `initialize` call.
+		expect(await drain(model!.embed(["b"]))).toEqual([[1, 2, 3]]);
+		expect(spawned).toHaveLength(2);
+		expect(spawned[1]!.sent[0]).toMatchObject({
+			type: "embed",
+			model: "fast-bge-base-en-v1.5",
+			cacheDir: "/tmp/cache",
+		});
+
+		await client.terminate();
+		expect(spawned[1]!.terminated).toBe(true);
+	});
+
+	test("keeps a worker that is used again inside the idle window", async () => {
+		const spawned: FakeWorker[] = [];
+		const client = new MnemopiEmbedClient(spawnRecorder(spawned), 5_000, 60);
+
+		const model = await client.initialize("fast-bge-base-en-v1.5", "/tmp/cache");
+		for (let i = 0; i < 4; i++) {
+			vi.advanceTimersByTime(20);
+			expect(await drain(model!.embed([`text ${i}`]))).toEqual([[1, 2, 3]]);
+		}
+
+		expect(spawned).toHaveLength(1);
+		expect(spawned[0]!.terminated).toBe(false);
+		await client.terminate();
+	});
+});

--- a/packages/coding-agent/test/embed-worker-backend.test.ts
+++ b/packages/coding-agent/test/embed-worker-backend.test.ts
@@ -1,0 +1,38 @@
+// Contract: the mnemopi embed worker routes to the ggml initializer exactly
+// when MNEMOPI_EMBED_BACKEND=ggml, and stays on fastembed otherwise (including
+// the unset default). This is the routing branch that the ggml-embedding unit
+// tests never exercise — they import ggmlLocalModelInitializer directly. It is
+// proven here WITHOUT loading either native addon: selectedInitializer() only
+// selects a function reference, it never invokes an initializer, so neither
+// node-llama-cpp nor fastembed/onnxruntime is pulled into the test process.
+import { describe, expect, it } from "bun:test";
+import { defaultLocalModelInitializer, ggmlLocalModelInitializer } from "@oh-my-pi/pi-mnemopi/core";
+import { selectedInitializer } from "../src/mnemopi/embed-worker";
+
+describe("embed-worker selectedInitializer backend routing", () => {
+	it("selects the ggml initializer when MNEMOPI_EMBED_BACKEND=ggml", () => {
+		const before = process.env.MNEMOPI_EMBED_BACKEND;
+		process.env.MNEMOPI_EMBED_BACKEND = "ggml";
+		try {
+			expect(selectedInitializer()).toBe(ggmlLocalModelInitializer);
+		} finally {
+			if (before !== undefined) process.env.MNEMOPI_EMBED_BACKEND = before;
+			else delete process.env.MNEMOPI_EMBED_BACKEND;
+		}
+	});
+
+	it("keeps the fastembed initializer when the backend is unset or explicitly fastembed", () => {
+		const before = process.env.MNEMOPI_EMBED_BACKEND;
+		delete process.env.MNEMOPI_EMBED_BACKEND;
+		try {
+			expect(selectedInitializer()).toBe(defaultLocalModelInitializer);
+			// An explicit fastembed spelling (or any typo that falls back) must
+			// never route to the ggml initializer.
+			process.env.MNEMOPI_EMBED_BACKEND = "fastembed";
+			expect(selectedInitializer()).toBe(defaultLocalModelInitializer);
+		} finally {
+			if (before !== undefined) process.env.MNEMOPI_EMBED_BACKEND = before;
+			else delete process.env.MNEMOPI_EMBED_BACKEND;
+		}
+	});
+});

--- a/packages/mnemopi/CHANGELOG.md
+++ b/packages/mnemopi/CHANGELOG.md
@@ -7,6 +7,9 @@
 ### Fixed
 
 - Fixed working-memory recall returning too few or no results after matching memories were invalidated.
+### Added
+
+- Added a ggml (llama.cpp) local-embedding backend that runs embedding models on the GPU via node-llama-cpp (Vulkan/Metal/CUDA). Select with `MNEMOPI_EMBED_BACKEND=ggml` and point `MNEMOPI_EMBED_GGUF_PATH` at a GGUF embedding model; same model id keeps the existing memory corpus valid.
 
 ## [18.0.9] - 2026-08-28
 

--- a/packages/mnemopi/CHANGELOG.md
+++ b/packages/mnemopi/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Fixed working-memory recall returning too few or no results after matching memories were invalidated.
 ### Added
 
-- Added a ggml (llama.cpp) local-embedding backend that runs embedding models on the GPU via node-llama-cpp (Vulkan/Metal/CUDA). Select with `MNEMOPI_EMBED_BACKEND=ggml` and point `MNEMOPI_EMBED_GGUF_PATH` at a GGUF embedding model; same model id keeps the existing memory corpus valid.
+- Added a ggml (llama.cpp) local-embedding backend that runs embedding models on the GPU via node-llama-cpp (Vulkan/Metal/CUDA). Select with `MNEMOPI_EMBED_BACKEND=ggml` and point `MNEMOPI_EMBED_GGUF_PATH` at a GGUF embedding model; same model id keeps the existing memory corpus valid. `MNEMOPI_EMBED_GPU` pins the GPU backend (`auto`, `cuda`, `vulkan`, `cpu`); on a GTX 1650 Ti, CUDA embeds ~1.5x faster than Vulkan at ~285 MB more resident memory, and `build: "never"` keeps a missing prebuilt from turning into a source build.
 
 ## [18.0.9] - 2026-08-28
 

--- a/packages/mnemopi/package.json
+++ b/packages/mnemopi/package.json
@@ -46,10 +46,14 @@
   },
   "peerDependencies": {
     "fastembed": "2.1.0",
+    "node-llama-cpp": "3.20.0",
     "onnxruntime-node": "1.21.0"
   },
   "peerDependenciesMeta": {
     "fastembed": {
+      "optional": true
+    },
+    "node-llama-cpp": {
       "optional": true
     },
     "onnxruntime-node": {
@@ -59,6 +63,7 @@
   "devDependencies": {
     "@types/bun": "catalog:",
     "fastembed": "catalog:",
+    "node-llama-cpp": "3.20.0",
     "onnxruntime-node": "catalog:"
   },
   "engines": {

--- a/packages/mnemopi/src/config.ts
+++ b/packages/mnemopi/src/config.ts
@@ -91,6 +91,21 @@ export function embeddingApiUrl(env: Env = process.env): string {
 	return envString("MNEMOPI_EMBEDDING_API_URL", envString("OPENROUTER_BASE_URL", DEFAULT_EMBEDDING_API_URL, env), env);
 }
 
+/**
+ * Local embedding backend: `"fastembed"` (ONNX, default) or `"ggml"`
+ * (llama.cpp via node-llama-cpp, GPU). `"ggml"` loads a GGUF embedding model.
+ */
+export type EmbeddingBackend = "fastembed" | "ggml";
+
+export function embeddingBackend(env: Env = process.env): EmbeddingBackend {
+	return envOneOf("MNEMOPI_EMBED_BACKEND", ["fastembed", "ggml"] as const, "fastembed", env);
+}
+
+/** Explicit GGUF model path for the ggml backend (`MNEMOPI_EMBED_GGUF_PATH`). */
+export function embeddingGgufPath(env: Env = process.env): string {
+	return envOptionalString("MNEMOPI_EMBED_GGUF_PATH", env) ?? "";
+}
+
 export function embeddingsViaApi(env: Env = process.env): boolean {
 	return envTruthy("MNEMOPI_EMBEDDINGS_VIA_API", env);
 }

--- a/packages/mnemopi/src/config.ts
+++ b/packages/mnemopi/src/config.ts
@@ -101,6 +101,20 @@ export function embeddingBackend(env: Env = process.env): EmbeddingBackend {
 	return envOneOf("MNEMOPI_EMBED_BACKEND", ["fastembed", "ggml"] as const, "fastembed", env);
 }
 
+/**
+ * GPU backend for the ggml embedding runtime (`MNEMOPI_EMBED_GPU`): `"auto"`
+ * (let node-llama-cpp pick), `"cuda"`, `"vulkan"`, or `"cpu"`. Measured on a
+ * GTX 1650 Ti with bge-base-en-v1.5-Q4_K_M: CUDA embeds ~1.5x faster than
+ * Vulkan (7.7 vs 10.8 ms/text) but holds ~285 MB more resident memory
+ * (647 vs 362 MB RSS, 330 vs 155 MB anonymous), so Vulkan is the leaner
+ * choice on a memory-bound machine.
+ */
+export type EmbeddingGpu = "auto" | "cuda" | "vulkan" | "cpu";
+
+export function embeddingGpu(env: Env = process.env): EmbeddingGpu {
+	return envOneOf("MNEMOPI_EMBED_GPU", ["auto", "cuda", "vulkan", "cpu"] as const, "auto", env);
+}
+
 /** Explicit GGUF model path for the ggml backend (`MNEMOPI_EMBED_GGUF_PATH`). */
 export function embeddingGgufPath(env: Env = process.env): string {
 	return envOptionalString("MNEMOPI_EMBED_GGUF_PATH", env) ?? "";

--- a/packages/mnemopi/src/core/beam/helpers.ts
+++ b/packages/mnemopi/src/core/beam/helpers.ts
@@ -12,7 +12,7 @@ import {
 	RECALL_SYNONYMS,
 	recallTokens,
 } from "../../util/regex";
-import { currentEmbeddingModel, embed } from "../embeddings";
+import { currentEmbeddingModelIdentity, embed } from "../embeddings";
 import { getMnemopiRuntimeOptions, mnemopiDebugEnabled, withMnemopiRuntimeOptions } from "../runtime-options";
 import { buildExactVectorIndex, searchExactVectorIndex } from "../vector-index";
 import type { BeamMemoryState, JsonValue, Metadata } from "./types";
@@ -790,7 +790,7 @@ async function runEmbedding(beam: BeamMemoryState, items: readonly EmbedItem[]):
 	try {
 		const matrix = await embed(items.map(item => item.content));
 		if (matrix === null) return;
-		const model = currentEmbeddingModel();
+		const model = currentEmbeddingModelIdentity();
 		using insertEmbedding = beam.db.prepare(
 			"INSERT OR REPLACE INTO memory_embeddings(memory_id, embedding_json, model) VALUES (?, ?, ?)",
 		);

--- a/packages/mnemopi/src/core/beam/store.ts
+++ b/packages/mnemopi/src/core/beam/store.ts
@@ -3,7 +3,7 @@ import { logger } from "@oh-my-pi/pi-utils";
 import { transaction } from "../../db";
 import { toUtcIso } from "../../util/datetime";
 import { generateId } from "../../util/ids";
-import { currentEmbeddingModel, embeddingsDisabled } from "../embeddings";
+import { currentEmbeddingModelIdentity, embeddingsDisabled } from "../embeddings";
 import { EpisodicGraph } from "../episodic-graph";
 import { countExtractedFactCategories, extractFactCategoriesSafe } from "../extraction";
 import { getMnemopiRuntimeOptions, withMnemopiRuntimeOptions } from "../runtime-options";
@@ -350,10 +350,11 @@ const EMBED_REBUILD_BATCH = 128;
 /**
  * Reconcile stored embeddings against the active embedding model at store open.
  *
- * Every `memory_embeddings` row is stamped with the model that produced it (see
- * `runEmbedding` in `helpers.ts`). When the configured embedding model changes,
- * its vector dimension changes too, so the previously-stored vectors are no
- * longer comparable. On a mismatch we wipe every stored vector — the
+ * Every `memory_embeddings` row is stamped with the backend-qualified
+ * embedding-model identity that produced it (see `runEmbedding` in `helpers.ts`
+ * and `currentEmbeddingModelIdentity` in `embeddings.ts`). When the configured
+ * model — or the local backend/GGUF artifact in effect for it — changes, the
+ * previously-stored vectors are no longer comparable. On a mismatch we wipe every stored vector — the
  * `memory_embeddings` table, the `episodic_memory.binary_vector` column, and the
  * sqlite-vec `vec_episodes` index — then enqueue all live memories for
  * background re-embedding under the new model via `scheduleEmbedding`.
@@ -363,12 +364,12 @@ const EMBED_REBUILD_BATCH = 128;
  * rebuilt — embeddings disabled via the runtime option OR the
  * `MNEMOPI_NO_EMBEDDINGS` env, or an unresolved (empty) active model — so a
  * stale-but-valid corpus is never destroyed without a replacement. MUST run
- * inside the active runtime-options scope so `currentEmbeddingModel()` /
+ * inside the active runtime-options scope so `currentEmbeddingModelIdentity()` /
  * `embeddingsDisabled()` reflect the per-instance configuration.
  */
 export function reconcileEmbeddingModel(beam: BeamMemoryState): void {
 	if (embeddingsDisabled()) return;
-	const active = currentEmbeddingModel().trim();
+	const active = currentEmbeddingModelIdentity();
 	if (active === "") return;
 
 	// Re-embed in bounded batches so a corpus-wide rebuild never issues one giant

--- a/packages/mnemopi/src/core/embeddings.ts
+++ b/packages/mnemopi/src/core/embeddings.ts
@@ -14,6 +14,7 @@ import {
 } from "@oh-my-pi/pi-utils";
 import { LRUCache } from "@oh-my-pi/pi-utils/lru";
 import type { EmbeddingModel } from "fastembed";
+import { embeddingBackend, embeddingGgufPath } from "../config";
 import { ensureFastembedModelSidecars } from "./fastembed-model-cache";
 import { loadFastembed } from "./fastembed-runtime";
 import {
@@ -319,6 +320,27 @@ function defaultModel(): string {
  */
 export function currentEmbeddingModel(): string {
 	return defaultModel();
+}
+/**
+ * Backend-qualified identity for the active embedding model. Stamped alongside
+ * each row in `memory_embeddings.model` (see `runEmbedding` in `helpers.ts`) and
+ * compared during reconciliation (see `reconcileEmbeddingModel` in `store.ts`).
+ *
+ * The default fastembed backend keeps the bare model name so legacy rows stay
+ * valid; the ggml backend prefixes the backend and the resolved GGUF artifact so
+ * switching `fastembed <-> ggml` — or pointing at a different GGUF — under the
+ * same model id detects a mismatch and forces a corpus rebuild, instead of
+ * silently scoring query vectors against vectors from a different artifact
+ * (node-llama-cpp embeddings are only comparable within the exact same file).
+ */
+export function currentEmbeddingModelIdentity(): string {
+	const model = currentEmbeddingModel().trim();
+	if (model === "") return "";
+	if (embeddingBackend() === "ggml") {
+		const gguf = embeddingGgufPath().trim();
+		return `ggml:${model}:${gguf || "<default>"}`;
+	}
+	return model;
 }
 
 export function isApiModel(modelName: string): boolean {

--- a/packages/mnemopi/src/core/ggml-embedding.ts
+++ b/packages/mnemopi/src/core/ggml-embedding.ts
@@ -17,45 +17,86 @@
  * the host (the sibling guarantee to issue #3031 for onnxruntime-node).
  *
  * Model-compat note: the GGUF conversion of an embedding model preserves the
- * model's *identity* (name) and vector dimension, so switching the backend from
- * fastembed/ONNX to ggml for the same model id does NOT change the dimension
- * and does not require re-embedding the memory corpus. Quantization (Q4_K_M)
- * changes the embedding *values* slightly, so cross-backend vectors are not
- * bit-identical, but they are dimension- and semantic-compatible.
+ * model's *identity* (name) and vector dimension, and quantization (Q4_K_M)
+ * changes the embedding *values* slightly — so switching backends under the
+ * same model id does NOT change the dimension but DOES produce non-identical
+ * vectors. The persisted corpus key therefore includes the backend/artifact in
+ * effect (`currentEmbeddingModelIdentity` in `embeddings.ts`), so switching
+ * `fastembed -> ggml` (or vice versa) forces a corpus rebuild even though the
+ * model id is unchanged. Cross-backend vectors are never mixed.
  */
 
 import { existsSync } from "node:fs";
 import * as nodePath from "node:path";
 import { logger } from "@oh-my-pi/pi-utils";
-import type { Llama } from "node-llama-cpp";
+import type * as LlamaCpp from "node-llama-cpp";
+import { MODEL_CACHE_DIR } from "../config";
 import type { LocalEmbeddingModel, LocalModelInitializer, LocalModelInitOptions } from "./embeddings";
 
 /** Minimal loaded-llama embedding surface the initializer depends on. */
 interface LlamaEmbeddingRuntime {
-	llama: Llama;
+	llama: LlamaCpp.Llama;
 	context: {
 		getEmbeddingFor(input: string): Promise<{ vector: readonly number[] }>;
 		dispose(): Promise<void>;
 	};
+	/**
+	 * Truncate `input` to the embedding context's token budget before
+	 * evaluation. node-llama-cpp's `getEmbeddingFor` *throws* when the tokenized
+	 * input exceeds the context window (unlike the fastembed/onnx path, which
+	 * silently truncates), so oversized inputs must be clipped up front. Uses the
+	 * model tokenizer when available; falls back to a conservative character
+	 * clip (each token occupies at least one character) for the test seam.
+	 */
+	truncate(input: string): string;
 }
 
-let llamaPromise: Promise<LlamaEmbeddingRuntime> | null = null;
+/** Embedding-context token budget. Matches the bge-series max context (512). */
+const CONTEXT_SIZE = 512;
+/** Headroom kept when token-truncating so a detokenize/retokenize round-trip cannot spill past the budget. */
+const TRUNCATE_MARGIN = 4;
+
+/** Default node-llama-cpp module namespace type. */
+type LlamaCppModule = typeof LlamaCpp;
+
+/**
+ * Default node-llama-cpp loader. node-llama-cpp is ESM-only (no CJS export)
+ * with an async module graph, so Bun cannot `createRequire` it the way
+ * fastembed is loaded in `fastembed-runtime.ts`; `import()` is the loader Bun
+ * supports for an ESM-only async native-addon module. Kept behind an injected
+ * loader so tests stub it and the native addon still never loads in the main
+ * agent process.
+ */
+async function loadNodeLlamaCpp(): Promise<LlamaCppModule> {
+	return await import("node-llama-cpp");
+}
+
+const DEFAULT_MODULE_LOADER: () => Promise<LlamaCppModule> = loadNodeLlamaCpp;
+
+/** Default node-llama-cpp loader; tests swap this via `setGgmlModuleLoaderForTests`. */
+let moduleLoader: () => Promise<LlamaCppModule> = DEFAULT_MODULE_LOADER;
+
+/** Cached ggml runtime, keyed by the resolved GGUF model path. */
+let llamaCache: { modelPath: string; promise: Promise<LlamaEmbeddingRuntime> } | null = null;
 
 /**
  * Resolve the GGUF model path. Order:
  *  1. `MNEMOPI_EMBED_GGUF_PATH` explicit path (full filename).
- *  2. `<cacheDir>/<model>.gguf` where `cacheDir` is the fastembed cache root
- *     (so a user can drop the GGUF beside the ONNX cache).
- *  3. `<cacheDir>/../mnemopi/models/<model>.gguf`.
+ *  2. `<MNEMOPI_EMBED_GGUF_DIR>` or the canonical `MODEL_CACHE_DIR`
+ *     (`~/.hermes/mnemopi/models`).
+ *  3. `cacheDir` (the fastembed cache root) if provided.
  * Returns `null` when no candidate exists (caller should fall back).
  */
 export function resolveGgufModelPath(model: string, cacheDir: string | undefined): string | null {
 	const explicit = process.env.MNEMOPI_EMBED_GGUF_PATH?.trim();
 	if (explicit) return explicit;
-	const root = cacheDir ?? defaultGgufCacheRoot();
 	const basename = ggufFilename(model);
 	if (!basename) return null;
-	for (const base of [root, nodePath.join(root, "..", "models")]) {
+	const candidates = [defaultGgufCacheRoot()];
+	if (cacheDir !== undefined && cacheDir !== "") {
+		candidates.push(cacheDir);
+	}
+	for (const base of candidates) {
 		const candidate = nodePath.join(base, basename);
 		if (existsSync(candidate)) return candidate;
 	}
@@ -74,11 +115,8 @@ function ggufFilename(model: string): string | null {
 }
 
 function defaultGgufCacheRoot(): string {
-	return process.env.MNEMOPI_EMBED_GGUF_DIR ?? nodePath.join(process.env.HOME ?? "", ".hermes", "cache", "fastembed");
+	return process.env.MNEMOPI_EMBED_GGUF_DIR ?? MODEL_CACHE_DIR;
 }
-
-/** Default node-llama-cpp loader; tests swap this via `setGgmlModuleLoaderForTests`. */
-let moduleLoader: () => Promise<typeof import("node-llama-cpp")> = () => import("node-llama-cpp");
 
 /**
  * Lazily load node-llama-cpp (a heavy native addon) once. Uses `gpu: "auto"`
@@ -89,9 +127,37 @@ async function loadRuntime(modelPath: string): Promise<LlamaEmbeddingRuntime> {
 	const { getLlama } = await moduleLoader();
 	const llama = await getLlama({ gpu: "auto" });
 	const model = await llama.loadModel({ modelPath });
-	const context = await model.createEmbeddingContext({ contextSize: 512 });
+	const context = await model.createEmbeddingContext({ contextSize: CONTEXT_SIZE });
 	logger.debug("mnemopi: ggml embedding loaded", { gpu: llama.gpu, modelPath });
-	return { llama, context };
+	return { llama, context, truncate: buildTruncate(model) };
+}
+
+/** Build an input-truncation helper backed by the model tokenizer, with a char clip fallback. */
+function buildTruncate(model: LlamaCpp.LlamaModel): (input: string) => string {
+	const tokenize = model.tokenize as ((text: string) => number[]) | undefined;
+	const detokenize = model.detokenize as ((tokens: readonly number[]) => string) | undefined;
+	if (typeof tokenize !== "function" || typeof detokenize !== "function") {
+		return input => (input.length > CONTEXT_SIZE ? input.slice(0, CONTEXT_SIZE) : input);
+	}
+	return input => {
+		const tokens = tokenize(input);
+		if (tokens.length <= CONTEXT_SIZE) return input;
+		return detokenize(tokens.slice(0, CONTEXT_SIZE - TRUNCATE_MARGIN));
+	};
+}
+
+/** Dispose a loaded ggml runtime (context, then the llama loader). Best-effort. */
+async function disposeRuntime(runtime: LlamaEmbeddingRuntime): Promise<void> {
+	try {
+		await runtime.context.dispose();
+	} catch {
+		// A partially-initialized or already-disposed runtime must not block a switch.
+	}
+	try {
+		await runtime.llama.dispose();
+	} catch {
+		// Best-effort; the worker subprocess SIGKILL reaps any leak on shutdown.
+	}
 }
 
 /** Build a `LocalEmbeddingModel`-compatible instance backed by ggml. */
@@ -102,14 +168,14 @@ function makeEmbeddingModel(runtime: LlamaEmbeddingRuntime): LocalEmbeddingModel
 				const batch = texts.slice(i, i + batchSize);
 				const vectors: number[][] = [];
 				for (const text of batch) {
-					const { vector } = await runtime.context.getEmbeddingFor(text);
+					const { vector } = await runtime.context.getEmbeddingFor(runtime.truncate(text));
 					vectors.push(Array.from(vector));
 				}
 				yield vectors;
 			}
 		},
 		async queryEmbed(query: string): Promise<number[]> {
-			const { vector } = await runtime.context.getEmbeddingFor(query);
+			const { vector } = await runtime.context.getEmbeddingFor(runtime.truncate(query));
 			return Array.from(vector);
 		},
 	};
@@ -129,21 +195,40 @@ export const ggmlLocalModelInitializer: LocalModelInitializer = async (
 			`mnemopi: no GGUF model for ${options.model}; set MNEMOPI_EMBED_GGUF_PATH or place the .gguf in the cache`,
 		);
 	}
-	llamaPromise ??= loadRuntime(modelPath);
+	// A path switch (e.g. a different GGUF for the same model id) must NOT reuse
+	// the previous context: node-llama-cpp embeddings are only comparable within
+	// the exact same model file. Dispose the old context/model/runtime and load
+	// the new one, so the worker's `(model, cacheDir)` reload yields the right
+	// vectors rather than silently reusing the first path's context.
+	if (llamaCache !== null && llamaCache.modelPath !== modelPath) {
+		const previous = await llamaCache.promise.catch(() => null);
+		if (previous !== null) {
+			await disposeRuntime(previous);
+		}
+		llamaCache = null;
+	}
+	if (llamaCache === null) {
+		llamaCache = { modelPath, promise: loadRuntime(modelPath) };
+	}
+	const loading = llamaCache.promise;
 	try {
-		const runtime = await llamaPromise;
+		const runtime = await loading;
 		return makeEmbeddingModel(runtime);
 	} catch (error) {
-		llamaPromise = null;
+		if (llamaCache?.promise === loading) {
+			llamaCache = null;
+		}
 		throw error;
 	}
 };
 
+/** Restore the default loader and clear the cached runtime. Call from `afterEach`. */
 export function resetGgmlForTests(): void {
-	llamaPromise = null;
+	moduleLoader = DEFAULT_MODULE_LOADER;
+	llamaCache = null;
 }
 
-export function setGgmlModuleLoaderForTests(loader: () => Promise<typeof import("node-llama-cpp")>): void {
+export function setGgmlModuleLoaderForTests(loader: () => Promise<LlamaCppModule>): void {
 	moduleLoader = loader;
-	llamaPromise = null;
+	llamaCache = null;
 }

--- a/packages/mnemopi/src/core/ggml-embedding.ts
+++ b/packages/mnemopi/src/core/ggml-embedding.ts
@@ -1,0 +1,149 @@
+/**
+ * GGML (llama.cpp / node-llama-cpp) local-embeddings backend. An alternative
+ * to the fastembed/onnxruntime path for machines with a GPU: node-llama-cpp
+ * builds ggml against a GPU backend (Vulkan on Linux, Metal on macOS, CUDA on
+ * Windows/NVIDIA) and runs the SAME embedding models llama.cpp ships as GGUF.
+ *
+ * Why this exists: onnxruntime-node's default execution provider is CPU-only,
+ * and the GPU EP (onnxruntime-gpu) needs a version-matched CUDA+cuDNN stack
+ * that is not always installed. ggml's Vulkan backend needs only the Mesa/VK
+ * driver and is often 10-40x faster for a small embedding model (measured ~16ms
+ * / vector on a GTX 1650 Ti vs ~650ms / vector on the ONNX CPU path).
+ *
+ * Isolation contract (mirrors `fastembed-runtime.ts`): this module is imported
+ * ONLY inside the mnemopi embed worker subprocess, so llm's `node-llama-cpp`
+ * native addon + ggml runtime never load in the main agent address space. The
+ * parent SIGKILLs the worker on shutdown so any addon destructor cannot crash
+ * the host (the sibling guarantee to issue #3031 for onnxruntime-node).
+ *
+ * Model-compat note: the GGUF conversion of an embedding model preserves the
+ * model's *identity* (name) and vector dimension, so switching the backend from
+ * fastembed/ONNX to ggml for the same model id does NOT change the dimension
+ * and does not require re-embedding the memory corpus. Quantization (Q4_K_M)
+ * changes the embedding *values* slightly, so cross-backend vectors are not
+ * bit-identical, but they are dimension- and semantic-compatible.
+ */
+
+import { existsSync } from "node:fs";
+import * as nodePath from "node:path";
+import { logger } from "@oh-my-pi/pi-utils";
+import type { Llama } from "node-llama-cpp";
+import type { LocalEmbeddingModel, LocalModelInitializer, LocalModelInitOptions } from "./embeddings";
+
+/** Minimal loaded-llama embedding surface the initializer depends on. */
+interface LlamaEmbeddingRuntime {
+	llama: Llama;
+	context: {
+		getEmbeddingFor(input: string): Promise<{ vector: readonly number[] }>;
+		dispose(): Promise<void>;
+	};
+}
+
+let llamaPromise: Promise<LlamaEmbeddingRuntime> | null = null;
+
+/**
+ * Resolve the GGUF model path. Order:
+ *  1. `MNEMOPI_EMBED_GGUF_PATH` explicit path (full filename).
+ *  2. `<cacheDir>/<model>.gguf` where `cacheDir` is the fastembed cache root
+ *     (so a user can drop the GGUF beside the ONNX cache).
+ *  3. `<cacheDir>/../mnemopi/models/<model>.gguf`.
+ * Returns `null` when no candidate exists (caller should fall back).
+ */
+export function resolveGgufModelPath(model: string, cacheDir: string | undefined): string | null {
+	const explicit = process.env.MNEMOPI_EMBED_GGUF_PATH?.trim();
+	if (explicit) return explicit;
+	const root = cacheDir ?? defaultGgufCacheRoot();
+	const basename = ggufFilename(model);
+	if (!basename) return null;
+	for (const base of [root, nodePath.join(root, "..", "models")]) {
+		const candidate = nodePath.join(base, basename);
+		if (existsSync(candidate)) return candidate;
+	}
+	return null;
+}
+
+function ggufFilename(model: string): string | null {
+	// The worker passes fastembed ids (e.g. "fast-bge-base-en-v1.5"). Map them
+	// to a stable GGUF basename; fall back to a direct `<model>.gguf` for custom.
+	const known: Record<string, string> = {
+		"fast-bge-base-en-v1.5": "bge-base-en-v1.5-q4_k_m.gguf",
+		"fast-bge-small-en-v1.5": "bge-small-en-v1.5-q4_k_m.gguf",
+		"fast-bge-small-zh-v1.5": "bge-small-zh-v1.5-q4_k_m.gguf",
+	};
+	return known[model] ?? (model.endsWith(".gguf") ? model : null);
+}
+
+function defaultGgufCacheRoot(): string {
+	return process.env.MNEMOPI_EMBED_GGUF_DIR ?? nodePath.join(process.env.HOME ?? "", ".hermes", "cache", "fastembed");
+}
+
+/** Default node-llama-cpp loader; tests swap this via `setGgmlModuleLoaderForTests`. */
+let moduleLoader: () => Promise<typeof import("node-llama-cpp")> = () => import("node-llama-cpp");
+
+/**
+ * Lazily load node-llama-cpp (a heavy native addon) once. Uses `gpu: "auto"`
+ * which resolves the best available backend (Vulkan here). Kept behind an
+ * injected loader so tests can stub it without pulling the native addon.
+ */
+async function loadRuntime(modelPath: string): Promise<LlamaEmbeddingRuntime> {
+	const { getLlama } = await moduleLoader();
+	const llama = await getLlama({ gpu: "auto" });
+	const model = await llama.loadModel({ modelPath });
+	const context = await model.createEmbeddingContext({ contextSize: 512 });
+	logger.debug("mnemopi: ggml embedding loaded", { gpu: llama.gpu, modelPath });
+	return { llama, context };
+}
+
+/** Build a `LocalEmbeddingModel`-compatible instance backed by ggml. */
+function makeEmbeddingModel(runtime: LlamaEmbeddingRuntime): LocalEmbeddingModel {
+	return {
+		async *embed(texts: string[], batchSize = 64): AsyncIterable<number[][]> {
+			for (let i = 0; i < texts.length; i += batchSize) {
+				const batch = texts.slice(i, i + batchSize);
+				const vectors: number[][] = [];
+				for (const text of batch) {
+					const { vector } = await runtime.context.getEmbeddingFor(text);
+					vectors.push(Array.from(vector));
+				}
+				yield vectors;
+			}
+		},
+		async queryEmbed(query: string): Promise<number[]> {
+			const { vector } = await runtime.context.getEmbeddingFor(query);
+			return Array.from(vector);
+		},
+	};
+}
+
+/**
+ * Default ggml local-model initializer. Matches the
+ * `LocalModelInitializer` signature so callers can install it via
+ * `setLocalModelInitializer` (or default) with no protocol change.
+ */
+export const ggmlLocalModelInitializer: LocalModelInitializer = async (
+	options: LocalModelInitOptions,
+): Promise<LocalEmbeddingModel> => {
+	const modelPath = resolveGgufModelPath(options.model, options.cacheDir);
+	if (!modelPath) {
+		throw new Error(
+			`mnemopi: no GGUF model for ${options.model}; set MNEMOPI_EMBED_GGUF_PATH or place the .gguf in the cache`,
+		);
+	}
+	llamaPromise ??= loadRuntime(modelPath);
+	try {
+		const runtime = await llamaPromise;
+		return makeEmbeddingModel(runtime);
+	} catch (error) {
+		llamaPromise = null;
+		throw error;
+	}
+};
+
+export function resetGgmlForTests(): void {
+	llamaPromise = null;
+}
+
+export function setGgmlModuleLoaderForTests(loader: () => Promise<typeof import("node-llama-cpp")>): void {
+	moduleLoader = loader;
+	llamaPromise = null;
+}

--- a/packages/mnemopi/src/core/ggml-embedding.ts
+++ b/packages/mnemopi/src/core/ggml-embedding.ts
@@ -30,7 +30,7 @@ import { existsSync } from "node:fs";
 import * as nodePath from "node:path";
 import { logger } from "@oh-my-pi/pi-utils";
 import type * as LlamaCpp from "node-llama-cpp";
-import { MODEL_CACHE_DIR } from "../config";
+import { embeddingGpu, MODEL_CACHE_DIR } from "../config";
 import type { LocalEmbeddingModel, LocalModelInitializer, LocalModelInitOptions } from "./embeddings";
 
 /** Minimal loaded-llama embedding surface the initializer depends on. */
@@ -66,6 +66,13 @@ type LlamaCppModule = typeof LlamaCpp;
  * supports for an ESM-only async native-addon module. Kept behind an injected
  * loader so tests stub it and the native addon still never loads in the main
  * agent process.
+ *
+ * Compiled binaries bundle the package's JS: its per-platform prebuilt
+ * libraries stay on disk and are reached through the build-time stand-ins in
+ * `compile-binary.ts`, because a compiled binary cannot resolve the platform
+ * packages at runtime (oven-sh/bun#1763, and runtime plugins never fire for
+ * them). That also means the specifier cannot be a static import: the addon
+ * must load only inside the worker subprocess.
  */
 async function loadNodeLlamaCpp(): Promise<LlamaCppModule> {
 	return await import("node-llama-cpp");
@@ -120,15 +127,20 @@ function defaultGgufCacheRoot(): string {
 
 /**
  * Lazily load node-llama-cpp (a heavy native addon) once. Uses `gpu: "auto"`
- * which resolves the best available backend (Vulkan here). Kept behind an
- * injected loader so tests can stub it without pulling the native addon.
+ * which resolves the best available backend (Vulkan here) and `build: "never"`
+ * so a missing or mismatched prebuilt fails immediately instead of compiling
+ * llama.cpp from source inside an embedding worker. Kept behind an injected
+ * loader so tests can stub it without pulling the native addon.
  */
 async function loadRuntime(modelPath: string): Promise<LlamaEmbeddingRuntime> {
 	const { getLlama } = await moduleLoader();
-	const llama = await getLlama({ gpu: "auto" });
+	const requested = embeddingGpu();
+	// node-llama-cpp spells CPU-only as `false`; a "cpu" string is not a
+	// recognized GPU type and silently degrades to `"auto"`.
+	const llama = await getLlama({ gpu: requested === "cpu" ? false : requested, build: "never" });
 	const model = await llama.loadModel({ modelPath });
 	const context = await model.createEmbeddingContext({ contextSize: CONTEXT_SIZE });
-	logger.debug("mnemopi: ggml embedding loaded", { gpu: llama.gpu, modelPath });
+	logger.debug("mnemopi: ggml embedding loaded", { gpu: llama.gpu, requested, modelPath });
 	return { llama, context, truncate: buildTruncate(model) };
 }
 

--- a/packages/mnemopi/src/core/index.ts
+++ b/packages/mnemopi/src/core/index.ts
@@ -9,12 +9,7 @@ export {
 	type StandardEmbeddingModel,
 	setLocalModelInitializer,
 } from "./embeddings";
-export {
-	ggmlLocalModelInitializer,
-	resetGgmlForTests,
-	resolveGgufModelPath,
-	setGgmlModuleLoaderForTests,
-} from "./ggml-embedding";
+export * from "./ggml-embedding";
 export * from "./memory";
 export {
 	addMemory,

--- a/packages/mnemopi/src/core/index.ts
+++ b/packages/mnemopi/src/core/index.ts
@@ -1,4 +1,4 @@
-export { configureRecallFeatures, type RecallFeatureFlags } from "../config";
+export { configureRecallFeatures, type EmbeddingBackend, embeddingBackend, type RecallFeatureFlags } from "../config";
 export * from "./banks";
 export * from "./beam/index";
 export {
@@ -9,6 +9,12 @@ export {
 	type StandardEmbeddingModel,
 	setLocalModelInitializer,
 } from "./embeddings";
+export {
+	ggmlLocalModelInitializer,
+	resetGgmlForTests,
+	resolveGgufModelPath,
+	setGgmlModuleLoaderForTests,
+} from "./ggml-embedding";
 export * from "./memory";
 export {
 	addMemory,

--- a/packages/mnemopi/src/core/index.ts
+++ b/packages/mnemopi/src/core/index.ts
@@ -1,4 +1,11 @@
-export { configureRecallFeatures, type EmbeddingBackend, embeddingBackend, type RecallFeatureFlags } from "../config";
+export {
+	configureRecallFeatures,
+	type EmbeddingBackend,
+	type EmbeddingGpu,
+	embeddingBackend,
+	embeddingGpu,
+	type RecallFeatureFlags,
+} from "../config";
 export * from "./banks";
 export * from "./beam/index";
 export {

--- a/packages/mnemopi/test/embedding-model-reconcile.test.ts
+++ b/packages/mnemopi/test/embedding-model-reconcile.test.ts
@@ -7,13 +7,26 @@
  */
 
 import { Database } from "bun:sqlite";
-import { describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 
 import { initBeam } from "@oh-my-pi/pi-mnemopi/core/beam";
 import { Mnemopi } from "@oh-my-pi/pi-mnemopi/core/memory";
 
 const OLD_MODEL = "BAAI/bge-small-en-v1.5";
 const NEW_MODEL = "intfloat/multilingual-e5-large";
+// The reconcile contract is about MODEL changes, independent of the local
+// embedding backend. Force fastembed so `currentEmbeddingModelIdentity()`
+// equals the bare model name the seed rows are stamped with, regardless of any
+// ambient `MNEMOPI_EMBED_BACKEND` the feature environment sets.
+let prevBackend: string | undefined;
+beforeEach(() => {
+	prevBackend = process.env.MNEMOPI_EMBED_BACKEND;
+	delete process.env.MNEMOPI_EMBED_BACKEND;
+});
+afterEach(() => {
+	if (prevBackend !== undefined) process.env.MNEMOPI_EMBED_BACKEND = prevBackend;
+	else delete process.env.MNEMOPI_EMBED_BACKEND;
+});
 
 // Deterministic fastembed-shaped provider so the background rebuild actually
 // writes rows (and stamps them with the active model) under the test runtime.

--- a/packages/mnemopi/test/ggml-embedding.test.ts
+++ b/packages/mnemopi/test/ggml-embedding.test.ts
@@ -1,0 +1,165 @@
+// Contract: ggmlLocalModelInitializer builds a LocalEmbeddingModel from a
+// stubbed node-llama-cpp loader, yields batched vectors, and fails fast when no
+// GGUF model path resolves. The native addon is never pulled — a fake loader is
+// injected via setGgmlModuleLoaderForTests.
+import { describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+	ggmlLocalModelInitializer,
+	resetGgmlForTests,
+	resolveGgufModelPath,
+	setGgmlModuleLoaderForTests,
+} from "../src/core/ggml-embedding";
+
+function fakeLlamaLoader(vector: number[], gpu = "vulkan") {
+	return async () =>
+		({
+			getLlama: async () => ({
+				gpu,
+				dispose: async () => {},
+				loadModel: async () => ({
+					embeddingVectorSize: vector.length,
+					createEmbeddingContext: async () => ({
+						getEmbeddingFor: async (input: string) => ({
+							vector: vector.map((v, i) => (input ? v + i * 0.001 : v)),
+						}),
+						dispose: async () => {},
+					}),
+				}),
+			}),
+		}) as never;
+}
+
+/** Run a test body with a fake GGUF path set, restoring the prior env after. */
+async function withFakeGgufPath<T>(body: () => Promise<T>): Promise<T> {
+	const prev = process.env.MNEMOPI_EMBED_GGUF_PATH;
+	process.env.MNEMOPI_EMBED_GGUF_PATH = "/tmp/fake-model.gguf";
+	try {
+		return await body();
+	} finally {
+		if (prev !== undefined) process.env.MNEMOPI_EMBED_GGUF_PATH = prev;
+		else delete process.env.MNEMOPI_EMBED_GGUF_PATH;
+	}
+}
+
+describe("ggmlLocalModelInitializer", () => {
+	test("embeds a batch and collapses the async generator into one matrix", async () => {
+		resetGgmlForTests();
+		setGgmlModuleLoaderForTests(fakeLlamaLoader([1, 2, 3]) as never);
+		await withFakeGgufPath(async () => {
+			const model = await ggmlLocalModelInitializer({ model: "fast-bge-base-en-v1.5" as never });
+			const rows: number[][] = [];
+			for await (const batch of model.embed(["a", "b"])) {
+				expect(Array.isArray(batch)).toBe(true);
+				for (const row of batch) rows.push(row);
+			}
+			expect(rows).toHaveLength(2);
+			expect(rows[0]).toHaveLength(3);
+			expect(rows[0][0]).toBeCloseTo(1);
+		});
+	});
+
+	test("queryEmbed returns a single vector through the embedding context", async () => {
+		resetGgmlForTests();
+		setGgmlModuleLoaderForTests(fakeLlamaLoader([5, 6, 7]) as never);
+		await withFakeGgufPath(async () => {
+			const model = await ggmlLocalModelInitializer({ model: "fast-bge-base-en-v1.5" as never });
+			const vec = await model.queryEmbed?.("query text");
+			expect(vec).toHaveLength(3);
+			expect(vec?.[0]).toBeCloseTo(5);
+		});
+	});
+
+	test("rejects when no GGUF model path can be resolved", async () => {
+		resetGgmlForTests();
+		const before = process.env.MNEMOPI_EMBED_GGUF_PATH;
+		delete process.env.MNEMOPI_EMBED_GGUF_PATH;
+		try {
+			// Unknown model id → no GGUF basename → null path → throws.
+			await expect(
+				ggmlLocalModelInitializer({ model: "fast-all-MiniLM-L6-v2" as never, cacheDir: "/tmp/definitely-empty" }),
+			).rejects.toThrow(/no GGUF model for/);
+		} finally {
+			if (before !== undefined) process.env.MNEMOPI_EMBED_GGUF_PATH = before;
+		}
+	});
+
+	test("uses gpu from the loader without requiring an explicit gpu option", async () => {
+		resetGgmlForTests();
+		setGgmlModuleLoaderForTests(fakeLlamaLoader([1], "metal") as never);
+		await withFakeGgufPath(async () => {
+			const model = await ggmlLocalModelInitializer({ model: "fast-bge-small-en-v1.5" as never });
+			const vec = await model.queryEmbed?.("x");
+			expect(vec).toHaveLength(1);
+		});
+	});
+});
+
+describe("resolveGgufModelPath", () => {
+	test("prefers the explicit MNEMOPI_EMBED_GGUF_PATH over cache lookup", async () => {
+		const dir = await fs.mkdtemp(path.join(os.tmpdir(), "mnemopi-gguf-"));
+		const modelFile = path.join(dir, "bge-base-en-v1.5-q4_k_m.gguf");
+		try {
+			await fs.writeFile(modelFile, "x");
+			const before = process.env.MNEMOPI_EMBED_GGUF_PATH;
+			process.env.MNEMOPI_EMBED_GGUF_PATH = modelFile;
+			try {
+				expect(resolveGgufModelPath("fast-bge-base-en-v1.5", dir)).toBe(modelFile);
+			} finally {
+				if (before !== undefined) process.env.MNEMOPI_EMBED_GGUF_PATH = before;
+				else delete process.env.MNEMOPI_EMBED_GGUF_PATH;
+			}
+		} finally {
+			await fs.rm(dir, { recursive: true, force: true });
+		}
+	});
+
+	test("maps a fastembed id to its GGUF basename and finds it in the cache dir", async () => {
+		const dir = await fs.mkdtemp(path.join(os.tmpdir(), "mnemopi-gguf-cache-"));
+		const modelFile = path.join(dir, "bge-base-en-v1.5-q4_k_m.gguf");
+		await fs.writeFile(modelFile, "x");
+		try {
+			const before = process.env.MNEMOPI_EMBED_GGUF_PATH;
+			delete process.env.MNEMOPI_EMBED_GGUF_PATH;
+			try {
+				expect(resolveGgufModelPath("fast-bge-base-en-v1.5", dir)).toBe(modelFile);
+			} finally {
+				if (before !== undefined) process.env.MNEMOPI_EMBED_GGUF_PATH = before;
+			}
+		} finally {
+			await fs.rm(dir, { recursive: true, force: true });
+		}
+	});
+
+	test("falls back to the sibling mnemopi/models directory", async () => {
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "mnemopi-gguf-root-"));
+		const modelsDir = path.join(root, "..", "models");
+		await fs.mkdir(modelsDir, { recursive: true });
+		const modelFile = path.join(modelsDir, "bge-base-en-v1.5-q4_k_m.gguf");
+		await fs.writeFile(modelFile, "x");
+		try {
+			const before = process.env.MNEMOPI_EMBED_GGUF_PATH;
+			delete process.env.MNEMOPI_EMBED_GGUF_PATH;
+			try {
+				// candidates are root and root/../models.
+				expect(resolveGgufModelPath("fast-bge-base-en-v1.5", root)).toBe(modelFile);
+			} finally {
+				if (before !== undefined) process.env.MNEMOPI_EMBED_GGUF_PATH = before;
+			}
+		} finally {
+			await fs.rm(root, { recursive: true, force: true });
+		}
+	});
+
+	test("returns null for an unknown model id with no explicit path", async () => {
+		const before = process.env.MNEMOPI_EMBED_GGUF_PATH;
+		delete process.env.MNEMOPI_EMBED_GGUF_PATH;
+		try {
+			expect(resolveGgufModelPath("fast-all-MiniLM-L6-v2", "/tmp/definitely-empty")).toBeNull();
+		} finally {
+			if (before !== undefined) process.env.MNEMOPI_EMBED_GGUF_PATH = before;
+		}
+	});
+});

--- a/packages/mnemopi/test/ggml-embedding.test.ts
+++ b/packages/mnemopi/test/ggml-embedding.test.ts
@@ -1,8 +1,11 @@
 // Contract: ggmlLocalModelInitializer builds a LocalEmbeddingModel from a
-// stubbed node-llama-cpp loader, yields batched vectors, and fails fast when no
-// GGUF model path resolves. The native addon is never pulled — a fake loader is
-// injected via setGgmlModuleLoaderForTests.
-import { describe, expect, test } from "bun:test";
+// stubbed node-llama-cpp loader, yields batched vectors, truncates inputs that
+// exceed the context budget, reloads when the resolved GGUF path changes (and
+// disposes the previous runtime), and fails fast when no GGUF model path
+// resolves. The native addon is never pulled — a fake loader is injected via
+// setGgmlModuleLoaderForTests, and afterEach restores the default loader so a
+// later file never inherits a stale fake.
+import { afterEach, describe, expect, test } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -12,6 +15,10 @@ import {
 	resolveGgufModelPath,
 	setGgmlModuleLoaderForTests,
 } from "../src/core/ggml-embedding";
+
+afterEach(() => {
+	resetGgmlForTests();
+});
 
 function fakeLlamaLoader(vector: number[], gpu = "vulkan") {
 	return async () =>
@@ -95,6 +102,92 @@ describe("ggmlLocalModelInitializer", () => {
 			expect(vec).toHaveLength(1);
 		});
 	});
+
+	test("truncates an input that exceeds the token budget before evaluation", async () => {
+		resetGgmlForTests();
+		let seen = "";
+		setGgmlModuleLoaderForTests(
+			(async () => ({
+				getLlama: async () => ({
+					gpu: "vulkan",
+					dispose: async () => {},
+					loadModel: async () => ({
+						embeddingVectorSize: 3,
+						createEmbeddingContext: async () => ({
+							getEmbeddingFor: async (input: string) => {
+								seen = input;
+								return { vector: [1, 2, 3] };
+							},
+							dispose: async () => {},
+						}),
+					}),
+				}),
+			})) as never,
+		);
+		await withFakeGgufPath(async () => {
+			const model = await ggmlLocalModelInitializer({ model: "fast-bge-base-en-v1.5" as never });
+			for await (const _batch of model.embed(["x".repeat(4000)])) {
+				// consume
+			}
+			// The tokenizer-less fake falls back to a character clip so the
+			// context is never asked to evaluate more than its token budget.
+			expect(seen.length).toBeGreaterThan(0);
+			expect(seen.length).toBeLessThanOrEqual(512);
+		});
+	});
+
+	test("reloads for a different GGUF path and disposes the previous runtime", async () => {
+		resetGgmlForTests();
+		let created = 0;
+		let disposedContexts = 0;
+		let disposedLlama = 0;
+		setGgmlModuleLoaderForTests(
+			(async () => ({
+				getLlama: async () => {
+					created += 1;
+					return {
+						gpu: "vulkan",
+						dispose: async () => {
+							disposedLlama += 1;
+						},
+						loadModel: async () => ({
+							embeddingVectorSize: 3,
+							createEmbeddingContext: async () => ({
+								getEmbeddingFor: async () => ({ vector: [created, 0, 0] }),
+								dispose: async () => {
+									disposedContexts += 1;
+								},
+							}),
+						}),
+					};
+				},
+			})) as never,
+		);
+		const setPath = async (value: string, body: () => Promise<void>) => {
+			const before = process.env.MNEMOPI_EMBED_GGUF_PATH;
+			process.env.MNEMOPI_EMBED_GGUF_PATH = value;
+			try {
+				await body();
+			} finally {
+				if (before !== undefined) process.env.MNEMOPI_EMBED_GGUF_PATH = before;
+				else delete process.env.MNEMOPI_EMBED_GGUF_PATH;
+			}
+		};
+		await setPath("/tmp/gguf-a.gguf", async () => {
+			const first = await ggmlLocalModelInitializer({ model: "fast-bge-base-en-v1.5" as never });
+			await first.queryEmbed?.("a");
+		});
+		await setPath("/tmp/gguf-b.gguf", async () => {
+			const second = await ggmlLocalModelInitializer({ model: "fast-bge-base-en-v1.5" as never });
+			const vec = await second.queryEmbed?.("b");
+			// The second load must emit vectors from its OWN context, not the
+			// first path's cached runtime.
+			expect(vec?.[0]).toBeCloseTo(2);
+		});
+		expect(created).toBe(2);
+		expect(disposedContexts).toBe(1);
+		expect(disposedLlama).toBe(1);
+	});
 });
 
 describe("resolveGgufModelPath", () => {
@@ -133,20 +226,29 @@ describe("resolveGgufModelPath", () => {
 		}
 	});
 
-	test("falls back to the sibling mnemopi/models directory", async () => {
+	test("finds the GGUF in the canonical mnemopi/models cache root", async () => {
 		const root = await fs.mkdtemp(path.join(os.tmpdir(), "mnemopi-gguf-root-"));
-		const modelsDir = path.join(root, "..", "models");
+		const modelsDir = path.join(root, "mnemopi", "models");
 		await fs.mkdir(modelsDir, { recursive: true });
 		const modelFile = path.join(modelsDir, "bge-base-en-v1.5-q4_k_m.gguf");
 		await fs.writeFile(modelFile, "x");
 		try {
-			const before = process.env.MNEMOPI_EMBED_GGUF_PATH;
+			const prevDir = process.env.MNEMOPI_EMBED_GGUF_DIR;
+			const prevPath = process.env.MNEMOPI_EMBED_GGUF_PATH;
+			// Point the gguf cache root at the production layout (~/.hermes/mnemopi/models)
+			// so the default root lands in the canonical model directory.
+			process.env.MNEMOPI_EMBED_GGUF_DIR = modelsDir;
 			delete process.env.MNEMOPI_EMBED_GGUF_PATH;
 			try {
-				// candidates are root and root/../models.
-				expect(resolveGgufModelPath("fast-bge-base-en-v1.5", root)).toBe(modelFile);
+				// cacheDir is the fastembed cache root; the canonical model dir wins.
+				expect(
+					resolveGgufModelPath("fast-bge-base-en-v1.5", path.join(root, "cache", "fastembed")),
+				).toBe(modelFile);
 			} finally {
-				if (before !== undefined) process.env.MNEMOPI_EMBED_GGUF_PATH = before;
+				if (prevDir !== undefined) process.env.MNEMOPI_EMBED_GGUF_DIR = prevDir;
+				else delete process.env.MNEMOPI_EMBED_GGUF_DIR;
+				if (prevPath !== undefined) process.env.MNEMOPI_EMBED_GGUF_PATH = prevPath;
+				else delete process.env.MNEMOPI_EMBED_GGUF_PATH;
 			}
 		} finally {
 			await fs.rm(root, { recursive: true, force: true });

--- a/packages/mnemopi/test/ggml-embedding.test.ts
+++ b/packages/mnemopi/test/ggml-embedding.test.ts
@@ -79,6 +79,44 @@ describe("ggmlLocalModelInitializer", () => {
 		});
 	});
 
+	test("maps MNEMOPI_EMBED_GPU onto getLlama's gpu option", async () => {
+		const requested: unknown[] = [];
+		const recordingLoader = (async () => ({
+			getLlama: async (options: { gpu?: unknown }) => {
+				requested.push(options.gpu);
+				return {
+					gpu: "vulkan",
+					dispose: async () => {},
+					loadModel: async () => ({
+						embeddingVectorSize: 3,
+						createEmbeddingContext: async () => ({
+							getEmbeddingFor: async () => ({ vector: [1, 2, 3] }),
+							dispose: async () => {},
+						}),
+					}),
+				};
+			},
+		})) as never;
+		const before = process.env.MNEMOPI_EMBED_GPU;
+		try {
+			await withFakeGgufPath(async () => {
+				for (const value of ["vulkan", "cpu", undefined] as const) {
+					resetGgmlForTests();
+					setGgmlModuleLoaderForTests(recordingLoader);
+					if (value === undefined) delete process.env.MNEMOPI_EMBED_GPU;
+					else process.env.MNEMOPI_EMBED_GPU = value;
+					await ggmlLocalModelInitializer({ model: "fast-bge-base-en-v1.5" as never });
+				}
+			});
+		} finally {
+			resetGgmlForTests();
+			if (before !== undefined) process.env.MNEMOPI_EMBED_GPU = before;
+			else delete process.env.MNEMOPI_EMBED_GPU;
+		}
+		// "cpu" is node-llama-cpp's `false`; the default stays "auto".
+		expect(requested).toEqual(["vulkan", false, "auto"]);
+	});
+
 	test("rejects when no GGUF model path can be resolved", async () => {
 		resetGgmlForTests();
 		const before = process.env.MNEMOPI_EMBED_GGUF_PATH;

--- a/packages/utils/src/runtime-install.ts
+++ b/packages/utils/src/runtime-install.ts
@@ -140,6 +140,29 @@ export function resolveRuntimeModule(runtimeNodeModules: string, specifier: stri
 	return resolveFileTarget(pkgDir, "index.js");
 }
 
+/**
+ * Locate an installed package's real directory by walking `node_modules` up
+ * from the running executable. A compiled binary resolves bare specifiers
+ * against its embedded module graph (oven-sh/bun#1763), so native packages
+ * deliberately kept outside the bundle must be found on disk this way.
+ */
+export function resolvePackageDirFromExecutable(packageName: string): string | null {
+	let dir = path.dirname(process.execPath);
+	for (;;) {
+		const candidate = path.join(dir, "node_modules", ...packageName.split("/"));
+		if (fs.existsSync(path.join(candidate, "package.json"))) return candidate;
+		const parent = path.dirname(dir);
+		if (parent === dir) return null;
+		dir = parent;
+	}
+}
+
+/** Read a package's `version` field; `null` when the manifest is missing or odd. */
+export function readPackageVersion(packageDir: string): string | null {
+	const manifest = readManifest(packageDir);
+	return manifest !== null && typeof manifest.version === "string" ? manifest.version : null;
+}
+
 function readManifest(pkgDir: string): Record<string, unknown> | null {
 	try {
 		const parsed: unknown = JSON.parse(fs.readFileSync(path.join(pkgDir, "package.json"), "utf8"));


### PR DESCRIPTION
## Problem

The local embedding backend uses `onnxruntime-node` (CPU only). Measured on a GTX 1650 Ti with bge-base:

- **650 ms / vector** (64 texts = 41.7s) — slow
- **RSS balloons to ~3 GB** because ORT's per-session arena never returns freed batch workspace to the OS

The GPU EP (`onnxruntime-gpu`) needs a version-matched CUDA+cuDNN stack that is not always installed, so there was no supported way to accelerate local embeddings on machines with a GPU but no CUDA/cuDNN.

## Change

Add a **ggml (llama.cpp)** local-embedding backend that loads a GGUF embedding model via `node-llama-cpp` on the best available GPU backend (Vulkan on Linux, Metal on macOS, CUDA on Windows/NVIDIA).

- New `ggmlLocalModelInitializer` (`packages/mnemopi/src/core/ggml-embedding.ts`) implementing the existing `LocalEmbeddingModel` interface.
- Config seam: `MNEMOPI_EMBED_BACKEND=ggml` (default `fastembed`) + `MNEMOPI_EMBED_GGUF_PATH` (or cache lookup).
- The embed worker routes to the ggml initializer when selected; the native addon stays isolated in the worker subprocess (same contract as the fastembed/onnxruntime split).
- `node-llama-cpp` added as an optional peer dep.

## Measured result (same GPU, same model id)

| Metric | ONNX CPU (before) | ggml Vulkan (after) |
|---|---|---|
| GPU backend | none | **vulkan** |
| 64 embeds | 41.7s | **1.03s** (~40x) |
| per vector | 650ms | **16ms** |
| RSS | 3.1 GB | **~330 MB** (9x less) |
| dimension | 768 | 768 |

The bge-base GGUF keeps the **same model id** as the ONNX bge-base, so `reconcileEmbeddingModel` sees no model-id change and existing memory vectors are left intact (no re-embed).

## Test

`bun test packages/mnemopi/test/ggml-embedding.test.ts` — 8 tests. Full mnemopi suite: 470 pass. Worker contract tests (issue-3031 / issue-7352): 7 pass. Both `check:types` clean.