### PR TITLE
fix(tui): honor tui.hyperlinks setting for chat markdown links

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed chat markdown links and bare URLs not becoming OSC 8 hyperlinks under `tui.hyperlinks=always`, so they are now clickable consistently with file/path links ([#10195](https://github.com/can1357/oh-my-pi/issues/10195)).
+
 ## [18.0.10] - 2026-08-28
 
 ### Added

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -38,6 +38,7 @@ import { isLightTheme, setAutoThemeMapping, setColorBlindMode, setSymbolPreset }
 import { AgentStorage } from "../session/agent-storage";
 import { type CompactionMethod, DEFAULT_COMPACTION_METHOD_ORDER } from "../session/compaction-methods";
 import { AUTO_IMAGE_PROVIDER_ORDER, isImageProviderId } from "../tools/image-providers";
+import { applyHyperlinkSetting } from "../tui/hyperlink";
 import { replaceFileAtomically } from "../utils/atomic-file";
 import { type EditMode, normalizeEditMode } from "../utils/edit-mode";
 import { INSPECT_IMAGE_MODES } from "../utils/inspect-image-mode";
@@ -2759,6 +2760,11 @@ const SETTING_HOOKS: Partial<Record<SettingPath, SettingHook<any>>> = {
 			});
 		}
 	},
+	// A project-scoped reload (`/move`, cross-project resume, rollback) can change
+	// the effective value; reapply so pi-tui renderers gating on the shared flag
+	// track it the same instant path/resource links do. Runtime `/settings` edits
+	// go through the selector controller instead (`set()` does not fire hooks).
+	"tui.hyperlinks": () => applyHyperlinkSetting(),
 	"provider.appendOnlyContext": value => {
 		if (typeof value === "string") {
 			appendOnlyModeSignal.fire(value);

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -80,6 +80,7 @@ import {
 import { AskTool, type AskToolDetails, type AskToolInput } from "../../tools/ask";
 import { shortenPath } from "../../tools/render-utils";
 import { ToolAbortError } from "../../tools/tool-errors";
+import { applyHyperlinkSetting } from "../../tui/hyperlink";
 import { copyToClipboard } from "../../utils/clipboard";
 import { setSessionTerminalTitle } from "../../utils/title-generator";
 import { type AdvisorConfigDeps, AdvisorConfigOverlayComponent } from "../components/advisor-config";
@@ -618,6 +619,12 @@ export class SelectorController {
 				break;
 			case "tui.tight":
 				setTuiTight(value as boolean);
+				this.ctx.ui.invalidate();
+				this.ctx.ui.requestRender();
+				break;
+			case "tui.hyperlinks":
+				applyHyperlinkSetting();
+				this.ctx.statusLine.invalidate();
 				this.ctx.ui.invalidate();
 				this.ctx.ui.requestRender();
 				break;

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -30,7 +30,6 @@ import {
 	Loader,
 	Markdown,
 	Spacer,
-	setTerminalHyperlinks,
 	setTerminalTextSizing,
 	setTuiTight,
 	TERMINAL,
@@ -140,7 +139,7 @@ import {
 	todoMatchesAnyDescription,
 } from "../tools/todo";
 import { vocalizer } from "../tts/vocalizer";
-import { isHyperlinkEnabled } from "../tui/hyperlink";
+import { applyHyperlinkSetting } from "../tui/hyperlink";
 import { renderTreeList } from "../tui/tree-list";
 import { formatStartupChangelogSummary, type StartupChangelogSelection } from "../utils/changelog";
 import { copyToClipboard } from "../utils/clipboard";
@@ -931,11 +930,8 @@ export class InteractiveMode implements InteractiveModeContext {
 		// capability (`TERMINAL.supportsTextSizing` defaults on for Kitty) so it stays off
 		// unless the user opts in, and never emits raw escapes on other terminals.
 		setTerminalTextSizing(settings.get("tui.textSizing") && TERMINAL.supportsTextSizing);
-		// Route the resolved `tui.hyperlinks` policy into TERMINAL.hyperlinks so
-		// renderers that gate on the raw capability flag (the Markdown component's
-		// `[text](url)`/bare-URL links, status-line PR links) honor `off`/`always`
-		// the same way the path/resource links do via isHyperlinkEnabled().
-		setTerminalHyperlinks(isHyperlinkEnabled());
+		// Keep generic pi-tui renderers aligned with the coding-agent setting.
+		applyHyperlinkSetting();
 		this.chatContainer = new TranscriptContainer();
 		this.pendingMessagesContainer = new AnchoredLiveContainer();
 		this.statusContainer = new StatusHudContainer(this);

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -30,6 +30,7 @@ import {
 	Loader,
 	Markdown,
 	Spacer,
+	setTerminalHyperlinks,
 	setTerminalTextSizing,
 	setTuiTight,
 	TERMINAL,
@@ -139,6 +140,7 @@ import {
 	todoMatchesAnyDescription,
 } from "../tools/todo";
 import { vocalizer } from "../tts/vocalizer";
+import { isHyperlinkEnabled } from "../tui/hyperlink";
 import { renderTreeList } from "../tui/tree-list";
 import { formatStartupChangelogSummary, type StartupChangelogSelection } from "../utils/changelog";
 import { copyToClipboard } from "../utils/clipboard";
@@ -929,6 +931,11 @@ export class InteractiveMode implements InteractiveModeContext {
 		// capability (`TERMINAL.supportsTextSizing` defaults on for Kitty) so it stays off
 		// unless the user opts in, and never emits raw escapes on other terminals.
 		setTerminalTextSizing(settings.get("tui.textSizing") && TERMINAL.supportsTextSizing);
+		// Route the resolved `tui.hyperlinks` policy into TERMINAL.hyperlinks so
+		// renderers that gate on the raw capability flag (the Markdown component's
+		// `[text](url)`/bare-URL links, status-line PR links) honor `off`/`always`
+		// the same way the path/resource links do via isHyperlinkEnabled().
+		setTerminalHyperlinks(isHyperlinkEnabled());
 		this.chatContainer = new TranscriptContainer();
 		this.pendingMessagesContainer = new AnchoredLiveContainer();
 		this.statusContainer = new StatusHudContainer(this);

--- a/packages/coding-agent/src/tui/hyperlink.ts
+++ b/packages/coding-agent/src/tui/hyperlink.ts
@@ -6,7 +6,7 @@
  * permits it. Falls back to plain text when disabled.
  */
 import * as url from "node:url";
-import { TERMINAL } from "@oh-my-pi/pi-tui";
+import { setTerminalHyperlinks, TERMINAL } from "@oh-my-pi/pi-tui";
 import { isSettingsInitialized, settings } from "../config/settings";
 import {
 	LocalProtocolHandler,
@@ -19,6 +19,8 @@ import {
 const OSC = "\x1b]";
 const ST = "\x1b\\";
 const BEL = "\x07";
+
+const DETECTED_TERMINAL_HYPERLINKS = TERMINAL.hyperlinks;
 
 /** Stable 8-char hex ID derived from a URI — hints terminals to coalesce identical adjacent links. */
 function buildLinkId(uri: string): string {
@@ -56,6 +58,20 @@ export function isHyperlinkEnabled(): boolean {
 	if (Bun.env.NO_COLOR) return false;
 	if (!process.stdout.isTTY) return false;
 	return TERMINAL.hyperlinks;
+}
+
+/**
+ * Apply the current `tui.hyperlinks` policy to renderers that read
+ * {@link TERMINAL}.hyperlinks directly.
+ *
+ * Auto mode first restores the process-start capability because prior
+ * `always`/`off` applications overwrite the mutable runtime flag.
+ */
+export function applyHyperlinkSetting(): void {
+	if (isSettingsInitialized() && settings.get("tui.hyperlinks") === "auto") {
+		setTerminalHyperlinks(DETECTED_TERMINAL_HYPERLINKS);
+	}
+	setTerminalHyperlinks(isHyperlinkEnabled());
 }
 
 function safeHyperlinkUri(uri: string): string | undefined {

--- a/packages/coding-agent/src/tui/hyperlink.ts
+++ b/packages/coding-agent/src/tui/hyperlink.ts
@@ -20,6 +20,12 @@ const OSC = "\x1b]";
 const ST = "\x1b\\";
 const BEL = "\x07";
 
+/**
+ * The terminal's detected OSC 8 capability, captured once at import before any
+ * policy application mutates {@link TERMINAL}.hyperlinks. `auto` resolves against
+ * this immutable value so a prior `always`/`off` selection can never poison
+ * detection when the user switches back to `auto`.
+ */
 const DETECTED_TERMINAL_HYPERLINKS = TERMINAL.hyperlinks;
 
 /** Stable 8-char hex ID derived from a URI — hints terminals to coalesce identical adjacent links. */
@@ -54,23 +60,24 @@ export function isHyperlinkEnabled(): boolean {
 	const mode = settings.get("tui.hyperlinks");
 	if (mode === "off") return false;
 	if (mode === "always") return true;
-	// auto: respect terminal capabilities and NO_COLOR
+	// auto: respect the detected capability (immutable snapshot, not the mutable
+	// runtime flag that applyHyperlinkSetting overwrites) and NO_COLOR.
 	if (Bun.env.NO_COLOR) return false;
 	if (!process.stdout.isTTY) return false;
-	return TERMINAL.hyperlinks;
+	return DETECTED_TERMINAL_HYPERLINKS;
 }
 
 /**
- * Apply the current `tui.hyperlinks` policy to renderers that read
- * {@link TERMINAL}.hyperlinks directly.
+ * Push the resolved `tui.hyperlinks` policy into {@link TERMINAL}.hyperlinks, the
+ * effective flag that pi-tui renderers gating on it directly — the Markdown
+ * component's `[text](url)`/bare-URL links and the status-line PR link — consult.
  *
- * Auto mode first restores the process-start capability because prior
- * `always`/`off` applications overwrite the mutable runtime flag.
+ * Detection stays immutable in {@link DETECTED_TERMINAL_HYPERLINKS}, so this only
+ * ever writes the effective decision; `auto` transitions restore real detection
+ * via {@link isHyperlinkEnabled}. Called at TUI startup and whenever the setting
+ * changes at runtime.
  */
 export function applyHyperlinkSetting(): void {
-	if (isSettingsInitialized() && settings.get("tui.hyperlinks") === "auto") {
-		setTerminalHyperlinks(DETECTED_TERMINAL_HYPERLINKS);
-	}
 	setTerminalHyperlinks(isHyperlinkEnabled());
 }
 

--- a/packages/coding-agent/test/selector-settings-side-effects.test.ts
+++ b/packages/coding-agent/test/selector-settings-side-effects.test.ts
@@ -16,6 +16,7 @@ import { getThemeByName, setThemeInstance } from "@oh-my-pi/pi-coding-agent/mode
 import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
 import type { ResolvedRoleModel } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AUTO_THINKING } from "@oh-my-pi/pi-coding-agent/thinking";
+import { setTerminalHyperlinks, TERMINAL } from "@oh-my-pi/pi-tui";
 import { removeSyncWithRetries, Snowflake } from "@oh-my-pi/pi-utils";
 import { beginSettingsTest, restoreSettingsTestState, type SettingsTestState } from "./helpers/settings-test-state";
 
@@ -66,6 +67,32 @@ describe("selector setting side effects", () => {
 
 		expect(invalidate).toHaveBeenCalledTimes(1);
 		expect(requestRender).toHaveBeenCalledTimes(1);
+	});
+	it("applies tui.hyperlinks changes to live renderers", () => {
+		const originalHyperlinks = TERMINAL.hyperlinks;
+		const statusInvalidate = vi.fn();
+		const invalidate = vi.fn();
+		const requestRender = vi.fn();
+		const controller = new SelectorController({
+			statusLine: { invalidate: statusInvalidate },
+			ui: { invalidate, requestRender },
+		} as unknown as InteractiveModeContext);
+
+		try {
+			setTerminalHyperlinks(false);
+			Settings.instance.override("tui.hyperlinks", "always");
+			controller.handleSettingChange("tui.hyperlinks", "always");
+			expect(TERMINAL.hyperlinks).toBe(true);
+
+			Settings.instance.override("tui.hyperlinks", "off");
+			controller.handleSettingChange("tui.hyperlinks", "off");
+			expect(TERMINAL.hyperlinks).toBe(false);
+			expect(statusInvalidate).toHaveBeenCalledTimes(2);
+			expect(invalidate).toHaveBeenCalledTimes(2);
+			expect(requestRender).toHaveBeenCalledTimes(2);
+		} finally {
+			setTerminalHyperlinks(originalHyperlinks);
+		}
 	});
 	it("applies memory backend changes to the live session", () => {
 		const applyMemoryBackend = vi.fn(async () => {});

--- a/packages/coding-agent/test/tui/hyperlink.test.ts
+++ b/packages/coding-agent/test/tui/hyperlink.test.ts
@@ -1,4 +1,5 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test";
+import * as os from "node:os";
 import * as path from "node:path";
 import * as url from "node:url";
 import { resetSettingsForTest, Settings, settings } from "@oh-my-pi/pi-coding-agent/config/settings";
@@ -361,5 +362,30 @@ describe("chat markdown links honor tui.hyperlinks", () => {
 		const output = renderChatLink();
 		expect(output).toContain("the docs");
 		expect(output.includes(`${OSC}8;`)).toBe(false);
+	});
+});
+
+describe("applyHyperlinkSetting on project-scoped reload", () => {
+	// A cross-project reload (`/move`, resume, rollback) fires SETTING_HOOKS via
+	// Settings.reloadForCwd → the tui.hyperlinks hook reapplies the policy, so
+	// renderers gating on TERMINAL.hyperlinks never keep the previous project's
+	// value while path links already track the new one (#10196 review).
+	it("reapplies the effective policy so the runtime flag tracks the reloaded setting", async () => {
+		const origHyperlinks = terminalCaps.TERMINAL.hyperlinks;
+		const dirA = path.join(os.tmpdir(), "omp-hyperlink-reload-a");
+		const dirB = path.join(os.tmpdir(), "omp-hyperlink-reload-b");
+		try {
+			terminalCaps.setTerminalHyperlinks(false);
+			settings.override("tui.hyperlinks", "always");
+			await settings.reloadForCwd(dirA);
+			expect(terminalCaps.TERMINAL.hyperlinks).toBe(true);
+
+			settings.override("tui.hyperlinks", "off");
+			await settings.reloadForCwd(dirB);
+			expect(terminalCaps.TERMINAL.hyperlinks).toBe(false);
+		} finally {
+			settings.clearOverride("tui.hyperlinks");
+			terminalCaps.setTerminalHyperlinks(origHyperlinks);
+		}
 	});
 });

--- a/packages/coding-agent/test/tui/hyperlink.test.ts
+++ b/packages/coding-agent/test/tui/hyperlink.test.ts
@@ -22,6 +22,9 @@ const ST = "\x1b\\";
 const BEL = "\x07";
 const LINK_END = `${OSC}8;;${ST}`;
 const ORIGINAL_NO_COLOR = Bun.env.NO_COLOR;
+// Detected OSC 8 capability, captured at import exactly as hyperlink.ts snapshots
+// it — before any test mutates the runtime flag.
+const DETECTED_HYPERLINKS = terminalCaps.TERMINAL.hyperlinks;
 
 /** Extract the hyperlink URI from a wrapped string. Returns undefined if not wrapped. */
 function extractLinkUri(text: string): string | undefined {
@@ -104,17 +107,21 @@ describe("isHyperlinkEnabled", () => {
 		}
 	});
 
-	it("returns TERMINAL.hyperlinks value in auto mode when conditions are met", () => {
+	it("resolves auto against detected capability, immune to runtime flag mutation", () => {
 		setHyperlinkMode("auto");
 		delete Bun.env.NO_COLOR;
 		const origTTY = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
+		const origHyperlinks = terminalCaps.TERMINAL.hyperlinks;
 		try {
 			Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true });
-			// TERMINAL.hyperlinks may be true or false depending on the test runner env;
-			// what matters is that isHyperlinkEnabled mirrors it.
-			const expected = terminalCaps.TERMINAL.hyperlinks;
-			expect(isHyperlinkEnabled()).toBe(expected);
+			// auto mirrors the capability detected at import...
+			expect(isHyperlinkEnabled()).toBe(DETECTED_HYPERLINKS);
+			// ...and a prior always/off application that flipped the runtime flag
+			// must not poison it (regression: #10196 review).
+			terminalCaps.setTerminalHyperlinks(!DETECTED_HYPERLINKS);
+			expect(isHyperlinkEnabled()).toBe(DETECTED_HYPERLINKS);
 		} finally {
+			terminalCaps.setTerminalHyperlinks(origHyperlinks);
 			if (origTTY) {
 				Object.defineProperty(process.stdout, "isTTY", origTTY);
 			} else {

--- a/packages/coding-agent/test/tui/hyperlink.test.ts
+++ b/packages/coding-agent/test/tui/hyperlink.test.ts
@@ -6,6 +6,7 @@ import { LocalProtocolHandler } from "@oh-my-pi/pi-coding-agent/internal-urls/lo
 import { getMarkdownTheme, initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import { AgentRegistry } from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
 import {
+	applyHyperlinkSetting,
 	fileHyperlink,
 	isHyperlinkEnabled,
 	tryResolveInternalUrlSync,
@@ -315,11 +316,9 @@ describe("tryResolveInternalUrlSync", () => {
 });
 
 describe("chat markdown links honor tui.hyperlinks", () => {
-	// The Markdown renderer gates OSC 8 on the raw TERMINAL.hyperlinks capability
-	// flag, so the coding-agent routes the resolved `tui.hyperlinks` policy into it
-	// via setTerminalHyperlinks(isHyperlinkEnabled()) at TUI startup. These tests
-	// exercise that exact wiring so a `[text](url)` chat link tracks the setting the
-	// same way path/resource links already do (issue #10195).
+	// The Markdown renderer gates OSC 8 on TERMINAL.hyperlinks. The coding-agent
+	// applies its setting to that shared flag so chat links track path/resource
+	// links (issue #10195).
 	const originalHyperlinks = terminalCaps.TERMINAL.hyperlinks;
 
 	beforeAll(async () => {
@@ -330,7 +329,7 @@ describe("chat markdown links honor tui.hyperlinks", () => {
 	});
 
 	function renderChatLink(): string {
-		terminalCaps.setTerminalHyperlinks(isHyperlinkEnabled());
+		applyHyperlinkSetting();
 		const md = new terminalCaps.Markdown(
 			"See [the docs](https://example.com/path) for details.",
 			0,

--- a/packages/coding-agent/test/tui/hyperlink.test.ts
+++ b/packages/coding-agent/test/tui/hyperlink.test.ts
@@ -3,6 +3,7 @@ import * as path from "node:path";
 import * as url from "node:url";
 import { resetSettingsForTest, Settings, settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { LocalProtocolHandler } from "@oh-my-pi/pi-coding-agent/internal-urls/local-protocol";
+import { getMarkdownTheme, initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import { AgentRegistry } from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
 import {
 	fileHyperlink,
@@ -310,5 +311,49 @@ describe("tryResolveInternalUrlSync", () => {
 	it("swallows errors from malformed URLs", () => {
 		// Malformed input should not throw, just return undefined.
 		expect(tryResolveInternalUrlSync("local://%ZZ")).toBeUndefined();
+	});
+});
+
+describe("chat markdown links honor tui.hyperlinks", () => {
+	// The Markdown renderer gates OSC 8 on the raw TERMINAL.hyperlinks capability
+	// flag, so the coding-agent routes the resolved `tui.hyperlinks` policy into it
+	// via setTerminalHyperlinks(isHyperlinkEnabled()) at TUI startup. These tests
+	// exercise that exact wiring so a `[text](url)` chat link tracks the setting the
+	// same way path/resource links already do (issue #10195).
+	const originalHyperlinks = terminalCaps.TERMINAL.hyperlinks;
+
+	beforeAll(async () => {
+		await initTheme();
+	});
+	afterEach(() => {
+		terminalCaps.TERMINAL.hyperlinks = originalHyperlinks;
+	});
+
+	function renderChatLink(): string {
+		terminalCaps.setTerminalHyperlinks(isHyperlinkEnabled());
+		const md = new terminalCaps.Markdown(
+			"See [the docs](https://example.com/path) for details.",
+			0,
+			0,
+			getMarkdownTheme(),
+		);
+		return md.render(80).join("\n");
+	}
+
+	it('wraps the link in OSC 8 under "always" even when the terminal did not advertise support', () => {
+		terminalCaps.TERMINAL.hyperlinks = false;
+		setHyperlinkMode("always");
+		const output = renderChatLink();
+		// The Markdown renderer terminates OSC 8 with BEL, so match either terminator.
+		expect(output.includes(`${OSC}8;`)).toBe(true);
+		expect(extractAnyTerminatorLinkUri(output)).toBe("https://example.com/path");
+	});
+
+	it('suppresses the OSC 8 wrap under "off" even when the terminal advertised support', () => {
+		terminalCaps.TERMINAL.hyperlinks = true;
+		setHyperlinkMode("off");
+		const output = renderChatLink();
+		expect(output).toContain("the docs");
+		expect(output.includes(`${OSC}8;`)).toBe(false);
 	});
 });

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `setTerminalHyperlinks()` so hosts can route their OSC 8 hyperlink policy into the Markdown renderer's link wrapping.
+
 ## [18.0.10] - 2026-08-28
 
 ### Added

--- a/packages/tui/src/terminal-capabilities.ts
+++ b/packages/tui/src/terminal-capabilities.ts
@@ -676,6 +676,18 @@ export function setTerminalTextSizing(enabled: boolean): void {
 	TERMINAL.textSizing = enabled;
 }
 
+/**
+ * Override OSC 8 hyperlink capability at runtime. The coding-agent calls this
+ * from the `tui.hyperlinks` setting so its resolved policy (`off`/`auto`/`always`)
+ * drives every renderer that gates on {@link TERMINAL}`.hyperlinks` — notably the
+ * Markdown component's `[text](url)`/bare-URL links — consistently with the
+ * path/resource links that already consult the setting directly. Tests flip it
+ * to exercise the OSC 8 and plain-text paths deterministically.
+ */
+export function setTerminalHyperlinks(enabled: boolean): void {
+	TERMINAL.hyperlinks = enabled;
+}
+
 export function getTerminalInfo(
 	terminalId: TerminalId,
 	platform: NodeJS.Platform = process.platform,


### PR DESCRIPTION
## Repro
With `tui.hyperlinks=always` on a terminal that did not advertise OSC 8 support (e.g. `TERM=tmux-256color`, or macOS Ghostty), a chat markdown link `[text](url)` or a bare URL renders as underlined plain text with no OSC 8 sequence, while file/path links are clickable. Reproduced by rendering `See [the docs](https://example.com/path) for details.` through the `Markdown` component with `Settings` set to `tui.hyperlinks=always` and `TERMINAL.hyperlinks=false`:

```
tui.hyperlinks = always
TERMINAL.hyperlinks = false
chat markdown link emits OSC 8: false
file path link emits OSC 8:    true
```

## Cause
pi-tui's Markdown renderer wraps links via `formatHyperlink()` in `packages/tui/src/components/markdown.ts`, which gates OSC 8 solely on the detected capability flag `TERMINAL.hyperlinks`. That flag is written only by `shouldEnableHyperlinksByDefault()` (`packages/tui/src/terminal-capabilities.ts`) from env overrides + the static per-terminal table; the `tui.hyperlinks` user setting never flows into it. File/path links instead go through coding-agent's `isHyperlinkEnabled()` (`packages/coding-agent/src/tui/hyperlink.ts`), which returns true unconditionally for mode `always`. The two gates disagree, producing the reported asymmetry (and, symmetrically, `off` failed to suppress markdown links when detection was on).

## Fix
- Add `setTerminalHyperlinks(enabled)` to `packages/tui/src/terminal-capabilities.ts`, mirroring `setTerminalTextSizing`, so a host can drive the flag the Markdown renderer reads.
- At TUI startup in `packages/coding-agent/src/modes/interactive-mode.ts`, call `setTerminalHyperlinks(isHyperlinkEnabled())` alongside the existing `setTerminalTextSizing` line, routing the resolved `tui.hyperlinks` policy (`off`/`auto`/`always`) into `TERMINAL.hyperlinks`. Chat markdown links, bare URLs, and the status-line PR link now track the setting the same way path/resource links already did.
- Changelog entries for both packages.

## Verification
`bun test test/tui/hyperlink.test.ts` (30 pass) with two added cases under `chat markdown links honor tui.hyperlinks`: a `[text](url)` link is OSC 8 wrapped under `always` even when `TERMINAL.hyperlinks=false`, and suppressed under `off` even when `TERMINAL.hyperlinks=true`. Manually confirmed the repro flips from `false` to `true` after wiring the setter. Fixes #10195