### PR TITLE
fix(auth): prevent unregistered Z.AI callback ports

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Z.AI browser sign-in using an unregistered random callback port when port 54548 is occupied; it now reports the conflict before opening the browser ([#10157](https://github.com/can1357/oh-my-pi/issues/10157)).
+
 ## [18.0.9] - 2026-08-28
 
 ### Fixed

--- a/packages/ai/src/registry/oauth/zai.ts
+++ b/packages/ai/src/registry/oauth/zai.ts
@@ -217,7 +217,11 @@ export class ZaiOAuthFlow extends OAuthCallbackFlow {
 	#fetch: FetchImpl;
 
 	constructor(ctrl: OAuthController) {
-		super(ctrl, CALLBACK_PORT, CALLBACK_PATH);
+		super(ctrl, {
+			preferredPort: CALLBACK_PORT,
+			callbackPath: CALLBACK_PATH,
+			allowPortFallback: false,
+		});
 		this.#fetch = ctrl.fetch ?? fetch;
 	}
 

--- a/packages/ai/test/zai-oauth.test.ts
+++ b/packages/ai/test/zai-oauth.test.ts
@@ -117,6 +117,24 @@ describe("zai oauth flow", () => {
 		expect(authUrl.searchParams.get("code_challenge_method")).toBeNull();
 	});
 
+	it("rejects an occupied fixed callback port before opening the browser", async () => {
+		const serveSpy = vi.spyOn(Bun, "serve").mockImplementation(() => {
+			throw Object.assign(new Error("EADDRINUSE"), { code: "EADDRINUSE" });
+		});
+		const onAuth = vi.fn();
+		const flow = new ZaiOAuthFlow({ onAuth });
+
+		const error = await flow.login().catch((caught: unknown) => caught);
+
+		expect(error).toBeInstanceOf(AIError.ConfigurationError);
+		if (!(error instanceof AIError.ConfigurationError)) throw error;
+		expect(error.message).toContain(
+			"OAuth callback port 54548 is in use. The OAuth provider validates redirect URIs",
+		);
+		expect(onAuth).not.toHaveBeenCalled();
+		expect(serveSpy.mock.calls.every(([options]) => options.port === 54548)).toBe(true);
+	});
+
 	it("exchanges the code, does business-login, then mints an id.secret key (create path)", async () => {
 		const { fetchMock, requests } = makeBizFetch();
 		const flow = new ZaiOAuthFlow({ fetch: fetchMock as unknown as typeof fetch });


### PR DESCRIPTION
## Repro
With port `54548` occupied, instantiate `ZaiOAuthFlow` and start `login()`. Before this fix, the flow logged `Preferred port 54548 unavailable, using port 40529` and advertised `redirect_uri=http://localhost:40529/callback`, which cannot match Z.AI's fixed OAuth allowlist. The reproduction used `bun -e` to bind `127.0.0.1:54548`, capture `onAuth`, and inspect the authorization URL.

## Cause
`ZaiOAuthFlow` in `packages/ai/src/registry/oauth/zai.ts` passed the callback port through the numeric `OAuthCallbackFlow` constructor. That constructor enables random-port fallback by default, despite Z.AI requiring the registered port `54548` and path `/callback` exactly.

## Fix
- Construct the Z.AI callback flow with `allowPortFallback: false`, preserving `http://localhost:54548/callback`.
- Add a Z.AI-specific regression test proving an occupied fixed port raises `ConfigurationError` before opening the browser.
- Document the corrected sign-in behavior in the AI package changelog.

## Verification
`bun test packages/ai/test/zai-oauth.test.ts` passed: 8 tests, 0 failures. A manual occupied-port smoke probe reported `browser opened=false` and the actionable port-conflict error. The pre-publish gate also completed `bun run fix` and `bun check` successfully.

Fixes #10157