### PR TITLE
fix(mnemopi): invalidate the recall cache when a memory is retired

### DIFF
--- a/packages/mnemopi/CHANGELOG.md
+++ b/packages/mnemopi/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed an explicitly invalidated memory still being returned by an identical repeat query until the recall cache expired.
+
 ## [18.0.9] - 2026-08-28
 
 ### Fixed

--- a/packages/mnemopi/src/core/beam/store.ts
+++ b/packages/mnemopi/src/core/beam/store.ts
@@ -651,7 +651,16 @@ export function invalidate(beam: BeamMemoryState, memoryId: string, replacementI
 		`,
 		[now, replacementId, memoryId, beam.sessionId],
 	);
-	if (working.changes > 0) return true;
+	if (working.changes > 0) {
+		// Recall filters `valid_until`/`superseded_by` in SQL, but the enhanced path consults the
+		// query cache BEFORE it reaches SQL. Without this the row a caller just retired keeps being
+		// served to an identical query for the rest of the cache TTL -- the one thing an explicit
+		// invalidation is supposed to guarantee against. Every other mutator here already does this;
+		// this one was the omission. Gated on an actual row change, like `forgetWorking`, so a
+		// no-op invalidation never discards a valid cache.
+		invalidateCaches(beam);
+		return true;
+	}
 	const episodic = beam.db.run(
 		`
 			UPDATE episodic_memory
@@ -660,7 +669,11 @@ export function invalidate(beam: BeamMemoryState, memoryId: string, replacementI
 		`,
 		[now, replacementId, memoryId, beam.sessionId],
 	);
-	return episodic.changes > 0;
+	if (episodic.changes > 0) {
+		invalidateCaches(beam);
+		return true;
+	}
+	return false;
 }
 
 export function getWorkingStats(

--- a/packages/mnemopi/test/invalidate-clears-caches.test.ts
+++ b/packages/mnemopi/test/invalidate-clears-caches.test.ts
@@ -1,0 +1,98 @@
+/**
+ * `invalidate()` retires a memory by setting `valid_until`/`superseded_by`. Recall filters both in
+ * SQL, but a host that installs a query cache consults it BEFORE reaching SQL, so the retired row
+ * keeps being served to an identical query until the cache expires.
+ *
+ * Every other mutator in `store.ts` calls `invalidateCaches()` after changing what recall would
+ * return; `invalidate()` did not. These tests pin the contract at the seam `invalidateCaches()`
+ * itself uses — the `invalidate()` hook on `beam.caches.queryCache` — so they hold regardless of
+ * which cache implementation a host wires in.
+ */
+import { describe, expect, test } from "bun:test";
+import { initBeam } from "@oh-my-pi/pi-mnemopi/core/beam/schema";
+import { invalidate, remember } from "@oh-my-pi/pi-mnemopi/core/beam/store";
+import type { BeamMemoryState } from "@oh-my-pi/pi-mnemopi/core/beam/types";
+import { openDatabase } from "@oh-my-pi/pi-mnemopi/db";
+
+/** A beam whose query cache counts how often it is invalidated. */
+function makeBeam(): { beam: BeamMemoryState; cleared: () => number } {
+	const db = openDatabase(":memory:");
+	initBeam(db);
+	let cleared = 0;
+	const beam = {
+		db,
+		dbPath: ":memory:",
+		sessionId: "session-a",
+		authorId: null,
+		authorType: null,
+		channelId: "session-a",
+		useCloud: false,
+		eventEmitter: () => {},
+		pluginManager: { emit: () => {} },
+		annotations: null,
+		triples: null,
+		episodicGraph: null,
+		veracityConsolidator: null,
+		caches: {
+			timestampParse: new Map(),
+			extractionBuffer: [],
+			queryCache: {
+				invalidate: () => {
+					cleared += 1;
+				},
+			},
+		},
+		config: {
+			workingMemoryLimit: 1000,
+			workingMemoryTtlHours: 24,
+			recencyHalflifeHours: 72,
+			vecWeight: 0.5,
+			ftsWeight: 0.3,
+			importanceWeight: 0.2,
+			useCloud: false,
+			localLlmEnabled: false,
+			maxEpisodeChars: 100_000,
+		},
+	} as unknown as BeamMemoryState;
+	return { beam, cleared: () => cleared };
+}
+
+describe("invalidate() clears the recall caches", () => {
+	test("retiring a working-memory row invalidates the query cache", () => {
+		const { beam, cleared } = makeBeam();
+		const id = remember(beam, "the quarterly corridor forecast was withdrawn", { source: "conversation" });
+		const before = cleared();
+
+		expect(invalidate(beam, id)).toBe(true);
+		expect(cleared()).toBe(before + 1);
+
+		beam.db.close();
+	});
+
+	test("retiring an episodic row invalidates the query cache", () => {
+		const { beam, cleared } = makeBeam();
+		beam.db.run(
+			`INSERT INTO episodic_memory (id, content, source, timestamp, importance, scope, session_id)
+			 VALUES (?, ?, 'conversation', ?, 0.5, 'session', ?)`,
+			["ep-1", "an episodic summary that is no longer true", new Date().toISOString(), "session-a"],
+		);
+		const before = cleared();
+
+		// Falls through the working-memory UPDATE, which matches nothing, into the episodic one.
+		expect(invalidate(beam, "ep-1")).toBe(true);
+		expect(cleared()).toBe(before + 1);
+
+		beam.db.close();
+	});
+
+	test("an invalidation that matches no row leaves the cache alone", () => {
+		const { beam, cleared } = makeBeam();
+		remember(beam, "a memory that is not the target", { source: "conversation" });
+		const before = cleared();
+
+		expect(invalidate(beam, "no-such-memory-id")).toBe(false);
+		expect(cleared()).toBe(before);
+
+		beam.db.close();
+	});
+});


### PR DESCRIPTION
Diff reviewed in full, an explicit invalidation was leaving a stale row
in the recall cache, so the same query kept returning it.

## Repro

Retire a memory with an explicit invalidation, then repeat the query that surfaced it. With a query cache installed, the retired row is served again from the cache for the rest of its TTL — the one outcome an explicit invalidation is supposed to rule out.

## Cause

`invalidate()` sets `valid_until`/`superseded_by`, and recall filters both in SQL — but a host that installs a cache consults it *before* reaching SQL.

Every other mutator in `store.ts` calls `invalidateCaches()` after changing what recall would return; `invalidate()` was the one omission. There are 7 such call sites on `main` today and this is not among them.

Note on severity: with no query cache wired into `beam.caches` in this repo today, the bug is **latent** — it becomes live for any host that installs one, which is the case `invalidateCaches()` exists to serve.

## Fix

Both tiers clear the caches when they actually change a row, gated on `changes > 0` exactly like `forgetWorking`, so an invalidation matching nothing never discards a valid cache.

## Verification

- `packages/mnemopi`: **465 pass / 0 fail** on this branch (1 commit over `main`).
- New `test/invalidate-clears-caches.test.ts` pins the contract at the seam `invalidateCaches()` itself uses — the `invalidate()` hook on `beam.caches.queryCache` — so it holds for any cache implementation rather than assuming one. Covers the working tier, the episodic fallback, and the no-op case.
- Three mutants all turn the suite red: dropping either tier's clear, and firing it unconditionally.
- `bun run check:rs` not run — no Rust toolchain here. No CI has run on this branch.

## Exercised behaviour

The repro below was ran on both this branch and current main, to satisfy the CONTRIBUTION rules: I saw exactly what the table below shows.

Repro used (not part of the PR — it asserts nothing, it prints what a real `QueryCache` still
returns). It installs the `QueryCache` already shipped in `core/query-cache.ts`, which is exactly
the host this code path exists to serve:

```
cd ~/dev/omp-polyphonic/oh-my-pi
git fetch origin
git checkout --detach origin/main   && bun test ../work/repro-cache-invalidation.test.ts
git checkout fix/invalidate-clears-recall-cache && bun test ../work/repro-cache-invalidation.test.ts
```

| | after the operation, the cached ranking is… |
|---|---|
| `origin/main` | cache still holds the retired row |
| this branch | cache was cleared |
