### PR TITLE
fix(mcp): support sub-path OAuth issuer discovery

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed MCP OAuth discovery for authorization-server issuer URLs with nested paths, including Keycloak realms ([#10042](https://github.com/can1357/oh-my-pi/issues/10042)).
+
 ## [18.0.9] - 2026-08-28
 
 ### Breaking Changes

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed MCP OAuth discovery for authorization-server issuer URLs with nested paths, including Keycloak realms ([#10042](https://github.com/can1357/oh-my-pi/issues/10042)).
+- Fixed MCP OAuth endpoint and dynamic client registration discovery for authorization-server URLs with nested paths, including Keycloak realms ([#10042](https://github.com/can1357/oh-my-pi/issues/10042)).
 
 ## [18.0.9] - 2026-08-28
 

--- a/packages/coding-agent/src/mcp/oauth-discovery.ts
+++ b/packages/coding-agent/src/mcp/oauth-discovery.ts
@@ -576,6 +576,13 @@ function buildWellKnownUrls(wellKnownPath: string, baseUrl: string): URL[] {
 	};
 	push(relUrl);
 
+	// OIDC Discovery §4 issuer-path form: <issuer>/.well-known/openid-configuration.
+	// Some path-routed OAuth servers expose their other metadata the same way.
+	if (wellKnownPath.startsWith("/.well-known/")) {
+		const pathAppendedUrl = new URL(`${normalizedPath}${wellKnownPath}`, parsed.origin);
+		push(pathAppendedUrl);
+	}
+
 	// RFC 8414 §3.1 path-ful issuer form: /.well-known/<suffix>/<issuer-path>.
 	// Only meaningful for well-known metadata documents.
 	if (wellKnownPath.startsWith("/.well-known/")) {

--- a/packages/coding-agent/src/mcp/oauth-discovery.ts
+++ b/packages/coding-agent/src/mcp/oauth-discovery.ts
@@ -577,18 +577,19 @@ export function buildWellKnownUrls(wellKnownPath: string, baseUrl: string): URL[
 	};
 	push(relUrl);
 
-	// OIDC Discovery §4 issuer-path form: <issuer>/.well-known/openid-configuration.
-	// Some path-routed OAuth servers expose their other metadata the same way.
 	if (wellKnownPath.startsWith("/.well-known/")) {
 		const pathAppendedUrl = new URL(`${normalizedPath}${wellKnownPath}`, parsed.origin);
-		push(pathAppendedUrl);
-	}
-
-	// RFC 8414 §3.1 path-ful issuer form: /.well-known/<suffix>/<issuer-path>.
-	// Only meaningful for well-known metadata documents.
-	if (wellKnownPath.startsWith("/.well-known/")) {
 		const pathfulUrl = new URL(`${wellKnownPath}${normalizedPath}`, parsed.origin);
-		push(pathfulUrl);
+
+		if (wellKnownPath === "/.well-known/openid-configuration") {
+			// OIDC Discovery §4 uses <issuer>/.well-known/openid-configuration.
+			push(pathAppendedUrl);
+			push(pathfulUrl);
+		} else {
+			// RFC 8414 §3.1 uses /.well-known/<suffix>/<issuer-path>.
+			push(pathfulUrl);
+			push(pathAppendedUrl);
+		}
 	}
 
 	return candidates;

--- a/packages/coding-agent/src/mcp/oauth-discovery.ts
+++ b/packages/coding-agent/src/mcp/oauth-discovery.ts
@@ -575,21 +575,22 @@ export function buildWellKnownUrls(wellKnownPath: string, baseUrl: string): URL[
 			seen.add(u.href);
 		}
 	};
-	push(relUrl);
 
-	if (wellKnownPath.startsWith("/.well-known/")) {
-		const pathAppendedUrl = new URL(`${normalizedPath}${wellKnownPath}`, parsed.origin);
-		const pathfulUrl = new URL(`${wellKnownPath}${normalizedPath}`, parsed.origin);
-
-		if (wellKnownPath === "/.well-known/openid-configuration") {
-			// OIDC Discovery §4 uses <issuer>/.well-known/openid-configuration.
-			push(pathAppendedUrl);
-			push(pathfulUrl);
-		} else {
-			// RFC 8414 §3.1 uses /.well-known/<suffix>/<issuer-path>.
-			push(pathfulUrl);
-			push(pathAppendedUrl);
-		}
+	if (wellKnownPath === "/.well-known/openid-configuration") {
+		// OIDC Discovery §4 standard form is <issuer>/.well-known/openid-configuration;
+		// try it before the parent-relative and RFC 8414 compatibility fallbacks.
+		push(new URL(`${normalizedPath}${wellKnownPath}`, parsed.origin));
+		push(relUrl);
+		push(new URL(`${wellKnownPath}${normalizedPath}`, parsed.origin));
+	} else if (wellKnownPath.startsWith("/.well-known/")) {
+		// RFC 8414 §3.1 standard form is /.well-known/<suffix>/<issuer-path>;
+		// try it before the parent-relative and path-appended compatibility fallbacks.
+		push(new URL(`${wellKnownPath}${normalizedPath}`, parsed.origin));
+		push(relUrl);
+		push(new URL(`${normalizedPath}${wellKnownPath}`, parsed.origin));
+	} else {
+		// Non-metadata paths only have the parent-relative gateway fallback.
+		push(relUrl);
 	}
 
 	return candidates;

--- a/packages/coding-agent/src/mcp/oauth-discovery.ts
+++ b/packages/coding-agent/src/mcp/oauth-discovery.ts
@@ -544,7 +544,8 @@ export async function discoverOAuthEndpoints(
 	return null;
 }
 
-function buildWellKnownUrls(wellKnownPath: string, baseUrl: string): URL[] {
+/** Build ordered metadata URL candidates for OAuth and OIDC discovery. */
+export function buildWellKnownUrls(wellKnownPath: string, baseUrl: string): URL[] {
 	let parsed: URL;
 	try {
 		parsed = new URL(baseUrl);

--- a/packages/coding-agent/src/mcp/oauth-discovery.ts
+++ b/packages/coding-agent/src/mcp/oauth-discovery.ts
@@ -14,6 +14,8 @@ const DISCOVERY_FETCH_TIMEOUT_MS = 10_000;
 export interface OAuthEndpoints {
 	authorizationUrl: string;
 	tokenUrl: string;
+	/** Authorization-server issuer URL used for metadata discovery. */
+	issuerUrl?: string;
 	clientId?: string;
 	/** Dynamic client registration endpoint advertised by the authorization server. */
 	registrationUrl?: string;
@@ -29,6 +31,11 @@ function readRegistrationUrl(metadata: Record<string, unknown>): string | undefi
 		metadata.registrationUrl ??
 		metadata.registration_uri ??
 		metadata.registrationUri;
+	return typeof value === "string" && value.trim() !== "" ? value : undefined;
+}
+
+function readIssuerUrl(metadata: Record<string, unknown>): string | undefined {
+	const value = metadata.issuer ?? metadata.issuer_url ?? metadata.issuerUrl;
 	return typeof value === "string" && value.trim() !== "" ? value : undefined;
 }
 
@@ -119,7 +126,15 @@ export function extractOAuthEndpoints(error: Error): OAuthEndpoints | null {
 			(obj.resource_uri as string | undefined) ||
 			(obj.resourceUri as string | undefined);
 
-		return { authorizationUrl, tokenUrl, registrationUrl: readRegistrationUrl(obj), clientId, scopes, resource };
+		return {
+			authorizationUrl,
+			tokenUrl,
+			issuerUrl: readIssuerUrl(obj),
+			registrationUrl: readRegistrationUrl(obj),
+			clientId,
+			scopes,
+			resource,
+		};
 	};
 
 	const clientIdFromAuthUrl = (authorizationUrl: string): string | undefined => {
@@ -192,6 +207,7 @@ export function extractOAuthEndpoints(error: Error): OAuthEndpoints | null {
 			return {
 				authorizationUrl,
 				tokenUrl,
+				issuerUrl: challengeValues.get("issuer") || challengeValues.get("issuer_url"),
 				registrationUrl:
 					challengeValues.get("registration_endpoint") ||
 					challengeValues.get("registration_url") ||
@@ -438,6 +454,7 @@ export async function discoverOAuthEndpoints(
 			return {
 				authorizationUrl: String(metadata.authorization_endpoint),
 				tokenUrl: String(metadata.token_endpoint),
+				issuerUrl: readIssuerUrl(metadata),
 				registrationUrl: readRegistrationUrl(metadata),
 				clientId:
 					typeof metadata.client_id === "string"
@@ -462,6 +479,7 @@ export async function discoverOAuthEndpoints(
 				return {
 					authorizationUrl: oauthData.authorization_url || String(oauthData.authorizationUrl),
 					tokenUrl: oauthData.token_url || String(oauthData.tokenUrl),
+					issuerUrl: readIssuerUrl(oauthData) ?? readIssuerUrl(metadata),
 					registrationUrl: readRegistrationUrl(oauthData),
 					clientId:
 						typeof oauthData.client_id === "string"

--- a/packages/coding-agent/src/mcp/oauth-flow.ts
+++ b/packages/coding-agent/src/mcp/oauth-flow.ts
@@ -11,6 +11,7 @@ import type { OAuthController, OAuthCredentials } from "@oh-my-pi/pi-ai/oauth/ty
 import type { FetchImpl } from "@oh-my-pi/pi-ai/types";
 import { getActiveProfile } from "@oh-my-pi/pi-utils/dirs";
 import type { OAuthCredential } from "../session/auth-storage";
+import { buildWellKnownUrls } from "./oauth-discovery";
 
 /** Credential-id prefix for OMP-managed MCP OAuth credentials keyed by profile and server URL. */
 const MCP_OAUTH_URL_CREDENTIAL_PREFIX = "mcp_oauth:";
@@ -664,35 +665,12 @@ export class MCPOAuthFlow extends OAuthCallbackFlow {
 	}
 
 	async #resolveRegistrationEndpoint(): Promise<string | null> {
-		const authorizationUrl = new URL(this.config.authorizationUrl);
-
-		// origin-root well-known; most servers serve metadata here.
-		const rootUrl = new URL("/.well-known/oauth-authorization-server", authorizationUrl.origin).toString();
-		const endpoint = await this.#tryWellKnownForRegistration(rootUrl);
-		if (endpoint) return endpoint;
-
-		// path-prefixed well-known for gateways (e.g. https://gateway.example.com/my-service/).
-		const normalizedPath = authorizationUrl.pathname.replace(/\/$/, "");
-		const lastSlash = normalizedPath.lastIndexOf("/");
-		// Bare-origin authorization URL — nothing further to try.
-		if (lastSlash < 0) return null;
-
-		// Single-segment paths are the gateway prefix itself; multi-segment paths
-		// drop the trailing segment (typically a service endpoint).
-		const prefixPath = lastSlash === 0 ? normalizedPath : normalizedPath.slice(0, lastSlash);
-		const prefixedUrl = new URL(
-			".well-known/oauth-authorization-server",
-			`${authorizationUrl.origin}${prefixPath}/`,
-		).toString();
-		const prefixedEndpoint = await this.#tryWellKnownForRegistration(prefixedUrl);
-		if (prefixedEndpoint) return prefixedEndpoint;
-
-		// RFC 8414 §3.1 path-ful issuer form: /.well-known/oauth-authorization-server/<path>.
-		const pathfulUrl = new URL(
-			`/.well-known/oauth-authorization-server${normalizedPath}`,
-			authorizationUrl.origin,
-		).toString();
-		return await this.#tryWellKnownForRegistration(pathfulUrl);
+		const candidates = buildWellKnownUrls("/.well-known/oauth-authorization-server", this.config.authorizationUrl);
+		for (const url of candidates) {
+			const endpoint = await this.#tryWellKnownForRegistration(url.toString());
+			if (endpoint) return endpoint;
+		}
+		return null;
 	}
 
 	async #tryWellKnownForRegistration(wellKnownUrl: string): Promise<string | null> {

--- a/packages/coding-agent/src/mcp/oauth-flow.ts
+++ b/packages/coding-agent/src/mcp/oauth-flow.ts
@@ -299,6 +299,8 @@ export interface MCPOAuthConfig {
 	authorizationUrl: string;
 	/** Token endpoint URL */
 	tokenUrl: string;
+	/** Authorization-server issuer URL used for metadata discovery. */
+	issuerUrl?: string;
 	/** Dynamic client registration endpoint advertised by the authorization server. */
 	registrationUrl?: string;
 	/** Client ID (optional when already embedded in authorization URL) */
@@ -665,7 +667,10 @@ export class MCPOAuthFlow extends OAuthCallbackFlow {
 	}
 
 	async #resolveRegistrationEndpoint(): Promise<string | null> {
-		const candidates = buildWellKnownUrls("/.well-known/oauth-authorization-server", this.config.authorizationUrl);
+		const candidates = buildWellKnownUrls(
+			"/.well-known/oauth-authorization-server",
+			this.config.issuerUrl ?? this.config.authorizationUrl,
+		);
 		for (const url of candidates) {
 			const endpoint = await this.#tryWellKnownForRegistration(url.toString());
 			if (endpoint) return endpoint;

--- a/packages/coding-agent/src/modes/components/mcp-add-wizard.ts
+++ b/packages/coding-agent/src/modes/components/mcp-add-wizard.ts
@@ -55,6 +55,7 @@ interface MCPAddWizardOAuthOptions {
 	serverUrl?: string;
 	resource?: string;
 	registrationUrl?: string;
+	issuerUrl?: string;
 	/**
 	 * External cancellation source. Aborting it tears down the in-flight OAuth
 	 * flow and surfaces a neutral cancellation error. The wizard wires its own
@@ -75,6 +76,7 @@ interface WizardState {
 	oauthAuthUrl: string;
 	oauthTokenUrl: string;
 	oauthRegistrationUrl: string;
+	oauthIssuerUrl: string;
 	oauthClientId: string;
 	oauthClientSecret: string;
 	oauthScopes: string;
@@ -107,6 +109,7 @@ export class MCPAddWizard extends OverlayPanel {
 		oauthAuthUrl: "",
 		oauthTokenUrl: "",
 		oauthRegistrationUrl: "",
+		oauthIssuerUrl: "",
 		oauthClientId: "",
 		oauthClientSecret: "",
 		oauthScopes: "",
@@ -1012,6 +1015,7 @@ export class MCPAddWizard extends OverlayPanel {
 					this.#state.oauthAuthUrl = oauth.authorizationUrl;
 					this.#state.oauthTokenUrl = oauth.tokenUrl;
 					this.#state.oauthRegistrationUrl = oauth.registrationUrl || "";
+					this.#state.oauthIssuerUrl = oauth.issuerUrl || "";
 					this.#state.oauthClientId = oauth.clientId || "";
 					this.#state.oauthScopes = oauth.scopes || "";
 					this.#state.oauthResource = oauth.resource || (this.#state.transport === "stdio" ? "" : this.#state.url);
@@ -1183,6 +1187,7 @@ export class MCPAddWizard extends OverlayPanel {
 				{
 					serverUrl: this.#state.url || undefined,
 					registrationUrl: this.#state.oauthRegistrationUrl || undefined,
+					issuerUrl: this.#state.oauthIssuerUrl || undefined,
 					resource: oauthResource || undefined,
 					abortSignal: this.#oauthAbort.signal,
 				},

--- a/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
@@ -751,6 +751,7 @@ export class MCPCommandController {
 									redirectUri: finalConfig.oauth?.redirectUri,
 									prompt: finalConfig.oauth?.prompt,
 									registrationUrl: oauth.registrationUrl,
+									issuerUrl: oauth.issuerUrl,
 									serverUrl: finalConfig.url,
 									resource: oauthResource,
 									stripSameOriginResource: oauthResourceIsFallback,
@@ -833,6 +834,7 @@ export class MCPCommandController {
 			prompt?: string;
 			serverUrl?: string;
 			registrationUrl?: string;
+			issuerUrl?: string;
 			resource?: string;
 			stripSameOriginResource?: boolean;
 			/**
@@ -898,6 +900,7 @@ export class MCPCommandController {
 					authorizationUrl: authUrl,
 					tokenUrl: tokenUrl,
 					registrationUrl: opts?.registrationUrl,
+					issuerUrl: opts?.issuerUrl,
 					clientId: resolvedClientId,
 					clientSecret: resolvedClientSecret,
 					scopes: scopes || undefined,
@@ -2014,6 +2017,7 @@ export class MCPCommandController {
 					redirectUri: found.config.oauth?.redirectUri,
 					prompt: found.config.oauth?.prompt,
 					registrationUrl: oauth.registrationUrl,
+					issuerUrl: oauth.issuerUrl,
 					serverUrl,
 					resource: oauthResource,
 					stripSameOriginResource: oauthResourceIsFallback,

--- a/packages/coding-agent/test/oauth-discovery.test.ts
+++ b/packages/coding-agent/test/oauth-discovery.test.ts
@@ -162,6 +162,9 @@ describe("path-prefixed auth servers", () => {
 		});
 		expect(calls).toContain("https://auth.example.com/auth/realms/myrealm/.well-known/openid-configuration");
 		expect(calls).not.toContain("https://auth.example.com/.well-known/openid-configuration/auth/realms/myrealm");
+		// The standard issuer form is tried before the parent-relative fallback, so the
+		// slow/absent parent-relative URL is never probed once the issuer form succeeds.
+		expect(calls).not.toContain("https://auth.example.com/auth/realms/.well-known/openid-configuration");
 	});
 
 	it("tries RFC 8414 path-ful metadata before the path-appended compatibility form", async () => {

--- a/packages/coding-agent/test/oauth-discovery.test.ts
+++ b/packages/coding-agent/test/oauth-discovery.test.ts
@@ -158,6 +158,7 @@ describe("path-prefixed auth servers", () => {
 
 		expect(oauth).toEqual({
 			authorizationUrl: "https://auth.example.com/auth/realms/myrealm/protocol/openid-connect/auth",
+			issuerUrl: "https://auth.example.com/auth/realms/myrealm",
 			tokenUrl: "https://auth.example.com/auth/realms/myrealm/protocol/openid-connect/token",
 		});
 		expect(calls).toContain("https://auth.example.com/auth/realms/myrealm/.well-known/openid-configuration");
@@ -197,6 +198,7 @@ describe("path-prefixed auth servers", () => {
 
 		expect(oauth).toEqual({
 			authorizationUrl: "https://auth.example.com/tenants/acme/oauth",
+			issuerUrl: "https://auth.example.com/tenants/acme",
 			tokenUrl: "https://auth.example.com/tenants/acme/token",
 			registrationUrl: "https://auth.example.com/tenants/acme/register",
 		});
@@ -363,6 +365,7 @@ describe("resource_metadata chain", () => {
 
 		expect(oauth).toEqual({
 			authorizationUrl: "https://sso.example.com/oauth/auth",
+			issuerUrl: "https://sso.example.com",
 			tokenUrl: "https://sso.example.com/oauth/token",
 			scopes: "k8s.logging-mcp-server k8s.annotations",
 			resource: "https://gateway.example.com",
@@ -409,6 +412,7 @@ describe("resource_metadata chain", () => {
 
 		expect(oauth).toEqual({
 			authorizationUrl: "https://ws.cloud.databricks.com/oidc/v1/authorize",
+			issuerUrl: "https://ws.cloud.databricks.com/oidc",
 			tokenUrl: "https://ws.cloud.databricks.com/oidc/v1/token",
 			scopes: "genie offline_access",
 			resource: "https://ws.cloud.databricks.com/api/2.0/mcp/genie",
@@ -600,6 +604,7 @@ describe("RFC 8414 §3.3 issuer validation", () => {
 
 		expect(oauth).toEqual({
 			authorizationUrl: "https://mcp.atlassian.com/v1/authorize",
+			issuerUrl: "https://cf.mcp.atlassian.com",
 			tokenUrl: "https://cf.mcp.atlassian.com/v1/token",
 			registrationUrl: "https://cf.mcp.atlassian.com/v1/register",
 		});
@@ -667,6 +672,7 @@ describe("RFC 8414 §3.3 issuer validation", () => {
 
 		expect(oauth).toEqual({
 			authorizationUrl: "https://mcp.plane.so/http/authorize",
+			issuerUrl: "https://mcp.plane.so/http",
 			tokenUrl: "https://mcp.plane.so/http/token",
 			registrationUrl: "https://mcp.plane.so/http/register",
 			resource: "https://mcp.plane.so/http/mcp",
@@ -700,6 +706,7 @@ describe("RFC 8414 §3.3 issuer validation", () => {
 
 		expect(oauth).toEqual({
 			authorizationUrl: "https://auth.example.com/oauth/authorize",
+			issuerUrl: "https://auth.example.com/",
 			tokenUrl: "https://auth.example.com/oauth/token",
 		});
 	});

--- a/packages/coding-agent/test/oauth-discovery.test.ts
+++ b/packages/coding-agent/test/oauth-discovery.test.ts
@@ -129,6 +129,40 @@ describe("path-prefixed auth servers", () => {
 		expect(calls).toContain("https://gateway.example.com/my-service/.well-known/oauth-authorization-server");
 	});
 
+	it("discovers OIDC metadata appended to a multi-segment issuer path", async () => {
+		const calls: string[] = [];
+		const fetchImpl = mockFetch((input: FetchInput) => {
+			const url = String(input);
+			calls.push(url);
+
+			if (url === "https://auth.example.com/auth/realms/myrealm/.well-known/openid-configuration") {
+				return new Response(
+					JSON.stringify({
+						issuer: "https://auth.example.com/auth/realms/myrealm",
+						authorization_endpoint: "https://auth.example.com/auth/realms/myrealm/protocol/openid-connect/auth",
+						token_endpoint: "https://auth.example.com/auth/realms/myrealm/protocol/openid-connect/token",
+					}),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				);
+			}
+
+			return new Response("not found", { status: 404 });
+		});
+
+		const oauth = await discoverOAuthEndpoints(
+			"https://mcp.example.com/mcp",
+			"https://auth.example.com/auth/realms/myrealm",
+			undefined,
+			{ fetch: fetchImpl },
+		);
+
+		expect(oauth).toEqual({
+			authorizationUrl: "https://auth.example.com/auth/realms/myrealm/protocol/openid-connect/auth",
+			tokenUrl: "https://auth.example.com/auth/realms/myrealm/protocol/openid-connect/token",
+		});
+		expect(calls).toContain("https://auth.example.com/auth/realms/myrealm/.well-known/openid-configuration");
+	});
+
 	it("falls back to RFC 8414 path-ful issuer form (/.well-known/oauth-authorization-server/<path>)", async () => {
 		const calls: string[] = [];
 		const fetchImpl = mockFetch((input: FetchInput) => {

--- a/packages/coding-agent/test/oauth-discovery.test.ts
+++ b/packages/coding-agent/test/oauth-discovery.test.ts
@@ -161,20 +161,22 @@ describe("path-prefixed auth servers", () => {
 			tokenUrl: "https://auth.example.com/auth/realms/myrealm/protocol/openid-connect/token",
 		});
 		expect(calls).toContain("https://auth.example.com/auth/realms/myrealm/.well-known/openid-configuration");
+		expect(calls).not.toContain("https://auth.example.com/.well-known/openid-configuration/auth/realms/myrealm");
 	});
 
-	it("falls back to RFC 8414 path-ful issuer form (/.well-known/oauth-authorization-server/<path>)", async () => {
+	it("tries RFC 8414 path-ful metadata before the path-appended compatibility form", async () => {
 		const calls: string[] = [];
 		const fetchImpl = mockFetch((input: FetchInput) => {
 			const url = String(input);
 			calls.push(url);
 
-			if (url === "https://gateway.example.com/.well-known/oauth-authorization-server/my-service") {
+			if (url === "https://auth.example.com/.well-known/oauth-authorization-server/tenants/acme") {
 				return new Response(
 					JSON.stringify({
-						authorization_endpoint: "https://gateway.example.com/my-service/oauth",
-						token_endpoint: "https://gateway.example.com/my-service/token",
-						registration_endpoint: "https://gateway.example.com/my-service/register",
+						issuer: "https://auth.example.com/tenants/acme",
+						authorization_endpoint: "https://auth.example.com/tenants/acme/oauth",
+						token_endpoint: "https://auth.example.com/tenants/acme/token",
+						registration_endpoint: "https://auth.example.com/tenants/acme/register",
 					}),
 					{ status: 200, headers: { "Content-Type": "application/json" } },
 				);
@@ -183,16 +185,20 @@ describe("path-prefixed auth servers", () => {
 			return new Response("not found", { status: 404 });
 		});
 
-		const oauth = await discoverOAuthEndpoints("https://gateway.example.com/my-service", undefined, undefined, {
-			fetch: fetchImpl,
-		});
+		const oauth = await discoverOAuthEndpoints(
+			"https://mcp.example.com/mcp",
+			"https://auth.example.com/tenants/acme",
+			undefined,
+			{ fetch: fetchImpl },
+		);
 
 		expect(oauth).toEqual({
-			authorizationUrl: "https://gateway.example.com/my-service/oauth",
-			tokenUrl: "https://gateway.example.com/my-service/token",
-			registrationUrl: "https://gateway.example.com/my-service/register",
+			authorizationUrl: "https://auth.example.com/tenants/acme/oauth",
+			tokenUrl: "https://auth.example.com/tenants/acme/token",
+			registrationUrl: "https://auth.example.com/tenants/acme/register",
 		});
-		expect(calls).toContain("https://gateway.example.com/.well-known/oauth-authorization-server/my-service");
+		expect(calls).toContain("https://auth.example.com/.well-known/oauth-authorization-server/tenants/acme");
+		expect(calls).not.toContain("https://auth.example.com/tenants/acme/.well-known/oauth-authorization-server");
 	});
 
 	it("prefers absolute well-known when it succeeds (origin-root servers still work)", async () => {

--- a/packages/coding-agent/test/oauth-flow.test.ts
+++ b/packages/coding-agent/test/oauth-flow.test.ts
@@ -84,7 +84,7 @@ describe("mcp oauth flow", () => {
 		expect(authUrl.searchParams.get("state")).toBe("test-state");
 	});
 
-	it("discovers DCR metadata appended to a multi-segment authorization path", async () => {
+	it("uses the issuer rather than the authorization endpoint to discover DCR metadata", async () => {
 		const calls: string[] = [];
 		const fetchImpl: FetchImpl = async input => {
 			const url = String(input);
@@ -110,8 +110,9 @@ describe("mcp oauth flow", () => {
 
 		const flow = new MCPOAuthFlow(
 			{
-				authorizationUrl: "https://auth.example.com/auth/realms/myrealm",
-				tokenUrl: "https://auth.example.com/auth/realms/myrealm/token",
+				authorizationUrl: "https://auth.example.com/auth/realms/myrealm/protocol/openid-connect/auth",
+				tokenUrl: "https://auth.example.com/auth/realms/myrealm/protocol/openid-connect/token",
+				issuerUrl: "https://auth.example.com/auth/realms/myrealm",
 				fetch: fetchImpl,
 			},
 			{},

--- a/packages/coding-agent/test/oauth-flow.test.ts
+++ b/packages/coding-agent/test/oauth-flow.test.ts
@@ -84,6 +84,45 @@ describe("mcp oauth flow", () => {
 		expect(authUrl.searchParams.get("state")).toBe("test-state");
 	});
 
+	it("discovers DCR metadata appended to a multi-segment authorization path", async () => {
+		const calls: string[] = [];
+		const fetchImpl: FetchImpl = async input => {
+			const url = String(input);
+			calls.push(url);
+
+			if (url === "https://auth.example.com/auth/realms/myrealm/.well-known/oauth-authorization-server") {
+				return new Response(
+					JSON.stringify({
+						registration_endpoint:
+							"https://auth.example.com/auth/realms/myrealm/clients-registrations/openid-connect",
+					}),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				);
+			}
+			if (url === "https://auth.example.com/auth/realms/myrealm/clients-registrations/openid-connect") {
+				return new Response(JSON.stringify({ client_id: "registered-client-id" }), {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				});
+			}
+			return new Response("not found", { status: 404 });
+		};
+
+		const flow = new MCPOAuthFlow(
+			{
+				authorizationUrl: "https://auth.example.com/auth/realms/myrealm",
+				tokenUrl: "https://auth.example.com/auth/realms/myrealm/token",
+				fetch: fetchImpl,
+			},
+			{},
+		);
+
+		const { url } = await flow.generateAuthUrl("test-state", "http://127.0.0.1:53175/callback");
+
+		expect(new URL(url).searchParams.get("client_id")).toBe("registered-client-id");
+		expect(calls).toContain("https://auth.example.com/auth/realms/myrealm/.well-known/oauth-authorization-server");
+	});
+
 	it("removes a whitespace-only embedded client id before authorization", async () => {
 		const flow = new MCPOAuthFlow(
 			{


### PR DESCRIPTION
## Repro
An MCP authorization server with issuer `https://auth.example.com/auth/realms/myrealm` serves OIDC metadata at the issuer-appended well-known URL, but discovery never queried it and returned `null`. Reproduced with `bun test packages/coding-agent/test/oauth-discovery.test.ts --test-name-pattern "discovers OIDC metadata appended"` (`0 pass, 1 fail` before the fix).

## Cause
`buildWellKnownUrls` in `packages/coding-agent/src/mcp/oauth-discovery.ts` generated the origin-root, parent-relative, and RFC 8414 path-ful candidates, but omitted the OIDC Discovery issuer-path form `<issuer>/.well-known/openid-configuration`. The separately reported RFC 9728 scope precedence was already fixed on `main` by `6f91876fbe` and shipped in 17.4.1.

## Fix
- Add the full issuer-path well-known candidate after the existing parent-relative candidate.
- Cover a Keycloak-style multi-segment issuer through the public `discoverOAuthEndpoints` contract.
- Add the user-visible fix to the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/oauth-discovery.test.ts` passes all 24 tests (51 assertions); the pre-publish `bun run fix` and `bun check` gate also passed. Fixes #10042