### PR TITLE
fix(skills): discover native skills recursively

### DIFF
--- a/docs/config-usage.md
+++ b/docs/config-usage.md
@@ -238,13 +238,13 @@ Native provider (`id: native`) reads native config from:
 ### Directory admission rules
 
 - Slash commands, directory rules, prompts, instructions, hooks, tools, extensions, extension modules, and settings use a project/user root only when the root directory exists and is non-empty.
-- Skills scan `<ancestor>/.omp/skills` for each ancestor from the current working directory up to the repo root/home boundary, plus `~/.omp/agent/skills`, without requiring the root `.omp` directory itself to be non-empty.
+- Skills recursively scan `<ancestor>/.omp/skills` for each ancestor from the current working directory up to the repo root/home boundary, plus `~/.omp/agent/skills`, without requiring the root `.omp` directory itself to be non-empty.
 - `SYSTEM.md`, `RULES.md`, and `.omp/AGENTS.md` read user-level files directly and use the nearest non-empty ancestor `.omp` directory for project files. `RULES.md` becomes an always-apply sticky rule. See [`docs/system-prompt-customization.md`](./system-prompt-customization.md) for the full `SYSTEM.md` / `APPEND_SYSTEM.md` contract.
 - MCP does not use the non-empty-root admission helper. It reads project `.omp/mcp.json` then `.omp/.mcp.json`, followed by user `mcp.json` then `.mcp.json`, directly.
 
 ### Scope-specific loading
 
-- Skills: `<ancestor>/.omp/skills/*/SKILL.md` and `~/.omp/agent/skills/*/SKILL.md`
+- Skills: `<ancestor>/.omp/skills/**/SKILL.md` and `~/.omp/agent/skills/**/SKILL.md`
 - Slash commands: `commands/*.md`
 - Rules: `rules/*.{md,mdc}` plus top-level `RULES.md`
 - Prompts: `prompts/*.md`

--- a/docs/config-usage.md
+++ b/docs/config-usage.md
@@ -238,7 +238,7 @@ Native provider (`id: native`) reads native config from:
 ### Directory admission rules
 
 - Slash commands, directory rules, prompts, instructions, hooks, tools, extensions, extension modules, and settings use a project/user root only when the root directory exists and is non-empty.
-- Skills recursively scan `<ancestor>/.omp/skills` for each ancestor from the current working directory up to the repo root/home boundary, plus `~/.omp/agent/skills`, without requiring the root `.omp` directory itself to be non-empty.
+- Skills recursively scan `<ancestor>/.omp/skills` for each ancestor from the current working directory up to the repo root/home boundary, plus `~/.omp/agent/skills`, without requiring the root `.omp` directory itself to be non-empty. Scans stop at depth 6, 2,000 directories, or 20,000 entries; prune hidden directories, `.git`, and `node_modules`; and warn when truncated.
 - `SYSTEM.md`, `RULES.md`, and `.omp/AGENTS.md` read user-level files directly and use the nearest non-empty ancestor `.omp` directory for project files. `RULES.md` becomes an always-apply sticky rule. See [`docs/system-prompt-customization.md`](./system-prompt-customization.md) for the full `SYSTEM.md` / `APPEND_SYSTEM.md` contract.
 - MCP does not use the non-empty-root admission helper. It reads project `.omp/mcp.json` then `.omp/.mcp.json`, followed by user `mcp.json` then `.mcp.json`, directly.
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -32,7 +32,9 @@ The OMP-native `native` and `agents` providers discover skills recursively:
 - `~/.agent/skills/**/SKILL.md` and `~/.agents/skills/**/SKILL.md`
 
 This permits grouping directories such as `<skills-root>/team/internal/<skill>/SKILL.md`.
-Directory symlinks are treated as leaf skill candidates and are not traversed recursively.
+Recursive scans stop at depth 6, 2,000 visited directories, or 20,000 visited entries. Hidden directories,
+`.git`, and `node_modules` are pruned. Directory symlinks remain leaf skill candidates and are not traversed
+recursively. Reaching any traversal limit emits a discovery warning instead of silently returning a partial result.
 
 Third-party and plugin providers retain their specified one-level layout:
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -24,27 +24,33 @@ The runtime only requires `name` and `path` for validity. In practice, matching 
 
 ### Directory layout
 
-For provider-based discovery (native/Claude/Codex/Agents/plugin providers), skills are discovered as **one level under `skills/`**:
+The OMP-native `native` and `agents` providers discover skills recursively:
+
+- `<ancestor>/.omp/skills/**/SKILL.md`
+- `~/.omp/agent/skills/**/SKILL.md`
+- `<ancestor>/.agent/skills/**/SKILL.md` and `<ancestor>/.agents/skills/**/SKILL.md`
+- `~/.agent/skills/**/SKILL.md` and `~/.agents/skills/**/SKILL.md`
+
+This permits grouping directories such as `<skills-root>/team/internal/<skill>/SKILL.md`.
+Directory symlinks are treated as leaf skill candidates and are not traversed recursively.
+
+Third-party and plugin providers retain their specified one-level layout:
 
 - `<skills-root>/<skill-name>/SKILL.md`
 
-Nested patterns like `<skills-root>/group/<skill>/SKILL.md` are not discovered by provider loaders.
-
-For `skills.customDirectories`, scanning uses the same non-recursive layout (`*/SKILL.md`).
+`skills.customDirectories` also remains non-recursive (`*/SKILL.md`).
 
 ```text
-Provider-discovered layout (non-recursive under skills/):
+OMP-native layout (recursive under skills/):
 
 <root>/skills/
   ├─ postgres/
   │   └─ SKILL.md      ✅ discovered
-  ├─ pdf/
-  │   └─ SKILL.md      ✅ discovered
   └─ team/
       └─ internal/
-          └─ SKILL.md  ❌ not discovered by provider loaders
+          └─ SKILL.md  ✅ discovered by native and agents providers
 
-Custom-directory scanning is also non-recursive, so nested paths are ignored unless you point `customDirectories` at that nested parent.
+The nested skill is not discovered by flat third-party, plugin, or custom-directory scans.
 ```
 
 ### `SKILL.md` frontmatter
@@ -113,7 +119,7 @@ Filter order is:
 3. not ignored
 4. included (if include list present)
 
-The `agents` provider (`.agent[s]/skills`) is the canonical OMP-native location and has its own `enableAgentsUser`/`enableAgentsProject` toggles — disabling Claude/Codex/Pi does **not** turn it off. Providers without a dedicated toggle (`claude-plugins`, `opencode`, `github`, …) are enabled if **any** named third-party source toggle is enabled.
+The `agents` provider (`.agent[s]/skills`) is the canonical OMP-native location, scans recursively, and has its own `enableAgentsUser`/`enableAgentsProject` toggles — disabling Claude/Codex/Pi does **not** turn it off. Providers without a dedicated toggle (`claude-plugins`, `opencode`, `github`, …) are enabled if **any** named third-party source toggle is enabled.
 
 ### Collision and duplicate handling
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -36,6 +36,9 @@ Recursive scans stop at depth 6, 2,000 visited directories, or 20,000 visited en
 `.git`, and `node_modules` are pruned. Directory symlinks remain leaf skill candidates and are not traversed
 recursively. Reaching any traversal limit emits a discovery warning instead of silently returning a partial result.
 
+A matched skill directory remains traversable: it may be both an independently invocable skill and a namespace
+for independently invocable child skills.
+
 Third-party and plugin providers retain their specified one-level layout:
 
 - `<skills-root>/<skill-name>/SKILL.md`

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Enabled recursive skill discovery under `.omp/skills` and `.agent[s]/skills`, so nested grouping directories load without flattening.
+
 ## [18.0.10] - 2026-08-28
 
 ### Added

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Enabled recursive skill discovery under `.omp/skills` and `.agent[s]/skills`, so nested grouping directories load without flattening.
+- Enabled bounded recursive skill discovery under `.omp/skills` and `.agent[s]/skills`, so nested grouping directories load without flattening while symlinks, hidden directories, `.git`, and `node_modules` cannot trigger unbounded traversal.
 
 ## [18.0.10] - 2026-08-28
 

--- a/packages/coding-agent/src/capability/fs.ts
+++ b/packages/coding-agent/src/capability/fs.ts
@@ -8,10 +8,20 @@ function resolvePath(filePath: string): string {
 	return path.resolve(filePath);
 }
 
-export async function readFile(filePath: string): Promise<string | null> {
+export interface ReadFileOptions {
+	/**
+	 * Cache `null` results. Disable for optional files that may be created between
+	 * discovery passes without an explicit filesystem cache invalidation.
+	 * @default true
+	 */
+	cacheMisses?: boolean;
+}
+
+export async function readFile(filePath: string, options: ReadFileOptions = {}): Promise<string | null> {
 	const abs = resolvePath(filePath);
 	if (contentCache.has(abs)) {
-		return contentCache.get(abs) ?? null;
+		const cached = contentCache.get(abs) ?? null;
+		if (cached !== null || options.cacheMisses !== false) return cached;
 	}
 
 	try {
@@ -22,14 +32,14 @@ export async function readFile(filePath: string): Promise<string | null> {
 		// context files (CLAUDE.md -> AGENTS.md) still resolve.
 		const stats = await fs.promises.stat(abs);
 		if (!stats.isFile()) {
-			contentCache.set(abs, null);
+			if (options.cacheMisses !== false) contentCache.set(abs, null);
 			return null;
 		}
 		const content = await Bun.file(abs).text();
 		contentCache.set(abs, content);
 		return content;
 	} catch {
-		contentCache.set(abs, null);
+		if (options.cacheMisses !== false) contentCache.set(abs, null);
 		return null;
 	}
 }
@@ -48,6 +58,44 @@ export async function readDirEntries(dirPath: string): Promise<fs.Dirent[]> {
 		dirCache.set(abs, []);
 		return [];
 	}
+}
+
+/**
+ * Read and sort a directory while bounding the number of entries retained.
+ *
+ * Returns `null` when the directory contains more than `maxEntries`. Truncated
+ * results are never cached because a partial cache entry would violate
+ * `readDirEntries()` semantics. Filesystem errors are left to the caller.
+ */
+export async function readDirEntriesWithinLimit(
+	dirPath: string,
+	maxEntries: number | undefined,
+): Promise<fs.Dirent[] | null> {
+	const abs = resolvePath(dirPath);
+	const cached = dirCache.get(abs);
+	if (cached) {
+		if (maxEntries !== undefined && cached.length > maxEntries) return null;
+		return [...cached].sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+	}
+
+	let entries: fs.Dirent[];
+	if (maxEntries === undefined) {
+		entries = await fs.promises.readdir(abs, { withFileTypes: true });
+	} else {
+		entries = [];
+		const directory = await fs.promises.opendir(abs);
+		for await (const entry of directory) {
+			if (entries.length >= maxEntries) {
+				// A deterministic subset cannot be selected without reading the entire
+				// directory. Reject it instead of exposing filesystem-order-dependent data.
+				return null;
+			}
+			entries.push(entry);
+		}
+	}
+
+	dirCache.set(abs, entries);
+	return [...entries].sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
 }
 
 export async function readDir(dirPath: string): Promise<string[]> {

--- a/packages/coding-agent/src/capability/fs.ts
+++ b/packages/coding-agent/src/capability/fs.ts
@@ -60,22 +60,36 @@ export async function readDirEntries(dirPath: string): Promise<fs.Dirent[]> {
 	}
 }
 
+export interface ReadDirEntriesWithinLimitOptions {
+	/**
+	 * Ignore and replace any cached listing. A truncated or failed refresh
+	 * removes the stale cache entry instead of preserving outdated results.
+	 * @default false
+	 */
+	refresh?: boolean;
+}
+
 /**
  * Read and sort a directory while bounding the number of entries retained.
  *
- * Returns `null` when the directory contains more than `maxEntries`. Truncated
- * results are never cached because a partial cache entry would violate
- * `readDirEntries()` semantics. Filesystem errors are left to the caller.
+ * Returns `null` when the directory contains more than `maxEntries`; truncated
+ * results are never cached. `refresh` bypasses any cached listing and replaces
+ * it after a complete read. Filesystem errors are left to the caller.
  */
 export async function readDirEntriesWithinLimit(
 	dirPath: string,
 	maxEntries: number | undefined,
+	options: ReadDirEntriesWithinLimitOptions = {},
 ): Promise<fs.Dirent[] | null> {
 	const abs = resolvePath(dirPath);
-	const cached = dirCache.get(abs);
-	if (cached) {
-		if (maxEntries !== undefined && cached.length > maxEntries) return null;
-		return [...cached].sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+	if (options.refresh) {
+		dirCache.delete(abs);
+	} else {
+		const cached = dirCache.get(abs);
+		if (cached) {
+			if (maxEntries !== undefined && cached.length > maxEntries) return null;
+			return [...cached].sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+		}
 	}
 
 	let entries: fs.Dirent[];

--- a/packages/coding-agent/src/discovery/agents.ts
+++ b/packages/coding-agent/src/discovery/agents.ts
@@ -172,10 +172,10 @@ export function getProjectPathCandidates(ctx: LoadContext, ...segments: string[]
 // Skills
 async function loadSkills(ctx: LoadContext): Promise<LoadResult<Skill>> {
 	const projectScans = getProjectPathCandidates(ctx, "skills").map(dir =>
-		scanSkillsFromDir(ctx, { dir, providerId: PROVIDER_ID, level: "project" }),
+		scanSkillsFromDir(ctx, { dir, providerId: PROVIDER_ID, level: "project", recursive: true }),
 	);
 	const userScans = getUserPathCandidates(ctx, "skills").map(dir =>
-		scanSkillsFromDir(ctx, { dir, providerId: PROVIDER_ID, level: "user" }),
+		scanSkillsFromDir(ctx, { dir, providerId: PROVIDER_ID, level: "user", recursive: true }),
 	);
 
 	const results = await Promise.all([...projectScans, ...userScans]);

--- a/packages/coding-agent/src/discovery/builtin.ts
+++ b/packages/coding-agent/src/discovery/builtin.ts
@@ -288,6 +288,7 @@ async function loadSkills(ctx: LoadContext): Promise<LoadResult<Skill>> {
 			providerId: PROVIDER_ID,
 			level: "project",
 			requireDescription: true,
+			recursive: true,
 		}),
 	);
 
@@ -297,6 +298,7 @@ async function loadSkills(ctx: LoadContext): Promise<LoadResult<Skill>> {
 		providerId: PROVIDER_ID,
 		level: "user",
 		requireDescription: true,
+		recursive: true,
 	});
 
 	const results = await Promise.all([...projectScans, userScan]);

--- a/packages/coding-agent/src/discovery/helpers.ts
+++ b/packages/coding-agent/src/discovery/helpers.ts
@@ -12,7 +12,7 @@ import {
 	tryParseJson,
 } from "@oh-my-pi/pi-utils";
 import type { ExtensionModule } from "../capability/extension-module";
-import { invalidate as invalidateFsCache, readDirEntries, readFile } from "../capability/fs";
+import { invalidate as invalidateFsCache, readDirEntries, readDirEntriesWithinLimit, readFile } from "../capability/fs";
 import { parseRuleConditionAndScope, type Rule, type RuleFrontmatter } from "../capability/rule";
 import type { Skill, SkillFrontmatter } from "../capability/skill";
 import type { LoadContext, LoadResult, SourceMeta } from "../capability/types";
@@ -364,31 +364,6 @@ const PRUNED_RECURSIVE_SKILL_DIRECTORIES: Record<string, true> = {
 	node_modules: true,
 };
 
-async function readSortedDirectoryEntriesWithinLimit(
-	directoryPath: string,
-	maxEntries: number | undefined,
-): Promise<fs.Dirent[] | null> {
-	if (maxEntries === undefined) {
-		const entries = await fs.promises.readdir(directoryPath, { withFileTypes: true });
-		entries.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
-		return entries;
-	}
-
-	const entries: fs.Dirent[] = [];
-	const directory = await fs.promises.opendir(directoryPath);
-	for await (const entry of directory) {
-		if (entries.length >= maxEntries) {
-			// A deterministic subset cannot be selected without reading the entire directory.
-			// Reject this directory instead: memory and enumeration stay bounded, and truncation
-			// never exposes a filesystem-order-dependent subset of skills.
-			return null;
-		}
-		entries.push(entry);
-	}
-	entries.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
-	return entries;
-}
-
 export interface ScanSkillsFromDirOptions {
 	dir: string;
 	providerId: string;
@@ -433,7 +408,7 @@ export async function scanSkillsFromDir(
 
 	const loadSkill = async (skillPath: string) => {
 		try {
-			const content = await readFile(skillPath);
+			const content = await readFile(skillPath, { cacheMisses: false });
 			if (!content) return;
 			const { frontmatter, body } = parseFrontmatter(content, { source: skillPath });
 			if (frontmatter.enabled === false) {
@@ -476,7 +451,7 @@ export async function scanSkillsFromDir(
 		const remainingEntries = options.recursive ? Math.max(0, limits.maxEntries - visitedEntries) : undefined;
 		let entries: fs.Dirent[] | null;
 		try {
-			entries = await readSortedDirectoryEntriesWithinLimit(current.path, remainingEntries);
+			entries = await readDirEntriesWithinLimit(current.path, remainingEntries);
 		} catch (error) {
 			if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
 				warnings.push(`Failed to read skills directory: ${current.path} (${String(error)})`);

--- a/packages/coding-agent/src/discovery/helpers.ts
+++ b/packages/coding-agent/src/discovery/helpers.ts
@@ -479,11 +479,11 @@ export async function scanSkillsFromDir(
 			}
 			if (!entry.isDirectory() && !entry.isSymbolicLink()) continue;
 			const childDir = path.join(current.path, entry.name);
+			if (options.recursive && current.depth >= limits.maxDepth) {
+				truncationReasons.add(`maximum depth ${limits.maxDepth} reached`);
+				continue;
+			}
 			if (options.recursive && entry.isDirectory()) {
-				if (current.depth >= limits.maxDepth) {
-					truncationReasons.add(`maximum depth ${limits.maxDepth} reached`);
-					continue;
-				}
 				directories.push({ path: childDir, depth: current.depth + 1 });
 			} else {
 				work.push(loadSkill(path.join(childDir, "SKILL.md")));

--- a/packages/coding-agent/src/discovery/helpers.ts
+++ b/packages/coding-agent/src/discovery/helpers.ts
@@ -451,7 +451,7 @@ export async function scanSkillsFromDir(
 		const remainingEntries = options.recursive ? Math.max(0, limits.maxEntries - visitedEntries) : undefined;
 		let entries: fs.Dirent[] | null;
 		try {
-			entries = await readDirEntriesWithinLimit(current.path, remainingEntries);
+			entries = await readDirEntriesWithinLimit(current.path, remainingEntries, { refresh: true });
 		} catch (error) {
 			if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
 				warnings.push(`Failed to read skills directory: ${current.path} (${String(error)})`);

--- a/packages/coding-agent/src/discovery/helpers.ts
+++ b/packages/coding-agent/src/discovery/helpers.ts
@@ -353,6 +353,12 @@ export interface ScanSkillsFromDirOptions {
 	level: "user" | "project";
 	requireDescription?: boolean;
 	/**
+	 * When true, descend through ordinary subdirectories and load every `SKILL.md`.
+	 * Directory symlinks remain leaf candidates so recursive discovery cannot loop.
+	 * Default `false` preserves providers whose skill layout is specified as flat.
+	 */
+	recursive?: boolean;
+	/**
 	 * When true, treat a `SKILL.md` sitting directly under `dir` as a single skill in addition to
 	 * scanning `<dir>/<name>/SKILL.md` children. Matches the Claude plugin manifest convention
 	 * that lets a skill path point at a directory containing `SKILL.md` directly (e.g.
@@ -381,15 +387,6 @@ export async function scanSkillsFromDir(
 	const warnings: string[] = [];
 	const { dir, level, providerId, requireDescription = false } = options;
 
-	let entries: fs.Dirent[];
-	try {
-		entries = await fs.promises.readdir(dir, { withFileTypes: true });
-	} catch (error) {
-		if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
-			warnings.push(`Failed to read skills directory: ${dir} (${String(error)})`);
-		}
-		return { items, warnings };
-	}
 	const loadSkill = async (skillPath: string) => {
 		try {
 			const content = await readFile(skillPath);
@@ -418,18 +415,31 @@ export async function scanSkillsFromDir(
 	};
 
 	const work: Promise<void>[] = [];
-	if (options.includeSelf) {
-		const selfSkillPath = path.join(dir, "SKILL.md");
-		if (fs.existsSync(selfSkillPath)) {
-			work.push(loadSkill(selfSkillPath));
+	const directories = [dir];
+	for (let index = 0; index < directories.length; index++) {
+		const currentDir = directories[index];
+		let entries: fs.Dirent[];
+		try {
+			entries = await fs.promises.readdir(currentDir, { withFileTypes: true });
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+				warnings.push(`Failed to read skills directory: ${currentDir} (${String(error)})`);
+			}
+			continue;
 		}
-	}
-	for (const entry of entries) {
-		if (entry.name.startsWith(".")) continue;
-		if (!entry.isDirectory() && !entry.isSymbolicLink()) continue;
-		const skillPath = path.join(dir, entry.name, "SKILL.md");
-		if (fs.existsSync(skillPath)) {
-			work.push(loadSkill(skillPath));
+
+		if (currentDir !== dir || options.includeSelf) {
+			work.push(loadSkill(path.join(currentDir, "SKILL.md")));
+		}
+		for (const entry of entries) {
+			if (entry.name.startsWith(".")) continue;
+			if (!entry.isDirectory() && !entry.isSymbolicLink()) continue;
+			const childDir = path.join(currentDir, entry.name);
+			if (options.recursive && entry.isDirectory()) {
+				directories.push(childDir);
+			} else {
+				work.push(loadSkill(path.join(childDir, "SKILL.md")));
+			}
 		}
 	}
 	await Promise.all(work);

--- a/packages/coding-agent/src/discovery/helpers.ts
+++ b/packages/coding-agent/src/discovery/helpers.ts
@@ -364,6 +364,31 @@ const PRUNED_RECURSIVE_SKILL_DIRECTORIES: Record<string, true> = {
 	node_modules: true,
 };
 
+async function readSortedDirectoryEntriesWithinLimit(
+	directoryPath: string,
+	maxEntries: number | undefined,
+): Promise<fs.Dirent[] | null> {
+	if (maxEntries === undefined) {
+		const entries = await fs.promises.readdir(directoryPath, { withFileTypes: true });
+		entries.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+		return entries;
+	}
+
+	const entries: fs.Dirent[] = [];
+	const directory = await fs.promises.opendir(directoryPath);
+	for await (const entry of directory) {
+		if (entries.length >= maxEntries) {
+			// A deterministic subset cannot be selected without reading the entire directory.
+			// Reject this directory instead: memory and enumeration stay bounded, and truncation
+			// never exposes a filesystem-order-dependent subset of skills.
+			return null;
+		}
+		entries.push(entry);
+	}
+	entries.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+	return entries;
+}
+
 export interface ScanSkillsFromDirOptions {
 	dir: string;
 	providerId: string;
@@ -439,7 +464,6 @@ export async function scanSkillsFromDir(
 	const truncationReasons = new Set<string>();
 	let visitedDirectories = 0;
 	let visitedEntries = 0;
-	let entryLimitReached = false;
 
 	for (let index = 0; index < directories.length; index++) {
 		if (options.recursive && visitedDirectories >= limits.maxDirectories) {
@@ -449,28 +473,26 @@ export async function scanSkillsFromDir(
 
 		const current = directories[index];
 		visitedDirectories++;
-		let entries: fs.Dirent[];
+		const remainingEntries = options.recursive ? Math.max(0, limits.maxEntries - visitedEntries) : undefined;
+		let entries: fs.Dirent[] | null;
 		try {
-			entries = await fs.promises.readdir(current.path, { withFileTypes: true });
+			entries = await readSortedDirectoryEntriesWithinLimit(current.path, remainingEntries);
 		} catch (error) {
 			if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
 				warnings.push(`Failed to read skills directory: ${current.path} (${String(error)})`);
 			}
 			continue;
 		}
+		if (entries === null) {
+			truncationReasons.add(`maximum entry count ${limits.maxEntries} reached`);
+			break;
+		}
+		if (options.recursive) visitedEntries += entries.length;
 
 		if (current.path !== dir || options.includeSelf) {
 			work.push(loadSkill(path.join(current.path, "SKILL.md")));
 		}
 		for (const entry of entries) {
-			if (options.recursive) {
-				if (visitedEntries >= limits.maxEntries) {
-					truncationReasons.add(`maximum entry count ${limits.maxEntries} reached`);
-					entryLimitReached = true;
-					break;
-				}
-				visitedEntries++;
-			}
 			if (
 				entry.name.startsWith(".") ||
 				(options.recursive && PRUNED_RECURSIVE_SKILL_DIRECTORIES[entry.name] === true)
@@ -489,7 +511,6 @@ export async function scanSkillsFromDir(
 				work.push(loadSkill(path.join(childDir, "SKILL.md")));
 			}
 		}
-		if (entryLimitReached) break;
 	}
 	await Promise.all(work);
 	for (const reason of truncationReasons) {

--- a/packages/coding-agent/src/discovery/helpers.ts
+++ b/packages/coding-agent/src/discovery/helpers.ts
@@ -347,6 +347,23 @@ async function globIf(
 	}
 }
 
+export interface SkillScanLimits {
+	maxDepth: number;
+	maxDirectories: number;
+	maxEntries: number;
+}
+
+const DEFAULT_RECURSIVE_SKILL_SCAN_LIMITS = {
+	maxDepth: 6,
+	maxDirectories: 2_000,
+	maxEntries: 20_000,
+} as const satisfies SkillScanLimits;
+
+const PRUNED_RECURSIVE_SKILL_DIRECTORIES: Record<string, true> = {
+	".git": true,
+	node_modules: true,
+};
+
 export interface ScanSkillsFromDirOptions {
 	dir: string;
 	providerId: string;
@@ -358,6 +375,8 @@ export interface ScanSkillsFromDirOptions {
 	 * Default `false` preserves providers whose skill layout is specified as flat.
 	 */
 	recursive?: boolean;
+	/** Traversal limits applied only when `recursive` is true. */
+	limits?: Partial<SkillScanLimits>;
 	/**
 	 * When true, treat a `SKILL.md` sitting directly under `dir` as a single skill in addition to
 	 * scanning `<dir>/<name>/SKILL.md` children. Matches the Claude plugin manifest convention
@@ -415,34 +434,67 @@ export async function scanSkillsFromDir(
 	};
 
 	const work: Promise<void>[] = [];
-	const directories = [dir];
+	const limits = { ...DEFAULT_RECURSIVE_SKILL_SCAN_LIMITS, ...options.limits };
+	const directories: Array<{ path: string; depth: number }> = [{ path: dir, depth: 0 }];
+	const truncationReasons = new Set<string>();
+	let visitedDirectories = 0;
+	let visitedEntries = 0;
+	let entryLimitReached = false;
+
 	for (let index = 0; index < directories.length; index++) {
-		const currentDir = directories[index];
+		if (options.recursive && visitedDirectories >= limits.maxDirectories) {
+			truncationReasons.add(`maximum directory count ${limits.maxDirectories} reached`);
+			break;
+		}
+
+		const current = directories[index];
+		visitedDirectories++;
 		let entries: fs.Dirent[];
 		try {
-			entries = await fs.promises.readdir(currentDir, { withFileTypes: true });
+			entries = await fs.promises.readdir(current.path, { withFileTypes: true });
 		} catch (error) {
 			if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
-				warnings.push(`Failed to read skills directory: ${currentDir} (${String(error)})`);
+				warnings.push(`Failed to read skills directory: ${current.path} (${String(error)})`);
 			}
 			continue;
 		}
 
-		if (currentDir !== dir || options.includeSelf) {
-			work.push(loadSkill(path.join(currentDir, "SKILL.md")));
+		if (current.path !== dir || options.includeSelf) {
+			work.push(loadSkill(path.join(current.path, "SKILL.md")));
 		}
 		for (const entry of entries) {
-			if (entry.name.startsWith(".")) continue;
+			if (options.recursive) {
+				if (visitedEntries >= limits.maxEntries) {
+					truncationReasons.add(`maximum entry count ${limits.maxEntries} reached`);
+					entryLimitReached = true;
+					break;
+				}
+				visitedEntries++;
+			}
+			if (
+				entry.name.startsWith(".") ||
+				(options.recursive && PRUNED_RECURSIVE_SKILL_DIRECTORIES[entry.name] === true)
+			) {
+				continue;
+			}
 			if (!entry.isDirectory() && !entry.isSymbolicLink()) continue;
-			const childDir = path.join(currentDir, entry.name);
+			const childDir = path.join(current.path, entry.name);
 			if (options.recursive && entry.isDirectory()) {
-				directories.push(childDir);
+				if (current.depth >= limits.maxDepth) {
+					truncationReasons.add(`maximum depth ${limits.maxDepth} reached`);
+					continue;
+				}
+				directories.push({ path: childDir, depth: current.depth + 1 });
 			} else {
 				work.push(loadSkill(path.join(childDir, "SKILL.md")));
 			}
 		}
+		if (entryLimitReached) break;
 	}
 	await Promise.all(work);
+	for (const reason of truncationReasons) {
+		warnings.push(`Skill discovery truncated at ${dir}: ${reason}`);
+	}
 
 	// Deterministic ordering: async file reads complete nondeterministically, so sort after loading.
 	items.sort((a, b) => compareSkillOrder(a.name, a.path, b.name, b.path));

--- a/packages/coding-agent/test/capability/fs-special-files.test.ts
+++ b/packages/coding-agent/test/capability/fs-special-files.test.ts
@@ -2,7 +2,7 @@ import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { clearCache, readFile } from "@oh-my-pi/pi-coding-agent/capability/fs";
+import { clearCache, invalidate, readDirEntriesWithinLimit, readFile } from "@oh-my-pi/pi-coding-agent/capability/fs";
 
 const isWindows = process.platform === "win32";
 
@@ -48,5 +48,45 @@ describe("capability/fs readFile on special files", () => {
 		await fs.promises.symlink(target, link);
 		clearCache();
 		expect(await readFile(link)).toBe("# context");
+	});
+});
+
+describe("capability/fs cache controls", () => {
+	it("shares bounded directory reads with cache invalidation without caching truncation", async () => {
+		const directory = await fs.promises.mkdtemp(path.join(os.tmpdir(), "omp-fs-bounded-"));
+		const firstPath = path.join(directory, "a");
+		const secondPath = path.join(directory, "b");
+		try {
+			await Bun.write(firstPath, "");
+			clearCache();
+			expect((await readDirEntriesWithinLimit(directory, 1))?.map(entry => entry.name)).toEqual(["a"]);
+
+			await Bun.write(secondPath, "");
+			expect((await readDirEntriesWithinLimit(directory, 1))?.map(entry => entry.name)).toEqual(["a"]);
+
+			invalidate(secondPath);
+			expect(await readDirEntriesWithinLimit(directory, 1)).toBeNull();
+
+			await fs.promises.rm(secondPath);
+			expect((await readDirEntriesWithinLimit(directory, 1))?.map(entry => entry.name)).toEqual(["a"]);
+		} finally {
+			clearCache();
+			await fs.promises.rm(directory, { recursive: true, force: true });
+		}
+	});
+
+	it("can bypass a cached miss when an optional file appears", async () => {
+		const directory = await fs.promises.mkdtemp(path.join(os.tmpdir(), "omp-fs-cache-miss-"));
+		const filePath = path.join(directory, "SKILL.md");
+		try {
+			clearCache();
+			expect(await readFile(filePath)).toBeNull();
+			await Bun.write(filePath, "# created");
+			expect(await readFile(filePath)).toBeNull();
+			expect(await readFile(filePath, { cacheMisses: false })).toBe("# created");
+		} finally {
+			clearCache();
+			await fs.promises.rm(directory, { recursive: true, force: true });
+		}
 	});
 });

--- a/packages/coding-agent/test/capability/fs-special-files.test.ts
+++ b/packages/coding-agent/test/capability/fs-special-files.test.ts
@@ -75,6 +75,26 @@ describe("capability/fs cache controls", () => {
 		}
 	});
 
+	it("refreshes and replaces a cached bounded directory listing", async () => {
+		const directory = await fs.promises.mkdtemp(path.join(os.tmpdir(), "omp-fs-refresh-"));
+		try {
+			await Bun.write(path.join(directory, "a"), "");
+			clearCache();
+			expect((await readDirEntriesWithinLimit(directory, 2))?.map(entry => entry.name)).toEqual(["a"]);
+
+			await Bun.write(path.join(directory, "b"), "");
+			expect((await readDirEntriesWithinLimit(directory, 2))?.map(entry => entry.name)).toEqual(["a"]);
+			expect((await readDirEntriesWithinLimit(directory, 2, { refresh: true }))?.map(entry => entry.name)).toEqual([
+				"a",
+				"b",
+			]);
+			expect((await readDirEntriesWithinLimit(directory, 2))?.map(entry => entry.name)).toEqual(["a", "b"]);
+		} finally {
+			clearCache();
+			await fs.promises.rm(directory, { recursive: true, force: true });
+		}
+	});
+
 	it("can bypass a cached miss when an optional file appears", async () => {
 		const directory = await fs.promises.mkdtemp(path.join(os.tmpdir(), "omp-fs-cache-miss-"));
 		const filePath = path.join(directory, "SKILL.md");

--- a/packages/coding-agent/test/skills.test.ts
+++ b/packages/coding-agent/test/skills.test.ts
@@ -390,6 +390,42 @@ describe("skills", () => {
 			}
 		});
 
+		it("should recursively load nested user skills from ~/.agents/skills", async () => {
+			const tempHome = await fs.mkdtemp(path.join(os.tmpdir(), "pi-agents-nested-user-home-"));
+			const tempProject = await fs.mkdtemp(path.join(os.tmpdir(), "pi-agents-nested-user-project-"));
+			const parentDir = path.join(tempHome, ".agents", "skills", "home-parent");
+			const childDir = path.join(parentDir, "home-child");
+			await fs.mkdir(childDir, { recursive: true });
+			await fs.writeFile(
+				path.join(parentDir, "SKILL.md"),
+				["---", "name: home-parent", "description: Nested user parent skill", "---", "", "# home-parent"].join(
+					"\n",
+				),
+			);
+			await fs.writeFile(
+				path.join(childDir, "SKILL.md"),
+				["---", "name: home-child", "description: Nested user child skill", "---", "", "# home-child"].join("\n"),
+			);
+			const homedirSpy = spyOn(os, "homedir").mockReturnValue(tempHome);
+			try {
+				const { skills } = await loadSkills({
+					...DISABLE_ALL_BUILTIN_SKILLS,
+					enableAgentsUser: true,
+					cwd: tempProject,
+				});
+				const parent = skills.find(skill => skill.name === "home-parent");
+				const child = skills.find(skill => skill.name === "home-child");
+				expect(parent?.filePath).toBe(path.join(parentDir, "SKILL.md"));
+				expect(parent?.source).toBe("agents:user");
+				expect(child?.filePath).toBe(path.join(childDir, "SKILL.md"));
+				expect(child?.source).toBe("agents:user");
+			} finally {
+				homedirSpy.mockRestore();
+				await removeWithRetries(tempHome);
+				await removeWithRetries(tempProject);
+			}
+		});
+
 		it("should recursively load project skills from .agents/skills", async () => {
 			const tempHome = await fs.mkdtemp(path.join(os.tmpdir(), "pi-agents-nested-home-"));
 			const tempProject = await fs.mkdtemp(path.join(os.tmpdir(), "pi-agents-nested-project-"));

--- a/packages/coding-agent/test/skills.test.ts
+++ b/packages/coding-agent/test/skills.test.ts
@@ -210,6 +210,21 @@ describe("skills", () => {
 			}
 		});
 
+		it("discovers a skill directory created after an earlier scan", async () => {
+			const root = await fs.mkdtemp(path.join(os.tmpdir(), "pi-skills-created-directory-"));
+			try {
+				expect((await scanRecursive(root)).items).toHaveLength(0);
+
+				await writeTestSkill(path.join(root, "created-later"), "created-later");
+				const result = await scanRecursive(root);
+
+				expect(result.items.map(skill => skill.name)).toEqual(["created-later"]);
+				expect(result.warnings).toHaveLength(0);
+			} finally {
+				await removeWithRetries(root);
+			}
+		});
+
 		it("loads through depth six and truncates skills at depths seven and eight", async () => {
 			const root = await fs.mkdtemp(path.join(os.tmpdir(), "pi-skills-depth-"));
 			const depthSix = path.join(root, "one", "two", "three", "four", "five", "six");

--- a/packages/coding-agent/test/skills.test.ts
+++ b/packages/coding-agent/test/skills.test.ts
@@ -193,6 +193,23 @@ describe("skills", () => {
 			}
 		});
 
+		it("discovers a manifest created in an existing directory after an earlier scan", async () => {
+			const root = await fs.mkdtemp(path.join(os.tmpdir(), "pi-skills-created-manifest-"));
+			const skillDir = path.join(root, "created-later");
+			try {
+				await fs.mkdir(skillDir);
+				expect((await scanRecursive(root)).items).toHaveLength(0);
+
+				await writeTestSkill(skillDir, "created-later");
+				const result = await scanRecursive(root);
+
+				expect(result.items.map(skill => skill.name)).toEqual(["created-later"]);
+				expect(result.warnings).toHaveLength(0);
+			} finally {
+				await removeWithRetries(root);
+			}
+		});
+
 		it("loads through depth six and truncates skills at depths seven and eight", async () => {
 			const root = await fs.mkdtemp(path.join(os.tmpdir(), "pi-skills-depth-"));
 			const depthSix = path.join(root, "one", "two", "three", "four", "five", "six");

--- a/packages/coding-agent/test/skills.test.ts
+++ b/packages/coding-agent/test/skills.test.ts
@@ -5,6 +5,7 @@ import * as path from "node:path";
 import { type Skill as CapabilitySkill, skillCapability } from "@oh-my-pi/pi-coding-agent/capability/skill";
 import { getCapability } from "@oh-my-pi/pi-coding-agent/discovery";
 import { getWslWindowsHomeCandidate, runHostProbe } from "@oh-my-pi/pi-coding-agent/discovery/agents";
+import { type SkillScanLimits, scanSkillsFromDir } from "@oh-my-pi/pi-coding-agent/discovery/helpers";
 import {
 	type LoadSkillsResult,
 	loadSkills,
@@ -160,6 +161,109 @@ describe("skills", () => {
 
 			expect(skills).toHaveLength(0);
 		});
+	});
+
+	describe("recursive skill scanning", () => {
+		const writeTestSkill = async (skillDir: string, name: string): Promise<void> => {
+			await fs.mkdir(skillDir, { recursive: true });
+			await fs.writeFile(
+				path.join(skillDir, "SKILL.md"),
+				["---", `name: ${name}`, `description: ${name} description`, "---", "", `# ${name}`].join("\n"),
+			);
+		};
+
+		const scanRecursive = (dir: string, limits?: Partial<SkillScanLimits>) =>
+			scanSkillsFromDir(
+				{ cwd: dir, home: dir, repoRoot: null },
+				{ dir, providerId: "test", level: "project", recursive: true, limits },
+			);
+
+		it("loads through depth six and warns when deeper directories are truncated", async () => {
+			const root = await fs.mkdtemp(path.join(os.tmpdir(), "pi-skills-depth-"));
+			const depthSix = path.join(root, "one", "two", "three", "four", "five", "six");
+			const depthSeven = path.join(depthSix, "seven");
+			try {
+				await writeTestSkill(depthSix, "depth-six");
+				await writeTestSkill(depthSeven, "depth-seven");
+
+				const result = await scanRecursive(root);
+
+				expect(result.items.map(skill => skill.name)).toContain("depth-six");
+				expect(result.items.map(skill => skill.name)).not.toContain("depth-seven");
+				expect(result.warnings).toContain(`Skill discovery truncated at ${root}: maximum depth 6 reached`);
+			} finally {
+				await removeWithRetries(root);
+			}
+		});
+
+		it("caps visited directories and reports truncation", async () => {
+			const root = await fs.mkdtemp(path.join(os.tmpdir(), "pi-skills-directories-"));
+			try {
+				await writeTestSkill(path.join(root, "first"), "first");
+				await writeTestSkill(path.join(root, "second"), "second");
+
+				const result = await scanRecursive(root, { maxDirectories: 1 });
+
+				expect(result.items).toHaveLength(0);
+				expect(result.warnings).toContain(
+					`Skill discovery truncated at ${root}: maximum directory count 1 reached`,
+				);
+			} finally {
+				await removeWithRetries(root);
+			}
+		});
+
+		it("caps visited entries and reports truncation", async () => {
+			const root = await fs.mkdtemp(path.join(os.tmpdir(), "pi-skills-entries-"));
+			try {
+				await writeTestSkill(path.join(root, "first"), "first");
+				await writeTestSkill(path.join(root, "second"), "second");
+
+				const result = await scanRecursive(root, { maxEntries: 1 });
+
+				expect(result.items).toHaveLength(0);
+				expect(result.warnings).toContain(`Skill discovery truncated at ${root}: maximum entry count 1 reached`);
+			} finally {
+				await removeWithRetries(root);
+			}
+		});
+
+		it("prunes .git and node_modules from recursive discovery", async () => {
+			const root = await fs.mkdtemp(path.join(os.tmpdir(), "pi-skills-pruned-"));
+			try {
+				await writeTestSkill(path.join(root, ".git", "ignored-git"), "ignored-git");
+				await writeTestSkill(path.join(root, "node_modules", "ignored-module"), "ignored-module");
+				await writeTestSkill(path.join(root, "visible"), "visible");
+
+				const result = await scanRecursive(root);
+
+				expect(result.items.map(skill => skill.name)).toEqual(["visible"]);
+				expect(result.warnings).toHaveLength(0);
+			} finally {
+				await removeWithRetries(root);
+			}
+		});
+
+		it.skipIf(process.platform === "win32")(
+			"loads a symlinked skill root without recursively traversing it",
+			async () => {
+				const root = await fs.mkdtemp(path.join(os.tmpdir(), "pi-skills-symlink-root-"));
+				const target = await fs.mkdtemp(path.join(os.tmpdir(), "pi-skills-symlink-target-"));
+				try {
+					await writeTestSkill(target, "linked-root");
+					await writeTestSkill(path.join(target, "nested"), "linked-nested");
+					await fs.symlink(target, path.join(root, "linked"), "dir");
+
+					const result = await scanRecursive(root);
+
+					expect(result.items.map(skill => skill.name)).toEqual(["linked-root"]);
+					expect(result.warnings).toHaveLength(0);
+				} finally {
+					await removeWithRetries(root);
+					await removeWithRetries(target);
+				}
+			},
+		);
 	});
 
 	describe("loadSkills with options", () => {

--- a/packages/coding-agent/test/skills.test.ts
+++ b/packages/coding-agent/test/skills.test.ts
@@ -249,6 +249,64 @@ describe("skills", () => {
 			}
 		});
 
+		it("should recursively load project skills from .agents/skills", async () => {
+			const tempHome = await fs.mkdtemp(path.join(os.tmpdir(), "pi-agents-nested-home-"));
+			const tempProject = await fs.mkdtemp(path.join(os.tmpdir(), "pi-agents-nested-project-"));
+			const skillDir = path.join(tempProject, ".agents", "skills", "group", "nested-agents-skill");
+			await fs.mkdir(skillDir, { recursive: true });
+			await fs.writeFile(
+				path.join(skillDir, "SKILL.md"),
+				["---", "description: Nested project agents skill", "---", "", "# nested-agents-skill"].join("\n"),
+			);
+
+			try {
+				const capability = getCapability<CapabilitySkill>(skillCapability.id);
+				const agentsProvider = capability?.providers.find(provider => provider.id === "agents");
+				expect(agentsProvider).toBeDefined();
+
+				const result = await agentsProvider!.load({
+					cwd: tempProject,
+					home: tempHome,
+					repoRoot: tempProject,
+				});
+				const skill = result.items.find(item => item.name === "nested-agents-skill");
+				expect(skill?.path).toBe(path.join(skillDir, "SKILL.md"));
+				expect(skill?.level).toBe("project");
+			} finally {
+				await removeWithRetries(tempProject);
+				await removeWithRetries(tempHome);
+			}
+		});
+
+		it("should recursively load project skills from .omp/skills", async () => {
+			const tempHome = await fs.mkdtemp(path.join(os.tmpdir(), "pi-native-nested-home-"));
+			const tempProject = await fs.mkdtemp(path.join(os.tmpdir(), "pi-native-nested-project-"));
+			const skillDir = path.join(tempProject, ".omp", "skills", "group", "nested-native-skill");
+			await fs.mkdir(skillDir, { recursive: true });
+			await fs.writeFile(
+				path.join(skillDir, "SKILL.md"),
+				["---", "description: Nested project OMP skill", "---", "", "# nested-native-skill"].join("\n"),
+			);
+
+			try {
+				const capability = getCapability<CapabilitySkill>(skillCapability.id);
+				const nativeProvider = capability?.providers.find(provider => provider.id === "native");
+				expect(nativeProvider).toBeDefined();
+
+				const result = await nativeProvider!.load({
+					cwd: tempProject,
+					home: tempHome,
+					repoRoot: tempProject,
+				});
+				const skill = result.items.find(item => item.name === "nested-native-skill");
+				expect(skill?.path).toBe(path.join(skillDir, "SKILL.md"));
+				expect(skill?.level).toBe("project");
+			} finally {
+				await removeWithRetries(tempProject);
+				await removeWithRetries(tempHome);
+			}
+		});
+
 		it("should load Windows host ~/.agents/skills when running under WSL (#3779)", async () => {
 			const tempHostHome = await fs.mkdtemp(path.join(os.tmpdir(), "pi-agents-wsl-host-"));
 			const tempCwd = await fs.mkdtemp(path.join(os.tmpdir(), "pi-agents-wsl-cwd-"));

--- a/packages/coding-agent/test/skills.test.ts
+++ b/packages/coding-agent/test/skills.test.ts
@@ -178,18 +178,36 @@ describe("skills", () => {
 				{ dir, providerId: "test", level: "project", recursive: true, limits },
 			);
 
-		it("loads through depth six and warns when deeper directories are truncated", async () => {
+		it("continues discovery below a directory that is also a skill", async () => {
+			const root = await fs.mkdtemp(path.join(os.tmpdir(), "pi-skills-parent-child-"));
+			try {
+				await writeTestSkill(path.join(root, "parent"), "parent");
+				await writeTestSkill(path.join(root, "parent", "child"), "child");
+
+				const result = await scanRecursive(root);
+
+				expect(result.items.map(skill => skill.name)).toEqual(["child", "parent"]);
+				expect(result.warnings).toHaveLength(0);
+			} finally {
+				await removeWithRetries(root);
+			}
+		});
+
+		it("loads through depth six and truncates skills at depths seven and eight", async () => {
 			const root = await fs.mkdtemp(path.join(os.tmpdir(), "pi-skills-depth-"));
 			const depthSix = path.join(root, "one", "two", "three", "four", "five", "six");
 			const depthSeven = path.join(depthSix, "seven");
+			const depthEight = path.join(depthSeven, "eight");
 			try {
 				await writeTestSkill(depthSix, "depth-six");
 				await writeTestSkill(depthSeven, "depth-seven");
+				await writeTestSkill(depthEight, "depth-eight");
 
 				const result = await scanRecursive(root);
 
 				expect(result.items.map(skill => skill.name)).toContain("depth-six");
 				expect(result.items.map(skill => skill.name)).not.toContain("depth-seven");
+				expect(result.items.map(skill => skill.name)).not.toContain("depth-eight");
 				expect(result.warnings).toContain(`Skill discovery truncated at ${root}: maximum depth 6 reached`);
 			} finally {
 				await removeWithRetries(root);
@@ -264,6 +282,25 @@ describe("skills", () => {
 				}
 			},
 		);
+
+		it.skipIf(process.platform === "win32")("applies the depth cap to symlinked skill leaves", async () => {
+			const root = await fs.mkdtemp(path.join(os.tmpdir(), "pi-skills-symlink-depth-root-"));
+			const target = await fs.mkdtemp(path.join(os.tmpdir(), "pi-skills-symlink-depth-target-"));
+			const depthSix = path.join(root, "one", "two", "three", "four", "five", "six");
+			try {
+				await fs.mkdir(depthSix, { recursive: true });
+				await writeTestSkill(target, "linked-depth-seven");
+				await fs.symlink(target, path.join(depthSix, "linked"), "dir");
+
+				const result = await scanRecursive(root);
+
+				expect(result.items.map(skill => skill.name)).not.toContain("linked-depth-seven");
+				expect(result.warnings).toContain(`Skill discovery truncated at ${root}: maximum depth 6 reached`);
+			} finally {
+				await removeWithRetries(root);
+				await removeWithRetries(target);
+			}
+		});
 	});
 
 	describe("loadSkills with options", () => {

--- a/packages/coding-agent/test/skills.test.ts
+++ b/packages/coding-agent/test/skills.test.ts
@@ -231,6 +231,37 @@ describe("skills", () => {
 			}
 		});
 
+		it("uses deterministic directory order before applying the directory cap", async () => {
+			const root = await fs.mkdtemp(path.join(os.tmpdir(), "pi-skills-directory-order-"));
+			try {
+				await writeTestSkill(path.join(root, "z-last"), "z-last");
+				await writeTestSkill(path.join(root, "a-first"), "a-first");
+
+				const result = await scanRecursive(root, { maxDirectories: 2 });
+
+				expect(result.items.map(skill => skill.name)).toEqual(["a-first"]);
+				expect(result.warnings).toContain(
+					`Skill discovery truncated at ${root}: maximum directory count 2 reached`,
+				);
+			} finally {
+				await removeWithRetries(root);
+			}
+		});
+
+		it("loads a skill when its entries exactly fit the entry cap", async () => {
+			const root = await fs.mkdtemp(path.join(os.tmpdir(), "pi-skills-exact-entries-"));
+			try {
+				await writeTestSkill(path.join(root, "only"), "only");
+
+				const result = await scanRecursive(root, { maxEntries: 2 });
+
+				expect(result.items.map(skill => skill.name)).toEqual(["only"]);
+				expect(result.warnings).toHaveLength(0);
+			} finally {
+				await removeWithRetries(root);
+			}
+		});
+
 		it("caps visited entries and reports truncation", async () => {
 			const root = await fs.mkdtemp(path.join(os.tmpdir(), "pi-skills-entries-"));
 			try {


### PR DESCRIPTION
## What

- Recursively discover `SKILL.md` files under OMP-native `.omp/skills` and `.agent[s]/skills` roots.
- Bound traversal to depth 6, 2,000 directories, and 20,000 entries, with warnings when discovery is truncated.
- Stream recursive directory entries through the shared filesystem layer with bounded buffering and deterministic ordering; an oversized directory is rejected rather than exposing a filesystem-order-dependent subset.
- Refresh directory listings on every skill discovery pass while replacing complete shared-cache entries, so newly created skill directories are visible without explicit invalidation.
- Avoid negative-caching absent skill manifests so a later discovery pass sees `SKILL.md` created inside an already-known directory.
- Prune hidden directories, `.git`, and `node_modules`; load symlink-root skills without recursively following directory symlinks.
- Keep spec-defined third-party, plugin, and custom-directory scans non-recursive.
- Document the discovery contract and add regression coverage for nesting, limits, pruning, caching, rescans, and symlinks.

## Intentional parent-and-child semantics

A directory containing `SKILL.md` is **not** a discovery leaf for OMP-native roots. It may be both an independently invocable skill and a namespace containing more independently invocable child skills. For example, both of these must be discovered:

```text
my-skill/SKILL.md
my-skill/local-repo-only-skill-i-want-to-.gitigignore/SKILL.md
```

Traversal therefore intentionally continues below a matched skill directory. Stopping at the first `SKILL.md` would break router skills and grouped parent/child skill collections—the primary use case for recursive native discovery. Agent Plugin, third-party, and custom-directory roots retain their existing direct-child contracts.

## Why

OMP only inspected direct children of native skill roots, so grouped skill collections such as `.agents/skills/team/internal/<skill>/SKILL.md` were invisible. Grok and Codex support recursive native skill discovery; this adds the same organization capability without allowing unbounded or cyclic traversal.

## Testing

- `bun test packages/coding-agent/test/capability/fs-special-files.test.ts packages/coding-agent/test/skills.test.ts` — 68 passed
- `mise exec rust@nightly -- bun check`
- Parent and child `SKILL.md` files are both discovered when the parent is also a skill
- Nested user `~/.agents/skills` and project `.agents/skills` providers are both covered
- Depth 6 remains discoverable while real-directory and symlink skills at depth 7 are truncated with warnings
- Entry enumeration is bounded; exact limits, oversized directories, deterministic directory-cap ordering, cache reuse, invalidation, and explicit refresh are covered
- A new skill directory and a `SKILL.md` created inside an existing directory are both discovered on a later pass without clearing capability caches
- Simultaneous local eight-level user and project fixtures expose depths 1–6 while hiding depths 7–8
- Source-linked OMP smoke test discovered and invoked nested native skills successfully

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (user-facing)