### PR TITLE
fix(tui): render prototype-label reference links as plain text

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed a crash when rendering a reference-style Markdown link whose label matches a JavaScript built-in name (e.g. `[x][constructor]`, `[x][__proto__]`); such links now render as plain text instead of terminating the TUI, including during session resume ([#10283](https://github.com/can1357/oh-my-pi/issues/10283)).
+
 ## [18.0.11] - 2026-08-29
 
 ### Added

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -3155,17 +3155,21 @@ export class Markdown implements Component {
 					markHtmlItemWhenContent(token.text);
 					const linkText = this.#renderInlineTokens(token.tokens || [], resolvedStyleContext);
 					const styledLinkText = this.#theme.link(this.#theme.underline(linkText));
-					const clickableLinkText = formatHyperlink(styledLinkText, token.href);
-					// If link text matches href, only show the link once
+					const href = typeof token.href === "string" ? token.href : "";
+					const clickableLinkText = formatHyperlink(styledLinkText, href);
+					// If link text matches href, only show the link once. A missing
+					// href (malformed/partial link token) renders as plain link text
+					// instead of crashing the renderer or emitting an empty "()"
+					// (issue #10283).
 					// Compare raw text (token.text) not styled text (linkText) since linkText has ANSI codes
 					// For mailto: links, strip the prefix before comparing (autolinked emails have
 					// text="foo@bar.com" but href="mailto:foo@bar.com")
-					const hrefForComparison = token.href.startsWith("mailto:") ? token.href.slice(7) : token.href;
-					if (token.text === token.href || token.text === hrefForComparison)
+					const hrefForComparison = href.startsWith("mailto:") ? href.slice(7) : href;
+					if (!href || token.text === href || token.text === hrefForComparison)
 						result += clickableLinkText + stylePrefix;
 					else {
-						const styledLinkUrl = this.#theme.linkUrl(`(${token.href})`);
-						result += `${clickableLinkText} ${formatHyperlink(styledLinkUrl, token.href)}${stylePrefix}`;
+						const styledLinkUrl = this.#theme.linkUrl(`(${href})`);
+						result += `${clickableLinkText} ${formatHyperlink(styledLinkUrl, href)}${stylePrefix}`;
 					}
 					break;
 				}

--- a/packages/tui/test/markdown.test.ts
+++ b/packages/tui/test/markdown.test.ts
@@ -1574,6 +1574,26 @@ bar`,
 			const output = markdown.render(80).join("\n");
 			expect(output.includes("\x1b]8;;http://www.example.com\x07")).toBe(true);
 		});
+
+		it("renders a reference link with a prototype-key label as plain text without crashing (issue #10283)", () => {
+			// A reference-style link whose label collides with an Object.prototype
+			// member used to resolve to an inherited non-definition, producing a
+			// link token with `href: undefined` that crashed the renderer at
+			// `token.href.startsWith` — fatal during transcript replay.
+			// `constructor`/`toString` render as literal label text; every case
+			// must avoid emitting an OSC 8 hyperlink and must not throw.
+			for (const label of ["constructor", "toString", "valueOf", "isPrototypeOf"]) {
+				const markdown = new Markdown(`See [${label}] for details`, 0, 0, defaultMarkdownTheme);
+				const output = markdown.render(80).join("\n");
+				expect(stripTerminalSequences(output).trim()).toBe(`See [${label}] for details`);
+				expect(output.includes("\x1b]8;;")).toBe(false);
+			}
+			// `__proto__`'s double underscores are legitimately parsed as emphasis;
+			// the contract here is only that it never becomes a link or crashes.
+			const protoOut = new Markdown("See [__proto__] for details", 0, 0, defaultMarkdownTheme).render(80).join("\n");
+			expect(protoOut.includes("\x1b]8;;")).toBe(false);
+			expect(stripTerminalSequences(protoOut)).toContain("proto");
+		});
 	});
 
 	describe("HTML-like tags in text", () => {

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the Markdown lexer treating reference-link labels that collide with `Object.prototype` members (`constructor`, `__proto__`, …) as definitions; such labels no longer produce link tokens with an undefined `href` ([#10283](https://github.com/can1357/oh-my-pi/issues/10283)).
+
 ## [18.0.11] - 2026-08-29
 
 ### Fixed

--- a/packages/utils/src/marked/core.ts
+++ b/packages/utils/src/marked/core.ts
@@ -343,8 +343,15 @@ const DEFAULTS: MarkedOptions = {
 };
 const PUNCTUATION = /[!"#$%&'()*+,\-./:;<=>?@[\\\]^_`{|}~]/;
 
-function tokenList(links: Links = {}): TokensList {
+function tokenList(links: Links = Object.create(null)): TokensList {
 	const list = [] as unknown as TokensList;
+	// The reference-definition map is keyed by user-controlled labels. A plain
+	// `{}` inherits `Object.prototype`, so a reference-style link whose label is
+	// an inherited member (`[x][constructor]`, `[x][__proto__]`) resolves to a
+	// truthy non-definition and yields a link token with `href: undefined`
+	// (issue #10283). A null-prototype map makes such lookups miss, so the link
+	// correctly falls back to literal text, and label writes cannot pollute the
+	// prototype.
 	list.links = links;
 	return list;
 }

--- a/packages/utils/test/marked.test.ts
+++ b/packages/utils/test/marked.test.ts
@@ -174,4 +174,28 @@ describe("marked compatibility", () => {
 		]);
 		expect(marked.parse("before $x_i$\n\n$$\ny^2\n$$\n")).toBe("<p>before <i>x_i</i></p>\n<math>y^2</math>\n");
 	});
+
+	// Reference labels are user-controlled and index the ref-def map. An
+	// `Object.prototype` member (`constructor`, `__proto__`, `toString`, …) must
+	// not resolve to a fake definition: the link falls back to literal text and
+	// never yields a `href: undefined` token that crashes downstream renderers
+	// (issue #10283).
+	for (const label of ["constructor", "__proto__", "toString", "valueOf", "hasOwnProperty"]) {
+		test(`treats reference label ${label} as literal text, not an inherited definition`, () => {
+			const tokens = [...Lexer.lex(`[text][${label}]`)];
+			const links: unknown[] = [];
+			const walk = (list: readonly { type: string; tokens?: unknown[] }[]) => {
+				for (const token of list) {
+					if (token.type === "link") links.push(token);
+					if (Array.isArray(token.tokens)) {
+						walk(token.tokens as { type: string; tokens?: unknown[] }[]);
+					}
+				}
+			};
+			walk(tokens as { type: string; tokens?: unknown[] }[]);
+			expect(links).toEqual([]);
+			// No anchor element is produced: the label is not a reference definition.
+			expect(new Marked().parse(`[text][${label}]`)).not.toContain("<a ");
+		});
+	}
 });


### PR DESCRIPTION
## Repro
Rendering Markdown that contains a reference-style link whose label matches a JavaScript built-in name — e.g. `See [constructor] for details` or `[x][__proto__]` — crashes the TUI. The first render is caught (`Tool renderer failed`), but on transcript replay (`omp --resume`) the same content throws an uncaught `TypeError: undefined is not an object (evaluating 'token.href.startsWith')`, terminating the process and permanently blocking resume of the affected session. Reproduced with `bun` rendering `new Markdown("See [constructor] for details").render(80)` → crash at `packages/tui/src/components/markdown.ts:3163` (exit 1), matching the reporter's `p.href.startsWith` stack. Platform-independent (not Windows-specific).

## Cause
`tokenList()` in `packages/utils/src/marked/core.ts` initialized the reference-definition map as a plain `{}`, which inherits `Object.prototype`. `matchLink` (`core.ts:500-506`) looks a label up in that map and only rejects falsy results (`if (!def) return undefined`); an inherited member such as `constructor` or `__proto__` returns a truthy prototype value, so the label is treated as a definition and a link token is emitted with `href: def.href === undefined`. `Markdown.#renderInlineTokens` (`packages/tui/src/components/markdown.ts:3163`) then dereferenced `token.href.startsWith` unguarded, throwing.

## Fix
- `packages/utils/src/marked/core.ts`: build the ref-def map with `Object.create(null)` so inherited-member labels miss the lookup (link falls back to literal text, CommonMark-correct) and label writes cannot pollute the prototype.
- `packages/tui/src/components/markdown.ts`: in the `link` render branch, normalize `token.href` to a string and render plain link text (no clickable URL, no empty `()`) when it is missing — defense-in-depth against any malformed/partial link token, matching the existing `formatHyperlink` falsy guard.
- Regression tests: `packages/utils/test/marked.test.ts` asserts prototype-key labels produce no link token / anchor; `packages/tui/test/markdown.test.ts` asserts such content renders as plain text, emits no OSC 8 hyperlink, and does not crash.

## Verification
`cd packages/utils && bun test test/marked.test.ts` → 27 pass. `cd packages/tui && bun test test/markdown.test.ts` → 146 pass; plus `markdown-incremental-lex`, `markdown-bplus-fast-path`, `markdown-math`, `markdown-tree-wrap` → 98 pass. Pre-repro script now renders `See [constructor] for details` as literal text without throwing. Valid inline and reference links (including the reporter's `https://handlebarsjs.com/...#options-to-control-prototype-access`) still resolve their href and render as clickable links. Fixes #10283