### PR TITLE
fix(browser): don't pin viewport on visible headless launches

### DIFF
--- a/packages/coding-agent/src/tools/browser/tab-supervisor.ts
+++ b/packages/coding-agent/src/tools/browser/tab-supervisor.ts
@@ -763,7 +763,14 @@ async function buildInitPayload(browser: PuppeteerBrowserHandle, opts: AcquireTa
 	const safeDir = getPuppeteerDir();
 	const browserWSEndpoint = browser.browser.wsEndpoint();
 	if (!browserWSEndpoint) throw new ToolError("Browser websocket endpoint is unavailable");
-	if (browser.kind.kind === "headless") {
+	// Only a truly hidden launch runs the headless tab worker, which pins the
+	// page to a fixed viewport (CDP Emulation.setDeviceMetricsOverride) for
+	// deterministic screenshots. A "visible" headless kind (browser.headless:
+	// false) is a real window the user resizes; the headless path would lock
+	// its content at a fixed size and leave a gray letterbox when the OS window
+	// grows. Attach to the visible page instead — that path never overrides the
+	// viewport, so the window resizes naturally.
+	if (browser.kind.kind === "headless" && browser.kind.headless) {
 		return {
 			mode: "headless",
 			browserWSEndpoint,


### PR DESCRIPTION
## Problem

When `browser.headless: false` (visible mode), OMP launches a real Chrome window, but the tab worker still runs in the **headless** code path:

- `buildInitPayload` in `tab-supervisor.ts` routes every `{ kind: "headless" }` browser to `mode: "headless"`, ignoring the `headless` visibility flag.
- The headless tab worker calls `applyViewport(page, viewport)` → CDP `Emulation.setDeviceMetricsOverride({ width: 1365, height: 768, deviceScaleFactor: 1.25 })`, which **pins the page's layout viewport** (and DPR) regardless of the OS window size.
- Result: when the user drags the window larger, the content stays a fixed 1365×768 and a gray/empty letterbox appears around it — exactly like DevTools device emulation mode.

`--window-size=1365,768` is passed at launch but is not the cause (a plain launch resizes normally; verified empirically).

## Fix

Gate the headless tab-worker mode on the visibility flag:

```ts
if (browser.kind.kind === "headless" && browser.kind.headless) { … mode: "headless" … }
```

A **visible** headless launch now flows through the existing **attach** path (`mode: "attach"` + `targetId`), which never calls `applyViewport`/`Emulation.setDeviceMetricsOverride` — so the window resizes naturally. True hidden headless launches keep the deterministic-viewport behavior for screenshots.

## Validation

- Reproduced the pinned 1365×768 viewport (and forced DPR 1.25) on the real headed Chrome-for-Testing window via CDP, confirmed content stays fixed while the OS window grows, then confirmed the attach path never overrides the viewport.
- `tsgo -p tsconfig.json --noEmit` passes.
- `biome check packages/coding-agent/src/tools/browser/tab-supervisor.ts` passes.