### PR TITLE
feat(coding-agent): add managed main-session worktrees

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `--worktree`/`-w` to start a main session in a persistent managed Git workspace ([#452](https://github.com/can1357/oh-my-pi/issues/452)).
+
 ### Fixed
 
 - Fixed `import numpy` (and other native-extension imports) hanging indefinitely in the Python eval tool on Windows, where the runner's always-on background stdin reader deadlocked native DLL loading; Windows now reads the control channel serially between requests while POSIX keeps concurrent request dispatch ([#7985](https://github.com/can1357/oh-my-pi/issues/7985)).

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -82,6 +82,8 @@ export interface Args {
 	noTitle?: boolean;
 	autoApprove?: boolean;
 	approvalMode?: "always-ask" | "write" | "yolo";
+	/** `--worktree`/`-w`: explicit name or `true` to generate one. */
+	worktree?: string | true;
 	messages: string[];
 	fileArgs: string[];
 	/** Extension-registered flags this parse recognized — name to value. */

--- a/packages/coding-agent/src/cli/file-processor.ts
+++ b/packages/coding-agent/src/cli/file-processor.ts
@@ -26,6 +26,19 @@ export interface ProcessFileOptions {
 	autoResizeImages?: boolean;
 }
 
+/** Validate explicit CLI attachments before starting a durable workspace or session. */
+export function resolveFileArguments(fileArgs: string[], cwd = getProjectDir()): string[] {
+	return fileArgs.map(fileArg => path.resolve(resolveReadPath(fileArg, cwd)));
+}
+
+export function validateFileArguments(fileArgs: string[], cwd = getProjectDir()): void {
+	for (const absolutePath of resolveFileArguments(fileArgs, cwd)) {
+		if (!fs.statSync(absolutePath, { throwIfNoEntry: false })) {
+			throw new Error(`File not found: ${absolutePath}`);
+		}
+	}
+}
+
 /** Process @file arguments into text, document content, and image attachments */
 export async function processFileArguments(fileArgs: string[], options?: ProcessFileOptions): Promise<ProcessedFiles> {
 	const autoResizeImages = options?.autoResizeImages ?? true;

--- a/packages/coding-agent/src/cli/flag-tables.ts
+++ b/packages/coding-agent/src/cli/flag-tables.ts
@@ -86,6 +86,10 @@ const setResume: OptionalSetter = (result, value) => {
 	result.resume = value !== undefined ? value : true;
 };
 
+const setWorktree: OptionalSetter = (result, value) => {
+	result.worktree = value !== undefined ? value : true;
+};
+
 const MAX_TIME_DURATION_RE = /^(\d+(?:\.\d+)?)([smh])$/;
 
 function maxTimeMultiplier(unit: string | undefined): number {
@@ -246,6 +250,8 @@ export const OPTIONAL_FLAGS: Record<string, OptionalFlagConfig> = {
 	"--resume": { set: setResume, rejectEmpty: true },
 	"-r": { set: setResume, rejectEmpty: true },
 	"--session": { set: setResume, rejectEmpty: true },
+	"--worktree": { set: setWorktree, rejectEmpty: true },
+	"-w": { set: setWorktree, rejectEmpty: true },
 };
 
 /**

--- a/packages/coding-agent/src/cli/worktree-cli.ts
+++ b/packages/coding-agent/src/cli/worktree-cli.ts
@@ -6,6 +6,8 @@
  *   - **PR-checkout worktrees** (`tools/gh.ts`): a regular git worktree dir
  *     containing a `.git` *file* that points back at
  *     `<parent-repo>/.git/worktrees/<name>/`.
+ *   - **Main-session worktrees** (`--worktree`): regular linked Git worktrees
+ *     marked inside their per-worktree Git admin directory.
  *   - **Task-isolation dirs** (`task/worktree.ts`): a wrapper dir with a
  *     compact `m` subdir mounted/cloned by `natives.isoStart`. Legacy `merged`
  *     subdirs are still recognized. `ensureIsolation` writes an ownership
@@ -22,8 +24,9 @@ import * as vcs from "@oh-my-pi/pi-natives/vcs";
 import { getWorktreesDir, isEnoent } from "@oh-my-pi/pi-utils";
 import chalk from "@oh-my-pi/pi-utils/chalk";
 import { hasLiveIsolationOwner, ISOLATION_OWNER_FILE } from "../task/isolation-ownership";
+import { MAIN_SESSION_WORKTREE_MARKER } from "./worktree-create";
 
-type WorktreeKind = "pr-checkout" | "task-isolation" | "empty" | "stray";
+type WorktreeKind = "pr-checkout" | "main-session" | "task-isolation" | "empty" | "stray";
 
 const TASK_ISOLATION_MOUNT_DIRS = ["m", "merged"] as const;
 
@@ -77,7 +80,11 @@ export async function listWorktrees(options: ListWorktreesOptions): Promise<void
 
 export async function clearWorktrees(options: ClearWorktreesOptions): Promise<void> {
 	const entries = await scanWorktrees();
-	const targets = options.all ? entries : entries.filter(entry => entry.orphanReason !== undefined);
+	const targets = options.all
+		? entries
+		: entries.filter(
+				entry => entry.orphanReason !== undefined && entry.kind !== "pr-checkout" && entry.kind !== "main-session",
+			);
 
 	if (targets.length === 0) {
 		if (options.json) {
@@ -104,14 +111,18 @@ export async function clearWorktrees(options: ClearWorktreesOptions): Promise<vo
 	const parentsToPrune = new Set<string>();
 	for (const target of targets) {
 		try {
-			if (target.kind === "pr-checkout" && target.parentRepo && !target.orphanReason) {
-				// Live worktree: ask git to remove it cleanly. If git refuses (locked,
-				// dirty, etc.), fall back to fs.rm and rely on `worktree prune` to
-				// clean the bookkeeping on the parent side.
-				const removed = await vcs.git(target.parentRepo)?.worktreeRemove(target.path, true);
+			if (
+				(target.kind === "pr-checkout" || target.kind === "main-session") &&
+				target.parentRepo &&
+				!target.orphanReason
+			) {
+				// Never discard dirty work: a user must clean or explicitly remove the
+				// linked checkout themselves before the managed-worktree GC can proceed.
+				const removed = await vcs.git(target.parentRepo)?.worktreeRemove(target.path, false);
 				if (!removed) {
-					await fs.rm(target.path, { recursive: true, force: true });
-					parentsToPrune.add(target.parentRepo);
+					throw new Error(
+						"Git refused to remove the linked worktree because it has uncommitted changes or is locked.",
+					);
 				}
 			} else {
 				await fs.rm(target.path, { recursive: true, force: true });
@@ -212,7 +223,7 @@ async function classifyDir(dir: string): Promise<WorktreeEntry | null> {
 	const gitEntry = path.join(dir, ".git");
 	const gitStat = await fs.stat(gitEntry).catch(() => null);
 	if (gitStat?.isFile()) {
-		return classifyPrCheckout(dir, gitEntry);
+		return classifyLinkedWorktree(dir, gitEntry);
 	}
 	// A task-isolation sandbox is identified by its ownership marker — written
 	// before the backend materialises the mount — or by the `m`/`merged` mount
@@ -240,7 +251,7 @@ async function classifyDir(dir: string): Promise<WorktreeEntry | null> {
 	};
 }
 
-async function classifyPrCheckout(dir: string, gitEntry: string): Promise<WorktreeEntry> {
+async function classifyLinkedWorktree(dir: string, gitEntry: string): Promise<WorktreeEntry> {
 	let contents: string;
 	try {
 		contents = await fs.readFile(gitEntry, "utf8");
@@ -256,11 +267,14 @@ async function classifyPrCheckout(dir: string, gitEntry: string): Promise<Worktr
 	if (!parentGitDir) {
 		return { path: dir, kind: "pr-checkout", orphanReason: "malformed .git file (no gitdir line)" };
 	}
+	const resolvedGitDir = path.isAbsolute(parentGitDir)
+		? parentGitDir
+		: path.resolve(path.dirname(gitEntry), parentGitDir);
 	// parentGitDir is `<parent-repo>/.git/worktrees/<name>`; back out the repo root.
-	const parentRepo = path.dirname(path.dirname(path.dirname(parentGitDir)));
-	const branch = await readWorktreeBranch(path.join(parentGitDir, "HEAD"));
+	const parentRepo = path.dirname(path.dirname(path.dirname(resolvedGitDir)));
+	const branch = await readWorktreeBranch(path.join(resolvedGitDir, "HEAD"));
 
-	const parentDirStat = await fs.stat(parentGitDir).catch(() => null);
+	const parentDirStat = await fs.stat(resolvedGitDir).catch(() => null);
 	if (!parentDirStat?.isDirectory()) {
 		return {
 			path: dir,
@@ -280,7 +294,8 @@ async function classifyPrCheckout(dir: string, gitEntry: string): Promise<Worktr
 			orphanReason: "parent repo missing",
 		};
 	}
-	return { path: dir, kind: "pr-checkout", parentRepo, branch };
+	const persistent = await Bun.file(path.join(resolvedGitDir, MAIN_SESSION_WORKTREE_MARKER)).exists();
+	return { path: dir, kind: persistent ? "main-session" : "pr-checkout", parentRepo, branch };
 }
 
 async function readWorktreeBranch(headFile: string): Promise<string | undefined> {
@@ -299,6 +314,8 @@ function formatEntryDetail(entry: WorktreeEntry): string {
 		const repo = entry.parentRepo ? path.basename(entry.parentRepo) : "unknown repo";
 		const branch = entry.branch ?? "unknown branch";
 		parts.push(`${repo} · ${branch}`);
+	} else if (entry.kind === "main-session") {
+		parts.push("persistent main-session workspace");
 	} else if (entry.kind === "task-isolation") {
 		parts.push("task-isolation sandbox");
 	} else if (entry.kind === "empty") {

--- a/packages/coding-agent/src/cli/worktree-create.ts
+++ b/packages/coding-agent/src/cli/worktree-create.ts
@@ -1,0 +1,209 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import type { VcsGitRepo } from "@oh-my-pi/pi-natives";
+import * as vcs from "@oh-my-pi/pi-natives/vcs";
+import { getWorktreeDir, hashPath, isEnoent } from "@oh-my-pi/pi-utils";
+import chalk from "@oh-my-pi/pi-utils/chalk";
+import { generateTaskName } from "../task/name-generator";
+import { getRepoRoot } from "../task/worktree";
+import { withRepoLock } from "../utils/repo-lock";
+
+/** Stored in Git's linked-worktree admin dir, never in the user's checkout. */
+export const MAIN_SESSION_WORKTREE_MARKER = ".omp-main-session";
+
+export interface CreatedWorktree {
+	name: string;
+	workspacePath: string;
+	branch: string;
+	reused: boolean;
+}
+
+interface MainSessionWorktreeMarker {
+	name: string;
+	branch: string;
+}
+
+export function slugifyWorktreeName(input: string): string {
+	return input
+		.trim()
+		.replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, "-")
+		.replace(/^-+|-+$/g, "");
+}
+
+function isPullRequestRef(value: string): boolean {
+	return value.startsWith("#") || /\bgithub\.com\/[^/\s]+\/[^/\s]+\/pull\/\d+/i.test(value);
+}
+
+function reportCreatedWorktree(created: CreatedWorktree): void {
+	process.stderr.write(
+		`${chalk.green(created.reused ? "Reused managed workspace" : "Managed workspace")} ${chalk.bold(created.name)} ${chalk.dim(`(${created.branch})`)}\n`,
+	);
+	process.stderr.write(chalk.dim(`  ${created.workspacePath}\n`));
+	process.stderr.write(chalk.dim("  Inspect managed workspaces with: omp wt list\n"));
+}
+
+const PROJECT_CONFIGURATION_PATHS = [
+	".agents",
+	".claude",
+	".claude.json",
+	".codex",
+	".gemini",
+	".mcp.json",
+	".omp",
+	".pi",
+	"AGENTS.md",
+	"CLAUDE.md",
+	"GEMINI.md",
+] as const;
+
+function isMainSessionWorktreeMarker(value: unknown): value is MainSessionWorktreeMarker {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		"name" in value &&
+		typeof value.name === "string" &&
+		"branch" in value &&
+		typeof value.branch === "string"
+	);
+}
+
+async function copyMissingProjectConfigurationFiles(sourceRoot: string, workspacePath: string): Promise<void> {
+	async function copyMissing(source: string, destination: string): Promise<void> {
+		const sourceEntry = await fs.lstat(source).catch(error => {
+			if (isEnoent(error)) return null;
+			throw error;
+		});
+		if (!sourceEntry || sourceEntry.isSymbolicLink()) return;
+		const destinationEntry = await fs.lstat(destination).catch(error => {
+			if (isEnoent(error)) return null;
+			throw error;
+		});
+		if (sourceEntry.isDirectory()) {
+			if (!destinationEntry) {
+				await fs.mkdir(destination, { recursive: true, mode: sourceEntry.mode });
+			}
+			if (!destinationEntry || destinationEntry.isDirectory()) {
+				for (const child of await fs.readdir(source)) {
+					await copyMissing(path.join(source, child), path.join(destination, child));
+				}
+			}
+			return;
+		}
+		if (sourceEntry.isFile() && !destinationEntry) {
+			await fs.mkdir(path.dirname(destination), { recursive: true });
+			await fs.copyFile(source, destination);
+			await fs.chmod(destination, sourceEntry.mode);
+		}
+	}
+
+	for (const relativePath of PROJECT_CONFIGURATION_PATHS) {
+		await copyMissing(path.join(sourceRoot, relativePath), path.join(workspacePath, relativePath));
+	}
+}
+
+async function reuseManagedWorkspace(
+	repository: VcsGitRepo,
+	workspacePath: string,
+	name: string,
+	branch: string,
+): Promise<CreatedWorktree> {
+	const workspaceRepository = vcs.git(workspacePath);
+	if (
+		!workspaceRepository ||
+		path.resolve(workspaceRepository.primaryRoot()) !== path.resolve(repository.primaryRoot())
+	) {
+		throw new Error(`The existing path ${workspacePath} is not a managed workspace for this repository.`);
+	}
+	let marker: unknown;
+	try {
+		marker = JSON.parse(
+			await Bun.file(path.join(workspaceRepository.info().gitDir, MAIN_SESSION_WORKTREE_MARKER)).text(),
+		);
+	} catch {
+		throw new Error(`The existing path ${workspacePath} is not a persistent OMP-managed workspace.`);
+	}
+	if (!isMainSessionWorktreeMarker(marker) || marker.name !== name || marker.branch !== branch) {
+		throw new Error(`The existing path ${workspacePath} has an invalid managed-workspace marker.`);
+	}
+	if ((await workspaceRepository.currentBranch()) !== branch) {
+		throw new Error(`The managed workspace ${workspacePath} is no longer on branch ${branch}.`);
+	}
+	return { name, workspacePath, branch, reused: true };
+}
+
+export async function createWorktree(cwd: string, value: string | true): Promise<CreatedWorktree> {
+	let repoRoot: string;
+	try {
+		repoRoot = await getRepoRoot(cwd);
+	} catch (error) {
+		if (error instanceof Error && error.message.includes("pure Jujutsu")) throw error;
+		throw new Error("--worktree requires a Git repository. Run omp from inside a repository.");
+	}
+
+	if (value !== true && isPullRequestRef(value.trim())) {
+		throw new Error(`--worktree does not check out pull requests. Use \`omp gh pr_checkout ${value.trim()}\`.`);
+	}
+
+	const requested = value === true ? "" : slugifyWorktreeName(value);
+	const name = requested || slugifyWorktreeName(generateTaskName());
+	if (!name) throw new Error("--worktree requires a name containing letters or numbers.");
+	const branch = `omp/${name}`;
+	const workspacePath = getWorktreeDir(`main-${hashPath(repoRoot)}-${name}`);
+
+	return withRepoLock(repoRoot, async () => {
+		const repository = vcs.requireGit(repoRoot);
+		try {
+			await fs.stat(workspacePath);
+			const reused = await reuseManagedWorkspace(repository, workspacePath, name, branch);
+			reportCreatedWorktree(reused);
+			return reused;
+		} catch (error) {
+			if (!isEnoent(error)) throw error;
+		}
+
+		if (await repository.refExists(`refs/heads/${branch}`)) {
+			throw new Error(
+				`The managed branch "${branch}" already exists. Choose another workspace name or open its existing checkout directly.`,
+			);
+		}
+
+		try {
+			await repository.createBranch(branch, "HEAD", false);
+			await repository.worktreeAdd(workspacePath, branch, false);
+			const workspaceRepository = vcs.requireGit(workspacePath);
+			await copyMissingProjectConfigurationFiles(repoRoot, workspacePath);
+			await Bun.write(
+				path.join(workspaceRepository.info().gitDir, MAIN_SESSION_WORKTREE_MARKER),
+				`${JSON.stringify({ name, branch, createdAt: new Date().toISOString() })}\n`,
+			);
+		} catch (error) {
+			await repository.worktreeRemove(workspacePath, true).catch(() => {});
+			await repository.deleteBranch(branch, true).catch(() => {});
+			throw new Error(
+				`Failed to create the managed worktree: ${error instanceof Error ? error.message : String(error)}`,
+			);
+		}
+
+		const created: CreatedWorktree = {
+			name,
+			workspacePath,
+			branch,
+			reused: false,
+		};
+		reportCreatedWorktree(created);
+		return created;
+	});
+}
+
+/** Remove only a workspace freshly created by this invocation before startup fails. */
+export async function cleanupCreatedWorktree(cwd: string, created: CreatedWorktree): Promise<void> {
+	if (created.reused) return;
+	const repoRoot = await getRepoRoot(cwd);
+	await withRepoLock(repoRoot, async () => {
+		const repository = vcs.requireGit(repoRoot);
+		await repository.worktreeRemove(created.workspacePath, true).catch(() => {});
+		await repository.deleteBranch(created.branch, true).catch(() => {});
+	});
+}

--- a/packages/coding-agent/src/commands/launch-help.ts
+++ b/packages/coding-agent/src/commands/launch-help.ts
@@ -54,6 +54,10 @@ export const launchHelp = {
 		print: Flags.boolean({ char: "p", description: "Non-interactive mode: process prompt and exit" }),
 		continue: Flags.boolean({ char: "c", description: "Continue previous session" }),
 		resume: Flags.string({ char: "r", description: "Resume a session (by ID prefix, path, or picker if omitted)" }),
+		worktree: Flags.string({
+			char: "w",
+			description: "Start in a persistent managed workspace (name optional)",
+		}),
 		"from-claude": Flags.boolean({ description: "Import a Claude Code session into OMP" }),
 		"from-codex": Flags.boolean({ description: "Import a Codex session into OMP" }),
 		"session-dir": Flags.string({ description: "Directory for session storage and lookup" }),
@@ -112,6 +116,7 @@ export const launchHelp = {
 		`# Include files in initial message\n  ${APP_NAME} @prompt.md @image.png "What color is the sky?"`,
 		`# Non-interactive mode (process and exit)\n  ${APP_NAME} -p "List all .ts files in src/"`,
 		`# Continue previous session\n  ${APP_NAME} --continue "What did we discuss?"`,
+		`# Start a main session in a persistent managed workspace\n  ${APP_NAME} --worktree feature-auth`,
 		`# Create a shell shortcut for a work profile\n  ${APP_NAME} --profile work --alias omp-work`,
 		`# Use different model (fuzzy matching)\n  ${APP_NAME} --model opus "Help me refactor this code"`,
 		`# Limit model cycling to specific models\n  ${APP_NAME} --models claude-sonnet,claude-haiku,gpt-4o`,

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -26,11 +26,12 @@ import chalk from "@oh-my-pi/pi-utils/chalk";
 import { reset as resetCapabilities } from "./capability";
 import { type Args, reportUnrecognizedFlags, validateToolNames } from "./cli/args";
 import { applyExtensionFlags, type ExtensionFlagSink } from "./cli/extension-flags";
-import { processFileArguments } from "./cli/file-processor";
+import { processFileArguments, resolveFileArguments, validateFileArguments } from "./cli/file-processor";
 import { buildInitialMessage } from "./cli/initial-message";
 import { selectSession } from "./cli/session-picker";
 import { applyStartupCwd } from "./cli/startup-cwd";
 import { getLatestRelease } from "./cli/update-cli";
+import { type CreatedWorktree, cleanupCreatedWorktree, createWorktree } from "./cli/worktree-create";
 import { findConfigFile } from "./config";
 import { ModelRegistry } from "./config/model-registry";
 import {
@@ -1405,6 +1406,9 @@ export async function runRootCommand(
 		}
 
 		const notifs: (InteractiveModeNotify | null)[] = [];
+		let startupSettingsPromise: Promise<Settings> | undefined;
+		let createdWorktree: CreatedWorktree | undefined;
+		let worktreeSourceCwd: string | undefined;
 
 		if (parsedArgs.version) {
 			writeStartupNotice(parsedArgs, `${VERSION}\n`);
@@ -1429,6 +1433,33 @@ export async function runRootCommand(
 		if ((parsedArgs.mode === "rpc" || parsedArgs.mode === "rpc-ui") && parsedArgs.fileArgs.length > 0) {
 			process.stderr.write(`${chalk.red("Error: @file arguments are not supported in RPC mode")}\n`);
 			process.exit(1);
+		}
+
+		if (parsedArgs.worktree !== undefined) {
+			if (parsedArgs.fork !== undefined || parsedArgs.fromClaude || parsedArgs.fromCodex) {
+				process.stderr.write(
+					`${chalk.red("Error: --worktree cannot be combined with fork or session import flags")}\n`,
+				);
+				process.exit(1);
+			}
+
+			const launchCwd = getProjectDir();
+			worktreeSourceCwd = launchCwd;
+			startupSettingsPromise = deps.settings
+				? Promise.resolve(deps.settings)
+				: logger.time("settings:init:worktree", Settings.init, { cwd: launchCwd, configFiles: parsedArgs.config });
+			startupSettingsPromise.catch(() => {});
+			try {
+				const startupSettings = await startupSettingsPromise;
+				const worktree = await logger.time("createWorktree", createWorktree, launchCwd, parsedArgs.worktree);
+				createdWorktree = worktree;
+				setProjectDir(worktree.workspacePath);
+				await startupSettings.reloadForCwd(getProjectDir());
+			} catch (error) {
+				const message = error instanceof Error ? error.message : "Failed to create worktree";
+				process.stderr.write(`${chalk.red(`Error: ${message}`)}\n`);
+				process.exit(1);
+			}
 		}
 		const mode = parsedArgs.mode || "text";
 		// RPC owns stdin. Claim its singleton stream before plugin/extension discovery can load an in-process consumer.
@@ -1481,9 +1512,11 @@ export async function runRootCommand(
 		// startup error below, while its cache/config I/O overlaps settings I/O.
 		const authStoragePromise = logger.time("discoverAuthStorage", deps.discoverAuthStorage ?? discoverAuthStorage);
 		authStoragePromise.catch(() => {});
-		const settingsPromise = deps.settings
-			? Promise.resolve(deps.settings)
-			: logger.time("settings:init", Settings.init, { cwd, configFiles: parsedArgs.config });
+		const settingsPromise =
+			startupSettingsPromise ??
+			(deps.settings
+				? Promise.resolve(deps.settings)
+				: logger.time("settings:init", Settings.init, { cwd, configFiles: parsedArgs.config }));
 		settingsPromise.catch(() => {});
 		let authStorage: AuthStorage;
 		try {
@@ -1890,6 +1923,11 @@ export async function runRootCommand(
 				},
 			};
 			const initialArgs = applyExtensionFlags(extensionFlagSink, rawArgs) ?? parsedArgs;
+			// The user supplied relative @files from the primary checkout. Keep those
+			// attachments stable after switching the process into the linked workspace.
+			if (worktreeSourceCwd) {
+				initialArgs.fileArgs = resolveFileArguments(initialArgs.fileArgs, worktreeSourceCwd);
+			}
 			normalizeContinueSessionArgs(initialArgs, rawArgs);
 			if ((parsedArgs.trustedExtensions?.length ?? 0) > 0 && extensionsResult.errors.length > 0) {
 				throw new Error(
@@ -1910,7 +1948,20 @@ export async function runRootCommand(
 			// tool calls (issue #2459). Exit code 2 matches the conventional
 			// "command line usage error" convention.
 			if (reportUnrecognizedFlags(initialArgs)) {
+				if (createdWorktree && worktreeSourceCwd) {
+					await cleanupCreatedWorktree(worktreeSourceCwd, createdWorktree);
+				}
 				process.exit(2);
+			}
+			try {
+				validateFileArguments(initialArgs.fileArgs);
+			} catch (error) {
+				if (createdWorktree && worktreeSourceCwd) {
+					await cleanupCreatedWorktree(worktreeSourceCwd, createdWorktree);
+				}
+				const message = error instanceof Error ? error.message : String(error);
+				process.stderr.write(`${chalk.red(`Error: ${message}`)}\n`);
+				process.exit(1);
 			}
 			const processedFiles =
 				initialArgs.fileArgs.length > 0

--- a/packages/coding-agent/test/cli-main-worktree.test.ts
+++ b/packages/coding-agent/test/cli-main-worktree.test.ts
@@ -1,0 +1,195 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { getWorktreesDir, setWorktreesDir } from "@oh-my-pi/pi-utils";
+import { parseArgs } from "../src/cli/args";
+import { resolveFileArguments } from "../src/cli/file-processor";
+import { clearWorktrees } from "../src/cli/worktree-cli";
+import { cleanupCreatedWorktree, createWorktree } from "../src/cli/worktree-create";
+
+describe("main-session worktree launch flags", () => {
+	it("parses a named or generated managed workspace without consuming the prompt", () => {
+		const named = parseArgs(["--worktree", "feature-auth", "implement the feature"]);
+		expect(named.worktree).toBe("feature-auth");
+		expect(named.messages).toEqual(["implement the feature"]);
+
+		const generated = parseArgs(["--worktree", "--print", "inspect the repository"]);
+		expect(generated.worktree).toBe(true);
+		expect(generated.print).toBe(true);
+		expect(generated.messages).toEqual(["inspect the repository"]);
+	});
+});
+
+describe("main-session managed workspace", () => {
+	const tempDirs: string[] = [];
+	let originalWorktreesDir: string;
+
+	async function git(repo: string, ...args: string[]): Promise<string> {
+		const proc = Bun.spawn(["git", ...args], { cwd: repo, stdout: "pipe", stderr: "pipe" });
+		const stdout = await new Response(proc.stdout).text();
+		const exitCode = await proc.exited;
+		if (exitCode !== 0) throw new Error(await new Response(proc.stderr).text());
+		return stdout;
+	}
+
+	async function createRepository(): Promise<string> {
+		const repo = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "omp-main-wt-repo-")));
+		tempDirs.push(repo);
+		await git(repo, "init", "-q");
+		await git(repo, "config", "user.email", "test@example.com");
+		await git(repo, "config", "user.name", "Test User");
+		await git(repo, "remote", "add", "origin", "https://example.test/owner/repo.git");
+		await Bun.write(path.join(repo, "tracked.txt"), "base\n");
+		await git(repo, "add", "tracked.txt");
+		await git(repo, "commit", "-qm", "initial");
+		return repo;
+	}
+
+	beforeEach(async () => {
+		originalWorktreesDir = getWorktreesDir();
+		const home = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "omp-main-wt-home-")));
+		tempDirs.push(home);
+		setWorktreesDir(path.join(home, "wt"));
+	});
+
+	afterEach(async () => {
+		setWorktreesDir(originalWorktreesDir);
+		vi.restoreAllMocks();
+		await Promise.all(tempDirs.splice(0).map(dir => fs.rm(dir, { recursive: true, force: true })));
+	});
+
+	it("creates a persistent linked workspace with normal Git delivery metadata", async () => {
+		const repo = await createRepository();
+		const created = await createWorktree(repo, "feature-auth");
+
+		expect(await Bun.file(path.join(created.workspacePath, "tracked.txt")).text()).toBe("base\n");
+		expect((await git(created.workspacePath, "branch", "--show-current")).trim()).toBe("omp/feature-auth");
+		expect((await git(created.workspacePath, "remote", "get-url", "origin")).trim()).toBe(
+			"https://example.test/owner/repo.git",
+		);
+		expect(await git(created.workspacePath, "status", "--porcelain")).toBe("");
+		expect(await git(repo, "status", "--porcelain")).toBe("");
+		const reused = await createWorktree(repo, "feature-auth");
+		expect(reused).toMatchObject({ ...created, reused: true });
+	});
+
+	it("inherits source-only agent configuration without overwriting tracked worktree files", async () => {
+		const repo = await createRepository();
+		await fs.mkdir(path.join(repo, ".omp", "skills"), { recursive: true });
+		await fs.mkdir(path.join(repo, ".claude"), { recursive: true });
+		await fs.mkdir(path.join(repo, ".codex"), { recursive: true });
+		await fs.mkdir(path.join(repo, ".gemini"), { recursive: true });
+		await fs.mkdir(path.join(repo, ".agents", "skills"), { recursive: true });
+		await Bun.write(path.join(repo, ".omp", "config.yml"), "textVerbosity: high\n");
+		await Bun.write(path.join(repo, ".omp", "skills", "local.md"), "# Local skill\n");
+		await Bun.write(path.join(repo, ".claude", "settings.json"), '{"permissions": {}}\n');
+		await Bun.write(path.join(repo, ".codex", "config.toml"), "[mcp_servers]\n");
+		await Bun.write(path.join(repo, ".gemini", "settings.json"), '{"mcpServers": {}}\n');
+		await Bun.write(path.join(repo, ".agents", "skills", "local.md"), "# Agent skill\n");
+		await Bun.write(path.join(repo, ".mcp.json"), '{"mcpServers": {}}\n');
+		await Bun.write(path.join(repo, "AGENTS.md"), "# Agent instructions\n");
+
+		const created = await createWorktree(repo, "configured");
+
+		expect(await Bun.file(path.join(created.workspacePath, ".omp", "config.yml")).text()).toBe(
+			"textVerbosity: high\n",
+		);
+		expect(await Bun.file(path.join(created.workspacePath, ".omp", "skills", "local.md")).text()).toBe(
+			"# Local skill\n",
+		);
+		expect(await Bun.file(path.join(created.workspacePath, ".claude", "settings.json")).text()).toBe(
+			'{"permissions": {}}\n',
+		);
+		expect(await Bun.file(path.join(created.workspacePath, ".codex", "config.toml")).text()).toBe("[mcp_servers]\n");
+		expect(await Bun.file(path.join(created.workspacePath, ".gemini", "settings.json")).text()).toBe(
+			'{"mcpServers": {}}\n',
+		);
+		expect(await Bun.file(path.join(created.workspacePath, ".agents", "skills", "local.md")).text()).toBe(
+			"# Agent skill\n",
+		);
+		expect(await Bun.file(path.join(created.workspacePath, ".mcp.json")).text()).toBe('{"mcpServers": {}}\n');
+		expect(await Bun.file(path.join(created.workspacePath, "AGENTS.md")).text()).toBe("# Agent instructions\n");
+	});
+
+	it("keeps a persistent main-session workspace after its process owner exits", async () => {
+		const repo = await createRepository();
+		const created = await createWorktree(repo, "keep-me");
+
+		const output: string[] = [];
+		vi.spyOn(console, "log").mockImplementation(value => output.push(String(value)));
+		await clearWorktrees({ all: false, dryRun: true, json: true });
+
+		const result: { wouldRemove?: string[] } = JSON.parse(output.join("\n"));
+		expect(result.wouldRemove ?? []).not.toContain(created.workspacePath);
+	});
+
+	it("does not clear a linked workspace by default when its primary checkout is missing", async () => {
+		const repo = await createRepository();
+		const created = await createWorktree(repo, "primary-moved");
+		const movedRepo = `${repo}-moved`;
+		tempDirs.push(movedRepo);
+		await fs.rename(repo, movedRepo);
+
+		await clearWorktrees({ all: false, dryRun: false, json: true });
+
+		expect(await Bun.file(path.join(created.workspacePath, "tracked.txt")).exists()).toBe(true);
+	});
+
+	it("does not force-remove a dirty linked workspace even with --all", async () => {
+		const repo = await createRepository();
+		const created = await createWorktree(repo, "dirty-workspace");
+		await Bun.write(path.join(created.workspacePath, "tracked.txt"), "changed\n");
+		const output: string[] = [];
+		const previousExitCode = process.exitCode;
+		vi.spyOn(console, "log").mockImplementation(value => output.push(String(value)));
+
+		try {
+			await clearWorktrees({ all: true, dryRun: false, json: true });
+			expect(process.exitCode).toBe(1);
+		} finally {
+			process.exitCode = previousExitCode;
+		}
+
+		expect(await Bun.file(path.join(created.workspacePath, "tracked.txt")).text()).toBe("changed\n");
+		expect(JSON.parse(output.join("\n"))).toMatchObject({ removed: 0, failed: 1 });
+	});
+
+	it("serializes concurrent creation and reuses the completed workspace", async () => {
+		const repo = await createRepository();
+		const results = await Promise.allSettled([
+			createWorktree(repo, "shared-name"),
+			createWorktree(repo, "shared-name"),
+		]);
+
+		const created = results.filter(
+			(result): result is PromiseFulfilledResult<Awaited<ReturnType<typeof createWorktree>>> =>
+				result.status === "fulfilled",
+		);
+		expect(created).toHaveLength(2);
+		expect(created.map(result => result.value.reused).sort()).toEqual([false, true]);
+		expect(new Set(created.map(result => result.value.workspacePath)).size).toBe(1);
+	});
+
+	it("removes a newly created workspace when startup aborts before a session begins", async () => {
+		const repo = await createRepository();
+		const created = await createWorktree(repo, "abort-before-session");
+
+		await cleanupCreatedWorktree(repo, created);
+
+		expect(await Bun.file(created.workspacePath).exists()).toBe(false);
+		expect((await git(repo, "branch", "--list", created.branch)).trim()).toBe("");
+	});
+
+	it("accepts --continue alongside a managed-workspace name", () => {
+		const parsed = parseArgs(["--worktree", "resume-test", "--continue"]);
+		expect(parsed).toMatchObject({ worktree: "resume-test", continue: true });
+	});
+
+	it("anchors relative initial attachments to the primary checkout", async () => {
+		const repo = await createRepository();
+		await Bun.write(path.join(repo, "notes.md"), "outside the linked worktree\n");
+
+		expect(resolveFileArguments(["notes.md"], repo)).toEqual([path.join(repo, "notes.md")]);
+	});
+});


### PR DESCRIPTION
## Summary
- add `omp --worktree [name]` / `-w` for a persistent, linked Git worktree for the main session
- reuse the named workspace safely, retain normal Git remotes and delivery flow, and inherit source-only local agent configuration
- make managed-worktree cleanup Git-aware: default cleanup keeps persistent linked checkouts and explicit cleanup never force-removes dirty work
- preserve relative `@file` arguments from the launch checkout

This is a fresh, Git-native implementation of the requested main-session isolation in #452. It intentionally has no CMUX dependency.

## Verification
- `bun test test/cli-main-worktree.test.ts` (10 passed)
- `bun run check:ts`
- `bun run check:rs` (skipped: no Rust-affecting changes)
- `git diff --check`

Related to #452.