### PR TITLE
fix(ai): tolerate qianfan invalid_model during api key validation

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `/login` for Qianfan rejecting valid API keys that lack access to the validation model, treating an authenticated `invalid_model` response as a successful credential check.
+
 ## [18.0.9] - 2026-08-28
 
 ### Fixed

--- a/packages/ai/src/registry/api-key-login.ts
+++ b/packages/ai/src/registry/api-key-login.ts
@@ -19,8 +19,9 @@ type ChatCompletionsValidation = {
 	provider: string;
 	baseUrl: string;
 	model: string;
+	/** Treat an authenticated 401 (`invalid_model`) as a valid key. */
+	tolerateModelDenied?: boolean;
 };
-
 type AnthropicMessagesValidation = {
 	kind: "anthropic-messages";
 	provider: string;
@@ -99,6 +100,7 @@ export function createApiKeyLogin(config: ApiKeyLoginConfig): (options: OAuthCon
 					model: config.validation.model,
 					signal: options.signal,
 					fetch: options.fetch,
+					tolerateModelDenied: config.validation.tolerateModelDenied,
 				});
 			} else if (config.validation.kind === "anthropic-messages") {
 				await validateAnthropicCompatibleApiKey({

--- a/packages/ai/src/registry/api-key-validation.ts
+++ b/packages/ai/src/registry/api-key-validation.ts
@@ -1,4 +1,4 @@
-import { ProviderHttpError } from "../error/classes";
+import { OpenAIHttpError, ProviderHttpError } from "../error/classes";
 import type { FetchImpl } from "../types";
 
 type OpenAICompatibleValidationOptions = {
@@ -8,6 +8,7 @@ type OpenAICompatibleValidationOptions = {
 	model: string;
 	signal?: AbortSignal;
 	fetch?: FetchImpl;
+	tolerateModelDenied?: boolean;
 };
 type AnthropicCompatibleValidationOptions = {
 	provider: string;
@@ -40,7 +41,7 @@ function resolveValidationHeaders(
 	return typeof headers === "function" ? headers() : headers;
 }
 
-async function createApiKeyValidationError(provider: string, response: Response): Promise<ProviderHttpError> {
+async function readErrorEnvelope(response: Response): Promise<{ details: string; code: string | undefined }> {
 	let details = "";
 	try {
 		details = (await response.text()).trim();
@@ -48,10 +49,34 @@ async function createApiKeyValidationError(provider: string, response: Response)
 		// Ignore body read errors; the HTTP status still preserves the failure category.
 	}
 
+	let bodyJson: unknown;
+	try {
+		bodyJson = details ? JSON.parse(details) : undefined;
+	} catch {
+		bodyJson = undefined;
+	}
+	const { code } = OpenAIHttpError.parseEnvelope(bodyJson, details);
+	return { details, code };
+}
+
+async function createApiKeyValidationError(provider: string, response: Response): Promise<ProviderHttpError> {
+	const { details, code } = await readErrorEnvelope(response);
+
 	const message = details
 		? `${provider} API key validation failed (${response.status}): ${details}`
 		: `${provider} API key validation failed (${response.status})`;
-	return new ProviderHttpError(message, response.status, { headers: response.headers });
+	return new ProviderHttpError(message, response.status, { headers: response.headers, code });
+}
+
+/**
+ * Whether an OpenAI-compatible error body reports that the request was
+ * authenticated but the model was denied. Providers such as Qianfan return
+ * `401 invalid_model` when the key has no access to the validation model —
+ * the key itself is valid, so it must not block login.
+ */
+async function isAuthenticatedModelDenied(response: Response): Promise<boolean> {
+	if (response.status !== 401) return false;
+	return (await readErrorEnvelope(response)).code === "invalid_model";
 }
 
 /**
@@ -80,6 +105,10 @@ export async function validateOpenAICompatibleApiKey(options: OpenAICompatibleVa
 	});
 
 	if (response.ok) {
+		return;
+	}
+
+	if (options.tolerateModelDenied && (await isAuthenticatedModelDenied(response))) {
 		return;
 	}
 

--- a/packages/ai/src/registry/api-key-validation.ts
+++ b/packages/ai/src/registry/api-key-validation.ts
@@ -28,6 +28,11 @@ type ModelListValidationOptions = {
 	fetch?: FetchImpl;
 };
 
+type ErrorEnvelope = {
+	details: string;
+	code: string | undefined;
+};
+
 const VALIDATION_TIMEOUT_MS = 15_000;
 
 function normalizeAnthropicCompatibleBaseUrl(baseUrl: string): string {
@@ -41,7 +46,7 @@ function resolveValidationHeaders(
 	return typeof headers === "function" ? headers() : headers;
 }
 
-async function readErrorEnvelope(response: Response): Promise<{ details: string; code: string | undefined }> {
+async function readErrorEnvelope(response: Response): Promise<ErrorEnvelope> {
 	let details = "";
 	try {
 		details = (await response.text()).trim();
@@ -59,8 +64,12 @@ async function readErrorEnvelope(response: Response): Promise<{ details: string;
 	return { details, code };
 }
 
-async function createApiKeyValidationError(provider: string, response: Response): Promise<ProviderHttpError> {
-	const { details, code } = await readErrorEnvelope(response);
+async function createApiKeyValidationError(
+	provider: string,
+	response: Response,
+	envelope?: ErrorEnvelope,
+): Promise<ProviderHttpError> {
+	const { details, code } = envelope ?? (await readErrorEnvelope(response));
 
 	const message = details
 		? `${provider} API key validation failed (${response.status}): ${details}`
@@ -97,15 +106,12 @@ export async function validateOpenAICompatibleApiKey(options: OpenAICompatibleVa
 		return;
 	}
 
-	const { details, code } = await readErrorEnvelope(response);
-	if (options.tolerateModelDenied && response.status === 401 && code === "invalid_model") {
+	const envelope = await readErrorEnvelope(response);
+	if (options.tolerateModelDenied && response.status === 401 && envelope.code === "invalid_model") {
 		return;
 	}
 
-	const message = details
-		? `${options.provider} API key validation failed (${response.status}): ${details}`
-		: `${options.provider} API key validation failed (${response.status})`;
-	throw new ProviderHttpError(message, response.status, { headers: response.headers, code });
+	throw await createApiKeyValidationError(options.provider, response, envelope);
 }
 
 /**

--- a/packages/ai/src/registry/api-key-validation.ts
+++ b/packages/ai/src/registry/api-key-validation.ts
@@ -69,17 +69,6 @@ async function createApiKeyValidationError(provider: string, response: Response)
 }
 
 /**
- * Whether an OpenAI-compatible error body reports that the request was
- * authenticated but the model was denied. Providers such as Qianfan return
- * `401 invalid_model` when the key has no access to the validation model —
- * the key itself is valid, so it must not block login.
- */
-async function isAuthenticatedModelDenied(response: Response): Promise<boolean> {
-	if (response.status !== 401) return false;
-	return (await readErrorEnvelope(response)).code === "invalid_model";
-}
-
-/**
  * Validate an API key against an OpenAI-compatible chat completions endpoint.
  *
  * Performs a minimal request to verify credentials and endpoint access.
@@ -108,11 +97,15 @@ export async function validateOpenAICompatibleApiKey(options: OpenAICompatibleVa
 		return;
 	}
 
-	if (options.tolerateModelDenied && (await isAuthenticatedModelDenied(response))) {
+	const { details, code } = await readErrorEnvelope(response);
+	if (options.tolerateModelDenied && response.status === 401 && code === "invalid_model") {
 		return;
 	}
 
-	throw await createApiKeyValidationError(options.provider, response);
+	const message = details
+		? `${options.provider} API key validation failed (${response.status}): ${details}`
+		: `${options.provider} API key validation failed (${response.status})`;
+	throw new ProviderHttpError(message, response.status, { headers: response.headers, code });
 }
 
 /**

--- a/packages/ai/src/registry/qianfan.ts
+++ b/packages/ai/src/registry/qianfan.ts
@@ -17,6 +17,7 @@ export const loginQianfan = createApiKeyLogin({
 		provider: "qianfan",
 		baseUrl: API_BASE_URL,
 		model: VALIDATION_MODEL,
+		tolerateModelDenied: true,
 	},
 });
 

--- a/packages/ai/test/api-key-validation.test.ts
+++ b/packages/ai/test/api-key-validation.test.ts
@@ -105,3 +105,80 @@ describe("API key validation HTTP errors", () => {
 		expect(error).not.toBeInstanceOf(ApiKeyRequiredError);
 	});
 });
+
+describe("model-denied 401 triage", () => {
+	const modelDeniedBody = JSON.stringify({
+		error: {
+			code: "invalid_model",
+			message: "The model does not exist or you do not have access to it.",
+			type: "invalid_request_error",
+		},
+	});
+
+	function qianfanValidator(fetch: FetchImpl, tolerateModelDenied?: boolean) {
+		return validateOpenAICompatibleApiKey({
+			provider: "qianfan",
+			apiKey: "bce-v3/ALTAK-test",
+			baseUrl: "https://qianfan.baidubce.com/v2",
+			model: "deepseek-v3.2",
+			fetch,
+			tolerateModelDenied,
+		});
+	}
+
+	it("accepts a valid key that lacks access to the validation model when tolerated", async () => {
+		const fetchMock: FetchImpl = async () =>
+			new Response(modelDeniedBody, {
+				status: 401,
+				headers: { "Content-Type": "application/json" },
+			});
+
+		await expect(qianfanValidator(fetchMock, true)).resolves.toBeUndefined();
+	});
+
+	it("still rejects the same 401 when model denial is not tolerated", async () => {
+		const fetchMock: FetchImpl = async () =>
+			new Response(modelDeniedBody, {
+				status: 401,
+				headers: { "Content-Type": "application/json" },
+			});
+
+		const error = await captureError(() => qianfanValidator(fetchMock, false));
+
+		expect(error).toBeInstanceOf(ProviderHttpError);
+		expect((error as ProviderHttpError).status).toBe(401);
+		expect(error.message).toContain("qianfan API key validation failed (401)");
+	});
+
+	it("still rejects a genuinely invalid key even when model denial is tolerated", async () => {
+		const fetchMock: FetchImpl = async () =>
+			new Response(
+				JSON.stringify({
+					error: { code: "invalid_iam_token", message: "invalid IAM token", type: "invalid_request_error" },
+				}),
+				{
+					status: 401,
+					headers: { "Content-Type": "application/json" },
+				},
+			);
+
+		const error = await captureError(() => qianfanValidator(fetchMock, true));
+
+		expect(error).toBeInstanceOf(ProviderHttpError);
+		expect((error as ProviderHttpError).status).toBe(401);
+		expect(error.message).toContain("qianfan API key validation failed (401)");
+	});
+
+	it("exposes the provider error code on the thrown error for diagnostics", async () => {
+		const fetchMock: FetchImpl = async () =>
+			new Response(modelDeniedBody, {
+				status: 401,
+				headers: { "Content-Type": "application/json" },
+			});
+
+		const error = await captureError(() => qianfanValidator(fetchMock, false));
+
+		expect(error).toBeInstanceOf(ProviderHttpError);
+		expect((error as ProviderHttpError).code).toBe("invalid_model");
+	});
+});

--- a/packages/ai/test/api-key-validation.test.ts
+++ b/packages/ai/test/api-key-validation.test.ts
@@ -168,6 +168,7 @@ describe("model-denied 401 triage", () => {
 		expect((error as ProviderHttpError).status).toBe(401);
 		expect((error as ProviderHttpError).code).toBe("invalid_iam_token");
 		expect(error.message).toContain("qianfan API key validation failed (401)");
+		expect(error.message).toContain("invalid IAM token");
 	});
 
 	it("exposes the provider error code on the thrown error for diagnostics", async () => {

--- a/packages/ai/test/api-key-validation.test.ts
+++ b/packages/ai/test/api-key-validation.test.ts
@@ -166,6 +166,7 @@ describe("model-denied 401 triage", () => {
 
 		expect(error).toBeInstanceOf(ProviderHttpError);
 		expect((error as ProviderHttpError).status).toBe(401);
+		expect((error as ProviderHttpError).code).toBe("invalid_iam_token");
 		expect(error.message).toContain("qianfan API key validation failed (401)");
 	});
 


### PR DESCRIPTION
## What

Qianfan `/login` was rejecting valid API keys that lack access to the validation model. Qianfan keys are model-scoped, and the login flow validated with `deepseek-v3.2` while user keys were restricted to other models — the resulting `401 invalid_model` was treated as a bad key and blocked login.

The fix adds an opt-in `tolerateModelDenied` flag to OpenAI-compatible API key validation: a `401` whose error body carries `code: "invalid_model"` is treated as a successful credential check, since the key itself is valid — only the validation model is inaccessible. Only Qianfan enables the flag; all other providers keep the previous strict behavior.

## Why

A Qianfan API key is authorized for a specific model set (e.g. `deepseek-v4-flash-0731`, `deepseek-v4-pro-0813`, `glm-5.3`). The validation request against `deepseek-v3.2` returns `401 invalid_model` for these keys — an authenticated, model-permission error, not a credential failure. The bug blocked `/login qianfan` entirely for affected users.

## Testing

- `bunx tsgo -p tsconfig.json --noEmit` in `packages/ai` passes
- `bun test test/api-key-validation.test.ts` in `packages/ai` → 13 pass, 0 fail (4 new triage cases)
- Real-endpoint check against `https://qianfan.baidubce.com/v2`:
  - valid key + flag off → rejected with `401 invalid_model` (bug reproduced)
  - valid key + flag on → accepted
  - invalid key + flag on → still rejected with `401 invalid_iam_token`

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)