### PR TITLE
fix(acp): harden ndjson transport and move v2-drafted caps into _meta

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -18,6 +18,9 @@
 - Fixed an issue where custom model overrides were lost during configuration updates
 - Fixed "Please use nerdfont" notification incorrectly persisting after theme configuration
 - Fixed sampling parameter errors for newer Anthropic models (Opus 4.7+, Sonnet 5+)
+### Fixed
+
+- ACP initialize no longer advertises the v2-draft `fork` capability as a direct v1 `sessionCapabilities` key; it lives in the reserved `_meta` extension bag so strict clients cannot reject the session negotiation.
 
 ## [18.0.11] - 2026-08-29
 

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -667,9 +667,9 @@ export class AcpAgent implements Agent {
 				},
 				sessionCapabilities: {
 					list: {},
-					fork: {},
 					resume: {},
 					close: {},
+					_meta: { fork: {} },
 				},
 			},
 		};

--- a/packages/coding-agent/test/acp-initialize-conformance.test.ts
+++ b/packages/coding-agent/test/acp-initialize-conformance.test.ts
@@ -250,11 +250,15 @@ describe("ACP initialize conformance", () => {
 				promptCapabilities: expect.objectContaining({ embeddedContext: true, image: true }),
 				sessionCapabilities: expect.objectContaining({
 					list: expect.any(Object),
-					fork: expect.any(Object),
 					resume: expect.any(Object),
 					close: expect.any(Object),
 				}),
 			}),
 		);
+		const capabilities = response.agentCapabilities! as {
+			sessionCapabilities: Record<string, unknown>;
+		};
+		expect(capabilities.sessionCapabilities).not.toHaveProperty("fork");
+		expect(capabilities.sessionCapabilities._meta).toEqual({ fork: {} });
 	});
 });

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- The ACP stdio transport keeps running when a malformed frame arrives; bad lines now get a JSON-RPC error reply instead of dropping the whole connection.
+
 ## [18.0.11] - 2026-08-29
 
 ### Fixed

--- a/packages/utils/src/acp/stream.ts
+++ b/packages/utils/src/acp/stream.ts
@@ -129,7 +129,7 @@ function isResponseEnvelope(message: Record<string, unknown>): boolean {
 	const error = message.error;
 	// A present error member must be shape-valid; result and error members
 	// must be mutually exclusive, so both-present frames never pass.
-	if (error !== undefined) {
+	if (error !== undefined && error !== null) {
 		return (
 			typeof error === "object" &&
 			!Array.isArray(error) &&

--- a/packages/utils/src/acp/stream.ts
+++ b/packages/utils/src/acp/stream.ts
@@ -113,7 +113,12 @@ function isProtocolMessage(value: unknown): value is AnyMessage {
 	// A string method means a request or notification; anything else must be a
 	// complete response envelope, so bare id frames can never be mistaken for
 	// responses and resolve outstanding requests with `undefined`.
-	if (typeof message.method === "string") return true;
+	// Keep only valid request ids; shape-invalid ids fall through to the
+	// -32600 path instead of echoing unusable ids back to clients.
+	if (typeof message.method === "string") {
+		const id = message.id;
+		return id === undefined || typeof id === "string" || typeof id === "number" || id === null;
+	}
 	return isResponseEnvelope(message);
 }
 
@@ -121,7 +126,14 @@ function isResponseEnvelope(message: Record<string, unknown>): boolean {
 	const id = message.id;
 	if (typeof id !== "string" && typeof id !== "number" && id !== null) return false;
 	const hasResult = "result" in message;
-	const hasError = message.error !== undefined && message.error !== null && typeof message.error === "object";
+	const error = message.error;
+	const hasError =
+		error !== undefined &&
+		error !== null &&
+		typeof error === "object" &&
+		!Array.isArray(error) &&
+		typeof (error as Record<string, unknown>).code === "number" &&
+		typeof (error as Record<string, unknown>).message === "string";
 	return hasResult !== hasError;
 }
 

--- a/packages/utils/src/acp/stream.ts
+++ b/packages/utils/src/acp/stream.ts
@@ -1,4 +1,4 @@
-import type { AnyMessage } from "./transport";
+import type { AnyMessage, JsonRpcId } from "./transport";
 
 /** Bidirectional JSON-RPC message transport. */
 export interface Stream {
@@ -10,36 +10,72 @@ export interface Stream {
 export function ndJsonStream(output: WritableStream<Uint8Array>, input: ReadableStream<Uint8Array>): Stream {
 	const encoder = new TextEncoder();
 	const decoder = new TextDecoder();
-	const writable = new WritableStream<AnyMessage>({
-		async write(message) {
+	let writeTail: Promise<void> = Promise.resolve();
+	// Serializes every write to `output`, including protocol-error responses
+	// emitted from the read loop, so concurrent writer locks never collide.
+	const writeLine = (message: unknown): Promise<void> => {
+		const write = writeTail.then(async () => {
 			const writer = output.getWriter();
 			try {
 				await writer.write(encoder.encode(`${JSON.stringify(message)}\n`));
 			} finally {
 				writer.releaseLock();
 			}
+		});
+		writeTail = write.catch(() => {});
+		return write;
+	};
+	const writable = new WritableStream<AnyMessage>({
+		async write(message) {
+			await writeLine(message);
 		},
 		async close() {
-			const writer = output.getWriter();
-			try {
-				await writer.close();
-			} finally {
-				writer.releaseLock();
-			}
+			const close = writeTail.then(async () => {
+				const writer = output.getWriter();
+				try {
+					await writer.close();
+				} finally {
+					writer.releaseLock();
+				}
+			});
+			writeTail = close.catch(() => {});
+			return close;
 		},
 		async abort(reason) {
-			const writer = output.getWriter();
-			try {
-				await writer.abort(reason);
-			} finally {
-				writer.releaseLock();
-			}
+			const abort = writeTail.then(async () => {
+				const writer = output.getWriter();
+				try {
+					await writer.abort(reason);
+				} finally {
+					writer.releaseLock();
+				}
+			});
+			writeTail = abort.catch(() => {});
+			return abort;
 		},
 	});
 	let buffered = "";
 	const readable = new ReadableStream<AnyMessage>({
 		async start(controller) {
 			const reader = input.getReader();
+			const enqueueLine = async (line: string) => {
+				let value: unknown;
+				try {
+					value = JSON.parse(line);
+				} catch {
+					await writeLine({ jsonrpc: "2.0", id: null, error: { code: -32700, message: "Parse error" } });
+					return;
+				}
+				if (!isProtocolMessage(value)) {
+					await writeLine({
+						jsonrpc: "2.0",
+						id: requestId(value),
+						error: { code: -32600, message: "Invalid request" },
+					});
+					return;
+				}
+				controller.enqueue(value);
+			};
 			try {
 				while (true) {
 					const next = await reader.read();
@@ -49,13 +85,13 @@ export function ndJsonStream(output: WritableStream<Uint8Array>, input: Readable
 					while (newline >= 0) {
 						const line = buffered.slice(0, newline).trimEnd();
 						buffered = buffered.slice(newline + 1);
-						if (line.length > 0) controller.enqueue(parseMessage(line));
+						if (line.length > 0) await enqueueLine(line);
 						newline = buffered.indexOf("\n");
 					}
 				}
 				buffered += decoder.decode();
 				const finalLine = buffered.trim();
-				if (finalLine.length > 0) controller.enqueue(parseMessage(finalLine));
+				if (finalLine.length > 0) await enqueueLine(finalLine);
 				controller.close();
 			} catch (error) {
 				controller.error(error);
@@ -67,16 +103,20 @@ export function ndJsonStream(output: WritableStream<Uint8Array>, input: Readable
 	return { writable, readable };
 }
 
-function parseMessage(line: string): AnyMessage {
-	const value: unknown = JSON.parse(line);
-	if (
-		typeof value !== "object" ||
-		value === null ||
-		Array.isArray(value) ||
-		!("jsonrpc" in value) ||
-		value.jsonrpc !== "2.0"
-	) {
-		throw new Error("Invalid JSON-RPC message");
+function isProtocolMessage(value: unknown): value is AnyMessage {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		!Array.isArray(value) &&
+		"jsonrpc" in value &&
+		value.jsonrpc === "2.0"
+	);
+}
+
+function requestId(value: unknown): JsonRpcId {
+	if (typeof value === "object" && value !== null) {
+		const id = (value as Record<string, unknown>).id;
+		if (typeof id === "string" || typeof id === "number" || id === null) return id;
 	}
-	return value as AnyMessage;
+	return null;
 }

--- a/packages/utils/src/acp/stream.ts
+++ b/packages/utils/src/acp/stream.ts
@@ -107,13 +107,22 @@ export function ndJsonStream(output: WritableStream<Uint8Array>, input: Readable
 }
 
 function isProtocolMessage(value: unknown): value is AnyMessage {
-	return (
-		typeof value === "object" &&
-		value !== null &&
-		!Array.isArray(value) &&
-		"jsonrpc" in value &&
-		value.jsonrpc === "2.0"
-	);
+	if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+	if (!("jsonrpc" in value) || value.jsonrpc !== "2.0") return false;
+	const message = value as Record<string, unknown>;
+	// A string method means a request or notification; anything else must be a
+	// complete response envelope, so bare id frames can never be mistaken for
+	// responses and resolve outstanding requests with `undefined`.
+	if (typeof message.method === "string") return true;
+	return isResponseEnvelope(message);
+}
+
+function isResponseEnvelope(message: Record<string, unknown>): boolean {
+	const id = message.id;
+	if (typeof id !== "string" && typeof id !== "number" && id !== null) return false;
+	const hasResult = "result" in message;
+	const hasError = message.error !== undefined && message.error !== null && typeof message.error === "object";
+	return hasResult !== hasError;
 }
 
 function requestId(value: unknown): JsonRpcId {

--- a/packages/utils/src/acp/stream.ts
+++ b/packages/utils/src/acp/stream.ts
@@ -126,19 +126,19 @@ function isResponseEnvelope(message: Record<string, unknown>): boolean {
 	const id = message.id;
 	if (typeof id !== "string" && typeof id !== "number" && id !== null) return false;
 	const hasResult = "result" in message;
+	if (!("error" in message)) return hasResult;
 	const error = message.error;
-	// A present error member must be shape-valid; result and error members
-	// must be mutually exclusive, so both-present frames never pass.
-	if (error !== undefined && error !== null) {
-		return (
-			typeof error === "object" &&
-			!Array.isArray(error) &&
-			typeof (error as Record<string, unknown>).code === "number" &&
-			typeof (error as Record<string, unknown>).message === "string" &&
-			!hasResult
-		);
-	}
-	return hasResult;
+	// A present error member must be shape-valid regardless of its value;
+	// result and error members must be mutually exclusive, so both-present
+	// frames never pass.
+	return (
+		error !== null &&
+		typeof error === "object" &&
+		!Array.isArray(error) &&
+		typeof (error as Record<string, unknown>).code === "number" &&
+		typeof (error as Record<string, unknown>).message === "string" &&
+		!hasResult
+	);
 }
 
 function requestId(value: unknown): JsonRpcId {

--- a/packages/utils/src/acp/stream.ts
+++ b/packages/utils/src/acp/stream.ts
@@ -127,14 +127,18 @@ function isResponseEnvelope(message: Record<string, unknown>): boolean {
 	if (typeof id !== "string" && typeof id !== "number" && id !== null) return false;
 	const hasResult = "result" in message;
 	const error = message.error;
-	const hasError =
-		error !== undefined &&
-		error !== null &&
-		typeof error === "object" &&
-		!Array.isArray(error) &&
-		typeof (error as Record<string, unknown>).code === "number" &&
-		typeof (error as Record<string, unknown>).message === "string";
-	return hasResult !== hasError;
+	// A present error member must be shape-valid; result and error members
+	// must be mutually exclusive, so both-present frames never pass.
+	if (error !== undefined) {
+		return (
+			typeof error === "object" &&
+			!Array.isArray(error) &&
+			typeof (error as Record<string, unknown>).code === "number" &&
+			typeof (error as Record<string, unknown>).message === "string" &&
+			!hasResult
+		);
+	}
+	return hasResult;
 }
 
 function requestId(value: unknown): JsonRpcId {

--- a/packages/utils/src/acp/stream.ts
+++ b/packages/utils/src/acp/stream.ts
@@ -63,7 +63,10 @@ export function ndJsonStream(output: WritableStream<Uint8Array>, input: Readable
 				try {
 					value = JSON.parse(line);
 				} catch {
-					await writeLine({ jsonrpc: "2.0", id: null, error: { code: -32700, message: "Parse error" } });
+					// Error replies are best-effort: a dead output must not error the read side.
+					await writeLine({ jsonrpc: "2.0", id: null, error: { code: -32700, message: "Parse error" } }).catch(
+						() => {},
+					);
 					return;
 				}
 				if (!isProtocolMessage(value)) {
@@ -71,7 +74,7 @@ export function ndJsonStream(output: WritableStream<Uint8Array>, input: Readable
 						jsonrpc: "2.0",
 						id: requestId(value),
 						error: { code: -32600, message: "Invalid request" },
-					});
+					}).catch(() => {});
 					return;
 				}
 				controller.enqueue(value);

--- a/packages/utils/test/acp.test.ts
+++ b/packages/utils/test/acp.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import type { ReadableStreamReadResult } from "node:stream/web";
 import {
 	type Agent,
 	AgentSideConnection,
@@ -101,6 +102,41 @@ describe("ACP JSON-RPC transport", () => {
 		expect(await reader.read()).toMatchObject({ value: { method: "a", params: {} } });
 		expect(await reader.read()).toMatchObject({ value: { method: "b" } });
 		writer.releaseLock();
+		reader.releaseLock();
+	});
+
+	it("keeps consuming after unparseable lines and rejects them per JSON-RPC", async () => {
+		const bytes = new TransformStream<Uint8Array, Uint8Array>();
+		const output = new TransformStream<Uint8Array, Uint8Array>();
+		const stream = ndJsonStream(output.writable, bytes.readable);
+		const bytesWriter = bytes.writable.getWriter();
+		const outputReader = output.readable.getReader();
+		const reader = stream.readable.getReader();
+		const encoder = new TextEncoder();
+		const readLine = async (source: { read(): Promise<ReadableStreamReadResult<Uint8Array>> }) => {
+			const chunk = await source.read();
+			if (chunk.done) throw new Error("Expected bytes");
+			return new TextDecoder().decode(chunk.value);
+		};
+
+		await bytesWriter.write(encoder.encode("not json\n"));
+		expect(JSON.parse(await readLine(outputReader))).toEqual({
+			jsonrpc: "2.0",
+			id: null,
+			error: { code: -32700, message: "Parse error" },
+		});
+
+		await bytesWriter.write(encoder.encode('{"id":7,"method":"m"}\n'));
+		expect(JSON.parse(await readLine(outputReader))).toEqual({
+			jsonrpc: "2.0",
+			id: 7,
+			error: { code: -32600, message: "Invalid request" },
+		});
+
+		await bytesWriter.write(encoder.encode('{"jsonrpc":"2.0","id":9,"method":"ok"}\n'));
+		expect(await reader.read()).toMatchObject({ value: { jsonrpc: "2.0", id: 9, method: "ok" } });
+		bytesWriter.releaseLock();
+		outputReader.releaseLock();
 		reader.releaseLock();
 	});
 	it("matches the SDK error-code fixtures", () => {

--- a/packages/utils/test/acp.test.ts
+++ b/packages/utils/test/acp.test.ts
@@ -139,6 +139,22 @@ describe("ACP JSON-RPC transport", () => {
 		outputReader.releaseLock();
 		reader.releaseLock();
 	});
+
+	it("does not error the read side when error replies cannot be written", async () => {
+		const bytes = new TransformStream<Uint8Array, Uint8Array>();
+		const output = new TransformStream<Uint8Array, Uint8Array>();
+		const stream = ndJsonStream(output.writable, bytes.readable);
+		const bytesWriter = bytes.writable.getWriter();
+		const reader = stream.readable.getReader();
+		const encoder = new TextEncoder();
+		await output.writable.abort(new Error("EPIPE"));
+
+		await bytesWriter.write(encoder.encode("garbage\n"));
+		await bytesWriter.write(encoder.encode('{"jsonrpc":"2.0","id":9,"method":"ok"}\n'));
+		expect(await reader.read()).toMatchObject({ value: { jsonrpc: "2.0", id: 9, method: "ok" } });
+		bytesWriter.releaseLock();
+		reader.releaseLock();
+	});
 	it("matches the SDK error-code fixtures", () => {
 		expect([
 			RequestError.parseError().toErrorResponse(),

--- a/packages/utils/test/acp.test.ts
+++ b/packages/utils/test/acp.test.ts
@@ -180,10 +180,20 @@ describe("ACP JSON-RPC transport", () => {
 			error: { code: -32600, message: "Invalid request" },
 		});
 
+		// A present error member with a null value is a member, not an absent one:
+		// under the value-gated predicate this frame passed as a bare result, made
+		// #handle dereference null.code after it deleted the pending entry, closed
+		// the connection, and left the request permanently unsettled.
+		await bytesWriter.write(encoder.encode('{"jsonrpc":"2.0","id":0,"result":"ok","error":null}\n'));
+		expect(JSON.parse(await readLine(outputReader))).toEqual({
+			jsonrpc: "2.0",
+			id: 0,
+			error: { code: -32600, message: "Invalid request" },
+		});
+
 		// Under the old shallow predicate this frame settled `outstanding` with a
 		// spurious `undefined` before the correlated response arrived; the final
 		// value assertion fails in that case without any timing.
-
 		await bytesWriter.write(encoder.encode('{"jsonrpc":"2.0","id":0,"result":"ok"}\n'));
 		await expect(outstanding).resolves.toBe("ok");
 		bytesWriter.releaseLock();

--- a/packages/utils/test/acp.test.ts
+++ b/packages/utils/test/acp.test.ts
@@ -155,6 +155,40 @@ describe("ACP JSON-RPC transport", () => {
 		bytesWriter.releaseLock();
 		reader.releaseLock();
 	});
+
+	it("rejects envelope garbage instead of resolving outstanding requests", async () => {
+		const bytes = new TransformStream<Uint8Array, Uint8Array>();
+		const output = new TransformStream<Uint8Array, Uint8Array>();
+		const stream = ndJsonStream(output.writable, bytes.readable);
+		const connection = new RpcConnection(stream, () => undefined);
+		const bytesWriter = bytes.writable.getWriter();
+		const outputReader = output.readable.getReader();
+		const encoder = new TextEncoder();
+		const readLine = async (source: { read(): Promise<ReadableStreamReadResult<Uint8Array>> }) => {
+			const chunk = await source.read();
+			if (chunk.done) throw new Error("Expected bytes");
+			return new TextDecoder().decode(chunk.value);
+		};
+
+		// `request()` takes id 0; a bare id frame must not pass for its response.
+		const outstanding = connection.request<string>("session/prompt");
+		await bytesWriter.write(encoder.encode('{"jsonrpc":"2.0","id":0}\n'));
+		await readLine(outputReader); // discard the outgoing request frame
+		expect(JSON.parse(await readLine(outputReader))).toEqual({
+			jsonrpc: "2.0",
+			id: 0,
+			error: { code: -32600, message: "Invalid request" },
+		});
+
+		// Under the old shallow predicate this frame settled `outstanding` with a
+		// spurious `undefined` before the correlated response arrived; the final
+		// value assertion fails in that case without any timing.
+
+		await bytesWriter.write(encoder.encode('{"jsonrpc":"2.0","id":0,"result":"ok"}\n'));
+		await expect(outstanding).resolves.toBe("ok");
+		bytesWriter.releaseLock();
+		outputReader.releaseLock();
+	});
 	it("matches the SDK error-code fixtures", () => {
 		expect([
 			RequestError.parseError().toErrorResponse(),


### PR DESCRIPTION
- `ndJsonStream` now answers unparseable or non-protocol lines with JSON-RPC -32700/-32600 error responses (echoing the request id when detectable) and keeps consuming, matching the official SDK, instead of tearing down the whole connection. All writes to the output stream serialize through one promise chain so error responses cannot collide with in-flight writes.
- `AcpAgent.initialize` no longer advertises the v2-draft `fork` capability as a direct v1 `sessionCapabilities` key; it moves into the reserved `_meta` extension bag so strict clients cannot reject the initialize response.

## What

- `packages/utils/src/acp/stream.ts`: malformed ndjson frames now get JSON-RPC error replies and the stream keeps going; output writes serialize through one promise chain.
- `packages/coding-agent/src/modes/acp/acp-agent.ts`: the v2-draft `fork` capability advertises via `sessionCapabilities._meta` under the v1 negotiation.
- New transport test covering the error-reply + keep-going path; conformance test updated to pin the `_meta` placement.

## Why

A malformed frame reaching an ACP transport (a stray log line, a non-JSON-RPC message) killed the entire `omp acp` session: the stream errored and the connection closed, while JSON-RPC 2.0 requires replying with an error frame and continuing. The official SDK behaves this way; the vendored reimplementation diverged.

Separately, `sessionCapabilities.fork` is a v2-draft key sent under a v1 `protocolVersion` negotiation. Tolerant clients (Zed) strip unknown keys, but a strict client rejects the whole `initialize` response, so one extra key can end the session before the first turn runs. v1 reserves `_meta` for exactly this.

## Testing

- `bun test packages/utils/test/acp.test.ts`: 7/7, including the new test feeding garbage, id-carrying invalid, and valid frames, asserting the -32700/-32600 replies, the id echo, and continued delivery of valid messages.
- `bun test packages/coding-agent/test/acp-initialize-conformance.test.ts`: 5/5; the agentCapabilities contract test asserts `fork` is absent as a direct v1 key and present under `sessionCapabilities._meta`.
- `bun check` passes (biome + per-package tsgo + cargo check); changes are TS-only, Rust untouched.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
