### PR TITLE
fix(session): exclude inherited cost from /tan forks

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Fixed an issue where custom model overrides were lost during configuration updates
 - Fixed "Please use nerdfont" notification incorrectly persisting after theme configuration
 - Fixed sampling parameter errors for newer Anthropic models (Opus 4.7+, Sonnet 5+)
+- Fixed `/tan` sessions inheriting the parent's accumulated cost, which exaggerated subagent totals in the Agents view ([#10317](https://github.com/can1357/oh-my-pi/issues/10317)).
 
 ## [18.0.11] - 2026-08-29
 

--- a/packages/coding-agent/src/modes/controllers/tan-command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/tan-command-controller.ts
@@ -114,6 +114,10 @@ export class TanCommandController {
 				copyArtifacts: false,
 				suppressBreadcrumb: true,
 				sessionFile: cloneFile,
+				// A tan is a fresh agent forking the parent's transcript only for
+				// context; its cost must reflect its own work, not the parent's
+				// accumulated spend that session cost is otherwise derived from.
+				resetInheritedCost: true,
 			});
 
 			jobId = manager.register(

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -198,6 +198,19 @@ function addUsage(target: UsageStatistics, usage: Usage | undefined): void {
 	target.cost += usage.cost.total;
 }
 
+/**
+ * Zero the monetary attribution on one usage record in place, leaving token
+ * counts untouched. Cost, credit meters, and premium-request counts describe
+ * billing; forks that must not inherit spend (see {@link SessionManager.forkFrom}
+ * `resetInheritedCost`) drop them while keeping the tokens compaction relies on.
+ */
+function resetUsageCost(usage: Usage | undefined): void {
+	if (!usage) return;
+	usage.cost = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 };
+	usage.credits = undefined;
+	usage.premiumRequests = undefined;
+}
+
 function isAssistantEntry(entry: SessionEntry): boolean {
 	return entry.type === "message" && entry.message.role === "assistant";
 }
@@ -2799,7 +2812,12 @@ export class SessionManager {
 		cwd: string,
 		sessionDir?: string,
 		storage: SessionStorage = new FileSessionStorage(),
-		options?: { copyArtifacts?: boolean; suppressBreadcrumb?: boolean; sessionFile?: string },
+		options?: {
+			copyArtifacts?: boolean;
+			suppressBreadcrumb?: boolean;
+			sessionFile?: string;
+			resetInheritedCost?: boolean;
+		},
 	): Promise<SessionManager> {
 		const dir = sessionDir ?? SessionManager.getDefaultSessionDir(cwd, undefined, storage);
 		const manager = new SessionManager(cwd, dir, true, storage);
@@ -2811,6 +2829,7 @@ export class SessionManager {
 
 		const sourceHeader = sourceEntries.find(entry => entry.type === "session") as SessionHeader | undefined;
 		const history = sourceEntries.filter(entry => entry.type !== "session") as SessionEntry[];
+		if (options?.resetInheritedCost) SessionManager.#resetInheritedUsageCost(history);
 		manager.#resetToNewSession(
 			{
 				parentSession: sourceHeader?.id,
@@ -2836,6 +2855,21 @@ export class SessionManager {
 			await copySessionArtifacts(sourcePath, manager.#sessionFile!);
 		}
 		return manager;
+	}
+
+	/**
+	 * Zero the monetary attribution (cost, credits, premium requests) on the
+	 * forked history's assistant turns and completed `task` results, in place.
+	 *
+	 * A tan fork is a fresh agent that inherits the parent's transcript purely
+	 * for context; its spend must reflect only its own work. Session cost is
+	 * derived by summing `usage.cost` over the transcript, so without this the
+	 * clone's Agent Hub row would open at the parent's entire accumulated cost.
+	 * Token counts are left intact — compaction anchors and context math depend
+	 * on them — since only billing attribution is inherited, not context size.
+	 */
+	static #resetInheritedUsageCost(history: SessionEntry[]): void {
+		for (const entry of history) resetUsageCost(entryUsage(entry));
 	}
 
 	/**

--- a/packages/coding-agent/test/modes/controllers/tan-command-controller.test.ts
+++ b/packages/coding-agent/test/modes/controllers/tan-command-controller.test.ts
@@ -218,7 +218,12 @@ describe("TanCommandController", () => {
 			harness.tempDir.path(),
 			harness.parentFile.slice(0, -6),
 			undefined,
-			{ copyArtifacts: false, suppressBreadcrumb: true, sessionFile: expect.stringMatching(/Tan-.+\.jsonl$/) },
+			{
+				copyArtifacts: false,
+				suppressBreadcrumb: true,
+				sessionFile: expect.stringMatching(/Tan-.+\.jsonl$/),
+				resetInheritedCost: true,
+			},
 		);
 		expect(harness.register).toHaveBeenCalledWith("task", "/tan write the release note", expect.any(Function), {
 			ownerId: MAIN_AGENT_ID,

--- a/packages/coding-agent/test/session/session-manager-fork.test.ts
+++ b/packages/coding-agent/test/session/session-manager-fork.test.ts
@@ -171,4 +171,77 @@ describe("SessionManager.forkFrom", () => {
 		expect(await Bun.file(path.join(forkArtifactsDir, "unrelated.txt")).exists()).toBe(false);
 		expect(await Bun.file(unrelatedFile).text()).toBe("must not be copied");
 	});
+
+	it("zeroes inherited cost while preserving token counts only when reset is requested", async () => {
+		using tempDir = TempDir.createSync("@omp-session-fork-cost-");
+		const cwd = path.join(tempDir.path(), "project");
+		const sessionDir = path.join(tempDir.path(), "sessions");
+		await fs.mkdir(sessionDir, { recursive: true });
+		const sourceFile = path.join(sessionDir, "source.jsonl");
+		const timestamp = new Date().toISOString();
+		const sourceHeader: SessionHeader = {
+			type: "session",
+			version: CURRENT_SESSION_VERSION,
+			id: "cost-source",
+			timestamp,
+			cwd,
+		};
+		const assistantEntry = {
+			type: "message",
+			id: "assistant-1",
+			parentId: null,
+			timestamp,
+			message: {
+				role: "assistant",
+				content: [],
+				api: "anthropic-messages",
+				provider: "anthropic",
+				model: "claude",
+				stopReason: "stop",
+				timestamp: Date.now(),
+				usage: {
+					input: 100,
+					output: 50,
+					cacheRead: 10,
+					cacheWrite: 5,
+					totalTokens: 165,
+					premiumRequests: 2,
+					credits: { cost: 3, committedCost: 3, acuCost: 1 },
+					cost: { input: 1, output: 4, cacheRead: 0.5, cacheWrite: 0.5, total: 6 },
+				},
+			},
+		};
+		await Bun.write(sourceFile, `${JSON.stringify(sourceHeader)}\n${JSON.stringify(assistantEntry)}\n`);
+
+		const findAssistant = async (file: string) => {
+			const entries = await loadEntriesFromFile(file);
+			const entry = entries.find((e): e is SessionMessageEntry => e.type === "message");
+			if (entry?.message.role !== "assistant") throw new Error("expected assistant message");
+			return entry.message;
+		};
+
+		const preserved = await SessionManager.forkFrom(sourceFile, cwd, path.join(tempDir.path(), "keep"), undefined, {
+			suppressBreadcrumb: true,
+		});
+		const preservedFile = preserved.getSessionFile();
+		if (!preservedFile) throw new Error("expected preserved fork file");
+		const preservedMessage = await findAssistant(preservedFile);
+		expect(preservedMessage.usage.cost.total).toBe(6);
+		expect(preservedMessage.usage.premiumRequests).toBe(2);
+
+		const reset = await SessionManager.forkFrom(sourceFile, cwd, path.join(tempDir.path(), "reset"), undefined, {
+			suppressBreadcrumb: true,
+			resetInheritedCost: true,
+		});
+		const resetFile = reset.getSessionFile();
+		if (!resetFile) throw new Error("expected reset fork file");
+		const resetMessage = await findAssistant(resetFile);
+		expect(resetMessage.usage.cost).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 });
+		expect(resetMessage.usage.credits).toBeUndefined();
+		expect(resetMessage.usage.premiumRequests).toBeUndefined();
+		// Token counts are context, not spend — compaction anchors depend on them.
+		expect(resetMessage.usage.input).toBe(100);
+		expect(resetMessage.usage.output).toBe(50);
+		expect(resetMessage.usage.totalTokens).toBe(165);
+	});
 });


### PR DESCRIPTION
## Repro
With a long-running main session (say $5000 accumulated), running `/tan <prompt>` and opening the Agents view (CMD+A) shows the freshly started tan agent's cost already at the parent's full total. Minimal reproduction: build a parent session whose assistant turns sum to $5000, fork it the way `/tan` does (`SessionManager.forkFrom`), and sum `usage.cost.total` over the clone's transcript — the clone reports $5000 before doing any work.

```
default fork (pre-fix tan behavior): 5000
resetInheritedCost fork (fixed tan): 0
```

## Cause
`/tan` forks the parent's entire transcript into the clone via `SessionManager.forkFrom` (`tan-command-controller.ts`), and per-session cost is never tracked as a delta — it is derived by summing `usage.cost.total` over every assistant turn (and embedded `task` results) in the transcript (`SessionStatsTracker.getSessionStats`, `agent-hub-projection.ts` `readSessionMetrics`, `persisted-agents.ts`). Because the clone's transcript contains all of the parent's billed turns, the parent's spend is re-attributed to the child. Providers are not re-billed — the copied `usage` is historical metadata — so only the displayed attribution double-counts (both the per-row total and the Hub aggregate).

## Fix
- `SessionManager.forkFrom` gains a `resetInheritedCost` option. When set, a new static helper walks the forked history and, via the existing `entryUsage` accessor, zeroes the monetary attribution (`cost`, `credits`, `premiumRequests`) on inherited assistant turns and completed `task` results in place. Token counts are left untouched — compaction anchors and context math depend on them; only billing attribution is inherited, not context size.
- A module-level `resetUsageCost` helper performs the in-place zeroing.
- `TanCommandController.start` passes `resetInheritedCost: true`. The `--fork` resume path in `main.ts` is unchanged, so resuming your own session still preserves full cost history.
- Applied at the entry level, so every downstream cost path — live `readSessionMetrics`/`getSessionStats`, the on-disk `persisted-agents` reconstruction for parked tans, and the Hub aggregate — sees only the tan's own spend, and the fix survives compaction.

## Verification
`bun test test/session/session-manager-fork.test.ts test/modes/controllers/tan-command-controller.test.ts test/agent-session-stats.test.ts` → 19 pass / 0 fail. Added a fork regression test asserting the reset path zeroes cost/credits/premium-requests while preserving token counts, and that the default fork preserves cost (branch distinction). Manually reproduced the $5000→$0 contrast shown above against the current source. `Fixes #10317`