### PR TITLE
fix: restore portable Linux and Responses behavior

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7624,6 +7624,7 @@ dependencies = [
  "omp-storage",
  "omp-tool",
  "parking_lot",
+ "portable-atomic",
  "proptest",
  "regex",
  "schemars",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,6 +119,7 @@ objc2-app-kit = "0.3"
 notify = { version = "=8.2.0", features = ["macos_kqueue"] }
 num-bigint = "0.4"
 num-traits = "0.2"
+portable-atomic = "1.15"
 omp-agent = { path = "crates/agent", version = "0.1.0" }
 omp-app = { path = "crates/app", version = "0.1.0" }
 omp-chat-ui = { path = "crates/chat-ui", version = "0.1.0" }

--- a/crates/agent/Cargo.toml
+++ b/crates/agent/Cargo.toml
@@ -34,6 +34,7 @@ omp-observability = { workspace = true }
 omp-storage = { workspace = true }
 omp-tool = { workspace = true }
 parking_lot = { workspace = true }
+portable-atomic = { workspace = true }
 schemars = { workspace = true }
 regex = { workspace = true }
 globset = { workspace = true }

--- a/crates/agent/src/batch.rs
+++ b/crates/agent/src/batch.rs
@@ -5,7 +5,7 @@ use std::{
 	future,
 	sync::{
 		Arc, OnceLock,
-		atomic::{AtomicBool, AtomicU128, Ordering},
+		atomic::{AtomicBool, Ordering},
 	},
 	time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
@@ -29,6 +29,7 @@ use omp_tool::{
 	Abort, ArgIssue, ArgPath, CallOutcome, CallOutcomeDetails, CapsBase, Effects, ExecutionMode,
 	JobRef, Part, PromptCaps, Registry, ToolIdentity, ToolTerminal,
 };
+use portable_atomic::AtomicU128;
 use serde_json::Value;
 use tokio::{sync::Notify, task, time};
 

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(integer_atomics)]
 //! Transport-neutral foundations for durable, interruptible OMP agent loops.
 //!
 //! The crate composes immutable configuration snapshots, deterministic system

--- a/crates/desktop/src/linux/actor.rs
+++ b/crates/desktop/src/linux/actor.rs
@@ -1,4 +1,7 @@
-use std::sync::{LazyLock, mpsc};
+use std::{
+	sync::{LazyLock, mpsc},
+	thread,
+};
 
 use atspi::ObjectRefOwned;
 use flume::{Receiver, Sender};

--- a/crates/desktop/src/linux/wayland/libei.rs
+++ b/crates/desktop/src/linux/wayland/libei.rs
@@ -54,7 +54,7 @@ struct PortalSession {
 }
 
 pub(crate) struct ActorLibei {
-	context:        Context,
+	context:        ei::Context,
 	pointer:        Option<EiDevice>,
 	keyboard:       Option<EiDevice>,
 	sequence:       u32,

--- a/crates/docserver/src/types.rs
+++ b/crates/docserver/src/types.rs
@@ -677,6 +677,7 @@ impl ServerConfig {
 
 	/// Acquires process authority on the opened project directory.
 	pub fn try_lock_authority(&self) -> Result<AuthorityLock> {
+		#[cfg(not(unix))]
 		use cap_std::fs;
 
 		if self
@@ -694,6 +695,22 @@ impl ServerConfig {
 			});
 		}
 		let result = (|| {
+			#[cfg(unix)]
+			let root = {
+				use rustix::fs::{Mode, OFlags};
+
+				let flags = OFlags::RDONLY | OFlags::DIRECTORY | OFlags::CLOEXEC;
+				let descriptor =
+					rustix::fs::openat(&self.root, ".", flags, Mode::empty()).map_err(|source| {
+						Error::Io {
+							operation: sf!("reopen Environment authority handle"),
+							path:      self.environment_root.clone(),
+							source:    source.into(),
+						}
+					})?;
+				std::fs::File::from(descriptor)
+			};
+			#[cfg(not(unix))]
 			let root = self
 				.root
 				.try_clone()

--- a/crates/envd/src/process_identity.rs
+++ b/crates/envd/src/process_identity.rs
@@ -179,19 +179,52 @@ mod platform {
 			.parse::<u64>()
 			.map_err(|_| IdentityError::Incomplete { pid })?;
 		let executable = fs::read_link(proc.join("exe")).map_err(|source| map_io(pid, source))?;
-		let boot_seconds = fs::metadata("/proc/1")
-			.map_err(|source| map_io(pid, source))?
-			.ctime()
-			.max(0) as u64;
+		let boot_seconds = boot_seconds().ok_or(IdentityError::Incomplete { pid })?;
 		// SAFETY: `_SC_CLK_TCK` is a read-only process configuration query.
 		let ticks_per_second = unsafe { libc::sysconf(libc::_SC_CLK_TCK) };
-		if ticks_per_second <= 0 {
+		let ticks_per_second =
+			u64::try_from(ticks_per_second).map_err(|_| IdentityError::Incomplete { pid })?;
+		if ticks_per_second == 0 {
 			return Err(IdentityError::Incomplete { pid });
 		}
 		let started = SystemTime::UNIX_EPOCH
-			+ Duration::from_secs(boot_seconds)
-			+ Duration::from_secs_f64(start_generation as f64 / ticks_per_second as f64);
+			+ Duration::from_secs(boot_seconds.saturating_add(start_generation / ticks_per_second))
+			+ Duration::from_nanos(
+				start_generation % ticks_per_second * 1_000_000_000 / ticks_per_second,
+			);
 		Ok(ProcessIdentity { pid, started_at_ms: unix_millis(started), start_generation, executable })
+	}
+
+	/// Reads the kernel boot epoch used to turn `/proc/<pid>/stat` jiffies into
+	/// the informational wall-clock start time.
+	///
+	/// `btime` is the procfs-native source. Uptime and `/proc/1` metadata are
+	/// fallbacks for kernels that omit it.
+	fn boot_seconds() -> Option<u64> {
+		if let Ok(stat) = fs::read_to_string("/proc/stat")
+			&& let Some(seconds) = parse_boot_seconds(&stat)
+		{
+			return Some(seconds);
+		}
+		if let Ok(uptime) = fs::read_to_string("/proc/uptime")
+			&& let Some(uptime) = uptime
+				.split_ascii_whitespace()
+				.next()
+				.and_then(|value| value.parse::<f64>().ok())
+			&& let Ok(now) = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH)
+		{
+			return Some(now.as_secs().saturating_sub(uptime as u64));
+		}
+		fs::metadata("/proc/1")
+			.ok()
+			.map(|metadata| metadata.ctime().max(0) as u64)
+	}
+
+	fn parse_boot_seconds(stat: &str) -> Option<u64> {
+		stat
+			.lines()
+			.find_map(|line| line.strip_prefix("btime "))
+			.and_then(|value| value.trim().parse().ok())
 	}
 
 	fn map_io(pid: u32, source: io::Error) -> IdentityError {

--- a/crates/inference/src/codec/openai_chat.rs
+++ b/crates/inference/src/codec/openai_chat.rs
@@ -1264,8 +1264,8 @@ fn lower_tools(
 			None
 		};
 		let parameters = match (normalize, flattened) {
-			(true, Some(flattened)) => strict_schema(&flattened)?,
-			(true, None) => strict_schema(parameters.as_value())?,
+			(true, Some(flattened)) => strict_schema(&flattened),
+			(true, None) => strict_schema(parameters.as_value()),
 			(false, Some(flattened)) => flattened,
 			(false, None) => parameters.as_value().clone(),
 		};
@@ -1372,15 +1372,27 @@ fn exclusive_required_branch(branch: &Value) -> bool {
 		.all(|key| matches!(key.as_str(), "required" | "description" | "title"))
 }
 
-fn strict_schema(schema: &Value) -> Result<Value, Error> {
+pub(crate) fn strict_schema(schema: &Value) -> Value {
 	match schema {
 		Value::Object(object) => {
 			let mut output = object.clone();
+			if let Some(constant) = output.remove("const") {
+				let values = output
+					.entry("enum")
+					.or_insert_with(|| Value::Array(Vec::new()));
+				if let Value::Array(values) = values
+					&& !values.contains(&constant)
+				{
+					values.push(constant);
+				}
+			}
+			output.remove("default");
+			output.remove("format");
 			if let Some(Value::Object(properties)) = object.get("properties") {
 				let mut normalized = serde_json::Map::with_capacity(properties.len());
 				let mut required = Vec::with_capacity(properties.len());
 				for (name, property) in properties {
-					normalized.insert(name.clone(), strict_schema(property)?);
+					normalized.insert(name.clone(), strict_schema(property));
 					required.push(Value::String(name.clone()));
 				}
 				output.insert("properties".into(), Value::Object(normalized));
@@ -1389,21 +1401,84 @@ fn strict_schema(schema: &Value) -> Result<Value, Error> {
 			}
 			for keyword in ["items", "additionalProperties", "not", "if", "then", "else"] {
 				if let Some(value) = object.get(keyword).filter(|value| value.is_object()) {
-					output.insert(keyword.into(), strict_schema(value)?);
+					output.insert(keyword.into(), strict_schema(value));
 				}
 			}
 			for keyword in ["allOf", "anyOf", "oneOf", "prefixItems"] {
 				if let Some(Value::Array(values)) = object.get(keyword) {
-					output.insert(
-						keyword.into(),
-						Value::Array(values.iter().map(strict_schema).collect::<Result<_, _>>()?),
-					);
+					output
+						.insert(keyword.into(), Value::Array(values.iter().map(strict_schema).collect()));
 				}
 			}
-			Ok(Value::Object(output))
+			Value::Object(output)
 		},
-		_ => Ok(schema.clone()),
+		_ => schema.clone(),
 	}
+}
+
+/// Reports whether recursive strict normalization can preserve an input
+/// schema's object semantics.
+pub(crate) fn strict_schema_supported(schema: &Value) -> bool {
+	let Value::Object(object) = schema else {
+		return false;
+	};
+	if object
+		.get("additionalProperties")
+		.is_some_and(|additional| additional != &Value::Bool(false))
+	{
+		return false;
+	}
+	let representable = object.contains_key("type")
+		|| object.contains_key("$ref")
+		|| object.get("not").is_some_and(Value::is_object)
+		|| ["anyOf", "oneOf", "allOf"]
+			.iter()
+			.any(|key| object.get(*key).is_some_and(Value::is_array));
+	if !representable {
+		return false;
+	}
+	for key in [
+		"properties",
+		"patternProperties",
+		"dependencies",
+		"dependentSchemas",
+		"$defs",
+		"definitions",
+	] {
+		if let Some(Value::Object(entries)) = object.get(key)
+			&& !entries.values().all(strict_schema_supported)
+		{
+			return false;
+		}
+	}
+	for key in ["anyOf", "oneOf", "allOf", "prefixItems"] {
+		if let Some(Value::Array(entries)) = object.get(key)
+			&& !entries.iter().all(strict_schema_supported)
+		{
+			return false;
+		}
+	}
+	for key in [
+		"items",
+		"additionalItems",
+		"contains",
+		"contentSchema",
+		"propertyNames",
+		"if",
+		"then",
+		"else",
+		"not",
+		"unevaluatedItems",
+		"unevaluatedProperties",
+	] {
+		if let Some(child) = object.get(key)
+			&& child.is_object()
+			&& !strict_schema_supported(child)
+		{
+			return false;
+		}
+	}
+	true
 }
 
 fn lower_hosted_tools(
@@ -1501,7 +1576,7 @@ fn lower_output(output: &Setting<StructuredOutput>) -> Result<Option<ResponseFor
 			json_schema: JsonSchemaFormat {
 				name:   name.clone(),
 				schema: if *strict {
-					strict_schema(schema.as_value())?
+					strict_schema(schema.as_value())
 				} else {
 					schema.as_value().clone()
 				},

--- a/crates/inference/src/codec/openai_chat.rs
+++ b/crates/inference/src/codec/openai_chat.rs
@@ -1377,13 +1377,13 @@ pub(crate) fn strict_schema(schema: &Value) -> Value {
 		Value::Object(object) => {
 			let mut output = object.clone();
 			if let Some(constant) = output.remove("const") {
-				let values = output
-					.entry("enum")
-					.or_insert_with(|| Value::Array(Vec::new()));
-				if let Value::Array(values) = values
-					&& !values.contains(&constant)
-				{
-					values.push(constant);
+				if let Some(Value::Array(values)) = output.get_mut("enum") {
+					// `const` and `enum` are conjunctive assertions.  Keep
+					// only the enum member selected by the constant instead
+					// of widening the schema with a new member.
+					values.retain(|value| schema_value_equal(value, &constant));
+				} else {
+					output.insert("enum".into(), Value::Array(vec![constant]));
 				}
 			}
 			output.remove("default");
@@ -1416,6 +1416,79 @@ pub(crate) fn strict_schema(schema: &Value) -> Value {
 	}
 }
 
+/// JSON Schema compares numeric instances by mathematical value rather than
+/// by their source representation (`1` and `1.0` are equal).
+pub(crate) fn schema_value_equal(left: &Value, right: &Value) -> bool {
+	match (left, right) {
+		(Value::Number(left), Value::Number(right)) => {
+			if left == right {
+				return true;
+			}
+			let left_integer = left
+				.as_i64()
+				.map(i128::from)
+				.or_else(|| left.as_u64().map(i128::from));
+			let right_integer = right
+				.as_i64()
+				.map(i128::from)
+				.or_else(|| right.as_u64().map(i128::from));
+			match (left_integer, right_integer) {
+				(Some(left), Some(right)) => left == right,
+				(Some(integer), None) => right
+					.as_f64()
+					.is_some_and(|float| integer_equals_float(integer, float)),
+				(None, Some(integer)) => left
+					.as_f64()
+					.is_some_and(|float| integer_equals_float(integer, float)),
+				(None, None) => left.as_f64() == right.as_f64(),
+			}
+		},
+		(Value::Array(left), Value::Array(right)) => {
+			left.len() == right.len()
+				&& left
+					.iter()
+					.zip(right)
+					.all(|(left, right)| schema_value_equal(left, right))
+		},
+		(Value::Object(left), Value::Object(right)) => {
+			left.len() == right.len()
+				&& left.iter().all(|(key, left)| {
+					right
+						.get(key)
+						.is_some_and(|right| schema_value_equal(left, right))
+				})
+		},
+		_ => left == right,
+	}
+}
+
+fn integer_equals_float(integer: i128, float: f64) -> bool {
+	const U64_EXCLUSIVE_MAX: f64 = 18_446_744_073_709_551_616.0;
+	if !float.is_finite() || float.fract() != 0.0 {
+		return false;
+	}
+	if integer < 0 {
+		float >= i64::MIN as f64 && float < 0.0 && i128::from(float as i64) == integer
+	} else {
+		float >= 0.0 && float < U64_EXCLUSIVE_MAX && i128::from(float as u64) == integer
+	}
+}
+
+/// Propertyless object schemas are open maps unless they explicitly reject
+/// additional properties. Strict normalization cannot close those maps without
+/// changing which arguments the tool accepts.
+fn propertyless_open_object(object: &serde_json::Map<String, Value>) -> bool {
+	if !declares_object_root(object) {
+		return false;
+	}
+	let propertyless = match object.get("properties") {
+		None => true,
+		Some(Value::Object(properties)) => properties.is_empty(),
+		Some(_) => false,
+	};
+	propertyless && object.get("additionalProperties") != Some(&Value::Bool(false))
+}
+
 /// Reports whether recursive strict normalization can preserve an input
 /// schema's object semantics.
 pub(crate) fn strict_schema_supported(schema: &Value) -> bool {
@@ -1426,6 +1499,9 @@ pub(crate) fn strict_schema_supported(schema: &Value) -> bool {
 		.get("additionalProperties")
 		.is_some_and(|additional| additional != &Value::Bool(false))
 	{
+		return false;
+	}
+	if propertyless_open_object(object) {
 		return false;
 	}
 	let representable = object.contains_key("type")
@@ -2804,6 +2880,46 @@ mod tests {
 		assert_eq!(function.parameters.required, ["q"]);
 		assert!(!function.parameters.additional_properties);
 		assert!(function.parameters.properties.contains_key("q"));
+	}
+
+	#[test]
+	fn strict_schema_intersects_const_with_enum() {
+		let schema = serde_json::json!({
+			"type": "string",
+			"const": "x",
+			"enum": ["x", "y"]
+		});
+		assert_eq!(
+			super::strict_schema(&schema),
+			serde_json::json!({
+				"type": "string",
+				"enum": ["x"]
+			}),
+		);
+	}
+
+	#[test]
+	fn strict_schema_treats_equivalent_numeric_const_and_enum_values_as_equal() {
+		let schema = serde_json::json!({
+			"type": "number",
+			"const": 1,
+			"enum": [1.0, 2]
+		});
+		assert_eq!(
+			super::strict_schema(&schema),
+			serde_json::json!({
+				"type": "number",
+				"enum": [1.0]
+			}),
+		);
+	}
+
+	#[test]
+	fn schema_value_equality_recurses_through_arrays_and_objects() {
+		assert!(super::schema_value_equal(
+			&serde_json::json!({"values": [1, {"nested": 2.0}]}),
+			&serde_json::json!({"values": [1.0, {"nested": 2}]})
+		));
 	}
 
 	#[derive(Deserialize)]

--- a/crates/inference/src/codec/openai_codex.rs
+++ b/crates/inference/src/codec/openai_codex.rs
@@ -197,7 +197,7 @@ pub fn transform_codex_request(
 			arguments: None,
 			input: None,
 			output: None,
-			summary: Vec::new(),
+			summary: None,
 			encrypted_content: None,
 			actions: Vec::new(),
 			pending_safety_checks: Vec::new(),
@@ -995,7 +995,7 @@ impl Codec for OpenAiCodexCodec {
 		let encoded = self
 			.responses
 			.encode_chat(context, chat)
-			.map_err(|_| fail("codex_responses_encoding"))?;
+			.map_err(super::openai_responses::encode_error)?;
 		if !encoded.adjustments.is_empty() {
 			return Err(fail("codex_adjustment_requires_planning"));
 		}

--- a/crates/inference/src/codec/openai_responses.rs
+++ b/crates/inference/src/codec/openai_responses.rs
@@ -3505,6 +3505,10 @@ impl Decoder for ResponsesDecoderAdapter {
 		}
 		Ok(())
 	}
+
+	fn is_complete(&self) -> bool {
+		self.inner.is_terminal()
+	}
 }
 
 fn encoding_error(code: &'static str) -> Error {
@@ -4925,6 +4929,31 @@ mod tests {
 			true,
 		);
 		assert_eq!(action, RetryAction::Never);
+	}
+
+	#[test]
+	fn terminal_envelope_completes_the_transport_before_eof() {
+		let mut adapter = ResponsesDecoderAdapter {
+			inner: OpenAiResponsesDecoder::default(),
+			request_id: RequestId::new("request"),
+			provider: ProviderId::from("openai"),
+			route: RouteId::from("openai/responses"),
+			wire_model: Some(sf!("gpt")),
+			thinking_close_max_retries: None,
+		};
+		assert!(!adapter.is_complete());
+		adapter
+			.push(
+				Frame::Sse(crate::transport::SseEvent {
+					name: None,
+					data: Bytes::from_static(
+						br#"{"type":"response.completed","response":{"id":"resp_complete","status":"completed"}}"#,
+					),
+				}),
+				&mut |_| {},
+			)
+			.expect("terminal Responses event");
+		assert!(adapter.is_complete());
 	}
 
 	#[test]

--- a/crates/inference/src/codec/openai_responses.rs
+++ b/crates/inference/src/codec/openai_responses.rs
@@ -2703,6 +2703,10 @@ impl OpenAiResponsesCodec {
 					&& apply_patch == Some(ApplyPatchWireKind::Freeform);
 				let (kind, parameters, strict, format) = match &tool.input {
 					ToolInputConstraint::JsonSchema { parameters, strict } if !freeform_patch => {
+						// Eligibility must be decided before sanitization:
+						// adding `properties: {}` to a propertyless object
+						// would otherwise make an open map look closed.
+						let original_strict = openai_chat::strict_schema_supported(parameters.as_value());
 						let mut schema = sanitize_tool_schema(parameters.as_value());
 						if flatten_root_unions {
 							if let Some(flattened) =
@@ -2715,7 +2719,13 @@ impl OpenAiResponsesCodec {
 								return None;
 							}
 						}
-						let effective_strict = *strict && openai_chat::strict_schema_supported(&schema);
+						// Responses strict schemas only have an exact
+						// representation after oneOf was either proven
+						// disjoint and lowered by the sanitizer or absent.
+						let effective_strict = *strict
+							&& original_strict
+							&& openai_chat::strict_schema_supported(&schema)
+							&& !contains_one_of(&schema);
 						if effective_strict {
 							schema = openai_chat::strict_schema(&schema);
 						}
@@ -3235,6 +3245,10 @@ struct ResponsesDecoderAdapter {
 	wire_model: Option<Str>,
 	thinking_close_max_retries: Option<u32>,
 }
+/// Normalizes a schema for the Responses tool wire shape without changing its
+/// assertions. `oneOf` is lowered to `anyOf` only when the branches are
+/// provably disjoint and there is no sibling `anyOf` whose conjunction would
+/// otherwise be lost.
 fn sanitize_tool_schema(schema: &Value) -> Value {
 	let Value::Object(object) = schema else {
 		return schema.clone();
@@ -3242,9 +3256,15 @@ fn sanitize_tool_schema(schema: &Value) -> Value {
 	if object.is_empty() {
 		return Value::Bool(true);
 	}
+	let rewrite_one_of = object
+		.get("oneOf")
+		.and_then(Value::as_array)
+		.is_some_and(|branches| {
+			!object.contains_key("anyOf") && one_of_branches_are_disjoint(branches)
+		});
 	let mut output = serde_json::Map::with_capacity(object.len());
 	for (key, value) in object {
-		if key == "oneOf" && value.is_array() {
+		if key == "oneOf" && rewrite_one_of {
 			continue;
 		}
 		let normalized = match key.as_str() {
@@ -3261,7 +3281,7 @@ fn sanitize_tool_schema(schema: &Value) -> Value {
 					value.clone()
 				}
 			},
-			"anyOf" | "allOf" | "prefixItems" => {
+			"anyOf" | "allOf" | "oneOf" | "prefixItems" => {
 				if let Value::Array(entries) = value {
 					Value::Array(entries.iter().map(sanitize_tool_schema).collect())
 				} else {
@@ -3288,14 +3308,9 @@ fn sanitize_tool_schema(schema: &Value) -> Value {
 		};
 		output.insert(key.clone(), normalized);
 	}
-	if let Some(Value::Array(one_of)) = object.get("oneOf") {
-		let rewritten = one_of.iter().map(sanitize_tool_schema);
-		match output.get_mut("anyOf") {
-			Some(Value::Array(any_of)) => any_of.extend(rewritten),
-			_ => {
-				output.insert("anyOf".into(), Value::Array(rewritten.collect()));
-			},
-		}
+	if rewrite_one_of && let Some(Value::Array(one_of)) = object.get("oneOf") {
+		output
+			.insert("anyOf".into(), Value::Array(one_of.iter().map(sanitize_tool_schema).collect()));
 	}
 	let object_typed = match object.get("type") {
 		Some(Value::String(kind)) => kind == "object",
@@ -3306,6 +3321,91 @@ fn sanitize_tool_schema(schema: &Value) -> Value {
 		output.insert("properties".into(), Value::Object(serde_json::Map::new()));
 	}
 	Value::Object(output)
+}
+
+/// True when every pair of `oneOf` branches has a syntactic disjointness
+/// proof. The proof is deliberately conservative: unknown constraints never
+/// authorize an exclusive union to be represented as an inclusive one.
+fn one_of_branches_are_disjoint(branches: &[Value]) -> bool {
+	for (index, left) in branches.iter().enumerate() {
+		if branches
+			.iter()
+			.skip(index + 1)
+			.any(|right| !schemas_are_disjoint(left, right))
+		{
+			return false;
+		}
+	}
+	true
+}
+
+fn schemas_are_disjoint(left: &Value, right: &Value) -> bool {
+	if let (Some(left_values), Some(right_values)) =
+		(exact_schema_values(left), exact_schema_values(right))
+	{
+		return left_values.iter().all(|left| {
+			right_values
+				.iter()
+				.all(|right| !openai_chat::schema_value_equal(left, right))
+		});
+	}
+	if let (Some(left_types), Some(right_types)) = (schema_types(left), schema_types(right)) {
+		return left_types.iter().all(|left| {
+			right_types
+				.iter()
+				.all(|right| schema_types_are_disjoint(left, right))
+		});
+	}
+	false
+}
+
+fn schema_types_are_disjoint(left: &str, right: &str) -> bool {
+	left != right && !matches!((left, right), ("integer", "number") | ("number", "integer"))
+}
+
+fn exact_schema_values(schema: &Value) -> Option<Vec<&Value>> {
+	let object = schema.as_object()?;
+	match (object.get("const"), object.get("enum")) {
+		(Some(constant), Some(Value::Array(values))) => {
+			if values
+				.iter()
+				.any(|value| openai_chat::schema_value_equal(value, constant))
+			{
+				Some(vec![constant])
+			} else {
+				Some(Vec::new())
+			}
+		},
+		(Some(_), Some(_)) => None,
+		(Some(constant), None) => Some(vec![constant]),
+		(None, Some(Value::Array(values))) => Some(values.iter().collect()),
+		_ => None,
+	}
+}
+
+fn schema_types(schema: &Value) -> Option<Vec<&str>> {
+	let object = schema.as_object()?;
+	match object.get("type") {
+		Some(Value::String(kind)) => Some(vec![kind.as_str()]),
+		Some(Value::Array(kinds)) => {
+			let mut types = Vec::with_capacity(kinds.len());
+			for kind in kinds {
+				types.push(kind.as_str()?);
+			}
+			Some(types)
+		},
+		_ => None,
+	}
+}
+
+fn contains_one_of(schema: &Value) -> bool {
+	match schema {
+		Value::Array(entries) => entries.iter().any(contains_one_of),
+		Value::Object(object) => object
+			.iter()
+			.any(|(key, value)| key == "oneOf" || contains_one_of(value)),
+		_ => false,
+	}
 }
 
 impl ResponsesDecoderAdapter {
@@ -3342,7 +3442,7 @@ impl ResponsesDecoderAdapter {
 				}
 				let proof = ResponsesProviderProof {
 					item_id,
-					encrypted_reasoning: Some(Str::new(String::from_utf8_lossy(&signature).as_ref())),
+					encrypted_reasoning: Some(Str::from_utf8_lossy(&signature)),
 					..ResponsesProviderProof::default()
 				};
 				match encode_provider_proof(&proof) {
@@ -4533,6 +4633,17 @@ mod tests {
 	}
 
 	#[test]
+	fn json_schema_tool_encoding_keeps_declared_strict_root_maps_open() {
+		assert_tool_json(
+			ToolInputConstraint::JsonSchema {
+				parameters: OpaqueJson::new(serde_json::json!({"type": "object"})),
+				strict: true,
+			},
+			br#"[{"type":"function","name":"match_input","parameters":{"type":"object","properties":{}},"strict":false}]"#,
+		);
+	}
+
+	#[test]
 	fn json_schema_tool_encoding_rewrites_one_of_for_responses() {
 		assert_tool_json(
 			ToolInputConstraint::JsonSchema {
@@ -4551,6 +4662,86 @@ mod tests {
 				strict: true,
 			},
 			br#"[{"type":"function","name":"match_input","parameters":{"additionalProperties":false,"properties":{"action":{"anyOf":[{"enum":["launch"],"type":"string"},{"enum":["attach"],"type":"string"}]}},"required":["action"],"type":"object"},"strict":true}]"#,
+		);
+	}
+
+	#[test]
+	fn json_schema_tool_encoding_preserves_any_of_one_of_conjunction() {
+		assert_tool_json(
+			ToolInputConstraint::JsonSchema {
+				parameters: OpaqueJson::new(serde_json::json!({
+					"type": "object",
+					"properties": {
+						"action": {
+							"anyOf": [{"type": "string"}],
+							"oneOf": [{"type": "number"}, {"type": "boolean"}]
+						}
+					},
+					"required": ["action"]
+				})),
+				strict: true,
+			},
+			br#"[{"type":"function","name":"match_input","parameters":{"properties":{"action":{"anyOf":[{"type":"string"}],"oneOf":[{"type":"number"},{"type":"boolean"}]}},"required":["action"],"type":"object"},"strict":false}]"#,
+		);
+	}
+
+	#[test]
+	fn json_schema_tool_encoding_preserves_overlapping_one_of_and_downgrades_strict() {
+		assert_tool_json(
+			ToolInputConstraint::JsonSchema {
+				parameters: OpaqueJson::new(serde_json::json!({
+					"type": "object",
+					"properties": {
+						"value": {
+							"oneOf": [
+								{"type": "number"},
+								{"type": "number", "minimum": 0}
+							]
+						}
+					},
+					"required": ["value"]
+				})),
+				strict: true,
+			},
+			br#"[{"type":"function","name":"match_input","parameters":{"properties":{"value":{"oneOf":[{"type":"number"},{"minimum":0,"type":"number"}]}},"required":["value"],"type":"object"},"strict":false}]"#,
+		);
+	}
+
+	#[test]
+	fn json_schema_tool_encoding_preserves_nested_numeric_equivalent_one_of_constants() {
+		assert_tool_json(
+			ToolInputConstraint::JsonSchema {
+				parameters: OpaqueJson::new(serde_json::json!({
+					"type": "object",
+					"properties": {
+						"value": {
+							"oneOf": [{"const": {"x": 1}}, {"const": {"x": 1.0}}]
+						}
+					},
+					"required": ["value"]
+				})),
+				strict: false,
+			},
+			br#"[{"type":"function","name":"match_input","parameters":{"properties":{"value":{"oneOf":[{"const":{"x":1}},{"const":{"x":1.0}}]}},"required":["value"],"type":"object"},"strict":false}]"#,
+		);
+	}
+
+	#[test]
+	fn json_schema_tool_encoding_preserves_integer_number_one_of_overlap() {
+		assert_tool_json(
+			ToolInputConstraint::JsonSchema {
+				parameters: OpaqueJson::new(serde_json::json!({
+					"type": "object",
+					"properties": {
+						"value": {
+							"oneOf": [{"type": "integer"}, {"type": "number"}]
+						}
+					},
+					"required": ["value"]
+				})),
+				strict: false,
+			},
+			br#"[{"type":"function","name":"match_input","parameters":{"properties":{"value":{"oneOf":[{"type":"integer"},{"type":"number"}]}},"required":["value"],"type":"object"},"strict":false}]"#,
 		);
 	}
 
@@ -4994,6 +5185,36 @@ mod tests {
 				..ResponsesProviderProof::default()
 			}
 		);
+	}
+
+	#[test]
+	fn invalid_reasoning_signature_uses_lossy_shared_string() {
+		let adapter = ResponsesDecoderAdapter {
+			inner: OpenAiResponsesDecoder::default(),
+			request_id: RequestId::new("request"),
+			provider: ProviderId::from("openai-codex"),
+			route: RouteId::from("openai-codex/primary"),
+			wire_model: Some(sf!("gpt")),
+			thinking_close_max_retries: None,
+		};
+		let mut events = Vec::new();
+		adapter.emit_projection(
+			ResponsesProjection::ReasoningSignature {
+				index:     0,
+				item_id:   None,
+				signature: Bytes::from_static(b"enc_\xff"),
+			},
+			&mut |event| events.push(event),
+		);
+		let RawEvent::ProviderState(crate::codec::ProviderStateEvent::ReasoningSignature {
+			signature,
+			..
+		}) = &events[0]
+		else {
+			panic!("typed reasoning proof");
+		};
+		let proof = super::decode_provider_proof(signature).expect("proof decodes");
+		assert_eq!(proof.encrypted_reasoning.as_deref(), Some("enc_�"));
 	}
 
 	#[test]

--- a/crates/inference/src/codec/openai_responses.rs
+++ b/crates/inference/src/codec/openai_responses.rs
@@ -2694,7 +2694,7 @@ impl OpenAiResponsesCodec {
 					&& apply_patch == Some(ApplyPatchWireKind::Freeform);
 				let (kind, parameters, strict, format) = match &tool.input {
 					ToolInputConstraint::JsonSchema { parameters, strict } if !freeform_patch => {
-						let mut schema = parameters.as_value().clone();
+						let mut schema = sanitize_tool_schema(parameters.as_value());
 						if flatten_root_unions {
 							if let Some(flattened) =
 								openai_chat::flatten_exclusive_required_root_union(&schema)
@@ -2706,7 +2706,11 @@ impl OpenAiResponsesCodec {
 								return None;
 							}
 						}
-						(ResponsesToolKind::Function, Some(schema), Some(*strict), None)
+						let effective_strict = *strict && openai_chat::strict_schema_supported(&schema);
+						if effective_strict {
+							schema = openai_chat::strict_schema(&schema);
+						}
+						(ResponsesToolKind::Function, Some(schema), Some(effective_strict), None)
 					},
 					ToolInputConstraint::JsonSchema { .. } => {
 						(ResponsesToolKind::Custom, None, None, None)
@@ -3222,6 +3226,78 @@ struct ResponsesDecoderAdapter {
 	wire_model: Option<Str>,
 	thinking_close_max_retries: Option<u32>,
 }
+fn sanitize_tool_schema(schema: &Value) -> Value {
+	let Value::Object(object) = schema else {
+		return schema.clone();
+	};
+	if object.is_empty() {
+		return Value::Bool(true);
+	}
+	let mut output = serde_json::Map::with_capacity(object.len());
+	for (key, value) in object {
+		if key == "oneOf" && value.is_array() {
+			continue;
+		}
+		let normalized = match key.as_str() {
+			"properties" | "patternProperties" | "dependencies" | "dependentSchemas" | "$defs"
+			| "definitions" => {
+				if let Value::Object(entries) = value {
+					Value::Object(
+						entries
+							.iter()
+							.map(|(name, schema)| (name.clone(), sanitize_tool_schema(schema)))
+							.collect(),
+					)
+				} else {
+					value.clone()
+				}
+			},
+			"anyOf" | "allOf" | "prefixItems" => {
+				if let Value::Array(entries) = value {
+					Value::Array(entries.iter().map(sanitize_tool_schema).collect())
+				} else {
+					value.clone()
+				}
+			},
+			"items"
+			| "additionalItems"
+			| "contains"
+			| "contentSchema"
+			| "propertyNames"
+			| "if"
+			| "then"
+			| "else"
+			| "not"
+			| "additionalProperties"
+			| "unevaluatedItems"
+			| "unevaluatedProperties"
+				if value.is_object() =>
+			{
+				sanitize_tool_schema(value)
+			},
+			_ => value.clone(),
+		};
+		output.insert(key.clone(), normalized);
+	}
+	if let Some(Value::Array(one_of)) = object.get("oneOf") {
+		let rewritten = one_of.iter().map(sanitize_tool_schema);
+		match output.get_mut("anyOf") {
+			Some(Value::Array(any_of)) => any_of.extend(rewritten),
+			_ => {
+				output.insert("anyOf".into(), Value::Array(rewritten.collect()));
+			},
+		}
+	}
+	let object_typed = match object.get("type") {
+		Some(Value::String(kind)) => kind == "object",
+		Some(Value::Array(kinds)) => kinds.iter().any(|kind| kind.as_str() == Some("object")),
+		_ => false,
+	};
+	if object_typed && !object.contains_key("properties") {
+		output.insert("properties".into(), Value::Object(serde_json::Map::new()));
+	}
+	Value::Object(output)
+}
 
 impl ResponsesDecoderAdapter {
 	fn emit_projection(&self, projection: ResponsesProjection, emit: &mut dyn FnMut(RawEvent)) {
@@ -3285,7 +3361,7 @@ impl ResponsesDecoderAdapter {
 
 	fn error_from_evidence(&self, evidence: ResponsesErrorEvidence) -> Error {
 		use crate::{
-			error::{Error, ErrorKind, ErrorPhase, RetryAction},
+			error::{Error, ErrorDetail, ErrorKind, ErrorPhase, RetryAction},
 			receipt::ExecutionReceipt,
 		};
 		let model_policy_denial = evidence.continuation == ResponsesContinuationFailure::NotStale
@@ -3343,6 +3419,7 @@ impl ResponsesDecoderAdapter {
 		)
 		.provider(self.provider.clone())
 		.route(self.route.clone())
+		.detail(ErrorDetail::provider(evidence.message))
 		.request_id(self.request_id.clone())
 		.optional_code(code)
 		.committed(committed)
@@ -4385,13 +4462,77 @@ mod tests {
 	}
 
 	#[test]
-	fn json_schema_tool_encoding_remains_a_strict_function_tool() {
+	fn json_schema_tool_encoding_normalizes_strict_function_parameters() {
 		assert_eq!(
 			encode_tool(ToolInputConstraint::JsonSchema {
-				parameters: OpaqueJson::new(serde_json::json!({"type": "object"})),
+				parameters: OpaqueJson::new(serde_json::json!({
+					"type": "object",
+					"properties": {
+						"required_value": {"type": "string"},
+						"optional_value": {"type": ["string", "null"]}
+					},
+					"required": ["required_value"]
+				})),
 				strict: true,
 			}),
-			br#"[{"type":"function","name":"match_input","parameters":{"type":"object"},"strict":true}]"#,
+			br#"[{"type":"function","name":"match_input","parameters":{"additionalProperties":false,"properties":{"optional_value":{"type":["string","null"]},"required_value":{"type":"string"}},"required":["optional_value","required_value"],"type":"object"},"strict":true}]"#,
+		);
+	}
+
+	#[test]
+	fn json_schema_tool_encoding_downgrades_open_maps_from_strict() {
+		assert_eq!(
+			encode_tool(ToolInputConstraint::JsonSchema {
+				parameters: OpaqueJson::new(serde_json::json!({
+					"type": "object",
+					"properties": {
+						"command": {"type": "string"},
+						"env": {
+							"type": "object",
+							"additionalProperties": {"type": ["string", "null"]}
+						}
+					},
+					"required": ["command"]
+				})),
+				strict: true,
+			}),
+			br#"[{"type":"function","name":"match_input","parameters":{"properties":{"command":{"type":"string"},"env":{"additionalProperties":{"type":["string","null"]},"type":"object"}},"required":["command"],"type":"object"},"strict":false}]"#,
+		);
+	}
+
+	#[test]
+	fn json_schema_tool_encoding_rewrites_one_of_for_responses() {
+		assert_eq!(
+			encode_tool(ToolInputConstraint::JsonSchema {
+				parameters: OpaqueJson::new(serde_json::json!({
+					"type": "object",
+					"properties": {
+						"action": {
+							"oneOf": [
+								{"type": "string", "const": "launch"},
+								{"type": "string", "const": "attach"}
+							]
+						}
+					},
+					"required": ["action"]
+				})),
+				strict: true,
+			}),
+			br#"[{"type":"function","name":"match_input","parameters":{"additionalProperties":false,"properties":{"action":{"anyOf":[{"enum":["launch"],"type":"string"},{"enum":["attach"],"type":"string"}]}},"required":["action"],"type":"object"},"strict":true}]"#,
+		);
+	}
+
+	#[test]
+	fn json_schema_tool_encoding_downgrades_unconstrained_values_from_strict() {
+		assert_eq!(
+			encode_tool(ToolInputConstraint::JsonSchema {
+				parameters: OpaqueJson::new(serde_json::json!({
+					"type": "object",
+					"properties": {"arguments": {}}
+				})),
+				strict: true,
+			}),
+			br#"[{"type":"function","name":"match_input","parameters":{"properties":{"arguments":true},"type":"object"},"strict":false}]"#,
 		);
 	}
 

--- a/crates/inference/src/codec/openai_responses.rs
+++ b/crates/inference/src/codec/openai_responses.rs
@@ -3982,6 +3982,13 @@ mod tests {
 			.expect("tool request encodes");
 		serde_json::to_vec(&encoded.request.tools).expect("tools serialize")
 	}
+	fn assert_tool_json(input: ToolInputConstraint, expected: &[u8]) {
+		let actual = encode_tool(input);
+		assert_eq!(
+			serde_json::from_slice::<serde_json::Value>(&actual).expect("actual tool JSON"),
+			serde_json::from_slice::<serde_json::Value>(expected).expect("expected tool JSON"),
+		);
+	}
 	fn encode_cache_affinity(disable_prompt_caching: bool) -> Option<Str> {
 		let catalog = Catalog::embedded();
 		let model = catalog
@@ -4488,8 +4495,8 @@ mod tests {
 
 	#[test]
 	fn json_schema_tool_encoding_normalizes_strict_function_parameters() {
-		assert_eq!(
-			encode_tool(ToolInputConstraint::JsonSchema {
+		assert_tool_json(
+			ToolInputConstraint::JsonSchema {
 				parameters: OpaqueJson::new(serde_json::json!({
 					"type": "object",
 					"properties": {
@@ -4499,15 +4506,15 @@ mod tests {
 					"required": ["required_value"]
 				})),
 				strict: true,
-			}),
-			br#"[{"type":"function","name":"match_input","parameters":{"additionalProperties":false,"properties":{"optional_value":{"type":["string","null"]},"required_value":{"type":"string"}},"required":["optional_value","required_value"],"type":"object"},"strict":true}]"#,
+			},
+			br#"[{"type":"function","name":"match_input","parameters":{"type":"object","properties":{"required_value":{"type":"string"},"optional_value":{"type":["string","null"]}},"required":["required_value","optional_value"],"additionalProperties":false},"strict":true}]"#,
 		);
 	}
 
 	#[test]
 	fn json_schema_tool_encoding_downgrades_open_maps_from_strict() {
-		assert_eq!(
-			encode_tool(ToolInputConstraint::JsonSchema {
+		assert_tool_json(
+			ToolInputConstraint::JsonSchema {
 				parameters: OpaqueJson::new(serde_json::json!({
 					"type": "object",
 					"properties": {
@@ -4520,15 +4527,15 @@ mod tests {
 					"required": ["command"]
 				})),
 				strict: true,
-			}),
-			br#"[{"type":"function","name":"match_input","parameters":{"properties":{"command":{"type":"string"},"env":{"additionalProperties":{"type":["string","null"]},"type":"object"}},"required":["command"],"type":"object"},"strict":false}]"#,
+			},
+			br#"[{"type":"function","name":"match_input","parameters":{"type":"object","properties":{"command":{"type":"string"},"env":{"type":"object","additionalProperties":{"type":["string","null"]},"properties":{}}},"required":["command"]},"strict":false}]"#,
 		);
 	}
 
 	#[test]
 	fn json_schema_tool_encoding_rewrites_one_of_for_responses() {
-		assert_eq!(
-			encode_tool(ToolInputConstraint::JsonSchema {
+		assert_tool_json(
+			ToolInputConstraint::JsonSchema {
 				parameters: OpaqueJson::new(serde_json::json!({
 					"type": "object",
 					"properties": {
@@ -4542,21 +4549,21 @@ mod tests {
 					"required": ["action"]
 				})),
 				strict: true,
-			}),
+			},
 			br#"[{"type":"function","name":"match_input","parameters":{"additionalProperties":false,"properties":{"action":{"anyOf":[{"enum":["launch"],"type":"string"},{"enum":["attach"],"type":"string"}]}},"required":["action"],"type":"object"},"strict":true}]"#,
 		);
 	}
 
 	#[test]
 	fn json_schema_tool_encoding_downgrades_unconstrained_values_from_strict() {
-		assert_eq!(
-			encode_tool(ToolInputConstraint::JsonSchema {
+		assert_tool_json(
+			ToolInputConstraint::JsonSchema {
 				parameters: OpaqueJson::new(serde_json::json!({
 					"type": "object",
 					"properties": {"arguments": {}}
 				})),
 				strict: true,
-			}),
+			},
 			br#"[{"type":"function","name":"match_input","parameters":{"properties":{"arguments":true},"type":"object"},"strict":false}]"#,
 		);
 	}

--- a/crates/inference/src/codec/openai_responses.rs
+++ b/crates/inference/src/codec/openai_responses.rs
@@ -171,6 +171,14 @@ impl ResponsesContent {
 			file_id:   None,
 		}
 	}
+
+	fn message_text(role: ResponsesRole, text: impl Into<Str>) -> Self {
+		let mut content = Self::input_text(text);
+		if role == ResponsesRole::Assistant {
+			content.kind = ResponsesContentKind::OutputText;
+		}
+		content
+	}
 }
 
 /// Message input content, preserving the API's string and typed-part shapes.
@@ -328,9 +336,9 @@ pub struct ResponsesInputItem {
 	/// Tool output.
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub output: Option<ResponsesToolOutput>,
-	/// Reasoning summaries.
-	#[serde(default, skip_serializing_if = "Vec::is_empty")]
-	pub summary: Vec<ResponsesSummaryPart>,
+	/// Reasoning summaries; present, including when empty, on reasoning items.
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub summary: Option<Vec<ResponsesSummaryPart>>,
 	/// Encrypted reasoning continuation payload.
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub encrypted_content: Option<Str>,
@@ -371,7 +379,7 @@ impl ResponsesInputItem {
 			arguments: None,
 			input: None,
 			output: None,
-			summary: Vec::new(),
+			summary: None,
 			encrypted_content: None,
 			actions: Vec::new(),
 			pending_safety_checks: Vec::new(),
@@ -2391,7 +2399,7 @@ impl OpenAiResponsesCodec {
 						arguments: None,
 						input: None,
 						output: None,
-						summary: Vec::new(),
+						summary: None,
 						encrypted_content: None,
 						actions: Vec::new(),
 						pending_safety_checks: Vec::new(),
@@ -2459,13 +2467,14 @@ impl OpenAiResponsesCodec {
 								input.push(ResponsesInputItem::message(role, mem::take(&mut content)));
 							}
 							let mut item =
-								ResponsesInputItem::message(role, vec![ResponsesContent::input_text(
+								ResponsesInputItem::message(role, vec![ResponsesContent::message_text(
+									role,
 									text.clone(),
 								)]);
 							item.id = decoded.item_id;
 							input.push(item);
 						} else {
-							content.push(ResponsesContent::input_text(text.clone()));
+							content.push(ResponsesContent::message_text(role, text.clone()));
 						}
 					},
 					ContentPart::Reasoning { text, proof } => {
@@ -2509,11 +2518,11 @@ impl OpenAiResponsesCodec {
 							arguments: None,
 							input: None,
 							output: None,
-							summary: if text.is_empty() {
+							summary: Some(if text.is_empty() {
 								Vec::new()
 							} else {
 								vec![ResponsesSummaryPart { kind: sf!("summary_text"), text: text.clone() }]
-							},
+							}),
 							encrypted_content: decoded.encrypted_reasoning,
 							actions: Vec::new(),
 							pending_safety_checks: Vec::new(),
@@ -2588,7 +2597,7 @@ impl OpenAiResponsesCodec {
 								arguments: (!custom).then(|| serialized.into()),
 								input: custom_input,
 								output: None,
-								summary: Vec::new(),
+								summary: None,
 								encrypted_content: None,
 								actions: Vec::new(),
 								pending_safety_checks: Vec::new(),
@@ -2630,7 +2639,7 @@ impl OpenAiResponsesCodec {
 							arguments: None,
 							input: None,
 							output: Some(ResponsesToolOutput::Text(output.into())),
-							summary: Vec::new(),
+							summary: None,
 							encrypted_content: None,
 							actions: Vec::new(),
 							pending_safety_checks: Vec::new(),
@@ -3325,13 +3334,28 @@ impl ResponsesDecoderAdapter {
 				emit(RawEvent::ProviderState(ProviderStateEvent::OutputItem { index, id }));
 			},
 			ResponsesProjection::ReasoningSignature { index, item_id, signature } => {
-				if let Some(id) = item_id {
-					emit(RawEvent::ProviderState(ProviderStateEvent::OutputItem { index, id }));
+				if let Some(id) = item_id.as_ref() {
+					emit(RawEvent::ProviderState(ProviderStateEvent::OutputItem {
+						index,
+						id: id.clone(),
+					}));
 				}
-				emit(RawEvent::ProviderState(ProviderStateEvent::ReasoningSignature {
-					index,
-					signature,
-				}));
+				let proof = ResponsesProviderProof {
+					item_id,
+					encrypted_reasoning: Some(Str::new(String::from_utf8_lossy(&signature).as_ref())),
+					..ResponsesProviderProof::default()
+				};
+				match encode_provider_proof(&proof) {
+					Ok(signature) => {
+						emit(RawEvent::ProviderState(ProviderStateEvent::ReasoningSignature {
+							index,
+							signature,
+						}));
+					},
+					Err(_) => {
+						emit(RawEvent::Failure(encoding_error("responses_reasoning_proof_serialization")))
+					},
+				}
 			},
 			ResponsesProjection::HostedTool { index, kind, completed } => {
 				let data = serde_json::to_vec(&HostedCheckpoint { index, kind, completed })
@@ -3525,6 +3549,36 @@ fn encoding_error(code: &'static str) -> Error {
 	.code(Str::new(code))
 }
 
+pub(super) fn encode_error(error: ResponsesEncodeError) -> Error {
+	match error {
+		ResponsesEncodeError::MismatchedProviderProof => {
+			encoding_error("mismatched_responses_provider_proof")
+		},
+		ResponsesEncodeError::MissingWireTarget => encoding_error("missing_responses_wire_target"),
+		ResponsesEncodeError::MissingCallIdentity => {
+			encoding_error("missing_responses_call_identity")
+		},
+		ResponsesEncodeError::UnresolvedStoredMedia => encoding_error("unresolved_responses_media"),
+		ResponsesEncodeError::UnreplayableProviderProof => {
+			encoding_error("unreplayable_responses_provider_proof")
+		},
+		ResponsesEncodeError::UnsupportedOutputFormat => {
+			encoding_error("unsupported_responses_output_format")
+		},
+		ResponsesEncodeError::UnsupportedComputerUse => {
+			encoding_error("unsupported_responses_computer_use")
+		},
+		ResponsesEncodeError::UnsupportedComputerUseConfig => {
+			encoding_error("unsupported_responses_computer_use_config")
+		},
+		ResponsesEncodeError::MalformedServerState => {
+			encoding_error("malformed_responses_server_state")
+		},
+		ResponsesEncodeError::MismatchedServerState => {
+			encoding_error("mismatched_responses_server_state")
+		},
+	}
+}
 pub(super) fn responses_uri(base_url: &str) -> Str {
 	openai_chat::join_uri(base_url, "/responses")
 }
@@ -3765,40 +3819,7 @@ impl Codec for OpenAiResponsesCodec {
 		let OperationCall::Chat(request) = operation else {
 			return Err(encoding_error("responses_operation_unsupported"));
 		};
-		let encoded = self
-			.encode_chat(context, request)
-			.map_err(|error| match error {
-				ResponsesEncodeError::MismatchedProviderProof => {
-					encoding_error("mismatched_responses_provider_proof")
-				},
-				ResponsesEncodeError::MissingWireTarget => {
-					encoding_error("missing_responses_wire_target")
-				},
-				ResponsesEncodeError::MissingCallIdentity => {
-					encoding_error("missing_responses_call_identity")
-				},
-				ResponsesEncodeError::UnresolvedStoredMedia => {
-					encoding_error("unresolved_responses_media")
-				},
-				ResponsesEncodeError::UnreplayableProviderProof => {
-					encoding_error("unreplayable_responses_provider_proof")
-				},
-				ResponsesEncodeError::UnsupportedOutputFormat => {
-					encoding_error("unsupported_responses_output_format")
-				},
-				ResponsesEncodeError::UnsupportedComputerUse => {
-					encoding_error("unsupported_responses_computer_use")
-				},
-				ResponsesEncodeError::UnsupportedComputerUseConfig => {
-					encoding_error("unsupported_responses_computer_use_config")
-				},
-				ResponsesEncodeError::MalformedServerState => {
-					encoding_error("malformed_responses_server_state")
-				},
-				ResponsesEncodeError::MismatchedServerState => {
-					encoding_error("mismatched_responses_server_state")
-				},
-			})?;
+		let encoded = self.encode_chat(context, request).map_err(encode_error)?;
 		if !encoded.adjustments.is_empty() {
 			return Err(encoding_error("responses_adjustment_requires_planning"));
 		}
@@ -4932,6 +4953,43 @@ mod tests {
 	}
 
 	#[test]
+	fn reasoning_signature_is_stored_as_a_typed_responses_proof() {
+		let adapter = ResponsesDecoderAdapter {
+			inner: OpenAiResponsesDecoder::default(),
+			request_id: RequestId::new("request"),
+			provider: ProviderId::from("openai-codex"),
+			route: RouteId::from("openai-codex/primary"),
+			wire_model: Some(sf!("gpt")),
+			thinking_close_max_retries: None,
+		};
+		let mut events = Vec::new();
+		adapter.emit_projection(
+			ResponsesProjection::ReasoningSignature {
+				index:     2,
+				item_id:   Some(sf!("rs_1")),
+				signature: Bytes::from_static(b"enc_reasoning"),
+			},
+			&mut |event| events.push(event),
+		);
+		let RawEvent::ProviderState(crate::codec::ProviderStateEvent::ReasoningSignature {
+			index,
+			signature,
+		}) = &events[1]
+		else {
+			panic!("typed reasoning proof");
+		};
+		assert_eq!(*index, 2);
+		assert_eq!(
+			super::decode_provider_proof(signature).expect("proof decodes"),
+			ResponsesProviderProof {
+				item_id: Some(sf!("rs_1")),
+				encrypted_reasoning: Some(sf!("enc_reasoning")),
+				..ResponsesProviderProof::default()
+			}
+		);
+	}
+
+	#[test]
 	fn terminal_envelope_completes_the_transport_before_eof() {
 		let mut adapter = ResponsesDecoderAdapter {
 			inner: OpenAiResponsesDecoder::default(),
@@ -5121,12 +5179,40 @@ mod tests {
 		// Canonical message(s) → calls → outputs, byte-exact on the wire.
 		assert_eq!(
 			serde_json::to_string(&encoded.request.input).expect("input serializes"),
-			r#"[{"role":"assistant","content":[{"type":"input_text","text":"<think>\n</thinking\n</think>"}]},{"type":"function_call","name":"read","call_id":"call_a","arguments":"{\"path\":\"a\"}"},{"type":"function_call","name":"read","call_id":"call_b","arguments":"{\"path\":\"b\"}"},{"type":"function_call","name":"read","call_id":"call_c","arguments":"{\"path\":\"c\"}"},{"type":"function_call_output","call_id":"call_a","output":"out a"},{"type":"function_call_output","call_id":"call_b","output":"out b"},{"type":"function_call_output","call_id":"call_c","output":"out c"},{"role":"user","content":[{"type":"input_text","text":"continue"}]}]"#,
+			r#"[{"role":"assistant","content":[{"type":"output_text","text":"<think>\n</thinking\n</think>"}]},{"type":"function_call","name":"read","call_id":"call_a","arguments":"{\"path\":\"a\"}"},{"type":"function_call","name":"read","call_id":"call_b","arguments":"{\"path\":\"b\"}"},{"type":"function_call","name":"read","call_id":"call_c","arguments":"{\"path\":\"c\"}"},{"type":"function_call_output","call_id":"call_a","output":"out a"},{"type":"function_call_output","call_id":"call_b","output":"out b"},{"type":"function_call_output","call_id":"call_c","output":"out c"},{"role":"user","content":[{"type":"input_text","text":"continue"}]}]"#,
 		);
 		// Hoisting is idempotent: a second pass changes nothing.
 		let mut again = encoded.request.input.clone();
 		hoist_interleaved_tool_batch_messages(&mut again);
 		assert_eq!(again, encoded.request.input);
+	}
+
+	#[test]
+	fn assistant_followup_after_tool_output_uses_output_text() {
+		let request = history_request(vec![
+			Message {
+				role:    Role::User,
+				content: Arc::from([ContentPart::Text { text: sf!("read it"), proof: None }]),
+				name:    None,
+			},
+			Message {
+				role:    Role::Assistant,
+				content: Arc::from([read_call("call_a", "a")]),
+				name:    None,
+			},
+			read_results(&[("call_a", "contents")]),
+			Message {
+				role:    Role::Assistant,
+				content: Arc::from([ContentPart::Text { text: sf!("done"), proof: None }]),
+				name:    None,
+			},
+		]);
+		let policy = policy::WirePolicy::baseline();
+		let encoded = encode_with_policy(&policy, |_, _| request);
+		assert_eq!(
+			serde_json::to_string(&encoded.request.input).expect("input serializes"),
+			r#"[{"role":"user","content":[{"type":"input_text","text":"read it"}]},{"type":"function_call","name":"read","call_id":"call_a","arguments":"{\"path\":\"a\"}"},{"type":"function_call_output","call_id":"call_a","output":"contents"},{"role":"assistant","content":[{"type":"output_text","text":"done"}]}]"#,
+		);
 	}
 
 	#[test]
@@ -5147,7 +5233,7 @@ mod tests {
 		let encoded = encode_with_policy(&policy, |_, _| request);
 		assert_eq!(
 			serde_json::to_string(&encoded.request.input).expect("input serializes"),
-			r#"[{"role":"assistant","content":[{"type":"input_text","text":"calling read on two files"}]},{"type":"function_call","name":"read","call_id":"call_a","arguments":"{\"path\":\"a\"}"},{"type":"function_call","name":"read","call_id":"call_b","arguments":"{\"path\":\"b\"}"},{"type":"function_call_output","call_id":"call_a","output":"out a"},{"type":"function_call_output","call_id":"call_b","output":"out b"}]"#,
+			r#"[{"role":"assistant","content":[{"type":"output_text","text":"calling read on two files"}]},{"type":"function_call","name":"read","call_id":"call_a","arguments":"{\"path\":\"a\"}"},{"type":"function_call","name":"read","call_id":"call_b","arguments":"{\"path\":\"b\"}"},{"type":"function_call_output","call_id":"call_a","output":"out a"},{"type":"function_call_output","call_id":"call_b","output":"out b"}]"#,
 		);
 	}
 	#[test]

--- a/crates/inference/src/local/applefm.rs
+++ b/crates/inference/src/local/applefm.rs
@@ -66,7 +66,7 @@ mod abi;
 mod platform;
 #[cfg(not(target_os = "macos"))]
 mod platform {
-	use omp_core::Str;
+	use omp_core::{Str, sf};
 	use tokio_util::sync::CancellationToken;
 
 	use super::{
@@ -688,7 +688,7 @@ impl AppleFmTransport {
 	/// Model availability is intentionally checked per request so discovery can
 	/// report a temporarily blocked system model and later observe it becoming
 	/// available without rebuilding the registry.
-	pub const fn new() -> result::Result<Self, AppleFmAvailabilityEvidence> {
+	pub fn new() -> result::Result<Self, AppleFmAvailabilityEvidence> {
 		#[cfg(target_os = "macos")]
 		{
 			Ok(Self { ready: None })

--- a/crates/inference/src/transport/tests.rs
+++ b/crates/inference/src/transport/tests.rs
@@ -163,6 +163,32 @@ impl Decoder for CompletionOnlyDecoder {
 	}
 }
 
+#[derive(Default)]
+struct TerminalEnvelopeDecoder {
+	complete: bool,
+}
+
+impl Decoder for TerminalEnvelopeDecoder {
+	fn push(&mut self, _frame: Frame, emit: &mut dyn FnMut(RawEvent)) -> Result<(), Error> {
+		emit(RawEvent::Chat(ChatEvent::TextDelta { index: 0, text: sf!("visible") }));
+		emit(RawEvent::Completion(RawCompletion {
+			reason: FinishReason::Stop,
+			blocks: 1,
+			usage:  Usage::default(),
+		}));
+		self.complete = true;
+		Ok(())
+	}
+
+	fn finish(&mut self, _emit: &mut dyn FnMut(RawEvent)) -> Result<(), Error> {
+		Ok(())
+	}
+
+	fn is_complete(&self) -> bool {
+		self.complete
+	}
+}
+
 struct FailDecoder;
 
 impl Decoder for FailDecoder {
@@ -1191,6 +1217,54 @@ async fn websocket_upgrade_sends_initial_frame_before_first_decodable_event() {
 	assert_eq!(captures.len(), 1);
 	assert_eq!(captures[0].frames.len(), 1);
 	assert_eq!(captures[0].frames[0].redaction, Bytes::from_static(b"<redacted>"));
+}
+
+#[tokio::test]
+async fn websocket_terminal_envelope_ends_stream_before_peer_close() {
+	let listener = TcpListener::bind("127.0.0.1:0")
+		.await
+		.expect("bind websocket fixture");
+	let address = listener.local_addr().expect("websocket fixture address");
+	let server = tokio::spawn(async move {
+		let (socket, _) = listener.accept().await.expect("accept websocket fixture");
+		let mut socket = tokio_tungstenite::accept_async(socket)
+			.await
+			.expect("upgrade websocket fixture");
+		let _ = socket
+			.next()
+			.await
+			.expect("initial websocket frame")
+			.expect("valid websocket frame");
+		use futures::SinkExt as _;
+		socket
+			.send(tungstenite::Message::text("terminal"))
+			.await
+			.expect("send terminal frame");
+		let _ = socket.next().await;
+	});
+	let mut service = WebSocketTransport::new();
+	service.ready().await.expect("websocket ready");
+	let mut call = request(
+		BodySource::Bytes(Bytes::from_static(b"request")),
+		TerminalEnvelopeDecoder::default(),
+		Cancellation::default(),
+	);
+	call.encoded.framing = FramingProtocol::WebSocket;
+	call.encoded.uri = sf!("ws://{address}/responses");
+	let response = service.call(call).await.expect("websocket handshake");
+	let mut events = response.events.expect("ordinary event stream");
+	assert!(matches!(events.next().await, Some(Ok(RawEvent::Chat(_)))));
+	assert!(matches!(events.next().await, Some(Ok(RawEvent::Completion(_)))));
+	assert!(
+		time::timeout(time::Duration::from_secs(1), events.next())
+			.await
+			.expect("semantic completion must not wait for peer close")
+			.is_none()
+	);
+	time::timeout(time::Duration::from_secs(1), server)
+		.await
+		.expect("client closes websocket after semantic completion")
+		.expect("websocket fixture");
 }
 
 #[tokio::test]

--- a/crates/inference/src/transport/websocket_transport.rs
+++ b/crates/inference/src/transport/websocket_transport.rs
@@ -455,6 +455,9 @@ async fn execute(
 									break;
 								},
 							}
+							if decoder.is_complete() {
+								break;
+							}
 						},
 						Some(Ok(Message::Binary(payload))) => {
 							if payload.len() as u64 > bounds.frame { break; }
@@ -476,6 +479,9 @@ async fn execute(
 									let _ = event_tx.send_async(Err(error)).await;
 									break;
 								},
+							}
+							if decoder.is_complete() {
+								break;
 							}
 						},
 						Some(Ok(Message::Close(_))) | None => {

--- a/crates/shell-builtins/src/mv.rs
+++ b/crates/shell-builtins/src/mv.rs
@@ -20,8 +20,6 @@ use std::{
 
 use clap::{Arg, ArgAction, ArgMatches, Command, builder::ValueParser, error::ErrorKind};
 use indicatif::{MultiProgress, ProgressBar, ProgressDrawTarget, ProgressStyle, TermLike};
-#[cfg(all(unix, not(any(target_os = "macos", target_os = "redox"))))]
-use omp_core::FastHashMap;
 use omp_core::{FastHashSet, FastState};
 use omp_shell_engine::{ShellExtensions, builtins::Registration, openfiles::OpenFile};
 use parking_lot::Mutex;
@@ -36,7 +34,7 @@ use self::hardlink::{
 };
 #[cfg(unix)]
 use crate::support::fsutil::{display_permissions_unix, make_fifo};
-#[cfg(all(unix, not(any(target_os = "macos", target_os = "redox"))))]
+#[cfg(target_os = "linux")]
 use crate::support::xattr as fsxattr;
 use crate::{
 	host::{Host, Utility, format_usage, matches_parser, util},
@@ -1166,9 +1164,9 @@ fn rename_symlink_fallback(host: &mut Host, from: &Path, to: &Path) -> io::Resul
 	// must not be resolved; only the from/to operands are filesystem locations.
 	let path_symlink_points_to = fs::read_link(host.resolve(from))?;
 	unix::fs::symlink(path_symlink_points_to, host.resolve(to))?;
-	#[cfg(not(any(target_os = "macos", target_os = "redox")))]
+	#[cfg(target_os = "linux")]
 	{
-		let _ = copy_xattrs_if_supported(host, from, to);
+		preserve_xattrs(host, from, to)?;
 	}
 	fs::remove_file(host.resolve(from))
 }
@@ -1206,6 +1204,9 @@ fn rename_dir_fallback(
 	#[cfg(unix)] hardlink_tracker: Option<&mut HardlinkTracker>,
 	#[cfg(unix)] hardlink_scanner: Option<&HardlinkGroupScanner>,
 ) -> io::Result<()> {
+	#[cfg(target_os = "linux")]
+	let xattrs = fsxattr::retrieve_xattrs(host.resolve(from))?;
+
 	// We remove the destination directory if it exists to match the
 	// behavior of `fs::rename`. As far as I can tell, `fs_extra`'s
 	// `move_dir` would otherwise behave differently.
@@ -1231,10 +1232,6 @@ fn rename_dir_fallback(
 		(..) => None,
 	};
 
-	#[cfg(all(unix, not(any(target_os = "macos", target_os = "redox"))))]
-	let xattrs =
-		fsxattr::retrieve_xattrs(host.resolve(from)).unwrap_or_else(|_| FastHashMap::default());
-
 	// Use directory copying (with or without hardlink support)
 	let result = copy_dir_contents(
 		host,
@@ -1249,7 +1246,7 @@ fn rename_dir_fallback(
 		display_manager,
 	);
 
-	#[cfg(all(unix, not(any(target_os = "macos", target_os = "redox"))))]
+	#[cfg(target_os = "linux")]
 	fsxattr::apply_xattrs(host.resolve(to), xattrs)?;
 
 	result?;
@@ -1434,10 +1431,10 @@ fn copy_file_with_hardlinks_helper(
 	} else {
 		// Copy a regular file.
 		fs::copy(host.resolve(from), host.resolve(to))?;
-		// Copy xattrs, ignoring ENOTSUP errors (filesystem doesn't support xattrs)
-		#[cfg(all(unix, not(any(target_os = "macos", target_os = "redox"))))]
+		// Copy xattrs before removing the source.
+		#[cfg(target_os = "linux")]
 		{
-			let _ = copy_xattrs_if_supported(host, from, to);
+			preserve_xattrs(host, from, to)?;
 		}
 	}
 
@@ -1489,10 +1486,10 @@ fn rename_file_fallback(
 	fs::copy(host.resolve(from), &to_fs)
 		.map_err(|err| io::Error::new(err.kind(), "Permission denied"))?;
 
-	// Copy xattrs, ignoring ENOTSUP errors (filesystem doesn't support xattrs)
-	#[cfg(all(unix, not(any(target_os = "macos", target_os = "redox"))))]
+	// Copy xattrs before removing the source.
+	#[cfg(target_os = "linux")]
 	{
-		let _ = copy_xattrs_if_supported(host, from, to);
+		preserve_xattrs(host, from, to)?;
 	}
 
 	fs::remove_file(host.resolve(from))
@@ -1500,16 +1497,12 @@ fn rename_file_fallback(
 	Ok(())
 }
 
-/// Copy xattrs from source to destination, ignoring ENOTSUP/EOPNOTSUPP errors.
-/// These errors indicate the filesystem doesn't support extended attributes,
-/// which is acceptable when moving files across filesystems.
-#[cfg(all(unix, not(any(target_os = "macos", target_os = "redox"))))]
-fn copy_xattrs_if_supported(host: &Host, from: &Path, to: &Path) -> io::Result<()> {
-	match fsxattr::copy_xattrs(host.resolve(from), host.resolve(to)) {
-		Ok(()) => Ok(()),
-		Err(e) if e.raw_os_error() == Some(libc::EOPNOTSUPP) => Ok(()),
-		Err(e) => Err(e),
-	}
+/// Copies xattrs from source to destination before the source is removed.
+///
+/// Errors are propagated because dropping metadata during a move is not safe.
+#[cfg(target_os = "linux")]
+fn preserve_xattrs(host: &Host, from: &Path, to: &Path) -> io::Result<()> {
+	fsxattr::copy_xattrs(host.resolve(from), host.resolve(to))
 }
 
 fn is_empty_dir(host: &Host, path: &Path) -> bool {

--- a/crates/shell-builtins/src/support/xattr.rs
+++ b/crates/shell-builtins/src/support/xattr.rs
@@ -1,15 +1,16 @@
 //! Minimal extended-attribute probes used by `ls` and `mkdir`.
 
+#[cfg(all(unix, not(any(target_os = "android", target_os = "macos"))))]
+use std::path::Path;
 #[cfg(target_os = "linux")]
 use std::{ffi, ptr};
-#[cfg(all(unix, not(any(target_os = "macos", target_os = "redox"))))]
+#[cfg(target_os = "linux")]
 use std::{
 	ffi::{OsStr, OsString},
 	io,
-	path::Path,
 };
 
-#[cfg(all(unix, not(any(target_os = "macos", target_os = "redox"))))]
+#[cfg(target_os = "linux")]
 use omp_core::FastHashMap;
 
 /// Returns whether a path has at least one extended ACL or attribute.
@@ -61,8 +62,8 @@ fn path_cstring(path: &Path) -> io::Result<ffi::CString> {
 fn list_xattrs(path: &Path) -> io::Result<Vec<u8>> {
 	let path = path_cstring(path)?;
 	// SAFETY: the C path is valid and a null buffer with length zero performs a
-	// size query.
-	let size = unsafe { libc::listxattr(path.as_ptr(), ptr::null_mut(), 0) };
+	// size query without following a final symlink.
+	let size = unsafe { libc::llistxattr(path.as_ptr(), ptr::null_mut(), 0) };
 	if size < 0 {
 		return Err(io::Error::last_os_error());
 	}
@@ -71,7 +72,7 @@ fn list_xattrs(path: &Path) -> io::Result<Vec<u8>> {
 	}
 	let mut names = vec![0_u8; size as usize];
 	// SAFETY: `names` is writable for its full reported capacity.
-	let read = unsafe { libc::listxattr(path.as_ptr(), names.as_mut_ptr().cast(), names.len()) };
+	let read = unsafe { libc::llistxattr(path.as_ptr(), names.as_mut_ptr().cast(), names.len()) };
 	if read < 0 {
 		return Err(io::Error::last_os_error());
 	}
@@ -84,8 +85,9 @@ fn get_xattr(path: &Path, name: &[u8]) -> io::Result<Vec<u8>> {
 	let path = path_cstring(path)?;
 	let name = ffi::CStr::from_bytes_with_nul(name)
 		.map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "invalid attribute name"))?;
-	// SAFETY: both C strings are valid; a null value pointer performs a size query.
-	let size = unsafe { libc::getxattr(path.as_ptr(), name.as_ptr(), ptr::null_mut(), 0) };
+	// SAFETY: both C strings are valid; a null value pointer performs a size
+	// query without following a final symlink.
+	let size = unsafe { libc::lgetxattr(path.as_ptr(), name.as_ptr(), ptr::null_mut(), 0) };
 	if size < 0 {
 		return Err(io::Error::last_os_error());
 	}
@@ -93,7 +95,7 @@ fn get_xattr(path: &Path, name: &[u8]) -> io::Result<Vec<u8>> {
 	// SAFETY: `value` is writable for the queried size and all pointers remain
 	// live.
 	let read = unsafe {
-		libc::getxattr(path.as_ptr(), name.as_ptr(), value.as_mut_ptr().cast(), value.len())
+		libc::lgetxattr(path.as_ptr(), name.as_ptr(), value.as_mut_ptr().cast(), value.len())
 	};
 	if read < 0 {
 		return Err(io::Error::last_os_error());
@@ -101,59 +103,46 @@ fn get_xattr(path: &Path, name: &[u8]) -> io::Result<Vec<u8>> {
 	value.truncate(read as usize);
 	Ok(value)
 }
-/// Reads every extended attribute attached to `path`.
-#[cfg(all(unix, not(any(target_os = "macos", target_os = "redox"))))]
+
+/// Reads every extended attribute attached to `path` without following a
+/// final symlink.
+#[cfg(target_os = "linux")]
 pub(crate) fn retrieve_xattrs(
 	path: impl AsRef<Path>,
 ) -> io::Result<FastHashMap<OsString, Vec<u8>>> {
-	#[cfg(target_os = "linux")]
-	{
-		use std::os::unix::ffi::OsStringExt;
+	use std::os::unix::ffi::OsStringExt;
 
-		let path = path.as_ref();
-		let names = list_xattrs(path)?;
-		let mut attrs = FastHashMap::default();
-		for name in names
-			.split(|byte| *byte == 0)
-			.filter(|name| !name.is_empty())
-		{
-			let mut terminated_name = Vec::with_capacity(name.len() + 1);
-			terminated_name.extend_from_slice(name);
-			terminated_name.push(0);
-			attrs.insert(OsString::from_vec(name.to_vec()), get_xattr(path, &terminated_name)?);
-		}
-		return Ok(attrs);
-	}
-	#[cfg(not(target_os = "linux"))]
+	let path = path.as_ref();
+	let names = list_xattrs(path)?;
+	let mut attrs = FastHashMap::default();
+	for name in names
+		.split(|byte| *byte == 0)
+		.filter(|name| !name.is_empty())
 	{
-		let _ = path;
-		Ok(FastHashMap::default())
+		let mut terminated_name = Vec::with_capacity(name.len() + 1);
+		terminated_name.extend_from_slice(name);
+		terminated_name.push(0);
+		attrs.insert(OsString::from_vec(name.to_vec()), get_xattr(path, &terminated_name)?);
 	}
+	Ok(attrs)
 }
 
-/// Applies extended attributes to `path`.
-#[cfg(all(unix, not(any(target_os = "macos", target_os = "redox"))))]
+/// Applies extended attributes to `path` without following a final symlink.
+#[cfg(target_os = "linux")]
 pub(crate) fn apply_xattrs(
 	path: impl AsRef<Path>,
 	xattrs: FastHashMap<OsString, Vec<u8>>,
 ) -> io::Result<()> {
-	#[cfg(target_os = "linux")]
-	{
-		let path = path.as_ref();
-		for (name, value) in xattrs {
-			set_xattr(path, &name, &value)?;
-		}
-		return Ok(());
+	let path = path.as_ref();
+	for (name, value) in xattrs {
+		set_xattr(path, &name, &value)?;
 	}
-	#[cfg(not(target_os = "linux"))]
-	{
-		let _ = (path, xattrs);
-		Ok(())
-	}
+	Ok(())
 }
 
-/// Copies every extended attribute from `source` to `destination`.
-#[cfg(all(unix, not(any(target_os = "macos", target_os = "redox"))))]
+/// Copies every extended attribute from `source` to `destination` without
+/// following final symlinks.
+#[cfg(target_os = "linux")]
 pub(crate) fn copy_xattrs(
 	source: impl AsRef<Path>,
 	destination: impl AsRef<Path>,
@@ -171,7 +160,7 @@ fn set_xattr(path: &Path, name: &OsStr, value: &[u8]) -> io::Result<()> {
 		.map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "attribute name contains NUL"))?;
 	// SAFETY: both C strings and the value slice remain live for the call.
 	let result = unsafe {
-		libc::setxattr(path.as_ptr(), name.as_ptr(), value.as_ptr().cast(), value.len(), 0)
+		libc::lsetxattr(path.as_ptr(), name.as_ptr(), value.as_ptr().cast(), value.len(), 0)
 	};
 	if result < 0 {
 		return Err(io::Error::last_os_error());
@@ -240,6 +229,48 @@ mod tests {
 		copy_xattrs(&source, &destination)?;
 		let copied = retrieve_xattrs(&destination)?;
 		assert_eq!(copied.get(name).map(Vec::as_slice), Some(b"value".as_slice()));
+		Ok(())
+	}
+
+	#[test]
+	fn does_not_follow_symlinks_when_copying_extended_attributes() -> io::Result<()> {
+		use std::os::unix::fs::symlink;
+
+		let directory = tempfile::tempdir()?;
+		let source_dir = directory.path().join("source");
+		let destination_dir = directory.path().join("destination");
+		std::fs::create_dir(&source_dir)?;
+		std::fs::create_dir(&destination_dir)?;
+
+		let source_target = source_dir.join("target");
+		let destination_target = destination_dir.join("target");
+		std::fs::write(&source_target, b"source")?;
+		std::fs::write(&destination_target, b"destination")?;
+
+		let name = OsStr::new("user.omp-symlink-test");
+		for (path, value) in
+			[(&source_target, &b"source-value"[..]), (&destination_target, &b"destination-value"[..])]
+		{
+			if let Err(error) = set_xattr(path, name, value) {
+				if matches!(error.raw_os_error(), Some(libc::EOPNOTSUPP | libc::EPERM)) {
+					return Ok(());
+				}
+				return Err(error);
+			}
+		}
+
+		let source_link = source_dir.join("link");
+		let destination_link = destination_dir.join("link");
+		symlink("target", &source_link)?;
+		symlink("target", &destination_link)?;
+
+		copy_xattrs(&source_link, &destination_link)?;
+
+		let destination_attrs = retrieve_xattrs(&destination_target)?;
+		assert_eq!(
+			destination_attrs.get(name).map(Vec::as_slice),
+			Some(b"destination-value".as_slice())
+		);
 		Ok(())
 	}
 }

--- a/crates/shell-builtins/src/support/xattr.rs
+++ b/crates/shell-builtins/src/support/xattr.rs
@@ -1,9 +1,16 @@
 //! Minimal extended-attribute probes used by `ls` and `mkdir`.
 
-#[cfg(all(unix, not(any(target_os = "android", target_os = "macos"))))]
-use std::path::Path;
 #[cfg(target_os = "linux")]
-use std::{ffi, io, ptr};
+use std::{ffi, ptr};
+#[cfg(all(unix, not(any(target_os = "macos", target_os = "redox"))))]
+use std::{
+	ffi::{OsStr, OsString},
+	io,
+	path::Path,
+};
+
+#[cfg(all(unix, not(any(target_os = "macos", target_os = "redox"))))]
+use omp_core::FastHashMap;
 
 /// Returns whether a path has at least one extended ACL or attribute.
 #[cfg(all(unix, not(any(target_os = "android", target_os = "macos"))))]
@@ -94,6 +101,83 @@ fn get_xattr(path: &Path, name: &[u8]) -> io::Result<Vec<u8>> {
 	value.truncate(read as usize);
 	Ok(value)
 }
+/// Reads every extended attribute attached to `path`.
+#[cfg(all(unix, not(any(target_os = "macos", target_os = "redox"))))]
+pub(crate) fn retrieve_xattrs(
+	path: impl AsRef<Path>,
+) -> io::Result<FastHashMap<OsString, Vec<u8>>> {
+	#[cfg(target_os = "linux")]
+	{
+		use std::os::unix::ffi::OsStringExt;
+
+		let path = path.as_ref();
+		let names = list_xattrs(path)?;
+		let mut attrs = FastHashMap::default();
+		for name in names
+			.split(|byte| *byte == 0)
+			.filter(|name| !name.is_empty())
+		{
+			let mut terminated_name = Vec::with_capacity(name.len() + 1);
+			terminated_name.extend_from_slice(name);
+			terminated_name.push(0);
+			attrs.insert(OsString::from_vec(name.to_vec()), get_xattr(path, &terminated_name)?);
+		}
+		return Ok(attrs);
+	}
+	#[cfg(not(target_os = "linux"))]
+	{
+		let _ = path;
+		Ok(FastHashMap::default())
+	}
+}
+
+/// Applies extended attributes to `path`.
+#[cfg(all(unix, not(any(target_os = "macos", target_os = "redox"))))]
+pub(crate) fn apply_xattrs(
+	path: impl AsRef<Path>,
+	xattrs: FastHashMap<OsString, Vec<u8>>,
+) -> io::Result<()> {
+	#[cfg(target_os = "linux")]
+	{
+		let path = path.as_ref();
+		for (name, value) in xattrs {
+			set_xattr(path, &name, &value)?;
+		}
+		return Ok(());
+	}
+	#[cfg(not(target_os = "linux"))]
+	{
+		let _ = (path, xattrs);
+		Ok(())
+	}
+}
+
+/// Copies every extended attribute from `source` to `destination`.
+#[cfg(all(unix, not(any(target_os = "macos", target_os = "redox"))))]
+pub(crate) fn copy_xattrs(
+	source: impl AsRef<Path>,
+	destination: impl AsRef<Path>,
+) -> io::Result<()> {
+	let xattrs = retrieve_xattrs(source)?;
+	apply_xattrs(destination, xattrs)
+}
+
+#[cfg(target_os = "linux")]
+fn set_xattr(path: &Path, name: &OsStr, value: &[u8]) -> io::Result<()> {
+	use std::os::unix::ffi::OsStrExt;
+
+	let path = path_cstring(path)?;
+	let name = ffi::CString::new(name.as_bytes())
+		.map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "attribute name contains NUL"))?;
+	// SAFETY: both C strings and the value slice remain live for the call.
+	let result = unsafe {
+		libc::setxattr(path.as_ptr(), name.as_ptr(), value.as_ptr().cast(), value.len(), 0)
+	};
+	if result < 0 {
+		return Err(io::Error::last_os_error());
+	}
+	Ok(())
+}
 
 #[cfg(target_os = "linux")]
 fn parse_default_acl_permissions(value: &[u8]) -> Option<u32> {
@@ -135,5 +219,27 @@ mod tests {
 			value.extend_from_slice(&u32::MAX.to_le_bytes());
 		}
 		assert_eq!(parse_default_acl_permissions(&value), Some(0o741));
+	}
+
+	#[test]
+	fn copies_extended_attributes() -> io::Result<()> {
+		let directory = tempfile::tempdir()?;
+		let source = directory.path().join("source");
+		let destination = directory.path().join("destination");
+		std::fs::write(&source, b"source")?;
+		std::fs::write(&destination, b"destination")?;
+
+		let name = OsStr::new("user.omp-test");
+		if let Err(error) = set_xattr(&source, name, b"value") {
+			if matches!(error.raw_os_error(), Some(libc::EOPNOTSUPP | libc::EPERM)) {
+				return Ok(());
+			}
+			return Err(error);
+		}
+
+		copy_xattrs(&source, &destination)?;
+		let copied = retrieve_xattrs(&destination)?;
+		assert_eq!(copied.get(name).map(Vec::as_slice), Some(b"value".as_slice()));
+		Ok(())
 	}
 }

--- a/crates/tui/src/components/table.rs
+++ b/crates/tui/src/components/table.rs
@@ -286,11 +286,11 @@ impl TableCell {
 	/// that cannot join a single-line flatten (images, containers).
 	fn flatten_run<'a>(child: &'a mut Cached, ctx: &UiContext) -> Option<(&'a Str, Style)> {
 		let style = child.comp().props().style(&ctx.theme);
-		let comp = child.comp_mut();
-		if let Some(pre) = comp.downcast_mut::<Pre>() {
+		let comp = child.comp();
+		if let Some(pre) = comp.downcast_ref::<Pre>() {
 			return Some((pre.content(), style));
 		}
-		if let Some(text) = comp.downcast_mut::<TextLeaf>() {
+		if let Some(text) = comp.downcast_ref::<TextLeaf>() {
 			return Some((text.content(), style));
 		}
 		None


### PR DESCRIPTION
## Summary

Portable fixes extracted from the Termux bring-up. No Android target/profile code is included.

- fix Linux compilation around 128-bit atomics, desktop imports/types, Apple FM stubs, and xattr handling
- reopen Unix document-authority handles with descriptor-relative `openat(".")` instead of relying on cloned/procfs-backed handles
- derive Linux process boot epochs from `/proc/stat` with bounded fallbacks and exact integer clock-tick conversion
- normalize OpenAI tool schemas without changing open-map semantics; downgrade strict mode when the schema cannot be represented strictly
- preserve provider error detail and Responses reasoning proofs
- terminate Responses transports on authoritative terminal envelopes
- replay assistant continuation text as `output_text` and preserve explicit empty reasoning summaries

## Verification

Executed on the native Termux/aarch64 development host:

- `cargo fmt --all -- --check`
- `just check-pkg omp-docserver`
- `PYO3_CONFIG_FILE=vendor/python-android/pyo3-config.txt cargo check -p omp-inference --tests --locked`
- built the `omp-docserver` and `omp-inference` test executables
- document-authority reentry and rename tests: 2 passed
- OpenAI schema normalization regressions: 5 passed
- Responses continuation, terminal-envelope, and reasoning-proof regressions: 3 passed

`omp-envd` cannot be checked from this portable-only branch on Android because upstream's desktop `omp-py` build requires the python-build-standalone vendor tree. The stacked Android branch supplies its native Termux CPython integration and validates the joined binary.

## Stack

This is the portable base. Android/Termux target support is maintained separately on the fork and is stacked on this branch.