### PR TITLE
fix(natives): reuse released addons in source checkouts

### DIFF
--- a/packages/coding-agent/DEVELOPMENT.md
+++ b/packages/coding-agent/DEVELOPMENT.md
@@ -26,6 +26,11 @@ Never invoke `tsc`/`npx tsc` directly — `bun run check` is the typecheck gate.
 changing the React tool renderers under `collab-web/src/tool-render/`, rebuild them
 with `bun run gen:tool-views`.
 
+Tests that import `@oh-my-pi/pi-natives` need a host addon. Build it with
+`bun --cwd=packages/natives run build`; without a native toolchain, run the
+matching released `omp` version once and the workspace loader will reuse its
+versioned addon cache.
+
 ## Boot flow
 
 ```text

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fresh source checkouts can reuse a matching released `omp` native addon, and failed extraction no longer suggests nonexistent release assets.
+
 ## [18.0.10] - 2026-08-28
 
 ### Added

--- a/packages/natives/native/loader-state.d.ts
+++ b/packages/natives/native/loader-state.d.ts
@@ -47,6 +47,8 @@ export interface ResolveLoaderCandidatesInput {
 	addonFilenames: string[];
 	isCompiledBinary: boolean;
 	stageFromNodeModules?: boolean;
+	/** Also probes the exact package version's standalone-binary extraction cache. */
+	includeVersionedCache?: boolean;
 	nativeDir: string;
 	leafPackageDir?: string | null;
 	execDir: string;
@@ -55,6 +57,9 @@ export interface ResolveLoaderCandidatesInput {
 }
 
 export function resolveLoaderCandidates(input: ResolveLoaderCandidatesInput): string[];
+
+/** Formats recovery instructions for native addon load failures. */
+export function buildHelpMessage(ctx: NativeLoaderContext): string;
 
 export interface InitLoaderContextOverrides {
 	nativeDir?: string;

--- a/packages/natives/native/loader-state.js
+++ b/packages/natives/native/loader-state.js
@@ -133,10 +133,13 @@ export function shouldStageNodeModulesAddon({ platform, isCompiledBinary, native
 }
 
 /**
+ * Resolve native addon candidates in loader precedence order.
+ *
  * @param {{
  *   addonFilenames: string[];
  *   isCompiledBinary: boolean;
  *   stageFromNodeModules?: boolean;
+ *   includeVersionedCache?: boolean;
  *   nativeDir: string;
  *   leafPackageDir?: string | null;
  *   execDir: string;
@@ -149,6 +152,7 @@ export function resolveLoaderCandidates({
 	addonFilenames,
 	isCompiledBinary,
 	stageFromNodeModules = false,
+	includeVersionedCache = false,
 	nativeDir,
 	leafPackageDir = null,
 	execDir,
@@ -160,18 +164,23 @@ export function resolveLoaderCandidates({
 		path.join(execDir, filename),
 	]);
 	const leafCandidates = leafPackageDir ? addonFilenames.map(filename => path.join(leafPackageDir, filename)) : [];
+	const versionedCandidates = addonFilenames.map(filename => path.join(versionedDir, filename));
 	const compiledCandidates = addonFilenames.flatMap(filename => [
 		path.join(versionedDir, filename),
 		path.join(userDataDir, filename),
 	]);
-	const stagedCandidates = stageFromNodeModules ? addonFilenames.map(filename => path.join(versionedDir, filename)) : [];
+	const stagedCandidates = stageFromNodeModules ? versionedCandidates : [];
 	let releaseCandidates;
 	if (isCompiledBinary) {
 		releaseCandidates = [...compiledCandidates, ...baseReleaseCandidates];
 	} else if (stageFromNodeModules) {
 		releaseCandidates = [...stagedCandidates, ...leafCandidates, ...baseReleaseCandidates];
 	} else {
-		releaseCandidates = [...leafCandidates, ...baseReleaseCandidates];
+		releaseCandidates = [
+			...leafCandidates,
+			...baseReleaseCandidates,
+			...(includeVersionedCache ? versionedCandidates : []),
+		];
 	}
 	return [...new Set(releaseCandidates)];
 }
@@ -740,24 +749,27 @@ function installNativeTokioRuntime(bindings) {
 }
 
 
-function buildHelpMessage(ctx) {
+/**
+ * Format actionable recovery steps for a native addon load failure.
+ *
+ * @param {{ isCompiledBinary: boolean; addonFilenames: string[]; versionedDir: string; packageVersion: string }} ctx
+ * @returns {string}
+ */
+export function buildHelpMessage(ctx) {
+	const releasePage = `https://github.com/can1357/oh-my-pi/releases/tag/v${ctx.packageVersion}`;
 	if (ctx.isCompiledBinary) {
 		const expectedPaths = ctx.addonFilenames.map(filename => `  ${path.join(ctx.versionedDir, filename)}`).join("\n");
-		const downloadHints = ctx.addonFilenames
-			.map(filename => {
-				const downloadUrl = `https://github.com/can1357/oh-my-pi/releases/latest/download/${filename}`;
-				const targetPath = path.join(ctx.versionedDir, filename);
-				return `  curl -fsSL "${downloadUrl}" -o "${targetPath}"`;
-			})
-			.join("\n");
 		return (
 			`The compiled binary should extract one of:\n${expectedPaths}\n\n` +
-			`If missing, delete ${ctx.versionedDir} and re-run, or download manually:\n${downloadHints}`
+			`If missing, delete ${ctx.versionedDir} and re-run. If extraction still fails, ` +
+			`reinstall omp v${ctx.packageVersion} from:\n  ${releasePage}`
 		);
 	}
 	return (
 		"If installed via npm/bun, try reinstalling: bun install @oh-my-pi/pi-natives\n" +
 		"If developing locally, build with: bun --cwd=packages/natives run build\n" +
+		`Without a native toolchain, run omp v${ctx.packageVersion} once to populate ${ctx.versionedDir}:\n` +
+		`  ${releasePage}\n` +
 		"Explicit targets: bun scripts/bazel-natives.ts <target> --dest packages/natives/native"
 	);
 }
@@ -816,6 +828,7 @@ export function initLoaderContext(overrides = {}) {
 		addonFilenames,
 		isCompiledBinary,
 		stageFromNodeModules,
+		includeVersionedCache: isWorkspaceLoad,
 		nativeDir,
 		leafPackageDir,
 		execDir,

--- a/packages/natives/test/issue-10126-repro.test.ts
+++ b/packages/natives/test/issue-10126-repro.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "bun:test";
+import * as path from "node:path";
+import { buildHelpMessage, initLoaderContext } from "../native/loader-state.js";
+
+describe("issue 10126: fresh-checkout native recovery", () => {
+	it("reuses the matching standalone release cache for workspace development", () => {
+		const ctx = initLoaderContext({
+			isCompiledBinary: false,
+			nativeDir: "/repo/packages/natives/native",
+		});
+
+		expect(ctx.isWorkspaceLoad).toBe(true);
+		for (const filename of ctx.addonFilenames) {
+			const cachedAddon = path.join(ctx.versionedDir, filename);
+			expect(ctx.candidates).toContain(cachedAddon);
+			expect(ctx.candidates.indexOf(cachedAddon)).toBeGreaterThan(
+				ctx.candidates.indexOf(path.join(ctx.nativeDir, filename)),
+			);
+		}
+	});
+
+	it("points failed compiled extraction at the matching binary release instead of unpublished addon assets", () => {
+		const ctx = initLoaderContext({
+			isCompiledBinary: true,
+			nativeDir: "/repo/packages/natives/native",
+		});
+		const help = buildHelpMessage(ctx);
+
+		expect(help).toContain(`https://github.com/can1357/oh-my-pi/releases/tag/v${ctx.packageVersion}`);
+		expect(help).not.toContain("/releases/latest/download/pi_natives.");
+	});
+});


### PR DESCRIPTION
## Repro
On a checkout without a locally loadable addon, `env HOME=/tmp/omp-issue-10126 PI_COMPILED=1 bun -e 'import("./packages/natives/native/loader-state.js").then(m => m.loadNative())'` prints a `releases/latest/download/pi_natives.<target>.node` recovery command; `curl -fsSIL https://github.com/can1357/oh-my-pi/releases/latest/download/pi_natives.linux-x64-modern.node` follows the current release redirect and returns HTTP 404.

## Cause
`buildHelpMessage` in `packages/natives/native/loader-state.js` assumed native addons were standalone release assets even though releases embed them only in `omp-*` binaries. The same loader excluded the exact-version extraction cache from workspace candidates, so source checkouts could not reuse the addon after a matching released binary extracted it.

## Fix
- Probe `~/.omp/natives/<package-version>/` after local build candidates for workspace loads.
- Point extraction failures at the matching binary release instead of nonexistent `.node` assets.
- Document the no-toolchain development path and cover candidate precedence plus recovery URLs.

## Verification
`bun test packages/natives/test/issue-10126-repro.test.ts packages/natives/test/issue-823-repro.test.ts packages/natives/test/windows-staging.test.ts` passed 15 tests; `bun run check` passed in `packages/natives`; a v18.0.10 binary populated a temporary HOME cache and `bun -e 'await import("./packages/natives/native/index.js")'` loaded it successfully from the source checkout. The pre-publish `bun check` gate also passed. Fixes #10126