### PR TITLE
fix(stats): ingest named-profile sessions into shared stats.db

### DIFF
--- a/packages/stats/CHANGELOG.md
+++ b/packages/stats/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed session sync reading only the active agent dir: `omp stats` now ingests `<config-root>/agent/sessions` plus every `profiles/<name>/agent/sessions` into the shared app-root `stats.db`, so named-profile traffic no longer vanishes from 24h/7d.
+
+
 ## [18.0.9] - 2026-08-28
 
 ### Fixed

--- a/packages/stats/src/db.ts
+++ b/packages/stats/src/db.ts
@@ -1,5 +1,6 @@
 import { Database } from "bun:sqlite";
 import * as fs from "node:fs/promises";
+import * as path from "node:path";
 import type { Usage } from "@oh-my-pi/pi-ai";
 import {
 	calculateUncachedInputCost,
@@ -8,7 +9,7 @@ import {
 	getBundledModel,
 } from "@oh-my-pi/pi-catalog/models";
 import type { ModelCost } from "@oh-my-pi/pi-catalog/types";
-import { getConfigRootDir, getStatsDbPath } from "@oh-my-pi/pi-utils";
+import { getStatsDbPath } from "@oh-my-pi/pi-utils";
 import { classifyAgentType } from "./parser";
 import type {
 	AgentType,
@@ -136,7 +137,7 @@ export async function initDb(): Promise<Database> {
 	if (db) return db;
 
 	// Ensure directory exists
-	await fs.mkdir(getConfigRootDir(), { recursive: true });
+	await fs.mkdir(path.dirname(getStatsDbPath()), { recursive: true });
 
 	db = new Database(getStatsDbPath());
 	// Install the busy handler BEFORE any lock-taking statement. See

--- a/packages/stats/src/parser.ts
+++ b/packages/stats/src/parser.ts
@@ -10,7 +10,7 @@ import {
 	type ToolResultMessage,
 	type Usage,
 } from "@oh-my-pi/pi-ai";
-import { getSessionsDir, isEnoent, readLines } from "@oh-my-pi/pi-utils";
+import { getSessionsDir, isEnoent, listAgentDirs, readLines } from "@oh-my-pi/pi-utils";
 import type {
 	AgentType,
 	MessageStats,
@@ -27,6 +27,14 @@ import { computeUserMessageMetrics } from "./user-metrics";
 /** Basename of an advisor agent's transcript inside a session artifacts dir. */
 const ADVISOR_TRANSCRIPT_BASENAME = "__advisor.jsonl";
 
+/** Sessions root that contains `sessionPath` (`.../agent/sessions`). */
+function sessionsRootFor(sessionPath: string): string {
+	const resolved = path.resolve(sessionPath);
+	const marker = `${path.sep}agent${path.sep}sessions${path.sep}`;
+	const idx = resolved.lastIndexOf(marker);
+	if (idx >= 0) return resolved.slice(0, idx + marker.length - 1);
+	return getSessionsDir();
+}
 /**
  * Classify which agent produced a transcript from its path within the sessions
  * directory. Layout: `<sessionsDir>/<project>/<file>.jsonl` is the `main`
@@ -42,7 +50,7 @@ export function classifyAgentType(sessionPath: string): AgentType {
 	if (base === ADVISOR_TRANSCRIPT_BASENAME || (base.startsWith("__advisor.") && base.endsWith(".jsonl"))) {
 		return "advisor";
 	}
-	const rel = path.relative(getSessionsDir(), sessionPath);
+	const rel = path.relative(sessionsRootFor(sessionPath), sessionPath);
 	// `<project>/<file>.jsonl` -> 2 segments. Deeper nesting is a subagent.
 	return rel.split(path.sep).length <= 2 ? "main" : "subagent";
 }
@@ -53,8 +61,7 @@ export function classifyAgentType(sessionPath: string): AgentType {
  * The folder part uses -- as path separator.
  */
 function extractFolderFromPath(sessionPath: string): string {
-	const sessionsDir = getSessionsDir();
-	const rel = path.relative(sessionsDir, sessionPath);
+	const rel = path.relative(sessionsRootFor(sessionPath), sessionPath);
 	const projectDir = rel.split(path.sep)[0];
 	// Convert --work--pi-- to /work/pi
 	return projectDir.replace(/^--/, "/").replace(/--/g, "/");
@@ -444,13 +451,19 @@ export async function parseSessionFile(sessionPath: string, fromOffset = 0): Pro
  * List all session directories (folders).
  */
 export async function listSessionFolders(): Promise<string[]> {
-	try {
-		const sessionsDir = getSessionsDir();
-		const entries = await fs.readdir(sessionsDir, { withFileTypes: true });
-		return entries.filter(e => e.isDirectory()).map(e => path.join(sessionsDir, e.name));
-	} catch {
-		return [];
+	const folders: string[] = [];
+	for (const agentDir of await listAgentDirs()) {
+		const sessionsDir = getSessionsDir(agentDir);
+		try {
+			const entries = await fs.readdir(sessionsDir, { withFileTypes: true });
+			for (const entry of entries) {
+				if (entry.isDirectory()) folders.push(path.join(sessionsDir, entry.name));
+			}
+		} catch {
+			// Missing or unreadable sessions dir — skip that tree.
+		}
 	}
+	return folders;
 }
 
 /**

--- a/packages/stats/test/agent-type.test.ts
+++ b/packages/stats/test/agent-type.test.ts
@@ -6,7 +6,7 @@ import { getOverviewStats } from "@oh-my-pi/omp-stats/aggregator";
 import { getStatsByAgentType, initDb, insertMessageStats } from "@oh-my-pi/omp-stats/db";
 import { classifyAgentType } from "@oh-my-pi/omp-stats/parser";
 import type { AgentType, MessageStats } from "@oh-my-pi/omp-stats/types";
-import { getConfigRootDir, getSessionsDir, getStatsDbPath } from "@oh-my-pi/pi-utils";
+import { getAgentDir, getConfigRootDir, getSessionsDir, getStatsDbPath } from "@oh-my-pi/pi-utils";
 import { installStatsTestIsolation } from "./helpers/temp-agent";
 
 installStatsTestIsolation("@pi-stats-agent-type-");
@@ -60,6 +60,20 @@ describe("classifyAgentType", () => {
 		expect(classifyAgentType(path.join(session, "AuthLoader", "__advisor.security.jsonl"))).toBe("advisor");
 		// `__advisor-2.jsonl` (output-manager bump namespace) is NOT an advisor transcript.
 		expect(classifyAgentType(path.join(session, "__advisor-2.jsonl"))).toBe("subagent");
+	});
+
+	it("classifies profile-dir transcripts relative to that profile's sessions root", () => {
+		const project = path.join(
+			path.dirname(getAgentDir()),
+			"profiles",
+			"grok",
+			"agent",
+			"sessions",
+			"--work--pi",
+		);
+		const session = path.join(project, "1700000000000_abc");
+		expect(classifyAgentType(path.join(project, "1700000000000_abc.jsonl"))).toBe("main");
+		expect(classifyAgentType(path.join(session, "AuthLoader.jsonl"))).toBe("subagent");
 	});
 });
 

--- a/packages/stats/test/profile-sessions-sync.test.ts
+++ b/packages/stats/test/profile-sessions-sync.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { syncAllSessions } from "@oh-my-pi/omp-stats/aggregator";
+import { getOverallStats } from "@oh-my-pi/omp-stats/db";
+import { getAgentDir, getSessionsDir, getStatsDbPath, setProfile } from "@oh-my-pi/pi-utils";
+import { installStatsTestIsolation } from "./helpers/temp-agent";
+
+installStatsTestIsolation("@pi-stats-profile-sessions-");
+
+async function writeAssistantSession(sessionDir: string, entryId: string): Promise<void> {
+	await fs.mkdir(sessionDir, { recursive: true });
+	const timestamp = new Date().toISOString();
+	const sessionFile = path.join(sessionDir, `${entryId}.jsonl`);
+	const assistant = {
+		type: "message",
+		id: entryId,
+		parentId: null,
+		timestamp,
+		message: {
+			role: "assistant",
+			content: [{ type: "text", text: "ok" }],
+			api: "openai-responses",
+			provider: "openai",
+			model: "gpt-5.4",
+			usage: {
+				input: 1,
+				output: 2,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 3,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "stop",
+			timestamp: Date.now(),
+			duration: 10,
+			ttft: 5,
+		},
+	};
+	await Bun.write(sessionFile, `${JSON.stringify(assistant)}\n`);
+}
+
+describe("stats sync across profile session trees", () => {
+	it("ingests default-dir and profiles/<name>/agent sessions into one DB", async () => {
+		await writeAssistantSession(path.join(getSessionsDir(), "--tmp--default-tree"), "assistant-default");
+		await writeAssistantSession(
+			path.join(path.dirname(getAgentDir()), "profiles", "grok", "agent", "sessions", "--tmp--grok-tree"),
+			"assistant-grok",
+		);
+
+		const synced = await syncAllSessions({ workers: 1 });
+		const overall = getOverallStats();
+
+		expect(synced.files).toBe(2);
+		expect(overall.totalRequests).toBe(2);
+	});
+
+	it("keeps stats.db at the app config root under a named profile and still sees sibling trees", async () => {
+		const appStatsDb = getStatsDbPath();
+		await writeAssistantSession(path.join(getSessionsDir(), "--tmp--default-tree"), "assistant-default");
+		await writeAssistantSession(
+			path.join(path.dirname(getAgentDir()), "profiles", "work", "agent", "sessions", "--tmp--work-tree"),
+			"assistant-work",
+		);
+
+		setProfile("work");
+		expect(getStatsDbPath()).toBe(appStatsDb);
+
+		const synced = await syncAllSessions({ workers: 1 });
+		expect(synced.files).toBe(2);
+		expect(getOverallStats().totalRequests).toBe(2);
+	});
+});

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `listAgentDirs()` to enumerate the default agent directory plus every `profiles/<name>/agent` directory.
+
+### Fixed
+
+- `getStatsDbPath()` stays at the app config root under a named profile so `omp stats` shares one database across `~/.omp/agent` and `~/.omp/profiles/<name>/`.
+
 ## [18.0.11] - 2026-08-29
 
 ### Fixed

--- a/packages/utils/src/dirs.ts
+++ b/packages/utils/src/dirs.ts
@@ -795,9 +795,12 @@ export function getNativesDir(): string {
 	return dirs.rootSubdir("natives", "cache");
 }
 
-/** Get the stats database path (~/.omp/stats.db). */
+/** Get the stats database path (~/.omp/stats.db). Shared across named profiles. */
 export function getStatsDbPath(): string {
-	return dirs.rootSubdir("stats.db", "data");
+	if (!activeProfile) return dirs.rootSubdir("stats.db", "data");
+	// Named-profile configRoot is ~/.omp/profiles/<name>. Usage history is
+	// process-wide, so `omp stats` under OMP_PROFILE still opens the app-root DB.
+	return path.join(getBaseConfigRoot(), "stats.db");
 }
 
 /** Get the autoresearch state directory (~/.omp/autoresearch). */
@@ -871,6 +874,44 @@ export function getComposerCacheDir(agentDir?: string): string {
 /** Get the sessions directory (~/.omp/agent/sessions). */
 export function getSessionsDir(agentDir?: string): string {
 	return dirs.agentSubdir(agentDir, "sessions", "data");
+}
+
+/**
+ * Agent dirs whose session logs / minimizer JSONL belong in the shared stats
+ * view: `<config-root>/agent` plus every `profiles/<name>/agent`. A custom
+ * `PI_CODING_AGENT_DIR` whose basename is not `agent` stays a single dir.
+ */
+export async function listAgentDirs(): Promise<string[]> {
+	const agentDir = getAgentDir();
+	if (path.basename(agentDir) !== "agent") return [agentDir];
+
+	const agentParent = path.dirname(agentDir);
+	const configRoot =
+		path.basename(path.dirname(agentParent)) === "profiles"
+			? path.dirname(path.dirname(agentParent))
+			: agentParent;
+
+	const agentDirs = [path.join(configRoot, "agent")];
+	const profilesDir = path.join(configRoot, "profiles");
+	try {
+		const entries = await fs.promises.readdir(profilesDir);
+		for (const entry of entries) {
+			if (!entry.startsWith(".")) agentDirs.push(path.join(profilesDir, entry, "agent"));
+		}
+	} catch (err) {
+		if (!isEnoent(err)) {
+			throw err;
+		}
+	}
+
+	const seen = new Set<string>();
+	const out: string[] = [];
+	for (const dir of agentDirs) {
+		if (seen.has(dir)) continue;
+		seen.add(dir);
+		out.push(dir);
+	}
+	return out;
 }
 
 /** Get the content-addressed blob store directory (~/.omp/agent/blobs). */

--- a/packages/utils/test/profiles.test.ts
+++ b/packages/utils/test/profiles.test.ts
@@ -120,7 +120,8 @@ describe("profile directories", () => {
 	it("moves agent and root data under the named profile root", () => {
 		setProfile("work");
 
-		const root = path.join(os.homedir(), configDir, "profiles", "work");
+		const appRoot = path.join(os.homedir(), configDir);
+		const root = path.join(appRoot, "profiles", "work");
 		const agent = path.join(root, "agent");
 		expect(getActiveProfile()).toBe("work");
 		expect(getConfigRootDir()).toBe(root);
@@ -128,7 +129,7 @@ describe("profile directories", () => {
 		expect(getAgentDir()).toBe(agent);
 		expect(getAgentDbPath()).toBe(path.join(agent, "agent.db"));
 		expect(getSessionsDir()).toBe(path.join(agent, "sessions"));
-		expect(getStatsDbPath()).toBe(path.join(root, "stats.db"));
+		expect(getStatsDbPath()).toBe(path.join(appRoot, "stats.db"));
 	});
 
 	it("treats the default profile as regular mode", () => {


### PR DESCRIPTION
## Summary

`omp stats` listed session files only from `getSessionsDir()` for the active agent. After moving off `--pm-profile` to `~/.omp/profiles/<name>/agent/`, new JSONL never entered `~/.omp/stats.db`. 24h/7d went empty while 30d/all still showed default-dir history.

## Changes

- Walk `<config-root>/agent/sessions` plus every `profiles/<name>/agent/sessions`
- Classify and extract folders relative to the containing sessions root
- Keep `getStatsDbPath()` at the app config root under a named profile
- Add `listAgentDirs()` for that shared walk

## Test plan

- [x] `bun test packages/stats/test/profile-sessions-sync.test.ts packages/stats/test/agent-type.test.ts packages/utils/test/profiles.test.ts`
- [ ] `omp stats` after profile-mode use shows 24h/7d traffic from `~/.omp/profiles/<name>/agent/sessions`