### PR TITLE
fix(config): preserve dangling symlink chains on config write

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 ### Fixed
 
-- Fixed config writes through a dangling symlink chain so the write lands on the chain's final target and preserves every intermediate link, instead of clobbering an intermediate link into a regular file on first run.
+- Fixed config writes through a dangling symlink chain so the write lands on the chain's final target and preserves every intermediate link, instead of clobbering an intermediate link into a regular file on first run ([#10285](https://github.com/can1357/oh-my-pi/pull/10285) by [@mattwilkinsonn](https://github.com/mattwilkinsonn)).
 
 ## [18.0.11] - 2026-08-29
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,10 @@
 - Devin model selectors now accept the native CLI's short aliases (`devin/opus`, `devin/swe`), dotted upstream spellings (`devin/gemini-3.7-flash`), and raw effort-route wire uids for dynamically collapsed families ([#8590](https://github.com/can1357/oh-my-pi/pull/8590) by [@will-bogusz](https://github.com/will-bogusz)).
 - Added provider-supplied model metadata to the `/models` detail line: `new`, `beta`, and `recommended` badges beside the model name, and the upstream description after the context, cost, and perf facts ([#8590](https://github.com/can1357/oh-my-pi/pull/8590) by [@will-bogusz](https://github.com/will-bogusz)).
 
+### Fixed
+
+- Fixed config writes through a dangling symlink chain so the write lands on the chain's final target and preserves every intermediate link, instead of clobbering an intermediate link into a regular file on first run.
+
 ## [18.0.11] - 2026-08-29
 
 ### Added

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -1404,14 +1404,29 @@ export class Settings {
 			if (!isEnoent(error)) throw error;
 		}
 
-		// realpath fails for a dangling symlink. Resolve its immediate target so
-		// recreating a quarantined config repairs the target without replacing
-		// the user-managed link.
+		// realpath fails for a dangling symlink. Resolve its target so recreating
+		// a quarantined config repairs the target without replacing the
+		// user-managed link. Walk the symlink chain hop by hop: realpath already
+		// handled the case where every referent exists, so we only reach here when
+		// the final referent is missing. Follow each existing intermediate link
+		// until the referent is a non-symlink or does not exist, so the write
+		// lands on the final target and preserves every intermediate link instead
+		// of clobbering one into a regular file.
 		try {
-			const stat = await fs.promises.lstat(filePath);
-			if (stat.isSymbolicLink()) {
-				const target = await fs.promises.readlink(filePath);
-				return path.resolve(path.dirname(filePath), target);
+			if ((await fs.promises.lstat(filePath)).isSymbolicLink()) {
+				let current = filePath;
+				for (;;) {
+					const target = await fs.promises.readlink(current);
+					const resolved = path.resolve(path.dirname(current), target);
+					let nextIsSymlink = false;
+					try {
+						nextIsSymlink = (await fs.promises.lstat(resolved)).isSymbolicLink();
+					} catch (error) {
+						if (!isEnoent(error)) throw error;
+					}
+					if (!nextIsSymlink) return resolved;
+					current = resolved;
+				}
 			}
 		} catch (error) {
 			if (!isEnoent(error)) throw error;

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -1540,7 +1540,27 @@ export class Settings {
 							// and dropping the segment would land the atomic rename on top
 							// of it while the logical config path is really ENOTDIR. Verify
 							// the requirement holds instead of assuming it.
-							if (!(await fs.promises.stat(acc)).isDirectory()) {
+							let accStat: fs.Stats;
+							try {
+								accStat = await fs.promises.stat(acc);
+							} catch (error) {
+								// `acc` was resolved by realpath() moments ago, but a
+								// concurrent process can remove the component between that
+								// realpath and this stat (`config.yml -> dir/../final.yml`
+								// while `dir` is deleted). The trailing `/` or `/.` still
+								// requires `acc` to be a traversable directory, and that
+								// requirement provably cannot hold once the component is
+								// gone. Surface ENOTDIR here instead of letting the ENOENT
+								// reach the outer catch, which would swallow it and return
+								// the chain head — clobbering config.yml itself.
+								if (!isEnoent(error)) throw error;
+								const notDir = new Error(
+									`ENOTDIR: symlink target requires a directory but ${acc} is gone for ${filePath}`,
+								) as Error & { code?: string };
+								notDir.code = "ENOTDIR";
+								throw notDir;
+							}
+							if (!accStat.isDirectory()) {
 								const notDir = new Error(
 									`ENOTDIR: symlink target requires a directory but ${acc} is not one for ${filePath}`,
 								) as Error & { code?: string };
@@ -1579,7 +1599,26 @@ export class Settings {
 							// the atomic rename land on a mislocated sibling
 							// (`config.yml -> racetarget/../victim.yml`) while the logical
 							// config path is really ENOTDIR. Verify before popping.
-							if (!(await fs.promises.stat(acc)).isDirectory()) {
+							let accStat: fs.Stats;
+							try {
+								accStat = await fs.promises.stat(acc);
+							} catch (error) {
+								// `acc` was resolved by realpath() moments ago, but a
+								// concurrent process can remove the component between that
+								// realpath and this stat. The `..` still requires `acc` to
+								// be a traversable directory to pop its parent, and that
+								// requirement provably cannot hold once the component is
+								// gone. Surface ENOTDIR here instead of letting the ENOENT
+								// reach the outer catch, which would swallow it and return
+								// the chain head — clobbering config.yml itself.
+								if (!isEnoent(error)) throw error;
+								const notDir = new Error(
+									`ENOTDIR: symlink target requires a directory but ${acc} is gone for ${filePath}`,
+								) as Error & { code?: string };
+								notDir.code = "ENOTDIR";
+								throw notDir;
+							}
+							if (!accStat.isDirectory()) {
 								const notDir = new Error(
 									`ENOTDIR: symlink target requires a directory but ${acc} is not one for ${filePath}`,
 								) as Error & { code?: string };

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -428,6 +428,15 @@ function resolvePathScopedStringArray(settingPath: SettingPath, value: unknown, 
 	return resolved;
 }
 
+/**
+ * Upper bound on symlink hops while resolving a dangling config chain by hand.
+ * `realpath()` already rejects a fully-linked cycle with ELOOP; this caps the
+ * manual walk so a chain that turns cyclic AFTER realpath reported ENOENT (a
+ * concurrent retarget mid-walk) surfaces a bounded ELOOP instead of spinning
+ * forever. Matches Linux's MAXSYMLINKS (40).
+ */
+const MAX_SYMLINK_HOPS = 40;
+
 // ═══════════════════════════════════════════════════════════════════════════
 // Settings Class
 // ═══════════════════════════════════════════════════════════════════════════
@@ -1415,7 +1424,20 @@ export class Settings {
 		try {
 			if ((await fs.promises.lstat(filePath)).isSymbolicLink()) {
 				let current = filePath;
-				for (;;) {
+				for (let hops = 0; ; hops++) {
+					// realpath() rejects a fully-linked cycle up front, so we only
+					// reach the manual walk on a chain that dangles today. It can
+					// still turn cyclic mid-walk if another process retargets an
+					// intermediate link, at which point readlink() would alternate
+					// forever. Cap the hops and surface an ELOOP so a cycle has
+					// bounded behavior instead of hanging flush().
+					if (hops >= MAX_SYMLINK_HOPS) {
+						const cyclic = new Error(
+							`ELOOP: symlink chain for ${filePath} exceeds ${MAX_SYMLINK_HOPS} hops (possible cycle)`,
+						) as Error & { code?: string };
+						cyclic.code = "ELOOP";
+						throw cyclic;
+					}
 					let target: string;
 					try {
 						target = await fs.promises.readlink(current);
@@ -1447,7 +1469,33 @@ export class Settings {
 						} catch (error) {
 							if (!isEnoent(error)) throw error;
 						}
-						resolved = path.resolve(canonicalDir, target);
+						// Resolve the relative target one segment at a time so an
+						// intermediate directory symlink WITHIN the target is followed
+						// by the filesystem BEFORE a later `..` is applied. Normalizing
+						// the whole target string up front (path.resolve) collapses
+						// `alias/..` lexically to the config dir, but the kernel follows
+						// `alias` first and then pops its PHYSICAL parent, so the two
+						// disagree whenever an alias precedes a `..`. realpath() on the
+						// deepest existing prefix keeps `acc` canonical, so each `..`
+						// pops the real parent; a missing component (the dangling final
+						// referent, or a vanished intermediate) falls back to a lexical
+						// join since there is nothing left to follow.
+						let acc = canonicalDir;
+						for (const segment of target.split(/[\\/]+/)) {
+							if (segment === "" || segment === ".") continue;
+							if (segment === "..") {
+								acc = path.dirname(acc);
+								continue;
+							}
+							const candidate = path.join(acc, segment);
+							try {
+								acc = await fs.promises.realpath(candidate);
+							} catch (error) {
+								if (!isEnoent(error)) throw error;
+								acc = candidate;
+							}
+						}
+						resolved = acc;
 					}
 					let nextIsSymlink = false;
 					try {

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -1428,7 +1428,27 @@ export class Settings {
 						// atomic rename replace the first user-managed symlink.
 						return current === filePath ? path.resolve(filePath) : current;
 					}
-					const resolved = path.resolve(path.dirname(current), target);
+					// A relative target resolves against the link's REAL parent dir,
+					// not its lexical one. When `current` sits under a symlinked
+					// directory alias, a target with enough `..` to climb out of the
+					// alias must pop off the PHYSICAL parent — a lexical resolve would
+					// collapse `..` against the alias and land on an unrelated sibling,
+					// letting the write clobber a foreign file. Absolute targets are
+					// already anchored, so canonicalize only for relative ones and fall
+					// back to the lexical parent if realpath throws (a dangling parent).
+					let resolved: string;
+					if (path.isAbsolute(target)) {
+						resolved = path.resolve(target);
+					} else {
+						const lexicalDir = path.dirname(current);
+						let canonicalDir = lexicalDir;
+						try {
+							canonicalDir = await fs.promises.realpath(lexicalDir);
+						} catch (error) {
+							if (!isEnoent(error)) throw error;
+						}
+						resolved = path.resolve(canonicalDir, target);
+					}
 					let nextIsSymlink = false;
 					try {
 						nextIsSymlink = (await fs.promises.lstat(resolved)).isSymbolicLink();

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -1416,7 +1416,18 @@ export class Settings {
 			if ((await fs.promises.lstat(filePath)).isSymbolicLink()) {
 				let current = filePath;
 				for (;;) {
-					const target = await fs.promises.readlink(current);
+					let target: string;
+					try {
+						target = await fs.promises.readlink(current);
+					} catch (error) {
+						if (!isEnoent(error)) throw error;
+						// An intermediate link vanished mid-walk: it was confirmed a
+						// symlink by the lstat below on the prior hop, then removed
+						// before this readlink. Land on the deepest hop we resolved
+						// rather than collapsing to the chain head, which would let the
+						// atomic rename replace the first user-managed symlink.
+						return current === filePath ? path.resolve(filePath) : current;
+					}
 					const resolved = path.resolve(path.dirname(current), target);
 					let nextIsSymlink = false;
 					try {

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -437,6 +437,35 @@ function resolvePathScopedStringArray(settingPath: SettingPath, value: unknown, 
  */
 const MAX_SYMLINK_HOPS = 40;
 
+/**
+ * Split a dangling symlink target into the physical path segments the flush
+ * walk should follow. Two platform-correctness rules that a naive
+ * `target.split(/[\\/]+/)` gets wrong:
+ *
+ *  1. Root double-count. An ABSOLUTE target seeds the accumulator at
+ *     `parse(target).root` — `C:\` on Windows, the `\\server\share\` prefix of
+ *     a UNC path, `/` on POSIX. The root must therefore be STRIPPED from the
+ *     string before splitting; otherwise it is re-emitted as a leading segment
+ *     and `C:\managed\final.yml` resolves to `C:\` + `C:` + `managed` + … =
+ *     `C:\C:\managed\final.yml`, so the flush fails against a dangling absolute
+ *     link on Windows. (POSIX escaped this by luck: the leading `/` splits to an
+ *     empty leading segment that the walk already skips.) A RELATIVE target
+ *     seeds at the link's real parent dir and keeps every segment unchanged.
+ *  2. Separator set. `\` is a separator only on Windows. On POSIX it is a valid
+ *     filename character, so a target literally named `managed\config.yml` must
+ *     stay ONE segment, not two. Split on the platform separator set: `/` only
+ *     on POSIX, `/` or `\` on Windows. Keyed off `pathApi.sep` so the rule is
+ *     driven by the platform, not a hardcoded cross-platform class.
+ *
+ * `pathApi` is injectable so the platform-specific behavior is testable off the
+ * host OS (drive with `path.win32` / `path.posix`); it defaults to the host.
+ */
+function physicalTargetSegments(target: string, pathApi: typeof path = path): string[] {
+	const separator = pathApi.sep === "\\" ? /[\\/]+/ : /\/+/;
+	const body = pathApi.isAbsolute(target) ? target.slice(pathApi.parse(target).root.length) : target;
+	return body.split(separator);
+}
+
 // ═══════════════════════════════════════════════════════════════════════════
 // Settings Class
 // ═══════════════════════════════════════════════════════════════════════════
@@ -1482,7 +1511,7 @@ export class Settings {
 					// so `..` only unwinds segments actually entered post-miss.
 					let frozen = false;
 					let lexicalDepth = 0;
-					for (const segment of target.split(/[\\/]+/)) {
+					for (const segment of physicalTargetSegments(target)) {
 						if (segment === "" || segment === ".") continue;
 						if (segment === "..") {
 							if (!frozen) {
@@ -3011,6 +3040,15 @@ export function resetSettingsForTest(): void {
 	configureProviderMaxInFlightRequests(undefined);
 	configureCredentialRedaction(false);
 }
+
+/**
+ * Exposes the dangling-symlink target segment splitter for platform-specific
+ * tests: the root-double-count and POSIX-backslash bugs only reproduce with an
+ * explicit `path.win32` / `path.posix` engine, which cannot be forced from the
+ * host OS otherwise.
+ * @internal
+ */
+export const __physicalTargetSegmentsForTesting = physicalTargetSegments;
 
 /**
  * The global settings singleton.

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -1502,45 +1502,59 @@ export class Settings {
 							if (!isEnoent(error)) throw error;
 						}
 					}
-					// realpath() on the deepest existing prefix keeps `acc` canonical
-					// so each `..` pops the real parent. Once a NAMED component does
-					// not exist on disk, stop physically resolving: the remainder is
-					// joined lexically, and a following `..` must NOT pop a component
-					// that was never traversed (`missing/../final` must not climb to a
-					// sibling of `missing`). Track the depth appended after that point
-					// so `..` only unwinds segments actually entered post-miss.
+					// realpath() on the deepest existing prefix keeps `acc` canonical so
+					// each `..` pops the real parent. Once a NAMED component does not
+					// exist on disk the walk is FROZEN: the remainder is joined
+					// lexically, but nothing past the miss was physically traversable,
+					// so any construct that requires ENTERING the frozen component — a
+					// `..`, or a trailing `/` or `/.` that demands it be a directory —
+					// cannot be satisfied by the filesystem and must surface ENOTDIR
+					// rather than lexically landing a regular file at a mislocated path.
 					let frozen = false;
-					let lexicalDepth = 0;
 					for (const segment of physicalTargetSegments(target)) {
-						if (segment === "" || segment === ".") continue;
-						if (segment === "..") {
-							if (!frozen) {
-								acc = path.dirname(acc);
-							} else if (lexicalDepth > 0) {
-								acc = path.dirname(acc);
-								lexicalDepth--;
-							} else {
-								// `..` immediately follows a component that could not be
-								// physically traversed — a missing name or, worse, a
-								// dangling symlink. The kernel cannot take the parent of a
-								// path it never entered: `link/..` with `link -> missing`
-								// fails once `missing` is found absent. Popping nothing here
-								// and continuing would leave `acc` on the frozen component;
-								// a dangling symlink is then followed to its missing referent
-								// and the write lands a regular file at the wrong path while
-								// reporting success. Surface the same ENOTDIR the filesystem
-								// raises so the save fails instead of mislocating.
+						if (segment === "" || segment === ".") {
+							if (frozen) {
+								// A trailing `/` (empty segment) or `/.` demands the
+								// preceding component be a traversable directory. Before the
+								// freeze that component was confirmed on disk, so the
+								// requirement holds and the segment is inert. After the
+								// freeze the component is a nonexistent/dangling name that
+								// can never be a directory (`config.yml -> missing/`):
+								// dropping the segment and writing a regular file there
+								// mislocates and falsely reports success while the logical
+								// config path stays unusable with ENOTDIR. Surface it.
 								const notDir = new Error(
-									`ENOTDIR: cannot resolve '..' past an unresolved component in symlink target for ${filePath}`,
+									`ENOTDIR: symlink target requires an unresolved component to be a directory for ${filePath}`,
 								) as Error & { code?: string };
 								notDir.code = "ENOTDIR";
 								throw notDir;
 							}
 							continue;
 						}
+						if (segment === "..") {
+							if (frozen) {
+								// `..` after a component that could not be physically
+								// traversed — a missing name or a dangling symlink — whether
+								// the `..` follows it immediately (`link/..`) or after further
+								// lexical names (`missing/child/..`). The kernel cannot take
+								// the parent of a path it never entered: `missing/child/..`
+								// fails because `missing` was never a directory to descend,
+								// so the lexically appended `child` is not a real component to
+								// pop. Popping and continuing would leave `acc` on a
+								// mislocated path and land a regular file there while
+								// reporting success. Surface the ENOTDIR the filesystem
+								// raises instead.
+								const notDir = new Error(
+									`ENOTDIR: cannot resolve '..' past an unresolved component in symlink target for ${filePath}`,
+								) as Error & { code?: string };
+								notDir.code = "ENOTDIR";
+								throw notDir;
+							}
+							acc = path.dirname(acc);
+							continue;
+						}
 						if (frozen) {
 							acc = path.join(acc, segment);
-							lexicalDepth++;
 							continue;
 						}
 						const candidate = path.join(acc, segment);
@@ -1550,7 +1564,6 @@ export class Settings {
 							if (!isEnoent(error)) throw error;
 							acc = candidate;
 							frozen = true;
-							lexicalDepth = 0;
 						}
 					}
 					const resolved = acc;

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -1519,6 +1519,22 @@ export class Settings {
 							} else if (lexicalDepth > 0) {
 								acc = path.dirname(acc);
 								lexicalDepth--;
+							} else {
+								// `..` immediately follows a component that could not be
+								// physically traversed — a missing name or, worse, a
+								// dangling symlink. The kernel cannot take the parent of a
+								// path it never entered: `link/..` with `link -> missing`
+								// fails once `missing` is found absent. Popping nothing here
+								// and continuing would leave `acc` on the frozen component;
+								// a dangling symlink is then followed to its missing referent
+								// and the write lands a regular file at the wrong path while
+								// reporting success. Surface the same ENOTDIR the filesystem
+								// raises so the save fails instead of mislocating.
+								const notDir = new Error(
+									`ENOTDIR: cannot resolve '..' past an unresolved component in symlink target for ${filePath}`,
+								) as Error & { code?: string };
+								notDir.code = "ENOTDIR";
+								throw notDir;
 							}
 							continue;
 						}

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -1568,6 +1568,24 @@ export class Settings {
 								notDir.code = "ENOTDIR";
 								throw notDir;
 							}
+							// `acc` was resolved by realpath() and exists on disk, but a
+							// `..` demands it be a traversable directory to pop its parent.
+							// A concurrent process can win a TOCTOU race: the initial
+							// realpath(filePath) saw the component missing, then it was
+							// created as a REGULAR FILE before realpath(candidate) reached
+							// it, so that call succeeded and left `frozen` false. The
+							// kernel cannot take the parent of `regularfile/..` — it fails
+							// with ENOTDIR — so lexically popping and continuing would let
+							// the atomic rename land on a mislocated sibling
+							// (`config.yml -> racetarget/../victim.yml`) while the logical
+							// config path is really ENOTDIR. Verify before popping.
+							if (!(await fs.promises.stat(acc)).isDirectory()) {
+								const notDir = new Error(
+									`ENOTDIR: symlink target requires a directory but ${acc} is not one for ${filePath}`,
+								) as Error & { code?: string };
+								notDir.code = "ENOTDIR";
+								throw notDir;
+							}
 							acc = path.dirname(acc);
 							continue;
 						}

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -1529,6 +1529,24 @@ export class Settings {
 								notDir.code = "ENOTDIR";
 								throw notDir;
 							}
+							// The walk is not frozen, so `acc` was resolved by realpath()
+							// and exists on disk — but existence is not enough. A trailing
+							// `/` or `/.` demands `acc` be a directory, and a concurrent
+							// process can win a TOCTOU race: the initial realpath(filePath)
+							// saw the target missing, then the target was created as a
+							// REGULAR FILE before this segment walk reached it, so
+							// realpath(candidate) succeeded and left `frozen` false. The
+							// preceding component is now a regular file, not a directory,
+							// and dropping the segment would land the atomic rename on top
+							// of it while the logical config path is really ENOTDIR. Verify
+							// the requirement holds instead of assuming it.
+							if (!(await fs.promises.stat(acc)).isDirectory()) {
+								const notDir = new Error(
+									`ENOTDIR: symlink target requires a directory but ${acc} is not one for ${filePath}`,
+								) as Error & { code?: string };
+								notDir.code = "ENOTDIR";
+								throw notDir;
+							}
 							continue;
 						}
 						if (segment === "..") {

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -1450,53 +1450,65 @@ export class Settings {
 						// atomic rename replace the first user-managed symlink.
 						return current === filePath ? path.resolve(filePath) : current;
 					}
-					// A relative target resolves against the link's REAL parent dir,
-					// not its lexical one. When `current` sits under a symlinked
-					// directory alias, a target with enough `..` to climb out of the
-					// alias must pop off the PHYSICAL parent — a lexical resolve would
-					// collapse `..` against the alias and land on an unrelated sibling,
-					// letting the write clobber a foreign file. Absolute targets are
-					// already anchored, so canonicalize only for relative ones and fall
-					// back to the lexical parent if realpath throws (a dangling parent).
-					let resolved: string;
+					// Resolve the target one physical segment at a time so an
+					// intermediate directory symlink is followed by the filesystem
+					// BEFORE a later `..` pops its PHYSICAL parent. Both absolute and
+					// relative targets take the same walk: normalizing the whole
+					// string up front (path.resolve) collapses `alias/..` lexically
+					// to the anchor, but the kernel follows `alias` first and then
+					// pops its real parent, so the two disagree whenever an alias
+					// precedes a `..` — the lexical result can escape to an unrelated
+					// sibling and let the write clobber a foreign file. An absolute
+					// target seeds the accumulator at its filesystem anchor; a
+					// relative one seeds at the link's REAL parent dir.
+					let acc: string;
 					if (path.isAbsolute(target)) {
-						resolved = path.resolve(target);
+						acc = path.parse(target).root;
 					} else {
 						const lexicalDir = path.dirname(current);
-						let canonicalDir = lexicalDir;
+						acc = lexicalDir;
 						try {
-							canonicalDir = await fs.promises.realpath(lexicalDir);
+							acc = await fs.promises.realpath(lexicalDir);
 						} catch (error) {
 							if (!isEnoent(error)) throw error;
 						}
-						// Resolve the relative target one segment at a time so an
-						// intermediate directory symlink WITHIN the target is followed
-						// by the filesystem BEFORE a later `..` is applied. Normalizing
-						// the whole target string up front (path.resolve) collapses
-						// `alias/..` lexically to the config dir, but the kernel follows
-						// `alias` first and then pops its PHYSICAL parent, so the two
-						// disagree whenever an alias precedes a `..`. realpath() on the
-						// deepest existing prefix keeps `acc` canonical, so each `..`
-						// pops the real parent; a missing component (the dangling final
-						// referent, or a vanished intermediate) falls back to a lexical
-						// join since there is nothing left to follow.
-						let acc = canonicalDir;
-						for (const segment of target.split(/[\\/]+/)) {
-							if (segment === "" || segment === ".") continue;
-							if (segment === "..") {
-								acc = path.dirname(acc);
-								continue;
-							}
-							const candidate = path.join(acc, segment);
-							try {
-								acc = await fs.promises.realpath(candidate);
-							} catch (error) {
-								if (!isEnoent(error)) throw error;
-								acc = candidate;
-							}
-						}
-						resolved = acc;
 					}
+					// realpath() on the deepest existing prefix keeps `acc` canonical
+					// so each `..` pops the real parent. Once a NAMED component does
+					// not exist on disk, stop physically resolving: the remainder is
+					// joined lexically, and a following `..` must NOT pop a component
+					// that was never traversed (`missing/../final` must not climb to a
+					// sibling of `missing`). Track the depth appended after that point
+					// so `..` only unwinds segments actually entered post-miss.
+					let frozen = false;
+					let lexicalDepth = 0;
+					for (const segment of target.split(/[\\/]+/)) {
+						if (segment === "" || segment === ".") continue;
+						if (segment === "..") {
+							if (!frozen) {
+								acc = path.dirname(acc);
+							} else if (lexicalDepth > 0) {
+								acc = path.dirname(acc);
+								lexicalDepth--;
+							}
+							continue;
+						}
+						if (frozen) {
+							acc = path.join(acc, segment);
+							lexicalDepth++;
+							continue;
+						}
+						const candidate = path.join(acc, segment);
+						try {
+							acc = await fs.promises.realpath(candidate);
+						} catch (error) {
+							if (!isEnoent(error)) throw error;
+							acc = candidate;
+							frozen = true;
+							lexicalDepth = 0;
+						}
+					}
+					const resolved = acc;
 					let nextIsSymlink = false;
 					try {
 						nextIsSymlink = (await fs.promises.lstat(resolved)).isSymbolicLink();

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -369,6 +369,39 @@ describe("Settings", () => {
 			expect(fs.existsSync(finalPath)).toBe(false);
 		});
 
+		it("resolves a relative intermediate target against the link's physical parent, not a symlinked alias", async () => {
+			// config.yml -> alias/sub/mid.yml, where `alias` is a symlinked
+			// directory (alias -> physical/deep) and mid.yml is a dangling link
+			// whose relative target has enough `..` to climb out of the alias.
+			// Popping `..` off the PHYSICAL parent lands on physical/final.yml; a
+			// lexical resolve would collapse `..` against the alias and clobber an
+			// unrelated sibling of the alias while leaving the real chain dangling.
+			const deepDir = tempDir.join("physical", "deep");
+			const subDir = path.join(deepDir, "sub");
+			fs.mkdirSync(subDir, { recursive: true });
+			const aliasDir = tempDir.join("alias");
+			await fs.promises.symlink(deepDir, aliasDir, "dir");
+
+			const midPath = path.join(aliasDir, "sub", "mid-config.yml");
+			await fs.promises.symlink("../../final-config.yml", midPath, "file");
+			await fs.promises.symlink(midPath, getConfigPath(), "file");
+
+			const physicalFinal = tempDir.join("physical", "final-config.yml");
+			const lexicalSibling = tempDir.join("final-config.yml");
+
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			settings.set("setupVersion", 7);
+			await settings.flush();
+
+			// The write lands on the physical target, recreating it, while the
+			// alias's lexical sibling (the mis-resolution) stays untouched.
+			expect(YAML.parse(await Bun.file(physicalFinal).text())).toEqual({ setupVersion: 7 });
+			expect(fs.existsSync(lexicalSibling)).toBe(false);
+			// Every user-managed link in the chain survives.
+			expect(fs.lstatSync(getConfigPath()).isSymbolicLink()).toBe(true);
+			expect(fs.lstatSync(midPath).isSymbolicLink()).toBe(true);
+		});
+
 		it("falls back to move-aside replacement when Windows reports EPERM", async () => {
 			await writeSettings({ setupVersion: 1 });
 			const settings = await Settings.init({ cwd: projectDir, agentDir });

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -467,6 +467,64 @@ describe("Settings", () => {
 			expect(fs.lstatSync(getConfigPath()).isSymbolicLink()).toBe(true);
 		});
 
+		it("resolves an absolute target's intermediate directory symlink before applying ..", async () => {
+			// config.yml -> /base/alias/../final.yml (ABSOLUTE target), where
+			// `alias` is a symlinked directory (alias -> elsewhere/deep) and
+			// final.yml is missing. The filesystem follows `alias` first and then
+			// pops its PHYSICAL parent, landing on elsewhere/final.yml. Lexically
+			// collapsing the absolute string up front turns `/base/alias/..` into
+			// /base and would clobber /base/final.yml while leaving the real chain
+			// dangling — the same bug already fixed for relative targets.
+			const elsewhereDir = tempDir.join("elsewhere");
+			const deepDir = path.join(elsewhereDir, "deep");
+			fs.mkdirSync(deepDir, { recursive: true });
+			const baseDir = tempDir.join("base");
+			fs.mkdirSync(baseDir, { recursive: true });
+			const aliasDir = path.join(baseDir, "alias");
+			await fs.promises.symlink(deepDir, aliasDir, "dir");
+
+			// Build the target string manually so path.join does not collapse the
+			// `..` before the symlink can be written.
+			const absTarget = `${aliasDir}${path.sep}..${path.sep}final-config.yml`;
+			await fs.promises.symlink(absTarget, getConfigPath(), "file");
+
+			const physicalFinal = path.join(elsewhereDir, "final-config.yml");
+			const lexicalSibling = path.join(baseDir, "final-config.yml");
+
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			settings.set("setupVersion", 9);
+			await settings.flush();
+
+			// The write lands on the physical target (fs semantics), recreating it,
+			// while the lexically collapsed sibling stays untouched.
+			expect(YAML.parse(await Bun.file(physicalFinal).text())).toEqual({ setupVersion: 9 });
+			expect(fs.existsSync(lexicalSibling)).toBe(false);
+			// The user-managed chain head survives as a symlink.
+			expect(fs.lstatSync(getConfigPath()).isSymbolicLink()).toBe(true);
+		});
+
+		it("does not write to an unrelated sibling when a non-final component is missing before ..", async () => {
+			// config.yml -> missing/../final.yml, where `missing` does not exist.
+			// Filesystem lookup fails at `missing`, so a following `..` must NOT
+			// pop a component that was never entered. Collapsing the target
+			// lexically instead pops `missing` and lands on <configdir>/final.yml,
+			// clobbering an unrelated sibling while the real (dangling) target is
+			// never written. The resolver must not escape to that sibling.
+			await fs.promises.symlink("missing/../final-config.yml", getConfigPath(), "file");
+			const lexicalSibling = path.join(agentDir, "final-config.yml");
+
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			settings.set("setupVersion", 10);
+			// The resolved path sits under the never-entered `missing` dir (fs
+			// semantics), whose parent does not exist, so the atomic write fails
+			// rather than clobbering the sibling.
+			await expect(settings.flush()).rejects.toThrow();
+
+			expect(fs.existsSync(lexicalSibling)).toBe(false);
+			// The user-managed chain head survives as a symlink.
+			expect(fs.lstatSync(getConfigPath()).isSymbolicLink()).toBe(true);
+		});
+
 		it("falls back to move-aside replacement when Windows reports EPERM", async () => {
 			await writeSettings({ setupVersion: 1 });
 			const settings = await Settings.init({ cwd: projectDir, agentDir });

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -8,6 +8,7 @@ import { createMockModel, registerMockApi } from "@oh-my-pi/pi-ai/providers/mock
 import { __providerInFlightForTesting, streamSimple } from "@oh-my-pi/pi-ai/stream";
 import type { Context } from "@oh-my-pi/pi-ai/types";
 import {
+	__physicalTargetSegmentsForTesting,
 	onAppendOnlyModeChanged,
 	onCodeModeChanged,
 	onModelRolesChanged,
@@ -523,6 +524,45 @@ describe("Settings", () => {
 			expect(fs.existsSync(lexicalSibling)).toBe(false);
 			// The user-managed chain head survives as a symlink.
 			expect(fs.lstatSync(getConfigPath()).isSymbolicLink()).toBe(true);
+		});
+
+		it("does not re-emit the filesystem root as a segment for an absolute Windows target", async () => {
+			// On Windows the flush walk seeds the accumulator at parse(target).root
+			// (`C:\`) and then walks the segments. If the root is left in the string
+			// that is split, it is re-emitted as a leading `C:` segment and joined
+			// on top of the seeded root — `C:\managed\final.yml` resolves to
+			// `C:\C:\managed\final.yml`, so flushing through a dangling absolute link
+			// fails. Drive the splitter with the win32 engine so the bug reproduces
+			// on this POSIX host.
+			const segments = __physicalTargetSegmentsForTesting("C:\\managed\\final.yml", path.win32).filter(
+				segment => segment !== "" && segment !== ".",
+			);
+			expect(segments).toEqual(["managed", "final.yml"]);
+			// A UNC target seeds at the `\\server\share\` root, which must likewise
+			// be stripped rather than re-walked as `server` / `share` segments.
+			const uncSegments = __physicalTargetSegmentsForTesting(
+				"\\\\server\\share\\managed\\final.yml",
+				path.win32,
+			).filter(segment => segment !== "" && segment !== ".");
+			expect(uncSegments).toEqual(["managed", "final.yml"]);
+			// A relative Windows target seeds at the link's real parent, so every
+			// segment is preserved unchanged.
+			expect(__physicalTargetSegmentsForTesting("managed\\final.yml", path.win32)).toEqual(["managed", "final.yml"]);
+		});
+
+		it("treats a backslash as a filename character on POSIX, not a separator", async () => {
+			// `\` is a valid filename character on POSIX. A dangling target literally
+			// named `managed\config.yml` must stay ONE segment; splitting it into
+			// `managed`/`config.yml` makes flush either fail on the missing dir or
+			// write an unrelated file while the real link stays dangling. Drive the
+			// splitter with the posix engine so the bug reproduces on any host.
+			expect(__physicalTargetSegmentsForTesting("managed\\config.yml", path.posix)).toEqual(["managed\\config.yml"]);
+			// Forward slashes still split, and the leading `/` of an absolute POSIX
+			// target strips to no extra segment (root seeded separately).
+			const absSegments = __physicalTargetSegmentsForTesting("/managed/final.yml", path.posix).filter(
+				segment => segment !== "" && segment !== ".",
+			);
+			expect(absSegments).toEqual(["managed", "final.yml"]);
 		});
 
 		it("falls back to move-aside replacement when Windows reports EPERM", async () => {

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -526,6 +526,28 @@ describe("Settings", () => {
 			expect(fs.lstatSync(getConfigPath()).isSymbolicLink()).toBe(true);
 		});
 
+		it("does not mislocate when a dangling symlink component is followed by ..", async () => {
+			// config.yml -> link/.., where `link -> missing` and `missing` does
+			// not exist. The filesystem follows `link` to its missing referent, so
+			// looking up `link/..` fails: there is no parent of a path that was
+			// never entered. Leaving the accumulator on the dangling `link` and
+			// then following it to `missing` would create a regular file at the
+			// wrong path and report success while the config path still fails with
+			// ENOTDIR. The resolver must surface the failure instead.
+			await fs.promises.symlink("missing", path.join(agentDir, "link"), "file");
+			await fs.promises.symlink("link/..", getConfigPath(), "file");
+			const misplaced = path.join(agentDir, "missing");
+
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			settings.set("setupVersion", 11);
+			await expect(settings.flush()).rejects.toThrow();
+
+			// No regular file was landed at the wrong resolved location.
+			expect(fs.existsSync(misplaced)).toBe(false);
+			// The user-managed chain head survives as a symlink.
+			expect(fs.lstatSync(getConfigPath()).isSymbolicLink()).toBe(true);
+		});
+
 		it("does not re-emit the filesystem root as a segment for an absolute Windows target", async () => {
 			// On Windows the flush walk seeds the accumulator at parse(target).root
 			// (`C:\`) and then walks the segments. If the root is left in the string

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -334,6 +334,41 @@ describe("Settings", () => {
 			expect(YAML.parse(await Bun.file(finalPath).text())).toEqual({ setupVersion: 3 });
 		});
 
+		it("lands on the deepest resolved hop when an intermediate link vanishes mid-walk", async () => {
+			// config.yml -> mid.yml -> final.yml (final dangling). The resolver
+			// confirms mid.yml is a symlink via lstat, then a concurrent process
+			// removes mid.yml before readlink(mid.yml) runs. The ENOENT must not
+			// collapse the write back to the chain head (config.yml) — that would
+			// let the atomic rename replace the first user-managed link.
+			const finalPath = tempDir.join("final-config.yml");
+			const midPath = tempDir.join("mid-config.yml");
+			await fs.promises.symlink(finalPath, midPath, "file");
+			await fs.promises.symlink(midPath, getConfigPath(), "file");
+
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			const readlink = fs.promises.readlink.bind(fs.promises);
+			let injected = false;
+			vi.spyOn(fs.promises, "readlink").mockImplementation((async (target: fs.PathLike) => {
+				if (!injected && String(target) === midPath) {
+					injected = true;
+					await fs.promises.unlink(midPath);
+					throw new FsCodeError("ENOENT", "injected mid-chain link removal");
+				}
+				return readlink(target);
+			}) as typeof fs.promises.readlink);
+
+			settings.set("setupVersion", 4);
+			await settings.flush();
+
+			expect(injected).toBe(true);
+			// The chain head must survive as a symlink; the write lands on the
+			// deepest resolved hop (mid.yml), never clobbering config.yml.
+			expect(fs.lstatSync(getConfigPath()).isSymbolicLink()).toBe(true);
+			expect(fs.lstatSync(midPath).isSymbolicLink()).toBe(false);
+			expect(YAML.parse(await Bun.file(midPath).text())).toEqual({ setupVersion: 4 });
+			expect(fs.existsSync(finalPath)).toBe(false);
+		});
+
 		it("falls back to move-aside replacement when Windows reports EPERM", async () => {
 			await writeSettings({ setupVersion: 1 });
 			const settings = await Settings.init({ cwd: projectDir, agentDir });

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -548,6 +548,66 @@ describe("Settings", () => {
 			expect(fs.lstatSync(getConfigPath()).isSymbolicLink()).toBe(true);
 		});
 
+		it("does not mislocate when a dangling component precedes further names then ..", async () => {
+			// config.yml -> missing/child/.., where `missing` does not exist. The
+			// walk freezes at `missing`, appends `child` lexically, then hits `..`.
+			// `missing` was never entered, so `child` is not a real component the
+			// kernel can pop: `missing/child/..` fails with ENOTDIR. Lexically
+			// popping `child` and returning `missing` would land a regular file at
+			// the wrong path and report success while config.yml stays unusable.
+			await fs.promises.symlink("missing/child/..", getConfigPath(), "file");
+			const misplaced = path.join(agentDir, "missing");
+
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			settings.set("setupVersion", 12);
+			await expect(settings.flush()).rejects.toThrow();
+
+			// No regular file was landed at the frozen component.
+			expect(fs.existsSync(misplaced)).toBe(false);
+			// The user-managed chain head survives as a symlink.
+			expect(fs.lstatSync(getConfigPath()).isSymbolicLink()).toBe(true);
+		});
+
+		it("still pops correctly when a real child/.. was actually traversed", async () => {
+			// config.yml -> realdir/child/final.yml, where realdir and
+			// realdir/child both exist on disk and final.yml is missing. The `..`
+			// after `child` pops a component that WAS entered, so the write must
+			// still land on realdir/final.yml — proving the frozen-branch throw
+			// does not over-reject a legitimate physically traversed `..`.
+			const realDir = path.join(agentDir, "realdir");
+			const childDir = path.join(realDir, "child");
+			fs.mkdirSync(childDir, { recursive: true });
+			await fs.promises.symlink("realdir/child/../final-config.yml", getConfigPath(), "file");
+			const finalPath = path.join(realDir, "final-config.yml");
+
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			settings.set("setupVersion", 13);
+			await settings.flush();
+
+			expect(YAML.parse(await Bun.file(finalPath).text())).toEqual({ setupVersion: 13 });
+			// The user-managed chain head survives as a symlink.
+			expect(fs.lstatSync(getConfigPath()).isSymbolicLink()).toBe(true);
+		});
+
+		it("does not mislocate when a dangling target ends in a trailing slash", async () => {
+			// config.yml -> missing/, where `missing` does not exist. The trailing
+			// slash demands `missing` be a traversable directory. Dropping the
+			// terminal empty segment and returning `missing` would land a regular
+			// file there and report success, while opening config.yml then fails
+			// with ENOTDIR because a file is not a directory. Surface the failure.
+			await fs.promises.symlink("missing/", getConfigPath(), "file");
+			const misplaced = path.join(agentDir, "missing");
+
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			settings.set("setupVersion", 14);
+			await expect(settings.flush()).rejects.toThrow();
+
+			// No regular file was landed at the frozen component.
+			expect(fs.existsSync(misplaced)).toBe(false);
+			// The user-managed chain head survives as a symlink.
+			expect(fs.lstatSync(getConfigPath()).isSymbolicLink()).toBe(true);
+		});
+
 		it("does not re-emit the filesystem root as a segment for an absolute Windows target", async () => {
 			// On Windows the flush walk seeds the accumulator at parse(target).root
 			// (`C:\`) and then walks the segments. If the root is left in the string

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -684,6 +684,111 @@ describe("Settings", () => {
 			expect(fs.lstatSync(getConfigPath()).isSymbolicLink()).toBe(true);
 		});
 
+		it("rejects with ENOTDIR when a trailing-slash target's directory is removed before the validation stat", async () => {
+			// config.yml -> racetarget/, where `racetarget` does not exist when the
+			// initial realpath(config.yml) runs, so the manual segment walk begins.
+			// A concurrent process creates `racetarget` as a real DIRECTORY before
+			// the walk's realpath(candidate) reaches it, so that realpath succeeds
+			// and the walk stays UNFROZEN, reaching the trailing-slash
+			// directory-requirement stat. The directory is then removed between that
+			// realpath and this stat, so the stat throws ENOENT. The requirement —
+			// `racetarget` must be a traversable directory — provably cannot hold
+			// now the component is gone. Letting the ENOENT reach the outer catch
+			// would swallow it and return path.resolve(config.yml), so the atomic
+			// rename would replace config.yml ITSELF with a regular file while the
+			// dangling symlink survives. Surface ENOTDIR instead.
+			await fs.promises.symlink("racetarget/", getConfigPath(), "file");
+			const raceTarget = path.join(agentDir, "racetarget");
+
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			const realpath = fs.promises.realpath.bind(fs.promises);
+			const stat = fs.promises.stat.bind(fs.promises);
+			let created = false;
+			let removed = false;
+			vi.spyOn(fs.promises, "realpath").mockImplementation((async (target: fs.PathLike, ...rest: unknown[]) => {
+				if (!created && String(target) === raceTarget) {
+					created = true;
+					// Win the first half of the race: materialize the component as a
+					// real directory so this realpath resolves it and the walk stays
+					// unfrozen.
+					fs.mkdirSync(raceTarget);
+				}
+				return (realpath as (t: fs.PathLike, ...r: unknown[]) => Promise<string>)(target, ...rest);
+			}) as typeof fs.promises.realpath);
+			vi.spyOn(fs.promises, "stat").mockImplementation((async (target: fs.PathLike, ...rest: unknown[]) => {
+				if (!removed && String(target) === raceTarget) {
+					removed = true;
+					// Win the second half: remove the required directory after
+					// realpath resolved it but before this validation stat inspects
+					// it, so the stat throws ENOENT.
+					fs.rmSync(raceTarget, { recursive: true, force: true });
+				}
+				return (stat as (t: fs.PathLike, ...r: unknown[]) => Promise<fs.Stats>)(target, ...rest);
+			}) as typeof fs.promises.stat);
+
+			settings.set("setupVersion", 17);
+			await expect(settings.flush()).rejects.toThrow(/ENOTDIR/);
+
+			expect(created).toBe(true);
+			expect(removed).toBe(true);
+			// config.yml itself was NOT clobbered into a regular file.
+			expect(fs.lstatSync(getConfigPath()).isSymbolicLink()).toBe(true);
+		});
+
+		it("rejects with ENOTDIR when a `..` target's directory is removed before the validation stat", async () => {
+			// config.yml -> racetarget/../victim.yml, where `racetarget` does not
+			// exist when the initial realpath(config.yml) runs, so the manual walk
+			// begins. A concurrent process creates `racetarget` as a real DIRECTORY
+			// before the walk's realpath(candidate) reaches it, so that realpath
+			// succeeds and the walk stays UNFROZEN, reaching the `..`
+			// directory-requirement stat. The directory is then removed between that
+			// realpath and this stat, so the stat throws ENOENT. The `..` still
+			// requires `racetarget` to be a traversable directory to pop its parent,
+			// and that provably cannot hold now. Letting the ENOENT reach the outer
+			// catch would swallow it and return path.resolve(config.yml), clobbering
+			// config.yml itself while the dangling symlink survives. Surface ENOTDIR.
+			await fs.promises.symlink("racetarget/../victim.yml", getConfigPath(), "file");
+			const raceTarget = path.join(agentDir, "racetarget");
+			const victim = path.join(agentDir, "victim.yml");
+			await Bun.write(victim, "keep: me");
+
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			const realpath = fs.promises.realpath.bind(fs.promises);
+			const stat = fs.promises.stat.bind(fs.promises);
+			let created = false;
+			let removed = false;
+			vi.spyOn(fs.promises, "realpath").mockImplementation((async (target: fs.PathLike, ...rest: unknown[]) => {
+				if (!created && String(target) === raceTarget) {
+					created = true;
+					// Win the first half of the race: materialize the component as a
+					// real directory so this realpath resolves it and the walk stays
+					// unfrozen.
+					fs.mkdirSync(raceTarget);
+				}
+				return (realpath as (t: fs.PathLike, ...r: unknown[]) => Promise<string>)(target, ...rest);
+			}) as typeof fs.promises.realpath);
+			vi.spyOn(fs.promises, "stat").mockImplementation((async (target: fs.PathLike, ...rest: unknown[]) => {
+				if (!removed && String(target) === raceTarget) {
+					removed = true;
+					// Win the second half: remove the required directory after
+					// realpath resolved it but before this validation stat inspects
+					// it, so the stat throws ENOENT.
+					fs.rmSync(raceTarget, { recursive: true, force: true });
+				}
+				return (stat as (t: fs.PathLike, ...r: unknown[]) => Promise<fs.Stats>)(target, ...rest);
+			}) as typeof fs.promises.stat);
+
+			settings.set("setupVersion", 18);
+			await expect(settings.flush()).rejects.toThrow(/ENOTDIR/);
+
+			expect(created).toBe(true);
+			expect(removed).toBe(true);
+			// The unrelated sibling was NOT overwritten with YAML.
+			expect(await Bun.file(victim).text()).toBe("keep: me");
+			// config.yml itself was NOT clobbered into a regular file.
+			expect(fs.lstatSync(getConfigPath()).isSymbolicLink()).toBe(true);
+		});
+
 		it("does not re-emit the filesystem root as a segment for an absolute Windows target", async () => {
 			// On Windows the flush walk seeds the accumulator at parse(target).root
 			// (`C:\`) and then walks the segments. If the root is left in the string

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -402,6 +402,71 @@ describe("Settings", () => {
 			expect(fs.lstatSync(midPath).isSymbolicLink()).toBe(true);
 		});
 
+		it("throws a bounded ELOOP when the chain turns cyclic after realpath reports ENOENT", async () => {
+			// config.yml -> mid.yml -> final.yml (final missing), so the initial
+			// realpath() reports ENOENT and the manual chain walk runs. A
+			// concurrent process then retargets mid.yml back at the chain head, so
+			// readlink() alternates head<->mid forever. The resolver must cap its
+			// hops and throw an ELOOP-style error rather than hang flush().
+			const finalPath = tempDir.join("final-config.yml");
+			const midPath = tempDir.join("mid-config.yml");
+			await fs.promises.symlink(finalPath, midPath, "file");
+			await fs.promises.symlink(midPath, getConfigPath(), "file");
+
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+
+			const readlink = fs.promises.readlink.bind(fs.promises);
+			let readlinkCalls = 0;
+			// Bounded safety valve set far above the resolver's hop cap: the fixed
+			// resolver throws ELOOP well before this fires, so it never trips. An
+			// unbounded walk (pre-fix) only stops here, surfacing a distinct error
+			// that proves no ELOOP was raised — RED without hanging the suite.
+			const safetyValve = 500;
+			vi.spyOn(fs.promises, "readlink").mockImplementation((async (target: fs.PathLike) => {
+				readlinkCalls++;
+				if (readlinkCalls > safetyValve) {
+					throw new FsCodeError("ETESTVALVE", "unbounded symlink walk");
+				}
+				// Retarget mid back at the chain head to close the cycle.
+				if (String(target) === midPath) return getConfigPath();
+				return readlink(target);
+			}) as typeof fs.promises.readlink);
+
+			settings.set("setupVersion", 5);
+			await expect(settings.flush()).rejects.toThrow(/ELOOP/);
+			expect(readlinkCalls).toBeLessThanOrEqual(safetyValve);
+		});
+
+		it("follows an intermediate directory symlink inside a relative target before applying ..", async () => {
+			// config.yml -> alias/../final.yml, where `alias` is a symlinked
+			// directory (alias -> elsewhere/deep) and final.yml is missing. The
+			// filesystem follows `alias` first and then pops its PHYSICAL parent,
+			// landing on elsewhere/final.yml. A lexical normalization of the whole
+			// target collapses `alias/..` to the config dir up front and would
+			// clobber <configdir>/final.yml while leaving the real chain dangling.
+			const elsewhereDir = tempDir.join("elsewhere");
+			const deepDir = path.join(elsewhereDir, "deep");
+			fs.mkdirSync(deepDir, { recursive: true });
+			const aliasDir = path.join(agentDir, "alias");
+			await fs.promises.symlink(deepDir, aliasDir, "dir");
+
+			await fs.promises.symlink("alias/../final-config.yml", getConfigPath(), "file");
+
+			const physicalFinal = path.join(elsewhereDir, "final-config.yml");
+			const lexicalSibling = path.join(agentDir, "final-config.yml");
+
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			settings.set("setupVersion", 8);
+			await settings.flush();
+
+			// The write lands on the physical target (fs semantics), recreating it,
+			// while the lexically collapsed sibling stays untouched.
+			expect(YAML.parse(await Bun.file(physicalFinal).text())).toEqual({ setupVersion: 8 });
+			expect(fs.existsSync(lexicalSibling)).toBe(false);
+			// The user-managed chain head survives as a symlink.
+			expect(fs.lstatSync(getConfigPath()).isSymbolicLink()).toBe(true);
+		});
+
 		it("falls back to move-aside replacement when Windows reports EPERM", async () => {
 			await writeSettings({ setupVersion: 1 });
 			const settings = await Settings.init({ cwd: projectDir, agentDir });

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -608,6 +608,42 @@ describe("Settings", () => {
 			expect(fs.lstatSync(getConfigPath()).isSymbolicLink()).toBe(true);
 		});
 
+		it("rejects with ENOTDIR when a trailing-slash target is created as a regular file mid-walk", async () => {
+			// config.yml -> racetarget/, where `racetarget` does not exist when the
+			// initial realpath(config.yml) runs, so it reports ENOENT and the manual
+			// segment walk begins. A concurrent process then creates `racetarget` as
+			// a REGULAR FILE before the walk's realpath(candidate) reaches it, so
+			// that realpath succeeds and the walk stays UNFROZEN. The trailing slash
+			// still demands `racetarget` be a traversable directory; a regular file
+			// is not, so opening config.yml really fails with ENOTDIR. Dropping the
+			// terminal empty segment and returning the regular file would let the
+			// atomic rename overwrite it and falsely report success. Surface it.
+			await fs.promises.symlink("racetarget/", getConfigPath(), "file");
+			const raceTarget = path.join(agentDir, "racetarget");
+
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			const realpath = fs.promises.realpath.bind(fs.promises);
+			let injected = false;
+			vi.spyOn(fs.promises, "realpath").mockImplementation((async (target: fs.PathLike, ...rest: unknown[]) => {
+				if (!injected && String(target) === raceTarget) {
+					injected = true;
+					// Win the race: materialize the target as a regular file so this
+					// realpath resolves it and the walk never freezes.
+					await Bun.write(raceTarget, "not a dir");
+				}
+				return (realpath as (t: fs.PathLike, ...r: unknown[]) => Promise<string>)(target, ...rest);
+			}) as typeof fs.promises.realpath);
+
+			settings.set("setupVersion", 15);
+			await expect(settings.flush()).rejects.toThrow(/ENOTDIR/);
+
+			expect(injected).toBe(true);
+			// The concurrently created regular file was NOT overwritten with YAML.
+			expect(await Bun.file(raceTarget).text()).toBe("not a dir");
+			// The user-managed chain head survives as a symlink.
+			expect(fs.lstatSync(getConfigPath()).isSymbolicLink()).toBe(true);
+		});
+
 		it("does not re-emit the filesystem root as a segment for an absolute Windows target", async () => {
 			// On Windows the flush walk seeds the accumulator at parse(target).root
 			// (`C:\`) and then walks the segments. If the root is left in the string

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -644,6 +644,46 @@ describe("Settings", () => {
 			expect(fs.lstatSync(getConfigPath()).isSymbolicLink()).toBe(true);
 		});
 
+		it("rejects with ENOTDIR when a `..` target's component is created as a regular file mid-walk", async () => {
+			// config.yml -> racetarget/../victim.yml, where `racetarget` does not
+			// exist when the initial realpath(config.yml) runs, so it reports ENOENT
+			// and the manual segment walk begins. A concurrent process then creates
+			// `racetarget` as a REGULAR FILE before the walk's realpath(candidate)
+			// reaches it, so that realpath succeeds and the walk stays UNFROZEN. The
+			// following `..` demands `racetarget` be a traversable directory to pop
+			// its parent; a regular file is not, so opening config.yml really fails
+			// with ENOTDIR (the kernel rejects `regularfile/..`). Popping lexically
+			// and continuing would resolve to victim.yml in the parent dir and let
+			// the atomic rename overwrite an unrelated sibling while falsely
+			// reporting success. Surface it.
+			await fs.promises.symlink("racetarget/../victim.yml", getConfigPath(), "file");
+			const raceTarget = path.join(agentDir, "racetarget");
+			const victim = path.join(agentDir, "victim.yml");
+			await Bun.write(victim, "keep: me");
+
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			const realpath = fs.promises.realpath.bind(fs.promises);
+			let injected = false;
+			vi.spyOn(fs.promises, "realpath").mockImplementation((async (target: fs.PathLike, ...rest: unknown[]) => {
+				if (!injected && String(target) === raceTarget) {
+					injected = true;
+					// Win the race: materialize the component as a regular file so this
+					// realpath resolves it and the walk never freezes.
+					await Bun.write(raceTarget, "not a dir");
+				}
+				return (realpath as (t: fs.PathLike, ...r: unknown[]) => Promise<string>)(target, ...rest);
+			}) as typeof fs.promises.realpath);
+
+			settings.set("setupVersion", 16);
+			await expect(settings.flush()).rejects.toThrow(/ENOTDIR/);
+
+			expect(injected).toBe(true);
+			// The unrelated sibling was NOT overwritten with YAML.
+			expect(await Bun.file(victim).text()).toBe("keep: me");
+			// The user-managed chain head survives as a symlink.
+			expect(fs.lstatSync(getConfigPath()).isSymbolicLink()).toBe(true);
+		});
+
 		it("does not re-emit the filesystem root as a segment for an absolute Windows target", async () => {
 			// On Windows the flush walk seeds the accumulator at parse(target).root
 			// (`C:\`) and then walks the segments. If the root is left in the string

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -314,6 +314,26 @@ describe("Settings", () => {
 			expect(YAML.parse(await Bun.file(managedConfigPath).text())).toEqual({ setupVersion: 2 });
 		});
 
+		it("writes through a dangling symlink chain to the final target, preserving every link", async () => {
+			// config.yml -> mid.yml -> final.yml where final.yml does not exist yet
+			// (first-run into a dotfiles/managed checkout). realpath throws ENOENT at
+			// the missing tail, so the write path must walk the chain hop by hop and
+			// land on final.yml — recreating it while leaving both links intact.
+			const finalPath = tempDir.join("final-config.yml");
+			const midPath = tempDir.join("mid-config.yml");
+			await fs.promises.symlink(finalPath, midPath, "file");
+			await fs.promises.symlink(midPath, getConfigPath(), "file");
+
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			settings.set("setupVersion", 3);
+			await settings.flush();
+
+			expect(fs.lstatSync(getConfigPath()).isSymbolicLink()).toBe(true);
+			expect(fs.lstatSync(midPath).isSymbolicLink()).toBe(true);
+			expect(fs.lstatSync(finalPath).isSymbolicLink()).toBe(false);
+			expect(YAML.parse(await Bun.file(finalPath).text())).toEqual({ setupVersion: 3 });
+		});
+
 		it("falls back to move-aside replacement when Windows reports EPERM", async () => {
 			await writeSettings({ setupVersion: 1 });
 			const settings = await Settings.init({ cwd: projectDir, agentDir });


### PR DESCRIPTION
## What

Make the config write path preserve a symlink chain when the chain's final target does not exist yet, instead of clobbering an intermediate link into a regular file.

## Why

A config path is often a symlink into a dotfiles/managed checkout — e.g. `config.yml -> current.yml -> a-not-yet-created.yml` on first run. `realpath` throws `ENOENT` at the missing tail, so the write-path resolver fell back to a single `readlink` (one hop) and landed on the first intermediate link, clobbering it into a regular file and stranding the managed target.

The resolver now walks the chain hop by hop, following each existing intermediate link until the referent is a non-symlink or does not exist. The write lands on the chain's final target and every intermediate link is preserved.

(The related secure-mode concern is already handled upstream: `#writeYamlAtomically` opens the staging temp at mode `0600` from creation, so a brand-new secret config is never briefly world-readable. Only the chain-walk was missing, so this PR is chain-walk only.)

I reviewed the full diff and exercised it against a three-hop dangling chain: the write lands on the final target and both intermediate links survive as symlinks.

## Testing

- `packages/coding-agent/test/settings-manager.test.ts` — 97 pass / 0 fail, including a new test that writes through a `config.yml -> mid -> final` dangling chain and asserts both links stay links while `final` receives the write.
- `tsgo --noEmit` and `biome check` clean.

Built on current `main` (`51f03804`).

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
