### PR TITLE
fix(catalog): mirror Workers AI models into Cloudflare gateway

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Cloudflare AI Gateway shared-catalog refresh to include active Workers AI chat models, including newly released models not present in the bundled snapshot.
+
 ## [18.0.9] - 2026-08-28
 
 ### Added

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -36,6 +36,7 @@ import type {
 } from "../types";
 import { discoveryFetch, isAnthropicOAuthToken, isRecord, toBoolean, toNumber, toPositiveNumber } from "../utils";
 import { ALIBABA_TOKEN_PLAN_BASE_URL, parseAlibabaTokenPlanCredential } from "../wire/alibaba-token-plan";
+import { CLOUDFLARE_AI_GATEWAY_COMPAT_BASE_URL } from "../wire/cloudflare-ai-gateway";
 import { coreWeaveProjectHeaders } from "../wire/coreweave";
 import {
 	COPILOT_API_HEADERS,
@@ -6757,6 +6758,15 @@ const MODELS_DEV_PROVIDER_DESCRIPTORS_SPECIALIZED: readonly ModelsDevProviderDes
 		"cloudflare-ai-gateway",
 		"cloudflare-ai-gateway",
 		"https://gateway.ai.cloudflare.com/v1/<account>/<gateway>/anthropic",
+	),
+	openAiCompletionsDescriptor(
+		"cloudflare-workers-ai",
+		"cloudflare-ai-gateway",
+		CLOUDFLARE_AI_GATEWAY_COMPAT_BASE_URL,
+		{
+			filterModel: filterActiveToolCallModels,
+			transformModel: model => ({ ...model, id: `workers-ai/${model.id}` }),
+		},
 	),
 	// --- Mistral ---
 	openAiCompletionsDescriptor("mistral", "mistral", "https://api.mistral.ai/v1"),

--- a/packages/catalog/test/cloudflare-ai-gateway-provider.test.ts
+++ b/packages/catalog/test/cloudflare-ai-gateway-provider.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+import { modelsDevCatalogFallback } from "@oh-my-pi/pi-catalog/provider-models";
+import { CLOUDFLARE_AI_GATEWAY_COMPAT_BASE_URL } from "@oh-my-pi/pi-catalog/wire/cloudflare-ai-gateway";
+
+describe("Cloudflare AI Gateway shared catalog", () => {
+	test("mirrors active Workers AI chat models into the gateway provider", () => {
+		const fallback = modelsDevCatalogFallback("cloudflare-ai-gateway");
+		if (!fallback) throw new Error("Cloudflare AI Gateway did not configure a shared catalog fallback");
+
+		const models = fallback.map(
+			{
+				"cloudflare-workers-ai": {
+					models: {
+						"@cf/zai-org/glm-5.3-flash": {
+							name: "GLM 5.3 Flash",
+							tool_call: true,
+							reasoning: true,
+							modalities: { input: ["text", "image"] },
+						},
+						"@cf/example/deprecated": {
+							name: "Deprecated",
+							tool_call: true,
+							status: "deprecated",
+						},
+						"@cf/example/no-tools": {
+							name: "No tools",
+							tool_call: false,
+						},
+					},
+				},
+			},
+			"cloudflare-ai-gateway",
+		);
+
+		expect(models).toHaveLength(1);
+		expect(models[0]).toMatchObject({
+			provider: "cloudflare-ai-gateway",
+			id: "workers-ai/@cf/zai-org/glm-5.3-flash",
+			api: "openai-completions",
+			baseUrl: CLOUDFLARE_AI_GATEWAY_COMPAT_BASE_URL,
+			reasoning: true,
+			input: ["text", "image"],
+		});
+	});
+});


### PR DESCRIPTION
## What

I noticed that GLM-5.3 Flash was available in Cloudflare Workers AI but missing from OMP's `cloudflare-ai-gateway` catalog, even after a forced model refresh.

This PR adds the missing shared-catalog mapping from `cloudflare-workers-ai` into the existing `cloudflare-ai-gateway` provider. Active Workers AI models with tool support are exposed as `workers-ai/<model-id>` and routed through the gateway's `/compat` endpoint.

The change does not regenerate `models.json`. Runtime shared-catalog refresh can add newly released Workers AI models without waiting for another bundled catalog update.

## Why

OMP currently reads only the `cloudflare-ai-gateway` bucket when refreshing that provider. The shared catalog now publishes Workers AI models under a separate `cloudflare-workers-ai` bucket.

Older Workers AI models remain visible because they were already present in OMP's bundled snapshot. New entries have no bundled row to retain, so the current mapper never sees them. The shared catalog already contains:

```text
cloudflare-workers-ai/@cf/zai-org/glm-5.3-flash
```

The new descriptor maps it to:

```text
cloudflare-ai-gateway/workers-ai/@cf/zai-org/glm-5.3-flash
```

This maps the source bucket rather than hardcoding GLM-5.3 Flash, so future active Workers AI chat models follow the same refresh path.

## Testing

- Added a regression test against `modelsDevCatalogFallback("cloudflare-ai-gateway")`. It failed with zero mapped models before the descriptor was added and now verifies the provider, model ID, API, route, reasoning, vision, deprecated filtering, and tool-support filtering.
- `bun test packages/catalog/test/cloudflare-ai-gateway-provider.test.ts packages/catalog/test/opencode-provider.test.ts`: 18 passed, 0 failed.
- `bun --cwd=packages/catalog run check`: passed.
- `bun run check:ts`: passed across all TypeScript workspaces.
- A local `models refresh` exposed `cloudflare-ai-gateway/workers-ai/@cf/zai-org/glm-5.3-flash`.
- A live request through the refreshed selector returned `GLM53_GATEWAY_OK`.

---

- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
