### PR TITLE
fix(tui): correct Nerd Font pi icon

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### Fixed
 
+- Fixed the Nerd Font statusline brand icon rendering as an axis-rotation symbol instead of pi.
 - Fixed edit-tool parsing of `－`-prefixed MATCH lines so they correctly represent whole-line deletions and can be replaced by a following `＋` run.
 - Fixed interrupted and failed Python evaluation cells being reported as successful results instead of errors, improving model handling, telemetry, retries, and background-job failure reporting.
 - Fixed native-extension imports such as `numpy` hanging indefinitely in the Python evaluation tool on Windows.

--- a/packages/coding-agent/src/modes/theme/symbols.ts
+++ b/packages/coding-agent/src/modes/theme/symbols.ts
@@ -783,8 +783,8 @@ const NERD_SYMBOLS: SymbolMap = {
 	"icon.advisor": "\uea70",
 	// pick:  | alt: ◷ ◴
 	"icon.time": "\uf017",
-	// pick: 󰵗 (nf-md-pi) | alt:  π ∏ ∑
-	"icon.omp": "\u{f0d57}",
+	// pick: 󰏿 (nf-md-pi) | alt:  π ∏ ∑
+	"icon.omp": "\u{f03ff}",
 	// pick: 󱊷 (nf-md-keyboard_esc) | alt: ⎋
 	"icon.esc": "\u{f12b7}",
 	// pick: 󰊠 (nf-md-ghost) | alt: 👻

--- a/packages/coding-agent/test/theme-nerd-symbols.test.ts
+++ b/packages/coding-agent/test/theme-nerd-symbols.test.ts
@@ -23,7 +23,7 @@ afterEach(async () => {
 	tempAgentDir = undefined;
 });
 
-it("uses the Nerd Fonts v3 session and C# icons", async () => {
+it("uses the Nerd Fonts v3 brand, session, and C# icons", async () => {
 	originalAgentDir = getAgentDir();
 	originalAgentDirEnv = process.env.PI_CODING_AGENT_DIR;
 	tempAgentDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-nerd-symbols-"));
@@ -37,6 +37,7 @@ it("uses the Nerd Fonts v3 session and C# icons", async () => {
 	);
 
 	const theme = await getThemeByName(customThemeName);
+	expect(theme?.symbol("icon.omp")).toBe("\u{f03ff}");
 	expect(theme?.symbol("icon.session")).toBe("\u{f0051}");
 	expect(theme?.getLangIcon("csharp")).toBe("\u{e7b2}");
 });


### PR DESCRIPTION
## Repro
With the Nerd symbol preset, `bun -e 'import { SYMBOL_PRESETS } from "./packages/coding-agent/src/modes/theme/symbols.ts"; const glyph = SYMBOL_PRESETS.nerd["icon.omp"]; console.log(`U+${glyph.codePointAt(0)?.toString(16).toUpperCase()}`);'` printed `U+F0D57`, which Nerd Fonts assigns to `md-axis_z_rotate_clockwise` rather than `md-pi`.

## Cause
`packages/coding-agent/src/modes/theme/symbols.ts` mapped the Nerd preset's `icon.omp` entry to U+F0D57 while labeling it `nf-md-pi`; the actual Nerd Fonts v3 `md-pi` codepoint is U+F03FF.

## Fix
- Map `icon.omp` to Nerd Fonts v3 U+F03FF (`md-pi`).
- Cover the brand codepoint in `theme-nerd-symbols.test.ts`.
- Document the user-visible correction in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/theme-nerd-symbols.test.ts` passed: 2 tests, 0 failures. The corrected runtime probe prints `U+F03FF`; the pre-publish `bun check` gate passed. Fixes #10158