### PR TITLE
fix(retry): bypass long OpenCode usage waits

### DIFF
--- a/packages/catalog/src/compat/axes.ts
+++ b/packages/catalog/src/compat/axes.ts
@@ -245,6 +245,7 @@ export const AXES: Readonly<Record<string, AxisDef>> = {
 	"input-modalities": { key: "inputModalities", set: "catalog", shape: "array", values: ["text", "image"] },
 	"limits-patch": { key: "limitsPatch", set: "catalog", shape: "object" },
 	"long-context-cost": { key: "longContext", set: "catalog", shape: "object" },
+	"long-usage-limit-fallback": { key: "longUsageLimitFallback", set: "catalog", shape: "scalar" },
 	priority: { key: "priority", set: "catalog", shape: "scalar" },
 	"service-tier-cost": { key: "serviceTierCost", set: "catalog", shape: "object" },
 };

--- a/packages/catalog/src/compat/rules.json
+++ b/packages/catalog/src/compat/rules.json
@@ -10336,7 +10336,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:6",
+				"source": "providers/opencode-go.kdl:9",
 				"class": "deepseek",
 				"providers": [
 					"opencode-go"
@@ -10347,7 +10347,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:4",
+				"source": "providers/opencode-go.kdl:7",
 				"class": "deepseek",
 				"providers": [
 					"opencode-go"
@@ -10357,7 +10357,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:11",
+				"source": "providers/opencode-go.kdl:14",
 				"providers": [
 					"opencode-go"
 				],
@@ -10372,7 +10372,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:17",
+				"source": "providers/opencode-go.kdl:20",
 				"providers": [
 					"opencode-go"
 				],
@@ -10394,7 +10394,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:23",
+				"source": "providers/opencode-go.kdl:26",
 				"class": "glm",
 				"providers": [
 					"opencode-go"
@@ -10404,7 +10404,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:26",
+				"source": "providers/opencode-go.kdl:29",
 				"class": "kimi",
 				"providers": [
 					"opencode-go"
@@ -10414,7 +10414,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:30",
+				"source": "providers/opencode-go.kdl:33",
 				"class": "mimo",
 				"providers": [
 					"opencode-go"
@@ -10425,7 +10425,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:29",
+				"source": "providers/opencode-go.kdl:32",
 				"class": "mimo",
 				"providers": [
 					"opencode-go"
@@ -10435,7 +10435,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:37",
+				"source": "providers/opencode-go.kdl:40",
 				"class": "qwen",
 				"providers": [
 					"opencode-go"
@@ -10461,7 +10461,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:41",
+				"source": "providers/opencode-go.kdl:44",
 				"class": "qwen",
 				"providers": [
 					"opencode-go"
@@ -10487,7 +10487,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:47",
+				"source": "providers/opencode-go.kdl:50",
 				"providers": [
 					"opencode-go"
 				],
@@ -10512,7 +10512,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:52",
+				"source": "providers/opencode-go.kdl:55",
 				"providers": [
 					"opencode-go"
 				],
@@ -10532,7 +10532,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:57",
+				"source": "providers/opencode-go.kdl:60",
 				"providers": [
 					"opencode-go"
 				],
@@ -10554,7 +10554,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:62",
+				"source": "providers/opencode-go.kdl:65",
 				"providers": [
 					"opencode-go"
 				],
@@ -10575,7 +10575,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:66",
+				"source": "providers/opencode-go.kdl:69",
 				"providers": [
 					"opencode-go"
 				],
@@ -10602,7 +10602,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:70",
+				"source": "providers/opencode-go.kdl:73",
 				"providers": [
 					"opencode-go"
 				],
@@ -10624,7 +10624,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:75",
+				"source": "providers/opencode-go.kdl:78",
 				"providers": [
 					"opencode-go"
 				],
@@ -10639,7 +10639,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:79",
+				"source": "providers/opencode-go.kdl:82",
 				"providers": [
 					"opencode-go"
 				],
@@ -10651,6 +10651,15 @@
 				],
 				"thinking": {
 					"mode": "anthropic-adaptive"
+				}
+			},
+			{
+				"source": "providers/opencode-go.kdl:3",
+				"providers": [
+					"opencode-go"
+				],
+				"catalog": {
+					"longUsageLimitFallback": true
 				}
 			},
 			{

--- a/packages/catalog/src/compat/rules/providers/opencode-go.kdl
+++ b/packages/catalog/src/compat/rules/providers/opencode-go.kdl
@@ -1,6 +1,9 @@
 // Provider-wire compat for "opencode-go"; regenerated from the frozen census using deployment contract selectors.
 
 provider "opencode-go" {
+	// The gateway's usage-limit error means a provider-wide quota window; when it
+	// exceeds the retry cap, recovery may route to a different provider.
+	long-usage-limit-fallback #true
 	class "deepseek" {
 		thinking-mode "effort"
 		family "flash" {

--- a/packages/catalog/test/opencode-provider.test.ts
+++ b/packages/catalog/test/opencode-provider.test.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import { resolveModelPolicy } from "@oh-my-pi/pi-catalog/compat/resolve";
 import { Effort } from "@oh-my-pi/pi-catalog/effort";
 import { readModelCache, writeModelCache } from "@oh-my-pi/pi-catalog/model-cache";
 import { resolveProviderModels } from "@oh-my-pi/pi-catalog/model-manager";
@@ -788,5 +789,21 @@ describe("OpenCode provider discovery", () => {
 		} finally {
 			await fs.rm(tempDir, { recursive: true, force: true });
 		}
+	});
+	test("resolves the OpenCode Go long-usage fallback policy from KDL", () => {
+		const policy = resolveModelPolicy({
+			id: "deepseek-v4-flash",
+			name: "DeepSeek V4 Flash",
+			api: "openai-completions",
+			provider: "opencode-go",
+			baseUrl: "https://opencode.ai/zen/v1",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 128_000,
+			maxTokens: 16_384,
+		});
+
+		expect(policy.catalog).toMatchObject({ longUsageLimitFallback: true });
 	});
 });

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Fixed an issue where custom model overrides were lost during configuration updates
 - Fixed "Please use nerdfont" notification incorrectly persisting after theme configuration
 - Fixed sampling parameter errors for newer Anthropic models (Opus 4.7+, Sonnet 5+)
+- Fixed long OpenCode Go usage-limit waits to immediately switch replay-safe turns to a distinct configured provider when the retry delay exceeds `retry.maxDelayMs`.
 
 ## [18.0.11] - 2026-08-29
 
@@ -53,7 +54,6 @@
 - Fixed `lsp diagnostics` incorrectly reporting success for project-aware pull-diagnostic servers when diagnostics time out or fail.
 - Corrected labels under `Settings > Context > Compaction Token Limit`.
 - Fixed orphaned pages, iframes, and workers accumulating in the shared headless browser after abnormal OMP session termination.
-- Fixed long OpenCode Go usage-limit waits to immediately switch replay-safe turns to a distinct configured provider when the retry delay exceeds `retry.maxDelayMs`.
 
 ## [18.0.10] - 2026-08-28
 
@@ -112,6 +112,7 @@
 - Transcript usage rows now show the total prompt-to-yield time (Δ + clock, including tool calls) after the turn timestamp, opt-in via `display.showTurnTime` (off by default).
 - `omp usage` now shows Z.AI GLM Coding Plan credit quotas (5h + weekly) with the subscribed plan tier.
 - The usage status line now labels untiered quota windows with the report's plan tier, surfacing Z.AI Coding Plan (`pro`) and Codex plan names next to the 5h/7d percentages.
+
 ### Fixed
 
 - Fixed corrupt session headers silently overwriting recoverable transcripts during resume ([#9915](https://github.com/can1357/oh-my-pi/issues/9915)).

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -53,6 +53,7 @@
 - Fixed `lsp diagnostics` incorrectly reporting success for project-aware pull-diagnostic servers when diagnostics time out or fail.
 - Corrected labels under `Settings > Context > Compaction Token Limit`.
 - Fixed orphaned pages, iframes, and workers accumulating in the shared headless browser after abnormal OMP session termination.
+- Fixed long OpenCode Go usage-limit waits to immediately switch replay-safe turns to a distinct configured provider when the retry delay exceeds `retry.maxDelayMs`.
 
 ## [18.0.10] - 2026-08-28
 

--- a/packages/coding-agent/src/session/retry-fallback-chains.ts
+++ b/packages/coding-agent/src/session/retry-fallback-chains.ts
@@ -448,7 +448,7 @@ export function findRetryFallbackCandidates(
 	chainKey: string,
 	currentSelector: string,
 	currentModel?: Model | null,
-	options?: { allowMissingPrimary?: boolean },
+	options?: { allowMissingPrimary?: boolean; wrapAround?: boolean },
 ): RetryFallbackSelector[] {
 	const chain = getRetryFallbackEffectiveChain(
 		context,
@@ -474,13 +474,19 @@ export function findRetryFallbackCandidates(
 	const exactIndex = chain.findIndex(
 		selector => selector.raw === currentSelector || selector.raw === currentPlainSelector,
 	);
-	if (exactIndex >= 0) return chain.slice(exactIndex + 1);
+	if (exactIndex >= 0) {
+		const candidatesAfter = chain.slice(exactIndex + 1);
+		return options?.wrapAround ? [...candidatesAfter, ...chain.slice(0, exactIndex)] : candidatesAfter;
+	}
 	const baseIndex = currentBaseSelector
 		? chain.findIndex(selector => {
 				const selectorBase = formatRetryFallbackBaseSelector(selector);
 				return selectorBase === currentBaseSelector || selectorBase === currentPlainBaseSelector;
 			})
 		: -1;
-	if (baseIndex >= 0) return chain.slice(baseIndex + 1);
+	if (baseIndex >= 0) {
+		const candidatesAfter = chain.slice(baseIndex + 1);
+		return options?.wrapAround ? [...candidatesAfter, ...chain.slice(0, baseIndex)] : candidatesAfter;
+	}
 	return chain.slice(1);
 }

--- a/packages/coding-agent/src/session/retry-fallback-chains.ts
+++ b/packages/coding-agent/src/session/retry-fallback-chains.ts
@@ -442,7 +442,11 @@ function getRetryFallbackEffectiveChain(
 	return chain;
 }
 
-/** Return the candidates after the current selector in an effective chain. */
+/**
+ * Return candidates after the current selector in an effective chain.
+ * `wrapAround` additionally appends entries before the current selector,
+ * without returning the current selector itself.
+ */
 export function findRetryFallbackCandidates(
 	context: RetryFallbackResolutionContext,
 	chainKey: string,

--- a/packages/coding-agent/src/session/turn-recovery.ts
+++ b/packages/coding-agent/src/session/turn-recovery.ts
@@ -20,6 +20,7 @@ import type {
 } from "@oh-my-pi/pi-ai";
 import { calculateRateLimitBackoffMs, parseRateLimitReason } from "@oh-my-pi/pi-ai";
 import * as AIError from "@oh-my-pi/pi-ai/error";
+import { resolveModelPolicy } from "@oh-my-pi/pi-catalog/compat/resolve";
 import { isFireworksFastModelId, toFireworksBaseModelId } from "@oh-my-pi/pi-catalog/fireworks-model-id";
 import { modelsAreEqual } from "@oh-my-pi/pi-catalog/models";
 import { extractRetryHint, logger, prompt } from "@oh-my-pi/pi-utils";
@@ -2129,6 +2130,10 @@ export class TurnRecovery {
 		// Set when a usage-limit error pinned the wait to credential
 		// availability — suppresses the generic retry-after bump below.
 		let usageLimitWaitMs: number | undefined;
+		const siblingAvailabilityWaitMs =
+			recordedUsageLimitOutcome?.retryAtMs === undefined
+				? undefined
+				: Math.max(0, recordedUsageLimitOutcome.retryAtMs - Date.now()) + SIBLING_UNBLOCK_BUFFER_MS;
 
 		if (staleOpenAIResponsesReplayError) {
 			this.#host.resetCurrentResponsesProviderSession("stale replay error");
@@ -2155,12 +2160,8 @@ export class TurnRecovery {
 				// recoverable situation into the provider's multi-hour wait and
 				// trips the fail-fast cap below.
 				usageLimitWaitMs = recordedUsageLimitOutcome.retryAfterMs;
-				if (recordedUsageLimitOutcome.retryAtMs !== undefined) {
-					const siblingWaitMs =
-						Math.max(0, recordedUsageLimitOutcome.retryAtMs - Date.now()) + SIBLING_UNBLOCK_BUFFER_MS;
-					if (siblingWaitMs < usageLimitWaitMs) {
-						usageLimitWaitMs = siblingWaitMs;
-					}
+				if (siblingAvailabilityWaitMs !== undefined && siblingAvailabilityWaitMs < usageLimitWaitMs) {
+					usageLimitWaitMs = siblingAvailabilityWaitMs;
 				}
 				if (usageLimitWaitMs > delayMs) {
 					delayMs = usageLimitWaitMs;
@@ -2189,11 +2190,24 @@ export class TurnRecovery {
 		// contents, not model health (issue #8760). Keep it on the same model; the
 		// retry budget still bounds a genuinely stuck stream.
 		const thinkingLoop = AIError.is(id, AIError.Flag.ThinkingLoop);
-		const longOpenCodeUsageLimit =
-			currentModel?.provider === "opencode-go" &&
+		const effectiveUsageLimitWaitMs =
+			usageLimitWaitMs ??
+			(siblingAvailabilityWaitMs === undefined
+				? (recordedUsageLimitOutcome?.retryAfterMs ?? parsedRetryAfterMs)
+				: Math.min(
+						recordedUsageLimitOutcome?.retryAfterMs ?? parsedRetryAfterMs ?? Infinity,
+						siblingAvailabilityWaitMs,
+					));
+		const waitForSiblingCredential =
+			siblingAvailabilityWaitMs !== undefined &&
+			effectiveUsageLimitWaitMs !== undefined &&
+			effectiveUsageLimitWaitMs <= retrySettings.maxDelayMs;
+		const longUsageLimitFallback =
+			currentModel !== undefined &&
+			resolveModelPolicy(currentModel).catalog.longUsageLimitFallback === true &&
 			retrySettings.maxDelayMs > 0 &&
-			parsedRetryAfterMs !== undefined &&
-			parsedRetryAfterMs > retrySettings.maxDelayMs &&
+			effectiveUsageLimitWaitMs !== undefined &&
+			effectiveUsageLimitWaitMs > retrySettings.maxDelayMs &&
 			/\bGoUsageLimitError\b/.test(errorMessage) &&
 			(!this.#hasReplayUnsafeOutput(message) || this.#unexecutedToolCallsReplaySafe(message));
 
@@ -2204,16 +2218,17 @@ export class TurnRecovery {
 				allowModelFallback &&
 				retrySettings.modelFallback &&
 				!thinkingLoop &&
+				!waitForSiblingCredential &&
 				!(retryBudgetExhausted && classifierRefusal)
 			) {
 				if (!classifierRefusal) {
 					this.noteRetryFallbackCooldown(currentSelector, parsedRetryAfterMs, errorMessage);
 				}
 				switchedModel = await this.#tryRetryModelFallback(currentSelector, message, {
-					excludeProvider: longOpenCodeUsageLimit ? "opencode-go" : undefined,
+					excludeProvider: longUsageLimitFallback ? currentModel.provider : undefined,
 					pinFallback: classifierRefusal,
 					preserveFailedTurn,
-					wrapAround: longOpenCodeUsageLimit,
+					wrapAround: longUsageLimitFallback,
 				});
 			}
 			// Auto fallback from a Fireworks Fast variant to its base model. Independent

--- a/packages/coding-agent/src/session/turn-recovery.ts
+++ b/packages/coding-agent/src/session/turn-recovery.ts
@@ -1515,12 +1515,14 @@ export class TurnRecovery {
 		role: string,
 		currentSelector: string,
 		currentModel: Model | null | undefined = this.#host.model(),
+		options?: { wrapAround?: boolean },
 	): RetryFallbackSelector[] {
 		return findRetryFallbackCandidates(
 			this.#getRetryFallbackResolutionContext(),
 			role,
 			currentSelector,
 			currentModel,
+			options,
 		);
 	}
 
@@ -1775,7 +1777,12 @@ export class TurnRecovery {
 	async #tryRetryModelFallback(
 		currentSelector: string,
 		failedMessage: AssistantMessage,
-		options?: { pinFallback?: boolean; preserveFailedTurn?: boolean },
+		options?: {
+			excludeProvider?: string;
+			pinFallback?: boolean;
+			preserveFailedTurn?: boolean;
+			wrapAround?: boolean;
+		},
 	): Promise<boolean> {
 		const ceiling = this.#host.thinkingLevelCeiling();
 		const latestAssistant = options?.preserveFailedTurn
@@ -1784,11 +1791,12 @@ export class TurnRecovery {
 					(message): message is AssistantMessage => message.role === "assistant" && message !== failedMessage,
 				);
 		for (const role of this.retryFallbackChainKeys(currentSelector)) {
-			for (const selector of this.findRetryFallbackCandidates(role, currentSelector)) {
+			for (const selector of this.findRetryFallbackCandidates(role, currentSelector, undefined, options)) {
 				if (this.isRetryFallbackSelectorSuppressed(selector)) continue;
 				const resolved = resolveModelOverride([selector.raw], this.#host.modelRegistry, this.#host.settings);
 				const candidate = resolved.model ?? this.#host.modelRegistry.find(selector.provider, selector.id);
 				if (!candidate) continue;
+				if (options?.excludeProvider === candidate.provider) continue;
 				// Anthropic signatures and redacted blocks are model-bound, while the
 				// latest assistant response must remain byte-identical. A same-provider
 				// model switch can satisfy neither constraint, so keep retrying the
@@ -2181,6 +2189,14 @@ export class TurnRecovery {
 		// contents, not model health (issue #8760). Keep it on the same model; the
 		// retry budget still bounds a genuinely stuck stream.
 		const thinkingLoop = AIError.is(id, AIError.Flag.ThinkingLoop);
+		const longOpenCodeUsageLimit =
+			currentModel?.provider === "opencode-go" &&
+			retrySettings.maxDelayMs > 0 &&
+			parsedRetryAfterMs !== undefined &&
+			parsedRetryAfterMs > retrySettings.maxDelayMs &&
+			/\bGoUsageLimitError\b/.test(errorMessage) &&
+			(!this.#hasReplayUnsafeOutput(message) || this.#unexecutedToolCallsReplaySafe(message));
+
 		if (!staleOpenAIResponsesReplayError && !switchedCredential && currentSelector) {
 			// A refusal chain stops at the retry budget: the exhausted-attempt
 			// last resort is for provider failures, not classifier decisions.
@@ -2194,8 +2210,10 @@ export class TurnRecovery {
 					this.noteRetryFallbackCooldown(currentSelector, parsedRetryAfterMs, errorMessage);
 				}
 				switchedModel = await this.#tryRetryModelFallback(currentSelector, message, {
+					excludeProvider: longOpenCodeUsageLimit ? "opencode-go" : undefined,
 					pinFallback: classifierRefusal,
 					preserveFailedTurn,
+					wrapAround: longOpenCodeUsageLimit,
 				});
 			}
 			// Auto fallback from a Fireworks Fast variant to its base model. Independent

--- a/packages/coding-agent/test/agent-session-retry-cap.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-cap.test.ts
@@ -286,6 +286,87 @@ describe("AgentSession retry delay cap", () => {
 			text: "recovered on cross-provider fallback",
 		});
 	});
+	it("waits for a short OpenCode Go sibling credential before model fallback", async () => {
+		const exhaustedModel = getBundledModel("opencode-go", "deepseek-v4-flash");
+		const fallbackModel = getBundledModel("openai", "gpt-5.5");
+		if (!exhaustedModel || !fallbackModel) {
+			throw new Error("Expected bundled OpenCode Go and fallback test models to exist");
+		}
+
+		await authStorage.set("opencode-go", [
+			{ type: "api_key", key: "opencode-go-key-1" },
+			{ type: "api_key", key: "opencode-go-key-2" },
+		]);
+		authStorage.setRuntimeApiKey("openai", "openai-test-key");
+		await modelRegistry.getApiKeyForProvider("opencode-go", "other-session");
+		const blocked = await authStorage.markUsageLimitReached("opencode-go", "other-session", {
+			retryAfterMs: 2_000,
+		});
+		expect(blocked.switched).toBe(true);
+		const usageLimitSpy = vi.spyOn(authStorage, "markUsageLimitReached");
+
+		const mock = createMockModel();
+		const requestedModels: string[] = [];
+		let agent!: Agent;
+		agent = new Agent({
+			getApiKey: model => modelRegistry.resolver(model, agent.sessionId),
+			initialState: {
+				model: exhaustedModel,
+				systemPrompt: ["Test"],
+				tools: [],
+				messages: [],
+			},
+			streamFn: (requestedModel, context, options) => {
+				requestedModels.push(`${requestedModel.provider}/${requestedModel.id}`);
+				mock.push(
+					requestedModels.length === 1
+						? {
+								throw: "429 Weekly usage limit reached. type=GoUsageLimitError retry-after-ms=3242000",
+							}
+						: { content: ["recovered after sibling unblock"], stopReason: "stop" },
+				);
+				return mock.stream(requestedModel, context, options);
+			},
+		});
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"retry.maxDelayMs": 300_000,
+			"retry.maxRetries": 2,
+			"retry.modelFallback": true,
+			"retry.fallbackChains": { default: [`${fallbackModel.provider}/${fallbackModel.id}`] },
+		});
+		settings.setModelRole("default", `${exhaustedModel.provider}/${exhaustedModel.id}`);
+
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+		});
+		const waitSpy = vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+		const fallbackEvents: Array<Extract<AgentSessionEvent, { type: "retry_fallback_applied" }>> = [];
+		session.subscribe(event => {
+			if (event.type === "retry_fallback_applied") fallbackEvents.push(event);
+		});
+
+		await session.prompt("Trigger the long OpenCode Go limit while a sibling is briefly blocked");
+		await session.waitForIdle();
+		expect(usageLimitSpy).toHaveBeenCalledTimes(1);
+		const usageLimitResult = usageLimitSpy.mock.results[0]?.value;
+		expect(usageLimitResult).toBeDefined();
+		expect(await usageLimitResult).toMatchObject({ retryAtMs: expect.any(Number), switched: false });
+
+		expect(requestedModels).toEqual([
+			`${exhaustedModel.provider}/${exhaustedModel.id}`,
+			`${exhaustedModel.provider}/${exhaustedModel.id}`,
+		]);
+		expect(fallbackEvents).toEqual([]);
+		expect(waitSpy.mock.calls.some(call => call[0] >= 1_000 && call[0] <= 3_000)).toBe(true);
+		expect(lastAssistant(session).content).toContainEqual({
+			type: "text",
+			text: "recovered after sibling unblock",
+		});
+	});
 
 	it("honors the reason backoff for a transient rate-limit 429 without a provider hint", async () => {
 		const model = getBundledModel("anthropic", "claude-sonnet-4-5");

--- a/packages/coding-agent/test/agent-session-retry-cap.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-cap.test.ts
@@ -216,8 +216,7 @@ describe("AgentSession retry delay cap", () => {
 					stopReason: "error",
 				},
 				{
-					throw:
-						"429 Weekly usage limit reached. Resets in 55min. type=GoUsageLimitError retry-after-ms=3242000",
+					throw: "429 Weekly usage limit reached. Resets in 55min. type=GoUsageLimitError retry-after-ms=3242000",
 				},
 				{ content: ["recovered on cross-provider fallback"], stopReason: "stop" },
 			],

--- a/packages/coding-agent/test/agent-session-retry-cap.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-cap.test.ts
@@ -86,7 +86,15 @@ describe("AgentSession retry delay cap", () => {
 		for (const provider of ["anthropic", "openai-codex"]) {
 			await authStorage.remove(provider);
 		}
-		for (const provider of ["anthropic", "openai", "openai-codex", "openrouter", "github-copilot", "cursor"]) {
+		for (const provider of [
+			"anthropic",
+			"openai",
+			"openai-codex",
+			"opencode-go",
+			"openrouter",
+			"github-copilot",
+			"cursor",
+		]) {
 			authStorage.removeRuntimeApiKey(provider);
 		}
 		authStorage.setRuntimeApiKey("anthropic", "anthropic-test-key");

--- a/packages/coding-agent/test/agent-session-retry-cap.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-cap.test.ts
@@ -180,6 +180,106 @@ describe("AgentSession retry delay cap", () => {
 		expect(session.isRetrying).toBe(false);
 	});
 
+	it("switches a long OpenCode Go usage limit to an earlier cross-provider fallback", async () => {
+		const primaryModel = getBundledModel("anthropic", "claude-sonnet-4-5");
+		const alternateOpenCodeModel = getBundledModel("opencode-go", "deepseek-v4-pro");
+		const exhaustedModel = getBundledModel("opencode-go", "deepseek-v4-flash");
+		const fallbackModel = getBundledModel("openai", "gpt-5.5");
+		if (!primaryModel || !alternateOpenCodeModel || !exhaustedModel || !fallbackModel) {
+			throw new Error("Expected bundled primary, OpenCode Go, and cross-provider fallback test models to exist");
+		}
+
+		authStorage.setRuntimeApiKey("opencode-go", "opencode-go-test-key");
+		authStorage.setRuntimeApiKey("openai", "openai-test-key");
+
+		const mock = createMockModel({
+			responses: [
+				{ throw: "503 service unavailable: overloaded_error retry-after-ms=60000" },
+				{
+					content: [{ type: "thinking", thinking: "Classifier refusal." }],
+					errorMessage: "Refusal (cyber): Declined.",
+					stopDetails: { type: "refusal", category: "cyber", explanation: "Declined." },
+					stopReason: "error",
+				},
+				{
+					content: [{ type: "thinking", thinking: "Classifier refusal." }],
+					errorMessage: "Refusal (cyber): Declined.",
+					stopDetails: { type: "refusal", category: "cyber", explanation: "Declined." },
+					stopReason: "error",
+				},
+				{
+					throw:
+						"429 Weekly usage limit reached. Resets in 55min. type=GoUsageLimitError retry-after-ms=3242000",
+				},
+				{ content: ["recovered on cross-provider fallback"], stopReason: "stop" },
+			],
+		});
+		const requestedModels: string[] = [];
+		const agent = new Agent({
+			getApiKey: requestedModel => `${requestedModel.provider}-test-key`,
+			initialState: {
+				model: primaryModel,
+				systemPrompt: ["Test"],
+				tools: [],
+				messages: [],
+			},
+			streamFn: (requestedModel, context, options) => {
+				requestedModels.push(`${requestedModel.provider}/${requestedModel.id}`);
+				return mock.stream(requestedModel, context, options);
+			},
+		});
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"retry.maxDelayMs": 300_000,
+			"retry.maxRetries": 3,
+			"retry.modelFallback": true,
+			"retry.fallbackChains": {
+				default: [
+					`${alternateOpenCodeModel.provider}/${alternateOpenCodeModel.id}`,
+					`${fallbackModel.provider}/${fallbackModel.id}`,
+					`${exhaustedModel.provider}/${exhaustedModel.id}`,
+				],
+			},
+		});
+		settings.setModelRole("default", `${primaryModel.provider}/${primaryModel.id}`);
+
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+		});
+		const waitSpy = vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+		const fallbackEvents: Array<Extract<AgentSessionEvent, { type: "retry_fallback_applied" }>> = [];
+		session.subscribe(event => {
+			if (event.type === "retry_fallback_applied") fallbackEvents.push(event);
+		});
+
+		await session.prompt("Trigger the long OpenCode Go weekly usage limit");
+		await session.waitForIdle();
+
+		expect(requestedModels).toEqual([
+			`${primaryModel.provider}/${primaryModel.id}`,
+			`${alternateOpenCodeModel.provider}/${alternateOpenCodeModel.id}`,
+			`${fallbackModel.provider}/${fallbackModel.id}`,
+			`${exhaustedModel.provider}/${exhaustedModel.id}`,
+			`${fallbackModel.provider}/${fallbackModel.id}`,
+		]);
+		expect(fallbackEvents).toContainEqual({
+			type: "retry_fallback_applied",
+			from: `${exhaustedModel.provider}/${exhaustedModel.id}`,
+			to: `${fallbackModel.provider}/${fallbackModel.id}`,
+			role: "default",
+		});
+		for (const call of waitSpy.mock.calls) {
+			expect(call[0]).toBeLessThan(300_000);
+		}
+		expect(lastAssistant(session).content).toContainEqual({
+			type: "text",
+			text: "recovered on cross-provider fallback",
+		});
+	});
+
 	it("honors the reason backoff for a transient rate-limit 429 without a provider hint", async () => {
 		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
 		if (!model) {

--- a/packages/coding-agent/test/turn-recovery-replay-unsafe.test.ts
+++ b/packages/coding-agent/test/turn-recovery-replay-unsafe.test.ts
@@ -282,8 +282,7 @@ describe("TurnRecovery replay-unsafe output classification", () => {
 		);
 		const message = {
 			...makeMessage([{ type: "text", text: "Already shown to the user" }], openCodeModel),
-			errorMessage:
-				"429 Weekly usage limit reached. type=GoUsageLimitError retry-after-ms=3242000",
+			errorMessage: "429 Weekly usage limit reached. type=GoUsageLimitError retry-after-ms=3242000",
 		} as AssistantMessage;
 		expect(recovery.isRetryableError(message)).toBe(false);
 	});

--- a/packages/coding-agent/test/turn-recovery-replay-unsafe.test.ts
+++ b/packages/coding-agent/test/turn-recovery-replay-unsafe.test.ts
@@ -270,6 +270,24 @@ describe("TurnRecovery replay-unsafe output classification", () => {
 		expect(recovery.isRetryableError(message)).toBe(false);
 	});
 
+	it("does not replay a long OpenCode Go usage limit after committed text", () => {
+		const openCodeModel = getBundledModel("opencode-go", "deepseek-v4-flash");
+		if (!openCodeModel) throw new Error("Expected bundled OpenCode Go model");
+		const recovery = new TurnRecovery(
+			createHost(openCodeModel, modelRegistry, {
+				fallbackChains: {
+					[`${openCodeModel.provider}/${openCodeModel.id}`]: ["openai/gpt-4o-mini"],
+				},
+			}),
+		);
+		const message = {
+			...makeMessage([{ type: "text", text: "Already shown to the user" }], openCodeModel),
+			errorMessage:
+				"429 Weekly usage limit reached. type=GoUsageLimitError retry-after-ms=3242000",
+		} as AssistantMessage;
+		expect(recovery.isRetryableError(message)).toBe(false);
+	});
+
 	it("allows replay-safe hard fallback and excludes committed text with a configured chain", () => {
 		const fallbackChains = {
 			[`${model.provider}/${model.id}`]: ["openai/gpt-4o-mini"],


### PR DESCRIPTION
When GoUsageLimitError carries a retry-after beyond retry.maxDelayMs, replay-safe turns now wrap configured fallback chains and omit every opencode-go candidate. A zero maxDelayMs continues to disable the cap.\n\nTests: bun test packages/coding-agent/test/agent-session-retry-cap.test.ts packages/coding-agent/test/turn-recovery-replay-unsafe.test.ts (87 pass).\n\nNegative control: setting wrapAround to false makes the long-quota regression fail; restored implementation passes.