### PR TITLE
test(browser): gate visible tab-worker test on display and keep headful browser alive

### DIFF
--- a/packages/coding-agent/test/tools/browser-tab-worker-startup.test.ts
+++ b/packages/coding-agent/test/tools/browser-tab-worker-startup.test.ts
@@ -15,9 +15,10 @@ import {
 	initializeTabWorkerForTest,
 	releaseTab,
 } from "@oh-my-pi/pi-coding-agent/tools/browser/tab-supervisor";
-import { chromiumAvailable } from "./chromium-probe";
+import { chromiumAvailable, visibleBrowserAvailable } from "./chromium-probe";
 
 const CHROMIUM_AVAILABLE = await chromiumAvailable();
+const VISIBLE_BROWSER_AVAILABLE = await visibleBrowserAvailable();
 
 class FakeStartupWorker {
 	#errorHandlers = new Set<(error: Error) => void>();
@@ -217,7 +218,7 @@ describe("browser init deadline carry-over", () => {
 	);
 });
 describe("visible OMP-owned browser tabs", () => {
-	it.skipIf(!CHROMIUM_AVAILABLE)(
+	it.skipIf(!VISIBLE_BROWSER_AVAILABLE)(
 		"creates independent pages without pinning the resizable window viewport",
 		async () => {
 			let browser: BrowserHandle | undefined;
@@ -225,16 +226,23 @@ describe("visible OMP-owned browser tabs", () => {
 			try {
 				browser = await acquireBrowser({ kind: "headless", headless: false }, { cwd: process.cwd() });
 				if (!("browser" in browser)) throw new Error("Expected a Puppeteer browser");
-				// Shared broker launches use --no-startup-window. Mirror that empty
-				// target set even though bun tests use the process-local launcher.
-				for (const page of await browser.browser.pages()) await page.close();
-				expect(await browser.browser.pages()).toHaveLength(0);
+				// Shared broker launches use --no-startup-window, so a broker-backed
+				// visible browser starts with no pages. The process-local test launcher
+				// instead opens a startup window, and closing the last page of a headful
+				// Chromium quits the process — which would kill the CDP endpoint before
+				// acquireTab connects. So acquire the first OMP-owned page first, then
+				// drop the startup pages, so the browser never falls to zero windows
+				// while still ending with only OMP-owned pages.
+				const startupPages = await browser.browser.pages();
 
 				const firstName = `visible-owned-a-${process.pid}-${Math.random().toString(36).slice(2)}`;
 				const firstUrl = `data:text/html,<title>${firstName}</title><main>first</main>`;
 				const first = await acquireTab(firstName, browser, { url: firstUrl, timeoutMs: 30_000 });
 				names.push(firstName);
-				const firstPage = (await browser.browser.pages()).find(page => page.url() === firstUrl);
+				for (const page of startupPages) await page.close();
+				const remaining = await browser.browser.pages();
+				expect(remaining.map(page => page.url())).toEqual([firstUrl]);
+				const firstPage = remaining.find(page => page.url() === firstUrl);
 				if (!firstPage) throw new Error("Expected the first managed page");
 
 				const before = await firstPage.evaluate(() => ({ width: innerWidth, height: innerHeight }));

--- a/packages/coding-agent/test/tools/chromium-probe.ts
+++ b/packages/coding-agent/test/tools/chromium-probe.ts
@@ -48,3 +48,17 @@ export function chromiumAvailable(): Promise<boolean> {
 	probe ??= chromiumCanLaunch();
 	return probe;
 }
+
+/**
+ * Gate for tests that launch a *visible* (headful) Chromium. A headful launch
+ * on Linux needs an X or Wayland display; `chromiumAvailable()` only proves the
+ * binary executes (`chrome --version` succeeds with no display), so a visible
+ * suite gated on it alone runs and then dies with "Missing X server or
+ * $DISPLAY" on displayless CI (GH-hosted ubuntu-22.04 PR runners). macOS and
+ * Windows headful launches do not need X, so only Linux is display-gated.
+ */
+export async function visibleBrowserAvailable(): Promise<boolean> {
+	if (!(await chromiumAvailable())) return false;
+	if (process.platform !== "linux") return true;
+	return Boolean(process.env.DISPLAY || process.env.WAYLAND_DISPLAY);
+}


### PR DESCRIPTION
## Repro
The `browser tab worker startup` suite test "creates independent pages without pinning the resizable window viewport" (`packages/coding-agent/test/tools/browser-tab-worker-startup.test.ts`) fails deterministically in two environments. (a) On GH-hosted ubuntu-22.04 PR runners there is no X server, yet the suite gate `chromiumAvailable()` (`test/tools/chromium-probe.ts`) only probes `chrome --version`, which exits 0 with no display, so the headful (`headless:false`) launch path is entered and `puppeteer.launch` throws `Missing X server or $DISPLAY`. (b) With a display present, the test closes every page to mirror the broker's `--no-startup-window` target set; a headful Chromium quits when its last window closes, so the following `acquireTab` worker connect fails with `connect ECONNREFUSED`. Reproduced with `PUPPETEER_EXECUTABLE_PATH=<--version-capable exe> bun -e 'import {chromiumAvailable} from "./test/tools/chromium-probe"; console.log(await chromiumAvailable())'` returning `true` on Linux with `DISPLAY`/`WAYLAND_DISPLAY` unset.

## Cause
The visible test is gated only on `CHROMIUM_AVAILABLE`, which is display-blind — `chromiumCanLaunch()` in `chromium-probe.ts` runs `chrome --version` and never checks for a display. Separately, the process-local headful launcher omits `--no-startup-window` (`buildHeadlessLaunchArgs`, `src/tools/browser/launch.ts:436-458`), so Chromium opens a startup window; the test's close-all-pages step (formerly line 230) then quits the headful process, so `browser.connected` is false when the worker's `puppeteer.connect` (`src/tools/browser/tab-worker.ts:1077`) runs.

## Fix
- Add `visibleBrowserAvailable()` to `test/tools/chromium-probe.ts`: requires `chromiumAvailable()` and, on Linux, a `DISPLAY` or `WAYLAND_DISPLAY` (macOS/Windows headful need no X). Gate the visible test with `it.skipIf(!VISIBLE_BROWSER_AVAILABLE)`; the hidden (`headless:true`) test keeps the plain `CHROMIUM_AVAILABLE` gate.
- Restructure the visible test so it acquires the first OMP-owned page before closing the startup pages, so a headful browser never falls to zero windows; it then asserts only the owned page remains (`toEqual([firstUrl])`), preserving the original "OMP-owned pages only" intent.

## Verification
`bun test test/tools/browser-tab-worker-startup.test.ts` → 6 pass, 3 skip, 0 fail (visible test skips here: displayless Linux). Gate logic verified deterministically: `visibleBrowserAvailable()` returns `false` on Linux with no display, `true` with `DISPLAY=:0` or `WAYLAND_DISPLAY=wayland-0`. Pre-publish `bun run fix` + `bun check` passed. Fixes #10238