### PR TITLE
fix(tui): fuse resumed-session repaint with overlay exit

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed resumed sessions sometimes showing stale background bands until the next keypress on WSL and Windows Terminal ([#9799](https://github.com/can1357/oh-my-pi/issues/9799)).
+
 ## [18.0.5] - 2026-08-25
 
 ### Breaking Changes

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -2300,8 +2300,8 @@ export class TUI extends Container {
 		const geometryStable = this.#hasEverRendered && this.#previousWidth === width && this.#previousHeight === height;
 		const startTop = destructiveReset ? 0 : Math.min(this.#providerViewportTop, Math.max(0, height - 1));
 		const newTop = Math.max(0, Math.min(startTop + historyRows.length, height - rows));
-		let buffer = this.#paintBeginSequence + this.#pendingAltExit;
-		this.#pendingAltExit = "";
+		const pendingAltExit = this.#pendingAltExit;
+		let buffer = this.#paintBeginSequence + pendingAltExit;
 		if (destructiveReset && TERMINAL.imageProtocol === ImageProtocol.Kitty) {
 			// ED2/ED3 erase text cells but leave Kitty graphics visible. A reset is
 			// explicitly destructive, so remove every placement—not only the ones
@@ -2402,6 +2402,10 @@ export class TUI extends Container {
 		}
 		buffer += this.#paintEndSequence;
 		this.terminal.write(buffer);
+		if (pendingAltExit) {
+			this.#pendingAltExit = "";
+			setAltScreenActive(false);
+		}
 		if (target) this.#recordHardwareCursorState(target);
 		else this.#recordHardwareCursorHidden();
 		this.#providerWindow = mutablePrepared;
@@ -2469,9 +2473,12 @@ export class TUI extends Container {
 			// Session replacement finishes while its fullscreen selector still
 			// covers the old normal buffer. Fuse the restore into the destructive
 			// repaint so no stale frame can become visible between writes.
-			if (this.#clearScrollbackOnNextRender) this.#pendingAltExit = exitSequence;
-			else this.terminal.write(exitSequence);
-			setAltScreenActive(false);
+			if (this.#clearScrollbackOnNextRender) {
+				this.#pendingAltExit = exitSequence;
+			} else {
+				this.terminal.write(exitSequence);
+				setAltScreenActive(false);
+			}
 			this.#forgetHardwareCursorState();
 			this.#altActive = false;
 			this.#altMouseTrackingActive = false;

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -2300,7 +2300,8 @@ export class TUI extends Container {
 		const geometryStable = this.#hasEverRendered && this.#previousWidth === width && this.#previousHeight === height;
 		const startTop = destructiveReset ? 0 : Math.min(this.#providerViewportTop, Math.max(0, height - 1));
 		const newTop = Math.max(0, Math.min(startTop + historyRows.length, height - rows));
-		let buffer = this.#paintBeginSequence;
+		let buffer = this.#paintBeginSequence + this.#pendingAltExit;
+		this.#pendingAltExit = "";
 		if (destructiveReset && TERMINAL.imageProtocol === ImageProtocol.Kitty) {
 			// ED2/ED3 erase text cells but leave Kitty graphics visible. A reset is
 			// explicitly destructive, so remove every placement—not only the ones
@@ -2465,7 +2466,11 @@ export class TUI extends Container {
 			const mouseExit = this.#altMouseTrackingActive ? MOUSE_TRACKING_OFF : "";
 			const enhancementExit = this.#keyboardEnhancementExit();
 			const exitSequence = `${mouseExit}${enhancementExit}\x1b[?1049l`;
-			this.terminal.write(exitSequence);
+			// Session replacement finishes while its fullscreen selector still
+			// covers the old normal buffer. Fuse the restore into the destructive
+			// repaint so no stale frame can become visible between writes.
+			if (this.#clearScrollbackOnNextRender) this.#pendingAltExit = exitSequence;
+			else this.terminal.write(exitSequence);
 			setAltScreenActive(false);
 			this.#forgetHardwareCursorState();
 			this.#altActive = false;

--- a/packages/tui/test/emergency-restore-altscreen.test.ts
+++ b/packages/tui/test/emergency-restore-altscreen.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import { type TerminalFrameProvider, TUI } from "@oh-my-pi/pi-tui";
 import { emergencyTerminalRestore, ProcessTerminal, setAltScreenActive } from "@oh-my-pi/pi-tui/terminal";
 import { setTerminalHeadless } from "@oh-my-pi/pi-utils";
 
@@ -123,6 +124,39 @@ describe("emergencyTerminalRestore alt-screen gating", () => {
 		expect(activeRestore).toContain("\x1b[?1006l");
 		expect(activeRestore).toContain("\x1b[?1003l");
 		expect(activeRestore).toContain("\x1b[?1000l");
+	});
+	it("restores the alternate screen when a deferred replacement paint throws", () => {
+		const { writes, terminal } = startCapturedTerminal();
+		let failReplacement = false;
+		const provider: TerminalFrameProvider = {
+			renderFrame: () => {
+				if (failReplacement) throw new Error("replacement failed");
+				return { viewport: ["old session"] };
+			},
+			acknowledgeHistory: () => {},
+		};
+		const immediateScheduler = {
+			now: () => 0,
+			scheduleImmediate: (callback: () => void) => callback(),
+			scheduleRender: (callback: () => void) => {
+				callback();
+				return { cancel() {} };
+			},
+		};
+		const tui = new TUI(terminal, undefined, { renderScheduler: immediateScheduler });
+		tui.setFrameProvider(provider);
+		const overlay = tui.showOverlay(
+			{ render: () => ["session selector"] },
+			{ fullscreen: true, width: "100%", maxHeight: "100%" },
+		);
+		tui.requestRender(true, { clearScrollback: true });
+		failReplacement = true;
+
+		expect(() => overlay.hide()).toThrow("replacement failed");
+		writes.length = 0;
+		emergencyTerminalRestore();
+
+		expect(writes.join("")).toContain("\x1b[?1049l");
 	});
 	it("pops keyboard enhancement frames on both screens when crashing from a fullscreen overlay", () => {
 		const { terminal, writes } = startCapturedTerminal();

--- a/packages/tui/test/history-frame-plan.test.ts
+++ b/packages/tui/test/history-frame-plan.test.ts
@@ -207,6 +207,34 @@ describe("terminal frame plans", () => {
 		tui.stop();
 	});
 
+	it("fuses fullscreen overlay exit into a session replacement paint", () => {
+		const terminal = new CountingTerminal(171, 39);
+		const provider = new Provider({ viewport: ["old session"] });
+		const tui = new TUI(terminal, undefined, { renderScheduler: scheduler });
+		tui.setFrameProvider(provider);
+		const overlay = tui.showOverlay(
+			{
+				render: () => ["session selector"],
+			},
+			{
+				width: "100%",
+				maxHeight: "100%",
+				fullscreen: true,
+			},
+		);
+		terminal.writes.length = 0;
+
+		provider.plan = { viewport: ["resumed transcript", "resumed prompt"] };
+		tui.requestRender(true, { clearScrollback: true });
+		overlay.hide();
+
+		const exitPaints = terminal.writes.filter(write => write.includes("\x1b[?1049l"));
+		expect(exitPaints).toHaveLength(1);
+		expect(exitPaints[0]).toContain("\x1b[3J");
+		expect(exitPaints[0]).toContain("resumed transcript");
+		tui.stop();
+	});
+
 	it("repaints a viewport-only frame in place without scrolling", () => {
 		const terminal = new VirtualTerminal(20, 4);
 		const provider = new Provider({ viewport: ["spinner one", "editor"] });


### PR DESCRIPTION
## Repro
Repeatedly selecting the same session through `/resume` leaves the fullscreen selector while `requestRender(true, { clearScrollback: true })` is pending. `bun test packages/tui/test/history-frame-plan.test.ts --test-name-pattern "fuses fullscreen overlay exit"` reproduced the failure: the `DECRST 1049` write contained neither `ED3` nor the resumed transcript bytes, exposing the stale normal buffer before the replacement paint.

## Cause
The explicit-history-batching rewrite dropped the `TUI.#pendingAltExit` assignment in `packages/tui/src/tui.ts`. `TUI.#doRender()` therefore wrote the fullscreen overlay exit immediately, while `TUI.#emitPlanFrame()` sent the destructive resumed-session paint in a second terminal write. Windows Terminal could retain stale background cells during that gap until an editor keypress repainted the viewport.

## Fix
- Defer fullscreen overlay exit when a destructive replacement is pending.
- Prefix the next provider paint with that deferred exit, restoring one atomic terminal write.
- Add a 171x39 frame-provider regression and an Unreleased TUI changelog entry.

## Verification
`bun test packages/tui/test/history-frame-plan.test.ts packages/tui/test/kitty-keyboard-da1-ordering.test.ts packages/tui/test/image-budget.test.ts` — 56 passed, 0 failed. `bun check` in `packages/tui` passed. The publish gate also ran repository `bun run fix` and `bun check` successfully. Physical WSL/Windows Terminal verification was unavailable in this workspace; the regression asserts the exact split-write contract from the report.

Fixes #9799