### PR TITLE
fix(coding-agent): stop an undecodable image wedging a session

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -26,6 +26,9 @@
 - Fixed a macOS composer display issue where undercurl could remain attached to stale text after rapid typing.
 - Improved `xd://` MCP failure messages with actionable transport stages, failure categories, server and tool context, retryability, trace IDs, and redacted JSON-RPC details.
 - Fixed ACP `read` tool-call locations so clients such as Zed Follow receive the resolved filesystem path rather than the OMP line-range selector.
+### Fixed
+
+- Fixed an undecodable image (a truncated or partially written screenshot) permanently wedging a session: the provider rejected every later request, including on resume, with no way out. Reading one now fails with an actionable error, and any that reach the transcript are replaced by a note before the request instead of breaking it.
 
 ## [18.0.9] - 2026-08-28
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed an undecodable image (a truncated or partially written screenshot) permanently wedging a session: the provider rejected every later request, including on resume, with no way out. Reading one now fails with an actionable error, and any that reach the transcript are replaced by a note before the request instead of breaking it.
+
 ## [18.0.10] - 2026-08-28
 
 ### Added
@@ -26,9 +30,6 @@
 - Fixed a macOS composer display issue where undercurl could remain attached to stale text after rapid typing.
 - Improved `xd://` MCP failure messages with actionable transport stages, failure categories, server and tool context, retryability, trace IDs, and redacted JSON-RPC details.
 - Fixed ACP `read` tool-call locations so clients such as Zed Follow receive the resolved filesystem path rather than the OMP line-range selector.
-### Fixed
-
-- Fixed an undecodable image (a truncated or partially written screenshot) permanently wedging a session: the provider rejected every later request, including on resume, with no way out. Reading one now fails with an actionable error, and any that reach the transcript are replaced by a note before the request instead of breaking it.
 
 ## [18.0.9] - 2026-08-28
 

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -161,7 +161,7 @@ import {
 	USER_INTERRUPT_LABEL,
 	wrapSteeringForModel,
 } from "./session/messages";
-import { clampProviderContextImages } from "./session/provider-image-budget";
+import { clampProviderContextImages, dropUnreadableContextImages } from "./session/provider-image-budget";
 import {
 	expandDefaultRetryFallbackChains,
 	findRetryFallbackCandidates,
@@ -3368,6 +3368,10 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			if (snapcompactInline) transformed = await snapcompactInline.transform(transformed, transformModel);
 			transformed = clampProviderContextImages(transformed, transformModel);
 			transformed = await normalizeProviderContextImagesForModel(transformed, transformModel);
+			// After the model-specific normalizers: they carry better wording for the
+			// cases they own (STB WebP), so this stays the backstop for everything
+			// else, and it runs before the blob broker uploads any of these bytes.
+			transformed = await dropUnreadableContextImages(transformed);
 			if (blobBroker) transformed = await blobBroker.decorateContext(transformed, transformModel);
 			// Keep per-request volatility out of the system prompt: the date/cwd
 			// reminder rides on the first user turn so open-weight providers keep
@@ -4042,6 +4046,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 						let transformed = obfuscator ? obfuscateProviderContext(obfuscator, context) : context;
 						transformed = clampProviderContextImages(transformed, transformModel);
 						transformed = await normalizeProviderContextImagesForModel(transformed, transformModel);
+						transformed = await dropUnreadableContextImages(transformed);
 						if (blobBroker) transformed = await blobBroker.decorateContext(transformed, transformModel);
 						return withDateCwdReminder(
 							transformed,

--- a/packages/coding-agent/src/session/provider-image-budget.ts
+++ b/packages/coding-agent/src/session/provider-image-budget.ts
@@ -2,12 +2,15 @@ import type {
 	Context,
 	DeveloperMessage,
 	ImageContent,
+	Message,
 	Model,
 	TextContent,
 	ToolResultMessage,
 	UserMessage,
 } from "@oh-my-pi/pi-ai";
+import { LRUCache } from "@oh-my-pi/pi-utils/lru";
 import { providerImageBudget } from "@oh-my-pi/snapcompact";
+import { imageDecodeFailureReason } from "../utils/image-loading";
 
 const TOOL_RESULT_IMAGE_OMISSION: TextContent = {
 	type: "text",
@@ -83,4 +86,78 @@ export function clampProviderContextImages(context: Context, model: Model): Cont
 		return message;
 	});
 	return { ...context, messages };
+}
+
+/**
+ * Decode verdicts keyed by payload hash: the same historical images ride along
+ * on every turn of a session, and decoding all of them per request would be a
+ * real cost. `null` means the image decodes.
+ */
+const IMAGE_DECODE_CACHE_MAX_ENTRIES = 512;
+const imageDecodeFailures = new LRUCache<string, string | null>({ max: IMAGE_DECODE_CACHE_MAX_ENTRIES });
+
+async function unreadableImageReason(image: ImageContent): Promise<string | null> {
+	const key = `${image.mimeType}:${image.data.length}:${String(Bun.hash(image.data))}`;
+	const cached = imageDecodeFailures.get(key);
+	if (cached !== undefined) return cached;
+	const reason = await imageDecodeFailureReason(image);
+	imageDecodeFailures.set(key, reason);
+	return reason;
+}
+
+/** `undefined` when every image decodes, so callers can keep the original array. */
+async function replaceUnreadableContent(
+	content: readonly (TextContent | ImageContent)[],
+): Promise<(TextContent | ImageContent)[] | undefined> {
+	let replaced: (TextContent | ImageContent)[] | undefined;
+	for (let index = 0; index < content.length; index++) {
+		const part = content[index];
+		if (part.type !== "image") continue;
+		const reason = await unreadableImageReason(part);
+		if (reason === null) continue;
+		replaced ??= [...content];
+		replaced[index] = {
+			type: "text",
+			text: `[image omitted: undecodable ${part.mimeType ?? "image"} data (${reason})]`,
+		};
+	}
+	return replaced;
+}
+
+/** `undefined` when the message needs no rewrite. */
+async function dropUnreadableFromMessage(message: Message): Promise<Message | undefined> {
+	switch (message.role) {
+		case "user":
+		case "developer": {
+			if (!Array.isArray(message.content)) return undefined;
+			const content = await replaceUnreadableContent(message.content);
+			// The provider payload embeds the same bytes, so it has to be rebuilt
+			// from the rewritten content rather than replayed verbatim.
+			return content ? { ...message, content, providerPayload: undefined } : undefined;
+		}
+		case "toolResult": {
+			const content = await replaceUnreadableContent(message.content);
+			return content ? { ...message, content } : undefined;
+		}
+		case "assistant":
+			return undefined;
+	}
+}
+
+/**
+ * Last line of defence before the wire: an undecodable image makes the provider
+ * reject the entire request rather than the offending block, so one bad payload
+ * anywhere in history leaves the session permanently unable to send. Degrades
+ * those blocks to text and leaves everything else — including the `context`
+ * object itself — untouched.
+ */
+export async function dropUnreadableContextImages(context: Context): Promise<Context> {
+	let messages: Message[] | undefined;
+	for (let index = 0; index < context.messages.length; index++) {
+		const rewritten = await dropUnreadableFromMessage(context.messages[index]);
+		if (!rewritten) continue;
+		messages ??= [...context.messages];
+		messages[index] = rewritten;
+	}
+	return messages ? { ...context, messages } : context;
 }

--- a/packages/coding-agent/src/session/provider-image-budget.ts
+++ b/packages/coding-agent/src/session/provider-image-budget.ts
@@ -4,10 +4,14 @@ import type {
 	ImageContent,
 	Message,
 	Model,
+	ProviderPayload,
 	TextContent,
 	ToolResultMessage,
+	ToolResultProviderMetadata,
 	UserMessage,
 } from "@oh-my-pi/pi-ai";
+import { decodeDataUri } from "@oh-my-pi/pi-ai/providers/openai-data-uri";
+import { isRecord } from "@oh-my-pi/pi-utils";
 import { LRUCache } from "@oh-my-pi/pi-utils/lru";
 import { providerImageBudget } from "@oh-my-pi/snapcompact";
 import { imageDecodeFailureReason } from "../utils/image-loading";
@@ -105,6 +109,42 @@ async function unreadableImageReason(image: ImageContent): Promise<string | null
 	return reason;
 }
 
+/**
+ * True when this block's inline `data` is what actually travels on the wire.
+ *
+ * An `ImageContent` may legitimately carry EMPTY `data` beside an external
+ * reference, and it is the reference — never those bytes — that the provider
+ * receives. Two producers make exactly that shape:
+ *   - `openai-responses-server.ts` `functionOutputContent()` represents a
+ *     native `input_image` URL / file id as `{ data: "", url }` or
+ *     `{ data: "", providerFile }`;
+ *   - `blob-broker/service.ts` `frameSink` publishes lazy snapcompact frames as
+ *     `{ data: "", url }` whose PNG renders only when a provider fetches it —
+ *     and `SnapcompactInlineTransformer` runs BEFORE this guard in `sdk.ts`, so
+ *     those placeholders are already reference-shaped when we see them.
+ * `openai-shared.ts` `convertResponsesInputImage()` prefers `providerFile`, then
+ * `url`, and only falls back to `data:<mime>;base64,<data>`. Decoding a
+ * reference-backed block would therefore destroy a perfectly good image over
+ * bytes the provider is never sent.
+ */
+function sendsInlineImageBytes(image: ImageContent): boolean {
+	if (image.providerFile?.id || image.providerFile?.uri) return false;
+	if (image.url) return false;
+	return image.data.length > 0;
+}
+
+/**
+ * Inline image bytes carried by a native `image_url`, or `undefined` when there
+ * is nothing local to decode. An `https:` URL or a `file_id` is a reference the
+ * provider resolves itself — the same rule as {@link sendsInlineImageBytes}.
+ */
+function inlineImageFromDataUri(imageUrl: unknown): ImageContent | undefined {
+	if (typeof imageUrl !== "string") return undefined;
+	const decoded = decodeDataUri(imageUrl);
+	if (!decoded || decoded.data.length === 0) return undefined;
+	return { type: "image", data: decoded.data, mimeType: decoded.mimeType };
+}
+
 /** `undefined` when every image decodes, so callers can keep the original array. */
 async function replaceUnreadableContent(
 	content: readonly (TextContent | ImageContent)[],
@@ -112,7 +152,7 @@ async function replaceUnreadableContent(
 	let replaced: (TextContent | ImageContent)[] | undefined;
 	for (let index = 0; index < content.length; index++) {
 		const part = content[index];
-		if (part.type !== "image") continue;
+		if (part.type !== "image" || !sendsInlineImageBytes(part)) continue;
 		const reason = await unreadableImageReason(part);
 		if (reason === null) continue;
 		replaced ??= [...content];
@@ -124,22 +164,116 @@ async function replaceUnreadableContent(
 	return replaced;
 }
 
+/**
+ * `undefined` when the native part needs no rewrite. A replayed `input_image`
+ * degrades to the `input_text` part the Responses input schema accepts in the
+ * same position, so the surrounding item keeps its shape, its ids, and its
+ * ordering.
+ */
+async function replaceUnreadableNativePart(part: unknown): Promise<Record<string, unknown> | undefined> {
+	if (!isRecord(part) || part.type !== "input_image") return undefined;
+	const image = inlineImageFromDataUri(part.image_url);
+	if (!image) return undefined;
+	const reason = await unreadableImageReason(image);
+	if (reason === null) return undefined;
+	return { type: "input_text", text: `[image omitted: undecodable ${image.mimeType} data (${reason})]` };
+}
+
+/** `undefined` when the item needs no rewrite. */
+async function replaceUnreadableNativeItem(
+	item: Record<string, unknown>,
+): Promise<Record<string, unknown> | undefined> {
+	const rewrittenItem = await replaceUnreadableNativePart(item);
+	if (rewrittenItem) return rewrittenItem;
+	if (!Array.isArray(item.content)) return undefined;
+
+	let content: unknown[] | undefined;
+	for (let index = 0; index < item.content.length; index++) {
+		const rewritten = await replaceUnreadableNativePart(item.content[index]);
+		if (!rewritten) continue;
+		content ??= [...item.content];
+		content[index] = rewritten;
+	}
+	return content ? { ...item, content } : undefined;
+}
+
+/**
+ * `undefined` when no replayed item carries an undecodable image.
+ *
+ * A corrupt image can bypass the generic `content` view entirely:
+ * `openai-responses-server.ts` `inputContentParts()` retains only text for the
+ * generic view and keeps the raw native item on `providerPayload`, which
+ * `openai-shared.ts` `convertConversationMessages()` then replays verbatim in
+ * place of that content. So the payload has to be walked in its own right.
+ *
+ * Rewriting the offending part in place — rather than dropping the payload — is
+ * what keeps this safe: payload items also carry `compaction` /
+ * `compaction_summary` markers and native call ids that the generic content does
+ * NOT reproduce, so clearing the payload would trade one broken request for
+ * silent history loss. A valid image is never touched: every level returns
+ * `undefined` when nothing changed, so the original objects survive by identity.
+ */
+async function replaceUnreadableNativePayload(
+	payload: ProviderPayload | undefined,
+): Promise<ProviderPayload | undefined> {
+	if (payload?.type !== "openaiResponsesHistory" || !Array.isArray(payload.items)) return undefined;
+	let items: Array<Record<string, unknown>> | undefined;
+	for (let index = 0; index < payload.items.length; index++) {
+		const rewritten = await replaceUnreadableNativeItem(payload.items[index]!);
+		if (!rewritten) continue;
+		items ??= [...payload.items];
+		items[index] = rewritten;
+	}
+	return items ? { ...payload, items } : undefined;
+}
+
+/**
+ * Why a computer screenshot cannot be decoded, or `null` when there is nothing
+ * wrong (or nothing inline to check).
+ *
+ * `openai-shared.ts` `appendResponsesToolResultMessages()` replays
+ * `providerMetadata.screenshot` verbatim into `computer_call_output.output`,
+ * which accepts only a `computer_screenshot` ref — there is no text part to
+ * degrade it to in place, so the caller clears the metadata instead.
+ */
+async function unreadableComputerScreenshotReason(
+	metadata: ToolResultProviderMetadata | undefined,
+): Promise<string | null> {
+	if (metadata?.type !== "computer") return null;
+	const image = inlineImageFromDataUri(metadata.screenshot.image_url);
+	return image ? await unreadableImageReason(image) : null;
+}
+
 /** `undefined` when the message needs no rewrite. */
 async function dropUnreadableFromMessage(message: Message): Promise<Message | undefined> {
 	switch (message.role) {
 		case "user":
 		case "developer": {
-			if (!Array.isArray(message.content)) return undefined;
-			const content = await replaceUnreadableContent(message.content);
-			// The provider payload embeds the same bytes, so it has to be rebuilt
-			// from the rewritten content rather than replayed verbatim.
-			return content ? { ...message, content, providerPayload: undefined } : undefined;
+			// Both views matter, and they can disagree: a native input image is
+			// stripped out of generic content and survives only on the payload.
+			const content = Array.isArray(message.content) ? await replaceUnreadableContent(message.content) : undefined;
+			const providerPayload = await replaceUnreadableNativePayload(message.providerPayload);
+			if (!content && !providerPayload) return undefined;
+			return { ...message, ...(content ? { content } : {}), ...(providerPayload ? { providerPayload } : {}) };
 		}
 		case "toolResult": {
 			const content = await replaceUnreadableContent(message.content);
-			return content ? { ...message, content } : undefined;
+			const screenshotReason = await unreadableComputerScreenshotReason(message.providerMetadata);
+			if (!content && screenshotReason === null) return undefined;
+			// Dropping the computer metadata is safe here specifically because the
+			// provider layer then takes its `computerCallIds` fallback and emits an
+			// assistant note built from this result's generic `content`, so the model
+			// still learns the call ran and what it reported — the screenshot bytes
+			// were the only thing lost, and they were unreadable anyway.
+			return {
+				...message,
+				...(content ? { content } : {}),
+				...(screenshotReason === null ? {} : { providerMetadata: undefined }),
+			};
 		}
 		case "assistant":
+			// Assistant payloads replay model OUTPUT items (reasoning, tool calls,
+			// output text); input images never live there.
 			return undefined;
 	}
 }
@@ -150,6 +284,11 @@ async function dropUnreadableFromMessage(message: Message): Promise<Message | un
  * anywhere in history leaves the session permanently unable to send. Degrades
  * those blocks to text and leaves everything else — including the `context`
  * object itself — untouched.
+ *
+ * Covers all three places outbound image bytes can hide: generic `content`, the
+ * native `providerPayload` items that get replayed in place of that content, and
+ * a computer result's `providerMetadata.screenshot`. Only bytes that actually
+ * travel are checked — see {@link sendsInlineImageBytes}.
  */
 export async function dropUnreadableContextImages(context: Context): Promise<Context> {
 	let messages: Message[] | undefined;

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -47,6 +47,7 @@ import { isCpuProfilePath, renderCpuProfile } from "../utils/cpuprofile";
 import { resolveFileDisplayMode } from "../utils/file-display-mode";
 import {
 	ImageInputTooLargeError,
+	InvalidImageDataError,
 	loadImageInput,
 	loadSvgImageInput,
 	MAX_IMAGE_INPUT_BYTES,
@@ -875,7 +876,9 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 				sourcePath: imageInput.resolvedPath,
 			};
 		} catch (error) {
-			if (error instanceof ImageInputTooLargeError) {
+			// Both surface as an actionable tool error so the model can fix the input
+			// instead of the corrupt/oversized payload entering the transcript.
+			if (error instanceof ImageInputTooLargeError || error instanceof InvalidImageDataError) {
 				throw new ToolError(error.message);
 			}
 			throw error;

--- a/packages/coding-agent/src/utils/image-loading.ts
+++ b/packages/coding-agent/src/utils/image-loading.ts
@@ -214,6 +214,44 @@ export class ImageInputTooLargeError extends Error {
 	}
 }
 
+/**
+ * Raised when image bytes cannot be decoded — a truncated stream, a payload
+ * with a hole in the middle, or bytes that are not the container they claim.
+ * Failing at ingress keeps them out of the transcript, where they would
+ * otherwise be persisted and rejected by the provider on every later request,
+ * with no way to resume the session.
+ */
+export class InvalidImageDataError extends Error {
+	readonly reason: string;
+
+	constructor(label: string, mimeType: string, reason: string) {
+		super(`${label} is not a decodable ${mimeType} image: ${reason}`);
+		this.name = "InvalidImageDataError";
+		this.reason = reason;
+	}
+}
+
+/**
+ * Why an image cannot be decoded, or `null` when it decodes.
+ *
+ * A full decode is the only check that matches what vision backends accept: a
+ * middle-elided PNG keeps its signature, its header, and even a well-formed
+ * `IEND` trailer, so header sniffing and chunk-framing walks both pass it —
+ * while real-world images that decoders render happily do have odd framing, so
+ * a structural walk rejects payloads providers accept. Decoding is the ground
+ * truth on both sides. Callers on hot paths must cache the verdict.
+ */
+export async function imageDecodeFailureReason(image: ImageContent): Promise<string | null> {
+	const bytes = Buffer.from(image.data, "base64");
+	if (bytes.length === 0) return "empty image data";
+	try {
+		await new Bun.Image(bytes).png().toBase64();
+		return null;
+	} catch (error) {
+		return error instanceof Error ? error.message : String(error);
+	}
+}
+
 interface LoadInMemoryImageInputOptions {
 	image: ImageContent;
 	resolvedPath: string;
@@ -227,6 +265,14 @@ async function loadInMemoryImageInput(options: LoadInMemoryImageInputOptions): P
 	const inputBytes = Buffer.byteLength(options.image.data, "base64");
 	if (inputBytes > options.maxBytes) {
 		throw new ImageInputTooLargeError(inputBytes, options.maxBytes);
+	}
+
+	// Decode before anything else: a payload that cannot be decoded is rejected
+	// by the provider for the whole request, so it must fail here — where the
+	// caller still has a path to act on — instead of entering the transcript.
+	const decodeFailure = await imageDecodeFailureReason(options.image);
+	if (decodeFailure !== null) {
+		throw new InvalidImageDataError(options.resolvedPath, options.image.mimeType, decodeFailure);
 	}
 
 	let outputData = options.image.data;

--- a/packages/coding-agent/src/utils/image-loading.ts
+++ b/packages/coding-agent/src/utils/image-loading.ts
@@ -232,6 +232,14 @@ export class InvalidImageDataError extends Error {
 }
 
 /**
+ * Smallest raster the decode probe terminates into. The decode is the oracle,
+ * so the output size cannot change the verdict — a 1x1 sink keeps the check
+ * from allocating a full-size pixel buffer, a full-size PNG, and a base64
+ * string for a payload that may be up to {@link MAX_IMAGE_INPUT_BYTES}.
+ */
+const DECODE_PROBE_EDGE_PX = 1;
+
+/**
  * Why an image cannot be decoded, or `null` when it decodes.
  *
  * A full decode is the only check that matches what vision backends accept: a
@@ -245,7 +253,10 @@ export async function imageDecodeFailureReason(image: ImageContent): Promise<str
 	const bytes = Buffer.from(image.data, "base64");
 	if (bytes.length === 0) return "empty image data";
 	try {
-		await new Bun.Image(bytes).png().toBase64();
+		// Decode in full (that is what catches a hole in the compressed stream),
+		// then terminate into a 1x1 raster's bytes instead of re-encoding at the
+		// source dimensions and base64-ing a result nobody reads.
+		await new Bun.Image(bytes).resize(DECODE_PROBE_EDGE_PX, DECODE_PROBE_EDGE_PX).png().bytes();
 		return null;
 	} catch (error) {
 		return error instanceof Error ? error.message : String(error);

--- a/packages/coding-agent/test/provider-image-integrity.test.ts
+++ b/packages/coding-agent/test/provider-image-integrity.test.ts
@@ -3,10 +3,19 @@
  * the WHOLE request, not just the offending block, so a single corrupt payload
  * in history leaves a session permanently unable to send anything. The outbound
  * guard must degrade exactly that block to text and leave everything else —
- * including images with unusual-but-decodable framing — byte-identical.
+ * including images with unusual-but-decodable framing, and images whose bytes
+ * never travel because a reference does — byte-identical.
  */
 import { describe, expect, test } from "bun:test";
-import type { Context, ImageContent, ToolResultMessage, UserMessage } from "@oh-my-pi/pi-ai";
+import type {
+	Context,
+	ImageContent,
+	Message,
+	ProviderPayload,
+	TextContent,
+	ToolResultMessage,
+	UserMessage,
+} from "@oh-my-pi/pi-ai";
 import { dropUnreadableContextImages } from "@oh-my-pi/pi-coding-agent/session/provider-image-budget";
 
 /**
@@ -21,43 +30,228 @@ const ODD_FRAMED_PNG = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4
  * written to disk, so the signature, the header and the `IEND` trailer all
  * survive while the compressed stream has a hole in it.
  */
-function middleElidedPng(): string {
+const MIDDLE_ELIDED_PNG = (() => {
 	const whole = Buffer.from(ODD_FRAMED_PNG, "base64");
 	return Buffer.concat([whole.subarray(0, 20), whole.subarray(40)]).toString("base64");
+})();
+
+const INTACT_IMAGE: ImageContent = { type: "image", data: ODD_FRAMED_PNG, mimeType: "image/png" };
+const BROKEN_IMAGE: ImageContent = { type: "image", data: MIDDLE_ELIDED_PNG, mimeType: "image/png" };
+
+function userMessage(content: (TextContent | ImageContent)[], providerPayload?: ProviderPayload): UserMessage {
+	return {
+		role: "user",
+		content,
+		timestamp: 0,
+		...(providerPayload ? { providerPayload } : {}),
+	} satisfies UserMessage;
 }
 
-function userMessage(content: (ImageContent | { type: "text"; text: string })[]): UserMessage {
-	return { role: "user", content, timestamp: 0 } as UserMessage;
+function toolResult(content: (TextContent | ImageContent)[]): ToolResultMessage {
+	return {
+		role: "toolResult",
+		toolCallId: "call_1",
+		toolName: "read",
+		content,
+		isError: false,
+		timestamp: 0,
+	} satisfies ToolResultMessage;
+}
+
+/** Native Responses input item as `parseRequest` records it on `providerPayload`. */
+function nativeImagePayload(imageUrl: string): ProviderPayload {
+	return {
+		type: "openaiResponsesHistory",
+		dt: true,
+		items: [
+			{
+				type: "message",
+				role: "user",
+				content: [
+					{ type: "input_text", text: "what is in this screenshot?" },
+					{ type: "input_image", detail: "auto", image_url: imageUrl },
+				],
+			},
+		],
+	} satisfies ProviderPayload;
+}
+
+function nativeItems(message: Message): unknown[] {
+	if (message.role !== "user" && message.role !== "developer") throw new Error("expected an input message");
+	const payload = message.providerPayload;
+	if (payload?.type !== "openaiResponsesHistory") throw new Error("expected a native history payload");
+	return payload.items;
+}
+
+function nativeContentParts(message: Message): unknown[] {
+	const item = nativeItems(message)[0];
+	if (!item || typeof item !== "object" || !("content" in item)) throw new Error("expected a native content array");
+	const content = item.content;
+	if (!Array.isArray(content)) throw new Error("expected a native content array");
+	return content;
+}
+
+/** Reads a native part's `text` only after confirming it really is an `input_text` part. */
+function nativeTextOf(part: unknown): string {
+	if (!part || typeof part !== "object") throw new Error("expected a native part object");
+	if (!("type" in part) || part.type !== "input_text") throw new Error("expected an input_text part");
+	if (!("text" in part) || typeof part.text !== "string") throw new Error("expected input_text.text");
+	return part.text;
+}
+
+function textOf(part: TextContent | ImageContent | undefined): string {
+	if (part?.type !== "text") throw new Error(`expected a text block, got ${part?.type}`);
+	return part.text;
 }
 
 describe("dropUnreadableContextImages", () => {
 	test("degrades an undecodable image to text and keeps decodable siblings byte-identical", async () => {
-		const broken: ImageContent = { type: "image", data: middleElidedPng(), mimeType: "image/png" };
-		const intact: ImageContent = { type: "image", data: ODD_FRAMED_PNG, mimeType: "image/png" };
-		const toolResult: ToolResultMessage = {
-			role: "toolResult",
-			toolCallId: "call_1",
-			toolName: "read",
-			content: [{ type: "text", text: "Read image file [image/png]" }, broken, intact],
-			timestamp: 0,
-		} as ToolResultMessage;
-		const context: Context = { messages: [userMessage([intact]), toolResult] } as Context;
+		const context: Context = {
+			messages: [
+				userMessage([INTACT_IMAGE]),
+				toolResult([{ type: "text", text: "Read image file [image/png]" }, BROKEN_IMAGE, INTACT_IMAGE]),
+			],
+		};
 
 		const guarded = await dropUnreadableContextImages(context);
 
-		const guardedResult = guarded.messages[1] as ToolResultMessage;
+		const guardedResult = guarded.messages[1];
+		if (guardedResult?.role !== "toolResult") throw new Error("expected a tool result");
 		expect(guardedResult.content[0]).toEqual({ type: "text", text: "Read image file [image/png]" });
-		const omission = guardedResult.content[1];
-		expect(omission.type).toBe("text");
-		expect(omission.type === "text" ? omission.text : "").toContain("image omitted");
-		expect(guardedResult.content[2]).toEqual(intact);
+		expect(textOf(guardedResult.content[1])).toContain("image omitted");
+		expect(guardedResult.content[2]).toEqual(INTACT_IMAGE);
 		// The user turn carried only the decodable image, so it is untouched.
 		expect(guarded.messages[0]).toBe(context.messages[0]);
 	});
 
 	test("returns the original context when every image decodes", async () => {
-		const intact: ImageContent = { type: "image", data: ODD_FRAMED_PNG, mimeType: "image/png" };
-		const context: Context = { messages: [userMessage([{ type: "text", text: "look" }, intact])] } as Context;
+		const context: Context = { messages: [userMessage([{ type: "text", text: "look" }, INTACT_IMAGE])] };
+
+		expect(await dropUnreadableContextImages(context)).toBe(context);
+	});
+
+	/**
+	 * The reviewer's repro. A reference-backed block carries EMPTY `data` on
+	 * purpose — `functionOutputContent()` builds `{ data: "", url }` /
+	 * `{ data: "", providerFile }`, and the lazy snapcompact frame sink builds
+	 * `{ data: "", url }` before this guard even runs. Decoding those bytes yields
+	 * "empty image data" and would delete a perfectly good image.
+	 */
+	test("leaves reference-backed images alone instead of decoding bytes that never travel", async () => {
+		const urlBacked: ImageContent = {
+			type: "image",
+			data: "",
+			mimeType: "image/png",
+			url: "https://blobs.example/sc:deadbeef:0",
+		};
+		const fileBacked: ImageContent = {
+			type: "image",
+			data: "",
+			mimeType: "application/octet-stream",
+			providerFile: { provider: "openai", id: "file-abc123" },
+		};
+		const context: Context = {
+			messages: [userMessage([urlBacked, fileBacked]), toolResult([urlBacked, fileBacked])],
+		};
+
+		const guarded = await dropUnreadableContextImages(context);
+
+		expect(guarded).toBe(context);
+		expect(guarded.messages[0]).toBe(context.messages[0]);
+		expect(guarded.messages[1]).toBe(context.messages[1]);
+	});
+
+	/**
+	 * `inputContentParts()` keeps only text in the generic view, so a native input
+	 * image exists ONLY on `providerPayload` — and `convertConversationMessages()`
+	 * replays that payload in place of the content. An undecodable image there
+	 * must not reach the wire; a decodable one must survive byte-identical.
+	 */
+	test("degrades an undecodable image reachable only through a native replay payload", async () => {
+		const original = userMessage(
+			[{ type: "text", text: "what is in this screenshot?" }],
+			nativeImagePayload(`data:image/png;base64,${MIDDLE_ELIDED_PNG}`),
+		);
+		const context: Context = { messages: [original] };
+
+		const guarded = await dropUnreadableContextImages(context);
+
+		expect(guarded).not.toBe(context);
+		const parts = nativeContentParts(guarded.messages[0]!);
+		// The text part keeps its place and shape.
+		expect(parts[0]).toEqual({ type: "input_text", text: "what is in this screenshot?" });
+		// The image part became the input_text equivalent the schema accepts here.
+		expect(nativeTextOf(parts[1])).toContain("image omitted");
+		// Generic content carried no image, so it is reused as-is.
+		const guardedMessage = guarded.messages[0];
+		if (guardedMessage?.role !== "user") throw new Error("expected a user message");
+		expect(guardedMessage.content).toBe(original.content);
+	});
+
+	test("keeps a decodable native replay payload byte-identical", async () => {
+		const context: Context = {
+			messages: [
+				userMessage(
+					[{ type: "text", text: "what is in this screenshot?" }],
+					nativeImagePayload(`data:image/png;base64,${ODD_FRAMED_PNG}`),
+				),
+			],
+		};
+
+		expect(await dropUnreadableContextImages(context)).toBe(context);
+	});
+
+	/**
+	 * A native `file_id` / https `image_url` in a replayed payload is a reference
+	 * with no local bytes, so it must not be decode-checked either.
+	 */
+	test("leaves reference-backed native replay payloads untouched", async () => {
+		const context: Context = {
+			messages: [userMessage([{ type: "text", text: "look" }], nativeImagePayload("https://cdn.example/shot.png"))],
+		};
+
+		expect(await dropUnreadableContextImages(context)).toBe(context);
+	});
+
+	/**
+	 * A computer screenshot rides on `providerMetadata` and is replayed verbatim
+	 * into `computer_call_output.output`, bypassing generic content entirely.
+	 * `computer_call_output` accepts only a `computer_screenshot` ref, so the
+	 * unreadable one is cleared — the provider layer then falls back to an
+	 * assistant note built from this result's generic content.
+	 */
+	test("clears computer metadata whose screenshot cannot be decoded", async () => {
+		const result: ToolResultMessage = {
+			...toolResult([{ type: "text", text: "clicked at 100,200" }]),
+			toolName: "computer",
+			providerMetadata: {
+				type: "computer",
+				screenshot: { type: "computer_screenshot", image_url: `data:image/png;base64,${MIDDLE_ELIDED_PNG}` },
+				acknowledgedSafetyChecks: [],
+			},
+		};
+		const context: Context = { messages: [result] };
+
+		const guarded = await dropUnreadableContextImages(context);
+
+		const guardedResult = guarded.messages[0];
+		if (guardedResult?.role !== "toolResult") throw new Error("expected a tool result");
+		expect(guardedResult.providerMetadata).toBeUndefined();
+		// The text the fallback note is built from survives untouched.
+		expect(guardedResult.content).toBe(result.content);
+	});
+
+	test("keeps a decodable computer screenshot byte-identical", async () => {
+		const result: ToolResultMessage = {
+			...toolResult([{ type: "text", text: "clicked at 100,200" }]),
+			toolName: "computer",
+			providerMetadata: {
+				type: "computer",
+				screenshot: { type: "computer_screenshot", image_url: `data:image/png;base64,${ODD_FRAMED_PNG}` },
+				acknowledgedSafetyChecks: [],
+			},
+		};
+		const context: Context = { messages: [result] };
 
 		expect(await dropUnreadableContextImages(context)).toBe(context);
 	});

--- a/packages/coding-agent/test/provider-image-integrity.test.ts
+++ b/packages/coding-agent/test/provider-image-integrity.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Regression: an image whose bytes cannot be decoded makes the provider reject
+ * the WHOLE request, not just the offending block, so a single corrupt payload
+ * in history leaves a session permanently unable to send anything. The outbound
+ * guard must degrade exactly that block to text and leave everything else —
+ * including images with unusual-but-decodable framing — byte-identical.
+ */
+import { describe, expect, test } from "bun:test";
+import type { Context, ImageContent, ToolResultMessage, UserMessage } from "@oh-my-pi/pi-ai";
+import { dropUnreadableContextImages } from "@oh-my-pi/pi-coding-agent/session/provider-image-budget";
+
+/**
+ * 1x1 PNG whose chunk framing does not land exactly on `IEND`, yet every
+ * decoder (and every vision backend) accepts it. Pins the guard against a
+ * structural walk that would reject payloads providers happily read.
+ */
+const ODD_FRAMED_PNG = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M8AAAMBAQDJ/pLvAAAAAElFTkSuQmCC";
+
+/**
+ * The incident shape: a base64 payload that was middle-elided before being
+ * written to disk, so the signature, the header and the `IEND` trailer all
+ * survive while the compressed stream has a hole in it.
+ */
+function middleElidedPng(): string {
+	const whole = Buffer.from(ODD_FRAMED_PNG, "base64");
+	return Buffer.concat([whole.subarray(0, 20), whole.subarray(40)]).toString("base64");
+}
+
+function userMessage(content: (ImageContent | { type: "text"; text: string })[]): UserMessage {
+	return { role: "user", content, timestamp: 0 } as UserMessage;
+}
+
+describe("dropUnreadableContextImages", () => {
+	test("degrades an undecodable image to text and keeps decodable siblings byte-identical", async () => {
+		const broken: ImageContent = { type: "image", data: middleElidedPng(), mimeType: "image/png" };
+		const intact: ImageContent = { type: "image", data: ODD_FRAMED_PNG, mimeType: "image/png" };
+		const toolResult: ToolResultMessage = {
+			role: "toolResult",
+			toolCallId: "call_1",
+			toolName: "read",
+			content: [{ type: "text", text: "Read image file [image/png]" }, broken, intact],
+			timestamp: 0,
+		} as ToolResultMessage;
+		const context: Context = { messages: [userMessage([intact]), toolResult] } as Context;
+
+		const guarded = await dropUnreadableContextImages(context);
+
+		const guardedResult = guarded.messages[1] as ToolResultMessage;
+		expect(guardedResult.content[0]).toEqual({ type: "text", text: "Read image file [image/png]" });
+		const omission = guardedResult.content[1];
+		expect(omission.type).toBe("text");
+		expect(omission.type === "text" ? omission.text : "").toContain("image omitted");
+		expect(guardedResult.content[2]).toEqual(intact);
+		// The user turn carried only the decodable image, so it is untouched.
+		expect(guarded.messages[0]).toBe(context.messages[0]);
+	});
+
+	test("returns the original context when every image decodes", async () => {
+		const intact: ImageContent = { type: "image", data: ODD_FRAMED_PNG, mimeType: "image/png" };
+		const context: Context = { messages: [userMessage([{ type: "text", text: "look" }, intact])] } as Context;
+
+		expect(await dropUnreadableContextImages(context)).toBe(context);
+	});
+});


### PR DESCRIPTION
## Problem

A single image whose bytes cannot be decoded makes the provider reject the **entire request**, not just the offending block. Once such an image is in the transcript the session is unusable — every later turn fails, resume fails too, and there is no recovery path short of hand-editing the JSONL.

Real incident (OMP 18.0.9, `openai-codex/gpt-5.6-sol`):

```
Codex error event: The image data you provided does not represent a valid image.
Please check your input and try again. (code=invalid_value)
```

The payload was a screenshot an `eval` cell had written to disk after base64-decoding a middle-elided tool output. The resulting PNG kept its signature, its `IHDR`, six intact `IDAT` chunks and even a well-formed `IEND` trailer — only ~1965 bytes were missing from the middle. `tools/read.ts` ingested it (nothing anywhere validates image bytes), `session-persistence` externalized it to the blob store, and from then on every request died before inference.

Bisected on a copy of the affected session:

| variant | result |
|---|---|
| drop all 17 snapcompact frames, keep tool-result images | still fails |
| keep frames, drop the 3 tool-result images | works |
| send each tool-result image on its own | exactly one is rejected |

This is adjacent to #9901 (persisted snapcompact frames truncated into invalid base64) but distinct: those bytes were corrupted *by* persistence, these arrive corrupt and no layer looks at them. It is also the concrete shape of #3576 — a provider-rejected payload stays in the transcript and poisons every retry.

## Why a decode, and not a structural check

The first version of this patch walked the PNG chunk list to `IEND`. It caught the incident, and it **also rejected images the provider accepts** — `test/issue-3506-repro.test.ts` went 9 pass → 3 pass on the classic 1x1 PNG fixture, whose chunk framing is off by one byte. That fixture was sent to the Codex backend directly and came back accepted.

Decoding is the only oracle that agrees with vision backends on both sides:

| buffer | header sniff | chunk-framing walk | decode | provider |
|---|---|---|---|---|
| 1x1 PNG, odd framing | pass | **reject** | pass | **accepts** |
| middle-elided PNG (the incident) | pass | reject | **fail** | **rejects** |
| tail-truncated PNG | pass | reject | **fail** | — |

So `parseImageMetadata` is not enough (it only reads the header window) and a framing walk is actively wrong. The structural validator was dropped from this PR.

## Change

- **`utils/image-loading.ts`** — `imageDecodeFailureReason(image)` decodes through `Bun.Image` and returns the reason or `null`. `loadInMemoryImageInput` runs it before any resize, so all three loaders (`loadImageInput`, `loadSvgImageInput`, `loadImageAttachmentInput`) are covered by one gate, and a bad payload raises the new `InvalidImageDataError`.
- **`tools/read.ts`** — maps that error to a `ToolError` next to the existing `ImageInputTooLargeError` branch, so the model gets an actionable message instead of a poisoned transcript.
- **`session/provider-image-budget.ts`** — `dropUnreadableContextImages(context)` is the outbound backstop for producers that never touch those loaders (fetch, browser/computer captures, already-persisted history): undecodable blocks degrade to `[image omitted: …]` text. Verdicts are memoized in a 512-entry LRU keyed on the payload hash, so each distinct image is decoded once per process, and a clean context is returned by identity (no allocation on the common path).
- **`sdk.ts`** — called on both outbound pipelines, deliberately **after** `normalizeProviderContextImagesForModel` (the STB-WebP path owns better wording for the case it handles) and **before** `blobBroker.decorateContext` (so corrupt bytes are never uploaded).

Rationale for two gates: ingress gives an error the model can act on at the moment the file is read; the outbound guard is what actually un-wedges a session whose history already contains the payload.

No load-time repair pass was added — the outbound guard already covers resume, and walking every entry of every loaded session would be pure cost for the same outcome.

## Tests

`test/provider-image-integrity.test.ts`, two contracts:

1. An undecodable block is replaced by the omission text while a **decodable sibling in the same tool result survives byte-identical**, and an untouched message is returned by identity. The corrupt fixture is built in the test by cutting a slice out of the middle of a valid PNG — the incident's exact shape, no committed binary.
2. The odd-framed 1x1 PNG is pinned as *accepted*, so a future structural check cannot reintroduce the false positive described above.

## Verification

- `bun --cwd=packages/coding-agent run check:types` clean; `biome check` clean.
- `bun test` on `provider-image-integrity`, `agent-session-message-pipeline`, `issue-3506-repro`, `image-input`: 38 pass / 0 fail.
- Full `packages/coding-agent` suite diffed against a stashed baseline (test names normalized to strip timings): no new failures. The pre-existing failures on this Windows box (symlink `EPERM`, libkitty TUI, git worktree) are identical before and after.
- End-to-end against the real Codex backend, running the CLI from source:
  - `read` on the corrupt PNG → `... is not a decodable image/png image: Image: decode failed`, and the turn continues; `read` on the valid sibling in the same turn → described correctly.
  - A session carrying the corrupt image, which previously failed instantly with `invalid_value`, now completes a turn normally with only the outbound guard in play.