### PR TITLE
fix(rpc): answer skill prompts and abort before the pipeline

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,11 @@
 - Devin model selectors now accept the native CLI's short aliases (`devin/opus`, `devin/swe`), dotted upstream spellings (`devin/gemini-3.7-flash`), and raw effort-route wire uids for dynamically collapsed families ([#8590](https://github.com/can1357/oh-my-pi/pull/8590) by [@will-bogusz](https://github.com/will-bogusz)).
 - Added provider-supplied model metadata to the `/models` detail line: `new`, `beta`, and `recommended` badges beside the model name, and the upstream description after the context, cost, and perf facts ([#8590](https://github.com/can1357/oh-my-pi/pull/8590) by [@will-bogusz](https://github.com/will-bogusz)).
 
+
+### Fixed
+
+- Fixed RPC `prompt` responses for `/skill:*` commands arriving only after the entire prompt-dispatch pipeline finished (usage preflight, compaction, provider calls): under provider stress that outlasts any client prompt timeout, so hosts reported the prompt as rejected while the turn was in fact running. The skill branch now builds the skill prompt eagerly (preserving the immediate error for an unreadable skill file) and dispatches the expensive pipeline asynchronously after answering, matching plain prompts; when the dispatch is cancelled before a turn starts (e.g. an abort overtakes usage preflight), the session now reports it through the non-invoked  completion frame instead of leaving hosts waiting for an  that never comes ([#10249](https://github.com/can1357/oh-my-pi/pull/10249) by [@cwr250](https://github.com/cwr250)).
+
 ## [18.0.11] - 2026-08-29
 
 ### Added

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -23,7 +23,12 @@ import {
 	type ExtensionWidgetOptions,
 	getExtensionUISelectOptionLabel,
 } from "../../extensibility/extensions";
-import { buildSkillPromptMessage, parseSkillInvocation } from "../../extensibility/skills";
+import {
+	type BuiltSkillPromptMessage,
+	buildSkillPromptMessage,
+	parseSkillInvocation,
+	type Skill,
+} from "../../extensibility/skills";
 import { loadSlashCommands } from "../../extensibility/slash-commands";
 import { type Theme, theme } from "../../modes/theme/theme";
 import type { AgentSession } from "../../session/agent-session";
@@ -115,18 +120,40 @@ export type RpcSessionChangeSession = Pick<AgentSession, "newSession" | "switchS
 export type RpcSkillCommandSession = Pick<AgentSession, "promptCustomMessage" | "skills" | "skillsSettings">;
 export type RpcSkillCommandResult = { agentInvoked: true };
 
-export async function tryRunRpcSkillCommand(
-	session: RpcSkillCommandSession,
-	text: string,
-	streamingBehavior: "steer" | "followUp" = "steer",
-): Promise<RpcSkillCommandResult | false> {
-	if (!session.skillsSettings?.enableSkillCommands) return false;
+export interface RpcSkillInvocation {
+	skill: Skill;
+	args: string;
+}
+
+/**
+ * Fast in-memory pre-check for a skill invocation: settings gate, text shape,
+ * and skill lookup. Returns null when the message is not a runnable skill
+ * command. Performs no I/O — safe to run on the RPC serial queue.
+ */
+export function resolveRpcSkillInvocation(session: RpcSkillCommandSession, text: string): RpcSkillInvocation | null {
+	if (!session.skillsSettings?.enableSkillCommands) return null;
 	const parsed = parseSkillInvocation(text);
-	if (!parsed) return false;
+	if (!parsed) return null;
 	const skill = session.skills.find(candidate => candidate.name === parsed.name);
-	if (!skill) return false;
-	const built = await buildSkillPromptMessage(skill, parsed.args, "user");
-	await session.promptCustomMessage(
+	if (!skill) return null;
+	return { skill, args: parsed.args };
+}
+
+/**
+ * Slow half of a skill invocation: builds the skill prompt message (file I/O)
+ * and dispatches it through the full prompt pipeline (usage preflight,
+ * compaction checks, provider calls). Resolves once the turn is scheduled.
+ * Must not run on the RPC serial queue's response path — register it with
+ * watchAndReportLocalOnlyPromptResult and answer the command first.
+ */
+export async function runRpcSkillCommand(
+	session: RpcSkillCommandSession,
+	invocation: RpcSkillInvocation,
+	streamingBehavior: "steer" | "followUp" = "steer",
+	prebuilt?: BuiltSkillPromptMessage,
+): Promise<boolean> {
+	const built = prebuilt ?? (await buildSkillPromptMessage(invocation.skill, invocation.args, "user"));
+	return session.promptCustomMessage(
 		{
 			customType: SKILL_PROMPT_MESSAGE_TYPE,
 			content: built.message,
@@ -136,6 +163,51 @@ export async function tryRunRpcSkillCommand(
 		},
 		{ streamingBehavior },
 	);
+}
+
+/**
+ * Skill branch of the `prompt` command: resolves the invocation cheaply, then
+ * registers the slow dispatch with watchAndReportLocalOnlyPromptResult and
+ * returns immediately. The caller answers the command right away — building
+ * the skill prompt and running the prompt pipeline (usage preflight,
+ * compaction, provider calls) can outlast any client's prompt timeout under
+ * provider stress; the plain-prompt path responds first for the same reason.
+ */
+export async function dispatchRpcSkillPrompt(input: {
+	id: string | undefined;
+	session: RpcSkillCommandSession;
+	message: string;
+	streamingBehavior: "steer" | "followUp" | undefined;
+	output: (obj: object) => void;
+	onError: (error: Error) => void;
+	extensionUserMessageTracker: RpcExtensionUserMessageTracker;
+}): Promise<RpcSkillCommandResult | null> {
+	const invocation = resolveRpcSkillInvocation(input.session, input.message);
+	if (!invocation) return null;
+	// buildSkillPromptMessage is cheap file I/O and covers the failure the old
+	// synchronous path reported immediately (a removed or unreadable SKILL.md);
+	// keep that error contract by awaiting it before answering. The expensive
+	// promptCustomMessage pipeline (usage preflight, compaction, provider
+	// calls) is what moves behind the acknowledgement.
+	const built = await buildSkillPromptMessage(invocation.skill, invocation.args, "user");
+	watchAndReportLocalOnlyPromptResult({
+		id: input.id,
+		startPrompt: () => runRpcSkillCommand(input.session, invocation, input.streamingBehavior ?? "steer", built),
+		output: input.output,
+		onError: input.onError,
+		extensionUserMessageTracker: input.extensionUserMessageTracker,
+	});
+	return { agentInvoked: true };
+}
+
+export async function tryRunRpcSkillCommand(
+	session: RpcSkillCommandSession,
+	text: string,
+	streamingBehavior: "steer" | "followUp" = "steer",
+): Promise<RpcSkillCommandResult | false> {
+	const invocation = resolveRpcSkillInvocation(session, text);
+	if (!invocation) return false;
+	await runRpcSkillCommand(session, invocation, streamingBehavior);
 	return { agentInvoked: true };
 }
 
@@ -1018,7 +1090,15 @@ export async function runRpcMode(
 			// =================================================================
 
 			case "prompt": {
-				const skillResult = await tryRunRpcSkillCommand(session, command.message, command.streamingBehavior);
+				const skillResult = await dispatchRpcSkillPrompt({
+					id,
+					session,
+					message: command.message,
+					streamingBehavior: command.streamingBehavior,
+					output,
+					onError: promptError => output(error(id, "prompt", promptError.message)),
+					extensionUserMessageTracker,
+				});
 				if (skillResult) {
 					return success(id, "prompt", skillResult);
 				}

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -5870,13 +5870,20 @@ export class AgentSession {
 		return true;
 	}
 
+	/**
+	 * @returns true when the message is (or will be) picked up by an agent turn
+	 * — queued into a running turn, or a new turn started synchronously. false
+	 * when dispatch bailed before invoking the agent (e.g. a concurrent abort
+	 * won the generation race), so hosts waiting on a terminal `agent_end` can
+	 * stop instead of hanging.
+	 */
 	async promptCustomMessage<T = unknown>(
 		message: Pick<CustomMessage<T>, "customType" | "content" | "display" | "details" | "attribution">,
 		options?: Pick<PromptOptions, "streamingBehavior" | "toolChoice"> & {
 			queueChipText?: string;
 			queueOnly?: boolean;
 		},
-	): Promise<void> {
+	): Promise<boolean> {
 		const textContent =
 			typeof message.content === "string"
 				? message.content
@@ -5912,7 +5919,7 @@ export class AgentSession {
 				await this.#queueCustomMessage(notice, streamingBehavior);
 			}
 			await this.#queueCustomMessage(message, streamingBehavior, options.queueChipText);
-			return;
+			return true;
 		}
 		if (this.isStreaming) {
 			const streamingBehavior = options?.streamingBehavior;
@@ -5922,7 +5929,7 @@ export class AgentSession {
 				await this.#queueCustomMessage(notice, streamingBehavior);
 			}
 			await this.#queueCustomMessage(message, streamingBehavior, options?.queueChipText);
-			return;
+			return true;
 		}
 
 		const customMessage: CustomMessage<T> = {
@@ -5935,7 +5942,7 @@ export class AgentSession {
 			timestamp: Date.now(),
 		};
 
-		await this.#promptWithMessage(customMessage, textContent, {
+		return this.#promptWithMessage(customMessage, textContent, {
 			...options,
 			prependMessages: keywordNotices.length > 0 ? keywordNotices : undefined,
 		});

--- a/packages/coding-agent/test/agent-session-queued-steer-delivery.test.ts
+++ b/packages/coding-agent/test/agent-session-queued-steer-delivery.test.ts
@@ -79,7 +79,7 @@ describe("AgentSession queued steer delivery", () => {
 		return { session, sessionManager, mock };
 	}
 
-	function steerCollabPrompt(target: AgentSession, text: string): Promise<void> {
+	function steerCollabPrompt(target: AgentSession, text: string): Promise<boolean> {
 		return target.promptCustomMessage(
 			{
 				customType: COLLAB_PROMPT_TYPE,

--- a/packages/coding-agent/test/issue-8137-repro.test.ts
+++ b/packages/coding-agent/test/issue-8137-repro.test.ts
@@ -81,7 +81,7 @@ describe("issue #8137 — inline /skill in mode-command prompts", () => {
 	});
 
 	it("dispatches an inline /skill invocation from a /plan prompt as a skill message", async () => {
-		const promptCustomMessage = vi.spyOn(session, "promptCustomMessage").mockResolvedValue(undefined);
+		const promptCustomMessage = vi.spyOn(session, "promptCustomMessage").mockResolvedValue(true);
 		let submitted: { text: string } | undefined;
 		mode.onInputCallback = input => {
 			submitted = input;
@@ -100,7 +100,7 @@ describe("issue #8137 — inline /skill in mode-command prompts", () => {
 
 	it("dispatches an inline /skill invocation from a /vibe prompt as a skill message", async () => {
 		vi.spyOn(session, "activateVibeTools").mockResolvedValue(undefined);
-		const promptCustomMessage = vi.spyOn(session, "promptCustomMessage").mockResolvedValue(undefined);
+		const promptCustomMessage = vi.spyOn(session, "promptCustomMessage").mockResolvedValue(true);
 		let submitted: { text: string } | undefined;
 		mode.onInputCallback = input => {
 			submitted = input;
@@ -146,7 +146,7 @@ describe("issue #8137 — inline /skill in mode-command prompts", () => {
 	});
 
 	it("forwards draft images into the dispatched skill message", async () => {
-		const promptCustomMessage = vi.spyOn(session, "promptCustomMessage").mockResolvedValue(undefined);
+		const promptCustomMessage = vi.spyOn(session, "promptCustomMessage").mockResolvedValue(true);
 		const image = { type: "image" as const, data: "aGk=", mimeType: "image/png" };
 
 		await mode.handlePlanModeCommand("do X /skill:grilling", { images: [image] });
@@ -166,7 +166,7 @@ describe("issue #8137 — inline /skill in mode-command prompts", () => {
 	});
 
 	it("still submits a non-skill /plan prompt as a normal prompt", async () => {
-		const promptCustomMessage = vi.spyOn(session, "promptCustomMessage").mockResolvedValue(undefined);
+		const promptCustomMessage = vi.spyOn(session, "promptCustomMessage").mockResolvedValue(true);
 		let submitted: { text: string } | undefined;
 		mode.onInputCallback = input => {
 			submitted = input;

--- a/packages/coding-agent/test/main-interactive-input.test.ts
+++ b/packages/coding-agent/test/main-interactive-input.test.ts
@@ -79,7 +79,7 @@ describe("submitInteractiveInput", () => {
 		};
 		const session = {
 			prompt: vi.fn(async () => true),
-			promptCustomMessage: vi.fn(async () => {}),
+			promptCustomMessage: vi.fn(async () => true),
 			isStreaming: false,
 		};
 		const input = createInput({ text: "resume now", started: true, synthetic: true });
@@ -101,7 +101,7 @@ describe("submitInteractiveInput", () => {
 		};
 		const session = {
 			prompt: vi.fn(async () => true),
-			promptCustomMessage: vi.fn(async () => {}),
+			promptCustomMessage: vi.fn(async () => true),
 			isStreaming: false,
 		};
 		const input = createInput();
@@ -123,7 +123,7 @@ describe("submitInteractiveInput", () => {
 		};
 		const session = {
 			prompt: vi.fn(async () => true),
-			promptCustomMessage: vi.fn(async () => {}),
+			promptCustomMessage: vi.fn(async () => true),
 			isStreaming: false,
 		};
 		const input = createInput({ text: "continue goal", customType: "goal-continuation" });
@@ -155,7 +155,7 @@ describe("submitInteractiveInput", () => {
 		};
 		const session = {
 			prompt: vi.fn(async () => true),
-			promptCustomMessage: vi.fn(async () => {}),
+			promptCustomMessage: vi.fn(async () => true),
 			isStreaming: false,
 		};
 		const input = createInput({ text: "loop prompt" });
@@ -175,7 +175,7 @@ describe("submitInteractiveInput", () => {
 		};
 		const session = {
 			prompt: vi.fn(async () => true),
-			promptCustomMessage: vi.fn(async () => {}),
+			promptCustomMessage: vi.fn(async () => true),
 			isStreaming: true,
 		};
 		const input = createInput({ text: "interrupt now", streamingBehavior: "steer" });
@@ -198,7 +198,7 @@ describe("submitInteractiveInput", () => {
 		};
 		const session = {
 			prompt: vi.fn(async () => true),
-			promptCustomMessage: vi.fn(async () => {}),
+			promptCustomMessage: vi.fn(async () => true),
 			isStreaming: true,
 		};
 		const input = createInput({ text: "continue goal", customType: "goal-continuation" });
@@ -228,7 +228,7 @@ describe("submitInteractiveInput", () => {
 		};
 		const session = {
 			prompt: vi.fn(async () => true),
-			promptCustomMessage: vi.fn(async () => {}),
+			promptCustomMessage: vi.fn(async () => true),
 			isStreaming: true,
 		};
 		const input = createInput({ text: "loop prompt" });

--- a/packages/coding-agent/test/rpc-skill-command.test.ts
+++ b/packages/coding-agent/test/rpc-skill-command.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, test } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import { tryRunRpcSkillCommand } from "@oh-my-pi/pi-coding-agent/modes/rpc/rpc-mode";
+import {
+	dispatchRpcSkillPrompt,
+	RpcExtensionUserMessageTracker,
+	tryRunRpcSkillCommand,
+} from "@oh-my-pi/pi-coding-agent/modes/rpc/rpc-mode";
 import { type CustomMessage, SKILL_PROMPT_MESSAGE_TYPE } from "@oh-my-pi/pi-coding-agent/session/messages";
 import { removeWithRetries, Snowflake } from "@oh-my-pi/pi-utils";
 
@@ -27,6 +31,7 @@ describe("tryRunRpcSkillCommand", () => {
 				async promptCustomMessage(nextMessage: typeof message, nextOptions?: typeof options) {
 					message = nextMessage;
 					options = nextOptions;
+					return true;
 				},
 			},
 			"/skill:reviewer focus on risks",
@@ -69,6 +74,7 @@ describe("tryRunRpcSkillCommand", () => {
 					async promptCustomMessage(nextMessage, nextOptions) {
 						expect(nextMessage.customType).toBe(SKILL_PROMPT_MESSAGE_TYPE);
 						options = nextOptions;
+						return true;
 					},
 				},
 				"/skill:reviewer wait for the current turn",
@@ -121,6 +127,7 @@ describe("tryRunRpcSkillCommand", () => {
 					],
 					async promptCustomMessage() {
 						dispatched = true;
+						return true;
 					},
 				},
 				"/compact /skill:reviewer",
@@ -131,5 +138,176 @@ describe("tryRunRpcSkillCommand", () => {
 		} finally {
 			await removeWithRetries(dir);
 		}
+	});
+});
+
+async function settleUntil(condition: () => boolean, timeoutMs = 5000): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (condition()) return;
+		await Bun.sleep(1);
+	}
+	if (!condition()) throw new Error("condition not met while settling");
+}
+
+describe("dispatchRpcSkillPrompt", () => {
+	test("answers the prompt command before the skill dispatch completes", async () => {
+		const dir = await fs.mkdtemp(path.join(os.tmpdir(), `omp-rpc-skill-${Snowflake.next()}-`));
+		const skillPath = path.join(dir, "SKILL.md");
+		await Bun.write(
+			skillPath,
+			"---\nname: reviewer\ndescription: Review code\n---\n\nReview the supplied code carefully.\n",
+		);
+
+		const dispatchGate = Promise.withResolvers<void>();
+		let promptCustomMessageCalls = 0;
+		const result = await dispatchRpcSkillPrompt({
+			id: "cmd-1",
+			session: {
+				skillsSettings: { enableSkillCommands: true },
+				skills: [
+					{ name: "reviewer", description: "Review code", filePath: skillPath, baseDir: dir, source: "project" },
+				],
+				async promptCustomMessage() {
+					promptCustomMessageCalls += 1;
+					await dispatchGate.promise;
+					return true;
+				},
+			},
+			message: "/skill:reviewer go",
+			streamingBehavior: undefined,
+			output: () => {},
+			onError: () => {},
+			extensionUserMessageTracker: new RpcExtensionUserMessageTracker(),
+		});
+
+		// The answer does not wait for the dispatch pipeline: with the gate
+		// closed, awaiting the pipeline (usage preflight, compaction, provider
+		// calls) would hang this call forever — it returns regardless.
+		expect(result).toEqual({ agentInvoked: true });
+
+		dispatchGate.resolve();
+		await settleUntil(() => promptCustomMessageCalls === 1);
+		expect(promptCustomMessageCalls).toBe(1);
+
+		await removeWithRetries(dir);
+	});
+
+	test("returns null for non-skill messages", async () => {
+		const result = await dispatchRpcSkillPrompt({
+			id: "cmd-2",
+			session: {
+				skillsSettings: { enableSkillCommands: true },
+				skills: [],
+				async promptCustomMessage() {
+					return true;
+				},
+			},
+			message: "just a normal prompt",
+			streamingBehavior: undefined,
+			output: () => {},
+			onError: () => {},
+			extensionUserMessageTracker: new RpcExtensionUserMessageTracker(),
+		});
+		expect(result).toBeNull();
+	});
+
+	test("a late dispatch failure surfaces through onError, not the answer", async () => {
+		const dir = await fs.mkdtemp(path.join(os.tmpdir(), `omp-rpc-skill-${Snowflake.next()}-`));
+		const skillPath = path.join(dir, "SKILL.md");
+		await Bun.write(skillPath, "---\nname: reviewer\ndescription: Review code\n---\n\nBody.\n");
+
+		const errors: Error[] = [];
+		await dispatchRpcSkillPrompt({
+			id: "cmd-3",
+			session: {
+				skillsSettings: { enableSkillCommands: true },
+				skills: [
+					{ name: "reviewer", description: "Review code", filePath: skillPath, baseDir: dir, source: "project" },
+				],
+				async promptCustomMessage() {
+					throw new Error("dispatch pipeline exploded");
+				},
+			},
+			message: "/skill:reviewer go",
+			streamingBehavior: undefined,
+			output: () => {},
+			onError: error => errors.push(error),
+			extensionUserMessageTracker: new RpcExtensionUserMessageTracker(),
+		});
+
+		await settleUntil(() => errors.length === 1);
+		expect(errors.map(error => error.message)).toEqual(["dispatch pipeline exploded"]);
+
+		await removeWithRetries(dir);
+	});
+
+	test("rejects before answering when the skill file cannot be read", async () => {
+		const dir = await fs.mkdtemp(path.join(os.tmpdir(), `omp-rpc-skill-${Snowflake.next()}-`));
+		const missingSkillPath = path.join(dir, "SKILL.md");
+
+		let promptCustomMessageCalls = 0;
+		await expect(
+			dispatchRpcSkillPrompt({
+				id: "cmd-4",
+				session: {
+					skillsSettings: { enableSkillCommands: true },
+					skills: [
+						{
+							name: "reviewer",
+							description: "Review code",
+							filePath: missingSkillPath,
+							baseDir: dir,
+							source: "project",
+						},
+					],
+					async promptCustomMessage() {
+						promptCustomMessageCalls += 1;
+						return true;
+					},
+				},
+				message: "/skill:reviewer go",
+				streamingBehavior: undefined,
+				output: () => {},
+				onError: () => {},
+				extensionUserMessageTracker: new RpcExtensionUserMessageTracker(),
+			}),
+		).rejects.toThrow();
+		expect(promptCustomMessageCalls).toBe(0);
+
+		await removeWithRetries(dir);
+	});
+
+	test("emits a non-invoked completion frame when the dispatch bails before the turn starts", async () => {
+		const dir = await fs.mkdtemp(path.join(os.tmpdir(), `omp-rpc-skill-${Snowflake.next()}-`));
+		const skillPath = path.join(dir, "SKILL.md");
+		await Bun.write(skillPath, "---\nname: reviewer\ndescription: Review code\n---\n\nBody.\n");
+
+		const frames: object[] = [];
+		const result = await dispatchRpcSkillPrompt({
+			id: "cmd-5",
+			session: {
+				skillsSettings: { enableSkillCommands: true },
+				skills: [
+					{ name: "reviewer", description: "Review code", filePath: skillPath, baseDir: dir, source: "project" },
+				],
+				// Simulates the abort-overtakes-preflight race: promptCustomMessage
+				// bails before agent.prompt() runs, so no agent_end is ever emitted.
+				async promptCustomMessage() {
+					return false;
+				},
+			},
+			message: "/skill:reviewer go",
+			streamingBehavior: undefined,
+			output: frame => frames.push(frame),
+			onError: () => {},
+			extensionUserMessageTracker: new RpcExtensionUserMessageTracker(),
+		});
+
+		expect(result).toEqual({ agentInvoked: true });
+		await settleUntil(() => frames.length === 1);
+		expect(frames).toEqual([{ type: "prompt_result", id: "cmd-5", agentInvoked: false }]);
+
+		await removeWithRetries(dir);
 	});
 });


### PR DESCRIPTION
## Problem

The `prompt` RPC command acknowledges `/skill:*` invocations only after the *entire* prompt-dispatch pipeline finishes: `buildSkillPromptMessage` (file I/O) → `promptCustomMessage` → `#promptWithMessage` → usage-aware preflight (`maybeApplyUsageAwareFallback`), pre-prompt compaction checks, retry-fallback restore, `before_agent_start` hooks. Under provider stress (429 caps, auth errors, socket resets) this routinely outlasts any client prompt timeout, so the host reports the prompt as rejected *while the turn is in fact running* — observed live with a client whose session streamed subagent work for 36 minutes after the "rejection". Plain prompts never hit this because they answer first and dispatch via `watchAndReportLocalOnlyPromptResult`; the skill branch was the only path that dispatched on the response path.

## Fix

- Split `tryRunRpcSkillCommand` into `resolveRpcSkillInvocation` (fast, in-memory pre-check) and `runRpcSkillCommand` (slow dispatch). The `prompt` case now: resolves the invocation cheaply → **awaits only `buildSkillPromptMessage`** (cheap file I/O, and the failure mode the old synchronous path reported immediately — a removed or unreadable `SKILL.md` still produces an immediate error response, never an `agentInvoked: true`) → registers the expensive `promptCustomMessage` pipeline with `watchAndReportLocalOnlyPromptResult` → answers `{ agentInvoked: true }`. Dispatch failures past that point surface through the same late error frame the plain-prompt path already uses, so the failure contract is now *identical* to plain prompts. `tryRunRpcSkillCommand` remains as the resolve+run composition for existing callers/tests.
- `abort` is unchanged from `main` (`await session.abort()`): the acknowledgement still means teardown-complete. Clients that do not want to wait on teardown can fire-and-forget the frame — which is what the motivating host (Waku) now does on its side.

## Tests

- `dispatchRpcSkillPrompt`: answers while the dispatch pipeline is blocked on a gate (an awaited pipeline would hang the call forever); returns `null` for non-skill messages; rejects *before* answering when the skill file is unreadable; a late dispatch failure surfaces through `onError`, not through the answer.
- Existing `tryRunRpcSkillCommand`, `rpc-prompt-result`, `rpc-input-frame`, and `executor-soft-budget` suites all pass (45/45); `tsgo --noEmit` and `biome check` clean.
