### PR TITLE
fix(browser): preserve pre-existing app processes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Fixed an issue where custom model overrides were lost during configuration updates
 - Fixed "Please use nerdfont" notification incorrectly persisting after theme configuration
 - Fixed sampling parameter errors for newer Anthropic models (Opus 4.7+, Sonnet 5+)
+- Prevented browser `app.path` from terminating pre-existing same-executable applications when no reusable CDP endpoint is available ([#10264](https://github.com/can1357/oh-my-pi/issues/10264)).
 
 ## [18.0.11] - 2026-08-29
 

--- a/packages/coding-agent/src/tools/browser/attach.ts
+++ b/packages/coding-agent/src/tools/browser/attach.ts
@@ -1,4 +1,5 @@
 import * as net from "node:net";
+import * as path from "node:path";
 import { Process, ProcessStatus } from "@oh-my-pi/pi-natives";
 import type { Socket } from "bun";
 import type { Browser, Page } from "puppeteer-core";
@@ -148,27 +149,32 @@ async function probeCdpAt(port: number, signal?: AbortSignal): Promise<boolean> 
 }
 
 /**
- * If any running instance of `exe` was launched with `--remote-debugging-port`
- * and that endpoint actually answers, return it so attach can reuse it instead
- * of killing and respawning. Idempotent re-attaches are the common case.
+ * Return a reusable CDP endpoint for `exe`, or null when no instance is
+ * running. Refuse to replace an occupied instance that does not expose CDP.
  */
 export async function findReusableCdp(
 	exe: string,
 	signal?: AbortSignal,
 ): Promise<{ cdpUrl: string; pid: number } | null> {
-	const candidates = Process.fromPath(exe).filter(p => p.status() === ProcessStatus.Running);
-	for (const proc of candidates) {
+	const candidates = Process.fromPath(exe).filter(process => process.status() === ProcessStatus.Running);
+	for (const process of candidates) {
 		let args: string[];
 		try {
-			args = proc.args();
+			args = process.args();
 		} catch {
 			continue;
 		}
 		const port = findCdpPortInArgs(args);
 		if (port === null) continue;
 		if (await probeCdpAt(port, signal)) {
-			return { cdpUrl: `http://127.0.0.1:${port}`, pid: proc.pid };
+			return { cdpUrl: `http://127.0.0.1:${port}`, pid: process.pid };
 		}
+	}
+	if (candidates.length > 0) {
+		const name = path.basename(exe);
+		throw new ToolError(
+			`Cannot launch ${name} because it is already running without a reusable CDP endpoint. Close ${name}, relaunch it with --remote-debugging-port, or pass app.cdp_url for an existing endpoint.`,
+		);
 	}
 	return null;
 }
@@ -255,20 +261,4 @@ export async function gracefulKillTreeOnce(pid: number, gracePeriodMs = 2000): P
 	const process = Process.fromPid(pid);
 	if (!process) return;
 	await process.terminate({ gracefulMs: gracePeriodMs, timeoutMs: 500 });
-}
-
-/**
- * Multi-process variant for attach: find every PID running `executablePath`
- * (single-instance apps may keep an orphan around) and tear them all down.
- */
-export async function killExistingByPath(executablePath: string, signal?: AbortSignal): Promise<number> {
-	const processes = Process.fromPath(executablePath);
-	if (!processes.length) return 0;
-	const results = await Promise.all(
-		processes.map(async process => {
-			throwIfAborted(signal);
-			return await process.terminate({ gracefulMs: 3000, timeoutMs: 1000 });
-		}),
-	);
-	return results.length;
 }

--- a/packages/coding-agent/src/tools/browser/attach.ts
+++ b/packages/coding-agent/src/tools/browser/attach.ts
@@ -150,11 +150,12 @@ async function probeCdpAt(port: number, signal?: AbortSignal): Promise<boolean> 
 
 /**
  * Return a reusable CDP endpoint for `exe`, or null when no instance is
- * running. Refuse to replace an occupied instance that does not expose CDP.
+ * running. Refuse to replace an occupied instance unless the caller can
+ * launch an isolated profile.
  */
 export async function findReusableCdp(
 	exe: string,
-	signal?: AbortSignal,
+	options: { signal?: AbortSignal; allowOccupied?: boolean } = {},
 ): Promise<{ cdpUrl: string; pid: number } | null> {
 	const candidates = Process.fromPath(exe).filter(process => process.status() === ProcessStatus.Running);
 	for (const process of candidates) {
@@ -166,11 +167,11 @@ export async function findReusableCdp(
 		}
 		const port = findCdpPortInArgs(args);
 		if (port === null) continue;
-		if (await probeCdpAt(port, signal)) {
+		if (await probeCdpAt(port, options.signal)) {
 			return { cdpUrl: `http://127.0.0.1:${port}`, pid: process.pid };
 		}
 	}
-	if (candidates.length > 0) {
+	if (!options.allowOccupied && candidates.length > 0) {
 		const name = path.basename(exe);
 		throw new ToolError(
 			`Cannot launch ${name} because it is already running without a reusable CDP endpoint. Close ${name}, relaunch it with --remote-debugging-port, or pass app.cdp_url for an existing endpoint.`,

--- a/packages/coding-agent/src/tools/browser/registry.ts
+++ b/packages/coding-agent/src/tools/browser/registry.ts
@@ -161,6 +161,17 @@ export function normalizeConnectedCdpUrl(rawCdpUrl: string): string {
 	return cdpUrl;
 }
 
+function hasIsolatedUserDataDir(args: string[] | undefined): boolean {
+	if (!args) return false;
+	const inlinePrefix = "--user-data-dir=";
+	return args.some((arg, index) => {
+		if (arg.startsWith(inlinePrefix)) return arg.length > inlinePrefix.length;
+		if (arg !== "--user-data-dir") return false;
+		const value = args[index + 1];
+		return value !== undefined && value.length > 0 && !value.startsWith("--");
+	});
+}
+
 async function openBrowserHandle(kind: BrowserKind, opts: AcquireBrowserOptions): Promise<BrowserHandle> {
 	if (kind.kind === "cmux") {
 		const client = new CmuxSocketClient({ socketPath: kind.socketPath, password: kind.password });
@@ -259,7 +270,10 @@ async function openBrowserHandle(kind: BrowserKind, opts: AcquireBrowserOptions)
 			`app.path must be absolute (got ${JSON.stringify(exe)}). Pass the binary inside Foo.app/Contents/MacOS/, not the .app bundle.`,
 		);
 	}
-	const reused = await findReusableCdp(exe, opts.signal);
+	const reused = await findReusableCdp(exe, {
+		signal: opts.signal,
+		allowOccupied: hasIsolatedUserDataDir(opts.appArgs),
+	});
 	let cdpUrl: string;
 	let pid: number;
 	let subprocess: Subprocess | undefined;

--- a/packages/coding-agent/src/tools/browser/registry.ts
+++ b/packages/coding-agent/src/tools/browser/registry.ts
@@ -3,7 +3,7 @@ import { isCompiledBinary, logger, withTimeout, workerHostEntry } from "@oh-my-p
 import type { Subprocess } from "bun";
 import type { Browser, CDPSession } from "puppeteer-core";
 import { ToolAbortError, ToolError } from "../tool-errors";
-import { findFreeCdpPort, findReusableCdp, gracefulKillTreeOnce, killExistingByPath, waitForCdp } from "./attach";
+import { findFreeCdpPort, findReusableCdp, gracefulKillTreeOnce, waitForCdp } from "./attach";
 import type { CmuxKind } from "./cmux/rpc";
 import { CmuxSocketClient } from "./cmux/socket-client";
 import {
@@ -268,8 +268,6 @@ async function openBrowserHandle(kind: BrowserKind, opts: AcquireBrowserOptions)
 		cdpUrl = reused.cdpUrl;
 		pid = reused.pid;
 	} else {
-		const killed = await killExistingByPath(exe, opts.signal);
-		if (killed > 0) logger.debug("Killed existing instances before attach", { exe, killed });
 		const port = await findFreeCdpPort();
 		const launchArgs = [...(opts.appArgs ?? []), `--remote-debugging-port=${port}`];
 		const child = Bun.spawn([exe, ...launchArgs], {

--- a/packages/coding-agent/test/tools/browser-attach.test.ts
+++ b/packages/coding-agent/test/tools/browser-attach.test.ts
@@ -56,6 +56,36 @@ function fakeTarget(type: string, page: Page | null): Target {
 	} as unknown as Target;
 }
 
+interface DisposableExecutable {
+	path: string;
+	pid: number;
+	close(): Promise<void>;
+}
+
+async function spawnDisposableExecutable(): Promise<DisposableExecutable> {
+	const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-browser-app-path-"));
+	const executable = path.join(tempDir, path.basename(process.execPath));
+	await Bun.write(executable, Bun.file(process.execPath));
+	if (process.platform !== "win32") await fs.chmod(executable, 0o755);
+	const child = Bun.spawn([executable, "--eval", 'process.stdout.write("ready\\n"); await Bun.stdin.text()'], {
+		stdin: "pipe",
+		stdout: "pipe",
+		stderr: "ignore",
+	});
+	const readiness = child.stdout.getReader();
+	await readiness.read();
+	readiness.releaseLock();
+	return {
+		path: executable,
+		pid: child.pid,
+		async close() {
+			child.kill();
+			await child.exited;
+			await fs.rm(tempDir, { recursive: true, force: true });
+		},
+	};
+}
+
 describe("pickElectronTarget", () => {
 	beforeAll(async () => {
 		if (!CHROMIUM_AVAILABLE) return;
@@ -139,31 +169,60 @@ describe("pickElectronTarget", () => {
 	});
 
 	test("refuses to replace a running same-executable process", async () => {
-		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-browser-app-path-"));
-		const executable = path.join(tempDir, path.basename(process.execPath));
-		await Bun.write(executable, Bun.file(process.execPath));
-		if (process.platform !== "win32") await fs.chmod(executable, 0o755);
-		const existing = Bun.spawn([executable, "--eval", 'process.stdout.write("ready\\n"); await Bun.stdin.text()'], {
-			stdin: "pipe",
-			stdout: "pipe",
-			stderr: "ignore",
-		});
-		const readiness = existing.stdout.getReader();
-		await readiness.read();
-		readiness.releaseLock();
-
+		const existing = await spawnDisposableExecutable();
 		try {
 			await expect(
 				acquireBrowser(
-					{ kind: "spawned", path: executable },
+					{ kind: "spawned", path: existing.path },
 					{ cwd: process.cwd(), signal: AbortSignal.timeout(2_000) },
 				),
 			).rejects.toThrow("already running without a reusable CDP endpoint");
 			expect(Process.fromPid(existing.pid)?.status()).toBe(ProcessStatus.Running);
 		} finally {
-			existing.kill();
-			await existing.exited;
-			await fs.rm(tempDir, { recursive: true, force: true });
+			await existing.close();
+		}
+	}, 10_000);
+
+	test("launches an isolated user-data-dir beside a running executable", async () => {
+		const existing = await spawnDisposableExecutable();
+		const { promise: launched, resolve: markLaunched } = Promise.withResolvers<void>();
+		const marker = Bun.serve({
+			hostname: "127.0.0.1",
+			port: 0,
+			fetch() {
+				markLaunched();
+				return new Response("ok");
+			},
+		});
+		const controller = new AbortController();
+		const childScript = `await fetch(${JSON.stringify(marker.url.href)}); Bun.serve({ port: 0, fetch: () => new Response("ok") });`;
+		const openError = acquireBrowser(
+			{ kind: "spawned", path: existing.path },
+			{
+				cwd: process.cwd(),
+				appArgs: ["--eval", childScript, `--user-data-dir=${path.join(path.dirname(existing.path), "profile")}`],
+				signal: controller.signal,
+			},
+		).then(
+			() => new Error("Expected isolated app acquisition to remain pending"),
+			error => (error instanceof Error ? error : new Error(String(error))),
+		);
+
+		try {
+			await Promise.race([
+				launched,
+				openError.then(error => {
+					throw error;
+				}),
+			]);
+			expect(Process.fromPid(existing.pid)?.status()).toBe(ProcessStatus.Running);
+			controller.abort();
+			expect((await openError).name).toBe("ToolAbortError");
+		} finally {
+			controller.abort();
+			await openError;
+			await marker.stop(true);
+			await existing.close();
 		}
 	}, 10_000);
 

--- a/packages/coding-agent/test/tools/browser-attach.test.ts
+++ b/packages/coding-agent/test/tools/browser-attach.test.ts
@@ -1,4 +1,7 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/sdk";
 import { BrowserTool } from "@oh-my-pi/pi-coding-agent/tools/browser";
@@ -15,6 +18,7 @@ import {
 	releaseBrowser,
 } from "@oh-my-pi/pi-coding-agent/tools/browser/registry";
 import { acquireTab } from "@oh-my-pi/pi-coding-agent/tools/browser/tab-supervisor";
+import { Process, ProcessStatus } from "@oh-my-pi/pi-natives";
 import type { Browser, HTTPRequest, Page, Target } from "puppeteer-core";
 import { chromiumAvailable } from "./chromium-probe";
 
@@ -133,6 +137,35 @@ describe("pickElectronTarget", () => {
 		);
 		expect(normalizeConnectedCdpUrl("http://127.0.0.1:9222/")).toBe("http://127.0.0.1:9222");
 	});
+
+	test("refuses to replace a running same-executable process", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-browser-app-path-"));
+		const executable = path.join(tempDir, path.basename(process.execPath));
+		await Bun.write(executable, Bun.file(process.execPath));
+		if (process.platform !== "win32") await fs.chmod(executable, 0o755);
+		const existing = Bun.spawn([executable, "--eval", 'process.stdout.write("ready\\n"); await Bun.stdin.text()'], {
+			stdin: "pipe",
+			stdout: "pipe",
+			stderr: "ignore",
+		});
+		const readiness = existing.stdout.getReader();
+		await readiness.read();
+		readiness.releaseLock();
+
+		try {
+			await expect(
+				acquireBrowser(
+					{ kind: "spawned", path: executable },
+					{ cwd: process.cwd(), signal: AbortSignal.timeout(2_000) },
+				),
+			).rejects.toThrow("already running without a reusable CDP endpoint");
+			expect(Process.fromPid(existing.pid)?.status()).toBe(ProcessStatus.Running);
+		} finally {
+			existing.kill();
+			await existing.exited;
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+	}, 10_000);
 
 	// Launches real headless Chromium; skipped where Chrome's system libraries are absent.
 	test.skipIf(!CHROMIUM_AVAILABLE)(


### PR DESCRIPTION
## Repro
A disposable executable was started without CDP, then acquired through spawned `app.path` mode with `bun /tmp/omp-browser-10264-repro.ts`; before the fix its pre-existing PID exited with code 143 before the open aborted.

## Cause
`openBrowserHandle()` in `packages/coding-agent/src/tools/browser/registry.ts` called `killExistingByPath()` whenever `findReusableCdp()` found no usable endpoint, so executable-path equality was treated as process ownership.

## Fix
- Make `findReusableCdp()` reject occupied executables that expose no reusable CDP endpoint, with guidance to close or CDP-enable the app.
- Remove the same-path termination fallback while retaining exact-PID cleanup for OMP-spawned subprocesses.
- Add regression coverage proving the pre-existing process remains running.
- Document the user-visible fix in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/tools/browser-attach.test.ts` passed with 12 tests and 2 environment-dependent skips; `bun check` passed. Re-running the disposable-process repro reported `preexisting_exit=still-running` and the actionable `ToolError`.

Fixes #10264