### PR TITLE
feat(coding-agent): add session-local primary provider pin

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Classified local DNS and network reachability failures separately so retry recovery can keep the current route instead of entering model fallback.
+
 ## [18.0.9] - 2026-08-28
 
 ### Fixed

--- a/packages/ai/src/error/flags.ts
+++ b/packages/ai/src/error/flags.ts
@@ -154,6 +154,8 @@ function matchesPayloadRejectionText(text: string): boolean {
 const TIMEOUT_PATTERN = /\b(?:operation\s+)?timed?\s*out\b|\btimeout\b|\bstream stall\b/i;
 const TRANSIENT_ENVELOPE_PATTERN = /anthropic stream envelope error:/i;
 const TRANSIENT_ENVELOPE_BEFORE_START_PATTERN = /before message_start/i;
+const NETWORK_UNAVAILABLE_PATTERN =
+	/\b(?:ENETUNREACH|EHOSTUNREACH|EAI_AGAIN|ENOTFOUND|network is unreachable|getaddrinfo|temporary failure in name resolution)\b|\bfetch failed\b|unable.?to.?connect\.\s*is the computer able to access the url\?/i;
 export const STREAM_READ_ERROR_PATTERN = /stream[_ -]?read[_ -]?error/i;
 export const TRANSIENT_TRANSPORT_PATTERN =
 	/\b(?:no[_ -]?capacity|(?:high|peak)[ _-]?demand|(?:at|over|insufficient)[ _-]?capacity|capacity[ _-]?(?:exceeded|exhausted)|peak[ _-]?load)\b|overloaded|provider.?returned.?error|rate.?limit|too many requests|\b(?:429|500|502|503|504)\b|service.?unavailable|server.?error|internal.?error|retry your request|network.?error|connection.?error|connection.?refused|unable.?to.?connect\.\s*is the computer able to access the url\?|other side closed|fetch failed|upstream.?connect|upstream.?request.?failed|reset before headers|socket hang up|timed? out|timeout|terminated|retry delay|stream stall|no error details in response|HTTP2(?:StreamReset|RefusedStream|EnhanceYourCalm)|nghttp2_(?:internal_error|refused_stream)|stream closed with error code nghttp2_(?:internal_error|refused_stream)|malformed.?function.?call/i;
@@ -390,6 +392,11 @@ function statusInternal(error: unknown, depth: number): number | undefined {
 
 export function isStreamReadErrorText(text: string): boolean {
 	return STREAM_READ_ERROR_PATTERN.test(text);
+}
+
+/** Whether persisted provider text points to local DNS/network reachability, not provider capacity. */
+export function isNetworkUnavailableText(text: string): boolean {
+	return NETWORK_UNAVAILABLE_PATTERN.test(text);
 }
 
 /** Persisted-text form of {@link isStreamEnvelopeError}: recognizes the

--- a/packages/ai/test/error-id.test.ts
+++ b/packages/ai/test/error-id.test.ts
@@ -50,6 +50,13 @@ describe("error-id classification", () => {
 		const id = AIError.classifyMessage(assistant);
 		expect(AIError.is(id, AIError.Flag.Transient)).toBe(true);
 		expect(AIError.retriable(id)).toBe(true);
+		expect(AIError.isNetworkUnavailableText(assistant.errorMessage ?? "")).toBe(true);
+	});
+
+	it("does not mistake a provider service restart for local network loss", () => {
+		expect(
+			AIError.isNetworkUnavailableText("received 1012 (service restart); then sent 1012 (service restart)"),
+		).toBe(false);
 	});
 
 	it("keeps authenticated connection rejections non-retryable", () => {

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added a session-local primary-provider pin (`Alt+Shift+R`) that persists in session JSONL, keeps retrying the original primary instead of entering model fallback, restores primary from active, sticky, and usage-aware fallback state, and advertises support through `omp config capabilities --json`.
+
 ### Fixed
 
 - Fixed `import numpy` (and other native-extension imports) hanging indefinitely in the Python eval tool on Windows, where the runner's always-on background stdin reader deadlocked native DLL loading; Windows now reads the control channel serially between requests while POSIX keeps concurrent request dispatch ([#7985](https://github.com/can1357/oh-my-pi/issues/7985)).

--- a/packages/coding-agent/src/cli/config-cli.ts
+++ b/packages/coding-agent/src/cli/config-cli.ts
@@ -27,7 +27,7 @@ import { initXdg } from "./commands/init-xdg";
 // Types
 // =============================================================================
 
-export type ConfigAction = "list" | "get" | "set" | "reset" | "path" | "init-xdg";
+export type ConfigAction = "list" | "get" | "set" | "reset" | "path" | "init-xdg" | "capabilities";
 
 export interface ConfigCommandArgs {
 	action: ConfigAction;
@@ -78,7 +78,7 @@ function getSettingValues(def: CliSettingDef): readonly string[] | undefined {
 // Argument Parser
 // =============================================================================
 
-const VALID_ACTIONS: ConfigAction[] = ["list", "get", "set", "reset", "path", "init-xdg"];
+const VALID_ACTIONS: ConfigAction[] = ["list", "get", "set", "reset", "path", "init-xdg", "capabilities"];
 
 /**
  * Parse config subcommand arguments.
@@ -241,6 +241,14 @@ function parseAndSetValue(path: SettingPath, rawValue: string): void {
 // =============================================================================
 
 export async function runConfigCommand(cmd: ConfigCommandArgs): Promise<void> {
+	// Capability negotiation must stay usable even when user configuration is
+	// missing or invalid: external hosts use this before enabling runtime-only
+	// controls, and older builds reject this action quickly as unsupported.
+	if (cmd.action === "capabilities") {
+		await handleCapabilities(cmd.flags);
+		return;
+	}
+
 	await Settings.init();
 
 	switch (cmd.action) {
@@ -275,6 +283,21 @@ async function writeStdout(text: string): Promise<void> {
 		pending.resolve();
 	});
 	await pending.promise;
+}
+const RUNTIME_CAPABILITIES = {
+	primaryProviderPin: true,
+} as const;
+
+async function handleCapabilities(flags: { json?: boolean }): Promise<void> {
+	if (flags.json) {
+		await writeStdout(`${JSON.stringify(RUNTIME_CAPABILITIES, null, 2)}\n`);
+		return;
+	}
+
+	console.log(chalk.bold("Runtime capabilities:\n"));
+	for (const [name, enabled] of Object.entries(RUNTIME_CAPABILITIES)) {
+		console.log(`  ${chalk.white(name)} = ${formatValue(enabled)}`);
+	}
 }
 
 async function handleList(flags: { json?: boolean }): Promise<void> {
@@ -439,6 +462,7 @@ ${chalk.bold("Commands:")}
   reset <key>        Reset a setting to its default value
   path               Print the config directory path
   init-xdg           Initialize XDG Base Directory structure
+  capabilities       Print machine-detectable runtime capabilities
 
 ${chalk.bold("Options:")}
   --json             Output as JSON
@@ -451,6 +475,7 @@ ${chalk.bold("Examples:")}
   ${APP_NAME} config set defaultThinkingLevel medium
   ${APP_NAME} config reset steeringMode
   ${APP_NAME} config list --json
+  ${APP_NAME} config capabilities --json
   ${APP_NAME} config init-xdg
 
 ${chalk.bold("Boolean Values:")}

--- a/packages/coding-agent/src/commands/config.ts
+++ b/packages/coding-agent/src/commands/config.ts
@@ -7,7 +7,7 @@ import { configHelp as commandHelp } from "../cli/command-help";
 import { type ConfigAction, type ConfigCommandArgs, runConfigCommand } from "../cli/config-cli";
 import { initTheme } from "../modes/theme/theme";
 
-const ACTIONS: ConfigAction[] = ["list", "get", "set", "reset", "path", "init-xdg"];
+const ACTIONS: ConfigAction[] = ["list", "get", "set", "reset", "path", "init-xdg", "capabilities"];
 
 export default class Config extends Command {
 	static description = commandHelp.description;

--- a/packages/coding-agent/src/config/keybindings.ts
+++ b/packages/coding-agent/src/config/keybindings.ts
@@ -29,6 +29,7 @@ interface AppKeybindings {
 	"app.model.cycleBackward": true;
 	"app.model.select": true;
 	"app.model.selectTemporary": true;
+	"app.provider.pinPrimary": true;
 	"app.tools.expand": true;
 	"app.tools.toggleVisibility": true;
 	"app.editor.external": true;
@@ -121,6 +122,10 @@ export const KEYBINDINGS = {
 	"app.model.selectTemporary": {
 		defaultKeys: "alt+p",
 		description: "Select temporary model for current session",
+	},
+	"app.provider.pinPrimary": {
+		defaultKeys: "alt+shift+r",
+		description: "Toggle primary provider pin for this session",
 	},
 	"app.tools.expand": {
 		defaultKeys: "ctrl+o",

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -37,6 +37,7 @@ type ConfigurableEditorAction = Extract<
 	| "app.model.cycleBackward"
 	| "app.model.select"
 	| "app.model.selectTemporary"
+	| "app.provider.pinPrimary"
 	| "app.tools.toggleVisibility"
 	| "app.thinking.toggle"
 	| "app.editor.external"
@@ -59,6 +60,7 @@ const DEFAULT_ACTION_KEYS: Record<ConfigurableEditorAction, KeyId[]> = {
 	"app.model.cycleBackward": ["shift+ctrl+p"],
 	"app.model.select": ["alt+m"],
 	"app.model.selectTemporary": ["alt+p"],
+	"app.provider.pinPrimary": ["alt+shift+r"],
 	"app.tools.toggleVisibility": ["ctrl+shift+o"],
 	"app.thinking.toggle": ["ctrl+t"],
 	"app.editor.external": ["ctrl+g"],
@@ -699,6 +701,7 @@ export class CustomEditor extends Editor {
 	onHistorySearch?: () => void;
 	onSuspend?: () => void;
 	onSelectModelTemporary?: () => void;
+	onTogglePrimaryProviderPin?: () => void;
 	/** Called when the configured copy-prompt shortcut is pressed. */
 	onCopyPrompt?: () => void;
 	/** Called when the configured image-paste shortcut is pressed. */
@@ -1015,6 +1018,12 @@ export class CustomEditor extends Editor {
 			// Intercept configured temporary model selector shortcut
 			if (this.#matchesAction(canonical, "app.model.selectTemporary") && this.onSelectModelTemporary) {
 				this.onSelectModelTemporary();
+				return;
+			}
+
+			// Intercept the session-local primary provider pin toggle.
+			if (this.#matchesAction(canonical, "app.provider.pinPrimary") && this.onTogglePrimaryProviderPin) {
+				this.onTogglePrimaryProviderPin();
 				return;
 			}
 

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -493,6 +493,8 @@ export class InputController {
 			this.ctx.keybindings.getKeys("app.model.selectTemporary"),
 		);
 		this.ctx.editor.onSelectModelTemporary = () => this.ctx.showModelSelector({ temporaryOnly: true });
+		this.ctx.editor.setActionKeys("app.provider.pinPrimary", this.ctx.keybindings.getKeys("app.provider.pinPrimary"));
+		this.ctx.editor.onTogglePrimaryProviderPin = () => this.togglePrimaryProviderPin();
 
 		// Global debug handler on TUI (works regardless of focus)
 		this.ctx.ui.onDebug = () => this.ctx.showDebugSelector();
@@ -2011,6 +2013,16 @@ export class InputController {
 			this.ctx.statusLine.invalidate();
 			this.ctx.updateEditorBorderColor();
 		}
+	}
+
+	togglePrimaryProviderPin(): void {
+		if (this.ctx.focusedAgentId) {
+			this.ctx.showStatus("Provider routing applies to the main session — press ←← to return first");
+			return;
+		}
+		const pinned = this.ctx.session.togglePrimaryProviderPin();
+		this.ctx.statusLine.invalidate();
+		this.ctx.showStatus(pinned ? "Primary provider pinned for this session" : "Primary provider fallback restored");
 	}
 
 	async cycleRoleModel(direction: "forward" | "backward" = "forward"): Promise<void> {

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -658,6 +658,7 @@ export class AgentSession {
 	#usagePreflightReadyModel: Model | undefined;
 	#detachUsageBeforeQueueDequeue: (() => void) | undefined;
 	#detachUsageBeforeModelCall: (() => void) | undefined;
+	#detachFallbackRestoreBeforeModelCall: (() => void) | undefined;
 
 	#transformContext: (messages: AgentMessage[], signal?: AbortSignal) => AgentMessage[] | Promise<AgentMessage[]>;
 	#onPayload: SimpleStreamOptions["onPayload"] | undefined;
@@ -1216,6 +1217,10 @@ export class AgentSession {
 				signal?.throwIfAborted();
 				throw new DOMException("Usage preflight cancelled", "AbortError");
 			}
+		});
+		this.#detachFallbackRestoreBeforeModelCall = this.agent.addBeforeModelCallHook(async signal => {
+			await this.#recovery.maybeRestoreRetryFallbackPrimary({ requireContextFit: true, signal });
+			signal?.throwIfAborted();
 		});
 		this.#detachUsageBeforeModelCall = this.agent.addBeforeModelCallHook(async signal => {
 			if (!this.settings.get("retry.usageAwareFallback")) return;
@@ -4173,6 +4178,8 @@ export class AgentSession {
 		this.#usagePreflightReadyForNextModelCall = false;
 		this.#detachUsageBeforeQueueDequeue?.();
 		this.#detachUsageBeforeQueueDequeue = undefined;
+		this.#detachFallbackRestoreBeforeModelCall?.();
+		this.#detachFallbackRestoreBeforeModelCall = undefined;
 		this.#detachUsageBeforeModelCall?.();
 		this.#detachUsageBeforeModelCall = undefined;
 		this.#memory.cancelLocalMemoryStartup();
@@ -4630,6 +4637,21 @@ export class AgentSession {
 	 */
 	get servingModel(): ServingModel | undefined {
 		return this.#recovery.servingModel;
+	}
+
+	/** Whether this session waits on its primary provider instead of using model fallback. */
+	get primaryProviderPinned(): boolean {
+		return this.#recovery.primaryProviderPinned;
+	}
+
+	/** Persist an explicit primary-provider pin for this session. */
+	setPrimaryProviderPinned(pinned: boolean): boolean {
+		return this.#recovery.setPrimaryProviderPinned(pinned);
+	}
+
+	/** Toggle the primary-provider pin for this session. */
+	togglePrimaryProviderPin(): boolean {
+		return this.#recovery.togglePrimaryProviderPin();
 	}
 
 	/** Install the interactive decision surface for reserve-triggered model changes. */

--- a/packages/coding-agent/src/session/turn-recovery.ts
+++ b/packages/coding-agent/src/session/turn-recovery.ts
@@ -70,6 +70,7 @@ const THINKING_LOOP_REDIRECT_TYPE = "thinking-loop-redirect";
 const UNEXPECTED_STOP_MAX_RETRIES = 3;
 const UNEXPECTED_STOP_TIMEOUT_MS = 4000;
 const EMPTY_STOP_MAX_RETRIES = 3;
+const PRIMARY_PROVIDER_PIN_CUSTOM_TYPE = "primary_provider_pin";
 const SIBLING_UNBLOCK_BUFFER_MS = 1_000;
 const NON_WHITESPACE_RE = /\S/;
 const USAGE_PREFLIGHT_BLOCKED_PREFIX = "Usage preflight blocked:";
@@ -261,6 +262,32 @@ export class TurnRecovery {
 	get retryPromise(): Promise<void> | undefined {
 		return this.#retryPromise;
 	}
+	/** Whether this session must keep retrying its primary route instead of using model fallback. */
+	get primaryProviderPinned(): boolean {
+		const branch = this.#host.sessionManager.getBranch();
+		for (let index = branch.length - 1; index >= 0; index--) {
+			const entry = branch[index];
+			if (entry.type !== "custom" || entry.customType !== PRIMARY_PROVIDER_PIN_CUSTOM_TYPE) continue;
+			const data = entry.data;
+			if (data !== null && typeof data === "object" && "pinned" in data && typeof data.pinned === "boolean") {
+				return data.pinned;
+			}
+			return false;
+		}
+		return false;
+	}
+
+	/** Persist an idempotent session-local primary-route policy change. */
+	setPrimaryProviderPinned(pinned: boolean): boolean {
+		if (this.primaryProviderPinned === pinned) return pinned;
+		this.#host.sessionManager.appendCustomEntry(PRIMARY_PROVIDER_PIN_CUSTOM_TYPE, { pinned });
+		return pinned;
+	}
+
+	/** Toggle and persist the session-local primary-route policy. */
+	togglePrimaryProviderPin(): boolean {
+		return this.setPrimaryProviderPinned(!this.primaryProviderPinned);
+	}
 
 	/** Whether the CURRENT session's model was reached by fallback routing. */
 	get #fallbackRouted(): boolean {
@@ -436,12 +463,14 @@ export class TurnRecovery {
 
 	/**
 	 * Restores the configured primary after fallback cooldown expiry.
+	 * `requireContextFit` leaves the fallback active when an in-flight agent loop
+	 * cannot safely compact before its next provider request.
 	 * @returns true when the active model was actually switched back to the
 	 * primary, so callers can re-run the pre-send context-fit check against the
 	 * reverted (possibly smaller) window before issuing the next request.
 	 */
-	maybeRestoreRetryFallbackPrimary(): Promise<boolean> {
-		return this.#maybeRestoreRetryFallbackPrimary();
+	maybeRestoreRetryFallbackPrimary(options?: { requireContextFit?: boolean; signal?: AbortSignal }): Promise<boolean> {
+		return this.#maybeRestoreRetryFallbackPrimary(options);
 	}
 
 	/** Applies model fallback policy from live usage health before a turn starts. */
@@ -1406,6 +1435,7 @@ export class TurnRecovery {
 	}
 
 	async #maybeApplyUsageAwareFallback(signal: AbortSignal, confirmer?: UsageFallbackConfirmer): Promise<boolean> {
+		if (this.primaryProviderPinned) return false;
 		if (!this.#host.settings.get("retry.usageAwareFallback")) return false;
 		const currentModel = this.#host.model();
 		if (!currentModel) return false;
@@ -1808,10 +1838,14 @@ export class TurnRecovery {
 		return true;
 	}
 
-	async #maybeRestoreRetryFallbackPrimary(): Promise<boolean> {
+	async #maybeRestoreRetryFallbackPrimary(options?: {
+		requireContextFit?: boolean;
+		signal?: AbortSignal;
+	}): Promise<boolean> {
 		if (!this.#activeRetryFallback) return false;
-		if (this.#activeRetryFallback.pinned) return false;
-		if (this.#getRetryFallbackRevertPolicy() !== "cooldown-expiry") return false;
+		const forcePrimary = this.primaryProviderPinned;
+		if (this.#activeRetryFallback.pinned && !forcePrimary) return false;
+		if (!forcePrimary && this.#getRetryFallbackRevertPolicy() !== "cooldown-expiry") return false;
 
 		const {
 			originalSelector: originalSelectorRaw,
@@ -1833,12 +1867,12 @@ export class TurnRecovery {
 		if (!currentModel) return false;
 		const currentSelector = formatRetryFallbackSelector(currentModel, this.#host.thinkingLevel());
 		if (currentSelector === originalSelector.raw) {
-			if (!this.isRetryFallbackSelectorSuppressed(originalSelector)) {
+			if (forcePrimary || !this.isRetryFallbackSelectorSuppressed(originalSelector)) {
 				this.clearActiveRetryFallback();
 			}
 			return false;
 		}
-		if (this.isRetryFallbackSelectorSuppressed(originalSelector)) return false;
+		if (!forcePrimary && this.isRetryFallbackSelectorSuppressed(originalSelector)) return false;
 
 		const resolvedPrimary = resolveModelOverride(
 			[originalSelector.raw],
@@ -1848,8 +1882,11 @@ export class TurnRecovery {
 		const primaryModel =
 			resolvedPrimary.model ?? this.#host.modelRegistry.find(originalSelector.provider, originalSelector.id);
 		if (!primaryModel) return false;
-		const apiKey = await this.#host.modelRegistry.getApiKey(primaryModel, this.#host.sessionId());
-		if (!apiKey) return false;
+		if (options?.requireContextFit && !this.#host.contextFitsModel(primaryModel)) return false;
+		const apiKey = await this.#host.modelRegistry.getApiKey(primaryModel, this.#host.sessionId(), {
+			signal: options?.signal,
+		});
+		if (!apiKey || options?.signal?.aborted) return false;
 
 		const currentThinkingLevel = this.#host.configuredThinkingLevel();
 		const thinkingToApply =
@@ -1936,10 +1973,12 @@ export class TurnRecovery {
 		},
 	): Promise<boolean> {
 		const retrySettings = this.#host.settings.getGroup("retry");
+		const primaryProviderPinned = this.primaryProviderPinned;
 		// The Fireworks Fast→base degrade is an intrinsic model-selection safety net,
 		// not a retry loop, so it runs even when the user disabled retries: it switches
-		// the model once and lets the base turn proceed.
-		if (!retrySettings.enabled && !options?.fireworksFastFallback) return false;
+		// the model once and lets the base turn proceed. A session-local primary pin
+		// explicitly keeps availability retries alive even when global retries are off.
+		if (!retrySettings.enabled && !options?.fireworksFastFallback && !primaryProviderPinned) return false;
 		const classifierRefusal = this.isClassifierRefusal(message);
 
 		const generation = this.#host.promptGeneration();
@@ -1953,19 +1992,19 @@ export class TurnRecovery {
 			this.#retryResolve = resolve;
 		}
 
-		// All attempts on the current model are spent. Don't fail yet: the
-		// fallback chain below gets one last consult. Credential rotation can
-		// consume the entire budget without the fallback branch ever running
-		// (every rotation sets switchedCredential and skips it), so without
-		// this last resort a provider-wide usage cap never fails over to the
-		// configured chain.
-		const maxRetries = this.#isBoundedThinkingStreamClose(message)
-			? Math.min(retrySettings.maxRetries, 1)
-			: retrySettings.maxRetries;
-		const retryBudgetExhausted = this.#retryAttempt > maxRetries;
-
 		const errorMessage = message.errorMessage || "Unknown error";
 		const id = this.#classifyRetryMessage(message);
+		const waitForNetworkRecovery = AIError.isNetworkUnavailableText(errorMessage);
+		const unboundedRouteWait = primaryProviderPinned || waitForNetworkRecovery;
+		// A pinned primary and a locally unavailable network are wait states, not
+		// provider failures. Keep retrying the same route until it recovers or the
+		// user aborts instead of exhausting the normal provider retry budget.
+		const maxRetries = unboundedRouteWait
+			? Number.MAX_SAFE_INTEGER
+			: this.#isBoundedThinkingStreamClose(message)
+				? Math.min(retrySettings.maxRetries, 1)
+				: retrySettings.maxRetries;
+		const retryBudgetExhausted = !unboundedRouteWait && this.#retryAttempt > maxRetries;
 		const preserveFailedTurn =
 			options?.preserveFailedTurn === true ||
 			((classifierRefusal || AIError.is(id, AIError.Flag.MalformedFunctionCall)) &&
@@ -2037,7 +2076,8 @@ export class TurnRecovery {
 			}
 		}
 
-		const allowModelFallback = options?.allowModelFallback !== false;
+		const allowModelFallback =
+			options?.allowModelFallback !== false && !primaryProviderPinned && !waitForNetworkRecovery;
 		const currentModel = this.#host.model();
 		const currentSelector = currentModel
 			? formatRetryFallbackSelector(currentModel, this.#host.thinkingLevel())
@@ -2167,7 +2207,7 @@ export class TurnRecovery {
 		// assistant error message is preserved in agent state so the caller
 		// can act on it.
 		const maxDelayMs = retrySettings.maxDelayMs;
-		if (maxDelayMs > 0 && delayMs > maxDelayMs && !switchedCredential && !switchedModel) {
+		if (!unboundedRouteWait && maxDelayMs > 0 && delayMs > maxDelayMs && !switchedCredential && !switchedModel) {
 			await this.persistTerminalEmptyErrorTurn(message);
 			const attempt = this.#retryAttempt;
 			this.#retryAttempt = 0;

--- a/packages/coding-agent/test/agent-session-retry-fallback.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-fallback.test.ts
@@ -305,6 +305,148 @@ describe("AgentSession retry fallback", () => {
 		]);
 	});
 
+	it("keeps a pinned primary beyond the retry budget without consulting model fallback", async () => {
+		const primaryModel = getBundledModel("anthropic", "claude-sonnet-4-5");
+		const fallbackModel = getBundledModel("openai", "gpt-4o-mini");
+		if (!primaryModel || !fallbackModel) throw new Error("Expected bundled test models to exist");
+
+		const requestedModels: string[] = [];
+		let primaryAttempts = 0;
+		const mock = createMockModel();
+		const agent = new Agent({
+			getApiKey: model => `${model.provider}-test-key`,
+			initialState: { model: primaryModel, systemPrompt: ["Test"], tools: [], messages: [] },
+			streamFn: (model, context, options) => {
+				requestedModels.push(`${model.provider}/${model.id}`);
+				if (model.provider !== primaryModel.provider || model.id !== primaryModel.id) {
+					throw new Error("Pinned primary unexpectedly routed to fallback");
+				}
+				primaryAttempts++;
+				mock.push(
+					primaryAttempts <= 2
+						? { throw: "overloaded_error: provider returned error 503" }
+						: { content: ["Recovered on pinned primary"] },
+				);
+				return mock.stream(model, context, options);
+			},
+		});
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"retry.baseDelayMs": 1,
+			"retry.maxRetries": 1,
+			"retry.fallbackChains": { default: [`${fallbackModel.provider}/${fallbackModel.id}`] },
+		});
+		settings.setModelRole("default", `${primaryModel.provider}/${primaryModel.id}`);
+		const sessionManager = SessionManager.inMemory();
+		session = new AgentSession({ agent, sessionManager, settings, modelRegistry });
+
+		expect(session.setPrimaryProviderPinned(true)).toBe(true);
+		expect(session.primaryProviderPinned).toBe(true);
+		await session.prompt("Wait for the primary");
+		await session.waitForIdle();
+
+		expect(requestedModels).toEqual(Array(3).fill(`${primaryModel.provider}/${primaryModel.id}`));
+		expect(getLastAssistantMessage(session).content).toContainEqual({
+			type: "text",
+			text: "Recovered on pinned primary",
+		});
+		expect(session.setPrimaryProviderPinned(false)).toBe(false);
+		expect(session.primaryProviderPinned).toBe(false);
+		expect(sessionManager.getEntries().filter(entry => entry.type === "custom")).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ customType: "primary_provider_pin", data: { pinned: true } }),
+				expect.objectContaining({ customType: "primary_provider_pin", data: { pinned: false } }),
+			]),
+		);
+	});
+
+	it("restores the primary-provider pin from the persisted session branch", async () => {
+		using sessionDir = TempDir.createSync("@omp-primary-provider-pin-");
+		try {
+			const primaryModel = getBundledModel("anthropic", "claude-sonnet-4-5");
+			if (!primaryModel) throw new Error("Expected bundled Anthropic test model to exist");
+
+			const settings = Settings.isolated({ "compaction.enabled": false });
+			settings.setModelRole("default", `${primaryModel.provider}/${primaryModel.id}`);
+			const firstManager = SessionManager.create(sessionDir.path(), sessionDir.path());
+			session = new AgentSession({
+				agent: createFallbackAgent(primaryModel, []),
+				sessionManager: firstManager,
+				settings,
+				modelRegistry,
+			});
+			expect(session.setPrimaryProviderPinned(true)).toBe(true);
+			await firstManager.ensureOnDisk();
+			await firstManager.flush();
+			const sessionFile = firstManager.getSessionFile();
+			if (!sessionFile) throw new Error("Expected persisted session path");
+
+			const firstSession = session;
+			session = undefined;
+			await firstSession.dispose();
+			const resumedManager = await SessionManager.open(sessionFile, sessionDir.path());
+			session = new AgentSession({
+				agent: createFallbackAgent(primaryModel, []),
+				sessionManager: resumedManager,
+				settings,
+				modelRegistry,
+			});
+
+			expect(session.primaryProviderPinned).toBe(true);
+		} finally {
+			const activeSession = session;
+			session = undefined;
+			await activeSession?.dispose();
+		}
+	});
+
+	it("waits for local network recovery without consulting model fallback", async () => {
+		const primaryModel = getBundledModel("anthropic", "claude-sonnet-4-5");
+		const fallbackModel = getBundledModel("openai", "gpt-4o-mini");
+		if (!primaryModel || !fallbackModel) throw new Error("Expected bundled test models to exist");
+
+		const requestedModels: string[] = [];
+		let primaryAttempts = 0;
+		const mock = createMockModel();
+		const agent = new Agent({
+			getApiKey: model => `${model.provider}-test-key`,
+			initialState: { model: primaryModel, systemPrompt: ["Test"], tools: [], messages: [] },
+			streamFn: (model, context, options) => {
+				requestedModels.push(`${model.provider}/${model.id}`);
+				primaryAttempts++;
+				mock.push(
+					primaryAttempts <= 4
+						? { throw: "Unable to connect. Is the computer able to access the url?" }
+						: { content: ["Recovered after the network returned"] },
+				);
+				return mock.stream(model, context, options);
+			},
+		});
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"retry.baseDelayMs": 1,
+			"retry.maxRetries": 1,
+			"retry.fallbackChains": { default: [`${fallbackModel.provider}/${fallbackModel.id}`] },
+		});
+		settings.setModelRole("default", `${primaryModel.provider}/${primaryModel.id}`);
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+		});
+		vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+
+		await session.prompt("Wait for network recovery");
+		await session.waitForIdle();
+
+		expect(requestedModels).toEqual(Array(5).fill(`${primaryModel.provider}/${primaryModel.id}`));
+		expect(getLastAssistantMessage(session).content).toContainEqual({
+			type: "text",
+			text: "Recovered after the network returned",
+		});
+	});
+
 	it("hops to the chain owned by a fallback that is the last entry of the chain it came from", async () => {
 		const primaryModel = getBundledModel("anthropic", "claude-sonnet-4-5");
 		const firstFallback = getBundledModel("openai", "gpt-4o-mini");
@@ -4023,6 +4165,95 @@ describe("AgentSession retry fallback", () => {
 		expect(session.model?.provider).toBe(fallbackModel.provider);
 		expect(session.model?.id).toBe(fallbackModel.id);
 	});
+	it("restores the primary after cooldown expiry inside one tool-call loop", async () => {
+		const primaryModel = getBundledModel("anthropic", "claude-sonnet-4-5");
+		const fallbackModel = getBundledModel("openai", "gpt-4o-mini");
+		if (!primaryModel || !fallbackModel) {
+			throw new Error("Expected bundled Anthropic and OpenAI test models to exist");
+		}
+
+		let now = Date.now();
+		let toolExecutions = 0;
+		const toolSchema = type({ value: type("string") });
+		const tool: AgentTool<typeof toolSchema, { value: string }> = {
+			name: "advance_cooldown",
+			label: "Advance cooldown",
+			description: "Advance the test clock between model requests",
+			parameters: toolSchema,
+			async execute(_toolCallId, params) {
+				toolExecutions += 1;
+				now += 240;
+				return { content: [{ type: "text", text: params.value }], details: params };
+			},
+		};
+		const primarySelector = `${primaryModel.provider}/${primaryModel.id}`;
+		const fallbackSelector = `${fallbackModel.provider}/${fallbackModel.id}`;
+		const requestedModels: string[] = [];
+		const mock = createMockModel();
+		let primaryAttempts = 0;
+		let fallbackAttempts = 0;
+		const agent = new Agent({
+			getApiKey: model => `${model.provider}-test-key`,
+			initialState: { model: primaryModel, systemPrompt: ["Test"], tools: [tool], messages: [] },
+			streamFn: (model, context, options) => {
+				const selector = `${model.provider}/${model.id}`;
+				requestedModels.push(selector);
+				if (selector === primarySelector) {
+					if (primaryAttempts++ === 0) {
+						mock.push({ throw: "rate limit exceeded retry-after-ms=200" });
+					} else {
+						mock.push({ content: ["Primary restored inside the active tool loop"] });
+					}
+				} else if (selector === fallbackSelector) {
+					if (fallbackAttempts++ === 0) {
+						mock.push({
+							content: [
+								{
+									type: "toolCall",
+									id: "advance-cooldown",
+									name: "advance_cooldown",
+									arguments: { value: "cooldown expired" },
+								},
+							],
+							stopReason: "toolUse",
+						});
+					} else {
+						mock.push({ content: ["Fallback remained active"] });
+					}
+				} else {
+					throw new Error(`Unexpected model requested: ${selector}`);
+				}
+				return mock.stream(model, context, options);
+			},
+		});
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"retry.baseDelayMs": 5,
+			"retry.fallbackChains": { default: [fallbackSelector] },
+			"retry.fallbackRevertPolicy": "cooldown-expiry",
+		});
+		settings.setModelRole("default", primarySelector);
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+		});
+		vi.spyOn(Date, "now").mockImplementation(() => now);
+
+		await session.prompt("Restore the primary without starting a second prompt");
+		await session.waitForIdle();
+
+		expect(requestedModels).toEqual([primarySelector, fallbackSelector, primarySelector]);
+		expect(toolExecutions).toBe(1);
+		expect(session.model?.provider).toBe(primaryModel.provider);
+		expect(session.model?.id).toBe(primaryModel.id);
+		expect(getLastAssistantMessage(session).content).toContainEqual({
+			type: "text",
+			text: "Primary restored inside the active tool loop",
+		});
+	});
+
 	it("suppresses cooled selectors and lazily reverts to the role primary after cooldown expiry", async () => {
 		const primaryModel = getBundledModel("anthropic", "claude-sonnet-4-5");
 		const fallbackModel = getBundledModel("openai", "gpt-4o-mini");
@@ -4087,6 +4318,44 @@ describe("AgentSession retry fallback", () => {
 			selector: `${primaryModel.provider}/${primaryModel.id}`,
 			isFallback: false,
 		});
+	});
+
+	it("forces an active fallback back to the primary when the session is pinned", async () => {
+		const primaryModel = getBundledModel("anthropic", "claude-sonnet-4-5");
+		const fallbackModel = getBundledModel("openai", "gpt-4o-mini");
+		if (!primaryModel || !fallbackModel) {
+			throw new Error("Expected bundled Anthropic and OpenAI test models to exist");
+		}
+
+		const primarySelector = `${primaryModel.provider}/${primaryModel.id}`;
+		const fallbackSelector = `${fallbackModel.provider}/${fallbackModel.id}`;
+		const requestedModels: string[] = [];
+		const agent = createFallbackAgent(primaryModel, requestedModels, { retryAfterMs: 60_000 });
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"retry.baseDelayMs": 5,
+			"retry.fallbackChains": { default: [fallbackSelector] },
+			"retry.fallbackRevertPolicy": "never",
+		});
+		settings.setModelRole("default", primarySelector);
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+		});
+
+		await session.prompt("First prompt triggers fallback");
+		await session.waitForIdle();
+		expect(requestedModels).toEqual([primarySelector, fallbackSelector]);
+		expect(session.model?.id).toBe(fallbackModel.id);
+
+		session.setPrimaryProviderPinned(true);
+		await session.prompt("Pinned prompt must return to the primary");
+		await session.waitForIdle();
+
+		expect(requestedModels).toEqual([primarySelector, fallbackSelector, primarySelector]);
+		expect(session.model?.id).toBe(primaryModel.id);
 	});
 
 	it("keeps credit with the fallback when a restored primary fails without serving", async () => {
@@ -5336,6 +5605,51 @@ describe("AgentSession retry fallback", () => {
 			selector: `${fallbackModel.provider}/${fallbackModel.id}`,
 			isFallback: true,
 		});
+	});
+
+	it("does not apply usage-aware model fallback while the primary route is pinned", async () => {
+		const primaryModel = getBundledModel("anthropic", "claude-sonnet-4-5");
+		const fallbackModel = getBundledModel("openai", "gpt-4o-mini");
+		if (!primaryModel || !fallbackModel) {
+			throw new Error("Expected bundled Anthropic and OpenAI test models to exist");
+		}
+
+		const primarySelector = `${primaryModel.provider}/${primaryModel.id}`;
+		const requestedModels: string[] = [];
+		const mock = createMockModel({ responses: [{ content: ["served on the pinned primary"] }] });
+		const agent = new Agent({
+			getApiKey: model => `${model.provider}-test-key`,
+			initialState: { model: primaryModel, systemPrompt: ["Test"], tools: [], messages: [] },
+			streamFn: (model, context, options) => {
+				requestedModels.push(`${model.provider}/${model.id}`);
+				return mock.stream(model, context, options);
+			},
+		});
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"retry.usageAwareFallback": true,
+			"retry.fallbackChains": { default: [`${fallbackModel.provider}/${fallbackModel.id}`] },
+		});
+		settings.setModelRole("default", primarySelector);
+		const usageHealth = vi.spyOn(modelRegistry.authStorage, "getModelUsageHealth").mockResolvedValue({
+			state: "depleted",
+			accounts: [{ credentialId: 1, credentialType: "oauth", state: "depleted" }],
+		});
+
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+		});
+		session.setPrimaryProviderPinned(true);
+
+		await session.prompt("Stay on the pinned primary");
+		await session.waitForIdle();
+
+		expect(usageHealth).not.toHaveBeenCalled();
+		expect(requestedModels).toEqual([primarySelector]);
+		expect(session.model?.id).toBe(primaryModel.id);
 	});
 
 	// A thinking-loop abort is a same-model resample signal (the guard pairs it

--- a/packages/coding-agent/test/config-cli.test.ts
+++ b/packages/coding-agent/test/config-cli.test.ts
@@ -197,6 +197,18 @@ describe("config CLI schema coverage", () => {
 		const parsed: unknown = JSON.parse(output);
 		expect(parsed).toMatchObject({ modelRoles: { type: "record" } });
 	});
+	it("exports stable runtime capabilities without loading user settings", async () => {
+		if (!testAgentDir) throw new Error("Test agent directory was not initialized");
+		await Bun.write(path.join(testAgentDir.path(), "config.yml"), "invalid: [unterminated\n");
+
+		const { exitCode, output, error } = await runCliProcess(["config", "capabilities", "--json"], {
+			PI_CODING_AGENT_DIR: testAgentDir.path(),
+		});
+
+		expect(exitCode).toBe(0);
+		expect(error).toBe("");
+		expect(JSON.parse(output)).toEqual({ primaryProviderPin: true });
+	});
 	it("loads PI_CONFIG_FILES overlays in path-list order", async () => {
 		if (!testAgentDir) throw new Error("Test agent directory was not initialized");
 		const baseOverlayPath = path.join(testAgentDir.path(), "base-overlay.yml");

--- a/packages/coding-agent/test/custom-editor-keybindings.test.ts
+++ b/packages/coding-agent/test/custom-editor-keybindings.test.ts
@@ -19,6 +19,27 @@ describe("CustomEditor keybindings", () => {
 		expect(onRetry).toHaveBeenCalledTimes(1);
 	});
 
+	it("routes the shipped primary provider pin chord through handleInput", () => {
+		const editor = new CustomEditor(getEditorTheme());
+		const onTogglePrimaryProviderPin = vi.fn();
+
+		editor.onTogglePrimaryProviderPin = onTogglePrimaryProviderPin;
+		editor.handleInput("\x1bR");
+
+		expect(onTogglePrimaryProviderPin).toHaveBeenCalledTimes(1);
+	});
+
+	it("routes the configured primary provider pin chord through handleInput", () => {
+		const editor = new CustomEditor(getEditorTheme());
+		const onTogglePrimaryProviderPin = vi.fn();
+
+		editor.setActionKeys("app.provider.pinPrimary", ["alt+shift+r"]);
+		editor.onTogglePrimaryProviderPin = onTogglePrimaryProviderPin;
+		editor.handleInput("\x1bR");
+
+		expect(onTogglePrimaryProviderPin).toHaveBeenCalledTimes(1);
+	});
+
 	it("routes the configured tool activity visibility chord through handleInput", () => {
 		const editor = new CustomEditor(getEditorTheme());
 		const onToggleToolActivity = vi.fn();

--- a/packages/coding-agent/test/input-controller-keybindings.test.ts
+++ b/packages/coding-agent/test/input-controller-keybindings.test.ts
@@ -20,6 +20,7 @@ type FakeEditor = {
 	onCycleModelBackward?: () => void;
 	onSelectModelTemporary?: () => void;
 	onSelectModel?: () => void;
+	onTogglePrimaryProviderPin?: () => void;
 	onHistorySearch?: () => void;
 	onPasteImage?: () => Promise<boolean>;
 	onCopyPrompt?: () => void;
@@ -67,6 +68,7 @@ async function createContext() {
 		"app.display.reset": ["ctrl+l"],
 		"app.model.selectTemporary": ["ctrl+y"],
 		"app.model.select": ["alt+m"],
+		"app.provider.pinPrimary": ["alt+shift+r"],
 		"app.retry": ["alt+r"],
 		"app.clipboard.pasteImage": ["ctrl+v"],
 		"app.tools.toggleVisibility": ["ctrl+shift+o"],
@@ -100,6 +102,7 @@ async function createContext() {
 	const prompt = vi.fn(async () => {});
 	const retry = vi.fn(async () => true);
 	const abort = vi.fn(async () => {});
+	const togglePrimaryProviderPin = vi.fn(() => true);
 	const session = {
 		isStreaming: false,
 		isCompacting: false,
@@ -111,6 +114,7 @@ async function createContext() {
 		queuedMessageCount: 0,
 		abort,
 		retry,
+		togglePrimaryProviderPin,
 	};
 	const updatePendingMessagesDisplay = vi.fn();
 	const handleBtwBranchKey = vi.fn(async () => true);
@@ -153,9 +157,12 @@ async function createContext() {
 		},
 	};
 	focused = editor;
+	const showStatus = vi.fn();
+	const invalidateStatusLine = vi.fn();
 	const ctx = {
 		editor: editor as unknown as InteractiveModeContext["editor"],
 		resetDisplayAfterAppearanceRefresh,
+		statusLine: { invalidate: invalidateStatusLine } as unknown as InteractiveModeContext["statusLine"],
 		ui: {
 			requestRender,
 			resetDisplay,
@@ -234,7 +241,7 @@ async function createContext() {
 		canCopyBtw,
 		handleBtwCopyKey,
 		showError,
-		showStatus: vi.fn(),
+		showStatus,
 	} as unknown as InteractiveModeContext;
 
 	return {
@@ -271,6 +278,8 @@ async function createContext() {
 			handleBtwCopyKey,
 			canCopyBtw,
 			showError,
+			showStatus,
+			invalidateStatusLine,
 		},
 	};
 }
@@ -285,18 +294,23 @@ describe("InputController keybinding setup", () => {
 		expect(spies.setActionKeys).toHaveBeenCalledWith("app.display.reset", ["ctrl+l"]);
 		expect(spies.setActionKeys).toHaveBeenCalledWith("app.model.selectTemporary", ["ctrl+y"]);
 		expect(spies.setActionKeys).toHaveBeenCalledWith("app.model.select", ["alt+m"]);
+		expect(spies.setActionKeys).toHaveBeenCalledWith("app.provider.pinPrimary", ["alt+shift+r"]);
 		expect(editor.onDisplayReset).toBeDefined();
 		expect(editor.onSelectModelTemporary).toBeDefined();
 		expect(editor.onSelectModel).toBeDefined();
+		expect(editor.onTogglePrimaryProviderPin).toBeDefined();
 		expect(editor.onSelectModelTemporary).not.toBe(editor.onSelectModel);
 
 		editor.onDisplayReset?.();
 		editor.onSelectModelTemporary?.();
 		editor.onSelectModel?.();
+		editor.onTogglePrimaryProviderPin?.();
 
 		expect(spies.showModelSelector).toHaveBeenNthCalledWith(1, { temporaryOnly: true });
 		expect(spies.showModelSelector).toHaveBeenNthCalledWith(2);
 		expect(spies.resetDisplayAfterAppearanceRefresh).toHaveBeenCalledTimes(1);
+		expect(spies.showStatus).toHaveBeenCalledWith("Primary provider pinned for this session");
+		expect(spies.invalidateStatusLine).toHaveBeenCalledTimes(1);
 	});
 
 	it("registers the tool activity visibility action", async () => {


### PR DESCRIPTION
## Summary

- add a session-local primary-provider pin, toggled with `Alt+Shift+R`
- persist the policy as `primary_provider_pin` custom entries in session JSONL and restore it on resume
- keep retrying the original primary without model fallback while pinned, including restoration from active, sticky, and usage-aware fallback state
- keep local DNS/network outages on the current route instead of treating them as provider failures
- expose support through `omp config capabilities --json` without loading user settings

## Verification

- `bun run check:ts`
- 152 focused AI/config/keybinding/retry-fallback tests
- runtime/session shard: the affected retry-fallback chunk passed all 164 tests
- source smoke: `omp config capabilities --json` returned `{ "primaryProviderPin": true }`

The full runtime shard is not Windows-clean on current `main`: unrelated RPC tests hard-code `/usr/bin/false`, and several existing SDK fixtures leave locked temp directories. No changed file participates in those failures.