### PR TITLE
fix(session): defer retry.fallbackChains warnings for pending discovery

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `retry.fallbackChains` reporting valid selectors as `references unknown model` at startup when a config-declared discovery provider (e.g. LiteLLM in `models.yml`) had a cold discovery cache — such as the first launch after an update bumps the cache namespace. Warnings for pending-discovery providers are now deferred and re-evaluated once discovery lands, and cleared from the header if resolved ([#10048](https://github.com/can1357/oh-my-pi/issues/10048)).
+
 ## [18.0.9] - 2026-08-28
 
 ### Breaking Changes

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -238,6 +238,10 @@ export class ModelRegistry {
 	#cacheDbPath?: string;
 	#suppressedSelectors: Map<string, number> = new Map();
 	#backgroundRefresh?: Promise<void>;
+	/** Whether the first background discovery has settled; latches once so a late-armed waiter still resolves. */
+	#initialRefreshSettled = false;
+	/** Waiter armed before the initial background refresh starts (CLI kicks it off after the session is built, #10048). */
+	#initialRefreshWaiters?: PromiseWithResolvers<void>;
 	#credentialScopedCacheHydration?: Promise<void>;
 	#configuredDiscoveryInFlight: Map<DiscoveryProviderConfig, Map<ModelRefreshStrategy, Promise<Model<Api>[]>>> =
 		new Map();
@@ -437,6 +441,7 @@ export class ModelRegistry {
 				if (this.#backgroundRefresh === refreshPromise) {
 					this.#backgroundRefresh = undefined;
 				}
+				this.#markInitialRefreshSettled();
 			});
 		this.#backgroundRefresh = refreshPromise;
 	}
@@ -464,12 +469,27 @@ export class ModelRegistry {
 	}
 
 	/**
-	 * Whether an initial background discovery is still running. Read before
-	 * awaiting {@link awaitBackgroundRefresh} so a consumer can tell a genuine
-	 * pending discovery from a registry that will never refresh (#10048).
+	 * Resolve once the initial background discovery has settled, arming a waiter
+	 * even when the refresh has not started yet. In the CLI path
+	 * {@link refreshInBackground} runs right after the session is constructed
+	 * (`main.ts`), so a consumer created in the constructor cannot rely on an
+	 * in-flight snapshot — it must observe the settle whenever it happens.
+	 * Resolves immediately once any background refresh has completed; never
+	 * rejects (discovery errors are swallowed by `refreshInBackground`). Stays
+	 * pending when no background refresh is ever started (e.g. an embedder that
+	 * manages discovery itself), which leaves startup suppression in place.
 	 */
-	hasBackgroundRefreshInFlight(): boolean {
-		return this.#backgroundRefresh !== undefined;
+	awaitInitialBackgroundRefresh(): Promise<void> {
+		if (this.#initialRefreshSettled) return Promise.resolve();
+		this.#initialRefreshWaiters ??= Promise.withResolvers<void>();
+		return this.#initialRefreshWaiters.promise;
+	}
+
+	#markInitialRefreshSettled(): void {
+		if (this.#initialRefreshSettled) return;
+		this.#initialRefreshSettled = true;
+		this.#initialRefreshWaiters?.resolve();
+		this.#initialRefreshWaiters = undefined;
 	}
 
 	async refreshProvider(providerId: string, strategy: ModelRefreshStrategy = "online"): Promise<void> {

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -463,6 +463,15 @@ export class ModelRegistry {
 		}
 	}
 
+	/**
+	 * Whether an initial background discovery is still running. Read before
+	 * awaiting {@link awaitBackgroundRefresh} so a consumer can tell a genuine
+	 * pending discovery from a registry that will never refresh (#10048).
+	 */
+	hasBackgroundRefreshInFlight(): boolean {
+		return this.#backgroundRefresh !== undefined;
+	}
+
 	async refreshProvider(providerId: string, strategy: ModelRefreshStrategy = "online"): Promise<void> {
 		this.#reloadStaticModels();
 		for (const selector of this.#suppressedSelectors.keys()) {
@@ -2266,6 +2275,17 @@ export class ModelRegistry {
 
 	getProviderDiscoveryState(provider: string): ProviderDiscoveryState | undefined {
 		return this.#providerDiscoveryStates.get(provider);
+	}
+
+	/**
+	 * Whether a config-declared discovery provider has not yet produced a
+	 * catalog in this process. A cold discovery cache (e.g. after `omp update`
+	 * bumps the cache namespace) leaves the provider in its initial `idle`
+	 * state with no models, so a selector the provider will supply looks
+	 * unknown until background discovery lands (#10048).
+	 */
+	isProviderDiscoveryPending(provider: string): boolean {
+		return this.#providerDiscoveryStates.get(provider)?.status === "idle";
 	}
 
 	/**

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -264,6 +264,9 @@ export class EventController {
 				this.ctx.statusLine.invalidate();
 				this.ctx.ui.requestRender();
 			},
+			// Header rebuild is owned by InteractiveMode's own session
+			// subscription (mirrors model_changed); nothing to do here.
+			config_warnings_changed: async () => {},
 			advisor_cost_changed: async () => {
 				this.ctx.statusLine.invalidate();
 				this.ctx.ui.requestRender();

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -724,6 +724,8 @@ export class InteractiveMode implements InteractiveModeContext {
 	#signalTeardown?: SessionTeardown;
 	readonly #version: string;
 	readonly #startupChangelog: StartupChangelogSelection | undefined;
+	/** Header components below the config warnings + welcome, retained so a live config-warning change can rebuild the header (#10048). */
+	#headerAfter: readonly Component[] = [];
 	#planModePreviousTools: string[] | undefined;
 	#goalModePreviousTools: string[] | undefined;
 	#vibeModePreviousTools: string[] | undefined;
@@ -1164,10 +1166,7 @@ export class InteractiveMode implements InteractiveModeContext {
 			lspServers: this.#getWelcomeLspServers(),
 		});
 		this.#persistComposerWelcome(modelName, providerName);
-		const headerBefore: Component[] = [];
-		for (const warning of this.session.configWarnings) {
-			headerBefore.push(new Text(theme.fg("warning", `Warning: ${warning}`), 1, 0), new Spacer(1));
-		}
+		const headerBefore = this.#buildConfigWarningComponents();
 		const headerAfter: Component[] = [];
 		if (!startupQuiet && this.#startupChangelog && settings.get("startup.changelogMode") !== "hidden") {
 			headerAfter.push(
@@ -1186,6 +1185,7 @@ export class InteractiveMode implements InteractiveModeContext {
 			}
 			headerAfter.push(new Spacer(1), new DynamicBorder());
 		}
+		this.#headerAfter = headerAfter;
 		this.composer.setHeaderExtras(headerBefore, headerAfter);
 		this.statusLine.watchBranch(() => {
 			this.ui.requestRender();
@@ -1339,6 +1339,9 @@ export class InteractiveMode implements InteractiveModeContext {
 			this.session.subscribe(event => {
 				if (event.type === "model_changed") {
 					this.#updateWelcomeModel();
+				}
+				if (event.type === "config_warnings_changed") {
+					this.composer.setHeaderExtras(this.#buildConfigWarningComponents(), this.#headerAfter);
 				}
 				void this.#handleGoalSessionEvent(event);
 			}),
@@ -5005,6 +5008,15 @@ export class InteractiveMode implements InteractiveModeContext {
 		const providerName = this.session.model?.provider ?? "Unknown";
 		this.composer.updateWelcome({ modelName, providerName });
 		this.#persistComposerWelcome(modelName, providerName);
+	}
+
+	/** Header rows for the current config warnings, rebuilt when they change (#10048). */
+	#buildConfigWarningComponents(): Component[] {
+		const components: Component[] = [];
+		for (const warning of this.session.configWarnings) {
+			components.push(new Text(theme.fg("warning", `Warning: ${warning}`), 1, 0), new Spacer(1));
+		}
+		return components;
 	}
 
 	#persistComposerWelcome(modelName: string, providerName: string): void {

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -1341,7 +1341,7 @@ export class InteractiveMode implements InteractiveModeContext {
 					this.#updateWelcomeModel();
 				}
 				if (event.type === "config_warnings_changed") {
-					this.composer.setHeaderExtras(this.#buildConfigWarningComponents(), this.#headerAfter);
+					this.#syncConfigWarningHeader();
 				}
 				void this.#handleGoalSessionEvent(event);
 			}),
@@ -1355,6 +1355,9 @@ export class InteractiveMode implements InteractiveModeContext {
 		// can change the model before this subscription exists, so the
 		// model_changed events they emit are never observed by the handler above.
 		this.#updateWelcomeModel();
+		// Config warnings can change during the same pre-subscription window; the
+		// event is not replayed, so rebuild from the live array once here too.
+		this.#syncConfigWarningHeader();
 		this.#eventBusUnsubscribers.push(
 			onModelRolesChanged(() => {
 				void this.#reapplyPlanModeModelOnRoleChange();
@@ -5008,6 +5011,10 @@ export class InteractiveMode implements InteractiveModeContext {
 		const providerName = this.session.model?.provider ?? "Unknown";
 		this.composer.updateWelcome({ modelName, providerName });
 		this.#persistComposerWelcome(modelName, providerName);
+	}
+
+	#syncConfigWarningHeader(): void {
+		this.composer.setHeaderExtras(this.#buildConfigWarningComponents(), this.#headerAfter);
 	}
 
 	/** Header rows for the current config warnings, rebuilt when they change (#10048). */

--- a/packages/coding-agent/src/session/agent-session-events.ts
+++ b/packages/coding-agent/src/session/agent-session-events.ts
@@ -48,6 +48,7 @@ export type AgentSessionEvent =
 	| { type: "retry_fallback_applied"; from: string; to: string; role: string }
 	| { type: "retry_fallback_succeeded"; model: string; role: string }
 	| { type: "model_changed" }
+	| { type: "config_warnings_changed" }
 	| { type: "advisor_cost_changed" }
 	| { type: "ttsr_triggered"; rules: Rule[] }
 	| { type: "todo_reminder"; todos: TodoItem[]; attempt: number; maxAttempts: number }

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1722,13 +1722,14 @@ export class AgentSession {
 			});
 		});
 
-		// An advisor enabled in config resolves its role against the model catalog
-		// as it stands at construction. Discovery-backed providers (e.g. GitHub
-		// Copilot) may not be populated yet — background discovery is started
-		// fire-and-forget before the session is built — so a valid configured model
-		// can land as `no_model`. Retry once the initial refresh settles so the
-		// advisor activates without a manual /advisor toggle. See #9010.
-		void this.#retryInactiveAdvisorAfterModelDiscovery();
+		// Config-declared resolution done against the catalog as it stands at
+		// construction can be premature: background discovery is started
+		// fire-and-forget before the session is built, so discovery-backed
+		// providers (e.g. GitHub Copilot, or a models.yml LiteLLM provider with a
+		// cold cache) may not be populated yet. Reconcile once the initial refresh
+		// settles — reactivate a `no_model` advisor (#9010) and retract stale
+		// retry.fallbackChains warnings (#10048).
+		void this.#reconcileSessionAfterModelDiscovery();
 	}
 	/** Model registry for API key resolution and model discovery */
 	get modelRegistry(): ModelRegistry {
@@ -9873,16 +9874,35 @@ export class AgentSession {
 	}
 
 	/**
-	 * Reactivate an advisor that resolved to `no_model` at construction because a
-	 * discovery-backed provider had not populated the model registry yet. Awaits
-	 * the initial background refresh, then rebuilds the advisor and emits
-	 * `model_changed` so the status line reflects the now-active advisor. See #9010.
+	 * After the initial background model discovery settles, reconcile session
+	 * state resolved against a possibly-incomplete catalog at construction:
+	 * reactivate an advisor that fell back to `no_model` (#9010) and re-run
+	 * retry.fallbackChains validation so config-declared discovery providers
+	 * whose models arrived a beat late stop reporting valid selectors as
+	 * unknown (#10048).
+	 *
+	 * The fallback re-check only runs when a background refresh was actually in
+	 * flight: without one, discovery will not populate the registry, so the
+	 * startup suppression stands rather than surfacing an unverifiable warning.
 	 */
-	async #retryInactiveAdvisorAfterModelDiscovery(): Promise<void> {
-		if (this.#isDisposed || !this.#advisors.hasInactiveNoModelAdvisor()) return;
+	async #reconcileSessionAfterModelDiscovery(): Promise<void> {
+		if (this.#isDisposed) return;
+		const hasInactiveAdvisor = this.#advisors.hasInactiveNoModelAdvisor();
+		const hasDeferredValidation = this.#recovery.hasPendingDiscoveryDeferredFallbackValidation();
+		if (!hasInactiveAdvisor && !hasDeferredValidation) return;
+		const discoveryWasInFlight = this.#modelRegistry.hasBackgroundRefreshInFlight();
 		await this.#modelRegistry.awaitBackgroundRefresh();
 		if (this.#isDisposed) return;
-		if (this.#advisors.retryAfterModelDiscovery()) this.#emit({ type: "model_changed" });
+		if (hasInactiveAdvisor && this.#advisors.retryAfterModelDiscovery()) {
+			this.#emit({ type: "model_changed" });
+		}
+		if (
+			hasDeferredValidation &&
+			discoveryWasInFlight &&
+			this.#recovery.revalidateRetryFallbackChainsAfterDiscovery()
+		) {
+			this.#emit({ type: "config_warnings_changed" });
+		}
 	}
 
 	/**

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1724,12 +1724,13 @@ export class AgentSession {
 
 		// Config-declared resolution done against the catalog as it stands at
 		// construction can be premature: background discovery is started
-		// fire-and-forget before the session is built, so discovery-backed
-		// providers (e.g. GitHub Copilot, or a models.yml LiteLLM provider with a
-		// cold cache) may not be populated yet. Reconcile once the initial refresh
-		// settles — reactivate a `no_model` advisor (#9010) and retract stale
-		// retry.fallbackChains warnings (#10048).
-		void this.#reconcileSessionAfterModelDiscovery();
+		// fire-and-forget (before the session in the SDK path, right after it in
+		// the CLI path), so discovery-backed providers (e.g. GitHub Copilot, or a
+		// models.yml LiteLLM provider with a cold cache) may not be populated yet.
+		// Reactivate a `no_model` advisor (#9010) and retract stale
+		// retry.fallbackChains warnings (#10048) once discovery settles.
+		void this.#retryInactiveAdvisorAfterModelDiscovery();
+		void this.#revalidateFallbackChainsAfterModelDiscovery();
 	}
 	/** Model registry for API key resolution and model discovery */
 	get modelRegistry(): ModelRegistry {
@@ -9874,33 +9875,32 @@ export class AgentSession {
 	}
 
 	/**
-	 * After the initial background model discovery settles, reconcile session
-	 * state resolved against a possibly-incomplete catalog at construction:
-	 * reactivate an advisor that fell back to `no_model` (#9010) and re-run
-	 * retry.fallbackChains validation so config-declared discovery providers
-	 * whose models arrived a beat late stop reporting valid selectors as
-	 * unknown (#10048).
-	 *
-	 * The fallback re-check only runs when a background refresh was actually in
-	 * flight: without one, discovery will not populate the registry, so the
-	 * startup suppression stands rather than surfacing an unverifiable warning.
+	 * Reactivate an advisor that resolved to `no_model` at construction because a
+	 * discovery-backed provider had not populated the model registry yet. Awaits
+	 * the initial background refresh, then rebuilds the advisor and emits
+	 * `model_changed` so the status line reflects the now-active advisor. See #9010.
 	 */
-	async #reconcileSessionAfterModelDiscovery(): Promise<void> {
-		if (this.#isDisposed) return;
-		const hasInactiveAdvisor = this.#advisors.hasInactiveNoModelAdvisor();
-		const hasDeferredValidation = this.#recovery.hasPendingDiscoveryDeferredFallbackValidation();
-		if (!hasInactiveAdvisor && !hasDeferredValidation) return;
-		const discoveryWasInFlight = this.#modelRegistry.hasBackgroundRefreshInFlight();
+	async #retryInactiveAdvisorAfterModelDiscovery(): Promise<void> {
+		if (this.#isDisposed || !this.#advisors.hasInactiveNoModelAdvisor()) return;
 		await this.#modelRegistry.awaitBackgroundRefresh();
 		if (this.#isDisposed) return;
-		if (hasInactiveAdvisor && this.#advisors.retryAfterModelDiscovery()) {
-			this.#emit({ type: "model_changed" });
-		}
-		if (
-			hasDeferredValidation &&
-			discoveryWasInFlight &&
-			this.#recovery.revalidateRetryFallbackChainsAfterDiscovery()
-		) {
+		if (this.#advisors.retryAfterModelDiscovery()) this.#emit({ type: "model_changed" });
+	}
+
+	/**
+	 * Re-run retry.fallbackChains validation once the initial background discovery
+	 * settles. Startup validation suppresses "unknown model" warnings for
+	 * config-declared discovery providers whose cold cache left the registry empty
+	 * (#10048); this retracts the ones discovery resolved and surfaces any that
+	 * stayed unknown. Uses {@link ModelRegistry.awaitInitialBackgroundRefresh}
+	 * because the CLI starts that refresh right after the session is built, so an
+	 * in-flight snapshot taken in the constructor would always miss it.
+	 */
+	async #revalidateFallbackChainsAfterModelDiscovery(): Promise<void> {
+		if (this.#isDisposed || !this.#recovery.hasPendingDiscoveryDeferredFallbackValidation()) return;
+		await this.#modelRegistry.awaitInitialBackgroundRefresh();
+		if (this.#isDisposed) return;
+		if (this.#recovery.revalidateRetryFallbackChainsAfterDiscovery()) {
 			this.#emit({ type: "config_warnings_changed" });
 		}
 	}

--- a/packages/coding-agent/src/session/retry-fallback-chains.ts
+++ b/packages/coding-agent/src/session/retry-fallback-chains.ts
@@ -1,6 +1,5 @@
 import type { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import type { Model } from "@oh-my-pi/pi-ai";
-import { logger } from "@oh-my-pi/pi-utils";
 import type { ModelRegistry } from "../config/model-registry";
 import {
 	formatModelSelectorValue,
@@ -154,18 +153,26 @@ export function getRetryFallbackChains(settings: Settings): RetryFallbackChains 
 	return expandDefaultRetryFallbackChains(configuredChains, Object.keys(settings.getModelRoles()));
 }
 
-/** Validates configured fallback chains and reports each warning. */
+/**
+ * Validates configured fallback chains and reports each warning via `warn`.
+ *
+ * `options.isDiscoveryPending` suppresses "unknown model" warnings for
+ * selectors whose config-declared discovery provider has not yet populated the
+ * registry (a cold discovery cache after `omp update` bumps the cache
+ * namespace, #10048). Such selectors are re-checked once background discovery
+ * settles. Logging is the caller's responsibility so a post-discovery re-run
+ * does not double-log persistent warnings.
+ */
 export function validateRetryFallbackChains(
 	settings: Settings,
 	modelRegistry: ModelRegistry,
 	warn: (message: string) => void,
+	options: { isDiscoveryPending?: (provider: string) => boolean } = {},
 ): void {
 	const configuredChains = settings.get("retry.fallbackChains");
 	if (configuredChains === undefined) return;
-	const report = (message: string) => {
-		logger.warn(message);
-		warn(message);
-	};
+	const report = warn;
+	const isDiscoveryPending = options.isDiscoveryPending ?? (() => false);
 	if (!configuredChains || typeof configuredChains !== "object" || Array.isArray(configuredChains)) {
 		report("retry.fallbackChains must be a mapping of role names or model selectors to selector arrays.");
 		return;
@@ -186,7 +193,10 @@ export function validateRetryFallbackChains(
 				const parsedKey = parseRetryFallbackSelector(key, modelRegistry);
 				if (!parsedKey) {
 					report(`Invalid model selector key in retry.fallbackChains: ${key}`);
-				} else if (!modelRegistry.find(parsedKey.provider, parsedKey.id)) {
+				} else if (
+					!modelRegistry.find(parsedKey.provider, parsedKey.id) &&
+					!isDiscoveryPending(parsedKey.provider)
+				) {
 					report(`retry.fallbackChains key references unknown model: ${key}`);
 				}
 			}
@@ -214,7 +224,7 @@ export function validateRetryFallbackChains(
 				report(`Invalid fallback selector format in ${keyKind} '${key}': ${selectorStr}`);
 				continue;
 			}
-			if (!modelRegistry.find(parsed.provider, parsed.id)) {
+			if (!modelRegistry.find(parsed.provider, parsed.id) && !isDiscoveryPending(parsed.provider)) {
 				report(`Fallback chain for ${keyKind} '${key}' references unknown model: ${selectorStr}`);
 			}
 		}

--- a/packages/coding-agent/src/session/turn-recovery.ts
+++ b/packages/coding-agent/src/session/turn-recovery.ts
@@ -238,6 +238,14 @@ export class TurnRecovery {
 	#bootstrapCache:
 		| { model: Model; level: ThinkingLevel | undefined; routed: boolean; value: ServingModel }
 		| undefined;
+	/**
+	 * Fallback-chain warnings pushed to `configWarnings` by startup validation,
+	 * tracked so a post-discovery re-check can retract the ones discovery
+	 * resolved (#10048).
+	 */
+	#fallbackChainWarnings = new Set<string>();
+	/** Whether startup validation deferred any warning pending in-flight discovery (#10048). */
+	#pendingDiscoveryDeferredValidation = false;
 
 	constructor(host: TurnRecoveryHost, options: TurnRecoveryOptions = {}) {
 		this.#host = host;
@@ -1303,9 +1311,63 @@ export class TurnRecovery {
 	}
 
 	#validateRetryFallbackChains(): void {
-		validateRetryFallbackChains(this.#host.settings, this.#host.modelRegistry, message =>
-			this.#host.configWarnings.push(message),
+		let deferred = false;
+		validateRetryFallbackChains(
+			this.#host.settings,
+			this.#host.modelRegistry,
+			message => {
+				logger.warn(message);
+				this.#fallbackChainWarnings.add(message);
+				this.#host.configWarnings.push(message);
+			},
+			{
+				isDiscoveryPending: provider => {
+					const pending = this.#host.modelRegistry.isProviderDiscoveryPending(provider);
+					if (pending) deferred = true;
+					return pending;
+				},
+			},
 		);
+		this.#pendingDiscoveryDeferredValidation = deferred;
+	}
+
+	/** Whether startup fallback-chain validation deferred any warning pending in-flight discovery (#10048). */
+	hasPendingDiscoveryDeferredFallbackValidation(): boolean {
+		return this.#pendingDiscoveryDeferredValidation;
+	}
+
+	/**
+	 * Re-run fallback-chain validation once background discovery has settled and
+	 * reconcile `configWarnings`. Startup validation suppresses "unknown model"
+	 * warnings for selectors whose config-declared discovery provider had not yet
+	 * populated the registry (a cold cache after `omp update` bumps the discovery
+	 * namespace, #10048). With discovery done, drop any startup warning discovery
+	 * resolved and surface warnings for selectors that stayed unknown.
+	 *
+	 * @returns true when `configWarnings` changed and the header must rebuild.
+	 */
+	revalidateRetryFallbackChainsAfterDiscovery(): boolean {
+		const definitive = new Set<string>();
+		validateRetryFallbackChains(this.#host.settings, this.#host.modelRegistry, message => definitive.add(message));
+		this.#pendingDiscoveryDeferredValidation = false;
+		let changed = false;
+		for (const message of [...this.#fallbackChainWarnings]) {
+			if (definitive.has(message)) continue;
+			const index = this.#host.configWarnings.indexOf(message);
+			if (index !== -1) {
+				this.#host.configWarnings.splice(index, 1);
+				changed = true;
+			}
+			this.#fallbackChainWarnings.delete(message);
+		}
+		for (const message of definitive) {
+			if (this.#fallbackChainWarnings.has(message)) continue;
+			logger.warn(message);
+			this.#fallbackChainWarnings.add(message);
+			this.#host.configWarnings.push(message);
+			changed = true;
+		}
+		return changed;
 	}
 
 	#getRetryFallbackRevertPolicy(): RetryFallbackRevertPolicy {

--- a/packages/coding-agent/test/agent-session-retry-fallback.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-fallback.test.ts
@@ -25,7 +25,10 @@ import { ExtensionRunner } from "@oh-my-pi/pi-coding-agent/extensibility/extensi
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import { AgentSession, type AgentSessionEvent } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
-import type { ServingModel } from "@oh-my-pi/pi-coding-agent/session/retry-fallback-chains";
+import {
+	type ServingModel,
+	validateRetryFallbackChains,
+} from "@oh-my-pi/pi-coding-agent/session/retry-fallback-chains";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import { EventBus } from "@oh-my-pi/pi-coding-agent/utils/event-bus";
 import { TempDir } from "@oh-my-pi/pi-utils";
@@ -4778,6 +4781,84 @@ describe("AgentSession retry fallback", () => {
 		expect(session.configWarnings).not.toContain(
 			"Fallback chain for role 'default' references unknown model: ollama-cloud/deepseek-v4-pro",
 		);
+	});
+
+	it("suppresses unknown-model warnings for a config-declared discovery provider with a cold cache", async () => {
+		const primaryModel = getBundledModel("openai", "gpt-4o-mini");
+		if (!primaryModel) {
+			throw new Error("Expected bundled OpenAI test model to exist");
+		}
+		const modelsConfigPath = path.join(tempDir.path(), "cold-discovery-models.json");
+		await Bun.write(
+			modelsConfigPath,
+			JSON.stringify({
+				providers: {
+					litellm: {
+						baseUrl: "https://litellm.example.net/v1",
+						api: "openai-completions",
+						discovery: { type: "litellm" },
+					},
+				},
+			}),
+		);
+		// Cold cache: no discovery row exists, so the provider contributes no
+		// models and its discovery state is `idle` (pending) at construction —
+		// the exact state that made valid selectors look unknown (#10048).
+		const coldRegistry = new ModelRegistry(authStorage, modelsConfigPath);
+		expect(coldRegistry.isProviderDiscoveryPending("litellm")).toBe(true);
+		expect(coldRegistry.find("litellm", "Qwen3.8-27B")).toBeUndefined();
+
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"retry.fallbackChains": {
+				"litellm/Qwen3.8-27B": ["litellm/Qwen3.8-27B-hetzner"],
+			},
+		});
+		settings.setModelRole("default", `${primaryModel.provider}/${primaryModel.id}`);
+		const agent = new Agent({
+			getApiKey: model => `${model.provider}-test-key`,
+			initialState: { model: primaryModel, systemPrompt: ["Test"], tools: [], messages: [] },
+			streamFn: () => {
+				throw new Error("Not exercised");
+			},
+		});
+
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry: coldRegistry,
+		});
+		await session.waitForIdle();
+
+		expect(session.configWarnings).not.toContain(
+			"retry.fallbackChains key references unknown model: litellm/Qwen3.8-27B",
+		);
+		expect(session.configWarnings).not.toContain(
+			"Fallback chain for model 'litellm/Qwen3.8-27B' references unknown model: litellm/Qwen3.8-27B-hetzner",
+		);
+	});
+
+	it("defers fallback warnings while a selector's provider discovery is pending, then surfaces them once settled", () => {
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"retry.fallbackChains": {
+				"litellm/Qwen3.8-27B": ["litellm/Qwen3.8-27B-hetzner"],
+			},
+		});
+
+		const pendingWarnings: string[] = [];
+		validateRetryFallbackChains(settings, sharedRegistry, message => pendingWarnings.push(message), {
+			isDiscoveryPending: provider => provider === "litellm",
+		});
+		expect(pendingWarnings).toEqual([]);
+
+		const settledWarnings: string[] = [];
+		validateRetryFallbackChains(settings, sharedRegistry, message => settledWarnings.push(message));
+		expect(settledWarnings).toEqual([
+			"retry.fallbackChains key references unknown model: litellm/Qwen3.8-27B",
+			"Fallback chain for model 'litellm/Qwen3.8-27B' references unknown model: litellm/Qwen3.8-27B-hetzner",
+		]);
 	});
 
 	it("warns on unknown or malformed model-selector chain keys at startup", () => {

--- a/packages/coding-agent/test/agent-session-retry-fallback.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-fallback.test.ts
@@ -4861,6 +4861,39 @@ describe("AgentSession retry fallback", () => {
 		]);
 	});
 
+	it("resolves awaitInitialBackgroundRefresh for a refresh started after the waiter is armed", async () => {
+		const modelsConfigPath = path.join(tempDir.path(), "late-refresh-models.json");
+		await Bun.write(
+			modelsConfigPath,
+			JSON.stringify({
+				providers: {
+					litellm: {
+						baseUrl: "https://litellm.example.net/v1",
+						api: "openai-completions",
+						discovery: { type: "litellm" },
+					},
+				},
+			}),
+		);
+		const registry = new ModelRegistry(authStorage, modelsConfigPath);
+		// The CLI starts background discovery only after the session — and thus
+		// this awaiter — is constructed, so a waiter armed before any refresh must
+		// still resolve when the later refresh settles (#10048).
+		let settled = false;
+		const waiter = registry.awaitInitialBackgroundRefresh().then(() => {
+			settled = true;
+		});
+		await scheduler.wait(10);
+		expect(settled).toBe(false);
+
+		registry.refreshInBackground("offline");
+		await waiter;
+		expect(settled).toBe(true);
+
+		// Once settled, a fresh waiter resolves immediately.
+		await registry.awaitInitialBackgroundRefresh();
+	});
+
 	it("warns on unknown or malformed model-selector chain keys at startup", () => {
 		const primaryModel = getBundledModel("openai", "gpt-4o-mini");
 		if (!primaryModel) {


### PR DESCRIPTION
## Repro
With a config-declared discovery provider (e.g. LiteLLM in `models.yml`) whose SQLite discovery-cache row is absent — the cold namespace that follows an `omp update` bumping the `litellm:rich-vN`/`litellm-rich-vN` id — the model registry contributes no models at session construction. `retry.fallbackChains` validation runs synchronously before background discovery lands, so valid selectors the provider is about to supply are reported unknown. A minimal in-process repro against a cold registry produces exactly the reporter's three warnings:

```
litellm discovery pending (cold): true
Warning: retry.fallbackChains key references unknown model: litellm/Qwen3.8-27B
Warning: Fallback chain for model 'litellm/Qwen3.8-27B' references unknown model: litellm/Qwen3.8-27B-hetzner
Warning: Fallback chain for role 'advisor' references unknown model: litellm/gpt-5.6-luna
```

## Cause
`validateRetryFallbackChains` (`session/retry-fallback-chains.ts`) treated "absent from the registry" as "unknown" with no pending-discovery state, and ran inside the `TurnRecovery` constructor (`session/turn-recovery.ts`) before the fire-and-forget `refreshInBackground()` kicked off in `sdk.ts` could settle. `ModelRegistry.#loadCachedDiscoverableModels` records a cold config-discovery provider as `status: "idle"` with no models. Meanwhile `configWarnings` is append-only and `InteractiveMode` snapshots it once into static header components, so a warning accurate for a few hundred ms stayed in the header for the whole session.

## Fix
- `validateRetryFallbackChains` takes an `isDiscoveryPending` predicate and suppresses "unknown model" warnings for selectors whose provider discovery is pending; logging moved to the caller so a re-run does not double-log.
- `ModelRegistry.isProviderDiscoveryPending` (state `idle`) and `hasBackgroundRefreshInFlight` expose the pending/in-flight signals.
- `TurnRecovery` tracks emitted fallback warnings, marks when validation deferred any, and adds `revalidateRetryFallbackChainsAfterDiscovery()` that reconciles `configWarnings` (retract resolved, surface still-unknown).
- `AgentSession` replaces the advisor-only post-discovery hook with `#reconcileSessionAfterModelDiscovery`, which awaits the initial refresh, retries the `no_model` advisor (#9010) and re-validates fallback chains — only when a refresh was actually in flight, so a registry that never refreshes keeps the startup suppression rather than surfacing an unverifiable warning.
- New `config_warnings_changed` event; `InteractiveMode` rebuilds the config-warning header from the live array when it fires.

## Verification
`bun test packages/coding-agent/test/agent-session-retry-fallback.test.ts` — 80 pass (adds a cold-cache AgentSession regression test and a pending-vs-settled validator test). `bun run check:types` clean. Fixes #10048