### PR TITLE
fix(tui): round fractional retry durations

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Fixed an issue where custom model overrides were lost during configuration updates
 - Fixed "Please use nerdfont" notification incorrectly persisting after theme configuration
 - Fixed sampling parameter errors for newer Anthropic models (Opus 4.7+, Sonnet 5+)
+- Fixed retry countdowns and capped-wait errors displaying floating-point noise in millisecond durations.
 
 ## [18.0.11] - 2026-08-29
 

--- a/packages/coding-agent/src/session/turn-recovery.ts
+++ b/packages/coding-agent/src/session/turn-recovery.ts
@@ -2299,7 +2299,7 @@ export class TurnRecovery {
 				type: "auto_retry_end",
 				success: false,
 				attempt,
-				finalError: `Provider requested ${Math.floor(delayMs)}ms wait, exceeds retry.maxDelayMs (${maxDelayMs}ms). Original error: ${errorMessage}`,
+				finalError: `Provider requested ${Math.ceil(delayMs)}ms wait, exceeds retry.maxDelayMs (${maxDelayMs}ms). Original error: ${errorMessage}`,
 			});
 			this.#clearPendingRetryErrors();
 			this.resolveRetry();

--- a/packages/coding-agent/src/session/turn-recovery.ts
+++ b/packages/coding-agent/src/session/turn-recovery.ts
@@ -2299,7 +2299,7 @@ export class TurnRecovery {
 				type: "auto_retry_end",
 				success: false,
 				attempt,
-				finalError: `Provider requested ${delayMs}ms wait, exceeds retry.maxDelayMs (${maxDelayMs}ms). Original error: ${errorMessage}`,
+				finalError: `Provider requested ${Math.floor(delayMs)}ms wait, exceeds retry.maxDelayMs (${maxDelayMs}ms). Original error: ${errorMessage}`,
 			});
 			this.#clearPendingRetryErrors();
 			this.resolveRetry();

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed sub-second duration formatting exposing floating-point precision noise.
+
 ## [18.0.11] - 2026-08-29
 
 ### Fixed

--- a/packages/utils/src/format.ts
+++ b/packages/utils/src/format.ts
@@ -9,7 +9,7 @@ const DAY = 24 * HOUR;
  */
 export function formatDuration(ms: number): string {
 	if (!Number.isFinite(ms) || ms <= 0) return "0ms";
-	if (ms < SEC) return `${ms}ms`;
+	if (ms < SEC) return `${Math.floor(ms)}ms`;
 	if (ms < MIN) return `${(ms / SEC).toFixed(1)}s`;
 	if (ms < HOUR) {
 		const mins = Math.floor(ms / MIN);

--- a/packages/utils/test/format.test.ts
+++ b/packages/utils/test/format.test.ts
@@ -17,6 +17,7 @@ describe("formatDuration", () => {
 
 	it("formats sub-second, sub-minute, sub-hour, sub-day, and multi-day ranges", () => {
 		expect(formatDuration(500)).toBe("500ms");
+		expect(formatDuration(289.99999999999994)).toBe("289ms");
 		expect(formatDuration(1_500)).toBe("1.5s");
 		expect(formatDuration(90_000)).toBe("1m30s");
 		expect(formatDuration(3_600_000)).toBe("1h");


### PR DESCRIPTION
## Repro
On current `main`, `bun -e 'import { formatDuration } from "./packages/utils/src/format.ts"; console.log(formatDuration(289.99999999999994));'` prints `289.99999999999994ms`, which the retry loader exposes as `Retrying (1/3) in 289.99999999999994ms…`.

## Cause
`formatDuration` in `packages/utils/src/format.ts` interpolated sub-second values without normalization, unlike every longer-duration branch. `TurnRecovery.#handleRetryableError` in `packages/coding-agent/src/session/turn-recovery.ts` independently interpolated the same raw delay in capped-wait errors.

## Fix
- Floor sub-second display values before appending the millisecond unit.
- Apply the same normalization to retry cap errors.
- Cover the observed IEEE-754 value in the duration formatter test and document both package-visible fixes.

## Verification
`bun test packages/utils/test/format.test.ts packages/coding-agent/test/agent-session-retry-cap.test.ts` passed: 31 tests, 0 failures. A direct smoke command now prints `Retrying (1/3) in 289ms…`. The pre-publish `bun run fix` and `bun check` gate passed. Fixes #10263