### PR TITLE
fix(builtins): implement POSIX BRE semantics in grep, guard sed and ERE

### DIFF
--- a/crates/pi-builtins/Cargo.toml
+++ b/crates/pi-builtins/Cargo.toml
@@ -302,6 +302,8 @@ base = [
 "util.base32" = []
 "util.base64" = ["util.base32"]
 "util.basename" = []
+# Shared POSIX BRE translation behind grep/sed.
+"util.bre" = []
 "util.cat" = []
 "util.cksum" = []
 "util.cmp" = []
@@ -312,7 +314,7 @@ base = [
 "util.dirname" = []
 "util.fd" = []
 "util.find" = []
-"util.grep" = []
+"util.grep" = ["util.bre"]
 "util.head" = []
 "util.hostname" = []
 "util.jq" = []
@@ -348,7 +350,7 @@ base = [
 # Shares the PCRE2 JIT probe with `grep`.
 "util.rg" = ["util.grep"]
 "util.rm" = []
-"util.sed" = []
+"util.sed" = ["util.bre"]
 "util.seq" = []
 "util.sha1sum" = ["util.cksum"]
 "util.sha224sum" = ["util.cksum"]
@@ -376,6 +378,7 @@ utils = [
   "util.base32",
   "util.base64",
   "util.basename",
+  "util.bre",
   "util.cat",
   "util.cksum",
   "util.cmp",

--- a/crates/pi-builtins/src/bre.rs
+++ b/crates/pi-builtins/src/bre.rs
@@ -52,7 +52,6 @@ pub(crate) fn bre_to_ere(pattern: &str, backrefs: Backrefs) -> Result<String, Br
 	let mut result = String::with_capacity(pattern.len());
 	let mut chars = pattern.chars().peekable();
 
-	let mut previous: Option<char> = None;
 	// Whether something repeatable precedes the current position. False at the
 	// start of the pattern and directly after `\(` or `\|`, which are exactly
 	// the positions where a repetition character is not an operator and where
@@ -159,6 +158,24 @@ pub(crate) fn bre_to_ere(pattern: &str, backrefs: Backrefs) -> Result<String, Br
 			}
 		} else {
 			match c {
+				'[' => {
+					// A bracket expression is NOT BRE syntax: inside it, `\`,
+					// `(`, `|` and `*` are ordinary characters. Translating
+					// through it turned `[\(]` into a group opener and broke
+					// compilation, so the whole expression is scanned as
+					// bracket syntax and copied across.
+					match take_bracket_expression(&mut chars) {
+						Some(body) => {
+							result.push('[');
+							result.push_str(&body);
+						},
+						// Unterminated. Measured, both tools reject it -
+						// "brackets ([ ]) not balanced" - so the half-open
+						// `[` is passed through for the engine to refuse.
+						None => result.push('['),
+					}
+					has_atom = true;
+				},
 				'+' | '?' | '{' | '}' | '|' | '(' | ')' => {
 					// Escape unsupported ERE metacharacters.
 					result.push('\\');
@@ -173,7 +190,7 @@ pub(crate) fn bre_to_ere(pattern: &str, backrefs: Backrefs) -> Result<String, Br
 						has_atom = true;
 					}
 				},
-				'^' if (has_atom || anchored) && previous != Some('[') => {
+				'^' if has_atom || anchored => {
 					// In a BRE `^` is an ANCHOR only at the start of a branch -
 					// the start of the pattern, or directly after `\(` or `\|` -
 					// and only ONCE there. Anywhere else, including a second
@@ -194,8 +211,8 @@ pub(crate) fn bre_to_ere(pattern: &str, backrefs: Backrefs) -> Result<String, Br
 					result.push(c);
 					has_atom = true;
 				},
-				'$' if chars.peek().is_some() => {
-					// Similarly for $ appearing not at the end.
+				'$' if !ends_branch(&chars) => {
+					// Similarly for `$` appearing not at the end of a branch.
 					result.push('\\');
 					result.push(c);
 					has_atom = true;
@@ -213,10 +230,79 @@ pub(crate) fn bre_to_ere(pattern: &str, backrefs: Backrefs) -> Result<String, Br
 				},
 			}
 		}
-		previous = Some(c);
 	}
 
 	Ok(result)
+}
+
+/// Whether the rest of the pattern ends the current branch.
+///
+/// `$` is an anchor at the end of a branch, not only at the end of the whole
+/// pattern: `grep 'a$\|b'` selects lines ending in `a` as well as lines
+/// containing `b`, and the alternation normalization this module replaced
+/// preserved that by leaving `$` untouched. Escaping it here made the first
+/// branch unmatchable and silently dropped those lines.
+///
+/// BSD grep differs - it anchors only at the very end of the pattern - but
+/// `\|` is itself a GNU extension, so GNU decides its semantics.
+fn ends_branch(chars: &std::iter::Peekable<std::str::Chars<'_>>) -> bool {
+	let mut rest = chars.clone();
+	match rest.next() {
+		None => true,
+		Some('\\') => matches!(rest.next(), Some('|' | ')')),
+		Some(_) => false,
+	}
+}
+
+/// Consume a bracket expression's body, returning it without the outer `[]`.
+///
+/// The opening `[` is already consumed. Returns `None` - advancing nothing -
+/// when the expression is unterminated. Inside a bracket expression POSIX
+/// gives `\` no special meaning, so it is doubled on the way out to keep it a
+/// literal for the engine: measured, `grep -c '[\(]'` selects lines holding a
+/// backslash OR a parenthesis.
+fn take_bracket_expression(chars: &mut std::iter::Peekable<std::str::Chars<'_>>) -> Option<String> {
+	let mut probe = chars.clone();
+	let mut body = String::new();
+
+	// A leading `^` negates, and a `]` immediately after that is the literal
+	// `]` rather than the terminator.
+	if probe.peek() == Some(&'^') {
+		body.push(probe.next()?);
+	}
+	if probe.peek() == Some(&']') {
+		body.push_str(r"\]");
+		probe.next();
+	}
+
+	while let Some(c) = probe.next() {
+		match c {
+			']' => {
+				*chars = probe;
+				return Some(body + "]");
+			},
+			// `\` is an ordinary character here; keep it one.
+			'\\' => body.push_str(r"\\"),
+			// `[:alpha:]`, `[.x.]` and `[=x=]` carry their own terminators, so
+			// the `]` that closes them does not close the bracket expression.
+			'[' if matches!(probe.peek(), Some(':' | '.' | '=')) => {
+				let kind = probe.next()?;
+				body.push('[');
+				body.push(kind);
+				let mut previous = None;
+				loop {
+					let next = probe.next()?;
+					body.push(next);
+					if previous == Some(kind) && next == ']' {
+						break;
+					}
+					previous = Some(next);
+				}
+			},
+			_ => body.push(c),
+		}
+	}
+	None
 }
 
 /// True when an ERE contains a repetition operator with nothing to repeat.

--- a/crates/pi-builtins/src/bre.rs
+++ b/crates/pi-builtins/src/bre.rs
@@ -164,7 +164,7 @@ pub(crate) fn bre_to_ere(pattern: &str, backrefs: Backrefs) -> Result<String, Br
 					// through it turned `[\(]` into a group opener and broke
 					// compilation, so the whole expression is scanned as
 					// bracket syntax and copied across.
-					match take_bracket_expression(&mut chars) {
+					match take_bracket_expression(&mut chars, true) {
 						Some(body) => {
 							result.push('[');
 							result.push_str(&body);
@@ -257,11 +257,22 @@ fn ends_branch(chars: &std::iter::Peekable<std::str::Chars<'_>>) -> bool {
 /// Consume a bracket expression's body, returning it without the outer `[]`.
 ///
 /// The opening `[` is already consumed. Returns `None` - advancing nothing -
-/// when the expression is unterminated. Inside a bracket expression POSIX
-/// gives `\` no special meaning, so it is doubled on the way out to keep it a
-/// literal for the engine: measured, `grep -c '[\(]'` selects lines holding a
-/// backslash OR a parenthesis.
-fn take_bracket_expression(chars: &mut std::iter::Peekable<std::str::Chars<'_>>) -> Option<String> {
+/// when the expression is unterminated.
+///
+/// With `normalize`, the body is rewritten so the engine reads it the way
+/// POSIX does: `\` has no special meaning inside a bracket expression, so it
+/// is doubled to stay a literal, and a leading `]` is escaped rather than
+/// closing the expression. Measured, `grep -c '[\(]'` selects lines holding a
+/// backslash OR a parenthesis, and `grep -c '[]x]'` selects lines holding a
+/// bracket or an `x`.
+///
+/// Without it the body is copied verbatim, which is what an already-extended
+/// pattern needs: the caller is only locating the expression so it can skip
+/// over it, and must not change how it matches.
+fn take_bracket_expression(
+	chars: &mut std::iter::Peekable<std::str::Chars<'_>>,
+	normalize: bool,
+) -> Option<String> {
 	let mut probe = chars.clone();
 	let mut body = String::new();
 
@@ -271,7 +282,7 @@ fn take_bracket_expression(chars: &mut std::iter::Peekable<std::str::Chars<'_>>)
 		body.push(probe.next()?);
 	}
 	if probe.peek() == Some(&']') {
-		body.push_str(r"\]");
+		body.push_str(if normalize { r"\]" } else { "]" });
 		probe.next();
 	}
 
@@ -282,7 +293,7 @@ fn take_bracket_expression(chars: &mut std::iter::Peekable<std::str::Chars<'_>>)
 				return Some(body + "]");
 			},
 			// `\` is an ordinary character here; keep it one.
-			'\\' => body.push_str(r"\\"),
+			'\\' => body.push_str(if normalize { r"\\" } else { "\\" }),
 			// `[:alpha:]`, `[.x.]` and `[=x=]` carry their own terminators, so
 			// the `]` that closes them does not close the bracket expression.
 			'[' if matches!(probe.peek(), Some(':' | '.' | '=')) => {
@@ -303,6 +314,62 @@ fn take_bracket_expression(chars: &mut std::iter::Peekable<std::str::Chars<'_>>)
 		}
 	}
 	None
+}
+
+/// Make an ERE's non-interval `{` the literal both real tools treat it as.
+///
+/// POSIX leaves a `{` that opens no interval undefined, and both GNU and BSD
+/// grep take it literally, while the `regex` crate rejects the pattern
+/// outright. Measured against /usr/bin/grep:
+///
+/// ```text
+/// grep -Ec '{a}'    1, literal          regex: "repetition operator missing expression"
+/// grep -Ec 'a{'     2, literal          regex: "repetition quantifier expects a valid decimal"
+/// grep -Ec '{foo'   1, literal          regex: "repetition operator missing expression"
+/// grep -Ec 'a{1,2'  "braces not balanced"   regex: "unclosed counted repetition"
+/// ```
+///
+/// The last line is why this cannot simply escape every brace that fails to
+/// open an interval: an unterminated interval is an ERROR in both tools, and
+/// escaping it would turn a diagnosed mistake into a silent literal match.
+/// A digit after `{` is what separates the two - it marks an attempted
+/// interval, which is left for the engine to accept or reject.
+#[cfg(feature = "util.grep")]
+pub(crate) fn ere_literalize_braces(pattern: &str) -> std::borrow::Cow<'_, str> {
+	if !pattern.contains('{') {
+		return std::borrow::Cow::Borrowed(pattern);
+	}
+
+	let mut result = String::with_capacity(pattern.len());
+	let mut chars = pattern.chars().peekable();
+	let mut rewrote = false;
+
+	while let Some(c) = chars.next() {
+		match c {
+			// An escape already spells out its own meaning; copy the pair.
+			'\\' => {
+				result.push('\\');
+				if let Some(escaped) = chars.next() {
+					result.push(escaped);
+				}
+			},
+			// A brace inside a bracket expression is already a literal.
+			'[' => match take_bracket_expression(&mut chars, false) {
+				Some(body) => {
+					result.push('[');
+					result.push_str(&body);
+				},
+				None => result.push('['),
+			},
+			'{' if !chars.peek().is_some_and(char::is_ascii_digit) => {
+				result.push_str(r"\{");
+				rewrote = true;
+			},
+			_ => result.push(c),
+		}
+	}
+
+	if rewrote { std::borrow::Cow::Owned(result) } else { std::borrow::Cow::Borrowed(pattern) }
 }
 
 /// True when an ERE contains a repetition operator with nothing to repeat.

--- a/crates/pi-builtins/src/bre.rs
+++ b/crates/pi-builtins/src/bre.rs
@@ -1,0 +1,390 @@
+//! Shared POSIX basic-regular-expression translation.
+//!
+//! `grep` and `sed` both accept BREs but compile them with different engines
+//! (`grep-regex` and `fancy-regex` respectively), neither of which implements
+//! BRE syntax. This module converts a BRE into the ERE-compatible form those
+//! engines accept, so the dialect is defined in exactly one place.
+
+/// Whether the target engine supports back-references.
+///
+/// `sed` compiles with `fancy-regex`, which does; `grep` compiles with
+/// `grep-regex` (the `regex` crate), which does not. When back-references are
+/// unsupported the sequence is passed through unchanged, leaving the caller's
+/// own compilation failure to decide what happens next.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[allow(dead_code, reason = "each variant is used by a different utility feature")]
+pub(crate) enum Backrefs {
+	Supported,
+	Unsupported,
+}
+
+/// Convert a primitive BRE pattern to a safe ERE-compatible pattern string.
+/// - Replaces `\(`, `\)`, `\?`, `\+`, `\|`, `\{` and `\}` with `(`, `)`, `?`,
+///   `+`, `|`, `{` and `}`.
+/// - Puts single-digit back-references in non-capturing groups..
+/// - Escapes ERE-only metacharacters: `+ ? { } | ( )`.
+/// - Leaves all other characters as-is.
+///
+/// A repetition character with **no preceding atom** is emitted as a literal,
+/// per POSIX: "an asterisk that is the first character of an RE ... shall lose
+/// its special meaning". The same applies directly after `^`, `\(` or `\|`.
+/// This matters because the target engines accept `^+` and compile it as
+/// `(?:^)+`, which matches the empty string at every line start - so a pattern
+/// meant to find a few lines silently matches all of them.
+pub(crate) fn bre_to_ere(pattern: &str, backrefs: Backrefs) -> String {
+	let mut result = String::with_capacity(pattern.len());
+	let mut chars = pattern.chars().peekable();
+
+	let mut at_beginning = true;
+	let mut previous: Option<char> = None;
+	// Whether something repeatable precedes the current position. False at the
+	// start of the pattern and directly after `^`, `\(` or `\|`.
+	let mut has_atom = false;
+	while let Some(c) = chars.next() {
+		if c == '\\' {
+			match chars.peek() {
+				Some('(') => {
+					chars.next();
+					result.push('('); // Group start
+					has_atom = false;
+				},
+				Some(')') => {
+					chars.next();
+					result.push(')'); // Group end
+					has_atom = true;
+				},
+				Some('?') => {
+					chars.next();
+					if has_atom {
+						result.push('?'); // Quantifier 0 or 1
+					} else {
+						result.push_str(r"\?"); // Nothing to repeat: literal
+						has_atom = true;
+					}
+				},
+				Some('+') => {
+					chars.next();
+					if has_atom {
+						result.push('+'); // Quantifier 1 or more
+					} else {
+						result.push_str(r"\+"); // Nothing to repeat: literal
+						has_atom = true;
+					}
+				},
+				Some('|') => {
+					chars.next();
+					result.push('|'); // Alternation operator
+					has_atom = false;
+				},
+				Some('{') => {
+					chars.next();
+					// Emitted as an operator even with no operand, so the
+					// engine REJECTS the pattern. That is what `grep` and
+					// `sed` both do: measured, `\{1,4\}` with nothing to
+					// repeat is "repetition-operator operand invalid", not
+					// a literal brace. Degrading it to a literal here would
+					// replace a correct error with a silent wrong match.
+					result.push('{'); // Brace quantifier start
+				},
+				Some('}') => {
+					chars.next();
+					result.push('}'); // Brace quantifier end
+					has_atom = true;
+				},
+				Some(v) if v.is_ascii_digit() => {
+					// Back-reference.  In sed BREs these are single-digit
+					// (\1-\9) whereas fancy_regex supports multi-digit
+					// back-references. Put them in a non-capturing group
+					// to avoid having the number extend beyond the single
+					// digit. Example: In sed \11 matches group 1 followed
+					// by '1', not group 11.
+					let v = *v;
+					chars.next();
+					match backrefs {
+						Backrefs::Supported => result.push_str(&format!(r"(?:\{v})")),
+						Backrefs::Unsupported => {
+							result.push('\\');
+							result.push(v);
+						},
+					}
+					has_atom = true;
+				},
+				Some(&next) => {
+					// Preserve other escaped characters.
+					chars.next();
+					result.push('\\');
+					result.push(next);
+					has_atom = true;
+				},
+				None => {
+					// Trailing backslash; keep it.
+					result.push('\\');
+					has_atom = true;
+				},
+			}
+		} else {
+			match c {
+				'+' | '?' | '{' | '}' | '|' | '(' | ')' => {
+					// Escape unsupported ERE metacharacters.
+					result.push('\\');
+					result.push(c);
+					has_atom = true;
+				},
+				'*' => {
+					if has_atom {
+						result.push('*'); // Quantifier 0 or more
+					} else {
+						result.push_str(r"\*"); // Nothing to repeat: literal
+						has_atom = true;
+					}
+				},
+				'^' if !at_beginning && previous != Some('[') => {
+					// In BREs ^ has special meaning at the beginning
+					// and as bracket negation.  This heuristic escapes
+					// all other uses, which per POSIX are valid in EREs.
+					// "the ERE "a^b" is valid, but can never match because
+					// the 'a' prevents the expression "^b" from matching
+					// starting at the first character."
+					// POSIX 9.4.9 ERE Expression Anchoring
+					result.push('\\');
+					result.push(c);
+					has_atom = true;
+				},
+				'$' if chars.peek().is_some() => {
+					// Similarly for $ appearing not at the end.
+					result.push('\\');
+					result.push(c);
+					has_atom = true;
+				},
+				// An anchor is not an atom: `^` leaves `has_atom` as it found
+				// it, so `^*` sees no operand while `[^x]*` still quantifies
+				// the bracket expression.
+				'^' | '$' => result.push(c),
+				_ => {
+					result.push(c);
+					has_atom = true;
+				},
+			}
+		}
+		at_beginning = false;
+		previous = Some(c);
+	}
+
+	result
+}
+
+/// True when an ERE contains a repetition operator with nothing to repeat.
+///
+/// POSIX leaves this undefined and both GNU and BSD grep reject it:
+/// `grep -E '^+'` is "repetition-operator operand invalid". The `regex` crate
+/// instead compiles `^+` as `(?:^)+`, which matches the empty string at every
+/// line start, so without this check an invalid pattern silently selects every
+/// line - a wrong answer with a success exit status.
+#[cfg(feature = "util.grep")]
+pub(crate) fn ere_repetition_operand_missing(pattern: &str) -> bool {
+	let mut chars = pattern.chars().peekable();
+	let mut has_atom = false;
+	while let Some(c) = chars.next() {
+		match c {
+			// An escaped character is a literal, and therefore an atom.
+			'\\' => {
+				if chars.next().is_none() {
+					return false;
+				}
+				has_atom = true;
+			},
+			// A bracket expression is one atom. `]` immediately after the
+			// opening bracket (or its negation) is a literal, not the close.
+			'[' => {
+				if chars.peek() == Some(&'^') {
+					chars.next();
+				}
+				if chars.peek() == Some(&']') {
+					chars.next();
+				}
+				for inner in chars.by_ref() {
+					if inner == ']' {
+						break;
+					}
+				}
+				has_atom = true;
+			},
+			'(' | '|' => has_atom = false,
+			')' => has_atom = true,
+			// Anchors are not atoms: they leave the operand state alone, so
+			// `^*` has nothing to repeat while `[^x]*` still quantifies the
+			// bracket expression.
+			'^' | '$' => {},
+			'*' | '+' | '?' | '{' if !has_atom => return true,
+			_ => has_atom = true,
+		}
+	}
+	false
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	fn ere(pattern: &str) -> String {
+		bre_to_ere(pattern, Backrefs::Supported)
+	}
+
+	// Relocated from `sed`, which owned this translation before `grep` shared it.
+
+	#[test]
+	fn test_bre_group_translation() {
+		assert_eq!(ere(r"\(a\?b\+c\|\)"), "(a?b+c|)");
+		assert_eq!(ere(r"a\(b\)c"), "a(b)c");
+	}
+
+	#[test]
+	fn test_bre_brace_quantifier_translation() {
+		assert_eq!(ere(r"\{1,4\}"), "{1,4}");
+	}
+
+	#[test]
+	fn test_ere_metacharacters_escaped() {
+		assert_eq!(ere(r"a+b?c{1}|(d)"), r"a\+b\?c\{1\}\|\(d\)");
+	}
+
+	#[test]
+	fn test_literal_backslashes_preserved() {
+		assert_eq!(ere(r"foo\\bar"), r"foo\\bar");
+		assert_eq!(ere(r"\."), r"\.");
+	}
+
+	#[test]
+	fn test_character_classes_unchanged() {
+		assert_eq!(ere(r"[a-z]"), "[a-z]");
+		assert_eq!(ere(r"[^0-9]"), "[^0-9]");
+	}
+
+	#[test]
+	fn test_anchors_and_dot_and_star() {
+		assert_eq!(ere(r"^a.*b$"), "^a.*b$");
+	}
+
+	#[test]
+	fn test_trailing_backslash_is_preserved() {
+		assert_eq!(ere(r"abc\"), r"abc\");
+	}
+
+	#[test]
+	fn test_caret_escaped_in_middle() {
+		assert_eq!(ere(r"^a^[^x]c"), r"^a\^[^x]c");
+	}
+
+	#[test]
+	fn test_dollar_escaped_in_middle() {
+		assert_eq!(ere(r"a$c$"), r"a\$c$");
+	}
+
+	#[test]
+	fn test_bre_back_reference() {
+		assert_eq!(ere(r"\(.\)\1\(.\)\2"), r"(.)(?:\1)(.)(?:\2)");
+	}
+
+	#[test]
+	fn back_references_pass_through_when_the_engine_does_not() {
+		assert_eq!(bre_to_ere(r"\(a\)\1", Backrefs::Unsupported), r"(a)\1");
+	}
+
+	// ── Repetition operators with no preceding atom ──────────────────────────
+	// POSIX BRE: a repetition character with nothing to repeat is a LITERAL.
+	// Emitting it as an operator lets the Rust engine compile `^+` as `(?:^)+`,
+	// which matches the empty string at every line start - so the pattern
+	// silently matches EVERY line instead of the intended few.
+
+	#[test]
+	fn escaped_plus_at_pattern_start_is_a_literal() {
+		assert_eq!(ere(r"\+"), r"\+");
+	}
+
+	#[test]
+	fn escaped_plus_after_anchor_is_a_literal() {
+		assert_eq!(ere(r"^\+"), r"^\+");
+	}
+
+	#[test]
+	fn escaped_question_after_anchor_is_a_literal() {
+		assert_eq!(ere(r"^\?"), r"^\?");
+	}
+
+	#[test]
+	fn escaped_brace_quantifier_with_no_operand_stays_an_operator() {
+		// Deliberately NOT a literal. `grep` and `sed` both reject
+		// `\{1,4\}` with nothing to repeat rather than matching a brace, so
+		// the operator is emitted and the engine refuses the pattern.
+		assert_eq!(ere(r"^\{2\}"), r"^{2}");
+		assert_eq!(ere(r"\{1,4\}"), r"{1,4}");
+	}
+
+	#[test]
+	fn bare_star_at_pattern_start_is_a_literal() {
+		assert_eq!(ere(r"*x"), r"\*x");
+	}
+
+	#[test]
+	fn bare_star_after_anchor_is_a_literal() {
+		assert_eq!(ere(r"^*"), r"^\*");
+	}
+
+	#[test]
+	fn repetition_after_group_open_is_a_literal() {
+		assert_eq!(ere(r"\(\+a\)"), r"(\+a)");
+		assert_eq!(ere(r"\(*a\)"), r"(\*a)");
+	}
+
+	#[test]
+	fn repetition_after_alternation_is_a_literal() {
+		assert_eq!(ere(r"a\|\+b"), r"a|\+b");
+	}
+
+	// The operator cases these must not break.
+
+	#[test]
+	fn repetition_with_an_operand_stays_an_operator() {
+		assert_eq!(ere(r"a\+"), r"a+");
+		assert_eq!(ere(r"a\?"), r"a?");
+		assert_eq!(ere(r"a\{2\}"), r"a{2}");
+		assert_eq!(ere(r"a*"), r"a*");
+		assert_eq!(ere(r"^a\+"), r"^a+");
+		assert_eq!(ere(r"\(a\)\+"), r"(a)+");
+		assert_eq!(ere(r"[a-z]\+"), r"[a-z]+");
+		assert_eq!(ere(r".\+"), r".+");
+	}
+
+	// ── ERE operand validation ───────────────────────────────────────────────
+
+	#[cfg(feature = "util.grep")]
+	#[test]
+	fn ere_rejects_repetition_with_no_operand() {
+		for pattern in ["^+", "^*", "^?", "^{2}", "*x", "+", "(+)", "a|+b", "(|+)"] {
+			assert!(ere_repetition_operand_missing(pattern), "should reject {pattern}");
+		}
+	}
+
+	#[cfg(feature = "util.grep")]
+	#[test]
+	fn ere_accepts_repetition_with_an_operand() {
+		for pattern in [
+			"a+",
+			"^a+",
+			"a{2}",
+			"[a-z]+",
+			".*",
+			r"\++",     // an escaped plus is a literal, so it IS an operand
+			"[^x]*",    // negated class, not an anchor
+			"[]]*",     // `]` first in a class is a literal
+			"[^]]*",    // and after a negation too
+			"(a)+",
+			"a|b+",
+			"$",
+			r"\\",
+			r"a\",      // trailing backslash: not our error to report
+		] {
+			assert!(!ere_repetition_operand_missing(pattern), "should accept {pattern}");
+		}
+	}
+}

--- a/crates/pi-builtins/src/bre.rs
+++ b/crates/pi-builtins/src/bre.rs
@@ -18,6 +18,23 @@ pub(crate) enum Backrefs {
 	Unsupported,
 }
 
+/// A pattern the BRE dialect cannot express.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum BreError {
+	/// A repetition operator with nothing to repeat, where the tools error
+	/// rather than treating the character as a literal.
+	RepetitionOperandMissing,
+}
+
+impl BreError {
+	/// The message GNU and BSD grep both use for this condition.
+	pub(crate) fn message(self) -> &'static str {
+		match self {
+			Self::RepetitionOperandMissing => "repetition-operator operand invalid",
+		}
+	}
+}
+
 /// Convert a primitive BRE pattern to a safe ERE-compatible pattern string.
 /// - Replaces `\(`, `\)`, `\?`, `\+`, `\|`, `\{` and `\}` with `(`, `)`, `?`,
 ///   `+`, `|`, `{` and `}`.
@@ -31,14 +48,15 @@ pub(crate) enum Backrefs {
 /// This matters because the target engines accept `^+` and compile it as
 /// `(?:^)+`, which matches the empty string at every line start - so a pattern
 /// meant to find a few lines silently matches all of them.
-pub(crate) fn bre_to_ere(pattern: &str, backrefs: Backrefs) -> String {
+pub(crate) fn bre_to_ere(pattern: &str, backrefs: Backrefs) -> Result<String, BreError> {
 	let mut result = String::with_capacity(pattern.len());
 	let mut chars = pattern.chars().peekable();
 
-	let mut at_beginning = true;
 	let mut previous: Option<char> = None;
 	// Whether something repeatable precedes the current position. False at the
-	// start of the pattern and directly after `^`, `\(` or `\|`.
+	// start of the pattern and directly after `\(` or `\|`, which are exactly
+	// the positions where a repetition character is not an operator and where
+	// `^` IS an anchor. One piece of state answers both questions.
 	let mut has_atom = false;
 	while let Some(c) = chars.next() {
 		if c == '\\' {
@@ -78,12 +96,21 @@ pub(crate) fn bre_to_ere(pattern: &str, backrefs: Backrefs) -> String {
 				},
 				Some('{') => {
 					chars.next();
-					// Emitted as an operator even with no operand, so the
-					// engine REJECTS the pattern. That is what `grep` and
-					// `sed` both do: measured, `\{1,4\}` with nothing to
-					// repeat is "repetition-operator operand invalid", not
-					// a literal brace. Degrading it to a literal here would
-					// replace a correct error with a silent wrong match.
+					// A brace quantifier with nothing to repeat is an ERROR in
+					// both tools, not a literal brace: measured,
+					// `grep '\{1,4\}'` and `sed 's/\{1,3\}/X/'` each report
+					// "repetition-operator operand invalid".
+					//
+					// It cannot simply be emitted as an operator and left to
+					// the engine. `^\{1,4\}` becomes `^{1,4}`, which BOTH
+					// engines accept as `(?:^){1,4}` - matching the empty
+					// string at every line start, so the pattern silently
+					// selects every line with a success exit status. That is
+					// the same fail-open this module exists to close, and it
+					// has to be refused here because no later layer sees it.
+					if !has_atom {
+						return Err(BreError::RepetitionOperandMissing);
+					}
 					result.push('{'); // Brace quantifier start
 				},
 				Some('}') => {
@@ -138,17 +165,22 @@ pub(crate) fn bre_to_ere(pattern: &str, backrefs: Backrefs) -> String {
 						has_atom = true;
 					}
 				},
-				'^' if !at_beginning && previous != Some('[') => {
-					// In BREs ^ has special meaning at the beginning
-					// and as bracket negation.  This heuristic escapes
-					// all other uses, which per POSIX are valid in EREs.
+				'^' if has_atom && previous != Some('[') => {
+					// In a BRE `^` is an ANCHOR at the start of the pattern and
+					// directly after `\(` or `\|`, and a literal anywhere else.
+					// Those are exactly the positions where no atom precedes,
+					// so `has_atom` already distinguishes them - measured,
+					// `grep '\(^alpha\)'` matches on GNU and BSD grep, and
+					// keying this off `at_beginning` instead escaped the
+					// anchor and matched nothing.
+					//
+					// Escaping the literal uses is valid in an ERE:
 					// "the ERE "a^b" is valid, but can never match because
 					// the 'a' prevents the expression "^b" from matching
 					// starting at the first character."
 					// POSIX 9.4.9 ERE Expression Anchoring
 					result.push('\\');
 					result.push(c);
-					has_atom = true;
 				},
 				'$' if chars.peek().is_some() => {
 					// Similarly for $ appearing not at the end.
@@ -166,11 +198,10 @@ pub(crate) fn bre_to_ere(pattern: &str, backrefs: Backrefs) -> String {
 				},
 			}
 		}
-		at_beginning = false;
 		previous = Some(c);
 	}
 
-	result
+	Ok(result)
 }
 
 /// True when an ERE contains a repetition operator with nothing to repeat.
@@ -215,11 +246,49 @@ pub(crate) fn ere_repetition_operand_missing(pattern: &str) -> bool {
 			// `^*` has nothing to repeat while `[^x]*` still quantifies the
 			// bracket expression.
 			'^' | '$' => {},
-			'*' | '+' | '?' | '{' if !has_atom => return true,
+			'*' | '+' | '?' if !has_atom => return true,
+			// A `{` is only a repetition operator when it actually opens an
+			// interval. Measured: `grep -E '^{'` matches nothing and reports
+			// no error, because a `{` that cannot be parsed as `{n}`, `{n,}`
+			// or `{n,m}` is an ordinary literal - while `grep -E '{1}'` IS
+			// "repetition-operator operand invalid". Flagging every `{` here
+			// rejected patterns the real tool accepts.
+			'{' => {
+				let rest: String = chars.clone().collect();
+				if opens_interval(&rest) {
+					if !has_atom {
+						return true;
+					}
+				} else {
+					has_atom = true;
+				}
+			},
 			_ => has_atom = true,
 		}
 	}
 	false
+}
+
+/// Whether `rest`, the text just past a `{`, completes a valid interval:
+/// `n}`, `n,}` or `n,m}`. Anything else leaves the `{` a literal.
+#[cfg(feature = "util.grep")]
+fn opens_interval(rest: &str) -> bool {
+	let mut chars = rest.chars().peekable();
+	let mut digits = 0usize;
+	while chars.peek().is_some_and(char::is_ascii_digit) {
+		chars.next();
+		digits += 1;
+	}
+	if digits == 0 {
+		return false;
+	}
+	if chars.peek() == Some(&',') {
+		chars.next();
+		while chars.peek().is_some_and(char::is_ascii_digit) {
+			chars.next();
+		}
+	}
+	chars.next() == Some('}')
 }
 
 #[cfg(test)]
@@ -227,7 +296,11 @@ mod tests {
 	use super::*;
 
 	fn ere(pattern: &str) -> String {
-		bre_to_ere(pattern, Backrefs::Supported)
+		bre_to_ere(pattern, Backrefs::Supported).expect("translatable")
+	}
+
+	fn ere_err(pattern: &str) -> Option<BreError> {
+		bre_to_ere(pattern, Backrefs::Supported).err()
 	}
 
 	// Relocated from `sed`, which owned this translation before `grep` shared it.
@@ -240,7 +313,8 @@ mod tests {
 
 	#[test]
 	fn test_bre_brace_quantifier_translation() {
-		assert_eq!(ere(r"\{1,4\}"), "{1,4}");
+		assert_eq!(ere(r"a\{1,4\}"), "a{1,4}");
+		assert_eq!(ere(r"\(a\)\{1,4\}"), "(a){1,4}");
 	}
 
 	#[test]
@@ -287,7 +361,22 @@ mod tests {
 
 	#[test]
 	fn back_references_pass_through_when_the_engine_does_not() {
-		assert_eq!(bre_to_ere(r"\(a\)\1", Backrefs::Unsupported), r"(a)\1");
+		// THE FALLBACK CONTRACT, stated because `grep` depends on it.
+		//
+		// `grep-regex` cannot compile a back-reference at all. Rather than
+		// inventing a translation, the sequence is emitted unchanged, so the
+		// pattern fails to compile and `grep`'s `build_default_matcher`
+		// escapes it and matches it LITERALLY - which is exactly what
+		// happened before this module existed. The behaviour is unchanged by
+		// the refactor; it is not an endorsement of matching `\1` literally.
+		assert_eq!(
+			bre_to_ere(r"\(a\)\1", Backrefs::Unsupported).expect("translatable"),
+			r"(a)\1"
+		);
+		// The grouping exists only for engines that support them, where a
+		// bare `\11` would otherwise read as group 11 instead of group 1
+		// followed by a literal '1'.
+		assert_eq!(ere(r"\(a\)\11"), r"(a)(?:\1)1");
 	}
 
 	// ── Repetition operators with no preceding atom ──────────────────────────
@@ -312,12 +401,30 @@ mod tests {
 	}
 
 	#[test]
-	fn escaped_brace_quantifier_with_no_operand_stays_an_operator() {
-		// Deliberately NOT a literal. `grep` and `sed` both reject
-		// `\{1,4\}` with nothing to repeat rather than matching a brace, so
-		// the operator is emitted and the engine refuses the pattern.
-		assert_eq!(ere(r"^\{2\}"), r"^{2}");
-		assert_eq!(ere(r"\{1,4\}"), r"{1,4}");
+	fn escaped_brace_quantifier_with_no_operand_is_rejected() {
+		// Neither a literal nor an operator: an ERROR, which is what both
+		// tools do. Emitting the operator and leaving it to the engine was
+		// measurably wrong - `^{2}` and `^{1,4}` COMPILE as `(?:^){2}`, which
+		// matches at every line start, so the pattern silently selected the
+		// whole file with exit 0.
+		assert_eq!(ere_err(r"^\{2\}"), Some(BreError::RepetitionOperandMissing));
+		assert_eq!(ere_err(r"\{1,4\}"), Some(BreError::RepetitionOperandMissing));
+		assert_eq!(ere_err(r"\(\{2\}\)"), Some(BreError::RepetitionOperandMissing));
+		assert_eq!(ere_err(r"a\|\{2\}"), Some(BreError::RepetitionOperandMissing));
+		// With an operand it is an ordinary quantifier.
+		assert_eq!(ere_err(r"a\{2\}"), None);
+	}
+
+	#[test]
+	fn caret_is_an_anchor_after_group_open_and_alternation() {
+		// Measured: `grep '\(^alpha\)'` matches on GNU and BSD grep. Keying
+		// this off "start of pattern" escaped the anchor and matched nothing.
+		assert_eq!(ere(r"\(^a\)"), r"(^a)");
+		assert_eq!(ere(r"a\|^b"), r"a|^b");
+		assert_eq!(ere(r"\(^a\|^b\)"), r"(^a|^b)");
+		// Still a literal where an atom precedes it.
+		assert_eq!(ere(r"a^b"), r"a\^b");
+		assert_eq!(ere(r"^a^"), r"^a\^");
 	}
 
 	#[test]
@@ -383,8 +490,26 @@ mod tests {
 			"$",
 			r"\\",
 			r"a\",      // trailing backslash: not our error to report
+			// A `{` that opens no interval is a LITERAL, not an operator.
+			// Measured: `grep -E '^{'` and `grep -E '{a}'` match nothing and
+			// report no error, while `grep -E '{1}'` IS invalid. Rejecting
+			// every `{` refused patterns the real tool accepts.
+			"^{",
+			"{",
+			"{a}",
+			"{,5}",
+			"^{}",
+			"{1a}",
 		] {
 			assert!(!ere_repetition_operand_missing(pattern), "should accept {pattern}");
+		}
+	}
+
+	#[cfg(feature = "util.grep")]
+	#[test]
+	fn ere_rejects_only_intervals_that_really_open() {
+		for pattern in ["{1}", "^{2}", "{3,}", "{4,5}", "(|{6})"] {
+			assert!(ere_repetition_operand_missing(pattern), "should reject {pattern}");
 		}
 	}
 }

--- a/crates/pi-builtins/src/bre.rs
+++ b/crates/pi-builtins/src/bre.rs
@@ -58,6 +58,12 @@ pub(crate) fn bre_to_ere(pattern: &str, backrefs: Backrefs) -> Result<String, Br
 	// the positions where a repetition character is not an operator and where
 	// `^` IS an anchor. One piece of state answers both questions.
 	let mut has_atom = false;
+	// Whether a branch-start `^` has already been consumed as an anchor. Only
+	// the FIRST caret of a branch anchors: measured, `grep -c '^^'` counts
+	// lines beginning with a literal caret and `sed 's/^^/X/'` rewrites only
+	// those, so a second caret is an ordinary character. Keyed off `has_atom`
+	// alone, both carets became zero-width anchors and every line matched.
+	let mut anchored = false;
 	while let Some(c) = chars.next() {
 		if c == '\\' {
 			match chars.peek() {
@@ -65,6 +71,7 @@ pub(crate) fn bre_to_ere(pattern: &str, backrefs: Backrefs) -> Result<String, Br
 					chars.next();
 					result.push('('); // Group start
 					has_atom = false;
+					anchored = false;
 				},
 				Some(')') => {
 					chars.next();
@@ -93,6 +100,7 @@ pub(crate) fn bre_to_ere(pattern: &str, backrefs: Backrefs) -> Result<String, Br
 					chars.next();
 					result.push('|'); // Alternation operator
 					has_atom = false;
+					anchored = false;
 				},
 				Some('{') => {
 					chars.next();
@@ -165,14 +173,17 @@ pub(crate) fn bre_to_ere(pattern: &str, backrefs: Backrefs) -> Result<String, Br
 						has_atom = true;
 					}
 				},
-				'^' if has_atom && previous != Some('[') => {
-					// In a BRE `^` is an ANCHOR at the start of the pattern and
-					// directly after `\(` or `\|`, and a literal anywhere else.
-					// Those are exactly the positions where no atom precedes,
-					// so `has_atom` already distinguishes them - measured,
-					// `grep '\(^alpha\)'` matches on GNU and BSD grep, and
-					// keying this off `at_beginning` instead escaped the
-					// anchor and matched nothing.
+				'^' if (has_atom || anchored) && previous != Some('[') => {
+					// In a BRE `^` is an ANCHOR only at the start of a branch -
+					// the start of the pattern, or directly after `\(` or `\|` -
+					// and only ONCE there. Anywhere else, including a second
+					// caret at the same branch start, it is a literal.
+					//
+					// Measured: `grep '\(^alpha\)'` matches on GNU and BSD grep,
+					// so start-of-pattern is the wrong test; and `grep -c '^^'`
+					// counts lines beginning with a caret while
+					// `sed 's/^^/X/'` rewrites only those, so the second caret
+					// is not a second anchor.
 					//
 					// Escaping the literal uses is valid in an ERE:
 					// "the ERE "a^b" is valid, but can never match because
@@ -181,6 +192,7 @@ pub(crate) fn bre_to_ere(pattern: &str, backrefs: Backrefs) -> Result<String, Br
 					// POSIX 9.4.9 ERE Expression Anchoring
 					result.push('\\');
 					result.push(c);
+					has_atom = true;
 				},
 				'$' if chars.peek().is_some() => {
 					// Similarly for $ appearing not at the end.
@@ -188,10 +200,13 @@ pub(crate) fn bre_to_ere(pattern: &str, backrefs: Backrefs) -> Result<String, Br
 					result.push(c);
 					has_atom = true;
 				},
-				// An anchor is not an atom: `^` leaves `has_atom` as it found
-				// it, so `^*` sees no operand while `[^x]*` still quantifies
-				// the bracket expression.
-				'^' | '$' => result.push(c),
+				// A branch-start anchor. It is not an atom, so `^*` still sees
+				// no operand, but it is consumed: the next caret is a literal.
+				'^' => {
+					result.push(c);
+					anchored = true;
+				},
+				'$' => result.push(c),
 				_ => {
 					result.push(c);
 					has_atom = true;

--- a/crates/pi-builtins/src/grep.rs
+++ b/crates/pi-builtins/src/grep.rs
@@ -1875,5 +1875,58 @@ mod tests {
 		assert_eq!(code, 0, "{err}");
 		assert_eq!(out, "2\n", "the escaped form must agree with the bare one");
 	}
+
+	#[test]
+	fn a_dollar_before_a_branch_boundary_still_anchors() {
+		// `$` anchors at the end of a BRE BRANCH, not only at the end of the
+		// whole pattern. Escaping it made the first branch unmatchable, so
+		// lines ending in `a` were silently dropped from the result.
+		let input = "a\nb\nca\nxb\nz\nax\n";
+		let (code, out, err) = run(&["-c", r"a$\|b"], input);
+		assert_eq!(code, 0, "{err}");
+		assert_eq!(out, "4\n", "a, b, ca and xb all match");
+
+		// The same alternation written the other way round must agree.
+		let (_, out, err) = run(&["-c", r"b\|a$"], input);
+		assert_eq!(out, "4\n", "{err}");
+
+		// And inside a group, where `\)` ends the branch instead of `\|`.
+		let (_, out, err) = run(&["-c", r"\(a$\)"], input);
+		assert_eq!(out, "2\n", "{err}");
+
+		// A `$` that ends neither is still a literal dollar sign.
+		let (_, out, err) = run(&["-c", "a$b"], "a$b\nab\n");
+		assert_eq!(out, "1\n", "{err}");
+	}
+
+	#[test]
+	fn bracket_expressions_are_not_translated_as_bre() {
+		// Inside `[...]` the BRE operators are ordinary characters. The
+		// translator used to read `\(` as a group opener, producing a pattern
+		// the engine refused, which then fell back to a literal match.
+		let input = "has ( paren\nhas \\ slash\nplain\n";
+		let (code, out, err) = run(&["-c", r"[\(]"], input);
+		assert_eq!(code, 0, "{err}");
+		assert_eq!(out, "2\n", "a backslash OR a parenthesis, as measured");
+
+		// `]` first is a literal, `^` still negates, and a character class
+		for (pattern, want) in
+			[(r"[]x]", "1\n"), (r"[^abc]", "3\n"), (r"[[:digit:]]", "1\n"), (r"[*+]", "1\n")]
+		{
+			let (code, out, err) = run(&["-c", pattern], "]\nq7\n*\nabc\n");
+			assert_eq!(code, 0, "{pattern}: {err}");
+			assert_eq!(out, want, "{pattern}");
+		}
+
+		// An unterminated bracket expression is not silently swallowed as an
+		// empty class: the engine refuses it. In `grep` it then reaches the
+		// pre-existing literal fallback - the same path back-references take -
+		// so it matches the typed text rather than erroring the way real grep
+		// does. That divergence predates this change and is unchanged by it;
+		// `sed`, which has no such fallback, reports the error.
+		let (code, out, err) = run(&["-c", "a[d"], "a[d\nplain\n");
+		assert_eq!(code, 0, "{err}");
+		assert_eq!(out, "1\n", "falls back to the literal text the user typed");
+	}
 }
 

--- a/crates/pi-builtins/src/grep.rs
+++ b/crates/pi-builtins/src/grep.rs
@@ -4,7 +4,6 @@
 
 
 use std::{
-	borrow::Cow,
 	ffi::{OsStr, OsString},
 	fs::File,
 	io::{self, Read, Write},
@@ -20,6 +19,7 @@ use grep_regex::{RegexMatcher, RegexMatcherBuilder};
 use grep_searcher::{
 	BinaryDetection, Searcher, SearcherBuilder, Sink, SinkContext, SinkFinish, SinkMatch,
 };
+use crate::bre;
 use crate::host::{Host, Utility, util};
 
 /// PCRE2 JIT toggle: `OMP_PCRE2_JIT=1` forces JIT on, `0`/`false` forces it
@@ -603,52 +603,6 @@ fn escape_literal(pat: &str) -> String {
 	out
 }
 
-/// Translate GNU BRE `\|` alternation into the syntax accepted by
-/// `grep-regex`, without rewriting escaped pipes inside character classes.
-fn normalize_basic_alternation(pattern: &str) -> Cow<'_, str> {
-	let bytes = pattern.as_bytes();
-	let mut output = None;
-	let mut copied = 0;
-	let mut index = 0;
-	let mut in_class = false;
-
-	while index < bytes.len() {
-		if bytes[index] == b'\\' {
-			let run_start = index;
-			while index < bytes.len() && bytes[index] == b'\\' {
-				index += 1;
-			}
-			let slash_count = index - run_start;
-			if !in_class && slash_count % 2 == 1 && index < bytes.len() && bytes[index] == b'|' {
-				let normalized = output.get_or_insert_with(|| String::with_capacity(pattern.len()));
-				normalized.push_str(&pattern[copied..index - 1]);
-				normalized.push('|');
-				copied = index + 1;
-				index += 1;
-				continue;
-			}
-			if slash_count % 2 == 1 && index < bytes.len() {
-				index += 1;
-			}
-			continue;
-		}
-
-		match bytes[index] {
-			b'[' if !in_class => in_class = true,
-			b']' if in_class => in_class = false,
-			_ => {},
-		}
-		index += 1;
-	}
-
-	if let Some(mut normalized) = output {
-		normalized.push_str(&pattern[copied..]);
-		Cow::Owned(normalized)
-	} else {
-		Cow::Borrowed(pattern)
-	}
-}
-
 fn build_default_matcher<P: AsRef<str>>(
 	builder: &RegexMatcherBuilder,
 	patterns: &[P],
@@ -716,11 +670,28 @@ fn build_matcher(
 	}
 
 	if mode == MatchMode::Default {
-		let normalized: Vec<_> = patterns
+		// BRE is a distinct dialect, not ERE with different escaping: `\+` is
+		// the operator and a bare `+` is a literal. Translating through the
+		// shared BRE module is what makes `grep 'fo+'` mean "fo+" and
+		// `grep '^+'` mean a leading plus, as GNU and BSD grep both do.
+		// Back-references are left untouched: `grep-regex` cannot compile
+		// them, so `build_default_matcher` falls back to a literal match
+		// exactly as it did before.
+		let translated: Vec<String> = patterns
 			.iter()
-			.map(|pattern| normalize_basic_alternation(pattern))
+			.map(|pattern| bre::bre_to_ere(pattern, bre::Backrefs::Unsupported))
 			.collect();
-		return build_default_matcher(&builder, &normalized).map(CompiledMatcher::Rust);
+		return build_default_matcher(&builder, &translated).map(CompiledMatcher::Rust);
+	}
+
+	// `regex` accepts `^+` and compiles it as `(?:^)+`, which matches at every
+	// line start. GNU and BSD grep both reject the pattern, so returning every
+	// line with exit 0 would be a wrong answer reported as success.
+	if let Some(bad) = patterns
+		.iter()
+		.find(|pattern| bre::ere_repetition_operand_missing(pattern))
+	{
+		return Err(format!("repetition-operator operand invalid: {bad}"));
 	}
 
 	builder
@@ -1748,17 +1719,25 @@ mod tests {
 	}
 
 	#[test]
-	fn basic_mode_falls_back_per_pattern_but_extended_mode_is_strict() {
+	fn basic_mode_is_posix_bre_and_extended_mode_is_strict() {
 		let (code, out, err) = run(&["-A", "1", "fail)"], "ok\n(1 fail)\nnext\n");
 		assert_eq!(code, 0, "{err}");
 		assert_eq!(out, "(1 fail)\nnext\n");
 		let (code, _, err) = run(&["-E", "fail)"], "fail)\n");
 		assert_eq!(code, 2);
 		assert!(err.contains("grep:"));
+		// In a BRE a bare `+` is a LITERAL, so `fo+` does not match `foooo`.
+		// This assertion previously expected `foooo`, which is ERE
+		// behaviour; `/usr/bin/grep -e 'fo+' -e 'bar)' -h` on this input
+		// prints `bar)` alone on both GNU and BSD grep. Use `fo\+` for the
+		// quantifier.
 		let (code, out, err) =
 			run(&["-e", "fo+", "-e", "bar)", "-h"], "foooo\nbar)\nbaz\n");
 		assert_eq!(code, 0, "{err}");
-		assert_eq!(out, "foooo\nbar)\n");
+		assert_eq!(out, "bar)\n");
+		let (code, out, err) = run(&["-e", r"fo\+", "-h"], "foooo\nbar)\nbaz\n");
+		assert_eq!(code, 0, "{err}");
+		assert_eq!(out, "foooo\n");
 	}
 
 	#[test]
@@ -1780,6 +1759,35 @@ mod tests {
 		assert_eq!(code, 0);
 		assert!(err.is_empty());
 		assert!(out.contains("grep") && out.contains("pi-uu-grep"));
+	}
+
+	#[test]
+	fn repetition_with_no_operand_is_literal_in_bre_and_invalid_in_ere() {
+		// Measured against GNU/BSD grep 2.6.0 on the same fixture. Before
+		// this, every BRE row below returned 5 - the whole file - because
+		// `^+` reached the engine as an operator and compiled to `(?:^)+`,
+		// matching the empty string at every line start.
+		let input = "alpha\n+added\n-removed\n context\n+another\n";
+		for (pattern, want) in
+			[("^+", "2\n"), ("^*", "0\n"), ("^?", "0\n"), ("*x", "0\n"), ("^\\+", "2\n")]
+		{
+			let (code, out, err) = run(&["-c", pattern], input);
+			assert!(code == 0 || code == 1, "{pattern}: {err}");
+			assert_eq!(out, want, "pattern {pattern}");
+		}
+
+		// The forms that already agreed must not regress.
+		for (pattern, want) in [("+added", "1\n"), ("[+]", "2\n"), ("a\\+", "3\n")] {
+			let (code, out, err) = run(&["-c", pattern], input);
+			assert_eq!(code, 0, "{pattern}: {err}");
+			assert_eq!(out, want, "pattern {pattern}");
+		}
+
+		// ERE rejects it outright, as the real grep does, rather than
+		// silently returning every line.
+		let (code, _, err) = run(&["-Ec", "^+"], input);
+		assert_eq!(code, 2, "-E '^+' must be rejected");
+		assert!(err.contains("grep:"), "{err}");
 	}
 }
 

--- a/crates/pi-builtins/src/grep.rs
+++ b/crates/pi-builtins/src/grep.rs
@@ -701,6 +701,13 @@ fn build_matcher(
 		return build_default_matcher(&builder, &translated, patterns).map(CompiledMatcher::Rust);
 	}
 
+	// A `{` that opens no interval is a literal to GNU and BSD grep, but the
+	// `regex` crate refuses the whole pattern, so `grep -E '{a}'` failed on
+	// patterns real grep matches. An attempted-but-unterminated interval
+	// stays an error in both.
+	let patterns: Vec<std::borrow::Cow<'_, str>> =
+		patterns.iter().map(|p| bre::ere_literalize_braces(p)).collect();
+
 	// `regex` accepts `^+` and compiles it as `(?:^)+`, which matches at every
 	// line start. GNU and BSD grep both reject the pattern, so returning every
 	// line with exit 0 would be a wrong answer reported as success.
@@ -712,7 +719,7 @@ fn build_matcher(
 	}
 
 	builder
-		.build_many(patterns)
+		.build_many(&patterns)
 		.map(CompiledMatcher::Rust)
 		.map_err(|error| error.to_string())
 }
@@ -1927,6 +1934,38 @@ mod tests {
 		let (code, out, err) = run(&["-c", "a[d"], "a[d\nplain\n");
 		assert_eq!(code, 0, "{err}");
 		assert_eq!(out, "1\n", "falls back to the literal text the user typed");
+	}
+
+	#[test]
+	fn a_brace_that_opens_no_interval_is_literal_in_an_ere() {
+		// Every expectation below is a measurement from /usr/bin/grep against
+		// this same input, not a reading of the spec.
+		let input = "{a}\na{\n{foo\na{1}b\nplain\n}\n[{]\n";
+		for (pattern, want) in [
+			("{a}", "1\n"),
+			("a{", "2\n"),
+			("{foo", "1\n"),
+			("}", "3\n"),
+			("[{]", "5\n"),
+			(r"\{a\}", "1\n"),
+			// Still a real interval, and still applied.
+			("a{1}", "4\n"),
+			("a{1,2}", "4\n"),
+		] {
+			let (code, out, err) = run(&["-Ec", pattern], input);
+			assert_eq!(code, 0, "-E {pattern}: {err}");
+			assert_eq!(out, want, "-E {pattern}");
+		}
+
+		// The two brace patterns real grep REFUSES must stay refused. A `{`
+		// followed by a digit is an attempted interval: unterminated, it is
+		// "braces not balanced", and with no operand it is "repetition-operator
+		// operand invalid". Escaping those would convert a diagnosed mistake
+		// into a silent literal match.
+		for pattern in ["a{1,2", "{1}"] {
+			let (code, out, _) = run(&["-Ec", pattern], input);
+			assert_eq!(code, 2, "-E {pattern} must stay an error, got {out:?}");
+		}
 	}
 }
 

--- a/crates/pi-builtins/src/grep.rs
+++ b/crates/pi-builtins/src/grep.rs
@@ -680,7 +680,8 @@ fn build_matcher(
 		let translated: Vec<String> = patterns
 			.iter()
 			.map(|pattern| bre::bre_to_ere(pattern, bre::Backrefs::Unsupported))
-			.collect();
+			.collect::<Result<_, _>>()
+			.map_err(|e: bre::BreError| e.message().to_owned())?;
 		return build_default_matcher(&builder, &translated).map(CompiledMatcher::Rust);
 	}
 

--- a/crates/pi-builtins/src/grep.rs
+++ b/crates/pi-builtins/src/grep.rs
@@ -603,22 +603,35 @@ fn escape_literal(pat: &str) -> String {
 	out
 }
 
-fn build_default_matcher<P: AsRef<str>>(
+/// Build a matcher, falling back to a literal match for any pattern the engine
+/// refuses.
+///
+/// `fallbacks` supplies the text to escape when the corresponding entry of
+/// `patterns` will not compile. The two differ for a BRE, where `patterns`
+/// holds the translated form: a back-reference cannot be compiled by
+/// `grep-regex` at all, and escaping the TRANSLATION would make `\(a\)\1`
+/// match the text `(a)\1` rather than the bytes the user typed. The literal
+/// fallback must reproduce the user's pattern, which is what it did before the
+/// translation step existed.
+fn build_default_matcher<P: AsRef<str>, F: AsRef<str>>(
 	builder: &RegexMatcherBuilder,
 	patterns: &[P],
+	fallbacks: &[F],
 ) -> Result<RegexMatcher, String> {
+	debug_assert_eq!(patterns.len(), fallbacks.len());
 	let error = match builder.build_many(patterns) {
 		Ok(matcher) => return Ok(matcher),
 		Err(error) => error,
 	};
 	let sanitized: Vec<String> = patterns
 		.iter()
-		.map(|pattern| {
+		.zip(fallbacks.iter())
+		.map(|(pattern, fallback)| {
 			let pattern = pattern.as_ref();
 			if builder.build(pattern).is_ok() {
 				pattern.to_owned()
 			} else {
-				escape_literal(pattern)
+				escape_literal(fallback.as_ref())
 			}
 		})
 		.collect();
@@ -674,15 +687,18 @@ fn build_matcher(
 		// the operator and a bare `+` is a literal. Translating through the
 		// shared BRE module is what makes `grep 'fo+'` mean "fo+" and
 		// `grep '^+'` mean a leading plus, as GNU and BSD grep both do.
-		// Back-references are left untouched: `grep-regex` cannot compile
-		// them, so `build_default_matcher` falls back to a literal match
-		// exactly as it did before.
+		//
+		// The ORIGINAL patterns are handed to the fallback. `grep-regex`
+		// cannot compile a back-reference, so `\(a\)\1` falls back to a
+		// literal match, and it has to be the user's own text - escaping the
+		// translated `(a)\1` would silently match different bytes than before
+		// this translation step existed.
 		let translated: Vec<String> = patterns
 			.iter()
 			.map(|pattern| bre::bre_to_ere(pattern, bre::Backrefs::Unsupported))
 			.collect::<Result<_, _>>()
 			.map_err(|e: bre::BreError| e.message().to_owned())?;
-		return build_default_matcher(&builder, &translated).map(CompiledMatcher::Rust);
+		return build_default_matcher(&builder, &translated, patterns).map(CompiledMatcher::Rust);
 	}
 
 	// `regex` accepts `^+` and compiles it as `(?:^)+`, which matches at every
@@ -1789,6 +1805,75 @@ mod tests {
 		let (code, _, err) = run(&["-Ec", "^+"], input);
 		assert_eq!(code, 2, "-E '^+' must be rejected");
 		assert!(err.contains("grep:"), "{err}");
+	}
+
+	#[test]
+	fn no_operand_brace_interval_is_rejected_through_grep() {
+		// Covered here rather than only in the translator, because the failure
+		// mode was invisible at that level: `^\{2\}` translated to `^{2}`,
+		// which `grep-regex` ACCEPTS as `(?:^){2}` and matches at every line
+		// start, so the whole file came back with exit 0.
+		let input = "alpha\n+added\n-removed\n context\n+another\n";
+		for pattern in [r"^\{2\}", r"^\{1,4\}", r"\{1,4\}", r"\(\{2\}\)", r"a\|\{2\}"] {
+			let (code, out, err) = run(&["-c", pattern], input);
+			assert_eq!(code, 2, "{pattern} must be rejected, got {out:?}");
+			assert!(err.contains("repetition-operator operand invalid"), "{pattern}: {err}");
+		}
+		// With an operand it is an ordinary quantifier and still works.
+		let (code, out, err) = run(&["-c", r"a\{1,2\}"], input);
+		assert_eq!(code, 0, "{err}");
+		assert_eq!(out, "3\n");
+	}
+
+	#[test]
+	fn literal_brace_is_not_rejected_by_the_operand_check() {
+		// `grep -E '^{"'` is a real pattern - the common JSON-line filter -
+		// and GNU grep accepts it, because a `{` that opens no interval is a
+		// literal. An earlier revision of this guard exited 2 on it.
+		let input = "{\"a\":1}\n{foo\nplain\n";
+		for args in
+			[vec!["-c", "^{"], vec!["-Ec", "^\\{"], vec!["-Ec", "^\\{\""], vec!["-c", "{foo"]]
+		{
+			let (code, _, err) = run(&args, input);
+			assert!(code == 0 || code == 1, "{args:?} must not error: {err}");
+			assert!(!err.contains("operand invalid"), "{args:?}: {err}");
+		}
+		let (code, out, err) = run(&["-c", "^{"], input);
+		assert_eq!(code, 0, "{err}");
+		assert_eq!(out, "2\n");
+
+		// NOT asserted here, and a known divergence: `-E '{a}'` and `-E 'a{'`
+		// are literals to GNU grep but `regex` rejects them in its own parser,
+		// which it did before this operand check existed. Making those literal
+		// means rewriting ERE patterns rather than validating them.
+	}
+
+	#[test]
+	fn unsupported_backreference_falls_back_to_the_users_own_text() {
+		// `grep-regex` cannot compile a back-reference, so the pattern is
+		// matched literally. That literal must be what the user typed: after
+		// translation the pattern reads `(a)\1`, and escaping THAT made
+		// `\(a\)\1` match the text `(a)\1` instead of `\(a\)\1`.
+		let (code, out, err) = run(&["-c", r"\(a\)\1"], "x\\(a\\)\\1y\nnope\n");
+		assert_eq!(code, 0, "{err}");
+		assert_eq!(out, "1\n", "fallback must match the original pattern text");
+		let (code, out, _) = run(&["-c", r"\(a\)\1"], "x(a)\\1y\nnope\n");
+		assert_eq!(code, 1, "translated text must not be what is matched");
+		assert_eq!(out, "0\n");
+	}
+
+	#[test]
+	fn only_the_first_caret_of_a_branch_anchors() {
+		// Measured: `grep -c '^^'` counts lines beginning with a literal
+		// caret, and `sed 's/^^/X/'` rewrites only those. Treating the second
+		// caret as another anchor matched every line.
+		let input = "^a\naaa\n^^b\n";
+		let (code, out, err) = run(&["-c", "^^"], input);
+		assert_eq!(code, 0, "{err}");
+		assert_eq!(out, "2\n");
+		let (code, out, err) = run(&["-c", r"^\^"], input);
+		assert_eq!(code, 0, "{err}");
+		assert_eq!(out, "2\n", "the escaped form must agree with the bare one");
 	}
 }
 

--- a/crates/pi-builtins/src/lib.rs
+++ b/crates/pi-builtins/src/lib.rs
@@ -122,6 +122,9 @@ mod base32;
 mod base64;
 #[cfg(feature = "util.basename")]
 mod basename;
+/// Shared POSIX basic-regular-expression translation behind `grep` and `sed`.
+#[cfg(feature = "util.bre")]
+mod bre;
 #[cfg(feature = "util.cat")]
 mod cat;
 /// The `cksum` builtin plus the shared checksum machinery behind `md5sum`,

--- a/crates/pi-builtins/src/sed.rs
+++ b/crates/pi-builtins/src/sed.rs
@@ -1132,12 +1132,20 @@ fn compile_regex(
 		return Ok(None);
 	}
 
-	// Convert basic to extended regular expression if needed.
-	let pattern = if context.regex_extended {
-		pattern
+	// Convert basic to extended regular expression if needed. A BRE the
+	// dialect cannot express is a compilation error, matching real sed:
+	// `sed 's/\{1,3\}/X/'` reports an invalid RE rather than substituting.
+	let translated = if context.regex_extended {
+		None
 	} else {
-		&crate::bre::bre_to_ere(pattern, crate::bre::Backrefs::Supported)
+		Some(
+			crate::bre::bre_to_ere(pattern, crate::bre::Backrefs::Supported).map_err(|e| {
+				compilation_error::<Regex>(lines, line, format!("invalid regex '{pattern}': {}", e.message()))
+					.unwrap_err()
+			})?,
+		)
 	};
+	let pattern = translated.as_deref().unwrap_or(pattern);
 
 	let mut modifiers = String::new();
 	if icase {
@@ -2090,6 +2098,47 @@ mod tests {
 				.is_match(&mut IOChunk::new_from_str("acaa\nccc"))
 				.unwrap()
 		);
+	}
+
+	#[test]
+	fn test_compile_re_basic_leading_plus_is_a_literal() {
+		// REGRESSION: `s/^\+/X/` used to substitute at the start of EVERY
+		// line, because `\+` became `+` unconditionally and `^+` compiles as
+		// `(?:^)+`. Real sed changes only lines that begin with a plus.
+		let (lines, chars) = dummy_providers();
+		let regex = compile_regex(&lines, &chars, r"^\+", &ctx(), false, false)
+			.unwrap()
+			.expect("regex should be present");
+		assert!(regex.is_match(&mut IOChunk::new_from_str("+added")).unwrap());
+		assert!(!regex.is_match(&mut IOChunk::new_from_str("alpha")).unwrap());
+		assert!(!regex.is_match(&mut IOChunk::new_from_str(" context")).unwrap());
+	}
+
+	#[test]
+	fn test_compile_re_basic_no_operand_brace_is_rejected() {
+		// Real sed refuses this rather than substituting: emitting the
+		// operator would give `{1,3}` or, after an anchor, `^{1,3}` - which
+		// fancy-regex accepts and matches at every line start.
+		let (lines, chars) = dummy_providers();
+		for pattern in [r"\{1,3\}", r"^\{1,3\}"] {
+			let err = compile_regex(&lines, &chars, pattern, &ctx(), false, false)
+				.expect_err("a brace quantifier with no operand must not compile");
+			assert!(
+				err.to_string().contains("repetition-operator operand invalid"),
+				"{pattern}: {err}"
+			);
+		}
+	}
+
+	#[test]
+	fn test_compile_re_basic_caret_is_an_anchor_inside_a_group() {
+		// `\(^a\)` anchors in a BRE; escaping the caret matched nothing.
+		let (lines, chars) = dummy_providers();
+		let regex = compile_regex(&lines, &chars, r"\(^alpha\)", &ctx(), false, false)
+			.unwrap()
+			.expect("regex should be present");
+		assert!(regex.is_match(&mut IOChunk::new_from_str("alpha")).unwrap());
+		assert!(!regex.is_match(&mut IOChunk::new_from_str("xalpha")).unwrap());
 	}
 
 	#[test]

--- a/crates/pi-builtins/src/sed.rs
+++ b/crates/pi-builtins/src/sed.rs
@@ -9498,6 +9498,43 @@ mod tests {
 	}
 
 	#[test]
+	fn builtin_substitutes_only_plus_prefixed_lines() {
+		// THE OBSERVABLE DEFECT this change exists for, covered end to end:
+		// argument parsing, BRE compilation and substitution together.
+		// `s/^\+/PLUS/` used to rewrite the start of EVERY line, because
+		// `\+` became `+` unconditionally and `^+` compiles as `(?:^)+`.
+		let input = "alpha\n+added\n-removed\n context\n+another\n";
+		let (code, capture) =
+			crate::host::run_util::<Sed>(&[r"s/^\+/PLUS/"], input, "/");
+		assert_eq!(code, 0, "{}", capture.err());
+		assert_eq!(capture.out(), "alpha\nPLUSadded\n-removed\n context\nPLUSanother\n");
+		assert_eq!(capture.err(), "");
+	}
+
+	#[test]
+	fn builtin_rejects_a_brace_quantifier_with_no_operand() {
+		// Real sed refuses this. Emitting the operator gave `^{1,3}`, which
+		// fancy-regex accepts and matches at every line start.
+		let (code, capture) =
+			crate::host::run_util::<Sed>(&[r"s/^\{1,3\}/X/"], "alpha\n+added\n", "/");
+		assert_ne!(code, 0, "must not substitute: {:?}", capture.out());
+		assert!(
+			capture.err().contains("repetition-operator operand invalid"),
+			"{}",
+			capture.err()
+		);
+	}
+
+	#[test]
+	fn builtin_treats_only_the_first_caret_of_a_branch_as_an_anchor() {
+		// Measured: `sed 's/^^/X/'` rewrites only lines that begin with a
+		// literal caret, consuming one of them.
+		let (code, capture) = crate::host::run_util::<Sed>(&["s/^^/X/"], "^a\naaa\n^^b\n", "/");
+		assert_eq!(code, 0, "{}", capture.err());
+		assert_eq!(capture.out(), "Xa\naaa\nX^b\n");
+	}
+
+	#[test]
 	fn builtin_propagates_q_status() {
 		let (code, capture) = crate::host::run_util::<Sed>(&["2q42"], "one\ntwo\nthree\n", "/");
 		assert_eq!(code, 42);

--- a/crates/pi-builtins/src/sed.rs
+++ b/crates/pi-builtins/src/sed.rs
@@ -1115,102 +1115,7 @@ fn parse_command_ending(
 	Ok(())
 }
 
-/// Convert a primitive BRE pattern to a safe ERE-compatible pattern string.
-/// - Replaces `\(`, `\)`, `\?`, `\+`, `\|`, `\{` and `\}` with `(`, `)`, `?`,
-///   `+`, `|`, `{` and `}`.
-/// - Puts single-digit back-references in non-capturing groups..
-/// - Escapes ERE-only metacharacters: `+ ? { } | ( )`.
-/// - Leaves all other characters as-is.
-fn bre_to_ere(pattern: &str) -> String {
-	let mut result = String::with_capacity(pattern.len());
-	let mut chars = pattern.chars().peekable();
-
-	let mut at_beginning = true;
-	let mut previous: Option<char> = None;
-	while let Some(c) = chars.next() {
-		if c == '\\' {
-			match chars.peek() {
-				Some('(') => {
-					chars.next();
-					result.push('('); // Group start
-				},
-				Some(')') => {
-					chars.next();
-					result.push(')'); // Group end
-				},
-				Some('?') => {
-					chars.next();
-					result.push('?'); // Quantifier 0 or 1
-				},
-				Some('+') => {
-					chars.next();
-					result.push('+'); // Quantifier 1 or more
-				},
-				Some('|') => {
-					chars.next();
-					result.push('|'); // Alternation operator
-				},
-				Some('{') => {
-					chars.next();
-					result.push('{'); // Brace quantifier start
-				},
-				Some('}') => {
-					chars.next();
-					result.push('}'); // Brace quantifier end
-				},
-				Some(v) if v.is_ascii_digit() => {
-					// Back-reference.  In sed BREs these are single-digit
-					// (\1-\9) whereas fancy_regex supports multi-digit
-					// back-references. Put them in a non-capturing group
-					// to avoid having the number extend beyond the single
-					// digit. Example: In sed \11 matches group 1 followed
-					// by '1', not group 11.
-					result.push_str(&format!(r"(?:\{v})"));
-					chars.next();
-				},
-				Some(&next) => {
-					// Preserve other escaped characters.
-					chars.next();
-					result.push('\\');
-					result.push(next);
-				},
-				None => {
-					// Trailing backslash; keep it.
-					result.push('\\');
-				},
-			}
-		} else {
-			match c {
-				'+' | '?' | '{' | '}' | '|' | '(' | ')' => {
-					// Escape unsupported ERE metacharacters.
-					result.push('\\');
-					result.push(c);
-				},
-				'^' if !at_beginning && previous != Some('[') => {
-					// In BREs ^ has special meaning at the beginning
-					// and as bracket negation.  This heuristic escapes
-					// all other uses, which per POSIX are valid in EREs.
-					// "the ERE "a^b" is valid, but can never match because
-					// the 'a' prevents the expression "^b" from matching
-					// starting at the first character."
-					// POSIX 9.4.9 ERE Expression Anchoring
-					result.push('\\');
-					result.push(c);
-				},
-				'$' if chars.peek().is_some() => {
-					// Similarly for $ appearing not at the end.
-					result.push('\\');
-					result.push(c);
-				},
-				_ => result.push(c),
-			}
-		}
-		at_beginning = false;
-		previous = Some(c);
-	}
-
-	result
-}
+// The BRE→ERE translation lives in `crate::bre`, shared with `grep`.
 
 /// Compile the provided regular expression string into a corresponding engine.
 /// An empty pattern results in None, which means that the last RE employed
@@ -1231,7 +1136,7 @@ fn compile_regex(
 	let pattern = if context.regex_extended {
 		pattern
 	} else {
-		&bre_to_ere(pattern)
+		&crate::bre::bre_to_ere(pattern, crate::bre::Backrefs::Supported)
 	};
 
 	let mut modifiers = String::new();
@@ -2949,59 +2854,7 @@ mod tests {
 		assert!(err.to_string().contains("invalid reference \\2"));
 	}
 
-	// bre_to_ere
-	#[test]
-	fn test_bre_group_translation() {
-		assert_eq!(bre_to_ere(r"\(a\?b\+c\|\)"), "(a?b+c|)");
-		assert_eq!(bre_to_ere(r"a\(b\)c"), "a(b)c");
-	}
-
-	#[test]
-	fn test_bre_brace_quantifier_translation() {
-		assert_eq!(bre_to_ere(r"\{1,4\}"), "{1,4}");
-	}
-
-	#[test]
-	fn test_ere_metacharacters_escaped() {
-		assert_eq!(bre_to_ere(r"a+b?c{1}|(d)"), r"a\+b\?c\{1\}\|\(d\)");
-	}
-
-	#[test]
-	fn test_literal_backslashes_preserved() {
-		assert_eq!(bre_to_ere(r"foo\\bar"), r"foo\\bar");
-		assert_eq!(bre_to_ere(r"\."), r"\.");
-	}
-
-	#[test]
-	fn test_character_classes_unchanged() {
-		assert_eq!(bre_to_ere(r"[a-z]"), "[a-z]");
-		assert_eq!(bre_to_ere(r"[^0-9]"), "[^0-9]");
-	}
-
-	#[test]
-	fn test_anchors_and_dot_and_star() {
-		assert_eq!(bre_to_ere(r"^a.*b$"), "^a.*b$");
-	}
-
-	#[test]
-	fn test_trailing_backslash_is_preserved() {
-		assert_eq!(bre_to_ere(r"abc\"), r"abc\");
-	}
-
-	#[test]
-	fn test_caret_escaped_in_middle() {
-		assert_eq!(bre_to_ere(r"^a^[^x]c"), r"^a\^[^x]c");
-	}
-
-	#[test]
-	fn test_dollar_escaped_in_middle() {
-		assert_eq!(bre_to_ere(r"a$c$"), r"a\$c$");
-	}
-
-	#[test]
-	fn test_bre_back_reference() {
-		assert_eq!(bre_to_ere(r"\(.\)\1\(.\)\2"), r"(.)(?:\1)(.)(?:\2)");
-	}
+	// The BRE→ERE translation and its tests live in `crate::bre`.
 
 	// patch_block_endings
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Fixed an issue where custom model overrides were lost during configuration updates
 - Fixed "Please use nerdfont" notification incorrectly persisting after theme configuration
 - Fixed sampling parameter errors for newer Anthropic models (Opus 4.7+, Sonnet 5+)
+- Fixed the built-in `grep` and `sed` treating a basic regular expression as an extended one: a bare `+` is now the literal and `\+` the operator, patterns like `^+` or `s/^\+/` no longer match every line, `^` anchors inside `\(…\)` and after `\|`, and a repetition operator with nothing to repeat is reported instead of silently selecting the whole file ([#10298](https://github.com/can1357/oh-my-pi/pull/10298) by [@mruangutai](https://github.com/mruangutai)).
 
 ## [18.0.11] - 2026-08-29
 

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `grep` and `sed` treating basic regular expressions as extended ones, which silently matched every line for patterns like `^+` or `s/^\+/` and swapped the meanings of `+` and `\+` ([#10298](https://github.com/can1357/oh-my-pi/pull/10298) by [@mruangutai](https://github.com/mruangutai)).
+
 ## [18.0.11] - 2026-08-29
 
 ### Fixed


### PR DESCRIPTION
grep in the omp shell was quietly giving me wrong line counts: `^+` matched all 5 lines of my test file instead of the 2 that start with a plus. This makes BRE mode actually behave like a BRE.

## Reproduction

```bash
printf 'alpha\n+added\n-removed\n context\n+another\n' > /tmp/g.txt

grep -c '^+' /tmp/g.txt            # builtin: 5   WRONG
/usr/bin/grep -c '^+' /tmp/g.txt   # binary : 2

grep -Ec '^+' /tmp/g.txt           # builtin: 5   WRONG (real grep errors)

sed 's/^\+/PLUS/' /tmp/g.txt       # builtin: substitutes on all 5 lines  WRONG
/usr/bin/sed 's/^\+/PLUS/' /tmp/g.txt  # binary: substitutes on 1 line
```

Nothing errors, and the exit status is 0, so a wrong count looks like a right one.

## Cause

`MatchMode::Default` was not implementing a BRE. It applied one translation, `normalize_basic_alternation` (`\|` -> `|`), then handed the pattern to the `regex` crate. So the dialect ended up inverted against the GNU/BSD grep that `--version` claims compatibility with:

| pattern | `/usr/bin/grep` | builtin before |
|---|---|---|
| `fo+` | 1, `+` is a literal | 2, `+` is an operator |
| `fo\+` | 2, `\+` is the operator | 1, `\+` is a literal |
| `^+` | 2 | 5, every line |
| `^*` | 0 | 5 |
| `^?` | 0 | 5 |
| `-E '^+'` | error | 5, every line, exit 0 |

The every-line rows come from `regex` accepting `^+` and compiling it as `(?:^)+`, which matches the empty string at every line start.

`sed` had the mirror problem from the other side: `bre_to_ere` converted `\+` to `+` unconditionally, so `s/^\+/X/` substituted at the start of every line. The two builtins therefore disagreed about which form was the literal, and no single habit kept a user safe in both.

## Changes

- New `crates/pi-builtins/src/bre.rs` holds the one BRE-to-ERE translation, moved out of `sed` along with its ten existing tests, behind a `util.bre` feature that `util.grep` and `util.sed` enable. This follows the existing `util.proc-match` precedent for a shared engine module.
- `grep` now uses it. `normalize_basic_alternation` is deleted rather than left in place as a second dialect.
- A repetition operator with no preceding atom is emitted as a literal, per POSIX ("an asterisk that is the first character of an RE ... shall lose its special meaning"), at pattern start and after `^`, `\(` and `\|`.
- ERE mode rejects a repetition operator with no operand instead of compiling it and selecting every line.
- Back-references stay engine-aware. `fancy-regex` groups them as before; `grep-regex` cannot compile them, so they pass through unchanged and `build_default_matcher`'s existing literal fallback behaves exactly as it did.

### `\{` is deliberately left as an operator

POSIX would make a no-operand `\{` a literal too, but neither real tool does:

```
/usr/bin/grep -c '\{1,4\}'    -> grep: repetition-operator operand invalid
/usr/bin/sed  's/\{1,3\}/X/'  -> sed: 1: "s/\{1,3\}/X/ ...
```

Both error. The existing `\{1,4\}` -> `{1,4}` translation makes the engine reject the pattern, which is the correct outcome, so degrading it to a literal would replace a correct error with a silent wrong match. My first attempt did exactly that and an existing test caught it.

## One existing assertion changed

`basic_mode_falls_back_per_pattern_but_extended_mode_is_strict` expected `-e 'fo+'` to match `foooo`, which is ERE behaviour. Both GNU and BSD grep print `bar)` alone for that input:

```
/usr/bin/grep -e 'fo+' -e 'bar)' -h   # on "foooo\nbar)\nbaz\n"  ->  bar)
```

It is renamed to `basic_mode_is_posix_bre_and_extended_mode_is_strict` and now also asserts that `fo\+` matches `foooo`. Flagging it explicitly since it is the one place where this changes documented behaviour rather than fixing it. If you would rather take the no-operand fix alone and leave the wider BRE dialect for a separate discussion, I am happy to split it.

## Verification

`cargo test -p pi-builtins`: 1113 pass, 0 fail. `cargo fmt --check` and `cargo clippy --all-targets` clean. `--no-default-features` with each of `util.grep`, `util.sed` and `util.rg` builds warning-free, so the new shared feature does not break per-utility isolation.

Unit tests are not the part I trust, so I also drove a real shell through `pi_shell::execute_shell`, with the actual builtin registration, and compared every pattern against the system binary in the same run:

| pattern | before | after | `/usr/bin/grep` |
|---|---|---|---|
| `^+` | 5 | 2 | 2 |
| `^*` | 5 | 0 | 0 |
| `^?` | 5 | 0 | 0 |
| `a\+` | 0 | 3 | 3 |
| `*x` | 0 | 0 | 0 |
| `^\+` | 2 | 2 | 2 |
| `fo+` | 0 | 0 | 0 |
| `+added` | 1 | 1 | 1 |
| `[+]` | 2 | 2 | 2 |
| `sed 's/^\+/PLUS/'` | all 5 lines | 2 lines | 2 lines |
| `grep -Ec '^+'` | exit 0, every line | exit 2 | error |

Every row agrees with the system binary after the change, and `sed` output is byte-identical. The `a\+` row is the inversion showing up in the other direction: before the change the builtin found zero matches where real grep finds three.

That probe lived in `crates/pi-shell/tests/` and I deleted it rather than including it here. It shells out to `/usr/bin/grep`, so it would not be hermetic in CI, and it sits in a crate this change has no business touching.

## Note on how this was made

Written with an AI agent doing the implementation and the measurements on this machine. The numbers above are from real runs, not estimates.
