### PR TITLE
fix(tui): lift the startup submit gate when the first turn starts

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Fixed an issue where custom model overrides were lost during configuration updates
 - Fixed "Please use nerdfont" notification incorrectly persisting after theme configuration
 - Fixed sampling parameter errors for newer Anthropic models (Opus 4.7+, Sonnet 5+)
+- Fixed Enter being silently dropped for the entire first turn when omp is launched with an initial prompt; typed messages now steer into the running turn ([#10302](https://github.com/can1357/oh-my-pi/pull/10302) by [@nick-maderight](https://github.com/nick-maderight)).
 
 ## [18.0.11] - 2026-08-29
 

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -606,7 +606,11 @@ async function runInteractiveMode(
 		session.maybeStartTitleGeneration(initialMessage);
 		try {
 			using _keepalive = new EventLoopKeepalive();
-			await session.prompt(initialMessage, { images: initialImages });
+			// `steer` covers the race where the user submits a prompt of their own
+			// before this dispatch runs (the composer accepts input as soon as the
+			// first turn starts): the CLI message queues into that turn instead of
+			// dying with AgentBusyError.
+			await session.prompt(initialMessage, { images: initialImages, streamingBehavior: "steer" });
 		} catch (error: unknown) {
 			const errorMessage = error instanceof Error ? error.message : "Unknown error occurred";
 			mode.showError(errorMessage);
@@ -617,7 +621,7 @@ async function runInteractiveMode(
 		session.maybeStartTitleGeneration(message);
 		try {
 			using _keepalive = new EventLoopKeepalive();
-			await session.prompt(message);
+			await session.prompt(message, { streamingBehavior: "steer" });
 		} catch (error: unknown) {
 			const errorMessage = error instanceof Error ? error.message : "Unknown error occurred";
 			mode.showError(errorMessage);

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -557,7 +557,6 @@ const CTRL_L_APPEARANCE_RESPONSE_DEADLINE_MS = 2000;
 
 export class InteractiveMode implements InteractiveModeContext {
 	#ownsStartedUi: boolean;
-	#startupSubmitGated: boolean;
 	session: AgentSession;
 	sessionManager: SessionManager;
 	settings: Settings;
@@ -894,7 +893,6 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.editor.magicKeywordsEnabled = () => this.settings.get("magicKeywords.enabled");
 		this.editor.imageReferenceHyperlink = imageReferenceHyperlink;
 		this.#ownsStartedUi = wasStarted;
-		this.#startupSubmitGated = true;
 		this.keybindings = KeybindingsManager.inMemory();
 		this.agent = session.agent;
 		this.#version = version;
@@ -1434,6 +1432,17 @@ export class InteractiveMode implements InteractiveModeContext {
 			// replay with the newly detected palette.
 			onTerminalAppearanceChange(mode, appearanceRefreshWasRequested ? {} : undefined);
 		});
+
+		// Everything is wired: subscriptions observe agent events, the session
+		// mode is reconciled, and the submit handler is installed. Lift the
+		// composer's bootstrap submit gate (`disableSubmit = true` since
+		// construction, so an Enter typed before the pipeline existed could not
+		// clear the draft into nowhere, and a turn started mid-init could not run
+		// unobserved). From here Enter dispatches safely in every state — the
+		// initial CLI prompt and a user submission both flow with
+		// `streamingBehavior: "steer"`, so whichever lands second queues into the
+		// other's turn instead of dying.
+		this.editor.disableSubmit = false;
 	}
 
 	/** Reload the title-generation system prompt override for the provided working
@@ -1649,11 +1658,6 @@ export class InteractiveMode implements InteractiveModeContext {
 			this.onInputCallback = undefined;
 			resolve(input);
 		};
-		if (this.#startupSubmitGated) {
-			this.#startupSubmitGated = false;
-			this.editor.disableSubmit = false;
-			this.ui.requestRender();
-		}
 		this.#scheduleLoopAutoSubmit();
 		this.#scheduleGoalContinuation();
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -5813,6 +5813,27 @@ export class AgentSession {
 			? await this.#buildImageDescriptionNotice(normalizedImages)
 			: undefined;
 
+		// A concurrent prompt() can start a turn during the awaits above: image
+		// normalization and the vision-description call suspend after the
+		// isStreaming check at the top, so two callers — the CLI initial message
+		// and a freshly typed submission — can both observe an idle session.
+		// Re-check before dispatch so the loser queues exactly like the early
+		// branch instead of racing #promptWithMessage into AgentBusyError. No
+		// await sits between this check and #beginInFlight, so the winner's
+		// in-flight increment is visible to every later re-check.
+		if (this.isStreaming) {
+			const streamingBehavior = options?.streamingBehavior;
+			if (!streamingBehavior) throw new AgentBusyError();
+			for (const notice of keywordNotices) {
+				await this.#queueCustomMessage(notice, streamingBehavior);
+			}
+			await this.#queueUserMessage(expandedText, options?.images, streamingBehavior, submittedAt, {
+				images: normalizedImages,
+				descriptionNotice: imageDescriptionNotice,
+			});
+			return true;
+		}
+
 		const promptAttribution = options?.attribution ?? (options?.synthetic ? "agent" : "user");
 		if (externalThinkingToolChoice) {
 			this.#toolChoiceQueue.pushOnce(externalThinkingToolChoice, {
@@ -6434,21 +6455,27 @@ export class AgentSession {
 		images: ImageContent[] | undefined,
 		mode: "steer" | "followUp",
 		timestamp?: number,
+		preprocessed?: { images: ImageContent[] | undefined; descriptionNotice: CustomMessage | undefined },
 	): Promise<void> {
 		// A queued user message (RPC/SDK/collab steer or follow-up, or a typed message
 		// while streaming) is a deliberate resume; re-enable advisor auto-resume that
 		// a user interrupt suppressed.
 		this.#advisors.autoResumeSuppressed = false;
-		const normalizedImages = await this.#normalizeImagesForModel(images);
+		// The pre-dispatch re-check in prompt() arrives with normalization and the
+		// vision description already done — reuse them instead of paying a second
+		// vision-model request for the same attachment.
+		const normalizedImages = preprocessed ? preprocessed.images : await this.#normalizeImagesForModel(images);
 		const content: (TextContent | ImageContent)[] = [{ type: "text", text }];
 		if (normalizedImages?.length) {
 			content.push(...normalizedImages);
 		}
 		// Text-only model + image attachment: describe via a vision model and enqueue the
 		// description as a hidden companion immediately before the user message.
-		const imageDescriptionNotice = normalizedImages?.length
-			? await this.#buildImageDescriptionNotice(normalizedImages)
-			: undefined;
+		const imageDescriptionNotice = preprocessed
+			? preprocessed.descriptionNotice
+			: normalizedImages?.length
+				? await this.#buildImageDescriptionNotice(normalizedImages)
+				: undefined;
 		this.#allowQueuedMessageDrainRetry();
 		if (mode === "followUp") {
 			if (imageDescriptionNotice) this.agent.followUp(imageDescriptionNotice);

--- a/packages/coding-agent/test/agent-session-prompt-dispatch-race.test.ts
+++ b/packages/coding-agent/test/agent-session-prompt-dispatch-race.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Two concurrent `prompt()` calls must serialize instead of racing dispatch.
+ *
+ * `prompt()` checks `isStreaming` at the top, but image normalization (and the
+ * vision-description call) suspend before `#promptWithMessage` increments the
+ * in-flight count. Two callers that both saw an idle session — the CLI initial
+ * message of an `omp "prompt"` launch and a submission typed right after the
+ * startup composer opens its submit gate — used to both dispatch: the loser
+ * died with AgentBusyError and the prompts could land out of order. The
+ * post-await re-check queues the loser as a steer into the winner's turn.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import { Agent } from "@oh-my-pi/pi-agent-core";
+import { createMockModel } from "@oh-my-pi/pi-ai/providers/mock";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+
+describe("AgentSession concurrent prompt dispatch", () => {
+	let session: AgentSession;
+	let modelRegistry: ModelRegistry;
+	let authStorage: AuthStorage | undefined;
+
+	beforeEach(async () => {
+		authStorage = await AuthStorage.create(":memory:");
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		modelRegistry = new ModelRegistry(authStorage);
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		if (session) {
+			await session.dispose();
+		}
+		authStorage?.close();
+		authStorage = undefined;
+	});
+
+	function createSession() {
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected claude-sonnet-4-5 model to exist");
+
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: {
+				model,
+				systemPrompt: ["Test"],
+				tools: [],
+				messages: [],
+			},
+			streamFn: createMockModel({
+				responses: [{ content: ["First done"] }, { content: ["Second done"] }, { content: ["Third done"] }],
+			}).stream,
+		});
+
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({ "compaction.enabled": false }),
+			modelRegistry,
+		});
+	}
+
+	it("queues a prompt that loses the pre-dispatch race instead of racing a second turn", async () => {
+		createSession();
+
+		// Neither call is awaited before the other starts: both pass the
+		// top-of-prompt isStreaming check because the pre-dispatch awaits
+		// suspend before the in-flight count increments.
+		const first = session.prompt("initial CLI prompt", { streamingBehavior: "steer" });
+		const second = session.prompt("typed during preflight", { streamingBehavior: "steer" });
+
+		// Pre-fix, the loser reached agent.prompt() on a busy agent and this
+		// rejected with AgentBusyError.
+		await expect(Promise.all([first, second])).resolves.toEqual([true, true]);
+
+		const users = session.messages.filter(message => message.role === "user");
+		const textOf = (message: (typeof users)[number]): string =>
+			typeof message.content === "string"
+				? message.content
+				: message.content.flatMap(block => (block.type === "text" ? [block.text] : [])).join("");
+		const firstIndex = users.findIndex(message => textOf(message) === "initial CLI prompt");
+		const secondIndex = users.findIndex(message => textOf(message) === "typed during preflight");
+		expect(firstIndex).toBeGreaterThanOrEqual(0);
+		expect(secondIndex).toBeGreaterThanOrEqual(0);
+		// The first dispatch keeps its turn; the loser steers into it.
+		expect(firstIndex).toBeLessThan(secondIndex);
+		// The queue path marks the message as steering. Pre-fix the loser was
+		// absorbed by the recovery idle-retry instead: it waited for the first
+		// turn and ran as a detached second turn (plain user message), and a
+		// first turn longer than the retry deadline dropped the prompt.
+		expect(users[secondIndex]?.steering).toBe(true);
+	});
+});

--- a/packages/coding-agent/test/config-value-fd-inheritance.test.ts
+++ b/packages/coding-agent/test/config-value-fd-inheritance.test.ts
@@ -151,6 +151,15 @@ test.skipIf(process.platform !== "linux")(
 
 			const pid = Number.parseInt((await Bun.file(pidFile).text()).trim(), 10);
 			escaped = Process.fromPid(pid);
+			// Real subprocess timing: fake timers cannot advance the kill sweep,
+			// and the session-escape sweep can complete a beat after the resolver
+			// returns under CI load — poll with the same margin the marker-based
+			// siblings use instead of sampling once. A real leak still fails: the
+			// worker sleeps far past the window.
+			const deadline = Date.now() + 2000;
+			while (Date.now() < deadline && escaped?.status() === ProcessStatus.Running) {
+				await Bun.sleep(50);
+			}
 			expect(escaped?.status(), `session-escaping descendant ${pid} survived the timeout`).not.toBe(
 				ProcessStatus.Running,
 			);

--- a/packages/coding-agent/test/startup-composer.test.ts
+++ b/packages/coding-agent/test/startup-composer.test.ts
@@ -160,9 +160,8 @@ describe("Composer prepaint", () => {
 			expect(mode.editor.getExpandedText()).toBe(expectedDraft);
 			terminal.sendInput("\x18");
 			expect(mode.editor.getExpandedText()).toBe("");
-			expect(mode.editor.disableSubmit).toBe(true);
+			expect(mode.editor.disableSubmit).toBe(false);
 			terminal.sendInput("ready");
-			terminal.sendInput("\r");
 			expect(mode.editor.getExpandedText()).toBe("ready");
 
 			const submitted = mode.getUserInput();
@@ -179,7 +178,7 @@ describe("Composer prepaint", () => {
 		}
 	});
 
-	it("keeps submit gated while initialization and loop readiness are pending", async () => {
+	it("keeps submit gated during initialization, then dispatches with steer", async () => {
 		const terminal = new CountingTerminal();
 		const composer = new Composer({ preferences: config, terminal });
 		composer.start();
@@ -203,7 +202,8 @@ describe("Composer prepaint", () => {
 			await releaseInit.promise;
 		});
 		vi.spyOn(mode.statusLine, "watchBranch").mockImplementation(() => {});
-		const prompt = vi.spyOn(testSession.session, "prompt");
+		vi.spyOn(testSession.session, "maybeStartTitleGeneration").mockImplementation(() => {});
+		const prompt = vi.spyOn(testSession.session, "prompt").mockResolvedValue(true);
 
 		try {
 			const initializing = mode.init({ suppressWelcomeIntro: true });
@@ -217,16 +217,63 @@ describe("Composer prepaint", () => {
 
 			releaseInit.resolve();
 			await initializing;
+			// Init wired the submit pipeline and lifted the gate: an Enter before
+			// the input loop's first getUserInput dispatches directly with steer
+			// instead of being silently dropped.
+			expect(mode.editor.disableSubmit).toBe(false);
 			terminal.sendInput("\r");
-			expect(prompt).not.toHaveBeenCalled();
-			expect(mode.editor.getExpandedText()).toBe("alpha");
-
-			const submitted = mode.getUserInput();
-			terminal.sendInput("\r");
-			expect(await submitted).toEqual(expect.objectContaining({ text: "alpha" }));
-			expect(prompt).not.toHaveBeenCalled();
+			for (let i = 0; i < 50 && prompt.mock.calls.length === 0; i++) await Promise.resolve();
+			expect(prompt).toHaveBeenCalledWith("alpha", expect.objectContaining({ streamingBehavior: "steer" }));
+			expect(mode.editor.getExpandedText()).toBe("");
 		} finally {
 			releaseInit.resolve();
+			mode.stop();
+			lease.dispose();
+			await testSession.cleanup();
+			vi.restoreAllMocks();
+		}
+	});
+
+	it("accepts input while the initial CLI prompt's first turn is still running", async () => {
+		const terminal = new CountingTerminal();
+		const composer = new Composer({ preferences: config, terminal });
+		composer.start();
+		const lease = new ComposerLease(composer);
+		const testSession = await createTestSession({ inMemory: true });
+		const mode = new InteractiveMode(
+			testSession.session,
+			"test",
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			lease.composer,
+		);
+		lease.adopt();
+		vi.spyOn(mode.statusLine, "watchBranch").mockImplementation(() => {});
+		vi.spyOn(testSession.session, "maybeStartTitleGeneration").mockImplementation(() => {});
+		const turn = Promise.withResolvers<boolean>();
+		const prompt = vi.spyOn(testSession.session, "prompt").mockResolvedValue(true);
+
+		try {
+			await mode.init({ suppressWelcomeIntro: true });
+
+			// The `omp "prompt"` launch shape: the CLI message is dispatched after
+			// init and its first turn is still in flight when the user types. The
+			// input loop has not reached getUserInput yet.
+			prompt.mockReturnValueOnce(turn.promise);
+			const initialTurn = testSession.session.prompt("count to 25", { streamingBehavior: "steer" });
+
+			terminal.sendInput("also add tests");
+			terminal.sendInput("\r");
+			for (let i = 0; i < 50 && prompt.mock.calls.length < 2; i++) await Promise.resolve();
+			expect(prompt).toHaveBeenCalledWith("also add tests", expect.objectContaining({ streamingBehavior: "steer" }));
+			expect(mode.editor.getExpandedText()).toBe("");
+
+			turn.resolve(true);
+			await initialTurn;
+		} finally {
 			mode.stop();
 			lease.dispose();
 			await testSession.cleanup();

--- a/packages/coding-agent/test/tools/browser-tab-worker-startup.test.ts
+++ b/packages/coding-agent/test/tools/browser-tab-worker-startup.test.ts
@@ -18,6 +18,12 @@ import {
 import { chromiumAvailable } from "./chromium-probe";
 
 const CHROMIUM_AVAILABLE = await chromiumAvailable();
+// Headful Chromium needs a windowing system on Linux. The chromium probe only
+// proves the binary can exec, so a display-less CI runner passes it and then
+// dies in puppeteer with "Missing X server" — gate visible-window launches on
+// a display too (same check as `hasDisplay()` in src/utils/clipboard.ts).
+const HEADFUL_AVAILABLE =
+	CHROMIUM_AVAILABLE && (process.platform !== "linux" || Boolean(process.env.DISPLAY || process.env.WAYLAND_DISPLAY));
 
 class FakeStartupWorker {
 	#errorHandlers = new Set<(error: Error) => void>();
@@ -217,7 +223,7 @@ describe("browser init deadline carry-over", () => {
 	);
 });
 describe("visible OMP-owned browser tabs", () => {
-	it.skipIf(!CHROMIUM_AVAILABLE)(
+	it.skipIf(!HEADFUL_AVAILABLE)(
 		"creates independent pages without pinning the resizable window viewport",
 		async () => {
 			let browser: BrowserHandle | undefined;


### PR DESCRIPTION
## What

Enter is silently dropped when omp is launched with an initial prompt (`omp "do X"`). Typing works, but submitting does nothing: no queue chip, no error, the draft just sits. Steering only becomes possible once the input loop reaches its first `getUserInput()` — after the whole first turn. Interactive-first sessions are unaffected, which makes the bug look intermittent.

The composer boots the shared editor with `disableSubmit = true` so an Enter typed before the submit pipeline exists cannot clear the draft into nowhere. Since c03a26a26c that gate is only lifted at the first `getUserInput()` — but `runInteractiveMode` awaits the CLI initial-prompt turn (preflight included) before the input loop ever gets there, so the gate holds Enter shut the entire time (`editor.ts`: `if (this.disableSubmit) return`).

This PR lifts the gate at the very end of `init()`, once the submit handler is installed, agent-event subscriptions are live, and mode reconciliation is done — so an early dispatch can never start a turn that runs unobserved or under a pre-reconciliation mode. From that point Enter dispatches safely in every state: the CLI `initialMessage`/`initialMessages` now go out with `streamingBehavior: "steer"`, so a user submission and the CLI prompt can land in either order and the second one queues into the first one's turn instead of dying with `AgentBusyError`.

Codex review shaped the final form: the first revision lifted the gate from `agent_start` (Enter stayed dead during prompt preflight — P2), the second lifted it mid-init (a dispatch could precede `#subscribeToAgent()` and run an unobserved turn — P1), and a third finding showed two concurrent `prompt()` calls could both pass the top `isStreaming` check during the image-normalization awaits. The last one is fixed in `AgentSession.prompt()` itself: a post-await re-check queues the losing caller with its `streamingBehavior`, instead of the recovery idle-retry running it as a detached second turn (or dropping it when the first turn outlives the retry deadline).

## Why

Any launch that passes the prompt on the command line (scripting, wrappers, resume-with-message) leaves the user unable to add steering input during the first — often longest — turn, with no feedback at all.

## Testing

- Three `startup-composer.test.ts` tests assert the new contract and fail on unpatched main: submit stays gated while `init()` is still running; an Enter after init dispatches with steer before any `getUserInput()`; typing while the initial CLI prompt's turn is in flight dispatches with steer and clears the editor.
- Affected suites pass (`startup-composer`, `event-controller-*`, `usage-row-turn-time`, `repro-issue-6879-tool-double-render-retry`, `interactive-mode-loop`), and package `biome check` + `tsgo --noEmit` are clean.
- Live TUI smoke: launched from source with a CLI counting prompt, typed an extra instruction mid-first-turn; it queued as a steer and the model honored it within that turn.
- A session-level race test fires two concurrent `prompt()` calls and asserts the loser lands as a steering message inside the winner's turn; on unpatched code it ran as a detached second turn.
- Two commits stabilize CI tests this PR's runs kept tripping, both otherwise unrelated to the fix: the headful-browser test ran `headless: false` on display-less runners whenever the chromium probe passed ("Missing X server") and is now gated on `DISPLAY`/`WAYLAND_DISPLAY` like `hasDisplay()` in `src/utils/clipboard.ts`; the session-escape kill test sampled `Process.status()` once where its marker-based siblings poll, and now polls the same window. Happy to split either into its own PR if preferred.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
