### PR TITLE
fix(mnemopi): invalidate the recall cache when embeddings commit

### DIFF
--- a/packages/mnemopi/CHANGELOG.md
+++ b/packages/mnemopi/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed recall continuing to serve a stale, pre-embedding ranking for up to an hour after background embeddings finished, when the enhanced recall cache is enabled.
+
 ## [18.0.9] - 2026-08-28
 
 ### Fixed

--- a/packages/mnemopi/src/core/beam/helpers.ts
+++ b/packages/mnemopi/src/core/beam/helpers.ts
@@ -791,15 +791,31 @@ async function runEmbedding(beam: BeamMemoryState, items: readonly EmbedItem[]):
 		using insertEmbedding = beam.db.prepare(
 			"INSERT OR REPLACE INTO memory_embeddings(memory_id, embedding_json, model) VALUES (?, ?, ?)",
 		);
+		let committed = 0;
 		const insertMany = beam.db.transaction((rows: readonly EmbedItem[]) => {
 			for (let i = 0; i < rows.length; i += 1) {
 				const vector = matrix[i];
 				const item = rows[i];
 				if (vector === undefined || item === undefined) continue;
 				insertEmbedding.run(item.memoryId, JSON.stringify(Array.from(vector)), model);
+				committed += 1;
 			}
 		});
 		insertMany(items);
+		// A recall taken while these vectors were still generating cached an FTS-only ranking, and
+		// committing vectors changes what recall returns -- so that cache must be dropped, or the
+		// pre-embedding order keeps being served for the whole cache TTL. Gated on `committed`: a
+		// batch whose provider returned a short or empty matrix inserts nothing, changes no ranking,
+		// and invalidating there would only discard a still-valid cache. Only the query cache is
+		// affected; the polyphonic subject dictionary is built from facts/gists, which an embedding
+		// batch never touches.
+		if (committed > 0) {
+			const caches = beam.caches as
+				| { queryCache?: { invalidate?: () => void }; _queryCache?: { invalidate?: () => void } }
+				| undefined;
+			caches?.queryCache?.invalidate?.();
+			caches?._queryCache?.invalidate?.();
+		}
 	} catch (error) {
 		// Background embedding generation is best-effort: a failing provider, a closed DB
 		// during shutdown, or a transient API error must never disrupt the synchronous

--- a/packages/mnemopi/test/embedding-cache-invalidation.test.ts
+++ b/packages/mnemopi/test/embedding-cache-invalidation.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Regression: a recall taken while background embeddings are still generating caches an FTS-only
+ * ranking. Committing the vectors changes what recall returns, but the commit did not invalidate
+ * that cache, so the pre-embedding order kept being served for the whole cache TTL (one hour).
+ *
+ * The invalidation is deliberately gated on rows actually committing: a provider that returns a
+ * short or empty matrix inserts nothing, changes no ranking, and must not discard a valid cache.
+ */
+import { describe, expect, it } from "bun:test";
+import { initBeam } from "@oh-my-pi/pi-mnemopi/core/beam/schema";
+import { remember } from "@oh-my-pi/pi-mnemopi/core/beam/store";
+import type { BeamEvent, BeamMemoryState } from "@oh-my-pi/pi-mnemopi/core/beam/types";
+import { resetEmbeddingProviderForTests, setEmbeddingProviderForTests } from "@oh-my-pi/pi-mnemopi/core/embeddings";
+import { openDatabase } from "@oh-my-pi/pi-mnemopi/db";
+
+function makeState(sessionId = "session-a", events: BeamEvent[] = []): BeamMemoryState {
+	const db = openDatabase(":memory:");
+	initBeam(db);
+	const state: BeamMemoryState = {
+		db,
+		dbPath: ":memory:",
+		sessionId,
+		authorId: "author-a",
+		authorType: "user",
+		channelId: "channel-a",
+		useCloud: false,
+		eventEmitter: event => {
+			events.push(event);
+		},
+		pluginManager: {
+			emit: event => {
+				events.push({ ...event, type: `plugin:${event.type}` });
+			},
+		},
+		annotations: null,
+		triples: null,
+		episodicGraph: null,
+		veracityConsolidator: null,
+		caches: { timestampParse: new Map(), extractionBuffer: [] },
+		config: {
+			workingMemoryLimit: 1000,
+			workingMemoryTtlHours: 24,
+			recencyHalflifeHours: 72,
+			vecWeight: 0.5,
+			ftsWeight: 0.3,
+			importanceWeight: 0.2,
+			useCloud: false,
+			localLlmEnabled: false,
+			maxEpisodeChars: 100_000,
+		},
+	};
+	return state;
+}
+
+/** Counts invalidations and lets a test resolve the provider on demand, so ordering is provable. */
+function instrument(sessionId: string): {
+	beam: BeamMemoryState;
+	counts: { invalidations: number };
+} {
+	const beam = makeState(sessionId);
+	const counts = { invalidations: 0 };
+	(beam.caches as { queryCache?: { invalidate: () => void } }).queryCache = {
+		invalidate: () => {
+			counts.invalidations += 1;
+		},
+	};
+	beam.pendingExtractions = new Set();
+	return { beam, counts };
+}
+
+describe("embedding commit invalidates the recall cache", () => {
+	it("invalidates exactly once, and only AFTER the vectors are committed", async () => {
+		const { beam, counts } = instrument("embed-invalidate");
+		let release: () => void = () => {};
+		const gate = new Promise<void>(resolve => {
+			release = resolve;
+		});
+		setEmbeddingProviderForTests({
+			embed: async function* embedForTest(texts: readonly string[]) {
+				await gate; // held open so the assertions below run BEFORE any commit
+				yield texts.map(() => [0.1, 0.2, 0.3]);
+			},
+			available: () => true,
+		});
+		try {
+			remember(beam, "a memory that will be embedded in the background", { source: "conversation" });
+			counts.invalidations = 0; // remember() invalidates synchronously; measure only the commit
+			const pending = [...(beam.pendingExtractions ?? [])];
+			expect(pending).toHaveLength(1);
+			// Provider still blocked: nothing committed, so nothing invalidated yet.
+			const before = beam.db.prepare("SELECT COUNT(*) AS count FROM memory_embeddings").get() as {
+				count: number;
+			};
+			expect(before.count).toBe(0);
+			expect(counts.invalidations).toBe(0);
+
+			release();
+			await Promise.all(pending);
+
+			const after = beam.db.prepare("SELECT COUNT(*) AS count FROM memory_embeddings").get() as {
+				count: number;
+			};
+			expect(after.count).toBe(1);
+			expect(counts.invalidations).toBe(1);
+		} finally {
+			resetEmbeddingProviderForTests();
+			beam.db.close();
+		}
+	});
+
+	it("does NOT invalidate when the batch commits no rows", async () => {
+		const { beam, counts } = instrument("embed-no-commit");
+		setEmbeddingProviderForTests({
+			// Empty matrix: every item's vector is undefined, so nothing is inserted.
+			embed: async function* embedForTest() {
+				yield [] as number[][];
+			},
+			available: () => true,
+		});
+		try {
+			remember(beam, "a memory whose embedding batch returns nothing", { source: "conversation" });
+			counts.invalidations = 0;
+			await Promise.all([...(beam.pendingExtractions ?? [])]);
+			const stored = beam.db.prepare("SELECT COUNT(*) AS count FROM memory_embeddings").get() as {
+				count: number;
+			};
+			expect(stored.count).toBe(0);
+			// No ranking changed, so a valid cache must be left in place.
+			expect(counts.invalidations).toBe(0);
+		} finally {
+			resetEmbeddingProviderForTests();
+			beam.db.close();
+		}
+	});
+});


### PR DESCRIPTION
I reviewed the diff, a background embedding batch committed its vectors without dropping the cached ranking, so the same query kept returning the stale order.

## Repro

Enable the enhanced recall cache, then recall a query while `remember()` is still generating embeddings in the background. The recall stores an FTS-only ranking in the cache. When the vectors land moments later they change what recall *should* return — but the identical query keeps being served the pre-embedding order for the rest of the cache TTL (one hour by default).

## Cause

`runEmbedding()` inserts the vectors and returns without touching `beam.caches.queryCache`. Every other mutation path in the beam clears the caches after changing what recall would return; this one did not, so the cache outlived the ranking it was built from.

## Fix

`runEmbedding()` counts the rows actually committed inside the insert transaction and invalidates the query cache only when `committed > 0`.

The gate matters: a provider that returns a short or empty matrix inserts nothing, changes no ranking, and must not discard a valid cache. The polyphonic subject dictionary is deliberately left alone — it derives from facts and gists, not embeddings.

## Verification

- `packages/mnemopi`: **464 pass / 0 fail** on this branch (2 commits over `main`).
- New `test/embedding-cache-invalidation.test.ts`: the embedding provider is held open behind a promise gate so ordering is provable — blocked, 0 rows stored and 0 invalidations; released, exactly 1 row and exactly 1 invalidation. A second test covers the zero-insert no-op.
- **Revert-proof:** removing the invalidation turns the suite red (1 pass / 1 fail).
- Anti-vacuity: the tests observe stored rows in `memory_embeddings`, not provider invocations, so a provider whose output is discarded cannot make them pass.
- `bun run check:rs` not run — no Rust toolchain here. No CI has run on this branch.

## Exercised behaviour

The repro below was run on both this branch and current main, I observed exactly what is stated below in the table.

Repro used (not part of the PR — it asserts nothing, it prints what a real `QueryCache` still
returns). It installs the `QueryCache` already shipped in `core/query-cache.ts`, which is exactly
the host this code path exists to serve:

```
cd ~/dev/omp-polyphonic/oh-my-pi
git fetch origin
git checkout --detach origin/main   && bun test ../work/repro-cache-invalidation.test.ts
git checkout fix/embedding-commit-cache-invalidation && bun test ../work/repro-cache-invalidation.test.ts
```

| | after the operation, the cached ranking is… |
|---|---|
| `origin/main` | pre-embedding ranking still served |
| this branch | cache was cleared |
