### PR TITLE
fix(agent): retry transient Codex compaction socket closures

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -24,6 +24,10 @@
 ### Fixed
 
 - Fixed preservation of Claude thinking/reasoning context when conversations are compacted or tool results are pruned.
+### Fixed
+
+- Fixed Codex remote compaction retries for both Bun and proxy socket-closure messages and stopped falling back to the unsupported `/responses/compact` endpoint after V2 failures.
+
 
 ## [18.0.11] - 2026-08-29
 

--- a/packages/agent/src/compaction/compaction-v2-streaming.ts
+++ b/packages/agent/src/compaction/compaction-v2-streaming.ts
@@ -32,7 +32,7 @@ import {
 	OPENAI_HEADER_VALUES,
 	OPENAI_HEADERS,
 } from "@oh-my-pi/pi-catalog/wire/codex";
-import { $env, logger, stringifyJson } from "@oh-my-pi/pi-utils";
+import { $env, isUnexpectedSocketCloseMessage, logger, stringifyJson } from "@oh-my-pi/pi-utils";
 
 // ============================================================================
 // Types & Configuration
@@ -651,6 +651,7 @@ function isRetryableCompactionError(error: Error): boolean {
 	}
 	const message = error.message.toLowerCase();
 	return (
+		isUnexpectedSocketCloseMessage(message) ||
 		message.includes("stream closed before response.completed") ||
 		message.includes("stream parse failed") ||
 		message.includes("server_error") ||

--- a/packages/agent/src/compaction/openai.ts
+++ b/packages/agent/src/compaction/openai.ts
@@ -288,9 +288,16 @@ function isOpenAiRemoteCompactionApi(api: Api | undefined): boolean {
 
 export function shouldUseOpenAiRemoteCompaction(model: Model): boolean {
 	if (model.remoteCompaction?.enabled === false) return false;
-	if (model.provider === "openai" || model.provider === "openai-codex") return true;
+	const compactionApi = model.remoteCompaction?.api ?? model.api;
+	// ChatGPT's Codex backend exposes V2 compaction on /codex/responses, but
+	// does not expose the OpenAI V1 /responses/compact endpoint. Only use the
+	// V1 path for Codex when an explicit compatible endpoint was configured.
+	if (model.provider === "openai-codex") {
+		return (model.remoteCompaction?.endpoint?.trim().length ?? 0) > 0;
+	}
+	if (model.provider === "openai") return true;
 	if (model.remoteCompaction?.enabled !== true) return false;
-	return isOpenAiRemoteCompactionApi(model.remoteCompaction.api ?? model.api);
+	return isOpenAiRemoteCompactionApi(compactionApi);
 }
 
 function resolveOpenAiCompactEndpoint(model: Model): string {

--- a/packages/agent/test/remote-compaction.test.ts
+++ b/packages/agent/test/remote-compaction.test.ts
@@ -908,6 +908,71 @@ describe("requestCompactionV2Streaming", () => {
 		expect(result.usage?.cachedInputTokens).toBe(7);
 		expect(result.usage?.reasoningOutputTokens).toBe(1);
 	});
+	test.each(["The socket connection was closed unexpectedly", "socket connection closed unexpectedly"] as const)(
+		"retries a transient socket closure: %s",
+		async socketCloseMessage => {
+			const model = makeOpenAiModel({
+				remoteCompaction: {
+					enabled: true,
+					v2StreamingEnabled: true,
+					v2Endpoint: "https://compact.example/v1/responses",
+				},
+			});
+			const userItem = { type: "message", role: "user", content: [{ type: "input_text", text: "real user" }] };
+			const request = buildCompactionV2Request(model, [userItem], "instructions");
+			const compactionItem = { type: "compaction", encrypted_content: "enc_123" };
+			let attempts = 0;
+			const fetchMock: FetchImpl = async () => {
+				attempts++;
+				if (attempts === 1) {
+					throw new Error(socketCloseMessage);
+				}
+				return sseResponse([
+					{ type: "response.output_item.done", output_index: 0, item: compactionItem },
+					{ type: "response.completed" },
+				]);
+			};
+
+			const result = await requestCompactionV2Streaming(model, "test-key", request, undefined, {
+				fetch: fetchMock,
+				retryWait: async () => {},
+			});
+
+			expect(attempts).toBe(2);
+			expect(result.compactionItem).toEqual(compactionItem);
+		},
+	);
+	test("does not select Codex's unsupported V1 compact endpoint by default", () => {
+		const model = makeOpenAiModel({
+			provider: "openai-codex",
+			remoteCompaction: {
+				enabled: true,
+				v2StreamingEnabled: true,
+			},
+		});
+
+		expect(shouldUseOpenAiRemoteCompaction(model)).toBe(false);
+	});
+	test("requires explicit opt-in for custom Codex API compaction", () => {
+		const model = buildModel({
+			id: "custom-gpt-5",
+			name: "Custom GPT-5",
+			api: "openai-codex-responses",
+			provider: "custom-provider",
+			baseUrl: "https://compact.example/v1",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 400000,
+			maxTokens: 128000,
+			remoteCompaction: {
+				api: "openai-codex-responses",
+				endpoint: "https://compact.example/v1/responses/compact",
+			},
+		});
+
+		expect(shouldUseOpenAiRemoteCompaction(model)).toBe(false);
+	});
 
 	test("negotiates Codex V2 compaction for an explicit Responses endpoint", async () => {
 		const model = buildModel({

--- a/packages/coding-agent/test/compaction.test.ts
+++ b/packages/coding-agent/test/compaction.test.ts
@@ -703,7 +703,7 @@ describe("remote compaction setting", () => {
 		]);
 	});
 
-	it("uses the ChatGPT Codex compact endpoint for openai-codex models", async () => {
+	it("uses the explicitly configured Codex compact endpoint for openai-codex models", async () => {
 		const baseModel = getBundledModel("openai", "gpt-5.1");
 		if (!baseModel) throw new Error("Expected openai/gpt-5.1 model to exist");
 
@@ -712,6 +712,11 @@ describe("remote compaction setting", () => {
 			api: "openai-codex-responses",
 			provider: "openai-codex",
 			baseUrl: "https://chatgpt.com/backend-api",
+			remoteCompaction: {
+				...baseModel.remoteCompaction,
+				enabled: true,
+				endpoint: "https://chatgpt.com/backend-api/codex/responses/compact",
+			},
 		};
 
 		const entries: SessionEntry[] = [
@@ -750,6 +755,11 @@ describe("remote compaction setting", () => {
 			api: "openai-codex-responses",
 			provider: "openai-codex",
 			baseUrl: "https://chatgpt.com/backend-api",
+			remoteCompaction: {
+				...baseModel.remoteCompaction,
+				enabled: true,
+				endpoint: "https://chatgpt.com/backend-api/codex/responses/compact",
+			},
 		};
 		const assistant: AssistantMessage = {
 			role: "assistant",

--- a/packages/coding-agent/test/issue-986-compaction-auth-fallback.test.ts
+++ b/packages/coding-agent/test/issue-986-compaction-auth-fallback.test.ts
@@ -33,12 +33,19 @@ describe("issue #986 compaction auth fallback", () => {
 	});
 
 	async function createSession(options?: { fallbackModelRole?: string; configureFallbackAuth?: boolean }) {
-		const currentModel = getBundledModel("openai-codex", "gpt-5.4-mini");
+		const bundledCurrentModel = getBundledModel("openai-codex", "gpt-5.4-mini");
+		const currentModel = bundledCurrentModel && {
+			...bundledCurrentModel,
+			remoteCompaction: {
+				...bundledCurrentModel.remoteCompaction,
+				enabled: true,
+				endpoint: "https://compact.example/v1/responses/compact",
+			},
+		};
 		const fallbackModel = getBundledModel("anthropic", "claude-sonnet-4-5");
 		if (!currentModel || !fallbackModel) {
 			throw new Error("Expected bundled test models to exist");
 		}
-
 		const settings = Settings.isolated({
 			"compaction.keepRecentTokens": 1,
 			"compaction.methodOrder": ["remote", "soft"],


### PR DESCRIPTION
## Problem
Recent OMP logs show Codex compaction failing after a transient V2 stream socket closure:

- V2 `/backend-api/codex/responses` reports `The socket connection was closed unexpectedly`.
- The fallback then requests `/backend-api/codex/responses/compact`, which returns HTTP 404 because the ChatGPT Codex backend exposes V2 compaction on `/codex/responses`, not the OpenAI V1 `/responses/compact` route.
- The strict native-compaction path then leaves automatic compaction failed.

## Fix
- Treat socket closures as retryable V2 compaction transport failures.
- Do not select the unsupported Codex V1 compact endpoint unless an explicit compatible endpoint is configured.

## Verification
- `bun test packages/agent/test/remote-compaction.test.ts` (52 pass)
- `bun --cwd=packages/agent run check:types`
- `bunx biome check packages/agent/src/compaction/compaction-v2-streaming.ts packages/agent/src/compaction/openai.ts packages/agent/test/remote-compaction.test.ts`
