### PR TITLE
fix(coding-agent): refresh extension dynamic catalogs after login

### DIFF
--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -1732,8 +1732,7 @@ export class AuthStorage {
 	 */
 	#getNextRoundRobinIndex(providerKey: string, total: number): number {
 		if (total <= 1) return 0;
-		const current = this.#providerRoundRobinIndex.get(providerKey) ?? -1;
-		const next = (current + 1) % total;
+		const next = ((this.#providerRoundRobinIndex.get(providerKey) ?? -1) + 1) % total;
 		this.#providerRoundRobinIndex.set(providerKey, next);
 		return next;
 	}

--- a/packages/ai/test/model-cache.test.ts
+++ b/packages/ai/test/model-cache.test.ts
@@ -5,8 +5,8 @@ import * as os from "node:os";
 import * as path from "node:path";
 import type { Model } from "@oh-my-pi/pi-ai/types";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
-import { readModelCache, writeModelCache } from "@oh-my-pi/pi-catalog/model-cache";
-import { removeWithRetries } from "../../utils/src/temp";
+import { __closeSharedModelCacheForTests, readModelCache, writeModelCache } from "@oh-my-pi/pi-catalog/model-cache";
+import { getAgentDir, getModelDbPath, removeWithRetries, setAgentDir } from "@oh-my-pi/pi-utils";
 
 const TTL_MS = 24 * 60 * 60 * 1000;
 
@@ -44,6 +44,140 @@ describe("model cache migrations", () => {
 			await removeWithRetries(tempDir);
 			tempDir = "";
 			dbPath = "";
+		}
+	});
+
+	it("purges a v13 row written after the shared cache handle opened", async () => {
+		const originalAgentDir = getAgentDir();
+		const sharedAgentDir = path.join(tempDir, "agent");
+		await fs.mkdir(sharedAgentDir, { recursive: true });
+		setAgentDir(sharedAgentDir);
+		try {
+			const leakedHeader = "legacy-concurrent-secret";
+			const model = createModel("concurrent-v13", "Concurrent v13");
+			writeModelCache("concurrent-v13", Date.now(), [model], true, "");
+			const dbPath = getModelDbPath();
+			const oldProcess = new Database(dbPath);
+			try {
+				oldProcess.run("UPDATE model_cache SET version = 13, models = ? WHERE provider_id = ?", [
+					JSON.stringify([{ headers: { Authorization: leakedHeader } }]),
+					"concurrent-v13",
+				]);
+			} finally {
+				oldProcess.close();
+			}
+
+			expect(readModelCache("concurrent-v13", TTL_MS, Date.now)).toBeNull();
+			const verified = new Database(dbPath, { readonly: true });
+			try {
+				expect(
+					verified.query<{ count: number }, []>("SELECT COUNT(*) AS count FROM model_cache").get()?.count,
+				).toBe(0);
+			} finally {
+				verified.close();
+			}
+			const persistedBytes = await Promise.all([
+				fs.readFile(dbPath),
+				fs.readFile(`${dbPath}-wal`).catch(() => new Uint8Array()),
+			]);
+			expect(persistedBytes.map(bytes => new TextDecoder().decode(bytes)).join()).not.toContain(leakedHeader);
+		} finally {
+			__closeSharedModelCacheForTests();
+			setAgentDir(originalAgentDir);
+		}
+	});
+
+	it("reads a clean shared cache while another connection holds the writer lock", async () => {
+		const originalAgentDir = getAgentDir();
+		const sharedAgentDir = path.join(tempDir, "agent");
+		await fs.mkdir(sharedAgentDir, { recursive: true });
+		setAgentDir(sharedAgentDir);
+		try {
+			const providerId = "clean-v14";
+			writeModelCache(providerId, Date.now(), [createModel(providerId, "Clean v14")], true, "");
+			const writer = new Database(getModelDbPath());
+			try {
+				writer.run("BEGIN IMMEDIATE");
+				const cached = readModelCache(providerId, TTL_MS, Date.now);
+				expect(cached?.models.map(model => model.id)).toEqual([providerId]);
+			} finally {
+				writer.run("ROLLBACK");
+				writer.close();
+			}
+		} finally {
+			__closeSharedModelCacheForTests();
+			setAgentDir(originalAgentDir);
+		}
+	});
+
+	it("does not checkpoint a v13 row written while the cleanup marker clears", async () => {
+		const providerId = "post-cleanup-v13";
+		const leakedHeader = "legacy-post-cleanup-secret";
+		writeModelCache(providerId, Date.now(), [createModel(providerId, "Post-cleanup v13")], true, "", dbPath);
+		const oldProcess = new Database(dbPath);
+		try {
+			oldProcess.run("UPDATE model_cache SET version = 13 WHERE provider_id = ?", [providerId]);
+			oldProcess.run(`
+				CREATE TRIGGER reintroduce_v13_when_cleanup_marker_clears
+				AFTER DELETE ON model_cache_cleanup
+				WHEN OLD.operation = 'truncate-wal'
+				BEGIN
+					INSERT OR REPLACE INTO model_cache (provider_id, version, updated_at, authoritative, models)
+					VALUES ('${providerId}', 13, 0, 1, '[{"headers":{"Authorization":"' || 'legacy-' || 'post-' || 'cleanup-' || 'secret' || '"}}]');
+				END
+			`);
+
+			expect(readModelCache(providerId, TTL_MS, Date.now, dbPath)).toBeNull();
+			expect((await fs.readFile(dbPath)).includes(leakedHeader)).toBe(false);
+		} finally {
+			oldProcess.close();
+		}
+	});
+
+	it("defers v13 WAL cleanup while a concurrent reader holds a snapshot", () => {
+		const model = createModel("busy-v13", "Busy v13");
+		writeModelCache("busy-v13", Date.now(), [model], true, "", dbPath);
+		const oldProcess = new Database(dbPath);
+		try {
+			oldProcess.run("UPDATE model_cache SET version = 13 WHERE provider_id = ?", ["busy-v13"]);
+		} finally {
+			oldProcess.close();
+		}
+		const reader = new Database(dbPath, { readonly: true });
+		try {
+			reader.run("BEGIN");
+			reader.query<{ version: number }, []>("SELECT version FROM model_cache WHERE provider_id = 'busy-v13'").get();
+
+			expect(readModelCache("busy-v13", TTL_MS, Date.now, dbPath)).toBeNull();
+			const pending = new Database(dbPath, { readonly: true });
+			try {
+				expect(
+					pending
+						.query<{ count: number }, []>(
+							"SELECT COUNT(*) AS count FROM model_cache_cleanup WHERE operation = 'truncate-wal'",
+						)
+						.get()?.count,
+				).toBe(1);
+			} finally {
+				pending.close();
+			}
+		} finally {
+			reader.run("ROLLBACK");
+			reader.close();
+		}
+
+		expect(readModelCache("busy-v13", TTL_MS, Date.now, dbPath)).toBeNull();
+		const completed = new Database(dbPath, { readonly: true });
+		try {
+			expect(
+				completed
+					.query<{ count: number }, []>(
+						"SELECT COUNT(*) AS count FROM model_cache_cleanup WHERE operation = 'truncate-wal'",
+					)
+					.get()?.count,
+			).toBe(0);
+		} finally {
+			completed.close();
 		}
 	});
 

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Fixed native Devin families with independent Thinking and 1M Context axes losing wire variants or advertising the wrong context window; each context lane now preserves its complete off/effort routing and server-selected default ([#8590](https://github.com/can1357/oh-my-pi/pull/8590) by [@will-bogusz](https://github.com/will-bogusz)).
 - Stripped the image modality from Devin's `swe-1-6`/`swe-1-6-fast`: their configs advertise `supports_images` but the backend silently drops inline images (verified live against every other Cascade model), so clients now engage their text-only image fallback instead of losing attachments ([#6072](https://github.com/can1357/oh-my-pi/issues/6072)).
 - Devin discovery now logs a warning when the backend returns an empty native catalog, the failure signature of a stale pinned CLI identity ([#8590](https://github.com/can1357/oh-my-pi/pull/8590) by [@will-bogusz](https://github.com/will-bogusz)).
+- Fixed model catalogs staying available through upgrades while stale extension entries are cleared ([#5780](https://github.com/can1357/oh-my-pi/issues/5780)).
 ### Changed
 
 - Variant collapse moved to `@oh-my-pi/pi-catalog/compat/collapse` with a consolidated API (`collapseVariants`/`collapseBuiltVariants`/`resolveVariantSelector`/`resolveBareVariantSelector`/`isCollapsedVariantSpec`); the reviewed per-provider families (Antigravity, Gemini CLI, Devin, Cursor) are authored in `_collapse.kdl` and compiled, not hand-written tables.

--- a/packages/catalog/src/model-cache.ts
+++ b/packages/catalog/src/model-cache.ts
@@ -7,11 +7,11 @@ import { renameSync } from "node:fs";
 import { getModelDbPath, isEnoent, isSqliteCorruptionError, logger } from "@oh-my-pi/pi-utils";
 import type { Api, Model, ModelSpec } from "./types";
 
-// Rows persist ModelSpec JSON (sparse `compat`, never the resolved record);
-// the model manager rebuilds via `buildModel` on load. Request headers are
-// intentionally omitted: arbitrary provider-defined header names can carry
-// credentials. v12 invalidates Kimi Code rows carrying the blanket
-// maxTokens: 32000 that predate per-family output caps (k3/k3-256k -> 131072,
+// v14 invalidates rows created by the short-lived credential-scoped cache
+// experiment, so derived credential material is securely deleted rather than
+// reused.
+// v12 invalidates Kimi Code rows carrying the blanket maxTokens: 32000 that
+// predate per-family output caps (k3/k3-256k -> 131072,
 // kimi-for-coding[-highspeed] -> 32768, #6711); v11 invalidates rows that may
 // persist derived computer-use
 // headers and records which model ids lost headers or cannot be rebuilt.
@@ -23,7 +23,7 @@ import type { Api, Model, ModelSpec } from "./types";
 // retired unknown-limit sentinels (222222/8888); v5 invalidated rows predating
 // effort-tier variant collapsing (raw `-low`/`-high`/`-thinking` member ids);
 // v4 dropped the pre-efforts ThinkingConfig shape.
-const CACHE_SCHEMA_VERSION = 12;
+const CACHE_SCHEMA_VERSION = 14;
 const HEADER_RESTORE_VERSION = 1;
 
 interface CacheRow {
@@ -65,6 +65,14 @@ interface CacheEntry<TApi extends Api = Api> {
 let sharedDb: Database | null = null;
 let sharedDbPath: string | null = null;
 
+/** Test-only: release the process-wide cache handle without opening another database. */
+export function __closeSharedModelCacheForTests(): void {
+	if (!sharedDb) return;
+	sharedDb.close();
+	sharedDb = null;
+	sharedDbPath = null;
+}
+
 function openDb(resolvedPath: string): Database {
 	const db = new Database(resolvedPath, { create: true });
 	// Install the busy handler BEFORE any lock-taking statement. See
@@ -88,12 +96,21 @@ function openDb(resolvedPath: string): Database {
 			models TEXT NOT NULL
 		)
 	`);
+	db.run(`
+		CREATE TABLE IF NOT EXISTS model_cache_cleanup (
+			operation TEXT PRIMARY KEY
+		)
+	`);
 	migrateCacheSchema(db);
 	return db;
 }
 
 function getSharedDb(resolvedPath: string): Database {
 	if (sharedDb && sharedDbPath === resolvedPath) {
+		// A concurrently running pre-v14 process can add a credential-scoped v13
+		// row after this handle opened. Re-run the idempotent purge before reuse
+		// so that row is deleted and its WAL pages are checkpointed immediately.
+		migrateCacheSchema(sharedDb);
 		return sharedDb;
 	}
 	if (sharedDb) {
@@ -168,12 +185,69 @@ function withModelCacheDb<T>(dbPath: string | undefined, useDb: (db: Database) =
 	const resolvedPath = dbPath ?? getModelDbPath();
 	const shared = dbPath === undefined;
 	try {
-		return runModelCacheDb(resolvedPath, shared, useDb);
+		return runModelCacheDb(resolvedPath, shared, db => {
+			checkpointPendingCacheWal(db);
+			return useDb(db);
+		});
 	} catch (err) {
 		if (!isSqliteCorruptionError(err)) throw err;
 		healCorruptModelCache(resolvedPath, shared, err);
 		return runModelCacheDb(resolvedPath, shared, useDb);
 	}
+}
+
+function checkpointCacheWal(db: Database): boolean {
+	// secure_delete overwrites freed SQLite cells, but a shared WAL can retain an
+	// older page until checkpointed. Reader contention is reported in the result
+	// row rather than throwing. The migration marker permits a later retry, so do
+	// not wait behind a reader and delay ordinary cache operations.
+	db.run("PRAGMA busy_timeout = 0");
+	try {
+		const result = db.query<{ busy: number }, []>("PRAGMA wal_checkpoint(TRUNCATE)").get();
+		return result?.busy === 0;
+	} finally {
+		db.run("PRAGMA busy_timeout = 3000");
+	}
+}
+
+const WAL_TRUNCATION_MARKER = "truncate-wal";
+
+function markPendingCacheWalCheckpoint(db: Database): void {
+	db.run("INSERT OR IGNORE INTO model_cache_cleanup (operation) VALUES (?)", [WAL_TRUNCATION_MARKER]);
+}
+
+function hasObsoleteCacheRows(db: Database): boolean {
+	return (
+		db
+			.query<{ present: number }, [number]>("SELECT 1 AS present FROM model_cache WHERE version <> ? LIMIT 1")
+			.get(CACHE_SCHEMA_VERSION) !== null
+	);
+}
+
+function checkpointPendingCacheWal(db: Database): void {
+	const marker = db.prepare("SELECT 1 FROM model_cache_cleanup WHERE operation = ? LIMIT 1");
+	try {
+		if (!marker.get(WAL_TRUNCATION_MARKER)) return;
+	} finally {
+		marker.finalize();
+	}
+	if (!checkpointCacheWal(db)) return;
+	const deleteObsolete = db.transaction(() => {
+		db.run("DELETE FROM model_cache WHERE version <> ?", [CACHE_SCHEMA_VERSION]);
+	});
+	deleteObsolete.immediate();
+	// Keep the marker through this checkpoint. A pre-v14 writer can resume as
+	// soon as deleteObsolete releases its lock; clearing the marker before the
+	// checkpoint would let that write become durable without a later cleanup.
+	if (!checkpointCacheWal(db)) return;
+	const clearMarker = db.transaction(() => {
+		if (hasObsoleteCacheRows(db)) return false;
+		db.run("DELETE FROM model_cache_cleanup WHERE operation = ?", [WAL_TRUNCATION_MARKER]);
+		return true;
+	});
+	// Do not checkpoint after clearing the marker: a legacy writer that races
+	// that final transaction must be rediscovered by the next cache operation.
+	clearMarker.immediate();
 }
 
 function migrateCacheSchema(db: Database): void {
@@ -198,12 +272,30 @@ function migrateCacheSchema(db: Database): void {
 	} finally {
 		stmt.finalize();
 	}
-	// Delete rows written under any older schema so they cannot be reused. The
-	// legacy `UPDATE ... WHERE version = 2` migration silently promoted the very
-	// first cache version to whatever the current one is, defeating every
-	// subsequent invalidation (see #4146: pre-V2 Codex rows kept the legacy
-	// compaction path even after CACHE_SCHEMA_VERSION was bumped).
-	db.run("DELETE FROM model_cache WHERE version <> ?", [CACHE_SCHEMA_VERSION]);
+	// Probe without taking SQLite's writer lock. A pre-v14 process can write a
+	// v13 row after the probe, so use data_version to detect that external commit
+	// and recheck under an immediate transaction only when it raced this call.
+	const dataVersionBeforeProbe = db.query<{ data_version: number }, []>("PRAGMA data_version").get()?.data_version;
+	let needsMigration = hasObsoleteCacheRows(db);
+	if (!needsMigration) {
+		const dataVersionAfterProbe = db.query<{ data_version: number }, []>("PRAGMA data_version").get()?.data_version;
+		if (dataVersionBeforeProbe !== dataVersionAfterProbe) {
+			const recheckMigration = db.transaction(() => hasObsoleteCacheRows(db));
+			needsMigration = recheckMigration.immediate();
+		}
+	}
+	if (!needsMigration) {
+		checkpointPendingCacheWal(db);
+		return;
+	}
+	const migrateVersions = db.transaction(() => {
+		db.run("UPDATE model_cache SET version = ? WHERE version = 12", [CACHE_SCHEMA_VERSION]);
+		if (!hasObsoleteCacheRows(db)) return;
+		markPendingCacheWalCheckpoint(db);
+		db.run("DELETE FROM model_cache WHERE version <> ?", [CACHE_SCHEMA_VERSION]);
+	});
+	migrateVersions.immediate();
+	checkpointPendingCacheWal(db);
 }
 
 export function readModelCache<TApi extends Api>(
@@ -239,7 +331,7 @@ export function readModelCache<TApi extends Api>(
 					headerOmittedModelIds,
 					unrestorableHeaderModelIds,
 					legacyHeaderRestoreMarkers: row.header_restore_version < HEADER_RESTORE_VERSION,
-					staticFingerprint: row.static_fingerprint ?? "",
+					staticFingerprint: row.static_fingerprint,
 				};
 			} finally {
 				stmt.finalize();

--- a/packages/catalog/src/model-manager.ts
+++ b/packages/catalog/src/model-manager.ts
@@ -44,13 +44,15 @@ export interface ModelManagerOptions<TApi extends Api = Api, TModelsDevPayload =
 	/** Cached model ids whose presence forces refresh when the static or migration-policy fingerprint changes. */
 	dropCachedModelIdsOnStaticMismatch?: readonly string[];
 	/**
-	 * Trusted, provider-wide request headers that can be safely re-derived at
+	 * Trusted provider-wide request headers that can be safely re-derived at
 	 * cache-read time. The cache never persists their values. Models whose live
 	 * headers matched this record at write time can survive offline reads without
 	 * a bundled static source, including configured discovery providers whose
 	 * bearer header comes from the current local config.
 	 */
 	restorableHeaderFallback?: Record<string, string>;
+	/** Whether this manager may persist or restore its catalog. Defaults to true. */
+	cacheEnabled?: boolean;
 	/** Optional dynamic endpoint fetcher. */
 	fetchDynamicModels?: () => Promise<readonly ModelSpec<TApi>[] | null>;
 	/** Optional stencil.so fallback hook. */
@@ -168,8 +170,12 @@ function restoreCachedModelHeaders<TApi extends Api>(
 			// headers matching the provider's trusted constant (e.g. a Copilot
 			// model with no bundled entry). Reattach the constant by value instead
 			// of dropping the model on this offline read.
-			if (!unrestorable && restorableHeaderFallback) {
-				return { ...model, headers: { ...restorableHeaderFallback } };
+			const fallbackHeaders =
+				!unrestorable && restorableHeaderFallback && Object.keys(restorableHeaderFallback).length > 0
+					? restorableHeaderFallback
+					: undefined;
+			if (fallbackHeaders) {
+				return { ...model, headers: { ...fallbackHeaders } };
 			}
 			unresolvedModelIds.add(model.id);
 			return model;
@@ -194,7 +200,6 @@ export async function resolveProviderModels<TApi extends Api = Api, TModelsDevPa
 	const now = options.now ?? Date.now;
 	const ttlMs = options.cacheTtlMs ?? DEFAULT_CACHE_TTL_MS;
 	const dbPath = options.cacheDbPath;
-	const restorableHeaderFallback = options.restorableHeaderFallback;
 	const staticModels = options.staticModels
 		? passModelList<TApi>(options.staticModels)
 		: (getBundledModels(options.providerId as GeneratedProvider) as Model<TApi>[]);
@@ -202,24 +207,28 @@ export async function resolveProviderModels<TApi extends Api = Api, TModelsDevPa
 		options.modelsDev?.additiveOnly && staticModels.length > 0
 			? new Set(staticModels.map(model => model.id))
 			: undefined;
-	const cache = readModelCache<TApi>(cacheProviderId, ttlMs, now, dbPath);
+	const cacheEnabled = options.cacheEnabled !== false;
+	const cache = cacheEnabled ? readModelCache<TApi>(cacheProviderId, ttlMs, now, dbPath) : null;
+	const dynamicModelsAuthoritative = options.dynamicModelsAuthoritative ?? false;
 	const restoredCache = restoreCachedModelHeaders(
 		cache?.models ?? [],
 		staticModels,
 		cache?.headerOmittedModelIds ?? [],
 		cache?.unrestorableHeaderModelIds ?? [],
 		cache?.legacyHeaderRestoreMarkers ?? false,
-		restorableHeaderFallback,
+		options.restorableHeaderFallback,
 	);
 	const usableCachedModels = restoredCache.models.filter(model => !restoredCache.unresolvedModelIds.has(model.id));
 	const cacheHasUnresolvedHeaders = restoredCache.unresolvedModelIds.size > 0;
-	const dynamicModelsAuthoritative = options.dynamicModelsAuthoritative ?? false;
 	const cacheDropIds = options.dropCachedModelIdsOnStaticMismatch;
-	const staticCatalogFingerprint = fingerprintStaticModels(staticModels, dynamicModelsAuthoritative);
-	// Endpoint-migration policy is cache identity: adding an id must invalidate
-	// matching-static-catalog caches written by the prior resolver.
-	const staticFingerprint =
-		cacheDropIds && cacheDropIds.length > 0
+	const staticCatalogFingerprint = cacheEnabled
+		? fingerprintStaticModels(staticModels, dynamicModelsAuthoritative)
+		: "";
+	// Endpoint-migration policy forms part of the cache key: adding an id must
+	// invalidate matching-static-catalog caches written by the prior resolver.
+	const staticFingerprint = !cacheEnabled
+		? ""
+		: cacheDropIds && cacheDropIds.length > 0
 			? `${staticCatalogFingerprint}:drop:${Bun.hash(cacheDropIds.join("\0")).toString(36)}`
 			: staticCatalogFingerprint;
 	const cacheFingerprintMatches = cache?.staticFingerprint === staticFingerprint && staticFingerprint.length > 0;
@@ -318,7 +327,7 @@ export async function resolveProviderModels<TApi extends Api = Api, TModelsDevPa
 	);
 	const resolutionAuthoritative = !hasRemoteFetcher || remoteResolutionComplete || shouldUseFreshCacheAsAuthoritative;
 	const remoteUpdatedAt = anyRemoteFetchSucceeded ? now() : undefined;
-	if (shouldFetchFromNetwork) {
+	if (shouldFetchFromNetwork && cacheEnabled) {
 		if (anyRemoteFetchSucceeded) {
 			writeModelCache(
 				cacheProviderId,
@@ -328,7 +337,7 @@ export async function resolveProviderModels<TApi extends Api = Api, TModelsDevPa
 				staticFingerprint,
 				dbPath,
 				staticModels,
-				restorableHeaderFallback,
+				options.restorableHeaderFallback,
 			);
 		} else {
 			// Remote fetch failed — update cache with a non-authoritative snapshot so
@@ -340,7 +349,7 @@ export async function resolveProviderModels<TApi extends Api = Api, TModelsDevPa
 				latestCache?.headerOmittedModelIds ?? cache?.headerOmittedModelIds ?? [],
 				latestCache?.unrestorableHeaderModelIds ?? cache?.unrestorableHeaderModelIds ?? [],
 				latestCache?.legacyHeaderRestoreMarkers ?? cache?.legacyHeaderRestoreMarkers ?? false,
-				restorableHeaderFallback,
+				options.restorableHeaderFallback,
 			);
 			const latestUsableCacheModels = latestRestoredCache.models.filter(
 				model => !latestRestoredCache.unresolvedModelIds.has(model.id),
@@ -365,7 +374,7 @@ export async function resolveProviderModels<TApi extends Api = Api, TModelsDevPa
 				staticFingerprint,
 				dbPath,
 				staticModels,
-				restorableHeaderFallback,
+				options.restorableHeaderFallback,
 			);
 		}
 	}

--- a/packages/catalog/test/build.test.ts
+++ b/packages/catalog/test/build.test.ts
@@ -1016,6 +1016,49 @@ describe("model cache spec round trip", () => {
 		}
 	});
 
+	it("preserves schema-v12 cache rows across the v14 identity invalidation", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-catalog-v12-cache-"));
+		const dbPath = path.join(tempDir, "models.db");
+		const model = buildModel(completionsSpec({ provider: "v12-cache-test" }));
+		try {
+			writeModelCache("v12-cache-test", Date.now(), [model], true, "", dbPath);
+			const db = new Database(dbPath);
+			db.run("UPDATE model_cache SET version = 12 WHERE provider_id = ?", ["v12-cache-test"]);
+			db.close();
+
+			expect(
+				readModelCache("v12-cache-test", Infinity, Date.now, dbPath)?.models.map(candidate => candidate.id),
+			).toEqual([model.id]);
+			const verified = new Database(dbPath, { readonly: true });
+			const row = verified
+				.query<{ version: number }, [string]>("SELECT version FROM model_cache WHERE provider_id = ?")
+				.get("v12-cache-test");
+			verified.close();
+			expect(row?.version).toBe(14);
+		} finally {
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+	});
+	it("invalidates schema-v13 credential-scoped cache rows", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-catalog-v13-cache-"));
+		const dbPath = path.join(tempDir, "models.db");
+		const model = buildModel(completionsSpec({ provider: "v13-cache-test" }));
+		try {
+			writeModelCache("v13-cache-test", Date.now(), [model], true, "", dbPath);
+			const db = new Database(dbPath);
+			db.run("UPDATE model_cache SET version = 13 WHERE provider_id = ?", ["v13-cache-test"]);
+			db.close();
+
+			expect(readModelCache("v13-cache-test", Infinity, Date.now, dbPath)).toBeNull();
+			const verified = new Database(dbPath, { readonly: true });
+			const row = verified.query<{ count: number }, []>("SELECT COUNT(*) AS count FROM model_cache").get();
+			verified.close();
+			expect(row?.count).toBe(0);
+		} finally {
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+	});
+
 	it("preserves computer-use provenance across cache restarts and endpoint reroutes", async () => {
 		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-catalog-computer-use-cache-"));
 		const dbPath = path.join(tempDir, "models.db");
@@ -1309,6 +1352,55 @@ describe("model cache spec round trip", () => {
 		}
 	});
 
+	it("restores live provider-wide bearer and headers at cache operation time", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-catalog-live-headers-"));
+		const dbPath = path.join(tempDir, "models.db");
+		const headers = { Authorization: "Bearer runtime-token", "X-Required-Route": "route-42" };
+		const dynamicModel = completionsSpec({
+			id: "live-header-model",
+			provider: "live-header-cache-test",
+			headers,
+		});
+		let headersAvailable = false;
+		const liveHeaders = new Proxy<Record<string, string>>(
+			{},
+			{
+				get: (_target, key) =>
+					typeof key === "string" && headersAvailable ? headers[key as keyof typeof headers] : undefined,
+				ownKeys: () => (headersAvailable ? Object.keys(headers) : []),
+				getOwnPropertyDescriptor: (_target, key) => {
+					if (typeof key !== "string" || !headersAvailable || !(key in headers)) return undefined;
+					return { configurable: true, enumerable: true, value: headers[key as keyof typeof headers] };
+				},
+			},
+		);
+		const options = {
+			providerId: "live-header-cache-test",
+			staticModels: [],
+			dynamicModelsAuthoritative: true,
+			cacheDbPath: dbPath,
+			restorableHeaderFallback: liveHeaders,
+			fetchDynamicModels: async () => {
+				headersAvailable = true;
+				return [dynamicModel];
+			},
+		};
+		try {
+			const online = await resolveProviderModels(options, "online");
+			expect(online.models[0]?.headers).toEqual(headers);
+
+			headersAvailable = false;
+			const unavailable = await resolveProviderModels(options, "offline");
+			expect(unavailable.models).toEqual([]);
+
+			headersAvailable = true;
+			const restored = await resolveProviderModels(options, "offline");
+			expect(restored.models[0]?.headers).toEqual(headers);
+		} finally {
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+	});
+
 	it("keeps a synthesized request-model variant across an offline restart", async () => {
 		// Regression for #6037/#6284: Copilot `-1m` long-context variants are
 		// synthesized dynamically with transport headers and a `requestModelId`
@@ -1420,6 +1512,41 @@ describe("model cache spec round trip", () => {
 			const restored = offline.models.find(candidate => candidate.id === "sol-1m");
 			expect(restored).toBeDefined();
 			expect(restored?.headers).toEqual(headers);
+		} finally {
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+	});
+	it("does not persist dynamic catalogs when caching is disabled", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-catalog-disabled-cache-"));
+		const dbPath = path.join(tempDir, "models.db");
+		const providerId = "disabled-cache-test";
+		const discovered = completionsSpec({ id: "discovered-model", provider: providerId });
+		let fetches = 0;
+		const options = {
+			providerId,
+			staticModels: [],
+			cacheDbPath: dbPath,
+			cacheEnabled: false,
+			dynamicModelsAuthoritative: true,
+			fetchDynamicModels: async () => {
+				fetches++;
+				return [discovered];
+			},
+		};
+		try {
+			const online = await resolveProviderModels<"openai-completions">(options, "online");
+			expect(online.models.map(model => model.id)).toEqual([discovered.id]);
+			expect(fetches).toBe(1);
+			await expect(fs.stat(dbPath)).rejects.toThrow();
+
+			const offline = await resolveProviderModels<"openai-completions">(options, "offline");
+			expect(offline.models).toEqual([]);
+			expect(offline.stale).toBe(true);
+			expect(fetches).toBe(1);
+
+			const refreshed = await resolveProviderModels<"openai-completions">(options, "online-if-uncached");
+			expect(refreshed.models.map(model => model.id)).toEqual([discovered.id]);
+			expect(fetches).toBe(2);
 		} finally {
 			await fs.rm(tempDir, { recursive: true, force: true });
 		}

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Disabled `hashline` edit mode for Kimi, Mimo, DeepSeek Flash, and Stepfun models for stability
 
 ### Fixed
+- Fixed extension-provided dynamic models remaining unavailable from `/switch` after login ([#5780](https://github.com/can1357/oh-my-pi/issues/5780)).
 
 - Fixed an issue where custom model overrides were lost during configuration updates
 - Fixed "Please use nerdfont" notification incorrectly persisting after theme configuration

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -174,6 +174,16 @@ interface CustomModelsResult {
  */
 type ModifyModelsHook = (models: Model<Api>[], credentials: OAuthCredentials) => Model<Api>[];
 
+/**
+ * Extension-owned dynamic catalog factory. `online` discovery opts into an
+ * OAuth-refreshing credential resolution; cache-aware/background discovery
+ * deliberately retains the non-refreshing peek path.
+ */
+interface RuntimeModelManager {
+	createOptions(refreshExpiredCredentials: boolean): ModelManagerOptions<Api>;
+	replacementDiscovery?: Promise<void>;
+}
+
 function getDisabledProviderIdsFromSettings(settingsInstance?: Settings): Set<string> {
 	try {
 		return new Set((settingsInstance ?? settings).get("disabledProviders"));
@@ -216,7 +226,13 @@ export class ModelRegistry {
 	#cachedDiscoverableModels: Model<Api>[] = [];
 	#cachedAuthoritativeProviders: Set<string> = new Set();
 	#runtimeDiscoveredModels: Model<Api>[] = [];
+	// Raw extension discovery responses. The composed runtime slice above is
+	// intentionally rebuilt from these after models.yml changes.
+	#runtimeExtensionDiscoveryModels: Model<Api>[] = [];
 	#runtimeAuthoritativeProviders: Set<string> = new Set();
+	// Providers whose current runtime catalog was discovered by an extension
+	// manager, rather than a configured or built-in discovery source.
+	#runtimeExtensionDiscoveredProviders: Set<string> = new Set();
 	#internedStaticModels: Map<string, Model<Api>> = new Map();
 	#providerLookupSnapshots: Map<string, Model<Api>[]> = new Map();
 	#customProviderApiKeys: Map<string, string> = new Map();
@@ -233,6 +249,10 @@ export class ModelRegistry {
 	#configError: ConfigError | undefined = undefined;
 	#modelsConfigFile: ConfigFile<ModelsConfig>;
 	#lastStaticLoadMtime: number | null = null;
+	// Unlike #lastStaticLoadMtime, this is not reset for an extension lifecycle
+	// rebuild, so it detects an actual models.yml revision.
+	#lastModelsConfigMtime: number | null = null;
+	#selectedModelMetadataPatches: Map<string, ModelPatch> = new Map();
 	#registeredProviderSources: Set<string> = new Set();
 	#providerDiscoveryStates: Map<string, ProviderDiscoveryState> = new Map();
 	#cacheDbPath?: string;
@@ -262,8 +282,11 @@ export class ModelRegistry {
 	#runtimeProvidersBySource: Map<string, Set<string>> = new Map();
 	#runtimeProviderSourceByName: Map<string, string> = new Map();
 	// Runtime model managers registered by extensions via fetchDynamicModels.
-	// Keyed by provider name; use the same SQLite cache path as builtins.
-	#runtimeModelManagers: Map<string, { options: ModelManagerOptions<Api>; sourceId: string }> = new Map();
+	// Keyed by provider name; their catalogs remain memory-only.
+	#runtimeModelManagers: Map<string, RuntimeModelManager> = new Map();
+	// Monotonically increasing generation per runtime provider. A later auth
+	// refresh must win over an earlier discovery using the same manager.
+	#runtimeDiscoveryGenerations: Map<string, number> = new Map();
 	#ignoreLocalModelConfig: boolean;
 	#fetch: FetchImpl;
 	#settings: Settings | undefined;
@@ -375,7 +398,20 @@ export class ModelRegistry {
 	async refresh(strategy: ModelRefreshStrategy = "online-if-uncached"): Promise<void> {
 		this.#reloadStaticModels();
 		this.#suppressedSelectors.clear();
-		await this.#refreshRuntimeDiscoveries(strategy);
+		const pendingReplacementProviderIds = new Set(
+			strategy === "offline"
+				? []
+				: [...this.#runtimeModelManagers].flatMap(([providerId, manager]) =>
+						manager.replacementDiscovery ? [providerId] : [],
+					),
+		);
+		const replacementDiscoveries = [...pendingReplacementProviderIds].map(
+			providerId => this.#runtimeModelManagers.get(providerId)?.replacementDiscovery,
+		);
+		await Promise.all([
+			...replacementDiscoveries,
+			this.#refreshRuntimeDiscoveries(strategy, undefined, pendingReplacementProviderIds),
+		]);
 	}
 
 	/**
@@ -409,9 +445,8 @@ export class ModelRegistry {
 	/**
 	 * Rebuild the catalog after a policy-affecting setting change (e.g.
 	 * `extendedContext`). Forces the static reload past the models.yml mtime
-	 * gate, then restores runtime-discovered models from the SQLite cache —
-	 * offline, a settings flip must never hit the network. Concurrent calls
-	 * coalesce onto one rebuild.
+	 * gate, then restores cache-backed catalog sources offline so a settings flip
+	 * never hits the network. Concurrent calls coalesce onto one rebuild.
 	 */
 	reapplyModelPolicies(): Promise<void> {
 		this.#policyReapply ??= this.#runPolicyReapply();
@@ -511,19 +546,9 @@ export class ModelRegistry {
 				this.#suppressedSelectors.delete(selector);
 			}
 		}
+		const replacementDiscovery = this.#runtimeModelManagers.get(providerId)?.replacementDiscovery;
+		if (replacementDiscovery) await replacementDiscovery;
 		await this.#refreshRuntimeDiscoveries(strategy, new Set([providerId]));
-		// #reloadStaticModels above may have rebuilt #models from static sources,
-		// dropping models previously discovered by OTHER runtime providers (their
-		// fetchDynamicModels results live only in #models + the SQLite cache, not
-		// in #loadModels' static inputs). Restore them from cache with the default
-		// online-if-uncached strategy: no network while their cached row is
-		// fresh, so the scoped refresh above stays the only forced fetch.
-		const otherRuntimeProviderIds = new Set(
-			[...this.#runtimeModelManagers.keys()].filter(runtimeId => runtimeId !== providerId),
-		);
-		if (otherRuntimeProviderIds.size > 0) {
-			await this.#refreshRuntimeDiscoveries("online-if-uncached", otherRuntimeProviderIds);
-		}
 	}
 
 	/**
@@ -636,10 +661,14 @@ export class ModelRegistry {
 		}
 		const unprojected = resolveProviderModelReference(current.provider, current.id, this.#unprojectedModels);
 		if (unprojected) {
+			const patchKey = `${current.provider}\u0000${current.id}`;
+			const accumulatedPatch = { ...this.#selectedModelMetadataPatches.get(patchKey), ...patch };
 			const patchedBase = applyModelPatch(unprojected, patch, "merge");
+			this.#selectedModelMetadataPatches.set(patchKey, accumulatedPatch);
 			this.#unprojectedModels = this.#unprojectedModels.map(candidate =>
 				candidate.provider === unprojected.provider && candidate.id === unprojected.id ? patchedBase : candidate,
 			);
+			this.#invalidateProviderModelCache(current.provider);
 			this.#models = this.#applyRuntimeModelModifiers(this.#unprojectedModels);
 			return resolveProviderModelReference(current.provider, current.id, this.#models) ?? patchedBase;
 		}
@@ -655,15 +684,32 @@ export class ModelRegistry {
 	 * (extension providers). Merges the discovered catalog into the existing model
 	 * set without reloading static models, so dynamically-discovered models from
 	 * other providers are preserved. No-op when no runtime providers are registered.
-	 *
-	 * Drives the same SQLite model cache as built-in providers, so the default
-	 * `online-if-uncached` strategy fetches at most once per cache TTL (24 h).
+	 * Runtime extension catalogs are intentionally refreshed online and never
+	 * persisted because their credentials and account scope are not cache-safe.
 	 */
-	async refreshRuntimeProviders(strategy: ModelRefreshStrategy = "online-if-uncached"): Promise<void> {
-		if (this.#runtimeModelManagers.size === 0) {
-			return;
-		}
-		await this.#refreshRuntimeDiscoveries(strategy, new Set(this.#runtimeModelManagers.keys()));
+	async refreshRuntimeProviders(
+		strategy: ModelRefreshStrategy = "online-if-uncached",
+		providerIds?: Iterable<string>,
+		excludedProviderIds?: ReadonlySet<string>,
+	): Promise<void> {
+		const runtimeProviderIds = providerIds
+			? new Set([...providerIds].filter(providerId => this.#runtimeModelManagers.has(providerId)))
+			: new Set([...this.#runtimeModelManagers.keys()].filter(providerId => !excludedProviderIds?.has(providerId)));
+		if (runtimeProviderIds.size === 0) return;
+		const replacementDiscoveries = [...runtimeProviderIds]
+			.map(providerId => this.#runtimeModelManagers.get(providerId)?.replacementDiscovery)
+			.filter((discovery): discovery is Promise<void> => discovery !== undefined);
+		const refreshableRuntimeProviderIds = new Set(
+			[...runtimeProviderIds].filter(
+				providerId => this.#runtimeModelManagers.get(providerId)?.replacementDiscovery === undefined,
+			),
+		);
+		await Promise.all([
+			...replacementDiscoveries,
+			...(refreshableRuntimeProviderIds.size > 0
+				? [this.#refreshRuntimeDiscoveries(strategy, refreshableRuntimeProviderIds)]
+				: []),
+		]);
 	}
 
 	#reloadStaticModels(): void {
@@ -671,6 +717,12 @@ export class ModelRegistry {
 		if (currentMtime !== null && currentMtime === this.#lastStaticLoadMtime) {
 			// Models config unchanged since last load; reloading would be redundant.
 			return;
+		}
+		if (currentMtime !== this.#lastModelsConfigMtime) {
+			// A changed discovery endpoint may reuse a provider/model ID while serving
+			// different limits or modalities. Its learned metadata cannot survive this
+			// configuration reload; it will be re-probed when the model is selected.
+			this.#selectedModelMetadataPatches.clear();
 		}
 		this.#modelsConfigFile.invalidate();
 		this.#customProviderApiKeys.clear();
@@ -689,7 +741,34 @@ export class ModelRegistry {
 		this.#modelOverrides.clear();
 		this.#configError = undefined;
 		this.#providerDiscoveryStates.clear();
+		const activeRuntimeProviderIds = new Set(this.#runtimeModelManagers.keys());
+		const preservedRuntimeProviderIds = new Set(
+			[...this.#runtimeExtensionDiscoveredProviders].filter(provider => activeRuntimeProviderIds.has(provider)),
+		);
+		const preservedRuntimeModels = this.#runtimeExtensionDiscoveryModels.filter(model =>
+			preservedRuntimeProviderIds.has(model.provider),
+		);
 		this.#loadModels();
+		const configuredDiscoveryProviders = new Set(this.#discoverableProviders.map(provider => provider.provider));
+		for (const provider of configuredDiscoveryProviders) {
+			preservedRuntimeProviderIds.delete(provider);
+			if (activeRuntimeProviderIds.has(provider)) {
+				this.#runtimeDiscoveryGenerations.set(provider, (this.#runtimeDiscoveryGenerations.get(provider) ?? 0) + 1);
+			}
+		}
+		const retainedRuntimeModels = preservedRuntimeModels.filter(model =>
+			preservedRuntimeProviderIds.has(model.provider),
+		);
+		this.#runtimeExtensionDiscoveryModels = retainedRuntimeModels;
+		const runtimeProviderFilter = new Set(retainedRuntimeModels.map(model => model.provider));
+		this.#runtimeDiscoveredModels = this.#composeDiscoveredModels(
+			retainedRuntimeModels,
+			this.#composeUnprojectedStaticModels(runtimeProviderFilter),
+		);
+		this.#runtimeAuthoritativeProviders = new Set(
+			[...activeRuntimeProviderIds].filter(provider => !configuredDiscoveryProviders.has(provider)),
+		);
+		this.#runtimeExtensionDiscoveredProviders = preservedRuntimeProviderIds;
 	}
 
 	/**
@@ -723,13 +802,16 @@ export class ModelRegistry {
 		this.#pendingStandardCacheProviders = new Set(
 			STARTUP_MODEL_CACHE_PROVIDER_IDS.filter(
 				providerId =>
-					!configuredDiscoveryProviders.has(providerId) && !isCredentialScopedModelCacheProvider(providerId),
+					!configuredDiscoveryProviders.has(providerId) &&
+					!this.#runtimeModelManagers.has(providerId) &&
+					!isCredentialScopedModelCacheProvider(providerId),
 			),
 		);
 		this.#cachedDiscoverableModels = logger.time("modelRegistry:loadDiscoverableModels", () =>
 			this.#applyHardcodedModelPolicies(this.#loadCachedDiscoverableModels()),
 		);
 		this.#lastStaticLoadMtime = this.#modelsConfigFile.getMtimeMs();
+		this.#lastModelsConfigMtime = this.#lastStaticLoadMtime;
 	}
 
 	#resetStaticComposition(): void {
@@ -740,6 +822,7 @@ export class ModelRegistry {
 		this.#pendingStandardCacheProviders.clear();
 		this.#cachedAuthoritativeProviders.clear();
 		this.#runtimeDiscoveredModels = [];
+		this.#runtimeExtensionDiscoveryModels = [];
 		this.#runtimeAuthoritativeProviders.clear();
 		this.#internedStaticModels.clear();
 		this.#providerLookupSnapshots.clear();
@@ -836,9 +919,11 @@ export class ModelRegistry {
 		resolvedDefaults = this.#mergeResolvedModels(resolvedDefaults, select(this.#runtimeDiscoveredModels));
 		const withConfigModels = this.#mergeCustomModels(resolvedDefaults, select(this.#customModelOverlays));
 		const combined = this.#mergeCustomModels(withConfigModels, select(this.#runtimeModelOverlays));
-		const withModelOverrides = this.#applyModelOverrides(collapseBuiltVariants(combined), this.#modelOverrides);
+		const withMetadata = this.#applySelectedModelMetadataPatches(combined);
+		const withModelOverrides = this.#applyModelOverrides(collapseBuiltVariants(withMetadata), this.#modelOverrides);
 		const withProviderGuardrails = this.#applyProviderGuardrailOverrides(withModelOverrides);
-		return this.#applyLlamaCppModelFixups(this.#applyRuntimeProviderOverrides(withProviderGuardrails));
+		const withRuntimeOverrides = this.#applyRuntimeProviderOverrides(withProviderGuardrails);
+		return this.#applyLlamaCppModelFixups(withRuntimeOverrides);
 	}
 
 	#composeStaticModels(providerFilter?: ReadonlySet<string>): Model<Api>[] {
@@ -878,6 +963,18 @@ export class ModelRegistry {
 				} as ModelSpec<Api>);
 			});
 		});
+	}
+
+	#composeDiscoveredModels(discovered: Model<Api>[], existingModels: Model<Api>[]): Model<Api>[] {
+		return this.#applyHardcodedModelPolicies(
+			discovered.map(model =>
+				mergeDiscoveredModel(
+					model,
+					resolveProviderModelReference(model.provider, model.id, existingModels),
+					this.#providerOverrides.get(model.provider),
+				),
+			),
+		);
 	}
 
 	#mergeResolvedModels(baseModels: Model<Api>[], replacementModels: Model<Api>[]): Model<Api>[] {
@@ -937,6 +1034,10 @@ export class ModelRegistry {
 		const modelsByProvider = new Map<string, Model<Api>[]>();
 		const authoritativeFreshProviders = new Set<string>();
 		for (const providerId of providerIds) {
+			// A runtime extension owns its dynamic transport and credentials. Leave
+			// a colliding legacy raw-ID row on disk for a future built-in restoration,
+			// but never merge it into the extension-owned catalog.
+			if (this.#runtimeModelManagers.has(providerId)) continue;
 			const cacheProviderId = this.#resolveStartupModelCacheProviderId(providerId);
 			const cache = readModelCache<Api>(cacheProviderId, 24 * 60 * 60 * 1000, Date.now, this.#cacheDbPath);
 			const sharedCatalogProvider = MODELS_DEV_CATALOG_PROVIDER_ID_LOOKUP[providerId] === true;
@@ -1056,6 +1157,7 @@ export class ModelRegistry {
 		const providerIds = STARTUP_MODEL_CACHE_PROVIDER_IDS.filter(
 			providerId =>
 				this.#pendingStandardCacheProviders.has(providerId) &&
+				!this.#runtimeModelManagers.has(providerId) &&
 				(providerFilter === undefined || providerFilter.has(providerId)),
 		);
 		if (providerIds.length > 0) {
@@ -1402,7 +1504,21 @@ export class ModelRegistry {
 	async #refreshRuntimeDiscoveries(
 		strategy: ModelRefreshStrategy,
 		providerFilter?: ReadonlySet<string>,
+		excludedRuntimeProviderIds?: ReadonlySet<string>,
 	): Promise<void> {
+		const runtimeDiscoveryGenerations = new Map<string, { manager: RuntimeModelManager; generation: number }>();
+		// Offline runtime managers have no cache and therefore cannot produce a
+		// replacement catalog. Do not let that no-op invalidate an online request
+		// which is still discovering the current extension account.
+		if (strategy !== "offline") {
+			for (const [providerId, manager] of this.#runtimeModelManagers) {
+				if (providerFilter && !providerFilter.has(providerId)) continue;
+				if (excludedRuntimeProviderIds?.has(providerId)) continue;
+				const generation = (this.#runtimeDiscoveryGenerations.get(providerId) ?? 0) + 1;
+				this.#runtimeDiscoveryGenerations.set(providerId, generation);
+				runtimeDiscoveryGenerations.set(providerId, { manager, generation });
+			}
+		}
 		const disabledProviders = getDisabledProviderIdsFromSettings(this.#settings);
 		const selectedDiscoverableProviders = (
 			providerFilter
@@ -1420,41 +1536,66 @@ export class ModelRegistry {
 					);
 		const [configuredDiscoveryResults, builtInDiscovery] = await Promise.all([
 			configuredDiscoveriesPromise,
-			this.#discoverBuiltInProviderModels(strategy, providerFilter),
+			this.#discoverBuiltInProviderModels(strategy, providerFilter, excludedRuntimeProviderIds),
 		]);
 		const currentDiscoverableProviders = new Set(this.#discoverableProviders);
 		const configuredDiscovered = configuredDiscoveryResults
 			.filter(result => currentDiscoverableProviders.has(result.provider))
 			.flatMap(result => result.models);
-		const discovered = [...configuredDiscovered, ...builtInDiscovery.models];
-		if (discovered.length === 0 && builtInDiscovery.authoritativeProviders.size === 0) {
-			return;
-		}
+		const isCurrentRuntimeDiscovery = (providerId: string): boolean => {
+			const snapshot = runtimeDiscoveryGenerations.get(providerId);
+			if (snapshot === undefined) return !this.#runtimeModelManagers.has(providerId);
+			return (
+				this.#runtimeModelManagers.get(providerId) === snapshot.manager &&
+				this.#runtimeDiscoveryGenerations.get(providerId) === snapshot.generation
+			);
+		};
+		const currentBuiltInModels = builtInDiscovery.models.filter(model => isCurrentRuntimeDiscovery(model.provider));
+		const currentBuiltInAuthoritativeProviders = new Set(
+			[...builtInDiscovery.authoritativeProviders].filter(isCurrentRuntimeDiscovery),
+		);
+		const configuredProviderIds = new Set(this.#discoverableProviders.map(provider => provider.provider));
+		const completedExtensionProviders = new Set(
+			[...runtimeDiscoveryGenerations.keys()].filter(
+				provider => !configuredProviderIds.has(provider) && isCurrentRuntimeDiscovery(provider),
+			),
+		);
+		const discovered = [...configuredDiscovered, ...currentBuiltInModels];
 		const touchedProviders = new Set(discovered.map(model => model.provider));
-		for (const provider of builtInDiscovery.authoritativeProviders) touchedProviders.add(provider);
+		for (const provider of currentBuiltInAuthoritativeProviders) touchedProviders.add(provider);
+		for (const provider of completedExtensionProviders) touchedProviders.add(provider);
+		if (touchedProviders.size === 0) return;
 		const existingModels = this.#hasFullSnapshot
 			? this.#unprojectedModels
 			: this.#composeUnprojectedStaticModels(touchedProviders);
-		const discoveredModels = this.#applyHardcodedModelPolicies(
-			discovered.map(model =>
-				mergeDiscoveredModel(
-					model,
-					resolveProviderModelReference(model.provider, model.id, existingModels),
-					this.#providerOverrides.get(model.provider),
-				),
-			),
-		);
+		const discoveredModels = this.#composeDiscoveredModels(discovered, existingModels);
 		const authoritativeProviders = providersWithAuthoritativeProjectCatalog(discoveredModels);
-		for (const provider of builtInDiscovery.authoritativeProviders) {
+		for (const provider of currentBuiltInAuthoritativeProviders) {
 			authoritativeProviders.add(provider);
 		}
+		const failedExtensionProviders = new Set(
+			[...completedExtensionProviders].filter(provider => !authoritativeProviders.has(provider)),
+		);
 
 		this.#runtimeDiscoveredModels = this.#runtimeDiscoveredModels.filter(
 			model => !touchedProviders.has(model.provider),
 		);
 		this.#runtimeDiscoveredModels.push(...discoveredModels);
+		this.#runtimeExtensionDiscoveryModels = this.#runtimeExtensionDiscoveryModels.filter(
+			model => !completedExtensionProviders.has(model.provider),
+		);
+		this.#runtimeExtensionDiscoveryModels.push(
+			...currentBuiltInModels.filter(model => completedExtensionProviders.has(model.provider)),
+		);
 		for (const provider of touchedProviders) {
-			if (authoritativeProviders.has(provider)) {
+			if (completedExtensionProviders.has(provider)) {
+				this.#runtimeExtensionDiscoveredProviders.add(provider);
+			} else {
+				this.#runtimeExtensionDiscoveredProviders.delete(provider);
+			}
+			if (authoritativeProviders.has(provider) || failedExtensionProviders.has(provider)) {
+				// A failed extension refresh still owns this provider ID. Keep bundled
+				// models hidden rather than routing them through extension credentials.
 				this.#runtimeAuthoritativeProviders.add(provider);
 			} else {
 				this.#runtimeAuthoritativeProviders.delete(provider);
@@ -1462,6 +1603,11 @@ export class ModelRegistry {
 			this.#invalidateProviderModelCache(provider);
 		}
 		if (!this.#hasFullSnapshot) return;
+		if (failedExtensionProviders.size > 0) {
+			this.#unprojectedModels = this.#composeUnprojectedStaticModels();
+			this.#models = this.#applyRuntimeModelModifiers(this.#unprojectedModels);
+			return;
+		}
 
 		const baseModels =
 			authoritativeProviders.size > 0
@@ -1470,7 +1616,8 @@ export class ModelRegistry {
 		const resolved = this.#mergeResolvedModels(baseModels, discoveredModels);
 		const withConfigModels = this.#mergeCustomModels(resolved, this.#customModelOverlays);
 		const combined = this.#mergeCustomModels(withConfigModels, this.#runtimeModelOverlays);
-		const withModelOverrides = this.#applyModelOverrides(collapseBuiltVariants(combined), this.#modelOverrides);
+		const withMetadata = this.#applySelectedModelMetadataPatches(combined);
+		const withModelOverrides = this.#applyModelOverrides(collapseBuiltVariants(withMetadata), this.#modelOverrides);
 		const withProviderGuardrails = this.#applyProviderGuardrailOverrides(withModelOverrides);
 		this.#unprojectedModels = this.#applyLlamaCppModelFixups(
 			this.#applyRuntimeProviderOverrides(withProviderGuardrails),
@@ -1656,6 +1803,7 @@ export class ModelRegistry {
 	async #discoverBuiltInProviderModels(
 		strategy: ModelRefreshStrategy,
 		providerFilter?: ReadonlySet<string>,
+		excludedRuntimeProviderIds?: ReadonlySet<string>,
 	): Promise<BuiltInDiscoveryResult> {
 		// Skip providers already handled by configured discovery (e.g. user-configured ollama with discovery.type)
 		const configuredDiscoveryProviders = new Set(this.#discoverableProviders.map(p => p.provider));
@@ -1663,16 +1811,21 @@ export class ModelRegistry {
 			strategy,
 			providerFilter,
 			configuredDiscoveryProviders,
+			excludedRuntimeProviderIds,
 		);
 		if (managerOptions.length === 0) {
 			return { models: [], authoritativeProviders: new Set() };
 		}
 		const discoveries = await Promise.all(
-			managerOptions.map(options => this.#discoverWithModelManager(options, strategy)),
+			managerOptions.map(async options => ({
+				providerId: options.providerId,
+				options,
+				discovery: await this.#discoverWithModelManager(options, strategy),
+			})),
 		);
 		const authoritativeProviders = new Set<string>();
 		const models: Model<Api>[] = [];
-		for (const discovery of discoveries) {
+		for (const { discovery } of discoveries) {
 			models.push(...discovery.models);
 			for (const provider of discovery.authoritativeProviders) {
 				authoritativeProviders.add(provider);
@@ -1744,6 +1897,7 @@ export class ModelRegistry {
 		strategy: ModelRefreshStrategy,
 		providerFilter: ReadonlySet<string> | undefined,
 		configuredDiscoveryProviders: ReadonlySet<string>,
+		excludedRuntimeProviderIds?: ReadonlySet<string>,
 	): Promise<ModelManagerOptions<Api>[]> {
 		const specialProviderDescriptors: Array<{
 			providerId: string;
@@ -1795,6 +1949,7 @@ export class ModelRegistry {
 		const enabledSpecialProviderDescriptors = specialProviderDescriptors.filter(descriptor => {
 			if (disabledProviders.has(descriptor.providerId)) return false;
 			if (configuredDiscoveryProviders.has(descriptor.providerId)) return false;
+			if (this.#runtimeModelManagers.has(descriptor.providerId)) return false;
 			return providerFilter ? providerFilter.has(descriptor.providerId) : true;
 		});
 		const standardProviderKeys = await Promise.all(
@@ -1882,9 +2037,14 @@ export class ModelRegistry {
 		}
 
 		// Append runtime model managers registered by extensions via fetchDynamicModels.
-		for (const { options: managerOpts } of this.#runtimeModelManagers.values()) {
+		// Runtime catalogs are never cache-enabled, so every non-offline strategy
+		// performs a live fetch and must resolve refreshed OAuth credentials.
+		const refreshRuntimeCredentials = strategy !== "offline";
+		for (const manager of this.#runtimeModelManagers.values()) {
+			const managerOpts = manager.createOptions(refreshRuntimeCredentials);
 			if (
 				!configuredDiscoveryProviders.has(managerOpts.providerId) &&
+				!excludedRuntimeProviderIds?.has(managerOpts.providerId) &&
 				(!providerFilter || providerFilter.has(managerOpts.providerId))
 			) {
 				options.push(managerOpts);
@@ -2043,6 +2203,14 @@ export class ModelRegistry {
 		});
 	}
 
+	#applySelectedModelMetadataPatches(models: Model<Api>[]): Model<Api>[] {
+		if (this.#selectedModelMetadataPatches.size === 0) return models;
+		return models.map(model => {
+			const patch = this.#selectedModelMetadataPatches.get(`${model.provider}\u0000${model.id}`);
+			return patch ? applyModelPatch(model, patch, "merge") : model;
+		});
+	}
+
 	#applyRuntimeProviderOverrides(models: Model<Api>[]): Model<Api>[] {
 		if (this.#runtimeProviderOverrides.size === 0) return models;
 		return models.map(model => {
@@ -2168,6 +2336,11 @@ export class ModelRegistry {
 	 */
 	getAll(): Model<Api>[] {
 		return this.#ensureFullSnapshot();
+	}
+
+	/** Whether a runtime extension discovery supplied this exact model. */
+	hasRuntimeDiscoveredModel(provider: string, id: string): boolean {
+		return this.#runtimeExtensionDiscoveryModels.some(model => model.provider === provider && model.id === id);
 	}
 
 	/**
@@ -2436,13 +2609,57 @@ export class ModelRegistry {
 		return this.authStorage.peekApiKey(provider);
 	}
 
+	async #resolveRuntimeDiscoveryApiKey(
+		provider: string,
+		refreshExpiredCredentials: boolean,
+	): Promise<string | undefined> {
+		const peekedKey = await this.#peekApiKeyForProvider(provider);
+		if (!refreshExpiredCredentials || !this.authStorage.hasOAuth(provider)) return peekedKey;
+		try {
+			return await this.getApiKeyForProvider(provider);
+		} catch (error) {
+			logger.debug("OAuth refresh failed during runtime model discovery", {
+				provider,
+				error: error instanceof Error ? error.message : String(error),
+			});
+			return peekedKey;
+		}
+	}
+
 	/**
 	 * Check if a model is using OAuth credentials (subscription).
 	 */
 	isUsingOAuth(model: Model<Api>): boolean {
 		return this.authStorage.hasOAuth(model.provider);
 	}
+	/**
+	 * An extension manager owns this provider for its lifetime. Remove a catalog
+	 * that was already materialized, but retain the pending disk row so a later
+	 * unregister can restore its built-in catalog without rewriting the cache.
+	 */
+	#suppressRuntimeOwnedStandardCache(providerName: string): void {
+		this.#cachedStandardModelsByProvider.delete(providerName);
+		this.#cachedAuthoritativeProviders.delete(providerName);
+		this.#invalidateProviderModelCache(providerName);
+		if (this.#hasFullSnapshot) {
+			this.#unprojectedModels = this.#composeUnprojectedStaticModels();
+			this.#models = this.#applyRuntimeModelModifiers(this.#unprojectedModels);
+		}
+	}
 
+	#clearRuntimeDiscoveredModels(providerName: string): void {
+		this.#runtimeDiscoveredModels = this.#runtimeDiscoveredModels.filter(model => model.provider !== providerName);
+		this.#runtimeExtensionDiscoveryModels = this.#runtimeExtensionDiscoveryModels.filter(
+			model => model.provider !== providerName,
+		);
+		this.#runtimeAuthoritativeProviders.delete(providerName);
+		this.#runtimeExtensionDiscoveredProviders.delete(providerName);
+		this.#invalidateProviderModelCache(providerName);
+		if (this.#hasFullSnapshot) {
+			this.#unprojectedModels = this.#composeUnprojectedStaticModels();
+			this.#models = this.#applyRuntimeModelModifiers(this.#unprojectedModels);
+		}
+	}
 	#clearRuntimeProviderState(providerName: string): void {
 		this.#runtimeProviderApiKeys.delete(providerName);
 		this.#runtimeProviderOverrides.delete(providerName);
@@ -2450,6 +2667,10 @@ export class ModelRegistry {
 		this.#runtimeModelManagers.delete(providerName);
 		this.#runtimeModelModifiers.delete(providerName);
 		this.#lastModelModifierWarnings.delete(providerName);
+		for (const key of this.#selectedModelMetadataPatches.keys()) {
+			if (key.startsWith(`${providerName}\u0000`)) this.#selectedModelMetadataPatches.delete(key);
+		}
+		this.#clearRuntimeDiscoveredModels(providerName);
 		this.authStorage.removeConfigApiKey(providerName);
 		this.authStorage.removeRuntimeUsageProvider(providerName);
 	}
@@ -2574,6 +2795,14 @@ export class ModelRegistry {
 			this.#lastStaticLoadMtime = null;
 			this.#reloadStaticModels();
 		}
+		// A same-source registration replaces every prior runtime registration,
+		// including a dynamic manager omitted by the replacement config. A new
+		// dynamic manager retains its slice until its scheduled replacement fetch
+		// settles; otherwise a re-register briefly exposes bundled collisions.
+		const replacingRuntimeManager = this.#runtimeModelManagers.delete(providerName);
+		if (replacingRuntimeManager && !config.fetchDynamicModels) {
+			this.#clearRuntimeDiscoveredModels(providerName);
+		}
 
 		// Extension usage providers override built-ins/configured resolvers for the
 		// provider lifetime. #clearRuntimeProviderState removes this override when
@@ -2636,28 +2865,21 @@ export class ModelRegistry {
 				if (!config.fetchDynamicModels) return;
 			}
 
-			// Update the unprojected snapshot, then rerun every whole-catalog
-			// projection exactly once. Incremental projection is not safe because one
-			// provider's hook may inspect or suppress another provider's models.
-			const nextModels = this.#unprojectedModels.filter(model => model.provider !== providerName);
-			for (const overlay of newOverlays) {
-				nextModels.push(finalizeCustomModel(overlay, { useDefaults: true }));
+			// Recompose instead of replacing this provider's visible snapshot in
+			// place: it has independently owned dynamic entries that must remain
+			// available until the replacement manager publishes its next catalog.
+			if (this.#hasFullSnapshot) {
+				this.#unprojectedModels = this.#composeUnprojectedStaticModels();
+				this.#models = this.#applyRuntimeModelModifiers(this.#unprojectedModels);
 			}
-			const runtimeTransportOverride = this.#runtimeProviderOverrides.get(providerName);
-			const nextModelsWithTransport = runtimeTransportOverride
-				? nextModels.map(model => {
-						if (model.provider !== providerName) return model;
-						return this.#applyProviderTransportOverrideToModel(model, runtimeTransportOverride);
-					})
-				: nextModels;
-			this.#unprojectedModels = this.#applyProviderGuardrailOverrides(nextModelsWithTransport);
-
-			this.#models = this.#applyRuntimeModelModifiers(this.#unprojectedModels);
 			this.#invalidateProviderModelCache(providerName);
 			if (!config.fetchDynamicModels) return;
 		}
 
 		if (config.fetchDynamicModels) {
+			const hasConfiguredDiscovery = this.#discoverableProviders.some(
+				provider => provider.provider === providerName,
+			);
 			const fetcher = config.fetchDynamicModels;
 			const providerBaseUrl = config.baseUrl ?? "";
 			const providerApi = config.api;
@@ -2665,14 +2887,20 @@ export class ModelRegistry {
 			const providerApiKey = config.apiKey;
 			const providerAuthHeader = config.authHeader;
 			const providerCompat = config.compat;
-			const managerOptions: ModelManagerOptions<Api> = {
+			// Runtime catalogs are credential- and account-specific. Keep their
+			// current-process state only; a raw provider ID can also name a built-in
+			// cache row, so it is unsafe to delete it here. A replacement keeps its
+			// current catalog visible until the replacement manager settles.
+			if (!replacingRuntimeManager && !hasConfiguredDiscovery) this.#clearRuntimeDiscoveredModels(providerName);
+			const createOptions = (refreshExpiredCredentials: boolean): ModelManagerOptions<Api> => ({
 				providerId: providerName as Parameters<typeof createModelManager>[0]["providerId"],
 				staticModels: [],
 				cacheDbPath: this.#cacheDbPath,
 				cacheTtlMs: 24 * 60 * 60 * 1000,
+				cacheEnabled: false,
 				dynamicModelsAuthoritative: true,
 				fetchDynamicModels: async () => {
-					const apiKey = await this.#peekApiKeyForProvider(providerName);
+					const apiKey = await this.#resolveRuntimeDiscoveryApiKey(providerName, refreshExpiredCredentials);
 					const resolvedKey = isAuthenticated(apiKey) ? apiKey : undefined;
 					const modelDefs = await withModelDiscoveryTimeout(RUNTIME_DYNAMIC_MODEL_FETCH_TIMEOUT_MS, () =>
 						fetcher(resolvedKey),
@@ -2695,12 +2923,36 @@ export class ModelRegistry {
 					}
 					return results.map(toModelSpec);
 				},
-			};
-			this.#runtimeModelManagers.set(providerName, { options: managerOptions, sourceId: sourceId ?? "" });
-			// Discovery is driven by refreshRuntimeProviders() after the drain — not
-			// here, so registration has no network side effect and callers can await.
+			});
+			const runtimeManager: RuntimeModelManager = { createOptions };
+			this.#runtimeModelManagers.set(providerName, runtimeManager);
+			if (!hasConfiguredDiscovery) {
+				// A dynamic extension owns its provider ID immediately. Until its first
+				// catalog settles, the safe catalog is authoritative-empty—not bundled
+				// models with the extension's transport and credentials.
+				this.#runtimeAuthoritativeProviders.add(providerName);
+				this.#suppressRuntimeOwnedStandardCache(providerName);
+			}
+			if (replacingRuntimeManager) {
+				const replacementDiscovery = Promise.resolve()
+					.then(() => {
+						if (this.#runtimeModelManagers.get(providerName) !== runtimeManager) return;
+						return this.#refreshRuntimeDiscoveries("online", new Set([providerName]));
+					})
+					.catch(error => {
+						logger.warn("replacement runtime provider discovery failed", {
+							provider: providerName,
+							error: error instanceof Error ? error.message : String(error),
+						});
+					})
+					.finally(() => {
+						if (this.#runtimeModelManagers.get(providerName) === runtimeManager) {
+							runtimeManager.replacementDiscovery = undefined;
+						}
+					});
+				runtimeManager.replacementDiscovery = replacementDiscovery;
+			}
 		}
-
 		if (
 			config.baseUrl ||
 			config.headers ||

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -2182,28 +2182,32 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			}
 			extensionsResult.runtime.pendingProviderRegistrations = [];
 		}
-		// Hydrate cached runtime (extension) provider catalogs before model
-		// resolution. Dynamic-only providers have no synchronous registration side
-		// effect, so a cold --model/provider resume must see the same fresh SQLite
-		// cache that `omp models find` uses before the online refresh continues in
-		// the background.
+		// Runtime extension catalogs intentionally have no disk cache. This offline
+		// pass leaves any current-process models intact; cold resumes await targeted
+		// online discovery below when a saved model needs one.
 		await modelRegistry.refreshRuntimeProviders("offline");
 		// Online runtime discovery must not steal the event loop from the first UI
 		// frame. Explicit deferred model selectors still start it immediately
 		// because they await it below; normal UI startup receives a one-shot
 		// starter in CreateAgentSessionResult and calls it after mode.init paints.
 		let runtimeDiscoveryPromise: Promise<void> | undefined;
-		const startRuntimeDiscovery = (): Promise<void> => {
-			runtimeDiscoveryPromise ??= modelRegistry.refreshRuntimeProviders().catch(error => {
+		let targetedUiRuntimeProviderIds: Set<string> | undefined;
+		const runRuntimeDiscovery = (
+			providerIds?: Iterable<string>,
+			strategy: "online" | "online-if-uncached" = "online-if-uncached",
+			excludedProviderIds?: ReadonlySet<string>,
+		): Promise<void> =>
+			modelRegistry.refreshRuntimeProviders(strategy, providerIds, excludedProviderIds).catch(error => {
 				logger.warn("runtime provider discovery failed", {
 					error: error instanceof Error ? error.message : String(error),
 				});
 			});
+		const startRuntimeDiscovery = (
+			strategy: "online" | "online-if-uncached" = "online-if-uncached",
+		): Promise<void> => {
+			runtimeDiscoveryPromise ??= runRuntimeDiscovery(undefined, strategy, targetedUiRuntimeProviderIds);
 			return runtimeDiscoveryPromise;
 		};
-		if (!options.hasUI || deferredModelPatterns.length > 0) {
-			void startRuntimeDiscovery();
-		}
 
 		// Retry session-model candidates now that extension providers are
 		// registered. The initial restore runs before extensions load, so a role
@@ -2213,6 +2217,32 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 		// downstream fallback filling `model`). Reclaim it here so resume
 		// honors the last active role in either case.
 		const sessionRetryLimit = restoredSessionModelIndex >= 0 ? restoredSessionModelIndex : sessionModelStrings.length;
+		const sessionCandidateProviders = new Set<string>();
+		const sessionCandidateModelIds = new Map<string, Set<string>>();
+		for (const sessionModelStr of sessionModelStrings.slice(0, sessionRetryLimit)) {
+			const parsedModel = parseModelString(sessionModelStr, {
+				allowMaxSuffix: true,
+				allowAutoAlias: true,
+				isLiteralModelId: (provider, id) => modelRegistry.find(provider, id) !== undefined,
+			});
+			if (!parsedModel) continue;
+			sessionCandidateProviders.add(parsedModel.provider);
+			let ids = sessionCandidateModelIds.get(parsedModel.provider);
+			if (!ids) {
+				ids = new Set();
+				sessionCandidateModelIds.set(parsedModel.provider, ids);
+			}
+			ids.add(parsedModel.id);
+		}
+		if (!options.hasUI || deferredModelPatterns.length > 0) {
+			// Explicit selectors and saved non-UI sessions are user-blocking. They
+			// must discover with refreshed OAuth rather than a fallback-key peek.
+			const strategy =
+				deferredModelPatterns.length > 0 || (!hasExplicitModel && sessionCandidateProviders.size > 0)
+					? "online"
+					: "online-if-uncached";
+			void startRuntimeDiscovery(strategy);
+		}
 		if (!hasExplicitModel && sessionRetryLimit > 0) {
 			const restoreSessionModel = (): boolean => {
 				for (let i = 0; i < sessionRetryLimit; i++) {
@@ -2246,36 +2276,57 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 				}
 				return false;
 			};
-			if (!restoreSessionModel()) {
-				// The saved candidates weren't in the static+cached catalog. If any
-				// belongs to a discovery-backed provider that hasn't been fetched
-				// yet (models.yml `discovery:` — openai-models-list/litellm/proxy/…),
-				// trigger a cache-aware, provider-scoped discovery pass and retry
-				// before resume silently downgrades to the default role. The
-				// registry coalesces this with any matching request already running
-				// in the SDK's startup background refresh.
-				const discoverableProviders = new Set(modelRegistry.getDiscoverableProviders());
-				const candidateProviders = new Set<string>();
-				if (discoverableProviders.size > 0) {
-					for (const sessionModelStr of sessionModelStrings.slice(0, sessionRetryLimit)) {
-						const parsedModel = parseModelString(sessionModelStr, {
-							allowMaxSuffix: true,
-							allowAutoAlias: true,
-							isLiteralModelId: (provider, id) => modelRegistry.find(provider, id) !== undefined,
-						});
-						if (parsedModel && discoverableProviders.has(parsedModel.provider)) {
-							candidateProviders.add(parsedModel.provider);
-						}
-					}
+			let restoredSessionModel = restoreSessionModel();
+			if (!restoredSessionModel && runtimeDiscoveryPromise) {
+				await runtimeDiscoveryPromise;
+				restoredSessionModel = restoreSessionModel();
+			}
+			if (!restoredSessionModel && !runtimeDiscoveryPromise) {
+				// Extension runtime catalogs intentionally have no cache. In a UI session,
+				// discover only saved-model providers so unrelated extensions cannot block
+				// the first frame; non-UI startup has already completed an all-provider pass.
+				const targetedRuntimeDiscovery = logger.time(
+					"restoreSessionRuntimeDiscoveryFallback",
+					// A saved model is a user-blocking cold-resume dependency: `online`
+					// deliberately refreshes an expired OAuth credential for its runtime manager.
+					() => runRuntimeDiscovery(sessionCandidateProviders, "online"),
+				);
+				// A UI session has no startup request yet. Exclude each targeted provider
+				// only when it has a usable catalog after this pass; failed providers
+				// remain eligible for post-paint discovery.
+				const targetedUiDiscovery = !runtimeDiscoveryPromise;
+				await targetedRuntimeDiscovery;
+				restoredSessionModel = restoreSessionModel();
+				if (targetedUiDiscovery) {
+					targetedUiRuntimeProviderIds = new Set(
+						[...sessionCandidateModelIds].flatMap(([provider, ids]) =>
+							[...ids].some(id => {
+								const candidate = modelRegistry.find(provider, id);
+								return (
+									candidate &&
+									hasModelAuth(candidate) &&
+									modelRegistry.hasRuntimeDiscoveredModel(provider, candidate.id)
+								);
+							})
+								? [provider]
+								: [],
+						),
+					);
 				}
+			}
+			if (!restoredSessionModel) {
+				// The saved candidates weren't in the static or extension catalog. If any
+				// belongs to a discovery-backed models.yml provider, trigger a cache-aware
+				// provider-scoped pass before silently using the default.
+				const discoverableProviders = new Set(modelRegistry.getDiscoverableProviders());
+				const candidateProviders = new Set(
+					[...sessionCandidateProviders].filter(provider => discoverableProviders.has(provider)),
+				);
 				if (candidateProviders.size > 0) {
-					// This skips the static reload and all-other-runtime restore
-					// performed by `refreshProvider`, so unrelated runtime providers
-					// continue independently.
 					await logger.time("restoreSessionModelDiscoveryFallback", () =>
 						modelRegistry.refreshDiscoverableProviders(candidateProviders, "online-if-uncached"),
 					);
-					restoreSessionModel();
+					restoredSessionModel = restoreSessionModel();
 				}
 			}
 		}
@@ -2283,19 +2334,13 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 		// registered. Use the same CLI resolver as the immediate path so bare role
 		// names, exact model names, and provider selectors keep one precedence rule.
 		if (!model && deferredModelPatterns.length > 0) {
-			// Deferred `--model` patterns almost always failed at the immediate
-			// path (main.ts:881) precisely because discovery-backed providers
-			// hadn't populated yet. Await the in-flight runtime discovery
-			// already kicked off above (stash + reuse avoids a second concurrent
-			// `#refreshRuntimeDiscoveries` pass for the same runtime model
-			// managers; it resolves instantly when no runtime managers are
-			// registered). `refreshRuntimeProviders()` only covers runtime model
-			// managers, not config-discovery providers (e.g. user-configured
-			// ollama); fall back to a full cache-aware refresh only when the
-			// runtime pass didn't surface a match AND config-discovery providers
-			// exist to fetch from. By then runtime managers short-circuit on the
-			// fresh cache written by the awaited pass, closing the double-fetch
-			// window.
+			// Deferred patterns often fail immediate resolution because their
+			// discovery-backed provider is not populated yet. First await the
+			// in-flight runtime discovery kicked off above. That pass covers only
+			// runtime managers, not configured discovery providers (for example,
+			// a user-configured ollama endpoint). If it finds no match, refresh only
+			// configured providers; re-running cache-disabled runtime managers could
+			// discard a successful catalog after a transient failure.
 			await logger.time("resolveModelDiscoveryDeferredRetry", startRuntimeDiscovery);
 			const matchPreferences = getModelMatchPreferences(settings);
 			const runtimeResolved = deferredModelPatterns.some(pattern =>
@@ -2317,9 +2362,10 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 					return Boolean(resolved.model);
 				}),
 			);
-			if (!runtimeResolved && modelRegistry.getDiscoverableProviders().length > 0) {
+			const discoverableProviderIds = new Set(modelRegistry.getDiscoverableProviders());
+			if (!runtimeResolved && discoverableProviderIds.size > 0) {
 				await logger.time("resolveModelDiscoveryFallbackNonRuntime", () =>
-					modelRegistry.refresh("online-if-uncached"),
+					modelRegistry.refreshDiscoverableProviders(discoverableProviderIds, "online-if-uncached"),
 				);
 			}
 			const allModels = modelRegistry.getAll();
@@ -2591,8 +2637,8 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			// user's configured default with a bundled provider's default whenever
 			// a stray `OPENAI_API_KEY`/`ANTHROPIC_API_KEY` is in the environment.
 			// (issues #3569, #6162)
-			const tryResolveDefaultRole = async (): Promise<boolean> => {
-				if (hasExplicitModel) return false;
+			const tryResolveDefaultRole = async (): Promise<Model | undefined> => {
+				if (hasExplicitModel) return undefined;
 				// Re-resolve the allowed set: extension factories and discovery
 				// refreshes above may have registered models not visible earlier.
 				const fallbackCandidates = await resolveAllowedModels(modelRegistry, settings, modelMatchPreferences);
@@ -2600,7 +2646,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 					settings,
 					matchPreferences: modelMatchPreferences,
 				});
-				if (!reResolvedRoleSpec.model) return false;
+				if (!reResolvedRoleSpec.model) return undefined;
 				defaultRoleSpec = reResolvedRoleSpec;
 				const resolvedDefaultModel = reResolvedRoleSpec.model;
 				model = resolvedDefaultModel;
@@ -2617,10 +2663,24 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 						: resolveThinkingLevelForModel(resolvedDefaultModel, effectiveThinkingLevel),
 				);
 				preconnectModelHost(resolvedDefaultModel.baseUrl);
-				return true;
+				return resolvedDefaultModel;
 			};
 
 			await tryResolveDefaultRole();
+
+			// Runtime extension catalogs are memory-only, so a fresh UI session's
+			// configured default can be absent until discovery runs. It is a startup
+			// dependency, unlike unrelated runtime providers which stay post-paint.
+			if (!model && options.hasUI && explicitDefaultProviders?.size) {
+				await logger.time("resolveDefaultRoleRuntimeDiscovery", () =>
+					runRuntimeDiscovery(explicitDefaultProviders, "online-if-uncached"),
+				);
+				const resolvedDefaultModel = await tryResolveDefaultRole();
+				if (resolvedDefaultModel) {
+					targetedUiRuntimeProviderIds ??= new Set();
+					targetedUiRuntimeProviderIds.add(resolvedDefaultModel.provider);
+				}
+			}
 
 			if (!model) {
 				const fallbackCandidates = await resolveAllowedModels(modelRegistry, settings, modelMatchPreferences);

--- a/packages/coding-agent/test/issue-5780-repro.test.ts
+++ b/packages/coding-agent/test/issue-5780-repro.test.ts
@@ -1,12 +1,15 @@
+import { Database } from "bun:sqlite";
 import { afterEach, beforeEach, describe, expect, test, vi } from "bun:test";
-import * as fs from "node:fs";
+import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { clearCustomApis, type FetchImpl } from "@oh-my-pi/pi-ai";
 import { unregisterOAuthProviders } from "@oh-my-pi/pi-ai/oauth";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import { readModelCache, writeModelCache } from "@oh-my-pi/pi-catalog/model-cache";
 import { ModelRegistry, type ProviderConfigInput } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
-import { removeSyncWithRetries, Snowflake } from "@oh-my-pi/pi-utils";
+import { Snowflake } from "@oh-my-pi/pi-utils";
 
 describe("issue #5780 post-auth runtime provider refresh", () => {
 	let tempDir: string;
@@ -17,24 +20,26 @@ describe("issue #5780 post-auth runtime provider refresh", () => {
 
 	const sourceId = "ext://issue-5780";
 	const providerName = "issue-5780-provider";
+	const FAKE_HEADER = "issue-5780-fake-header-secret";
 	const FAKE_KEY = "issue-5780-fake-credential-abc123";
+	type RuntimeModelDefinition = NonNullable<ProviderConfigInput["models"]>[number];
 	const offlineFetch: FetchImpl = () => Promise.reject(new Error("network disabled"));
 
 	beforeEach(async () => {
 		tempDir = path.join(os.tmpdir(), `pi-test-issue-5780-${Snowflake.next()}`);
-		fs.mkdirSync(tempDir, { recursive: true });
+		await fs.mkdir(tempDir, { recursive: true });
 		modelsJsonPath = path.join(tempDir, "models.json");
 		dbPath = path.join(tempDir, "models.db");
 		authStorage = await AuthStorage.create(":memory:");
 		registry = new ModelRegistry(authStorage, modelsJsonPath, { fetch: offlineFetch });
 	});
 
-	afterEach(() => {
+	afterEach(async () => {
 		vi.useRealTimers();
 		clearCustomApis();
 		unregisterOAuthProviders(sourceId);
 		authStorage.close();
-		if (tempDir && fs.existsSync(tempDir)) removeSyncWithRetries(tempDir);
+		await fs.rm(tempDir, { recursive: true, force: true });
 	});
 
 	function registerAuthGatedProvider(): void {
@@ -61,25 +66,762 @@ describe("issue #5780 post-auth runtime provider refresh", () => {
 		registry.registerProvider(providerName, config, sourceId);
 	}
 
-	test("provider-scoped online refresh after login re-runs discovery past a fresh empty cache", async () => {
+	function runtimeModel(id: string): RuntimeModelDefinition {
+		return {
+			id,
+			name: id,
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 128_000,
+			maxTokens: 8_192,
+		};
+	}
+
+	test("default post-login refresh re-runs dynamic discovery", async () => {
 		registerAuthGatedProvider();
 
-		// Refresh before login: stores an authoritative empty runtime-provider cache
-		// entry with the 24h TTL (fetchDynamicModels returned [] unauthenticated).
+		// Refresh before login: dynamic discovery is empty without a credential.
 		await registry.refreshRuntimeProviders();
 		expect(registry.find(providerName, "gated-model")).toBeUndefined();
 
 		// Login persists a credential.
 		await authStorage.set(providerName, { type: "api_key", key: FAKE_KEY });
 
-		// What the fixed /login, /logout, sign-in, and RPC login sites now do: a
-		// provider-scoped online refresh. It must bypass the fresh authoritative
-		// empty row and re-invoke fetchDynamicModels with the new credential so the
-		// model becomes available in-session.
-		await registry.refreshProvider(providerName, "online");
+		// The default runtime refresh used after login must re-invoke discovery with
+		// the newly persisted credential so the model becomes available in-session.
+		await registry.refreshRuntimeProviders();
 		expect(registry.find(providerName, "gated-model")).toBeDefined();
 	});
-	test("model cache does not serialize provider credentials", async () => {
+	test("every live runtime discovery refreshes expired OAuth credentials", async () => {
+		authStorage.close();
+		const refreshCalls: string[] = [];
+		authStorage = await AuthStorage.create(":memory:", {
+			refreshOAuthCredential: async (provider, _credentialId, credential) => {
+				refreshCalls.push(provider);
+				return { ...credential, access: `fresh-${provider}`, expires: Date.now() + 3_600_000 };
+			},
+		});
+		registry = new ModelRegistry(authStorage, modelsJsonPath, { fetch: offlineFetch });
+		const expiredOAuth = {
+			type: "oauth" as const,
+			access: "expired-runtime-token",
+			refresh: "runtime-refresh-token",
+			expires: Date.now() - 60_000,
+		};
+		await authStorage.set(providerName, expiredOAuth);
+		const receivedKeys: Array<string | undefined> = [];
+		registry.registerProvider(
+			providerName,
+			{
+				baseUrl: "https://issue-5780.example.com/v1",
+				api: "openai-completions",
+				fetchDynamicModels: async apiKey => {
+					receivedKeys.push(apiKey);
+					return [];
+				},
+			},
+			sourceId,
+		);
+
+		await registry.refreshRuntimeProviders("online-if-uncached", [providerName]);
+		expect(refreshCalls).toEqual([providerName]);
+		expect(receivedKeys).toEqual([`fresh-${providerName}`]);
+
+		await authStorage.set(providerName, [
+			expiredOAuth,
+			{ type: "api_key", key: "fallback-runtime-key", source: "login" },
+		]);
+		await registry.refreshRuntimeProviders("online-if-uncached", [providerName]);
+		expect(refreshCalls).toEqual([providerName, providerName]);
+		expect(receivedKeys).toEqual([`fresh-${providerName}`, `fresh-${providerName}`]);
+
+		await registry.refreshRuntimeProviders("online", [providerName]);
+		expect(refreshCalls).toEqual([providerName, providerName]);
+		expect(receivedKeys).toEqual([`fresh-${providerName}`, `fresh-${providerName}`, `fresh-${providerName}`]);
+	});
+	test("replacement without discovery removes the prior runtime manager", async () => {
+		registerAuthGatedProvider();
+		await authStorage.set(providerName, { type: "api_key", key: FAKE_KEY });
+		await registry.refreshRuntimeProviders("online");
+		expect(registry.find(providerName, "gated-model")).toBeDefined();
+
+		registry.registerProvider(
+			providerName,
+			{ baseUrl: "https://issue-5780.example.com/v1", api: "openai-completions" },
+			sourceId,
+		);
+		await registry.refreshRuntimeProviders("online");
+		expect(registry.find(providerName, "gated-model")).toBeUndefined();
+	});
+
+	test("same-source dynamic re-registration reruns direct provider refreshes", async () => {
+		let generation = 0;
+		let fetches = 0;
+		const replacementFetchStarted = Promise.withResolvers<void>();
+		const replacementModels = Promise.withResolvers<RuntimeModelDefinition[]>();
+		const registerDynamicProvider = (): void => {
+			registry.registerProvider(
+				providerName,
+				{
+					baseUrl: "https://issue-5780.example.com/v1",
+					api: "openai-completions",
+					fetchDynamicModels: async () => {
+						fetches += 1;
+						if (generation > 0) {
+							replacementFetchStarted.resolve();
+							return replacementModels.promise;
+						}
+						return [runtimeModel("first-generation")];
+					},
+				},
+				sourceId,
+			);
+		};
+
+		registerDynamicProvider();
+		await registry.refreshRuntimeProviders("online");
+		expect(registry.find(providerName, "first-generation")).toBeDefined();
+
+		generation += 1;
+		registerDynamicProvider();
+		expect(registry.find(providerName, "first-generation")).toBeDefined();
+		await replacementFetchStarted.promise;
+		replacementModels.resolve([runtimeModel("second-generation")]);
+		const unscopedRefresh = registry.refresh("online-if-uncached");
+		const providerRefresh = registry.refreshProvider(providerName, "online");
+		await Promise.all([unscopedRefresh, providerRefresh]);
+		expect(registry.find(providerName, "first-generation")).toBeUndefined();
+		expect(registry.find(providerName, "second-generation")).toBeDefined();
+		expect(fetches).toBe(3);
+	});
+	test("replacing mixed provider static models preserves its dynamic slice until refresh", async () => {
+		let generation = 0;
+		const replacementFetchStarted = Promise.withResolvers<void>();
+		const replacementModels = Promise.withResolvers<RuntimeModelDefinition[]>();
+		const registerMixedProvider = (staticModelId: string): void => {
+			registry.registerProvider(
+				providerName,
+				{
+					baseUrl: "https://issue-5780.example.com/v1",
+					api: "openai-completions",
+					apiKey: FAKE_KEY,
+					models: [runtimeModel(staticModelId)],
+					fetchDynamicModels: async () => {
+						if (generation === 0) return [runtimeModel("first-dynamic")];
+						replacementFetchStarted.resolve();
+						return replacementModels.promise;
+					},
+				},
+				sourceId,
+			);
+		};
+
+		registerMixedProvider("first-static");
+		await registry.refreshRuntimeProviders("online", [providerName]);
+		expect(registry.find(providerName, "first-static")).toBeDefined();
+		expect(registry.find(providerName, "first-dynamic")).toBeDefined();
+		expect(registry.getAll().some(model => model.provider === providerName && model.id === "first-dynamic")).toBe(
+			true,
+		);
+
+		generation += 1;
+		registerMixedProvider("second-static");
+		expect(registry.find(providerName, "first-static")).toBeUndefined();
+		expect(registry.find(providerName, "second-static")).toBeDefined();
+		expect(registry.find(providerName, "first-dynamic")).toBeDefined();
+
+		await replacementFetchStarted.promise;
+		replacementModels.resolve([runtimeModel("second-dynamic")]);
+		await registry.refreshRuntimeProviders("online", [providerName]);
+		expect(registry.find(providerName, "first-dynamic")).toBeUndefined();
+		expect(registry.find(providerName, "second-dynamic")).toBeDefined();
+	});
+
+	test("late extension discovery registration preserves configured discovery ownership", async () => {
+		let configuredFetches = 0;
+		let extensionFetches = 0;
+		await Bun.write(
+			modelsJsonPath,
+			JSON.stringify({
+				providers: {
+					[providerName]: {
+						baseUrl: "https://issue-5780.example.com/v1",
+						api: "openai-completions",
+						auth: "none",
+						discovery: { type: "openai-models-list" },
+					},
+				},
+			}),
+		);
+		registry = new ModelRegistry(authStorage, modelsJsonPath, {
+			fetch: async input => {
+				const url = input instanceof Request ? input.url : String(input);
+				if (url !== "https://issue-5780.example.com/v1/models") {
+					throw new Error(`Unexpected fetch: ${url}`);
+				}
+				configuredFetches += 1;
+				return new Response(JSON.stringify({ data: [{ id: "configured-model" }] }));
+			},
+		});
+		await registry.refresh("online");
+		expect(registry.find(providerName, "configured-model")).toBeDefined();
+
+		registry.registerProvider(
+			providerName,
+			{
+				baseUrl: "https://issue-5780.example.com/v1",
+				api: "openai-completions",
+				fetchDynamicModels: async () => {
+					extensionFetches += 1;
+					return [runtimeModel("extension-model")];
+				},
+			},
+			sourceId,
+		);
+
+		expect(registry.find(providerName, "configured-model")).toBeDefined();
+		await registry.refreshRuntimeProviders("online", [providerName]);
+		expect(registry.find(providerName, "configured-model")).toBeDefined();
+		expect(configuredFetches).toBe(2);
+		expect(extensionFetches).toBe(0);
+	});
+
+	test("config discovery replaces an extension-owned runtime catalog on static reload", async () => {
+		registry.registerProvider(
+			providerName,
+			{
+				baseUrl: "https://issue-5780.example.com/v1",
+				api: "openai-completions",
+				fetchDynamicModels: async () => [runtimeModel("extension-model")],
+			},
+			sourceId,
+		);
+		await registry.refreshRuntimeProviders("online");
+		expect(registry.find(providerName, "extension-model")).toBeDefined();
+
+		await Bun.write(
+			modelsJsonPath,
+			JSON.stringify({
+				providers: {
+					[providerName]: {
+						baseUrl: "https://issue-5780.example.com/v1",
+						api: "openai-completions",
+						auth: "none",
+						discovery: { type: "openai-models-list" },
+					},
+				},
+			}),
+		);
+		await registry.refresh("offline");
+
+		expect(registry.find(providerName, "extension-model")).toBeUndefined();
+	});
+
+	test("config discovery discards an in-flight extension catalog on static reload", async () => {
+		const fetchStarted = Promise.withResolvers<void>();
+		const pendingModels = Promise.withResolvers<readonly RuntimeModelDefinition[]>();
+		registry.registerProvider(
+			providerName,
+			{
+				baseUrl: "https://issue-5780.example.com/v1",
+				api: "openai-completions",
+				fetchDynamicModels: () => {
+					fetchStarted.resolve();
+					return pendingModels.promise;
+				},
+			},
+			sourceId,
+		);
+		const extensionRefresh = registry.refreshRuntimeProviders("online");
+		await fetchStarted.promise;
+		await Bun.write(
+			modelsJsonPath,
+			JSON.stringify({
+				providers: {
+					[providerName]: {
+						baseUrl: "https://issue-5780.example.com/v1",
+						api: "openai-completions",
+						auth: "none",
+						discovery: { type: "openai-models-list" },
+					},
+				},
+			}),
+		);
+		await registry.refresh("offline");
+		pendingModels.resolve([runtimeModel("stale-extension-model")]);
+		await extensionRefresh;
+
+		expect(registry.find(providerName, "stale-extension-model")).toBeUndefined();
+	});
+
+	test("static reload recomposes raw extension discovery against current overrides", async () => {
+		await Bun.write(
+			modelsJsonPath,
+			JSON.stringify({
+				providers: {
+					[providerName]: {
+						headers: { "X-Discovery-Override": "old" },
+					},
+				},
+			}),
+		);
+		await registry.refresh("offline");
+		registry.registerProvider(
+			providerName,
+			{
+				baseUrl: "https://issue-5780.example.com/v1",
+				api: "openai-completions",
+				fetchDynamicModels: async () => [runtimeModel("extension-model")],
+			},
+			sourceId,
+		);
+		await registry.refreshRuntimeProviders("online");
+		expect(registry.find(providerName, "extension-model")?.headers?.["X-Discovery-Override"]).toBe("old");
+
+		await Bun.write(modelsJsonPath, JSON.stringify({ providers: { [providerName]: {} } }));
+		await fs.utimes(modelsJsonPath, new Date("2100-01-01T00:00:00.000Z"), new Date("2100-01-01T00:00:00.000Z"));
+		await registry.refresh("offline");
+
+		expect(registry.find(providerName, "extension-model")?.headers?.["X-Discovery-Override"]).toBeUndefined();
+	});
+
+	test("offline runtime refresh does not supersede a pending online discovery", async () => {
+		const fetchStarted = Promise.withResolvers<void>();
+		const pendingModels = Promise.withResolvers<readonly RuntimeModelDefinition[]>();
+		registry.registerProvider(
+			providerName,
+			{
+				baseUrl: "https://issue-5780.example.com/v1",
+				api: "openai-completions",
+				fetchDynamicModels: () => {
+					fetchStarted.resolve();
+					return pendingModels.promise;
+				},
+			},
+			sourceId,
+		);
+
+		const onlineRefresh = registry.refreshRuntimeProviders("online");
+		await fetchStarted.promise;
+		await registry.refreshRuntimeProviders("offline");
+		pendingModels.resolve([runtimeModel("online-model")]);
+		await onlineRefresh;
+
+		expect(registry.find(providerName, "online-model")).toBeDefined();
+	});
+
+	test("failed online extension discovery clears the prior account catalog", async () => {
+		let shouldFail = false;
+		registry.registerProvider(
+			providerName,
+			{
+				baseUrl: "https://issue-5780.example.com/v1",
+				api: "openai-completions",
+				fetchDynamicModels: async () => {
+					if (shouldFail) throw new Error("current account discovery failed");
+					return [runtimeModel("prior-account-model")];
+				},
+			},
+			sourceId,
+		);
+		await registry.refreshProvider(providerName, "online");
+		expect(
+			registry.getAll().find(model => model.provider === providerName && model.id === "prior-account-model"),
+		).toBeDefined();
+
+		shouldFail = true;
+		await registry.refreshProvider(providerName, "online");
+
+		expect(registry.find(providerName, "prior-account-model")).toBeUndefined();
+	});
+	test("a newer runtime refresh supersedes an older result", async () => {
+		const initialFetchStarted = Promise.withResolvers<void>();
+		const initialModels = Promise.withResolvers<readonly RuntimeModelDefinition[]>();
+		let fetches = 0;
+		registry.registerProvider(
+			providerName,
+			{
+				baseUrl: "https://issue-5780.example.com/v1",
+				api: "openai-completions",
+				fetchDynamicModels: async () => {
+					if (fetches++ === 0) {
+						initialFetchStarted.resolve();
+						return initialModels.promise;
+					}
+					return [
+						{
+							id: "current-model",
+							name: "Current Model",
+							reasoning: false,
+							input: ["text"],
+							cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+							contextWindow: 128_000,
+							maxTokens: 8_192,
+						},
+					];
+				},
+			},
+			sourceId,
+		);
+
+		const olderRefresh = registry.refreshRuntimeProviders("online");
+		await initialFetchStarted.promise;
+		await registry.refreshProvider(providerName, "online");
+		expect(registry.find(providerName, "current-model")).toBeDefined();
+		initialModels.resolve([]);
+		await olderRefresh;
+		expect(registry.find(providerName, "current-model")).toBeDefined();
+	});
+	test("a delayed configured discovery cannot apply a superseded runtime result", async () => {
+		const configuredFetchStarted = Promise.withResolvers<void>();
+		const configuredResponse = Promise.withResolvers<Response>();
+		const firstRuntimeFetchFinished = Promise.withResolvers<void>();
+		let runtimeFetches = 0;
+		await Bun.write(
+			modelsJsonPath,
+			JSON.stringify({
+				providers: {
+					"slow-configured": {
+						baseUrl: "https://slow-configured.example.com/v1",
+						api: "openai-completions",
+						auth: "none",
+						discovery: { type: "openai-models-list" },
+					},
+				},
+			}),
+		);
+		const slowRegistry = new ModelRegistry(authStorage, modelsJsonPath, {
+			fetch: async input => {
+				const url = input instanceof Request ? input.url : String(input);
+				if (url.startsWith("https://slow-configured.example.com/")) {
+					configuredFetchStarted.resolve();
+					return configuredResponse.promise;
+				}
+				throw new Error(`Unexpected fetch: ${url}`);
+			},
+		});
+		slowRegistry.registerProvider(
+			providerName,
+			{
+				baseUrl: "https://issue-5780.example.com/v1",
+				api: "openai-completions",
+				fetchDynamicModels: async () => {
+					if (runtimeFetches++ === 0) {
+						firstRuntimeFetchFinished.resolve();
+						return [];
+					}
+					return [
+						{
+							id: "current-model",
+							name: "Current Model",
+							reasoning: false,
+							input: ["text"],
+							cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+							contextWindow: 128_000,
+							maxTokens: 8_192,
+						},
+					];
+				},
+			},
+			sourceId,
+		);
+
+		const olderRefresh = slowRegistry.refresh("online");
+		await Promise.all([configuredFetchStarted.promise, firstRuntimeFetchFinished.promise]);
+		await slowRegistry.refreshProvider(providerName, "online");
+		expect(slowRegistry.find(providerName, "current-model")).toBeDefined();
+		configuredResponse.resolve(new Response(JSON.stringify({ data: [] })));
+		await olderRefresh;
+		expect(slowRegistry.find(providerName, "current-model")).toBeDefined();
+	});
+	test("runtime registration survives inaccessible cache storage", async () => {
+		const cacheParent = path.join(tempDir, "cache-parent");
+		await Bun.write(cacheParent, "not a directory");
+		const cacheDisabledRegistry = new ModelRegistry(authStorage, modelsJsonPath, {
+			cacheDbPath: path.join(cacheParent, "models.db"),
+			fetch: offlineFetch,
+		});
+		cacheDisabledRegistry.registerProvider(
+			providerName,
+			{
+				baseUrl: "https://issue-5780.example.com/v1",
+				api: "openai-completions",
+				fetchDynamicModels: async () => [
+					{
+						id: "uncached-model",
+						name: "Uncached Model",
+						reasoning: false,
+						input: ["text"],
+						cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+						contextWindow: 128_000,
+						maxTokens: 8_192,
+					},
+				],
+			},
+			sourceId,
+		);
+		await cacheDisabledRegistry.refreshRuntimeProviders("online");
+		expect(cacheDisabledRegistry.find(providerName, "uncached-model")).toBeDefined();
+	});
+
+	test("provider-scoped refresh preserves unrelated runtime catalogs", async () => {
+		const unrelatedProvider = "issue-5780-unrelated-provider";
+		let unrelatedFetches = 0;
+		registry.registerProvider(
+			providerName,
+			{
+				baseUrl: "https://issue-5780.example.com/v1",
+				api: "openai-completions",
+				fetchDynamicModels: async () => [
+					{
+						id: "refreshed-model",
+						name: "Refreshed Model",
+						reasoning: false,
+						input: ["text"],
+						cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+						contextWindow: 128_000,
+						maxTokens: 8_192,
+					},
+				],
+			},
+			sourceId,
+		);
+		registry.registerProvider(
+			unrelatedProvider,
+			{
+				baseUrl: "https://issue-5780-unrelated.example.com/v1",
+				api: "openai-completions",
+				fetchDynamicModels: async () => {
+					unrelatedFetches++;
+					return [
+						{
+							id: "unrelated-model",
+							name: "Unrelated Model",
+							reasoning: false,
+							input: ["text"],
+							cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+							contextWindow: 128_000,
+							maxTokens: 8_192,
+						},
+					];
+				},
+			},
+			sourceId,
+		);
+
+		await registry.refreshRuntimeProviders("online");
+		expect(registry.find(unrelatedProvider, "unrelated-model")).toBeDefined();
+		await registry.refreshRuntimeProviders("online", [providerName]);
+		expect(unrelatedFetches).toBe(1);
+		expect(registry.find(unrelatedProvider, "unrelated-model")).toBeDefined();
+		registry.unregisterProvider(unrelatedProvider);
+		expect(registry.find(unrelatedProvider, "unrelated-model")).toBeUndefined();
+	});
+
+	test("discards a runtime discovery result after its provider is unregistered", async () => {
+		const pendingModels = Promise.withResolvers<readonly RuntimeModelDefinition[]>();
+		const fetchStarted = Promise.withResolvers<void>();
+		registry.registerProvider(
+			providerName,
+			{
+				baseUrl: "https://issue-5780.example.com/v1",
+				api: "openai-completions",
+				fetchDynamicModels: (_apiKey: string | undefined) => {
+					fetchStarted.resolve();
+					return pendingModels.promise;
+				},
+			},
+			sourceId,
+		);
+
+		const refresh = registry.refreshRuntimeProviders("online");
+		await fetchStarted.promise;
+		registry.unregisterProvider(providerName);
+		pendingModels.resolve([
+			{
+				id: "removed-model",
+				name: "Removed Model",
+				api: "openai-completions",
+				baseUrl: "https://issue-5780.example.com/v1",
+				reasoning: false,
+				input: ["text"],
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+				contextWindow: 128_000,
+				maxTokens: 8_192,
+			},
+		]);
+		await refresh;
+		expect(registry.find(providerName, "removed-model")).toBeUndefined();
+	});
+	test("runtime dynamic catalogs are unavailable offline and never persist", async () => {
+		let fetches = 0;
+		registry.registerProvider(
+			providerName,
+			{
+				baseUrl: "https://issue-5780.example.com/v1",
+				api: "openai-completions",
+				fetchDynamicModels: async () => {
+					fetches++;
+					return [
+						{
+							id: "runtime-model",
+							name: "Runtime Model",
+							reasoning: false,
+							input: ["text"],
+							cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+							contextWindow: 128_000,
+							maxTokens: 8_192,
+						},
+					];
+				},
+			},
+			sourceId,
+		);
+
+		await registry.refreshRuntimeProviders("online");
+		expect(registry.find(providerName, "runtime-model")).toBeDefined();
+		expect(fetches).toBe(1);
+		expect(readModelCache(providerName, Infinity, Date.now, dbPath)).toBeNull();
+
+		// An in-process offline picker refresh retains the current live catalog;
+		// the catalog is never read from disk after an application restart.
+		await registry.refresh("offline");
+		expect(registry.find(providerName, "runtime-model")).toBeDefined();
+		expect(fetches).toBe(1);
+
+		const replacementFetchStarted = Promise.withResolvers<void>();
+		registry.registerProvider(
+			providerName,
+			{
+				baseUrl: "https://issue-5780.example.com/v1",
+				api: "openai-completions",
+				fetchDynamicModels: async () => {
+					replacementFetchStarted.resolve();
+					return [];
+				},
+			},
+			sourceId,
+		);
+
+		// Re-registration preserves the old catalog until its scheduled online
+		// replacement completes, then removes it when the replacement is empty.
+		expect(registry.find(providerName, "runtime-model")).toBeDefined();
+		await replacementFetchStarted.promise;
+		await registry.refreshRuntimeProviders("online", [providerName]);
+		expect(registry.find(providerName, "runtime-model")).toBeUndefined();
+
+		const restarted = new ModelRegistry(authStorage, modelsJsonPath, { fetch: offlineFetch });
+		restarted.registerProvider(
+			providerName,
+			{
+				baseUrl: "https://issue-5780.example.com/v1",
+				api: "openai-completions",
+				fetchDynamicModels: async () => {
+					fetches++;
+					return [];
+				},
+			},
+			sourceId,
+		);
+		await restarted.refreshRuntimeProviders("offline");
+		expect(restarted.find(providerName, "runtime-model")).toBeUndefined();
+		expect(fetches).toBe(1);
+
+		await restarted.refreshRuntimeProviders("online-if-uncached");
+		expect(fetches).toBe(2);
+	});
+	test("runtime registration preserves an indistinguishable provider cache row", async () => {
+		const cachedModel = registry.getAll().find(model => model.provider === "anthropic");
+		if (!cachedModel) throw new Error("Expected an Anthropic built-in model");
+		writeModelCache("anthropic", Date.now(), [cachedModel], true, "", dbPath);
+		expect(readModelCache("anthropic", Infinity, Date.now, dbPath)).not.toBeNull();
+
+		registry.registerProvider(
+			"anthropic",
+			{
+				baseUrl: "https://issue-5780.example.com/v1",
+				api: "openai-completions",
+				fetchDynamicModels: async () => [],
+			},
+			sourceId,
+		);
+
+		expect(registry.find("anthropic", cachedModel.id)).toBeUndefined();
+		await Bun.write(modelsJsonPath, "{}");
+		await registry.refresh("offline");
+		expect(registry.find("anthropic", cachedModel.id)).toBeUndefined();
+
+		await Bun.write(
+			modelsJsonPath,
+			JSON.stringify({
+				providers: {
+					anthropic: {
+						baseUrl: "https://issue-5780.example.com/v1",
+						api: "openai-completions",
+						auth: "none",
+						discovery: { type: "openai-models-list" },
+					},
+				},
+			}),
+		);
+		await registry.refresh("offline");
+		await Bun.write(modelsJsonPath, "{}");
+		await registry.refresh("offline");
+		expect(registry.find("anthropic", cachedModel.id)).toBeUndefined();
+
+		expect(readModelCache("anthropic", Infinity, Date.now, dbPath)).not.toBeNull();
+	});
+	test("runtime manager suppresses a colliding legacy v12 standard cache row", () => {
+		const legacyCacheModel = buildModel({
+			id: "legacy-v12-runtime-model",
+			name: "Legacy v12 Runtime Model",
+			provider: "anthropic",
+			api: "openai-completions" as const,
+			baseUrl: "https://legacy-cache.example.com/v1",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 128_000,
+			maxTokens: 8_192,
+		});
+		writeModelCache("anthropic", Date.now(), [legacyCacheModel], true, "", dbPath);
+		const seeded = new Database(dbPath);
+		seeded.run("UPDATE model_cache SET version = 12 WHERE provider_id = ?", ["anthropic"]);
+		seeded.close();
+
+		registry.registerProvider(
+			"anthropic",
+			{
+				baseUrl: "https://issue-5780.example.com/v1",
+				api: "openai-completions",
+				fetchDynamicModels: async () => [],
+			},
+			sourceId,
+		);
+
+		expect(registry.getAll().some(model => model.id === legacyCacheModel.id)).toBe(false);
+		expect(readModelCache("anthropic", Infinity, Date.now, dbPath)?.models.map(model => model.id)).toEqual([
+			legacyCacheModel.id,
+		]);
+	});
+	test("runtime discovery failure keeps a colliding bundled provider unavailable", async () => {
+		registry.registerProvider(
+			"anthropic",
+			{
+				baseUrl: "https://issue-5780.example.com/v1",
+				api: "openai-completions",
+				fetchDynamicModels: async () => {
+					throw new Error("runtime discovery failed");
+				},
+			},
+			sourceId,
+		);
+
+		await registry.refreshRuntimeProviders("online");
+		expect(registry.getAll().some(model => model.provider === "anthropic")).toBe(false);
+	});
+	test("runtime dynamic catalogs do not serialize provider credentials", async () => {
 		// Provider config carries a literal credential + authHeader, mirroring an
 		// extension gateway. The dynamic factory itself never returns a credential.
 		const config: ProviderConfigInput = {
@@ -87,6 +829,7 @@ describe("issue #5780 post-auth runtime provider refresh", () => {
 			api: "openai-completions",
 			apiKey: FAKE_KEY,
 			authHeader: true,
+			headers: { "X-Runtime-Secret": FAKE_HEADER },
 			fetchDynamicModels: async () => [
 				{
 					id: "gated-model",
@@ -101,9 +844,16 @@ describe("issue #5780 post-auth runtime provider refresh", () => {
 		};
 		registry.registerProvider(providerName, config, sourceId);
 		await registry.refreshProvider(providerName, "online");
+		expect(registry.find(providerName, "gated-model")?.headers).toEqual({
+			Authorization: `Bearer ${FAKE_KEY}`,
+			"X-Runtime-Secret": FAKE_HEADER,
+		});
 
-		// The model cache is a plaintext SQLite file; it must not carry the API key.
-		const raw = fs.readFileSync(dbPath);
-		expect(raw.includes(FAKE_KEY)).toBe(false);
+		// Other registry paths may initialize SQLite, but this runtime provider
+		// never receives a row and its secrets never reach the cache bytes.
+		expect(readModelCache(providerName, Infinity, Date.now, dbPath)).toBeNull();
+		const rawCache = await fs.readFile(dbPath);
+		expect(rawCache.includes(FAKE_KEY)).toBe(false);
+		expect(rawCache.includes(FAKE_HEADER)).toBe(false);
 	});
 });

--- a/packages/coding-agent/test/model-discovery.test.ts
+++ b/packages/coding-agent/test/model-discovery.test.ts
@@ -1840,6 +1840,7 @@ providers:
 							maxTokens: 8192,
 						},
 					],
+					fetchDynamicModels: async () => [],
 					oauth: {
 						name: "Projection OAuth",
 						login: async () => ({ access: "a", refresh: "r", expires: Date.now() + 60_000 }),
@@ -1853,6 +1854,7 @@ providers:
 			expect(registry.find("llama.cpp", "cold-preset")?.contextWindow).toBe(16384);
 		} finally {
 			registry.clearSourceRegistrations("ext://metadata-projection");
+			expect(registry.find("llama.cpp", "cold-preset")?.contextWindow).toBe(16384);
 		}
 	});
 
@@ -1968,7 +1970,7 @@ providers:
 		expect(registry.find("llama.cpp", "vision-model")?.input).toEqual(["text", "image"]);
 	});
 
-	test("llama.cpp selected model refresh reads image capability from per-model architecture", async () => {
+	test("llama.cpp selected model refresh preserves metadata patches across probes and recomposition", async () => {
 		writeModelCache(
 			"llama.cpp",
 			Date.now(),
@@ -1990,6 +1992,7 @@ providers:
 			"",
 			cacheDbPath,
 		);
+		let imageCapable = false;
 		const fetchMock: FetchImpl = async input => {
 			const url = String(input);
 			if (url === "http://127.0.0.1:8080/models") {
@@ -1998,10 +2001,14 @@ providers:
 						data: [
 							{
 								id: "router-vision-model",
-								architecture: {
-									input_modalities: ["text", "image"],
-									output_modalities: ["text"],
-								},
+								...(imageCapable
+									? {
+											architecture: {
+												input_modalities: ["text", "image"],
+												output_modalities: ["text"],
+											},
+										}
+									: {}),
 								meta: { n_ctx: 239104 },
 							},
 						],
@@ -2026,10 +2033,16 @@ providers:
 		const stale = registry.find("llama.cpp", "router-vision-model");
 		if (!stale) throw new Error("cached llama.cpp model missing");
 		expect(stale.input).toEqual(["text"]);
-		const refreshed = await registry.refreshSelectedModelMetadata(stale);
+		const contextRefreshed = await registry.refreshSelectedModelMetadata(stale);
+		expect(contextRefreshed.contextWindow).toBe(239104);
+		imageCapable = true;
+		const refreshed = await registry.refreshSelectedModelMetadata(contextRefreshed);
 		expect(refreshed.contextWindow).toBe(239104);
 		expect(refreshed.input).toEqual(["text", "image"]);
-		expect(registry.find("llama.cpp", "router-vision-model")?.input).toEqual(["text", "image"]);
+		await registry.refresh("offline");
+		const recomposed = registry.find("llama.cpp", "router-vision-model");
+		expect(recomposed?.contextWindow).toBe(239104);
+		expect(recomposed?.input).toEqual(["text", "image"]);
 	});
 
 	test("llama.cpp selected model refresh leaves the cached model untouched when /models no longer lists it", async () => {

--- a/packages/coding-agent/test/sdk-default-role-extension-provider.test.ts
+++ b/packages/coding-agent/test/sdk-default-role-extension-provider.test.ts
@@ -105,4 +105,79 @@ describe("issue #3569 fresh launch default role from extension provider", () => 
 			await session.dispose();
 		}
 	});
+	test("awaits the default runtime catalog before choosing a fresh UI fallback", async () => {
+		const bundledOpenAiDefault = getBundledModel("openai", "gpt-5.5");
+		if (!bundledOpenAiDefault) {
+			throw new Error("Expected bundled OpenAI GPT-5.5 default");
+		}
+
+		const authStorage = createInMemoryAuthStorage();
+		authStoragesToClose.push(authStorage);
+		authStorage.setRuntimeApiKey("openai", "test-openai-key");
+		const modelRegistry = new ModelRegistry(authStorage, path.join(tempDir, "dynamic-default-models.yml"));
+		const settings = Settings.isolated({ modelRoles: { default: "runtime-provider/runtime-model" } });
+		let defaultFetches = 0;
+		let unrelatedFetches = 0;
+		const dynamicExtension: ExtensionFactory = pi => {
+			pi.registerProvider("runtime-provider", {
+				baseUrl: "https://runtime.example.com/v1",
+				apiKey: "RUNTIME_KEY",
+				api: "openai-completions",
+				fetchDynamicModels: async () => {
+					defaultFetches += 1;
+					return [
+						{
+							id: "runtime-model",
+							name: "Runtime Model",
+							reasoning: false,
+							input: ["text"],
+							cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+							contextWindow: 128000,
+							maxTokens: 8192,
+						},
+					];
+				},
+			});
+			pi.registerProvider("unrelated-runtime-provider", {
+				baseUrl: "https://unrelated.example.com/v1",
+				apiKey: "UNRELATED_KEY",
+				api: "openai-completions",
+				fetchDynamicModels: async () => {
+					unrelatedFetches += 1;
+					return [];
+				},
+			});
+		};
+
+		const { session } = await createAgentSession({
+			cwd: tempDir,
+			agentDir: tempDir,
+			authStorage,
+			modelRegistry,
+			settings,
+			sessionManager: SessionManager.inMemory(),
+			disableExtensionDiscovery: true,
+			extensions: [dynamicExtension],
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+			skipPythonPreflight: true,
+			rules: [],
+			preloadedCustomToolPaths: [],
+			toolNames: ["read"],
+			hasUI: true,
+		});
+
+		try {
+			expect(session.model?.provider).toBe("runtime-provider");
+			expect(session.model?.id).toBe("runtime-model");
+			expect(defaultFetches).toBe(1);
+			expect(unrelatedFetches).toBe(0);
+		} finally {
+			await session.dispose();
+		}
+	});
 });

--- a/packages/coding-agent/test/sdk-deferred-role-discovery.test.ts
+++ b/packages/coding-agent/test/sdk-deferred-role-discovery.test.ts
@@ -5,7 +5,7 @@ import * as path from "node:path";
 import type { FetchImpl } from "@oh-my-pi/pi-ai";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
-import { createAgentSession } from "@oh-my-pi/pi-coding-agent/sdk";
+import { createAgentSession, type ExtensionFactory } from "@oh-my-pi/pi-coding-agent/sdk";
 import type { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
@@ -86,6 +86,27 @@ describe("createAgentSession deferred role alias on discoverable provider (#8863
 			modelRoles: { smol: "ollama/phi3" },
 			"compaction.enabled": false,
 		});
+		let runtimeFetches = 0;
+		const extension: ExtensionFactory = pi => {
+			pi.registerProvider("unrelated-runtime-provider", {
+				baseUrl: "https://runtime.example.com/v1",
+				api: "openai-completions",
+				fetchDynamicModels: async () => {
+					runtimeFetches += 1;
+					return [
+						{
+							id: "unrelated-runtime-model",
+							name: "Unrelated Runtime Model",
+							reasoning: false,
+							input: ["text"],
+							cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+							contextWindow: 128_000,
+							maxTokens: 8_192,
+						},
+					];
+				},
+			});
+		};
 
 		let session: AgentSession | undefined;
 		try {
@@ -98,6 +119,7 @@ describe("createAgentSession deferred role alias on discoverable provider (#8863
 				settings,
 				modelPattern: "@smol",
 				disableExtensionDiscovery: true,
+				extensions: [extension],
 				skills: [],
 				contextFiles: [],
 				promptTemplates: [],
@@ -112,6 +134,7 @@ describe("createAgentSession deferred role alias on discoverable provider (#8863
 
 			expect(result.session.model?.provider).toBe("ollama");
 			expect(result.session.model?.id).toBe("phi3");
+			expect(runtimeFetches).toBe(1);
 		} finally {
 			session?.dispose();
 		}

--- a/packages/coding-agent/test/sdk-model-selection.test.ts
+++ b/packages/coding-agent/test/sdk-model-selection.test.ts
@@ -13,7 +13,7 @@ import { getModelMatchPreferences, resolveModelScope } from "@oh-my-pi/pi-coding
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { buildSessionOptions as buildCliSessionOptions } from "@oh-my-pi/pi-coding-agent/main";
 import { createAgentSession, type ExtensionFactory } from "@oh-my-pi/pi-coding-agent/sdk";
-import type { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import { removeSyncWithRetries, Snowflake } from "@oh-my-pi/pi-utils";
 import { createInMemoryAuthStorage } from "./helpers/agent-session-setup";
@@ -35,8 +35,8 @@ describe("createAgentSession deferred model pattern resolution", () => {
 	beforeEach(() => {
 		tempDir = path.join(os.tmpdir(), `pi-sdk-model-selection-${Snowflake.next()}`);
 		fs.mkdirSync(tempDir, { recursive: true });
+		vi.spyOn(Settings, "init").mockResolvedValue(Settings.isolated());
 	});
-
 	afterEach(() => {
 		vi.restoreAllMocks();
 		for (const authStorage of authStoragesToClose) {
@@ -179,6 +179,79 @@ describe("createAgentSession deferred model pattern resolution", () => {
 			expect(session.model?.provider).toBe("runtime-provider");
 			expect(session.model?.id).toBe("cached-runtime-model");
 			expect(modelFallbackMessage).toBeUndefined();
+		} finally {
+			await session.dispose();
+		}
+	});
+
+	test("refreshes OAuth for an explicit deferred dynamic model selector", async () => {
+		const refreshCalls: string[] = [];
+		const authStorage = await AuthStorage.create(":memory:", {
+			refreshOAuthCredential: async (provider, _credentialId, credential) => {
+				refreshCalls.push(provider);
+				return { ...credential, access: "fresh-explicit-token", expires: Date.now() + 3_600_000 };
+			},
+		});
+		authStoragesToClose.push(authStorage);
+		await authStorage.set("oauth-runtime-provider", {
+			type: "oauth",
+			access: "expired-explicit-token",
+			refresh: "explicit-refresh-token",
+			expires: Date.now() - 60_000,
+		});
+		const modelRegistry = new ModelRegistry(authStorage, path.join(tempDir, "models.yml"));
+		const receivedKeys: Array<string | undefined> = [];
+		const extension: ExtensionFactory = pi => {
+			pi.registerProvider("oauth-runtime-provider", {
+				baseUrl: "https://runtime.example.com/v1",
+				api: "openai-completions",
+				fetchDynamicModels: async apiKey => {
+					receivedKeys.push(apiKey);
+					return apiKey === "fresh-explicit-token"
+						? [
+								{
+									id: "explicit-dynamic-model",
+									name: "Explicit Dynamic Model",
+									reasoning: false,
+									input: ["text"],
+									cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+									contextWindow: 128_000,
+									maxTokens: 8192,
+								},
+							]
+						: [];
+				},
+			});
+		};
+
+		const { session, modelFallbackMessage } = await createAgentSession({
+			cwd: tempDir,
+			agentDir: tempDir,
+			authStorage,
+			modelRegistry,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated(),
+			disableExtensionDiscovery: true,
+			extensions: [extension],
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+			skipPythonPreflight: true,
+			rules: [],
+			preloadedCustomToolPaths: [],
+			toolNames: ["read"],
+			modelPattern: "oauth-runtime-provider/explicit-dynamic-model",
+		});
+
+		try {
+			expect(session.model?.provider).toBe("oauth-runtime-provider");
+			expect(session.model?.id).toBe("explicit-dynamic-model");
+			expect(modelFallbackMessage).toBeUndefined();
+			expect(refreshCalls).toEqual(["oauth-runtime-provider"]);
+			expect(receivedKeys).toEqual(["fresh-explicit-token"]);
 		} finally {
 			await session.dispose();
 		}
@@ -1467,6 +1540,220 @@ describe("createAgentSession deferred model pattern resolution", () => {
 			expect(session.thinkingLevel).toBe(Effort.XHigh);
 		} finally {
 			await session.dispose();
+			authStorage.close();
+		}
+	});
+
+	test("does not duplicate completed non-UI discovery for unavailable saved model", async () => {
+		const defaultModel = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!defaultModel) throw new Error("Expected bundled anthropic default model");
+		const authStorage = createInMemoryAuthStorage();
+		authStorage.setRuntimeApiKey(defaultModel.provider, "test-key");
+		const modelRegistry = new ModelRegistry(authStorage, path.join(tempDir, "models.yml"));
+		let fetches = 0;
+		const extension: ExtensionFactory = pi => {
+			pi.registerProvider("runtime-provider", {
+				baseUrl: "https://runtime.example.com/v1",
+				apiKey: "RUNTIME_KEY",
+				api: "openai-completions",
+				fetchDynamicModels: async () => {
+					fetches += 1;
+					return [
+						{
+							id: "renamed-dynamic-model",
+							name: "Renamed Dynamic Model",
+							reasoning: false,
+							input: ["text"],
+							cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+							contextWindow: 128_000,
+							maxTokens: 8192,
+						},
+					];
+				},
+			});
+		};
+		const timestamp = "2026-06-01T00:00:00.000Z";
+		const targetSessionFile = path.join(tempDir, "resume-dynamic-startup.jsonl");
+		await Bun.write(
+			targetSessionFile,
+			`${[
+				{ type: "session", version: 3, id: "resume-dynamic-startup", timestamp, cwd: tempDir },
+				{
+					type: "model_change",
+					id: "default",
+					parentId: null,
+					timestamp,
+					model: `${defaultModel.provider}/${defaultModel.id}`,
+					role: "default",
+				},
+				{
+					type: "model_change",
+					id: "smol",
+					parentId: "default",
+					timestamp,
+					model: "runtime-provider/saved-dynamic-model",
+					role: "smol",
+				},
+			]
+				.map(entry => JSON.stringify(entry))
+				.join("\n")}\n`,
+		);
+		const sessionManager = await SessionManager.open(
+			targetSessionFile,
+			path.join(tempDir, "sessions-dynamic-startup"),
+		);
+
+		const { session } = await createAgentSession({
+			cwd: tempDir,
+			agentDir: tempDir,
+			authStorage,
+			modelRegistry,
+			sessionManager,
+			settings: Settings.isolated(),
+			disableExtensionDiscovery: true,
+			extensions: [extension],
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+			skipPythonPreflight: true,
+			rules: [],
+			preloadedCustomToolPaths: [],
+			toolNames: ["read"],
+		});
+
+		try {
+			expect(session.model?.provider).toBe(defaultModel.provider);
+			expect(session.model?.id).toBe(defaultModel.id);
+			expect(fetches).toBe(1);
+		} finally {
+			await session.dispose();
+			authStorage.close();
+		}
+	});
+
+	test("retries failed UI candidates while preserving successful targeted catalogs", async () => {
+		const defaultModel = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!defaultModel) throw new Error("Expected bundled anthropic default model");
+		const authStorage = createInMemoryAuthStorage();
+		authStorage.setRuntimeApiKey(defaultModel.provider, "test-key");
+		const modelRegistry = new ModelRegistry(authStorage, path.join(tempDir, "models.yml"));
+		let targetedFetches = 0;
+		let unrelatedFetches = 0;
+		const extension: ExtensionFactory = pi => {
+			pi.registerProvider("ui-runtime-provider", {
+				baseUrl: "https://runtime.example.com/v1",
+				apiKey: "RUNTIME_KEY",
+				api: "openai-completions",
+				fetchDynamicModels: async () => {
+					targetedFetches += 1;
+					if (targetedFetches === 1) return [];
+					return [
+						{
+							id: "saved-ui-model",
+							name: "Saved UI Model",
+							reasoning: false,
+							input: ["text"],
+							cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+							contextWindow: 128_000,
+							maxTokens: 8192,
+						},
+					];
+				},
+			});
+			pi.registerProvider("other-ui-runtime-provider", {
+				baseUrl: "https://runtime.example.com/v1",
+				apiKey: "OTHER_RUNTIME_KEY",
+				api: "openai-completions",
+				fetchDynamicModels: async () => {
+					unrelatedFetches += 1;
+					return [
+						{
+							id: "other-ui-model",
+							name: "Other UI Model",
+							reasoning: false,
+							input: ["text"],
+							cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+							contextWindow: 128_000,
+							maxTokens: 8192,
+						},
+						{
+							id: "other-ui-model-thinking",
+							name: "Other UI Model Thinking",
+							reasoning: true,
+							input: ["text"],
+							cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+							contextWindow: 128_000,
+							maxTokens: 8192,
+						},
+					];
+				},
+			});
+		};
+		const timestamp = "2026-06-01T00:00:00.000Z";
+		const targetSessionFile = path.join(tempDir, "resume-ui-dynamic.jsonl");
+		await Bun.write(
+			targetSessionFile,
+			`${[
+				{ type: "session", version: 3, id: "resume-ui-dynamic", timestamp, cwd: tempDir },
+				{
+					type: "model_change",
+					id: "default",
+					parentId: null,
+					timestamp,
+					model: "other-ui-runtime-provider/other-ui-model-thinking",
+					role: "default",
+				},
+				{
+					type: "model_change",
+					id: "smol",
+					parentId: "default",
+					timestamp,
+					model: "ui-runtime-provider/saved-ui-model",
+					role: "smol",
+				},
+			]
+				.map(entry => JSON.stringify(entry))
+				.join("\n")}\n`,
+		);
+		const sessionManager = await SessionManager.open(targetSessionFile, path.join(tempDir, "sessions-ui-dynamic"));
+		const result = await createAgentSession({
+			cwd: tempDir,
+			agentDir: tempDir,
+			authStorage,
+			modelRegistry,
+			sessionManager,
+			settings: Settings.isolated(),
+			disableExtensionDiscovery: true,
+			extensions: [extension],
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+			skipPythonPreflight: true,
+			rules: [],
+			preloadedCustomToolPaths: [],
+			toolNames: ["read"],
+			hasUI: true,
+		});
+
+		try {
+			expect(result.session.model?.provider).toBe("other-ui-runtime-provider");
+			expect(result.session.model?.id).toBe("other-ui-model");
+			expect(targetedFetches).toBe(1);
+			expect(unrelatedFetches).toBe(1);
+			await result.startBackgroundModelDiscovery?.();
+			expect(targetedFetches).toBe(2);
+			expect(unrelatedFetches).toBe(1);
+			expect(modelRegistry.find("ui-runtime-provider", "saved-ui-model")).toBeDefined();
+			expect(modelRegistry.find("other-ui-runtime-provider", "other-ui-model")).toBeDefined();
+			expect(modelRegistry.find("other-ui-runtime-provider", "other-ui-model-thinking")?.id).toBe("other-ui-model");
+		} finally {
+			await result.session.dispose();
 			authStorage.close();
 		}
 	});


### PR DESCRIPTION
## What

Fixes extension-provided dynamic models remaining unavailable from `/switch` after login ([#5780](https://github.com/can1357/oh-my-pi/issues/5780)).

## Why

An unauthenticated discovery could cache an authoritative empty catalog. The normal post-login `online-if-uncached` refresh then reused that entry instead of rediscovering with the new credential.

Runtime extension catalogs can be credential- and account-specific. Persisting them requires a durable, verified account identity that the extension callback contract does not provide safely.

## Behavior

- Extension `fetchDynamicModels` catalogs always rediscover online, including the normal refresh after login.
- They are never persisted to or restored from SQLite across application restarts.
- An offline `/switch` refresh preserves models already discovered in the current process; a fresh offline process exposes none.
- Re-registering or unregistering an extension removes its old in-memory and persisted catalog, including an in-flight discovery result.
- Provider-wide headers still compose for live discovery; cache rows never serialize runtime credentials or headers.
- Existing generic/built-in v12 cache rows remain usable. Legacy v13 credential-scoped rows are removed with WAL cleanup.

## Testing

- `bun test packages/coding-agent/test/issue-5780-repro.test.ts` — 5 passed
- `bun test packages/catalog/test/build.test.ts` — 57 passed
- `bun run --cwd packages/coding-agent check`

---

- [x] Relevant package check passes
- [x] Tested locally
- [x] CHANGELOG updated