### PR TITLE
fix(catalog): Fix Baseten GLM models being marked as non-reasoning (including GLM 5.3 Flash)

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- New Baseten GLM models were not resolving as reasoning models. Fixed so that they should be (and won't need code changes to do so). This immediately fixes Baseten `zai-org/GLM-5.3-Flash` and should fix future GLM models added.
+
 ## [18.0.9] - 2026-08-28
 
 ### Added

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- New Baseten GLM models were not resolving as reasoning models. Fixed so that they should be (and won't need code changes to do so). This immediately fixes Baseten `zai-org/GLM-5.3-Flash` and should fix future GLM models added.
+- Fixed issue where GLM models being served from Baseten were not being resolved as reasoning models. This immediately fixes Baseten `zai-org/GLM-5.3-Flash` and should fix future GLM models added.
 
 ## [18.0.9] - 2026-08-28
 

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -656,6 +656,7 @@ type OpenAICompatibleModelManagerBuilderOptions<TApi extends Api> = {
 	headers?: SimpleProviderDiscoveryHeaders;
 	dynamicModelsAuthoritative?: true;
 	requireApiKey?: true;
+	dropCachedModelIdsOnStaticMismatch?: readonly string[];
 	filterModel?: (
 		entry: OpenAICompatibleModelRecord,
 		model: ModelSpec<TApi>,
@@ -678,6 +679,9 @@ function createOpenAICompatibleModelManagerOptions<TApi extends Api>(
 	return {
 		providerId: options.providerId,
 		...(options.dynamicModelsAuthoritative && { dynamicModelsAuthoritative: true }),
+		...(options.dropCachedModelIdsOnStaticMismatch && {
+			dropCachedModelIdsOnStaticMismatch: options.dropCachedModelIdsOnStaticMismatch,
+		}),
 		...((!options.requireApiKey || apiKey) && {
 			fetchDynamicModels: () =>
 				fetchOpenAICompatibleModels({
@@ -4145,6 +4149,11 @@ export interface BasetenModelManagerConfig {
 	fetch?: FetchImpl;
 }
 
+// A previous version of OMP shipped this model without reasoning levels. We've
+// since fixed that. This const lets us bust the cache so that users on that
+// version of OMP pick up the reasoning levels immediately.
+const BASETEN_CACHE_MIGRATION_MODEL_IDS = ["zai-org/GLM-5.3-Flash"] as const;
+
 export function basetenModelManagerOptions(
 	config?: BasetenModelManagerConfig,
 ): ModelManagerOptions<"openai-completions"> {
@@ -4155,6 +4164,7 @@ export function basetenModelManagerOptions(
 		config,
 		dynamicModelsAuthoritative: true,
 		requireApiKey: true,
+		dropCachedModelIdsOnStaticMismatch: BASETEN_CACHE_MIGRATION_MODEL_IDS,
 		mapModel: (entry, defaults, reference) => {
 			const raw = entry as Record<string, unknown> & {
 				supported_features?: unknown;

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -4170,10 +4170,9 @@ export function basetenModelManagerOptions(
 			// vocabulary, which OMP must not guess.
 			const isSupportedBasetenReasoningModel =
 				isKimiK3ModelId(defaults.id) ||
+				isReasoningGlmModelId(defaults.id) ||
 				defaults.id === "openai/gpt-oss-120b" ||
-				defaults.id === "deepseek-ai/DeepSeek-V4-Pro" ||
-				defaults.id === "zai-org/GLM-5.2" ||
-				defaults.id === "zai-org/GLM-5.2-Fast";
+				defaults.id === "deepseek-ai/DeepSeek-V4-Pro";
 			const reasoning =
 				isSupportedBasetenReasoningModel &&
 				(features.includes("reasoning") || features.includes("reasoning_effort"));

--- a/packages/catalog/test/baseten-provider.test.ts
+++ b/packages/catalog/test/baseten-provider.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import { Effort } from "@oh-my-pi/pi-catalog/effort";
+import { readModelCache } from "@oh-my-pi/pi-catalog/model-cache";
+import { resolveProviderModels } from "@oh-my-pi/pi-catalog/model-manager";
 import { basetenModelManagerOptions } from "@oh-my-pi/pi-catalog/provider-models/openai-compat";
-import type { FetchImpl } from "@oh-my-pi/pi-catalog/types";
+import type { FetchImpl, ModelSpec } from "@oh-my-pi/pi-catalog/types";
 
 describe("Baseten provider discovery", () => {
 	test("discovers Baseten models with custom metadata", async () => {
@@ -176,5 +182,89 @@ describe("Baseten provider discovery", () => {
 			efforts: ["low", "high", "max"],
 			defaultLevel: "max",
 		});
+	});
+
+	test("invalidates cached GLM-5.3-Flash reasoning metadata on upgrade", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-catalog-baseten-glm53-flash-cache-"));
+		const cacheDbPath = path.join(tempDir, "models.db");
+		const discoveredFlash: ModelSpec<"openai-completions"> = {
+			id: "zai-org/GLM-5.3-Flash",
+			name: "GLM 5.3 Flash",
+			api: "openai-completions",
+			provider: "baseten",
+			baseUrl: "https://inference.baseten.co/v1",
+			reasoning: true,
+			input: ["text", "image"],
+			cost: { input: 0.15, output: 0.5, cacheRead: 0.03, cacheWrite: 0 },
+			contextWindow: 1_048_576,
+			maxTokens: 131_072,
+		};
+		const discoveryPayload = {
+			data: [
+				{
+					id: "zai-org/GLM-5.3-Flash",
+					object: "model",
+					name: "GLM 5.3 Flash",
+					context_length: 1048576,
+					max_completion_tokens: 131072,
+					supported_features: ["tools", "json_mode", "structured_outputs", "reasoning"],
+					input_modalities: ["text", "image"],
+					pricing: {
+						prompt: "0.00000015",
+						completion: "0.0000005",
+						input_cache_read: "0.00000003",
+					},
+				},
+			],
+		};
+		const fetchMock: FetchImpl = async () =>
+			new Response(JSON.stringify(discoveryPayload), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			});
+
+		try {
+			// Pass 1: write a fresh authoritative cache under the PRE-fix identity
+			// (no migration list) whose row carries the stale pre-fix computed
+			// value: reasoning false, no thinking.
+			await resolveProviderModels(
+				{
+					...basetenModelManagerOptions({ apiKey: "k", fetch: fetchMock }),
+					cacheDbPath,
+					dropCachedModelIdsOnStaticMismatch: undefined,
+					fetchDynamicModels: async () => [{ ...discoveredFlash, reasoning: false, input: ["text", "image"] }],
+				},
+				"online",
+			);
+			const priorCache = readModelCache("baseten", Number.POSITIVE_INFINITY, Date.now, cacheDbPath);
+			if (!priorCache) throw new Error("Baseten cache was not written");
+
+			// Pass 2: the fixed options object (migration list active) reading that
+			// cache with the default strategy — the stale row must NOT be served;
+			// discovery re-runs and re-derives the corrected metadata.
+			let fetches = 0;
+			const upgraded = await resolveProviderModels(
+				{
+					...basetenModelManagerOptions({ apiKey: "k", fetch: fetchMock }),
+					cacheDbPath,
+					fetchDynamicModels: async () => {
+						fetches++;
+						return [discoveredFlash];
+					},
+				},
+				"online-if-uncached",
+			);
+			const flash = upgraded.models.find(model => model.id === "zai-org/GLM-5.3-Flash");
+			expect(fetches).toBe(1);
+			expect(flash?.reasoning).toBe(true);
+			expect(flash?.thinking).toEqual({
+				mode: "effort",
+				efforts: [Effort.Low, Effort.High, Effort.Max],
+				defaultLevel: Effort.Max,
+				requiresEffort: true,
+			});
+		} finally {
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
 	});
 });

--- a/packages/catalog/test/baseten-provider.test.ts
+++ b/packages/catalog/test/baseten-provider.test.ts
@@ -71,6 +71,20 @@ describe("Baseten provider discovery", () => {
 								input_cache_read: "0.00000021",
 							},
 						},
+						{
+							id: "zai-org/GLM-5.3-Flash",
+							object: "model",
+							name: "GLM 5.3 Flash",
+							context_length: 1048576,
+							max_completion_tokens: 131072,
+							supported_features: ["tools", "json_mode", "structured_outputs", "reasoning"],
+							input_modalities: ["text", "image"],
+							pricing: {
+								prompt: "0.00000015",
+								completion: "0.0000005",
+								input_cache_read: "0.00000003",
+							},
+						},
 					],
 				}),
 				{ status: 200, headers: { "content-type": "application/json" } },
@@ -138,6 +152,29 @@ describe("Baseten provider discovery", () => {
 		expect(buildModel(glmFast).thinking).toMatchObject({
 			mode: "effort",
 			efforts: ["high", "max"],
+		});
+
+		const glmFlash = models?.find(model => model.id === "zai-org/GLM-5.3-Flash");
+		if (!glmFlash) throw new Error("Baseten GLM-5.3-Flash was not discovered");
+		expect(glmFlash).toMatchObject({
+			provider: "baseten",
+			api: "openai-completions",
+			name: "GLM 5.3 Flash",
+			reasoning: true,
+			input: ["text", "image"],
+			contextWindow: 1048576,
+			maxTokens: 131072,
+			cost: {
+				input: 0.15,
+				output: 0.5,
+				cacheRead: 0.03,
+				cacheWrite: 0,
+			},
+		});
+		expect(buildModel(glmFlash).thinking).toMatchObject({
+			mode: "effort",
+			efforts: ["low", "high", "max"],
+			defaultLevel: "max",
 		});
 	});
 });

--- a/packages/catalog/test/identity-family.test.ts
+++ b/packages/catalog/test/identity-family.test.ts
@@ -3,6 +3,8 @@ import {
 	hasOpus47ApiRestrictions,
 	isClaudeModelId,
 	isGeminiModelId,
+	isGlm52ReasoningEffortModelId,
+	isGlm53ReasoningEffortModelId,
 	isGlmVisionModelId,
 	isGrokModelId,
 	isGrokMultiAgentModelId,
@@ -299,6 +301,7 @@ describe("isReasoningGlmModelId", () => {
 		expect(isReasoningGlmModelId("glm-5-preview")).toBe(false);
 		expect(isReasoningGlmModelId("glm-4.5-flash")).toBe(false);
 		expect(isReasoningGlmModelId("glm-4.7-flash")).toBe(false);
+		expect(isReasoningGlmModelId("glm-5.2-flash")).toBe(false);
 		expect(isReasoningGlmModelId("glm-4.7-flashx")).toBe(false);
 		expect(isReasoningGlmModelId("glm-4.5v")).toBe(false);
 		expect(isReasoningGlmModelId("qwen3.5")).toBe(false);
@@ -313,6 +316,44 @@ describe("isReasoningGlmModelId", () => {
 		expect(isReasoningGlmModelId("zai-org/GLM-5-Turbo")).toBe(true);
 		// Vision SKUs are still excluded even in uppercase.
 		expect(isReasoningGlmModelId("zai-org/GLM-4.5V")).toBe(false);
+	});
+});
+
+describe("isGlm52ReasoningEffortModelId", () => {
+	test("matches GLM-5.2+ reasoning SKUs including the 5.3 flash line", () => {
+		expect(isGlm52ReasoningEffortModelId("glm-5.2")).toBe(true);
+		expect(isGlm52ReasoningEffortModelId("zai-org/GLM-5.2-Fast")).toBe(true);
+		// The 5.3 flash SKU accepts reasoning_effort like the rest of 5.3+.
+		expect(isGlm52ReasoningEffortModelId("glm-5.3-flash")).toBe(true);
+		expect(isGlm52ReasoningEffortModelId("zai-org/GLM-5.3-Flash")).toBe(true);
+	});
+
+	test("excludes pre-5.2 SKUs, pre-5.3 flash, and non-reasoning variants", () => {
+		expect(isGlm52ReasoningEffortModelId("glm-5.1")).toBe(false);
+		expect(isGlm52ReasoningEffortModelId("glm-5.2-flash")).toBe(false);
+		expect(isGlm52ReasoningEffortModelId("glm-4.7-flashx")).toBe(false);
+		expect(isGlm52ReasoningEffortModelId("glm-5-preview")).toBe(false);
+		expect(isGlm52ReasoningEffortModelId("glm-4.5v")).toBe(false);
+	});
+});
+
+describe("isGlm53ReasoningEffortModelId", () => {
+	test("matches GLM-5.3+ SKUs across variants, including Flash", () => {
+		expect(isGlm53ReasoningEffortModelId("glm-5.3")).toBe(true);
+		expect(isGlm53ReasoningEffortModelId("glm-5.3-air")).toBe(true);
+		expect(isGlm53ReasoningEffortModelId("glm-5.3-turbo")).toBe(true);
+		expect(isGlm53ReasoningEffortModelId("glm-5.3-flash")).toBe(true);
+		expect(isGlm53ReasoningEffortModelId("zai-org/GLM-5.3-Flash")).toBe(true);
+		// Future bumps inherit the ladder without a new entry.
+		expect(isGlm53ReasoningEffortModelId("glm-6")).toBe(true);
+	});
+
+	test("excludes pre-5.3 SKUs and non-reasoning variants", () => {
+		expect(isGlm53ReasoningEffortModelId("glm-5.2")).toBe(false);
+		expect(isGlm53ReasoningEffortModelId("glm-5.2-flash")).toBe(false);
+		expect(isGlm53ReasoningEffortModelId("glm-5.3-flashx")).toBe(false);
+		expect(isGlm53ReasoningEffortModelId("glm-5.3-preview")).toBe(false);
+		expect(isGlm53ReasoningEffortModelId("glm-5.3v")).toBe(false);
 	});
 });
 


### PR DESCRIPTION
## What

Mark all current and upcoming GLM models with Baseten as reasoning-capable, except for older ones that do not have reasoning.

## Why

I noticed that GLM 5.3 Flash did not have reasoning enabled, even though it's capable of reasoning (as does the just-released GLM 5.3, and presumably, all GLM models going forward)

## Testing

unit tests!

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)