### PR TITLE
fix(storage): flush deferred writes on exit

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Fixed
 
 - Fixed `import numpy` (and other native-extension imports) hanging indefinitely in the Python eval tool on Windows, where the runner's always-on background stdin reader deadlocked native DLL loading; Windows now reads the control channel serially between requests while POSIX keeps concurrent request dispatch ([#7985](https://github.com/can1357/oh-my-pi/issues/7985)).
-- Preserved prompts submitted immediately before exit and checkpointed prompt and agent database WALs during shutdown ([#10079](https://github.com/can1357/oh-my-pi/issues/10079)).
+- Made prompt history write through synchronously so a submitted prompt is durable immediately, and checkpointed the prompt and agent database WALs on exit so they no longer grow unbounded across sessions ([#10079](https://github.com/can1357/oh-my-pi/issues/10079)).
 
 ## [18.0.9] - 2026-08-28
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed `import numpy` (and other native-extension imports) hanging indefinitely in the Python eval tool on Windows, where the runner's always-on background stdin reader deadlocked native DLL loading; Windows now reads the control channel serially between requests while POSIX keeps concurrent request dispatch ([#7985](https://github.com/can1357/oh-my-pi/issues/7985)).
+- Preserved prompts submitted immediately before exit and checkpointed prompt and agent database WALs during shutdown ([#10079](https://github.com/can1357/oh-my-pi/issues/10079)).
 
 ## [18.0.9] - 2026-08-28
 

--- a/packages/coding-agent/src/session/agent-storage.ts
+++ b/packages/coding-agent/src/session/agent-storage.ts
@@ -8,7 +8,16 @@ import {
 	SqliteAuthCredentialStore,
 	type StoredAuthCredential,
 } from "@oh-my-pi/pi-ai";
-import { AsyncDrain, getAgentDbPath, getDbBusyTimeoutMs, getStatsDbPath, isRecord, logger } from "@oh-my-pi/pi-utils";
+import {
+	AsyncDrain,
+	checkpointWal,
+	getAgentDbPath,
+	getDbBusyTimeoutMs,
+	getStatsDbPath,
+	isRecord,
+	logger,
+	postmortem,
+} from "@oh-my-pi/pi-utils";
 import type { RawSettings as Settings } from "../config/settings";
 
 /** Row shape for settings table queries */
@@ -121,6 +130,7 @@ const SQLITE_NOW_EPOCH = "CAST(strftime('%s','now') AS INTEGER)";
 
 /** Singleton instances per database path */
 const instances = new Map<string, AgentStorage>();
+let cancelExitCleanup: (() => void) | undefined;
 
 /**
  * Unified SQLite storage for agent settings, model usage, and auth credentials.
@@ -385,6 +395,7 @@ FROM model_usage_legacy
 			try {
 				const storage = new AgentStorage(dbPath);
 				instances.set(dbPath, storage);
+				cancelExitCleanup ??= postmortem.register("agent-storage", () => AgentStorage.close());
 				return storage;
 			} catch (err) {
 				if (!isSqliteBusyError(err)) {
@@ -402,13 +413,20 @@ FROM model_usage_legacy
 			{ cause: lastError },
 		);
 	}
-	/** @internal Reset all singletons and close their databases — test-only. */
-	static resetInstance(): void {
+
+	/** Flushes deferred writes, closes every process-wide database, and permits reopening them. */
+	static close(): void {
 		for (const storage of instances.values()) storage.#close();
 		instances.clear();
+		cancelExitCleanup?.();
+		cancelExitCleanup = undefined;
 	}
 
 	#close(): void {
+		// Model-performance batches are synchronous once invoked, so this
+		// persists them before finalizing their statements during process exit.
+		void this.#perfDrain.flush();
+		checkpointWal(this.#db);
 		this.#listSettingsStmt.finalize();
 		this.#upsertModelUsageStmt.finalize();
 		this.#listModelUsageStmt.finalize();

--- a/packages/coding-agent/src/session/agent-storage.ts
+++ b/packages/coding-agent/src/session/agent-storage.ts
@@ -395,9 +395,11 @@ FROM model_usage_legacy
 		for (let attempt = 0; attempt < maxRetries; attempt++) {
 			try {
 				const storage = new AgentStorage(dbPath);
-				// Register before publishing the first instance: late
-				// registrations run immediately and must see an empty map.
-				cancelExitCleanup ??= postmortem.register("agent-storage", () => AgentStorage.close());
+				// Exit-only: a keep-alive cleanup leaves the open handle valid for the
+				// continuing process (Settings, MCP cache, callers hold it); the real
+				// exit closes. Register before publishing so a real-exit-in-progress
+				// late registration sees an empty map.
+				cancelExitCleanup ??= postmortem.register("agent-storage", () => AgentStorage.close(), true);
 				instances.set(dbPath, storage);
 				return storage;
 			} catch (err) {

--- a/packages/coding-agent/src/session/agent-storage.ts
+++ b/packages/coding-agent/src/session/agent-storage.ts
@@ -394,8 +394,10 @@ FROM model_usage_legacy
 		for (let attempt = 0; attempt < maxRetries; attempt++) {
 			try {
 				const storage = new AgentStorage(dbPath);
-				instances.set(dbPath, storage);
+				// Register before publishing the first instance: late
+				// registrations run immediately and must see an empty map.
 				cancelExitCleanup ??= postmortem.register("agent-storage", () => AgentStorage.close());
+				instances.set(dbPath, storage);
 				return storage;
 			} catch (err) {
 				if (!isSqliteBusyError(err)) {

--- a/packages/coding-agent/src/session/agent-storage.ts
+++ b/packages/coding-agent/src/session/agent-storage.ts
@@ -399,7 +399,7 @@ FROM model_usage_legacy
 				// continuing process (Settings, MCP cache, callers hold it); the real
 				// exit closes. Register before publishing so a real-exit-in-progress
 				// late registration sees an empty map.
-				cancelExitCleanup ??= postmortem.register("agent-storage", () => AgentStorage.close(), true);
+				cancelExitCleanup ??= postmortem.register("agent-storage", () => AgentStorage.close(), { exitOnly: true });
 				instances.set(dbPath, storage);
 				return storage;
 			} catch (err) {

--- a/packages/coding-agent/src/session/agent-storage.ts
+++ b/packages/coding-agent/src/session/agent-storage.ts
@@ -155,6 +155,7 @@ export class AgentStorage {
 	#perfBackfillChecked = false;
 	/** Coalesces per-turn perf samples into one deferred transaction off the turn's hot path. */
 	#perfDrain = new AsyncDrain<ModelPerfInsert>(MODEL_PERF_FLUSH_DELAY_MS);
+	#closing = false;
 
 	private constructor(dbPath: string) {
 		this.#autoPerfBackfill = dbPath === getAgentDbPath();
@@ -425,6 +426,7 @@ FROM model_usage_legacy
 	}
 
 	#close(): void {
+		this.#closing = true;
 		// Model-performance batches are synchronous once invoked, so this
 		// persists them before finalizing their statements during process exit.
 		void this.#perfDrain.flush();
@@ -544,10 +546,9 @@ FROM model_usage_legacy
 	}
 
 	#flushModelPerf(rows: ModelPerfInsert[]): void {
-		// Kick the one-time history import too, so aggregates populate even if
-		// the user never opens /models. Additive merge makes ordering with live
-		// samples irrelevant.
-		this.#kickModelPerfBackfill();
+		// A close-triggered flush must persist only the queued live batch. Starting
+		// the async stats import here could commit aggregates without its marker.
+		if (!this.#closing) this.#kickModelPerfBackfill();
 		try {
 			this.#db.transaction((batch: ModelPerfInsert[]) => {
 				for (const row of batch) this.#foldModelPerf(row);

--- a/packages/coding-agent/src/session/history-storage.ts
+++ b/packages/coding-agent/src/session/history-storage.ts
@@ -1,7 +1,14 @@
 import { Database, type Statement } from "bun:sqlite";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { AsyncDrain, getDbBusyTimeoutMs, getHistoryDbPath, logger } from "@oh-my-pi/pi-utils";
+import {
+	AsyncDrain,
+	checkpointWal,
+	getDbBusyTimeoutMs,
+	getHistoryDbPath,
+	logger,
+	postmortem,
+} from "@oh-my-pi/pi-utils";
 
 /** A unique prompt with provenance from its most recent submission. */
 export interface HistoryEntry {
@@ -59,6 +66,8 @@ CREATE TABLE IF NOT EXISTS history (
 );
 CREATE INDEX IF NOT EXISTS idx_history_created_at ON history(created_at DESC);
 `;
+
+let cancelExitCleanup: (() => void) | undefined;
 
 /** Stores searchable prompts with only their latest project and session metadata. */
 export class HistoryStorage {
@@ -128,18 +137,25 @@ ON CONFLICT(prompt) DO UPDATE SET
 	static open(dbPath: string = getHistoryDbPath()): HistoryStorage {
 		if (!HistoryStorage.#instance) {
 			HistoryStorage.#instance = new HistoryStorage(dbPath);
+			cancelExitCleanup = postmortem.register("history-storage", () => HistoryStorage.close());
 		}
 		return HistoryStorage.#instance;
 	}
 
-	/** @internal Reset the singleton and close its database — test-only. */
-	static resetInstance(): void {
+	/** Flushes queued prompts, closes the process-wide database, and permits reopening it. */
+	static close(): void {
 		const instance = HistoryStorage.#instance;
 		HistoryStorage.#instance = undefined;
+		cancelExitCleanup?.();
+		cancelExitCleanup = undefined;
 		if (instance) instance.#close();
 	}
 
 	#close(): void {
+		// History batches are synchronous once invoked, so this persists them
+		// before finalizing the statements they use, including in process.on("exit").
+		void this.#drain.flush();
+		checkpointWal(this.#db);
 		for (const stmt of this.#substringStmts.values()) stmt.finalize();
 		this.#substringStmts.clear();
 		this.#upsertRowStmt.finalize();

--- a/packages/coding-agent/src/session/history-storage.ts
+++ b/packages/coding-agent/src/session/history-storage.ts
@@ -134,7 +134,7 @@ ON CONFLICT(prompt) DO UPDATE SET
 		// Exit-only: a keep-alive cleanup leaves the handle valid so the editor can
 		// keep submitting prompts; the real exit closes. Register before publishing
 		// so a real-exit-in-progress late registration cannot close this instance.
-		cancelExitCleanup = postmortem.register("history-storage", () => HistoryStorage.close(), true);
+		cancelExitCleanup = postmortem.register("history-storage", () => HistoryStorage.close(), { exitOnly: true });
 		HistoryStorage.#instance = instance;
 		return instance;
 	}

--- a/packages/coding-agent/src/session/history-storage.ts
+++ b/packages/coding-agent/src/session/history-storage.ts
@@ -135,11 +135,15 @@ ON CONFLICT(prompt) DO UPDATE SET
 
 	/** Opens the process-wide prompt history database. */
 	static open(dbPath: string = getHistoryDbPath()): HistoryStorage {
-		if (!HistoryStorage.#instance) {
-			HistoryStorage.#instance = new HistoryStorage(dbPath);
-			cancelExitCleanup = postmortem.register("history-storage", () => HistoryStorage.close());
-		}
-		return HistoryStorage.#instance;
+		const existing = HistoryStorage.#instance;
+		if (existing) return existing;
+
+		const instance = new HistoryStorage(dbPath);
+		// Register before publishing the singleton: late registrations run
+		// immediately, and must not close the instance this call returns.
+		cancelExitCleanup = postmortem.register("history-storage", () => HistoryStorage.close());
+		HistoryStorage.#instance = instance;
+		return instance;
 	}
 
 	/** Flushes queued prompts, closes the process-wide database, and permits reopening it. */

--- a/packages/coding-agent/src/session/history-storage.ts
+++ b/packages/coding-agent/src/session/history-storage.ts
@@ -1,14 +1,7 @@
 import { Database, type Statement } from "bun:sqlite";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import {
-	AsyncDrain,
-	checkpointWal,
-	getDbBusyTimeoutMs,
-	getHistoryDbPath,
-	logger,
-	postmortem,
-} from "@oh-my-pi/pi-utils";
+import { checkpointWal, getDbBusyTimeoutMs, getHistoryDbPath, logger, postmortem } from "@oh-my-pi/pi-utils";
 
 /** A unique prompt with provenance from its most recent submission. */
 export interface HistoryEntry {
@@ -73,7 +66,6 @@ let cancelExitCleanup: (() => void) | undefined;
 export class HistoryStorage {
 	#db: Database;
 	static #instance?: HistoryStorage;
-	#drain = new AsyncDrain<Pick<HistoryEntry, "prompt" | "cwd" | "sessionId">>(100);
 	#sessionResolver?: () => string | undefined;
 
 	// Prepared statements
@@ -146,7 +138,7 @@ ON CONFLICT(prompt) DO UPDATE SET
 		return instance;
 	}
 
-	/** Flushes queued prompts, closes the process-wide database, and permits reopening it. */
+	/** Checkpoints and closes the process-wide database, and permits reopening it. */
 	static close(): void {
 		const instance = HistoryStorage.#instance;
 		HistoryStorage.#instance = undefined;
@@ -156,9 +148,6 @@ ON CONFLICT(prompt) DO UPDATE SET
 	}
 
 	#close(): void {
-		// History batches are synchronous once invoked, so this persists them
-		// before finalizing the statements they use, including in process.on("exit").
-		void this.#drain.flush();
 		checkpointWal(this.#db);
 		for (const stmt of this.#substringStmts.values()) stmt.finalize();
 		this.#substringStmts.clear();
@@ -179,20 +168,28 @@ ON CONFLICT(prompt) DO UPDATE SET
 	/**
 	 * Register a resolver that supplies the current session ID for prompts added
 	 * without an explicit `sessionId`. Evaluated synchronously at `add()` time so
-	 * batched writes capture the session active when the prompt was submitted.
+	 * each write captures the session active when the prompt was submitted.
 	 */
 	setSessionResolver(resolver: () => string | undefined): void {
 		this.#sessionResolver = resolver;
 	}
 
-	/** Stores a prompt and replaces its provenance with the latest submission. */
+	/**
+	 * Stores a prompt and replaces its provenance with the latest submission.
+	 * The write is synchronous: prompt submission is human-paced, not a hot
+	 * path, so the row is durable the moment `add()` returns and can never be
+	 * lost to an exit racing a deferred flush. Failures are logged, not thrown.
+	 */
 	add(prompt: string, cwd?: string, sessionId?: string): Promise<void> {
 		const trimmed = normalizePrompt(prompt);
 		if (!trimmed) return Promise.resolve();
 		const session = sessionId ?? this.#sessionResolver?.();
-		return this.#drain.push({ prompt: trimmed, cwd: cwd ?? undefined, sessionId: session || undefined }, rows => {
-			this.#insertBatch(rows);
-		});
+		try {
+			this.#insertBatch([{ prompt: trimmed, cwd: cwd ?? undefined, sessionId: session || undefined }]);
+		} catch (error) {
+			logger.error("HistoryStorage add failed", { error: String(error) });
+		}
+		return Promise.resolve();
 	}
 
 	/** Returns unique prompts ordered by their most recent submission. */

--- a/packages/coding-agent/src/session/history-storage.ts
+++ b/packages/coding-agent/src/session/history-storage.ts
@@ -131,9 +131,10 @@ ON CONFLICT(prompt) DO UPDATE SET
 		if (existing) return existing;
 
 		const instance = new HistoryStorage(dbPath);
-		// Register before publishing the singleton: late registrations run
-		// immediately, and must not close the instance this call returns.
-		cancelExitCleanup = postmortem.register("history-storage", () => HistoryStorage.close());
+		// Exit-only: a keep-alive cleanup leaves the handle valid so the editor can
+		// keep submitting prompts; the real exit closes. Register before publishing
+		// so a real-exit-in-progress late registration cannot close this instance.
+		cancelExitCleanup = postmortem.register("history-storage", () => HistoryStorage.close(), true);
 		HistoryStorage.#instance = instance;
 		return instance;
 	}

--- a/packages/coding-agent/test/advisor-toggle.test.ts
+++ b/packages/coding-agent/test/advisor-toggle.test.ts
@@ -254,7 +254,7 @@ describe("AgentSession advisor toggle", () => {
 			expect(customSession.getAdvisorAgent()?.state.model.id).toBe(replacementModel.id);
 		} finally {
 			await customSession.dispose();
-			AgentStorage.resetInstance();
+			AgentStorage.close();
 		}
 	});
 

--- a/packages/coding-agent/test/agent-session-python-cleanup.test.ts
+++ b/packages/coding-agent/test/agent-session-python-cleanup.test.ts
@@ -167,7 +167,7 @@ describe("AgentSession python cleanup", () => {
 		}
 		originalNullPrompt = undefined;
 		vi.restoreAllMocks();
-		AgentStorage.resetInstance();
+		AgentStorage.close();
 		await pythonExecutor.disposeAllKernelSessions();
 		await Bun.sleep(0);
 		// Best-effort cleanup: createAgentSession opens AuthStorage/AgentStorage

--- a/packages/coding-agent/test/agent-storage-command-usage.test.ts
+++ b/packages/coding-agent/test/agent-storage-command-usage.test.ts
@@ -7,7 +7,7 @@ describe("AgentStorage command usage", () => {
 	let tempDir: TempDir | undefined;
 
 	afterEach(async () => {
-		AgentStorage.resetInstance();
+		AgentStorage.close();
 		if (tempDir) {
 			try {
 				await tempDir.remove();
@@ -27,7 +27,7 @@ describe("AgentStorage command usage", () => {
 		expect(storage.listCommandUsage()).toEqual({ model: 2, "skill:review": 1 });
 
 		// Counts are a cross-session contract: a fresh handle must see them.
-		AgentStorage.resetInstance();
+		AgentStorage.close();
 		const reopened = await AgentStorage.open(dbPath);
 		expect(reopened.listCommandUsage()).toEqual({ model: 2, "skill:review": 1 });
 		reopened.recordCommandUsage("model");

--- a/packages/coding-agent/test/agent-storage-model-perf.test.ts
+++ b/packages/coding-agent/test/agent-storage-model-perf.test.ts
@@ -21,7 +21,7 @@ describe("AgentStorage model perf aggregates", () => {
 
 	afterEach(async () => {
 		vi.useRealTimers();
-		AgentStorage.resetInstance();
+		AgentStorage.close();
 		if (tempDir) {
 			try {
 				await tempDir.remove();

--- a/packages/coding-agent/test/agent-storage-model-perf.test.ts
+++ b/packages/coding-agent/test/agent-storage-model-perf.test.ts
@@ -7,6 +7,20 @@ import { createSubagentSettings } from "@oh-my-pi/pi-coding-agent/task/executor"
 import { TempDir } from "@oh-my-pi/pi-utils";
 
 const MODEL_PERF_FLUSH_DELAY_MS = 100;
+const REPO_ROOT = path.resolve(import.meta.dir, "../../..");
+const AGENT_STORAGE_MODULE = path.resolve(import.meta.dir, "../src/session/agent-storage.ts");
+
+async function runProbe(script: string, env: NodeJS.ProcessEnv): Promise<{ exitCode: number; stderr: string }> {
+	const child = Bun.spawn([process.execPath, "--eval", script], {
+		cwd: REPO_ROOT,
+		env,
+		stdin: "ignore",
+		stdout: "ignore",
+		stderr: "pipe",
+	});
+	const [exitCode, stderr] = await Promise.all([child.exited, new Response(child.stderr).text()]);
+	return { exitCode, stderr };
+}
 
 async function flushPerf(...writes: Promise<void>[]): Promise<void> {
 	vi.advanceTimersByTime(MODEL_PERF_FLUSH_DELAY_MS);
@@ -215,5 +229,70 @@ describe("AgentStorage model perf aggregates", () => {
 		const stats = storage.getModelPerf().get("openai/gpt-5");
 		expect(stats?.samples).toBe(256);
 		expect(stats?.tps).toBeCloseTo(100, 5);
+	});
+
+	it("does not start the stats backfill while flushing a live batch on exit", async () => {
+		tempDir = TempDir.createSync("@omp-agent-storage-exit-backfill-");
+		const homeDir = tempDir.join("home");
+		const agentDir = tempDir.join("agent");
+		const env = {
+			...process.env,
+			HOME: homeDir,
+			OMP_PROFILE: "",
+			PI_CODING_AGENT_DIR: agentDir,
+			PI_PROFILE: "",
+			XDG_CACHE_HOME: tempDir.join("xdg-cache"),
+			XDG_CONFIG_HOME: tempDir.join("xdg-config"),
+			XDG_DATA_HOME: tempDir.join("xdg-data"),
+			XDG_STATE_HOME: tempDir.join("xdg-state"),
+		};
+		const exiting = await runProbe(
+			[
+				'import { Database } from "bun:sqlite";',
+				'import * as fs from "node:fs";',
+				'import * as path from "node:path";',
+				'import { getStatsDbPath } from "@oh-my-pi/pi-utils";',
+				`import { AgentStorage } from ${JSON.stringify(AGENT_STORAGE_MODULE)};`,
+				"const statsPath = getStatsDbPath();",
+				"fs.mkdirSync(path.dirname(statsPath), { recursive: true });",
+				"const statsDb = new Database(statsPath);",
+				'statsDb.run("CREATE TABLE messages (provider TEXT, model TEXT, output_tokens INTEGER, duration INTEGER, ttft INTEGER, stop_reason TEXT, timestamp INTEGER)");',
+				'statsDb.run("INSERT INTO messages VALUES (?, ?, ?, ?, ?, ?, ?)", ["openai", "repro", 20, 2000, null, "stop", Date.now()]);',
+				"statsDb.close();",
+				"const storage = await AgentStorage.open();",
+				'void storage.recordModelPerf("openai/repro", { outputTokens: 10, durationMs: 1000 });',
+				"process.exit(0);",
+			].join("\n"),
+			env,
+		);
+		expect(exiting.exitCode, exiting.stderr).toBe(0);
+
+		const reopening = await runProbe(
+			[
+				`import { AgentStorage } from ${JSON.stringify(AGENT_STORAGE_MODULE)};`,
+				"const storage = await AgentStorage.open();",
+				"storage.getModelPerf();",
+				"await Promise.resolve();",
+				"AgentStorage.close();",
+			].join("\n"),
+			env,
+		);
+		expect(reopening.exitCode, reopening.stderr).toBe(0);
+
+		const db = new Database(path.join(agentDir, "agent.db"), { readonly: true });
+		try {
+			expect(
+				db
+					.query<{ samples: number; output_tokens: number; gen_ms: number }, []>(
+						"SELECT samples, output_tokens, gen_ms FROM model_perf WHERE model_key = 'openai/repro'",
+					)
+					.get(),
+			).toEqual({ samples: 2, output_tokens: 30, gen_ms: 3000 });
+			expect(
+				db.query<{ value: string }, [string]>("SELECT value FROM meta WHERE key = ?").get("model_perf_backfill"),
+			).toEqual({ value: "complete" });
+		} finally {
+			db.close();
+		}
 	});
 });

--- a/packages/coding-agent/test/agent-storage-sqlite-compat.test.ts
+++ b/packages/coding-agent/test/agent-storage-sqlite-compat.test.ts
@@ -36,7 +36,7 @@ describe("AgentStorage SQLite compatibility", () => {
 	let tempDir: TempDir;
 
 	afterEach(async () => {
-		AgentStorage.resetInstance();
+		AgentStorage.close();
 		if (tempDir) {
 			try {
 				await tempDir.remove();

--- a/packages/coding-agent/test/autocomplete-max-visible.test.ts
+++ b/packages/coding-agent/test/autocomplete-max-visible.test.ts
@@ -24,7 +24,7 @@ describe("autocompleteMaxVisible setting", () => {
 	});
 
 	afterEach(async () => {
-		AgentStorage.resetInstance();
+		AgentStorage.close();
 		restoreSettingsTestState(settingsState);
 		settingsState = undefined;
 		if (tempDir) {

--- a/packages/coding-agent/test/config-cli-credentials.test.ts
+++ b/packages/coding-agent/test/config-cli-credentials.test.ts
@@ -88,7 +88,7 @@ describe("config list output", () => {
 
 	afterEach(async () => {
 		vi.restoreAllMocks();
-		AgentStorage.resetInstance();
+		AgentStorage.close();
 		resetSettingsForTest();
 		if (originalAgentDir) setAgentDir(originalAgentDir);
 		else {

--- a/packages/coding-agent/test/config-cli.test.ts
+++ b/packages/coding-agent/test/config-cli.test.ts
@@ -36,7 +36,7 @@ beforeEach(() => {
 
 afterEach(async () => {
 	vi.restoreAllMocks();
-	AgentStorage.resetInstance();
+	AgentStorage.close();
 	resetSettingsForTest();
 	if (originalAgentDir) {
 		setAgentDir(originalAgentDir);

--- a/packages/coding-agent/test/history-storage-drain.test.ts
+++ b/packages/coding-agent/test/history-storage-drain.test.ts
@@ -1,3 +1,4 @@
+import { Database } from "bun:sqlite";
 import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
@@ -10,7 +11,7 @@ let tempDir = "";
 async function freshStorage(prefix = "omp-history-drain-"): Promise<HistoryStorage> {
 	tempDir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
 	const dbPath = path.join(tempDir, "history.db");
-	HistoryStorage.resetInstance();
+	HistoryStorage.close();
 	return HistoryStorage.open(dbPath);
 }
 
@@ -21,12 +22,12 @@ async function flush(...writes: Promise<void>[]): Promise<void> {
 }
 
 beforeEach(() => {
-	HistoryStorage.resetInstance();
+	HistoryStorage.close();
 	vi.useFakeTimers();
 });
 
 afterEach(async () => {
-	HistoryStorage.resetInstance();
+	HistoryStorage.close();
 	vi.useRealTimers();
 	if (tempDir) {
 		await removeWithRetries(tempDir).catch(() => {});
@@ -68,5 +69,58 @@ describe("HistoryStorage AsyncDrain batching", () => {
 		// After the first batch flushes, a new add starts a new batch.
 		await flush(storage.add("batch-two"));
 		expect(storage.getRecent(10).map(r => r.prompt)).toEqual(["batch-two", "batch-one"]);
+	});
+});
+
+describe("storage process-exit cleanup", () => {
+	it("flushes queued writes and checkpoints both databases before a hard exit", async () => {
+		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-storage-exit-"));
+		const historyDbPath = path.join(tempDir, "history.db");
+		const agentDbPath = path.join(tempDir, "agent.db");
+		const historyModule = path.resolve(import.meta.dir, "../src/session/history-storage.ts");
+		const agentModule = path.resolve(import.meta.dir, "../src/session/agent-storage.ts");
+		const script = [
+			`import { HistoryStorage } from ${JSON.stringify(historyModule)};`,
+			`import { AgentStorage } from ${JSON.stringify(agentModule)};`,
+			`const history = HistoryStorage.open(${JSON.stringify(historyDbPath)});`,
+			`const agent = await AgentStorage.open(${JSON.stringify(agentDbPath)});`,
+			'void history.add("queued immediately before exit", "/tmp", "exit-session");',
+			'void agent.recordModelPerf("openai/repro", { outputTokens: 10, durationMs: 1000 });',
+			"process.exit(0);",
+		].join("\n");
+		const child = Bun.spawn([process.execPath, "--eval", script], {
+			cwd: path.resolve(import.meta.dir, "../../.."),
+			stdin: "ignore",
+			stdout: "ignore",
+			stderr: "pipe",
+		});
+		const [exitCode, stderr] = await Promise.all([child.exited, new Response(child.stderr).text()]);
+		expect(exitCode, stderr).toBe(0);
+		const historyCheckpoint = path.join(tempDir, "history-checkpoint.db");
+		const agentCheckpoint = path.join(tempDir, "agent-checkpoint.db");
+		await Promise.all([
+			Bun.write(historyCheckpoint, Bun.file(historyDbPath)),
+			Bun.write(agentCheckpoint, Bun.file(agentDbPath)),
+		]);
+
+		// Read copies of the main database files without their WALs. The queued
+		// rows are visible only if process-exit cleanup checkpointed them.
+		const historyDb = new Database(historyCheckpoint, { readonly: true });
+		const agentDb = new Database(agentCheckpoint, { readonly: true });
+		try {
+			expect(historyDb.query<{ prompt: string }, []>("SELECT prompt FROM history").get()).toEqual({
+				prompt: "queued immediately before exit",
+			});
+			expect(
+				agentDb
+					.query<{ samples: number; output_tokens: number; gen_ms: number }, []>(
+						"SELECT samples, output_tokens, gen_ms FROM model_perf WHERE model_key = 'openai/repro'",
+					)
+					.get(),
+			).toEqual({ samples: 1, output_tokens: 10, gen_ms: 1000 });
+		} finally {
+			historyDb.close();
+			agentDb.close();
+		}
 	});
 });

--- a/packages/coding-agent/test/history-storage-drain.test.ts
+++ b/packages/coding-agent/test/history-storage-drain.test.ts
@@ -7,6 +7,9 @@ import { HistoryStorage } from "@oh-my-pi/pi-coding-agent/session/history-storag
 import { removeWithRetries } from "@oh-my-pi/pi-utils";
 
 let tempDir = "";
+const REPO_ROOT = path.resolve(import.meta.dir, "../../..");
+const HISTORY_STORAGE_MODULE = path.resolve(import.meta.dir, "../src/session/history-storage.ts");
+const AGENT_STORAGE_MODULE = path.resolve(import.meta.dir, "../src/session/agent-storage.ts");
 
 async function freshStorage(prefix = "omp-history-drain-"): Promise<HistoryStorage> {
 	tempDir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
@@ -77,8 +80,8 @@ describe("storage process-exit cleanup", () => {
 		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-storage-exit-"));
 		const historyDbPath = path.join(tempDir, "history.db");
 		const agentDbPath = path.join(tempDir, "agent.db");
-		const historyModule = path.resolve(import.meta.dir, "../src/session/history-storage.ts");
-		const agentModule = path.resolve(import.meta.dir, "../src/session/agent-storage.ts");
+		const historyModule = HISTORY_STORAGE_MODULE;
+		const agentModule = AGENT_STORAGE_MODULE;
 		const script = [
 			`import { HistoryStorage } from ${JSON.stringify(historyModule)};`,
 			`import { AgentStorage } from ${JSON.stringify(agentModule)};`,
@@ -89,7 +92,7 @@ describe("storage process-exit cleanup", () => {
 			"process.exit(0);",
 		].join("\n");
 		const child = Bun.spawn([process.execPath, "--eval", script], {
-			cwd: path.resolve(import.meta.dir, "../../.."),
+			cwd: REPO_ROOT,
 			stdin: "ignore",
 			stdout: "ignore",
 			stderr: "pipe",
@@ -122,5 +125,43 @@ describe("storage process-exit cleanup", () => {
 			historyDb.close();
 			agentDb.close();
 		}
+	});
+
+	it("keeps stores opened after manual postmortem cleanup usable", async () => {
+		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-storage-late-open-"));
+		const historyDbPath = path.join(tempDir, "history.db");
+		const agentDbPath = path.join(tempDir, "agent.db");
+		const script = [
+			'import { postmortem } from "@oh-my-pi/pi-utils";',
+			`import { HistoryStorage } from ${JSON.stringify(HISTORY_STORAGE_MODULE)};`,
+			`import { AgentStorage } from ${JSON.stringify(AGENT_STORAGE_MODULE)};`,
+			"await postmortem.cleanup();",
+			`const history = HistoryStorage.open(${JSON.stringify(historyDbPath)});`,
+			'void history.add("opened after cleanup", "/tmp", "late-session");',
+			"HistoryStorage.close();",
+			`const reopenedHistory = HistoryStorage.open(${JSON.stringify(historyDbPath)});`,
+			"const prompts = reopenedHistory.getRecent(10).map(row => row.prompt);",
+			"HistoryStorage.close();",
+			`const agent = await AgentStorage.open(${JSON.stringify(agentDbPath)});`,
+			'agent.recordCommandUsage("after-cleanup");',
+			"const commands = agent.listCommandUsage();",
+			"AgentStorage.close();",
+			"console.log(JSON.stringify({ prompts, commands }));",
+		].join("\n");
+		const child = Bun.spawn([process.execPath, "--eval", script], {
+			cwd: REPO_ROOT,
+			stdin: "ignore",
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		const [exitCode, stdout, stderr] = await Promise.all([
+			child.exited,
+			new Response(child.stdout).text(),
+			new Response(child.stderr).text(),
+		]);
+		expect(exitCode, stderr).toBe(0);
+		expect(stdout.trim()).toBe(
+			JSON.stringify({ prompts: ["opened after cleanup"], commands: { "after-cleanup": 1 } }),
+		);
 	});
 });

--- a/packages/coding-agent/test/history-storage-search.test.ts
+++ b/packages/coding-agent/test/history-storage-search.test.ts
@@ -6,7 +6,7 @@ let tempDir: TempDir | null = null;
 
 async function freshStorage(): Promise<HistoryStorage> {
 	tempDir = TempDir.createSync("@omp-history-search-");
-	HistoryStorage.resetInstance();
+	HistoryStorage.close();
 	return HistoryStorage.open(tempDir.join("history.db"));
 }
 
@@ -17,12 +17,12 @@ async function seed(storage: HistoryStorage, prompts: string[]): Promise<void> {
 }
 
 beforeEach(() => {
-	HistoryStorage.resetInstance();
+	HistoryStorage.close();
 	vi.useFakeTimers();
 });
 
 afterEach(async () => {
-	HistoryStorage.resetInstance();
+	HistoryStorage.close();
 	vi.useRealTimers();
 	if (tempDir) {
 		await Bun.sleep(0);

--- a/packages/coding-agent/test/history-storage-session.test.ts
+++ b/packages/coding-agent/test/history-storage-session.test.ts
@@ -8,7 +8,7 @@ let tempDir: TempDir | null = null;
 async function freshStorage(prefix = "omp-history-session-"): Promise<{ storage: HistoryStorage; dbPath: string }> {
 	tempDir = TempDir.createSync(`@${prefix}`);
 	const dbPath = tempDir.join("history.db");
-	HistoryStorage.resetInstance();
+	HistoryStorage.close();
 	return { storage: HistoryStorage.open(dbPath), dbPath };
 }
 
@@ -19,12 +19,12 @@ async function flush(...writes: Promise<void>[]): Promise<void> {
 }
 
 beforeEach(() => {
-	HistoryStorage.resetInstance();
+	HistoryStorage.close();
 	vi.useFakeTimers();
 });
 
 afterEach(async () => {
-	HistoryStorage.resetInstance();
+	HistoryStorage.close();
 	vi.useRealTimers();
 	if (tempDir) {
 		await Bun.sleep(0);
@@ -97,7 +97,7 @@ describe("HistoryStorage session linkage", () => {
 		legacyDb.prepare("INSERT INTO history (prompt, cwd) VALUES (?, ?)").run("legacy prompt", "/legacy");
 		legacyDb.close();
 
-		HistoryStorage.resetInstance();
+		HistoryStorage.close();
 		const storage = HistoryStorage.open(dbPath);
 		await flush(storage.add("new prompt", "/new", "session-xyz"));
 

--- a/packages/coding-agent/test/history-storage-sqlite-compat.test.ts
+++ b/packages/coding-agent/test/history-storage-sqlite-compat.test.ts
@@ -9,11 +9,11 @@ const LEGACY_TIMESTAMP = 1_700_000_000;
 let tempDir: TempDir | null = null;
 
 beforeEach(() => {
-	HistoryStorage.resetInstance();
+	HistoryStorage.close();
 });
 
 afterEach(async () => {
-	HistoryStorage.resetInstance();
+	HistoryStorage.close();
 	if (tempDir) {
 		await Bun.sleep(0);
 		await tempDir.remove().catch(() => {});
@@ -121,7 +121,7 @@ it("collapses preexisting whitespace-padded duplicates on open, keeping the late
 	tempDir = TempDir.createSync("@omp-history-storage-padded-");
 	const dbPath = tempDir.join("history.db");
 	HistoryStorage.open(dbPath);
-	HistoryStorage.resetInstance();
+	HistoryStorage.close();
 
 	const raw = new Database(dbPath);
 	const insert = raw.prepare("INSERT INTO history (prompt, created_at, cwd, session_id) VALUES (?, ?, ?, ?)");

--- a/packages/coding-agent/test/issue-2510-repro.test.ts
+++ b/packages/coding-agent/test/issue-2510-repro.test.ts
@@ -57,7 +57,7 @@ describe("issue #2510 — /plan toggles plan → plan_paused → none", () => {
 	afterEach(async () => {
 		vi.restoreAllMocks();
 		mode?.stop();
-		HistoryStorage.resetInstance();
+		HistoryStorage.close();
 		await session?.dispose();
 		authStorage?.close();
 		tempDir?.removeSync();

--- a/packages/coding-agent/test/issue-3656-shake-during-stream.test.ts
+++ b/packages/coding-agent/test/issue-3656-shake-during-stream.test.ts
@@ -90,7 +90,7 @@ describe("issue #3656 /shake mid-stream preserves the in-flight assistant turn",
 
 	afterEach(async () => {
 		mode?.stop();
-		HistoryStorage.resetInstance();
+		HistoryStorage.close();
 		vi.restoreAllMocks();
 		await session?.dispose();
 		authStorage?.close();

--- a/packages/coding-agent/test/issue-4806-command-output.test.ts
+++ b/packages/coding-agent/test/issue-4806-command-output.test.ts
@@ -55,7 +55,7 @@ describe("issue #4806 command output during streaming", () => {
 
 	afterEach(async () => {
 		mode?.stop();
-		HistoryStorage.resetInstance();
+		HistoryStorage.close();
 		vi.restoreAllMocks();
 		await session?.dispose();
 		authStorage?.close();

--- a/packages/coding-agent/test/issue-6767-usage-command-streaming.test.ts
+++ b/packages/coding-agent/test/issue-6767-usage-command-streaming.test.ts
@@ -74,7 +74,7 @@ describe("issue #6767 /usage output during streaming", () => {
 
 	afterEach(async () => {
 		mode?.stop();
-		HistoryStorage.resetInstance();
+		HistoryStorage.close();
 		vi.restoreAllMocks();
 		await session?.dispose();
 		authStorage?.close();

--- a/packages/coding-agent/test/issue-8137-repro.test.ts
+++ b/packages/coding-agent/test/issue-8137-repro.test.ts
@@ -73,7 +73,7 @@ describe("issue #8137 — inline /skill in mode-command prompts", () => {
 	afterEach(async () => {
 		vi.restoreAllMocks();
 		mode?.stop();
-		HistoryStorage.resetInstance();
+		HistoryStorage.close();
 		await session?.dispose();
 		authStorage?.close();
 		tempDir?.removeSync();

--- a/packages/coding-agent/test/issue-816-repro.test.ts
+++ b/packages/coding-agent/test/issue-816-repro.test.ts
@@ -51,7 +51,7 @@ describe("issue #816 — plan mode pendingModelSwitch leak", () => {
 	afterEach(async () => {
 		vi.restoreAllMocks();
 		mode?.stop();
-		HistoryStorage.resetInstance();
+		HistoryStorage.close();
 		await session?.dispose();
 		authStorage?.close();
 		tempDir?.removeSync();

--- a/packages/coding-agent/test/issue-927-repro.test.ts
+++ b/packages/coding-agent/test/issue-927-repro.test.ts
@@ -53,7 +53,7 @@ describe("issue #927 optimistic pending spinner", () => {
 
 	afterEach(async () => {
 		mode?.stop();
-		HistoryStorage.resetInstance();
+		HistoryStorage.close();
 		vi.restoreAllMocks();
 		await session?.dispose();
 		authStorage?.close();

--- a/packages/coding-agent/test/keybindings-selector-navigation.test.ts
+++ b/packages/coding-agent/test/keybindings-selector-navigation.test.ts
@@ -29,7 +29,7 @@ beforeAll(() => {
 
 afterEach(async () => {
 	setKeybindings(KeybindingsManager.inMemory());
-	HistoryStorage.resetInstance();
+	HistoryStorage.close();
 	await Bun.sleep(0);
 	await Promise.all(tempDirs.splice(0).map(tempDir => tempDir.remove().catch(() => {})));
 });
@@ -96,7 +96,7 @@ function createExtension(id: string, displayName: string): Extension {
 async function createHistoryStorage(prompts: string[]): Promise<HistoryStorage> {
 	const dir = TempDir.createSync("@omp-history-nav-");
 	tempDirs.push(dir);
-	HistoryStorage.resetInstance();
+	HistoryStorage.close();
 	const storage = HistoryStorage.open(dir.join("history.db"));
 	// add() batches writes behind a 100ms AsyncDrain timer. Drive that timer with
 	// fake timers so the flush is instant instead of waiting real wall-clock time.

--- a/packages/coding-agent/test/service-tier-migration.test.ts
+++ b/packages/coding-agent/test/service-tier-migration.test.ts
@@ -26,7 +26,7 @@ describe("serviceTier → tier.* settings migration", () => {
 	});
 
 	afterEach(async () => {
-		AgentStorage.resetInstance();
+		AgentStorage.close();
 		restoreSettingsTestState(settingsState);
 		settingsState = undefined;
 		try {

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -79,7 +79,7 @@ describe("Settings", () => {
 		vi.restoreAllMocks();
 		clearCustomApis();
 		__providerInFlightForTesting.setRoot(undefined);
-		AgentStorage.resetInstance();
+		AgentStorage.close();
 		restoreSettingsTestState(settingsState);
 		settingsState = undefined;
 		await Bun.sleep(0);

--- a/packages/coding-agent/test/storage-exit-lifecycle.test.ts
+++ b/packages/coding-agent/test/storage-exit-lifecycle.test.ts
@@ -147,6 +147,50 @@ describe("storage process-exit cleanup", () => {
 		);
 	});
 
+	it("arms storage opened while a keep-alive cleanup is still running", async () => {
+		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-storage-running-cleanup-"));
+		const agentDbPath = path.join(tempDir, "agent.db");
+		const checkpointed = path.join(tempDir, "agent-checkpoint.db");
+		const script = [
+			'import { postmortem } from "@oh-my-pi/pi-utils";',
+			`import { AgentStorage } from ${JSON.stringify(AGENT_STORAGE_MODULE)};`,
+			"const gate = Promise.withResolvers();",
+			'postmortem.register("blocker", () => gate.promise);',
+			"const cleanup = postmortem.cleanup();",
+			// Open while the blocker keeps cleanupStage="running". The exit-only
+			// registration must stay armed rather than firing before publication.
+			`const agent = await AgentStorage.open(${JSON.stringify(agentDbPath)});`,
+			'void agent.recordModelPerf("openai/running", { outputTokens: 30, durationMs: 3000 });',
+			"gate.resolve();",
+			"await cleanup;",
+			"process.exit(0);",
+		].join("\n");
+		const child = Bun.spawn([process.execPath, "--eval", script], {
+			cwd: REPO_ROOT,
+			stdin: "ignore",
+			stdout: "ignore",
+			stderr: "pipe",
+		});
+		const [exitCode, stderr] = await Promise.all([child.exited, new Response(child.stderr).text()]);
+		expect(exitCode, stderr).toBe(0);
+
+		// Read the main file without its WAL: only the real-exit callback flushes
+		// the deferred sample and checkpoints it into this copy.
+		await Bun.write(checkpointed, Bun.file(agentDbPath));
+		const agentDb = new Database(checkpointed, { readonly: true });
+		try {
+			expect(
+				agentDb
+					.query<{ samples: number; output_tokens: number; gen_ms: number }, []>(
+						"SELECT samples, output_tokens, gen_ms FROM model_perf WHERE model_key = 'openai/running'",
+					)
+					.get(),
+			).toEqual({ samples: 1, output_tokens: 30, gen_ms: 3000 });
+		} finally {
+			agentDb.close();
+		}
+	});
+
 	it("re-arms exit cleanup for a store opened after a manual postmortem cleanup", async () => {
 		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-storage-rearm-"));
 		const agentDbPath = path.join(tempDir, "agent.db");

--- a/packages/coding-agent/test/storage-exit-lifecycle.test.ts
+++ b/packages/coding-agent/test/storage-exit-lifecycle.test.ts
@@ -183,4 +183,36 @@ describe("storage process-exit cleanup", () => {
 			agentDb.close();
 		}
 	});
+
+	it("keeps a handle held across a manual cleanup usable", async () => {
+		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-storage-keepalive-"));
+		const agentDbPath = path.join(tempDir, "agent.db");
+		// A cached handle (Settings, MCP cache, the editor) survives a keep-alive
+		// cleanup that keeps the process running: its statements must not be
+		// finalized, so writes through the same handle keep working afterward.
+		const script = [
+			'import { postmortem } from "@oh-my-pi/pi-utils";',
+			`import { AgentStorage } from ${JSON.stringify(AGENT_STORAGE_MODULE)};`,
+			`const agent = await AgentStorage.open(${JSON.stringify(agentDbPath)});`,
+			'agent.recordCommandUsage("before-cleanup");',
+			"await postmortem.cleanup();",
+			// Same handle after cleanup: writing here throws if statements were finalized.
+			'agent.recordCommandUsage("after-cleanup");',
+			"console.log(JSON.stringify(agent.listCommandUsage()));",
+			"process.exit(0);",
+		].join("\n");
+		const child = Bun.spawn([process.execPath, "--eval", script], {
+			cwd: REPO_ROOT,
+			stdin: "ignore",
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		const [exitCode, stdout, stderr] = await Promise.all([
+			child.exited,
+			new Response(child.stdout).text(),
+			new Response(child.stderr).text(),
+		]);
+		expect(exitCode, stderr).toBe(0);
+		expect(JSON.parse(stdout.trim())).toEqual({ "before-cleanup": 1, "after-cleanup": 1 });
+	});
 });

--- a/packages/coding-agent/test/storage-exit-lifecycle.test.ts
+++ b/packages/coding-agent/test/storage-exit-lifecycle.test.ts
@@ -1,5 +1,5 @@
 import { Database } from "bun:sqlite";
-import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -11,27 +11,19 @@ const REPO_ROOT = path.resolve(import.meta.dir, "../../..");
 const HISTORY_STORAGE_MODULE = path.resolve(import.meta.dir, "../src/session/history-storage.ts");
 const AGENT_STORAGE_MODULE = path.resolve(import.meta.dir, "../src/session/agent-storage.ts");
 
-async function freshStorage(prefix = "omp-history-drain-"): Promise<HistoryStorage> {
+async function freshStorage(prefix = "omp-history-write-through-"): Promise<HistoryStorage> {
 	tempDir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
 	const dbPath = path.join(tempDir, "history.db");
 	HistoryStorage.close();
 	return HistoryStorage.open(dbPath);
 }
 
-/** Drain the 100ms insert batch window, then await the pending writes. */
-async function flush(...writes: Promise<void>[]): Promise<void> {
-	vi.advanceTimersByTime(100);
-	await Promise.all(writes);
-}
-
 beforeEach(() => {
 	HistoryStorage.close();
-	vi.useFakeTimers();
 });
 
 afterEach(async () => {
 	HistoryStorage.close();
-	vi.useRealTimers();
 	if (tempDir) {
 		await removeWithRetries(tempDir).catch(() => {});
 		tempDir = "";
@@ -39,44 +31,33 @@ afterEach(async () => {
 });
 
 /**
- * Contract for the history-storage async drain: multiple rapid `add()` calls
- * within the drain window are batched into a single flushed write, and the
- * returned promise resolves once the batch is persisted. This guards the
- * `Promise.withResolvers()` refactor of `AsyncDrain` — the drain must still
- * coalesce pushes and resolve its per-batch promise.
+ * Prompt submission is human-paced, so history writes through synchronously:
+ * every accepted prompt is durable the moment `add()` resolves, with no batch
+ * window a fast exit could race.
  */
-describe("HistoryStorage AsyncDrain batching", () => {
-	it("coalesces pushes within the drain window into one flushed write", async () => {
+describe("HistoryStorage write-through", () => {
+	it("persists each submitted prompt without waiting on a timer", async () => {
 		const storage = await freshStorage();
-		// Three rapid adds before the 100ms drain window fires.
-		const p1 = storage.add("first prompt");
-		const p2 = storage.add("second prompt");
-		const p3 = storage.add("third prompt");
-		await flush(p1, p2, p3);
+		await storage.add("first prompt");
+		await storage.add("second prompt");
+		await storage.add("third prompt");
 
 		expect(storage.getRecent(10).map(r => r.prompt)).toEqual(["third prompt", "second prompt", "first prompt"]);
 	});
 
-	it("resolves the returned promise for each coalesced push", async () => {
+	it("replaces provenance when the same prompt is resubmitted", async () => {
 		const storage = await freshStorage();
-		const p1 = storage.add("a");
-		const p2 = storage.add("b");
-		await flush(p1, p2);
-		// Both promises must have resolved (not hang) — flush awaited them.
-		expect(storage.getRecent(10)).toHaveLength(2);
-	});
+		await storage.add("repeat", "/first", "session-a");
+		await storage.add("repeat", "/second", "session-b");
 
-	it("starts a fresh batch after the prior one flushes", async () => {
-		const storage = await freshStorage();
-		await flush(storage.add("batch-one"));
-		// After the first batch flushes, a new add starts a new batch.
-		await flush(storage.add("batch-two"));
-		expect(storage.getRecent(10).map(r => r.prompt)).toEqual(["batch-two", "batch-one"]);
+		const entries = storage.getRecent(10);
+		expect(entries).toHaveLength(1);
+		expect(entries[0]).toMatchObject({ prompt: "repeat", cwd: "/second", sessionId: "session-b" });
 	});
 });
 
 describe("storage process-exit cleanup", () => {
-	it("flushes queued writes and checkpoints both databases before a hard exit", async () => {
+	it("persists a synchronous prompt and flushes the deferred perf sample before a hard exit", async () => {
 		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-storage-exit-"));
 		const historyDbPath = path.join(tempDir, "history.db");
 		const agentDbPath = path.join(tempDir, "agent.db");
@@ -87,7 +68,7 @@ describe("storage process-exit cleanup", () => {
 			`import { AgentStorage } from ${JSON.stringify(agentModule)};`,
 			`const history = HistoryStorage.open(${JSON.stringify(historyDbPath)});`,
 			`const agent = await AgentStorage.open(${JSON.stringify(agentDbPath)});`,
-			'void history.add("queued immediately before exit", "/tmp", "exit-session");',
+			'void history.add("written immediately before exit", "/tmp", "exit-session");',
 			'void agent.recordModelPerf("openai/repro", { outputTokens: 10, durationMs: 1000 });',
 			"process.exit(0);",
 		].join("\n");
@@ -106,13 +87,14 @@ describe("storage process-exit cleanup", () => {
 			Bun.write(agentCheckpoint, Bun.file(agentDbPath)),
 		]);
 
-		// Read copies of the main database files without their WALs. The queued
-		// rows are visible only if process-exit cleanup checkpointed them.
+		// Read copies of the main database files without their WALs. Both rows are
+		// visible only if process-exit cleanup flushed the deferred perf batch and
+		// checkpointed committed frames into the main file.
 		const historyDb = new Database(historyCheckpoint, { readonly: true });
 		const agentDb = new Database(agentCheckpoint, { readonly: true });
 		try {
 			expect(historyDb.query<{ prompt: string }, []>("SELECT prompt FROM history").get()).toEqual({
-				prompt: "queued immediately before exit",
+				prompt: "written immediately before exit",
 			});
 			expect(
 				agentDb
@@ -163,5 +145,42 @@ describe("storage process-exit cleanup", () => {
 		expect(stdout.trim()).toBe(
 			JSON.stringify({ prompts: ["opened after cleanup"], commands: { "after-cleanup": 1 } }),
 		);
+	});
+
+	it("re-arms exit cleanup for a store opened after a manual postmortem cleanup", async () => {
+		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-storage-rearm-"));
+		const agentDbPath = path.join(tempDir, "agent.db");
+		// A manual cleanup keeps the process alive; the store is opened afterward,
+		// then only a real exit flushes its deferred perf batch. If postmortem did
+		// not re-arm, the exit callback would never fire and the sample would be lost.
+		const script = [
+			'import { postmortem } from "@oh-my-pi/pi-utils";',
+			`import { AgentStorage } from ${JSON.stringify(AGENT_STORAGE_MODULE)};`,
+			"await postmortem.cleanup();",
+			`const agent = await AgentStorage.open(${JSON.stringify(agentDbPath)});`,
+			'void agent.recordModelPerf("openai/rearm", { outputTokens: 20, durationMs: 2000 });',
+			"process.exit(0);",
+		].join("\n");
+		const child = Bun.spawn([process.execPath, "--eval", script], {
+			cwd: REPO_ROOT,
+			stdin: "ignore",
+			stdout: "ignore",
+			stderr: "pipe",
+		});
+		const [exitCode, stderr] = await Promise.all([child.exited, new Response(child.stderr).text()]);
+		expect(exitCode, stderr).toBe(0);
+
+		const agentDb = new Database(agentDbPath, { readonly: true });
+		try {
+			expect(
+				agentDb
+					.query<{ samples: number; output_tokens: number; gen_ms: number }, []>(
+						"SELECT samples, output_tokens, gen_ms FROM model_perf WHERE model_key = 'openai/rearm'",
+					)
+					.get(),
+			).toEqual({ samples: 1, output_tokens: 20, gen_ms: 2000 });
+		} finally {
+			agentDb.close();
+		}
 	});
 });

--- a/packages/coding-agent/test/tools/fetch-jina-stall.test.ts
+++ b/packages/coding-agent/test/tools/fetch-jina-stall.test.ts
@@ -156,7 +156,7 @@ describe("renderHtmlToText: Jina response validation", () => {
 			expect(result.method).toBe("jina");
 			expect(requestHeaders?.get("authorization")).toBe("Bearer stored-jina-key");
 		} finally {
-			AgentStorage.resetInstance();
+			AgentStorage.close();
 			await tempDir.remove().catch(() => {});
 			if (originalApiKey === undefined) delete process.env.JINA_API_KEY;
 			else process.env.JINA_API_KEY = originalApiKey;

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Added `checkpointWal` to checkpoint committed SQLite WAL frames without blocking concurrent readers.
+- Added an `exitOnly` option to `postmortem.register` for resources that must survive a keep-alive `cleanup()` and release only on a real exit.
 
 ### Fixed
 

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Added `checkpointWal` to checkpoint committed SQLite WAL frames without blocking concurrent readers.
 
+### Fixed
+
+- Re-armed `postmortem` after a manual `cleanup()` that keeps the process alive, so resources opened afterwards are still cleaned at the eventual real exit instead of being silently orphaned.
+
 ## [18.0.9] - 2026-08-28
 
 ### Fixed

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Ran synchronous postmortem callbacks during process exit so resource cleanup completes before Bun terminates.
+
 ## [18.0.9] - 2026-08-28
 
 ### Fixed

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## [Unreleased]
 
-### Fixed
+### Added
 
-- Ran synchronous postmortem callbacks during process exit so resource cleanup completes before Bun terminates.
+- Added `checkpointWal` to checkpoint committed SQLite WAL frames without blocking concurrent readers.
 
 ## [18.0.9] - 2026-08-28
 

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Fixed
 
-- Re-armed `postmortem` after a manual `cleanup()` that keeps the process alive, so resources opened afterwards are still cleaned at the eventual real exit instead of being silently orphaned.
+- Made `postmortem` registrations repeatable across manual keep-alive cleanup passes, so persistent resource owners and callbacks registered mid-pass remain armed for the eventual real exit.
 
 ## [18.0.9] - 2026-08-28
 

--- a/packages/utils/src/async.ts
+++ b/packages/utils/src/async.ts
@@ -59,6 +59,7 @@ export function withTimeout<T>(promise: Promise<T>, ms: number, message: string,
 export class AsyncDrain<T> {
 	#queue?: T[];
 	#promise = Promise.resolve();
+	#flush?: () => void;
 
 	constructor(readonly delayMs: number = 0) {}
 
@@ -66,26 +67,39 @@ export class AsyncDrain<T> {
 	push(value: T, hnd: (values: T[]) => Promise<void> | void): Promise<void> {
 		let queue = this.#queue;
 		if (!queue) {
-			this.#queue = queue = [];
+			const batch: T[] = [];
+			this.#queue = batch;
+			queue = batch;
 			const { promise, resolve, reject } = Promise.withResolvers<void>();
 			const exec = (): void => {
+				if (this.#queue !== batch) return;
+				this.#queue = undefined;
+				this.#flush = undefined;
 				try {
-					if (this.#queue === queue) {
-						this.#queue = undefined;
-					}
-					resolve(hnd(queue!));
+					resolve(hnd(batch));
 				} catch (error) {
 					reject(error);
 				}
 			};
 			if (this.delayMs > 0) {
-				setTimeout(exec, this.delayMs);
+				const timer = setTimeout(exec, this.delayMs);
+				this.#flush = () => {
+					clearTimeout(timer);
+					exec();
+				};
 			} else {
+				this.#flush = exec;
 				queueMicrotask(exec);
 			}
 			this.#promise = promise;
 		}
 		queue.push(value);
+		return this.#promise;
+	}
+
+	/** Runs the pending batch handler immediately and returns its completion promise. */
+	flush(): Promise<void> {
+		this.#flush?.();
 		return this.#promise;
 	}
 }

--- a/packages/utils/src/postmortem.ts
+++ b/packages/utils/src/postmortem.ts
@@ -80,11 +80,18 @@ const fatalRecoveryHintProviders = new Set<FatalRecoveryHintProvider>();
 
 /**
  * Internal: runs all registered cleanup callbacks for the given reason.
- * Ensures each callback is invoked at most once. Handles errors and prevents reentrancy.
+ * Ensures each armed callback is invoked at most once per pass. Handles errors
+ * and prevents reentrancy.
+ *
+ * `keepAlive` marks a manual cleanup that keeps the process running (see
+ * {@link cleanup}). Such a pass re-arms the system afterwards — the stage
+ * returns to `idle` so resources opened later are still cleaned at the real
+ * exit, and callbacks that already ran stay latched (`done`) so they never run
+ * twice. An exit-driven pass instead settles to `complete` and stays there.
  *
  * Returns a Promise that settles after all cleanups complete or error out.
  */
-function runCleanup(reason: Reason): Promise<void> {
+function runCleanup(reason: Reason, keepAlive = false): Promise<void> {
 	switch (cleanupStage) {
 		case "idle":
 			cleanupStage = "running";
@@ -94,6 +101,10 @@ function runCleanup(reason: Reason): Promise<void> {
 		case "complete":
 			return Promise.resolve();
 	}
+
+	const settle = (): void => {
+		cleanupStage = keepAlive ? "idle" : "complete";
+	};
 
 	// Call .cleanup() for each callback that is still "armed".
 	// Use Promise.try to handle sync/async, but only those armed.
@@ -108,16 +119,19 @@ function runCleanup(reason: Reason): Promise<void> {
 				logger.error("Cleanup callback failed", { err, stack: err.stack });
 			}
 		}
-		cleanupStage = "complete";
+		settle();
 	});
 	const deadline = Promise.withResolvers<void>();
 	const deadlineTimer = setTimeout(() => {
 		logger.error("Cleanup deadline exceeded; proceeding with exit", { reason });
-		cleanupStage = "complete";
+		settle();
 		deadline.resolve();
 	}, CLEANUP_DEADLINE_MS);
 	cleanupPromise = Promise.race([cleanupSettled, deadline.promise]).finally(() => {
 		clearTimeout(deadlineTimer);
+		// A re-armed pass must drop its settled promise so the next real exit
+		// starts a fresh cleanup instead of returning this resolved one.
+		if (keepAlive) cleanupPromise = undefined;
 	});
 	return cleanupPromise;
 }
@@ -510,11 +524,12 @@ export function register(id: string, callback: (reason: Reason) => void | Promis
 }
 
 /**
- * Runs all cleanup callbacks without exiting.
+ * Runs all cleanup callbacks without exiting, then re-arms the system so
+ * resources opened afterwards are still cleaned at the eventual real exit.
  * Use this in workers or when you need to clean up but continue execution.
  */
 export function cleanup(): Promise<void> {
-	return runCleanup(Reason.MANUAL);
+	return runCleanup(Reason.MANUAL, true);
 }
 
 /** Controls how manual process shutdown handles terminal output. */

--- a/packages/utils/src/postmortem.ts
+++ b/packages/utils/src/postmortem.ts
@@ -95,14 +95,10 @@ function runCleanup(reason: Reason): Promise<void> {
 			return Promise.resolve();
 	}
 
-	// Invoke callbacks before wrapping their results: Bun defers Promise.try's
-	// callback, but the process "exit" event only permits synchronous cleanup.
+	// Call .cleanup() for each callback that is still "armed".
+	// Use Promise.try to handle sync/async, but only those armed.
 	const promises = callbackList.toReversed().map(callback => {
-		try {
-			return Promise.resolve(callback(reason));
-		} catch (error) {
-			return Promise.reject(error);
-		}
+		return Promise.try(() => callback(reason));
 	});
 
 	const cleanupSettled = Promise.allSettled(promises).then(results => {

--- a/packages/utils/src/postmortem.ts
+++ b/packages/utils/src/postmortem.ts
@@ -24,10 +24,22 @@ export enum Reason {
 	MANUAL = "manual", // Manual cleanup (not triggered by process)
 }
 
-// Internal list of active cleanup callbacks (in registration order)
-const callbackList: ((reason: Reason, keepAlive: boolean) => Promise<void> | void)[] = [];
-// Tracks cleanup run state (to prevent recursion/reentry issues)
+interface CleanupRegistration {
+	id: string;
+	callback: (reason: Reason) => Promise<void> | void;
+	exitOnly: boolean;
+	cancelled: boolean;
+	lastPass: number;
+}
+
+// Active cleanup callbacks in registration order. Registrations survive
+// keep-alive passes; `lastPass` enforces at-most-once invocation per pass.
+const callbackList: CleanupRegistration[] = [];
+// Tracks cleanup run state (to prevent recursion/reentry issues).
 let cleanupStage: "idle" | "running" | "complete" = "idle";
+let cleanupPass = 0;
+let activeCleanupReason: Reason | undefined;
+let activeCleanupKeepAlive = false;
 const CLEANUP_DEADLINE_MS = 10_000;
 /**
  * Symbol stamped by the extension-load guard onto the throwing replacement it
@@ -78,16 +90,28 @@ export interface FatalRecoveryHint {
 type FatalRecoveryHintProvider = () => FatalRecoveryHint | undefined;
 const fatalRecoveryHintProviders = new Set<FatalRecoveryHintProvider>();
 
+function invokeCleanup(
+	registration: CleanupRegistration,
+	reason: Reason,
+	keepAlive: boolean,
+	pass: number,
+): Promise<void> | void {
+	if (registration.cancelled || registration.lastPass === pass) return;
+	if (registration.exitOnly && keepAlive) return;
+	registration.lastPass = pass;
+	return registration.callback(reason);
+}
+
 /**
  * Internal: runs all registered cleanup callbacks for the given reason.
- * Ensures each armed callback is invoked at most once per pass. Handles errors
+ * Ensures each registration is invoked at most once per pass, handles errors,
  * and prevents reentrancy.
  *
  * `keepAlive` marks a manual cleanup that keeps the process running (see
- * {@link cleanup}). Such a pass re-arms the system afterwards — the stage
- * returns to `idle` so resources opened later are still cleaned at the real
- * exit, and callbacks that already ran stay latched (`done`) so they never run
- * twice. An exit-driven pass instead settles to `complete` and stays there.
+ * {@link cleanup}). Such a pass returns the stage to `idle`; registrations stay
+ * active for later resources and the eventual real exit. Exit-only callbacks
+ * skip keep-alive passes without consuming their registration. An exit-driven
+ * pass instead settles to `complete` and stays there.
  *
  * Returns a Promise that settles after all cleanups complete or error out.
  */
@@ -102,14 +126,22 @@ function runCleanup(reason: Reason, keepAlive = false): Promise<void> {
 			return Promise.resolve();
 	}
 
+	const pass = ++cleanupPass;
+	activeCleanupReason = reason;
+	activeCleanupKeepAlive = keepAlive;
 	const settle = (): void => {
+		if (cleanupPass !== pass) return;
 		cleanupStage = keepAlive ? "idle" : "complete";
+		if (keepAlive) {
+			activeCleanupReason = undefined;
+			activeCleanupKeepAlive = false;
+		}
 	};
 
-	// Call .cleanup() for each callback that is still "armed".
-	// Use Promise.try to handle sync/async, but only those armed.
-	const promises = callbackList.toReversed().map(callback => {
-		return Promise.try(() => callback(reason, keepAlive));
+	// Snapshot the pass. Registrations added while a keep-alive cleanup runs are
+	// invoked by register() when appropriate and remain active for later passes.
+	const promises = callbackList.toReversed().map(registration => {
+		return Promise.try(() => invokeCleanup(registration, reason, keepAlive, pass));
 	});
 
 	const cleanupSettled = Promise.allSettled(promises).then(results => {
@@ -127,12 +159,13 @@ function runCleanup(reason: Reason, keepAlive = false): Promise<void> {
 		settle();
 		deadline.resolve();
 	}, CLEANUP_DEADLINE_MS);
-	cleanupPromise = Promise.race([cleanupSettled, deadline.promise]).finally(() => {
+	const passPromise = Promise.race([cleanupSettled, deadline.promise]).finally(() => {
 		clearTimeout(deadlineTimer);
-		// A re-armed pass must drop its settled promise so the next real exit
-		// starts a fresh cleanup instead of returning this resolved one.
-		if (keepAlive) cleanupPromise = undefined;
+		// A re-armed pass must drop only its own settled promise; an older
+		// deadline-limited pass may finish after a newer one has already started.
+		if (keepAlive && cleanupPass === pass && cleanupPromise === passPromise) cleanupPromise = undefined;
 	});
+	cleanupPromise = passPromise;
 	return cleanupPromise;
 }
 
@@ -478,63 +511,78 @@ if (isMainThread) {
 	});
 }
 
+/** Controls when a registered cleanup callback participates in cleanup passes. */
+export interface CleanupRegistrationOptions {
+	/**
+	 * Run only on a real exit, never during a manual keep-alive cleanup.
+	 * The registration remains armed when a keep-alive pass skips it.
+	 */
+	exitOnly?: boolean;
+}
+
 /**
- * Register a process cleanup callback, to be run on shutdown, signal, or fatal error.
+ * Registers a cleanup callback for shutdown, signals, fatal errors, and
+ * repeatable manual cleanup passes.
  *
- * `exitOnly` marks a callback that must run only on a real exit, never on a
- * manual keep-alive {@link cleanup}: such a pass skips it without latching, so
- * it stays armed for the eventual exit. Use it for resources the continuation
- * still holds after a keep-alive cleanup (open databases, cached handles) —
- * tearing them down mid-process would orphan their references.
+ * Registrations persist across keep-alive {@link cleanup} passes and run at
+ * most once per pass. Set `exitOnly` for resources the continuing process still
+ * holds (open databases, cached handles): keep-alive passes skip the callback
+ * without consuming its registration, while the eventual real exit runs it.
  *
- * Returns a function that cancels (unregisters) the callback.
- * If register is called after cleanup already began, a normal callback runs
- * once immediately; an `exitOnly` one only arms for the real exit.
+ * A callback registered during a running keep-alive pass joins future passes;
+ * normal callbacks also run immediately for the current pass. Registrations
+ * made during a real exit run immediately.
+ *
+ * Returns a function that permanently cancels the registration.
  */
-export function register(id: string, callback: (reason: Reason) => void | Promise<void>, exitOnly = false): () => void {
-	let done = false;
-	const exec = (reason: Reason, keepAlive: boolean) => {
-		if (done) return;
-		// Exit-only callbacks skip keep-alive passes without latching, so the
-		// real exit still runs them.
-		if (exitOnly && keepAlive) return;
-		done = true;
+export function register(
+	id: string,
+	callback: (reason: Reason) => void | Promise<void>,
+	options: CleanupRegistrationOptions = {},
+): () => void {
+	const registration: CleanupRegistration = {
+		id,
+		callback,
+		exitOnly: options.exitOnly ?? false,
+		cancelled: false,
+		lastPass: 0,
+	};
+	const cancel = (): void => {
+		registration.cancelled = true;
+		const index = callbackList.indexOf(registration);
+		if (index >= 0) callbackList.splice(index, 1);
+	};
+	const invokeLate = (reason: Reason, keepAlive: boolean): void => {
 		try {
-			return callback(reason);
-		} catch (e) {
-			const err = e instanceof Error ? e : new Error(String(e));
+			const pending = invokeCleanup(registration, reason, keepAlive, cleanupPass);
+			void pending?.catch(error => {
+				const err = error instanceof Error ? error : new Error(String(error));
+				logger.error("Cleanup callback failed", { err, id, stack: err.stack });
+			});
+		} catch (error) {
+			const err = error instanceof Error ? error : new Error(String(error));
 			logger.error("Cleanup callback failed", { err, id, stack: err.stack });
 		}
 	};
 
-	const cancel = () => {
-		const index = callbackList.indexOf(exec);
-		if (index >= 0) {
-			callbackList.splice(index, 1);
-		}
-		done = true;
-	};
-
-	if (cleanupStage !== "idle") {
-		// Cleanup is already in progress or complete. Exit-only callbacks must not
-		// fire on a keep-alive pass, so arm them for the real exit instead of
-		// running now; normal callbacks run once without re-entering the pass.
-		if (exitOnly) {
-			callbackList.push(exec);
-			return cancel;
-		}
-		logger.debug("Cleanup already started; running late callback once", { id });
-		try {
-			callback(Reason.MANUAL);
-		} catch (e) {
-			const err = e instanceof Error ? e : new Error(String(e));
-			logger.error("Cleanup callback failed", { err, id, stack: err.stack });
-		}
-		return () => {};
+	if (cleanupStage === "idle") {
+		callbackList.push(registration);
+		return cancel;
 	}
 
-	// Register callback as "armed" (active).
-	callbackList.push(exec);
+	const reason = activeCleanupReason ?? Reason.MANUAL;
+	if (cleanupStage === "running" && activeCleanupKeepAlive) {
+		// The current pass already snapshotted its callbacks. Keep the new owner
+		// registered for future passes; normal callbacks also join this pass now.
+		callbackList.push(registration);
+		if (!registration.exitOnly) invokeLate(reason, true);
+		return cancel;
+	}
+
+	// A real exit is running or complete. There is no later pass to arm for, so
+	// invoke every late registration now, including exit-only callbacks.
+	logger.debug("Cleanup already started; running late callback once", { id });
+	invokeLate(reason, false);
 	return cancel;
 }
 

--- a/packages/utils/src/postmortem.ts
+++ b/packages/utils/src/postmortem.ts
@@ -25,7 +25,7 @@ export enum Reason {
 }
 
 // Internal list of active cleanup callbacks (in registration order)
-const callbackList: ((reason: Reason) => Promise<void> | void)[] = [];
+const callbackList: ((reason: Reason, keepAlive: boolean) => Promise<void> | void)[] = [];
 // Tracks cleanup run state (to prevent recursion/reentry issues)
 let cleanupStage: "idle" | "running" | "complete" = "idle";
 const CLEANUP_DEADLINE_MS = 10_000;
@@ -109,7 +109,7 @@ function runCleanup(reason: Reason, keepAlive = false): Promise<void> {
 	// Call .cleanup() for each callback that is still "armed".
 	// Use Promise.try to handle sync/async, but only those armed.
 	const promises = callbackList.toReversed().map(callback => {
-		return Promise.try(() => callback(reason));
+		return Promise.try(() => callback(reason, keepAlive));
 	});
 
 	const cleanupSettled = Promise.allSettled(promises).then(results => {
@@ -481,13 +481,23 @@ if (isMainThread) {
 /**
  * Register a process cleanup callback, to be run on shutdown, signal, or fatal error.
  *
- * Returns a Callback instance that can be used to cancel (unregister) or manually clean up.
- * If register is called after cleanup already began, invokes callback on a microtask.
+ * `exitOnly` marks a callback that must run only on a real exit, never on a
+ * manual keep-alive {@link cleanup}: such a pass skips it without latching, so
+ * it stays armed for the eventual exit. Use it for resources the continuation
+ * still holds after a keep-alive cleanup (open databases, cached handles) —
+ * tearing them down mid-process would orphan their references.
+ *
+ * Returns a function that cancels (unregisters) the callback.
+ * If register is called after cleanup already began, a normal callback runs
+ * once immediately; an `exitOnly` one only arms for the real exit.
  */
-export function register(id: string, callback: (reason: Reason) => void | Promise<void>): () => void {
+export function register(id: string, callback: (reason: Reason) => void | Promise<void>, exitOnly = false): () => void {
 	let done = false;
-	const exec = (reason: Reason) => {
+	const exec = (reason: Reason, keepAlive: boolean) => {
 		if (done) return;
+		// Exit-only callbacks skip keep-alive passes without latching, so the
+		// real exit still runs them.
+		if (exitOnly && keepAlive) return;
 		done = true;
 		try {
 			return callback(reason);
@@ -506,8 +516,13 @@ export function register(id: string, callback: (reason: Reason) => void | Promis
 	};
 
 	if (cleanupStage !== "idle") {
-		// Cleanup is already in progress or complete; run late registrations once
-		// without re-entering the global cleanup pass.
+		// Cleanup is already in progress or complete. Exit-only callbacks must not
+		// fire on a keep-alive pass, so arm them for the real exit instead of
+		// running now; normal callbacks run once without re-entering the pass.
+		if (exitOnly) {
+			callbackList.push(exec);
+			return cancel;
+		}
 		logger.debug("Cleanup already started; running late callback once", { id });
 		try {
 			callback(Reason.MANUAL);

--- a/packages/utils/src/postmortem.ts
+++ b/packages/utils/src/postmortem.ts
@@ -95,10 +95,14 @@ function runCleanup(reason: Reason): Promise<void> {
 			return Promise.resolve();
 	}
 
-	// Call .cleanup() for each callback that is still "armed".
-	// Use Promise.try to handle sync/async, but only those armed.
+	// Invoke callbacks before wrapping their results: Bun defers Promise.try's
+	// callback, but the process "exit" event only permits synchronous cleanup.
 	const promises = callbackList.toReversed().map(callback => {
-		return Promise.try(() => callback(reason));
+		try {
+			return Promise.resolve(callback(reason));
+		} catch (error) {
+			return Promise.reject(error);
+		}
 	});
 
 	const cleanupSettled = Promise.allSettled(promises).then(results => {

--- a/packages/utils/src/sqlite.ts
+++ b/packages/utils/src/sqlite.ts
@@ -7,6 +7,12 @@
  * one implementation here prevents the classifiers from drifting between the
  * credential store and the model cache.
  */
+import type { Database } from "bun:sqlite";
+
+/** Checkpoints committed WAL frames without waiting for concurrent readers. */
+export function checkpointWal(db: Database): void {
+	db.run("PRAGMA wal_checkpoint(PASSIVE)");
+}
 
 /**
  * SQLite's busy result-code family — base `SQLITE_BUSY` plus the extended

--- a/packages/utils/test/postmortem-cleanup-error.test.ts
+++ b/packages/utils/test/postmortem-cleanup-error.test.ts
@@ -267,4 +267,22 @@ describe("postmortem expected cleanup errors", () => {
 		expect(result.exitCode).toBe(0);
 		expect(result.stdout).toContain('["registered","cleanup"]');
 	});
+
+	it("skips exit-only callbacks on keep-alive cleanup but runs them on the real exit", async () => {
+		const result = await runPostmortemProbe(`
+			import { postmortem } from "${postmortemModuleUrl}";
+
+			const order = [];
+			// Exit-only: a keep-alive cleanup must skip it without latching, so the
+			// registration survives for the eventual real exit.
+			postmortem.register("exit-only", () => { order.push("cleanup"); }, true);
+			await postmortem.cleanup();
+			order.push("after-keepalive");
+			process.on("exit", () => { console.log(JSON.stringify(order)); });
+			process.exit(0);
+		`);
+
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout).toContain('["after-keepalive","cleanup"]');
+	});
 });

--- a/packages/utils/test/postmortem-cleanup-error.test.ts
+++ b/packages/utils/test/postmortem-cleanup-error.test.ts
@@ -268,6 +268,24 @@ describe("postmortem expected cleanup errors", () => {
 		expect(result.stdout).toContain('["registered","cleanup"]');
 	});
 
+	it("runs a persistent owner again at real exit after a keep-alive cleanup", async () => {
+		const result = await runPostmortemProbe(`
+			import { postmortem } from "${postmortemModuleUrl}";
+
+			const order = [];
+			postmortem.register("persistent", () => { order.push("cleanup"); });
+			await postmortem.cleanup();
+			// The owner remains registered while its subsystem creates resources
+			// again; the real exit must run the same registration a second time.
+			order.push("reused");
+			process.on("exit", () => { console.log(JSON.stringify(order)); });
+			process.exit(0);
+		`);
+
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout).toContain('["cleanup","reused","cleanup"]');
+	});
+
 	it("skips exit-only callbacks on keep-alive cleanup but runs them on the real exit", async () => {
 		const result = await runPostmortemProbe(`
 			import { postmortem } from "${postmortemModuleUrl}";
@@ -275,7 +293,7 @@ describe("postmortem expected cleanup errors", () => {
 			const order = [];
 			// Exit-only: a keep-alive cleanup must skip it without latching, so the
 			// registration survives for the eventual real exit.
-			postmortem.register("exit-only", () => { order.push("cleanup"); }, true);
+			postmortem.register("exit-only", () => { order.push("cleanup"); }, { exitOnly: true });
 			await postmortem.cleanup();
 			order.push("after-keepalive");
 			process.on("exit", () => { console.log(JSON.stringify(order)); });

--- a/packages/utils/test/postmortem-cleanup-error.test.ts
+++ b/packages/utils/test/postmortem-cleanup-error.test.ts
@@ -249,4 +249,22 @@ describe("postmortem expected cleanup errors", () => {
 		expect(result.stdout).toContain("cleanup deadline released");
 		expect(result.stderr).not.toContain("cleanup stayed pending after the deadline");
 	});
+
+	it("re-arms registrations after a manual cleanup keeps the process alive", async () => {
+		const result = await runPostmortemProbe(`
+			import { postmortem } from "${postmortemModuleUrl}";
+
+			const order = [];
+			await postmortem.cleanup();
+			// Registered after a completed manual cleanup: must arm for the next pass,
+			// not run immediately as a one-shot late callback.
+			postmortem.register("late", () => { order.push("cleanup"); });
+			order.push("registered");
+			await postmortem.cleanup();
+			console.log(JSON.stringify(order));
+		`);
+
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout).toContain('["registered","cleanup"]');
+	});
 });


### PR DESCRIPTION
## Repro
A Bun child process opens `HistoryStorage`, queues a prompt, and immediately calls `process.exit(0)` via `bun /tmp/issue-10079-repro.ts`; before the fix, a second process reads `rows: []` and finds the committed schema in `history.db-wal` rather than the main database file.

## Cause
`AsyncDrain` had no immediate flush operation, while `HistoryStorage.resetInstance()` and `AgentStorage.resetInstance()` were test-only call paths. Neither singleton registered production cleanup, and `postmortem.runCleanup()` wrapped callbacks in Bun's deferred `Promise.try`, so even synchronous callbacks could not execute inside the process `exit` event. `Database.close()` alone also does not checkpoint Bun SQLite WAL frames.

## Fix
- Add `AsyncDrain.flush()` and close APIs that synchronously drain queued history/model-performance batches before finalizing statements.
- Register both storage singletons with postmortem and checkpoint committed WAL frames with a non-blocking passive checkpoint before closing.
- Invoke postmortem callbacks synchronously before wrapping their results so hard `process.exit` paths can complete synchronous cleanup.
- Add a subprocess regression test that hard-exits inside both 100 ms batch windows, then reads copies of the main database files without their WALs.

## Verification
`bun test packages/utils/test/postmortem-cleanup-error.test.ts packages/coding-agent/test/history-storage-drain.test.ts packages/coding-agent/test/history-storage-search.test.ts packages/coding-agent/test/history-storage-session.test.ts packages/coding-agent/test/history-storage-sqlite-compat.test.ts packages/coding-agent/test/agent-storage-model-perf.test.ts packages/coding-agent/test/agent-storage-sqlite-compat.test.ts` passed: 51 tests, 0 failures. `bun check` passed. Re-running `bun /tmp/issue-10079-repro.ts` now returns the queued prompt after immediate exit; the regression test additionally proves both main database copies contain their deferred rows without either WAL.

Fixes #10079