### PR TITLE
fix(utils): make runtime install lock crash-safe

### DIFF
--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `ensureRuntimeInstalled` so a crashed or killed runtime installer no longer wedges every later install for 60s: it now serializes with the OS-backed crash-safe lock (`withFileLock`) instead of a hand-rolled lock directory ([#10120](https://github.com/can1357/oh-my-pi/issues/10120)).
+
 ## [18.0.10] - 2026-08-28
 
 ### Added

--- a/packages/utils/src/runtime-install.ts
+++ b/packages/utils/src/runtime-install.ts
@@ -3,6 +3,7 @@ import * as fsp from "node:fs/promises";
 import * as Module from "node:module";
 import * as path from "node:path";
 import { withFileLock } from "./file-lock";
+import { isEexist, isEnoent } from "./fs-error";
 
 /**
  * On-demand runtime dependency support for native-heavy optional packages
@@ -304,35 +305,61 @@ export interface EnsureRuntimeInstalledOptions {
 	lockSleepMs?: number;
 }
 
-/** No runtime install plausibly runs this long, so an older legacy lock directory is a crash orphan. */
+/** No runtime install plausibly runs this long, so older legacy lock directories are crash orphans. */
 const STALE_LEGACY_LOCK_MS = 10 * 60_000;
 
 /**
- * Reclaim the pre-crash-safe `${runtimeDir}.lock` mkdir lock during migration.
+ * Run `fn` while reserving the pre-crash-safe `${runtimeDir}.lock` namespace.
  *
  * Versions through 18.0.10 serialized installs with a bare lock *directory*
  * that only its creator removed; an installer killed outside that window
  * (SIGKILL/OOM/Ctrl-C) left it unreleasable, wedging every later install for
- * the full wait envelope (issue #10120). The OS-backed lock now lives at a
- * distinct path, but during an in-flight upgrade a legacy process may still
- * legitimately own this directory. Wait for such an owner to finish — it
- * removes the directory on completion — before force-reclaiming, so old and new
- * installers do not `bun install` concurrently into the same tree. A directory
- * older than any plausible install ({@link STALE_LEGACY_LOCK_MS}) is a certain
- * crash orphan and is reclaimed at once. Ownership is otherwise never inferred
- * from this directory.
+ * the full wait envelope (issue #10120). During an in-flight upgrade a legacy
+ * process may still legitimately own this directory, so wait for it to finish
+ * before force-reclaiming. After the directory is released or reclaimed,
+ * atomically create and retain it through `fn`: an older process cannot acquire
+ * the legacy namespace between the handoff check and the new install.
  */
-async function reclaimLegacyLockDir(runtimeDir: string, attempts: number, sleepMs: number): Promise<void> {
+async function withLegacyInstallLock<T>(
+	runtimeDir: string,
+	attempts: number,
+	sleepMs: number,
+	fn: () => Promise<T>,
+): Promise<T> {
 	const legacy = `${runtimeDir}.lock`;
-	for (let attempt = 0; attempt < attempts; attempt++) {
-		const stat = await fsp.stat(legacy).catch(() => null);
-		// Gone (released by a live owner) or never the legacy directory shape.
-		if (!stat?.isDirectory()) return;
-		// Too old for any live install; treat as a crash orphan and reclaim now.
-		if (Date.now() - stat.mtimeMs > STALE_LEGACY_LOCK_MS) break;
-		await Bun.sleep(sleepMs);
+	for (;;) {
+		let reserved = false;
+		for (let attempt = 0; attempt < attempts; attempt++) {
+			try {
+				await fsp.mkdir(legacy);
+				reserved = true;
+				break;
+			} catch (error) {
+				if (!isEexist(error)) throw error;
+			}
+
+			let stat: fs.Stats;
+			try {
+				stat = await fsp.stat(legacy);
+			} catch (error) {
+				if (isEnoent(error)) continue;
+				throw error;
+			}
+			// A non-directory already reserves the namespace against old mkdir lockers.
+			if (!stat.isDirectory()) return fn();
+			if (Date.now() - stat.mtimeMs > STALE_LEGACY_LOCK_MS) break;
+			if (attempt + 1 < attempts) await Bun.sleep(sleepMs);
+		}
+
+		if (reserved) {
+			try {
+				return await fn();
+			} finally {
+				await fsp.rm(legacy, { recursive: true, force: true });
+			}
+		}
+		await fsp.rm(legacy, { recursive: true, force: true });
 	}
-	await fsp.rm(legacy, { recursive: true, force: true }).catch(() => {});
 }
 
 export async function writeRuntimeManifest(runtimeDir: string, install: RuntimeInstallSpec): Promise<void> {
@@ -380,8 +407,8 @@ async function runRuntimeInstall(runtimeDir: string): Promise<void> {
  * `${runtimeDir}.install.lock`, which the kernel releases on process death, so
  * a crashed installer cannot wedge later attempts (issue #10120). The path is
  * deliberately distinct from the legacy `${runtimeDir}.lock` mkdir directory;
- * see {@link reclaimLegacyLockDir} for how an in-flight legacy owner is handed
- * off during an upgrade rather than deleted out from under it.
+ * {@link withLegacyInstallLock} atomically reserves that namespace during the
+ * new install so older processes cannot cross the migration boundary.
  */
 export async function ensureRuntimeInstalled(options: EnsureRuntimeInstalledOptions): Promise<string> {
 	const { runtimeDir, install, onPhase, lockAttempts = 240, lockSleepMs = 250 } = options;
@@ -400,17 +427,17 @@ export async function ensureRuntimeInstalled(options: EnsureRuntimeInstalledOpti
 	// withFileLock does not create parent directories; the runtime cache dir may
 	// not exist yet on the very first install.
 	await fsp.mkdir(path.dirname(runtimeDir), { recursive: true });
-	await reclaimLegacyLockDir(runtimeDir, lockAttempts, lockSleepMs);
 	return withFileLock(
 		`${runtimeDir}.install`,
-		async () => {
-			if (await probeManifest.exists()) return runtimeDir;
-			await writeRuntimeManifest(runtimeDir, install);
-			onPhase?.("download");
-			await runRuntimeInstall(runtimeDir);
-			onPhase?.("done");
-			return runtimeDir;
-		},
+		() =>
+			withLegacyInstallLock(runtimeDir, lockAttempts, lockSleepMs, async () => {
+				if (await probeManifest.exists()) return runtimeDir;
+				await writeRuntimeManifest(runtimeDir, install);
+				onPhase?.("download");
+				await runRuntimeInstall(runtimeDir);
+				onPhase?.("done");
+				return runtimeDir;
+			}),
 		{ retries: lockAttempts, retryDelayMs: lockSleepMs },
 	);
 }

--- a/packages/utils/src/runtime-install.ts
+++ b/packages/utils/src/runtime-install.ts
@@ -315,50 +315,47 @@ const STALE_LEGACY_LOCK_MS = 10 * 60_000;
  * that only its creator removed; an installer killed outside that window
  * (SIGKILL/OOM/Ctrl-C) left it unreleasable, wedging every later install for
  * the full wait envelope (issue #10120). During an in-flight upgrade a legacy
- * process may still legitimately own this directory, so wait for it to finish
- * before force-reclaiming. After the directory is released or reclaimed,
- * atomically create and retain it through `fn`: an older process cannot acquire
- * the legacy namespace between the handoff check and the new install.
+ * process may still legitimately own this directory, so poll until it is
+ * released and only force-reclaim once the directory is older than any
+ * plausible install ({@link STALE_LEGACY_LOCK_MS}) — never merely because a
+ * retry budget elapsed, which would delete a still-active legacy lock and let
+ * two installers race the same tree. Once the namespace is free, atomically
+ * create and retain the directory through `fn`: an older process cannot acquire
+ * it between the handoff check and the new install.
  */
-async function withLegacyInstallLock<T>(
-	runtimeDir: string,
-	attempts: number,
-	sleepMs: number,
-	fn: () => Promise<T>,
-): Promise<T> {
+async function withLegacyInstallLock<T>(runtimeDir: string, sleepMs: number, fn: () => Promise<T>): Promise<T> {
 	const legacy = `${runtimeDir}.lock`;
 	for (;;) {
-		let reserved = false;
-		for (let attempt = 0; attempt < attempts; attempt++) {
-			try {
-				await fsp.mkdir(legacy);
-				reserved = true;
-				break;
-			} catch (error) {
-				if (!isEexist(error)) throw error;
-			}
-
+		try {
+			await fsp.mkdir(legacy);
+		} catch (error) {
+			if (!isEexist(error)) throw error;
+			// Someone already holds the legacy namespace.
 			let stat: fs.Stats;
 			try {
 				stat = await fsp.stat(legacy);
-			} catch (error) {
-				if (isEnoent(error)) continue;
-				throw error;
+			} catch (statError) {
+				if (isEnoent(statError)) continue; // released between mkdir and stat; retry
+				throw statError;
 			}
-			// A non-directory already reserves the namespace against old mkdir lockers.
+			// A non-directory is a newer lock file, which already excludes old mkdir lockers.
 			if (!stat.isDirectory()) return fn();
-			if (Date.now() - stat.mtimeMs > STALE_LEGACY_LOCK_MS) break;
-			if (attempt + 1 < attempts) await Bun.sleep(sleepMs);
-		}
-
-		if (reserved) {
-			try {
-				return await fn();
-			} finally {
+			// A fresh directory may still belong to a live pre-18.x installer, so
+			// wait for it to finish; only a crash orphan (older than any plausible
+			// install) is force-reclaimed.
+			if (Date.now() - stat.mtimeMs > STALE_LEGACY_LOCK_MS) {
 				await fsp.rm(legacy, { recursive: true, force: true });
+			} else {
+				await Bun.sleep(sleepMs);
 			}
+			continue;
 		}
-		await fsp.rm(legacy, { recursive: true, force: true });
+		// Reserved the legacy namespace; retain it across the install.
+		try {
+			return await fn();
+		} finally {
+			await fsp.rm(legacy, { recursive: true, force: true });
+		}
 	}
 }
 
@@ -430,7 +427,7 @@ export async function ensureRuntimeInstalled(options: EnsureRuntimeInstalledOpti
 	return withFileLock(
 		`${runtimeDir}.install`,
 		() =>
-			withLegacyInstallLock(runtimeDir, lockAttempts, lockSleepMs, async () => {
+			withLegacyInstallLock(runtimeDir, lockSleepMs, async () => {
 				if (await probeManifest.exists()) return runtimeDir;
 				await writeRuntimeManifest(runtimeDir, install);
 				onPhase?.("download");

--- a/packages/utils/src/runtime-install.ts
+++ b/packages/utils/src/runtime-install.ts
@@ -2,6 +2,7 @@ import * as fs from "node:fs";
 import * as fsp from "node:fs/promises";
 import * as Module from "node:module";
 import * as path from "node:path";
+import { withFileLock } from "./file-lock";
 
 /**
  * On-demand runtime dependency support for native-heavy optional packages
@@ -303,25 +304,24 @@ export interface EnsureRuntimeInstalledOptions {
 	lockSleepMs?: number;
 }
 
-function isErrnoCode(error: unknown, code: string): boolean {
-	return typeof error === "object" && error !== null && "code" in error && error.code === code;
-}
-
-async function acquireInstallLock(runtimeDir: string, attempts: number, sleepMs: number): Promise<() => Promise<void>> {
-	const lockDir = `${runtimeDir}.lock`;
-	await fsp.mkdir(path.dirname(lockDir), { recursive: true });
-	for (let attempt = 0; attempt < attempts; attempt++) {
-		try {
-			await fsp.mkdir(lockDir);
-			return async () => {
-				await fsp.rm(lockDir, { recursive: true, force: true });
-			};
-		} catch (error) {
-			if (!isErrnoCode(error, "EEXIST")) throw error;
-			await Bun.sleep(sleepMs);
-		}
+/**
+ * Best-effort removal of the pre-crash-safe `${runtimeDir}.lock` mkdir lock.
+ *
+ * Versions through 18.0.10 serialized installs with a bare lock *directory*
+ * that only its creator removed; an installer killed outside that window
+ * (SIGKILL/OOM/Ctrl-C) left it unreleasable, wedging every later install for
+ * the full wait envelope (issue #10120). The OS-backed lock now lives at a
+ * distinct path, so any leftover directory here is inert; clear it so it does
+ * not linger. Ownership is never inferred from this directory.
+ */
+async function removeLegacyLockDir(runtimeDir: string): Promise<void> {
+	try {
+		const legacy = `${runtimeDir}.lock`;
+		const stat = await fsp.stat(legacy).catch(() => null);
+		if (stat?.isDirectory()) await fsp.rm(legacy, { recursive: true, force: true });
+	} catch {
+		// A lingering legacy directory is inert with the new lock path; ignore.
 	}
-	throw new Error(`Timed out waiting for runtime install lock: ${lockDir}`);
 }
 
 export async function writeRuntimeManifest(runtimeDir: string, install: RuntimeInstallSpec): Promise<void> {
@@ -363,7 +363,13 @@ async function runRuntimeInstall(runtimeDir: string): Promise<void> {
 
 /**
  * Materialize a pinned dependency set into `runtimeDir` (idempotent,
- * cross-process safe via a lock directory). Returns `runtimeDir`.
+ * cross-process safe). Returns `runtimeDir`.
+ *
+ * Serialization uses the OS-backed {@link withFileLock} at
+ * `${runtimeDir}.install.lock`, which the kernel releases on process death, so
+ * a crashed installer cannot wedge later attempts (issue #10120). The path is
+ * deliberately distinct from the legacy `${runtimeDir}.lock` mkdir directory
+ * so stale directories from older versions are inert.
  */
 export async function ensureRuntimeInstalled(options: EnsureRuntimeInstalledOptions): Promise<string> {
 	const { runtimeDir, install, onPhase, lockAttempts = 240, lockSleepMs = 250 } = options;
@@ -379,15 +385,20 @@ export async function ensureRuntimeInstalled(options: EnsureRuntimeInstalledOpti
 	if (await probeManifest.exists()) return runtimeDir;
 
 	onPhase?.("initiate");
-	const releaseLock = await acquireInstallLock(runtimeDir, lockAttempts, lockSleepMs);
-	try {
-		if (await probeManifest.exists()) return runtimeDir;
-		await writeRuntimeManifest(runtimeDir, install);
-		onPhase?.("download");
-		await runRuntimeInstall(runtimeDir);
-		onPhase?.("done");
-		return runtimeDir;
-	} finally {
-		await releaseLock();
-	}
+	// withFileLock does not create parent directories; the runtime cache dir may
+	// not exist yet on the very first install.
+	await fsp.mkdir(path.dirname(runtimeDir), { recursive: true });
+	await removeLegacyLockDir(runtimeDir);
+	return withFileLock(
+		`${runtimeDir}.install`,
+		async () => {
+			if (await probeManifest.exists()) return runtimeDir;
+			await writeRuntimeManifest(runtimeDir, install);
+			onPhase?.("download");
+			await runRuntimeInstall(runtimeDir);
+			onPhase?.("done");
+			return runtimeDir;
+		},
+		{ retries: lockAttempts, retryDelayMs: lockSleepMs },
+	);
 }

--- a/packages/utils/src/runtime-install.ts
+++ b/packages/utils/src/runtime-install.ts
@@ -304,24 +304,35 @@ export interface EnsureRuntimeInstalledOptions {
 	lockSleepMs?: number;
 }
 
+/** No runtime install plausibly runs this long, so an older legacy lock directory is a crash orphan. */
+const STALE_LEGACY_LOCK_MS = 10 * 60_000;
+
 /**
- * Best-effort removal of the pre-crash-safe `${runtimeDir}.lock` mkdir lock.
+ * Reclaim the pre-crash-safe `${runtimeDir}.lock` mkdir lock during migration.
  *
  * Versions through 18.0.10 serialized installs with a bare lock *directory*
  * that only its creator removed; an installer killed outside that window
  * (SIGKILL/OOM/Ctrl-C) left it unreleasable, wedging every later install for
  * the full wait envelope (issue #10120). The OS-backed lock now lives at a
- * distinct path, so any leftover directory here is inert; clear it so it does
- * not linger. Ownership is never inferred from this directory.
+ * distinct path, but during an in-flight upgrade a legacy process may still
+ * legitimately own this directory. Wait for such an owner to finish — it
+ * removes the directory on completion — before force-reclaiming, so old and new
+ * installers do not `bun install` concurrently into the same tree. A directory
+ * older than any plausible install ({@link STALE_LEGACY_LOCK_MS}) is a certain
+ * crash orphan and is reclaimed at once. Ownership is otherwise never inferred
+ * from this directory.
  */
-async function removeLegacyLockDir(runtimeDir: string): Promise<void> {
-	try {
-		const legacy = `${runtimeDir}.lock`;
+async function reclaimLegacyLockDir(runtimeDir: string, attempts: number, sleepMs: number): Promise<void> {
+	const legacy = `${runtimeDir}.lock`;
+	for (let attempt = 0; attempt < attempts; attempt++) {
 		const stat = await fsp.stat(legacy).catch(() => null);
-		if (stat?.isDirectory()) await fsp.rm(legacy, { recursive: true, force: true });
-	} catch {
-		// A lingering legacy directory is inert with the new lock path; ignore.
+		// Gone (released by a live owner) or never the legacy directory shape.
+		if (!stat?.isDirectory()) return;
+		// Too old for any live install; treat as a crash orphan and reclaim now.
+		if (Date.now() - stat.mtimeMs > STALE_LEGACY_LOCK_MS) break;
+		await Bun.sleep(sleepMs);
 	}
+	await fsp.rm(legacy, { recursive: true, force: true }).catch(() => {});
 }
 
 export async function writeRuntimeManifest(runtimeDir: string, install: RuntimeInstallSpec): Promise<void> {
@@ -368,8 +379,9 @@ async function runRuntimeInstall(runtimeDir: string): Promise<void> {
  * Serialization uses the OS-backed {@link withFileLock} at
  * `${runtimeDir}.install.lock`, which the kernel releases on process death, so
  * a crashed installer cannot wedge later attempts (issue #10120). The path is
- * deliberately distinct from the legacy `${runtimeDir}.lock` mkdir directory
- * so stale directories from older versions are inert.
+ * deliberately distinct from the legacy `${runtimeDir}.lock` mkdir directory;
+ * see {@link reclaimLegacyLockDir} for how an in-flight legacy owner is handed
+ * off during an upgrade rather than deleted out from under it.
  */
 export async function ensureRuntimeInstalled(options: EnsureRuntimeInstalledOptions): Promise<string> {
 	const { runtimeDir, install, onPhase, lockAttempts = 240, lockSleepMs = 250 } = options;
@@ -388,7 +400,7 @@ export async function ensureRuntimeInstalled(options: EnsureRuntimeInstalledOpti
 	// withFileLock does not create parent directories; the runtime cache dir may
 	// not exist yet on the very first install.
 	await fsp.mkdir(path.dirname(runtimeDir), { recursive: true });
-	await removeLegacyLockDir(runtimeDir);
+	await reclaimLegacyLockDir(runtimeDir, lockAttempts, lockSleepMs);
 	return withFileLock(
 		`${runtimeDir}.install`,
 		async () => {

--- a/packages/utils/test/runtime-install.test.ts
+++ b/packages/utils/test/runtime-install.test.ts
@@ -3,7 +3,9 @@ import * as fs from "node:fs/promises";
 import * as Module from "node:module";
 import * as os from "node:os";
 import * as path from "node:path";
+import { isEnoent } from "../src/fs-error";
 import {
+	ensureRuntimeInstalled,
 	installRuntimeModuleResolver,
 	resolveRuntimeModule,
 	splitBareSpecifier,
@@ -238,4 +240,105 @@ describe("writeRuntimeManifest", () => {
 		const empty = await readManifest({ dependencies: { "kokoro-js": "1.2.1" }, overrides: {} });
 		expect("overrides" in empty).toBe(false);
 	});
+});
+
+// Contract under test: ensureRuntimeInstalled serializes installs with the
+// crash-safe OS-backed lock (issue #10120). A lock left behind by a process
+// that died mid-install must not wedge later attempts, and the pre-18.x
+// `${runtimeDir}.lock` mkdir *directory* must not permanently break the new
+// file-backed lock path.
+describe("ensureRuntimeInstalled install lock", () => {
+	// A local `file:` dependency keeps the real `bun install` offline and
+	// deterministic — no registry, no network.
+	async function makeFileDependency(): Promise<{ spec: string; probe: string }> {
+		const src = await fs.mkdtemp(path.join(os.tmpdir(), "omp-runtime-dep-"));
+		tempDirs.push(src);
+		await fs.writeFile(
+			path.join(src, "package.json"),
+			JSON.stringify({ name: "omp-runtime-fixture", version: "1.0.0" }),
+		);
+		return { spec: `file:${src}`, probe: "omp-runtime-fixture" };
+	}
+
+	async function makeRuntimeDir(): Promise<string> {
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "omp-runtime-cache-"));
+		tempDirs.push(root);
+		return path.join(root, "cache", "fixture-runtime");
+	}
+
+	test("a stale legacy .lock directory does not block install and is cleared", async () => {
+		const { spec, probe } = await makeFileDependency();
+		const runtimeDir = await makeRuntimeDir();
+		// The pre-18.x crash orphan: a bare lock directory with no live owner.
+		await fs.mkdir(`${runtimeDir}.lock`, { recursive: true });
+
+		await ensureRuntimeInstalled({
+			runtimeDir,
+			install: { dependencies: { [probe]: spec } },
+			probePackage: probe,
+			lockAttempts: 8,
+			lockSleepMs: 50,
+		});
+
+		expect(await Bun.file(path.join(runtimeDir, "node_modules", probe, "package.json")).exists()).toBe(true);
+		await expect(fs.stat(`${runtimeDir}.lock`)).rejects.toThrow();
+	}, 15_000);
+
+	test("a crashed lock owner does not wedge a later install", async () => {
+		const { spec, probe } = await makeFileDependency();
+		const runtimeDir = await makeRuntimeDir();
+		await fs.mkdir(path.dirname(runtimeDir), { recursive: true });
+		const readyPath = `${runtimeDir}.holder-ready`;
+		// Hold the exact lock ensureRuntimeInstalled contends for, then die.
+		const holder = Bun.spawn(
+			[
+				process.execPath,
+				path.join(import.meta.dir, "fixtures/file-lock-holder.ts"),
+				`${runtimeDir}.install`,
+				readyPath,
+			],
+			{
+				cwd: path.resolve(import.meta.dir, "../../.."),
+				env: { HOME: process.env.HOME ?? "", PATH: process.env.PATH ?? "" },
+				stdin: "ignore",
+				stdout: "ignore",
+				stderr: "pipe",
+			},
+		);
+
+		try {
+			for (;;) {
+				try {
+					await fs.access(readyPath);
+					break;
+				} catch (error) {
+					if (!isEnoent(error)) throw error;
+					if (holder.exitCode !== null) {
+						throw new Error(
+							`lock holder exited before readiness (${holder.exitCode}): ${await new Response(holder.stderr).text()}`,
+						);
+					}
+				}
+			}
+
+			holder.kill("SIGKILL");
+			await holder.exited;
+
+			// Kernel released the abandoned lock on death; the install must
+			// proceed rather than burn the wait envelope and throw.
+			await ensureRuntimeInstalled({
+				runtimeDir,
+				install: { dependencies: { [probe]: spec } },
+				probePackage: probe,
+				lockAttempts: 20,
+				lockSleepMs: 50,
+			});
+			expect(await Bun.file(path.join(runtimeDir, "node_modules", probe, "package.json")).exists()).toBe(true);
+		} finally {
+			if (holder.exitCode === null) {
+				holder.kill("SIGKILL");
+				await holder.exited;
+			}
+		}
+	}, 20_000);
 });

--- a/packages/utils/test/runtime-install.test.ts
+++ b/packages/utils/test/runtime-install.test.ts
@@ -287,27 +287,36 @@ describe("ensureRuntimeInstalled install lock", () => {
 		await expect(fs.stat(`${runtimeDir}.lock`)).rejects.toThrow();
 	}, 15_000);
 
-	test("a fresh legacy .lock directory is waited on before it is reclaimed", async () => {
+	test("a live legacy .lock owner is waited out, never reclaimed on retry exhaustion", async () => {
 		const { spec, probe } = await makeFileDependency();
 		const runtimeDir = await makeRuntimeDir();
-		// A recently created directory could still belong to a live pre-18.x
-		// installer, so the migration must poll the wait envelope before
-		// force-reclaiming rather than delete a possibly-active lock immediately.
+		// A recently created directory may still belong to a live pre-18.x
+		// installer. Retry exhaustion must NOT reclaim it — that would race two
+		// installs against the same tree — only its owner releasing the lock may
+		// let the new install proceed.
 		await fs.mkdir(`${runtimeDir}.lock`, { recursive: true });
 
-		const attempts = 5;
-		const sleepMs = 80;
-		const start = Date.now();
-		await ensureRuntimeInstalled({
+		const sleepMs = 40;
+		const install = ensureRuntimeInstalled({
 			runtimeDir,
 			install: { dependencies: { [probe]: spec } },
 			probePackage: probe,
-			lockAttempts: attempts,
+			lockAttempts: 3,
 			lockSleepMs: sleepMs,
 		});
-		const waited = Date.now() - start;
 
-		expect(waited).toBeGreaterThanOrEqual((attempts - 1) * sleepMs);
+		// Integration timing: the reclaim decision runs on the module's own
+		// `Bun.sleep` poll loop and a real `bun install` subprocess, so fake
+		// timers cannot drive it. Wait past the retry window (lockAttempts x
+		// lockSleepMs) — under the old bug the install would have reclaimed the
+		// fresh lock and populated node_modules by now; it must not have.
+		await Bun.sleep(sleepMs * 8);
+		expect((await fs.stat(`${runtimeDir}.lock`)).isDirectory()).toBe(true);
+		expect(await Bun.file(path.join(runtimeDir, "node_modules", probe, "package.json")).exists()).toBe(false);
+
+		// The legacy owner finishes and releases; only now does the install proceed.
+		await fs.rm(`${runtimeDir}.lock`, { recursive: true, force: true });
+		await install;
 		expect(await Bun.file(path.join(runtimeDir, "node_modules", probe, "package.json")).exists()).toBe(true);
 		await expect(fs.stat(`${runtimeDir}.lock`)).rejects.toThrow();
 	}, 15_000);

--- a/packages/utils/test/runtime-install.test.ts
+++ b/packages/utils/test/runtime-install.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import * as fsSync from "node:fs";
 import * as fs from "node:fs/promises";
 import * as Module from "node:module";
 import * as os from "node:os";
@@ -307,6 +308,31 @@ describe("ensureRuntimeInstalled install lock", () => {
 		const waited = Date.now() - start;
 
 		expect(waited).toBeGreaterThanOrEqual((attempts - 1) * sleepMs);
+		expect(await Bun.file(path.join(runtimeDir, "node_modules", probe, "package.json")).exists()).toBe(true);
+		await expect(fs.stat(`${runtimeDir}.lock`)).rejects.toThrow();
+	}, 15_000);
+
+	test("reserves the legacy namespace before the new install starts", async () => {
+		const { spec, probe } = await makeFileDependency();
+		const runtimeDir = await makeRuntimeDir();
+		let observedDownload = false;
+
+		await ensureRuntimeInstalled({
+			runtimeDir,
+			install: { dependencies: { [probe]: spec } },
+			probePackage: probe,
+			lockAttempts: 8,
+			lockSleepMs: 50,
+			onPhase: phase => {
+				if (phase !== "download") return;
+				observedDownload = true;
+				// A legacy process racing in after the handoff must lose its
+				// atomic mkdir before the new process mutates node_modules.
+				expect(() => fsSync.mkdirSync(`${runtimeDir}.lock`)).toThrow();
+			},
+		});
+
+		expect(observedDownload).toBe(true);
 		expect(await Bun.file(path.join(runtimeDir, "node_modules", probe, "package.json")).exists()).toBe(true);
 		await expect(fs.stat(`${runtimeDir}.lock`)).rejects.toThrow();
 	}, 15_000);

--- a/packages/utils/test/runtime-install.test.ts
+++ b/packages/utils/test/runtime-install.test.ts
@@ -269,8 +269,10 @@ describe("ensureRuntimeInstalled install lock", () => {
 	test("a stale legacy .lock directory does not block install and is cleared", async () => {
 		const { spec, probe } = await makeFileDependency();
 		const runtimeDir = await makeRuntimeDir();
-		// The pre-18.x crash orphan: a bare lock directory with no live owner.
+		// A pre-18.x crash orphan, older than any live install: reclaimed at once.
 		await fs.mkdir(`${runtimeDir}.lock`, { recursive: true });
+		const stale = new Date(Date.now() - 60 * 60_000);
+		await fs.utimes(`${runtimeDir}.lock`, stale, stale);
 
 		await ensureRuntimeInstalled({
 			runtimeDir,
@@ -280,6 +282,31 @@ describe("ensureRuntimeInstalled install lock", () => {
 			lockSleepMs: 50,
 		});
 
+		expect(await Bun.file(path.join(runtimeDir, "node_modules", probe, "package.json")).exists()).toBe(true);
+		await expect(fs.stat(`${runtimeDir}.lock`)).rejects.toThrow();
+	}, 15_000);
+
+	test("a fresh legacy .lock directory is waited on before it is reclaimed", async () => {
+		const { spec, probe } = await makeFileDependency();
+		const runtimeDir = await makeRuntimeDir();
+		// A recently created directory could still belong to a live pre-18.x
+		// installer, so the migration must poll the wait envelope before
+		// force-reclaiming rather than delete a possibly-active lock immediately.
+		await fs.mkdir(`${runtimeDir}.lock`, { recursive: true });
+
+		const attempts = 5;
+		const sleepMs = 80;
+		const start = Date.now();
+		await ensureRuntimeInstalled({
+			runtimeDir,
+			install: { dependencies: { [probe]: spec } },
+			probePackage: probe,
+			lockAttempts: attempts,
+			lockSleepMs: sleepMs,
+		});
+		const waited = Date.now() - start;
+
+		expect(waited).toBeGreaterThanOrEqual((attempts - 1) * sleepMs);
 		expect(await Bun.file(path.join(runtimeDir, "node_modules", probe, "package.json")).exists()).toBe(true);
 		await expect(fs.stat(`${runtimeDir}.lock`)).rejects.toThrow();
 	}, 15_000);


### PR DESCRIPTION
## Repro
An on-demand runtime install (fastembed, Transformers.js, STT/TTS/subprocess worker runtimes) killed outside its `finally` window — SIGKILL, OOM, reboot, or Ctrl-C mid-install — leaves the hand-rolled `${runtimeDir}.lock` directory behind. It has no owner identity, so no later process can tell it from a live install. Every subsequent `ensureRuntimeInstalled` call then burns the full `240 × 250 ms = 60 s` wait and throws, per call, per session, until the directory is removed by hand. Reproduced by pre-creating the bare lock directory (`mkdir ${runtimeDir}.lock`) and calling `ensureRuntimeInstalled`: it stalls the entire wait envelope, then throws `Timed out waiting for runtime install lock`.

## Cause
`acquireInstallLock` in `packages/utils/src/runtime-install.ts` serialized installs with an `fsp.mkdir(lockDir)` loop released only by the closure returned to `ensureRuntimeInstalled`'s `finally`. The lock is safe against concurrency but not against crashes: liveness is never established, so a dead owner's directory is unreleasable and indistinguishable from a fresh lock by any age heuristic (it is empty and its mtime is never refreshed). The doc comment claiming "cross-process safe via a lock directory" overstated the guarantee.

## Fix
- Replace the `mkdir` lock loop with the package's existing OS-backed `withFileLock` (`packages/utils/src/file-lock.ts`, backed by `@oh-my-pi/pi-natives` `FileLock`: abstract Unix sockets on Linux, named mutexes on Windows, `flock(2)` elsewhere). All three are released by the kernel on process death, so a crashed installer cannot wedge later attempts.
- Wrap the whole critical section (double-checked probe → `writeRuntimeManifest` → `runRuntimeInstall`) inside the `withFileLock` callback, and pass the caller's `{ retries: lockAttempts, retryDelayMs: lockSleepMs }` (still `240 × 250 ms`) so the long install window is preserved.
- Put the lock at the distinct path `${runtimeDir}.install.lock` rather than `${runtimeDir}.lock`, so a leftover pre-18.x lock *directory* at the old path cannot make `flock(2)` acquisition fail permanently (the documented migration hazard). Best-effort remove a stale legacy `.lock` directory so it does not linger; ownership is never inferred from it.
- Keep `fsp.mkdir(path.dirname(runtimeDir), …)` since `withFileLock` does not create parent directories.
- Remove the now-dead `acquireInstallLock`/`isErrnoCode` and correct the doc comment.

## Verification
`bun test packages/utils/test/runtime-install.test.ts` → 13 pass. Two new regression tests: (1) a stale legacy `.lock` *directory* no longer blocks install and is cleared; (2) a lock owner SIGKILLed mid-hold (via the `file-lock-holder` fixture) does not wedge a later `ensureRuntimeInstalled` — both drive a real offline `bun install` of a local `file:` dependency. `bun test packages/utils/test/file-lock.test.ts` → 3 pass. Manual repro before the fix stalled the full wait envelope then threw; after the fix it completes in ~7 ms and clears the orphaned directory. `bun run fix` + `bun check` pass via the pre-publish gate. Fixes #10120