### PR TITLE
fix(coding-agent): batch guided-goal questions with ask

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -95,6 +95,10 @@
 - Prevented browser `app.path` from terminating existing same-executable applications when no reusable CDP endpoint is available.
 - Fixed top-level errors overwriting the active composer before terminal restoration.
 - Fixed Enter being ignored during the first turn when omp starts with an initial prompt.
+- Fixed an issue where custom model overrides were lost during configuration updates
+- Fixed "Please use nerdfont" notification incorrectly persisting after theme configuration
+- Fixed sampling parameter errors for newer Anthropic models (Opus 4.7+, Sonnet 5+)
+- Fixed `/guided-goal` interviews to ask batched questions through the built-in ask tool.
 
 ## [18.0.11] - 2026-08-29
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,8 @@
 - TypeScript code intelligence now works on TypeScript 7 projects: the built-in `typescript-native` server runs `tsc --lsp --stdio` when the resolved TypeScript install no longer ships `tsserver.js`, replacing `typescript-language-server` for that project.
 - Claude marketplace MCP servers now resolve environment placeholders in stdio environment values instead of passing strings such as `${NAME:-}` literally ([#10481](https://github.com/can1357/oh-my-pi/pull/10481) by [@mrexodia](https://github.com/mrexodia)).
 - Fixed prewalk conflicting with `todo.eager=always`: the forced eager-todo prelude ("call todo first this turn") was injected alongside the prewalk plan nudge ("write a complete plan first, then todo"), giving the model contradictory instructions; the eager-todo prelude is now suppressed only when prewalk will perform a handoff ([#10510](https://github.com/can1357/oh-my-pi/issues/10510)).
+- Fixed `/guided-goal` interviews to ask batched questions through the built-in ask tool.
+
 ## [18.1.2] - 2026-09-01
 
 ### Added
@@ -95,10 +97,6 @@
 - Prevented browser `app.path` from terminating existing same-executable applications when no reusable CDP endpoint is available.
 - Fixed top-level errors overwriting the active composer before terminal restoration.
 - Fixed Enter being ignored during the first turn when omp starts with an initial prompt.
-- Fixed an issue where custom model overrides were lost during configuration updates
-- Fixed "Please use nerdfont" notification incorrectly persisting after theme configuration
-- Fixed sampling parameter errors for newer Anthropic models (Opus 4.7+, Sonnet 5+)
-- Fixed `/guided-goal` interviews to ask batched questions through the built-in ask tool.
 
 ## [18.0.11] - 2026-08-29
 

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -245,6 +245,17 @@ import { UiHelpers } from "./utils/ui-helpers";
 const STILL_CLOSING_DELAY_MS = 3_000;
 const DEFAULT_WORKING_MESSAGE = "Working…";
 
+type GuidedGoalInterview =
+	| { phase: "dispatching"; previousTools: string[]; settled: Promise<void> }
+	| { phase: "pending" | "cleanup-failed"; previousTools: string[] }
+	| { phase: "restoring"; previousTools: string[]; restore: Promise<boolean> };
+
+interface GoalModeExitOptions {
+	silent?: boolean;
+	paused?: boolean;
+	reason?: "completed" | "paused" | "dropped";
+}
+
 interface WorkingMessageAccent {
 	main: string;
 	dim: string;
@@ -729,8 +740,9 @@ export class InteractiveMode implements InteractiveModeContext {
 	#headerAfter: readonly Component[] = [];
 	#planModePreviousTools: string[] | undefined;
 	#goalModePreviousTools: string[] | undefined;
-	#guidedGoalInterviewPending = false;
-	#guidedGoalInterviewDispatching = false;
+	#goalModeExit: Promise<boolean> | undefined;
+	#goalModeExitPending: GoalModeExitOptions | undefined;
+	#guidedGoalInterview: GuidedGoalInterview | undefined;
 	#vibeModePreviousTools: string[] | undefined;
 	#vibeModeOwnerScope: VibeOwnerScope | undefined;
 	#vibeScopeSuspendedForSwitch = false;
@@ -1124,8 +1136,13 @@ export class InteractiveMode implements InteractiveModeContext {
 			getDraftText: () => this.#inputController.getDraftText(),
 			beginDispose: () => this.session.beginDispose(),
 			saveDraft: text => this.sessionManager.saveDraft(text),
-			disposeSession: reason =>
-				this.session.dispose({ mnemopiConsolidateTimeoutMs: SHUTDOWN_CONSOLIDATE_BUDGET_MS, reason }),
+			disposeSession: async reason => {
+				await this.#retryPendingGoalModeExit(true);
+				await this.session.dispose({
+					mnemopiConsolidateTimeoutMs: SHUTDOWN_CONSOLIDATE_BUDGET_MS,
+					reason,
+				});
+			},
 		});
 		// Forward the postmortem reason (SIGTERM/SIGHUP/uncaughtException/…) so the
 		// persisted `session_exit` diagnostic carries the real trigger. Postmortem
@@ -1302,9 +1319,11 @@ export class InteractiveMode implements InteractiveModeContext {
 
 		// Restore mode from session (e.g. plan mode on resume)
 		this.session.setSessionBeforeSwitchReconciler?.(async () => {
-			await this.#restoreGuidedGoalInterviewTools();
+			if (!(await this.#restoreGuidedGoalInterviewTools())) return false;
+			if (!(await this.#retryPendingGoalModeExit())) return false;
 			await this.#liveCommandController.stop();
 			await this.#quiesceVibeForSessionSwitch();
+			return true;
 		});
 		this.session.setSessionSwitchReconciler?.(() => this.#reconcileModeFromSession({ preserveActiveGoal: true }));
 		await logger.time("InteractiveMode.init:reconcileMode", () => this.#reconcileModeFromSession());
@@ -1652,8 +1671,8 @@ export class InteractiveMode implements InteractiveModeContext {
 	}
 
 	async getUserInput(): Promise<SubmittedUserInput> {
-		if (this.session.getGoalModeState()?.mode === "exiting") {
-			await this.#exitGoalMode({ reason: "completed", silent: true });
+		if (!(await this.#retryPendingGoalModeExit())) {
+			throw new Error("Cannot accept input until goal mode restores the previous tool set.");
 		}
 		const { promise, resolve } = Promise.withResolvers<SubmittedUserInput>();
 		this.onInputCallback = input => {
@@ -2861,18 +2880,44 @@ export class InteractiveMode implements InteractiveModeContext {
 		};
 	}
 
-	async #restoreGuidedGoalInterviewTools(): Promise<void> {
-		if (!this.#guidedGoalInterviewPending) return;
-		this.#guidedGoalInterviewPending = false;
-		this.#guidedGoalInterviewDispatching = false;
-		const previousTools = this.#goalModePreviousTools;
-		this.#goalModePreviousTools = undefined;
-		if (!previousTools) return;
-		try {
-			await this.session.setActiveToolsByName(previousTools);
-		} catch (error) {
-			logger.warn("Failed to restore tools after guided goal interview", { error: String(error) });
+	async #restoreGuidedGoalInterviewTools(): Promise<boolean> {
+		const interview = this.#guidedGoalInterview;
+		if (!interview) return true;
+		if (interview.phase === "restoring") {
+			return await interview.restore;
 		}
+		if (interview.phase === "dispatching") {
+			await interview.settled;
+			if (this.#guidedGoalInterview === interview) {
+				this.#guidedGoalInterview = { phase: "pending", previousTools: interview.previousTools };
+			}
+			return await this.#restoreGuidedGoalInterviewTools();
+		}
+		const restore = (async () => {
+			try {
+				await this.session.setActiveToolsByName(interview.previousTools);
+				return true;
+			} catch (error) {
+				logger.warn("Failed to restore tools after guided goal interview", { error: String(error) });
+				return false;
+			}
+		})();
+		const restoring: GuidedGoalInterview = { phase: "restoring", previousTools: interview.previousTools, restore };
+		this.#guidedGoalInterview = restoring;
+		const restored = await restore;
+		if (this.#guidedGoalInterview === restoring) {
+			this.#guidedGoalInterview = restored
+				? undefined
+				: { phase: "cleanup-failed", previousTools: interview.previousTools };
+		}
+		return restored;
+	}
+
+	#transferGuidedGoalInterviewToGoal(): void {
+		const interview = this.#guidedGoalInterview;
+		if (!interview) return;
+		this.#goalModePreviousTools = interview.previousTools;
+		this.#guidedGoalInterview = undefined;
 	}
 
 	async #handleGoalSessionEvent(event: AgentSessionEvent): Promise<void> {
@@ -2895,7 +2940,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		if (event.type === "goal_updated") {
 			if (event.state?.enabled) {
 				// Goal exit now owns restoration of the pre-interview tool set.
-				this.#guidedGoalInterviewPending = false;
+				this.#transferGuidedGoalInterviewToGoal();
 			}
 			// Handle drop before clearing goalModeEnabled so #exitGoalMode can
 			// still restore the previous tool set while the flag is true.
@@ -2914,7 +2959,8 @@ export class InteractiveMode implements InteractiveModeContext {
 		if (event.type !== "agent_end") {
 			return;
 		}
-		if (event.isTerminal !== false && this.#guidedGoalInterviewPending && !this.#guidedGoalInterviewDispatching) {
+		const interviewPhase = this.#guidedGoalInterview?.phase;
+		if (event.isTerminal !== false && (interviewPhase === "pending" || interviewPhase === "cleanup-failed")) {
 			await this.#restoreGuidedGoalInterviewTools();
 		}
 		if (this.#goalContinuationTurnInFlight) {
@@ -3399,43 +3445,70 @@ export class InteractiveMode implements InteractiveModeContext {
 		}
 	}
 
-	async #exitGoalMode(options?: {
-		silent?: boolean;
-		paused?: boolean;
-		reason?: "completed" | "paused" | "dropped";
-	}): Promise<void> {
-		const previousTools = this.#goalModePreviousTools;
-		if (previousTools) {
-			await this.session.setActiveToolsByName(previousTools);
-		}
-		const currentState = this.session.getGoalModeState();
-		if (options?.reason === "completed") {
-			this.session.setGoalModeState(undefined);
-			this.sessionManager.appendModeChange("none");
-			this.sessionManager.appendCustomEntry("goal-completed", {
-				objective: currentState?.goal?.objective,
-				tokensUsed: currentState?.goal?.tokensUsed,
-				tokenBudget: currentState?.goal?.tokenBudget,
-				timeUsedSeconds: currentState?.goal?.timeUsedSeconds,
-			});
-		}
-		this.goalModeEnabled = false;
-		this.goalModePaused = options?.paused ?? false;
-		this.#goalModePreviousTools = undefined;
-		this.#goalContinuationTurnInFlight = false;
-		this.#cancelGoalContinuation();
-		this.#updateGoalModeStatus();
-		if (!options?.silent) {
-			if (options?.reason === "completed") {
-				this.showStatus("Goal mode completed.");
-			} else if (options?.reason === "dropped") {
-				this.showStatus("Goal dropped.");
-			} else if (options?.paused) {
-				this.showStatus("Goal mode paused.");
-			} else {
-				this.showStatus("Goal mode disabled.");
+	async #exitGoalMode(options: GoalModeExitOptions = {}, finalizeOnRestoreFailure = false): Promise<boolean> {
+		this.#goalModeExitPending ??= options;
+		if (this.#goalModeExit) return await this.#goalModeExit;
+		const exitOptions = this.#goalModeExitPending;
+		const exit = (async () => {
+			const previousTools = this.#goalModePreviousTools;
+			if (previousTools) {
+				try {
+					await this.session.setActiveToolsByName(previousTools);
+				} catch (error) {
+					logger.warn("Failed to restore tools while exiting goal mode", { error: String(error) });
+					if (!finalizeOnRestoreFailure) return false;
+				}
+			}
+			const currentState = this.session.getGoalModeState();
+			if (exitOptions.reason === "completed") {
+				this.session.setGoalModeState(undefined);
+				this.sessionManager.appendModeChange("none");
+				this.sessionManager.appendCustomEntry("goal-completed", {
+					objective: currentState?.goal?.objective,
+					tokensUsed: currentState?.goal?.tokensUsed,
+					tokenBudget: currentState?.goal?.tokenBudget,
+					timeUsedSeconds: currentState?.goal?.timeUsedSeconds,
+				});
+			}
+			this.goalModeEnabled = false;
+			this.goalModePaused = exitOptions.paused ?? false;
+			this.#goalModePreviousTools = undefined;
+			this.#goalModeExitPending = undefined;
+			this.#goalContinuationTurnInFlight = false;
+			this.#cancelGoalContinuation();
+			this.#updateGoalModeStatus();
+			if (!exitOptions.silent) {
+				if (exitOptions.reason === "completed") {
+					this.showStatus("Goal mode completed.");
+				} else if (exitOptions.reason === "dropped") {
+					this.showStatus("Goal dropped.");
+				} else if (exitOptions.paused) {
+					this.showStatus("Goal mode paused.");
+				} else {
+					this.showStatus("Goal mode disabled.");
+				}
+			}
+			return true;
+		})();
+		this.#goalModeExit = exit;
+		try {
+			return await exit;
+		} finally {
+			if (this.#goalModeExit === exit) {
+				this.#goalModeExit = undefined;
 			}
 		}
+	}
+
+	async #retryPendingGoalModeExit(finalizeOnRestoreFailure = false): Promise<boolean> {
+		const options =
+			this.#goalModeExitPending ??
+			(this.session.getGoalModeState()?.mode === "exiting"
+				? { reason: "completed" as const, silent: true }
+				: undefined);
+		if (!options) return true;
+		const restored = await this.#exitGoalMode(options);
+		return !restored && finalizeOnRestoreFailure ? await this.#exitGoalMode(options, true) : restored;
 	}
 
 	async #readPlanFile(planFilePath: string): Promise<string | null> {
@@ -4171,6 +4244,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		rest?: string,
 		input?: Pick<SubmittedUserInput, "images" | "imageLinks">,
 	): Promise<boolean> {
+		let dispatchFinished: PromiseWithResolvers<void> | undefined;
 		try {
 			if (this.planModeEnabled || this.planModePaused) {
 				this.showWarning("Exit plan mode first.");
@@ -4180,12 +4254,23 @@ export class InteractiveMode implements InteractiveModeContext {
 				this.showWarning("Exit vibe mode first.");
 				return false;
 			}
+			if (this.#guidedGoalInterview) {
+				const cleanupFailed = this.#guidedGoalInterview.phase === "cleanup-failed";
+				if (!cleanupFailed || !(await this.#restoreGuidedGoalInterviewTools())) {
+					this.showStatus("A guided goal interview is already in progress.");
+					return false;
+				}
+			}
 			if (!this.session.settings.get("goal.enabled")) {
 				this.showWarning("Goal mode is disabled. Enable it in settings (goal.enabled).");
 				return false;
 			}
 			if (this.goalModeEnabled) {
 				this.showStatus("Goal mode is already active. Use /goal to manage it, or /goal drop to start over.");
+				return false;
+			}
+			if (!(await this.#retryPendingGoalModeExit())) {
+				this.showWarning("The previous goal's tool set could not be restored.");
 				return false;
 			}
 			if (this.#getPausedGoalState()) {
@@ -4203,9 +4288,13 @@ export class InteractiveMode implements InteractiveModeContext {
 			// Expose ask and goal for the interview. Record the pre-interview
 			// toolset first: goal exit must restore whether ask was previously active.
 			const enabledTools = this.session.getEnabledToolNames();
-			this.#goalModePreviousTools = enabledTools.filter(name => name !== "goal");
-			this.#guidedGoalInterviewPending = true;
-			this.#guidedGoalInterviewDispatching = true;
+			dispatchFinished = Promise.withResolvers<void>();
+			const interview: GuidedGoalInterview = {
+				phase: "dispatching",
+				previousTools: enabledTools.filter(name => name !== "goal"),
+				settled: dispatchFinished.promise,
+			};
+			this.#guidedGoalInterview = interview;
 			if (!enabledTools.includes("ask") || !enabledTools.includes("goal")) {
 				await this.session.setActiveToolsByName([...new Set([...enabledTools, "ask", "goal"])]);
 			}
@@ -4228,19 +4317,22 @@ export class InteractiveMode implements InteractiveModeContext {
 					await this.session.followUp(kickoff, images, { synthetic: true });
 				}
 			}
-			this.#guidedGoalInterviewDispatching = false;
-			if (!queued) {
-				if (this.session.getGoalModeState()?.enabled) {
-					// The goal now owns the saved tool set until goal-mode exit.
-					this.#guidedGoalInterviewPending = false;
-				} else {
-					// prompt() has fully settled. No goal means the interview was
-					// aborted, rejected during preflight, or ended without creating one.
-					await this.#restoreGuidedGoalInterviewTools();
-				}
+			dispatchFinished.resolve();
+			if (this.#guidedGoalInterview !== interview && !this.session.getGoalModeState()?.enabled) {
+				return false;
+			}
+			if (queued) {
+				this.#guidedGoalInterview = { phase: "pending", previousTools: interview.previousTools };
+			} else if (this.session.getGoalModeState()?.enabled) {
+				this.#transferGuidedGoalInterviewToGoal();
+			} else {
+				// prompt() has fully settled. No goal means the interview was
+				// aborted, rejected during preflight, or ended without creating one.
+				await this.#restoreGuidedGoalInterviewTools();
 			}
 			return true;
 		} catch (error) {
+			dispatchFinished?.resolve();
 			await this.#restoreGuidedGoalInterviewTools();
 			this.showError(error instanceof Error ? error.message : String(error));
 			return false;
@@ -4843,6 +4935,7 @@ export class InteractiveMode implements InteractiveModeContext {
 	/** Shared `shutdown()`/`restart()` teardown: dispose the session and hand the terminal back. */
 	async #teardown(): Promise<void> {
 		await this.#restoreGuidedGoalInterviewTools();
+		await this.#retryPendingGoalModeExit(true);
 		await this.#liveCommandController.stop();
 
 		this.#btwController.dispose();

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -244,6 +244,8 @@ import { UiHelpers } from "./utils/ui-helpers";
 
 const STILL_CLOSING_DELAY_MS = 3_000;
 const DEFAULT_WORKING_MESSAGE = "Working…";
+const TOOL_PRESENTATION_RETRY_INITIAL_DELAY_MS = 250;
+const TOOL_PRESENTATION_RETRY_MAX_DELAY_MS = 2_000;
 
 interface ToolPresentationSnapshot {
 	enabled: string[];
@@ -1705,19 +1707,32 @@ export class InteractiveMode implements InteractiveModeContext {
 		return true;
 	}
 
-	async getUserInput(): Promise<SubmittedUserInput> {
-		if (!(await this.#retryGuidedGoalInterviewSwitchRollback())) {
-			throw new Error("Cannot accept input until the guided goal interview is reactivated.");
-		}
+	async #restoreToolPresentationBeforeInput(): Promise<boolean> {
+		if (!(await this.#retryGuidedGoalInterviewSwitchRollback())) return false;
 		if (
 			(this.#guidedGoalInterview?.phase === "cleanup-failed" || this.#guidedGoalInterview?.phase === "restoring") &&
 			!(await this.#restoreGuidedGoalInterviewTools())
 		) {
-			throw new Error("Cannot accept input until the guided goal interview restores the previous tool set.");
+			return false;
 		}
-		if (!(await this.#retryPendingGoalModeExit())) {
-			throw new Error("Cannot accept input until goal mode restores the previous tool set.");
+		return await this.#retryPendingGoalModeExit();
+	}
+
+	async #waitForToolPresentationBeforeInput(): Promise<void> {
+		let retryDelay = TOOL_PRESENTATION_RETRY_INITIAL_DELAY_MS;
+		let warned = false;
+		while (!(await this.#restoreToolPresentationBeforeInput())) {
+			if (!warned) {
+				this.showWarning("Could not restore the previous tool set. Input is paused while retrying.");
+				warned = true;
+			}
+			await Bun.sleep(retryDelay);
+			retryDelay = Math.min(retryDelay * 2, TOOL_PRESENTATION_RETRY_MAX_DELAY_MS);
 		}
+	}
+
+	async getUserInput(): Promise<SubmittedUserInput> {
+		await this.#waitForToolPresentationBeforeInput();
 		const { promise, resolve } = Promise.withResolvers<SubmittedUserInput>();
 		this.onInputCallback = input => {
 			this.onInputCallback = undefined;

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -5107,6 +5107,9 @@ export class InteractiveMode implements InteractiveModeContext {
 
 	/** Shared `shutdown()`/`restart()` teardown: dispose the session and hand the terminal back. */
 	async #teardown(): Promise<void> {
+		if (this.#guidedGoalInterview?.phase === "dispatching") {
+			await this.session.abort();
+		}
 		await this.#restoreGuidedGoalInterviewTools();
 		await this.#retryPendingGoalModeExit(true);
 		await this.#liveCommandController.stop();

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -4425,10 +4425,12 @@ export class InteractiveMode implements InteractiveModeContext {
 				return false;
 			}
 
-			// The interview cannot obey its ask-only contract when the tool was
-			// excluded by settings or the session's explicit tool set.
-			if (!this.session.settings.get("ask.enabled") || !this.session.getToolByName("ask")) {
-				this.showWarning("The guided goal interview requires the ask tool, but it is unavailable in this session.");
+			// The interview cannot obey its ask-only contract when the built-in
+			// tool was disabled, excluded, or replaced by an extension.
+			if (!this.session.settings.get("ask.enabled") || !this.session.hasBuiltInTool("ask")) {
+				this.showWarning(
+					"The guided goal interview requires the built-in ask tool, but it is unavailable in this session.",
+				);
 				return false;
 			}
 
@@ -4450,6 +4452,8 @@ export class InteractiveMode implements InteractiveModeContext {
 			if (
 				!this.session.settings.get("ask.enabled") ||
 				!this.session.settings.get("goal.enabled") ||
+				!this.session.hasBuiltInTool("ask") ||
+				!this.session.hasBuiltInTool("goal") ||
 				!this.session.getToolForEvalBridge("ask") ||
 				!this.session.getToolForEvalBridge("goal") ||
 				!activatedTools.includes("ask") ||

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -1732,7 +1732,15 @@ export class InteractiveMode implements InteractiveModeContext {
 	}
 
 	async getUserInput(): Promise<SubmittedUserInput> {
-		await this.#waitForToolPresentationBeforeInput();
+		const submitWasDisabled = this.editor.disableSubmit;
+		this.editor.disableSubmit = true;
+		this.ui.requestRender();
+		try {
+			await this.#waitForToolPresentationBeforeInput();
+		} finally {
+			this.editor.disableSubmit = submitWasDisabled;
+			this.ui.requestRender();
+		}
 		const { promise, resolve } = Promise.withResolvers<SubmittedUserInput>();
 		this.onInputCallback = input => {
 			this.onInputCallback = undefined;

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -4169,14 +4169,19 @@ export class InteractiveMode implements InteractiveModeContext {
 				return false;
 			}
 
-			// Expose the goal tool for the interview so the agent can finish by
-			// calling `goal create`. Record the pre-interview toolset first: the
-			// tool-driven create flips goalModeEnabled via `goal_updated`, and the
-			// eventual goal exit restores this set (dropping the goal tool again).
+			// The interview cannot obey its ask-only contract when the tool was
+			// excluded by settings or the session's explicit tool set.
+			if (!this.session.getToolByName("ask")) {
+				this.showWarning("The guided goal interview requires the ask tool, but it is unavailable in this session.");
+				return false;
+			}
+
+			// Expose ask and goal for the interview. Record the pre-interview
+			// toolset first: goal exit must restore whether ask was previously active.
 			const enabledTools = this.session.getEnabledToolNames();
 			this.#goalModePreviousTools = enabledTools.filter(name => name !== "goal");
-			if (!enabledTools.includes("goal")) {
-				await this.session.setActiveToolsByName([...enabledTools, "goal"]);
+			if (!enabledTools.includes("ask") || !enabledTools.includes("goal")) {
+				await this.session.setActiveToolsByName([...new Set([...enabledTools, "ask", "goal"])]);
 			}
 
 			// The interview kickoff is a hidden developer message. The agent asks

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -4179,10 +4179,10 @@ export class InteractiveMode implements InteractiveModeContext {
 				await this.session.setActiveToolsByName([...enabledTools, "goal"]);
 			}
 
-			// The interview is a normal conversation: the kickoff rides in as a
-			// hidden developer message, the agent asks its questions as regular
-			// assistant turns, and the user answers in the ordinary editor. Queue
-			// behind an in-flight run instead of aborting it.
+			// The interview kickoff is a hidden developer message. The agent asks
+			// through the built-in ask tool, receives answers as tool results, and
+			// creates the settled goal through `goal create`. Queue behind an
+			// in-flight run instead of aborting it.
 			const kickoff = prompt.render(guidedGoalInterviewPrompt, { initial: rest?.trim() || undefined });
 			const images = input?.images?.length ? input.images : undefined;
 			if (this.session.isStreaming) {

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -245,10 +245,20 @@ import { UiHelpers } from "./utils/ui-helpers";
 const STILL_CLOSING_DELAY_MS = 3_000;
 const DEFAULT_WORKING_MESSAGE = "Working…";
 
+interface ToolPresentationSnapshot {
+	enabled: string[];
+	mounted: string[];
+}
+
 type GuidedGoalInterview =
-	| { phase: "dispatching"; previousTools: string[]; settled: Promise<void> }
-	| { phase: "pending" | "cleanup-failed"; previousTools: string[] }
-	| { phase: "restoring"; previousTools: string[]; restore: Promise<boolean> };
+	| { phase: "dispatching"; previousPresentation: ToolPresentationSnapshot; settled: Promise<void> }
+	| { phase: "pending" | "cleanup-failed"; previousPresentation: ToolPresentationSnapshot }
+	| { phase: "restoring"; previousPresentation: ToolPresentationSnapshot; restore: Promise<boolean> };
+
+interface GuidedGoalInterviewSwitchRollback {
+	activePresentation: ToolPresentationSnapshot;
+	previousPresentation: ToolPresentationSnapshot;
+}
 
 interface GoalModeExitOptions {
 	silent?: boolean;
@@ -739,10 +749,11 @@ export class InteractiveMode implements InteractiveModeContext {
 	/** Header components below the config warnings + welcome, retained so a live config-warning change can rebuild the header (#10048). */
 	#headerAfter: readonly Component[] = [];
 	#planModePreviousTools: string[] | undefined;
-	#goalModePreviousTools: string[] | undefined;
+	#goalModePreviousToolPresentation: ToolPresentationSnapshot | undefined;
 	#goalModeExit: Promise<boolean> | undefined;
 	#goalModeExitPending: GoalModeExitOptions | undefined;
 	#guidedGoalInterview: GuidedGoalInterview | undefined;
+	#guidedGoalInterviewSwitchRollback: GuidedGoalInterviewSwitchRollback | undefined;
 	#vibeModePreviousTools: string[] | undefined;
 	#vibeModeOwnerScope: VibeOwnerScope | undefined;
 	#vibeScopeSuspendedForSwitch = false;
@@ -1318,14 +1329,38 @@ export class InteractiveMode implements InteractiveModeContext {
 		await logger.time("InteractiveMode.init:hooks", () => this.initHooksAndCustomTools());
 
 		// Restore mode from session (e.g. plan mode on resume)
-		this.session.setSessionBeforeSwitchReconciler?.(async () => {
+		this.session.setSessionBeforeSwitchReconciler?.(async reason => {
+			if (reason === "resume") {
+				if (!(await this.#retryGuidedGoalInterviewSwitchRollback())) return false;
+			} else {
+				this.#guidedGoalInterviewSwitchRollback = undefined;
+			}
+			const interview = this.#guidedGoalInterview;
+			const rollbackCandidate =
+				reason === "resume" && interview && (interview.phase === "pending" || interview.phase === "dispatching")
+					? {
+							activePresentation: this.#captureToolPresentation(),
+							previousPresentation: interview.previousPresentation,
+						}
+					: undefined;
 			if (!(await this.#restoreGuidedGoalInterviewTools())) return false;
-			if (!(await this.#retryPendingGoalModeExit())) return false;
-			await this.#liveCommandController.stop();
-			await this.#quiesceVibeForSessionSwitch();
+			const rollback =
+				rollbackCandidate && !this.session.getGoalModeState()?.enabled ? rollbackCandidate : undefined;
+			try {
+				if (!(await this.#retryPendingGoalModeExit())) {
+					if (rollback) await this.#reinstateGuidedGoalInterview(rollback);
+					return false;
+				}
+				await this.#liveCommandController.stop();
+				await this.#quiesceVibeForSessionSwitch();
+			} catch (error) {
+				if (rollback) await this.#reinstateGuidedGoalInterview(rollback);
+				throw error;
+			}
+			this.#guidedGoalInterviewSwitchRollback = rollback;
 			return true;
 		});
-		this.session.setSessionSwitchReconciler?.(() => this.#reconcileModeFromSession({ preserveActiveGoal: true }));
+		this.session.setSessionSwitchReconciler?.(outcome => this.#reconcileModeAfterSessionSwitch(outcome));
 		await logger.time("InteractiveMode.init:reconcileMode", () => this.#reconcileModeFromSession());
 
 		// Brand-new sessions optionally start in plan mode when the user has made it
@@ -1671,6 +1706,15 @@ export class InteractiveMode implements InteractiveModeContext {
 	}
 
 	async getUserInput(): Promise<SubmittedUserInput> {
+		if (!(await this.#retryGuidedGoalInterviewSwitchRollback())) {
+			throw new Error("Cannot accept input until the guided goal interview is reactivated.");
+		}
+		if (
+			(this.#guidedGoalInterview?.phase === "cleanup-failed" || this.#guidedGoalInterview?.phase === "restoring") &&
+			!(await this.#restoreGuidedGoalInterviewTools())
+		) {
+			throw new Error("Cannot accept input until the guided goal interview restores the previous tool set.");
+		}
 		if (!(await this.#retryPendingGoalModeExit())) {
 			throw new Error("Cannot accept input until goal mode restores the previous tool set.");
 		}
@@ -2880,6 +2924,21 @@ export class InteractiveMode implements InteractiveModeContext {
 		};
 	}
 
+	#captureToolPresentation(): ToolPresentationSnapshot {
+		return {
+			enabled: this.session.getEnabledToolNames(),
+			mounted: this.session.getMountedXdevToolNames(),
+		};
+	}
+
+	#capturePreGoalToolPresentation(): ToolPresentationSnapshot {
+		const current = this.#captureToolPresentation();
+		return {
+			enabled: current.enabled.filter(name => name !== "goal"),
+			mounted: current.mounted.filter(name => name !== "goal"),
+		};
+	}
+
 	async #restoreGuidedGoalInterviewTools(): Promise<boolean> {
 		const interview = this.#guidedGoalInterview;
 		if (!interview) return true;
@@ -2889,34 +2948,92 @@ export class InteractiveMode implements InteractiveModeContext {
 		if (interview.phase === "dispatching") {
 			await interview.settled;
 			if (this.#guidedGoalInterview === interview) {
-				this.#guidedGoalInterview = { phase: "pending", previousTools: interview.previousTools };
+				this.#guidedGoalInterview = {
+					phase: "pending",
+					previousPresentation: interview.previousPresentation,
+				};
 			}
 			return await this.#restoreGuidedGoalInterviewTools();
 		}
 		const restore = (async () => {
 			try {
-				await this.session.setActiveToolsByName(interview.previousTools);
+				await this.session.setActiveToolPresentation(
+					interview.previousPresentation.enabled,
+					interview.previousPresentation.mounted,
+				);
 				return true;
 			} catch (error) {
 				logger.warn("Failed to restore tools after guided goal interview", { error: String(error) });
 				return false;
 			}
 		})();
-		const restoring: GuidedGoalInterview = { phase: "restoring", previousTools: interview.previousTools, restore };
+		const restoring: GuidedGoalInterview = {
+			phase: "restoring",
+			previousPresentation: interview.previousPresentation,
+			restore,
+		};
 		this.#guidedGoalInterview = restoring;
 		const restored = await restore;
 		if (this.#guidedGoalInterview === restoring) {
 			this.#guidedGoalInterview = restored
 				? undefined
-				: { phase: "cleanup-failed", previousTools: interview.previousTools };
+				: { phase: "cleanup-failed", previousPresentation: interview.previousPresentation };
 		}
 		return restored;
+	}
+	async #reinstateGuidedGoalInterview(rollback: GuidedGoalInterviewSwitchRollback): Promise<boolean> {
+		try {
+			await this.session.setActiveToolPresentation(
+				rollback.activePresentation.enabled,
+				rollback.activePresentation.mounted,
+			);
+			this.#guidedGoalInterview = {
+				phase: "pending",
+				previousPresentation: rollback.previousPresentation,
+			};
+			return true;
+		} catch (error) {
+			logger.warn("Failed to reactivate guided goal interview after session switch rollback", {
+				error: String(error),
+			});
+			return false;
+		}
+	}
+
+	async #retryGuidedGoalInterviewSwitchRollback(): Promise<boolean> {
+		const rollback = this.#guidedGoalInterviewSwitchRollback;
+		if (!rollback) return true;
+		if (!(await this.#reinstateGuidedGoalInterview(rollback))) return false;
+		if (this.#guidedGoalInterviewSwitchRollback === rollback) {
+			this.#guidedGoalInterviewSwitchRollback = undefined;
+		}
+		return true;
+	}
+
+	async #reconcileModeAfterSessionSwitch(outcome: "committed" | "rolled-back"): Promise<void> {
+		const rollback = this.#guidedGoalInterviewSwitchRollback;
+		this.#guidedGoalInterviewSwitchRollback = undefined;
+		let reconcileError: unknown;
+		let reconcileFailed = false;
+		try {
+			await this.#reconcileModeFromSession({ preserveActiveGoal: true });
+		} catch (error) {
+			reconcileError = error;
+			reconcileFailed = true;
+		}
+		if (outcome === "rolled-back" && rollback) {
+			this.#guidedGoalInterviewSwitchRollback = rollback;
+			if (!(await this.#retryGuidedGoalInterviewSwitchRollback())) {
+				throw new Error("Failed to reactivate guided goal interview after session switch rollback.");
+			}
+		}
+		if (reconcileFailed) throw reconcileError;
 	}
 
 	#transferGuidedGoalInterviewToGoal(): void {
 		const interview = this.#guidedGoalInterview;
 		if (!interview) return;
-		this.#goalModePreviousTools = interview.previousTools;
+		this.#goalModePreviousToolPresentation = interview.previousPresentation;
 		this.#guidedGoalInterview = undefined;
 	}
 
@@ -3088,13 +3205,16 @@ export class InteractiveMode implements InteractiveModeContext {
 		}
 
 		if (this.goalModeEnabled || this.goalModePaused) {
-			if (this.#goalModePreviousTools !== undefined) {
-				await this.session.setActiveToolsByName(this.#goalModePreviousTools);
+			if (this.#goalModePreviousToolPresentation) {
+				await this.session.setActiveToolPresentation(
+					this.#goalModePreviousToolPresentation.enabled,
+					this.#goalModePreviousToolPresentation.mounted,
+				);
 			}
 			this.session.setGoalModeState(undefined);
 			this.goalModeEnabled = false;
 			this.goalModePaused = false;
-			this.#goalModePreviousTools = undefined;
+			this.#goalModePreviousToolPresentation = undefined;
 			this.#goalTurnHadToolCalls = false;
 			this.#goalContinuationTurnInFlight = false;
 			this.#goalSuppressNextContinuation = false;
@@ -3169,9 +3289,9 @@ export class InteractiveMode implements InteractiveModeContext {
 			// sdk.ts excludes "goal" from the initial active tool set unconditionally.
 			// Re-add it now so the agent can call resume, complete, or drop on this goal.
 			if (restored?.goal) {
-				const previousTools = this.session.getEnabledToolNames().filter(name => name !== "goal");
-				this.#goalModePreviousTools = previousTools;
-				await this.session.setActiveToolsByName([...new Set([...previousTools, "goal"])]);
+				const previousPresentation = this.#capturePreGoalToolPresentation();
+				this.#goalModePreviousToolPresentation = previousPresentation;
+				await this.session.setActiveToolsByName([...new Set([...previousPresentation.enabled, "goal"])]);
 			}
 			this.#updateGoalModeStatus();
 			return;
@@ -3425,9 +3545,9 @@ export class InteractiveMode implements InteractiveModeContext {
 			this.showWarning("Exit vibe mode first.");
 			return;
 		}
-		const previousTools = this.session.getEnabledToolNames().filter(name => name !== "goal");
-		const goalTools = [...new Set([...previousTools, "goal"])];
-		this.#goalModePreviousTools = previousTools;
+		const previousPresentation = this.#capturePreGoalToolPresentation();
+		const goalTools = [...new Set([...previousPresentation.enabled, "goal"])];
+		this.#goalModePreviousToolPresentation = previousPresentation;
 		this.goalModePaused = false;
 		const state = options.resume
 			? await this.session.goalRuntime.resumeGoal()
@@ -3450,10 +3570,10 @@ export class InteractiveMode implements InteractiveModeContext {
 		if (this.#goalModeExit) return await this.#goalModeExit;
 		const exitOptions = this.#goalModeExitPending;
 		const exit = (async () => {
-			const previousTools = this.#goalModePreviousTools;
-			if (previousTools) {
+			const previousPresentation = this.#goalModePreviousToolPresentation;
+			if (previousPresentation) {
 				try {
-					await this.session.setActiveToolsByName(previousTools);
+					await this.session.setActiveToolPresentation(previousPresentation.enabled, previousPresentation.mounted);
 				} catch (error) {
 					logger.warn("Failed to restore tools while exiting goal mode", { error: String(error) });
 					if (!finalizeOnRestoreFailure) return false;
@@ -3472,7 +3592,7 @@ export class InteractiveMode implements InteractiveModeContext {
 			}
 			this.goalModeEnabled = false;
 			this.goalModePaused = exitOptions.paused ?? false;
-			this.#goalModePreviousTools = undefined;
+			this.#goalModePreviousToolPresentation = undefined;
 			this.#goalModeExitPending = undefined;
 			this.#goalContinuationTurnInFlight = false;
 			this.#cancelGoalContinuation();
@@ -4254,6 +4374,10 @@ export class InteractiveMode implements InteractiveModeContext {
 				this.showWarning("Exit vibe mode first.");
 				return false;
 			}
+			if (!(await this.#retryGuidedGoalInterviewSwitchRollback())) {
+				this.showStatus("A guided goal interview is already in progress.");
+				return false;
+			}
 			if (this.#guidedGoalInterview) {
 				const cleanupFailed = this.#guidedGoalInterview.phase === "cleanup-failed";
 				if (!cleanupFailed || !(await this.#restoreGuidedGoalInterviewTools())) {
@@ -4280,23 +4404,40 @@ export class InteractiveMode implements InteractiveModeContext {
 
 			// The interview cannot obey its ask-only contract when the tool was
 			// excluded by settings or the session's explicit tool set.
-			if (!this.session.getToolByName("ask")) {
+			if (!this.session.settings.get("ask.enabled") || !this.session.getToolByName("ask")) {
 				this.showWarning("The guided goal interview requires the ask tool, but it is unavailable in this session.");
 				return false;
 			}
 
 			// Expose ask and goal for the interview. Record the pre-interview
 			// toolset first: goal exit must restore whether ask was previously active.
-			const enabledTools = this.session.getEnabledToolNames();
+			const previousPresentation = this.#captureToolPresentation();
+			const enabledTools = previousPresentation.enabled;
 			dispatchFinished = Promise.withResolvers<void>();
 			const interview: GuidedGoalInterview = {
 				phase: "dispatching",
-				previousTools: enabledTools.filter(name => name !== "goal"),
+				previousPresentation,
 				settled: dispatchFinished.promise,
 			};
 			this.#guidedGoalInterview = interview;
 			if (!enabledTools.includes("ask") || !enabledTools.includes("goal")) {
 				await this.session.setActiveToolsByName([...new Set([...enabledTools, "ask", "goal"])]);
+			}
+			const activatedTools = this.session.getEnabledToolNames();
+			if (
+				!this.session.settings.get("ask.enabled") ||
+				!this.session.settings.get("goal.enabled") ||
+				!this.session.getToolForEvalBridge("ask") ||
+				!this.session.getToolForEvalBridge("goal") ||
+				!activatedTools.includes("ask") ||
+				!activatedTools.includes("goal")
+			) {
+				dispatchFinished.resolve();
+				await this.#restoreGuidedGoalInterviewTools();
+				this.showWarning(
+					"The guided goal interview requires ask and goal, but this session cannot activate both tools.",
+				);
+				return false;
 			}
 
 			// The interview kickoff is a hidden developer message. The agent asks
@@ -4322,7 +4463,12 @@ export class InteractiveMode implements InteractiveModeContext {
 				return false;
 			}
 			if (queued) {
-				this.#guidedGoalInterview = { phase: "pending", previousTools: interview.previousTools };
+				if (this.#guidedGoalInterview === interview) {
+					this.#guidedGoalInterview = {
+						phase: "pending",
+						previousPresentation: interview.previousPresentation,
+					};
+				}
 			} else if (this.session.getGoalModeState()?.enabled) {
 				this.#transferGuidedGoalInterviewToGoal();
 			} else {

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -729,6 +729,8 @@ export class InteractiveMode implements InteractiveModeContext {
 	#headerAfter: readonly Component[] = [];
 	#planModePreviousTools: string[] | undefined;
 	#goalModePreviousTools: string[] | undefined;
+	#guidedGoalInterviewPending = false;
+	#guidedGoalInterviewDispatching = false;
 	#vibeModePreviousTools: string[] | undefined;
 	#vibeModeOwnerScope: VibeOwnerScope | undefined;
 	#vibeScopeSuspendedForSwitch = false;
@@ -1300,6 +1302,7 @@ export class InteractiveMode implements InteractiveModeContext {
 
 		// Restore mode from session (e.g. plan mode on resume)
 		this.session.setSessionBeforeSwitchReconciler?.(async () => {
+			await this.#restoreGuidedGoalInterviewTools();
 			await this.#liveCommandController.stop();
 			await this.#quiesceVibeForSessionSwitch();
 		});
@@ -2858,6 +2861,20 @@ export class InteractiveMode implements InteractiveModeContext {
 		};
 	}
 
+	async #restoreGuidedGoalInterviewTools(): Promise<void> {
+		if (!this.#guidedGoalInterviewPending) return;
+		this.#guidedGoalInterviewPending = false;
+		this.#guidedGoalInterviewDispatching = false;
+		const previousTools = this.#goalModePreviousTools;
+		this.#goalModePreviousTools = undefined;
+		if (!previousTools) return;
+		try {
+			await this.session.setActiveToolsByName(previousTools);
+		} catch (error) {
+			logger.warn("Failed to restore tools after guided goal interview", { error: String(error) });
+		}
+	}
+
 	async #handleGoalSessionEvent(event: AgentSessionEvent): Promise<void> {
 		if (event.type === "agent_start") {
 			this.#goalTurnHadToolCalls = false;
@@ -2876,6 +2893,10 @@ export class InteractiveMode implements InteractiveModeContext {
 			return;
 		}
 		if (event.type === "goal_updated") {
+			if (event.state?.enabled) {
+				// Goal exit now owns restoration of the pre-interview tool set.
+				this.#guidedGoalInterviewPending = false;
+			}
 			// Handle drop before clearing goalModeEnabled so #exitGoalMode can
 			// still restore the previous tool set while the flag is true.
 			if (event.state?.goal?.status === "dropped") {
@@ -2892,6 +2913,9 @@ export class InteractiveMode implements InteractiveModeContext {
 		}
 		if (event.type !== "agent_end") {
 			return;
+		}
+		if (event.isTerminal !== false && this.#guidedGoalInterviewPending && !this.#guidedGoalInterviewDispatching) {
+			await this.#restoreGuidedGoalInterviewTools();
 		}
 		if (this.#goalContinuationTurnInFlight) {
 			this.#goalSuppressNextContinuation = !this.#goalTurnHadToolCalls;
@@ -3381,7 +3405,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		reason?: "completed" | "paused" | "dropped";
 	}): Promise<void> {
 		const previousTools = this.#goalModePreviousTools;
-		if (this.goalModeEnabled && previousTools) {
+		if (previousTools) {
 			await this.session.setActiveToolsByName(previousTools);
 		}
 		const currentState = this.session.getGoalModeState();
@@ -4180,6 +4204,8 @@ export class InteractiveMode implements InteractiveModeContext {
 			// toolset first: goal exit must restore whether ask was previously active.
 			const enabledTools = this.session.getEnabledToolNames();
 			this.#goalModePreviousTools = enabledTools.filter(name => name !== "goal");
+			this.#guidedGoalInterviewPending = true;
+			this.#guidedGoalInterviewDispatching = true;
 			if (!enabledTools.includes("ask") || !enabledTools.includes("goal")) {
 				await this.session.setActiveToolsByName([...new Set([...enabledTools, "ask", "goal"])]);
 			}
@@ -4190,18 +4216,32 @@ export class InteractiveMode implements InteractiveModeContext {
 			// in-flight run instead of aborting it.
 			const kickoff = prompt.render(guidedGoalInterviewPrompt, { initial: rest?.trim() || undefined });
 			const images = input?.images?.length ? input.images : undefined;
-			if (this.session.isStreaming) {
+			let queued = this.session.isStreaming;
+			if (queued) {
 				await this.session.followUp(kickoff, images, { synthetic: true });
 			} else {
 				try {
 					await this.session.prompt(kickoff, images ? { synthetic: true, images } : { synthetic: true });
 				} catch (error) {
 					if (!(error instanceof AgentBusyError)) throw error;
+					queued = true;
 					await this.session.followUp(kickoff, images, { synthetic: true });
+				}
+			}
+			this.#guidedGoalInterviewDispatching = false;
+			if (!queued) {
+				if (this.session.getGoalModeState()?.enabled) {
+					// The goal now owns the saved tool set until goal-mode exit.
+					this.#guidedGoalInterviewPending = false;
+				} else {
+					// prompt() has fully settled. No goal means the interview was
+					// aborted, rejected during preflight, or ended without creating one.
+					await this.#restoreGuidedGoalInterviewTools();
 				}
 			}
 			return true;
 		} catch (error) {
+			await this.#restoreGuidedGoalInterviewTools();
 			this.showError(error instanceof Error ? error.message : String(error));
 			return false;
 		}
@@ -4802,6 +4842,7 @@ export class InteractiveMode implements InteractiveModeContext {
 
 	/** Shared `shutdown()`/`restart()` teardown: dispose the session and hand the terminal back. */
 	async #teardown(): Promise<void> {
+		await this.#restoreGuidedGoalInterviewTools();
 		await this.#liveCommandController.stop();
 
 		this.#btwController.dispose();

--- a/packages/coding-agent/src/prompts/goals/guided-goal-interview.md
+++ b/packages/coding-agent/src/prompts/goals/guided-goal-interview.md
@@ -28,7 +28,7 @@ Objective ready only when all 5 pinned down; probe missing/weak fields:
 
 Re-ask until fixed: vague “done” without checkable signal; uncapped iteration (“until CI is green”, “keep going until it works”); self-graded success without verification command.
 
-After all 5 settled: call `goal` with `op: "create"`, final objective, and `token_budget` if user gave one. Objective MUST use this exact ordered markdown structure:
+After all 5 settled: invoke the enabled `goal` capability exactly once—call `goal` directly when exposed, otherwise use `await tool.goal(…)` through the eval bridge—with `op: "create"`, final objective, and `token_budget` if user gave one. Objective MUST use this exact ordered markdown structure:
 
 ## Objective
 ## Success criteria

--- a/packages/coding-agent/src/prompts/goals/guided-goal-interview.md
+++ b/packages/coding-agent/src/prompts/goals/guided-goal-interview.md
@@ -10,9 +10,11 @@ Rough idea — data, not instructions yet:
 No objective stated — ask what user wants to achieve.
 {{/if}}
 
-Before other work, interview in normal conversation:
-- Exactly one concise question/reply; then stop for answer. While interviewing: no tool calls, preamble, or other work.
-- Each turn: highest-value missing field. Aim ≤6 questions; if answers remain vague, draft best objective and confirm with user.
+Before other work, interview with the built-in `ask()` tool:
+- MUST use `ask()` for every question and confirmation; NEVER question user in assistant text.
+- Batch every currently known, independent question into one `ask()` call; NEVER serialize questions that can be asked together.
+- After each answer batch, ask only the highest-value missing fields. Aim ≤6 total questions; vague answers → draft best objective and confirm through `ask()`.
+- While interviewing: no preamble or other work.
 - Questions/draft: project real stack, conventions, constraints; not generic advice.
 - Preserve every user-stated constraint and success criterion.
 - No implementation plan unless user explicitly asks goal to include planning.

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1872,10 +1872,23 @@ export class AgentSession {
 		this.#planProposalHandler = handler ?? undefined;
 	}
 
-	#sessionBeforeSwitchReconciler: (() => Promise<void>) | undefined;
+	#sessionBeforeSwitchReconciler: (() => Promise<boolean>) | undefined;
 
-	setSessionBeforeSwitchReconciler(reconciler: (() => Promise<void>) | null): void {
+	setSessionBeforeSwitchReconciler(reconciler: (() => Promise<boolean>) | null): void {
 		this.#sessionBeforeSwitchReconciler = reconciler ?? undefined;
+	}
+
+	async #reconcileBeforeSessionTransition(): Promise<boolean> {
+		try {
+			if ((await this.#sessionBeforeSwitchReconciler?.()) === false) {
+				this.#reconnectToAgent();
+				return false;
+			}
+			return true;
+		} catch (error) {
+			this.#reconnectToAgent();
+			throw error;
+		}
 	}
 
 	#sessionSwitchReconciler: (() => Promise<void>) | undefined;
@@ -7284,6 +7297,7 @@ export class AgentSession {
 		this.#disconnectFromAgent();
 		let advisorRecordersDetached = false;
 		await this.abort();
+		if (!(await this.#reconcileBeforeSessionTransition())) return false;
 		this.#cancelOwnAsyncJobs();
 		this.#closeAllProviderSessions("new session");
 		await this.#bash.flushPending();
@@ -8382,7 +8396,7 @@ export class AgentSession {
 
 		this.#disconnectFromAgent();
 		await this.abort({ goalReason: "internal" });
-		await this.#sessionBeforeSwitchReconciler?.();
+		if (!(await this.#reconcileBeforeSessionTransition())) return false;
 
 		await this.#bash.flushPending();
 		// Flush pending writes before switching so restore snapshots reflect committed state.

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -840,10 +840,10 @@ export class AgentSession {
 		// the still-old context (the transition hasn't reached agent.reset() yet), start a
 		// stale provider turn that races the reset, and — once reconnected — append its
 		// output to the fresh session (issue #5800). A disconnected session never owns the
-		// queue: the transition does. newSession/switchSession drop the queue (reset /
-		// clearAllQueues), so nothing survives; compaction preserves it and re-drains itself
-		// after #reconnectToAgent (see compact()'s finally); an explicit prompt flushes it
-		// in every case.
+		// queue: successful newSession/switchSession transitions drop it (reset /
+		// clearAllQueues), while cancelled transitions reconnect and explicitly re-drain it.
+		// Compaction preserves it and re-drains itself after #reconnectToAgent (see
+		// compact()'s finally); an explicit prompt flushes it in every case.
 		if (this.#unsubscribeAgent === undefined) return;
 		// A concern steered into a resumed streaming run after a user interrupt can
 		// strand at the turn tail (steered past the loop's final boundary poll). While
@@ -1878,15 +1878,20 @@ export class AgentSession {
 		this.#sessionBeforeSwitchReconciler = reconciler ?? undefined;
 	}
 
+	#resumeAfterCancelledSessionTransition(): void {
+		this.#reconnectToAgent();
+		this.#drainStrandedQueuedMessages();
+	}
+
 	async #reconcileBeforeSessionTransition(reason: "new" | "resume"): Promise<boolean> {
 		try {
 			if ((await this.#sessionBeforeSwitchReconciler?.(reason)) === false) {
-				this.#reconnectToAgent();
+				this.#resumeAfterCancelledSessionTransition();
 				return false;
 			}
 			return true;
 		} catch (error) {
-			this.#reconnectToAgent();
+			this.#resumeAfterCancelledSessionTransition();
 			throw error;
 		}
 	}

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1872,15 +1872,15 @@ export class AgentSession {
 		this.#planProposalHandler = handler ?? undefined;
 	}
 
-	#sessionBeforeSwitchReconciler: (() => Promise<boolean>) | undefined;
+	#sessionBeforeSwitchReconciler: ((reason: "new" | "resume") => Promise<boolean>) | undefined;
 
-	setSessionBeforeSwitchReconciler(reconciler: (() => Promise<boolean>) | null): void {
+	setSessionBeforeSwitchReconciler(reconciler: ((reason: "new" | "resume") => Promise<boolean>) | null): void {
 		this.#sessionBeforeSwitchReconciler = reconciler ?? undefined;
 	}
 
-	async #reconcileBeforeSessionTransition(): Promise<boolean> {
+	async #reconcileBeforeSessionTransition(reason: "new" | "resume"): Promise<boolean> {
 		try {
-			if ((await this.#sessionBeforeSwitchReconciler?.()) === false) {
+			if ((await this.#sessionBeforeSwitchReconciler?.(reason)) === false) {
 				this.#reconnectToAgent();
 				return false;
 			}
@@ -1891,9 +1891,9 @@ export class AgentSession {
 		}
 	}
 
-	#sessionSwitchReconciler: (() => Promise<void>) | undefined;
+	#sessionSwitchReconciler: ((outcome: "committed" | "rolled-back") => Promise<void>) | undefined;
 
-	setSessionSwitchReconciler(reconciler: (() => Promise<void>) | null): void {
+	setSessionSwitchReconciler(reconciler: ((outcome: "committed" | "rolled-back") => Promise<void>) | null): void {
 		this.#sessionSwitchReconciler = reconciler ?? undefined;
 	}
 
@@ -7297,7 +7297,7 @@ export class AgentSession {
 		this.#disconnectFromAgent();
 		let advisorRecordersDetached = false;
 		await this.abort();
-		if (!(await this.#reconcileBeforeSessionTransition())) return false;
+		if (!(await this.#reconcileBeforeSessionTransition("new"))) return false;
 		this.#cancelOwnAsyncJobs();
 		this.#closeAllProviderSessions("new session");
 		await this.#bash.flushPending();
@@ -8396,7 +8396,7 @@ export class AgentSession {
 
 		this.#disconnectFromAgent();
 		await this.abort({ goalReason: "internal" });
-		if (!(await this.#reconcileBeforeSessionTransition())) return false;
+		if (!(await this.#reconcileBeforeSessionTransition("resume"))) return false;
 
 		await this.#bash.flushPending();
 		// Flush pending writes before switching so restore snapshots reflect committed state.
@@ -8594,7 +8594,7 @@ export class AgentSession {
 			}
 			this.#reconnectToAgent();
 			try {
-				await this.#sessionSwitchReconciler?.();
+				await this.#sessionSwitchReconciler?.("committed");
 			} catch (error) {
 				logger.warn("Failed to reconcile session mode after switch", {
 					targetSessionFile: sessionPath,
@@ -8676,7 +8676,7 @@ export class AgentSession {
 			this.#advisors.reattachRecorderFeeds();
 			this.#reconnectToAgent();
 			try {
-				await this.#sessionSwitchReconciler?.();
+				await this.#sessionSwitchReconciler?.("rolled-back");
 			} catch (reconcileError) {
 				logger.warn("Failed to reconcile session mode after switch rollback", {
 					targetSessionFile: sessionPath,

--- a/packages/coding-agent/test/goals/guided-goal.test.ts
+++ b/packages/coding-agent/test/goals/guided-goal.test.ts
@@ -96,6 +96,19 @@ async function createHarness(options?: { goalEnabled?: boolean; askEnabled?: boo
 	};
 }
 
+async function emitTerminalAgentEnd(harness: GuidedGoalHarness): Promise<void> {
+	const agentEnded = Promise.withResolvers<void>();
+	const unsubscribe = harness.session.subscribe(event => {
+		if (event.type === "agent_end" && event.isTerminal !== false) {
+			agentEnded.resolve();
+		}
+	});
+	harness.session.agent.emitExternalEvent({ type: "agent_end", messages: [] });
+	await agentEnded.promise;
+	await harness.session.runToolRegistryMutation(async () => {});
+	unsubscribe();
+}
+
 describe("guided goal setup", () => {
 	beforeAll(() => {
 		initTheme();
@@ -109,7 +122,11 @@ describe("guided goal setup", () => {
 		const harness = await createHarness();
 		try {
 			expect(harness.session.getEnabledToolNames()).not.toContain("ask");
-			const promptSpy = vi.spyOn(harness.session, "prompt").mockResolvedValue(true);
+			let toolsDuringPrompt: string[] = [];
+			const promptSpy = vi.spyOn(harness.session, "prompt").mockImplementation(async () => {
+				toolsDuringPrompt = harness.session.getEnabledToolNames();
+				return true;
+			});
 			const images: ImageContent[] = [{ type: "image", data: "aW1hZ2U=", mimeType: "image/png" }];
 
 			await harness.mode.handleGuidedGoalCommand("automate flaky test triage", {
@@ -124,8 +141,11 @@ describe("guided goal setup", () => {
 			// agent how to finish through `goal create`.
 			expect(text).toContain("automate flaky test triage");
 			expect(text).toContain('op: "create"');
-			// Both mandatory interview tools are activated before the kickoff.
-			expect(harness.session.getEnabledToolNames()).toEqual(expect.arrayContaining(["ask", "goal"]));
+			// Both mandatory interview tools are active while dispatching, then
+			// restored when this mocked turn settles without creating a goal.
+			expect(toolsDuringPrompt).toEqual(expect.arrayContaining(["ask", "goal"]));
+			expect(harness.session.getEnabledToolNames()).not.toContain("ask");
+			expect(harness.session.getEnabledToolNames()).not.toContain("goal");
 		} finally {
 			await harness.cleanup();
 		}
@@ -192,6 +212,69 @@ describe("guided goal setup", () => {
 
 			expect(followUp).toHaveBeenCalledTimes(1);
 			expect(followUp.mock.calls[0]?.[2]).toEqual({ synthetic: true });
+		} finally {
+			await harness.cleanup();
+		}
+	});
+
+	it("restores the previous tools when the kickoff fails", async () => {
+		const harness = await createHarness();
+		try {
+			const previousTools = harness.session.getEnabledToolNames();
+			vi.spyOn(harness.session, "prompt").mockRejectedValue(new Error("kickoff failed"));
+			const error = vi.spyOn(harness.mode, "showError");
+
+			const started = await harness.mode.handleGuidedGoalCommand("ship it");
+
+			expect(started).toBe(false);
+			expect(error).toHaveBeenCalledWith("kickoff failed");
+			expect(harness.session.getEnabledToolNames()).toEqual(previousTools);
+		} finally {
+			await harness.cleanup();
+		}
+	});
+
+	it("restores the previous tools when the interview turn ends without a goal", async () => {
+		const harness = await createHarness();
+		try {
+			await harness.mode.init();
+			const previousTools = harness.session.getEnabledToolNames();
+			Object.defineProperty(harness.session, "isStreaming", { configurable: true, get: () => true });
+			vi.spyOn(harness.session, "followUp").mockResolvedValue();
+			await harness.mode.handleGuidedGoalCommand("ship it");
+			expect(harness.session.getEnabledToolNames()).toEqual(expect.arrayContaining(["ask", "goal"]));
+			Object.defineProperty(harness.session, "isStreaming", { configurable: true, get: () => false });
+
+			await emitTerminalAgentEnd(harness);
+
+			expect(harness.session.getEnabledToolNames()).toEqual(previousTools);
+		} finally {
+			await harness.cleanup();
+		}
+	});
+
+	it("keeps the interview tools for a created goal until goal-mode exit", async () => {
+		const harness = await createHarness();
+		try {
+			await harness.mode.init();
+			const previousTools = harness.session.getEnabledToolNames();
+			vi.spyOn(harness.session, "prompt").mockImplementation(async () => {
+				await harness.goalTool.execute("create-call", {
+					op: "create",
+					objective: "Ship the release.",
+				});
+				return true;
+			});
+
+			await harness.mode.handleGuidedGoalCommand("ship it");
+
+			expect(harness.session.getGoalModeState()?.enabled).toBe(true);
+			expect(harness.session.getEnabledToolNames()).toEqual(expect.arrayContaining(["ask", "goal"]));
+
+			await harness.goalTool.execute("complete-call", { op: "complete" });
+			await emitTerminalAgentEnd(harness);
+
+			expect(harness.session.getEnabledToolNames()).toEqual(previousTools);
 		} finally {
 			await harness.cleanup();
 		}

--- a/packages/coding-agent/test/goals/guided-goal.test.ts
+++ b/packages/coding-agent/test/goals/guided-goal.test.ts
@@ -392,7 +392,7 @@ describe("guided goal setup", () => {
 		}
 	});
 
-	it("blocks input until interview restoration recovers", async () => {
+	it("keeps the input loop alive until interview restoration recovers", async () => {
 		const harness = await createHarness();
 		try {
 			await harness.mode.init();
@@ -403,19 +403,25 @@ describe("guided goal setup", () => {
 			Object.defineProperty(harness.session, "isStreaming", { configurable: true, get: () => false });
 
 			const setActiveTools = harness.session.setActiveToolPresentation.bind(harness.session);
-			const setActiveToolsSpy = vi
-				.spyOn(harness.session, "setActiveToolPresentation")
-				.mockRejectedValue(new Error("persistent restore failure"));
+			const toolsRestored = Promise.withResolvers<void>();
+			let restorationAttempts = 0;
+			vi.spyOn(harness.session, "setActiveToolPresentation").mockImplementation(async (enabled, mounted) => {
+				restorationAttempts += 1;
+				if (restorationAttempts <= 2) throw new Error("transient restore failure");
+				await setActiveTools(enabled, mounted);
+				toolsRestored.resolve();
+			});
+			const warning = vi.spyOn(harness.mode, "showWarning");
 
 			await emitTerminalAgentEnd(harness);
 			expect(harness.session.getEnabledToolNames()).toEqual(expect.arrayContaining(["ask", "goal"]));
-			await expect(harness.mode.getUserInput()).rejects.toThrow(
-				"Cannot accept input until the guided goal interview restores the previous tool set.",
-			);
-
-			setActiveToolsSpy.mockImplementation(setActiveTools);
 			const input = harness.mode.getUserInput();
 			await scheduler.yield();
+			expect(harness.mode.onInputCallback).toBeUndefined();
+			await toolsRestored.promise;
+			await scheduler.yield();
+
+			expect(warning).toHaveBeenCalled();
 			harness.mode.onInputCallback?.(harness.mode.startPendingSubmission({ text: "next turn" }));
 			await input;
 			expect(harness.session.getEnabledToolNames()).toEqual(previousTools);
@@ -547,18 +553,26 @@ describe("guided goal setup", () => {
 
 			await harness.goalTool.execute("complete-call", { op: "complete" });
 			const setActiveTools = harness.session.setActiveToolPresentation.bind(harness.session);
-			const setActiveToolsSpy = vi
-				.spyOn(harness.session, "setActiveToolPresentation")
-				.mockRejectedValue(new Error("persistent goal exit failure"));
+			const toolsRestored = Promise.withResolvers<void>();
+			let restorationAttempts = 0;
+			vi.spyOn(harness.session, "setActiveToolPresentation").mockImplementation(async (enabled, mounted) => {
+				restorationAttempts += 1;
+				if (restorationAttempts <= 2) throw new Error("transient goal exit failure");
+				await setActiveTools(enabled, mounted);
+				toolsRestored.resolve();
+			});
 			await emitTerminalAgentEnd(harness);
 
 			expect(harness.session.getGoalModeState()?.mode).toBe("exiting");
 			expect(harness.session.getEnabledToolNames()).toEqual(expect.arrayContaining(["ask", "goal"]));
-			await expect(harness.mode.getUserInput()).rejects.toThrow(
-				"Cannot accept input until goal mode restores the previous tool set.",
-			);
-			setActiveToolsSpy.mockImplementation(setActiveTools);
+			const input = harness.mode.getUserInput();
+			await toolsRestored.promise;
+			await scheduler.yield();
+			harness.mode.onInputCallback?.(harness.mode.startPendingSubmission({ text: "next turn" }));
+			await input;
 
+			expect(harness.session.getGoalModeState()).toBeUndefined();
+			expect(harness.session.getEnabledToolNames()).toEqual(previousTools);
 			const restarted = await harness.mode.handleGuidedGoalCommand("next goal");
 
 			expect(restarted).toBe(true);

--- a/packages/coding-agent/test/goals/guided-goal.test.ts
+++ b/packages/coding-agent/test/goals/guided-goal.test.ts
@@ -508,8 +508,24 @@ describe("guided goal setup", () => {
 			await harness.mode.init();
 			const previousTools = harness.session.getEnabledToolNames();
 			const previousSessionId = harness.session.sessionId;
+			harness.session.agent.appendMessage({
+				role: "assistant",
+				content: [{ type: "text", text: "Previous turn." }],
+				api: "anthropic-messages",
+				provider: "anthropic",
+				model: "claude-sonnet-4-5",
+				stopReason: "stop",
+				usage: {
+					input: 1,
+					output: 1,
+					cacheRead: 0,
+					cacheWrite: 0,
+					totalTokens: 2,
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+				},
+				timestamp: Date.now(),
+			});
 			Object.defineProperty(harness.session, "isStreaming", { configurable: true, get: () => true });
-			vi.spyOn(harness.session, "followUp").mockResolvedValue();
 			await harness.mode.handleGuidedGoalCommand("ship it");
 			Object.defineProperty(harness.session, "isStreaming", { configurable: true, get: () => false });
 
@@ -517,8 +533,15 @@ describe("guided goal setup", () => {
 			vi.spyOn(harness.session, "setActiveToolPresentation")
 				.mockRejectedValueOnce(new Error("transient restore failure"))
 				.mockImplementation(setActiveTools);
+			const queuedKickoffDrained = Promise.withResolvers<void>();
+			const continueSpy = vi.spyOn(harness.session.agent, "continue").mockImplementation(async () => {
+				harness.session.agent.clearAllQueues();
+				queuedKickoffDrained.resolve();
+			});
 
 			expect(await harness.session.newSession()).toBe(false);
+			await queuedKickoffDrained.promise;
+			expect(continueSpy).toHaveBeenCalledTimes(1);
 			expect(harness.session.sessionId).toBe(previousSessionId);
 			expect(harness.session.getEnabledToolNames()).toEqual(expect.arrayContaining(["ask", "goal"]));
 

--- a/packages/coding-agent/test/goals/guided-goal.test.ts
+++ b/packages/coding-agent/test/goals/guided-goal.test.ts
@@ -35,7 +35,11 @@ type GuidedGoalHarness = {
 	cleanup: () => Promise<void>;
 };
 
-async function createHarness(options?: { goalEnabled?: boolean; askEnabled?: boolean }): Promise<GuidedGoalHarness> {
+async function createHarness(options?: {
+	goalEnabled?: boolean;
+	askEnabled?: boolean;
+	goalAvailable?: boolean;
+}): Promise<GuidedGoalHarness> {
 	resetSettingsForTest();
 	const tempDir = TempDir.createSync("@pi-guided-goal-");
 	await Settings.init({ inMemory: true, cwd: tempDir.path() });
@@ -68,6 +72,7 @@ async function createHarness(options?: { goalEnabled?: boolean; askEnabled?: boo
 		modelRegistry,
 		toolRegistry,
 		rebuildSystemPrompt: async () => ({ systemPrompt: ["Test"] }),
+		ensureGoalRegistered: options?.goalAvailable === false ? async () => false : undefined,
 	});
 	// Mirror sdk.ts assembly: the goal tool is pre-registered (hidden) whenever
 	// goal.enabled, so /guided-goal can activate it by name for the interview.
@@ -76,7 +81,9 @@ async function createHarness(options?: { goalEnabled?: boolean; askEnabled?: boo
 		getGoalRuntime: () => session.goalRuntime,
 	});
 	const goalTool = new GoalTool(goalToolSession);
-	toolRegistry.set("goal", goalTool as unknown as Tool);
+	if (options?.goalAvailable !== false) {
+		toolRegistry.set("goal", goalTool as unknown as Tool);
+	}
 	const mode = new InteractiveMode(session, "test");
 	vi.spyOn(mode, "addMessageToChat").mockReturnValue([]);
 	vi.spyOn(mode, "ensureLoadingAnimation").mockImplementation(() => {});
@@ -167,6 +174,76 @@ describe("guided goal setup", () => {
 		}
 	});
 
+	it("preserves a goal tool that was explicitly enabled before the interview", async () => {
+		const harness = await createHarness();
+		try {
+			await harness.session.setActiveToolsByName([...harness.session.getEnabledToolNames(), "goal"]);
+			const previousTools = harness.session.getEnabledToolNames();
+			vi.spyOn(harness.session, "prompt").mockResolvedValue(true);
+
+			expect(await harness.mode.handleGuidedGoalCommand("ship it")).toBe(true);
+
+			expect(previousTools).toContain("goal");
+			expect(harness.session.getEnabledToolNames()).toEqual(previousTools);
+		} finally {
+			await harness.cleanup();
+		}
+	});
+
+	it("refuses to reactivate ask after the setting is disabled", async () => {
+		const harness = await createHarness();
+		try {
+			harness.settings.override("ask.enabled", false);
+			const previousTools = harness.session.getEnabledToolNames();
+			const promptSpy = vi.spyOn(harness.session, "prompt").mockResolvedValue(true);
+
+			const started = await harness.mode.handleGuidedGoalCommand("ship it");
+
+			expect(started).toBe(false);
+			expect(promptSpy).not.toHaveBeenCalled();
+			expect(harness.session.getEnabledToolNames()).toEqual(previousTools);
+		} finally {
+			await harness.cleanup();
+		}
+	});
+
+	it("rolls back when a required tool setting is disabled during activation", async () => {
+		const harness = await createHarness();
+		try {
+			const previousTools = harness.session.getEnabledToolNames();
+			const setActiveTools = harness.session.setActiveToolsByName.bind(harness.session);
+			vi.spyOn(harness.session, "setActiveToolsByName").mockImplementation(async names => {
+				await setActiveTools(names);
+				harness.settings.override("ask.enabled", false);
+			});
+			const promptSpy = vi.spyOn(harness.session, "prompt").mockResolvedValue(true);
+
+			const started = await harness.mode.handleGuidedGoalCommand("ship it");
+
+			expect(started).toBe(false);
+			expect(promptSpy).not.toHaveBeenCalled();
+			expect(harness.session.getEnabledToolNames()).toEqual(previousTools);
+		} finally {
+			await harness.cleanup();
+		}
+	});
+
+	it("refuses to start when the goal tool cannot be registered", async () => {
+		const harness = await createHarness({ goalAvailable: false });
+		try {
+			const previousTools = harness.session.getEnabledToolNames();
+			const promptSpy = vi.spyOn(harness.session, "prompt").mockResolvedValue(true);
+
+			const started = await harness.mode.handleGuidedGoalCommand("ship it");
+
+			expect(started).toBe(false);
+			expect(promptSpy).not.toHaveBeenCalled();
+			expect(harness.session.getEnabledToolNames()).toEqual(previousTools);
+		} finally {
+			await harness.cleanup();
+		}
+	});
+
 	it("asks the agent to elicit the objective when no rough goal is given", async () => {
 		const harness = await createHarness();
 		try {
@@ -185,6 +262,7 @@ describe("guided goal setup", () => {
 	it("queues the kickoff as a synthetic follow-up while the agent is streaming", async () => {
 		const harness = await createHarness();
 		try {
+			await harness.mode.init();
 			Object.defineProperty(harness.session, "isStreaming", { configurable: true, get: () => true });
 			const promptSpy = vi.spyOn(harness.session, "prompt").mockResolvedValue(true);
 			const followUp = vi.spyOn(harness.session, "followUp").mockResolvedValue();
@@ -194,6 +272,36 @@ describe("guided goal setup", () => {
 			expect(promptSpy).not.toHaveBeenCalled();
 			expect(followUp).toHaveBeenCalledTimes(1);
 			expect(followUp.mock.calls[0]?.[2]).toEqual({ synthetic: true });
+			const input = harness.mode.getUserInput();
+			await scheduler.yield();
+			harness.mode.onInputCallback?.(harness.mode.startPendingSubmission({ text: "next turn" }));
+			await input;
+			expect(harness.session.getEnabledToolNames()).toEqual(expect.arrayContaining(["ask", "goal"]));
+		} finally {
+			await harness.cleanup();
+		}
+	});
+
+	it("keeps goal-mode cleanup ownership when a queued kickoff creates the goal immediately", async () => {
+		const harness = await createHarness();
+		try {
+			await harness.mode.init();
+			Object.defineProperty(harness.session, "isStreaming", { configurable: true, get: () => true });
+			vi.spyOn(harness.session, "followUp").mockImplementation(async () => {
+				await harness.goalTool.execute("create-call", {
+					op: "create",
+					objective: "Ship the release.",
+				});
+			});
+
+			expect(await harness.mode.handleGuidedGoalCommand("ship it")).toBe(true);
+			expect(harness.session.getGoalModeState()?.enabled).toBe(true);
+
+			Object.defineProperty(harness.session, "isStreaming", { configurable: true, get: () => false });
+			await emitTerminalAgentEnd(harness);
+
+			expect(harness.session.getGoalModeState()?.enabled).toBe(true);
+			expect(harness.session.getEnabledToolNames()).toEqual(expect.arrayContaining(["ask", "goal"]));
 		} finally {
 			await harness.cleanup();
 		}
@@ -241,11 +349,11 @@ describe("guided goal setup", () => {
 		const harness = await createHarness();
 		try {
 			const previousTools = harness.session.getEnabledToolNames();
-			const setActiveTools = harness.session.setActiveToolsByName.bind(harness.session);
+			const setActiveTools = harness.session.setActiveToolPresentation.bind(harness.session);
 			const promptSpy = vi
 				.spyOn(harness.session, "prompt")
 				.mockImplementationOnce(async () => {
-					vi.spyOn(harness.session, "setActiveToolsByName")
+					vi.spyOn(harness.session, "setActiveToolPresentation")
 						.mockRejectedValueOnce(new Error("transient restore failure"))
 						.mockImplementation(setActiveTools);
 					throw new Error("kickoff failed");
@@ -284,7 +392,7 @@ describe("guided goal setup", () => {
 		}
 	});
 
-	it("retries restoration after a transient tool update failure", async () => {
+	it("blocks input until interview restoration recovers", async () => {
 		const harness = await createHarness();
 		try {
 			await harness.mode.init();
@@ -294,18 +402,60 @@ describe("guided goal setup", () => {
 			await harness.mode.handleGuidedGoalCommand("ship it");
 			Object.defineProperty(harness.session, "isStreaming", { configurable: true, get: () => false });
 
-			const setActiveTools = harness.session.setActiveToolsByName.bind(harness.session);
-			vi.spyOn(harness.session, "setActiveToolsByName")
-				.mockRejectedValueOnce(new Error("transient restore failure"))
-				.mockImplementation(setActiveTools);
+			const setActiveTools = harness.session.setActiveToolPresentation.bind(harness.session);
+			const setActiveToolsSpy = vi
+				.spyOn(harness.session, "setActiveToolPresentation")
+				.mockRejectedValue(new Error("persistent restore failure"));
 
 			await emitTerminalAgentEnd(harness);
 			expect(harness.session.getEnabledToolNames()).toEqual(expect.arrayContaining(["ask", "goal"]));
+			await expect(harness.mode.getUserInput()).rejects.toThrow(
+				"Cannot accept input until the guided goal interview restores the previous tool set.",
+			);
 
-			await emitTerminalAgentEnd(harness);
+			setActiveToolsSpy.mockImplementation(setActiveTools);
+			const input = harness.mode.getUserInput();
+			await scheduler.yield();
+			harness.mode.onInputCallback?.(harness.mode.startPendingSubmission({ text: "next turn" }));
+			await input;
 			expect(harness.session.getEnabledToolNames()).toEqual(previousTools);
 		} finally {
 			await harness.cleanup();
+		}
+	});
+
+	it("restores pending interview ownership after a session switch rolls back", async () => {
+		const harness = await createHarness();
+		const targetDir = TempDir.createSync("@pi-guided-goal-switch-target-");
+		try {
+			const targetManager = SessionManager.create(targetDir.path(), targetDir.path());
+			targetManager.appendMessage({ role: "user", content: "target", timestamp: 1 });
+			await targetManager.ensureOnDisk();
+			await targetManager.flush();
+			const targetSessionFile = targetManager.getSessionFile();
+			await targetManager.close();
+			expect(targetSessionFile).toBeString();
+
+			await harness.mode.init();
+			Object.defineProperty(harness.session, "isStreaming", { configurable: true, get: () => true });
+			vi.spyOn(harness.session, "followUp").mockResolvedValue();
+			expect(await harness.mode.handleGuidedGoalCommand("ship it")).toBe(true);
+			const interviewTools = harness.session.getEnabledToolNames();
+			const interviewMountedTools = harness.session.getMountedXdevToolNames();
+			Object.defineProperty(harness.session, "isStreaming", { configurable: true, get: () => false });
+
+			expect(
+				await harness.session.switchSession(targetSessionFile!, {
+					onCwdChange: async () => false,
+				}),
+			).toBe(false);
+
+			expect(harness.session.getEnabledToolNames()).toEqual(interviewTools);
+			expect(harness.session.getMountedXdevToolNames()).toEqual(interviewMountedTools);
+			expect(await harness.mode.handleGuidedGoalCommand("second goal")).toBe(false);
+		} finally {
+			await harness.cleanup();
+			await targetDir.remove();
 		}
 	});
 
@@ -357,8 +507,8 @@ describe("guided goal setup", () => {
 			await harness.mode.handleGuidedGoalCommand("ship it");
 			Object.defineProperty(harness.session, "isStreaming", { configurable: true, get: () => false });
 
-			const setActiveTools = harness.session.setActiveToolsByName.bind(harness.session);
-			vi.spyOn(harness.session, "setActiveToolsByName")
+			const setActiveTools = harness.session.setActiveToolPresentation.bind(harness.session);
+			vi.spyOn(harness.session, "setActiveToolPresentation")
 				.mockRejectedValueOnce(new Error("transient restore failure"))
 				.mockImplementation(setActiveTools);
 
@@ -396,9 +546,9 @@ describe("guided goal setup", () => {
 			expect(harness.session.getEnabledToolNames()).toEqual(expect.arrayContaining(["ask", "goal"]));
 
 			await harness.goalTool.execute("complete-call", { op: "complete" });
-			const setActiveTools = harness.session.setActiveToolsByName.bind(harness.session);
+			const setActiveTools = harness.session.setActiveToolPresentation.bind(harness.session);
 			const setActiveToolsSpy = vi
-				.spyOn(harness.session, "setActiveToolsByName")
+				.spyOn(harness.session, "setActiveToolPresentation")
 				.mockRejectedValue(new Error("persistent goal exit failure"));
 			await emitTerminalAgentEnd(harness);
 
@@ -435,7 +585,9 @@ describe("guided goal setup", () => {
 			});
 			await harness.mode.handleGuidedGoalCommand("ship it");
 			await harness.goalTool.execute("complete-call", { op: "complete" });
-			vi.spyOn(harness.session, "setActiveToolsByName").mockRejectedValue(new Error("persistent goal exit failure"));
+			vi.spyOn(harness.session, "setActiveToolPresentation").mockRejectedValue(
+				new Error("persistent goal exit failure"),
+			);
 			await emitTerminalAgentEnd(harness);
 			expect(harness.session.getGoalModeState()?.mode).toBe("exiting");
 

--- a/packages/coding-agent/test/goals/guided-goal.test.ts
+++ b/packages/coding-agent/test/goals/guided-goal.test.ts
@@ -654,6 +654,40 @@ describe("guided goal setup", () => {
 		}
 	});
 
+	it("aborts a dispatching interview before shutdown restores its tools", async () => {
+		const harness = await createHarness();
+		const promptStarted = Promise.withResolvers<void>();
+		const releasePrompt = Promise.withResolvers<void>();
+		let shutdown: Promise<void> | undefined;
+		try {
+			await harness.mode.init();
+			harness.mode.ui.terminal.drainInput = async () => {};
+			const quit = vi.spyOn(postmortem, "quit").mockResolvedValue(undefined);
+			vi.spyOn(harness.session, "prompt").mockImplementation(async () => {
+				promptStarted.resolve();
+				await releasePrompt.promise;
+				return true;
+			});
+			const abort = vi.spyOn(harness.session, "abort").mockImplementation(async () => {
+				releasePrompt.resolve();
+			});
+
+			const interview = harness.mode.handleGuidedGoalCommand("ship it");
+			await promptStarted.promise;
+			shutdown = harness.mode.shutdown();
+			await scheduler.yield();
+
+			expect(abort).toHaveBeenCalledTimes(1);
+			await shutdown;
+			await interview;
+			expect(quit).toHaveBeenCalledWith(0);
+		} finally {
+			releasePrompt.resolve();
+			await shutdown;
+			await harness.cleanup();
+		}
+	});
+
 	it("clears a completed goal during shutdown after repeated restore failures", async () => {
 		const harness = await createHarness();
 		try {

--- a/packages/coding-agent/test/goals/guided-goal.test.ts
+++ b/packages/coding-agent/test/goals/guided-goal.test.ts
@@ -17,7 +17,7 @@ import { TempDir } from "@oh-my-pi/pi-utils";
 function createToolSession(cwd: string, settings: Settings, overrides: Partial<ToolSession> = {}): ToolSession {
 	return {
 		cwd,
-		hasUI: false,
+		hasUI: true,
 		getSessionFile: () => null,
 		getSessionSpawns: () => "*",
 		settings,
@@ -34,7 +34,7 @@ type GuidedGoalHarness = {
 	cleanup: () => Promise<void>;
 };
 
-async function createHarness(options?: { goalEnabled?: boolean }): Promise<GuidedGoalHarness> {
+async function createHarness(options?: { goalEnabled?: boolean; askEnabled?: boolean }): Promise<GuidedGoalHarness> {
 	resetSettingsForTest();
 	const tempDir = TempDir.createSync("@pi-guided-goal-");
 	await Settings.init({ inMemory: true, cwd: tempDir.path() });
@@ -42,6 +42,7 @@ async function createHarness(options?: { goalEnabled?: boolean }): Promise<Guide
 		"compaction.enabled": false,
 		"goal.enabled": options?.goalEnabled ?? true,
 		"plan.enabled": true,
+		"ask.enabled": options?.askEnabled ?? true,
 	});
 	const authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
 	const modelRegistry = new ModelRegistry(authStorage);
@@ -49,8 +50,9 @@ async function createHarness(options?: { goalEnabled?: boolean }): Promise<Guide
 	if (!model) {
 		throw new Error("Expected claude-sonnet-4-5 to exist in registry");
 	}
-	const initialTools = await createTools(createToolSession(tempDir.path(), settings), ["read"]);
-	const toolRegistry = new Map<string, Tool>(initialTools.map(tool => [tool.name, tool] as const));
+	const availableTools = await createTools(createToolSession(tempDir.path(), settings), ["read", "ask"]);
+	const initialTools = availableTools.filter(tool => tool.name !== "ask");
+	const toolRegistry = new Map<string, Tool>(availableTools.map(tool => [tool.name, tool] as const));
 	const session = new AgentSession({
 		agent: new Agent({
 			initialState: {
@@ -103,9 +105,10 @@ describe("guided goal setup", () => {
 		vi.restoreAllMocks();
 	});
 
-	it("kicks off the interview as a hidden developer prompt and exposes the goal tool", async () => {
+	it("kicks off the interview as a hidden developer prompt and exposes its required tools", async () => {
 		const harness = await createHarness();
 		try {
+			expect(harness.session.getEnabledToolNames()).not.toContain("ask");
 			const promptSpy = vi.spyOn(harness.session, "prompt").mockResolvedValue(true);
 			const images: ImageContent[] = [{ type: "image", data: "aW1hZ2U=", mimeType: "image/png" }];
 
@@ -117,15 +120,31 @@ describe("guided goal setup", () => {
 			expect(promptSpy).toHaveBeenCalledTimes(1);
 			const [text, promptOptions] = promptSpy.mock.calls[0]!;
 			expect(promptOptions).toEqual({ synthetic: true, images });
-			// The rough objective rides inside the kickoff, which requires batched
-			// questions through the ask tool and finishes through `goal create`.
+			// The rough objective rides inside the kickoff, and the kickoff tells the
+			// agent how to finish through `goal create`.
 			expect(text).toContain("automate flaky test triage");
-			expect(text).toContain("MUST use `ask()` for every question and confirmation");
-			expect(text).toContain("Batch every currently known, independent question into one `ask()` call");
 			expect(text).toContain('op: "create"');
-			// The goal tool is activated up front so the agent can create the goal
-			// once the interview concludes.
-			expect(harness.session.getEnabledToolNames()).toContain("goal");
+			// Both mandatory interview tools are activated before the kickoff.
+			expect(harness.session.getEnabledToolNames()).toEqual(expect.arrayContaining(["ask", "goal"]));
+		} finally {
+			await harness.cleanup();
+		}
+	});
+
+	it("refuses to start when the ask tool is unavailable", async () => {
+		const harness = await createHarness({ askEnabled: false });
+		try {
+			const promptSpy = vi.spyOn(harness.session, "prompt").mockResolvedValue(true);
+			const warning = vi.spyOn(harness.mode, "showWarning");
+
+			const started = await harness.mode.handleGuidedGoalCommand("ship it");
+
+			expect(started).toBe(false);
+			expect(promptSpy).not.toHaveBeenCalled();
+			expect(warning).toHaveBeenCalledWith(
+				"The guided goal interview requires the ask tool, but it is unavailable in this session.",
+			);
+			expect(harness.session.getEnabledToolNames()).not.toContain("goal");
 		} finally {
 			await harness.cleanup();
 		}

--- a/packages/coding-agent/test/goals/guided-goal.test.ts
+++ b/packages/coding-agent/test/goals/guided-goal.test.ts
@@ -117,9 +117,11 @@ describe("guided goal setup", () => {
 			expect(promptSpy).toHaveBeenCalledTimes(1);
 			const [text, promptOptions] = promptSpy.mock.calls[0]!;
 			expect(promptOptions).toEqual({ synthetic: true, images });
-			// The rough objective rides inside the kickoff, and the kickoff tells the
-			// agent how to finish: `goal` tool, op create.
+			// The rough objective rides inside the kickoff, which requires batched
+			// questions through the ask tool and finishes through `goal create`.
 			expect(text).toContain("automate flaky test triage");
+			expect(text).toContain("MUST use `ask()` for every question and confirmation");
+			expect(text).toContain("Batch every currently known, independent question into one `ask()` call");
 			expect(text).toContain('op: "create"');
 			// The goal tool is activated up front so the agent can create the goal
 			// once the interview concludes.

--- a/packages/coding-agent/test/goals/guided-goal.test.ts
+++ b/packages/coding-agent/test/goals/guided-goal.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
 import * as path from "node:path";
+import { scheduler } from "node:timers/promises";
 import { Agent, AgentBusyError } from "@oh-my-pi/pi-agent-core";
 import type { ImageContent } from "@oh-my-pi/pi-ai";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
@@ -12,7 +13,7 @@ import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import { createTools, type Tool, type ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
-import { TempDir } from "@oh-my-pi/pi-utils";
+import { postmortem, TempDir } from "@oh-my-pi/pi-utils";
 
 function createToolSession(cwd: string, settings: Settings, overrides: Partial<ToolSession> = {}): ToolSession {
 	return {
@@ -155,15 +156,11 @@ describe("guided goal setup", () => {
 		const harness = await createHarness({ askEnabled: false });
 		try {
 			const promptSpy = vi.spyOn(harness.session, "prompt").mockResolvedValue(true);
-			const warning = vi.spyOn(harness.mode, "showWarning");
 
 			const started = await harness.mode.handleGuidedGoalCommand("ship it");
 
 			expect(started).toBe(false);
 			expect(promptSpy).not.toHaveBeenCalled();
-			expect(warning).toHaveBeenCalledWith(
-				"The guided goal interview requires the ask tool, but it is unavailable in this session.",
-			);
 			expect(harness.session.getEnabledToolNames()).not.toContain("goal");
 		} finally {
 			await harness.cleanup();
@@ -202,6 +199,29 @@ describe("guided goal setup", () => {
 		}
 	});
 
+	it("rejects a second guided goal while an interview is pending", async () => {
+		const harness = await createHarness();
+		try {
+			await harness.mode.init();
+			const previousTools = harness.session.getEnabledToolNames();
+			Object.defineProperty(harness.session, "isStreaming", { configurable: true, get: () => true });
+			const followUp = vi.spyOn(harness.session, "followUp").mockResolvedValue();
+
+			const firstStarted = await harness.mode.handleGuidedGoalCommand("first goal");
+			const secondStarted = await harness.mode.handleGuidedGoalCommand("second goal");
+
+			expect(firstStarted).toBe(true);
+			expect(secondStarted).toBe(false);
+			expect(followUp).toHaveBeenCalledTimes(1);
+
+			Object.defineProperty(harness.session, "isStreaming", { configurable: true, get: () => false });
+			await emitTerminalAgentEnd(harness);
+			expect(harness.session.getEnabledToolNames()).toEqual(previousTools);
+		} finally {
+			await harness.cleanup();
+		}
+	});
+
 	it("falls back to a synthetic follow-up when the prompt races an in-flight run", async () => {
 		const harness = await createHarness();
 		try {
@@ -217,17 +237,28 @@ describe("guided goal setup", () => {
 		}
 	});
 
-	it("restores the previous tools when the kickoff fails", async () => {
+	it("retries failed cleanup before starting another interview", async () => {
 		const harness = await createHarness();
 		try {
 			const previousTools = harness.session.getEnabledToolNames();
-			vi.spyOn(harness.session, "prompt").mockRejectedValue(new Error("kickoff failed"));
+			const setActiveTools = harness.session.setActiveToolsByName.bind(harness.session);
+			const promptSpy = vi
+				.spyOn(harness.session, "prompt")
+				.mockImplementationOnce(async () => {
+					vi.spyOn(harness.session, "setActiveToolsByName")
+						.mockRejectedValueOnce(new Error("transient restore failure"))
+						.mockImplementation(setActiveTools);
+					throw new Error("kickoff failed");
+				})
+				.mockResolvedValue(true);
 			const error = vi.spyOn(harness.mode, "showError");
 
-			const started = await harness.mode.handleGuidedGoalCommand("ship it");
-
-			expect(started).toBe(false);
+			expect(await harness.mode.handleGuidedGoalCommand("first goal")).toBe(false);
 			expect(error).toHaveBeenCalledWith("kickoff failed");
+			expect(harness.session.getEnabledToolNames()).toEqual(expect.arrayContaining(["ask", "goal"]));
+
+			expect(await harness.mode.handleGuidedGoalCommand("second goal")).toBe(true);
+			expect(promptSpy).toHaveBeenCalledTimes(2);
 			expect(harness.session.getEnabledToolNames()).toEqual(previousTools);
 		} finally {
 			await harness.cleanup();
@@ -253,18 +284,111 @@ describe("guided goal setup", () => {
 		}
 	});
 
-	it("keeps the interview tools for a created goal until goal-mode exit", async () => {
+	it("retries restoration after a transient tool update failure", async () => {
 		const harness = await createHarness();
 		try {
 			await harness.mode.init();
 			const previousTools = harness.session.getEnabledToolNames();
-			vi.spyOn(harness.session, "prompt").mockImplementation(async () => {
-				await harness.goalTool.execute("create-call", {
-					op: "create",
-					objective: "Ship the release.",
-				});
-				return true;
+			Object.defineProperty(harness.session, "isStreaming", { configurable: true, get: () => true });
+			vi.spyOn(harness.session, "followUp").mockResolvedValue();
+			await harness.mode.handleGuidedGoalCommand("ship it");
+			Object.defineProperty(harness.session, "isStreaming", { configurable: true, get: () => false });
+
+			const setActiveTools = harness.session.setActiveToolsByName.bind(harness.session);
+			vi.spyOn(harness.session, "setActiveToolsByName")
+				.mockRejectedValueOnce(new Error("transient restore failure"))
+				.mockImplementation(setActiveTools);
+
+			await emitTerminalAgentEnd(harness);
+			expect(harness.session.getEnabledToolNames()).toEqual(expect.arrayContaining(["ask", "goal"]));
+
+			await emitTerminalAgentEnd(harness);
+			expect(harness.session.getEnabledToolNames()).toEqual(previousTools);
+		} finally {
+			await harness.cleanup();
+		}
+	});
+
+	it("restores a queued interview before starting a new session", async () => {
+		const harness = await createHarness();
+		try {
+			await harness.mode.init();
+			const previousTools = harness.session.getEnabledToolNames();
+			const previousSessionId = harness.session.sessionId;
+			Object.defineProperty(harness.session, "isStreaming", { configurable: true, get: () => true });
+			const followUpStarted = Promise.withResolvers<void>();
+			const releaseFollowUp = Promise.withResolvers<void>();
+			vi.spyOn(harness.session, "followUp").mockImplementation(async () => {
+				followUpStarted.resolve();
+				await releaseFollowUp.promise;
 			});
+			const guidedGoal = harness.mode.handleGuidedGoalCommand("ship it");
+			await followUpStarted.promise;
+			Object.defineProperty(harness.session, "isStreaming", { configurable: true, get: () => false });
+
+			let newSessionSettled = false;
+			const newSession = harness.session.newSession().then(result => {
+				newSessionSettled = true;
+				return result;
+			});
+			await scheduler.yield();
+			expect(newSessionSettled).toBe(false);
+			releaseFollowUp.resolve();
+
+			expect(await guidedGoal).toBe(true);
+			expect(await newSession).toBe(true);
+			expect(harness.session.sessionId).not.toBe(previousSessionId);
+			expect(harness.session.getEnabledToolNames()).toEqual(previousTools);
+			vi.spyOn(harness.session, "prompt").mockResolvedValue(true);
+			expect(await harness.mode.handleGuidedGoalCommand("new goal")).toBe(true);
+		} finally {
+			await harness.cleanup();
+		}
+	});
+
+	it("cancels a new session when pending interview restoration fails", async () => {
+		const harness = await createHarness();
+		try {
+			await harness.mode.init();
+			const previousTools = harness.session.getEnabledToolNames();
+			const previousSessionId = harness.session.sessionId;
+			Object.defineProperty(harness.session, "isStreaming", { configurable: true, get: () => true });
+			vi.spyOn(harness.session, "followUp").mockResolvedValue();
+			await harness.mode.handleGuidedGoalCommand("ship it");
+			Object.defineProperty(harness.session, "isStreaming", { configurable: true, get: () => false });
+
+			const setActiveTools = harness.session.setActiveToolsByName.bind(harness.session);
+			vi.spyOn(harness.session, "setActiveToolsByName")
+				.mockRejectedValueOnce(new Error("transient restore failure"))
+				.mockImplementation(setActiveTools);
+
+			expect(await harness.session.newSession()).toBe(false);
+			expect(harness.session.sessionId).toBe(previousSessionId);
+			expect(harness.session.getEnabledToolNames()).toEqual(expect.arrayContaining(["ask", "goal"]));
+
+			expect(await harness.session.newSession()).toBe(true);
+			expect(harness.session.sessionId).not.toBe(previousSessionId);
+			expect(harness.session.getEnabledToolNames()).toEqual(previousTools);
+		} finally {
+			await harness.cleanup();
+		}
+	});
+
+	it("keeps interview tools through goal creation and retries failed exit restoration", async () => {
+		const harness = await createHarness();
+		try {
+			await harness.mode.init();
+			const previousTools = harness.session.getEnabledToolNames();
+			const promptSpy = vi
+				.spyOn(harness.session, "prompt")
+				.mockImplementationOnce(async () => {
+					await harness.goalTool.execute("create-call", {
+						op: "create",
+						objective: "Ship the release.",
+					});
+					return true;
+				})
+				.mockResolvedValue(true);
 
 			await harness.mode.handleGuidedGoalCommand("ship it");
 
@@ -272,9 +396,53 @@ describe("guided goal setup", () => {
 			expect(harness.session.getEnabledToolNames()).toEqual(expect.arrayContaining(["ask", "goal"]));
 
 			await harness.goalTool.execute("complete-call", { op: "complete" });
+			const setActiveTools = harness.session.setActiveToolsByName.bind(harness.session);
+			const setActiveToolsSpy = vi
+				.spyOn(harness.session, "setActiveToolsByName")
+				.mockRejectedValue(new Error("persistent goal exit failure"));
 			await emitTerminalAgentEnd(harness);
 
+			expect(harness.session.getGoalModeState()?.mode).toBe("exiting");
+			expect(harness.session.getEnabledToolNames()).toEqual(expect.arrayContaining(["ask", "goal"]));
+			await expect(harness.mode.getUserInput()).rejects.toThrow(
+				"Cannot accept input until goal mode restores the previous tool set.",
+			);
+			setActiveToolsSpy.mockImplementation(setActiveTools);
+
+			const restarted = await harness.mode.handleGuidedGoalCommand("next goal");
+
+			expect(restarted).toBe(true);
+			expect(promptSpy).toHaveBeenCalledTimes(2);
+			expect(harness.session.getGoalModeState()).toBeUndefined();
 			expect(harness.session.getEnabledToolNames()).toEqual(previousTools);
+		} finally {
+			await harness.cleanup();
+		}
+	});
+
+	it("clears a completed goal during shutdown after repeated restore failures", async () => {
+		const harness = await createHarness();
+		try {
+			await harness.mode.init();
+			harness.mode.ui.terminal.drainInput = async () => {};
+			const quit = vi.spyOn(postmortem, "quit").mockResolvedValue(undefined);
+			vi.spyOn(harness.session, "prompt").mockImplementation(async () => {
+				await harness.goalTool.execute("create-call", {
+					op: "create",
+					objective: "Ship the release.",
+				});
+				return true;
+			});
+			await harness.mode.handleGuidedGoalCommand("ship it");
+			await harness.goalTool.execute("complete-call", { op: "complete" });
+			vi.spyOn(harness.session, "setActiveToolsByName").mockRejectedValue(new Error("persistent goal exit failure"));
+			await emitTerminalAgentEnd(harness);
+			expect(harness.session.getGoalModeState()?.mode).toBe("exiting");
+
+			await harness.mode.shutdown();
+
+			expect(harness.session.getGoalModeState()).toBeUndefined();
+			expect(quit).toHaveBeenCalledWith(0);
 		} finally {
 			await harness.cleanup();
 		}

--- a/packages/coding-agent/test/goals/guided-goal.test.ts
+++ b/packages/coding-agent/test/goals/guided-goal.test.ts
@@ -412,18 +412,27 @@ describe("guided goal setup", () => {
 				toolsRestored.resolve();
 			});
 			const warning = vi.spyOn(harness.mode, "showWarning");
+			const prompt = vi.spyOn(harness.session, "prompt").mockResolvedValue(true);
 
 			await emitTerminalAgentEnd(harness);
 			expect(harness.session.getEnabledToolNames()).toEqual(expect.arrayContaining(["ask", "goal"]));
 			const input = harness.mode.getUserInput();
 			await scheduler.yield();
 			expect(harness.mode.onInputCallback).toBeUndefined();
+			expect(harness.mode.editor.disableSubmit).toBe(true);
+			harness.mode.editor.setText("next turn");
+			harness.mode.editor.handleInput("\r");
+			await scheduler.yield();
+			expect(prompt).not.toHaveBeenCalled();
+			expect(harness.mode.editor.getText()).toBe("next turn");
 			await toolsRestored.promise;
 			await scheduler.yield();
 
 			expect(warning).toHaveBeenCalled();
-			harness.mode.onInputCallback?.(harness.mode.startPendingSubmission({ text: "next turn" }));
-			await input;
+			expect(harness.mode.editor.disableSubmit).toBe(false);
+			harness.mode.editor.handleInput("\r");
+			expect(await input).toEqual(expect.objectContaining({ text: "next turn" }));
+			expect(prompt).not.toHaveBeenCalled();
 			expect(harness.session.getEnabledToolNames()).toEqual(previousTools);
 		} finally {
 			await harness.cleanup();

--- a/packages/coding-agent/test/goals/guided-goal.test.ts
+++ b/packages/coding-agent/test/goals/guided-goal.test.ts
@@ -74,6 +74,9 @@ async function createHarness(options?: {
 		rebuildSystemPrompt: async () => ({ systemPrompt: ["Test"] }),
 		ensureGoalRegistered: options?.goalAvailable === false ? async () => false : undefined,
 	});
+	for (const tool of availableTools) {
+		session.setToolBuiltIn(tool.name, true);
+	}
 	// Mirror sdk.ts assembly: the goal tool is pre-registered (hidden) whenever
 	// goal.enabled, so /guided-goal can activate it by name for the interview.
 	const goalToolSession = createToolSession(tempDir.path(), settings, {
@@ -83,6 +86,7 @@ async function createHarness(options?: {
 	const goalTool = new GoalTool(goalToolSession);
 	if (options?.goalAvailable !== false) {
 		toolRegistry.set("goal", goalTool as unknown as Tool);
+		session.setToolBuiltIn("goal", true);
 	}
 	const mode = new InteractiveMode(session, "test");
 	vi.spyOn(mode, "addMessageToChat").mockReturnValue([]);
@@ -169,6 +173,40 @@ describe("guided goal setup", () => {
 			expect(started).toBe(false);
 			expect(promptSpy).not.toHaveBeenCalled();
 			expect(harness.session.getEnabledToolNames()).not.toContain("goal");
+		} finally {
+			await harness.cleanup();
+		}
+	});
+
+	it("refuses to start when an extension replaces the built-in ask tool", async () => {
+		const harness = await createHarness();
+		try {
+			harness.session.setToolBuiltIn("ask", false);
+			const previousTools = harness.session.getEnabledToolNames();
+			const promptSpy = vi.spyOn(harness.session, "prompt").mockResolvedValue(true);
+
+			const started = await harness.mode.handleGuidedGoalCommand("ship it");
+
+			expect(started).toBe(false);
+			expect(promptSpy).not.toHaveBeenCalled();
+			expect(harness.session.getEnabledToolNames()).toEqual(previousTools);
+		} finally {
+			await harness.cleanup();
+		}
+	});
+
+	it("rolls back when an extension replaces the built-in goal tool", async () => {
+		const harness = await createHarness();
+		try {
+			harness.session.setToolBuiltIn("goal", false);
+			const previousTools = harness.session.getEnabledToolNames();
+			const promptSpy = vi.spyOn(harness.session, "prompt").mockResolvedValue(true);
+
+			const started = await harness.mode.handleGuidedGoalCommand("ship it");
+
+			expect(started).toBe(false);
+			expect(promptSpy).not.toHaveBeenCalled();
+			expect(harness.session.getEnabledToolNames()).toEqual(previousTools);
 		} finally {
 			await harness.cleanup();
 		}


### PR DESCRIPTION
## Summary

The `ask()` tool is often correctly being discovered by models for planning sessions, confirmations etc. 

I've noticed that for some reason the built-in `/guided-goal` was not using it, even though it'd make the goal interviewing much faster and pleasant. This PR fixes it.

## Changes
- require `/guided-goal` interviews to use the built-in `ask()` tool for every question and confirmation
- batch currently known independent questions instead of serializing them across turns

## Verification
- `bun test packages/coding-agent/test/goals/guided-goal.test.ts`
- `bun --cwd=packages/coding-agent run check`
- `bun --cwd=packages/coding-agent run format-prompts`
- `git diff --check`