### PR TITLE
feat(coding-agent/theme): derive unset userMessageText from the theme accent

### DIFF
--- a/docs/theme.md
+++ b/docs/theme.md
@@ -36,6 +36,12 @@ Color values accept:
 - variable reference string (resolved through `vars`)
 - empty string (`""`) meaning terminal default (`\x1b[39m` fg, `\x1b[49m` bg)
 
+Exception: an unset `userMessageText` inherits the theme `accent` when the
+accent keeps a WCAG contrast ratio of at least 3:1 against `userMessageBg`
+(so user input stays visually distinct from assistant replies, #1633);
+otherwise it remains the terminal default. Setting the token explicitly
+always wins.
+
 ## Required and optional color tokens
 
 All tokens below are required in `colors` except `thinkingMax`, which is optional for compatibility and falls back to `thinkingXhigh`.

--- a/docs/theme.md
+++ b/docs/theme.md
@@ -36,11 +36,13 @@ Color values accept:
 - variable reference string (resolved through `vars`)
 - empty string (`""`) meaning terminal default (`\x1b[39m` fg, `\x1b[49m` bg)
 
-Exception: an unset `userMessageText` inherits the theme `accent` when the
-accent keeps a WCAG contrast ratio of at least 3:1 against `userMessageBg`
-(so user input stays visually distinct from assistant replies, #1633);
-otherwise it remains the terminal default. Setting the token explicitly
-always wins.
+Exception: `userMessageText: ""` does not keep the terminal default — it
+inherits the theme `accent` while that keeps a WCAG contrast ratio of at
+least 3:1 against the surface the message is painted on: `userMessageBg` in
+the TUI, and the exported 6%-accent-over-page background in HTML export
+(#1633). Below the threshold the terminal default (and, in HTML export, the
+readable text fallback) applies. Setting the token to a non-empty color always
+wins; to restore the pre-#1633 look, set an explicit foreground color.
 
 ## Required and optional color tokens
 

--- a/docs/theme.md
+++ b/docs/theme.md
@@ -38,11 +38,13 @@ Color values accept:
 
 Exception: `userMessageText: ""` does not keep the terminal default — it
 inherits the theme `accent` while that keeps a WCAG contrast ratio of at
-least 3:1 against the surface the message is painted on: `userMessageBg` in
-the TUI, and the exported 6%-accent-over-page background in HTML export
-(#1633). Below the threshold the terminal default (and, in HTML export, the
-readable text fallback) applies. Setting the token to a non-empty color always
-wins; to restore the pre-#1633 look, set an explicit foreground color.
+least 3:1 against the surface the message is painted on, using the colors
+the output device actually renders (quantized to the xterm palette in
+256-color terminals): `userMessageBg` in the TUI, and the exported
+6%-accent-over-page background in HTML export (#1633). Below the threshold
+the terminal default (and, in HTML export, the readable text fallback)
+applies. Setting the token to a non-empty color always wins; to restore the
+pre-#1633 look, set an explicit foreground color.
 
 ## Required and optional color tokens
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Changed
 
 - Disabled `hashline` edit mode for Kimi, Mimo, DeepSeek Flash, and Stepfun models for stability
+- User messages now render in the theme accent color when `userMessageText` is unset, making user input visually distinct from agent replies ([#1633](https://github.com/can1357/oh-my-pi/issues/1633) by [@Svtter](https://github.com/Svtter))
 
 ### Fixed
 

--- a/packages/coding-agent/src/export/html/export-surface.ts
+++ b/packages/coding-agent/src/export/html/export-surface.ts
@@ -1,0 +1,88 @@
+// Export-surface color math shared by the HTML export pipeline and the theme
+// resolver. Extracted from index.ts so `modes/theme/theme.ts` can guard derived
+// colors against the surface the exported CSS actually paints.
+
+/** Parse a color string to RGB values. */
+export function parseColor(color: string): { r: number; g: number; b: number } | undefined {
+	const hexMatch = color.match(/^#([0-9a-fA-F]{2})([0-9a-fA-F]{2})([0-9a-fA-F]{2})$/);
+	if (hexMatch) {
+		return {
+			r: Number.parseInt(hexMatch[1], 16),
+			g: Number.parseInt(hexMatch[2], 16),
+			b: Number.parseInt(hexMatch[3], 16),
+		};
+	}
+	const rgbMatch = color.match(/^rgb\s*\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*\)$/);
+	if (rgbMatch) {
+		return {
+			r: Number.parseInt(rgbMatch[1], 10),
+			g: Number.parseInt(rgbMatch[2], 10),
+			b: Number.parseInt(rgbMatch[3], 10),
+		};
+	}
+	return undefined;
+}
+
+/** Calculate relative luminance of a color (0-1, higher = lighter). */
+export function getLuminance(r: number, g: number, b: number): number {
+	const toLinear = (c: number) => {
+		const s = c / 255;
+		return s <= 0.03928 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+	};
+	return 0.2126 * toLinear(r) + 0.7152 * toLinear(g) + 0.0722 * toLinear(b);
+}
+
+/** Adjust color brightness. */
+export function adjustBrightness(color: string, factor: number): string {
+	const parsed = parseColor(color);
+	if (!parsed) return color;
+	const adjust = (c: number) => Math.min(255, Math.max(0, Math.round(c * factor)));
+	return `rgb(${adjust(parsed.r)}, ${adjust(parsed.g)}, ${adjust(parsed.b)})`;
+}
+
+/** Derive export background colors from a base color. */
+export function deriveExportColors(baseColor: string): { pageBg: string; cardBg: string; infoBg: string } {
+	const parsed = parseColor(baseColor);
+	if (!parsed) {
+		return { pageBg: "rgb(24, 24, 30)", cardBg: "rgb(30, 30, 36)", infoBg: "rgb(60, 55, 40)" };
+	}
+
+	const luminance = getLuminance(parsed.r, parsed.g, parsed.b);
+	if (luminance > 0.5) {
+		return {
+			pageBg: adjustBrightness(baseColor, 0.96),
+			cardBg: baseColor,
+			infoBg: `rgb(${Math.min(255, parsed.r + 10)}, ${Math.min(255, parsed.g + 5)}, ${Math.max(0, parsed.b - 20)})`,
+		};
+	}
+	return {
+		pageBg: adjustBrightness(baseColor, 0.7),
+		cardBg: adjustBrightness(baseColor, 0.85),
+		infoBg: `rgb(${Math.min(255, parsed.r + 20)}, ${Math.min(255, parsed.g + 15)}, ${parsed.b})`,
+	};
+}
+
+/**
+ * Per-channel sRGB mix mirroring CSS `color-mix(in srgb, a W%, b)`. Returns a
+ * hex string (the format `relativeLuminance` accepts); returns `b` unchanged
+ * when either input is unparseable.
+ */
+export function mixSrgb(a: string, b: string, weightOfA: number): string {
+	const pa = parseColor(a);
+	const pb = parseColor(b);
+	if (!pa || !pb) return b;
+	const channel = (x: number, y: number) => Math.round(x * weightOfA + y * (1 - weightOfA));
+	const toHex = (c: number) => c.toString(16).padStart(2, "0");
+	return `#${toHex(channel(pa.r, pb.r))}${toHex(channel(pa.g, pb.g))}${toHex(channel(pa.b, pb.b))}`;
+}
+
+/**
+ * Effective backdrop of an exported `.user-message`: the template paints
+ * `color-mix(in srgb, var(--accent) 6%, transparent)` over `--body-bg` — the
+ * export `pageBg` when the theme defines one, else the background derived
+ * from the TUI bubble color.
+ */
+export function exportUserMessageSurface(accent: string, pageBg: string | undefined, userMessageBg: string): string {
+	const bodyBg = pageBg ?? deriveExportColors(userMessageBg || "#343541").pageBg;
+	return mixSrgb(accent, bodyBg, 0.06);
+}

--- a/packages/coding-agent/src/export/html/index.ts
+++ b/packages/coding-agent/src/export/html/index.ts
@@ -7,6 +7,7 @@ import type { SessionEntry, SessionHeader } from "../../session/session-entries"
 import { loadEntriesFromFile } from "../../session/session-loader";
 import { SessionManager } from "../../session/session-manager";
 import type { ExportThemeNames } from "./args";
+import { deriveExportColors } from "./export-surface";
 import templateCssPath from "./template.css" with { type: "file" };
 import templateHtmlPath from "./template.html" with { type: "file" };
 import templateJsPath from "./template.js" with { type: "file" };
@@ -55,66 +56,6 @@ export interface ExportOptions {
 	themeNames?: ExportThemeNames;
 	/** Embed subagent session transcripts found next to the session file (default true). */
 	includeSubSessions?: boolean;
-}
-
-/** Parse a color string to RGB values. */
-function parseColor(color: string): { r: number; g: number; b: number } | undefined {
-	const hexMatch = color.match(/^#([0-9a-fA-F]{2})([0-9a-fA-F]{2})([0-9a-fA-F]{2})$/);
-	if (hexMatch) {
-		return {
-			r: Number.parseInt(hexMatch[1], 16),
-			g: Number.parseInt(hexMatch[2], 16),
-			b: Number.parseInt(hexMatch[3], 16),
-		};
-	}
-	const rgbMatch = color.match(/^rgb\s*\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*\)$/);
-	if (rgbMatch) {
-		return {
-			r: Number.parseInt(rgbMatch[1], 10),
-			g: Number.parseInt(rgbMatch[2], 10),
-			b: Number.parseInt(rgbMatch[3], 10),
-		};
-	}
-	return undefined;
-}
-
-/** Calculate relative luminance of a color (0-1, higher = lighter). */
-function getLuminance(r: number, g: number, b: number): number {
-	const toLinear = (c: number) => {
-		const s = c / 255;
-		return s <= 0.03928 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
-	};
-	return 0.2126 * toLinear(r) + 0.7152 * toLinear(g) + 0.0722 * toLinear(b);
-}
-
-/** Adjust color brightness. */
-function adjustBrightness(color: string, factor: number): string {
-	const parsed = parseColor(color);
-	if (!parsed) return color;
-	const adjust = (c: number) => Math.min(255, Math.max(0, Math.round(c * factor)));
-	return `rgb(${adjust(parsed.r)}, ${adjust(parsed.g)}, ${adjust(parsed.b)})`;
-}
-
-/** Derive export background colors from a base color. */
-function deriveExportColors(baseColor: string): { pageBg: string; cardBg: string; infoBg: string } {
-	const parsed = parseColor(baseColor);
-	if (!parsed) {
-		return { pageBg: "rgb(24, 24, 30)", cardBg: "rgb(30, 30, 36)", infoBg: "rgb(60, 55, 40)" };
-	}
-
-	const luminance = getLuminance(parsed.r, parsed.g, parsed.b);
-	if (luminance > 0.5) {
-		return {
-			pageBg: adjustBrightness(baseColor, 0.96),
-			cardBg: baseColor,
-			infoBg: `rgb(${Math.min(255, parsed.r + 10)}, ${Math.min(255, parsed.g + 5)}, ${Math.max(0, parsed.b - 20)})`,
-		};
-	}
-	return {
-		pageBg: adjustBrightness(baseColor, 0.7),
-		cardBg: adjustBrightness(baseColor, 0.85),
-		infoBg: `rgb(${Math.min(255, parsed.r + 20)}, ${Math.min(255, parsed.g + 15)}, ${parsed.b})`,
-	};
 }
 
 /**

--- a/packages/coding-agent/src/modes/theme/color.ts
+++ b/packages/coding-agent/src/modes/theme/color.ts
@@ -85,18 +85,33 @@ const USER_MESSAGE_ACCENT_CONTRAST_MIN = 3;
 export function deriveUserMessageTextDefault(
 	resolved: Record<string, string | number>,
 	surface?: string,
+	mode?: ColorMode,
 ): string | number {
 	const current = resolved.userMessageText;
 	if (current !== undefined && current !== "") return current;
 	const accent = resolved.accent;
 	if (accent === undefined || accent === "") return current ?? "";
 	const background = surface ?? resolved.userMessageBg;
-	const accentLuminance = relativeLuminance(accent);
-	const backgroundLuminance = relativeLuminance(background);
+	const accentLuminance = relativeLuminance(renderedHex(accent, mode));
+	const backgroundLuminance = relativeLuminance(renderedHex(background, mode));
 	if (accentLuminance === undefined || backgroundLuminance === undefined) return current ?? "";
 	const contrast =
 		(Math.max(accentLuminance, backgroundLuminance) + 0.05) / (Math.min(accentLuminance, backgroundLuminance) + 0.05);
 	return contrast >= USER_MESSAGE_ACCENT_CONTRAST_MIN ? accent : (current ?? "");
+}
+
+/**
+ * Hex actually painted for a color token in `mode`. Truecolor terminals render
+ * the value as-is; 256-color terminals quantize both the accent and the bubble
+ * to the xterm palette, so contrast decisions must use the quantized pair —
+ * e.g. limestone passes 3.38:1 in truecolor but its palette colors (137 on
+ * 255) only reach 2.80:1 (#10344 review).
+ */
+function renderedHex(value: string | number, mode: ColorMode | undefined): string | number {
+	if (mode !== "256color") return value;
+	const ansi = colorToAnsi(typeof value === "number" ? ansi256ToHex(value) : value, mode);
+	const paletteIndex = /38;5;(\d+)/.exec(ansi);
+	return paletteIndex ? ansi256ToHex(Number(paletteIndex[1])) : value;
 }
 
 /**

--- a/packages/coding-agent/src/modes/theme/color.ts
+++ b/packages/coding-agent/src/modes/theme/color.ts
@@ -1,4 +1,5 @@
 import { detectTerminalId, getTerminalInfo } from "@oh-my-pi/pi-tui";
+import { relativeLuminance } from "@oh-my-pi/pi-utils";
 import type { ColorMode, ColorValue } from "./schema";
 
 // ============================================================================
@@ -64,6 +65,36 @@ export function resolveThemeColors<T extends Record<string, ColorValue>>(
 		resolved[key] = resolveVarRefs(value, vars);
 	}
 	return resolved as Record<keyof T, string | number>;
+}
+
+/**
+ * Minimum WCAG contrast ratio for the accent to qualify as user bubble text —
+ * the AA bar for large text / UI components. Body text asks for 4.5, but the
+ * state this replaces offered no distinction at all, and any theme can set
+ * `userMessageText` explicitly to opt out.
+ */
+const USER_MESSAGE_ACCENT_CONTRAST_MIN = 3;
+
+/**
+ * Themes that leave `userMessageText` unset paint user input with the terminal
+ * default — indistinguishable from assistant output (#1633). Inherit the theme
+ * accent when it stays readable on the bubble background; otherwise return the
+ * token unchanged so `Theme.getFgOnBgAnsi` keeps its near-black/near-white
+ * fallback. Explicit theme values always win.
+ */
+export function deriveUserMessageTextDefault(resolved: Record<string, string | number>): string | number {
+	const current = resolved.userMessageText;
+	if (current !== undefined && current !== "") return current;
+	const accent = resolved.accent;
+	if (accent === undefined || accent === "") return current ?? "";
+	const background = resolved.userMessageBg;
+	if (background === undefined || background === "") return current ?? "";
+	const accentLuminance = relativeLuminance(accent);
+	const backgroundLuminance = relativeLuminance(background);
+	if (accentLuminance === undefined || backgroundLuminance === undefined) return current ?? "";
+	const contrast =
+		(Math.max(accentLuminance, backgroundLuminance) + 0.05) / (Math.min(accentLuminance, backgroundLuminance) + 0.05);
+	return contrast >= USER_MESSAGE_ACCENT_CONTRAST_MIN ? accent : (current ?? "");
 }
 
 /**

--- a/packages/coding-agent/src/modes/theme/color.ts
+++ b/packages/coding-agent/src/modes/theme/color.ts
@@ -80,15 +80,17 @@ const USER_MESSAGE_ACCENT_CONTRAST_MIN = 3;
  * default — indistinguishable from assistant output (#1633). Inherit the theme
  * accent when it stays readable on the bubble background; otherwise return the
  * token unchanged so `Theme.getFgOnBgAnsi` keeps its near-black/near-white
- * fallback. Explicit theme values always win.
+ * fallback. Explicit non-empty theme values always win; `""` derives.
  */
-export function deriveUserMessageTextDefault(resolved: Record<string, string | number>): string | number {
+export function deriveUserMessageTextDefault(
+	resolved: Record<string, string | number>,
+	surface?: string,
+): string | number {
 	const current = resolved.userMessageText;
 	if (current !== undefined && current !== "") return current;
 	const accent = resolved.accent;
 	if (accent === undefined || accent === "") return current ?? "";
-	const background = resolved.userMessageBg;
-	if (background === undefined || background === "") return current ?? "";
+	const background = surface ?? resolved.userMessageBg;
 	const accentLuminance = relativeLuminance(accent);
 	const backgroundLuminance = relativeLuminance(background);
 	if (accentLuminance === undefined || backgroundLuminance === undefined) return current ?? "";

--- a/packages/coding-agent/src/modes/theme/loader.ts
+++ b/packages/coding-agent/src/modes/theme/loader.ts
@@ -2,7 +2,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { type } from "@oh-my-pi/omptype";
 import { adjustHsv, getCustomThemesDir, isEnoent } from "@oh-my-pi/pi-utils";
-import { detectColorMode, resolveThemeColors } from "./color";
+import { deriveUserMessageTextDefault, detectColorMode, resolveThemeColors } from "./color";
 import darkThemeJson from "./dark.json" with { type: "json" };
 import { defaultThemes } from "./defaults";
 import lightThemeJson from "./light.json" with { type: "json" };
@@ -156,6 +156,9 @@ export function createTheme(themeJson: ThemeJson, options: CreateThemeOptions = 
 		}
 	}
 
+	// #1633: unset userMessageText renders user input identically to assistant
+	// output. Default it to the accent when that stays readable on the bubble.
+	resolvedColors.userMessageText = deriveUserMessageTextDefault(resolvedColors);
 	const fgColors: Record<ThemeColor, string | number> = {} as Record<ThemeColor, string | number>;
 	const bgColors: Record<ThemeBg, string | number> = {} as Record<ThemeBg, string | number>;
 	const bgColorKeys: Set<string> = new Set([

--- a/packages/coding-agent/src/modes/theme/loader.ts
+++ b/packages/coding-agent/src/modes/theme/loader.ts
@@ -158,7 +158,7 @@ export function createTheme(themeJson: ThemeJson, options: CreateThemeOptions = 
 
 	// #1633: unset userMessageText renders user input identically to assistant
 	// output. Default it to the accent when that stays readable on the bubble.
-	resolvedColors.userMessageText = deriveUserMessageTextDefault(resolvedColors);
+	resolvedColors.userMessageText = deriveUserMessageTextDefault(resolvedColors, undefined, colorMode);
 	const fgColors: Record<ThemeColor, string | number> = {} as Record<ThemeColor, string | number>;
 	const bgColors: Record<ThemeBg, string | number> = {} as Record<ThemeBg, string | number>;
 	const bgColorKeys: Set<string> = new Set([

--- a/packages/coding-agent/src/modes/theme/theme.ts
+++ b/packages/coding-agent/src/modes/theme/theme.ts
@@ -3,6 +3,7 @@ import * as path from "node:path";
 import { detectMacOSAppearance, MacAppearanceObserver } from "@oh-my-pi/pi-natives";
 import type { Terminal, TerminalAppearance } from "@oh-my-pi/pi-tui";
 import { colorLuma, getCustomThemesDir, logger } from "@oh-my-pi/pi-utils";
+import { exportUserMessageSurface } from "../../export/html/export-surface";
 import { ansi256ToHex, deriveUserMessageTextDefault, resolveThemeColors, resolveVarRefs } from "./color";
 import { type CreateThemeOptions, getBuiltinThemes, loadTheme, loadThemeJson, loadThemeSync } from "./loader";
 import type { ThemeColor, ThemeJson } from "./schema";
@@ -718,7 +719,23 @@ export async function getResolvedThemeColors(themeName?: string): Promise<Record
 	const themeJson = await loadThemeJson(name);
 	const exportColors = resolveThemeExportColors(themeJson);
 	const resolved = resolveThemeColors(themeJson.colors, themeJson.vars);
-	resolved.userMessageText = deriveUserMessageTextDefault(resolved);
+	// #10344 review: the exported .user-message paints color-mix(accent 6%,
+	// transparent) over --body-bg, NOT userMessageBg — guard the derived accent
+	// against that actual surface (dark-slate clears 3:1 on the TUI bubble but
+	// only reaches ~2.9:1 on the export surface).
+	const toHex = (value: string | number | undefined): string | undefined => {
+		if (value === undefined || value === "") return undefined;
+		return typeof value === "number" ? ansi256ToHex(value) : value;
+	};
+	const accentHex = toHex(resolved.accent);
+	const bubbleHex = toHex(resolved.userMessageBg);
+	resolved.userMessageText =
+		accentHex === undefined
+			? deriveUserMessageTextDefault(resolved)
+			: deriveUserMessageTextDefault(
+					resolved,
+					exportUserMessageSurface(accentHex, exportColors.pageBg, bubbleHex ?? ""),
+				);
 
 	// Empty foreground tokens use the terminal default color. In HTML export,
 	// custom light themes can still export dark transcript cards when they omit

--- a/packages/coding-agent/src/modes/theme/theme.ts
+++ b/packages/coding-agent/src/modes/theme/theme.ts
@@ -3,7 +3,7 @@ import * as path from "node:path";
 import { detectMacOSAppearance, MacAppearanceObserver } from "@oh-my-pi/pi-natives";
 import type { Terminal, TerminalAppearance } from "@oh-my-pi/pi-tui";
 import { colorLuma, getCustomThemesDir, logger } from "@oh-my-pi/pi-utils";
-import { ansi256ToHex, resolveThemeColors, resolveVarRefs } from "./color";
+import { ansi256ToHex, deriveUserMessageTextDefault, resolveThemeColors, resolveVarRefs } from "./color";
 import { type CreateThemeOptions, getBuiltinThemes, loadTheme, loadThemeJson, loadThemeSync } from "./loader";
 import type { ThemeColor, ThemeJson } from "./schema";
 import type { SymbolPreset } from "./symbols";
@@ -718,9 +718,9 @@ export async function getResolvedThemeColors(themeName?: string): Promise<Record
 	const themeJson = await loadThemeJson(name);
 	const exportColors = resolveThemeExportColors(themeJson);
 	const resolved = resolveThemeColors(themeJson.colors, themeJson.vars);
+	resolved.userMessageText = deriveUserMessageTextDefault(resolved);
 
 	// Empty foreground tokens use the terminal default color. In HTML export,
-	// that default must contrast the export surface, not the TUI status line:
 	// custom light themes can still export dark transcript cards when they omit
 	// `export`, because generateThemeVars derives those cards from userMessageBg.
 	const defaultText = getHtmlDefaultTextForSurface(

--- a/packages/coding-agent/test/modes/theme/user-message-text-default.test.ts
+++ b/packages/coding-agent/test/modes/theme/user-message-text-default.test.ts
@@ -39,6 +39,20 @@ describe("userMessageText derived default", () => {
 		expect(birch.getFgOnBgAnsi("userMessageText", "userMessageBg")).toBe("\x1b[38;2;40;40;32m");
 	});
 
+	it("guards against 256-color quantization of the rendered palette", async () => {
+		// limestone passes 3.38:1 in truecolor but its quantized palette colors
+		// (137 on 255) only reach 2.80:1, so the 256-color terminal keeps the
+		// contrast fallback while the truecolor terminal derives the accent.
+		const json = getBuiltinThemes().limestone;
+		if (!json) throw new Error("limestone theme is unavailable");
+		const truecolor = createTheme(json, { mode: "truecolor" });
+		const quantized = createTheme(json, { mode: "256color" });
+
+		expect(truecolor.getFgOnBgAnsi("userMessageText", "userMessageBg")).toBe(truecolor.getFgAnsi("accent"));
+		expect(quantized.getFgOnBgAnsi("userMessageText", "userMessageBg")).toBe("\x1b[38;5;16m");
+		expect(quantized.getFgOnBgAnsi("userMessageText", "userMessageBg")).not.toBe(quantized.getFgAnsi("accent"));
+	});
+
 	it("feeds the derived accent into HTML export colors", async () => {
 		const dark = await getResolvedThemeColors("dark");
 

--- a/packages/coding-agent/test/modes/theme/user-message-text-default.test.ts
+++ b/packages/coding-agent/test/modes/theme/user-message-text-default.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "bun:test";
+import { createTheme, getBuiltinThemes, loadTheme } from "../../../src/modes/theme/loader";
+import { getResolvedThemeColors } from "../../../src/modes/theme/theme";
+
+// #1633: an unset `userMessageText` painted user input with the terminal
+// default, making user and assistant turns indistinguishable. Unset tokens now
+// inherit the theme accent while that stays readable on the bubble background.
+describe("userMessageText derived default", () => {
+	it("inherits the accent when it contrasts the bubble background", async () => {
+		const dark = await loadTheme("dark", { mode: "truecolor" });
+
+		expect(dark.getFgOnBgAnsi("userMessageText", "userMessageBg")).toBe(dark.getFgAnsi("accent"));
+	});
+
+	it("keeps the terminal default when the accent matches the bubble", async () => {
+		// porcelain uses the same color for accent and userMessageBg (contrast 1.0).
+		const porcelain = await loadTheme("porcelain", { mode: "truecolor" });
+
+		expect(porcelain.getFgOnBgAnsi("userMessageText", "userMessageBg")).toBe("\x1b[38;2;229;229;231m");
+	});
+	it("keeps the terminal default when the bubble background is also default", () => {
+		const darkJson = getBuiltinThemes().dark;
+		if (!darkJson) throw new Error("dark theme is unavailable");
+		const theme = createTheme(
+			{
+				...darkJson,
+				colors: { ...darkJson.colors, userMessageBg: "", userMessageText: "" },
+			},
+			{ mode: "truecolor" },
+		);
+
+		expect(theme.getFgOnBgAnsi("userMessageText", "userMessageBg")).toBe("\x1b[39m");
+	});
+
+	it("prefers an explicit token over the derived accent", async () => {
+		const birch = await loadTheme("birch", { mode: "truecolor" });
+
+		expect(birch.getFgOnBgAnsi("userMessageText", "userMessageBg")).not.toBe(birch.getFgAnsi("accent"));
+		expect(birch.getFgOnBgAnsi("userMessageText", "userMessageBg")).toBe("\x1b[38;2;40;40;32m");
+	});
+
+	it("feeds the derived accent into HTML export colors", async () => {
+		const dark = await getResolvedThemeColors("dark");
+		const porcelain = await getResolvedThemeColors("porcelain");
+
+		expect(dark.userMessageText).toBe("#febc38");
+		// Unchanged theme keeps the export text fallback.
+		expect(porcelain.userMessageText).toBe(porcelain.text);
+	});
+});

--- a/packages/coding-agent/test/modes/theme/user-message-text-default.test.ts
+++ b/packages/coding-agent/test/modes/theme/user-message-text-default.test.ts
@@ -41,10 +41,19 @@ describe("userMessageText derived default", () => {
 
 	it("feeds the derived accent into HTML export colors", async () => {
 		const dark = await getResolvedThemeColors("dark");
-		const porcelain = await getResolvedThemeColors("porcelain");
 
 		expect(dark.userMessageText).toBe("#febc38");
-		// Unchanged theme keeps the export text fallback.
-		expect(porcelain.userMessageText).toBe(porcelain.text);
+	});
+
+	it("guards the export derivation against the exported surface, not the bubble", async () => {
+		// dark-slate: accent 3.10:1 on userMessageBg but ~2.9:1 on the exported
+		// 6%-accent-over-bodyBg surface, so the export keeps the readable fallback
+		// while the TUI still derives. porcelain inverts: its accent equals the
+		// bubble (TUI keeps the fallback) but clears 3:1 on the light export page.
+		const darkSlate = await getResolvedThemeColors("dark-slate");
+		const porcelain = await getResolvedThemeColors("porcelain");
+
+		expect(darkSlate.userMessageText).toBe(darkSlate.text);
+		expect(porcelain.userMessageText).toBe(porcelain.accent);
 	});
 });

--- a/packages/coding-agent/test/theme-islight.test.ts
+++ b/packages/coding-agent/test/theme-islight.test.ts
@@ -51,15 +51,16 @@ describe("empty foreground contrast", () => {
 		const { light, dark } = createBaseThemes();
 
 		expect(light.getFgAnsi("text")).toBe("\x1b[39m");
-		expect(light.getFgAnsi("userMessageText")).toBe("\x1b[39m");
 		expect(dark.getFgAnsi("text")).toBe("\x1b[39m");
 	});
 
 	it("chooses empty-token contrast from the controlled background", () => {
 		const { light } = createBaseThemes();
 		const porcelain = createTheme(defaultThemes.porcelain, { mode: "truecolor" });
-
-		expect(light.getFgOnBgAnsi("userMessageText", "userMessageBg")).toBe("\x1b[38;2;0;0;0m");
+		// light derives userMessageText from its accent (#5a8080, contrast 3.55
+		// on the #e8e8e8 bubble); porcelain's accent IS its bubble color, so it
+		// keeps the terminal default and the near-white fallback.
+		expect(light.getFgOnBgAnsi("userMessageText", "userMessageBg")).toBe("\x1b[38;2;90;128;128m");
 		expect(porcelain.getFgOnBgAnsi("userMessageText", "userMessageBg")).toBe("\x1b[38;2;229;229;231m");
 	});
 
@@ -91,8 +92,7 @@ describe("empty foreground contrast", () => {
 			setThemeInstance(light);
 			const surfaceColor = getEditorTheme().surfaceColor;
 			if (!surfaceColor) throw new Error("Editor surface color is unavailable");
-
-			expect(surfaceColor("typed")).toContain("\x1b[48;2;232;232;232m\x1b[38;2;0;0;0mtyped");
+			expect(surfaceColor("typed")).toContain("\x1b[48;2;232;232;232m\x1b[38;2;90;128;128mtyped");
 		} finally {
 			setThemeInstance(dark);
 		}
@@ -138,8 +138,8 @@ describe("empty foreground contrast", () => {
 			if (!surfaceColor) throw new Error("Editor surface color is unavailable");
 
 			const styled = surfaceColor("before\x1b[39mafter-default\x1b[0mafter-full");
-			expect(styled).toContain("\x1b[39m\x1b[38;2;0;0;0mafter-default");
-			expect(styled).toContain("\x1b[0m\x1b[48;2;232;232;232m\x1b[38;2;0;0;0mafter-full");
+			expect(styled).toContain("\x1b[39m\x1b[38;2;90;128;128mafter-default");
+			expect(styled).toContain("\x1b[0m\x1b[48;2;232;232;232m\x1b[38;2;90;128;128mafter-full");
 		} finally {
 			setThemeInstance(dark);
 		}
@@ -170,7 +170,7 @@ describe("getResolvedThemeColors HTML export defaults", () => {
 	it("uses near-black for empty text tokens on light themes", async () => {
 		const colors = await getResolvedThemeColors("sandstone");
 		expect(colors.text).toBe("#000000");
-		expect(colors.userMessageText).toBe("#000000");
+		expect(colors.userMessageText).toBe("#b86040");
 		expect(colors.customMessageText).toBe("#000000");
 		expect(colors.toolTitle).toBe("#000000");
 	});
@@ -178,7 +178,7 @@ describe("getResolvedThemeColors HTML export defaults", () => {
 	it("uses light grey for empty text tokens on dark themes", async () => {
 		const colors = await getResolvedThemeColors("dark");
 		expect(colors.text).toBe("#e5e5e7");
-		expect(colors.userMessageText).toBe("#e5e5e7");
+		expect(colors.userMessageText).toBe("#febc38");
 	});
 	let tempAgentDir: string | undefined;
 	let originalAgentDir = "";


### PR DESCRIPTION
Closes #1633.

## Problem

93 of 99 built-in themes leave `userMessageText` unset (`""`). The token exists and the bubble renderer already consumes it (`UserMessageComponent` → `theme.fgOnBg("userMessageText", "userMessageBg", …)`), but unset, `Theme.getFgOnBgAnsi` resolves it to a contrast-safe near-black/near-white — effectively the same foreground as assistant text. The only remaining cue is the bubble tint, which is nearly invisible in the dark family (`userMsgBg` `#221d1a` on a near-black terminal), so user and assistant turns are hard to tell apart.

## Change

Derive the unset token at resolution time instead of curating 93 theme files:

- `deriveUserMessageTextDefault()` in `src/modes/theme/color.ts`: when `userMessageText` is unset and the theme accent keeps a WCAG contrast ratio ≥ 3:1 against `userMessageBg`, inherit the accent; otherwise keep the terminal default so the existing near-black/near-white fallback still applies.
- Wired into both resolution paths — `createTheme()` (TUI) and `getResolvedThemeColors()` (HTML export) — so the live transcript and exported HTML agree.
- Explicit theme values always win; the six themes that already set the token (`birch`, `dark/light-poimandres`, `light-cyberpunk`, `light-retro`) render exactly as before.

## Why the contrast guard

Measured across every built-in theme (accent vs. bubble background): 69/92 unset-token themes pass 3:1 — including the entire dark family, where the complaint is loudest (`dark`: amber `#febc38` on `#221d1a`, ratio 9.9). The other 23 fail the bar (`porcelain` is 1.00 — its accent *is* its bubble color — plus most `light-*` themes whose bubbles are visible accent tints with dark text) and keep today's readable rendering; those stay overridable by setting the token.

This answers the triage questions: existing theme tokens (no new knob), applied to the message body, with the current contrast-safe fallback retained as the poor-contrast path.

## Verification

- `bun run check` (biome + `tsgo`) clean.
- `bun test test/modes/theme/ test/theme-islight.test.ts` — 40/40 pass; `theme-islight` assertions updated to the new contract (dark export `#febc38`, sandstone `#b86040`, light surfaces accent `#5a8080`; porcelain fallbacks unchanged).
- New `test/modes/theme/user-message-text-default.test.ts` covers accent inheritance (dark), guard rejection (porcelain), the default-background escape hatch, explicit-token precedence (birch), and HTML export propagation.
- `export-html-themes`, `export-html-markdown`, `composer-cache`, `composer-shape-preview` suites pass. The `export-html-template` / `startup-composer` failures in this sandbox reproduce identically on a clean `origin/main` (missing native bundle paths), i.e. pre-existing and unrelated.

`docs/theme.md` documents the derived default.

Side observation, not addressed here: loading the built-in `onyx` theme throws `Variable reference not found: $vein` on `origin/main` — its colors use `$`-prefixed var refs that `resolveVarRefs` does not strip (while `resolveThemeExportColors` does). Happy to fix separately if wanted.
