### PR TITLE
Make n on the ask dialog Other row open the custom-answer prompt

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Pressing `n` on the ask dialog's "Other" row now opens the custom-answer prompt, so the typed text is the answer itself
+
 ### Fixed
 
 - The startup update notice counts every change in a release: bullets written above a `###` heading now count under `Other`, and `+`/`*` markers and lightly indented bullets count like `-`.

--- a/packages/coding-agent/src/modes/components/ask-dialog.ts
+++ b/packages/coding-agent/src/modes/components/ask-dialog.ts
@@ -287,7 +287,6 @@ function clearNoteUnlessRow(state: QuestionState, rowKey: string): void {
 
 function noteForSubmittedAnswer(question: ExtensionAskDialogQuestion, state: QuestionState): string | undefined {
 	if (state.note === undefined || state.noteRowKey === undefined) return undefined;
-	if (state.noteRowKey === "other") return state.customInput !== undefined ? state.note : undefined;
 	const match = /^option:(\d+)$/.exec(state.noteRowKey);
 	const optionIndex = match?.[1] === undefined ? Number.NaN : Number.parseInt(match[1], 10);
 	const option = Number.isInteger(optionIndex) ? question.options[optionIndex] : undefined;
@@ -657,9 +656,18 @@ export class AskDialogComponent implements Component {
 			return `Enter submit · ↑/↓ scroll ·${scroll} ${cancel}`;
 		}
 		const question = this.#questions[this.#currentQuestionIndex()];
+		const state = this.#states[this.#currentQuestionIndex()];
+		const onOtherRow =
+			question !== undefined &&
+			state !== undefined &&
+			this.#questionRows(question)[state.cursorIndex]?.kind === "other";
 		// Enter advances in multi-question dialogs and submits single-question ones.
 		const enterAction = this.#questions.length > 1 ? "next" : "submit";
-		const action = question?.multi ? `Space toggle · Enter ${enterAction}` : "Enter select · n note";
+		const action = question?.multi
+			? `Space toggle · Enter ${enterAction}`
+			: onOtherRow
+				? "Enter answer"
+				: "Enter select · n note";
 		const tabs = this.#hasSubmitTab() ? " · Tab/←/→" : "";
 		const expand = this.#expandHint();
 		if (this.#questionCanPage && indicator) {
@@ -725,16 +733,15 @@ export class AskDialogComponent implements Component {
 		const rowItem = rows[state.cursorIndex];
 		if (!rowItem) return;
 		if (keyData === "n" || keyData === "N") {
-			if (rowItem.kind === "option" || rowItem.kind === "other") {
-				void this.#promptForNote(question, state, rowItem);
-			}
+			if (rowItem.kind === "other") void this.#promptForCustomInput(question, state);
+			else void this.#promptForNote(question, state, rowItem);
 			return;
 		}
 		const isEnter = matchesKey(keyData, "enter") || matchesKey(keyData, "return") || keyData === "\n";
 		const isSpace = matchesKey(keyData, "space") || keyData === " ";
 		if (!isEnter && !(question.multi && isSpace)) return;
 		if (rowItem.kind === "other") {
-			void this.#promptForCustomInput(question, state, rowItem);
+			void this.#promptForCustomInput(question, state);
 			return;
 		}
 		const option = question.options[rowItem.optionIndex ?? -1];
@@ -796,11 +803,7 @@ export class AskDialogComponent implements Component {
 		this.#requestRender();
 	}
 
-	async #promptForCustomInput(
-		question: ExtensionAskDialogQuestion,
-		state: QuestionState,
-		rowItem: QuestionRow,
-	): Promise<void> {
+	async #promptForCustomInput(question: ExtensionAskDialogQuestion, state: QuestionState): Promise<void> {
 		this.#promptActive = true;
 		try {
 			const input = await this.callbacks.onPrompt(
@@ -811,13 +814,12 @@ export class AskDialogComponent implements Component {
 			if (input.trim() === "") {
 				// Submitting an empty value unselects the custom answer.
 				state.customInput = undefined;
-				clearNoteIfRow(state, rowItem.key);
 				return;
 			}
 			state.customInput = input;
 			if (!question.multi) {
 				state.selectedOptions.clear();
-				clearNoteUnlessRow(state, rowItem.key);
+				clearNote(state);
 			}
 			if (question.multi && this.#questions.length === 1) {
 				this.#activeTabIndex = this.#submitTabIndex();

--- a/packages/coding-agent/test/modes/components/ask-dialog.test.ts
+++ b/packages/coding-agent/test/modes/components/ask-dialog.test.ts
@@ -444,6 +444,39 @@ describe("AskDialogComponent", () => {
 		expect(onSubmit.mock.calls[0][0].results[0].note).toBe("My Custom Note");
 	});
 
+	it("n on Other opens the custom-answer prompt and submits the text as the answer, not a note", async () => {
+		const onPrompt = vi.fn().mockReturnValue(Promise.resolve("free-form reply"));
+		const onSubmit = vi.fn();
+		const questions: ExtensionAskDialogQuestion[] = [
+			{
+				id: "q1",
+				question: "Choose one?",
+				options: [{ label: "Option A" }],
+			},
+		];
+
+		const component = new AskDialogComponent(questions, {
+			onSubmit,
+			onCancel: vi.fn(),
+			onPrompt,
+		});
+
+		// Move to the Other row and press 'n'.
+		component.handleInput(DOWN);
+		component.handleInput("n");
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(onPrompt).toHaveBeenCalledTimes(1);
+
+		// Single-select: the custom answer submits the question directly.
+		expect(onSubmit).toHaveBeenCalledTimes(1);
+		const result = onSubmit.mock.calls[0][0].results[0];
+		expect(result.customInput).toBe("free-form reply");
+		expect(result.selectedOptions).toEqual([]);
+		expect(result.note).toBeUndefined();
+	});
+
 	it("note prefill is empty when editing a different row after noting another option", async () => {
 		const onPrompt = vi.fn();
 		const onSubmit = vi.fn();


### PR DESCRIPTION
The `Other` row of the ask dialog already collects free text, yet pressing `n` on it opened a second editor for a note attached to that text. It was easy to type the whole reply into the note out of habit, ending up with an empty answer plus a note that was meant to be the answer.

Pressing `n` on `Other` now opens the same custom-answer prompt Enter does, so whatever the user types is the answer itself. Notes on regular option rows are unchanged, and the plumbing that attached a note to `Other` is removed.