### PR TITLE
fix(ai): preserve Gemini thought signatures

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Gemini 3.x tool-call continuations through OpenAI-compatible endpoints failing with missing thought signature errors. ([#10172](https://github.com/can1357/oh-my-pi/issues/10172))
+
 ## [18.0.9] - 2026-08-28
 
 ### Fixed

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -63,6 +63,7 @@ import type {
 	ChatCompletionContentPart,
 	ChatCompletionContentPartImage,
 	ChatCompletionContentPartText,
+	ChatCompletionMessageFunctionToolCall,
 	ChatCompletionMessageParam,
 	ChatCompletionTool,
 	ChatCompletionToolMessageParam,
@@ -131,6 +132,44 @@ type OpenAICompletionsChoiceUsage = ChatCompletionChunk.Choice & {
 type OpenAICompletionsDeltaWithReasoningDetails = ChatCompletionChunk.Choice["delta"] & {
 	reasoning_details?: unknown;
 };
+
+type GeminiThoughtSignatureNamespace = "google" | "vertex";
+
+type GeminiThoughtSignatureExtraContent = Partial<
+	Record<GeminiThoughtSignatureNamespace, { thought_signature: string }>
+>;
+
+type OpenAICompletionsFunctionToolCall = ChatCompletionMessageFunctionToolCall & {
+	extra_content?: GeminiThoughtSignatureExtraContent;
+};
+
+const GEMINI_THOUGHT_SIGNATURE_NAMESPACES: readonly GeminiThoughtSignatureNamespace[] = ["google", "vertex"];
+
+function getGeminiThoughtSignatureExtraContent(value: unknown): GeminiThoughtSignatureExtraContent | undefined {
+	if (typeof value !== "object" || value === null) return undefined;
+	for (const namespace of GEMINI_THOUGHT_SIGNATURE_NAMESPACES) {
+		const providerContent = Reflect.get(value, namespace);
+		if (typeof providerContent !== "object" || providerContent === null) continue;
+		const thoughtSignature = Reflect.get(providerContent, "thought_signature");
+		if (typeof thoughtSignature !== "string" || thoughtSignature.length === 0) continue;
+		return namespace === "google"
+			? { google: { thought_signature: thoughtSignature } }
+			: { vertex: { thought_signature: thoughtSignature } };
+	}
+	return undefined;
+}
+
+function parseGeminiThoughtSignatureExtraContent(
+	thoughtSignature: string | undefined,
+): GeminiThoughtSignatureExtraContent | undefined {
+	if (!thoughtSignature) return undefined;
+	try {
+		const parsed: unknown = JSON.parse(thoughtSignature);
+		return getGeminiThoughtSignatureExtraContent(parsed);
+	} catch {
+		return undefined;
+	}
+}
 
 type OpenAICompletionsAssistantMessageParam = ChatCompletionAssistantMessageParam &
 	Partial<Record<OpenAICompletionsReasoningField, string>> & {
@@ -1257,6 +1296,8 @@ const streamOpenAICompletionsOnce = (
 
 							if (toolCall.id) block.id = toolCall.id;
 							if (incomingName) block.name = incomingName;
+							const extraContent = getGeminiThoughtSignatureExtraContent(Reflect.get(toolCall, "extra_content"));
+							if (extraContent) block.thoughtSignature = JSON.stringify(extraContent);
 							let delta = "";
 							// The OpenAI SDK types `function.arguments` as a JSON string, but MiniMax-compatible
 							// hosts stream a fully-formed object instead. Model both shapes so the branches below
@@ -2235,26 +2276,28 @@ export function convertMessages(
 				assistantMsg.tool_calls = toolCalls.map((tc, toolCallIndex) => {
 					const toolCallId = ensureToolCallId(tc.id, `${i}:${toolCallIndex}:${tc.name}`, msg);
 					rememberToolCallId(tc.id, toolCallId);
-					return {
+					const replayedToolCall: OpenAICompletionsFunctionToolCall = {
 						id: normalizeMistralToolId(toolCallId, compat.requiresMistralToolIds),
-						type: "function" as const,
+						type: "function",
 						function: {
 							name: tc.name,
 							arguments: serializeToolArguments(tc.arguments),
 						},
 					};
+					const extraContent = parseGeminiThoughtSignatureExtraContent(tc.thoughtSignature);
+					if (extraContent) replayedToolCall.extra_content = extraContent;
+					return replayedToolCall;
 				});
-				const reasoningDetails = toolCalls
-					.filter(tc => tc.thoughtSignature)
-					.map(tc => {
-						try {
-							const parsed: unknown = JSON.parse(tc.thoughtSignature!);
-							return parsed;
-						} catch {
-							return null;
-						}
-					})
-					.filter(Boolean);
+				const reasoningDetails = toolCalls.flatMap(tc => {
+					const thoughtSignature = tc.thoughtSignature;
+					if (!thoughtSignature) return [];
+					try {
+						const parsed: unknown = JSON.parse(thoughtSignature);
+						return getGeminiThoughtSignatureExtraContent(parsed) ? [] : [parsed];
+					} catch {
+						return [];
+					}
+				});
 				if (reasoningDetails.length > 0) {
 					assistantMsg.reasoning_details = reasoningDetails;
 				}

--- a/packages/ai/test/openai-completions-thought-signature.test.ts
+++ b/packages/ai/test/openai-completions-thought-signature.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "bun:test";
+import { streamOpenAICompletions } from "@oh-my-pi/pi-ai/providers/openai-completions";
+import type { FetchImpl, Message, ModelSpec, ToolCall } from "@oh-my-pi/pi-ai/types";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+
+const model = buildModel({
+	id: "gemini-3.7-flash",
+	name: "Gemini 3.7 Flash",
+	api: "openai-completions",
+	provider: "gemini",
+	baseUrl: "https://generativelanguage.googleapis.com/v1beta/openai",
+	reasoning: true,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 1_000_000,
+	maxTokens: 65_536,
+} satisfies ModelSpec<"openai-completions">);
+
+const userMessage: Message = {
+	role: "user",
+	content: "Read README.md",
+	timestamp: 1,
+};
+
+function sseResponse(delta: Record<string, unknown>, finishReason: "stop" | "tool_calls"): Response {
+	const chunks = [
+		{
+			id: "chatcmpl-gemini",
+			object: "chat.completion.chunk",
+			created: 0,
+			model: model.id,
+			choices: [{ index: 0, delta }],
+		},
+		{
+			id: "chatcmpl-gemini",
+			object: "chat.completion.chunk",
+			created: 0,
+			model: model.id,
+			choices: [{ index: 0, delta: {}, finish_reason: finishReason }],
+		},
+	];
+	const body = `${chunks.map(chunk => `data: ${JSON.stringify(chunk)}`).join("\n\n")}\n\ndata: [DONE]\n\n`;
+	return new Response(body, { headers: { "content-type": "text/event-stream" } });
+}
+
+function createFetch(namespace: "google" | "vertex", payloads: unknown[]): FetchImpl {
+	let requestIndex = 0;
+	async function mockFetch(_input: string | URL | Request, init?: RequestInit): Promise<Response> {
+		if (typeof init?.body === "string") payloads.push(JSON.parse(init.body));
+		if (requestIndex++ === 0) {
+			return sseResponse(
+				{
+					role: "assistant",
+					tool_calls: [
+						{
+							index: 0,
+							id: "call_1",
+							type: "function",
+							function: { name: "read", arguments: '{"path":"README.md"}' },
+							extra_content: { [namespace]: { thought_signature: "opaque-signature" } },
+						},
+					],
+				},
+				"tool_calls",
+			);
+		}
+		return sseResponse({ role: "assistant", content: "done" }, "stop");
+	}
+	return Object.assign(mockFetch, { preconnect: fetch.preconnect });
+}
+
+function findToolCall(messages: Message[]): ToolCall {
+	const assistant = messages.find(message => message.role === "assistant");
+	const toolCall = assistant?.content.find(block => block.type === "toolCall");
+	if (toolCall?.type !== "toolCall") throw new Error("streamed tool call missing");
+	return toolCall;
+}
+
+async function expectThoughtSignatureRoundTrip(namespace: "google" | "vertex"): Promise<void> {
+	const payloads: unknown[] = [];
+	const fetchMock = createFetch(namespace, payloads);
+	const assistant = await streamOpenAICompletions(
+		model,
+		{ messages: [userMessage] },
+		{ apiKey: "test-key", fetch: fetchMock },
+	).result();
+	const toolCall = findToolCall([assistant]);
+	const extraContent = { [namespace]: { thought_signature: "opaque-signature" } };
+
+	expect(toolCall.thoughtSignature).toBe(JSON.stringify(extraContent));
+
+	const toolResult: Message = {
+		role: "toolResult",
+		toolCallId: toolCall.id,
+		toolName: toolCall.name,
+		content: [{ type: "text", text: "README contents" }],
+		isError: false,
+		timestamp: 2,
+	};
+	await streamOpenAICompletions(
+		model,
+		{ messages: [userMessage, assistant, toolResult] },
+		{ apiKey: "test-key", fetch: fetchMock },
+	).result();
+
+	const replayPayload = payloads[1];
+	if (typeof replayPayload !== "object" || replayPayload === null) {
+		throw new Error("continuation payload missing");
+	}
+	const replayMessages = Reflect.get(replayPayload, "messages");
+	if (!Array.isArray(replayMessages)) throw new Error("continuation messages missing");
+	const replayedAssistant = replayMessages.find(
+		message => typeof message === "object" && message !== null && Reflect.get(message, "role") === "assistant",
+	);
+	expect(replayedAssistant).toMatchObject({
+		role: "assistant",
+		tool_calls: [{ id: "call_1", extra_content: extraContent }],
+	});
+}
+
+describe("OpenAI-compatible Gemini thought signatures", () => {
+	it("round-trips the google signature namespace", async () => {
+		await expectThoughtSignatureRoundTrip("google");
+	});
+
+	it("round-trips the vertex signature namespace", async () => {
+		await expectThoughtSignatureRoundTrip("vertex");
+	});
+});


### PR DESCRIPTION
## Repro
A provider-level Gemini OpenAI-compatible stream containing `extra_content.google.thought_signature` or `extra_content.vertex.thought_signature` loses that field before the first continuation. Before the fix, `bun test packages/ai/test/openai-completions-thought-signature.test.ts` failed both namespace cases because `ToolCall.thoughtSignature` was `undefined`.

## Cause
`streamOpenAICompletionsOnce` in `packages/ai/src/providers/openai-completions.ts` parsed standard tool-call fields and OpenRouter `reasoning_details`, but ignored Gemini's per-tool-call `extra_content`; `convertMessages` therefore had no signature to attach to the replayed assistant tool call.

## Fix
- Capture validated Google and Vertex thought-signature namespaces from streamed tool-call deltas.
- Replay the stored namespace as `tool_calls[].extra_content` without misrouting it into `reasoning_details`.
- Cover both provider namespaces with a two-turn wire-level regression and document the user-visible fix.

## Verification
`bun test packages/ai/test/openai-completions-thought-signature.test.ts packages/ai/test/openai-completions-compat.test.ts` — 75 pass, 0 fail. `bun check` — passed.

Fixes #10172