### PR TITLE
fix(extensions): restore subagent context callbacks

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed `import numpy` (and other native-extension imports) hanging indefinitely in the Python eval tool on Windows, where the runner's always-on background stdin reader deadlocked native DLL loading; Windows now reads the control channel serially between requests while POSIX keeps concurrent request dispatch ([#7985](https://github.com/can1357/oh-my-pi/issues/7985)).
+- Fixed subagent extension contexts so `ctx.getContextUsage()` reports the child session's usage and `ctx.compact()` compacts that session ([#10097](https://github.com/can1357/oh-my-pi/issues/10097)).
 
 ## [18.0.9] - 2026-08-28
 

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -682,6 +682,8 @@ export class ExtensionRunner {
 		this.#abortFn = contextActions.abort;
 		this.#hasPendingMessagesFn = contextActions.hasPendingMessages;
 		this.#shutdownHandler = contextActions.shutdown;
+		this.#getContextUsageFn = contextActions.getContextUsage;
+		this.#compactFn = contextActions.compact;
 		this.#getSystemPromptFn = contextActions.getSystemPrompt;
 
 		// Command context actions (optional, only for interactive mode)

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -159,6 +159,51 @@ describe("ExtensionRunner", () => {
 		expect(runner.createContext().mode).toBe("tui");
 	});
 
+	it("uses required context actions when command actions are unavailable", async () => {
+		const result = await loadTestExtensions();
+		const runner = new ExtensionRunner(
+			result.extensions,
+			result.runtime,
+			tempDir.path(),
+			sessionManager,
+			modelRegistry,
+		);
+		const usage = { tokens: 1200, contextWindow: 8000, percent: 15 };
+		const compact = vi.fn(async () => {});
+
+		runner.initialize(
+			{
+				sendMessage: () => {},
+				sendUserMessage: () => {},
+				appendEntry: () => {},
+				setLabel: () => {},
+				getActiveTools: () => [],
+				getAllTools: () => [],
+				setActiveTools: async () => {},
+				getCommands: () => [],
+				setModel: async () => false,
+				getThinkingLevel: () => undefined,
+				setThinkingLevel: () => {},
+				getSessionName: () => undefined,
+				setSessionName: async () => {},
+			},
+			{
+				getModel: () => undefined,
+				isIdle: () => true,
+				abort: () => {},
+				hasPendingMessages: () => false,
+				shutdown: () => {},
+				getContextUsage: () => usage,
+				compact,
+				getSystemPrompt: () => [],
+			},
+		);
+
+		expect(runner.createContext().getContextUsage()).toEqual(usage);
+		await runner.createContext().compact("preserve current task");
+		expect(compact).toHaveBeenCalledWith("preserve current task");
+	});
+
 	describe("shortcut conflicts", () => {
 		it("warns when extension shortcut conflicts with built-in", async () => {
 			const extCode = `


### PR DESCRIPTION
## Repro
Initializing an `ExtensionRunner` with valid required `ExtensionContextActions` but no optional command actions reproduces the task-session host shape: `ctx.getContextUsage()` returns `undefined` and `ctx.compact()` remains a no-op. Reproduced with `bun test packages/coding-agent/test/extensions-runner.test.ts -t "uses required context actions when command actions are unavailable"`.

## Cause
`ExtensionRunner.initialize()` in `packages/coding-agent/src/extensibility/extensions/runner.ts` only assigned `#getContextUsageFn` and `#compactFn` inside the optional `commandContextActions` branch. `packages/coding-agent/src/task/executor.ts` correctly supplied both callbacks through required `ExtensionContextActions`, but subagent sessions have no command actions, so the runner retained its default stubs.

## Fix
- Install context usage and compaction callbacks from required `ExtensionContextActions`.
- Preserve the existing optional command-action override for interactive hosts.
- Cover usage reporting and compaction dispatch when command actions are unavailable.
- Document the user-visible subagent extension fix in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/extensions-runner.test.ts` passed: 84 tests, 210 expectations, 0 failures. The publish gate also completed `bun run fix` and `bun check`.

Fixes #10097