### PR TITLE
fix(ai): pair composite Responses tool-call ids on the call_ component

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -19,6 +19,10 @@
 - Devin auth, model assignment, and chat requests now send the native Devin CLI identity (`ideName: devin-cli`, `ideType: chisel`, `extensionName: chisel`, mapped `os`) instead of the Windsurf IDE identity; `ideType: chisel` is what the backend requires for router assignment ([#8590](https://github.com/can1357/oh-my-pi/pull/8590) by [@will-bogusz](https://github.com/will-bogusz)).
 - Devin parallel tool calls follow `compat.supportsParallelToolCalls` instead of being disabled unconditionally, so natively discovered configs that support parallelism can use it ([#8590](https://github.com/can1357/oh-my-pi/pull/8590) by [@will-bogusz](https://github.com/will-bogusz)).
 
+### Fixed
+
+- Fixed OpenAI Codex/Responses tool results being dropped when their composite id (`call_X|fc_Y`) failed to pair with the assistant call, so the model no longer sees a synthetic "No result provided" stub in place of a result it produced; opaque Chat Completions ids are left untouched and pairing survives a cross-provider session switch ([#10284](https://github.com/can1357/oh-my-pi/pull/10284) by [@mattwilkinsonn](https://github.com/mattwilkinsonn)).
+
 ## [18.0.11] - 2026-08-29
 
 ### Fixed

--- a/packages/ai/src/providers/transform-messages.ts
+++ b/packages/ai/src/providers/transform-messages.ts
@@ -51,20 +51,42 @@ function responsesCallComponent(id: string): string {
 }
 
 /**
- * The set of `call_` components that provably originate from a Responses-family
- * assistant turn (keyed off the source message `api`). Only these may be
- * canonicalized by {@link toolCallPairingKey}: an opaque Chat Completions id
- * that merely contains `|` must pair by raw equality, never by its prefix.
+ * Origin classification for tool-call ids, tracked per CONCRETE id rather than
+ * by a global prefix set. Two facts drive whether an id may be canonicalized to
+ * its `call_` component for pairing:
+ *
+ *  - `responsesComponents`: the `call_` components of ids provably minted by a
+ *    Responses-family assistant turn (keyed off the source message `api`).
+ *  - `opaqueCompositeCallIds`: the FULL ids of pipe-bearing tool calls from a
+ *    NON-Responses (opaque Chat Completions) assistant turn. openai-completions
+ *    preserves these verbatim as provider correlation tokens; the `|` is
+ *    literal, so they must pair by raw equality even when their `call_` prefix
+ *    happens to collide with a Responses component seen elsewhere in history.
+ *
+ * Scoping by concrete id (not merely a shared prefix) is load-bearing (#10284):
+ * an earlier Responses `call_A` must not license canonicalizing later same-model
+ * Chat Completions ids `call_A|first` / `call_A|second` onto one `call_A`
+ * bucket, which would collapse two distinct opaque calls and steer a lone
+ * `call_A|second` result onto the wrong call.
  */
-function collectResponsesCompositePrefixes(messages: readonly Message[]): Set<string> {
-	const prefixes = new Set<string>();
+interface ToolCallOriginScope {
+	responsesComponents: ReadonlySet<string>;
+	opaqueCompositeCallIds: ReadonlySet<string>;
+}
+
+function collectToolCallOriginScope(messages: readonly Message[]): ToolCallOriginScope {
+	const responsesComponents = new Set<string>();
+	const opaqueCompositeCallIds = new Set<string>();
 	for (const msg of messages) {
-		if (msg.role !== "assistant" || !isResponsesFamilyApi(msg.api)) continue;
+		if (msg.role !== "assistant") continue;
+		const responsesOrigin = isResponsesFamilyApi(msg.api);
 		for (const block of msg.content) {
-			if (block.type === "toolCall") prefixes.add(responsesCallComponent(block.id));
+			if (block.type !== "toolCall") continue;
+			if (responsesOrigin) responsesComponents.add(responsesCallComponent(block.id));
+			else if (block.id.includes("|")) opaqueCompositeCallIds.add(block.id);
 		}
 	}
-	return prefixes;
+	return { responsesComponents, opaqueCompositeCallIds };
 }
 
 /**
@@ -77,15 +99,16 @@ function collectResponsesCompositePrefixes(messages: readonly Message[]): Set<st
  * while NOT collapsing two distinct parallel calls whose results happen to
  * share a `response_item` (`fc_`) half.
  *
- * SCOPING (load-bearing, #10284): only ids whose `call_` component is in
- * `responsesCompositePrefixes` — i.e. provably minted by a Responses-family
- * assistant turn — are canonicalized. A same-model Chat Completions id is an
- * OPAQUE provider correlation token that may itself contain `|`
- * (openai-completions.ts preserves it verbatim); splitting it would collapse
- * two distinct opaque calls onto one bucket, so the real result never pairs and
- * the call is back-filled with a synthetic stub. Opaque ids fall through to
- * full-id keying, where the provider's own echoed `tool_call_id` already pairs
- * result to call by raw equality.
+ * SCOPING (load-bearing, #10284): a pipe-bearing id is canonicalized to its
+ * `call_` component ONLY when it is not itself a concrete opaque-origin call id
+ * ({@link ToolCallOriginScope.opaqueCompositeCallIds}) and its component was
+ * minted by a Responses-family turn ({@link ToolCallOriginScope.responsesComponents}).
+ * A same-model Chat Completions id is an OPAQUE provider correlation token that
+ * may itself contain `|` (openai-completions.ts preserves it verbatim);
+ * splitting it would collapse two distinct opaque calls onto one bucket, so the
+ * real result never pairs and the call is back-filled with a synthetic stub.
+ * Opaque ids fall through to full-id keying, where the provider's own echoed
+ * `tool_call_id` already pairs result to call by raw equality.
  *
  * Pairing keys are used only for lookup; the messages' own ids are left intact
  * so the provider encoder still receives the exact wire ids it expects.
@@ -96,11 +119,12 @@ function collectResponsesCompositePrefixes(messages: readonly Message[]): Set<st
  * and genuine cross-turn id reuse is `_dup`-suffixed on the call_ segment by
  * `deduplicateToolCallIds` (which this key preserves).
  */
-function toolCallPairingKey(id: string, responsesCompositePrefixes: ReadonlySet<string>): string {
+function toolCallPairingKey(id: string, originScope: ToolCallOriginScope): string {
 	const pipe = id.indexOf("|");
 	if (pipe <= 0) return id;
+	if (originScope.opaqueCompositeCallIds.has(id)) return id;
 	const prefix = id.slice(0, pipe);
-	return responsesCompositePrefixes.has(prefix) ? prefix : id;
+	return originScope.responsesComponents.has(prefix) ? prefix : id;
 }
 
 function appendDuplicateSuffix(originalId: string, suffix: string, maxLength: number): string {
@@ -128,7 +152,7 @@ type PendingToolResultRewrite = { replacementId: string } | undefined;
 
 function deduplicateToolCallIds(
 	messages: Message[],
-	responsesCompositePrefixes: ReadonlySet<string>,
+	originScope: ToolCallOriginScope,
 	maxToolCallIdLength = MAX_TOOL_CALL_ID_LENGTH,
 	duplicateSuffixPrefix = "_dup",
 ): Message[] {
@@ -142,7 +166,7 @@ function deduplicateToolCallIds(
 			// call's canonical id. Raw-string keying here misses the composite,
 			// so the `_dup` remap silently no-ops and a reused call_id's later
 			// result is dropped downstream.
-			const key = toolCallPairingKey(msg.toolCallId, responsesCompositePrefixes);
+			const key = toolCallPairingKey(msg.toolCallId, originScope);
 			const rewrites = pendingToolResultRewrites.get(key);
 			if (!rewrites || rewrites.length === 0) return msg;
 
@@ -176,7 +200,7 @@ function deduplicateToolCallIds(
 			// share one counter + rewrite queue. The `_dup` SUFFIX still lands on
 			// the full wire id via `appendDuplicateSuffix` (below) — only the
 			// KEYING is canonical, so emitted ids are unchanged.
-			const blockKey = toolCallPairingKey(block.id, responsesCompositePrefixes);
+			const blockKey = toolCallPairingKey(block.id, originScope);
 
 			// Drop any pending rewrites carried over from a prior assistant turn
 			// for this id on its first appearance this turn. When a later turn
@@ -203,7 +227,7 @@ function deduplicateToolCallIds(
 				`${duplicateSuffixPrefix}${duplicateIndex}`,
 				maxToolCallIdLength,
 			);
-			while (seenToolCallIds.has(toolCallPairingKey(replacementId, responsesCompositePrefixes))) {
+			while (seenToolCallIds.has(toolCallPairingKey(replacementId, originScope))) {
 				duplicateIndex += 1;
 				replacementId = appendDuplicateSuffix(
 					block.id,
@@ -212,7 +236,7 @@ function deduplicateToolCallIds(
 				);
 			}
 			seenToolCallIds.set(blockKey, duplicateIndex + 1);
-			seenToolCallIds.set(toolCallPairingKey(replacementId, responsesCompositePrefixes), 1);
+			seenToolCallIds.set(toolCallPairingKey(replacementId, originScope), 1);
 			enqueueToolResultRewrite(blockKey, { replacementId });
 			contentChanged = true;
 			return { ...block, id: replacementId };
@@ -896,28 +920,33 @@ export function transformMessages<TApi extends Api>(
 						normalizedToolCall = { ...toolCall, thoughtSignature: undefined };
 					}
 
+					let normalizedId: string | undefined;
 					if (isAnthropicTarget) {
-						const normalizedId = normalizeAnthropicTargetToolCallId(
+						normalizedId = normalizeAnthropicTargetToolCallId(
 							toolCall.id,
 							model,
 							assistantMsg,
 							normalizeToolCallId,
 						);
+					} else if (!isSameModel && normalizeToolCallId) {
+						normalizedId = normalizeToolCallId(toolCall.id, model, assistantMsg);
+					}
+
+					if (normalizedId !== undefined) {
 						if (normalizedId !== toolCall.id) {
 							toolCallIdMap.set(toolCall.id, normalizedId);
-							if (isResponsesFamilyApi(assistantMsg.api) && toolCall.id.includes("|")) {
-								responsesCompositeIdMap.set(responsesCallComponent(toolCall.id), normalizedId);
-							}
 							normalizedToolCall = { ...normalizedToolCall, id: normalizedId };
 						}
-					} else if (!isSameModel && normalizeToolCallId) {
-						const normalizedId = normalizeToolCallId(toolCall.id, model, assistantMsg);
-						if (normalizedId !== toolCall.id) {
-							toolCallIdMap.set(toolCall.id, normalizedId);
-							if (isResponsesFamilyApi(assistantMsg.api) && toolCall.id.includes("|")) {
-								responsesCompositeIdMap.set(responsesCallComponent(toolCall.id), normalizedId);
-							}
-							normalizedToolCall = { ...normalizedToolCall, id: normalizedId };
+						// Record the Responses call-component → emitted-id mapping
+						// EVEN WHEN the assistant id is plain and normalization is
+						// identity. A composite RESULT (`call_A|fc_R`) for a plain
+						// Responses call `call_A` still needs this mapping to resolve
+						// onto the emitted id; without it the result stays composite
+						// and the target sees a call `call_A` beside a result
+						// `call_A|fc_R`, breaking call/result correspondence (and, on
+						// Anthropic, the id char rules).
+						if (isResponsesFamilyApi(assistantMsg.api)) {
+							responsesCompositeIdMap.set(responsesCallComponent(toolCall.id), normalizedId);
 						}
 					}
 
@@ -946,12 +975,13 @@ export function transformMessages<TApi extends Api>(
 		}
 		return msg;
 	});
-	// Prefixes provably minted by a Responses-family assistant turn — the only
-	// ids `toolCallPairingKey` may canonicalize to their `call_` component.
-	const responsesCompositePrefixes = collectResponsesCompositePrefixes(normalizedMessages);
+	// Per-concrete-id origin classification — the only scope `toolCallPairingKey`
+	// consults to decide whether a pipe-bearing id is a canonicalizable Responses
+	// composite or an opaque Chat Completions token that pairs by raw equality.
+	const originScope = collectToolCallOriginScope(normalizedMessages);
 	const transformed = deduplicateToolCallIds(
 		normalizedMessages,
-		responsesCompositePrefixes,
+		originScope,
 		maxNormalizedToolCallIdLength,
 		duplicateToolCallIdSuffixPrefix,
 	);
@@ -967,14 +997,14 @@ export function transformMessages<TApi extends Api>(
 		const msg = transformed[index];
 		if (msg.role === "toolResult") {
 			const entry: IndexedToolResult = { index, msg, consumed: false };
-			const key = toolCallPairingKey(msg.toolCallId, responsesCompositePrefixes);
+			const key = toolCallPairingKey(msg.toolCallId, originScope);
 			const entries = realToolResultsById.get(key);
 			if (entries) entries.push(entry);
 			else realToolResultsById.set(key, [entry]);
 		}
 	}
 	const takeRealToolResult = (id: string, afterIndex: number): ToolResultMessage | undefined => {
-		const entries = realToolResultsById.get(toolCallPairingKey(id, responsesCompositePrefixes));
+		const entries = realToolResultsById.get(toolCallPairingKey(id, originScope));
 		if (!entries) return undefined;
 		for (const entry of entries) {
 			if (entry.consumed || entry.index <= afterIndex) continue;
@@ -993,7 +1023,7 @@ export function transformMessages<TApi extends Api>(
 	for (const msg of transformed) {
 		if (msg.role !== "assistant") continue;
 		for (const block of msg.content) {
-			if (block.type === "toolCall") validToolUseIds.add(toolCallPairingKey(block.id, responsesCompositePrefixes));
+			if (block.type === "toolCall") validToolUseIds.add(toolCallPairingKey(block.id, originScope));
 		}
 	}
 
@@ -1014,7 +1044,7 @@ export function transformMessages<TApi extends Api>(
 	const flushPendingToolCalls = (timestamp: number): void => {
 		if (pendingToolCalls.length === 0) return;
 		for (const tc of pendingToolCalls) {
-			const statusKey = toolCallPairingKey(tc.id, responsesCompositePrefixes);
+			const statusKey = toolCallPairingKey(tc.id, originScope);
 			if (toolCallStatus.has(statusKey)) continue;
 			const realToolResult = takeRealToolResult(tc.id, pendingToolCallsStartIndex);
 			if (realToolResult) {
@@ -1038,7 +1068,7 @@ export function transformMessages<TApi extends Api>(
 	const flushPendingAbortedToolCalls = (): void => {
 		if (pendingAbortedTimestamp === undefined) return;
 		for (const tc of pendingAbortedToolCalls.values()) {
-			const statusKey = toolCallPairingKey(tc.id, responsesCompositePrefixes);
+			const statusKey = toolCallPairingKey(tc.id, originScope);
 			if (toolCallStatus.has(statusKey)) continue;
 			const realToolResult = takeRealToolResult(tc.id, pendingAbortedStartIndex);
 			if (realToolResult) {
@@ -1095,9 +1125,7 @@ export function transformMessages<TApi extends Api>(
 				// before the next turn boundary.
 				result.push(msg);
 				pendingAbortedToolCalls = new Map(
-					toolCalls.map(
-						toolCall => [toolCallPairingKey(toolCall.id, responsesCompositePrefixes), toolCall] as const,
-					),
+					toolCalls.map(toolCall => [toolCallPairingKey(toolCall.id, originScope), toolCall] as const),
 				);
 				pendingAbortedTimestamp = assistantMsg.timestamp;
 				pendingAbortedStartIndex = i;
@@ -1111,7 +1139,7 @@ export function transformMessages<TApi extends Api>(
 
 			result.push(msg);
 		} else if (msg.role === "toolResult") {
-			const resultKey = toolCallPairingKey(msg.toolCallId, responsesCompositePrefixes);
+			const resultKey = toolCallPairingKey(msg.toolCallId, originScope);
 			if (toolCallStatus.has(resultKey)) continue;
 
 			if (pendingAbortedToolCalls.has(resultKey)) {
@@ -1121,7 +1149,7 @@ export function transformMessages<TApi extends Api>(
 				continue;
 			}
 
-			if (pendingToolCalls.some(tc => toolCallPairingKey(tc.id, responsesCompositePrefixes) === resultKey)) {
+			if (pendingToolCalls.some(tc => toolCallPairingKey(tc.id, originScope) === resultKey)) {
 				toolCallStatus.set(resultKey, ToolCallStatus.Resolved);
 				result.push(msg);
 				continue;
@@ -1147,9 +1175,7 @@ export function transformMessages<TApi extends Api>(
 				// Drop the orphan silently in that case; the pending calls will be
 				// resolved in their own contiguous result window or at the next boundary.
 				if (
-					pendingToolCalls.some(
-						tc => !toolCallStatus.has(toolCallPairingKey(tc.id, responsesCompositePrefixes)),
-					) ||
+					pendingToolCalls.some(tc => !toolCallStatus.has(toolCallPairingKey(tc.id, originScope))) ||
 					pendingAbortedToolCalls.size > 0
 				) {
 					continue;

--- a/packages/ai/src/providers/transform-messages.ts
+++ b/packages/ai/src/providers/transform-messages.ts
@@ -29,6 +29,40 @@ const enum ToolCallStatus {
  */
 const MAX_TOOL_CALL_ID_LENGTH = 64;
 
+/**
+ * Canonical key for pairing a tool result with its assistant tool call.
+ *
+ * The OpenAI Codex Responses API stores a tool result's id as a composite
+ * `<call_id>|<response_item_id>` (e.g. `call_ABC|fc_XYZ`), while the assistant
+ * `toolCall` that produced it carries the plain `call_ABC`. The two must pair,
+ * but a raw-string compare treats them as disjoint — the real result is never
+ * pulled into the call's window and the call is back-filled with a synthetic
+ * "No result provided" stub. Keying both sides on the FIRST segment
+ * (the wire call_id — see `appendDuplicateSuffix` / `normalizeResponsesToolCallId`,
+ * which split on `|`) pairs them, while NOT collapsing two distinct parallel
+ * calls whose results happen to share a `response_item` (`fc_`) half.
+ *
+ * Pairing keys are used only for lookup; the messages' own ids are left intact
+ * so the provider encoder still receives the exact wire ids it expects.
+ *
+ * A valid wire call_id is non-empty, so the first segment is too; a degenerate
+ * `|itemId` (empty call half) is keyed on its full id rather than collapsing
+ * every such result onto one empty-string bucket.
+ *
+ * LOAD-BEARING INVARIANT: pairing correctness depends on the wire `call_id`
+ * being unique per distinct tool call. The Codex Responses wire guarantees this
+ * (distinct parallel calls carry distinct call_ids; only the `fc_` half varies),
+ * and genuine cross-turn id reuse is `_dup`-suffixed on the call_ segment by
+ * `deduplicateToolCallIds` (which this key preserves). Two DISTINCT calls sharing
+ * a call_ half with different item halves would collapse onto one key — but that
+ * shape is not producible by the wire; if a provider ever emits it, this needs a
+ * FIFO tiebreaker on the full id.
+ */
+function toolCallPairingKey(id: string): string {
+	const pipe = id.indexOf("|");
+	return pipe <= 0 ? id : id.slice(0, pipe);
+}
+
 function appendDuplicateSuffix(originalId: string, suffix: string, maxLength: number): string {
 	// Responses-family ids are composites (`callId|itemId`): the wire call_id is
 	// the FIRST segment (normalizeResponsesToolCallId splits on `|`), so the
@@ -62,11 +96,17 @@ function deduplicateToolCallIds(
 
 	return messages.map(msg => {
 		if (msg.role === "toolResult") {
-			const rewrites = pendingToolResultRewrites.get(msg.toolCallId);
+			// Pair on the call_ component: a composite result id
+			// (`call_X|fc_Y`) must find the rewrite enqueued under its assistant
+			// call's canonical id. Raw-string keying here misses the composite,
+			// so the `_dup` remap silently no-ops and a reused call_id's later
+			// result is dropped downstream.
+			const key = toolCallPairingKey(msg.toolCallId);
+			const rewrites = pendingToolResultRewrites.get(key);
 			if (!rewrites || rewrites.length === 0) return msg;
 
 			const rewrite = rewrites.shift();
-			if (rewrites.length === 0) pendingToolResultRewrites.delete(msg.toolCallId);
+			if (rewrites.length === 0) pendingToolResultRewrites.delete(key);
 			if (rewrite) return { ...msg, toolCallId: rewrite.replacementId };
 			return msg;
 		}
@@ -90,6 +130,13 @@ function deduplicateToolCallIds(
 		const content = msg.content.map(block => {
 			if (block.type !== "toolCall") return block;
 
+			// Route all dedup bookkeeping by the call_ component so a plain
+			// assistant id and a composite result id (`call_X` / `call_X|fc_Y`)
+			// share one counter + rewrite queue. The `_dup` SUFFIX still lands on
+			// the full wire id via `appendDuplicateSuffix` (below) — only the
+			// KEYING is canonical, so emitted ids are unchanged.
+			const blockKey = toolCallPairingKey(block.id);
+
 			// Drop any pending rewrites carried over from a prior assistant turn
 			// for this id on its first appearance this turn. When a later turn
 			// re-emits the same id, the older duplicate call's expected result
@@ -97,15 +144,15 @@ function deduplicateToolCallIds(
 			// "No result provided" for it, and the upcoming real result(id) must
 			// route to one of THIS turn's calls. Without this guard the older
 			// `_dup` id would steal the next result.
-			if (!idsTouchedInTurn.has(block.id)) {
-				pendingToolResultRewrites.delete(block.id);
-				idsTouchedInTurn.add(block.id);
+			if (!idsTouchedInTurn.has(blockKey)) {
+				pendingToolResultRewrites.delete(blockKey);
+				idsTouchedInTurn.add(blockKey);
 			}
 
-			const previousCount = seenToolCallIds.get(block.id) ?? 0;
+			const previousCount = seenToolCallIds.get(blockKey) ?? 0;
 			if (previousCount === 0) {
-				seenToolCallIds.set(block.id, 1);
-				enqueueToolResultRewrite(block.id, undefined);
+				seenToolCallIds.set(blockKey, 1);
+				enqueueToolResultRewrite(blockKey, undefined);
 				return block;
 			}
 
@@ -115,7 +162,7 @@ function deduplicateToolCallIds(
 				`${duplicateSuffixPrefix}${duplicateIndex}`,
 				maxToolCallIdLength,
 			);
-			while (seenToolCallIds.has(replacementId)) {
+			while (seenToolCallIds.has(toolCallPairingKey(replacementId))) {
 				duplicateIndex += 1;
 				replacementId = appendDuplicateSuffix(
 					block.id,
@@ -123,9 +170,9 @@ function deduplicateToolCallIds(
 					maxToolCallIdLength,
 				);
 			}
-			seenToolCallIds.set(block.id, duplicateIndex + 1);
-			seenToolCallIds.set(replacementId, 1);
-			enqueueToolResultRewrite(block.id, { replacementId });
+			seenToolCallIds.set(blockKey, duplicateIndex + 1);
+			seenToolCallIds.set(toolCallPairingKey(replacementId), 1);
+			enqueueToolResultRewrite(blockKey, { replacementId });
 			contentChanged = true;
 			return { ...block, id: replacementId };
 		});
@@ -858,13 +905,14 @@ export function transformMessages<TApi extends Api>(
 		const msg = transformed[index];
 		if (msg.role === "toolResult") {
 			const entry: IndexedToolResult = { index, msg, consumed: false };
-			const entries = realToolResultsById.get(msg.toolCallId);
+			const key = toolCallPairingKey(msg.toolCallId);
+			const entries = realToolResultsById.get(key);
 			if (entries) entries.push(entry);
-			else realToolResultsById.set(msg.toolCallId, [entry]);
+			else realToolResultsById.set(key, [entry]);
 		}
 	}
 	const takeRealToolResult = (id: string, afterIndex: number): ToolResultMessage | undefined => {
-		const entries = realToolResultsById.get(id);
+		const entries = realToolResultsById.get(toolCallPairingKey(id));
 		if (!entries) return undefined;
 		for (const entry of entries) {
 			if (entry.consumed || entry.index <= afterIndex) continue;
@@ -883,7 +931,7 @@ export function transformMessages<TApi extends Api>(
 	for (const msg of transformed) {
 		if (msg.role !== "assistant") continue;
 		for (const block of msg.content) {
-			if (block.type === "toolCall") validToolUseIds.add(block.id);
+			if (block.type === "toolCall") validToolUseIds.add(toolCallPairingKey(block.id));
 		}
 	}
 
@@ -904,11 +952,12 @@ export function transformMessages<TApi extends Api>(
 	const flushPendingToolCalls = (timestamp: number): void => {
 		if (pendingToolCalls.length === 0) return;
 		for (const tc of pendingToolCalls) {
-			if (toolCallStatus.has(tc.id)) continue;
+			const statusKey = toolCallPairingKey(tc.id);
+			if (toolCallStatus.has(statusKey)) continue;
 			const realToolResult = takeRealToolResult(tc.id, pendingToolCallsStartIndex);
 			if (realToolResult) {
 				result.push(realToolResult);
-				toolCallStatus.set(tc.id, ToolCallStatus.Resolved);
+				toolCallStatus.set(statusKey, ToolCallStatus.Resolved);
 				continue;
 			}
 			result.push({
@@ -919,7 +968,7 @@ export function transformMessages<TApi extends Api>(
 				isError: true,
 				timestamp,
 			} as ToolResultMessage);
-			toolCallStatus.set(tc.id, ToolCallStatus.Resolved);
+			toolCallStatus.set(statusKey, ToolCallStatus.Resolved);
 		}
 		pendingToolCalls = [];
 	};
@@ -927,11 +976,12 @@ export function transformMessages<TApi extends Api>(
 	const flushPendingAbortedToolCalls = (): void => {
 		if (pendingAbortedTimestamp === undefined) return;
 		for (const tc of pendingAbortedToolCalls.values()) {
-			if (toolCallStatus.has(tc.id)) continue;
+			const statusKey = toolCallPairingKey(tc.id);
+			if (toolCallStatus.has(statusKey)) continue;
 			const realToolResult = takeRealToolResult(tc.id, pendingAbortedStartIndex);
 			if (realToolResult) {
 				result.push(realToolResult);
-				toolCallStatus.set(tc.id, ToolCallStatus.Resolved);
+				toolCallStatus.set(statusKey, ToolCallStatus.Resolved);
 				continue;
 			}
 			result.push({
@@ -942,7 +992,7 @@ export function transformMessages<TApi extends Api>(
 				isError: true,
 				timestamp: pendingAbortedTimestamp,
 			} as ToolResultMessage);
-			toolCallStatus.set(tc.id, ToolCallStatus.Aborted);
+			toolCallStatus.set(statusKey, ToolCallStatus.Aborted);
 		}
 		pendingAbortedToolCalls = new Map();
 		pendingAbortedTimestamp = undefined;
@@ -982,7 +1032,9 @@ export function transformMessages<TApi extends Api>(
 				// emitted immediately if available; otherwise synthesize aborted results
 				// before the next turn boundary.
 				result.push(msg);
-				pendingAbortedToolCalls = new Map(toolCalls.map(toolCall => [toolCall.id, toolCall] as const));
+				pendingAbortedToolCalls = new Map(
+					toolCalls.map(toolCall => [toolCallPairingKey(toolCall.id), toolCall] as const),
+				);
 				pendingAbortedTimestamp = assistantMsg.timestamp;
 				pendingAbortedStartIndex = i;
 				continue;
@@ -995,22 +1047,23 @@ export function transformMessages<TApi extends Api>(
 
 			result.push(msg);
 		} else if (msg.role === "toolResult") {
-			if (toolCallStatus.has(msg.toolCallId)) continue;
+			const resultKey = toolCallPairingKey(msg.toolCallId);
+			if (toolCallStatus.has(resultKey)) continue;
 
-			if (pendingAbortedToolCalls.has(msg.toolCallId)) {
-				pendingAbortedToolCalls.delete(msg.toolCallId);
-				toolCallStatus.set(msg.toolCallId, ToolCallStatus.Resolved);
+			if (pendingAbortedToolCalls.has(resultKey)) {
+				pendingAbortedToolCalls.delete(resultKey);
+				toolCallStatus.set(resultKey, ToolCallStatus.Resolved);
 				result.push(msg);
 				continue;
 			}
 
-			if (pendingToolCalls.some(tc => tc.id === msg.toolCallId)) {
-				toolCallStatus.set(msg.toolCallId, ToolCallStatus.Resolved);
+			if (pendingToolCalls.some(tc => toolCallPairingKey(tc.id) === resultKey)) {
+				toolCallStatus.set(resultKey, ToolCallStatus.Resolved);
 				result.push(msg);
 				continue;
 			}
 
-			if (!validToolUseIds.has(msg.toolCallId)) {
+			if (!validToolUseIds.has(resultKey)) {
 				// Orphan `tool_result`: the originating `tool_use` is not present in the
 				// transformed history (typically because handoff/compaction folded the
 				// assistant message into a summary string while the user-side result
@@ -1029,7 +1082,10 @@ export function transformMessages<TApi extends Api>(
 				//
 				// Drop the orphan silently in that case; the pending calls will be
 				// resolved in their own contiguous result window or at the next boundary.
-				if (pendingToolCalls.some(tc => !toolCallStatus.has(tc.id)) || pendingAbortedToolCalls.size > 0) {
+				if (
+					pendingToolCalls.some(tc => !toolCallStatus.has(toolCallPairingKey(tc.id))) ||
+					pendingAbortedToolCalls.size > 0
+				) {
 					continue;
 				}
 				// No pending tool-call window: safe to preserve the text payload so the

--- a/packages/ai/src/providers/transform-messages.ts
+++ b/packages/ai/src/providers/transform-messages.ts
@@ -30,37 +30,77 @@ const enum ToolCallStatus {
 const MAX_TOOL_CALL_ID_LENGTH = 64;
 
 /**
+ * OpenAI Responses-family APIs mint composite tool ids (`call_id|item_id`);
+ * opaque Chat Completions ids do not (openai-completions preserves same-model
+ * ids verbatim as provider correlation tokens), so ONLY these origins may be
+ * canonicalized to their `call_` component for pairing.
+ */
+function isResponsesFamilyApi(api: Api | undefined): boolean {
+	return api === "openai-responses" || api === "openai-codex-responses" || api === "azure-openai-responses";
+}
+
+/**
+ * The wire `call_id` component of a (possibly composite) Responses id: the
+ * FIRST segment before `|`. A degenerate `|itemId` (empty call half, pipe at
+ * index 0) keeps its full id so unrelated empty-half ids never collapse onto
+ * one empty-string bucket.
+ */
+function responsesCallComponent(id: string): string {
+	const pipe = id.indexOf("|");
+	return pipe <= 0 ? id : id.slice(0, pipe);
+}
+
+/**
+ * The set of `call_` components that provably originate from a Responses-family
+ * assistant turn (keyed off the source message `api`). Only these may be
+ * canonicalized by {@link toolCallPairingKey}: an opaque Chat Completions id
+ * that merely contains `|` must pair by raw equality, never by its prefix.
+ */
+function collectResponsesCompositePrefixes(messages: readonly Message[]): Set<string> {
+	const prefixes = new Set<string>();
+	for (const msg of messages) {
+		if (msg.role !== "assistant" || !isResponsesFamilyApi(msg.api)) continue;
+		for (const block of msg.content) {
+			if (block.type === "toolCall") prefixes.add(responsesCallComponent(block.id));
+		}
+	}
+	return prefixes;
+}
+
+/**
  * Canonical key for pairing a tool result with its assistant tool call.
  *
- * The OpenAI Codex Responses API stores a tool result's id as a composite
+ * The OpenAI Codex/Responses APIs store a tool result's id as a composite
  * `<call_id>|<response_item_id>` (e.g. `call_ABC|fc_XYZ`), while the assistant
- * `toolCall` that produced it carries the plain `call_ABC`. The two must pair,
- * but a raw-string compare treats them as disjoint — the real result is never
- * pulled into the call's window and the call is back-filled with a synthetic
- * "No result provided" stub. Keying both sides on the FIRST segment
- * (the wire call_id — see `appendDuplicateSuffix` / `normalizeResponsesToolCallId`,
- * which split on `|`) pairs them, while NOT collapsing two distinct parallel
- * calls whose results happen to share a `response_item` (`fc_`) half.
+ * `toolCall` that produced it carries the plain `call_ABC` (or a composite with
+ * a DIFFERENT item half). Keying both sides on the FIRST segment pairs them,
+ * while NOT collapsing two distinct parallel calls whose results happen to
+ * share a `response_item` (`fc_`) half.
+ *
+ * SCOPING (load-bearing, #10284): only ids whose `call_` component is in
+ * `responsesCompositePrefixes` — i.e. provably minted by a Responses-family
+ * assistant turn — are canonicalized. A same-model Chat Completions id is an
+ * OPAQUE provider correlation token that may itself contain `|`
+ * (openai-completions.ts preserves it verbatim); splitting it would collapse
+ * two distinct opaque calls onto one bucket, so the real result never pairs and
+ * the call is back-filled with a synthetic stub. Opaque ids fall through to
+ * full-id keying, where the provider's own echoed `tool_call_id` already pairs
+ * result to call by raw equality.
  *
  * Pairing keys are used only for lookup; the messages' own ids are left intact
  * so the provider encoder still receives the exact wire ids it expects.
- *
- * A valid wire call_id is non-empty, so the first segment is too; a degenerate
- * `|itemId` (empty call half) is keyed on its full id rather than collapsing
- * every such result onto one empty-string bucket.
  *
  * LOAD-BEARING INVARIANT: pairing correctness depends on the wire `call_id`
  * being unique per distinct tool call. The Codex Responses wire guarantees this
  * (distinct parallel calls carry distinct call_ids; only the `fc_` half varies),
  * and genuine cross-turn id reuse is `_dup`-suffixed on the call_ segment by
- * `deduplicateToolCallIds` (which this key preserves). Two DISTINCT calls sharing
- * a call_ half with different item halves would collapse onto one key — but that
- * shape is not producible by the wire; if a provider ever emits it, this needs a
- * FIFO tiebreaker on the full id.
+ * `deduplicateToolCallIds` (which this key preserves).
  */
-function toolCallPairingKey(id: string): string {
+function toolCallPairingKey(id: string, responsesCompositePrefixes: ReadonlySet<string>): string {
 	const pipe = id.indexOf("|");
-	return pipe <= 0 ? id : id.slice(0, pipe);
+	if (pipe <= 0) return id;
+	const prefix = id.slice(0, pipe);
+	return responsesCompositePrefixes.has(prefix) ? prefix : id;
 }
 
 function appendDuplicateSuffix(originalId: string, suffix: string, maxLength: number): string {
@@ -88,6 +128,7 @@ type PendingToolResultRewrite = { replacementId: string } | undefined;
 
 function deduplicateToolCallIds(
 	messages: Message[],
+	responsesCompositePrefixes: ReadonlySet<string>,
 	maxToolCallIdLength = MAX_TOOL_CALL_ID_LENGTH,
 	duplicateSuffixPrefix = "_dup",
 ): Message[] {
@@ -101,7 +142,7 @@ function deduplicateToolCallIds(
 			// call's canonical id. Raw-string keying here misses the composite,
 			// so the `_dup` remap silently no-ops and a reused call_id's later
 			// result is dropped downstream.
-			const key = toolCallPairingKey(msg.toolCallId);
+			const key = toolCallPairingKey(msg.toolCallId, responsesCompositePrefixes);
 			const rewrites = pendingToolResultRewrites.get(key);
 			if (!rewrites || rewrites.length === 0) return msg;
 
@@ -135,7 +176,7 @@ function deduplicateToolCallIds(
 			// share one counter + rewrite queue. The `_dup` SUFFIX still lands on
 			// the full wire id via `appendDuplicateSuffix` (below) — only the
 			// KEYING is canonical, so emitted ids are unchanged.
-			const blockKey = toolCallPairingKey(block.id);
+			const blockKey = toolCallPairingKey(block.id, responsesCompositePrefixes);
 
 			// Drop any pending rewrites carried over from a prior assistant turn
 			// for this id on its first appearance this turn. When a later turn
@@ -162,7 +203,7 @@ function deduplicateToolCallIds(
 				`${duplicateSuffixPrefix}${duplicateIndex}`,
 				maxToolCallIdLength,
 			);
-			while (seenToolCallIds.has(toolCallPairingKey(replacementId))) {
+			while (seenToolCallIds.has(toolCallPairingKey(replacementId, responsesCompositePrefixes))) {
 				duplicateIndex += 1;
 				replacementId = appendDuplicateSuffix(
 					block.id,
@@ -171,7 +212,7 @@ function deduplicateToolCallIds(
 				);
 			}
 			seenToolCallIds.set(blockKey, duplicateIndex + 1);
-			seenToolCallIds.set(toolCallPairingKey(replacementId), 1);
+			seenToolCallIds.set(toolCallPairingKey(replacementId, responsesCompositePrefixes), 1);
 			enqueueToolResultRewrite(blockKey, { replacementId });
 			contentChanged = true;
 			return { ...block, id: replacementId };
@@ -541,6 +582,12 @@ export function transformMessages<TApi extends Api>(
 
 	// Build a map of original tool call IDs to normalized IDs
 	const toolCallIdMap = new Map<string, string>();
+	// Responses-family assistant composite ids (`call_id|item_id`) normalized for
+	// a cross-provider target keyed by their `call_id` component, so a paired
+	// tool RESULT arriving with a DIFFERENT item half still resolves to the same
+	// normalized id. Only Responses-origin ids populate this (opaque Chat
+	// Completions ids pair by raw equality and must never be canonicalized).
+	const responsesCompositeIdMap = new Map<string, string>();
 
 	const latestSurvivingAssistantIndex = getLatestSurvivingAssistantIndex(messages);
 	// First pass: transform messages (thinking blocks, tool call ID normalization)
@@ -552,7 +599,12 @@ export function transformMessages<TApi extends Api>(
 
 		// Handle toolResult messages - normalize toolCallId if we have a mapping
 		if (msg.role === "toolResult") {
-			const normalizedId = toolCallIdMap.get(msg.toolCallId);
+			const exactNormalizedId = toolCallIdMap.get(msg.toolCallId);
+			const normalizedId =
+				exactNormalizedId ??
+				(msg.toolCallId.includes("|")
+					? responsesCompositeIdMap.get(responsesCallComponent(msg.toolCallId))
+					: undefined);
 			if (normalizedId && normalizedId !== msg.toolCallId) {
 				return { ...msg, toolCallId: normalizedId };
 			}
@@ -853,12 +905,18 @@ export function transformMessages<TApi extends Api>(
 						);
 						if (normalizedId !== toolCall.id) {
 							toolCallIdMap.set(toolCall.id, normalizedId);
+							if (isResponsesFamilyApi(assistantMsg.api) && toolCall.id.includes("|")) {
+								responsesCompositeIdMap.set(responsesCallComponent(toolCall.id), normalizedId);
+							}
 							normalizedToolCall = { ...normalizedToolCall, id: normalizedId };
 						}
 					} else if (!isSameModel && normalizeToolCallId) {
 						const normalizedId = normalizeToolCallId(toolCall.id, model, assistantMsg);
 						if (normalizedId !== toolCall.id) {
 							toolCallIdMap.set(toolCall.id, normalizedId);
+							if (isResponsesFamilyApi(assistantMsg.api) && toolCall.id.includes("|")) {
+								responsesCompositeIdMap.set(responsesCallComponent(toolCall.id), normalizedId);
+							}
 							normalizedToolCall = { ...normalizedToolCall, id: normalizedId };
 						}
 					}
@@ -888,8 +946,12 @@ export function transformMessages<TApi extends Api>(
 		}
 		return msg;
 	});
+	// Prefixes provably minted by a Responses-family assistant turn — the only
+	// ids `toolCallPairingKey` may canonicalize to their `call_` component.
+	const responsesCompositePrefixes = collectResponsesCompositePrefixes(normalizedMessages);
 	const transformed = deduplicateToolCallIds(
 		normalizedMessages,
+		responsesCompositePrefixes,
 		maxNormalizedToolCallIdLength,
 		duplicateToolCallIdSuffixPrefix,
 	);
@@ -905,14 +967,14 @@ export function transformMessages<TApi extends Api>(
 		const msg = transformed[index];
 		if (msg.role === "toolResult") {
 			const entry: IndexedToolResult = { index, msg, consumed: false };
-			const key = toolCallPairingKey(msg.toolCallId);
+			const key = toolCallPairingKey(msg.toolCallId, responsesCompositePrefixes);
 			const entries = realToolResultsById.get(key);
 			if (entries) entries.push(entry);
 			else realToolResultsById.set(key, [entry]);
 		}
 	}
 	const takeRealToolResult = (id: string, afterIndex: number): ToolResultMessage | undefined => {
-		const entries = realToolResultsById.get(toolCallPairingKey(id));
+		const entries = realToolResultsById.get(toolCallPairingKey(id, responsesCompositePrefixes));
 		if (!entries) return undefined;
 		for (const entry of entries) {
 			if (entry.consumed || entry.index <= afterIndex) continue;
@@ -931,7 +993,7 @@ export function transformMessages<TApi extends Api>(
 	for (const msg of transformed) {
 		if (msg.role !== "assistant") continue;
 		for (const block of msg.content) {
-			if (block.type === "toolCall") validToolUseIds.add(toolCallPairingKey(block.id));
+			if (block.type === "toolCall") validToolUseIds.add(toolCallPairingKey(block.id, responsesCompositePrefixes));
 		}
 	}
 
@@ -952,7 +1014,7 @@ export function transformMessages<TApi extends Api>(
 	const flushPendingToolCalls = (timestamp: number): void => {
 		if (pendingToolCalls.length === 0) return;
 		for (const tc of pendingToolCalls) {
-			const statusKey = toolCallPairingKey(tc.id);
+			const statusKey = toolCallPairingKey(tc.id, responsesCompositePrefixes);
 			if (toolCallStatus.has(statusKey)) continue;
 			const realToolResult = takeRealToolResult(tc.id, pendingToolCallsStartIndex);
 			if (realToolResult) {
@@ -976,7 +1038,7 @@ export function transformMessages<TApi extends Api>(
 	const flushPendingAbortedToolCalls = (): void => {
 		if (pendingAbortedTimestamp === undefined) return;
 		for (const tc of pendingAbortedToolCalls.values()) {
-			const statusKey = toolCallPairingKey(tc.id);
+			const statusKey = toolCallPairingKey(tc.id, responsesCompositePrefixes);
 			if (toolCallStatus.has(statusKey)) continue;
 			const realToolResult = takeRealToolResult(tc.id, pendingAbortedStartIndex);
 			if (realToolResult) {
@@ -1033,7 +1095,9 @@ export function transformMessages<TApi extends Api>(
 				// before the next turn boundary.
 				result.push(msg);
 				pendingAbortedToolCalls = new Map(
-					toolCalls.map(toolCall => [toolCallPairingKey(toolCall.id), toolCall] as const),
+					toolCalls.map(
+						toolCall => [toolCallPairingKey(toolCall.id, responsesCompositePrefixes), toolCall] as const,
+					),
 				);
 				pendingAbortedTimestamp = assistantMsg.timestamp;
 				pendingAbortedStartIndex = i;
@@ -1047,7 +1111,7 @@ export function transformMessages<TApi extends Api>(
 
 			result.push(msg);
 		} else if (msg.role === "toolResult") {
-			const resultKey = toolCallPairingKey(msg.toolCallId);
+			const resultKey = toolCallPairingKey(msg.toolCallId, responsesCompositePrefixes);
 			if (toolCallStatus.has(resultKey)) continue;
 
 			if (pendingAbortedToolCalls.has(resultKey)) {
@@ -1057,7 +1121,7 @@ export function transformMessages<TApi extends Api>(
 				continue;
 			}
 
-			if (pendingToolCalls.some(tc => toolCallPairingKey(tc.id) === resultKey)) {
+			if (pendingToolCalls.some(tc => toolCallPairingKey(tc.id, responsesCompositePrefixes) === resultKey)) {
 				toolCallStatus.set(resultKey, ToolCallStatus.Resolved);
 				result.push(msg);
 				continue;
@@ -1083,7 +1147,9 @@ export function transformMessages<TApi extends Api>(
 				// Drop the orphan silently in that case; the pending calls will be
 				// resolved in their own contiguous result window or at the next boundary.
 				if (
-					pendingToolCalls.some(tc => !toolCallStatus.has(toolCallPairingKey(tc.id))) ||
+					pendingToolCalls.some(
+						tc => !toolCallStatus.has(toolCallPairingKey(tc.id, responsesCompositePrefixes)),
+					) ||
 					pendingAbortedToolCalls.size > 0
 				) {
 					continue;

--- a/packages/ai/test/duplicate-tool-results.test.ts
+++ b/packages/ai/test/duplicate-tool-results.test.ts
@@ -629,6 +629,357 @@ describe("Duplicate Tool Results Regression", () => {
 });
 
 /**
+ * Regression test for composite tool-call id pairing.
+ *
+ * The OpenAI Codex Responses API stores a tool result's id as a composite
+ * `<call_id>|<response_item_id>` (e.g. `call_ABC|fc_XYZ`), while the assistant
+ * `toolCall` that produced it carries the plain `call_ABC`. `transformMessages`
+ * paired the two by raw-string equality, so a valid pair looked disjoint: the
+ * real result was never pulled into the call's result window and the call was
+ * back-filled with a synthetic `"No result provided"` stub — the model ran a
+ * tool, the result was persisted, but the model saw nothing.
+ *
+ * Pairing must match on the stable `call_` component so a composite result finds
+ * its plain call, WITHOUT collapsing two distinct parallel calls whose results
+ * happen to share a `response_item` (`fc_`) half.
+ */
+describe("Composite Tool-Call Id Pairing", () => {
+	// The deployed gateway path is a SAME-MODEL Codex (openai-responses) replay:
+	// omp re-encodes Codex history back to a Codex target, so `isSameModel` holds
+	// and composite tool-call ids pass through untouched to the pairing logic
+	// (the cross-provider / anthropic-target id normalization at :598-613 does
+	// NOT fire). Model the tests on that path so composite ids reach the fix.
+	const model: Model<"openai-responses"> = buildModel({
+		api: "openai-responses",
+		provider: "openai",
+		id: "gpt-5-codex",
+		name: "GPT-5 Codex",
+		baseUrl: "https://api.openai.com",
+		input: ["text"],
+		cost: { input: 1, output: 4, cacheRead: 0.1, cacheWrite: 0 },
+		maxTokens: 8192,
+		contextWindow: 200000,
+		reasoning: true,
+	});
+
+	const makeToolCallAssistant = (ids: string[], timestamp: number): AssistantMessage => ({
+		role: "assistant",
+		content: ids.map(id => ({ type: "toolCall", id, name: "tool_search", arguments: {} })),
+		api: "openai-responses",
+		provider: "openai",
+		model: "gpt-5-codex",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "toolUse",
+		timestamp,
+	});
+
+	const makeToolResult = (id: string, text: string, timestamp: number): ToolResultMessage => ({
+		role: "toolResult",
+		toolCallId: id,
+		toolName: "tool_search",
+		content: [{ type: "text", text }],
+		isError: false,
+		timestamp,
+	});
+
+	// The transform preserves each result's own wire id (composite stays
+	// composite), so match on the stable call_ component, not the raw id.
+	//
+	// NOT `_dup`-aware: this keys on `toolCallId.split("|")[0]`, so a result whose
+	// call was `_dup`-renamed across turns (`call_X_dup1|fc_Y` splits to
+	// `call_X_dup1`) will NOT match `resultsFor(_, "call_X")` — it returns []. That
+	// is deliberate: stripping `_dupN` here would re-collapse the two now-distinct
+	// calls dedup separated and could mask a real drop. For any
+	// reuse/dedup case use a flat resultTexts scan (see the reuse tests below), not
+	// this helper.
+	const resultsFor = (messages: Message[], callId: string): ToolResultMessage[] =>
+		messages.filter(
+			(m): m is ToolResultMessage =>
+				m.role === "toolResult" &&
+				((m as ToolResultMessage).toolCallId === callId ||
+					(m as ToolResultMessage).toolCallId.split("|", 1)[0] === callId),
+		);
+
+	const hasSynthetic = (messages: Message[]): boolean =>
+		messages.some(
+			m =>
+				m.role === "toolResult" &&
+				(m as ToolResultMessage).content.some(part => part.type === "text" && part.text === "No result provided"),
+		);
+
+	it("pairs a composite result id with its plain assistant call id", () => {
+		const messages: Message[] = [
+			{ role: "user", content: "search", timestamp: 1 },
+			makeToolCallAssistant(["call_ABC"], 2),
+			makeToolResult("call_ABC|fc_XYZ", "205 tools found", 3),
+		];
+
+		const transformed = transformMessages(messages, model);
+
+		expect(hasSynthetic(transformed)).toBe(false);
+		const results = resultsFor(transformed, "call_ABC");
+		expect(results).toHaveLength(1);
+		expect(results[0]!.content).toEqual([{ type: "text", text: "205 tools found" }]);
+	});
+
+	it("keeps parallel composite results distinct when they share an fc_ half", () => {
+		const messages: Message[] = [
+			{ role: "user", content: "search twice", timestamp: 1 },
+			makeToolCallAssistant(["call_AAA", "call_BBB"], 2),
+			makeToolResult("call_AAA|fc_SHARED", "result A", 3),
+			makeToolResult("call_BBB|fc_SHARED", "result B", 4),
+		];
+
+		const transformed = transformMessages(messages, model);
+
+		expect(hasSynthetic(transformed)).toBe(false);
+		expect(resultsFor(transformed, "call_AAA").at(0)?.content).toEqual([{ type: "text", text: "result A" }]);
+		expect(resultsFor(transformed, "call_BBB").at(0)?.content).toEqual([{ type: "text", text: "result B" }]);
+	});
+
+	it("still pairs plain-to-plain ids (no regression)", () => {
+		const messages: Message[] = [
+			{ role: "user", content: "search", timestamp: 1 },
+			makeToolCallAssistant(["call_PLAIN"], 2),
+			makeToolResult("call_PLAIN", "plain result", 3),
+		];
+
+		const transformed = transformMessages(messages, model);
+
+		expect(hasSynthetic(transformed)).toBe(false);
+		expect(resultsFor(transformed, "call_PLAIN")).toHaveLength(1);
+	});
+
+	it("pairs when BOTH assistant and result ids are composite (same-provider Codex replay)", () => {
+		// The real deployed shape: the Codex decode path mints the assistant
+		// toolCall id composite too (encodeResponsesToolCallId(call_id, item_id)),
+		// while the result carries the same call_ half with a DIFFERENT item half.
+		// Both must collapse to the call_ component and pair.
+		const messages: Message[] = [
+			{ role: "user", content: "search", timestamp: 1 },
+			makeToolCallAssistant(["call_ABC|fc_ASSISTANT"], 2),
+			makeToolResult("call_ABC|fc_RESULT", "205 tools found", 3),
+		];
+
+		const transformed = transformMessages(messages, model);
+
+		expect(hasSynthetic(transformed)).toBe(false);
+		const results = resultsFor(transformed, "call_ABC");
+		expect(results).toHaveLength(1);
+		expect(results[0]!.content).toEqual([{ type: "text", text: "205 tools found" }]);
+	});
+
+	it("survives a reused wire call_id across turns (composite results)", () => {
+		// The SAME plain wire call_id is reused across two assistant turns,
+		// each result arriving as a composite with a DIFFERENT fc_ half. Before the
+		// fix, dedup keyed on the raw composite id, so turn-2's real result was
+		// dropped and back-filled with the "No result provided" synthetic stub.
+		// Canonical keying (toolCallPairingKey) now _dup-suffixes the reused call,
+		// so both turns' real results survive under distinct call_ halves.
+		const messages: Message[] = [
+			{ role: "user", content: "search", timestamp: 1 },
+			makeToolCallAssistant(["call_REUSE"], 2),
+			makeToolResult("call_REUSE|fc_T1", "result one", 3),
+			makeToolCallAssistant(["call_REUSE"], 4),
+			makeToolResult("call_REUSE|fc_T2", "result two", 5),
+		];
+
+		const transformed = transformMessages(messages, model);
+
+		expect(hasSynthetic(transformed)).toBe(false);
+		const resultTexts = transformed
+			.filter((m): m is ToolResultMessage => m.role === "toolResult")
+			.flatMap(m => m.content.flatMap(p => (p.type === "text" ? [p.text] : [])));
+		expect(resultTexts).toContain("result one");
+		expect(resultTexts).toContain("result two");
+	});
+
+	it("separates two calls sharing a call_ half so both results survive", () => {
+		// dedup's canonical keying (toolCallPairingKey) keeps two same-turn calls
+		// that share a call_ half (call_DUP|fc_A + call_DUP|fc_B) distinct: the
+		// second is _dup-suffixed rather than collapsing onto the first's pairing
+		// key, so BOTH results survive instead of one being dropped.
+		const messages: Message[] = [
+			{ role: "user", content: "search twice", timestamp: 1 },
+			makeToolCallAssistant(["call_DUP|fc_A", "call_DUP|fc_B"], 2),
+			makeToolResult("call_DUP|fc_A", "result A", 3),
+			makeToolResult("call_DUP|fc_B", "result B", 4),
+		];
+
+		const transformed = transformMessages(messages, model);
+
+		expect(hasSynthetic(transformed)).toBe(false);
+		const resultTexts = transformed
+			.filter((m): m is ToolResultMessage => m.role === "toolResult")
+			.flatMap(m => m.content.flatMap(p => (p.type === "text" ? [p.text] : [])));
+		expect(resultTexts).toContain("result A");
+		expect(resultTexts).toContain("result B");
+	});
+
+	it("survives a wire call_id reused across THREE turns (_dup2 + seen-counter)", () => {
+		// The reuse case extended past two turns: the SAME plain wire call_id is reused across
+		// THREE assistant turns, each result a distinct composite (`fc_`) half. The
+		// third turn drives dedup's per-key seen-counter to 2 (the `_dup2` suffix) and
+		// exercises the collision-guard `while` loop that bumps duplicateIndex past an
+		// already-taken `_dupN` key. Pre-fix (raw-composite keying) turns 2 & 3 were
+		// dropped to "No result provided" stubs; canonical keying keeps all three real
+		// results under distinct call_ halves.
+		const messages: Message[] = [
+			{ role: "user", content: "search", timestamp: 1 },
+			makeToolCallAssistant(["call_REUSE3"], 2),
+			makeToolResult("call_REUSE3|fc_T1", "result one", 3),
+			makeToolCallAssistant(["call_REUSE3"], 4),
+			makeToolResult("call_REUSE3|fc_T2", "result two", 5),
+			makeToolCallAssistant(["call_REUSE3"], 6),
+			makeToolResult("call_REUSE3|fc_T3", "result three", 7),
+		];
+
+		const transformed = transformMessages(messages, model);
+
+		expect(hasSynthetic(transformed)).toBe(false);
+		const resultTexts = transformed
+			.filter((m): m is ToolResultMessage => m.role === "toolResult")
+			.flatMap(m => m.content.flatMap(p => (p.type === "text" ? [p.text] : [])));
+		expect(resultTexts).toContain("result one");
+		expect(resultTexts).toContain("result two");
+		expect(resultTexts).toContain("result three");
+	});
+
+	it("pairs a composite assistant call id with a PLAIN result id (mirror of the composite-result/plain-call case)", () => {
+		// Mirror of the "pairs a composite result id with its plain assistant call
+		// id" case: here the assistant
+		// call carries the composite (`call_MIRROR|fc_X`) and the result arrives plain
+		// (`call_MIRROR`). Both must collapse to the `call_` component and pair.
+		// Pre-fix, raw-key pairing missed (`call_MIRROR|fc_X` !== `call_MIRROR`) and the
+		// call was back-filled with the synthetic stub.
+		const messages: Message[] = [
+			{ role: "user", content: "search", timestamp: 1 },
+			makeToolCallAssistant(["call_MIRROR|fc_X"], 2),
+			makeToolResult("call_MIRROR", "205 tools found", 3),
+		];
+
+		const transformed = transformMessages(messages, model);
+
+		expect(hasSynthetic(transformed)).toBe(false);
+		const results = resultsFor(transformed, "call_MIRROR");
+		expect(results).toHaveLength(1);
+		expect(results[0]!.content).toEqual([{ type: "text", text: "205 tools found" }]);
+	});
+
+	it("keeps two empty-call-half results distinct end-to-end", () => {
+		// Characterization of the empty-call-half shape (`|fc_X`, pipe at index 0).
+		// `toolCallPairingKey` returns the FULL id when `pipe <= 0` rather than the
+		// empty-string prefix, specifically so two
+		// UNRELATED empty-half calls don't collapse onto one shared "" bucket.
+		//
+		// What this test actually defends: an empty-call-half id is representable
+		// end-to-end — `sanitizeMalformedToolCalls` does NOT drop it (the id is a
+		// non-empty string; only ""/whitespace ids are malformed), and both parallel
+		// results survive distinct rather than one being dropped to a synthetic stub.
+		//
+		// NOTE (deliberately narrow claim): this does NOT independently pin the
+		// `pipe <= 0` branch. `deduplicateToolCallIds` runs first, and if both ids
+		// collapsed to "" it would `_dup`-suffix the second (`_dup1`) and re-separate
+		// them — so a `<= 0` -> `< 0` regression stays masked and green here. The teeth
+		// this test has are on the upstream-representability + no-collapse contract.
+		const messages: Message[] = [
+			{ role: "user", content: "search twice", timestamp: 1 },
+			makeToolCallAssistant(["|fc_A", "|fc_B"], 2),
+			makeToolResult("|fc_A", "result A", 3),
+			makeToolResult("|fc_B", "result B", 4),
+		];
+
+		const transformed = transformMessages(messages, model);
+
+		expect(hasSynthetic(transformed)).toBe(false);
+		const resultTexts = transformed
+			.filter((m): m is ToolResultMessage => m.role === "toolResult")
+			.flatMap(m => m.content.flatMap(p => (p.type === "text" ? [p.text] : [])));
+		expect(resultTexts).toContain("result A");
+		expect(resultTexts).toContain("result B");
+	});
+
+	it("pairs a composite result on the aborted-turn path", () => {
+		// flushPendingAbortedToolCalls also keys on the pairing key. An assistant
+		// turn that aborted mid-tool-call, then a real composite result arriving
+		// after, must pair — not be replaced by the "aborted" synthetic stub.
+		const abortedAssistant: AssistantMessage = { ...makeToolCallAssistant(["call_ABORT"], 2), stopReason: "aborted" };
+		const messages: Message[] = [
+			{ role: "user", content: "search", timestamp: 1 },
+			abortedAssistant,
+			makeToolResult("call_ABORT|fc_LATE", "205 tools found", 3),
+		];
+
+		const transformed = transformMessages(messages, model);
+
+		const results = resultsFor(transformed, "call_ABORT");
+		expect(results).toHaveLength(1);
+		expect(results[0]!.content).toEqual([{ type: "text", text: "205 tools found" }]);
+		expect(results.some(r => r.content.some(p => p.type === "text" && p.text === "aborted"))).toBe(false);
+	});
+
+	it("preserves a later orphan after a composite call was resolved by a plain result (Greptile P1 regression)", () => {
+		// The composite assistant call `call_A|fc_1` is resolved INLINE by a PLAIN
+		// result `call_A`: line 833-834 sets toolCallStatus["call_A"] = Resolved but
+		// leaves `call_A|fc_1` sitting in pendingToolCalls (an inline result never
+		// clears the pending window — only a flush does). A later orphan then arrives
+		// with NO user/assistant/developer message between it and the plain result,
+		// so the composite call is still unflushed and the orphan branch's guard
+		// (l.858-863) runs against a live pendingToolCalls entry.
+		//
+		// The guard must recognise that entry as ALREADY resolved via its canonical
+		// key: `!toolCallStatus.has(toolCallPairingKey(tc.id))` -> `!has("call_A")` ->
+		// false, so the guard does not fire and the orphan is preserved as a note.
+		// Under the raw-key regression (`!toolCallStatus.has(tc.id)` -> `!has(
+		// "call_A|fc_1")` -> true) the guard wrongly fires and the orphan is dropped
+		// silently. This locks Greptile P1 on #758 (cf8bceae; fixed 4dc0198b).
+		const messages: Message[] = [
+			{ role: "user", content: "search", timestamp: 1 },
+			makeToolCallAssistant(["call_A|fc_1"], 2),
+			makeToolResult("call_A", "205 tools found", 3),
+			makeToolResult("toolu_orphan_stale", "stale orphan payload", 4),
+		];
+
+		const transformed = transformMessages(messages, model);
+
+		// 1. The orphan's payload survives as exactly one user-level stale note
+		//    (reds under the line-859 raw-key mutation, which drops it silently).
+		const noteCarriers = transformed.filter(
+			(m): m is UserMessage =>
+				m.role === "user" &&
+				typeof (m as UserMessage).content === "string" &&
+				((m as UserMessage).content as string).includes("toolu_orphan_stale"),
+		);
+		expect(noteCarriers).toHaveLength(1);
+		expect(noteCarriers[0]!.content as string).toContain("stale orphan payload");
+
+		// 2. The orphan must not leak into the developer channel (would gain
+		//    system/instruction priority on Ollama / OpenAI reasoning paths).
+		const developerLeaks = transformed.filter(
+			(m): m is DeveloperMessage =>
+				m.role === "developer" &&
+				typeof (m as DeveloperMessage).content === "string" &&
+				((m as DeveloperMessage).content as string).includes("toolu_orphan_stale"),
+		);
+		expect(developerLeaks).toHaveLength(0);
+
+		// 3. The real composite pair survived intact — no "No result provided" stub
+		//    back-filled for `call_A|fc_1`, and the plain `call_A` result is kept.
+		expect(hasSynthetic(transformed)).toBe(false);
+		const results = resultsFor(transformed, "call_A");
+		expect(results).toHaveLength(1);
+		expect(results[0]!.content).toEqual([{ type: "text", text: "205 tools found" }]);
+	});
+});
+
+/**
  * Regression test for: "messages.0.content.1: unexpected `tool_use_id` found in
  * `tool_result` blocks ... Each `tool_result` block must have a corresponding
  * `tool_use` block in the previous message."

--- a/packages/ai/test/duplicate-tool-results.test.ts
+++ b/packages/ai/test/duplicate-tool-results.test.ts
@@ -17,6 +17,7 @@ import type {
 	ToolResultMessage,
 	UserMessage,
 } from "@oh-my-pi/pi-ai/types";
+import { normalizeToolCallId } from "@oh-my-pi/pi-ai/utils";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 
 /**
@@ -976,6 +977,128 @@ describe("Composite Tool-Call Id Pairing", () => {
 		const results = resultsFor(transformed, "call_A");
 		expect(results).toHaveLength(1);
 		expect(results[0]!.content).toEqual([{ type: "text", text: "205 tools found" }]);
+	});
+
+	it("survives cross-provider normalization to an Anthropic target (#10284)", () => {
+		// Codex's cross-provider angle: a session model/provider switch replays a
+		// Responses-origin composite call to an Anthropic target. The `|` is
+		// invalid for Anthropic, so the assistant call `call_A|fc_ASSISTANT`
+		// normalizes to `call_A_fc_ASSISTANT` while its real result arrives with a
+		// DIFFERENT item half (`call_A|fc_RESULT`). Pre-fix the result missed the
+		// exact-key lookup and stayed composite, so the pairing pass replaced the
+		// real result with the synthetic stub. Canonical pairing must carry the
+		// call_ component's normalized id onto the result across normalization.
+		const anthropicTarget: Model<"anthropic-messages"> = buildModel({
+			api: "anthropic-messages",
+			provider: "anthropic",
+			id: "claude-sonnet-4-5",
+			name: "Claude Sonnet 4.5",
+			baseUrl: "https://api.anthropic.com",
+			input: ["text"],
+			cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
+			maxTokens: 8192,
+			contextWindow: 200000,
+			reasoning: true,
+		});
+		const messages: Message[] = [
+			{ role: "user", content: "search", timestamp: 1 },
+			makeToolCallAssistant(["call_A|fc_ASSISTANT"], 2),
+			makeToolResult("call_A|fc_RESULT", "205 tools found", 3),
+		];
+
+		const transformed = transformMessages(messages, anthropicTarget, normalizeToolCallId);
+
+		expect(hasSynthetic(transformed)).toBe(false);
+		const callIds = transformed
+			.filter((m): m is AssistantMessage => m.role === "assistant")
+			.flatMap(m => m.content)
+			.filter((b): b is ToolCall => b.type === "toolCall")
+			.map(b => b.id);
+		expect(callIds).toEqual(["call_A_fc_ASSISTANT"]);
+		const results = transformed.filter((m): m is ToolResultMessage => m.role === "toolResult");
+		expect(results).toHaveLength(1);
+		expect(results[0]!.toolCallId).toBe("call_A_fc_ASSISTANT");
+		expect(results[0]!.content).toEqual([{ type: "text", text: "205 tools found" }]);
+	});
+});
+
+/**
+ * Regression for #10284: same-model Chat Completions tool-call ids are OPAQUE
+ * provider correlation tokens that may themselves contain `|`
+ * (`openai-completions.ts` preserves them verbatim on same-model replay). The
+ * composite-`call_` pairing must NOT canonicalize them: splitting `opaque|first`
+ * and `opaque|second` onto one `opaque` bucket collapsed two distinct calls, so
+ * the assistant halves were `_dup`-suffixed (`opaque_dup1|second_dup1`) and the
+ * lone result (`opaque|second`) paired with neither surviving wire id — the
+ * provider then rejected the replay.
+ */
+describe("Opaque Chat Completions ids are not canonicalized (#10284)", () => {
+	const model: Model<"openai-completions"> = buildModel({
+		api: "openai-completions",
+		provider: "openai",
+		id: "gpt-4o",
+		name: "GPT-4o",
+		baseUrl: "https://api.openai.com/v1",
+		input: ["text"],
+		cost: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0 },
+		maxTokens: 8192,
+		contextWindow: 128000,
+		reasoning: false,
+	});
+
+	const assistantWithCalls = (ids: string[], timestamp: number): AssistantMessage => ({
+		role: "assistant",
+		content: ids.map(id => ({ type: "toolCall", id, name: "read", arguments: {} })),
+		api: "openai-completions",
+		provider: "openai",
+		model: "gpt-4o",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "toolUse",
+		timestamp,
+	});
+
+	const toolResult = (id: string, text: string, timestamp: number): ToolResultMessage => ({
+		role: "toolResult",
+		toolCallId: id,
+		toolName: "read",
+		content: [{ type: "text", text }],
+		isError: false,
+		timestamp,
+	});
+
+	it("leaves pipe-bearing opaque ids intact and pairs the lone result to its call", () => {
+		const messages: Message[] = [
+			{ role: "user", content: "read twice", timestamp: 1 },
+			assistantWithCalls(["opaque|first", "opaque|second"], 2),
+			toolResult("opaque|second", "second output", 3),
+		];
+
+		const context: Context = { messages };
+		const wireMessages = convertMessages(model, context, model.compat);
+
+		const assistantIds = wireMessages
+			.filter((m): m is ChatCompletionAssistantMessageParam => m.role === "assistant" && Array.isArray(m.tool_calls))
+			.flatMap(m => m.tool_calls?.map(tc => tc.id) ?? []);
+		// Both opaque ids survive verbatim — neither collapsed onto `opaque` nor
+		// `_dup`-suffixed.
+		expect(assistantIds).toEqual(["opaque|first", "opaque|second"]);
+
+		const toolWireIds = wireMessages
+			.filter((m): m is ChatCompletionToolMessageParam => m.role === "tool")
+			.map(m => m.tool_call_id);
+		// The real result pairs with its own call; every emitted result id matches
+		// a surviving assistant call.
+		expect(toolWireIds).toContain("opaque|second");
+		for (const id of toolWireIds) {
+			expect(assistantIds).toContain(id);
+		}
 	});
 });
 

--- a/packages/ai/test/duplicate-tool-results.test.ts
+++ b/packages/ai/test/duplicate-tool-results.test.ts
@@ -1020,6 +1020,51 @@ describe("Composite Tool-Call Id Pairing", () => {
 		expect(results[0]!.toolCallId).toBe("call_A_fc_ASSISTANT");
 		expect(results[0]!.content).toEqual([{ type: "text", text: "205 tools found" }]);
 	});
+
+	it("maps a composite result to a PLAIN Responses call across Anthropic replay (#10284 P1)", () => {
+		// The plain-call variant of the cross-provider case above: the Responses
+		// assistant call carries a PLAIN id `call_A` (already a valid Anthropic
+		// id, so normalization is identity), while its real result arrives
+		// composite (`call_A|fc_RESULT`). Pre-fix the plain call skipped recording
+		// the Responses call-component mapping (the record lived behind
+		// `normalizedId !== toolCall.id`), so the composite result never resolved
+		// to the plain emitted id and stayed composite — the encoder would emit an
+		// assistant call `call_A` beside a result `call_A|fc_RESULT`, breaking
+		// call/result correspondence and the Anthropic id char rules. The mapping
+		// must be recorded even when the assistant id is plain.
+		const anthropicTarget: Model<"anthropic-messages"> = buildModel({
+			api: "anthropic-messages",
+			provider: "anthropic",
+			id: "claude-sonnet-4-5",
+			name: "Claude Sonnet 4.5",
+			baseUrl: "https://api.anthropic.com",
+			input: ["text"],
+			cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
+			maxTokens: 8192,
+			contextWindow: 200000,
+			reasoning: true,
+		});
+		const messages: Message[] = [
+			{ role: "user", content: "search", timestamp: 1 },
+			makeToolCallAssistant(["call_A"], 2),
+			makeToolResult("call_A|fc_RESULT", "205 tools found", 3),
+		];
+
+		const transformed = transformMessages(messages, anthropicTarget, normalizeToolCallId);
+
+		expect(hasSynthetic(transformed)).toBe(false);
+		const callIds = transformed
+			.filter((m): m is AssistantMessage => m.role === "assistant")
+			.flatMap(m => m.content)
+			.filter((b): b is ToolCall => b.type === "toolCall")
+			.map(b => b.id);
+		expect(callIds).toEqual(["call_A"]);
+		const results = transformed.filter((m): m is ToolResultMessage => m.role === "toolResult");
+		expect(results).toHaveLength(1);
+		// The composite result must adopt the plain call's emitted id, not stay composite.
+		expect(results[0]!.toolCallId).toBe("call_A");
+		expect(results[0]!.content).toEqual([{ type: "text", text: "205 tools found" }]);
+	});
 });
 
 /**
@@ -1096,6 +1141,63 @@ describe("Opaque Chat Completions ids are not canonicalized (#10284)", () => {
 		// The real result pairs with its own call; every emitted result id matches
 		// a surviving assistant call.
 		expect(toolWireIds).toContain("opaque|second");
+		for (const id of toolWireIds) {
+			expect(assistantIds).toContain(id);
+		}
+	});
+
+	it("does not collapse opaque completions ids that share a prefix with an earlier Responses call (#10284 P2)", () => {
+		// Mixed-provider history: an EARLIER Responses-family assistant call
+		// `call_A` seeds `call_A` as a Responses component. Later, SAME-MODEL Chat
+		// Completions ids `call_A|first` / `call_A|second` are OPAQUE (the pipe is
+		// literal, preserved verbatim). Pre-fix the global prefix set let the
+		// shared `call_A` prefix canonicalize both opaque ids onto one `call_A`
+		// bucket: dedup `_dup`-suffixed the second call and the lone result for
+		// `call_A|second` was wrongly consumed by the first. Concrete per-id origin
+		// tracking keeps the opaque ids keyed by raw equality.
+		const responsesAssistant: AssistantMessage = {
+			role: "assistant",
+			content: [{ type: "toolCall", id: "call_A", name: "read", arguments: {} }],
+			api: "openai-responses",
+			provider: "openai",
+			model: "gpt-5-codex",
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "toolUse",
+			timestamp: 2,
+		};
+		const messages: Message[] = [
+			{ role: "user", content: "read", timestamp: 1 },
+			responsesAssistant,
+			toolResult("call_A|fc_R", "responses output", 3),
+			{ role: "user", content: "read twice", timestamp: 4 },
+			assistantWithCalls(["call_A|first", "call_A|second"], 5),
+			toolResult("call_A|second", "second output", 6),
+		];
+
+		const context: Context = { messages };
+		const wireMessages = convertMessages(model, context, model.compat);
+
+		const assistantIds = wireMessages
+			.filter((m): m is ChatCompletionAssistantMessageParam => m.role === "assistant" && Array.isArray(m.tool_calls))
+			.flatMap(m => m.tool_calls?.map(tc => tc.id) ?? []);
+		// Both opaque ids survive verbatim — neither collapsed onto `call_A` nor
+		// `_dup`-suffixed by the shared-prefix Responses call.
+		expect(assistantIds).toContain("call_A|first");
+		expect(assistantIds).toContain("call_A|second");
+
+		const toolWireIds = wireMessages
+			.filter((m): m is ChatCompletionToolMessageParam => m.role === "tool")
+			.map(m => m.tool_call_id);
+		// The lone opaque result pairs with its OWN call, and every emitted result
+		// id matches a surviving assistant call.
+		expect(toolWireIds).toContain("call_A|second");
 		for (const id of toolWireIds) {
 			expect(assistantIds).toContain(id);
 		}

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,10 @@
 - Devin model selectors now accept the native CLI's short aliases (`devin/opus`, `devin/swe`), dotted upstream spellings (`devin/gemini-3.7-flash`), and raw effort-route wire uids for dynamically collapsed families ([#8590](https://github.com/can1357/oh-my-pi/pull/8590) by [@will-bogusz](https://github.com/will-bogusz)).
 - Added provider-supplied model metadata to the `/models` detail line: `new`, `beta`, and `recommended` badges beside the model name, and the upstream description after the context, cost, and perf facts ([#8590](https://github.com/can1357/oh-my-pi/pull/8590) by [@will-bogusz](https://github.com/will-bogusz)).
 
+### Fixed
+
+- Fixed OpenAI Codex Responses tool results being dropped when their composite id (`call_X|fc_Y`) failed to pair with the assistant call's plain id (`call_X`), so the model saw a synthetic "No result provided" stub in place of a tool result it had actually produced.
+
 ## [18.0.11] - 2026-08-29
 
 ### Added

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 ### Fixed
 
-- Fixed OpenAI Codex Responses tool results being dropped when their composite id (`call_X|fc_Y`) failed to pair with the assistant call's plain id (`call_X`), so the model saw a synthetic "No result provided" stub in place of a tool result it had actually produced.
+- Fixed OpenAI Codex Responses tool results being dropped when their composite id (`call_X|fc_Y`) failed to pair with the assistant call's plain id (`call_X`), so the model saw a synthetic "No result provided" stub in place of a tool result it had actually produced ([#10284](https://github.com/can1357/oh-my-pi/pull/10284) by [@mattwilkinsonn](https://github.com/mattwilkinsonn)).
 
 ## [18.0.11] - 2026-08-29
 


### PR DESCRIPTION
## What

Pair an OpenAI Codex Responses tool result with its assistant tool call on the stable `call_` component of the id, so a composite result id (`call_X|fc_Y`) matches the plain call id (`call_X`) it belongs to.

## Why

The Codex Responses API stores a tool result's id as a composite `<call_id>|<response_item_id>` (e.g. `call_ABC|fc_XYZ`), while the assistant `toolCall` that produced it carries the plain `call_ABC`. `transformMessages` paired the two by raw-string equality, so a valid pair looked disjoint: the real result was never pulled into the call's result window, and the call was back-filled with a synthetic `"No result provided"` stub. The model ran a tool and the result was persisted, but on the next turn the model saw nothing — it re-ran the tool or hallucinated around the missing output.

The fix keys the dedup/pairing bookkeeping on the first segment (the wire `call_id`) via a small `toolCallPairingKey` helper, matching what `appendDuplicateSuffix` / `normalizeResponsesToolCallId` already do when they split on `|`. It pairs the composite result with its plain call without collapsing two distinct parallel calls that happen to share a `response_item` (`fc_`) half, and without changing the emitted ids — only the lookup keying is canonical, so the provider encoder still receives the exact wire ids it expects. A degenerate empty-call-half id (`|fc_X`, pipe at index 0) keys on its full id rather than bucketing every such result onto the empty string.

<!-- YOUR LINE: replace with one sentence in your own words -->
I hit this as tool results silently vanishing on Codex Responses replays; the pairing was comparing a composite id against a plain one and giving up, so this keys both on the wire call_id half.

## Testing

Red/green on the regression file (`bun test`, in the nix dev shell):

- With the fix: `packages/ai/test/duplicate-tool-results.test.ts` — 32 pass, 0 fail. Covers composite-result/plain-call pairing, both-composite same-provider replay, a wire call_id reused across two and three turns (the `_dup` / `_dup2` seen-counter path), two same-turn calls sharing a `call_` half staying distinct, and the empty-call-half shape.
- `tsgo --noEmit` and `biome check` clean on `packages/ai`.

Rebased onto current `main` (`51f03804`) and re-run before submitting.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
