### PR TITLE
feat(collab-web): added scroll-to-current pill on the guest transcript

### DIFF
--- a/packages/collab-web/CHANGELOG.md
+++ b/packages/collab-web/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Collab guest transcript shows a centered Scroll to current pill after scrolling up more than one viewport, jumping to the tail and resuming follow.
+
 ## [18.0.8] - 2026-08-27
 
 ### Added

--- a/packages/collab-web/src/components/transcript/Transcript.tsx
+++ b/packages/collab-web/src/components/transcript/Transcript.tsx
@@ -1,5 +1,5 @@
 import type { AssistantMessage, ImageContent, SessionEntry, TextContent, ToolResultMessage } from "@oh-my-pi/pi-wire";
-import { ChevronRight } from "lucide-react";
+import { ChevronRight, ChevronsDown } from "lucide-react";
 import type { ReactNode } from "react";
 import { memo, useEffect, useMemo, useRef, useState } from "react";
 import type { ActiveTool } from "../../lib/client";
@@ -7,6 +7,7 @@ import { fmtTokens } from "../../lib/format";
 import type { ToolRenderHost } from "../../tool-render";
 import { Markdown } from "./Markdown";
 import { ToolCard } from "./ToolCard";
+import { useTranscriptScroll } from "./use-transcript-scroll";
 import "./transcript.css";
 
 export interface TranscriptProps {
@@ -238,6 +239,49 @@ const EntryRow = memo(function EntryRow({ entry, results, active, host }: EntryR
 	}
 }, entryRowEqual);
 
+function JumpPill({ visible, onJump }: { visible: boolean; onJump: () => void }): ReactNode {
+	const skipExit = useRef(false);
+	const [mounted, setMounted] = useState(visible);
+	const [leaving, setLeaving] = useState(false);
+
+	useEffect(() => {
+		if (visible) {
+			skipExit.current = false;
+			setMounted(true);
+			setLeaving(false);
+			return;
+		}
+		if (skipExit.current || window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+			skipExit.current = false;
+			setMounted(false);
+			setLeaving(false);
+			return;
+		}
+		setLeaving(true);
+	}, [visible]);
+
+	if (!mounted) return null;
+
+	return (
+		<button
+			type="button"
+			className={`tr-jump${leaving ? " tr-jump--out" : ""}`}
+			onClick={() => {
+				skipExit.current = true;
+				onJump();
+			}}
+			onAnimationEnd={() => {
+				if (!leaving) return;
+				setMounted(false);
+				setLeaving(false);
+			}}
+		>
+			<ChevronsDown size={15} aria-hidden />
+			Scroll to current
+		</button>
+	);
+}
+
 export function Transcript(props: TranscriptProps): ReactNode {
 	const { entries, stream, streamDone, activeTools, working, compact, host } = props;
 
@@ -251,16 +295,15 @@ export function Transcript(props: TranscriptProps): ReactNode {
 		return map;
 	}, [entries]);
 
-	const rootRef = useRef<HTMLDivElement | null>(null);
-	const lockRef = useRef(true);
+	const isCompact = compact === true;
+	const { rootRef, showJump, onScroll, jumpToBottom } = useTranscriptScroll(
+		!isCompact,
+		entries,
+		stream,
+		activeTools,
+		working,
+	);
 
-	// Follow the tail while bottom-locked; releasing/re-arming happens in onScroll.
-	useEffect(() => {
-		const el = rootRef.current;
-		if (el !== null && lockRef.current) el.scrollTop = el.scrollHeight;
-	}, [entries, stream, activeTools, working]);
-
-	// Active tools not already represented as toolCall blocks in committed rows or the stream ghost.
 	const renderedToolIds = new Set<string>();
 	for (const entry of entries) {
 		if (entry.type !== "message" || entry.message.role !== "assistant") continue;
@@ -278,16 +321,13 @@ export function Transcript(props: TranscriptProps): ReactNode {
 		if (!renderedToolIds.has(tool.toolCallId)) tailTools.push(tool);
 	}
 
-	return (
+	const scroller = (
 		<div
 			ref={rootRef}
-			className={`tr-root${compact === true ? " tr-root--compact" : ""}`}
-			onScroll={() => {
-				const el = rootRef.current;
-				if (el !== null) {
-					lockRef.current = el.scrollHeight - el.scrollTop - el.clientHeight <= 40;
-				}
-			}}
+			className={`tr-root${isCompact ? " tr-root--compact" : ""}`}
+			tabIndex={isCompact ? undefined : -1}
+			aria-label={isCompact ? undefined : "Transcript"}
+			onScroll={onScroll}
 		>
 			{entries.length === 0 && stream === null && !working && <div className="tr-empty">no activity yet</div>}
 			{entries.map(entry => (
@@ -325,6 +365,15 @@ export function Transcript(props: TranscriptProps): ReactNode {
 					<div className="tr-shimmer">thinking…</div>
 				</Row>
 			)}
+		</div>
+	);
+
+	if (isCompact) return scroller;
+
+	return (
+		<div className="tr-shell">
+			{scroller}
+			<JumpPill visible={showJump} onJump={jumpToBottom} />
 		</div>
 	);
 }

--- a/packages/collab-web/src/components/transcript/Transcript.tsx
+++ b/packages/collab-web/src/components/transcript/Transcript.tsx
@@ -296,7 +296,7 @@ export function Transcript(props: TranscriptProps): ReactNode {
 	}, [entries]);
 
 	const isCompact = compact === true;
-	const { rootRef, showJump, onScroll, jumpToBottom } = useTranscriptScroll(
+	const { rootRef, contentRef, showJump, onScroll, jumpToBottom } = useTranscriptScroll(
 		!isCompact,
 		entries,
 		stream,
@@ -329,42 +329,44 @@ export function Transcript(props: TranscriptProps): ReactNode {
 			aria-label={isCompact ? undefined : "Transcript"}
 			onScroll={onScroll}
 		>
-			{entries.length === 0 && stream === null && !working && <div className="tr-empty">no activity yet</div>}
-			{entries.map(entry => (
-				<EntryRow key={entry.id} entry={entry} results={results} active={activeTools} host={host} />
-			))}
-			{stream !== null && (
-				<Row kind="assistant" gutter="agent">
-					<AssistantBody
-						message={stream}
-						results={results}
-						active={activeTools}
-						pending={!streamDone}
-						host={host}
-					/>
-				</Row>
-			)}
-			{tailTools.length > 0 && (
-				<Row kind="assistant" gutter={stream === null ? "agent" : ""}>
-					{tailTools.map(tool => (
-						<ToolCard
-							key={tool.toolCallId}
-							toolCallId={tool.toolCallId}
-							name={tool.toolName}
-							intent={tool.intent}
-							args={tool.args}
-							running
-							partialResult={tool.partialResult}
+			<div ref={contentRef} className="tr-content">
+				{entries.length === 0 && stream === null && !working && <div className="tr-empty">no activity yet</div>}
+				{entries.map(entry => (
+					<EntryRow key={entry.id} entry={entry} results={results} active={activeTools} host={host} />
+				))}
+				{stream !== null && (
+					<Row kind="assistant" gutter="agent">
+						<AssistantBody
+							message={stream}
+							results={results}
+							active={activeTools}
+							pending={!streamDone}
 							host={host}
 						/>
-					))}
-				</Row>
-			)}
-			{working && stream === null && activeTools.size === 0 && (
-				<Row kind="assistant" gutter="agent">
-					<div className="tr-shimmer">thinking…</div>
-				</Row>
-			)}
+					</Row>
+				)}
+				{tailTools.length > 0 && (
+					<Row kind="assistant" gutter={stream === null ? "agent" : ""}>
+						{tailTools.map(tool => (
+							<ToolCard
+								key={tool.toolCallId}
+								toolCallId={tool.toolCallId}
+								name={tool.toolName}
+								intent={tool.intent}
+								args={tool.args}
+								running
+								partialResult={tool.partialResult}
+								host={host}
+							/>
+						))}
+					</Row>
+				)}
+				{working && stream === null && activeTools.size === 0 && (
+					<Row kind="assistant" gutter="agent">
+						<div className="tr-shimmer">thinking…</div>
+					</Row>
+				)}
+			</div>
 		</div>
 	);
 

--- a/packages/collab-web/src/components/transcript/transcript.css
+++ b/packages/collab-web/src/components/transcript/transcript.css
@@ -11,6 +11,40 @@
 	color: var(--fg);
 }
 
+.tr-shell {
+	position: relative;
+	height: 100%;
+	min-height: 0;
+}
+
+.tr-jump {
+	position: absolute;
+	z-index: 1;
+	left: 50%;
+	bottom: 14px;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	gap: 5px;
+	min-height: 36px;
+	padding: 6px 12px;
+	transform: translateX(-50%);
+	border: 1px solid var(--border);
+	border-radius: 999px;
+	background: var(--bg-raised);
+	box-shadow: var(--shadow-overlay);
+	color: var(--fg);
+	font-family: var(--font-ui);
+	font-size: 12px;
+	font-weight: 500;
+	line-height: 1.2;
+	animation: tr-jump-in 150ms ease-out;
+}
+
+.tr-jump--out {
+	animation: tr-jump-out 120ms ease-out forwards;
+}
+
 .tr-empty {
 	padding: 24px 0;
 	text-align: center;
@@ -419,6 +453,31 @@
 	}
 	50% {
 		opacity: 1;
+	}
+}
+
+@keyframes tr-jump-in {
+	from {
+		opacity: 0;
+	}
+	to {
+		opacity: 1;
+	}
+}
+
+@keyframes tr-jump-out {
+	from {
+		opacity: 1;
+	}
+	to {
+		opacity: 0;
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.tr-jump,
+	.tr-jump--out {
+		animation: none;
 	}
 }
 

--- a/packages/collab-web/src/components/transcript/use-transcript-scroll.ts
+++ b/packages/collab-web/src/components/transcript/use-transcript-scroll.ts
@@ -47,11 +47,13 @@ export function useTranscriptScroll(
 	working: unknown,
 ): {
 	rootRef: RefObject<HTMLDivElement | null>;
+	contentRef: RefObject<HTMLDivElement | null>;
 	showJump: boolean;
 	onScroll: () => void;
 	jumpToBottom: () => void;
 } {
 	const rootRef = useRef<HTMLDivElement | null>(null);
+	const contentRef = useRef<HTMLDivElement | null>(null);
 	const lockRef = useRef(true);
 	const [showJump, setShowJump] = useState(false);
 
@@ -90,7 +92,12 @@ export function useTranscriptScroll(
 		const el = rootRef.current;
 		if (el === null) return;
 		const ro = new ResizeObserver(onResize);
+		// Scroller box: viewport resizes (mobile keyboard). Content wrapper:
+		// scrollHeight growth without new entries (tool card expansion, image
+		// decode) changes no box the scroller observer would see.
 		ro.observe(el);
+		const content = contentRef.current;
+		if (content !== null) ro.observe(content);
 		return () => {
 			ro.disconnect();
 		};
@@ -103,5 +110,5 @@ export function useTranscriptScroll(
 		el.focus();
 	}, [applyDecision]);
 
-	return { rootRef, showJump, onScroll, jumpToBottom };
+	return { rootRef, contentRef, showJump, onScroll, jumpToBottom };
 }

--- a/packages/collab-web/src/components/transcript/use-transcript-scroll.ts
+++ b/packages/collab-web/src/components/transcript/use-transcript-scroll.ts
@@ -1,0 +1,62 @@
+import { type RefObject, useCallback, useEffect, useRef, useState } from "react";
+
+export const FOLLOW_LOCK_PX = 40;
+
+/** True when the transcript tail is more than one viewport below the current view. */
+export function jumpVisible(gap: number, view: number): boolean {
+	return gap > view;
+}
+
+export function useTranscriptScroll(
+	jumpEnabled: boolean,
+	entries: unknown,
+	stream: unknown,
+	activeTools: unknown,
+	working: unknown,
+): {
+	rootRef: RefObject<HTMLDivElement | null>;
+	showJump: boolean;
+	onScroll: () => void;
+	jumpToBottom: () => void;
+} {
+	const rootRef = useRef<HTMLDivElement | null>(null);
+	const lockRef = useRef(true);
+	const [showJump, setShowJump] = useState(false);
+
+	const syncGap = useCallback((): void => {
+		const el = rootRef.current;
+		if (el === null) return;
+		const gap = el.scrollHeight - el.scrollTop - el.clientHeight;
+		lockRef.current = gap <= FOLLOW_LOCK_PX;
+		const next = jumpEnabled && jumpVisible(gap, el.clientHeight);
+		setShowJump(prev => (prev === next ? prev : next));
+	}, [jumpEnabled]);
+
+	useEffect(() => {
+		const el = rootRef.current;
+		if (el !== null && lockRef.current) el.scrollTop = el.scrollHeight;
+		syncGap();
+	}, [entries, stream, activeTools, working, syncGap]);
+
+	useEffect(() => {
+		if (!jumpEnabled) return;
+		const el = rootRef.current;
+		if (el === null) return;
+		const ro = new ResizeObserver(syncGap);
+		ro.observe(el);
+		return () => {
+			ro.disconnect();
+		};
+	}, [jumpEnabled, syncGap]);
+
+	const jumpToBottom = useCallback((): void => {
+		const el = rootRef.current;
+		if (el === null) return;
+		el.scrollTop = el.scrollHeight;
+		lockRef.current = true;
+		setShowJump(false);
+		el.focus();
+	}, []);
+
+	return { rootRef, showJump, onScroll: syncGap, jumpToBottom };
+}

--- a/packages/collab-web/src/components/transcript/use-transcript-scroll.ts
+++ b/packages/collab-web/src/components/transcript/use-transcript-scroll.ts
@@ -2,9 +2,41 @@ import { type RefObject, useCallback, useEffect, useRef, useState } from "react"
 
 export const FOLLOW_LOCK_PX = 40;
 
+/** Scroller metrics the follow-lock decisions are computed from. */
+export interface ScrollView {
+	scrollTop: number;
+	scrollHeight: number;
+	clientHeight: number;
+}
+
+export interface ScrollDecision {
+	locked: boolean;
+	jump: boolean;
+	/** Next scrollTop; differs from the input only when the caller must pin. */
+	scrollTop: number;
+}
+
 /** True when the transcript tail is more than one viewport below the current view. */
 export function jumpVisible(gap: number, view: number): boolean {
 	return gap > view;
+}
+
+/** Follow-lock + pill decision after a user scroll: lock re-arms within FOLLOW_LOCK_PX of the tail. */
+export function reconcileUserScroll(view: ScrollView): ScrollDecision {
+	const gap = view.scrollHeight - view.scrollTop - view.clientHeight;
+	return { locked: gap <= FOLLOW_LOCK_PX, jump: jumpVisible(gap, view.clientHeight), scrollTop: view.scrollTop };
+}
+
+/**
+ * Follow-lock + pill decision after the scroller itself resized (mobile keyboard,
+ * split view): a locked scroller stays pinned to the tail so the height change is
+ * not misread as a user scroll-up. An unlocked scroller keeps its position; only
+ * the pill re-derives from the new clientHeight (plus lock re-arm if the browser
+ * clamped the scroller to the tail).
+ */
+export function reconcileResize(view: ScrollView, locked: boolean): ScrollDecision {
+	if (locked) return { locked: true, jump: false, scrollTop: view.scrollHeight };
+	return reconcileUserScroll(view);
 }
 
 export function useTranscriptScroll(
@@ -23,40 +55,53 @@ export function useTranscriptScroll(
 	const lockRef = useRef(true);
 	const [showJump, setShowJump] = useState(false);
 
-	const syncGap = useCallback((): void => {
+	const applyDecision = useCallback(
+		(decision: ScrollDecision): void => {
+			const el = rootRef.current;
+			if (el !== null && decision.scrollTop !== el.scrollTop) el.scrollTop = decision.scrollTop;
+			lockRef.current = decision.locked;
+			const next = jumpEnabled && decision.jump;
+			setShowJump(prev => (prev === next ? prev : next));
+		},
+		[jumpEnabled],
+	);
+
+	const onScroll = useCallback((): void => {
 		const el = rootRef.current;
 		if (el === null) return;
-		const gap = el.scrollHeight - el.scrollTop - el.clientHeight;
-		lockRef.current = gap <= FOLLOW_LOCK_PX;
-		const next = jumpEnabled && jumpVisible(gap, el.clientHeight);
-		setShowJump(prev => (prev === next ? prev : next));
-	}, [jumpEnabled]);
+		applyDecision(reconcileUserScroll(el));
+	}, [applyDecision]);
+
+	// Resize (mobile keyboard) is not a user scroll: keep a locked scroller pinned.
+	const onResize = useCallback((): void => {
+		const el = rootRef.current;
+		if (el === null) return;
+		applyDecision(reconcileResize(el, lockRef.current));
+	}, [applyDecision]);
 
 	useEffect(() => {
 		const el = rootRef.current;
 		if (el !== null && lockRef.current) el.scrollTop = el.scrollHeight;
-		syncGap();
-	}, [entries, stream, activeTools, working, syncGap]);
+		onScroll();
+	}, [entries, stream, activeTools, working, onScroll]);
 
 	useEffect(() => {
 		if (!jumpEnabled) return;
 		const el = rootRef.current;
 		if (el === null) return;
-		const ro = new ResizeObserver(syncGap);
+		const ro = new ResizeObserver(onResize);
 		ro.observe(el);
 		return () => {
 			ro.disconnect();
 		};
-	}, [jumpEnabled, syncGap]);
+	}, [jumpEnabled, onResize]);
 
 	const jumpToBottom = useCallback((): void => {
 		const el = rootRef.current;
 		if (el === null) return;
-		el.scrollTop = el.scrollHeight;
-		lockRef.current = true;
-		setShowJump(false);
+		applyDecision({ locked: true, jump: false, scrollTop: el.scrollHeight });
 		el.focus();
-	}, []);
+	}, [applyDecision]);
 
-	return { rootRef, showJump, onScroll: syncGap, jumpToBottom };
+	return { rootRef, showJump, onScroll, jumpToBottom };
 }

--- a/packages/collab-web/test/jump.test.ts
+++ b/packages/collab-web/test/jump.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "bun:test";
+import { FOLLOW_LOCK_PX, jumpVisible } from "../src/components/transcript/use-transcript-scroll";
+
+describe("jumpVisible", () => {
+	it("hides while follow-locked", () => {
+		expect(jumpVisible(0, 800)).toBe(false);
+		expect(jumpVisible(FOLLOW_LOCK_PX, 800)).toBe(false);
+	});
+
+	it("hides in the band between lock and one viewport", () => {
+		expect(jumpVisible(FOLLOW_LOCK_PX + 1, 800)).toBe(false);
+		expect(jumpVisible(800, 800)).toBe(false);
+	});
+
+	it("shows after more than one viewport of scroll-up", () => {
+		expect(jumpVisible(801, 800)).toBe(true);
+	});
+});

--- a/packages/collab-web/test/jump.test.ts
+++ b/packages/collab-web/test/jump.test.ts
@@ -59,3 +59,64 @@ describe("reconcileUserScroll", () => {
 		expect(justInside).toEqual({ locked: true, jump: false, scrollTop: 1161 }); // gap 39
 	});
 });
+
+describe("pill + follow state machine (chained transitions)", () => {
+	it("follows the reviewer scenario: scroll up, pill, resize, jump back, keep following", () => {
+		// Transcript of 3000px in an 800px viewport; guest starts locked at the tail.
+		let view = { scrollTop: 2200, scrollHeight: 3000, clientHeight: 800 };
+		let locked = true;
+
+		// Streamed output lands while locked: entries effect pins to the tail.
+		view.scrollHeight += 200;
+		let decision = reconcileUserScroll({ ...view, scrollTop: view.scrollHeight });
+		expect(decision.locked).toBe(true);
+		locked = decision.locked;
+
+		// User scrolls up 1.5 viewports: lock releases, pill appears.
+		view.scrollTop = 1500;
+		decision = reconcileUserScroll(view);
+		locked = decision.locked;
+		expect(locked).toBe(false);
+		expect(decision.jump).toBe(true); // gap 1700 > 800
+
+		// Keyboard opens (viewport 800 -> 450) while unlocked: position kept, pill stays.
+		view.clientHeight = 450;
+		decision = reconcileResize(view, locked);
+		locked = decision.locked;
+		expect(locked).toBe(false);
+		expect(decision.jump).toBe(true); // gap 1700 > 450
+		expect(decision.scrollTop).toBe(1500);
+
+		// Guest taps the pill: instant jump, follow re-armed.
+		decision = reconcileResize({ ...view, scrollTop: view.scrollHeight }, true);
+		locked = decision.locked;
+		view.scrollTop = decision.scrollTop;
+		expect(locked).toBe(true);
+		expect(decision.jump).toBe(false);
+
+		// More output while locked + another keyboard resize: stays pinned at the tail.
+		view.scrollHeight += 300;
+		view.clientHeight = 800;
+		decision = reconcileResize({ ...view, scrollTop: view.scrollHeight }, true);
+		view.scrollTop = decision.scrollTop;
+		locked = decision.locked;
+		expect(locked).toBe(true);
+		expect(view.scrollTop).toBe(view.scrollHeight);
+		expect(decision.jump).toBe(false);
+	});
+
+	it("regression: keyboard shrink while locked no longer releases follow", () => {
+		// The exact sequence from the review: at the tail, viewport shrinks under it.
+		const view = { scrollTop: 2200, scrollHeight: 3000, clientHeight: 800 };
+		const shrunk = { ...view, clientHeight: 450 }; // keyboard eats 350px
+
+		// Pre-fix behavior routed this through the user-scroll path and unlocked.
+		const oldBehavior = reconcileUserScroll(shrunk);
+		expect(oldBehavior.locked).toBe(false); // gap 350 > 40 — the bug
+
+		const fixed = reconcileResize(shrunk, true);
+		expect(fixed.locked).toBe(true);
+		expect(fixed.scrollTop).toBe(3000); // pinned to the tail
+		expect(fixed.jump).toBe(false);
+	});
+});

--- a/packages/collab-web/test/jump.test.ts
+++ b/packages/collab-web/test/jump.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "bun:test";
-import { FOLLOW_LOCK_PX, jumpVisible } from "../src/components/transcript/use-transcript-scroll";
+import {
+	FOLLOW_LOCK_PX,
+	jumpVisible,
+	reconcileResize,
+	reconcileUserScroll,
+} from "../src/components/transcript/use-transcript-scroll";
 
 describe("jumpVisible", () => {
 	it("hides while follow-locked", () => {
@@ -14,5 +19,43 @@ describe("jumpVisible", () => {
 
 	it("shows after more than one viewport of scroll-up", () => {
 		expect(jumpVisible(801, 800)).toBe(true);
+	});
+});
+
+describe("reconcileResize", () => {
+	it("keeps a locked scroller pinned when the keyboard shrinks the viewport", () => {
+		// At the tail (scrollTop 900 of 1000, 100px viewport); the keyboard eats 250px
+		// of height while scrollTop stays at the old maximum.
+		const decision = reconcileResize({ scrollTop: 900, scrollHeight: 1000, clientHeight: 75 }, true);
+		expect(decision).toEqual({ locked: true, jump: false, scrollTop: 1000 });
+	});
+
+	it("keeps an unlocked scroller in place and re-derives the pill from the new height", () => {
+		// User had scrolled 400px up (gap 400 < 500 viewport, no pill); the shrink
+		// halves the viewport, so the same position is now > one viewport away.
+		const decision = reconcileResize({ scrollTop: 350, scrollHeight: 1000, clientHeight: 250 }, false);
+		expect(decision).toEqual({ locked: false, jump: true, scrollTop: 350 });
+	});
+
+	it("re-arms the lock when a resize clamps an unlocked scroller to the tail", () => {
+		// Browser clamps scrollTop to the new maximum: gap collapses to 0.
+		const decision = reconcileResize({ scrollTop: 750, scrollHeight: 1000, clientHeight: 250 }, false);
+		expect(decision.locked).toBe(true);
+		expect(decision.jump).toBe(false);
+	});
+});
+
+describe("reconcileUserScroll", () => {
+	it("releases the lock and shows the pill after more than one viewport", () => {
+		const decision = reconcileUserScroll({ scrollTop: 0, scrollHeight: 2000, clientHeight: 800 });
+		expect(decision).toEqual({ locked: false, jump: true, scrollTop: 0 });
+	});
+
+	it("re-arms the lock within FOLLOW_LOCK_PX of the tail", () => {
+		// scrollHeight 2000, viewport 800: the tail sits at scrollTop 1200.
+		const justOutside = reconcileUserScroll({ scrollTop: 1159, scrollHeight: 2000, clientHeight: 800 });
+		expect(justOutside).toEqual({ locked: false, jump: false, scrollTop: 1159 }); // gap 41
+		const justInside = reconcileUserScroll({ scrollTop: 1161, scrollHeight: 2000, clientHeight: 800 });
+		expect(justInside).toEqual({ locked: true, jump: false, scrollTop: 1161 }); // gap 39
 	});
 });

--- a/packages/collab-web/test/transcript.test.tsx
+++ b/packages/collab-web/test/transcript.test.tsx
@@ -159,6 +159,7 @@ describe("Transcript jump pill", () => {
 	it("wraps the main scroller and labels it", () => {
 		const html = renderTranscript({ working: false });
 		expect(html).toContain("tr-shell");
+		expect(html).toContain("tr-content");
 		expect(html).toContain('aria-label="Transcript"');
 		expect(html).not.toContain("Scroll to current");
 	});

--- a/packages/collab-web/test/transcript.test.tsx
+++ b/packages/collab-web/test/transcript.test.tsx
@@ -55,6 +55,7 @@ function renderTranscript(props: {
 	entries?: readonly SessionEntry[];
 	activeTools?: ReadonlyMap<string, ActiveTool>;
 	working: boolean;
+	compact?: boolean;
 }): string {
 	return renderToStaticMarkup(
 		<Transcript
@@ -63,6 +64,7 @@ function renderTranscript(props: {
 			streamDone={true}
 			activeTools={props.activeTools ?? new Map()}
 			working={props.working}
+			compact={props.compact}
 		/>,
 	);
 }
@@ -143,5 +145,21 @@ describe("Transcript message Markdown", () => {
 
 		expect(countElements(html, ".tr-row--user .tr-md code")).toBe(1);
 		expect(countElements(html, ".tr-row--user .tr-md strong")).toBe(1);
+	});
+});
+
+describe("Transcript jump pill", () => {
+	it("does not render the jump pill in compact/drawer mode", () => {
+		const html = renderTranscript({ working: false, compact: true });
+		expect(html).not.toContain("Scroll to current");
+		expect(html).not.toContain("tr-shell");
+		expect(html).not.toContain('aria-label="Transcript"');
+	});
+
+	it("wraps the main scroller and labels it", () => {
+		const html = renderTranscript({ working: false });
+		expect(html).toContain("tr-shell");
+		expect(html).toContain('aria-label="Transcript"');
+		expect(html).not.toContain("Scroll to current");
 	});
 });


### PR DESCRIPTION
I reviewed the full diff. I added a Scroll to current pill on the collab guest transcript because on a phone there's no real scrollbar, so once you scroll up you're stuck away from the tail.

## What

Centered pill on the main collab transcript (not the agent drawer). It shows after you scroll up more than one viewport, jumps to the bottom instantly, and turns follow-lock back on. Follow-lock itself is still the old 40px rule.

Scroll show/hide fades. Clicking it skips the fade so it doesn't feel sluggish. `prefers-reduced-motion` skips the animation too.

## Why

`/collab` QR on mobile. Desktop can use the scrollbar; the phone UI couldn't jump back.

## Testing

- `bun test --parallel` and `bun run check` in `packages/collab-web`
- Local: `bun run mock-host` + `bun run dev`, opened the join link at iPhone width, closed the agent rail, scrolled up more than one screen, tapped **Scroll to current**, landed on the tail and stayed there. Tab + Enter on the pill. Drawer still has no pill.

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)