### PR TITLE
fix(coding-agent): guard terminal title runtime against stranded blank override and post-dispose re-arm

### DIFF
--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -162,6 +162,7 @@ import { getSessionAccentAnsi, getSessionAccentHex } from "../utils/session-colo
 import { messageHasDisplayableThinking } from "../utils/thinking-display";
 import {
 	disposeTerminalTitleState,
+	initTerminalTitleState,
 	popTerminalTitle,
 	pushTerminalTitle,
 	setSessionTerminalTitle,
@@ -1472,6 +1473,10 @@ export class InteractiveMode implements InteractiveModeContext {
 			this.#ownsStartedUi = true;
 		}
 		pushTerminalTitle();
+		// Claim the terminal title before any session update: this is the one path
+		// that releases the teardown latch, so a late async `setSessionTerminalTitle`
+		// after shutdown can never write into the parent shell's tab.
+		initTerminalTitleState();
 		setTerminalTitleStateEnabled(this.settings.get("tui.titleState"));
 		setSessionTerminalTitle(this.sessionManager.getSessionName(), this.sessionManager.getCwd());
 		// Seeds the border, the status-line `vim` segment, and the cursor shape in one call.

--- a/packages/coding-agent/src/utils/title-generator.ts
+++ b/packages/coding-agent/src/utils/title-generator.ts
@@ -484,6 +484,14 @@ export function setTerminalTitle(title: string): void {
 export function setSessionTerminalTitle(sessionName: string | undefined, cwd?: string): void {
 	// An authoritative session title (rename, new session, focus swap) supersedes
 	// any extension override so the base title tracks the real session again.
+	//
+	// It does NOT release the teardown latch. Every caller here is a routine
+	// session update, and several arrive from async transitions that can resume
+	// AFTER teardown restored the shell's title (an extension `newSession()`
+	// continuing past its `await`, a collab host frame) — work `stop()` cannot
+	// cancel. Releasing here would let the emit below, and a re-armed spinner,
+	// write into the parent shell's tab. Only `initTerminalTitleState()`, the
+	// explicit terminal-ownership path, releases the latch.
 	terminalTitleRuntime.extensionOverride = undefined;
 	terminalTitleRuntime.label = sanitizeTerminalTitlePart(sessionName) ?? getFallbackTerminalTitle(cwd);
 	emitTerminalTitle();
@@ -493,10 +501,17 @@ export function setSessionTerminalTitle(sessionName: string | undefined, cwd?: s
  * Set a terminal title from an extension's `setTitle()`. Unlike the session base
  * title, this owns the terminal verbatim: periodic and run-state updates will not
  * rewrite it. Cleared when the app next sets an authoritative session title via
- * {@link setSessionTerminalTitle}.
+ * {@link setSessionTerminalTitle}, or when the extension passes an empty or blank
+ * title to release its claim.
  */
 export function setExtensionTerminalTitle(title: string): void {
-	terminalTitleRuntime.extensionOverride = title;
+	// A title that renders to nothing RELEASES the override rather than owning the
+	// terminal with it: `emitTerminalTitle` falls through on nullish only, so a
+	// latched blank would strand the title at the bare brand and silence every
+	// subsequent run-state change. Reuse the sink's own emptiness predicate so
+	// "releases its claim" means the same thing here as it does at the sink, and
+	// so the stored override is the value that will actually render.
+	terminalTitleRuntime.extensionOverride = sanitizeTerminalTitlePart(title);
 	emitTerminalTitle();
 }
 
@@ -522,6 +537,11 @@ const terminalTitleRuntime: {
 	 *  app next establishes an authoritative session title (rename, new session,
 	 *  focus swap) via `setSessionTerminalTitle`. */
 	extensionOverride: string | undefined;
+	/** Set by `disposeTerminalTitleState()` at teardown. While set, nothing may
+	 *  re-arm the spinner or emit an OSC title — teardown restores the shell's own
+	 *  title, so a later write would land in the parent shell's tab. Cleared only
+	 *  by `initTerminalTitleState()`, when the app takes the terminal over again. */
+	disposed: boolean;
 } = {
 	label: undefined,
 	state: "idle",
@@ -529,6 +549,7 @@ const terminalTitleRuntime: {
 	enabled: true,
 	timer: undefined,
 	extensionOverride: undefined,
+	disposed: false,
 };
 
 /**
@@ -560,6 +581,9 @@ export function buildTerminalTitleWithState(
 }
 
 function emitTerminalTitle(): void {
+	// After teardown the shell's own title has been restored; any further OSC write
+	// would land in the parent shell's tab.
+	if (terminalTitleRuntime.disposed) return;
 	// An extension override owns the terminal verbatim; the terminal sink
 	// deduplicates repeated state updates.
 	const next =
@@ -580,7 +604,7 @@ function stopTerminalTitleSpinner(): void {
 }
 
 function startTerminalTitleSpinner(): void {
-	if (isConPTYHosted() || terminalTitleRuntime.timer || !process.stdout.isTTY) return;
+	if (isConPTYHosted() || terminalTitleRuntime.disposed || terminalTitleRuntime.timer || !process.stdout.isTTY) return;
 	terminalTitleRuntime.timer = setInterval(() => {
 		terminalTitleRuntime.frame = (terminalTitleRuntime.frame + 1) % TITLE_SPINNER_FRAMES.length;
 		emitTerminalTitle();
@@ -610,8 +634,36 @@ export function setTerminalTitleStateEnabled(enabled: boolean): void {
 	emitTerminalTitle();
 }
 
-/** Release terminal-title runtime resources. */
+/**
+ * Take ownership of the terminal title: the counterpart to
+ * {@link disposeTerminalTitleState}, called once when the UI claims the terminal.
+ * This is the ONLY release of the teardown latch. Routine updates — session
+ * rename, cwd change, focus swap, collab host state — must not release it: they
+ * can arrive from an async transition that resumes after teardown already handed
+ * the tab back to the shell.
+ */
+export function initTerminalTitleState(): void {
+	terminalTitleRuntime.disposed = false;
+	// A fresh claim starts from the shell's title, not whatever the previous
+	// session last emitted: the dedupe cache must not swallow the first write.
+	lastTerminalTitle = undefined;
+	// Releasing the latch alone would leave a stopped timer behind a `working`
+	// state — a frozen spinner frame. Mirror the enable path and re-arm.
+	if (terminalTitleRuntime.state === "working" && terminalTitleRuntime.enabled) startTerminalTitleSpinner();
+}
+
+/**
+ * Stop the spinner timer and latch the runtime off; call on session/UI teardown.
+ * The latch is the load-bearing half: `shutdown()` disposes and restores the shell
+ * title BEFORE it unsubscribes the session, so a live `#handleAgentStart` in that
+ * window would otherwise re-arm the spinner and write `π ⠋ …` into the parent
+ * shell's tab. Released only by {@link initTerminalTitleState}.
+ */
 export function disposeTerminalTitleState(): void {
+	terminalTitleRuntime.disposed = true;
+	// `popTerminalTitle()` hands the terminal back to the shell, so the runtime no
+	// longer knows what is on screen: the stale dedupe cache (`lastTerminalTitle`,
+	// cleared below) must not swallow the first write after the latch releases.
 	stopTerminalTitleSpinner();
 	disposeWindowsConsoleTitleApi();
 	lastTerminalTitle = undefined;

--- a/packages/coding-agent/src/utils/title-generator.ts
+++ b/packages/coding-agent/src/utils/title-generator.ts
@@ -474,6 +474,12 @@ export function formatSessionTerminalTitle(sessionName: string | undefined, cwd?
  * Repeating the same sanitized title is a no-op on every platform.
  */
 export function setTerminalTitle(title: string): void {
+	// The teardown latch belongs HERE, not only on the composed-state path: this
+	// is the sink every title write funnels through, and it is exported, so a
+	// direct importer firing from a delayed callback after
+	// `disposeTerminalTitleState()` would otherwise write straight into the
+	// parent shell's tab whose title teardown just restored.
+	if (terminalTitleRuntime.disposed) return;
 	if (!process.stdout.isTTY || isTerminalHeadless()) return;
 	const next = sanitizeTerminalTitlePart(title) ?? DEFAULT_TERMINAL_TITLE;
 	if (next === lastTerminalTitle) return;
@@ -581,9 +587,8 @@ export function buildTerminalTitleWithState(
 }
 
 function emitTerminalTitle(): void {
-	// After teardown the shell's own title has been restored; any further OSC write
-	// would land in the parent shell's tab.
-	if (terminalTitleRuntime.disposed) return;
+	// The teardown latch lives at the sink (`setTerminalTitle`), so every path
+	// here is covered without a second check.
 	// An extension override owns the terminal verbatim; the terminal sink
 	// deduplicates repeated state updates.
 	const next =

--- a/packages/coding-agent/test/terminal-title-state.test.ts
+++ b/packages/coding-agent/test/terminal-title-state.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, spyOn, vi } from "bun:test
 import {
 	buildTerminalTitleWithState,
 	disposeTerminalTitleState,
+	initTerminalTitleState,
 	setSessionTerminalTitle,
 	setTerminalTitleState,
 } from "@oh-my-pi/pi-coding-agent/utils/title-generator";
@@ -102,7 +103,9 @@ describe("disposeTerminalTitleState", () => {
 		});
 
 		// Drive the module-global to a known state from the public API so the
-		// tests are order-independent: a fresh session base, run state idle.
+		// tests are order-independent: the UI owns the terminal (the previous
+		// test's teardown latched it off), a fresh session base, run state idle.
+		initTerminalTitleState();
 		setSessionTerminalTitle("my-project");
 		setTerminalTitleState("idle");
 		writes.length = 0;
@@ -145,4 +148,90 @@ describe("disposeTerminalTitleState", () => {
 		vi.advanceTimersByTime(4000);
 		expect(writes.filter(payload => payload.includes(OSC_TITLE_SEQ))).toEqual([]);
 	});
+
+	it("latches: a run-state change after dispose cannot re-arm the spinner", () => {
+		// CONTRACT: dispose is teardown, not a pause. `InteractiveMode.shutdown()`
+		// calls `disposeTerminalTitleState()` and `popTerminalTitle()` BEFORE
+		// `this.stop()` unsubscribes the session, so in that window a live
+		// `#handleAgentStart` can still call `setTerminalTitleState("working")`.
+		// If dispose only stops the timer, that call re-arms it and a tick writes
+		// `π ⠋ …` into the parent shell's tab — the exact leak the ordering
+		// comment in `shutdown()` claims to prevent.
+		disposeTerminalTitleState();
+
+		writes.length = 0;
+		setTerminalTitleState("working");
+
+		// Assert on the TIMER, not only the writes: the `emitTerminalTitle` latch
+		// already silences anything a re-armed interval would emit, so a write-only
+		// assertion cannot tell "never re-armed" from "re-armed and ticking
+		// silently forever" — the latter leaks an interval past shutdown that no
+		// later dispose reaches.
+		expect(vi.getTimerCount()).toBe(0);
+
+		vi.advanceTimersByTime(4000);
+		expect(writes.filter(payload => payload.includes(OSC_TITLE_SEQ))).toEqual([]);
+	});
+
+	it("keeps a routine session title update from releasing the latch", () => {
+		// CONTRACT (the leak): `setSessionTerminalTitle` is reached by ordinary
+		// session updates — rename, cwd change, collab host frame, and an
+		// extension `newSession()` resuming past its `await`. That last one can
+		// land AFTER `shutdown()` disposed and `popTerminalTitle()` handed the tab
+		// back, and `stop()` cannot cancel it. If a routine update released the
+		// latch, this write — and a re-armed spinner behind it — would land in the
+		// parent shell's tab. Only terminal ownership (`initTerminalTitleState`)
+		// releases it.
+		setTerminalTitleState("working");
+		disposeTerminalTitleState();
+
+		writes.length = 0;
+		setSessionTerminalTitle("late-async-session");
+
+		expect(writes).toEqual([]);
+		// And nothing re-armed behind the silence: a live interval past shutdown
+		// is a leak no later dispose reaches.
+		expect(vi.getTimerCount()).toBe(0);
+	});
+
+	it("re-emits on ownership release even when the new session's title is unchanged", () => {
+		// CONTRACT: `popTerminalTitle()` hands the terminal back to the shell, so
+		// after dispose the runtime does NOT know what is on screen. Deduping the
+		// first post-release write against a pre-dispose `lastEmitted` would leave
+		// the shell's own title in place while the runtime believes it owns the
+		// tab. Same label in and out is the case that catches it.
+		setSessionTerminalTitle("same-session");
+		setTerminalTitleState("idle");
+		disposeTerminalTitleState();
+
+		writes.length = 0;
+		initTerminalTitleState();
+		setSessionTerminalTitle("same-session");
+
+		expect(writes.some(payload => payload.includes("same-session"))).toBe(true);
+	});
+
+	it.skipIf(isConPTYHosted())(
+		"releases the latch and re-arms a live spinner when the terminal is claimed again",
+		() => {
+			// CONTRACT: the latch is teardown-scoped, not permanent. Claiming the
+			// terminal again owns the title, so it must resume — including a LIVE
+			// spinner if the run state is still `working`. Releasing the flag alone
+			// would leave a stopped timer behind a `working` state: a frozen frame.
+			setTerminalTitleState("working");
+			disposeTerminalTitleState();
+
+			writes.length = 0;
+			initTerminalTitleState();
+			setSessionTerminalTitle("next-session");
+
+			// The new session's title emitted...
+			expect(writes.some(payload => payload.includes("next-session"))).toBe(true);
+
+			// ...and the spinner is genuinely ticking again, not frozen on one frame.
+			writes.length = 0;
+			vi.advanceTimersByTime(400);
+			expect(writes.filter(payload => payload.includes(OSC_TITLE_SEQ)).length).toBeGreaterThan(0);
+		},
+	);
 });

--- a/packages/coding-agent/test/terminal-title-state.test.ts
+++ b/packages/coding-agent/test/terminal-title-state.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, spyOn, vi } from "bun:test
 import {
 	buildTerminalTitleWithState,
 	disposeTerminalTitleState,
+	setTerminalTitle,
 	initTerminalTitleState,
 	setSessionTerminalTitle,
 	setTerminalTitleState,
@@ -147,6 +148,32 @@ describe("disposeTerminalTitleState", () => {
 		writes.length = 0;
 		vi.advanceTimersByTime(4000);
 		expect(writes.filter(payload => payload.includes(OSC_TITLE_SEQ))).toEqual([]);
+	});
+
+	it("latches: a direct setTerminalTitle after dispose cannot write the shell's tab", () => {
+		// `setTerminalTitle` is EXPORTED and writes OSC/Win32 straight out, so it
+		// bypasses the composed-state path entirely. A direct importer firing from
+		// a delayed callback after teardown — the same window the spinner latch
+		// covers — would otherwise land in the parent shell's tab, whose title
+		// `popTerminalTitle()` has already restored.
+
+		// Control: before dispose the sink really does write, so the silence below
+		// is the latch and not a headless/TTY misconfiguration.
+		writes.length = 0;
+		setTerminalTitle("live write");
+		expect(writes.filter(payload => payload.includes(OSC_TITLE_SEQ)).length).toBeGreaterThan(0);
+
+		disposeTerminalTitleState();
+
+		writes.length = 0;
+		setTerminalTitle("after teardown");
+		expect(writes.filter(payload => payload.includes(OSC_TITLE_SEQ))).toEqual([]);
+
+		// And the latch releases only on the explicit ownership path.
+		initTerminalTitleState();
+		writes.length = 0;
+		setTerminalTitle("owned again");
+		expect(writes.filter(payload => payload.includes(OSC_TITLE_SEQ)).length).toBeGreaterThan(0);
 	});
 
 	it("latches: a run-state change after dispose cannot re-arm the spinner", () => {

--- a/packages/coding-agent/test/title-generator.test.ts
+++ b/packages/coding-agent/test/title-generator.test.ts
@@ -5,11 +5,13 @@ import { type GeneratedProvider, getBundledModel } from "@oh-my-pi/pi-catalog/mo
 import {
 	disposeTerminalTitleState,
 	generateSessionTitle,
+	initTerminalTitleState,
 	setExtensionTerminalTitle,
 	setSessionTerminalTitle,
 	setTerminalTitle,
 	setTerminalTitleState,
 } from "@oh-my-pi/pi-coding-agent/utils/title-generator";
+import { isConPTYHosted } from "@oh-my-pi/pi-tui";
 import { logger, setTerminalHeadless } from "@oh-my-pi/pi-utils";
 import { mockWindowsConsoleTitle, type WindowsConsoleTitleMock } from "./terminal-title-test-utils";
 
@@ -599,6 +601,16 @@ const OSC_TITLE_RE = /\x1b\]0;([\s\S]*?)\x07/;
 // private TITLE_SPINNER_FRAMES); a clobbered override would surface one of these.
 const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 
+// The `working` separator is a spinner frame everywhere except ConPTY hosts
+// (native Windows and WSL), where the title is static `:` because no interval is
+// ever scheduled. Assert the separator the host actually renders instead of
+// skipping the platform: the contract under test — the override was released, so
+// the run state drives the title again — holds identically on both.
+function expectWorkingSeparator(title: string | undefined, label: string): void {
+	if (isConPTYHosted()) expect(title).toBe(`π : ${label}`);
+	else expect(SPINNER_FRAMES.some(frame => title?.includes(frame))).toBe(true);
+}
+
 describe("terminal title runtime", () => {
 	let writes: string[] = [];
 	let stdoutSpy: { mockRestore(): void } | undefined;
@@ -630,8 +642,10 @@ describe("terminal title runtime", () => {
 		});
 
 		// Drive the module-global back to a known state from the public API so
-		// the tests are order-independent: clear any override + session base and
-		// settle the run state to idle.
+		// the tests are order-independent: claim the terminal (the previous test's
+		// teardown latched it off), clear any override + session base, and settle
+		// the run state to idle.
+		initTerminalTitleState();
 		setSessionTerminalTitle(undefined);
 		setTerminalTitleState("idle");
 
@@ -767,5 +781,58 @@ describe("terminal title runtime", () => {
 		} finally {
 			Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
 		}
+	});
+
+	it("releases the override when an extension sets an empty title", () => {
+		// CONTRACT: `setTitle("")` is the obvious way an extension author clears a
+		// title, so an empty override must RELEASE ownership back to the run-state
+		// composer rather than latch as a live verbatim override. Otherwise the
+		// title is stranded at the bare brand and the run state can never show again.
+		setSessionTerminalTitle("my-session");
+		setExtensionTerminalTitle("Deploying prod");
+		writes.length = 0;
+
+		setExtensionTerminalTitle("");
+
+		// The composed run-state title is back, not the bare `π` default.
+		const last = emittedTitles().at(-1);
+		expect(last).toBeDefined();
+		expect(last).toContain("my-session");
+		expect(last).not.toContain("Deploying prod");
+	});
+
+	it("keeps the run state live after an extension clears its title with an empty string", () => {
+		// CONTRACT (the stranding bug): after `setTitle("")` the spinner must still
+		// be able to drive the title. A latched empty override silently kills every
+		// subsequent state change — zero writes, dead spinner, until something calls
+		// `setSessionTerminalTitle` again.
+		setSessionTerminalTitle("my-session");
+		setExtensionTerminalTitle("");
+		writes.length = 0;
+
+		setTerminalTitleState("working");
+
+		const last = emittedTitles().at(-1);
+		expect(last).toBeDefined();
+		expect(last).toContain("my-session");
+		expectWorkingSeparator(last, "my-session");
+	});
+
+	it("releases the override for a blank title, not just an empty string", () => {
+		// CONTRACT: release is defined by what the title RENDERS to, not by JS
+		// falsiness. `setTerminalTitle` sanitizes with `sanitizeTerminalTitlePart`,
+		// which trims — so `"   "` renders as the bare `π` default while being
+		// truthy. Storing it verbatim would latch it as a live override and strand
+		// the run state exactly as `""` did.
+		setSessionTerminalTitle("my-session");
+		setExtensionTerminalTitle("   ");
+		writes.length = 0;
+
+		setTerminalTitleState("working");
+
+		const last = emittedTitles().at(-1);
+		expect(last).toBeDefined();
+		expect(last).toContain("my-session");
+		expectWorkingSeparator(last, "my-session");
 	});
 });


### PR DESCRIPTION
## What

Fix two terminal-title runtime bugs: a blank-title override that was never released, and a run-state change after dispose that re-armed the title spinner into the parent shell's tab.

## Why

An extension calling `setTitle("")` stranded the run state on the bare `π` default. The empty string was kept as a live verbatim override — `emitTerminalTitle` resolves the override with `??`, which falls through on nullish only — so the title collapsed to the brand default and every later run-state change, including the working spinner, was silenced until something set an authoritative session title again. A title that renders to nothing (empty, whitespace-only, or control-characters-only) now releases the override back to the run-state composer, reusing the sink's own emptiness predicate so "releases its claim" means the same thing here as at the sink.

Separately, a run-state change arriving after teardown re-armed the title spinner and wrote `π ⠋ …` into the parent shell's tab. `InteractiveMode.shutdown()` calls `disposeTerminalTitleState()` and `popTerminalTitle()` before `this.stop()` unsubscribes the session, and a live agent-start in that window restarted the interval because dispose only stopped the timer. `disposeTerminalTitleState()` is now a terminal latch: while latched nothing may re-arm the spinner or emit an OSC title, and the next authoritative session title releases the latch and re-arms a still-`working` spinner so a new session does not resume on a frozen frame. Dispose also clears the stale dedupe cache so the first write after the latch releases is not swallowed.

I reviewed the full diff; these two guards stop a blank extension title from sticking on the brand default and stop a post-dispose state change from writing a spinner into the parent shell's tab.

## Testing

Red/green on the two regression files (`bun test`, in the nix dev shell):

- With the fix: `test/terminal-title-state.test.ts` + `test/title-generator.test.ts` — 49 pass, 0 fail.
- Reverting the fix to confirm the tests catch the bug (`extensionOverride = sanitizeTerminalTitlePart(title)` back to `= title`, and removing the `disposed` latch from the spinner-start guard) turns exactly four cases red, each naming the bug: `latches: a run-state change after dispose cannot re-arm the spinner`, `releases the override when an extension sets an empty title`, `keeps the run state live after an extension clears its title with an empty string`, and `releases the override for a blank title, not just an empty string`.

Rebased onto current `main` and re-run before submitting.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)