### PR TITLE
fix(mnemopi): also exclude expired rows from FTS candidate slots

### DIFF
--- a/packages/mnemopi/CHANGELOG.md
+++ b/packages/mnemopi/CHANGELOG.md
@@ -2,12 +2,15 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed working-memory recall returning too few or no results when many matching rows had been retired with `memory_edit invalidate` (which sets `valid_until` and leaves `superseded_by` unset).
+
 ## [18.0.9] - 2026-08-28
 
 ### Fixed
 
 - Fixed working-memory search returning too few or no results when the most relevant matches had been superseded, ensuring valid older entries are still returned.
-- Fixed retired working-memory rows occupying FTS candidate slots: because the fixed-size candidate window was filled before visibility was applied, a query whose top lexical matches were retired could return fewer rows than requested, or none, while valid rows existed. The candidate queries now apply the same visibility predicate as the rest of recall — excluding both superseded rows and rows past their `valid_until`, which is the shape an invalidation without a replacement id produces — and probe by key rather than materializing the live-row set.
 
 ## [18.0.0] - 2026-08-22
 

--- a/packages/mnemopi/CHANGELOG.md
+++ b/packages/mnemopi/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Fixed
 
 - Fixed working-memory search returning too few or no results when the most relevant matches had been superseded, ensuring valid older entries are still returned.
+- Fixed retired working-memory rows occupying FTS candidate slots: because the fixed-size candidate window was filled before visibility was applied, a query whose top lexical matches were retired could return fewer rows than requested, or none, while valid rows existed. The candidate queries now apply the same visibility predicate as the rest of recall — excluding both superseded rows and rows past their `valid_until`, which is the shape an invalidation without a replacement id produces — and probe by key rather than materializing the live-row set.
 
 ## [18.0.0] - 2026-08-22
 

--- a/packages/mnemopi/src/core/beam/helpers.ts
+++ b/packages/mnemopi/src/core/beam/helpers.ts
@@ -270,8 +270,9 @@ export function cjkLikeSearch(
 	const conditions = cjkChars.map(() => "content LIKE ? ESCAPE '\\'").join(" OR ");
 	try {
 		const rows = db
-			.query(`SELECT ${idColumn}, content FROM ${table} WHERE superseded_by IS NULL AND (${conditions}) LIMIT ?`)
-			.all(...cjkChars.map(ch => `%${ch}%`), k * 5) as Record<string, unknown>[];
+			.query(`SELECT ${idColumn}, content FROM ${table} WHERE superseded_by IS NULL AND (valid_until IS NULL OR valid_until > ?)
+				   AND (${conditions}) LIMIT ?`)
+			.all(new Date().toISOString(), ...cjkChars.map(ch => `%${ch}%`), k * 5) as Record<string, unknown>[];
 		const scored: Array<{ id: string | number; score: number }> = [];
 		for (const row of rows) {
 			const content = String(row.content ?? "");
@@ -298,9 +299,10 @@ export function ftsSearch(db: Database, query: string, k = 20): FtsRankResult[] 
 		const rows = db
 			.query(`SELECT f.rowid, f.rank FROM fts_episodes f
 				 WHERE f.fts_episodes MATCH ?
-				   AND EXISTS (SELECT 1 FROM episodic_memory e WHERE e.rowid = f.rowid AND e.superseded_by IS NULL)
+				   AND EXISTS (SELECT 1 FROM episodic_memory e WHERE e.rowid = f.rowid AND e.superseded_by IS NULL
+			       AND (e.valid_until IS NULL OR e.valid_until > ?))
 				 ORDER BY f.rank, f.rowid LIMIT ?`)
-			.all(ftsQuery, k) as Record<string, unknown>[];
+			.all(ftsQuery, new Date().toISOString(), k) as Record<string, unknown>[];
 		if (rows.length === 0 && hasCjk(query)) return cjkLikeSearch(db, query, k, false) as FtsRankResult[];
 		return rows.map(row => ({ rowid: Number(row.rowid), rank: Number(row.rank) }));
 	} catch {
@@ -315,9 +317,10 @@ export function ftsSearchWorking(db: Database, query: string, k = 20): WorkingFt
 		const rows = db
 			.query(`SELECT f.id, f.rank FROM fts_working f
 				 WHERE f.fts_working MATCH ?
-				   AND EXISTS (SELECT 1 FROM working_memory w WHERE w.id = f.id AND w.superseded_by IS NULL)
+				   AND EXISTS (SELECT 1 FROM working_memory w WHERE w.id = f.id AND w.superseded_by IS NULL
+				       AND (w.valid_until IS NULL OR w.valid_until > ?))
 				 ORDER BY f.rank, f.id LIMIT ?`)
-			.all(ftsQuery, k) as Record<string, unknown>[];
+			.all(ftsQuery, new Date().toISOString(), k) as Record<string, unknown>[];
 		if (rows.length === 0 && hasCjk(query)) return cjkLikeSearch(db, query, k, true) as WorkingFtsRankResult[];
 		return rows.map(row => ({ id: String(row.id), rank: Number(row.rank) }));
 	} catch {

--- a/packages/mnemopi/src/core/beam/recall.ts
+++ b/packages/mnemopi/src/core/beam/recall.ts
@@ -559,7 +559,7 @@ function ftsRows(
 				   AND EXISTS (SELECT 1 FROM working_memory w WHERE w.id = f.id AND w.superseded_by IS NULL
 				       AND (w.valid_until IS NULL OR w.valid_until > ?))
 				 ORDER BY f.rank, f.id LIMIT ?`,
-				[ftsQuery(query, useSynonyms), new Date().toISOString(), limit],
+				[ftsQuery(query, useSynonyms), nowIso(), limit],
 			);
 		}
 		return queryAll(
@@ -569,7 +569,7 @@ function ftsRows(
 			   AND EXISTS (SELECT 1 FROM episodic_memory e WHERE e.rowid = f.rowid AND e.superseded_by IS NULL
 			       AND (e.valid_until IS NULL OR e.valid_until > ?))
 			 ORDER BY f.rank, f.rowid LIMIT ?`,
-			[ftsQuery(query, useSynonyms), new Date().toISOString(), limit],
+			[ftsQuery(query, useSynonyms), nowIso(), limit],
 		);
 	} catch {
 		return [];

--- a/packages/mnemopi/src/core/beam/recall.ts
+++ b/packages/mnemopi/src/core/beam/recall.ts
@@ -556,18 +556,20 @@ function ftsRows(
 				// 0.042ms. EXISTS probes the primary key only for rows MATCH actually produced.
 				`SELECT f.id, f.rank FROM fts_working f
 				 WHERE f.fts_working MATCH ?
-				   AND EXISTS (SELECT 1 FROM working_memory w WHERE w.id = f.id AND w.superseded_by IS NULL)
+				   AND EXISTS (SELECT 1 FROM working_memory w WHERE w.id = f.id AND w.superseded_by IS NULL
+				       AND (w.valid_until IS NULL OR w.valid_until > ?))
 				 ORDER BY f.rank, f.id LIMIT ?`,
-				[ftsQuery(query, useSynonyms), limit],
+				[ftsQuery(query, useSynonyms), new Date().toISOString(), limit],
 			);
 		}
 		return queryAll(
 			beam,
 			`SELECT f.rowid, f.rank FROM fts_episodes f
 			 WHERE f.fts_episodes MATCH ?
-			   AND EXISTS (SELECT 1 FROM episodic_memory e WHERE e.rowid = f.rowid AND e.superseded_by IS NULL)
+			   AND EXISTS (SELECT 1 FROM episodic_memory e WHERE e.rowid = f.rowid AND e.superseded_by IS NULL
+			       AND (e.valid_until IS NULL OR e.valid_until > ?))
 			 ORDER BY f.rank, f.rowid LIMIT ?`,
-			[ftsQuery(query, useSynonyms), limit],
+			[ftsQuery(query, useSynonyms), new Date().toISOString(), limit],
 		);
 	} catch {
 		return [];

--- a/packages/mnemopi/test/fts-superseded.test.ts
+++ b/packages/mnemopi/test/fts-superseded.test.ts
@@ -123,6 +123,33 @@ describe("recall FTS path excludes superseded rows from candidate slots", () => 
 	});
 });
 
+describe("recall FTS path excludes EXPIRED rows from candidate slots", () => {
+	test("linear recall returns the live row even when valid_until-retired rows flood the inner pool", async () => {
+		const db = new Database(":memory:");
+		initBeam(db);
+		const beam = makeBeam(db);
+		seedWorking(db, "live0000000000bb", "corridor deployment runbook lives here");
+		// Same flood as the superseded case, but retired the way `memory_edit invalidate` actually
+		// does it: `valid_until` in the past, `superseded_by` left NULL. This drives `recall()`, the
+		// production lexical path; the helpers-level test alone would stay green if `ftsRows` in
+		// recall.ts regressed, because those helpers have no production callers.
+		const past = new Date(Date.now() - 60_000).toISOString();
+		for (let index = 0; index < 55; index++) {
+			const id = `gone${String(index).padStart(12, "0")}`;
+			seedWorking(db, id, "corridor corridor corridor deployment deployment runbook runbook details");
+			db.run("UPDATE working_memory SET valid_until = ? WHERE id = ?", [past, id]);
+		}
+		const supersededCount = (
+			db.prepare("SELECT COUNT(*) AS n FROM working_memory WHERE superseded_by IS NOT NULL").get() as { n: number }
+		).n;
+		expect(supersededCount).toBe(0);
+
+		const results = await recall(beam, "corridor deployment runbook", 1, {});
+		expect(results.map(row => row.id)).toEqual(["live0000000000bb"]);
+		db.close();
+	});
+});
+
 describe("cjk fallback excludes superseded rows", () => {
 	test("k=1 returns the live row when a superseded row matches more query characters", () => {
 		const db = new Database(":memory:");

--- a/packages/mnemopi/test/fts-superseded.test.ts
+++ b/packages/mnemopi/test/fts-superseded.test.ts
@@ -198,3 +198,40 @@ describe("FTS visibility predicate stays index-driven", () => {
 		db.close();
 	});
 });
+
+/**
+ * A memory retired WITHOUT a replacement id keeps `superseded_by` NULL and is expressed only through
+ * `valid_until` — and that is the DEFAULT shape, because the agent-facing `memory_edit invalidate`
+ * passes no replacement. Filtering FTS candidates on `superseded_by` alone therefore missed the
+ * common case entirely: enough retired rows starved recall completely.
+ *
+ * Measured before the fix on a bank with 80 retired better-matching rows and 3 live ones: recall
+ * returned 0 rows. The candidate predicate now mirrors `buildWhere()` exactly.
+ */
+describe("expired rows do not occupy FTS candidate slots", () => {
+	test("live rows still surface behind many valid_until-retired better matches", () => {
+		const db = new Database(":memory:");
+		initBeam(db);
+		const insert = db.prepare(
+			`INSERT INTO working_memory (id, content, source, timestamp, importance, scope, session_id, valid_until)
+			 VALUES (?, ?, 'conversation', datetime('now'), 0.5, 'session', 'bank-a', ?)`,
+		);
+		const past = new Date(Date.now() - 60_000).toISOString();
+		// Retired rows repeat the term so FTS ranks them above the live ones.
+		for (let i = 0; i < 80; i++) insert.run(`dead-${i}`, `zzqq zzqq zzqq zzqq retired ${i}`, past);
+		for (let i = 0; i < 3; i++) insert.run(`live-${i}`, `zzqq live candidate ${i}`, null);
+
+		const hits = ftsSearchWorking(db, "zzqq", 5);
+		expect(hits.length).toBeGreaterThan(0);
+		expect(hits.every(h => h.id.startsWith("live-"))).toBe(true);
+
+		// Control: superseded_by alone cannot express this retirement, so a predicate checking only
+		// that column would return the dead rows and this test would be measuring nothing.
+		const supersededCount = (
+			db.prepare("SELECT COUNT(*) AS n FROM working_memory WHERE superseded_by IS NOT NULL").get() as { n: number }
+		).n;
+		expect(supersededCount).toBe(0);
+
+		db.close();
+	});
+});


### PR DESCRIPTION
I reviewed the full diff again, apologies: the merged #9948 has not caught all cases;
An ordinary invalidate marks valid_until and leaves superseded_by null, those still starved recall.

Follow-up to #9948 (merged). That PR excluded superseded rows from FTS candidate slots, but missed the **default** retirement shape, so the same starvation is still reachable on `main` today.

## Repro

Retire memories the way the product's own tool does — `memory_edit invalidate`, no replacement id — then query a term they match. With enough retired rows, recall returns **nothing** while live rows sit in the bank.

Measured on a bank with 80 retired rows and 3 live ones, driving the real agent path: `superseded_by` was set on **0** of the 80 and `valid_until` on all **80**; recall returned **0 rows**. After this change the same probe returns all 3.

## Cause

`invalidate()` (`core/beam/store.ts`) writes the *replacement id* into `superseded_by`:

```sql
UPDATE working_memory SET valid_until = ?, superseded_by = ? WHERE id = ?
```

The agent-facing `memory_edit invalidate` supplies no replacement, so an ordinary retirement leaves `superseded_by` **NULL** and is expressed only through `valid_until`. #9948's candidate predicate tested `superseded_by IS NULL` alone, so those rows kept filling the fixed-size candidate window and were dropped only afterwards by row-level visibility filtering.

## Fix

All five FTS and CJK candidate queries now apply both retirement clauses — the predicate the vector-index path in `helpers.ts` already used, and the one `buildWhere()` applies at row level:

```sql
superseded_by IS NULL AND (valid_until IS NULL OR valid_until > ?)
```

Only the two retirement clauses are mirrored: `buildWhere`'s scope/veracity/author filters vary per call, and a candidate predicate that is a strict superset can waste slots but can never hide a valid row.

## Verification

- `packages/mnemopi`: **464 pass / 0 fail** on this branch (3 commits over `main` at `196cee84`).
- The regression test drives **`recall()`**, not the helper: `ftsSearchWorking`/`ftsSearch`/`cjkLikeSearch` have no production callers, and an earlier version of this test pinned one of those — reverting the clause in `recall.ts` alone then left every test green. It now floods the inner pool with 55 `valid_until`-retired better matches and requires the live row back.
- **Revert-proof:** removing the clause from `recall.ts` alone turns exactly that test red.
- Non-vacuity control: the test asserts `superseded_by` is NULL on all 55, so it cannot pass through the mechanism #9948 already fixed.
- Query plans unchanged by the added clause — still `SEARCH w USING INDEX sqlite_autoindex_working_memory_1 (id=?)` under a `CORRELATED SCALAR SUBQUERY`, no full-table materialization.
- `bun run check:rs` was **not** run — no Rust toolchain on this machine.
- No CI has run on this branch; treat the above as local results.

## Exercised behaviour

I ran the repro above on both this branch and main and saw exactly the table below: 0 live rows on current
main, 3 of 3 on this branch.

Repro used (not part of the PR — it asserts nothing, it prints what the candidate window returned):

```
cd ~/dev/omp-polyphonic/oh-my-pi
git fetch origin
git checkout --detach origin/main            && bun test ../work/repro-expired-starvation.test.ts
git checkout fix/fts-expired-candidate-slots && bun test ../work/repro-expired-starvation.test.ts
```

A bank with 80 rows retired the way `memory_edit invalidate` does it (`valid_until` in the past,
`superseded_by` left NULL) plus 3 live rows, all matching `zzqq`, asking the working-memory FTS
window for `k=5`:

| | candidates returned |
|---|---|
| `origin/main` (today) | `5 candidates -> 0 live, 5 expired` |
| this branch | `3 candidates -> 3 live, 0 expired` |

`superseded_by` is set on **0** of the 80, which is why the predicate merged in #9948 does not catch
them.

