### PR TITLE
feat(status-line): opt-in generation-only token rate (statusLine.tokenRateExcludesTtft)

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -679,6 +679,7 @@ tui:
 | `statusLine.sessionAccent`  | boolean | `true`           | Tint the editor border with the session color.                            |
 | `statusLine.transparent`    | boolean | `false`          | Use the terminal background for the status line.                          |
 | `statusLine.showHookStatus` | boolean | `true`           | Show hook status messages.                                                |
+| `statusLine.tokenRateExcludesTtft` | boolean | `false`    | Compute the `token_rate` segment from generation time only (request duration minus time-to-first-token), so long-prefill requests no longer depress the displayed tok/s. |
 | `terminal.showImages`       | boolean | `true`           | Render images inline (when the terminal supports it).                     |
 | `images.autoResize`         | boolean | `true`           | Resize large images for model compatibility.                              |
 | `images.blockImages`        | boolean | `false`          | Never send images to providers.                                           |

--- a/packages/ai/src/providers/amazon-bedrock.ts
+++ b/packages/ai/src/providers/amazon-bedrock.ts
@@ -531,12 +531,18 @@ export const streamBedrock: StreamFunction<"bedrock-converse-stream"> = (
 						break;
 					}
 					case "contentBlockStart": {
-						if (!firstTokenTime) firstTokenTime = performance.now();
+						if (!firstTokenTime) {
+							firstTokenTime = performance.now();
+							output.ttft = firstTokenTime - startTime;
+						}
 						handleContentBlockStart(payload as ContentBlockStartEvent, blocks, output, stream, sentinelInjected);
 						break;
 					}
 					case "contentBlockDelta": {
-						if (!firstTokenTime) firstTokenTime = performance.now();
+						if (!firstTokenTime) {
+							firstTokenTime = performance.now();
+							output.ttft = firstTokenTime - startTime;
+						}
 						handleContentBlockDelta(payload as ContentBlockDeltaEvent, blocks, output, stream);
 						break;
 					}

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -2354,7 +2354,10 @@ const streamAnthropicOnce = (
 								reportAnthropicEnvelopeAnomaly("content_block_start missing content_block payload");
 								continue;
 							}
-							if (!firstTokenTime) firstTokenTime = performance.now();
+							if (!firstTokenTime) {
+								firstTokenTime = performance.now();
+								output.ttft = firstTokenTime - startTime;
+							}
 							if (event.content_block.type === "fallback") {
 								// Fallback boundary is only meaningful when the request
 								// opted into the beta chain — silently drop otherwise so

--- a/packages/ai/src/providers/azure-openai-responses.ts
+++ b/packages/ai/src/providers/azure-openai-responses.ts
@@ -209,7 +209,10 @@ const streamAzureOpenAIResponsesOnce = (
 			let sawTerminalResponseEvent = false;
 			await processResponsesStream(timedOpenaiStream, output, stream, model, {
 				onFirstToken: () => {
-					if (!firstTokenTime) firstTokenTime = performance.now();
+					if (!firstTokenTime) {
+						firstTokenTime = performance.now();
+						output.ttft = firstTokenTime - startTime;
+					}
 				},
 				onCompleted: () => {
 					sawTerminalResponseEvent = true;

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -794,7 +794,10 @@ function streamCursorWithWireMode(
 					currentToolCall = t;
 				},
 				setFirstTokenTime: () => {
-					if (!firstTokenTime) firstTokenTime = performance.now();
+					if (!firstTokenTime) {
+						firstTokenTime = performance.now();
+						output.ttft = firstTokenTime - startTime;
+					}
 				},
 				onTodoSnapshot: options?.execHandlers?.todoSync?.bind(options.execHandlers),
 				onToolResult: options?.onToolResult,

--- a/packages/ai/src/providers/devin.ts
+++ b/packages/ai/src/providers/devin.ts
@@ -134,7 +134,10 @@ export const streamDevin: StreamFunction<"devin-agent"> = (
 		let latestStopReason = StopReason.UNSPECIFIED;
 
 		const markFirstToken = () => {
-			if (firstTokenTime === undefined) firstTokenTime = performance.now();
+			if (firstTokenTime === undefined) {
+				firstTokenTime = performance.now();
+				output.ttft = firstTokenTime - startTime;
+			}
 		};
 
 		const endTextBlock = () => {

--- a/packages/ai/src/providers/google-gemini-cli.ts
+++ b/packages/ai/src/providers/google-gemini-cli.ts
@@ -621,7 +621,10 @@ export const streamGoogleGeminiCli: StreamFunction<"google-gemini-cli"> = (
 			let lastResponseId: string | undefined;
 			const ensureStarted = () => {
 				if (!started) {
-					if (!firstTokenTime) firstTokenTime = performance.now();
+					if (!firstTokenTime) {
+						firstTokenTime = performance.now();
+						output.ttft = firstTokenTime - startTime;
+					}
 					stream.push({ type: "start", partial: output });
 					started = true;
 				}

--- a/packages/ai/src/providers/google-shared.ts
+++ b/packages/ai/src/providers/google-shared.ts
@@ -691,6 +691,10 @@ export async function consumeGoogleStream<T extends GoogleApiType>(args: {
 				}
 
 				if (part.functionCall) {
+					if (!firstTokenSeen) {
+						firstTokenSeen = true;
+						onFirstToken?.();
+					}
 					if (currentBlock) {
 						flushCurrent();
 						currentBlock = null;

--- a/packages/ai/src/providers/google-shared.ts
+++ b/packages/ai/src/providers/google-shared.ts
@@ -1028,6 +1028,7 @@ export function streamGoogleGenAI<T extends "google-generative-ai" | "google-ver
 					retainTextSignature,
 					onFirstToken: () => {
 						firstTokenTime = performance.now();
+						output.ttft = firstTokenTime - startTime;
 					},
 				});
 

--- a/packages/ai/src/providers/ollama.ts
+++ b/packages/ai/src/providers/ollama.ts
@@ -509,7 +509,10 @@ const streamOllamaOnce = (
 					partial: output,
 				});
 			}
-			if (!firstTokenTime) firstTokenTime = performance.now();
+			if (!firstTokenTime) {
+				firstTokenTime = performance.now();
+				output.ttft = firstTokenTime - startTime;
+			}
 		};
 		const appendVisibleThinking = (thinking: string): void => {
 			if (thinking.length === 0) return;
@@ -529,7 +532,10 @@ const streamOllamaOnce = (
 					partial: output,
 				});
 			}
-			if (!firstTokenTime) firstTokenTime = performance.now();
+			if (!firstTokenTime) {
+				firstTokenTime = performance.now();
+				output.ttft = firstTokenTime - startTime;
+			}
 		};
 		const emitHealedToolCall = (call: HealedToolCall): void => {
 			endActiveThinkingBlock();
@@ -552,7 +558,10 @@ const streamOllamaOnce = (
 			});
 			endToolCallBlock(stream, output, index);
 			healedToolCallEmitted = true;
-			if (!firstTokenTime) firstTokenTime = performance.now();
+			if (!firstTokenTime) {
+				firstTokenTime = performance.now();
+				output.ttft = firstTokenTime - startTime;
+			}
 		};
 		const emitHealingEvent = (event: StreamMarkupHealingEvent): void => {
 			if (event.type === "text") {
@@ -650,6 +659,7 @@ const streamOllamaOnce = (
 					}
 					if (!firstTokenTime) {
 						firstTokenTime = performance.now();
+						output.ttft = firstTokenTime - startTime;
 					}
 				}
 				const chunkContent = chunk.message?.content;
@@ -692,6 +702,7 @@ const streamOllamaOnce = (
 						});
 						if (!firstTokenTime) {
 							firstTokenTime = performance.now();
+							output.ttft = firstTokenTime - startTime;
 						}
 					}
 				}

--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -2139,7 +2139,10 @@ class CodexStreamProcessor {
 
 		if (eventType === "response.output_item.added") {
 			this.runtime.whitespaceToolCallArgumentsDelta = undefined;
-			if (!firstTokenTime) firstTokenTime = performance.now();
+			if (!firstTokenTime) {
+				firstTokenTime = performance.now();
+				output.ttft = firstTokenTime - this.startTime;
+			}
 			const item = rawEvent.item as CodexEventItem;
 			this.runtime.currentItem = item;
 			this.runtime.currentBlock = createOutputBlockForItem(item);
@@ -2204,7 +2207,10 @@ class CodexStreamProcessor {
 			const entry = this.runtime.openItemForEvent(rawEvent);
 			if (entry?.item.type === "reasoning" && entry.block?.type === "thinking") {
 				this.runtime.takeSummaryDeltas(entry);
-				if (!firstTokenTime) firstTokenTime = performance.now();
+				if (!firstTokenTime) {
+					firstTokenTime = performance.now();
+					output.ttft = firstTokenTime - this.startTime;
+				}
 				const summaryIndex =
 					typeof rawEvent.summary_index === "number" && Number.isFinite(rawEvent.summary_index)
 						? Math.trunc(rawEvent.summary_index)

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -1241,6 +1241,10 @@ const streamOpenAICompletionsOnce = (
 					}
 
 					if (choice?.delta?.tool_calls && choice.delta.tool_calls.length > 0) {
+						if (!firstTokenTime) {
+							firstTokenTime = performance.now();
+							output.ttft = firstTokenTime - startTime;
+						}
 						const toolCalls = choice.delta.tool_calls;
 						for (let toolCallOffset = 0; toolCallOffset < toolCalls.length; toolCallOffset++) {
 							const toolCall = toolCalls[toolCallOffset]!;

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -1005,7 +1005,10 @@ const streamOpenAICompletionsOnce = (
 
 			const appendTextDelta = (text: string): void => {
 				if (!text) return;
-				if (!firstTokenTime) firstTokenTime = performance.now();
+				if (!firstTokenTime) {
+					firstTokenTime = performance.now();
+					output.ttft = firstTokenTime - startTime;
+				}
 				appendText(output, stream, text);
 			};
 			// Tracks the last full cumulative reasoning snapshot per signature (the
@@ -1032,7 +1035,10 @@ const streamOpenAICompletionsOnce = (
 					lastCumulativeReasoningBySignature.set(key, thinking);
 					if (!emittedThinking) return;
 				}
-				if (!firstTokenTime) firstTokenTime = performance.now();
+				if (!firstTokenTime) {
+					firstTokenTime = performance.now();
+					output.ttft = firstTokenTime - startTime;
+				}
 				appendThinking(output, stream, emittedThinking, signature);
 			};
 
@@ -1215,7 +1221,10 @@ const streamOpenAICompletionsOnce = (
 
 					const normalizedDeltaText = normalizeStreamingContentText(choice.delta.content);
 					if (normalizedDeltaText.length > 0) {
-						if (!firstTokenTime) firstTokenTime = performance.now();
+						if (!firstTokenTime) {
+							firstTokenTime = performance.now();
+							output.ttft = firstTokenTime - startTime;
+						}
 						const hasStructuredToolCalls =
 							Array.isArray(choice.delta.tool_calls) && choice.delta.tool_calls.length > 0;
 

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -759,7 +759,10 @@ const streamOpenAIResponsesOnce = (
 				try {
 					await processResponsesStream(observedOpenaiStream, output, attemptStream, model, {
 						onFirstToken: () => {
-							if (!firstTokenTime) firstTokenTime = performance.now();
+							if (!firstTokenTime) {
+								firstTokenTime = performance.now();
+								output.ttft = firstTokenTime - startTime;
+							}
 						},
 						onOutputItemDone: item => {
 							// `processResponsesStream` hands over a private clone already; no

--- a/packages/ai/test/azure-openai-responses-stream.test.ts
+++ b/packages/ai/test/azure-openai-responses-stream.test.ts
@@ -429,3 +429,61 @@ describe("azure openai responses streaming", () => {
 		]);
 	});
 });
+
+describe("azure openai responses streaming ttft", () => {
+	it("stamps ttft on the assistant message at first output item, before done", async () => {
+		const fetchMock = vi.fn(async () =>
+			createSseResponse([
+				{ type: "response.created", response: { status: "in_progress" } },
+				{
+					type: "response.output_item.added",
+					output_index: 0,
+					item: { type: "message", id: "msg_1" },
+				},
+				{
+					type: "response.output_text.done",
+					output_index: 0,
+					content_index: 0,
+					text: "Hi",
+				},
+				{
+					type: "response.completed",
+					response: {
+						status: "completed",
+						usage: {
+							input_tokens: 1,
+							output_tokens: 1,
+							total_tokens: 2,
+							input_tokens_details: { cached_tokens: 0 },
+						},
+					},
+				},
+			]),
+		);
+
+		const stream = streamAzureOpenAIResponses(
+			azureModel,
+			{ messages: [{ role: "user", content: "Say hello", timestamp: Date.now() }] },
+			{
+				apiKey: "test-key",
+				fetch: fetchMock as unknown as typeof fetch,
+				azureBaseUrl: azureModel.baseUrl,
+				azureApiVersion: "v1",
+			},
+		);
+
+		let ttftAtFirstUpdate: number | undefined;
+		for await (const event of stream) {
+			if ("partial" in event && ttftAtFirstUpdate === undefined) {
+				ttftAtFirstUpdate = event.partial.ttft;
+			}
+			if (event.type === "done") {
+				expect(event.message.ttft).toBeDefined();
+				expect(event.message.ttft).toBeGreaterThanOrEqual(0);
+			}
+		}
+		// The review's core complaint: ttft must be visible on the streaming
+		// partial, not only on the finalized message.
+		expect(ttftAtFirstUpdate).toBeDefined();
+	});
+});

--- a/packages/ai/test/google-thinking-fence-strip.test.ts
+++ b/packages/ai/test/google-thinking-fence-strip.test.ts
@@ -132,3 +132,38 @@ describe("consumeGoogleStream leaked thinking-fence delimiter (#8719)", () => {
 		expect(thinking).toBe("");
 	});
 });
+
+describe("consumeGoogleStream first-token callback", () => {
+	it("fires onFirstToken for a functionCall-only stream (no text parts)", async () => {
+		const output = emptyAssistant();
+		const stream = new AssistantMessageEventStream();
+		let firstTokenFired = 0;
+		const done = (async () => {
+			for await (const _event of stream as AsyncIterable<AssistantMessageEvent> as AsyncIterable<AssistantMessageEvent>) {
+				// drain
+			}
+		})();
+
+		async function* googleStream(): AsyncGenerator<GenerateContentResponse> {
+			yield {
+				candidates: [{ content: { parts: [{ functionCall: { id: "call_1", name: "get_weather", args: {} } }] } }],
+			} as unknown as GenerateContentResponse;
+			yield { candidates: [{ finishReason: "STOP" }] } as unknown as GenerateContentResponse;
+		}
+
+		await consumeGoogleStream({
+			googleStream: googleStream(),
+			output,
+			stream,
+			model: vertexModel,
+			options: undefined,
+			onFirstToken: () => {
+				firstTokenFired++;
+			},
+		});
+		stream.end(output);
+		await done;
+
+		expect(firstTokenFired).toBe(1);
+	});
+});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Devin model selectors now accept the native CLI's short aliases (`devin/opus`, `devin/swe`), dotted upstream spellings (`devin/gemini-3.7-flash`), and raw effort-route wire uids for dynamically collapsed families ([#8590](https://github.com/can1357/oh-my-pi/pull/8590) by [@will-bogusz](https://github.com/will-bogusz)).
 - Added provider-supplied model metadata to the `/models` detail line: `new`, `beta`, and `recommended` badges beside the model name, and the upstream description after the context, cost, and perf facts ([#8590](https://github.com/can1357/oh-my-pi/pull/8590) by [@will-bogusz](https://github.com/will-bogusz)).
 - Standalone `CLAUDE.md` files in the project root (and ancestor directories) are now loaded as context, mirroring `AGENTS.md` discovery; config-directory context files still take precedence per scope.
+- Added `statusLine.tokenRateExcludesTtft` (default `false`); when enabled, the status line `token_rate` segment divides output tokens by generation time only (request duration minus time-to-first-token), so long-prefill requests no longer depress the displayed tok/s.
 
 ### Changed
 

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -848,6 +848,17 @@ export const SETTINGS_SCHEMA = {
 				"Show the thinking level as a single icon on the model name instead of a separate ` · <level>` suffix.",
 		},
 	},
+	"statusLine.tokenRateExcludesTtft": {
+		type: "boolean",
+		default: false,
+		ui: {
+			tab: "appearance",
+			group: "Status Line",
+			label: "Token Rate Excludes TTFT",
+			description:
+				"Compute the token_rate segment from generation time only (request duration minus time-to-first-token), so long-prefill requests no longer depress the displayed tok/s.",
+		},
+	},
 	"tools.artifactSpillThreshold": {
 		type: "number",
 		default: 50,

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -504,6 +504,7 @@ export class StatusLineComponent implements Component {
 			sessionAccent: settings.get("statusLine.sessionAccent"),
 			transparent: settings.get("statusLine.transparent"),
 			compactThinkingLevel: settings.get("statusLine.compactThinkingLevel"),
+			tokenRateExcludesTtft: settings.get("statusLine.tokenRateExcludesTtft"),
 			contextLine: settings.get("statusLine.contextLine"),
 		};
 	}
@@ -1260,7 +1261,11 @@ export class StatusLineComponent implements Component {
 			// At least one worker is streaming — add the director's live rate
 			// only when it is itself streaming (a finalized last-turn rate would
 			// double-count and overstate throughput).
-			const mainRate = this.session.isStreaming ? calculateTokensPerSecond(this.session.state.messages, true) : 0;
+			const mainRate = this.session.isStreaming
+				? calculateTokensPerSecond(this.session.state.messages, true, undefined, {
+						excludeTtft: this.#resolveSettings().tokenRateExcludesTtft ?? false,
+					})
+				: 0;
 			return (mainRate ?? 0) + workerRate;
 		}
 
@@ -1291,7 +1296,9 @@ export class StatusLineComponent implements Component {
 			return null;
 		}
 
-		const rate = calculateTokensPerSecond(this.session.state.messages, this.session.isStreaming);
+		const rate = calculateTokensPerSecond(this.session.state.messages, this.session.isStreaming, undefined, {
+			excludeTtft: this.#resolveSettings().tokenRateExcludesTtft ?? false,
+		});
 		if (rate !== null) {
 			this.#lastTokensPerSecond = rate;
 			this.#lastTokensPerSecondTimestamp = lastAssistantTimestamp;

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -1262,9 +1262,16 @@ export class StatusLineComponent implements Component {
 			// only when it is itself streaming (a finalized last-turn rate would
 			// double-count and overstate throughput).
 			const mainRate = this.session.isStreaming
-				? calculateTokensPerSecond(this.session.state.messages, true, undefined, {
-						excludeTtft: this.#resolveSettings().tokenRateExcludesTtft ?? false,
-					})
+				? calculateTokensPerSecond(
+						this.session.state.streamMessage?.role === "assistant"
+							? [...this.session.state.messages, this.session.state.streamMessage]
+							: this.session.state.messages,
+						true,
+						undefined,
+						{
+							excludeTtft: this.#resolveSettings().tokenRateExcludesTtft ?? false,
+						},
+					)
 				: 0;
 			return (mainRate ?? 0) + workerRate;
 		}
@@ -1281,9 +1288,19 @@ export class StatusLineComponent implements Component {
 	 * workers are active.
 	 */
 	#getMainSessionTokensPerSecond(): number | null {
+		// The in-flight assistant partial lives on `state.streamMessage` until
+		// `message_end` appends it to `state.messages`; include it so the badge
+		// reflects the live turn while tokens are decoding instead of the
+		// previous completed turn's rate.
+		const streamingPartial = this.session.isStreaming ? this.session.state.streamMessage : null;
+		const messages =
+			streamingPartial && streamingPartial.role === "assistant"
+				? [...this.session.state.messages, streamingPartial]
+				: this.session.state.messages;
+
 		let lastAssistantTimestamp: number | null = null;
-		for (let i = this.session.state.messages.length - 1; i >= 0; i--) {
-			const message = this.session.state.messages[i];
+		for (let i = messages.length - 1; i >= 0; i--) {
+			const message = messages[i];
 			if (message?.role === "assistant") {
 				lastAssistantTimestamp = message.timestamp;
 				break;
@@ -1296,7 +1313,7 @@ export class StatusLineComponent implements Component {
 			return null;
 		}
 
-		const rate = calculateTokensPerSecond(this.session.state.messages, this.session.isStreaming, undefined, {
+		const rate = calculateTokensPerSecond(messages, this.session.isStreaming, undefined, {
 			excludeTtft: this.#resolveSettings().tokenRateExcludesTtft ?? false,
 		});
 		if (rate !== null) {

--- a/packages/coding-agent/src/modes/components/status-line/types.ts
+++ b/packages/coding-agent/src/modes/components/status-line/types.ts
@@ -44,6 +44,9 @@ export interface StatusLineSettings {
 	 *  usage. `embedded` moves configured context segments into the annotated
 	 *  gauge as percentage and window labels. Box composer only. */
 	contextLine?: ContextLineMode;
+	/** Compute the `token_rate` segment from generation time only (request
+	 *  duration minus time-to-first-token) instead of the full request. */
+	tokenRateExcludesTtft?: boolean;
 }
 
 export type EffectiveStatusLineSettings = Required<

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -230,6 +230,7 @@ export class SelectorController {
 							sessionAccent: settings.get("statusLine.sessionAccent"),
 							transparent: settings.get("statusLine.transparent"),
 							compactThinkingLevel: settings.get("statusLine.compactThinkingLevel"),
+							tokenRateExcludesTtft: settings.get("statusLine.tokenRateExcludesTtft"),
 							contextLine: settings.get("statusLine.contextLine"),
 							...previewSettings,
 						});
@@ -261,6 +262,7 @@ export class SelectorController {
 							sessionAccent: settings.get("statusLine.sessionAccent"),
 							transparent: settings.get("statusLine.transparent"),
 							compactThinkingLevel: settings.get("statusLine.compactThinkingLevel"),
+							tokenRateExcludesTtft: settings.get("statusLine.tokenRateExcludesTtft"),
 							contextLine: settings.get("statusLine.contextLine"),
 						});
 						this.ctx.ui.requestRender();
@@ -706,6 +708,7 @@ export class SelectorController {
 			case "statusLine.sessionAccent":
 			case "statusLine.transparent":
 			case "statusLine.compactThinkingLevel":
+			case "statusLine.tokenRateExcludesTtft":
 			case "statusLineSegments":
 			case "statusLineModelThinking":
 			case "statusLinePathAbbreviate":
@@ -727,6 +730,7 @@ export class SelectorController {
 					transparent: settings.get("statusLine.transparent"),
 					segmentOptions: settings.get("statusLine.segmentOptions"),
 					compactThinkingLevel: settings.get("statusLine.compactThinkingLevel"),
+					tokenRateExcludesTtft: settings.get("statusLine.tokenRateExcludesTtft"),
 				};
 				this.ctx.statusLine.updateSettings(statusLineSettings);
 				this.ctx.ui.requestRender();

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -998,7 +998,9 @@ export class InteractiveMode implements InteractiveModeContext {
 		// workers stream, so without this the tok/s badge would show a stale
 		// value while parallel work is actively generating tokens.
 		this.statusLine.setVibeWorkerTokenRateProvider(() =>
-			aggregateVibeWorkerTokensPerSecond(this.session.getAgentId() ?? MAIN_AGENT_ID),
+			aggregateVibeWorkerTokensPerSecond(this.session.getAgentId() ?? MAIN_AGENT_ID, {
+				excludeTtft: settings.get("statusLine.tokenRateExcludesTtft") ?? false,
+			}),
 		);
 
 		this.hideToolActivity = settings.get("display.hideToolActivity");
@@ -2130,6 +2132,7 @@ export class InteractiveMode implements InteractiveModeContext {
 			transparent: settings.get("statusLine.transparent"),
 			segmentOptions: settings.get("statusLine.segmentOptions"),
 			compactThinkingLevel: settings.get("statusLine.compactThinkingLevel"),
+			tokenRateExcludesTtft: settings.get("statusLine.tokenRateExcludesTtft"),
 			contextLine: settings.get("statusLine.contextLine"),
 		});
 	}

--- a/packages/coding-agent/src/utils/token-rate.ts
+++ b/packages/coding-agent/src/utils/token-rate.ts
@@ -31,9 +31,10 @@ type MaybeAssistantMessage = {
 export type CalculateTokensPerSecondOptions = {
 	/**
 	 * Exclude time-to-first-token from the denominator so the rate reflects
-	 * generation-only throughput (prompt evaluation / prefill is not counted).
-	 * Falls back to the full duration when the message has no usable TTFT or
-	 * the subtraction would leave less than {@link MIN_DURATION_MS}.
+	 * generation-only throughput (the initial latency before the first token
+	 * is not counted). Falls back to the full duration when the message has
+	 * no usable TTFT or the subtraction would leave less than
+	 * {@link MIN_DURATION_MS}.
 	 */
 	excludeTtft?: boolean;
 };

--- a/packages/coding-agent/src/utils/token-rate.ts
+++ b/packages/coding-agent/src/utils/token-rate.ts
@@ -14,6 +14,7 @@ type AssistantLikeMessage = {
 	role: "assistant";
 	timestamp: number;
 	duration?: number;
+	ttft?: number;
 	usage: AssistantUsage;
 };
 
@@ -21,9 +22,20 @@ type MaybeAssistantMessage = {
 	role?: string;
 	timestamp?: number;
 	duration?: number;
+	ttft?: number;
 	usage?: {
 		output?: number;
 	};
+};
+
+export type CalculateTokensPerSecondOptions = {
+	/**
+	 * Exclude time-to-first-token from the denominator so the rate reflects
+	 * generation-only throughput (prompt evaluation / prefill is not counted).
+	 * Falls back to the full duration when the message has no usable TTFT or
+	 * the subtraction would leave less than {@link MIN_DURATION_MS}.
+	 */
+	excludeTtft?: boolean;
 };
 
 function isAssistantMessage(message: MaybeAssistantMessage | undefined): message is AssistantLikeMessage {
@@ -49,6 +61,7 @@ export function calculateTokensPerSecond(
 	messages: ReadonlyArray<MaybeAssistantMessage>,
 	isStreaming: boolean,
 	nowMs: number = Date.now(),
+	options?: CalculateTokensPerSecondOptions,
 ): number | null {
 	const assistant = getLastAssistantMessage(messages);
 	if (!assistant) return null;
@@ -65,7 +78,20 @@ export function calculateTokensPerSecond(
 
 	if (resolvedDurationMs === null || resolvedDurationMs < MIN_DURATION_MS) return null;
 
-	const tokensPerSecond = (outputTokens * 1000) / resolvedDurationMs;
+	let denominatorMs = resolvedDurationMs;
+	if (options?.excludeTtft) {
+		const ttftMs = assistant.ttft;
+		if (typeof ttftMs === "number" && Number.isFinite(ttftMs) && ttftMs > 0) {
+			const generationMs = resolvedDurationMs - ttftMs;
+			// Only honor TTFT when it leaves a measurable generation window;
+			// otherwise keep the full duration so the rate stays sane.
+			if (generationMs >= MIN_DURATION_MS) {
+				denominatorMs = generationMs;
+			}
+		}
+	}
+
+	const tokensPerSecond = (outputTokens * 1000) / denominatorMs;
 	if (!Number.isFinite(tokensPerSecond) || tokensPerSecond <= 0) return null;
 
 	return tokensPerSecond;

--- a/packages/coding-agent/src/vibe/runtime.ts
+++ b/packages/coding-agent/src/vibe/runtime.ts
@@ -1598,7 +1598,14 @@ export function aggregateVibeWorkerTokensPerSecond(
 	for (const id of ids) {
 		const workerSession = registry.get(id)?.session;
 		if (!workerSession?.isStreaming) continue;
-		const rate = calculateTokensPerSecond(workerSession.state.messages, true, undefined, options);
+		// Same gap as the main badge: the in-flight partial lives on
+		// `state.streamMessage` until `message_end` appends it to `messages`.
+		const partial = workerSession.state.streamMessage;
+		const messages =
+			partial && partial.role === "assistant"
+				? [...workerSession.state.messages, partial]
+				: workerSession.state.messages;
+		const rate = calculateTokensPerSecond(messages, true, undefined, options);
 		if (rate !== null) {
 			total += rate;
 			any = true;

--- a/packages/coding-agent/src/vibe/runtime.ts
+++ b/packages/coding-agent/src/vibe/runtime.ts
@@ -1586,7 +1586,10 @@ export class VibeSessionRegistry {
  * — the same leaf calculator the main status line uses — so worker rates are
  * computed identically to the main session's rate.
  */
-export function aggregateVibeWorkerTokensPerSecond(ownerId: string): number | null {
+export function aggregateVibeWorkerTokensPerSecond(
+	ownerId: string,
+	options?: { excludeTtft?: boolean },
+): number | null {
 	const ids = VibeSessionRegistry.global().listIdsByOwner(ownerId);
 	if (ids.length === 0) return null;
 	let total = 0;
@@ -1595,7 +1598,7 @@ export function aggregateVibeWorkerTokensPerSecond(ownerId: string): number | nu
 	for (const id of ids) {
 		const workerSession = registry.get(id)?.session;
 		if (!workerSession?.isStreaming) continue;
-		const rate = calculateTokensPerSecond(workerSession.state.messages, true);
+		const rate = calculateTokensPerSecond(workerSession.state.messages, true, undefined, options);
 		if (rate !== null) {
 			total += rate;
 			any = true;

--- a/packages/coding-agent/test/status-line-token-rate.test.ts
+++ b/packages/coding-agent/test/status-line-token-rate.test.ts
@@ -1,7 +1,7 @@
-import { beforeAll, describe, expect, it } from "bun:test";
+import { afterEach, beforeAll, describe, expect, it } from "bun:test";
 import { stripVTControlCharacters } from "node:util";
 import type { AssistantMessage } from "@oh-my-pi/pi-ai";
-import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { StatusLineComponent } from "@oh-my-pi/pi-coding-agent/modes/components/status-line/component";
 import { renderSegment } from "@oh-my-pi/pi-coding-agent/modes/components/status-line/segments";
 import type { SegmentContext } from "@oh-my-pi/pi-coding-agent/modes/components/status-line/types";
@@ -147,6 +147,10 @@ describe("token rate calculation", () => {
 });
 
 describe("token rate runtime toggle", () => {
+	afterEach(() => {
+		resetSettingsForTest();
+	});
+
 	it("updateSettings on a live component flips the rate policy without reconstruction", async () => {
 		await Settings.init({ inMemory: true });
 		const assistant = assistantMessage({
@@ -156,7 +160,7 @@ describe("token rate runtime toggle", () => {
 			ttft: 1_500,
 		} as Partial<AssistantMessage>);
 		const session = {
-			state: { messages: [assistant] },
+			state: { messages: [], streamMessage: assistant },
 			isStreaming: true,
 			settings: { get: () => false },
 			sessionManager: { getSessionName: () => undefined },

--- a/packages/coding-agent/test/status-line-token-rate.test.ts
+++ b/packages/coding-agent/test/status-line-token-rate.test.ts
@@ -134,15 +134,44 @@ describe("token rate calculation", () => {
 		expect(rate).toBe(60);
 	});
 
-	it("ignores negative or non-numeric ttft values", () => {
+	it("ignores negative and non-finite ttft values", () => {
 		const base = assistantMessage();
+		for (const ttft of [-5, Number.NaN, Number.POSITIVE_INFINITY]) {
+			const rate = calculateTokensPerSecond(
+				[assistantMessage({ usage: { ...base.usage, output: 120 }, duration: 2_000, ttft })],
+				false,
+				undefined,
+				{ excludeTtft: true },
+			);
+			expect(rate).toBe(60);
+		}
+	});
+
+	it("excludes ttft from the streaming window (no duration, nowMs - timestamp)", () => {
+		const base = assistantMessage();
+		// timestamp=1000, ttft=1500, nowMs=4500: streaming duration is 3500ms,
+		// generation window 3500 - 1500 = 2000ms → 120 tokens / 2s = 60 tok/s.
+		// Without exclusion the streaming rate would be ~34.3 tok/s.
 		const rate = calculateTokensPerSecond(
-			[assistantMessage({ usage: { ...base.usage, output: 120 }, duration: 2_000, ttft: -5 })],
-			false,
-			undefined,
+			[assistantMessage({ usage: { ...base.usage, output: 120 }, timestamp: 1_000, ttft: 1_500 })],
+			true,
+			4_500,
 			{ excludeTtft: true },
 		);
 		expect(rate).toBe(60);
+	});
+
+	it("falls back to the streaming duration when ttft leaves no measurable window mid-stream", () => {
+		const base = assistantMessage();
+		// timestamp=1000, ttft=3410, nowMs=4500: generation window would be
+		// 90ms < MIN_DURATION_MS (100) → full 3500ms streaming duration applies.
+		const rate = calculateTokensPerSecond(
+			[assistantMessage({ usage: { ...base.usage, output: 350 }, timestamp: 1_000, ttft: 3_410 })],
+			true,
+			4_500,
+			{ excludeTtft: true },
+		);
+		expect(rate).toBe(100);
 	});
 });
 

--- a/packages/coding-agent/test/status-line-token-rate.test.ts
+++ b/packages/coding-agent/test/status-line-token-rate.test.ts
@@ -100,4 +100,46 @@ describe("token rate calculation", () => {
 		);
 		expect(rate).toBeNull();
 	});
+
+	it("excludes ttft from the denominator when excludeTtft is set", () => {
+		const base = assistantMessage();
+		const rate = calculateTokensPerSecond(
+			[assistantMessage({ usage: { ...base.usage, output: 120 }, duration: 2_000, ttft: 1_500 })],
+			false,
+			undefined,
+			{ excludeTtft: true },
+		);
+		expect(rate).toBe(240);
+	});
+
+	it("keeps the full duration as the denominator by default", () => {
+		const base = assistantMessage();
+		const rate = calculateTokensPerSecond(
+			[assistantMessage({ usage: { ...base.usage, output: 120 }, duration: 2_000, ttft: 1_500 })],
+			false,
+		);
+		expect(rate).toBe(60);
+	});
+
+	it("falls back to the full duration when ttft leaves no measurable generation window", () => {
+		const base = assistantMessage();
+		const rate = calculateTokensPerSecond(
+			[assistantMessage({ usage: { ...base.usage, output: 120 }, duration: 2_000, ttft: 1_995 })],
+			false,
+			undefined,
+			{ excludeTtft: true },
+		);
+		expect(rate).toBe(60);
+	});
+
+	it("ignores negative or non-numeric ttft values", () => {
+		const base = assistantMessage();
+		const rate = calculateTokensPerSecond(
+			[assistantMessage({ usage: { ...base.usage, output: 120 }, duration: 2_000, ttft: -5 })],
+			false,
+			undefined,
+			{ excludeTtft: true },
+		);
+		expect(rate).toBe(60);
+	});
 });

--- a/packages/coding-agent/test/status-line-token-rate.test.ts
+++ b/packages/coding-agent/test/status-line-token-rate.test.ts
@@ -1,6 +1,8 @@
 import { beforeAll, describe, expect, it } from "bun:test";
 import { stripVTControlCharacters } from "node:util";
 import type { AssistantMessage } from "@oh-my-pi/pi-ai";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { StatusLineComponent } from "@oh-my-pi/pi-coding-agent/modes/components/status-line/component";
 import { renderSegment } from "@oh-my-pi/pi-coding-agent/modes/components/status-line/segments";
 import type { SegmentContext } from "@oh-my-pi/pi-coding-agent/modes/components/status-line/types";
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
@@ -141,5 +143,45 @@ describe("token rate calculation", () => {
 			{ excludeTtft: true },
 		);
 		expect(rate).toBe(60);
+	});
+});
+
+describe("token rate runtime toggle", () => {
+	it("updateSettings on a live component flips the rate policy without reconstruction", async () => {
+		await Settings.init({ inMemory: true });
+		const assistant = assistantMessage({
+			usage: { ...assistantMessage().usage, output: 120 },
+			timestamp: 1_000,
+			duration: 2_000,
+			ttft: 1_500,
+		} as Partial<AssistantMessage>);
+		const session = {
+			state: { messages: [assistant] },
+			isStreaming: true,
+			settings: { get: () => false },
+			sessionManager: { getSessionName: () => undefined },
+			modelRegistry: { isUsingOAuth: () => false },
+			getContextUsage: () => undefined,
+		} as unknown as ConstructorParameters<typeof StatusLineComponent>[0];
+		const component = new StatusLineComponent(session);
+
+		// Default: full-duration denominator → 120 tokens / 2000ms = 60 tok/s.
+		component.updateSettings({ preset: "custom", leftSegments: [], rightSegments: [], separator: "none" });
+		expect(component.getEffectiveSettingsForTest().tokenRateExcludesTtft ?? false).toBe(false);
+
+		// Runtime toggle on the already-running component.
+		component.updateSettings({
+			preset: "custom",
+			leftSegments: [],
+			rightSegments: [],
+			separator: "none",
+			tokenRateExcludesTtft: true,
+		});
+		expect(component.getEffectiveSettingsForTest().tokenRateExcludesTtft).toBe(true);
+
+		// A later sync that omits the field (as #syncStatusLineSettings sends a
+		// full payload read from the store) resolves through the store default.
+		component.updateSettings({ preset: "custom", leftSegments: [], rightSegments: [], separator: "none" });
+		expect(component.getEffectiveSettingsForTest().tokenRateExcludesTtft ?? false).toBe(false);
 	});
 });

--- a/packages/coding-agent/test/vibe/token-rate.test.ts
+++ b/packages/coding-agent/test/vibe/token-rate.test.ts
@@ -93,4 +93,26 @@ describe("aggregateVibeWorkerTokensPerSecond", () => {
 	it("returns null for the main-agent owner id when no workers are registered", () => {
 		expect(aggregateVibeWorkerTokensPerSecond(MAIN_AGENT_ID)).toBeNull();
 	});
+
+	it("excludeTtft divides by generation time only when workers carry ttft", () => {
+		// 100 output tokens, 2000ms full duration, 1500ms TTFT → generation
+		// window 500ms → 200 tok/s per worker.
+		const withTtft = {
+			role: "assistant",
+			timestamp: 1000,
+			duration: 2000,
+			ttft: 1500,
+			usage: { output: 100 },
+		};
+		registerWorker("w1", fakeSession([withTtft], true));
+		registerWorker("w2", fakeSession([withTtft], true));
+		expect(aggregateVibeWorkerTokensPerSecond(OWNER, { excludeTtft: true })).toBe(400);
+		// Without the option, the same workers aggregate at full-duration rates.
+		expect(aggregateVibeWorkerTokensPerSecond(OWNER)).toBe(100);
+	});
+
+	it("excludeTtft falls back to full duration for workers without ttft", () => {
+		registerWorker("w1", fakeSession([assistantMessage(100, 1000)], true));
+		expect(aggregateVibeWorkerTokensPerSecond(OWNER, { excludeTtft: true })).toBe(100);
+	});
 });


### PR DESCRIPTION
## What

Adds an opt-in status line setting, `statusLine.tokenRateExcludesTtft` (default `false`), that changes the `token_rate` segment denominator from the full request duration to the generation window (request duration minus time-to-first-token). Applied to the status line's main-session rate and its vibe-worker aggregation path; RPC and vibe-runtime callers keep the existing full-duration semantics.

## Why

I run omp against reasoning models over an OpenAI-compatible gateway, and with long contexts the badge was reporting ~40-60 tok/s while the model was visibly decoding far faster. The current formula in `calculateTokensPerSecond` divides by `duration`, which includes TTFT (prompt evaluation / prefill) — so the longer the context, the more the badge under-reports the actual decode rate. omp already stamps `ttft` on assistant messages, so the generation window is available; this just makes using it configurable instead of changing the default for everyone. I personally want the badge to reflect model decode throughput, and other users watching long-context sessions likely see the same gap, but I kept it opt-in so existing expectations and comparisons stay stable.

## Review follow-up (08a5218)

Addressed all three blocking review comments and both Codex P2s:

1. **TTFT during live streaming**: providers now stamp `assistant.ttft` at the first streamed token instead of only right before `done` — updated all eleven streaming providers (`anthropic`, `openai-responses`, `openai-completions`, `openai-codex-responses`, `azure-openai-responses`, `google-shared`, `google-gemini-cli`, `amazon-bedrock`, `cursor`, `devin`, `ollama`). The generation-only rate now applies while tokens are decoding.
2. **Runtime setting updates**: `tokenRateExcludesTtft` now flows through every runtime update path — `interactive-mode`'s `#syncStatusLineSettings()`, both `selector-controller` appearance payloads (preview + cancel-restore), a `handleSettingChange()` case, and `aggregateVibeWorkerTokensPerSecond()` (now accepts `{ excludeTtft }`, wired from the injected provider so toggling mid-session reaches the live badge and worker aggregate).
3. **Vibe worker rates**: the worker aggregation honors the same option, so vibe mode no longer mixes generation-only director throughput with full-duration worker throughput.

New tests cover each path: streaming `ttft` visible on the partial (azure responses harness, asserting it's set at `message_update` time, not just `done`), vibe aggregation with/without `excludeTtft` including the no-ttft fallback, and a live-component runtime-toggle regression.

Docs: `statusLine.tokenRateExcludesTtft` documented in `docs/settings.md`.

## Testing

- `bun run check` (biome + tsgo) passes on `packages/coding-agent`; `tsc --noEmit` passes on `packages/ai`.
- `bun test test/status-line-token-rate.test.ts` — 11 pass / 0 fail (6 pre-PR, 4 from the original commit, 1 new runtime-toggle).
- `bun test test/vibe/token-rate.test.ts` — 10 pass / 0 fail (2 new: worker aggregation with `excludeTtft`, no-ttft fallback).
- `bun test test/azure-openai-responses-stream.test.ts` (packages/ai) — 13 pass / 0 fail (new streaming-ttft regression).
- Exercised end-to-end on a local build against a `litellm/bigmodel-glm-5.3-flash` reasoning model with a ~200K-token session: with `statusLine.tokenRateExcludesTtft: false` the badge read ~55 tok/s; flipping it to `true` moved the same in-flight turn to ~180 tok/s, matching the provider-side decode rate rather than the prefill-diluted number. Fall-back path verified by resuming an old session whose stored messages have no `ttft` (badge unchanged from current behavior). After the streaming fix, the mid-stream badge now shows the generation-only rate during decoding, not only after completion.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
