### PR TITLE
feat(coding-agent): add AnySearch as web_search provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ _[Watch the capture ↗](https://omp.sh/clips/collab.mp4)_
 
 ### 08 · Read a pdf on arxiv, why not?
 
-web_search chains twenty-three ranked providers and hands whatever URLs it finds straight to read. Arxiv PDFs, GitHub pages, Stack Overflow threads come back as structured markdown with anchors intact — the same tool surface you use on local files. Cite, follow, quote, never lose where you came from.
+web_search chains twenty-four ranked providers and hands whatever URLs it finds straight to read. Arxiv PDFs, GitHub pages, Stack Overflow threads come back as structured markdown with anchors intact — the same tool surface you use on local files. Cite, follow, quote, never lose where you came from.
 
 ![omp TUI: web_search returns 10 ranked Perplexity sources for inference-time compute scaling, the agent picks an arxiv paper, calls read https://arxiv.org/pdf/2604.10739v1, and summarizes the paper's headline result with real numbers.](https://omp.sh/clips/web-poster.webp)
 
@@ -387,13 +387,13 @@ modelRoles:
 
 Full provider & routing reference at [omp.sh/docs/providers](https://omp.sh/docs/providers).
 
-## Twenty-three backends. _One tool the agent already knows_.
+## Twenty-four backends. _One tool the agent already knows_.
 
-`web_search` is built in, not bolted on. `auto` walks a twenty-three-provider chain; pin one by name if you already pay for it. Behind every hit, site-aware extraction turns GitHub, registries, arXiv, Stack Overflow, and docs into structured markdown — anchors and link targets survive.
+`web_search` is built in, not bolted on. `auto` walks a twenty-four-provider chain; pin one by name if you already pay for it. Behind every hit, site-aware extraction turns GitHub, registries, arXiv, Stack Overflow, and docs into structured markdown — anchors and link targets survive.
 
 ### Search providers
 
-Twenty-three backends. Pin one, or let `auto` walk the chain in order.
+Twenty-four backends. Pin one, or let `auto` walk the chain in order.
 
 | provider     | auth                                      |
 | ------------ | ----------------------------------------- |
@@ -410,6 +410,7 @@ Twenty-three backends. Pin one, or let `auto` walk the chain in order.
 | `kagi`       | `KAGI_API_KEY`                            |
 | `tavily`     | `TAVILY_API_KEY`                          |
 | `firecrawl`  | `FIRECRAWL_API_KEY` (keyless fallback)    |
+| `anysearch`  | `ANYSEARCH_API_KEY` (anonymous fallback)  |
 | `brave`      | `BRAVE_API_KEY`                           |
 | `kimi`       | `/login kimi-code` or search key          |
 | `parallel`   | `PARALLEL_API_KEY`                        |

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -342,6 +342,7 @@ therefore completes through the paste-code path.
 | `PI_PERPLEXITY_MODEL`                               | Perplexity consumer-subscription model preference (default `experimental`) |
 | `PI_PERPLEXITY_API_MODEL`                           | Perplexity direct API model override (default `sonar-pro`)                |
 | `FIRECRAWL_BASE_URL`                                | Firecrawl search endpoint override (`FIRECRAWL_API_URL` is a fallback alias) |
+| `ANYSEARCH_API_KEY`                                 | AnySearch search provider (optional; anonymous search works without it) |
 | `GOOGLE_GEMINI_BASE_URL`                            | Gemini search endpoint override; must be a valid absolute HTTP(S) URL     |
 | `TAVILY_API_KEY`                                    | Tavily search provider                                                    |
 | `ZAI_API_KEY`                                       | z.ai search provider (also checks stored OAuth in `agent.db`)             |

--- a/docs/tools/web_search.md
+++ b/docs/tools/web_search.md
@@ -15,6 +15,7 @@
   - `packages/coding-agent/src/web/search/query.ts` — Google-style query parsing, provider syntax formatting, and lenient result filtering.
   - `packages/coding-agent/src/web/search/providers/browser-page.ts` — shared fetch/headless-browser page loader for scrape providers.
   - `packages/coding-agent/src/web/search/providers/anthropic.ts` — Claude web-search provider.
+  - `packages/coding-agent/src/web/search/providers/anysearch.ts` — AnySearch REST adapter.
   - `packages/coding-agent/src/web/search/providers/brave.ts` — Brave Search API adapter.
   - `packages/coding-agent/src/web/search/providers/codex.ts` — OpenAI Codex SSE adapter.
   - `packages/coding-agent/src/web/search/providers/duckduckgo.ts` — DuckDuckGo HTML frontend scraper.
@@ -108,7 +109,7 @@ Each provider search transport receives a hard timeout from `providers.webSearch
   - **Forced provider**: internal callers may pass `provider`; a non-`auto` value is the only attempted provider and uses `isExplicitlyAvailable()`, while `auto` (or omitting it) walks the configured chain. This field is not in the model-facing schema.
   - **Configured order**: `setSearchProviderOrder()` prioritizes valid, first-occurrence provider IDs in `providers.webSearchOrder`; omitted providers follow in built-in relative order. Listed providers are explicit selections and resolve through `isExplicitlyAvailable()`, so Perplexity, Exa, and Firecrawl can use their unauthenticated/keyless paths.
   - **Excluded providers**: `setExcludedSearchProviders()` removes providers from the automatic/configured chain and Public Web fan-out. Wired from `providers.webSearchExclude` through `packages/coding-agent/src/config/provider-globals.ts`.
-  - **Default auto chain order** (23 providers): `perplexity`, `gemini`, `anthropic`, `codex`, `xai`, `zai`, `exa`, `tinyfish`, `jina`, `kagi`, `tavily`, `firecrawl`, `brave`, `kimi`, `parallel`, `synthetic`, `searxng`, `startpage`, `duckduckgo`, `ecosia`, `google`, `mojeek`, `public` (`SEARCH_PROVIDER_ORDER` in `packages/coding-agent/src/web/search/types.ts`). `public` is explicit-only: its `isAvailable()` returns `false`, so the auto chain never fans out implicitly.
+  - **Default auto chain order** (24 providers): `perplexity`, `gemini`, `anthropic`, `codex`, `xai`, `zai`, `exa`, `tinyfish`, `jina`, `kagi`, `tavily`, `firecrawl`, `anysearch`, `brave`, `kimi`, `parallel`, `synthetic`, `searxng`, `startpage`, `duckduckgo`, `ecosia`, `google`, `mojeek`, `public` (`SEARCH_PROVIDER_ORDER` in `packages/coding-agent/src/web/search/types.ts`). `public` is explicit-only: its `isAvailable()` returns `false`, so the auto chain never fans out implicitly.
 - **Provider timeout**: `providers.webSearchTimeoutSeconds` supplies the hard ceiling for each provider's search transport before the automatic chain advances. It defaults to `60`; invalid non-positive values fall back to that default and values above `300` are capped, while provider-specific upstream or aggregate limits may still be shorter.
 - **Provider adapters**
   - **Perplexity** — `packages/coding-agent/src/web/search/providers/perplexity.ts`
@@ -182,6 +183,10 @@ Each provider search transport receives a hard timeout from `providers.webSearch
     - Availability: credentials admit it to the automatic chain; explicit/configured selection is always available and uses keyless mode when no credential resolves.
     - Querying: POST `https://api.firecrawl.dev/v2/search` with `sources: [{ type: "web" }]`. Google-style operators are formatted into the query; `recency` and parsed absolute dates map to `tbs`.
     - `limit` / `num_search_results`: collapsed and clamped to `1..100`, default `10`; output `sources`, `requestId`, and `authMode: "api_key" | "keyless"`.
+  - **AnySearch** — `packages/coding-agent/src/web/search/providers/anysearch.ts`
+    - Availability: credentials admit it to the automatic chain; explicit selection is always available and uses the anonymous tier (~1000 requests/day) when no credential resolves. When `ANYSEARCH_API_KEY` resolves, requests send `Authorization: Bearer <key>`. HTTP 401/403 are non-retryable and never fall back to anonymous.
+    - Querying: POST `https://api.anysearch.com/v1/search` with `{ query, max_results }`. Optional API fields (`tag`, `zone`, `language`, `params`) and `/v1/extract` are not used.
+    - `limit` / `num_search_results`: collapsed and clamped to `1..10`, default `10`. Non-zero body `code` is a provider error using `message`. Output `sources` (`snippet` falls back to `content`) and `authMode: "api_key" | "anonymous"`. Rate limit: 20 requests/minute (`X-Ratelimit-Limit`).
   - **Brave** — `packages/coding-agent/src/web/search/providers/brave.ts`
     - Availability: `BRAVE_API_KEY` only.
     - Querying: GET `https://api.search.brave.com/res/v1/web/search` with `count`, `extra_snippets=true`, and `freshness=pd|pw|pm|py` for `recency`.
@@ -244,7 +249,7 @@ Each provider search transport receives a hard timeout from `providers.webSearch
   - Many provider adapters accept `AbortSignal`; `WebSearchTool.execute()` passes the tool call signal into `executeSearch()`, which forwards it as `params.signal` to providers and rethrows cancellation during fallback.
 
 ## Limits & Caps
-- Provider auto-order length: 23 providers (`SEARCH_PROVIDER_ORDER` in `packages/coding-agent/src/web/search/types.ts`).
+- Provider auto-order length: 24 providers (`SEARCH_PROVIDER_ORDER` in `packages/coding-agent/src/web/search/types.ts`).
 - `formatForLLM()` truncates source snippets and citation text to 240 chars (`packages/coding-agent/src/web/search/index.ts`).
 - `formatForLLM()` emits at most 3 search queries, each truncated to 120 chars (`packages/coding-agent/src/web/search/index.ts`).
 - Brave result count: default `10`, max `20` (`DEFAULT_NUM_RESULTS`, `MAX_NUM_RESULTS` in `packages/coding-agent/src/web/search/providers/brave.ts`).
@@ -254,6 +259,7 @@ Each provider search transport receives a hard timeout from `providers.webSearch
 - Public Web result count: default `15`, max `30`; fan-out soft deadline `5s`, hard cap `30s` (`packages/coding-agent/src/web/search/providers/public.ts`).
 - Tavily result count: default `5`, max `20` (`packages/coding-agent/src/web/search/providers/tavily.ts`).
 - Firecrawl result count: default `10`, max `100` (`packages/coding-agent/src/web/search/providers/firecrawl.ts`).
+- AnySearch result count: default `10`, max `10` (`packages/coding-agent/src/web/search/providers/anysearch.ts`).
 - Kimi result count: default `10`, max `20`; request timeout field fixed to `30` seconds (`packages/coding-agent/src/web/search/providers/kimi.ts`).
 - Parallel result count: default `10`, max `40`; per-result excerpt cap `10_000` chars (`packages/coding-agent/src/web/search/providers/parallel.ts`, `packages/coding-agent/src/web/parallel.ts`).
 - Kagi result count: default `10`, max `40` (`packages/coding-agent/src/web/search/providers/kagi.ts`).

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -809,6 +809,7 @@ const LEGACY_ENV_KEYS: Record<string, KeyResolver> = {
 	brave: "BRAVE_API_KEY",
 	tinyfish: "TINYFISH_API_KEY",
 	firecrawl: "FIRECRAWL_API_KEY",
+	anysearch: "ANYSEARCH_API_KEY",
 };
 
 /**

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added AnySearch as a `web_search` provider (`ANYSEARCH_API_KEY` for the auto chain; explicit selection works keyless via the anonymous tier).
+
 ### Fixed
 
 - Fixed `import numpy` (and other native-extension imports) hanging indefinitely in the Python eval tool on Windows, where the runner's always-on background stdin reader deadlocked native DLL loading; Windows now reads the control channel serially between requests while POSIX keeps concurrent request dispatch ([#7985](https://github.com/can1357/oh-my-pi/issues/7985)).

--- a/packages/coding-agent/src/cli/help-extra.ts
+++ b/packages/coding-agent/src/cli/help-extra.ts
@@ -49,6 +49,7 @@ export function getExtraHelpText(): string {
   TAVILY_API_KEY             - Tavily web search
   TINYFISH_API_KEY           - TinyFish web search
   FIRECRAWL_API_KEY          - Firecrawl web search
+  ANYSEARCH_API_KEY          - AnySearch web search (optional; anonymous fallback)
   ANTHROPIC_SEARCH_API_KEY   - Anthropic web search (override; isolates search from main ANTHROPIC_API_KEY)
   ANTHROPIC_SEARCH_BASE_URL  - Anthropic web search base URL (override; pairs with ANTHROPIC_SEARCH_API_KEY)
 

--- a/packages/coding-agent/src/web/search/index.ts
+++ b/packages/coding-agent/src/web/search/index.ts
@@ -1,7 +1,7 @@
 /**
  * Unified Web Search Tool
  *
- * Single tool supporting Anthropic, Perplexity, Exa, Brave, Jina, Kimi, Gemini, Codex, Tavily, Kagi, Z.AI, SearXNG, and Synthetic
+ * Single tool supporting Anthropic, Perplexity, Exa, Brave, Jina, Kimi, Gemini, Codex, Tavily, Kagi, Z.AI, SearXNG, Synthetic, and AnySearch
  * providers with provider-specific parameters exposed conditionally.
  */
 

--- a/packages/coding-agent/src/web/search/provider.ts
+++ b/packages/coding-agent/src/web/search/provider.ts
@@ -84,6 +84,11 @@ const PROVIDER_META: Record<SearchProviderId, ProviderMeta> = {
 		label: SEARCH_PROVIDER_LABELS.firecrawl,
 		load: async () => new (await import("./providers/firecrawl")).FirecrawlProvider(),
 	},
+	anysearch: {
+		id: "anysearch",
+		label: SEARCH_PROVIDER_LABELS.anysearch,
+		load: async () => new (await import("./providers/anysearch")).AnySearchProvider(),
+	},
 	brave: {
 		id: "brave",
 		label: SEARCH_PROVIDER_LABELS.brave,

--- a/packages/coding-agent/src/web/search/provider.ts
+++ b/packages/coding-agent/src/web/search/provider.ts
@@ -1,14 +1,15 @@
 // Lazy registry of web search providers.
 //
-// Each provider is loaded on first use; importing this module loads zero
-// provider implementations. Provider modules are heavy (each pulls in
-// fetch/parse/format helpers) and only one — at most — is needed per session,
-// so eager construction was wasted work at startup.
+// Most providers are loaded on first use. Provider modules are heavy (each
+// pulls in fetch/parse/format helpers) and only one — at most — is needed per
+// session, so eager construction was wasted work at startup. AnySearch is
+// imported top-level per the no-dynamic-imports rule (AGENTS.md).
 //
-// Provider modules are loaded lazily; display metadata lives in types.ts so UI
-// listings can share it without importing provider implementations.
+// Display metadata lives in types.ts so UI listings can share it without
+// importing provider implementations.
 
 import type { AuthStorage } from "@oh-my-pi/pi-ai";
+import { AnySearchProvider } from "./providers/anysearch";
 import type { SearchProvider } from "./providers/base";
 import { SEARCH_PROVIDER_LABELS, SEARCH_PROVIDER_ORDER, SearchProviderError, type SearchProviderId } from "./types";
 
@@ -87,7 +88,7 @@ const PROVIDER_META: Record<SearchProviderId, ProviderMeta> = {
 	anysearch: {
 		id: "anysearch",
 		label: SEARCH_PROVIDER_LABELS.anysearch,
-		load: async () => new (await import("./providers/anysearch")).AnySearchProvider(),
+		load: async () => new AnySearchProvider(),
 	},
 	brave: {
 		id: "brave",

--- a/packages/coding-agent/src/web/search/providers/anysearch.ts
+++ b/packages/coding-agent/src/web/search/providers/anysearch.ts
@@ -1,0 +1,173 @@
+/**
+ * AnySearch Web Search Provider
+ *
+ * Calls AnySearch's search API and maps results into the unified
+ * SearchResponse shape used by the web search tool.
+ */
+import {
+	type AuthStorage,
+	type FetchImpl,
+	getEnvApiKey,
+	resolveApiKeyOnce,
+	seedApiKeyResolver,
+	withAuth,
+} from "@oh-my-pi/pi-ai";
+import type { SearchResponse, SearchSource } from "../../../web/search/types";
+import { SearchProviderError } from "../../../web/search/types";
+import { clampNumResults } from "../utils";
+import type { SearchParams } from "./base";
+import { SearchProvider } from "./base";
+import { classifyProviderHttpError, withHardTimeout } from "./utils";
+
+const ANYSEARCH_SEARCH_URL = "https://api.anysearch.com/v1/search";
+const DEFAULT_NUM_RESULTS = 10;
+const MAX_NUM_RESULTS = 10;
+
+export interface AnySearchSearchParams {
+	query: string;
+	num_results?: number;
+	signal?: AbortSignal;
+	timeoutMs?: number;
+	fetch?: FetchImpl;
+}
+
+interface AnySearchResult {
+	title?: string | null;
+	url?: string | null;
+	snippet?: string | null;
+	content?: string | null;
+}
+
+interface AnySearchSearchResponse {
+	code?: number | null;
+	message?: string | null;
+	data?: {
+		results?: AnySearchResult[] | null;
+		metadata?: {
+			search_time_ms?: number | null;
+		} | null;
+	} | null;
+}
+
+/** Resolve AnySearch API key through the shared auth storage pipeline. */
+export function findApiKey(
+	authStorage: AuthStorage,
+	sessionId?: string,
+	signal?: AbortSignal,
+): Promise<string | undefined> {
+	return authStorage.getApiKey("anysearch", sessionId, { signal });
+}
+
+function buildRequestBody(params: AnySearchSearchParams): Record<string, unknown> {
+	return {
+		query: params.query,
+		max_results: clampNumResults(params.num_results, DEFAULT_NUM_RESULTS, MAX_NUM_RESULTS),
+	};
+}
+
+async function callAnySearch(
+	apiKey: string | undefined,
+	params: AnySearchSearchParams,
+): Promise<AnySearchSearchResponse> {
+	const headers: Record<string, string> = {
+		"Content-Type": "application/json",
+	};
+	if (apiKey) {
+		headers.Authorization = `Bearer ${apiKey}`;
+	}
+	const response = await (params.fetch ?? fetch)(ANYSEARCH_SEARCH_URL, {
+		method: "POST",
+		headers,
+		body: JSON.stringify(buildRequestBody(params)),
+		signal: withHardTimeout(params.signal, params.timeoutMs),
+	});
+
+	if (!response.ok) {
+		const errorText = await response.text();
+		const classified = classifyProviderHttpError("anysearch", response.status, errorText);
+		if (classified) throw classified;
+		throw new SearchProviderError(
+			"anysearch",
+			`AnySearch API error (${response.status}): ${errorText}`,
+			response.status,
+		);
+	}
+
+	const data = (await response.json()) as AnySearchSearchResponse;
+	if (typeof data.code === "number" && data.code !== 0) {
+		throw new SearchProviderError("anysearch", data.message?.trim() || "AnySearch request failed");
+	}
+	return data;
+}
+
+/** Execute AnySearch web search. */
+export async function searchAnysearch(params: SearchParams): Promise<SearchResponse> {
+	const anysearchParams: AnySearchSearchParams = {
+		query: params.query,
+		num_results: params.numSearchResults ?? params.limit,
+		signal: params.signal,
+		timeoutMs: params.timeoutMs,
+		fetch: params.fetch,
+	};
+	const keyResolver = params.authStorage.resolver("anysearch", {
+		sessionId: params.sessionId,
+	});
+	const numResults = clampNumResults(anysearchParams.num_results, DEFAULT_NUM_RESULTS, MAX_NUM_RESULTS);
+
+	const resolvedKey = await resolveApiKeyOnce(keyResolver, params.signal);
+	let data: AnySearchSearchResponse;
+	if (resolvedKey) {
+		// Reuse the preflight credential for the initial authenticated attempt.
+		const seededResolver = seedApiKeyResolver(resolvedKey, keyResolver);
+		data = await withAuth(seededResolver, key => callAnySearch(key, anysearchParams), {
+			signal: params.signal,
+		});
+	} else {
+		// Anonymous mode — omit Authorization header. Never fall back here after a 401.
+		data = await callAnySearch(undefined, anysearchParams);
+	}
+
+	const sources: SearchSource[] = [];
+
+	for (const result of data.data?.results ?? []) {
+		if (!result.url) continue;
+		sources.push({
+			title: result.title ?? result.url,
+			url: result.url,
+			snippet: result.snippet ?? result.content ?? undefined,
+		});
+	}
+
+	return {
+		provider: "anysearch",
+		sources: sources.slice(0, numResults),
+		authMode: resolvedKey ? "api_key" : "anonymous",
+	};
+}
+
+/** Search provider for AnySearch web search. */
+export class AnySearchProvider extends SearchProvider {
+	readonly id = "anysearch";
+	readonly label = "AnySearch";
+
+	/**
+	 * Auto-chain admission requires a credential so unconfigured users' queries
+	 * are not routed to a new third party by default. Anonymous mode stays
+	 * explicit-only.
+	 */
+	isAvailable(authStorage: AuthStorage): boolean {
+		return authStorage.hasAuth("anysearch") || !!getEnvApiKey("anysearch");
+	}
+
+	/**
+	 * Explicit selection (`webSearch: anysearch`) works without a key via the
+	 * anonymous tier.
+	 */
+	override isExplicitlyAvailable(_authStorage: AuthStorage): boolean {
+		return true;
+	}
+
+	search(params: SearchParams): Promise<SearchResponse> {
+		return searchAnysearch(params);
+	}
+}

--- a/packages/coding-agent/src/web/search/types.ts
+++ b/packages/coding-agent/src/web/search/types.ts
@@ -47,6 +47,11 @@ export const SEARCH_PROVIDER_OPTIONS = [
 		label: "Firecrawl",
 		description: "Uses Firecrawl API when FIRECRAWL_API_KEY is set; falls back to keyless mode",
 	},
+	{
+		value: "anysearch",
+		label: "AnySearch",
+		description: "Anonymous web search via AnySearch; optional ANYSEARCH_API_KEY",
+	},
 	{ value: "brave", label: "Brave", description: "Requires BRAVE_API_KEY" },
 	{
 		value: "kimi",

--- a/packages/coding-agent/test/tools/web-search-anysearch.test.ts
+++ b/packages/coding-agent/test/tools/web-search-anysearch.test.ts
@@ -1,0 +1,298 @@
+import { describe, expect, it } from "bun:test";
+import type { AuthStorage, FetchImpl } from "@oh-my-pi/pi-ai";
+import { AnySearchProvider, searchAnysearch } from "@oh-my-pi/pi-coding-agent/web/search/providers/anysearch";
+import { SearchProviderError } from "@oh-my-pi/pi-coding-agent/web/search/types";
+
+const TEST_KEY = "test-anysearch-key";
+
+function makeAuthStorage(apiKey: string | undefined): AuthStorage {
+	return {
+		resolver(provider: string, options?: { sessionId?: string }) {
+			expect(provider).toBe("anysearch");
+			expect(options?.sessionId).toBe("session-anysearch-test");
+			return async () => apiKey;
+		},
+		hasAuth(provider: string) {
+			return provider === "anysearch" && Boolean(apiKey);
+		},
+	} as unknown as AuthStorage;
+}
+
+function makeParams(query: string, authStorage: AuthStorage = makeAuthStorage(TEST_KEY)) {
+	return {
+		query,
+		authStorage,
+		systemPrompt: "AnySearch test prompt",
+		sessionId: "session-anysearch-test",
+	} as const;
+}
+
+function getHeader(headers: RequestInit["headers"] | undefined, name: string): string | null {
+	if (!headers) return null;
+	if (headers instanceof Headers) return headers.get(name);
+	if (Array.isArray(headers)) {
+		return headers.find(([key]) => key.toLowerCase() === name.toLowerCase())?.[1] ?? null;
+	}
+	const record = headers as Record<string, string>;
+	return record[name] ?? record[name.toLowerCase()] ?? null;
+}
+
+function okEnvelope(results: Array<Record<string, unknown>> = []) {
+	return {
+		code: 0,
+		message: "ok",
+		data: { results, metadata: { search_time_ms: 12 } },
+	};
+}
+
+describe("AnySearch web search provider", () => {
+	it("sends a keyless POST without Authorization", async () => {
+		const captured: { url?: string; init?: RequestInit; body?: unknown } = {};
+
+		const fetchMock: FetchImpl = async (input, init) => {
+			captured.url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+			captured.init = init;
+			captured.body = JSON.parse(String(init?.body ?? "null")) as unknown;
+			return new Response(
+				JSON.stringify(
+					okEnvelope([
+						{
+							title: "Anonymous result",
+							url: "https://example.com/anon",
+							snippet: "From anonymous AnySearch",
+						},
+					]),
+				),
+				{ status: 200, headers: { "Content-Type": "application/json" } },
+			);
+		};
+
+		const response = await searchAnysearch({
+			...makeParams("anonymous query", makeAuthStorage(undefined)),
+			fetch: fetchMock,
+		});
+
+		expect(captured.url).toBe("https://api.anysearch.com/v1/search");
+		expect(captured.init?.method).toBe("POST");
+		expect(getHeader(captured.init?.headers, "Authorization")).toBeNull();
+		expect(getHeader(captured.init?.headers, "Content-Type")).toBe("application/json");
+		expect(captured.body).toEqual({
+			query: "anonymous query",
+			max_results: 10,
+		});
+		expect(response).toEqual({
+			provider: "anysearch",
+			sources: [
+				{
+					title: "Anonymous result",
+					url: "https://example.com/anon",
+					snippet: "From anonymous AnySearch",
+				},
+			],
+			authMode: "anonymous",
+		});
+	});
+
+	it("sends Bearer when an API key resolves", async () => {
+		const captured: { init?: RequestInit; body?: unknown } = {};
+
+		const fetchMock: FetchImpl = async (_input, init) => {
+			captured.init = init;
+			captured.body = JSON.parse(String(init?.body ?? "null")) as unknown;
+			return new Response(
+				JSON.stringify(
+					okEnvelope([
+						{
+							title: "Keyed result",
+							url: "https://example.com/keyed",
+							snippet: "From keyed AnySearch",
+						},
+					]),
+				),
+				{ status: 200, headers: { "Content-Type": "application/json" } },
+			);
+		};
+
+		const response = await searchAnysearch({
+			...makeParams("keyed query"),
+			numSearchResults: 3,
+			fetch: fetchMock,
+		});
+
+		expect(getHeader(captured.init?.headers, "Authorization")).toBe(`Bearer ${TEST_KEY}`);
+		expect(captured.body).toEqual({
+			query: "keyed query",
+			max_results: 3,
+		});
+		expect(response.authMode).toBe("api_key");
+		expect(response.sources).toEqual([
+			{
+				title: "Keyed result",
+				url: "https://example.com/keyed",
+				snippet: "From keyed AnySearch",
+			},
+		]);
+	});
+
+	it("does not fall back to anonymous after HTTP 401", async () => {
+		const authorizationHeaders: Array<string | null> = [];
+		const fetchMock: FetchImpl = async (_input, init) => {
+			authorizationHeaders.push(getHeader(init?.headers, "Authorization"));
+			return new Response("invalid key", { status: 401 });
+		};
+
+		try {
+			await searchAnysearch({ ...makeParams("bad auth"), fetch: fetchMock });
+			expect.unreachable("expected searchAnysearch to throw");
+		} catch (error) {
+			expect(error).toBeInstanceOf(SearchProviderError);
+			expect(error).toMatchObject({
+				provider: "anysearch",
+				status: 401,
+				message: "anysearch: 401 unauthorized",
+			});
+		}
+
+		expect(authorizationHeaders.length).toBeGreaterThan(0);
+		expect(authorizationHeaders.every(header => header === `Bearer ${TEST_KEY}`)).toBe(true);
+	});
+
+	it("throws on a non-zero API code", async () => {
+		const fetchMock: FetchImpl = async () =>
+			new Response(
+				JSON.stringify({
+					code: 1001,
+					message: "quota exceeded",
+					data: { results: [] },
+				}),
+				{ status: 200, headers: { "Content-Type": "application/json" } },
+			);
+
+		try {
+			await searchAnysearch({ ...makeParams("quota"), fetch: fetchMock });
+			expect.unreachable("expected searchAnysearch to throw");
+		} catch (error) {
+			expect(error).toBeInstanceOf(SearchProviderError);
+			expect(error).toMatchObject({ provider: "anysearch", message: "quota exceeded" });
+			expect((error as SearchProviderError).status).toBeUndefined();
+		}
+	});
+
+	it("returns empty sources when the API returns no results", async () => {
+		const fetchMock: FetchImpl = async () =>
+			new Response(JSON.stringify(okEnvelope([])), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			});
+
+		const response = await searchAnysearch({
+			...makeParams("empty query"),
+			fetch: fetchMock,
+		});
+
+		expect(response).toEqual({
+			provider: "anysearch",
+			sources: [],
+			authMode: "api_key",
+		});
+	});
+
+	it.each([
+		[undefined, 10],
+		[0, 10],
+		[1, 1],
+		[10, 10],
+		[11, 10],
+		[100, 10],
+	] as const)("clamps max_results from %s to %d", async (requested, expected) => {
+		let body: unknown;
+		const fetchMock: FetchImpl = async (_input, init) => {
+			body = JSON.parse(String(init?.body ?? "null")) as unknown;
+			return new Response(JSON.stringify(okEnvelope([])), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			});
+		};
+
+		await searchAnysearch({
+			...makeParams("clamp query"),
+			numSearchResults: requested,
+			fetch: fetchMock,
+		});
+
+		expect(body).toEqual({
+			query: "clamp query",
+			max_results: expected,
+		});
+	});
+
+	it("falls back from snippet to content", async () => {
+		const fetchMock: FetchImpl = async () =>
+			new Response(
+				JSON.stringify(
+					okEnvelope([
+						{
+							title: "Snippet result",
+							url: "https://example.com/snippet",
+							snippet: "Preferred snippet",
+							content: "Ignored content",
+						},
+						{
+							title: "Content result",
+							url: "https://example.com/content",
+							snippet: null,
+							content: "Content fallback snippet",
+						},
+						{
+							url: "https://example.com/untitled",
+							content: "Untitled content",
+						},
+					]),
+				),
+				{ status: 200, headers: { "Content-Type": "application/json" } },
+			);
+
+		const response = await searchAnysearch({
+			...makeParams("snippet query"),
+			fetch: fetchMock,
+		});
+
+		expect(response.sources).toEqual([
+			{
+				title: "Snippet result",
+				url: "https://example.com/snippet",
+				snippet: "Preferred snippet",
+			},
+			{
+				title: "Content result",
+				url: "https://example.com/content",
+				snippet: "Content fallback snippet",
+			},
+			{
+				title: "https://example.com/untitled",
+				url: "https://example.com/untitled",
+				snippet: "Untitled content",
+			},
+		]);
+	});
+
+	it("joins the auto chain only with a credential; explicit selection works keyless", () => {
+		const provider = new AnySearchProvider();
+		const originalEnvKey = process.env.ANYSEARCH_API_KEY;
+		delete process.env.ANYSEARCH_API_KEY;
+		try {
+			const keyless = makeAuthStorage(undefined);
+			expect(provider.isAvailable(keyless)).toBe(false);
+			expect(provider.isExplicitlyAvailable(keyless)).toBe(true);
+
+			const keyed = makeAuthStorage(TEST_KEY);
+			expect(provider.isAvailable(keyed)).toBe(true);
+
+			process.env.ANYSEARCH_API_KEY = TEST_KEY;
+			expect(provider.isAvailable(keyless)).toBe(true);
+		} finally {
+			if (originalEnvKey === undefined) delete process.env.ANYSEARCH_API_KEY;
+			else process.env.ANYSEARCH_API_KEY = originalEnvKey;
+		}
+	});
+});


### PR DESCRIPTION
## What

Adds AnySearch as a `web_search` provider. The adapter POSTs to `https://api.anysearch.com/v1/search` with `{ query, max_results }` (clamped 1–10) and maps `data.results[]` to `sources`, with `snippet` falling back to `content`. `ANYSEARCH_API_KEY` is optional: when it resolves the request sends `Authorization: Bearer`, otherwise the header is omitted and the anonymous tier is used.

## Why

One more search option with a usable free tier (~1000 anonymous requests/day, 20/min). Same shape as the providers from #3572: a credential admits it to the auto chain; without one it stays explicit-only, so queries from unconfigured users are not routed to a new third party by default. Explicit selection (`--provider anysearch`) works keyless. A rejected key is a hard error — the adapter never strips the header and retries anonymously.

AnySearch provides quality websearch tools for models with 1000 daily quotas with/without api keys. Would be very useful to most of omp users imo.

## Testing

Exercised end to end from this branch with `omp q`:

- `ANYSEARCH_API_KEY` unset: `omp q "bun javascript runtime documentation" --provider anysearch` → 10 real sources (bun.com/docs, github.com/oven-sh/bun, Wikipedia, …) in ~3.6s.
- With a key set: `omp q "typescript satisfies operator" --provider anysearch` → 10 real sources in ~1.7s.
- `bun test packages/coding-agent/test/tools/web-search-anysearch.test.ts` → 13 pass, 0 fail (no Authorization header when keyless, Bearer when keyed, 401 never falls back to anonymous, non-zero body `code` surfaces `message`, `max_results` clamp, snippet←content fallback, auto-chain gating).

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
