### PR TITLE
fix(nix): restore bun lock guard

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -57,3 +57,5 @@ jobs:
             accept-flake-config = true
       - name: Evaluate every supported system
         run: nix flake check --all-systems --no-build --show-trace
+      - name: Verify generated Bun dependencies
+        run: nix build --no-link .#checks.x86_64-linux.bun-lock --show-trace

--- a/flake.nix
+++ b/flake.nix
@@ -164,6 +164,7 @@
             cd source
             mv nix/bun.nix nix/bun.expected.nix
             bun2nix -l bun.lock -c ../ -o nix/bun.nix
+            sed -i -e '$a\' nix/bun.nix
             diff -u nix/bun.expected.nix nix/bun.nix
             touch "$out"
           '';

--- a/nix/bun.nix
+++ b/nix/bun.nix
@@ -121,6 +121,10 @@
     url = "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz";
     hash = "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==";
   };
+  "@bgotink/kdl@0.4.0" = fetchurl {
+    url = "https://registry.npmjs.org/@bgotink/kdl/-/kdl-0.4.0.tgz";
+    hash = "sha512-F0uJCjo5FQvFdcGF5QbYVNfcGiRWlocuzyIdQxottZF2+gu6L2xjMGEu9PIpse2hifAca/19vIospgaETCKxIg==";
+  };
   "@biomejs/biome@2.5.10" = fetchurl {
     url = "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.10.tgz";
     hash = "sha512-WRKXARA3kTuiV5sxqTpobJ/I0MVd4vk3pOL6wnp5az4LntFIhWTj1RWZq3DI9PCEN3lXcqy7p5aqUHzvq8AXyQ==";

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Fixed an issue where custom model overrides were lost during configuration updates
 - Fixed "Please use nerdfont" notification incorrectly persisting after theme configuration
 - Fixed sampling parameter errors for newer Anthropic models (Opus 4.7+, Sonnet 5+)
+- Fixed Nix flake builds failing after dependency updates by regenerating offline Bun sources and making CI execute the lockfile consistency check ([#10280](https://github.com/can1357/oh-my-pi/issues/10280)).
 
 ## [18.0.11] - 2026-08-29
 

--- a/scripts/gen-nix-bun.test.ts
+++ b/scripts/gen-nix-bun.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import { BUN2NIX_NPM_SPEC, normalizeLockfileVersion, resolveNixBunDepsGenerator } from "./gen-nix-bun";
+import {
+	BUN2NIX_NPM_SPEC,
+	normalizeGeneratedNix,
+	normalizeLockfileVersion,
+	resolveNixBunDepsGenerator,
+} from "./gen-nix-bun";
 
 describe("resolveNixBunDepsGenerator", () => {
 	test("prefers bun2nix from the active development shell", () => {
@@ -43,5 +48,13 @@ describe("normalizeLockfileVersion", () => {
 
 	test("rejects a lockfile without a version stamp", () => {
 		expect(() => normalizeLockfileVersion("{}\n")).toThrow(/missing a lockfileVersion/);
+	});
+});
+
+describe("normalizeGeneratedNix", () => {
+	test("writes exactly one trailing LF for every generator output shape", () => {
+		expect(normalizeGeneratedNix("}")).toBe("}\n");
+		expect(normalizeGeneratedNix("}\n")).toBe("}\n");
+		expect(normalizeGeneratedNix("}\r\n\r\n")).toBe("}\n");
 	});
 });

--- a/scripts/gen-nix-bun.ts
+++ b/scripts/gen-nix-bun.ts
@@ -31,6 +31,11 @@ export function normalizeLockfileVersion(contents: string): string {
 	return `${contents.slice(0, stamp.index)}${stamp[1]}1${stamp[3]}${contents.slice(stamp.index + stamp[0].length)}`;
 }
 
+/** Canonicalize generated Nix output to exactly one trailing LF. */
+export function normalizeGeneratedNix(contents: string): string {
+	return `${contents.replace(/[\r\n]+$/, "")}\n`;
+}
+
 /** Rewrite `bun.lock` in place when Bun 1.4+ stamped it lockfileVersion 2. */
 async function normalizeBunLock(): Promise<void> {
 	const lockPath = path.join(repoRoot, "bun.lock");
@@ -63,16 +68,18 @@ export async function generateNixBunDeps(generator: NixBunDepsGenerator = resolv
 	await normalizeBunLock();
 	if (generator.kind === "bun2nix") {
 		await $`${generator.executable} -l bun.lock -c ../ -o nix/bun.nix`.cwd(repoRoot);
-		return;
-	}
-	if (generator.kind === "nix") {
+	} else if (generator.kind === "nix") {
 		await $`${generator.executable} --extra-experimental-features ${"nix-command flakes"} --accept-flake-config develop --command bun2nix -l bun.lock -c ../ -o nix/bun.nix`.cwd(
 			repoRoot,
 		);
-		return;
+	} else {
+		await $`bunx ${generator.package} -l bun.lock -c ../ -o nix/bun.nix`.cwd(repoRoot);
 	}
 
-	await $`bunx ${generator.package} -l bun.lock -c ../ -o nix/bun.nix`.cwd(repoRoot);
+	const outputPath = path.join(repoRoot, "nix/bun.nix");
+	const contents = await Bun.file(outputPath).text();
+	const normalized = normalizeGeneratedNix(contents);
+	if (normalized !== contents) await Bun.write(outputPath, normalized);
 }
 
 if (import.meta.main) await generateNixBunDeps();


### PR DESCRIPTION
## Repro

At the reported revision, `nix build --no-link .#checks.x86_64-linux.bun-lock` regenerates `nix/bun.nix` with the pinned bun2nix revision and fails its bytewise diff. I built that exact `0f2a1f…` bun2nix source and ran `cargo run --manifest-path /tmp/bun2nix-0f2a1f/programs/bun2nix/Cargo.toml -- -l bun.lock -c ../ -o /tmp/pinned-bun.nix`; the result adds `@bgotink/kdl@0.4.0`, differs from the committed file, and ends at `}` instead of LF.

## Cause

`nix/bun.nix` was not regenerated when `bun.lock` gained `@bgotink/kdl@0.4.0`. The `bun-lock` derivation in `flake.nix` then compared bun2nix's unterminated output byte-for-byte against the formatter-terminated committed file, so even synchronized content failed. `.github/workflows/nix.yml` only evaluated checks with `--no-build`, leaving that permanently red derivation unexecuted.

## Fix

- Regenerate `nix/bun.nix` with the missing fixed-output fetch entry.
- Canonicalize `gen:nix` output to one trailing LF and normalize the pinned generator output before the flake diff.
- Build `checks.x86_64-linux.bun-lock` in Linux CI so future lockfile drift blocks the change.
- Add a regression test for generated-output newline canonicalization and document the user-visible fix.

## Verification

`bun test scripts/gen-nix-bun.test.ts` passes: 8 tests, 0 failures. Running `bun run gen:nix` succeeds; after the same GNU `sed -i -e '$a\'` normalization used by the flake check, the exact pinned bun2nix output is byte-identical to the checked-in `nix/bun.nix`. The workspace does not provide `nix`, so the full flake derivation is delegated to the newly wired CI step. The pre-publish `bun check` gate passed.

Fixes #10280