### PR TITLE
fix(mnemopi): preserve fts recall during embed failures

### DIFF
--- a/packages/mnemopi/CHANGELOG.md
+++ b/packages/mnemopi/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed concurrent recall calls leaking local embedding initialization failures instead of degrading to FTS-only recall ([#10241](https://github.com/can1357/oh-my-pi/issues/10241)).
+
 ## [18.0.11] - 2026-08-29
 
 ### Fixed

--- a/packages/mnemopi/src/core/embeddings.ts
+++ b/packages/mnemopi/src/core/embeddings.ts
@@ -51,7 +51,7 @@ export type LocalModelInitializer = (options: LocalModelInitOptions) => Promise<
 const QUERY_CACHE_MAX = 512;
 
 let providerOverride: EmbeddingProvider | null = null;
-let localModelPromise: Promise<LocalEmbeddingModel> | null = null;
+let localModelPromise: Promise<LocalEmbeddingModel | null> | null = null;
 let localModelInitializer: LocalModelInitializer = defaultLocalModelInitializer;
 let apiCallCount = 0;
 const queryCache = new LRUCache<string, Vector>({ max: QUERY_CACHE_MAX });
@@ -410,18 +410,16 @@ async function getLocalModel(): Promise<LocalEmbeddingModel | null> {
 		model: modelName,
 		cacheDir,
 		showDownloadProgress: false,
-	});
-	localModelPromise = loading;
-	try {
-		return await loading;
-	} catch (error) {
+	}).catch(error => {
 		logger[mnemopiDebugEnabled() ? "warn" : "debug"]("mnemopi: local embedding model failed to load", {
 			model: modelName,
 			error: String(error),
 		});
-		if (localModelPromise === loading) localModelPromise = null;
+		localModelPromise = null;
 		return null;
-	}
+	});
+	localModelPromise = loading;
+	return loading;
 }
 
 async function embedApi(texts: readonly string[]): Promise<EmbeddingMatrix | null> {

--- a/packages/mnemopi/src/core/embeddings.ts
+++ b/packages/mnemopi/src/core/embeddings.ts
@@ -406,7 +406,8 @@ async function getLocalModel(): Promise<LocalEmbeddingModel | null> {
 	}
 	const cacheDir = getFastembedCacheDir();
 	mkdirSync(cacheDir, { recursive: true });
-	const loading = localModelInitializer({
+	let loading: Promise<LocalEmbeddingModel | null>;
+	loading = localModelInitializer({
 		model: modelName,
 		cacheDir,
 		showDownloadProgress: false,
@@ -415,7 +416,7 @@ async function getLocalModel(): Promise<LocalEmbeddingModel | null> {
 			model: modelName,
 			error: String(error),
 		});
-		localModelPromise = null;
+		if (localModelPromise === loading) localModelPromise = null;
 		return null;
 	});
 	localModelPromise = loading;

--- a/packages/mnemopi/test/optional-embeddings.test.ts
+++ b/packages/mnemopi/test/optional-embeddings.test.ts
@@ -215,7 +215,7 @@ describe("optional embeddings", () => {
 		}
 	});
 
-	it("retries local model initialization after a transient failure", async () => {
+	it("returns null to every caller sharing a failed local model initialization, then retries", async () => {
 		await withEnv(
 			{
 				NODE_ENV: undefined,
@@ -229,17 +229,27 @@ describe("optional embeddings", () => {
 			},
 			async () => {
 				let initCalls = 0;
+				const unavailable = Promise.withResolvers<never>();
+				const initializationStarted = Promise.withResolvers<void>();
 				const observedCacheDirs: Array<string | undefined> = [];
 				setLocalModelInitializerForTests(async options => {
 					initCalls += 1;
 					observedCacheDirs.push(options.cacheDir);
-					if (initCalls === 1) throw new Error("transient init failure");
+					if (initCalls === 1) {
+						initializationStarted.resolve();
+						return unavailable.promise;
+					}
 					return {
 						embed: streamRows(texts => texts.map(text => [text.length, text.charCodeAt(0) || 0])),
 					};
 				});
 
-				expect(await embed(["first"])).toBeNull();
+				const first = embed(["first"]);
+				await initializationStarted.promise;
+				const waiter = embed(["same initialization"]);
+				unavailable.reject(new Error("mnemopi embed subprocess unavailable"));
+
+				expect(await Promise.all([first, waiter])).toEqual([null, null]);
 				expect(await embed(["second"])).toEqual([new Float32Array([6, 115])]);
 				expect(initCalls).toBe(2);
 				expect(observedCacheDirs).toEqual([getFastembedCacheDir(), getFastembedCacheDir()]);

--- a/packages/mnemopi/test/optional-embeddings.test.ts
+++ b/packages/mnemopi/test/optional-embeddings.test.ts
@@ -70,6 +70,22 @@ async function withEnv<T>(updates: Partial<Record<EnvKey, string | undefined>>, 
 	}
 }
 
+function withLocalEmbeddingEnv<T>(fn: () => Promise<T> | T): Promise<T> {
+	return withEnv(
+		{
+			NODE_ENV: undefined,
+			BUN_ENV: undefined,
+			MNEMOPI_NO_EMBEDDINGS: undefined,
+			MNEMOPI_EMBEDDING_MODEL: "BAAI/bge-small-en-v1.5",
+			MNEMOPI_EMBEDDING_API_URL: undefined,
+			OPENROUTER_BASE_URL: undefined,
+			OPENROUTER_API_KEY: undefined,
+			OPENAI_API_KEY: undefined,
+		},
+		fn,
+	);
+}
+
 afterEach(() => {
 	resetEmbeddingProviderForTests();
 });
@@ -216,45 +232,61 @@ describe("optional embeddings", () => {
 	});
 
 	it("returns null to every caller sharing a failed local model initialization, then retries", async () => {
-		await withEnv(
-			{
-				NODE_ENV: undefined,
-				BUN_ENV: undefined,
-				MNEMOPI_NO_EMBEDDINGS: undefined,
-				MNEMOPI_EMBEDDING_MODEL: "BAAI/bge-small-en-v1.5",
-				MNEMOPI_EMBEDDING_API_URL: undefined,
-				OPENROUTER_BASE_URL: undefined,
-				OPENROUTER_API_KEY: undefined,
-				OPENAI_API_KEY: undefined,
-			},
-			async () => {
-				let initCalls = 0;
-				const unavailable = Promise.withResolvers<never>();
-				const initializationStarted = Promise.withResolvers<void>();
-				const observedCacheDirs: Array<string | undefined> = [];
-				setLocalModelInitializerForTests(async options => {
-					initCalls += 1;
-					observedCacheDirs.push(options.cacheDir);
-					if (initCalls === 1) {
-						initializationStarted.resolve();
-						return unavailable.promise;
-					}
-					return {
-						embed: streamRows(texts => texts.map(text => [text.length, text.charCodeAt(0) || 0])),
-					};
-				});
+		await withLocalEmbeddingEnv(async () => {
+			let initCalls = 0;
+			const unavailable = Promise.withResolvers<never>();
+			const initializationStarted = Promise.withResolvers<void>();
+			const observedCacheDirs: Array<string | undefined> = [];
+			setLocalModelInitializerForTests(async options => {
+				initCalls += 1;
+				observedCacheDirs.push(options.cacheDir);
+				if (initCalls === 1) {
+					initializationStarted.resolve();
+					return unavailable.promise;
+				}
+				return {
+					embed: streamRows(texts => texts.map(text => [text.length, text.charCodeAt(0) || 0])),
+				};
+			});
 
-				const first = embed(["first"]);
-				await initializationStarted.promise;
-				const waiter = embed(["same initialization"]);
-				unavailable.reject(new Error("mnemopi embed subprocess unavailable"));
+			const first = embed(["first"]);
+			await initializationStarted.promise;
+			const waiter = embed(["same initialization"]);
+			unavailable.reject(new Error("mnemopi embed subprocess unavailable"));
 
-				expect(await Promise.all([first, waiter])).toEqual([null, null]);
-				expect(await embed(["second"])).toEqual([new Float32Array([6, 115])]);
-				expect(initCalls).toBe(2);
-				expect(observedCacheDirs).toEqual([getFastembedCacheDir(), getFastembedCacheDir()]);
-				expect(observedCacheDirs.some(cacheDir => cacheDir?.includes(".hermes") ?? false)).toBe(false);
-			},
-		);
+			expect(await Promise.all([first, waiter])).toEqual([null, null]);
+			expect(await embed(["second"])).toEqual([new Float32Array([6, 115])]);
+			expect(initCalls).toBe(2);
+			expect(observedCacheDirs).toEqual([getFastembedCacheDir(), getFastembedCacheDir()]);
+			expect(observedCacheDirs.some(cacheDir => cacheDir?.includes(".hermes") ?? false)).toBe(false);
+		});
+	});
+
+	it("keeps a replacement local model cached when a stale initialization fails", async () => {
+		await withLocalEmbeddingEnv(async () => {
+			const stale = Promise.withResolvers<never>();
+			const staleStarted = Promise.withResolvers<void>();
+			setLocalModelInitializerForTests(() => {
+				staleStarted.resolve();
+				return stale.promise;
+			});
+
+			const staleEmbed = embed(["stale"]);
+			await staleStarted.promise;
+
+			let replacementInitCalls = 0;
+			setLocalModelInitializerForTests(async () => {
+				replacementInitCalls += 1;
+				return {
+					embed: streamRows(texts => texts.map(text => [text.length])),
+				};
+			});
+			expect(await embed(["replacement"])).toEqual([new Float32Array([11])]);
+
+			stale.reject(new Error("stale initialization failed"));
+			expect(await staleEmbed).toBeNull();
+			expect(await embed(["cached"])).toEqual([new Float32Array([6])]);
+			expect(replacementInitCalls).toBe(1);
+		});
 	});
 });


### PR DESCRIPTION
## Repro
A deferred local-model initializer shared by two concurrent `embed()` calls reproduces the auto-recall race: before this change, `bun .tmp-mnemopi-auto-recall-repro.ts` produced one fulfilled `null` result and one rejection with `mnemopi embed subprocess unavailable`. The permanent regression case is in `packages/mnemopi/test/optional-embeddings.test.ts` and runs with `HOME=/tmp/omp-test-home bun test packages/mnemopi/test/optional-embeddings.test.ts`.

## Cause
`getLocalModel()` in `packages/mnemopi/src/core/embeddings.ts` stored the raw initializer promise in `localModelPromise`, but caught rejection only around the first caller's local `await`. Concurrent callers returned the raw shared promise directly, so only the initializer owner converted failure to `null`; a waiting auto-recall received the rejection and aborted before FTS candidate collection.

## Fix
- Store the caught, nullable initializer promise so every concurrent caller receives the same FTS-only fallback result.
- Clear the shared promise after failure so later calls can retry initialization.
- Extend the transient-initialization regression test to cover concurrent waiters and the subsequent successful retry.
- Document the user-visible fix in the mnemopi changelog.

## Verification
`HOME=/tmp/omp-test-home bun test packages/mnemopi/test/optional-embeddings.test.ts` passes: 8 tests, 0 failures. Re-running the concurrency probe returns two fulfilled `null` results. The publish gate also passed `bun run fix` and `bun check`.

Fixes #10241