### PR TITLE
feat(coding-agent): allow ask-tool <-> chat box focus switching

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -110,6 +110,8 @@
 - Transcript usage rows now show the total prompt-to-yield time (Δ + clock, including tool calls) after the turn timestamp, opt-in via `display.showTurnTime` (off by default).
 - `omp usage` now shows Z.AI GLM Coding Plan credit quotas (5h + weekly) with the subscribed plan tier.
 - The usage status line now labels untiered quota windows with the report's plan tier, surfacing Z.AI Coding Plan (`pro`) and Codex plan names next to the 5h/7d percentages.
+- Added `app.dialog.toggleFocus` (default Alt+E) to toggle input focus between a pending ask dialog and the chat draft in both directions; the chat editor now stays mounted beneath local ask dialogs so a draft can be started mid-ask.
+
 ### Fixed
 
 - Fixed corrupt session headers silently overwriting recoverable transcripts during resume ([#9915](https://github.com/can1357/oh-my-pi/issues/9915)).

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -111,6 +111,7 @@
 - `omp usage` now shows Z.AI GLM Coding Plan credit quotas (5h + weekly) with the subscribed plan tier.
 - The usage status line now labels untiered quota windows with the report's plan tier, surfacing Z.AI Coding Plan (`pro`) and Codex plan names next to the 5h/7d percentages.
 - Added `app.dialog.toggleFocus` (default Alt+E) to toggle input focus between a pending ask dialog and the chat draft in both directions; the chat editor now stays mounted beneath local ask dialogs so a draft can be started mid-ask.
+- Dequeueing steering/queued messages now works while an ask dialog is open. Restoring a queued message moves input focus to the chat draft.
 
 ### Fixed
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -112,6 +112,7 @@
 - The usage status line now labels untiered quota windows with the report's plan tier, surfacing Z.AI Coding Plan (`pro`) and Codex plan names next to the 5h/7d percentages.
 - Added `app.dialog.toggleFocus` (default Alt+E) to toggle input focus between a pending ask dialog and the chat draft in both directions; the chat editor now stays mounted beneath local ask dialogs so a draft can be started mid-ask.
 - Dequeueing steering/queued messages now works while an ask dialog is open. Restoring a queued message moves input focus to the chat draft.
+- The ask dialog's title bar now dims while the chat draft is in focus.
 
 ### Fixed
 

--- a/packages/coding-agent/src/config/keybindings.ts
+++ b/packages/coding-agent/src/config/keybindings.ts
@@ -32,6 +32,7 @@ interface AppKeybindings {
 	"app.tools.expand": true;
 	"app.tools.toggleVisibility": true;
 	"app.editor.external": true;
+	"app.dialog.toggleFocus": true;
 	"app.message.followUp": true;
 	"app.retry": true;
 	"app.message.dequeue": true;
@@ -133,6 +134,10 @@ export const KEYBINDINGS = {
 	"app.editor.external": {
 		defaultKeys: "ctrl+g",
 		description: "Open external editor",
+	},
+	"app.dialog.toggleFocus": {
+		defaultKeys: "alt+e",
+		description: "Switch focus between pending dialog and chat draft",
 	},
 	"app.message.followUp": {
 		// Ctrl+Enter is preserved for terminals that deliver it (Kitty/iTerm2/WezTerm/Ghostty),

--- a/packages/coding-agent/src/modes/components/ask-dialog.ts
+++ b/packages/coding-agent/src/modes/components/ask-dialog.ts
@@ -538,10 +538,8 @@ export class AskDialogComponent implements Component {
 			this.#requestRender();
 			return;
 		}
-		if (focusGuard?.handleDequeue && matchesAppMessageDequeue(keyData)) {
-			if (focusGuard.handleDequeue()) {
-				this.#requestRender();
-			}
+		if (focusGuard?.handleDequeue && matchesAppMessageDequeue(keyData) && focusGuard.handleDequeue()) {
+			this.#requestRender();
 			return;
 		}
 		if (matchesSelectCancel(keyData)) {

--- a/packages/coding-agent/src/modes/components/ask-dialog.ts
+++ b/packages/coding-agent/src/modes/components/ask-dialog.ts
@@ -27,6 +27,7 @@ import { getTabBarTheme } from "../shared";
 import { getMarkdownTheme, highlightCode, theme } from "../theme/theme";
 import {
 	matchesAppDialogFocusToggle,
+	matchesAppMessageDequeue,
 	matchesAppToolsExpand,
 	matchesSelectCancel,
 	matchesSelectDown,
@@ -84,6 +85,7 @@ interface AskDialogCallbacks {
 	onCancel(): void;
 	onPrompt(title: string, prefill?: string): Promise<string | undefined>;
 }
+
 /** Gate on the dialog's input stream. The dialog holds TUI focus, so every
  *  keystroke arrives at its `handleInput` first; a guard can take over that
  *  stream and reroute it — the draft-focus guard routes it to the chat draft.
@@ -95,6 +97,9 @@ export interface AskDialogInputGuard {
 	handleInput(keyData: string): void;
 	/** Move input ownership between the dialog and the guarded draft. */
 	toggleFocus(): void;
+	/** Consume the queued-message dequeue chord. Returns false when this guard
+	 *  has no dequeue wiring and the dialog should keep the key. */
+	handleDequeue?(): boolean;
 	/** Mirror the guard's ownership state onto the proxied draft surface each
 	 *  render, so a draft that owns input shows a visible insertion cursor even
 	 *  though this dialog holds TUI focus. */
@@ -106,6 +111,7 @@ export interface DraftFocusEditor {
 	getText(): string;
 	handleDraftEdit(data: string): void;
 	focused: boolean;
+	onDequeue?: () => void;
 }
 
 /** Guard that routes dialog input to the chat draft. Ownership is explicit:
@@ -119,6 +125,10 @@ export function createDraftFocusGuard(draft: DraftFocusEditor): AskDialogInputGu
 	return {
 		draftOwnsInput: () => draftOwnsInput,
 		handleInput: keyData => {
+			if (matchesAppMessageDequeue(keyData) && draft.onDequeue) {
+				draft.onDequeue();
+				return;
+			}
 			const hadText = draft.getText().length > 0;
 			draft.handleDraftEdit(keyData);
 			if (draftOwnsInput && hadText && draft.getText().length === 0) {
@@ -130,6 +140,13 @@ export function createDraftFocusGuard(draft: DraftFocusEditor): AskDialogInputGu
 		},
 		syncPresentation: () => {
 			draft.focused = draftOwnsInput;
+		},
+		handleDequeue: () => {
+			if (!draft.onDequeue) return false;
+			draft.onDequeue();
+			// A restore puts text into the draft. It owns input now.
+			draftOwnsInput = draft.getText().length > 0;
+			return true;
 		},
 	};
 }
@@ -519,6 +536,12 @@ export class AskDialogComponent implements Component {
 		if (focusGuard && matchesAppDialogFocusToggle(keyData)) {
 			focusGuard.toggleFocus();
 			this.#requestRender();
+			return;
+		}
+		if (focusGuard?.handleDequeue && matchesAppMessageDequeue(keyData)) {
+			if (focusGuard.handleDequeue()) {
+				this.#requestRender();
+			}
 			return;
 		}
 		if (matchesSelectCancel(keyData)) {

--- a/packages/coding-agent/src/modes/components/ask-dialog.ts
+++ b/packages/coding-agent/src/modes/components/ask-dialog.ts
@@ -26,6 +26,7 @@ import { expandKeyHint } from "../../tools/render-utils";
 import { getTabBarTheme } from "../shared";
 import { getMarkdownTheme, highlightCode, theme } from "../theme/theme";
 import {
+	matchesAppDialogFocusToggle,
 	matchesAppToolsExpand,
 	matchesSelectCancel,
 	matchesSelectDown,
@@ -83,15 +84,54 @@ interface AskDialogCallbacks {
 	onCancel(): void;
 	onPrompt(title: string, prefill?: string): Promise<string | undefined>;
 }
-
-interface AskDialogInputGuard {
-	isBlocked(): boolean;
+/** Gate on the dialog's input stream. The dialog holds TUI focus, so every
+ *  keystroke arrives at its `handleInput` first; a guard can take over that
+ *  stream and reroute it — the draft-focus guard routes it to the chat draft.
+ *  Input ownership is the guard's single bit: while the guarded draft owns
+ *  it, the dialog forwards keystrokes instead of handling them itself. */
+export interface AskDialogInputGuard {
+	/** Does the guarded draft currently own input? */
+	draftOwnsInput(): boolean;
 	handleInput(keyData: string): void;
-	hint: string;
-	/** Mirror the guard's blocked state onto the proxied draft surface each
+	/** Move input ownership between the dialog and the guarded draft. */
+	toggleFocus(): void;
+	/** Mirror the guard's ownership state onto the proxied draft surface each
 	 *  render, so a draft that owns input shows a visible insertion cursor even
 	 *  though this dialog holds TUI focus. */
 	syncPresentation?(): void;
+}
+
+/** Structural subset of the main editor the draft-focus guard drives. */
+export interface DraftFocusEditor {
+	getText(): string;
+	handleDraftEdit(data: string): void;
+	focused: boolean;
+}
+
+/** Guard that routes dialog input to the chat draft. Ownership is explicit:
+ *  - Derived once from the draft text at creation
+ *  - Afterwards, either...
+ * 	  - The focus toggle (`app.dialog.toggleFocus`) moves it, or
+ * 		- Emptying the draft — by submitting or erasing — returns input to
+ *        the dialog */
+export function createDraftFocusGuard(draft: DraftFocusEditor): AskDialogInputGuard {
+	let draftOwnsInput = draft.getText().length > 0;
+	return {
+		draftOwnsInput: () => draftOwnsInput,
+		handleInput: keyData => {
+			const hadText = draft.getText().length > 0;
+			draft.handleDraftEdit(keyData);
+			if (draftOwnsInput && hadText && draft.getText().length === 0) {
+				draftOwnsInput = false;
+			}
+		},
+		toggleFocus: () => {
+			draftOwnsInput = !draftOwnsInput;
+		},
+		syncPresentation: () => {
+			draft.focused = draftOwnsInput;
+		},
+	};
 }
 
 interface AskDialogOptions {
@@ -475,6 +515,12 @@ export class AskDialogComponent implements Component {
 		// Reset the inactivity countdown on any key that reaches past the
 		// closed/prompt guards, matching HookSelector/HookInput semantics.
 		this.#countdown?.reset();
+		const focusGuard = this.options.inputGuard;
+		if (focusGuard && matchesAppDialogFocusToggle(keyData)) {
+			focusGuard.toggleFocus();
+			this.#requestRender();
+			return;
+		}
 		if (matchesSelectCancel(keyData)) {
 			this.#finishCancel();
 			return;
@@ -486,7 +532,7 @@ export class AskDialogComponent implements Component {
 			return;
 		}
 		const inputGuard = this.options.inputGuard;
-		if (inputGuard?.isBlocked()) {
+		if (inputGuard?.draftOwnsInput()) {
 			inputGuard.handleInput(keyData);
 			this.#requestRender();
 			return;
@@ -651,10 +697,13 @@ export class AskDialogComponent implements Component {
 	#footerHintText(indicator: string): string {
 		const cancel = `${cancelKeyLabel()} cancel`;
 		const inputGuard = this.options.inputGuard;
-		if (inputGuard?.isBlocked()) return `${inputGuard.hint}${this.#expandHint()} · ${cancel}`;
+		if (inputGuard?.draftOwnsInput()) {
+			return `${editorKey("app.dialog.toggleFocus")} switch to ask${this.#expandHint()} · ${cancel}`;
+		}
+		const draftHint = inputGuard ? ` · ${editorKey("app.dialog.toggleFocus")} switch to draft` : "";
 		if (this.#isSubmitTab()) {
 			const scroll = indicator ? ` ${indicator} scroll ·` : "";
-			return `Enter submit · ↑/↓ scroll ·${scroll} ${cancel}`;
+			return `Enter submit · ↑/↓ scroll ·${scroll} ${cancel}${draftHint}`;
 		}
 		const question = this.#questions[this.#currentQuestionIndex()];
 		// Enter advances in multi-question dialogs and submits single-question ones.
@@ -663,10 +712,10 @@ export class AskDialogComponent implements Component {
 		const tabs = this.#hasSubmitTab() ? " · Tab/←/→" : "";
 		const expand = this.#expandHint();
 		if (this.#questionCanPage && indicator) {
-			return `${action} · ↑/↓${tabs} · ${cancel}${expand} · ${pageKeysLabel()} ${indicator}`;
+			return `${action} · ↑/↓${tabs} · ${cancel}${expand} · ${pageKeysLabel()} ${indicator}${draftHint}`;
 		}
 		const scroll = indicator ? ` ${indicator} scroll ·` : "";
-		return `${action} · ↑/↓ move${tabs} ·${scroll} ${cancel}${expand}`;
+		return `${action} · ↑/↓ move${tabs} ·${scroll} ${cancel}${expand}${draftHint}`;
 	}
 
 	#questionRows(question: ExtensionAskDialogQuestion): QuestionRow[] {

--- a/packages/coding-agent/src/modes/components/ask-dialog.ts
+++ b/packages/coding-agent/src/modes/components/ask-dialog.ts
@@ -599,7 +599,7 @@ export class AskDialogComponent implements Component {
 			: this.#renderQuestionBody(innerWidth, bodyRows);
 		const footer = this.#footerHintText(bodyLines.indicator);
 		return [
-			topBorder(width, this.#titleText()),
+			topBorder(width, this.#titleText(), undefined, this.#hasFocus() ? undefined : "dim"),
 			...headerLines.map(line => row(line, width)),
 			divider(width),
 			...bodyLines.lines.map(line => row(line, width)),
@@ -655,6 +655,10 @@ export class AskDialogComponent implements Component {
 
 	#titleText(): string {
 		return this.#remainingSeconds === undefined ? "Ask" : `Ask (${this.#remainingSeconds}s)`;
+	}
+
+	#hasFocus(): boolean {
+		return this.options.inputGuard == null || !this.options.inputGuard.draftOwnsInput();
 	}
 
 	#hasSubmitTab(): boolean {

--- a/packages/coding-agent/src/modes/components/model-picker.ts
+++ b/packages/coding-agent/src/modes/components/model-picker.ts
@@ -279,7 +279,7 @@ export class ModelPickerComponent implements Component {
 		}
 
 		const out: string[] = [];
-		out.push(topBorder(width, this.#taskMode ? "Switch Task Model" : "Switch Model", borderColor));
+		out.push(topBorder(width, this.#taskMode ? "Switch Task Model" : "Switch Model", borderColor, borderColor));
 		out.push(row(status, width, borderColor));
 		for (const line of this.#browser.render(inner)) {
 			out.push(row(line, width, borderColor));

--- a/packages/coding-agent/src/modes/components/overlay-box.ts
+++ b/packages/coding-agent/src/modes/components/overlay-box.ts
@@ -24,8 +24,10 @@ function paint(s: string, color: ThemeColor = "border"): string {
 	return theme.fg(color, s);
 }
 
-/** Top border with an optional title inset into the rule. `color` recolors border and title (default border/accent). */
-export function topBorder(width: number, title: string, color?: ThemeColor): string {
+/** Top border with an optional title inset into the rule.
+ *  `color` recolors border (defaults to "border").
+ *  `titleColor` recolors title (defaults to "accent") */
+export function topBorder(width: number, title: string, color?: ThemeColor, titleColor?: ThemeColor): string {
 	const box = theme.boxRound;
 	const inner = Math.max(0, width - 2);
 	if (!title) return paint(box.topLeft + box.horizontal.repeat(inner) + box.topRight, color);
@@ -33,7 +35,7 @@ export function topBorder(width: number, title: string, color?: ThemeColor): str
 	const fillWidth = Math.max(0, inner - 1 - visibleWidth(shown));
 	return (
 		paint(box.topLeft + box.horizontal, color) +
-		theme.bold(theme.fg(color ?? "accent", shown)) +
+		theme.bold(theme.fg(titleColor ?? "accent", shown)) +
 		paint(box.horizontal.repeat(fillWidth) + box.topRight, color)
 	);
 }

--- a/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
@@ -22,7 +22,7 @@ import type {
 	TerminalInputHandler,
 } from "../../extensibility/extensions";
 import { getSessionSlashCommands } from "../../extensibility/extensions/get-commands-handler";
-import { AskDialogComponent, boundPromptTitle } from "../../modes/components/ask-dialog";
+import { AskDialogComponent, boundPromptTitle, createDraftFocusGuard } from "../../modes/components/ask-dialog";
 import { installExtensionComposerShape } from "../../modes/components/composer-shape-registry";
 import { EditorTopGap } from "../../modes/components/editor-top-gap";
 import { HookEditorComponent } from "../../modes/components/hook-editor";
@@ -644,29 +644,16 @@ export class ExtensionUiController {
 			let promptResolve: ((value: string | undefined) => void) | undefined;
 			let closed = false;
 			const draftEditor = this.ctx.editor;
-			const inputGuard =
-				draftEditor.getText().length > 0
-					? {
-							isBlocked: () => draftEditor.getText().length > 0,
-							handleInput: (keyData: string) => draftEditor.handleDraftEdit(keyData),
-							hint: "Finish or clear the current prompt to answer",
-							// Show the draft's insertion cursor while it owns input; drop it
-							// once the draft clears and the ask controls take over.
-							syncPresentation: () => {
-								draftEditor.focused = draftEditor.getText().length > 0;
-							},
-						}
-					: undefined;
+			const inputGuard = createDraftFocusGuard(draftEditor);
 
 			const restoreAskDialog = (): void => {
 				if (closed || !askDialog) return;
 				this.ctx.editorContainer.clear();
 				this.ctx.editorContainer.addChild(askDialog);
-				// Keep the draft editor mounted beneath the restored ask, matching the
-				// initial presentation: the guard re-blocks whenever the draft is
-				// non-empty (e.g. a failed submit restored its text while a nested
-				// prompt was open), and routed input must land on a visible surface.
-				if (inputGuard) this.ctx.editorContainer.addChild(this.ctx.editor);
+				// Keep the draft editor mounted beneath the restored ask, matching
+				// the initial presentation: focus can toggle to the draft at any
+				// time, and routed input must land on a visible surface.
+				this.ctx.editorContainer.addChild(this.ctx.editor);
 				this.ctx.ui.setFocus(askDialog);
 				this.ctx.ui.requestRender();
 			};
@@ -714,7 +701,7 @@ export class ExtensionUiController {
 			);
 			this.ctx.editorContainer.clear();
 			this.ctx.editorContainer.addChild(askDialog);
-			if (inputGuard) this.ctx.editorContainer.addChild(this.ctx.editor);
+			this.ctx.editorContainer.addChild(this.ctx.editor);
 			this.ctx.ui.setFocus(askDialog);
 			this.ctx.ui.requestRender();
 

--- a/packages/coding-agent/src/modes/utils/hotkeys-markdown.ts
+++ b/packages/coding-agent/src/modes/utils/hotkeys-markdown.ts
@@ -53,6 +53,7 @@ export function buildHotkeysMarkdown(bindings: HotkeysMarkdownBindings): string 
 		`| \`${appKey(bindings, "app.tools.toggleVisibility")}\` | Toggle tool activity visibility |`,
 		`| \`${appKey(bindings, "app.thinking.toggle")}\` | Toggle thinking block visibility |`,
 		`| \`${appKey(bindings, "app.editor.external")}\` | Edit message in external editor |`,
+		`| \`${appKey(bindings, "app.dialog.toggleFocus")}\` | Toggle focus between ask dialog and chat draft |`,
 		`| \`${appKey(bindings, "app.retry")}\` | Retry last failed assistant turn |`,
 		`| \`${appKey(bindings, "app.clipboard.pasteImage")}\` | Paste image or text from clipboard |`,
 		"| Hold `Space` | Speech-to-text (push-to-talk): hold to record, release to transcribe |",

--- a/packages/coding-agent/src/modes/utils/keybinding-matchers.ts
+++ b/packages/coding-agent/src/modes/utils/keybinding-matchers.ts
@@ -26,6 +26,16 @@ export function matchesAppToolsExpand(data: string): boolean {
 	return matchesKey(data, "ctrl+o");
 }
 
+/** Match `app.dialog.toggleFocus`, falling back to Alt+E when the action is unbound. */
+export function matchesAppDialogFocusToggle(data: string): boolean {
+	const keybindings = getKeybindings();
+	const keys = keybindings.getKeys("app.dialog.toggleFocus");
+	if (keys.length > 0) {
+		return keybindings.matches(data, "app.dialog.toggleFocus");
+	}
+	return matchesKey(data, "alt+e");
+}
+
 /** Match the generic selector cancel keybinding. */
 export function matchesSelectCancel(data: string): boolean {
 	return getKeybindings().matches(data, "tui.select.cancel");

--- a/packages/coding-agent/src/modes/utils/keybinding-matchers.ts
+++ b/packages/coding-agent/src/modes/utils/keybinding-matchers.ts
@@ -36,6 +36,11 @@ export function matchesAppDialogFocusToggle(data: string): boolean {
 	return matchesKey(data, "alt+e");
 }
 
+/** Match the queued-message dequeue keybinding (`app.message.dequeue`). */
+export function matchesAppMessageDequeue(data: string): boolean {
+	return getKeybindings().matches(data, "app.message.dequeue");
+}
+
 /** Match the generic selector cancel keybinding. */
 export function matchesSelectCancel(data: string): boolean {
 	return getKeybindings().matches(data, "tui.select.cancel");

--- a/packages/coding-agent/test/modes/components/ask-dialog.test.ts
+++ b/packages/coding-agent/test/modes/components/ask-dialog.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:
 import { stripVTControlCharacters } from "node:util";
 import { KeybindingsManager } from "@oh-my-pi/pi-coding-agent/config/keybindings";
 import type { ExtensionAskDialogQuestion } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/types";
-import { AskDialogComponent } from "@oh-my-pi/pi-coding-agent/modes/components/ask-dialog";
+import { AskDialogComponent, createDraftFocusGuard } from "@oh-my-pi/pi-coding-agent/modes/components/ask-dialog";
 import { getThemeByName, setThemeInstance } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import { setKeybindings } from "@oh-my-pi/pi-tui";
 
@@ -12,6 +12,8 @@ const PAGE_DOWN = "\x1b[6~";
 const PAGE_UP = "\x1b[5~";
 const ENTER = "\n";
 const CANCEL = "\x07";
+const ALT_E = "\x1be";
+const BACKSPACE = "\x7f";
 const SPACE = " ";
 const TAB = "\t";
 const SHIFT_TAB = "\x1b[Z";
@@ -20,6 +22,28 @@ let darkTheme = await getThemeByName("dark");
 
 function render(component: AskDialogComponent): string {
 	return stripVTControlCharacters(component.render(80).join("\n"));
+}
+
+/** Minimal DraftFocusEditor stand-in: models the editor semantics the guard's
+ *  ownership rules observe. */
+function fakeDraft(text: string) {
+	const draft = {
+		text,
+		focused: false,
+		handleDraftEdit: vi.fn((data: string) => {
+			if ((data === "\n" || data === "\r") && draft.text.length > 0) {
+				draft.text = "";
+			} else if (data === BACKSPACE) {
+				draft.text = draft.text.slice(0, -1);
+			} else if (data.length === 1 && data !== "\n" && data !== "\r") {
+				draft.text += data;
+			}
+		}),
+		getText(): string {
+			return draft.text;
+		},
+	};
+	return draft;
 }
 
 describe("AskDialogComponent", () => {
@@ -1596,5 +1620,164 @@ describe("AskDialogComponent", () => {
 		const result = onSubmit.mock.calls[0][0].results[0];
 		expect(result.question).toBe("");
 		expect(result.selectedOptions).toEqual(["Option A"]);
+	});
+
+	it("routes input to a non-empty draft and hands it back after toggling", () => {
+		const onSubmit = vi.fn();
+		const draft = fakeDraft("hello");
+		const questions: ExtensionAskDialogQuestion[] = [
+			{ id: "q1", question: "Q1?", options: [{ label: "A1" }, { label: "B1" }] },
+			{ id: "q2", question: "Q2?", options: [{ label: "A2" }, { label: "B2" }] },
+		];
+
+		const component = new AskDialogComponent(
+			questions,
+			{ onSubmit, onCancel: vi.fn(), onPrompt: vi.fn() },
+			{ inputGuard: createDraftFocusGuard(draft) },
+		);
+
+		// The non-empty draft owns input: typing edits it, never the dialog.
+		component.handleInput("x");
+		expect(draft.handleDraftEdit).toHaveBeenCalledTimes(1);
+		expect(draft.handleDraftEdit).toHaveBeenCalledWith("x");
+		expect(onSubmit).not.toHaveBeenCalled();
+
+		// Alt+E moves ownership to the dialog: arrows navigate, Enter advances
+		// to Q2, and no keystroke leaks into the draft.
+		component.handleInput(ALT_E);
+		component.handleInput(DOWN);
+		component.handleInput(ENTER);
+		expect(render(component)).toContain("Q2?");
+		expect(onSubmit).not.toHaveBeenCalled();
+		expect(draft.handleDraftEdit).toHaveBeenCalledTimes(1);
+
+		// Alt+E again: typing lands back in the draft, dialog untouched.
+		component.handleInput(ALT_E);
+		component.handleInput("y");
+		expect(draft.handleDraftEdit).toHaveBeenCalledTimes(2);
+		expect(draft.handleDraftEdit).toHaveBeenLastCalledWith("y");
+		expect(draft.text).toBe("helloxy");
+	});
+
+	it("derives initial ownership from the draft text", () => {
+		const onSubmit = vi.fn();
+		const draft = fakeDraft("");
+		const questions: ExtensionAskDialogQuestion[] = [
+			{ id: "q1", question: "Choose one?", options: [{ label: "Option A" }, { label: "Option B" }] },
+		];
+
+		const component = new AskDialogComponent(
+			questions,
+			{ onSubmit, onCancel: vi.fn(), onPrompt: vi.fn() },
+			{ inputGuard: createDraftFocusGuard(draft) },
+		);
+
+		// Empty draft: the dialog owns input from the start — typing does not
+		// reach the draft.
+		component.handleInput("a");
+		expect(draft.handleDraftEdit).not.toHaveBeenCalled();
+
+		// Toggling hands input to the (still empty) draft.
+		component.handleInput(ALT_E);
+		component.handleInput("a");
+		expect(draft.handleDraftEdit).toHaveBeenCalledTimes(1);
+		expect(draft.text).toBe("a");
+
+		// Toggling back restores dialog ownership: Enter submits without
+		// touching the draft.
+		component.handleInput(ALT_E);
+		component.handleInput(DOWN);
+		component.handleInput(ENTER);
+		expect(onSubmit).toHaveBeenCalledTimes(1);
+		expect(onSubmit.mock.calls[0][0].results[0].selectedOptions).toEqual(["Option B"]);
+		expect(draft.handleDraftEdit).toHaveBeenCalledTimes(1);
+	});
+
+	it("keeps cancel while the draft owns input (#7734 unchanged)", () => {
+		const onCancel = vi.fn();
+		const draft = fakeDraft("hello");
+		const questions: ExtensionAskDialogQuestion[] = [
+			{ id: "q1", question: "Choose one?", options: [{ label: "Option A" }, { label: "Option B" }] },
+		];
+
+		const component = new AskDialogComponent(
+			questions,
+			{ onSubmit: vi.fn(), onCancel, onPrompt: vi.fn() },
+			{ inputGuard: createDraftFocusGuard(draft) },
+		);
+
+		// The cancel chord is checked before the draft guard: canceling while a
+		// draft owns input cancels the whole ask (#7734 owns changing this).
+		component.handleInput(CANCEL);
+		expect(onCancel).toHaveBeenCalledTimes(1);
+		expect(draft.handleDraftEdit).not.toHaveBeenCalled();
+	});
+
+	it("mirrors ownership onto the draft cursor each render", () => {
+		const draft = fakeDraft("hello");
+		const questions: ExtensionAskDialogQuestion[] = [
+			{ id: "q1", question: "Choose one?", options: [{ label: "Option A" }, { label: "Option B" }] },
+		];
+
+		const component = new AskDialogComponent(
+			questions,
+			{ onSubmit: vi.fn(), onCancel: vi.fn(), onPrompt: vi.fn() },
+			{ inputGuard: createDraftFocusGuard(draft) },
+		);
+
+		// Blocked: the draft shows the insertion cursor.
+		render(component);
+		expect(draft.focused).toBe(true);
+
+		// After toggling to the dialog, the draft cursor drops.
+		component.handleInput(ALT_E);
+		render(component);
+		expect(draft.focused).toBe(false);
+	});
+
+	it("returns input to the dialog after the draft is sent", () => {
+		const questions: ExtensionAskDialogQuestion[] = [
+			{ id: "q1", question: "Choose one?", options: [{ label: "Option A" }, { label: "Option B" }] },
+		];
+
+		const onSubmit = vi.fn();
+		const draft = fakeDraft("hi");
+		const component = new AskDialogComponent(
+			questions,
+			{ onSubmit, onCancel: vi.fn(), onPrompt: vi.fn() },
+			{ inputGuard: createDraftFocusGuard(draft) },
+		);
+
+		// Sending clears the draft and hands input back to the dialog —
+		// Enter now submits the dialog's selection, not the empty editor.
+		component.handleInput(ENTER);
+		expect(draft.text).toBe("");
+		component.handleInput(ENTER);
+		expect(onSubmit).toHaveBeenCalledTimes(1);
+		expect(draft.handleDraftEdit).toHaveBeenCalledTimes(1);
+	});
+
+	it("hands input back to the dialog when the draft is erased", () => {
+		const onSubmit = vi.fn();
+		const draft = fakeDraft("hi");
+		const questions: ExtensionAskDialogQuestion[] = [
+			{ id: "q1", question: "Choose one?", options: [{ label: "Option A" }, { label: "Option B" }] },
+		];
+
+		const component = new AskDialogComponent(
+			questions,
+			{ onSubmit, onCancel: vi.fn(), onPrompt: vi.fn() },
+			{ inputGuard: createDraftFocusGuard(draft) },
+		);
+
+		// Backspacing the draft to empty hands input back: Enter then submits
+		// the dialog's selection instead of editing the draft.
+		component.handleInput(BACKSPACE);
+		expect(draft.text).toBe("h");
+		component.handleInput(BACKSPACE);
+		expect(draft.text).toBe("");
+		component.handleInput(ENTER);
+		expect(onSubmit).toHaveBeenCalledTimes(1);
+		expect(draft.handleDraftEdit).toHaveBeenCalledTimes(2);
 	});
 });

--- a/packages/coding-agent/test/modes/components/ask-dialog.test.ts
+++ b/packages/coding-agent/test/modes/components/ask-dialog.test.ts
@@ -2,7 +2,11 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:
 import { stripVTControlCharacters } from "node:util";
 import { KeybindingsManager } from "@oh-my-pi/pi-coding-agent/config/keybindings";
 import type { ExtensionAskDialogQuestion } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/types";
-import { AskDialogComponent, createDraftFocusGuard } from "@oh-my-pi/pi-coding-agent/modes/components/ask-dialog";
+import {
+	AskDialogComponent,
+	createDraftFocusGuard,
+	type DraftFocusEditor,
+} from "@oh-my-pi/pi-coding-agent/modes/components/ask-dialog";
 import { getThemeByName, setThemeInstance } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import { setKeybindings } from "@oh-my-pi/pi-tui";
 
@@ -13,6 +17,8 @@ const PAGE_UP = "\x1b[5~";
 const ENTER = "\n";
 const CANCEL = "\x07";
 const ALT_E = "\x1be";
+const SHIFT_UP = "\x1b[1;2A";
+const ALT_UP = "\x1b[1;3A";
 const BACKSPACE = "\x7f";
 const SPACE = " ";
 const TAB = "\t";
@@ -27,7 +33,7 @@ function render(component: AskDialogComponent): string {
 /** Minimal DraftFocusEditor stand-in: models the editor semantics the guard's
  *  ownership rules observe. */
 function fakeDraft(text: string) {
-	const draft = {
+	const draft: DraftFocusEditor & { text: string } = {
 		text,
 		focused: false,
 		handleDraftEdit: vi.fn((data: string) => {
@@ -1779,5 +1785,38 @@ describe("AskDialogComponent", () => {
 		component.handleInput(ENTER);
 		expect(onSubmit).toHaveBeenCalledTimes(1);
 		expect(draft.handleDraftEdit).toHaveBeenCalledTimes(2);
+	});
+
+	it("dequeues queued messages from both ownership states", () => {
+		const draft = fakeDraft("");
+		const queuedText = "queued";
+		// Imitate restoreQueuedMessagesToEditor: queued text is prepended to the
+		// current draft.
+		draft.onDequeue = vi.fn(() => {
+			draft.text = draft.text ? `${queuedText} ${draft.text}` : queuedText;
+		});
+		const questions: ExtensionAskDialogQuestion[] = [
+			{ id: "q1", question: "Choose one?", options: [{ label: "Option A" }, { label: "Option B" }] },
+		];
+
+		const component = new AskDialogComponent(
+			questions,
+			{ onSubmit: vi.fn(), onCancel: vi.fn(), onPrompt: vi.fn() },
+			{ inputGuard: createDraftFocusGuard(draft) },
+		);
+
+		// Dialog owns input (empty draft): the dequeue chord restores the
+		// message and moves input to the draft — the next keystroke edits it.
+		component.handleInput(SHIFT_UP);
+		expect(draft.onDequeue).toHaveBeenCalledTimes(1);
+		expect(draft.text).toBe(queuedText);
+		component.handleInput("!");
+		expect(draft.text).toBe(`${queuedText}!`);
+
+		// Draft owns input: the other default chord also restores, without
+		// leaking the key into the draft as text.
+		component.handleInput(ALT_UP);
+		expect(draft.onDequeue).toHaveBeenCalledTimes(2);
+		expect(draft.text).toBe(`${queuedText} ${queuedText}!`);
 	});
 });


### PR DESCRIPTION
## What

Allow switching input handling between the ask-tool dialog and the chat draft/chat box. The switch happens explicitly when using the new `app.dialog.toggleFocus` keybind (Alt+E), or implicitly when the draft is erased (like before this PR) or when the user submits the draft (72375a9e6c0620e83070220c9b72c870ed3466d9).

When not in focus, the ask-tool dialog now also has a dim-colored title that makes it more apparent that user's inputs are not being handled by it (241facef3eb32fe066a6ed71e7d96cfa904ed929).

| Chat draft has focus | Ask-tool dialog has focus |
|-|-|
| <img width="667" height="303" alt="Chat draft has focus" src="https://github.com/user-attachments/assets/5ddc48d2-20f6-4ef1-91dd-0b6f0729b37f" /> | <img width="667" height="294" alt="Ask-tool dialog has focus" src="https://github.com/user-attachments/assets/8fced5e0-752f-4a7a-8685-3ca17c214402" /> |

Also, handle dequeue requests even while the ask-tool dialog is in focus (9ea4e2d735f00f55739ee27978eeae2d5f3fdf2c). Dequeuing a message forces focus on the chat draft.

## Why

This is the first of a (planned) series of improvements I had for the dialog TUI/UX.

As described in #7729, one of my main pet peeves with omp is being half-way through typing a draft and getting a tool call that steals focus from me and doesn't let me see or continue with my draft until I handle it.

The ask-tool dialog is the only example that almost does it right, since it doesn't eat your inputs if you already had something drafted. So I'm starting with it to "perfect" it and have some base logic that can be reimplemented into the other dialogs in the future.

I also haven't talked to anyone about this outside of my comment #7729 😅. So I'm hoping this PR serves to spark a discussion on how these dialogs are handled.

I'm trying to [follow the contribution guide](https://github.com/can1357/oh-my-pi/blob/969062200754ea02cfac922e5ebb8c608c079e15/CONTRIBUTING.md#before-you-start) here. This feels like a "small change" to me while the "all dialogs should do this" change sounds like a major refactor and user experience change.

## Testing

- New tests + `bun check`
- `npm run dev -- --no-session` using a prompt like "Use the ask tool to ask 3 questions with sample answers like "a", "b", "c", "d", etc.. Do nothing else." and verifying manually.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
