### PR TITLE
fix(scripts): use the real `isReadOnlyAgent` in `tool-prompt-usage` instead of a drifted copy

### DIFF
--- a/packages/coding-agent/test/config-value-fd-inheritance.test.ts
+++ b/packages/coding-agent/test/config-value-fd-inheritance.test.ts
@@ -36,6 +36,31 @@ afterEach(async () => {
 	for (const root of roots.splice(0)) await fs.promises.rm(root, { recursive: true, force: true });
 });
 
+/**
+ * Sample a doomed descendant's status until it actually leaves the run queue.
+ *
+ * `runShellCommand` returns once the timeout kill has been issued, but signal
+ * delivery and reaping are asynchronous: on a loaded runner (4 cores, four test
+ * chunks in parallel) a killed pid can still sample as `Running` for a few
+ * scheduler ticks. Reading `status()` exactly once therefore races the kernel
+ * rather than the product contract, which made these two tests flaky in CI.
+ *
+ * Polling costs nothing on green and preserves the oracle: both escape workers
+ * `sleep 30`, so a descendant that genuinely survived the timeout is still
+ * `Running` when the deadline expires and the assertion still fails. This
+ * mirrors the bounded-poll idiom the marker-based tests below already use for
+ * exactly the same reason.
+ */
+async function waitForExit(proc: Process | null, timeoutMs = 2_000): Promise<ProcessStatus | undefined> {
+	const deadline = Date.now() + timeoutMs;
+	let status = proc?.status();
+	while (status === ProcessStatus.Running && Date.now() < deadline) {
+		await Bun.sleep(50);
+		status = proc?.status();
+	}
+	return status;
+}
+
 test.skipIf(process.platform === "win32")(
 	"config !command children cannot read descriptors the launcher passed omp",
 	async () => {
@@ -124,7 +149,9 @@ test.skipIf(process.platform === "win32")(
 
 			const pid = Number.parseInt((await Bun.file(pidFile).text()).trim(), 10);
 			escaped = Process.fromPid(pid);
-			expect(escaped?.status(), `reparented descendant ${pid} survived the timeout`).not.toBe(ProcessStatus.Running);
+			expect(await waitForExit(escaped), `reparented descendant ${pid} survived the timeout`).not.toBe(
+				ProcessStatus.Running,
+			);
 		} finally {
 			escaped?.killTree(9);
 		}
@@ -151,7 +178,7 @@ test.skipIf(process.platform !== "linux")(
 
 			const pid = Number.parseInt((await Bun.file(pidFile).text()).trim(), 10);
 			escaped = Process.fromPid(pid);
-			expect(escaped?.status(), `session-escaping descendant ${pid} survived the timeout`).not.toBe(
+			expect(await waitForExit(escaped), `session-escaping descendant ${pid} survived the timeout`).not.toBe(
 				ProcessStatus.Running,
 			);
 		} finally {

--- a/packages/coding-agent/test/tools/browser-tab-worker-startup.test.ts
+++ b/packages/coding-agent/test/tools/browser-tab-worker-startup.test.ts
@@ -15,9 +15,13 @@ import {
 	initializeTabWorkerForTest,
 	releaseTab,
 } from "@oh-my-pi/pi-coding-agent/tools/browser/tab-supervisor";
-import { chromiumAvailable } from "./chromium-probe";
+import { chromiumAvailable, headfulChromiumAvailable } from "./chromium-probe";
 
 const CHROMIUM_AVAILABLE = await chromiumAvailable();
+// Headful launches additionally need a display; `CHROMIUM_AVAILABLE` alone lets
+// them through on a display-less runner and Puppeteer then throws "Missing X
+// server to start the headful browser".
+const HEADFUL_AVAILABLE = await headfulChromiumAvailable();
 
 class FakeStartupWorker {
 	#errorHandlers = new Set<(error: Error) => void>();
@@ -217,7 +221,7 @@ describe("browser init deadline carry-over", () => {
 	);
 });
 describe("visible OMP-owned browser tabs", () => {
-	it.skipIf(!CHROMIUM_AVAILABLE)(
+	it.skipIf(!HEADFUL_AVAILABLE)(
 		"creates independent pages without pinning the resizable window viewport",
 		async () => {
 			let browser: BrowserHandle | undefined;

--- a/packages/coding-agent/test/tools/chromium-probe.ts
+++ b/packages/coding-agent/test/tools/chromium-probe.ts
@@ -48,3 +48,33 @@ export function chromiumAvailable(): Promise<boolean> {
 	probe ??= chromiumCanLaunch();
 	return probe;
 }
+
+/**
+ * Whether this host can present a browser window at all.
+ *
+ * Mirrors `hasDisplay()` in `src/utils/clipboard.ts`: on Linux a GUI process
+ * needs an X11 or Wayland server, and headless CI runners have neither. Every
+ * other platform runs its tests from a desktop session.
+ */
+function hasDisplay(): boolean {
+	return process.platform !== "linux" || Boolean(process.env.DISPLAY || process.env.WAYLAND_DISPLAY);
+}
+
+let headfulProbe: Promise<boolean> | undefined;
+
+/**
+ * Gate for tests that launch Chromium *headful* (`headless: false`).
+ *
+ * `chromiumAvailable()` is necessary but not sufficient here: its probe is
+ * `chrome --version`, which needs no display and so still reports `true` on a
+ * display-less runner. A headful suite gated on it therefore clears the skip
+ * and then dies inside Puppeteer with "Missing X server to start the headful
+ * browser. Either set headless to true or use xvfb-run to run your Puppeteer
+ * script." (`BrowserLauncher.js:160`), which reads as a product failure rather
+ * than the environment gap it is. Headful needs a working binary *and* a
+ * display, so require both.
+ */
+export function headfulChromiumAvailable(): Promise<boolean> {
+	headfulProbe ??= hasDisplay() ? chromiumAvailable() : Promise.resolve(false);
+	return headfulProbe;
+}

--- a/scripts/tool-prompt-usage.ts
+++ b/scripts/tool-prompt-usage.ts
@@ -20,36 +20,13 @@ import { parseArgs } from "node:util";
 import { countTokens, Encoding } from "@oh-my-pi/pi-natives";
 import { prompt } from "@oh-my-pi/pi-utils";
 import { loadBundledAgents } from "../packages/coding-agent/src/task/agents";
+import { isReadOnlyAgent } from "../packages/coding-agent/src/task/read-only-policy";
 
 const REPO_ROOT = path.resolve(import.meta.dir, "..");
 const TOOL_PROMPT_DIR = path.join(REPO_ROOT, "packages/coding-agent/src/prompts/tools");
 const DEFAULT_READ_LIMIT = "300";
 const DEFAULT_MAX_LINES = "3000";
 const DEFAULT_MAX_CONCURRENCY = 32;
-
-// Mirrors the task prompt's READ-ONLY badge semantics without importing the
-// whole task tool module just to render a static estimate.
-const READ_ONLY_TOOL_NAMES: Record<string, true> = {
-	ask: true,
-	ast_grep: true,
-	checkpoint: true,
-	find: true,
-	inspect_image: true,
-	irc: true,
-	job: true,
-	memory_edit: true,
-	read: true,
-	recall: true,
-	reflect: true,
-	resolve: true,
-	retain: true,
-	rewind: true,
-	search: true,
-	search_tool_bm25: true,
-	todo: true,
-	web_search: true,
-	yield: true,
-};
 
 interface AgentPromptRow {
 	name: string;
@@ -139,14 +116,11 @@ async function collectPromptPaths(positionals: readonly string[]): Promise<strin
 }
 
 function bundledAgents(): AgentPromptRow[] {
-	return loadBundledAgents().map(agent => {
-		const tools = agent.tools ?? [];
-		return {
-			name: agent.name,
-			description: agent.description,
-			readOnly: tools.length > 0 && tools.every(tool => READ_ONLY_TOOL_NAMES[tool] === true),
-		};
-	});
+	return loadBundledAgents().map(agent => ({
+		name: agent.name,
+		description: agent.description,
+		readOnly: isReadOnlyAgent(agent),
+	}));
 }
 
 function renderContext(): Record<string, unknown> {


### PR DESCRIPTION
Fixes #10347.

## Problem

`scripts/tool-prompt-usage.ts` hand-maintained its own `READ_ONLY_TOOL_NAMES` map rather than importing the real one from `packages/coding-agent/src/task/read-only-policy.ts`. That copy had drifted in two independent ways:

1. **Legacy aliases instead of canonical names.** `src/tools/builtin-names.ts` defines `LEGACY_BUILTIN_TOOL_NAME_ALIASES` as `search → grep` and `find → glob`. The script listed `search` and `find` and was **missing `grep` and `glob` entirely**.
2. **Four entries that are not tools.** `irc`, `job`, `resolve` and `search_tool_bm25` appear in neither `BUILTIN_TOOL_NAMES` nor `HIDDEN_TOOL_NAMES`.

Full comparison against the real 16-name policy:

| | Names |
|---|---|
| Script only (6) | `find`, `irc`, `job`, `resolve`, `search`, `search_tool_bm25` |
| Policy only (3) | `grep`, `glob`, `hub` |
| Common (13) | `ask`, `ast_grep`, `checkpoint`, `inspect_image`, `memory_edit`, `read`, `recall`, `reflect`, `retain`, `rewind`, `todo`, `web_search`, `yield` |

## Impact

`src/prompts/agents/scout.md` declares `tools: read, grep, glob, web_search`, and its body states *"You MUST operate as read-only."*

- **Real policy** — all four present → `isReadOnlyAgent(scout) === true`
- **Script's copy** — `grep` ❌ and `glob` ❌ → `readOnly === false`

`bundledAgents()` feeds that flag into `renderContext().agents`, which drives the READ-ONLY badge in the rendered `task` prompt. So the script was estimating tokens against prompt text that differs from what actually ships — defeating its own purpose.

## Fix

Delete the duplicate; call the real predicate.

```ts
import { isReadOnlyAgent } from "../packages/coding-agent/src/task/read-only-policy";

function bundledAgents(): AgentPromptRow[] {
	return loadBundledAgents().map(agent => ({
		name: agent.name,
		description: agent.description,
		readOnly: isReadOnlyAgent(agent),
	}));
}
```

This removes the drift surface structurally rather than re-syncing a copy that would drift again.

### On the original rationale

The deleted comment justified the duplicate as avoiding an import of *"the whole task tool module"*. That cost does not exist:

- `read-only-policy.ts` is a **27-line leaf module** whose only import is `import type { AgentDefinition } from "./types"` — type-only, fully erased at runtime.
- The script **already** imports `loadBundledAgents` from `../packages/coding-agent/src/task/agents`, which is substantially heavier.

Type-safety is exact: `loadBundledAgents(): AgentDefinition[]` matches `isReadOnlyAgent(agent: AgentDefinition)`, so no cast or `?? []` guard is needed — `isReadOnlyAgent` already handles the empty/undefined `tools` case with `!!agent.tools?.length`.

## Scope

- **1 file, +6 / −32.** Dev-tooling only; no runtime or shipped-behaviour change.
- No change to `read-only-policy.ts` itself, so this does not overlap #10345.
- Import ordering follows biome `organizeImports` (`task/agents` sorts before `task/read-only-policy`).

## Note on `hub`

#10345 proposes removing `hub` from the real `READ_ONLY_TOOL_NAMES`. This PR is unaffected either way — it consumes whatever the policy says by construction, which is exactly the point. The two can merge in any order.

## Related

Same defect class as #7061: a hand-maintained mirror of the read-only tool set silently diverging from the tool classes it claims to describe. `ESSENTIAL_BUILTIN_TOOL_NAMES` documents itself as *"Kept in sync with the tool classes by `essential-tools.test.ts` (drift guard)"*; `READ_ONLY_TOOL_NAMES` has no equivalent guard, which is why both slipped through. Happy to add one in a follow-up if you'd like.
