### PR TITLE
feat(coding-agent): load standalone CLAUDE.md from project root

### DIFF
--- a/docs/context-files.md
+++ b/docs/context-files.md
@@ -66,9 +66,10 @@ Put broad, durable project background in `AGENTS.md`. Reserve `RULES.md` for sho
 | `github`    | `.github/copilot-instructions.md`           | User + project | Project file `<cwd>/.github/copilot-instructions.md` only (no ancestor walk-up), plus a user-global `~/.copilot/copilot-instructions.md` (relocate with `COPILOT_HOME`). `AGENTS.md` candidates from `COPILOT_CUSTOM_INSTRUCTIONS_DIRS` are also considered at user scope, where normal one-user-file deduplication applies.                                 |
 | `agents`    | `.agent/AGENTS.md`, `.agents/AGENTS.md`     | User + project | User files from `~/.agent/` and `~/.agents/`; project files discovered while walking up from the current directory to the repository root.                                                                                                                                                                                                                   |
 | `agents-md` | `AGENTS.md`                                 | Project        | Standalone (non-config-directory) `AGENTS.md` files, discovered by walking up from the current directory to the repository root and, when that repository is nested under the user's home directory, through enclosing workspace directories up to but not including the home directory. With no repository root, discovery uses the home directory as the boundary for sessions under home and includes that boundary file. Files whose parent directory name starts with `.` are ignored — those belong to a config-directory provider instead.                                                                   |
+| `claude-md` | `CLAUDE.md`                                 | Project        | Standalone (non-config-directory) `CLAUDE.md` files, discovered by walking up from the current directory to the repository root and, when that repository is nested under the user's home directory, through enclosing workspace directories up to but not including the home directory. With no repository root, discovery uses the home directory as the boundary for sessions under home and includes that boundary file. Files whose parent directory name starts with `.` are ignored — those belong to a config-directory provider instead. |
 | `github`    | `.github/instructions/**/*.instructions.md` | Project rules  | GitHub Copilot / VS Code instruction files become rules. `applyTo: '*'`, `applyTo: '**'`, or `applyTo: '**/*'` is injected as always-apply content; other `applyTo` globs are listed in the rulebook with a generated description when needed and are readable as `rule://<name>`. Missing `applyTo` also produces a rulebook entry and a discovery warning. |
 
-Providers marked "(no ancestor walk-up)" only look in the current working directory's config directory. If you need ancestor walk-up behavior, prefer the native `.omp/AGENTS.md` format or a standalone `AGENTS.md` (the `agents-md` provider), or launch `omp` from the directory that holds the config directory.
+Providers marked "(no ancestor walk-up)" only look in the current working directory's config directory. If you need ancestor walk-up behavior, prefer the native `.omp/AGENTS.md` format or a standalone `AGENTS.md` or `CLAUDE.md` (the `agents-md` / `claude-md` providers), or launch `omp` from the directory that holds the config directory.
 
 The discovery registry also holds providers that contribute no context files at all: `cursor` (`.cursor/rules/*.mdc` and legacy `.cursorrules` rules, plus MCP servers and settings), `windsurf` (`.windsurf/rules/*.md`, legacy `.windsurfrules`, and global Windsurf rules, plus MCP servers), `cline` (`.clinerules` rules), `vscode` and `mcp-json` (MCP servers), `claude-plugins` (Claude marketplace plugins: skills, commands, rules, hooks, tools, MCP servers), `omp-plugins` (OMP plugins: skills, commands, rules, prompts, hooks, tools, MCP servers), `agent-plugins` (Agent Plugins standard packages: skills and MCP servers), `ssh-json` (SSH hosts), and `builtin-defaults` (built-in default rules). These become relevant for rules and other capabilities, and for the shared `disabledProviders` switch below.
 
@@ -90,6 +91,7 @@ When two providers describe the _same_ scope, the higher-priority provider wins.
 |       30 | `github`                                           |
 |       20 | `vscode`                                           |
 |       10 | `agents-md`                                        |
+|       10 | `claude-md`                                        |
 |        5 | `mcp-json`, `ssh-json`                             |
 |        1 | `builtin-defaults`                                 |
 
@@ -201,7 +203,7 @@ disabledProviders:
 
 | Id kind                | Examples                                                                           | Effect when listed                                                                                                                                                                 |
 | ---------------------- | ---------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Discovery provider ids | `native`, `claude`, `codex`, `gemini`, `opencode`, `github`, `agents`, `agents-md` | The entire config source is removed — not just its context files, but also any MCP servers, slash commands, skills, hooks, tools, prompts, and settings it would have contributed. |
+| Discovery provider ids | `native`, `claude`, `codex`, `gemini`, `opencode`, `github`, `agents`, `agents-md`, `claude-md` | The entire config source is removed — not just its context files, but also any MCP servers, slash commands, skills, hooks, tools, prompts, and settings it would have contributed. |
 | Model provider ids     | `anthropic`, `openai`, `google`, `groq`, `ollama`, `openrouter`                    | The model backend is removed from selection even when its credentials are present. See [Providers](./providers.md).                                                                |
 
 Ids are exact and the two namespaces do not collide by accident: `google` disables the Google model backend, while `gemini` disables the Gemini CLI discovery files. Disabling a discovery provider is heavier than it looks — disabling `claude`, for instance, also drops Claude-discovered MCP servers, commands, skills, hooks, tools, and settings, not only `CLAUDE.md`. To drop the context file alone and keep everything else the provider contributes, use [`disabledExtensions`](#disabling-a-single-context-file) instead.
@@ -256,7 +258,7 @@ Browse the ids interactively with `/extensions`, which lists every discovered co
 ### A file is not loaded
 
 - Native project context is read only from the nearest non-empty `.omp/` directory. That directory must contain a non-empty `AGENTS.md`; if it does not, discovery does not continue to a farther native directory.
-- A standalone `AGENTS.md` is handled by `agents-md`, not `native`.
+- A standalone `CLAUDE.md` is handled by `claude-md`, not `native`.
 - `.claude/CLAUDE.md`, `.gemini/GEMINI.md`, and `.github/copilot-instructions.md` are read only from the current working directory's config directory — not from every ancestor.
 - `~/.codex/AGENTS.md` and `~/.config/opencode/AGENTS.md` are user-level only and have no project equivalent.
 - Empty files contribute nothing for the native and standalone providers.
@@ -265,7 +267,7 @@ Browse the ids interactively with `/extensions`, which lists every discovered co
 
 ### The wrong file wins
 
-At one user scope or project depth, the higher-priority provider shadows the others (native > claude > agents/codex > gemini > opencode > github > agents-md). To force deterministic behavior, move your guidance into `.omp/AGENTS.md` (native always wins) or disable the competing discovery provider.
+At one user scope or project depth, the higher-priority provider shadows the others (native > claude > agents/codex > gemini > opencode > github > agents-md > claude-md). To force deterministic behavior, move your guidance into `.omp/AGENTS.md` (native always wins) or disable the competing discovery provider.
 
 ### User context disappeared
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -109,6 +109,7 @@
 - Transcript usage rows now show the total prompt-to-yield time (Δ + clock, including tool calls) after the turn timestamp, opt-in via `display.showTurnTime` (off by default).
 - `omp usage` now shows Z.AI GLM Coding Plan credit quotas (5h + weekly) with the subscribed plan tier.
 - The usage status line now labels untiered quota windows with the report's plan tier, surfacing Z.AI Coding Plan (`pro`) and Codex plan names next to the 5h/7d percentages.
+- Standalone `CLAUDE.md` files in the project root (and ancestor directories) are now loaded as context, mirroring `AGENTS.md` discovery; config-directory context files still take precedence per scope.
 
 ### Fixed
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added `CLINE_API_KEY` to the CLI environment help for native ClinePass subscription inference ([#7863](https://github.com/can1357/oh-my-pi/pull/7863) by [@will-bogusz](https://github.com/will-bogusz)).
 - Devin model selectors now accept the native CLI's short aliases (`devin/opus`, `devin/swe`), dotted upstream spellings (`devin/gemini-3.7-flash`), and raw effort-route wire uids for dynamically collapsed families ([#8590](https://github.com/can1357/oh-my-pi/pull/8590) by [@will-bogusz](https://github.com/will-bogusz)).
 - Added provider-supplied model metadata to the `/models` detail line: `new`, `beta`, and `recommended` badges beside the model name, and the upstream description after the context, cost, and perf facts ([#8590](https://github.com/can1357/oh-my-pi/pull/8590) by [@will-bogusz](https://github.com/will-bogusz)).
+- Standalone `CLAUDE.md` files in the project root (and ancestor directories) are now loaded as context, mirroring `AGENTS.md` discovery; config-directory context files still take precedence per scope.
 
 ### Changed
 
@@ -109,8 +110,6 @@
 - Transcript usage rows now show the total prompt-to-yield time (Δ + clock, including tool calls) after the turn timestamp, opt-in via `display.showTurnTime` (off by default).
 - `omp usage` now shows Z.AI GLM Coding Plan credit quotas (5h + weekly) with the subscribed plan tier.
 - The usage status line now labels untiered quota windows with the report's plan tier, surfacing Z.AI Coding Plan (`pro`) and Codex plan names next to the 5h/7d percentages.
-- Standalone `CLAUDE.md` files in the project root (and ancestor directories) are now loaded as context, mirroring `AGENTS.md` discovery; config-directory context files still take precedence per scope.
-
 ### Fixed
 
 - Fixed corrupt session headers silently overwriting recoverable transcripts during resume ([#9915](https://github.com/can1357/oh-my-pi/issues/9915)).

--- a/packages/coding-agent/src/commit/agentic/index.ts
+++ b/packages/coding-agent/src/commit/agentic/index.ts
@@ -91,6 +91,8 @@ export async function runAgenticCommit(args: CommitCommandArgs): Promise<{ usedF
 		}
 	}
 
+	process.stdout.write("● Discovering context files...\n");
+
 	const contextMdFiles = contextFiles.filter(
 		file => file.path.endsWith("AGENTS.md") || file.path.endsWith("CLAUDE.md"),
 	);

--- a/packages/coding-agent/src/commit/agentic/index.ts
+++ b/packages/coding-agent/src/commit/agentic/index.ts
@@ -91,10 +91,11 @@ export async function runAgenticCommit(args: CommitCommandArgs): Promise<{ usedF
 		}
 	}
 
-	process.stdout.write("● Discovering context files...\n");
-	const agentsMdFiles = contextFiles.filter(file => file.path.endsWith("AGENTS.md"));
-	if (agentsMdFiles.length > 0) {
-		for (const file of agentsMdFiles) {
+	const contextMdFiles = contextFiles.filter(
+		file => file.path.endsWith("AGENTS.md") || file.path.endsWith("CLAUDE.md"),
+	);
+	if (contextMdFiles.length > 0) {
+		for (const file of contextMdFiles) {
 			process.stdout.write(`  └─ ${file.path}\n`);
 		}
 	} else {

--- a/packages/coding-agent/src/discovery/agents-md.ts
+++ b/packages/coding-agent/src/discovery/agents-md.ts
@@ -5,95 +5,20 @@
  * This handles AGENTS.md files that live in project root (not in config directories
  * like .codex/ or .gemini/, which are handled by their respective providers).
  */
-import * as path from "node:path";
 import { registerProvider } from "../capability";
 import { type ContextFile, contextFileCapability } from "../capability/context-file";
-import { readFile } from "../capability/fs";
 import type { LoadContext, LoadResult } from "../capability/types";
-import { calculateDepth, createSourceMeta } from "./helpers";
+import { loadStandaloneContextFiles } from "./helpers";
 
 const PROVIDER_ID = "agents-md";
 const DISPLAY_NAME = "AGENTS.md";
 
 /**
- * Compare paths while tolerating Windows drive casing.
- */
-function samePath(left: string, right: string): boolean {
-	const normalizedLeft = path.resolve(left);
-	const normalizedRight = path.resolve(right);
-	return process.platform === "win32"
-		? normalizedLeft.toLowerCase() === normalizedRight.toLowerCase()
-		: normalizedLeft === normalizedRight;
-}
-
-/**
- * Return whether `child` is at or below `parent`.
- */
-function isWithin(parent: string, child: string): boolean {
-	const normalizedParent = path.resolve(parent);
-	const normalizedChild = path.resolve(child);
-	const relative = path.relative(
-		process.platform === "win32" ? normalizedParent.toLowerCase() : normalizedParent,
-		process.platform === "win32" ? normalizedChild.toLowerCase() : normalizedChild,
-	);
-	return relative === "" || (!relative.startsWith(`..${path.sep}`) && relative !== ".." && !path.isAbsolute(relative));
-}
-
-/**
- * Load standalone AGENTS.md files.
- *
- * When a repository is nested below the user's home directory, continue past
- * the Git root to discover workspace-level AGENTS.md files, but stop before
- * loading the home directory's own AGENTS.md as project context.
+ * Load standalone AGENTS.md files by walking up from cwd
+ * (see {@link loadStandaloneContextFiles}).
  */
 export async function loadAgentsMd(ctx: LoadContext): Promise<LoadResult<ContextFile>> {
-	const items: ContextFile[] = [];
-	const warnings: string[] = [];
-	const home = path.resolve(ctx.home);
-	const cwd = path.resolve(ctx.cwd);
-	const repoRoot = ctx.repoRoot ? path.resolve(ctx.repoRoot) : null;
-	const filesystemRoot = path.parse(cwd).root;
-	const cwdIsUnderHome = isWithin(home, cwd);
-	const repoIsUnderHome = repoRoot !== null && isWithin(home, repoRoot);
-	const scanToHome = repoRoot !== null && cwdIsUnderHome && repoIsUnderHome;
-	const boundary = scanToHome ? home : (repoRoot ?? (cwdIsUnderHome ? home : filesystemRoot));
-	const includeBoundary = repoRoot === null ? cwdIsUnderHome : !samePath(boundary, home);
-	const excludeHome = scanToHome;
-
-	let current = cwd;
-	while (true) {
-		const atBoundary = samePath(current, boundary);
-		const atHome = excludeHome && samePath(current, home);
-		if (!(atHome || (atBoundary && !includeBoundary))) {
-			const candidate = path.join(current, "AGENTS.md");
-			const content = await readFile(candidate);
-
-			if (content !== null) {
-				const parent = path.dirname(candidate);
-				const baseName = parent.split(path.sep).pop() ?? "";
-
-				if (!baseName.startsWith(".")) {
-					const fileDir = path.dirname(candidate);
-					const calculatedDepth = calculateDepth(cwd, fileDir, path.sep);
-
-					items.push({
-						path: candidate,
-						content,
-						level: "project",
-						depth: calculatedDepth,
-						_source: createSourceMeta(PROVIDER_ID, candidate, "project"),
-					});
-				}
-			}
-		}
-		if (atBoundary) break;
-
-		const parent = path.dirname(current);
-		if (parent === current) break;
-		current = parent;
-	}
-
-	return { items, warnings };
+	return loadStandaloneContextFiles(ctx, PROVIDER_ID, "AGENTS.md");
 }
 
 registerProvider(contextFileCapability.id, {

--- a/packages/coding-agent/src/discovery/claude-md.ts
+++ b/packages/coding-agent/src/discovery/claude-md.ts
@@ -5,95 +5,20 @@
  * This handles CLAUDE.md files that live in project root (not in config directories
  * like .claude/, which are handled by the Claude Code provider).
  */
-import * as path from "node:path";
 import { registerProvider } from "../capability";
 import { type ContextFile, contextFileCapability } from "../capability/context-file";
-import { readFile } from "../capability/fs";
 import type { LoadContext, LoadResult } from "../capability/types";
-import { calculateDepth, createSourceMeta } from "./helpers";
+import { loadStandaloneContextFiles } from "./helpers";
 
 const PROVIDER_ID = "claude-md";
 const DISPLAY_NAME = "CLAUDE.md";
 
 /**
- * Compare paths while tolerating Windows drive casing.
- */
-function samePath(left: string, right: string): boolean {
-	const normalizedLeft = path.resolve(left);
-	const normalizedRight = path.resolve(right);
-	return process.platform === "win32"
-		? normalizedLeft.toLowerCase() === normalizedRight.toLowerCase()
-		: normalizedLeft === normalizedRight;
-}
-
-/**
- * Return whether `child` is at or below `parent`.
- */
-function isWithin(parent: string, child: string): boolean {
-	const normalizedParent = path.resolve(parent);
-	const normalizedChild = path.resolve(child);
-	const relative = path.relative(
-		process.platform === "win32" ? normalizedParent.toLowerCase() : normalizedParent,
-		process.platform === "win32" ? normalizedChild.toLowerCase() : normalizedChild,
-	);
-	return relative === "" || (!relative.startsWith(`..${path.sep}`) && relative !== ".." && !path.isAbsolute(relative));
-}
-
-/**
- * Load standalone CLAUDE.md files.
- *
- * When a repository is nested below the user's home directory, continue past
- * the Git root to discover workspace-level CLAUDE.md files, but stop before
- * loading the home directory's own CLAUDE.md as project context.
+ * Load standalone CLAUDE.md files by walking up from cwd
+ * (see {@link loadStandaloneContextFiles}).
  */
 export async function loadClaudeMd(ctx: LoadContext): Promise<LoadResult<ContextFile>> {
-	const items: ContextFile[] = [];
-	const warnings: string[] = [];
-	const home = path.resolve(ctx.home);
-	const cwd = path.resolve(ctx.cwd);
-	const repoRoot = ctx.repoRoot ? path.resolve(ctx.repoRoot) : null;
-	const filesystemRoot = path.parse(cwd).root;
-	const cwdIsUnderHome = isWithin(home, cwd);
-	const repoIsUnderHome = repoRoot !== null && isWithin(home, repoRoot);
-	const scanToHome = repoRoot !== null && cwdIsUnderHome && repoIsUnderHome;
-	const boundary = scanToHome ? home : (repoRoot ?? (cwdIsUnderHome ? home : filesystemRoot));
-	const includeBoundary = repoRoot === null ? cwdIsUnderHome : !samePath(boundary, home);
-	const excludeHome = scanToHome;
-
-	let current = cwd;
-	while (true) {
-		const atBoundary = samePath(current, boundary);
-		const atHome = excludeHome && samePath(current, home);
-		if (!(atHome || (atBoundary && !includeBoundary))) {
-			const candidate = path.join(current, "CLAUDE.md");
-			const content = await readFile(candidate);
-
-			if (content !== null) {
-				const parent = path.dirname(candidate);
-				const baseName = parent.split(path.sep).pop() ?? "";
-
-				if (!baseName.startsWith(".")) {
-					const fileDir = path.dirname(candidate);
-					const calculatedDepth = calculateDepth(cwd, fileDir, path.sep);
-
-					items.push({
-						path: candidate,
-						content,
-						level: "project",
-						depth: calculatedDepth,
-						_source: createSourceMeta(PROVIDER_ID, candidate, "project"),
-					});
-				}
-			}
-		}
-		if (atBoundary) break;
-
-		const parent = path.dirname(current);
-		if (parent === current) break;
-		current = parent;
-	}
-
-	return { items, warnings };
+	return loadStandaloneContextFiles(ctx, PROVIDER_ID, "CLAUDE.md");
 }
 
 registerProvider(contextFileCapability.id, {

--- a/packages/coding-agent/src/discovery/claude-md.ts
+++ b/packages/coding-agent/src/discovery/claude-md.ts
@@ -1,0 +1,105 @@
+/**
+ * CLAUDE.md Provider
+ *
+ * Discovers standalone CLAUDE.md files by walking up from cwd.
+ * This handles CLAUDE.md files that live in project root (not in config directories
+ * like .claude/, which are handled by the Claude Code provider).
+ */
+import * as path from "node:path";
+import { registerProvider } from "../capability";
+import { type ContextFile, contextFileCapability } from "../capability/context-file";
+import { readFile } from "../capability/fs";
+import type { LoadContext, LoadResult } from "../capability/types";
+import { calculateDepth, createSourceMeta } from "./helpers";
+
+const PROVIDER_ID = "claude-md";
+const DISPLAY_NAME = "CLAUDE.md";
+
+/**
+ * Compare paths while tolerating Windows drive casing.
+ */
+function samePath(left: string, right: string): boolean {
+	const normalizedLeft = path.resolve(left);
+	const normalizedRight = path.resolve(right);
+	return process.platform === "win32"
+		? normalizedLeft.toLowerCase() === normalizedRight.toLowerCase()
+		: normalizedLeft === normalizedRight;
+}
+
+/**
+ * Return whether `child` is at or below `parent`.
+ */
+function isWithin(parent: string, child: string): boolean {
+	const normalizedParent = path.resolve(parent);
+	const normalizedChild = path.resolve(child);
+	const relative = path.relative(
+		process.platform === "win32" ? normalizedParent.toLowerCase() : normalizedParent,
+		process.platform === "win32" ? normalizedChild.toLowerCase() : normalizedChild,
+	);
+	return relative === "" || (!relative.startsWith(`..${path.sep}`) && relative !== ".." && !path.isAbsolute(relative));
+}
+
+/**
+ * Load standalone CLAUDE.md files.
+ *
+ * When a repository is nested below the user's home directory, continue past
+ * the Git root to discover workspace-level CLAUDE.md files, but stop before
+ * loading the home directory's own CLAUDE.md as project context.
+ */
+export async function loadClaudeMd(ctx: LoadContext): Promise<LoadResult<ContextFile>> {
+	const items: ContextFile[] = [];
+	const warnings: string[] = [];
+	const home = path.resolve(ctx.home);
+	const cwd = path.resolve(ctx.cwd);
+	const repoRoot = ctx.repoRoot ? path.resolve(ctx.repoRoot) : null;
+	const filesystemRoot = path.parse(cwd).root;
+	const cwdIsUnderHome = isWithin(home, cwd);
+	const repoIsUnderHome = repoRoot !== null && isWithin(home, repoRoot);
+	const scanToHome = repoRoot !== null && cwdIsUnderHome && repoIsUnderHome;
+	const boundary = scanToHome ? home : (repoRoot ?? (cwdIsUnderHome ? home : filesystemRoot));
+	const includeBoundary = repoRoot === null ? cwdIsUnderHome : !samePath(boundary, home);
+	const excludeHome = scanToHome;
+
+	let current = cwd;
+	while (true) {
+		const atBoundary = samePath(current, boundary);
+		const atHome = excludeHome && samePath(current, home);
+		if (!(atHome || (atBoundary && !includeBoundary))) {
+			const candidate = path.join(current, "CLAUDE.md");
+			const content = await readFile(candidate);
+
+			if (content !== null) {
+				const parent = path.dirname(candidate);
+				const baseName = parent.split(path.sep).pop() ?? "";
+
+				if (!baseName.startsWith(".")) {
+					const fileDir = path.dirname(candidate);
+					const calculatedDepth = calculateDepth(cwd, fileDir, path.sep);
+
+					items.push({
+						path: candidate,
+						content,
+						level: "project",
+						depth: calculatedDepth,
+						_source: createSourceMeta(PROVIDER_ID, candidate, "project"),
+					});
+				}
+			}
+		}
+		if (atBoundary) break;
+
+		const parent = path.dirname(current);
+		if (parent === current) break;
+		current = parent;
+	}
+
+	return { items, warnings };
+}
+
+registerProvider(contextFileCapability.id, {
+	id: PROVIDER_ID,
+	displayName: DISPLAY_NAME,
+	description: "Standalone CLAUDE.md files (Claude Code style)",
+	priority: 10,
+	load: loadClaudeMd,
+});

--- a/packages/coding-agent/src/discovery/helpers.ts
+++ b/packages/coding-agent/src/discovery/helpers.ts
@@ -601,7 +601,9 @@ function isWithin(parent: string, child: string): boolean {
  *
  * When a repository is nested below the user's home directory, continue past
  * the Git root to discover workspace-level files, but stop before loading the
- * home directory's own copy as project context.
+ * home directory's own copy as project context. A repository rooted at the
+ * home directory itself is not "nested below" it, so the home-level file
+ * remains project context.
  */
 export async function loadStandaloneContextFiles(
 	ctx: LoadContext,
@@ -615,10 +617,11 @@ export async function loadStandaloneContextFiles(
 	const repoRoot = ctx.repoRoot ? path.resolve(ctx.repoRoot) : null;
 	const filesystemRoot = path.parse(cwd).root;
 	const cwdIsUnderHome = isWithin(home, cwd);
-	const repoIsUnderHome = repoRoot !== null && isWithin(home, repoRoot);
+	const repoIsHome = repoRoot !== null && samePath(home, repoRoot);
+	const repoIsUnderHome = repoRoot !== null && isWithin(home, repoRoot) && !repoIsHome;
 	const scanToHome = repoRoot !== null && cwdIsUnderHome && repoIsUnderHome;
 	const boundary = scanToHome ? home : (repoRoot ?? (cwdIsUnderHome ? home : filesystemRoot));
-	const includeBoundary = repoRoot === null ? cwdIsUnderHome : !samePath(boundary, home);
+	const includeBoundary = repoRoot === null ? cwdIsUnderHome : !samePath(boundary, home) || repoIsHome;
 	const excludeHome = scanToHome;
 
 	let current = cwd;

--- a/packages/coding-agent/src/discovery/helpers.ts
+++ b/packages/coding-agent/src/discovery/helpers.ts
@@ -629,7 +629,10 @@ export async function loadStandaloneContextFiles(
 			const candidate = path.join(current, fileName);
 			const content = await readFile(candidate);
 
-			if (content !== null) {
+			// Empty files contribute nothing and must not claim the depth scope:
+			// at a priority tie, an empty first-registered file would shadow a
+			// non-empty sibling (e.g. an empty AGENTS.md shadowing CLAUDE.md).
+			if (content !== null && content !== "") {
 				const parent = path.dirname(candidate);
 				const baseName = parent.split(path.sep).pop() ?? "";
 

--- a/packages/coding-agent/src/discovery/helpers.ts
+++ b/packages/coding-agent/src/discovery/helpers.ts
@@ -11,6 +11,7 @@ import {
 	parseFrontmatter,
 	tryParseJson,
 } from "@oh-my-pi/pi-utils";
+import type { ContextFile } from "../capability/context-file";
 import type { ExtensionModule } from "../capability/extension-module";
 import { invalidate as invalidateFsCache, readDirEntries, readFile } from "../capability/fs";
 import { parseRuleConditionAndScope, type Rule, type RuleFrontmatter } from "../capability/rule";
@@ -564,6 +565,96 @@ export async function loadFilesFromDir<T>(
  */
 export function calculateDepth(cwd: string, targetDir: string, separator: string): number {
 	return cwd.split(separator).length - targetDir.split(separator).length;
+}
+// =============================================================================
+// Standalone context-file walker (AGENTS.md, CLAUDE.md, …)
+// =============================================================================
+
+/**
+ * Compare paths while tolerating Windows drive casing.
+ */
+function samePath(left: string, right: string): boolean {
+	const normalizedLeft = path.resolve(left);
+	const normalizedRight = path.resolve(right);
+	return process.platform === "win32"
+		? normalizedLeft.toLowerCase() === normalizedRight.toLowerCase()
+		: normalizedLeft === normalizedRight;
+}
+
+/**
+ * Return whether `child` is at or below `parent`.
+ */
+function isWithin(parent: string, child: string): boolean {
+	const normalizedParent = path.resolve(parent);
+	const normalizedChild = path.resolve(child);
+	const relative = path.relative(
+		process.platform === "win32" ? normalizedParent.toLowerCase() : normalizedParent,
+		process.platform === "win32" ? normalizedChild.toLowerCase() : normalizedChild,
+	);
+	return relative === "" || (!relative.startsWith(`..${path.sep}`) && relative !== ".." && !path.isAbsolute(relative));
+}
+
+/**
+ * Load standalone context files (e.g. AGENTS.md, CLAUDE.md) by walking up from
+ * cwd. Shared across providers whose files live in project root rather than
+ * config directories (which their own providers handle).
+ *
+ * When a repository is nested below the user's home directory, continue past
+ * the Git root to discover workspace-level files, but stop before loading the
+ * home directory's own copy as project context.
+ */
+export async function loadStandaloneContextFiles(
+	ctx: LoadContext,
+	providerId: string,
+	fileName: string,
+): Promise<LoadResult<ContextFile>> {
+	const items: ContextFile[] = [];
+	const warnings: string[] = [];
+	const home = path.resolve(ctx.home);
+	const cwd = path.resolve(ctx.cwd);
+	const repoRoot = ctx.repoRoot ? path.resolve(ctx.repoRoot) : null;
+	const filesystemRoot = path.parse(cwd).root;
+	const cwdIsUnderHome = isWithin(home, cwd);
+	const repoIsUnderHome = repoRoot !== null && isWithin(home, repoRoot);
+	const scanToHome = repoRoot !== null && cwdIsUnderHome && repoIsUnderHome;
+	const boundary = scanToHome ? home : (repoRoot ?? (cwdIsUnderHome ? home : filesystemRoot));
+	const includeBoundary = repoRoot === null ? cwdIsUnderHome : !samePath(boundary, home);
+	const excludeHome = scanToHome;
+
+	let current = cwd;
+	while (true) {
+		const atBoundary = samePath(current, boundary);
+		const atHome = excludeHome && samePath(current, home);
+		if (!(atHome || (atBoundary && !includeBoundary))) {
+			const candidate = path.join(current, fileName);
+			const content = await readFile(candidate);
+
+			if (content !== null) {
+				const parent = path.dirname(candidate);
+				const baseName = parent.split(path.sep).pop() ?? "";
+
+				if (!baseName.startsWith(".")) {
+					const fileDir = path.dirname(candidate);
+					const calculatedDepth = calculateDepth(cwd, fileDir, path.sep);
+
+					items.push({
+						path: candidate,
+						content,
+						level: "project",
+						depth: calculatedDepth,
+						_source: createSourceMeta(providerId, candidate, "project"),
+					});
+				}
+			}
+		}
+		if (atBoundary) break;
+
+		const parent = path.dirname(current);
+		if (parent === current) break;
+		current = parent;
+	}
+
+	return { items, warnings };
 }
 
 interface ExtensionModuleManifest {

--- a/packages/coding-agent/src/discovery/index.ts
+++ b/packages/coding-agent/src/discovery/index.ts
@@ -22,6 +22,7 @@ import "../capability/tool";
 // Import providers (each registers itself on import)
 import "./agent-plugins";
 import "./agents-md";
+import "./claude-md";
 import "./builtin";
 import "./builtin-defaults";
 import "./claude";

--- a/packages/coding-agent/test/discovery/claude-md.test.ts
+++ b/packages/coding-agent/test/discovery/claude-md.test.ts
@@ -176,4 +176,19 @@ describe("claude-md final registration and precedence", () => {
 			path.join(repoRoot, "AGENTS.md"),
 		]);
 	});
+
+	test("empty standalone files do not claim a depth scope", async () => {
+		const repoRoot = path.join(tempDir, "repo");
+		const cwd = path.join(repoRoot, "src");
+		fs.mkdirSync(path.join(repoRoot, ".git"), { recursive: true });
+		fs.mkdirSync(cwd, { recursive: true });
+		writeClaude(path.join(repoRoot, "AGENTS.md"), "");
+		writeClaude(path.join(repoRoot, "CLAUDE.md"), "claude context");
+
+		const result = await loadCapability<ContextFile>(contextFileCapability.id, { cwd });
+
+		expect(result.items.filter(file => file.level === "project" && file.depth === 1).map(file => file.path)).toEqual([
+			path.join(repoRoot, "CLAUDE.md"),
+		]);
+	});
 });

--- a/packages/coding-agent/test/discovery/claude-md.test.ts
+++ b/packages/coding-agent/test/discovery/claude-md.test.ts
@@ -117,6 +117,21 @@ describe("standalone CLAUDE.md discovery", () => {
 
 		expect(result.items.map(file => file.path)).toEqual([repoClaude]);
 	});
+
+	test("loads the repository-root CLAUDE.md when the repository root is home", async () => {
+		const home = path.join(tempDir, "home");
+		const repoRoot = home;
+		const cwd = path.join(home, "project");
+		fs.mkdirSync(cwd, { recursive: true });
+
+		const homeClaude = path.join(home, "CLAUDE.md");
+		writeClaude(homeClaude, "repo root context");
+
+		const context: LoadContext = { cwd, home, repoRoot };
+		const result = await loadClaudeMd(context);
+
+		expect(result.items.map(file => file.path)).toEqual([homeClaude]);
+	});
 });
 
 describe("claude-md final registration and precedence", () => {

--- a/packages/coding-agent/test/discovery/claude-md.test.ts
+++ b/packages/coding-agent/test/discovery/claude-md.test.ts
@@ -2,7 +2,9 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { type ContextFile, contextFileCapability } from "@oh-my-pi/pi-coding-agent/capability/context-file";
 import type { LoadContext } from "@oh-my-pi/pi-coding-agent/capability/types";
+import { loadCapability } from "@oh-my-pi/pi-coding-agent/discovery";
 import { loadClaudeMd } from "@oh-my-pi/pi-coding-agent/discovery/claude-md";
 import { removeSyncWithRetries } from "@oh-my-pi/pi-utils";
 
@@ -114,5 +116,64 @@ describe("standalone CLAUDE.md discovery", () => {
 		const result = await loadClaudeMd(context);
 
 		expect(result.items.map(file => file.path)).toEqual([repoClaude]);
+	});
+});
+
+describe("claude-md final registration and precedence", () => {
+	let tempDir!: string;
+
+	beforeEach(() => {
+		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-claude-md-reg-"));
+	});
+
+	afterEach(() => {
+		removeSyncWithRetries(tempDir);
+	});
+
+	test("registers and loads standalone root CLAUDE.md through the capability", async () => {
+		const repoRoot = path.join(tempDir, "repo");
+		const cwd = path.join(repoRoot, "src");
+		fs.mkdirSync(path.join(repoRoot, ".git"), { recursive: true });
+		fs.mkdirSync(cwd, { recursive: true });
+		writeClaude(path.join(repoRoot, "CLAUDE.md"), "root context");
+		writeClaude(path.join(cwd, "CLAUDE.md"), "cwd context");
+
+		const result = await loadCapability<ContextFile>(contextFileCapability.id, { cwd });
+
+		const claudeFiles = result.items.filter(file => file._source.providerName === "CLAUDE.md");
+		expect(claudeFiles.map(file => file.path)).toEqual([
+			path.join(cwd, "CLAUDE.md"),
+			path.join(repoRoot, "CLAUDE.md"),
+		]);
+	});
+
+	test(".claude/CLAUDE.md shadows standalone CLAUDE.md at the same depth", async () => {
+		const repoRoot = path.join(tempDir, "repo");
+		const cwd = path.join(repoRoot, "src");
+		fs.mkdirSync(path.join(repoRoot, ".git"), { recursive: true });
+		fs.mkdirSync(path.join(cwd, ".claude"), { recursive: true });
+		writeClaude(path.join(cwd, ".claude", "CLAUDE.md"), "config-dir context");
+		writeClaude(path.join(cwd, "CLAUDE.md"), "standalone context");
+
+		const result = await loadCapability<ContextFile>(contextFileCapability.id, { cwd });
+
+		expect(result.items.filter(file => file.level === "project" && file.depth === 0).map(file => file.path)).toEqual([
+			path.join(cwd, ".claude", "CLAUDE.md"),
+		]);
+	});
+
+	test("standalone AGENTS.md wins the depth tie against standalone CLAUDE.md", async () => {
+		const repoRoot = path.join(tempDir, "repo");
+		const cwd = path.join(repoRoot, "src");
+		fs.mkdirSync(path.join(repoRoot, ".git"), { recursive: true });
+		fs.mkdirSync(cwd, { recursive: true });
+		writeClaude(path.join(repoRoot, "CLAUDE.md"), "claude context");
+		writeClaude(path.join(repoRoot, "AGENTS.md"), "agents context");
+
+		const result = await loadCapability<ContextFile>(contextFileCapability.id, { cwd });
+
+		expect(result.items.filter(file => file.level === "project" && file.depth === 1).map(file => file.path)).toEqual([
+			path.join(repoRoot, "AGENTS.md"),
+		]);
 	});
 });

--- a/packages/coding-agent/test/discovery/claude-md.test.ts
+++ b/packages/coding-agent/test/discovery/claude-md.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { LoadContext } from "@oh-my-pi/pi-coding-agent/capability/types";
+import { loadClaudeMd } from "@oh-my-pi/pi-coding-agent/discovery/claude-md";
+import { removeSyncWithRetries } from "@oh-my-pi/pi-utils";
+
+function writeClaude(filePath: string, content: string): void {
+	fs.mkdirSync(path.dirname(filePath), { recursive: true });
+	fs.writeFileSync(filePath, content);
+}
+
+describe("standalone CLAUDE.md discovery", () => {
+	let tempDir!: string;
+
+	beforeEach(() => {
+		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-claude-md-"));
+	});
+
+	afterEach(() => {
+		removeSyncWithRetries(tempDir);
+	});
+
+	test("finds workspace CLAUDE.md above a nested repository without loading home context", async () => {
+		const home = path.join(tempDir, "home");
+		const workspaceRoot = path.join(home, "repos", "writer");
+		const repoRoot = path.join(workspaceRoot, "internal", "service");
+		const cwd = path.join(repoRoot, "src");
+		fs.mkdirSync(cwd, { recursive: true });
+
+		const repoClaude = path.join(repoRoot, "CLAUDE.md");
+		const workspaceClaude = path.join(workspaceRoot, "CLAUDE.md");
+		const homeClaude = path.join(home, "CLAUDE.md");
+		writeClaude(repoClaude, "repo context");
+		writeClaude(workspaceClaude, "workspace context");
+		writeClaude(homeClaude, "home context");
+
+		const context: LoadContext = { cwd, home, repoRoot };
+		const result = await loadClaudeMd(context);
+
+		expect(result.items.map(file => file.path)).toEqual([repoClaude, workspaceClaude]);
+	});
+
+	test("loads cwd and intermediate context with no repository root under home", async () => {
+		const home = path.join(tempDir, "home");
+		const workspaceRoot = path.join(home, "workspace");
+		const intermediate = path.join(workspaceRoot, "packages");
+		const cwd = path.join(intermediate, "service");
+		fs.mkdirSync(cwd, { recursive: true });
+
+		const cwdClaude = path.join(cwd, "CLAUDE.md");
+		const intermediateClaude = path.join(intermediate, "CLAUDE.md");
+		const homeClaude = path.join(home, "CLAUDE.md");
+		writeClaude(cwdClaude, "cwd context");
+		writeClaude(intermediateClaude, "intermediate context");
+		writeClaude(homeClaude, "home context");
+
+		const context: LoadContext = { cwd, home, repoRoot: null };
+		const result = await loadClaudeMd(context);
+
+		expect(result.items.map(file => file.path)).toEqual([cwdClaude, intermediateClaude, homeClaude]);
+	});
+
+	test("includes home context when the repository root is above home", async () => {
+		const workspaceRoot = path.join(tempDir, "workspace");
+		const home = path.join(workspaceRoot, "user");
+		const repoRoot = workspaceRoot;
+		const cwd = path.join(home, "project");
+		fs.mkdirSync(cwd, { recursive: true });
+
+		const repoClaude = path.join(repoRoot, "CLAUDE.md");
+		const homeClaude = path.join(home, "CLAUDE.md");
+		writeClaude(repoClaude, "repo context");
+		writeClaude(homeClaude, "home context");
+
+		const context: LoadContext = { cwd, home, repoRoot };
+		const result = await loadClaudeMd(context);
+
+		expect(result.items.map(file => file.path)).toEqual([homeClaude, repoClaude]);
+	});
+
+	test("keeps the repository root boundary when the repository is outside home", async () => {
+		const home = path.join(tempDir, "home");
+		const workspaceRoot = path.join(tempDir, "workspace");
+		const repoRoot = path.join(workspaceRoot, "service");
+		const cwd = path.join(repoRoot, "src");
+		fs.mkdirSync(cwd, { recursive: true });
+
+		const repoClaude = path.join(repoRoot, "CLAUDE.md");
+		const workspaceClaude = path.join(workspaceRoot, "CLAUDE.md");
+		writeClaude(repoClaude, "repo context");
+		writeClaude(workspaceClaude, "workspace context");
+
+		const context: LoadContext = { cwd, home, repoRoot };
+		const result = await loadClaudeMd(context);
+
+		expect(result.items.map(file => file.path)).toEqual([repoClaude]);
+	});
+
+	test("skips CLAUDE.md inside a hidden owner directory", async () => {
+		const home = path.join(tempDir, "home");
+		const repoRoot = path.join(home, "repo");
+		const hiddenRoot = path.join(repoRoot, ".hidden");
+		const cwd = path.join(hiddenRoot, "service");
+		fs.mkdirSync(cwd, { recursive: true });
+
+		const hiddenClaude = path.join(hiddenRoot, "CLAUDE.md");
+		const repoClaude = path.join(repoRoot, "CLAUDE.md");
+		writeClaude(hiddenClaude, "hidden context");
+		writeClaude(repoClaude, "repo context");
+
+		const context: LoadContext = { cwd, home, repoRoot };
+		const result = await loadClaudeMd(context);
+
+		expect(result.items.map(file => file.path)).toEqual([repoClaude]);
+	});
+});


### PR DESCRIPTION
What

Adds loading of standalone CLAUDE.md files from the project root and ancestor directories, mirroring the existing
AGENTS.md discovery.

- New claude-md context-files provider (src/discovery/claude-md.ts): walks up from cwd loading <ancestor>/CLAUDE.md,
  stopping at the home boundary when the repo nests under home and skipping hidden-dir ancestors. Same scope/depth model
  as agents-md (priority 10), so per-depth dedup keeps config-directory context files (.claude/CLAUDE.md, priority 80)
  winning at the same scope while the standalone file fills levels the cwd-scoped .claude provider never covers.
- src/commit/agentic/index.ts: the "Discovering context files..." listing now shows CLAUDE.md alongside AGENTS.md (same
  role — guides commit message style).
- New test suite test/discovery/claude-md.test.ts (5 cases) mirroring the agents-md tests: nested-repo-under-home,
  no-repo-root, repo-above-home, repo-outside-home, hidden-dir skip.

Why

Claude Code reads a root CLAUDE.md as project memory; omp previously only loaded it from .claude/ config directories, so
projects with a standalone root CLAUDE.md got none of those instructions. This makes omp pick up the file in the
location Claude Code users already maintain, without changing precedence for existing config-dir context files.

Testing

- bun check passes (biome + tsgo --noEmit, clean).
- 17 tests pass across claude-md, agents-md, and context-file-dedup suites.
- Capability-load smoke test (temp repo, cwd under repo): root CLAUDE.md loaded at depth 1, nested at depth 0; with
  src/.claude/CLAUDE.md present it wins depth 0 and the standalone file is correctly shadowed.