### PR TITLE
fix(agent): fall back when native tokenizer encoding is unknown

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Unknown native tokenizer encodings now fall back to the byte estimate instead of crashing spawn and compaction.
+
 ## [18.0.10] - 2026-08-28
 
 ### Added

--- a/packages/agent/src/tokenizer.ts
+++ b/packages/agent/src/tokenizer.ts
@@ -1,6 +1,6 @@
 import type { Model } from "@oh-my-pi/pi-ai";
 import type { ModelTokenizer } from "@oh-my-pi/pi-catalog/types";
-import { countTokens as countTokensNat, Encoding } from "@oh-my-pi/pi-natives";
+import * as natives from "@oh-my-pi/pi-natives";
 import { stringifyJson } from "@oh-my-pi/pi-utils";
 import * as snapcompact from "@oh-my-pi/snapcompact";
 import { isEstimateCacheable, messageEstimateVersion } from "./compaction/message-cache";
@@ -9,19 +9,19 @@ import type { AgentMessage } from "./types";
 const testEnv = Bun.env.NODE_ENV === "test";
 const accurate = process.env.PI_TOKENIZER_ACCURATE === "1" && !testEnv;
 
-const NATIVE_ENCODING: Record<ModelTokenizer, Encoding> = {
-	"claude-v3": Encoding.ClaudeV3,
-	"claude-v47": Encoding.ClaudeV47,
-	"claude-v5": Encoding.ClaudeV5,
-	"claude-v5-sonnet": Encoding.ClaudeV5Sonnet,
-	qwen3: Encoding.Qwen3,
-	"deepseek-v3": Encoding.DeepSeekV3,
-	"kimi-k2": Encoding.KimiK2,
-	glm5: Encoding.Glm5,
+const NATIVE_ENCODING: Record<ModelTokenizer, natives.Encoding> = {
+	"claude-v3": natives.Encoding.ClaudeV3,
+	"claude-v47": natives.Encoding.ClaudeV47,
+	"claude-v5": natives.Encoding.ClaudeV5,
+	"claude-v5-sonnet": natives.Encoding.ClaudeV5Sonnet,
+	qwen3: natives.Encoding.Qwen3,
+	"deepseek-v3": natives.Encoding.DeepSeekV3,
+	"kimi-k2": natives.Encoding.KimiK2,
+	glm5: natives.Encoding.Glm5,
 };
 
 /** Maps the catalog-resolved tokenizer family to its native implementation. */
-export function tokenizerEncodingForModel(model: Pick<Model, "tokenizer"> | null | undefined): Encoding | null {
+export function tokenizerEncodingForModel(model: Pick<Model, "tokenizer"> | null | undefined): natives.Encoding | null {
 	return model?.tokenizer ? NATIVE_ENCODING[model.tokenizer] : null;
 }
 
@@ -59,6 +59,21 @@ function byteLength(text: string): number {
 
 function sumFragments(text: string | string[], perFragment: (t: string) => number): number {
 	return Array.isArray(text) ? text.reduce((sum, t) => sum + perFragment(t), 0) : perFragment(text);
+}
+
+function countTokensNat(text: string | string[], encoding: natives.Encoding | null | undefined, mode: TokenCountMode): number {
+	try {
+		return natives.countTokens(text, encoding);
+	} catch (error) {
+		if (
+			!(error instanceof Error) ||
+			(!error.message.includes("does not match any variant of enum") &&
+				!error.message.includes("unknown enum variant"))
+		) {
+			throw error;
+		}
+		return sumFragments(text, mode === "upperbound" ? byteLength : byteEstimate);
+	}
 }
 
 /** Verdict from {@link Tokenizer.checkTokenBudget}. */
@@ -104,7 +119,7 @@ interface MessageEstimate {
  * `PI_TOKENIZER_ACCURATE=1`).
  */
 export class Tokenizer {
-	readonly #encoding: Encoding | null;
+	readonly #encoding: natives.Encoding | null;
 
 	/**
 	 * Per-message estimate memo. Keyed by message identity, deliberately not a
@@ -120,14 +135,14 @@ export class Tokenizer {
 		this.#encoding = tokenizerEncodingForModel(model);
 	}
 
-	get encoding(): Encoding | null {
+	get encoding(): natives.Encoding | null {
 		return this.#encoding;
 	}
 
 	countTokens(text: string | string[], mode: TokenCountMode = "approximate"): number {
-		if (mode === "strict") return countTokensNat(text, this.#encoding);
-		if (!testEnv && this.#encoding !== null) return countTokensNat(text, this.#encoding);
-		if (accurate) return countTokensNat(text);
+		if (mode === "strict") return countTokensNat(text, this.#encoding, mode);
+		if (!testEnv && this.#encoding !== null) return countTokensNat(text, this.#encoding, mode);
+		if (accurate) return countTokensNat(text, undefined, mode);
 		return sumFragments(text, mode === "upperbound" ? byteLength : byteEstimate);
 	}
 

--- a/packages/agent/test/tokenizer.test.ts
+++ b/packages/agent/test/tokenizer.test.ts
@@ -1,20 +1,24 @@
-import { describe, expect, test } from "bun:test";
-import { Encoding } from "@oh-my-pi/pi-natives";
+import { afterEach, describe, expect, test, vi } from "bun:test";
+import * as natives from "@oh-my-pi/pi-natives";
 import { Tokenizer, tokenizerEncodingForModel } from "../src/tokenizer";
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
 
 // Contract: the catalog resolves model identity once as Model.tokenizer; the
 // agent maps that catalog property to the matching native counter. A wrong
 // row silently skews every context-budget and compaction decision.
 describe("tokenizerEncodingForModel", () => {
 	test("maps every catalog tokenizer family to its native counter", () => {
-		expect(tokenizerEncodingForModel({ tokenizer: "claude-v3" })).toBe(Encoding.ClaudeV3);
-		expect(tokenizerEncodingForModel({ tokenizer: "claude-v47" })).toBe(Encoding.ClaudeV47);
-		expect(tokenizerEncodingForModel({ tokenizer: "claude-v5" })).toBe(Encoding.ClaudeV5);
-		expect(tokenizerEncodingForModel({ tokenizer: "claude-v5-sonnet" })).toBe(Encoding.ClaudeV5Sonnet);
-		expect(tokenizerEncodingForModel({ tokenizer: "qwen3" })).toBe(Encoding.Qwen3);
-		expect(tokenizerEncodingForModel({ tokenizer: "deepseek-v3" })).toBe(Encoding.DeepSeekV3);
-		expect(tokenizerEncodingForModel({ tokenizer: "kimi-k2" })).toBe(Encoding.KimiK2);
-		expect(tokenizerEncodingForModel({ tokenizer: "glm5" })).toBe(Encoding.Glm5);
+		expect(tokenizerEncodingForModel({ tokenizer: "claude-v3" })).toBe(natives.Encoding.ClaudeV3);
+		expect(tokenizerEncodingForModel({ tokenizer: "claude-v47" })).toBe(natives.Encoding.ClaudeV47);
+		expect(tokenizerEncodingForModel({ tokenizer: "claude-v5" })).toBe(natives.Encoding.ClaudeV5);
+		expect(tokenizerEncodingForModel({ tokenizer: "claude-v5-sonnet" })).toBe(natives.Encoding.ClaudeV5Sonnet);
+		expect(tokenizerEncodingForModel({ tokenizer: "qwen3" })).toBe(natives.Encoding.Qwen3);
+		expect(tokenizerEncodingForModel({ tokenizer: "deepseek-v3" })).toBe(natives.Encoding.DeepSeekV3);
+		expect(tokenizerEncodingForModel({ tokenizer: "kimi-k2" })).toBe(natives.Encoding.KimiK2);
+		expect(tokenizerEncodingForModel({ tokenizer: "glm5" })).toBe(natives.Encoding.Glm5);
 	});
 
 	test("leaves unknown catalog models on the estimate policy", () => {
@@ -31,8 +35,8 @@ describe("Tokenizer", () => {
 	});
 
 	test("encoding is fixed at construction from the catalog model", () => {
-		expect(new Tokenizer({ tokenizer: "claude-v47" }).encoding).toBe(Encoding.ClaudeV47);
-		expect(new Tokenizer({ tokenizer: "claude-v5" }).encoding).toBe(Encoding.ClaudeV5);
+		expect(new Tokenizer({ tokenizer: "claude-v47" }).encoding).toBe(natives.Encoding.ClaudeV47);
+		expect(new Tokenizer({ tokenizer: "claude-v5" }).encoding).toBe(natives.Encoding.ClaudeV5);
 		expect(new Tokenizer({}).encoding).toBeNull();
 		expect(new Tokenizer(undefined).encoding).toBeNull();
 	});
@@ -42,14 +46,14 @@ describe("Tokenizer", () => {
 		const t2 = new Tokenizer({ tokenizer: "qwen3" });
 		const t3 = new Tokenizer({});
 
-		expect(t1.encoding).toBe(Encoding.ClaudeV47);
-		expect(t2.encoding).toBe(Encoding.Qwen3);
+		expect(t1.encoding).toBe(natives.Encoding.ClaudeV47);
+		expect(t2.encoding).toBe(natives.Encoding.Qwen3);
 		expect(t3.encoding).toBeNull();
 
 		const t4 = new Tokenizer({ tokenizer: "claude-v3" });
-		expect(t4.encoding).toBe(Encoding.ClaudeV3);
-		expect(t1.encoding).toBe(Encoding.ClaudeV47);
-		expect(t2.encoding).toBe(Encoding.Qwen3);
+		expect(t4.encoding).toBe(natives.Encoding.ClaudeV3);
+		expect(t1.encoding).toBe(natives.Encoding.ClaudeV47);
+		expect(t2.encoding).toBe(natives.Encoding.Qwen3);
 		expect(t3.encoding).toBeNull();
 	});
 });
@@ -79,5 +83,23 @@ describe("countTokens with modes", () => {
 		const claude = new Tokenizer({ tokenizer: "claude-v47" });
 		const generic = new Tokenizer({});
 		expect(claude.countTokens("hello world", "strict")).not.toBe(generic.countTokens("hello world", "strict"));
+	});
+
+	test("falls back to the byte estimate when native encoding is unknown", () => {
+		vi.spyOn(natives, "countTokens").mockImplementation(() => {
+			throw new Error('value "DeepSeekV3" does not match any variant of enum Encoding');
+		});
+		const tokenizer = new Tokenizer({ tokenizer: "deepseek-v3" });
+		expect(tokenizer.countTokens("hello world", "strict")).toBe(3);
+		expect(tokenizer.countTokens("hello world", "upperbound")).toBe(11);
+	});
+
+	test("does not swallow unrelated native tokenizer errors", () => {
+		vi.spyOn(natives, "countTokens").mockImplementation(() => {
+			throw new Error("native tokenizer exploded");
+		});
+		expect(() => new Tokenizer({ tokenizer: "deepseek-v3" }).countTokens("hello world", "strict")).toThrow(
+			"native tokenizer exploded",
+		);
 	});
 });

--- a/packages/natives/test/native.test.ts
+++ b/packages/natives/test/native.test.ts
@@ -99,6 +99,14 @@ describe("countTokens", () => {
 		expect(countTokens("hello world", Encoding.O200kBase)).toBe(2);
 		expect(countTokens(["hello world", "hello world"], Encoding.O200kBase)).toBe(4);
 	});
+
+	it("round-trips every Encoding through the local addon", () => {
+		for (const encoding of Object.values(Encoding)) {
+			const n = countTokens("hello", encoding);
+			expect(typeof n).toBe("number");
+			expect(n).toBeGreaterThan(0);
+		}
+	});
 });
 
 async function cleanupFixtures() {


### PR DESCRIPTION
## Problem

JS `Encoding` (generated into `packages/natives/native/index.js`) can list variants the loaded napi `.node` does not implement. `countTokens(text, Encoding.DeepSeekV3)` then throws:

```
Error: value "DeepSeekV3" does not match any variant of enum Encoding
```

That happens during pre-prompt token count (`Tokenizer.countTokens` → `runPrePromptCompactionIfNeeded`) and aborts subagent spawn for models whose catalog tokenizer is `deepseek-v3` (and the same class of skew for Claude/Qwen/Kimi/GLM).

The version sentinel (`__piNativesV{major}_{minor}_{patch}`) does not cover this: same package version, regenerated JS enums, unrebuilt addon.

Rust already has `Encoding::DeepSeekV3`. This is not a missing rust variant.

## Fix

- `Tokenizer.countTokens` catches napi unknown-encoding errors and falls back to the existing byte heuristic instead of killing the run.
- Unrelated native errors still throw.
- Natives test: every `Object.values(Encoding)` round-trips through `countTokens` as a positive number (catches JS/napi enum skew after a rebuild).

## Test plan

- [x] `bun test packages/agent/test/tokenizer.test.ts`
- [x] `bun test packages/natives/test/native.test.ts`
- [x] `countTokens("hello", Encoding.DeepSeekV3)` returns a number against a rebuilt host addon