### PR TITLE
fix(bash): answer terminal queries on user-shell PTY

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `!`/`!!` shell commands stalling ~5s when a program probes the terminal (e.g. `gh` via terminal capability queries); the user-shell PTY now answers cursor-position, device-attribute, and OSC color queries instead of leaving them unanswered ([#10214](https://github.com/can1357/oh-my-pi/issues/10214)).
+
 ## [18.0.11] - 2026-08-29
 
 ### Added

--- a/packages/coding-agent/src/exec/bash-executor.ts
+++ b/packages/coding-agent/src/exec/bash-executor.ts
@@ -13,6 +13,7 @@ import { resolveOutputMaxColumns, resolveOutputSinkHeadBytes } from "../tools/ou
 import { getOrCreateSnapshot } from "../utils/shell-snapshot";
 import { loadDirenvEnv } from "./direnv";
 import { buildNonInteractiveEnv } from "./non-interactive-env";
+import { TerminalQueryResponder } from "./terminal-query-responder";
 
 export interface BashExecutorOptions {
 	cwd?: string;
@@ -385,6 +386,10 @@ async function executeUserShellPty(run: {
 	sink: OutputSink;
 }): Promise<BashResult> {
 	const session = new PtySession();
+	// A headless PTY advertises a real terminal but has nobody to answer the
+	// capability queries probing tools emit, so they block on their reply
+	// timeout (issue #10214). Reply as a terminal would, writing back to stdin.
+	const responder = new TerminalQueryResponder();
 	const result = await session.startArgv(
 		{
 			application: run.shell,
@@ -398,6 +403,14 @@ async function executeUserShellPty(run: {
 		},
 		(err, chunk) => {
 			if (err || !chunk) return;
+			const reply = responder.feed(chunk);
+			if (reply) {
+				try {
+					session.write(reply);
+				} catch {
+					// PTY already closed; nothing to answer.
+				}
+			}
 			run.pty.onChunk(chunk);
 			// CRLF → LF for the capture; the sink strips ANSI itself.
 			run.sink.push(chunk.replace(/\r\n?/gu, "\n"));

--- a/packages/coding-agent/src/exec/terminal-query-responder.ts
+++ b/packages/coding-agent/src/exec/terminal-query-responder.ts
@@ -1,0 +1,76 @@
+/**
+ * Answers terminal capability queries emitted by programs running on OMP's
+ * headless user-shell PTY (the `!` / `!!` hotkey path).
+ *
+ * The PTY advertises `TERM=xterm-256color`, so stdout is a TTY and
+ * capability-probing tools (`gh` via termenv, anything issuing terminfo
+ * cursor/device-attribute probes) write a query escape to stdout and block
+ * until the terminal replies on stdin. Nothing on the OMP side plays terminal,
+ * so those tools wait out their full response timeout — the ~5s `pselect6()`
+ * stall in issue #10214.
+ *
+ * This scanner watches the raw PTY output for the standard queries and returns
+ * the replies a real terminal would send, so the caller writes them back into
+ * the PTY. Queries can straddle chunk boundaries, so an unfinished trailing
+ * escape is buffered until the next chunk completes it.
+ */
+export class TerminalQueryResponder {
+	/** Trailing bytes that may be the start of an unfinished query escape. */
+	#residual = "";
+
+	/**
+	 * Feed one raw PTY output chunk. Returns the reply bytes to write back to
+	 * the PTY, or an empty string when the chunk held no answerable query.
+	 */
+	feed(chunk: string): string {
+		const buf = this.#residual + chunk;
+		let responses = "";
+		let lastEnd = 0;
+		QUERY.lastIndex = 0;
+		for (let m = QUERY.exec(buf); m !== null; m = QUERY.exec(buf)) {
+			lastEnd = m.index + m[0].length;
+			responses += replyFor(m);
+		}
+		// Keep only a short unmatched trailing escape as residual: a query split
+		// across chunks completes on the next feed, while a long tail is ordinary
+		// output that will never become a query.
+		const tailEsc = buf.lastIndexOf("\x1b");
+		this.#residual = tailEsc >= lastEnd && buf.length - tailEsc <= MAX_PARTIAL_QUERY ? buf.slice(tailEsc) : "";
+		return responses;
+	}
+}
+
+/** Longest query escape we answer, bounding the cross-chunk residual buffer. */
+const MAX_PARTIAL_QUERY = 32;
+
+// CSI DSR/DA queries (ending in `n` or `c`) and OSC 10/11 color queries. Only
+// the forms with canned answers are matched; anything else stays plain output.
+const QUERY = /\x1b\[([?>=]?)([0-9;]*)([nc])|\x1b\](10|11);\?(\x07|\x1b\\)/gu;
+
+/** Map a matched query to the reply a real xterm-class terminal would send. */
+function replyFor(m: RegExpExecArray): string {
+	const final = m[3];
+	if (final !== undefined) {
+		const intermediate = m[1];
+		const params = m[2] ?? "";
+		if (final === "c") {
+			// Device attributes.
+			if (intermediate === ">") return "\x1b[>0;10;1c"; // secondary DA
+			if (intermediate === "" || intermediate === "0") return "\x1b[?1;2c"; // primary DA (VT100 + AVO)
+			return ""; // tertiary (`=`) DA has no widely-expected reply
+		}
+		// Device status report.
+		if (intermediate !== "") return "";
+		const ps = params.split(";", 1)[0];
+		if (ps === "6") return "\x1b[1;1R"; // cursor position report
+		if (ps === "5") return "\x1b[0n"; // terminal OK
+		return "";
+	}
+	// OSC color queries: hand back neutral colors so probes resolve instead of
+	// blocking. The terminator is echoed to match the requester's framing.
+	const selector = m[4];
+	const terminator = m[5] ?? "\x07";
+	if (selector === "10") return `\x1b]10;rgb:ffff/ffff/ffff${terminator}`; // foreground
+	if (selector === "11") return `\x1b]11;rgb:0000/0000/0000${terminator}`; // background
+	return "";
+}

--- a/packages/coding-agent/test/terminal-query-responder.test.ts
+++ b/packages/coding-agent/test/terminal-query-responder.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "bun:test";
+import { TerminalQueryResponder } from "@oh-my-pi/pi-coding-agent/exec/terminal-query-responder";
+
+/**
+ * The `!`/`!!` user-shell PTY advertises `TERM=xterm-256color`, so probing
+ * tools (`gh` via termenv) emit terminal queries and block on the reply. The
+ * responder must answer those queries so the tool proceeds instead of waiting
+ * out its timeout (issue #10214), while leaving ordinary output untouched so
+ * injected bytes never corrupt the shell's stdin.
+ */
+describe("TerminalQueryResponder", () => {
+	it("answers a cursor-position query (the terminator gh's probe waits on)", () => {
+		expect(new TerminalQueryResponder().feed("\x1b[6n")).toBe("\x1b[1;1R");
+	});
+
+	it("answers device-status, primary and secondary device-attribute queries", () => {
+		const r = new TerminalQueryResponder();
+		expect(r.feed("\x1b[5n")).toBe("\x1b[0n");
+		expect(r.feed("\x1b[c")).toBe("\x1b[?1;2c");
+		expect(r.feed("\x1b[0c")).toBe("\x1b[?1;2c");
+		expect(r.feed("\x1b[>c")).toBe("\x1b[>0;10;1c");
+	});
+
+	it("answers OSC background/foreground color queries, echoing the terminator", () => {
+		const r = new TerminalQueryResponder();
+		// BEL-terminated request → BEL-terminated reply.
+		expect(r.feed("\x1b]11;?\x07")).toBe("\x1b]11;rgb:0000/0000/0000\x07");
+		// ST-terminated request → ST-terminated reply.
+		expect(r.feed("\x1b]10;?\x1b\\")).toBe("\x1b]10;rgb:ffff/ffff/ffff\x1b\\");
+	});
+
+	it("reassembles a query split across chunk boundaries", () => {
+		const r = new TerminalQueryResponder();
+		expect(r.feed("output\x1b[")).toBe("");
+		expect(r.feed("6n")).toBe("\x1b[1;1R");
+	});
+
+	it("concatenates replies for the OSC + cursor probe pair gh emits together", () => {
+		expect(new TerminalQueryResponder().feed("\x1b]11;?\x07\x1b[6n")).toBe("\x1b]11;rgb:0000/0000/0000\x07\x1b[1;1R");
+	});
+
+	it("stays silent on ordinary output so it never injects into the shell", () => {
+		const r = new TerminalQueryResponder();
+		// SGR color, cursor movement, and plain text are not queries.
+		expect(r.feed("\x1b[31mred\x1b[0m\x1b[2Aplain text\n")).toBe("");
+	});
+});


### PR DESCRIPTION
## Repro
Running a terminal-probing program through the `!`/`!!` user-shell path stalls ~5s. `!! time gh api user --silent` takes ~5.3s versus ~0.3s outside OMP or through the model-facing Bash tool; `TERM=dumb` makes the delay vanish. Reduced to the mechanism with a `PtySession` running a program that issues a cursor-position query and reads the reply with a 5s timeout (same shape as `gh` via termenv): it waits the full 5.01s with no responder, 0.02s once the terminal reply is written back.

## Cause
`executeUserShellPty` in `packages/coding-agent/src/exec/bash-executor.ts` runs zsh/fish `!` commands on a headless PTY with `TERM=xterm-256color`, so stdout is a TTY. Capability-probing tools then emit terminal queries (OSC 10/11 color, cursor position `CSI 6n`, device attributes) and block on the reply. OMP consumed the PTY output but never played terminal, so those tools waited out their full response timeout — the ~5s `pselect6()` the reporter traced. The model-facing Bash tool uses no PTY, so it never triggers the queries and stays fast.

## Fix
- Add `packages/coding-agent/src/exec/terminal-query-responder.ts`: `TerminalQueryResponder` scans raw PTY output for the standard queries (DSR cursor-position/status, primary/secondary device attributes, OSC 10/11 color), buffering an escape split across chunks, and returns the reply a real xterm-class terminal would send.
- Wire it into `executeUserShellPty`'s output callback: feed each chunk to the responder and `session.write` any reply back into the PTY. Replies go to stdin only, never to the captured output or display.
- Add `packages/coding-agent/test/terminal-query-responder.test.ts` covering each query branch, cross-chunk reassembly, terminator echoing, and silence on ordinary output.
- Changelog entry.

## Verification
`bun test test/terminal-query-responder.test.ts` (6 pass) and `bun test test/bash-executor.test.ts` (69 pass). Mechanism repro via `PtySession` with the real responder: `no responder: 5.01s` → `with responder: 0.02s`. Fixes #10214