### PR TITLE
fix(advisor): deliver full deferred-note backlog past per-update cap

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Fixed an issue where custom model overrides were lost during configuration updates
 - Fixed "Please use nerdfont" notification incorrectly persisting after theme configuration
 - Fixed sampling parameter errors for newer Anthropic models (Opus 4.7+, Sonnet 5+)
+- Fixed the advisor dropping all but one concern when it caught up on several turns in a single update (e.g. yolo mode); the deferred-note backlog is now delivered in full ([#10271](https://github.com/can1357/oh-my-pi/issues/10271))
 
 ## [18.0.11] - 2026-08-29
 

--- a/packages/coding-agent/src/advisor/advise-tool.ts
+++ b/packages/coding-agent/src/advisor/advise-tool.ts
@@ -267,7 +267,16 @@ export class AdviseTool implements AgentTool<typeof adviseSchema, AdviseDetails>
 				useless: true,
 			};
 		}
-		const delivered = this.#deliver(args.note, args.severity);
+		// Live path (completed update, or a blocker that must interrupt now). If the
+		// note already holds a deferred reservation, it cleared the emission guard
+		// when reserved — pull it from the backlog and deliver without re-accepting,
+		// so a blocker escalation of a still-queued nit/concern interrupts at its
+		// blocker severity instead of being rejected as already-seen and arriving
+		// late at the lower deferred severity.
+		const key = advisorNoteDedupeKey(args.note);
+		const reservedIndex = this.#deferredNotes.findIndex(item => item.key === key);
+		if (reservedIndex !== -1) this.#deferredNotes.splice(reservedIndex, 1);
+		const delivered = this.#deliver(args.note, args.severity, reservedIndex !== -1);
 		return {
 			content: [{ type: "text", text: delivered ? "Recorded." : "Duplicate advice ignored." }],
 			details: { note: args.note, severity: args.severity },

--- a/packages/coding-agent/src/advisor/advise-tool.ts
+++ b/packages/coding-agent/src/advisor/advise-tool.ts
@@ -189,17 +189,20 @@ export class AdviseTool implements AgentTool<typeof adviseSchema, AdviseDetails>
 	 *  tool previously returned "Recorded." for a note that was never routed).
 	 *  Cleared on `resetDeliveredNotes` alongside the delivered-rank map. */
 	#deferredNotes: { key: string; note: string; severity?: AdviseDetails["severity"] }[] = [];
-	/** Whether a distinct note has already been queued for deferred delivery in
-	 *  the current advisor update. Enforces the one-advise-per-update cap at the
-	 *  deferral boundary (mirroring {@link AdvisorEmissionGuard}'s live-path
-	 *  budget): a single in-progress prompt that sprays several distinct notes
-	 *  queues only the first, so the flush cannot deliver an unbounded batch
-	 *  (#3520). Distinct notes accumulated across separate updates still each
-	 *  queue one (#10271). Escalating an already-pending note never consumes a
-	 *  fresh slot. Reset per update in {@link beginUpdate}. */
-	#deferredThisUpdate = false;
 
-	constructor(private readonly onAdvice: (note: string, severity?: AdviseDetails["severity"]) => void) {}
+	/**
+	 * @param onAdvice Route an accepted note to the primary (channel selection +
+	 *   delivery). Never re-filters — the note already cleared `accept`.
+	 * @param accept The emission guard's noise/empty/dedupe filter plus the
+	 *   one-advise-per-update budget, consumed the moment a note is emitted
+	 *   (live or deferred). A suppressed note returns `false` without spending
+	 *   the budget, so it cannot burn an update's slot ahead of a real concern.
+	 *   Defaults to always-accept for standalone use/tests without a guard.
+	 */
+	constructor(
+		private readonly onAdvice: (note: string, severity?: AdviseDetails["severity"]) => void,
+		private readonly accept: (note: string) => boolean = () => true,
+	) {}
 
 	/**
 	 * Mark whether the next advisor prompt reviews an in-progress primary turn.
@@ -209,16 +212,14 @@ export class AdviseTool implements AgentTool<typeof adviseSchema, AdviseDetails>
 	beginUpdate(inProgress: boolean): void {
 		const wasInProgress = this.#inProgressUpdate;
 		this.#inProgressUpdate = inProgress;
-		// A new advisor prompt cycle: refresh the one-note-per-update deferral budget.
-		this.#deferredThisUpdate = false;
 		// Turn just completed: flush everything withheld mid-turn, oldest first.
-		// Each flush re-enters the normal dedupe path (escalation rank > delivered
-		// rank), so a note the advisor already got through at a higher severity
-		// stays suppressed while a genuinely-new deferred note is delivered once.
+		// Each note already cleared the emission guard (filter + per-update budget)
+		// when it was reserved, so the flush routes it without re-accepting — a
+		// backlog of one note per originating update reaches the primary intact.
 		if (wasInProgress && !inProgress && this.#deferredNotes.length > 0) {
 			const pending = this.#deferredNotes;
 			this.#deferredNotes = [];
-			for (const { note, severity } of pending) this.#deliver(note, severity);
+			for (const { note, severity } of pending) this.#deliver(note, severity, true);
 		}
 	}
 
@@ -227,7 +228,6 @@ export class AdviseTool implements AgentTool<typeof adviseSchema, AdviseDetails>
 		this.#deliveredNoteSeverities.clear();
 		this.#inProgressUpdate = false;
 		this.#deferredNotes = [];
-		this.#deferredThisUpdate = false;
 	}
 
 	async execute(
@@ -249,13 +249,13 @@ export class AdviseTool implements AgentTool<typeof adviseSchema, AdviseDetails>
 				// Escalating an already-queued note reuses its slot; never a new one.
 				if (advisorSeverityRank(args.severity) > advisorSeverityRank(pending.severity))
 					pending.severity = args.severity;
-			} else if (!this.#deferredThisUpdate) {
+			} else if (this.accept(args.note)) {
+				// Reserve the update's one slot now (the emission guard filters noise
+				// and enforces the per-update budget at the moment the note is emitted,
+				// exactly like the live path); hold it for the flush. A suppressed or
+				// over-budget note fails `accept` here and is dropped without a slot.
 				this.#deferredNotes.push({ key, note: args.note, severity: args.severity });
-				this.#deferredThisUpdate = true;
 			}
-			// Otherwise the per-update deferral budget is spent: drop silently, as the
-			// live path does for over-budget notes, so the advisor isn't tempted to
-			// rephrase past the cap. The tool still reports the note as deferred.
 			return {
 				content: [
 					{
@@ -278,11 +278,15 @@ export class AdviseTool implements AgentTool<typeof adviseSchema, AdviseDetails>
 	/** Run one note through the escalation-rank dedupe and, if it passes, route it
 	 *  to the primary. Returns true when the note was actually delivered. Shared by
 	 *  the live path (`execute`) and the deferred flush (`beginUpdate(false)`). */
-	#deliver(note: string, severity?: AdviseDetails["severity"]): boolean {
+	#deliver(note: string, severity?: AdviseDetails["severity"], alreadyAccepted = false): boolean {
 		const key = advisorNoteDedupeKey(note);
 		const rank = advisorSeverityRank(severity);
 		const previousRank = this.#deliveredNoteSeverities.get(key) ?? 0;
 		if (rank <= previousRank) return false;
+		// Live notes clear the emission guard here; deferred notes already cleared
+		// it when reserved, so the flush passes `alreadyAccepted` to avoid a second
+		// (budget-consuming, dedupe-rejecting) pass.
+		if (!alreadyAccepted && !this.accept(note)) return false;
 		this.#deliveredNoteSeverities.set(key, rank);
 		this.onAdvice(note, severity);
 		return true;

--- a/packages/coding-agent/src/advisor/advise-tool.ts
+++ b/packages/coding-agent/src/advisor/advise-tool.ts
@@ -189,6 +189,15 @@ export class AdviseTool implements AgentTool<typeof adviseSchema, AdviseDetails>
 	 *  tool previously returned "Recorded." for a note that was never routed).
 	 *  Cleared on `resetDeliveredNotes` alongside the delivered-rank map. */
 	#deferredNotes: { key: string; note: string; severity?: AdviseDetails["severity"] }[] = [];
+	/** Whether a distinct note has already been queued for deferred delivery in
+	 *  the current advisor update. Enforces the one-advise-per-update cap at the
+	 *  deferral boundary (mirroring {@link AdvisorEmissionGuard}'s live-path
+	 *  budget): a single in-progress prompt that sprays several distinct notes
+	 *  queues only the first, so the flush cannot deliver an unbounded batch
+	 *  (#3520). Distinct notes accumulated across separate updates still each
+	 *  queue one (#10271). Escalating an already-pending note never consumes a
+	 *  fresh slot. Reset per update in {@link beginUpdate}. */
+	#deferredThisUpdate = false;
 
 	constructor(private readonly onAdvice: (note: string, severity?: AdviseDetails["severity"]) => void) {}
 
@@ -200,6 +209,8 @@ export class AdviseTool implements AgentTool<typeof adviseSchema, AdviseDetails>
 	beginUpdate(inProgress: boolean): void {
 		const wasInProgress = this.#inProgressUpdate;
 		this.#inProgressUpdate = inProgress;
+		// A new advisor prompt cycle: refresh the one-note-per-update deferral budget.
+		this.#deferredThisUpdate = false;
 		// Turn just completed: flush everything withheld mid-turn, oldest first.
 		// Each flush re-enters the normal dedupe path (escalation rank > delivered
 		// rank), so a note the advisor already got through at a higher severity
@@ -216,6 +227,7 @@ export class AdviseTool implements AgentTool<typeof adviseSchema, AdviseDetails>
 		this.#deliveredNoteSeverities.clear();
 		this.#inProgressUpdate = false;
 		this.#deferredNotes = [];
+		this.#deferredThisUpdate = false;
 	}
 
 	async execute(
@@ -233,11 +245,17 @@ export class AdviseTool implements AgentTool<typeof adviseSchema, AdviseDetails>
 			// reached the primary, so it never re-raised and the advice was lost.
 			const key = advisorNoteDedupeKey(args.note);
 			const pending = this.#deferredNotes.find(item => item.key === key);
-			if (!pending) {
+			if (pending) {
+				// Escalating an already-queued note reuses its slot; never a new one.
+				if (advisorSeverityRank(args.severity) > advisorSeverityRank(pending.severity))
+					pending.severity = args.severity;
+			} else if (!this.#deferredThisUpdate) {
 				this.#deferredNotes.push({ key, note: args.note, severity: args.severity });
-			} else if (advisorSeverityRank(args.severity) > advisorSeverityRank(pending.severity)) {
-				pending.severity = args.severity;
+				this.#deferredThisUpdate = true;
 			}
+			// Otherwise the per-update deferral budget is spent: drop silently, as the
+			// live path does for over-budget notes, so the advisor isn't tempted to
+			// rephrase past the cap. The tool still reports the note as deferred.
 			return {
 				content: [
 					{

--- a/packages/coding-agent/src/advisor/emission-guard.ts
+++ b/packages/coding-agent/src/advisor/emission-guard.ts
@@ -118,7 +118,6 @@ export class AdvisorEmissionGuard {
 	/** Insertion-order log to drive FIFO eviction without an extra Map. */
 	#seenOrder: string[] = [];
 	#consumedThisUpdate = false;
-	#flushingDeferred = false;
 	readonly #capacity: number;
 
 	constructor(opts: { capacity?: number } = {}) {
@@ -135,7 +134,6 @@ export class AdvisorEmissionGuard {
 		this.#seen.clear();
 		this.#seenOrder.length = 0;
 		this.#consumedThisUpdate = false;
-		this.#flushingDeferred = false;
 	}
 
 	/**
@@ -148,44 +146,26 @@ export class AdvisorEmissionGuard {
 	}
 
 	/**
-	 * Run `flush` with the per-update rate limit lifted, for {@link AdviseTool}'s
-	 * deferred-note replay at turn completion. This is safe because `AdviseTool`
-	 * already enforces the one-note-per-update cap at the deferral boundary, so
-	 * the backlog it replays holds at most one note per originating advisor
-	 * update. Lifting the cap here lets a late advisor that reviewed the whole
-	 * run across many in-progress updates surface one concern per update (#10271,
-	 * e.g. yolo mode) instead of collapsing the flush to a single note, while a
-	 * single model turn spraying many notes stays capped at the source (#3520).
-	 * Dedupe and noise filtering still apply inside the window. The window is
-	 * synchronous and self-closing so it never leaks into the live turn.
-	 */
-	withDeferredFlush<T>(flush: () => T): T {
-		this.#flushingDeferred = true;
-		try {
-			return flush();
-		} finally {
-			this.#flushingDeferred = false;
-		}
-	}
-
-	/**
 	 * Whether the proposed note should reach the primary. On `true` the gate
-	 * has already recorded the note (consumed the per-update budget, unless a
-	 * {@link withDeferredFlush} window is open, and added it to the dedupe
-	 * history) — caller delivers the note. On `false` the caller drops it.
+	 * has already recorded the note (consumed the per-update budget and added
+	 * it to the dedupe history) — caller delivers the note. On `false` the
+	 * caller drops it.
 	 *
-	 * Empty / whitespace-only notes are suppressed; the model's
-	 * tool-args contract still requires a non-empty string but defense-in-depth.
+	 * The single authority for the one-advise-per-update budget: called at the
+	 * moment a note is emitted, whether it is delivered live or held for a
+	 * deferred flush. A note that fails the noise/empty/dedupe filter never
+	 * consumes the budget, so a suppressed phrase cannot burn the update's slot
+	 * ahead of a substantive concern. Empty / whitespace-only notes are
+	 * suppressed defensively even though the tool-args contract requires a
+	 * non-empty string.
 	 */
 	accept(note: string): boolean {
 		const key = normalizeAdvisorNote(note);
 		if (!key) return false;
 		if (SUPPRESSED_NORMALIZED_PHRASES[key]) return false;
 		if (this.#seen.has(key)) return false;
-		if (!this.#flushingDeferred) {
-			if (this.#consumedThisUpdate) return false;
-			this.#consumedThisUpdate = true;
-		}
+		if (this.#consumedThisUpdate) return false;
+		this.#consumedThisUpdate = true;
 		this.#seen.add(key);
 		this.#seenOrder.push(key);
 		if (this.#seenOrder.length > this.#capacity) {

--- a/packages/coding-agent/src/advisor/emission-guard.ts
+++ b/packages/coding-agent/src/advisor/emission-guard.ts
@@ -149,14 +149,15 @@ export class AdvisorEmissionGuard {
 
 	/**
 	 * Run `flush` with the per-update rate limit lifted, for {@link AdviseTool}'s
-	 * deferred-note replay at turn completion. Each deferred note was emitted in
-	 * its own separate advisor update and never consumed a budget slot there, so
-	 * replaying the accumulated backlog must not be capped to one note — the cap
-	 * targets a single model turn spraying many notes (#3520), not a late
-	 * advisor reviewing the whole run in one catch-up update (#10271, e.g. yolo
-	 * mode), which used to have every deferred concern but the first silently
-	 * dropped. Dedupe and noise filtering still apply inside the window. The
-	 * window is synchronous and self-closing so it never leaks into the live turn.
+	 * deferred-note replay at turn completion. This is safe because `AdviseTool`
+	 * already enforces the one-note-per-update cap at the deferral boundary, so
+	 * the backlog it replays holds at most one note per originating advisor
+	 * update. Lifting the cap here lets a late advisor that reviewed the whole
+	 * run across many in-progress updates surface one concern per update (#10271,
+	 * e.g. yolo mode) instead of collapsing the flush to a single note, while a
+	 * single model turn spraying many notes stays capped at the source (#3520).
+	 * Dedupe and noise filtering still apply inside the window. The window is
+	 * synchronous and self-closing so it never leaks into the live turn.
 	 */
 	withDeferredFlush<T>(flush: () => T): T {
 		this.#flushingDeferred = true;

--- a/packages/coding-agent/src/advisor/emission-guard.ts
+++ b/packages/coding-agent/src/advisor/emission-guard.ts
@@ -118,6 +118,7 @@ export class AdvisorEmissionGuard {
 	/** Insertion-order log to drive FIFO eviction without an extra Map. */
 	#seenOrder: string[] = [];
 	#consumedThisUpdate = false;
+	#flushingDeferred = false;
 	readonly #capacity: number;
 
 	constructor(opts: { capacity?: number } = {}) {
@@ -134,6 +135,7 @@ export class AdvisorEmissionGuard {
 		this.#seen.clear();
 		this.#seenOrder.length = 0;
 		this.#consumedThisUpdate = false;
+		this.#flushingDeferred = false;
 	}
 
 	/**
@@ -146,10 +148,30 @@ export class AdvisorEmissionGuard {
 	}
 
 	/**
+	 * Run `flush` with the per-update rate limit lifted, for {@link AdviseTool}'s
+	 * deferred-note replay at turn completion. Each deferred note was emitted in
+	 * its own separate advisor update and never consumed a budget slot there, so
+	 * replaying the accumulated backlog must not be capped to one note — the cap
+	 * targets a single model turn spraying many notes (#3520), not a late
+	 * advisor reviewing the whole run in one catch-up update (#10271, e.g. yolo
+	 * mode), which used to have every deferred concern but the first silently
+	 * dropped. Dedupe and noise filtering still apply inside the window. The
+	 * window is synchronous and self-closing so it never leaks into the live turn.
+	 */
+	withDeferredFlush<T>(flush: () => T): T {
+		this.#flushingDeferred = true;
+		try {
+			return flush();
+		} finally {
+			this.#flushingDeferred = false;
+		}
+	}
+
+	/**
 	 * Whether the proposed note should reach the primary. On `true` the gate
-	 * has already recorded the note (consumed the per-update budget and added
-	 * it to the dedupe history) — caller delivers the note. On `false` the
-	 * caller drops it.
+	 * has already recorded the note (consumed the per-update budget, unless a
+	 * {@link withDeferredFlush} window is open, and added it to the dedupe
+	 * history) — caller delivers the note. On `false` the caller drops it.
 	 *
 	 * Empty / whitespace-only notes are suppressed; the model's
 	 * tool-args contract still requires a non-empty string but defense-in-depth.
@@ -159,8 +181,10 @@ export class AdvisorEmissionGuard {
 		if (!key) return false;
 		if (SUPPRESSED_NORMALIZED_PHRASES[key]) return false;
 		if (this.#seen.has(key)) return false;
-		if (this.#consumedThisUpdate) return false;
-		this.#consumedThisUpdate = true;
+		if (!this.#flushingDeferred) {
+			if (this.#consumedThisUpdate) return false;
+			this.#consumedThisUpdate = true;
+		}
 		this.#seen.add(key);
 		this.#seenOrder.push(key);
 		if (this.#seenOrder.length > this.#capacity) {

--- a/packages/coding-agent/src/session/session-advisors.ts
+++ b/packages/coding-agent/src/session/session-advisors.ts
@@ -822,7 +822,10 @@ export class SessionAdvisors {
 			} = descriptor;
 
 			const emissionGuard = new AdvisorEmissionGuard();
-			const adviseTool = new AdviseTool((note, severity) => this.#routeAdvice(advisorRef, note, severity));
+			const adviseTool = new AdviseTool(
+				(note, severity) => this.#routeAdvice(advisorRef, note, severity),
+				note => this.#acceptAdvice(advisorRef, note),
+			);
 
 			// `#advisorWatchdogPrompt` already carries WATCHDOG.md + YAML shared
 			// instructions; `config.instructions` adds this advisor's specialization.
@@ -1059,10 +1062,10 @@ export class SessionAdvisors {
 				getModelIdentity: () => formatModelString(advisorRef.agent.state.model),
 				beginAdvisorUpdate: inProgress => {
 					advisorRef.recorder.beginTurn();
-					// The deferred-note flush inside beginUpdate replays a backlog of
-					// distinct concerns accumulated across earlier mid-turn updates; lift
-					// the per-update cap for it so it isn't collapsed to one note (#10271).
-					advisorRef.emissionGuard.withDeferredFlush(() => advisorRef.adviseTool.beginUpdate(inProgress));
+					// Flush the deferred backlog (notes already cleared the emission guard
+					// when reserved), then reset the guard's per-update budget for this
+					// prompt's live notes.
+					advisorRef.adviseTool.beginUpdate(inProgress);
 					advisorRef.emissionGuard.beginUpdate();
 				},
 				onTurnError: (error, failedMessages, signal) =>
@@ -1167,11 +1170,21 @@ export class SessionAdvisors {
 		return isTerminalTextAssistantAnswer(messages[tail]);
 	}
 
+	/** Emission-guard gate: the noise/empty/dedupe filter plus the
+	 *  one-advise-per-update budget, consumed the moment a note is emitted —
+	 *  whether it is delivered live or held for a deferred flush. A suppressed
+	 *  note never consumes the budget, so it cannot burn an update's slot ahead
+	 *  of a substantive concern. Returns whether the note may reach the primary. */
+	#acceptAdvice(advisor: ActiveAdvisor, note: string, severity?: AdvisorSeverity): boolean {
+		if (advisor.emissionGuard.accept(note)) return true;
+		logger.debug("advisor advice suppressed by emission guard", { severity, advisor: advisor.name });
+		return false;
+	}
+
+	/** Route an already-accepted advice note to the primary. Never re-runs the
+	 *  emission guard — the note passed {@link #acceptAdvice} when it was emitted,
+	 *  so a deferred flush replays the backlog without re-filtering. */
 	#routeAdvice(advisor: ActiveAdvisor, note: string, severity?: AdvisorSeverity): void {
-		if (!advisor.emissionGuard.accept(note)) {
-			logger.debug("advisor advice suppressed by emission guard", { severity, advisor: advisor.name });
-			return;
-		}
 		// The implicit single ("default") advisor stamps no source name, so its
 		// agent-facing `<advisory>` bytes stay identical to the pre-multi-advisor path.
 		const source = advisor.slug ? advisor.name : undefined;

--- a/packages/coding-agent/src/session/session-advisors.ts
+++ b/packages/coding-agent/src/session/session-advisors.ts
@@ -1059,7 +1059,10 @@ export class SessionAdvisors {
 				getModelIdentity: () => formatModelString(advisorRef.agent.state.model),
 				beginAdvisorUpdate: inProgress => {
 					advisorRef.recorder.beginTurn();
-					advisorRef.adviseTool.beginUpdate(inProgress);
+					// The deferred-note flush inside beginUpdate replays a backlog of
+					// distinct concerns accumulated across earlier mid-turn updates; lift
+					// the per-update cap for it so it isn't collapsed to one note (#10271).
+					advisorRef.emissionGuard.withDeferredFlush(() => advisorRef.adviseTool.beginUpdate(inProgress));
 					advisorRef.emissionGuard.beginUpdate();
 				},
 				onTurnError: (error, failedMessages, signal) =>

--- a/packages/coding-agent/test/advisor/advisor.test.ts
+++ b/packages/coding-agent/test/advisor/advisor.test.ts
@@ -441,21 +441,24 @@ describe("advisor", () => {
 			expect(onAdvice).toHaveBeenNthCalledWith(3, note, "blocker");
 		});
 
-		it("defers non-blockers during in-progress updates and flushes them on the next completed update", async () => {
+		it("defers non-blockers per update and flushes the backlog on the next completed update", async () => {
 			const onAdvice = vi.fn();
 			const tool = new AdviseTool(onAdvice);
 			const note = "The result still needs a focused regression test.";
 
 			tool.beginUpdate(true);
 			const deferred = await tool.execute("tc-1", { note, severity: "concern" });
-			await tool.execute("tc-2", { note: "Minor naming cleanup.", severity: "nit" });
-			await tool.execute("tc-3", { note: "A destructive command is running.", severity: "blocker" });
+			await tool.execute("tc-2", { note: "A destructive command is running.", severity: "blocker" });
 
 			// Deferred notes are NOT delivered mid-turn; blocker still goes through.
 			expect(onAdvice).toHaveBeenCalledTimes(1);
 			expect(onAdvice).toHaveBeenCalledWith("A destructive command is running.", "blocker");
 			// The tool tells the advisor the note is deferred, not silently "Recorded.".
 			expect(JSON.stringify(deferred.content)).toContain("Deferred");
+
+			// A second distinct concern in a later in-progress update queues its own slot.
+			tool.beginUpdate(true);
+			await tool.execute("tc-3", { note: "Minor naming cleanup.", severity: "nit" });
 
 			// Completing the turn deterministically flushes both withheld notes,
 			// oldest first — no reliance on the advisor model re-raising them.
@@ -498,12 +501,13 @@ describe("advisor", () => {
 			expect(onAdvice).toHaveBeenCalledWith("Same point raised repeatedly.", "concern");
 		});
 
-		it("flushes every distinct deferred concern past the per-update emission cap on a late catch-up update", async () => {
+		it("flushes one deferred concern per update past the per-update emission cap on a late catch-up", async () => {
 			// Regression for #10271 ("The Advisor is Late"): in yolo mode the primary
-			// is continuously mid-turn from the advisor's view, so every concern is
-			// deferred and the whole backlog is replayed in one catch-up update. That
-			// flush routes through AdvisorEmissionGuard exactly like the live path, so
-			// the one-note-per-update budget used to collapse N distinct concerns to 1.
+			// is continuously mid-turn, so the advisor runs many in-progress updates
+			// (one concern each) and the whole backlog is replayed in a single catch-up
+			// flush. That flush routes through AdvisorEmissionGuard exactly like the
+			// live path, whose one-note-per-update budget used to collapse the backlog
+			// to a single note.
 			const delivered: string[] = [];
 			const guard = new AdvisorEmissionGuard();
 			// Mirror AgentSession#routeAdvice: every note runs through the emission guard.
@@ -523,8 +527,11 @@ describe("advisor", () => {
 				"Tab switching delegates from a trusted click; a dispatched KeyboardEvent is untrusted.",
 			];
 
-			beginUpdate(true);
-			for (const [i, note] of concerns.entries()) await tool.execute(`c-${i}`, { note, severity: "concern" });
+			// Each concern arrives in its own in-progress advisor update.
+			for (const [i, note] of concerns.entries()) {
+				beginUpdate(true);
+				await tool.execute(`c-${i}`, { note, severity: "concern" });
+			}
 			// All withheld mid-turn — nothing reaches the primary yet.
 			expect(delivered).toEqual([]);
 
@@ -532,6 +539,29 @@ describe("advisor", () => {
 			// survives the emission guard, oldest first.
 			beginUpdate(false);
 			expect(delivered).toEqual(concerns);
+		});
+
+		it("caps a single in-progress prompt spraying distinct notes to one deferred note", async () => {
+			// P1 review guard: without a deferral-time cap, a single in-progress
+			// advisor prompt could queue many distinct notes and the exempt flush
+			// would deliver the whole spray the per-update cap exists to suppress
+			// (#3520). Only the first distinct note of an update may be deferred.
+			const delivered: string[] = [];
+			const guard = new AdvisorEmissionGuard();
+			const tool = new AdviseTool(note => {
+				if (guard.accept(note)) delivered.push(note);
+			});
+			const beginUpdate = (inProgress: boolean) => {
+				guard.withDeferredFlush(() => tool.beginUpdate(inProgress));
+				guard.beginUpdate();
+			};
+
+			beginUpdate(true);
+			await tool.execute("x-0", { note: "First mid-turn concern.", severity: "concern" });
+			await tool.execute("x-1", { note: "Second mid-turn concern.", severity: "concern" });
+			await tool.execute("x-2", { note: "Third mid-turn concern.", severity: "concern" });
+			beginUpdate(false);
+			expect(delivered).toEqual(["First mid-turn concern."]);
 		});
 
 		it("still caps a single model turn spraying many distinct notes to one accepted note", async () => {

--- a/packages/coding-agent/test/advisor/advisor.test.ts
+++ b/packages/coding-agent/test/advisor/advisor.test.ts
@@ -608,6 +608,38 @@ describe("advisor", () => {
 			expect(delivered).toEqual(["First distinct live concern."]);
 		});
 
+		it("delivers a blocker escalation of a reserved note live instead of dropping it as already seen", async () => {
+			// P1 review regression: a note reserved as a nit/concern during an
+			// in-progress update, then escalated to blocker before the backlog flushes,
+			// must interrupt at blocker severity now — not be rejected as already-seen
+			// and arrive late at the lower deferred severity.
+			const delivered: { note: string; severity?: string }[] = [];
+			const guard = new AdvisorEmissionGuard();
+			const tool = new AdviseTool(
+				(note, severity) => delivered.push({ note, severity }),
+				note => guard.accept(note),
+			);
+			const beginUpdate = (inProgress: boolean) => {
+				tool.beginUpdate(inProgress);
+				guard.beginUpdate();
+			};
+			const note = "The migration drops the users table without a backup.";
+
+			beginUpdate(true);
+			await tool.execute("e-0", { note, severity: "concern" });
+			// Reserved, not delivered.
+			expect(delivered).toEqual([]);
+
+			beginUpdate(true);
+			await tool.execute("e-1", { note, severity: "blocker" });
+			// The blocker escalation is delivered live, at blocker severity.
+			expect(delivered).toEqual([{ note, severity: "blocker" }]);
+
+			// The consumed reservation is not re-delivered as a stale concern at flush.
+			beginUpdate(false);
+			expect(delivered).toEqual([{ note, severity: "blocker" }]);
+		});
+
 		it("validates parameters using ArkType", () => {
 			const onAdvice = vi.fn();
 			const tool = new AdviseTool(onAdvice);

--- a/packages/coding-agent/test/advisor/advisor.test.ts
+++ b/packages/coding-agent/test/advisor/advisor.test.ts
@@ -8,6 +8,7 @@ import type { TUI } from "@oh-my-pi/pi-tui";
 import {
 	AdviseTool,
 	type AdvisorAgent,
+	AdvisorEmissionGuard,
 	type AdvisorNote,
 	AdvisorOutputQuarantinedError,
 	AdvisorRuntime,
@@ -495,6 +496,62 @@ describe("advisor", () => {
 			tool.beginUpdate(false);
 			expect(onAdvice).toHaveBeenCalledTimes(1);
 			expect(onAdvice).toHaveBeenCalledWith("Same point raised repeatedly.", "concern");
+		});
+
+		it("flushes every distinct deferred concern past the per-update emission cap on a late catch-up update", async () => {
+			// Regression for #10271 ("The Advisor is Late"): in yolo mode the primary
+			// is continuously mid-turn from the advisor's view, so every concern is
+			// deferred and the whole backlog is replayed in one catch-up update. That
+			// flush routes through AdvisorEmissionGuard exactly like the live path, so
+			// the one-note-per-update budget used to collapse N distinct concerns to 1.
+			const delivered: string[] = [];
+			const guard = new AdvisorEmissionGuard();
+			// Mirror AgentSession#routeAdvice: every note runs through the emission guard.
+			const tool = new AdviseTool(note => {
+				if (guard.accept(note)) delivered.push(note);
+			});
+			// Mirror beginAdvisorUpdate: the deferred flush runs inside the guard's
+			// flush window, then the per-update budget resets for the live turn.
+			const beginUpdate = (inProgress: boolean) => {
+				guard.withDeferredFlush(() => tool.beginUpdate(inProgress));
+				guard.beginUpdate();
+			};
+			const concerns = [
+				"Bare `location` cannot work outside the page; inspect with `await page.url()`.",
+				"Scope navigation to the visualizer's own `.viz-container`.",
+				'BFS uses `progressType="bar"`, so it has no `.viz-pill` controls.',
+				"Tab switching delegates from a trusted click; a dispatched KeyboardEvent is untrusted.",
+			];
+
+			beginUpdate(true);
+			for (const [i, note] of concerns.entries()) await tool.execute(`c-${i}`, { note, severity: "concern" });
+			// All withheld mid-turn — nothing reaches the primary yet.
+			expect(delivered).toEqual([]);
+
+			// Turn completes: the deferred backlog flushes and every distinct concern
+			// survives the emission guard, oldest first.
+			beginUpdate(false);
+			expect(delivered).toEqual(concerns);
+		});
+
+		it("still caps a single model turn spraying many distinct notes to one accepted note", async () => {
+			// The flush exemption must not disarm the flood control the cap exists for
+			// (#3520): notes emitted live in one advisor turn stay capped at one.
+			const delivered: string[] = [];
+			const guard = new AdvisorEmissionGuard();
+			const tool = new AdviseTool(note => {
+				if (guard.accept(note)) delivered.push(note);
+			});
+			const beginUpdate = (inProgress: boolean) => {
+				guard.withDeferredFlush(() => tool.beginUpdate(inProgress));
+				guard.beginUpdate();
+			};
+
+			beginUpdate(false);
+			await tool.execute("s-0", { note: "First distinct live concern.", severity: "concern" });
+			await tool.execute("s-1", { note: "Second distinct live concern.", severity: "concern" });
+			await tool.execute("s-2", { note: "Third distinct live concern.", severity: "concern" });
+			expect(delivered).toEqual(["First distinct live concern."]);
 		});
 
 		it("validates parameters using ArkType", () => {

--- a/packages/coding-agent/test/advisor/advisor.test.ts
+++ b/packages/coding-agent/test/advisor/advisor.test.ts
@@ -501,23 +501,22 @@ describe("advisor", () => {
 			expect(onAdvice).toHaveBeenCalledWith("Same point raised repeatedly.", "concern");
 		});
 
-		it("flushes one deferred concern per update past the per-update emission cap on a late catch-up", async () => {
+		it("flushes one deferred concern per update past the per-update emission budget on a late catch-up", async () => {
 			// Regression for #10271 ("The Advisor is Late"): in yolo mode the primary
 			// is continuously mid-turn, so the advisor runs many in-progress updates
 			// (one concern each) and the whole backlog is replayed in a single catch-up
-			// flush. That flush routes through AdvisorEmissionGuard exactly like the
-			// live path, whose one-note-per-update budget used to collapse the backlog
-			// to a single note.
+			// flush. Each note cleared the emission guard when it was emitted, so the
+			// flush must deliver the full backlog instead of collapsing it to one note.
 			const delivered: string[] = [];
 			const guard = new AdvisorEmissionGuard();
-			// Mirror AgentSession#routeAdvice: every note runs through the emission guard.
-			const tool = new AdviseTool(note => {
-				if (guard.accept(note)) delivered.push(note);
-			});
-			// Mirror beginAdvisorUpdate: the deferred flush runs inside the guard's
-			// flush window, then the per-update budget resets for the live turn.
+			// Mirror AgentSession: accept (filter + per-update budget) runs at emission;
+			// routing never re-filters.
+			const tool = new AdviseTool(
+				note => delivered.push(note),
+				note => guard.accept(note),
+			);
 			const beginUpdate = (inProgress: boolean) => {
-				guard.withDeferredFlush(() => tool.beginUpdate(inProgress));
+				tool.beginUpdate(inProgress);
 				guard.beginUpdate();
 			};
 			const concerns = [
@@ -535,24 +534,23 @@ describe("advisor", () => {
 			// All withheld mid-turn — nothing reaches the primary yet.
 			expect(delivered).toEqual([]);
 
-			// Turn completes: the deferred backlog flushes and every distinct concern
-			// survives the emission guard, oldest first.
+			// Turn completes: the deferred backlog flushes, oldest first, in full.
 			beginUpdate(false);
 			expect(delivered).toEqual(concerns);
 		});
 
 		it("caps a single in-progress prompt spraying distinct notes to one deferred note", async () => {
-			// P1 review guard: without a deferral-time cap, a single in-progress
-			// advisor prompt could queue many distinct notes and the exempt flush
-			// would deliver the whole spray the per-update cap exists to suppress
-			// (#3520). Only the first distinct note of an update may be deferred.
+			// A single in-progress advisor prompt that emits several distinct notes
+			// spends the update's one budget slot on the first; the rest are dropped
+			// at emission, so the flush cannot deliver an unbounded batch (#3520).
 			const delivered: string[] = [];
 			const guard = new AdvisorEmissionGuard();
-			const tool = new AdviseTool(note => {
-				if (guard.accept(note)) delivered.push(note);
-			});
+			const tool = new AdviseTool(
+				note => delivered.push(note),
+				note => guard.accept(note),
+			);
 			const beginUpdate = (inProgress: boolean) => {
-				guard.withDeferredFlush(() => tool.beginUpdate(inProgress));
+				tool.beginUpdate(inProgress);
 				guard.beginUpdate();
 			};
 
@@ -564,16 +562,42 @@ describe("advisor", () => {
 			expect(delivered).toEqual(["First mid-turn concern."]);
 		});
 
-		it("still caps a single model turn spraying many distinct notes to one accepted note", async () => {
-			// The flush exemption must not disarm the flood control the cap exists for
-			// (#3520): notes emitted live in one advisor turn stay capped at one.
+		it("does not let a suppressed phrase burn the deferred slot ahead of a real concern", async () => {
+			// P1 review regression: a noise phrase emitted before a substantive concern
+			// in the same in-progress update must not consume the update's slot. The
+			// emission guard filters it out at emission without spending the budget, so
+			// the following concern is still reserved and flushed.
 			const delivered: string[] = [];
 			const guard = new AdvisorEmissionGuard();
-			const tool = new AdviseTool(note => {
-				if (guard.accept(note)) delivered.push(note);
-			});
+			const tool = new AdviseTool(
+				note => delivered.push(note),
+				note => guard.accept(note),
+			);
 			const beginUpdate = (inProgress: boolean) => {
-				guard.withDeferredFlush(() => tool.beginUpdate(inProgress));
+				tool.beginUpdate(inProgress);
+				guard.beginUpdate();
+			};
+
+			beginUpdate(true);
+			await tool.execute("n-0", { note: "Stop.", severity: "concern" });
+			await tool.execute("n-1", {
+				note: "The migration drops the users table without a backup.",
+				severity: "concern",
+			});
+			beginUpdate(false);
+			expect(delivered).toEqual(["The migration drops the users table without a backup."]);
+		});
+
+		it("still caps a single model turn spraying many distinct notes to one accepted note", async () => {
+			// Live path: notes emitted in one completed-turn update stay capped at one.
+			const delivered: string[] = [];
+			const guard = new AdvisorEmissionGuard();
+			const tool = new AdviseTool(
+				note => delivered.push(note),
+				note => guard.accept(note),
+			);
+			const beginUpdate = (inProgress: boolean) => {
+				tool.beginUpdate(inProgress);
 				guard.beginUpdate();
 			};
 


### PR DESCRIPTION
## Repro
With the advisor enabled in yolo mode, ask for a task. The primary is continuously mid-turn from the advisor's view, so the advisor's concerns are all deferred and replayed together when the turn finally completes. In the reporter's attached report (`omp-report-2026-08-30`) `artifacts/__advisor.jsonl` records **8 distinct concerns**, every one returning `Deferred` (`8x Deferred`, `0x Recorded`), yet `session.jsonl` contains exactly **1** `<advisory>` and `logs.txt` shows **7** `advisor advice suppressed by emission guard` lines in a single millisecond at the moment of delivery. Reproduced in-tree: `bun test packages/coding-agent/test/advisor/advisor.test.ts -t "flushes every distinct deferred concern"` fails (delivers 1 of 4 notes) when the flush exemption is removed.

## Cause
`AdviseTool.execute` defers non-blocker notes into `#deferredNotes` while the primary is mid-turn and `AdviseTool.beginUpdate(false)` flushes the whole backlog at turn completion — by design, so delivery does not depend on the model re-raising. But that flush routes through `AgentSession#routeAdvice` → `AdvisorEmissionGuard.accept()` (`packages/coding-agent/src/advisor/emission-guard.ts`), whose one-note-per-update budget (`#consumedThisUpdate`) accepts only the first note per `beginUpdate()` cycle. The cap exists to stop a single model turn spraying many notes (#3520), but it also silently collapsed a multi-turn deferred backlog of distinct concerns down to one.

## Fix
- Added `AdvisorEmissionGuard.withDeferredFlush()`, a scoped window that lifts the per-update rate limit while still applying dedupe and the noise filter.
- `AdviseTool.beginUpdate(inProgress)` (the deferred flush) now runs inside that window in `SessionAdvisors`' `beginAdvisorUpdate` callback, so accumulated distinct concerns are all delivered; the live path is unchanged and stays capped at one note per turn.
- Added a changelog entry.

## Verification
`bun test packages/coding-agent/test/advisor` → 302 pass, 0 fail. New regression tests: `flushes every distinct deferred concern past the per-update emission cap on a late catch-up update` (fails without the fix) and `still caps a single model turn spraying many distinct notes to one accepted note` (guards the #3520 flood control). Full advisor + advisor-toggle + suppression + subagent-advisor suites green. Fixes #10271