### PR TITLE
feat(usage): query ollama.com /api/usage for ollama-cloud accounts

### DIFF
--- a/packages/ai/src/usage/ollama.ts
+++ b/packages/ai/src/usage/ollama.ts
@@ -1,9 +1,34 @@
-import type { UsageFetchContext, UsageFetchParams, UsageProvider, UsageReport } from "../usage";
+import type { UsageFetchContext, UsageFetchParams, UsageLimit, UsageProvider, UsageReport } from "../usage";
 
 const OLLAMA_PROVIDER = "ollama";
 const OLLAMA_CLOUD_PROVIDER = "ollama-cloud";
 
-async function fetchOllamaUsage(params: UsageFetchParams, _ctx: UsageFetchContext): Promise<UsageReport | null> {
+/**
+ * Undocumented but live since at least 2026-08: ollama.com exposes account
+ * usage for Cloud keys. Response shape (observed 2026-08-27):
+ * {
+ *   "activity": { "cost": "...", "period": { "type": "last_4_weeks", ... } },
+ *   "limits": {
+ *     "session": { "usage": 0.03, "models": [{ "name": "...", "request_count": 54 }] },
+ *     "weekly":  { "usage": 0.005, "models": [...] }
+ *   }
+ * }
+ * `usage` is a normalized 0..1 fraction of the session (5h) / weekly (7d)
+ * allowance, not a token count.
+ */
+const OLLAMA_COM_API_USAGE = "https://ollama.com/api/usage";
+
+const OLLAMA_WINDOWS: ReadonlyArray<{
+	key: "session" | "weekly";
+	windowId: string;
+	label: string;
+	durationMs: number;
+}> = [
+	{ key: "session", windowId: "5h", label: "5 Hour", durationMs: 5 * 60 * 60 * 1000 },
+	{ key: "weekly", windowId: "7d", label: "7 Day", durationMs: 7 * 24 * 60 * 60 * 1000 },
+];
+
+async function fetchOllamaUsage(params: UsageFetchParams, ctx: UsageFetchContext): Promise<UsageReport | null> {
 	if (params.provider !== OLLAMA_PROVIDER && params.provider !== OLLAMA_CLOUD_PROVIDER) {
 		return null;
 	}
@@ -13,18 +38,94 @@ async function fetchOllamaUsage(params: UsageFetchParams, _ctx: UsageFetchContex
 	if (params.credential.accountId) metadata.accountId = params.credential.accountId;
 	if (params.credential.projectId) metadata.projectId = params.credential.projectId;
 
-	return {
-		provider: params.provider,
-		fetchedAt: Date.now(),
-		limits: [],
-		notes: [
-			"Ollama does not expose a standalone quota usage API; per-response token usage is reported during requests.",
-		],
-		metadata: Object.keys(metadata).length > 0 ? metadata : undefined,
-	};
+	// Local Ollama has no quota at all; Cloud needs an API-key credential to
+	// query the usage endpoint.
+	const apiKey = params.credential.type === "api_key" ? params.credential.apiKey : undefined;
+	if (params.provider !== OLLAMA_CLOUD_PROVIDER || !apiKey) {
+		return {
+			provider: params.provider,
+			fetchedAt: Date.now(),
+			limits: [],
+			notes: [
+				params.provider === OLLAMA_CLOUD_PROVIDER
+					? "Ollama Cloud usage requires an API-key credential."
+					: "Local Ollama has no quota; per-response token usage is reported during requests.",
+			],
+			metadata: Object.keys(metadata).length > 0 ? metadata : undefined,
+		};
+	}
+
+	try {
+		const response = await ctx.fetch(OLLAMA_COM_API_USAGE, {
+			headers: { Accept: "application/json", Authorization: `Bearer ${apiKey}` },
+			signal: params.signal,
+		});
+		if (!response.ok) {
+			ctx.logger?.warn("Ollama usage fetch failed", { provider: params.provider, status: response.status });
+			return null;
+		}
+		const payload = (await response.json()) as {
+			limits?: Partial<
+				Record<
+					"session" | "weekly",
+					{
+						usage?: number;
+						models?: ReadonlyArray<{ name?: string; request_count?: number }>;
+					}
+				>
+			>;
+		} | null;
+		const limits = payload?.limits;
+		if (!limits) return null;
+
+		const out: UsageLimit[] = [];
+		for (const win of OLLAMA_WINDOWS) {
+			const seg = limits[win.key];
+			if (!seg || typeof seg.usage !== "number" || !Number.isFinite(seg.usage)) continue;
+			const used = Math.min(1, Math.max(0, seg.usage));
+			const topConsumers = (seg.models ?? [])
+				.filter(m => typeof m?.name === "string")
+				.slice(0, 4)
+				.map(m => `${m.name} x${m.request_count ?? 0}`)
+				.join(", ");
+			out.push({
+				id: `ollama-account:${win.windowId}`,
+				label: `Ollama ${win.label}`,
+				scope: {
+					provider: params.provider,
+					...(typeof metadata.accountId === "string" ? { accountId: metadata.accountId } : {}),
+					shared: true,
+					windowId: win.windowId,
+				},
+				window: { id: win.windowId, label: win.label, durationMs: win.durationMs },
+				amount: {
+					used: used * 100,
+					usedFraction: used,
+					remaining: 100 - used * 100,
+					remainingFraction: 1 - used,
+					unit: "percent",
+				},
+				status: used >= 1 ? "exhausted" : used >= 0.9 ? "warning" : "ok",
+				...(topConsumers ? { notes: [`Top consumers: ${topConsumers}`] } : {}),
+			});
+		}
+		return {
+			provider: params.provider,
+			fetchedAt: Date.now(),
+			limits: out,
+			metadata: { ...metadata, source: "ollama-api-usage" },
+			raw: payload,
+		};
+	} catch (err) {
+		ctx.logger?.warn("Ollama usage request failed", {
+			provider: params.provider,
+			error: err instanceof Error ? err.name : "unknown",
+		});
+		return null;
+	}
 }
 
-/** Registers Ollama accounts with usage views even though no quota endpoint is exposed. */
+/** Registers Ollama accounts with usage views (local ollama reports no quota). */
 export const ollamaUsageProvider: UsageProvider = {
 	id: OLLAMA_PROVIDER,
 	fetchUsage: fetchOllamaUsage,
@@ -32,7 +133,7 @@ export const ollamaUsageProvider: UsageProvider = {
 	validatesCredentials: false,
 };
 
-/** Registers Ollama Cloud accounts with usage views until a quota endpoint is available. */
+/** Registers Ollama Cloud accounts and queries the account usage endpoint. */
 export const ollamaCloudUsageProvider: UsageProvider = {
 	id: OLLAMA_CLOUD_PROVIDER,
 	fetchUsage: fetchOllamaUsage,

--- a/packages/ai/test/issue-3555-repro.test.ts
+++ b/packages/ai/test/issue-3555-repro.test.ts
@@ -47,7 +47,7 @@ describe("issue 3555 Ollama usage registration", () => {
 				limits: [],
 				metadata: { email: "cloud@example.test" },
 			});
-			expect(report?.notes?.[0]).toContain("does not expose a standalone quota usage API");
+			expect(report?.notes?.[0]).toContain("requires an API-key credential");
 		} finally {
 			storage.close();
 		}

--- a/packages/ai/test/usage-ollama-cloud.test.ts
+++ b/packages/ai/test/usage-ollama-cloud.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "bun:test";
+import type { UsageFetchContext, UsageFetchParams } from "@oh-my-pi/pi-ai/usage";
+import { ollamaCloudUsageProvider, ollamaUsageProvider } from "@oh-my-pi/pi-ai/usage/ollama";
+
+function ctxWith(payload: unknown, status = 200): { ctx: UsageFetchContext; calls: () => number } {
+	let calls = 0;
+	return {
+		ctx: {
+			fetch: (async (_input: string | URL | Request) => {
+				calls++;
+				return new Response(status === 200 ? JSON.stringify(payload) : "nope", { status });
+			}) as unknown as typeof fetch,
+			logger: undefined,
+		} as unknown as UsageFetchContext,
+		calls: () => calls,
+	};
+}
+
+function params(provider: "ollama" | "ollama-cloud", apiKey?: string): UsageFetchParams {
+	return {
+		provider,
+		credential: { type: "api_key", apiKey: apiKey ?? "" },
+	};
+}
+
+const PAYLOAD = {
+	activity: { cost: "12.34", period: { type: "last_4_weeks" } },
+	limits: {
+		session: { usage: 0.352, models: [{ name: "glm-5.3-flash", request_count: 458 }] },
+		weekly: { usage: 0.215, models: [{ name: "glm-5.3-flash", request_count: 458 }] },
+	},
+};
+
+describe("ollama-cloud usage provider", () => {
+	it("maps session/weekly fractions to percent limits", async () => {
+		const { ctx, calls } = ctxWith(PAYLOAD);
+		const report = await ollamaCloudUsageProvider.fetchUsage!(params("ollama-cloud", "ok-key"), ctx);
+		expect(calls()).toBe(1);
+		expect(report).not.toBeNull();
+		const limits = report!.limits;
+		expect(limits).toHaveLength(2);
+		expect(limits[0].id).toBe("ollama-account:5h");
+		expect(limits[0].label).toBe("Ollama 5 Hour");
+		expect(limits[0].amount.usedFraction).toBeCloseTo(0.352);
+		expect(limits[0].amount.unit).toBe("percent");
+		expect(limits[0].status).toBe("ok");
+		expect(limits[1].id).toBe("ollama-account:7d");
+		expect(limits[1].label).toBe("Ollama 7 Day");
+		expect(limits[1].amount.usedFraction).toBeCloseTo(0.215);
+	});
+
+	it("flags exhausted and warning statuses", async () => {
+		const { ctx } = ctxWith({
+			limits: {
+				session: { usage: 1 },
+				weekly: { usage: 0.93 },
+			},
+		});
+		const report = await ollamaCloudUsageProvider.fetchUsage!(params("ollama-cloud", "k"), ctx);
+		expect(report!.limits[0].status).toBe("exhausted");
+		expect(report!.limits[1].status).toBe("warning");
+	});
+
+	it("keeps top consumers as notes", async () => {
+		const { ctx } = ctxWith(PAYLOAD);
+		const report = await ollamaCloudUsageProvider.fetchUsage!(params("ollama-cloud", "k"), ctx);
+		expect(report!.limits[0].notes?.[0]).toContain("glm-5.3-flash x458");
+	});
+
+	it("returns null on non-2xx responses", async () => {
+		const { ctx } = ctxWith(PAYLOAD, 401);
+		const report = await ollamaCloudUsageProvider.fetchUsage!(params("ollama-cloud", "k"), ctx);
+		expect(report).toBeNull();
+	});
+
+	it("does not hit the network for local ollama", async () => {
+		const { ctx, calls } = ctxWith(PAYLOAD);
+		const report = await ollamaUsageProvider.fetchUsage!(params("ollama", "k"), ctx);
+		expect(calls()).toBe(0);
+		expect(report!.limits).toHaveLength(0);
+	});
+
+	it("supports() routes by provider id", () => {
+		expect(ollamaCloudUsageProvider.supports!(params("ollama-cloud", "k"))).toBe(true);
+		expect(ollamaCloudUsageProvider.supports!(params("ollama", "k"))).toBe(false);
+		expect(ollamaUsageProvider.supports!(params("ollama-cloud", "k"))).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary

`ollama.com` exposes an undocumented-but-stable account usage endpoint for Cloud API keys: `GET https://ollama.com/api/usage` (Bearer auth). The response carries `limits.session` / `limits.weekly`, each a **normalized 0..1 fraction** of the 5-hour / 7-day allowance, plus per-model request counts:

```json
{
  "activity": { "cost": "...", "period": { "type": "last_4_weeks" } },
  "limits": {
    "session": { "usage": 0.03, "models": [{ "name": "glm-5.3-flash", "request_count": 54 }] },
    "weekly":  { "usage": 0.005, "models": [{ "name": "glm-5.3-flash", "request_count": 458 }] }
  }
}
```

Today `packages/ai/src/usage/ollama.ts` returns a placeholder note ("Ollama does not expose a standalone quota usage API") for both providers, so `omp usage` and the statusline show nothing useful for ollama-cloud accounts. This maps the real fractions onto `UsageLimit` entries:

- `session` → `ollama-account:5h` (label "Ollama 5 Hour", durationMs 5h)
- `weekly` → `ollama-account:7d` (label "Ollama 7 Day", durationMs 7d)

## Behavior

- Only `ollama-cloud` **with an `api_key` credential** hits the network. Local `ollama` keeps the existing no-quota report and never fetches; OAuth ollama-cloud credentials (no key) get an explicit "requires an API-key credential" note instead of the misleading old text.
- Fraction is clamped to `[0,1]`; `status` is `ok` / `warning` (≥90%) / `exhausted` (100%).
- Top consumers (up to 4, rendered as `name xN`) ride along as limit `notes`; the raw payload is preserved on the report for debugging.
- Non-2xx and network errors degrade to `null` via `ctx.logger` warn — the usage view stays stable instead of erroring.

## Test plan

- New `packages/ai/test/usage-ollama-cloud.test.ts` (mocked `fetch`): fraction→percent mapping, status thresholds, top-consumer notes, 401 → `null`, local-ollama never fetches, `supports()` routing.
- Updated `issue-3555-repro.test.ts` assertion for the new OAuth-credential note.
- `tsc --noEmit` clean, `biome check` clean.
- Full `packages/ai` suite: 4602 tests — only pre-existing environment timeouts remain (Bedrock ×3, cursor gRPC ×1), identical on `main` without this patch; the previously-failing `issue-3555` case passes with the updated assertion.