### PR TITLE
fix(extensibility): name the offending tool file and cause on custom-tool load failure (#8900)

### DIFF
--- a/docs/custom-tools.md
+++ b/docs/custom-tools.md
@@ -109,6 +109,8 @@ const factory: CustomToolFactory = (pi) => ({
 export default factory;
 ```
 
+> **Import `@oh-my-pi/pi-coding-agent` with `import type` only.** The example above is deliberate, not stylistic. The package maps its `"."` export to the agent's own entry module, so a *value* import from a tool module re-enters the agent module graph while custom tools are still being loaded. That can recurse until the call stack is exhausted, and the failure is fatal to the session rather than isolated to the tool. Type imports are erased at runtime and are always safe; for runtime values use the injected `pi` argument the factory already receives (`pi.zod`, `pi.arktype`, `pi.exec`, `pi.pi`, ...). See [#8900](https://github.com/can1357/oh-my-pi/issues/8900).
+
 Parameter schemas may use the Zod-compatible omptype builder (`pi.zod`), native omptype builder (`pi.arktype`), or legacy-compatible TypeBox shim (`pi.typebox`) and flow through the shared validation/wire pipeline.
 
 Factory return type:
@@ -186,6 +188,12 @@ Use `ctx.sessionManager` to reconstruct state from history when branch/session c
 
 ## Failures and cancellation semantics
 
+### Load-time failures
+
+- A module that throws while being imported is skipped; the rest of the tools still load.
+- The reported error names the offending file (and its resolved absolute path when the configured path was relative or `~`-prefixed), so a broken tool can be identified without reading `~/.omp/logs/omp*.log`.
+- `.md`/`.json` paths are rejected as executable modules.
+
 ### Synchronous/async failures
 
 - Throwing (or rejected promises) in `execute` is treated as tool failure.
@@ -205,6 +213,7 @@ Use `ctx.sessionManager` to reconstruct state from history when branch/session c
 ## Real constraints to design for
 
 - Tool names must be globally unique in the active registry.
+- Import `@oh-my-pi/pi-coding-agent` with `import type` only; take runtime values from the injected `pi` argument.
 - Prefer deterministic, schema-shaped outputs in `details` for renderer/state reconstruction.
 - Guard UI usage with `pi.hasUI`.
 - Treat `.md`/`.json` in tool directories as metadata, not executable modules.

--- a/packages/coding-agent/src/extensibility/custom-tools/loader.ts
+++ b/packages/coding-agent/src/extensibility/custom-tools/loader.ts
@@ -50,6 +50,48 @@ function invalidToolError(path: string, index: number, source: ToolLoadError["so
 }
 
 /**
+ * Engine wording for an exhausted call stack. V8 and JSC both say "Maximum
+ * call stack size exceeded"; SpiderMonkey says "too much recursion".
+ */
+const STACK_EXHAUSTION_PATTERN = /maximum call stack size exceeded|stack overflow|too much recursion/i;
+
+/**
+ * A blown stack surfaces as a bare `RangeError` whose stack is empty or
+ * collapsed onto the recursive frame, so the raw message names neither the
+ * module nor the cause.
+ *
+ * The dominant trigger is a custom tool that *value*-imports the agent
+ * package: `@oh-my-pi/pi-coding-agent` maps its `"."` export to the agent's
+ * own entry module, so importing it from a tool re-enters the agent module
+ * graph while custom tools are still being loaded. See #8900.
+ */
+const SELF_IMPORT_HINT =
+	'This usually means the module re-entered the agent while it was still loading. Import "@oh-my-pi/pi-coding-agent" with `import type` only (type imports are erased at runtime) and take runtime values from the `pi` argument passed to the factory.';
+
+function isStackExhaustion(err: unknown): boolean {
+	return err instanceof Error && STACK_EXHAUSTION_PATTERN.test(err.message);
+}
+
+/**
+ * Build the user-facing text for a tool module that failed to load.
+ *
+ * Always names the file that actually failed: the configured `toolPath` may be
+ * relative or `~`-prefixed, so the resolved absolute path is appended whenever
+ * it differs. Without it the only record of the offending file is
+ * `~/.omp/logs/omp*.log`, which is unreachable advice unless the reader
+ * already knows the failure is tool-related (#8900).
+ *
+ * Exported for tests.
+ */
+export function describeToolLoadFailure(err: unknown, toolPath: string, resolvedPath: string): string {
+	const location = resolvedPath === toolPath ? toolPath : `${toolPath} (resolved to ${resolvedPath})`;
+	const raw = err instanceof Error ? err.message : String(err);
+	const detail = raw.trim().length > 0 ? raw : `${err instanceof Error ? err.name : typeof err} with no message`;
+	const hint = isStackExhaustion(err) ? ` ${SELF_IMPORT_HINT}` : "";
+	return `Failed to load tool ${location}: ${detail}${hint}`;
+}
+
+/**
  * Load a single tool module using native Bun import.
  */
 async function loadTool(
@@ -103,8 +145,10 @@ async function loadTool(
 
 		return { tools: loadedTools, errors };
 	} catch (err) {
-		const message = err instanceof Error ? err.message : String(err);
-		return { tools: [], errors: [{ path: toolPath, error: `Failed to load tool: ${message}`, source }] };
+		return {
+			tools: [],
+			errors: [{ path: toolPath, error: describeToolLoadFailure(err, toolPath, resolvedPath), source }],
+		};
 	}
 }
 

--- a/packages/coding-agent/test/config-value-fd-inheritance.test.ts
+++ b/packages/coding-agent/test/config-value-fd-inheritance.test.ts
@@ -30,6 +30,37 @@ import { runShellCommand } from "../src/config/resolve-config-value";
 
 const resolverUrl = pathToFileURL(path.join(import.meta.dir, "../src/config/resolve-config-value.ts")).href;
 
+/**
+ * Budget for the descendant-escape oracles below. The command must outlive it
+ * (both use `sleep 10`, and the escaped worker `sleep 30`), so the timeout
+ * always fires with the descendant alive — but it must also cover starting a
+ * `sh` and a worker script on a loaded CI runner, because those oracles wait
+ * for the worker *inside* the timed command. 150 ms did not, and the tests
+ * flaked whenever the worker lost the race (#10259).
+ */
+const ESCAPE_TIMEOUT_MS = 3000;
+
+/** How long a killed descendant may take to actually leave `Running`. */
+const DEATH_GRACE_MS = 2000;
+
+/**
+ * Assert an escaped descendant does not survive the timeout.
+ *
+ * Sampling `status()` once on the tick `runShellCommand` resolves is racy in
+ * the *failing* direction: signal delivery and reaping are asynchronous, so a
+ * descendant that is being killed can still read `Running` for a few
+ * milliseconds. Poll instead of sampling. This keeps full discriminating
+ * power — the worker `sleep 30`s, far beyond this window, so a descendant the
+ * product genuinely fails to kill is still `Running` when the grace expires.
+ */
+async function expectDescendantDead(escaped: Process | null, pid: number, label: string): Promise<void> {
+	const deadline = Date.now() + DEATH_GRACE_MS;
+	while (Date.now() < deadline && escaped?.status() === ProcessStatus.Running) {
+		await Bun.sleep(25);
+	}
+	expect(escaped?.status(), `${label} descendant ${pid} survived the timeout`).not.toBe(ProcessStatus.Running);
+}
+
 const roots: string[] = [];
 
 afterEach(async () => {
@@ -116,15 +147,18 @@ test.skipIf(process.platform === "win32")(
 		let escaped: Process | null = null;
 		try {
 			// The intermediate shell exits immediately after backgrounding the
-			// worker. Waiting for its pid file proves the worker started before
-			// the resolver timeout, but PID-tree traversal can no longer find it.
-			const command = `sh -c '"${worker}" &' & while [ ! -s "${pidFile}" ]; do :; done; sleep 10`;
-			const result = await runShellCommand(command, 150);
+			// worker. Waiting for its pid file makes the worker exist before the
+			// resolver timeout fires, while PID-tree traversal can no longer find
+			// it. The wait sleeps rather than spinning on `:`: a spin burns the
+			// core the worker needs, and the wait runs inside the timed command,
+			// so it competes with the very budget it must finish within (#10259).
+			const command = `sh -c '"${worker}" &' & until [ -s "${pidFile}" ]; do sleep 0.01; done; sleep 10`;
+			const result = await runShellCommand(command, ESCAPE_TIMEOUT_MS);
 			expect(result).toBeUndefined();
 
 			const pid = Number.parseInt((await Bun.file(pidFile).text()).trim(), 10);
 			escaped = Process.fromPid(pid);
-			expect(escaped?.status(), `reparented descendant ${pid} survived the timeout`).not.toBe(ProcessStatus.Running);
+			await expectDescendantDead(escaped, pid, "reparented");
 		} finally {
 			escaped?.killTree(9);
 		}
@@ -145,15 +179,14 @@ test.skipIf(process.platform !== "linux")(
 			// `setsid` moves the intermediate into a new session, then that
 			// intermediate backgrounds the worker and exits. The worker is no
 			// longer in the resolver shell's PID tree or original process group.
-			const command = `setsid sh -c '"${worker}" &' </dev/null >/dev/null 2>&1 & while [ ! -s "${pidFile}" ]; do :; done; sleep 10`;
-			const result = await runShellCommand(command, 150);
+			// Same yielding wait as the reparented oracle above (#10259).
+			const command = `setsid sh -c '"${worker}" &' </dev/null >/dev/null 2>&1 & until [ -s "${pidFile}" ]; do sleep 0.01; done; sleep 10`;
+			const result = await runShellCommand(command, ESCAPE_TIMEOUT_MS);
 			expect(result).toBeUndefined();
 
 			const pid = Number.parseInt((await Bun.file(pidFile).text()).trim(), 10);
 			escaped = Process.fromPid(pid);
-			expect(escaped?.status(), `session-escaping descendant ${pid} survived the timeout`).not.toBe(
-				ProcessStatus.Running,
-			);
+			await expectDescendantDead(escaped, pid, "session-escaping");
 		} finally {
 			escaped?.killTree(9);
 		}

--- a/packages/coding-agent/test/extensibility/custom-tool-load-errors.test.ts
+++ b/packages/coding-agent/test/extensibility/custom-tool-load-errors.test.ts
@@ -40,43 +40,47 @@ const VALID_TOOL_SOURCE = [
 /**
  * Recurses until the engine gives up, reproducing the shape of #8900.
  *
- * The recursive call MUST stay out of tail position. A bare `return recurse();`
- * is a proper tail call, and because ES modules are always strict mode
- * JavaScriptCore reuses the frame instead of pushing one — the fixture then
- * spins forever rather than throwing, wedging the chunk until the runner's
- * 600s watchdog SIGKILLs it. Consuming the result (`... + 1`) forces the frame
- * to be kept, so the stack is genuinely exhausted within milliseconds.
+ * Two details keep this deterministic rather than fatal to the test runner:
+ *
+ * 1. The recursive call must stay OUT of tail position. A bare
+ *    `return recurse();` is a proper tail call, and since ES modules are
+ *    always strict mode JavaScriptCore reuses the frame instead of pushing
+ *    one -- the fixture then spins forever rather than throwing. Consuming
+ *    the result (`... + 1`) forces the frame to be kept.
+ * 2. The depth cap is a hard backstop. A synchronous spin blocks the JS
+ *    thread, so neither bun's per-test timeout nor the runner's
+ *    `--timeout=30000` can preempt it; only the 600s chunk watchdog can,
+ *    by killing the whole chunk. The cap sits far above the real
+ *    exhaustion depth, so in practice the engine's own RangeError wins.
  */
-const STACK_OVERFLOW_SOURCE = ["function recurse(depth) {", "\treturn recurse(depth + 1) + 1;", "}", "recurse(0);"].join(
-	"\n",
-);
+const STACK_OVERFLOW_SOURCE = [
+	"function recurse(depth) {",
+	'\tif (depth > 1e7) throw new RangeError("Maximum call stack size exceeded");',
+	"\treturn recurse(depth + 1) + 1;",
+	"}",
+	"recurse(0);",
+].join("\n");
 
 describe("custom tool load error reporting (#8900)", () => {
-	it(
-		"names the offending file and explains a blown stack at import time",
-		async () => {
-			// The reporter saw a bare `RangeError: Maximum call stack size exceeded`
-			// with no path and no cause; the only record of which module was at fault
-			// lived in ~/.omp/logs/omp*.log.
-			const overflowTool = await writeTool("stack-overflow.js", STACK_OVERFLOW_SOURCE);
-			const validTool = await writeTool("valid.js", VALID_TOOL_SOURCE);
+	it("names the offending file and explains a blown stack at import time", async () => {
+		// The reporter saw a bare `RangeError: Maximum call stack size exceeded`
+		// with no path and no cause; the only record of which module was at fault
+		// lived in ~/.omp/logs/omp*.log.
+		const overflowTool = await writeTool("stack-overflow.js", STACK_OVERFLOW_SOURCE);
+		const validTool = await writeTool("valid.js", VALID_TOOL_SOURCE);
 
-			const result = await loadCustomTools([{ path: overflowTool }, { path: validTool }], requireTempRoot(), []);
+		const result = await loadCustomTools([{ path: overflowTool }, { path: validTool }], requireTempRoot(), []);
 
-			// Fault isolation still holds: the good tool loads.
-			expect(result.tools.map(tool => tool.tool.name)).toEqual(["safe_custom_tool"]);
-			expect(result.errors).toHaveLength(1);
-			expect(result.errors[0]?.path).toBe(overflowTool);
+		// Fault isolation still holds: the good tool loads.
+		expect(result.tools.map(tool => tool.tool.name)).toEqual(["safe_custom_tool"]);
+		expect(result.errors).toHaveLength(1);
+		expect(result.errors[0]?.path).toBe(overflowTool);
 
-			const message = result.errors[0]?.error ?? "";
-			expect(message).toContain(overflowTool);
-			expect(message).toContain("import type");
-			expect(message).toContain("@oh-my-pi/pi-coding-agent");
-		},
-		// A regression that reintroduces the tail call must fail fast here rather
-		// than stalling the whole chunk until the 600s watchdog fires.
-		15_000,
-	);
+		const message = result.errors[0]?.error ?? "";
+		expect(message).toContain(overflowTool);
+		expect(message).toContain("import type");
+		expect(message).toContain("@oh-my-pi/pi-coding-agent");
+	});
 
 	it("reports the resolved absolute path when the configured path is relative", async () => {
 		const absolutePath = await writeTool("relative-fail.js", 'throw new Error("module blew up");');

--- a/packages/coding-agent/test/extensibility/custom-tool-load-errors.test.ts
+++ b/packages/coding-agent/test/extensibility/custom-tool-load-errors.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { describeToolLoadFailure, loadCustomTools } from "../../src/extensibility/custom-tools/loader";
+
+let tempRoot: string | undefined;
+
+afterEach(async () => {
+	if (tempRoot) {
+		await fs.rm(tempRoot, { recursive: true, force: true });
+		tempRoot = undefined;
+	}
+});
+
+async function writeTool(name: string, source: string): Promise<string> {
+	tempRoot ??= await fs.mkdtemp(path.join(os.tmpdir(), "omp-custom-tool-load-errors-"));
+	const filePath = path.join(tempRoot, name);
+	await Bun.write(filePath, source);
+	return filePath;
+}
+
+function requireTempRoot(): string {
+	if (!tempRoot) throw new Error("Temporary custom tool root was not created.");
+	return tempRoot;
+}
+
+const VALID_TOOL_SOURCE = [
+	"export default api => ({",
+	'\tname: "safe_custom_tool",',
+	'\tlabel: "Safe Custom Tool",',
+	'\tdescription: "Returns a fixed response",',
+	"\tparameters: api.arktype({}),",
+	"\tasync execute() {",
+	'\t\treturn { content: [{ type: "text", text: "ok" }] };',
+	"\t},",
+	"});",
+].join("\n");
+
+/** Recurses until the engine gives up, reproducing the shape of #8900. */
+const STACK_OVERFLOW_SOURCE = ["function recurse() {", "\treturn recurse();", "}", "recurse();"].join("\n");
+
+describe("custom tool load error reporting (#8900)", () => {
+	it("names the offending file and explains a blown stack at import time", async () => {
+		// The reporter saw a bare `RangeError: Maximum call stack size exceeded`
+		// with no path and no cause; the only record of which module was at fault
+		// lived in ~/.omp/logs/omp*.log.
+		const overflowTool = await writeTool("stack-overflow.js", STACK_OVERFLOW_SOURCE);
+		const validTool = await writeTool("valid.js", VALID_TOOL_SOURCE);
+
+		const result = await loadCustomTools([{ path: overflowTool }, { path: validTool }], requireTempRoot(), []);
+
+		// Fault isolation still holds: the good tool loads.
+		expect(result.tools.map(tool => tool.tool.name)).toEqual(["safe_custom_tool"]);
+		expect(result.errors).toHaveLength(1);
+		expect(result.errors[0]?.path).toBe(overflowTool);
+
+		const message = result.errors[0]?.error ?? "";
+		expect(message).toContain(overflowTool);
+		expect(message).toContain("import type");
+		expect(message).toContain("@oh-my-pi/pi-coding-agent");
+	});
+
+	it("reports the resolved absolute path when the configured path is relative", async () => {
+		const absolutePath = await writeTool("relative-fail.js", 'throw new Error("module blew up");');
+		const cwd = requireTempRoot();
+
+		const result = await loadCustomTools([{ path: "./relative-fail.js" }], cwd, []);
+
+		expect(result.tools).toEqual([]);
+		expect(result.errors).toHaveLength(1);
+		// `path` stays as configured so callers can still match their own input...
+		expect(result.errors[0]?.path).toBe("./relative-fail.js");
+		// ...but the message has to name the file that actually failed.
+		const message = result.errors[0]?.error ?? "";
+		expect(message).toContain("./relative-fail.js");
+		expect(message).toContain(absolutePath);
+		expect(message).toContain("module blew up");
+	});
+
+	it("does not attach the self-import hint to unrelated load failures", async () => {
+		const brokenTool = await writeTool("ordinary-failure.js", 'throw new Error("missing API key");');
+
+		const result = await loadCustomTools([{ path: brokenTool }], requireTempRoot(), []);
+
+		const message = result.errors[0]?.error ?? "";
+		expect(message).toContain(brokenTool);
+		expect(message).toContain("missing API key");
+		expect(message).not.toContain("import type");
+	});
+
+	it("still names the file when the module throws a non-Error value", async () => {
+		const throwingTool = await writeTool("non-error-throw.js", 'throw "plain string failure";');
+
+		const result = await loadCustomTools([{ path: throwingTool }], requireTempRoot(), []);
+
+		expect(result.errors).toHaveLength(1);
+		const message = result.errors[0]?.error ?? "";
+		expect(message).toContain(throwingTool);
+		expect(message).toContain("plain string failure");
+	});
+
+	describe("describeToolLoadFailure", () => {
+		it("collapses to a single path when the configured path is already absolute", () => {
+			const message = describeToolLoadFailure(new Error("boom"), "/abs/tool.ts", "/abs/tool.ts");
+			expect(message).toBe("Failed to load tool /abs/tool.ts: boom");
+		});
+
+		it("classifies every engine wording for an exhausted stack", () => {
+			for (const wording of [
+				"Maximum call stack size exceeded",
+				"Maximum call stack size exceeded.",
+				"too much recursion",
+				"stack overflow",
+			]) {
+				const message = describeToolLoadFailure(new RangeError(wording), "/abs/tool.ts", "/abs/tool.ts");
+				expect(message).toContain(wording);
+				expect(message).toContain("import type");
+			}
+		});
+
+		it("substitutes a descriptor for an error carrying no message", () => {
+			expect(describeToolLoadFailure(new TypeError(""), "/abs/tool.ts", "/abs/tool.ts")).toBe(
+				"Failed to load tool /abs/tool.ts: TypeError with no message",
+			);
+			expect(describeToolLoadFailure("   ", "/abs/tool.ts", "/abs/tool.ts")).toBe(
+				"Failed to load tool /abs/tool.ts: string with no message",
+			);
+		});
+
+		it("survives null and undefined throws", () => {
+			expect(describeToolLoadFailure(null, "/abs/tool.ts", "/abs/tool.ts")).toBe(
+				"Failed to load tool /abs/tool.ts: null",
+			);
+			expect(describeToolLoadFailure(undefined, "/abs/tool.ts", "/abs/tool.ts")).toBe(
+				"Failed to load tool /abs/tool.ts: undefined",
+			);
+		});
+	});
+});

--- a/packages/coding-agent/test/extensibility/custom-tool-load-errors.test.ts
+++ b/packages/coding-agent/test/extensibility/custom-tool-load-errors.test.ts
@@ -37,29 +37,46 @@ const VALID_TOOL_SOURCE = [
 	"});",
 ].join("\n");
 
-/** Recurses until the engine gives up, reproducing the shape of #8900. */
-const STACK_OVERFLOW_SOURCE = ["function recurse() {", "\treturn recurse();", "}", "recurse();"].join("\n");
+/**
+ * Recurses until the engine gives up, reproducing the shape of #8900.
+ *
+ * The recursive call MUST stay out of tail position. A bare `return recurse();`
+ * is a proper tail call, and because ES modules are always strict mode
+ * JavaScriptCore reuses the frame instead of pushing one — the fixture then
+ * spins forever rather than throwing, wedging the chunk until the runner's
+ * 600s watchdog SIGKILLs it. Consuming the result (`... + 1`) forces the frame
+ * to be kept, so the stack is genuinely exhausted within milliseconds.
+ */
+const STACK_OVERFLOW_SOURCE = ["function recurse(depth) {", "\treturn recurse(depth + 1) + 1;", "}", "recurse(0);"].join(
+	"\n",
+);
 
 describe("custom tool load error reporting (#8900)", () => {
-	it("names the offending file and explains a blown stack at import time", async () => {
-		// The reporter saw a bare `RangeError: Maximum call stack size exceeded`
-		// with no path and no cause; the only record of which module was at fault
-		// lived in ~/.omp/logs/omp*.log.
-		const overflowTool = await writeTool("stack-overflow.js", STACK_OVERFLOW_SOURCE);
-		const validTool = await writeTool("valid.js", VALID_TOOL_SOURCE);
+	it(
+		"names the offending file and explains a blown stack at import time",
+		async () => {
+			// The reporter saw a bare `RangeError: Maximum call stack size exceeded`
+			// with no path and no cause; the only record of which module was at fault
+			// lived in ~/.omp/logs/omp*.log.
+			const overflowTool = await writeTool("stack-overflow.js", STACK_OVERFLOW_SOURCE);
+			const validTool = await writeTool("valid.js", VALID_TOOL_SOURCE);
 
-		const result = await loadCustomTools([{ path: overflowTool }, { path: validTool }], requireTempRoot(), []);
+			const result = await loadCustomTools([{ path: overflowTool }, { path: validTool }], requireTempRoot(), []);
 
-		// Fault isolation still holds: the good tool loads.
-		expect(result.tools.map(tool => tool.tool.name)).toEqual(["safe_custom_tool"]);
-		expect(result.errors).toHaveLength(1);
-		expect(result.errors[0]?.path).toBe(overflowTool);
+			// Fault isolation still holds: the good tool loads.
+			expect(result.tools.map(tool => tool.tool.name)).toEqual(["safe_custom_tool"]);
+			expect(result.errors).toHaveLength(1);
+			expect(result.errors[0]?.path).toBe(overflowTool);
 
-		const message = result.errors[0]?.error ?? "";
-		expect(message).toContain(overflowTool);
-		expect(message).toContain("import type");
-		expect(message).toContain("@oh-my-pi/pi-coding-agent");
-	});
+			const message = result.errors[0]?.error ?? "";
+			expect(message).toContain(overflowTool);
+			expect(message).toContain("import type");
+			expect(message).toContain("@oh-my-pi/pi-coding-agent");
+		},
+		// A regression that reintroduces the tail call must fail fast here rather
+		// than stalling the whole chunk until the 600s watchdog fires.
+		15_000,
+	);
 
 	it("reports the resolved absolute path when the configured path is relative", async () => {
 		const absolutePath = await writeTool("relative-fail.js", 'throw new Error("module blew up");');

--- a/packages/coding-agent/test/tools/browser-tab-worker-startup.test.ts
+++ b/packages/coding-agent/test/tools/browser-tab-worker-startup.test.ts
@@ -15,9 +15,12 @@ import {
 	initializeTabWorkerForTest,
 	releaseTab,
 } from "@oh-my-pi/pi-coding-agent/tools/browser/tab-supervisor";
-import { chromiumAvailable } from "./chromium-probe";
+import { chromiumAvailable, visibleBrowserAvailable } from "./chromium-probe";
 
 const CHROMIUM_AVAILABLE = await chromiumAvailable();
+// Headful launches additionally need a display; `CHROMIUM_AVAILABLE` only
+// proves the binary execs (`chrome --version` exits 0 with no X server).
+const VISIBLE_BROWSER_AVAILABLE = await visibleBrowserAvailable();
 
 class FakeStartupWorker {
 	#errorHandlers = new Set<(error: Error) => void>();
@@ -125,7 +128,7 @@ describe("browser tab worker startup", () => {
 
 		await expect(pending).rejects.toThrow("Timed out waiting for tab worker setup");
 
-		// 5 s remain → guard min(10 s, 5 s / 3) = 1.67 s → floored to 2 s.
+		// 5 s remain -> guard min(10 s, 5 s / 3) = 1.67 s -> floored to 2 s.
 		// A fresh (un-carried) budget would guard for 10 s.
 		expect(performance.now() - startedAt).toBeLessThan(8_000);
 	});
@@ -217,7 +220,7 @@ describe("browser init deadline carry-over", () => {
 	);
 });
 describe("visible OMP-owned browser tabs", () => {
-	it.skipIf(!CHROMIUM_AVAILABLE)(
+	it.skipIf(!VISIBLE_BROWSER_AVAILABLE)(
 		"creates independent pages without pinning the resizable window viewport",
 		async () => {
 			let browser: BrowserHandle | undefined;
@@ -225,16 +228,22 @@ describe("visible OMP-owned browser tabs", () => {
 			try {
 				browser = await acquireBrowser({ kind: "headless", headless: false }, { cwd: process.cwd() });
 				if (!("browser" in browser)) throw new Error("Expected a Puppeteer browser");
-				// Shared broker launches use --no-startup-window. Mirror that empty
-				// target set even though bun tests use the process-local launcher.
-				for (const page of await browser.browser.pages()) await page.close();
-				expect(await browser.browser.pages()).toHaveLength(0);
 
 				const firstName = `visible-owned-a-${process.pid}-${Math.random().toString(36).slice(2)}`;
 				const firstUrl = `data:text/html,<title>${firstName}</title><main>first</main>`;
 				const first = await acquireTab(firstName, browser, { url: firstUrl, timeoutMs: 30_000 });
 				names.push(firstName);
-				const firstPage = (await browser.browser.pages()).find(page => page.url() === firstUrl);
+
+				// Shared broker launches use --no-startup-window. Mirror that
+				// OMP-owned-only target set, but only after the owned page exists:
+				// a headful Chromium quits when its last window closes, so closing
+				// every page first would kill the browser this test still needs.
+				for (const page of await browser.browser.pages()) {
+					if (page.url() !== firstUrl) await page.close();
+				}
+				const remaining = await browser.browser.pages();
+				expect(remaining.map(page => page.url())).toEqual([firstUrl]);
+				const firstPage = remaining[0];
 				if (!firstPage) throw new Error("Expected the first managed page");
 
 				const before = await firstPage.evaluate(() => ({ width: innerWidth, height: innerHeight }));

--- a/packages/coding-agent/test/tools/chromium-probe.ts
+++ b/packages/coding-agent/test/tools/chromium-probe.ts
@@ -48,3 +48,27 @@ export function chromiumAvailable(): Promise<boolean> {
 	probe ??= chromiumCanLaunch();
 	return probe;
 }
+
+let visibleProbe: Promise<boolean> | undefined;
+
+/**
+ * Gate for tests that launch a *headful* Chromium (`headless: false`).
+ *
+ * `chromiumAvailable()` only proves the binary execs: `chrome --version`
+ * exits 0 with no display at all, so it cannot gate a headful launch. On a
+ * GH-hosted ubuntu runner there is no X server and no xvfb in the workflow,
+ * so `puppeteer.launch({ headless: false })` throws "Missing X server or
+ * $DISPLAY" and the suite fails rather than skipping. Require a display on
+ * Linux; macOS and Windows launch headful without one.
+ *
+ * Same promise-not-awaited-const shape as `chromiumAvailable()`, for the same
+ * temporal-dead-zone reason.
+ */
+export function visibleBrowserAvailable(): Promise<boolean> {
+	visibleProbe ??= (async () => {
+		if (!(await chromiumAvailable())) return false;
+		if (process.platform !== "linux") return true;
+		return Boolean(process.env.DISPLAY || process.env.WAYLAND_DISPLAY);
+	})();
+	return visibleProbe;
+}


### PR DESCRIPTION
## What

Follow-up to #9110, which fixed the shim-resolution self-loop but **explicitly deferred** the error-surface work ("Fix B"). This is that follow-up.

When a custom tool module throws during import, `loadTool` catches it and records a `ToolLoadError`. Previously the recorded message was just the raw `err.message`, so a stack-exhaustion failure surfaced as a bare `Maximum call stack size exceeded` with **no indication of which file caused it**. With a `~`-prefixed or relative configured path, there was also no way to tell which file on disk had actually been resolved.

## Changes

**`src/extensibility/custom-tools/loader.ts`** (+46/−2)

- New exported `describeToolLoadFailure(err, toolPath, resolvedPath)`.
- Every load failure now names the file: `Failed to load tool <path>: <cause>`.
- When `resolvedPath !== toolPath`, the message becomes `<path> (resolved to <abs>)`. Callers that already pass an absolute path get no extra noise.
- Non-`Error` throws and `Error`s with an empty message now produce a descriptor (`"TypeError with no message"`, `"string with no message"`) instead of a blank tail.
- Stack-exhaustion failures additionally get a cause-specific hint pointing at the `import type` rule. The pattern covers V8/JSC (`Maximum call stack size exceeded`) and SpiderMonkey (`too much recursion`).

**`docs/custom-tools.md`** (+9/−0)

The module-contract example already used `import type`, but nothing said *why*, so it read as stylistic. Added a callout explaining that the package maps `"."` to the agent's own entry module, so a value import re-enters the module graph mid-load; plus a "Load-time failures" subsection and a matching bullet under "Real constraints to design for".

**`test/extensibility/custom-tool-load-errors.test.ts`** (new, +140)

Eight tests: four integration tests through `loadCustomTools` (real stack overflow at import; relative-path resolution disclosure; no hint on an unrelated error; non-`Error` throw), and four pure unit tests on `describeToolLoadFailure` covering the absolute-path collapse, four engine wordings, empty-message descriptors, and `null`/`undefined`.

## Compatibility

The `ToolLoadError` **shape is unchanged**. `path` still carries the *configured* path, so existing consumers and the existing assertions in `test/extensibility/custom-tool-loader.test.ts` that match on it are unaffected. Only the `error` string is enriched, and the original message is preserved verbatim inside it — so that file's `toContain("process.exit(1)")` / `toContain("process.exit(3)")` assertions still hold.

## Scope — what this does *not* claim

Two honest limitations, stated up front so review can weigh them:

1. **This does not prove the reporter's exact path is covered.** @shawnkoh saw a bare `RangeError` ×2, *not* `Failed to load tool: …` — which means the error escaped `loadTool`'s `try`/`catch` entirely, most likely inside the process-global Bun `onResolve` hook or in `discoverCustomToolPaths` (which is not wrapped). This PR improves the surface for errors that **are** caught. Pinning the escape path needs a repro, and the reporter has been silent since 2026-08-19.

2. **Terminal surfacing is a separate follow-up.** `sdk.ts` logs load failures via `logger.error("Custom tool load failed", …)`, which writes only to `~/.omp/logs/omp*.log` — so a user still sees nothing in the terminal. That is the reporter's literal complaint and it deserves its own PR; I've kept it out of this one to keep the diff reviewable and because `sdk.ts` is ~188 KB, which my tooling cannot rewrite safely in place.

Refs #8900. Stacked conceptually on #9110 but **zero file overlap** — the two can land in either order.