### PR TITLE
[DO NOT MERGE] CI verification only: #10267 stacked on #10262

### DIFF
--- a/packages/coding-agent/src/extensibility/custom-tools/loader.ts
+++ b/packages/coding-agent/src/extensibility/custom-tools/loader.ts
@@ -50,6 +50,48 @@ function invalidToolError(path: string, index: number, source: ToolLoadError["so
 }
 
 /**
+ * Engine wording for an exhausted call stack. V8 and JSC both say "Maximum
+ * call stack size exceeded"; SpiderMonkey says "too much recursion".
+ */
+const STACK_EXHAUSTION_PATTERN = /maximum call stack size exceeded|stack overflow|too much recursion/i;
+
+/**
+ * A blown stack surfaces as a bare `RangeError` whose stack is empty or
+ * collapsed onto the recursive frame, so the raw message names neither the
+ * module nor the cause.
+ *
+ * The dominant trigger is a custom tool that *value*-imports the agent
+ * package: `@oh-my-pi/pi-coding-agent` maps its `"."` export to the agent's
+ * own entry module, so importing it from a tool re-enters the agent module
+ * graph while custom tools are still being loaded. See #8900.
+ */
+const SELF_IMPORT_HINT =
+	'This usually means the module re-entered the agent while it was still loading. Import "@oh-my-pi/pi-coding-agent" with `import type` only (type imports are erased at runtime) and take runtime values from the `pi` argument passed to the factory.';
+
+function isStackExhaustion(err: unknown): boolean {
+	return err instanceof Error && STACK_EXHAUSTION_PATTERN.test(err.message);
+}
+
+/**
+ * Build the user-facing text for a tool module that failed to load.
+ *
+ * Always names the file that actually failed: the configured `toolPath` may be
+ * relative or `~`-prefixed, so the resolved absolute path is appended whenever
+ * it differs. Without it the only record of the offending file is
+ * `~/.omp/logs/omp*.log`, which is unreachable advice unless the reader
+ * already knows the failure is tool-related (#8900).
+ *
+ * Exported for tests.
+ */
+export function describeToolLoadFailure(err: unknown, toolPath: string, resolvedPath: string): string {
+	const location = resolvedPath === toolPath ? toolPath : `${toolPath} (resolved to ${resolvedPath})`;
+	const raw = err instanceof Error ? err.message : String(err);
+	const detail = raw.trim().length > 0 ? raw : `${err instanceof Error ? err.name : typeof err} with no message`;
+	const hint = isStackExhaustion(err) ? ` ${SELF_IMPORT_HINT}` : "";
+	return `Failed to load tool ${location}: ${detail}${hint}`;
+}
+
+/**
  * Load a single tool module using native Bun import.
  */
 async function loadTool(
@@ -103,8 +145,10 @@ async function loadTool(
 
 		return { tools: loadedTools, errors };
 	} catch (err) {
-		const message = err instanceof Error ? err.message : String(err);
-		return { tools: [], errors: [{ path: toolPath, error: `Failed to load tool: ${message}`, source }] };
+		return {
+			tools: [],
+			errors: [{ path: toolPath, error: describeToolLoadFailure(err, toolPath, resolvedPath), source }],
+		};
 	}
 }
 

--- a/packages/coding-agent/test/config-value-fd-inheritance.test.ts
+++ b/packages/coding-agent/test/config-value-fd-inheritance.test.ts
@@ -38,7 +38,28 @@ const resolverUrl = pathToFileURL(path.join(import.meta.dir, "../src/config/reso
  * for the worker *inside* the timed command. 150 ms did not, and the tests
  * flaked whenever the worker lost the race (#10259).
  */
-const ESCAPE_TIMEOUT_MS = 2000;
+const ESCAPE_TIMEOUT_MS = 3000;
+
+/** How long a killed descendant may take to actually leave `Running`. */
+const DEATH_GRACE_MS = 2000;
+
+/**
+ * Assert an escaped descendant does not survive the timeout.
+ *
+ * Sampling `status()` once on the tick `runShellCommand` resolves is racy in
+ * the *failing* direction: signal delivery and reaping are asynchronous, so a
+ * descendant that is being killed can still read `Running` for a few
+ * milliseconds. Poll instead of sampling. This keeps full discriminating
+ * power — the worker `sleep 30`s, far beyond this window, so a descendant the
+ * product genuinely fails to kill is still `Running` when the grace expires.
+ */
+async function expectDescendantDead(escaped: Process | null, pid: number, label: string): Promise<void> {
+	const deadline = Date.now() + DEATH_GRACE_MS;
+	while (Date.now() < deadline && escaped?.status() === ProcessStatus.Running) {
+		await Bun.sleep(25);
+	}
+	expect(escaped?.status(), `${label} descendant ${pid} survived the timeout`).not.toBe(ProcessStatus.Running);
+}
 
 const roots: string[] = [];
 
@@ -137,7 +158,7 @@ test.skipIf(process.platform === "win32")(
 
 			const pid = Number.parseInt((await Bun.file(pidFile).text()).trim(), 10);
 			escaped = Process.fromPid(pid);
-			expect(escaped?.status(), `reparented descendant ${pid} survived the timeout`).not.toBe(ProcessStatus.Running);
+			await expectDescendantDead(escaped, pid, "reparented");
 		} finally {
 			escaped?.killTree(9);
 		}
@@ -165,9 +186,7 @@ test.skipIf(process.platform !== "linux")(
 
 			const pid = Number.parseInt((await Bun.file(pidFile).text()).trim(), 10);
 			escaped = Process.fromPid(pid);
-			expect(escaped?.status(), `session-escaping descendant ${pid} survived the timeout`).not.toBe(
-				ProcessStatus.Running,
-			);
+			await expectDescendantDead(escaped, pid, "session-escaping");
 		} finally {
 			escaped?.killTree(9);
 		}

--- a/packages/coding-agent/test/config-value-fd-inheritance.test.ts
+++ b/packages/coding-agent/test/config-value-fd-inheritance.test.ts
@@ -30,6 +30,16 @@ import { runShellCommand } from "../src/config/resolve-config-value";
 
 const resolverUrl = pathToFileURL(path.join(import.meta.dir, "../src/config/resolve-config-value.ts")).href;
 
+/**
+ * Budget for the descendant-escape oracles below. The command must outlive it
+ * (both use `sleep 10`, and the escaped worker `sleep 30`), so the timeout
+ * always fires with the descendant alive — but it must also cover starting a
+ * `sh` and a worker script on a loaded CI runner, because those oracles wait
+ * for the worker *inside* the timed command. 150 ms did not, and the tests
+ * flaked whenever the worker lost the race (#10259).
+ */
+const ESCAPE_TIMEOUT_MS = 2000;
+
 const roots: string[] = [];
 
 afterEach(async () => {
@@ -116,10 +126,13 @@ test.skipIf(process.platform === "win32")(
 		let escaped: Process | null = null;
 		try {
 			// The intermediate shell exits immediately after backgrounding the
-			// worker. Waiting for its pid file proves the worker started before
-			// the resolver timeout, but PID-tree traversal can no longer find it.
-			const command = `sh -c '"${worker}" &' & while [ ! -s "${pidFile}" ]; do :; done; sleep 10`;
-			const result = await runShellCommand(command, 150);
+			// worker. Waiting for its pid file makes the worker exist before the
+			// resolver timeout fires, while PID-tree traversal can no longer find
+			// it. The wait sleeps rather than spinning on `:`: a spin burns the
+			// core the worker needs, and the wait runs inside the timed command,
+			// so it competes with the very budget it must finish within (#10259).
+			const command = `sh -c '"${worker}" &' & until [ -s "${pidFile}" ]; do sleep 0.01; done; sleep 10`;
+			const result = await runShellCommand(command, ESCAPE_TIMEOUT_MS);
 			expect(result).toBeUndefined();
 
 			const pid = Number.parseInt((await Bun.file(pidFile).text()).trim(), 10);
@@ -145,8 +158,9 @@ test.skipIf(process.platform !== "linux")(
 			// `setsid` moves the intermediate into a new session, then that
 			// intermediate backgrounds the worker and exits. The worker is no
 			// longer in the resolver shell's PID tree or original process group.
-			const command = `setsid sh -c '"${worker}" &' </dev/null >/dev/null 2>&1 & while [ ! -s "${pidFile}" ]; do :; done; sleep 10`;
-			const result = await runShellCommand(command, 150);
+			// Same yielding wait as the reparented oracle above (#10259).
+			const command = `setsid sh -c '"${worker}" &' </dev/null >/dev/null 2>&1 & until [ -s "${pidFile}" ]; do sleep 0.01; done; sleep 10`;
+			const result = await runShellCommand(command, ESCAPE_TIMEOUT_MS);
 			expect(result).toBeUndefined();
 
 			const pid = Number.parseInt((await Bun.file(pidFile).text()).trim(), 10);

--- a/packages/coding-agent/test/extensibility/custom-tool-load-errors.test.ts
+++ b/packages/coding-agent/test/extensibility/custom-tool-load-errors.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { describeToolLoadFailure, loadCustomTools } from "../../src/extensibility/custom-tools/loader";
+
+let tempRoot: string | undefined;
+
+afterEach(async () => {
+	if (tempRoot) {
+		await fs.rm(tempRoot, { recursive: true, force: true });
+		tempRoot = undefined;
+	}
+});
+
+async function writeTool(name: string, source: string): Promise<string> {
+	tempRoot ??= await fs.mkdtemp(path.join(os.tmpdir(), "omp-custom-tool-load-errors-"));
+	const filePath = path.join(tempRoot, name);
+	await Bun.write(filePath, source);
+	return filePath;
+}
+
+function requireTempRoot(): string {
+	if (!tempRoot) throw new Error("Temporary custom tool root was not created.");
+	return tempRoot;
+}
+
+const VALID_TOOL_SOURCE = [
+	"export default api => ({",
+	'\tname: "safe_custom_tool",',
+	'\tlabel: "Safe Custom Tool",',
+	'\tdescription: "Returns a fixed response",',
+	"\tparameters: api.arktype({}),",
+	"\tasync execute() {",
+	'\t\treturn { content: [{ type: "text", text: "ok" }] };',
+	"\t},",
+	"});",
+].join("\n");
+
+/** Recurses until the engine gives up, reproducing the shape of #8900. */
+const STACK_OVERFLOW_SOURCE = ["function recurse() {", "\treturn recurse();", "}", "recurse();"].join("\n");
+
+describe("custom tool load error reporting (#8900)", () => {
+	it("names the offending file and explains a blown stack at import time", async () => {
+		// The reporter saw a bare `RangeError: Maximum call stack size exceeded`
+		// with no path and no cause; the only record of which module was at fault
+		// lived in ~/.omp/logs/omp*.log.
+		const overflowTool = await writeTool("stack-overflow.js", STACK_OVERFLOW_SOURCE);
+		const validTool = await writeTool("valid.js", VALID_TOOL_SOURCE);
+
+		const result = await loadCustomTools([{ path: overflowTool }, { path: validTool }], requireTempRoot(), []);
+
+		// Fault isolation still holds: the good tool loads.
+		expect(result.tools.map(tool => tool.tool.name)).toEqual(["safe_custom_tool"]);
+		expect(result.errors).toHaveLength(1);
+		expect(result.errors[0]?.path).toBe(overflowTool);
+
+		const message = result.errors[0]?.error ?? "";
+		expect(message).toContain(overflowTool);
+		expect(message).toContain("import type");
+		expect(message).toContain("@oh-my-pi/pi-coding-agent");
+	});
+
+	it("reports the resolved absolute path when the configured path is relative", async () => {
+		const absolutePath = await writeTool("relative-fail.js", 'throw new Error("module blew up");');
+		const cwd = requireTempRoot();
+
+		const result = await loadCustomTools([{ path: "./relative-fail.js" }], cwd, []);
+
+		expect(result.tools).toEqual([]);
+		expect(result.errors).toHaveLength(1);
+		// `path` stays as configured so callers can still match their own input...
+		expect(result.errors[0]?.path).toBe("./relative-fail.js");
+		// ...but the message has to name the file that actually failed.
+		const message = result.errors[0]?.error ?? "";
+		expect(message).toContain("./relative-fail.js");
+		expect(message).toContain(absolutePath);
+		expect(message).toContain("module blew up");
+	});
+
+	it("does not attach the self-import hint to unrelated load failures", async () => {
+		const brokenTool = await writeTool("ordinary-failure.js", 'throw new Error("missing API key");');
+
+		const result = await loadCustomTools([{ path: brokenTool }], requireTempRoot(), []);
+
+		const message = result.errors[0]?.error ?? "";
+		expect(message).toContain(brokenTool);
+		expect(message).toContain("missing API key");
+		expect(message).not.toContain("import type");
+	});
+
+	it("still names the file when the module throws a non-Error value", async () => {
+		const throwingTool = await writeTool("non-error-throw.js", 'throw "plain string failure";');
+
+		const result = await loadCustomTools([{ path: throwingTool }], requireTempRoot(), []);
+
+		expect(result.errors).toHaveLength(1);
+		const message = result.errors[0]?.error ?? "";
+		expect(message).toContain(throwingTool);
+		expect(message).toContain("plain string failure");
+	});
+
+	describe("describeToolLoadFailure", () => {
+		it("collapses to a single path when the configured path is already absolute", () => {
+			const message = describeToolLoadFailure(new Error("boom"), "/abs/tool.ts", "/abs/tool.ts");
+			expect(message).toBe("Failed to load tool /abs/tool.ts: boom");
+		});
+
+		it("classifies every engine wording for an exhausted stack", () => {
+			for (const wording of [
+				"Maximum call stack size exceeded",
+				"Maximum call stack size exceeded.",
+				"too much recursion",
+				"stack overflow",
+			]) {
+				const message = describeToolLoadFailure(new RangeError(wording), "/abs/tool.ts", "/abs/tool.ts");
+				expect(message).toContain(wording);
+				expect(message).toContain("import type");
+			}
+		});
+
+		it("substitutes a descriptor for an error carrying no message", () => {
+			expect(describeToolLoadFailure(new TypeError(""), "/abs/tool.ts", "/abs/tool.ts")).toBe(
+				"Failed to load tool /abs/tool.ts: TypeError with no message",
+			);
+			expect(describeToolLoadFailure("   ", "/abs/tool.ts", "/abs/tool.ts")).toBe(
+				"Failed to load tool /abs/tool.ts: string with no message",
+			);
+		});
+
+		it("survives null and undefined throws", () => {
+			expect(describeToolLoadFailure(null, "/abs/tool.ts", "/abs/tool.ts")).toBe(
+				"Failed to load tool /abs/tool.ts: null",
+			);
+			expect(describeToolLoadFailure(undefined, "/abs/tool.ts", "/abs/tool.ts")).toBe(
+				"Failed to load tool /abs/tool.ts: undefined",
+			);
+		});
+	});
+});

--- a/packages/coding-agent/test/tools/browser-tab-worker-startup.test.ts
+++ b/packages/coding-agent/test/tools/browser-tab-worker-startup.test.ts
@@ -15,9 +15,12 @@ import {
 	initializeTabWorkerForTest,
 	releaseTab,
 } from "@oh-my-pi/pi-coding-agent/tools/browser/tab-supervisor";
-import { chromiumAvailable } from "./chromium-probe";
+import { chromiumAvailable, visibleBrowserAvailable } from "./chromium-probe";
 
 const CHROMIUM_AVAILABLE = await chromiumAvailable();
+// Headful launches additionally need a display; `CHROMIUM_AVAILABLE` only
+// proves the binary execs (`chrome --version` exits 0 with no X server).
+const VISIBLE_BROWSER_AVAILABLE = await visibleBrowserAvailable();
 
 class FakeStartupWorker {
 	#errorHandlers = new Set<(error: Error) => void>();
@@ -125,7 +128,7 @@ describe("browser tab worker startup", () => {
 
 		await expect(pending).rejects.toThrow("Timed out waiting for tab worker setup");
 
-		// 5 s remain → guard min(10 s, 5 s / 3) = 1.67 s → floored to 2 s.
+		// 5 s remain -> guard min(10 s, 5 s / 3) = 1.67 s -> floored to 2 s.
 		// A fresh (un-carried) budget would guard for 10 s.
 		expect(performance.now() - startedAt).toBeLessThan(8_000);
 	});
@@ -217,7 +220,7 @@ describe("browser init deadline carry-over", () => {
 	);
 });
 describe("visible OMP-owned browser tabs", () => {
-	it.skipIf(!CHROMIUM_AVAILABLE)(
+	it.skipIf(!VISIBLE_BROWSER_AVAILABLE)(
 		"creates independent pages without pinning the resizable window viewport",
 		async () => {
 			let browser: BrowserHandle | undefined;
@@ -225,16 +228,22 @@ describe("visible OMP-owned browser tabs", () => {
 			try {
 				browser = await acquireBrowser({ kind: "headless", headless: false }, { cwd: process.cwd() });
 				if (!("browser" in browser)) throw new Error("Expected a Puppeteer browser");
-				// Shared broker launches use --no-startup-window. Mirror that empty
-				// target set even though bun tests use the process-local launcher.
-				for (const page of await browser.browser.pages()) await page.close();
-				expect(await browser.browser.pages()).toHaveLength(0);
 
 				const firstName = `visible-owned-a-${process.pid}-${Math.random().toString(36).slice(2)}`;
 				const firstUrl = `data:text/html,<title>${firstName}</title><main>first</main>`;
 				const first = await acquireTab(firstName, browser, { url: firstUrl, timeoutMs: 30_000 });
 				names.push(firstName);
-				const firstPage = (await browser.browser.pages()).find(page => page.url() === firstUrl);
+
+				// Shared broker launches use --no-startup-window. Mirror that
+				// OMP-owned-only target set, but only after the owned page exists:
+				// a headful Chromium quits when its last window closes, so closing
+				// every page first would kill the browser this test still needs.
+				for (const page of await browser.browser.pages()) {
+					if (page.url() !== firstUrl) await page.close();
+				}
+				const remaining = await browser.browser.pages();
+				expect(remaining.map(page => page.url())).toEqual([firstUrl]);
+				const firstPage = remaining[0];
 				if (!firstPage) throw new Error("Expected the first managed page");
 
 				const before = await firstPage.evaluate(() => ({ width: innerWidth, height: innerHeight }));

--- a/packages/coding-agent/test/tools/chromium-probe.ts
+++ b/packages/coding-agent/test/tools/chromium-probe.ts
@@ -48,3 +48,27 @@ export function chromiumAvailable(): Promise<boolean> {
 	probe ??= chromiumCanLaunch();
 	return probe;
 }
+
+let visibleProbe: Promise<boolean> | undefined;
+
+/**
+ * Gate for tests that launch a *headful* Chromium (`headless: false`).
+ *
+ * `chromiumAvailable()` only proves the binary execs: `chrome --version`
+ * exits 0 with no display at all, so it cannot gate a headful launch. On a
+ * GH-hosted ubuntu runner there is no X server and no xvfb in the workflow,
+ * so `puppeteer.launch({ headless: false })` throws "Missing X server or
+ * $DISPLAY" and the suite fails rather than skipping. Require a display on
+ * Linux; macOS and Windows launch headful without one.
+ *
+ * Same promise-not-awaited-const shape as `chromiumAvailable()`, for the same
+ * temporal-dead-zone reason.
+ */
+export function visibleBrowserAvailable(): Promise<boolean> {
+	visibleProbe ??= (async () => {
+		if (!(await chromiumAvailable())) return false;
+		if (process.platform !== "linux") return true;
+		return Boolean(process.env.DISPLAY || process.env.WAYLAND_DISPLAY);
+	})();
+	return visibleProbe;
+}


### PR DESCRIPTION
**This PR is a throwaway. Please do not review or merge it. I will close it as soon as CI reports.**

## Why it exists

`Test coding-agent native/unit (TS)` is currently red on *every* PR against `main`, for two reasons that have nothing to do with any given diff:

- `test/tools/browser-tab-worker-startup.test.ts` — "Missing X server". Deterministic on GitHub-hosted runners; the push-triggered self-hosted runner has a display, PR-triggered `ubuntu-22.04` does not, and `ci.yml` sets up no xvfb/`DISPLAY`.
- `test/config-value-fd-inheritance.test.ts` — a two-part race (busy-spin start + single-sample death oracle).

Both are fixed, test-side only, in **#10262** (21/21 green).

That means the red check on **#10267** carries no information: I cannot tell an inherited failure from a regression introduced by #10267's new test file.

## What this branch is

`Mustaqeem66:fix/ci-native-unit-green` (#10262's head, `f18317b2`) **+** the two source files from #10267, pushed byte-identically (`+186/−2`, matching #10267's `3af38d4c` exactly).

So:

- **Green** ⇒ #10267's change is clean, and its red check is purely inherited from its pre-#10262 base.
- **Red in `custom-tool-load-errors.test.ts`** ⇒ the regression is mine, and I fix it in #10267.

Closing immediately either way. Apologies for the noise — CI logs are not reachable to me any other way.

Refs #10267, #10262, #8900, #10259.