### PR TITLE
fix(coding-agent): hide leftover MCP OAuth from omp usage

### DIFF
--- a/docs/mcp-config.md
+++ b/docs/mcp-config.md
@@ -456,7 +456,7 @@ After editing, use:
 - `/mcp list` to see which config file a server came from
 - `/mcp test <name>` to test a single server
 - `/mcp reconnect <name>` to reconnect one server without rediscovering all configs
-- `/mcp reauth <name>` to replace managed OAuth credentials, or `/mcp unauth <name>` to remove them
+- `/mcp reauth <name>` to replace managed OAuth credentials, `/mcp unauth <name>` to remove them, or `/mcp remove <name>` which also drops the managed OAuth rows so they cannot linger in `omp usage`
 - `/mcp resources`, `/mcp prompts`, and `/mcp notifications` to inspect non-tool MCP capabilities
 
 ## Validation rules OMP enforces

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `omp usage` listing auto-disabled MCP OAuth tombstones after a server was removed from `mcp.json`. `/mcp remove` now drops the managed OAuth rows the way `/mcp unauth` already did.
+
 ## [18.0.10] - 2026-08-28
 
 ### Added

--- a/packages/coding-agent/src/cli/usage-cli.ts
+++ b/packages/coding-agent/src/cli/usage-cli.ts
@@ -578,10 +578,14 @@ function formatReloginDeadline(
  * Tombstones worth a row in `omp usage`: OAuth credentials torn down
  * automatically (refresh failure, upstream invalidation). Rows the user
  * replaced or deleted deliberately are lifecycle noise, not lost capacity.
+ * Managed MCP OAuth (`mcp_oauth:*`) is a connection token, not LLM quota —
+ * a failed refresh after `/mcp remove` or a hand-edit of `mcp.json` must not
+ * render as lost capacity.
  */
 function isActionableDisable(summary: DisabledCredentialSummary, activeAccounts: UsageAccountIdentity[] = []): boolean {
 	if (summary.type !== "oauth") return false;
 	if (/^(replaced by|deleted by user)/i.test(summary.cause)) return false;
+	if (summary.provider.startsWith("mcp_oauth:") || summary.provider.startsWith("mcp_oauth_")) return false;
 
 	// Do not display tombstone if there is an active account for the same provider
 	// matching the same identity (email, accountId, or org).
@@ -922,6 +926,21 @@ export function selectReportableAccounts(
 	return accounts.filter(account => hasUsageProvider(account.provider));
 }
 
+/**
+ * Same cull as {@link selectReportableAccounts} for auto-disabled tombstones.
+ * A refresh-failed MCP OAuth row (or any other credential with no usage
+ * endpoint) is not lost quota; without this, `omp usage` invents a provider
+ * section for it after the live-account filter already dropped the sibling.
+ */
+export function selectReportableDisabled(
+	disabled: DisabledCredentialSummary[],
+	hasUsageProvider: (provider: string) => boolean,
+	explicitProvider?: string,
+): DisabledCredentialSummary[] {
+	if (explicitProvider) return disabled;
+	return disabled.filter(summary => hasUsageProvider(summary.provider));
+}
+
 /** Apply a redaction mask to an optional identity field. */
 function maskIdentity(redaction: Map<string, string>, value: string | undefined): string | undefined {
 	return value === undefined ? undefined : (redaction.get(value) ?? value);
@@ -1124,7 +1143,11 @@ export async function runUsageCommand(cmd: UsageCommandArgs): Promise<void> {
 		// missing. Best-effort: a broker predating the endpoint yields [].
 		let disabled: DisabledCredentialSummary[] = [];
 		try {
-			disabled = await authStorage.listDisabledCredentials();
+			disabled = selectReportableDisabled(
+				await authStorage.listDisabledCredentials(),
+				provider => authStorage.usageProviderFor(provider) !== undefined,
+				cmd.provider,
+			);
 		} catch {
 			// Usage output must not fail because tombstone listing did.
 		}

--- a/packages/coding-agent/src/mcp/oauth-credentials.ts
+++ b/packages/coding-agent/src/mcp/oauth-credentials.ts
@@ -241,3 +241,25 @@ export async function removeManagedMcpOAuthCredentials(
 	}
 	return removed;
 }
+
+/**
+ * Drop every managed OAuth row this profile holds for `config`: the explicit
+ * `auth.credentialId` (when present) and the url-keyed binding used by
+ * definition-only entries. `/mcp unauth` and `/mcp remove` share this so
+ * deleting a server cannot leave a refresh-failed tombstone in `omp usage`.
+ */
+export async function dropManagedMcpOAuthForServer(
+	authStorage: AuthStorage,
+	config: MCPServerConfig,
+): Promise<boolean> {
+	let removed = false;
+	if (config.auth?.type === "oauth") {
+		removed = (await removeManagedMcpOAuthCredential(authStorage, config.auth.credentialId)) || removed;
+	}
+	if ((config.type === "http" || config.type === "sse") && config.url) {
+		removed =
+			(await removeManagedMcpOAuthCredentials(authStorage, mcpOAuthCredentialIdsForServerUrl(config.url))) ||
+			removed;
+	}
+	return removed;
+}

--- a/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
@@ -27,10 +27,9 @@ import {
 	updateMCPServer,
 } from "../../mcp/config-writer";
 import {
+	dropManagedMcpOAuthForServer,
 	lookupMcpOAuthCredentialForServer,
-	mcpOAuthCredentialIdsForServerUrl,
 	removeManagedMcpOAuthCredential,
-	removeManagedMcpOAuthCredentials,
 } from "../../mcp/oauth-credentials";
 import { MCPOAuthFlow, type MCPStoredOAuthCredential, mcpOAuthCredentialId } from "../../mcp/oauth-flow";
 import {
@@ -1564,7 +1563,8 @@ export class MCPCommandController {
 			const projectPath = getMCPConfigPath("project", cwd);
 			const filePath = scope === "user" ? userPath : projectPath;
 			const config = await readMCPConfigFile(filePath);
-			if (!config.mcpServers?.[name]) {
+			const serverConfig = config.mcpServers?.[name];
+			if (!serverConfig) {
 				this.ctx.showError(`Server "${name}" not found in ${scope} config.`);
 				return;
 			}
@@ -1574,8 +1574,8 @@ export class MCPCommandController {
 				await this.ctx.mcpManager.disconnectServer(name);
 			}
 
-			// Remove from config
 			await removeMCPServer(filePath, name);
+			await dropManagedMcpOAuthForServer(this.ctx.session.modelRegistry.authStorage, serverConfig);
 
 			// Reload MCP manager
 			await this.reloadServers();
@@ -1880,23 +1880,11 @@ export class MCPCommandController {
 
 			const currentAuth = (found.config as MCPServerConfig & { auth?: MCPAuthConfig }).auth;
 			const authStorage = this.ctx.session.modelRegistry.authStorage;
-			if (currentAuth?.type === "oauth") {
-				await removeManagedMcpOAuthCredential(authStorage, currentAuth.credentialId);
-			}
-			// Also drop this profile's url-keyed binding so the server is truly
-			// signed out even when the config carries no auth block. Runtime
-			// discovery expands `${...}` URL values before MCPManager looks up the
-			// deterministic credential row, so unauth must clear that same key.
-			let removedUrlKeyedCredential = false;
-			if ((found.config.type === "http" || found.config.type === "sse") && found.config.url) {
-				removedUrlKeyedCredential = await removeManagedMcpOAuthCredentials(
-					authStorage,
-					mcpOAuthCredentialIdsForServerUrl(found.config.url),
-				);
-			}
+			// Drop explicit + url-keyed bindings (env-expanded URL included).
+			const removedCredential = await dropManagedMcpOAuthForServer(authStorage, found.config);
 
 			if (found.discovered && currentAuth?.type !== "oauth") {
-				if (!removedUrlKeyedCredential) {
+				if (!removedCredential) {
 					this.#showMessage(
 						["", theme.fg("muted", `No stored OAuth auth to remove for "${name}".`), ""].join("\n"),
 					);

--- a/packages/coding-agent/src/slash-commands/helpers/mcp.ts
+++ b/packages/coding-agent/src/slash-commands/helpers/mcp.ts
@@ -10,6 +10,7 @@ import {
 	updateMCPServer,
 } from "../../mcp/config-writer";
 import { MCPManager } from "../../mcp/manager";
+import { dropManagedMcpOAuthForServer } from "../../mcp/oauth-credentials";
 import { getSmitheryApiKey } from "../../mcp/smithery-auth";
 import { searchSmitheryRegistry } from "../../mcp/smithery-registry";
 import type { MCPServerConfig, MCPServerConnection } from "../../mcp/types";
@@ -459,7 +460,12 @@ async function handleRemoveCommand(rest: string, runtime: SlashCommandRuntime): 
 	if (!parsed.name) return usage("Usage: /mcp remove <name> [--scope project|user]", runtime);
 	try {
 		const filePath = getMCPConfigPath(parsed.scope, runtime.cwd);
+		const existing = await readMCPConfigFile(filePath);
+		const server = existing.mcpServers?.[parsed.name];
 		await removeMCPServer(filePath, parsed.name);
+		if (server) {
+			await dropManagedMcpOAuthForServer(runtime.session.modelRegistry.authStorage, server);
+		}
 		await runtime.output(`Removed server "${parsed.name}" from ${parsed.scope} config.`);
 		return commandConsumed();
 	} catch (err) {

--- a/packages/coding-agent/test/mcp-command-reauth.test.ts
+++ b/packages/coding-agent/test/mcp-command-reauth.test.ts
@@ -1031,6 +1031,38 @@ describe("/mcp auth commands", () => {
 		expect(userConfig.mcpServers?.discovered).toBeUndefined();
 	});
 
+	test("drops url-keyed OAuth credentials when removing a server", async () => {
+		const authStorage = freshAuthStorage();
+		await authStorage.reload();
+		const projectConfigPath = getMCPConfigPath("project", projectDir);
+		await fs.mkdir(path.dirname(projectConfigPath), { recursive: true });
+		await Bun.write(
+			projectConfigPath,
+			`${JSON.stringify({
+				mcpServers: {
+					hg: { type: "http", url: EXPANDED_SERVER_URL },
+				},
+			})}\n`,
+		);
+		await authStorage.set(oauthFlow.mcpOAuthCredentialId(EXPANDED_SERVER_URL), {
+			type: "oauth",
+			access: "hg-access",
+			refresh: "hg-refresh",
+			expires: Date.now() + 3_600_000,
+		});
+		const { controller, showError } = createController(authStorage, {
+			getConnection: vi.fn(() => undefined),
+			disconnectServer: vi.fn(async () => {}),
+		});
+
+		await controller.handle("/mcp remove hg");
+
+		expect(showError).not.toHaveBeenCalled();
+		expect(authStorage.get(oauthFlow.mcpOAuthCredentialId(EXPANDED_SERVER_URL))).toBeUndefined();
+		const saved = JSON.parse(await Bun.file(projectConfigPath).text()) as TestConfigFile;
+		expect(saved.mcpServers?.hg).toBeUndefined();
+	});
+
 	test("passes env-expanded OAuth client credentials to the reauth flow", async () => {
 		const authStorage = freshAuthStorage();
 		await authStorage.reload();

--- a/packages/coding-agent/test/usage-cli.test.ts
+++ b/packages/coding-agent/test/usage-cli.test.ts
@@ -1,12 +1,13 @@
 import { describe, expect, it } from "bun:test";
 import { stripVTControlCharacters } from "node:util";
-import type { UsageReport } from "@oh-my-pi/pi-ai";
+import type { DisabledCredentialSummary, UsageReport } from "@oh-my-pi/pi-ai";
 import {
 	buildRedactionMap,
 	collectUnreportedAccounts,
 	computeProviderWindowStats,
 	formatUsageBreakdown,
 	formatUsageHistory,
+	selectReportableDisabled,
 	type UsageAccountIdentity,
 } from "@oh-my-pi/pi-coding-agent/cli/usage-cli";
 
@@ -299,6 +300,36 @@ describe("collectUnreportedAccounts", () => {
 	});
 });
 
+describe("selectReportableDisabled", () => {
+	const mcpTombstone: DisabledCredentialSummary = {
+		id: 24,
+		provider: "mcp_oauth:profile:default:https://mcp.higgsfield.ai/mcp",
+		type: "oauth",
+		cause: "oauth refresh failed: invalid_grant",
+	};
+	const anthropicTombstone: DisabledCredentialSummary = {
+		id: 26,
+		provider: "anthropic",
+		type: "oauth",
+		email: "dead@example.test",
+		cause: "oauth refresh failed: Refresh token expired",
+	};
+
+	it("drops credentials whose provider has no usage endpoint", () => {
+		const kept = selectReportableDisabled([mcpTombstone, anthropicTombstone], provider => provider === "anthropic");
+		expect(kept).toEqual([anthropicTombstone]);
+	});
+
+	it("keeps every tombstone when --provider is explicit", () => {
+		const kept = selectReportableDisabled(
+			[mcpTombstone, anthropicTombstone],
+			() => false,
+			"mcp_oauth:profile:default:https://mcp.higgsfield.ai/mcp",
+		);
+		expect(kept).toEqual([mcpTombstone, anthropicTombstone]);
+	});
+});
+
 describe("formatUsageBreakdown", () => {
 	const reports = [
 		makeReport("anthropic", "dummy.primary@example.test", [
@@ -471,6 +502,20 @@ describe("formatUsageBreakdown", () => {
 		const text = stripVTControlCharacters(formatUsageBreakdown([], [], Date.now(), undefined, disabled));
 		expect(text).toContain("Anthropic");
 		expect(text).toContain("✗ last@example.test — disabled: token endpoint said no (re-login to restore)");
+	});
+	it("hides auto-disabled MCP OAuth tombstones — they are not LLM quota", () => {
+		const disabled: DisabledCredentialSummary[] = [
+			{
+				id: 24,
+				provider: "mcp_oauth:profile:default:https://mcp.higgsfield.ai/mcp",
+				type: "oauth",
+				cause: 'oauth refresh failed: MCP OAuth refresh failed: 400 {"error":"invalid_grant"}',
+			},
+		];
+		const text = stripVTControlCharacters(formatUsageBreakdown([], [], Date.now(), undefined, disabled));
+		expect(text).not.toContain("higgsfield");
+		expect(text).not.toContain("mcp_oauth");
+		expect(text).not.toContain("re-login to restore");
 	});
 
 	it("warns about Anthropic's ~30d grant lifetime only inside the final week", () => {


### PR DESCRIPTION
## What

`omp usage` no longer lists leftover MCP OAuth as unauthorized after the server is removed. `/mcp remove` also drops the managed OAuth rows.

## Why

Removing an OAuth MCP from `mcp.json` left vault tokens that later failed refresh. Live credentials without a usage API were already hidden; auto-disabled tombstones were not, so a dead MCP token looked like lost quota.

## Testing

tested working with `bun run dev`: `omp usage` no longer shows the unauthorized Higgsfield MCP OAuth after the server was removed.

`bun test packages/coding-agent/test/usage-cli.test.ts packages/coding-agent/test/mcp-command-reauth.test.ts` — 50 pass.
`bun run check` in `packages/coding-agent` passes.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)