### PR TITLE
fix(tools): respect custom web search overrides

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Fixed
 
+- Fixed custom extension `web_search` tools being shadowed by built-in search when enabled ([#10315](https://github.com/can1357/oh-my-pi/issues/10315)).
 - Fixed an issue where custom model overrides were lost during configuration updates
 - Fixed "Please use nerdfont" notification incorrectly persisting after theme configuration
 - Fixed sampling parameter errors for newer Anthropic models (Opus 4.7+, Sonnet 5+)

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -209,7 +209,6 @@ import {
 	EvalTool,
 	GlobTool,
 	GrepTool,
-	getSearchTools,
 	HIDDEN_TOOLS,
 	isMountableUnderXdev,
 	type LspStartupServerInfo,
@@ -2045,11 +2044,6 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 
 			if (settings.get("speechgen.enabled")) {
 				customTools.push(ttsTool as unknown as CustomTool);
-			}
-
-			// Add web search tools
-			if (options.toolNames?.includes("web_search")) {
-				customTools.push(...getSearchTools());
 			}
 
 			// Discover custom tools from `.omp/tools/`, `.claude/tools/`, plugins, etc.

--- a/packages/coding-agent/src/web/search/index.ts
+++ b/packages/coding-agent/src/web/search/index.ts
@@ -11,8 +11,6 @@ import type { AuthStorage } from "@oh-my-pi/pi-ai";
 import { prompt } from "@oh-my-pi/pi-utils";
 import { ModelRegistry } from "../../config/model-registry";
 import { settings } from "../../config/settings";
-import type { CustomTool, CustomToolContext, RenderResultOptions } from "../../extensibility/custom-tools/types";
-import type { Theme } from "../../modes/theme/theme";
 import webSearchSystemPrompt from "../../prompts/system/web-search.md" with { type: "text" };
 import webSearchDescription from "../../prompts/tools/web-search.md" with { type: "text" };
 import { discoverAuthStorage } from "../../sdk";
@@ -29,7 +27,7 @@ import {
 	type SearchProviderCandidate,
 } from "./provider";
 import { applyQueryConstraints, parseSearchQuery } from "./query";
-import { renderSearchCall, renderSearchResult, type SearchRenderDetails } from "./render";
+import type { SearchRenderDetails } from "./render";
 import {
 	DEFAULT_WEB_SEARCH_TIMEOUT_SECONDS,
 	MAX_WEB_SEARCH_TIMEOUT_SECONDS,
@@ -348,44 +346,6 @@ export class WebSearchTool implements AgentTool<typeof webSearchSchema, SearchRe
 			signal,
 		});
 	}
-}
-
-/** Web search tool as CustomTool (for TUI rendering support) */
-export const webSearchCustomTool: CustomTool<typeof webSearchSchema, SearchRenderDetails> = {
-	name: "web_search",
-	label: "Web Search",
-	description: prompt.render(webSearchDescription),
-	parameters: webSearchSchema,
-
-	approval: "read",
-	async execute(
-		toolCallId: string,
-		params: SearchToolParams,
-		_onUpdate,
-		ctx: CustomToolContext,
-		signal?: AbortSignal,
-	) {
-		const authStorage = ctx.modelRegistry?.authStorage ?? (await discoverAuthStorage());
-		const sessionId = ctx.sessionManager.getSessionId();
-		return executeSearch(toolCallId, params, {
-			authStorage,
-			modelRegistry: ctx.modelRegistry,
-			sessionId,
-			signal,
-		});
-	},
-
-	renderCall(args: SearchToolParams, options: RenderResultOptions, theme: Theme) {
-		return renderSearchCall(args, options, theme);
-	},
-
-	renderResult(result, options: RenderResultOptions, theme: Theme, args) {
-		return renderSearchResult(result, options, theme, args);
-	},
-};
-
-export function getSearchTools(): CustomTool<any, any>[] {
-	return [webSearchCustomTool];
 }
 
 export { getSearchProvider, setExcludedSearchProviders, setSearchProviderOrder } from "./provider";

--- a/packages/coding-agent/test/agent-session-message-pipeline.test.ts
+++ b/packages/coding-agent/test/agent-session-message-pipeline.test.ts
@@ -17,6 +17,7 @@ import {
 	registerCustomApi,
 	type SimpleStreamOptions,
 	type TextContent,
+	type ToolCall,
 } from "@oh-my-pi/pi-ai";
 import { AssistantMessageEventStream } from "@oh-my-pi/pi-ai/utils/event-stream";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
@@ -1217,6 +1218,101 @@ describe("AgentSession message pipeline", () => {
 			// The native bash actually ran the wrapper's command, not the model's.
 			expect(delegatedText).toContain("from-wrapper");
 			expect(delegatedText).not.toContain("from-model");
+		} finally {
+			await session.dispose();
+			authStorage.close();
+		}
+	});
+
+	it("uses an extension web_search implementation when the built-in is enabled", async () => {
+		using tempDir = TempDir.createSync("@pi-web-search-override-");
+		const api: Api = "test-web-search-override";
+		let requests = 0;
+		registerCustomApi(api, () => {
+			requests++;
+			const stream = new AssistantMessageEventStream();
+			queueMicrotask(() => {
+				if (requests === 1) {
+					const message = createAssistantMessage("");
+					const toolCall: ToolCall = {
+						type: "toolCall",
+						id: "call-web-search-1",
+						name: "web_search",
+						arguments: {},
+					};
+					message.content = [toolCall];
+					message.stopReason = "toolUse";
+					stream.push({ type: "toolcall_start", contentIndex: 0, partial: message });
+					stream.push({ type: "toolcall_end", contentIndex: 0, toolCall, partial: message });
+					stream.push({ type: "done", reason: "toolUse", message });
+				} else {
+					const message = createAssistantMessage("done");
+					stream.push({ type: "done", reason: "stop", message });
+				}
+			});
+			return stream;
+		});
+		const modelSpec: ModelSpec<Api> = {
+			id: "local-web-search-override-model",
+			name: "Local Web Search Override Model",
+			api,
+			provider: "ollama",
+			baseUrl: "http://127.0.0.1:11434",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 4096,
+			maxTokens: 1024,
+		};
+		const model = buildModel(modelSpec);
+		let customInvoked = false;
+		const customWebSearch: ExtensionFactory = pi => {
+			pi.registerTool({
+				name: "web_search",
+				label: "Custom Web Search",
+				description: "Custom extension web search",
+				parameters: pi.arktype({}),
+				async execute() {
+					customInvoked = true;
+					return {
+						content: [{ type: "text", text: "custom-web-search-result" }],
+						details: {},
+					};
+				},
+			});
+		};
+		const authStorage = await AuthStorage.create(tempDir.join("auth.db"));
+		const modelRegistry = new ModelRegistry(authStorage, tempDir.join("models.yml"));
+		const { session } = await createAgentSession({
+			cwd: tempDir.path(),
+			agentDir: tempDir.path(),
+			sessionManager: SessionManager.inMemory(tempDir.path()),
+			authStorage,
+			modelRegistry,
+			settings: Settings.isolated({
+				"compaction.enabled": false,
+				"tools.xdev": false,
+				"web_search.enabled": true,
+			}),
+			model,
+			disableExtensionDiscovery: true,
+			extensions: [customWebSearch],
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+			skipPythonPreflight: true,
+			toolNames: ["web_search"],
+		});
+		try {
+			await session.sendUserMessage("search");
+
+			expect(customInvoked).toBe(true);
+			const toolResult = session.agent.state.messages.find(message => message.role === "toolResult");
+			const text = toolResult?.content.find(block => block.type === "text");
+			expect(text?.type === "text" ? text.text : "").toBe("custom-web-search-result");
 		} finally {
 			await session.dispose();
 			authStorage.close();


### PR DESCRIPTION
## Repro
An extension registers `web_search`, then starts a session with built-in search enabled through `toolNames: ["web_search"]`; `bun test packages/coding-agent/test/agent-session-message-pipeline.test.ts --test-name-pattern "uses an extension web_search"` previously showed the extension executor was never called.

## Cause
`createAgentSession()` in `packages/coding-agent/src/sdk.ts` appended `getSearchTools()` to the synthetic custom-tools extension after user extensions loaded. `ExtensionRunner.getAllRegisteredTools()` preserves extension order and the registry applies last-extension-wins precedence, so the duplicate built-in `web_search` wrapper replaced the user's registration.

## Fix
- Remove the duplicate custom-tool representation and register web search only through the native `WebSearchTool`.
- Add an end-to-end regression test that invokes an extension-owned `web_search` while built-in search is enabled.
- Document the corrected extension behavior in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/agent-session-message-pipeline.test.ts packages/coding-agent/test/web/search/render.test.ts packages/coding-agent/test/tools/web-search-public.test.ts` passes 36 tests; `bun check` passes.

Fixes #10315