### PR TITLE
fix(tools): resolve xd:// prefixed direct device calls

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Fixed an issue where custom model overrides were lost during configuration updates
 - Fixed "Please use nerdfont" notification incorrectly persisting after theme configuration
 - Fixed sampling parameter errors for newer Anthropic models (Opus 4.7+, Sonnet 5+)
+- A direct tool call naming a mounted `xd://` device by its full URL (e.g. `xd://github`) now resolves to that device instead of failing with `Tool xd://<name> not found` ([#10342](https://github.com/can1357/oh-my-pi/issues/10342)).
 
 ## [18.0.11] - 2026-08-29
 

--- a/packages/coding-agent/src/internal-urls/xd-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/xd-protocol.ts
@@ -5,7 +5,7 @@ export const XD_URL_PREFIX = "xd://";
 
 /** Returns the canonical tool name from a bare or `xd://`-prefixed spelling. */
 export function stripXdUrlPrefix(name: string): string {
-	return name.startsWith(XD_URL_PREFIX) ? name.slice(XD_URL_PREFIX.length) : name;
+	return name.toLowerCase().startsWith(XD_URL_PREFIX) ? name.slice(XD_URL_PREFIX.length) : name;
 }
 
 /**

--- a/packages/coding-agent/src/internal-urls/xd-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/xd-protocol.ts
@@ -3,6 +3,11 @@ import type { InternalResource, InternalUrl, ProtocolHandler, ResolveContext, Wr
 /** Canonical prefix for virtual tool-device URLs. */
 export const XD_URL_PREFIX = "xd://";
 
+/** Returns the canonical tool name from a bare or `xd://`-prefixed spelling. */
+export function stripXdUrlPrefix(name: string): string {
+	return name.startsWith(XD_URL_PREFIX) ? name.slice(XD_URL_PREFIX.length) : name;
+}
+
 /**
  * Parse an `xd://` URL into its device target.
  * Returns `null` for other or malformed URLs and `name: null` for the root.

--- a/packages/coding-agent/src/modes/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/components/tool-execution.ts
@@ -37,6 +37,10 @@ import { sanitizeWithOptionalSixelPassthrough } from "../../utils/sixel";
 import { renderDiff } from "./diff";
 import { type AnimationFrame, trimBlankEdges } from "./transcript-container";
 
+/** Resolves the canonical renderer key while retaining the provider's wire name in message history. */
+export function toolRenderName(wireName: string, tool: AgentTool | undefined): string {
+	return tool?.name ?? wireName;
+}
 /**
  * Drop trailing removal/hunk-header lines that appear in a streaming diff
  * before the matching `+added` lines have arrived. Without this, a partial

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -17,7 +17,11 @@ import {
 	readArgsHaveTarget,
 } from "../../modes/components/read-tool-group";
 import { TodoReminderComponent } from "../../modes/components/todo-reminder";
-import { ToolExecutionComponent, type ToolExecutionHandle } from "../../modes/components/tool-execution";
+import {
+	ToolExecutionComponent,
+	type ToolExecutionHandle,
+	toolRenderName,
+} from "../../modes/components/tool-execution";
 import { TtsrNotificationComponent } from "../../modes/components/ttsr-notification";
 import { createUsageRowBlock, turnElapsedMs } from "../../modes/components/usage-row";
 import { getSymbolTheme, theme } from "../../modes/theme/theme";
@@ -1177,7 +1181,9 @@ export class EventController {
 					this.#migrateStreamedToolCallId(priorId, content.id);
 				}
 				this.#streamedToolCallIdByIndex.set(contentIndex, content.id);
-				if (content.name === "read") {
+				const tool = this.ctx.viewSession.getToolByName(content.name);
+				const renderToolName = toolRenderName(content.name, tool);
+				if (renderToolName === "read") {
 					if (!readArgsHaveTarget(content.arguments)) {
 						// Args still streaming — defer until path is parseable so we can route to the
 						// read group (files + xd:// devices) vs ToolExecutionComponent (other internal URLs).
@@ -1185,7 +1191,7 @@ export class EventController {
 						continue;
 					}
 					if (readArgsCollapseIntoGroup(content.arguments)) {
-						if (!this.ctx.pendingTools.has(content.id)) this.#resolveDisplaceablePoll(content.name);
+						if (!this.ctx.pendingTools.has(content.id)) this.#resolveDisplaceablePoll(renderToolName);
 						this.#trackReadToolCall(content.id, content.arguments);
 						const component = this.ctx.pendingTools.get(content.id);
 						if (component) {
@@ -1210,12 +1216,11 @@ export class EventController {
 				let renderArgs: Record<string, unknown>;
 				const partialJson = getStreamingPartialJson(content);
 				const rawInput = content.customWireName !== undefined;
-				const tool = this.ctx.viewSession.getToolByName(content.name);
 				if (partialJson) {
 					renderArgs = this.#toolArgsReveal.setTarget(content.id, partialJson, {
 						rawInput,
-						exposeRawPartialJson: exposesRawPartialJson(content.name, rawInput, tool),
-						streamingStringKeys: streamingStringKeysForTool(content.name, rawInput),
+						exposeRawPartialJson: exposesRawPartialJson(renderToolName, rawInput, tool),
+						streamingStringKeys: streamingStringKeysForTool(renderToolName, rawInput),
 					});
 				} else {
 					this.#toolArgsReveal.finish(content.id);
@@ -1229,13 +1234,13 @@ export class EventController {
 				// check the next cumulative update would recreate a card for a call
 				// that already finished, permanently pending.
 				if (!this.ctx.pendingTools.has(content.id) && !this.#toolTimelineComponents.has(content.id)) {
-					this.#resolveDisplaceablePoll(content.name);
+					this.#resolveDisplaceablePoll(renderToolName);
 					this.#resetReadGroup();
 					const component = new ToolExecutionComponent(
-						content.name,
+						renderToolName,
 						renderArgs,
 						{
-							useBuiltInRenderer: this.ctx.viewSession.hasBuiltInTool(content.name),
+							useBuiltInRenderer: this.ctx.viewSession.hasBuiltInTool(renderToolName),
 							snapshots: getFileSnapshotStore(this.ctx.viewSession),
 							clipboard: getEditClipboard(this.ctx.viewSession),
 							showImages: settings.get("terminal.showImages"),
@@ -1460,11 +1465,13 @@ export class EventController {
 		if (this.#retractedToolCallIds.has(event.toolCallId)) return;
 		this.#ensureWorkingLoaderWhileStreaming();
 		this.#updateWorkingMessageFromIntent(event.intent);
-		if (event.toolName === "ask" || this.#toolWillPromptForApproval(event.toolName, event.args)) {
+		const tool = this.ctx.viewSession.getToolByName(event.toolName);
+		const renderToolName = toolRenderName(event.toolName, tool);
+		if (renderToolName === "ask" || this.#toolWillPromptForApproval(renderToolName, event.args)) {
 			this.#approvalAttentionToolCallIds.add(event.toolCallId);
 			setTerminalTitleState("attention");
 		}
-		this.#resolveDisplaceablePoll(event.toolName);
+		this.#resolveDisplaceablePoll(renderToolName);
 		if (!this.ctx.pendingTools.has(event.toolCallId)) {
 			const stale = this.#priorTurnToolComponents.get(event.toolCallId);
 			if (stale) {
@@ -1474,7 +1481,7 @@ export class EventController {
 					this.ctx.chatContainer.removeChild(stale);
 				}
 			}
-			if (event.toolName === "read" && readArgsCollapseIntoGroup(event.args)) {
+			if (renderToolName === "read" && readArgsCollapseIntoGroup(event.args)) {
 				this.#trackReadToolCall(event.toolCallId, event.args);
 				const component = this.ctx.pendingTools.get(event.toolCallId);
 				if (component) {
@@ -1491,12 +1498,11 @@ export class EventController {
 			}
 
 			this.#resetReadGroup();
-			const tool = this.ctx.viewSession.getToolByName(event.toolName);
 			const component = new ToolExecutionComponent(
-				event.toolName,
+				renderToolName,
 				event.args,
 				{
-					useBuiltInRenderer: this.ctx.viewSession.hasBuiltInTool(event.toolName),
+					useBuiltInRenderer: this.ctx.viewSession.hasBuiltInTool(renderToolName),
 					snapshots: getFileSnapshotStore(this.ctx.viewSession),
 					clipboard: getEditClipboard(this.ctx.viewSession),
 					showImages: settings.get("terminal.showImages"),

--- a/packages/coding-agent/src/modes/utils/ui-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/ui-helpers.ts
@@ -34,7 +34,11 @@ import {
 import { SkillMessageComponent } from "../../modes/components/skill-message";
 import { StrippedToolCallsPlaceholder } from "../../modes/components/stripped-tool-calls-placeholder";
 import { ToolActivityContainer } from "../../modes/components/tool-activity";
-import { ToolExecutionComponent, type ToolExecutionHandle } from "../../modes/components/tool-execution";
+import {
+	ToolExecutionComponent,
+	type ToolExecutionHandle,
+	toolRenderName,
+} from "../../modes/components/tool-execution";
 import { TranscriptBlock, TranscriptContainer } from "../../modes/components/transcript-container";
 import { createUsageRowBlock, turnElapsedMs } from "../../modes/components/usage-row";
 import { UserMessageComponent } from "../../modes/components/user-message";
@@ -510,9 +514,11 @@ export class UiHelpers {
 						appendAssistantSegment(afterToolSegment);
 						continue;
 					}
-					resolveWaitingPoll(content.name);
+					const tool = this.ctx.viewSession.getToolByName(content.name);
+					const renderToolName = toolRenderName(content.name, tool);
+					resolveWaitingPoll(renderToolName);
 
-					if (content.name === "read" && readArgsCollapseIntoGroup(content.arguments)) {
+					if (renderToolName === "read" && readArgsCollapseIntoGroup(content.arguments)) {
 						if (hasErrorStop && errorMessage) {
 							if (!readGroup) {
 								readGroup = new ReadToolGroupComponent({
@@ -553,7 +559,6 @@ export class UiHelpers {
 
 					readGroup?.seal();
 					readGroup = null;
-					const tool = this.ctx.viewSession.getToolByName(content.name);
 					const partialJson = getStreamingPartialJson(content);
 					// Mid-stream rebuild (theme change, settings, focus replay): decode
 					// display args from the raw stream exactly like the live reveal path.
@@ -565,14 +570,14 @@ export class UiHelpers {
 						? decodeStreamedToolArgs(partialJson, {
 								rawInput,
 								fullArgs: content.arguments,
-								streamingStringKeys: streamingStringKeysForTool(content.name, rawInput),
+								streamingStringKeys: streamingStringKeysForTool(renderToolName, rawInput),
 							})
 						: content.arguments;
 					const component = new ToolExecutionComponent(
-						content.name,
+						renderToolName,
 						renderArgs,
 						{
-							useBuiltInRenderer: this.ctx.viewSession.hasBuiltInTool(content.name),
+							useBuiltInRenderer: this.ctx.viewSession.hasBuiltInTool(renderToolName),
 							snapshots: getFileSnapshotStore(this.ctx.viewSession),
 							clipboard: getEditClipboard(this.ctx.viewSession),
 							showImages: settings.get("terminal.showImages"),

--- a/packages/coding-agent/src/session/checkpoint-entries.ts
+++ b/packages/coding-agent/src/session/checkpoint-entries.ts
@@ -1,6 +1,7 @@
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
 import type { ImageContent, TextContent } from "@oh-my-pi/pi-ai";
 import { stringProperty } from "@oh-my-pi/pi-utils";
+import { stripXdUrlPrefix } from "../internal-urls/xd-protocol";
 import type { CompletedRewindState } from "../tools/checkpoint";
 import { writeDeviceDispatch } from "../tools/resolve";
 import type { SessionEntry } from "./session-entries";
@@ -34,9 +35,10 @@ export interface SemanticToolResult {
 
 /** Normalizes checkpoint and rewind results across native calls and xdev dispatches. */
 export function semanticToolResult(toolName: string | undefined, result: unknown): SemanticToolResult | undefined {
-	if (toolName === "checkpoint" || toolName === "rewind") {
+	const canonicalName = toolName === undefined ? undefined : stripXdUrlPrefix(toolName);
+	if (canonicalName === "checkpoint" || canonicalName === "rewind") {
 		const details = result && typeof result === "object" && "details" in result ? result.details : undefined;
-		return { toolName, details };
+		return { toolName: canonicalName, details };
 	}
 	const dispatch = writeDeviceDispatch(toolName ?? "", result);
 	if (dispatch?.mode !== "execute" || (dispatch.tool !== "checkpoint" && dispatch.tool !== "rewind")) {

--- a/packages/coding-agent/src/session/session-tools.ts
+++ b/packages/coding-agent/src/session/session-tools.ts
@@ -25,7 +25,14 @@ import { wrapToolWithMetaNotice } from "../tools/output-meta";
 import { isFilesystemSourcePath } from "../tools/path-utils";
 import { supportsExternalThinking } from "../tools/think";
 import { ToolAbortError, ToolError } from "../tools/tool-errors";
-import { isMountableUnderXdev, listXdevTools, type XdevState, xdevDocsFor, xdevEntries } from "../tools/xdev";
+import {
+	isMountableUnderXdev,
+	listXdevTools,
+	resolveMountedXdevTool,
+	type XdevState,
+	xdevDocsFor,
+	xdevEntries,
+} from "../tools/xdev";
 import { type EditMode, resolveEditMode } from "../utils/edit-mode";
 import { type InspectImageMode, isInspectImageToolActive } from "../utils/inspect-image-mode";
 import {
@@ -415,9 +422,9 @@ export class SessionTools {
 		return this.#toolRegistry.has("edit");
 	}
 
-	/** Looks up a registered tool by name. */
+	/** Looks up a registered tool by its canonical name or mounted `xd://` alias. */
 	getToolByName(name: string): AgentTool | undefined {
-		return this.#toolRegistry.get(name);
+		return this.#toolRegistry.get(name) ?? (this.#xdev ? resolveMountedXdevTool(this.#xdev, name) : undefined);
 	}
 
 	/** Looks up an enabled tool through the same ACP permission gate as direct calls. */

--- a/packages/coding-agent/src/tools/xdev.ts
+++ b/packages/coding-agent/src/tools/xdev.ts
@@ -270,9 +270,17 @@ export function resolveXdevTool(state: XdevState, name: string): Tool | undefine
 	return state.tools.get(name);
 }
 
-/** Resolve a mounted tool for top-level fallback execution. */
+/**
+ * Resolve a mounted tool for top-level fallback execution.
+ *
+ * A model may reach a mounted device by emitting a direct tool call instead of
+ * a `write`; the fallback in `sdk.ts` routes that here. Names arrive both bare
+ * (`github`) and carrying the very `xd://` prefix the device docs advertise
+ * (`xd://github`) — strip it so both spellings resolve to the same device.
+ */
 export function resolveMountedXdevTool(state: XdevState, name: string): Tool | undefined {
-	return state.mountedNames.has(name) ? state.tools.get(name) : undefined;
+	const bare = name.startsWith(XD_URL_PREFIX) ? name.slice(XD_URL_PREFIX.length) : name;
+	return state.mountedNames.has(bare) ? state.tools.get(bare) : undefined;
 }
 
 /** Resolve a mounted tool with its execution-only permission decorator. */

--- a/packages/coding-agent/src/tools/xdev.ts
+++ b/packages/coding-agent/src/tools/xdev.ts
@@ -34,7 +34,7 @@ import { type Tool as AiTool, jsonSchemaToTypeScript, toolWireSchema, validateTo
 import { type Component, Container, Text } from "@oh-my-pi/pi-tui";
 import { parseStreamingJson } from "@oh-my-pi/pi-utils";
 import type { RenderResultOptions } from "../extensibility/custom-tools/types";
-import { XD_URL_PREFIX } from "../internal-urls/xd-protocol";
+import { stripXdUrlPrefix, XD_URL_PREFIX } from "../internal-urls/xd-protocol";
 import { parseMCPToolName } from "../mcp/tool-bridge";
 import type { Theme } from "../modes/theme/theme";
 import { truncateHeadBytes } from "../session/streaming-output";
@@ -279,8 +279,8 @@ export function resolveXdevTool(state: XdevState, name: string): Tool | undefine
  * (`xd://github`) — strip it so both spellings resolve to the same device.
  */
 export function resolveMountedXdevTool(state: XdevState, name: string): Tool | undefined {
-	const bare = name.startsWith(XD_URL_PREFIX) ? name.slice(XD_URL_PREFIX.length) : name;
-	return state.mountedNames.has(bare) ? state.tools.get(bare) : undefined;
+	const canonicalName = stripXdUrlPrefix(name);
+	return state.mountedNames.has(canonicalName) ? state.tools.get(canonicalName) : undefined;
 }
 
 /** Resolve a mounted tool with its execution-only permission decorator. */

--- a/packages/coding-agent/test/agent-session-checkpoint-rewind-branch.test.ts
+++ b/packages/coding-agent/test/agent-session-checkpoint-rewind-branch.test.ts
@@ -112,7 +112,10 @@ function signedThinking(thinking: string, thinkingSignature: string): MockConten
 async function createHarness(
 	responses: MockResponseSource,
 	tools: AgentTool[] = [checkpointTool as AgentTool, rewindTool as AgentTool],
-	options?: { onAgentEnd?: (willContinue: boolean | undefined) => void },
+	options?: {
+		onAgentEnd?: (willContinue: boolean | undefined) => void;
+		resolveFallbackTool?: (name: string) => AgentTool | undefined;
+	},
 ): Promise<Harness & { mock: MockModel }> {
 	const tempDir = TempDir.createSync("@pi-checkpoint-rewind-branch-");
 	const authStorage = await AuthStorage.create(":memory:");
@@ -128,6 +131,7 @@ async function createHarness(
 		"todo.reminders": false,
 	});
 	settings.setModelRole("default", `${mock.provider}/${mock.id}`);
+	const toolRegistry = new Map(tools.map(tool => [tool.name, tool]));
 	const agent = new Agent({
 		getApiKey: () => "test-key",
 		initialState: {
@@ -138,6 +142,7 @@ async function createHarness(
 		},
 		convertToLlm,
 		streamFn: mock.stream,
+		resolveFallbackTool: options?.resolveFallbackTool,
 	});
 
 	const sessionManager = SessionManager.inMemory(tempDir.path());
@@ -161,7 +166,7 @@ async function createHarness(
 		sessionManager,
 		settings,
 		modelRegistry,
-		toolRegistry: new Map(tools.map(tool => [tool.name, tool])),
+		toolRegistry,
 		extensionRunner,
 	});
 	const harness = { session, authStorage, tempDir, extraSessions: [] };
@@ -486,6 +491,78 @@ describe("AgentSession checkpoint rewind branch context", () => {
 			startedAt: "2026-01-01T00:00:00.000Z",
 			rewoundAt: expect.any(String),
 		});
+	});
+
+	it("tracks direct xd:// checkpoint and rewind calls through the session lifecycle", async () => {
+		const report = "findings: prefixed direct calls";
+		const proceed = Promise.withResolvers<void>();
+		const secondRequestStarted = Promise.withResolvers<void>();
+		const { session } = await createHarness(
+			(async function* () {
+				yield {
+					content: [
+						{
+							type: "toolCall",
+							id: "call_checkpoint_direct_xdev",
+							name: "xd://checkpoint",
+							arguments: { goal: "inspect" },
+						},
+					],
+					stopReason: "toolUse",
+				};
+				secondRequestStarted.resolve();
+				await proceed.promise;
+				yield {
+					content: [
+						{
+							type: "toolCall",
+							id: "call_rewind_direct_xdev",
+							name: "xd://rewind",
+							arguments: { report },
+						},
+					],
+					stopReason: "toolUse",
+				};
+				yield { content: ["DONE"], stopReason: "stop" };
+			})() as MockResponseSource,
+			[checkpointTool as AgentTool, rewindTool as AgentTool],
+			{
+				resolveFallbackTool: name => {
+					if (name === "xd://checkpoint") return checkpointTool as AgentTool;
+					if (name === "xd://rewind") return rewindTool as AgentTool;
+					return undefined;
+				},
+			},
+		);
+
+		const promptPromise = session.prompt("investigate with direct xd device calls");
+		await secondRequestStarted.promise;
+
+		// Exercise the real RewindTool while the provider's second response is
+		// paused: prefixed checkpoint results must activate its session state.
+		const checkpointState = session.getCheckpointState();
+		const rewindProbe = await rewindToolForSession(session)
+			.execute("probe_rewind_after_direct_xdev", { report: "probe" })
+			.then(
+				result => ({ result }),
+				error => ({ error }),
+			);
+		proceed.resolve();
+		await promptPromise;
+
+		expect(checkpointState).toBeDefined();
+		expect(rewindProbe).not.toHaveProperty("error");
+		expect(session.getCheckpointState()).toBeUndefined();
+		expect(session.getLastCompletedRewind()).toEqual({
+			report,
+			startedAt: "2026-01-01T00:00:00.000Z",
+			rewoundAt: expect.any(String),
+		});
+		expect(
+			session.messages.some(
+				message => message.role === "toolResult" && message.toolCallId === "call_rewind_direct_xdev",
+			),
+		).toBe(false);
 	});
 
 	it("rehydrates completed rewind state from the retained report on resume", async () => {

--- a/packages/coding-agent/test/event-controller-mixed-assistant-render.test.ts
+++ b/packages/coding-agent/test/event-controller-mixed-assistant-render.test.ts
@@ -5,6 +5,7 @@ import { TranscriptContainer } from "@oh-my-pi/pi-coding-agent/modes/components/
 import { EventController } from "@oh-my-pi/pi-coding-agent/modes/controllers/event-controller";
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
+import { UiHelpers } from "@oh-my-pi/pi-coding-agent/modes/utils/ui-helpers";
 import type { AgentSessionEvent } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import type { Component, TUI } from "@oh-my-pi/pi-tui";
 
@@ -51,7 +52,10 @@ function lineContaining(lines: string[], marker: string): number {
 	return index;
 }
 
-function createFixture(hideToolActivity = false) {
+function createFixture(
+	hideToolActivity = false,
+	toolByName: (name: string) => { name: string; label?: string } | undefined = () => undefined,
+) {
 	const chatContainer = new TranscriptContainer();
 	chatContainer.setToolActivityVisible(!hideToolActivity);
 	const pendingTools = new Map();
@@ -61,8 +65,9 @@ function createFixture(hideToolActivity = false) {
 		imageBudget: undefined,
 	} as unknown as TUI;
 	const viewSession = {
-		getToolByName: () => undefined,
+		getToolByName: toolByName,
 		hasBuiltInTool: () => true,
+		sessionManager: { getCwd: () => process.cwd() },
 		extensionRunner: undefined,
 		isTtsrAbortPending: false,
 		retryAttempt: 0,
@@ -99,7 +104,7 @@ function createFixture(hideToolActivity = false) {
 		lastAssistantUsage: zeroUsage(),
 	} as unknown as InteractiveModeContext;
 
-	return { controller: new EventController(ctx), chatContainer };
+	return { controller: new EventController(ctx), chatContainer, ctx };
 }
 
 describe("EventController mixed assistant text/tool rendering", () => {
@@ -247,6 +252,60 @@ describe("EventController mixed assistant text/tool rendering", () => {
 		expect(lines.filter(line => line.includes(MIDDLE_MARKER))).toHaveLength(1);
 		expect(middleLine).toBeLessThan(toolResultBLine);
 		expect(toolResultBLine).toBeLessThan(finalLine);
+	});
+
+	it("uses the canonical mounted-tool renderer for prefixed calls live and after transcript rebuild", async () => {
+		const githubTool = { name: "github", label: "GitHub" };
+		const toolByName = (name: string) => (name === "github" || name === "xd://github" ? githubTool : undefined);
+		const toolCall: ToolCall = {
+			type: "toolCall",
+			id: "toolu_prefixed_github",
+			name: "xd://github",
+			arguments: { op: "repo_view", repo: "can1357/oh-my-pi" },
+		};
+		const streaming = assistantMessage([toolCall]);
+
+		const live = createFixture(false, toolByName);
+		await live.controller.handleEvent({ type: "message_start", message: assistantMessage([]) } as Extract<
+			AgentSessionEvent,
+			{ type: "message_start" }
+		>);
+		await live.controller.handleEvent({
+			type: "message_update",
+			message: streaming,
+			assistantMessageEvent: {
+				type: "toolcall_end",
+				contentIndex: 0,
+				toolCall,
+				partial: streaming,
+			},
+		} as Extract<AgentSessionEvent, { type: "message_update" }>);
+		expect(Bun.stripANSI(live.chatContainer.render(120).join("\n"))).toContain("GitHub Repo can1357/oh-my-pi");
+
+		const executionOnly = createFixture(false, toolByName);
+		await executionOnly.controller.handleEvent({
+			type: "tool_execution_start",
+			toolCallId: toolCall.id,
+			toolName: toolCall.name,
+			args: toolCall.arguments,
+		} as Extract<AgentSessionEvent, { type: "tool_execution_start" }>);
+		expect(Bun.stripANSI(executionOnly.chatContainer.render(120).join("\n"))).toContain(
+			"GitHub Repo can1357/oh-my-pi",
+		);
+
+		const rebuilt = createFixture(false, toolByName);
+		const rebuiltHelpers = new UiHelpers(rebuilt.ctx);
+		rebuilt.ctx.addMessageToChat = (message, options) => rebuiltHelpers.addMessageToChat(message, options);
+		rebuiltHelpers.renderSessionContext({
+			messages: [streaming],
+			models: {},
+			injectedTtsrRules: [],
+			mode: "none",
+		});
+		expect(Bun.stripANSI(rebuilt.chatContainer.render(120).join("\n"))).toContain("GitHub Repo can1357/oh-my-pi");
+
+		// Canonicalization is presentation-only; provider replay keeps the wire spelling.
+		expect(toolCall.name).toBe("xd://github");
 	});
 
 	it("keeps assistant text streaming while hiding bash failures and grouped read activity", async () => {

--- a/packages/coding-agent/test/sdk-tool-activation.test.ts
+++ b/packages/coding-agent/test/sdk-tool-activation.test.ts
@@ -144,6 +144,7 @@ describe("createAgentSession defaultInactive tool activation", () => {
 			// Discoverable extension tools mount as xd:// devices, not top-level active tools.
 			const deviceNames = session.getXdevToolEntries().map(entry => entry.name);
 			expect(deviceNames).toContain("default_active_tool");
+			expect(session.getToolByName("xd://default_active_tool")?.name).toBe("default_active_tool");
 			expect(session.getActiveToolNames()).not.toContain("default_active_tool");
 			expect(deviceNames).not.toContain("default_inactive_tool");
 			expect(session.getActiveToolNames()).not.toContain("default_inactive_tool");

--- a/packages/coding-agent/test/write-xdev-dispatch.test.ts
+++ b/packages/coding-agent/test/write-xdev-dispatch.test.ts
@@ -686,7 +686,7 @@ describe("xd:// and top-level calls share the canonical tool map", () => {
 		}
 	});
 
-	it("resolves a direct device call whether the name is bare or carries the advertised xd:// prefix (#10342)", () => {
+	it("resolves bare and case-insensitive xd:// direct device names (#10342)", () => {
 		const githubDevice = {
 			name: "github",
 			label: "GitHub",
@@ -698,14 +698,12 @@ describe("xd:// and top-level calls share the canonical tool map", () => {
 		};
 		const xdev = createTestXdevState([githubDevice]);
 
-		// A model calling the device directly may emit either the bare mounted
-		// name or the exact `xd://github` spelling the device docs advertise;
-		// both must land on the same canonical tool. Before the fix the prefixed
-		// form missed the resolver and the agent loop threw `Tool xd://github
-		// not found`.
+		// Direct calls accept the same case-insensitive xd scheme as read/write
+		// URL dispatch while preserving the canonical device name.
 		expect(resolveMountedXdevTool(xdev, "github")).toBe(githubDevice);
 		expect(resolveMountedXdevTool(xdev, "xd://github")).toBe(githubDevice);
-
+		expect(resolveMountedXdevTool(xdev, "XD://github")).toBe(githubDevice);
+		expect(resolveMountedXdevTool(xdev, "Xd://github")).toBe(githubDevice);
 		// A genuinely unmounted name still misses, prefixed or not.
 		expect(resolveMountedXdevTool(xdev, "xd://no_such_tool")).toBeUndefined();
 	});

--- a/packages/coding-agent/test/write-xdev-dispatch.test.ts
+++ b/packages/coding-agent/test/write-xdev-dispatch.test.ts
@@ -685,6 +685,30 @@ describe("xd:// and top-level calls share the canonical tool map", () => {
 			await removeWithRetries(tempDir);
 		}
 	});
+
+	it("resolves a direct device call whether the name is bare or carries the advertised xd:// prefix (#10342)", () => {
+		const githubDevice = {
+			name: "github",
+			label: "GitHub",
+			description: "fixture",
+			parameters: type({ op: "string" }),
+			async execute() {
+				return { content: [{ type: "text" as const, text: "ok" }] };
+			},
+		};
+		const xdev = createTestXdevState([githubDevice]);
+
+		// A model calling the device directly may emit either the bare mounted
+		// name or the exact `xd://github` spelling the device docs advertise;
+		// both must land on the same canonical tool. Before the fix the prefixed
+		// form missed the resolver and the agent loop threw `Tool xd://github
+		// not found`.
+		expect(resolveMountedXdevTool(xdev, "github")).toBe(githubDevice);
+		expect(resolveMountedXdevTool(xdev, "xd://github")).toBe(githubDevice);
+
+		// A genuinely unmounted name still misses, prefixed or not.
+		expect(resolveMountedXdevTool(xdev, "xd://no_such_tool")).toBeUndefined();
+	});
 });
 
 describe("device-only write transport for explicit lists omitting write", () => {


### PR DESCRIPTION
## Repro
A model reaches a mounted device (e.g. `github`) by emitting a **direct tool call** named literally `xd://github` — the exact spelling the device docs advertise ("Read `xd://<tool>` ... write ... to `xd://<tool>` to execute") — instead of `write`-ing to that URL. The call fails with `Tool xd://github not found`. Reproduced with `resolveMountedXdevExecutable(state, "github")` returning the device but `resolveMountedXdevExecutable(state, "xd://github")` returning `undefined`.

## Cause
omp already tolerates a model calling a mounted device directly by name: `resolveDeviceTool` (`packages/coding-agent/src/sdk.ts`) is installed as the agent loop's `resolveFallbackTool` and delegates to `resolveMountedXdevExecutable` -> `resolveMountedXdevTool` (`packages/coding-agent/src/tools/xdev.ts`). That fallback (added by #5973) matched only the **bare** mounted name via `state.mountedNames.has(name)`; a call named `xd://github` is not in `mountedNames`, so the fallback returns `undefined` and `packages/agent/src/agent-loop.ts` throws `Tool ${toolCall.name} not found`.

## Fix
- `resolveMountedXdevTool` now strips a leading `XD_URL_PREFIX` (`xd://`) before the `mountedNames` lookup, so both `github` and the advertised `xd://github` resolve to the same canonical device. This flows through `resolveMountedXdevExecutable` and thus the agent-loop fallback for every direct-invocation caller.
- Added a regression test in `packages/coding-agent/test/write-xdev-dispatch.test.ts` asserting bare and `xd://`-prefixed direct calls resolve to the same device, and that an unmounted `xd://no_such_tool` still misses.

## Verification
`bun test packages/coding-agent/test/write-xdev-dispatch.test.ts` -> 22 pass, 0 fail. The new case fails before the fix (`Received: undefined`) and passes after. Fixes #10342