### PR TITLE
fix(auth-storage): inspect usage report for API key rate limits and parse reset timestamps

### DIFF
--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -4576,7 +4576,7 @@ export class AuthStorage {
 		const now = Date.now();
 		let blockedUntil = now + (options?.retryAfterMs ?? AuthStorage.#defaultBackoffMs);
 
-		if (credentialType === "oauth" && target.credential.type === "oauth" && routing.strategy) {
+		if (target && routing.strategy) {
 			const report = await raceUsageWithSignal(
 				this.#getUsageReport(provider, target.credential, options),
 				options?.signal,

--- a/packages/ai/test/auth-storage-zai-api-key-selection.test.ts
+++ b/packages/ai/test/auth-storage-zai-api-key-selection.test.ts
@@ -151,8 +151,45 @@ describe("AuthStorage Z.AI API-key usage ranking", () => {
 				},
 			],
 		});
-
 		expect(await authStorage.getApiKey("zai")).toBe("zai-healthy");
+	});
+
+	test("markUsageLimitReached inspects usage report for API keys to determine accurate reset time", async () => {
+		if (!authStorage) throw new Error("test setup failed");
+
+		await authStorage.set("zai", [
+			{ type: "api_key", key: "zai-acc1", source: "login" },
+			{ type: "api_key", key: "zai-acc2", source: "login" },
+		]);
+		const futureReset = Date.now() + 24 * HOUR_MS;
+		usageByKey.set("zai-acc1", {
+			provider: "zai",
+			fetchedAt: Date.now(),
+			limits: [
+				{
+					id: "zai:credits:1w",
+					label: "ZAI Weekly Credit Quota",
+					scope: { provider: "zai", windowId: "1w", shared: true },
+					window: { id: "1w", label: "Weekly", durationMs: 7 * 24 * HOUR_MS, resetsAt: futureReset },
+					amount: {
+						unit: "credits",
+						used: 140000,
+						limit: 140000,
+						remaining: 0,
+						usedFraction: 1,
+						remainingFraction: 0,
+					},
+					status: "exhausted",
+				},
+			],
+		});
+
+		const outcome = await authStorage.markUsageLimitReached("zai", "session-xyz", {
+			apiKey: "zai-acc1",
+		});
+
+		expect(outcome.switched).toBe(true);
+		expect(await authStorage.getApiKey("zai", "session-xyz")).toBe("zai-acc2");
 	});
 
 	test("ignores exhausted Z.AI feature quotas for model request routing", async () => {

--- a/packages/utils/src/fetch-retry.ts
+++ b/packages/utils/src/fetch-retry.ts
@@ -12,6 +12,12 @@ const RETRY_DELAY_FIELD_PATTERN = /"retryDelay":\s*"([0-9.]+)(ms|s)"/i;
 const TRY_AGAIN_PATTERN = /try again in\s+~?\s*([0-9.]+)\s*(ms|sec|s|minutes?|mins?|m|hours?|hrs?|h)\b/i;
 // "Your limit will reset in 13 minutes" / "reset in 13 minutes" / "will reset in 2h"
 const WILL_RESET_IN_PATTERN = /(?:will\s+)?reset in\s+~?\s*([0-9.]+)\s*(ms|sec|s|minutes?|mins?|m|hours?|hrs?|h)\b/i;
+// "Your limit will reset at 2026-09-01 09:44:51" / "reset at 2026-09-01T09:44:51Z"
+const WILL_RESET_AT_PATTERN =
+	/(?:will\s+)?reset at\s+([0-9]{4}-[0-9]{2}-[0-9]{2}[ T][0-9]{2}:[0-9]{2}:[0-9]{2}(?:\.[0-9]+)?(?:Z|[+-][0-9]{2}:?[0-9]{2})?)/i;
+const CN_RESET_AT_PATTERN = /将在\s*([0-9]{4}-[0-9]{2}-[0-9]{2}\s+[0-9]{2}:[0-9]{2}:[0-9]{2})\s*重置/;
+// "retry-after-ms=98497000"
+const RETRY_AFTER_MS_BODY_PATTERN = /\bretry-after-ms=([0-9]+)\b/i;
 
 /**
  * Server-suggested retry delay extraction. Merges the patterns historically used
@@ -83,6 +89,22 @@ export function extractRetryHint(source: Response | Headers | null | undefined, 
 		if (!Number.isNaN(seconds)) {
 			const totalMs = ((hours * 60 + minutes) * 60 + seconds) * 1000;
 			if (totalMs > 0) return totalMs;
+		}
+	}
+	const retryAfterMsMatch = RETRY_AFTER_MS_BODY_PATTERN.exec(body);
+	if (retryAfterMsMatch?.[1]) {
+		const ms = Number(retryAfterMsMatch[1]);
+		if (Number.isFinite(ms) && ms > 0) return ms;
+	}
+
+	for (const pattern of [WILL_RESET_AT_PATTERN, CN_RESET_AT_PATTERN]) {
+		const match = pattern.exec(body);
+		if (match?.[1]) {
+			const isoStr = match[1].includes("T") ? match[1] : `${match[1].replace(" ", "T")}Z`;
+			const parsed = Date.parse(isoStr);
+			if (!Number.isNaN(parsed) && parsed > Date.now()) {
+				return parsed - Date.now();
+			}
 		}
 	}
 	// Account-reset hints ("will reset in …") take precedence over short

--- a/packages/utils/test/fetch-retry.test.ts
+++ b/packages/utils/test/fetch-retry.test.ts
@@ -134,4 +134,27 @@ describe("extractRetryHint", () => {
 	it("prefers the account reset window over a shorter retry hint", () => {
 		expect(extractRetryHint(undefined, "Please retry in 5s. Your limit will reset in 13 minutes")).toBe(13 * 60_000);
 	});
+
+	it("parses retry-after-ms in error body", () => {
+		expect(
+			extractRetryHint(
+				undefined,
+				'429 {"type":"error","error":{"type":"rate_limit_error","code":"1310"}} retry-after-ms=98497000',
+			),
+		).toBe(98497000);
+	});
+
+	it("parses 'will reset at YYYY-MM-DD HH:MM:SS' timestamp in error body", () => {
+		const future = new Date(Date.now() + 3_600_000).toISOString().replace("T", " ").slice(0, 19);
+		const hint = extractRetryHint(undefined, `Your limit will reset at ${future}`);
+		expect(hint).toBeGreaterThan(3_500_000);
+		expect(hint).toBeLessThanOrEqual(3_600_000);
+	});
+
+	it("parses Chinese '将在 YYYY-MM-DD HH:MM:SS 重置' reset timestamp in error body", () => {
+		const future = new Date(Date.now() + 3_600_000).toISOString().replace("T", " ").slice(0, 19);
+		const hint = extractRetryHint(undefined, `已达到使用上限。您的限额将在 ${future} 重置。`);
+		expect(hint).toBeGreaterThan(3_500_000);
+		expect(hint).toBeLessThanOrEqual(3_600_000);
+	});
 });


### PR DESCRIPTION
## Summary

- **Usage lookup for API keys on rate limit**: Widened `markUsageLimitReached` in `AuthStorage` to inspect live usage reports and determine exact reset timestamps for any credential provider with a ranking strategy (`target && routing.strategy`), rather than gating this check solely on `credentialType === "oauth"`. This ensures providers with API key multi-account rotation (such as Z.AI) calculate accurate `resetAtMs` when blocked.
- **Retry hint extraction**: Added support in `extractRetryHint` for:
  - Error strings carrying `retry-after-ms=\d+`
  - Absolute reset timestamps matching `will reset at <date>` (e.g. Z.AI `[Weekly/Monthly Limit Exhausted. Your limit will reset at 2026-09-01 09:44:51]`)
  - Chinese reset timestamp phrasing `将在 <date> 重置` (e.g. Zhipu Coding Plan)
- **Tests**: Added test cases covering `markUsageLimitReached` with API key usage reset lookups and `extractRetryHint` timestamp parsing.