### PR TITLE
fix(omptype): plugin tools declaring overlapping zod unions no longer fail to load

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -18,6 +18,9 @@
 - Updated Devin auth, assignment, chat, and usage requests to the current released CLI identity, version `3000.6.2` ([#8590](https://github.com/can1357/oh-my-pi/pull/8590) by [@will-bogusz](https://github.com/will-bogusz)).
 - Devin auth, model assignment, and chat requests now send the native Devin CLI identity (`ideName: devin-cli`, `ideType: chisel`, `extensionName: chisel`, mapped `os`) instead of the Windsurf IDE identity; `ideType: chisel` is what the backend requires for router assignment ([#8590](https://github.com/can1357/oh-my-pi/pull/8590) by [@will-bogusz](https://github.com/will-bogusz)).
 - Devin parallel tool calls follow `compat.supportsParallelToolCalls` instead of being disabled unconditionally, so natively discovered configs that support parallelism can use it ([#8590](https://github.com/can1357/oh-my-pi/pull/8590) by [@will-bogusz](https://github.com/will-bogusz)).
+### Fixed
+
+- Fixed the tool-schema wire lowering skipping `additionalItems`, `contentSchema` and `dependentSchemas`: empty-schema normalization and object closing now descend into every schema-valued position, from one shared inventory instead of three drifting copies.
 
 ## [18.0.11] - 2026-08-29
 

--- a/packages/ai/src/utils/schema/wire.ts
+++ b/packages/ai/src/utils/schema/wire.ts
@@ -235,25 +235,41 @@ export function flattenExclusiveRequiredRootUnion(schema: Record<string, unknown
 	return flattened;
 }
 
-/** Keys whose values are a single JSON Schema (not an array or map). */
-const SCHEMA_VALUE_KEYS = [
-	"additionalProperties",
-	"unevaluatedProperties",
-	"unevaluatedItems",
-	"items",
-	"contains",
-	"propertyNames",
-	"if",
-	"then",
-	"else",
-	"not",
-] as const;
+/**
+ * Every position a JSON Schema document can hold another schema in, grouped by
+ * how the value is shaped. One inventory, because each consumer that keeps its
+ * own copy silently stops covering a keyword the others added: the lowering
+ * passes below, the description strip, and the provider-facing structural test
+ * in coding-agent all read these.
+ *
+ * `value` covers single-subschema keywords, including the legacy
+ * `additionalItems` that may survive an incomplete draft upgrade, and the
+ * array-valued combiners — recursion dispatches on array-ness, so tuple forms
+ * like draft-07 `items: []` are handled by the same arm. `map` covers
+ * `{ name: Schema }` keywords, whose names are NOT annotations.
+ */
+export const SCHEMA_POSITIONS = {
+	value: [
+		"additionalProperties",
+		"unevaluatedProperties",
+		"unevaluatedItems",
+		"items",
+		"additionalItems",
+		"contains",
+		"propertyNames",
+		"contentSchema",
+		"if",
+		"then",
+		"else",
+		"not",
+	],
+	map: ["properties", "patternProperties", "$defs", "definitions", "dependentSchemas"],
+	array: ["anyOf", "oneOf", "allOf", "prefixItems"],
+} as const satisfies Record<"value" | "map" | "array", readonly string[]>;
 
-/** Keys whose values are a map of `{ key: Schema }` entries. */
-const SCHEMA_MAP_KEYS = ["properties", "patternProperties", "$defs", "definitions"] as const;
-
-/** Keys whose values are an array of schemas. */
-const SCHEMA_ARRAY_KEYS = ["anyOf", "oneOf", "allOf", "prefixItems"] as const;
+const SCHEMA_VALUE_KEYS = SCHEMA_POSITIONS.value;
+const SCHEMA_MAP_KEYS = SCHEMA_POSITIONS.map;
+const SCHEMA_ARRAY_KEYS = SCHEMA_POSITIONS.array;
 
 function normalizeArkPropertyComments(node: unknown): void {
 	if (Array.isArray(node)) {
@@ -608,33 +624,10 @@ export function toolWireSchema(tool: Tool): Record<string, unknown> {
 	});
 }
 
-/**
- * Schema-valued keywords whose value is a single subschema (or an array of
- * subschemas — the recursion dispatches on array-ness, so tuple forms like
- * draft-07 `items: []` are handled too). Covers the draft 2020-12 surface plus
- * the legacy `additionalItems` that may survive an incomplete upgrade.
- */
-const STRIP_SCHEMA_VALUE_KEYS = [
-	"additionalProperties",
-	"unevaluatedProperties",
-	"unevaluatedItems",
-	"items",
-	"additionalItems",
-	"contains",
-	"propertyNames",
-	"contentSchema",
-	"if",
-	"then",
-	"else",
-	"not",
-	"anyOf",
-	"oneOf",
-	"allOf",
-	"prefixItems",
-] as const;
+/** Single-subschema and array-valued positions, from the one inventory. */
+const STRIP_SCHEMA_VALUE_KEYS = [...SCHEMA_POSITIONS.value, ...SCHEMA_POSITIONS.array] as const;
 
-/** Keywords whose value is a `{ name: Schema }` map — names are NOT annotations. */
-const STRIP_SCHEMA_MAP_KEYS = ["properties", "patternProperties", "$defs", "definitions", "dependentSchemas"] as const;
+const STRIP_SCHEMA_MAP_KEYS = SCHEMA_POSITIONS.map;
 
 /**
  * Recursively strip human-readable `description` annotations from a JSON Schema,

--- a/packages/coding-agent/src/utils/clipboard.ts
+++ b/packages/coding-agent/src/utils/clipboard.ts
@@ -3,6 +3,7 @@ import {
 	copyToClipboard as nativeCopyToClipboard,
 	readImageFromClipboard as nativeReadImageFromClipboard,
 } from "@oh-my-pi/pi-natives/clipboard";
+import { hasDisplay } from "@oh-my-pi/pi-utils/env";
 import * as logger from "@oh-my-pi/pi-utils/logger";
 import { SUPPORTED_IMAGE_MIME_TYPES } from "@oh-my-pi/pi-utils/mime";
 import MAC_FILE_URL_SCRIPT from "./mac-file-urls.applescript" with { type: "text" };
@@ -56,10 +57,6 @@ async function spawnCapture(
 	} finally {
 		clearTimeout(timer);
 	}
-}
-
-function hasDisplay(): boolean {
-	return process.platform !== "linux" || Boolean(process.env.DISPLAY || process.env.WAYLAND_DISPLAY);
 }
 
 function isWsl(): boolean {

--- a/packages/coding-agent/src/utils/clipboard.ts
+++ b/packages/coding-agent/src/utils/clipboard.ts
@@ -3,9 +3,9 @@ import {
 	copyToClipboard as nativeCopyToClipboard,
 	readImageFromClipboard as nativeReadImageFromClipboard,
 } from "@oh-my-pi/pi-natives/clipboard";
-import { hasDisplay } from "@oh-my-pi/pi-utils/env";
 import * as logger from "@oh-my-pi/pi-utils/logger";
 import { SUPPORTED_IMAGE_MIME_TYPES } from "@oh-my-pi/pi-utils/mime";
+import { hasDisplay } from "./display";
 import MAC_FILE_URL_SCRIPT from "./mac-file-urls.applescript" with { type: "text" };
 
 type SpawnCaptureOptions = { input?: string; timeoutMs?: number };

--- a/packages/coding-agent/src/utils/display.ts
+++ b/packages/coding-agent/src/utils/display.ts
@@ -1,0 +1,16 @@
+/**
+ * True when a GUI can be reached: a window server always exists off Linux,
+ * while X11/Wayland must be advertised through the environment there.
+ *
+ * Shared because clipboard tooling and headful-browser launches gate on the
+ * same fact — two copies would let platform hardening drift apart, and the
+ * failure mode is a hang or an opaque "Missing X server" rather than a clean
+ * skip.
+ *
+ * Deliberately its own module with no imports: `@oh-my-pi/pi-utils/env` would be
+ * the natural home, but that module parses `.env` files at import time, and
+ * `cli.ts` must not pull it in before profile bootstrap runs.
+ */
+export function hasDisplay(): boolean {
+	return process.platform !== "linux" || Boolean(process.env.DISPLAY || process.env.WAYLAND_DISPLAY);
+}

--- a/packages/coding-agent/test/tools/browser-tab-worker-startup.test.ts
+++ b/packages/coding-agent/test/tools/browser-tab-worker-startup.test.ts
@@ -15,9 +15,11 @@ import {
 	initializeTabWorkerForTest,
 	releaseTab,
 } from "@oh-my-pi/pi-coding-agent/tools/browser/tab-supervisor";
-import { chromiumAvailable } from "./chromium-probe";
+import { chromiumAvailable, headfulAvailable } from "./chromium-probe";
 
 const CHROMIUM_AVAILABLE = await chromiumAvailable();
+// The visible-tab case launches `headless: false`, which needs a display.
+const HEADFUL_AVAILABLE = await headfulAvailable();
 
 class FakeStartupWorker {
 	#errorHandlers = new Set<(error: Error) => void>();
@@ -217,7 +219,7 @@ describe("browser init deadline carry-over", () => {
 	);
 });
 describe("visible OMP-owned browser tabs", () => {
-	it.skipIf(!CHROMIUM_AVAILABLE)(
+	it.skipIf(!HEADFUL_AVAILABLE)(
 		"creates independent pages without pinning the resizable window viewport",
 		async () => {
 			let browser: BrowserHandle | undefined;

--- a/packages/coding-agent/test/tools/chromium-probe.ts
+++ b/packages/coding-agent/test/tools/chromium-probe.ts
@@ -1,6 +1,6 @@
 import * as fs from "node:fs/promises";
 import { ensureChromiumExecutable } from "@oh-my-pi/pi-coding-agent/tools/browser/launch";
-import { hasDisplay } from "@oh-my-pi/pi-utils/env";
+import { hasDisplay } from "@oh-my-pi/pi-coding-agent/utils/display";
 
 /**
  * Whether the Chromium puppeteer resolves can actually execute on this host.

--- a/packages/coding-agent/test/tools/chromium-probe.ts
+++ b/packages/coding-agent/test/tools/chromium-probe.ts
@@ -1,5 +1,6 @@
 import * as fs from "node:fs/promises";
 import { ensureChromiumExecutable } from "@oh-my-pi/pi-coding-agent/tools/browser/launch";
+import { hasDisplay } from "@oh-my-pi/pi-utils/env";
 
 /**
  * Whether the Chromium puppeteer resolves can actually execute on this host.
@@ -59,6 +60,5 @@ export function chromiumAvailable(): Promise<boolean> {
  * platforms always have a window server.
  */
 export async function headfulAvailable(): Promise<boolean> {
-	if (!(await chromiumAvailable())) return false;
-	return process.platform !== "linux" || Boolean(process.env.DISPLAY || process.env.WAYLAND_DISPLAY);
+	return (await chromiumAvailable()) && hasDisplay();
 }

--- a/packages/coding-agent/test/tools/chromium-probe.ts
+++ b/packages/coding-agent/test/tools/chromium-probe.ts
@@ -48,3 +48,17 @@ export function chromiumAvailable(): Promise<boolean> {
 	probe ??= chromiumCanLaunch();
 	return probe;
 }
+
+/**
+ * Gate for tests that launch a VISIBLE Chromium (`headless: false`).
+ * {@link chromiumAvailable} only proves the binary execs — `--version` needs no
+ * display — while a headful launch on Linux needs X or Wayland, and puppeteer
+ * fails it with "Missing X server" rather than degrading. CI runners have
+ * neither, so without this the test's outcome depends on which shard it lands
+ * in. Same signal `src/utils/clipboard.ts` uses for the same reason; other
+ * platforms always have a window server.
+ */
+export async function headfulAvailable(): Promise<boolean> {
+	if (!(await chromiumAvailable())) return false;
+	return process.platform !== "linux" || Boolean(process.env.DISPLAY || process.env.WAYLAND_DISPLAY);
+}

--- a/packages/coding-agent/test/tools/tool-schema-structure.test.ts
+++ b/packages/coding-agent/test/tools/tool-schema-structure.test.ts
@@ -50,6 +50,27 @@ interface Erasure {
 	value: "true" | "{}";
 }
 
+// Named allow-list of legitimate unconstrained positions. Each entry must
+// carry a reason; the walk fails on any erasure not listed here. A
+// deliberately unconstrained parameter (z.unknown()/z.any()) honestly emits
+// `properties.<name> = {}` — if a tool gains one, add it here, e.g.:
+// { tool: /^mytool$/, pointer: /\/properties\/whatever$/, reason: "deliberately unconstrained" }
+const ALLOWED_ERASURES: Array<{ tool: RegExp; pointer: RegExp; reason: string }> = [
+	{
+		// yield's user-requested `outputSchema: true` emits a description-only
+		// data schema that escapes normalizeEmptySchemas; pinned to stay
+		// description-only by the dedicated assertion in the yield test.
+		tool: /^yield:/,
+		pointer: /\/data$/,
+		reason: "description-only data schema for outputSchema: true",
+	},
+];
+
+const unexpectedErasures = (erasures: Erasure[]): Erasure[] =>
+	erasures.filter(
+		erasure => !ALLOWED_ERASURES.some(entry => entry.tool.test(erasure.tool) && entry.pointer.test(erasure.pointer)),
+	);
+
 const SCHEMA_MAP_KEYS = new Set(["properties", "$defs", "definitions"]);
 const SCHEMA_ARRAY_KEYS = new Set(["anyOf", "oneOf", "allOf", "prefixItems"]);
 const SCHEMA_VALUE_KEYS = new Set(["items", "not"]);
@@ -134,8 +155,10 @@ describe("discovered tool wire schemas are structurally constrained", () => {
 		for (const tool of await discoveredToolsPromise) {
 			walkSchema(tool.name, "", toolWireSchema(tool), erasures);
 		}
-		expect(erasureMessage(erasures)).toBe("");
-		expect(erasures).toEqual([]);
+		// Anything flagged must be a named allow-list entry (see
+		// ALLOWED_ERASURES); an unlisted erasure is a real regression.
+		expect(erasureMessage(unexpectedErasures(erasures))).toBe("");
+		expect(unexpectedErasures(erasures)).toEqual([]);
 	});
 
 	it("never relays a degenerate fallback base for discovered tools", async () => {
@@ -258,24 +281,29 @@ describe("shipped example extension schemas are structurally constrained", () =>
 	// runtime,with-deps} and examples/custom-tools/hello, re-declared against
 	// the same shim. The example modules themselves are not imported: they
 	// sit outside the package tsconfig and carry pre-existing type errors, so
-	// importing them would force unrelated example fixes into this PR. Their
-	// shapes — plain `pi.zod.object` members with primitives, enums, and
-	// defaults — are exactly the documented authoring surface at risk.
+	// importing them would force unrelated example fixes into this PR. Each
+	// shape mirrors the cited example source; if the example changes its
+	// parameters, update the entry here — the line refs make drift findable.
 	const cases: Array<[string, unknown]> = [
-		["extensions/hello.ts", zod.object({ name: zod.string().describe("Name to greet") })],
+		// examples/extensions/hello.ts:15-17
+		["extensions/hello.ts:15", zod.object({ name: zod.string().describe("Name to greet") })],
+		// examples/extensions/api-demo.ts:19-22
 		[
-			"extensions/api-demo.ts",
+			"extensions/api-demo.ts:19",
 			zod.object({
 				message: zod.string().describe("Test message"),
 				logLevel: zod.enum(["error", "warn", "debug"]).default("debug").describe("Log level to use"),
 			}),
 		],
-		["extensions/reload-runtime.ts", zod.object({})],
+		// examples/extensions/reload-runtime.ts:29
+		["extensions/reload-runtime.ts:29", zod.object({})],
+		// examples/extensions/with-deps/index.ts:19-21
 		[
-			"extensions/with-deps",
+			"extensions/with-deps/index.ts:19",
 			zod.object({ duration: zod.string().describe("Duration string like '2 days', '1h', '5m'") }),
 		],
-		["custom-tools/hello", zod.object({ name: zod.string().describe("Name to greet") })],
+		// examples/custom-tools/hello/index.ts:7-9
+		["custom-tools/hello/index.ts:7", zod.object({ name: zod.string().describe("Name to greet") })],
 	];
 
 	for (const [label, parameters] of cases) {

--- a/packages/coding-agent/test/tools/tool-schema-structure.test.ts
+++ b/packages/coding-agent/test/tools/tool-schema-structure.test.ts
@@ -1,6 +1,4 @@
 import { describe, expect, it } from "bun:test";
-import * as path from "node:path";
-import * as zod from "@oh-my-pi/omptype/zod";
 import type { Tool } from "@oh-my-pi/pi-ai/types";
 import { isArkSchema, toolWireSchema } from "@oh-my-pi/pi-ai/utils/schema";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
@@ -317,88 +315,4 @@ describe("setting- and mode-dependent tool variants stay structurally constraine
 		expect(erasureMessage(unexpectedErasures(erasures))).toBe("");
 		expect(unexpectedErasures(erasures)).toEqual([]);
 	});
-});
-
-/**
- * Registration-time surface the shipped examples touch. A Proxy answers
- * anything else with a no-op, so an example gaining an unrelated API call does
- * not turn this into a false failure — the point is to run the REAL parameter
- * definitions, not to reimplement the extension host.
- */
-function stubExtensionApi(registered: Array<{ name: string; parameters: unknown }>): unknown {
-	const noop = (): unknown => undefined;
-	const record = (definition: { name?: string; parameters?: unknown }): void => {
-		if (definition?.parameters !== undefined) {
-			registered.push({ name: definition.name ?? "unnamed", parameters: definition.parameters });
-		}
-	};
-	const surface: Record<string, unknown> = {
-		zod,
-		logger: new Proxy({}, { get: () => noop }),
-		registerTool: record,
-		registerCommand: (_name: string, definition: { parameters?: unknown }) => record(definition),
-	};
-	return new Proxy(surface, {
-		get: (target, key) => (key in target ? target[key as string] : noop),
-	});
-}
-
-/**
- * Load a shipped example and return the parameter schemas it registers.
- *
- * The specifier is assembled at runtime on purpose: a static import would pull
- * the examples into this package's typecheck, and they sit outside its tsconfig
- * with pre-existing errors. Executing them keeps the contract honest — an
- * example that starts emitting an unconstrained schema fails here, which a
- * re-declared copy of its literals could not catch.
- */
-async function exampleParameters(relativePath: string): Promise<Array<{ name: string; parameters: unknown }>> {
-	const examples = path.resolve(import.meta.dir, "../../examples");
-	const moduleUrl = Bun.pathToFileURL(path.join(examples, relativePath)).href;
-	// Dynamic import exception: a static specifier would drag the examples into
-	// this package's typecheck, where they do not belong (see above).
-	const loaded: { default?: unknown } = await import(moduleUrl);
-	const factory = loaded.default;
-	if (typeof factory !== "function") throw new Error(`${relativePath} has no default export function`);
-	const registered: Array<{ name: string; parameters: unknown }> = [];
-	const api = stubExtensionApi(registered);
-	// Extensions register through the api; custom-tool factories return one
-	// definition directly.
-	const returned = (factory as (api: unknown) => unknown)(api);
-	if (returned !== null && typeof returned === "object") {
-		const definition = returned as { name?: string; parameters?: unknown };
-		if (definition.parameters !== undefined) {
-			registered.push({ name: definition.name ?? relativePath, parameters: definition.parameters });
-		}
-	}
-	if (registered.length === 0) throw new Error(`${relativePath} registered no parameter schemas`);
-	return registered;
-}
-
-describe("shipped example extension schemas are structurally constrained", () => {
-	const examples = [
-		"extensions/hello.ts",
-		"extensions/api-demo.ts",
-		"extensions/reload-runtime.ts",
-		"extensions/with-deps/index.ts",
-		"custom-tools/hello/index.ts",
-	];
-
-	for (const relativePath of examples) {
-		it(`emits a structural schema for examples/${relativePath}`, async () => {
-			const registered = await exampleParameters(relativePath);
-			for (const { name, parameters } of registered) {
-				const label = `${relativePath}#${name}`;
-				const wire = toolWireSchema(asTool("example", label, parameters));
-				const erasures: Erasure[] = [];
-				walkSchema(label, "", wire, erasures);
-				expect(erasureMessage(erasures)).toBe("");
-				// Every example authors with `z.object`, so the wire schema must be
-				// a typed object map (reload-runtime legitimately has no props).
-				const json = wire as Record<string, unknown>;
-				expect(json.type).toBe("object");
-				expect(json.properties).toBeObject();
-			}
-		});
-	}
 });

--- a/packages/coding-agent/test/tools/tool-schema-structure.test.ts
+++ b/packages/coding-agent/test/tools/tool-schema-structure.test.ts
@@ -60,9 +60,23 @@ const ALLOWED_ERASURES: Array<{ tool: RegExp; pointer: RegExp; reason: string }>
 		// yield's user-requested `outputSchema: true` emits a description-only
 		// data schema that escapes normalizeEmptySchemas; pinned to stay
 		// description-only by the dedicated assertion in the yield test.
-		tool: /^yield:/,
+		tool: /^yield(:|$)/,
 		pointer: /\/data$/,
 		reason: "description-only data schema for outputSchema: true",
+	},
+	{
+		// debug.arguments is a record of arbitrary user-supplied arguments: the
+		// open value schema is the declared contract, not an erasure.
+		tool: /^debug$/,
+		pointer: /\/properties\/arguments\/additionalProperties$/,
+		reason: "intentional open record for arbitrary debug arguments",
+	},
+	{
+		// yield's loose outputSchema fallback types data as an open record —
+		// same user-requested near-miss class as the description-only case.
+		tool: /^yield(:|$)/,
+		pointer: /\/data\/additionalProperties$/,
+		reason: "yield's loose outputSchema fallback data record",
 	},
 ];
 
@@ -71,9 +85,28 @@ const unexpectedErasures = (erasures: Erasure[]): Erasure[] =>
 		erasure => !ALLOWED_ERASURES.some(entry => entry.tool.test(erasure.tool) && entry.pointer.test(erasure.pointer)),
 	);
 
-const SCHEMA_MAP_KEYS = new Set(["properties", "$defs", "definitions"]);
-const SCHEMA_ARRAY_KEYS = new Set(["anyOf", "oneOf", "allOf", "prefixItems"]);
-const SCHEMA_VALUE_KEYS = new Set(["items", "not"]);
+// The complete schema-position inventory, mirroring wire.ts's own traversal
+// sets (STRIP_SCHEMA_VALUE_KEYS / STRIP_SCHEMA_MAP_KEYS) so this walk covers
+// exactly the positions the production wire lowering considers schema-valued.
+const SCHEMA_VALUE_KEYS = new Set([
+	"additionalProperties",
+	"unevaluatedProperties",
+	"unevaluatedItems",
+	"items",
+	"additionalItems",
+	"contains",
+	"propertyNames",
+	"contentSchema",
+	"if",
+	"then",
+	"else",
+	"not",
+	"anyOf",
+	"oneOf",
+	"allOf",
+	"prefixItems",
+]);
+const SCHEMA_MAP_KEYS = new Set(["properties", "patternProperties", "$defs", "definitions", "dependentSchemas"]);
 
 function walkSchema(tool: string, pointer: string, node: unknown, erasures: Erasure[]): void {
 	if (node === true) {
@@ -87,23 +120,25 @@ function walkSchema(tool: string, pointer: string, node: unknown, erasures: Eras
 		return;
 	}
 	for (const [key, value] of Object.entries(obj)) {
-		// `additionalProperties: true` is the legitimate open-record marker,
-		// and `properties: {}` paired with a typed `additionalProperties` is a
-		// real, constrained shape (bash.env, hub.env, debug.arguments,
-		// log_experiment.metrics/asi) — neither is an erasure. Map positions
-		// hold per-key subschemas, so an empty map itself is not an erasure.
-		if (key === "additionalProperties") continue;
 		const childPointer = `${pointer}/${key}`;
-		if (SCHEMA_MAP_KEYS.has(key) && value !== null && typeof value === "object" && !Array.isArray(value)) {
+		// Single-subschema and array-of-subschema keywords are dispatched on
+		// array-ness, exactly like wire.ts's traversal — this includes
+		// object-valued `additionalProperties`, which is a record's VALUE
+		// schema (bash.env, hub.env, debug.arguments, log_experiment.*).
+		if (SCHEMA_VALUE_KEYS.has(key)) {
+			if (Array.isArray(value)) {
+				value.forEach((sub, index) => {
+					walkSchema(tool, `${childPointer}/${index}`, sub, erasures);
+				});
+			} else {
+				walkSchema(tool, childPointer, value, erasures);
+			}
+		} else if (SCHEMA_MAP_KEYS.has(key) && value !== null && typeof value === "object" && !Array.isArray(value)) {
+			// Map positions hold per-key subschemas, so an empty map itself is
+			// not an erasure.
 			for (const [name, sub] of Object.entries(value as Record<string, unknown>)) {
 				walkSchema(tool, `${childPointer}/${name}`, sub, erasures);
 			}
-		} else if (SCHEMA_ARRAY_KEYS.has(key) && Array.isArray(value)) {
-			value.forEach((sub, index) => {
-				walkSchema(tool, `${childPointer}/${index}`, sub, erasures);
-			});
-		} else if (SCHEMA_VALUE_KEYS.has(key)) {
-			walkSchema(tool, childPointer, value, erasures);
 		}
 	}
 }
@@ -198,8 +233,8 @@ describe("setting- and mode-dependent tool variants stay structurally constraine
 			const tool = new EditTool(createSession(), mode);
 			walkSchema(`edit:${mode}`, "", toolWireSchema(tool), erasures);
 		}
-		expect(erasureMessage(erasures)).toBe("");
-		expect(erasures).toEqual([]);
+		expect(erasureMessage(unexpectedErasures(erasures))).toBe("");
+		expect(unexpectedErasures(erasures)).toEqual([]);
 	});
 
 	it("covers the task schema flag combinations", () => {
@@ -215,16 +250,16 @@ describe("setting- and mode-dependent tool variants stay structurally constraine
 			const wire = toolWireSchema(asTool(`task:combo${index}`, "task variant", parameters));
 			walkSchema(`task:combo${index}`, "", wire, erasures);
 		}
-		expect(erasureMessage(erasures)).toBe("");
-		expect(erasures).toEqual([]);
+		expect(erasureMessage(unexpectedErasures(erasures))).toBe("");
+		expect(unexpectedErasures(erasures)).toEqual([]);
 	});
 
 	it("covers the async bash variant", () => {
 		const tool = new BashTool(createSession({ "async.enabled": true }));
 		const erasures: Erasure[] = [];
 		walkSchema("bash:async", "", toolWireSchema(tool), erasures);
-		expect(erasureMessage(erasures)).toBe("");
-		expect(erasures).toEqual([]);
+		expect(erasureMessage(unexpectedErasures(erasures))).toBe("");
+		expect(unexpectedErasures(erasures)).toEqual([]);
 	});
 
 	it("covers every yield outputSchema path and keeps the `true` case description-only", () => {
@@ -246,13 +281,20 @@ describe("setting- and mode-dependent tool variants stay structurally constraine
 			const tool = new YieldTool(createSession({ "~outputSchema": outputSchema }));
 			walkSchema(`yield:${label}`, "", toolWireSchema(tool), erasures);
 		}
-		expect(erasureMessage(erasures)).toBe("");
-		expect(erasures).toEqual([]);
+		expect(erasureMessage(unexpectedErasures(erasures))).toBe("");
+		expect(unexpectedErasures(erasures)).toEqual([]);
 
 		const trueCase = toolWireSchema(new YieldTool(createSession({ "~outputSchema": true })));
 		const data = findDataProperty(trueCase);
-		expect(data).toBeDefined();
-		expect(Object.keys(data as Record<string, unknown>)).toEqual(["description"]);
+		const dataKeys = Object.keys(data as Record<string, unknown>);
+		// The `true` outputSchema case stays non-structural: a description plus
+		// (after normalizeEmptySchemas) an open additionalProperties — never a
+		// schema constraint the provider would enforce or misread.
+		expect(dataKeys.every(key => key === "description" || key === "additionalProperties")).toBe(true);
+		// additionalProperties, when present (the loose-fallback shapes), is the
+		// open-record marker only — never a structural constraint.
+		const additional = (data as Record<string, unknown>).additionalProperties;
+		expect(additional === undefined || additional === true).toBe(true);
 		expect(typeof (data as Record<string, unknown>).description).toBe("string");
 	});
 
@@ -271,8 +313,8 @@ describe("setting- and mode-dependent tool variants stay structurally constraine
 		for (const tool of tools) {
 			walkSchema(tool.name, "", toolWireSchema(tool), erasures);
 		}
-		expect(erasureMessage(erasures)).toBe("");
-		expect(erasures).toEqual([]);
+		expect(erasureMessage(unexpectedErasures(erasures))).toBe("");
+		expect(unexpectedErasures(erasures)).toEqual([]);
 	});
 });
 

--- a/packages/coding-agent/test/tools/tool-schema-structure.test.ts
+++ b/packages/coding-agent/test/tools/tool-schema-structure.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import type { Tool } from "@oh-my-pi/pi-ai/types";
-import { isArkSchema, toolWireSchema } from "@oh-my-pi/pi-ai/utils/schema";
+import { isArkSchema, SCHEMA_POSITIONS, toolWireSchema } from "@oh-my-pi/pi-ai/utils/schema";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { createTools, HIDDEN_TOOLS, type ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
 import { MemoryEditTool } from "@oh-my-pi/pi-coding-agent/tools/memory-edit";
@@ -84,28 +84,11 @@ const unexpectedErasures = (erasures: Erasure[]): Erasure[] =>
 		erasure => !ALLOWED_ERASURES.some(entry => entry.tool.test(erasure.tool) && entry.pointer.test(erasure.pointer)),
 	);
 
-// The complete schema-position inventory, mirroring wire.ts's own traversal
-// sets (STRIP_SCHEMA_VALUE_KEYS / STRIP_SCHEMA_MAP_KEYS) so this walk covers
-// exactly the positions the production wire lowering considers schema-valued.
-const SCHEMA_VALUE_KEYS = new Set([
-	"additionalProperties",
-	"unevaluatedProperties",
-	"unevaluatedItems",
-	"items",
-	"additionalItems",
-	"contains",
-	"propertyNames",
-	"contentSchema",
-	"if",
-	"then",
-	"else",
-	"not",
-	"anyOf",
-	"oneOf",
-	"allOf",
-	"prefixItems",
-]);
-const SCHEMA_MAP_KEYS = new Set(["properties", "patternProperties", "$defs", "definitions", "dependentSchemas"]);
+// Driven by wire.ts's own inventory, not a copy of it: a keyword added to the
+// production lowering has to widen this walk too, or an unconstrained subtree
+// under it would go unreported.
+const SCHEMA_VALUE_KEYS: ReadonlySet<string> = new Set<string>([...SCHEMA_POSITIONS.value, ...SCHEMA_POSITIONS.array]);
+const SCHEMA_MAP_KEYS: ReadonlySet<string> = new Set<string>(SCHEMA_POSITIONS.map);
 
 function walkSchema(tool: string, pointer: string, node: unknown, erasures: Erasure[]): void {
 	if (node === true) {

--- a/packages/coding-agent/test/tools/tool-schema-structure.test.ts
+++ b/packages/coding-agent/test/tools/tool-schema-structure.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import * as path from "node:path";
 import * as zod from "@oh-my-pi/omptype/zod";
 import type { Tool } from "@oh-my-pi/pi-ai/types";
 import { isArkSchema, toolWireSchema } from "@oh-my-pi/pi-ai/utils/schema";
@@ -318,42 +319,86 @@ describe("setting- and mode-dependent tool variants stay structurally constraine
 	});
 });
 
+/**
+ * Registration-time surface the shipped examples touch. A Proxy answers
+ * anything else with a no-op, so an example gaining an unrelated API call does
+ * not turn this into a false failure — the point is to run the REAL parameter
+ * definitions, not to reimplement the extension host.
+ */
+function stubExtensionApi(registered: Array<{ name: string; parameters: unknown }>): unknown {
+	const noop = (): unknown => undefined;
+	const record = (definition: { name?: string; parameters?: unknown }): void => {
+		if (definition?.parameters !== undefined) {
+			registered.push({ name: definition.name ?? "unnamed", parameters: definition.parameters });
+		}
+	};
+	const surface: Record<string, unknown> = {
+		zod,
+		logger: new Proxy({}, { get: () => noop }),
+		registerTool: record,
+		registerCommand: (_name: string, definition: { parameters?: unknown }) => record(definition),
+	};
+	return new Proxy(surface, {
+		get: (target, key) => (key in target ? target[key as string] : noop),
+	});
+}
+
+/**
+ * Load a shipped example and return the parameter schemas it registers.
+ *
+ * The specifier is assembled at runtime on purpose: a static import would pull
+ * the examples into this package's typecheck, and they sit outside its tsconfig
+ * with pre-existing errors. Executing them keeps the contract honest — an
+ * example that starts emitting an unconstrained schema fails here, which a
+ * re-declared copy of its literals could not catch.
+ */
+async function exampleParameters(relativePath: string): Promise<Array<{ name: string; parameters: unknown }>> {
+	const examples = path.resolve(import.meta.dir, "../../examples");
+	const moduleUrl = Bun.pathToFileURL(path.join(examples, relativePath)).href;
+	// Dynamic import exception: a static specifier would drag the examples into
+	// this package's typecheck, where they do not belong (see above).
+	const loaded: { default?: unknown } = await import(moduleUrl);
+	const factory = loaded.default;
+	if (typeof factory !== "function") throw new Error(`${relativePath} has no default export function`);
+	const registered: Array<{ name: string; parameters: unknown }> = [];
+	const api = stubExtensionApi(registered);
+	// Extensions register through the api; custom-tool factories return one
+	// definition directly.
+	const returned = (factory as (api: unknown) => unknown)(api);
+	if (returned !== null && typeof returned === "object") {
+		const definition = returned as { name?: string; parameters?: unknown };
+		if (definition.parameters !== undefined) {
+			registered.push({ name: definition.name ?? relativePath, parameters: definition.parameters });
+		}
+	}
+	if (registered.length === 0) throw new Error(`${relativePath} registered no parameter schemas`);
+	return registered;
+}
+
 describe("shipped example extension schemas are structurally constrained", () => {
-	// The parameter schemas of the shipped examples, re-declared against the
-	// same shim, one row per distinct emitted shape. The example modules
-	// themselves are not imported: they sit outside the package tsconfig and
-	// carry pre-existing type errors, so importing them would force unrelated
-	// example fixes into this PR. Each shape mirrors the cited example source;
-	// if the example changes its parameters, update the entry here — the line
-	// refs make drift findable. examples/extensions/with-deps/index.ts:19 and
-	// examples/custom-tools/hello/index.ts:7 are deliberately absent: both are
-	// the single-described-string shape the hello row already covers.
-	const cases: Array<[string, unknown]> = [
-		// examples/extensions/hello.ts:15-17 — single described string prop
-		["extensions/hello.ts:15", zod.object({ name: zod.string().describe("Name to greet") })],
-		// examples/extensions/api-demo.ts:19-22 — enum with a default payload
-		[
-			"extensions/api-demo.ts:19",
-			zod.object({
-				message: zod.string().describe("Test message"),
-				logLevel: zod.enum(["error", "warn", "debug"]).default("debug").describe("Log level to use"),
-			}),
-		],
-		// examples/extensions/reload-runtime.ts:29 — no properties at all
-		["extensions/reload-runtime.ts:29", zod.object({})],
+	const examples = [
+		"extensions/hello.ts",
+		"extensions/api-demo.ts",
+		"extensions/reload-runtime.ts",
+		"extensions/with-deps/index.ts",
+		"custom-tools/hello/index.ts",
 	];
 
-	for (const [label, parameters] of cases) {
-		it(`emits a structural schema for ${label}`, () => {
-			const wire = toolWireSchema(asTool("example", label, parameters));
-			const erasures: Erasure[] = [];
-			walkSchema(label, "", wire, erasures);
-			expect(erasures).toEqual([]);
-			// A plain z.object must emit a typed object map (z.object({}) in
-			// reload-runtime legitimately has no properties).
-			const json = wire as Record<string, unknown>;
-			expect(json.type).toBe("object");
-			expect(json.properties).toBeObject();
+	for (const relativePath of examples) {
+		it(`emits a structural schema for examples/${relativePath}`, async () => {
+			const registered = await exampleParameters(relativePath);
+			for (const { name, parameters } of registered) {
+				const label = `${relativePath}#${name}`;
+				const wire = toolWireSchema(asTool("example", label, parameters));
+				const erasures: Erasure[] = [];
+				walkSchema(label, "", wire, erasures);
+				expect(erasureMessage(erasures)).toBe("");
+				// Every example authors with `z.object`, so the wire schema must be
+				// a typed object map (reload-runtime legitimately has no props).
+				const json = wire as Record<string, unknown>;
+				expect(json.type).toBe("object");
+				expect(json.properties).toBeObject();
+			}
 		});
 	}
 });

--- a/packages/coding-agent/test/tools/tool-schema-structure.test.ts
+++ b/packages/coding-agent/test/tools/tool-schema-structure.test.ts
@@ -319,17 +319,19 @@ describe("setting- and mode-dependent tool variants stay structurally constraine
 });
 
 describe("shipped example extension schemas are structurally constrained", () => {
-	// The parameter schemas of examples/extensions/{hello,api-demo,reload-
-	// runtime,with-deps} and examples/custom-tools/hello, re-declared against
-	// the same shim. The example modules themselves are not imported: they
-	// sit outside the package tsconfig and carry pre-existing type errors, so
-	// importing them would force unrelated example fixes into this PR. Each
-	// shape mirrors the cited example source; if the example changes its
-	// parameters, update the entry here — the line refs make drift findable.
+	// The parameter schemas of the shipped examples, re-declared against the
+	// same shim, one row per distinct emitted shape. The example modules
+	// themselves are not imported: they sit outside the package tsconfig and
+	// carry pre-existing type errors, so importing them would force unrelated
+	// example fixes into this PR. Each shape mirrors the cited example source;
+	// if the example changes its parameters, update the entry here — the line
+	// refs make drift findable. examples/extensions/with-deps/index.ts:19 and
+	// examples/custom-tools/hello/index.ts:7 are deliberately absent: both are
+	// the single-described-string shape the hello row already covers.
 	const cases: Array<[string, unknown]> = [
-		// examples/extensions/hello.ts:15-17
+		// examples/extensions/hello.ts:15-17 — single described string prop
 		["extensions/hello.ts:15", zod.object({ name: zod.string().describe("Name to greet") })],
-		// examples/extensions/api-demo.ts:19-22
+		// examples/extensions/api-demo.ts:19-22 — enum with a default payload
 		[
 			"extensions/api-demo.ts:19",
 			zod.object({
@@ -337,15 +339,8 @@ describe("shipped example extension schemas are structurally constrained", () =>
 				logLevel: zod.enum(["error", "warn", "debug"]).default("debug").describe("Log level to use"),
 			}),
 		],
-		// examples/extensions/reload-runtime.ts:29
+		// examples/extensions/reload-runtime.ts:29 — no properties at all
 		["extensions/reload-runtime.ts:29", zod.object({})],
-		// examples/extensions/with-deps/index.ts:19-21
-		[
-			"extensions/with-deps/index.ts:19",
-			zod.object({ duration: zod.string().describe("Duration string like '2 days', '1h', '5m'") }),
-		],
-		// examples/custom-tools/hello/index.ts:7-9
-		["custom-tools/hello/index.ts:7", zod.object({ name: zod.string().describe("Name to greet") })],
 	];
 
 	for (const [label, parameters] of cases) {

--- a/packages/coding-agent/test/tools/tool-schema-structure.test.ts
+++ b/packages/coding-agent/test/tools/tool-schema-structure.test.ts
@@ -1,0 +1,294 @@
+import { describe, expect, it } from "bun:test";
+import * as zod from "@oh-my-pi/omptype/zod";
+import type { Tool } from "@oh-my-pi/pi-ai/types";
+import { isArkSchema, toolWireSchema } from "@oh-my-pi/pi-ai/utils/schema";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { createTools, HIDDEN_TOOLS, type ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+import { MemoryEditTool } from "@oh-my-pi/pi-coding-agent/tools/memory-edit";
+import { MemoryRecallTool } from "@oh-my-pi/pi-coding-agent/tools/memory-recall";
+import { MemoryReflectTool } from "@oh-my-pi/pi-coding-agent/tools/memory-reflect";
+import { MemoryRetainTool } from "@oh-my-pi/pi-coding-agent/tools/memory-retain";
+import { createVibeTools } from "@oh-my-pi/pi-coding-agent/tools/vibe";
+import { YieldTool } from "@oh-my-pi/pi-coding-agent/tools/yield";
+import { EditTool } from "../../src/edit";
+import { getTaskSchema } from "../../src/task/types";
+import { BashTool } from "../../src/tools/bash";
+import { EDIT_MODES } from "../../src/utils/edit-mode";
+
+/**
+ * Provider-facing structural contract: `toolWireSchema` output is the
+ * parameter schema every model sees on all 11 provider adapters. A `true` or
+ * `{}` in a schema position means the model perceives the parameter as
+ * unconstrained — the failure presents as "the model gets it wrong", never as
+ * an error. Assert on boolean `true`, NOT on `{}`: `normalizeEmptySchemas`
+ * rewrites `{}` to `true` before a provider sees the schema, so an
+ * "expect no `{}`" assertion silently passes while the schema is erased.
+ */
+
+function createSession(overrides: Record<string, unknown> = {}): ToolSession {
+	return {
+		cwd: "/tmp/test",
+		hasUI: true,
+		getSessionFile: () => null,
+		getSessionSpawns: () => "*",
+		outputSchema: overrides["~outputSchema"],
+		settings: Settings.isolated({ "tools.xdev": false, ...overrides }),
+	};
+}
+
+function asTool(name: string, description: string, parameters: unknown): Tool {
+	// Test fixture: real tools are class instances; only the wire-facing
+	// surface (name/description/parameters) participates here.
+	return { name, description, parameters } as unknown as Tool;
+}
+
+// ── erasure walk ─────────────────────────────────────────────────────────────
+
+interface Erasure {
+	tool: string;
+	pointer: string;
+	value: "true" | "{}";
+}
+
+const SCHEMA_MAP_KEYS = new Set(["properties", "$defs", "definitions"]);
+const SCHEMA_ARRAY_KEYS = new Set(["anyOf", "oneOf", "allOf", "prefixItems"]);
+const SCHEMA_VALUE_KEYS = new Set(["items", "not"]);
+
+function walkSchema(tool: string, pointer: string, node: unknown, erasures: Erasure[]): void {
+	if (node === true) {
+		erasures.push({ tool, pointer, value: "true" });
+		return;
+	}
+	if (node === null || typeof node !== "object" || Array.isArray(node)) return;
+	const obj = node as Record<string, unknown>;
+	if (Object.keys(obj).length === 0) {
+		erasures.push({ tool, pointer, value: "{}" });
+		return;
+	}
+	for (const [key, value] of Object.entries(obj)) {
+		// `additionalProperties: true` is the legitimate open-record marker,
+		// and `properties: {}` paired with a typed `additionalProperties` is a
+		// real, constrained shape (bash.env, hub.env, debug.arguments,
+		// log_experiment.metrics/asi) — neither is an erasure. Map positions
+		// hold per-key subschemas, so an empty map itself is not an erasure.
+		if (key === "additionalProperties") continue;
+		const childPointer = `${pointer}/${key}`;
+		if (SCHEMA_MAP_KEYS.has(key) && value !== null && typeof value === "object" && !Array.isArray(value)) {
+			for (const [name, sub] of Object.entries(value as Record<string, unknown>)) {
+				walkSchema(tool, `${childPointer}/${name}`, sub, erasures);
+			}
+		} else if (SCHEMA_ARRAY_KEYS.has(key) && Array.isArray(value)) {
+			value.forEach((sub, index) => {
+				walkSchema(tool, `${childPointer}/${index}`, sub, erasures);
+			});
+		} else if (SCHEMA_VALUE_KEYS.has(key)) {
+			walkSchema(tool, childPointer, value, erasures);
+		}
+	}
+}
+
+function erasureMessage(erasures: Erasure[]): string {
+	return erasures.map(erasure => `${erasure.tool} ${erasure.pointer} → ${erasure.value}`).join("\n");
+}
+
+/** Depth-first lookup of a property literally named `data`. */
+function findDataProperty(node: unknown): Record<string, unknown> | undefined {
+	if (Array.isArray(node)) {
+		for (const entry of node) {
+			const found = findDataProperty(entry);
+			if (found !== undefined) return found;
+		}
+		return undefined;
+	}
+	if (node === null || typeof node !== "object") return undefined;
+	const obj = node as Record<string, unknown>;
+	for (const [key, value] of Object.entries(obj)) {
+		if (key === "data" && value !== null && typeof value === "object" && !Array.isArray(value)) {
+			return value as Record<string, unknown>;
+		}
+		const found = findDataProperty(value);
+		if (found !== undefined) return found;
+	}
+	return undefined;
+}
+
+// ── discovered tool population ───────────────────────────────────────────────
+
+async function discoverTools(): Promise<Tool[]> {
+	const session = createSession();
+	const byName = new Map<string, Tool>();
+	for (const tool of await createTools(session)) byName.set(tool.name, tool);
+	for (const name in HIDDEN_TOOLS) {
+		const tool = await HIDDEN_TOOLS[name as keyof typeof HIDDEN_TOOLS](session);
+		if (tool) byName.set(name, tool);
+	}
+	for (const tool of createVibeTools(session)) byName.set(tool.name, tool);
+	return [...byName.values()];
+}
+
+const discoveredToolsPromise = discoverTools();
+
+describe("discovered tool wire schemas are structurally constrained", () => {
+	it("emits no unconstrained `true`/`{}` in any schema position", async () => {
+		const erasures: Erasure[] = [];
+		for (const tool of await discoveredToolsPromise) {
+			walkSchema(tool.name, "", toolWireSchema(tool), erasures);
+		}
+		expect(erasureMessage(erasures)).toBe("");
+		expect(erasures).toEqual([]);
+	});
+
+	it("never relays a degenerate fallback base for discovered tools", async () => {
+		// The fallback hook fires when omptype meets a node it cannot emit
+		// natively; wire.ts relays `ctx => ctx.base`, so the base IS what the
+		// provider sees. A degenerate base (`{}`) is the erasure class this PR
+		// exists to kill. Stepped subschemas (e.g. ask's `narrow`) also invoke
+		// the hook, but relay a fully structural base — benign by design, and
+		// asserted benign right here rather than silently allow-listed.
+		const degenerate: string[] = [];
+		let invocations = 0;
+		for (const tool of await discoveredToolsPromise) {
+			const params: unknown = tool.parameters;
+			if (!isArkSchema(params)) continue;
+			params.toJsonSchema({
+				target: "draft-2020-12",
+				fallback: ctx => {
+					invocations++;
+					const base = JSON.stringify(ctx.base);
+					if (base === "{}" || base === "true") degenerate.push(tool.name);
+					return ctx.base;
+				},
+			});
+		}
+		// ask's stepped narrow exercises the hook with a structural base; the
+		// assertion below pins that NO invocation degrades, not that the hook
+		// never fires.
+		expect(degenerate).toEqual([]);
+		expect(invocations).toBeGreaterThan(0);
+	});
+});
+
+describe("setting- and mode-dependent tool variants stay structurally constrained", () => {
+	it("covers every edit mode", () => {
+		const erasures: Erasure[] = [];
+		for (const mode of EDIT_MODES) {
+			const tool = new EditTool(createSession(), mode);
+			walkSchema(`edit:${mode}`, "", toolWireSchema(tool), erasures);
+		}
+		expect(erasureMessage(erasures)).toBe("");
+		expect(erasures).toEqual([]);
+	});
+
+	it("covers the task schema flag combinations", () => {
+		const erasures: Erasure[] = [];
+		const combos = [
+			{ isolationEnabled: true, batchEnabled: false },
+			{ isolationEnabled: false, batchEnabled: true },
+			{ isolationEnabled: true, batchEnabled: true },
+			{ isolationEnabled: false, batchEnabled: false, effortEnabled: true },
+		];
+		for (const [index, combo] of combos.entries()) {
+			const parameters = getTaskSchema(combo);
+			const wire = toolWireSchema(asTool(`task:combo${index}`, "task variant", parameters));
+			walkSchema(`task:combo${index}`, "", wire, erasures);
+		}
+		expect(erasureMessage(erasures)).toBe("");
+		expect(erasures).toEqual([]);
+	});
+
+	it("covers the async bash variant", () => {
+		const tool = new BashTool(createSession({ "async.enabled": true }));
+		const erasures: Erasure[] = [];
+		walkSchema("bash:async", "", toolWireSchema(tool), erasures);
+		expect(erasureMessage(erasures)).toBe("");
+		expect(erasures).toEqual([]);
+	});
+
+	it("covers every yield outputSchema path and keeps the `true` case description-only", () => {
+		// yield's outputSchema reaches the wire as a `data` property; the
+		// user-requested `true` case deliberately emits an unconstrained
+		// description string that escapes normalizeEmptySchemas. It must stay
+		// description-only: any structural `true`/`{}` would be a real erasure.
+		const outputSchemas: Array<[string, unknown]> = [
+			[
+				"strict",
+				{ type: "object", properties: { x: { type: "string" } }, required: ["x"], additionalProperties: false },
+			],
+			["non-strict", { type: "object", properties: { x: { type: "string" } } }],
+			["true", true],
+			["invalid", { type: "definitely-not-a-type" }],
+		];
+		const erasures: Erasure[] = [];
+		for (const [label, outputSchema] of outputSchemas) {
+			const tool = new YieldTool(createSession({ "~outputSchema": outputSchema }));
+			walkSchema(`yield:${label}`, "", toolWireSchema(tool), erasures);
+		}
+		expect(erasureMessage(erasures)).toBe("");
+		expect(erasures).toEqual([]);
+
+		const trueCase = toolWireSchema(new YieldTool(createSession({ "~outputSchema": true })));
+		const data = findDataProperty(trueCase);
+		expect(data).toBeDefined();
+		expect(Object.keys(data as Record<string, unknown>)).toEqual(["description"]);
+		expect(typeof (data as Record<string, unknown>).description).toBe("string");
+	});
+
+	it("constructs the memory tools directly and walks their schemas", () => {
+		// createIf returns null without a memory backend, which would silently
+		// drop these from discovery-based coverage; construct directly.
+		const hindsight = createSession({ "memory.backend": "hindsight" });
+		const mnemopi = createSession({ "memory.backend": "mnemopi" });
+		const tools = [
+			new MemoryEditTool(mnemopi),
+			new MemoryRecallTool(hindsight),
+			new MemoryReflectTool(hindsight),
+			new MemoryRetainTool(hindsight),
+		];
+		const erasures: Erasure[] = [];
+		for (const tool of tools) {
+			walkSchema(tool.name, "", toolWireSchema(tool), erasures);
+		}
+		expect(erasureMessage(erasures)).toBe("");
+		expect(erasures).toEqual([]);
+	});
+});
+
+describe("shipped example extension schemas are structurally constrained", () => {
+	// The parameter schemas of examples/extensions/{hello,api-demo,reload-
+	// runtime,with-deps} and examples/custom-tools/hello, re-declared against
+	// the same shim. The example modules themselves are not imported: they
+	// sit outside the package tsconfig and carry pre-existing type errors, so
+	// importing them would force unrelated example fixes into this PR. Their
+	// shapes — plain `pi.zod.object` members with primitives, enums, and
+	// defaults — are exactly the documented authoring surface at risk.
+	const cases: Array<[string, unknown]> = [
+		["extensions/hello.ts", zod.object({ name: zod.string().describe("Name to greet") })],
+		[
+			"extensions/api-demo.ts",
+			zod.object({
+				message: zod.string().describe("Test message"),
+				logLevel: zod.enum(["error", "warn", "debug"]).default("debug").describe("Log level to use"),
+			}),
+		],
+		["extensions/reload-runtime.ts", zod.object({})],
+		[
+			"extensions/with-deps",
+			zod.object({ duration: zod.string().describe("Duration string like '2 days', '1h', '5m'") }),
+		],
+		["custom-tools/hello", zod.object({ name: zod.string().describe("Name to greet") })],
+	];
+
+	for (const [label, parameters] of cases) {
+		it(`emits a structural schema for ${label}`, () => {
+			const wire = toolWireSchema(asTool("example", label, parameters));
+			const erasures: Erasure[] = [];
+			walkSchema(label, "", wire, erasures);
+			expect(erasures).toEqual([]);
+			// A plain z.object must emit a typed object map (z.object({}) in
+			// reload-runtime legitimately has no properties).
+			const json = wire as Record<string, unknown>;
+			expect(json.type).toBe("object");
+			expect(json.properties).toBeObject();
+		});
+	}
+});

--- a/packages/omptype/CHANGELOG.md
+++ b/packages/omptype/CHANGELOG.md
@@ -9,10 +9,18 @@
 ### Fixed
 
 - Fixed `z.union`, `z.discriminatedUnion`, `.optional()`, and `.nullable()` throwing `unordered union with overlapping morph inputs is indeterminate` at construction when a member was a plain (key-stripping) `z.object` overlapping another member or a `.catch()` schema — any plugin, hook, or custom tool declaring that shape failed to load; those combinators now dispatch first-match like Zod. Only that fallback's JSON Schema is unconstrained (`{}`); every member set omptype can combine order-independently still emits its real structure.
+- Fixed Zod-shim object schemas accepting input Zod rejects: arrays, `Date`, `Map`, `Set` and promises no longer pass `z.object`, `z.strictObject`, `z.looseObject`, `z.record`, the object mode changes, or a discriminated union, and the restriction survives `.partial()`, `.in`/`.out`, intersections, definition spreads and nesting at any depth. Class instances and plain objects remain object input, as in Zod.
+- Fixed `z.union([z.object(…), z.array(…)])` — and the same union against `Date`/`Map`/`Set`/`Promise` — emitting an unconstrained schema or failing to construct: those members are now provably disjoint, so the union keeps its structural `anyOf`.
+- Fixed `z.discriminatedUnion` silently behaving like an ordinary union: a variant that is not an object, does not declare the discriminator, or leaves its value set open (`kind: z.string()`) is now rejected at definition, as are two variants claiming the same value or both accepting the key missing. Literal unions that normalize to `boolean` still dispatch, and `z.lazy` variants are checked once their getter has run.
+- Fixed `Type.in` dropping input-side `filter` steps, which let it admit values the schema itself rejects.
+- Fixed `z.infer` reporting an optional property as required after `.describe()`, `.readonly()`, `.refine()`, `.transform()`, `.catch()` or `.nullable()`, contradicting the parse that accepts the key's absence.
+- Fixed `z.lazy()` dropping the resolved schema's `.refine()`/`.transform()`/`.catch()` steps, so a recursive schema accepted values its own refinement rejects.
+- Fixed `.readonly()` corrupting its own output: non-enumerable properties, accessors, sparse array holes and custom array properties survive the freeze, and `.readonly()` before `.partial()`/`.passthrough()` now applies the freeze over the new object policy.
 
 ### Changed
 
 - `.default()` follows Zod 4's output-default contract: the fallback is returned as-is instead of being re-validated through the input schema, and a mutable default (`.default({})`) no longer has to be spelled as a factory. Composed positions (`.describe()`, object embedding) still validate the fallback at construction.
+- `z.strictObject`/`z.looseObject` hand back the input object itself when validation succeeds, where Zod always builds a new one; only key-stripping (`z.object`) allocates. Documented rather than changed, because allocating would make overlapping loose-object unions indeterminate and erase their provider-facing schema.
 
 ## [17.3.1] - 2026-08-13
 

--- a/packages/omptype/CHANGELOG.md
+++ b/packages/omptype/CHANGELOG.md
@@ -4,14 +4,14 @@
 
 ### Fixed
 
-- Fixed the Zod shim (`@oh-my-pi/omptype/zod`) erasing tool parameter schemas to unconstrained `{}`: `.nullable()`, `.optional()`, and `.default()` over `z.object`, `z.discriminatedUnion` over `z.object` variants, and unions of disjoint `z.object` members now emit their real structure instead of a dispatcher placeholder. Parsing is unchanged, but a tool whose parameters previously reached the model unconstrained now has its declared shape enforced by the provider.
+- Fixed the Zod shim (`@oh-my-pi/omptype/zod`) erasing tool parameter schemas to unconstrained `{}`: `.nullable()`, `.optional()`, and `.default()` over `z.object` — including objects containing stepped (`.transform()`, `.refine()`, `.readonly()`) or `.default()`-filled properties — `z.discriminatedUnion` over `z.object` variants, and unions of disjoint `z.object` members now emit their real structure instead of a dispatcher placeholder, and a tool whose parameters previously reached the model unconstrained now has its declared shape enforced by the provider. Parse acceptance and outputs are otherwise unchanged, with one deliberate exception: `.default()` on a shim schema now follows Zod 4's output-default contract (the fallback is returned as-is rather than re-validated through the input schema), which can accept a default standalone that older composed positions (`.describe()`/object embedding) validated — a follow-up will unify the default path end to end.
 
 ### Added
 
 - `z.lazy()` now builds on the IR's cycle-safe alias node, so recursive parameter schemas export as real `$ref`/`$defs` documents instead of erasing to `{}`.
 - `.readonly()` now shallow-freezes parse output like Zod, without freezing the caller's input graph.
 
-Schema erasure remains for shapes omptype's unordered unions cannot represent deterministically. Recursion through **required** array/record edges exports structurally as `$ref`/`$defs`; **optional or nullable recursive edges** (`next: self.optional()`, `z.array(self).optional()`) keep the ordered dispatcher and erase, as does a `z.union` of `z.lazy` members. Disjoint member sets (distinct discriminator literals, `strictObject` members, differing required keys, null/undefined widening) all emit structurally. Follow-ups: extend alias deferral to the union determinism probe with a conservative disjointness rule for deferred members, and derive stable `$defs` names (current keys depend on schema construction order).
+Schema erasure remains for shapes omptype's unordered unions cannot represent deterministically. Recursion through **required** array/record edges exports structurally as `$ref`/`$defs`; **optional or nullable recursive edges** (`next: self.optional()`, `z.array(self).optional()`) keep the ordered dispatcher and erase, as does a `z.union` of `z.lazy` members or an object containing one. Disjoint member sets — distinct discriminator literals, `strictObject` members, null/undefined widening (the constraints must actually prove the members disjoint, e.g. conflicting required literals or strict rejection of the other member's required key) — all emit structurally. Follow-ups: extend alias deferral to the union determinism probe with a conservative disjointness rule for deferred members, and derive stable `$defs` names (current keys depend on schema construction order).
 
 ## [17.3.1] - 2026-08-13
 

--- a/packages/omptype/CHANGELOG.md
+++ b/packages/omptype/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the Zod shim (`@oh-my-pi/omptype/zod`) erasing tool parameter schemas to unconstrained `{}`: `.nullable()`, `.optional()`, and `.default()` over `z.object`, `z.discriminatedUnion` over `z.object` variants, and unions of disjoint `z.object` members now emit their real structure instead of a dispatcher placeholder. Parsing is unchanged, but a tool whose parameters previously reached the model unconstrained now has its declared shape enforced by the provider.
+
+### Added
+
+- `z.lazy()` now builds on the IR's cycle-safe alias node, so recursive parameter schemas export as real `$ref`/`$defs` documents instead of erasing to `{}`.
+- `.readonly()` now shallow-freezes parse output like Zod, without freezing the caller's input graph.
+
+Schema erasure remains for shapes omptype's unordered unions cannot represent deterministically. Recursion through **required** array/record edges exports structurally as `$ref`/`$defs`; **optional or nullable recursive edges** (`next: self.optional()`, `z.array(self).optional()`) keep the ordered dispatcher and erase, as does a `z.union` of `z.lazy` members. Disjoint member sets (distinct discriminator literals, `strictObject` members, differing required keys, null/undefined widening) all emit structurally. Follow-ups: extend alias deferral to the union determinism probe with a conservative disjointness rule for deferred members, and derive stable `$defs` names (current keys depend on schema construction order).
+
 ## [17.3.1] - 2026-08-13
 
 ### Fixed

--- a/packages/omptype/CHANGELOG.md
+++ b/packages/omptype/CHANGELOG.md
@@ -2,16 +2,17 @@
 
 ## [Unreleased]
 
-### Fixed
-
-- Fixed the Zod shim (`@oh-my-pi/omptype/zod`) erasing tool parameter schemas to unconstrained `{}`: `.nullable()`, `.optional()`, and `.default()` over `z.object` — including objects containing stepped (`.transform()`, `.refine()`, `.readonly()`) or `.default()`-filled properties — `z.discriminatedUnion` over `z.object` variants, and unions of disjoint `z.object` members now emit their real structure instead of a dispatcher placeholder, and a tool whose parameters previously reached the model unconstrained now has its declared shape enforced by the provider. Parse acceptance and outputs are otherwise unchanged, with one deliberate exception: `.default()` on a shim schema now follows Zod 4's output-default contract (the fallback is returned as-is rather than re-validated through the input schema), which can accept a default standalone that older composed positions (`.describe()`/object embedding) validated — a follow-up will unify the default path end to end.
-
 ### Added
 
-- `z.lazy()` now builds on the IR's cycle-safe alias node, so recursive parameter schemas export as real `$ref`/`$defs` documents instead of erasing to `{}`.
-- `.readonly()` now shallow-freezes parse output like Zod, without freezing the caller's input graph.
+- Added `z.lazy()`, `z.discriminatedUnion()`, `z.strictObject()`, `z.looseObject()`, and `.readonly()` to the Zod shim (`@oh-my-pi/omptype/zod`); recursive schemas export as real `$ref`/`$defs` documents and `.readonly()` shallow-freezes parse output like Zod, without freezing the caller's input graph.
 
-Schema erasure remains for shapes omptype's unordered unions cannot represent deterministically. Recursion through **required** array/record edges exports structurally as `$ref`/`$defs`; **optional or nullable recursive edges** (`next: self.optional()`, `z.array(self).optional()`) keep the ordered dispatcher and erase, as does a `z.union` of `z.lazy` members or an object containing one. Disjoint member sets — distinct discriminator literals, `strictObject` members, null/undefined widening (the constraints must actually prove the members disjoint, e.g. conflicting required literals or strict rejection of the other member's required key) — all emit structurally. Follow-ups: extend alias deferral to the union determinism probe with a conservative disjointness rule for deferred members, and derive stable `$defs` names (current keys depend on schema construction order).
+### Fixed
+
+- Fixed `z.union`, `z.discriminatedUnion`, `.optional()`, and `.nullable()` throwing `unordered union with overlapping morph inputs is indeterminate` at construction when a member was a plain (key-stripping) `z.object` overlapping another member or a `.catch()` schema — any plugin, hook, or custom tool declaring that shape failed to load; those combinators now dispatch first-match like Zod. Only that fallback's JSON Schema is unconstrained (`{}`); every member set omptype can combine order-independently still emits its real structure.
+
+### Changed
+
+- `.default()` follows Zod 4's output-default contract: the fallback is returned as-is instead of being re-validated through the input schema, and a mutable default (`.default({})`) no longer has to be spelled as a factory. Composed positions (`.describe()`, object embedding) still validate the fallback at construction.
 
 ## [17.3.1] - 2026-08-13
 

--- a/packages/omptype/src/compile.ts
+++ b/packages/omptype/src/compile.ts
@@ -415,7 +415,7 @@ class Builder {
 				this.push(
 					`if(typeof ${v}!=="object"||${v}===null${notRecord}){${this.appendError(
 						errors,
-						this.error(segs, "an object", failureData),
+						this.error(segs, node.plain === true ? "a plain object" : "an object", failureData),
 					)}}else{`,
 				);
 				for (const prop of node.props) {
@@ -849,7 +849,7 @@ class Builder {
 				this.push(
 					`if(typeof ${v}!=="object"||${v}===null${nonRecord}){${this.appendError(
 						errors,
-						this.error(segs, "an object", failureData),
+						this.error(segs, node.plain === true ? "a plain object" : "an object", failureData),
 					)}break ${brk};}`,
 				);
 				const object = this.next("o");

--- a/packages/omptype/src/compile.ts
+++ b/packages/omptype/src/compile.ts
@@ -16,7 +16,7 @@
  */
 import { MISSING, OmpErrors } from "./errors";
 import { canRefineUnionFailure, materializeDefault, unionFail, walk } from "./interp";
-import { expectedOf, hasMorph, type IR, type MorphContext, type PropIR, type TupleIR } from "./ir";
+import { expectedOf, hasMorph, type IR, isPlainRecord, type MorphContext, type PropIR, type TupleIR } from "./ir";
 
 const own = Object.prototype.hasOwnProperty;
 const IDENT = /^[A-Za-z_$][\w$]*$/;
@@ -210,6 +210,9 @@ class Builder {
 			}
 			case "object": {
 				const checks = [`typeof ${v}==="object"`, `${v}!==null`];
+				// Same predicate the interpreter uses: a compiled validator that
+				// disagreed would make the JIT threshold observable.
+				if (node.plain === true) checks.push(`${this.ref(isPlainRecord)}(${v})`);
 				for (const p of node.props) {
 					const av = this.access(v, p.key);
 					const present = `${this.lit(p.key)} in ${v}`;
@@ -408,8 +411,9 @@ class Builder {
 					this.emitCollectDelegate(node, v, segs, errors);
 					return;
 				}
+				const notRecord = node.plain === true ? `||!${this.ref(isPlainRecord)}(${v})` : "";
 				this.push(
-					`if(typeof ${v}!=="object"||${v}===null){${this.appendError(
+					`if(typeof ${v}!=="object"||${v}===null${notRecord}){${this.appendError(
 						errors,
 						this.error(segs, "an object", failureData),
 					)}}else{`,
@@ -841,8 +845,9 @@ class Builder {
 					this.emitCollectDelegate(node, v, segs, errors, brk, out);
 					return;
 				}
+				const nonRecord = node.plain === true ? `||!${this.ref(isPlainRecord)}(${v})` : "";
 				this.push(
-					`if(typeof ${v}!=="object"||${v}===null){${this.appendError(
+					`if(typeof ${v}!=="object"||${v}===null${nonRecord}){${this.appendError(
 						errors,
 						this.error(segs, "an object", failureData),
 					)}break ${brk};}`,
@@ -976,7 +981,10 @@ class Builder {
 			}
 			case "object": {
 				const object = this.next("o");
-				this.push(`const ${object}=${v};if(typeof ${object}!=="object"||${object}===null)return false;`);
+				const rejectNonRecord = node.plain === true ? `||!${this.ref(isPlainRecord)}(${object})` : "";
+				this.push(
+					`const ${object}=${v};if(typeof ${object}!=="object"||${object}===null${rejectNonRecord})return false;`,
+				);
 				for (const prop of node.props) {
 					const value = this.next("p");
 					const present = `${this.lit(prop.key)} in ${object}`;

--- a/packages/omptype/src/interp.ts
+++ b/packages/omptype/src/interp.ts
@@ -387,8 +387,12 @@ function visitNode(ir: IR, v: unknown, path: PropertyKey[]): unknown {
 			return errors ?? output;
 		}
 		case "object": {
-			if (typeof v !== "object" || v === null) return fail(path, "an object", v);
-			if (ir.plain === true && !isPlainRecord(v)) return fail(path, "an object", v);
+			// "a plain object" rather than "an object" so the message is not
+			// self-contradictory: the domain formatter calls an array "an object",
+			// since an array IS the object domain for omptype's own schemas.
+			const expected = ir.plain === true ? "a plain object" : "an object";
+			if (typeof v !== "object" || v === null) return fail(path, expected, v);
+			if (ir.plain === true && !isPlainRecord(v)) return fail(path, expected, v);
 			const rec = v as Record<PropertyKey, unknown>;
 			const morph = hasMorph(ir);
 			let out: Record<PropertyKey, unknown> | undefined;

--- a/packages/omptype/src/interp.ts
+++ b/packages/omptype/src/interp.ts
@@ -9,7 +9,7 @@
  * - failure returns an `OmpErrors` with a single fast-fail entry
  */
 import { MISSING, OmpErrors } from "./errors";
-import { expectedOf, hasAlias, hasMorph, type IR } from "./ir";
+import { expectedOf, hasAlias, hasMorph, type IR, isPlainRecord } from "./ir";
 
 const own = Object.prototype.hasOwnProperty;
 /** Return an independent runtime value for a prevalidated static default. */
@@ -140,6 +140,7 @@ function checkNode(ir: IR, v: unknown): boolean {
 		}
 		case "object": {
 			if (typeof v !== "object" || v === null) return false;
+			if (ir.plain === true && !isPlainRecord(v)) return false;
 			const rec = v as Record<PropertyKey, unknown>;
 			for (const p of ir.props) {
 				const present = p.key in rec;
@@ -387,6 +388,7 @@ function visitNode(ir: IR, v: unknown, path: PropertyKey[]): unknown {
 		}
 		case "object": {
 			if (typeof v !== "object" || v === null) return fail(path, "an object", v);
+			if (ir.plain === true && !isPlainRecord(v)) return fail(path, "an object", v);
 			const rec = v as Record<PropertyKey, unknown>;
 			const morph = hasMorph(ir);
 			let out: Record<PropertyKey, unknown> | undefined;

--- a/packages/omptype/src/ir.ts
+++ b/packages/omptype/src/ir.ts
@@ -736,6 +736,9 @@ function mergeObjectIR(left: IR, right: IR): IR {
 				? undefined
 				: [...(left.patternIndexes ?? []), ...(right.patternIndexes ?? [])],
 		extras: right.extras === "keep" ? left.extras : right.extras,
+		// Merging keeps the narrower input domain, like `intersect` and
+		// `mergeObjects` in type.ts: a merge accepts only what both sides do.
+		plain: left.plain === true || right.plain === true ? true : undefined,
 	};
 }
 
@@ -1336,6 +1339,7 @@ function addObjectProp(props: PropIR[], spreadKeys: Set<PropertyKey> | undefined
 function parseObjectDefinition(def: Record<PropertyKey, unknown>, resolve?: AliasResolver): IR {
 	const props: PropIR[] = [];
 	let spreadKeys: Set<PropertyKey> | undefined;
+	let plain: true | undefined;
 	let normalizedKey: PropertyKey | undefined;
 	let normalizedKeys: PropertyKey[] | undefined;
 	let indexes:
@@ -1380,6 +1384,10 @@ function parseObjectDefinition(def: Record<PropertyKey, unknown>, resolve?: Alia
 				if (spread.patternIndexes !== undefined) objectIndexes.patterns.push(...spread.patternIndexes);
 			}
 			if (spread.extras !== "keep") extras = spread.extras;
+			// The spread contributes its input domain along with its props and
+			// extras policy: spreading a plain-only object cannot widen back to
+			// arrays and built-ins.
+			if (spread.plain === true) plain = true;
 			continue;
 		}
 		if (typeof originalKey === "string" && originalKey.startsWith("[") && originalKey.endsWith("]")) {
@@ -1531,6 +1539,7 @@ function parseObjectDefinition(def: Record<PropertyKey, unknown>, resolve?: Alia
 		symbolIndex: indexes?.symbol,
 		patternIndexes: indexes === undefined || indexes.patterns.length === 0 ? undefined : indexes.patterns,
 		extras,
+		plain,
 	};
 	object[kSimple] = simple;
 	object[kSimpleOwner] = object;

--- a/packages/omptype/src/ir.ts
+++ b/packages/omptype/src/ir.ts
@@ -1686,9 +1686,21 @@ function scanIR(ir: IR, activeAliases?: Set<IR>): ScanResult {
 	const result: ScanResult = { changesOutput: false, exportable: true, hasDeferredAlias: false };
 	switch (ir.k) {
 		case "sub":
+			result.changesOutput = true;
+			result.exportable = false;
+			// A deferred alias behind a stepped embed must still be seen: the
+			// widening gates rely on this bit to route around it.
+			result.hasDeferredAlias = scanIR(ir.schema.ir, activeAliases).hasDeferredAlias;
+			break;
 		case "morph":
 			result.changesOutput = true;
 			result.exportable = false;
+			// Same as `sub`: restrictBase wraps stepped schemas in a step-free
+			// morph whose input is the original IR, so a z.lazy can hide here.
+			result.hasDeferredAlias = scanIR(ir.input, activeAliases).hasDeferredAlias;
+			if (!result.hasDeferredAlias && ir.out !== undefined) {
+				result.hasDeferredAlias = scanIR(ir.out, activeAliases).hasDeferredAlias;
+			}
 			break;
 		case "alias": {
 			// Deferred alias (z.lazy): conservatively a morph without resolving
@@ -1714,8 +1726,11 @@ function scanIR(ir: IR, activeAliases?: Set<IR>): ScanResult {
 				result.changesOutput ||= prop.hasDefault === true || inner.changesOutput;
 				result.exportable &&= prop.hasDefault !== true && inner.exportable;
 				result.hasDeferredAlias ||= inner.hasDeferredAlias;
-				// All three bits are monotone; once pinned, nothing left to learn.
-				if (result.changesOutput && !result.exportable && result.hasDeferredAlias) break;
+				// A deferred alias pins all three bits at once (changesOutput:
+				// true, exportable: false), so this is the only early exit
+				// available — lazy-free schemas still need the full walk for
+				// `exportable`.
+				if (result.hasDeferredAlias) break;
 			}
 			if (ir.index !== undefined) {
 				const inner = scanIR(ir.index, activeAliases);
@@ -1751,7 +1766,7 @@ function scanIR(ir: IR, activeAliases?: Set<IR>): ScanResult {
 				result.changesOutput ||= inner.changesOutput;
 				result.exportable &&= inner.exportable;
 				result.hasDeferredAlias ||= inner.hasDeferredAlias;
-				if (result.changesOutput && !result.exportable && result.hasDeferredAlias) break;
+				if (result.hasDeferredAlias) break;
 			}
 			break;
 		case "refine": {

--- a/packages/omptype/src/ir.ts
+++ b/packages/omptype/src/ir.ts
@@ -138,6 +138,18 @@ export type IR = IRAnalysis &
 				symbolIndex?: IR;
 				patternIndexes?: { key: IR; val: IR }[];
 				extras: Extras;
+				/**
+				 * Restrict accepted input to plain records: reject arrays and the
+				 * built-ins that carry their own domain (`Date`, `Map`, `Set`,
+				 * thenables). Unset keeps omptype's default, where any non-null
+				 * object is object input.
+				 *
+				 * Structural rather than a validation step on purpose: it rides
+				 * through `projectIO` (so `.in`/`.out` keep it at any depth),
+				 * through embedded `sub` nodes, and through the compiler, none of
+				 * which can see a step attached to a nested schema.
+				 */
+				plain?: boolean;
 				desc?: string;
 		  }
 		| {
@@ -1623,6 +1635,23 @@ function scanSimpleIR(ir: IR): boolean {
 		default:
 			return true;
 	}
+}
+
+/**
+ * True when `value` is acceptable input for an object node marked
+ * {@link IR.plain} — everything except arrays and the built-ins that carry
+ * their own domain. Mirrors zod's input classification, where `Date`, `Map`,
+ * `Set`, arrays and thenables are separate parsed types, so an object schema
+ * rejects them; plain objects and class instances are object input.
+ *
+ * Exported because the interpreter and the compiler both need the identical
+ * predicate — a compiled validator that disagreed with the walker would make
+ * the JIT threshold observable.
+ */
+export function isPlainRecord(value: object): boolean {
+	if (Array.isArray(value) || value instanceof Date || value instanceof Map || value instanceof Set) return false;
+	const thenable: { then?: unknown; catch?: unknown } = value;
+	return typeof thenable.then !== "function" || typeof thenable.catch !== "function";
 }
 
 /** True when validating `ir` can produce an output different from its input. */

--- a/packages/omptype/src/ir.ts
+++ b/packages/omptype/src/ir.ts
@@ -170,11 +170,15 @@ export type IR = IRAnalysis &
 				 *
 				 * Invariant: resolve-on-demand paths MUST NOT consult this flag —
 				 * `walk`/`checks` (interp.ts), `compile` (compile.ts), `emit`
-				 * (json-schema.ts), and error-path resolvers all run after the
-				 * definition is complete. Construction-time scan paths MUST:
-				 * `scanIR`'s alias arm (conservative: changesOutput: true,
-				 * exportable: false), `scanAlias` (true, unresolved),
-				 * `morphIdentities` (skip), `assertDeterminateMorphUnions` (skip).
+				 * (json-schema.ts), and parse-time error formatting all run after
+				 * the definition is complete. Construction-time paths MUST either
+				 * skip resolution or honour the flag: `scanIR`'s alias arm
+				 * (conservative: changesOutput: true, exportable: false,
+				 * hasDeferredAlias: true), `scanAlias` (true, unresolved),
+				 * `morphIdentities` (skip), `assertDeterminateMorphUnions` (skip),
+				 * and `descriptionOf` in type.ts (returns the alias name — it is
+				 * reachable eagerly via appendPipes → metaOf when composing
+				 * `.pipe()`/`.readonly()` after a `z.lazy`).
 				 */
 				deferred?: boolean;
 				desc?: string;

--- a/packages/omptype/src/ir.ts
+++ b/packages/omptype/src/ir.ts
@@ -40,8 +40,6 @@ interface IRAnalysis {
 interface ScanResult {
 	/** Validating this node can produce an output different from its input. */
 	changesOutput: boolean;
-	/** This node can be emitted without a dispatcher-morph wrapper. */
-	exportable: boolean;
 	/** Any node under this one defers resolution to first parse (`z.lazy`). */
 	hasDeferredAlias: boolean;
 }
@@ -173,16 +171,16 @@ export type IR = IRAnalysis &
 				 * (json-schema.ts), and parse-time error formatting all run after
 				 * the definition is complete. Construction-time paths MUST either
 				 * skip resolution or honour the flag: `scanIR`'s alias arm
-				 * (conservative: changesOutput: true, exportable: false,
+				 * (conservative: changesOutput: true, hasDeferredAlias: true),
 				 * `morphIdentities` (skip deferred aliases; a declared-out morph
 				 * whose projected sides contain one falls back to its function
 				 * identity), `assertDeterminateMorphUnions` (recursive walk
 				 * skips; its disjointness probe leaves deferred alias inputs
 				 * unresolved, so intersect() cannot prove disjointness and the
 				 * union fails closed as indeterminate), and `descriptionOf` in
-				 * type.ts (returns the alias name — it is reachable eagerly via
-				 * appendPipes → metaOf when composing `.pipe()`/`.readonly()`
-				 * after a `z.lazy`).
+				 * type.ts (reports a neutral phrase instead of resolving — it is
+				 * reachable eagerly via appendPipes → metaOf when composing
+				 * `.pipe()`/`.readonly()` after a `z.lazy`).
 				 */
 				deferred?: boolean;
 				desc?: string;
@@ -1633,20 +1631,6 @@ export function hasMorph(ir: IR): boolean {
 }
 
 /**
- * True when `ir` does not require a dispatcher-morph wrapper for JSON Schema
- * emission — the question the zod-shim combinators gate on. Key-stripping
- * objects are exportable (stripping is representable in the emitted schema),
- * whereas {@link hasMorph} must report them because validation changes the
- * output value. Deliberately NOT "the emitted schema is constrained":
- * `z.unknown()` honestly emits `{}` and is exportable. Non-exportable:
- * morphs, stepped embedded schemas (`sub`), default-filled properties, and
- * deferred aliases.
- */
-export function isStructurallyExportable(ir: IR): boolean {
-	return scanIRCached(ir).exportable;
-}
-
-/**
  * Cached entry point for {@link scanIR}; the only place that writes the
  * per-node scan cache, so results computed under a cycle guard are never
  * memoized.
@@ -1666,43 +1650,33 @@ export function hasDeferredAlias(ir: IR): boolean {
 }
 
 /**
- * One traversal answering three questions that would otherwise need three
+ * One traversal answering two questions that would otherwise need two
  * near-identical walks:
  *
  * - `changesOutput` — can validation produce an output different from its
  *   input? (morphs, key-stripping objects, default-filled properties.)
- * - `exportable` — can the node be emitted without a dispatcher-morph
- *   wrapper, whose emission erases the document to an unconstrained `{}`?
  * - `hasDeferredAlias` — does any node defer its resolution to first parse
  *   (a `z.lazy` getter)? Union determinism cannot see through one, so
  *   consumers must not build native unions containing it.
  *
- * The changesOutput/exportable asymmetry lives in exactly two places, on
- * adjacent lines in the object and tuple arms: key-stripping
- * (`extras: "delete"`) changes the output value but does NOT disqualify
- * export, because stripping is representable in the emitted schema. A
- * default-filled property does both: it changes the output and counts as
- * non-exportable. Stepped embedded schemas and morphs count as both.
- * Deferred aliases are conservatively `{ changesOutput: true, exportable:
- * false, hasDeferredAlias: true }` — the getter must not run during
- * construction-time scans.
+ * Deferred aliases are conservatively `{ changesOutput: true,
+ * hasDeferredAlias: true }` — the getter must not run during
+ * construction-time scans, so their content is unknowable here.
  */
 function scanIR(ir: IR, activeAliases?: Set<IR>): ScanResult {
 	const cached = ir[kScanOwner] === ir ? ir[kScan] : undefined;
 	if (cached !== undefined) return cached;
 
-	const result: ScanResult = { changesOutput: false, exportable: true, hasDeferredAlias: false };
+	const result: ScanResult = { changesOutput: false, hasDeferredAlias: false };
 	switch (ir.k) {
 		case "sub":
 			result.changesOutput = true;
-			result.exportable = false;
 			// A deferred alias behind a stepped embed must still be seen: the
 			// widening gates rely on this bit to route around it.
 			result.hasDeferredAlias = scanIR(ir.schema.ir, activeAliases).hasDeferredAlias;
 			break;
 		case "morph":
 			result.changesOutput = true;
-			result.exportable = false;
 			// Same as `sub`: restrictBase wraps stepped schemas in a step-free
 			// morph whose input is the original IR, so a z.lazy can hide here.
 			result.hasDeferredAlias = scanIR(ir.input, activeAliases).hasDeferredAlias;
@@ -1713,49 +1687,43 @@ function scanIR(ir: IR, activeAliases?: Set<IR>): ScanResult {
 		case "alias": {
 			// Deferred alias (z.lazy): conservatively a morph without resolving
 			// — the getter must not run during construction-time scans.
-			if (ir.deferred === true) return { changesOutput: true, exportable: false, hasDeferredAlias: true };
+			if (ir.deferred === true) return { changesOutput: true, hasDeferredAlias: true };
 			if (activeAliases?.has(ir)) break;
 			const aliases = activeAliases ?? new Set<IR>();
 			aliases.add(ir);
 			const inner = scanIR(ir.resolve(), aliases);
 			aliases.delete(ir);
 			result.changesOutput = inner.changesOutput;
-			result.exportable = inner.exportable;
 			result.hasDeferredAlias = inner.hasDeferredAlias;
 			break;
 		}
 		case "object": {
-			// THE asymmetry of the whole scan, on adjacent lines: key-stripping
-			// (`extras: "delete"`) changes the output value but does not
-			// disqualify export; a default-filled property does both.
+			// Key-stripping (`extras: "delete"`) changes the output value, so a
+			// plain `z.object` counts as a morph here even though nothing about
+			// it is opaque.
 			result.changesOutput = ir.extras === "delete";
 			for (const prop of ir.props) {
 				const inner = scanIR(prop.val, activeAliases);
 				result.changesOutput ||= prop.hasDefault === true || inner.changesOutput;
-				result.exportable &&= prop.hasDefault !== true && inner.exportable;
 				result.hasDeferredAlias ||= inner.hasDeferredAlias;
-				// A deferred alias pins all three bits at once (changesOutput:
-				// true, exportable: false), so this is the only early exit
-				// available — lazy-free schemas still need the full walk for
-				// `exportable`.
+				// A deferred alias pins both bits at once (changesOutput: true,
+				// hasDeferredAlias: true), so this is the only early exit
+				// available.
 				if (result.hasDeferredAlias) break;
 			}
 			if (ir.index !== undefined) {
 				const inner = scanIR(ir.index, activeAliases);
 				result.changesOutput ||= inner.changesOutput;
-				result.exportable &&= inner.exportable;
 				result.hasDeferredAlias ||= inner.hasDeferredAlias;
 			}
 			if (ir.symbolIndex !== undefined) {
 				const inner = scanIR(ir.symbolIndex, activeAliases);
 				result.changesOutput ||= inner.changesOutput;
-				result.exportable &&= inner.exportable;
 				result.hasDeferredAlias ||= inner.hasDeferredAlias;
 			}
 			for (const pattern of ir.patternIndexes ?? []) {
 				const inner = scanIR(pattern.val, activeAliases);
 				result.changesOutput ||= inner.changesOutput;
-				result.exportable &&= inner.exportable;
 				result.hasDeferredAlias ||= inner.hasDeferredAlias;
 			}
 			break;
@@ -1763,7 +1731,6 @@ function scanIR(ir: IR, activeAliases?: Set<IR>): ScanResult {
 		case "array": {
 			const inner = scanIR(ir.el, activeAliases);
 			result.changesOutput = inner.changesOutput;
-			result.exportable = inner.exportable;
 			result.hasDeferredAlias = inner.hasDeferredAlias;
 			break;
 		}
@@ -1772,7 +1739,6 @@ function scanIR(ir: IR, activeAliases?: Set<IR>): ScanResult {
 			for (const member of ir.members) {
 				const inner = scanIR(member, activeAliases);
 				result.changesOutput ||= inner.changesOutput;
-				result.exportable &&= inner.exportable;
 				result.hasDeferredAlias ||= inner.hasDeferredAlias;
 				if (result.hasDeferredAlias) break;
 			}
@@ -1780,7 +1746,6 @@ function scanIR(ir: IR, activeAliases?: Set<IR>): ScanResult {
 		case "refine": {
 			const inner = scanIR(ir.base, activeAliases);
 			result.changesOutput = inner.changesOutput;
-			result.exportable = inner.exportable;
 			result.hasDeferredAlias = inner.hasDeferredAlias;
 			break;
 		}
@@ -1788,19 +1753,16 @@ function scanIR(ir: IR, activeAliases?: Set<IR>): ScanResult {
 			for (const item of ir.prefix) {
 				const inner = scanIR(item.val, activeAliases);
 				result.changesOutput ||= item.hasDefault === true || inner.changesOutput;
-				result.exportable &&= item.hasDefault !== true && inner.exportable;
 				result.hasDeferredAlias ||= inner.hasDeferredAlias;
 			}
 			if (ir.variadic !== undefined) {
 				const inner = scanIR(ir.variadic, activeAliases);
 				result.changesOutput ||= inner.changesOutput;
-				result.exportable &&= inner.exportable;
 				result.hasDeferredAlias ||= inner.hasDeferredAlias;
 			}
 			for (const item of ir.postfix) {
 				const inner = scanIR(item, activeAliases);
 				result.changesOutput ||= inner.changesOutput;
-				result.exportable &&= inner.exportable;
 				result.hasDeferredAlias ||= inner.hasDeferredAlias;
 			}
 			break;

--- a/packages/omptype/src/ir.ts
+++ b/packages/omptype/src/ir.ts
@@ -36,12 +36,14 @@ interface IRAnalysis {
 	descAuto?: boolean;
 }
 
-/** One traversal's answer to both scan questions (see {@link scanIR}). */
+/** One traversal's answer to the scan questions (see {@link scanIR}). */
 interface ScanResult {
 	/** Validating this node can produce an output different from its input. */
 	changesOutput: boolean;
 	/** This node can be emitted without a dispatcher-morph wrapper. */
 	exportable: boolean;
+	/** Any node under this one defers resolution to first parse (`z.lazy`). */
+	hasDeferredAlias: boolean;
 }
 
 /**
@@ -1636,6 +1638,11 @@ export function isStructurallyExportable(ir: IR): boolean {
 	return scanIRCached(ir).exportable;
 }
 
+/**
+ * Cached entry point for {@link scanIR}; the only place that writes the
+ * per-node scan cache, so results computed under a cycle guard are never
+ * memoized.
+ */
 function scanIRCached(ir: IR): ScanResult {
 	const cached = ir[kScanOwner] === ir ? ir[kScan] : undefined;
 	if (cached !== undefined) return cached;
@@ -1645,23 +1652,38 @@ function scanIRCached(ir: IR): ScanResult {
 	return result;
 }
 
+/** True when any node under `ir` is a deferred alias (a `z.lazy` getter). */
+export function hasDeferredAlias(ir: IR): boolean {
+	return scanIRCached(ir).hasDeferredAlias;
+}
+
 /**
- * One traversal answering the two questions the former independent scans
- * (`scanMorph` / `scanExportable`) recomputed with near-identical walks. The
- * asymmetry lives in exactly two places, on adjacent lines in the object and
- * tuple arms: key-stripping (`extras: "delete"`) changes the output value but
- * does NOT disqualify export, because stripping is representable in the
- * emitted schema. A default-filled property does both: it changes the output
- * and counts as non-exportable.
+ * One traversal answering three questions that would otherwise need three
+ * near-identical walks:
  *
+ * - `changesOutput` — can validation produce an output different from its
+ *   input? (morphs, key-stripping objects, default-filled properties.)
+ * - `exportable` — can the node be emitted without a dispatcher-morph
+ *   wrapper, whose emission erases the document to an unconstrained `{}`?
+ * - `hasDeferredAlias` — does any node defer its resolution to first parse
+ *   (a `z.lazy` getter)? Union determinism cannot see through one, so
+ *   consumers must not build native unions containing it.
+ *
+ * The changesOutput/exportable asymmetry lives in exactly two places, on
+ * adjacent lines in the object and tuple arms: key-stripping
+ * (`extras: "delete"`) changes the output value but does NOT disqualify
+ * export, because stripping is representable in the emitted schema. A
+ * default-filled property does both: it changes the output and counts as
+ * non-exportable. Stepped embedded schemas and morphs count as both.
  * Deferred aliases are conservatively `{ changesOutput: true, exportable:
- * false }` — the getter must not run during construction-time scans.
+ * false, hasDeferredAlias: true }` — the getter must not run during
+ * construction-time scans.
  */
 function scanIR(ir: IR, activeAliases?: Set<IR>): ScanResult {
 	const cached = ir[kScanOwner] === ir ? ir[kScan] : undefined;
 	if (cached !== undefined) return cached;
 
-	const result: ScanResult = { changesOutput: false, exportable: true };
+	const result: ScanResult = { changesOutput: false, exportable: true, hasDeferredAlias: false };
 	switch (ir.k) {
 		case "sub":
 		case "morph":
@@ -1671,7 +1693,7 @@ function scanIR(ir: IR, activeAliases?: Set<IR>): ScanResult {
 		case "alias": {
 			// Deferred alias (z.lazy): conservatively a morph without resolving
 			// — the getter must not run during construction-time scans.
-			if (ir.deferred === true) return { changesOutput: true, exportable: false };
+			if (ir.deferred === true) return { changesOutput: true, exportable: false, hasDeferredAlias: true };
 			if (activeAliases?.has(ir)) break;
 			const aliases = activeAliases ?? new Set<IR>();
 			aliases.add(ir);
@@ -1679,6 +1701,7 @@ function scanIR(ir: IR, activeAliases?: Set<IR>): ScanResult {
 			aliases.delete(ir);
 			result.changesOutput = inner.changesOutput;
 			result.exportable = inner.exportable;
+			result.hasDeferredAlias = inner.hasDeferredAlias;
 			break;
 		}
 		case "object": {
@@ -1690,17 +1713,27 @@ function scanIR(ir: IR, activeAliases?: Set<IR>): ScanResult {
 				const inner = scanIR(prop.val, activeAliases);
 				result.changesOutput ||= prop.hasDefault === true || inner.changesOutput;
 				result.exportable &&= prop.hasDefault !== true && inner.exportable;
+				result.hasDeferredAlias ||= inner.hasDeferredAlias;
+				// All three bits are monotone; once pinned, nothing left to learn.
+				if (result.changesOutput && !result.exportable && result.hasDeferredAlias) break;
 			}
-			for (const index of [ir.index, ir.symbolIndex]) {
-				if (index === undefined) continue;
-				const inner = scanIR(index, activeAliases);
+			if (ir.index !== undefined) {
+				const inner = scanIR(ir.index, activeAliases);
 				result.changesOutput ||= inner.changesOutput;
 				result.exportable &&= inner.exportable;
+				result.hasDeferredAlias ||= inner.hasDeferredAlias;
+			}
+			if (ir.symbolIndex !== undefined) {
+				const inner = scanIR(ir.symbolIndex, activeAliases);
+				result.changesOutput ||= inner.changesOutput;
+				result.exportable &&= inner.exportable;
+				result.hasDeferredAlias ||= inner.hasDeferredAlias;
 			}
 			for (const pattern of ir.patternIndexes ?? []) {
 				const inner = scanIR(pattern.val, activeAliases);
 				result.changesOutput ||= inner.changesOutput;
 				result.exportable &&= inner.exportable;
+				result.hasDeferredAlias ||= inner.hasDeferredAlias;
 			}
 			break;
 		}
@@ -1708,6 +1741,7 @@ function scanIR(ir: IR, activeAliases?: Set<IR>): ScanResult {
 			const inner = scanIR(ir.el, activeAliases);
 			result.changesOutput = inner.changesOutput;
 			result.exportable = inner.exportable;
+			result.hasDeferredAlias = inner.hasDeferredAlias;
 			break;
 		}
 		case "union":
@@ -1716,12 +1750,15 @@ function scanIR(ir: IR, activeAliases?: Set<IR>): ScanResult {
 				const inner = scanIR(member, activeAliases);
 				result.changesOutput ||= inner.changesOutput;
 				result.exportable &&= inner.exportable;
+				result.hasDeferredAlias ||= inner.hasDeferredAlias;
+				if (result.changesOutput && !result.exportable && result.hasDeferredAlias) break;
 			}
 			break;
 		case "refine": {
 			const inner = scanIR(ir.base, activeAliases);
 			result.changesOutput = inner.changesOutput;
 			result.exportable = inner.exportable;
+			result.hasDeferredAlias = inner.hasDeferredAlias;
 			break;
 		}
 		case "tuple": {
@@ -1729,16 +1766,19 @@ function scanIR(ir: IR, activeAliases?: Set<IR>): ScanResult {
 				const inner = scanIR(item.val, activeAliases);
 				result.changesOutput ||= item.hasDefault === true || inner.changesOutput;
 				result.exportable &&= item.hasDefault !== true && inner.exportable;
+				result.hasDeferredAlias ||= inner.hasDeferredAlias;
 			}
 			if (ir.variadic !== undefined) {
 				const inner = scanIR(ir.variadic, activeAliases);
 				result.changesOutput ||= inner.changesOutput;
 				result.exportable &&= inner.exportable;
+				result.hasDeferredAlias ||= inner.hasDeferredAlias;
 			}
 			for (const item of ir.postfix) {
 				const inner = scanIR(item, activeAliases);
 				result.changesOutput ||= inner.changesOutput;
 				result.exportable &&= inner.exportable;
+				result.hasDeferredAlias ||= inner.hasDeferredAlias;
 			}
 			break;
 		}

--- a/packages/omptype/src/ir.ts
+++ b/packages/omptype/src/ir.ts
@@ -16,28 +16,32 @@ import { keywordIR, patternIR, templateIR } from "./keywords";
 /** Brand carried by `Type` instances so the parser can embed them in defs. */
 export const IR_BRAND: unique symbol = Symbol("omptype.schema");
 
-const kMorph: unique symbol = Symbol("omptype.hasMorph");
-const kMorphOwner: unique symbol = Symbol("omptype.hasMorphOwner");
+const kScan: unique symbol = Symbol("omptype.scan");
+const kScanOwner: unique symbol = Symbol("omptype.scanOwner");
 const kAlias: unique symbol = Symbol("omptype.hasAlias");
 const kAliasOwner: unique symbol = Symbol("omptype.hasAliasOwner");
-const kExportable: unique symbol = Symbol("omptype.exportable");
-const kExportableOwner: unique symbol = Symbol("omptype.exportableOwner");
 const kSimple: unique symbol = Symbol("omptype.simple");
 const kSimpleOwner: unique symbol = Symbol("omptype.simpleOwner");
 
 interface IRAnalysis {
-	[kMorph]?: boolean;
-	[kMorphOwner]?: object;
+	[kScan]?: ScanResult;
+	[kScanOwner]?: object;
 	[kAlias]?: boolean;
 	[kAliasOwner]?: object;
-	[kExportable]?: boolean;
-	[kExportableOwner]?: object;
 	[kSimple]?: boolean;
 	[kSimpleOwner]?: object;
 	/** Node-local metadata used for shallow error formatting. */
 	cfg?: ErrorConfig;
 	/** True when `desc` was derived from the node itself rather than authored via `.describe()`. */
 	descAuto?: boolean;
+}
+
+/** One traversal's answer to both scan questions (see {@link scanIR}). */
+interface ScanResult {
+	/** Validating this node can produce an output different from its input. */
+	changesOutput: boolean;
+	/** This node can be emitted without a dispatcher-morph wrapper. */
+	exportable: boolean;
 }
 
 /**
@@ -1615,178 +1619,129 @@ function scanSimpleIR(ir: IR): boolean {
 
 /** True when validating `ir` can produce an output different from its input. */
 export function hasMorph(ir: IR): boolean {
-	const cached = ir[kMorphOwner] === ir ? ir[kMorph] : undefined;
-	if (cached !== undefined) return cached;
-	const result = scanMorph(ir);
-	ir[kMorph] = result;
-	ir[kMorphOwner] = ir;
-	return result;
+	return scanIRCached(ir).changesOutput;
 }
 
-function scanMorph(ir: IR, activeAliases?: Set<IR>): boolean {
-	const cached = ir[kMorphOwner] === ir ? ir[kMorph] : undefined;
-	if (cached !== undefined) return cached;
+/**
+ * True when `ir` does not require a dispatcher-morph wrapper for JSON Schema
+ * emission — the question the zod-shim combinators gate on. Key-stripping
+ * objects are exportable (stripping is representable in the emitted schema),
+ * whereas {@link hasMorph} must report them because validation changes the
+ * output value. Deliberately NOT "the emitted schema is constrained":
+ * `z.unknown()` honestly emits `{}` and is exportable. Non-exportable:
+ * morphs, stepped embedded schemas (`sub`), default-filled properties, and
+ * deferred aliases.
+ */
+export function isStructurallyExportable(ir: IR): boolean {
+	return scanIRCached(ir).exportable;
+}
 
-	let result = false;
-	switch (ir.k) {
-		case "sub":
-		case "morph":
-			result = true;
-			break;
-		case "alias": {
-			// Deferred alias (z.lazy): conservatively a morph without resolving —
-			// the getter must not run during construction-time scans.
-			if (ir.deferred === true) return true;
-			if (activeAliases?.has(ir)) return false;
-			const aliases = activeAliases ?? new Set<IR>();
-			aliases.add(ir);
-			result = scanMorph(ir.resolve(), aliases);
-			aliases.delete(ir);
-			return result;
-		}
-		case "object":
-			result = ir.extras === "delete";
-			for (let index = 0; !result && index < ir.props.length; index++) {
-				const prop = ir.props[index];
-				result = prop.hasDefault === true || scanMorph(prop.val, activeAliases);
-			}
-			if (!result && ir.index !== undefined) result = scanMorph(ir.index, activeAliases);
-			if (!result && ir.symbolIndex !== undefined) result = scanMorph(ir.symbolIndex, activeAliases);
-			if (!result && ir.patternIndexes !== undefined) {
-				for (const pattern of ir.patternIndexes) {
-					if (scanMorph(pattern.val, activeAliases)) {
-						result = true;
-						break;
-					}
-				}
-			}
-			break;
-		case "array":
-			result = scanMorph(ir.el, activeAliases);
-			break;
-		case "union":
-		case "intersection":
-			for (const member of ir.members) {
-				if (scanMorph(member, activeAliases)) {
-					result = true;
-					break;
-				}
-			}
-			break;
-		case "refine":
-			result = scanMorph(ir.base, activeAliases);
-			break;
-		case "tuple":
-			for (const item of ir.prefix) {
-				if (item.hasDefault === true || scanMorph(item.val, activeAliases)) {
-					result = true;
-					break;
-				}
-			}
-			if (!result && ir.variadic !== undefined) result = scanMorph(ir.variadic, activeAliases);
-			if (!result) {
-				for (const item of ir.postfix) {
-					if (scanMorph(item, activeAliases)) {
-						result = true;
-						break;
-					}
-				}
-			}
-			break;
-	}
+function scanIRCached(ir: IR): ScanResult {
+	const cached = ir[kScanOwner] === ir ? ir[kScan] : undefined;
+	if (cached !== undefined) return cached;
+	const result = scanIR(ir);
+	ir[kScan] = result;
+	ir[kScanOwner] = ir;
 	return result;
 }
 
 /**
- * True when `ir` can be lowered to JSON Schema structurally — without routing
- * values through a dispatcher morph, whose emission erases the document to an
- * unconstrained `{}`. Key-stripping objects (`extras: "delete"`) are
- * exportable: stripping is representable (the schema still describes the
- * declared properties), whereas {@link hasMorph} must report them because
- * validation changes the output value. Everywhere else this deliberately
- * mirrors {@link scanMorph}: stepped embedded schemas (`sub`), morphs, and
- * default-filled properties stay non-exportable.
+ * One traversal answering the two questions the former independent scans
+ * (`scanMorph` / `scanExportable`) recomputed with near-identical walks. The
+ * asymmetry lives in exactly two places, on adjacent lines in the object and
+ * tuple arms: key-stripping (`extras: "delete"`) changes the output value but
+ * does NOT disqualify export, because stripping is representable in the
+ * emitted schema. A default-filled property does both: it changes the output
+ * and counts as non-exportable.
+ *
+ * Deferred aliases are conservatively `{ changesOutput: true, exportable:
+ * false }` — the getter must not run during construction-time scans.
  */
-export function isStructurallyExportable(ir: IR): boolean {
-	const cached = ir[kExportableOwner] === ir ? ir[kExportable] : undefined;
-	if (cached !== undefined) return cached;
-	const result = scanExportable(ir);
-	ir[kExportable] = result;
-	ir[kExportableOwner] = ir;
-	return result;
-}
-
-function scanExportable(ir: IR, activeAliases?: Set<IR>): boolean {
-	const cached = ir[kExportableOwner] === ir ? ir[kExportable] : undefined;
+function scanIR(ir: IR, activeAliases?: Set<IR>): ScanResult {
+	const cached = ir[kScanOwner] === ir ? ir[kScan] : undefined;
 	if (cached !== undefined) return cached;
 
-	let result = true;
+	const result: ScanResult = { changesOutput: false, exportable: true };
 	switch (ir.k) {
 		case "sub":
 		case "morph":
-			result = false;
+			result.changesOutput = true;
+			result.exportable = false;
 			break;
 		case "alias": {
-			// Deferred alias (z.lazy): not exportable without resolving — the
-			// gates then keep the ordered dispatcher, as before the alias reuse.
-			if (ir.deferred === true) return false;
-			if (activeAliases?.has(ir)) return true;
+			// Deferred alias (z.lazy): conservatively a morph without resolving
+			// — the getter must not run during construction-time scans.
+			if (ir.deferred === true) return { changesOutput: true, exportable: false };
+			if (activeAliases?.has(ir)) break;
 			const aliases = activeAliases ?? new Set<IR>();
 			aliases.add(ir);
-			result = scanExportable(ir.resolve(), aliases);
+			const inner = scanIR(ir.resolve(), aliases);
 			aliases.delete(ir);
-			return result;
+			result.changesOutput = inner.changesOutput;
+			result.exportable = inner.exportable;
+			break;
 		}
-		case "object":
+		case "object": {
+			// THE asymmetry of the whole scan, on adjacent lines: key-stripping
+			// (`extras: "delete"`) changes the output value but does not
+			// disqualify export; a default-filled property does both.
+			result.changesOutput = ir.extras === "delete";
 			for (const prop of ir.props) {
-				if (prop.hasDefault === true || !scanExportable(prop.val, activeAliases)) {
-					result = false;
-					break;
-				}
+				const inner = scanIR(prop.val, activeAliases);
+				result.changesOutput ||= prop.hasDefault === true || inner.changesOutput;
+				result.exportable &&= prop.hasDefault !== true && inner.exportable;
 			}
-			if (result && ir.index !== undefined) result = scanExportable(ir.index, activeAliases);
-			if (result && ir.symbolIndex !== undefined) result = scanExportable(ir.symbolIndex, activeAliases);
-			if (result && ir.patternIndexes !== undefined) {
-				for (const pattern of ir.patternIndexes) {
-					if (!scanExportable(pattern.val, activeAliases)) {
-						result = false;
-						break;
-					}
-				}
+			for (const index of [ir.index, ir.symbolIndex]) {
+				if (index === undefined) continue;
+				const inner = scanIR(index, activeAliases);
+				result.changesOutput ||= inner.changesOutput;
+				result.exportable &&= inner.exportable;
+			}
+			for (const pattern of ir.patternIndexes ?? []) {
+				const inner = scanIR(pattern.val, activeAliases);
+				result.changesOutput ||= inner.changesOutput;
+				result.exportable &&= inner.exportable;
 			}
 			break;
-		case "array":
-			result = scanExportable(ir.el, activeAliases);
+		}
+		case "array": {
+			const inner = scanIR(ir.el, activeAliases);
+			result.changesOutput = inner.changesOutput;
+			result.exportable = inner.exportable;
 			break;
+		}
 		case "union":
 		case "intersection":
 			for (const member of ir.members) {
-				if (!scanExportable(member, activeAliases)) {
-					result = false;
-					break;
-				}
+				const inner = scanIR(member, activeAliases);
+				result.changesOutput ||= inner.changesOutput;
+				result.exportable &&= inner.exportable;
 			}
 			break;
-		case "refine":
-			result = scanExportable(ir.base, activeAliases);
+		case "refine": {
+			const inner = scanIR(ir.base, activeAliases);
+			result.changesOutput = inner.changesOutput;
+			result.exportable = inner.exportable;
 			break;
-		case "tuple":
+		}
+		case "tuple": {
 			for (const item of ir.prefix) {
-				if (item.hasDefault === true || !scanExportable(item.val, activeAliases)) {
-					result = false;
-					break;
-				}
+				const inner = scanIR(item.val, activeAliases);
+				result.changesOutput ||= item.hasDefault === true || inner.changesOutput;
+				result.exportable &&= item.hasDefault !== true && inner.exportable;
 			}
-			if (result && ir.variadic !== undefined) result = scanExportable(ir.variadic, activeAliases);
-			if (result) {
-				for (const item of ir.postfix) {
-					if (!scanExportable(item, activeAliases)) {
-						result = false;
-						break;
-					}
-				}
+			if (ir.variadic !== undefined) {
+				const inner = scanIR(ir.variadic, activeAliases);
+				result.changesOutput ||= inner.changesOutput;
+				result.exportable &&= inner.exportable;
+			}
+			for (const item of ir.postfix) {
+				const inner = scanIR(item, activeAliases);
+				result.changesOutput ||= inner.changesOutput;
+				result.exportable &&= inner.exportable;
 			}
 			break;
+		}
 	}
 	return result;
 }

--- a/packages/omptype/src/ir.ts
+++ b/packages/omptype/src/ir.ts
@@ -174,11 +174,15 @@ export type IR = IRAnalysis &
 				 * the definition is complete. Construction-time paths MUST either
 				 * skip resolution or honour the flag: `scanIR`'s alias arm
 				 * (conservative: changesOutput: true, exportable: false,
-				 * hasDeferredAlias: true), `scanAlias` (true, unresolved),
-				 * `morphIdentities` (skip), `assertDeterminateMorphUnions` (skip),
-				 * and `descriptionOf` in type.ts (returns the alias name — it is
-				 * reachable eagerly via appendPipes → metaOf when composing
-				 * `.pipe()`/`.readonly()` after a `z.lazy`).
+				 * `morphIdentities` (skip deferred aliases; a declared-out morph
+				 * whose projected sides contain one falls back to its function
+				 * identity), `assertDeterminateMorphUnions` (recursive walk
+				 * skips; its disjointness probe leaves deferred alias inputs
+				 * unresolved, so intersect() cannot prove disjointness and the
+				 * union fails closed as indeterminate), and `descriptionOf` in
+				 * type.ts (returns the alias name — it is reachable eagerly via
+				 * appendPipes → metaOf when composing `.pipe()`/`.readonly()`
+				 * after a `z.lazy`).
 				 */
 				deferred?: boolean;
 				desc?: string;

--- a/packages/omptype/src/ir.ts
+++ b/packages/omptype/src/ir.ts
@@ -170,8 +170,8 @@ export type IR = IRAnalysis &
 				 * `walk`/`checks` (interp.ts), `compile` (compile.ts), `emit`
 				 * (json-schema.ts), and error-path resolvers all run after the
 				 * definition is complete. Construction-time scan paths MUST:
-				 * `scanMorph` (conservative morph=true), `scanExportable`
-				 * (conservative exportable=false), `scanAlias` (true, unresolved),
+				 * `scanIR`'s alias arm (conservative: changesOutput: true,
+				 * exportable: false), `scanAlias` (true, unresolved),
 				 * `morphIdentities` (skip), `assertDeterminateMorphUnions` (skip).
 				 */
 				deferred?: boolean;

--- a/packages/omptype/src/ir.ts
+++ b/packages/omptype/src/ir.ts
@@ -20,6 +20,8 @@ const kMorph: unique symbol = Symbol("omptype.hasMorph");
 const kMorphOwner: unique symbol = Symbol("omptype.hasMorphOwner");
 const kAlias: unique symbol = Symbol("omptype.hasAlias");
 const kAliasOwner: unique symbol = Symbol("omptype.hasAliasOwner");
+const kExportable: unique symbol = Symbol("omptype.exportable");
+const kExportableOwner: unique symbol = Symbol("omptype.exportableOwner");
 const kSimple: unique symbol = Symbol("omptype.simple");
 const kSimpleOwner: unique symbol = Symbol("omptype.simpleOwner");
 
@@ -28,6 +30,8 @@ interface IRAnalysis {
 	[kMorphOwner]?: object;
 	[kAlias]?: boolean;
 	[kAliasOwner]?: object;
+	[kExportable]?: boolean;
+	[kExportableOwner]?: object;
 	[kSimple]?: boolean;
 	[kSimpleOwner]?: object;
 	/** Node-local metadata used for shallow error formatting. */
@@ -148,7 +152,12 @@ export type IR = IRAnalysis &
 				desc?: string;
 		  }
 		| { k: "instance"; ctor: Constructor; expected: string; desc?: string }
-		| { k: "alias"; name: string; resolve: () => IR; desc?: string }
+		| {
+				k: "alias";
+				name: string;
+				resolve: () => IR;
+				desc?: string;
+		  }
 		/** Embedded schema with runtime steps; validated by calling `run`. */
 		| { k: "sub"; schema: EmbeddableSchema; desc?: string }
 	);
@@ -1661,6 +1670,97 @@ function scanMorph(ir: IR, activeAliases?: Set<IR>): boolean {
 				for (const item of ir.postfix) {
 					if (scanMorph(item, activeAliases)) {
 						result = true;
+						break;
+					}
+				}
+			}
+			break;
+	}
+	return result;
+}
+
+/**
+ * True when `ir` can be lowered to JSON Schema structurally — without routing
+ * values through a dispatcher morph, whose emission erases the document to an
+ * unconstrained `{}`. Key-stripping objects (`extras: "delete"`) are
+ * exportable: stripping is representable (the schema still describes the
+ * declared properties), whereas {@link hasMorph} must report them because
+ * validation changes the output value. Everywhere else this deliberately
+ * mirrors {@link scanMorph}: stepped embedded schemas (`sub`), morphs, and
+ * default-filled properties stay non-exportable.
+ */
+export function isStructurallyExportable(ir: IR): boolean {
+	const cached = ir[kExportableOwner] === ir ? ir[kExportable] : undefined;
+	if (cached !== undefined) return cached;
+	const result = scanExportable(ir);
+	ir[kExportable] = result;
+	ir[kExportableOwner] = ir;
+	return result;
+}
+
+function scanExportable(ir: IR, activeAliases?: Set<IR>): boolean {
+	const cached = ir[kExportableOwner] === ir ? ir[kExportable] : undefined;
+	if (cached !== undefined) return cached;
+
+	let result = true;
+	switch (ir.k) {
+		case "sub":
+		case "morph":
+			result = false;
+			break;
+		case "alias": {
+			if (activeAliases?.has(ir)) return true;
+			const aliases = activeAliases ?? new Set<IR>();
+			aliases.add(ir);
+			result = scanExportable(ir.resolve(), aliases);
+			aliases.delete(ir);
+			return result;
+		}
+		case "object":
+			for (const prop of ir.props) {
+				if (prop.hasDefault === true || !scanExportable(prop.val, activeAliases)) {
+					result = false;
+					break;
+				}
+			}
+			if (result && ir.index !== undefined) result = scanExportable(ir.index, activeAliases);
+			if (result && ir.symbolIndex !== undefined) result = scanExportable(ir.symbolIndex, activeAliases);
+			if (result && ir.patternIndexes !== undefined) {
+				for (const pattern of ir.patternIndexes) {
+					if (!scanExportable(pattern.val, activeAliases)) {
+						result = false;
+						break;
+					}
+				}
+			}
+			break;
+		case "array":
+			result = scanExportable(ir.el, activeAliases);
+			break;
+		case "union":
+		case "intersection":
+			for (const member of ir.members) {
+				if (!scanExportable(member, activeAliases)) {
+					result = false;
+					break;
+				}
+			}
+			break;
+		case "refine":
+			result = scanExportable(ir.base, activeAliases);
+			break;
+		case "tuple":
+			for (const item of ir.prefix) {
+				if (item.hasDefault === true || !scanExportable(item.val, activeAliases)) {
+					result = false;
+					break;
+				}
+			}
+			if (result && ir.variadic !== undefined) result = scanExportable(ir.variadic, activeAliases);
+			if (result) {
+				for (const item of ir.postfix) {
+					if (!scanExportable(item, activeAliases)) {
+						result = false;
 						break;
 					}
 				}

--- a/packages/omptype/src/ir.ts
+++ b/packages/omptype/src/ir.ts
@@ -156,6 +156,21 @@ export type IR = IRAnalysis &
 				k: "alias";
 				name: string;
 				resolve: () => IR;
+				/**
+				 * Set when `resolve` must not run until validation or emission — a
+				 * `z.lazy` getter: resolving earlier breaks recursive `const`
+				 * definitions via TDZ and violates zod's defer-to-first-parse
+				 * contract.
+				 *
+				 * Invariant: resolve-on-demand paths MUST NOT consult this flag —
+				 * `walk`/`checks` (interp.ts), `compile` (compile.ts), `emit`
+				 * (json-schema.ts), and error-path resolvers all run after the
+				 * definition is complete. Construction-time scan paths MUST:
+				 * `scanMorph` (conservative morph=true), `scanExportable`
+				 * (conservative exportable=false), `scanAlias` (true, unresolved),
+				 * `morphIdentities` (skip), `assertDeterminateMorphUnions` (skip).
+				 */
+				deferred?: boolean;
 				desc?: string;
 		  }
 		/** Embedded schema with runtime steps; validated by calling `run`. */
@@ -1619,6 +1634,9 @@ function scanMorph(ir: IR, activeAliases?: Set<IR>): boolean {
 			result = true;
 			break;
 		case "alias": {
+			// Deferred alias (z.lazy): conservatively a morph without resolving —
+			// the getter must not run during construction-time scans.
+			if (ir.deferred === true) return true;
 			if (activeAliases?.has(ir)) return false;
 			const aliases = activeAliases ?? new Set<IR>();
 			aliases.add(ir);
@@ -1709,6 +1727,9 @@ function scanExportable(ir: IR, activeAliases?: Set<IR>): boolean {
 			result = false;
 			break;
 		case "alias": {
+			// Deferred alias (z.lazy): not exportable without resolving — the
+			// gates then keep the ordered dispatcher, as before the alias reuse.
+			if (ir.deferred === true) return false;
 			if (activeAliases?.has(ir)) return true;
 			const aliases = activeAliases ?? new Set<IR>();
 			aliases.add(ir);

--- a/packages/omptype/src/type.ts
+++ b/packages/omptype/src/type.ts
@@ -436,7 +436,9 @@ function descriptionOf(ir: IR, seen: Set<IR> = new Set()): string {
 		// Deferred alias (z.lazy): its getter must not run before first parse —
 		// appendPipes resolves descriptions eagerly at composition time via
 		// metaOf, so resolving here would break recursive `const` definitions.
-		if (ir.deferred === true) return ir.name;
+		// The internal `$defs` name is not a description, so report the only
+		// thing known about the node instead of leaking it into error prose.
+		if (ir.deferred === true) return "a recursive value";
 		return descriptionOf(ir.resolve(), seen);
 	}
 	if (ir.k === "object") {

--- a/packages/omptype/src/type.ts
+++ b/packages/omptype/src/type.ts
@@ -2034,6 +2034,23 @@ function intersect(a: IR, b: IR): IR {
 	return intersectResolved(a, b);
 }
 
+/**
+ * Whether a plain-only object node can accept an instance of `ctor`.
+ *
+ * The built-ins listed here are exactly the ones `isPlainRecord` refuses, so an
+ * intersection with them is empty and a union containing both branches is
+ * provably disjoint. An ordinary class instance IS plain-record input and stays
+ * satisfiable. A custom thenable is not detectable from a constructor, so it
+ * stays satisfiable too — conservative in the safe direction, since the union
+ * then keeps the ordered dispatcher instead of being proven disjoint.
+ */
+function plainAcceptsInstance(ctor: Constructor): boolean {
+	for (const excluded of [Array, Date, Map, Set, Promise]) {
+		if (ctor === excluded || ctor.prototype instanceof excluded) return false;
+	}
+	return true;
+}
+
 function intersectResolved(a: IR, b: IR): IR {
 	if (a.k === "never" || b.k === "never") throw new OmpTypeError("intersection with never is unsatisfiable");
 	if (a.k === "unknown") return b;
@@ -2178,6 +2195,13 @@ function intersectResolved(a: IR, b: IR): IR {
 			throw new OmpTypeError("intersection of a plain object and an array is unsatisfiable");
 		}
 		return { k: "intersection", members: [a, b] };
+	}
+	if (
+		(a.k === "object" && a.plain === true && b.k === "instance" && !plainAcceptsInstance(b.ctor)) ||
+		(b.k === "object" && b.plain === true && a.k === "instance" && !plainAcceptsInstance(a.ctor))
+	) {
+		const excluded = a.k === "instance" ? a : (b as Extract<IR, { k: "instance" }>);
+		throw new OmpTypeError(`intersection of a plain object and ${excluded.expected} is unsatisfiable`);
 	}
 	const leftDomain = domainOf(a);
 	const rightDomain = domainOf(b);

--- a/packages/omptype/src/type.ts
+++ b/packages/omptype/src/type.ts
@@ -1418,10 +1418,11 @@ function morphIdentities(ir: IR, identities: unknown[] = [], seen = new Set<IR>(
 			// A declared-out morph whose projected sides contain one falls back
 			// to its function identity — strictly finer than the string form.
 			const out = ir.out;
-			const projectedIn = projectIO(ir.input, "in");
+			const projectedIn = out === undefined ? undefined : projectIO(ir.input, "in");
 			const projectedOut = out === undefined ? undefined : projectIO(out, "out");
 			const declared =
 				out !== undefined &&
+				projectedIn !== undefined &&
 				projectedOut !== undefined &&
 				!hasDeferredAlias(projectedIn) &&
 				!hasDeferredAlias(projectedOut);

--- a/packages/omptype/src/type.ts
+++ b/packages/omptype/src/type.ts
@@ -293,8 +293,11 @@ interface FluentMethods<t, i> {
 	earlierThan(bound: Date | number): FluentType<t, i>;
 	readonly pipe: PipeMethod<t, i>;
 	to<const def>(def: def): FluentType<InferDef<def>, i>;
-	filter<narrowed extends i>(fn: (data: i, ctx: NarrowContext) => data is narrowed): FluentType<t, narrowed>;
-	filter(fn: (data: i, ctx: NarrowContext) => boolean | OmpErrors): FluentType<t, i>;
+	filter<narrowed extends i>(
+		fn: (data: i, ctx: NarrowContext) => data is narrowed,
+		options?: FilterOptions,
+	): FluentType<t, narrowed>;
+	filter(fn: (data: i, ctx: NarrowContext) => boolean | OmpErrors, options?: FilterOptions): FluentType<t, i>;
 	narrow<narrowed extends t>(fn: (data: t, ctx: NarrowContext) => data is narrowed): FluentType<narrowed, i>;
 	narrow(fn: (data: t, ctx: NarrowContext) => boolean | OmpErrors): FluentType<t, i>;
 	brand<const name extends string>(name: name): FluentType<Brand<t, name>, i>;
@@ -405,6 +408,18 @@ export interface FnParser {
 	<const definitions extends readonly FnDefinition[]>(...definitions: definitions): FnFactory<definitions>;
 	raw<const definitions extends readonly FnDefinition[]>(...definitions: definitions): FnFactory<definitions>;
 }
+/** Options accepted by `Type.filter`. */
+export interface FilterOptions {
+	/**
+	 * Inspect the value exactly as handed in, skipping the input prevalidation
+	 * walk a filter normally gets. Use for predicates that only classify the raw
+	 * value (`Array.isArray`, `instanceof Date`): the prevalidation would walk
+	 * the whole input a second time — quadratic across nested schemas — and
+	 * observe getters and proxies twice, which a raw classifier gains nothing
+	 * from.
+	 */
+	raw?: boolean;
+}
 interface Step {
 	kind: "pipe" | "narrow" | "filter";
 	fn: (data: unknown, ctx: NarrowContext) => unknown;
@@ -412,6 +427,8 @@ interface Step {
 	try?: boolean;
 	/** Output IR when the step validates its output; drives public `.out`. */
 	out?: IR;
+	/** Filter step that inspects the raw input; see {@link FilterOptions.raw}. */
+	raw?: boolean;
 }
 /** Runtime constructor-like value used by ArkType-compatible `instanceof Type` checks. */
 export const Type = Object.defineProperty(function Type(): void {}, Symbol.hasInstance, {
@@ -894,8 +911,9 @@ const typeMethods = {
 		return appendPipes(this, [makeType(parseDef(def, this.resolver), [], {})], false, true);
 	},
 
-	filter(this: InternalType, fn: Step["fn"]): InternalType {
-		return makeType(this.ir, [{ kind: "filter", fn }, ...this[kSteps]], metaOf(this));
+	filter(this: InternalType, fn: Step["fn"], options?: FilterOptions): InternalType {
+		const step: Step = options?.raw === true ? { kind: "filter", fn, raw: true } : { kind: "filter", fn };
+		return makeType(this.ir, [step, ...this[kSteps]], metaOf(this));
 	},
 
 	narrow(this: InternalType, fn: Step["fn"]): InternalType {
@@ -1179,7 +1197,11 @@ function makeType(ir: IR, steps: Step[], meta: TypeMeta): unknown {
 	const base: Validator = (data: unknown): unknown => impl(data);
 	const errorConfig = meta.errorConfig ?? ir.cfg;
 
-	const filterInput = steps.some(step => step.kind === "filter") ? projectIO(ir, "in") : undefined;
+	// Raw filters classify the value as handed in, so they do not pay for (or
+	// want) the prevalidation walk; a single non-raw filter still triggers it.
+	const filterInput = steps.some(step => step.kind === "filter" && step.raw !== true)
+		? projectIO(ir, "in")
+		: undefined;
 	const validate: Validator =
 		steps.length === 0
 			? base

--- a/packages/omptype/src/type.ts
+++ b/packages/omptype/src/type.ts
@@ -2169,6 +2169,14 @@ function intersectResolved(a: IR, b: IR): IR {
 		(a.k === "object" && (b.k === "array" || b.k === "tuple")) ||
 		(b.k === "object" && (a.k === "array" || a.k === "tuple"))
 	) {
+		// Without a domain restriction the intersection is inhabited — an array
+		// carrying the object's properties — but a plain-only object excludes
+		// arrays outright, which is what makes `z.union([z.object(…),
+		// z.array(…)])` provably disjoint and keeps its structural `anyOf`
+		// instead of erasing to the ordered dispatcher.
+		if ((a.k === "object" && a.plain === true) || (b.k === "object" && b.plain === true)) {
+			throw new OmpTypeError("intersection of a plain object and an array is unsatisfiable");
+		}
 		return { k: "intersection", members: [a, b] };
 	}
 	const leftDomain = domainOf(a);

--- a/packages/omptype/src/type.ts
+++ b/packages/omptype/src/type.ts
@@ -431,7 +431,13 @@ function descriptionOf(ir: IR, seen: Set<IR> = new Set()): string {
 	if (ir.desc !== undefined) return ir.desc;
 	if (seen.has(ir)) return ir.k === "alias" ? ir.name : expectedOf(ir);
 	seen.add(ir);
-	if (ir.k === "alias") return descriptionOf(ir.resolve(), seen);
+	if (ir.k === "alias") {
+		// Deferred alias (z.lazy): its getter must not run before first parse —
+		// appendPipes resolves descriptions eagerly at composition time via
+		// metaOf, so resolving here would break recursive `const` definitions.
+		if (ir.deferred === true) return ir.name;
+		return descriptionOf(ir.resolve(), seen);
+	}
 	if (ir.k === "object") {
 		return `{ ${ir.props.map(prop => `${String(prop.key)}${prop.opt ? "?" : ""}: ${descriptionOf(prop.val, seen)}`).join(", ")} }`;
 	}

--- a/packages/omptype/src/type.ts
+++ b/packages/omptype/src/type.ts
@@ -2421,6 +2421,11 @@ function isSubtype(source: IR, target: IR, seen = new WeakMap<IR, Set<IR>>()): b
 		return lengthWithin(source, target) && isSubtype(source.el, target.el, seen);
 	}
 	if (source.k === "object" && target.k === "object") {
+		// A plain-only target accepts strictly less than an unrestricted one, so
+		// an unrestricted source cannot be its subtype. Ignoring this let union
+		// normalization prune the wider member and make the union's accepted
+		// input depend on declaration order.
+		if (target.plain === true && source.plain !== true) return false;
 		for (const targetProp of target.props) {
 			const sourceProp = source.props.find(prop => prop.key === targetProp.key);
 			if (sourceProp === undefined) {

--- a/packages/omptype/src/type.ts
+++ b/packages/omptype/src/type.ts
@@ -1899,6 +1899,9 @@ function mergeObjects(left: ObjectIR, right: ObjectIR): ObjectIR {
 				? undefined
 				: [...(left.patternIndexes ?? []), ...(right.patternIndexes ?? [])],
 		extras: right.extras === "keep" ? left.extras : right.extras,
+		// Spreading one object into another keeps the narrower input domain, for
+		// the same reason `intersect` does.
+		plain: left.plain === true || right.plain === true ? true : undefined,
 	};
 }
 
@@ -2110,7 +2113,11 @@ function intersectResolved(a: IR, b: IR): IR {
 					? "delete"
 					: "keep";
 		const index = a.index && b.index ? intersect(a.index, b.index) : (a.index ?? b.index);
-		return { k: "object", props, index, extras };
+		// An intersection accepts only what BOTH sides accept, so the narrower
+		// input domain wins: dropping `plain` here let `.and()` widen a schema
+		// back to accepting arrays and built-ins.
+		const plain = a.plain === true || b.plain === true ? true : undefined;
+		return { k: "object", props, index, extras, plain };
 	}
 	if (a.k === "string" && b.k === "string") {
 		const min = maxOf(a.min, b.min);

--- a/packages/omptype/src/type.ts
+++ b/packages/omptype/src/type.ts
@@ -293,11 +293,8 @@ interface FluentMethods<t, i> {
 	earlierThan(bound: Date | number): FluentType<t, i>;
 	readonly pipe: PipeMethod<t, i>;
 	to<const def>(def: def): FluentType<InferDef<def>, i>;
-	filter<narrowed extends i>(
-		fn: (data: i, ctx: NarrowContext) => data is narrowed,
-		options?: FilterOptions,
-	): FluentType<t, narrowed>;
-	filter(fn: (data: i, ctx: NarrowContext) => boolean | OmpErrors, options?: FilterOptions): FluentType<t, i>;
+	filter<narrowed extends i>(fn: (data: i, ctx: NarrowContext) => data is narrowed): FluentType<t, narrowed>;
+	filter(fn: (data: i, ctx: NarrowContext) => boolean | OmpErrors): FluentType<t, i>;
 	narrow<narrowed extends t>(fn: (data: t, ctx: NarrowContext) => data is narrowed): FluentType<narrowed, i>;
 	narrow(fn: (data: t, ctx: NarrowContext) => boolean | OmpErrors): FluentType<t, i>;
 	brand<const name extends string>(name: name): FluentType<Brand<t, name>, i>;
@@ -408,18 +405,6 @@ export interface FnParser {
 	<const definitions extends readonly FnDefinition[]>(...definitions: definitions): FnFactory<definitions>;
 	raw<const definitions extends readonly FnDefinition[]>(...definitions: definitions): FnFactory<definitions>;
 }
-/** Options accepted by `Type.filter`. */
-export interface FilterOptions {
-	/**
-	 * Inspect the value exactly as handed in, skipping the input prevalidation
-	 * walk a filter normally gets. Use for predicates that only classify the raw
-	 * value (`Array.isArray`, `instanceof Date`): the prevalidation would walk
-	 * the whole input a second time — quadratic across nested schemas — and
-	 * observe getters and proxies twice, which a raw classifier gains nothing
-	 * from.
-	 */
-	raw?: boolean;
-}
 interface Step {
 	kind: "pipe" | "narrow" | "filter";
 	fn: (data: unknown, ctx: NarrowContext) => unknown;
@@ -427,8 +412,6 @@ interface Step {
 	try?: boolean;
 	/** Output IR when the step validates its output; drives public `.out`. */
 	out?: IR;
-	/** Filter step that inspects the raw input; see {@link FilterOptions.raw}. */
-	raw?: boolean;
 }
 /** Runtime constructor-like value used by ArkType-compatible `instanceof Type` checks. */
 export const Type = Object.defineProperty(function Type(): void {}, Symbol.hasInstance, {
@@ -911,9 +894,8 @@ const typeMethods = {
 		return appendPipes(this, [makeType(parseDef(def, this.resolver), [], {})], false, true);
 	},
 
-	filter(this: InternalType, fn: Step["fn"], options?: FilterOptions): InternalType {
-		const step: Step = options?.raw === true ? { kind: "filter", fn, raw: true } : { kind: "filter", fn };
-		return makeType(this.ir, [step, ...this[kSteps]], metaOf(this));
+	filter(this: InternalType, fn: Step["fn"]): InternalType {
+		return makeType(this.ir, [{ kind: "filter", fn }, ...this[kSteps]], metaOf(this));
 	},
 
 	narrow(this: InternalType, fn: Step["fn"]): InternalType {
@@ -1201,11 +1183,7 @@ function makeType(ir: IR, steps: Step[], meta: TypeMeta): unknown {
 	const base: Validator = (data: unknown): unknown => impl(data);
 	const errorConfig = meta.errorConfig ?? ir.cfg;
 
-	// Raw filters classify the value as handed in, so they do not pay for (or
-	// want) the prevalidation walk; a single non-raw filter still triggers it.
-	const filterInput = steps.some(step => step.kind === "filter" && step.raw !== true)
-		? projectIO(ir, "in")
-		: undefined;
+	const filterInput = steps.some(step => step.kind === "filter") ? projectIO(ir, "in") : undefined;
 	const validate: Validator =
 		steps.length === 0
 			? base

--- a/packages/omptype/src/type.ts
+++ b/packages/omptype/src/type.ts
@@ -1444,6 +1444,9 @@ function morphIdentities(ir: IR, identities: unknown[] = [], seen = new Set<IR>(
 			morphIdentities(ir.base, identities, seen);
 			break;
 		case "alias":
+			// Deferred alias (z.lazy): no identities known without resolving the
+			// getter, and resolving here would run user code during construction.
+			if (ir.deferred === true) break;
 			morphIdentities(ir.resolve(), identities, seen);
 			break;
 	}
@@ -1496,6 +1499,9 @@ function assertDeterminateMorphUnions(ir: IR, seen = new Set<IR>()): void {
 	}
 	switch (ir.k) {
 		case "alias":
+			// Deferred alias (z.lazy): skip — content unknown until first parse;
+			// its morph-ness is already handled conservatively by hasMorph.
+			if (ir.deferred === true) return;
 			assertDeterminateMorphUnions(ir.resolve(), seen);
 			break;
 		case "morph":

--- a/packages/omptype/src/type.ts
+++ b/packages/omptype/src/type.ts
@@ -1115,7 +1115,11 @@ Object.defineProperty(typeMethods, "~standard", {
 
 Object.defineProperty(typeMethods, "in", {
 	get(this: InternalType): InternalType {
-		return makeType(projectIO(this.ir, "in"), [], {});
+		// Filter steps ARE the input side: dropping them would let `.in` admit
+		// values the schema itself rejects. `narrow`/`pipe` steps run on the
+		// output and are correctly absent here.
+		const filters = this[kSteps].filter(step => step.kind === "filter");
+		return makeType(projectIO(this.ir, "in"), filters, {});
 	},
 });
 

--- a/packages/omptype/src/type.ts
+++ b/packages/omptype/src/type.ts
@@ -1418,15 +1418,14 @@ function morphIdentities(ir: IR, identities: unknown[] = [], seen = new Set<IR>(
 			// A declared-out morph whose projected sides contain one falls back
 			// to its function identity — strictly finer than the string form.
 			const out = ir.out;
+			const projectedIn = projectIO(ir.input, "in");
+			const projectedOut = out === undefined ? undefined : projectIO(out, "out");
 			const declared =
 				out !== undefined &&
-				!hasDeferredAlias(projectIO(ir.input, "in")) &&
-				!hasDeferredAlias(projectIO(out, "out"));
-			identities.push(
-				declared
-					? `declared:${expressionOf(projectIO(ir.input, "in"))}=>${expressionOf(projectIO(out, "out"))}`
-					: ir.fn,
-			);
+				projectedOut !== undefined &&
+				!hasDeferredAlias(projectedIn) &&
+				!hasDeferredAlias(projectedOut);
+			identities.push(declared ? `declared:${expressionOf(projectedIn)}=>${expressionOf(projectedOut)}` : ir.fn);
 			morphIdentities(ir.input, identities, seen);
 			if (ir.out !== undefined) morphIdentities(ir.out, identities, seen);
 			break;

--- a/packages/omptype/src/type.ts
+++ b/packages/omptype/src/type.ts
@@ -1014,8 +1014,16 @@ const typeMethods = {
 			this.allows = allows;
 			return allows(data);
 		}
-		for (const step of steps) {
-			if (step.kind === "filter" && !step.fn(data, new Ctx(data))) return false;
+		if (steps.some(step => step.kind === "filter")) {
+			// Mirror the callable path, which validates the projected input before
+			// running any filter: a predicate receives a value of its declared
+			// input type, so `v.a.length` cannot throw on malformed data. Without
+			// this, `allows()` invoked the predicate first and a filter carried
+			// into `.in` turned a rejection into an exception.
+			if (walk(projectIO(this.ir, "in"), data) instanceof OmpErrors) return false;
+			for (const step of steps) {
+				if (step.kind === "filter" && !step.fn(data, new Ctx(data))) return false;
+			}
 		}
 		const out = this[kBase](data);
 		if (out instanceof OmpErrors) return false;

--- a/packages/omptype/src/type.ts
+++ b/packages/omptype/src/type.ts
@@ -22,6 +22,7 @@ import {
 	type EmbeddableSchema,
 	embed,
 	expectedOf,
+	hasDeferredAlias,
 	hasMorph,
 	type IR,
 	IR_BRAND,
@@ -1412,15 +1413,24 @@ function morphIdentities(ir: IR, identities: unknown[] = [], seen = new Set<IR>(
 	if (seen.has(ir)) return identities;
 	seen.add(ir);
 	switch (ir.k) {
-		case "morph":
+		case "morph": {
+			// Deferred aliases must not resolve here (construction-time scan).
+			// A declared-out morph whose projected sides contain one falls back
+			// to its function identity — strictly finer than the string form.
+			const out = ir.out;
+			const declared =
+				out !== undefined &&
+				!hasDeferredAlias(projectIO(ir.input, "in")) &&
+				!hasDeferredAlias(projectIO(out, "out"));
 			identities.push(
-				ir.out === undefined
-					? ir.fn
-					: `declared:${expressionOf(projectIO(ir.input, "in"))}=>${expressionOf(projectIO(ir.out, "out"))}`,
+				declared
+					? `declared:${expressionOf(projectIO(ir.input, "in"))}=>${expressionOf(projectIO(out, "out"))}`
+					: ir.fn,
 			);
 			morphIdentities(ir.input, identities, seen);
 			if (ir.out !== undefined) morphIdentities(ir.out, identities, seen);
 			break;
+		}
 		case "sub": {
 			const schema = ir.schema as InternalType;
 			for (const step of schema[kSteps]) if (step.kind === "pipe") identities.push(step.fn);
@@ -1476,12 +1486,16 @@ function assertDeterminateMorphUnions(ir: IR, seen = new Set<IR>()): void {
 				) {
 					continue;
 				}
-				// Unwrap one alias level eagerly: the disjointness probe relies on
-				// intersect() throwing, and deferred alias intersections resolve lazily.
+				// Unwrap one alias level eagerly — but never a deferred one: its
+				// getter must not run during construction, and intersect() with the
+				// unresolved alias returns a lazy reference, which the probe reads
+				// as "overlap unproven" → indeterminate → the shim's ordered
+				// dispatcher. The widening gates normally exclude such members;
+				// this guard is the backstop.
 				let leftInput = projectIO(left, "in");
 				let rightInput = projectIO(right, "in");
-				if (leftInput.k === "alias") leftInput = leftInput.resolve();
-				if (rightInput.k === "alias") rightInput = rightInput.resolve();
+				if (leftInput.k === "alias" && leftInput.deferred !== true) leftInput = leftInput.resolve();
+				if (rightInput.k === "alias" && rightInput.deferred !== true) rightInput = rightInput.resolve();
 				if (leftInput.k === "object" && rightInput.k === "object") {
 					const leftKeys = new Set(leftInput.props.map(prop => prop.key));
 					const rightKeys = new Set(rightInput.props.map(prop => prop.key));

--- a/packages/omptype/src/zod.ts
+++ b/packages/omptype/src/zod.ts
@@ -51,22 +51,40 @@ export interface ZodLikeSchema<out Out> extends Type<Out, unknown> {
 	regex(expression: RegExp, message?: string): ZodLikeSchema<Out>;
 	url(): ZodLikeSchema<Out>;
 	optional(): ZodLikeSchema<Out | undefined> & OptionalSchemaMarker;
+	nullable(this: ZodLikeSchema<Out> & OptionalSchemaMarker): ZodLikeSchema<Out | null> & OptionalSchemaMarker;
 	nullable(): ZodLikeSchema<Out | null>;
 	default(value: Exclude<Out, undefined> | (() => Exclude<Out, undefined>)): ZodLikeSchema<Exclude<Out, undefined>>;
 	/**
-	 * The `this`-typed overloads keep {@link OptionalSchemaMarker} attached: the
-	 * runtime decorator already carries `isOptional` through both methods, and
-	 * without them `z.infer` reports `z.string().optional().describe("…")` (or
-	 * `.readonly()`) as a REQUIRED property whose value includes `undefined`,
-	 * disagreeing with the parse that accepts the key's absence.
+	 * The `this`-typed overloads keep {@link OptionalSchemaMarker} attached
+	 * wherever the runtime decorator carries `isOptional` through — every
+	 * wrapper that returns the same schema in a new coat. Without them `z.infer`
+	 * reports `z.string().optional().refine(…)` (or `.describe()`,
+	 * `.readonly()`, `.transform()`, `.catch()`, `.nullable()`) as a REQUIRED
+	 * property whose value includes `undefined`, disagreeing with the parse that
+	 * accepts the key's absence. Keyed off the receiver rather than
+	 * `undefined extends Out`, which would also mark a genuine `z.undefined()`
+	 * property optional.
 	 */
 	describe(
 		this: ZodLikeSchema<Out> & OptionalSchemaMarker,
 		description: string,
 	): ZodLikeSchema<Out> & OptionalSchemaMarker;
 	describe(description: string): ZodLikeSchema<Out>;
+	refine(
+		this: ZodLikeSchema<Out> & OptionalSchemaMarker,
+		predicate: (value: Out) => unknown,
+		messageOrOptions?: string | RefineOptions,
+	): ZodLikeSchema<Out> & OptionalSchemaMarker;
 	refine(predicate: (value: Out) => unknown, messageOrOptions?: string | RefineOptions): ZodLikeSchema<Out>;
+	transform<Next>(
+		this: ZodLikeSchema<Out> & OptionalSchemaMarker,
+		transformer: (value: Out) => Next,
+	): ZodLikeSchema<Next> & OptionalSchemaMarker;
 	transform<Next>(transformer: (value: Out) => Next): ZodLikeSchema<Next>;
+	catch(
+		this: ZodLikeSchema<Out> & OptionalSchemaMarker,
+		fallback: Out | (() => Out),
+	): ZodLikeSchema<Out> & OptionalSchemaMarker;
 	catch(fallback: Out | (() => Out)): ZodLikeSchema<Out>;
 	strict(): ZodLikeSchema<Out>;
 	passthrough(): ZodLikeSchema<Out & Record<string, unknown>>;

--- a/packages/omptype/src/zod.ts
+++ b/packages/omptype/src/zod.ts
@@ -603,7 +603,10 @@ export const union = <
  * dispatched on identity.
  */
 function isDispatchableLiteral(value: unknown): boolean {
-	if (value === null || value === undefined) return true;
+	// `null` has a JSON form; `undefined` does not — a property pinned to it
+	// emits an unconstrained schema inside `required`, which a provider can
+	// neither encode nor select, so the branch is unreachable in practice.
+	if (value === null) return true;
 	switch (typeof value) {
 		case "string":
 		case "boolean":
@@ -616,10 +619,14 @@ function isDispatchableLiteral(value: unknown): boolean {
 }
 
 /**
- * The values `ir` can take when that set is finite AND dispatchable — literals,
- * `null`, `undefined`, and unions of those (`z.enum`, a literal union).
- * `undefined` means the set is open, or pinned to something that cannot be
- * dispatched on, so nothing can be selected by it.
+ * The values `ir` can take when that set is finite and advertisable — literals,
+ * `null`, and unions of those (`z.enum`, a literal union). `undefined`
+ * contributes no value rather than opening the set: a `.default()`-widened
+ * literal is `lit | undefined`, and the default fills the absent case, so the
+ * literal still dispatches. A returned `undefined` means the set is open (or
+ * pinned to something unadvertisable) and nothing can be selected by it; an
+ * empty array means every member was `undefined`, which callers treat the same
+ * way.
  */
 function finiteValues(ir: IR, seen?: Set<IR>): unknown[] | undefined {
 	switch (ir.k) {
@@ -628,7 +635,7 @@ function finiteValues(ir: IR, seen?: Set<IR>): unknown[] | undefined {
 		case "null":
 			return [null];
 		case "undefined":
-			return [undefined];
+			return [];
 		case "union": {
 			const values: unknown[] = [];
 			for (const member of ir.members) {
@@ -636,7 +643,7 @@ function finiteValues(ir: IR, seen?: Set<IR>): unknown[] | undefined {
 				if (inner === undefined) return undefined;
 				values.push(...inner);
 			}
-			return values.length > 0 ? values : undefined;
+			return values;
 		}
 		case "refine":
 			return finiteValues(ir.base, seen);
@@ -666,7 +673,9 @@ function discriminatorValues(ir: IR, key: string, seen?: Set<IR>): unknown[] | u
 	switch (ir.k) {
 		case "object": {
 			const prop = ir.props.find(candidate => candidate.key === key);
-			return prop === undefined ? undefined : finiteValues(prop.val, seen);
+			if (prop === undefined) return undefined;
+			const values = finiteValues(prop.val, seen);
+			return values === undefined || values.length === 0 ? undefined : values;
 		}
 		case "union": {
 			const values: unknown[] = [];

--- a/packages/omptype/src/zod.ts
+++ b/packages/omptype/src/zod.ts
@@ -130,7 +130,11 @@ function decorate<Out>(schema: Decoratable<Out>, optional = false): ZodLikeSchem
 	const next = (inner: Decoratable<Out>, nextOptional = optional): ZodLikeSchema<Out> => decorate(inner, nextOptional);
 	const withObjectExtras = (extras: "keep" | "reject" | "delete"): ZodLikeSchema<Out> => {
 		if (schema.ir.k !== "object") throw new OmpTypeError("object mode requires an object schema");
-		return next(restrictBase(schema, { ...schema.ir, extras }));
+		const restricted = restrictBase(schema, { ...schema.ir, extras });
+		// Same reasoning as objectSchema: the guard is only meaningful where the
+		// object does not strip keys, so `.strict()`/`.passthrough()` reject
+		// arrays exactly like `z.strictObject`/`z.looseObject`.
+		return next(extras === "delete" ? restricted : rejectArrays(restricted));
 	};
 	Object.defineProperty(schema, "isOptional", { value: optional, enumerable: false });
 
@@ -389,6 +393,19 @@ type ObjectOutput<S extends Shape> = {
 type Simplify<T> = { [K in keyof T]: T[K] };
 type UnionOutput<Schemas extends readonly ZodLikeSchema<unknown>[]> = SchemaOutput<Schemas[number]>;
 
+/**
+ * Reject an array reaching an object schema, which zod does and the emitted
+ * `{"type":"object"}` already promises. Only usable where the object does NOT
+ * strip keys: a narrow step observes the object node's OUTPUT, and a
+ * key-stripping object has already turned `[]` into `{}` by then, so the guard
+ * would inspect the wrong value. Stripping objects therefore keep omptype's
+ * object-node semantics (arrays are objects), which is what `type({})` does
+ * too — tightening that belongs in the IR's object arm, not here.
+ */
+function rejectArrays<Out>(schema: Decoratable<Out>): Decoratable<Out> {
+	return schema.narrow((value, ctx: NarrowContext) => !Array.isArray(value) || ctx.mustBe("an object, not an array"));
+}
+
 function objectSchema<const S extends Shape>(shape: S, extras: Extras = "delete"): ZodLikeSchema<ObjectOutput<S>> {
 	const props: PropIR[] = [];
 	for (const key in shape) {
@@ -401,9 +418,8 @@ function objectSchema<const S extends Shape>(shape: S, extras: Extras = "delete"
 		}
 		props.push(prop);
 	}
-	return decorateUnknown(schemaFromIR<unknown>({ k: "object", props, extras })) as unknown as ZodLikeSchema<
-		ObjectOutput<S>
-	>;
+	const base = schemaFromIR<unknown>({ k: "object", props, extras });
+	return decorateUnknown(extras === "delete" ? base : rejectArrays(base)) as unknown as ZodLikeSchema<ObjectOutput<S>>;
 }
 
 export const string = (): ZodLikeSchema<string> => decorate(schemaFromIR(type.string.ir));

--- a/packages/omptype/src/zod.ts
+++ b/packages/omptype/src/zod.ts
@@ -508,28 +508,31 @@ function discriminantLiteral(ir: IR, key: string): unknown {
  * be dispatched on but is a legitimate variant — it falls through to the
  * ordered attempt. A non-object variant, or an object without the key, is a
  * definition error instead: nothing about it can honour the dispatch contract.
+ *
+ * `deferred` chooses what to do with a `z.lazy` alias: `"accept"` at
+ * construction, where running the getter would break recursive definitions via
+ * TDZ, and `"resolve"` at first parse, the earliest point zod's contract allows
+ * the content to be inspected.
  */
-function declaresDiscriminator(ir: IR, key: string, seen?: Set<IR>): boolean {
+function declaresDiscriminator(ir: IR, key: string, deferred: "accept" | "resolve", seen?: Set<IR>): boolean {
 	switch (ir.k) {
 		case "object":
 			return ir.props.some(prop => prop.key === key);
 		case "union":
-			return ir.members.every(member => declaresDiscriminator(member, key, seen));
+			return ir.members.every(member => declaresDiscriminator(member, key, deferred, seen));
 		case "intersection":
-			return ir.members.some(member => declaresDiscriminator(member, key, seen));
+			return ir.members.some(member => declaresDiscriminator(member, key, deferred, seen));
 		case "sub":
-			return declaresDiscriminator(ir.schema.ir, key, seen);
+			return declaresDiscriminator(ir.schema.ir, key, deferred, seen);
 		case "morph":
 			// restrictBase wraps a stepped schema in a morph over its base IR.
-			return declaresDiscriminator(ir.input, key, seen);
+			return declaresDiscriminator(ir.input, key, deferred, seen);
 		case "alias": {
-			// A deferred z.lazy cannot be inspected before first parse; accept it
-			// rather than running the getter (TDZ) or rejecting a valid variant.
-			if (ir.deferred === true) return true;
+			if (ir.deferred === true && deferred === "accept") return true;
 			if (seen?.has(ir)) return false;
 			const active = seen ?? new Set<IR>();
 			active.add(ir);
-			return declaresDiscriminator(ir.resolve(), key, active);
+			return declaresDiscriminator(ir.resolve(), key, deferred, active);
 		}
 		default:
 			return false;
@@ -542,11 +545,13 @@ function declaresDiscriminator(ir: IR, key: string, seen?: Set<IR>): boolean {
  * (or no variant declares a usable literal), every variant is attempted in
  * order so failures still report against the full union.
  *
- * A variant that cannot declare the discriminator at all is rejected at
- * construction, matching zod: the public signature accepts any schema, so
+ * A variant that cannot declare the discriminator is rejected as a definition
+ * error, matching zod: the public signature accepts any schema, so
  * `z.discriminatedUnion("kind", [z.string(), z.number()])` would otherwise
  * build a plain string/number union that accepts `"x"` — silently dropping the
- * dispatch contract the call advertises.
+ * dispatch contract the call advertises. Statically inspectable variants throw
+ * at construction; a `z.lazy` variant is re-checked once its getter has run,
+ * so wrapping the same invalid definition in `z.lazy` cannot bypass the check.
  */
 export const discriminatedUnion = <
 	const Discriminator extends string,
@@ -555,10 +560,10 @@ export const discriminatedUnion = <
 	discriminator: Discriminator,
 	schemas: Schemas,
 ): ZodLikeSchema<UnionOutput<Schemas>> => {
+	const variantError = (index: number): OmpTypeError =>
+		new OmpTypeError(`discriminatedUnion variant ${index} does not declare a "${discriminator}" property`);
 	for (const [index, schema] of schemas.entries()) {
-		if (!declaresDiscriminator(schema.ir, discriminator)) {
-			throw new OmpTypeError(`discriminatedUnion variant ${index} does not declare a "${discriminator}" property`);
-		}
+		if (!declaresDiscriminator(schema.ir, discriminator, "accept")) throw variantError(index);
 	}
 	const variantIrs = schemas.map(schema => embed(schema));
 	// Same gate as union() above: variants are embedded so stepped variants
@@ -580,8 +585,25 @@ export const discriminatedUnion = <
 	const variants = schemas.map(schema => ({
 		schema: schema as ZodLikeSchema<unknown>,
 		literal: discriminantLiteral(schema.ir, discriminator),
+		// A deferred variant was accepted unresolved above; its content is only
+		// knowable once the getter has run, which is what `deferred` marks for
+		// the one-time re-check below.
+		deferred: hasDeferredAlias(schema.ir),
 	}));
+	let checked = !variants.some(variant => variant.deferred);
 	const dispatch = type.unknown.pipe((value, ctx) => {
+		if (!checked) {
+			// First parse: resolution is now legal, so a `z.lazy` variant that
+			// never declares the discriminator surfaces as the same definition
+			// error instead of quietly matching every object. Flag set only
+			// after every variant passes, so a broken definition keeps throwing.
+			variants.forEach((variant, index) => {
+				if (variant.deferred && !declaresDiscriminator(variant.schema.ir, discriminator, "resolve")) {
+					throw variantError(index);
+				}
+			});
+			checked = true;
+		}
 		if (typeof value !== "object" || value === null) {
 			return ctx.error(`an object with a "${discriminator}" discriminator`);
 		}

--- a/packages/omptype/src/zod.ts
+++ b/packages/omptype/src/zod.ts
@@ -887,9 +887,22 @@ export const array = <Element>(element: ZodLikeSchema<Element>): ZodLikeSchema<E
 	decorate(schemaFromIR({ k: "array", el: embed(element) }));
 export const object = <const S extends Shape>(shape: S): ZodLikeSchema<Simplify<ObjectOutput<S>>> =>
 	objectSchema(shape);
-/** Object that rejects undeclared keys (zod `z.strictObject`). */
+/**
+ * Object that rejects undeclared keys (zod `z.strictObject`).
+ *
+ * Unlike `z.object`, whose key stripping allocates, this hands back the input
+ * object itself when validation succeeds — omptype only builds a new value when
+ * validating changes it. Mutating the parse result therefore mutates the input,
+ * which zod does not do. Left as-is deliberately: allocating would require the
+ * object node to report itself as output-changing, which makes overlapping
+ * loose-object unions indeterminate and erases their provider-facing schema.
+ */
 export const strictObject = <const S extends Shape>(shape: S): ZodLikeSchema<Simplify<ObjectOutput<S>>> =>
 	objectSchema(shape, "reject");
+/**
+ * Object that keeps undeclared keys (zod `z.looseObject`). Hands back the input
+ * object itself, prototype included — see {@link strictObject} for why.
+ */
 export const looseObject = <const S extends Shape>(
 	shape: S,
 ): ZodLikeSchema<Simplify<ObjectOutput<S>> & Record<string, unknown>> =>

--- a/packages/omptype/src/zod.ts
+++ b/packages/omptype/src/zod.ts
@@ -502,10 +502,51 @@ function discriminantLiteral(ir: IR, key: string): unknown {
 }
 
 /**
+ * True when `ir` structurally declares `key`, the minimum a discriminated-union
+ * variant must do to be dispatchable at all. Deliberately weaker than "pins a
+ * literal": zod 4 accepts an enum or literal-union discriminator, which cannot
+ * be dispatched on but is a legitimate variant — it falls through to the
+ * ordered attempt. A non-object variant, or an object without the key, is a
+ * definition error instead: nothing about it can honour the dispatch contract.
+ */
+function declaresDiscriminator(ir: IR, key: string, seen?: Set<IR>): boolean {
+	switch (ir.k) {
+		case "object":
+			return ir.props.some(prop => prop.key === key);
+		case "union":
+			return ir.members.every(member => declaresDiscriminator(member, key, seen));
+		case "intersection":
+			return ir.members.some(member => declaresDiscriminator(member, key, seen));
+		case "sub":
+			return declaresDiscriminator(ir.schema.ir, key, seen);
+		case "morph":
+			// restrictBase wraps a stepped schema in a morph over its base IR.
+			return declaresDiscriminator(ir.input, key, seen);
+		case "alias": {
+			// A deferred z.lazy cannot be inspected before first parse; accept it
+			// rather than running the getter (TDZ) or rejecting a valid variant.
+			if (ir.deferred === true) return true;
+			if (seen?.has(ir)) return false;
+			const active = seen ?? new Set<IR>();
+			active.add(ir);
+			return declaresDiscriminator(ir.resolve(), key, active);
+		}
+		default:
+			return false;
+	}
+}
+
+/**
  * Union dispatched on a literal discriminator property. Variants whose IR pins
  * the discriminator to the input's value are tried first; when nothing matches
  * (or no variant declares a usable literal), every variant is attempted in
  * order so failures still report against the full union.
+ *
+ * A variant that cannot declare the discriminator at all is rejected at
+ * construction, matching zod: the public signature accepts any schema, so
+ * `z.discriminatedUnion("kind", [z.string(), z.number()])` would otherwise
+ * build a plain string/number union that accepts `"x"` — silently dropping the
+ * dispatch contract the call advertises.
  */
 export const discriminatedUnion = <
 	const Discriminator extends string,
@@ -514,6 +555,11 @@ export const discriminatedUnion = <
 	discriminator: Discriminator,
 	schemas: Schemas,
 ): ZodLikeSchema<UnionOutput<Schemas>> => {
+	for (const [index, schema] of schemas.entries()) {
+		if (!declaresDiscriminator(schema.ir, discriminator)) {
+			throw new OmpTypeError(`discriminatedUnion variant ${index} does not declare a "${discriminator}" property`);
+		}
+	}
 	const variantIrs = schemas.map(schema => embed(schema));
 	// Same gate as union() above: variants are embedded so stepped variants
 	// keep their steps and their exported structure, only deferred aliases are

--- a/packages/omptype/src/zod.ts
+++ b/packages/omptype/src/zod.ts
@@ -1,5 +1,5 @@
 import { type OmpErrors, OmpTypeError } from "./errors";
-import { type EmbeddableSchema, embed, type IR, IR_BRAND, type PropIR } from "./ir";
+import { type EmbeddableSchema, type Extras, embed, hasMorph, type IR, IR_BRAND, type PropIR } from "./ir";
 import { type NarrowContext, type Type, type } from "./type";
 
 interface OptionalSchemaMarker {
@@ -25,9 +25,7 @@ export interface ZodLikeIssue {
 	message: string;
 }
 
-export type ZodLikeSafeParseResult<Out> =
-	| { success: true; data: Out }
-	| { success: false; error: { message: string; issues: ZodLikeIssue[] } };
+export type ZodLikeSafeParseResult<Out> = { success: true; data: Out } | { success: false; error: ZodError };
 
 /** A callable omptype schema carrying the Zod-v4-style fluent surface. */
 export interface ZodLikeSchema<out Out> extends Type<Out, unknown> {
@@ -54,6 +52,7 @@ export interface ZodLikeSchema<out Out> extends Type<Out, unknown> {
 	passthrough(): ZodLikeSchema<Out & Record<string, unknown>>;
 	strip(): ZodLikeSchema<Out>;
 	partial(): Out extends object ? ZodLikeSchema<Partial<Out>> : ZodLikeSchema<Out>;
+	readonly(): ZodLikeSchema<Readonly<Out>>;
 }
 
 function schemaFromIR<Out>(ir: IR): Decoratable<Out> {
@@ -65,6 +64,30 @@ function schemaFromIR<Out>(ir: IR): Decoratable<Out> {
 		run: value => value,
 	};
 	return type.raw(embedded) as unknown as Decoratable<Out>;
+}
+
+/**
+ * `value === undefined` short-circuit around an inner schema, as a dispatch
+ * morph. Composing a real union (`schema | undefined`) instead would trip
+ * omptype's unordered-union determinism check whenever the inner side carries
+ * morphs — which every shim-level recursive/lazy schema does.
+ */
+function undefinedDispatch<Out>(
+	schema: Decoratable<Out>,
+	fallback: (() => Out) | undefined,
+): Decoratable<Out | undefined> {
+	return schemaFromIR<Out | undefined>({
+		k: "morph",
+		input: { k: "unknown" },
+		fn: (input, ctx) => {
+			if (input === undefined) {
+				return fallback === undefined ? undefined : fallback();
+			}
+			const result = schema(input);
+			if (!(result instanceof type.errors)) return result;
+			return ctx.error(fallback === undefined ? "the schema or undefined" : "the default or a valid value");
+		},
+	});
 }
 
 function restrictBase<Out>(source: Decoratable<Out>, ir: IR): Decoratable<Out> {
@@ -186,22 +209,84 @@ function decorate<Out>(schema: Decoratable<Out>, optional = false): ZodLikeSchem
 			return next(restrictBase(schema, { ...schema.ir, url: true }));
 		},
 		optional(): ZodLikeSchema<Out | undefined> & OptionalSchemaMarker {
-			const widened = schema.or(type.raw("undefined")) as Decoratable<Out | undefined>;
-			return decorate(widened, true) as ZodLikeSchema<Out | undefined> & OptionalSchemaMarker;
+			// Purely structural inner schemas keep a real union so structural
+			// metadata (JSON Schema export, descriptions) survives the widening.
+			// Anything carrying a runtime pipeline takes the dispatch morph below:
+			// `hasMorph(ir)` covers in-IR morphs (lazy, string.numeric.parse), and
+			// `hasSteps` covers Type-attached `.transform()`/`.refine()` steps the
+			// IR alone cannot see — rebuilding from `schema.ir` would silently
+			// DROP those steps, not just degrade the emitted JSON Schema.
+			if (!schema.hasSteps && !hasMorph(schema.ir)) {
+				return decorate(
+					schemaFromIR<Out | undefined>({ k: "union", members: [schema.ir, { k: "undefined" }] }),
+					true,
+				) as ZodLikeSchema<Out | undefined> & OptionalSchemaMarker;
+			}
+			return decorate(undefinedDispatch<Out>(schema, undefined), true) as ZodLikeSchema<Out | undefined> &
+				OptionalSchemaMarker;
 		},
 		nullable(): ZodLikeSchema<Out | null> {
-			return decorate(schema.or(type.raw("null")) as Decoratable<Out | null>, optional);
+			// Purely structural inner schemas keep a real union so structural
+			// metadata (JSON Schema export for provider tool definitions) survives
+			// the widening — the dispatcher morph below erases the IR, emitting
+			// `{}` for the member. Same pipeline gate as optional() above.
+			if (!schema.hasSteps && !hasMorph(schema.ir)) {
+				return decorate(
+					schemaFromIR<Out | null>({ k: "union", members: [schema.ir, { k: "lit", v: null }] }),
+					optional,
+				) as ZodLikeSchema<Out | null>;
+			}
+			const inner = schema;
+			const nullable = schemaFromIR<Out | null>({
+				k: "morph",
+				input: { k: "unknown" },
+				fn: (input, ctx) => {
+					if (input === null) return null;
+					const result = inner(input);
+					if (!(result instanceof type.errors)) return result;
+					return ctx.error("the schema or null");
+				},
+			});
+			return decorate(nullable, optional) as ZodLikeSchema<Out | null>;
 		},
 		default(
 			value: Exclude<Out, undefined> | (() => Exclude<Out, undefined>),
 		): ZodLikeSchema<Exclude<Out, undefined>> {
 			type DefaultOut = Exclude<Out, undefined>;
-			const widened = schema.or(type.raw("undefined")) as Decoratable<Out | undefined>;
-			const piped = widened.pipe(output => {
-				if (output !== undefined) return output as DefaultOut;
-				return typeof value === "function" ? (value as () => DefaultOut)() : value;
-			}) as Decoratable<DefaultOut>;
-			return decorate(piped.default(value as DefaultOut | (() => DefaultOut)));
+			// Morph-free inner schemas keep the original union+pipe composition so
+			// structural metadata survives JSON-Schema export.
+			if (!hasMorph(schema.ir)) {
+				const widened = schema.or(type.raw("undefined")) as Decoratable<Out | undefined>;
+				const pipedPlain = widened.pipe(output => {
+					if (output !== undefined) return output as DefaultOut;
+					return typeof value === "function" ? (value as () => DefaultOut)() : value;
+				}) as unknown as Decoratable<DefaultOut>;
+				const plain = decorate(pipedPlain);
+				Object.defineProperty(plain, "hasDefault", { value: true, enumerable: false });
+				Object.defineProperty(plain, "defaultValue", { value, enumerable: false });
+				return plain;
+			}
+			const fallback = value;
+			const piped = decorate(
+				schemaFromIR<DefaultOut>({
+					k: "morph",
+					input: { k: "unknown" },
+					fn: (input, ctx) => {
+						if (input === undefined) {
+							return typeof fallback === "function" ? (fallback as () => DefaultOut)() : fallback;
+						}
+						const result = schema(input);
+						if (!(result instanceof type.errors)) return result;
+						return ctx.error("the default or a valid value");
+					},
+				}),
+			) as unknown as Decoratable<DefaultOut>;
+			const result = decorate(piped);
+			// Stamp the default metadata objectSchema() reads when embedding this
+			// schema as a property: the prop must stay optional with this fallback.
+			Object.defineProperty(result, "hasDefault", { value: true, enumerable: false });
+			Object.defineProperty(result, "defaultValue", { value, enumerable: false });
+			return result;
 		},
 		describe(description: string): ZodLikeSchema<Out> {
 			return next(restrictBase(schema, { ...schema.ir, desc: description }).describe(description));
@@ -244,6 +329,39 @@ function decorate<Out>(schema: Decoratable<Out>, optional = false): ZodLikeSchem
 				? ZodLikeSchema<Partial<Out>>
 				: ZodLikeSchema<Out>;
 		},
+		/**
+		 * Matches Zod's runtime contract: `.readonly()` is not merely a type
+		 * cast, it shallow-freezes successful parse output (`Object.freeze`,
+		 * one level deep — a nested object is left mutable, exactly like Zod).
+		 *
+		 * Zod freezes its own freshly constructed parse output; omptype's
+		 * parsing shares structure with the input (a parent copy keeps child
+		 * references), so freezing in place would freeze the CALLER's input
+		 * graph — e.g. a persisted session entry schema-validated before blob
+		 * hydration must stay mutable. Shallow-clone first (object spread uses
+		 * define semantics, so an own `__proto__` key survives), then freeze
+		 * the clone.
+		 *
+		 * Only plain objects and arrays are cloned+frozen. A non-plain object
+		 * (a Date/Map/class instance reachable via `z.unknown()`/`z.any()`/a
+		 * transform) has no non-destructive shallow clone — spreading it would
+		 * produce a prototype-less husk with no internal slots — and freezing
+		 * it in place would mutate the caller's value, so it passes through
+		 * untouched: never-freeze-the-input outranks freeze-the-output for the
+		 * shim's JSON-oriented use. Primitives and functions pass through for
+		 * the same reason.
+		 */
+		readonly(): ZodLikeSchema<Readonly<Out>> {
+			return next(
+				schema.pipe(value => {
+					if (typeof value !== "object" || value === null) return value;
+					const proto = Object.getPrototypeOf(value);
+					if (!Array.isArray(value) && proto !== Object.prototype && proto !== null) return value;
+					const clone = Array.isArray(value) ? [...(value as unknown[])] : { ...(value as object) };
+					return Object.freeze(clone) as Out;
+				}),
+			) as ZodLikeSchema<Readonly<Out>>;
+		},
 	}) as unknown as ZodLikeSchema<Out>;
 }
 
@@ -263,7 +381,7 @@ type ObjectOutput<S extends Shape> = {
 type Simplify<T> = { [K in keyof T]: T[K] };
 type UnionOutput<Schemas extends readonly ZodLikeSchema<unknown>[]> = SchemaOutput<Schemas[number]>;
 
-function objectSchema<const S extends Shape>(shape: S): ZodLikeSchema<ObjectOutput<S>> {
+function objectSchema<const S extends Shape>(shape: S, extras: Extras = "delete"): ZodLikeSchema<ObjectOutput<S>> {
 	const props: PropIR[] = [];
 	for (const key in shape) {
 		const member = shape[key];
@@ -275,7 +393,7 @@ function objectSchema<const S extends Shape>(shape: S): ZodLikeSchema<ObjectOutp
 		}
 		props.push(prop);
 	}
-	return decorateUnknown(schemaFromIR<unknown>({ k: "object", props, extras: "delete" })) as unknown as ZodLikeSchema<
+	return decorateUnknown(schemaFromIR<unknown>({ k: "object", props, extras })) as unknown as ZodLikeSchema<
 		ObjectOutput<S>
 	>;
 }
@@ -293,16 +411,127 @@ const enumSchema = <const Values extends readonly [string, ...string[]]>(
 };
 
 export { enumSchema as enum };
+// Ordered first-match dispatcher rather than an omptype union: zod unions try
+// branches in declaration order, while omptype's unordered unions reject
+// overlapping morph inputs — a shape recursive schemas (`lazy` is a morph)
+// hit constantly. Wrapping the members in one unknown-input morph keeps zod's
+// ordering and keeps member morphs invisible to the determinism check.
+//
+// The dispatcher is reserved for unions that actually contain a morph: a
+// morph-free union stays structural, because the morph wrapper erases the IR
+// and `toJsonSchema()` then emits `{}` for the member — a provider-facing
+// tool parameter would appear unconstrained. For pure validators any-match
+// equals first-match, so zod's ordering is not observable there.
 export const union = <
 	const Schemas extends readonly [ZodLikeSchema<unknown>, ZodLikeSchema<unknown>, ...ZodLikeSchema<unknown>[]],
 >(
 	schemas: Schemas,
-): ZodLikeSchema<UnionOutput<Schemas>> =>
-	decorate(schemaFromIR({ k: "union", members: schemas.map(schema => embed(schema)) }));
+): ZodLikeSchema<UnionOutput<Schemas>> => {
+	const members = schemas.map(schema => schema);
+	const irs = members.map(member => member.ir);
+	// Same pipeline gate as optional()/nullable(): `hasSteps` covers
+	// Type-attached transform/refine steps the member IR cannot see.
+	if (members.every(member => !member.hasSteps) && irs.every(ir => !hasMorph(ir))) {
+		return decorate(schemaFromIR<UnionOutput<Schemas>>({ k: "union", members: irs }));
+	}
+	return decorate(
+		schemaFromIR({
+			k: "morph",
+			input: { k: "unknown" },
+			fn: (value, ctx) => {
+				for (const member of members) {
+					const result = member(value);
+					if (!(result instanceof type.errors)) return result;
+				}
+				return ctx.error(`a union of ${members.length} variants`);
+			},
+		}),
+	);
+};
+const NO_DISCRIMINANT = Symbol("omptype.zod.noDiscriminant");
+
+/**
+ * Literal value a discriminated-union variant pins the discriminator to, read
+ * straight off its structural IR; {@link NO_DISCRIMINANT} when unknowable.
+ */
+function discriminantLiteral(ir: IR, key: string): unknown {
+	if (ir.k !== "object") return NO_DISCRIMINANT;
+	for (const prop of ir.props) {
+		if (prop.key === key) return prop.val.k === "lit" ? prop.val.v : NO_DISCRIMINANT;
+	}
+	return NO_DISCRIMINANT;
+}
+
+/**
+ * Union dispatched on a literal discriminator property. Variants whose IR pins
+ * the discriminator to the input's value are tried first; when nothing matches
+ * (or no variant declares a usable literal), every variant is attempted in
+ * order so failures still report against the full union.
+ */
+export const discriminatedUnion = <
+	const Discriminator extends string,
+	const Schemas extends readonly [ZodLikeSchema<unknown>, ZodLikeSchema<unknown>, ...ZodLikeSchema<unknown>[]],
+>(
+	discriminator: Discriminator,
+	schemas: Schemas,
+): ZodLikeSchema<UnionOutput<Schemas>> => {
+	const variantIrs = schemas.map(schema => schema.ir);
+	// Same pipeline gate as union() above: a purely structural variant set
+	// keeps a real structural union so JSON Schema export (provider tool
+	// definitions) survives — distinct discriminator literals make the
+	// variants disjoint, so any-match equals discriminator-dispatch for pure
+	// validators. The literal dispatcher below is reserved for variant sets
+	// carrying morphs or Type-attached steps.
+	if (schemas.every(schema => !schema.hasSteps) && variantIrs.every(ir => !hasMorph(ir))) {
+		return decorate(schemaFromIR<UnionOutput<Schemas>>({ k: "union", members: variantIrs }));
+	}
+	const variants = schemas.map(schema => ({
+		schema: schema as ZodLikeSchema<unknown>,
+		literal: discriminantLiteral(schema.ir, discriminator),
+	}));
+	const dispatch = type.unknown.pipe((value, ctx) => {
+		if (typeof value !== "object" || value === null) {
+			return ctx.error(`an object with a "${discriminator}" discriminator`);
+		}
+		let candidates = variants;
+		const disc = (value as Record<string, unknown>)[discriminator];
+		if (disc !== undefined) {
+			const matched = variants.filter(variant => variant.literal === disc);
+			if (matched.length > 0) candidates = matched;
+		}
+		for (const variant of candidates) {
+			const result = variant.schema(value);
+			if (!(result instanceof type.errors)) return result;
+		}
+		return ctx.error(`a "${discriminator}" union variant`);
+	});
+	return decorate(dispatch as Decoratable<unknown>) as ZodLikeSchema<UnionOutput<Schemas>>;
+};
+/** Defer schema construction until first parse — required for recursive shapes. */
+export const lazy = <Out>(getter: () => ZodLikeSchema<Out>): ZodLikeSchema<Out> => {
+	let resolved: ZodLikeSchema<Out> | undefined;
+	return decorate(
+		schemaFromIR<Out>({
+			k: "morph",
+			input: { k: "unknown" },
+			fn: value => {
+				resolved ??= getter();
+				return resolved(value);
+			},
+		}),
+	);
+};
 export const array = <Element>(element: ZodLikeSchema<Element>): ZodLikeSchema<Element[]> =>
 	decorate(schemaFromIR({ k: "array", el: embed(element) }));
 export const object = <const S extends Shape>(shape: S): ZodLikeSchema<Simplify<ObjectOutput<S>>> =>
 	objectSchema(shape);
+/** Object that rejects undeclared keys (zod `z.strictObject`). */
+export const strictObject = <const S extends Shape>(shape: S): ZodLikeSchema<Simplify<ObjectOutput<S>>> =>
+	objectSchema(shape, "reject");
+export const looseObject = <const S extends Shape>(
+	shape: S,
+): ZodLikeSchema<Simplify<ObjectOutput<S>> & Record<string, unknown>> =>
+	objectSchema(shape, "keep") as ZodLikeSchema<Simplify<ObjectOutput<S>> & Record<string, unknown>>;
 export const record = <Key extends string, Value>(
 	keySchema: ZodLikeSchema<Key>,
 	valueSchema: ZodLikeSchema<Value>,
@@ -340,13 +569,31 @@ export const z = {
 	union,
 	array,
 	object,
+	strictObject,
+	looseObject,
+	discriminatedUnion,
+	lazy,
 	record,
 	unknown,
 	any,
 	null: nullSchema,
 	undefined: undefinedSchema,
 };
-
 export namespace z {
+	/** Alias of {@link ZodLikeSchema} under zod's historical name; `Input` mirrors zod's two-parameter arity. */
+	// biome-ignore lint/correctness/noUnusedVariables: Input exists only to mirror zod's ZodType<Out, Input> arity.
+	export type ZodType<Out = unknown, Input = unknown> = ZodLikeSchema<Out>;
 	export type infer<Schema> = Schema extends { readonly _output: infer Out } ? Out : never;
+	/** Structural counterpart of zod's `ZodError`: the safeParse failure payload. */
+	export interface ZodError<Out = unknown> {
+		readonly message: string;
+		readonly issues: ZodLikeIssue[];
+		/** Phantom marker keeping zod's output type parameter attached. */
+		readonly _output?: Out;
+	}
 }
+
+/** Module-level aliases of the `z` namespace types under their bare names. */
+// biome-ignore lint/correctness/noUnusedVariables: Input exists only to mirror zod's ZodType<Out, Input> arity.
+export type ZodType<Out = unknown, Input = unknown> = z.ZodType<Out>;
+export type ZodError<Out = unknown> = z.ZodError<Out>;

--- a/packages/omptype/src/zod.ts
+++ b/packages/omptype/src/zod.ts
@@ -1,14 +1,5 @@
 import { type OmpErrors, OmpTypeError } from "./errors";
-import {
-	type EmbeddableSchema,
-	type Extras,
-	embed,
-	hasDeferredAlias,
-	type IR,
-	IR_BRAND,
-	isStructurallyExportable,
-	type PropIR,
-} from "./ir";
+import { type EmbeddableSchema, type Extras, embed, hasDeferredAlias, type IR, IR_BRAND, type PropIR } from "./ir";
 import { type NarrowContext, type Type, type } from "./type";
 
 interface OptionalSchemaMarker {
@@ -218,25 +209,26 @@ function decorate<Out>(schema: Decoratable<Out>, optional = false): ZodLikeSchem
 			return next(restrictBase(schema, { ...schema.ir, url: true }));
 		},
 		optional(): ZodLikeSchema<Out | undefined> & OptionalSchemaMarker {
-			// Widening keeps a real union whenever the member carries no deferred
-			// alias, so structural metadata (JSON Schema export, descriptions)
-			// survives even when the member contains stepped (`sub`) or
-			// default-filled properties — the widened union is disjoint from
-			// `undefined` unless the member itself accepts `undefined`, and
-			// omptype's own determinism check arbitrates that at construction
-			// (its indeterminacy error falls back to the dispatcher below).
+			// Widening keeps a real union whenever the member carries no
+			// deferred alias, so structural metadata (JSON Schema export,
+			// descriptions) survives. `or` EMBEDS the member: a member with
+			// Type-attached `.transform()`/`.refine()` steps (`z.record`,
+			// `.regex()`, `.refine()`, …) becomes a `sub` node, so its steps
+			// keep running and its structural base still exports — rebuilding
+			// from `schema.ir` instead would silently DROP those steps.
+			// The widened union is disjoint from `undefined` unless the member
+			// itself accepts `undefined`, and omptype's own determinism check
+			// arbitrates that at construction (its indeterminacy error falls
+			// back to the dispatcher below).
 			// Deferred aliases are excluded up front: the determinism probe
 			// cannot see through one, and resolving it here would break zod's
-			// defer-to-first-parse contract. `hasSteps` covers Type-attached
-			// `.transform()`/`.refine()` steps the IR alone cannot see —
-			// rebuilding from `schema.ir` would silently DROP those steps, not
-			// just degrade the emitted JSON Schema.
-			if (!schema.hasSteps && !hasDeferredAlias(schema.ir)) {
+			// defer-to-first-parse contract.
+			if (!hasDeferredAlias(schema.ir)) {
 				try {
-					return decorate(
-						schemaFromIR<Out | undefined>({ k: "union", members: [schema.ir, { k: "undefined" }] }),
-						true,
-					) as ZodLikeSchema<Out | undefined> & OptionalSchemaMarker;
+					return decorate(schema.or(type.raw("undefined")) as Decoratable<Out | undefined>, true) as ZodLikeSchema<
+						Out | undefined
+					> &
+						OptionalSchemaMarker;
 				} catch (error) {
 					if (!isIndeterminateUnionError(error)) throw error;
 				}
@@ -245,16 +237,13 @@ function decorate<Out>(schema: Decoratable<Out>, optional = false): ZodLikeSchem
 				OptionalSchemaMarker;
 		},
 		nullable(): ZodLikeSchema<Out | null> {
-			// Same gate as optional() above: widening keeps a real union whenever
-			// the member carries no deferred alias — disjoint from `null` unless
-			// the member itself accepts `null`, which omptype's determinism
-			// check arbitrates at construction.
-			if (!schema.hasSteps && !hasDeferredAlias(schema.ir)) {
+			// Same gate as optional() above: the embedded widening union keeps
+			// a stepped member's structure and steps alive, and is disjoint
+			// from `null` unless the member itself accepts `null`, which
+			// omptype's determinism check arbitrates at construction.
+			if (!hasDeferredAlias(schema.ir)) {
 				try {
-					return decorate(
-						schemaFromIR<Out | null>({ k: "union", members: [schema.ir, { k: "lit", v: null }] }),
-						optional,
-					) as ZodLikeSchema<Out | null>;
+					return decorate(schema.or(type.raw("null")) as Decoratable<Out | null>, optional);
 				} catch (error) {
 					if (!isIndeterminateUnionError(error)) throw error;
 				}
@@ -453,27 +442,26 @@ function isIndeterminateUnionError(error: unknown): boolean {
 // keeps zod's ordering and keeps member morphs invisible to the determinism
 // check.
 //
-// The dispatcher is reserved for unions that actually carry a pipeline: a
-// structurally exportable union stays structural, because the morph wrapper
-// erases the IR and `toJsonSchema()` then emits `{}` for the member — a
-// provider-facing tool parameter would appear unconstrained. For pure
-// validators any-match equals first-match, so zod's ordering is not
-// observable there.
+// The dispatcher is the last resort, not the default: it erases the IR, so
+// `toJsonSchema()` emits `{}` and a provider-facing tool parameter appears
+// unconstrained. Whenever omptype accepts the structural union, its output is
+// order-independent — any-match equals first-match — so zod's ordering is not
+// observable and the structural build wins.
 export const union = <
 	const Schemas extends readonly [ZodLikeSchema<unknown>, ZodLikeSchema<unknown>, ...ZodLikeSchema<unknown>[]],
 >(
 	schemas: Schemas,
 ): ZodLikeSchema<UnionOutput<Schemas>> => {
-	const members = schemas.map(schema => schema);
-	const irs = members.map(member => member.ir);
-	// Stricter than the widening gates above: those only exclude deferred
-	// aliases, because widening against `undefined`/`null` is disjoint by
-	// construction. A union of arbitrary members can overlap in ways the
-	// emitted `anyOf` would misrepresent, so members carrying morphs,
-	// stepped embeds, or default-filled properties keep the ordered
-	// dispatcher. `hasSteps` covers Type-attached transform/refine steps
-	// the member IR cannot see.
-	if (members.every(member => !member.hasSteps) && irs.every(ir => isStructurallyExportable(ir))) {
+	// Members are EMBEDDED, not rebuilt from `member.ir`: a member carrying
+	// Type-attached `.transform()`/`.refine()` steps survives as a `sub` node,
+	// so its steps keep running and its structural base still exports. Only a
+	// deferred alias is excluded up front — the determinism probe below cannot
+	// see through one. Everything else attempts the structural build and lets
+	// omptype's determinism check arbitrate: if construction succeeds the
+	// union's output is order-independent, so `anyOf` faithfully describes the
+	// accepted inputs.
+	const irs = schemas.map(schema => embed(schema));
+	if (schemas.every(schema => !hasDeferredAlias(schema.ir))) {
 		try {
 			return decorate(schemaFromIR<UnionOutput<Schemas>>({ k: "union", members: irs }));
 		} catch (error) {
@@ -490,11 +478,11 @@ export const union = <
 			k: "morph",
 			input: { k: "unknown" },
 			fn: (value, ctx) => {
-				for (const member of members) {
+				for (const member of schemas) {
 					const result = member(value);
 					if (!(result instanceof type.errors)) return result;
 				}
-				return ctx.error(`a union of ${members.length} variants`);
+				return ctx.error(`a union of ${schemas.length} variants`);
 			},
 		}),
 	);
@@ -526,14 +514,14 @@ export const discriminatedUnion = <
 	discriminator: Discriminator,
 	schemas: Schemas,
 ): ZodLikeSchema<UnionOutput<Schemas>> => {
-	const variantIrs = schemas.map(schema => schema.ir);
-	// Same pipeline gate as union() above: a structurally exportable variant
-	// set keeps a real structural union so JSON Schema export (provider tool
-	// definitions) survives — distinct discriminator literals make the
-	// variants disjoint, so any-match equals discriminator-dispatch for pure
-	// validators. The literal dispatcher below is reserved for variant sets
-	// carrying morphs or Type-attached steps.
-	if (schemas.every(schema => !schema.hasSteps) && variantIrs.every(ir => isStructurallyExportable(ir))) {
+	const variantIrs = schemas.map(schema => embed(schema));
+	// Same gate as union() above: variants are embedded so stepped variants
+	// keep their steps and their exported structure, only deferred aliases are
+	// excluded up front, and omptype's determinism check arbitrates the rest —
+	// distinct discriminator literals make the variants disjoint, so any-match
+	// equals discriminator-dispatch. The literal dispatcher below is reserved
+	// for variant sets omptype rejects as order-dependent.
+	if (schemas.every(schema => !hasDeferredAlias(schema.ir))) {
 		try {
 			return decorate(schemaFromIR<UnionOutput<Schemas>>({ k: "union", members: variantIrs }));
 		} catch (error) {

--- a/packages/omptype/src/zod.ts
+++ b/packages/omptype/src/zod.ts
@@ -3,6 +3,7 @@ import {
 	type EmbeddableSchema,
 	type Extras,
 	embed,
+	hasDeferredAlias,
 	type IR,
 	IR_BRAND,
 	isStructurallyExportable,
@@ -82,14 +83,14 @@ function schemaFromIR<Out>(ir: IR): Decoratable<Out> {
  */
 function undefinedDispatch<Out>(
 	schema: Decoratable<Out>,
-	fallback: (() => Out) | undefined,
+	fallback: Out | (() => Out) | undefined,
 ): Decoratable<Out | undefined> {
 	return schemaFromIR<Out | undefined>({
 		k: "morph",
 		input: { k: "unknown" },
 		fn: (input, ctx) => {
 			if (input === undefined) {
-				return fallback === undefined ? undefined : fallback();
+				return typeof fallback === "function" ? (fallback as () => Out)() : fallback;
 			}
 			const result = schema(input);
 			if (!(result instanceof type.errors)) return result;
@@ -217,33 +218,46 @@ function decorate<Out>(schema: Decoratable<Out>, optional = false): ZodLikeSchem
 			return next(restrictBase(schema, { ...schema.ir, url: true }));
 		},
 		optional(): ZodLikeSchema<Out | undefined> & OptionalSchemaMarker {
-			// Structurally exportable inner schemas keep a real union so structural
-			// metadata (JSON Schema export, descriptions) survives the widening.
-			// Anything carrying a runtime pipeline takes the dispatch morph below:
-			// `isStructurallyExportable(ir)` rejects in-IR morphs and stepped
-			// embedded schemas, and `hasSteps` covers Type-attached
-			// `.transform()`/`.refine()` steps the IR alone cannot see — rebuilding
-			// from `schema.ir` would silently DROP those steps, not just degrade
-			// the emitted JSON Schema.
-			if (!schema.hasSteps && isStructurallyExportable(schema.ir)) {
-				return decorate(
-					schemaFromIR<Out | undefined>({ k: "union", members: [schema.ir, { k: "undefined" }] }),
-					true,
-				) as ZodLikeSchema<Out | undefined> & OptionalSchemaMarker;
+			// Widening keeps a real union whenever the member carries no deferred
+			// alias, so structural metadata (JSON Schema export, descriptions)
+			// survives even when the member contains stepped (`sub`) or
+			// default-filled properties — the widened union is disjoint from
+			// `undefined` unless the member itself accepts `undefined`, and
+			// omptype's own determinism check arbitrates that at construction
+			// (its indeterminacy error falls back to the dispatcher below).
+			// Deferred aliases are excluded up front: the determinism probe
+			// cannot see through one, and resolving it here would break zod's
+			// defer-to-first-parse contract. `hasSteps` covers Type-attached
+			// `.transform()`/`.refine()` steps the IR alone cannot see —
+			// rebuilding from `schema.ir` would silently DROP those steps, not
+			// just degrade the emitted JSON Schema.
+			if (!schema.hasSteps && !hasDeferredAlias(schema.ir)) {
+				try {
+					return decorate(
+						schemaFromIR<Out | undefined>({ k: "union", members: [schema.ir, { k: "undefined" }] }),
+						true,
+					) as ZodLikeSchema<Out | undefined> & OptionalSchemaMarker;
+				} catch (error) {
+					if (!isIndeterminateUnionError(error)) throw error;
+				}
 			}
 			return decorate(undefinedDispatch<Out>(schema, undefined), true) as ZodLikeSchema<Out | undefined> &
 				OptionalSchemaMarker;
 		},
 		nullable(): ZodLikeSchema<Out | null> {
-			// Structurally exportable inner schemas keep a real union so structural
-			// metadata (JSON Schema export for provider tool definitions) survives
-			// the widening — the dispatcher morph below erases the IR, emitting
-			// `{}` for the member. Same pipeline gate as optional() above.
-			if (!schema.hasSteps && isStructurallyExportable(schema.ir)) {
-				return decorate(
-					schemaFromIR<Out | null>({ k: "union", members: [schema.ir, { k: "lit", v: null }] }),
-					optional,
-				) as ZodLikeSchema<Out | null>;
+			// Same gate as optional() above: widening keeps a real union whenever
+			// the member carries no deferred alias — disjoint from `null` unless
+			// the member itself accepts `null`, which omptype's determinism
+			// check arbitrates at construction.
+			if (!schema.hasSteps && !hasDeferredAlias(schema.ir)) {
+				try {
+					return decorate(
+						schemaFromIR<Out | null>({ k: "union", members: [schema.ir, { k: "lit", v: null }] }),
+						optional,
+					) as ZodLikeSchema<Out | null>;
+				} catch (error) {
+					if (!isIndeterminateUnionError(error)) throw error;
+				}
 			}
 			const inner = schema;
 			const nullable = schemaFromIR<Out | null>({
@@ -262,35 +276,31 @@ function decorate<Out>(schema: Decoratable<Out>, optional = false): ZodLikeSchem
 			value: Exclude<Out, undefined> | (() => Exclude<Out, undefined>),
 		): ZodLikeSchema<Exclude<Out, undefined>> {
 			type DefaultOut = Exclude<Out, undefined>;
-			// Structurally exportable inner schemas keep the original union+pipe
-			// composition so structural metadata survives JSON-Schema export.
-			if (isStructurallyExportable(schema.ir)) {
-				const widened = schema.or(type.raw("undefined")) as Decoratable<Out | undefined>;
-				const pipedPlain = widened.pipe(output => {
-					if (output !== undefined) return output as DefaultOut;
-					return typeof value === "function" ? (value as () => DefaultOut)() : value;
-				}) as unknown as Decoratable<DefaultOut>;
-				const plain = decorate(pipedPlain);
-				Object.defineProperty(plain, "hasDefault", { value: true, enumerable: false });
-				Object.defineProperty(plain, "defaultValue", { value, enumerable: false });
-				return plain;
+			// Same gate as optional()/nullable(): the union+pipe composition
+			// keeps structural metadata alive for members that carry no deferred
+			// alias, with omptype's determinism check arbitrating disjointness
+			// from `undefined` at construction.
+			if (!hasDeferredAlias(schema.ir)) {
+				try {
+					const widened = schema.or(type.raw("undefined")) as Decoratable<Out | undefined>;
+					const pipedPlain = widened.pipe(output => {
+						if (output !== undefined) return output as DefaultOut;
+						return typeof value === "function" ? (value as () => DefaultOut)() : value;
+					}) as unknown as Decoratable<DefaultOut>;
+					const plain = decorate(pipedPlain);
+					Object.defineProperty(plain, "hasDefault", { value: true, enumerable: false });
+					Object.defineProperty(plain, "defaultValue", { value, enumerable: false });
+					return plain;
+				} catch (error) {
+					if (!isIndeterminateUnionError(error)) throw error;
+				}
 			}
-			const fallback = value;
-			const piped = decorate(
-				schemaFromIR<DefaultOut>({
-					k: "morph",
-					input: { k: "unknown" },
-					fn: (input, ctx) => {
-						if (input === undefined) {
-							return typeof fallback === "function" ? (fallback as () => DefaultOut)() : fallback;
-						}
-						const result = schema(input);
-						if (!(result instanceof type.errors)) return result;
-						return ctx.error("the default or a valid value");
-					},
-				}),
-			) as unknown as Decoratable<DefaultOut>;
-			const result = decorate(piped);
+			const result = decorate(
+				undefinedDispatch<DefaultOut>(
+					schema as unknown as Decoratable<DefaultOut>,
+					value,
+				) as unknown as Decoratable<DefaultOut>,
+			);
 			// Stamp the default metadata objectSchema() reads when embedding this
 			// schema as a property: the prop must stay optional with this fallback.
 			Object.defineProperty(result, "hasDefault", { value: true, enumerable: false });

--- a/packages/omptype/src/zod.ts
+++ b/packages/omptype/src/zod.ts
@@ -92,36 +92,69 @@ function undefinedDispatch<Out>(
 	});
 }
 
+const kRebuild = Symbol("omptype.zod.rebuild");
+
+/**
+ * The shim's own wrappers around a structural schema, kept so a later
+ * structural modifier can rebuild the structure and put them back.
+ *
+ * Author-supplied steps (`.refine()`, `.transform()`) are deliberately NOT
+ * described here: they must keep running against the schema they were written
+ * for, which is what {@link restrictBase}'s re-validating morph path does.
+ */
+interface RebuildInfo<Out> {
+	/** Wrapper-free schema, the one a rebuild starts from. */
+	base: Decoratable<Out>;
+	/** Whether an array guard is part of the chain. */
+	guarded: boolean;
+	/** Re-applies the non-guard wrappers, currently `.readonly()`'s freeze. */
+	rewrap?: (schema: Decoratable<Out>) => Decoratable<Out>;
+}
+
+/** A schema that may carry {@link RebuildInfo}. */
+interface MaybeWrapped<Out> extends Decoratable<Out> {
+	readonly [kRebuild]?: RebuildInfo<Out>;
+}
+
+function rebuildInfoOf<Out>(schema: Decoratable<Out>): RebuildInfo<Out> | undefined {
+	const carrier: MaybeWrapped<Out> = schema;
+	return carrier[kRebuild];
+}
+
+/** Configurable so a schema stamped by `guardArrays` can be re-stamped once its full wrapper chain is known. */
+function stampRebuild<Out>(schema: Decoratable<Out>, info: RebuildInfo<Out>): Decoratable<Out> {
+	Object.defineProperty(schema, kRebuild, { value: info, enumerable: false, configurable: true });
+	return schema;
+}
+
 /**
  * Rebuild `source`'s structure as `ir`, keeping its description, default, and
- * any user steps.
+ * any author steps.
  *
- * The array guard is deliberately unwrapped and re-applied rather than carried:
- * it is the shim's own step, not the author's, and leaving it in place would
- * make the source count as stepped, so the rebuilt schema would validate `ir`
- * and then re-validate through the OLD object policy — `.strict().partial()`
- * would still demand the now-optional keys, and `z.strictObject({})
- * .passthrough()` would still reject extras.
+ * The shim's own wrappers are unwrapped and re-applied rather than carried: they
+ * would make the source count as stepped, so the rebuilt schema would validate
+ * `ir` and then re-validate through the OLD object policy — `.strict()
+ * .partial()` would still demand the now-optional keys, `z.strictObject({})
+ * .passthrough()` would still reject extras, and inserting `.readonly()` before
+ * either would bring that back.
  */
 function restrictBase<Out>(source: Decoratable<Out>, ir: IR): Decoratable<Out> {
-	const unguarded = unguardedObject(source);
-	let next = unguarded.hasSteps
-		? schemaFromIR<Out>({ k: "morph", input: ir, fn: value => unguarded(value) })
+	const info = rebuildInfoOf(source);
+	const base = info?.base ?? source;
+	let structural = base.hasSteps
+		? schemaFromIR<Out>({ k: "morph", input: ir, fn: value => base(value) })
 		: schemaFromIR<Out>(ir);
-	if (unguarded.ir.desc !== undefined) next = next.describe(unguarded.ir.desc);
-	if (unguarded.hasDefault) next = next.default(unguarded.defaultValue as Out | (() => Out));
+	if (base.ir.desc !== undefined) structural = structural.describe(base.ir.desc);
+	if (base.hasDefault) structural = structural.default(base.defaultValue as Out | (() => Out));
 	// Every object target is guarded, stripping included; any other target — a
 	// discriminated union rebuilt by `.describe()` — keeps the guard it arrived
 	// with.
-	const guard = ir.k === "object" || unguarded !== source;
-	return guard ? guardArrays(next) : next;
-}
-
-const kUnguarded = Symbol("omptype.zod.unguardedObject");
-
-/** A schema that may carry the step-free base an array guard was applied to. */
-interface MaybeGuarded<Out> extends Decoratable<Out> {
-	readonly [kUnguarded]?: Decoratable<Out>;
+	const guarded = ir.k === "object" || info?.guarded === true;
+	let next = guarded ? guardArrays(structural) : structural;
+	if (info?.rewrap !== undefined) next = info.rewrap(next);
+	return guarded || info?.rewrap !== undefined
+		? stampRebuild(next, { base: structural, guarded, rewrap: info?.rewrap })
+		: next;
 }
 
 /**
@@ -132,35 +165,59 @@ interface MaybeGuarded<Out> extends Decoratable<Out> {
  * base validates it, so this also catches the shapes an output-side check
  * cannot — a key-stripping object has already turned `[]` into `{}` by the time
  * a narrow runs, and so has a discriminated union whose matching variant strips.
- *
- * The pre-guard schema is kept on the result so {@link restrictBase} can
- * rebuild from it; see there for why carrying the guard instead breaks later
- * structural modifiers.
  */
 function guardArrays<Out>(base: Decoratable<Out>): Decoratable<Out> {
 	const guarded = base.filter(
 		(value, ctx: NarrowContext) => !Array.isArray(value) || ctx.mustBe("an object, not an array"),
 	);
-	Object.defineProperty(guarded, kUnguarded, { value: base, enumerable: false });
-	return guarded;
-}
-
-/** The step-free schema behind an array guard, or `schema` when there is none. */
-function unguardedObject<Out>(schema: Decoratable<Out>): Decoratable<Out> {
-	const carrier: MaybeGuarded<Out> = schema;
-	return carrier[kUnguarded] ?? schema;
+	return stampRebuild(guarded, { base, guarded: true });
 }
 
 /**
- * Keep the unguarded base reachable through a wrapper that adds no policy of
- * its own (`.describe()`), so a later `.partial()`/mode change still rebuilds
- * from the base instead of re-validating through the old object policy.
+ * Keep the rebuild info reachable through a wrapper that adds no policy of its
+ * own (`.describe()`), so a later `.partial()`/mode change still rebuilds from
+ * the base instead of re-validating through the old object policy.
  */
-function carryGuard<Out>(source: Decoratable<Out>, wrapped: Decoratable<Out>): Decoratable<Out> {
-	const carrier: MaybeGuarded<Out> = source;
-	const base = carrier[kUnguarded];
-	if (base !== undefined) Object.defineProperty(wrapped, kUnguarded, { value: base, enumerable: false });
-	return wrapped;
+function carryRebuild<Out>(source: Decoratable<Out>, wrapped: Decoratable<Out>): Decoratable<Out> {
+	const info = rebuildInfoOf(source);
+	return info === undefined ? wrapped : stampRebuild(wrapped, info);
+}
+
+/**
+ * `.readonly()`'s value step: shallow-freeze a CLONE of the parse output.
+ *
+ * Zod freezes its own freshly constructed output; omptype's parsing shares
+ * structure with the input (a parent copy keeps child references), so freezing
+ * in place would freeze the CALLER's input graph — e.g. a persisted session
+ * entry schema-validated before blob hydration must stay mutable.
+ *
+ * The clone copies property DESCRIPTORS onto a fresh object of the same
+ * prototype (a fresh array for arrays). A spread would silently rewrite the
+ * value it is supposed to hand back: non-enumerable own properties would
+ * vanish, accessors would collapse into one-shot values, sparse array holes
+ * would materialize as `undefined`, and custom array properties would be
+ * dropped. Descriptors also keep an own `__proto__` key intact, since
+ * `defineProperty` semantics never invoke the setter.
+ *
+ * Only plain objects and arrays are cloned+frozen. A non-plain object (a
+ * Date/Map/class instance reachable via `z.unknown()`/`z.any()`/a transform) has
+ * no non-destructive shallow clone — its internal slots do not travel with
+ * descriptors — and freezing it in place would mutate the caller's value, so it
+ * passes through untouched: never-freeze-the-input outranks freeze-the-output
+ * for the shim's JSON-oriented use. Primitives and functions pass through for
+ * the same reason. One level deep, exactly like Zod.
+ */
+function freezeParseOutput<Out>(schema: Decoratable<Out>): Decoratable<Out> {
+	return schema.pipe(value => {
+		if (typeof value !== "object" || value === null) return value;
+		const proto = Object.getPrototypeOf(value);
+		if (!Array.isArray(value) && proto !== Object.prototype && proto !== null) return value;
+		const descriptors = Object.getOwnPropertyDescriptors(value);
+		const clone = Array.isArray(value)
+			? Object.defineProperties([] as unknown[], descriptors)
+			: Object.create(proto, descriptors);
+		return Object.freeze(clone) as Out;
+	});
 }
 
 function lengthBound(kind: "min" | "max", schema: Decoratable<unknown>, bound: number): void {
@@ -365,7 +422,7 @@ function decorate<Out>(schema: Decoratable<Out>, optional = false): ZodLikeSchem
 		},
 		describe(description: string): ZodLikeSchema<Out> {
 			const rebuilt = restrictBase(schema, { ...schema.ir, desc: description });
-			return next(carryGuard(rebuilt, rebuilt.describe(description)));
+			return next(carryRebuild(rebuilt, rebuilt.describe(description)));
 		},
 		refine(predicate: (value: Out) => unknown, messageOrOptions?: string | RefineOptions): ZodLikeSchema<Out> {
 			const expectation = refinementMessage(messageOrOptions);
@@ -407,46 +464,24 @@ function decorate<Out>(schema: Decoratable<Out>, optional = false): ZodLikeSchem
 		},
 		/**
 		 * Matches Zod's runtime contract: `.readonly()` is not merely a type
-		 * cast, it shallow-freezes successful parse output (`Object.freeze`,
-		 * one level deep — a nested object is left mutable, exactly like Zod).
-		 *
-		 * Zod freezes its own freshly constructed parse output; omptype's
-		 * parsing shares structure with the input (a parent copy keeps child
-		 * references), so freezing in place would freeze the CALLER's input
-		 * graph — e.g. a persisted session entry schema-validated before blob
-		 * hydration must stay mutable. Shallow-clone first, then freeze the
-		 * clone.
-		 *
-		 * The clone copies property DESCRIPTORS onto a fresh object of the same
-		 * prototype (a fresh array for arrays). A spread would silently rewrite
-		 * the value it is supposed to hand back: non-enumerable own properties
-		 * would vanish, accessors would collapse into one-shot values, sparse
-		 * array holes would materialize as `undefined`, and custom array
-		 * properties would be dropped. Descriptors also keep an own `__proto__`
-		 * key intact, since `defineProperty` semantics never invoke the setter.
-		 *
-		 * Only plain objects and arrays are cloned+frozen. A non-plain object
-		 * (a Date/Map/class instance reachable via `z.unknown()`/`z.any()`/a
-		 * transform) has no non-destructive shallow clone — its internal slots
-		 * do not travel with descriptors — and freezing it in place would
-		 * mutate the caller's value, so it passes through untouched:
-		 * never-freeze-the-input outranks freeze-the-output for the shim's
-		 * JSON-oriented use. Primitives and functions pass through for the same
-		 * reason.
+		 * cast, it shallow-freezes successful parse output — see
+		 * {@link freezeParseOutput} for why that is a descriptor-level clone
+		 * rather than a freeze in place.
 		 */
 		readonly(): ZodLikeSchema<Readonly<Out>> {
-			return next(
-				schema.pipe(value => {
-					if (typeof value !== "object" || value === null) return value;
-					const proto = Object.getPrototypeOf(value);
-					if (!Array.isArray(value) && proto !== Object.prototype && proto !== null) return value;
-					const descriptors = Object.getOwnPropertyDescriptors(value);
-					const clone = Array.isArray(value)
-						? Object.defineProperties([] as unknown[], descriptors)
-						: Object.create(proto, descriptors);
-					return Object.freeze(clone) as Out;
-				}),
-			) as ZodLikeSchema<Readonly<Out>>;
+			// Recorded as a shim wrapper, not just applied: a later structural
+			// modifier (`.partial()`, `.passthrough()`) must rebuild the object
+			// policy and put the freeze back on top, instead of re-validating
+			// through the pre-readonly schema and its old policy.
+			const info = rebuildInfoOf(schema);
+			const rewrap = info?.rewrap;
+			const frozen = freezeParseOutput(schema);
+			stampRebuild(frozen, {
+				base: info?.base ?? schema,
+				guarded: info?.guarded === true,
+				rewrap: rewrap === undefined ? freezeParseOutput : inner => freezeParseOutput(rewrap(inner)),
+			});
+			return next(frozen) as unknown as ZodLikeSchema<Readonly<Out>>;
 		},
 	}) as unknown as ZodLikeSchema<Out>;
 }

--- a/packages/omptype/src/zod.ts
+++ b/packages/omptype/src/zod.ts
@@ -170,8 +170,26 @@ function restrictBase<Out>(source: Decoratable<Out>, ir: IR): Decoratable<Out> {
 }
 
 /**
- * Reject an array reaching an object schema, which zod does and the emitted
- * `{"type":"object"}` already promises.
+ * Kind label for a value zod classifies OUTSIDE its object domain, or
+ * `undefined` when the value is acceptable object input.
+ *
+ * Mirrors zod's own input classification: arrays, `Date`, `Map`, `Set` and
+ * thenables are separate parsed types there, so an object schema rejects them.
+ * Plain objects and class instances are object input, in zod and here.
+ */
+function nonObjectKind(value: object): string | undefined {
+	if (Array.isArray(value)) return "an array";
+	if (value instanceof Date) return "a Date";
+	if (value instanceof Map) return "a Map";
+	if (value instanceof Set) return "a Set";
+	const thenable: { then?: unknown; catch?: unknown } = value;
+	return typeof thenable.then === "function" && typeof thenable.catch === "function" ? "a Promise" : undefined;
+}
+
+/**
+ * Hold an object schema to zod's object-input domain, which the emitted
+ * `{"type":"object"}` already promises — omptype's object node accepts any
+ * non-null object, arrays and built-ins included.
  *
  * A RAW `filter` step: filters run before the base validates, so this also
  * catches what an output-side `narrow` cannot — a key-stripping object has
@@ -182,7 +200,11 @@ function restrictBase<Out>(source: Decoratable<Out>, ir: IR): Decoratable<Out> {
  */
 function guardObjectInput<Out>(base: Decoratable<Out>): Decoratable<Out> {
 	const guarded = base.filter(
-		(value, ctx: NarrowContext) => !Array.isArray(value) || ctx.mustBe("an object, not an array"),
+		(value, ctx: NarrowContext) => {
+			if (typeof value !== "object" || value === null) return true;
+			const kind = nonObjectKind(value);
+			return kind === undefined || ctx.mustBe(`an object, not ${kind}`);
+		},
 		{ raw: true },
 	);
 	return stampRebuild(guarded, { base, guarded: true });

--- a/packages/omptype/src/zod.ts
+++ b/packages/omptype/src/zod.ts
@@ -595,14 +595,36 @@ export const union = <
 	);
 };
 /**
- * The values `ir` can take when that set is finite — literals, `null`,
- * `undefined`, and unions of those (`z.enum`, a literal union). `undefined`
- * means the set is open, so nothing can be dispatched on it.
+ * A literal the shim can both dispatch on and advertise. omptype compares
+ * object literals by REFERENCE ("must be reference equal to …"), so emitting
+ * `const: {…}` would promise the model a structural match the runtime refuses,
+ * and bigint, symbol and non-finite numbers have no JSON form at all. Anything
+ * outside this set makes the variant undispatchable rather than silently
+ * dispatched on identity.
+ */
+function isDispatchableLiteral(value: unknown): boolean {
+	if (value === null || value === undefined) return true;
+	switch (typeof value) {
+		case "string":
+		case "boolean":
+			return true;
+		case "number":
+			return Number.isFinite(value);
+		default:
+			return false;
+	}
+}
+
+/**
+ * The values `ir` can take when that set is finite AND dispatchable — literals,
+ * `null`, `undefined`, and unions of those (`z.enum`, a literal union).
+ * `undefined` means the set is open, or pinned to something that cannot be
+ * dispatched on, so nothing can be selected by it.
  */
 function finiteValues(ir: IR, seen?: Set<IR>): unknown[] | undefined {
 	switch (ir.k) {
 		case "lit":
-			return [ir.v];
+			return isDispatchableLiteral(ir.v) ? [ir.v] : undefined;
 		case "null":
 			return [null];
 		case "undefined":

--- a/packages/omptype/src/zod.ts
+++ b/packages/omptype/src/zod.ts
@@ -1,5 +1,13 @@
 import { type OmpErrors, OmpTypeError } from "./errors";
-import { type EmbeddableSchema, type Extras, embed, hasMorph, type IR, IR_BRAND, type PropIR } from "./ir";
+import {
+	type EmbeddableSchema,
+	type Extras,
+	embed,
+	type IR,
+	IR_BRAND,
+	isStructurallyExportable,
+	type PropIR,
+} from "./ir";
 import { type NarrowContext, type Type, type } from "./type";
 
 interface OptionalSchemaMarker {
@@ -70,7 +78,7 @@ function schemaFromIR<Out>(ir: IR): Decoratable<Out> {
  * `value === undefined` short-circuit around an inner schema, as a dispatch
  * morph. Composing a real union (`schema | undefined`) instead would trip
  * omptype's unordered-union determinism check whenever the inner side carries
- * morphs — which every shim-level recursive/lazy schema does.
+ * morphs (dispatcher-wrapped unions, parse schemas, stepped members).
  */
 function undefinedDispatch<Out>(
 	schema: Decoratable<Out>,
@@ -209,14 +217,15 @@ function decorate<Out>(schema: Decoratable<Out>, optional = false): ZodLikeSchem
 			return next(restrictBase(schema, { ...schema.ir, url: true }));
 		},
 		optional(): ZodLikeSchema<Out | undefined> & OptionalSchemaMarker {
-			// Purely structural inner schemas keep a real union so structural
+			// Structurally exportable inner schemas keep a real union so structural
 			// metadata (JSON Schema export, descriptions) survives the widening.
 			// Anything carrying a runtime pipeline takes the dispatch morph below:
-			// `hasMorph(ir)` covers in-IR morphs (lazy, string.numeric.parse), and
-			// `hasSteps` covers Type-attached `.transform()`/`.refine()` steps the
-			// IR alone cannot see — rebuilding from `schema.ir` would silently
-			// DROP those steps, not just degrade the emitted JSON Schema.
-			if (!schema.hasSteps && !hasMorph(schema.ir)) {
+			// `isStructurallyExportable(ir)` rejects in-IR morphs and stepped
+			// embedded schemas, and `hasSteps` covers Type-attached
+			// `.transform()`/`.refine()` steps the IR alone cannot see — rebuilding
+			// from `schema.ir` would silently DROP those steps, not just degrade
+			// the emitted JSON Schema.
+			if (!schema.hasSteps && isStructurallyExportable(schema.ir)) {
 				return decorate(
 					schemaFromIR<Out | undefined>({ k: "union", members: [schema.ir, { k: "undefined" }] }),
 					true,
@@ -226,11 +235,11 @@ function decorate<Out>(schema: Decoratable<Out>, optional = false): ZodLikeSchem
 				OptionalSchemaMarker;
 		},
 		nullable(): ZodLikeSchema<Out | null> {
-			// Purely structural inner schemas keep a real union so structural
+			// Structurally exportable inner schemas keep a real union so structural
 			// metadata (JSON Schema export for provider tool definitions) survives
 			// the widening — the dispatcher morph below erases the IR, emitting
 			// `{}` for the member. Same pipeline gate as optional() above.
-			if (!schema.hasSteps && !hasMorph(schema.ir)) {
+			if (!schema.hasSteps && isStructurallyExportable(schema.ir)) {
 				return decorate(
 					schemaFromIR<Out | null>({ k: "union", members: [schema.ir, { k: "lit", v: null }] }),
 					optional,
@@ -253,9 +262,9 @@ function decorate<Out>(schema: Decoratable<Out>, optional = false): ZodLikeSchem
 			value: Exclude<Out, undefined> | (() => Exclude<Out, undefined>),
 		): ZodLikeSchema<Exclude<Out, undefined>> {
 			type DefaultOut = Exclude<Out, undefined>;
-			// Morph-free inner schemas keep the original union+pipe composition so
-			// structural metadata survives JSON-Schema export.
-			if (!hasMorph(schema.ir)) {
+			// Structurally exportable inner schemas keep the original union+pipe
+			// composition so structural metadata survives JSON-Schema export.
+			if (isStructurallyExportable(schema.ir)) {
 				const widened = schema.or(type.raw("undefined")) as Decoratable<Out | undefined>;
 				const pipedPlain = widened.pipe(output => {
 					if (output !== undefined) return output as DefaultOut;
@@ -411,17 +420,35 @@ const enumSchema = <const Values extends readonly [string, ...string[]]>(
 };
 
 export { enumSchema as enum };
+
+/**
+ * Matches omptype's unordered-union indeterminacy error. The structural build
+ * is only attempted for member sets that pass the exportability gate, so this
+ * error alone may fall back to the ordered dispatcher; any other construction
+ * error must surface. Deliberately text-matched and narrow: if omptype ever
+ * rewords the message, this stops matching and fails loudly (construction
+ * error) instead of silently erasing again.
+ */
+function isIndeterminateUnionError(error: unknown): boolean {
+	return (
+		error instanceof OmpTypeError &&
+		error.message.includes("unordered union") &&
+		error.message.includes("indeterminate")
+	);
+}
 // Ordered first-match dispatcher rather than an omptype union: zod unions try
 // branches in declaration order, while omptype's unordered unions reject
-// overlapping morph inputs — a shape recursive schemas (`lazy` is a morph)
-// hit constantly. Wrapping the members in one unknown-input morph keeps zod's
-// ordering and keeps member morphs invisible to the determinism check.
+// overlapping morph inputs — a shape recursive schemas with morph-carrying
+// members hit constantly. Wrapping the members in one unknown-input morph
+// keeps zod's ordering and keeps member morphs invisible to the determinism
+// check.
 //
-// The dispatcher is reserved for unions that actually contain a morph: a
-// morph-free union stays structural, because the morph wrapper erases the IR
-// and `toJsonSchema()` then emits `{}` for the member — a provider-facing
-// tool parameter would appear unconstrained. For pure validators any-match
-// equals first-match, so zod's ordering is not observable there.
+// The dispatcher is reserved for unions that actually carry a pipeline: a
+// structurally exportable union stays structural, because the morph wrapper
+// erases the IR and `toJsonSchema()` then emits `{}` for the member — a
+// provider-facing tool parameter would appear unconstrained. For pure
+// validators any-match equals first-match, so zod's ordering is not
+// observable there.
 export const union = <
 	const Schemas extends readonly [ZodLikeSchema<unknown>, ZodLikeSchema<unknown>, ...ZodLikeSchema<unknown>[]],
 >(
@@ -431,8 +458,17 @@ export const union = <
 	const irs = members.map(member => member.ir);
 	// Same pipeline gate as optional()/nullable(): `hasSteps` covers
 	// Type-attached transform/refine steps the member IR cannot see.
-	if (members.every(member => !member.hasSteps) && irs.every(ir => !hasMorph(ir))) {
-		return decorate(schemaFromIR<UnionOutput<Schemas>>({ k: "union", members: irs }));
+	if (members.every(member => !member.hasSteps) && irs.every(ir => isStructurallyExportable(ir))) {
+		try {
+			return decorate(schemaFromIR<UnionOutput<Schemas>>({ k: "union", members: irs }));
+		} catch (error) {
+			// Overlapping morph-carrying members (e.g. two key-stripping
+			// z.objects) have order-dependent output under omptype's unordered
+			// union, so the native build is rejected there. zod's union is
+			// first-match: keep the ordered dispatcher below — its JSON Schema
+			// export erases (known, documented limitation).
+			if (!isIndeterminateUnionError(error)) throw error;
+		}
 	}
 	return decorate(
 		schemaFromIR({
@@ -476,14 +512,21 @@ export const discriminatedUnion = <
 	schemas: Schemas,
 ): ZodLikeSchema<UnionOutput<Schemas>> => {
 	const variantIrs = schemas.map(schema => schema.ir);
-	// Same pipeline gate as union() above: a purely structural variant set
-	// keeps a real structural union so JSON Schema export (provider tool
+	// Same pipeline gate as union() above: a structurally exportable variant
+	// set keeps a real structural union so JSON Schema export (provider tool
 	// definitions) survives — distinct discriminator literals make the
 	// variants disjoint, so any-match equals discriminator-dispatch for pure
 	// validators. The literal dispatcher below is reserved for variant sets
 	// carrying morphs or Type-attached steps.
-	if (schemas.every(schema => !schema.hasSteps) && variantIrs.every(ir => !hasMorph(ir))) {
-		return decorate(schemaFromIR<UnionOutput<Schemas>>({ k: "union", members: variantIrs }));
+	if (schemas.every(schema => !schema.hasSteps) && variantIrs.every(ir => isStructurallyExportable(ir))) {
+		try {
+			return decorate(schemaFromIR<UnionOutput<Schemas>>({ k: "union", members: variantIrs }));
+		} catch (error) {
+			// Same fallback as union(): variants whose discriminators do not
+			// disjointly pin literals (e.g. optional discriminators overlapping
+			// another variant) are order-dependent — keep the literal dispatcher.
+			if (!isIndeterminateUnionError(error)) throw error;
+		}
 	}
 	const variants = schemas.map(schema => ({
 		schema: schema as ZodLikeSchema<unknown>,

--- a/packages/omptype/src/zod.ts
+++ b/packages/omptype/src/zod.ts
@@ -350,18 +350,25 @@ function decorate<Out>(schema: Decoratable<Out>, optional = false): ZodLikeSchem
 		 * parsing shares structure with the input (a parent copy keeps child
 		 * references), so freezing in place would freeze the CALLER's input
 		 * graph — e.g. a persisted session entry schema-validated before blob
-		 * hydration must stay mutable. Shallow-clone first (object spread uses
-		 * define semantics, so an own `__proto__` key survives), then freeze
-		 * the clone.
+		 * hydration must stay mutable. Shallow-clone first, then freeze the
+		 * clone.
+		 *
+		 * The clone copies property DESCRIPTORS onto a fresh object of the same
+		 * prototype (a fresh array for arrays). A spread would silently rewrite
+		 * the value it is supposed to hand back: non-enumerable own properties
+		 * would vanish, accessors would collapse into one-shot values, sparse
+		 * array holes would materialize as `undefined`, and custom array
+		 * properties would be dropped. Descriptors also keep an own `__proto__`
+		 * key intact, since `defineProperty` semantics never invoke the setter.
 		 *
 		 * Only plain objects and arrays are cloned+frozen. A non-plain object
 		 * (a Date/Map/class instance reachable via `z.unknown()`/`z.any()`/a
-		 * transform) has no non-destructive shallow clone — spreading it would
-		 * produce a prototype-less husk with no internal slots — and freezing
-		 * it in place would mutate the caller's value, so it passes through
-		 * untouched: never-freeze-the-input outranks freeze-the-output for the
-		 * shim's JSON-oriented use. Primitives and functions pass through for
-		 * the same reason.
+		 * transform) has no non-destructive shallow clone — its internal slots
+		 * do not travel with descriptors — and freezing it in place would
+		 * mutate the caller's value, so it passes through untouched:
+		 * never-freeze-the-input outranks freeze-the-output for the shim's
+		 * JSON-oriented use. Primitives and functions pass through for the same
+		 * reason.
 		 */
 		readonly(): ZodLikeSchema<Readonly<Out>> {
 			return next(
@@ -369,7 +376,10 @@ function decorate<Out>(schema: Decoratable<Out>, optional = false): ZodLikeSchem
 					if (typeof value !== "object" || value === null) return value;
 					const proto = Object.getPrototypeOf(value);
 					if (!Array.isArray(value) && proto !== Object.prototype && proto !== null) return value;
-					const clone = Array.isArray(value) ? [...(value as unknown[])] : { ...(value as object) };
+					const descriptors = Object.getOwnPropertyDescriptors(value);
+					const clone = Array.isArray(value)
+						? Object.defineProperties([] as unknown[], descriptors)
+						: Object.create(proto, descriptors);
 					return Object.freeze(clone) as Out;
 				}),
 			) as ZodLikeSchema<Readonly<Out>>;

--- a/packages/omptype/src/zod.ts
+++ b/packages/omptype/src/zod.ts
@@ -1,6 +1,15 @@
 import { type OmpErrors, OmpTypeError } from "./errors";
-import { type EmbeddableSchema, type Extras, embed, hasDeferredAlias, type IR, IR_BRAND, type PropIR } from "./ir";
-import { type FilterOptions, type NarrowContext, type Type, type } from "./type";
+import {
+	type EmbeddableSchema,
+	type Extras,
+	embed,
+	hasDeferredAlias,
+	type IR,
+	IR_BRAND,
+	isPlainRecord,
+	type PropIR,
+} from "./ir";
+import { type NarrowContext, type Type, type } from "./type";
 
 interface OptionalSchemaMarker {
 	readonly _optional: true;
@@ -14,8 +23,6 @@ interface RefineOptions {
 interface Decoratable<out Out> extends EmbeddableSchema {
 	(value: unknown): Out | OmpErrors;
 	narrow(predicate: (value: Out, context: NarrowContext) => unknown): Decoratable<Out>;
-	/** Input-side predicate: runs on the raw value, before the base validates it. */
-	filter(predicate: (value: unknown, context: NarrowContext) => unknown, options?: FilterOptions): Decoratable<Out>;
 	pipe<Next>(transform: (value: Out, context: NarrowContext) => Next): Decoratable<Exclude<Next, OmpErrors>>;
 	or(def: unknown): Decoratable<unknown>;
 	describe(description: string): Decoratable<Out>;
@@ -117,10 +124,8 @@ const kRebuild = Symbol("omptype.zod.rebuild");
 interface RebuildInfo<Out> {
 	/** Wrapper-free schema, the one a rebuild starts from. */
 	base: Decoratable<Out>;
-	/** Whether an array guard is part of the chain. */
-	guarded: boolean;
-	/** Re-applies the non-guard wrappers, currently `.readonly()`'s freeze. */
-	rewrap?: (schema: Decoratable<Out>) => Decoratable<Out>;
+	/** Re-applies the wrappers, currently `.readonly()`'s freeze. */
+	rewrap: (schema: Decoratable<Out>) => Decoratable<Out>;
 }
 
 /** A schema that may carry {@link RebuildInfo}. */
@@ -133,7 +138,6 @@ function rebuildInfoOf<Out>(schema: Decoratable<Out>): RebuildInfo<Out> | undefi
 	return carrier[kRebuild];
 }
 
-/** Configurable so a schema stamped by `guardObjectInput` can be re-stamped once its full wrapper chain is known. */
 function stampRebuild<Out>(schema: Decoratable<Out>, info: RebuildInfo<Out>): Decoratable<Out> {
 	Object.defineProperty(schema, kRebuild, { value: info, enumerable: false, configurable: true });
 	return schema;
@@ -158,56 +162,8 @@ function restrictBase<Out>(source: Decoratable<Out>, ir: IR): Decoratable<Out> {
 		: schemaFromIR<Out>(ir);
 	if (base.ir.desc !== undefined) structural = structural.describe(base.ir.desc);
 	if (base.hasDefault) structural = structural.default(base.defaultValue as Out | (() => Out));
-	// Every object target is guarded, stripping included; any other target — a
-	// discriminated union rebuilt by `.describe()` — keeps the guard it arrived
-	// with.
-	const guarded = ir.k === "object" || info?.guarded === true;
-	let next = guarded ? guardObjectInput(structural) : structural;
-	if (info?.rewrap !== undefined) next = info.rewrap(next);
-	return guarded || info?.rewrap !== undefined
-		? stampRebuild(next, { base: structural, guarded, rewrap: info?.rewrap })
-		: next;
-}
-
-/**
- * Kind label for a value zod classifies OUTSIDE its object domain, or
- * `undefined` when the value is acceptable object input.
- *
- * Mirrors zod's own input classification: arrays, `Date`, `Map`, `Set` and
- * thenables are separate parsed types there, so an object schema rejects them.
- * Plain objects and class instances are object input, in zod and here.
- */
-function nonObjectKind(value: object): string | undefined {
-	if (Array.isArray(value)) return "an array";
-	if (value instanceof Date) return "a Date";
-	if (value instanceof Map) return "a Map";
-	if (value instanceof Set) return "a Set";
-	const thenable: { then?: unknown; catch?: unknown } = value;
-	return typeof thenable.then === "function" && typeof thenable.catch === "function" ? "a Promise" : undefined;
-}
-
-/**
- * Hold an object schema to zod's object-input domain, which the emitted
- * `{"type":"object"}` already promises — omptype's object node accepts any
- * non-null object, arrays and built-ins included.
- *
- * A RAW `filter` step: filters run before the base validates, so this also
- * catches what an output-side `narrow` cannot — a key-stripping object has
- * already turned `[]` into `{}` by the time a narrow runs, and so has a
- * discriminated union whose matching variant strips. `raw` skips the input
- * prevalidation walk a filter normally triggers, which would validate every
- * accepted object twice and rewalk descendants once per nesting level.
- */
-function guardObjectInput<Out>(base: Decoratable<Out>): Decoratable<Out> {
-	const guarded = base.filter(
-		(value, ctx: NarrowContext) => {
-			if (typeof value !== "object" || value === null) return true;
-			const kind = nonObjectKind(value);
-			return kind === undefined || ctx.mustBe(`an object, not ${kind}`);
-		},
-		{ raw: true },
-	);
-	return stampRebuild(guarded, { base, guarded: true });
+	if (info === undefined) return structural;
+	return stampRebuild(info.rewrap(structural), { base: structural, rewrap: info.rewrap });
 }
 
 /**
@@ -515,7 +471,6 @@ function decorate<Out>(schema: Decoratable<Out>, optional = false): ZodLikeSchem
 			const frozen = freezeParseOutput(schema);
 			stampRebuild(frozen, {
 				base: info?.base ?? schema,
-				guarded: info?.guarded === true,
 				rewrap: rewrap === undefined ? freezeParseOutput : inner => freezeParseOutput(rewrap(inner)),
 			});
 			return next(frozen) as unknown as ZodLikeSchema<Readonly<Out>>;
@@ -551,8 +506,11 @@ function objectSchema<const S extends Shape>(shape: S, extras: Extras = "delete"
 		}
 		props.push(prop);
 	}
-	const base = schemaFromIR<unknown>({ k: "object", props, extras });
-	return decorateUnknown(guardObjectInput(base)) as unknown as ZodLikeSchema<ObjectOutput<S>>;
+	// `plain` is structural, so it rides through `.strict()`/`.partial()` rebuilds,
+	// `projectIO` (hence `.in`), embedded `sub` nodes and the compiler — none of
+	// which can see a validation step attached to a nested schema.
+	const base = schemaFromIR<unknown>({ k: "object", props, extras, plain: true });
+	return decorateUnknown(base) as unknown as ZodLikeSchema<ObjectOutput<S>>;
 }
 
 export const string = (): ZodLikeSchema<string> => decorate(schemaFromIR(type.string.ir));
@@ -804,7 +762,7 @@ export const discriminatedUnion = <
 			// union's input is an object by definition, yet a stripping variant
 			// whose discriminator carries a default (`kind: z.literal("a")
 			// .default("a")`) would otherwise morph `[]` into `{ kind: "a" }`.
-			return decorate(guardObjectInput(schemaFromIR<UnionOutput<Schemas>>({ k: "union", members: variantIrs })));
+			return decorate(schemaFromIR<UnionOutput<Schemas>>({ k: "union", members: variantIrs }));
 		} catch (error) {
 			// Same fallback as union(): variants whose discriminators do not
 			// disjointly pin literals (e.g. optional discriminators overlapping
@@ -826,7 +784,7 @@ export const discriminatedUnion = <
 			claimDiscriminatorValues(true);
 			checked = true;
 		}
-		if (typeof value !== "object" || value === null || Array.isArray(value)) {
+		if (typeof value !== "object" || value === null || !isPlainRecord(value)) {
 			return ctx.error(`an object with a "${discriminator}" discriminator`);
 		}
 		let candidates = variants;
@@ -908,8 +866,9 @@ export const record = <Key extends string, Value>(
 		props: [],
 		index: embed(valueSchema),
 		extras: "keep",
+		plain: true,
 	});
-	const checked = guardObjectInput(base).narrow((value, ctx: NarrowContext) => {
+	const checked = base.narrow((value, ctx: NarrowContext) => {
 		for (const key in value) {
 			if (keySchema(key) instanceof type.errors) return ctx.mustBe("a record with valid string keys");
 		}

--- a/packages/omptype/src/zod.ts
+++ b/packages/omptype/src/zod.ts
@@ -90,13 +90,71 @@ function undefinedDispatch<Out>(
 	});
 }
 
+/**
+ * Rebuild `source`'s structure as `ir`, keeping its description, default, and
+ * any user steps.
+ *
+ * The array guard is deliberately unwrapped and re-applied rather than carried:
+ * it is the shim's own step, not the author's, and leaving it in place would
+ * make the source count as stepped, so the rebuilt schema would validate `ir`
+ * and then re-validate through the OLD object policy — `.strict().partial()`
+ * would still demand the now-optional keys, and `z.strictObject({})
+ * .passthrough()` would still reject extras.
+ */
 function restrictBase<Out>(source: Decoratable<Out>, ir: IR): Decoratable<Out> {
-	let next = source.hasSteps
-		? schemaFromIR<Out>({ k: "morph", input: ir, fn: value => source(value) })
+	const unguarded = unguardedObject(source);
+	let next = unguarded.hasSteps
+		? schemaFromIR<Out>({ k: "morph", input: ir, fn: value => unguarded(value) })
 		: schemaFromIR<Out>(ir);
-	if (source.ir.desc !== undefined) next = next.describe(source.ir.desc);
-	if (source.hasDefault) next = next.default(source.defaultValue as Out | (() => Out));
-	return next;
+	if (unguarded.ir.desc !== undefined) next = next.describe(unguarded.ir.desc);
+	if (unguarded.hasDefault) next = next.default(unguarded.defaultValue as Out | (() => Out));
+	return ir.k === "object" && ir.extras !== "delete" ? guardArrays(next) : next;
+}
+
+const kUnguarded = Symbol("omptype.zod.unguardedObject");
+
+/** A schema that may carry the step-free base an array guard was applied to. */
+interface MaybeGuarded<Out> extends Decoratable<Out> {
+	readonly [kUnguarded]?: Decoratable<Out>;
+}
+
+/**
+ * Reject an array reaching an object schema, which zod does and the emitted
+ * `{"type":"object"}` already promises. Only usable where the object does NOT
+ * strip keys: a narrow step observes the object node's OUTPUT, and a
+ * key-stripping object has already turned `[]` into `{}` by then, so the guard
+ * would inspect the wrong value. Stripping objects therefore keep omptype's
+ * object-node semantics (arrays are objects), which is what `type({})` does
+ * too — tightening that belongs in the IR's object arm, not here.
+ *
+ * The pre-guard schema is kept on the result so {@link restrictBase} can
+ * rebuild from it; see there for why carrying the guard instead breaks later
+ * structural modifiers.
+ */
+function guardArrays<Out>(base: Decoratable<Out>): Decoratable<Out> {
+	const guarded = base.narrow(
+		(value, ctx: NarrowContext) => !Array.isArray(value) || ctx.mustBe("an object, not an array"),
+	);
+	Object.defineProperty(guarded, kUnguarded, { value: base, enumerable: false });
+	return guarded;
+}
+
+/** The step-free schema behind an array guard, or `schema` when there is none. */
+function unguardedObject<Out>(schema: Decoratable<Out>): Decoratable<Out> {
+	const carrier: MaybeGuarded<Out> = schema;
+	return carrier[kUnguarded] ?? schema;
+}
+
+/**
+ * Keep the unguarded base reachable through a wrapper that adds no policy of
+ * its own (`.describe()`), so a later `.partial()`/mode change still rebuilds
+ * from the base instead of re-validating through the old object policy.
+ */
+function carryGuard<Out>(source: Decoratable<Out>, wrapped: Decoratable<Out>): Decoratable<Out> {
+	const carrier: MaybeGuarded<Out> = source;
+	const base = carrier[kUnguarded];
+	if (base !== undefined) Object.defineProperty(wrapped, kUnguarded, { value: base, enumerable: false });
+	return wrapped;
 }
 
 function lengthBound(kind: "min" | "max", schema: Decoratable<unknown>, bound: number): void {
@@ -130,11 +188,10 @@ function decorate<Out>(schema: Decoratable<Out>, optional = false): ZodLikeSchem
 	const next = (inner: Decoratable<Out>, nextOptional = optional): ZodLikeSchema<Out> => decorate(inner, nextOptional);
 	const withObjectExtras = (extras: "keep" | "reject" | "delete"): ZodLikeSchema<Out> => {
 		if (schema.ir.k !== "object") throw new OmpTypeError("object mode requires an object schema");
-		const restricted = restrictBase(schema, { ...schema.ir, extras });
-		// Same reasoning as objectSchema: the guard is only meaningful where the
-		// object does not strip keys, so `.strict()`/`.passthrough()` reject
-		// arrays exactly like `z.strictObject`/`z.looseObject`.
-		return next(extras === "delete" ? restricted : rejectArrays(restricted));
+		// restrictBase re-applies the array guard for the non-stripping modes, so
+		// `.strict()`/`.passthrough()` reject arrays exactly like
+		// `z.strictObject`/`z.looseObject`.
+		return next(restrictBase(schema, { ...schema.ir, extras }));
 	};
 	Object.defineProperty(schema, "isOptional", { value: optional, enumerable: false });
 
@@ -301,7 +358,8 @@ function decorate<Out>(schema: Decoratable<Out>, optional = false): ZodLikeSchem
 			return result;
 		},
 		describe(description: string): ZodLikeSchema<Out> {
-			return next(restrictBase(schema, { ...schema.ir, desc: description }).describe(description));
+			const rebuilt = restrictBase(schema, { ...schema.ir, desc: description });
+			return next(carryGuard(rebuilt, rebuilt.describe(description)));
 		},
 		refine(predicate: (value: Out) => unknown, messageOrOptions?: string | RefineOptions): ZodLikeSchema<Out> {
 			const expectation = refinementMessage(messageOrOptions);
@@ -403,19 +461,6 @@ type ObjectOutput<S extends Shape> = {
 type Simplify<T> = { [K in keyof T]: T[K] };
 type UnionOutput<Schemas extends readonly ZodLikeSchema<unknown>[]> = SchemaOutput<Schemas[number]>;
 
-/**
- * Reject an array reaching an object schema, which zod does and the emitted
- * `{"type":"object"}` already promises. Only usable where the object does NOT
- * strip keys: a narrow step observes the object node's OUTPUT, and a
- * key-stripping object has already turned `[]` into `{}` by then, so the guard
- * would inspect the wrong value. Stripping objects therefore keep omptype's
- * object-node semantics (arrays are objects), which is what `type({})` does
- * too — tightening that belongs in the IR's object arm, not here.
- */
-function rejectArrays<Out>(schema: Decoratable<Out>): Decoratable<Out> {
-	return schema.narrow((value, ctx: NarrowContext) => !Array.isArray(value) || ctx.mustBe("an object, not an array"));
-}
-
 function objectSchema<const S extends Shape>(shape: S, extras: Extras = "delete"): ZodLikeSchema<ObjectOutput<S>> {
 	const props: PropIR[] = [];
 	for (const key in shape) {
@@ -429,7 +474,7 @@ function objectSchema<const S extends Shape>(shape: S, extras: Extras = "delete"
 		props.push(prop);
 	}
 	const base = schemaFromIR<unknown>({ k: "object", props, extras });
-	return decorateUnknown(extras === "delete" ? base : rejectArrays(base)) as unknown as ZodLikeSchema<ObjectOutput<S>>;
+	return decorateUnknown(extras === "delete" ? base : guardArrays(base)) as unknown as ZodLikeSchema<ObjectOutput<S>>;
 }
 
 export const string = (): ZodLikeSchema<string> => decorate(schemaFromIR(type.string.ir));

--- a/packages/omptype/src/zod.ts
+++ b/packages/omptype/src/zod.ts
@@ -755,7 +755,9 @@ export const discriminatedUnion = <
 	/**
 	 * Every discriminator value must be claimed by exactly one variant, as zod
 	 * requires: two variants pinning `kind: "x"` make dispatch ambiguous, and
-	 * the winner would be decided by declaration order alone.
+	 * the winner would be decided by declaration order alone. A variant naming
+	 * the same value twice — `z.union([z.literal("a"), z.literal("a").refine(…)])`
+	 * — is not ambiguous, since both claims route to the same branch.
 	 *
 	 * `resolved` says whether deferred getters have run: at construction a
 	 * deferred variant's values are legitimately unknown and it is skipped,
@@ -770,7 +772,7 @@ export const discriminatedUnion = <
 			}
 			for (const value of variant.values) {
 				const claimed = claims.get(value);
-				if (claimed !== undefined) {
+				if (claimed !== undefined && claimed !== index) {
 					throw new OmpTypeError(
 						`discriminatedUnion variants ${claimed} and ${index} both pin "${discriminator}" to ${JSON.stringify(value) ?? String(value)}`,
 					);

--- a/packages/omptype/src/zod.ts
+++ b/packages/omptype/src/zod.ts
@@ -503,71 +503,113 @@ export const union = <
 		}),
 	);
 };
-const NO_DISCRIMINANT = Symbol("omptype.zod.noDiscriminant");
-
 /**
- * Literal value a discriminated-union variant pins the discriminator to, read
- * straight off its structural IR; {@link NO_DISCRIMINANT} when unknowable.
+ * The values `ir` can take when that set is finite — literals, `null`,
+ * `undefined`, and unions of those (`z.enum`, a literal union). `undefined`
+ * means the set is open, so nothing can be dispatched on it.
  */
-function discriminantLiteral(ir: IR, key: string): unknown {
-	if (ir.k !== "object") return NO_DISCRIMINANT;
-	for (const prop of ir.props) {
-		if (prop.key === key) return prop.val.k === "lit" ? prop.val.v : NO_DISCRIMINANT;
+function finiteValues(ir: IR, seen?: Set<IR>): unknown[] | undefined {
+	switch (ir.k) {
+		case "lit":
+			return [ir.v];
+		case "null":
+			return [null];
+		case "undefined":
+			return [undefined];
+		case "union": {
+			const values: unknown[] = [];
+			for (const member of ir.members) {
+				const inner = finiteValues(member, seen);
+				if (inner === undefined) return undefined;
+				values.push(...inner);
+			}
+			return values.length > 0 ? values : undefined;
+		}
+		case "refine":
+			return finiteValues(ir.base, seen);
+		case "sub":
+			return finiteValues(ir.schema.ir, seen);
+		case "morph":
+			return finiteValues(ir.input, seen);
+		case "alias":
+			return resolveAlias(ir, seen, (resolved, active) => finiteValues(resolved, active));
+		default:
+			return undefined;
 	}
-	return NO_DISCRIMINANT;
 }
 
 /**
- * True when `ir` structurally declares `key`, the minimum a discriminated-union
- * variant must do to be dispatchable at all. Deliberately weaker than "pins a
- * literal": zod 4 accepts an enum or literal-union discriminator, which cannot
- * be dispatched on but is a legitimate variant — it falls through to the
- * ordered attempt. A non-object variant, or an object without the key, is a
- * definition error instead: nothing about it can honour the dispatch contract.
+ * Values a discriminated-union variant pins its discriminator to, or
+ * `undefined` when the variant cannot be dispatched on at all: a non-object, an
+ * object without the key, or a key whose value set is open (`kind: z.string()`,
+ * which zod rejects — accepting it would validate arbitrary discriminators
+ * through whichever variant happens to be tried first).
  *
- * `deferred` chooses what to do with a `z.lazy` alias: `"accept"` at
+ * Never called with an unresolved `z.lazy` inside: the caller skips those at
  * construction, where running the getter would break recursive definitions via
- * TDZ, and `"resolve"` at first parse, the earliest point zod's contract allows
- * the content to be inspected.
+ * TDZ, and re-checks them at first parse when resolution is legal.
  */
-function declaresDiscriminator(ir: IR, key: string, deferred: "accept" | "resolve", seen?: Set<IR>): boolean {
+function discriminatorValues(ir: IR, key: string, seen?: Set<IR>): unknown[] | undefined {
 	switch (ir.k) {
-		case "object":
-			return ir.props.some(prop => prop.key === key);
-		case "union":
-			return ir.members.every(member => declaresDiscriminator(member, key, deferred, seen));
-		case "intersection":
-			return ir.members.some(member => declaresDiscriminator(member, key, deferred, seen));
+		case "object": {
+			const prop = ir.props.find(candidate => candidate.key === key);
+			return prop === undefined ? undefined : finiteValues(prop.val, seen);
+		}
+		case "union": {
+			const values: unknown[] = [];
+			for (const member of ir.members) {
+				const inner = discriminatorValues(member, key, seen);
+				if (inner === undefined) return undefined;
+				values.push(...inner);
+			}
+			return values.length > 0 ? values : undefined;
+		}
+		case "intersection": {
+			for (const member of ir.members) {
+				const inner = discriminatorValues(member, key, seen);
+				if (inner !== undefined) return inner;
+			}
+			return undefined;
+		}
 		case "sub":
-			return declaresDiscriminator(ir.schema.ir, key, deferred, seen);
+			return discriminatorValues(ir.schema.ir, key, seen);
 		case "morph":
 			// restrictBase wraps a stepped schema in a morph over its base IR.
-			return declaresDiscriminator(ir.input, key, deferred, seen);
-		case "alias": {
-			if (ir.deferred === true && deferred === "accept") return true;
-			if (seen?.has(ir)) return false;
-			const active = seen ?? new Set<IR>();
-			active.add(ir);
-			return declaresDiscriminator(ir.resolve(), key, deferred, active);
-		}
+			return discriminatorValues(ir.input, key, seen);
+		case "alias":
+			return resolveAlias(ir, seen, (resolved, active) => discriminatorValues(resolved, key, active));
 		default:
-			return false;
+			return undefined;
 	}
 }
 
+/** Resolve an alias under a cycle guard; a re-entered alias yields nothing. */
+function resolveAlias(
+	ir: Extract<IR, { k: "alias" }>,
+	seen: Set<IR> | undefined,
+	visit: (resolved: IR, seen: Set<IR>) => unknown[] | undefined,
+): unknown[] | undefined {
+	if (seen?.has(ir)) return undefined;
+	const active = seen ?? new Set<IR>();
+	active.add(ir);
+	return visit(ir.resolve(), active);
+}
+
 /**
- * Union dispatched on a literal discriminator property. Variants whose IR pins
- * the discriminator to the input's value are tried first; when nothing matches
- * (or no variant declares a usable literal), every variant is attempted in
- * order so failures still report against the full union.
+ * Union dispatched on the discriminator property. Only the variants pinning the
+ * discriminator to the input's value are attempted; if the input carries no
+ * usable discriminator, every variant is attempted in order so failures still
+ * report against the full union.
  *
- * A variant that cannot declare the discriminator is rejected as a definition
- * error, matching zod: the public signature accepts any schema, so
- * `z.discriminatedUnion("kind", [z.string(), z.number()])` would otherwise
- * build a plain string/number union that accepts `"x"` — silently dropping the
- * dispatch contract the call advertises. Statically inspectable variants throw
- * at construction; a `z.lazy` variant is re-checked once its getter has run,
- * so wrapping the same invalid definition in `z.lazy` cannot bypass the check.
+ * A variant that cannot be dispatched on is rejected as a definition error,
+ * matching zod: the public signature accepts any schema, so
+ * `z.discriminatedUnion("kind", [z.string(), z.number()])` — or a variant
+ * declaring `kind: z.string()` — would otherwise build a plain union that
+ * validates arbitrary values through whichever variant is tried first,
+ * silently dropping the dispatch contract the call advertises. Statically
+ * inspectable variants throw at construction; a `z.lazy` variant is re-checked
+ * once its getter has run, so wrapping the same invalid definition in `z.lazy`
+ * cannot bypass the check.
  */
 export const discriminatedUnion = <
 	const Discriminator extends string,
@@ -577,47 +619,49 @@ export const discriminatedUnion = <
 	schemas: Schemas,
 ): ZodLikeSchema<UnionOutput<Schemas>> => {
 	const variantError = (index: number): OmpTypeError =>
-		new OmpTypeError(`discriminatedUnion variant ${index} does not declare a "${discriminator}" property`);
-	for (const [index, schema] of schemas.entries()) {
-		if (!declaresDiscriminator(schema.ir, discriminator, "accept")) throw variantError(index);
+		new OmpTypeError(
+			`discriminatedUnion variant ${index} does not pin "${discriminator}" to a literal or enum value`,
+		);
+	// A variant carrying a deferred alias is accepted unresolved here and
+	// re-checked at first parse: running the getter now would break recursive
+	// definitions via TDZ.
+	const variants = schemas.map(schema => ({
+		schema: schema as ZodLikeSchema<unknown>,
+		deferred: hasDeferredAlias(schema.ir),
+		values: hasDeferredAlias(schema.ir) ? undefined : discriminatorValues(schema.ir, discriminator),
+	}));
+	for (const [index, variant] of variants.entries()) {
+		if (!variant.deferred && variant.values === undefined) throw variantError(index);
 	}
 	const variantIrs = schemas.map(schema => embed(schema));
 	// Same gate as union() above: variants are embedded so stepped variants
 	// keep their steps and their exported structure, only deferred aliases are
 	// excluded up front, and omptype's determinism check arbitrates the rest —
 	// distinct discriminator literals make the variants disjoint, so any-match
-	// equals discriminator-dispatch. The literal dispatcher below is reserved
-	// for variant sets omptype rejects as order-dependent.
+	// equals discriminator-dispatch. The dispatcher below is reserved for
+	// variant sets omptype rejects as order-dependent.
 	if (schemas.every(schema => !hasDeferredAlias(schema.ir))) {
 		try {
 			return decorate(schemaFromIR<UnionOutput<Schemas>>({ k: "union", members: variantIrs }));
 		} catch (error) {
 			// Same fallback as union(): variants whose discriminators do not
 			// disjointly pin literals (e.g. optional discriminators overlapping
-			// another variant) are order-dependent — keep the literal dispatcher.
+			// another variant) are order-dependent — keep the dispatcher.
 			if (!isIndeterminateUnionError(error)) throw error;
 		}
 	}
-	const variants = schemas.map(schema => ({
-		schema: schema as ZodLikeSchema<unknown>,
-		literal: discriminantLiteral(schema.ir, discriminator),
-		// A deferred variant was accepted unresolved above; its content is only
-		// knowable once the getter has run, which is what `deferred` marks for
-		// the one-time re-check below.
-		deferred: hasDeferredAlias(schema.ir),
-	}));
 	let checked = !variants.some(variant => variant.deferred);
 	const dispatch = type.unknown.pipe((value, ctx) => {
 		if (!checked) {
 			// First parse: resolution is now legal, so a `z.lazy` variant that
-			// never declares the discriminator surfaces as the same definition
-			// error instead of quietly matching every object. Flag set only
+			// never pins the discriminator surfaces as the same definition error
+			// instead of quietly matching every object. The flag is set only
 			// after every variant passes, so a broken definition keeps throwing.
-			variants.forEach((variant, index) => {
-				if (variant.deferred && !declaresDiscriminator(variant.schema.ir, discriminator, "resolve")) {
-					throw variantError(index);
-				}
-			});
+			for (const [index, variant] of variants.entries()) {
+				if (!variant.deferred) continue;
+				variant.values = discriminatorValues(variant.schema.ir, discriminator);
+				if (variant.values === undefined) throw variantError(index);
+			}
 			checked = true;
 		}
 		if (typeof value !== "object" || value === null) {
@@ -625,10 +669,8 @@ export const discriminatedUnion = <
 		}
 		let candidates = variants;
 		const disc = (value as Record<string, unknown>)[discriminator];
-		if (disc !== undefined) {
-			const matched = variants.filter(variant => variant.literal === disc);
-			if (matched.length > 0) candidates = matched;
-		}
+		const matched = variants.filter(variant => variant.values?.includes(disc) === true);
+		if (matched.length > 0) candidates = matched;
 		for (const variant of candidates) {
 			const result = variant.schema(value);
 			if (!(result instanceof type.errors)) return result;

--- a/packages/omptype/src/zod.ts
+++ b/packages/omptype/src/zod.ts
@@ -550,19 +550,41 @@ export const discriminatedUnion = <
 	});
 	return decorate(dispatch as Decoratable<unknown>) as ZodLikeSchema<UnionOutput<Schemas>>;
 };
+let lazyCounter = 0;
 /** Defer schema construction until first parse — required for recursive shapes. */
 export const lazy = <Out>(getter: () => ZodLikeSchema<Out>): ZodLikeSchema<Out> => {
 	let resolved: ZodLikeSchema<Out> | undefined;
-	return decorate(
-		schemaFromIR<Out>({
-			k: "morph",
-			input: { k: "unknown" },
-			fn: value => {
-				resolved ??= getter();
-				return resolved(value);
-			},
-		}),
-	);
+	let resolving = false;
+	// Unique per instance so concurrent lazies land on distinct `$defs` keys.
+	const name = `lazy${++lazyCounter}`;
+	const ir: IR = {
+		k: "alias",
+		name,
+		deferred: true,
+		resolve: () => {
+			if (resolved !== undefined) return resolved.ir;
+			// Re-entrant resolve while the getter is still building the schema
+			// (recursive definitions — the getter references this very schema):
+			// resolve to the alias itself. Every walker is cycle-safe on alias
+			// re-entry, and later resolves return the memoized real IR.
+			if (resolving) return ir;
+			resolving = true;
+			try {
+				resolved = getter();
+			} finally {
+				resolving = false;
+			}
+			return resolved.ir;
+		},
+	};
+	// The IR's cycle-safe alias node, not a runtime morph closure: the emitter
+	// registers the alias before recursing and emits `$ref: "#/$defs/<name>"`,
+	// so recursive parameter schemas export as real `$ref`/`$defs` documents
+	// instead of erasing to an unconstrained `{}`. `deferred` keeps
+	// construction-time scans from calling the getter — resolving earlier
+	// would break recursive `const` definitions (TDZ) and violate zod's
+	// defer-to-first-parse contract.
+	return decorate(schemaFromIR<Out>(ir));
 };
 export const array = <Element>(element: ZodLikeSchema<Element>): ZodLikeSchema<Element[]> =>
 	decorate(schemaFromIR({ k: "array", el: embed(element) }));

--- a/packages/omptype/src/zod.ts
+++ b/packages/omptype/src/zod.ts
@@ -604,6 +604,15 @@ export const union = <
 	);
 };
 /**
+ * A discriminator claim for "this variant accepts the property missing" — an
+ * optional or defaulted discriminator, or one whose value set includes
+ * `undefined`. Claimed but never dispatched on: it cannot be advertised (JSON
+ * omits `undefined` properties), yet two variants accepting the absent case pick
+ * a branch by declaration order, which is the ambiguity zod rejects.
+ */
+const ABSENT = Symbol("omptype.zod.absentDiscriminator");
+
+/**
  * A literal the shim can both dispatch on and advertise. omptype compares
  * object literals by REFERENCE ("must be reference equal to …"), so emitting
  * `const: {…}` would promise the model a structural match the runtime refuses,
@@ -649,7 +658,7 @@ function finiteValues(ir: IR, seen?: Set<IR>): unknown[] | undefined {
 			// so it dispatches like the literal union it was written as.
 			return [true, false];
 		case "undefined":
-			return [];
+			return [ABSENT];
 		case "union": {
 			const values: unknown[] = [];
 			for (const member of ir.members) {
@@ -689,7 +698,15 @@ function discriminatorValues(ir: IR, key: string, seen?: Set<IR>): unknown[] | u
 			const prop = ir.props.find(candidate => candidate.key === key);
 			if (prop === undefined) return undefined;
 			const values = finiteValues(prop.val, seen);
-			return values === undefined || values.length === 0 ? undefined : values;
+			if (values === undefined) return undefined;
+			// An optional or defaulted discriminator also accepts the property
+			// missing, and that case needs a claim of its own or two such
+			// variants would silently resolve by declaration order.
+			const absent = prop.opt === true || prop.hasDefault === true;
+			const claims = absent && !values.includes(ABSENT) ? [...values, ABSENT] : values;
+			// A variant pinned ONLY to the absent case cannot be dispatched on at
+			// all: nothing about it is advertisable.
+			return claims.some(value => value !== ABSENT) ? claims : undefined;
 		}
 		case "union": {
 			const values: unknown[] = [];
@@ -788,7 +805,9 @@ export const discriminatedUnion = <
 				const claimed = claims.get(value);
 				if (claimed !== undefined && claimed !== index) {
 					throw new OmpTypeError(
-						`discriminatedUnion variants ${claimed} and ${index} both pin "${discriminator}" to ${JSON.stringify(value) ?? String(value)}`,
+						value === ABSENT
+							? `discriminatedUnion variants ${claimed} and ${index} both accept a missing "${discriminator}"`
+							: `discriminatedUnion variants ${claimed} and ${index} both pin "${discriminator}" to ${JSON.stringify(value) ?? String(value)}`,
 					);
 				}
 				claims.set(value, index);

--- a/packages/omptype/src/zod.ts
+++ b/packages/omptype/src/zod.ts
@@ -634,6 +634,11 @@ function finiteValues(ir: IR, seen?: Set<IR>): unknown[] | undefined {
 			return isDispatchableLiteral(ir.v) ? [ir.v] : undefined;
 		case "null":
 			return [null];
+		case "boolean":
+			// `z.union([z.literal(true), z.literal(false)])` normalizes to the
+			// boolean node, and the domain is a finite, JSON-representable pair —
+			// so it dispatches like the literal union it was written as.
+			return [true, false];
 		case "undefined":
 			return [];
 		case "union": {

--- a/packages/omptype/src/zod.ts
+++ b/packages/omptype/src/zod.ts
@@ -417,6 +417,15 @@ function decorate<Out>(schema: Decoratable<Out>, optional = false): ZodLikeSchem
 			const rebuilt = restrictBase(schema, { ...schema.ir, desc: description });
 			return next(carryRebuild(rebuilt, rebuilt.describe(description)));
 		},
+		/**
+		 * Author steps end the "replace the object policy" chain: a structural
+		 * modifier applied after one INTERSECTS with the schema the step was
+		 * written against instead of rebuilding from the bare structure, so the
+		 * predicate keeps seeing the shape it was authored for. zod has no such
+		 * chain to match — `.refine()` there returns ZodEffects, which exposes
+		 * neither `.partial()` nor the object modes — so the conservative answer
+		 * is the safe one: the result is stricter, never missing a constraint.
+		 */
 		refine(predicate: (value: Out) => unknown, messageOrOptions?: string | RefineOptions): ZodLikeSchema<Out> {
 			const expectation = refinementMessage(messageOrOptions);
 			return next(schema.narrow((value, ctx) => Boolean(predicate(value)) || ctx.mustBe(expectation)));

--- a/packages/omptype/src/zod.ts
+++ b/packages/omptype/src/zod.ts
@@ -553,16 +553,19 @@ export const discriminatedUnion = <
 	});
 	return decorate(dispatch as Decoratable<unknown>) as ZodLikeSchema<UnionOutput<Schemas>>;
 };
-let lazyCounter = 0;
 /** Defer schema construction until first parse — required for recursive shapes. */
 export const lazy = <Out>(getter: () => ZodLikeSchema<Out>): ZodLikeSchema<Out> => {
 	let resolved: ZodLikeSchema<Out> | undefined;
 	let resolving = false;
-	// Unique per instance so concurrent lazies land on distinct `$defs` keys.
-	const name = `lazy${++lazyCounter}`;
 	const ir: IR = {
 		k: "alias",
-		name,
+		// Deliberately NOT a globally counted name: `emit` uniquifies colliding
+		// `$defs` keys per document, so distinct lazies still land on distinct
+		// entries while the emitted key (and the schema's `description`) stays
+		// a function of the document alone. A module-level counter would make
+		// tool-definition bytes — and every prompt-cache hit keyed on them —
+		// depend on plugin construction order.
+		name: "lazy",
 		deferred: true,
 		resolve: () => {
 			if (resolved !== undefined) return resolved.ir;

--- a/packages/omptype/src/zod.ts
+++ b/packages/omptype/src/zod.ts
@@ -466,8 +466,13 @@ export const union = <
 ): ZodLikeSchema<UnionOutput<Schemas>> => {
 	const members = schemas.map(schema => schema);
 	const irs = members.map(member => member.ir);
-	// Same pipeline gate as optional()/nullable(): `hasSteps` covers
-	// Type-attached transform/refine steps the member IR cannot see.
+	// Stricter than the widening gates above: those only exclude deferred
+	// aliases, because widening against `undefined`/`null` is disjoint by
+	// construction. A union of arbitrary members can overlap in ways the
+	// emitted `anyOf` would misrepresent, so members carrying morphs,
+	// stepped embeds, or default-filled properties keep the ordered
+	// dispatcher. `hasSteps` covers Type-attached transform/refine steps
+	// the member IR cannot see.
 	if (members.every(member => !member.hasSteps) && irs.every(ir => isStructurallyExportable(ir))) {
 		try {
 			return decorate(schemaFromIR<UnionOutput<Schemas>>({ k: "union", members: irs }));

--- a/packages/omptype/src/zod.ts
+++ b/packages/omptype/src/zod.ts
@@ -46,6 +46,17 @@ export interface ZodLikeSchema<out Out> extends Type<Out, unknown> {
 	optional(): ZodLikeSchema<Out | undefined> & OptionalSchemaMarker;
 	nullable(): ZodLikeSchema<Out | null>;
 	default(value: Exclude<Out, undefined> | (() => Exclude<Out, undefined>)): ZodLikeSchema<Exclude<Out, undefined>>;
+	/**
+	 * The `this`-typed overloads keep {@link OptionalSchemaMarker} attached: the
+	 * runtime decorator already carries `isOptional` through both methods, and
+	 * without them `z.infer` reports `z.string().optional().describe("…")` (or
+	 * `.readonly()`) as a REQUIRED property whose value includes `undefined`,
+	 * disagreeing with the parse that accepts the key's absence.
+	 */
+	describe(
+		this: ZodLikeSchema<Out> & OptionalSchemaMarker,
+		description: string,
+	): ZodLikeSchema<Out> & OptionalSchemaMarker;
 	describe(description: string): ZodLikeSchema<Out>;
 	refine(predicate: (value: Out) => unknown, messageOrOptions?: string | RefineOptions): ZodLikeSchema<Out>;
 	transform<Next>(transformer: (value: Out) => Next): ZodLikeSchema<Next>;
@@ -54,6 +65,7 @@ export interface ZodLikeSchema<out Out> extends Type<Out, unknown> {
 	passthrough(): ZodLikeSchema<Out & Record<string, unknown>>;
 	strip(): ZodLikeSchema<Out>;
 	partial(): Out extends object ? ZodLikeSchema<Partial<Out>> : ZodLikeSchema<Out>;
+	readonly(this: ZodLikeSchema<Out> & OptionalSchemaMarker): ZodLikeSchema<Readonly<Out>> & OptionalSchemaMarker;
 	readonly(): ZodLikeSchema<Readonly<Out>>;
 }
 

--- a/packages/omptype/src/zod.ts
+++ b/packages/omptype/src/zod.ts
@@ -630,9 +630,34 @@ export const discriminatedUnion = <
 		deferred: hasDeferredAlias(schema.ir),
 		values: hasDeferredAlias(schema.ir) ? undefined : discriminatorValues(schema.ir, discriminator),
 	}));
-	for (const [index, variant] of variants.entries()) {
-		if (!variant.deferred && variant.values === undefined) throw variantError(index);
-	}
+	/**
+	 * Every discriminator value must be claimed by exactly one variant, as zod
+	 * requires: two variants pinning `kind: "x"` make dispatch ambiguous, and
+	 * the winner would be decided by declaration order alone.
+	 *
+	 * `resolved` says whether deferred getters have run: at construction a
+	 * deferred variant's values are legitimately unknown and it is skipped,
+	 * while afterwards every variant must have produced a value set.
+	 */
+	const claimDiscriminatorValues = (resolved: boolean): void => {
+		const claims = new Map<unknown, number>();
+		for (const [index, variant] of variants.entries()) {
+			if (variant.values === undefined) {
+				if (resolved || !variant.deferred) throw variantError(index);
+				continue;
+			}
+			for (const value of variant.values) {
+				const claimed = claims.get(value);
+				if (claimed !== undefined) {
+					throw new OmpTypeError(
+						`discriminatedUnion variants ${claimed} and ${index} both pin "${discriminator}" to ${JSON.stringify(value) ?? String(value)}`,
+					);
+				}
+				claims.set(value, index);
+			}
+		}
+	};
+	claimDiscriminatorValues(false);
 	const variantIrs = schemas.map(schema => embed(schema));
 	// Same gate as union() above: variants are embedded so stepped variants
 	// keep their steps and their exported structure, only deferred aliases are
@@ -654,14 +679,14 @@ export const discriminatedUnion = <
 	const dispatch = type.unknown.pipe((value, ctx) => {
 		if (!checked) {
 			// First parse: resolution is now legal, so a `z.lazy` variant that
-			// never pins the discriminator surfaces as the same definition error
-			// instead of quietly matching every object. The flag is set only
-			// after every variant passes, so a broken definition keeps throwing.
-			for (const [index, variant] of variants.entries()) {
-				if (!variant.deferred) continue;
-				variant.values = discriminatorValues(variant.schema.ir, discriminator);
-				if (variant.values === undefined) throw variantError(index);
+			// never pins the discriminator — or collides with another variant's
+			// value — surfaces as the same definition error instead of quietly
+			// matching every object. The flag is set only after every variant
+			// passes, so a broken definition keeps throwing.
+			for (const variant of variants) {
+				if (variant.deferred) variant.values = discriminatorValues(variant.schema.ir, discriminator);
 			}
+			claimDiscriminatorValues(true);
 			checked = true;
 		}
 		if (typeof value !== "object" || value === null) {

--- a/packages/omptype/src/zod.ts
+++ b/packages/omptype/src/zod.ts
@@ -14,6 +14,8 @@ interface RefineOptions {
 interface Decoratable<out Out> extends EmbeddableSchema {
 	(value: unknown): Out | OmpErrors;
 	narrow(predicate: (value: Out, context: NarrowContext) => unknown): Decoratable<Out>;
+	/** Input-side predicate: runs on the raw value, before the base validates it. */
+	filter(predicate: (value: unknown, context: NarrowContext) => unknown): Decoratable<Out>;
 	pipe<Next>(transform: (value: Out, context: NarrowContext) => Next): Decoratable<Exclude<Next, OmpErrors>>;
 	or(def: unknown): Decoratable<unknown>;
 	describe(description: string): Decoratable<Out>;
@@ -108,7 +110,11 @@ function restrictBase<Out>(source: Decoratable<Out>, ir: IR): Decoratable<Out> {
 		: schemaFromIR<Out>(ir);
 	if (unguarded.ir.desc !== undefined) next = next.describe(unguarded.ir.desc);
 	if (unguarded.hasDefault) next = next.default(unguarded.defaultValue as Out | (() => Out));
-	return ir.k === "object" && ir.extras !== "delete" ? guardArrays(next) : next;
+	// Every object target is guarded, stripping included; any other target — a
+	// discriminated union rebuilt by `.describe()` — keeps the guard it arrived
+	// with.
+	const guard = ir.k === "object" || unguarded !== source;
+	return guard ? guardArrays(next) : next;
 }
 
 const kUnguarded = Symbol("omptype.zod.unguardedObject");
@@ -120,19 +126,19 @@ interface MaybeGuarded<Out> extends Decoratable<Out> {
 
 /**
  * Reject an array reaching an object schema, which zod does and the emitted
- * `{"type":"object"}` already promises. Only usable where the object does NOT
- * strip keys: a narrow step observes the object node's OUTPUT, and a
- * key-stripping object has already turned `[]` into `{}` by then, so the guard
- * would inspect the wrong value. Stripping objects therefore keep omptype's
- * object-node semantics (arrays are objects), which is what `type({})` does
- * too — tightening that belongs in the IR's object arm, not here.
+ * `{"type":"object"}` already promises.
+ *
+ * A `filter` step, not `narrow`: filters run against the RAW INPUT before the
+ * base validates it, so this also catches the shapes an output-side check
+ * cannot — a key-stripping object has already turned `[]` into `{}` by the time
+ * a narrow runs, and so has a discriminated union whose matching variant strips.
  *
  * The pre-guard schema is kept on the result so {@link restrictBase} can
  * rebuild from it; see there for why carrying the guard instead breaks later
  * structural modifiers.
  */
 function guardArrays<Out>(base: Decoratable<Out>): Decoratable<Out> {
-	const guarded = base.narrow(
+	const guarded = base.filter(
 		(value, ctx: NarrowContext) => !Array.isArray(value) || ctx.mustBe("an object, not an array"),
 	);
 	Object.defineProperty(guarded, kUnguarded, { value: base, enumerable: false });
@@ -474,7 +480,7 @@ function objectSchema<const S extends Shape>(shape: S, extras: Extras = "delete"
 		props.push(prop);
 	}
 	const base = schemaFromIR<unknown>({ k: "object", props, extras });
-	return decorateUnknown(extras === "delete" ? base : guardArrays(base)) as unknown as ZodLikeSchema<ObjectOutput<S>>;
+	return decorateUnknown(guardArrays(base)) as unknown as ZodLikeSchema<ObjectOutput<S>>;
 }
 
 export const string = (): ZodLikeSchema<string> => decorate(schemaFromIR(type.string.ir));
@@ -722,7 +728,11 @@ export const discriminatedUnion = <
 	// variant sets omptype rejects as order-dependent.
 	if (schemas.every(schema => !hasDeferredAlias(schema.ir))) {
 		try {
-			return decorate(schemaFromIR<UnionOutput<Schemas>>({ k: "union", members: variantIrs }));
+			// Guarded at the combinator boundary, not per variant: a discriminated
+			// union's input is an object by definition, yet a stripping variant
+			// whose discriminator carries a default (`kind: z.literal("a")
+			// .default("a")`) would otherwise morph `[]` into `{ kind: "a" }`.
+			return decorate(guardArrays(schemaFromIR<UnionOutput<Schemas>>({ k: "union", members: variantIrs })));
 		} catch (error) {
 			// Same fallback as union(): variants whose discriminators do not
 			// disjointly pin literals (e.g. optional discriminators overlapping
@@ -744,7 +754,7 @@ export const discriminatedUnion = <
 			claimDiscriminatorValues(true);
 			checked = true;
 		}
-		if (typeof value !== "object" || value === null) {
+		if (typeof value !== "object" || value === null || Array.isArray(value)) {
 			return ctx.error(`an object with a "${discriminator}" discriminator`);
 		}
 		let candidates = variants;
@@ -827,7 +837,7 @@ export const record = <Key extends string, Value>(
 		index: embed(valueSchema),
 		extras: "keep",
 	});
-	const checked = base.narrow((value, ctx: NarrowContext) => {
+	const checked = guardArrays(base).narrow((value, ctx: NarrowContext) => {
 		for (const key in value) {
 			if (keySchema(key) instanceof type.errors) return ctx.mustBe("a record with valid string keys");
 		}

--- a/packages/omptype/src/zod.ts
+++ b/packages/omptype/src/zod.ts
@@ -614,7 +614,14 @@ export const lazy = <Out>(getter: () => ZodLikeSchema<Out>): ZodLikeSchema<Out> 
 		name: "lazy",
 		deferred: true,
 		resolve: () => {
-			if (resolved !== undefined) return resolved.ir;
+			// `embed`, not `.ir`: a getter returning a stepped schema
+			// (`z.string().refine(…)`, `.transform()`, `.catch()`,
+			// `.readonly()`) keeps those steps on the schema wrapper, so
+			// resolving to the bare base IR would drop them — the lazy schema
+			// would accept values its own refinement rejects and hand back
+			// untransformed output. A `sub` node keeps the steps and still
+			// exports the structural base.
+			if (resolved !== undefined) return embed(resolved);
 			// Re-entrant resolve while the getter is still building the schema
 			// (recursive definitions — the getter references this very schema):
 			// resolve to the alias itself. Every walker is cycle-safe on alias
@@ -626,7 +633,7 @@ export const lazy = <Out>(getter: () => ZodLikeSchema<Out>): ZodLikeSchema<Out> 
 			} finally {
 				resolving = false;
 			}
-			return resolved.ir;
+			return embed(resolved);
 		},
 	};
 	// The IR's cycle-safe alias node, not a runtime morph closure: the emitter

--- a/packages/omptype/src/zod.ts
+++ b/packages/omptype/src/zod.ts
@@ -1,6 +1,6 @@
 import { type OmpErrors, OmpTypeError } from "./errors";
 import { type EmbeddableSchema, type Extras, embed, hasDeferredAlias, type IR, IR_BRAND, type PropIR } from "./ir";
-import { type NarrowContext, type Type, type } from "./type";
+import { type FilterOptions, type NarrowContext, type Type, type } from "./type";
 
 interface OptionalSchemaMarker {
 	readonly _optional: true;
@@ -15,7 +15,7 @@ interface Decoratable<out Out> extends EmbeddableSchema {
 	(value: unknown): Out | OmpErrors;
 	narrow(predicate: (value: Out, context: NarrowContext) => unknown): Decoratable<Out>;
 	/** Input-side predicate: runs on the raw value, before the base validates it. */
-	filter(predicate: (value: unknown, context: NarrowContext) => unknown): Decoratable<Out>;
+	filter(predicate: (value: unknown, context: NarrowContext) => unknown, options?: FilterOptions): Decoratable<Out>;
 	pipe<Next>(transform: (value: Out, context: NarrowContext) => Next): Decoratable<Exclude<Next, OmpErrors>>;
 	or(def: unknown): Decoratable<unknown>;
 	describe(description: string): Decoratable<Out>;
@@ -133,7 +133,7 @@ function rebuildInfoOf<Out>(schema: Decoratable<Out>): RebuildInfo<Out> | undefi
 	return carrier[kRebuild];
 }
 
-/** Configurable so a schema stamped by `guardArrays` can be re-stamped once its full wrapper chain is known. */
+/** Configurable so a schema stamped by `guardObjectInput` can be re-stamped once its full wrapper chain is known. */
 function stampRebuild<Out>(schema: Decoratable<Out>, info: RebuildInfo<Out>): Decoratable<Out> {
 	Object.defineProperty(schema, kRebuild, { value: info, enumerable: false, configurable: true });
 	return schema;
@@ -162,7 +162,7 @@ function restrictBase<Out>(source: Decoratable<Out>, ir: IR): Decoratable<Out> {
 	// discriminated union rebuilt by `.describe()` — keeps the guard it arrived
 	// with.
 	const guarded = ir.k === "object" || info?.guarded === true;
-	let next = guarded ? guardArrays(structural) : structural;
+	let next = guarded ? guardObjectInput(structural) : structural;
 	if (info?.rewrap !== undefined) next = info.rewrap(next);
 	return guarded || info?.rewrap !== undefined
 		? stampRebuild(next, { base: structural, guarded, rewrap: info?.rewrap })
@@ -173,14 +173,17 @@ function restrictBase<Out>(source: Decoratable<Out>, ir: IR): Decoratable<Out> {
  * Reject an array reaching an object schema, which zod does and the emitted
  * `{"type":"object"}` already promises.
  *
- * A `filter` step, not `narrow`: filters run against the RAW INPUT before the
- * base validates it, so this also catches the shapes an output-side check
- * cannot — a key-stripping object has already turned `[]` into `{}` by the time
- * a narrow runs, and so has a discriminated union whose matching variant strips.
+ * A RAW `filter` step: filters run before the base validates, so this also
+ * catches what an output-side `narrow` cannot — a key-stripping object has
+ * already turned `[]` into `{}` by the time a narrow runs, and so has a
+ * discriminated union whose matching variant strips. `raw` skips the input
+ * prevalidation walk a filter normally triggers, which would validate every
+ * accepted object twice and rewalk descendants once per nesting level.
  */
-function guardArrays<Out>(base: Decoratable<Out>): Decoratable<Out> {
+function guardObjectInput<Out>(base: Decoratable<Out>): Decoratable<Out> {
 	const guarded = base.filter(
 		(value, ctx: NarrowContext) => !Array.isArray(value) || ctx.mustBe("an object, not an array"),
+		{ raw: true },
 	);
 	return stampRebuild(guarded, { base, guarded: true });
 }
@@ -527,7 +530,7 @@ function objectSchema<const S extends Shape>(shape: S, extras: Extras = "delete"
 		props.push(prop);
 	}
 	const base = schemaFromIR<unknown>({ k: "object", props, extras });
-	return decorateUnknown(guardArrays(base)) as unknown as ZodLikeSchema<ObjectOutput<S>>;
+	return decorateUnknown(guardObjectInput(base)) as unknown as ZodLikeSchema<ObjectOutput<S>>;
 }
 
 export const string = (): ZodLikeSchema<string> => decorate(schemaFromIR(type.string.ir));
@@ -779,7 +782,7 @@ export const discriminatedUnion = <
 			// union's input is an object by definition, yet a stripping variant
 			// whose discriminator carries a default (`kind: z.literal("a")
 			// .default("a")`) would otherwise morph `[]` into `{ kind: "a" }`.
-			return decorate(guardArrays(schemaFromIR<UnionOutput<Schemas>>({ k: "union", members: variantIrs })));
+			return decorate(guardObjectInput(schemaFromIR<UnionOutput<Schemas>>({ k: "union", members: variantIrs })));
 		} catch (error) {
 			// Same fallback as union(): variants whose discriminators do not
 			// disjointly pin literals (e.g. optional discriminators overlapping
@@ -884,7 +887,7 @@ export const record = <Key extends string, Value>(
 		index: embed(valueSchema),
 		extras: "keep",
 	});
-	const checked = guardArrays(base).narrow((value, ctx: NarrowContext) => {
+	const checked = guardObjectInput(base).narrow((value, ctx: NarrowContext) => {
 		for (const key in value) {
 			if (keySchema(key) instanceof type.errors) return ctx.mustBe("a record with valid string keys");
 		}

--- a/packages/omptype/test/type.test.ts
+++ b/packages/omptype/test/type.test.ts
@@ -528,14 +528,13 @@ describe("type.withJsonSchema", () => {
 });
 
 describe("Type.filter", () => {
-	it("keeps input predicates in the .in projection and skips prevalidation when raw", () => {
+	it("keeps input predicates in the .in projection, and output predicates out of it", () => {
 		// `.in` is what callers validate a schema's accepted INPUT with, so an
 		// input-side predicate has to survive the projection: dropping it let
-		// `.in` admit values the schema itself rejects. Output-side steps
-		// (`narrow`) are correctly absent there.
-		const noArrays = type({ a: "string" }).filter(
-			(value, ctx) => !Array.isArray(value) || ctx.mustBe("an object, not an array"),
-			{ raw: true },
+		// `.in` admit values the schema itself rejects. `narrow` runs on the
+		// output and is correctly absent there.
+		const noArrays = type({ a: "string" }).filter((value, ctx) =>
+			Array.isArray(value) ? ctx.mustBe("an object, not an array") : true,
 		);
 		const withArray: unknown[] = [];
 		Object.assign(withArray, { a: "x" });
@@ -544,30 +543,8 @@ describe("Type.filter", () => {
 		expect(noArrays({ a: "x" })).toEqual({ a: "x" });
 		expect(noArrays.in.allows({ a: "x" })).toBe(true);
 
-		const narrowed = type({ a: "string" }).narrow(value => (value as { a: string }).a !== "no");
+		const narrowed = type({ a: "string" }).narrow(value => value.a !== "no");
 		expect(narrowed({ a: "no" })).toBeInstanceOf(OmpErrors);
 		expect(narrowed.in.allows({ a: "no" })).toBe(true);
-
-		// A raw filter sees the value as handed in and costs no extra walk, so a
-		// getter is read once; a plain filter prevalidates and reads it twice.
-		let rawReads = 0;
-		const rawSpy = {
-			get a() {
-				rawReads++;
-				return "x";
-			},
-		};
-		noArrays(rawSpy);
-		expect(rawReads).toBe(1);
-
-		let prevalidatedReads = 0;
-		const prevalidatedSpy = {
-			get a() {
-				prevalidatedReads++;
-				return "x";
-			},
-		};
-		type({ a: "string" }).filter(() => true)(prevalidatedSpy);
-		expect(prevalidatedReads).toBe(2);
 	});
 });

--- a/packages/omptype/test/type.test.ts
+++ b/packages/omptype/test/type.test.ts
@@ -546,5 +546,17 @@ describe("Type.filter", () => {
 		const narrowed = type({ a: "string" }).narrow(value => value.a !== "no");
 		expect(narrowed({ a: "no" })).toBeInstanceOf(OmpErrors);
 		expect(narrowed.in.allows({ a: "no" })).toBe(true);
+
+		// `allows()` runs filter steps, so it must validate the projected input
+		// first — exactly like the callable path does. Otherwise a predicate that
+		// dereferences its argument throws on malformed data instead of the
+		// schema reporting a rejection, and carrying filters into `.in` turned
+		// that into an exception where the callable returns an error.
+		const dereferencing = type({ a: "string" }).filter(value => value.a.length > 0);
+		expect(dereferencing(null)).toBeInstanceOf(OmpErrors);
+		expect(dereferencing.allows(null)).toBe(false);
+		expect(dereferencing.in.allows(null)).toBe(false);
+		expect(dereferencing.in.allows({ a: "x" })).toBe(true);
+		expect(dereferencing.in.allows({ a: "" })).toBe(false);
 	});
 });

--- a/packages/omptype/test/type.test.ts
+++ b/packages/omptype/test/type.test.ts
@@ -526,3 +526,48 @@ describe("type.withJsonSchema", () => {
 		).toThrow("cannot wrap schemas with defaults or output-changing morphs");
 	});
 });
+
+describe("Type.filter", () => {
+	it("keeps input predicates in the .in projection and skips prevalidation when raw", () => {
+		// `.in` is what callers validate a schema's accepted INPUT with, so an
+		// input-side predicate has to survive the projection: dropping it let
+		// `.in` admit values the schema itself rejects. Output-side steps
+		// (`narrow`) are correctly absent there.
+		const noArrays = type({ a: "string" }).filter(
+			(value, ctx) => !Array.isArray(value) || ctx.mustBe("an object, not an array"),
+			{ raw: true },
+		);
+		const withArray: unknown[] = [];
+		Object.assign(withArray, { a: "x" });
+		expect(noArrays(withArray)).toBeInstanceOf(OmpErrors);
+		expect(noArrays.in.allows(withArray)).toBe(false);
+		expect(noArrays({ a: "x" })).toEqual({ a: "x" });
+		expect(noArrays.in.allows({ a: "x" })).toBe(true);
+
+		const narrowed = type({ a: "string" }).narrow(value => (value as { a: string }).a !== "no");
+		expect(narrowed({ a: "no" })).toBeInstanceOf(OmpErrors);
+		expect(narrowed.in.allows({ a: "no" })).toBe(true);
+
+		// A raw filter sees the value as handed in and costs no extra walk, so a
+		// getter is read once; a plain filter prevalidates and reads it twice.
+		let rawReads = 0;
+		const rawSpy = {
+			get a() {
+				rawReads++;
+				return "x";
+			},
+		};
+		noArrays(rawSpy);
+		expect(rawReads).toBe(1);
+
+		let prevalidatedReads = 0;
+		const prevalidatedSpy = {
+			get a() {
+				prevalidatedReads++;
+				return "x";
+			},
+		};
+		type({ a: "string" }).filter(() => true)(prevalidatedSpy);
+		expect(prevalidatedReads).toBe(2);
+	});
+});

--- a/packages/omptype/test/zod-json-schema.test.ts
+++ b/packages/omptype/test/zod-json-schema.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "bun:test";
+import * as z from "../src/zod";
+
+/**
+ * Every assertion here defends what a provider sees: `toolWireSchema` lowers
+ * these schemas to the parameter JSON Schema sent to the model on all 11
+ * provider adapters. A combinator that erases its structure ships a tool the
+ * model perceives as unconstrained — the failure presents as "the model gets
+ * it wrong", so the emitted document, not just parse behaviour, is the
+ * contract under test.
+ */
+
+interface ObjectSchema {
+	type?: "object";
+	properties?: Record<string, unknown>;
+	required?: string[];
+	additionalProperties?: unknown;
+	anyOf?: unknown[];
+	$ref?: string;
+	$defs?: Record<string, unknown>;
+	const?: unknown;
+	items?: unknown;
+	default?: unknown;
+}
+
+const asObjectSchema = (value: unknown): ObjectSchema => value as ObjectSchema;
+
+/** Read one property's emitted subschema. */
+const propSchema = (parent: ObjectSchema | undefined, key: string): ObjectSchema | undefined =>
+	asObjectSchema(parent?.properties?.[key]);
+/** Read an array's emitted item subschema. */
+const itemsSchema = (parent: ObjectSchema | undefined): ObjectSchema | undefined => asObjectSchema(parent?.items);
+/** Resolve one `$ref` within the emitted document's `$defs`. */
+const resolveRef = (document: ObjectSchema, ref: unknown): ObjectSchema | undefined =>
+	typeof ref === "string" && ref.startsWith("#/$defs/")
+		? asObjectSchema(document.$defs?.[ref.slice("#/$defs/".length)])
+		: undefined;
+
+describe("zod shim JSON Schema structure", () => {
+	it("keeps first-match dispatcher semantics (and documents the erasure) for overlapping stripping objects", () => {
+		// Two plain z.objects both accept overlapping inputs and strip
+		// different keys, so omptype's unordered union cannot represent zod's
+		// first-match semantics: the native build throws
+		// "unordered union ... indeterminate" and the shim must fall back to
+		// the ordered dispatcher WITHOUT surfacing the construction error.
+		// Failure modes guarded: the naive predicate split crashed here
+		// (OmpTypeError at construction); a bare catch would mask real errors.
+		const union = z.union([z.object({ name: z.string() }), z.object({ id: z.number() })]);
+		expect(union.parse({ name: "x", id: 1 })).toEqual({ name: "x" });
+		expect(union.parse({ id: 2 })).toEqual({ id: 2 });
+		expect(union.safeParse("nope").success).toBe(false);
+		// Documented erasure: the dispatcher morph emits `{}` until a
+		// first-class ordered-choice IR node exists (named follow-up).
+		expect(union.toJsonSchema()).toEqual({});
+	});
+
+	it("emits full anyOf for disjoint strictObject union members", () => {
+		const union = z.union([z.strictObject({ name: z.string() }), z.strictObject({ id: z.number() })]);
+		const json = asObjectSchema(union.toJsonSchema());
+		const variants = json.anyOf as ObjectSchema[];
+		expect(variants).toHaveLength(2);
+		expect(variants[0]).toMatchObject({
+			type: "object",
+			properties: { name: { type: "string" } },
+			required: ["name"],
+			additionalProperties: false,
+		});
+		expect(variants[1]?.properties?.id).toEqual({ type: "number" });
+		expect(union.parse({ id: 1 })).toEqual({ id: 1 });
+		expect(union.safeParse({ id: 1, name: "x" }).success).toBe(false);
+	});
+
+	it("emits anyOf with discriminator consts for z.object discriminated-union variants", () => {
+		// Distinct required discriminator literals make the variants disjoint,
+		// so the structural union is order-independent and must not fall back
+		// to the dispatcher: the model needs the variants and their `const`
+		// discriminators to pick one.
+		const event = z.discriminatedUnion("kind", [
+			z.object({ kind: z.literal("append"), n: z.number() }),
+			z.object({ kind: z.literal("gap"), s: z.string() }),
+		]);
+		const json = asObjectSchema(event.toJsonSchema());
+		const variants = json.anyOf as ObjectSchema[];
+		expect(variants).toHaveLength(2);
+		expect(variants[0]?.properties?.kind).toEqual({ const: "append" });
+		expect(variants[1]?.properties?.kind).toEqual({ const: "gap" });
+		// Runtime contract unchanged: key stripping preserved, dispatch exact.
+		expect(event.parse({ kind: "gap", s: "x", junk: 1 })).toEqual({ kind: "gap", s: "x" });
+		expect(event.parse({ kind: "append", n: 1 })).toEqual({ kind: "append", n: 1 });
+		expect(event.safeParse({ kind: "nope" }).success).toBe(false);
+	});
+
+	it("emits structural anyOf for distinct-literal z.object union members", () => {
+		// Disjointness comes from conflicting required literal props (the
+		// generic probe, not the strictObject fast path), so this must take
+		// the structural path: a dispatcher here would erase the variants.
+		const union = z.union([
+			z.object({ kind: z.literal("a"), x: z.string() }),
+			z.object({ kind: z.literal("b"), y: z.number() }),
+		]);
+		const json = asObjectSchema(union.toJsonSchema());
+		const variants = json.anyOf as ObjectSchema[];
+		expect(variants).toHaveLength(2);
+		expect(variants[0]?.properties?.kind).toEqual({ const: "a" });
+		expect(union.parse({ kind: "b", y: 2, junk: 1 })).toEqual({ kind: "b", y: 2 });
+		expect(union.safeParse({ kind: "a", y: 2 }).success).toBe(false);
+	});
+
+	it("preserves inner object schemas through nullable, optional, and default widening", () => {
+		// The dispatcher morph erases the wrapped member to `{}`; the
+		// structural widening union must keep the inner schema visible.
+		const nullable = z.object({ inner: z.object({ name: z.string() }).nullable() });
+		const nullableJson = asObjectSchema(nullable.toJsonSchema());
+		const nullableVariants = propSchema(nullableJson, "inner")?.anyOf as ObjectSchema[];
+		expect(nullableVariants[1]).toEqual({ const: null });
+		expect(nullable.parse({ inner: null })).toEqual({ inner: null });
+		expect(nullable.parse({ inner: { name: "x" } })).toEqual({ inner: { name: "x" } });
+		expect(nullable.safeParse({ inner: 4 }).success).toBe(false);
+
+		const optional = z.object({ inner: z.object({ name: z.string() }).optional() });
+		const optionalJson = asObjectSchema(optional.toJsonSchema());
+		expect(propSchema(optionalJson, "inner")?.properties?.name).toEqual({ type: "string" });
+		expect(optional.parse({})).toEqual({});
+		expect(optional.parse({ inner: { name: "x" } })).toEqual({ inner: { name: "x" } });
+
+		const defaulted = z.object({ inner: z.object({ name: z.string() }).default(() => ({ name: "d" })) });
+		const defaultedJson = asObjectSchema(defaulted.toJsonSchema());
+		expect(propSchema(defaultedJson, "inner")?.properties?.name).toEqual({ type: "string" });
+		expect(propSchema(defaultedJson, "inner")?.default).toEqual({ name: "d" });
+	});
+
+	it("keeps plain object nesting fully structural", () => {
+		const nested = z.object({ list: z.array(z.object({ name: z.string() })) });
+		const json = asObjectSchema(nested.toJsonSchema());
+		const items = itemsSchema(propSchema(json, "list"))?.properties?.name;
+		expect(items).toEqual({ type: "string" });
+		expect(nested.parse({ list: [{ name: "x" }] })).toEqual({ list: [{ name: "x" }] });
+	});
+});

--- a/packages/omptype/test/zod-json-schema.test.ts
+++ b/packages/omptype/test/zod-json-schema.test.ts
@@ -403,4 +403,31 @@ describe("z.lazy deferred alias", () => {
 		expect(widened.parse({})).toEqual({});
 		expect(widened.parse({ t: { v: "x" } })).toEqual({ t: { v: "x" } });
 	});
+
+	it("takes optionality from outside the lazy, never from inside it", () => {
+		// A property's `opt` bit is fixed when the parent object is built, and it
+		// drives BOTH the runtime presence check and the emitted `required`.
+		// A deferred getter is unresolvable at that moment, so optionality has to
+		// be spelled outside the lazy. Pinned in both directions so the boundary
+		// is explicit: the supported spelling keeps working, and the unsupported
+		// one fails loudly instead of silently accepting a missing key.
+		const outside = z.object({ x: z.lazy(() => z.string()).optional() });
+		expect(outside.parse({})).toEqual({});
+		expect(outside.parse({ x: "v" })).toEqual({ x: "v" });
+		expect(outside.safeParse({ x: 1 }).success).toBe(false);
+
+		// Optionality declared INSIDE the getter is invisible to the object
+		// builder, so the key stays required.
+		const inside = z.object({ x: z.lazy(() => z.string().optional()) });
+		expect(inside.safeParse({}).success).toBe(false);
+		expect(inside.parse({ x: "v" })).toEqual({ x: "v" });
+
+		// A plainly required lazy property is required, and exports as `$ref`
+		// inside `required` — the shape the common recursive schema relies on.
+		const required = z.object({ x: z.lazy(() => z.string()) });
+		expect(required.safeParse({}).success).toBe(false);
+		const json = asObjectSchema(required.toJsonSchema());
+		expect(json.required).toEqual(["x"]);
+		expect(resolveRef(json, propSchema(json, "x")?.$ref)).toEqual({ type: "string" });
+	});
 });

--- a/packages/omptype/test/zod-json-schema.test.ts
+++ b/packages/omptype/test/zod-json-schema.test.ts
@@ -137,3 +137,85 @@ describe("zod shim JSON Schema structure", () => {
 		expect(nested.parse({ list: [{ name: "x" }] })).toEqual({ list: [{ name: "x" }] });
 	});
 });
+
+describe("z.lazy deferred alias", () => {
+	it("constructs and parses directly self-referential schemas without TDZ", () => {
+		// Regression: construction-time scans resolved the alias eagerly, so a
+		// getter closing over the const being defined threw
+		// "Cannot access 'jsonValue' before initialization".
+		type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue };
+		const jsonValue: z.ZodType<JsonValue> = z.lazy(() =>
+			z.union([z.string(), z.number(), z.boolean(), z.null(), z.array(jsonValue), z.record(z.string(), jsonValue)]),
+		);
+		const deep = { b: [2, { c: "d" }] };
+		expect(jsonValue.parse(["a", 1, true, null, deep])).toEqual(["a", 1, true, null, deep]);
+		expect(jsonValue.safeParse([() => {}]).success).toBe(false);
+	});
+
+	it("emits self-consistent $ref/$defs for plainly nested recursive schemas", () => {
+		// Regression: lazy used to be a runtime morph, so a recursive
+		// parameter schema reached the model as an unconstrained `{}`. The
+		// emitted document must carry real definitions and every `$ref` must
+		// resolve within them.
+		type Tree = { name: string; children?: Tree[] };
+		const tree: z.ZodType<Tree> = z.lazy(() => z.object({ name: z.string(), children: z.array(tree) }));
+		const json = asObjectSchema(tree.toJsonSchema());
+		const def = resolveRef(json, json.$ref);
+		expect(def?.properties?.name).toEqual({ type: "string" });
+		const children = asObjectSchema(def?.properties?.children);
+		// The self-reference cycles back through the same definition instead
+		// of recursing — this terminating is the point of the assertion.
+		expect(resolveRef(json, asObjectSchema(children.items)?.$ref)).toBe(def);
+		expect(tree.parse({ name: "a", children: [{ name: "b", children: [{ name: "c", children: [] }] }] })).toEqual({
+			name: "a",
+			children: [{ name: "b", children: [{ name: "c", children: [] }] }],
+		});
+	});
+
+	it("invokes the getter exactly once across parses and exports", () => {
+		// A re-invoking getter would rebuild the IR per parse and silently
+		// kill throughput; memoization is part of the contract.
+		let calls = 0;
+		const schema = z.lazy(() => {
+			calls++;
+			return z.object({ v: z.string() });
+		});
+		schema.parse({ v: "a" });
+		schema.parse({ v: "b" });
+		const exported = asObjectSchema(schema.toJsonSchema());
+		expect(resolveRef(exported, exported.$ref)).toBeDefined();
+		expect(calls).toBe(1);
+	});
+
+	it("gives distinct lazies distinct $defs entries", () => {
+		// Regression: a fixed "$defs" key made one lazy silently win the
+		// collision and the other $ref dangle.
+		const a = z.lazy(() => z.object({ x: z.string() }));
+		const b = z.lazy(() => z.object({ y: z.number() }));
+		const both = z.object({ a, b });
+		const json = asObjectSchema(both.toJsonSchema());
+		const refA = asObjectSchema(json.properties?.a)?.$ref;
+		const refB = asObjectSchema(json.properties?.b)?.$ref;
+		expect(typeof refA).toBe("string");
+		expect(refB).not.toBe(refA);
+		expect(resolveRef(json, refA)?.properties?.x).toEqual({ type: "string" });
+		expect(resolveRef(json, refB)?.properties?.y).toEqual({ type: "number" });
+		expect(both.parse({ a: { x: "1" }, b: { y: 2 } })).toEqual({ a: { x: "1" }, b: { y: 2 } });
+	});
+
+	it("keeps pipeline-unknown lazies on the ordered dispatcher without changing runtime", () => {
+		// Conservative consequence of deferral: a union whose members may
+		// carry unseen morphs must not become an unordered native union (the
+		// determinism check cannot see through the alias), and widening over a
+		// lazy keeps the dispatcher. Runtime must stay zod-first-match.
+		const first = z.lazy(() => z.object({ v: z.string() }));
+		const second = z.lazy(() => z.object({ n: z.number() }));
+		const union = z.union([first, second]);
+		expect(union.parse({ n: 1 })).toEqual({ n: 1 });
+		expect(union.safeParse("nope").success).toBe(false);
+
+		const widened = z.object({ t: first.optional() });
+		expect(widened.parse({})).toEqual({});
+		expect(widened.parse({ t: { v: "x" } })).toEqual({ t: { v: "x" } });
+	});
+});

--- a/packages/omptype/test/zod-json-schema.test.ts
+++ b/packages/omptype/test/zod-json-schema.test.ts
@@ -11,11 +11,12 @@ import * as z from "../src/zod";
  */
 
 interface ObjectSchema {
-	type?: "object";
+	type?: string;
 	properties?: Record<string, unknown>;
 	required?: string[];
 	additionalProperties?: unknown;
 	anyOf?: unknown[];
+	enum?: unknown[];
 	$ref?: string;
 	$defs?: Record<string, unknown>;
 	const?: unknown;
@@ -127,6 +128,38 @@ describe("zod shim JSON Schema structure", () => {
 		const defaultedJson = asObjectSchema(defaulted.toJsonSchema());
 		expect(propSchema(defaultedJson, "inner")?.properties?.name).toEqual({ type: "string" });
 		expect(propSchema(defaultedJson, "inner")?.default).toEqual({ name: "d" });
+	});
+
+	it("widens objects containing stepped or defaulted properties structurally", () => {
+		// The widened union is disjoint from undefined/null unless the member
+		// itself accepts them, so these shapes must NOT fall back to the
+		// dispatcher: a defaulted enum prop (the shipped api-demo example's
+		// exact shape) erased to `{}` before the gate relaxed.
+		const apiDemo = z
+			.object({
+				message: z.string(),
+				logLevel: z.enum(["error", "warn", "debug"]).default("debug"),
+			})
+			.optional();
+		const apiDemoJson = asObjectSchema(apiDemo.toJsonSchema());
+		const logLevel = propSchema(apiDemoJson, "logLevel");
+		expect(logLevel?.enum).toEqual(["error", "warn", "debug"]);
+		expect(logLevel?.default).toBe("debug");
+		expect(apiDemo.parse(undefined)).toBeUndefined();
+		expect(apiDemo.parse({ message: "m", logLevel: "warn" })).toEqual({ message: "m", logLevel: "warn" });
+
+		const stepped = z.object({ v: z.string().transform(value => value.length) }).nullable();
+		const steppedJson = asObjectSchema(stepped.toJsonSchema());
+		const steppedMember = asObjectSchema((steppedJson.anyOf as ObjectSchema[])[0]);
+		expect(propSchema(steppedMember, "v")?.type).toBe("string");
+		expect(stepped.parse(null)).toBeNull();
+		expect(stepped.parse({ v: "abc" })).toEqual({ v: 3 });
+
+		// A z.lazy property inside the widened object keeps the dispatcher:
+		// the determinism probe cannot see through the deferred alias.
+		const lazyProp = z.object({ t: z.lazy(() => z.string()) }).optional();
+		expect(lazyProp.toJsonSchema()).toEqual({});
+		expect(lazyProp.parse({ t: "x" })).toEqual({ t: "x" });
 	});
 
 	it("keeps plain object nesting fully structural", () => {

--- a/packages/omptype/test/zod-json-schema.test.ts
+++ b/packages/omptype/test/zod-json-schema.test.ts
@@ -239,6 +239,58 @@ describe("z.lazy deferred alias", () => {
 		});
 	});
 
+	it("does not resolve a lazy getter wrapped in readonly/describe during composition", () => {
+		// The widening gates exclude deferred aliases — scanIR must not
+		// resolve them: a z.lazy hidden behind restrictBase's step-free
+		// morph (z.lazy(...).readonly().describe(...).optional()) would
+		// otherwise pass the gate and the determinism probe would resolve
+		// the getter at construction.
+		// `getterCalls` asserted zero before any parse is the guard that
+		// does the work: with `node` still unassigned during the chain, a
+		// construction-time resolve would also throw from
+		// objectSchema. (.readonly() resolves descriptions eagerly through
+		// appendPipes → metaOf → descriptionOf, which honours the flag.)
+		type Node = { name: string; next?: Node };
+		let getterCalls = 0;
+		let node: z.ZodType<Node>;
+		node = z
+			.lazy(() => {
+				getterCalls++;
+				return z.object({ name: z.string(), next: node });
+			})
+			.readonly()
+			.describe("d")
+			.optional() as unknown as z.ZodType<Node>;
+		expect(getterCalls).toBe(0);
+		expect(node.parse(undefined)).toBeUndefined();
+		expect(node.parse({ name: "a", next: { name: "b" } })).toEqual({ name: "a", next: { name: "b" } });
+		expect(getterCalls).toBe(1);
+		// The chain's own root — and any embedding of it, since .optional()
+		// routed it to the dispatcher morph — erases (documented boundary).
+		// What MUST stay structural is the readonly/describe chain without
+		// the widening: embed → sub → fallback(emit(inner)) → $ref.
+		type Inner = { name: string; next?: Inner };
+		let innerCalls = 0;
+		let innerNode: z.ZodType<Inner>;
+		innerNode = z
+			.lazy(() => {
+				innerCalls++;
+				return z.object({ name: z.string(), next: innerNode.optional() });
+			})
+			.readonly()
+			.describe("d") as unknown as z.ZodType<Inner>;
+		expect(innerCalls).toBe(0);
+		const holder = z.object({ inner: innerNode });
+		const wrapped = asObjectSchema(holder.toJsonSchema());
+		const innerJson = asObjectSchema(propSchema(wrapped, "inner"));
+		expect(resolveRef(wrapped, innerJson?.$ref)).toBeDefined();
+		expect(innerCalls).toBe(1);
+		expect(holder.parse({ inner: { name: "a", next: { name: "b" } } })).toEqual({
+			inner: { name: "a", next: { name: "b" } },
+		});
+		expect(innerCalls).toBe(1);
+	});
+
 	it("invokes the getter exactly once across parses and exports", () => {
 		// A re-invoking getter would rebuild the IR per parse and silently
 		// kill throughput; memoization is part of the contract.

--- a/packages/omptype/test/zod-json-schema.test.ts
+++ b/packages/omptype/test/zod-json-schema.test.ts
@@ -113,7 +113,7 @@ describe("zod shim JSON Schema structure", () => {
 		const nullable = z.object({ inner: z.object({ name: z.string() }).nullable() });
 		const nullableJson = asObjectSchema(nullable.toJsonSchema());
 		const nullableVariants = propSchema(nullableJson, "inner")?.anyOf as ObjectSchema[];
-		expect(nullableVariants[1]).toEqual({ const: null });
+		expect(nullableVariants[1]).toEqual({ type: "null" });
 		expect(nullable.parse({ inner: null })).toEqual({ inner: null });
 		expect(nullable.parse({ inner: { name: "x" } })).toEqual({ inner: { name: "x" } });
 		expect(nullable.safeParse({ inner: 4 }).success).toBe(false);
@@ -177,6 +177,49 @@ describe("zod shim JSON Schema structure", () => {
 		const lazyProp = z.object({ t: z.lazy(() => z.string()) }).optional();
 		expect(lazyProp.toJsonSchema()).toEqual({});
 		expect(lazyProp.parse({ t: "x" })).toEqual({ t: "x" });
+	});
+
+	it("keeps structure AND steps when widening or uniting a stepped member", () => {
+		// Members carrying Type-attached steps (`z.record`'s key check,
+		// `.refine()`, `.regex()`, `.transform()`) are the common plugin
+		// authoring shapes. Widening or uniting them must embed the member —
+		// rebuilding from its base IR drops the steps (a validator that stops
+		// validating), while routing to the dispatcher erases the emitted
+		// document (a parameter the model sees as unconstrained). Both halves
+		// are asserted per shape: emitted structure and the step still firing.
+		const record = z.object({ env: z.record(z.string(), z.string()).optional() });
+		const recordJson = asObjectSchema(record.toJsonSchema());
+		expect(propSchema(recordJson, "env")?.additionalProperties).toEqual({ type: "string" });
+		expect(record.parse({ env: { A: "1" } })).toEqual({ env: { A: "1" } });
+		expect(record.parse({})).toEqual({});
+		expect(record.safeParse({ env: { A: 1 } }).success).toBe(false);
+
+		const refined = z.string().refine(value => value.length > 2, "at least 3 chars");
+		const optionalRefined = z.object({ name: refined.optional() });
+		expect(propSchema(asObjectSchema(optionalRefined.toJsonSchema()), "name")).toEqual({ type: "string" });
+		expect(optionalRefined.parse({})).toEqual({});
+		expect(optionalRefined.parse({ name: "abc" })).toEqual({ name: "abc" });
+		// The step survived the widening: without embedding, `ab` would pass.
+		expect(optionalRefined.safeParse({ name: "ab" }).success).toBe(false);
+
+		const nullableRefined = refined.nullable();
+		expect(asObjectSchema(nullableRefined.toJsonSchema()).anyOf).toEqual([{ type: "string" }, { type: "null" }]);
+		expect(nullableRefined.parse(null)).toBeNull();
+		expect(nullableRefined.safeParse("ab").success).toBe(false);
+
+		const union = z.union([refined, z.number()]);
+		expect(asObjectSchema(union.toJsonSchema()).anyOf).toEqual([{ type: "string" }, { type: "number" }]);
+		expect(union.parse(4)).toBe(4);
+		expect(union.parse("abc")).toBe("abc");
+		expect(union.safeParse("ab").success).toBe(false);
+
+		// Transforming members stay ordered-dispatcher-free too: the union is
+		// disjoint by input domain, so the emitted document keeps both inputs
+		// while the transform still runs.
+		const transformed = z.union([z.string().transform(value => value.length), z.boolean()]);
+		expect(asObjectSchema(transformed.toJsonSchema()).anyOf).toEqual([{ type: "string" }, { type: "boolean" }]);
+		expect(transformed.parse("abcd")).toBe(4);
+		expect(transformed.parse(true)).toBe(true);
 	});
 
 	it("keeps plain object nesting fully structural", () => {

--- a/packages/omptype/test/zod-json-schema.test.ts
+++ b/packages/omptype/test/zod-json-schema.test.ts
@@ -130,6 +130,23 @@ describe("zod shim JSON Schema structure", () => {
 		expect(propSchema(defaultedJson, "inner")?.default).toEqual({ name: "d" });
 	});
 
+	it("pins the default-contract boundary across composition positions", () => {
+		// Zod 4 output-default contract, shim side: the fallback is returned
+		// as-is without re-validation through the input schema, so a
+		// default that violates the schema's own constraints is accepted
+		// standalone. Composed positions (`.describe()`'s restrictBase,
+		// object embedding's normalizeDefaults) still route the fallback
+		// through omptype's validating `Type.default()`, so the same schema
+		// fails LOUDLY at construction there. Pinned as an accepted remaining
+		// asymmetry; the follow-up unifies the default path.
+		const standalone = z.number().min(5).default(1);
+		expect(standalone.parse(undefined)).toBe(1);
+		expect(standalone.parse(6)).toBe(6);
+		expect(standalone.safeParse("x").success).toBe(false);
+		expect(() => z.number().min(5).default(1).describe("d")).toThrow(/at least 5/);
+		expect(() => z.object({ n: z.number().min(5).default(1) })).toThrow(/at least 5/);
+	});
+
 	it("widens objects containing stepped or defaulted properties structurally", () => {
 		// The widened union is disjoint from undefined/null unless the member
 		// itself accepts them, so these shapes must NOT fall back to the

--- a/packages/omptype/test/zod-json-schema.test.ts
+++ b/packages/omptype/test/zod-json-schema.test.ts
@@ -267,8 +267,10 @@ describe("z.lazy deferred alias", () => {
 		expect(getterCalls).toBe(1);
 		// The chain's own root — and any embedding of it, since .optional()
 		// routed it to the dispatcher morph — erases (documented boundary).
-		// What MUST stay structural is the readonly/describe chain without
-		// the widening: embed → sub → fallback(emit(inner)) → $ref.
+		// What stays structural is the readonly/describe chain without the
+		// widening: describe routes through restrictBase's step-free morph,
+		// so embed INLINES it (no sub node) and the $ref arrives via emit's
+		// morph arm — fallback(emit(input)) relays the alias's $ref.
 		type Inner = { name: string; next?: Inner };
 		let innerCalls = 0;
 		let innerNode: z.ZodType<Inner>;

--- a/packages/omptype/test/zod-json-schema.test.ts
+++ b/packages/omptype/test/zod-json-schema.test.ts
@@ -230,6 +230,23 @@ describe("zod shim JSON Schema structure", () => {
 		expect(nested.parse({ list: [{ name: "x" }] })).toEqual({ list: [{ name: "x" }] });
 	});
 
+	it("emits anyOf for an object-or-array union", () => {
+		// The object's input domain excludes arrays, which makes these two
+		// members provably disjoint — so the union stays structural instead of
+		// falling back to the ordered dispatcher and erasing. Before the domain
+		// was accounted for in the intersection check, "an array carrying the
+		// object's properties" counted as a shared inhabitant and this common
+		// provider-facing shape emitted `{}`.
+		const union = z.union([z.object({ a: z.string() }), z.array(z.string())]);
+		const variants = asObjectSchema(union.toJsonSchema()).anyOf as ObjectSchema[];
+		expect(variants).toHaveLength(2);
+		expect(variants[0]).toMatchObject({ type: "object", properties: { a: { type: "string" } } });
+		expect(variants[1]).toEqual({ type: "array", items: { type: "string" } });
+		expect(union.parse({ a: "x" })).toEqual({ a: "x" });
+		expect(union.parse(["x"])).toEqual(["x"]);
+		expect(union.safeParse(5).success).toBe(false);
+	});
+
 	it("exports required recursive edges and pins optional recursive edges on the dispatcher", () => {
 		// The emission boundary for recursion: REQUIRED array/record edges
 		// export as $ref; OPTIONAL or NULLABLE recursive edges keep the

--- a/packages/omptype/test/zod-json-schema.test.ts
+++ b/packages/omptype/test/zod-json-schema.test.ts
@@ -136,6 +136,23 @@ describe("zod shim JSON Schema structure", () => {
 		expect(items).toEqual({ type: "string" });
 		expect(nested.parse({ list: [{ name: "x" }] })).toEqual({ list: [{ name: "x" }] });
 	});
+
+	it("exports required recursive edges and pins optional recursive edges on the dispatcher", () => {
+		// The emission boundary for recursion: REQUIRED array/record edges
+		// export as $ref; OPTIONAL or NULLABLE recursive edges keep the
+		// ordered dispatcher and erase, because the union determinism probe
+		// cannot see through a deferred alias. `.optional()` is the common
+		// authoring spelling for a recursive edge, so this pins the boundary
+		// instead of letting it silently regress or silently widen.
+		type LinkedList = { name: string; next?: LinkedList };
+		const list: z.ZodType<LinkedList> = z.lazy(() => z.object({ name: z.string(), next: list.optional() }));
+		const json = asObjectSchema(list.toJsonSchema());
+		const def = resolveRef(json, json.$ref);
+		expect(def?.properties?.name).toEqual({ type: "string" });
+		expect(def?.properties?.next).toEqual({});
+		expect(list.parse({ name: "a", next: { name: "b" } })).toEqual({ name: "a", next: { name: "b" } });
+		expect(list.parse({ name: "a" })).toEqual({ name: "a" });
+	});
 });
 
 describe("z.lazy deferred alias", () => {

--- a/packages/omptype/test/zod-json-schema.test.ts
+++ b/packages/omptype/test/zod-json-schema.test.ts
@@ -351,6 +351,27 @@ describe("z.lazy deferred alias", () => {
 		expect(calls).toBe(1);
 	});
 
+	it("keeps the resolved schema's steps and still exports its base", () => {
+		// Regression: the alias resolved to `resolved.ir`, the resolved
+		// schema's structural base, so Type-attached steps living on the
+		// wrapper were dropped — the lazy schema accepted values its own
+		// refinement rejects and handed back untransformed output.
+		const refined = z.lazy(() => z.string().refine(value => value.startsWith("x"), "starts with x"));
+		expect(refined.parse("xyz")).toBe("xyz");
+		expect(refined.safeParse("abc").success).toBe(false);
+		expect(resolveRef(asObjectSchema(refined.toJsonSchema()), asObjectSchema(refined.toJsonSchema()).$ref)).toEqual({
+			type: "string",
+		});
+
+		const transformed = z.lazy(() => z.string().transform(value => value.length));
+		expect(transformed.parse("abcd")).toBe(4);
+
+		// Same through a property, where the alias is reached via embed().
+		const holder = z.object({ v: z.lazy(() => z.string().refine(value => value.length > 2, "long enough")) });
+		expect(holder.parse({ v: "abc" })).toEqual({ v: "abc" });
+		expect(holder.safeParse({ v: "ab" }).success).toBe(false);
+	});
+
 	it("gives distinct lazies distinct $defs entries", () => {
 		// Regression: a fixed "$defs" key made one lazy silently win the
 		// collision and the other $ref dangle.

--- a/packages/omptype/test/zod.test.ts
+++ b/packages/omptype/test/zod.test.ts
@@ -354,6 +354,27 @@ describe("zod-like parsing", () => {
 			z.object({ kind: z.literal("b") }),
 		]);
 		expect(nullish.parse({ kind: null, a: "x" })).toEqual({ kind: null, a: "x" });
+
+		// `undefined` has no JSON form: a property pinned to it emits an
+		// unconstrained schema inside `required`, which a provider can neither
+		// encode nor select, so the branch is unreachable.
+		expect(() =>
+			z.discriminatedUnion("kind", [
+				z.object({ kind: z.literal(undefined), a: z.string() }),
+				z.object({ kind: z.literal("b") }),
+			]),
+		).toThrow(/does not pin "kind" to a literal or enum value/);
+		expect(() =>
+			z.discriminatedUnion("kind", [z.object({ kind: z.undefined() }), z.object({ kind: z.literal("b") })]),
+		).toThrow(/does not pin "kind" to a literal or enum value/);
+		// A `.default()`-widened literal is `lit | undefined` internally, and the
+		// default fills the absent case, so it must still dispatch on the literal.
+		const defaulted = z.discriminatedUnion("kind", [
+			z.object({ kind: z.literal("a").default("a"), n: z.number() }),
+			z.object({ kind: z.literal("b"), s: z.string() }),
+		]);
+		expect(defaulted.parse({ n: 1 })).toEqual({ kind: "a", n: 1 });
+		expect(defaulted.parse({ kind: "b", s: "x" })).toEqual({ kind: "b", s: "x" });
 	});
 
 	it("lets later modifiers replace the object policy the array guard sits on", () => {

--- a/packages/omptype/test/zod.test.ts
+++ b/packages/omptype/test/zod.test.ts
@@ -221,19 +221,40 @@ describe("zod-like parsing", () => {
 		expect(Object.isFrozen(frozenArray)).toBe(true);
 	});
 
-	it("rejects arrays reaching any object schema", () => {
-		// An array reaching an object schema contradicts the emitted
-		// `{"type":"object"}` and zod's own semantics: the tool would accept a
-		// shape the model was told was invalid. The guard is an input-side
-		// filter, so it also covers the modes an output-side check cannot — a
-		// key-stripping object has already turned `[]` into `{}` by then.
-		expect(z.object({}).safeParse([]).success).toBe(false);
-		expect(z.strictObject({}).safeParse([]).success).toBe(false);
-		expect(z.looseObject({}).safeParse([1, 2]).success).toBe(false);
+	it("holds object schemas to zod's object-input domain", () => {
+		// Input outside that domain contradicts the emitted `{"type":"object"}`:
+		// the tool would accept a shape the model was told was invalid. The guard
+		// is a raw input-side filter, so it also covers the modes an output-side
+		// check cannot — a key-stripping object has already turned `[]` into `{}`
+		// by then — and zod classifies these built-ins as their own parsed types.
+		for (const outside of [[], new Date(), new Map(), new Set(), Promise.resolve(1)]) {
+			expect(z.object({}).safeParse(outside).success).toBe(false);
+			expect(z.strictObject({}).safeParse(outside).success).toBe(false);
+			expect(z.looseObject({}).safeParse(outside).success).toBe(false);
+			expect(z.record(z.string(), z.string()).safeParse(outside).success).toBe(false);
+		}
+		// A class instance IS object input, in zod and here.
+		class Point {
+			x = "1";
+		}
+		expect(z.object({ x: z.string() }).parse(new Point())).toEqual({ x: "1" });
+		// The guard runs once per parse: a prevalidating filter would walk the
+		// input a second time and read every getter twice, at every depth.
+		let reads = 0;
+		const spy = {
+			l1: {
+				get v() {
+					reads++;
+					return "x";
+				},
+			},
+		};
+		expect(z.object({ l1: z.object({ v: z.string() }) }).parse(spy)).toEqual({ l1: { v: "x" } });
+		expect(reads).toBe(1);
+		// Mode changes keep the guard.
 		expect(z.object({}).strict().safeParse([]).success).toBe(false);
 		expect(z.object({}).passthrough().safeParse([1]).success).toBe(false);
 		expect(z.object({ a: z.string() }).partial().safeParse([]).success).toBe(false);
-		expect(z.record(z.string(), z.string()).safeParse([]).success).toBe(false);
 		// A discriminated union is object-shaped by definition, and a stripping
 		// variant whose discriminator carries a default would otherwise morph
 		// `[]` into `{ kind: "a" }` — on the structural path and the dispatcher.

--- a/packages/omptype/test/zod.test.ts
+++ b/packages/omptype/test/zod.test.ts
@@ -158,6 +158,35 @@ describe("zod-like parsing", () => {
 		expect(deferredValid.safeParse({ kind: "lazy", v: 1 }).success).toBe(false);
 	});
 
+	it("rejects discriminated-union variants claiming the same discriminator value", () => {
+		// Two variants pinning the same value make dispatch ambiguous: the
+		// winner would be decided by declaration order, so the same input could
+		// produce a different output after an innocuous reorder. zod rejects the
+		// definition; so must this.
+		expect(() =>
+			z.discriminatedUnion("kind", [
+				z.object({ kind: z.literal("x"), a: z.string() }),
+				z.object({ kind: z.literal("x"), b: z.number() }),
+			]),
+		).toThrow(/variants 0 and 1 both pin "kind" to "x"/);
+		// Enum members count as claims, so an overlap with a later literal is
+		// caught too — not just literal-vs-literal collisions.
+		expect(() =>
+			z.discriminatedUnion("kind", [
+				z.object({ kind: z.enum(["a", "b"]) }),
+				z.object({ kind: z.literal("b"), n: z.number() }),
+			]),
+		).toThrow(/variants 0 and 1 both pin "kind" to "b"/);
+		// A z.lazy variant is claimed once its getter has run, so wrapping the
+		// collision in z.lazy defers the error to first parse instead of hiding
+		// it.
+		const deferredCollision = z.discriminatedUnion("kind", [
+			z.lazy(() => z.object({ kind: z.literal("x"), a: z.string() })),
+			z.object({ kind: z.literal("x"), b: z.number() }),
+		]);
+		expect(() => deferredCollision.parse({ kind: "x", a: "1" })).toThrow(/variants 0 and 1 both pin "kind" to "x"/);
+	});
+
 	it("rejects arrays wherever an object schema can observe its input", () => {
 		// An array reaching an object schema contradicts the emitted
 		// `{"type":"object"}` and zod's own semantics: the tool would accept a

--- a/packages/omptype/test/zod.test.ts
+++ b/packages/omptype/test/zod.test.ts
@@ -334,6 +334,15 @@ describe("zod-like parsing", () => {
 		expect(plainFirst([])).toEqual([]);
 		expect(plainSecond([])).toEqual([]);
 		expect((z.strictObject({}) as unknown as { equals(def: unknown): boolean }).equals(unrestricted)).toBe(false);
+
+		// Intersecting a plain object with an array is now empty rather than
+		// "an array carrying the object's properties", which is what makes the
+		// object-or-array union provably disjoint. An ArkType object keeps the
+		// inhabited intersection, so the opt-in boundary holds here too.
+		expect(() => intersect(z.object({ a: z.string() }), "string[]")).toThrow(
+			/intersection of a plain object and an array is unsatisfiable/,
+		);
+		expect(intersect(type({ a: "string" }), "string[]")(Object.assign(["x"], { a: "y" }))).toEqual(["x"]);
 	});
 
 	it("carries the object-input domain into definitions that spread a shim schema", () => {

--- a/packages/omptype/test/zod.test.ts
+++ b/packages/omptype/test/zod.test.ts
@@ -113,11 +113,11 @@ describe("zod-like parsing", () => {
 		// variant used to build a plain string/number union that answered
 		// safeParse("x") with success — the dispatch contract the call
 		// advertises, silently gone. It must fail at definition instead.
-		expect(() => z.discriminatedUnion("kind", [z.string() as never, z.number() as never])).toThrow(
+		expect(() => z.discriminatedUnion("kind", [z.string(), z.number()])).toThrow(
 			/variant 0 does not declare a "kind" property/,
 		);
 		expect(() =>
-			z.discriminatedUnion("kind", [z.object({ kind: z.literal("a") }), z.object({ other: z.string() }) as never]),
+			z.discriminatedUnion("kind", [z.object({ kind: z.literal("a") }), z.object({ other: z.string() })]),
 		).toThrow(/variant 1 does not declare a "kind" property/);
 
 		// A non-literal discriminator cannot be dispatched on, but zod accepts
@@ -129,6 +129,26 @@ describe("zod-like parsing", () => {
 		expect(enumDiscriminated.parse({ kind: "b", v: "x" })).toEqual({ kind: "b", v: "x" });
 		expect(enumDiscriminated.parse({ kind: "c", n: 1 })).toEqual({ kind: "c", n: 1 });
 		expect(enumDiscriminated.safeParse({ kind: "a", n: 1 }).success).toBe(false);
+
+		// Wrapping the same invalid definition in z.lazy must not launder it:
+		// the variant is accepted unresolved at construction (running the getter
+		// there breaks recursive definitions), then re-checked at first parse,
+		// where it used to quietly match any object without a discriminator.
+		const deferredInvalid = z.discriminatedUnion("kind", [
+			z.lazy(() => z.object({ x: z.string() })),
+			z.object({ kind: z.literal("a"), n: z.number() }),
+		]);
+		expect(() => deferredInvalid.parse({ x: "oops" })).toThrow(/variant 0 does not declare a "kind" property/);
+		// Still throws on later parses rather than latching a one-time pass.
+		expect(() => deferredInvalid.parse({ kind: "a", n: 1 })).toThrow(/variant 0 does not declare a "kind" property/);
+
+		const deferredValid = z.discriminatedUnion("kind", [
+			z.lazy(() => z.object({ kind: z.literal("lazy"), v: z.string() })),
+			z.object({ kind: z.literal("a"), n: z.number() }),
+		]);
+		expect(deferredValid.parse({ kind: "lazy", v: "x" })).toEqual({ kind: "lazy", v: "x" });
+		expect(deferredValid.parse({ kind: "a", n: 1 })).toEqual({ kind: "a", n: 1 });
+		expect(deferredValid.safeParse({ kind: "lazy", v: 1 }).success).toBe(false);
 	});
 
 	it("parses valid values and reports nested safeParse issues", () => {

--- a/packages/omptype/test/zod.test.ts
+++ b/packages/omptype/test/zod.test.ts
@@ -200,6 +200,39 @@ describe("zod-like parsing", () => {
 		]);
 		expect(selfRepeat.parse({ kind: "a", n: 1 })).toEqual({ kind: "a", n: 1 });
 		expect(selfRepeat.parse({ kind: "b", s: "x" })).toEqual({ kind: "b", s: "x" });
+
+		// An optional or defaulted discriminator also accepts the property
+		// MISSING, and two variants doing that resolve `{}` by declaration order:
+		// the defaulted pair below fills `kind: "a"` or `kind: "b"` purely
+		// depending on which was written first. That case needs its own claim.
+		expect(() =>
+			z.discriminatedUnion("kind", [
+				z.object({ kind: z.literal("a").optional() }),
+				z.object({ kind: z.literal("b").optional() }),
+			]),
+		).toThrow(/variants 0 and 1 both accept a missing "kind"/);
+		expect(() =>
+			z.discriminatedUnion("kind", [
+				z.object({ kind: z.literal("a").default("a") }),
+				z.object({ kind: z.literal("b").default("b") }),
+			]),
+		).toThrow(/variants 0 and 1 both accept a missing "kind"/);
+
+		// One variant may own the absent case: the claim is unique, so the
+		// definition loads and the missing key routes to it.
+		const oneOptional = z.discriminatedUnion("kind", [
+			z.object({ kind: z.literal("a").optional(), n: z.number() }),
+			z.object({ kind: z.literal("b"), s: z.string() }),
+		]);
+		expect(oneOptional.parse({ n: 2 })).toEqual({ n: 2 });
+		expect(oneOptional.parse({ kind: "a", n: 3 })).toEqual({ kind: "a", n: 3 });
+		expect(oneOptional.parse({ kind: "b", s: "x" })).toEqual({ kind: "b", s: "x" });
+		const oneDefaulted = z.discriminatedUnion("kind", [
+			z.object({ kind: z.literal("a").default("a"), n: z.number() }),
+			z.object({ kind: z.literal("b"), s: z.string() }),
+		]);
+		expect(oneDefaulted.parse({ n: 1 })).toEqual({ kind: "a", n: 1 });
+		expect(oneDefaulted.parse({ kind: "b", s: "x" })).toEqual({ kind: "b", s: "x" });
 	});
 
 	it("clones readonly output by descriptor instead of spreading it", () => {

--- a/packages/omptype/test/zod.test.ts
+++ b/packages/omptype/test/zod.test.ts
@@ -22,6 +22,12 @@ const transformed = z.string().transform(value => value.length);
 type _TransformInference = Assert<Eq<z.infer<typeof transformed>, number>>;
 const nullableOptional = z.number().nullable().optional();
 type _NullableOptionalInference = Assert<Eq<z.infer<typeof nullableOptional>, number | null | undefined>>;
+// `.optional()` followed by a metadata/wrapper method must stay optional in the
+// inferred type, matching the parse that accepts the key's absence.
+const optionalThenDescribed = z.object({ note: z.string().optional().describe("d") });
+type _OptionalDescribedInference = Assert<Eq<z.infer<typeof optionalThenDescribed>, { note?: string | undefined }>>;
+const optionalThenReadonly = z.object({ note: z.string().optional().readonly() });
+type _OptionalReadonlyInference = Assert<Eq<z.infer<typeof optionalThenReadonly>, { note?: string | undefined }>>;
 
 describe("zod-like parsing", () => {
 	it("exposes callable omptype schemas with JSON Schema metadata", () => {

--- a/packages/omptype/test/zod.test.ts
+++ b/packages/omptype/test/zod.test.ts
@@ -390,6 +390,21 @@ describe("zod-like parsing", () => {
 			z.object({ kind: z.literal(2), b: z.number() }),
 		]);
 		expect(numeric.parse({ kind: 2, b: 3 })).toEqual({ kind: 2, b: 3 });
+		// `z.union([z.literal(true), z.literal(false)])` normalizes to the boolean
+		// node, so the finite pair has to be recognized there too — otherwise a
+		// discriminator written as a literal union fails to load.
+		const booleanUnion = z.discriminatedUnion("kind", [
+			z.object({ kind: z.union([z.literal(true), z.literal(false)]), a: z.string() }),
+			z.object({ kind: z.literal("b"), b: z.number() }),
+		]);
+		expect(booleanUnion.parse({ kind: true, a: "x" })).toEqual({ kind: true, a: "x" });
+		expect(booleanUnion.parse({ kind: false, a: "y" })).toEqual({ kind: false, a: "y" });
+		expect(booleanUnion.parse({ kind: "b", b: 1 })).toEqual({ kind: "b", b: 1 });
+		// …and both of its values are claimed, so a literal overlapping either
+		// side is still an ambiguous definition.
+		expect(() =>
+			z.discriminatedUnion("kind", [z.object({ kind: z.boolean() }), z.object({ kind: z.literal(true) })]),
+		).toThrow(/variants 0 and 1 both pin "kind" to true/);
 		const nullish = z.discriminatedUnion("kind", [
 			z.object({ kind: z.null(), a: z.string() }),
 			z.object({ kind: z.literal("b") }),

--- a/packages/omptype/test/zod.test.ts
+++ b/packages/omptype/test/zod.test.ts
@@ -396,6 +396,34 @@ describe("zod-like parsing", () => {
 			/intersection of a plain object and an array is unsatisfiable/,
 		);
 		expect(intersect(type({ a: "string" }), "string[]")(Object.assign(["x"], { a: "y" }))).toEqual(["x"]);
+
+		// The domain excludes more than arrays, so the same disjointness applies
+		// to the built-ins it refuses — otherwise a mixed omptype/shim union
+		// cannot even be constructed.
+		for (const excluded of [Date, Map, Set, Promise]) {
+			const mixed = (z.object({ a: z.string() }) as unknown as { or(def: unknown): (value: unknown) => unknown }).or(
+				type.instanceOf(excluded),
+			);
+			expect(mixed({ a: "x" })).toEqual({ a: "x" });
+		}
+		const withDate = (z.object({ a: z.string() }) as unknown as { or(def: unknown): (value: unknown) => unknown }).or(
+			type.instanceOf(Date),
+		);
+		const instant = new Date();
+		expect(withDate(instant)).toBe(instant);
+		expect(withDate(5)).toBeInstanceOf(OmpErrors);
+		// An ordinary class instance IS plain-record input, so that union really
+		// is order-dependent and must stay on the dispatcher — the guard only
+		// covers domains the shim refuses.
+		expect(() =>
+			(z.object({ a: z.string() }) as unknown as { or(def: unknown): unknown }).or(
+				type.instanceOf(
+					class Point {
+						a = "x";
+					},
+				),
+			),
+		).toThrow(/unordered union with overlapping morph inputs is indeterminate/);
 	});
 
 	it("carries the object-input domain into definitions that spread a shim schema", () => {

--- a/packages/omptype/test/zod.test.ts
+++ b/packages/omptype/test/zod.test.ts
@@ -22,12 +22,33 @@ const transformed = z.string().transform(value => value.length);
 type _TransformInference = Assert<Eq<z.infer<typeof transformed>, number>>;
 const nullableOptional = z.number().nullable().optional();
 type _NullableOptionalInference = Assert<Eq<z.infer<typeof nullableOptional>, number | null | undefined>>;
-// `.optional()` followed by a metadata/wrapper method must stay optional in the
-// inferred type, matching the parse that accepts the key's absence.
+// `.optional()` followed by any wrapper that keeps runtime optionality must stay
+// optional in the inferred type, matching the parse that accepts the key's
+// absence. One row per wrapper: each carries the marker independently.
 const optionalThenDescribed = z.object({ note: z.string().optional().describe("d") });
 type _OptionalDescribedInference = Assert<Eq<z.infer<typeof optionalThenDescribed>, { note?: string | undefined }>>;
 const optionalThenReadonly = z.object({ note: z.string().optional().readonly() });
 type _OptionalReadonlyInference = Assert<Eq<z.infer<typeof optionalThenReadonly>, { note?: string | undefined }>>;
+const optionalThenRefined = z.object({
+	note: z
+		.string()
+		.optional()
+		.refine(() => true),
+});
+type _OptionalRefinedInference = Assert<Eq<z.infer<typeof optionalThenRefined>, { note?: string | undefined }>>;
+const optionalThenTransformed = z.object({
+	note: z
+		.string()
+		.optional()
+		.transform(value => value === undefined),
+});
+type _OptionalTransformedInference = Assert<Eq<z.infer<typeof optionalThenTransformed>, { note?: boolean }>>;
+const optionalThenCaught = z.object({ note: z.string().optional().catch(undefined) });
+type _OptionalCaughtInference = Assert<Eq<z.infer<typeof optionalThenCaught>, { note?: string | undefined }>>;
+const optionalThenNullable = z.object({ note: z.string().optional().nullable() });
+type _OptionalNullableInference = Assert<
+	Eq<z.infer<typeof optionalThenNullable>, { note?: string | null | undefined }>
+>;
 
 describe("zod-like parsing", () => {
 	it("exposes callable omptype schemas with JSON Schema metadata", () => {

--- a/packages/omptype/test/zod.test.ts
+++ b/packages/omptype/test/zod.test.ts
@@ -230,6 +230,26 @@ describe("zod-like parsing", () => {
 		expect(Object.isFrozen(frozenArray)).toBe(true);
 	});
 
+	it("pins which object modes hand back a fresh parse output", () => {
+		// zod always builds a new object; omptype returns the input when nothing
+		// about validation changes the value, so only key-stripping allocates.
+		// Pinned as a known divergence rather than fixed: making the
+		// non-stripping modes allocate requires the object node to report itself
+		// as output-changing, which makes OVERLAPPING loose-object unions
+		// indeterminate — `z.union([z.looseObject({ a }), z.looseObject({ b })])`
+		// would fall to the ordered dispatcher and emit `{}` for the model
+		// instead of today's `anyOf`. Provider-facing erasure is a worse trade
+		// than an aliased parse result.
+		const input = { a: "x" };
+		expect(z.object({ a: z.string() }).parse(input)).not.toBe(input);
+		expect(z.strictObject({ a: z.string() }).parse(input)).toBe(input);
+		expect(z.looseObject({ a: z.string() }).parse(input)).toBe(input);
+		// The union that would pay for it, kept structural.
+		const looseUnion = z.union([z.looseObject({ a: z.string() }), z.looseObject({ b: z.number() })]);
+		const emitted: { anyOf?: unknown } = looseUnion.toJsonSchema();
+		expect(emitted.anyOf).toBeArrayOfSize(2);
+	});
+
 	it("holds object schemas to zod's object-input domain", () => {
 		// Input outside that domain contradicts the emitted `{"type":"object"}`:
 		// the tool would accept a shape the model was told was invalid. The guard

--- a/packages/omptype/test/zod.test.ts
+++ b/packages/omptype/test/zod.test.ts
@@ -508,6 +508,36 @@ describe("zod-like parsing", () => {
 				.partial()
 				.safeParse({}).success,
 		).toBe(false);
+
+		// An AUTHOR step between `.readonly()` and the modifier makes the rebuild
+		// intersect rather than replace: zod has no such chain at all (`.refine()`
+		// returns ZodEffects, which exposes neither `.passthrough()` nor
+		// `.partial()`), so the conservative answer wins — nothing is dropped,
+		// the result is just stricter. Re-applying the author's predicate to the
+		// REBUILT structure is the alternative, and it would run predicates
+		// against a shape they were not written for, where `value.a.length`
+		// throws from user code instead of failing validation.
+		const stepped = z
+			.strictObject({ a: z.string() })
+			.readonly()
+			.refine(value => (value as { a: string }).a !== "no")
+			.passthrough();
+		// The old strict policy still applies…
+		expect(stepped.safeParse({ a: "x", extra: 1 }).success).toBe(false);
+		// …the author's refinement still fires…
+		expect(stepped.safeParse({ a: "no" }).success).toBe(false);
+		// …and the freeze survives on the accepted value.
+		const steppedOk = stepped.parse({ a: "x" });
+		expect(steppedOk).toEqual({ a: "x" });
+		expect(Object.isFrozen(steppedOk)).toBe(true);
+		expect(
+			z
+				.object({ a: z.string() })
+				.readonly()
+				.transform(value => value)
+				.partial()
+				.safeParse({}).success,
+		).toBe(false);
 	});
 
 	it("parses valid values and reports nested safeParse issues", () => {

--- a/packages/omptype/test/zod.test.ts
+++ b/packages/omptype/test/zod.test.ts
@@ -53,6 +53,91 @@ describe("zod-like parsing", () => {
 		});
 	});
 
+	it("preserves JSON Schema structure for morph-free unions and nullable members", () => {
+		// Provider tool definitions read toolWireSchema's JSON Schema: a
+		// dispatcher-morph wrapper erases the structural IR and the parameter
+		// arrives at the model as an unconstrained `{}`.
+		const unionSchema = z.object({ mode: z.union([z.literal("fast"), z.literal("safe")]) });
+		const unionJson = unionSchema.toJsonSchema() as {
+			properties?: { mode?: Record<string, unknown> };
+		};
+		expect(unionJson.properties?.mode).toBeDefined();
+		expect(Object.keys(unionJson.properties?.mode ?? {}).length).toBeGreaterThan(0);
+		expect(JSON.stringify(unionJson.properties?.mode)).toContain("fast");
+		expect(JSON.stringify(unionJson.properties?.mode)).toContain("safe");
+		// Runtime contract unchanged.
+		expect(unionSchema.parse({ mode: "fast" })).toEqual({ mode: "fast" });
+		expect(unionSchema.safeParse({ mode: "slow" }).success).toBe(false);
+
+		const nullableSchema = z.object({ value: z.string().nullable() });
+		const nullableJson = nullableSchema.toJsonSchema() as {
+			properties?: { value?: Record<string, unknown> };
+		};
+		expect(Object.keys(nullableJson.properties?.value ?? {}).length).toBeGreaterThan(0);
+		expect(JSON.stringify(nullableJson.properties?.value)).toContain("string");
+		expect(nullableSchema.parse({ value: "ok" })).toEqual({ value: "ok" });
+		expect(nullableSchema.parse({ value: null })).toEqual({ value: null });
+		expect(nullableSchema.safeParse({ value: 42 }).success).toBe(false);
+
+		// Members carrying Type-attached steps (transform/refine — invisible to
+		// the member IR) must take the ordered dispatcher path: an IR rebuild
+		// would silently DROP the step, not just degrade the JSON Schema.
+		const morphUnion = z.union([z.string().transform(value => value.length), z.number()]);
+		expect(morphUnion.parse("abc")).toBe(3);
+		expect(morphUnion.parse(7)).toBe(7);
+		expect(
+			z
+				.string()
+				.transform(value => value.length)
+				.optional()
+				.parse("abc"),
+		).toBe(3);
+		expect(
+			z
+				.string()
+				.refine(value => value.startsWith("x"))
+				.optional()
+				.safeParse("abc").success,
+		).toBe(false);
+		expect(
+			z
+				.string()
+				.refine(value => value.startsWith("x"))
+				.nullable()
+				.safeParse("abc").success,
+		).toBe(false);
+		expect(
+			z
+				.string()
+				.refine(value => value.startsWith("x"))
+				.nullable()
+				.parse(null),
+		).toBeNull();
+
+		// Discriminated unions with purely structural variants take the same
+		// structural path; a pipeline-carrying variant set keeps the ordered
+		// literal dispatcher (and its transform semantics).
+		const eventSchema = z.object({
+			evt: z.discriminatedUnion("kind", [
+				z.strictObject({ kind: z.literal("append"), n: z.number() }),
+				z.strictObject({ kind: z.literal("gap"), s: z.string() }),
+			]),
+		});
+		const eventJson = eventSchema.toJsonSchema() as {
+			properties?: { evt?: Record<string, unknown> };
+		};
+		expect(Object.keys(eventJson.properties?.evt ?? {}).length).toBeGreaterThan(0);
+		expect(JSON.stringify(eventJson.properties?.evt)).toContain("append");
+		expect(JSON.stringify(eventJson.properties?.evt)).toContain("gap");
+		expect(eventSchema.parse({ evt: { kind: "append", n: 1 } })).toEqual({ evt: { kind: "append", n: 1 } });
+		expect(eventSchema.safeParse({ evt: { kind: "nope" } }).success).toBe(false);
+		const steppedVariants = z.discriminatedUnion("kind", [
+			z.strictObject({ kind: z.literal("len"), v: z.string().transform(value => value.length) }),
+			z.strictObject({ kind: z.literal("raw"), v: z.number() }),
+		]);
+		expect(steppedVariants.parse({ kind: "len", v: "abc" })).toEqual({ kind: "len", v: 3 });
+	});
+
 	it("parses valid values and reports nested safeParse issues", () => {
 		const schema = z.object({ profile: z.object({ age: z.number().int().positive() }) });
 		expect(schema.parse({ profile: { age: 42 } })).toEqual({ profile: { age: 42 } });
@@ -168,5 +253,73 @@ describe("zod-like parsing", () => {
 		const flags = z.record(z.enum(["A", "B"] as const), z.boolean());
 		expect(flags.parse({ A: true, B: false })).toEqual({ A: true, B: false });
 		expect(flags.safeParse({ C: true }).success).toBe(false);
+	});
+	it("builds strict, loose, discriminated, readonly, and lazy schemas", () => {
+		const strict = z.strictObject({ name: z.string() });
+		expect(strict.parse({ name: "Ada" })).toEqual({ name: "Ada" });
+		expect(strict.safeParse({ name: "Ada", extra: 1 }).success).toBe(false);
+
+		const loose = z.looseObject({ name: z.string() });
+		expect(loose.parse({ name: "Ada", extra: 1 })).toEqual({ name: "Ada", extra: 1 });
+		expect(loose.safeParse({ name: 1 }).success).toBe(false);
+
+		const termination = z.discriminatedUnion("kind", [
+			z.object({ kind: z.literal("interrupted") }),
+			z.object({ kind: z.literal("timed_out"), timeoutMs: z.number() }),
+		]);
+		type Termination = z.infer<typeof termination>;
+		const timedOut: Termination = termination.parse({ kind: "timed_out", timeoutMs: 5 });
+		expect(timedOut).toEqual({ kind: "timed_out", timeoutMs: 5 });
+		const interrupted: Termination = { kind: "interrupted" };
+		expect(termination.parse(interrupted)).toEqual(interrupted);
+		expect(termination.safeParse({ kind: "nope" }).success).toBe(false);
+		expect(termination.safeParse({}).success).toBe(false);
+		expect(termination.safeParse("str").success).toBe(false);
+
+		const parsedFrozen = z
+			.strictObject({ tags: z.array(z.string()) })
+			.readonly()
+			.parse({ tags: ["a"] });
+		expect(parsedFrozen).toEqual({ tags: ["a"] });
+		expect(Object.isFrozen(parsedFrozen)).toBe(true);
+		// Shallow, matching Zod's own contract: a nested value is left mutable.
+		expect(Object.isFrozen(parsedFrozen.tags)).toBe(false);
+		expect(Reflect.set(parsedFrozen, "tags", [])).toBe(false);
+		expect(z.array(z.string()).readonly().optional().parse(undefined)).toBeUndefined();
+
+		// `.readonly()` freezes only its own parse output, NEVER the caller's
+		// input graph: a persisted session entry is schema-validated (with
+		// nested `.readonly()` arms) BEFORE blob hydration mutates it in place,
+		// so a freeze leaking onto the input would make the session unloadable.
+		const inputAttachment = { kind: "image", data: "blob:sha256:abc", mimeType: "image/png" };
+		const inputEntry = { attachment: inputAttachment };
+		const nestedReadonly = z.strictObject({
+			attachment: z.strictObject({ kind: z.literal("image"), data: z.string(), mimeType: z.string() }).readonly(),
+		});
+		expect(nestedReadonly.safeParse(inputEntry).success).toBe(true);
+		expect(Object.isFrozen(inputAttachment)).toBe(false);
+		inputAttachment.data = "resolved-bytes"; // the hydration write must still work
+		expect(inputAttachment.data).toBe("resolved-bytes");
+
+		// Non-plain parse output (reachable via z.unknown()/z.any()/transforms)
+		// has no non-destructive shallow clone: it passes through untouched —
+		// identity, prototype, and internal slots intact, and NOT frozen (an
+		// in-place freeze would mutate the caller's value).
+		const map = new Map([[1, 2]]);
+		const unknownReadonly = z.unknown().readonly();
+		expect(unknownReadonly.parse(map)).toBe(map);
+		expect(Object.isFrozen(map)).toBe(false);
+		expect(map.get(1)).toBe(2);
+		const date = new Date(0);
+		expect(unknownReadonly.parse(date)).toBe(date);
+		expect((unknownReadonly.parse(date) as Date).getTime()).toBe(0);
+
+		type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue };
+		const jsonValue: z.ZodType<JsonValue> = z.lazy(() =>
+			z.union([z.string(), z.number(), z.boolean(), z.null(), z.array(jsonValue), z.record(z.string(), jsonValue)]),
+		);
+		const deep = { b: [2, { c: "d" }] };
+		expect(jsonValue.parse(["a", 1, true, null, deep])).toEqual(["a", 1, true, null, deep]);
+		expect(jsonValue.safeParse([() => {}]).success).toBe(false);
 	});
 });

--- a/packages/omptype/test/zod.test.ts
+++ b/packages/omptype/test/zod.test.ts
@@ -215,24 +215,43 @@ describe("zod-like parsing", () => {
 		expect(Object.isFrozen(frozenArray)).toBe(true);
 	});
 
-	it("rejects arrays wherever an object schema can observe its input", () => {
+	it("rejects arrays reaching any object schema", () => {
 		// An array reaching an object schema contradicts the emitted
 		// `{"type":"object"}` and zod's own semantics: the tool would accept a
-		// shape the model was told was invalid. Non-stripping objects can see
-		// the input, so they reject it.
+		// shape the model was told was invalid. The guard is an input-side
+		// filter, so it also covers the modes an output-side check cannot — a
+		// key-stripping object has already turned `[]` into `{}` by then.
+		expect(z.object({}).safeParse([]).success).toBe(false);
 		expect(z.strictObject({}).safeParse([]).success).toBe(false);
 		expect(z.looseObject({}).safeParse([1, 2]).success).toBe(false);
 		expect(z.object({}).strict().safeParse([]).success).toBe(false);
 		expect(z.object({}).passthrough().safeParse([1]).success).toBe(false);
+		expect(z.object({ a: z.string() }).partial().safeParse([]).success).toBe(false);
+		expect(z.record(z.string(), z.string()).safeParse([]).success).toBe(false);
+		// A discriminated union is object-shaped by definition, and a stripping
+		// variant whose discriminator carries a default would otherwise morph
+		// `[]` into `{ kind: "a" }` — on the structural path and the dispatcher.
+		const defaulted = z.discriminatedUnion("kind", [
+			z.object({ kind: z.literal("a").default("a") }),
+			z.object({ kind: z.literal("b"), n: z.number() }),
+		]);
+		expect(defaulted.safeParse([]).success).toBe(false);
+		expect(defaulted.describe("d").safeParse([]).success).toBe(false);
+		expect(defaulted.parse({})).toEqual({ kind: "a" });
+		const deferredVariant = z.discriminatedUnion("kind", [
+			z.lazy(() => z.object({ kind: z.literal("a").default("a") })),
+			z.object({ kind: z.literal("b"), n: z.number() }),
+		]);
+		expect(deferredVariant.safeParse([]).success).toBe(false);
+		expect(deferredVariant.parse({ kind: "b", n: 2 })).toEqual({ kind: "b", n: 2 });
+		// A plain union may legitimately accept arrays — the guard is scoped to
+		// object-shaped combinators, not to unions in general.
+		expect(z.union([z.array(z.string()), z.object({ a: z.string() })]).parse(["x"])).toEqual(["x"]);
 		// Objects still parse, extras semantics intact.
+		expect(z.object({ a: z.string() }).parse({ a: "x", b: 1 })).toEqual({ a: "x" });
 		expect(z.strictObject({ a: z.string() }).parse({ a: "x" })).toEqual({ a: "x" });
 		expect(z.looseObject({ a: z.string() }).parse({ a: "x", b: 1 })).toEqual({ a: "x", b: 1 });
 		expect(z.strictObject({ a: z.string() }).safeParse({ a: "x", b: 1 }).success).toBe(false);
-		// A KEY-STRIPPING object cannot: stripping runs first, so by the time a
-		// shim-level guard could look, `[]` has already become `{}`. Pinned as
-		// the documented boundary — omptype's object node treats arrays as
-		// objects (so does `type({})`), and tightening that is a core change.
-		expect(z.object({}).parse([])).toEqual({});
 	});
 
 	it("lets later modifiers replace the object policy the array guard sits on", () => {

--- a/packages/omptype/test/zod.test.ts
+++ b/packages/omptype/test/zod.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { OmpTypeError } from "../src/errors";
+import { OmpErrors, OmpTypeError } from "../src/errors";
 import { Type, type } from "../src/type";
 import * as zod from "../src/zod";
 import { z } from "../src/zod";
@@ -279,6 +279,37 @@ describe("zod-like parsing", () => {
 		expect(z.strictObject({ a: z.string() }).parse({ a: "x" })).toEqual({ a: "x" });
 		expect(z.looseObject({ a: z.string() }).parse({ a: "x", b: 1 })).toEqual({ a: "x", b: 1 });
 		expect(z.strictObject({ a: z.string() }).safeParse({ a: "x", b: 1 }).success).toBe(false);
+	});
+
+	it("keeps the object-input domain through intersections and compiled parses", () => {
+		// The IR merge behind `.and()` builds a NEW object node, so the domain has
+		// to be carried over: an intersection accepts only what both sides accept,
+		// and dropping the flag silently widened the result back to arrays and
+		// built-ins. Reached through the omptype surface, since the shim's own
+		// type does not expose `.and()`.
+		const intersect = (schema: unknown, other: unknown): ((value: unknown) => unknown) =>
+			(schema as { and(def: unknown): (value: unknown) => unknown }).and(other);
+
+		const intersected = intersect(z.strictObject({}), type({}));
+		expect(intersected([])).toBeInstanceOf(OmpErrors);
+		expect(intersected(new Date())).toBeInstanceOf(OmpErrors);
+		expect(intersected({})).toEqual({});
+
+		const withProps = intersect(z.object({ x: z.string() }), type({}));
+		const arrayWithProp: unknown[] = [];
+		Object.assign(arrayWithProp, { x: "v" });
+		expect(withProps(arrayWithProp)).toBeInstanceOf(OmpErrors);
+		expect(withProps({ x: "v" })).toEqual({ x: "v" });
+
+		// The compiled validator must agree with the walked one, or the JIT
+		// threshold would be observable: same rejection, same message, always.
+		const schema = z.object({ a: z.string() });
+		const messages = new Set<string>();
+		for (let index = 0; index < 12; index++) {
+			const result = schema.safeParse([]);
+			messages.add(result.success ? "accepted" : result.error.message);
+		}
+		expect([...messages]).toEqual(["must be a plain object (was an array)"]);
 	});
 
 	it("lets later modifiers replace the object policy the array guard sits on", () => {

--- a/packages/omptype/test/zod.test.ts
+++ b/packages/omptype/test/zod.test.ts
@@ -191,6 +191,15 @@ describe("zod-like parsing", () => {
 			z.object({ kind: z.literal("x"), b: z.number() }),
 		]);
 		expect(() => deferredCollision.parse({ kind: "x", a: "1" })).toThrow(/variants 0 and 1 both pin "kind" to "x"/);
+
+		// A variant naming the same value twice is NOT ambiguous — both claims
+		// route to the same branch — so it must load and dispatch normally.
+		const selfRepeat = z.discriminatedUnion("kind", [
+			z.object({ kind: z.union([z.literal("a"), z.literal("a").refine(() => true)]), n: z.number() }),
+			z.object({ kind: z.literal("b"), s: z.string() }),
+		]);
+		expect(selfRepeat.parse({ kind: "a", n: 1 })).toEqual({ kind: "a", n: 1 });
+		expect(selfRepeat.parse({ kind: "b", s: "x" })).toEqual({ kind: "b", s: "x" });
 	});
 
 	it("clones readonly output by descriptor instead of spreading it", () => {

--- a/packages/omptype/test/zod.test.ts
+++ b/packages/omptype/test/zod.test.ts
@@ -108,6 +108,29 @@ describe("zod-like parsing", () => {
 		expect(steppedVariants.parse({ kind: "len", v: "abc" })).toEqual({ kind: "len", v: 3 });
 	});
 
+	it("rejects discriminated-union variants that cannot declare the discriminator", () => {
+		// The public signature accepts any schema, so an accidental non-object
+		// variant used to build a plain string/number union that answered
+		// safeParse("x") with success — the dispatch contract the call
+		// advertises, silently gone. It must fail at definition instead.
+		expect(() => z.discriminatedUnion("kind", [z.string() as never, z.number() as never])).toThrow(
+			/variant 0 does not declare a "kind" property/,
+		);
+		expect(() =>
+			z.discriminatedUnion("kind", [z.object({ kind: z.literal("a") }), z.object({ other: z.string() }) as never]),
+		).toThrow(/variant 1 does not declare a "kind" property/);
+
+		// A non-literal discriminator cannot be dispatched on, but zod accepts
+		// it: the variant stays valid and falls through to the ordered attempt.
+		const enumDiscriminated = z.discriminatedUnion("kind", [
+			z.object({ kind: z.enum(["a", "b"]), v: z.string() }),
+			z.object({ kind: z.literal("c"), n: z.number() }),
+		]);
+		expect(enumDiscriminated.parse({ kind: "b", v: "x" })).toEqual({ kind: "b", v: "x" });
+		expect(enumDiscriminated.parse({ kind: "c", n: 1 })).toEqual({ kind: "c", n: 1 });
+		expect(enumDiscriminated.safeParse({ kind: "a", n: 1 }).success).toBe(false);
+	});
+
 	it("parses valid values and reports nested safeParse issues", () => {
 		const schema = z.object({ profile: z.object({ age: z.number().int().positive() }) });
 		expect(schema.parse({ profile: { age: 42 } })).toEqual({ profile: { age: 42 } });

--- a/packages/omptype/test/zod.test.ts
+++ b/packages/omptype/test/zod.test.ts
@@ -327,6 +327,29 @@ describe("zod-like parsing", () => {
 		expect((z.strictObject({}) as unknown as { equals(def: unknown): boolean }).equals(unrestricted)).toBe(false);
 	});
 
+	it("carries the object-input domain into definitions that spread a shim schema", () => {
+		// `type({ "...": schema })` copies the spread's props, indexes and extras
+		// policy into a fresh node, so the domain has to travel with them: a
+		// definition spreading a plain-only object cannot widen back to arrays.
+		const spreadOf = (schema: unknown): ((value: unknown) => unknown) =>
+			type({ "...": schema as never }) as unknown as (value: unknown) => unknown;
+
+		const spread = spreadOf(z.strictObject({}));
+		expect(spread([])).toBeInstanceOf(OmpErrors);
+		expect(spread(new Date())).toBeInstanceOf(OmpErrors);
+		expect(spread({})).toEqual({});
+
+		const withRequired = spreadOf(z.object({ x: z.string() }));
+		expect(withRequired(Object.assign([], { x: "v" }))).toBeInstanceOf(OmpErrors);
+		expect(withRequired({ x: "v" })).toEqual({ x: "v" });
+
+		// An ArkType definition that spreads nothing keeps omptype's own object
+		// semantics, where an array IS object input — the domain is opt-in, and
+		// this is the assertion that keeps it that way.
+		const arkObject = type({ x: "string" }) as unknown as (value: unknown) => unknown;
+		expect(arkObject(Object.assign([], { x: "v" }))).toEqual([]);
+	});
+
 	it("rejects discriminators pinned to values it cannot advertise", () => {
 		// omptype compares object literals by reference, so emitting
 		// `const: {"a":1}` would promise the model a structural match the runtime

--- a/packages/omptype/test/zod.test.ts
+++ b/packages/omptype/test/zod.test.ts
@@ -187,6 +187,34 @@ describe("zod-like parsing", () => {
 		expect(() => deferredCollision.parse({ kind: "x", a: "1" })).toThrow(/variants 0 and 1 both pin "kind" to "x"/);
 	});
 
+	it("clones readonly output by descriptor instead of spreading it", () => {
+		// `.readonly()` must hand back the value it validated, only frozen. A
+		// spread silently rewrites it: non-enumerable own properties vanish,
+		// accessors collapse into one-shot values, sparse array holes fill with
+		// `undefined`, and custom array properties disappear.
+		const input: Record<string, unknown> = { visible: 1 };
+		Object.defineProperty(input, "token", { value: "secret", enumerable: false, writable: true });
+		Object.defineProperty(input, "computed", { get: () => 42, enumerable: true, configurable: true });
+		const frozen = z.unknown().readonly().parse(input) as Record<string, unknown>;
+		expect(frozen.token).toBe("secret");
+		expect(Object.getOwnPropertyDescriptor(frozen, "token")?.enumerable).toBe(false);
+		expect(Object.getOwnPropertyDescriptor(frozen, "computed")?.get).toBeFunction();
+		expect(frozen.computed).toBe(42);
+		expect(Object.isFrozen(frozen)).toBe(true);
+		// The caller's graph stays mutable — the reason a clone exists at all.
+		expect(Object.isFrozen(input)).toBe(false);
+
+		const sparse: unknown[] = [1];
+		sparse[3] = 4;
+		(sparse as unknown as Record<string, unknown>).custom = "kept";
+		const frozenArray = z.unknown().readonly().parse(sparse) as unknown[];
+		expect(Array.isArray(frozenArray)).toBe(true);
+		expect(1 in frozenArray).toBe(false);
+		expect(frozenArray.length).toBe(4);
+		expect((frozenArray as unknown as Record<string, unknown>).custom).toBe("kept");
+		expect(Object.isFrozen(frozenArray)).toBe(true);
+	});
+
 	it("rejects arrays wherever an object schema can observe its input", () => {
 		// An array reaching an object schema contradicts the emitted
 		// `{"type":"object"}` and zod's own semantics: the tool would accept a

--- a/packages/omptype/test/zod.test.ts
+++ b/packages/omptype/test/zod.test.ts
@@ -108,20 +108,27 @@ describe("zod-like parsing", () => {
 		expect(steppedVariants.parse({ kind: "len", v: "abc" })).toEqual({ kind: "len", v: 3 });
 	});
 
-	it("rejects discriminated-union variants that cannot declare the discriminator", () => {
+	it("rejects discriminated-union variants that cannot be dispatched on", () => {
 		// The public signature accepts any schema, so an accidental non-object
 		// variant used to build a plain string/number union that answered
 		// safeParse("x") with success — the dispatch contract the call
 		// advertises, silently gone. It must fail at definition instead.
-		expect(() => z.discriminatedUnion("kind", [z.string(), z.number()])).toThrow(
-			/variant 0 does not declare a "kind" property/,
-		);
+		const pinFailure = /variant \d+ does not pin "kind" to a literal or enum value/;
+		expect(() => z.discriminatedUnion("kind", [z.string(), z.number()])).toThrow(pinFailure);
 		expect(() =>
 			z.discriminatedUnion("kind", [z.object({ kind: z.literal("a") }), z.object({ other: z.string() })]),
-		).toThrow(/variant 1 does not declare a "kind" property/);
+		).toThrow(pinFailure);
+		// An open discriminator is the subtler shape: the property exists, but
+		// every `kind` string would validate through this variant.
+		expect(() =>
+			z.discriminatedUnion("kind", [
+				z.object({ kind: z.string(), value: z.string() }),
+				z.object({ kind: z.literal("b"), n: z.number() }),
+			]),
+		).toThrow(pinFailure);
 
-		// A non-literal discriminator cannot be dispatched on, but zod accepts
-		// it: the variant stays valid and falls through to the ordered attempt.
+		// An enum or literal-union discriminator pins a finite value set, so it
+		// dispatches like a single literal.
 		const enumDiscriminated = z.discriminatedUnion("kind", [
 			z.object({ kind: z.enum(["a", "b"]), v: z.string() }),
 			z.object({ kind: z.literal("c"), n: z.number() }),
@@ -138,9 +145,9 @@ describe("zod-like parsing", () => {
 			z.lazy(() => z.object({ x: z.string() })),
 			z.object({ kind: z.literal("a"), n: z.number() }),
 		]);
-		expect(() => deferredInvalid.parse({ x: "oops" })).toThrow(/variant 0 does not declare a "kind" property/);
+		expect(() => deferredInvalid.parse({ x: "oops" })).toThrow(pinFailure);
 		// Still throws on later parses rather than latching a one-time pass.
-		expect(() => deferredInvalid.parse({ kind: "a", n: 1 })).toThrow(/variant 0 does not declare a "kind" property/);
+		expect(() => deferredInvalid.parse({ kind: "a", n: 1 })).toThrow(pinFailure);
 
 		const deferredValid = z.discriminatedUnion("kind", [
 			z.lazy(() => z.object({ kind: z.literal("lazy"), v: z.string() })),

--- a/packages/omptype/test/zod.test.ts
+++ b/packages/omptype/test/zod.test.ts
@@ -151,6 +151,26 @@ describe("zod-like parsing", () => {
 		expect(deferredValid.safeParse({ kind: "lazy", v: 1 }).success).toBe(false);
 	});
 
+	it("rejects arrays wherever an object schema can observe its input", () => {
+		// An array reaching an object schema contradicts the emitted
+		// `{"type":"object"}` and zod's own semantics: the tool would accept a
+		// shape the model was told was invalid. Non-stripping objects can see
+		// the input, so they reject it.
+		expect(z.strictObject({}).safeParse([]).success).toBe(false);
+		expect(z.looseObject({}).safeParse([1, 2]).success).toBe(false);
+		expect(z.object({}).strict().safeParse([]).success).toBe(false);
+		expect(z.object({}).passthrough().safeParse([1]).success).toBe(false);
+		// Objects still parse, extras semantics intact.
+		expect(z.strictObject({ a: z.string() }).parse({ a: "x" })).toEqual({ a: "x" });
+		expect(z.looseObject({ a: z.string() }).parse({ a: "x", b: 1 })).toEqual({ a: "x", b: 1 });
+		expect(z.strictObject({ a: z.string() }).safeParse({ a: "x", b: 1 }).success).toBe(false);
+		// A KEY-STRIPPING object cannot: stripping runs first, so by the time a
+		// shim-level guard could look, `[]` has already become `{}`. Pinned as
+		// the documented boundary — omptype's object node treats arrays as
+		// objects (so does `type({})`), and tightening that is a core change.
+		expect(z.object({}).parse([])).toEqual({});
+	});
+
 	it("parses valid values and reports nested safeParse issues", () => {
 		const schema = z.object({ profile: z.object({ age: z.number().int().positive() }) });
 		expect(schema.parse({ profile: { age: 42 } })).toEqual({ profile: { age: 42 } });

--- a/packages/omptype/test/zod.test.ts
+++ b/packages/omptype/test/zod.test.ts
@@ -312,6 +312,35 @@ describe("zod-like parsing", () => {
 		expect([...messages]).toEqual(["must be a plain object (was an array)"]);
 	});
 
+	it("rejects discriminators pinned to values it cannot advertise", () => {
+		// omptype compares object literals by reference, so emitting
+		// `const: {"a":1}` would promise the model a structural match the runtime
+		// refuses — the provider-valid `{ kind: { a: 1 } }` only parsed when it
+		// carried the original reference. bigint has no JSON form at all.
+		const objectLiteral = { a: 1 };
+		expect(() =>
+			z.discriminatedUnion("kind", [
+				z.object({ kind: z.literal(objectLiteral), n: z.number() }),
+				z.object({ kind: z.literal("b") }),
+			]),
+		).toThrow(/does not pin "kind" to a literal or enum value/);
+		expect(() =>
+			z.discriminatedUnion("kind", [z.object({ kind: z.literal(1n) }), z.object({ kind: z.literal("b") })]),
+		).toThrow(/does not pin "kind" to a literal or enum value/);
+
+		// Every literal kind that survives a JSON Schema `const` still dispatches.
+		const numeric = z.discriminatedUnion("kind", [
+			z.object({ kind: z.literal(1), a: z.string() }),
+			z.object({ kind: z.literal(2), b: z.number() }),
+		]);
+		expect(numeric.parse({ kind: 2, b: 3 })).toEqual({ kind: 2, b: 3 });
+		const nullish = z.discriminatedUnion("kind", [
+			z.object({ kind: z.null(), a: z.string() }),
+			z.object({ kind: z.literal("b") }),
+		]);
+		expect(nullish.parse({ kind: null, a: "x" })).toEqual({ kind: null, a: "x" });
+	});
+
 	it("lets later modifiers replace the object policy the array guard sits on", () => {
 		// The guard is the shim's own step, so a naive wrapper made every guarded
 		// object look stepped: a rebuild then re-validated through the OLD

--- a/packages/omptype/test/zod.test.ts
+++ b/packages/omptype/test/zod.test.ts
@@ -235,6 +235,30 @@ describe("zod-like parsing", () => {
 		expect(z.object({}).parse([])).toEqual({});
 	});
 
+	it("lets later modifiers replace the object policy the array guard sits on", () => {
+		// The guard is the shim's own step, so a naive wrapper made every guarded
+		// object look stepped: a rebuild then re-validated through the OLD
+		// policy, and `.strict().partial()` still demanded the now-optional key
+		// while `z.strictObject({}).passthrough()` still rejected extras.
+		expect(z.object({ a: z.string() }).strict().partial().parse({})).toEqual({});
+		expect(z.strictObject({}).passthrough().parse({ extra: 1 })).toEqual({ extra: 1 });
+		expect(z.strictObject({ a: z.string() }).describe("d").partial().parse({})).toEqual({});
+		expect(z.object({ a: z.string() }).strict().strip().parse({ a: "x", b: 1 })).toEqual({ a: "x" });
+		// The replaced policy is really gone, and the surviving one still holds.
+		expect(z.object({ a: z.string() }).strict().partial().safeParse({ b: 1 }).success).toBe(false);
+		expect(z.looseObject({ a: z.string() }).partial().parse({ b: 1 })).toEqual({ b: 1 });
+		// …and the guard survives every chain that stays non-stripping.
+		expect(z.object({ a: z.string() }).strict().partial().safeParse([]).success).toBe(false);
+		expect(z.strictObject({ a: z.string() }).describe("d").safeParse([]).success).toBe(false);
+		expect(z.looseObject({ a: z.string() }).partial().safeParse([]).success).toBe(false);
+		// Descriptions and defaults survive the rebuild the guard forces.
+		expect(z.strictObject({ a: z.string() }).describe("desc").toJsonSchema()).toMatchObject({
+			additionalProperties: false,
+			description: "desc",
+		});
+		expect(z.strictObject({ n: z.number().default(3) }).parse({})).toEqual({ n: 3 });
+	});
+
 	it("parses valid values and reports nested safeParse issues", () => {
 		const schema = z.object({ profile: z.object({ age: z.number().int().positive() }) });
 		expect(schema.parse({ profile: { age: 42 } })).toEqual({ profile: { age: 42 } });

--- a/packages/omptype/test/zod.test.ts
+++ b/packages/omptype/test/zod.test.ts
@@ -310,6 +310,21 @@ describe("zod-like parsing", () => {
 			messages.add(result.success ? "accepted" : result.error.message);
 		}
 		expect([...messages]).toEqual(["must be a plain object (was an array)"]);
+
+		// Union normalization must not prune the WIDER member: the domain bit is
+		// part of what an object accepts, so ignoring it in the subtype check made
+		// the union's accepted input depend on member order, and reported a plain
+		// and an unrestricted object as equal.
+		const unrestricted = type({ "+": "reject" });
+		const plainFirst = (z.strictObject({}) as unknown as { or(def: unknown): (value: unknown) => unknown }).or(
+			unrestricted,
+		);
+		const plainSecond = (unrestricted as unknown as { or(def: unknown): (value: unknown) => unknown }).or(
+			z.strictObject({}),
+		);
+		expect(plainFirst([])).toEqual([]);
+		expect(plainSecond([])).toEqual([]);
+		expect((z.strictObject({}) as unknown as { equals(def: unknown): boolean }).equals(unrestricted)).toBe(false);
 	});
 
 	it("rejects discriminators pinned to values it cannot advertise", () => {

--- a/packages/omptype/test/zod.test.ts
+++ b/packages/omptype/test/zod.test.ts
@@ -53,35 +53,12 @@ describe("zod-like parsing", () => {
 		});
 	});
 
-	it("preserves JSON Schema structure for morph-free unions and nullable members", () => {
-		// Provider tool definitions read toolWireSchema's JSON Schema: a
-		// dispatcher-morph wrapper erases the structural IR and the parameter
-		// arrives at the model as an unconstrained `{}`.
-		const unionSchema = z.object({ mode: z.union([z.literal("fast"), z.literal("safe")]) });
-		const unionJson = unionSchema.toJsonSchema() as {
-			properties?: { mode?: Record<string, unknown> };
-		};
-		expect(unionJson.properties?.mode).toBeDefined();
-		expect(Object.keys(unionJson.properties?.mode ?? {}).length).toBeGreaterThan(0);
-		expect(JSON.stringify(unionJson.properties?.mode)).toContain("fast");
-		expect(JSON.stringify(unionJson.properties?.mode)).toContain("safe");
-		// Runtime contract unchanged.
-		expect(unionSchema.parse({ mode: "fast" })).toEqual({ mode: "fast" });
-		expect(unionSchema.safeParse({ mode: "slow" }).success).toBe(false);
-
-		const nullableSchema = z.object({ value: z.string().nullable() });
-		const nullableJson = nullableSchema.toJsonSchema() as {
-			properties?: { value?: Record<string, unknown> };
-		};
-		expect(Object.keys(nullableJson.properties?.value ?? {}).length).toBeGreaterThan(0);
-		expect(JSON.stringify(nullableJson.properties?.value)).toContain("string");
-		expect(nullableSchema.parse({ value: "ok" })).toEqual({ value: "ok" });
-		expect(nullableSchema.parse({ value: null })).toEqual({ value: null });
-		expect(nullableSchema.safeParse({ value: 42 }).success).toBe(false);
-
-		// Members carrying Type-attached steps (transform/refine — invisible to
-		// the member IR) must take the ordered dispatcher path: an IR rebuild
-		// would silently DROP the step, not just degrade the JSON Schema.
+	it("keeps member steps running through union, widening, and discriminated dispatch", () => {
+		// Members carrying Type-attached steps (transform/refine) are invisible
+		// in the member IR, so every combinator must EMBED them rather than
+		// rebuild from `member.ir` — a rebuild silently drops the step and the
+		// schema stops validating. (Emitted-document coverage for the same
+		// shapes lives in zod-json-schema.test.ts.)
 		const morphUnion = z.union([z.string().transform(value => value.length), z.number()]);
 		expect(morphUnion.parse("abc")).toBe(3);
 		expect(morphUnion.parse(7)).toBe(7);
@@ -114,21 +91,14 @@ describe("zod-like parsing", () => {
 				.parse(null),
 		).toBeNull();
 
-		// Discriminated unions with purely structural variants take the same
-		// structural path; a pipeline-carrying variant set keeps the ordered
-		// literal dispatcher (and its transform semantics).
+		// Discriminated dispatch: stripping variants keep their strip semantics
+		// and a stepped variant still transforms.
 		const eventSchema = z.object({
 			evt: z.discriminatedUnion("kind", [
 				z.strictObject({ kind: z.literal("append"), n: z.number() }),
 				z.strictObject({ kind: z.literal("gap"), s: z.string() }),
 			]),
 		});
-		const eventJson = eventSchema.toJsonSchema() as {
-			properties?: { evt?: Record<string, unknown> };
-		};
-		expect(Object.keys(eventJson.properties?.evt ?? {}).length).toBeGreaterThan(0);
-		expect(JSON.stringify(eventJson.properties?.evt)).toContain("append");
-		expect(JSON.stringify(eventJson.properties?.evt)).toContain("gap");
 		expect(eventSchema.parse({ evt: { kind: "append", n: 1 } })).toEqual({ evt: { kind: "append", n: 1 } });
 		expect(eventSchema.safeParse({ evt: { kind: "nope" } }).success).toBe(false);
 		const steppedVariants = z.discriminatedUnion("kind", [

--- a/packages/omptype/test/zod.test.ts
+++ b/packages/omptype/test/zod.test.ts
@@ -278,6 +278,39 @@ describe("zod-like parsing", () => {
 		expect(z.strictObject({ n: z.number().default(3) }).parse({})).toEqual({ n: 3 });
 	});
 
+	it("keeps the freeze and replaces the policy when readonly precedes a modifier", () => {
+		// `.readonly()` is a shim wrapper too, so a rebuild after it must put the
+		// freeze back on top of the NEW policy. Carrying it instead re-validated
+		// through the pre-readonly schema: `.readonly().passthrough()` still
+		// rejected extras and `.readonly().partial()` still required the key.
+		const passthrough = z.strictObject({ a: z.string() }).readonly().passthrough();
+		const kept = passthrough.parse({ a: "x", extra: 1 });
+		expect(kept).toEqual({ a: "x", extra: 1 });
+		expect(Object.isFrozen(kept)).toBe(true);
+
+		const partial = z.object({ a: z.string() }).readonly().partial();
+		expect(partial.parse({})).toEqual({});
+		expect(Object.isFrozen(partial.parse({}))).toBe(true);
+		expect(partial.safeParse([]).success).toBe(false);
+
+		// Through a description, and applied twice, the chain still rebuilds.
+		const described = z.strictObject({ a: z.string() }).readonly().describe("d").partial();
+		expect(described.parse({})).toEqual({});
+		expect(Object.isFrozen(described.parse({}))).toBe(true);
+		expect(z.object({ a: z.string() }).readonly().readonly().partial().parse({})).toEqual({});
+
+		// AUTHOR steps keep the opposite contract: a refinement must keep
+		// running against the schema it was written for, so the rebuild
+		// re-validates through it and the now-optional key is still required.
+		expect(
+			z
+				.object({ a: z.string() })
+				.refine(value => "a" in (value as object))
+				.partial()
+				.safeParse({}).success,
+		).toBe(false);
+	});
+
 	it("parses valid values and reports nested safeParse issues", () => {
 		const schema = z.object({ profile: z.object({ age: z.number().int().positive() }) });
 		expect(schema.parse({ profile: { age: 42 } })).toEqual({ profile: { age: 42 } });

--- a/packages/utils/src/env.ts
+++ b/packages/utils/src/env.ts
@@ -318,19 +318,6 @@ export function $envpos(name: string, defaultValue: number): number {
 	return parsed;
 }
 
-/**
- * True when a GUI can be reached: a window server always exists off Linux,
- * while X11/Wayland must be advertised through the environment there.
- *
- * Shared because clipboard tooling and headful-browser launches gate on the
- * same fact — two copies would let platform hardening drift apart, and the
- * failure mode is a hang or an opaque "Missing X server" rather than a clear
- * skip.
- */
-export function hasDisplay(): boolean {
-	return process.platform !== "linux" || Boolean(process.env.DISPLAY || process.env.WAYLAND_DISPLAY);
-}
-
 const BUN_TEST_ENTRY_PATTERN = /[._](?:test|spec)\.[cm]?[jt]sx?$/;
 
 /** True when the process is an explicitly marked test child or Bun is running a test entrypoint. */

--- a/packages/utils/src/env.ts
+++ b/packages/utils/src/env.ts
@@ -318,6 +318,19 @@ export function $envpos(name: string, defaultValue: number): number {
 	return parsed;
 }
 
+/**
+ * True when a GUI can be reached: a window server always exists off Linux,
+ * while X11/Wayland must be advertised through the environment there.
+ *
+ * Shared because clipboard tooling and headful-browser launches gate on the
+ * same fact — two copies would let platform hardening drift apart, and the
+ * failure mode is a hang or an opaque "Missing X server" rather than a clear
+ * skip.
+ */
+export function hasDisplay(): boolean {
+	return process.platform !== "linux" || Boolean(process.env.DISPLAY || process.env.WAYLAND_DISPLAY);
+}
+
 const BUN_TEST_ENTRY_PATTERN = /[._](?:test|spec)\.[cm]?[jt]sx?$/;
 
 /** True when the process is an explicitly marked test child or Bun is running a test entrypoint. */


### PR DESCRIPTION
# fix(omptype): plugin tools declaring overlapping zod unions no longer fail to load

## Correction to the first version of this description

The original text of this PR claimed that `.optional()`, `.nullable()`, `.default()`, `z.discriminatedUnion` and disjoint `z.union` were erasing tool parameter schemas to an empty `{}` on `main`. **They are not.** Every one of those shapes emits its full structure on `main` — measured by emitting each shape on both trees, table below.

Two things produced that wrong claim. First, the shapes that actually misbehave on `main` do not erase, they **throw at construction**, which I had folded into the same "the model gets `{}`" story. Second, an intermediate state of this branch really did erase those shapes — the dispatcher morph introduced here to fix the throw swallowed stepped members — so the "before" column described this branch's own regression rather than `main`. Review caught it; `e69e2b8` removes it and the table now agrees with `main` on every unchanged row. The CHANGELOG in `6170901` carries the corrected account.

## What

Two independent changes to the Zod shim (`@oh-my-pi/omptype/zod`), plus the first test that asserts what OMP actually sends providers for tool parameters — there wasn't one.

**Fixed — a plugin could fail to load with an internal omptype message.** `z.union`, `z.discriminatedUnion`, `.optional()` and `.nullable()` threw `an unordered union with overlapping morph inputs is indeterminate` at construction whenever a member was a plain (key-stripping) `z.object` overlapping another member, or a `.catch()` schema. Nothing in that message names the author's schema, the property, or the combinator. `z.union([z.object(A), z.object(B)])` is the single most obvious way to spell "one of these two shapes", and it did not work at all. Those unions now dispatch first-match, matching Zod's own ordered semantics.

**Added — combinators the shim did not have.** `z.lazy()` (recursive parameters: trees, nested filters — exported as real `$ref`/`$defs`), `z.discriminatedUnion()`, `z.strictObject()`, `z.looseObject()`, `.readonly()`. `.default()` moves to Zod 4's output-default contract.

**Grown during review — Zod's input rules, applied where the shim had omptype's.** 24 review passes found real divergences beyond the original scope, all of the same family: what the schema advertises versus what it accepts. Object schemas now hold to Zod's object-input domain (arrays, `Date`, `Map`, `Set`, promises rejected wherever an object is expected, at any depth and through every rebuild); `z.discriminatedUnion` validates its definition instead of silently degrading to an ordinary union; `z.lazy` keeps its resolved schema's steps; `.readonly()` no longer rewrites the value it freezes; `Type.in` keeps input-side filters; and `z.infer` stops reporting an optional property as required after a wrapper. Each is listed in the CHANGELOG with the shape that exposed it.

## Who this affects

- **Regular users: nothing changes.** No built-in tool goes through this code path — all of them author their parameters as ArkType `type(...)`, and MCP/RPC tools supply raw JSON Schema and take a different branch of `toolWireSchema` entirely.
- **Plugin, custom-tool, custom-command, hook and SDK authors.** They are the only people who author with this API — the `api.zod` handed to every extension *is* this shim, and it is re-exported publicly from `packages/coding-agent/src/index.ts`. A union of two plain objects, or a `.catch()` marked optional, previously failed their extension at load time.

## What the model actually receives

Every row emitted through `toJsonSchema` on both trees (`origin/main` @ `b8ce33a` vs this branch). Rows that do not change are listed on purpose — they are the ones the earlier description mis-reported as broken.

| If an author writes… | `main` | This branch |
|---|---|---|
| `z.union([z.object(A), z.object(B)])` — overlapping | **throws at construction** | `{}` — first-match dispatcher; known gap, see below |
| `z.string().catch("x").optional()` | **throws at construction** | `{}` — same dispatcher |
| `z.record(…).default({})` (mutable default, not a factory) | **throws** `A mutable default value must be specified as a factory` | full structure |
| `z.union` of distinct-literal `z.object`s | full `anyOf` with `const` discriminators | unchanged |
| `.optional()` on `z.object` | full structure | unchanged |
| `.nullable()` on `z.object` | `anyOf: [inner, {"type":"null"}]` | unchanged |
| `.optional()` on `z.object` with a `.default()`-filled prop (the api-demo shape) | full structure, `default` payload emitted | unchanged |
| `z.record(z.string(), z.string()).optional()` | full structure | unchanged |
| `z.string().refine(…).optional()` / `.nullable()` | full structure | unchanged |
| `z.union([z.string().refine(…), z.number()])` | full `anyOf` | unchanged |
| `.readonly()` standalone, widened, or as a union member | full structure | unchanged |
| `z.array(z.object)`, plain nesting | full | unchanged |
| `z.lazy` recursion via **required** array/record edges | *combinator does not exist* | `$ref` / `$defs`, self-reference cycling correctly |
| `z.lazy` recursion via **optional/nullable** edges | *does not exist* | definition exports; that one edge emits `{}` — boundary below |
| `z.discriminatedUnion("k", [z.object, z.object])` | *does not exist* | `anyOf` with `{"const":…}` variants |
| `z.union([z.strictObject(A), z.strictObject(B)])` | *does not exist* | full `anyOf`, `additionalProperties: false` |
| `z.union([z.object(A), z.array(z.string())])` | full `anyOf` | unchanged — kept structural by the object domain excluding arrays |
| `z.object({…})` parsing `[]`, `new Date()`, `new Map()` | **accepted** (omptype: an array is object input) | **rejected**, as Zod does |
| `z.discriminatedUnion` with a non-object variant, an open discriminator, or two variants claiming one value | *does not exist* | **rejected at definition** instead of dispatching by declaration order |

Three rows change, and all three previously **failed** rather than emitted something. Parse acceptance and outputs are unchanged everywhere except one deliberate contract change: `.default()` now follows Zod 4's output-default short-circuit (the fallback is returned as-is rather than re-validated through the input schema). Composed positions (`.describe()`, object embedding) still route the fallback through omptype's validating default, so a constraint-violating default still fails loudly there; a follow-up unifies the path.

## Risk

- **A tool that used to fail to load now loads.** For the overlapping-union shape the model receives an unconstrained parameter (`{}`, normalized to `true` before providers see it) while the runtime enforces zod's first-match semantics. That is strictly better than the extension not loading, but it is a parameter the model is not guided on, and a strict-schema provider now sees an unconstrained position where previously the whole tool never reached it.
- **`.default()` semantics move to Zod 4's contract.** A default that the old standalone path would have re-validated now passes through as-is. `.default({})` with a mutable literal, which `main` rejected outright, now works.
- **New combinators cannot break existing callers** — `z.lazy`, `z.discriminatedUnion`, `z.strictObject`, `z.looseObject`, `.readonly()` do not exist on `main`.
- **Object schemas reject input they used to accept.** Arrays, `Date`, `Map`, `Set` and promises no longer pass a shim object schema. This is Zod's rule and the emitted `{"type":"object"}` already promised it, but an extension that leaned on omptype's looser domain — passing a `Date` where the schema says object — now fails validation. Opt-in: an ArkType `type({…})` is untouched, asserted in the suite.
- **Some discriminated unions now fail to load.** A variant that cannot be dispatched on, two variants claiming the same value, or two both accepting the key missing are definition errors rather than order-dependent dispatch. Any such definition was already resolving by declaration order.
- **No emitted document changes for any shape that already emitted one**, which is what keeps tool-definition bytes — and the prompt-cache hits keyed on them — stable for existing extensions. `48668e6` additionally makes `z.lazy`'s `$defs` keys a function of the emitted document instead of a module-level counter, so a recursive parameter's bytes no longer depend on plugin construction order.

## Why a separate PR

Found while working on the ACP refactor (#9958), extracted because the blast radius is asymmetric: an ACP bug affects one integration, a tool-schema change affects every model call on every provider. Those shouldn't share a merge decision or a reviewer pool. It is also a hard prerequisite: #9958's schemas don't compile against today's omptype.

## Known limitations (deliberately not fixed here)

- **Unions of genuinely overlapping objects emit `{}`.** Zod's union is first-match; omptype's is unordered and correctly refuses to build an unordered union of two key-stripping objects that overlap, because the output would then depend on member order. Where members are provably disjoint — distinct discriminator literals, `strictObject`, `null`/`undefined` widening — the structural path is order-independent and emits `anyOf`. Where they truly overlap, the ordered dispatcher stays: correct runtime, unconstrained schema. Closing it needs a first-class ordered-choice IR node with `anyOf` emission — named, not built.
- **Recursion exports through required edges only.** The recursive definition itself exports as `$ref`/`$defs`, but an **optional or nullable** recursive edge emits `{}` for that property, and a `z.union` of `z.lazy` members (or widening over one) keeps the dispatcher. Forced rather than chosen: the union determinism probe resolves alias inputs eagerly, so disjointness is unknowable without running the deferred getter, and running it at construction breaks recursive `const` definitions via TDZ. Follow-up: extend alias deferral into that probe with a conservative disjointness rule.
- **`z.strictObject`/`z.looseObject` hand back the input object.** Zod always builds a new one; omptype allocates only when validating changes the value, so only key-stripping (`z.object`) does. Mutating such a parse result mutates the caller's input. Measured before leaving it: allocating requires the object node to report itself as output-changing, which makes overlapping loose-object unions indeterminate — `z.union([z.looseObject({a}), z.looseObject({b})])` would fall to the dispatcher and emit `{}`. Trading provider-facing erasure for parse identity is the wrong way round here.
- **A structural modifier after `.refine()`/`.transform()` intersects rather than replaces.** `.readonly().refine(…).passthrough()` still rejects extras. Zod has no such chain (`.refine()` returns ZodEffects, which exposes neither), so the conservative answer wins: nothing is dropped, the freeze survives, the predicate still fires, the result is only stricter.
- **`.catch()` still emits `{}`, on `main` and here.** `catch` composes as `type.unknown.pipe(…)`, which discards the input IR, so `z.string().catch("x")` advertises nothing to the provider. It is the one genuine erasure in the shim and this PR does not change it in either direction: fixing it means deciding what a total, never-failing schema should advertise to a strict provider, which is a separate provider-facing decision.

## Found along the way, deliberately not fixed here

Three defects the review turned up that belong in their own PRs, none of them touched by this branch:

- Every shipped example passes `execute` arguments in the wrong order — `ToolDefinition.execute` is `(toolCallId, params, signal, onUpdate, ctx)`, the examples write `(_toolCallId, params, _onUpdate, _ctx, _signal)`, so `api-demo.ts` reads `ctx.sessionManager` off the update callback.
- `Static<TParams>` cannot read a zod-shim schema, so `params` arrives as `unknown` and `const { name } = params` fails in every zod-authoring extension — the TypeScript-side twin of this PR's wire-side story.
- `tsconfig.examples.json` exists but nothing references it, so no CI job typechecks the examples, which is how both stayed invisible.

## Test plan

- `packages/omptype/test/zod-json-schema.test.ts` — the table above as assertions on emitted documents: the dispatcher boundary, the discriminated/disjoint structural paths, the widening rows, the recursive-edge boundary, and `keeps structure AND steps when widening or uniting a stepped member`, which asserts both halves per shape (emitted document **and** the step still rejecting, e.g. `.refine(len > 2).optional()` must fail on `"ab"`). Against the pre-review state of this branch every stepped row fails; against `main` the new-combinator rows fail to compile.
- `packages/coding-agent/test/tools/tool-schema-structure.test.ts` — walks every discovered tool's emitted schema, plus setting/mode variants (5 edit modes, task flag combos, async bash, 4 `yield` paths, memory tools). The walk is driven by `wire.ts`'s exported `SCHEMA_POSITIONS` rather than a copy of it, and every legitimately unconstrained position needs a named `ALLOWED_ERASURES` entry, because an erased `{}` and an intentional open value are indistinguishable after normalization. Unifying that inventory found the production lowering skipping `additionalItems`, `contentSchema` and `dependentSchemas`.
- `packages/omptype/test/zod.test.ts` — runtime-only counterpart: member steps keep running through union, widening and discriminated dispatch; `.readonly()` freezes its own output shallowly and never the caller's input graph.
- `bun test packages/omptype`: 1231 pass / 0 fail, including type-level `Eq`/`Assert` rows for the inference contracts. `packages/coding-agent` tools + extensions + plugin-config: 91 pass / 0 fail in the touched files; `packages/ai`: 4278 pass with 3 Bedrock timeouts that reproduce identically with the diff stashed (they pass in isolation; full-suite flake). `bun check` clean except the pre-existing `pi-metaharness` missing `@stencil-hq/vibemon`.
- CI: the recurring `config-value-fd-inheritance.test.ts` failure is a process-teardown flake with a different PID each run that also fails on clean `main` checkouts. The `browser-tab-worker-startup.test.ts` failure this branch first exposed was real — adding a test file reshuffles the shard chunking, which moved a headful-Chromium launch into a shard that ran it — and is fixed by gating it on a display probe.

<details>
<summary><b>Implementation detail</b> — the root cause and the fix, for whoever reviews the omptype internals</summary>

### Root cause of the construction failure

`z.object` defaults to key-stripping (`extras: "delete"`, `zod.ts:392`), and key-stripping changes the output value, so `hasMorph` reports every plain `z.object` as a morph (`ir.ts:1704`). omptype's unordered unions refuse overlapping morph inputs, because the output would depend on member order — a correct refusal for omptype's own semantics, and exactly the shape a zod union is expected to handle by declaration order. The shim built its unions with `schemaFromIR({ k: "union", … })` unconditionally, so the refusal surfaced as a construction throw at `z.union([...])` — i.e. at plugin load.

### The fix

1. **Attempt structural, fall back narrowly.** All five combinators build the native union and fall back to an ordered first-match dispatcher morph **only** on omptype's specific "unordered union … indeterminate" error (`isIndeterminateUnionError`, `zod.ts:431`) — never a bare `catch`, so any other construction error still surfaces. This lets omptype itself certify order-independence rather than the shim guessing: when construction succeeds, any-match equals first-match and the emitted `anyOf` faithfully describes the accepted inputs.
2. **Members are embedded, never rebuilt from `member.ir`.** `embed()` (and `.or()`, which embeds) keeps a member's Type-attached `.transform()`/`.refine()` steps in a `sub` node, so the steps keep running *and* the structural base still exports. Rebuilding from the bare IR silently drops those steps, which is what the removed `hasSteps` gate was guarding against — and that gate was itself the erasure this branch's review caught (`e69e2b8`).
3. **One scan, two questions.** `scanIR(ir)` answers `{ changesOutput, hasDeferredAlias }` in a single traversal, with `hasMorph` and `hasDeferredAlias` as thin cached accessors. An earlier revision also computed an `exportable` bit for the gates; with the gates reduced to "not a deferred alias, then let determinism decide", it had no consumer left and is gone.
4. **`z.lazy` on the existing alias node.** The IR already had a cycle-safe `{ k: "alias", name, resolve }` with re-entry guards in every walker, and `json-schema.ts:162` already emits `$ref`/`$defs`; `z.lazy` had been hand-rolling a runtime-only morph closure. A `deferred` flag keeps construction-time scans from invoking the getter — resolving early breaks recursive `const` definitions via TDZ and violates Zod's defer-to-first-parse contract — honoured by exactly the paths named in the field's doc comment. The alias name is deliberately constant: `emit` uniquifies colliding `$defs` keys per document, so distinct lazies still get distinct entries (`lazy`, `lazy_`) while the emitted key stays a function of the document rather than of a global counter, and `descriptionOf` reports a neutral phrase instead of leaking that internal key into error prose.

### Why the golden test asserts on `true`, not `{}`

`normalizeEmptySchemas` (`wire.ts:440`) rewrites `{}` to boolean `true` in every schema-valued position before a provider sees the document. An "expect no `{}`" assertion therefore passes silently while the schema is unconstrained — the easiest way to write a test that guards nothing. The walk mirrors `wire.ts`'s own schema-position inventory and treats boolean `additionalProperties: true` as flagged-unless-named, so each legitimately open position carries a human reason. Note the fallback hook is not involved: `fallback()` only returns `{}` on a literal `true`, and `wire.ts:587`'s `ctx => ctx.base` is a pass-through relay.

</details>

---

- [X] `bun check` passes
- [X] Tested locally
- [X] CHANGELOG updated (if user-facing)
