### PR TITLE
fix(coding-agent): prevent streamed edit preview starvation

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the TUI becoming unresponsive while streamed edit previews arrive in a burst.
+
 ## [18.0.11] - 2026-08-29
 
 ### Added

--- a/packages/coding-agent/src/modes/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/components/tool-execution.ts
@@ -268,6 +268,8 @@ export interface ToolExecutionHandle extends Component {
 export const SPINNER_RENDER_INTERVAL_MS = 80;
 /** Advance the spinner glyph at its classic ~12.5fps step (mirrors `Loader`). */
 export const SPINNER_GLYPH_ADVANCE_MS = 80;
+/** Keep a burst of streamed edit previews from monopolizing the event loop. */
+const EDIT_PREVIEW_DRAIN_BATCH_SIZE = 8;
 
 /** Phase-locked spinner glyph index shared by every live tool block so parallel
  * spinners advance in lockstep instead of each tracking its own start time. */
@@ -539,7 +541,13 @@ export class ToolExecutionComponent extends Container {
 	 * deterministically instead of racing the spinner's render ticks.
 	 */
 	async whenPreviewSettled(): Promise<void> {
-		await this.#editDiffInFlight;
+		// The cleanup callback can replace the settled promise when an update
+		// lands in the finalization window. Keep following replacements so callers
+		// never observe a preview as settled before the latest drain completes.
+		while (this.#editDiffInFlight) {
+			const inFlight = this.#editDiffInFlight;
+			await inFlight;
+		}
 	}
 
 	/**
@@ -558,6 +566,9 @@ export class ToolExecutionComponent extends Container {
 		if (this.#editDiffInFlight) return;
 		this.#editDiffInFlight = this.#drainPreviewDiff().finally(() => {
 			this.#editDiffInFlight = undefined;
+			// A stream update can land in the microtask between the final
+			// compute and this cleanup. Start another drain instead of losing it.
+			if (this.#editDiffDirty) this.#schedulePreviewDiff();
 		});
 	}
 
@@ -569,9 +580,14 @@ export class ToolExecutionComponent extends Container {
 		// the deferral each one re-ran the full sloppy matcher + whole-file diff
 		// to produce a preview the renderer discards in favor of `details.diff`.
 		await undefined;
+		let computesSinceYield = 0;
 		while (this.#editDiffDirty) {
 			this.#editDiffDirty = false;
 			await this.#computePreviewDiff();
+			if (this.#editDiffDirty && ++computesSinceYield >= EDIT_PREVIEW_DRAIN_BATCH_SIZE) {
+				computesSinceYield = 0;
+				await Bun.sleep(0);
+			}
 		}
 	}
 

--- a/packages/coding-agent/test/tool-execution-preview-coalesce.test.ts
+++ b/packages/coding-agent/test/tool-execution-preview-coalesce.test.ts
@@ -117,6 +117,129 @@ describe("streaming edit preview coalescing", () => {
 			component.stopAnimation();
 		}
 	});
+	test("whenPreviewSettled waits for a cleanup-window follow-up drain", async () => {
+		const deferreds: Array<PromiseWithResolvers<PerFileDiffPreview[] | null>> = [];
+		const firstStarted = Promise.withResolvers<void>();
+		const secondStarted = Promise.withResolvers<void>();
+		let component: ToolExecutionComponent | undefined;
+		let stopped = false;
+		let settled = false;
+		let previewSettled: Promise<void> | undefined;
+		const spy = spyOn(EDIT_MODE_STRATEGIES.replace, "computeDiffPreview").mockImplementation(() => {
+			const deferred = Promise.withResolvers<PerFileDiffPreview[] | null>();
+			deferreds.push(deferred);
+			if (deferreds.length === 1) firstStarted.resolve();
+			if (deferreds.length === 2) secondStarted.resolve();
+			return deferred.promise;
+		});
+		restore = () => spy.mockRestore();
+
+		const ui = { requestRender() {} } as unknown as TUI;
+		const tool = { mode: "replace" } as unknown as AgentTool;
+		component = new ToolExecutionComponent(
+			"edit",
+			{ path: file, old_string: "const a = 1;", new_string: "a" },
+			{},
+			tool,
+			ui,
+			tmpDir,
+		);
+		try {
+			await firstStarted.promise;
+			previewSettled = component.whenPreviewSettled().then(() => {
+				settled = true;
+			});
+
+			// Register after the component's await reaction. The nested microtask
+			// lands after the drain loop observes clean state but before its
+			// finalizer, which is the replacement-drain window.
+			deferreds[0]!.promise.then(() => {
+				queueMicrotask(() => {
+					if (stopped) return;
+					component?.updateArgs({
+						path: file,
+						old_string: "const a = 1;",
+						new_string: "latest",
+					});
+				});
+			});
+			deferreds[0]!.resolve(null);
+
+			await secondStarted.promise;
+			await Promise.resolve();
+			expect(settled).toBe(false);
+
+			deferreds[1]!.resolve(null);
+			await previewSettled;
+			expect(settled).toBe(true);
+		} finally {
+			stopped = true;
+			for (const deferred of deferreds) deferred.resolve(null);
+			component.stopAnimation();
+			await previewSettled;
+		}
+	});
+	// A microtask-fed stream must still let an independently queued macrotask
+	// run before the preview catches up with every update.
+	test("yields to the event loop while streamed args keep queuing preview work", async () => {
+		const maxUpdates = 128;
+		const maxComputes = maxUpdates + 2;
+		let updates = 0;
+		let computes = 0;
+		let stopped = false;
+		let component: ToolExecutionComponent | undefined;
+		const updatesDone = Promise.withResolvers<void>();
+		const beaconResult = Promise.withResolvers<{ updates: number; computes: number }>();
+		// This is a task boundary, not a duration-based wait; fake timers cannot
+		// prove that the real event loop was allowed to run.
+		const beacon = setImmediate(() => beaconResult.resolve({ updates, computes }));
+		const spy = spyOn(EDIT_MODE_STRATEGIES.replace, "computeDiffPreview").mockImplementation(async () => {
+			computes++;
+			// Bound a failed implementation so this regression never hangs CI.
+			if (computes >= maxComputes) {
+				updatesDone.resolve();
+				beaconResult.resolve({ updates, computes });
+				return null;
+			}
+			if (updates >= maxUpdates) return null;
+			queueMicrotask(() => {
+				if (stopped || updates >= maxUpdates) return;
+				updates++;
+				if (updates === maxUpdates) updatesDone.resolve();
+				component?.updateArgs({
+					path: file,
+					old_string: "const a = 1;",
+					new_string: String(updates),
+				});
+			});
+			return null;
+		});
+		restore = () => spy.mockRestore();
+
+		const ui = { requestRender() {} } as unknown as TUI;
+		const tool = { mode: "replace" } as unknown as AgentTool;
+		component = new ToolExecutionComponent(
+			"edit",
+			{ path: file, old_string: "const a = 1;", new_string: "0" },
+			{},
+			tool,
+			ui,
+			tmpDir,
+		);
+		try {
+			const observed = await beaconResult.promise;
+			expect(observed.updates).toBeLessThan(maxUpdates);
+			expect(observed.computes).toBeLessThan(maxUpdates + 1);
+			await updatesDone.promise;
+			await component.whenPreviewSettled();
+			expect(updates).toBe(maxUpdates);
+		} finally {
+			stopped = true;
+			clearImmediate(beacon);
+			component.stopAnimation();
+			await component.whenPreviewSettled();
+		}
+	});
 	// Transcript rebuild constructs a historical edit call and applies its
 	// persisted result within the same sync replay chunk. The renderer prefers
 	// `details.diff` from that result, so the streaming preview compute must be


### PR DESCRIPTION
## What

Bound streamed edit-preview recomputes to cooperative batches and yield to the event loop between batches. A dirty update that arrives during cleanup starts a follow-up drain instead of being lost.

## Why

`ToolExecutionComponent` previously drained every newly queued preview in one microtask chain. A burst of streamed edit deltas could therefore monopolize the TUI event loop, leaving the edit card and input unresponsive.

## Testing

- `bun test packages/coding-agent/test/tool-execution-preview-coalesce.test.ts` — 3 passed
- `bun test packages/coding-agent/test/streaming-edit-abort.test.ts packages/coding-agent/test/edit-streaming-preview.test.ts` — 37 passed
- `bun test packages/coding-agent/test/tool-execution-preview-coalesce.test.ts --test-name-pattern='yields to the event loop' --rerun-each=20` — 20 passed
- `bun run check` in `packages/coding-agent` — passed
- `bun run ci:test:coding-agent:ui` — passed
- Full `bun run ci:test:coding-agent:heavy` reached an unrelated exact-byte mismatch in `test/export-html-template.test.ts`; no changed file failed.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)