### PR TITLE
fix(bash): bound native output-drain so timeouts fire on time

### DIFF
--- a/crates/pi-natives/src/shell.rs
+++ b/crates/pi-natives/src/shell.rs
@@ -1,6 +1,6 @@
 //! Brush-based shell execution exported via N-API.
 
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use napi::{
 	Env, Result,
@@ -231,9 +231,7 @@ impl Shell {
 				.await
 				.map(Into::into)
 				.map_err(|err| Error::from_reason(err.to_string()));
-			if let Some(handle) = drain_handle {
-				let _ = handle.await;
-			}
+			await_drain(drain_handle).await;
 			result
 		})
 	}
@@ -285,9 +283,7 @@ pub fn execute_shell<'env>(
 			.await
 			.map(Into::into)
 			.map_err(|err| Error::from_reason(err.to_string()));
-		if let Some(handle) = drain_handle {
-			let _ = handle.await;
-		}
+		await_drain(drain_handle).await;
 		result
 	})
 }
@@ -352,6 +348,32 @@ async fn pump_chunks(rx: flume::Receiver<String>, mut forward: impl AsyncFnMut(S
 	}
 }
 
+/// Upper bound on how long to wait for the chunk-forwarding pump to finish
+/// after the run future has resolved. The pump normally drains in microseconds
+/// once the command's pipe writers close, but a grandchild that inherited the
+/// stdout pipe can keep a pipe-reader task — and thus one of the bridge-queue
+/// senders — alive indefinitely, so the channel never disconnects and the pump
+/// never returns. Awaiting it unbounded wedged the whole run promise past the
+/// requested timeout, leaving the JS `+5s` watchdog as the only path that ever
+/// returned (#10308).
+const DRAIN_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Await the chunk-forwarding pump, bounded by [`DRAIN_SHUTDOWN_TIMEOUT`].
+///
+/// If the pump does not finish in time — an orphaned reader is still holding a
+/// sender — abort it. Dropping the pump drops its `flume::Receiver`, which
+/// disconnects the channel so the orphaned sender's next `send_async` fails
+/// fast and the detached reader unwinds instead of pinning the run promise.
+async fn await_drain(handle: Option<napi::tokio::task::JoinHandle<()>>) {
+	let Some(mut handle) = handle else {
+		return;
+	};
+	if napi::tokio::time::timeout(DRAIN_SHUTDOWN_TIMEOUT, &mut handle).await.is_err() {
+		handle.abort();
+		let _ = handle.await;
+	}
+}
+
 #[cfg(test)]
 mod tests {
 	use std::time::Duration;
@@ -363,7 +385,7 @@ mod tests {
 	};
 	use tokio::time;
 
-	use super::{BRIDGE_QUEUE_CHUNKS, CoreShell, pump_chunks};
+	use super::{BRIDGE_QUEUE_CHUNKS, CoreShell, DRAIN_SHUTDOWN_TIMEOUT, await_drain, pump_chunks};
 
 	/// Regression for #4078: the reader→JS bridge queue must stay bounded when
 	/// the JS side (here: a deliberately slow `forward`) cannot keep up with a
@@ -439,6 +461,32 @@ mod tests {
 			.await
 			.expect("pump should exit after forward fails")
 			.expect("pump task");
+	}
+
+	/// Regression for #10308: a grandchild that inherits the stdout pipe keeps a
+	/// pipe-reader task alive after the run future resolves, so one bridge-queue
+	/// sender is never dropped and `pump_chunks` never sees channel disconnect.
+	/// `await_drain` must still return (bounded by `DRAIN_SHUTDOWN_TIMEOUT` and
+	/// then aborting the pump) instead of wedging the run promise forever. On
+	/// the pre-fix `let _ = handle.await` this never returned and only the JS
+	/// `+5s` watchdog could recover, producing the reporter's `N+5.00s` signature.
+	#[tokio::test(flavor = "multi_thread")]
+	async fn await_drain_returns_when_a_reader_orphans_a_sender() {
+		let (tx, rx) = flume::bounded::<String>(BRIDGE_QUEUE_CHUNKS);
+		let orphan = tx.clone();
+		let handle = napi::tokio::spawn(pump_chunks(rx, async |_p: String| true));
+		drop(tx);
+		let started = time::Instant::now();
+		time::timeout(DRAIN_SHUTDOWN_TIMEOUT + Duration::from_secs(2), await_drain(Some(handle)))
+			.await
+			.expect("await_drain must return even when a sender is orphaned");
+		assert!(
+			started.elapsed() >= DRAIN_SHUTDOWN_TIMEOUT,
+			"await_drain returned before its bound; the drain was not actually blocked",
+		);
+		// The pump was aborted, so its receiver is dropped: the orphaned sender
+		// now observes a disconnected channel instead of parking forever.
+		assert!(orphan.send("late".to_string()).is_err(), "aborting the pump must disconnect the channel");
 	}
 
 	mod child_session_action_tests {

--- a/crates/pi-natives/src/shell.rs
+++ b/crates/pi-natives/src/shell.rs
@@ -231,7 +231,7 @@ impl Shell {
 				.await
 				.map(Into::into)
 				.map_err(|err| Error::from_reason(err.to_string()));
-			await_drain(drain_handle).await;
+			await_drain(drain_handle, &result).await;
 			result
 		})
 	}
@@ -283,7 +283,7 @@ pub fn execute_shell<'env>(
 			.await
 			.map(Into::into)
 			.map_err(|err| Error::from_reason(err.to_string()));
-		await_drain(drain_handle).await;
+		await_drain(drain_handle, &result).await;
 		result
 	})
 }
@@ -348,27 +348,35 @@ async fn pump_chunks(rx: flume::Receiver<String>, mut forward: impl AsyncFnMut(S
 	}
 }
 
-/// Upper bound on how long to wait for the chunk-forwarding pump to finish
-/// after the run future has resolved. The pump normally drains in microseconds
-/// once the command's pipe writers close, but a grandchild that inherited the
-/// stdout pipe can keep a pipe-reader task — and thus one of the bridge-queue
-/// senders — alive indefinitely, so the channel never disconnects and the pump
-/// never returns. Awaiting it unbounded wedged the whole run promise past the
-/// requested timeout, leaving the JS `+5s` watchdog as the only path that ever
-/// returned (#10308).
-const DRAIN_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(2);
+/// Upper bound on how long to wait for the chunk-forwarding pump after an
+/// interrupted run resolves. Native cancellation may detach a pipe reader whose
+/// sender never closes when a grandchild inherited stdout; waiting for channel
+/// disconnect would then wedge the run promise past its requested timeout
+/// (#10308). Successful and failed runs remain unbounded so every chunk already
+/// accepted by the bridge reaches JavaScript before the result resolves.
+const INTERRUPTED_DRAIN_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(2);
 
-/// Await the chunk-forwarding pump, bounded by [`DRAIN_SHUTDOWN_TIMEOUT`].
+/// Finish forwarding accepted output after a native shell run resolves.
 ///
-/// If the pump does not finish in time — an orphaned reader is still holding a
-/// sender — abort it. Dropping the pump drops its `flume::Receiver`, which
-/// disconnects the channel so the orphaned sender's next `send_async` fails
-/// fast and the detached reader unwinds instead of pinning the run promise.
-async fn await_drain(handle: Option<napi::tokio::task::JoinHandle<()>>) {
+/// Normal completion and errors drain without a deadline to preserve every
+/// accepted chunk. Cancellation and timeout are bounded because an orphaned
+/// pipe reader can otherwise keep a sender alive forever; aborting the pump
+/// drops its `flume::Receiver`, disconnecting that reader.
+async fn await_drain(
+	handle: Option<napi::tokio::task::JoinHandle<()>>,
+	result: &Result<ShellRunResult>,
+) {
 	let Some(mut handle) = handle else {
 		return;
 	};
-	if napi::tokio::time::timeout(DRAIN_SHUTDOWN_TIMEOUT, &mut handle).await.is_err() {
+	if !matches!(result, Ok(result) if result.cancelled || result.timed_out) {
+		let _ = handle.await;
+		return;
+	}
+	if napi::tokio::time::timeout(INTERRUPTED_DRAIN_SHUTDOWN_TIMEOUT, &mut handle)
+		.await
+		.is_err()
+	{
 		handle.abort();
 		let _ = handle.await;
 	}
@@ -376,7 +384,13 @@ async fn await_drain(handle: Option<napi::tokio::task::JoinHandle<()>>) {
 
 #[cfg(test)]
 mod tests {
-	use std::time::Duration;
+	use std::{
+		sync::{
+			Arc,
+			atomic::{AtomicBool, Ordering},
+		},
+		time::Duration,
+	};
 
 	use flume;
 	use pi_shell::{
@@ -385,7 +399,10 @@ mod tests {
 	};
 	use tokio::time;
 
-	use super::{BRIDGE_QUEUE_CHUNKS, CoreShell, DRAIN_SHUTDOWN_TIMEOUT, await_drain, pump_chunks};
+	use super::{
+		BRIDGE_QUEUE_CHUNKS, CoreShell, INTERRUPTED_DRAIN_SHUTDOWN_TIMEOUT, ShellRunResult,
+		await_drain, pump_chunks,
+	};
 
 	/// Regression for #4078: the reader→JS bridge queue must stay bounded when
 	/// the JS side (here: a deliberately slow `forward`) cannot keep up with a
@@ -463,25 +480,65 @@ mod tests {
 			.expect("pump task");
 	}
 
-	/// Regression for #10308: a grandchild that inherits the stdout pipe keeps a
-	/// pipe-reader task alive after the run future resolves, so one bridge-queue
-	/// sender is never dropped and `pump_chunks` never sees channel disconnect.
-	/// `await_drain` must still return (bounded by `DRAIN_SHUTDOWN_TIMEOUT` and
-	/// then aborting the pump) instead of wedging the run promise forever. On
-	/// the pre-fix `let _ = handle.await` this never returned and only the JS
-	/// `+5s` watchdog could recover, producing the reporter's `N+5.00s` signature.
+	/// A successful run must wait for every accepted bridge chunk even when a
+	/// slow JavaScript consumer takes longer than the interrupted-run bound.
+	/// Bounding this path reports success while silently dropping queued output.
 	#[tokio::test(flavor = "multi_thread")]
-	async fn await_drain_returns_when_a_reader_orphans_a_sender() {
+	async fn await_drain_preserves_slow_output_after_success() {
+		let (tx, rx) = flume::bounded::<String>(BRIDGE_QUEUE_CHUNKS);
+		let forwarded = Arc::new(AtomicBool::new(false));
+		let observed = Arc::clone(&forwarded);
+		let handle = napi::tokio::spawn(pump_chunks(rx, async move |_payload: String| {
+			time::sleep(INTERRUPTED_DRAIN_SHUTDOWN_TIMEOUT + Duration::from_millis(100)).await;
+			observed.store(true, Ordering::Release);
+			true
+		}));
+		tx.send("accepted".to_string()).expect("pump should be connected");
+		drop(tx);
+		let result = Ok(ShellRunResult {
+			exit_code:   Some(0),
+			cancelled:   false,
+			timed_out:   false,
+			minimized:   None,
+			working_dir: None,
+		});
+
+		time::timeout(
+			INTERRUPTED_DRAIN_SHUTDOWN_TIMEOUT + Duration::from_secs(2),
+			await_drain(Some(handle), &result),
+		)
+		.await
+		.expect("successful completion must drain slow accepted output");
+		assert!(forwarded.load(Ordering::Acquire), "accepted output was dropped before success returned");
+	}
+
+	/// Regression for #10308: a grandchild that inherits the stdout pipe keeps a
+	/// pipe-reader task alive after an interrupted run resolves, so one
+	/// bridge-queue sender is never dropped and `pump_chunks` never sees channel
+	/// disconnect. `await_drain` must return after the interrupted-run bound and
+	/// abort the pump instead of wedging the native promise forever.
+	#[tokio::test(flavor = "multi_thread")]
+	async fn await_drain_returns_when_a_reader_orphans_a_sender_after_timeout() {
 		let (tx, rx) = flume::bounded::<String>(BRIDGE_QUEUE_CHUNKS);
 		let orphan = tx.clone();
-		let handle = napi::tokio::spawn(pump_chunks(rx, async |_p: String| true));
+		let handle = napi::tokio::spawn(pump_chunks(rx, async |_payload: String| true));
 		drop(tx);
+		let result = Ok(ShellRunResult {
+			exit_code:   None,
+			cancelled:   false,
+			timed_out:   true,
+			minimized:   None,
+			working_dir: None,
+		});
 		let started = time::Instant::now();
-		time::timeout(DRAIN_SHUTDOWN_TIMEOUT + Duration::from_secs(2), await_drain(Some(handle)))
-			.await
-			.expect("await_drain must return even when a sender is orphaned");
+		time::timeout(
+			INTERRUPTED_DRAIN_SHUTDOWN_TIMEOUT + Duration::from_secs(2),
+			await_drain(Some(handle), &result),
+		)
+		.await
+		.expect("await_drain must return when an interrupted reader orphans a sender");
 		assert!(
-			started.elapsed() >= DRAIN_SHUTDOWN_TIMEOUT,
+			started.elapsed() >= INTERRUPTED_DRAIN_SHUTDOWN_TIMEOUT,
 			"await_drain returned before its bound; the drain was not actually blocked",
 		);
 		// The pump was aborted, so its receiver is dropped: the orphaned sender

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Fixed an issue where custom model overrides were lost during configuration updates
 - Fixed "Please use nerdfont" notification incorrectly persisting after theme configuration
 - Fixed sampling parameter errors for newer Anthropic models (Opus 4.7+, Sonnet 5+)
+- Fixed bash tool timeouts hanging an extra 5 seconds and reporting empty output identical to a silent success when a grandchild process held the command's output pipe open; the native shell now bounds its output-drain so the timeout fires on time, timeouts that the safety net had to enforce say the shell backend did not respond, and a wedged run no longer leaks its session ([#10308](https://github.com/can1357/oh-my-pi/issues/10308)).
 
 ## [18.0.11] - 2026-08-29
 

--- a/packages/coding-agent/src/exec/bash-executor.ts
+++ b/packages/coding-agent/src/exec/bash-executor.ts
@@ -159,6 +159,13 @@ const RETAIN_REAP_INTERVAL_MS = 5_000;
 // Native cancellation may spend two seconds unwinding the shell before its
 // N-API chunk bridge drains. The JS watchdog must not race that teardown.
 const NATIVE_TIMEOUT_FALLBACK_GRACE_MS = 5_000;
+// Upper bound on how long a quarantined session's cleanup may pend before the
+// record is force-released. Native cancellation normally settles `runPromise`
+// in ~2s, but a wedged native run (e.g. a grandchild holding the stdout pipe)
+// could otherwise leave the run promise pending for the life of the process,
+// leaking the session key in `brokenShellSessions`/`shellSessionQuarantines`
+// (#10308). The backing timer is unref'd so it never keeps the process alive.
+const QUARANTINE_CLEANUP_TIMEOUT_MS = 30_000;
 
 async function retainShellWithLiveBackgroundJobs(shell: Shell): Promise<void> {
 	let live: number;
@@ -185,15 +192,30 @@ async function retainShellWithLiveBackgroundJobs(shell: Shell): Promise<void> {
 	interval.unref?.();
 }
 
+/**
+ * A timer promise that resolves after {@link QUARANTINE_CLEANUP_TIMEOUT_MS}.
+ * Used to bound quarantine cleanup; the timer is unref'd so it never keeps the
+ * process alive on its own.
+ */
+function quarantineCleanupDeadline(): Promise<void> {
+	const { promise, resolve } = Promise.withResolvers<void>();
+	const timer = setTimeout(resolve, QUARANTINE_CLEANUP_TIMEOUT_MS);
+	timer.unref?.();
+	return promise;
+}
+
 function quarantineShellSession(
 	sessionKey: string,
 	runPromise: Promise<ShellRunResult>,
 	abortCleanupPromise: Promise<void> | undefined,
 ): void {
 	brokenShellSessions.add(sessionKey);
-	const cleanup = abortCleanupPromise
+	const settled = abortCleanupPromise
 		? Promise.allSettled([runPromise, abortCleanupPromise])
 		: Promise.allSettled([runPromise]);
+	// Defensive bound: a never-settling `runPromise` must not pin the quarantine
+	// record for the life of the process (#10308).
+	const cleanup = Promise.race([settled, quarantineCleanupDeadline()]);
 	shellSessionQuarantines.set(sessionKey, cleanup);
 	void cleanup
 		.finally(() => {
@@ -626,15 +648,22 @@ export async function executeBash(command: string, options?: BashExecutorOptions
 			} else {
 				void Promise.allSettled([runPromise, cleanupPromise]);
 			}
+			let notice = "Command cancelled";
+			if (winner.kind === "timeout" && deadlineTimeoutMs !== undefined) {
+				const seconds = Math.round(deadlineTimeoutMs / 1000);
+				// With an explicit timeout the native shell owns enforcement and
+				// this JS timer is only a backstop. If it still wins, the native
+				// run never returned — any output is stuck in the undrained pipe,
+				// so this is not a confirmed empty run (#10308).
+				notice = nativeOwnsTimeout
+					? `Command timed out after ${seconds} seconds; the shell backend did not respond, so any output above may be incomplete`
+					: `Command timed out after ${seconds} seconds`;
+			}
 			return {
 				exitCode: undefined,
 				cancelled: true,
 				...(winner.kind === "timeout" ? { timedOut: true } : {}),
-				...(await sink.dump(
-					winner.kind === "timeout" && deadlineTimeoutMs !== undefined
-						? `Command timed out after ${Math.round(deadlineTimeoutMs / 1000)} seconds`
-						: "Command cancelled",
-				)),
+				...(await sink.dump(notice)),
 			};
 		}
 		if (timeoutTimer) {

--- a/packages/coding-agent/test/bash-executor.test.ts
+++ b/packages/coding-agent/test/bash-executor.test.ts
@@ -787,6 +787,9 @@ exit 64
 		expect(result.cancelled).toBe(true);
 		expect(result.output).toContain("streamed-before-timeout");
 		expect(result.output).toContain("Command timed out after 1 seconds");
+		// Watchdog-win path: native never returned, so the result must be
+		// distinguishable from a confirmed empty run (#10308).
+		expect(result.output).toContain("the shell backend did not respond");
 		expect(nativeSignal?.aborted).toBe(false);
 		expect(abortSpy).toHaveBeenCalledTimes(1);
 	});
@@ -1299,6 +1302,8 @@ exit 64
 		expect(result.cancelled).toBe(true);
 		expect(result.output).toContain("flushed-during-timeout");
 		expect(result.output).toContain("Command timed out after 1 seconds");
+		// Native-confirmed timeout: no "backend did not respond" caveat.
+		expect(result.output).not.toContain("the shell backend did not respond");
 		expect(nativeSignal?.aborted).toBe(false);
 		expect(abortSpy).not.toHaveBeenCalled();
 	});


### PR DESCRIPTION
## Repro
Every bash-tool call with an explicit `timeout` in a poisoned session returned at exactly `timeout + 5.00s` with zero output. A focused Rust repro reproduces the native half: spawn `pump_chunks` over the bridge queue, leak one extra sender clone (simulating a detached pipe-reader task a grandchild keeps alive by holding the stdout pipe open), drop the original sender, then await the pump handle exactly as `pi-natives` did (`let _ = handle.await`). The await never returns; only a 2s outer timeout trips. `cargo nextest run -p pi-natives await_drain_returns_when_a_reader_orphans_a_sender`.

## Cause
`run_shell_command_once` (`crates/pi-shell/src/shell.rs:1097`) spawns `reader_handle`, moving the bridge-queue `Sender` into the reader task. On timeout, `run_shell_session` (`:331-355`) cancels, waits 2s, then `run_task.abort()`. Aborting the parent drops `run_shell_command_once`'s future — which drops the `reader_handle` **JoinHandle** but does not abort the detached reader task, and never reaches the `POST_EXIT` reader-drain/abort (`:1146-1188`) because `run_string` never returned. When a grandchild inherited the stdout write fd, the reader never sees EOF and keeps its `Sender` clone alive, so the flume channel never disconnects. `pump_chunks` only returns on disconnect, so `Shell::run`'s unbounded `drain_handle.await` (`crates/pi-natives/src/shell.rs:234-236`) blocked the run promise forever; only the JS `+5s` watchdog (`NATIVE_TIMEOUT_FALLBACK_GRACE_MS`) ever returned.

## Fix
- `crates/pi-natives/src/shell.rs`: add `await_drain`, bounding the pump-handle await by `DRAIN_SHUTDOWN_TIMEOUT` (2s) and aborting the pump on expiry; aborting drops its `flume::Receiver`, disconnecting the channel so orphaned senders fail fast. Wire it into both `Shell::run` and `execute_shell`.
- `packages/coding-agent/src/exec/bash-executor.ts`: when the JS watchdog wins for an explicit (native-owned) timeout, annotate that the shell backend did not respond and output may be incomplete — distinguishable from a confirmed empty run. The native-confirmed timeout path keeps its original wording.
- `packages/coding-agent/src/exec/bash-executor.ts`: bound `quarantineShellSession` cleanup with `Promise.race` against an unref'd `QUARANTINE_CLEANUP_TIMEOUT_MS` deadline so a never-settling `runPromise` can no longer leak the session key.

## Verification
- `cargo nextest run -p pi-natives shell::` — 12 passed (incl. new `await_drain_returns_when_a_reader_orphans_a_sender`).
- `bun test test/bash-executor.test.ts` — 69 passed (added assertions distinguishing watchdog-win vs native-confirmed timeout annotations).
- `bun test test/bash-failure-result.test.ts` — 5 passed.
- `bun check` — clean.

Fixes #10308