### PR TITLE
fix(mcp): preserve advertised OAuth resource

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Fixed
 
+- Fixed MCP OAuth token exchange when authorization endpoints embed a different resource indicator ([#10299](https://github.com/can1357/oh-my-pi/issues/10299)).
 - Fixed an issue where custom model overrides were lost during configuration updates
 - Fixed "Please use nerdfont" notification incorrectly persisting after theme configuration
 - Fixed sampling parameter errors for newer Anthropic models (Opus 4.7+, Sonnet 5+)

--- a/packages/coding-agent/src/mcp/oauth-flow.ts
+++ b/packages/coding-agent/src/mcp/oauth-flow.ts
@@ -440,12 +440,13 @@ export class MCPOAuthFlow extends OAuthCallbackFlow {
 			params.set("prompt", prompt);
 		}
 		const existingResource = params.get("resource")?.trim();
-		if (existingResource) {
-			// A resource already embedded in the provider's authorization URL is
-			// provider-authored, not OMP's server-URL fallback. Preserve same-host
-			// values here even when the caller marked its separate
-			// `config.resource` as fallback; gateway-hosted MCP servers can use
-			// origin-only or path-scoped values as the token audience.
+		if (this.#resource && !this.config.stripSameOriginResource) {
+			// Protected-resource or authorization-server metadata identifies the
+			// requested audience; a query carried by the endpoint URL does not.
+			params.set("resource", this.#resource);
+		} else if (existingResource) {
+			// An embedded resource outranks OMP's server-URL fallback. Gateway-
+			// hosted MCP servers can use origin-only or path-scoped audiences.
 			const filtered = filterResourceIndicator(resolveResourceUri(existingResource), this.config.authorizationUrl);
 			if (filtered) {
 				this.#resource = filtered;

--- a/packages/coding-agent/src/modes/components/mcp-add-wizard.ts
+++ b/packages/coding-agent/src/modes/components/mcp-add-wizard.ts
@@ -54,6 +54,7 @@ export interface MCPAddWizardOAuthResult {
 interface MCPAddWizardOAuthOptions {
 	serverUrl?: string;
 	resource?: string;
+	stripSameOriginResource?: boolean;
 	registrationUrl?: string;
 	issuerUrl?: string;
 	/**
@@ -81,6 +82,7 @@ interface WizardState {
 	oauthClientSecret: string;
 	oauthScopes: string;
 	oauthResource: string;
+	oauthResourceIsFallback: boolean;
 	oauthCredentialId: string | null;
 	apiKey: string;
 	authLocation: AuthLocation | null;
@@ -114,6 +116,7 @@ export class MCPAddWizard extends OverlayPanel {
 		oauthClientSecret: "",
 		oauthScopes: "",
 		oauthResource: "",
+		oauthResourceIsFallback: false,
 		oauthCredentialId: null,
 		apiKey: "",
 		authLocation: null,
@@ -1019,6 +1022,7 @@ export class MCPAddWizard extends OverlayPanel {
 					this.#state.oauthClientId = oauth.clientId || "";
 					this.#state.oauthScopes = oauth.scopes || "";
 					this.#state.oauthResource = oauth.resource || (this.#state.transport === "stdio" ? "" : this.#state.url);
+					this.#state.oauthResourceIsFallback = !oauth.resource && this.#state.transport !== "stdio";
 					this.#state.authMethod = "oauth";
 
 					this.#contentContainer.clear();
@@ -1177,6 +1181,9 @@ export class MCPAddWizard extends OverlayPanel {
 		this.#oauthAbort = new AbortController();
 		try {
 			// Call OAuth handler
+			const oauthResourceIsFallback =
+				this.#state.oauthResourceIsFallback || (!this.#state.oauthResource && this.#state.transport !== "stdio");
+			this.#state.oauthResourceIsFallback = oauthResourceIsFallback;
 			const oauthResource = this.#state.oauthResource || (this.#state.transport === "stdio" ? "" : this.#state.url);
 			const oauthResult = await this.#onOAuthCallback(
 				this.#state.oauthAuthUrl,
@@ -1189,6 +1196,7 @@ export class MCPAddWizard extends OverlayPanel {
 					registrationUrl: this.#state.oauthRegistrationUrl || undefined,
 					issuerUrl: this.#state.oauthIssuerUrl || undefined,
 					resource: oauthResource || undefined,
+					stripSameOriginResource: oauthResourceIsFallback,
 					abortSignal: this.#oauthAbort.signal,
 				},
 			);

--- a/packages/coding-agent/test/oauth-flow.test.ts
+++ b/packages/coding-agent/test/oauth-flow.test.ts
@@ -316,7 +316,7 @@ describe("mcp oauth flow", () => {
 		expect(authResource).toBe("https://mcp.example.com/mcp");
 		expect(tokenParams.get("resource")).toBe("https://mcp.example.com/mcp");
 	});
-	it("uses an authorization URL resource for the matching token request", async () => {
+	it("prefers the configured resource over one embedded in the authorization URL", async () => {
 		let authResource = "";
 		let tokenRequestBody = "";
 
@@ -349,8 +349,8 @@ describe("mcp oauth flow", () => {
 		await flow.login();
 		const tokenParams = new URLSearchParams(tokenRequestBody);
 
-		expect(authResource).toBe("https://auth-url-resource.example/mcp");
-		expect(tokenParams.get("resource")).toBe("https://auth-url-resource.example/mcp");
+		expect(authResource).toBe("https://config-resource.example/mcp");
+		expect(tokenParams.get("resource")).toBe("https://config-resource.example/mcp");
 	});
 
 	it("uses exact redirectUri and clientSecret for provider requests", async () => {


### PR DESCRIPTION
## Repro
When an authorization endpoint embeds `resource=https://auth.example.com` while protected-resource discovery supplies `resource=https://mcp.example.com`, `MCPOAuthFlow.generateAuthUrl()` used the endpoint query for both authorization and token requests. Before this change, `bun test packages/coding-agent/test/oauth-flow.test.ts --test-name-pattern "prefers the configured resource"` failed because the emitted audience was the authorization server.

## Cause
`MCPOAuthFlow.generateAuthUrl()` in `packages/coding-agent/src/mcp/oauth-flow.ts` treated every endpoint `resource` query as provider-authoritative, so it overwrote `#resource` even when that field came from protected-resource or authorization-server metadata; the fallback provenance flag was only used for same-origin filtering, not precedence.

## Fix
- Prefer metadata-advertised resources over conflicting authorization-endpoint query values.
- Preserve endpoint-query precedence for OMP-synthesized server-URL fallbacks used by gateway-hosted MCP servers.
- Update the OAuth flow regression test and coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/oauth-flow.test.ts` passes: 50 tests, 107 assertions. The pre-publish `bun run fix` and `bun check` gate also passes. Fixes #10299