### PR TITLE
fix(coding-agent): close /session panel with Esc without aborting the session

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Escape aborting an active turn when dismissing the `/session` information panel; the panel now owns focus until closed.
+
 ## [18.0.10] - 2026-08-28
 
 ### Added

--- a/packages/coding-agent/src/modes/components/session-info-overlay.ts
+++ b/packages/coding-agent/src/modes/components/session-info-overlay.ts
@@ -1,0 +1,96 @@
+import { type Component, Ellipsis, matchesKey, ScrollView, Text, truncateToWidth } from "@oh-my-pi/pi-tui";
+import { theme } from "../theme/theme";
+import { matchesSelectCancel } from "../utils/keybinding-matchers";
+import { OverlayPanel, PanelDivider } from "./overlay-box";
+
+const FOOTER_HINT = "↑/↓ scroll · Esc close";
+const PANEL_CHROME_ROWS = 4;
+
+/** Terminal surface needed to size the session info viewport. */
+export interface SessionInfoOverlayHost {
+	readonly terminal: {
+		readonly rows: number;
+	};
+}
+
+/** Focused, dismissible `/session` information panel. */
+export class SessionInfoOverlay implements Component {
+	readonly #host: SessionInfoOverlayHost;
+	readonly #onClose: () => void;
+	readonly #panel: OverlayPanel;
+	readonly #info: Text;
+	readonly #scrollView: ScrollView;
+	readonly #footer: Text;
+	#lastInfoWidth: number | undefined;
+	#lastInfoLines: readonly string[] | undefined;
+	#lastHeight: number | undefined;
+
+	constructor(host: SessionInfoOverlayHost, info: string, onClose: () => void) {
+		this.#host = host;
+		this.#onClose = onClose;
+		this.#info = new Text(info, 0, 0);
+		this.#scrollView = new ScrollView([], {
+			height: 0,
+			scrollbar: "auto",
+			ellipsis: Ellipsis.Omit,
+			theme: {
+				track: text => theme.fg("dim", text),
+				thumb: text => theme.fg("accent", text),
+			},
+		});
+		this.#footer = new Text(FOOTER_HINT, 0, 0);
+		this.#footer.setStyleFn(text => theme.fg("dim", text));
+		this.#panel = new OverlayPanel("Session Info");
+		this.#panel.addChild(this.#scrollView);
+		this.#panel.addChild(new PanelDivider());
+		this.#panel.addChild(this.#footer);
+	}
+
+	handleInput(data: string): void {
+		if (matchesSelectCancel(data) || matchesKey(data, "escape") || matchesKey(data, "esc")) {
+			this.#onClose();
+			return;
+		}
+		this.#scrollView.handleScrollKey(data);
+	}
+
+	invalidate(): void {
+		this.#info.invalidate();
+		this.#lastInfoWidth = undefined;
+		this.#lastInfoLines = undefined;
+		this.#lastHeight = undefined;
+		this.#panel.invalidate();
+	}
+
+	setIgnoreTight(ignore: boolean): this {
+		this.#info.setIgnoreTight(ignore);
+		this.#panel.setIgnoreTight(ignore);
+		return this;
+	}
+
+	dispose(): void {
+		this.#panel.dispose();
+	}
+
+	render(width: number): readonly string[] {
+		const innerWidth = Math.max(1, width - 4);
+		this.#footer.setText(truncateToWidth(FOOTER_HINT, innerWidth));
+
+		const maxBodyHeight = Math.max(1, this.#host.terminal.rows - PANEL_CHROME_ROWS);
+		const fullWidthInfoLines = this.#info.render(innerWidth);
+		const infoWidth = fullWidthInfoLines.length > maxBodyHeight ? Math.max(1, innerWidth - 1) : innerWidth;
+		const infoLines = infoWidth === innerWidth ? fullWidthInfoLines : this.#info.render(infoWidth);
+		if (this.#lastInfoWidth !== infoWidth || this.#lastInfoLines !== infoLines) {
+			this.#scrollView.setLines(infoLines);
+			this.#lastInfoWidth = infoWidth;
+			this.#lastInfoLines = infoLines;
+		}
+
+		const height = Math.max(1, Math.min(infoLines.length, maxBodyHeight));
+		if (this.#lastHeight !== height) {
+			this.#scrollView.setHeight(height);
+			this.#lastHeight = height;
+		}
+		return this.#panel.render(width);
+	}
+}

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -302,9 +302,9 @@ export class CommandController {
 				: this.ctx.session.sessionManager.getUsageStatistics().premiumRequests;
 		const normalizedPremiumRequests = Math.round((premiumRequests + Number.EPSILON) * 100) / 100;
 
-		let info = `${theme.bold("Session Info")}\n\n`;
+		let info = "";
 		info += `${theme.fg("dim", "File:")} ${stats.sessionFile ?? "In-memory"}\n`;
-		info += `${theme.fg("dim", "ID:")} ${stats.sessionId}\n\n`;
+		info += `${theme.fg("dim", "ID:")} ${stats.sessionId}\n`;
 		info += `\n${theme.bold("Provider")}\n`;
 		const model = this.ctx.session.model;
 		if (!model) {
@@ -396,7 +396,7 @@ export class CommandController {
 			}
 		}
 
-		this.ctx.presentCommandOutput([new Spacer(1), new Text(info, 1, 0)]);
+		this.ctx.showSessionInfo(info);
 	}
 
 	static readonly #advisorStatusGlyph: Record<string, string> = {

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -4957,7 +4957,10 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.#sessionInfoOverlayHandle = undefined;
 		if (!handle) return;
 		handle.hide();
-		this.ui.setFocus(this.editor);
+		// Focus the visible editor-slot owner, not this.editor: an extension ask
+		// or hook may have swapped into editorContainer while the panel was open,
+		// and keys must reach the visible prompt (same stale-focus class as #3349).
+		this.#selectorController.focusActiveEditorArea();
 		this.ui.requestRender();
 	}
 

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -175,6 +175,7 @@ import type { HookInputComponent } from "./components/hook-input";
 import type { HookSelectorComponent, HookSelectorSlider } from "./components/hook-selector";
 import { type PlanReviewAnnotationState, PlanReviewOverlay } from "./components/plan-review-overlay";
 import { PlanSaveOverlay, type PlanSaveOverlayResult } from "./components/plan-save-overlay";
+import { SessionInfoOverlay } from "./components/session-info-overlay";
 import { StatusLineComponent } from "./components/status-line";
 import { stopSharedSpinnerTicker, type ToolExecutionHandle } from "./components/tool-execution";
 import { TranscriptContainer } from "./components/transcript-container";
@@ -741,6 +742,7 @@ export class InteractiveMode implements InteractiveModeContext {
 	#planModeHasEntered = false;
 	#planReviewOverlay: PlanReviewOverlay | undefined;
 	#planReviewOverlayHandle: OverlayHandle | undefined;
+	#sessionInfoOverlayHandle: OverlayHandle | undefined;
 	#planReviewCancel: (() => void) | undefined;
 	/** Serializable review annotations keyed by the resolved plan file path. */
 	#planReviewAnnotationState = new Map<string, PlanReviewAnnotationState>();
@@ -788,6 +790,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		return this.#focusController.unfocus();
 	}
 	clearTransientSessionUi(): void {
+		this.#hideSessionInfo();
 		if (this.loadingAnimation) {
 			this.loadingAnimation.stop();
 			this.loadingAnimation = undefined;
@@ -4713,6 +4716,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		// Clear the process-global consent handler so it doesn't outlive this
 		// InteractiveMode instance (e.g. test harnesses, headless re-init).
 		setAutoQaConsentHandler(null, null);
+		this.#hideSessionInfo();
 		if (this.#ownsStartedUi) {
 			this.ui.stop();
 			this.#ownsStartedUi = false;
@@ -4933,6 +4937,27 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.#pendingCommandOutput.push(...items);
 		this.#pendingCommandOutputCommands += 1;
 		this.#renderDeferredCommandNotice();
+		this.ui.requestRender();
+	}
+	showSessionInfo(info: string): void {
+		this.#hideSessionInfo();
+		const overlay = new SessionInfoOverlay(this.ui, info, () => this.#hideSessionInfo());
+		this.#sessionInfoOverlayHandle = this.ui.showOverlay(overlay, {
+			anchor: "bottom-center",
+			width: "100%",
+			maxHeight: "100%",
+			margin: 0,
+		});
+		this.ui.setFocus(overlay);
+		this.ui.requestRender();
+	}
+
+	#hideSessionInfo(): void {
+		const handle = this.#sessionInfoOverlayHandle;
+		this.#sessionInfoOverlayHandle = undefined;
+		if (!handle) return;
+		handle.hide();
+		this.ui.setFocus(this.editor);
 		this.ui.requestRender();
 	}
 

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -271,6 +271,8 @@ export interface InteractiveModeContext {
 	 * native scrollback.
 	 */
 	presentCommandOutput(content: Component | readonly Component[]): void;
+	/** Show session information in a focused transient overlay. */
+	showSessionInfo(info: string): void;
 	/** Mount command output deferred by {@link presentCommandOutput}. */
 	flushPendingCommandOutput(): void;
 	/**

--- a/packages/coding-agent/test/modes/components/session-info-overlay.test.ts
+++ b/packages/coding-agent/test/modes/components/session-info-overlay.test.ts
@@ -1,0 +1,195 @@
+import { afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
+import { type Component, type OverlayHandle, setKeybindings, TUI, visibleWidth } from "@oh-my-pi/pi-tui";
+import type { Terminal, TerminalAppearance } from "@oh-my-pi/pi-tui/terminal";
+import { KeybindingsManager } from "../../../src/config/keybindings";
+import { Settings } from "../../../src/config/settings";
+import { SessionInfoOverlay } from "../../../src/modes/components/session-info-overlay";
+import { getThemeByName, setThemeInstance, type Theme } from "../../../src/modes/theme/theme";
+
+class MinimalTerminal implements Terminal {
+	columns = 80;
+	rows = 24;
+	kittyProtocolActive = false;
+	kittyEnableSequence: string | null = null;
+	keyboardEnhancementEnterSequence: string | null = null;
+	keyboardEnhancementExitSequence: string | null = null;
+	appearance: TerminalAppearance | undefined;
+	#onInput: ((data: string) => void) | undefined;
+	output = "";
+
+	start(onInput: (data: string) => void, _onResize: () => void): void {
+		this.#onInput = onInput;
+	}
+
+	stop(): void {
+		this.#onInput = undefined;
+	}
+
+	async drainInput(_maxMs?: number, _idleMs?: number): Promise<void> {}
+
+	write(data: string): void {
+		this.output += data;
+	}
+
+	moveBy(_lines: number): void {}
+
+	hideCursor(): void {}
+
+	showCursor(): void {}
+
+	clearLine(): void {}
+
+	clearFromCursor(): void {}
+
+	clearScreen(): void {}
+
+	setTitle(_title: string): void {}
+
+	setProgress(_active: boolean): void {}
+
+	onAppearanceChange(_callback: (appearance: TerminalAppearance) => void): void {}
+
+	sendInput(data: string): void {
+		this.#onInput?.(data);
+	}
+}
+
+class InputRecorder implements Component {
+	readonly inputs: string[] = [];
+
+	constructor(readonly label: string) {}
+
+	handleInput(data: string): void {
+		this.inputs.push(data);
+	}
+
+	render(_width: number): string[] {
+		return [this.label];
+	}
+}
+
+let uiTheme: Theme;
+
+beforeAll(async () => {
+	await Settings.init({ inMemory: true });
+	const loaded = await getThemeByName("dark");
+	if (!loaded) throw new Error("theme unavailable");
+	uiTheme = loaded;
+	setThemeInstance(uiTheme);
+});
+
+afterEach(() => {
+	setKeybindings(KeybindingsManager.inMemory());
+	vi.restoreAllMocks();
+});
+
+describe("SessionInfoOverlay", () => {
+	it("renders session details, footer help, and fixed-width box rows", () => {
+		const overlay = new SessionInfoOverlay(
+			{ terminal: { rows: 12 } },
+			"File: /tmp/session.jsonl\nProvider: openai\nTokens: 42",
+			() => {},
+		);
+
+		const lines = overlay.render(48);
+		const plain = lines.map(line => line.replace(/\x1b\[[0-9;]*m/g, ""));
+		const text = plain.join("\n");
+
+		expect(text).toContain("Session Info");
+		expect(text).toContain("File: /tmp/session.jsonl");
+		expect(text).toContain("↑/↓ scroll · Esc close");
+		expect(lines.map(line => visibleWidth(line))).toEqual(Array(lines.length).fill(48));
+		expect(plain[0]).toContain(uiTheme.boxRound.topLeft);
+		expect(plain.at(-1)).toContain(uiTheme.boxRound.bottomLeft);
+		expect(lines).toHaveLength(7);
+	});
+
+	it("preserves exact-width details when the scrollbar is visible", () => {
+		const exactWidthDetail = `${"A".repeat(43)}Z`;
+		const overlay = new SessionInfoOverlay(
+			{ terminal: { rows: 8 } },
+			[exactWidthDetail, "line 2", "line 3", "line 4", "line 5"].join("\n"),
+			() => {},
+		);
+
+		const text = overlay
+			.render(48)
+			.map(line => line.replace(/\x1b\[[0-9;]*m/g, ""))
+			.join("\n");
+
+		expect(text).toContain("Z");
+	});
+
+	it("keeps narrow panels within the terminal height", () => {
+		const overlay = new SessionInfoOverlay(
+			{ terminal: { rows: 8 } },
+			Array.from({ length: 20 }, (_, index) => `Detail ${index}`).join("\n"),
+			() => {},
+		);
+
+		const lines = overlay.render(12);
+		const plain = lines.map(line => line.replace(/\x1b\[[0-9;]*m/g, ""));
+
+		expect(lines.length).toBeLessThanOrEqual(8);
+		expect(plain[0]).toContain(uiTheme.boxRound.topLeft);
+		expect(plain.at(-1)).toContain(uiTheme.boxRound.bottomLeft);
+	});
+
+	it("scrolls long details and closes on the configured cancel key", () => {
+		setKeybindings(KeybindingsManager.inMemory({ "tui.select.cancel": "ctrl+g" }));
+		const onClose = vi.fn();
+		const overlay = new SessionInfoOverlay(
+			{ terminal: { rows: 8 } },
+			Array.from({ length: 20 }, (_, index) => `Detail ${index}`).join("\n"),
+			onClose,
+		);
+
+		const initial = overlay
+			.render(40)
+			.map(line => line.replace(/\x1b\[[0-9;]*m/g, ""))
+			.join("\n");
+		overlay.handleInput("\x1b[B");
+		const scrolled = overlay
+			.render(40)
+			.map(line => line.replace(/\x1b\[[0-9;]*m/g, ""))
+			.join("\n");
+
+		expect(scrolled).not.toBe(initial);
+		expect(onClose).not.toHaveBeenCalled();
+		overlay.handleInput("\x07");
+		expect(onClose).toHaveBeenCalledTimes(1);
+		overlay.handleInput("\x1b");
+		expect(onClose).toHaveBeenCalledTimes(2);
+	});
+
+	it("owns Escape through TUI focus and restores the editor without forwarding it", () => {
+		const terminal = new MinimalTerminal();
+		const tui = new TUI(terminal);
+		const editor = new InputRecorder("editor");
+		let handle: OverlayHandle | undefined;
+		const onClose = vi.fn(() => handle?.hide());
+		const overlay = new SessionInfoOverlay(tui, "File: in-memory", onClose);
+
+		tui.addChild(editor);
+		tui.setFocus(editor);
+		try {
+			tui.start();
+			handle = tui.showOverlay(overlay, {
+				anchor: "bottom-center",
+				width: "100%",
+				maxHeight: "100%",
+				margin: 0,
+			});
+
+			expect(tui.getFocused()).toBe(overlay);
+			terminal.sendInput("\x1b");
+
+			expect(onClose).toHaveBeenCalledTimes(1);
+			expect(editor.inputs).toEqual([]);
+			expect(tui.getFocused()).toBe(editor);
+		} finally {
+			handle?.hide();
+			tui.stop();
+		}
+	});
+});


### PR DESCRIPTION
## What

`/session` used to display the session info inline, and if the agent was working, dismissing it with `esc` aborted the ongoing agent turn

With this fix, `/session` opens its own info overlay, which can be dismissed with esc without interrupting the underlying session

<img width="5454" height="2986" alt="screenshot-2026-08-28_16-15-28" src="https://github.com/user-attachments/assets/1e9e955a-583f-4c15-84dd-3227281e6c8d" />

## Why

Many times I just wanted to get the session info to e.g. reference it in a different session, and ended up interrupting the current session to dismiss the info panel

## Testing

I manually tested it, and also included automated tests

---

- [X] `bun check` passes
- [X] Tested locally
- [X] CHANGELOG updated (if user-facing)