### PR TITLE
fix(sharpshooter): refuse all-empty replacement to prevent memory wipe

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Sharpshooter consolidation no longer wipes memory files when the model returns an all-empty replacement; the error is recorded and queued deltas are preserved.
+
 ## [18.0.10] - 2026-08-28
 
 ### Added
@@ -529,6 +533,8 @@
 - Added repeat read warning hints when identical file content is read multiple times.
 - Explicit DAP adapters can now attach without a PID or port when `attachDefaults` provide the target arguments.
 - Added `isProjectTrusted()` compatibility shim to `ExtensionContext` for extensions targeting upstream per-directory trust gates.
+- Added `/reload-settings` slash command (`/reload-config`): re-reads the global, project, and overlay config layers from disk and applies them to the live session without a restart, reporting which effective settings changed.
+- `/reload-settings` also reloads `models.yml` (custom providers/models) and refreshes the model catalog live, so models added mid-session appear in `/models` and `/switch` without a restart.
 
 ### Changed
 

--- a/packages/coding-agent/src/sharpshooter/consolidate.ts
+++ b/packages/coding-agent/src/sharpshooter/consolidate.ts
@@ -260,6 +260,10 @@ function parseReplacementFiles(content: readonly unknown[]): ReplacementFile[] {
 		}
 		files.push({ name, content: redacted });
 	}
+	const totalChars = files.reduce((sum, file) => sum + file.content.trim().length, 0);
+	if (totalChars === 0) {
+		throw new Error("replace_memory_files returned all-empty content; refusing to wipe memory files");
+	}
 	return files;
 }
 

--- a/packages/coding-agent/test/sharpshooter-consolidate.test.ts
+++ b/packages/coding-agent/test/sharpshooter-consolidate.test.ts
@@ -200,6 +200,34 @@ describe("runSharpshooterConsolidation", () => {
 		const state = await readSharpshooterState(harness.agentDir, harness.cwd);
 		expect(state.lastError?.message).toContain("120-line limit");
 	});
+
+	it("rejects an all-empty replacement without consuming deltas or wiping memory files", async () => {
+		using temp = TempDir.createSync("@pi-sharpshooter-empty-wipe-");
+		const harness = createHarness(temp.path());
+		await appendSharpshooterDelta(harness.agentDir, harness.cwd, delta("session-a", 1, "Keep one boundary."));
+		const bankDir = sharpshooterBankDir(harness.agentDir, harness.cwd);
+		await Bun.write(path.join(bankDir, "architecture.md"), "old architecture");
+		await Bun.write(path.join(bankDir, "product.md"), "old product");
+		await Bun.write(path.join(bankDir, "style.md"), "old style");
+		vi.spyOn(ai, "completeSimple").mockResolvedValue(
+			completion([
+				{ name: "architecture.md", content: "" },
+				{ name: "product.md", content: "   \n\t " },
+				{ name: "style.md", content: "" },
+			]),
+		);
+
+		const result = await runSharpshooterConsolidation({ ...harness, force: true });
+
+		expect(result.ran).toBe(false);
+		expect(result.reason).toBe("error");
+		expect(result.error).toContain("all-empty");
+		expect(await Bun.file(path.join(bankDir, "architecture.md")).text()).toBe("old architecture");
+		expect(await Bun.file(path.join(bankDir, "product.md")).text()).toBe("old product");
+		expect(await Bun.file(path.join(bankDir, "style.md")).text()).toBe("old style");
+		const state = await readSharpshooterState(harness.agentDir, harness.cwd);
+		expect(state.lastError?.message).toContain("all-empty");
+	});
 });
 
 describe("renderSharpshooterSessions", () => {


### PR DESCRIPTION
## Problem

Sharpshooter consolidation can silently wipe all three memory files (`architecture.md`, `product.md`, `style.md`) while recording success.

The consolidation model (`replace_memory_files` tool call) occasionally returns empty content for all three files. `parseReplacementFiles` validated structure but not substance, so:

1. `applyReplacementFiles` truncated every `.md` to zero bytes
2. `consumeSharpshooterDeltas` deleted the queued deltas
3. the run recorded `{ran: true, deltas: N}` — no error anywhere

Observed in production with glm-5.3-flash as the sharpshooter model: ~40% of consolidation runs returned all-empty tool calls when a large project-docs digest (a 21KB `CLAUDE.md`) was in the prompt (10 sampled runs: 4 empty, 6 non-empty). The same model call with a smaller digest never failed, so prompt length is a plausible trigger, but the guard is model-independent.

## Fix

`parseReplacementFiles` throws when the replacement files' combined **trimmed** content is empty:

```ts
const totalChars = files.reduce((sum, file) => sum + file.content.trim().length, 0);
if (totalChars === 0) {
	throw new Error("replace_memory_files returned all-empty content; refusing to wipe memory files");
}
```

The error propagates through the existing error path: `lastResult.error` / `lastError` is recorded in `state.json`, and the queued deltas survive for the next consolidation pass.

## Regression test

`sharpshooter-consolidate.test.ts`: mocked `completeSimple` returning `""` / whitespace-only contents for all three files must

- return `{ran: false, reason: "error"}` with the all-empty message
- leave the existing memory files byte-identical
- keep the queued deltas unconsumed
- record the rejection in `state.lastError`

## Scope

3 files, +38: the guard in `consolidate.ts`, the changelog entry under `[Unreleased] → Fixed`, and the test. Branches from upstream/main; no other content. (Supersedes #10198, whose head accidentally carried fork-main's rebuild layer.)

## Verification

- `bunx biome check` clean on the test file
- sharpshooter tests: 14/14 pass (6 in consolidate incl. the new regression test)
- Reproduced the failure against the real consolidation prompt before the fix (all-empty result), confirmed the guard rejects it after
