### PR TITLE
fix(models): resolve chained model role aliases

### DIFF
--- a/docs/models.md
+++ b/docs/models.md
@@ -426,7 +426,7 @@ The `tiny` role overrides the online model used for lightweight background tasks
 
 Role aliases like `@smol` expand through `settings.modelRoles`; `*` selects `@default`. Quote `@` aliases in YAML values (`fable: "@slow"`). Each role value can also append a thinking selector such as `:minimal`, `:low`, `:medium`, or `:high`.
 
-If a role points at another role, the target model still inherits normally and any explicit suffix on the referring role wins for that role-specific use.
+Chained role aliases are expanded recursively until they reach concrete model patterns. Cyclic candidates are discarded so later configured candidates remain eligible; when no configured candidate resolves, an unset built-in role uses its priority defaults. Any explicit suffix on the referring role wins for that role-specific use.
 
 Related settings:
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -19,7 +19,7 @@
 - Fixed an issue where custom model overrides were lost during configuration updates
 - Fixed "Please use nerdfont" notification incorrectly persisting after theme configuration
 - Fixed sampling parameter errors for newer Anthropic models (Opus 4.7+, Sonnet 5+)
-- Fixed chained `modelRoles` aliases stopping at an intermediate role instead of resolving to concrete model patterns.
+- Fixed chained `modelRoles` aliases stopping at an intermediate role instead of resolving to concrete model patterns ([#10324](https://github.com/can1357/oh-my-pi/pull/10324) by [@SiaoZeng](https://github.com/SiaoZeng)).
 
 ## [18.0.11] - 2026-08-29
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Fixed an issue where custom model overrides were lost during configuration updates
 - Fixed "Please use nerdfont" notification incorrectly persisting after theme configuration
 - Fixed sampling parameter errors for newer Anthropic models (Opus 4.7+, Sonnet 5+)
+- Fixed chained `modelRoles` aliases stopping at an intermediate role instead of resolving to concrete model patterns.
 
 ## [18.0.11] - 2026-08-29
 

--- a/packages/coding-agent/src/config/model-resolver.ts
+++ b/packages/coding-agent/src/config/model-resolver.ts
@@ -1138,14 +1138,16 @@ function resolveDefaultInheritedPatterns(
 			);
 			continue;
 		}
-		if (aliasRole && !visited.has(aliasRole)) {
-			// Cross-role alias (e.g. modelRoles.default = "@slow"): resolve the
-			// concrete model patterns instead of another role alias.
-			const recursed = resolveConfiguredRolePattern(pattern, settings, new Set(visited));
-			if (recursed && recursed.length > 0) {
-				resolved.push(...recursed);
-				continue;
+		if (aliasRole) {
+			if (!visited.has(aliasRole)) {
+				// Cross-role alias (e.g. modelRoles.default = "@slow"): resolve the
+				// concrete model patterns instead of another role alias.
+				const recursed = resolveConfiguredRolePattern(pattern, settings, new Set(visited));
+				if (recursed && recursed.length > 0) {
+					resolved.push(...recursed);
+				}
 			}
+			continue;
 		}
 		resolved.push(pattern);
 	}
@@ -1174,7 +1176,9 @@ function resolveConfiguredRolePattern(
 	const configuredDefault = settings?.getModelRole(DEFAULT_MODEL_ROLE)?.trim();
 	const roleDefaults = isModelRole(role) ? rolePriorityDefaults(role) : [];
 	const resolved = configured
-		? normalizeModelPatternList(configured)
+		? normalizeModelPatternList(configured).flatMap(
+				pattern => resolveConfiguredRolePattern(pattern, settings, new Set(visited)) ?? [],
+			)
 		: isModelRole(role)
 			? resolveDefaultInheritedPatterns(role, configuredDefault, roleDefaults, settings, visited)
 			: roleDefaults;

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -16,6 +16,7 @@ import {
 	resolveAgentPrewalkPattern,
 	resolveAllowedModels,
 	resolveCliModel,
+	resolveConfiguredModelPatterns,
 	resolveExplicitModelRole,
 	resolveModelFromString,
 	resolveModelOverride,
@@ -1103,6 +1104,74 @@ describe("resolveAgentModelPatterns", () => {
 		});
 
 		expect(resolveAgentModelPatterns({ agentModel: "@smol", settings })).toEqual(["anthropic/claude-sonnet-4-5"]);
+	});
+
+	test("expands chained configured role aliases to concrete model patterns", () => {
+		const settings = Settings.isolated({
+			modelRoles: {
+				default: "@slow",
+				slow: "@designer",
+				designer: "openai-codex/gpt-5.6-sol",
+			},
+		});
+
+		expect(resolveAgentModelPatterns({ agentModel: "@smol", settings })).toEqual(["openai-codex/gpt-5.6-sol"]);
+	});
+
+	test("stops chained configured role aliases at cycles", () => {
+		const settings = Settings.isolated({
+			modelRoles: {
+				alpha: "@beta",
+				beta: "@alpha",
+			},
+		});
+
+		expect(resolveConfiguredModelPatterns("@alpha", settings)).toEqual([]);
+	});
+
+	test("expands sibling alias chains with independent visited state and suffixes", () => {
+		const settings = Settings.isolated({
+			modelRoles: {
+				root: ["@left:high", "@right:low"],
+				left: "@shared",
+				right: "@shared",
+				shared: "anthropic/claude-sonnet-4-5",
+			},
+		});
+
+		expect(resolveConfiguredModelPatterns("@root", settings)).toEqual([
+			"anthropic/claude-sonnet-4-5:high",
+			"anthropic/claude-sonnet-4-5:low",
+		]);
+	});
+
+	test("keeps the outermost thinking suffix across a chained alias", () => {
+		const settings = Settings.isolated({
+			modelRoles: {
+				root: "@middle:low",
+				middle: "@leaf:medium",
+				leaf: "anthropic/claude-sonnet-4-5:minimal",
+			},
+		});
+
+		const [pattern] = resolveConfiguredModelPatterns("@root:high", settings);
+		const resolved = parseModelPattern(pattern, mockModels);
+		expect(resolved.model?.id).toBe("claude-sonnet-4-5");
+		expect(resolved.thinkingLevel).toBe(Effort.High);
+	});
+
+	test("uses built-in role defaults when an inherited custom alias chain cycles", () => {
+		const settings = Settings.isolated({
+			modelRoles: {
+				default: "@alpha",
+				alpha: "@beta",
+				beta: "@alpha",
+			},
+		});
+
+		const patterns = resolveAgentModelPatterns({ agentModel: "@smol", settings });
+		expect(patterns[0]).toBe("cerebras/zai-glm-4.7");
+		expect(patterns.every(pattern => !pattern.startsWith("@"))).toBe(true);
 	});
 
 	test("prefers configured designer role override over priority defaults", () => {


### PR DESCRIPTION
## What

Recursively expand configured `modelRoles` aliases until they reach concrete model patterns. Preserve branch-local cycle state for list candidates, retain outer thinking-suffix precedence, discard cyclic configured candidates, and let unset built-in roles use their priority defaults when no configured candidate resolves.

This is intentionally separate from #10322 and does not change `model: inherit` behavior.

## Why

A chain such as `default: "@slow"`, `slow: "@designer"`, and `designer: openai-codex/gpt-5.6-sol` currently stops at `@designer`. The unresolved alias can reach subagent model selection and fail instead of starting the configured concrete model.

I reviewed the full diff and tested the chained role configuration locally; modelRoles aliases now resolve through intermediate roles to the configured concrete model.

## Testing

- `bun test test/model-resolver.test.ts` — 171 passed, 0 failed
- `bun run check` — Biome and `tsgo --noEmit` passed
- Behavioral smoke: launched a project custom agent routed through `@smol -> @default -> @slow -> @designer -> openai-codex/gpt-5.6-sol`; the child selected `openai-codex/gpt-5.6-sol` with `resolvedModelIsFallback: false` and returned `{ "probe": "ALIAS_CHAIN_PROBE_OK" }`
- Regression coverage includes scalar and list chains, sibling paths with independent visited state, outer suffix precedence, direct cycles, and built-in fallback after cyclic configured candidates

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (user-facing)
