### PR TITLE
Preserve per-session drafts during Agent Hub navigation

### DIFF
--- a/docs/agent-hub.md
+++ b/docs/agent-hub.md
@@ -1,6 +1,6 @@
 # Agent Hub
 
-Agent Hub is the interactive TUI for watching and controlling subagents associated with the current session. It combines a live roster, per-agent activity and usage, transcript access, steering, revive, and kill controls. The main agent is not listed because its conversation is the ambient session view.
+Agent Hub is the interactive TUI for watching and controlling agents associated with the current session. It combines a stable operational roster, parent/child tree, per-agent activity and usage, transcript access, steering, revive, and kill controls. In a local tree view, Main is the selectable root; the flat roster remains subagent-only.
 
 The Hub also discovers parked subagents from the current session's persisted artifacts when a session is resumed. Advisor transcript files appear as read-only rows.
 
@@ -30,7 +30,12 @@ The roster updates from the session's agent registry and progress events. Its re
 - assigned task or current activity;
 - cost, active time or elapsed span, request count, tool-call count, and tokens.
 
-The header aggregates status and usage across measured agents. Press `t` to switch between the stable flat roster and a parent/child tree.
+The header aggregates status and usage across measured subagents. Press `t` to switch between the stable flat roster and a parent/child tree. The tree continues dim ancestry guides through each agent's wrapped activity and usage rows, stopping each guide after its last sibling. Set the initial view globally with:
+
+```yaml
+agentHub:
+  defaultView: tree
+```
 
 On a wide terminal, the selected agent's inspector appears beside the roster. On a narrow terminal, press `Tab` to replace the roster with it. The inspector adds:
 
@@ -54,17 +59,19 @@ Metrics depend on the progress or persisted usage data available for that agent.
 | `x`                         | Abort a running turn if necessary, then kill and release the selected agent. |
 | `Esc`                       | Close the inspector first on narrow terminals, then close the Hub.           |
 
-Only `parked` agents can be revived. `x` is immediate; use it only when you intend to discard that agent instance.
+Only `parked` subagents can be revived. `x` is immediate; use it only when you intend to discard that subagent instance.
 
 ## Read and steer a subagent
+
+In a local tree view, selecting Main returns the TUI to the root session without interrupting the focused child. The child continues working, and its unsent draft is restored when it is focused again.
 
 For a normal local subagent, `Enter` or click focuses the main TUI on that agent's session and closes the Hub. Focusing a parked agent revives it. The transcript, status line, and editor then belong to that subagent:
 
 1. Read its live transcript and tool activity.
 2. Type a message and press `Enter` to steer a running turn or prompt an idle agent.
-3. Press `Esc` with an empty editor, or double-tap `←`, to return to the main session.
+3. Press `Esc` with text in the editor to clear it. With an empty editor, `Esc` returns directly to Main. Double-tap `←` also returns to Main when the editor is empty.
 
-Steering uses the normal prompt path, so the message and response are written to the subagent's persisted session history. While a subagent is focused, `Esc` returns to the main session; it does not interrupt the subagent.
+While the top-level OMP process remains open, each focused session owns its unsent composer draft. Moving through Agent Hub preserves the current text and images, then restores the target session's draft.
 
 Contexts without a local focusable session use the Hub's full-screen transcript viewer instead. This includes collab guests and advisor rows. The viewer incrementally tails the file-backed transcript and provides an input line only when the selected agent can be messaged. Sending there has the same semantics: revive if parked, steer if running, and prompt if idle.
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -695,6 +695,7 @@ For a custom status line, set `statusLine.preset: custom` and configure `statusL
 | `followUpMode`         | enum    | `one-at-a-time` | `all`, `one-at-a-time`.                                                                                 |
 | `interruptMode`        | enum    | `immediate`     | `immediate`, `wait`.                                                                                    |
 | `doubleEscapeAction`   | enum    | `tree`          | `branch`, `tree`, `none`.                                                                               |
+| `agentHub.defaultView` | enum    | `roster`        | Initial Agent Hub layout: `roster` or `tree`.                                                          |
 | `autoResume`           | boolean | `false`         | Auto-resume the most recent session in the cwd.                                                         |
 | `plan.enabled`         | boolean | `true`          | Enable plan mode.                                                                                       |
 | `plan.defaultOnStartup` | boolean | `false`         | Start each fresh interactive session in plan mode when plan mode is enabled. Print/JSON (`--print`) mode ignores this and prints a note; use `--plan-yolo` for a headless plan flow. |

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,8 @@
 - Devin model selectors now accept the native CLI's short aliases (`devin/opus`, `devin/swe`), dotted upstream spellings (`devin/gemini-3.7-flash`), and raw effort-route wire uids for dynamically collapsed families ([#8590](https://github.com/can1357/oh-my-pi/pull/8590) by [@will-bogusz](https://github.com/will-bogusz)).
 - Added provider-supplied model metadata to the `/models` detail line: `new`, `beta`, and `recommended` badges beside the model name, and the upstream description after the context, cost, and perf facts ([#8590](https://github.com/can1357/oh-my-pi/pull/8590) by [@will-bogusz](https://github.com/will-bogusz)).
 - Standalone `CLAUDE.md` files in the project root (and ancestor directories) are now loaded as context, mirroring `AGENTS.md` discovery; config-directory context files still take precedence per scope.
+- Added `agentHub.defaultView` to open Agent Hub in either the flat roster or parent/child tree.
+- Added Main as the selectable root of local Agent Hub tree view, providing non-interrupting navigation out of a focused child.
 
 ### Changed
 
@@ -19,6 +21,8 @@
 - Fixed an issue where custom model overrides were lost during configuration updates
 - Fixed "Please use nerdfont" notification incorrectly persisting after theme configuration
 - Fixed sampling parameter errors for newer Anthropic models (Opus 4.7+, Sonnet 5+)
+- Preserved an independent composer draft for Main and each focused subagent when moving through Agent Hub, without changing focused-session `Esc` behaviour.
+- Rendered each nested Agent Hub tree depth with continuous ancestry guides through wrapped activity and usage rows.
 
 ## [18.0.11] - 2026-08-29
 

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -2001,6 +2001,22 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	"agentHub.defaultView": {
+		type: "enum",
+		values: ["roster", "tree"] as const,
+		default: "roster",
+		ui: {
+			tab: "interaction",
+			group: "Input",
+			label: "Agent Hub Default View",
+			description: "Initial Agent Hub layout",
+			options: [
+				{ value: "roster", label: "Flat roster" },
+				{ value: "tree", label: "Parent/child tree" },
+			],
+		},
+	},
+
 	treeFilterMode: {
 		type: "enum",
 		values: ["default", "no-tools", "user-only", "labeled-only", "all"] as const,

--- a/packages/coding-agent/src/modes/components/agent-hub-projection.ts
+++ b/packages/coding-agent/src/modes/components/agent-hub-projection.ts
@@ -159,7 +159,7 @@ export function aggregateMetrics(args: {
 }
 
 /** Parent-before-child projection preserving the roster's stable sibling order. */
-export function projectAgentTree(refs: readonly AgentRef[]): AgentTreeProjection {
+export function projectAgentTree(refs: readonly AgentRef[], mainRoot?: AgentRef): AgentTreeProjection {
 	const ids = new Set<string>();
 	const operationalIndex = new Map<string, number>();
 	for (let i = 0; i < refs.length; i++) {
@@ -241,8 +241,14 @@ export function projectAgentTree(refs: readonly AgentRef[]): AgentTreeProjection
 				stack.push({ ref: descendants[i], depth: current.depth + 1 });
 		}
 	};
-	for (const root of children.get(MAIN_AGENT_ID) ?? []) visit(root, 0);
-	// Corrupt persisted parent cycles remain visible as roots instead of disappearing.
-	for (const ref of refs) visit(ref, 0);
+	if (mainRoot) {
+		parentById.set(mainRoot.id, MAIN_AGENT_ID);
+		lastSiblingById.set(mainRoot.id, true);
+		visit(mainRoot, 0);
+	} else {
+		for (const root of children.get(MAIN_AGENT_ID) ?? []) visit(root, 0);
+	}
+	// Corrupt persisted parent cycles remain visible instead of disappearing.
+	for (const ref of refs) visit(ref, mainRoot ? 1 : 0);
 	return { rows, depthById, parentById, lastSiblingById };
 }

--- a/packages/coding-agent/src/modes/components/agent-hub-renderer.ts
+++ b/packages/coding-agent/src/modes/components/agent-hub-renderer.ts
@@ -3,7 +3,7 @@ import { Ellipsis, visibleWidth } from "@oh-my-pi/pi-tui";
 import { formatDuration, formatNumber, sanitizeText } from "@oh-my-pi/pi-utils";
 import { getRoleInfo } from "../../config/model-roles";
 import type { Settings } from "../../config/settings";
-import { type AgentRef, MAIN_AGENT_ID } from "../../registry/agent-registry";
+import type { AgentRef } from "../../registry/agent-registry";
 import { parseThinkingLevel } from "../../thinking";
 import { replaceTabs, TRUNCATE_LENGTHS, truncateToWidth } from "../../tools/render-utils";
 import type { ObservableSession } from "../session-observer-registry";
@@ -172,6 +172,32 @@ export function formatChildIds(children: readonly AgentRef[], width: number): st
 	return text;
 }
 
+function treePrefix(
+	ref: AgentRef,
+	maxWidth: number,
+	depthById: ReadonlyMap<string, number>,
+	parentById: ReadonlyMap<string, string>,
+	lastSiblingById: ReadonlyMap<string, boolean>,
+	ownSegment: string,
+): string {
+	const depth = depthById.get(ref.id) ?? 0;
+	if (depth === 0) return "";
+	const segments: string[] = [ownSegment];
+	const ancestry = new Set<string>();
+	let remainingAncestors = depth - 1;
+	let parent = parentById.get(ref.id);
+	while (parent && remainingAncestors > 0 && !ancestry.has(parent)) {
+		ancestry.add(parent);
+		segments.push(lastSiblingById.get(parent) ? "    " : "│   ");
+		parent = parentById.get(parent);
+		remainingAncestors--;
+	}
+	const maxSegments = Math.max(1, Math.floor(Math.max(4, maxWidth - 2) / 4));
+	const omitted = Math.max(0, segments.length - maxSegments);
+	const prefix = segments.slice(0, maxSegments).reverse().join("");
+	return theme.fg("dim", `${omitted > 0 ? "… " : ""}${prefix}`);
+}
+
 /** Bash `tree`-style ancestry prefix, clipped from the left on pathological depth. */
 export function treeBranch(
 	ref: AgentRef,
@@ -180,17 +206,30 @@ export function treeBranch(
 	parentById: ReadonlyMap<string, string>,
 	lastSiblingById: ReadonlyMap<string, boolean>,
 ): string {
-	if ((depthById.get(ref.id) ?? 0) === 0) return "";
-	const segments: string[] = [lastSiblingById.get(ref.id) ? "└── " : "├── "];
-	const ancestry = new Set<string>();
-	let parent = parentById.get(ref.id);
-	while (parent && parentById.get(parent) !== MAIN_AGENT_ID && !ancestry.has(parent)) {
-		ancestry.add(parent);
-		segments.push(lastSiblingById.get(parent) ? "    " : "│   ");
-		parent = parentById.get(parent);
-	}
-	const maxSegments = Math.max(1, Math.floor(Math.max(4, maxWidth - 2) / 4));
-	const omitted = Math.max(0, segments.length - maxSegments);
-	const prefix = segments.slice(0, maxSegments).reverse().join("");
-	return theme.fg("dim", `${omitted > 0 ? "… " : ""}${prefix}`);
+	return treePrefix(
+		ref,
+		maxWidth,
+		depthById,
+		parentById,
+		lastSiblingById,
+		lastSiblingById.get(ref.id) ? "└── " : "├── ",
+	);
+}
+
+/** Ancestry gutter continued through an agent entry's wrapped detail rows. */
+export function treeContinuation(
+	ref: AgentRef,
+	maxWidth: number,
+	depthById: ReadonlyMap<string, number>,
+	parentById: ReadonlyMap<string, string>,
+	lastSiblingById: ReadonlyMap<string, boolean>,
+): string {
+	return treePrefix(
+		ref,
+		maxWidth,
+		depthById,
+		parentById,
+		lastSiblingById,
+		lastSiblingById.get(ref.id) ? "    " : "│   ",
+	);
 }

--- a/packages/coding-agent/src/modes/components/agent-hub.ts
+++ b/packages/coding-agent/src/modes/components/agent-hub.ts
@@ -1,11 +1,10 @@
 /**
  * Agent Hub overlay component.
  *
- * One overlay, two views:
- * - Table view: every registered agent except Main (Main IS the ambient
- *   chat), live from the global AgentRegistry — status, unread irc count,
- *   current/last task, last activity. Navigate with keys, wheel, hover, and
- *   click; `r` revives a parked agent, `x` aborts + releases one.
+ * - Table view: every registered subagent in a stable operational roster. Tree
+ *   mode adds Main as the selectable root, letting focused users return without
+ *   interrupting a working child. Navigate with keys, wheel, hover, and click;
+ *   `r` revives a parked subagent, `x` aborts + releases one.
  * - Chat view: per-agent transcript (incremental session-file tail, absorbed
  *   from the old session observer overlay) plus an input line. Submitting
  *   revives a parked agent, then prompts/steers it; the message lands in the
@@ -63,6 +62,7 @@ import {
 	statusGlyph,
 	statusText,
 	treeBranch,
+	treeContinuation,
 } from "./agent-hub-renderer";
 import { AgentTranscriptViewer } from "./agent-transcript-viewer";
 import {
@@ -165,6 +165,7 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 
 	// Table state
 	#rows: AgentRef[] = [];
+	#subagentCount = 0;
 	#statusCounts: Record<AgentStatus, number> = { running: 0, idle: 0, parked: 0, aborted: 0 };
 	#selectedRow = 0;
 	#hoveredRow: number | null = null;
@@ -176,8 +177,8 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 	#nextRowOrder = 0;
 	/** Double-tap window state for the table's left-left "close hub" gesture. */
 	#lastLeftTap = 0;
-	/** Operational ordering by default; tree mode groups descendants under their spawner. */
-	#viewMode: HubViewMode = "roster";
+	/** Current projection; initialised from the Agent Hub default-view setting. */
+	#viewMode: HubViewMode;
 	#treeDepthById = new Map<string, number>();
 	#treeParentById = new Map<string, string>();
 	#treeLastSiblingById = new Map<string, boolean>();
@@ -226,6 +227,7 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 		this.#registry = deps.registry ?? AgentRegistry.global();
 		this.#observers = deps.observers;
 		this.#settings = deps.settings;
+		this.#viewMode = deps.settings?.get("agentHub.defaultView") ?? "roster";
 		this.#irc = deps.irc ?? IrcBus.global();
 		// Lazy: the lifecycle global self-constructs against the global
 		// registry, so only touch it when revive/kill actually needs it.
@@ -284,7 +286,7 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 	 * those included must wait for {@link persistedSubagentsReady} first.
 	 */
 	get isEmpty(): boolean {
-		return this.#rows.length === 0;
+		return this.#subagentCount === 0;
 	}
 
 	/** Tear down every subscription and timer. Called by the overlay owner on close. */
@@ -450,7 +452,8 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 		}
 
 		if (this.#viewMode === "tree") {
-			const tree = projectAgentTree(rosterRows);
+			const mainRoot = !this.#remote && this.#focusAgent ? this.#registry.get(MAIN_AGENT_ID) : undefined;
+			const tree = projectAgentTree(rosterRows, mainRoot);
 			this.#rows = tree.rows;
 			this.#treeDepthById = tree.depthById;
 			this.#treeParentById = tree.parentById;
@@ -461,6 +464,7 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 			this.#treeParentById.clear();
 			this.#treeLastSiblingById.clear();
 		}
+		this.#subagentCount = rosterRows.length;
 		const keptIndex = selectedId ? this.#rows.findIndex(ref => ref.id === selectedId) : -1;
 		this.#selectedRow = keptIndex >= 0 ? keptIndex : Math.min(this.#selectedRow, Math.max(0, this.#rows.length - 1));
 		const detailAgentId = this.#rows[this.#selectedRow]?.id;
@@ -713,7 +717,7 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 		if (metrics.reportedAgents === 0) {
 			lines.push(
 				...wrapTextWithAnsi(
-					theme.fg("dim", `Usage —${theme.sep.dot}0/${this.#rows.length} measured`),
+					theme.fg("dim", `Usage —${theme.sep.dot}0/${this.#subagentCount} measured`),
 					Math.max(1, width),
 				),
 			);
@@ -727,7 +731,7 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 			theme.fg("dim", `${formatNumber(metrics.tools)} tools`),
 			theme.fg("dim", `${formatNumber(metrics.tokens)} tok`),
 			theme.fg("dim", `${metrics.activeDurationAgents}/${metrics.reportedAgents} timed`),
-			theme.fg("dim", `${metrics.reportedAgents}/${this.#rows.length} measured`),
+			theme.fg("dim", `${metrics.reportedAgents}/${this.#subagentCount} measured`),
 		].join(theme.fg("dim", theme.sep.dot));
 		lines.push(...wrapTextWithAnsi(usage, Math.max(1, width)));
 		return lines;
@@ -746,8 +750,9 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 		const result = aggregateMetrics({
 			rows: this.#rows,
 			observedById: this.#observedById,
-			metricsFor: (ref, observed) => this.#metricsFor(ref, observed),
-			fallbackStatsSession: (ref, observed) => this.#fallbackStatsSession(ref, observed),
+			metricsFor: (ref, observed) => (ref.id === MAIN_AGENT_ID ? undefined : this.#metricsFor(ref, observed)),
+			fallbackStatsSession: (ref, observed) =>
+				ref.id === MAIN_AGENT_ID ? undefined : this.#fallbackStatsSession(ref, observed),
 			sessionMetrics: this.#sessionMetrics,
 			refreshFallback,
 		});
@@ -826,9 +831,13 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 		}
 
 		section("Lineage");
-		add(
-			`Spawned by ${sanitizeDisplayText(ref.parentId ?? MAIN_AGENT_ID)}${children.length > 0 ? ` · ${children.length} children` : ""}`,
-		);
+		if (ref.id === MAIN_AGENT_ID) {
+			add(`Root session${children.length > 0 ? ` · ${children.length} children` : ""}`);
+		} else {
+			add(
+				`Spawned by ${sanitizeDisplayText(ref.parentId ?? MAIN_AGENT_ID)}${children.length > 0 ? ` · ${children.length} children` : ""}`,
+			);
+		}
 		if (children.length > 0) add(theme.fg("dim", formatChildIds(children, width)));
 		add(theme.fg("dim", `Registered ${formatLocalDateTimeWithOffset(new Date(ref.createdAt))}`));
 
@@ -867,10 +876,13 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 	): string[] {
 		const max = Math.max(1, width);
 		const cursor = selected ? theme.fg("accent", theme.nav.cursor) : " ";
-		const depth = this.#viewMode === "tree" ? (this.#treeDepthById.get(ref.id) ?? 0) : 0;
 		const branch =
 			this.#viewMode === "tree"
 				? treeBranch(ref, max, this.#treeDepthById, this.#treeParentById, this.#treeLastSiblingById)
+				: "";
+		const continuation =
+			this.#viewMode === "tree"
+				? treeContinuation(ref, max, this.#treeDepthById, this.#treeParentById, this.#treeLastSiblingById)
 				: "";
 		const id = sanitizeDisplayText(ref.id);
 		const styledId = selected ? theme.bold(theme.fg("accent", id)) : theme.bold(id);
@@ -903,12 +915,17 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 		const leftWidth = visibleWidth(left);
 		const rightWidth = visibleWidth(right);
 		const entry: string[] = [];
-		const detailIndent = Math.min(max - 1, 4 + depth * 2);
+		const availableDetailPrefixWidth = Math.max(0, max - 1);
+		const detailPrefix =
+			availableDetailPrefixWidth > 0
+				? truncateToWidth(`${padding(4)}${continuation}`, availableDetailPrefixWidth)
+				: "";
+		const detailIndent = visibleWidth(detailPrefix);
 		if (leftWidth + 2 + rightWidth <= max) {
 			entry.push(left + padding(max - leftWidth - rightWidth) + right);
 		} else {
 			entry.push(truncateToWidth(left.replace(/[\r\n]+/g, " "), max));
-			entry.push(`${padding(Math.max(0, detailIndent))}${truncateToWidth(right, Math.max(1, max - detailIndent))}`);
+			entry.push(`${detailPrefix}${truncateToWidth(right, Math.max(1, max - detailIndent))}`);
 		}
 
 		const metrics = this.#metricsFor(ref, observed);
@@ -919,7 +936,7 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 			? `${theme.fg("muted", sanitizeLine(task, detailWidth))}${theme.fg("dim", theme.sep.dot)}${usage}`
 			: usage;
 		for (const wrapped of wrapTextWithAnsi(details, detailWidth)) {
-			entry.push(`${padding(Math.max(0, detailIndent))}${wrapped}`);
+			entry.push(`${detailPrefix}${wrapped}`);
 		}
 		if (!hovered) return entry;
 		return entry.map(lineRow => {
@@ -1074,6 +1091,11 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 	#reviveSelected(): void {
 		const ref = this.#rows[this.#selectedRow];
 		if (!ref) return;
+		if (ref.id === MAIN_AGENT_ID) {
+			this.#notice = "Main is the root session — it does not need revival.";
+			this.#requestRender();
+			return;
+		}
 		if (ref.kind === "advisor") {
 			this.#notice = `"${ref.id}" is a read-only advisor transcript — nothing to revive.`;
 			this.#requestRender();
@@ -1103,6 +1125,11 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 	#killSelected(): void {
 		const ref = this.#rows[this.#selectedRow];
 		if (!ref) return;
+		if (ref.id === MAIN_AGENT_ID) {
+			this.#notice = "Main is the root session — it cannot be killed from Agent Hub.";
+			this.#requestRender();
+			return;
+		}
 		if (ref.kind === "advisor") {
 			this.#notice = `"${ref.id}" is a read-only advisor transcript — cannot be killed.`;
 			this.#requestRender();

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -205,6 +205,11 @@ export class InputController {
 		this.ctx.ui.requestRender();
 	}
 
+	/** Drop text and image payloads retained for a terminal agent generation. */
+	discardComposerDraft(agentId: string): void {
+		this.#sessionDrafts.delete(agentId);
+	}
+
 	/** Return Main's draft even when teardown begins from a focused subagent. */
 	getDraftText(): string {
 		if (!this.ctx.focusedAgentId) return this.#draftText ?? this.ctx.editor.getExpandedText();

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -21,6 +21,7 @@ import { parseQueueShorthand, splitQueuedMessages } from "../../modes/queue-inpu
 import { buildSkillCommandPrompt, isKnownSkillCommand } from "../../modes/skill-command";
 import type { InteractiveModeContext } from "../../modes/types";
 import manualContinuePrompt from "../../prompts/system/manual-continue.md" with { type: "text" };
+import { MAIN_AGENT_ID } from "../../registry/agent-registry";
 import { USER_INTERRUPT_LABEL } from "../../session/messages";
 import { executeBuiltinSlashCommand, lookupBuiltinSlashCommand } from "../../slash-commands/builtin-registry";
 import { parseSlashCommand } from "../../slash-commands/helpers/parse";
@@ -182,15 +183,32 @@ export class InputController {
 
 	#enhancedPaste?: EnhancedPasteController;
 	#draftText: string | undefined;
+	#sessionDrafts = new Map<string, { text: string; images: ImageContent[] }>();
 	#focusedLeftTapListenerInstalled = false;
 	#focusedPasteListenerInstalled = false;
 	#btwBranchListenerInstalled = false;
 	#btwCopyListenerInstalled = false;
 	#expandToolsListenerInstalled = false;
 
-	/** Return the last full editor snapshot delivered by its change contract. */
+	/** Save the current composer and restore the composer owned by the target session. */
+	switchComposerDraft(fromAgentId: string | undefined, toAgentId: string | undefined): void {
+		const fromId = fromAgentId ?? MAIN_AGENT_ID;
+		const toId = toAgentId ?? MAIN_AGENT_ID;
+		this.#sessionDrafts.set(fromId, {
+			text: this.ctx.editor.getExpandedText(),
+			images: [...this.ctx.editor.pendingImages],
+		});
+		const target = this.#sessionDrafts.get(toId);
+		if (target) this.ctx.editor.setDraft(target.text, target.images);
+		else this.ctx.editor.clearDraft();
+		this.#draftText = this.ctx.editor.getText();
+		this.ctx.ui.requestRender();
+	}
+
+	/** Return Main's draft even when teardown begins from a focused subagent. */
 	getDraftText(): string {
-		return this.#draftText ?? this.ctx.editor.getText();
+		if (!this.ctx.focusedAgentId) return this.#draftText ?? this.ctx.editor.getExpandedText();
+		return this.#sessionDrafts.get(MAIN_AGENT_ID)?.text ?? "";
 	}
 
 	// Tap counter for the double-← gesture; reset whenever a quiet gap

--- a/packages/coding-agent/src/modes/controllers/session-focus-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/session-focus-controller.ts
@@ -63,9 +63,15 @@ export class SessionFocusController {
 	}
 
 	/** Return to the main session. No-op when unfocused. */
-	async unfocus(): Promise<void> {
+	unfocus(): Promise<void> {
+		return this.#unfocus(false);
+	}
+
+	async #unfocus(discardFocusedDraft: boolean): Promise<void> {
 		if (!this.#focusedAgentId) return;
-		this.ctx.switchComposerDraft(this.#focusedAgentId, undefined);
+		const focusedAgentId = this.#focusedAgentId;
+		this.ctx.switchComposerDraft(focusedAgentId, undefined);
+		if (discardFocusedDraft) this.ctx.discardComposerDraft(focusedAgentId);
 		this.#focusedAgentId = undefined;
 		this.#attachedSession = undefined;
 		const attached = await this.#attach(this.ctx.session);
@@ -78,11 +84,16 @@ export class SessionFocusController {
 	}
 
 	#onRegistryEvent(event: RegistryEvent): void {
-		if (event.ref.id !== this.#focusedAgentId) return;
 		const gone = event.type === "removed";
-		const dead = event.type === "status_changed" && (event.ref.status === "parked" || event.ref.status === "aborted");
-		if (!gone && !dead) return;
-		void this.unfocus().then(() => {
+		const aborted = event.type === "status_changed" && event.ref.status === "aborted";
+		const parked = event.type === "status_changed" && event.ref.status === "parked";
+		const terminal = gone || aborted;
+		if (event.ref.id !== this.#focusedAgentId) {
+			if (terminal) this.ctx.discardComposerDraft(event.ref.id);
+			return;
+		}
+		if (!terminal && !parked) return;
+		void this.#unfocus(terminal).then(() => {
 			this.ctx.showStatus(`Agent ${event.ref.id} is ${gone ? "gone" : event.ref.status}; returned to main session`);
 		});
 	}

--- a/packages/coding-agent/src/modes/controllers/session-focus-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/session-focus-controller.ts
@@ -4,9 +4,8 @@
  *
  * Focusing re-points the transcript, streaming event subscription, status
  * line, and editor prompt/interrupt at a subagent's live AgentSession (from
- * AgentRegistry) without touching the main session underneath; unfocusing
- * re-attaches the main session and rebuilds the transcript from its
- * authoritative state.
+ * AgentRegistry). Each session keeps its own composer draft while the
+ * transcript view moves between agents.
  */
 
 import { AgentLifecycleManager } from "../../registry/agent-lifecycle";
@@ -43,6 +42,7 @@ export class SessionFocusController {
 		if (id === MAIN_AGENT_ID) return this.unfocus();
 		const session = await this.lifecycle().ensureLive(id);
 		if (id === this.#focusedAgentId && session === this.#attachedSession) return;
+		this.ctx.switchComposerDraft(this.#focusedAgentId, id);
 		this.#focusedAgentId = id;
 		this.#attachedSession = session;
 		this.#registryUnsubscribe ??= this.registry.onChange(e => this.#onRegistryEvent(e));
@@ -65,6 +65,7 @@ export class SessionFocusController {
 	/** Return to the main session. No-op when unfocused. */
 	async unfocus(): Promise<void> {
 		if (!this.#focusedAgentId) return;
+		this.ctx.switchComposerDraft(this.#focusedAgentId, undefined);
 		this.#focusedAgentId = undefined;
 		this.#attachedSession = undefined;
 		const attached = await this.#attach(this.ctx.session);

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -792,8 +792,13 @@ export class InteractiveMode implements InteractiveModeContext {
 	unfocusSession(): Promise<void> {
 		return this.#focusController.unfocus();
 	}
+	/** Save the current session's composer draft and restore the target session's draft. */
 	switchComposerDraft(fromAgentId: string | undefined, toAgentId: string | undefined): void {
 		this.#inputController.switchComposerDraft(fromAgentId, toAgentId);
+	}
+	/** Drop text and image payloads retained for a terminal agent generation. */
+	discardComposerDraft(agentId: string): void {
+		this.#inputController.discardComposerDraft(agentId);
 	}
 	clearTransientSessionUi(): void {
 		this.#hideSessionInfo();

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -792,6 +792,9 @@ export class InteractiveMode implements InteractiveModeContext {
 	unfocusSession(): Promise<void> {
 		return this.#focusController.unfocus();
 	}
+	switchComposerDraft(fromAgentId: string | undefined, toAgentId: string | undefined): void {
+		this.#inputController.switchComposerDraft(fromAgentId, toAgentId);
+	}
 	clearTransientSessionUi(): void {
 		this.#hideSessionInfo();
 		if (this.loadingAnimation) {

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -145,6 +145,8 @@ export interface InteractiveModeContext {
 	unfocusSession(): Promise<void>;
 	/** Save the current session's composer draft and restore the target session's draft. */
 	switchComposerDraft(fromAgentId: string | undefined, toAgentId: string | undefined): void;
+	/** Drop text and image payloads retained for a terminal agent generation. */
+	discardComposerDraft(agentId: string): void;
 	/** Clear loader, transient HUD/pending containers, streaming state, and pending tools. */
 	clearTransientSessionUi(): void;
 	settings: Settings;

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -143,6 +143,8 @@ export interface InteractiveModeContext {
 	focusParentSession(): Promise<void>;
 	/** Return the view to the main session (delegates to SessionFocusController.unfocus). */
 	unfocusSession(): Promise<void>;
+	/** Save the current session's composer draft and restore the target session's draft. */
+	switchComposerDraft(fromAgentId: string | undefined, toAgentId: string | undefined): void;
 	/** Clear loader, transient HUD/pending containers, streaming state, and pending tools. */
 	clearTransientSessionUi(): void;
 	settings: Settings;

--- a/packages/coding-agent/test/agent-hub-activate.test.ts
+++ b/packages/coding-agent/test/agent-hub-activate.test.ts
@@ -120,6 +120,49 @@ describe("Agent hub Enter activation", () => {
 		hub.dispose();
 	});
 
+	it("selecting the Main tree root returns to Main without interrupting the child", async () => {
+		const agents = new AgentRegistry();
+		agents.register({
+			id: "Main",
+			displayName: "Main",
+			kind: "main",
+			session: { subscribe: () => () => {} } as unknown as AgentSession,
+			status: "running",
+		});
+		const childAbort = vi.fn(async () => {});
+		agents.register({
+			id: AGENT_ID,
+			displayName: AGENT_ID,
+			kind: "sub",
+			parentId: "Main",
+			session: { abort: childAbort, subscribe: () => () => {} } as unknown as AgentSession,
+			status: "running",
+		});
+		const settings = Settings.isolated();
+		settings.set("agentHub.defaultView", "tree");
+		const focusedIds: string[] = [];
+		const done = Promise.withResolvers<void>();
+		const hub = new AgentHubOverlayComponent({
+			settings,
+			observers: new SessionObserverRegistry(),
+			hubKeys: [],
+			onDone: () => done.resolve(),
+			requestRender: () => {},
+			registry: agents,
+			irc: new IrcBus(agents),
+			focusAgent: async id => {
+				focusedIds.push(id);
+			},
+		});
+
+		hub.handleInput("\r");
+		await done.promise;
+
+		expect(focusedIds).toEqual(["Main"]);
+		expect(childAbort).not.toHaveBeenCalled();
+		hub.dispose();
+	});
+
 	it("a focus failure keeps the hub open and shows the error as a notice", async () => {
 		const message = 'Agent "X" is aborted and cannot be revived';
 		const { hub, doneCalls, renderRequested } = makeHub(() => Promise.reject(new Error(message)));

--- a/packages/coding-agent/test/agent-hub-ordering.test.ts
+++ b/packages/coding-agent/test/agent-hub-ordering.test.ts
@@ -156,6 +156,104 @@ describe("Agent hub row ordering", () => {
 		}
 	});
 
+	it("opens in the configured parent/child tree view", () => {
+		geometry = stubStdoutGeometry(120);
+		const agents = new AgentRegistry();
+		agents.register({
+			id: "Parent",
+			displayName: "Parent",
+			kind: "sub",
+			parentId: "Main",
+			session: {} as AgentSession,
+		});
+		agents.register({
+			id: "Child",
+			displayName: "Child",
+			kind: "sub",
+			parentId: "Parent",
+			session: {} as AgentSession,
+		});
+		const settings = Settings.isolated();
+		settings.set("agentHub.defaultView", "tree");
+		const hub = makeHub(agents, { settings });
+
+		try {
+			expect(renderedAgentIds(hub)).toEqual(["Parent", "Child"]);
+			expect(Bun.stripANSI(renderedRosterEntry(hub, "Child", 120))).toContain("└── Child");
+		} finally {
+			hub.dispose();
+		}
+	});
+
+	it("renders selectable Main as the tree root without counting it as a subagent", () => {
+		geometry = stubStdoutGeometry(120);
+		const agents = new AgentRegistry();
+		agents.register({ id: "Main", displayName: "Main", kind: "main", session: {} as AgentSession });
+		agents.register({
+			id: "Parent",
+			displayName: "Parent",
+			kind: "sub",
+			parentId: "Main",
+			session: {} as AgentSession,
+		});
+		agents.register({
+			id: "Child",
+			displayName: "Child",
+			kind: "sub",
+			parentId: "Parent",
+			session: {} as AgentSession,
+		});
+		agents.register({
+			id: "DepthFour",
+			displayName: "Depth Four",
+			kind: "sub",
+			parentId: "Child",
+			session: {} as AgentSession,
+		});
+		const settings = Settings.isolated();
+		settings.set("agentHub.defaultView", "tree");
+		const hub = makeHub(agents, { settings });
+
+		try {
+			expect(renderedAgentIds(hub)).toEqual(["Main", "Parent", "Child", "DepthFour"]);
+			expect(Bun.stripANSI(renderedRosterHeaderLineRaw(hub, "Main", 120))).not.toMatch(/[├└]──/u);
+			expect(Bun.stripANSI(renderedRosterHeaderLineRaw(hub, "Parent", 120))).toContain("└── Parent");
+			expect(Bun.stripANSI(renderedRosterHeaderLineRaw(hub, "Child", 120))).toContain("    └── Child");
+			expect(Bun.stripANSI(renderedRosterHeaderLineRaw(hub, "DepthFour", 120))).toContain("        └── DepthFour");
+			const tree = Bun.stripANSI(hub.render(120).join("\n"));
+			expect(tree).toContain("Root session · 1 children");
+			expect(tree).toContain("0/3 measured");
+			expect(hub.isEmpty).toBe(false);
+
+			hub.handleInput("x");
+			expect(Bun.stripANSI(hub.render(120).join("\n"))).toContain("Main is the root session — it cannot be killed");
+			hub.handleInput("r");
+			expect(Bun.stripANSI(hub.render(120).join("\n"))).toContain(
+				"Main is the root session — it does not need revival",
+			);
+
+			hub.handleInput("t");
+			expect(renderedAgentIds(hub)).toEqual(["Child", "DepthFour", "Parent"]);
+		} finally {
+			hub.dispose();
+		}
+	});
+
+	it("keeps the Hub content-empty contract when tree mode has only Main", () => {
+		const agents = new AgentRegistry();
+		agents.register({ id: "Main", displayName: "Main", kind: "main", session: {} as AgentSession });
+		const settings = Settings.isolated();
+		settings.set("agentHub.defaultView", "tree");
+		const hub = makeHub(agents, { settings });
+
+		try {
+			expect(hub.isEmpty).toBe(true);
+			expect(renderedAgentIds(hub)).toEqual(["Main"]);
+		} finally {
+			hub.dispose();
+		}
+	});
+
 	it("freezes the initial lastActivity order while the hub is open", () => {
 		vi.useFakeTimers();
 		let hub: AgentHubOverlayComponent | undefined;
@@ -940,7 +1038,14 @@ describe("Agent hub row ordering", () => {
 		geometry.setRows(32);
 		const agents = new AgentRegistry();
 		agents.register({ id: "Parent", displayName: "Parent", kind: "sub", parentId: "Main", session: null });
-		agents.register({ id: "First", displayName: "First", kind: "sub", parentId: "Parent", session: null });
+		agents.register({
+			id: "First",
+			displayName: "First",
+			kind: "sub",
+			parentId: "Parent",
+			activity: "Inspect every wrapped detail row while preserving the visible parent lineage",
+			session: null,
+		});
 		agents.register({ id: "Grandchild", displayName: "Grandchild", kind: "sub", parentId: "First", session: null });
 		agents.register({ id: "Last", displayName: "Last", kind: "sub", parentId: "Parent", session: null });
 		const hub = makeHub(agents);
@@ -950,6 +1055,15 @@ describe("Agent hub row ordering", () => {
 			expect(Bun.stripANSI(renderedRosterHeaderLineRaw(hub, "First", 120))).toContain("├── First");
 			expect(Bun.stripANSI(renderedRosterHeaderLineRaw(hub, "Grandchild", 120))).toContain("│   └── Grandchild");
 			expect(Bun.stripANSI(renderedRosterHeaderLineRaw(hub, "Last", 120))).toContain("└── Last");
+			const firstEntry = Bun.stripANSI(renderedRosterEntry(hub, "First", 72)).split("\n");
+			expect(firstEntry.length).toBeGreaterThan(2);
+			for (const detailRow of firstEntry.slice(1)) {
+				expect(detailRow).toStartWith("    │   ");
+			}
+			const grandchildEntry = Bun.stripANSI(renderedRosterEntry(hub, "Grandchild", 72)).split("\n");
+			expect(grandchildEntry[1]).toStartWith("    │       ");
+			const lastEntry = Bun.stripANSI(renderedRosterEntry(hub, "Last", 72)).split("\n");
+			expect(lastEntry[1]).not.toContain("│");
 		} finally {
 			hub.dispose();
 		}

--- a/packages/coding-agent/test/input-controller-keybindings.test.ts
+++ b/packages/coding-agent/test/input-controller-keybindings.test.ts
@@ -336,6 +336,24 @@ describe("InputController keybinding setup", () => {
 		expect(editor.pendingImages).toEqual([workerImage]);
 	});
 
+	it("drops terminal agent composer text and image payloads", async () => {
+		const { InputController, ctx, editor } = await createContext();
+		const controller = new InputController(ctx);
+		const workerImage: ImageContent = { type: "image", mimeType: "image/png", data: "worker" };
+
+		editor.setText("main draft");
+		controller.switchComposerDraft(undefined, "Worker");
+		editor.setText("worker draft");
+		editor.pendingImages = [workerImage];
+		controller.switchComposerDraft("Worker", undefined);
+
+		controller.discardComposerDraft("Worker");
+		controller.switchComposerDraft(undefined, "Worker");
+
+		expect(editor.getText()).toBe("");
+		expect(editor.pendingImages).toEqual([]);
+	});
+
 	it("registers the tool activity visibility action", async () => {
 		const { InputController, ctx, editor, spies } = await createContext();
 		const controller = new InputController(ctx);

--- a/packages/coding-agent/test/input-controller-keybindings.test.ts
+++ b/packages/coding-agent/test/input-controller-keybindings.test.ts
@@ -34,6 +34,7 @@ type FakeEditor = {
 	getText(): string;
 	getExpandedText(): string;
 	setCollapsedText(text: string): void;
+	setDraft(text: string, images?: readonly ImageContent[]): void;
 	composerChips(): unknown[];
 	addToHistory(text: string): void;
 	setActionKeys(action: string, keys: string[]): void;
@@ -86,6 +87,7 @@ async function createContext() {
 	const requestRender = vi.fn();
 	const showError = vi.fn();
 	let focused: unknown;
+	let focusedAgentId: string | undefined;
 	let overlayVisible = false;
 	const addInputListener = vi.fn((listener: InputListener) => {
 		void listener;
@@ -132,6 +134,10 @@ async function createContext() {
 		setCollapsedText(text: string) {
 			editorText = text;
 		},
+		setDraft(text: string, images?: readonly ImageContent[]) {
+			editorText = text;
+			this.pendingImages = images ? [...images] : [];
+		},
 		composerChips() {
 			return [];
 		},
@@ -173,6 +179,9 @@ async function createContext() {
 		retryEscapeHandler: undefined,
 		session: session as unknown as InteractiveModeContext["session"],
 		viewSession: session as unknown as InteractiveModeContext["viewSession"],
+		get focusedAgentId() {
+			return focusedAgentId;
+		},
 		keybindings: {
 			getKeys(action: string) {
 				return keyMap[action] ? [...keyMap[action]] : [];
@@ -248,6 +257,9 @@ async function createContext() {
 		setOverlayVisible(visible: boolean) {
 			overlayVisible = visible;
 		},
+		setFocusedAgentId(id: string | undefined) {
+			focusedAgentId = id;
+		},
 		setKeybinding(action: string, keys: KeyId[]) {
 			keyMap[action] = keys;
 		},
@@ -297,6 +309,31 @@ describe("InputController keybinding setup", () => {
 		expect(spies.showModelSelector).toHaveBeenNthCalledWith(1, { temporaryOnly: true });
 		expect(spies.showModelSelector).toHaveBeenNthCalledWith(2);
 		expect(spies.resetDisplayAfterAppearanceRefresh).toHaveBeenCalledTimes(1);
+	});
+
+	it("keeps independent main and focused-agent composer drafts", async () => {
+		const { InputController, ctx, editor, setFocusedAgentId } = await createContext();
+		const controller = new InputController(ctx);
+		const mainImage: ImageContent = { type: "image", mimeType: "image/png", data: "main" };
+		const workerImage: ImageContent = { type: "image", mimeType: "image/jpeg", data: "worker" };
+
+		editor.setText("main draft");
+		editor.pendingImages = [mainImage];
+		controller.switchComposerDraft(undefined, "Worker");
+		expect(editor.getText()).toBe("");
+		expect(editor.pendingImages).toEqual([]);
+
+		editor.setText("worker draft");
+		editor.pendingImages = [workerImage];
+		setFocusedAgentId("Worker");
+		expect(controller.getDraftText()).toBe("main draft");
+
+		controller.switchComposerDraft("Worker", undefined);
+		expect(editor.getText()).toBe("main draft");
+		expect(editor.pendingImages).toEqual([mainImage]);
+		controller.switchComposerDraft(undefined, "Worker");
+		expect(editor.getText()).toBe("worker draft");
+		expect(editor.pendingImages).toEqual([workerImage]);
 	});
 
 	it("registers the tool activity visibility action", async () => {
@@ -352,11 +389,10 @@ describe("InputController keybinding setup", () => {
 	});
 
 	it("retries the focused view session instead of the main session", async () => {
-		const { InputController, ctx, editor, spies } = await createContext();
+		const { InputController, ctx, editor, setFocusedAgentId, spies } = await createContext();
 		const focusedRetry = vi.fn(async () => true);
-		(ctx as unknown as { focusedAgentId: string; viewSession: { retry: typeof focusedRetry } }).focusedAgentId =
-			"worker";
-		(ctx as unknown as { viewSession: { retry: typeof focusedRetry } }).viewSession = { retry: focusedRetry };
+		setFocusedAgentId("worker");
+		Reflect.set(ctx, "viewSession", { retry: focusedRetry });
 		const controller = new InputController(ctx);
 
 		controller.setupKeyHandlers();

--- a/packages/coding-agent/test/session-focus-controller.test.ts
+++ b/packages/coding-agent/test/session-focus-controller.test.ts
@@ -47,6 +47,7 @@ interface Harness {
 	handledEvents: unknown[];
 	setSessionCalls: Array<[AgentSession, string | undefined]>;
 	reloadTodoSessions: AgentSession[];
+	composerSwitches: Array<[string | undefined, string | undefined]>;
 	counts: {
 		clearTransientSessionUi: () => number;
 		resetTranscriptAnchors: () => number;
@@ -60,6 +61,7 @@ function makeHarness(options: { renderInitialMessages?: () => void | Promise<voi
 	const handledEvents: unknown[] = [];
 	const setSessionCalls: Array<[AgentSession, string | undefined]> = [];
 	const reloadTodoSessions: AgentSession[] = [];
+	const composerSwitches: Array<[string | undefined, string | undefined]> = [];
 	let clearTransientSessionUi = 0;
 	let resetTranscriptAnchors = 0;
 	let renderInitialMessages = 0;
@@ -94,6 +96,9 @@ function makeHarness(options: { renderInitialMessages?: () => void | Promise<voi
 		reloadTodos: async (source?: AgentSession) => {
 			reloadTodoSessions.push(source ?? main.session);
 		},
+		switchComposerDraft: (fromAgentId: string | undefined, toAgentId: string | undefined) => {
+			composerSwitches.push([fromAgentId, toAgentId]);
+		},
 		updateEditorBorderColor() {},
 		ui: { requestRender() {} },
 		showStatus() {},
@@ -112,6 +117,7 @@ function makeHarness(options: { renderInitialMessages?: () => void | Promise<voi
 		handledEvents,
 		setSessionCalls,
 		reloadTodoSessions,
+		composerSwitches,
 		counts: {
 			clearTransientSessionUi: () => clearTransientSessionUi,
 			resetTranscriptAnchors: () => resetTranscriptAnchors,
@@ -146,6 +152,7 @@ describe("SessionFocusController", () => {
 		expect(h.counts.renderInitialMessages()).toBe(1);
 		expect(h.reloadTodoSessions).toEqual([worker.session]);
 		expect(h.setSessionCalls).toEqual([[worker.session, "Worker"]]);
+		expect(h.composerSwitches).toEqual([[undefined, "Worker"]]);
 
 		const event = { type: "message_start", message: { role: "user" } };
 		await worker.emit(event);
@@ -169,6 +176,10 @@ describe("SessionFocusController", () => {
 		expect(h.controller.focusedAgentId).toBeUndefined();
 		expect(h.setSessionCalls.at(-1)).toEqual([h.main.session, undefined]);
 		expect(h.reloadTodoSessions).toEqual([worker.session, h.main.session]);
+		expect(h.composerSwitches).toEqual([
+			[undefined, "Worker"],
+			["Worker", undefined],
+		]);
 	});
 
 	it("does not let a superseded focus attachment restore the worker todo HUD after unfocusing", async () => {
@@ -247,6 +258,11 @@ describe("SessionFocusController", () => {
 			[worker.session, "Worker"],
 			[parent.session, "Parent"],
 			[h.main.session, undefined],
+		]);
+		expect(h.composerSwitches).toEqual([
+			[undefined, "Worker"],
+			["Worker", "Parent"],
+			["Parent", undefined],
 		]);
 	});
 

--- a/packages/coding-agent/test/session-focus-controller.test.ts
+++ b/packages/coding-agent/test/session-focus-controller.test.ts
@@ -48,6 +48,7 @@ interface Harness {
 	setSessionCalls: Array<[AgentSession, string | undefined]>;
 	reloadTodoSessions: AgentSession[];
 	composerSwitches: Array<[string | undefined, string | undefined]>;
+	discardedComposerDrafts: string[];
 	counts: {
 		clearTransientSessionUi: () => number;
 		resetTranscriptAnchors: () => number;
@@ -62,6 +63,7 @@ function makeHarness(options: { renderInitialMessages?: () => void | Promise<voi
 	const setSessionCalls: Array<[AgentSession, string | undefined]> = [];
 	const reloadTodoSessions: AgentSession[] = [];
 	const composerSwitches: Array<[string | undefined, string | undefined]> = [];
+	const discardedComposerDrafts: string[] = [];
 	let clearTransientSessionUi = 0;
 	let resetTranscriptAnchors = 0;
 	let renderInitialMessages = 0;
@@ -99,6 +101,9 @@ function makeHarness(options: { renderInitialMessages?: () => void | Promise<voi
 		switchComposerDraft: (fromAgentId: string | undefined, toAgentId: string | undefined) => {
 			composerSwitches.push([fromAgentId, toAgentId]);
 		},
+		discardComposerDraft: (agentId: string) => {
+			discardedComposerDrafts.push(agentId);
+		},
 		updateEditorBorderColor() {},
 		ui: { requestRender() {} },
 		showStatus() {},
@@ -118,6 +123,7 @@ function makeHarness(options: { renderInitialMessages?: () => void | Promise<voi
 		setSessionCalls,
 		reloadTodoSessions,
 		composerSwitches,
+		discardedComposerDrafts,
 		counts: {
 			clearTransientSessionUi: () => clearTransientSessionUi,
 			resetTranscriptAnchors: () => resetTranscriptAnchors,
@@ -282,5 +288,32 @@ describe("SessionFocusController", () => {
 			[worker.session, "Worker"],
 			[h.main.session, undefined],
 		]);
+		expect(h.discardedComposerDrafts).toEqual([]);
+	});
+
+	it("discards the focused agent draft when a hard kill becomes terminal", async () => {
+		const h = makeHarness();
+		const worker = makeSessionStub();
+		const ref = registerSub(h.registry, "Worker", worker.session, MAIN_AGENT_ID);
+
+		await h.controller.focusAgent("Worker");
+		h.registry.setStatus("Worker", "aborted", ref);
+		await flushAsync();
+
+		expect(h.controller.focusedAgentId).toBeUndefined();
+		expect(h.composerSwitches.at(-1)).toEqual(["Worker", undefined]);
+		expect(h.discardedComposerDrafts).toEqual(["Worker"]);
+	});
+
+	it("discards an unfocused agent draft when its registry generation is removed", async () => {
+		const h = makeHarness();
+		const worker = makeSessionStub();
+		const ref = registerSub(h.registry, "Worker", worker.session, MAIN_AGENT_ID);
+
+		await h.controller.focusAgent("Worker");
+		await h.controller.unfocus();
+		h.registry.unregister("Worker", ref);
+
+		expect(h.discardedComposerDrafts).toEqual(["Worker"]);
 	});
 });


### PR DESCRIPTION
## Human-written summary

This PR:
- Adds an option to have tree or roster be the default view in the Agent Hub (roster remains the default)
- shows the Main agent (root session) in the Agent Hub, when in tree view
- keeps the draft texts localised to each agent and subagent

Before: type text in Main agent -> Alt+A -> select a child subagent -> text from Main agent has been brought with you to the subagent.

After: type text in Main agent -> Alt+A -> select a child subagent -> message field is empty -> Alt+A -> tree view -> select Main agent (only in tree view) -> original text in Main agent message field is still there.

Reasoning:
- This is useful if you talk to subagents directly, and have a tendency to leave unfinished drafts while switching to another subagent. This allows you to do that.
- pressing left left doesn't work if there is text in the message field, so you can't go back up unless your message field is empty.
- pressing esc deletes the text in the message field, so you can go back up but you lose your draft.
- Therefore I decided to make the Main agent reachable in the Agent Hub (otherwise you could not go back up to it, if there are unsent drafts in all your subagents), when in tree view.

Notes:
- In tree view, Main agent is therefore the root of all other subagents
- I noticed that pressing esc and pressing left left always went back to Main agent, whereas the OMP UI text says that left left goes up to the parent. I did not fix that inconsistency.

---

## Technical details

This change:

- adds `agentHub.defaultView`, with `roster` and `tree` as the supported values;
- retains `roster` as the default;
- shows Main as the selectable root of local tree view;
- returns to Main through Agent Hub without interrupting the focused child;
- keeps Main out of the flat roster and subagent usage totals;
- preserves independent text and image drafts for Main and each focused subagent while the top-level OMP process remains open;
- saves the current draft and restores the target session's draft when Agent Hub changes focus;
- preserves Main's shutdown draft even when OMP exits while a child is focused;
- renders continuous ancestry guides through agent activity and usage rows in tree view.

Subagent drafts are process-local. They do not persist across a complete OMP restart.

## Configuration

Add the setting to the global OMP configuration file:

`~/.omp/agent/config.yml`

```yaml
agentHub:
  defaultView: tree
```

Use `roster` instead of `tree` to open Agent Hub in the flat roster. Omitting the setting also uses the default roster view.

## Verification

- TypeScript type-check passed.
- Biome checks passed.
- 123 focused tests passed with 589 assertions.
- Verified independent Main, child, and grandchild drafts through Agent Hub navigation and refocus.
- Verified Main -> child -> Main -> child draft restoration in the source TUI.
- Verified that selecting Main does not interrupt the focused child.
- Verified continuous tree ancestry guides against a copied real session.
- Verified nested rendering through the maximum live task depth and synthetic deeper lineage.
