### PR TITLE
fix(tui): hide thinking blocks emitted as append-only stable rows

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Ctrl+T "Thinking blocks: hidden" leaving long reasoning visible when it had already streamed into native scrollback as append-only stable rows; the toggle now forgets that emission ledger so the display reset re-renders those blocks hidden ([#10177](https://github.com/can1357/oh-my-pi/issues/10177)).
+
 ## [18.0.10] - 2026-08-28
 
 ### Added

--- a/packages/coding-agent/src/modes/components/assistant-message.ts
+++ b/packages/coding-agent/src/modes/components/assistant-message.ts
@@ -453,6 +453,19 @@ export class AssistantMessageComponent extends Container {
 		return this.#transcriptStableRows;
 	}
 
+	/**
+	 * Drop every published thinking stable row. Called by the transcript
+	 * container during a visibility-driven destructive replay so the head no
+	 * longer re-emits reasoning captured while thinking was visible. Safe only
+	 * because the paired display reset clears the scrollback those rows occupied
+	 * — see {@link AppendOnlyTranscriptBlock.resetTranscriptStableRows}.
+	 */
+	resetTranscriptStableRows(): void {
+		this.#stableSnapshots = [];
+		this.#transcriptStableRows = [];
+		this.#stableRenderCache.clear();
+	}
+
 	renderTranscriptStableRows(count: number, width: number): readonly string[] {
 		const index = Math.min(Math.trunc(count), this.#stableSnapshots.length);
 		if (index <= 0) return EMPTY_STABLE_RENDER;

--- a/packages/coding-agent/src/modes/components/transcript-container.ts
+++ b/packages/coding-agent/src/modes/components/transcript-container.ts
@@ -39,6 +39,15 @@ export interface AppendOnlyTranscriptBlock {
 	 * prefix the block's full render at the same width.
 	 */
 	renderTranscriptStableRows(count: number, width: number): readonly string[];
+	/**
+	 * Discard every published stable row so the block re-renders its head from
+	 * scratch. Called only alongside a destructive display reset (e.g. a
+	 * thinking-visibility toggle) that clears the native scrollback those rows
+	 * occupied — the sole context in which the append-only "published bytes never
+	 * change" contract may be retracted. Optional: blocks whose stable-row
+	 * presentation never changes may omit it.
+	 */
+	resetTranscriptStableRows?(): void;
 }
 
 interface FinalizableBlock {
@@ -170,6 +179,32 @@ export class TranscriptContainer extends Container {
 			if (isToolActivityComponent(child)) child.setToolActivityVisible(visible);
 		}
 		this.invalidate();
+	}
+
+	/**
+	 * Forget the append-only emission ledger — emitted counts, published stable
+	 * rows, per-width render cache, and freeze state — for every block, and ask
+	 * each append-only block to drop its own published rows. The next replay then
+	 * re-renders each block from its current {@link Component.render}, applying a
+	 * changed presentation (e.g. a thinking-visibility toggle) to rows that were
+	 * already emitted as stable heads while streaming (#10177).
+	 *
+	 * Callers MUST pair this with a scrollback-clearing {@link resetDisplay}: the
+	 * emitted rows it forgets still sit in native history until that clear
+	 * rewrites them, so unpaired use would duplicate them on the next retirement.
+	 */
+	resetStableEmission(): void {
+		this.#syncEntries();
+		if (this.#offered?.kind === "append") this.#offered = undefined;
+		for (const entry of this.#entries) {
+			entry.emitted = 0;
+			entry.stableRows = EMPTY_STABLE_ROWS;
+			entry.renderedStableByWidth = new Map();
+			entry.stableFrozen = false;
+			if (entry.mode === "appendOnly") {
+				(entry.component as Component & AppendOnlyTranscriptBlock).resetTranscriptStableRows?.();
+			}
+		}
 	}
 
 	/** Whether a transient block may be discarded without leaving tape history. */

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -2119,6 +2119,11 @@ export class InputController {
 
 		// This is an explicit user display gesture: rebuild native history so the
 		// visibility change also applies to rows already retired from the viewport.
+		// Append-only thinking heads emitted their stable rows to scrollback while
+		// streaming (visible); forget that emission ledger so the paired scrollback
+		// clear re-renders them under the new visibility instead of replaying the
+		// captured reasoning (#10177).
+		this.ctx.chatContainer.resetStableEmission();
 		this.ctx.ui.resetDisplay();
 
 		this.ctx.showStatus(`Thinking blocks: ${this.ctx.hideThinkingBlock ? "hidden" : "visible"}`);

--- a/packages/coding-agent/test/modes/components/transcript-container.test.ts
+++ b/packages/coding-agent/test/modes/components/transcript-container.test.ts
@@ -66,6 +66,16 @@ class AppendBlock extends Block {
 		this.#stableRender = rendered;
 	}
 
+	/** Change the block's full render without finalizing (e.g. hiding thinking). */
+	revise(rows: string[]): void {
+		this.finalize(rows);
+	}
+
+	resetTranscriptStableRows(): void {
+		this.#stable = [];
+		this.#stableRender = [];
+	}
+
 	getTranscriptStableRows(): readonly TranscriptStableRow[] {
 		return this.#stable;
 	}
@@ -242,6 +252,34 @@ describe("TranscriptContainer", () => {
 		block.finalize();
 		const suffix = transcript.peekFinalizedBatch(8, 0)!;
 		expect(suffix.rows).toEqual(["final", ""]);
+	});
+
+	it("drops emitted stable rows on reset so a replay honors a hidden presentation (#10177)", () => {
+		const transcript = new TranscriptContainer();
+		// A thinking block whose reasoning prefix streams into scrollback ahead of
+		// its answer while the whole block is still the live frontier head.
+		const block = new AppendBlock(["reasoning one", "reasoning two", "answer"], ["reasoning one", "reasoning two"]);
+		transcript.addChild(block);
+
+		const first = transcript.peekFinalizedBatch(80, 1)!;
+		expect(first.rows).toEqual(["reasoning one"]);
+		transcript.acknowledgeFinalizedBatch(first.id);
+		const second = transcript.peekFinalizedBatch(80, 1)!;
+		expect(second.rows).toEqual(["reasoning two"]);
+		transcript.acknowledgeFinalizedBatch(second.id);
+		expect(transcript.emittedStableRows()).toEqual([2]);
+
+		// Ctrl+T hides thinking: the block now renders only its answer and drops
+		// its published reasoning snapshots. resetStableEmission forgets the
+		// emitted prefix so the paired destructive replay does not resurrect the
+		// captured reasoning that visibly streamed into scrollback.
+		block.revise(["answer"]);
+		transcript.resetStableEmission();
+		expect(transcript.emittedStableRows()).toEqual([0]);
+
+		transcript.beginReplay();
+		expect(transcript.peekReplayBatch(80)).toBeUndefined();
+		expect(transcript.renderViewport(80, 5, frame)).toEqual(["answer"]);
 	});
 
 	beforeAll(async () => {


### PR DESCRIPTION
## Repro
With a thinking model, stream a long reasoning chain (so it retires into native scrollback while streaming), then press Ctrl+T ("Thinking blocks: hidden"). The long thinking block stays visible in scrollback. Reproduced at the container level by emitting an append-only thinking prefix under viewport pressure, hiding thinking, then requesting the destructive display replay:
```
emitted after streaming: [ 2 ]
BUG replay resurrects: [ 'reasoning one', 'reasoning two' ]
```

## Cause
`InputController.toggleThinkingBlockVisibility` (`packages/coding-agent/src/modes/controllers/input-controller.ts`) already calls `resetDisplay()` so a hide reaches rows retired to native scrollback (added by #9441 for #9440), and that works for *committed* blocks because they re-render fully on replay. But a thinking block whose reasoning prefix streamed into scrollback incrementally as **append-only stable rows** — while it was still the live frontier head — is replayed by `TranscriptContainer.#renderReplay` (`packages/coding-agent/src/modes/components/transcript-container.ts`), which re-emits the head's emitted stable prefix via `AssistantMessageComponent.renderTranscriptStableRows`. Those rows come from reasoning snapshots captured while thinking was visible and ignore the new `hideThinkingBlock` state, so the reasoning reappears verbatim.

## Fix
- Add `TranscriptContainer.resetStableEmission()`: forgets the append-only emission ledger (emitted counts, published stable rows, per-width render cache, freeze state) for every block and asks each append-only block to drop its own published rows.
- Add optional `AppendOnlyTranscriptBlock.resetTranscriptStableRows()` to the interface; implement it on `AssistantMessageComponent` to clear its published thinking snapshots and render cache.
- Call `resetStableEmission()` in `toggleThinkingBlockVisibility` immediately before `resetDisplay()`, so the paired scrollback clear re-renders those heads under the current visibility instead of replaying the captured reasoning.

## Verification
`bun test packages/coding-agent/test/modes/components/transcript-container.test.ts` (25 pass, incl. new `#10177` regression test) and `bun test packages/coding-agent/test/modes/components/assistant-message*.test.ts` (37 pass). `bun check` passes. The pre-existing `StatusLineComponent` failures in this environment come from an unbuilt `vcsGitDiscover` native binding and are unrelated. Fixes #10177