### PR TITLE
fix(coding-agent): auto-retry transport errors after proven-unexecuted tool calls

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Retriable transport errors (e.g. `socket connection was closed unexpectedly`, timeouts) after the model already streamed a complete tool call now auto-retry through the configured retry budget and fallback chains instead of ending the turn terminally. The retry is gated on positive proof that every emitted call never executed (each paired with a synthetic `executed: false` result) and no committed text or image output, so a side effect can never be replayed; turns with any executed call, real result, or committed visible output keep the existing replay-unsafe veto.
+
 ## [18.0.10] - 2026-08-28
 
 ### Added

--- a/packages/coding-agent/src/session/turn-recovery.ts
+++ b/packages/coding-agent/src/session/turn-recovery.ts
@@ -1158,11 +1158,16 @@ export class TurnRecovery {
 
 		// Credential rotation and classifier fallbacks are safe only before
 		// committed text, images, tool calls, or server tools. Thinking-only
-		// output remains replay-safe. A classifier refusal or malformed-function
-		// response may also be replayed when every emitted tool call is paired
-		// with positive proof that it never executed.
+		// output remains replay-safe. A classifier refusal, malformed-function
+		// response, or retriable transport error (the provider stream died
+		// mid-turn after a complete tool call — e.g. a socket close — and every
+		// emitted call was paired with a synthetic `executed: false` result) may
+		// also be replayed when every emitted tool call is paired with positive
+		// proof that it never executed.
 		const replaySafeUnexecutedTools =
-			(this.isClassifierRefusal(message) || AIError.is(id, AIError.Flag.MalformedFunctionCall)) &&
+			(this.isClassifierRefusal(message) ||
+				AIError.is(id, AIError.Flag.MalformedFunctionCall) ||
+				AIError.retriable(id)) &&
 			this.#unexecutedToolCallsReplaySafe(message);
 		if (this.#hasReplayUnsafeOutput(message) && !replaySafeUnexecutedTools) return false;
 		if (AIError.is(id, AIError.Flag.AccountPolicy) || this.isClassifierRefusal(message)) return true;
@@ -1172,7 +1177,8 @@ export class TurnRecovery {
 	/**
 	 * True when every emitted tool call provably never executed and no other
 	 * replay-unsafe output exists. The caller restricts this exception to
-	 * classifier refusals and malformed-function responses.
+	 * classifier refusals, malformed-function responses, and retriable
+	 * transport errors.
 	 *
 	 * Gemini can report `MALFORMED_FUNCTION_CALL` after streaming an earlier,
 	 * well-formed call. Anthropic classifiers can likewise refuse after a call.
@@ -2019,7 +2025,9 @@ export class TurnRecovery {
 		const id = this.#classifyRetryMessage(message);
 		const preserveFailedTurn =
 			options?.preserveFailedTurn === true ||
-			((classifierRefusal || AIError.is(id, AIError.Flag.MalformedFunctionCall)) &&
+			((classifierRefusal ||
+				AIError.is(id, AIError.Flag.MalformedFunctionCall) ||
+				AIError.retriable(id)) &&
 				this.#unexecutedToolCallsReplaySafe(message));
 		const rateLimitReason = parseRateLimitReason(errorMessage);
 		const staleOpenAIResponsesReplayError = AIError.is(id, AIError.Flag.StaleResponsesItem);

--- a/packages/coding-agent/test/agent-session-retry-cap.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-cap.test.ts
@@ -927,13 +927,20 @@ describe("AgentSession retry delay cap", () => {
 		expect(last.stopReason).toBe("stop");
 	});
 
-	it("does not auto-retry a timeout after streaming a complete write tool call", async () => {
+	it("auto-retries a timeout after streaming a complete unexecuted write tool call", async () => {
 		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
 		if (!model) {
 			throw new Error("Expected bundled Anthropic test model to exist");
 		}
 
+		const toolCall: ToolCall = {
+			type: "toolCall",
+			id: "tc-write",
+			name: "write",
+			arguments: { path: "doc/report.md", content: "large report chunk" },
+		};
 		let streamCalls = 0;
+		let resumedWithSyntheticResult = false;
 		const agent = new Agent({
 			getApiKey: model => `${model.provider}-test-key`,
 			initialState: {
@@ -942,8 +949,26 @@ describe("AgentSession retry delay cap", () => {
 				tools: [],
 				messages: [],
 			},
-			streamFn: requestedModel => {
+			streamFn: (requestedModel, context, options) => {
 				streamCalls += 1;
+				if (streamCalls > 1) {
+					const matchingResult = context.messages.find(
+						message => message.role === "toolResult" && message.toolCallId === toolCall.id,
+					);
+					resumedWithSyntheticResult =
+						matchingResult?.role === "toolResult" &&
+						typeof matchingResult.details === "object" &&
+						matchingResult.details !== null &&
+						"executed" in matchingResult.details &&
+						matchingResult.details.executed === false;
+					const recoveryModel = createMockModel({
+						id: requestedModel.id,
+						provider: requestedModel.provider,
+					});
+					recoveryModel.push({ content: ["Recovered after timeout"] });
+					return recoveryModel.stream(recoveryModel, context, options);
+				}
+
 				const stream = new AssistantMessageEventStream();
 				queueMicrotask(() => {
 					const partial: AssistantMessage = {
@@ -962,12 +987,6 @@ describe("AgentSession retry delay cap", () => {
 						},
 						stopReason: "stop",
 						timestamp: Date.now(),
-					};
-					const toolCall: ToolCall = {
-						type: "toolCall",
-						id: "tc-write",
-						name: "write",
-						arguments: { path: "doc/report.md", content: "large report chunk" },
 					};
 					partial.content.push(toolCall);
 					stream.push({ type: "start", partial });
@@ -1010,27 +1029,22 @@ describe("AgentSession retry delay cap", () => {
 
 		const retryStartEvents: AutoRetryStartEvent[] = [];
 		const retryEndEvents: AutoRetryEndEvent[] = [];
-		const agentEndEvents: Array<Extract<AgentSessionEvent, { type: "agent_end" }>> = [];
 		session.subscribe(event => {
 			if (event.type === "auto_retry_start") retryStartEvents.push(event);
 			if (event.type === "auto_retry_end") retryEndEvents.push(event);
-			if (event.type === "agent_end") agentEndEvents.push(event);
 		});
 
 		await session.prompt("Write a large report");
 		await session.waitForIdle();
 
-		expect(streamCalls).toBe(1);
-		expect(retryStartEvents).toHaveLength(0);
-		expect(retryEndEvents).toHaveLength(0);
-		expect(session.agent.state.messages.at(-1)?.role).toBe("toolResult");
-		expect(agentEndEvents).toHaveLength(1);
-		expect(agentEndEvents[0].isTerminal).toBe(true);
-		const terminalError = [...agentEndEvents[0].messages]
-			.reverse()
-			.find((message): message is AssistantMessage => message.role === "assistant");
-		expect(terminalError?.stopReason).toBe("error");
-		expect(terminalError?.errorMessage).toBe("The operation timed out.");
+		expect(streamCalls).toBe(2);
+		expect(resumedWithSyntheticResult).toBe(true);
+		expect(retryStartEvents).toHaveLength(1);
+		expect(retryEndEvents).toContainEqual(expect.objectContaining({ success: true, attempt: 1 }));
+		expect(lastAssistant(session).content).toContainEqual({
+			type: "text",
+			text: "Recovered after timeout",
+		});
 	});
 
 	it.each([

--- a/packages/coding-agent/test/turn-recovery-replay-unsafe.test.ts
+++ b/packages/coding-agent/test/turn-recovery-replay-unsafe.test.ts
@@ -60,7 +60,7 @@ function createHost(
 		}
 	}
 	return {
-		agent: (options.messages ? { state: { messages: options.messages } } : undefined) as never,
+		agent: { state: { messages: options.messages ?? [] } } as never,
 		sessionManager: {
 			getLastModelChangeRole: () => options.lastModelChangeRole,
 		} as never,
@@ -584,9 +584,84 @@ describe("TurnRecovery replay-unsafe output classification", () => {
 			expect(recoveryFor(message, [syntheticResult("call-1")]).isRetryableError(message)).toBe(false);
 		});
 
-		it("keeps a non-refusal error with an unexecuted tool call non-retriable", () => {
+		it("retries a transport error with a provably unexecuted tool call", () => {
 			const message = makeMessage([toolCall("call-1")], model);
-			expect(recoveryFor(message, [syntheticResult("call-1")]).isRetryableError(message)).toBe(false);
+			expect(recoveryFor(message, [syntheticResult("call-1")]).isRetryableError(message)).toBe(true);
+		});
+	});
+
+	// A provider transport error (e.g. `The socket connection was closed
+	// unexpectedly` after the model emitted a complete tool call) ends the turn
+	// with `stopReason: "error"`; the agent loop pairs every emitted-but-unrun
+	// call with a synthetic `executed: false` result. With positive proof that
+	// none of them ran, the turn is replay-safe the same way a post-call
+	// classifier refusal is, so the configured retry/fallback policy gets its
+	// chance instead of surfacing the socket error as terminal.
+	describe("transport error with emitted tool calls", () => {
+		const socketClose =
+			"The socket connection was closed unexpectedly. For more information, pass `verbose: true` in the second argument to fetch()";
+
+		function transportError(content: AssistantMessage["content"]): AssistantMessage {
+			const message = makeMessage(content, model);
+			message.errorMessage = socketClose;
+			return message;
+		}
+
+		function toolCall(id: string): AssistantMessage["content"][number] {
+			return { type: "toolCall", id, name: "bash", arguments: { command: "ssh host" } };
+		}
+
+		function syntheticResult(toolCallId: string): ToolResultMessage<SyntheticToolResultDetails> {
+			return {
+				role: "toolResult",
+				toolCallId,
+				toolName: "bash",
+				content: [{ type: "text", text: "Tool call was not executed." }],
+				isError: true,
+				details: { __synthetic: true, source: "assistant_stop_error", executed: false },
+				timestamp: Date.now(),
+			};
+		}
+
+		function realResult(toolCallId: string): ToolResultMessage {
+			return {
+				role: "toolResult",
+				toolCallId,
+				toolName: "bash",
+				content: [{ type: "text", text: "ok" }],
+				isError: false,
+				timestamp: Date.now(),
+			};
+		}
+
+		function recoveryForTransport(message: AssistantMessage, tail: readonly AgentMessage[]): TurnRecovery {
+			return new TurnRecovery(createHost(model, modelRegistry, { messages: [message as AgentMessage, ...tail] }));
+		}
+
+		it("retries when the only tool call provably never executed", () => {
+			const message = transportError([toolCall("call-1")]);
+			expect(recoveryForTransport(message, [syntheticResult("call-1")]).isRetryableError(message)).toBe(true);
+		});
+
+		it("does not retry when the tool call produced a real result", () => {
+			const message = transportError([toolCall("call-1")]);
+			expect(recoveryForTransport(message, [realResult("call-1")]).isRetryableError(message)).toBe(false);
+		});
+
+		it("does not retry when only some tool calls went unexecuted", () => {
+			const message = transportError([toolCall("call-1"), toolCall("call-2")]);
+			const recovery = recoveryForTransport(message, [realResult("call-1"), syntheticResult("call-2")]);
+			expect(recovery.isRetryableError(message)).toBe(false);
+		});
+
+		it("does not retry when the turn also committed visible text", () => {
+			const message = transportError([{ type: "text", text: "Connecting..." }, toolCall("call-1")]);
+			expect(recoveryForTransport(message, [syntheticResult("call-1")]).isRetryableError(message)).toBe(false);
+		});
+
+		it("does not retry when the tool call has no result at all", () => {
+			const message = transportError([toolCall("call-1")]);
+			expect(recoveryForTransport(message, []).isRetryableError(message)).toBe(false);
 		});
 	});
 


### PR DESCRIPTION
## Problem

A transient provider transport error (`socket connection was closed unexpectedly`, timeouts) that lands **after the model already streamed a complete tool call** ends the turn terminally even though the tool never executed.

Observed in a live session (omp 18.0.10, provider via a local balancer): the network blipped mid-turn; the assistant message carried a complete `toolCall`; the agent loop paired it with a synthetic `executed: false` result, but `TurnRecovery.isRetryableError` vetoed the retry because `#hasReplayUnsafeOutput` treats any retained tool call as committed, and the replay-safe exception covered only classifier refusals and malformed-function responses. The user had to retry manually; the configured retry budget and `retry.fallbackChains` were never consulted.

## Fix

Replay is provably safe when **every** emitted tool call is paired with a synthetic `executed: false` result (`#unexecutedToolCallsReplaySafe`) and no committed text/image output exists. Extend that exception and the preserved-turn continuation to `AIError.retriable` transport errors:

- `isRetryableError`: allow retriable errors through the unexecuted-call replay proof, so the retry budget + fallback chains get their chance.
- `#handleRetryableError` `preserveFailedTurn`: keep the failed assistant/synthetic-result pair for retriable transport errors so continuation re-runs only the proven-unexecuted calls.

Unchanged safety: turns with any executed call, real result, committed text, image, or server tool keep the replay-unsafe veto; usage-limit preflight, context overflow, refusals, aborts, and thinking-loop carve-outs are untouched.

## Tests

- `turn-recovery-replay-unsafe.test.ts`: new `transport error with emitted tool calls` block — retries on full synthetic proof; refuses with a real result, partial accounting, committed text, or no result at all. The test host now always exposes `agent.state` (production shape).
- `agent-session-retry-cap.test.ts`: `does not auto-retry a timeout after streaming a complete write tool call` now asserts the corrected contract (auto-retry, synthetic result preserved into the retried call, successful `auto_retry_end`).

`bun test` across the 11 retry/recovery/session suites: 220 pass, 0 fail.