### PR TITLE
fix(coding-agent): prefer RFC 9728 path-inserted protected-resource metadata

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed MCP OAuth discovery preferring RFC 9728 path-inserted protected-resource metadata over origin-root authorization-server documents on shared API gateways, so the grant targets the resource's issuer rather than a generic login hub.
+
 ## [18.0.10] - 2026-08-28
 
 ### Added

--- a/packages/coding-agent/src/mcp/oauth-discovery.ts
+++ b/packages/coding-agent/src/mcp/oauth-discovery.ts
@@ -231,7 +231,10 @@ export function analyzeAuthError(error: Error, serverUrl?: string): AuthDetectio
 	const authServerUrl = extractMcpAuthServerUrl(error, serverUrl);
 	// Extract resource_metadata URL from challenge entries in error message
 	const resourceMetaMatch = error.message.match(/resource_metadata\s*=\s*"([^"]+)"/i);
-	const resourceMetadataUrl = resourceMetaMatch?.[1];
+	// RFC 9728 / MCP: when WWW-Authenticate omits resource_metadata, still probe
+	// the path-inserted protected-resource URL. Origin-root authorization-server
+	// documents on shared gateways often name a different issuer.
+	const resourceMetadataUrl = resourceMetaMatch?.[1] ?? rfc9728ProtectedResourceMetadataUrl(serverUrl);
 
 	// Try to extract OAuth endpoints
 	const oauth = extractOAuthEndpoints(error);
@@ -257,6 +260,19 @@ export function analyzeAuthError(error: Error, serverUrl?: string): AuthDetectio
 
 	// Check if it might be API key based
 	const errorMsg = error.message.toLowerCase();
+	// A JSON 401 that mentions JWT is a bearer/OAuth challenge, not a static
+	// API key. The generic "token"/"bearer" heuristic below would otherwise
+	// classify it as apikey and skip protected-resource discovery.
+	if (/\bjwt\b/.test(errorMsg) && errorMsg.includes("token")) {
+		return {
+			requiresAuth: true,
+			authType: "oauth",
+			authServerUrl,
+			resourceMetadataUrl,
+			scopes: challengeScopes,
+			message: "Server requires OAuth authentication. Launching authorization flow...",
+		};
+	}
 	if (
 		errorMsg.includes("api key") ||
 		errorMsg.includes("api_key") ||
@@ -324,6 +340,24 @@ function issuerMatchesBase(metadataIssuer: unknown, baseUrl: string): boolean {
 }
 
 /**
+ * RFC 9728: insert `/.well-known/oauth-protected-resource` between the origin
+ * and the resource path. Origin-root protected-resource metadata on API
+ * gateways often names a shared login hub, not the issuer that minted the
+ * client's `client_id`.
+ */
+export function rfc9728ProtectedResourceMetadataUrl(serverUrl: string | undefined): string | undefined {
+	if (!serverUrl) return undefined;
+	try {
+		const parsed = new URL(serverUrl);
+		const path = parsed.pathname.replace(/\/+$/, "");
+		if (!path) return undefined;
+		return `${parsed.origin}/.well-known/oauth-protected-resource${path}`;
+	} catch {
+		return undefined;
+	}
+}
+
+/**
  * Read space-separated OAuth scopes off a metadata document. Accepts either
  * an array (RFC 8414 `scopes_supported`) or a space-separated string
  * (`scopes` / `scope`), matching what MCP gateways emit under
@@ -379,13 +413,25 @@ export async function discoverOAuthEndpoints(
 	opts?: { fetch?: FetchImpl; protectedResource?: string; protectedScopes?: string; signal?: AbortSignal },
 ): Promise<OAuthEndpoints | null> {
 	const fetchImpl: FetchImpl = opts?.fetch ?? fetch;
-	const wellKnownPaths = [
+	const issuerWellKnownPaths = [
 		"/.well-known/oauth-authorization-server",
 		"/.well-known/openid-configuration",
 		"/.well-known/oauth-protected-resource",
 		"/oauth/metadata",
 		"/.mcp/auth",
-		"/authorize", // Some MCP servers expose OAuth config here
+		"/authorize",
+	];
+	// Resource-server fallback: probe protected-resource metadata before
+	// origin-root authorization-server / OpenID documents. Gateways that front
+	// many tenants commonly publish a generic AS at the origin that is not the
+	// authorization server for this MCP URL.
+	const resourceWellKnownPaths = [
+		"/.well-known/oauth-protected-resource",
+		"/.well-known/oauth-authorization-server",
+		"/.well-known/openid-configuration",
+		"/oauth/metadata",
+		"/.mcp/auth",
+		"/authorize",
 	];
 	const urlsToQuery: Array<{ url: string; issuerCandidate: boolean }> = [];
 	const visitedAuthServers = new Set<string>();
@@ -483,6 +529,7 @@ export async function discoverOAuthEndpoints(
 	};
 
 	for (const base of urlsToQuery) {
+		const wellKnownPaths = base.issuerCandidate ? issuerWellKnownPaths : resourceWellKnownPaths;
 		for (const path of wellKnownPaths) {
 			// Try each well-known path at both the absolute origin and relative
 			const urlsToTry = buildWellKnownUrls(path, base.url);
@@ -566,22 +613,23 @@ function buildWellKnownUrls(wellKnownPath: string, baseUrl: string): URL[] {
 	const prefixPath = lastSlash === 0 ? normalizedPath : normalizedPath.slice(0, lastSlash);
 	const relUrl = new URL(wellKnownPath.slice(1), `${parsed.origin}${prefixPath}/`);
 
-	const candidates: URL[] = [absUrl];
-	const seen = new Set<string>([absUrl.href]);
+	const candidates: URL[] = [];
+	const seen = new Set<string>();
 	const push = (u: URL): void => {
 		if (!seen.has(u.href)) {
 			candidates.push(u);
 			seen.add(u.href);
 		}
 	};
-	push(relUrl);
 
-	// RFC 8414 §3.1 path-ful issuer form: /.well-known/<suffix>/<issuer-path>.
-	// Only meaningful for well-known metadata documents.
+	// RFC 8414 §3.1 / RFC 9728: insert the well-known suffix between origin and
+	// path first. Origin-root documents on MCP gateways often describe a
+	// different issuer than the path-scoped resource.
 	if (wellKnownPath.startsWith("/.well-known/")) {
-		const pathfulUrl = new URL(`${wellKnownPath}${normalizedPath}`, parsed.origin);
-		push(pathfulUrl);
+		push(new URL(`${wellKnownPath}${normalizedPath}`, parsed.origin));
 	}
+	push(relUrl);
+	push(absUrl);
 
 	return candidates;
 }

--- a/packages/coding-agent/test/oauth-discovery.test.ts
+++ b/packages/coding-agent/test/oauth-discovery.test.ts
@@ -6,6 +6,7 @@ import {
 	extractMcpAuthServerUrl,
 	extractOAuthChallengeScopes,
 	fetchResourceMetadataScopes,
+	rfc9728ProtectedResourceMetadataUrl,
 } from "@oh-my-pi/pi-coding-agent/mcp/oauth-discovery";
 import { type FetchInput, mockFetch } from "./helpers/fetch-mock";
 
@@ -89,9 +90,8 @@ describe("path-prefixed auth servers", () => {
 			authorizationUrl: "https://gateway.example.com/my-service/oauth/authorize",
 			tokenUrl: "https://gateway.example.com/my-service/oauth/token",
 		});
-		// Absolute well-known was tried first (existing behavior)
-		expect(calls[0]).toBe("https://gateway.example.com/.well-known/oauth-authorization-server");
-		// Relative well-known was tried as fallback
+		// Resource-server fallback probes RFC 9728 path-inserted PR metadata first.
+		expect(calls[0]).toBe("https://gateway.example.com/.well-known/oauth-protected-resource/my-service/mcp");
 		expect(calls).toContain("https://gateway.example.com/my-service/.well-known/oauth-authorization-server");
 	});
 
@@ -125,7 +125,7 @@ describe("path-prefixed auth servers", () => {
 			authorizationUrl: "https://gateway.example.com/my-service/oauth/authorize",
 			tokenUrl: "https://gateway.example.com/my-service/oauth/token",
 		});
-		expect(calls[0]).toBe("https://gateway.example.com/.well-known/oauth-authorization-server");
+		expect(calls[0]).toBe("https://gateway.example.com/.well-known/oauth-protected-resource/my-service");
 		expect(calls).toContain("https://gateway.example.com/my-service/.well-known/oauth-authorization-server");
 	});
 
@@ -529,6 +529,88 @@ describe("relative Mcp-Auth-Server URL", () => {
 	});
 });
 
+describe("RFC 9728 path-inserted protected resource", () => {
+	const mcpUrl = "https://mcp.gateway.example/platform/v1/d/tenant.example/prod/service";
+	const pathfulPr =
+		"https://mcp.gateway.example/.well-known/oauth-protected-resource/platform/v1/d/tenant.example/prod/service";
+	const originAs = "https://mcp.gateway.example/.well-known/oauth-authorization-server";
+	const tenantOidc = "https://tenant.example/.well-known/openid-configuration";
+
+	it("builds the path-inserted protected-resource URL between origin and MCP path", () => {
+		expect(rfc9728ProtectedResourceMetadataUrl(mcpUrl)).toBe(pathfulPr);
+		expect(rfc9728ProtectedResourceMetadataUrl("https://mcp.gateway.example")).toBeUndefined();
+		expect(rfc9728ProtectedResourceMetadataUrl(undefined)).toBeUndefined();
+	});
+
+	it("synthesizes resource_metadata for a 401 that omits WWW-Authenticate", () => {
+		const error = new Error('HTTP 401: {"errors":[{"message":"JWT Token is required"}]}');
+		const auth = analyzeAuthError(error, mcpUrl);
+		expect(auth.requiresAuth).toBe(true);
+		expect(auth.authType).toBe("oauth");
+		expect(auth.resourceMetadataUrl).toBe(pathfulPr);
+	});
+
+	it("does not classify a JWT bearer 401 as an API key", () => {
+		const error = new Error('HTTP 401: {"errors":[{"message":"JWT Token is required"}]}');
+		expect(analyzeAuthError(error).authType).toBe("oauth");
+	});
+
+	it("prefers path-inserted PR metadata over origin-root AS for a shared gateway", async () => {
+		const calls: string[] = [];
+		const fetchImpl = mockFetch((input: FetchInput) => {
+			const url = String(input);
+			calls.push(url);
+
+			if (url === pathfulPr) {
+				return new Response(
+					JSON.stringify({
+						resource: mcpUrl,
+						authorization_servers: ["https://tenant.example"],
+						scopes_supported: ["mcp_api", "offline_access"],
+					}),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				);
+			}
+
+			if (url === originAs) {
+				return new Response(
+					JSON.stringify({
+						authorization_endpoint: "https://login.hub.example/oauth/authorize",
+						token_endpoint: "https://login.hub.example/oauth/token",
+						scopes_supported: ["api", "profile", "refresh_token"],
+					}),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				);
+			}
+
+			if (url === tenantOidc) {
+				return new Response(
+					JSON.stringify({
+						issuer: "https://tenant.example",
+						authorization_endpoint: "https://tenant.example/oauth/authorize",
+						token_endpoint: "https://tenant.example/oauth/token",
+					}),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				);
+			}
+
+			return new Response("not found", { status: 404 });
+		});
+
+		const oauth = await discoverOAuthEndpoints(mcpUrl, undefined, undefined, { fetch: fetchImpl });
+
+		expect(oauth).toEqual({
+			authorizationUrl: "https://tenant.example/oauth/authorize",
+			tokenUrl: "https://tenant.example/oauth/token",
+			scopes: "mcp_api offline_access",
+			resource: mcpUrl,
+		});
+		expect(calls[0]).toBe(pathfulPr);
+		expect(calls).toContain(tenantOidc);
+		expect(calls).not.toContain(originAs);
+	});
+});
+
 describe("RFC 8414 §3.3 issuer validation", () => {
 	it("accepts cross-host issuer metadata on resource-server fallback (Atlassian regression)", async () => {
 		const calls: string[] = [];
@@ -560,7 +642,7 @@ describe("RFC 8414 §3.3 issuer validation", () => {
 			tokenUrl: "https://cf.mcp.atlassian.com/v1/token",
 			registrationUrl: "https://cf.mcp.atlassian.com/v1/register",
 		});
-		expect(calls[0]).toBe("https://mcp.atlassian.com/.well-known/oauth-authorization-server");
+		expect(calls).toContain("https://mcp.atlassian.com/.well-known/oauth-authorization-server");
 	});
 
 	it("rejects origin-root metadata whose issuer mismatches the path-scoped auth server (Plane regression)", async () => {
@@ -568,10 +650,9 @@ describe("RFC 8414 §3.3 issuer validation", () => {
 		// origin-root well-known *and* a path-scoped issuer
 		// (`https://mcp.plane.so/http`) at the path-prefixed well-known. The
 		// `/http/mcp` endpoint advertises only the path-scoped issuer via
-		// protected-resource metadata, but the discovery loop probes origin-root
-		// first; before the fix it accepted the wrong-issuer metadata and routed
-		// the OAuth flow to `https://mcp.plane.so/authorize`, which rejects every
-		// grant with `server_error`.
+		// protected-resource metadata. Origin-root AS metadata must not win:
+		// it routes the grant to `https://mcp.plane.so/authorize`, which rejects
+		// every grant with `server_error`.
 		const calls: string[] = [];
 		const fetchImpl = mockFetch((input: FetchInput) => {
 			const url = String(input);
@@ -628,9 +709,9 @@ describe("RFC 8414 §3.3 issuer validation", () => {
 			registrationUrl: "https://mcp.plane.so/http/register",
 			resource: "https://mcp.plane.so/http/mcp",
 		});
-		// Wrong-issuer origin-root metadata WAS fetched and skipped.
-		expect(calls).toContain("https://mcp.plane.so/.well-known/oauth-authorization-server");
-		// Path-prefixed well-known is the one that supplied the result.
+		// Path-prefixed well-known is tried before origin-root, so the
+		// wrong-issuer origin document is never consulted.
+		expect(calls).not.toContain("https://mcp.plane.so/.well-known/oauth-authorization-server");
 		expect(calls).toContain("https://mcp.plane.so/http/.well-known/oauth-authorization-server");
 	});
 


### PR DESCRIPTION
I hit this when `/mcp reauth` against a path-scoped MCP on a shared API gateway opened the hub authorize URL instead of the tenant issuer.

## What

MCP OAuth discovery now prefers RFC 9728 path-inserted protected-resource metadata over origin-root authorization-server documents, and treats JWT bearer 401s as OAuth rather than API keys.

## Why

Shared API gateways often publish a generic origin-root authorization server that is not the issuer for a path-scoped MCP resource. When a 401 omits `WWW-Authenticate` `resource_metadata`, discovery accepted that hub document first, so `/mcp reauth` and `/mcp add` launched the wrong authorize URL (and the wrong scopes).

This is not covered by #10045 (Keycloak-style OIDC issuer-path lookup) or by the existing Plane issuer-match / RFC 9728 scope-precedence work: those still treat origin-root AS as a valid first hit, and they do not synthesize a path-inserted protected-resource URL when the challenge omits it.

## Testing

- `bun test packages/coding-agent/test/oauth-discovery.test.ts` → 27 pass
- `bun check` → pass
- Existing Atlassian, Plane, Figma, and path-prefixed gateway tests updated for the new probe order

## Repro

A path-scoped MCP at `https://mcp.gateway.example/platform/v1/d/tenant.example/prod/service` sits behind a shared gateway.

- Origin-root `/.well-known/oauth-authorization-server` advertises a login-hub authorize/token pair and hub-wide scopes.
- The RFC 9728 path-inserted document (`/.well-known/oauth-protected-resource/<mcp-path>`) names `https://tenant.example` as the authorization server and the resource scopes (`mcp_api offline_access`).
- Tenant OIDC is at `https://tenant.example/.well-known/openid-configuration`.
- The 401 is JSON (`JWT Token is required`) with no `WWW-Authenticate` `resource_metadata`.

Before this change, discovery classified the 401 as `apikey` (because the message contains `"token"`), or, if discovery ran, accepted the origin-root AS and opened the hub authorize URL. After the change, discovery returns the tenant authorize/token URLs, the resource scopes, and does not fetch the hub AS.

## Cause

Four interacting gaps in `packages/coding-agent/src/mcp/oauth-discovery.ts`:

1. `analyzeAuthError` only used `resource_metadata` from `WWW-Authenticate`. A 401 without that challenge never got a protected-resource URL.
2. Resource-server fallback probed origin-root `/.well-known/oauth-authorization-server` before protected-resource metadata. Resource fallback also skips RFC 8414 issuer matching (`issuerCandidate: false`, the Atlassian exception), so a hub document with `authorization_endpoint` + `token_endpoint` won immediately.
3. `buildWellKnownUrls` put origin-root first and the RFC 8414 / RFC 9728 path-inserted form last.
4. The `"token"` / `"bearer"` heuristic classified `"JWT Token is required"` as `apikey`, so `/mcp reauth` skipped OAuth discovery entirely.

## Fix

- Synthesize the RFC 9728 path-inserted URL (`{origin}/.well-known/oauth-protected-resource{path}`) when the challenge omits `resource_metadata`.
- On resource-server fallback, probe protected-resource metadata before origin-root AS / OIDC documents.
- In `buildWellKnownUrls`, try path-inserted, then path-prefixed, then origin-root.
- Classify a JSON 401 that mentions JWT as `oauth` so discovery still runs. This is deliberate: a bearer JWT challenge is not a static API key. Servers that actually want API-key auth and happen to say "JWT token" would now enter the OAuth path; that tradeoff is noted in review.

Origin-root remains a candidate, just last. Servers that only publish origin-root metadata still work; they take two extra failed probes when the MCP URL has a path. That is the RFC 9728 tradeoff.

## Verification

Contract tests in `packages/coding-agent/test/oauth-discovery.test.ts`:

- Gateway fixture above: tenant endpoints + resource scopes; origin-root AS is not fetched.
- `analyzeAuthError` synthesizes the path-inserted URL for a 401 with no `WWW-Authenticate`.
- `"JWT Token is required"` is `authType: "oauth"`, not `apikey`.
- Plane regression still resolves the path-scoped issuer (origin-root hub document is no longer consulted once path-prefixed metadata succeeds).

Manually: `/mcp reauth` against the path-scoped MCP now opens the tenant authorize URL with the resource scopes, not the hub authorize URL.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
