### PR TITLE
fix(coding-agent): cache status-line repo discovery per cwd

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,10 @@
 - Devin model selectors now accept the native CLI's short aliases (`devin/opus`, `devin/swe`), dotted upstream spellings (`devin/gemini-3.7-flash`), and raw effort-route wire uids for dynamically collapsed families ([#8590](https://github.com/can1357/oh-my-pi/pull/8590) by [@will-bogusz](https://github.com/will-bogusz)).
 - Added provider-supplied model metadata to the `/models` detail line: `new`, `beta`, and `recommended` badges beside the model name, and the upstream description after the context, cost, and perf facts ([#8590](https://github.com/can1357/oh-my-pi/pull/8590) by [@will-bogusz](https://github.com/will-bogusz)).
 
+### Fixed
+
+- Reduced idle CPU while waiting on a background job: the status line no longer re-runs native git repository discovery on every rendered frame ([#10231](https://github.com/can1357/oh-my-pi/issues/10231)).
+
 ## [18.0.11] - 2026-08-29
 
 ### Added

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 ### Fixed
 
-- Reduced idle CPU while waiting on a background job: the status line no longer re-runs native git repository discovery on every rendered frame ([#10231](https://github.com/can1357/oh-my-pi/issues/10231)).
+- Reduced idle CPU while a background job repaints the status line: the `path` segment no longer runs per-frame `realpathSync` scratch-root/display-root resolution, and the status line no longer re-runs native git repository discovery, on every rendered frame ([#10231](https://github.com/can1357/oh-my-pi/issues/10231)).
 
 ## [18.0.11] - 2026-08-29
 

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -5,6 +5,7 @@ import {
 	getAntigravityCounterKeyForModel,
 	scopeAntigravityLimitsForModel,
 } from "@oh-my-pi/pi-ai/usage/google-antigravity";
+import type { VcsRepo } from "@oh-my-pi/pi-natives";
 import * as vcs from "@oh-my-pi/pi-natives/vcs";
 import {
 	type Component,
@@ -438,6 +439,14 @@ export class StatusLineComponent implements Component {
 	#collabStatus: CollabStatus | null = null;
 	#focusedAgentId: string | undefined;
 	#activeRepoCache: ActiveRepoCache | undefined;
+	// Repository-handle memo. `vcs.repo()` is a native filesystem walk; the three
+	// git-backed segments (branch, status, PR) each rediscover the same cwd on
+	// every rendered frame, so the working-spinner repaint loop re-walked the FS
+	// dozens of times per second (issue #10231, costly on WSL). Cache the handle
+	// per cwd; positive-only so a later `git init` is still picked up by the next
+	// discovery. Dropped by invalidateGitCaches (cwd switch / HEAD move).
+	#cachedRepoHandle: VcsRepo | null = null;
+	#cachedRepoHandleCwd: string | undefined = undefined;
 
 	// Git status caching (1s TTL)
 	#cachedGitStatus: { staged: number; unstaged: number; untracked: number } | null = null;
@@ -531,6 +540,31 @@ export class StatusLineComponent implements Component {
 		const worktree = activeRepo ? null : resolveWorktreeContext(effectiveGitCwd);
 		this.#activeRepoCache = { projectDir, activeRepo, effectiveGitCwd, worktree };
 		return this.#activeRepoCache;
+	}
+
+	/**
+	 * Memoized {@link vcs.repo} for the render path: the branch, status, and PR
+	 * segments all resolve the same effective cwd every frame, and a fresh
+	 * `vcs.repo()` walks the filesystem each call. Cache the positive handle per
+	 * cwd so a steady idle session discovers once instead of once per segment per
+	 * frame; a null result is never cached so a later `git init` is still seen.
+	 * The handle is a live repository reference (its reads re-hit disk), so
+	 * reusing it across frames returns fresh branch/status. Dropped on cwd switch
+	 * or HEAD move via {@link invalidateGitCaches}.
+	 */
+	#repoFor(gitCwd: string): VcsRepo | null {
+		if (this.#cachedRepoHandle && this.#cachedRepoHandleCwd === gitCwd) {
+			return this.#cachedRepoHandle;
+		}
+		const repository = vcs.repo(gitCwd);
+		if (repository) {
+			this.#cachedRepoHandle = repository;
+			this.#cachedRepoHandleCwd = gitCwd;
+		} else if (this.#cachedRepoHandleCwd === gitCwd) {
+			this.#cachedRepoHandle = null;
+			this.#cachedRepoHandleCwd = undefined;
+		}
+		return repository;
 	}
 
 	/**
@@ -923,6 +957,10 @@ export class StatusLineComponent implements Component {
 		this.#cachedBranch = undefined;
 		this.#cachedBranchRepoId = undefined;
 		this.#cachedBranchCwd = undefined;
+		// Drop the memoized repo handle: a cwd switch re-points the repository and
+		// a `.git` removal must be re-discovered on the next render.
+		this.#cachedRepoHandle = null;
+		this.#cachedRepoHandleCwd = undefined;
 		// Abort before releasing the in-flight slot. Releasing alone would allow
 		// repeated invalidations to fan out still-running git subprocesses.
 		this.#branchResolveActive?.controller.abort();
@@ -968,7 +1006,7 @@ export class StatusLineComponent implements Component {
 		if (!this.#gitEnabled()) return null;
 
 		const gitCwd = effectiveGitCwd ?? this.#resolveActiveRepoCache().effectiveGitCwd;
-		const repository = vcs.repo(gitCwd);
+		const repository = this.#repoFor(gitCwd);
 		if (!repository) return null;
 		const gitRepository = repository.asGit();
 		if (!gitRepository) {
@@ -1108,7 +1146,7 @@ export class StatusLineComponent implements Component {
 		if (!this.#gitEnabled()) return null;
 
 		const gitCwd = effectiveGitCwd ?? this.#resolveActiveRepoCache().effectiveGitCwd;
-		const repository = vcs.repo(gitCwd);
+		const repository = this.#repoFor(gitCwd);
 		if (!repository) return null;
 		if (repository.kind() === "jj") {
 			if (this.#jjStatusActive || Date.now() - this.#jjStatusLastFetch < JJ_REFRESH_TTL_MS) {
@@ -1176,7 +1214,7 @@ export class StatusLineComponent implements Component {
 		if (!this.#gitEnabled()) return null;
 
 		const gitCwd = effectiveGitCwd ?? this.#resolveActiveRepoCache().effectiveGitCwd;
-		if (vcs.repo(gitCwd)?.kind() !== "git") return null;
+		if (this.#repoFor(gitCwd)?.kind() !== "git") return null;
 		const branch = this.#getBranchLabel(gitCwd);
 		const currentContext = branch ? createPrCacheContext(branch, this.#cachedBranchRepoId ?? null) : null;
 

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -543,14 +543,23 @@ export class StatusLineComponent implements Component {
 	}
 
 	/**
-	 * Memoized {@link vcs.repo} for the render path: the branch, status, and PR
-	 * segments all resolve the same effective cwd every frame, and a fresh
-	 * `vcs.repo()` walks the filesystem each call. Cache the positive handle per
-	 * cwd so a steady idle session discovers once instead of once per segment per
-	 * frame; a null result is never cached so a later `git init` is still seen.
-	 * The handle is a live repository reference (its reads re-hit disk), so
-	 * reusing it across frames returns fresh branch/status. Dropped on cwd switch
-	 * or HEAD move via {@link invalidateGitCaches}.
+	 * Memoized {@link vcs.repo} discovery for the synchronous render path. The
+	 * branch, status, and PR segments each locate the same effective cwd every
+	 * frame, and a fresh `vcs.repo()` walks the filesystem each call, so the
+	 * working-spinner repaint loop re-walked the FS dozens of times per second
+	 * (issue #10231, costly on WSL). Cache the positive handle per cwd so a
+	 * steady idle session discovers once; a null result is never cached so a
+	 * later `git init` is still seen. Dropped on cwd switch or HEAD move via
+	 * {@link invalidateGitCaches}.
+	 *
+	 * Use this ONLY for the cheap, stable gate checks the render path makes on
+	 * every frame — `kind()`, `asGit()`, and the null test. It MUST NOT back a
+	 * ref-sensitive read: gitoxide's cached handle snapshots refs at first open
+	 * (`crates/pi-vcs/src/git/open.rs`), and a commit that advances the current
+	 * branch updates `refs/heads/*` without touching `.git/HEAD`, so the HEAD
+	 * watcher never fires and this memo would keep comparing the fresh index
+	 * against a stale HEAD tree. Reads that resolve HEAD (git `statusSummary`)
+	 * reopen a fresh handle instead.
 	 */
 	#repoFor(gitCwd: string): VcsRepo | null {
 		if (this.#cachedRepoHandle && this.#cachedRepoHandleCwd === gitCwd) {
@@ -1161,9 +1170,12 @@ export class StatusLineComponent implements Component {
 			(async () => {
 				let next: { staged: number; unstaged: number; untracked: number } | null = null;
 				try {
-					next = await repository.statusSummary(
-						withTimeoutSignal(JJ_COMMAND_TIMEOUT_MS, request.controller.signal),
-					);
+					// Fresh handle: jj status resolves the working commit; the memoized
+					// discovery handle can lag an op the watcher has not yet observed.
+					const freshRepo = vcs.repo(gitCwd);
+					next = freshRepo
+						? await freshRepo.statusSummary(withTimeoutSignal(JJ_COMMAND_TIMEOUT_MS, request.controller.signal))
+						: null;
 				} catch {
 					next = null;
 				} finally {
@@ -1190,7 +1202,12 @@ export class StatusLineComponent implements Component {
 		(async () => {
 			let nextStatus: { staged: number; unstaged: number; untracked: number } | null = null;
 			try {
-				nextStatus = (await repository.statusSummary()) ?? null;
+				// Reopen a fresh handle: staged = index vs HEAD tree, and the memoized
+				// discovery handle snapshots refs at open, so a same-branch commit
+				// (which never touches `.git/HEAD`, so the watcher stays quiet) would
+				// otherwise leave already-committed files counted as staged (#10235).
+				const freshRepo = vcs.repo(gitCwd);
+				nextStatus = (await freshRepo?.statusSummary()) ?? null;
 			} catch {
 				nextStatus = null;
 			} finally {

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -439,14 +439,14 @@ export class StatusLineComponent implements Component {
 	#collabStatus: CollabStatus | null = null;
 	#focusedAgentId: string | undefined;
 	#activeRepoCache: ActiveRepoCache | undefined;
-	// Repository-handle memo. `vcs.repo()` is a native filesystem walk; the three
-	// git-backed segments (branch, status, PR) each rediscover the same cwd on
-	// every rendered frame, so the working-spinner repaint loop re-walked the FS
-	// dozens of times per second (issue #10231, costly on WSL). Cache the handle
-	// per cwd; positive-only so a later `git init` is still picked up by the next
-	// discovery. Dropped by invalidateGitCaches (cwd switch / HEAD move).
+	// Repository-discovery memo. `vcs.repo()` is a native filesystem walk; the
+	// three git-backed segments (branch, status, PR) otherwise rediscover the
+	// same cwd on every rendered frame. Positive handles remain cached until
+	// explicit invalidation; negative results use a short TTL so a later
+	// `git init` is detected without spinner repaints repeatedly walking the FS.
 	#cachedRepoHandle: VcsRepo | null = null;
 	#cachedRepoHandleCwd: string | undefined = undefined;
+	#repoDiscoveryLastFetch: number | undefined = undefined;
 
 	// Git status caching (1s TTL)
 	#cachedGitStatus: { staged: number; unstaged: number; untracked: number } | null = null;
@@ -547,10 +547,9 @@ export class StatusLineComponent implements Component {
 	 * branch, status, and PR segments each locate the same effective cwd every
 	 * frame, and a fresh `vcs.repo()` walks the filesystem each call, so the
 	 * working-spinner repaint loop re-walked the FS dozens of times per second
-	 * (issue #10231, costly on WSL). Cache the positive handle per cwd so a
-	 * steady idle session discovers once; a null result is never cached so a
-	 * later `git init` is still seen. Dropped on cwd switch or HEAD move via
-	 * {@link invalidateGitCaches}.
+	 * (issue #10231, costly on WSL). Positive handles remain cached until
+	 * invalidation. Negative results expire at the watcher-failure polling
+	 * interval, bounding idle discovery while still detecting a later `git init`.
 	 *
 	 * Use this ONLY for the cheap, stable gate checks the render path makes on
 	 * every frame — `kind()`, `asGit()`, and the null test. It MUST NOT back a
@@ -562,17 +561,19 @@ export class StatusLineComponent implements Component {
 	 * reopen a fresh handle instead.
 	 */
 	#repoFor(gitCwd: string): VcsRepo | null {
-		if (this.#cachedRepoHandle && this.#cachedRepoHandleCwd === gitCwd) {
-			return this.#cachedRepoHandle;
+		if (this.#cachedRepoHandleCwd === gitCwd) {
+			if (this.#cachedRepoHandle) return this.#cachedRepoHandle;
+			if (
+				this.#repoDiscoveryLastFetch !== undefined &&
+				Date.now() - this.#repoDiscoveryLastFetch < WATCHER_FAILURE_POLL_TTL_MS
+			) {
+				return null;
+			}
 		}
 		const repository = vcs.repo(gitCwd);
-		if (repository) {
-			this.#cachedRepoHandle = repository;
-			this.#cachedRepoHandleCwd = gitCwd;
-		} else if (this.#cachedRepoHandleCwd === gitCwd) {
-			this.#cachedRepoHandle = null;
-			this.#cachedRepoHandleCwd = undefined;
-		}
+		this.#cachedRepoHandle = repository;
+		this.#cachedRepoHandleCwd = gitCwd;
+		this.#repoDiscoveryLastFetch = Date.now();
 		return repository;
 	}
 
@@ -970,6 +971,7 @@ export class StatusLineComponent implements Component {
 		// a `.git` removal must be re-discovered on the next render.
 		this.#cachedRepoHandle = null;
 		this.#cachedRepoHandleCwd = undefined;
+		this.#repoDiscoveryLastFetch = undefined;
 		// Abort before releasing the in-flight slot. Releasing alone would allow
 		// repeated invalidations to fan out still-running git subprocesses.
 		this.#branchResolveActive?.controller.abort();

--- a/packages/coding-agent/src/modes/components/status-line/segments.ts
+++ b/packages/coding-agent/src/modes/components/status-line/segments.ts
@@ -3,6 +3,7 @@ import * as path from "node:path";
 import { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import { SPINNER_ADVANCE_MS, TERMINAL } from "@oh-my-pi/pi-tui";
 import { formatDuration, formatNumber, getProjectDir, pathIsWithin, relativePathWithinRoot } from "@oh-my-pi/pi-utils";
+import { LRUCache } from "@oh-my-pi/pi-utils/lru";
 import { type Theme, type ThemeColor, theme } from "../../../modes/theme/theme";
 import { shortenPath, TRUNCATE_LENGTHS, truncateToWidth } from "../../../tools/render-utils";
 import { fileHyperlink } from "../../../tui/hyperlink";
@@ -59,21 +60,30 @@ function thinkingGlyph(display: string): string {
 }
 
 /**
+ * Entry lifetime for {@link memoizePathClassifier}. Long enough that the ~30fps
+ * working-spinner repaint loop recomputes at most once per interval (vs. every
+ * frame), short enough that a cwd symlink atomically retargeted under a fixed
+ * lexical path — the one input that changes a classification without changing
+ * the key — is re-resolved promptly instead of being pinned forever.
+ */
+const PATH_CLASSIFICATION_TTL_MS = 5000;
+
+/**
  * Memoize a pure `path`-segment classifier keyed by input directory. Both
  * callers below normalize paths through `fs.realpathSync` (via `pathIsWithin` /
  * `relativePathWithinRoot`), and the `path` segment runs them on every painted
  * frame, so the ~30fps working-spinner repaint loop performed a dozen-plus
- * filesystem ops for an unchanging cwd (issue #10231). The result depends only
- * on the input path and the constant root sets, so a per-path cache makes a
- * stable status line do zero filesystem work; a cwd change recomputes. Bounded
- * so alternating cwds cannot grow the cache without limit.
+ * filesystem ops for an unchanging cwd (issue #10231). Because the result is
+ * `realpathSync`-derived it is cached with a short TTL rather than permanently:
+ * a stable status line does zero filesystem work between refreshes, yet a
+ * retargeted cwd symlink re-resolves within {@link PATH_CLASSIFICATION_TTL_MS}.
  */
-function memoizePathClassifier<T>(compute: (pwd: string) => T): (pwd: string) => T {
-	const cache = new Map<string, T>();
+function memoizePathClassifier<T extends string | object>(compute: (pwd: string) => T): (pwd: string) => T {
+	const cache = new LRUCache<string, T>({ max: 64, ttl: PATH_CLASSIFICATION_TTL_MS });
 	return pwd => {
-		if (cache.has(pwd)) return cache.get(pwd) as T;
+		const cached = cache.get(pwd);
+		if (cached !== undefined) return cached;
 		const value = compute(pwd);
-		if (cache.size >= 64) cache.clear();
 		cache.set(pwd, value);
 		return value;
 	};

--- a/packages/coding-agent/src/modes/components/status-line/segments.ts
+++ b/packages/coding-agent/src/modes/components/status-line/segments.ts
@@ -58,13 +58,35 @@ function thinkingGlyph(display: string): string {
 	return space === -1 ? display : display.slice(0, space);
 }
 
-function stripDisplayRoot(pwd: string): string {
+/**
+ * Memoize a pure `path`-segment classifier keyed by input directory. Both
+ * callers below normalize paths through `fs.realpathSync` (via `pathIsWithin` /
+ * `relativePathWithinRoot`), and the `path` segment runs them on every painted
+ * frame, so the ~30fps working-spinner repaint loop performed a dozen-plus
+ * filesystem ops for an unchanging cwd (issue #10231). The result depends only
+ * on the input path and the constant root sets, so a per-path cache makes a
+ * stable status line do zero filesystem work; a cwd change recomputes. Bounded
+ * so alternating cwds cannot grow the cache without limit.
+ */
+function memoizePathClassifier<T>(compute: (pwd: string) => T): (pwd: string) => T {
+	const cache = new Map<string, T>();
+	return pwd => {
+		if (cache.has(pwd)) return cache.get(pwd) as T;
+		const value = compute(pwd);
+		if (cache.size >= 64) cache.clear();
+		cache.set(pwd, value);
+		return value;
+	};
+}
+
+/** Strip a known display root (`~/Projects`, `/work`) prefix from `pwd`. */
+const stripDisplayRoot = memoizePathClassifier((pwd: string): string => {
 	for (const root of [path.join(os.homedir(), "Projects"), "/work"]) {
 		const relative = relativePathWithinRoot(root, pwd);
 		if (relative) return relative;
 	}
 	return pwd;
-}
+});
 
 function normalizePremiumRequests(value: number): number {
 	return Math.round((value + Number.EPSILON) * 100) / 100;
@@ -106,14 +128,20 @@ const SCRATCH_ROOTS: readonly string[] = (() => {
 	return [...roots];
 })();
 
-function classifyProjectDir(pwd: string): { scratch: boolean; relative: string | null } {
+/**
+ * Whether `pwd` sits under a scratch root and its path relative to that root.
+ * Memoized by cwd: see {@link memoizePathClassifier} — the `path` segment calls
+ * this every painted frame and each {@link pathIsWithin} check runs
+ * `fs.realpathSync` twice per {@link SCRATCH_ROOTS} entry (issue #10231).
+ */
+const classifyProjectDir = memoizePathClassifier((pwd: string): { scratch: boolean; relative: string | null } => {
 	for (const root of SCRATCH_ROOTS) {
 		if (pathIsWithin(root, pwd)) {
 			return { scratch: true, relative: relativePathWithinRoot(root, pwd) };
 		}
 	}
 	return { scratch: false, relative: null };
-}
+});
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Segment Implementations

--- a/packages/coding-agent/test/helpers/git-fixture.ts
+++ b/packages/coding-agent/test/helpers/git-fixture.ts
@@ -1,0 +1,40 @@
+import * as os from "node:os";
+import { $ } from "bun";
+
+/**
+ * Environment that severs a fixture repository from host Git configuration.
+ *
+ * Global and system config are redirected to the null device (and
+ * `GIT_CONFIG_NOSYSTEM` disables `/etc/gitconfig` outright), so host settings
+ * like `commit.gpgsign` or a global `core.hooksPath` cannot make a fixture
+ * `commit` prompt, fail, or execute user hook code. Prompts are disabled, and a
+ * fixed author/committer identity is injected so `commit` never falls back to
+ * host `user.*` config. Callers still pass `--no-gpg-sign --no-verify` on
+ * commits as belt-and-suspenders (see {@link isolatedGitCommit}).
+ */
+const ISOLATED_GIT_ENV: Record<string, string> = {
+	GIT_CONFIG_GLOBAL: os.devNull,
+	GIT_CONFIG_SYSTEM: os.devNull,
+	GIT_CONFIG_NOSYSTEM: "1",
+	GIT_TERMINAL_PROMPT: "0",
+	GIT_AUTHOR_NAME: "Test User",
+	GIT_AUTHOR_EMAIL: "test@example.com",
+	GIT_COMMITTER_NAME: "Test User",
+	GIT_COMMITTER_EMAIL: "test@example.com",
+};
+
+/**
+ * Run one `git` invocation in `cwd`, isolated from host config, hooks, signing,
+ * and interactive prompts. Throws on a nonzero exit so setup failures surface.
+ */
+export async function isolatedGit(cwd: string, ...args: string[]): Promise<void> {
+	await $`git ${args}`
+		.cwd(cwd)
+		.env({ ...Bun.env, ...ISOLATED_GIT_ENV })
+		.quiet();
+}
+
+/** {@link isolatedGit} `commit`, additionally skipping signing and hooks. */
+export function isolatedGitCommit(cwd: string, message: string): Promise<void> {
+	return isolatedGit(cwd, "commit", "--no-gpg-sign", "--no-verify", "-m", message);
+}

--- a/packages/coding-agent/test/helpers/git-fixture.ts
+++ b/packages/coding-agent/test/helpers/git-fixture.ts
@@ -4,13 +4,14 @@ import { $ } from "bun";
 /**
  * Environment that severs a fixture repository from host Git configuration.
  *
- * Global and system config are redirected to the null device (and
- * `GIT_CONFIG_NOSYSTEM` disables `/etc/gitconfig` outright), so host settings
- * like `commit.gpgsign` or a global `core.hooksPath` cannot make a fixture
- * `commit` prompt, fail, or execute user hook code. Prompts are disabled, and a
- * fixed author/committer identity is injected so `commit` never falls back to
- * host `user.*` config. Callers still pass `--no-gpg-sign --no-verify` on
- * commits as belt-and-suspenders (see {@link isolatedGitCommit}).
+ * All inherited `GIT_*` variables are discarded before these controlled
+ * values are applied. This prevents repository-local overrides such as
+ * `GIT_DIR`, `GIT_WORK_TREE`, and `GIT_INDEX_FILE` from taking precedence
+ * over `cwd`, while also excluding host config, template, and execution-path
+ * overrides. Prompts are disabled, and a fixed author/committer identity is
+ * injected so `commit` never falls back to host `user.*` config. Callers still
+ * pass `--no-gpg-sign --no-verify` on commits as belt-and-suspenders (see
+ * {@link isolatedGitCommit}).
  */
 const ISOLATED_GIT_ENV: Record<string, string> = {
 	GIT_CONFIG_GLOBAL: os.devNull,
@@ -23,15 +24,21 @@ const ISOLATED_GIT_ENV: Record<string, string> = {
 	GIT_COMMITTER_EMAIL: "test@example.com",
 };
 
+function isolatedGitEnv(): Record<string, string> {
+	const env: Record<string, string> = {};
+	for (const key in Bun.env) {
+		const value = Bun.env[key];
+		if (value !== undefined && !key.startsWith("GIT_")) env[key] = value;
+	}
+	return { ...env, ...ISOLATED_GIT_ENV };
+}
+
 /**
  * Run one `git` invocation in `cwd`, isolated from host config, hooks, signing,
  * and interactive prompts. Throws on a nonzero exit so setup failures surface.
  */
 export async function isolatedGit(cwd: string, ...args: string[]): Promise<void> {
-	await $`git ${args}`
-		.cwd(cwd)
-		.env({ ...Bun.env, ...ISOLATED_GIT_ENV })
-		.quiet();
+	await $`git ${args}`.cwd(cwd).env(isolatedGitEnv()).quiet();
 }
 
 /** {@link isolatedGit} `commit`, additionally skipping signing and hooks. */

--- a/packages/coding-agent/test/status-line-path.test.ts
+++ b/packages/coding-agent/test/status-line-path.test.ts
@@ -261,12 +261,14 @@ describe("status line path segment", () => {
 			removeSyncWithRetries(parentDir);
 		}
 	});
-	it("memoizes classification so a stable cwd repaints without filesystem work", () => {
+	it("memoizes classification per cwd but revalidates after the TTL", () => {
 		const memoParent = path.join(originalProjectDir, ".wt");
 		fs.mkdirSync(memoParent, { recursive: true });
 		const dir = fs.mkdtempSync(path.join(memoParent, "omp-status-line-memo-"));
 		try {
 			setProjectDir(dir);
+			let clock = 1_000_000;
+			vi.spyOn(performance, "now").mockImplementation(() => clock);
 			const realpathSpy = vi.spyOn(fs, "realpathSync");
 
 			const first = Bun.stripANSI(renderSegment("path", createPathContext()).content);
@@ -276,10 +278,17 @@ describe("status line path segment", () => {
 
 			const second = Bun.stripANSI(renderSegment("path", createPathContext()).content);
 			// Repainting an unchanging cwd (the ~30fps working-spinner loop, issue
-			// #10231) must hit zero filesystem operations: classification is memoized.
+			// #10231) must hit zero filesystem operations within the TTL.
 			expect(realpathSpy.mock.calls.length).toBe(coldCalls);
 			expect(second).toBe(first);
 			expect(second).toContain(path.basename(dir));
+
+			// Past the TTL the classification is realpathSync-revalidated, so a cwd
+			// symlink atomically retargeted under a fixed lexical path cannot stay
+			// stale forever (PR #10235 review).
+			clock += 5_000 + 1;
+			renderSegment("path", createPathContext());
+			expect(realpathSpy.mock.calls.length).toBeGreaterThan(coldCalls);
 		} finally {
 			setProjectDir(originalProjectDir);
 			removeSyncWithRetries(dir);

--- a/packages/coding-agent/test/status-line-path.test.ts
+++ b/packages/coding-agent/test/status-line-path.test.ts
@@ -261,6 +261,30 @@ describe("status line path segment", () => {
 			removeSyncWithRetries(parentDir);
 		}
 	});
+	it("memoizes classification so a stable cwd repaints without filesystem work", () => {
+		const memoParent = path.join(originalProjectDir, ".wt");
+		fs.mkdirSync(memoParent, { recursive: true });
+		const dir = fs.mkdtempSync(path.join(memoParent, "omp-status-line-memo-"));
+		try {
+			setProjectDir(dir);
+			const realpathSpy = vi.spyOn(fs, "realpathSync");
+
+			const first = Bun.stripANSI(renderSegment("path", createPathContext()).content);
+			const coldCalls = realpathSpy.mock.calls.length;
+			// Cold classify normalizes the scratch roots + cwd through realpathSync.
+			expect(coldCalls).toBeGreaterThan(0);
+
+			const second = Bun.stripANSI(renderSegment("path", createPathContext()).content);
+			// Repainting an unchanging cwd (the ~30fps working-spinner loop, issue
+			// #10231) must hit zero filesystem operations: classification is memoized.
+			expect(realpathSpy.mock.calls.length).toBe(coldCalls);
+			expect(second).toBe(first);
+			expect(second).toContain(path.basename(dir));
+		} finally {
+			setProjectDir(originalProjectDir);
+			removeSyncWithRetries(dir);
+		}
+	});
 });
 
 describe("status line path segment in a linked worktree", () => {

--- a/packages/coding-agent/test/status-line-vcs-discovery.test.ts
+++ b/packages/coding-agent/test/status-line-vcs-discovery.test.ts
@@ -1,0 +1,113 @@
+import { beforeAll, describe, expect, it, type Mock, spyOn } from "bun:test";
+import type { VcsGitRepo, VcsGitRepoInfo, VcsRepo } from "@oh-my-pi/pi-natives";
+import * as vcs from "@oh-my-pi/pi-natives/vcs";
+import { Settings } from "../src/config/settings";
+import { StatusLineComponent } from "../src/modes/components/status-line";
+import { initTheme } from "../src/modes/theme/theme";
+import type { AgentSession } from "../src/session/agent-session";
+
+function fakeSession(): AgentSession {
+	const model = { id: "test-model", contextWindow: 200_000 };
+	const messages = [{ role: "user", content: "hi" }];
+	const session = {
+		messages,
+		systemPrompt: [],
+		agent: { state: { tools: [] } },
+		skills: [],
+		model,
+		modelRegistry: { isUsingOAuth: () => false },
+		state: { messages, model },
+		settings: undefined,
+		sessionManager: {
+			getUsageStatistics: () => ({
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				orchestrationInput: 0,
+				orchestrationOutput: 0,
+				orchestrationCacheRead: 0,
+				premiumRequests: 0,
+				cost: 0,
+			}),
+			getSessionName: () => "repro",
+		},
+		getAsyncJobSnapshot: () => ({ running: [] }),
+		isFastModeActive: () => false,
+		getContextUsage: () => ({ tokens: 6000, contextWindow: 200_000, percent: 3 }),
+		contextUsageRevision: 0,
+	};
+	return session as unknown as AgentSession;
+}
+
+/** Git-specific handle covering the synchronous render-path reads. */
+function fakeGitRepo(): VcsGitRepo {
+	const git = {
+		headSync: () => ({ kind: "ref", branch: "main" }),
+		head: async () => ({ kind: "ref", branch: "main" }),
+		linkedWorktree: () => null,
+		defaultBranch: async () => "main",
+	};
+	return git as unknown as VcsGitRepo;
+}
+
+/** Backend-agnostic repo handle the status line rediscovers per segment. */
+function fakeRepo(): VcsRepo {
+	const repo = {
+		kind: () => "git",
+		asJj: () => null,
+		asGit: () => fakeGitRepo(),
+		label: async () => "main",
+		statusSummary: async () => ({ staged: 0, unstaged: 0, untracked: 0 }),
+	};
+	return repo as unknown as VcsRepo;
+}
+
+function fakeGitInfo(): VcsGitRepoInfo {
+	const info = { isReftable: false, headPath: "/repo/.git/HEAD" };
+	return info as unknown as VcsGitRepoInfo;
+}
+
+describe("status line VCS discovery", () => {
+	beforeAll(async () => {
+		await Settings.init({ inMemory: true });
+		await initTheme();
+	});
+
+	it("discovers the repository once, not on every rendered frame", () => {
+		const repoSpy: Mock<typeof vcs.repo> = spyOn(vcs, "repo").mockImplementation(() => fakeRepo());
+		const gitSpy: Mock<typeof vcs.git> = spyOn(vcs, "git").mockImplementation(() => fakeGitRepo());
+		const infoSpy: Mock<typeof vcs.gitInfo> = spyOn(vcs, "gitInfo").mockImplementation(() => fakeGitInfo());
+
+		const component = new StatusLineComponent(fakeSession());
+		component.updateSettings({
+			preset: "custom",
+			leftSegments: ["path", "git"],
+			rightSegments: ["pr"],
+			separator: "powerline-thin",
+			sessionAccent: false,
+		});
+		try {
+			// Warm the projectDir/active-repo cache, then simulate the
+			// working-spinner repaint loop: the status line is rebuilt on every
+			// painted frame while nothing about the repository changed.
+			component.getTopBorder(120);
+			const perFrame = () => {
+				repoSpy.mockClear();
+				component.getTopBorder(120);
+				return repoSpy.mock.calls.length;
+			};
+			// Repository discovery is a native filesystem walk (costly on WSL). Once
+			// the handle is cached it must not re-walk on steady-state frames, and
+			// the count must never scale with the frame rate.
+			expect(perFrame()).toBe(0);
+			expect(perFrame()).toBe(0);
+		} finally {
+			component.dispose();
+			repoSpy.mockRestore();
+			gitSpy.mockRestore();
+			infoSpy.mockRestore();
+		}
+	});
+});

--- a/packages/coding-agent/test/status-line-vcs-discovery.test.ts
+++ b/packages/coding-agent/test/status-line-vcs-discovery.test.ts
@@ -83,10 +83,10 @@ interface Harness {
 	dispose: () => void;
 }
 
-function mountStatusLine(): Harness {
+function mountStatusLine(repoFactory: (id: number, probe: ReadProbe) => VcsRepo | null = fakeRepo): Harness {
 	const probe: ReadProbe = { kindIds: [], statusIds: [] };
 	let nextId = 0;
-	const repoSpy: Mock<typeof vcs.repo> = spyOn(vcs, "repo").mockImplementation(() => fakeRepo(nextId++, probe));
+	const repoSpy: Mock<typeof vcs.repo> = spyOn(vcs, "repo").mockImplementation(() => repoFactory(nextId++, probe));
 	const gitSpy = spyOn(vcs, "git").mockImplementation(() => fakeRepo(-1, probe).asGit());
 	const infoSpy = spyOn(vcs, "gitInfo").mockImplementation(() => fakeGitInfo());
 
@@ -135,6 +135,35 @@ describe("status line VCS discovery", () => {
 			expect(perFrame()).toBe(0);
 			expect(perFrame()).toBe(0);
 		} finally {
+			dispose();
+		}
+	});
+
+	it("bounds negative discovery and retries after the fallback polling interval", () => {
+		let now = 1_000_000;
+		const nowSpy = spyOn(Date, "now").mockImplementation(() => now);
+		const { component, repoSpy, dispose } = mountStatusLine(() => null);
+		try {
+			// Warm the unrelated active-repository resolution, then isolate the
+			// status line's repo memo.
+			component.getTopBorder(120);
+			component.invalidateGitCaches();
+			repoSpy.mockClear();
+
+			component.getTopBorder(120);
+			expect(repoSpy).toHaveBeenCalledTimes(1);
+			component.getTopBorder(120);
+			now += 4_999;
+			component.getTopBorder(120);
+			expect(repoSpy).toHaveBeenCalledTimes(1);
+
+			// A bounded miss must expire so `git init` becomes visible without a
+			// cwd or HEAD watcher event.
+			now += 1;
+			component.getTopBorder(120);
+			expect(repoSpy).toHaveBeenCalledTimes(2);
+		} finally {
+			nowSpy.mockRestore();
 			dispose();
 		}
 	});

--- a/packages/coding-agent/test/status-line-vcs-discovery.test.ts
+++ b/packages/coding-agent/test/status-line-vcs-discovery.test.ts
@@ -41,25 +41,32 @@ function fakeSession(): AgentSession {
 	return session as unknown as AgentSession;
 }
 
-/** Git-specific handle covering the synchronous render-path reads. */
-function fakeGitRepo(): VcsGitRepo {
+/** Records which repo instance each ref-sensitive read ran on. */
+interface ReadProbe {
+	kindIds: number[];
+	statusIds: number[];
+}
+
+/** A Git-backed repo handle tagged so tests can tell reused vs freshly opened. */
+function fakeRepo(id: number, probe: ReadProbe): VcsRepo {
 	const git = {
 		headSync: () => ({ kind: "ref", branch: "main" }),
 		head: async () => ({ kind: "ref", branch: "main" }),
 		linkedWorktree: () => null,
 		defaultBranch: async () => "main",
 	};
-	return git as unknown as VcsGitRepo;
-}
-
-/** Backend-agnostic repo handle the status line rediscovers per segment. */
-function fakeRepo(): VcsRepo {
 	const repo = {
-		kind: () => "git",
+		kind: () => {
+			probe.kindIds.push(id);
+			return "git";
+		},
 		asJj: () => null,
-		asGit: () => fakeGitRepo(),
+		asGit: () => git as unknown as VcsGitRepo,
 		label: async () => "main",
-		statusSummary: async () => ({ staged: 0, unstaged: 0, untracked: 0 }),
+		statusSummary: async () => {
+			probe.statusIds.push(id);
+			return { staged: 0, unstaged: 0, untracked: 0 };
+		},
 	};
 	return repo as unknown as VcsRepo;
 }
@@ -69,6 +76,41 @@ function fakeGitInfo(): VcsGitRepoInfo {
 	return info as unknown as VcsGitRepoInfo;
 }
 
+interface Harness {
+	component: StatusLineComponent;
+	probe: ReadProbe;
+	repoSpy: Mock<typeof vcs.repo>;
+	dispose: () => void;
+}
+
+function mountStatusLine(): Harness {
+	const probe: ReadProbe = { kindIds: [], statusIds: [] };
+	let nextId = 0;
+	const repoSpy: Mock<typeof vcs.repo> = spyOn(vcs, "repo").mockImplementation(() => fakeRepo(nextId++, probe));
+	const gitSpy = spyOn(vcs, "git").mockImplementation(() => fakeRepo(-1, probe).asGit());
+	const infoSpy = spyOn(vcs, "gitInfo").mockImplementation(() => fakeGitInfo());
+
+	const component = new StatusLineComponent(fakeSession());
+	component.updateSettings({
+		preset: "custom",
+		leftSegments: ["path", "git"],
+		rightSegments: ["pr"],
+		separator: "powerline-thin",
+		sessionAccent: false,
+	});
+	return {
+		component,
+		probe,
+		repoSpy,
+		dispose: () => {
+			component.dispose();
+			repoSpy.mockRestore();
+			gitSpy.mockRestore();
+			infoSpy.mockRestore();
+		},
+	};
+}
+
 describe("status line VCS discovery", () => {
 	beforeAll(async () => {
 		await Settings.init({ inMemory: true });
@@ -76,20 +118,9 @@ describe("status line VCS discovery", () => {
 	});
 
 	it("discovers the repository once, not on every rendered frame", () => {
-		const repoSpy: Mock<typeof vcs.repo> = spyOn(vcs, "repo").mockImplementation(() => fakeRepo());
-		const gitSpy: Mock<typeof vcs.git> = spyOn(vcs, "git").mockImplementation(() => fakeGitRepo());
-		const infoSpy: Mock<typeof vcs.gitInfo> = spyOn(vcs, "gitInfo").mockImplementation(() => fakeGitInfo());
-
-		const component = new StatusLineComponent(fakeSession());
-		component.updateSettings({
-			preset: "custom",
-			leftSegments: ["path", "git"],
-			rightSegments: ["pr"],
-			separator: "powerline-thin",
-			sessionAccent: false,
-		});
+		const { component, repoSpy, dispose } = mountStatusLine();
 		try {
-			// Warm the projectDir/active-repo cache, then simulate the
+			// Warm the projectDir / active-repo caches, then simulate the
 			// working-spinner repaint loop: the status line is rebuilt on every
 			// painted frame while nothing about the repository changed.
 			component.getTopBorder(120);
@@ -99,15 +130,31 @@ describe("status line VCS discovery", () => {
 				return repoSpy.mock.calls.length;
 			};
 			// Repository discovery is a native filesystem walk (costly on WSL). Once
-			// the handle is cached it must not re-walk on steady-state frames, and
+			// the handle is memoized it must not re-walk on steady-state frames, and
 			// the count must never scale with the frame rate.
 			expect(perFrame()).toBe(0);
 			expect(perFrame()).toBe(0);
 		} finally {
-			component.dispose();
-			repoSpy.mockRestore();
-			gitSpy.mockRestore();
-			infoSpy.mockRestore();
+			dispose();
+		}
+	});
+
+	it("reads status through a freshly opened handle, not the memoized one", () => {
+		const { component, probe, dispose } = mountStatusLine();
+		try {
+			// One render on a cold status cache: the cheap `kind()` gate runs on the
+			// memoized discovery handle, while `statusSummary` (staged = index vs HEAD
+			// tree) must reopen a fresh handle so a same-branch commit — which never
+			// touches `.git/HEAD`, so the HEAD watcher stays quiet — cannot leave the
+			// status segment comparing against a stale, ref-snapshotted HEAD.
+			component.getTopBorder(120);
+			expect(probe.statusIds.length).toBeGreaterThan(0);
+			expect(probe.kindIds.length).toBeGreaterThan(0);
+			const memoizedGateHandle = probe.kindIds[0];
+			expect(probe.kindIds.every(id => id === memoizedGateHandle)).toBe(true);
+			expect(probe.statusIds.every(id => id !== memoizedGateHandle)).toBe(true);
+		} finally {
+			dispose();
 		}
 	});
 });

--- a/packages/coding-agent/test/status-line-vcs-discovery.test.ts
+++ b/packages/coding-agent/test/status-line-vcs-discovery.test.ts
@@ -1,6 +1,9 @@
 import { beforeAll, describe, expect, it, type Mock, spyOn } from "bun:test";
+import * as path from "node:path";
 import type { VcsGitRepo, VcsGitRepoInfo, VcsRepo } from "@oh-my-pi/pi-natives";
 import * as vcs from "@oh-my-pi/pi-natives/vcs";
+import { getProjectDir, setProjectDir, TempDir } from "@oh-my-pi/pi-utils";
+import { $ } from "bun";
 import { Settings } from "../src/config/settings";
 import { StatusLineComponent } from "../src/modes/components/status-line";
 import { initTheme } from "../src/modes/theme/theme";
@@ -41,14 +44,7 @@ function fakeSession(): AgentSession {
 	return session as unknown as AgentSession;
 }
 
-/** Records which repo instance each ref-sensitive read ran on. */
-interface ReadProbe {
-	kindIds: number[];
-	statusIds: number[];
-}
-
-/** A Git-backed repo handle tagged so tests can tell reused vs freshly opened. */
-function fakeRepo(id: number, probe: ReadProbe): VcsRepo {
+function fakeRepo(): VcsRepo {
 	const git = {
 		headSync: () => ({ kind: "ref", branch: "main" }),
 		head: async () => ({ kind: "ref", branch: "main" }),
@@ -56,17 +52,11 @@ function fakeRepo(id: number, probe: ReadProbe): VcsRepo {
 		defaultBranch: async () => "main",
 	};
 	const repo = {
-		kind: () => {
-			probe.kindIds.push(id);
-			return "git";
-		},
+		kind: () => "git",
 		asJj: () => null,
 		asGit: () => git as unknown as VcsGitRepo,
 		label: async () => "main",
-		statusSummary: async () => {
-			probe.statusIds.push(id);
-			return { staged: 0, unstaged: 0, untracked: 0 };
-		},
+		statusSummary: async () => ({ staged: 0, unstaged: 0, untracked: 0 }),
 	};
 	return repo as unknown as VcsRepo;
 }
@@ -78,16 +68,13 @@ function fakeGitInfo(): VcsGitRepoInfo {
 
 interface Harness {
 	component: StatusLineComponent;
-	probe: ReadProbe;
 	repoSpy: Mock<typeof vcs.repo>;
 	dispose: () => void;
 }
 
-function mountStatusLine(repoFactory: (id: number, probe: ReadProbe) => VcsRepo | null = fakeRepo): Harness {
-	const probe: ReadProbe = { kindIds: [], statusIds: [] };
-	let nextId = 0;
-	const repoSpy: Mock<typeof vcs.repo> = spyOn(vcs, "repo").mockImplementation(() => repoFactory(nextId++, probe));
-	const gitSpy = spyOn(vcs, "git").mockImplementation(() => fakeRepo(-1, probe).asGit());
+function mountStatusLine(repoFactory: () => VcsRepo | null = fakeRepo): Harness {
+	const repoSpy: Mock<typeof vcs.repo> = spyOn(vcs, "repo").mockImplementation(repoFactory);
+	const gitSpy = spyOn(vcs, "git").mockImplementation(() => fakeRepo().asGit());
 	const infoSpy = spyOn(vcs, "gitInfo").mockImplementation(() => fakeGitInfo());
 
 	const component = new StatusLineComponent(fakeSession());
@@ -100,7 +87,6 @@ function mountStatusLine(repoFactory: (id: number, probe: ReadProbe) => VcsRepo 
 	});
 	return {
 		component,
-		probe,
 		repoSpy,
 		dispose: () => {
 			component.dispose();
@@ -168,22 +154,69 @@ describe("status line VCS discovery", () => {
 		}
 	});
 
-	it("reads status through a freshly opened handle, not the memoized one", () => {
-		const { component, probe, dispose } = mountStatusLine();
-		try {
-			// One render on a cold status cache: the cheap `kind()` gate runs on the
-			// memoized discovery handle, while `statusSummary` (staged = index vs HEAD
-			// tree) must reopen a fresh handle so a same-branch commit — which never
-			// touches `.git/HEAD`, so the HEAD watcher stays quiet — cannot leave the
-			// status segment comparing against a stale, ref-snapshotted HEAD.
+	it("clears the staged indicator after a same-branch commit", async () => {
+		using tempDir = TempDir.createSync("@omp-status-line-vcs-discovery-");
+		const cwd = tempDir.path();
+		await $`git init --initial-branch=main`.cwd(cwd).quiet();
+		await $`git config user.name "Test User"`.cwd(cwd).quiet();
+		await $`git config user.email "test@example.com"`.cwd(cwd).quiet();
+		await Bun.write(path.join(cwd, "tracked.txt"), "base\n");
+		await $`git add tracked.txt && git commit -m base`.cwd(cwd).quiet();
+		await Bun.write(path.join(cwd, "tracked.txt"), "staged\n");
+		await $`git add tracked.txt`.cwd(cwd).quiet();
+
+		const originalProjectDir = getProjectDir();
+		const discoverRepo = vcs.repo;
+		let statusReadDone: (() => void) | undefined;
+		const repoSpy = spyOn(vcs, "repo").mockImplementation(repoCwd => {
+			const repository = discoverRepo(repoCwd);
+			if (!repository) return null;
+			const statusSummary = repository.statusSummary.bind(repository);
+			repository.statusSummary = async signal => {
+				try {
+					return await statusSummary(signal);
+				} finally {
+					statusReadDone?.();
+					statusReadDone = undefined;
+				}
+			};
+			return repository;
+		});
+		const awaitStatusRead = async (component: StatusLineComponent): Promise<string> => {
+			const settled = Promise.withResolvers<void>();
+			statusReadDone = settled.resolve;
 			component.getTopBorder(120);
-			expect(probe.statusIds.length).toBeGreaterThan(0);
-			expect(probe.kindIds.length).toBeGreaterThan(0);
-			const memoizedGateHandle = probe.kindIds[0];
-			expect(probe.kindIds.every(id => id === memoizedGateHandle)).toBe(true);
-			expect(probe.statusIds.every(id => id !== memoizedGateHandle)).toBe(true);
+			await settled.promise;
+			await Promise.resolve();
+			return Bun.stripANSI(component.getTopBorder(120).content);
+		};
+
+		const headPath = path.join(cwd, ".git", "HEAD");
+		const headBeforeCommit = await Bun.file(headPath).text();
+		let now = 1_000_000;
+		const nowSpy = spyOn(Date, "now").mockImplementation(() => now);
+		setProjectDir(cwd);
+		const component = new StatusLineComponent(fakeSession());
+		component.updateSettings({
+			preset: "custom",
+			leftSegments: ["git"],
+			rightSegments: [],
+			separator: "powerline-thin",
+			sessionAccent: false,
+		});
+		try {
+			expect(await awaitStatusRead(component)).toContain("+1");
+
+			await $`git commit -m staged`.cwd(cwd).quiet();
+			expect(await Bun.file(headPath).text()).toBe(headBeforeCommit);
+			now += 1_000;
+
+			expect(await awaitStatusRead(component)).not.toContain("+1");
 		} finally {
-			dispose();
+			component.dispose();
+			setProjectDir(originalProjectDir);
+			nowSpy.mockRestore();
+			repoSpy.mockRestore();
 		}
 	});
 });

--- a/packages/coding-agent/test/status-line-vcs-discovery.test.ts
+++ b/packages/coding-agent/test/status-line-vcs-discovery.test.ts
@@ -3,11 +3,11 @@ import * as path from "node:path";
 import type { VcsGitRepo, VcsGitRepoInfo, VcsRepo } from "@oh-my-pi/pi-natives";
 import * as vcs from "@oh-my-pi/pi-natives/vcs";
 import { getProjectDir, setProjectDir, TempDir } from "@oh-my-pi/pi-utils";
-import { $ } from "bun";
 import { Settings } from "../src/config/settings";
 import { StatusLineComponent } from "../src/modes/components/status-line";
 import { initTheme } from "../src/modes/theme/theme";
 import type { AgentSession } from "../src/session/agent-session";
+import { isolatedGit, isolatedGitCommit } from "./helpers/git-fixture";
 
 function fakeSession(): AgentSession {
 	const model = { id: "test-model", contextWindow: 200_000 };
@@ -157,13 +157,12 @@ describe("status line VCS discovery", () => {
 	it("clears the staged indicator after a same-branch commit", async () => {
 		using tempDir = TempDir.createSync("@omp-status-line-vcs-discovery-");
 		const cwd = tempDir.path();
-		await $`git init --initial-branch=main`.cwd(cwd).quiet();
-		await $`git config user.name "Test User"`.cwd(cwd).quiet();
-		await $`git config user.email "test@example.com"`.cwd(cwd).quiet();
+		await isolatedGit(cwd, "init", "--initial-branch=main");
 		await Bun.write(path.join(cwd, "tracked.txt"), "base\n");
-		await $`git add tracked.txt && git commit -m base`.cwd(cwd).quiet();
+		await isolatedGit(cwd, "add", "tracked.txt");
+		await isolatedGitCommit(cwd, "base");
 		await Bun.write(path.join(cwd, "tracked.txt"), "staged\n");
-		await $`git add tracked.txt`.cwd(cwd).quiet();
+		await isolatedGit(cwd, "add", "tracked.txt");
 
 		const originalProjectDir = getProjectDir();
 		const discoverRepo = vcs.repo;
@@ -207,7 +206,7 @@ describe("status line VCS discovery", () => {
 		try {
 			expect(await awaitStatusRead(component)).toContain("+1");
 
-			await $`git commit -m staged`.cwd(cwd).quiet();
+			await isolatedGitCommit(cwd, "staged");
 			expect(await Bun.file(headPath).text()).toBe(headBeforeCommit);
 			now += 1_000;
 


### PR DESCRIPTION
## Repro
With a session sitting idle while a background `async` job (e.g. a long test run) is pending, the "Working…" spinner keeps repainting and CPU climbs to 40-100% of a core (issue #10231, WSL). The reporter's raw `profile.cpuprofile` shows ~88% of CPU in the TUI render loop, dominated by the status line (`getTopBorder` -> `#buildStatusLine`, ~32% inclusive) with `vcsDiscover` at 6.1% self, and `work.md` records `vcs.statusSummary` running 27x in 30s. Deterministic in-process repro: `bun test packages/coding-agent/test/status-line-vcs-discovery.test.ts` — before the fix, one `getTopBorder()` render triggers 4 native `vcs.repo()` filesystem discoveries.

## Cause
The editor resolves the top-border content once per painted frame (`packages/tui/src/components/editor.ts`), and the working spinner keeps painting during a background wait. `StatusLineComponent.#buildSegmentContext` then resolves the git segments every frame, and `#getBranchLabel`, `#getStatus`, and `#lookupPr` each open `vcs.repo(gitCwd)` — a native `pi-vcs` filesystem discovery — with no handle cache. `#lookupPr` also re-invokes `#getBranchLabel`, so a single frame runs `vcs.repo()` four times. At the spinner cadence that is dozens of native FS walks per second, amplified on WSL where each walk crosses the FS boundary. This is the residual hotspot left after the loader backpressure (#9892) and per-frame cost-segment catalog scan (#10131) fixes, mirroring #10131's shape.

## Fix
- `packages/coding-agent/src/modes/components/status-line/component.ts`: add a `#repoFor(gitCwd)` memo that caches the positive `vcs.repo()` handle per effective cwd; a null result is never cached so a later `git init` is still discovered. The handle is a live repository reference (its reads re-hit disk), so reuse across frames still returns fresh branch/status.
- Route `#getBranchLabel`, `#getStatus`, and `#lookupPr` through `#repoFor` instead of calling `vcs.repo()` directly.
- Drop the cached handle in `invalidateGitCaches()` so a cwd switch or HEAD move re-discovers.
- Add `packages/coding-agent/test/status-line-vcs-discovery.test.ts` and a CHANGELOG entry.

## Verification
`bun test packages/coding-agent/test/status-line-vcs-discovery.test.ts` — passes; native `vcs.repo` discovery drops from 4 per rendered frame to 0 in steady state (one discovery per cwd, cached across frames). `bun run check:types` for `packages/coding-agent` is clean. The related `packages/coding-agent/test/utils/vcs-adapter.test.ts` cases fail only in this worktree because its prebuilt native addon predates the `pi-vcs` crate (`vcsGitDiscover` missing) — unrelated to this change.

Fixes #10231