### PR TITLE
fix(coding-agent): force-complete streaming reveal at tool-call boundary

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Fixed an issue where custom model overrides were lost during configuration updates
 - Fixed "Please use nerdfont" notification incorrectly persisting after theme configuration
 - Fixed sampling parameter errors for newer Anthropic models (Opus 4.7+, Sonnet 5+)
+- Fixed trailing assistant text being truncated when a tool call started mid-stream: the smooth-streaming reveal now force-completes at the tool-call boundary instead of leaving un-revealed text to be committed to scrollback ([#10318](https://github.com/can1357/oh-my-pi/issues/10318)).
 
 ## [18.0.11] - 2026-08-29
 

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -953,10 +953,8 @@ export class EventController {
 			this.ctx.streamingComponent = createAssistantMessageComponent(this.ctx);
 			this.ctx.streamingMessage = event.message;
 			this.ctx.chatContainer.addChild(this.ctx.streamingComponent);
-			this.#streamingReveal.begin(
-				this.ctx.streamingComponent,
-				splitAssistantMessageToolTimeline(this.ctx.streamingMessage).beforeTools,
-			);
+			const timeline = splitAssistantMessageToolTimeline(this.ctx.streamingMessage);
+			this.#streamingReveal.begin(this.ctx.streamingComponent, timeline.beforeTools, timeline.hasToolCalls);
 			this.ctx.ui.requestRender();
 		}
 	}
@@ -1142,7 +1140,7 @@ export class EventController {
 			}
 			this.ctx.streamingMessage = event.message;
 			const timeline = splitAssistantMessageToolTimeline(this.ctx.streamingMessage);
-			this.#streamingReveal.setTarget(timeline.beforeTools);
+			this.#streamingReveal.setTarget(timeline.beforeTools, timeline.hasToolCalls);
 
 			const visibleBlockCount = this.ctx.streamingMessage.content.filter(
 				content =>

--- a/packages/coding-agent/src/modes/controllers/streaming-reveal.ts
+++ b/packages/coding-agent/src/modes/controllers/streaming-reveal.ts
@@ -248,7 +248,7 @@ export class StreamingRevealController {
 		);
 	}
 
-	begin(component: StreamingRevealComponent, message: AssistantMessage): void {
+	begin(component: StreamingRevealComponent, message: AssistantMessage, hasToolCalls: boolean): void {
 		this.stop();
 		this.#component = component;
 		this.#target = message;
@@ -262,7 +262,7 @@ export class StreamingRevealController {
 			return;
 		}
 		const total = this.#visibleUnits(message);
-		if (message.content.some(block => block.type === "toolCall")) {
+		if (hasToolCalls) {
 			// A tool call is a transcript-order boundary: finish any leading
 			// assistant text before EventController renders the separate tool card.
 			this.#revealed = total;
@@ -275,7 +275,7 @@ export class StreamingRevealController {
 		this.#syncTimer(total);
 	}
 
-	setTarget(message: AssistantMessage): void {
+	setTarget(message: AssistantMessage, hasToolCalls: boolean): void {
 		this.#target = message;
 		this.#hideThinkingBlock = this.#getHideThinkingBlock();
 		this.#proseOnlyThinking = this.#getProseOnlyThinking();
@@ -290,7 +290,7 @@ export class StreamingRevealController {
 			return;
 		}
 		const total = this.#visibleUnits(message);
-		if (message.content.some(block => block.type === "toolCall")) {
+		if (hasToolCalls) {
 			// A tool call is a transcript-order boundary: finish any leading
 			// assistant text before EventController renders the separate tool card.
 			this.#revealed = total;

--- a/packages/coding-agent/src/modes/controllers/streaming-reveal.ts
+++ b/packages/coding-agent/src/modes/controllers/streaming-reveal.ts
@@ -223,6 +223,7 @@ export class StreamingRevealController {
 	#timer: NodeJS.Timeout | undefined;
 	#revealed = 0;
 	#targetDirty = false;
+	#snappedToolBoundaryContent: AssistantMessage["content"] | undefined;
 	#hideThinkingBlock = false;
 	#proseOnlyThinking = true;
 	#smoothStreaming = true;
@@ -269,6 +270,7 @@ export class StreamingRevealController {
 			component.updateContent(this.#build(message, this.#revealed), {
 				transient: true,
 			});
+			this.#snappedToolBoundaryContent = message.content;
 			return;
 		}
 		this.#renderCurrent();
@@ -291,15 +293,23 @@ export class StreamingRevealController {
 		}
 		const total = this.#visibleUnits(message);
 		if (hasToolCalls) {
+			const alreadySnapped =
+				this.#revealed === total &&
+				this.#snappedToolBoundaryContent !== undefined &&
+				Bun.deepEquals(this.#snappedToolBoundaryContent, message.content);
 			// A tool call is a transcript-order boundary: finish any leading
 			// assistant text before EventController renders the separate tool card.
 			this.#revealed = total;
+			this.#targetDirty = false;
 			this.#stopTimer();
+			if (alreadySnapped) return;
 			this.#component.updateContent(this.#build(message, this.#revealed), {
 				transient: true,
 			});
+			this.#snappedToolBoundaryContent = message.content;
 			return;
 		}
+		this.#snappedToolBoundaryContent = undefined;
 		if (this.#revealed > total) {
 			this.#revealed = total;
 		}
@@ -324,6 +334,7 @@ export class StreamingRevealController {
 		this.#component = undefined;
 		this.#revealed = 0;
 		this.#targetDirty = false;
+		this.#snappedToolBoundaryContent = undefined;
 		this.#unitCounter.reset();
 	}
 

--- a/packages/coding-agent/src/modes/controllers/streaming-reveal.ts
+++ b/packages/coding-agent/src/modes/controllers/streaming-reveal.ts
@@ -223,6 +223,11 @@ export class StreamingRevealController {
 	#timer: NodeJS.Timeout | undefined;
 	#revealed = 0;
 	#targetDirty = false;
+	// Immutable deep clone of the leading content snapped at the tool-call
+	// boundary. Kept independent of the live message so an in-place provider
+	// rewrite of a previously emitted block (e.g. OpenAI Responses replacing
+	// streamed text with authoritative terminal content) is still detected —
+	// aliasing the live array would make the equality check compare it to itself.
 	#snappedToolBoundaryContent: AssistantMessage["content"] | undefined;
 	#hideThinkingBlock = false;
 	#proseOnlyThinking = true;
@@ -270,7 +275,7 @@ export class StreamingRevealController {
 			component.updateContent(this.#build(message, this.#revealed), {
 				transient: true,
 			});
-			this.#snappedToolBoundaryContent = message.content;
+			this.#snappedToolBoundaryContent = structuredClone(message.content);
 			return;
 		}
 		this.#renderCurrent();
@@ -306,7 +311,7 @@ export class StreamingRevealController {
 			this.#component.updateContent(this.#build(message, this.#revealed), {
 				transient: true,
 			});
-			this.#snappedToolBoundaryContent = message.content;
+			this.#snappedToolBoundaryContent = structuredClone(message.content);
 			return;
 		}
 		this.#snappedToolBoundaryContent = undefined;

--- a/packages/coding-agent/test/streaming-reveal.test.ts
+++ b/packages/coding-agent/test/streaming-reveal.test.ts
@@ -156,11 +156,11 @@ describe("streaming reveal", () => {
 		const target = makeMessage([{ type: "thinking", thinking: "```js\nconst x = 1;\n```" }]);
 		const { component, controller } = makeController({ smooth: false, proseOnly: () => proseOnly });
 
-		controller.begin(component, target);
+		controller.begin(component, target, false);
 		expect(thinkingAt(latestMessage(component), 0)).toBe("...");
 
 		proseOnly = false;
-		controller.setTarget(target);
+		controller.setTarget(target, false);
 		expect(thinkingAt(latestMessage(component), 0)).toBe("```js\nconst x = 1;\n```");
 	});
 
@@ -193,12 +193,12 @@ describe("streaming reveal", () => {
 		const first = makeMessage([{ type: "text", text: "Hello" }]);
 		const second = makeMessage([{ type: "text", text: "Hello world" }]);
 
-		controller.begin(component, makeMessage([{ type: "text", text: "" }]));
-		controller.setTarget(first);
+		controller.begin(component, makeMessage([{ type: "text", text: "" }]), false);
+		controller.setTarget(first, false);
 		for (let i = 0; i < 4; i++) {
 			vi.advanceTimersByTime(STREAMING_REVEAL_FRAME_MS);
 		}
-		controller.setTarget(second);
+		controller.setTarget(second, false);
 		for (let i = 0; i < 4; i++) {
 			vi.advanceTimersByTime(STREAMING_REVEAL_FRAME_MS);
 		}
@@ -215,13 +215,13 @@ describe("streaming reveal", () => {
 		vi.useFakeTimers();
 		const { component, controller } = makeController();
 
-		controller.begin(component, makeMessage([{ type: "text", text: "" }]));
-		controller.setTarget(makeMessage([{ type: "text", text: "ab👨" }]));
+		controller.begin(component, makeMessage([{ type: "text", text: "" }]), false);
+		controller.setTarget(makeMessage([{ type: "text", text: "ab👨" }]), false);
 		vi.advanceTimersByTime(STREAMING_REVEAL_FRAME_MS);
 		// The appended ZWJ sequence merges into the previous final grapheme:
 		// "👨" + "\u200D👩" becomes a single cluster, so the cached per-block
 		// count must re-segment from that cluster, not just add the suffix.
-		controller.setTarget(makeMessage([{ type: "text", text: "ab👨\u200D👩x" }]));
+		controller.setTarget(makeMessage([{ type: "text", text: "ab👨\u200D👩x" }]), false);
 		for (let i = 0; i < 6; i++) {
 			vi.advanceTimersByTime(STREAMING_REVEAL_FRAME_MS);
 		}
@@ -234,8 +234,8 @@ describe("streaming reveal", () => {
 		const requestRender = vi.fn();
 		const { component, controller } = makeController({ smooth: false, requestRender });
 
-		controller.begin(component, makeMessage([{ type: "text", text: "chunk" }]));
-		controller.setTarget(makeMessage([{ type: "text", text: "chunky" }]));
+		controller.begin(component, makeMessage([{ type: "text", text: "chunk" }]), false);
+		controller.setTarget(makeMessage([{ type: "text", text: "chunky" }]), false);
 		const updates = component.messages.length;
 		vi.advanceTimersByTime(STREAMING_REVEAL_FRAME_MS * 10);
 
@@ -247,8 +247,8 @@ describe("streaming reveal", () => {
 	it("marks unsmoothed in-flight updates as transient", () => {
 		const { component, controller } = makeController({ smooth: false });
 
-		controller.begin(component, makeMessage([{ type: "text", text: "chunk" }]));
-		controller.setTarget(makeMessage([{ type: "text", text: "chunky" }]));
+		controller.begin(component, makeMessage([{ type: "text", text: "chunk" }]), false);
+		controller.setTarget(makeMessage([{ type: "text", text: "chunky" }]), false);
 
 		expect(component.transientFlags).toEqual([true, true]);
 	});
@@ -257,8 +257,8 @@ describe("streaming reveal", () => {
 		vi.useFakeTimers();
 		const { component, controller } = makeController();
 
-		controller.begin(component, makeMessage([{ type: "text", text: "" }]));
-		controller.setTarget(makeMessage([{ type: "text", text: "abc" }]));
+		controller.begin(component, makeMessage([{ type: "text", text: "" }]), false);
+		controller.setTarget(makeMessage([{ type: "text", text: "abc" }]), false);
 		vi.advanceTimersByTime(STREAMING_REVEAL_FRAME_MS);
 
 		expect(textAt(latestMessage(component), 0)).toBe("abc");
@@ -270,8 +270,8 @@ describe("streaming reveal", () => {
 		vi.useFakeTimers();
 		const { component, controller } = makeController();
 
-		controller.begin(component, makeMessage([{ type: "text", text: "" }]));
-		controller.setTarget(makeMessage([{ type: "text", text: "abcdefghi" }]));
+		controller.begin(component, makeMessage([{ type: "text", text: "" }]), false);
+		controller.setTarget(makeMessage([{ type: "text", text: "abcdefghi" }]), false);
 		vi.advanceTimersByTime(STREAMING_REVEAL_FRAME_MS);
 		controller.stop();
 		const updates = component.messages.length;
@@ -287,23 +287,34 @@ describe("streaming reveal", () => {
 		const requestRender = vi.fn();
 		const { component, controller } = makeController({ requestRender });
 
-		controller.begin(component, makeMessage([{ type: "text", text: "" }]));
-		controller.setTarget(makeMessage([{ type: "text", text: "abcdefghi" }]));
+		controller.begin(component, makeMessage([{ type: "text", text: "" }]), false);
+		controller.setTarget(makeMessage([{ type: "text", text: "abcdefghi" }]), false);
 		vi.advanceTimersByTime(STREAMING_REVEAL_FRAME_MS);
 		expect(textAt(latestMessage(component), 0)).toBe("abc");
 
-		controller.setTarget(
-			makeMessage([
-				{ type: "text", text: "abcdefghi" },
-				{ type: "toolCall", id: "call-1", name: "read", arguments: { path: "README.md" } },
-			]),
-		);
+		// Production hands the reveal the tool-stripped `beforeTools` segment plus
+		// an explicit `hasToolCalls` flag — the target itself never carries a
+		// toolCall block, so the boundary must be signalled, not re-derived.
+		controller.setTarget(makeMessage([{ type: "text", text: "abcdefghi" }]), true);
 		const updates = component.messages.length;
 		vi.advanceTimersByTime(STREAMING_REVEAL_FRAME_MS * 10);
 
 		expect(textAt(latestMessage(component), 0)).toBe("abcdefghi");
 		expect(component.messages).toHaveLength(updates);
 		expect(requestRender).toHaveBeenCalledTimes(1);
+	});
+
+	it("snaps to full text when a tool call arrives before the first reveal tick", () => {
+		// #10318: when the tool call lands before any 30fps tick runs, #revealed
+		// is still 0. Without force-completing at the boundary the block commits
+		// blank and the entire reply vanishes, not just its tail.
+		vi.useFakeTimers();
+		const { component, controller } = makeController();
+
+		controller.begin(component, makeMessage([{ type: "text", text: "" }]), false);
+		controller.setTarget(makeMessage([{ type: "text", text: "Let me wait for that result." }]), true);
+
+		expect(textAt(latestMessage(component), 0)).toBe("Let me wait for that result.");
 	});
 
 	it("passes the bound component to requestRender on each smooth tick", () => {
@@ -314,8 +325,8 @@ describe("streaming reveal", () => {
 		const requestRender = vi.fn();
 		const { component, controller } = makeController({ requestRender });
 
-		controller.begin(component, makeMessage([{ type: "text", text: "" }]));
-		controller.setTarget(makeMessage([{ type: "text", text: "abcdef" }]));
+		controller.begin(component, makeMessage([{ type: "text", text: "" }]), false);
+		controller.setTarget(makeMessage([{ type: "text", text: "abcdef" }]), false);
 		vi.advanceTimersByTime(STREAMING_REVEAL_FRAME_MS);
 
 		expect(requestRender).toHaveBeenCalled();
@@ -435,8 +446,8 @@ describe("frame-skip coalescing", () => {
 		const tail = "x".repeat(30);
 		const fullText = base + tail;
 
-		controller.begin(component, makeMessage([{ type: "text", text: "" }]));
-		controller.setTarget(makeMessage([{ type: "text", text: base }]));
+		controller.begin(component, makeMessage([{ type: "text", text: "" }]), false);
+		controller.setTarget(makeMessage([{ type: "text", text: base }]), false);
 		vi.advanceTimersByTime(STREAMING_REVEAL_FRAME_MS * 10);
 		expect(textAt(latestMessage(component), 0)).toBe(base);
 
@@ -445,7 +456,7 @@ describe("frame-skip coalescing", () => {
 		let text = base;
 		for (let i = 0; i < 30; i++) {
 			text += tail[i];
-			controller.setTarget(makeMessage([{ type: "text", text }]));
+			controller.setTarget(makeMessage([{ type: "text", text }]), false);
 			vi.advanceTimersByTime(STREAMING_REVEAL_FRAME_MS / 5);
 		}
 		const burstRenders = component.messages.length - before;
@@ -463,25 +474,19 @@ describe("frame-skip coalescing", () => {
 		vi.useFakeTimers();
 		const { component, controller } = makeController();
 
-		controller.begin(component, makeMessage([{ type: "text", text: "" }]));
-		controller.setTarget(makeMessage([{ type: "text", text: "hi" }]));
+		controller.begin(component, makeMessage([{ type: "text", text: "" }]), false);
+		controller.setTarget(makeMessage([{ type: "text", text: "hi" }]), false);
 		vi.advanceTimersByTime(STREAMING_REVEAL_FRAME_MS);
 		expect(textAt(latestMessage(component), 0)).toBe("hi");
 
 		// Same reveal budget as "hi" -> caught up: drain is deferred to a tick.
-		controller.setTarget(makeMessage([{ type: "text", text: "yo" }]));
+		controller.setTarget(makeMessage([{ type: "text", text: "yo" }]), false);
 		const pending = component.messages.length;
 		expect(textAt(latestMessage(component), 0)).toBe("hi");
-		controller.setTarget(
-			makeMessage([
-				{ type: "text", text: "yo" },
-				{ type: "toolCall", id: "call-1", name: "read", arguments: { path: "README.md" } },
-			]),
-		);
+		controller.setTarget(makeMessage([{ type: "text", text: "yo" }]), true);
 		// The toolCall boundary still renders synchronously, before any tick.
 		expect(component.messages.length).toBe(pending + 1);
 		expect(textAt(latestMessage(component), 0)).toBe("yo");
-		expect(latestMessage(component).content.at(-1)?.type).toBe("toolCall");
 		vi.advanceTimersByTime(STREAMING_REVEAL_FRAME_MS * 4);
 		expect(component.messages.length).toBe(pending + 1);
 	});
@@ -490,10 +495,10 @@ describe("frame-skip coalescing", () => {
 		vi.useFakeTimers();
 		const { component, controller } = makeController({ smooth: false });
 
-		controller.begin(component, makeMessage([{ type: "text", text: "" }]));
-		controller.setTarget(makeMessage([{ type: "text", text: "one" }]));
+		controller.begin(component, makeMessage([{ type: "text", text: "" }]), false);
+		controller.setTarget(makeMessage([{ type: "text", text: "one" }]), false);
 		const before = component.messages.length;
-		controller.setTarget(makeMessage([{ type: "text", text: "one two" }]));
+		controller.setTarget(makeMessage([{ type: "text", text: "one two" }]), false);
 
 		expect(component.messages.length).toBe(before + 1);
 		expect(textAt(latestMessage(component), 0)).toBe("one two");
@@ -511,13 +516,13 @@ describe("frame-skip coalescing", () => {
 			requestRender: () => {},
 		});
 
-		controller.begin(component, makeMessage([{ type: "text", text: "" }]));
-		controller.setTarget(makeMessage([{ type: "text", text: "hi" }]));
+		controller.begin(component, makeMessage([{ type: "text", text: "" }]), false);
+		controller.setTarget(makeMessage([{ type: "text", text: "hi" }]), false);
 		vi.advanceTimersByTime(STREAMING_REVEAL_FRAME_MS);
-		controller.setTarget(makeMessage([{ type: "text", text: "yo" }]));
+		controller.setTarget(makeMessage([{ type: "text", text: "yo" }]), false);
 
 		smooth = false;
-		controller.setTarget(makeMessage([{ type: "text", text: "abcdefghij" }]));
+		controller.setTarget(makeMessage([{ type: "text", text: "abcdefghij" }]), false);
 		expect(textAt(latestMessage(component), 0)).toBe("abcdefghij");
 
 		vi.advanceTimersByTime(STREAMING_REVEAL_FRAME_MS);
@@ -529,12 +534,12 @@ describe("frame-skip coalescing", () => {
 		vi.useFakeTimers();
 		const { component, controller } = makeController();
 
-		controller.begin(component, makeMessage([{ type: "text", text: "" }]));
-		controller.setTarget(makeMessage([{ type: "text", text: "hi" }]));
+		controller.begin(component, makeMessage([{ type: "text", text: "" }]), false);
+		controller.setTarget(makeMessage([{ type: "text", text: "hi" }]), false);
 		vi.advanceTimersByTime(STREAMING_REVEAL_FRAME_MS);
 		expect(textAt(latestMessage(component), 0)).toBe("hi");
 
-		controller.setTarget(makeMessage([{ type: "text", text: "hi!" }]));
+		controller.setTarget(makeMessage([{ type: "text", text: "hi!" }]), false);
 		const before = component.messages.length;
 		vi.advanceTimersByTime(STREAMING_REVEAL_FRAME_MS);
 		expect(component.messages.length).toBe(before + 1);
@@ -549,13 +554,13 @@ describe("frame-skip coalescing", () => {
 		vi.useFakeTimers();
 		const { component, controller } = makeController();
 
-		controller.begin(component, makeMessage([{ type: "text", text: "" }]));
-		controller.setTarget(makeMessage([{ type: "text", text: "hi" }]));
+		controller.begin(component, makeMessage([{ type: "text", text: "" }]), false);
+		controller.setTarget(makeMessage([{ type: "text", text: "hi" }]), false);
 		vi.advanceTimersByTime(STREAMING_REVEAL_FRAME_MS);
 		expect(textAt(latestMessage(component), 0)).toBe("hi");
 
 		// Caught up: "yo" has the same reveal budget, so the render is deferred.
-		controller.setTarget(makeMessage([{ type: "text", text: "yo" }]));
+		controller.setTarget(makeMessage([{ type: "text", text: "yo" }]), false);
 		const before = component.messages.length;
 		vi.advanceTimersByTime(STREAMING_REVEAL_FRAME_MS);
 		expect(component.messages.length).toBe(before + 1);

--- a/packages/coding-agent/test/streaming-reveal.test.ts
+++ b/packages/coding-agent/test/streaming-reveal.test.ts
@@ -491,6 +491,25 @@ describe("frame-skip coalescing", () => {
 		expect(component.messages.length).toBe(pending + 1);
 	});
 
+	it("does not rebuild an unchanged target after the tool-call boundary", () => {
+		vi.useFakeTimers();
+		const { component, controller } = makeController();
+
+		controller.begin(component, makeMessage([{ type: "text", text: "" }]), false);
+		controller.setTarget(makeMessage([{ type: "text", text: "before tool" }]), true);
+		const snapped = component.messages.length;
+
+		// Cumulative tool argument deltas repeat the unchanged beforeTools segment.
+		controller.setTarget(makeMessage([{ type: "text", text: "before tool" }]), true);
+		expect(component.messages).toHaveLength(snapped);
+
+		// A provider rewrite of the leading segment must still repaint, even when
+		// the replacement has the same reveal-unit count.
+		controller.setTarget(makeMessage([{ type: "text", text: "after  tool" }]), true);
+		expect(component.messages).toHaveLength(snapped + 1);
+		expect(textAt(latestMessage(component), 0)).toBe("after  tool");
+	});
+
 	it("keeps synchronous per-setTarget renders when smooth streaming is off", () => {
 		vi.useFakeTimers();
 		const { component, controller } = makeController({ smooth: false });

--- a/packages/coding-agent/test/streaming-reveal.test.ts
+++ b/packages/coding-agent/test/streaming-reveal.test.ts
@@ -510,6 +510,28 @@ describe("frame-skip coalescing", () => {
 		expect(textAt(latestMessage(component), 0)).toBe("after  tool");
 	});
 
+	it("detects an in-place block rewrite of the snapped tool-boundary content", () => {
+		// OpenAI Responses reuses the cumulative output object and can replace
+		// streamed text with authoritative terminal content in place. Aliasing the
+		// snapped array would compare it to itself and keep the stale text; an
+		// immutable snapshot must still repaint even when the rewrite has the same
+		// grapheme count.
+		vi.useFakeTimers();
+		const { component, controller } = makeController();
+
+		const message = makeMessage([{ type: "text", text: "streamed abc" }]);
+		const block = message.content[0]! as Extract<AssistantMessage["content"][number], { type: "text" }>;
+		controller.begin(component, makeMessage([{ type: "text", text: "" }]), false);
+		controller.setTarget(message, true);
+		const snapped = component.messages.length;
+
+		// Same array, same length, block rewritten in place.
+		block.text = "streamed xyz";
+		controller.setTarget(message, true);
+		expect(component.messages).toHaveLength(snapped + 1);
+		expect(textAt(latestMessage(component), 0)).toBe("streamed xyz");
+	});
+
 	it("keeps synchronous per-setTarget renders when smooth streaming is off", () => {
 		vi.useFakeTimers();
 		const { component, controller } = makeController({ smooth: false });


### PR DESCRIPTION
## Repro
When smooth streaming was still typing out assistant text at the moment a tool call started, the trailing (un-revealed) words were truncated permanently — intermittent, depending on whether the reveal was behind at the boundary. Reproduced with `bun test test/streaming-reveal.test.ts -t "snaps to full text when a tool call arrives"`: with the shipped condition, the reveal defers to timer ticks (4 renders) instead of snapping (2), and those extra deferred renders are exactly the tail that production commits to native scrollback and loses.

## Cause
`splitAssistantMessageToolTimeline` (`packages/coding-agent/src/modes/utils/transcript-render-helpers.ts:208-227`) strips every `toolCall` block from the `beforeTools` segment by construction. `EventController` fed that stripped segment to `StreamingRevealController.begin`/`setTarget`, which decided whether to force-complete the typewriter by testing *that segment* for a `toolCall` block (`streaming-reveal.ts:265,293`) — a structurally unreachable branch. On the same delta, `event-controller.ts:1166` tested the *full* message, found the tool call, and called `markTranscriptBlockFinalized()`, committing the block's rows to native scrollback before the reveal had typed them. The `message_end` render arrives after the commit and cannot repaint committed rows.

## Fix
- `StreamingRevealController.begin`/`setTarget` take an explicit `hasToolCalls` flag and force-complete on it instead of re-deriving it from a segment that cannot carry a `toolCall` block (`streaming-reveal.ts`).
- `EventController` threads `timeline.hasToolCalls` into both `begin` (`event-controller.ts:957`) and `setTarget` (`event-controller.ts:1143`).
- Updated the two tests that handed `setTarget` an inline `toolCall` block — a shape production never produces — to signal the boundary via the flag, so they now exercise the real production path (`test/streaming-reveal.test.ts`).
- Changelog entry under `[Unreleased] > Fixed`.

## Verification
`bun test test/streaming-reveal.test.ts` → 27 pass, 0 fail. Confirmed the regression test fails (4 renders vs 2 expected) when the branch is reverted to the shipped `message.content.some(...)` check, and passes with the fix. Fixes #10318