### PR TITLE
fix(tui): preserve relative image URL pastes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed relative API addresses ending in image extensions being swallowed as missing local image files instead of pasted as text ([#10103](https://github.com/can1357/oh-my-pi/issues/10103)).
+
 ## [18.0.10] - 2026-08-28
 
 ### Added

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -92,7 +92,6 @@ const BRACKETED_IMAGE_PATH_REGEX = /\.(?:png|jpe?g|gif|webp)$/i;
 const SHELL_ESCAPED_PATH_CHAR_REGEX = /\\([\\\s'"()[\]{}&;<>|?*!$`])/g;
 const URI_SCHEME_REGEX = /^[a-z][a-z0-9+.-]*:/i;
 const FILE_URI_REGEX = /^file:\/\//i;
-const WINDOWS_DRIVE_PATH_REGEX = /^[a-z]:[\\/]/i;
 /**
  * Alternation of the filesystem prefixes that make a path unambiguously
  * absolute (POSIX root, home, `file://`, UNC, Windows drive). Shared by
@@ -179,9 +178,9 @@ function normalizePastedPath(path: string): string {
 }
 
 function isExplicitPastedPath(path: string): boolean {
-	if (WINDOWS_DRIVE_PATH_REGEX.test(path) || FILE_URI_REGEX.test(path)) return true;
+	if (ABSOLUTE_PATH_PREFIX_REGEX.test(path) || /^\.\.?[\\/]/.test(path)) return true;
 	if (URI_SCHEME_REGEX.test(path)) return false;
-	return path.includes("/") || path.includes("\\");
+	return path.includes("\\");
 }
 
 function isImagePath(path: string): boolean {
@@ -234,9 +233,9 @@ function splitPastedPathSegments(payload: string): string[] | undefined {
 /**
  * Extract whitespace/quoted-separated path-like segments from `payload`.
  * Shared backend of {@link extractBracketedPastePaths} and {@link extractPastePathsFromText}.
- * Returns the segments only when EVERY segment looks like an explicit path
- * (`/`, `\`, drive letter, or `file://`); otherwise undefined so the caller
- * falls back to a plain text paste.
+ * Returns the segments only when EVERY segment looks like an anchored local
+ * path or uses Windows separators; otherwise undefined so ambiguous relative
+ * URL/path text falls back to a plain text paste.
  */
 function extractExplicitPathSegments(payload: string): string[] | undefined {
 	const pasted = payload.trim();

--- a/packages/coding-agent/test/modes/components/custom-editor.test.ts
+++ b/packages/coding-agent/test/modes/components/custom-editor.test.ts
@@ -180,12 +180,28 @@ describe("CustomEditor bracketed path paste", () => {
 		expect(extractBracketedImagePastePaths(bracketedPaste("icon-photo-default.png"))).toBeUndefined();
 	});
 
+	it("inserts a relative .png API address as text instead of treating it as a local image", () => {
+		const { editor } = makeEditor();
+		const address = "api/file/icon/867d45144217eec6d3c5805fd5a2d548.png";
+		const onPasteImagePath = vi.fn();
+		editor.onPasteImagePath = onPasteImagePath;
+
+		editor.handleInput(bracketedPaste(address));
+
+		expect(editor.getText()).toBe(address);
+		expect(onPasteImagePath).not.toHaveBeenCalled();
+		expect(extractImagePathFromText(address)).toBeUndefined();
+	});
+
 	it("extracts explicit local image paths for attachment", () => {
 		expect(extractBracketedImagePastePaths(bracketedPaste("/tmp/icon-photo-default.png"))).toEqual([
 			"/tmp/icon-photo-default.png",
 		]);
 		expect(extractBracketedImagePastePaths(bracketedPaste("C:\\Users\\me\\icon-photo-default.png"))).toEqual([
 			"C:\\Users\\me\\icon-photo-default.png",
+		]);
+		expect(extractBracketedImagePastePaths(bracketedPaste("./images/icon-photo-default.png"))).toEqual([
+			"./images/icon-photo-default.png",
 		]);
 	});
 


### PR DESCRIPTION
## Repro
Pasting `api/file/icon/867d45144217eec6d3c5805fd5a2d548.png` through a bracketed paste reproduced the failure with `bun -e 'import { extractBracketedImagePastePaths } from "./packages/coding-agent/src/modes/components/custom-editor.ts"; const text = "api/file/icon/867d45144217eec6d3c5805fd5a2d548.png"; const paste = `\x1b[200~${text}\x1b[201~`; const paths = extractBracketedImagePastePaths(paste); console.log(JSON.stringify(paths)); process.exit(paths?.[0] === text ? 1 : 0);'`: before the fix it printed the address as an image-path array and exited 1.

## Cause
`isExplicitPastedPath` in `packages/coding-agent/src/modes/components/custom-editor.ts` treated every forward slash as proof of a local filesystem path. Relative API addresses ending in a supported image extension therefore bypassed normal text insertion and reached the missing-image path.

## Fix
- Keep unanchored forward-slash paths on the normal text paste route.
- Preserve image attachment for absolute, home-relative, dot-relative, `file://`, UNC, drive-letter, and Windows-backslash paths.
- Cover bracketed and clipboard-text paste routing, including explicit `./` image paths.
- Document the user-visible fix in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/modes/components/custom-editor.test.ts packages/coding-agent/test/issue-2375-repro.test.ts` passed: 60 tests, 143 expectations. `bun --cwd=packages/coding-agent run check` passed. The exact repro now prints `undefined` and exits 0. The pre-publish `bun check` gate also passed. Fixes #10103