### PR TITLE
fix(mcp): preserve actionable transport diagnostics

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed `import numpy` (and other native-extension imports) hanging indefinitely in the Python eval tool on Windows, where the runner's always-on background stdin reader deadlocked native DLL loading; Windows now reads the control channel serially between requests while POSIX keeps concurrent request dispatch ([#7985](https://github.com/can1357/oh-my-pi/issues/7985)).
+- Fixed `xd://` MCP failures reporting actionable transport stages, failure classes, server/tool context, retryability, safe trace IDs, and redacted JSON-RPC details instead of unusable fetch-library advice ([#10093](https://github.com/can1357/oh-my-pi/issues/10093)).
 
 ## [18.0.9] - 2026-08-28
 

--- a/packages/coding-agent/src/mcp/errors.ts
+++ b/packages/coding-agent/src/mcp/errors.ts
@@ -1,0 +1,284 @@
+import { isRecord } from "@oh-my-pi/pi-utils";
+import type { JsonRpcError } from "./types";
+
+/** MCP transport used by a failed operation. */
+export type MCPTransportKind = "http" | "stdio" | "unknown";
+
+/** Protocol stage at which an MCP operation failed. */
+export type MCPFailureStage = "connect" | "send" | "receive" | "decode" | "protocol";
+
+/** Stable failure classes exposed in MCP tool diagnostics. */
+export type MCPFailureClass =
+	| "connect"
+	| "timeout"
+	| "eof"
+	| "reset"
+	| "malformed_response"
+	| "json_rpc"
+	| "http_status"
+	| "closed"
+	| "unknown";
+
+interface MCPTransportErrorOptions {
+	transport: MCPTransportKind;
+	stage: MCPFailureStage;
+	failure: MCPFailureClass;
+	message: string;
+	retryable: boolean;
+	code?: string | number;
+	data?: string;
+	traceId?: string;
+	cause?: unknown;
+}
+
+const MAX_MESSAGE_CHARS = 1_000;
+const MAX_DATA_CHARS = 2_000;
+const MAX_TRACE_ID_CHARS = 128;
+const MAX_DATA_STRING_CHARS = 256;
+const MAX_DATA_DEPTH = 5;
+const MAX_DATA_ENTRIES = 30;
+const FETCH_VERBOSE_ADVICE =
+	/\s*For more information, pass `verbose: true` in the second argument to fetch\(\)\.?\s*$/i;
+const SECRET_KEY =
+	/^(?:authorization|cookie|set-cookie|api[-_]?key|access[-_]?token|refresh[-_]?token|token|secret|password)$/i;
+const TRACE_KEYS = /^(?:trace[-_]?id|request[-_]?id|correlation[-_]?id|traceparent)$/i;
+
+export class MCPTransportError extends Error {
+	/** Transport implementation handling the failed operation. */
+	readonly transport: MCPTransportKind;
+	/** Protocol stage reached before failure. */
+	readonly stage: MCPFailureStage;
+	/** Stable machine-readable failure classification. */
+	readonly failure: MCPFailureClass;
+	/** Whether reconnecting and replaying follows the existing safe-retry policy. */
+	readonly retryable: boolean;
+	/** Transport, HTTP, subprocess, or JSON-RPC error code when available. */
+	readonly code: string | number | undefined;
+	/** Bounded, credential-redacted JSON-RPC error data. */
+	readonly data: string | undefined;
+	/** Safe server trace or request identifier. */
+	readonly traceId: string | undefined;
+
+	constructor(options: MCPTransportErrorOptions) {
+		super(
+			sanitizeDiagnosticText(options.message, MAX_MESSAGE_CHARS),
+			options.cause === undefined ? undefined : { cause: options.cause },
+		);
+		this.name = "MCPTransportError";
+		this.transport = options.transport;
+		this.stage = options.stage;
+		this.failure = options.failure;
+		this.retryable = options.retryable;
+		this.code = options.code;
+		this.data = options.data;
+		this.traceId = options.traceId;
+	}
+}
+
+function errorCode(error: unknown): string | number | undefined {
+	if (!isRecord(error)) return undefined;
+	if (typeof error.code === "string" || typeof error.code === "number") return error.code;
+	return error.cause === undefined ? undefined : errorCode(error.cause);
+}
+
+function sanitizeDiagnosticText(value: string, maxChars: number): string {
+	return value
+		.replace(FETCH_VERBOSE_ADVICE, "")
+		.replace(/\b(Bearer|Basic)\s+[^\s,;]+/gi, "$1 [redacted]")
+		.replace(/([?&](?:access[-_]?token|api[-_]?key|key|token|secret|password)=)[^&#\s]+/gi, "$1[redacted]")
+		.replace(/((?:authorization|api[-_]?key|token|secret|password)\s*[:=]\s*)[^\s,;}]+/gi, "$1[redacted]")
+		.slice(0, maxChars)
+		.trim();
+}
+
+function sanitizeData(value: unknown, depth: number, seen: WeakSet<object>): unknown {
+	if (depth > MAX_DATA_DEPTH) return "[truncated]";
+	if (typeof value === "string") return sanitizeDiagnosticText(value, MAX_DATA_STRING_CHARS);
+	if (typeof value === "number" || typeof value === "boolean" || value === null) return value;
+	if (Array.isArray(value)) {
+		if (seen.has(value)) return "[circular]";
+		seen.add(value);
+		return value.slice(0, MAX_DATA_ENTRIES).map(item => sanitizeData(item, depth + 1, seen));
+	}
+	if (!isRecord(value)) return String(value);
+	if (seen.has(value)) return "[circular]";
+	seen.add(value);
+	const result: Record<string, unknown> = {};
+	let count = 0;
+	for (const key in value) {
+		if (count++ === MAX_DATA_ENTRIES) break;
+		const item = value[key];
+		result[key] = SECRET_KEY.test(key) ? "[redacted]" : sanitizeData(item, depth + 1, seen);
+	}
+	return result;
+}
+
+function serializeData(value: unknown): string | undefined {
+	if (value === undefined) return undefined;
+	try {
+		const serialized = JSON.stringify(sanitizeData(value, 0, new WeakSet()));
+		if (serialized.length <= MAX_DATA_CHARS) return serialized;
+		let previewChars = MAX_DATA_CHARS - 64;
+		for (;;) {
+			const bounded = JSON.stringify({ truncated: true, preview: serialized.slice(0, previewChars) });
+			if (bounded.length <= MAX_DATA_CHARS) return bounded;
+			previewChars -= bounded.length - MAX_DATA_CHARS;
+		}
+	} catch {
+		return undefined;
+	}
+}
+
+function safeTraceId(value: unknown): string | undefined {
+	if (typeof value !== "string") return undefined;
+	const trimmed = value.trim();
+	if (!trimmed || trimmed.length > MAX_TRACE_ID_CHARS || !/^[A-Za-z0-9._:/-]+$/.test(trimmed)) return undefined;
+	return trimmed;
+}
+
+function findTraceId(value: unknown, depth = 0): string | undefined {
+	if (depth > MAX_DATA_DEPTH || !isRecord(value)) return undefined;
+	for (const key in value) {
+		const item = value[key];
+		if (TRACE_KEYS.test(key)) {
+			const traceId = safeTraceId(item);
+			if (traceId) return traceId;
+		}
+		const nested = findTraceId(item, depth + 1);
+		if (nested) return nested;
+	}
+	return undefined;
+}
+
+/** Extract a safe request or trace identifier from MCP HTTP response headers. */
+export function mcpTraceIdFromHeaders(headers: Headers): string | undefined {
+	for (const name of ["traceparent", "x-request-id", "x-trace-id", "x-correlation-id", "cf-ray"]) {
+		const traceId = safeTraceId(headers.get(name));
+		if (traceId) return traceId;
+	}
+	return undefined;
+}
+
+/** Preserve a server-provided JSON-RPC error without exposing credential-shaped data. */
+export function createMCPJsonRpcError(
+	transport: MCPTransportKind,
+	error: JsonRpcError,
+	traceId?: string,
+): MCPTransportError {
+	return new MCPTransportError({
+		transport,
+		stage: "protocol",
+		failure: "json_rpc",
+		message: `MCP error ${error.code}: ${error.message}`,
+		retryable: false,
+		code: error.code,
+		data: serializeData(error.data),
+		traceId: safeTraceId(traceId) ?? findTraceId(error.data),
+	});
+}
+
+/** Classify an arbitrary transport exception while removing runtime-only advice. */
+export function normalizeMCPTransportError(
+	error: unknown,
+	options: { transport: MCPTransportKind; stage: MCPFailureStage; traceId?: string },
+): MCPTransportError {
+	if (error instanceof MCPTransportError) return error;
+	const message = sanitizeDiagnosticText(error instanceof Error ? error.message : String(error), MAX_MESSAGE_CHARS);
+	let code = errorCode(error);
+	const normalizedCode = typeof code === "string" ? code.toUpperCase() : code;
+	const httpStatusMatch = /^HTTP (\d{3}):/i.exec(message);
+	let failure: MCPFailureClass = "unknown";
+	let retryable = false;
+
+	if (
+		normalizedCode === "ECONNREFUSED" ||
+		normalizedCode === "CONNECTIONREFUSED" ||
+		normalizedCode === "ENETUNREACH" ||
+		normalizedCode === "EHOSTUNREACH" ||
+		/\b(?:ECONNREFUSED|ConnectionRefused|ENETUNREACH|EHOSTUNREACH)\b/i.test(message)
+	) {
+		failure = "connect";
+		retryable = true;
+	} else if (normalizedCode === "ECONNRESET" || /\bECONNRESET\b/i.test(message)) {
+		failure = "reset";
+		retryable = true;
+	} else if (normalizedCode === "EPIPE" || /\b(?:EPIPE|eof|transport closed|socket closed)\b/i.test(message)) {
+		failure = "eof";
+		retryable = true;
+	} else if (/timeout|timed out/i.test(message)) {
+		failure = "timeout";
+		retryable = false;
+	} else if (
+		error instanceof SyntaxError ||
+		/(?:invalid|unexpected end).*(?:json|jsonl)|jsonl? (?:parse|parser) error|malformed/i.test(message)
+	) {
+		failure = "malformed_response";
+	} else if (httpStatusMatch) {
+		code = Number(httpStatusMatch[1]);
+		failure = "http_status";
+		retryable = code === 404 || code === 502 || code === 503;
+	} else if (/not connected|connection failed|fetch failed/i.test(message)) {
+		failure = "connect";
+		retryable = true;
+	}
+
+	return new MCPTransportError({
+		transport: options.transport,
+		stage: failure === "connect" ? "connect" : failure === "malformed_response" ? "decode" : options.stage,
+		failure,
+		message: message || "Unknown MCP transport failure",
+		retryable,
+		code,
+		traceId: safeTraceId(options.traceId),
+		cause: error,
+	});
+}
+
+function nextStep(error: MCPTransportError): string {
+	switch (error.failure) {
+		case "connect":
+			return "Check that the MCP server is running and reachable, then retry.";
+		case "timeout":
+			return "Check server health or increase the MCP timeout; the request outcome is unknown.";
+		case "eof":
+		case "reset":
+			return error.transport === "stdio"
+				? "Inspect the MCP subprocess logs, restart the server, then retry."
+				: "Check the MCP server logs and availability, then retry.";
+		case "malformed_response":
+			return "Inspect the MCP server logs for an invalid JSON-RPC response.";
+		case "json_rpc":
+			return "Address the server-reported MCP error before retrying.";
+		case "http_status":
+			return error.retryable
+				? "Check the MCP server status, then retry."
+				: "Check the MCP endpoint and authentication configuration.";
+		case "closed":
+			return "Reconnect the MCP server, then retry.";
+		case "unknown":
+			return "Inspect the MCP server logs and transport configuration.";
+	}
+}
+
+/** Render an MCP tool failure as stable, actionable diagnostic fields. */
+export function formatMCPToolFailure(error: unknown, serverName: string, toolName: string): string {
+	const diagnostic =
+		error instanceof MCPTransportError
+			? error
+			: normalizeMCPTransportError(error, { transport: "unknown", stage: "protocol" });
+	const lines = [
+		"MCP failure",
+		`server: ${sanitizeDiagnosticText(serverName, MAX_MESSAGE_CHARS)}`,
+		`tool: ${sanitizeDiagnosticText(toolName, MAX_MESSAGE_CHARS)}`,
+		`transport: ${diagnostic.transport}`,
+		`stage: ${diagnostic.stage}`,
+		`failure: ${diagnostic.failure}`,
+		`retryable: ${diagnostic.retryable ? "yes" : "no"}`,
+		`message: ${diagnostic.message}`,
+	];
+	if (diagnostic.code !== undefined) lines.push(`code: ${String(diagnostic.code)}`);
+	if (diagnostic.traceId !== undefined) lines.push(`trace_id: ${diagnostic.traceId}`);
+	if (diagnostic.data !== undefined) lines.push(`data: ${diagnostic.data}`);
+	lines.push(`next: ${nextStep(diagnostic)}`);
+	return lines.join("\n");
+}

--- a/packages/coding-agent/src/mcp/errors.ts
+++ b/packages/coding-agent/src/mcp/errors.ts
@@ -39,8 +39,11 @@ const MAX_DATA_DEPTH = 5;
 const MAX_DATA_ENTRIES = 30;
 const FETCH_VERBOSE_ADVICE =
 	/\s*For more information, pass `verbose: true` in the second argument to fetch\(\)\.?\s*$/i;
+// Substring match, not exact: compound names (`client_secret`, `clientSecret`,
+// `private_key`, `signingSecret`, `access_token`) must classify as secrets so
+// their values never reach the exposed `data:` diagnostic.
 const SECRET_KEY =
-	/^(?:authorization|cookie|set-cookie|api[-_]?key|access[-_]?token|refresh[-_]?token|token|secret|password)$/i;
+	/(?:authorization|bearer|cookie|secret|passw(?:or)?d|pwd|token|credential|api[-_]?key|private[-_]?key|access[-_]?key|signature)/i;
 const TRACE_KEYS = /^(?:trace[-_]?id|request[-_]?id|correlation[-_]?id|traceparent)$/i;
 
 export class MCPTransportError extends Error {
@@ -86,7 +89,10 @@ function sanitizeDiagnosticText(value: string, maxChars: number): string {
 		.replace(FETCH_VERBOSE_ADVICE, "")
 		.replace(/\b(Bearer|Basic)\s+[^\s,;]+/gi, "$1 [redacted]")
 		.replace(/([?&](?:access[-_]?token|api[-_]?key|key|token|secret|password)=)[^&#\s]+/gi, "$1[redacted]")
-		.replace(/((?:authorization|api[-_]?key|token|secret|password)\s*[:=]\s*)[^\s,;}]+/gi, "$1[redacted]")
+		.replace(
+			/((?:authorization|api[-_]?key|private[-_]?key|access[-_]?key|token|secret|passw(?:or)?d|pwd|credential)\s*[:=]\s*)[^\s,;}]+/gi,
+			"$1[redacted]",
+		)
 		.slice(0, maxChars)
 		.trim();
 }

--- a/packages/coding-agent/src/mcp/tool-bridge.ts
+++ b/packages/coding-agent/src/mcp/tool-bridge.ts
@@ -21,6 +21,7 @@ import type { OutputMeta } from "../tools/output-meta";
 import { normalizeLocalScheme } from "../tools/path-utils";
 import { ToolAbortError, throwIfAborted } from "../tools/tool-errors";
 import { callTool } from "./client";
+import { formatMCPToolFailure, MCPTransportError } from "./errors";
 import { renderMCPCall, renderMCPResult } from "./render";
 import type {
 	MCPAuthChallenge,
@@ -50,9 +51,19 @@ const RETRIABLE_PATTERNS = [
 	"transport closed",
 	"network error",
 ];
-
 export function isRetriableConnectionError(error: unknown): boolean {
 	if (!(error instanceof Error)) return false;
+	if (error instanceof MCPTransportError) {
+		if (
+			error.failure === "connect" ||
+			error.failure === "reset" ||
+			error.failure === "eof" ||
+			error.failure === "closed"
+		) {
+			return true;
+		}
+		return error.failure === "http_status" && (error.code === 404 || error.code === 502 || error.code === 503);
+	}
 	const msg = error.message.toLowerCase();
 	// Stale session (server restarted, old session ID is gone)
 	if (/^http (404|502|503):/.test(msg)) return true;
@@ -267,9 +278,9 @@ function buildErrorResult(
 	provider?: string,
 	providerName?: string,
 ): CustomToolResult<MCPToolDetails> {
-	const message = error instanceof Error ? error.message : String(error);
+	const message = formatMCPToolFailure(error, serverName, mcpToolName);
 	return {
-		content: [{ type: "text", text: `MCP error: ${message}` }],
+		content: [{ type: "text", text: message }],
 		details: { serverName, mcpToolName, isError: true, provider, providerName },
 		isError: true,
 	};

--- a/packages/coding-agent/src/mcp/tool-bridge.ts
+++ b/packages/coding-agent/src/mcp/tool-bridge.ts
@@ -60,7 +60,7 @@ export function isRetriableConnectionError(error: unknown): boolean {
 			error.failure === "eof" ||
 			error.failure === "closed"
 		) {
-			return true;
+			return error.retryable;
 		}
 		return error.failure === "http_status" && (error.code === 404 || error.code === 502 || error.code === 503);
 	}

--- a/packages/coding-agent/src/mcp/transports/http.ts
+++ b/packages/coding-agent/src/mcp/transports/http.ts
@@ -618,7 +618,7 @@ export class HttpTransport implements MCPTransport {
 							stage: "receive",
 							failure: "eof",
 							message: `No response received for request ID ${expectedId}`,
-							retryable: true,
+							retryable: false,
 							traceId,
 						});
 					}

--- a/packages/coding-agent/src/mcp/transports/http.ts
+++ b/packages/coding-agent/src/mcp/transports/http.ts
@@ -6,18 +6,24 @@
  * header on every request (see `MCP_PROTOCOL_VERSION`).
  */
 import * as AIError from "@oh-my-pi/pi-ai/error";
-import { logger, postmortem, readSseEvents, readSseJson } from "@oh-my-pi/pi-utils";
+import { isRecord, logger, postmortem, readSseEvents, readSseJson } from "@oh-my-pi/pi-utils";
 import type {
 	JsonRpcError,
 	JsonRpcMessage,
 	JsonRpcRequest,
-	JsonRpcResponse,
 	MCPHttpServerConfig,
 	MCPRequestOptions,
 	MCPSseServerConfig,
 	MCPTransport,
 } from "../../mcp/types";
 import { toJsonRpcError } from "../../mcp/types";
+import {
+	createMCPJsonRpcError,
+	type MCPFailureStage,
+	MCPTransportError,
+	mcpTraceIdFromHeaders,
+	normalizeMCPTransportError,
+} from "../errors";
 import { RequestIdAllocator } from "../request-id";
 import { createMCPTimeout, getNeverAbortSignal, isMCPTimeoutEnabled, resolveMCPTimeoutMs } from "../timeout";
 import { type MCPFetchInit, mcpFetch, withoutHeader } from "./header-policy";
@@ -416,7 +422,13 @@ export class HttpTransport implements MCPTransport {
 		options: MCPRequestOptions | undefined,
 	): Promise<T> {
 		if (!this.#connected) {
-			throw new Error("Transport not connected");
+			throw new MCPTransportError({
+				transport: "http",
+				stage: "connect",
+				failure: "closed",
+				message: "Transport not connected",
+				retryable: true,
+			});
 		}
 
 		const id = this.#requestIds.next(this.config.requestIdFormat);
@@ -438,12 +450,16 @@ export class HttpTransport implements MCPTransport {
 
 		const timeout = resolveMCPTimeoutMs(this.config.timeout);
 		const operation = createMCPTimeout(timeout, this.#operationSignal(options?.signal));
+		let stage: MCPFailureStage = "send";
+		let traceId: string | undefined;
 
 		try {
 			const response = await this.#fetch(
 				{ method: "POST", body: JSON.stringify(body), signal: operation.signal },
 				generated,
 			);
+			stage = "receive";
+			traceId = mcpTraceIdFromHeaders(response.headers);
 
 			// Check for session ID in response
 			const newSessionId = response.headers.get("Mcp-Session-Id");
@@ -462,7 +478,15 @@ export class HttpTransport implements MCPTransport {
 					.filter(Boolean)
 					.join("; ");
 				const suffix = authHints ? ` [${authHints}]` : "";
-				throw new Error(`HTTP ${response.status}: ${text}${suffix}`);
+				throw new MCPTransportError({
+					transport: "http",
+					stage,
+					failure: "http_status",
+					message: `HTTP ${response.status}: ${text}${suffix}`,
+					retryable: response.status === 404 || response.status === 502 || response.status === 503,
+					code: response.status,
+					traceId,
+				});
 			}
 
 			const contentType = response.headers.get("Content-Type") ?? "";
@@ -472,27 +496,58 @@ export class HttpTransport implements MCPTransport {
 				return this.#parseSSEResponse<T>(response, id, options);
 			}
 
+			stage = "decode";
 			// Handle JSON response
-			const result = (await response.json()) as JsonRpcResponse;
-
-			if (result.error) {
-				throw new Error(`MCP error ${result.error.code}: ${result.error.message}`);
+			const result: unknown = await response.json();
+			if (!isRecord(result) || result.jsonrpc !== "2.0" || (!("result" in result) && !("error" in result))) {
+				throw new SyntaxError("Malformed JSON-RPC response");
+			}
+			if (result.error !== undefined) {
+				if (
+					!isRecord(result.error) ||
+					typeof result.error.code !== "number" ||
+					typeof result.error.message !== "string"
+				) {
+					throw new SyntaxError("Malformed JSON-RPC error response");
+				}
+				throw createMCPJsonRpcError(
+					"http",
+					{ code: result.error.code, message: result.error.message, data: result.error.data },
+					traceId,
+				);
 			}
 
 			return result.result as T;
 		} catch (error) {
 			if (operation.isTimeoutAbort(error) || operation.timedOut()) {
-				throw new Error(`Request timeout after ${timeout}ms`);
+				throw new MCPTransportError({
+					transport: "http",
+					stage,
+					failure: "timeout",
+					message: `Request timeout after ${timeout}ms`,
+					retryable: false,
+					traceId,
+					cause: error,
+				});
 			}
-			throw error;
+			if (error instanceof Error && error.name === "AbortError") throw error;
+			throw normalizeMCPTransportError(error, { transport: "http", stage, traceId });
 		} finally {
 			operation.clear();
 		}
 	}
 
 	#parseSSEResponse<T>(response: Response, expectedId: string | number, options?: MCPRequestOptions): Promise<T> {
+		const traceId = mcpTraceIdFromHeaders(response.headers);
 		if (!response.body) {
-			throw new Error("No response body");
+			throw new MCPTransportError({
+				transport: "http",
+				stage: "decode",
+				failure: "malformed_response",
+				message: "SSE response did not include a body",
+				retryable: false,
+				traceId,
+			});
 		}
 
 		const timeout = resolveMCPTimeoutMs(this.config.timeout);
@@ -532,7 +587,7 @@ export class HttpTransport implements MCPTransport {
 									captured = true;
 									operation.clear();
 									if (message.error) {
-										reject(new Error(`MCP error ${message.error.code}: ${message.error.message}`));
+										reject(createMCPJsonRpcError("http", message.error, traceId));
 									} else {
 										resolve(message.result as T);
 									}
@@ -558,16 +613,41 @@ export class HttpTransport implements MCPTransport {
 						throw signal.reason ?? new DOMException("MCP SSE response aborted", "AbortError");
 					}
 					if (resume.lastEventId === null) {
-						throw new Error(`No response received for request ID ${expectedId}`);
+						throw new MCPTransportError({
+							transport: "http",
+							stage: "receive",
+							failure: "eof",
+							message: `No response received for request ID ${expectedId}`,
+							retryable: true,
+							traceId,
+						});
 					}
 					current = await this.#fetchSSEResume(resume, signal);
 				}
 			} catch (error) {
 				if (captured) return;
 				if (operation.isTimeoutAbort(error)) {
-					reject(new Error(`SSE response timeout after ${timeout}ms`));
+					reject(
+						new MCPTransportError({
+							transport: "http",
+							stage: "receive",
+							failure: "timeout",
+							message: `SSE response timeout after ${timeout}ms`,
+							retryable: false,
+							traceId,
+							cause: error,
+						}),
+					);
+				} else if (error instanceof Error && error.name === "AbortError") {
+					reject(error);
 				} else {
-					reject(error as Error);
+					reject(
+						normalizeMCPTransportError(error, {
+							transport: "http",
+							stage: error instanceof SyntaxError ? "decode" : "receive",
+							traceId,
+						}),
+					);
 				}
 			} finally {
 				operation.clear();
@@ -645,7 +725,13 @@ export class HttpTransport implements MCPTransport {
 
 	async #sendNotification(method: string, params?: Record<string, unknown>): Promise<void> {
 		if (!this.#connected) {
-			throw new Error("Transport not connected");
+			throw new MCPTransportError({
+				transport: "http",
+				stage: "connect",
+				failure: "closed",
+				message: "Transport not connected",
+				retryable: true,
+			});
 		}
 
 		const body = {
@@ -665,17 +751,29 @@ export class HttpTransport implements MCPTransport {
 
 		const timeout = resolveMCPTimeoutMs(this.config.timeout);
 		const operation = createMCPTimeout(timeout, this.#operationSignal());
+		let stage: MCPFailureStage = "send";
+		let traceId: string | undefined;
 
 		try {
 			const response = await this.#fetch(
 				{ method: "POST", body: JSON.stringify(body), signal: operation.signal },
 				generated,
 			);
+			stage = "receive";
+			traceId = mcpTraceIdFromHeaders(response.headers);
 
 			// 202 Accepted is success for notifications
 			if (!response.ok && response.status !== 202) {
 				const text = await response.text();
-				throw new Error(`HTTP ${response.status}: ${text}`);
+				throw new MCPTransportError({
+					transport: "http",
+					stage,
+					failure: "http_status",
+					message: `HTTP ${response.status}: ${text}`,
+					retryable: response.status === 404 || response.status === 502 || response.status === 503,
+					code: response.status,
+					traceId,
+				});
 			}
 
 			// The server may piggyback server-to-client requests or notifications
@@ -699,9 +797,18 @@ export class HttpTransport implements MCPTransport {
 			}
 		} catch (error) {
 			if (operation.isTimeoutAbort(error)) {
-				throw new Error(`Notify timeout after ${timeout}ms`);
+				throw new MCPTransportError({
+					transport: "http",
+					stage,
+					failure: "timeout",
+					message: `Notify timeout after ${timeout}ms`,
+					retryable: false,
+					traceId,
+					cause: error,
+				});
 			}
-			throw error;
+			if (error instanceof Error && error.name === "AbortError") throw error;
+			throw normalizeMCPTransportError(error, { transport: "http", stage, traceId });
 		} finally {
 			operation.clear();
 		}

--- a/packages/coding-agent/src/mcp/transports/http.ts
+++ b/packages/coding-agent/src/mcp/transports/http.ts
@@ -626,7 +626,16 @@ export class HttpTransport implements MCPTransport {
 				}
 			} catch (error) {
 				if (captured) return;
-				if (operation.isTimeoutAbort(error)) {
+				// The server accepted this POST (it returned a 2xx SSE stream) before
+				// the drain or a resume GET failed, so the originating request must
+				// never be replayed — it may already have executed a state-changing
+				// tool. Preserve SSEResumeError so #requestWithAuthRetry's no-replay
+				// guard still fires instead of refreshing auth and re-POSTing, and
+				// force every other post-acceptance failure non-retryable so the
+				// reconnect path in isRetriableConnectionError cannot replay it.
+				if (error instanceof SSEResumeError || (error instanceof Error && error.name === "AbortError")) {
+					reject(error);
+				} else if (operation.isTimeoutAbort(error)) {
 					reject(
 						new MCPTransportError({
 							transport: "http",
@@ -638,15 +647,26 @@ export class HttpTransport implements MCPTransport {
 							cause: error,
 						}),
 					);
-				} else if (error instanceof Error && error.name === "AbortError") {
-					reject(error);
 				} else {
+					const normalized = normalizeMCPTransportError(error, {
+						transport: "http",
+						stage: error instanceof SyntaxError ? "decode" : "receive",
+						traceId,
+					});
 					reject(
-						normalizeMCPTransportError(error, {
-							transport: "http",
-							stage: error instanceof SyntaxError ? "decode" : "receive",
-							traceId,
-						}),
+						normalized.retryable
+							? new MCPTransportError({
+									transport: normalized.transport,
+									stage: normalized.stage,
+									failure: normalized.failure,
+									message: normalized.message,
+									retryable: false,
+									code: normalized.code,
+									data: normalized.data,
+									traceId: normalized.traceId,
+									cause: normalized,
+								})
+							: normalized,
 					);
 				}
 			} finally {

--- a/packages/coding-agent/src/mcp/transports/stdio.ts
+++ b/packages/coding-agent/src/mcp/transports/stdio.ts
@@ -20,6 +20,7 @@ import type {
 	MCPTransport,
 } from "../../mcp/types";
 import { toJsonRpcError } from "../../mcp/types";
+import { createMCPJsonRpcError, MCPTransportError, normalizeMCPTransportError } from "../errors";
 import { RequestIdAllocator } from "../request-id";
 import { isMCPTimeoutEnabled, resolveMCPTimeoutMs } from "../timeout";
 
@@ -620,21 +621,40 @@ export class StdioTransport implements MCPTransport {
 
 	async #startReadLoop(): Promise<void> {
 		if (!this.#process?.stdout) return;
+		let closeError: MCPTransportError | undefined;
 		try {
 			for await (const line of readJsonl(this.#process.stdout)) {
 				if (!this.#connected) break;
 				try {
 					this.#handleMessage(line as JsonRpcMessage);
 				} catch {
-					// Skip malformed lines
+					// Skip malformed message shapes; malformed JSON is handled by readJsonl.
 				}
 			}
 		} catch (error) {
+			closeError = normalizeMCPTransportError(error, {
+				transport: "stdio",
+				stage: error instanceof SyntaxError ? "decode" : "receive",
+			});
 			if (this.#connected) {
-				this.onError?.(error instanceof Error ? error : new Error(String(error)));
+				this.onError?.(closeError);
 			}
 		} finally {
-			this.#handleClose();
+			if (this.#connected && closeError === undefined) {
+				const exitCode = this.#process?.exitCode;
+				closeError = new MCPTransportError({
+					transport: "stdio",
+					stage: "receive",
+					failure: "eof",
+					message:
+						exitCode === null || exitCode === undefined
+							? "MCP subprocess closed stdout before responding"
+							: `MCP subprocess exited with code ${exitCode} before responding`,
+					retryable: true,
+					code: exitCode ?? undefined,
+				});
+			}
+			this.#handleClose(closeError);
 		}
 	}
 
@@ -680,7 +700,7 @@ export class StdioTransport implements MCPTransport {
 			if (pending) {
 				this.#pendingRequests.delete(response.id);
 				if (response.error) {
-					pending.reject(new Error(`MCP error ${response.error.code}: ${response.error.message}`));
+					pending.reject(createMCPJsonRpcError("stdio", response.error));
 				} else {
 					pending.resolve(response.result);
 				}
@@ -718,13 +738,21 @@ export class StdioTransport implements MCPTransport {
 		writeFrame(this.#process.stdin, `${JSON.stringify(response)}\n`);
 	}
 
-	#handleClose(): void {
+	#handleClose(error?: Error): void {
 		if (!this.#connected) return;
 		this.#connected = false;
 
-		// Reject all pending requests
+		const closeError =
+			error ??
+			new MCPTransportError({
+				transport: "stdio",
+				stage: "receive",
+				failure: "closed",
+				message: "Transport closed",
+				retryable: true,
+			});
 		for (const [, pending] of this.#pendingRequests) {
-			pending.reject(new Error("Transport closed"));
+			pending.reject(closeError);
 		}
 		this.#pendingRequests.clear();
 
@@ -737,7 +765,13 @@ export class StdioTransport implements MCPTransport {
 		options?: MCPRequestOptions,
 	): Promise<T> {
 		if (!this.#connected || !this.#process?.stdin) {
-			throw new Error("Transport not connected");
+			throw new MCPTransportError({
+				transport: "stdio",
+				stage: "connect",
+				failure: "closed",
+				message: "Transport not connected",
+				retryable: true,
+			});
 		}
 
 		const id = this.#requestIds.next(this.config.requestIdFormat);
@@ -797,7 +831,15 @@ export class StdioTransport implements MCPTransport {
 		if (isMCPTimeoutEnabled(timeout)) {
 			timer = setTimeout(() => {
 				cleanup();
-				reject(new Error(`Request timeout after ${timeout}ms`));
+				reject(
+					new MCPTransportError({
+						transport: "stdio",
+						stage: "receive",
+						failure: "timeout",
+						message: `Request timeout after ${timeout}ms`,
+						retryable: false,
+					}),
+				);
 			}, timeout);
 		}
 
@@ -806,7 +848,7 @@ export class StdioTransport implements MCPTransport {
 		const failFromSend = (error: unknown) => {
 			if (settled) return;
 			cleanup();
-			reject(error instanceof Error ? error : new Error(String(error)));
+			reject(normalizeMCPTransportError(error, { transport: "stdio", stage: "send" }));
 		};
 		try {
 			// Never `await` write/flush. Bun's FileSink returns a pending Promise
@@ -831,7 +873,13 @@ export class StdioTransport implements MCPTransport {
 
 	async notify(method: string, params?: Record<string, unknown>): Promise<void> {
 		if (!this.#connected || !this.#process?.stdin) {
-			throw new Error("Transport not connected");
+			throw new MCPTransportError({
+				transport: "stdio",
+				stage: "connect",
+				failure: "closed",
+				message: "Transport not connected",
+				retryable: true,
+			});
 		}
 
 		const notification = {
@@ -851,8 +899,15 @@ export class StdioTransport implements MCPTransport {
 		// `onClose` handler, so a swallowed failure there would yield a
 		// "connected" handle wrapping a dead transport. See #1710.
 		if (!writeFrame(this.#process.stdin, `${JSON.stringify(notification)}\n`)) {
-			this.#handleClose();
-			throw new Error(`Transport closed while sending notification "${method}"`);
+			const error = new MCPTransportError({
+				transport: "stdio",
+				stage: "send",
+				failure: "eof",
+				message: `Transport closed while sending notification "${method}"`,
+				retryable: true,
+			});
+			this.#handleClose(error);
+			throw error;
 		}
 	}
 
@@ -904,6 +959,10 @@ export class StdioTransport implements MCPTransport {
  */
 export async function createStdioTransport(config: MCPStdioServerConfig): Promise<StdioTransport> {
 	const transport = new StdioTransport(config);
-	await transport.connect();
-	return transport;
+	try {
+		await transport.connect();
+		return transport;
+	} catch (error) {
+		throw normalizeMCPTransportError(error, { transport: "stdio", stage: "connect" });
+	}
 }

--- a/packages/coding-agent/test/mcp-http-transport.test.ts
+++ b/packages/coding-agent/test/mcp-http-transport.test.ts
@@ -579,6 +579,25 @@ describe("MCP Streamable HTTP POST response resumption", () => {
 		expect(observed.auth).toEqual(["Bearer stale", "Bearer fresh"]);
 		expect(observed.lastEventId).toBe("stream-1");
 	});
+	it("marks a clean accepted SSE EOF without an event ID as non-replayable", async () => {
+		let posts = 0;
+		server = Bun.serve({
+			port: 0,
+			fetch() {
+				posts++;
+				return new Response("", { headers: { "Content-Type": "text/event-stream" } });
+			},
+		});
+		const transport = await connectedTransport();
+
+		await expect(withPendingGuard(transport.request("tools/call"), "request")).rejects.toMatchObject({
+			transport: "http",
+			stage: "receive",
+			failure: "eof",
+			retryable: false,
+		});
+		expect(posts).toBe(1);
+	});
 });
 
 describe("MCP Streamable HTTP GET listener resumption", () => {

--- a/packages/coding-agent/test/mcp-http-transport.test.ts
+++ b/packages/coding-agent/test/mcp-http-transport.test.ts
@@ -579,6 +579,44 @@ describe("MCP Streamable HTTP POST response resumption", () => {
 		expect(observed.auth).toEqual(["Bearer stale", "Bearer fresh"]);
 		expect(observed.lastEventId).toBe("stream-1");
 	});
+
+	it("never replays the POST when a resume GET stays unauthorized", async () => {
+		const observed = { posts: 0, gets: 0, refreshes: 0 };
+		server = Bun.serve({
+			port: 0,
+			fetch(req) {
+				if (req.method === "POST") {
+					observed.posts++;
+					return new Response("id: stream-1\nretry: 10\ndata:\n\n", {
+						headers: { "Content-Type": "text/event-stream" },
+					});
+				}
+				observed.gets++;
+				return new Response("expired", { status: 401 });
+			},
+		});
+		if (!server) throw new Error("Test server was not started");
+		const transport = new HttpTransport({
+			type: "http",
+			url: `http://127.0.0.1:${server.port}/mcp`,
+			timeout: GUARD_TIMEOUT_MS,
+			headers: { Authorization: "Bearer stale" },
+		});
+		// A live refresh would tempt #requestWithAuthRetry to re-POST if the
+		// SSEResumeError identity were lost during normalization.
+		transport.onAuthError = async () => {
+			observed.refreshes++;
+			return { Authorization: "Bearer fresh" };
+		};
+		await transport.connect();
+
+		await expect(withPendingGuard(transport.request("tools/call"), "request")).rejects.toBeDefined();
+		// The server accepted the POST once; auth refresh happens inside the resume
+		// GET only, and the originating POST is never replayed.
+		expect(observed.posts).toBe(1);
+		expect(observed.gets).toBe(2);
+		expect(observed.refreshes).toBe(1);
+	});
 	it("marks a clean accepted SSE EOF without an event ID as non-replayable", async () => {
 		let posts = 0;
 		server = Bun.serve({

--- a/packages/coding-agent/test/mcp-http-transport.test.ts
+++ b/packages/coding-agent/test/mcp-http-transport.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
 import { connectToServer } from "@oh-my-pi/pi-coding-agent/mcp/client";
+import { MCPTransportError } from "@oh-my-pi/pi-coding-agent/mcp/errors";
 import { HttpTransport } from "@oh-my-pi/pi-coding-agent/mcp/transports/http";
 import { postmortem } from "@oh-my-pi/pi-utils";
 
@@ -103,6 +104,125 @@ describe("MCP Streamable HTTP initialization", () => {
 	});
 });
 
+describe("MCP Streamable HTTP failure diagnostics", () => {
+	it("classifies an abrupt socket reset without leaking Bun fetch advice", async () => {
+		const tcp = Bun.listen({
+			hostname: "127.0.0.1",
+			port: 0,
+			socket: {
+				open(socket) {
+					socket.end();
+				},
+				data() {},
+			},
+		});
+		const transport = new HttpTransport({
+			type: "http",
+			url: `http://127.0.0.1:${tcp.port}/mcp`,
+			timeout: GUARD_TIMEOUT_MS,
+		});
+		try {
+			await transport.connect();
+			const error = await transport.request("tools/list").then(
+				() => undefined,
+				reason => reason,
+			);
+			if (!(error instanceof MCPTransportError)) throw error;
+			expect(error).toMatchObject({
+				transport: "http",
+				stage: "send",
+				failure: "reset",
+				retryable: true,
+				code: "ECONNRESET",
+			});
+			expect(error.message).not.toContain("verbose");
+		} finally {
+			await transport.close();
+			tcp.stop(true);
+		}
+	});
+
+	it("distinguishes connection refusal from a reset", async () => {
+		const unused = Bun.listen({
+			hostname: "127.0.0.1",
+			port: 0,
+			socket: { data() {} },
+		});
+		const port = unused.port;
+		unused.stop(true);
+		const transport = new HttpTransport({
+			type: "http",
+			url: `http://127.0.0.1:${port}/mcp`,
+			timeout: GUARD_TIMEOUT_MS,
+		});
+		await transport.connect();
+
+		await expect(transport.request("tools/list")).rejects.toMatchObject({
+			transport: "http",
+			stage: "connect",
+			failure: "connect",
+			retryable: true,
+		});
+		await transport.close();
+	});
+
+	it("classifies malformed JSON-RPC responses at the decode stage", async () => {
+		server = Bun.serve({
+			port: 0,
+			fetch() {
+				return new Response("{not-json", { headers: { "Content-Type": "application/json" } });
+			},
+		});
+		const transport = await connectedTransport();
+
+		await expect(transport.request("tools/list")).rejects.toMatchObject({
+			transport: "http",
+			stage: "decode",
+			failure: "malformed_response",
+			retryable: false,
+		});
+	});
+
+	it("preserves bounded redacted JSON-RPC data and a response trace ID", async () => {
+		server = Bun.serve({
+			port: 0,
+			async fetch(req) {
+				const body = (await req.json()) as { id: string | number };
+				return Response.json(
+					{
+						jsonrpc: "2.0",
+						id: body.id,
+						error: {
+							code: -32042,
+							message: "upstream rejected the call",
+							data: { detail: "x".repeat(3_000), token: "server-secret", traceId: "data-trace" },
+						},
+					},
+					{ headers: { "X-Request-Id": "request-abc123" } },
+				);
+			},
+		});
+		const transport = await connectedTransport();
+		const error = await transport.request("tools/list").then(
+			() => undefined,
+			reason => reason,
+		);
+		if (!(error instanceof MCPTransportError)) throw error;
+
+		expect(error).toMatchObject({
+			transport: "http",
+			stage: "protocol",
+			failure: "json_rpc",
+			retryable: false,
+			code: -32042,
+			traceId: "request-abc123",
+		});
+		expect(error.data?.length).toBeLessThanOrEqual(2_000);
+		expect(error.data).toContain("[redacted]");
+		expect(error.data).not.toContain("server-secret");
+	});
+});
+
 describe("MCP Streamable HTTP transport timeouts", () => {
 	it("keeps the request timeout active until a JSON response body is fully read", async () => {
 		server = Bun.serve({
@@ -115,9 +235,13 @@ describe("MCP Streamable HTTP transport timeouts", () => {
 		});
 		const transport = await connectedTransport();
 
-		await expect(withPendingGuard(transport.request("tools/list"), "request")).rejects.toThrow(
-			`Request timeout after ${REQUEST_TIMEOUT_MS}ms`,
-		);
+		await expect(withPendingGuard(transport.request("tools/list"), "request")).rejects.toMatchObject({
+			transport: "http",
+			stage: "decode",
+			failure: "timeout",
+			retryable: false,
+			message: `Request timeout after ${REQUEST_TIMEOUT_MS}ms`,
+		});
 	});
 
 	it("keeps the timeout result when the caller aborts before the JSON body rejection propagates", async () => {

--- a/packages/coding-agent/test/mcp-reconnect.test.ts
+++ b/packages/coding-agent/test/mcp-reconnect.test.ts
@@ -373,6 +373,29 @@ describe("MCPTool.execute retry on connection error", () => {
 		expect(content.text.match(/^next: /gm)).toHaveLength(1);
 	});
 
+	it("redacts compound credential keys in JSON-RPC error data", () => {
+		const error = createMCPJsonRpcError("http", {
+			code: -32001,
+			message: "server echoed its OAuth config",
+			data: {
+				client_secret: "cs-leak",
+				clientSecret: "cs-camel-leak",
+				private_key: "pk-leak",
+				signingSecret: "sign-leak",
+				access_token: "at-leak",
+				apiKey: "ak-leak",
+				note: "safe-detail",
+			},
+		});
+		if (error.data === undefined) throw new Error("Expected serialized error data");
+
+		for (const leaked of ["cs-leak", "cs-camel-leak", "pk-leak", "sign-leak", "at-leak", "ak-leak"]) {
+			expect(error.data).not.toContain(leaked);
+		}
+		expect(error.data).toContain('"note":"safe-detail"');
+		expect(error.data).toContain("[redacted]");
+	});
+
 	it("does not retry when no reconnect callback", async () => {
 		const failTransport = mockTransport(async () => {
 			throw new Error("ECONNREFUSED");

--- a/packages/coding-agent/test/mcp-reconnect.test.ts
+++ b/packages/coding-agent/test/mcp-reconnect.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "bun:test";
+import { createMCPJsonRpcError, MCPTransportError } from "@oh-my-pi/pi-coding-agent/mcp/errors";
 import type { MCPReconnect } from "@oh-my-pi/pi-coding-agent/mcp/tool-bridge";
 import {
 	createMCPToolName,
@@ -143,6 +144,31 @@ describe("isRetriableConnectionError", () => {
 		});
 	}
 
+	it("uses typed transport metadata without retrying ambiguous timeouts", () => {
+		expect(
+			isRetriableConnectionError(
+				new MCPTransportError({
+					transport: "http",
+					stage: "send",
+					failure: "reset",
+					message: "Connection reset",
+					retryable: true,
+				}),
+			),
+		).toBe(true);
+		expect(
+			isRetriableConnectionError(
+				new MCPTransportError({
+					transport: "http",
+					stage: "receive",
+					failure: "timeout",
+					message: "Request timeout",
+					retryable: false,
+				}),
+			),
+		).toBe(false);
+	});
+
 	it("returns false for non-Error values", () => {
 		expect(isRetriableConnectionError("ECONNREFUSED")).toBe(false);
 		expect(isRetriableConnectionError(null)).toBe(false);
@@ -267,7 +293,10 @@ describe("MCPTool.execute retry on connection error", () => {
 		const result = await tool.execute("call-1", {}, noop, noCtx);
 
 		expect(result.details?.isError).toBe(true);
-		expect(result.content[0]).toEqual({ type: "text", text: "MCP error: ECONNRESET" });
+		expect(result.content[0]).toMatchObject({
+			type: "text",
+			text: expect.stringContaining("failure: reset"),
+		});
 	});
 
 	it("does not retry on non-retriable error", async () => {
@@ -287,6 +316,33 @@ describe("MCPTool.execute retry on connection error", () => {
 		expect(result.details?.isError).toBe(true);
 	});
 
+	it("renders server, tool, protocol data, trace ID, retryability, and one next step", async () => {
+		const failTransport = mockTransport(async () => {
+			throw createMCPJsonRpcError("stdio", {
+				code: -32042,
+				message: "upstream rejected the call",
+				data: { detail: "invalid input", token: "server-secret", traceId: "trace-abc123" },
+			});
+		});
+		const tool = new MCPTool(makeConnection(failTransport), TOOL_DEF);
+
+		const result = await tool.execute("call-1", {}, noop, noCtx);
+		const content = result.content[0];
+		if (content?.type !== "text") throw new Error("Expected an MCP text diagnostic");
+
+		expect(content.text).toContain("server: test-server");
+		expect(content.text).toContain("tool: do_stuff");
+		expect(content.text).toContain("transport: stdio");
+		expect(content.text).toContain("stage: protocol");
+		expect(content.text).toContain("failure: json_rpc");
+		expect(content.text).toContain("retryable: no");
+		expect(content.text).toContain("code: -32042");
+		expect(content.text).toContain("trace_id: trace-abc123");
+		expect(content.text).toContain('"token":"[redacted]"');
+		expect(content.text).not.toContain("server-secret");
+		expect(content.text.match(/^next: /gm)).toHaveLength(1);
+	});
+
 	it("does not retry when no reconnect callback", async () => {
 		const failTransport = mockTransport(async () => {
 			throw new Error("ECONNREFUSED");
@@ -296,7 +352,10 @@ describe("MCPTool.execute retry on connection error", () => {
 		const result = await tool.execute("call-1", {}, noop, noCtx);
 
 		expect(result.details?.isError).toBe(true);
-		expect(result.content[0]).toEqual({ type: "text", text: "MCP error: ECONNREFUSED" });
+		expect(result.content[0]).toMatchObject({
+			type: "text",
+			text: expect.stringContaining("failure: connect"),
+		});
 	});
 
 	it("returns error from retry when retry also fails", async () => {
@@ -312,7 +371,10 @@ describe("MCPTool.execute retry on connection error", () => {
 		const result = await tool.execute("call-1", {}, noop, noCtx);
 
 		expect(result.details?.isError).toBe(true);
-		expect(result.content[0]).toEqual({ type: "text", text: "MCP error: HTTP 503: Service Unavailable" });
+		expect(result.content[0]).toMatchObject({
+			type: "text",
+			text: expect.stringContaining("failure: http_status"),
+		});
 	});
 
 	it("preserves provider info from new connection on successful retry", async () => {

--- a/packages/coding-agent/test/mcp-reconnect.test.ts
+++ b/packages/coding-agent/test/mcp-reconnect.test.ts
@@ -316,6 +316,36 @@ describe("MCPTool.execute retry on connection error", () => {
 		expect(result.details?.isError).toBe(true);
 	});
 
+	it("does not reconnect and replay a non-retryable accepted SSE EOF", async () => {
+		let calls = 0;
+		let reconnects = 0;
+		const failTransport = mockTransport(async () => {
+			calls++;
+			throw new MCPTransportError({
+				transport: "http",
+				stage: "receive",
+				failure: "eof",
+				message: "No response received after the server accepted the POST",
+				retryable: false,
+			});
+		});
+		const reconnect: MCPReconnect = async () => {
+			reconnects++;
+			return makeConnection(mockTransport(async () => toolCallResult("duplicated")));
+		};
+		const tool = new MCPTool(makeConnection(failTransport), TOOL_DEF, reconnect);
+
+		const result = await tool.execute("call-1", {}, noop, noCtx);
+
+		expect(calls).toBe(1);
+		expect(reconnects).toBe(0);
+		expect(result.details?.isError).toBe(true);
+		expect(result.content[0]).toMatchObject({
+			type: "text",
+			text: expect.stringContaining("retryable: no"),
+		});
+	});
+
 	it("renders server, tool, protocol data, trace ID, retryability, and one next step", async () => {
 		const failTransport = mockTransport(async () => {
 			throw createMCPJsonRpcError("stdio", {

--- a/packages/coding-agent/test/mcp-stdio-transport.test.ts
+++ b/packages/coding-agent/test/mcp-stdio-transport.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
+import { MCPTransportError } from "@oh-my-pi/pi-coding-agent/mcp/errors";
 import { resolveStdioSpawnCommand, StdioTransport, writeFrame } from "@oh-my-pi/pi-coding-agent/mcp/transports/stdio";
 import { removeWithRetries } from "@oh-my-pi/pi-utils";
 
@@ -764,6 +765,55 @@ describe("StdioTransport.notify", () => {
 		} finally {
 			tracker.release();
 		}
+	});
+});
+
+describe("StdioTransport request failure diagnostics", () => {
+	let transport: StdioTransport | undefined;
+
+	afterEach(async () => {
+		await transport?.close().catch(() => {});
+		transport = undefined;
+	});
+
+	it("reports abrupt subprocess termination as EOF instead of a generic close", async () => {
+		transport = new StdioTransport({
+			type: "stdio",
+			command: "bun",
+			args: ["-e", "process.stdin.once('data', () => process.exit(23)); process.stdin.resume()"],
+			timeout: 1_000,
+		});
+		await transport.connect();
+		const error = await transport.request("tools/list").then(
+			() => undefined,
+			reason => reason,
+		);
+		if (!(error instanceof MCPTransportError)) throw error;
+
+		expect(error).toMatchObject({
+			transport: "stdio",
+			stage: "receive",
+			failure: "eof",
+			retryable: true,
+		});
+		expect(error.message).toContain("MCP subprocess");
+	});
+
+	it("reports malformed subprocess JSON at the decode stage", async () => {
+		transport = new StdioTransport({
+			type: "stdio",
+			command: "bun",
+			args: ["-e", "process.stdin.once('data', () => console.log('{not-json')); process.stdin.resume()"],
+			timeout: 1_000,
+		});
+		await transport.connect();
+
+		await expect(transport.request("tools/list")).rejects.toMatchObject({
+			transport: "stdio",
+			stage: "decode",
+			failure: "malformed_response",
+			retryable: false,
+		});
 	});
 });
 


### PR DESCRIPTION
## Repro
A raw TCP peer that accepts and immediately closes an MCP HTTP POST reproduces the failure in `mcp-http-transport.test.ts`; run `bun test packages/coding-agent/test/mcp-http-transport.test.ts -t 'classifies an abrupt socket reset'`. Before this change, `HttpTransport.request()` returned Bun’s `pass verbose: true` fetch advice without MCP context.

## Cause
`HttpTransport.#executeRequest()` and `StdioTransport.request()` propagated runtime exceptions as plain `Error` values, while `buildErrorResult()` in `packages/coding-agent/src/mcp/tool-bridge.ts` copied only `error.message`. Transport stage, failure class, JSON-RPC data, trace identifiers, and subprocess termination context were discarded before the xd device rendered the result.

## Fix
- Added typed MCP transport diagnostics with stable stage/failure classes, bounded secret redaction, safe trace extraction, retryability, and actionable next steps.
- Classified HTTP connect/reset/timeout/malformed/HTTP/JSON-RPC paths and stdio EOF/send/timeout/malformed/JSON-RPC paths at their source.
- Rendered server/tool context through the existing MCP text-result contract without changing xd schemas or successful calls.
- Added HTTP, subprocess abrupt-termination, malformed-response, JSON-RPC preservation/redaction, retry-policy, and tool-rendering coverage plus a changelog entry.

## Verification
`bun test packages/coding-agent/test/mcp-http-transport.test.ts packages/coding-agent/test/mcp-stdio-transport.test.ts packages/coding-agent/test/mcp-reconnect.test.ts` passed 88 tests with 0 failures. `bun run check:types` passed in `packages/coding-agent`. A manual raw-socket smoke run produced `failure: reset`, `code: ECONNRESET`, one next step, and no `verbose` advice. The pre-publish `bun check` gate passed. Fixes #10093