### PR TITLE
fix(coding-agent): keep digits in minted MCP tool names

### DIFF
--- a/docs/mcp-server-tool-authoring.md
+++ b/docs/mcp-server-tool-authoring.md
@@ -143,7 +143,7 @@ mcp__<sanitized_server_name>_<sanitized_tool_name>
 Rules:
 
 - lowercases
-- non-`[a-z_]` chars become `_`
+- non-`[a-z0-9_]` chars become `_`
 - repeated underscores collapse
 - redundant `<server>_` prefix in tool name is stripped once
 - names longer than 64 characters keep a readable prefix and append `_` plus the first eight base-36

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed MCP tool names dropping digits, which renamed servers such as `context7` and collapsed servers differing only by a digit onto the same tool names ([#10179](https://github.com/can1357/oh-my-pi/pull/10179) by [@bitboxx](https://github.com/bitboxx)).
+
 ## [18.0.10] - 2026-08-28
 
 ### Added

--- a/packages/coding-agent/src/mcp/tool-bridge.ts
+++ b/packages/coding-agent/src/mcp/tool-bridge.ts
@@ -362,7 +362,7 @@ async function reconnectWithAbort(
 function sanitizeMCPToolNamePart(value: string, fallback: string): string {
 	const sanitized = value
 		.toLowerCase()
-		.replace(/[^a-z_]+/g, "_")
+		.replace(/[^a-z0-9_]+/g, "_")
 		.replace(/_+/g, "_")
 		.replace(/^_+|_+$/g, "");
 

--- a/packages/coding-agent/test/mcp-reconnect.test.ts
+++ b/packages/coding-agent/test/mcp-reconnect.test.ts
@@ -92,6 +92,15 @@ describe("createMCPToolName", () => {
 		expect(createMCPToolName("puppeteer", "puppeteer_screenshot")).toBe("mcp__puppeteer_screenshot");
 	});
 
+	it("keeps digits, so servers differing only by a digit stay distinct", () => {
+		// The sanitizer used to strip 0-9, minting mcp__context_query_docs for
+		// server "context7" and collapsing "foo1"/"foo2" onto one name, which
+		// then cost one of them a tool via deduplicateMCPToolsByName().
+		expect(createMCPToolName("context7", "query-docs")).toBe("mcp__context7_query_docs");
+		expect(createMCPToolName("s3-storage", "get_object")).toBe("mcp__s3_storage_get_object");
+		expect(createMCPToolName("foo1", "run")).not.toBe(createMCPToolName("foo2", "run"));
+	});
+
 	it("is deterministic and keeps distinct overlong names distinct", () => {
 		const a = createMCPToolName("chrome-devtools-mcp", "chrome_devtools_performance_analyze_insight");
 		const b = createMCPToolName("chrome-devtools-mcp", "chrome_devtools_performance_analyze_insight");


### PR DESCRIPTION
I found this issue while wondering why kebab-cased names are snake_cased. The current regex swallows numbers as well. Eg context7 -> context

## What changed

`sanitizeMCPToolNamePart` replaced every run of `[^a-z_]` with an underscore, so digits were stripped from both halves of `mcp__<server>_<tool>`:

| server | minted name |
|---|---|
| `context7` | `mcp__context_query_docs` |
| `s3-storage` | `mcp__s3_storage_*` → was `mcp__s_storage_*` |
| `foo1`, `foo2` | both `mcp__foo_*` |

The last row costs a tool: `deduplicateMCPToolsByName()` picks a deterministic winner and logs the loser, so one server's tool is dropped for a collision that only exists because the digits were removed.

Digits are valid in the output. `mcp.json` permits them in server names (`propertyNames.pattern` is `^[a-zA-Z0-9_.-]{1,100}$`), and the provider constraint quoted on `capMCPToolNameLength` twelve lines below is `^[a-zA-Z0-9_-]{1,64}$`. This adds `0-9` to the class and updates the rule documented in `docs/mcp-server-tool-authoring.md`.

## Why hyphens still collapse

Deliberately left alone — three consumers need `[A-Za-z_]\w*` identifiers and would break on `mcp__devtools-uk_click`:

- `packages/ai/src/dialect/gemma.ts:23` — `CALL_HEAD = /^call:\s*([A-Za-z_]\w*)\s*\{/` never matches, so the call is dropped as text.
- `packages/ai/src/dialect/gemini.ts:198-200` — the callee scan walks back over `[A-Za-z0-9_]`, stops at the hyphen and captures `uk_click`, which passes validation. Silent misroute.
- `packages/ai/src/dialect/inventory.ts:26` — the harmony catalog renders `type <name> = (...)`, which a hyphen makes invalid.

Digits hit none of these, since `\w` already covers `0-9`.

## Verification

Reproduced against the real CLI on macOS arm64, with `context7` configured, before and after the change on this branch:

```
# before
$ bun --cwd=packages/coding-agent src/cli.ts -p "List the exact names of every tool you have available"
mcp__context_query_docs
mcp__context_resolve_library_id

# after
mcp__context7_query_docs
mcp__context7_resolve_library_id
```

Then exercised the renamed tools end to end — resolved a library id and fetched a doc snippet through `mcp__context7_resolve_library_id` and `mcp__context7_query_docs`; both calls succeeded, so the rename routes correctly and is not cosmetic.

The added test fails on `main` (`Expected: "mcp__context7_query_docs"`, `Received: "mcp__context_query_docs"`) and passes here.

- `bun test test/mcp-*.test.ts` — 266 pass, 0 fail across 35 files
- `bun run check` — clean (biome + tsgo)

## Compatibility

This changes minted names for anyone whose server or tool names contain digits. `tools.approval` keys and `tools.xdevInlineDevices` globs written against the old form need updating, hence the changelog entry.

---

🤖 Patch prepared with [Claude Code](https://claude.com/claude-code).
