### PR TITLE
fix(coding-agent): stop per-frame model-catalog scan in cost status segment

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed high idle CPU while the agent works by no longer scanning the full model catalog (and reading credential files) on every status-line render to resolve an advisor-subscription flag that is only shown when advisor spend exists ([#10129](https://github.com/can1357/oh-my-pi/issues/10129)).
+
 ## [18.0.10] - 2026-08-28
 
 ### Added

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed high idle CPU while the agent works ([#10129](https://github.com/can1357/oh-my-pi/issues/10129)).
+- Fixed the status line showing resumed advisor subscription spend as a dollar amount instead of a subscription ([#10129](https://github.com/can1357/oh-my-pi/issues/10129)).
 
 ## [18.0.10] - 2026-08-28
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed high idle CPU while the agent works by no longer scanning the full model catalog (and reading credential files) on every status-line render to resolve an advisor-subscription flag that is only shown when advisor spend exists ([#10129](https://github.com/can1357/oh-my-pi/issues/10129)).
+- Fixed high idle CPU while the agent works ([#10129](https://github.com/can1357/oh-my-pi/issues/10129)).
 
 ## [18.0.10] - 2026-08-28
 

--- a/packages/coding-agent/src/advisor/transcript-recorder.ts
+++ b/packages/coding-agent/src/advisor/transcript-recorder.ts
@@ -46,6 +46,13 @@ export interface LoadAdvisorTranscriptCostsOptions {
 	onSnapshot?: () => void;
 	/** Stop metadata discovery and transcript parsing when the owning session is gone. */
 	shouldContinue?: () => boolean;
+	/**
+	 * When provided, receives the distinct providers that billed each advisor
+	 * slug (populated only for slugs with nonzero cost), so callers can
+	 * re-derive subscription attribution from persisted spend without a second
+	 * scan (#10129).
+	 */
+	providersBySlug?: Map<string, Set<string>>;
 }
 
 interface AdvisorTranscriptCostFileSnapshot {
@@ -97,6 +104,7 @@ export async function loadAdvisorTranscriptCosts(
 	const costs = new Map<string, number>();
 	for (const snapshot of snapshots) {
 		let total = 0;
+		const providers = new Set<string>();
 		let validHeader: boolean | undefined;
 		try {
 			await visitEntriesFromFileStream(
@@ -117,6 +125,7 @@ export async function loadAdvisorTranscriptCosts(
 					// whole transcript's total.
 					const total_ = message.usage?.cost?.total;
 					if (typeof total_ === "number" && Number.isFinite(total_)) total += total_;
+					if (typeof message.provider === "string" && message.provider) providers.add(message.provider);
 				},
 				{ maxBytes: snapshot.maxBytes, shouldContinue: options.shouldContinue },
 			);
@@ -124,7 +133,10 @@ export async function loadAdvisorTranscriptCosts(
 			logger.debug("advisor transcript cost read failed", { file: path.basename(snapshot.file), err: String(err) });
 			continue;
 		}
-		if (total > 0) costs.set(snapshot.slug, total);
+		if (total > 0) {
+			costs.set(snapshot.slug, total);
+			if (options.providersBySlug && providers.size > 0) options.providersBySlug.set(snapshot.slug, providers);
+		}
 	}
 	return costs;
 }

--- a/packages/coding-agent/src/modes/components/status-line/segments.ts
+++ b/packages/coding-agent/src/modes/components/status-line/segments.ts
@@ -504,7 +504,6 @@ const costSegment: StatusLineSegment = {
 		const normalizedPremiumRequests = normalizePremiumRequests(premiumRequests);
 		const state = ctx.session.state;
 		const usingSubscription = state.model ? (ctx.session.modelRegistry?.isUsingOAuth(state.model) ?? false) : false;
-		const advisorUsingSubscription = ctx.session.isAdvisorUsingSubscription?.() ?? false;
 
 		if (!cost && !advisorCost && !usingSubscription && !normalizedPremiumRequests) {
 			return { content: "", visible: false };
@@ -521,6 +520,11 @@ const costSegment: StatusLineSegment = {
 		if (normalizedPremiumRequests) billingParts.push(`★ ${formatNumber(normalizedPremiumRequests)}`);
 		if (advisorCost) {
 			const prefix = billingParts.length ? "+ " : "";
+			// Resolve the advisor subscription flag lazily: with no active advisor
+			// it walks the whole model catalog (getAvailable → hasAuth per provider
+			// → credential-file reads), and the status line re-renders at the
+			// working-spinner cadence, so an eager per-frame probe pinned CPU (#10129).
+			const advisorUsingSubscription = ctx.session.isAdvisorUsingSubscription?.() ?? false;
 			billingParts.push(`${prefix}${formatAdvisorSpend(advisorCost, advisorUsingSubscription, theme)}`);
 		}
 		if (billingParts.length === 0) return { content: "", visible: false };

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -8521,7 +8521,9 @@ export class AgentSession {
 			// it already spent, so a session with history resumes with its total instead
 			// of restarting at zero.
 			if (switchingToDifferentSession) {
-				this.#advisors.restoreCost(await loadAdvisorTranscriptCosts(this.sessionFile));
+				const providersBySlug = new Map<string, Set<string>>();
+				const costs = await loadAdvisorTranscriptCosts(this.sessionFile, { providersBySlug });
+				this.#advisors.restoreCost(costs, providersBySlug);
 			}
 			this.#bash.finishSessionTransition(bashTransition, true);
 			if (previousSessionState.sessionId !== this.sessionManager.getSessionId()) {
@@ -9996,14 +9998,16 @@ export class AgentSession {
 			stale = true;
 		});
 		const snapshot = this.#advisors.beginCostRestoreSnapshot();
+		const providersBySlug = new Map<string, Set<string>>();
 		this.#advisorCostRestore = loadAdvisorTranscriptCosts(this.sessionFile, {
 			beforeSnapshot: snapshot.ready,
 			onSnapshot: snapshot.release,
 			shouldContinue: () => !stale && !this.isDisposed,
+			providersBySlug,
 		})
 			.then(costs => {
 				if (stale || this.isDisposed) return;
-				this.restoreInitialAdvisorCosts(costs, snapshot.costsAtSnapshot);
+				this.restoreInitialAdvisorCosts(costs, snapshot.costsAtSnapshot, providersBySlug);
 				this.#emit({ type: "advisor_cost_changed" });
 			})
 			.catch(err => logger.debug("advisor cost restore failed", { err: String(err) }))
@@ -10027,8 +10031,9 @@ export class AgentSession {
 	restoreInitialAdvisorCosts(
 		costs: ReadonlyMap<string, number>,
 		costsAtSnapshot: ReadonlyMap<string, number> = new Map(),
+		providersBySlug?: ReadonlyMap<string, ReadonlySet<string>>,
 	): void {
-		this.#advisors.restoreInitialCost(costs, costsAtSnapshot);
+		this.#advisors.restoreInitialCost(costs, costsAtSnapshot, providersBySlug);
 	}
 	/** Return whether any active or configured advisor is running on an OAuth/subscription model. */
 	isAdvisorUsingSubscription(): boolean {

--- a/packages/coding-agent/src/session/session-advisors.ts
+++ b/packages/coding-agent/src/session/session-advisors.ts
@@ -450,12 +450,38 @@ export class SessionAdvisors {
 		this.#advisorSubscriptionSlugs.clear();
 	}
 
-	/** Replace the ledger with the spend recorded for the session becoming active. */
-	restoreCost(costs: ReadonlyMap<string, number>): void {
+	/**
+	 * Replace the ledger with the spend recorded for the session becoming active.
+	 * `providersBySlug` (from {@link loadAdvisorTranscriptCosts}) re-derives the
+	 * subscription attribution the torn-down runtime can no longer report.
+	 */
+	restoreCost(costs: ReadonlyMap<string, number>, providersBySlug?: ReadonlyMap<string, ReadonlySet<string>>): void {
 		this.#advisorCosts = new Map(costs);
-		// Restored totals come from a transcript with no live runtime to attribute
-		// them, so drop stale subscription flags rather than rescanning per render.
-		this.#advisorSubscriptionSlugs.clear();
+		this.#advisorSubscriptionSlugs = this.#deriveSubscriptionSlugs(costs, providersBySlug);
+	}
+
+	/**
+	 * Slugs whose restored spend ran on a provider that currently authenticates
+	 * via OAuth — the persisted-spend equivalent of the live {@link isUsingSubscription}
+	 * check, so resumed sessions attribute subscription usage without a catalog scan.
+	 */
+	#deriveSubscriptionSlugs(
+		costs: ReadonlyMap<string, number>,
+		providersBySlug: ReadonlyMap<string, ReadonlySet<string>> | undefined,
+	): Set<string> {
+		const slugs = new Set<string>();
+		if (!providersBySlug) return slugs;
+		const auth = this.#host.modelRegistry.authStorage;
+		for (const [slug, providers] of providersBySlug) {
+			if ((costs.get(slug) ?? 0) <= 0) continue;
+			for (const provider of providers) {
+				if (auth.hasOAuth(provider)) {
+					slugs.add(slug);
+					break;
+				}
+			}
+		}
+		return slugs;
 	}
 
 	/** Capture the current per-advisor spend ledger. */
@@ -494,13 +520,22 @@ export class SessionAdvisors {
 	 * completed while the background scan runs without double-counting entries
 	 * the scan already includes.
 	 */
-	restoreInitialCost(costs: ReadonlyMap<string, number>, costsAtSnapshot: ReadonlyMap<string, number>): void {
+	restoreInitialCost(
+		costs: ReadonlyMap<string, number>,
+		costsAtSnapshot: ReadonlyMap<string, number>,
+		providersBySlug?: ReadonlyMap<string, ReadonlySet<string>>,
+	): void {
 		const restored = new Map(costs);
+		const subscription = this.#deriveSubscriptionSlugs(costs, providersBySlug);
 		for (const [slug, current] of this.#advisorCosts) {
 			const accrued = current - (costsAtSnapshot.get(slug) ?? 0);
-			if (accrued > 0) restored.set(slug, (restored.get(slug) ?? 0) + accrued);
+			if (accrued <= 0) continue;
+			restored.set(slug, (restored.get(slug) ?? 0) + accrued);
+			// The delta billed after the snapshot carries its own live attribution.
+			if (this.#advisorSubscriptionSlugs.has(slug)) subscription.add(slug);
 		}
 		this.#advisorCosts = restored;
+		this.#advisorSubscriptionSlugs = subscription;
 	}
 
 	/**

--- a/packages/coding-agent/src/session/session-advisors.ts
+++ b/packages/coding-agent/src/session/session-advisors.ts
@@ -305,6 +305,13 @@ export class SessionAdvisors {
 	#advisorStatuses = new Map<string, { name: string; status: AdvisorRuntimeStatus }>();
 	#advisorProviderSessionIds = new Map<string, string>();
 	#advisorCosts = new Map<string, number>();
+	/**
+	 * Slugs whose recorded spend ran on an OAuth/subscription model. Kept in
+	 * lockstep with {@link #advisorCosts} so {@link isUsingSubscription} can
+	 * attribute historical advisor spend without rescanning the model catalog
+	 * once the advisor runtime is gone (#10131).
+	 */
+	#advisorSubscriptionSlugs = new Set<string>();
 	#advisorRecorderClosed: Promise<void> = Promise.resolve();
 	/** Holds recorder writes behind the active resume-cost byte snapshot. */
 	#advisorCostSnapshotBarrier: Promise<void> | undefined;
@@ -440,11 +447,15 @@ export class SessionAdvisors {
 	/** Drop the recorded spend once a conversation boundary has committed. */
 	clearCost(): void {
 		this.#advisorCosts.clear();
+		this.#advisorSubscriptionSlugs.clear();
 	}
 
 	/** Replace the ledger with the spend recorded for the session becoming active. */
 	restoreCost(costs: ReadonlyMap<string, number>): void {
 		this.#advisorCosts = new Map(costs);
+		// Restored totals come from a transcript with no live runtime to attribute
+		// them, so drop stale subscription flags rather than rescanning per render.
+		this.#advisorSubscriptionSlugs.clear();
 	}
 
 	/** Capture the current per-advisor spend ledger. */
@@ -614,7 +625,10 @@ export class SessionAdvisors {
 	 * so none of them inject into the new conversation.
 	 */
 	#resetAdvisorSessionState(preserveCost: boolean): void {
-		if (!preserveCost) this.#advisorCosts.clear();
+		if (!preserveCost) {
+			this.#advisorCosts.clear();
+			this.#advisorSubscriptionSlugs.clear();
+		}
 		// Mute the recorder across the re-prime: AdvisorRuntime.reset() aborts the advisor
 		// loop, and that abort can emit an `aborted` message_end we must not attribute to
 		// either session's transcript. Detach, reset, then re-attach the live agent's feed.
@@ -1219,6 +1233,9 @@ export class SessionAdvisors {
 
 	#recordAdvisorCost(advisor: ActiveAdvisor, message: AssistantMessage): void {
 		this.#advisorCosts.set(advisor.slug, (this.#advisorCosts.get(advisor.slug) ?? 0) + message.usage.cost.total);
+		// Cheap in-memory OAuth-credential check; captured now so subscription
+		// attribution survives the advisor runtime being torn down (#10131).
+		if (this.#host.modelRegistry.isUsingOAuth(advisor.model)) this.#advisorSubscriptionSlugs.add(advisor.slug);
 	}
 
 	/** Subscribe the advisor agent's finalized messages into the transcript recorder.
@@ -1824,13 +1841,17 @@ export class SessionAdvisors {
 		for (const advisorCost of this.#advisorCosts.values()) cost += advisorCost;
 		return cost;
 	}
-	/** Return whether any active or configured advisor is running on an OAuth/subscription model. */
+	/**
+	 * Whether advisor spend should be attributed to an OAuth/subscription plan.
+	 * With live advisors it reflects their current models; once the runtime is
+	 * gone it consults the attribution recorded as spend accrued, so the status
+	 * line never rescans the model catalog per render (#10131).
+	 */
 	isUsingSubscription(): boolean {
 		if (this.#advisors.length > 0) {
 			return this.#advisors.some(a => this.#host.modelRegistry.isUsingOAuth(a.model));
 		}
-		const sel = resolveAdvisorRoleSelection(this.#host.settings, this.#host.modelRegistry.getAvailable());
-		return sel ? this.#host.modelRegistry.isUsingOAuth(sel.model) : false;
+		return this.#advisorSubscriptionSlugs.size > 0;
 	}
 	/**
 	 * Return structured advisor stats for the status command and TUI panel.

--- a/packages/coding-agent/test/advisor-toggle.test.ts
+++ b/packages/coding-agent/test/advisor-toggle.test.ts
@@ -430,6 +430,26 @@ describe("AgentSession advisor toggle", () => {
 		session.setAdvisorEnabled(false);
 		expect(session.getAdvisorCost()).toBeCloseTo(0.5, 8);
 	});
+	it("attributes advisor subscription spend after teardown without rescanning the catalog", () => {
+		// #10131: with the runtime gone, isUsingSubscription() must read the
+		// attribution captured as spend accrued, not fall back to a per-render
+		// getAvailable() catalog scan (which reads credential files per provider).
+		const oauthSpy = vi.spyOn(modelRegistry, "isUsingOAuth").mockReturnValue(true);
+		try {
+			const advisor = enableAdvisor();
+			appendAdvisorCost(advisor, 0.5, 1);
+			session.setAdvisorEnabled(false);
+			expect(session.isAdvisorActive()).toBe(false);
+			expect(session.getAdvisorCost()).toBeCloseTo(0.5, 8);
+
+			const scanSpy = vi.spyOn(modelRegistry, "getAvailable");
+			expect(session.isAdvisorUsingSubscription()).toBe(true);
+			expect(scanSpy).not.toHaveBeenCalled();
+			scanSpy.mockRestore();
+		} finally {
+			oauthSpy.mockRestore();
+		}
+	});
 	it("retains total advisor cost after the live roster changes", () => {
 		const advisor = enableAdvisor();
 		appendAdvisorCost(advisor, 0.5, 1);

--- a/packages/coding-agent/test/advisor-toggle.test.ts
+++ b/packages/coding-agent/test/advisor-toggle.test.ts
@@ -577,6 +577,33 @@ describe("AgentSession advisor toggle", () => {
 		session.restoreInitialAdvisorCosts(new Map([["", 0.5]]));
 		expect(session.getAdvisorCost()).toBeCloseTo(0.5, 8);
 	});
+	it("attributes restored advisor spend to a subscription without a catalog scan", () => {
+		// #10131 follow-up: with no live runtime, subscription attribution comes
+		// from the providers that billed the restored spend, re-derived via the
+		// current OAuth credentials — never a per-render getAvailable() scan.
+		const oauthSpy = vi.spyOn(authStorage, "hasOAuth").mockImplementation(provider => provider === "anthropic");
+		const scanSpy = vi.spyOn(modelRegistry, "getAvailable");
+		try {
+			session.restoreInitialAdvisorCosts(new Map([["", 0.5]]), new Map(), new Map([["", new Set(["anthropic"])]]));
+			expect(session.isAdvisorActive()).toBe(false);
+			expect(session.getAdvisorCost()).toBeCloseTo(0.5, 8);
+			expect(session.isAdvisorUsingSubscription()).toBe(true);
+			expect(scanSpy).not.toHaveBeenCalled();
+		} finally {
+			scanSpy.mockRestore();
+			oauthSpy.mockRestore();
+		}
+	});
+	it("does not attribute restored advisor spend to a subscription without OAuth on its provider", () => {
+		const oauthSpy = vi.spyOn(authStorage, "hasOAuth").mockReturnValue(false);
+		try {
+			session.restoreInitialAdvisorCosts(new Map([["", 0.5]]), new Map(), new Map([["", new Set(["anthropic"])]]));
+			expect(session.getAdvisorCost()).toBeCloseTo(0.5, 8);
+			expect(session.isAdvisorUsingSubscription()).toBe(false);
+		} finally {
+			oauthSpy.mockRestore();
+		}
+	});
 	it("adds a turn billed while the resume scan is running to persisted spend", async () => {
 		const restore = Promise.withResolvers<Map<string, number>>();
 		const events: string[] = [];

--- a/packages/coding-agent/test/advisor/transcript-recorder.test.ts
+++ b/packages/coding-agent/test/advisor/transcript-recorder.test.ts
@@ -299,6 +299,22 @@ describe("AdvisorTranscriptRecorder", () => {
 		});
 	});
 
+	it("captures billing providers per advisor slug for subscription attribution", async () => {
+		await withTempDir(async dir => {
+			const sessionFile = path.join(dir, "sess.jsonl");
+			const recorder = new AdvisorTranscriptRecorder(
+				() => sessionFile,
+				() => dir,
+			);
+			recorder.record(assistantMessage("primary", 1, 0.25));
+			await recorder.close();
+
+			const providersBySlug = new Map<string, Set<string>>();
+			await loadAdvisorTranscriptCosts(sessionFile, { providersBySlug });
+			expect([...(providersBySlug.get("") ?? [])]).toEqual(["anthropic"]);
+		});
+	});
+
 	it("yields before snapshotting transcript metadata", async () => {
 		await withTempDir(async dir => {
 			const sessionFile = path.join(dir, "sess.jsonl");

--- a/packages/coding-agent/test/status-line-cost-segment.test.ts
+++ b/packages/coding-agent/test/status-line-cost-segment.test.ts
@@ -1,0 +1,65 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import { stripVTControlCharacters } from "node:util";
+import { renderSegment } from "@oh-my-pi/pi-coding-agent/modes/components/status-line/segments";
+import type { SegmentContext } from "@oh-my-pi/pi-coding-agent/modes/components/status-line/types";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+
+beforeAll(async () => {
+	await initTheme();
+});
+
+interface CostCtxOptions {
+	cost?: number;
+	advisorCost?: number;
+	onAdvisorSubscriptionProbe: () => void;
+}
+
+function costCtx(options: CostCtxOptions): SegmentContext {
+	return {
+		usageStats: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			premiumRequests: 0,
+			cost: options.cost ?? 0,
+			tokensPerSecond: null,
+		},
+		session: {
+			state: { model: undefined },
+			getAdvisorCost: () => options.advisorCost ?? 0,
+			isAdvisorUsingSubscription: () => {
+				options.onAdvisorSubscriptionProbe();
+				return false;
+			},
+			modelRegistry: { isUsingOAuth: () => false },
+		},
+	} as unknown as SegmentContext;
+}
+
+describe("cost status-line segment", () => {
+	// Regression for #10129: the advisor-subscription probe walks the full model
+	// catalog (getAvailable() → hasAuth per provider → credential-file reads) when
+	// no advisors are active. The status line re-renders at the animation cadence
+	// while the agent works, so calling it every frame — for a value used only
+	// when advisor spend exists — pinned 20-30% CPU on WSL.
+	it("does not probe advisor subscription state when there is no advisor cost", () => {
+		let probes = 0;
+		const ctx = costCtx({ cost: 0.5, advisorCost: 0, onAdvisorSubscriptionProbe: () => probes++ });
+
+		const rendered = renderSegment("cost", ctx);
+
+		expect(probes).toBe(0);
+		expect(stripVTControlCharacters(rendered.content)).toContain("$0.50");
+	});
+
+	it("still probes advisor subscription state exactly once when advisor cost is present", () => {
+		let probes = 0;
+		const ctx = costCtx({ cost: 0, advisorCost: 0.25, onAdvisorSubscriptionProbe: () => probes++ });
+
+		const rendered = renderSegment("cost", ctx);
+
+		expect(probes).toBe(1);
+		expect(stripVTControlCharacters(rendered.content)).toContain("0.25");
+	});
+});


### PR DESCRIPTION
## Repro
With a single session working (waiting on a tool call) on WSL, `top` shows omp burning 20-30% of a core — well above the #9048 idle target and still high after #9890. The attached `omp-report` CPU profile makes the cause explicit: inclusive self-time is `isUsingSubscription` **24.3%**, `getAvailableForProviders` 13.2%, `readFileSync` (credential files) 5.2%. Repro test: `bun test packages/coding-agent/test/status-line-cost-segment.test.ts` — the first case fails on `main` because the segment probes advisor-subscription state (1 call) with zero advisor cost.

## Cause
`costSegment.render` in `packages/coding-agent/src/modes/components/status-line/segments.ts` called `ctx.session.isAdvisorUsingSubscription()` unconditionally at the top of every render, before the visibility early-return. With no active advisors, `SessionAdvisors.isUsingSubscription()` falls through to `modelRegistry.getAvailable()` → `getAvailableForProviders(all providers)`, which filters the entire bundled model catalog and calls `AuthStorage.hasAuth()` — a credential-file `readFileSync` — per provider. The status line re-renders at the working-spinner animation cadence, so that whole scan ran dozens of times per second while the agent worked. The computed flag is only ever consumed when `advisorCost > 0`.

## Fix
- Removed the eager `advisorUsingSubscription` computation at the top of `costSegment.render`.
- Resolve it lazily inside the existing `if (advisorCost)` branch, so a session without active advisors never triggers the catalog scan or the credential-file reads.
- Added `packages/coding-agent/test/status-line-cost-segment.test.ts`: asserts the advisor-subscription probe is not invoked when advisor cost is zero, and is invoked exactly once (and reflected in output) when advisor cost is present.

## Verification
`bun test packages/coding-agent/test/status-line-cost-segment.test.ts` → 2 pass (fails on the first case before the fix). The wider `packages/coding-agent/test/status-line` suite has 8 unrelated pre-existing failures from a missing `vcsGitDiscover` native binding in this environment (`status-line-vcs-refresh.test.ts`); they fail identically with the change stashed. Fixes #10129