### PR TITLE
fix(sharpshooter): refuse all-empty replacement to prevent memory wipe

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -529,6 +529,8 @@
 - Added repeat read warning hints when identical file content is read multiple times.
 - Explicit DAP adapters can now attach without a PID or port when `attachDefaults` provide the target arguments.
 - Added `isProjectTrusted()` compatibility shim to `ExtensionContext` for extensions targeting upstream per-directory trust gates.
+- Added `/reload-settings` slash command (`/reload-config`): re-reads the global, project, and overlay config layers from disk and applies them to the live session without a restart, reporting which effective settings changed.
+- `/reload-settings` also reloads `models.yml` (custom providers/models) and refreshes the model catalog live, so models added mid-session appear in `/models` and `/switch` without a restart.
 
 ### Changed
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Sharpshooter consolidation no longer wipes memory files when the model returns an all-empty replacement; the error is recorded and queued deltas are preserved.
+
 ## [18.0.10] - 2026-08-28
 
 ### Added

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -632,6 +632,10 @@ export class ModelRegistry {
 			return;
 		}
 		this.#modelsConfigFile.invalidate();
+		// Snapshot the config-sourced API keys BEFORE the clear so a malformed
+		// models.yml (parse error) can restore them: the last-good provider keys
+		// must survive until the file is repaired, not vanish with the failed parse.
+		const lastGoodConfigApiKeys = new Map(this.#customProviderApiKeys);
 		this.#customProviderApiKeys.clear();
 		this.#keylessProviders.clear();
 		this.#discoverableProviders = [];
@@ -648,7 +652,7 @@ export class ModelRegistry {
 		this.#modelOverrides.clear();
 		this.#configError = undefined;
 		this.#providerDiscoveryStates.clear();
-		this.#loadModels();
+		this.#loadModels(lastGoodConfigApiKeys);
 	}
 
 	/**
@@ -658,7 +662,17 @@ export class ModelRegistry {
 		return this.#configError;
 	}
 
-	#loadModels() {
+	#loadModels(lastGoodConfigApiKeys?: Map<string, string>) {
+		// Snapshot the last-good custom layer BEFORE reset so a malformed
+		// models.yml (status "error") restores the previous valid catalog instead
+		// of installing the empty custom layer + dropped config keys.
+		const lastGood = {
+			customModels: this.#customModelOverlays,
+			providerOverrides: this.#providerOverrides,
+			modelOverrides: this.#modelOverrides,
+			keylessProviders: this.#keylessProviders,
+			discoverableProviders: this.#discoverableProviders,
+		};
 		this.#resetStaticComposition();
 		// Load custom config first (to know which providers to override).
 		const {
@@ -671,11 +685,29 @@ export class ModelRegistry {
 			error: configError,
 		} = logger.time("modelRegistry:loadCustomModels", () => this.#loadCustomModels());
 		this.#configError = configError;
-		this.#keylessProviders = keylessProviders;
-		this.#discoverableProviders = discoverableProviders;
-		this.#customModelOverlays = customModels;
-		this.#providerOverrides = overrides;
-		this.#modelOverrides = modelOverrides;
+		// On a parse failure keep the last-good custom layer: dropping it loses
+		// every valid custom model/provider until the file is repaired. The error
+		// still surfaces via getError() so the reload reports the failure; the
+		// prior catalog stays live. Config-sourced API keys are restored too.
+		if (configError) {
+			this.#customModelOverlays = lastGood.customModels;
+			this.#providerOverrides = lastGood.providerOverrides;
+			this.#modelOverrides = lastGood.modelOverrides;
+			this.#keylessProviders = lastGood.keylessProviders;
+			this.#discoverableProviders = lastGood.discoverableProviders;
+			for (const [provider, keyConfig] of lastGoodConfigApiKeys ?? []) {
+				this.#installProviderApiKey(provider, keyConfig);
+			}
+			// configuredProviders comes from the failed parse (none), but the
+			// last-good discoverable set is restored above; implicit add over an
+			// empty configured set is a no-op.
+		} else {
+			this.#customModelOverlays = customModels;
+			this.#providerOverrides = overrides;
+			this.#modelOverrides = modelOverrides;
+			this.#keylessProviders = keylessProviders;
+			this.#discoverableProviders = discoverableProviders;
+		}
 
 		this.#addImplicitDiscoverableProviders(configuredProviders);
 		const configuredDiscoveryProviders = new Set(this.#discoverableProviders.map(provider => provider.provider));

--- a/packages/coding-agent/src/config/model-resolver.ts
+++ b/packages/coding-agent/src/config/model-resolver.ts
@@ -33,6 +33,7 @@ import {
 	AUTO_THINKING,
 	type ConfiguredThinkingLevel,
 	concreteThinkingLevel,
+	parseConfiguredThinkingLevel,
 	parseThinkingLevel,
 	resolveThinkingLevelForModel,
 } from "../thinking";
@@ -1683,6 +1684,52 @@ export async function resolveModelScope(
 	}
 
 	return scopedModels;
+}
+/**
+ * Map resolver scope entries to the session's Ctrl+P cycle shape, filling in the
+ * configured default thinking level for entries without an explicit `:level`
+ * suffix. `auto` is session-level only, so it is coerced to a concrete default here.
+ */
+export function toSessionScopedModels(
+	scopedModels: readonly ScopedModel[],
+	activeSettings: Settings,
+): Array<{ model: Model; thinkingLevel?: ThinkingLevel }> {
+	if (scopedModels.length === 0) return [];
+	const defaultThinkingLevel = concreteThinkingLevel(
+		parseConfiguredThinkingLevel(activeSettings.get("defaultThinkingLevel")),
+	);
+	return scopedModels.map(scopedModel => ({
+		model: scopedModel.model,
+		thinkingLevel: scopedModel.explicitThinkingLevel
+			? (scopedModel.thinkingLevel ?? defaultThinkingLevel)
+			: defaultThinkingLevel,
+	}));
+}
+
+/**
+ * Whether two scope lists are equivalent for the live cycle: identical length,
+ * order, provider/id, thinking level, AND model-record reference. A rebuilt
+ * list is skipped only when it is byte-for-byte identical to what is already
+ * installed. This is the single guard for both scope-rebuild paths — startup's
+ * post-discovery rebuild and `/reload-settings` — so a reorder, a level change
+ * (`foo:low` → `foo:high`), OR a catalog-metadata change (a refresh that swaps
+ * in a new model object for the same provider/id) forces a reinstall: the cycle
+ * must adopt fresh records or later cycling keeps the stale metadata.
+ */
+export function sameScopedModelCycle(
+	a: ReadonlyArray<{ model: Model; thinkingLevel?: ThinkingLevel }>,
+	b: ReadonlyArray<{ model: Model; thinkingLevel?: ThinkingLevel }>,
+): boolean {
+	if (a.length !== b.length) return false;
+	return a.every((entry, index) => {
+		const other = b[index];
+		return (
+			entry.model.provider === other.model.provider &&
+			entry.model.id === other.model.id &&
+			entry.model === other.model &&
+			entry.thinkingLevel === other.thinkingLevel
+		);
+	});
 }
 
 /**

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -785,8 +785,15 @@ export class Settings {
 
 	async #reloadPersistedLayers(): Promise<void> {
 		for (;;) {
-			await this.flush();
+			// Sample the mutation generation BEFORE draining. A mutation that
+			// lands while flush() persists — or in the window between flush and
+			// the disk reads — bumps the generation since this sample and forces
+			// another pass, so the installed layers can never be older than an
+			// in-memory write whose debounced save has not fired yet. Sampling
+			// after flush() instead hides that window: the bump is counted in the
+			// sample itself and the stale read installs unchanged.
 			const mutationGeneration = this.#persistedMutationGeneration;
+			await this.flush();
 			const previousSignaledValues = {
 				modelRoles: this.get("modelRoles"),
 				sessionAccent: this.get("statusLine.sessionAccent"),

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -42,7 +42,12 @@ import {
 	resolveModelRoleValue,
 	resolveModelScope,
 	type ScopedModel,
+	sameScopedModelCycle,
+	toSessionScopedModels,
 } from "./config/model-resolver";
+
+export { toSessionScopedModels };
+
 import { ModelsConfigFile } from "./config/models-config";
 import { serviceTierSettingToTier } from "./config/service-tier";
 import { getDefault, type SettingPath, Settings, type SettingValue, settings } from "./config/settings";
@@ -104,7 +109,6 @@ import { shouldShowStartupSplash } from "./startup-splash";
 import { discoverTitleSystemPromptFile, resolvePromptInput } from "./system-prompt";
 import { createPersistedSubagentReviverFactory } from "./task/persisted-revive";
 import { createTelemetryExportConfig, initTelemetryExport, isTelemetryExportEnabled } from "./telemetry-export";
-import { concreteThinkingLevel, parseConfiguredThinkingLevel } from "./thinking";
 import type { LspStartupServerInfo } from "./tools";
 import { getChangelogPath, resolveStartupChangelogForDisplay, type StartupChangelogSelection } from "./utils/changelog";
 import { EventBus } from "./utils/event-bus";
@@ -824,34 +828,6 @@ export async function resolveScopedModels(
 	return await resolveModelScope(modelPatterns, modelRegistry, preferences, activeSettings);
 }
 
-/**
- * Map resolver scope entries to the session's Ctrl+P cycle shape, filling in the
- * configured default thinking level for entries without an explicit `:level`
- * suffix. `auto` is session-level only, so it is coerced to a concrete default here.
- */
-export function toSessionScopedModels(
-	scopedModels: readonly ScopedModel[],
-	activeSettings: Settings,
-): Array<{ model: Model; thinkingLevel?: ThinkingLevel }> {
-	if (scopedModels.length === 0) return [];
-	const defaultThinkingLevel = concreteThinkingLevel(
-		parseConfiguredThinkingLevel(activeSettings.get("defaultThinkingLevel")),
-	);
-	return scopedModels.map(scopedModel => ({
-		model: scopedModel.model,
-		thinkingLevel: scopedModel.explicitThinkingLevel
-			? (scopedModel.thinkingLevel ?? defaultThinkingLevel)
-			: defaultThinkingLevel,
-	}));
-}
-
-/** Whether two scope lists reference the same set of models (order-independent). */
-function sameScopedModelSet(a: ReadonlyArray<{ model: Model }>, b: ReadonlyArray<{ model: Model }>): boolean {
-	if (a.length !== b.length) return false;
-	const keys = new Set(a.map(entry => `${entry.model.provider}/${entry.model.id}`));
-	return b.every(entry => keys.has(`${entry.model.provider}/${entry.model.id}`));
-}
-
 /** Minimal session surface the post-discovery scope rebuild mutates. */
 export interface ScopedModelSink {
 	readonly isDisposed: boolean;
@@ -890,7 +866,7 @@ export async function rebuildScopedModelsAfterDiscovery(
 		activeSettings,
 	);
 	const mapped = toSessionScopedModels(rebuilt, activeSettings);
-	if (mapped.length === 0 || sameScopedModelSet(session.scopedModels, mapped)) return;
+	if (mapped.length === 0 || sameScopedModelCycle(session.scopedModels, mapped)) return;
 	session.setScopedModels(mapped);
 }
 
@@ -1301,6 +1277,10 @@ export async function buildSessionOptions(
 	if (scopedModels.length > 0) {
 		options.scopedModels = toSessionScopedModels(scopedModels, activeSettings);
 	}
+	// Frozen CLI `--models` scope for /reload-settings: when present the CLI scope
+	// never re-resolves (highest precedence); when absent the session is
+	// settings-derived and refreshScopedModels reads the live enabledModels value.
+	options.cliModelScope = parsed.models && parsed.models.length > 0 ? parsed.models : undefined;
 
 	// API key from CLI - set in authStorage
 	// (handled by caller before createAgentSession)

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -362,6 +362,8 @@ export class StatusLineComponent implements Component {
 	#standaloneGap = false;
 	#autocompleteActiveProbe: (() => boolean) | undefined;
 	#renderRevision = 0;
+	/** Revision bumped when the top border's width epoch changes (two-line overflow row width). */
+	#widthEpochRevision = 0;
 	#settings: StatusLineSettings = {};
 	#effectiveSettings: EffectiveStatusLineSettings | undefined;
 	#cachedBranch: string | null | undefined = undefined;
@@ -475,6 +477,13 @@ export class StatusLineComponent implements Component {
 		daily?: { percent: number; resetMinutes?: number };
 		sevenDay?: { percent: number; resetHours?: number };
 		monthly?: { percent: number; resetHours?: number };
+	} | null = null;
+	// Advisor-scoped share of the same provider reports: the advisor's own
+	// provider/identity, independent of the primary model's. Fetching both from
+	// one report array keeps a single 5-min refresh cycle.
+	#cachedAdvisorUsage: {
+		fiveHour?: { percent: number; resetMinutes?: number };
+		sevenDay?: { percent: number; resetHours?: number };
 	} | null = null;
 	#cachedUsageContextKey: string | null = null;
 	#usageFetchedAt = 0;
@@ -889,6 +898,7 @@ export class StatusLineComponent implements Component {
 
 	invalidate(): void {
 		this.#renderRevision++;
+		this.#widthEpochRevision++;
 		// Generic repaint invalidation (theme change, message event, model
 		// switch, …). Must NOT abort or restart a live reftable HEAD/PR resolve:
 		// the render path self-invalidates via cwd/context cache-miss checks, so
@@ -1340,7 +1350,18 @@ export class StatusLineComponent implements Component {
 		// so switching models must drop the previous model's cached scope instead
 		// of showing it for the rest of the TTL.
 		const activeModelId = session.state.model?.id ?? session.model?.id ?? "";
-		return `${this.#formatUsageContextKey(activeProvider, identity)}\0${activeModelId}`;
+		const parts = [`${this.#formatUsageContextKey(activeProvider, identity)}\0${activeModelId}`];
+		// The advisor share of the same reports is keyed to the advisor's own
+		// accounts; rotation must invalidate the cache the same way the primary's
+		// does. Order is the stable roster order, so the key is render-stable.
+		for (const account of session.getAdvisorUsageAccounts?.() ?? []) {
+			const accountIdentity = session.modelRegistry?.authStorage?.getOAuthAccountIdentity(
+				account.provider,
+				account.providerSessionId ?? session.sessionId,
+			);
+			parts.push(this.#formatUsageContextKey(account.provider, accountIdentity));
+		}
+		return parts.join("\u001e");
 	}
 
 	/**
@@ -1353,6 +1374,7 @@ export class StatusLineComponent implements Component {
 		const usageContextKey = this.#getUsageContextKey(session);
 		if (this.#cachedUsageContextKey !== usageContextKey) {
 			this.#cachedUsage = null;
+			this.#cachedAdvisorUsage = null;
 			this.#usageFetchedAt = 0;
 			this.#cachedUsageContextKey = usageContextKey;
 		}
@@ -1409,10 +1431,12 @@ export class StatusLineComponent implements Component {
 			modelId: activeModelId,
 			identity: activeIdentity,
 		});
+		const advisorUsage = this.#normalizeAdvisorUsage(reports, session.getAdvisorUsageAccounts?.() ?? [], session);
 		const resetSnapshot =
 			activeProvider === "openai-codex" ? this.#normalizeCodexResetSnapshot(reports, activeIdentity) : null;
-		const usageChanged = this.#cachedUsage !== normalized;
+		const usageChanged = this.#cachedUsage !== normalized || this.#cachedAdvisorUsage !== advisorUsage;
 		this.#cachedUsage = normalized;
+		this.#cachedAdvisorUsage = advisorUsage;
 		this.#usageFetchedAt = Date.now();
 		// Usage fetch is async; without a repaint the top border stays blank until
 		// some unrelated event (git resolve, keystroke, …) rebuilds it.
@@ -1690,6 +1714,103 @@ export class StatusLineComponent implements Component {
 	}
 
 	/**
+	 * Advisor-scoped usage windows from the same account-wide fetch. The advisor
+	 * often runs on a different provider/account than the primary model, so the
+	 * match is keyed to each live advisor's own provider + OAuth identity (the
+	 * same derivation the runtime uses to pick the advisor's API key). The
+	 * rendered percent is the worst across the roster — one shared quota pool,
+	 * and the operative number for status. Untiered windows win over tiered
+	 * within a provider, mirroring {@link #normalizeUsageReports}.
+	 */
+	#normalizeAdvisorUsage(
+		reports: unknown,
+		accounts: readonly { provider: string; providerSessionId?: string }[],
+		session: AgentSession,
+	): {
+		fiveHour?: { percent: number; resetMinutes?: number };
+		sevenDay?: { percent: number; resetHours?: number };
+	} | null {
+		if (!Array.isArray(reports) || accounts.length === 0) return null;
+		const authStorage = session.modelRegistry?.authStorage;
+		if (!authStorage?.getOAuthAccountIdentity) return null;
+		const now = Date.now();
+		const fiveHour: { percent: number; resetMinutes?: number; resetHours?: number } = { percent: -1 };
+		const sevenDay: { percent: number; resetMinutes?: number; resetHours?: number } = { percent: -1 };
+		let fiveHourUntiered = false;
+		let sevenDayUntiered = false;
+		const revise = (bucket: typeof fiveHour, percent: number, resetsAt: number | undefined): void => {
+			if (percent <= bucket.percent) return;
+			bucket.percent = percent;
+			if (typeof resetsAt === "number") {
+				bucket.resetMinutes = Math.max(0, Math.round((resetsAt - now) / 60_000));
+				bucket.resetHours = Math.max(0, Math.round((resetsAt - now) / 3_600_000));
+			}
+		};
+		for (const report of reports) {
+			if (!report || typeof report !== "object") continue;
+			const provider = (report as { provider?: unknown }).provider;
+			const limits = (report as { limits?: unknown }).limits;
+			if (!Array.isArray(limits) || typeof provider !== "string") continue;
+			if (!accounts.some(a => a.provider === provider)) continue;
+			const usageReport = report as UsageReport;
+			for (const account of accounts.filter(a => a.provider === provider)) {
+				const identity = authStorage.getOAuthAccountIdentity(
+					provider,
+					account.providerSessionId ?? session.sessionId,
+				);
+				for (const limit of limits) {
+					if (!limit || typeof limit !== "object") continue;
+					if (identity && !limitMatchesActiveAccount(usageReport, limit as UsageLimit, identity)) continue;
+					const l = limit as {
+						scope?: { windowId?: string; tier?: string };
+						window?: { resetsAt?: number; durationMs?: number };
+						amount?: { usedFraction?: number };
+					};
+					const windowClass = this.#advisorUsageWindowClass(l);
+					if (!windowClass) continue;
+					const fraction = l.amount?.usedFraction;
+					if (typeof fraction !== "number") continue;
+					const untiered = !l.scope?.tier;
+					if (windowClass === "5h") {
+						if (untiered) fiveHourUntiered = true;
+						if (fiveHourUntiered && !untiered) continue;
+						revise(fiveHour, fraction * 100, l.window?.resetsAt);
+					} else {
+						if (untiered) sevenDayUntiered = true;
+						if (sevenDayUntiered && !untiered) continue;
+						revise(sevenDay, fraction * 100, l.window?.resetsAt);
+					}
+				}
+			}
+		}
+		const result: {
+			fiveHour?: { percent: number; resetMinutes?: number };
+			sevenDay?: { percent: number; resetHours?: number };
+		} = {};
+		if (fiveHour.percent >= 0) result.fiveHour = { percent: fiveHour.percent, resetMinutes: fiveHour.resetMinutes };
+		if (sevenDay.percent >= 0) result.sevenDay = { percent: sevenDay.percent, resetHours: sevenDay.resetHours };
+		return result.fiveHour || result.sevenDay ? result : null;
+	}
+
+	/**
+	 * Map a reported limit onto the 5h/7d subscription windows. Canonical window
+	 * ids win; a duration within tolerance falls back so cache rows written
+	 * before a provider was canonicalized still map (same tolerance the primary
+	 * normalization uses).
+	 */
+	#advisorUsageWindowClass(l: {
+		scope?: { windowId?: string };
+		window?: { durationMs?: number };
+	}): "5h" | "7d" | undefined {
+		const windowId = l.scope?.windowId;
+		if (windowId === "5h" || windowId === "7d") return windowId;
+		const durationMs = l.window?.durationMs;
+		if (durationMs !== undefined && Math.abs(durationMs - 5 * 3_600_000) <= 60_000) return "5h";
+		if (durationMs !== undefined && Math.abs(durationMs - 7 * 86_400_000) <= 60_000) return "7d";
+		return undefined;
+	}
+
+	/**
 	 * Used-tokens / context-window totals for the status-line context% segment,
 	 * memoized so the per-event redraw stays O(1) when nothing changed.
 	 *
@@ -1839,6 +1960,7 @@ export class StatusLineComponent implements Component {
 			},
 			worktree: activeRepoCache.worktree,
 			usage: this.#cachedUsage,
+			advisorUsage: this.#cachedAdvisorUsage,
 		};
 	}
 
@@ -2049,28 +2171,51 @@ export class StatusLineComponent implements Component {
 		};
 		const totalWidth = () => leftWidth + rightWidth + minimumGapWidth();
 
+		// Segments shed by line 1's size budget move to the overflow line instead
+		// of being lost. Collected here in pop/drop order (right-to-left), then
+		// reversed back to reading order when assembling the second line.
+		const overflowLeft: string[] = [];
+		const overflowRight: string[] = [];
+
 		if (topFillWidth > 0) {
 			// Truncate the session-name segment before dropping right segments —
 			// the title is the only elastic one on the right, and dropping it
 			// wholesale left narrow bars (and the ≤76-col composer previews)
 			// without any title.
+			// The shrink exists to keep the title on line 1 at medium widths. If the
+			// segment is still popped past the floor, the overflow line has no width
+			// budget, so hand it the full (unshrunk) title — popping a chopped copy
+			// would defeat the two-line overflow.
+			let fullName: string | undefined;
+			let shrunkName: string | undefined;
 			const nameSegIdx = rightSegIds.indexOf("session_name");
 			if (nameSegIdx >= 0 && totalWidth() > topFillWidth) {
 				// Badge/job parts were unshifted ahead of the tracked segment ids.
-				const nameIdx = nameSegIdx + (right.length - rightSegIds.length);
-				const currentNameVW = visibleWidth(right[nameIdx]);
+				const nIdx = nameSegIdx + (right.length - rightSegIds.length);
+				const currentNameVW = visibleWidth(right[nIdx]);
 				const minNameVW = 8;
 				const shrinkBy = Math.min(Math.max(0, currentNameVW - minNameVW), totalWidth() - topFillWidth);
 				if (shrinkBy > 0) {
-					right[nameIdx] = truncateToWidth(right[nameIdx], currentNameVW - shrinkBy);
+					fullName = right[nIdx];
+					shrunkName = truncateToWidth(right[nIdx], currentNameVW - shrinkBy);
+					right[nIdx] = shrunkName;
 					rightWidth = groupWidth(right, rightCapWidth, rightSepWidth);
 				}
 			}
 			while (totalWidth() > topFillWidth && right.length > 0) {
-				right.pop();
+				const popped = right.pop();
+				if (popped !== undefined) {
+					// The shrink kept only the title on a narrow bar; when it is popped
+					// to the overflow line there is no width budget, so emit the full
+					// unshrunk title there instead of the chopped copy.
+					overflowRight.push(
+						shrunkName !== undefined && popped === shrunkName && fullName !== undefined ? fullName : popped,
+					);
+				}
 				rightWidth = groupWidth(right, rightCapWidth, rightSepWidth);
 			}
 			// Shrink path before dropping left segments — path is the only elastic segment
+			let fullPath: string | undefined;
 			const pathIdx = leftSegIds.indexOf("path");
 			if (pathIdx >= 0 && totalWidth() > topFillWidth) {
 				const overflow = totalWidth() - topFillWidth;
@@ -2098,7 +2243,8 @@ export class StatusLineComponent implements Component {
 							if (!adjusted.visible || !adjusted.content) break;
 							reRendered = adjusted;
 						}
-						left[pathIdx] = reRendered.content;
+						fullPath = reRendered.content;
+						left[pathIdx] = fullPath;
 						leftWidth = groupWidth(left, leftCapWidth + bandCapWidth, leftSepWidth);
 					}
 				}
@@ -2116,6 +2262,12 @@ export class StatusLineComponent implements Component {
 
 			while (totalWidth() > topFillWidth && left.length > 0) {
 				const dropIdx = leftOverflowDropIndex();
+				const dropped = left[dropIdx];
+				// Same reasoning as the right title: the over-shrunk path renders
+				// full on the overflow line when it is dropped to line 2.
+				overflowLeft.push(
+					fullPath !== undefined && dropped === left[pathIdx] && pathIdx === dropIdx ? fullPath : dropped,
+				);
 				left.splice(dropIdx, 1);
 				leftSegIds.splice(dropIdx, 1);
 				leftWidth = groupWidth(left, leftCapWidth + bandCapWidth, leftSepWidth);
@@ -2148,22 +2300,38 @@ export class StatusLineComponent implements Component {
 
 		const leftGroup = renderGroup(left, "left");
 		const rightGroup = renderGroup(right, "right");
-		if (!leftGroup && !rightGroup) return "";
 
-		if (topFillWidth === 0 || (plain && (left.length === 0 || right.length === 0))) {
-			return leftGroup + (leftGroup && rightGroup ? " " : "") + rightGroup;
+		// Line 1 keeps upstream's placement semantics verbatim (empty guard,
+		// space-fallback when a side is absent on plain layouts), with only the
+		// box-layout gap composed through the context gauge.
+		let line1: string;
+		if (!leftGroup && !rightGroup) {
+			line1 = "";
+		} else if (topFillWidth === 0 || (plain && (left.length === 0 || right.length === 0))) {
+			line1 = leftGroup + (leftGroup && rightGroup ? " " : "") + rightGroup;
+		} else {
+			const gapWidth = Math.max(1, topFillWidth - leftWidth - rightWidth);
+			if (plain) {
+				// Standalone composers: no gauge line between the groups, just air.
+				line1 = leftGroup + padding(gapWidth) + rightGroup;
+			} else {
+				// Box layout: with one group absent (an unnamed session hides
+				// `session_name`, emptying the default preset's right group) the
+				// gauge runs to the border edge instead of disappearing, so
+				// embedded context labels don't fall back to a context chip until
+				// the session is titled.
+				line1 =
+					leftGroup + this.#buildContextGaugeFill(gapWidth, ctx, effectiveSettings, embedContext) + rightGroup;
+			}
 		}
 
-		const gapWidth = Math.max(1, topFillWidth - leftWidth - rightWidth);
-		if (plain) {
-			// Standalone composers: no gauge line between the groups, just air.
-			return leftGroup + padding(gapWidth) + rightGroup;
-		}
-		// Box layout: with one group absent (an unnamed session hides
-		// `session_name`, emptying the default preset's right group) the gauge
-		// runs to the border edge instead of disappearing, so embedded context
-		// labels don't fall back to a context chip until the session is titled.
-		return leftGroup + this.#buildContextGaugeFill(gapWidth, ctx, effectiveSettings, embedContext) + rightGroup;
+		// Line 2: overflowed segments kept in original reading order — left group
+		// first, then right group — joined by the dot separator. Each part is
+		// already self-contained ANSI from renderSegment, so no bg group or
+		// powerline caps are needed; the editor frames/pads this row.
+		const overflowParts = [...overflowLeft.reverse(), ...overflowRight.reverse()];
+		if (overflowParts.length === 0) return line1;
+		return `${line1}\n${overflowParts.join(theme.sep.dot)}`;
 	}
 
 	/**
@@ -2315,10 +2483,17 @@ export class StatusLineComponent implements Component {
 
 	getTopBorder(width: number, previewTitle?: string): { content: string; width: number; revision: number } {
 		const content = this.#dimWhileFocusProxied(this.#buildStatusLine(width, "box", previewTitle));
+		// With a two-line overflow the reported width is the widest line, which is
+		// what the editor budgets per row. A single-line bar keeps today's value.
+		let borderWidth = 0;
+		for (const line of content.split("\n")) {
+			const lineWidth = visibleWidth(line);
+			if (lineWidth > borderWidth) borderWidth = lineWidth;
+		}
 		return {
 			content,
-			width: visibleWidth(content),
-			revision: this.#renderRevision,
+			width: borderWidth,
+			revision: this.#widthEpochRevision,
 		};
 	}
 

--- a/packages/coding-agent/src/modes/components/status-line/segments.ts
+++ b/packages/coding-agent/src/modes/components/status-line/segments.ts
@@ -501,12 +501,14 @@ const costSegment: StatusLineSegment = {
 	render(ctx) {
 		const { cost, premiumRequests } = ctx.usageStats;
 		const advisorCost = ctx.session.getAdvisorCost?.() ?? 0;
+		const advisorUsage = ctx.advisorUsage;
+		const hasAdvisorLimits = Boolean(advisorUsage && (advisorUsage.fiveHour || advisorUsage.sevenDay));
 		const normalizedPremiumRequests = normalizePremiumRequests(premiumRequests);
 		const state = ctx.session.state;
 		const usingSubscription = state.model ? (ctx.session.modelRegistry?.isUsingOAuth(state.model) ?? false) : false;
 		const advisorUsingSubscription = ctx.session.isAdvisorUsingSubscription?.() ?? false;
 
-		if (!cost && !advisorCost && !usingSubscription && !normalizedPremiumRequests) {
+		if (!cost && !advisorCost && !hasAdvisorLimits && !usingSubscription && !normalizedPremiumRequests) {
 			return { content: "", visible: false };
 		}
 
@@ -519,11 +521,36 @@ const costSegment: StatusLineSegment = {
 			);
 		}
 		if (normalizedPremiumRequests) billingParts.push(`★ ${formatNumber(normalizedPremiumRequests)}`);
-		if (advisorCost) {
-			const prefix = billingParts.length ? "+ " : "";
-			billingParts.push(`${prefix}${formatAdvisorSpend(advisorCost, advisorUsingSubscription, theme)}`);
+		// The advisor's dollar figure is imputed from token counts at list price
+		// and is meaningless on a subscription; the real gate is the account's
+		// provider-reported usage windows. Show the 5h/7d limits when the
+		// advisor's provider reports them, falling back to the token-derived
+		// amount only for providers with no quota endpoint (so non-quota
+		// advisors don't silently drop their only cost signal).
+		if (advisorUsage && (advisorUsage.fiveHour || advisorUsage.sevenDay)) {
+			const limitParts: string[] = [];
+			if (advisorUsage.fiveHour) {
+				const pct = advisorUsage.fiveHour.percent;
+				const reset =
+					advisorUsage.fiveHour.resetMinutes !== undefined
+						? ` (${formatUsageReset(advisorUsage.fiveHour.resetMinutes, "m")})`
+						: "";
+				limitParts.push(`5h ${usagePercent(pct)}${reset}`);
+			}
+			if (advisorUsage.sevenDay) {
+				const pct = advisorUsage.sevenDay.percent;
+				const reset =
+					advisorUsage.sevenDay.resetHours !== undefined
+						? ` (${formatUsageReset(advisorUsage.sevenDay.resetHours, "h")})`
+						: "";
+				limitParts.push(`7d ${usagePercent(pct)}${reset}`);
+			}
+			billingParts.push(`${billingParts.length ? "+ " : ""}${limitParts.join(theme.sep.dot)} (adv)`);
+		} else if (advisorCost) {
+			billingParts.push(
+				`${billingParts.length ? "+ " : ""}${formatAdvisorSpend(advisorCost, advisorUsingSubscription, theme)} (adv)`,
+			);
 		}
-		if (billingParts.length === 0) return { content: "", visible: false };
 
 		return { content: theme.fg("statusLineCost", billingParts.join(" ")), visible: true };
 	},
@@ -701,10 +728,18 @@ const collabSegment: StatusLineSegment = {
 	},
 };
 
-function pickUsageColor(percent: number): "muted" | "warning" | "error" {
+function pickUsageColor(percent: number): "warning" | "error" | undefined {
 	if (percent >= 80) return "error";
 	if (percent >= 50) return "warning";
-	return "muted";
+	return undefined;
+}
+
+/** Percent display: inherits the segment color (bright) until 50%, then
+ *  warning, then error at 80%. `floor` matches provider dashboard flooring. */
+function usagePercent(percent: number, floor = false): string {
+	const text = `${floor ? Math.floor(percent) : Math.round(percent)}%`;
+	const color = pickUsageColor(percent);
+	return color ? theme.fg(color, text) : text;
 }
 
 function formatUsageReset(value: number, unit: "m" | "h"): string {
@@ -736,16 +771,13 @@ const usageSegment: StatusLineSegment = {
 		}
 		if (u.fiveHour) {
 			const pct = u.fiveHour.percent;
-			const pctText = theme.fg(pickUsageColor(pct), `${Math.round(pct)}%`);
 			const reset =
-				u.fiveHour.resetMinutes !== undefined
-					? theme.fg("muted", ` (${formatUsageReset(u.fiveHour.resetMinutes, "m")})`)
-					: "";
-			parts.push(`5h ${pctText}${reset}`);
+				u.fiveHour.resetMinutes !== undefined ? ` (${formatUsageReset(u.fiveHour.resetMinutes, "m")})` : "";
+			parts.push(`5h ${usagePercent(pct)}${reset}`);
 		}
 		if (u.daily) {
 			const pct = u.daily.percent;
-			const pctText = theme.fg(pickUsageColor(pct), `${Math.round(pct)}%`);
+			const pctText = usagePercent(pct);
 			const reset =
 				u.daily.resetMinutes !== undefined
 					? theme.fg("muted", ` (${formatUsageReset(u.daily.resetMinutes, "m")})`)
@@ -754,24 +786,16 @@ const usageSegment: StatusLineSegment = {
 		}
 		if (u.sevenDay) {
 			const pct = u.sevenDay.percent;
-			const pctText = theme.fg(pickUsageColor(pct), `${Math.round(pct)}%`);
-			const reset =
-				u.sevenDay.resetHours !== undefined
-					? theme.fg("muted", ` (${formatUsageReset(u.sevenDay.resetHours, "h")})`)
-					: "";
-			parts.push(`7d ${pctText}${reset}`);
+			const reset = u.sevenDay.resetHours !== undefined ? ` (${formatUsageReset(u.sevenDay.resetHours, "h")})` : "";
+			parts.push(`7d ${usagePercent(pct)}${reset}`);
 		}
 		if (u.monthly) {
 			const pct = u.monthly.percent;
 			// Cursor and OpenCode Go (normalize gates monthly to those providers).
 			// Both floor used percents upstream (Cursor's dashboard shows 1.88 →
 			// "1% used"; OpenCode's endpoint already emits floored integers).
-			const pctText = theme.fg(pickUsageColor(pct), `${Math.floor(pct)}%`);
-			const reset =
-				u.monthly.resetHours !== undefined
-					? theme.fg("muted", ` (${formatUsageReset(u.monthly.resetHours, "h")})`)
-					: "";
-			parts.push(`mo ${pctText}${reset}`);
+			const reset = u.monthly.resetHours !== undefined ? ` (${formatUsageReset(u.monthly.resetHours, "h")})` : "";
+			parts.push(`mo ${usagePercent(pct, true)}${reset}`);
 		}
 		const content = withIcon(theme.icon.time, parts.join(theme.sep.dot));
 		return { content, visible: true };

--- a/packages/coding-agent/src/modes/components/status-line/types.ts
+++ b/packages/coding-agent/src/modes/components/status-line/types.ts
@@ -153,6 +153,12 @@ export interface SegmentContext {
 		sevenDay?: { percent: number; resetHours?: number };
 		monthly?: { percent: number; resetHours?: number };
 	} | null;
+	/** Provider-reported subscription windows for the advisor's own account,
+	 *  keyed to the advisor model's provider/identity (not the primary's). */
+	advisorUsage: {
+		fiveHour?: { percent: number; resetMinutes?: number };
+		sevenDay?: { percent: number; resetHours?: number };
+	} | null;
 }
 
 export interface RenderedSegment {

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -4,8 +4,8 @@ import { PASTE_CODE_LOGIN_PROVIDERS } from "@oh-my-pi/pi-ai";
 import { getOAuthProviders } from "@oh-my-pi/pi-ai/oauth";
 import type { OAuthProvider } from "@oh-my-pi/pi-ai/oauth/types";
 import * as vcs from "@oh-my-pi/pi-natives/vcs";
-import type { Component, OverlayHandle, ResizeScrollbackMode } from "@oh-my-pi/pi-tui";
-import { Loader, Spacer, setTuiTight, Text } from "@oh-my-pi/pi-tui";
+import type { Component, OverlayHandle } from "@oh-my-pi/pi-tui";
+import { Loader, Spacer, Text } from "@oh-my-pi/pi-tui";
 import { getAgentDbPath, getAgentDir, getProjectDir, normalizePathForComparison } from "@oh-my-pi/pi-utils";
 import {
 	type AdvisorConfigScope,
@@ -23,7 +23,6 @@ import {
 } from "../../config/model-resolver";
 import { getRoleInfo } from "../../config/model-roles";
 import { settings } from "../../config/settings";
-import { disableProvider, enableProvider } from "../../discovery";
 import { clearPluginRootsAndCaches, resolveActiveProjectRegistryPath } from "../../discovery/helpers";
 import {
 	getInstalledPluginsRegistryPath,
@@ -32,16 +31,7 @@ import {
 	getPluginsCacheDir,
 	MarketplaceManager,
 } from "../../extensibility/plugins/marketplace";
-import {
-	getAvailableThemes,
-	getSymbolTheme,
-	previewTheme,
-	setColorBlindMode,
-	setMarkdownMermaidRendering,
-	setSymbolPreset,
-	setTheme,
-	theme,
-} from "../../modes/theme/theme";
+import { getAvailableThemes, getSymbolTheme, previewTheme, theme } from "../../modes/theme/theme";
 import type { InteractiveModeContext } from "../../modes/types";
 import type { SessionOAuthAccountList } from "../../session/agent-session-types";
 import type { ResetCreditAccountStatus, ResetCreditRedeemOutcome } from "../../session/auth-storage";
@@ -64,19 +54,8 @@ import {
 	toResetUsageAccounts,
 } from "../../slash-commands/helpers/reset-usage";
 import { toSessionPinAccounts } from "../../slash-commands/helpers/session-pin";
-import {
-	AUTO_THINKING,
-	type ConfiguredThinkingLevel,
-	concreteThinkingLevel,
-	parseConfiguredThinkingLevel,
-} from "../../thinking";
-import {
-	isSearchProviderId,
-	setExcludedSearchProviders,
-	setImageProviderOrder,
-	setSearchProviderOrder,
-	type ToolSession,
-} from "../../tools";
+import { AUTO_THINKING, concreteThinkingLevel, parseConfiguredThinkingLevel } from "../../thinking";
+import type { ToolSession } from "../../tools";
 import { AskTool, type AskToolDetails, type AskToolInput } from "../../tools/ask";
 import { shortenPath } from "../../tools/render-utils";
 import { ToolAbortError } from "../../tools/tool-errors";
@@ -85,7 +64,6 @@ import { setSessionTerminalTitle } from "../../utils/title-generator";
 import { type AdvisorConfigDeps, AdvisorConfigOverlayComponent } from "../components/advisor-config";
 import { AgentHubOverlayComponent } from "../components/agent-hub";
 import { AgentsHubComponent } from "../components/agents-hub";
-import { AssistantMessageComponent } from "../components/assistant-message";
 import { CopySelectorComponent } from "../components/copy-selector";
 import { ExtensionDashboard } from "../components/extensions";
 import { listLiveToolRecords, liveToolRecordFromSession } from "../components/extensions/live-tool-session";
@@ -96,18 +74,17 @@ import { ModelHubComponent, type ModelRoleSelectionScope } from "../components/m
 import { ModelPickerComponent } from "../components/model-picker";
 import { OAuthSelectorComponent } from "../components/oauth-selector";
 import { PluginSelectorComponent } from "../components/plugin-selector";
-import { ReadToolGroupComponent } from "../components/read-tool-group";
 import { ResetUsageSelectorComponent } from "../components/reset-usage-selector";
 import { renderSegmentTrack } from "../components/segment-track";
 import { SessionAccountSelectorComponent } from "../components/session-account-selector";
 import { SessionSelectorComponent, type SessionSelectorOptions } from "../components/session-selector";
 import { SettingsSelectorComponent } from "../components/settings-selector";
-import { ToolExecutionComponent } from "../components/tool-execution";
 import { TranscriptBlock } from "../components/transcript-container";
 import { TreeSelectorComponent } from "../components/tree-selector";
 import { UserMessageSelectorComponent } from "../components/user-message-selector";
 import type { SessionObserverRegistry } from "../session-observer-registry";
 import { buildCopyTargets } from "../utils/copy-targets";
+import { applySettingSideEffects } from "./setting-side-effects";
 
 const MANUAL_LOGIN_PROMPT = "Paste the authorization code (or full redirect URL), then press Enter:";
 
@@ -238,7 +215,7 @@ export class SelectorController {
 						// The bar exactly as the active composer shape renders it (box top
 						// border, claude rule + chip, or the plain standalone bottom bar).
 						const availableWidth = this.ctx.editor.getTopBorderAvailableWidth(this.ctx.ui.terminal.columns);
-						return this.ctx.statusLine.getPreviewLines(availableWidth).join("\n");
+						return this.ctx.statusLine.getTopBorder(availableWidth).content.split("\n")[0];
 					},
 					onPluginsChanged: async () => {
 						const projectPath = await resolveActiveProjectRegistryPath(this.ctx.sessionManager.getCwd());
@@ -462,295 +439,7 @@ export class SelectorController {
 	 * This handles side effects and session-specific settings.
 	 */
 	handleSettingChange(id: string, value: unknown): void {
-		// Discovery provider toggles
-		if (id.startsWith("discovery.")) {
-			const providerId = id.replace("discovery.", "");
-			if (value) {
-				enableProvider(providerId);
-			} else {
-				disableProvider(providerId);
-			}
-			return;
-		}
-
-		switch (id) {
-			// Session-managed settings (not in SettingsManager)
-			case "autoCompact":
-				this.ctx.session.setAutoCompactionEnabled(value as boolean);
-				this.ctx.statusLine.setAutoCompactEnabled(value as boolean);
-				break;
-			case "composer.shape":
-				this.ctx.syncComposerShape();
-				break;
-			case "advisor.enabled":
-				this.ctx.session.setAdvisorEnabled(value as boolean);
-				this.ctx.statusLine.invalidate();
-				this.ctx.ui.requestRender();
-				break;
-			case "steeringMode":
-				this.ctx.session.setSteeringMode(value as "all" | "one-at-a-time");
-				break;
-			case "followUpMode":
-				this.ctx.session.setFollowUpMode(value as "all" | "one-at-a-time");
-				break;
-			case "interruptMode":
-				this.ctx.session.setInterruptMode(value as "immediate" | "wait");
-				break;
-			case "thinkingLevel":
-			case "defaultThinkingLevel":
-				this.ctx.session.setThinkingLevel(value as ConfiguredThinkingLevel, true);
-				this.ctx.statusLine.invalidate();
-				this.ctx.updateEditorBorderColor();
-				break;
-			case "personality":
-				void this.ctx.session.refreshBaseSystemPrompt().catch(err => {
-					this.ctx.showError(`Failed to apply personality: ${err}`);
-				});
-				break;
-			case "tools.xdevDocs":
-				void this.ctx.session.refreshBaseSystemPrompt().catch(err => {
-					this.ctx.showError(`Failed to apply xd:// prompt docs setting: ${err}`);
-				});
-				break;
-			case "memory.backend":
-				void this.ctx.session.applyMemoryBackend().catch(err => {
-					this.ctx.showError(`Failed to apply memory backend: ${err}`);
-				});
-				break;
-			case "inspect_image.mode":
-				void this.ctx.session.applyInspectImageModeChange().catch(err => {
-					this.ctx.showError(`Failed to apply vision mode: ${err}`);
-				});
-				break;
-			case "externalThinking":
-				void this.ctx.session.setThinkToolEnabled(value as boolean).catch(err => {
-					this.ctx.showError(`Failed to apply external thinking: ${err}`);
-				});
-				break;
-
-			case "autocompleteMaxVisible":
-				this.ctx.editor.setAutocompleteMaxVisible(typeof value === "number" ? value : Number(value));
-				break;
-			case "spelling.typoDetection":
-			case "spelling.autocomplete":
-			case "spelling.autocorrect":
-				this.ctx.syncEditorSpelling();
-				this.ctx.ui.requestRender();
-				break;
-
-			// Settings with UI side effects
-			case "display.hideToolActivity": {
-				const hidden = value as boolean;
-				this.ctx.hideToolActivity = hidden;
-				if (!hidden) this.ctx.toolOutputExpanded = false;
-				for (const child of this.ctx.chatContainer.children) {
-					if (!hidden && (child instanceof ToolExecutionComponent || child instanceof ReadToolGroupComponent)) {
-						child.setExpanded(false);
-					} else if (child instanceof AssistantMessageComponent) {
-						child.setToolResultImagesVisible(!hidden);
-					}
-				}
-				this.ctx.chatContainer.setToolActivityVisible(!hidden);
-				if (hidden) this.ctx.ui.clearInlineImages();
-				this.ctx.ui.requestRender(true);
-				break;
-			}
-			case "terminal.showImages":
-			case "showImages": {
-				const visible = value as boolean;
-				for (const child of this.ctx.chatContainer.children) {
-					if (child instanceof ToolExecutionComponent) {
-						child.setShowImages(visible);
-					} else if (child instanceof AssistantMessageComponent) {
-						child.setImagesVisible(visible);
-					}
-				}
-				if (!visible) this.ctx.ui.clearInlineImages();
-				this.ctx.ui.requestRender(true);
-				break;
-			}
-			case "hideThinkingBlock":
-				this.ctx.hideThinkingBlock = value as boolean;
-				for (const child of this.ctx.chatContainer.children) {
-					if (child instanceof AssistantMessageComponent) {
-						child.setHideThinkingBlock(this.ctx.effectiveHideThinkingBlock);
-					}
-				}
-				this.ctx.ui.requestRender(true);
-				break;
-			case "proseOnlyThinking":
-				this.ctx.proseOnlyThinking = value as boolean;
-				for (const child of this.ctx.chatContainer.children) {
-					if (child instanceof AssistantMessageComponent) {
-						child.setProseOnlyThinking(value as boolean);
-					}
-				}
-				this.ctx.ui.requestRender(true);
-				break;
-			case "omitThinking":
-				this.ctx.session.agent.hideThinkingSummary = value as boolean;
-				break;
-			case "display.cacheMissMarker":
-				// Rebuild re-runs the usage-based detection under the new setting so
-				// markers appear/disappear; full reset retires any already committed
-				// to native scrollback (mirrors hideThinking).
-				this.ctx.rebuildChatFromMessages();
-				this.ctx.ui.resetDisplay();
-				break;
-			case "display.collapseCompacted":
-				// Rebuild swaps between the collapsed tail and the full inline
-				// history; full reset retires blocks already committed to native
-				// scrollback (mirrors cacheMissMarker).
-				this.ctx.rebuildChatFromMessages();
-				this.ctx.ui.resetDisplay();
-				break;
-			case "display.showTokenUsage":
-				// Rebuild reruns usage-row detection under the new setting; resetDisplay
-				// retires rows already committed to native scrollback.
-				this.ctx.rebuildChatFromMessages();
-				this.ctx.ui.resetDisplay();
-				break;
-			case "display.showTurnTime":
-				// Same as showTokenUsage: the prompt→yield delta lives in the same
-				// usage row, so toggling it must rebuild and retire committed rows.
-				this.ctx.rebuildChatFromMessages();
-				this.ctx.ui.resetDisplay();
-				break;
-			case "tui.tight":
-				setTuiTight(value as boolean);
-				this.ctx.ui.invalidate();
-				this.ctx.ui.requestRender();
-				break;
-			case "tui.resizeScrollback":
-				this.ctx.ui.setResizeScrollback(value as ResizeScrollbackMode);
-				break;
-
-			case "tui.renderMermaid":
-				setMarkdownMermaidRendering(value as boolean);
-				this.ctx.session.refreshBaseSystemPrompt().catch(err => {
-					this.ctx.showError(`Failed to apply Mermaid rendering setting: ${err}`);
-				});
-				this.ctx.rebuildChatFromMessages();
-				this.ctx.ui.resetDisplay();
-				break;
-
-			case "theme": {
-				setTheme(value as string, true).then(result => {
-					this.ctx.statusLine.invalidate();
-					this.ctx.ui.requestRender();
-					this.ctx.ui.invalidate();
-					if (!result.success) {
-						this.ctx.showError(`Failed to load theme "${value}": ${result.error}\nFell back to dark theme.`);
-					}
-				});
-				break;
-			}
-			case "symbolPreset": {
-				setSymbolPreset(value as "unicode" | "nerd" | "ascii").then(() => {
-					this.ctx.statusLine.invalidate();
-					this.ctx.ui.requestRender();
-					this.ctx.ui.invalidate();
-				});
-				break;
-			}
-			case "colorBlindMode": {
-				setColorBlindMode(value === "true" || value === true).then(() => {
-					this.ctx.ui.invalidate();
-				});
-				break;
-			}
-			case "temperature": {
-				const temp = typeof value === "number" ? value : Number(value);
-				this.ctx.session.agent.temperature = temp >= 0 ? temp : undefined;
-				break;
-			}
-			case "topP": {
-				const topP = typeof value === "number" ? value : Number(value);
-				this.ctx.session.agent.topP = topP >= 0 ? topP : undefined;
-				break;
-			}
-			case "topK": {
-				const topK = typeof value === "number" ? value : Number(value);
-				this.ctx.session.agent.topK = topK >= 0 ? topK : undefined;
-				break;
-			}
-			case "minP": {
-				const minP = typeof value === "number" ? value : Number(value);
-				this.ctx.session.agent.minP = minP >= 0 ? minP : undefined;
-				break;
-			}
-			case "presencePenalty": {
-				const presencePenalty = typeof value === "number" ? value : Number(value);
-				this.ctx.session.agent.presencePenalty = presencePenalty >= 0 ? presencePenalty : undefined;
-				break;
-			}
-			case "repetitionPenalty": {
-				const repetitionPenalty = typeof value === "number" ? value : Number(value);
-				this.ctx.session.agent.repetitionPenalty = repetitionPenalty >= 0 ? repetitionPenalty : undefined;
-				break;
-			}
-			case "git.enabled":
-			case "statusLinePreset":
-			case "statusLine.preset":
-			case "statusLineSeparator":
-			case "statusLine.separator":
-			case "statusLineShowHooks":
-			case "statusLine.showHookStatus":
-			case "statusLine.sessionAccent":
-			case "statusLine.transparent":
-			case "statusLine.compactThinkingLevel":
-			case "statusLineSegments":
-			case "statusLineModelThinking":
-			case "statusLinePathAbbreviate":
-			case "statusLinePathMaxLength":
-			case "statusLinePathStripWorkPrefix":
-			case "statusLineGitShowBranch":
-			case "statusLineGitShowStaged":
-			case "statusLineGitShowUnstaged":
-			case "statusLineGitShowUntracked":
-			case "statusLineTimeFormat":
-			case "statusLineTimeShowSeconds": {
-				const statusLineSettings = {
-					preset: settings.get("statusLine.preset"),
-					leftSegments: settings.get("statusLine.leftSegments"),
-					rightSegments: settings.get("statusLine.rightSegments"),
-					separator: settings.get("statusLine.separator"),
-					showHookStatus: settings.get("statusLine.showHookStatus"),
-					sessionAccent: settings.get("statusLine.sessionAccent"),
-					transparent: settings.get("statusLine.transparent"),
-					segmentOptions: settings.get("statusLine.segmentOptions"),
-					compactThinkingLevel: settings.get("statusLine.compactThinkingLevel"),
-				};
-				this.ctx.statusLine.updateSettings(statusLineSettings);
-				this.ctx.ui.requestRender();
-				break;
-			}
-
-			// Provider settings - update runtime preferences
-			case "providers.webSearchOrder":
-				if (Array.isArray(value)) {
-					setSearchProviderOrder(value.filter(isSearchProviderId));
-				}
-				break;
-			case "providers.webSearchExclude":
-				if (Array.isArray(value)) {
-					setExcludedSearchProviders(value.filter(isSearchProviderId));
-				}
-				break;
-			case "providers.imageOrder":
-				if (Array.isArray(value)) {
-					setImageProviderOrder(value.filter((entry): entry is string => typeof entry === "string"));
-				}
-				break;
-
-			// MCP update injection - live subscribe/unsubscribe
-			case "mcp.notifications":
-				this.ctx.mcpManager?.setNotificationsEnabled(value as boolean);
-				break;
-
-			// All other settings are handled by the definitions (get/set on SettingsManager)
-			// No additional side effects needed
-		}
+		applySettingSideEffects(this.ctx, id, value);
 	}
 
 	showModelSelector(options?: { temporaryOnly?: boolean }): void {

--- a/packages/coding-agent/src/modes/controllers/setting-side-effects.ts
+++ b/packages/coding-agent/src/modes/controllers/setting-side-effects.ts
@@ -1,0 +1,370 @@
+import { type ResizeScrollbackMode, setTuiTight } from "@oh-my-pi/pi-tui";
+import { settings } from "../../config/settings";
+import { disableProvider, enableProvider } from "../../discovery";
+import { setColorBlindMode, setMarkdownMermaidRendering, setSymbolPreset, setTheme } from "../../modes/theme/theme";
+import type { ConfiguredThinkingLevel } from "../../thinking";
+import {
+	isSearchProviderId,
+	setExcludedSearchProviders,
+	setImageProviderOrder,
+	setSearchProviderOrder,
+} from "../../tools";
+import { AssistantMessageComponent } from "../components/assistant-message";
+import { ReadToolGroupComponent } from "../components/read-tool-group";
+import { ToolExecutionComponent } from "../components/tool-execution";
+import type { InteractiveModeContext } from "../types";
+
+export interface SettingSideEffectOptions {
+	/**
+	 * Whether persisting session setters write through to global config
+	 * (`setSteeringMode` and friends, `setThinkingLevel`). Selector changes
+	 * persist; replaying values that were just loaded from disk must not — a
+	 * project-overlay value would be promoted into global config.
+	 */
+	persist?: boolean;
+}
+
+/**
+ * Settings whose consumers cache the value on components or agent fields
+ * instead of re-reading it per use. A settings reload swaps layers without
+ * touching these caches, so `/reload-settings` replays each id through
+ * {@link applySettingSideEffects} after the refresh.
+ */
+export const REPLAYED_SETTING_IDS = [
+	"autocompleteMaxVisible",
+	"tui.imeSafeCursor",
+	"spelling.typoDetection",
+	"spelling.autocomplete",
+	"spelling.autocorrect",
+	"display.hideToolActivity",
+	"terminal.showImages",
+	"hideThinkingBlock",
+	"proseOnlyThinking",
+	"tui.tight",
+	"tui.resizeScrollback",
+	"composer.shape",
+	"defaultThinkingLevel",
+	"personality",
+	"tools.xdevDocs",
+	"externalThinking",
+	"memory.backend",
+	"mcp.notifications",
+	"git.enabled",
+	"statusLine.preset",
+	"statusLine.separator",
+	"statusLine.showHookStatus",
+	"statusLine.sessionAccent",
+	"statusLine.transparent",
+	"statusLine.compactThinkingLevel",
+] as const;
+
+/**
+ * Applies the live side effects of one setting change against the interactive
+ * mode context. Shared by the settings selector (`handleSettingChange`) and
+ * the TUI slash-command adapter's `notifyConfigChanged` so both paths run the
+ * same applies — a second partial implementation would drift.
+ *
+ * Session-managed queue modes and thinking level honor `options.persist`;
+ * callers replaying freshly loaded values pass `persist: false`.
+ */
+export function applySettingSideEffects(
+	ctx: InteractiveModeContext,
+	id: string,
+	value: unknown,
+	options: SettingSideEffectOptions = {},
+): void {
+	const persist = options.persist ?? true;
+
+	// Discovery provider toggles
+	if (id.startsWith("discovery.")) {
+		const providerId = id.replace("discovery.", "");
+		if (value) {
+			enableProvider(providerId);
+		} else {
+			disableProvider(providerId);
+		}
+		return;
+	}
+
+	switch (id) {
+		// Session-managed settings (not in SettingsManager)
+		case "autoCompact":
+			ctx.session.setAutoCompactionEnabled(value as boolean);
+			ctx.statusLine.setAutoCompactEnabled(value as boolean);
+			break;
+		case "composer.shape":
+			ctx.syncComposerShape();
+			break;
+		case "advisor.enabled":
+			ctx.session.setAdvisorEnabled(value as boolean);
+			ctx.statusLine.invalidate();
+			ctx.ui.requestRender();
+			break;
+		case "steeringMode":
+			ctx.session.setSteeringMode(value as "all" | "one-at-a-time", persist);
+			break;
+		case "followUpMode":
+			ctx.session.setFollowUpMode(value as "all" | "one-at-a-time", persist);
+			break;
+		case "interruptMode":
+			ctx.session.setInterruptMode(value as "immediate" | "wait", persist);
+			break;
+		case "thinkingLevel":
+		case "defaultThinkingLevel":
+			ctx.session.setThinkingLevel(value as ConfiguredThinkingLevel, persist);
+			ctx.statusLine.invalidate();
+			ctx.updateEditorBorderColor();
+			break;
+		case "personality":
+			void ctx.session.refreshBaseSystemPrompt().catch(err => {
+				ctx.showError(`Failed to apply personality: ${err}`);
+			});
+			break;
+		case "tools.xdevDocs":
+			void ctx.session.refreshBaseSystemPrompt().catch(err => {
+				ctx.showError(`Failed to apply xd:// prompt docs setting: ${err}`);
+			});
+			break;
+		case "memory.backend":
+			void ctx.session.applyMemoryBackend().catch(err => {
+				ctx.showError(`Failed to apply memory backend: ${err}`);
+			});
+			break;
+		case "inspect_image.mode":
+			void ctx.session.applyInspectImageModeChange().catch(err => {
+				ctx.showError(`Failed to apply vision mode: ${err}`);
+			});
+			break;
+		case "externalThinking":
+			void ctx.session.setThinkToolEnabled(value as boolean).catch(err => {
+				ctx.showError(`Failed to apply external thinking: ${err}`);
+			});
+			break;
+
+		case "autocompleteMaxVisible":
+			ctx.editor.setAutocompleteMaxVisible(typeof value === "number" ? value : Number(value));
+			break;
+		case "tui.imeSafeCursor":
+			ctx.editor.setImeSafeCursorLayout(value === true);
+			break;
+		case "spelling.typoDetection":
+		case "spelling.autocomplete":
+		case "spelling.autocorrect":
+			ctx.syncEditorSpelling();
+			ctx.ui.requestRender();
+			break;
+
+		// Settings with UI side effects
+		case "display.hideToolActivity": {
+			const hidden = value as boolean;
+			ctx.hideToolActivity = hidden;
+			if (!hidden) ctx.toolOutputExpanded = false;
+			for (const child of ctx.chatContainer.children) {
+				if (!hidden && (child instanceof ToolExecutionComponent || child instanceof ReadToolGroupComponent)) {
+					child.setExpanded(false);
+				} else if (child instanceof AssistantMessageComponent) {
+					child.setToolResultImagesVisible(!hidden);
+				}
+			}
+			ctx.chatContainer.setToolActivityVisible(!hidden);
+			if (hidden) ctx.ui.clearInlineImages();
+			ctx.ui.requestRender(true);
+			break;
+		}
+		case "terminal.showImages":
+		case "showImages": {
+			const visible = value as boolean;
+			for (const child of ctx.chatContainer.children) {
+				if (child instanceof ToolExecutionComponent) {
+					child.setShowImages(visible);
+				} else if (child instanceof AssistantMessageComponent) {
+					child.setImagesVisible(visible);
+				}
+			}
+			if (!visible) ctx.ui.clearInlineImages();
+			ctx.ui.requestRender(true);
+			break;
+		}
+		case "hideThinkingBlock":
+			ctx.hideThinkingBlock = value as boolean;
+			for (const child of ctx.chatContainer.children) {
+				if (child instanceof AssistantMessageComponent) {
+					child.setHideThinkingBlock(ctx.effectiveHideThinkingBlock);
+				}
+			}
+			ctx.ui.requestRender(true);
+			break;
+		case "proseOnlyThinking":
+			ctx.proseOnlyThinking = value as boolean;
+			for (const child of ctx.chatContainer.children) {
+				if (child instanceof AssistantMessageComponent) {
+					child.setProseOnlyThinking(value as boolean);
+				}
+			}
+			ctx.ui.requestRender(true);
+			break;
+		case "omitThinking":
+			ctx.session.agent.hideThinkingSummary = value as boolean;
+			break;
+		case "display.cacheMissMarker":
+			// Rebuild re-runs the usage-based detection under the new setting so
+			// markers appear/disappear; full reset retires any already committed
+			// to native scrollback (mirrors hideThinking).
+			ctx.rebuildChatFromMessages();
+			ctx.ui.resetDisplay();
+			break;
+		case "display.collapseCompacted":
+			// Rebuild swaps between the collapsed tail and the full inline
+			// history; full reset retires blocks already committed to native
+			// scrollback (mirrors cacheMissMarker).
+			ctx.rebuildChatFromMessages();
+			ctx.ui.resetDisplay();
+			break;
+		case "display.showTokenUsage":
+			// Rebuild reruns usage-row detection under the new setting; resetDisplay
+			// retires rows already committed to native scrollback.
+			ctx.rebuildChatFromMessages();
+			ctx.ui.resetDisplay();
+			break;
+		case "display.showTurnTime":
+			// Same as showTokenUsage: the prompt→yield delta lives in the same
+			// usage row, so toggling it must rebuild and retire committed rows.
+			ctx.rebuildChatFromMessages();
+			ctx.ui.resetDisplay();
+			break;
+		case "tui.tight":
+			setTuiTight(value as boolean);
+			ctx.ui.invalidate();
+			ctx.ui.requestRender();
+			break;
+		case "tui.resizeScrollback":
+			ctx.ui.setResizeScrollback(value as ResizeScrollbackMode);
+			break;
+
+		case "tui.renderMermaid":
+			setMarkdownMermaidRendering(value as boolean);
+			ctx.session.refreshBaseSystemPrompt().catch(err => {
+				ctx.showError(`Failed to apply Mermaid rendering setting: ${err}`);
+			});
+			ctx.rebuildChatFromMessages();
+			ctx.ui.resetDisplay();
+			break;
+
+		case "theme": {
+			setTheme(value as string, true).then(result => {
+				ctx.statusLine.invalidate();
+				ctx.ui.requestRender();
+				ctx.ui.invalidate();
+				if (!result.success) {
+					ctx.showError(`Failed to load theme "${value}": ${result.error}\nFell back to dark theme.`);
+				}
+			});
+			break;
+		}
+		case "symbolPreset": {
+			setSymbolPreset(value as "unicode" | "nerd" | "ascii").then(() => {
+				ctx.statusLine.invalidate();
+				ctx.ui.requestRender();
+				ctx.ui.invalidate();
+			});
+			break;
+		}
+		case "colorBlindMode": {
+			setColorBlindMode(value === "true" || value === true).then(() => {
+				ctx.ui.invalidate();
+			});
+			break;
+		}
+		case "temperature": {
+			const temp = typeof value === "number" ? value : Number(value);
+			ctx.session.agent.temperature = temp >= 0 ? temp : undefined;
+			break;
+		}
+		case "topP": {
+			const topP = typeof value === "number" ? value : Number(value);
+			ctx.session.agent.topP = topP >= 0 ? topP : undefined;
+			break;
+		}
+		case "topK": {
+			const topK = typeof value === "number" ? value : Number(value);
+			ctx.session.agent.topK = topK >= 0 ? topK : undefined;
+			break;
+		}
+		case "minP": {
+			const minP = typeof value === "number" ? value : Number(value);
+			ctx.session.agent.minP = minP >= 0 ? minP : undefined;
+			break;
+		}
+		case "presencePenalty": {
+			const presencePenalty = typeof value === "number" ? value : Number(value);
+			ctx.session.agent.presencePenalty = presencePenalty >= 0 ? presencePenalty : undefined;
+			break;
+		}
+		case "repetitionPenalty": {
+			const repetitionPenalty = typeof value === "number" ? value : Number(value);
+			ctx.session.agent.repetitionPenalty = repetitionPenalty >= 0 ? repetitionPenalty : undefined;
+			break;
+		}
+		case "git.enabled":
+		case "statusLinePreset":
+		case "statusLine.preset":
+		case "statusLineSeparator":
+		case "statusLine.separator":
+		case "statusLineShowHooks":
+		case "statusLine.showHookStatus":
+		case "statusLine.sessionAccent":
+		case "statusLine.transparent":
+		case "statusLine.compactThinkingLevel":
+		case "statusLineSegments":
+		case "statusLineModelThinking":
+		case "statusLinePathAbbreviate":
+		case "statusLinePathMaxLength":
+		case "statusLinePathStripWorkPrefix":
+		case "statusLineGitShowBranch":
+		case "statusLineGitShowStaged":
+		case "statusLineGitShowUnstaged":
+		case "statusLineGitShowUntracked":
+		case "statusLineTimeFormat":
+		case "statusLineTimeShowSeconds": {
+			const statusLineSettings = {
+				preset: settings.get("statusLine.preset"),
+				leftSegments: settings.get("statusLine.leftSegments"),
+				rightSegments: settings.get("statusLine.rightSegments"),
+				separator: settings.get("statusLine.separator"),
+				showHookStatus: settings.get("statusLine.showHookStatus"),
+				sessionAccent: settings.get("statusLine.sessionAccent"),
+				transparent: settings.get("statusLine.transparent"),
+				segmentOptions: settings.get("statusLine.segmentOptions"),
+				compactThinkingLevel: settings.get("statusLine.compactThinkingLevel"),
+			};
+			ctx.statusLine.updateSettings(statusLineSettings);
+			ctx.ui.requestRender();
+			break;
+		}
+
+		// Provider settings - update runtime preferences
+		case "providers.webSearchOrder":
+			if (Array.isArray(value)) {
+				setSearchProviderOrder(value.filter(isSearchProviderId));
+			}
+			break;
+		case "providers.webSearchExclude":
+			if (Array.isArray(value)) {
+				setExcludedSearchProviders(value.filter(isSearchProviderId));
+			}
+			break;
+		case "providers.imageOrder":
+			if (Array.isArray(value)) {
+				setImageProviderOrder(value.filter((entry): entry is string => typeof entry === "string"));
+			}
+			break;
+
+		// MCP update injection - live subscribe/unsubscribe
+		case "mcp.notifications":
+			ctx.mcpManager?.setNotificationsEnabled(value as boolean);
+			break;
+
+		// All other settings are handled by the definitions (get/set on SettingsManager)
+		// No additional side effects needed
+	}
+}

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -404,6 +404,8 @@ export interface CreateAgentSessionOptions {
 	openAIServiceTier?: ServiceTier | null;
 	/** Models available for cycling (Ctrl+P in interactive mode) */
 	scopedModels?: Array<{ model: Model; thinkingLevel?: ThinkingLevel }>;
+	/** Frozen `--models` scope patterns: never re-resolved on reload. */
+	cliModelScope?: readonly string[];
 	/** Prewalk from the starting model to a fast/cheap target at the first edit/write once the todo list exists. */
 	prewalk?: Prewalk;
 	/** Force read-only plan mode at start, auto-approve on the model's first resolve call, then switch to execute. */
@@ -3640,6 +3642,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			ownedAsyncJobManager: asyncJobManager,
 			asyncJobManager: scopedAsyncJobManager,
 			scopedModels: options.scopedModels,
+			cliModelScope: options.cliModelScope,
 			promptTemplates,
 			slashCommands,
 			extensionRunner,

--- a/packages/coding-agent/src/session/agent-session-types.ts
+++ b/packages/coding-agent/src/session/agent-session-types.ts
@@ -142,6 +142,8 @@ export interface AgentSessionConfig {
 	autoApprove?: boolean;
 	/** Models to cycle through with Ctrl+P (from --models flag). */
 	scopedModels?: Array<{ model: Model; thinkingLevel?: ThinkingLevel }>;
+	/** Frozen `--models` scope patterns: when set, the CLI scope never re-resolves on reload; undefined means settings-derived, re-resolved live. */
+	cliModelScope?: readonly string[];
 	/** Initial session thinking selector. */
 	thinkingLevel?: ConfiguredThinkingLevel;
 	/** Hard ceiling on the session's thinking effort (e.g. a task spawn's `task.maxEffort`-capped hint); every later change, including retry-fallback recovery, is re-clamped to it. */

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -80,6 +80,7 @@ import * as AIError from "@oh-my-pi/pi-ai/error";
 import { resetOpenAICodexHistoryAfterCompaction } from "@oh-my-pi/pi-ai/providers/openai-codex-responses";
 import { toolWireSchema } from "@oh-my-pi/pi-ai/utils/schema";
 import { preferredDialect } from "@oh-my-pi/pi-catalog/identity";
+import type { ModelRefreshStrategy } from "@oh-my-pi/pi-catalog/model-manager";
 import { modelsAreEqual } from "@oh-my-pi/pi-catalog/models";
 import { MacOSPowerAssertion } from "@oh-my-pi/pi-natives";
 import {
@@ -104,7 +105,13 @@ import { reset as resetCapabilities } from "../capability";
 import type { EffectiveExtensionRoots } from "../capability/types";
 import { shouldEnableAppendOnlyContext } from "../config/append-only-context-mode";
 import type { ModelRegistry } from "../config/model-registry";
-import type { ResolvedModelRoleValue } from "../config/model-resolver";
+import {
+	getModelMatchPreferences,
+	type ResolvedModelRoleValue,
+	resolveModelScope,
+	sameScopedModelCycle,
+	toSessionScopedModels,
+} from "../config/model-resolver";
 import { expandPromptTemplate, type PromptTemplate } from "../config/prompt-templates";
 import { buildServiceTierByFamily } from "../config/service-tier";
 import type { Settings, SkillsSettings } from "../config/settings";
@@ -652,6 +659,8 @@ export class AgentSession {
 
 	// Model registry for API key resolution
 	#modelRegistry: ModelRegistry;
+	/** Settings-derived enabledModels scope; undefined keeps a --models scope fixed at its launch resolution. */
+	#cliModelScope: readonly string[] | undefined;
 	#usageFallbackConfirmer: UsageFallbackConfirmer | undefined;
 	#usagePreflightAbortControllers = new Set<AbortController>();
 	#queuedMessageDrainBlocked = false;
@@ -1168,6 +1177,7 @@ export class AgentSession {
 			thinkingLevelCeiling: config.thinkingLevelCeiling,
 			serviceTierByFamily: config.serviceTierByFamily,
 		});
+		this.#cliModelScope = config.cliModelScope;
 
 		this.#promptTemplates = config.promptTemplates ?? [];
 		this.#slashCommands = config.slashCommands ?? [];
@@ -5221,6 +5231,48 @@ export class AgentSession {
 	setScopedModels(scopedModels: Array<{ model: Model; thinkingLevel?: ThinkingLevel }>): void {
 		this.#models.setScopedModels(scopedModels);
 	}
+	/**
+	 * Re-resolve the settings-derived scope and push it into the Ctrl+P cycle /
+	 * scoped pickers when the rebuilt list differs. Reads the LIVE `enabledModels`
+	 * value — not the one captured at construction — so a mid-session edit that
+	 * changes the configured scope (A→B) or clears it takes effect on the same
+	 * reload. When the setting becomes empty the scope is cleared (unfrozen) so
+	 * the picker falls back to the full catalog; a non-empty setting that merely
+	 * resolves to zero models keeps the previous scope to avoid a transient
+	 * collapse while discovery settles. No-op for `--models`-scoped sessions
+	 * (`#cliModelScope` set): the CLI scope is frozen and outranks settings.
+	 */
+	async refreshScopedModels(): Promise<boolean> {
+		if (this.#isDisposed || this.#cliModelScope) return false;
+		const patterns = this.settings.get("enabledModels");
+		// Explicitly cleared (or never set and now absent): unfreeze the pickers.
+		if (!patterns || patterns.length === 0) {
+			if (this.#models.scopedModels.length === 0) return false;
+			this.#models.setScopedModels([]);
+			return true;
+		}
+		const resolved = await resolveModelScope(
+			[...patterns],
+			this.#modelRegistry,
+			getModelMatchPreferences(this.settings),
+			this.settings,
+		);
+		// Adopt the fresh model records for the active model too: a reload that
+		// edits the current model's metadata (baseUrl, compat, limits) rebuilds
+		// the registry into new objects with the same provider/id, and the next
+		// request must read them rather than the stale construction-time record.
+		const current = this.agent.state.model;
+		if (current) {
+			const fresh = resolved.find(
+				entry => entry.model.provider === current.provider && entry.model.id === current.id,
+			)?.model;
+			if (fresh && fresh !== current) this.agent.setModel(fresh);
+		}
+		const mapped = toSessionScopedModels(resolved, this.settings);
+		if (mapped.length === 0 || sameScopedModelCycle(this.#models.scopedModels, mapped)) return false;
+		this.#models.setScopedModels(mapped);
+		return true;
+	}
 
 	/** Prompt templates */
 	getPlanModeState(): PlanModeState | undefined {
@@ -7440,6 +7492,37 @@ export class AgentSession {
 		return this.#models.getAvailableModels();
 	}
 
+	/**
+	 * Rebuild the model catalog from disk after a live config reload: re-parses
+	 * models.yml (custom providers/models) and re-runs provider discovery, then
+	 * re-applies settings-driven policies. Models added mid-session become
+	 * visible to /models and /switch without a restart.
+	 */
+	async refreshModels(strategy: ModelRefreshStrategy = "online-if-uncached"): Promise<void> {
+		// Serialize against startup's refreshInBackground(): a reload issued while
+		// background discovery is still running would start an unsynchronized
+		// refresh, and the older request could finish last and re-add a provider the
+		// reload just disabled (or overwrite the fresh catalog). No-op when no
+		// refresh is in flight.
+		await this.#modelRegistry.awaitBackgroundRefresh();
+		// Force the static rebuild BEFORE the online pass. `refresh()`'s static
+		// reload is mtime-gated, so a reload that only edits settings (e.g.
+		// removing a provider from `disabledProviders`, or toggling `extendedContext`)
+		// would reuse the old `#discoverableProviders` list; `reapplyModelPolicies()`
+		// forces the rebuild for the fresh settings, and the online pass below then
+		// discovers against it. Newly-enabled implicit providers (e.g. ollama) with
+		// no prior cache only surface here.
+		await this.#modelRegistry.reapplyModelPolicies();
+		await this.#modelRegistry.refresh(strategy);
+		// refresh() does not reject on a malformed models.yml: the custom layer
+		// comes back empty with a configError. Surface it so callers never report
+		// success while the live custom providers were dropped.
+		const configError = this.#modelRegistry.getError();
+		if (configError) {
+			throw new Error(`models.yml failed to load: ${configError.message}`);
+		}
+	}
+
 	/** Selects the session thinking level and optionally persists it as the default. */
 	setThinkingLevel(level: ConfiguredThinkingLevel | undefined, persist: boolean = false): void {
 		this.#models.setThinkingLevel(level, persist);
@@ -7486,29 +7569,30 @@ export class AgentSession {
 
 	/**
 	 * Set steering mode.
-	 * Saves to settings.
+	 * Saves to settings unless `persist` is false — reload reconciliation must
+	 * apply an overlay-provided value without promoting it into global config.
 	 */
-	setSteeringMode(mode: "all" | "one-at-a-time"): void {
+	setSteeringMode(mode: "all" | "one-at-a-time", persist: boolean = true): void {
 		this.agent.setSteeringMode(mode);
-		this.settings.set("steeringMode", mode);
+		if (persist) this.settings.set("steeringMode", mode);
 	}
 
 	/**
 	 * Set follow-up mode.
-	 * Saves to settings.
+	 * Saves to settings unless `persist` is false (see {@link setSteeringMode}).
 	 */
-	setFollowUpMode(mode: "all" | "one-at-a-time"): void {
+	setFollowUpMode(mode: "all" | "one-at-a-time", persist: boolean = true): void {
 		this.agent.setFollowUpMode(mode);
-		this.settings.set("followUpMode", mode);
+		if (persist) this.settings.set("followUpMode", mode);
 	}
 
 	/**
 	 * Set interrupt mode.
-	 * Saves to settings.
+	 * Saves to settings unless `persist` is false (see {@link setSteeringMode}).
 	 */
-	setInterruptMode(mode: "immediate" | "wait"): void {
+	setInterruptMode(mode: "immediate" | "wait", persist: boolean = true): void {
 		this.agent.setInterruptMode(mode);
-		this.settings.set("interruptMode", mode);
+		if (persist) this.settings.set("interruptMode", mode);
 	}
 
 	/**
@@ -9889,6 +9973,18 @@ export class AgentSession {
 	}
 
 	/**
+	 * Re-resolves role-driven consumers (advisors) against the current registry.
+	 * A reload that changes role assignments resolves them against whatever
+	 * catalog is loaded at signal time; call this after `refreshModels()` so a
+	 * consumer that recorded `no_model` during the stale window heals without
+	 * waiting for the next role change.
+	 */
+	reapplyModelRoles(): void {
+		if (this.#isDisposed) return;
+		this.#advisors.onModelRolesChanged();
+	}
+
+	/**
 	 * Reactivate an advisor that resolved to `no_model` at construction because a
 	 * discovery-backed provider had not populated the model registry yet. Awaits
 	 * the initial background refresh, then rebuilds the advisor and emits
@@ -9977,6 +10073,11 @@ export class AgentSession {
 	 */
 	getAdvisorStatusOverview(): { configured: boolean; advisors: { name: string; status: AdvisorRuntimeStatus }[] } {
 		return this.#advisors.getAdvisorStatusOverview();
+	}
+
+	/** Advisor OAuth contexts for provider usage-limit reporting (see SessionAdvisors). */
+	getAdvisorUsageAccounts(): { provider: string; providerSessionId?: string }[] {
+		return this.#advisors.getAdvisorUsageAccounts();
 	}
 
 	/** Return cumulative cost recorded for the current session's advisor activity. */

--- a/packages/coding-agent/src/session/session-advisors.ts
+++ b/packages/coding-agent/src/session/session-advisors.ts
@@ -1818,6 +1818,17 @@ export class SessionAdvisors {
 		return { configured: this.#advisorEnabled, advisors };
 	}
 
+	/**
+	 * Advisor OAuth contexts for usage-limit reporting. One entry per live
+	 * advisor: its model provider plus the provider session id its credentials
+	 * resolve from (the same derivation the runtime uses to pick the API key).
+	 * The status line keys its provider-usage fetch to these so the advisor's
+	 * 5h/7d quota displays independently of the primary model's provider.
+	 */
+	getAdvisorUsageAccounts(): { provider: string; providerSessionId?: string }[] {
+		return this.#advisors.map(a => ({ provider: a.model.provider, providerSessionId: a.providerSessionId }));
+	}
+
 	/** Return cumulative advisor cost recorded for the current session. */
 	getAdvisorCost(): number {
 		let cost = 0;

--- a/packages/coding-agent/src/session/turn-recovery.ts
+++ b/packages/coding-agent/src/session/turn-recovery.ts
@@ -2112,11 +2112,26 @@ export class TurnRecovery {
 		if (!staleOpenAIResponsesReplayError && !switchedCredential && currentSelector) {
 			// A refusal chain stops at the retry budget: the exhausted-attempt
 			// last resort is for provider failures, not classifier decisions.
+			// When the provider explicitly asked for a wait (retry-after header
+			// surfaced as `retry-after-ms=` in the error message), honor it on
+			// the same model/credential instead of drilling to a cold
+			// cross-provider fallback (cache bust + billed request) mid-window.
+			// The chain still engages after the budget exhausts.
+			//
+			// Capacity errors are the exception. A 429 quota window clears on its
+			// own and the same model is worth waiting for; a 503 "no capacity" or
+			// "hosted inference unavailable" is the route being down, and its
+			// retry-after is a guess at when that ends. Parking on it spends the
+			// whole budget on a model that cannot serve — a live outage burned ten
+			// attempts on `runinfra/deepseek-v4-pro` this way, with retry-after
+			// windows up to 38895ms, and never reached the OpenRouter leg.
+			const capacityUnavailable = rateLimitReason === "MODEL_CAPACITY_EXHAUSTED";
 			if (
 				allowModelFallback &&
 				retrySettings.modelFallback &&
 				!thinkingLoop &&
-				!(retryBudgetExhausted && classifierRefusal)
+				!(retryBudgetExhausted && classifierRefusal) &&
+				!(parsedRetryAfterMs !== undefined && !retryBudgetExhausted && !capacityUnavailable)
 			) {
 				if (!classifierRefusal) {
 					this.noteRetryFallbackCooldown(currentSelector, parsedRetryAfterMs, errorMessage);

--- a/packages/coding-agent/src/sharpshooter/consolidate.ts
+++ b/packages/coding-agent/src/sharpshooter/consolidate.ts
@@ -260,6 +260,10 @@ function parseReplacementFiles(content: readonly unknown[]): ReplacementFile[] {
 		}
 		files.push({ name, content: redacted });
 	}
+	const totalChars = files.reduce((sum, file) => sum + file.content.trim().length, 0);
+	if (totalChars === 0) {
+		throw new Error("replace_memory_files returned all-empty content; refusing to wipe memory files");
+	}
 	return files;
 }
 

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -1,5 +1,7 @@
 import type { AutocompleteItem } from "@oh-my-pi/pi-tui";
 import { COLLAB_GUEST_ALLOWED_COMMANDS } from "../collab/guest";
+import type { SettingPath } from "../config/settings";
+import { applySettingSideEffects, REPLAYED_SETTING_IDS } from "../modes/controllers/setting-side-effects";
 import { BUILTIN_COLLABORATION_SLASH_COMMANDS } from "./builtin-collaboration";
 import {
 	buildArgumentCompletions,
@@ -13,6 +15,7 @@ import { BUILTIN_LIFECYCLE_SLASH_COMMANDS } from "./builtin-lifecycle";
 import { BUILTIN_MARKETPLACE_SLASH_COMMANDS, reloadTuiPluginState } from "./builtin-marketplace";
 import { BUILTIN_MODE_SLASH_COMMANDS } from "./builtin-modes";
 import { BUILTIN_SESSION_SLASH_COMMANDS } from "./builtin-session";
+import { BUILTIN_SETTINGS_SLASH_COMMANDS } from "./builtin-settings";
 import { parseSlashCommand } from "./helpers/parse";
 import type {
 	BuiltinSlashCommand,
@@ -41,6 +44,7 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 	...BUILTIN_LIFECYCLE_SLASH_COMMANDS,
 	...BUILTIN_MARKETPLACE_SLASH_COMMANDS,
 	...BUILTIN_CONTROL_SLASH_COMMANDS,
+	...BUILTIN_SETTINGS_SLASH_COMMANDS,
 ];
 
 const BUILTIN_SLASH_COMMAND_LOOKUP = new Map<string, SlashCommandSpec>();
@@ -158,6 +162,15 @@ export async function executeBuiltinSlashCommand(
 			},
 			refreshCommands: () => ctx.refreshSlashCommandState(),
 			reloadPlugins: () => reloadTuiPluginState(ctx),
+			notifyConfigChanged: async () => {
+				// Replay the settings that components and agent fields cache at
+				// construction; a layer swap alone leaves them stale until the
+				// next editor swap. Queue modes are reconciled by the handler
+				// itself with persist=false, so they stay out of the replay list.
+				for (const id of REPLAYED_SETTING_IDS) {
+					applySettingSideEffects(ctx, id, ctx.settings.get(id as SettingPath), { persist: false });
+				}
+			},
 		};
 		const result = await command.handle(parsed, adapted);
 		ctx.editor.setText("");

--- a/packages/coding-agent/src/slash-commands/builtin-settings.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-settings.ts
@@ -1,0 +1,155 @@
+import { applyProviderGlobalsFromSettings } from "../config/provider-globals";
+import { buildServiceTierByFamily } from "../config/service-tier";
+import { SETTINGS_SCHEMA, type SettingPath } from "../config/settings";
+import type { SlashCommandSpec } from "./types";
+
+/**
+ * Maps a sampling setting value to the agent-field form: negative sentinels
+ * mean provider default and clear the field.
+ */
+function optionalNumber(raw: unknown): number | undefined {
+	const num = typeof raw === "number" ? raw : Number(raw);
+	return num >= 0 ? num : undefined;
+}
+
+export const BUILTIN_SETTINGS_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> = [
+	{
+		name: "reload-settings",
+		aliases: ["reload-config"],
+		description:
+			"Re-read config.yml (and project/overlay settings) from disk, refresh the models.yml model catalog, and apply both without a restart",
+		acpDescription: "Reload settings and models from disk",
+		handle: async (_command, runtime) => {
+			const before = new Map<SettingPath, unknown>();
+			for (const key of Object.keys(SETTINGS_SCHEMA) as SettingPath[]) {
+				before.set(key, runtime.settings.get(key));
+			}
+			await runtime.settings.reloadFromDisk();
+			await runtime.notifyConfigChanged?.();
+			// Refresh AFTER the settings reload so provider discovery sees the new
+			// disabled-provider set: an edit that enables a discovery-backed
+			// provider must surface its models in the same reload. Then re-resolve
+			// role consumers — the reload's modelRoles signal fired against the
+			// pre-refresh registry, so an advisor may have recorded no_model for a
+			// role that resolves fine now.
+			let modelsFailure: string | undefined;
+			try {
+				await runtime.session?.refreshModels();
+			} catch (error) {
+				modelsFailure = error instanceof Error ? error.message : String(error);
+			}
+			runtime.session?.reapplyModelRoles();
+			// Provider selection globals are module state consumed by web search
+			// and image tools in every host; a layer swap alone does not update it.
+			applyProviderGlobalsFromSettings(runtime.settings);
+			if (runtime.session && before.get("inspect_image.mode") !== runtime.settings.get("inspect_image.mode")) {
+				await runtime.session.applyInspectImageModeChange();
+			}
+			// Reconcile session-owned settings the reload cannot reach on its own:
+			// the live session snapshots these at construction (agent/SDK fields),
+			// so settings.get() alone would report them applied without changing
+			// actual behavior. persist=false — the value may come from a project
+			// or --config overlay, and writing it through settings.set would
+			// promote an overlay-only value into global config.
+			let scopeChanged = false;
+			let scopeFailure: string | undefined;
+			if (runtime.session) {
+				// Re-resolve the settings-derived model scope AFTER reloadFromDisk (new
+				// enabledModels values) and after refreshModels (fresh registry): the
+				// session freezes its scope at construction, so a reload that adds a
+				// model must push the rebuilt list or every scoped picker keeps the
+				// startup snapshot until restart.
+				try {
+					scopeChanged = (await runtime.session.refreshScopedModels?.()) ?? false;
+				} catch (error) {
+					scopeFailure = error instanceof Error ? error.message : String(error);
+				}
+				const nextAdvisorEnabled = runtime.settings.get("advisor.enabled");
+				if (runtime.session.isAdvisorEnabled() !== nextAdvisorEnabled) {
+					runtime.session.setAdvisorEnabled(nextAdvisorEnabled);
+				}
+				const nextSteeringMode = runtime.settings.get("steeringMode");
+				if (runtime.session.steeringMode !== nextSteeringMode) {
+					runtime.session.setSteeringMode(nextSteeringMode, false);
+				}
+				const nextFollowUpMode = runtime.settings.get("followUpMode");
+				if (runtime.session.followUpMode !== nextFollowUpMode) {
+					runtime.session.setFollowUpMode(nextFollowUpMode, false);
+				}
+				const nextInterruptMode = runtime.settings.get("interruptMode");
+				if (runtime.session.interruptMode !== nextInterruptMode) {
+					runtime.session.setInterruptMode(nextInterruptMode, false);
+				}
+				// Agent-owned request options: written through agent fields (never
+				// persisted), read per request by the SDK in every mode, so this
+				// reconcile is mode-independent. Negative settings values mean
+				// provider default and clear the field.
+				const agent = runtime.session.agent;
+				const nextTemperature = optionalNumber(runtime.settings.get("temperature"));
+				if (agent.temperature !== nextTemperature) {
+					agent.temperature = nextTemperature;
+				}
+				const nextTopP = optionalNumber(runtime.settings.get("topP"));
+				if (agent.topP !== nextTopP) {
+					agent.topP = nextTopP;
+				}
+				const nextTopK = optionalNumber(runtime.settings.get("topK"));
+				if (agent.topK !== nextTopK) {
+					agent.topK = nextTopK;
+				}
+				const nextMinP = optionalNumber(runtime.settings.get("minP"));
+				if (agent.minP !== nextMinP) {
+					agent.minP = nextMinP;
+				}
+				const nextPresencePenalty = optionalNumber(runtime.settings.get("presencePenalty"));
+				if (agent.presencePenalty !== nextPresencePenalty) {
+					agent.presencePenalty = nextPresencePenalty;
+				}
+				const nextRepetitionPenalty = optionalNumber(runtime.settings.get("repetitionPenalty"));
+				if (agent.repetitionPenalty !== nextRepetitionPenalty) {
+					agent.repetitionPenalty = nextRepetitionPenalty;
+				}
+				const nextOmitThinking = runtime.settings.get("omitThinking");
+				if (agent.hideThinkingSummary !== nextOmitThinking) {
+					agent.hideThinkingSummary = nextOmitThinking;
+				}
+				// Service tiers snapshot into ModelControls at construction; rebuild
+				// the per-family map from the reloaded `tier.*` settings and apply
+				// per-family changes so requests use the new tier without a restart.
+				// setServiceTierFamily does not persist — it mutates the live map.
+				const nextTierByFamily = buildServiceTierByFamily(
+					runtime.settings.get("tier.openai"),
+					runtime.settings.get("tier.anthropic"),
+					runtime.settings.get("tier.google"),
+				);
+				for (const family of ["openai", "anthropic", "google"] as const) {
+					const next = nextTierByFamily[family];
+					if (runtime.session.serviceTierByFamily[family] !== next) {
+						runtime.session.setServiceTierFamily(family, next);
+					}
+				}
+			}
+
+			const changed: SettingPath[] = [];
+			for (const [key, previous] of before) {
+				if (!Bun.deepEquals(previous, runtime.settings.get(key))) {
+					changed.push(key);
+				}
+			}
+			const scopeNote = scopeFailure
+				? ` Model scope refresh failed: ${scopeFailure}`
+				: scopeChanged
+					? " Model scope re-resolved."
+					: "";
+			if (modelsFailure) {
+				await runtime.output(`Settings reloaded from disk (models.yml failed: ${modelsFailure})${scopeNote}`);
+				return;
+			}
+			if (changed.length === 0) {
+				await runtime.output(`Settings reloaded from disk. No effective values changed.${scopeNote}`);
+				return;
+			}
+			await runtime.output(`Settings reloaded from disk. Applied: ${changed.join(", ")}${scopeNote}`);
+		},
+	},
+];

--- a/packages/coding-agent/test/agent-session-refresh-models.test.ts
+++ b/packages/coding-agent/test/agent-session-refresh-models.test.ts
@@ -1,0 +1,64 @@
+import { afterAll, describe, expect, it, vi } from "bun:test";
+import { Agent } from "@oh-my-pi/pi-agent-core";
+import { createMockModel } from "@oh-my-pi/pi-ai/providers/mock";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import type { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { TempDir } from "@oh-my-pi/pi-utils";
+import { YAML } from "bun";
+import { createInMemoryAuthStorage } from "./helpers/agent-session-setup";
+
+describe("AgentSession.refreshModels ordering", () => {
+	let tempDir: TempDir;
+	let authStorage: AuthStorage;
+	let session: AgentSession | undefined;
+
+	afterAll(async () => {
+		await session?.dispose();
+		authStorage.close();
+		await tempDir.remove();
+	});
+
+	it("forces the static rebuild before the online discovery pass", async () => {
+		tempDir = TempDir.createSync("@pi-refresh-models-");
+		authStorage = createInMemoryAuthStorage();
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		await Bun.write(tempDir.join("models.yml"), YAML.stringify({ models: [] }));
+
+		const modelRegistry = new ModelRegistry(authStorage, tempDir.join("models.yml"));
+		const settings = Settings.isolated({});
+		const primaryMock = createMockModel({ provider: "anthropic" });
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model: primaryMock, systemPrompt: [], tools: [] },
+			streamFn: primaryMock.stream,
+		});
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+		});
+
+		const order: string[] = [];
+		vi.spyOn(modelRegistry, "awaitBackgroundRefresh").mockImplementation(async () => {
+			order.push("awaitBackgroundRefresh");
+		});
+		vi.spyOn(modelRegistry, "reapplyModelPolicies").mockImplementation(async () => {
+			order.push("reapply");
+		});
+		vi.spyOn(modelRegistry, "refresh").mockImplementation(async () => {
+			order.push("refresh");
+		});
+
+		await session.refreshModels("offline");
+
+		// awaitBackgroundRefresh serializes against startup's in-flight discovery;
+		// reapplyModelPolicies forces the mtime-gated static rebuild; refresh then
+		// discovers against the fresh provider set. Any other order would reuse the
+		// stale provider set or let an out-of-order refresh re-add a disabled provider.
+		expect(order).toEqual(["awaitBackgroundRefresh", "reapply", "refresh"]);
+	});
+});

--- a/packages/coding-agent/test/agent-session-retry-fallback.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-fallback.test.ts
@@ -440,7 +440,9 @@ describe("AgentSession retry fallback", () => {
 		}
 
 		const requestedModels: string[] = [];
-		const agent = createFallbackAgent(primaryModel, requestedModels);
+		const agent = createFallbackAgent(primaryModel, requestedModels, {
+			firstError: "overloaded_error: provider returned error 503",
+		});
 
 		const settings = Settings.isolated({
 			"compaction.enabled": false,
@@ -1995,7 +1997,9 @@ describe("AgentSession retry fallback", () => {
 
 		const requestedModels: string[] = [];
 		const fallbackAppliedEvents: Array<Extract<AgentSessionEvent, { type: "retry_fallback_applied" }>> = [];
-		const agent = createFallbackAgent(primaryModel, requestedModels);
+		const agent = createFallbackAgent(primaryModel, requestedModels, {
+			firstError: "overloaded_error: provider returned error 503",
+		});
 
 		const settings = Settings.isolated({
 			"compaction.enabled": false,
@@ -2047,7 +2051,9 @@ describe("AgentSession retry fallback", () => {
 
 		const requestedModels: string[] = [];
 		const fallbackAppliedEvents: Array<Extract<AgentSessionEvent, { type: "retry_fallback_applied" }>> = [];
-		const agent = createFallbackAgent(primaryModel, requestedModels);
+		const agent = createFallbackAgent(primaryModel, requestedModels, {
+			firstError: "overloaded_error: provider returned error 503",
+		});
 
 		const settings = Settings.isolated({
 			"compaction.enabled": false,
@@ -2167,7 +2173,9 @@ describe("AgentSession retry fallback", () => {
 
 		const requestedModels: string[] = [];
 		const fallbackAppliedEvents: Array<Extract<AgentSessionEvent, { type: "retry_fallback_applied" }>> = [];
-		const agent = createFallbackAgent(primaryModel, requestedModels);
+		const agent = createFallbackAgent(primaryModel, requestedModels, {
+			firstError: "overloaded_error: provider returned error 503",
+		});
 
 		// No exact key for this model and no role assignment: only the
 		// `anthropic/*` wildcard can match, proving provider-level coverage.
@@ -2513,7 +2521,9 @@ describe("AgentSession retry fallback", () => {
 
 		const requestedModels: string[] = [];
 		const fallbackAppliedEvents: Array<Extract<AgentSessionEvent, { type: "retry_fallback_applied" }>> = [];
-		const agent = createFallbackAgent(primaryModel, requestedModels);
+		const agent = createFallbackAgent(primaryModel, requestedModels, {
+			firstError: "overloaded_error: provider returned error 503",
+		});
 
 		// `google-vertex/*` is not a fixed target: it must adopt the failing
 		// model's id (google/gemini-2.5-flash -> google-vertex/gemini-2.5-flash).
@@ -2566,7 +2576,9 @@ describe("AgentSession retry fallback", () => {
 
 		const requestedModels: string[] = [];
 		const fallbackAppliedEvents: Array<Extract<AgentSessionEvent, { type: "retry_fallback_applied" }>> = [];
-		const agent = createFallbackAgent(primaryModel, requestedModels);
+		const agent = createFallbackAgent(primaryModel, requestedModels, {
+			firstError: "overloaded_error: provider returned error 503",
+		});
 
 		// `openrouter/google/*` splits into provider `openrouter` + id prefix
 		// `google`: the failing bare id is re-prefixed into the aggregator's
@@ -2620,7 +2632,9 @@ describe("AgentSession retry fallback", () => {
 
 		const requestedModels: string[] = [];
 		const fallbackAppliedEvents: Array<Extract<AgentSessionEvent, { type: "retry_fallback_applied" }>> = [];
-		const agent = createFallbackAgent(primaryModel, requestedModels);
+		const agent = createFallbackAgent(primaryModel, requestedModels, {
+			firstError: "overloaded_error: provider returned error 503",
+		});
 
 		// Key `openrouter/google/*` covers only openrouter's google-namespaced
 		// ids; the plain `google-vertex/*` target drops the aggregator's vendor
@@ -2675,7 +2689,9 @@ describe("AgentSession retry fallback", () => {
 
 		const requestedModels: string[] = [];
 		const fallbackAppliedEvents: Array<Extract<AgentSessionEvent, { type: "retry_fallback_applied" }>> = [];
-		const agent = createFallbackAgent(primaryModel, requestedModels);
+		const agent = createFallbackAgent(primaryModel, requestedModels, {
+			firstError: "overloaded_error: provider returned error 503",
+		});
 
 		const settings = Settings.isolated({
 			"compaction.enabled": false,
@@ -3934,7 +3950,7 @@ describe("AgentSession retry fallback", () => {
 				requestedModels.push(requested);
 				if (requestedModel.provider === "openrouter" && primaryAttempts === 0) {
 					primaryAttempts += 1;
-					mock.push({ throw: "rate limit exceeded retry-after-ms=200" });
+					mock.push({ throw: "overloaded_error: provider returned error 503" });
 				} else {
 					mock.push({ content: [`ok:${requested}`] });
 				}
@@ -3990,7 +4006,7 @@ describe("AgentSession retry fallback", () => {
 				requestedModels.push(`${requestedModel.provider}/${requestedModel.id}`);
 				if (requestedModel.provider === primaryModel.provider && primaryAttempts === 0) {
 					primaryAttempts += 1;
-					mock.push({ throw: `rate limit exceeded retry-after-ms=${FALLBACK_TEST_RETRY_AFTER_MS}` });
+					mock.push({ throw: "overloaded_error: provider returned error 503" });
 				} else {
 					mock.push({ content: [`ok:${requestedModel.provider}/${requestedModel.id}`] });
 				}
@@ -4031,7 +4047,9 @@ describe("AgentSession retry fallback", () => {
 		}
 
 		const requestedModels: string[] = [];
-		const agent = createFallbackAgent(primaryModel, requestedModels, { retryAfterMs: 200 });
+		const agent = createFallbackAgent(primaryModel, requestedModels, {
+			firstError: "Too many requests",
+		});
 
 		const settings = Settings.isolated({
 			"compaction.enabled": false,
@@ -4071,7 +4089,7 @@ describe("AgentSession retry fallback", () => {
 		expect(session.model?.provider).toBe(fallbackModel.provider);
 		expect(session.model?.id).toBe(fallbackModel.id);
 
-		now += 240;
+		now += 31000;
 		await session.prompt("Third prompt should lazily revert to primary");
 		await session.waitForIdle();
 		expect(requestedModels).toEqual([
@@ -4261,7 +4279,7 @@ describe("AgentSession retry fallback", () => {
 				requestedModels.push(`${model.provider}/${model.id}`);
 				if (model.id === primaryModel.id && primaryAttempts === 0) {
 					primaryAttempts += 1;
-					mock.push({ throw: "rate limit exceeded retry-after-ms=200" });
+					mock.push({ throw: "Too many requests" });
 				} else if (model.id === fallbackModel.id && fallbackTurns === 0) {
 					fallbackTurns += 1;
 					mock.push({ content: [bigText] });
@@ -4380,7 +4398,7 @@ describe("AgentSession retry fallback", () => {
 				requestedModels.push(`${model.provider}/${model.id}`);
 				if (model.id === primaryModel.id && primaryAttempts === 0) {
 					primaryAttempts += 1;
-					mock.push({ throw: "rate limit exceeded retry-after-ms=200" });
+					mock.push({ throw: "overloaded_error: provider returned error 503" });
 				} else {
 					mock.push({ content: ["ok"] });
 				}
@@ -4464,7 +4482,7 @@ describe("AgentSession retry fallback", () => {
 					mock.push({
 						content: [{ type: "thinking", thinking: "lorem ipsum ".repeat(5000) }],
 						stopReason: "error",
-						errorMessage: "rate limit exceeded retry-after-ms=200",
+						errorMessage: "overloaded_error: provider returned error 503",
 					});
 				} else {
 					mock.push({ content: ["ok"] });
@@ -4541,7 +4559,7 @@ describe("AgentSession retry fallback", () => {
 				requestedModels.push(requested);
 				if (requested === "openrouter/z-ai/glm-4.7@cerebras" && primaryAttempts === 0) {
 					primaryAttempts += 1;
-					mock.push({ throw: "rate limit exceeded retry-after-ms=200" });
+					mock.push({ throw: "Too many requests" });
 				} else {
 					mock.push({ content: [`ok:${requested}`] });
 				}
@@ -4575,7 +4593,7 @@ describe("AgentSession retry fallback", () => {
 			`${fallbackModel.provider}/${fallbackModel.id}`,
 		]);
 
-		now += 240;
+		now += 31000;
 		await session.prompt("Second prompt should restore routed primary");
 		await session.waitForIdle();
 		expect(requestedModels).toEqual([
@@ -4597,7 +4615,9 @@ describe("AgentSession retry fallback", () => {
 		}
 
 		const requestedModels: string[] = [];
-		const agent = createFallbackAgent(primaryModel, requestedModels, { retryAfterMs: 200 });
+		const agent = createFallbackAgent(primaryModel, requestedModels, {
+			firstError: "Too many requests",
+		});
 
 		const settings = Settings.isolated({
 			"compaction.enabled": false,
@@ -4630,7 +4650,7 @@ describe("AgentSession retry fallback", () => {
 		expect(session.thinkingLevel).toBeUndefined();
 
 		session.setThinkingLevel(Effort.Low);
-		now += 240;
+		now += 31000;
 		await session.prompt("Second prompt should restore model but preserve user thinking change");
 		await session.waitForIdle();
 		expect(requestedModels).toEqual([
@@ -4651,7 +4671,9 @@ describe("AgentSession retry fallback", () => {
 		}
 
 		const requestedModels: string[] = [];
-		const agent = createFallbackAgent(primaryModel, requestedModels);
+		const agent = createFallbackAgent(primaryModel, requestedModels, {
+			firstError: "overloaded_error: provider returned error 503",
+		});
 
 		const settings = Settings.isolated({
 			"compaction.enabled": false,
@@ -4696,7 +4718,9 @@ describe("AgentSession retry fallback", () => {
 		}
 		const requestedModels: string[] = [];
 		const usageChecks: string[] = [];
-		const agent = createFallbackAgent(primaryModel, requestedModels);
+		const agent = createFallbackAgent(primaryModel, requestedModels, {
+			firstError: "overloaded_error: provider returned error 503",
+		});
 		const settings = Settings.isolated({
 			"compaction.enabled": false,
 			"retry.usageAwareFallback": true,
@@ -5142,7 +5166,9 @@ describe("AgentSession retry fallback", () => {
 		}
 
 		const requestedModels: string[] = [];
-		const agent = createFallbackAgent(primaryModel, requestedModels);
+		const agent = createFallbackAgent(primaryModel, requestedModels, {
+			firstError: "overloaded_error: provider returned error 503",
+		});
 		const settings = Settings.isolated({
 			"compaction.enabled": false,
 			"retry.baseDelayMs": 5,
@@ -5181,7 +5207,9 @@ describe("AgentSession retry fallback", () => {
 		}
 
 		const requestedModels: string[] = [];
-		const agent = createFallbackAgent(primaryModel, requestedModels);
+		const agent = createFallbackAgent(primaryModel, requestedModels, {
+			firstError: "overloaded_error: provider returned error 503",
+		});
 		const settings = Settings.isolated({
 			"compaction.enabled": false,
 			"retry.baseDelayMs": 5,
@@ -5332,6 +5360,248 @@ describe("AgentSession retry fallback", () => {
 
 		// Proactive: the primary was never requested, so no retry saga ran.
 		expect(requestedModels).toEqual([`${fallbackModel.provider}/${fallbackModel.id}`]);
+		expect(session.servingModel).toEqual({
+			selector: `${fallbackModel.provider}/${fallbackModel.id}`,
+			isFallback: true,
+		});
+	});
+
+	it("consults the chain on a capacity 503 even when it carries an explicit retry-after", async () => {
+		const primaryModel = getBundledModel("anthropic", "claude-sonnet-4-5");
+		const fallbackModel = getBundledModel("openai", "gpt-4o-mini");
+		if (!primaryModel || !fallbackModel) {
+			throw new Error("Expected bundled test models to exist");
+		}
+
+		const requestedModels: string[] = [];
+		const fallbackAppliedEvents: Array<Extract<AgentSessionEvent, { type: "retry_fallback_applied" }>> = [];
+		const mock = createMockModel({
+			responses: [
+				{ throw: "503 Hosted inference is temporarily unavailable. retry-after-ms=38895" },
+				{ content: ["Recovered on the fallback"] },
+			],
+		});
+		const agent = new Agent({
+			getApiKey: model => `${model.provider}-test-key`,
+			initialState: {
+				model: primaryModel,
+				systemPrompt: ["Test"],
+				tools: [],
+				messages: [],
+			},
+			streamFn: (requestedModel, context, options) => {
+				requestedModels.push(`${requestedModel.provider}/${requestedModel.id}`);
+				return mock.stream(requestedModel, context, options);
+			},
+		});
+
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"retry.baseDelayMs": 5,
+			"retry.maxRetries": 5,
+			"retry.fallbackChains": {
+				default: [`${fallbackModel.provider}/${fallbackModel.id}`],
+			},
+		});
+		settings.setModelRole("default", `${primaryModel.provider}/${primaryModel.id}`);
+
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+		});
+		const waitSpy = vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+		const { retryStartEvents } = trackRetryEvents(session);
+		session.subscribe(event => {
+			if (event.type === "retry_fallback_applied") {
+				fallbackAppliedEvents.push(event);
+			}
+		});
+
+		await session.prompt("Fail over instead of waiting out an outage");
+		await session.waitForIdle();
+
+		// The route is down, so its retry-after is a guess. The chain engages on
+		// the first attempt rather than spending the budget on a dead model.
+		expect(requestedModels).toEqual([
+			`${primaryModel.provider}/${primaryModel.id}`,
+			`${fallbackModel.provider}/${fallbackModel.id}`,
+		]);
+		expect(fallbackAppliedEvents).toHaveLength(1);
+		expect(fallbackAppliedEvents[0]).toMatchObject({
+			from: `${primaryModel.provider}/${primaryModel.id}`,
+			to: `${fallbackModel.provider}/${fallbackModel.id}`,
+			role: "default",
+		});
+		expect(retryStartEvents).toHaveLength(1);
+		expect(retryStartEvents[0]).toMatchObject({ delayMs: 0 });
+		expect(waitSpy).not.toHaveBeenCalledWith(38895, expect.anything());
+		expect(session.model?.provider).toBe(fallbackModel.provider);
+		expect(session.model?.id).toBe(fallbackModel.id);
+	});
+
+	it("parks the fallback consult on an explicit retry-after while budget remains", async () => {
+		const primaryModel = getBundledModel("anthropic", "claude-sonnet-4-5");
+		const fallbackModel = getBundledModel("openai", "gpt-4o-mini");
+		if (!primaryModel || !fallbackModel) {
+			throw new Error("Expected bundled test models to exist");
+		}
+
+		const requestedModels: string[] = [];
+		const fallbackAppliedEvents: Array<Extract<AgentSessionEvent, { type: "retry_fallback_applied" }>> = [];
+		const fallbackSucceededEvents: Array<Extract<AgentSessionEvent, { type: "retry_fallback_succeeded" }>> = [];
+		const mock = createMockModel({
+			responses: [{ throw: "rate limit exceeded retry-after-ms=200" }, { content: ["Recovered on primary retry"] }],
+		});
+		const agent = new Agent({
+			getApiKey: model => `${model.provider}-test-key`,
+			initialState: {
+				model: primaryModel,
+				systemPrompt: ["Test"],
+				tools: [],
+				messages: [],
+			},
+			streamFn: (requestedModel, context, options) => {
+				requestedModels.push(`${requestedModel.provider}/${requestedModel.id}`);
+				return mock.stream(requestedModel, context, options);
+			},
+		});
+
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"retry.baseDelayMs": 5,
+			"retry.maxRetries": 1,
+			"retry.fallbackChains": {
+				default: [`${fallbackModel.provider}/${fallbackModel.id}`],
+			},
+		});
+		settings.setModelRole("default", `${primaryModel.provider}/${primaryModel.id}`);
+
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+		});
+		const waitSpy = vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+		const { retryStartEvents, retryEndEvents } = trackRetryEvents(session);
+		session.subscribe(event => {
+			if (event.type === "retry_fallback_applied") {
+				fallbackAppliedEvents.push(event);
+			}
+			if (event.type === "retry_fallback_succeeded") {
+				fallbackSucceededEvents.push(event);
+			}
+		});
+
+		await session.prompt("Retry on the primary despite a configured chain");
+		await session.waitForIdle();
+
+		// The explicit retry-after parks the chain consult mid-budget: the same
+		// primary is retried after honoring the wait, never a cold fallback.
+		expect(requestedModels).toEqual([
+			`${primaryModel.provider}/${primaryModel.id}`,
+			`${primaryModel.provider}/${primaryModel.id}`,
+		]);
+		expect(retryStartEvents).toHaveLength(1);
+		expect(retryStartEvents[0]).toMatchObject({
+			attempt: 1,
+			maxAttempts: 1,
+			delayMs: 200,
+			errorMessage: "rate limit exceeded retry-after-ms=200",
+		});
+		expect(waitSpy).toHaveBeenCalledWith(200, { signal: expect.any(AbortSignal) });
+		expect(retryEndEvents).toHaveLength(1);
+		expect(retryEndEvents[0]).toMatchObject({ success: true, attempt: 1 });
+		expect(fallbackAppliedEvents).toHaveLength(0);
+		expect(fallbackSucceededEvents).toHaveLength(0);
+		expect(session.model?.provider).toBe(primaryModel.provider);
+		expect(session.model?.id).toBe(primaryModel.id);
+		const lastAssistant = getLastAssistantMessage(session);
+		expect(lastAssistant.stopReason).toBe("stop");
+		expect(lastAssistant.content).toContainEqual({ type: "text", text: "Recovered on primary retry" });
+	});
+
+	it("engages the fallback chain once the retry budget exhausts despite an explicit retry-after", async () => {
+		const primaryModel = getBundledModel("anthropic", "claude-sonnet-4-5");
+		const fallbackModel = getBundledModel("openai", "gpt-4o-mini");
+		if (!primaryModel || !fallbackModel) {
+			throw new Error("Expected bundled test models to exist");
+		}
+
+		const requestedModels: string[] = [];
+		const fallbackAppliedEvents: Array<Extract<AgentSessionEvent, { type: "retry_fallback_applied" }>> = [];
+		const mock = createMockModel();
+		let primaryAttempts = 0;
+		const agent = new Agent({
+			getApiKey: model => `${model.provider}-test-key`,
+			initialState: {
+				model: primaryModel,
+				systemPrompt: ["Test"],
+				tools: [],
+				messages: [],
+			},
+			streamFn: (model, context, options) => {
+				requestedModels.push(`${model.provider}/${model.id}`);
+				if (model.id === primaryModel.id && primaryAttempts < 2) {
+					primaryAttempts += 1;
+					mock.push({ throw: "rate limit exceeded retry-after-ms=200" });
+				} else {
+					mock.push({ content: [`ok:${model.provider}/${model.id}`] });
+				}
+				return mock.stream(model, context, options);
+			},
+		});
+
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"retry.baseDelayMs": 5,
+			"retry.maxRetries": 1,
+			"retry.fallbackChains": {
+				default: [`${fallbackModel.provider}/${fallbackModel.id}`],
+			},
+		});
+		settings.setModelRole("default", `${primaryModel.provider}/${primaryModel.id}`);
+
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+		});
+		const { retryStartEvents, retryEndEvents } = trackRetryEvents(session);
+		session.subscribe(event => {
+			if (event.type === "retry_fallback_applied") {
+				fallbackAppliedEvents.push(event);
+			}
+		});
+
+		await session.prompt("Exhaust the retry budget, then fail over");
+		await session.waitForIdle();
+
+		// The first park retries the primary after honoring the retry-after; the
+		// exhausted attempt finally consults the chain and lands on the fallback,
+		// which gets a fresh retry budget.
+		expect(requestedModels).toEqual([
+			`${primaryModel.provider}/${primaryModel.id}`,
+			`${primaryModel.provider}/${primaryModel.id}`,
+			`${fallbackModel.provider}/${fallbackModel.id}`,
+		]);
+		expect(retryStartEvents).toHaveLength(2);
+		expect(retryStartEvents[0]).toMatchObject({ maxAttempts: 1, delayMs: 200 });
+		expect(retryStartEvents[1]).toMatchObject({ maxAttempts: 1, delayMs: 0 });
+		expect(fallbackAppliedEvents).toHaveLength(1);
+		expect(fallbackAppliedEvents[0]).toMatchObject({
+			type: "retry_fallback_applied",
+			from: `${primaryModel.provider}/${primaryModel.id}`,
+			to: `${fallbackModel.provider}/${fallbackModel.id}`,
+			role: "default",
+		});
+		expect(retryEndEvents).toHaveLength(1);
+		expect(retryEndEvents[0]).toMatchObject({ success: true });
+		expect(session.model?.provider).toBe(fallbackModel.provider);
+		expect(session.model?.id).toBe(fallbackModel.id);
 		expect(session.servingModel).toEqual({
 			selector: `${fallbackModel.provider}/${fallbackModel.id}`,
 			isFallback: true,

--- a/packages/coding-agent/test/issue-3464-ollama-cloud-task-backoff.test.ts
+++ b/packages/coding-agent/test/issue-3464-ollama-cloud-task-backoff.test.ts
@@ -72,7 +72,7 @@ describe("issue #3464: ollama-cloud task backoff", () => {
 				requestedModels.push(`${model.provider}/${model.id}`);
 				if (model.provider === primary.provider && model.id === primary.id && primaryAttempts === 0) {
 					primaryAttempts += 1;
-					mock.push({ throw: "rate limit exceeded retry-after-ms=200" });
+					mock.push({ throw: "overloaded_error: provider returned error 503" });
 				} else {
 					mock.push({ content: [`ok:${model.provider}/${model.id}`] });
 				}

--- a/packages/coding-agent/test/main-rebuild-scoped-models.test.ts
+++ b/packages/coding-agent/test/main-rebuild-scoped-models.test.ts
@@ -100,8 +100,12 @@ describe("rebuildScopedModelsAfterDiscovery", () => {
 		const session = new FakeSession(await startupScope(["prov/a", "prov/b"], registry, settings));
 		const before = session.scopedModels;
 
-		// A later discovery pass adds an unrelated, out-of-scope model.
-		registry.available = [model("a"), model("b"), model("c")];
+		// A later discovery pass adds an unrelated, out-of-scope model. The
+		// in-scope records keep their original object identity — the real registry
+		// caches stable objects for unchanged providers, so a no-op pass must not
+		// look like a metadata change.
+		const [a, b] = registry.available;
+		registry.available = [a, b, model("c")];
 		await rebuildScopedModelsAfterDiscovery(session, parseArgs([]), registry, settings);
 
 		expect(session.setCalls).toBe(0);

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -995,6 +995,25 @@ describe("ModelRegistry", () => {
 			expect(anthropicModels.some(m => m.id.includes("claude"))).toBe(true);
 		});
 
+		test("refresh() keeps the last-good custom layer when models.json becomes malformed", async () => {
+			writeModelsJson({
+				prov: providerConfig("https://example.com/v1", [{ id: "m1" }]),
+			});
+			const registry = new ModelRegistry(authStorage, modelsJsonPath);
+			const model = registry.find("prov", "m1");
+			expect(model).toBeDefined();
+			expect(registry.hasConfiguredAuth(model!)).toBe(true);
+
+			// A malformed edit must surface the error but preserve the live catalog
+			// and its config-sourced API key instead of dropping them until repair.
+			fs.writeFileSync(modelsJsonPath, "{ definitely not valid json or yaml[");
+			await registry.refresh("offline");
+
+			expect(registry.getError()).toBeDefined();
+			expect(registry.find("prov", "m1")).toBeDefined();
+			expect(registry.hasConfiguredAuth(registry.find("prov", "m1")!)).toBe(true);
+		});
+
 		test("built-in gpt-5.4 applies the hardcoded context window policy", () => {
 			expect(sharedBuiltin.find("openai", "gpt-5.4")?.contextWindow).toBe(1_000_000);
 		});

--- a/packages/coding-agent/test/slash-commands/reload-settings.test.ts
+++ b/packages/coding-agent/test/slash-commands/reload-settings.test.ts
@@ -1,0 +1,457 @@
+import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from "bun:test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
+import type { Model } from "@oh-my-pi/pi-ai";
+import { clearCustomApis } from "@oh-my-pi/pi-ai/api-registry";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { sameScopedModelCycle, toSessionScopedModels } from "@oh-my-pi/pi-coding-agent/config/model-resolver";
+import type { SettingPath } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { REPLAYED_SETTING_IDS } from "@oh-my-pi/pi-coding-agent/modes/controllers/setting-side-effects";
+import { AgentStorage } from "@oh-my-pi/pi-coding-agent/session/agent-storage";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import {
+	executeBuiltinSlashCommand,
+	lookupBuiltinSlashCommand,
+} from "@oh-my-pi/pi-coding-agent/slash-commands/builtin-registry";
+import type { SlashCommandRuntime } from "@oh-my-pi/pi-coding-agent/slash-commands/types";
+import { getProjectAgentDir, TempDir } from "@oh-my-pi/pi-utils";
+import { YAML } from "bun";
+import { beginSettingsTest, restoreSettingsTestState, type SettingsTestState } from "../helpers/settings-test-state";
+
+describe("/reload-settings slash command", () => {
+	let settingsState: SettingsTestState | undefined;
+	let tempDir: TempDir;
+	let agentDir: string;
+	let projectDir: string;
+
+	beforeEach(() => {
+		settingsState = beginSettingsTest();
+		tempDir = TempDir.createSync("@pi-reload-settings-");
+		agentDir = tempDir.join("agent");
+		projectDir = tempDir.join("project");
+		fs.mkdirSync(agentDir, { recursive: true });
+		fs.mkdirSync(getProjectAgentDir(projectDir), { recursive: true });
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		clearCustomApis();
+		AgentStorage.close();
+		restoreSettingsTestState(settingsState);
+		settingsState = undefined;
+		await tempDir?.remove();
+	});
+
+	const configPath = () => path.join(agentDir, "config.yml");
+	const writeSettings = (settings: Record<string, unknown>) =>
+		Bun.write(configPath(), YAML.stringify(settings, null, 2));
+
+	interface CommandCalls {
+		output: Mock<(message?: string) => void>;
+		notifyConfigChanged: Mock<() => void>;
+		refreshModels: Mock<() => Promise<void>>;
+		reapplyModelRoles: Mock<() => void>;
+		setAdvisorEnabled: Mock<(enabled: boolean) => void>;
+		setSteeringMode: Mock<(mode: "all" | "one-at-a-time", persist?: boolean) => void>;
+		setServiceTierFamily: Mock<(family: "openai" | "anthropic" | "google", tier: unknown) => void>;
+		agent: {
+			temperature?: number;
+			topP?: number;
+			topK?: number;
+			minP?: number;
+			presencePenalty?: number;
+			repetitionPenalty?: number;
+			hideThinkingSummary?: boolean;
+		};
+	}
+
+	async function runCommand(
+		settings: Settings,
+		sessionOverrides: Partial<Record<string, unknown>> = {},
+	): Promise<CommandCalls> {
+		const command = lookupBuiltinSlashCommand("reload-settings");
+		expect(command).toBeDefined();
+		const output = vi.fn();
+		const notifyConfigChanged = vi.fn();
+		const refreshModels = vi.fn(async () => {});
+		const refreshScopedModels = vi.fn(async () => {});
+		const reapplyModelRoles = vi.fn();
+		const setAdvisorEnabled = vi.fn();
+		const setSteeringMode = vi.fn();
+		const setServiceTierFamily = vi.fn();
+		const agentFields = {
+			temperature: undefined as number | undefined,
+			topP: undefined as number | undefined,
+			topK: undefined as number | undefined,
+			minP: undefined as number | undefined,
+			presencePenalty: undefined as number | undefined,
+			repetitionPenalty: undefined as number | undefined,
+			hideThinkingSummary: false as boolean | undefined,
+		};
+		const session = {
+			refreshModels,
+			refreshScopedModels,
+			reapplyModelRoles,
+			isAdvisorEnabled: () => true,
+			setAdvisorEnabled,
+			steeringMode: "one-at-a-time",
+			followUpMode: "one-at-a-time",
+			interruptMode: "wait",
+			setSteeringMode,
+			setFollowUpMode: vi.fn(),
+			setInterruptMode: vi.fn(),
+			serviceTierByFamily: {},
+			setServiceTierFamily,
+			agent: agentFields,
+			...sessionOverrides,
+		};
+		const runtime = {
+			session,
+			sessionManager: undefined,
+			settings,
+			cwd: projectDir,
+			output,
+			refreshCommands: async () => {},
+			reloadPlugins: async () => {},
+			notifyConfigChanged,
+		} as unknown as SlashCommandRuntime;
+		await command!.handle?.({ name: "reload-settings", args: "", text: "/reload-settings" }, runtime);
+		return {
+			output,
+			notifyConfigChanged,
+			refreshModels: session.refreshModels as unknown as Mock<() => Promise<void>>,
+			reapplyModelRoles: session.reapplyModelRoles as unknown as Mock<() => void>,
+			setAdvisorEnabled,
+			setSteeringMode,
+			setServiceTierFamily,
+			agent: agentFields,
+		};
+	}
+
+	it("applies an on-disk edit and reports the changed setting", async () => {
+		await writeSettings({ advisor: { syncBacklog: "1" } });
+		const settings = await Settings.init({ cwd: projectDir, agentDir });
+		expect(settings.get("advisor.syncBacklog")).toBe("1");
+
+		await writeSettings({ advisor: { syncBacklog: "3" } });
+		const { output, notifyConfigChanged } = await runCommand(settings);
+
+		expect(settings.get("advisor.syncBacklog")).toBe("3");
+		expect(output).toHaveBeenCalledWith(expect.stringContaining("advisor.syncBacklog"));
+		expect(notifyConfigChanged).toHaveBeenCalled();
+	});
+
+	it("reports when nothing effectively changed", async () => {
+		await writeSettings({ advisor: { syncBacklog: "1" } });
+		const settings = await Settings.init({ cwd: projectDir, agentDir });
+
+		const { output } = await runCommand(settings);
+		expect(output).toHaveBeenCalledWith(expect.stringContaining("No effective values changed"));
+	});
+
+	it("refreshes the model catalog from a live models.yml edit", async () => {
+		const modelsPath = path.join(agentDir, "models.yml");
+		const writeModels = (withAdded: boolean) =>
+			Bun.write(
+				modelsPath,
+				YAML.stringify({
+					providers: {
+						liveprov: {
+							baseUrl: "https://example.invalid/v1",
+							api: "openai-completions",
+							apiKey: "sk-test",
+							models: [
+								{ id: "alpha-base", name: "Alpha Base" },
+								...(withAdded ? [{ id: "alpha-added", name: "Alpha Added" }] : []),
+							],
+						},
+					},
+				}),
+			);
+		await writeModels(false);
+		const authStorage = await AuthStorage.create(":memory:");
+		try {
+			const registry = new ModelRegistry(authStorage, modelsPath);
+			const idsBefore = registry.getAvailable().map(model => model.id);
+			expect(idsBefore).toContain("alpha-base");
+			expect(idsBefore).not.toContain("alpha-added");
+
+			// Static reloads are mtime-gated; stamp a distinct mtime instead of
+			// sleeping, so the rewrite deterministically passes the gate.
+			await writeModels(true);
+			const bumped = new Date(Date.now() + 60_000);
+			fs.utimesSync(modelsPath, bumped, bumped);
+			await registry.refresh("online-if-uncached");
+
+			const idsAfter = registry.getAvailable().map(model => model.id);
+			expect(idsAfter).toContain("alpha-base");
+			expect(idsAfter).toContain("alpha-added");
+		} finally {
+			authStorage.close();
+		}
+	});
+
+	it("tells the session to refresh its model catalog after a config reload", async () => {
+		await writeSettings({ advisor: { syncBacklog: "1" } });
+		const settings = await Settings.init({ cwd: projectDir, agentDir });
+
+		const { refreshModels, output } = await runCommand(settings);
+		expect(refreshModels).toHaveBeenCalled();
+		expect(output).toHaveBeenCalledWith(expect.stringContaining("No effective values changed"));
+	});
+
+	it("reloads settings before refreshing the catalog so provider discovery sees the new disabled set", async () => {
+		await writeSettings({ advisor: { syncBacklog: "1" } });
+		const settings = await Settings.init({ cwd: projectDir, agentDir });
+		const reloadSpy = vi.spyOn(settings, "reloadFromDisk");
+
+		const { refreshModels } = await runCommand(settings);
+		expect(reloadSpy.mock.invocationCallOrder[0]).toBeLessThan(refreshModels.mock.invocationCallOrder[0]);
+	});
+
+	it("re-resolves role consumers after the catalog refresh", async () => {
+		await writeSettings({ advisor: { syncBacklog: "1" } });
+		const settings = await Settings.init({ cwd: projectDir, agentDir });
+
+		const { refreshModels, reapplyModelRoles } = await runCommand(settings);
+		expect(reapplyModelRoles).toHaveBeenCalled();
+		expect(reapplyModelRoles.mock.invocationCallOrder[0]).toBeGreaterThan(refreshModels.mock.invocationCallOrder[0]);
+	});
+
+	it("reconciles session-owned advisor and queue-mode settings without promoting them into config", async () => {
+		await writeSettings({ advisor: { enabled: false, syncBacklog: "1" }, steeringMode: "one-at-a-time" });
+		const settings = await Settings.init({ cwd: projectDir, agentDir });
+		await writeSettings({ advisor: { enabled: true, syncBacklog: "1" }, steeringMode: "all" });
+		const setSpy = vi.spyOn(settings, "set");
+
+		const { setAdvisorEnabled, setSteeringMode, output } = await runCommand(settings, {
+			isAdvisorEnabled: () => false,
+			steeringMode: "one-at-a-time",
+		});
+		expect(setAdvisorEnabled).toHaveBeenCalledWith(true);
+		expect(setSteeringMode).toHaveBeenCalledWith("all", false);
+		for (const [key] of setSpy.mock.calls) {
+			expect(["steeringMode", "followUpMode", "interruptMode"]).not.toContain(key);
+		}
+		expect(output).toHaveBeenCalledWith(expect.stringContaining("advisor.enabled"));
+	});
+
+	it("reports a malformed models.yml instead of claiming success", async () => {
+		await writeSettings({ advisor: { syncBacklog: "1" } });
+		const settings = await Settings.init({ cwd: projectDir, agentDir });
+
+		const { refreshModels, output } = await runCommand(settings, {
+			refreshModels: vi.fn(async () => {
+				throw new Error("models.yml failed to load: boom");
+			}),
+		});
+		expect(refreshModels).toHaveBeenCalled();
+		expect(output).toHaveBeenCalledWith(expect.stringContaining("failed to load: boom"));
+	});
+
+	it("never installs layers older than a mutation that lands mid-reload", async () => {
+		await writeSettings({ advisor: { syncBacklog: "1" } });
+		const settings = await Settings.init({ cwd: projectDir, agentDir });
+
+		const reload = settings.reloadFromDisk();
+		settings.set("advisor.syncBacklog", "3");
+		await reload;
+
+		expect(settings.get("advisor.syncBacklog")).toBe("3");
+		const onDisk = YAML.parse(await Bun.file(configPath()).text());
+		expect((onDisk as { advisor: { syncBacklog: string } }).advisor.syncBacklog).toBe("3");
+	});
+	it("reapplies a changed service tier to the live session", async () => {
+		await writeSettings({ advisor: { syncBacklog: "1" } });
+		const settings = await Settings.init({ cwd: projectDir, agentDir });
+		await writeSettings({ advisor: { syncBacklog: "1" }, tier: { openai: "priority" } });
+
+		const { setServiceTierFamily, output } = await runCommand(settings);
+		expect(setServiceTierFamily).toHaveBeenCalledWith("openai", "priority");
+		expect(output).toHaveBeenCalledWith(expect.stringContaining("tier.openai"));
+	});
+
+	it("clears a service tier when its setting becomes empty", async () => {
+		await writeSettings({ advisor: { syncBacklog: "1" }, tier: { openai: "priority" } });
+		const settings = await Settings.init({ cwd: projectDir, agentDir });
+		const setServiceTierFamily = vi.fn();
+		await writeSettings({ advisor: { syncBacklog: "1" } });
+
+		const { output } = await runCommand(settings, {
+			serviceTierByFamily: { openai: "priority" },
+			setServiceTierFamily,
+		});
+		expect(setServiceTierFamily).toHaveBeenCalledWith("openai", undefined);
+		expect(output).toHaveBeenCalledWith(expect.stringContaining("tier.openai"));
+	});
+
+	it("reconciles agent-owned request options without persisting them", async () => {
+		await writeSettings({ advisor: { syncBacklog: "1" }, temperature: -1, omitThinking: false });
+		const settings = await Settings.init({ cwd: projectDir, agentDir });
+		await writeSettings({ advisor: { syncBacklog: "1" }, temperature: 0.7, omitThinking: true });
+		const setSpy = vi.spyOn(settings, "set");
+
+		const { agent } = await runCommand(settings);
+		expect(agent.temperature).toBe(0.7);
+		expect(agent.hideThinkingSummary).toBe(true);
+		for (const [key] of setSpy.mock.calls) {
+			expect(["temperature", "omitThinking"]).not.toContain(key);
+		}
+	});
+
+	it("replays only ids that are valid setting paths", async () => {
+		const settings = await Settings.init({ cwd: projectDir, agentDir });
+		for (const id of REPLAYED_SETTING_IDS) {
+			expect(() => settings.get(id as SettingPath)).not.toThrow();
+		}
+	});
+
+	it("runs the full reload through the TUI adapter without aborting", async () => {
+		await writeSettings({ advisor: { syncBacklog: "1" }, autocompleteMaxVisible: 7 });
+		const settings = await Settings.init({ cwd: projectDir, agentDir });
+
+		const editorSetAutocomplete = vi.fn();
+		const ctx = {
+			session: {
+				refreshModels: vi.fn(async () => {}),
+				reapplyModelRoles: vi.fn(),
+				isAdvisorEnabled: () => true,
+				setAdvisorEnabled: vi.fn(),
+				steeringMode: "one-at-a-time",
+				followUpMode: "one-at-a-time",
+				interruptMode: "wait",
+				setSteeringMode: vi.fn(),
+				setFollowUpMode: vi.fn(),
+				setInterruptMode: vi.fn(),
+				setThinkingLevel: vi.fn(),
+				refreshBaseSystemPrompt: vi.fn(async () => {}),
+				applyMemoryBackend: vi.fn(async () => {}),
+				setThinkToolEnabled: vi.fn(async () => {}),
+				setAutoCompactionEnabled: vi.fn(),
+				serviceTierByFamily: {},
+				setServiceTierFamily: vi.fn(),
+				agent: {},
+			},
+			sessionManager: { getCwd: () => projectDir },
+			settings,
+			ui: {
+				requestRender: vi.fn(),
+				invalidate: vi.fn(),
+				clearInlineImages: vi.fn(),
+				setResizeScrollback: vi.fn(),
+			},
+			editor: {
+				setText: vi.fn(),
+				setAutocompleteMaxVisible: editorSetAutocomplete,
+				setImeSafeCursorLayout: vi.fn(),
+			},
+			syncEditorSpelling: vi.fn(),
+			syncComposerShape: vi.fn(),
+			updateEditorBorderColor: vi.fn(),
+			rebuildChatFromMessages: vi.fn(),
+			effectiveHideThinkingBlock: false,
+			hideToolActivity: false,
+			toolOutputExpanded: false,
+			showError: vi.fn(),
+			statusLine: {
+				invalidate: vi.fn(),
+				setAutoCompactEnabled: vi.fn(),
+				updateSettings: vi.fn(),
+			},
+			chatContainer: { children: [], setToolActivityVisible: vi.fn() },
+			showStatus: vi.fn(),
+			refreshSlashCommandState: vi.fn(),
+		};
+		const result = await executeBuiltinSlashCommand("/reload-settings", { ctx } as never);
+		expect(result).toBe(true);
+		expect(editorSetAutocomplete).toHaveBeenCalledWith(7);
+	});
+
+	it("re-resolves the settings-derived model scope and reports it", async () => {
+		await writeSettings({ enabledModels: ["liveprov/alpha-base"] });
+		const settings = await Settings.init({ cwd: projectDir, agentDir });
+
+		const refreshScopedModels = vi.fn(async () => true);
+		const { output } = await runCommand(settings, { refreshScopedModels });
+
+		expect(refreshScopedModels).toHaveBeenCalled();
+		expect(output).toHaveBeenCalledWith(expect.stringContaining("Model scope re-resolved."));
+	});
+
+	it("reports a scope-refresh failure without losing the reload result", async () => {
+		await writeSettings({ advisor: { syncBacklog: "1" } });
+		const settings = await Settings.init({ cwd: projectDir, agentDir });
+		await writeSettings({ advisor: { syncBacklog: "3" } });
+
+		const { output } = await runCommand(settings, {
+			refreshScopedModels: vi.fn(async () => {
+				throw new Error("scope exploded");
+			}),
+		});
+
+		expect(output).toHaveBeenCalledWith(expect.stringContaining("advisor.syncBacklog"));
+		expect(output).toHaveBeenCalledWith(expect.stringContaining("Model scope refresh failed: scope exploded"));
+	});
+
+	it("re-resolves the scope only after the reloaded settings take effect", async () => {
+		await writeSettings({ advisor: { syncBacklog: "1" } });
+		const settings = await Settings.init({ cwd: projectDir, agentDir });
+		await writeSettings({
+			advisor: { syncBacklog: "1" },
+			enabledModels: ["liveprov/alpha-base"],
+		});
+
+		let seenDuringScopeRefresh: unknown;
+		await runCommand(settings, {
+			refreshScopedModels: vi.fn(async () => {
+				seenDuringScopeRefresh = settings.get("enabledModels");
+				return false;
+			}),
+		});
+
+		// A pre-reload resolution would observe the stale empty list.
+		expect(seenDuringScopeRefresh).toEqual(["liveprov/alpha-base"]);
+	});
+});
+
+describe("session scope helpers", () => {
+	const fakeModel = (provider: string, id: string): Model => ({ provider, id }) as unknown as Model;
+
+	it("maps resolver scope to cycle entries, filling non-explicit levels with the configured default", () => {
+		const mapped = toSessionScopedModels(
+			[
+				{ model: fakeModel("prov", "one"), thinkingLevel: "low" as ThinkingLevel, explicitThinkingLevel: true },
+				{ model: fakeModel("prov", "two"), thinkingLevel: undefined, explicitThinkingLevel: false },
+			],
+			Settings.isolated({ defaultThinkingLevel: "high" }),
+		);
+		expect(mapped.map(entry => entry.thinkingLevel).join(",")).toBe("low,high");
+		expect(toSessionScopedModels([], Settings.isolated())).toEqual([]);
+	});
+
+	it("is element-wise ordered, level-, and record-sensitive for the cycle guard", () => {
+		const a = [
+			{ model: fakeModel("p", "x"), thinkingLevel: "low" as ThinkingLevel },
+			{ model: fakeModel("q", "y"), thinkingLevel: "high" as ThinkingLevel },
+		];
+		expect(sameScopedModelCycle(a, [...a])).toBe(true);
+		// Same set, reordered: a reorder carries user intent in the scope cycle.
+		expect(sameScopedModelCycle(a, [a[1], a[0]])).toBe(false);
+		// Same order and set, thinking level changed: must reinstall the rebuilt scope.
+		expect(
+			sameScopedModelCycle(a, [{ model: fakeModel("p", "x"), thinkingLevel: "high" as ThinkingLevel }, a[1]]),
+		).toBe(false);
+		// Same order, level, different model id.
+		expect(
+			sameScopedModelCycle(a, [{ model: fakeModel("p", "z"), thinkingLevel: "low" as ThinkingLevel }, a[1]]),
+		).toBe(false);
+		// Same order, level, and provider/id but a NEW model record (catalog
+		// metadata change): refresh swapped in a fresh object, so the cycle must
+		// reinstall rather than keep the stale record.
+		expect(
+			sameScopedModelCycle(a, [{ model: fakeModel("p", "x"), thinkingLevel: "low" as ThinkingLevel }, a[1]]),
+		).toBe(false);
+	});
+});

--- a/packages/coding-agent/test/status-line-loop.test.ts
+++ b/packages/coding-agent/test/status-line-loop.test.ts
@@ -49,6 +49,7 @@ function createContext(loopMode: SegmentContext["loopMode"]): SegmentContext {
 		worktree: null,
 		git: { branch: null, status: null, pr: null },
 		usage: null,
+		advisorUsage: null,
 	};
 }
 

--- a/packages/coding-agent/test/status-line-model.test.ts
+++ b/packages/coding-agent/test/status-line-model.test.ts
@@ -56,6 +56,7 @@ function createModelContext(advisorActive: boolean): SegmentContext {
 		worktree: null,
 		git: { branch: null, status: null, pr: null },
 		usage: null,
+		advisorUsage: null,
 	};
 }
 

--- a/packages/coding-agent/test/status-line-overflow.test.ts
+++ b/packages/coding-agent/test/status-line-overflow.test.ts
@@ -88,6 +88,7 @@ function createCtx(overrides?: {
 			pr: null,
 		},
 		usage: null,
+		advisorUsage: null,
 	};
 }
 
@@ -297,7 +298,7 @@ describe("overflow: path shrinks before git is dropped", () => {
 		width: number,
 		leftSegmentIds: StatusLineSegmentId[],
 		ctx: SegmentContext,
-	): { surviving: StatusLineSegmentId[]; contents: string[] } {
+	): { surviving: StatusLineSegmentId[]; contents: string[]; overflow: string[] } {
 		const left: string[] = [];
 		const leftSegIds: StatusLineSegmentId[] = [];
 		for (const segId of leftSegmentIds) {
@@ -355,13 +356,17 @@ describe("overflow: path shrinks before git is dropped", () => {
 			}
 			return left.length - 1;
 		};
+		// Segment contents shed by the budget, in original (left-group reading) order —
+		// mirrors production, which moves these to the overflow line instead of losing them.
+		const overflow: string[] = [];
 		while (groupWidth() > width && left.length > 0) {
 			const dropIdx = leftOverflowDropIndex();
+			overflow.push(left[dropIdx]);
 			left.splice(dropIdx, 1);
 			leftSegIds.splice(dropIdx, 1);
 		}
 
-		return { surviving: [...leftSegIds], contents: [...left] };
+		return { surviving: [...leftSegIds], contents: [...left], overflow: [...overflow].reverse() };
 	}
 
 	it("keeps git segment when path can be shrunk to fit", () => {
@@ -377,6 +382,7 @@ describe("overflow: path shrinks before git is dropped", () => {
 
 		expect(result.surviving).toContain("git");
 		expect(result.surviving).toContain("path");
+		expect(result.overflow).toEqual([]);
 	});
 
 	it("drops git only when terminal is extremely narrow", () => {
@@ -393,6 +399,7 @@ describe("overflow: path shrinks before git is dropped", () => {
 		const result = simulateOverflow(200, ["path", "git"], ctx);
 
 		expect(result.surviving).toEqual(["path", "git"]);
+		expect(result.overflow).toEqual([]);
 	});
 
 	it("shrinks a short path when maxLength exceeds actual path length", () => {
@@ -504,8 +511,128 @@ describe("overflow: path survives before model", () => {
 		expect(groupWidth([pi, model, minPath])).toBeGreaterThan(width);
 		expect(groupWidth([pi, minPath])).toBeLessThanOrEqual(width);
 
-		const rendered = stripAnsi(component.getTopBorder(width).content);
-		expect(rendered).toContain("xyz");
-		expect(rendered).not.toContain("MODEL_SHOULD_DROP");
+		const border = component.getTopBorder(width);
+		const lines = border.content.split("\n");
+		// Line 1 keeps the cwd path and sheds the model segment — kept-set unchanged.
+		expect(stripAnsi(lines[0])).toContain("xyz");
+		expect(stripAnsi(lines[0])).not.toContain("MODEL_SHOULD_DROP");
+		// The shed segment is preserved on the overflow line instead of being lost.
+		expect(lines.length).toBe(2);
+		expect(stripAnsi(lines[1])).toContain("MODEL_SHOULD_DROP");
+	});
+});
+
+describe("status line two-line overflow", () => {
+	/**
+	 * Component whose left group (pi, model, path) overflows a tight width and
+	 * sheds the model segment; a generous width keeps everything on one line.
+	 */
+	function buildLeftOverflow() {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "omp-statusline-twoline-"));
+		const cwd = path.join(root, "cwdxyz");
+		fs.mkdirSync(cwd);
+		setProjectDir(cwd);
+
+		const modelName = `MODEL_KEPT_ON_LINE2_${"x".repeat(20)}`;
+		const component = new StatusLineComponent(createStatusLineSession("two line overflow", modelName));
+		const pathOptions = { abbreviate: false, maxLength: 32, stripWorkPrefix: false };
+		component.updateSettings({
+			preset: "custom",
+			leftSegments: ["pi", "model", "path"],
+			rightSegments: [],
+			separator: "none",
+			sessionAccent: false,
+			transparent: true,
+			segmentOptions: {
+				model: { showThinkingLevel: false },
+				path: pathOptions,
+			},
+		});
+		return { component, modelName, pathOptions };
+	}
+
+	function leftOverflowWidth(
+		session: object,
+		pathOptions: { abbreviate: boolean; maxLength: number; stripWorkPrefix: boolean },
+	): number {
+		const ctx = {
+			...createCtx({ pathMaxLength: pathOptions.maxLength }),
+			session,
+			options: {
+				model: { showThinkingLevel: false },
+				path: pathOptions,
+			},
+		} as SegmentContext;
+		const pi = renderSegment("pi", ctx).content;
+		const model = renderSegment("model", ctx).content;
+		const separatorWidth = visibleWidth(theme.sep.space);
+		const groupWidth = (parts: string[]) =>
+			parts.reduce((sum, part) => sum + visibleWidth(part), 0) +
+			Math.max(0, parts.length - 1) * (separatorWidth + 2) +
+			2;
+		return groupWidth([pi, model]) + 1;
+	}
+
+	it("moves the dropped left segment to a second line instead of losing it", () => {
+		const { component, modelName, pathOptions } = buildLeftOverflow();
+		const width = leftOverflowWidth(createStatusLineSession("two line overflow", modelName), pathOptions);
+
+		const border = component.getTopBorder(width);
+		const lines = border.content.split("\n");
+		// Line 1 sheds the model (same kept-set as before); line 2 keeps its text.
+		expect(lines.length).toBe(2);
+		expect(stripAnsi(lines[0])).toContain("xyz");
+		expect(stripAnsi(lines[0])).not.toContain(modelName);
+		expect(stripAnsi(lines[1])).toContain(modelName);
+	});
+
+	it("stays single-line at a generous width (no regression)", () => {
+		const { component, modelName } = buildLeftOverflow();
+		const border = component.getTopBorder(500);
+		expect(border.content).not.toContain("\n");
+		expect(stripAnsi(border.content)).toContain(modelName);
+	});
+
+	it("reports the max visible line width for a two-line overflow", () => {
+		const { component, modelName, pathOptions } = buildLeftOverflow();
+		const session = createStatusLineSession("two line overflow", modelName);
+		const width = leftOverflowWidth(session, pathOptions);
+
+		const border = component.getTopBorder(width);
+		const lines = border.content.split("\n");
+		expect(lines.length).toBe(2);
+		const lineWidths = lines.map(line => visibleWidth(line));
+		expect(border.width).toBe(Math.max(...lineWidths));
+	});
+
+	it("moves popped right segments to a second line instead of losing them", () => {
+		const session = createStatusLineSession("Right session", `MODEL_RIGHT_${"z".repeat(24)}`);
+		const component = new StatusLineComponent(session);
+		component.updateSettings({
+			preset: "custom",
+			leftSegments: ["pi"],
+			rightSegments: ["model", "session_name"],
+			separator: "none",
+			sessionAccent: false,
+			transparent: true,
+			segmentOptions: { model: { showThinkingLevel: false } },
+		});
+
+		// Generous width: everything fits on line 1.
+		const wide = component.getTopBorder(500).content;
+		expect(wide).not.toContain("\n");
+		expect(stripAnsi(wide)).toContain("Right session");
+		expect(stripAnsi(wide)).toContain("MODEL_RIGHT_");
+
+		// Very narrow width pops the right group's segments to the overflow line.
+		const border = component.getTopBorder(8);
+		const lines = border.content.split("\n");
+		expect(lines.length).toBe(2);
+		expect(stripAnsi(lines[0])).not.toContain("Right session");
+		const line2 = stripAnsi(lines[1]);
+		// Line-1 budgeting may truncate the elastic title before it pops;
+		// it must still land on the overflow row instead of being lost.
+		expect(line2).toContain("Right s");
+		expect(line2).toContain("MODEL_RIGHT_");
 	});
 });

--- a/packages/coding-agent/test/status-line-path.test.ts
+++ b/packages/coding-agent/test/status-line-path.test.ts
@@ -73,6 +73,7 @@ function createPathContext(): SegmentContext {
 			pr: null,
 		},
 		usage: null,
+		advisorUsage: null,
 	};
 }
 

--- a/packages/coding-agent/test/status-line-time-spent.test.ts
+++ b/packages/coding-agent/test/status-line-time-spent.test.ts
@@ -71,6 +71,7 @@ function createCtx(activeMs: number): SegmentContext {
 		worktree: null,
 		git: { branch: null, status: null, pr: null },
 		usage: null,
+		advisorUsage: null,
 	};
 }
 

--- a/packages/coding-agent/test/status-line-usage.test.ts
+++ b/packages/coding-agent/test/status-line-usage.test.ts
@@ -3,7 +3,7 @@ import { stripVTControlCharacters } from "node:util";
 import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { StatusLineComponent } from "@oh-my-pi/pi-coding-agent/modes/components/status-line";
 import { renderSegment } from "@oh-my-pi/pi-coding-agent/modes/components/status-line/segments";
-import type { SegmentContext } from "@oh-my-pi/pi-coding-agent/modes/components/status-line/types";
+import type { SegmentContext, StatusLineSegmentId } from "@oh-my-pi/pi-coding-agent/modes/components/status-line/types";
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 
 beforeAll(async () => {
@@ -22,6 +22,9 @@ function makeComponent(
 		provider?: string;
 		modelId?: string;
 		activeIdentity?: { accountId?: string; email?: string; projectId?: string };
+		advisorCost?: number;
+		advisorAccounts?: { provider: string; providerSessionId?: string }[];
+		rightSegments?: StatusLineSegmentId[];
 	} = {},
 ): StatusLineComponent {
 	const component = new StatusLineComponent({
@@ -43,18 +46,21 @@ function makeComponent(
 		},
 		fetchUsageReports: async () => reports,
 		modelRegistry: {
+			isUsingOAuth: () => false,
 			authStorage: {
 				getOAuthAccountIdentity: (provider: string) =>
 					provider === options.provider ? options.activeIdentity : undefined,
 			},
 		},
+		getAdvisorCost: () => options.advisorCost ?? 0,
+		getAdvisorUsageAccounts: () => options.advisorAccounts ?? [],
 		getAsyncJobSnapshot: () => ({ running: [] }),
 		getContextUsage: () => undefined,
 	} as unknown as ConstructorParameters<typeof StatusLineComponent>[0]);
 	component.updateSettings({
 		preset: "custom",
 		leftSegments: [],
-		rightSegments: ["usage"],
+		rightSegments: options.rightSegments ?? ["usage"],
 		sessionAccent: false,
 	});
 	return component;
@@ -66,6 +72,21 @@ async function flushUsageRefresh(): Promise<void> {
 	await timer.promise;
 	await Promise.resolve();
 	await Promise.resolve();
+}
+
+async function renderCost(options: {
+	reports: unknown;
+	advisorCost?: number;
+	advisorAccounts?: { provider: string; providerSessionId?: string }[];
+}): Promise<string> {
+	const component = makeComponent(options.reports, {
+		advisorCost: options.advisorCost,
+		advisorAccounts: options.advisorAccounts,
+		rightSegments: ["cost"],
+	});
+	component.refreshUsageInBackground();
+	await flushUsageRefresh();
+	return stripVTControlCharacters(component.getTopBorder(200).content);
 }
 
 describe("usage status-line segment", () => {
@@ -624,6 +645,11 @@ describe("usage status-line segment", () => {
 		expect(low.visible).toBe(true);
 		expect(stripVTControlCharacters(highWithoutValue)).toBe(stripVTControlCharacters(lowWithoutValue));
 		expect(highWithoutValue).not.toBe(lowWithoutValue);
+		// A low value carries no color of its own: it inherits the segment color
+		// (bright with the label) instead of dimming to muted.
+		expect(/\x1b\[[0-9;]*m24%/.test(low.content)).toBe(false);
+		// The eighty-percent value is wrapped in its own error color.
+		expect(/\x1b\[[0-9;]*m80%/.test(high.content)).toBe(true);
 	});
 
 	it("maps non-canonical window ids onto subscription windows by reported span", async () => {
@@ -830,5 +856,74 @@ describe("usage status-line segment", () => {
 		expect(content).toContain("5h");
 		expect(content).toContain("24%");
 		expect(content).not.toContain("7d");
+	});
+});
+
+describe("advisor usage in the cost segment", () => {
+	const now = Date.now();
+
+	it("shows advisor 5h/7d limits instead of the imputed dollar amount", async () => {
+		const content = await renderCost({
+			reports: [
+				{
+					provider: "anthropic",
+					limits: [
+						{
+							scope: { windowId: "5h" },
+							window: { resetsAt: now + 30 * 60_000 },
+							amount: { usedFraction: 0.42 },
+						},
+						{
+							scope: { windowId: "7d" },
+							window: { resetsAt: now + 141 * 3_600_000 },
+							amount: { usedFraction: 0.63 },
+						},
+					],
+				},
+			],
+			advisorCost: 250.86,
+			advisorAccounts: [{ provider: "anthropic" }],
+		});
+
+		expect(content).toContain("5h 42%");
+		expect(content).toContain("(30m)");
+		expect(content).toContain("7d 63%");
+		expect(content).toContain("(5d 21h)");
+		expect(content).toContain("(adv)");
+		expect(content).not.toContain("$");
+	});
+
+	it("still shows advisor limits when the imputed cost is zero", async () => {
+		const content = await renderCost({
+			reports: [
+				{
+					provider: "anthropic",
+					limits: [
+						{
+							scope: { windowId: "5h" },
+							window: { resetsAt: now + 10 * 60_000 },
+							amount: { usedFraction: 0.12 },
+						},
+					],
+				},
+			],
+			advisorCost: 0,
+			advisorAccounts: [{ provider: "anthropic" }],
+		});
+
+		expect(content).toContain("5h 12%");
+		expect(content).toContain("(10m)");
+		expect(content).toContain("(adv)");
+		expect(content).not.toContain("$");
+	});
+
+	it("falls back to the dollar amount for advisors with no quota endpoint", async () => {
+		const content = await renderCost({
+			reports: [],
+			advisorCost: 42.5,
+			advisorAccounts: [{ provider: "openai" }],
+		});
+
+		expect(content).toContain("$42.50 (adv)");
 	});
 });

--- a/packages/tui/src/components/composer/box.ts
+++ b/packages/tui/src/components/composer/box.ts
@@ -32,16 +32,51 @@ export const boxComposerStyle: ComposerStyle = {
 			return topLeft + borderColor(box.horizontal.repeat(topFillWidth)) + topRight;
 		}
 		const { content, width: statusWidth } = topBorder;
-		if (statusWidth <= topFillWidth) {
-			// Status fits - add fill after it
-			const fillWidth = topFillWidth - statusWidth;
-			return topLeft + content + borderColor(box.horizontal.repeat(fillWidth)) + topRight;
+		const lines = content.split("\n");
+		// Two-line status (line 2 = overflow/substrate segments) frames as one
+		// box: line 1 keeps the historical cornered row exactly, following rows
+		// render with vertical sides (`│` + padding) so the corner columns line
+		// up and the frame reads as one box. Single-line content is byte-identical
+		// to the old fit/truncate math.
+		if (lines.length <= 1) {
+			if (statusWidth <= topFillWidth) {
+				// Status fits - add fill after it
+				const fillWidth = topFillWidth - statusWidth;
+				return topLeft + content + borderColor(box.horizontal.repeat(fillWidth)) + topRight;
+			}
+			// Status too long - truncate it
+			const truncated = truncateToWidth(content, Math.max(0, topFillWidth - 1));
+			const truncatedWidth = visibleWidth(truncated);
+			const fillWidth = Math.max(0, topFillWidth - truncatedWidth);
+			return topLeft + truncated + borderColor(box.horizontal.repeat(fillWidth)) + topRight;
 		}
-		// Status too long - truncate it
-		const truncated = truncateToWidth(content, Math.max(0, topFillWidth - 1));
-		const truncatedWidth = visibleWidth(truncated);
-		const fillWidth = Math.max(0, topFillWidth - truncatedWidth);
-		return topLeft + truncated + borderColor(box.horizontal.repeat(fillWidth)) + topRight;
+		const rows: string[] = [];
+		const sideLeft = borderColor(`${box.vertical}${padding(paddingX)}`);
+		const sideRight = borderColor(`${padding(paddingX)}${box.vertical}`);
+		for (let i = 0; i < lines.length; i++) {
+			const lineText = lines[i]!;
+			const lineWidth = visibleWidth(lineText);
+			if (i === 0) {
+				if (lineWidth <= topFillWidth) {
+					const fillWidth = topFillWidth - lineWidth;
+					rows.push(topLeft + lineText + borderColor(box.horizontal.repeat(fillWidth)) + topRight);
+				} else {
+					const truncated = truncateToWidth(lineText, Math.max(0, topFillWidth - 1));
+					const truncatedWidth = visibleWidth(truncated);
+					const fillWidth = Math.max(0, topFillWidth - truncatedWidth);
+					rows.push(topLeft + truncated + borderColor(box.horizontal.repeat(fillWidth)) + topRight);
+				}
+			} else if (lineWidth <= topFillWidth) {
+				const fillWidth = topFillWidth - lineWidth;
+				rows.push(sideLeft + lineText + padding(fillWidth) + sideRight);
+			} else {
+				const truncated = truncateToWidth(lineText, Math.max(0, topFillWidth));
+				const truncatedWidth = visibleWidth(truncated);
+				const fillWidth = Math.max(0, topFillWidth - truncatedWidth);
+				rows.push(sideLeft + truncated + padding(fillWidth) + sideRight);
+			}
+		}
+		return rows.join("\n");
 	},
 
 	renderRow(ctx: ComposerRowContext): string[] {

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -1090,7 +1090,11 @@ export class Editor implements Component, Focusable {
 		};
 
 		const topRow = style.renderTop(chromeCtx);
-		if (topRow !== undefined) result.push(topRow);
+		if (topRow !== undefined) {
+			// A two-line status bar renders one framed row per `\n` (line 1 cornered,
+			// following lines with `│` sides) so the rows stay separate editor lines.
+			result.push(...topRow.split("\n"));
+		}
 
 		// Render each layout line
 		// Keep the hardware cursor at the text insertion point while autocomplete

--- a/packages/tui/test/editor-top-border-provider.test.ts
+++ b/packages/tui/test/editor-top-border-provider.test.ts
@@ -17,7 +17,9 @@
  * 4. Clearing the provider falls back to the eager slot.
  */
 import { describe, expect, it } from "bun:test";
+import { stripVTControlCharacters } from "node:util";
 import { Editor, type EditorTopBorder } from "@oh-my-pi/pi-tui/components/editor";
+import { visibleWidth } from "@oh-my-pi/pi-tui/utils";
 import { defaultEditorTheme } from "./test-themes";
 
 function stubTopBorder(label: string): EditorTopBorder {
@@ -89,5 +91,51 @@ describe("Editor lazy top-border provider (#4145)", () => {
 		expect(widths).toHaveLength(2);
 		expect(widths[0]).toBe(editor.getTopBorderAvailableWidth(80));
 		expect(widths[1]).toBe(editor.getTopBorderAvailableWidth(120));
+	});
+
+	it("renders content with one newline as two framed, width-filled border rows", () => {
+		const editor = new Editor(defaultEditorTheme);
+		const primary = "primary-status";
+		const overlay = "overflow-segments";
+		editor.setTopBorderProvider(() => ({
+			content: `${primary}\n${overlay}`,
+			// Contract: for multi-line content `width` is the MAX visibleWidth.
+			width: Math.max(primary.length, overlay.length),
+		}));
+
+		const frame = editor.render(40).map(line => stripVTControlCharacters(line));
+		expect(frame[0]).toContain(primary);
+		expect(frame[1]).toContain(overlay);
+		// Both rows are full-width rows of the content area; the first keeps the
+		// cornered top row and the second uses vertical sides, so the corner
+		// columns line up as one box.
+		expect(visibleWidth(frame[0])).toBe(40);
+		expect(visibleWidth(frame[1])).toBe(40);
+		expect(frame[0]).toMatch(/^\+.*\+$/);
+		expect(frame[1]).toMatch(/^\|.*\|$/);
+		// The second row's sides occupy the same columns as the top row's corners.
+		expect(frame[1][0]).toBe("|");
+		expect(frame[1][frame[1].length - 1]).toBe("|");
+		expect(frame[0][0]).toBe("+");
+		expect(frame[0][frame[0].length - 1]).toBe("+");
+		// The frame grows exactly one row taller than the single-line frame.
+		const single = new Editor(defaultEditorTheme);
+		single.setTopBorderProvider(() => ({ content: primary, width: primary.length }));
+		const singleFrame = single.render(40).map(line => stripVTControlCharacters(line));
+		expect(frame.length).toBe(singleFrame.length + 1);
+	});
+
+	it("truncates an overflowing second row to the fill width", () => {
+		const editor = new Editor(defaultEditorTheme);
+		const long = "x".repeat(100);
+		editor.setTopBorderProvider(() => ({ content: `short\n${long}`, width: long.length }));
+
+		const frame = editor.render(40).map(line => stripVTControlCharacters(line));
+		expect(frame[0]).toContain("short");
+		expect(visibleWidth(frame[0])).toBe(40);
+		// The oversized second row is truncated (with fill) to the full width.
+		expect(frame[1]).toMatch(/^\|.*\|$/);
+		expect(visibleWidth(frame[1])).toBe(40);
+		expect(frame[1]).not.toContain(long);
 	});
 });

--- a/rebuild.sh
+++ b/rebuild.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+step_label="startup"; allow_main=0; no_build=0
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+cd "$script_dir"
+
+die() {
+	printf 'ERROR [%s]: %s\n' "$step_label" "$*" >&2
+	return 1
+}
+package_version() {
+	local path="$1"
+	[[ -f "$path" ]] || { printf '(not present)'; return; }
+	node -p "require('./$path').version ?? '(not present)'" 2>/dev/null || printf '(unavailable)'
+}
+guard_count() {
+	local count
+	count="$(grep -c 'parsedRetryAfterMs !== undefined && !retryBudgetExhausted' packages/coding-agent/src/session/turn-recovery.ts 2>/dev/null || true)"
+	[[ "$count" =~ ^[0-9]+$ ]] || count=0
+	printf '%s' "$count"
+}
+diagnostics() {
+	local branch head_sha subject origin_ref upstream_ref origin_relation upstream_relation
+	branch="$(git branch --show-current 2>/dev/null || printf '(detached/unknown)')"
+	head_sha="$(git rev-parse --short HEAD 2>/dev/null || printf '(unknown)')"
+	subject="$(git log -1 --format=%s 2>/dev/null || printf '(unknown)')"
+	origin_ref="$(git rev-parse --short origin/main 2>/dev/null || printf '(missing)')"
+	upstream_ref="$(git rev-parse --short upstream/main 2>/dev/null || printf '(no upstream)')"
+	origin_relation="$(git rev-list --left-right --count origin/main...HEAD 2>/dev/null || printf '(unavailable)')"
+	upstream_relation="(no upstream)"
+	if git rev-parse --verify --quiet upstream/main >/dev/null; then
+		upstream_relation="$(git rev-list --left-right --count upstream/main...HEAD 2>/dev/null || printf '(unavailable)')"
+	fi
+	printf 'STEP=%s\nBRANCH=%s\nHEAD=%s (%s)\nORIGIN_MAIN=%s\nUPSTREAM_MAIN=%s\nORIGIN_MAIN...HEAD=%s\nUPSTREAM_MAIN...HEAD=%s\nGUARD=%s\nVERSION_ROOT=%s\nVERSION_UTILS=%s\n' \
+		"$step_label" "$branch" "$head_sha" "$subject" "$origin_ref" "$upstream_ref" \
+		"$origin_relation" "$upstream_relation" "$(guard_count)" \
+		"$(package_version package.json)" "$(package_version packages/utils/package.json)"
+}
+failure_handler() {
+	local status=$?
+	(( status == 0 )) && return
+	set +e
+	printf '\n=== DIAGNOSTIC BLOCK ===\n'
+	diagnostics
+	printf 'EXIT_STATUS=%s\n' "$status"
+}
+trap failure_handler EXIT
+for arg in "$@"; do
+	case "$arg" in
+		--allow-main) allow_main=1;;
+		--no-build) no_build=1;;
+		*) step_label="parse arguments"; die "unknown option: $arg";;
+	esac
+done
+step_label="determine default branch"
+default_ref="$(git symbolic-ref --quiet refs/remotes/origin/HEAD)" || die "origin/HEAD is not configured"
+default_branch="${default_ref##*/}"
+current_branch="$(git branch --show-current)"
+if [[ "$current_branch" == "$default_branch" && "$allow_main" -eq 0 ]]; then
+	printf 'ERROR: refusing to build from %s: main has NO guard.\n' "$default_branch" >&2
+	die "pass --allow-main for a deliberate upstream build"
+fi
+step_label="fetch origin"; git fetch origin
+upstream_exists=0
+if git remote get-url upstream >/dev/null 2>&1; then
+	upstream_exists=1; step_label="fetch upstream"; git fetch upstream
+fi
+step_label="check main refs"
+git rev-parse --verify --quiet origin/main >/dev/null || die "origin/main is unavailable"
+# The fork tracks upstream, so rebase the current branch onto the newest
+# upstream tip when an upstream remote is present; fall back to origin/main
+# only without one. Rebasing onto a stale origin/main would replay the whole
+# upstream drift backwards onto it (mass conflicts) whenever the current branch
+# is already based on upstream/main.
+if (( upstream_exists )) && git rev-parse --verify --quiet upstream/main >/dev/null; then
+	rebase_base=upstream/main
+else
+	rebase_base=origin/main
+fi
+step_label="rebase onto $rebase_base"
+# --no-fork-point: the default fork-point heuristic reads upstream's reflog
+# and can misclassify an ancestor base as a large divergence, replaying the
+# whole drift backwards onto it. Pure DAG ancestry is deterministic: an
+# ancestor base is a no-op.
+if ! git rebase --no-fork-point "$rebase_base"; then
+	printf 'Rebase failed. Resolve the rebase in place, then rerun rebuild.sh.\n' >&2
+	exit 1
+fi
+if (( no_build )); then
+	printf '\n=== DRY RUN ===\n'
+	diagnostics
+	printf 'dry run — build skipped\n'
+	exit 0
+fi
+# Keep the fork's main current so origin/main never rots behind upstream again.
+# Advance local main to upstream/main (ancestor-checked fast-forward only) and
+# push it. A refused push (origin/main diverged) warns and still builds.
+step_label="sync fork main to upstream"
+upstream_sha="$(git rev-parse --verify --quiet upstream/main 2>/dev/null)" || upstream_sha=""
+if (( upstream_exists )) && [[ -n "$upstream_sha" ]] \
+	&& git rev-parse --verify --quiet main >/dev/null \
+	&& [[ "$(git rev-parse main)" != "$upstream_sha" ]] \
+	&& git merge-base --is-ancestor main upstream/main; then
+	lag_count="$(git rev-list --count main..upstream/main)"
+	printf 'syncing main: %s -> %s (%s commits behind upstream)\n' \
+		"$(git rev-parse --short main)" "${upstream_sha:0:8}" "$lag_count"
+	if [[ "$current_branch" != "main" ]]; then
+		# update-ref (not `git branch -f`) so main keeps tracking origin/main.
+		git update-ref refs/heads/main "$upstream_sha"
+	fi
+	if git push origin main 2>&1; then
+		printf 'origin/main advanced to %s\n' "${upstream_sha:0:8}"
+	else
+		printf 'WARNING: origin/main push failed (diverged or no push access); local main is current, remote is not.\n' >&2
+	fi
+fi
+step_label="clean stale native"
+native_version="$(package_version packages/natives/package.json)"
+release_version="$(package_version packages/coding-agent/package.json)"
+[[ "$native_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ && "$native_version" == "$release_version" ]] ||
+	die "native/coding-agent versions disagree (native=$native_version coding-agent=$release_version)"
+native_addon="packages/natives/native/pi_natives.darwin-arm64.node"
+binary_output="packages/coding-agent/binaries/omp-darwin-arm64"
+printf 'clean stale native (%s): %s %s\n' "$native_version" "$native_addon" "$binary_output"
+rm -f -- "$native_addon" "$binary_output"
+step_label="bun install"; bun install
+step_label="build darwin-arm64 native"; bun --cwd=packages/natives run build
+step_label="build darwin-arm64 binary"; bun run ci:release:build-binaries --targets=darwin-arm64
+step_label="install binary"; mkdir -p "$HOME/.local/bin"
+install -m 755 packages/coding-agent/binaries/omp-darwin-arm64 "$HOME/.local/bin/omp"
+step_label="report success"; binary_path="$HOME/.local/bin/omp"
+printf '\n=== SUCCESS ===\nHEAD=%s\nGUARD=%s\nBINARY=%s\n' "$(git rev-parse HEAD)" "$(guard_count)" "$binary_path"
+if version="$("$binary_path" --version 2>/dev/null)"; then
+	printf 'OMP_VERSION=%s\n' "$version"
+else
+	printf 'OMP_VERSION=(failed to run)\n'
+fi

--- a/scripts/refresh-omp-main.sh
+++ b/scripts/refresh-omp-main.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Restore the caller's starting branch on every exit path, so running this
+# script never leaves the user on the default branch.
+start_branch="$(git branch --show-current)"
+restore() {
+	[[ -n "$start_branch" ]] && git switch --quiet "$start_branch" 2>/dev/null || true
+}
+trap restore EXIT
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+default_ref="$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD || true)"
+if [[ -z "$default_ref" ]]; then
+	echo "refresh-omp-main: origin/HEAD is not configured" >&2
+	exit 1
+fi
+default_branch="${default_ref#origin/}"
+if ! git rev-parse --verify --quiet "refs/heads/$default_branch" >/dev/null; then
+	echo "refresh-omp-main: local branch $default_branch does not exist" >&2
+	exit 1
+fi
+
+git fetch upstream
+git fetch origin
+git switch "$default_branch"
+git merge --ff-only upstream/main
+
+sha="$(git rev-parse "$default_branch")"
+subject="$(git log -1 --format=%s "$default_branch")"
+printf 'main synced to %s (%s)\n' "$sha" "$subject"
+
+git for-each-ref --format='%(refname:short)' refs/heads | while IFS= read -r b; do
+	printf "%-40s " "$b"
+	git rev-list --left-right --count "$default_branch...$b"
+done


### PR DESCRIPTION
## Problem

Sharpshooter consolidation can silently wipe all three memory files (`architecture.md`, `product.md`, `style.md`) while recording success.

The consolidation model (`replace_memory_files` tool call) occasionally returns empty content for all three files. `parseReplacementFiles` validated structure but not substance, so:

1. `applyReplacementFiles` truncated every `.md` to zero bytes
2. `consumeSharpshooterDeltas` deleted the queued deltas
3. the run recorded `{ran: true, deltas: N}` — no error anywhere

Observed in production with glm-5.3-flash as the sharpshooter model: ~40% of consolidation runs returned all-empty tool calls when a large project-docs digest (a 21KB `CLAUDE.md`) was in the prompt (10 sampled runs: 4 empty, 6 non-empty). The same model call with a smaller digest never failed, so prompt length is a plausible trigger, but the guard is model-independent.

## Fix

`parseReplacementFiles` throws when the replacement files' combined trimmed content is empty:

```ts
const totalChars = files.reduce((sum, file) => sum + file.content.trim().length, 0);
if (totalChars === 0) {
	throw new Error("replace_memory_files returned all-empty content; refusing to wipe memory files");
}
```

The error propagates through the existing error path: `lastResult.error` is recorded in `state.json`, and the queued deltas survive for the next consolidation pass.

Also adds the changelog entry under `[Unreleased] → Fixed`.

## Verification

- `bun check` clean
- sharpshooter test suite: 13/13 pass (no existing test asserted on empty-file behavior, so no test expectations changed)
- Reproduced the failure against the real consolidation prompt before the fix (all-empty result), confirmed the guard rejects it after