### PR TITLE
feat(coding-agent): add OMP_EDITOR/PI_EDITOR external editor override

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -525,6 +525,8 @@ These affect where coding-agent stores data and which process-local settings ove
 | `CLAUDE_BASH_NO_LOGIN`     | Legacy alias fallback for `PI_BASH_NO_LOGIN`                                   |
 | `PI_SHELL_PREFIX`          | Optional command prefix wrapper                                                |
 | `CLAUDE_CODE_SHELL_PREFIX` | Legacy alias fallback for `PI_SHELL_PREFIX`                                    |
+| `OMP_EDITOR`               | omp-specific external editor override; wins over `PI_EDITOR`/`VISUAL`/`EDITOR` |
+| `PI_EDITOR`                | omp-specific external editor override; wins over `VISUAL`/`EDITOR`             |
 | `VISUAL`                   | Preferred external editor command                                              |
 | `EDITOR`                   | Fallback external editor command                                               |
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `OMP_EDITOR`/`PI_EDITOR` environment variables to override the external editor, taking precedence over `VISUAL`/`EDITOR` ([#9996](https://github.com/can1357/oh-my-pi/issues/9996)).
+
 ## [18.0.9] - 2026-08-28
 
 ### Breaking Changes

--- a/packages/coding-agent/src/utils/external-editor.ts
+++ b/packages/coding-agent/src/utils/external-editor.ts
@@ -4,21 +4,25 @@
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import { $env, $which, Snowflake } from "@oh-my-pi/pi-utils";
+import { $pickenv, $which, Snowflake } from "@oh-my-pi/pi-utils";
 
 /**
  * Returns the user's preferred editor command, or a platform default.
  *
  * Resolution order:
- *   1. `$VISUAL`
- *   2. `$EDITOR`
- *   3. `notepad` on Windows (always present in `%SystemRoot%\System32`)
+ *   1. `$OMP_EDITOR`
+ *   2. `$PI_EDITOR`
+ *   3. `$VISUAL`
+ *   4. `$EDITOR`
+ *   5. `notepad` on Windows (always present in `%SystemRoot%\System32`)
  *
- * POSIX returns `undefined` when neither variable is set so the caller can
- * surface a warning that nudges the user to configure one.
+ * `OMP_EDITOR`/`PI_EDITOR` are omp-specific overrides that win over the generic
+ * `VISUAL`/`EDITOR`, so they can be set in an omp `.env` file even when the
+ * shell already exports an editor. POSIX returns `undefined` when no variable is
+ * set so the caller can surface a warning that nudges the user to configure one.
  */
 export function getEditorCommand(): string | undefined {
-	const configured = $env.VISUAL?.trim() || $env.EDITOR?.trim();
+	const configured = $pickenv("OMP_EDITOR", "PI_EDITOR", "VISUAL", "EDITOR");
 	if (configured) return configured;
 	if (process.platform === "win32") return "notepad";
 	return undefined;

--- a/packages/coding-agent/test/external-editor.test.ts
+++ b/packages/coding-agent/test/external-editor.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, spyOn } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { TempDir } from "@oh-my-pi/pi-utils";
@@ -16,13 +16,23 @@ describe("getEditorCommand", () => {
 	const originalPlatform = process.platform;
 	const originalVisual = Bun.env.VISUAL;
 	const originalEditor = Bun.env.EDITOR;
+	const originalOmpEditor = Bun.env.OMP_EDITOR;
+	const originalPiEditor = Bun.env.PI_EDITOR;
 
+	beforeEach(() => {
+		delete Bun.env.OMP_EDITOR;
+		delete Bun.env.PI_EDITOR;
+	});
 	afterEach(() => {
 		setPlatform(originalPlatform);
 		if (originalVisual === undefined) delete Bun.env.VISUAL;
 		else Bun.env.VISUAL = originalVisual;
 		if (originalEditor === undefined) delete Bun.env.EDITOR;
 		else Bun.env.EDITOR = originalEditor;
+		if (originalOmpEditor === undefined) delete Bun.env.OMP_EDITOR;
+		else Bun.env.OMP_EDITOR = originalOmpEditor;
+		if (originalPiEditor === undefined) delete Bun.env.PI_EDITOR;
+		else Bun.env.PI_EDITOR = originalPiEditor;
 	});
 
 	it("prefers $VISUAL over $EDITOR and the platform default", () => {
@@ -36,6 +46,33 @@ describe("getEditorCommand", () => {
 		delete Bun.env.VISUAL;
 		Bun.env.EDITOR = "nano";
 		expect(getEditorCommand()).toBe("nano");
+	});
+
+	it("prefers $OMP_EDITOR over $VISUAL and $EDITOR", () => {
+		Bun.env.OMP_EDITOR = "hx";
+		Bun.env.VISUAL = "nvim";
+		Bun.env.EDITOR = "nano";
+		expect(getEditorCommand()).toBe("hx");
+	});
+
+	it("prefers $PI_EDITOR over $VISUAL and $EDITOR", () => {
+		Bun.env.PI_EDITOR = "micro";
+		Bun.env.VISUAL = "nvim";
+		Bun.env.EDITOR = "nano";
+		expect(getEditorCommand()).toBe("micro");
+	});
+
+	it("prefers $OMP_EDITOR over $PI_EDITOR", () => {
+		Bun.env.OMP_EDITOR = "code --wait";
+		Bun.env.PI_EDITOR = "micro";
+		expect(getEditorCommand()).toBe("code --wait");
+	});
+
+	it("falls back from a whitespace-only $OMP_EDITOR to $VISUAL", () => {
+		Bun.env.OMP_EDITOR = "   ";
+		Bun.env.VISUAL = "nvim";
+		Bun.env.EDITOR = "nano";
+		expect(getEditorCommand()).toBe("nvim");
 	});
 
 	it("trims whitespace so an accidentally padded value still works", () => {


### PR DESCRIPTION
## What
Adds two omp-specific environment variables, OMP_EDITOR and PI_EDITOR, that
override the external editor selection ahead of the generic VISUAL/EDITOR.
Resolution order becomes OMP_EDITOR → PI_EDITOR → VISUAL → EDITOR → notepad.
Implementation reuses the existing $pickenv helper and updates docs + CHANGELOG.

## Why
Right now there's no way to set an omp-only editor from `.env` — the shell's
`VISUAL`/`EDITOR` always win, so if you want omp to open a different editor than
your shell does, you're stuck. This adds `OMP_EDITOR` (plus `PI_EDITOR` as a
legacy alias) that omp checks before the generic ones, so `~/.omp/.env` can
configure it.

## Testing
- Added 4 unit tests: OMP over VISUAL/EDITOR, PI over VISUAL/EDITOR, OMP over PI, whitespace-only fallback
- bun run check:types passes

Fixes #9996