### PR TITLE
fix(ai): complete Perplexity TOTP login

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Perplexity email login for accounts protected by authenticator two-factor authentication.
+
 ## [18.0.9] - 2026-08-28
 
 ### Fixed

--- a/packages/ai/src/registry/oauth/perplexity.ts
+++ b/packages/ai/src/registry/oauth/perplexity.ts
@@ -199,10 +199,11 @@ async function httpEmailLogin(ctrl: OAuthController): Promise<OAuthCredentials> 
 		signal: ctrl.signal,
 	});
 
-	const verifyData = (await verifyResponse.json()) as {
+	let verifyData = (await verifyResponse.json()) as {
 		token?: string;
 		challenge_token?: string;
 		status?: string;
+		error?: string;
 		error_code?: string;
 		text?: string;
 	};
@@ -216,7 +217,52 @@ async function httpEmailLogin(ctrl: OAuthController): Promise<OAuthCredentials> 
 		});
 	}
 
-	const token = verifyData.challenge_token || verifyData.token;
+	if (verifyData.status === "totp_challenge_required" && verifyData.challenge_token) {
+		const totp = await ctrl.onPrompt({
+			message: "Enter the code from your authenticator app",
+			placeholder: "123456",
+		});
+		if (ctrl.signal?.aborted) throw new AIError.LoginCancelledError();
+		const trimmedTotp = totp.trim();
+		if (!trimmedTotp) {
+			throw new AIError.OAuthError("Authenticator code is required", {
+				kind: "validation",
+				provider: "perplexity",
+			});
+		}
+		ctrl.onProgress?.("Verifying authenticator code...");
+		const totpResponse = await request("https://www.perplexity.ai/api/auth/totp/challenge-verify", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				"User-Agent": APP_USER_AGENT,
+				"X-App-ApiVersion": API_VERSION,
+			},
+			body: JSON.stringify({
+				token: verifyData.challenge_token,
+				code: trimmedTotp,
+			}),
+			signal: ctrl.signal,
+		});
+		verifyData = (await totpResponse.json()) as typeof verifyData;
+		if (!totpResponse.ok) {
+			const reason = verifyData.text ?? verifyData.error_code ?? verifyData.status ?? "TOTP verification failed";
+			throw new AIError.OAuthError(`Perplexity authenticator verification failed: ${reason}`, {
+				kind: "validation",
+				provider: "perplexity",
+				status: totpResponse.status,
+			});
+		}
+		if (!verifyData.token) {
+			verifyData = {
+				token:
+					cookies.get("__Secure-next-auth.session-token") ?? cookies.get("next-auth.session-token") ?? undefined,
+				status: "success",
+			};
+		}
+	}
+
+	const token = verifyData.token ?? verifyData.challenge_token;
 	if (!token || verifyData.error_code || (verifyData.status && verifyData.status !== "success")) {
 		const reason = verifyData.text ?? verifyData.error_code ?? verifyData.status ?? "missing token";
 		throw new AIError.OAuthError(`Perplexity OTP verification response rejected: ${reason}`, {

--- a/packages/ai/test/perplexity-login.test.ts
+++ b/packages/ai/test/perplexity-login.test.ts
@@ -70,4 +70,64 @@ describe("Perplexity email OTP login", () => {
 			);
 		},
 	);
+
+	it("completes an authenticator challenge after email OTP verification", async () => {
+		vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("Unexpected global fetch"));
+		const requests: Array<CapturedRequest & { body: unknown }> = [];
+		const fetchMock: FetchImpl = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+			const url = new URL(input instanceof Request ? input.url : input.toString());
+			requests.push({
+				path: url.pathname,
+				cookie: new Headers(init?.headers).get("Cookie"),
+				body: init?.body ? JSON.parse(init.body.toString()) : undefined,
+			});
+
+			if (url.pathname.endsWith("/csrf")) {
+				return new Response(JSON.stringify({ csrfToken: "csrf-token" }), {
+					status: 200,
+					headers: {
+						"Content-Type": "application/json",
+						"Set-Cookie": "next-auth.csrf-token=csrf-cookie; Path=/; HttpOnly; Secure",
+					},
+				});
+			}
+			if (url.pathname.endsWith("/signin-email")) return new Response("{}", { status: 200 });
+			if (requests.length === 3) {
+				return new Response(
+					JSON.stringify({ challenge_token: "perplexity-challenge", status: "totp_challenge_required" }),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				);
+			}
+			if (url.pathname.endsWith("/totp/challenge-verify")) {
+				return new Response(JSON.stringify({ redirect_url: "https://www.perplexity.ai/" }), {
+					status: 200,
+					headers: {
+						"Content-Type": "application/json",
+						"Set-Cookie": "next-auth.session-token=session-cookie; Path=/; HttpOnly; Secure",
+					},
+				});
+			}
+			throw new Error(`Unexpected request: ${url.pathname}`);
+		});
+		const answers = ["user@example.com", "123456", "654321"];
+
+		await withEnv({ PI_AUTH_NO_BORROW: "1" }, async () => {
+			const credentials = await loginPerplexity({
+				fetch: fetchMock,
+				onPrompt: async () => answers.shift() ?? "",
+			});
+			expect(credentials.access).toBe("session-cookie");
+		});
+		expect(requests.map(request => request.path)).toEqual([
+			"/api/auth/csrf",
+			"/api/auth/signin-email",
+			"/api/auth/signin-otp",
+			"/api/auth/totp/challenge-verify",
+		]);
+		expect(requests[3]?.body).toEqual({
+			token: "perplexity-challenge",
+			code: "654321",
+		});
+		expect(requests[3]?.cookie).toBe("next-auth.csrf-token=csrf-cookie");
+	});
 });


### PR DESCRIPTION
## Problem

Perplexity accounts with authenticator two-factor authentication still cannot complete email login. After the email OTP, Perplexity returns `totp_challenge_required`; OMP treated its `challenge_token` as a final session credential.

## Fix

- Prompt for the authenticator or backup code when Perplexity requires TOTP.
- Submit the challenge through Perplexity's current `/api/auth/totp/challenge-verify` endpoint.
- Preserve auth cookies and persist the session cookie issued after successful verification.
- Keep cancellation semantics and legacy non-TOTP token responses unchanged.
- Add complete regression coverage for email OTP, TOTP, cookie replay, and session credential persistence.

## Verification

- Live login with a TOTP-protected Perplexity account completed and saved credentials.
- `bun test packages/ai/test/perplexity-login.test.ts`: 3 passed.
- `bun --cwd=packages/ai run check`: passed.
- `bun run check`: passed.
- `cargo build --workspace`: passed.
- Full workspace suite: 24,314 passed, 695 skipped, 52 todo; 15 unrelated failures and 2 unrelated errors remain.
