### PR TITLE
fix(coding-agent): preserve activity after invalid rename

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### Fixed
 
 - Fixed an issue where custom model overrides were lost during configuration updates
+- Fixed entering `/rename` without a title interrupting active session activity ([#10326](https://github.com/can1357/oh-my-pi/issues/10326)).
 - Fixed "Please use nerdfont" notification incorrectly persisting after theme configuration
 - Fixed sampling parameter errors for newer Anthropic models (Opus 4.7+, Sonnet 5+)
 

--- a/packages/coding-agent/src/slash-commands/builtin-lifecycle.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-lifecycle.ts
@@ -561,7 +561,7 @@ export const BUILTIN_LIFECYCLE_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> =
 		handleTui: async (command, runtime) => {
 			const title = command.args.trim();
 			if (!title) {
-				runtime.ctx.showError("Usage: /rename <title>");
+				runtime.ctx.showStatus("Usage: /rename <title>");
 				runtime.ctx.editor.setText("");
 				return;
 			}

--- a/packages/coding-agent/test/interactive-mode-working-accent.test.ts
+++ b/packages/coding-agent/test/interactive-mode-working-accent.test.ts
@@ -1,9 +1,11 @@
 import { afterAll, afterEach, describe, expect, it, vi } from "bun:test";
+import { stripVTControlCharacters } from "node:util";
 import { resetSettingsForTest, Settings, settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { InteractiveMode } from "@oh-my-pi/pi-coding-agent/modes/interactive-mode";
 import { initTheme, theme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import type { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { executeBuiltinSlashCommand } from "@oh-my-pi/pi-coding-agent/slash-commands/builtin-registry";
 import * as sessionColor from "@oh-my-pi/pi-coding-agent/utils/session-color";
 import { adjustHsv, TempDir } from "@oh-my-pi/pi-utils";
 
@@ -57,6 +59,7 @@ async function createHarness(sessionName: string): Promise<Harness> {
 		messages: [],
 		systemPrompt: [],
 		state: { model: undefined },
+		isStreaming: true,
 		model: undefined,
 		thinkingLevel: undefined,
 	} as unknown as AgentSession;
@@ -178,5 +181,25 @@ describe("InteractiveMode working-message session accent cache", () => {
 		mode.loadingAnimation?.setMessage("Accent enabled");
 		expect(renderLoader(mode)).toContain(accentAnsi);
 		expect(getHex).toHaveBeenCalledTimes(2);
+	});
+});
+
+describe("InteractiveMode working activity", () => {
+	it("preserves the active loader when blank /rename reports usage", async () => {
+		const { mode } = await createHarness("Active rename session");
+		mode.ensureLoadingAnimation();
+		const loader = defined(mode.loadingAnimation);
+		expect(mode.session.isStreaming).toBe(true);
+
+		try {
+			const handled = await executeBuiltinSlashCommand("/rename", { ctx: mode });
+
+			expect(handled).toBe(true);
+			expect(mode.session.isStreaming).toBe(true);
+			expect(mode.loadingAnimation).toBe(loader);
+			expect(stripVTControlCharacters(renderLoader(mode))).toContain("Working");
+		} finally {
+			loader.stop();
+		}
 	});
 });

--- a/packages/coding-agent/test/slash-commands/rename.test.ts
+++ b/packages/coding-agent/test/slash-commands/rename.test.ts
@@ -5,17 +5,20 @@ import { executeBuiltinSlashCommand } from "@oh-my-pi/pi-coding-agent/slash-comm
 function createRuntime() {
 	const handleRenameCommand = vi.fn(async () => {});
 	const showError = vi.fn();
+	const showStatus = vi.fn();
 	const setText = vi.fn();
 	const addToHistory = vi.fn();
 	return {
 		handleRenameCommand,
 		showError,
+		showStatus,
 		setText,
 		addToHistory,
 		runtime: {
 			ctx: {
 				editor: { setText, addToHistory } as unknown as InteractiveModeContext["editor"],
 				showError,
+				showStatus,
 				handleRenameCommand,
 			} as unknown as InteractiveModeContext,
 		},
@@ -33,13 +36,14 @@ describe("/rename slash command", () => {
 		expect(harness.handleRenameCommand).toHaveBeenCalledWith("my session");
 	});
 
-	it("handles a blank /rename invocation without error", async () => {
+	it("reports blank input without stopping active session activity", async () => {
 		const harness = createRuntime();
 
 		const handled = await executeBuiltinSlashCommand("/rename   ", harness.runtime);
 
 		expect(handled).toBe(true);
-		expect(harness.showError).toHaveBeenCalledWith("Usage: /rename <title>");
+		expect(harness.showStatus).toHaveBeenCalledWith("Usage: /rename <title>");
+		expect(harness.showError).not.toHaveBeenCalled();
 		expect(harness.setText).toHaveBeenCalledWith("");
 		expect(harness.handleRenameCommand).not.toHaveBeenCalled();
 	});

--- a/packages/coding-agent/test/slash-commands/rename.test.ts
+++ b/packages/coding-agent/test/slash-commands/rename.test.ts
@@ -4,20 +4,17 @@ import { executeBuiltinSlashCommand } from "@oh-my-pi/pi-coding-agent/slash-comm
 
 function createRuntime() {
 	const handleRenameCommand = vi.fn(async () => {});
-	const showError = vi.fn();
 	const showStatus = vi.fn();
 	const setText = vi.fn();
 	const addToHistory = vi.fn();
 	return {
 		handleRenameCommand,
-		showError,
 		showStatus,
 		setText,
 		addToHistory,
 		runtime: {
 			ctx: {
 				editor: { setText, addToHistory } as unknown as InteractiveModeContext["editor"],
-				showError,
 				showStatus,
 				handleRenameCommand,
 			} as unknown as InteractiveModeContext,
@@ -36,14 +33,13 @@ describe("/rename slash command", () => {
 		expect(harness.handleRenameCommand).toHaveBeenCalledWith("my session");
 	});
 
-	it("reports blank input without stopping active session activity", async () => {
+	it("reports usage for blank input without renaming", async () => {
 		const harness = createRuntime();
 
 		const handled = await executeBuiltinSlashCommand("/rename   ", harness.runtime);
 
 		expect(handled).toBe(true);
 		expect(harness.showStatus).toHaveBeenCalledWith("Usage: /rename <title>");
-		expect(harness.showError).not.toHaveBeenCalled();
 		expect(harness.setText).toHaveBeenCalledWith("");
 		expect(harness.handleRenameCommand).not.toHaveBeenCalled();
 	});


### PR DESCRIPTION
## Repro
While an agent turn is streaming, submit `/rename` without a title. The focused regression command `bun test packages/coding-agent/test/slash-commands/rename.test.ts` showed that blank input used the activity-resetting error path instead of non-destructive usage feedback.

## Cause
`packages/coding-agent/src/slash-commands/builtin-lifecycle.ts` routed blank `/rename` input through `InteractiveMode.showError()`. That method clears pending submission and working state and stops the loading animation, so a local usage mistake appeared to halt the active turn.

## Fix
- Route blank `/rename` usage feedback through `showStatus()` so active turn state is untouched.
- Cover the blank invocation contract in `packages/coding-agent/test/slash-commands/rename.test.ts`.
- Document the fix in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/slash-commands` passed: 151 tests, 0 failures. In the v18.0.11 TUI, submitting `/rename` during a streaming turn displayed `Usage: /rename <title>` while the working indicator remained visible and the agent continued into tool execution. Pre-publish `bun run fix` and `bun check` passed through the publish gate.

Fixes #10326