### PR TITLE
fix(ai): fail open when strict adaptation would close a bare object

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed strict-mode tool schemas silently closing a bare open object property (`type: "object"` with no `properties` or `additionalProperties`) into a `{}`-only shape while still reporting `strict: true`; such schemas now fail open to non-strict like other unrepresentable open shapes ([#10125](https://github.com/can1357/oh-my-pi/issues/10125)).
+
 ## [18.0.9] - 2026-08-28
 
 ### Fixed

--- a/packages/ai/src/utils/schema/normalize.ts
+++ b/packages/ai/src/utils/schema/normalize.ts
@@ -1746,6 +1746,12 @@ function isUnrepresentableStrictBranch(value: unknown): boolean {
  *  - `patternProperties` (open keyset matched by regex),
  *  - `additionalProperties: true` or `additionalProperties: <schema>` (open
  *    keyset with optional further constraint).
+ *  - a bare open object (`type: "object"` with neither `properties`,
+ *    `patternProperties`, nor an `additionalProperties` keyword): it accepts
+ *    any object shape, but `enforceStrictSchema` would close it into
+ *    `{additionalProperties: false, properties: {}, required: []}` — a schema
+ *    that only matches `{}`, silently narrowing the field while `strict: true`
+ *    stays on (issue #10125).
  *  - boolean schemas (`true`/`false`) inside `anyOf`/`oneOf`/`allOf`/`items`/
  *    `prefixItems` — strict providers (OpenAI/Codex) reject the unconstrained
  *    branch, and `enforceStrictSchema` would otherwise wave the non-object
@@ -1770,6 +1776,18 @@ function hasUnrepresentableStrictObjectMap(schema: Record<string, unknown>, epoc
 	const additionalPropertiesValue = schema.additionalProperties;
 	const hasSchemaAdditionalProperties = additionalPropertiesValue === true || isJsonObject(additionalPropertiesValue);
 	if (hasPatternProperties || hasSchemaAdditionalProperties) {
+		return true;
+	}
+
+	// A bare open object closes into a `{}`-only shape under strict enforcement.
+	// `closeDeclaredObjects` only pins `additionalProperties: false` on nodes
+	// that declare `properties`, so a node with none survives the wire pass open;
+	// treat it as unrepresentable here so strict fails open instead of shipping a
+	// closed empty object (issue #10125). An explicit `additionalProperties`
+	// keyword (including `false`) or a `properties` map means the shape was
+	// declared, so those are left to normal enforcement.
+	const isObjectType = schema.type === "object" || (Array.isArray(schema.type) && schema.type.includes("object"));
+	if (isObjectType && !isJsonObject(schema.properties) && !("additionalProperties" in schema)) {
 		return true;
 	}
 

--- a/packages/ai/test/schema-strict-mode.test.ts
+++ b/packages/ai/test/schema-strict-mode.test.ts
@@ -1055,6 +1055,35 @@ describe("adaptSchemaForStrict — unrepresentable open branches fall back to no
 		expect(adaptSchemaForStrict(schema, true).strict).toBe(false);
 	});
 
+	it("falls back when a property is a bare open object (type:object, no properties/additionalProperties)", () => {
+		// A bare `type("object")` property survives `toolWireSchema` as
+		// `{type:"object"}` (closeDeclaredObjects only closes nodes that declare
+		// `properties`). Strict enforcement would otherwise close it into
+		// `{additionalProperties:false, properties:{}, required:[]}` — matching only
+		// `{}` — while `strict:true` stayed on, so real calls fail provider-side
+		// (issue #10125). It must instead downgrade to non-strict.
+		const wire = toolWireSchema({
+			name: "t",
+			description: "d",
+			parameters: type({ path: type("string"), "args?": type("object") }),
+		} as Tool);
+		expect((wire.properties as Record<string, Record<string, unknown>>).args).toEqual({ type: "object" });
+		expect(adaptSchemaForStrict(wire, true).strict).toBe(false);
+	});
+
+	it("still enforces strict for a declared empty object (properties:{})", () => {
+		// A `properties:{}` object is a *declared* closed shape (no fields), not an
+		// open object — strict must stay on so the #10125 fail-open does not
+		// over-fire on legitimate no-field objects.
+		const schema: Record<string, unknown> = {
+			type: "object",
+			properties: { cfg: { type: "object", properties: {}, additionalProperties: false } },
+			required: ["cfg"],
+			additionalProperties: false,
+		};
+		expect(adaptSchemaForStrict(schema, true).strict).toBe(true);
+	});
+
 	it("still enforces strict for fully-typed schemas (no false positives)", () => {
 		const schema: Record<string, unknown> = {
 			type: "object",


### PR DESCRIPTION
## Repro
A tool property declared as a bare `type("object")` (any object node with no `properties` and no explicit `additionalProperties`) survives `toolWireSchema` untouched as `{type:"object"}`, then strict adaptation closes it into `{additionalProperties:false, properties:{}, required:[]}` while the tool still reports `strict:true`. On an OpenAI/Codex strict path the model can then only emit `{}` or `null` for that property, and every call carrying real fields fails wrapped-tool validation, with nothing warning at build time, in tests, or at request time. Reproduced with the reporter's probe:

```
type("object") true {"anyOf":[{"type":"object","additionalProperties":false,"properties":{},"required":[]},{"type":"null"}]}
```

## Cause
`closeDeclaredObjects` (`packages/ai/src/utils/schema/wire.ts`) only pins `additionalProperties:false` on nodes that declare `properties`, so a bare object survives the wire pass open. `hasUnrepresentableStrictObjectMap` (`packages/ai/src/utils/schema/normalize.ts`) — the gate that fails strict open for other open shapes (`additionalProperties:true`, `patternProperties`, empty `{}`, boolean branches) — did not recognize the bare open object, so `enforceStrictSchemaBody` unconditionally set `additionalProperties:false` with an empty `properties` map and left `strict:true`. The wire pass and the strict pass are each correct; the composition silently narrowed the field.

## Fix
- In `hasUnrepresentableStrictObjectMap`, treat an object-type node (`type:"object"` or a `type` array containing `"object"`) that has no `properties` map and no `additionalProperties` keyword as unrepresentable, so `tryEnforceStrictSchema` fails open to non-strict instead of shipping a `{}`-only closed object. An explicit `additionalProperties` keyword (including `false`) or a declared `properties` map (even empty) still enforces strict, so legitimate closed/no-field objects are unaffected.
- Extended the doc comment to record the bare-open-object case and issue reference.
- Added regression tests in `packages/ai/test/schema-strict-mode.test.ts`: the reporter's bare `type("object")` property now downgrades to non-strict, and a declared empty object (`properties:{}`) still enforces strict (no over-firing).

## Verification
`bun test packages/ai/test/schema-strict-mode.test.ts` → 59 pass, 0 fail (both new tests included). Full schema suite (`schema-strict-mode`, `schema-normalization`, `schema-helpers`, `schema-wire`, `schema-compatibility`) → 197 pass, 0 fail. Also verified end-to-end via the barrel that the reporter's `type({ path, args?: object })` case now yields `strict:false` with `args` left open as `{type:"object"}`. Fixes #10125