### PR TITLE
fix(ai): classify zero-content message_stop stream truncation as transient

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed session-level auto-retry never firing for empty (`contentBlocks: 0`) Anthropic stream truncations reported as `stream ended before message_stop`, matching the existing retry behavior already applied to `stream ended before message_start`.
+
 ## [18.0.9] - 2026-08-28
 
 ### Fixed

--- a/packages/ai/src/error/flags.ts
+++ b/packages/ai/src/error/flags.ts
@@ -153,7 +153,7 @@ function matchesPayloadRejectionText(text: string): boolean {
 
 const TIMEOUT_PATTERN = /\b(?:operation\s+)?timed?\s*out\b|\btimeout\b|\bstream stall\b/i;
 const TRANSIENT_ENVELOPE_PATTERN = /anthropic stream envelope error:/i;
-const TRANSIENT_ENVELOPE_BEFORE_START_PATTERN = /before message_start/i;
+const TRANSIENT_ENVELOPE_TRUNCATION_PATTERN = /before message_(?:start|stop)/i;
 export const STREAM_READ_ERROR_PATTERN = /stream[_ -]?read[_ -]?error/i;
 export const TRANSIENT_TRANSPORT_PATTERN =
 	/\b(?:no[_ -]?capacity|(?:high|peak)[ _-]?demand|(?:at|over|insufficient)[ _-]?capacity|capacity[ _-]?(?:exceeded|exhausted)|peak[ _-]?load)\b|overloaded|provider.?returned.?error|rate.?limit|too many requests|\b(?:429|500|502|503|504)\b|service.?unavailable|server.?error|internal.?error|retry your request|network.?error|connection.?error|connection.?refused|unable.?to.?connect\.\s*is the computer able to access the url\?|other side closed|fetch failed|upstream.?connect|upstream.?request.?failed|reset before headers|socket hang up|timed? out|timeout|terminated|retry delay|stream stall|no error details in response|HTTP2(?:StreamReset|RefusedStream|EnhanceYourCalm)|nghttp2_(?:internal_error|refused_stream)|stream closed with error code nghttp2_(?:internal_error|refused_stream)|malformed.?function.?call/i;
@@ -404,7 +404,7 @@ function isTransientErrorText(text: string): boolean {
 	return (
 		isUnexpectedSocketCloseMessage(text) ||
 		isStreamReadErrorText(text) ||
-		(TRANSIENT_ENVELOPE_PATTERN.test(text) && TRANSIENT_ENVELOPE_BEFORE_START_PATTERN.test(text)) ||
+		(TRANSIENT_ENVELOPE_PATTERN.test(text) && TRANSIENT_ENVELOPE_TRUNCATION_PATTERN.test(text)) ||
 		TRANSIENT_TRANSPORT_PATTERN.test(text)
 	);
 }

--- a/packages/coding-agent/test/agent-session-retry-fallback.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-fallback.test.ts
@@ -3706,6 +3706,64 @@ describe("AgentSession retry fallback", () => {
 		expect(lastAssistant.content).toContainEqual({ type: "text", text: "Recovered after Anthropic envelope retry" });
 	});
 
+	it("auto-retries Anthropic stream-envelope failures before message_stop", async () => {
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) {
+			throw new Error("Expected bundled Anthropic test model to exist");
+		}
+
+		const envelopeError = "Anthropic stream envelope error: stream ended before message_stop";
+		const requestedModels: string[] = [];
+
+		const mock = createMockModel({
+			responses: [{ throw: envelopeError }, { content: ["Recovered after Anthropic envelope retry"] }],
+		});
+		const agent = new Agent({
+			getApiKey: model => `${model.provider}-test-key`,
+			initialState: {
+				model,
+				systemPrompt: ["Test"],
+				tools: [],
+				messages: [],
+			},
+			streamFn: (requestedModel, context, options) => {
+				requestedModels.push(`${requestedModel.provider}/${requestedModel.id}`);
+				return mock.stream(requestedModel, context, options);
+			},
+		});
+
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"retry.baseDelayMs": 5,
+			"retry.maxRetries": 1,
+		});
+		settings.setModelRole("default", `${model.provider}/${model.id}`);
+
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+		});
+		const { retryStartEvents, retryEndEvents } = trackRetryEvents(session);
+
+		await session.prompt("Retry Anthropic envelope failure before message_stop");
+		await session.waitForIdle();
+
+		expect(requestedModels).toEqual([`${model.provider}/${model.id}`, `${model.provider}/${model.id}`]);
+		expect(retryStartEvents).toHaveLength(1);
+		expect(retryStartEvents[0]).toMatchObject({
+			attempt: 1,
+			maxAttempts: 1,
+			errorMessage: envelopeError,
+		});
+		expect(retryEndEvents).toHaveLength(1);
+		expect(retryEndEvents[0]).toMatchObject({ success: true, attempt: 1 });
+		const lastAssistant = getLastAssistantMessage(session);
+		expect(lastAssistant.stopReason).toBe("stop");
+		expect(lastAssistant.content).toContainEqual({ type: "text", text: "Recovered after Anthropic envelope retry" });
+	});
+
 	it("falls back on mid-stream Anthropic envelope failures without same-model retries", async () => {
 		const primaryModel = getBundledModel("anthropic", "claude-sonnet-4-5");
 		const fallbackModel = getBundledModel("openai", "gpt-4o-mini");


### PR DESCRIPTION
## Problem

Session-level auto-retry (`#isRetryableError` in `AgentSession`) never fires for:

```
Anthropic stream envelope error: stream ended before message_stop
```

`TRANSIENT_ENVELOPE_BEFORE_START_PATTERN` in `packages/ai/src/error/flags.ts` only matched `before message_start`, excluding the symmetric `message_stop` case from `Flag.Transient` classification. Without that flag, `retriable()` returns `false` and the turn just dies with no `auto_retry_start`/`auto_retry_end` ever firing.

Provider-level retry (`anthropic.ts`, up to `PROVIDER_MAX_RETRIES`) already retries this exact text transparently, gated correctly by `!streamedReplayUnsafeContent` so it never replays over partial output. But once all provider attempts are exhausted (e.g. a persistent connection-level cutoff), the terminal error reaches the session layer as `stopReason: "error"`, and the session-layer classifier silently refuses to retry it further — even though the message is empty (`contentBlocks: 0`) and has nothing unsafe to replay.

## Evidence

Reproduced against production logs across 8+ independent sessions/models over many hours, all showing the identical shape:

```json
{"contentBlocks":0,"hasToolCalls":false,"hasText":false,"errorId":0,"stopReason":"error"}
```

`errorId: 0` confirms the message was completely unclassified (not `Flag.Transient`, not anything). Failure timing was a consistent ~40-53s window from stream start regardless of activity/gaps — pointing at an upstream connection-level cutoff (plausibly AWS Bedrock via a Bifrost-style gateway) rather than an idle timeout. Tuning gateway-side `network_config` (request/stream idle timeout, HTTP/2 keepalive ping) did not change the failure point, consistent with this being outside the client's control — which is exactly why session-level retry needs to cover it.

## Fix

Renamed `TRANSIENT_ENVELOPE_BEFORE_START_PATTERN` -> `TRANSIENT_ENVELOPE_TRUNCATION_PATTERN` and widened it to match both `before message_start` and `before message_stop`:

```diff
-const TRANSIENT_ENVELOPE_BEFORE_START_PATTERN = /before message_start/i;
+const TRANSIENT_ENVELOPE_TRUNCATION_PATTERN = /before message_(?:start|stop)/i;
```

The unrelated post-content exclusion (`before terminal stop signal`, handled separately by `STREAM_EVENT_ORDER_PATTERN` / `#hasReplayUnsafeToolOutput`'s tool-call check) is untouched and still correctly classified non-retryable — confirmed via smoke test, since the native test harness in this checkout has an unrelated pre-existing `desktop-adapter.js` WeakMap error blocking `bun test` on a clean `main` checkout too.

## Verification

```
message_stop:   { isTransient: true,  retriable: true  }  // was: false, false
message_start:  { isTransient: true,  retriable: true  }  // unchanged
post_content:   { isTransient: false, retriable: false }  // unchanged (correctly excluded)
```
