### PR TITLE
fix(advisor): cap provider requests per update

### DIFF
--- a/docs/advisor-watchdog.md
+++ b/docs/advisor-watchdog.md
@@ -150,6 +150,10 @@ Guard-level suppression is invisible to the model because `AdviseTool` has alrea
 
 The guard's full state — dedupe history and per-update gate — clears on every advisor reset (compaction, session switch, `/new`), so a re-primed reviewer can re-raise issues it already raised against the rewritten transcript.
 
+## Bounded updates with `advisor.maxRequestsPerUpdate`
+
+`advisor.maxRequestsPerUpdate` limits the provider requests made by one advisor update. It defaults to `10` and applies even when tool names or arguments change, so non-repeating loops cannot evade it. Reaching the limit stops that update and emits a warning that identifies the setting; set it to `0` to disable the limit.
+
 ## Bounded catch-up with `advisor.syncBacklog`
 
 `advisor.syncBacklog` is not lockstep turn execution. It is a bounded catch-up delay for the primary agent when the advisor falls behind.

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -376,6 +376,7 @@ See [Advisor and WATCHDOG.md](./advisor-watchdog.md) for runtime behavior, `WATC
 | Key                   | Type    | Default | Notes                                                                                                                                                |
 | --------------------- | ------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `advisor.enabled`     | boolean | `false` | Enable the advisor runtime when `modelRoles.advisor` resolves to an available model.                                                                 |
+| `advisor.maxRequestsPerUpdate` | number  | `10`    | Maximum provider requests per advisor update. Reaching the limit stops that update with a warning; `0` disables the limit.                           |
 | `task.agentAdvisor`   | record  | `{}`    | Per-agent subagent advisor: agent name → `"on"` / `"off"` / advisor model pattern. Overrides agent frontmatter `advisor`; configured from the `/agents` hub. |
 | `advisor.syncBacklog` | enum    | `off`   | Bounded advisor catch-up delay: `off`, `1`, `3`, or `5`. The primary waits up to 30 seconds only while advisor backlog is at or above the threshold. |
 | `advisor.immuneTurns` | number  | `3`     | After a `concern`/`blocker` interrupts, route further concerns/blockers as non-interrupting asides for this many completed primary turns.            |

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Bounded each advisor update with the configurable `advisor.maxRequestsPerUpdate` setting, preventing non-repeating tool loops from running indefinitely. Set it to `0` to disable the limit.
+
 ## [18.0.10] - 2026-08-28
 
 ### Added

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -540,6 +540,17 @@ export const SETTINGS_SCHEMA = {
 				"Pair a second model (assigned to the 'advisor' role) that passively reviews each turn and injects notes.",
 		},
 	},
+	"advisor.maxRequestsPerUpdate": {
+		type: "number",
+		default: 10,
+		ui: {
+			tab: "model",
+			group: "Advisor",
+			label: "Advisor Request Limit",
+			description: "Maximum provider requests per advisor update. Set to 0 to disable the limit.",
+			condition: "advisorEnabled",
+		},
+	},
 	"prewalk.enabled": {
 		type: "boolean",
 		default: false,

--- a/packages/coding-agent/src/session/session-advisors.ts
+++ b/packages/coding-agent/src/session/session-advisors.ts
@@ -980,6 +980,7 @@ export class SessionAdvisors {
 				},
 				abort: reason => advisorAgent.abort(reason),
 				reset: () => {
+					advisorRequests = 0;
 					advisorLoopGuard.reset();
 					advisorLoopGuardStopped = false;
 					advisorAgent.reset();

--- a/packages/coding-agent/src/session/session-advisors.ts
+++ b/packages/coding-agent/src/session/session-advisors.ts
@@ -919,10 +919,19 @@ export class SessionAdvisors {
 				serviceTierResolver: advisorServiceTierResolver,
 			});
 			advisorAgent.setDisableReasoning(shouldDisableReasoning(advisorThinkingLevel));
+			let advisorRequests = 0;
+			advisorAgent.addBeforeModelCall(() => {
+				advisorRequests++;
+				const maxRequests = this.#host.settings.get("advisor.maxRequestsPerUpdate");
+				if (maxRequests <= 0 || advisorRequests <= maxRequests) return;
+				this.#host.emitNotice(
+					"warning",
+					`Advisor "${advisorName}" reached its request limit (${maxRequests}); this update was stopped. Change advisor.maxRequestsPerUpdate or set it to 0 to disable the limit.`,
+					"advisor",
+				);
+				return { stop: true };
+			});
 			let advisorLoopGuardStopped = false;
-			// The advisor's own loop needs the same repeated-tool-call bound the
-			// primary gets from `LoopGuards`; nothing else stops it reissuing one
-			// failing call until the update is abandoned.
 			const advisorLoopGuard = new AdvisorLoopGuard({
 				settings: this.#host.settings,
 				name: advisorName,
@@ -941,6 +950,7 @@ export class SessionAdvisors {
 			const advisorAgentFacade: AdvisorAgent = {
 				prompt: async input => {
 					let quarantined: string | undefined;
+					advisorRequests = 0;
 					advisorLoopGuard.reset();
 					advisorLoopGuardStopped = false;
 					try {

--- a/packages/coding-agent/src/session/session-advisors.ts
+++ b/packages/coding-agent/src/session/session-advisors.ts
@@ -950,7 +950,6 @@ export class SessionAdvisors {
 			const advisorAgentFacade: AdvisorAgent = {
 				prompt: async input => {
 					let quarantined: string | undefined;
-					advisorRequests = 0;
 					advisorLoopGuard.reset();
 					advisorLoopGuardStopped = false;
 					try {
@@ -1026,6 +1025,7 @@ export class SessionAdvisors {
 				onTurnError: (error, failedMessages, signal) =>
 					this.#recoverAdvisorTurn(advisorRef, error, failedMessages, signal),
 				onTurnSuccess: async () => {
+					advisorRequests = 0;
 					// Commit the delivered batch so retries of a failed turn stay deduped
 					// while this successful turn's context is persisted once (issue #9553).
 					advisorRef.recorder.commitTurn();
@@ -1038,7 +1038,10 @@ export class SessionAdvisors {
 						role: fallback.role,
 					});
 				},
-				onTurnAbandoned: () => advisorRef.recorder.abandonTurn(),
+				onTurnAbandoned: () => {
+					advisorRequests = 0;
+					advisorRef.recorder.abandonTurn();
+				},
 				notifyFailure: error => {
 					this.#advisorStatuses.set(slug, { name: advisorName, status: "error" });
 					const message = error instanceof Error ? error.message : String(error);

--- a/packages/coding-agent/test/advisor-tool-call-loop-guard.test.ts
+++ b/packages/coding-agent/test/advisor-tool-call-loop-guard.test.ts
@@ -63,7 +63,7 @@ describe("advisor tool-call loop guard", () => {
 		guardSettings: Record<string, unknown>,
 		maxRepeatedTurns = 8,
 	): { advisor: Agent; contexts: Context[] } {
-		const primaryMock = createMockModel({ provider: "anthropic", responses: [{ content: ["primary complete"] }] });
+		const primaryMock = createMockModel({ provider: "anthropic", handler: { content: ["primary complete"] } });
 		const advisorMock = createMockModel({ provider: "anthropic" });
 		const contexts: Context[] = [];
 		let turn = 0;
@@ -141,10 +141,8 @@ describe("advisor tool-call loop guard", () => {
 		await session.prompt("review the current update");
 		expect(await session.waitForAdvisorCatchup(2_000)).toBe(true);
 
-		// First threshold injects one corrective; ignoring it re-arms the
-		// detector, and the second threshold aborts. The agent loop observes the
-		// abort after one already-scheduled request, bounding twenty repeats at 7.
-		expect(contexts).toHaveLength(7);
+		// The request gate observes the guard abort before another provider request starts.
+		expect(contexts).toHaveLength(6);
 		const delivered = JSON.stringify(contexts[3]!.messages);
 		expect(delivered).toContain("You called `read` 3 consecutive times");
 		expect(delivered).toContain("ENOENT: no such file or directory");
@@ -202,15 +200,47 @@ describe("advisor tool-call loop guard", () => {
 		expect(messages[0]?.role).toBe("user");
 	});
 
-	it("leaves the advisor unbounded when the shared loop guard is disabled", async () => {
-		const { advisor, contexts } = createAdvisor({ "model.toolCallLoopGuard.enabled": false });
+	it("stops every advisor update at the configured request limit", async () => {
+		const { advisor, contexts } = createAdvisor(
+			{
+				"advisor.maxRequestsPerUpdate": 3,
+				"model.toolCallLoopGuard.enabled": false,
+			},
+			20,
+		);
+
+		if (!session) throw new Error("Expected live session");
+		const notices: string[] = [];
+		session.subscribe(event => {
+			if (event.type === "notice" && event.level === "warning" && event.source === "advisor") {
+				notices.push(event.message);
+			}
+		});
+		await session.prompt("review the current update");
+		expect(await session.waitForAdvisorCatchup(2_000)).toBe(true);
+
+		expect(contexts).toHaveLength(3);
+		expect(notices).toHaveLength(1);
+		expect(notices[0]).toContain("reached its request limit (3)");
+		expect(notices[0]).toContain("advisor.maxRequestsPerUpdate");
+		await session.prompt("review another update");
+		expect(await session.waitForAdvisorCatchup(2_000)).toBe(true);
+		expect(contexts).toHaveLength(6);
+		expect(notices).toHaveLength(2);
+		expect(advisor.state.error).toBeUndefined();
+	});
+
+	it("allows an advisor update to opt out of the request limit", async () => {
+		const { advisor, contexts } = createAdvisor({
+			"advisor.maxRequestsPerUpdate": 0,
+			"model.toolCallLoopGuard.enabled": false,
+		});
 
 		await advisor.prompt("review the current update");
 
 		expect(contexts.some(context => JSON.stringify(context.messages).includes("tool_call_loop_detected"))).toBe(
 			false,
 		);
-		// Nine requests: eight repeated tool-call turns plus the final stop.
 		expect(contexts).toHaveLength(9);
 	});
 });

--- a/packages/coding-agent/test/advisor-tool-call-loop-guard.test.ts
+++ b/packages/coding-agent/test/advisor-tool-call-loop-guard.test.ts
@@ -62,6 +62,7 @@ describe("advisor tool-call loop guard", () => {
 	function createAdvisor(
 		guardSettings: Record<string, unknown>,
 		maxRepeatedTurns = 8,
+		failFirstRequest = false,
 	): { advisor: Agent; contexts: Context[] } {
 		const primaryMock = createMockModel({ provider: "anthropic", handler: { content: ["primary complete"] } });
 		const advisorMock = createMockModel({ provider: "anthropic" });
@@ -69,6 +70,27 @@ describe("advisor tool-call loop guard", () => {
 		let turn = 0;
 		const advisorStreamFn: typeof advisorMock.stream = (_model, context) => {
 			contexts.push(context);
+			const stream = new AssistantMessageEventStream();
+			if (failFirstRequest && turn === 0) {
+				turn++;
+				const message: AssistantMessage = {
+					role: "assistant",
+					content: [],
+					api: advisorMock.api,
+					provider: advisorMock.provider,
+					model: advisorMock.id,
+					usage: zeroUsage,
+					stopReason: "error",
+					errorMessage: "HTTP 503 Service Unavailable",
+					errorStatus: 503,
+					timestamp: Date.now(),
+				};
+				queueMicrotask(() => {
+					stream.push({ type: "start", partial: message });
+					stream.push({ type: "error", reason: "error", error: message });
+				});
+				return stream;
+			}
 			// Deliberately ignore the corrective. The enabled guard must hard-stop
 			// this stream; the finite ceiling keeps the disabled control bounded.
 			const repeating = turn < maxRepeatedTurns;
@@ -94,7 +116,6 @@ describe("advisor tool-call loop guard", () => {
 						stopReason: "stop",
 						timestamp: Date.now(),
 					};
-			const stream = new AssistantMessageEventStream();
 			queueMicrotask(() => {
 				stream.push({ type: "start", partial: message });
 				stream.push({ type: "done", reason: repeating ? "toolUse" : "stop", message });
@@ -228,6 +249,28 @@ describe("advisor tool-call loop guard", () => {
 		expect(contexts).toHaveLength(6);
 		expect(notices).toHaveLength(2);
 		expect(advisor.state.error).toBeUndefined();
+	});
+
+	it("preserves the request limit across a recoverable retry", async () => {
+		const { contexts } = createAdvisor(
+			{
+				"advisor.maxRequestsPerUpdate": 3,
+				"model.toolCallLoopGuard.enabled": false,
+			},
+			20,
+			true,
+		);
+
+		if (!session) throw new Error("Expected live session");
+		const capped = Promise.withResolvers<void>();
+		session.subscribe(event => {
+			if (event.type === "notice" && event.source === "advisor" && event.message.includes("request limit")) {
+				capped.resolve();
+			}
+		});
+		await session.prompt("review the current update");
+		await capped.promise;
+		expect(contexts).toHaveLength(3);
 	});
 
 	it("allows an advisor update to opt out of the request limit", async () => {


### PR DESCRIPTION
## Why

The repeated-call guard only catches identical calls. An advisor that alternates tools or changes arguments can still run forever.

## What changed

Each advisor update now has a configurable provider-request limit: `advisor.maxRequestsPerUpdate`, default `10`. Hitting it stops the update and shows a warning. Set it to `0` to opt out.

This stays at one counter plus the existing pre-model hook; it does not add per-tool budgets or cost accounting.

## Test plan

- `bunx bun@1.4.0 test test/advisor-tool-call-loop-guard.test.ts` from `packages/coding-agent` — 4 pass
- `bunx bun@1.4.0 run check` — pass, including cyclomatic-complexity lint
- `bunx bun@1.4.0 run test` — 4 pre-existing hardcoded hash failures in unchanged `export-html-template.test.ts`

## Risk / rollback

Ten requests may be too low for some workflows, so the setting can be raised or disabled. Revert the commit to remove the behavior.

Closes #7130
