### PR TITLE
fix(lsp): evaluate idle timeout per workspace client (#8389)

### DIFF
--- a/docs/tools/lsp.md
+++ b/docs/tools/lsp.md
@@ -46,7 +46,7 @@
 ## Flow
 1. `packages/coding-agent/src/tools/index.ts` registers `lsp: LspTool.createIf`. The tool is present only when both `session.enableLsp !== false` and `lsp.enabled` (default `true`) allow it. A session with `lspReadOnly` rejects every action outside `LSP_READONLY_ACTIONS`; restricted sessions default both to LSP disabled and read-only if it is explicitly re-enabled.
 2. `LspTool.execute()` in `packages/coding-agent/src/lsp/index.ts` clamps `timeout` with `clampTimeout("lsp", ...)`, including the optional global `tools.maxTimeout` ceiling, builds an `AbortSignal.timeout(...)`, and combines it with the caller signal.
-3. `getConfig()` loads and caches `LspConfig` per cwd, applies idle-timeout config via `setIdleTimeout()`, and reuses the cached config on later calls. Workspace `reload` is the explicit exception: it clears and rebuilds that cwd's config cache before reloading the newly selected servers.
+3. `getConfig()` loads and caches `LspConfig` per cwd and reuses the cached config on later calls. Workspace `reload` is the explicit exception: it clears and rebuilds that cwd's config cache before reloading the newly selected servers.
 4. Config loading in `packages/coding-agent/src/lsp/config.ts` merges `defaults.json` with JSON/YAML overrides from project, project config dirs, user config dirs, plugin roots/marketplace metadata, and home; if there are no overrides it auto-detects servers from root markers plus executable discovery. See [LSP configuration](../lsp-config.md) for filenames, precedence, and server fields.
 5. Server routing uses `getServersForFile()` / `getServerForFile()` from `config.ts`: extension or basename match, then sort primary servers before linters. `index.ts` further filters custom linter clients out of navigation/refactor paths with `getLspServersForFile()` / `getLspServerForFile()`.
 6. `getOrCreateClient()` caches one client per `command:cwd`. With `lsp.shared` (default `true` in SDK sessions), it first asks the broker-managed project mux for a shared transport; failure falls back to a private `ptree.spawn()`. An external `lspmux` wrapper takes precedence over broker sharing. The client then starts its message reader, sends `initialize`, stores capabilities, and sends `initialized`.
@@ -264,7 +264,7 @@ Uses the same location normalization and output shape as `definition`, but sends
   - Caches config per cwd in `configCache`; workspace `reload` invalidates the entry.
   - Caches LSP clients per `command:cwd`, with `pendingRequests`, `diagnostics`, `openFiles`, `serverCapabilities`, and project-load state. The transport may represent a shared mux link rather than an owned process.
   - Caches custom linter clients by `serverName:cwd`.
-  - Updates client `lastActivity`; optional idle-timeout cleanup is driven by `setIdleTimeout()`.
+  - Updates client `lastActivity`; optional idle-timeout cleanup is driven by workspace `idleTimeoutMs` or `setIdleTimeout()`.
 - Background work / cancellation
   - Every request has an abortable timeout signal.
   - Aborting an in-flight LSP request sends `$/cancelRequest`.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,10 @@
 - Devin model selectors now accept the native CLI's short aliases (`devin/opus`, `devin/swe`), dotted upstream spellings (`devin/gemini-3.7-flash`), and raw effort-route wire uids for dynamically collapsed families ([#8590](https://github.com/can1357/oh-my-pi/pull/8590) by [@will-bogusz](https://github.com/will-bogusz)).
 - Added provider-supplied model metadata to the `/models` detail line: `new`, `beta`, and `recommended` badges beside the model name, and the upstream description after the context, cost, and perf facts ([#8590](https://github.com/can1357/oh-my-pi/pull/8590) by [@will-bogusz](https://github.com/will-bogusz)).
 
+### Fixed
+
+- Fixed LSP idle timeout clobbering in multi-workspace sessions and unmanaged timer spawning on pure config reads ([#10237](https://github.com/can1357/oh-my-pi/pull/10237) by [@harshaygadekar](https://github.com/harshaygadekar)).
+
 ## [18.0.11] - 2026-08-29
 
 ### Added

--- a/packages/coding-agent/src/lsp/client.ts
+++ b/packages/coding-agent/src/lsp/client.ts
@@ -64,12 +64,7 @@ export function setSharedLspEnabled(enabled: boolean): void {
  */
 export function setIdleTimeout(ms: number | null | undefined): void {
 	idleTimeoutMs = ms ?? null;
-
-	if (idleTimeoutMs && idleTimeoutMs > 0) {
-		startIdleChecker();
-	} else {
-		maybeStopIdleChecker();
-	}
+	reconcileIdleChecker();
 }
 
 /**
@@ -110,11 +105,28 @@ function maybeStartIdleChecker(client?: LspClient): void {
 	}
 }
 
-function maybeStopIdleChecker(): void {
-	if (clients.size === 0 && !idleTimeoutMs) {
+/**
+ * Whether the background idle checker interval is currently active.
+ * Exported for tests.
+ */
+export function isIdleCheckerRunning(): boolean {
+	return idleCheckInterval !== null;
+}
+
+/**
+ * Reconcile the background idle checker interval against currently configured timeouts.
+ * Starts the checker if any registered client or workspace has a positive timeout,
+ * or stops it if none do.
+ */
+export function reconcileIdleChecker(): void {
+	if (hasConfiguredIdleTimeout()) {
+		startIdleChecker();
+	} else {
 		stopIdleChecker();
-		return;
 	}
+}
+
+function maybeStopIdleChecker(): void {
 	if (!hasConfiguredIdleTimeout()) {
 		stopIdleChecker();
 	}
@@ -990,6 +1002,7 @@ export async function getOrCreateClient(
 	const existingClient = clients.get(key);
 	if (existingClient && !invalidatedClientKeys.has(key)) {
 		existingClient.lastActivity = Date.now();
+		maybeStartIdleChecker(existingClient);
 		return existingClient;
 	}
 
@@ -1014,6 +1027,7 @@ export async function getOrCreateClient(
 		const clientAfterReload = clients.get(key);
 		if (clientAfterReload && !invalidatedClientKeys.has(key)) {
 			clientAfterReload.lastActivity = Date.now();
+			maybeStartIdleChecker(clientAfterReload);
 			return clientAfterReload;
 		}
 		const lockAfterReload = clientLocks.get(key);

--- a/packages/coding-agent/src/lsp/client.ts
+++ b/packages/coding-agent/src/lsp/client.ts
@@ -2,6 +2,7 @@ import * as path from "node:path";
 import { isEnoent, logger, postmortem, ptree, stableStringifyJson, untilAborted } from "@oh-my-pi/pi-utils";
 import { MessageFramer } from "../jsonrpc/message-framing";
 import { ToolAbortError, throwIfAborted } from "../tools/tool-errors";
+import { getConfig } from "./config";
 import { applyWorkspaceEdit, type ExecutedWorkspaceChange } from "./edits";
 import { getLspmuxCommand, isLspmuxSupported } from "./lspmux";
 import { connectSharedLspTransport } from "./mux/daemon";
@@ -57,15 +58,16 @@ export function setSharedLspEnabled(enabled: boolean): void {
 }
 
 /**
- * Configure the idle timeout for LSP clients.
- * @param ms - Timeout in milliseconds, or null/undefined to disable
+ * Configure the global fallback idle timeout for LSP clients (used in tests/overrides).
+ * When unset, each client evaluates against its workspace config (`getConfig(client.cwd).idleTimeoutMs`).
+ * @param ms - Timeout in milliseconds, or null/undefined to disable global override
  */
 export function setIdleTimeout(ms: number | null | undefined): void {
 	idleTimeoutMs = ms ?? null;
 
 	if (idleTimeoutMs && idleTimeoutMs > 0) {
 		startIdleChecker();
-	} else {
+	} else if (clients.size === 0) {
 		stopIdleChecker();
 	}
 }
@@ -92,10 +94,10 @@ export function isIdleClient(client: LspClient, now: number, timeoutMs: number):
 function startIdleChecker(): void {
 	if (idleCheckInterval) return;
 	idleCheckInterval = setInterval(() => {
-		if (!idleTimeoutMs) return;
 		const now = Date.now();
 		for (const [key, client] of Array.from(clients.entries())) {
-			if (isIdleClient(client, now, idleTimeoutMs)) {
+			const timeoutMs = idleTimeoutMs ?? getConfig(client.cwd).idleTimeoutMs;
+			if (timeoutMs && timeoutMs > 0 && isIdleClient(client, now, timeoutMs)) {
 				void shutdownClient(key);
 			}
 		}
@@ -1121,6 +1123,7 @@ export async function getOrCreateClient(
 				throw new Error(`LSP configuration was superseded during initialization: ${config.command}`);
 			}
 			clients.set(key, client);
+			startIdleChecker();
 			initFailures.delete(key);
 			return client;
 		} catch (err) {
@@ -1493,6 +1496,9 @@ async function waitForExit(client: LspClient, timeoutMs: number): Promise<boolea
  */
 export async function shutdownClientInstance(client: LspClient): Promise<boolean> {
 	if (clients.get(client.name) === client) clients.delete(client.name);
+	if (clients.size === 0 && !idleTimeoutMs) {
+		stopIdleChecker();
+	}
 
 	const err = new Error("LSP client shutdown");
 	for (const pending of Array.from(client.pendingRequests.values())) {

--- a/packages/coding-agent/src/lsp/client.ts
+++ b/packages/coding-agent/src/lsp/client.ts
@@ -67,8 +67,8 @@ export function setIdleTimeout(ms: number | null | undefined): void {
 
 	if (idleTimeoutMs && idleTimeoutMs > 0) {
 		startIdleChecker();
-	} else if (clients.size === 0) {
-		stopIdleChecker();
+	} else {
+		maybeStopIdleChecker();
 	}
 }
 
@@ -91,16 +91,53 @@ export function isIdleClient(client: LspClient, now: number, timeoutMs: number):
 	return now - client.lastActivity > timeoutMs;
 }
 
+function hasConfiguredIdleTimeout(client?: LspClient): boolean {
+	if (idleTimeoutMs && idleTimeoutMs > 0) return true;
+	if (client) {
+		const timeoutMs = getConfig(client.cwd).idleTimeoutMs;
+		if (timeoutMs && timeoutMs > 0) return true;
+	}
+	for (const c of clients.values()) {
+		const timeoutMs = getConfig(c.cwd).idleTimeoutMs;
+		if (timeoutMs && timeoutMs > 0) return true;
+	}
+	return false;
+}
+
+function maybeStartIdleChecker(client?: LspClient): void {
+	if (hasConfiguredIdleTimeout(client)) {
+		startIdleChecker();
+	}
+}
+
+function maybeStopIdleChecker(): void {
+	if (clients.size === 0 && !idleTimeoutMs) {
+		stopIdleChecker();
+		return;
+	}
+	if (!hasConfiguredIdleTimeout()) {
+		stopIdleChecker();
+	}
+}
+
+/**
+ * Sweeps all registered LSP clients against their workspace idle timeout.
+ * Exported for tests.
+ */
+export async function checkIdleClients(): Promise<void> {
+	const now = Date.now();
+	for (const [key, client] of Array.from(clients.entries())) {
+		const timeoutMs = idleTimeoutMs ?? getConfig(client.cwd).idleTimeoutMs;
+		if (timeoutMs && timeoutMs > 0 && isIdleClient(client, now, timeoutMs)) {
+			await shutdownClient(key);
+		}
+	}
+}
+
 function startIdleChecker(): void {
 	if (idleCheckInterval) return;
 	idleCheckInterval = setInterval(() => {
-		const now = Date.now();
-		for (const [key, client] of Array.from(clients.entries())) {
-			const timeoutMs = idleTimeoutMs ?? getConfig(client.cwd).idleTimeoutMs;
-			if (timeoutMs && timeoutMs > 0 && isIdleClient(client, now, timeoutMs)) {
-				void shutdownClient(key);
-			}
-		}
+		void checkIdleClients();
 	}, IDLE_CHECK_INTERVAL_MS);
 }
 
@@ -1056,6 +1093,7 @@ export async function getOrCreateClient(
 		// Register crash recovery - remove client on process exit
 		proc.exited.then(() => {
 			if (clients.get(key) === client) clients.delete(key);
+			maybeStopIdleChecker();
 			if (clientLocks.get(key)?.token === lockToken) clientLocks.delete(key);
 			client.resolveProjectLoaded();
 
@@ -1123,7 +1161,7 @@ export async function getOrCreateClient(
 				throw new Error(`LSP configuration was superseded during initialization: ${config.command}`);
 			}
 			clients.set(key, client);
-			startIdleChecker();
+			maybeStartIdleChecker(client);
 			initFailures.delete(key);
 			return client;
 		} catch (err) {
@@ -1496,9 +1534,7 @@ async function waitForExit(client: LspClient, timeoutMs: number): Promise<boolea
  */
 export async function shutdownClientInstance(client: LspClient): Promise<boolean> {
 	if (clients.get(client.name) === client) clients.delete(client.name);
-	if (clients.size === 0 && !idleTimeoutMs) {
-		stopIdleChecker();
-	}
+	maybeStopIdleChecker();
 
 	const err = new Error("LSP client shutdown");
 	for (const pending of Array.from(client.pendingRequests.values())) {
@@ -1517,7 +1553,10 @@ export async function shutdownClientInstance(client: LspClient): Promise<boolean
 
 	client.proc.kill();
 	const exited = await waitForExit(client, EXIT_TIMEOUT_MS);
-	if (!exited && !clients.has(client.name)) clients.set(client.name, client);
+	if (!exited && !clients.has(client.name)) {
+		clients.set(client.name, client);
+		maybeStartIdleChecker(client);
+	}
 	return exited;
 }
 

--- a/packages/coding-agent/src/lsp/config.ts
+++ b/packages/coding-agent/src/lsp/config.ts
@@ -488,6 +488,18 @@ export function loadConfig(cwd: string): LspConfig {
 	return { servers: available, idleTimeoutMs };
 }
 
+// Cache config per cwd to avoid repeated file I/O
+export const configCache = new Map<string, LspConfig>();
+
+export function getConfig(cwd: string): LspConfig {
+	let config = configCache.get(cwd);
+	if (!config) {
+		config = loadConfig(cwd);
+		configCache.set(cwd, config);
+	}
+	return config;
+}
+
 // =============================================================================
 // Server Selection
 // =============================================================================

--- a/packages/coding-agent/src/lsp/servers.ts
+++ b/packages/coding-agent/src/lsp/servers.ts
@@ -9,7 +9,6 @@ import {
 	notifySaved,
 	sendNotification,
 	sendRequest,
-	setIdleTimeout,
 	shutdownClientInstance,
 	syncContent,
 	WARMUP_TIMEOUT_MS,
@@ -17,6 +16,8 @@ import {
 import { getServersForFile, type LspConfig, loadConfig } from "./config";
 import { MUX_RESTART_METHOD } from "./mux/protocol";
 import type { LspClient, ServerConfig } from "./types";
+
+export { configCache, getConfig } from "./config";
 
 /**
  * LSP actions that do not mutate the workspace or language-server state.
@@ -75,7 +76,6 @@ export function discoverStartupLspServers(
  */
 export async function warmupLspServers(cwd: string, options?: LspWarmupOptions): Promise<LspWarmupResult> {
 	const config = loadConfig(cwd);
-	setIdleTimeout(config.idleTimeoutMs);
 	const servers: LspWarmupResult["servers"] = [];
 	const lspServers = getLspServers(config);
 
@@ -189,19 +189,6 @@ export async function notifyFileSaved(
 		}),
 	);
 	throwIfAborted(signal);
-}
-
-// Cache config per cwd to avoid repeated file I/O
-export const configCache = new Map<string, LspConfig>();
-
-export function getConfig(cwd: string): LspConfig {
-	let config = configCache.get(cwd);
-	if (!config) {
-		config = loadConfig(cwd);
-		configCache.set(cwd, config);
-	}
-	setIdleTimeout(config.idleTimeoutMs);
-	return config;
 }
 
 function isCustomLinter(serverConfig: ServerConfig): boolean {

--- a/packages/coding-agent/src/lsp/servers.ts
+++ b/packages/coding-agent/src/lsp/servers.ts
@@ -17,8 +17,6 @@ import { getServersForFile, type LspConfig, loadConfig } from "./config";
 import { MUX_RESTART_METHOD } from "./mux/protocol";
 import type { LspClient, ServerConfig } from "./types";
 
-export { configCache, getConfig } from "./config";
-
 /**
  * LSP actions that do not mutate the workspace or language-server state.
  * Anything not in this set (rename, code_actions with apply, rename_file,

--- a/packages/coding-agent/src/lsp/tool.ts
+++ b/packages/coding-agent/src/lsp/tool.ts
@@ -31,7 +31,7 @@ import {
 	waitForProjectLoaded,
 } from "./client";
 import { getLinterClient } from "./clients";
-import { getServersForFile } from "./config";
+import { configCache, getConfig, getServersForFile } from "./config";
 import {
 	BATCH_DIAGNOSTICS_WAIT_TIMEOUT_MS,
 	formatLocationWithContext,
@@ -57,8 +57,6 @@ import {
 } from "./edits";
 import { detectLspmux } from "./lspmux";
 import {
-	configCache,
-	getConfig,
 	getLspServerForFile,
 	getLspServers,
 	getLspServersForFile,

--- a/packages/coding-agent/src/lsp/tool.ts
+++ b/packages/coding-agent/src/lsp/tool.ts
@@ -24,6 +24,7 @@ import {
 	getOrCreateClient,
 	isRustAnalyzerClient,
 	type LspServerStatus,
+	reconcileIdleChecker,
 	refreshFile,
 	sendNotification,
 	sendRequest,
@@ -1093,6 +1094,7 @@ export class LspTool implements AgentTool<typeof lspSchema, LspToolDetails, Them
 			// the process lifetime (#3546).
 			configCache.delete(this.session.cwd);
 			const refreshedConfig = getConfig(this.session.cwd);
+			reconcileIdleChecker();
 			const servers = getLspServers(refreshedConfig);
 			// Identity-aware client keys make a changed server resolve to a fresh
 			// client below, but the process spawned from the superseded config

--- a/packages/coding-agent/src/lsp/writethrough.ts
+++ b/packages/coding-agent/src/lsp/writethrough.ts
@@ -3,7 +3,7 @@ import { isEnoent, logger, once, untilAborted } from "@oh-my-pi/pi-utils";
 import type { BunFile } from "bun";
 import { isPermissionDeniedError, writeFileWithFallback } from "../tools/file-write-fallback";
 import { FileChangeType, notifyWorkspaceWatchedFiles } from "./client";
-import { getServersForFile } from "./config";
+import { getConfig, getServersForFile } from "./config";
 import {
 	captureDiagnosticVersions,
 	captureOpenFileVersions,
@@ -16,7 +16,7 @@ import {
 	limitDiagnosticMessages,
 	type ServerVersionMap,
 } from "./diagnostics";
-import { getConfig, notifyFileSaved, splitServers, syncFileContent } from "./servers";
+import { notifyFileSaved, splitServers, syncFileContent } from "./servers";
 import type { ServerConfig } from "./types";
 import { summarizeDiagnosticMessages } from "./utils";
 

--- a/packages/coding-agent/test/tools/lsp-regressions.test.ts
+++ b/packages/coding-agent/test/tools/lsp-regressions.test.ts
@@ -530,21 +530,90 @@ describe("lsp regressions", () => {
 		}
 	});
 
-	it("rearms the idle checker from cached config after global shutdown", async () => {
-		const cwd = "/cached-lsp-config";
+	it("rearms the idle checker when starting a client after global shutdown without clobbering other workspaces (#8389)", async () => {
+		const tempDir = TempDir.createSync("@omp-lsp-rearm-");
 		const intervalSpy = vi.spyOn(globalThis, "setInterval");
-		configCache.set(cwd, { servers: {}, idleTimeoutMs: 60_000 });
+		const config: ServerConfig = {
+			command: "fake-lsp-rearm",
+			fileTypes: ["ts"],
+			rootMarkers: [],
+		};
 		try {
+			installFakeLsp((message, srv) => {
+				if (message.method === "initialize") {
+					srv.send({ jsonrpc: "2.0", id: message.id, result: { capabilities: {} } });
+				} else if (message.method === "shutdown") {
+					srv.send({ jsonrpc: "2.0", id: message.id, result: null });
+				} else if (message.method === "exit") {
+					srv.exit(0);
+				}
+			});
+
 			lspClient.setIdleTimeout(60_000);
-			expect(intervalSpy).toHaveBeenCalledTimes(1);
+			const initialCalls = intervalSpy.mock.calls.length;
+			expect(initialCalls).toBeGreaterThanOrEqual(1);
 
 			await lspClient.shutdownAll();
-			getConfig(cwd);
 
-			expect(intervalSpy).toHaveBeenCalledTimes(2);
+			// Pure config access should not mutate global timeout or spawn timers (#8389)
+			configCache.set(tempDir.path(), { servers: { "fake-lsp-rearm": config }, idleTimeoutMs: 60_000 });
+			getConfig(tempDir.path());
+			expect(intervalSpy).toHaveBeenCalledTimes(initialCalls);
+
+			// Starting an active client rearms the checker
+			await lspClient.getOrCreateClient(config, tempDir.path(), 1_000);
+			expect(intervalSpy).toHaveBeenCalledTimes(initialCalls + 1);
 		} finally {
 			lspClient.setIdleTimeout(null);
-			configCache.delete(cwd);
+			configCache.delete(tempDir.path());
+			await lspClient.shutdownAll();
+			tempDir.removeSync();
+		}
+	});
+
+	it("isolates idle timeout per workspace client without global cross-contamination (#8389)", async () => {
+		const tempDirA = TempDir.createSync("@omp-lsp-iso-a-");
+		const tempDirB = TempDir.createSync("@omp-lsp-iso-b-");
+		const configA: ServerConfig = {
+			command: "fake-lsp-iso-a",
+			fileTypes: ["ts"],
+			rootMarkers: [],
+		};
+		const configB: ServerConfig = {
+			command: "fake-lsp-iso-b",
+			fileTypes: ["ts"],
+			rootMarkers: [],
+		};
+
+		try {
+			configCache.set(tempDirA.path(), { servers: { [configA.command]: configA }, idleTimeoutMs: 600_000 }); // 10 min
+			configCache.set(tempDirB.path(), { servers: { [configB.command]: configB }, idleTimeoutMs: 1_000 }); // 1 sec
+
+			installHandshakeLsp();
+			const clientA = await lspClient.getOrCreateClient(configA, tempDirA.path(), 1_000);
+
+			installHandshakeLsp();
+			const clientB = await lspClient.getOrCreateClient(configB, tempDirB.path(), 1_000);
+
+			// Client A was active 2 seconds ago
+			clientA.lastActivity = Date.now() - 2_000;
+			clientB.lastActivity = Date.now() - 2_000;
+
+			// Accessing Workspace B's config should not affect client A's idle evaluation
+			getConfig(tempDirB.path());
+
+			const now = Date.now();
+			const timeoutA = getConfig(clientA.cwd).idleTimeoutMs!;
+			const timeoutB = getConfig(clientB.cwd).idleTimeoutMs!;
+
+			expect(lspClient.isIdleClient(clientA, now, timeoutA)).toBe(false);
+			expect(lspClient.isIdleClient(clientB, now, timeoutB)).toBe(true);
+		} finally {
+			configCache.delete(tempDirA.path());
+			configCache.delete(tempDirB.path());
+			await lspClient.shutdownAll();
+			tempDirA.removeSync();
+			tempDirB.removeSync();
 		}
 	});
 

--- a/packages/coding-agent/test/tools/lsp-regressions.test.ts
+++ b/packages/coding-agent/test/tools/lsp-regressions.test.ts
@@ -622,6 +622,52 @@ describe("lsp regressions", () => {
 		}
 	});
 
+	it("re-arms the idle checker after a config-only reload when timeout is added (#8389)", async () => {
+		const tempDir = TempDir.createSync("@omp-lsp-rearm-config-");
+		const config: ServerConfig = {
+			command: "fake-lsp-rearm-config",
+			fileTypes: ["ts"],
+			rootMarkers: [],
+		};
+
+		try {
+			// Initially no timeout configured: checker interval should remain stopped
+			configCache.set(tempDir.path(), { servers: { [config.command]: config } });
+			installHandshakeLsp();
+			const client = await lspClient.getOrCreateClient(config, tempDir.path(), 1_000);
+
+			expect(lspClient.isIdleCheckerRunning()).toBe(false);
+
+			// Config-only change: user adds idleTimeoutMs to config
+			configCache.delete(tempDir.path());
+			configCache.set(tempDir.path(), { servers: { [config.command]: config }, idleTimeoutMs: 5_000 });
+
+			// Simulate config reload (as done in `lsp reload *`)
+			getConfig(tempDir.path());
+			lspClient.reconcileIdleChecker();
+
+			// Checker must now be re-armed even though client identity is unchanged
+			expect(lspClient.isIdleCheckerRunning()).toBe(true);
+
+			// Client becomes idle and is reaped on sweep
+			client.lastActivity = Date.now() - 6_000;
+			await lspClient.checkIdleClients();
+			expect(lspClient.getActiveClients().map(c => c.name)).not.toContain("fake-lsp-rearm-config");
+
+			// Removing timeout and reloading stops the checker again
+			configCache.delete(tempDir.path());
+			configCache.set(tempDir.path(), { servers: { [config.command]: config } });
+			getConfig(tempDir.path());
+			lspClient.reconcileIdleChecker();
+			expect(lspClient.isIdleCheckerRunning()).toBe(false);
+		} finally {
+			lspClient.setIdleTimeout(null);
+			configCache.delete(tempDir.path());
+			await lspClient.shutdownAll();
+			tempDir.removeSync();
+		}
+	});
+
 	it("returns an already-starting client without creating a second client", async () => {
 		const tempDir = TempDir.createSync("@omp-lsp-pending-client-");
 		const initialize = Promise.withResolvers<void>();

--- a/packages/coding-agent/test/tools/lsp-regressions.test.ts
+++ b/packages/coding-agent/test/tools/lsp-regressions.test.ts
@@ -595,19 +595,19 @@ describe("lsp regressions", () => {
 			installHandshakeLsp();
 			const clientB = await lspClient.getOrCreateClient(configB, tempDirB.path(), 1_000);
 
-			// Client A was active 2 seconds ago
-			clientA.lastActivity = Date.now() - 2_000;
+			// Client A was active just now, Client B was active 2 seconds ago
+			clientA.lastActivity = Date.now();
 			clientB.lastActivity = Date.now() - 2_000;
 
-			// Accessing Workspace B's config should not affect client A's idle evaluation
+			// Accessing Workspace B's config should not affect client A
 			getConfig(tempDirB.path());
 
-			const now = Date.now();
-			const timeoutA = getConfig(clientA.cwd).idleTimeoutMs!;
-			const timeoutB = getConfig(clientB.cwd).idleTimeoutMs!;
+			// Drive the production idle sweep path end-to-end
+			await lspClient.checkIdleClients();
 
-			expect(lspClient.isIdleClient(clientA, now, timeoutA)).toBe(false);
-			expect(lspClient.isIdleClient(clientB, now, timeoutB)).toBe(true);
+			const activeNames = lspClient.getActiveClients().map(c => c.name);
+			expect(activeNames).toContain("fake-lsp-iso-a");
+			expect(activeNames).not.toContain("fake-lsp-iso-b");
 		} finally {
 			configCache.delete(tempDirA.path());
 			configCache.delete(tempDirB.path());

--- a/packages/coding-agent/test/tools/lsp-regressions.test.ts
+++ b/packages/coding-agent/test/tools/lsp-regressions.test.ts
@@ -10,7 +10,13 @@ import { preloadPluginRoots } from "@oh-my-pi/pi-coding-agent/discovery/helpers"
 import { LspTool } from "@oh-my-pi/pi-coding-agent/lsp";
 import * as lspClient from "@oh-my-pi/pi-coding-agent/lsp/client";
 import * as lspConfig from "@oh-my-pi/pi-coding-agent/lsp/config";
-import { getServersForFile, type LspConfig, loadConfig } from "@oh-my-pi/pi-coding-agent/lsp/config";
+import {
+	configCache,
+	getConfig,
+	getServersForFile,
+	type LspConfig,
+	loadConfig,
+} from "@oh-my-pi/pi-coding-agent/lsp/config";
 import { waitForDiagnostics } from "@oh-my-pi/pi-coding-agent/lsp/diagnostics";
 import {
 	applyTextEditsToString,
@@ -19,7 +25,6 @@ import {
 	sortAndValidateTextEdits,
 } from "@oh-my-pi/pi-coding-agent/lsp/edits";
 import { renderCall, renderResult } from "@oh-my-pi/pi-coding-agent/lsp/render";
-import { configCache, getConfig } from "@oh-my-pi/pi-coding-agent/lsp/servers";
 import {
 	type CodeAction,
 	type CreateFile,


### PR DESCRIPTION
## What

- Removed global `setIdleTimeout()` side-effects from `getConfig(cwd)` and `warmupLspServers(cwd)`.
- Moved `configCache` and `getConfig(cwd)` into `packages/coding-agent/src/lsp/config.ts` as pure functions without timer mutations.
- Updated `startIdleChecker()` in `packages/coding-agent/src/lsp/client.ts` so each client is evaluated against its workspace timeout (`getConfig(client.cwd).idleTimeoutMs`), with `idleTimeoutMs` retained as an optional fallback for test suites.
- Tied the background checker interval lifecycle to active client registration in `getOrCreateClient` and teardown in `shutdownClientInstance` / `shutdownAll`.
- Added multi-workspace timeout isolation regression tests in `lsp-regressions.test.ts`.

## Why

Fixes #8389.

In multi-workspace environments, `getConfig(cwd)` and `warmupLspServers(cwd)` mutated a single global `idleTimeoutMs` variable. Accessing config for a workspace with a short timeout (e.g. 1s) immediately lowered the threshold for clients in other workspaces (e.g. 10m), causing them to be reaped on the next sweep. Additionally, pure config access spawned an unmanaged `setInterval` holding the event loop open.

## Testing

- [x] `bun check` passes (`biome` lint/format + `tsgo` typecheck across all workspace packages)
- [x] Tested locally:
  - `bun test packages/coding-agent/test/tools/lsp-regressions.test.ts` (147/147 pass)
  - Regression test `isolates idle timeout per workspace client without global cross-contamination (#8389)` verifies Workspace A clients remain active when Workspace B config is accessed
- [x] CHANGELOG updated (if user-facing)

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
