### PR TITLE
test(browser): gate the headful tab test on an actual display, not just a Chromium binary

### DIFF
--- a/packages/coding-agent/test/tools/browser-tab-worker-startup.test.ts
+++ b/packages/coding-agent/test/tools/browser-tab-worker-startup.test.ts
@@ -15,9 +15,13 @@ import {
 	initializeTabWorkerForTest,
 	releaseTab,
 } from "@oh-my-pi/pi-coding-agent/tools/browser/tab-supervisor";
-import { chromiumAvailable } from "./chromium-probe";
+import { chromiumAvailable, headfulChromiumAvailable } from "./chromium-probe";
 
 const CHROMIUM_AVAILABLE = await chromiumAvailable();
+// Headful launches additionally need a display; `CHROMIUM_AVAILABLE` alone lets
+// them through on a display-less runner and Puppeteer then throws "Missing X
+// server to start the headful browser".
+const HEADFUL_AVAILABLE = await headfulChromiumAvailable();
 
 class FakeStartupWorker {
 	#errorHandlers = new Set<(error: Error) => void>();
@@ -217,7 +221,7 @@ describe("browser init deadline carry-over", () => {
 	);
 });
 describe("visible OMP-owned browser tabs", () => {
-	it.skipIf(!CHROMIUM_AVAILABLE)(
+	it.skipIf(!HEADFUL_AVAILABLE)(
 		"creates independent pages without pinning the resizable window viewport",
 		async () => {
 			let browser: BrowserHandle | undefined;

--- a/packages/coding-agent/test/tools/chromium-probe.ts
+++ b/packages/coding-agent/test/tools/chromium-probe.ts
@@ -48,3 +48,33 @@ export function chromiumAvailable(): Promise<boolean> {
 	probe ??= chromiumCanLaunch();
 	return probe;
 }
+
+/**
+ * Whether this host can present a browser window at all.
+ *
+ * Mirrors `hasDisplay()` in `src/utils/clipboard.ts`: on Linux a GUI process
+ * needs an X11 or Wayland server, and headless CI runners have neither. Every
+ * other platform runs its tests from a desktop session.
+ */
+function hasDisplay(): boolean {
+	return process.platform !== "linux" || Boolean(process.env.DISPLAY || process.env.WAYLAND_DISPLAY);
+}
+
+let headfulProbe: Promise<boolean> | undefined;
+
+/**
+ * Gate for tests that launch Chromium *headful* (`headless: false`).
+ *
+ * `chromiumAvailable()` is necessary but not sufficient here: its probe is
+ * `chrome --version`, which needs no display and so still reports `true` on a
+ * display-less runner. A headful suite gated on it therefore clears the skip
+ * and then dies inside Puppeteer with "Missing X server to start the headful
+ * browser. Either set headless to true or use xvfb-run to run your Puppeteer
+ * script." (`BrowserLauncher.js:160`), which reads as a product failure rather
+ * than the environment gap it is. Headful needs a working binary *and* a
+ * display, so require both.
+ */
+export function headfulChromiumAvailable(): Promise<boolean> {
+	headfulProbe ??= hasDisplay() ? chromiumAvailable() : Promise.resolve(false);
+	return headfulProbe;
+}


### PR DESCRIPTION
## Summary

`ci:test:coding-agent:native` is red on **every** PR right now. Chunk 56/74 fails with one test:

```
✗ test/tools/browser-tab-worker-startup.test.ts > visible OMP-owned browser tabs >
  creates independent pages without pinning the resizable window viewport

error: Missing X server to start the headful browser. Either set headless to true
       or use xvfb-run to run your Puppeteer script.
  at launch (node_modules/puppeteer-core/lib/puppeteer/node/BrowserLauncher.js:160:27)
  at async launchHeadlessBrowser (packages/coding-agent/src/tools/browser/launch.ts:485:35)
  at async openBrowserHandle (packages/coding-agent/src/tools/browser/registry.ts:185:42)
```

This is an environment gap wearing a product failure's clothes, and it is the only thing between that bucket and green.

## Root cause

The test is gated on `CHROMIUM_AVAILABLE`, but it launches **headful**:

```ts
it.skipIf(!CHROMIUM_AVAILABLE)(
  "creates independent pages without pinning the resizable window viewport",
  async () => {
    browser = await acquireBrowser({ kind: "headless", headless: false }, { cwd: process.cwd() });
```

`chromiumAvailable()` resolves `chromiumCanLaunch()`, whose probe is:

```ts
const probe = Bun.spawnSync([executable, "--version"], { stdout: "ignore", stderr: "ignore" });
return probe.exitCode === 0;
```

`chrome --version` needs **no display**. On a GitHub runner — Chromium installed, no X server, no `xvfb-run` — the probe returns `true`, the skip is cleared, and Puppeteer's own guard then throws:

```js
// BrowserLauncher.js:159-160
if (logs.includes('Missing X server') && options.headless === false) { throw ... }
```

So the gate tests the wrong capability. It answers *"can this binary execute?"* when the test needs *"can this host show a window?"*. The sibling test in the same `describe` launches `headless: true` and passes today, which confirms Chromium itself is fine on the runner.

## Fix

Extend the probe module rather than the CI image. `chromium-probe.ts` already exists to *"probe … and skip instead of failing"* when the environment can't support a launch — this is the same class of gap, one level further out.

Added `headfulChromiumAvailable()`: a headful launch needs a working binary **and** a display, so require both. The display check mirrors the existing repo idiom in `packages/coding-agent/src/utils/clipboard.ts`:

```ts
function hasDisplay(): boolean {
	return process.platform !== "linux" || Boolean(process.env.DISPLAY || process.env.WAYLAND_DISPLAY);
}
```

(`crates/pi-natives/src/desktop/linux/mod.rs` uses the same `WAYLAND_DISPLAY`/`DISPLAY` pair.) The result is memoized in a module-level promise for the same reason `chromiumAvailable()` is — an awaited top-level `export const` puts a second importing file in the binding's temporal dead zone.

## Scope

Deliberately minimal — **test-only, no production code touched**:

| File | Δ |
|---|---|
| `test/tools/chromium-probe.ts` | +30 / −0 (pure append) |
| `test/tools/browser-tab-worker-startup.test.ts` | +6 / −2 |

`search_code "headless: false" path:packages/coding-agent/test` returns **`total_count: 1`** — this is the only headful test in the package, so this one gate covers the whole failure mode.

**Only the headful test moves to the new gate.** Both headless tests (`"keeps deterministic viewport emulation for hidden launches"` and the deadline-carry-over suite) stay on `CHROMIUM_AVAILABLE` and keep running in CI. Coverage on a developer desktop or an `xvfb-run` runner is unchanged — `DISPLAY` is set there, so the test still executes exactly as before.

## Why not `xvfb-run`?

That's the other valid fix, and it's strictly better *if* the project wants headful coverage enforced in CI. It costs an apt install, adds wall-clock to an already 166 s bucket, and headful-under-Xvfb is a known flake source. Happy to switch to that approach instead if you'd prefer the coverage over the speed — say the word and I'll rework it.

## Verification

I can't run `bun test` in my environment, so I'm marking this **draft** and leaning on CI for the signal. The expected result is chunk 56/74 reporting the headful test as *skipped* and the bucket passing 74/74.

---

Filed while working on #7061 (see #10345) — that PR's lint/typecheck is green and only this pre-existing failure is red on it, identically to #10343 and #10336.
