### PR TITLE
fix(advisor): ignore repository operations

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Restricted Advisor review to implementation work by filtering Git, GitHub, and Graphite tool messages and suppressing repository-operation findings before delivery.
+
 ## [18.0.10] - 2026-08-28
 
 ### Added

--- a/packages/coding-agent/src/advisor/emission-guard.ts
+++ b/packages/coding-agent/src/advisor/emission-guard.ts
@@ -100,6 +100,12 @@ const SUPPRESSED_NORMALIZED_PHRASES: Record<string, true> = {
  */
 const DEFAULT_HISTORY_CAPACITY = 4096;
 
+const OPERATIONAL_NOTE_PATTERNS = [
+	/\b(?:git|github|graphite|gh|gt|pull request|tool call|tool result)\b/u,
+	/\b(?:shell|bash|command|tool)\b(?:\s+\S+){0,12}\s+\b(?:skipped|failed|timed out|timeout|retry|retried)\b/u,
+	/\b(?:branch|commit|checkout|merge|push|fetch|rebase|remote)\b(?:\s+\S+){0,12}\s+\b(?:repository|repo|origin|upstream|head|staging|main)\b/u,
+] as const;
+
 /**
  * Decides whether an advisor `advise()` call should reach the primary agent.
  *
@@ -158,6 +164,7 @@ export class AdvisorEmissionGuard {
 		const key = normalizeAdvisorNote(note);
 		if (!key) return false;
 		if (SUPPRESSED_NORMALIZED_PHRASES[key]) return false;
+		if (OPERATIONAL_NOTE_PATTERNS.some(pattern => pattern.test(key))) return false;
 		if (this.#seen.has(key)) return false;
 		if (this.#consumedThisUpdate) return false;
 		this.#consumedThisUpdate = true;

--- a/packages/coding-agent/src/advisor/input-filter.ts
+++ b/packages/coding-agent/src/advisor/input-filter.ts
@@ -1,0 +1,50 @@
+import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
+import type { ToolCall } from "@oh-my-pi/pi-ai";
+
+const OPERATIONAL_TOOL_NAMES: Record<string, true> = { git: true, github: true, gh: true, graphite: true, gt: true };
+const SHELL_TOOL_NAMES: Record<string, true> = { bash: true, shell: true, exec: true, terminal: true };
+const COMMAND_BOUNDARY =
+	/(?:^|[\n;&|()])\s*(?:(?:command|builtin|exec|nohup|sudo)\s+)*(?:env(?:\s+(?:-[^\s]+|[A-Za-z_][A-Za-z0-9_]*=[^\s]+))*\s+)?(?:git|gh|gt)(?=\s|$)/u;
+
+function stringArgument(arguments_: Record<string, unknown>, key: string): string | undefined {
+	const value = arguments_[key];
+	return typeof value === "string" ? value : undefined;
+}
+
+function isOperationalToolCall(call: ToolCall): boolean {
+	const name = call.name.toLowerCase();
+	const nameSegments = name.split(/[^a-z0-9]+/u);
+	if (nameSegments.some(segment => OPERATIONAL_TOOL_NAMES[segment])) return true;
+	if (!nameSegments.some(segment => SHELL_TOOL_NAMES[segment])) return false;
+	const command =
+		stringArgument(call.arguments, "command") ??
+		stringArgument(call.arguments, "cmd") ??
+		stringArgument(call.arguments, "script");
+	return command !== undefined && COMMAND_BOUNDARY.test(command);
+}
+
+/**
+ * Removes any assistant message containing a repository-operation call and all
+ * results paired with calls from that message. The primary transcript remains
+ * unchanged; only the model-visible Advisor view is filtered.
+ */
+export function filterAdvisorInput(
+	messages: readonly AgentMessage[],
+	hiddenCallIds = new Set<string>(),
+): AgentMessage[] {
+	const filtered: AgentMessage[] = [];
+	for (const message of messages) {
+		if (
+			message.role === "assistant" &&
+			message.content.some(block => block.type === "toolCall" && isOperationalToolCall(block))
+		) {
+			for (const block of message.content) {
+				if (block.type === "toolCall") hiddenCallIds.add(block.id);
+			}
+			continue;
+		}
+		if (message.role === "toolResult" && hiddenCallIds.has(message.toolCallId)) continue;
+		filtered.push(message);
+	}
+	return filtered;
+}

--- a/packages/coding-agent/src/advisor/runtime.ts
+++ b/packages/coding-agent/src/advisor/runtime.ts
@@ -13,6 +13,7 @@ import {
 	PRIMARY_CONTEXT_CUSTOM_TYPES,
 } from "../session/session-history-format";
 import { ADVISOR_RENDER_OPTIONS, renderAdvisorDeltaChunks } from "./delta-split";
+import { filterAdvisorInput } from "./input-filter";
 import { fingerprintMessage } from "./message-fingerprint";
 
 /**
@@ -285,6 +286,7 @@ export class AdvisorRuntime {
 	#renderRevision = 0;
 	/** Regex secret values observed in primary deltas and retained until advisor context resets. */
 	#advisorRegexSecretValues = new Set<string>();
+	readonly #hiddenOperationalCallIds = new Set<string>();
 	#pending: PendingDelta[] = [];
 	#busy = false;
 	#sessionTransitionPaused = false;
@@ -487,6 +489,7 @@ export class AdvisorRuntime {
 		}
 		this.#lastCount = 0;
 		this.#deliveredPrefix = [];
+		this.#hiddenOperationalCallIds.clear();
 		this.#pending = [];
 		this.#clearAdvisorContextAtCurrentCursor();
 		if (clearBacklog) {
@@ -573,6 +576,7 @@ export class AdvisorRuntime {
 	 */
 	seedTo(count: number): void {
 		const messages = this.host.snapshotMessages().slice(0, count);
+		filterAdvisorInput(messages, this.#hiddenOperationalCallIds);
 		this.#lastCount = messages.length;
 		this.#deliveredPrefix = messages.map(message => ({
 			message,
@@ -800,7 +804,7 @@ export class AdvisorRuntime {
 			logger.debug("advisor context reset", { reason: "delivered-prefix-changed", lastCount: this.#lastCount });
 			this.#resetAdvisorContext(true, true);
 		}
-		const rawMessages = all.slice(this.#lastCount);
+		const rawMessages = filterAdvisorInput(all.slice(this.#lastCount), this.#hiddenOperationalCallIds);
 		for (let i = this.#lastCount; i < all.length; i++) {
 			const message = all[i];
 			if (message === undefined) continue;

--- a/packages/coding-agent/test/advisor/emission-guard.test.ts
+++ b/packages/coding-agent/test/advisor/emission-guard.test.ts
@@ -39,6 +39,32 @@ describe("AdvisorEmissionGuard", () => {
 		expect(guard.accept("No further watcher input needed.")).toBe(false);
 	});
 
+	it("suppresses repository and tool-operation findings", () => {
+		const notes = [
+			"The git checkout was skipped; retry it before continuing.",
+			"Run gh pr view before merging.",
+			"The Graphite submission needs the correct parent branch.",
+			"The bash command timed out, so the tool result is unverified.",
+			"Fetch origin/main before changing the repository remote.",
+		];
+		for (const note of notes) {
+			const guard = new AdvisorEmissionGuard();
+			expect(guard.accept(note)).toBe(false);
+		}
+	});
+
+	it("preserves code findings that use operational words in a code context", () => {
+		const notes = [
+			"The retry schedule is unbounded after a transient database error.",
+			"The command parser accepts an empty executable name.",
+			"The conditional branch drops the authenticated user ID.",
+		];
+		for (const note of notes) {
+			const guard = new AdvisorEmissionGuard();
+			expect(guard.accept(note)).toBe(true);
+		}
+	});
+
 	it("dedupes by normalized text across the session, ignoring casing and trailing punctuation", () => {
 		const guard = new AdvisorEmissionGuard();
 		expect(guard.accept("Move retries into the queue, not the request path.")).toBe(true);

--- a/packages/coding-agent/test/advisor/input-filter.test.ts
+++ b/packages/coding-agent/test/advisor/input-filter.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "bun:test";
+import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
+import { filterAdvisorInput } from "../../src/advisor/input-filter";
+
+function assistant(content: unknown[]): AgentMessage {
+	return { role: "assistant", content, timestamp: 1 } as AgentMessage;
+}
+
+function result(toolCallId: string, toolName: string, text: string): AgentMessage {
+	return {
+		role: "toolResult",
+		toolCallId,
+		toolName,
+		content: [{ type: "text", text }],
+		isError: false,
+		timestamp: 2,
+	} as AgentMessage;
+}
+
+describe("filterAdvisorInput", () => {
+	it("removes shell Git calls and their results", () => {
+		const messages = [
+			assistant([{ type: "toolCall", id: "git-call", name: "bash", arguments: { command: "git status --short" } }]),
+			result("git-call", "bash", "M src/app.ts"),
+		];
+
+		expect(filterAdvisorInput(messages)).toEqual([]);
+	});
+
+	it("recognizes gh and gt through shell wrappers and command chains", () => {
+		const messages = [
+			assistant([
+				{ type: "toolCall", id: "gh-call", name: "shell", arguments: { command: "env GH_REPO=x/y gh pr view 1" } },
+				{ type: "toolCall", id: "gt-call", name: "bash", arguments: { command: "printf ready && sudo gt submit" } },
+			]),
+			result("gh-call", "shell", "PR data"),
+			result("gt-call", "bash", "submitted"),
+		];
+
+		expect(filterAdvisorInput(messages)).toEqual([]);
+	});
+
+	it("removes namespaced repository tools", () => {
+		const messages = [
+			assistant([
+				{ type: "toolCall", id: "github-call", name: "xd.github", arguments: { op: "pr_create" } },
+				{ type: "toolCall", id: "graphite-call", name: "mcp__graphite__submit", arguments: { op: "submit" } },
+			]),
+			result("github-call", "xd.github", "created"),
+			result("graphite-call", "mcp__graphite__submit", "submitted"),
+		];
+
+		expect(filterAdvisorInput(messages)).toEqual([]);
+	});
+
+	it("hides a result delivered after its operational call", () => {
+		const hiddenCallIds = new Set<string>();
+		const call = assistant([
+			{ type: "toolCall", id: "git-call", name: "bash", arguments: { command: "git fetch origin" } },
+		]);
+
+		expect(filterAdvisorInput([call], hiddenCallIds)).toEqual([]);
+		expect(filterAdvisorInput([result("git-call", "bash", "fetched")], hiddenCallIds)).toEqual([]);
+	});
+
+	it("removes an entire mixed message and every paired result", () => {
+		const mixed = assistant([
+			{ type: "text", text: "The parser needs a bounded retry." },
+			{ type: "toolCall", id: "git-call", name: "bash", arguments: { command: "git diff -- src/parser.ts" } },
+			{ type: "toolCall", id: "edit-call", name: "edit", arguments: { path: "src/parser.ts" } },
+		]);
+
+		expect(
+			filterAdvisorInput([mixed, result("git-call", "bash", "diff"), result("edit-call", "edit", "updated parser")]),
+		).toEqual([]);
+	});
+
+	it("preserves commands where git-like text is an argument rather than an executable", () => {
+		const call = assistant([
+			{ type: "toolCall", id: "search-call", name: "bash", arguments: { command: "printf '%s' git status" } },
+		]);
+		const callResult = result("search-call", "bash", "gitstatus");
+
+		expect(filterAdvisorInput([call, callResult])).toEqual([call, callResult]);
+	});
+});


### PR DESCRIPTION
## Problem

Advisor receives operational transcript events and can repeatedly block the primary over Git, GitHub, Graphite, and tool execution rather than reviewing implementation quality. Prompt guidance reduces this behavior but cannot enforce the boundary.

## Change

- remove any assistant transcript message containing a `git`, `gh`, `gt`, GitHub, or Graphite operation from Advisor input
- remove every paired tool result, including results delivered in later deltas
- recognize direct, namespaced, and shell-wrapped operational tools
- suppress repository/tool-operation notes at the existing emission guard
- retain code findings that use words such as retry, command, or branch in implementation contexts

## Trade-off

If one assistant message bundles a repository operation with a code edit or reasoning, the entire message is hidden from Advisor. This is intentional: it provides a hard message-level boundary at the cost of potentially missing code review for that bundled message.

## Verification

- 184 Advisor tests pass
- coding-agent type check passes
- Biome check passes for all changed TypeScript files
