### PR TITLE
fix(pi-ai): drop malformed function_call arguments from Responses replay

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -20,6 +20,10 @@
 - Devin auth, model assignment, and chat requests now send the native Devin CLI identity (`ideName: devin-cli`, `ideType: chisel`, `extensionName: chisel`, mapped `os`) instead of the Windsurf IDE identity; `ideType: chisel` is what the backend requires for router assignment ([#8590](https://github.com/can1357/oh-my-pi/pull/8590) by [@will-bogusz](https://github.com/will-bogusz)).
 - Devin parallel tool calls follow `compat.supportsParallelToolCalls` instead of being disabled unconditionally, so natively discovered configs that support parallelism can use it ([#8590](https://github.com/can1357/oh-my-pi/pull/8590) by [@will-bogusz](https://github.com/will-bogusz)).
 
+### Fixed
+
+- Fixed native Responses history replay so a malformed or truncated `function_call` arguments string no longer wedges the session with repeated 400 JSON parse errors; the item-level replay sanitizer drops the invalid item so the turn recovers.
+
 ## [18.0.11] - 2026-08-29
 
 ### Fixed

--- a/packages/ai/src/utils.ts
+++ b/packages/ai/src/utils.ts
@@ -389,6 +389,14 @@ function sanitizeOpenAIResponsesHistoryItemForReplay(
 	supportsImageDetailOriginal: boolean,
 	preserveReasoningItemIds: boolean,
 ): OpenAIResponsesReplayItem | undefined {
+	if (item.type === "function_call") {
+		if (typeof item.arguments !== "string" || item.arguments.trim().length === 0) return undefined;
+		try {
+			JSON.parse(item.arguments);
+		} catch {
+			return undefined;
+		}
+	}
 	if (item.type === "item_reference") return undefined;
 	if (item.type === "image_generation_call") return sanitizeOpenAIResponsesImageGenerationCallForReplay(item);
 	if (item.type === "reasoning") {

--- a/packages/ai/test/openai-responses-malformed-function-call-replay.test.ts
+++ b/packages/ai/test/openai-responses-malformed-function-call-replay.test.ts
@@ -1,0 +1,115 @@
+// Regression: a `function_call` whose `arguments` stream was cut off mid-JSON
+// is persisted verbatim in the native Responses history
+// (`AssistantMessage.providerPayload`) and replayed on every subsequent turn
+// via `buildResponsesInput()`. The gateway rejects the whole request with a
+// 400 JSON parse error (parse position == truncated arguments length), and
+// the session stays wedged until the item is dropped.
+//
+// `sanitizeOpenAIResponsesHistoryItemsForReplay` is the canonical replay
+// boundary for native Responses history, so the defensive check lives there.
+// Related: #3909 (same missing arguments-validation on the chat-completions
+// surface).
+import { describe, expect, it } from "bun:test";
+import { sanitizeOpenAIResponsesHistoryItemsForReplay } from "@oh-my-pi/pi-ai/utils";
+
+function sanitized(items: Array<Record<string, unknown>>): Array<Record<string, unknown>> {
+	return sanitizeOpenAIResponsesHistoryItemsForReplay(items) as unknown as Array<Record<string, unknown>>;
+}
+
+describe("sanitizeOpenAIResponsesHistoryItemsForReplay drops malformed function_call arguments", () => {
+	it("drops a truncated function_call and keeps the surrounding replay items", () => {
+		const fullArguments = JSON.stringify({ command: "ls -la /very/deep/path && echo done", i: "List directory" });
+		// A stream cut mid-JSON: a true prefix of a valid arguments string.
+		const truncatedArguments = fullArguments.slice(0, fullArguments.length - 6);
+		expect(() => JSON.parse(truncatedArguments)).toThrow();
+
+		const items = sanitized([
+			{ type: "reasoning", id: "rs_1", summary: [], encrypted_content: "enc_1" },
+			{
+				type: "function_call",
+				id: "item_poisoned",
+				call_id: "call_poisoned",
+				name: "bash",
+				arguments: truncatedArguments,
+			},
+			{ type: "function_call_output", call_id: "call_poisoned", output: "executed from the durable copy" },
+		]);
+
+		// The poisoned call never reaches the next request; its output and the
+		// turn's reasoning survive so context is not lost.
+		expect(items.some(item => item.type === "function_call")).toBe(false);
+		expect(items.map(item => String(item.type))).toEqual(["reasoning", "function_call_output"]);
+	});
+
+	it("drops function_call items with missing, empty, or non-string arguments", () => {
+		const malformed: Array<Record<string, unknown>> = [
+			{ type: "function_call", id: "item_missing", call_id: "call_missing", name: "bash" },
+			{ type: "function_call", id: "item_empty", call_id: "call_empty", name: "bash", arguments: "" },
+			{ type: "function_call", id: "item_blank", call_id: "call_blank", name: "bash", arguments: "   " },
+			{ type: "function_call", id: "item_nonstring", call_id: "call_nonstring", name: "bash", arguments: {} },
+		];
+
+		for (const item of malformed) {
+			expect(sanitized([item])).toEqual([]);
+		}
+	});
+
+	it("keeps parseable-JSON arguments byte-for-byte, including no-param and scalar forms", () => {
+		const validArguments = [
+			JSON.stringify({ command: "echo ok", i: "Say ok" }),
+			"{}", // a real no-param provider call
+			"null", // produced by OMP's own fallback emitter
+			"123", // scalar JSON — the locked keep-scalar semantics
+		];
+
+		for (const argumentsValue of validArguments) {
+			const items = sanitized([
+				{
+					type: "function_call",
+					id: "item_valid",
+					call_id: "call_valid",
+					name: "bash",
+					arguments: argumentsValue,
+				},
+			]);
+
+			expect(items).toHaveLength(1);
+			expect(items[0]).toMatchObject({
+				type: "function_call",
+				call_id: "call_valid",
+				name: "bash",
+				arguments: argumentsValue,
+			});
+		}
+	});
+
+	it("drops only the poisoned call when a turn mixes valid and truncated calls", () => {
+		const validArguments = JSON.stringify({ command: "date", i: "Time" });
+		const fullTruncated = JSON.stringify({
+			command: "curl -s https://example.com/api | jq . | sort",
+			i: "Endpoints",
+		});
+		const truncatedArguments = fullTruncated.slice(0, fullTruncated.length - 10);
+
+		const items = sanitized([
+			{ type: "function_call", id: "item_ok", call_id: "call_ok", name: "bash", arguments: validArguments },
+			{
+				type: "function_call",
+				id: "item_bad",
+				call_id: "call_bad",
+				name: "bash",
+				arguments: truncatedArguments,
+			},
+			{ type: "function_call_output", call_id: "call_ok", output: "Mon" },
+			{ type: "function_call_output", call_id: "call_bad", output: "result from the durable copy" },
+		]);
+
+		const calls = items.filter(item => item.type === "function_call");
+		expect(calls).toHaveLength(1);
+		expect(calls[0]).toMatchObject({ call_id: "call_ok", arguments: validArguments });
+		// Orphaned outputs of dropped calls survive this boundary; the
+		// downstream orphan repair folds them into an assistant note
+		// before the request reaches the wire.
+		expect(items.filter(item => item.type === "function_call_output")).toHaveLength(2);
+	});
+});


### PR DESCRIPTION
### What changed
I had a problem using OMP where a tool call that got truncated mid-generation ended up getting replayed, and when the session context window got close to the boundary started erroring out. The issue was that the malform output ended up getting repeated on every subsequent call, and session locked up. To fix, this change makes the replay sanitizer drop malformed items so the session can recover without manual intervention- I verified this against the stuck session that prompted me to prompt this. (I will attest that though the code and explainer below was written by an LLM, all was reviewed and this paragraph was written by a human.)

`sanitizeOpenAIResponsesHistoryItemForReplay` (`packages/ai/src/utils.ts`) now drops a native `function_call` replay item unless its `arguments` is a non-empty string that parses as JSON. I hit this wedging a real session, and the guard below is the same one I verified live against the corrupted history before opening this PR.

```ts
	if (item.type === "function_call") {
		if (typeof item.arguments !== "string" || item.arguments.trim().length === 0) return undefined;
		try {
			JSON.parse(item.arguments);
		} catch {
			return undefined;
		}
	}
```

### Why

When a provider stream is cut off mid tool call, the partially streamed `arguments` string is persisted verbatim in the native Responses history (`AssistantMessage.providerPayload`) and replayed on every subsequent turn via `buildResponsesInput()`. The gateway rejects the whole request with a 400 JSON parse error — the parse position equals the truncated arguments length — and the session is wedged permanently because every retry replays the same invalid item.

Live reproduction (OMP 18.0.10, LiteLLM gateway, OpenAI Responses surface):

- Captured failed request: POST `/v1/responses` with 2,340 input items containing exactly one invalid item — a `bash` `function_call` with `arguments` truncated at 2,378 chars (`Unexpected EOF`). Gateway error: `Expecting value: line 1 column 2379`. Position 2379 == stored length 2378, an exact match.
- A fresh direct completion to the same model and route succeeded, ruling out a provider-side failure.
- With this guard applied, the affected session resumed and completed a full turn (`stopReason: "stop"`, subsequent tool calls executed). The 400 did not recur.

### Scope notes

- Only the invalid item is dropped at this boundary. Its `function_call_output` survives the sanitizer and is folded into an assistant note by the existing orphan repair (`repairOrphanResponsesToolOutputs`) before the request is sent; the existing durable fallback covers turns where the poisoned call was the only assistant output.
- The chat-completions surface (`sanitizeMalformedToolCalls`) has the same missing validation, proposed in #3909. This PR covers the native Responses replay path only, to keep the change one logical unit.
- `custom_tool_call` carries the analogous `input` field and could take the same check; deliberately excluded — no evidence of that path corrupting today, and it would widen the behavioral surface.
- Known gap, out of scope here: the azure buildParams and codex convertMessages replay paths do not run the orphan repair, so a dropped call on those surfaces would leave the orphaned output un-repaired. Pre-patch, those requests already failed on the poisoned call itself; adding `repairOrphanOutputs: true` to the azure path is the one-line parity fix.

### Verification

- New regression test `packages/ai/test/openai-responses-malformed-function-call-replay.test.ts` — 4 tests: truncated prefix dropped with siblings kept; missing/empty/blank/non-string arguments dropped; parseable-JSON arguments (object, `{}`, `null`, scalar) kept byte-for-byte; a mixed valid+truncated turn drops only the poisoned call.
- `packages/ai` full suite: 4,328 pass / 332 skip / 0 fail.
- `bun run check` (biome + tsgo) clean in `packages/ai`.
- Live verification on the affected 18.0.10 install: the same guard was spliced into the installed bundle; the wedged session resumed and completed turns with no 400 recurrence.

### Related

Related to #3909 — its triage identifies the same missing arguments-validation ("a partial stream" named as the poisoning path, fix proposed as item 1 for the chat surface). This PR lands that class of guard on the native Responses replay path, with a deterministic repro.


