### PR TITLE
Enable image input for supported Cursor models

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Cursor Kimi K3, Grok 4, and Composer 2.5 models being treated as text-only despite accepting image attachments.
+
 ## [18.0.9] - 2026-08-28
 
 ### Added

--- a/packages/catalog/scripts/generated-policies.ts
+++ b/packages/catalog/scripts/generated-policies.ts
@@ -4,6 +4,7 @@
  * `generate-models.ts` — none of this ships in the runtime bundle.
  */
 import { buildCompat } from "../src/build";
+import { resolveCursorInput } from "../src/discovery/cursor";
 import {
 	type AnthropicModel,
 	bareModelId,
@@ -332,6 +333,9 @@ export function applyOllamaCloudOutputCap(models: ModelSpec<Api>[]): void {
 }
 
 function applyGeneratedModelPolicy(model: ModelSpec<Api>): void {
+	if (model.provider === "cursor") {
+		model.input = resolveCursorInput(model.id, model.input);
+	}
 	if ((model.provider === "xai" || model.provider === "xai-oauth") && model.api === "openai-responses") {
 		const updated = applyXaiResponsesThinkingPolicy(model as ModelSpec<"openai-responses">);
 		model.compat = updated.compat;

--- a/packages/catalog/src/discovery/cursor.ts
+++ b/packages/catalog/src/discovery/cursor.ts
@@ -33,14 +33,20 @@ const CURSOR_KIMI_K3_BARE_ID_PATTERN = /(^|\/)k3$/i;
  * reasoning models whose effort is carried in the per-tier sibling id.
  * `GetUsableModels` ships no `thinkingDetails` and the bundled references read
  * `reasoning: false`, so classification falls back to the id. The non-reasoning
- * `grok-code-*` coding models lack the version digit and stay out.
+ * `grok-code-fast-*` family deliberately stays out.
  */
 const CURSOR_GROK_REASONING_ID_PATTERN = /^cursor-grok-\d/i;
 
 /**
+ * Cursor-only families verified to accept `selectedImages` even though
+ * `GetUsableModels` does not advertise input modalities.
+ */
+const CURSOR_GROK_4_MULTIMODAL_ID_PATTERN = /^cursor-grok-4(?:[.:_-]|$)/i;
+const CURSOR_COMPOSER_25_MULTIMODAL_ID_PATTERN = /^composer-2\.5(?:[.:_-]|$)/i;
+
+/**
  * Model-id families whose native catalogs (anthropic, openai/openai-codex,
- * google) are multimodal. Cursor-only or text-only families (`composer-*`,
- * `grok-code-*`) intentionally stay outside this pattern.
+ * google) are multimodal. Cursor-only verified families are handled separately.
  */
 const CURSOR_MULTIMODAL_ID_PATTERN = /claude|gemini|gpt-|codex/;
 
@@ -319,6 +325,7 @@ function normalizeCursorModel(
 			name,
 			baseUrl: baseUrlOverride ?? reference.baseUrl,
 			reasoning,
+			input: resolveCursorInput(id, reference.input),
 			contextWindow: resolveCursorContextWindow(details, id, reference.contextWindow),
 			cursorMaxMode: details.maxMode,
 		};
@@ -330,7 +337,7 @@ function normalizeCursorModel(
 		provider: "cursor",
 		baseUrl: baseUrlOverride ?? CURSOR_DEFAULT_BASE_URL,
 		reasoning,
-		input: inferInputFromCursorId(id),
+		input: resolveCursorInput(id),
 		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 		contextWindow: resolveCursorContextWindow(details, id, DEFAULT_CONTEXT_WINDOW),
 		maxTokens: DEFAULT_MAX_TOKENS,
@@ -394,14 +401,22 @@ function pickModelDisplayName(model: CursorModelDetailsValue, fallbackId: string
 }
 
 /**
- * Infers input modalities for Cursor models without a bundled reference.
- *
- * `GetUsableModels` carries no per-model modality metadata, so classification
- * falls back to the model family: families that are multimodal in OMP's own
- * native catalogs accept images, everything else stays text-only. Mirrors
- * `inferInputFromGeminiId` in ./gemini.ts.
+ * Resolves input modalities from a bundled reference when available, except
+ * for Cursor-only families whose image support is known independently. Without
+ * a reference, native multimodal families fall back to id classification.
  */
-function inferInputFromCursorId(id: string): ("text" | "image")[] {
+export function resolveCursorInput(id: string, referenceInput?: ("text" | "image")[]): ("text" | "image")[] {
+	if (
+		isKimiK3ModelId(id) ||
+		CURSOR_KIMI_K3_BARE_ID_PATTERN.test(id) ||
+		CURSOR_GROK_4_MULTIMODAL_ID_PATTERN.test(id) ||
+		CURSOR_COMPOSER_25_MULTIMODAL_ID_PATTERN.test(id)
+	) {
+		return ["text", "image"];
+	}
+	if (referenceInput) {
+		return referenceInput;
+	}
 	if (CURSOR_MULTIMODAL_ID_PATTERN.test(id.toLowerCase())) {
 		return ["text", "image"];
 	}

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -45975,7 +45975,8 @@
 			"baseUrl": "https://api2.cursor.sh",
 			"reasoning": false,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0,
@@ -45998,7 +45999,8 @@
 			"baseUrl": "https://api2.cursor.sh",
 			"reasoning": false,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0,
@@ -46021,7 +46023,8 @@
 			"baseUrl": "https://api2.cursor.sh",
 			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0,
@@ -46059,7 +46062,8 @@
 			"baseUrl": "https://api2.cursor.sh",
 			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0,
@@ -46097,7 +46101,8 @@
 			"baseUrl": "https://api2.cursor.sh",
 			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0,
@@ -46137,7 +46142,8 @@
 			"baseUrl": "https://api2.cursor.sh",
 			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0,
@@ -47870,7 +47876,8 @@
 			"baseUrl": "https://api2.cursor.sh",
 			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0,
@@ -47904,7 +47911,8 @@
 			"baseUrl": "https://api2.cursor.sh",
 			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0,
@@ -47938,7 +47946,8 @@
 			"baseUrl": "https://api2.cursor.sh",
 			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0,

--- a/packages/catalog/test/cursor-discovery.test.ts
+++ b/packages/catalog/test/cursor-discovery.test.ts
@@ -18,15 +18,23 @@ const FIXTURE_MODEL_IDS = [
 	"claude-opus-4-8-99999999",
 	"gpt-5.5-codex-20991231",
 	"gemini-4-pro-exp",
-	// Reference-less ids from text-only families.
-	"composer-3",
-	// Reference-less K3 effort variants omit Cursor thinkingDetails.
+	// Cursor-only families verified to accept direct image attachments.
 	"kimi-k3-high",
 	"kimi-k3-low",
 	"kimi-k3-max",
+	"cursor-grok-4.5",
+	"cursor-grok-4.5-fast",
+	"cursor-grok-4.6",
+	"cursor-grok-4.6-fast",
+	"composer-2.5",
+	"composer-2.5-fast",
+	// Similar but unverified ids must not inherit image routing.
+	"composer-3",
+	"composer-2.50",
+	"cursor-grok-5",
 	"grok-code-fast-2",
-	// Versioned Cursor Grok siblings: bundled references read reasoning:false,
-	// but the id marks them reasoning.
+	"k3-256k",
+	// Versioned Cursor Grok siblings: the id marks them reasoning.
 	"cursor-grok-4.5-high",
 	"cursor-grok-4.6-xhigh",
 	// Bundled-reference ids: the reference stays authoritative.
@@ -83,10 +91,13 @@ describe("cursor discovery input modalities (issue #4726)", () => {
 		expect(byId.get("gemini-4-pro-exp")?.input).toEqual(["text", "image"]);
 	});
 
-	it("keeps reference-less text-only families text-only", async () => {
+	it("keeps unverified Cursor-only families text-only", async () => {
 		const byId = await discover();
 		expect(byId.get("composer-3")?.input).toEqual(["text"]);
+		expect(byId.get("composer-2.50")?.input).toEqual(["text"]);
+		expect(byId.get("cursor-grok-5")?.input).toEqual(["text"]);
 		expect(byId.get("grok-code-fast-2")?.input).toEqual(["text"]);
+		expect(byId.get("k3-256k")?.input).toEqual(["text"]);
 	});
 
 	it("recognizes reference-less Kimi K3 effort variants as reasoning models", async () => {
@@ -94,6 +105,24 @@ describe("cursor discovery input modalities (issue #4726)", () => {
 		expect(byId.get("kimi-k3-high")?.reasoning).toBe(true);
 		expect(byId.get("kimi-k3-low")?.reasoning).toBe(true);
 		expect(byId.get("kimi-k3-max")?.reasoning).toBe(true);
+	});
+
+	it("routes verified Cursor-only model variants as text+image", async () => {
+		const byId = await discover();
+		const verifiedIds = [
+			"kimi-k3-high",
+			"kimi-k3-low",
+			"kimi-k3-max",
+			"cursor-grok-4.5",
+			"cursor-grok-4.5-fast",
+			"cursor-grok-4.6",
+			"cursor-grok-4.6-fast",
+			"composer-2.5",
+			"composer-2.5-fast",
+		];
+		for (const id of verifiedIds) {
+			expect(byId.get(id)?.input).toEqual(["text", "image"]);
+		}
 	});
 
 	it("marks versioned Cursor Grok ids as reasoning despite reasoning:false references (issue #8803)", async () => {
@@ -104,10 +133,10 @@ describe("cursor discovery input modalities (issue #4726)", () => {
 		expect(byId.get("grok-code-fast-2")?.reasoning).toBe(false);
 	});
 
-	it("keeps bundled references authoritative for input modalities", async () => {
+	it("keeps bundled references authoritative outside verified image families", async () => {
 		const byId = await discover();
-		// Bundled cursor references carry their own input classification; the
-		// id-based inference must not override it in either direction.
+		// The id-based native-family inference must not override bundled
+		// classifications in either direction.
 		expect(byId.get("claude-4.5-opus-high")?.input).toEqual(["text", "image"]);
 		expect(byId.get("claude-4.6-opus-high")?.input).toEqual(["text"]);
 		expect(byId.get("composer-1")?.input).toEqual(["text"]);

--- a/packages/catalog/test/generated-policies.test.ts
+++ b/packages/catalog/test/generated-policies.test.ts
@@ -377,6 +377,33 @@ describe("generated model policies", () => {
 		}
 	});
 
+	it("bakes verified Cursor image families into the offline catalog", () => {
+		const verifiedIds = [
+			"kimi-k3-high",
+			"kimi-k3-low",
+			"kimi-k3-max",
+			"cursor-grok-4.5",
+			"cursor-grok-4.5-fast",
+			"cursor-grok-4.6",
+			"cursor-grok-4.6-fast",
+			"composer-2.5",
+			"composer-2.5-fast",
+		];
+		const unverifiedIds = ["cursor-grok-5", "composer-2.50", "k3-256k"];
+		const models = [...verifiedIds, ...unverifiedIds].map(id =>
+			createSpec({ id, api: "cursor-agent", provider: "cursor" }),
+		);
+
+		applyGeneratedModelPolicies(models);
+
+		for (const model of models.slice(0, verifiedIds.length)) {
+			expect(model.input).toEqual(["text", "image"]);
+		}
+		for (const model of models.slice(verifiedIds.length)) {
+			expect(model.input).toEqual(["text"]);
+		}
+	});
+
 	it("pins MiniMax-M3 long-context providers to 1M context", () => {
 		const models = [
 			createSpec({


### PR DESCRIPTION
 What

 Mark these Cursor models as image-capable:

 - Kimi K3 High, Low, and Max
 - Grok 4.5 and 4.6, including Fast variants
 - Composer 2.5 and Composer 2.5 Fast

 Why

 Some Cursor models cannot read images because OMP marks them as text-only, although the models can process images.

 Testing

 Tested manually. The result can be reproduced with these commands. Each command asks the agent to read a test image. 

```
echo 'iVBORw0KGgoAAAANSUhEUgAAAHgAAAAqCAIAAAD3QAh5AAABN0lEQVR42u2bzQ3DIAxGA8ow2awDMEcG6Gbdhl4rNTK/JiY8jhX48PTyySGuizFuLP3lQQBoQK+63AvQoyhXswY00WE1NOqk3msOne7ix9DcJn6cCqTDRP/qCvroMw9ENXGroC8Vjm+l6Dhd/51LhU/a6GpwpWqbNFpI5CKpvaKeqJ0Lup3U5KzlBqOo/aC9u93oXjJOK3WOsPlS+xF0CGuio13VzJ2AvtFojSd9qvQovc3I2Y/RZPRUt/vJU4Du9g1FPgtoomMqnZMVAH2j0UHhk0SIj9dZroPRZPSEOgvV/IgnPTDeJxjdi84y6SzXJDosZHS7jEvqfFnZK5IimmsGaIruOesQDx830NN5+xtJ8P3ZIXLrSNizZu8G6Pwr9W4ofI/ImyGvgs0T7PwrC6MBzQK02fUF5dFUomyXNNUAAAAASUVORK5CYII=' | /usr/bin/base64 -D -o /tmp/tmp_test_image.png


bun packages/coding-agent/src/cli.ts -p --no-session --no-tools --max-time 3m --model cursor/kimi-k3-high @/tmp/tmp_test_image.png 'Name the three colored shapes from left to right. Reply exactly: <color> <shape>, <color> <shape>, <color> <shape>.'
bun packages/coding-agent/src/cli.ts -p --no-session --no-tools --max-time 3m --model cursor/kimi-k3-low @/tmp/tmp_test_image.png 'Name the three colored shapes from left to right. Reply exactly: <color> <shape>, <color> <shape>, <color> <shape>.'
bun packages/coding-agent/src/cli.ts -p --no-session --no-tools --max-time 3m --model cursor/kimi-k3-max @/tmp/tmp_test_image.png 'Name the three colored shapes from left to right. Reply exactly: <color> <shape>, <color> <shape>, <color> <shape>.'
bun packages/coding-agent/src/cli.ts -p --no-session --no-tools --max-time 3m --model cursor/cursor-grok-4.5 @/tmp/tmp_test_image.png 'Name the three colored shapes from left to right. Reply exactly: <color> <shape>, <color> <shape>, <color> <shape>.'
bun packages/coding-agent/src/cli.ts -p --no-session --no-tools --max-time 3m --model cursor/cursor-grok-4.5-fast @/tmp/tmp_test_image.png 'Name the three colored shapes from left to right. Reply exactly: <color> <shape>, <color> <shape>, <color> <shape>.'
bun packages/coding-agent/src/cli.ts -p --no-session --no-tools --max-time 3m --model cursor/cursor-grok-4.6 @/tmp/tmp_test_image.png 'Name the three colored shapes from left to right. Reply exactly: <color> <shape>, <color> <shape>, <color> <shape>.'
bun packages/coding-agent/src/cli.ts -p --no-session --no-tools --max-time 3m --model cursor/cursor-grok-4.6-fast @/tmp/tmp_test_image.png 'Name the three colored shapes from left to right. Reply exactly: <color> <shape>, <color> <shape>, <color> <shape>.'
bun packages/coding-agent/src/cli.ts -p --no-session --no-tools --max-time 3m --model cursor/composer-2.5 @/tmp/tmp_test_image.png 'Name the three colored shapes from left to right. Reply exactly: <color> <shape>, <color> <shape>, <color> <shape>.'
bun packages/coding-agent/src/cli.ts -p --no-session --no-tools --max-time 3m --model cursor/composer-2.5-fast @/tmp/tmp_test_image.png 'Name the three colored shapes from left to right. Reply exactly: <color> <shape>, <color> <shape>, <color> <shape>.'
```

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated 





