### PR TITLE
fix(pi-vcs): read the git index from disk to avoid stale snapshot

### DIFF
--- a/crates/pi-vcs/src/git/diff.rs
+++ b/crates/pi-vcs/src/git/diff.rs
@@ -4,7 +4,10 @@ use std::{fmt::Write as _, io::Write as _, path::Path};
 
 use gix::bstr::{BStr, BString, ByteSlice};
 
-use super::{GitRepo, open::load_index_or_empty};
+use super::{
+	GitRepo,
+	open::{load_index_or_empty, status_with_fresh_index},
+};
 use crate::{
 	error::{Error, Result},
 	types::{DiffOptions, NumstatEntry, ShowResult},
@@ -430,9 +433,7 @@ fn index_change(repo: &gix::Repository, change: gix::diff::index::Change) -> Res
 
 fn worktree_changes(repo: &gix::Repository, files: &[String]) -> Result<Vec<FileChange>> {
 	let patterns = bstring_patterns(files);
-	let mut iter = repo
-		.status(gix::progress::Discard)
-		.map_err(|err| Error::backend("git diff", err))?
+	let mut iter = status_with_fresh_index(repo, "git diff")?
 		.untracked_files(gix::status::UntrackedFiles::None)
 		.index_worktree_options_mut(|options| options.dirwalk_options = None)
 		.into_index_worktree_iter(patterns)
@@ -1336,6 +1337,50 @@ mod tests {
 				.diff_text(&DiffOptions::default())
 				.expect("intent-to-add diff"),
 			git(dir.path(), &["diff"])
+		);
+	}
+
+	#[test]
+	fn status_reads_observe_same_tick_stage_on_reused_handle() {
+		let dir = fixture();
+		fs::write(dir.path().join("file.txt"), "changed\n").expect("edit tracked");
+		fs::write(dir.path().join("new.txt"), "new\n").expect("write untracked");
+		let repo = GitRepo::discover(dir.path())
+			.expect("discover")
+			.expect("repository");
+
+		// Populate gix's shared index snapshot through status-backed diff before
+		// staging, then force the write back onto the same mtime tick.
+		crate::git::pin_index_mtime(&repo);
+		assert!(!repo.diff_text(&DiffOptions::default()).expect("initial diff").is_empty());
+		repo.stage_files(&["file.txt".into(), "new.txt".into()])
+			.expect("stage files");
+		crate::git::pin_index_mtime(&repo);
+
+		assert_eq!(
+			repo.diff_text(&DiffOptions::default()).expect("worktree diff"),
+			git(dir.path(), &["diff"])
+		);
+		assert_eq!(
+			repo
+				.status_porcelain(&crate::types::StatusOptions::default())
+				.expect("status"),
+			git(dir.path(), &["status", "--porcelain"])
+		);
+		assert_eq!(
+			repo.status_summary().expect("summary"),
+			crate::types::StatusSummary { staged: 2, unstaged: 0, untracked: 0 }
+		);
+		assert_eq!(repo.ls_files(true, true).expect("untracked files"), Vec::<String>::new());
+
+		repo.commit_create("stage all", &crate::types::CommitOptions::default())
+			.expect("commit staged files");
+		assert!(!repo.is_dirty().expect("clean after commit"));
+		assert_eq!(
+			repo
+				.status_porcelain(&crate::types::StatusOptions::default())
+				.expect("clean status"),
+			""
 		);
 	}
 

--- a/crates/pi-vcs/src/git/diff.rs
+++ b/crates/pi-vcs/src/git/diff.rs
@@ -4,7 +4,7 @@ use std::{fmt::Write as _, io::Write as _, path::Path};
 
 use gix::bstr::{BStr, BString, ByteSlice};
 
-use super::GitRepo;
+use super::{GitRepo, open::load_index_or_empty};
 use crate::{
 	error::{Error, Result},
 	types::{DiffOptions, NumstatEntry, ShowResult},
@@ -310,9 +310,7 @@ fn index_changes(
 	tree_id: gix::ObjectId,
 	files: &[String],
 ) -> Result<Vec<FileChange>> {
-	let index = repo
-		.index_or_empty()
-		.map_err(|err| Error::backend("git diff --cached", err))?;
+	let index = load_index_or_empty(repo, "git diff --cached")?;
 	let mut pathspec = make_pathspec(repo, files, false)?;
 	let mut out = Vec::new();
 	repo
@@ -1149,9 +1147,7 @@ fn make_pathspec<'repo>(
 	if files.is_empty() {
 		return Ok(None);
 	}
-	let index = repo
-		.index_or_empty()
-		.map_err(|err| Error::backend("git diff pathspec", err))?;
+	let index = load_index_or_empty(repo, "git diff pathspec")?;
 	repo
 		.pathspec(
 			false,

--- a/crates/pi-vcs/src/git/mod.rs
+++ b/crates/pi-vcs/src/git/mod.rs
@@ -130,6 +130,19 @@ impl GitRepo {
 		relative_prefix(&self.info.repo_root, dir)
 	}
 }
+
+/// Pin the worktree index mtime to reproduce same-tick snapshot races in tests.
+#[cfg(test)]
+pub(crate) fn pin_index_mtime(repo: &GitRepo) {
+	let pinned =
+		std::time::SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(1_700_000_000);
+	std::fs::File::options()
+		.write(true)
+		.open(repo.info().git_dir.join("index"))
+		.expect("open index")
+		.set_modified(pinned)
+		.expect("pin index mtime");
+}
 /// Discover repository metadata for `dir` without opening gitoxide.
 pub fn discover_info(dir: &Path) -> Result<Option<GitRepoInfo>> {
 	let mut current = std::path::absolute(dir)?;

--- a/crates/pi-vcs/src/git/mutate.rs
+++ b/crates/pi-vcs/src/git/mutate.rs
@@ -1425,26 +1425,15 @@ mod tests {
 		// did not advance past the snapshot's (sub-second writes / coarse mtime
 		// filesystems), failing with "nothing to commit, working tree clean".
 		let (temp, repo) = fixture();
-		let index_path = repo.info().git_dir.join("index");
 		// Pin the mtime so the snapshot captured while staging and the index the
 		// write leaves behind collide on the exact same tick.
-		let pinned =
-			std::time::SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(1_700_000_000);
-		let pin = |path: &Path| {
-			fs::File::options()
-				.write(true)
-				.open(path)
-				.unwrap()
-				.set_modified(pinned)
-				.unwrap();
-		};
-		pin(&index_path);
+		crate::git::pin_index_mtime(&repo);
 
 		fs::write(temp.path().join("a"), "changed\n").unwrap();
 		repo.stage_files(&["a".into()]).unwrap();
-		// Staging bumped the mtime; forcing it back to `pinned` reproduces the
-		// same-tick collision that made gix serve the pre-stage index.
-		pin(&index_path);
+		// Staging bumped the mtime; forcing it back reproduces the same-tick
+		// collision that made gix serve the pre-stage index.
+		crate::git::pin_index_mtime(&repo);
 
 		let sha = repo
 			.commit_create("change", &CommitOptions::default())

--- a/crates/pi-vcs/src/git/mutate.rs
+++ b/crates/pi-vcs/src/git/mutate.rs
@@ -10,7 +10,7 @@ use std::{
 
 use gix::bstr::{BString, ByteSlice};
 
-use super::{GitRepo, normalize_path};
+use super::{GitRepo, normalize_path, open::load_index_or_head};
 use crate::{
 	error::{Error, Result},
 	types::{CleanOptions, CommitOptions, DetachGitDirResult, ResetMode, RestoreOptions},
@@ -77,10 +77,7 @@ impl GitRepo {
 	/// Stage worktree files, or every change when `files` is empty.
 	pub fn stage_files(&self, files: &[String]) -> Result<()> {
 		let repo = self.gix()?;
-		let mut index = repo
-			.index_or_load_from_head_or_empty()
-			.map_err(|err| Error::backend("git add", err))?
-			.into_owned();
+		let mut index = load_index_or_head(&repo, "git add")?;
 		let mut selected = collect_stage_paths(self.root(), files)?;
 		let all = files.is_empty();
 		let requested: BTreeSet<&str> = files.iter().map(String::as_str).collect();
@@ -111,10 +108,7 @@ impl GitRepo {
 		let repo = self.gix()?;
 		let head = head_tree(&repo)?;
 		let head_index = index_for_tree(&repo, head.as_ref())?;
-		let mut current = repo
-			.index_or_load_from_head_or_empty()
-			.map_err(|err| Error::backend("git reset", err))?
-			.into_owned();
+		let mut current = load_index_or_head(&repo, "git reset")?;
 		copy_index_paths(&mut current, &head_index, files);
 		current
 			.write(INDEX_WRITE)
@@ -132,10 +126,7 @@ impl GitRepo {
 			.try_peel_to_id()
 			.map_err(|err| Error::backend("git commit", err))?
 			.map(|id| id.detach());
-		let index = repo
-			.index_or_load_from_head_or_empty()
-			.map_err(|err| Error::backend("git commit", err))?
-			.into_owned();
+		let index = load_index_or_head(&repo, "git commit")?;
 		let tree = if options.files.is_empty() {
 			write_index_tree(&repo, &index)?
 		} else {
@@ -334,10 +325,7 @@ impl GitRepo {
 	pub fn restore(&self, options: &RestoreOptions) -> Result<()> {
 		let repo = self.gix()?;
 		let restore_worktree = options.worktree || !options.staged;
-		let mut index = repo
-			.index_or_load_from_head_or_empty()
-			.map_err(|e| Error::backend("git restore", e))?
-			.into_owned();
+		let mut index = load_index_or_head(&repo, "git restore")?;
 		if options.staged {
 			let source = resolve_tree(&repo, options.source.as_deref().unwrap_or("HEAD"))?;
 			let source_index = index_for_tree(&repo, Some(&source))?;
@@ -373,9 +361,7 @@ impl GitRepo {
 	/// Remove untracked files and directories according to ignore mode.
 	pub fn clean(&self, options: &CleanOptions) -> Result<()> {
 		let repo = self.gix()?;
-		let index = repo
-			.index_or_load_from_head_or_empty()
-			.map_err(|e| Error::backend("git clean", e))?;
+		let index = load_index_or_head(&repo, "git clean")?;
 		let tracked: BTreeSet<String> = index
 			.entries()
 			.iter()
@@ -971,10 +957,7 @@ fn checkout_tree(
 	let mut target = repo
 		.index_from_tree(&tree)
 		.map_err(|e| Error::backend("git checkout", e))?;
-	let current = repo
-		.index_or_load_from_head_or_empty()
-		.map_err(|e| Error::backend("git checkout", e))?
-		.into_owned();
+	let current = load_index_or_head(repo, "git checkout")?;
 	let conflicts = checkout_conflicts(owner.root(), repo, &current, &target)?;
 	if !overwrite && !conflicts.is_empty() {
 		return Err(Error::Conflict { paths: conflicts });
@@ -1278,10 +1261,7 @@ fn branch_is_checked_out(common: &Path, full_ref: &str) -> bool {
 
 fn tracked_worktree_dirty(repo: &GitRepo) -> Result<bool> {
 	let gix = repo.gix()?;
-	let index = gix
-		.index_or_load_from_head_or_empty()
-		.map_err(|e| Error::backend("git worktree remove", e))?
-		.into_owned();
+	let index = load_index_or_head(&gix, "git worktree remove")?;
 	for entry in index.entries() {
 		if worktree_id(
 			&gix,
@@ -1436,6 +1416,42 @@ mod tests {
 		fs::write(path, format!("#!/bin/sh\n{body}\n")).unwrap();
 		let mode = if executable { 0o755 } else { 0o644 };
 		fs::set_permissions(path, fs::Permissions::from_mode(mode)).unwrap();
+	}
+
+	#[test]
+	fn stage_commit_survives_unadvanced_index_mtime() {
+		// Regression: a commit right after staging on the same cached handle used
+		// to read a stale in-memory index snapshot when the on-disk index mtime
+		// did not advance past the snapshot's (sub-second writes / coarse mtime
+		// filesystems), failing with "nothing to commit, working tree clean".
+		let (temp, repo) = fixture();
+		let index_path = repo.info().git_dir.join("index");
+		// Pin the mtime so the snapshot captured while staging and the index the
+		// write leaves behind collide on the exact same tick.
+		let pinned =
+			std::time::SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(1_700_000_000);
+		let pin = |path: &Path| {
+			fs::File::options()
+				.write(true)
+				.open(path)
+				.unwrap()
+				.set_modified(pinned)
+				.unwrap();
+		};
+		pin(&index_path);
+
+		fs::write(temp.path().join("a"), "changed\n").unwrap();
+		repo.stage_files(&["a".into()]).unwrap();
+		// Staging bumped the mtime; forcing it back to `pinned` reproduces the
+		// same-tick collision that made gix serve the pre-stage index.
+		pin(&index_path);
+
+		let sha = repo
+			.commit_create("change", &CommitOptions::default())
+			.unwrap();
+		assert_eq!(git(temp.path(), &["rev-parse", "HEAD"]), sha);
+		// The commit must carry the staged content, not the stale base index.
+		assert_eq!(git(temp.path(), &["show", "HEAD:a"]), "changed");
 	}
 
 	#[cfg(unix)]

--- a/crates/pi-vcs/src/git/open.rs
+++ b/crates/pi-vcs/src/git/open.rs
@@ -57,6 +57,63 @@ impl GitRepo {
 	}
 }
 
+/// Load the persisted worktree index straight from disk, reconstructing it from
+/// `HEAD^{tree}` (or an empty index when `HEAD` is unborn) if no index file
+/// exists.
+///
+/// Reads bypass gix's shared, mtime-gated index snapshot. The cached
+/// [`gix`](GitRepo::gix) handle shares one
+/// `SharedFileSnapshot<gix_index::File>` across every thread-local clone and
+/// only reloads it when the index file's mtime is *strictly* newer than the
+/// snapshot — gix's freshness check is deliberately sub-second-racy (`gix_fs`
+/// `recent_snapshot` notes it "relies on sub-section precision or else is a
+/// race … up to the caller"). The in-process mutators here write a fresh index
+/// within the same mtime tick as the read that populated the snapshot, so a
+/// later read through that snapshot would return the pre-mutation index — e.g. a
+/// commit right after staging sees an unchanged tree and fails with "nothing to
+/// commit, working tree clean". Reading the index from disk makes mutate→read
+/// deterministic regardless of filesystem timestamp granularity.
+pub(crate) fn load_index_or_head(
+	repo: &gix::Repository,
+	op: &'static str,
+) -> Result<gix::index::File> {
+	match repo.open_index() {
+		Ok(index) => Ok(index),
+		Err(gix::worktree::open_index::Error::IndexFile(gix::index::file::init::Error::Io(err)))
+			if err.kind() == std::io::ErrorKind::NotFound =>
+		{
+			Ok(repo
+				.index_or_load_from_head_or_empty()
+				.map_err(|err| Error::backend(op, err))?
+				.into_owned())
+		},
+		Err(err) => Err(Error::backend(op, err)),
+	}
+}
+
+/// Load the persisted worktree index straight from disk, falling back to an
+/// empty index (never `HEAD^{tree}`) when no index file exists.
+///
+/// Same snapshot-bypass rationale as [`load_index_or_head`]; the empty-index
+/// fallback matches gix's [`index_or_empty`](gix::Repository::index_or_empty).
+pub(crate) fn load_index_or_empty(
+	repo: &gix::Repository,
+	op: &'static str,
+) -> Result<gix::index::File> {
+	match repo.open_index() {
+		Ok(index) => Ok(index),
+		Err(gix::worktree::open_index::Error::IndexFile(gix::index::file::init::Error::Io(err)))
+			if err.kind() == std::io::ErrorKind::NotFound =>
+		{
+			Ok(repo
+				.index_or_empty()
+				.map_err(|err| Error::backend(op, err))?
+				.into_owned_or_cloned())
+		},
+		Err(err) => Err(Error::backend(op, err)),
+	}
+}
+
 /// Open options for repositories the agent operates on.
 ///
 /// - Environment: deny `GIT_*` location/object overrides — operations bind to

--- a/crates/pi-vcs/src/git/open.rs
+++ b/crates/pi-vcs/src/git/open.rs
@@ -114,6 +114,22 @@ pub(crate) fn load_index_or_empty(
 	}
 }
 
+/// Start a status query with an index loaded directly from disk.
+///
+/// Supplying the index is required even after other read paths bypass the
+/// shared snapshot: [`gix::Repository::status`] otherwise reacquires that same
+/// mtime-gated snapshot internally.
+pub(crate) fn status_with_fresh_index<'repo>(
+	repo: &'repo gix::Repository,
+	op: &'static str,
+) -> Result<gix::status::Platform<'repo, gix::progress::Discard>> {
+	let index = load_index_or_empty(repo, op)?;
+	Ok(repo
+		.status(gix::progress::Discard)
+		.map_err(|err| Error::backend(op, err))?
+		.index(index.into()))
+}
+
 /// Open options for repositories the agent operates on.
 ///
 /// - Environment: deny `GIT_*` location/object overrides — operations bind to

--- a/crates/pi-vcs/src/git/patch.rs
+++ b/crates/pi-vcs/src/git/patch.rs
@@ -20,7 +20,7 @@ use gix::{
 	refs::transaction::PreviousValue,
 };
 
-use super::{GitRepo, mutate::update_reference};
+use super::{GitRepo, mutate::update_reference, open::load_index_or_head};
 use crate::{
 	error::{Error, Result},
 	types::{ApplyOptions, DiffOptions, HunkSelection, HunkSelectionError, HunkSpec},
@@ -1190,9 +1190,7 @@ fn blob_bytes(repo: &gix::Repository, id: gix::ObjectId) -> Result<Vec<u8>> {
 }
 
 fn index_map(repo: &gix::Repository) -> Result<BTreeMap<String, FileEntry>> {
-	let index = repo
-		.index_or_load_from_head_or_empty()
-		.map_err(|err| Error::backend("git read index", err))?;
+	let index = load_index_or_head(repo, "git read index")?;
 	Ok(index_state_map(&index))
 }
 
@@ -1306,10 +1304,7 @@ fn untracked_worktree_map(
 	gix_repo: &gix::Repository,
 	index: &BTreeMap<String, FileEntry>,
 ) -> Result<BTreeMap<String, FileEntry>> {
-	let mut walk_index = gix_repo
-		.index_or_load_from_head_or_empty()
-		.map_err(|err| Error::backend("git read index for untracked files", err))?
-		.into_owned();
+	let mut walk_index = load_index_or_head(gix_repo, "git read index for untracked files")?;
 	for entry in walk_index.entries_mut() {
 		entry.flags.insert(Flags::UPTODATE);
 	}

--- a/crates/pi-vcs/src/git/patch.rs
+++ b/crates/pi-vcs/src/git/patch.rs
@@ -1670,34 +1670,23 @@ mod tests {
 
 		// Freeze the index mtime so every read collides with the preceding write
 		// on the same tick — the exact race the fix removes.
-		let pinned =
-			std::time::SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(1_700_000_000);
-		let index_path = repo.info().git_dir.join("index");
-		let pin = || {
-			fs::File::options()
-				.write(true)
-				.open(&index_path)
-				.expect("open index")
-				.set_modified(pinned)
-				.expect("pin index mtime");
-		};
-		pin();
+		crate::git::pin_index_mtime(&repo);
 
 		repo.stage_hunks(
 			&[HunkSelection { path: "new-file.txt".into(), hunks: HunkSpec::All }],
 			Some(&raw),
 		)
 		.expect("stage new file");
-		pin();
+		crate::git::pin_index_mtime(&repo);
 		repo.commit_create("feat: add new file", &crate::types::CommitOptions::default())
 			.expect("commit new file");
-		pin();
+		crate::git::pin_index_mtime(&repo);
 		repo.stage_hunks(
 			&[HunkSelection { path: "tracked.txt".into(), hunks: HunkSpec::All }],
 			Some(&raw),
 		)
 		.expect("stage tracked file");
-		pin();
+		crate::git::pin_index_mtime(&repo);
 		repo.commit_create("fix: update tracked file", &crate::types::CommitOptions::default())
 			.expect("commit tracked file");
 

--- a/crates/pi-vcs/src/git/patch.rs
+++ b/crates/pi-vcs/src/git/patch.rs
@@ -1656,6 +1656,60 @@ mod tests {
 	}
 
 	#[test]
+	fn stage_hunks_commit_split_survives_unadvanced_index_mtime() {
+		// Regression for #10130 (the issue-966 split-commit repro): two
+		// back-to-back stage_hunks -> commit_create pairs on one reused handle
+		// read a stale in-memory index snapshot when every mutation landed in a
+		// single mtime tick, so the first commit errored "nothing to commit".
+		let temp = init(&[("tracked.txt", b"original\n")]);
+		fs::write(temp.path().join("tracked.txt"), b"updated\n").expect("edit tracked");
+		fs::write(temp.path().join("new-file.txt"), b"new\n").expect("write new");
+		git(temp.path(), &["add", "-N", "new-file.txt"]);
+		let repo = repo(temp.path());
+		let raw = repo.diff_text(&DiffOptions::default()).expect("diff");
+
+		// Freeze the index mtime so every read collides with the preceding write
+		// on the same tick — the exact race the fix removes.
+		let pinned =
+			std::time::SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(1_700_000_000);
+		let index_path = repo.info().git_dir.join("index");
+		let pin = || {
+			fs::File::options()
+				.write(true)
+				.open(&index_path)
+				.expect("open index")
+				.set_modified(pinned)
+				.expect("pin index mtime");
+		};
+		pin();
+
+		repo.stage_hunks(
+			&[HunkSelection { path: "new-file.txt".into(), hunks: HunkSpec::All }],
+			Some(&raw),
+		)
+		.expect("stage new file");
+		pin();
+		repo.commit_create("feat: add new file", &crate::types::CommitOptions::default())
+			.expect("commit new file");
+		pin();
+		repo.stage_hunks(
+			&[HunkSelection { path: "tracked.txt".into(), hunks: HunkSpec::All }],
+			Some(&raw),
+		)
+		.expect("stage tracked file");
+		pin();
+		repo.commit_create("fix: update tracked file", &crate::types::CommitOptions::default())
+			.expect("commit tracked file");
+
+		assert_eq!(
+			git(temp.path(), &["log", "--format=%s", "-2"]).trim(),
+			"fix: update tracked file\nfeat: add new file"
+		);
+		assert_eq!(git(temp.path(), &["show", "HEAD:tracked.txt"]), "updated\n");
+		assert_eq!(git(temp.path(), &["show", "HEAD~1:new-file.txt"]), "new\n");
+	}
+
+	#[test]
 	fn patch_join_and_validation_preserve_binary_terminators() {
 		assert_eq!(join_patches(&["one\n\n".into(), "two".into(), String::new()]), "one\n\ntwo\n\n");
 		let binary = "diff --git a/a.bin b/a.bin\nindex 1111111..2222222 100644\nGIT binary \

--- a/crates/pi-vcs/src/git/read.rs
+++ b/crates/pi-vcs/src/git/read.rs
@@ -7,7 +7,10 @@ use std::{
 
 use gix::bstr::ByteSlice;
 
-use super::{GitRepo, open::load_index_or_empty};
+use super::{
+	GitRepo,
+	open::{load_index_or_empty, status_with_fresh_index},
+};
 use crate::{
 	error::{Error, Result},
 	types::{
@@ -185,9 +188,7 @@ impl GitRepo {
 				.map(|status| !status.is_empty());
 		}
 		let repo = self.gix()?;
-		let platform = repo
-			.status(gix::progress::Discard)
-			.map_err(|err| Error::backend("git status", err))?
+		let platform = status_with_fresh_index(&repo, "git status")?
 			.untracked_files(gix::status::UntrackedFiles::Collapsed);
 		let iter = platform
 			.into_iter(options.pathspecs.iter().map(|path| path.as_bytes().into()))
@@ -246,9 +247,7 @@ impl GitRepo {
 			UntrackedMode::Normal => gix::status::UntrackedFiles::Collapsed,
 			UntrackedMode::All => gix::status::UntrackedFiles::Files,
 		};
-		let platform = repo
-			.status(gix::progress::Discard)
-			.map_err(|err| Error::backend("git status", err))?
+		let platform = status_with_fresh_index(&repo, "git status")?
 			.untracked_files(untracked);
 		let iter = platform
 			.into_iter(options.pathspecs.iter().map(|path| path.as_bytes().into()))
@@ -712,9 +711,7 @@ impl GitRepo {
 			return Ok(out);
 		}
 		let repo = self.gix()?;
-		let mut platform = repo
-			.status(gix::progress::Discard)
-			.map_err(|e| Error::backend("git ls-files", e))?
+		let mut platform = status_with_fresh_index(&repo, "git ls-files")?
 			.untracked_files(gix::status::UntrackedFiles::Files);
 		if !exclude_standard {
 			platform = platform.dirwalk_options(|opts| {

--- a/crates/pi-vcs/src/git/read.rs
+++ b/crates/pi-vcs/src/git/read.rs
@@ -7,7 +7,7 @@ use std::{
 
 use gix::bstr::ByteSlice;
 
-use super::GitRepo;
+use super::{GitRepo, open::load_index_or_empty};
 use crate::{
 	error::{Error, Result},
 	types::{
@@ -700,9 +700,7 @@ impl GitRepo {
 		}
 		if !others {
 			let repo = self.gix()?;
-			let index = repo
-				.index_or_empty()
-				.map_err(|err| Error::backend("git ls-files", err))?;
+			let index = load_index_or_empty(&repo, "git ls-files")?;
 			let mut out: Vec<_> = index
 				.entries()
 				.iter()

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `VcsGitRepo` staging and commits reading a stale in-memory index snapshot on a reused repo handle, which could make `commitCreate` fail with "nothing to commit, working tree clean" right after `stageFiles` on coarse-mtime filesystems ([#10130](https://github.com/can1357/oh-my-pi/issues/10130)).
+
 ## [18.0.10] - 2026-08-28
 
 ### Added


### PR DESCRIPTION
## Repro
On a reused `VcsGitRepo` handle, a `commitCreate` right after `stageFiles` intermittently errors `nothing to commit, working tree clean` even though the file is modified and staged on disk (18/20 runs on WSL2 in `packages/natives/test/vcs.test.ts`; wider on coarse-mtime filesystems). Made deterministic by pinning the index mtime so the stage write and the read that captured the snapshot collide on one tick:

```
cargo nextest run -p pi-vcs stage_commit_survives_unadvanced_index_mtime
# against the original cached-snapshot reads:
thread panicked: called `Result::unwrap()` on an `Err` value:
  Backend { context: "git commit", message: "nothing to commit, working tree clean" }
```

## Cause
The cached `GitRepo` handle (`crates/pi-vcs/src/git/open.rs`) opens one `gix::ThreadSafeRepository` whose `to_thread_local()` clones share a single `gix_fs::SharedFileSnapshot<gix_index::File>` index slot. Mutators (`stage_files`, `unstage`, `restore`, `checkout`, `clean`, worktree-remove) write the index via `gix_index::File::write` but never invalidate that shared snapshot, and reads (`commit_create`, diff/status, ls-files, patch index maps) go back through `index_or_load_from_head_or_empty()` → `try_index()` → `recent_snapshot()`. That freshness check is a strict `snapshot.modified < file_mtime` (gix-fs `snapshot.rs`, which documents it "relies on sub-section precision or else is a race … up to the caller"). When a stage and the preceding read land in the same mtime tick, the stale pre-stage snapshot is served, so `commit_create` builds the parent tree → `nothing to commit`.

## Fix
- Add `load_index_or_head` / `load_index_or_empty` in `git/open.rs`: load the persisted index with a fresh `open_index()` (direct disk read, no snapshot), falling back to `HEAD^{tree}`/empty (or an empty index) only when no index file exists.
- Route every pi-vcs index read through these helpers: `stage_files`, `unstage`, `commit_create`, `restore`, `clean`, `checkout`, worktree-remove (`mutate.rs`); `index_changes` and `make_pathspec` (`diff.rs`); `ls-files` (`read.rs`); `index_map` and untracked walk (`patch.rs`).
- mutate→read on a reused handle no longer depends on filesystem timestamp granularity.

## Verification
`cargo nextest run -p pi-vcs` — 38/38 pass (the new `stage_commit_survives_unadvanced_index_mtime` regression test included; it fails with the pre-fix cached reads and passes after). One unrelated test (`read_objects_logs_and_refs`) fails only when the ambient `GIT_AUTHOR_NAME=roboomp` env overrides the fixture's local git identity; it passes with a clean identity env and is untouched by this change.
Fixes #10130