### PR TITLE
fix(tui): enforce image budget before frame emission

### DIFF
--- a/packages/coding-agent/src/modes/components/transcript-container.ts
+++ b/packages/coding-agent/src/modes/components/transcript-container.ts
@@ -366,6 +366,26 @@ export class TranscriptContainer extends Container {
 		return this.#peekBatch(width, 0, "flush");
 	}
 
+	/** Recompose the unacknowledged batch so a discarded TUI frame can be rendered again. */
+	rerenderOfferedBatch(width: number): HistoryBatch | undefined {
+		const offered = this.#offered;
+		if (offered === undefined) return undefined;
+		let rows: readonly string[];
+		if (offered.kind === "append") {
+			const entry = this.#entries[offered.entry];
+			if (entry === undefined) return undefined;
+			const before = this.#renderStablePrefix(entry, entry.emitted, width);
+			const after = this.#renderStablePrefix(entry, offered.emittedEnd, width);
+			rows = after.slice(before.length);
+		} else if (offered.kind === "commit") {
+			rows = this.#renderRange(this.#frontier, offered.end, width, true);
+		} else {
+			rows = this.#renderReplay(width);
+		}
+		offered.batch = { id: offered.batch.id, rows, kind: offered.batch.kind };
+		return offered.batch;
+	}
+
 	#peekBatch(width: number, capacity: number, policy: RetirementPolicy): HistoryBatch | undefined {
 		this.#syncEntries();
 		this.#settleFinalized();

--- a/packages/coding-agent/src/modes/composer.ts
+++ b/packages/coding-agent/src/modes/composer.ts
@@ -329,6 +329,7 @@ export class Composer implements TerminalFrameProvider {
 		chromeRows: number,
 	): { id: number; rows: readonly string[]; kind: "append" | "replay" } | undefined {
 		if (this.#offeredHistory !== undefined) {
+			this.#rerenderOfferedHistory(width);
 			return {
 				id: this.#offeredHistory.id,
 				rows: this.#offeredHistory.rows,
@@ -399,6 +400,25 @@ export class Composer implements TerminalFrameProvider {
 			rows: this.#offeredHistory.rows,
 			kind: this.#offeredHistory.kind,
 		};
+	}
+
+	#rerenderOfferedHistory(width: number): void {
+		const offered = this.#offeredHistory;
+		if (offered === undefined) return;
+		if (offered.source === "header") {
+			const rows = this.#header.render(width);
+			offered.rows = rows.length > 0 ? [...rows, ""] : [];
+			return;
+		}
+		const transcript = offered.source.transcript.rerenderOfferedBatch(width);
+		if (offered.source.header === "none") {
+			if (transcript !== undefined) offered.rows = transcript.rows;
+			return;
+		}
+		const recomposed = this.#header.render(width);
+		const headerRows = recomposed.length > 0 ? [...recomposed, ""] : this.#reflowRetiredHeader(width, 0);
+		offered.source.headerRows = headerRows;
+		offered.rows = [...headerRows, ...(transcript?.rows ?? [])];
 	}
 
 	#renderRoots(roots: readonly Component[], width: number): string[] {

--- a/packages/coding-agent/test/welcome-history-resize.test.ts
+++ b/packages/coding-agent/test/welcome-history-resize.test.ts
@@ -2,10 +2,16 @@ import { afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
 import { TranscriptContainer } from "@oh-my-pi/pi-coding-agent/modes/components/transcript-container";
 import { COMPOSER_DEFAULTS, Composer } from "@oh-my-pi/pi-coding-agent/modes/composer";
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
-import { type Component, type RenderScheduler, visibleWidth } from "@oh-my-pi/pi-tui";
+import { type Component, Container, type RenderScheduler, visibleWidth } from "@oh-my-pi/pi-tui";
+import { Image } from "@oh-my-pi/pi-tui/components/image";
+import { getKittyGraphics, setKittyGraphics } from "@oh-my-pi/pi-tui/kitty-graphics";
+import { getCellDimensions, ImageProtocol, setCellDimensions, TERMINAL } from "@oh-my-pi/pi-tui/terminal-capabilities";
 import { VirtualRenderScheduler } from "../../tui/test/virtual-render-scheduler";
 import { VirtualTerminal } from "../../tui/test/virtual-terminal";
 import { withoutTerminalMultiplexer } from "./helpers/terminal-multiplexer";
+
+const BASE64_ONE_PIXEL_PNG =
+	"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACklEQVR4nGNgAAAAAgABSK+kcQAAAABJRU5ErkJggg==";
 
 withoutTerminalMultiplexer();
 
@@ -307,6 +313,53 @@ describe("composer welcome native-history resize", () => {
 		expect(resized).toContain("block-0@30");
 		expect(resized).toContain("block-3@30");
 		composer.ui.stop();
+	});
+
+	it("recomposes a cached history batch when the image budget retries", () => {
+		const originalProtocol = TERMINAL.imageProtocol;
+		const originalTerminalId = TERMINAL.id;
+		const originalCellDimensions = { ...getCellDimensions() };
+		const originalGraphics = { ...getKittyGraphics() };
+		Reflect.set(TERMINAL, "imageProtocol", ImageProtocol.Kitty);
+		Reflect.set(TERMINAL, "id", "xterm");
+		setCellDimensions({ widthPx: 10, heightPx: 10 });
+		setKittyGraphics({ unicodePlaceholders: false });
+
+		const terminal = new TrackingTerminal(40, 4);
+		const composer = new Composer({
+			terminal,
+			tuiOptions: { renderScheduler: new ResizeScheduler() },
+			preferences: { ...COMPOSER_DEFAULTS, quiet: true },
+		});
+		composer.ui.setMaxInlineImages(1);
+		const transcript = new TranscriptContainer();
+		const block = new Container();
+		for (const key of ["first", "second", "third"]) {
+			block.addChild(
+				new Image(
+					BASE64_ONE_PIXEL_PNG,
+					"image/png",
+					{ fallbackColor: text => text },
+					{ maxWidthCells: 1, maxHeightCells: 1, budget: composer.ui.imageBudget, imageKey: key },
+					{ widthPx: 10, heightPx: 10 },
+				),
+			);
+		}
+		transcript.addChild(block);
+		composer.setRuntimeChildren([transcript, new MutableComposerTail()]);
+
+		try {
+			composer.start({ playWelcomeIntro: false });
+			const output = terminal.writes.join("");
+			expect(output.match(/\x1b_Ga=t/g)).toHaveLength(1);
+			expect(plainBuffer(terminal).filter(row => row.includes("[Image:"))).toHaveLength(2);
+		} finally {
+			composer.ui.stop();
+			Reflect.set(TERMINAL, "imageProtocol", originalProtocol);
+			Reflect.set(TERMINAL, "id", originalTerminalId);
+			setCellDimensions(originalCellDimensions);
+			setKittyGraphics(originalGraphics);
+		}
 	});
 
 	it("flushes a roomy finalized transcript before composer shutdown", async () => {

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed image-heavy session resumes exceeding the terminal output limit before the inline-image budget was applied ([#10305](https://github.com/can1357/oh-my-pi/issues/10305)).
+
 ## [18.0.11] - 2026-08-29
 
 ### Added

--- a/packages/tui/src/components/image.ts
+++ b/packages/tui/src/components/image.ts
@@ -87,6 +87,8 @@ export class ImageBudget {
 	#idToKey = new Map<number, string>();
 	/** Display-order image ids observed during the in-flight pass. */
 	#passIds: number[] = [];
+	/** Per-id suppression decision from the first observation in this pass. */
+	#passSuppression = new Map<number, boolean>();
 	/**
 	 * Suppress threshold reflected in the frame currently on the terminal: images
 	 * at display indices `[0, #onTerminal)` are shown as text there.
@@ -185,6 +187,7 @@ export class ImageBudget {
 	 */
 	beginPass(stable = false): void {
 		this.#passIds.length = 0;
+		this.#passSuppression.clear();
 		this.#stablePass = stable;
 		this.#applyingReset = !stable && this.#cap > 0 && this.#planned > this.#onTerminal;
 	}
@@ -199,14 +202,18 @@ export class ImageBudget {
 	 * (`#suppressedIds`) keyed by id — order- and partiality-independent.
 	 */
 	observe(imageId: number): boolean {
+		const existing = this.#passSuppression.get(imageId);
+		if (existing !== undefined) return existing;
 		if (this.#stablePass) {
 			const suppressed = this.#cap > 0 && this.#suppressedIds.has(imageId);
+			this.#passSuppression.set(imageId, suppressed);
 			if (suppressed) this.#forgetKeyForId(imageId);
 			return suppressed;
 		}
 		const index = this.#passIds.length;
 		this.#passIds.push(imageId);
 		const suppressed = this.#cap > 0 && index < this.#planned;
+		this.#passSuppression.set(imageId, suppressed);
 		if (suppressed) this.#forgetKeyForId(imageId);
 		return suppressed;
 	}

--- a/packages/tui/src/components/image.ts
+++ b/packages/tui/src/components/image.ts
@@ -73,9 +73,9 @@ function nextImageIdSeed(): number {
  *
  * The budget keeps the most recent `cap` images live and demotes older ones to
  * their text fallback. Demotion needs a full redraw (so off-screen rows are
- * rewritten) plus an explicit graphics purge of the demoted ids — {@link Image}
- * reports display order via {@link observe}, and the TUI drives the purge +
- * redraw on the frame after a new image pushes the count past the cap.
+ * rewritten) plus an explicit graphics purge of the demoted ids. {@link Image}
+ * reports display order via {@link observe}; when that reveals a stricter split,
+ * the TUI repeats the pass before emitting its terminal frame.
  *
  * `cap <= 0` disables budgeting: every image stays a live graphic.
  */
@@ -104,7 +104,7 @@ export class ImageBudget {
 	/** Image ids whose data is believed to be loaded in the terminal's store. */
 	#transmitted = new Set<number>();
 	/** Transmit sequences (full base64) to write once, before this frame's placements. */
-	#pendingTransmits: string[] = [];
+	#pendingTransmits = new Map<number, string>();
 	// True while the in-flight pass is a partial/throwaway pass (the
 	// non-multiplexer resize viewport fast path) that walks only the visible
 	// tail, bottom-up. Such a pass cannot derive display order from observe()
@@ -212,34 +212,32 @@ export class ImageBudget {
 	}
 
 	/**
-	 * End a render pass. Returns true when this frame must purge graphics and
-	 * fully repaint to apply a stricter budget; read the ids via
-	 * {@link takePurgeIds}.
+	 * End a render pass. Returns true when the pass discovered a stricter budget
+	 * and must be repeated before its terminal frame is emitted.
 	 */
 	endPass(): boolean {
 		const total = this.#passIds.length;
 		this.#lastTotal = total;
-		let reset = false;
 		if (this.#applyingReset) {
 			for (let i = this.#onTerminal; i < this.#planned && i < total; i++) {
 				const id = this.#passIds[i];
-				this.#purgeIds.push(id);
-				// d=I frees the data too, so the image must re-transmit if it returns.
+				// A transmit queued by a discarded discovery pass never reached
+				// the terminal, so cancel it instead of transmitting then purging.
+				if (!this.#pendingTransmits.delete(id)) this.#purgeIds.push(id);
 				this.#transmitted.delete(id);
 				this.#deletePlacementState(id);
 				this.#forgetKeyForId(id);
 			}
 			this.#onTerminal = this.#planned;
 			this.#applyingReset = false;
-			reset = true;
 		}
-		this.#reconcile(total);
+		const retry = this.#reconcile(total);
 		// Snapshot the committed display-order suppression by id: the prefix
 		// [0, #onTerminal) is what the terminal currently shows as text. Partial
 		// passes replay this per id (see #stablePass) instead of re-deriving it
 		// from a reversed, tail-only walk.
 		this.#suppressedIds = new Set(this.#passIds.slice(0, this.#onTerminal));
-		return reset;
+		return retry;
 	}
 
 	/** Image ids to delete from the terminal this frame; clears the pending set. */
@@ -256,7 +254,7 @@ export class ImageBudget {
 		const ids = [...this.#transmitted];
 		this.#transmitted.clear();
 		this.#purgeIds = [];
-		this.#pendingTransmits = [];
+		this.#pendingTransmits.clear();
 		this.#keyToId.clear();
 		this.#idToKey.clear();
 		this.#placementState.clear();
@@ -393,12 +391,12 @@ export class ImageBudget {
 	enqueueTransmit(imageId: number, sequence: string): void {
 		if (this.#transmitted.has(imageId)) return;
 		this.#transmitted.add(imageId);
-		this.#pendingTransmits.push(sequence);
+		this.#pendingTransmits.set(imageId, sequence);
 	}
 
 	/** Whether a frame has image data queued but not yet written to the terminal. */
 	hasPendingTransmits(): boolean {
-		return this.#pendingTransmits.length > 0;
+		return this.#pendingTransmits.size > 0;
 	}
 
 	/**
@@ -410,7 +408,7 @@ export class ImageBudget {
 	get quiescent(): boolean {
 		return (
 			this.#lastTotal === 0 &&
-			this.#pendingTransmits.length === 0 &&
+			this.#pendingTransmits.size === 0 &&
 			this.#purgeIds.length === 0 &&
 			this.#planned === this.#onTerminal
 		);
@@ -418,9 +416,9 @@ export class ImageBudget {
 
 	/** Transmit sequences to write before this frame's placements; clears the queue. */
 	takeTransmits(): readonly string[] {
-		if (this.#pendingTransmits.length === 0) return EMPTY_TRANSMITS;
-		const sequences = this.#pendingTransmits;
-		this.#pendingTransmits = [];
+		if (this.#pendingTransmits.size === 0) return EMPTY_TRANSMITS;
+		const sequences = [...this.#pendingTransmits.values()];
+		this.#pendingTransmits.clear();
 		return sequences;
 	}
 
@@ -433,9 +431,9 @@ export class ImageBudget {
 	 * re-emit together; keeps no base64 in budget state (the transmit-once design).
 	 */
 	forgetTransmitted(): void {
-		if (this.#transmitted.size === 0 && this.#pendingTransmits.length === 0) return;
+		if (this.#transmitted.size === 0 && this.#pendingTransmits.size === 0) return;
 		this.#transmitted.clear();
-		this.#pendingTransmits = [];
+		this.#pendingTransmits.clear();
 	}
 
 	#forgetKeyForId(id: number): void {
@@ -445,15 +443,16 @@ export class ImageBudget {
 		if (this.#keyToId.get(key) === id) this.#keyToId.delete(key);
 	}
 
-	#reconcile(total: number): void {
+	#reconcile(total: number): boolean {
 		const desired = this.#cap > 0 ? Math.max(0, total - this.#cap) : 0;
 		if (desired === this.#planned) {
 			// Budget relaxed without a stricter frame (cap raised or images
 			// removed): surviving graphics are untouched and re-exposed rows
 			// repaint normally, so just track the looser threshold.
 			if (this.#planned < this.#onTerminal) this.#onTerminal = this.#planned;
-			return;
+			return false;
 		}
+		const retry = desired > this.#onTerminal;
 		this.#planned = desired;
 		// More images must be demoted than the terminal shows: schedule the purge +
 		// full-redraw frame. Fewer: no ghosts to clear, so just catch the tracking
@@ -461,6 +460,7 @@ export class ImageBudget {
 		// render is needed to apply the new threshold.
 		if (desired <= this.#onTerminal) this.#onTerminal = desired;
 		this.#requestRender();
+		return retry;
 	}
 }
 

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1422,11 +1422,13 @@ export class TUI extends Container {
 	/** Paint the full semantic tail on the borrowed resize buffer. */
 	#renderResizeAltFrame(width: number, height: number): void {
 		const provider = this.#frameProvider;
-		this.#imageBudget.beginPass();
-		const rendered =
-			provider?.renderResizeFrame?.({ columns: width, rows: height }) ??
-			(provider ? provider.renderFrame({ columns: width, rows: height }).viewport : this.render(width));
-		this.#imageBudget.endPass();
+		let rendered: readonly string[];
+		do {
+			this.#imageBudget.beginPass();
+			rendered =
+				provider?.renderResizeFrame?.({ columns: width, rows: height }) ??
+				(provider ? provider.renderFrame({ columns: width, rows: height }).viewport : this.render(width));
+		} while (this.#imageBudget.endPass());
 		const viewport = rendered.length > height ? rendered.slice(rendered.length - height) : Array.from(rendered);
 		this.#extractCursorMarkers(viewport);
 		this.#emitAltFrame(this.#prepareLinesArray(viewport, width), width, height);
@@ -1600,9 +1602,11 @@ export class TUI extends Container {
 		if (width <= 0 || height <= 0) return;
 		provider.beginHistoryFlush();
 		while (true) {
-			this.#imageBudget.beginPass();
-			const plan = provider.renderFrame({ columns: width, rows: height });
-			this.#imageBudget.endPass();
+			let plan: TerminalFramePlan;
+			do {
+				this.#imageBudget.beginPass();
+				plan = provider.renderFrame({ columns: width, rows: height });
+			} while (this.#imageBudget.endPass());
 			if (plan.history === undefined) return;
 			let viewport = Array.from(plan.viewport);
 			if (viewport.length > height) viewport = viewport.slice(0, height);
@@ -2262,9 +2266,11 @@ export class TUI extends Container {
 		const provider = this.#frameProvider;
 		if (!provider || width <= 0 || height <= 0) return;
 		this.#debugNextWindowTop = 0;
-		this.#imageBudget.beginPass();
-		const plan = provider.renderFrame({ columns: width, rows: height });
-		this.#imageBudget.endPass();
+		let plan: TerminalFramePlan;
+		do {
+			this.#imageBudget.beginPass();
+			plan = provider.renderFrame({ columns: width, rows: height });
+		} while (this.#imageBudget.endPass());
 		let viewport = Array.from(plan.viewport);
 		if (viewport.length > height) {
 			const message = `Frame provider returned ${viewport.length} rows for a ${height}-row viewport`;
@@ -2624,9 +2630,11 @@ export class TUI extends Container {
 	 * mutable viewport. Nothing is ever appended to terminal history.
 	 */
 	#renderChildrenFrame(width: number, height: number): void {
-		this.#imageBudget.beginPass();
-		const composed = this.render(width);
-		this.#imageBudget.endPass();
+		let composed: readonly string[];
+		do {
+			this.#imageBudget.beginPass();
+			composed = this.render(width);
+		} while (this.#imageBudget.endPass());
 		if (this.#maybeDeferGhosttyInitialImagePaint()) return;
 		this.#debugNextWindowTop = Math.max(0, composed.length - height);
 		const viewport = composed.length > height ? composed.slice(composed.length - height) : Array.from(composed);

--- a/packages/tui/test/image-budget.test.ts
+++ b/packages/tui/test/image-budget.test.ts
@@ -48,13 +48,13 @@ afterEach(() => {
 });
 
 /** Drive one render pass against the budget with `count` images (ids 1..count, stable across passes). */
-function pass(budget: ImageBudget, count: number): { suppressed: boolean[]; reset: boolean; purge: readonly number[] } {
+function pass(budget: ImageBudget, count: number): { suppressed: boolean[]; retry: boolean; purge: readonly number[] } {
 	budget.beginPass();
 	const suppressed: boolean[] = [];
 	for (let i = 0; i < count; i++) suppressed.push(budget.observe(i + 1));
-	const reset = budget.endPass();
+	const retry = budget.endPass();
 	const purge = [...budget.takePurgeIds()];
-	return { suppressed, reset, purge };
+	return { suppressed, retry, purge };
 }
 
 describe("ImageBudget", () => {
@@ -62,15 +62,15 @@ describe("ImageBudget", () => {
 		const budget = new ImageBudget(3, () => {});
 		const first = pass(budget, 2);
 		expect(first.suppressed).toEqual([false, false]);
-		expect(first.reset).toBe(false);
+		expect(first.retry).toBe(false);
 
 		const second = pass(budget, 3);
 		expect(second.suppressed).toEqual([false, false, false]);
-		expect(second.reset).toBe(false);
+		expect(second.retry).toBe(false);
 		expect(second.purge).toEqual([]);
 	});
 
-	it("demotes the oldest image on the frame after the cap is exceeded, purging its graphics id", () => {
+	it("repeats an over-cap pass before emission and purges the oldest graphics id", () => {
 		let renders = 0;
 		const budget = new ImageBudget(2, () => {
 			renders += 1;
@@ -79,31 +79,31 @@ describe("ImageBudget", () => {
 		// At cap: nothing demoted.
 		expect(pass(budget, 2).suppressed).toEqual([false, false]);
 
-		// Over cap: the new image still shows this frame; a follow-up render is scheduled.
+		// Discovery identifies the stricter split and requires a retry before emit.
 		const overflow = pass(budget, 3);
 		expect(overflow.suppressed).toEqual([false, false, false]);
-		expect(overflow.reset).toBe(false);
+		expect(overflow.retry).toBe(true);
 		expect(renders).toBe(1);
 
-		// The scheduled frame demotes the oldest image and purges its id (1) with a full redraw.
+		// The retry demotes the oldest image and purges its id (1).
 		const demote = pass(budget, 3);
 		expect(demote.suppressed).toEqual([true, false, false]);
-		expect(demote.reset).toBe(true);
+		expect(demote.retry).toBe(false);
 		expect(demote.purge).toEqual([1]);
 
-		// Steady state: no further resets while the count is unchanged.
+		// Steady state: no further retries while the count is unchanged.
 		const steady = pass(budget, 3);
 		expect(steady.suppressed).toEqual([true, false, false]);
-		expect(steady.reset).toBe(false);
+		expect(steady.retry).toBe(false);
 		expect(steady.purge).toEqual([]);
 	});
 
 	it("keeps exactly `cap` images live as more arrive", () => {
 		const budget = new ImageBudget(2, () => {});
-		// Walk up to 5 images; each addition settles into a demotion frame.
+		// Walk up to 5 images; each addition settles in a pre-emission retry.
 		for (let count = 3; count <= 5; count++) {
-			pass(budget, count); // overflow frame (schedules reset)
-			pass(budget, count); // reset frame (applies demotion)
+			pass(budget, count); // discovery pass requests a retry
+			pass(budget, count); // retry applies the demotion
 		}
 		const settled = pass(budget, 5);
 		// Newest 2 live, oldest 3 demoted.
@@ -118,7 +118,7 @@ describe("ImageBudget", () => {
 		expect(budget.enabled).toBe(false);
 		const result = pass(budget, 6);
 		expect(result.suppressed).toEqual([false, false, false, false, false, false]);
-		expect(result.reset).toBe(false);
+		expect(result.retry).toBe(false);
 		expect(result.purge).toEqual([]);
 		expect(renders).toBe(0);
 	});
@@ -133,7 +133,7 @@ describe("ImageBudget", () => {
 		pass(budget, 2);
 		const restored = pass(budget, 2);
 		expect(restored.suppressed).toEqual([false, false]);
-		expect(restored.reset).toBe(false);
+		expect(restored.retry).toBe(false);
 		expect(restored.purge).toEqual([]);
 	});
 
@@ -175,16 +175,16 @@ describe("ImageBudget", () => {
 		budget.observe(id3);
 		budget.endPass(); // schedules demotion of id1
 
-		// The key map should STILL hold id1 because it's not purged until the demotion frame.
+		// The key map still holds id1 until the retry applies the demotion.
 		expect(budget.acquireId("keyA")).toBe(id1);
 
-		// Demotion frame: applies the purge of id1.
+		// Retry pass: applies the purge of id1 without requiring another pass.
 		budget.beginPass();
 		budget.observe(id1);
 		budget.observe(id2);
 		budget.observe(id3);
-		const reset = budget.endPass();
-		expect(reset).toBe(true);
+		const retry = budget.endPass();
+		expect(retry).toBe(false);
 
 		// id1 was purged. Acquiring "keyA" now yields a fresh ID.
 		const id1Fresh = budget.acquireId("keyA");
@@ -211,7 +211,7 @@ describe("ImageBudget", () => {
 		budget.observe(oldId);
 		budget.observe(id2);
 		budget.observe(id3);
-		expect(budget.endPass()).toBe(true);
+		expect(budget.endPass()).toBe(false);
 		expect([...budget.takePurgeIds()]).toEqual([oldId]);
 
 		const suppressedId = budget.acquireId("keyA");
@@ -279,7 +279,7 @@ describe("ImageBudget", () => {
 		// the same split and schedules no purge or redraw.
 		const after = pass(budget, 4);
 		expect(after.suppressed).toEqual([true, true, false, false]);
-		expect(after.reset).toBe(false);
+		expect(after.retry).toBe(false);
 		expect(after.purge).toEqual([]);
 	});
 });
@@ -683,6 +683,34 @@ describe("TUI inline-image budget", () => {
 		}
 	});
 
+	it("applies the image budget before emitting the first frame", async () => {
+		const term = new VirtualTerminal(40, 12);
+		const writes: string[] = [];
+		const realWrite = term.write.bind(term);
+		vi.spyOn(term, "write").mockImplementation((data: string) => {
+			writes.push(data);
+			realWrite(data);
+		});
+
+		const tui = new TUI(term);
+		tui.setMaxInlineImages(1);
+		tui.addChild(makeImage(tui.imageBudget, "first"));
+		tui.addChild(makeImage(tui.imageBudget, "second"));
+		tui.addChild(makeImage(tui.imageBudget, "third"));
+
+		try {
+			tui.start();
+			await settle(term);
+
+			const output = writes.join("");
+			expect(output.match(/\x1b_Ga=t/g)).toHaveLength(1);
+			const viewport = term.getViewport().map(line => line.trimEnd());
+			expect(viewport.filter(line => line.includes("[Image:"))).toHaveLength(2);
+		} finally {
+			tui.stop();
+		}
+	});
+
 	it("purges demoted image graphics and repaints the fallback without a destructive replay", async () => {
 		const term = new VirtualTerminal(40, 12);
 		const writes: string[] = [];
@@ -987,11 +1015,12 @@ describe("ImageBudget transmit tracking", () => {
 	it("re-transmits an image after a purge frees its data", () => {
 		const budget = new ImageBudget(2, () => {});
 		budget.enqueueTransmit(1, "TX1");
+		expect([...budget.takeTransmits()]).toEqual(["TX1"]);
 		expect(budget.shouldTransmit(1)).toBe(false);
 
 		// Push past the cap so the oldest image (id 1) is demoted and purged.
-		pass(budget, 3); // overflow frame schedules the demotion
-		const demote = pass(budget, 3); // demotion frame purges id 1
+		pass(budget, 3); // discovery pass requests a retry
+		const demote = pass(budget, 3); // retry purges id 1
 		expect(demote.purge).toEqual([1]);
 
 		// d=I freed the data, so the image must transmit again if it returns.


### PR DESCRIPTION
## Repro

On current `main`, a synthetic first pass with the default cap of 8 and 70 1,125,000-byte image transmits suppressed no images and queued a 78,750,000-byte batch, exceeding the 67,108,864-byte stdout cap. Reproduced with:

```sh
bun -e 'import { ImageBudget } from "./packages/tui/src/components/image.ts"; const budget = new ImageBudget(8); const payload = "x".repeat(1_125_000); budget.beginPass(); const suppressed = []; for (let i = 1; i <= 70; i++) { const isSuppressed = budget.observe(i); suppressed.push(isSuppressed); if (!isSuppressed && budget.shouldTransmit(i)) budget.enqueueTransmit(i, payload); } budget.endPass(); const transmits = budget.takeTransmits(); console.log(JSON.stringify({ suppressed: suppressed.filter(Boolean).length, transmits: transmits.length, frameBytes: transmits.reduce((n, value) => n + Buffer.byteLength(value), 0), stdoutCapBytes: 64 * 1024 * 1024 }));'
```

## Cause

`ImageBudget.endPass()` in `packages/tui/src/components/image.ts` learned the stricter live-image split only after `Image.render()` had queued every Kitty transmit. The render paths in `packages/tui/src/tui.ts` ignored that discovery result and emitted the composed frame, while the transmit queue had no image ID index with which to cancel data for images demoted before output.

## Fix

- Make `ImageBudget.endPass()` request an immediate retry when a pass discovers a stricter split.
- Repeat each complete TUI composition pass until the current budget is applied, before emitting any terminal frame.
- Key queued transmits by image ID so the retry cancels never-emitted data instead of transmitting and then deleting it.
- Add integration coverage asserting an initial over-cap frame emits only the configured live set, plus update the TUI changelog.

## Verification

`bun run test` in `packages/tui` passed: 1,400 tests across 81 files. `bun run check` in `packages/tui` passed Biome and `tsgo`. The 70-image synthetic measurement after the fix performed one pre-emission retry, suppressed 62 images, emitted 8 transmits, and reduced the batch from 78,750,000 bytes to 9,000,000 bytes. The publish gate also passed root `bun check`.

Fixes #10305