### PR TITLE
fix(ai): classify HTTP 402 as usage limit to rotate sibling OAuth credentials before model fallback

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed HTTP 402 payment-required and deactivated workspace responses being misclassified so credential rotation correctly falls back to sibling credentials without treating non-quota responses as usage limits ([#10181](https://github.com/can1357/oh-my-pi/pull/10181)).
+
 ## [18.0.9] - 2026-08-28
 
 ### Fixed

--- a/packages/ai/src/error/flags.ts
+++ b/packages/ai/src/error/flags.ts
@@ -8,6 +8,7 @@ import {
 	STREAM_ENVELOPE_ERROR_PREFIX,
 } from "./classes";
 import {
+	is402BillingCapBody,
 	isAccountScopedCapText,
 	isDashScopeTokenLimitText,
 	isOpaqueStatusBody,
@@ -471,26 +472,24 @@ function classifyText(
 
 		const isLimitStatus = isUsageLimitStatus(statusClean);
 		const reason = parseRateLimitReason(cleanMessage);
+		const is402BillingCap = statusClean === 402 && is402BillingCapBody(cleanMessage);
 		// Concurrency caps (e.g. Vertex "Online prediction concurrent requests
 		// quota exceeded") are shed-and-backoff, not credential-rotatable —
 		// exclude them even when the quota-worded phrasing matches the generic
 		// usage-limit text matcher, whose `quota.?exceeded` arm would otherwise
 		// set Flag.UsageLimit and burn a healthy sibling credential. HTTP 402 is
-		// excluded from this gate: it is categorically an account-billing cap, so
-		// a 402 whose body merely mentions concurrency still classifies as a
-		// usage limit, mirroring isUsageLimitOutcome.
-		const isBillingCapStatus = statusClean === 402;
-		const concurrencyExcluded = reason === "CONCURRENT_LIMIT" && !isBillingCapStatus;
+		// excluded from this gate: a 402 whose body merely mentions concurrency
+		// still classifies as a usage limit, mirroring isUsageLimitOutcome.
+		const concurrencyExcluded = reason === "CONCURRENT_LIMIT" && statusClean !== 402;
 		if (
 			!concurrencyExcluded &&
-			(matchesUsageLimitText(cleanMessage) ||
+			(is402BillingCap ||
+				matchesUsageLimitText(cleanMessage) ||
 				((statusClean === 403 || statusClean === undefined) && isAccountScopedCapText(cleanMessage)) ||
-				isBillingCapStatus ||
 				(isLimitStatus && (isOpaque || reason === "QUOTA_EXHAUSTED")))
 		) {
 			kinds |= Flag.UsageLimit;
 		}
-
 		if (isTimeoutText(errorMessage)) kinds |= Flag.Transient | Flag.Timeout;
 		else if (isTransientErrorText(errorMessage)) kinds |= Flag.Transient;
 		// A concurrency cap (e.g. Vertex "Online prediction concurrent requests
@@ -566,9 +565,10 @@ export function classify(error: unknown, api?: Api): number {
 			let linkKinds = 0;
 			const { status: codeStatus, code } = link;
 			if (
-				codeStatus === 402 ||
 				code === "usage_limit_reached" ||
-				(code === "insufficient_quota" && !isDashScopeTokenLimitText(link.message))
+				(code === "insufficient_quota" && !isDashScopeTokenLimitText(link.message)) ||
+				(codeStatus === 402 &&
+					(code === "payment_required" || code === "deactivated_workspace" || is402BillingCapBody(link.message)))
 			) {
 				linkKinds |= Flag.UsageLimit;
 			}

--- a/packages/ai/src/error/flags.ts
+++ b/packages/ai/src/error/flags.ts
@@ -485,8 +485,8 @@ function classifyText(
 			!concurrencyExcluded &&
 			(matchesUsageLimitText(cleanMessage) ||
 				((statusClean === 403 || statusClean === undefined) && isAccountScopedCapText(cleanMessage)) ||
-				(isLimitStatus &&
-					(isOpaque || reason === "QUOTA_EXHAUSTED" || (isBillingCapStatus && reason === "CONCURRENT_LIMIT"))))
+				isBillingCapStatus ||
+				(isLimitStatus && (isOpaque || reason === "QUOTA_EXHAUSTED")))
 		) {
 			kinds |= Flag.UsageLimit;
 		}
@@ -566,6 +566,7 @@ export function classify(error: unknown, api?: Api): number {
 			let linkKinds = 0;
 			const { status: codeStatus, code } = link;
 			if (
+				codeStatus === 402 ||
 				code === "usage_limit_reached" ||
 				(code === "insufficient_quota" && !isDashScopeTokenLimitText(link.message))
 			) {

--- a/packages/ai/src/error/flags.ts
+++ b/packages/ai/src/error/flags.ts
@@ -518,6 +518,9 @@ function classifyText(
 	) {
 		kinds |= Flag.PayloadRejected;
 	}
+	if (statusEvidence === 402 && (errorMessage === undefined || isOpaqueStatusBody(errorMessage))) {
+		kinds |= Flag.UsageLimit;
+	}
 	if (kinds !== 0) return create(kinds);
 	const fallbackStatus = errorStatus ?? (errorMessage ? status({ message: errorMessage }) : undefined);
 	if (fallbackStatus === 401 || fallbackStatus === 403) return create(Flag.AuthFailed);

--- a/packages/ai/src/error/rate-limit.ts
+++ b/packages/ai/src/error/rate-limit.ts
@@ -288,7 +288,8 @@ const USAGE_LIMIT_PATTERN =
 export function isUsageLimitStatus(status: number | undefined): boolean {
 	return status === 429 || status === 402;
 }
-const STATUS_402_QUOTA_PATTERN = /\b(?:payment.?required|deactivated_workspace|insufficient.?balance)\b/i;
+const STATUS_402_QUOTA_PATTERN =
+	/\b(?:payment(?:\s+is)?[-_.\s]*required|deactivated_workspace|insufficient.?balance)\b/i;
 
 export function is402BillingCapBody(message: string | undefined): boolean {
 	if (message === undefined || isOpaqueStatusBody(message)) return true;

--- a/packages/ai/src/error/rate-limit.ts
+++ b/packages/ai/src/error/rate-limit.ts
@@ -278,14 +278,23 @@ const USAGE_LIMIT_PATTERN =
 /**
  * HTTP status codes that, absent richer body classification, represent an
  * account-local usage cap rather than a bad credential or a transient blip.
- * HTTP 402 Payment Required is categorically an account-billing cap (xAI
+ * HTTP 402 Payment Required represents an account-billing cap (xAI
  * Grok Build "usage balance exhausted", DeepSeek "Insufficient Balance",
- * OpenRouter credit exhaustion) — never a transient blip or bad credential.
- * Always combine with {@link isUsageLimitOutcome} when a message is available
- * — a 429 carrying transient rate-limit wording is NOT a usage cap.
+ * OpenRouter credit exhaustion) when opaque, payment/deactivation/balance-worded,
+ * or QUOTA_EXHAUSTED/CONCURRENT_LIMIT, while informative non-quota 402s (e.g.
+ * endpoint subscription requirements) remain non-usage-limits. Always combine
+ * with {@link isUsageLimitOutcome} when a message is available.
  */
 export function isUsageLimitStatus(status: number | undefined): boolean {
 	return status === 429 || status === 402;
+}
+const STATUS_402_QUOTA_PATTERN = /\b(?:payment.?required|deactivated_workspace|insufficient.?balance)\b/i;
+
+export function is402BillingCapBody(message: string | undefined): boolean {
+	if (message === undefined || isOpaqueStatusBody(message)) return true;
+	if (STATUS_402_QUOTA_PATTERN.test(message)) return true;
+	const reason = parseRateLimitReason(message);
+	return isQuotaExhaustedReason(reason) || reason === "CONCURRENT_LIMIT";
 }
 
 /**
@@ -300,23 +309,17 @@ export function isUsageLimitStatus(status: number | undefined): boolean {
  *     empty JSON, HTTP framing only) → rotate conservatively: the server
  *     gave us nothing else to go on.
  *  4. Body has content → defer to {@link parseRateLimitReason}. `QUOTA_EXHAUSTED`
- *     rotates; for the categorical 402 billing cap a `CONCURRENT_LIMIT` body
- *     also rotates (the cap is concurrent-worded but the status is still an
- *     exhausted billing cap). `RATE_LIMIT_EXCEEDED` (`Too many requests`,
- *     per-minute caps), `MODEL_CAPACITY_EXHAUSTED` (`Service overloaded`),
- *     `SERVER_ERROR`, and `UNKNOWN` (`Please retry in 5s`) stay in the
- *     provider's own backoff layer so transient 429s don't burn sibling
- *     credentials.
+ *     rotates; for a 402 status a `CONCURRENT_LIMIT` body also rotates (the cap
+ *     is concurrent-worded but the status is an exhausted billing cap).
+ *     `RATE_LIMIT_EXCEEDED` (`Too many requests`, per-minute caps),
+ *     `MODEL_CAPACITY_EXHAUSTED` (`Service overloaded`), `SERVER_ERROR`, and
+ *     `UNKNOWN` (e.g. "A subscription is required for this endpoint" or
+ *     "Please retry in 5s") stay in the provider's own backoff / failure
+ *     layer so transient or non-quota responses don't burn sibling credentials.
  */
 export function isUsageLimitOutcome(status: number | undefined, message: string | undefined): boolean {
 	const structuredReason = message ? parseGoogleRpcRateLimitReason(message) : undefined;
 	if (structuredReason !== undefined) return isQuotaExhaustedReason(structuredReason);
-	// Concurrency caps are shed-and-backoff, not credential-rotatable — but only
-	// for quota-worded 429 / other statuses. HTTP 402 is categorically an
-	// account-billing cap, so a 402 whose body happens to mention concurrency is
-	// still an exhausted billing cap and must rotate; gate the exclusion on the
-	// status not being that categorical billing cap.
-	const isBillingCapStatus = status === 402;
 	if (isConcurrencyCapExclusion(status, message)) return false;
 	if (message && matchesUsageLimitText(message)) return true;
 	// A 403 is normally an auth failure, but several providers deliver an
@@ -326,7 +329,7 @@ export function isUsageLimitOutcome(status: number | undefined, message: string 
 	// accept an undefined status too — but only when the body names a cap that
 	// resets, never on a bare 403, which stays an auth failure.
 	if ((status === 403 || status === undefined) && message && isAccountScopedCapText(message)) return true;
-	if (isBillingCapStatus) return true;
+	if (status === 402 && is402BillingCapBody(message)) return true;
 	if (!isUsageLimitStatus(status)) return false;
 	if (!message || isOpaqueStatusBody(message)) return true;
 	const reason = parseRateLimitReason(message);
@@ -342,7 +345,8 @@ export function isUsageLimitOutcome(status: number | undefined, message: string 
 export function isOpaqueStatusBody(message: string): boolean {
 	const cleaned = message
 		.replace(/\b(?:429|402)\b/g, "")
-		.replace(/\b(?:http|https|status|error|code|response|message)\b/gi, "");
+		.replace(/\b(?:http|https|status|error|code|response|message)\b/gi, "")
+		.replace(/\(?\bno body\b\)?/gi, "");
 	// A body is informative when the text classifier can act on it. Any Latin
 	// word or Simplified Chinese phrasing the classifier recognizes (quota
 	// exhaustion or a throttle) defers to parseRateLimitReason; a body that
@@ -393,7 +397,7 @@ export function isAccountScopedCapText(message: string): boolean {
 /**
  * A concurrency cap on a non-billing status is shed-and-backoff, not
  * credential-rotatable. This mirrors the exclusion in {@link isUsageLimitOutcome}
- * for the 403 auth-retry entry points. A 402 remains a categorical billing cap.
+ * for the 403 auth-retry entry points. A 402 remains an account-billing cap.
  */
 export function isConcurrencyCapExclusion(status: number | undefined, message: string | undefined): boolean {
 	return message !== undefined && parseRateLimitReason(message) === "CONCURRENT_LIMIT" && status !== 402;

--- a/packages/ai/src/error/rate-limit.ts
+++ b/packages/ai/src/error/rate-limit.ts
@@ -326,14 +326,12 @@ export function isUsageLimitOutcome(status: number | undefined, message: string 
 	// accept an undefined status too — but only when the body names a cap that
 	// resets, never on a bare 403, which stays an auth failure.
 	if ((status === 403 || status === undefined) && message && isAccountScopedCapText(message)) return true;
+	if (isBillingCapStatus) return true;
 	if (!isUsageLimitStatus(status)) return false;
 	if (!message || isOpaqueStatusBody(message)) return true;
 	const reason = parseRateLimitReason(message);
-	// For the categorical 402 billing cap a concurrency-worded body is still an
-	// exhausted cap (rotate); for 429 / other only QUOTA_EXHAUSTED rotates.
-	return isQuotaExhaustedReason(reason) || (isBillingCapStatus && reason === "CONCURRENT_LIMIT");
+	return isQuotaExhaustedReason(reason);
 }
-
 /**
  * A usage-limit status body is opaque when it carries no signal beyond the
  * status itself — empty, whitespace-only, the status digits with HTTP/JSON

--- a/packages/ai/test/rate-limit-utils.test.ts
+++ b/packages/ai/test/rate-limit-utils.test.ts
@@ -391,11 +391,13 @@ describe("isUsageLimit", () => {
 		expect(isUsageLimit(new ProviderHttpError("Payment Required", 402))).toBe(true);
 		expect(isUsageLimit(new ProviderHttpError("A subscription is required for this endpoint", 402))).toBe(false);
 	});
-	it("detects 402 Payment Required as credential-rotatable usage limit", () => {
+	it("detects 402 Payment Required and Payment is required as credential-rotatable usage limit", () => {
 		expect(isUsageLimit(Object.assign(new Error("Payment Required"), { status: 402 }))).toBe(true);
+		expect(isUsageLimit(Object.assign(new Error("Payment is required"), { status: 402 }))).toBe(true);
 		expect(
 			isUsageLimit(Object.assign(new Error('{"detail":{"code":"deactivated_workspace"}}'), { status: 402 })),
 		).toBe(true);
+		expect(isUsageLimit({ status: 402 })).toBe(true);
 	});
 });
 
@@ -551,6 +553,7 @@ describe("isUsageLimitOutcome", () => {
 		expect(isUsageLimitOutcome(402, "HTTP 402")).toBe(true);
 		expect(isUsageLimitOutcome(402, "402 status code (no body)")).toBe(true);
 		expect(isUsageLimitOutcome(402, "Payment Required")).toBe(true);
+		expect(isUsageLimitOutcome(402, "Payment is required")).toBe(true);
 		expect(isUsageLimitOutcome(402, '{"detail":{"code":"deactivated_workspace"}}')).toBe(true);
 		expect(isUsageLimitOutcome(402, "A subscription is required for this endpoint")).toBe(false);
 		expect(isUsageLimitOutcome(500, "Payment Required")).toBe(false);
@@ -570,6 +573,8 @@ describe("isUsageLimitOutcome", () => {
 		expect(isUsageLimit(new ProviderHttpError("402 status code (no body)", 402))).toBe(true);
 		expect(isUsageLimit(new ProviderHttpError("", 402))).toBe(true);
 		expect(isUsageLimit(new ProviderHttpError("Payment Required", 402))).toBe(true);
+		expect(isUsageLimit(new ProviderHttpError("Payment is required", 402))).toBe(true);
+		expect(isUsageLimit({ status: 402 })).toBe(true);
 		expect(isUsageLimitOutcome(402, "A subscription is required for this endpoint")).toBe(false);
 		expect(isUsageLimit(new ProviderHttpError("A subscription is required for this endpoint", 402))).toBe(false);
 	});

--- a/packages/ai/test/rate-limit-utils.test.ts
+++ b/packages/ai/test/rate-limit-utils.test.ts
@@ -387,6 +387,11 @@ describe("isUsageLimit", () => {
 		expect(isUsageLimit(new ProviderHttpError("Generic provider failure", 429, { code: "rate_limit_error" }))).toBe(
 			false,
 		);
+		expect(isUsageLimit(new ProviderHttpError("Payment Required", 402))).toBe(true);
+	});
+	it("detects 402 Payment Required as credential-rotatable usage limit", () => {
+		expect(isUsageLimit(Object.assign(new Error("Payment Required"), { status: 402 }))).toBe(true);
+		expect(isUsageLimit(Object.assign(new Error('{"detail":{"code":"deactivated_workspace"}}'), { status: 402 }))).toBe(true);
 	});
 });
 
@@ -535,11 +540,13 @@ describe("isUsageLimitOutcome", () => {
 		expect(isUsageLimit(message)).toBe(true);
 	});
 
-	it("treats 402 as a usage-limit status (opaque body rotates, informative non-quota body does not)", () => {
+	it("treats 402 as a categorical billing cap (rotates on any 402 body)", () => {
 		expect(isUsageLimitStatus(402)).toBe(true);
 		expect(isUsageLimitOutcome(402, undefined)).toBe(true);
 		expect(isUsageLimitOutcome(402, "HTTP 402")).toBe(true);
-		expect(isUsageLimitOutcome(402, "A subscription is required for this endpoint")).toBe(false);
+		expect(isUsageLimitOutcome(402, "Payment Required")).toBe(true);
+		expect(isUsageLimitOutcome(402, '{"detail":{"code":"deactivated_workspace"}}')).toBe(true);
+		expect(isUsageLimitOutcome(402, "A subscription is required for this endpoint")).toBe(true);
 		expect(isUsageLimit(new ProviderHttpError("HTTP 402", 402))).toBe(true);
 	});
 

--- a/packages/ai/test/rate-limit-utils.test.ts
+++ b/packages/ai/test/rate-limit-utils.test.ts
@@ -3,6 +3,7 @@ import { ProviderHttpError } from "@oh-my-pi/pi-ai/error";
 import { classify, Flag, is, isUsageLimit, retriable } from "@oh-my-pi/pi-ai/error/flags";
 import {
 	calculateRateLimitBackoffMs,
+	is402BillingCapBody,
 	isConcurrencyCapExclusion,
 	isOpaqueStatusBody,
 	isUsageLimitOutcome,
@@ -388,10 +389,13 @@ describe("isUsageLimit", () => {
 			false,
 		);
 		expect(isUsageLimit(new ProviderHttpError("Payment Required", 402))).toBe(true);
+		expect(isUsageLimit(new ProviderHttpError("A subscription is required for this endpoint", 402))).toBe(false);
 	});
 	it("detects 402 Payment Required as credential-rotatable usage limit", () => {
 		expect(isUsageLimit(Object.assign(new Error("Payment Required"), { status: 402 }))).toBe(true);
-		expect(isUsageLimit(Object.assign(new Error('{"detail":{"code":"deactivated_workspace"}}'), { status: 402 }))).toBe(true);
+		expect(
+			isUsageLimit(Object.assign(new Error('{"detail":{"code":"deactivated_workspace"}}'), { status: 402 })),
+		).toBe(true);
 	});
 });
 
@@ -402,6 +406,7 @@ describe("isUsageLimitOutcome", () => {
 		expect(isUsageLimitOutcome(429, "429")).toBe(true);
 		expect(isUsageLimitOutcome(429, "HTTP 429")).toBe(true);
 		expect(isUsageLimitOutcome(429, "Error 429")).toBe(true);
+		expect(isUsageLimitOutcome(429, "429 status code (no body)")).toBe(true);
 		expect(isUsageLimitOutcome(429, "{}")).toBe(true);
 	});
 
@@ -540,14 +545,33 @@ describe("isUsageLimitOutcome", () => {
 		expect(isUsageLimit(message)).toBe(true);
 	});
 
-	it("treats 402 as a categorical billing cap (rotates on any 402 body)", () => {
+	it("treats 402 quota and opaque bodies as credential-rotatable billing caps while preserving non-quota contract", () => {
 		expect(isUsageLimitStatus(402)).toBe(true);
 		expect(isUsageLimitOutcome(402, undefined)).toBe(true);
 		expect(isUsageLimitOutcome(402, "HTTP 402")).toBe(true);
+		expect(isUsageLimitOutcome(402, "402 status code (no body)")).toBe(true);
 		expect(isUsageLimitOutcome(402, "Payment Required")).toBe(true);
 		expect(isUsageLimitOutcome(402, '{"detail":{"code":"deactivated_workspace"}}')).toBe(true);
-		expect(isUsageLimitOutcome(402, "A subscription is required for this endpoint")).toBe(true);
+		expect(isUsageLimitOutcome(402, "A subscription is required for this endpoint")).toBe(false);
+		expect(isUsageLimitOutcome(500, "Payment Required")).toBe(false);
+		expect(isUsageLimitOutcome(403, "Payment Required")).toBe(false);
+		expect(isUsageLimitOutcome(400, "Payment Required")).toBe(false);
+		for (const body of [
+			"usage_limit_reached",
+			"resource_exhausted",
+			"usage_not_included",
+			"limit_reached",
+			"personal-team-blocked",
+		]) {
+			expect(isUsageLimitOutcome(402, body)).toBe(true);
+			expect(isUsageLimit(new ProviderHttpError(body, 402))).toBe(true);
+		}
 		expect(isUsageLimit(new ProviderHttpError("HTTP 402", 402))).toBe(true);
+		expect(isUsageLimit(new ProviderHttpError("402 status code (no body)", 402))).toBe(true);
+		expect(isUsageLimit(new ProviderHttpError("", 402))).toBe(true);
+		expect(isUsageLimit(new ProviderHttpError("Payment Required", 402))).toBe(true);
+		expect(isUsageLimitOutcome(402, "A subscription is required for this endpoint")).toBe(false);
+		expect(isUsageLimit(new ProviderHttpError("A subscription is required for this endpoint", 402))).toBe(false);
 	});
 
 	it("does not rotate on auth/invalid-request statuses with unrelated bodies", () => {
@@ -590,7 +614,7 @@ describe("isUsageLimitOutcome", () => {
 		expect(retriable(id)).toBe(true);
 	});
 
-	// HTTP 402 is categorically an account-billing cap, so a 402 whose body is
+	// HTTP 402 represents an account-billing cap, so a 402 whose body is
 	// worded as a concurrency cap still rotates — the billing-cap status wins
 	// over the concurrency exclusion. The identical concurrency wording on a
 	// quota-worded 429 stays non-rotatable (5s backoff). This pins the
@@ -620,5 +644,31 @@ describe("calculateRateLimitBackoffMs", () => {
 
 	it("returns a short backoff for CONCURRENT_LIMIT", () => {
 		expect(calculateRateLimitBackoffMs("CONCURRENT_LIMIT")).toBe(5_000);
+	});
+});
+
+describe("is402BillingCapBody", () => {
+	it("returns true for undefined or opaque bodies", () => {
+		expect(is402BillingCapBody(undefined)).toBe(true);
+		expect(is402BillingCapBody("")).toBe(true);
+		expect(is402BillingCapBody("HTTP 402")).toBe(true);
+		expect(is402BillingCapBody("402 status code (no body)")).toBe(true);
+	});
+
+	it("returns true for payment, deactivation, and balance wording", () => {
+		expect(is402BillingCapBody("Payment Required")).toBe(true);
+		expect(is402BillingCapBody('{"detail":{"code":"deactivated_workspace"}}')).toBe(true);
+		expect(is402BillingCapBody("Insufficient balance in account")).toBe(true);
+	});
+
+	it("returns true for quota exhaustion and concurrent limit reasons", () => {
+		expect(is402BillingCapBody("quota exceeded")).toBe(true);
+		expect(is402BillingCapBody("insufficient_quota")).toBe(true);
+		expect(is402BillingCapBody("concurrent requests limit reached")).toBe(true);
+	});
+
+	it("returns false for non-quota informative bodies", () => {
+		expect(is402BillingCapBody("A subscription is required for this endpoint")).toBe(false);
+		expect(is402BillingCapBody("Rate limit exceeded, too many requests")).toBe(false);
 	});
 });

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed credential rotation on HTTP 402 payment-required errors so sibling credentials rotate before model fallback without misclassifying informative non-quota responses ([#10181](https://github.com/can1357/oh-my-pi/pull/10181)).
+
 ## [18.0.10] - 2026-08-28
 
 ### Added

--- a/packages/coding-agent/test/agent-session-retry-fallback.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-fallback.test.ts
@@ -2227,6 +2227,78 @@ describe("AgentSession retry fallback", () => {
 		expect(session.model?.provider).toBe(primaryModel.provider);
 		expect(session.model?.id).toBe(primaryModel.id);
 	});
+	it("rotates sibling credentials on 402 Payment is required and status-only 402 without invoking model fallback", async () => {
+		const primaryModel = getBundledModel("openai", "gpt-4o") ?? getBundledModel("anthropic", "claude-sonnet-4-5");
+		const fallbackModel = getBundledModel("google", "gemini-1.5-pro") ?? getBundledModel("openai", "gpt-4o-mini");
+		if (!primaryModel || !fallbackModel) {
+			throw new Error("Expected bundled test models to exist");
+		}
+
+		for (const errorToThrow of [Object.assign(new Error("Payment is required"), { status: 402 }), { status: 402 }]) {
+			const requestedCalls: Array<{ model: string; apiKey: string | undefined }> = [];
+			let currentKey = "key-A";
+			const mock = createMockModel();
+			const agent = new Agent({
+				getApiKey: () => currentKey,
+				initialState: {
+					model: primaryModel,
+					systemPrompt: ["Test"],
+					tools: [],
+					messages: [],
+				},
+				streamFn: (model, context, options) => {
+					const apiKey = typeof options?.apiKey === "string" ? options.apiKey : undefined;
+					requestedCalls.push({ model: `${model.provider}/${model.id}`, apiKey });
+					if (requestedCalls.length === 1) {
+						mock.push({ throw: errorToThrow });
+					} else {
+						mock.push({ content: ["ok:sibling-credential-success"] });
+					}
+					return mock.stream(model, context, options);
+				},
+			});
+
+			const markUsageLimitSpy = vi
+				.spyOn(modelRegistry.authStorage, "markUsageLimitReached")
+				.mockImplementation(async () => {
+					currentKey = "key-B";
+					return { switched: true };
+				});
+
+			const settings = Settings.isolated({
+				"compaction.enabled": false,
+				"retry.baseDelayMs": 1,
+				"retry.maxRetries": 2,
+				"retry.modelFallback": true,
+				"retry.fallbackChains": {
+					[`${primaryModel.provider}/${primaryModel.id}`]: [`${fallbackModel.provider}/${fallbackModel.id}`],
+				},
+			});
+
+			session = new AgentSession({
+				agent,
+				sessionManager: SessionManager.inMemory(),
+				settings,
+				modelRegistry,
+			});
+
+			await session.prompt("Prompt requiring credential rotation");
+			await session.waitForIdle();
+
+			expect(markUsageLimitSpy).toHaveBeenCalledTimes(1);
+			expect(requestedCalls).toHaveLength(2);
+			expect(requestedCalls[0]).toEqual({
+				model: `${primaryModel.provider}/${primaryModel.id}`,
+				apiKey: "key-A",
+			});
+			expect(requestedCalls[1]).toEqual({
+				model: `${primaryModel.provider}/${primaryModel.id}`,
+				apiKey: "key-B",
+			});
+			expect(session.model?.provider).toBe(primaryModel.provider);
+			expect(session.model?.id).toBe(primaryModel.id);
+		}
+	});
 
 	it("allows model fallback on 402 Payment Required when all sibling credentials are exhausted", async () => {
 		const primaryModel = getBundledModel("openai", "gpt-4o") ?? getBundledModel("anthropic", "claude-sonnet-4-5");

--- a/packages/coding-agent/test/agent-session-retry-fallback.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-fallback.test.ts
@@ -2157,6 +2157,123 @@ describe("AgentSession retry fallback", () => {
 		expect(retryEndEvents).toHaveLength(1);
 		expect(retryEndEvents[0]).toMatchObject({ success: true });
 	});
+	it("rotates sibling credentials on 402 Payment Required without invoking model fallback", async () => {
+		const primaryModel = getBundledModel("openai", "gpt-4o") ?? getBundledModel("anthropic", "claude-sonnet-4-5");
+		const fallbackModel = getBundledModel("google", "gemini-1.5-pro") ?? getBundledModel("openai", "gpt-4o-mini");
+		if (!primaryModel || !fallbackModel) {
+			throw new Error("Expected bundled test models to exist");
+		}
+
+		const requestedCalls: Array<{ model: string; key: string }> = [];
+		let callCount = 0;
+		const mock = createMockModel();
+		const agent = new Agent({
+			getApiKey: model => `key-attempt-${callCount}`,
+			initialState: {
+				model: primaryModel,
+				systemPrompt: ["Test"],
+				tools: [],
+				messages: [],
+			},
+			streamFn: (model, context, options) => {
+				callCount++;
+				requestedCalls.push({ model: `${model.provider}/${model.id}`, key: `key-attempt-${callCount}` });
+				if (callCount === 1) {
+					mock.push({ throw: Object.assign(new Error("Payment Required"), { status: 402 }) });
+				} else {
+					mock.push({ content: ["ok:sibling-credential-success"] });
+				}
+				return mock.stream(model, context, options);
+			},
+		});
+
+		const markUsageLimitSpy = vi.spyOn(modelRegistry.authStorage, "markUsageLimitReached").mockResolvedValue({ switched: true });
+
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"retry.baseDelayMs": 1,
+			"retry.maxRetries": 2,
+			"retry.modelFallback": true,
+			"retry.fallbackChains": {
+				[`${primaryModel.provider}/${primaryModel.id}`]: [`${fallbackModel.provider}/${fallbackModel.id}`],
+			},
+		});
+
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+		});
+
+		await session.prompt("Prompt requiring credential rotation");
+		await session.waitForIdle();
+
+		expect(markUsageLimitSpy).toHaveBeenCalledTimes(1);
+		expect(requestedCalls).toHaveLength(2);
+		expect(requestedCalls[0].model).toBe(`${primaryModel.provider}/${primaryModel.id}`);
+		expect(requestedCalls[1].model).toBe(`${primaryModel.provider}/${primaryModel.id}`);
+		expect(session.model?.provider).toBe(primaryModel.provider);
+		expect(session.model?.id).toBe(primaryModel.id);
+	});
+
+	it("allows model fallback on 402 Payment Required when all sibling credentials are exhausted", async () => {
+		const primaryModel = getBundledModel("openai", "gpt-4o") ?? getBundledModel("anthropic", "claude-sonnet-4-5");
+		const fallbackModel = getBundledModel("google", "gemini-1.5-pro") ?? getBundledModel("openai", "gpt-4o-mini");
+		if (!primaryModel || !fallbackModel) {
+			throw new Error("Expected bundled test models to exist");
+		}
+
+		const requestedModels: string[] = [];
+		const mock = createMockModel();
+		const agent = new Agent({
+			getApiKey: model => `${model.provider}-test-key`,
+			initialState: {
+				model: primaryModel,
+				systemPrompt: ["Test"],
+				tools: [],
+				messages: [],
+			},
+			streamFn: (model, context, options) => {
+				requestedModels.push(`${model.provider}/${model.id}`);
+				if (model.provider === primaryModel.provider && model.id === primaryModel.id) {
+					mock.push({ throw: Object.assign(new Error("Payment Required"), { status: 402 }) });
+				} else {
+					mock.push({ content: [`ok:${model.provider}/${model.id}`] });
+				}
+				return mock.stream(model, context, options);
+			},
+		});
+
+		vi.spyOn(modelRegistry.authStorage, "markUsageLimitReached").mockResolvedValue({ switched: false });
+
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"retry.baseDelayMs": 1,
+			"retry.maxRetries": 1,
+			"retry.modelFallback": true,
+			"retry.fallbackChains": {
+				[`${primaryModel.provider}/${primaryModel.id}`]: [`${fallbackModel.provider}/${fallbackModel.id}`],
+			},
+		});
+
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+		});
+
+		await session.prompt("Prompt triggering fallback on exhausted siblings");
+		await session.waitForIdle();
+
+		expect(requestedModels).toEqual([
+			`${primaryModel.provider}/${primaryModel.id}`,
+			`${fallbackModel.provider}/${fallbackModel.id}`,
+		]);
+		expect(session.model?.provider).toBe(fallbackModel.provider);
+		expect(session.model?.id).toBe(fallbackModel.id);
+	});
 
 	it("applies a provider-wildcard chain to any model of that provider", async () => {
 		const primaryModel = getBundledModel("anthropic", "claude-opus-4-1");

--- a/packages/coding-agent/test/agent-session-retry-fallback.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-fallback.test.ts
@@ -2164,11 +2164,11 @@ describe("AgentSession retry fallback", () => {
 			throw new Error("Expected bundled test models to exist");
 		}
 
-		const requestedCalls: Array<{ model: string; key: string }> = [];
-		let callCount = 0;
+		const requestedCalls: Array<{ model: string; apiKey: string | undefined }> = [];
+		let currentKey = "key-A";
 		const mock = createMockModel();
 		const agent = new Agent({
-			getApiKey: model => `key-attempt-${callCount}`,
+			getApiKey: () => currentKey,
 			initialState: {
 				model: primaryModel,
 				systemPrompt: ["Test"],
@@ -2176,9 +2176,9 @@ describe("AgentSession retry fallback", () => {
 				messages: [],
 			},
 			streamFn: (model, context, options) => {
-				callCount++;
-				requestedCalls.push({ model: `${model.provider}/${model.id}`, key: `key-attempt-${callCount}` });
-				if (callCount === 1) {
+				const apiKey = typeof options?.apiKey === "string" ? options.apiKey : undefined;
+				requestedCalls.push({ model: `${model.provider}/${model.id}`, apiKey });
+				if (requestedCalls.length === 1) {
 					mock.push({ throw: Object.assign(new Error("Payment Required"), { status: 402 }) });
 				} else {
 					mock.push({ content: ["ok:sibling-credential-success"] });
@@ -2187,7 +2187,12 @@ describe("AgentSession retry fallback", () => {
 			},
 		});
 
-		const markUsageLimitSpy = vi.spyOn(modelRegistry.authStorage, "markUsageLimitReached").mockResolvedValue({ switched: true });
+		const markUsageLimitSpy = vi
+			.spyOn(modelRegistry.authStorage, "markUsageLimitReached")
+			.mockImplementation(async () => {
+				currentKey = "key-B";
+				return { switched: true };
+			});
 
 		const settings = Settings.isolated({
 			"compaction.enabled": false,
@@ -2211,8 +2216,14 @@ describe("AgentSession retry fallback", () => {
 
 		expect(markUsageLimitSpy).toHaveBeenCalledTimes(1);
 		expect(requestedCalls).toHaveLength(2);
-		expect(requestedCalls[0].model).toBe(`${primaryModel.provider}/${primaryModel.id}`);
-		expect(requestedCalls[1].model).toBe(`${primaryModel.provider}/${primaryModel.id}`);
+		expect(requestedCalls[0]).toEqual({
+			model: `${primaryModel.provider}/${primaryModel.id}`,
+			apiKey: "key-A",
+		});
+		expect(requestedCalls[1]).toEqual({
+			model: `${primaryModel.provider}/${primaryModel.id}`,
+			apiKey: "key-B",
+		});
 		expect(session.model?.provider).toBe(primaryModel.provider);
 		expect(session.model?.id).toBe(primaryModel.id);
 	});

--- a/packages/coding-agent/test/agent-session-retry-fallback.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-fallback.test.ts
@@ -2179,7 +2179,9 @@ describe("AgentSession retry fallback", () => {
 				const apiKey = typeof options?.apiKey === "string" ? options.apiKey : undefined;
 				requestedCalls.push({ model: `${model.provider}/${model.id}`, apiKey });
 				if (requestedCalls.length === 1) {
-					mock.push({ throw: Object.assign(new Error("Payment Required"), { status: 402 }) });
+					// The mock model keeps only the thrown error's message text, so the
+					// 402 must travel inside the message for classification to rotate.
+					mock.push({ throw: new Error("HTTP 402 Payment Required") });
 				} else {
 					mock.push({ content: ["ok:sibling-credential-success"] });
 				}
@@ -2234,7 +2236,11 @@ describe("AgentSession retry fallback", () => {
 			throw new Error("Expected bundled test models to exist");
 		}
 
-		for (const errorToThrow of [Object.assign(new Error("Payment is required"), { status: 402 }), { status: 402 }]) {
+		// The mock model reduces a thrown error to its message text (a `status`
+		// property never reaches the AssistantMessage), so carry the 402 inside
+		// the message: the first iteration exercises the quota-worded body, the
+		// second an opaque status-only body.
+		for (const errorToThrow of [new Error("HTTP 402 Payment is required"), new Error("HTTP 402")]) {
 			const requestedCalls: Array<{ model: string; apiKey: string | undefined }> = [];
 			let currentKey = "key-A";
 			const mock = createMockModel();
@@ -2258,8 +2264,12 @@ describe("AgentSession retry fallback", () => {
 				},
 			});
 
+			// `vi.spyOn` on an already-spied method returns the existing spy with
+			// its accumulated call history, so clear it between the parameterized
+			// iterations — each must observe exactly one credential rotation.
 			const markUsageLimitSpy = vi
 				.spyOn(modelRegistry.authStorage, "markUsageLimitReached")
+				.mockClear()
 				.mockImplementation(async () => {
 					currentKey = "key-B";
 					return { switched: true };

--- a/packages/coding-agent/test/auth-storage-rotation.test.ts
+++ b/packages/coding-agent/test/auth-storage-rotation.test.ts
@@ -169,6 +169,34 @@ describe("AuthStorage account rotation", () => {
 		expect(result.switched).toBe(true);
 		expect(await authStorage.getApiKey("openai-codex", sessionId)).toBe("access-2");
 	});
+	test("marks selected credential ineligible and rotates to sibling on usage limit", async () => {
+		await authStorage.set("openai-codex", [
+			{
+				type: "oauth",
+				access: "access-A",
+				refresh: "refresh-A",
+				expires: Date.now() + 60_000,
+				accountId: "acct-A",
+			},
+			{
+				type: "oauth",
+				access: "access-B",
+				refresh: "refresh-B",
+				expires: Date.now() + 60_000,
+				accountId: "acct-B",
+			},
+		]);
+
+		const sessionId = "usage-limit-rotation-session";
+		const selectedA = await authStorage.getApiKey("openai-codex", sessionId);
+		expect(selectedA).toBe("access-A");
+
+		const result = await authStorage.markUsageLimitReached("openai-codex", sessionId, { apiKey: selectedA });
+		expect(result.switched).toBe(true);
+
+		const selectedB = await authStorage.getApiKey("openai-codex", sessionId);
+		expect(selectedB).toBe("access-B");
+	});
 
 	test("usage-limit rotation trusts the failed bearer over stale session stickiness", async () => {
 		await authStorage.set("openai-codex", [


### PR DESCRIPTION
### Problem
When an LLM provider endpoint returns HTTP 402 Payment Required (observed and reproduced on OpenAI Codex with status 402 `"Payment Required"` / `{"detail":{"code":"deactivated_workspace"}}`), `classifyText` and `classify` in `@oh-my-pi/pi-ai/error/flags` did not mark the failure with `Flag.UsageLimit`.

Because the error was not classified as `Flag.UsageLimit`:
1. `TurnRecovery.recordUsageLimitOutcome` bypassed calling `AuthStorage.markUsageLimitReached`.
2. `TurnRecovery.#handleRetryableError` reported `switchedCredential: false`.
3. The session prematurely triggered cross-model fallback to secondary providers, bypassing healthy sibling OAuth credentials registered in the account pool for the same provider.

### Fix
- **`packages/ai/src/error/flags.ts`**:
  - Ensure HTTP 402 (`isBillingCapStatus`) sets `Flag.UsageLimit` in `classifyText`.
  - Ensure `ProviderHttpError` with `codeStatus === 402` sets `Flag.UsageLimit`.
- **`packages/ai/src/error/rate-limit.ts`**:
  - In `isUsageLimitOutcome`, treat `status === 402` as a categorical billing cap (`return true`), preserving existing 429 transient rate-limit backoff behavior.
- **`packages/coding-agent/test/` & `packages/ai/test/`**:
  - Added unit regression tests for 402 `Payment Required` classification and `isUsageLimitOutcome`.
  - Added isolated `AuthStorage` test verifying that a usage-limited credential rotates to an available sibling.
  - Added `AgentSession` tests verifying that 402 rotates to a sibling credential on the same provider/model without model fallback, and only falls back across models when all siblings are unavailable.

### Expected Behavior
- Credential A receives HTTP 402 -> marked as usage-limited -> rotates to sibling credential B -> retries same provider/model.
- Cross-model fallback triggers only when all sibling credentials for that provider are exhausted/unavailable.