### PR TITLE
fix(acp): strip read selector from ToolCallLocation.path

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed `import numpy` (and other native-extension imports) hanging indefinitely in the Python eval tool on Windows, where the runner's always-on background stdin reader deadlocked native DLL loading; Windows now reads the control channel serially between requests while POSIX keeps concurrent request dispatch ([#7985](https://github.com/can1357/oh-my-pi/issues/7985)).
+- Fixed ACP `read` tool-call locations leaking the OMP read selector (e.g. `file.md:1-20`) into `ToolCallLocation.path`, which made Zed Follow open an empty buffer; the location now names the resolved filesystem path, real files literally named like a selector stay literal, and `write`/`edit` colon paths are untouched ([#10088](https://github.com/can1357/oh-my-pi/issues/10088)).
 
 ## [18.0.9] - 2026-08-28
 

--- a/packages/coding-agent/src/modes/acp/acp-event-mapper.ts
+++ b/packages/coding-agent/src/modes/acp/acp-event-mapper.ts
@@ -8,7 +8,7 @@ import type {
 } from "@oh-my-pi/pi-utils/acp";
 import { parseXdUrl } from "../../internal-urls/xd-protocol";
 import type { AgentSessionEvent } from "../../session/agent-session";
-import { resolveToCwd } from "../../tools/path-utils";
+import { resolveToCwd, splitPathAndSel, splitPathAndSelPreferringLiteralSync } from "../../tools/path-utils";
 import type { TodoStatus } from "../../tools/todo";
 import { canonicalizeMessage } from "../../utils/thinking-display";
 
@@ -244,7 +244,7 @@ export function mapAgentSessionEventToAcpSessionUpdates(
 			if (content.length > 0) {
 				update.content = content;
 			}
-			const locations = extractToolLocations(event.args, options.cwd);
+			const locations = extractToolLocations(event.args, options.cwd, event.toolName);
 			if (locations.length > 0) {
 				update.locations = locations;
 			}
@@ -495,7 +495,7 @@ export function buildToolCallStartUpdate(input: {
 	if (content.length > 0) {
 		update.content = content;
 	}
-	const locations = extractToolLocations(input.args, input.cwd);
+	const locations = extractToolLocations(input.args, input.cwd, input.toolName);
 	if (locations.length > 0) {
 		update.locations = locations;
 	}
@@ -642,7 +642,26 @@ function toAcpLocationPath(value: string, cwd?: string): string {
  */
 const INTERNAL_URL_SUBJECT = /^[a-z][a-z0-9+.-]*:\/\//i;
 
-function extractToolLocations(args: unknown, cwd?: string): ToolCallLocation[] {
+/**
+ * For the `read` tool, peel a trailing read selector (`:1-20`, `:raw`,
+ * `:1-20:raw`, comma-separated ranges) off the filesystem path so the ACP
+ * location names the file actually accessed rather than the selector-bearing
+ * expression — Zed Follow otherwise treats the selector as part of the
+ * filename and opens an empty buffer. Literal POSIX filenames that legitimately
+ * end in selector-shaped text (e.g. `report:1-20`) are preserved via the same
+ * literal-path precedence the read tool uses. Non-read tools and internal URLs
+ * pass through unchanged — colons in write/edit targets are valid filenames.
+ */
+function readLocationBasePath(
+	raw: string | undefined,
+	cwd: string | undefined,
+	toolName: string | undefined,
+): string | undefined {
+	if (raw === undefined || toolName !== "read" || INTERNAL_URL_SUBJECT.test(raw)) return raw;
+	return cwd ? splitPathAndSelPreferringLiteralSync(raw, cwd).path : splitPathAndSel(raw).path;
+}
+
+function extractToolLocations(args: unknown, cwd?: string, toolName?: string): ToolCallLocation[] {
 	const locations: ToolCallLocation[] = [];
 	const seen = new Set<string>();
 	const pushPath = (raw: string | undefined) => {
@@ -653,7 +672,7 @@ function extractToolLocations(args: unknown, cwd?: string): ToolCallLocation[] {
 		locations.push({ path });
 	};
 
-	pushPath(extractStringProperty<PathContainer>(args, "path"));
+	pushPath(readLocationBasePath(extractStringProperty<PathContainer>(args, "path"), cwd, toolName));
 	pushPath(extractStringProperty<OldPathContainer>(args, "oldPath"));
 	pushPath(extractStringProperty<NewPathContainer>(args, "newPath"));
 

--- a/packages/coding-agent/src/tools/path-utils.ts
+++ b/packages/coding-agent/src/tools/path-utils.ts
@@ -382,6 +382,36 @@ export async function splitPathAndSelPreferringLiteral(
 }
 
 /**
+ * Synchronous sibling of {@link probeLiteralPathExists}. Some callers resolve
+ * paths on a synchronous hot path (the ACP event mapper builds tool-call
+ * notifications synchronously), so the async `lstat` probe is unavailable. The
+ * error-code handling matches the async version exactly.
+ */
+export function probeLiteralPathExistsSync(filePath: string, cwd: string): "exists" | "missing" | "unknown" {
+	const resolved = resolveReadPath(filePath, cwd);
+	try {
+		fs.lstatSync(resolved);
+		return "exists";
+	} catch (err) {
+		if (isEnoent(err) || isEnotdir(err) || hasFsCode(err, "ENAMETOOLONG")) return "missing";
+		return "unknown";
+	}
+}
+
+/**
+ * Synchronous sibling of {@link splitPathAndSelPreferringLiteral}. Identical
+ * literal-path precedence — a real file named `report:1-20` keeps its colon —
+ * for callers that cannot await, such as the ACP event mapper's location
+ * builder.
+ */
+export function splitPathAndSelPreferringLiteralSync(rawPath: string, cwd: string): { path: string; sel?: string } {
+	const strict = splitPathAndSel(rawPath);
+	if (strict.sel === undefined) return strict;
+	const probe = probeLiteralPathExistsSync(rawPath, cwd);
+	return probe === "missing" ? strict : { path: rawPath };
+}
+
+/**
  * Variant of {@link splitPathAndSel} for internal URLs (`scheme://...`).
  *
  * The filesystem-path splitter is intentionally conservative: it refuses to

--- a/packages/coding-agent/test/acp-event-mapper.test.ts
+++ b/packages/coding-agent/test/acp-event-mapper.test.ts
@@ -1148,6 +1148,70 @@ describe("ACP event mapper", () => {
 		expect(update.locations).toEqual([{ path: path.resolve("/repo", "src/file.ts") }]);
 		expect("content" in update).toBe(false);
 	});
+	it("strips read selectors from the ACP location while preserving rawInput", () => {
+		const cases: Array<{ path: string; base: string }> = [
+			{ path: "src/file.ts:1-20", base: "src/file.ts" },
+			{ path: "src/file.ts:raw", base: "src/file.ts" },
+			{ path: "src/file.ts:1-20:raw", base: "src/file.ts" },
+			{ path: "src/file.ts:raw:1-20", base: "src/file.ts" },
+			{ path: "src/file.ts:5-16,960-973", base: "src/file.ts" },
+		];
+		for (const { path: readPath, base } of cases) {
+			const updates = mapAgentSessionEventToAcpSessionUpdates(
+				{
+					type: "tool_execution_start",
+					toolCallId: `toolu_read_sel_${base}`,
+					toolName: "read",
+					args: { path: readPath },
+				} as AgentSessionEvent,
+				"session-1",
+				{ cwd: "/repo" },
+			);
+			expectAcpNotifications(updates);
+			const update = updates[0]!.update as { locations?: { path: string }[]; rawInput?: unknown };
+			expect(update.locations).toEqual([{ path: path.resolve("/repo", base) }]);
+			// The full selector-bearing expression stays in rawInput so the client
+			// can still see exactly what the model asked for.
+			expect(update.rawInput).toEqual({ path: readPath });
+		}
+	});
+	it("keeps a real file literally named like a selector as the read location", () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "acp-read-literal-"));
+		const literalName = "report:1-20";
+		fs.writeFileSync(path.join(dir, literalName), "data\n");
+		try {
+			const updates = mapAgentSessionEventToAcpSessionUpdates(
+				{
+					type: "tool_execution_start",
+					toolCallId: "toolu_read_literal",
+					toolName: "read",
+					args: { path: literalName },
+				} as AgentSessionEvent,
+				"session-1",
+				{ cwd: dir },
+			);
+			expectAcpNotifications(updates);
+			const update = updates[0]!.update as { locations?: { path: string }[] };
+			expect(update.locations).toEqual([{ path: path.join(dir, literalName) }]);
+		} finally {
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+	});
+	it("does not strip selector-looking suffixes from non-read tool paths", () => {
+		const updates = mapAgentSessionEventToAcpSessionUpdates(
+			{
+				type: "tool_execution_start",
+				toolCallId: "tc-write-colon",
+				toolName: "write",
+				args: { path: "src/report:1-20", content: "x" },
+			} as AgentSessionEvent,
+			"session-1",
+			{ cwd: "/repo" },
+		);
+		expectAcpNotifications(updates);
+		const update = updates[0]!.update as { locations?: { path: string }[] };
+		expect(update.locations).toEqual([{ path: path.resolve("/repo", "src/report:1-20") }]);
+	});
 	it("emits distinct locations for move-style path arguments", () => {
 		const updates = mapAgentSessionEventToAcpSessionUpdates(
 			{


### PR DESCRIPTION
## Repro
Driving the real ACP event mapper (`packages/coding-agent/src/modes/acp/acp-event-mapper.ts`) for a `read` with `{ path: "/workspace/.github/copilot-instructions.md:1-20" }` and `cwd: /workspace` emitted `"locations": [{ "path": "/workspace/.github/copilot-instructions.md:1-20" }]`. The `:1-20` read selector leaked into the ACP location, so Zed Follow treated it as part of the filename and opened an empty buffer. Confirmed via `bun test test/acp-event-mapper.test.ts`.

## Cause
`extractToolLocations` in `acp-event-mapper.ts` read `args.path` verbatim and only resolved it against cwd through `toAcpLocationPath` / `resolveToCwd`; it never consumed OMP's read-selector grammar. The read execution path peels selectors via `splitPathAndSel` / `splitPathAndSelPreferringLiteral` (`packages/coding-agent/src/tools/path-utils.ts`), but the mapper duplicated the raw argument instead of the resolved filesystem path. ACP defines `ToolCallLocation.path` as the absolute file path being accessed, and a selector-bearing expression is not that path. (The `tool_execution_end` result for `read` never emitted a location at all — read details carry `resolvedPath`, not `path` — so the leaked start-event location was the only one Zed saw.)

## Fix
- Add synchronous `probeLiteralPathExistsSync` / `splitPathAndSelPreferringLiteralSync` to `path-utils.ts`, mirroring the async literal-path precedence for callers that cannot await (the mapper builds notifications synchronously).
- Thread `toolName` into `extractToolLocations`; a new `readLocationBasePath` helper peels the read selector off the `path` field only when `toolName === "read"`, preserving literal filenames like `report:1-20` and leaving internal URLs alone.
- Non-read tools and `oldPath` / `newPath` keep their colons; the full expression stays in `rawInput`.
- Changelog entry under `[Unreleased]`.

## Verification
`bun test test/acp-event-mapper.test.ts` (44 pass) covers `:1-20`, `:raw`, compound `:1-20:raw`, comma ranges `:5-16,960-973`, preserved `rawInput`, a real on-disk file literally named `report:1-20` staying literal, and a non-read `write` selector-looking suffix left intact. `bun test test/tools/path-utils-dotdot-selector.test.ts test/tools/split-internal-url-sel.test.ts` (33 pass). Line emission (`ToolCallLocation.line`) is intentionally deferred: ACP v1 does not specify the field's indexing convention, so emitting it without client coordination and integration coverage risks wrong scroll positions; the path fix alone resolves the empty-buffer bug.

Fixes #10088