### PR TITLE
fix(task): stop classifying agents that declare `hub` as read-only

### DIFF
--- a/packages/coding-agent/src/task/read-only-policy.ts
+++ b/packages/coding-agent/src/task/read-only-policy.ts
@@ -3,6 +3,10 @@ import type { AgentDefinition } from "./types";
 // Built-in tools whose approval tier is "read" (see tool classes' `approval`).
 // An agent is read-only iff its declared tools are a non-empty subset of this set.
 // Fail-safe: any unknown tool makes the agent not read-only.
+//
+// `hub` is deliberately absent: it declares `approval = hubApproval`, a
+// parameter-dependent function that returns "exec" for start/stop/restart,
+// process-stdin `send`, unrecognized ops and malformed params. Do not re-add it.
 export const READ_ONLY_TOOL_NAMES: ReadonlySet<string> = new Set([
 	"read",
 	"grep",
@@ -10,7 +14,6 @@ export const READ_ONLY_TOOL_NAMES: ReadonlySet<string> = new Set([
 	"web_search",
 	"ast_grep",
 	"yield",
-	"hub",
 	"ask",
 	"todo",
 	"recall",

--- a/packages/coding-agent/test/config-value-fd-inheritance.test.ts
+++ b/packages/coding-agent/test/config-value-fd-inheritance.test.ts
@@ -36,6 +36,31 @@ afterEach(async () => {
 	for (const root of roots.splice(0)) await fs.promises.rm(root, { recursive: true, force: true });
 });
 
+/**
+ * Sample a doomed descendant's status until it actually leaves the run queue.
+ *
+ * `runShellCommand` returns once the timeout kill has been issued, but signal
+ * delivery and reaping are asynchronous: on a loaded runner (4 cores, four test
+ * chunks in parallel) a killed pid can still sample as `Running` for a few
+ * scheduler ticks. Reading `status()` exactly once therefore races the kernel
+ * rather than the product contract, which made these two tests flaky in CI.
+ *
+ * Polling costs nothing on green and preserves the oracle: both escape workers
+ * `sleep 30`, so a descendant that genuinely survived the timeout is still
+ * `Running` when the deadline expires and the assertion still fails. This
+ * mirrors the bounded-poll idiom the marker-based tests below already use for
+ * exactly the same reason.
+ */
+async function waitForExit(proc: Process | null, timeoutMs = 2_000): Promise<ProcessStatus | undefined> {
+	const deadline = Date.now() + timeoutMs;
+	let status = proc?.status();
+	while (status === ProcessStatus.Running && Date.now() < deadline) {
+		await Bun.sleep(50);
+		status = proc?.status();
+	}
+	return status;
+}
+
 test.skipIf(process.platform === "win32")(
 	"config !command children cannot read descriptors the launcher passed omp",
 	async () => {
@@ -124,7 +149,9 @@ test.skipIf(process.platform === "win32")(
 
 			const pid = Number.parseInt((await Bun.file(pidFile).text()).trim(), 10);
 			escaped = Process.fromPid(pid);
-			expect(escaped?.status(), `reparented descendant ${pid} survived the timeout`).not.toBe(ProcessStatus.Running);
+			expect(await waitForExit(escaped), `reparented descendant ${pid} survived the timeout`).not.toBe(
+				ProcessStatus.Running,
+			);
 		} finally {
 			escaped?.killTree(9);
 		}
@@ -151,7 +178,7 @@ test.skipIf(process.platform !== "linux")(
 
 			const pid = Number.parseInt((await Bun.file(pidFile).text()).trim(), 10);
 			escaped = Process.fromPid(pid);
-			expect(escaped?.status(), `session-escaping descendant ${pid} survived the timeout`).not.toBe(
+			expect(await waitForExit(escaped), `session-escaping descendant ${pid} survived the timeout`).not.toBe(
 				ProcessStatus.Running,
 			);
 		} finally {

--- a/packages/coding-agent/test/tools/browser-tab-worker-startup.test.ts
+++ b/packages/coding-agent/test/tools/browser-tab-worker-startup.test.ts
@@ -15,9 +15,13 @@ import {
 	initializeTabWorkerForTest,
 	releaseTab,
 } from "@oh-my-pi/pi-coding-agent/tools/browser/tab-supervisor";
-import { chromiumAvailable } from "./chromium-probe";
+import { chromiumAvailable, headfulChromiumAvailable } from "./chromium-probe";
 
 const CHROMIUM_AVAILABLE = await chromiumAvailable();
+// Headful launches additionally need a display; `CHROMIUM_AVAILABLE` alone lets
+// them through on a display-less runner and Puppeteer then throws "Missing X
+// server to start the headful browser".
+const HEADFUL_AVAILABLE = await headfulChromiumAvailable();
 
 class FakeStartupWorker {
 	#errorHandlers = new Set<(error: Error) => void>();
@@ -217,7 +221,7 @@ describe("browser init deadline carry-over", () => {
 	);
 });
 describe("visible OMP-owned browser tabs", () => {
-	it.skipIf(!CHROMIUM_AVAILABLE)(
+	it.skipIf(!HEADFUL_AVAILABLE)(
 		"creates independent pages without pinning the resizable window viewport",
 		async () => {
 			let browser: BrowserHandle | undefined;

--- a/packages/coding-agent/test/tools/chromium-probe.ts
+++ b/packages/coding-agent/test/tools/chromium-probe.ts
@@ -48,3 +48,33 @@ export function chromiumAvailable(): Promise<boolean> {
 	probe ??= chromiumCanLaunch();
 	return probe;
 }
+
+/**
+ * Whether this host can present a browser window at all.
+ *
+ * Mirrors `hasDisplay()` in `src/utils/clipboard.ts`: on Linux a GUI process
+ * needs an X11 or Wayland server, and headless CI runners have neither. Every
+ * other platform runs its tests from a desktop session.
+ */
+function hasDisplay(): boolean {
+	return process.platform !== "linux" || Boolean(process.env.DISPLAY || process.env.WAYLAND_DISPLAY);
+}
+
+let headfulProbe: Promise<boolean> | undefined;
+
+/**
+ * Gate for tests that launch Chromium *headful* (`headless: false`).
+ *
+ * `chromiumAvailable()` is necessary but not sufficient here: its probe is
+ * `chrome --version`, which needs no display and so still reports `true` on a
+ * display-less runner. A headful suite gated on it therefore clears the skip
+ * and then dies inside Puppeteer with "Missing X server to start the headful
+ * browser. Either set headless to true or use xvfb-run to run your Puppeteer
+ * script." (`BrowserLauncher.js:160`), which reads as a product failure rather
+ * than the environment gap it is. Headful needs a working binary *and* a
+ * display, so require both.
+ */
+export function headfulChromiumAvailable(): Promise<boolean> {
+	headfulProbe ??= hasDisplay() ? chromiumAvailable() : Promise.resolve(false);
+	return headfulProbe;
+}

--- a/packages/coding-agent/test/tools/task-agent-capabilities.test.ts
+++ b/packages/coding-agent/test/tools/task-agent-capabilities.test.ts
@@ -19,6 +19,19 @@ describe("task agent capability descriptions", () => {
 		}
 	});
 
+	it("does not classify an agent declaring `hub` as read-only", () => {
+		// `hub` resolves to exec approval for start/stop/restart, process-stdin
+		// `send`, unrecognized ops and malformed params, so declaring it must
+		// disqualify an agent from the read-only label surfaced to the model.
+		const scout = agentByName(loadBundledAgents(), "scout");
+
+		expect(isReadOnlyAgent({ ...scout, tools: ["read", "grep", "hub", "yield"] })).toBe(false);
+		expect(isReadOnlyAgent({ ...scout, tools: ["hub"] })).toBe(false);
+
+		// Guard against over-correcting: the positive case must still hold.
+		expect(isReadOnlyAgent({ ...scout, tools: ["read", "grep", "yield"] })).toBe(true);
+	});
+
 	it("disables read summarization for scout and librarian, leaves other agents summarizing", () => {
 		const agents = loadBundledAgents();
 


### PR DESCRIPTION
Draft, opened to make the proposal on #7061 concrete. Happy to close it if you'd rather keep that issue whole and land this under a narrower one — the scoping question is asked in [this comment](https://github.com/can1357/oh-my-pi/issues/7061#issuecomment-5474113439).

## The defect

`packages/coding-agent/src/task/read-only-policy.ts` documents its own membership rule directly above the set:

> Built-in tools whose approval tier is `"read"` (see tool classes' `approval`).

`"hub"` was a member and does not satisfy that rule. `HubTool` declares `readonly approval = hubApproval` — a *parameter-dependent function*, not a static tier — and it returns `"exec"` for:

| Input | Returns |
|---|---|
| `op: "start"` / `"stop"` / `"restart"` | `exec` |
| `op: "send"` with a process `name` and no `to` (stdin write) | `exec` |
| any unrecognized op, or params with no `op` | `exec` |

`hubApproval`'s own doc comment states it: *"Mutating process ops require exec approval; messaging, jobs, and inspection are read-only."*

## Why it matters

`isReadOnlyAgent()` isn't cosmetic — its result is surfaced as `readOnly` by three call sites:

| Call site | Surface |
|---|---|
| `src/task/index.ts` | the `task` tool's agent listing — **model-visible** |
| `src/task/executor.ts` | alongside `resolvedModel` / `spawnsEnv` |
| `src/registry/persisted-agents.ts` | persisted registry entry |

So an agent declaring `tools: read, grep, glob, hub` was advertised as **read-only** while retaining `hub op:"start"`, whose schema accepts `application`, `args`, `env`, `cwd`, `pty`, `persist` and `detached`. That is the process-execution path reproduced in #10257.

The stated fail-safe — "any unknown tool makes the agent not read-only" — was defeated not by an *unknown* tool but by a **known tool that was mis-tiered**.

## The change

One line of behaviour: `"hub"` removed from `READ_ONLY_TOOL_NAMES`, plus a comment recording *why* it's excluded so it isn't re-added by someone reading the list as a convenience allowlist.

## No bundled agent regresses

Every bundled agent's `tools:` frontmatter, read directly:

| Agent | `tools:` | before | after |
|---|---|---|---|
| `scout` | `read, grep, glob, web_search` | `true` | **`true`** |
| `security-reviewer` | `read, grep, glob, lsp, ast_grep` | `false` (`lsp`) | `false` |
| `reviewer` | `read, grep, glob, bash, lsp, web_search, ast_grep` | `false` | `false` |
| `librarian` | `read, grep, glob, bash, lsp, web_search, ast_grep` | `false` | `false` |
| `task` / `sonic` | none declared | `false` | `false` |

**No bundled agent declares `hub`**, and `parseAgentFields()` in `src/discovery/helpers.ts` only ever auto-injects `"yield"` into an explicit list — never `hub`. So `hub` can only appear in `agent.tools` if the author typed it. The existing assertions in `task-agent-capabilities.test.ts` (`scout === true`, others `false`) are unaffected.

The only agents whose classification changes are user- and plugin-defined agents that explicitly declare `hub` — precisely the mislabelled population.

## Test

New case in `test/tools/task-agent-capabilities.test.ts`: an agent declaring `hub` is not read-only, an agent declaring `["hub"]` alone is not read-only, and — guarding against over-correction — `["read", "grep", "yield"]` still is.

## Scope — what this does *not* fix

1. **The undeclared-grant half of #7061.** #10257's agent never declared `hub` and received it anyway. Lead: `HubTool` sets `readonly loadMode = "essential"`, so the baseline looks like it's assembled from load mode rather than the agent allowlist. Whether "essential" should outrank an explicit `tools:` list is a semantics call for you, not a drive-by change.
2. **#7061 problem 1 (unknown names silently dropped).** `normalizeToolName()` already maps `search` → `grep` and `find` → `glob`, and passes unknown names through *by design* so plugin tools survive. The gap is that nothing warns at agent load when a passed-through name matches no registered tool — a cheap, separate fix.

## Drift note (not fixed here)

`scripts/tool-prompt-usage.ts` keeps its **own private copy** of `READ_ONLY_TOOL_NAMES` as a `Record<string, true>`. It will silently diverge from the canonical set. Flagged rather than touched; consolidating them is a separate change if you want it.

Refs #7061, #10257