### PR TITLE
fix(ai): cache the Anthropic tool array with its own breakpoint

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed direct Anthropic requests never caching the tool array. Anthropic writes a cache entry only at a `cache_control` marker, and the backward lookback finds entries earlier requests wrote rather than unmarked stable content behind them, so with markers only on the trailing two messages the `tools` -> `system` head had no entry at any position and every message-region divergence (compaction rebuilding history, a rewind onto another branch, a resumed session) reprocessed the tool definitions too. The last tool definition now carries a breakpoint, which caches every definition before it as a single prefix that survives message-region rewrites and is shared byte for byte between sibling subagents of the same definition. This spends a third of the four available breakpoints; breakpoints themselves are free, and a tool array below the model's minimum cacheable length is processed uncached without an error rather than failing.
+
 ## [18.0.11] - 2026-08-29
 
 ### Fixed

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -3194,8 +3194,38 @@ function applyCacheControlToLastBlock(blocks: ContentBlockParam[], cacheControl:
 	return false;
 }
 
+/**
+ * Mark the tool array so the stable head gets a cache entry of its own.
+ *
+ * Anthropic writes an entry only AT a marked block; the backward lookback finds
+ * entries prior requests wrote, never unmarked stable content behind them. With
+ * markers only in the trailing message window, the `tools` -> `system` head has
+ * no entry at any position, so any divergence in the message region (compaction
+ * rebuilding history, a rewind onto another branch, a resumed session) reprocesses
+ * the tool definitions along with everything else.
+ *
+ * The tool array sits first in wire order, so an entry here survives every
+ * message-region rewrite, and it is the one region sibling subagents of the same
+ * definition share byte for byte. Breakpoints themselves are free (only written
+ * and read tokens are billed) and a prefix below the model's minimum cacheable
+ * length is processed uncached without an error, so a short tool array degrades
+ * to a no-op rather than a failure.
+ */
+function applyToolPromptCaching(tools: AnthropicWireTool[] | undefined, cacheControl: AnthropicCacheControl): void {
+	if (!tools?.length) return;
+	const lastIndex = tools.length - 1;
+	const lastTool = tools[lastIndex];
+	if (!lastTool || lastTool.cache_control != null) return;
+	tools[lastIndex] = { ...lastTool, cache_control: cloneAnthropicCacheControl(cacheControl) };
+}
+
 function applyPromptCaching(params: MessageCreateParamsStreaming, cacheControl?: AnthropicCacheControl): void {
 	if (!cacheControl) return;
+
+	// One marker on the tool array plus the two-message rolling window below is
+	// three of Anthropic's four breakpoints, leaving one spare. Both carry the
+	// same TTL, so the "longer TTL must precede shorter" rule cannot be violated.
+	applyToolPromptCaching(params.tools, cacheControl);
 
 	// `convertAnthropicMessages` appends this neutral pad after a trailing
 	// assistant because Anthropic rejects assistant-prefill endings. It is absent

--- a/packages/ai/test/anthropic-alignment.test.ts
+++ b/packages/ai/test/anthropic-alignment.test.ts
@@ -1624,7 +1624,53 @@ describe("Anthropic request fingerprint alignment", () => {
 		expect(payload.tools?.[0]?.name).toBe(`${claudeToolPrefix}bash`);
 		expect(payload.tools?.[0]?.strict).toBe(true);
 		expect(payload.tools?.[0]?.eager_input_streaming).toBe(true);
+		// Sole tool is also the last tool, so it carries the head breakpoint.
+		expect(payload.tools?.[0]?.cache_control).toEqual({ type: "ephemeral" });
+	});
+
+	it("breakpoints the last tool definition so the stable head gets its own cache entry", async () => {
+		const tools: Tool[] = ["search", "fetch", "run"].map(name => ({
+			name,
+			description: `${name} tool`,
+			parameters: {
+				type: "object",
+				properties: { value: { type: "string" } },
+				required: ["value"],
+			} as TJsonSchema,
+		}));
+
+		const payload = (await captureAnthropicPayload(ANTHROPIC_MODEL, {
+			systemPrompt: ["Stay concise."],
+			messages: [{ role: "user", content: "Hi", timestamp: Date.now() }],
+			tools,
+		})) as {
+			tools?: Array<{ cache_control?: unknown }>;
+			system?: Array<{ cache_control?: unknown }>;
+			messages?: Array<{ content?: Array<{ cache_control?: unknown }> | string }>;
+		};
+
+		// Only the last tool is marked: it caches every definition before it as a
+		// single prefix, so earlier markers would spend breakpoints for nothing.
 		expect(payload.tools?.[0]?.cache_control).toBeUndefined();
+		expect(payload.tools?.[1]?.cache_control).toBeUndefined();
+		expect(payload.tools?.at(-1)?.cache_control).toEqual({ type: "ephemeral" });
+
+		// The trailing message window is untouched, and system blocks stay uncached
+		// because the OAuth cloak blocks carry per-request bytes.
+		const content = payload.messages?.at(-1)?.content;
+		expect(Array.isArray(content) ? content.at(-1)?.cache_control : undefined).toEqual({
+			type: "ephemeral",
+		});
+		expect(payload.system?.some(block => block.cache_control != null)).toBe(false);
+
+		// Anthropic rejects a fifth breakpoint, so the total must stay in budget.
+		const marked = (blocks: Array<{ cache_control?: unknown }> | undefined) =>
+			(blocks ?? []).filter(block => block.cache_control != null).length;
+		const messageBreakpoints = (payload.messages ?? []).reduce(
+			(total, message) => total + (Array.isArray(message.content) ? marked(message.content) : 0),
+			0,
+		);
+		expect(marked(payload.tools) + marked(payload.system) + messageBreakpoints).toBeLessThanOrEqual(4);
 	});
 
 	it("marks only the Anthropic strict allowlist strict", async () => {


### PR DESCRIPTION
I was comparing omp's Anthropic prompt caching against how Claude Code does it, and found that the tool array never gets cached at all. The fix is one marker.

## What's wrong

`applyPromptCaching` marks the last block of the trailing two messages and nothing else. No marker ever lands on `tools` or `system`.

That reads like "the head is still cached, just behind the message breakpoint." It isn't. Anthropic writes a cache entry only at a marker, and the backward lookback searches for entries that earlier requests wrote, not for stable content sitting behind them. With no marker on the tool array there is no entry at that boundary at any point, so as soon as the message region diverges the tool definitions get reprocessed along with everything else. That happens when compaction rebuilds history, on a rewind onto a different branch, and when resuming a session.

## The change

Mark the last tool definition. Anthropic caches every definition before it as one prefix, so a single marker covers the whole array.

I picked the tool array over the system block for three reasons:

- It sits first in wire order, so the entry survives any rewrite of the message region.
- It is the one region sibling subagents of the same definition share byte for byte, so a fan-out can read it instead of each sibling writing its own copy.
- It does not depend on `system[0]` being stable, which matters because on OAuth that block carries a per-request billing header.

## Budget

Three of the four breakpoints: one on tools, two on the existing message window. Both carry the same TTL, so the rule that longer TTLs must precede shorter ones cannot be violated. Breakpoints cost nothing by themselves, only written and read tokens are billed. A tool array below the model's minimum cacheable length is processed uncached without an error, so a small array degrades to a no-op.

I checked that the Anthropic path has exactly two `cache_control` writers, both inside `applyPromptCaching`, so three markers cannot turn into five and trip the API limit.

## One thing I would like your call on

I did not gate this by endpoint, unlike `supportsLongCacheRetention` right next to it, which is official-only. My reasoning is that omp already sends this exact marker shape on message blocks to every Anthropic-compatible endpoint without gating, so anything that accepts one should accept the other. If you would rather be conservative, a compat flag is a one-line change and I will add it.

## Verification

The new test captures the real payload out of `streamAnthropic` through `onPayload`, so it asserts against the actual outgoing request rather than a mock: the marker lands on the last tool, earlier tools stay unmarked, the message window is untouched, system blocks stay uncached, and the total stays within four.

To confirm this change and nothing else accounts for the results, I stashed it and reran the package. Baseline is 4279 pass and 2 fail; with the change it is 4280 pass and 2 fail, the same two failures either way. Both are environmental in my sandbox: a Google OAuth test that connects to a loopback port, and a Bedrock guardrails test that times out at 5s under full-suite parallelism and passes on its own.

Also run: `anthropic-alignment.test.ts` 97 pass, cache-related suites 48 pass with the three auth-gateway e2e suites skipping without live credentials, `tsgo --noEmit` clean on `packages/ai`, and `biome check` clean on the changed files.

What I have not done is watch the cache token counters against the live API across a compaction boundary, which is the end-to-end proof that the tools prefix comes back as `cache_read_input_tokens` instead of being rewritten. I can run that before you merge if you want it.

Unrelated to this change, but worth flagging since I ran into it: `issue-6276-repro.test.ts` looks like a genuine flake rather than a sandbox artifact, since it fails only under full-suite parallelism.
