### PR TITLE
fix(coding-agent): persist streamed next-turn messages

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 ### Fixed
 
+- Fixed agent-initiated next-turn messages arriving during streaming being lost before the next prompt ([#10311](https://github.com/can1357/oh-my-pi/issues/10311)).
+
 - Fixed an issue where custom model overrides were lost during configuration updates
 - Fixed "Please use nerdfont" notification incorrectly persisting after theme configuration
 - Fixed sampling parameter errors for newer Anthropic models (Opus 4.7+, Sonnet 5+)

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -8469,12 +8469,6 @@ export class AgentSession {
 				previousSessionContext !== undefined &&
 				didSessionMessagesChange(previousSessionContext.messages, sessionContext.messages);
 			this.#rehydrateCheckpointRewindState();
-			// Re-arm durable next-turn messages from the freshly loaded branch: the
-			// wholesale clear above dropped the previous session's queue, and the
-			// constructor's restore never runs on switch/reload (issue #10311). The
-			// rollback snapshot at #pendingNextTurnMessages taken earlier restores
-			// the prior queue if this switch fails.
-			this.#restoreDurableNextTurnMessages();
 
 			// Emit session_switch event to hooks
 			if (this.#extensionRunner) {
@@ -8487,6 +8481,12 @@ export class AgentSession {
 
 			this.agent.replaceMessages(sessionContext.messages);
 			this.#advisors.resetSessionState({ preserveCost: true });
+			// Re-arm durable next-turn messages from the freshly loaded branch: the
+			// wholesale clear above dropped the previous session's queue, and the
+			// constructor's restore never runs on switch/reload (issue #10311). The
+			// rollback snapshot at #pendingNextTurnMessages taken earlier restores
+			// the prior queue if this switch fails.
+			this.#restoreDurableNextTurnMessages();
 			this.#todo.syncFromBranch();
 			if (switchingToDifferentSession) {
 				this.#closeAllProviderSessions("session switch");

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -369,6 +369,13 @@ import { TtsrCoordinator, type TtsrCoordinatorHost } from "./ttsr-coordinator";
 
 const PLAN_MODE_REMINDER_MAX = 3;
 const POST_PROMPT_DRAIN_TIMEOUT_MS = 5_000;
+const NEXT_TURN_QUEUE_ENTRY_TYPE = "agent-session-next-turn-queued";
+const NEXT_TURN_CONSUMED_ENTRY_TYPE = "agent-session-next-turn-consumed";
+const kDurableNextTurnEntryId = Symbol("agentSession.durableNextTurnEntryId");
+
+type DurableNextTurnMessage = CustomMessage & {
+	[kDurableNextTurnEntryId]?: string;
+};
 
 /** Internal marker for hook messages queued through the agent loop */
 // ============================================================================
@@ -544,9 +551,7 @@ export class AgentSession {
 	#observedSessionId: string | undefined;
 
 	/** Messages queued to be included with the next user prompt as context ("asides"). */
-	#pendingNextTurnMessages: CustomMessage[] = [];
-	/** Queued next-turn messages already persisted before their eventual message-end replay. */
-	#persistedNextTurnMessages = new WeakSet<CustomMessage>();
+	#pendingNextTurnMessages: DurableNextTurnMessage[] = [];
 	#scheduledHiddenNextTurnGeneration: number | undefined = undefined;
 	#queuedMessageDrainScheduled = false;
 	#planModeState: PlanModeState | undefined;
@@ -1053,6 +1058,7 @@ export class AgentSession {
 		this.agent = config.agent;
 		this.#codeModeState = config.codeModeState ?? {};
 		this.sessionManager = config.sessionManager;
+		this.#restoreDurableNextTurnMessages();
 		this.settings = config.settings;
 		this.#modelRegistry = config.modelRegistry;
 		this.#extensionRoots =
@@ -2533,23 +2539,26 @@ export class AgentSession {
 		};
 	}
 
+	#appendCustomMessageEntry(message: CustomMessage | HookMessage): void {
+		this.sessionManager.appendCustomMessageEntry(
+			message.customType,
+			message.content,
+			message.display,
+			message.details,
+			message.attribution ?? "agent",
+			message.timestamp,
+		);
+	}
+
 	#persistMessageEnd(message: AgentMessage): void {
 		if (message.role === "hookMessage" || message.role === "custom") {
-			const alreadyPersisted = message.role === "custom" && this.#persistedNextTurnMessages.delete(message);
 			// Prewalk's plan nudge is a one-run steering instruction. Persisting it would
 			// resurrect the consumed prompt on resume, fork, or any context rebuild.
-			if (!isPrewalkPlanNudge(message) && !alreadyPersisted) {
-				this.sessionManager.appendCustomMessageEntry(
-					message.customType,
-					message.content,
-					message.display,
-					message.details,
-					message.attribution ?? "agent",
-					// Preserve the initiating message's own timestamp: the entry
-					// otherwise records emission time, which on rebuild excludes
-					// provider preparation / hook time from the prompt→yield anchor.
-					message.timestamp,
-				);
+			if (!isPrewalkPlanNudge(message)) {
+				this.#appendCustomMessageEntry(message);
+			}
+			if (message.role === "custom") {
+				this.#consumeDurableNextTurnMessage(message);
 			}
 			if (message.role === "custom" && message.customType === "ttsr-injection") {
 				this.#ttsr.markInjectedFromDetails(message.details);
@@ -4408,6 +4417,7 @@ export class AgentSession {
 		} catch (error) {
 			logger.warn("Active agent run still settling at dispose deadline", { error: String(error) });
 		}
+		this.#materializeDurableNextTurnMessages();
 
 		// Event handlers can reopen the append writer while they persist their
 		// terminal message; that pipeline has drained (or hit the deadline).
@@ -4528,6 +4538,8 @@ export class AgentSession {
 		this.#promptGeneration++;
 		await this.#cancelPostPromptTasks();
 		this.#cancelOwnAsyncJobs();
+		await this.settleInFlightMessagePersistence();
+		this.#materializeDurableNextTurnMessages();
 
 		// Drop the conversation: messages, queued steers/follow-ups, pending tool
 		// calls, and error state. agent.reset() keeps the model and system prompt.
@@ -6550,20 +6562,72 @@ export class AgentSession {
 		return delivered;
 	}
 
-	#queueDurableNextTurnMessage(message: CustomMessage, triggerTurn: boolean): void {
-		this.sessionManager.appendCustomMessageEntry(
-			message.customType,
-			message.content,
-			message.display,
-			message.details,
-			message.attribution ?? "agent",
-			message.timestamp,
-		);
-		this.#persistedNextTurnMessages.add(message);
+	#restoreDurableNextTurnMessages(): void {
+		const queued = new Map<string, DurableNextTurnMessage>();
+		const consumed = new Set<string>();
+		for (const entry of this.sessionManager.getBranch()) {
+			if (entry.type !== "custom") continue;
+			if (entry.customType === NEXT_TURN_QUEUE_ENTRY_TYPE) {
+				const message = this.#parseDurableNextTurnMessage(entry.data);
+				if (message) queued.set(entry.id, message);
+				continue;
+			}
+			if (
+				entry.customType === NEXT_TURN_CONSUMED_ENTRY_TYPE &&
+				isRecord(entry.data) &&
+				typeof entry.data.queuedEntryId === "string"
+			) {
+				consumed.add(entry.data.queuedEntryId);
+			}
+		}
+		for (const entryId of consumed) queued.delete(entryId);
+		for (const [entryId, message] of queued) {
+			this.#pendingNextTurnMessages.push(message);
+			message[kDurableNextTurnEntryId] = entryId;
+		}
+	}
+
+	#parseDurableNextTurnMessage(data: unknown): DurableNextTurnMessage | undefined {
+		if (!isRecord(data) || !isRecord(data.message)) return undefined;
+		const message = data.message;
+		if (message.role !== "custom" || typeof message.timestamp !== "number" || !Number.isFinite(message.timestamp)) {
+			return undefined;
+		}
+		return {
+			role: "custom",
+			...normalizeCustomMessagePayload(message),
+			timestamp: message.timestamp,
+		};
+	}
+
+	#consumeDurableNextTurnMessage(message: DurableNextTurnMessage): boolean {
+		const queuedEntryId = message[kDurableNextTurnEntryId];
+		if (!queuedEntryId) return false;
+		this.sessionManager.appendCustomEntry(NEXT_TURN_CONSUMED_ENTRY_TYPE, { queuedEntryId });
+		delete message[kDurableNextTurnEntryId];
+		return true;
+	}
+
+	#materializeDurableNextTurnMessages(): void {
+		const remaining: DurableNextTurnMessage[] = [];
+		for (const message of this.#pendingNextTurnMessages) {
+			if (!message[kDurableNextTurnEntryId]) {
+				remaining.push(message);
+				continue;
+			}
+			this.#appendCustomMessageEntry(message);
+			this.#consumeDurableNextTurnMessage(message);
+		}
+		this.#pendingNextTurnMessages = remaining;
+	}
+
+	#queueDurableNextTurnMessage(message: DurableNextTurnMessage, triggerTurn: boolean): void {
+		const entryId = this.sessionManager.appendCustomEntry(NEXT_TURN_QUEUE_ENTRY_TYPE, { message });
+		message[kDurableNextTurnEntryId] = entryId;
 		this.#queueHiddenNextTurnMessage(message, triggerTurn);
 	}
 
-	#queueHiddenNextTurnMessage(message: CustomMessage, triggerTurn: boolean): void {
+	#queueHiddenNextTurnMessage(message: DurableNextTurnMessage, triggerTurn: boolean): void {
 		this.#pendingNextTurnMessages.push(message);
 		if (!triggerTurn) return;
 		const generation = this.#promptGeneration;
@@ -6775,13 +6839,7 @@ export class AgentSession {
 				return true;
 			}
 			this.agent.appendMessage(normalizedAppMessage);
-			this.sessionManager.appendCustomMessageEntry(
-				normalizedAppMessage.customType,
-				normalizedAppMessage.content,
-				normalizedAppMessage.display,
-				normalizedAppMessage.details,
-				normalizedAppMessage.attribution,
-			);
+			this.#appendCustomMessageEntry(normalizedAppMessage);
 			return false;
 		}
 
@@ -6795,13 +6853,7 @@ export class AgentSession {
 		}
 
 		this.agent.appendMessage(normalizedAppMessage);
-		this.sessionManager.appendCustomMessageEntry(
-			normalizedAppMessage.customType,
-			normalizedAppMessage.content,
-			normalizedAppMessage.display,
-			normalizedAppMessage.details,
-			normalizedAppMessage.attribution,
-		);
+		this.#appendCustomMessageEntry(normalizedAppMessage);
 		return false;
 	}
 
@@ -7231,6 +7283,8 @@ export class AgentSession {
 		try {
 			advisorRecordersDetached = true;
 			await this.#advisors.drainAndDetachRecorders();
+			await this.settleInFlightMessagePersistence();
+			this.#materializeDurableNextTurnMessages();
 			try {
 				this.agent.reset();
 				if (options?.drop && previousSessionFile) {

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -545,6 +545,8 @@ export class AgentSession {
 
 	/** Messages queued to be included with the next user prompt as context ("asides"). */
 	#pendingNextTurnMessages: CustomMessage[] = [];
+	/** Queued next-turn messages already persisted before their eventual message-end replay. */
+	#persistedNextTurnMessages = new WeakSet<CustomMessage>();
 	#scheduledHiddenNextTurnGeneration: number | undefined = undefined;
 	#queuedMessageDrainScheduled = false;
 	#planModeState: PlanModeState | undefined;
@@ -2533,9 +2535,10 @@ export class AgentSession {
 
 	#persistMessageEnd(message: AgentMessage): void {
 		if (message.role === "hookMessage" || message.role === "custom") {
+			const alreadyPersisted = message.role === "custom" && this.#persistedNextTurnMessages.delete(message);
 			// Prewalk's plan nudge is a one-run steering instruction. Persisting it would
 			// resurrect the consumed prompt on resume, fork, or any context rebuild.
-			if (!isPrewalkPlanNudge(message)) {
+			if (!isPrewalkPlanNudge(message) && !alreadyPersisted) {
 				this.sessionManager.appendCustomMessageEntry(
 					message.customType,
 					message.content,
@@ -6547,6 +6550,19 @@ export class AgentSession {
 		return delivered;
 	}
 
+	#queueDurableNextTurnMessage(message: CustomMessage, triggerTurn: boolean): void {
+		this.sessionManager.appendCustomMessageEntry(
+			message.customType,
+			message.content,
+			message.display,
+			message.details,
+			message.attribution ?? "agent",
+			message.timestamp,
+		);
+		this.#persistedNextTurnMessages.add(message);
+		this.#queueHiddenNextTurnMessage(message, triggerTurn);
+	}
+
 	#queueHiddenNextTurnMessage(message: CustomMessage, triggerTurn: boolean): void {
 		this.#pendingNextTurnMessages.push(message);
 		if (!triggerTurn) return;
@@ -6733,7 +6749,7 @@ export class AgentSession {
 		const normalizedAppMessage = await this.#normalizeAgentMessageImages(appMessage);
 		if (this.isStreaming) {
 			if (options?.deliverAs === "nextTurn") {
-				this.#queueHiddenNextTurnMessage(normalizedAppMessage, options?.triggerTurn ?? false);
+				this.#queueDurableNextTurnMessage(normalizedAppMessage, options?.triggerTurn ?? false);
 				return false;
 			}
 			this.#allowQueuedMessageDrainRetry();
@@ -6750,7 +6766,7 @@ export class AgentSession {
 		if (options?.deliverAs === "nextTurn") {
 			if (options?.triggerTurn) {
 				if (this.#clientBridge?.deferAgentInitiatedTurns && !this.#allowAcpAgentInitiatedTurns) {
-					this.#queueHiddenNextTurnMessage(normalizedAppMessage, false);
+					this.#queueDurableNextTurnMessage(normalizedAppMessage, false);
 					return false;
 				}
 				await this.#promptAgentInitiatedMessage(normalizedAppMessage, {
@@ -6771,7 +6787,7 @@ export class AgentSession {
 
 		if (options?.triggerTurn) {
 			if (this.#clientBridge?.deferAgentInitiatedTurns && !this.#allowAcpAgentInitiatedTurns) {
-				this.#queueHiddenNextTurnMessage(normalizedAppMessage, false);
+				this.#queueDurableNextTurnMessage(normalizedAppMessage, false);
 				return false;
 			}
 			await this.#promptAgentInitiatedMessage(normalizedAppMessage);

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -8469,6 +8469,12 @@ export class AgentSession {
 				previousSessionContext !== undefined &&
 				didSessionMessagesChange(previousSessionContext.messages, sessionContext.messages);
 			this.#rehydrateCheckpointRewindState();
+			// Re-arm durable next-turn messages from the freshly loaded branch: the
+			// wholesale clear above dropped the previous session's queue, and the
+			// constructor's restore never runs on switch/reload (issue #10311). The
+			// rollback snapshot at #pendingNextTurnMessages taken earlier restores
+			// the prior queue if this switch fails.
+			this.#restoreDurableNextTurnMessages();
 
 			// Emit session_switch event to hooks
 			if (this.#extensionRunner) {

--- a/packages/coding-agent/test/agent-session-advisor-suppression.test.ts
+++ b/packages/coding-agent/test/agent-session-advisor-suppression.test.ts
@@ -497,11 +497,11 @@ describe("AgentSession advisor auto-resume suppression", () => {
 		const running = session.prompt("do the thing");
 		await streamStarted;
 
-		// A suppressed delivery arriving while the turn is still streaming parks the
-		// concern hidden in #pendingNextTurnMessages (the mid-abort race window).
+		// A suppressed delivery arriving while the turn is still streaming stays
+		// hidden from live context but is durable during the mid-abort race window.
 		await session.sendCustomMessage(advisorCard("parked mid-abort"), { deliverAs: "nextTurn", triggerTurn: false });
 		expect(session.agent.state.messages.filter(isAdvisorCard)).toHaveLength(0);
-		expect(persisted).toEqual([]);
+		expect(persisted).toEqual(["parked mid-abort"]);
 
 		await session.abort({ reason: USER_INTERRUPT_LABEL });
 		await session.waitForIdle();

--- a/packages/coding-agent/test/agent-session-advisor-suppression.test.ts
+++ b/packages/coding-agent/test/agent-session-advisor-suppression.test.ts
@@ -498,10 +498,10 @@ describe("AgentSession advisor auto-resume suppression", () => {
 		await streamStarted;
 
 		// A suppressed delivery arriving while the turn is still streaming stays
-		// hidden from live context but is durable during the mid-abort race window.
+		// hidden and queued durably until abort cleanup can place it after the turn.
 		await session.sendCustomMessage(advisorCard("parked mid-abort"), { deliverAs: "nextTurn", triggerTurn: false });
 		expect(session.agent.state.messages.filter(isAdvisorCard)).toHaveLength(0);
-		expect(persisted).toEqual(["parked mid-abort"]);
+		expect(persisted).toEqual([]);
 
 		await session.abort({ reason: USER_INTERRUPT_LABEL });
 		await session.waitForIdle();

--- a/packages/coding-agent/test/agent-session-concurrent.test.ts
+++ b/packages/coding-agent/test/agent-session-concurrent.test.ts
@@ -407,7 +407,7 @@ describe("AgentSession concurrent prompt guard", () => {
 		).toHaveLength(1);
 	});
 
-	it("restores durable next-turn messages when switching into a session mid-queue", async () => {
+	it("restores durable advisor messages after session switch resets advisor state", async () => {
 		const model = getBundledModel("anthropic", "claude-sonnet-4-5")!;
 		const seedDir = path.join(tempDir, "seed-sessions");
 		fs.mkdirSync(seedDir, { recursive: true });
@@ -416,8 +416,8 @@ describe("AgentSession concurrent prompt guard", () => {
 		seedManager.appendCustomEntry("agent-session-next-turn-queued", {
 			message: {
 				role: "custom",
-				customType: "async-result",
-				content: "Background result",
+				customType: "advisor",
+				content: "Persisted concern",
 				display: true,
 				attribution: "agent",
 				timestamp: Date.now(),
@@ -471,16 +471,16 @@ describe("AgentSession concurrent prompt guard", () => {
 				.at(-1)
 				?.context.messages.some(message =>
 					typeof message.content === "string"
-						? message.content.includes("Background result")
+						? message.content.includes("Persisted concern")
 						: message.content.some(
-								content => content.type === "text" && content.text.includes("Background result"),
+								content => content.type === "text" && content.text.includes("Persisted concern"),
 							),
 				),
 		).toBe(true);
 		expect(
 			session.sessionManager
 				.getEntries()
-				.filter(entry => entry.type === "custom_message" && entry.customType === "async-result"),
+				.filter(entry => entry.type === "custom_message" && entry.customType === "advisor"),
 		).toHaveLength(1);
 		expect(
 			session.sessionManager

--- a/packages/coding-agent/test/agent-session-concurrent.test.ts
+++ b/packages/coding-agent/test/agent-session-concurrent.test.ts
@@ -407,6 +407,88 @@ describe("AgentSession concurrent prompt guard", () => {
 		).toHaveLength(1);
 	});
 
+	it("restores durable next-turn messages when switching into a session mid-queue", async () => {
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5")!;
+		const seedDir = path.join(tempDir, "seed-sessions");
+		fs.mkdirSync(seedDir, { recursive: true });
+		const seedManager = SessionManager.create(tempDir, seedDir);
+		seedManager.appendMessage({ role: "user", content: "First message", timestamp: Date.now() });
+		seedManager.appendCustomEntry("agent-session-next-turn-queued", {
+			message: {
+				role: "custom",
+				customType: "async-result",
+				content: "Background result",
+				display: true,
+				attribution: "agent",
+				timestamp: Date.now(),
+			},
+		});
+		seedManager.appendMessage({
+			role: "assistant",
+			content: [{ type: "text", text: "Done" }],
+			api: model.api,
+			provider: model.provider,
+			model: model.id,
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "stop",
+			timestamp: Date.now(),
+		});
+		await seedManager.flush();
+		const seedFile = seedManager.getSessionFile();
+		if (!seedFile) throw new Error("Expected seeded session file");
+		await seedManager.close();
+
+		const activeDir = path.join(tempDir, "active-sessions");
+		fs.mkdirSync(activeDir, { recursive: true });
+		const sessionManager = SessionManager.create(tempDir, activeDir);
+		const mock = createMockModel({ handler: () => ({ content: ["Continued"] }) });
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model, systemPrompt: ["Test"], tools: [] },
+			streamFn: mock.stream,
+			convertToLlm,
+		});
+		session = new AgentSession({
+			agent,
+			sessionManager,
+			settings: Settings.isolated(),
+			modelRegistry: sharedModelRegistry,
+		});
+
+		expect(await session.switchSession(seedFile)).toBe(true);
+		await session.prompt("Next user prompt");
+		await session.settleInFlightMessagePersistence();
+
+		expect(
+			mock.calls
+				.at(-1)
+				?.context.messages.some(message =>
+					typeof message.content === "string"
+						? message.content.includes("Background result")
+						: message.content.some(
+								content => content.type === "text" && content.text.includes("Background result"),
+							),
+				),
+		).toBe(true);
+		expect(
+			session.sessionManager
+				.getEntries()
+				.filter(entry => entry.type === "custom_message" && entry.customType === "async-result"),
+		).toHaveLength(1);
+		expect(
+			session.sessionManager
+				.getEntries()
+				.filter(entry => entry.type === "custom" && entry.customType === "agent-session-next-turn-consumed"),
+		).toHaveLength(1);
+	});
+
 	it("uses non-empty session_stop reason when additional context is empty", async () => {
 		const model = getBundledModel("anthropic", "claude-sonnet-4-5")!;
 		const mock = createMockModel({

--- a/packages/coding-agent/test/agent-session-concurrent.test.ts
+++ b/packages/coding-agent/test/agent-session-concurrent.test.ts
@@ -248,6 +248,72 @@ describe("AgentSession concurrent prompt guard", () => {
 		expect(session.isStreaming).toBe(false);
 	});
 
+	it("persists next-turn custom messages queued during streaming exactly once", async () => {
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5")!;
+		const started = Promise.withResolvers<void>();
+		const release = Promise.withResolvers<void>();
+		const mock = createMockModel({
+			handler: async () => {
+				started.resolve();
+				await release.promise;
+				return { content: ["Done"] };
+			},
+		});
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model, systemPrompt: ["Test"], tools: [] },
+			streamFn: mock.stream,
+			convertToLlm,
+		});
+		const sessionManager = SessionManager.inMemory();
+		session = new AgentSession({
+			agent,
+			sessionManager,
+			settings: Settings.isolated(),
+			modelRegistry: sharedModelRegistry,
+		});
+
+		const firstPrompt = session.prompt("First message");
+		await started.promise;
+		await session.sendCustomMessage(
+			{
+				customType: "async-result",
+				content: "Background result",
+				display: true,
+				attribution: "agent",
+			},
+			{ deliverAs: "nextTurn" },
+		);
+
+		expect(
+			sessionManager
+				.getEntries()
+				.filter(entry => entry.type === "custom_message" && entry.customType === "async-result"),
+		).toHaveLength(1);
+
+		release.resolve();
+		await firstPrompt;
+		await session.prompt("Next user prompt");
+		await session.settleInFlightMessagePersistence();
+
+		expect(
+			sessionManager
+				.getEntries()
+				.filter(entry => entry.type === "custom_message" && entry.customType === "async-result"),
+		).toHaveLength(1);
+		expect(
+			mock.calls
+				.at(-1)
+				?.context.messages.some(message =>
+					typeof message.content === "string"
+						? message.content.includes("Background result")
+						: message.content.some(
+								content => content.type === "text" && content.text.includes("Background result"),
+							),
+				),
+		).toBe(true);
+	});
+
 	it("uses non-empty session_stop reason when additional context is empty", async () => {
 		const model = getBundledModel("anthropic", "claude-sonnet-4-5")!;
 		const mock = createMockModel({

--- a/packages/coding-agent/test/agent-session-concurrent.test.ts
+++ b/packages/coding-agent/test/agent-session-concurrent.test.ts
@@ -288,11 +288,17 @@ describe("AgentSession concurrent prompt guard", () => {
 		expect(
 			sessionManager
 				.getEntries()
-				.filter(entry => entry.type === "custom_message" && entry.customType === "async-result"),
+				.filter(entry => entry.type === "custom" && entry.customType === "agent-session-next-turn-queued"),
 		).toHaveLength(1);
+		expect(
+			sessionManager
+				.getEntries()
+				.filter(entry => entry.type === "custom_message" && entry.customType === "async-result"),
+		).toHaveLength(0);
 
 		release.resolve();
 		await firstPrompt;
+		expect(JSON.stringify(sessionManager.buildSessionContext().messages)).not.toContain("Background result");
 		await session.prompt("Next user prompt");
 		await session.settleInFlightMessagePersistence();
 
@@ -300,6 +306,18 @@ describe("AgentSession concurrent prompt guard", () => {
 			sessionManager
 				.getEntries()
 				.filter(entry => entry.type === "custom_message" && entry.customType === "async-result"),
+		).toHaveLength(1);
+		expect(sessionManager.buildSessionContext().messages.map(message => message.role)).toEqual([
+			"user",
+			"assistant",
+			"user",
+			"custom",
+			"assistant",
+		]);
+		expect(
+			sessionManager
+				.getEntries()
+				.filter(entry => entry.type === "custom" && entry.customType === "agent-session-next-turn-consumed"),
 		).toHaveLength(1);
 		expect(
 			mock.calls
@@ -312,6 +330,81 @@ describe("AgentSession concurrent prompt guard", () => {
 							),
 				),
 		).toBe(true);
+	});
+
+	it("restores durable next-turn messages after a streaming interruption without reordering the transcript", async () => {
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5")!;
+		const sessionManager = SessionManager.inMemory();
+		sessionManager.appendMessage({ role: "user", content: "First message", timestamp: Date.now() });
+		sessionManager.appendCustomEntry("agent-session-next-turn-queued", {
+			message: {
+				role: "custom",
+				customType: "async-result",
+				content: "Background result",
+				display: true,
+				attribution: "agent",
+				timestamp: Date.now(),
+			},
+		});
+		const firstAssistant: AssistantMessage = {
+			role: "assistant",
+			content: [{ type: "text", text: "Done" }],
+			api: model.api,
+			provider: model.provider,
+			model: model.id,
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "stop",
+			timestamp: Date.now(),
+		};
+		sessionManager.appendMessage(firstAssistant);
+
+		const mock = createMockModel({ handler: () => ({ content: ["Continued"] }) });
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: {
+				model,
+				systemPrompt: ["Test"],
+				tools: [],
+				messages: sessionManager.buildSessionContext().messages,
+			},
+			streamFn: mock.stream,
+			convertToLlm,
+		});
+		session = new AgentSession({
+			agent,
+			sessionManager,
+			settings: Settings.isolated(),
+			modelRegistry: sharedModelRegistry,
+		});
+
+		await session.prompt("Next user prompt");
+		await session.settleInFlightMessagePersistence();
+
+		expect(sessionManager.buildSessionContext().messages.map(message => message.role)).toEqual([
+			"user",
+			"assistant",
+			"user",
+			"custom",
+			"assistant",
+		]);
+		expect(mock.calls.at(-1)?.context.messages.map(message => message.role)).toEqual([
+			"user",
+			"assistant",
+			"user",
+			"developer",
+		]);
+		expect(
+			sessionManager
+				.getEntries()
+				.filter(entry => entry.type === "custom_message" && entry.customType === "async-result"),
+		).toHaveLength(1);
 	});
 
 	it("uses non-empty session_stop reason when additional context is empty", async () => {


### PR DESCRIPTION
## Repro
While an agent turn is streaming, queue an agent-authored custom message with `sendCustomMessage(..., { deliverAs: "nextTurn" })`, then inspect `SessionManager` before another prompt. `bun test packages/coding-agent/test/agent-session-concurrent.test.ts -t "persists next-turn custom messages queued during streaming exactly once"` previously failed because zero `custom_message` entries existed.

## Cause
`AgentSession.sendCustomMessage` in `packages/coding-agent/src/session/agent-session.ts` routed streaming and deferred-client next-turn messages only through `#queueHiddenNextTurnMessage`. That queue is memory-only, while the idle path immediately appends a `CustomMessageEntry`, so durability depended on delivery timing.

## Fix
- Persist public next-turn messages when they enter the hidden queue.
- Track those message objects until replay so `#persistMessageEnd` does not write a duplicate entry.
- Cover immediate streaming durability, exactly-once replay persistence, and advisor abort cleanup.
- Document the user-visible fix in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/agent-session-concurrent.test.ts` — 25 passed. `bun test packages/coding-agent/test/agent-session-advisor-suppression.test.ts` — 17 passed. `bun check` — passed.

Fixes #10311