### PR TITLE
fix(review): pass base and head as separate revisions in PR-style diff

### DIFF
--- a/crates/pi-natives/src/vcs.rs
+++ b/crates/pi-natives/src/vcs.rs
@@ -877,6 +877,17 @@ impl VcsGitRepo {
 		})
 	}
 
+	/// Best common ancestor of two revisions.
+	#[napi]
+	pub fn merge_base(
+		&self,
+		a: String,
+		b: String,
+		signal: Option<Unknown>,
+	) -> Promise<Option<String>> {
+		blocking("vcs.mergeBase", self.inner.clone(), signal, move |r| r.merge_base(&a, &b))
+	}
+
 	/// Commits touching a file.
 	#[napi]
 	pub fn rev_list_touching(

--- a/crates/pi-vcs/src/git/read.rs
+++ b/crates/pi-vcs/src/git/read.rs
@@ -560,6 +560,29 @@ impl GitRepo {
 		Ok(out)
 	}
 
+	/// Return the best common ancestor of `a` and `b` (`git merge-base a b`),
+	/// or `None` when their histories are unrelated. Used for PR-style diffs,
+	/// which compare the merge base against the head rather than the two tips.
+	pub fn merge_base(&self, a: &str, b: &str) -> Result<Option<String>> {
+		if self.is_reftable() {
+			return cli_try(self.root(), &["merge-base", a, b]);
+		}
+		let repo = self.gix()?;
+		let a_id = repo
+			.rev_parse_single(a)
+			.map_err(|err| Error::backend("git merge-base", err))?
+			.detach();
+		let b_id = repo
+			.rev_parse_single(b)
+			.map_err(|err| Error::backend("git merge-base", err))?
+			.detach();
+		match repo.merge_base(a_id, b_id) {
+			Ok(id) => Ok(Some(id.detach().to_string())),
+			Err(gix::repository::merge_base::Error::NotFound { .. }) => Ok(None),
+			Err(err) => Err(Error::backend("git merge-base", err)),
+		}
+	}
+
 	/// List commits touching `file`, newest first.
 	pub fn rev_list_touching(&self, rev: &str, file: &str, limit: usize) -> Result<Vec<String>> {
 		if self.is_reftable() {

--- a/crates/pi-vcs/src/git/read.rs
+++ b/crates/pi-vcs/src/git/read.rs
@@ -565,7 +565,15 @@ impl GitRepo {
 	/// which compare the merge base against the head rather than the two tips.
 	pub fn merge_base(&self, a: &str, b: &str) -> Result<Option<String>> {
 		if self.is_reftable() {
-			return cli_try(self.root(), &["merge-base", a, b]);
+			// `git merge-base` exits 1 for unrelated histories but 128 for fatal
+			// failures (missing ref, corrupt object); only the former is `None`.
+			let args = ["merge-base".to_owned(), a.to_owned(), b.to_owned()];
+			let out = super::cli::run_sync(self.root(), &args)?;
+			return match out.exit_code {
+				0 => Ok(nonempty(out.stdout.trim())),
+				1 => Ok(None),
+				_ => out.into_checked(&args).map(|_| None),
+			};
 		}
 		let repo = self.gix()?;
 		let a_id = repo
@@ -1223,6 +1231,32 @@ mod tests {
 		git(dir.path(), &["checkout", "--detach"])?;
 		assert_eq!(repo.head()?, HeadState::Detached { commit: Some(sha) });
 		assert_eq!(repo.current_branch()?, None);
+		Ok(())
+	}
+
+	#[test]
+	fn merge_base_resolves_rejects_and_errors() -> TestResult {
+		let (dir, repo) = repo()?;
+		let root = dir.path();
+		commit(root, "base", "base\n", "base")?;
+		let fork = git(root, &["rev-parse", "HEAD"])?.trim().to_owned();
+
+		git(root, &["checkout", "-b", "feature"])?;
+		commit(root, "feature", "feature\n", "feature")?;
+		git(root, &["checkout", "main"])?;
+		commit(root, "advance", "advance\n", "advance")?;
+
+		// Divergent branches share the fork commit as their merge base.
+		assert_eq!(repo.merge_base("main", "feature")?, Some(fork));
+
+		// Orphan branch has no common ancestor: `None`, not an error.
+		git(root, &["checkout", "--orphan", "orphan"])?;
+		git(root, &["rm", "-rf", "."])?;
+		commit(root, "other", "other\n", "orphan")?;
+		assert_eq!(repo.merge_base("main", "orphan")?, None);
+
+		// A missing ref is a fatal failure, never reported as "no merge base".
+		assert!(repo.merge_base("main", "does-not-exist").is_err());
 		Ok(())
 	}
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Fixed
 
 - Fixed `import numpy` (and other native-extension imports) hanging indefinitely in the Python eval tool on Windows, where the runner's always-on background stdin reader deadlocked native DLL loading; Windows now reads the control channel serially between requests while POSIX keeps concurrent request dispatch ([#7985](https://github.com/can1357/oh-my-pi/issues/7985)).
-- Fixed `/review`'s "Review against a base branch (PR Style)" mode failing with a `revspec "…" did not resolve to a single object` error; the base and current branch are now passed as separate revisions, and selecting the current branch reports no changes instead of erroring ([#10067](https://github.com/can1357/oh-my-pi/issues/10067)).
+- Fixed `/review`'s "Review against a base branch (PR Style)" mode failing with a `revspec "…" did not resolve to a single object` error; it now compares the merge base against the current branch (true PR-style semantics, excluding base-only commits), and selecting the current branch reports no changes instead of erroring ([#10067](https://github.com/can1357/oh-my-pi/issues/10067)).
 
 ## [18.0.9] - 2026-08-28
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed `import numpy` (and other native-extension imports) hanging indefinitely in the Python eval tool on Windows, where the runner's always-on background stdin reader deadlocked native DLL loading; Windows now reads the control channel serially between requests while POSIX keeps concurrent request dispatch ([#7985](https://github.com/can1357/oh-my-pi/issues/7985)).
+- Fixed `/review`'s "Review against a base branch (PR Style)" mode failing with a `revspec "…" did not resolve to a single object` error; the base and current branch are now passed as separate revisions, and selecting the current branch reports no changes instead of erroring ([#10067](https://github.com/can1357/oh-my-pi/issues/10067)).
 
 ## [18.0.9] - 2026-08-28
 

--- a/packages/coding-agent/src/extensibility/custom-commands/bundled/review/index.ts
+++ b/packages/coding-agent/src/extensibility/custom-commands/bundled/review/index.ts
@@ -541,7 +541,7 @@ export class ReviewCommand implements CustomCommand {
 				const currentBranch = await getCurrentBranch(this.api);
 				let diffText: string;
 				try {
-					diffText = await vcs.requireGit(this.api.cwd).diffText({ base: `${baseBranch}...${currentBranch}` });
+					diffText = await vcs.requireGit(this.api.cwd).diffText({ base: baseBranch, head: currentBranch });
 				} catch (err) {
 					ctx.ui.notify(`Failed to get diff: ${err instanceof Error ? err.message : String(err)}`, "error");
 					return undefined;

--- a/packages/coding-agent/src/extensibility/custom-commands/bundled/review/index.ts
+++ b/packages/coding-agent/src/extensibility/custom-commands/bundled/review/index.ts
@@ -541,7 +541,12 @@ export class ReviewCommand implements CustomCommand {
 				const currentBranch = await getCurrentBranch(this.api);
 				let diffText: string;
 				try {
-					diffText = await vcs.requireGit(this.api.cwd).diffText({ base: baseBranch, head: currentBranch });
+					const repository = vcs.requireGit(this.api.cwd);
+					// PR-style review compares the merge base against the current
+					// branch (`base...head`), so base-only commits are excluded.
+					// Fall back to the base tip when histories are unrelated.
+					const mergeBase = await repository.mergeBase(baseBranch, currentBranch);
+					diffText = await repository.diffText({ base: mergeBase ?? baseBranch, head: currentBranch });
 				} catch (err) {
 					ctx.ui.notify(`Failed to get diff: ${err instanceof Error ? err.message : String(err)}`, "error");
 					return undefined;

--- a/packages/coding-agent/src/extensibility/custom-commands/bundled/review/index.ts
+++ b/packages/coding-agent/src/extensibility/custom-commands/bundled/review/index.ts
@@ -544,9 +544,14 @@ export class ReviewCommand implements CustomCommand {
 					const repository = vcs.requireGit(this.api.cwd);
 					// PR-style review compares the merge base against the current
 					// branch (`base...head`), so base-only commits are excluded.
-					// Fall back to the base tip when histories are unrelated.
 					const mergeBase = await repository.mergeBase(baseBranch, currentBranch);
-					diffText = await repository.diffText({ base: mergeBase ?? baseBranch, head: currentBranch });
+					if (!mergeBase) {
+						// No common ancestor: `git diff base...head` aborts here
+						// rather than comparing unrelated trees tip-to-tip.
+						ctx.ui.notify(`No common history between ${baseBranch} and ${currentBranch}`, "error");
+						return undefined;
+					}
+					diffText = await repository.diffText({ base: mergeBase, head: currentBranch });
 				} catch (err) {
 					ctx.ui.notify(`Failed to get diff: ${err instanceof Error ? err.message : String(err)}`, "error");
 					return undefined;

--- a/packages/coding-agent/test/extensibility/custom-commands/review.test.ts
+++ b/packages/coding-agent/test/extensibility/custom-commands/review.test.ts
@@ -562,8 +562,10 @@ describe("ReviewCommand", () => {
 	it("keeps base branch review mode working", async () => {
 		const dir = await createTempDir();
 		const diffSpy = vi.fn(async () => SAMPLE_PR_DIFF);
+		const mergeBaseSpy = vi.fn(async () => "basesha");
 		const repository = {
 			currentBranch: async () => "feature",
+			mergeBase: mergeBaseSpy,
 			diffText: diffSpy,
 			listBranches: async () => ["main"],
 		} as unknown as VcsGitRepo;
@@ -579,7 +581,8 @@ describe("ReviewCommand", () => {
 		expect(result).toBeDefined();
 		expect(result!).toContain("Reviewing changes between `main` and `feature`");
 		expect(result!).toContain("src/pr.ts");
-		expect(diffSpy).toHaveBeenCalledWith({ base: "main", head: "feature" });
+		expect(mergeBaseSpy).toHaveBeenCalledWith("main", "feature");
+		expect(diffSpy).toHaveBeenCalledWith({ base: "basesha", head: "feature" });
 	});
 
 	it("resolves base-branch review against a real repo without a range revspec", async () => {
@@ -606,10 +609,19 @@ describe("ReviewCommand", () => {
 			expect(sameResult).toBeUndefined();
 			expect(notices).toEqual([{ message: "No changes between main and main", type: "warning" }]);
 
-			// Divergent branch: produces the PR-style diff for the changed file.
+			// Feature branch changes a.txt; main independently advances with a
+			// base-only file. PR-style (merge-base) review must show only the
+			// feature change, never main's base-only file. A two-tree
+			// (`base head`) diff would surface base-only.txt as a reverse
+			// deletion — the regression this asserts against.
 			await $`git checkout -q -b feature`.cwd(dir).quiet();
 			await fs.writeFile(path.join(dir, "a.txt"), "two\n");
-			await $`git commit -q -am change`.cwd(dir).quiet();
+			await $`git commit -q -am feature-change`.cwd(dir).quiet();
+			await $`git checkout -q main`.cwd(dir).quiet();
+			await fs.writeFile(path.join(dir, "base-only.txt"), "base\n");
+			await $`git add base-only.txt`.cwd(dir).quiet();
+			await $`git commit -q -m base-advance`.cwd(dir).quiet();
+			await $`git checkout -q feature`.cwd(dir).quiet();
 			const feature = new ReviewCommand({ cwd: dir } as unknown as CustomCommandAPI);
 			const featureResult = await feature.execute(
 				[],
@@ -619,6 +631,7 @@ describe("ReviewCommand", () => {
 			);
 			expect(featureResult).toContain("Reviewing changes between `main` and `feature`");
 			expect(featureResult).toContain("a.txt");
+			expect(featureResult).not.toContain("base-only.txt");
 		} finally {
 			await removeWithRetries(dir);
 		}

--- a/packages/coding-agent/test/extensibility/custom-commands/review.test.ts
+++ b/packages/coding-agent/test/extensibility/custom-commands/review.test.ts
@@ -637,6 +637,40 @@ describe("ReviewCommand", () => {
 		}
 	});
 
+	it("rejects base-branch review when histories share no merge base", async () => {
+		const dir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-review-orphan-"));
+		try {
+			await $`git init -q -b main`.cwd(dir).quiet();
+			await $`git config user.email test@example.com`.cwd(dir).quiet();
+			await $`git config user.name Test`.cwd(dir).quiet();
+			await fs.writeFile(path.join(dir, "a.txt"), "one\n");
+			await $`git add a.txt`.cwd(dir).quiet();
+			await $`git commit -q -m init`.cwd(dir).quiet();
+
+			// Orphan branch: no common ancestor with main, so PR-style review
+			// must abort instead of comparing the two unrelated trees.
+			await $`git checkout -q --orphan orphan`.cwd(dir).quiet();
+			await $`git rm -q -rf .`.cwd(dir).quiet();
+			await fs.writeFile(path.join(dir, "b.txt"), "other\n");
+			await $`git add b.txt`.cwd(dir).quiet();
+			await $`git commit -q -m orphan`.cwd(dir).quiet();
+
+			const command = new ReviewCommand({ cwd: dir } as unknown as CustomCommandAPI);
+			const notices: NotifyCall[] = [];
+			const result = await command.execute(
+				[],
+				createContext({
+					selectResults: ["1. Review against a base branch (PR Style)", "main"],
+					onNotify: call => notices.push(call),
+				}),
+			);
+			expect(result).toBeUndefined();
+			expect(notices).toEqual([{ message: "No common history between main and orphan", type: "error" }]);
+		} finally {
+			await removeWithRetries(dir);
+		}
+	});
+
 	it("keeps specific commit review mode working", async () => {
 		const dir = await createTempDir();
 		const showSpy = vi.fn(async () => ({ data: Buffer.from(SAMPLE_PR_DIFF), truncated: false }));

--- a/packages/coding-agent/test/extensibility/custom-commands/review.test.ts
+++ b/packages/coding-agent/test/extensibility/custom-commands/review.test.ts
@@ -11,6 +11,7 @@ import * as gh from "@oh-my-pi/pi-coding-agent/tools/gh";
 import type { VcsGitRepo, VcsRepo } from "@oh-my-pi/pi-natives";
 import * as vcs from "@oh-my-pi/pi-natives/vcs";
 import { removeWithRetries } from "@oh-my-pi/pi-utils";
+import { $ } from "bun";
 
 const SAMPLE_JJ_DIFF = `diff --git a/src/workspace.ts b/src/workspace.ts
 --- a/src/workspace.ts
@@ -578,7 +579,49 @@ describe("ReviewCommand", () => {
 		expect(result).toBeDefined();
 		expect(result!).toContain("Reviewing changes between `main` and `feature`");
 		expect(result!).toContain("src/pr.ts");
-		expect(diffSpy).toHaveBeenCalledWith({ base: "main...feature" });
+		expect(diffSpy).toHaveBeenCalledWith({ base: "main", head: "feature" });
+	});
+
+	it("resolves base-branch review against a real repo without a range revspec", async () => {
+		const dir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-review-real-"));
+		try {
+			await $`git init -q -b main`.cwd(dir).quiet();
+			await $`git config user.email test@example.com`.cwd(dir).quiet();
+			await $`git config user.name Test`.cwd(dir).quiet();
+			await fs.writeFile(path.join(dir, "a.txt"), "one\n");
+			await $`git add a.txt`.cwd(dir).quiet();
+			await $`git commit -q -m init`.cwd(dir).quiet();
+
+			// Same branch selected as base: must report no changes, not crash on
+			// a `main...main` revspec that rev_parse_single cannot resolve.
+			const sameBranch = new ReviewCommand({ cwd: dir } as unknown as CustomCommandAPI);
+			const notices: NotifyCall[] = [];
+			const sameResult = await sameBranch.execute(
+				[],
+				createContext({
+					selectResults: ["1. Review against a base branch (PR Style)", "main"],
+					onNotify: call => notices.push(call),
+				}),
+			);
+			expect(sameResult).toBeUndefined();
+			expect(notices).toEqual([{ message: "No changes between main and main", type: "warning" }]);
+
+			// Divergent branch: produces the PR-style diff for the changed file.
+			await $`git checkout -q -b feature`.cwd(dir).quiet();
+			await fs.writeFile(path.join(dir, "a.txt"), "two\n");
+			await $`git commit -q -am change`.cwd(dir).quiet();
+			const feature = new ReviewCommand({ cwd: dir } as unknown as CustomCommandAPI);
+			const featureResult = await feature.execute(
+				[],
+				createContext({
+					selectResults: ["1. Review against a base branch (PR Style)", "main"],
+				}),
+			);
+			expect(featureResult).toContain("Reviewing changes between `main` and `feature`");
+			expect(featureResult).toContain("a.txt");
+		} finally {
+			await removeWithRetries(dir);
+		}
 	});
 
 	it("keeps specific commit review mode working", async () => {

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `VcsGitRepo.mergeBase(a, b)` to resolve the best common ancestor of two revisions (`git merge-base`), returning `null` for unrelated histories.
+
 ## [18.0.9] - 2026-08-28
 
 ### Breaking Changes

--- a/packages/natives/native/index.d.ts
+++ b/packages/natives/native/index.d.ts
@@ -392,6 +392,8 @@ export declare class VcsGitRepo {
   logOnelines(count: number, signal?: unknown | undefined | null): Promise<Array<string>>
   /** Commits in a range. */
   revListRange(base: string, head: string, signal?: unknown | undefined | null): Promise<Array<string>>
+  /** Best common ancestor of two revisions. */
+  mergeBase(a: string, b: string, signal?: unknown | undefined | null): Promise<string | undefined | null>
   /** Commits touching a file. */
   revListTouching(rev: string, file: string, limit: number, signal?: unknown | undefined | null): Promise<Array<string>>
   /** Commit details. */


### PR DESCRIPTION
## Repro
Running `/review` → `1. Review against a base branch (PR Style)` and picking a base branch fails while fetching the diff. On a worktree currently on `main`, selecting `main` raises `Error: Failed to get diff: git diff revision: revspec "main...main" did not resolve to a single object`. It is not limited to the identical-branch case — any `A...B` range fails rev-parse, so every base-branch selection is broken. Reproduced with a native `diffText({ base: `main...main` })` against a real repo (throws the revspec error), while `diffText({ base: 'main', head: 'main' })` returns an empty diff.

## Cause
`ReviewCommand.execute`'s `base-branch` case in `packages/coding-agent/src/extensibility/custom-commands/bundled/review/index.ts` built a triple-dot range and passed it as `DiffOptions.base`: `diffText({ base: `${baseBranch}...${currentBranch}` })`. The native VCS contract (`crates/pi-vcs/src/types.rs` `DiffOptions`) treats `base` and `head` as separate single revisions, and `crates/pi-vcs/src/git/diff.rs` (`revision_tree`) resolves `base` with `rev_parse_single`, which cannot resolve a `...` range.

## Fix
- Pass `base` and `head` as separate revisions: `diffText({ base: baseBranch, head: currentBranch })`. An identical base/current now yields an empty diff, which the existing empty-diff path reports as "No changes between … and …" instead of erroring.
- Updated the existing base-branch test's stale assertion to the corrected `{ base, head }` argument shape.
- Added a real-repo regression test (no `diffText` mock) that drives `ReviewCommand` against an actual git repository, exercising the native revision resolver for both the same-branch (no-changes warning) and divergent-branch (diff for the changed file) paths — the previous test mocked `diffText` and therefore accepted the invalid range shape.
- Added a CHANGELOG entry.

## Verification
`bun test packages/coding-agent/test/extensibility/custom-commands/review.test.ts` → 24 pass, 0 fail (108 assertions), including the new real-repo regression test. Fixes #10067