### PR TITLE
fix(hub): scope messaging to agent registries

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,10 @@
 - Devin model selectors now accept the native CLI's short aliases (`devin/opus`, `devin/swe`), dotted upstream spellings (`devin/gemini-3.7-flash`), and raw effort-route wire uids for dynamically collapsed families ([#8590](https://github.com/can1357/oh-my-pi/pull/8590) by [@will-bogusz](https://github.com/will-bogusz)).
 - Added provider-supplied model metadata to the `/models` detail line: `new`, `beta`, and `recommended` badges beside the model name, and the upstream description after the context, cost, and perf facts ([#8590](https://github.com/can1357/oh-my-pi/pull/8590) by [@will-bogusz](https://github.com/will-bogusz)).
 
+### Fixed
+
+- Fixed `hub` messaging, mailboxes, relays, and parked-agent revival for concurrent SDK sessions using private agent registries.
+
 ## [18.0.11] - 2026-08-29
 
 ### Added

--- a/packages/coding-agent/src/irc/bus.ts
+++ b/packages/coding-agent/src/irc/bus.ts
@@ -1,9 +1,9 @@
 /**
- * IrcBus - Process-global mailbox bus for agent-to-agent messaging.
+ * IrcBus - Registry-scoped mailbox bus for agent-to-agent messaging.
  *
  * Replaces the old auto-reply model: a `send` never blocks on the recipient
- * generating anything. Delivery resolves the recipient via the global
- * AgentRegistry — parked agents are revived through the
+ * generating anything. Delivery resolves the recipient via the bus's
+ * AgentRegistry — parked agents are revived through the matching
  * AgentLifecycleManager, idle agents are woken with a real turn, and busy
  * agents receive the message as a non-interrupting aside at the next step
  * boundary (see AgentSession.deliverIrcMessage). Replies are real turns by
@@ -21,6 +21,14 @@ import { AgentRegistry, MAIN_AGENT_ID } from "../registry/agent-registry";
 import type { AgentSession } from "../session/agent-session";
 import type { AgentSessionEvent } from "../session/agent-session-events";
 import type { CustomMessage } from "../session/messages";
+
+const ircBusKey = Symbol("AgentRegistry.ircBus");
+
+declare module "../registry/agent-registry" {
+	interface AgentRegistry {
+		[ircBusKey]?: IrcBus;
+	}
+}
 
 export interface IrcMessage {
 	id: string;
@@ -63,19 +71,26 @@ export class IrcAwaitTargetStopped extends Error {
 /** Mailbox cap per agent; oldest messages are dropped beyond it. */
 const MAILBOX_CAP = 100;
 
+/** Routes peer messages and owns mailboxes within one agent registry. */
 export class IrcBus {
-	static #global: IrcBus | undefined;
-
-	static global(): IrcBus {
-		if (!IrcBus.#global) {
-			IrcBus.#global = new IrcBus();
+	/** Returns the bus whose routing and mailboxes belong to `registry`. */
+	static forRegistry(registry: AgentRegistry): IrcBus {
+		let bus = registry[ircBusKey];
+		if (!bus) {
+			bus = new IrcBus(registry);
+			registry[ircBusKey] = bus;
 		}
-		return IrcBus.#global;
+		return bus;
 	}
 
-	/** Reset the global bus. Test-only. */
+	/** Returns the bus for the process-global registry. */
+	static global(): IrcBus {
+		return IrcBus.forRegistry(AgentRegistry.global());
+	}
+
+	/** Reset the global registry's bus. Test-only. */
 	static resetGlobalForTests(): void {
-		IrcBus.#global = undefined;
+		delete AgentRegistry.global()[ircBusKey];
 	}
 
 	readonly #registry: AgentRegistry;
@@ -85,9 +100,9 @@ export class IrcBus {
 
 	constructor(registry: AgentRegistry = AgentRegistry.global(), lifecycle?: AgentLifecycleManager) {
 		this.#registry = registry;
-		// Lazy: the lifecycle global self-constructs against the global registry,
-		// so only touch it when a parked recipient actually needs reviving.
-		this.#lifecycle = () => lifecycle ?? AgentLifecycleManager.global();
+		// Lazy: constructing a bus must not start lifecycle timers or registry
+		// subscriptions until a parked recipient actually needs reviving.
+		this.#lifecycle = () => lifecycle ?? AgentLifecycleManager.forRegistry(registry);
 	}
 
 	/**

--- a/packages/coding-agent/src/registry/agent-lifecycle.ts
+++ b/packages/coding-agent/src/registry/agent-lifecycle.ts
@@ -33,6 +33,14 @@ import {
 	type RegistryEvent,
 } from "./agent-registry";
 
+const agentLifecycleKey = Symbol("AgentRegistry.agentLifecycle");
+
+declare module "./agent-registry" {
+	interface AgentRegistry {
+		[agentLifecycleKey]?: AgentLifecycleManager;
+	}
+}
+
 export type AgentReviver = (expected: AgentRef) => Promise<AgentSession>;
 
 const AGENT_RELEASE_GRACE_MS = 5000;
@@ -89,14 +97,27 @@ interface RevivingAgent {
 export class AgentLifecycleManager {
 	static #global: AgentLifecycleManager | undefined;
 
+	/** Returns the lifecycle manager that owns `registry`. */
+	static forRegistry(registry: AgentRegistry): AgentLifecycleManager {
+		if (registry === AgentRegistry.global()) return AgentLifecycleManager.global();
+		let manager = registry[agentLifecycleKey];
+		if (!manager) {
+			manager = new AgentLifecycleManager(registry);
+			registry[agentLifecycleKey] = manager;
+		}
+		return manager;
+	}
+
 	static global(): AgentLifecycleManager {
-		if (!AgentLifecycleManager.#global) {
-			AgentLifecycleManager.#global = new AgentLifecycleManager();
+		const registry = AgentRegistry.global();
+		if (!AgentLifecycleManager.#global?.manages(registry)) {
+			AgentLifecycleManager.#global = registry[agentLifecycleKey] ?? new AgentLifecycleManager(registry);
+			registry[agentLifecycleKey] = AgentLifecycleManager.#global;
 		}
 		return AgentLifecycleManager.#global;
 	}
 
-	/** Reset the global manager. Test-only. */
+	/** Reset the global lifecycle manager. Test-only. */
 	static resetGlobalForTests(): void {
 		const current = AgentLifecycleManager.#global;
 		if (current) {
@@ -109,6 +130,7 @@ export class AgentLifecycleManager {
 			current.#revivals.clear();
 			current.#parks.clear();
 			current.#persistedReviverFactory = undefined;
+			delete current.#registry[agentLifecycleKey];
 		}
 		AgentLifecycleManager.#global = undefined;
 	}
@@ -455,7 +477,7 @@ export class AgentLifecycleManager {
 		return true;
 	}
 
-	/** Teardown everything; disposing the global manager makes its next owner a fresh instance. */
+	/** Tears down this registry's lifecycle and releases its memoized manager. */
 	async dispose(deadlineAt: number = Date.now() + AGENT_RELEASE_GRACE_MS): Promise<void> {
 		this.#unsubscribe?.();
 		this.#disposed = true;
@@ -480,6 +502,7 @@ export class AgentLifecycleManager {
 		this.#revivals.clear();
 		this.#parks.clear();
 		this.#persistedReviverFactory = undefined;
+		if (this.#registry[agentLifecycleKey] === this) delete this.#registry[agentLifecycleKey];
 		if (AgentLifecycleManager.#global === this) AgentLifecycleManager.#global = undefined;
 	}
 

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1727,7 +1727,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 		const ref = registeredAgentRef;
 		if (!ref || agentRegistry.get(resolvedAgentId) !== ref) return;
 		if (ref.status === "parked" || (ref.status === "aborted" && !ref.session)) return;
-		if (AgentLifecycleManager.global().isParking(resolvedAgentId, ref)) return;
+		if (AgentLifecycleManager.forRegistry(agentRegistry).isParking(resolvedAgentId, ref)) return;
 		agentRegistry.unregister(resolvedAgentId, ref);
 	};
 	const evalKernelOwnerId = `agent-session:${Snowflake.next()}`;
@@ -1808,11 +1808,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			getEvalBridgeToolNames: () => session?.getEvalBridgeToolNames() ?? [],
 			getCodeModeDirectToolNames: () => session?.getCodeModeDirectToolNames(),
 			agentRegistry,
-			// The global lifecycle releases through AgentRegistry.global(); wiring it
-			// onto a caller-supplied registry would report a cancel while releasing an
-			// unrelated global ref. With no lifecycle, hub cancel falls back to
-			// dispose + unregister on the session's own registry.
-			agentLifecycle: options.agentRegistry ? undefined : () => AgentLifecycleManager.global(),
+			agentLifecycle: () => AgentLifecycleManager.forRegistry(agentRegistry),
 			getSessionSpawns: () => options.spawns ?? "*",
 			getModelString: () => (hasExplicitModel && model ? formatModelString(model) : undefined),
 			getActiveModelString,
@@ -3249,7 +3245,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			// The reclaim is gated by the lifecycle owner and only touches the
 			// registry it manages; the corpse's transcript stays at history://.
 			const stale = agentRegistry.get(resolvedAgentId);
-			const lifecycle = AgentLifecycleManager.global();
+			const lifecycle = AgentLifecycleManager.forRegistry(agentRegistry);
 			if (stale && lifecycle.manages(agentRegistry) && (await lifecycle.reclaimDeadCorpse(resolvedAgentId, stale))) {
 				registeredAgentRef = agentRegistry.registerIfAvailable(registrationInput, null);
 			}
@@ -3631,6 +3627,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			serviceTierByFamily: initialServiceTierByFamily,
 			sessionManager,
 			settings,
+			agentRegistry,
 			additionalExtensionPaths: options.additionalExtensionPaths,
 			extensionRoots: buildSessionExtensionRoots,
 			disableExtensionDiscovery: options.disableExtensionDiscovery,
@@ -3893,10 +3890,9 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 					// AgentSession.dispose() would otherwise set its guards.
 					session.beginDispose();
 					if (agentKind === "main") {
-						// Top-level teardown owns the global agent lifecycle: park timers,
-						// adopted subagent sessions, revivers. Tear it down while shared
-						// resources (kernels, MCP, LSP) are still live. Subagent disposal
-						// must NOT touch the global lifecycle.
+						// Top-level teardown owns this session registry's lifecycle:
+						// park timers, adopted subagent sessions, and revivers.
+						// Subagent disposal must not tear down the shared owner.
 						const vibeRegistry = VibeSessionRegistry.global();
 						const vibeParentSession = {
 							getAgentId: () => resolvedAgentId,
@@ -3908,7 +3904,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 							getActiveModelString,
 						};
 						await vibeRegistry.suspendScope(vibeRegistry.ownerScope(vibeParentSession), scopedAsyncJobManager);
-						await AgentLifecycleManager.global().dispose();
+						await AgentLifecycleManager.forRegistry(agentRegistry).dispose();
 					}
 					await originalDispose();
 				} finally {

--- a/packages/coding-agent/src/session/agent-session-types.ts
+++ b/packages/coding-agent/src/session/agent-session-types.ts
@@ -33,6 +33,7 @@ import type { ExtensionRunner } from "../extensibility/extensions";
 import type { ContextUsage } from "../extensibility/extensions/types";
 import type { Skill, SkillWarning } from "../extensibility/skills";
 import type { FileSlashCommand } from "../extensibility/slash-commands";
+import type { AgentRegistry } from "../registry/agent-registry";
 import type { SecretObfuscator } from "../secrets/obfuscator";
 import type { ConfiguredThinkingLevel } from "../thinking";
 import type { XdevState } from "../tools/xdev";
@@ -126,6 +127,8 @@ export interface AgentSessionConfig {
 	codeModeState?: { namespacesInfo?: unknown };
 	sessionManager: SessionManager;
 	settings: Settings;
+	/** Registry that scopes this session's peer messaging. */
+	agentRegistry?: AgentRegistry;
 	/**
 	 * Live extension-root policy inherited from the owning session. Subagents use
 	 * this provider so explicit roots, discovery mode, configured roots, and

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1090,6 +1090,7 @@ export class AgentSession {
 			agent: this.agent,
 			sessionManager: this.sessionManager,
 			settings: this.settings,
+			agentRegistry: config.agentRegistry,
 			isDisposed: () => this.#isDisposed,
 			isStreaming: () => this.isStreaming,
 			planModeEnabled: () => this.#planModeState?.enabled === true,

--- a/packages/coding-agent/src/session/irc-bridge.ts
+++ b/packages/coding-agent/src/session/irc-bridge.ts
@@ -15,6 +15,8 @@ export interface IrcBridgeHost {
 	agent: Agent;
 	sessionManager: SessionManager;
 	settings: Settings;
+	/** Registry that scopes peer lookup and replies; `undefined` uses the process registry. */
+	agentRegistry: AgentRegistry | undefined;
 	isDisposed(): boolean;
 	isStreaming(): boolean;
 	planModeEnabled(): boolean;
@@ -26,12 +28,14 @@ export interface IrcBridgeHost {
 /** Owns incoming IRC queues, injection, and side-channel auto-replies. */
 export class IrcBridge {
 	readonly #host: IrcBridgeHost;
+	readonly #registry: AgentRegistry;
 	#interrupts: CustomMessage[] = [];
 	#asides: CustomMessage[] = [];
 	readonly #autoReplies = new Set<Promise<void>>();
 
 	constructor(host: IrcBridgeHost) {
 		this.#host = host;
+		this.#registry = host.agentRegistry ?? AgentRegistry.global();
 	}
 
 	/** Whether an incoming peer message can interrupt a wait. */
@@ -139,7 +143,7 @@ export class IrcBridge {
 		};
 		void this.#host.emitSessionEvent({ type: "irc_message", message: record });
 		if (streaming) {
-			const recipientParentId = AgentRegistry.global().get(msg.to)?.parentId;
+			const recipientParentId = this.#registry.get(msg.to)?.parentId;
 			if (recipientParentId === msg.from) {
 				this.#host.agent.steer({
 					role: "user",
@@ -211,7 +215,12 @@ export class IrcBridge {
 			};
 			void this.#host.emitSessionEvent({ type: "irc_message", message: record });
 			this.#asides.push(record);
-			const receipt = await IrcBus.global().send({ from: msg.to, to: msg.from, body, replyTo: msg.id });
+			const receipt = await IrcBus.forRegistry(this.#registry).send({
+				from: msg.to,
+				to: msg.from,
+				body,
+				replyTo: msg.id,
+			});
 			if (receipt.outcome === "failed") {
 				logger.warn("IRC auto-reply delivery failed", { to: msg.from, error: receipt.error });
 			}

--- a/packages/coding-agent/src/tools/hub/index.ts
+++ b/packages/coding-agent/src/tools/hub/index.ts
@@ -407,7 +407,7 @@ export class HubTool implements AgentTool<typeof hubSchema, HubDetails> {
 			// there, so without this take the liveness gate would answer "nothing
 			// to wait for" while `hub inbox` hands back the very message being
 			// waited on. Single atomic take: the rest of the backlog stays queued.
-			const queued = IrcBus.global().take(messaging.senderId, from);
+			const queued = IrcBus.forRegistry(messaging.registry).take(messaging.senderId, from);
 			if (queued) return messageResult(messaging.senderId, queued);
 			if (!from) {
 				// A bare wait can only be satisfied by a running peer eventually
@@ -438,7 +438,7 @@ export class HubTool implements AgentTool<typeof hubSchema, HubDetails> {
 		let removeBusAbortListener: (() => void) | undefined;
 		const busLeg =
 			messaging && busAbort
-				? IrcBus.global()
+				? IrcBus.forRegistry(messaging.registry)
 						.wait(messaging.senderId, { from }, 0, busAbort.signal)
 						.then(
 							message => ({ message, error: null as Error | null }),

--- a/packages/coding-agent/src/tools/hub/messaging.ts
+++ b/packages/coding-agent/src/tools/hub/messaging.ts
@@ -182,7 +182,7 @@ export async function executeList(
 		truncated,
 	};
 
-	const bus = IrcBus.global();
+	const bus = IrcBus.forRegistry(registry);
 	const peers = shownRefs.map(ref => ({
 		id: ref.id,
 		displayName: ref.displayName,
@@ -262,7 +262,7 @@ export async function executeSend(
 		await ensurePersistedRoster(registry, sessionFileHint);
 	}
 
-	const bus = IrcBus.global();
+	const bus = IrcBus.forRegistry(registry);
 	let waited: IrcMessage | null | undefined;
 	const timeoutMs = params.await ? resolveMessageTimeoutMs(settings, params.timeoutMs) : undefined;
 	const awaitAbort = params.await ? new AbortController() : undefined;
@@ -403,7 +403,7 @@ export async function executeMessageWait(
 	const from = params.from?.trim() || undefined;
 	const timeoutMs = resolveMessageTimeoutMs(settings, params.timeoutMs);
 	try {
-		const waited = await IrcBus.global().wait(senderId, { from }, timeoutMs, signal, {
+		const waited = await IrcBus.forRegistry(registry).wait(senderId, { from }, timeoutMs, signal, {
 			liveness: { registry, senderId },
 		});
 		if (!waited) {
@@ -429,7 +429,7 @@ export function executeInbox(
 	senderId: string,
 	peek?: boolean,
 ): AgentToolResult<CoordinationDetails> {
-	const busMessages = IrcBus.global().inbox(senderId, { peek });
+	const busMessages = IrcBus.forRegistry(registry).inbox(senderId, { peek });
 	const session = registry.get(senderId)?.session;
 	const pendingMessages =
 		typeof session?.drainPendingIrcInboxMessages === "function" ? session.drainPendingIrcInboxMessages(senderId) : [];

--- a/packages/coding-agent/test/tools/irc.test.ts
+++ b/packages/coding-agent/test/tools/irc.test.ts
@@ -96,7 +96,10 @@ function makeToolSession(registry: AgentRegistry, agentId: string): ToolSession 
 	};
 }
 
-function createRealSession(overrides: Partial<Record<SettingPath, unknown>> = {}): {
+function createRealSession(
+	overrides: Partial<Record<SettingPath, unknown>> = {},
+	agentRegistry?: AgentRegistry,
+): {
 	session: AgentSession;
 	sessionManager: SessionManager;
 } {
@@ -111,6 +114,7 @@ function createRealSession(overrides: Partial<Record<SettingPath, unknown>> = {}
 		}),
 		sessionManager,
 		settings: Settings.isolated({ "compaction.enabled": false, ...overrides }),
+		...(agentRegistry ? { agentRegistry } : {}),
 		modelRegistry: {} as never,
 	});
 	return { session, sessionManager };
@@ -210,6 +214,42 @@ describe("IRC", () => {
 			expect(main.relayed[0]?.details).toEqual({ from: "0-A", to: "0-B", body: "sibling note" });
 		});
 
+		it("scopes delivery, relays, and mailboxes to each registry", async () => {
+			const firstRegistry = new AgentRegistry();
+			const secondRegistry = new AgentRegistry();
+			const firstMain = makeFakeSession();
+			const firstA = makeFakeSession();
+			const firstB = makeFakeSession();
+			const secondMain = makeFakeSession();
+			const secondA = makeFakeSession();
+			const secondB = makeFakeSession();
+			firstRegistry.register({ id: "Main", displayName: "main", kind: "main", session: firstMain.session });
+			firstRegistry.register({ id: "0-A", displayName: "task", kind: "sub", session: firstA.session });
+			firstRegistry.register({ id: "0-B", displayName: "task", kind: "sub", session: firstB.session });
+			secondRegistry.register({ id: "Main", displayName: "main", kind: "main", session: secondMain.session });
+			secondRegistry.register({ id: "0-A", displayName: "task", kind: "sub", session: secondA.session });
+			secondRegistry.register({ id: "0-B", displayName: "task", kind: "sub", session: secondB.session });
+
+			const firstBus = IrcBus.forRegistry(firstRegistry);
+			await firstBus.send({ from: "0-A", to: "0-B", body: "first-session chatter" });
+
+			expect(firstB.delivered.map(message => message.body)).toEqual(["first-session chatter"]);
+			expect(secondB.delivered).toEqual([]);
+			expect(firstMain.relayed.map(record => record.details)).toEqual([
+				{ from: "0-A", to: "0-B", body: "first-session chatter" },
+			]);
+			expect(secondMain.relayed).toEqual([]);
+
+			firstB.setError(new Error("temporarily unavailable"));
+			await firstBus.send({ from: "0-A", to: "0-B", body: "first-session mailbox" });
+			expect(
+				IrcBus.forRegistry(firstRegistry)
+					.inbox("0-B")
+					.map(message => message.body),
+			).toEqual(["first-session mailbox"]);
+			expect(IrcBus.forRegistry(secondRegistry).inbox("0-B")).toEqual([]);
+		});
+
 		it("send to an unknown or aborted agent fails", async () => {
 			const unknown = await bus.send({ from: "0-Main", to: "0-Ghost", body: "hello?" });
 			expect(unknown.outcome).toBe("failed");
@@ -284,6 +324,30 @@ describe("IRC", () => {
 			expect(receipt).toEqual({ to: "0-Sub", outcome: "injected" });
 			expect(live.delivered.map(msg => msg.body)).toEqual(["hi"]);
 			expect(globalStub.delivered).toEqual([]);
+		});
+
+		it("revives a parked recipient through its registry lifecycle", async () => {
+			const scopedRegistry = new AgentRegistry();
+			const scopedBus = IrcBus.forRegistry(scopedRegistry);
+			const lifecycle = AgentLifecycleManager.forRegistry(scopedRegistry);
+			const sub = makeFakeSession();
+			scopedRegistry.register({
+				id: "0-Parked",
+				displayName: "task",
+				kind: "sub",
+				session: null,
+				status: "parked",
+			});
+			lifecycle.adopt("0-Parked", {
+				idleTtlMs: 0,
+				revive: async () => sub.session,
+			});
+
+			const receipt = await scopedBus.send({ from: "Main", to: "0-Parked", body: "wake up" });
+
+			expect(receipt.outcome).toBe("revived");
+			expect(sub.delivered.map(message => message.body)).toEqual(["wake up"]);
+			expect(scopedRegistry.get("0-Parked")?.status).toBe("idle");
 		});
 
 		it("send during pre-detach park keeps the live session and does not revive", async () => {
@@ -680,6 +744,47 @@ describe("IRC", () => {
 			expect(tool.interruptible({ op: "logs" })).toBe(false);
 			expect(tool.interruptible({ op: "start" })).toBe(false);
 			expect(tool.interruptible({ op: "send", await: true })).toBe(false);
+		});
+
+		it("uses the session registry for send, wait, and inbox", async () => {
+			const scopedRegistry = new AgentRegistry();
+			const scopedBus = IrcBus.forRegistry(scopedRegistry);
+			const main = makeFakeSession();
+			const sub = makeFakeSession();
+			scopedRegistry.register({ id: "Main", displayName: "main", kind: "main", session: main.session });
+			scopedRegistry.register({
+				id: "0-Sub",
+				displayName: "task",
+				kind: "sub",
+				parentId: "Main",
+				session: sub.session,
+			});
+			sub.onDeliver(message => {
+				void scopedBus.send({ from: "0-Sub", to: message.from, body: "scoped reply", replyTo: message.id });
+			});
+			const tool = new HubTool(makeToolSession(scopedRegistry, "Main"));
+
+			const sent = await tool.execute("call-send", {
+				op: "send",
+				to: "0-Sub",
+				message: "scoped question",
+				await: true,
+			});
+			const sentDetails = sent.details as CoordinationDetails | undefined;
+			expect(sent.isError).toBeFalsy();
+			expect(sentDetails?.waited?.body).toBe("scoped reply");
+
+			main.setError(new Error("temporarily unavailable"));
+			await scopedBus.send({ from: "0-Sub", to: "Main", body: "buffered scoped note" });
+			const inbox = await tool.execute("call-inbox", { op: "inbox" });
+			const inboxDetails = inbox.details as CoordinationDetails | undefined;
+			expect(inboxDetails?.inbox?.map(message => message.body)).toEqual(["buffered scoped note"]);
+
+			const waiting = tool.execute("call-wait", { op: "wait", from: "0-Sub", timeoutMs: 1000 });
+			await scopedBus.send({ from: "0-Sub", to: "Main", body: "live scoped note" });
+			const waited = await waiting;
+			const waitedDetails = waited.details as CoordinationDetails | undefined;
+			expect(waitedDetails?.waited?.body).toBe("live scoped note");
 		});
 
 		it("op=list defaults to live peers and reports parked counts without parked names", async () => {
@@ -1273,12 +1378,14 @@ describe("IRC", () => {
 			expect(await session.agent.hasIrcInterrupts?.()).toBe(true);
 		});
 
-		it("queues parent IRC as steering while a subagent turn is streaming", async () => {
-			const { session } = createRealSession();
+		it("queues parent IRC as steering from the session registry while a subagent turn is streaming", async () => {
+			const scopedRegistry = new AgentRegistry();
+			const { session } = createRealSession({}, scopedRegistry);
 			sessions.push(session);
 			const promptSpy = vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined);
 			Object.defineProperty(session, "isStreaming", { value: true, configurable: true });
-			registry.register({ id: "0-Child", displayName: "task", kind: "sub", parentId: "Main", session });
+			scopedRegistry.register({ id: "0-Child", displayName: "task", kind: "sub", parentId: "Main", session });
+			registry.register({ id: "0-Child", displayName: "task", kind: "sub", parentId: "Other", session: null });
 
 			const outcome = await session.deliverIrcMessage({
 				id: "msg-parent",
@@ -1298,42 +1405,40 @@ describe("IRC", () => {
 			expect(parentSteer.content).toContain("change approach");
 		});
 
-		it("auto-replies via an ephemeral side turn when the sender awaits and async execution is disabled", async () => {
-			const { session } = createRealSession({ "async.enabled": false });
+		it("auto-replies on the session registry when the sender awaits and async execution is disabled", async () => {
+			const scopedRegistry = new AgentRegistry();
+			const scopedBus = IrcBus.forRegistry(scopedRegistry);
+			const { session } = createRealSession({ "async.enabled": false }, scopedRegistry);
 			sessions.push(session);
-			registry.register({ id: "Main", displayName: "main", kind: "main", session });
+			scopedRegistry.register({ id: "Main", displayName: "main", kind: "main", session });
 			const sub = makeFakeSession();
-			registry.register({ id: "0-Sub", displayName: "task", kind: "sub", session: sub.session });
+			scopedRegistry.register({ id: "0-Sub", displayName: "task", kind: "sub", session: sub.session });
 			Object.defineProperty(session, "isStreaming", { value: true, configurable: true });
 			const ephemeralSpy = vi
 				.spyOn(session, "runEphemeralTurn")
 				.mockResolvedValue({ replyText: "auto answer", assistantMessage: {} as never });
-			const autoReplyEvent = new Promise<CustomMessage>(resolve => {
-				session.subscribe(event => {
-					if (event.type === "irc_message" && event.message.customType === "irc:autoreply") {
-						resolve(event.message);
-					}
-				});
+			const { promise: autoReplyEvent, resolve: resolveAutoReplyEvent } = Promise.withResolvers<CustomMessage>();
+			session.subscribe(event => {
+				if (event.type === "irc_message" && event.message.customType === "irc:autoreply") {
+					resolveAutoReplyEvent(event.message);
+				}
 			});
 
 			// The sender parks a waiter (the `await: true` path), then sends with
-			// the expectsReply hint — exactly what the irc tool does.
-			const waiting = bus.wait("0-Sub", { from: "Main" }, 1000);
-			const receipt = await bus.send(
+			// the expectsReply hint — exactly what the hub tool does.
+			const waiting = scopedBus.wait("0-Sub", { from: "Main" }, 1000);
+			const receipt = await scopedBus.send(
 				{ from: "0-Sub", to: "Main", body: "which PR did you mean?" },
 				{ expectsReply: true },
 			);
 			expect(receipt).toEqual({ to: "Main", outcome: "injected" });
 
-			// The side-channel reply resolves the sender's waiter as a real bus
-			// message threaded to the original send.
 			const reply = await waiting;
 			expect(reply?.from).toBe("Main");
 			expect(reply?.body).toBe("auto answer");
 			expect(reply?.replyTo).toBeTruthy();
 			expect(ephemeralSpy.mock.calls[0]?.[0]?.promptText).toContain("which PR did you mean?");
 
-			// The recipient records what was said on its behalf.
 			const record = await autoReplyEvent;
 			expect(record.details).toMatchObject({ to: "0-Sub", body: "auto answer" });
 		});


### PR DESCRIPTION
## Repro
Create two SDK sessions with separate `AgentRegistry` instances, register `Main` and a peer in one private registry, then invoke that session’s `hub send`; before this change the tool routes through `IrcBus.global()` and returns an unknown-agent failure. The equivalent direct repro is `bun repro-private-registry.ts` using the script from #10229; the regression suite is exercised with `bun test packages/coding-agent/test/tools/irc.test.ts`.

## Cause
`packages/coding-agent/src/tools/hub/messaging.ts`, `tools/hub/index.ts`, and `session/irc-bridge.ts` discarded the registry already held by the session and resolved delivery, mailboxes, relays, parent relationships, and auto-replies through process-global `IrcBus`, `AgentRegistry`, and `AgentLifecycleManager` instances.

## Fix
- Memoize `IrcBus` and `AgentLifecycleManager` on each `AgentRegistry`.
- Route hub operations and IRC bridge replies through the owning session registry.
- Wire the SDK session and teardown lifecycle to its resolved registry.
- Cover same-id registry isolation, relay/mailbox separation, scoped revival, hub operations, parent steering, and auto-replies.
- Document the user-visible fix in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/tools/irc.test.ts` passed: 57 tests, 191 assertions. `bun check` passed for all packages. The pre-publish gate also ran `bun run fix` and `bun check` successfully. Fixes #10229