### PR TITLE
fix(tui): restore terminal before fatal stderr output

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Fixed an issue where custom model overrides were lost during configuration updates
 - Fixed "Please use nerdfont" notification incorrectly persisting after theme configuration
 - Fixed sampling parameter errors for newer Anthropic models (Opus 4.7+, Sonnet 5+)
+- Fixed top-level errors overwriting the active composer before the terminal was restored ([#10275](https://github.com/can1357/oh-my-pi/issues/10275)).
 
 ## [18.0.11] - 2026-08-29
 

--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -24,7 +24,7 @@ import {
 	setProfile,
 	VERSION,
 } from "@oh-my-pi/pi-utils/dirs";
-import { interceptUnhandledRejections } from "@oh-my-pi/pi-utils/postmortem";
+import { fatal, interceptUnhandledRejections } from "@oh-my-pi/pi-utils/postmortem";
 import { setProcessName } from "@oh-my-pi/pi-utils/process-name";
 import { declareWorkerHostEntry, installWorkerInbox, isWorkerHostSelector } from "@oh-my-pi/pi-utils/worker-host";
 import { BLOB_BROKER_WORKER_ARG } from "./blob-broker/protocol";
@@ -468,8 +468,5 @@ export async function runCli(argv: string[]): Promise<void> {
 // their entry with `import.meta.main === false`, so the worker-host dispatch
 // is admitted via `!Bun.isMainThread`.
 if (isProcessEntry || !Bun.isMainThread) {
-	runCli(process.argv.slice(2)).catch((err: unknown) => {
-		process.stderr.write(`${Bun.inspect(err, { colors: process.stderr.isTTY === true })}\n`);
-		process.exit(1);
-	});
+	runCli(process.argv.slice(2)).catch(fatal);
 }

--- a/packages/coding-agent/test/fatal-stderr-pty.test.ts
+++ b/packages/coding-agent/test/fatal-stderr-pty.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "bun:test";
+import { Terminal as VirtualTerminal } from "@oh-my-pi/pi-utils/vterm";
+
+const COLUMNS = 120;
+const ROWS = 30;
+
+async function writeTerminal(terminal: VirtualTerminal, data: Uint8Array): Promise<void> {
+	const { promise, resolve } = Promise.withResolvers<void>();
+	terminal.write(data, resolve);
+	await promise;
+}
+
+describe.skipIf(process.platform === "win32")("fatal stderr terminal handoff", () => {
+	it("keeps the composer boundary intact in a real PTY", async () => {
+		const chunks: Uint8Array[] = [];
+		const closed = Promise.withResolvers<void>();
+		await using terminal = new Bun.Terminal({
+			cols: COLUMNS,
+			rows: ROWS,
+			data(_terminal, data) {
+				chunks.push(data.slice());
+			},
+			exit() {
+				closed.resolve();
+			},
+		});
+		const proc = Bun.spawn([process.execPath, `${import.meta.dir}/fixtures/fatal-tui.ts`], {
+			cwd: process.cwd(),
+			env: { ...process.env, OMP_TUI_DEBUG: undefined },
+			terminal,
+		});
+
+		const exitCode = await proc.exited;
+		terminal.close();
+		await closed.promise;
+		expect(exitCode).toBe(1);
+
+		const screen = new VirtualTerminal({ cols: COLUMNS, rows: ROWS, scrollback: 100 });
+		for (const chunk of chunks) await writeTerminal(screen, chunk);
+		const buffer = screen.buffer.active;
+		const lines = Array.from({ length: buffer.length }, (_, row) =>
+			buffer.getLine(row)?.translateToString(true).trimEnd(),
+		);
+		const composerRow = lines.indexOf("╰─");
+		const errorRow = lines.findIndex(line => line?.includes("error: fatal PTY fixture") === true);
+
+		expect(composerRow).toBeGreaterThanOrEqual(0);
+		expect(errorRow).toBeGreaterThan(composerRow);
+	}, 15_000);
+});

--- a/packages/coding-agent/test/fixtures/fatal-tui.ts
+++ b/packages/coding-agent/test/fixtures/fatal-tui.ts
@@ -1,0 +1,14 @@
+import { Input, ProcessTerminal, Text, TUI } from "@oh-my-pi/pi-tui";
+import { fatal } from "@oh-my-pi/pi-utils/postmortem";
+
+const tui = new TUI(new ProcessTerminal(), false);
+const input = new Input();
+input.prompt = "╰─ ";
+
+tui.addChild(new Text("safe transcript", 0, 0));
+tui.addChild(input);
+tui.setFocus(input);
+tui.start({ clearScrollback: true });
+
+await Bun.sleep(100);
+await fatal(new Error("fatal PTY fixture"));

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed fatal cleanup leaving the cursor inside a focused input before stderr output ([#10275](https://github.com/can1357/oh-my-pi/issues/10275)).
+
 ## [18.0.11] - 2026-08-29
 
 ### Added

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -14,7 +14,7 @@
  */
 import * as fs from "node:fs";
 import { performance } from "node:perf_hooks";
-import { $flag, getDebugLogPath, logger } from "@oh-my-pi/pi-utils";
+import { $flag, getDebugLogPath, logger, postmortem } from "@oh-my-pi/pi-utils";
 import { DEFAULT_MAX_INLINE_IMAGES, ImageBudget } from "./components/image";
 import { TuiDebugServer } from "./debug-server";
 import { isKeyRelease, matchesKey } from "./keys";
@@ -795,6 +795,7 @@ export class TUI extends Container {
 	#forceViewportRepaintOnNextRender = false;
 	#hasEverRendered = false;
 	#stopped = false;
+	#cancelPostmortemRestore?: () => void;
 	/** True between a `deferInput` start() and enableInput(). */
 	#inputDeferred = false;
 	// Always-on event-loop lag probe. The high default threshold keeps it quiet;
@@ -1126,6 +1127,8 @@ export class TUI extends Container {
 			{ deferInput: this.#inputDeferred },
 		);
 		if (this.#stopped) return;
+		this.#cancelPostmortemRestore?.();
+		this.#cancelPostmortemRestore = postmortem.register("tui-restore", () => this.stop());
 		for (const listener of this.#startListeners) {
 			try {
 				listener();
@@ -1615,6 +1618,8 @@ export class TUI extends Container {
 	}
 
 	stop(): void {
+		this.#cancelPostmortemRestore?.();
+		this.#cancelPostmortemRestore = undefined;
 		this.#debugServer?.stop();
 		this.#debugServer = undefined;
 		this.#resizeSettleTimer?.cancel();

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `postmortem.fatal` for terminal-safe top-level failure reporting.
+
+### Fixed
+
+- Fatal reports now begin registered display cleanup before writing to stderr ([#10275](https://github.com/can1357/oh-my-pi/issues/10275)).
+
 ## [18.0.11] - 2026-08-29
 
 ### Fixed

--- a/packages/utils/src/postmortem.ts
+++ b/packages/utils/src/postmortem.ts
@@ -395,21 +395,38 @@ function formatFatalError(label: string, err: Error): string {
 	return `\n[${label}] ${name}: ${message}${formattedStack}\n`;
 }
 
-async function exitAfterFatal(label: string, logMessage: string, err: Error, reason: Reason): Promise<void> {
+async function exitAfterFatal(output: string, logMessage: string, err: Error, reason: Reason): Promise<never> {
 	const forcedExit = setTimeout(() => exitProcess(1), CLEANUP_DEADLINE_MS);
 	try {
+		// Cleanup callbacks are invoked synchronously before runCleanup returns its
+		// completion promise. TUI owners therefore hand the cursor back before the
+		// fatal report is written, while slower resource cleanup continues afterward.
+		const cleanup = runCleanup(reason);
 		restoreTerminalStderr();
 		// A revoked terminal can make stream writes raise another fatal error. Use
 		// the descriptor directly so failure stays synchronous and contained.
 		try {
-			fs.writeSync(2, `${formatFatalError(label, err)}${formatFatalRecoveryHints()}`);
+			fs.writeSync(2, output);
 		} catch {}
 		logger.error(logMessage, { err });
-		await runCleanup(reason);
+		await cleanup;
 	} finally {
 		clearTimeout(forcedExit);
 		exitProcess(1);
 	}
+}
+
+/**
+ * Reports a caught top-level failure after terminal owners restore their display, then exits.
+ */
+export async function fatal(error: unknown): Promise<never> {
+	const err = error instanceof Error ? error : new Error(String(error));
+	const output = `${Bun.inspect(error, { colors: process.stderr.isTTY === true })}\n${formatFatalRecoveryHints()}`;
+	if (!isMainThread) {
+		process.stderr.write(output);
+		process.exit(1);
+	}
+	return exitAfterFatal(output, "Fatal error", err, Reason.UNHANDLED_REJECTION);
 }
 
 if (isMainThread) {
@@ -461,7 +478,12 @@ if (isMainThread) {
 				});
 				return;
 			}
-			await exitAfterFatal("Uncaught Exception", "Uncaught exception", err, Reason.UNCAUGHT_EXCEPTION);
+			await exitAfterFatal(
+				`${formatFatalError("Uncaught Exception", err)}${formatFatalRecoveryHints()}`,
+				"Uncaught exception",
+				err,
+				Reason.UNCAUGHT_EXCEPTION,
+			);
 		})
 		.on("unhandledRejection", async reason => {
 			const err = reason instanceof Error ? reason : new Error(String(reason));
@@ -497,7 +519,12 @@ if (isMainThread) {
 					});
 				}
 			}
-			await exitAfterFatal("Unhandled Rejection", "Unhandled rejection", err, Reason.UNHANDLED_REJECTION);
+			await exitAfterFatal(
+				`${formatFatalError("Unhandled Rejection", err)}${formatFatalRecoveryHints()}`,
+				"Unhandled rejection",
+				err,
+				Reason.UNHANDLED_REJECTION,
+			);
 		})
 		.on("exit", async () => {
 			void runCleanup(Reason.EXIT); // fire and forget (exit imminent)


### PR DESCRIPTION
## Repro

Start a `ProcessTerminal` TUI with a focused `Input`, then reject through the top-level fatal path while the terminal is 120×30. Before this fix, `bun test packages/coding-agent/test/fatal-stderr-pty.test.ts` observes the fatal text beginning on the same row immediately after `╰─`, replacing the composer boundary.

## Cause

`packages/coding-agent/src/cli.ts` wrote a rejected `runCli()` error directly to stderr while the TUI still owned the hardware cursor. `ProcessTerminal.stop()` restores terminal modes but cannot place the cursor after the rendered document; only `TUI.stop()` has the frame geometry needed for a clean handoff, and `packages/utils/src/postmortem.ts` emitted fatal output before invoking registered cleanup.

## Fix

- Register each started `TUI` with postmortem cleanup so fatal shutdown calls `TUI.stop()` and moves the cursor below the composer.
- Add `postmortem.fatal()` and route the CLI's caught top-level rejection through the same cleanup-before-output path as process-level fatal handlers.
- Add a Bun native-PTY regression that renders the captured byte stream through the virtual terminal and asserts the composer row remains intact above the error.

## Verification

`bun test packages/coding-agent/test/fatal-stderr-pty.test.ts packages/utils/test/postmortem-cleanup-error.test.ts packages/tui/test/start-listener.test.ts packages/tui/test/emergency-restore-altscreen.test.ts` — 24 passed, 0 failed. `bun check` passed for all workspace packages. Manual 120×30 real-PTY capture showed `╰─` unchanged and the fatal report beginning on the next row.

Fixes #10275