### PR TITLE
fix(advisor): include bounded tool results in reviews

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Fixed an issue where custom model overrides were lost during configuration updates
 - Fixed "Please use nerdfont" notification incorrectly persisting after theme configuration
 - Fixed sampling parameter errors for newer Anthropic models (Opus 4.7+, Sonnet 5+)
+- Advisors now receive bounded tool-result excerpts and complete `ask` questions and answers, preventing reviews from missing user decisions ([#5266](https://github.com/can1357/oh-my-pi/issues/5266)).
 
 ## [18.0.11] - 2026-08-29
 

--- a/packages/coding-agent/src/advisor/delta-split.ts
+++ b/packages/coding-agent/src/advisor/delta-split.ts
@@ -67,6 +67,9 @@ export function renderAdvisorDeltaChunks(
 			toolResultIndex: resultsByCallId,
 			consumedToolCallIds: consumed,
 			watchedRoleState,
+			transformExpandedToolIO: opts.obfuscator
+				? text => opts.obfuscator!.obfuscate(text, opts.advisorRegexSecretValues)
+				: undefined,
 		});
 
 	const heading = "### Session update";

--- a/packages/coding-agent/src/advisor/delta-split.ts
+++ b/packages/coding-agent/src/advisor/delta-split.ts
@@ -37,6 +37,7 @@ export const ADVISOR_RENDER_OPTIONS = {
 	watchedRoles: true,
 	expandPrimaryContext: true,
 	expandEditDiffs: true,
+	expandToolIO: true,
 } as const;
 
 export interface RenderAdvisorDeltaChunksOptions {

--- a/packages/coding-agent/src/advisor/runtime.ts
+++ b/packages/coding-agent/src/advisor/runtime.ts
@@ -9,7 +9,6 @@ import type { SecretObfuscator } from "../secrets/obfuscator";
 import {
 	formatExecutionSourcePreview,
 	formatSessionHistoryMarkdown,
-	formatToolResultErrorPreview,
 	PRIMARY_CONTEXT_CUSTOM_TYPES,
 } from "../session/session-history-format";
 import { ADVISOR_RENDER_OPTIONS, renderAdvisorDeltaChunks } from "./delta-split";
@@ -623,6 +622,15 @@ export class AdvisorRuntime {
 				discoveredNewRegexSecretValue = true;
 			}
 		};
+		const addTextualContent = (content: TextualContent): void => {
+			if (typeof content === "string") {
+				addRegexValues(content);
+				return;
+			}
+			for (const block of content) {
+				if (block.type === "text") addRegexValues(block.text);
+			}
+		};
 		for (const message of delta) {
 			if (
 				message.role === "custom" &&
@@ -631,6 +639,7 @@ export class AdvisorRuntime {
 			) {
 				addRegexValues(message.content);
 			}
+			if (message.role === "toolResult") addTextualContent(message.content as TextualContent);
 		}
 		addRegexValues(renderedMd);
 		scrubAdvisorHistory(obfuscator, this.agent.state.messages, this.#advisorRegexSecretValues);
@@ -746,6 +755,7 @@ export class AdvisorRuntime {
 			md = formatSessionHistoryMarkdown(this.#obfuscatePrimaryContextMessages(obfuscator, delta), {
 				...ADVISOR_RENDER_OPTIONS,
 				includeThinking: this.#includeThinking,
+				transformExpandedToolIO: text => obfuscator.obfuscate(text, this.#advisorRegexSecretValues),
 			});
 			md = obfuscator.obfuscate(md, this.#advisorRegexSecretValues);
 		}
@@ -1483,29 +1493,6 @@ function obfuscateTextualContent(
 	return changed ? result : content;
 }
 
-function firstAdvisorToolResultErrorLine(content: TextualContent): string | undefined {
-	if (typeof content === "string") return content.split("\n", 1)[0];
-	const first = content[0];
-	if (first?.type !== "text") return undefined;
-	return first.text.split("\n", 1)[0];
-}
-
-function obfuscateAdvisorToolResultErrorContent(
-	obfuscator: SecretObfuscator,
-	content: TextualContent,
-	sharedRegexSecretValues: ReadonlySet<string>,
-): TextualContent {
-	const firstLine = firstAdvisorToolResultErrorLine(content);
-	if (firstLine === undefined) return content;
-	const preview = formatToolResultErrorPreview(content);
-	const obfuscatedPreview = obfuscator.obfuscate(preview, sharedRegexSecretValues);
-	if (obfuscatedPreview === firstLine) return content;
-	if (typeof content === "string") return obfuscatedPreview + content.slice(firstLine.length);
-	const first = content[0]!;
-	if (first.type !== "text") return content;
-	return [{ ...first, text: obfuscatedPreview + first.text.slice(firstLine.length) }, ...content.slice(1)];
-}
-
 function obfuscateAssistantMessage(
 	obfuscator: SecretObfuscator,
 	message: AssistantMessage,
@@ -1569,9 +1556,7 @@ function obfuscateAdvisorMessage(
 				details?: Record<string, unknown>;
 				isError?: boolean;
 			};
-			const content = msg.isError
-				? obfuscateAdvisorToolResultErrorContent(obfuscator, msg.content, sharedRegexSecretValues)
-				: msg.content;
+			const content = obfuscateTextualContent(obfuscator, msg.content, sharedRegexSecretValues);
 			let details = msg.details;
 			if (typeof details?.diff === "string") {
 				const diff = obfuscator.obfuscate(details.diff, sharedRegexSecretValues);

--- a/packages/coding-agent/src/prompts/advisor/system.md
+++ b/packages/coding-agent/src/prompts/advisor/system.md
@@ -47,9 +47,9 @@ NEVER raise backwards compatibility unless user or standing project rule explici
 - NEVER preserve removed behavior solely to satisfy its tests.
 
 Cite only transcript evidence or personally inspected tool output.
+Tool transcript fields labeled `Ask input` or `Tool result` are rendered evidence; use them directly. A result containing an `elided` marker is only an excerpt.
 Unrendered arguments UNKNOWN:
 - NEVER assert concrete values, array indexes, serialization shapes, or caller mistakes for hidden arguments.
-- Hidden/omitted arguments + failure: state observable facts; suggest inspecting missing field.
 - Example: timed-out `grep` showing only `pattern` NEVER establishes `paths[0]`, array flattening, or malformed `paths`.
 Cite exact instruction or risk.
 </critical>

--- a/packages/coding-agent/src/session/session-history-format.ts
+++ b/packages/coding-agent/src/session/session-history-format.ts
@@ -19,6 +19,7 @@ import type {
 	HookMessage,
 	PythonExecutionMessage,
 } from "./messages";
+import { truncateMiddle } from "./streaming-output";
 
 export interface HistoryFormatOptions {
 	/** Optional H1 prepended to the transcript. */
@@ -47,6 +48,12 @@ export interface HistoryFormatOptions {
 	 */
 	expandEditDiffs?: boolean;
 	/**
+	 * Append bounded tool-result text and, for `ask`, the structured questions.
+	 * Advisor transcripts enable this so reviewers see user decisions and the
+	 * evidence returned by primary tools without admitting unbounded output.
+	 */
+	expandToolIO?: boolean;
+	/**
 	 * Chunked rendering support: a caller formatting one logical transcript in
 	 * several calls (the advisor's chunked delta render) passes a result index
 	 * built over the WHOLE delta plus one shared consumed-id set, so a toolCall
@@ -67,6 +74,9 @@ export interface HistoryFormatOptions {
 
 /** Max length of the primary-arg summary inside `→ tool(...)` lines. */
 const PRIMARY_ARG_MAX = 120;
+/** Per-tool budget for expanded advisor input/output. */
+const EXPANDED_TOOL_IO_MAX_BYTES = 8 * 1024;
+const EXPANDED_TOOL_IO_MAX_LINES = 80;
 
 /** Per-tool preference order for the most informative scalar argument. */
 const PRIMARY_ARG_KEYS = [
@@ -190,6 +200,29 @@ function fenceDiff(diff: string): string {
 	return `${fence}diff\n${diff}\n${fence}`;
 }
 
+function fencedText(text: string, language = "text"): string {
+	const longest = text.match(/`+/g)?.reduce((max, run) => Math.max(max, run.length), 0) ?? 0;
+	const fence = "`".repeat(Math.max(3, longest + 1));
+	return `${fence}${language}\n${text}\n${fence}`;
+}
+
+function boundedToolContext(text: string): string {
+	return truncateMiddle(text, {
+		maxBytes: EXPANDED_TOOL_IO_MAX_BYTES,
+		maxLines: EXPANDED_TOOL_IO_MAX_LINES,
+	}).content;
+}
+
+function expandedAskArguments(args: Record<string, unknown> | undefined): string | undefined {
+	if (!args) return undefined;
+	const visibleArgs = Object.fromEntries(Object.entries(args).filter(([key]) => key !== INTENT_FIELD));
+	try {
+		return JSON.stringify(visibleArgs, undefined, 2);
+	} catch {
+		return undefined;
+	}
+}
+
 /** One line per tool call: `→ read(src/foo.ts:50-80) ⇒ ok · 31 lines`. */
 function toolCallLine(
 	name: string,
@@ -197,6 +230,7 @@ function toolCallLine(
 	result: ToolResultMessage | undefined,
 	includeToolIntent?: boolean,
 	expandEditDiffs?: boolean,
+	expandToolIO?: boolean,
 ): string {
 	const head = `→ ${name}(${formatToolCallPrimaryArg(name, args)})`;
 	let base: string;
@@ -219,6 +253,23 @@ function toolCallLine(
 		if (typeof diff === "string" && diff.trim()) {
 			base = `${base}\n${fenceDiff(diff)}`;
 		}
+	}
+
+	if (expandToolIO) {
+		const sections: string[] = [];
+		if (name === "ask") {
+			const askArguments = expandedAskArguments(args);
+			if (askArguments) sections.push(`Ask input:\n${fencedText(askArguments, "json")}`);
+		}
+		if (
+			result &&
+			!(expandEditDiffs && typeof (result.details as { diff?: unknown } | undefined)?.diff === "string")
+		) {
+			const resultText = contentToText(result.content).trim();
+			const visibleResult = name === "ask" ? resultText : boundedToolContext(resultText);
+			if (visibleResult) sections.push(`Tool result:\n${fencedText(visibleResult)}`);
+		}
+		if (sections.length > 0) base = `${base}\n${sections.join("\n")}`;
 	}
 
 	const formattedIntent = includeToolIntent ? formatToolCallIntentPreview(args) : undefined;
@@ -366,7 +417,14 @@ export function formatSessionHistoryMarkdown(messages: unknown[], opts?: History
 						const result = resultsByCallId.get(block.id);
 						if (result) consumed.add(block.id);
 						body.push(
-							toolCallLine(block.name, block.arguments, result, opts?.includeToolIntent, opts?.expandEditDiffs),
+							toolCallLine(
+								block.name,
+								block.arguments,
+								result,
+								opts?.includeToolIntent,
+								opts?.expandEditDiffs,
+								opts?.expandToolIO,
+							),
 						);
 					} else if (opts?.includeThinking && block.type === "thinking" && block.thinking.trim()) {
 						body.push(`_thinking:_ ${block.thinking}`);
@@ -390,7 +448,17 @@ export function formatSessionHistoryMarkdown(messages: unknown[], opts?: History
 			case "toolResult": {
 				// Normally consumed by its toolCall; orphans (e.g. truncated history) get their own line.
 				if (consumed.has(msg.toolCallId)) break;
-				lines.push(toolCallLine(msg.toolName, undefined, msg, opts?.includeToolIntent, opts?.expandEditDiffs), "");
+				lines.push(
+					toolCallLine(
+						msg.toolName,
+						undefined,
+						msg,
+						opts?.includeToolIntent,
+						opts?.expandEditDiffs,
+						opts?.expandToolIO,
+					),
+					"",
+				);
 				lastWatchedLabel = undefined;
 				break;
 			}

--- a/packages/coding-agent/src/session/session-history-format.ts
+++ b/packages/coding-agent/src/session/session-history-format.ts
@@ -214,20 +214,6 @@ function boundedToolContext(text: string): string {
 	}).content;
 }
 
-function boundedFencedToolContext(text: string, language: string): string {
-	let bounded = boundedToolContext(text);
-	for (;;) {
-		const fenced = fencedText(bounded, language);
-		if (Buffer.byteLength(fenced, "utf-8") <= EXPANDED_TOOL_IO_MAX_BYTES) return fenced;
-		const longestFence = bounded.match(/`+/g)?.reduce((max, run) => Math.max(max, run.length), 0) ?? 0;
-		const fenceBytes = Math.max(3, longestFence + 1) * 2 + language.length + 2;
-		bounded = truncateMiddle(bounded, {
-			maxBytes: Math.max(1, EXPANDED_TOOL_IO_MAX_BYTES - fenceBytes),
-			maxLines: EXPANDED_TOOL_IO_MAX_LINES,
-		}).content;
-	}
-}
-
 function boundedAskJson(value: unknown): string {
 	return boundedToolContext(
 		JSON.stringify(
@@ -241,6 +227,28 @@ function boundedAskJson(value: unknown): string {
 					: nested,
 			2,
 		),
+	);
+}
+
+function boundedFencedToolContext(text: string, language: string): string {
+	const longestFence = text.match(/`+/g)?.reduce((max, run) => Math.max(max, run.length), 0) ?? 0;
+	// A pathological run can make Markdown fences larger than the whole budget.
+	// Use indented code in that case: constant wrapper cost and no delimiter collision.
+	if (longestFence * 2 > EXPANDED_TOOL_IO_MAX_BYTES / 2) {
+		const marker = "[…content elided to fit advisor context…]";
+		const bounded = truncateMiddle(text, {
+			maxBytes: EXPANDED_TOOL_IO_MAX_BYTES - Buffer.byteLength(marker) - 2,
+			maxLines: EXPANDED_TOOL_IO_MAX_LINES,
+		}).content;
+		return `${marker}\n${bounded}`.replace(/^/gm, "    ");
+	}
+	const fenceBytes = Math.max(3, longestFence + 1) * 2 + language.length + 2;
+	return fencedText(
+		truncateMiddle(text, {
+			maxBytes: Math.max(1, EXPANDED_TOOL_IO_MAX_BYTES - fenceBytes),
+			maxLines: EXPANDED_TOOL_IO_MAX_LINES,
+		}).content,
+		language,
 	);
 }
 

--- a/packages/coding-agent/src/session/session-history-format.ts
+++ b/packages/coding-agent/src/session/session-history-format.ts
@@ -19,7 +19,7 @@ import type {
 	HookMessage,
 	PythonExecutionMessage,
 } from "./messages";
-import { truncateMiddle } from "./streaming-output";
+import { truncateHeadBytes, truncateMiddle, truncateTailBytes } from "./streaming-output";
 
 export interface HistoryFormatOptions {
 	/** Optional H1 prepended to the transcript. */
@@ -212,8 +212,11 @@ function boundedToolContext(text: string): string {
 		maxLines: EXPANDED_TOOL_IO_MAX_LINES,
 	});
 	if (!truncated.truncated || truncated.content.includes(" elided…]")) return truncated.content;
-	const omittedBytes = Math.max(0, truncated.totalBytes - (truncated.outputBytes ?? 0));
-	return `[…${omittedBytes}B elided…]\n${truncated.content}`;
+	const windowBytes = Math.floor((EXPANDED_TOOL_IO_MAX_BYTES - 64) / 2);
+	const head = truncateHeadBytes(text, windowBytes);
+	const tail = truncateTailBytes(text, windowBytes);
+	const omittedBytes = Math.max(0, truncated.totalBytes - head.bytes - tail.bytes);
+	return `${head.text}\n[…${omittedBytes}B elided…]\n${tail.text}`;
 }
 
 function expandedAskArguments(args: Record<string, unknown> | undefined): string | undefined {

--- a/packages/coding-agent/src/session/session-history-format.ts
+++ b/packages/coding-agent/src/session/session-history-format.ts
@@ -228,6 +228,29 @@ function expandedAskArguments(args: Record<string, unknown> | undefined): string
 	}
 }
 
+function expandedAskDetails(result: ToolResultMessage | undefined): string | undefined {
+	if (!result?.details || typeof result.details !== "object") return undefined;
+	const details = result.details as {
+		question?: unknown;
+		questions?: unknown;
+		results?: unknown;
+	};
+	const questions = Array.isArray(details.results)
+		? details.results
+				.map(item =>
+					item && typeof item === "object" && typeof (item as { question?: unknown }).question === "string"
+						? (item as { question: string }).question
+						: undefined,
+				)
+				.filter((question): question is string => question !== undefined)
+		: Array.isArray(details.questions)
+			? details.questions.filter((question): question is string => typeof question === "string")
+			: typeof details.question === "string"
+				? [details.question]
+				: [];
+	return questions.length > 0 ? JSON.stringify({ questions }, undefined, 2) : undefined;
+}
+
 /** One line per tool call: `→ read(src/foo.ts:50-80) ⇒ ok · 31 lines`. */
 
 function expandedToolResultText(result: ToolResultMessage): string | undefined {
@@ -268,7 +291,7 @@ function toolCallLine(
 	if (expandToolIO) {
 		const sections: string[] = [];
 		if (name === "ask") {
-			const askArguments = expandedAskArguments(args);
+			const askArguments = expandedAskArguments(args) ?? expandedAskDetails(result);
 			if (askArguments) sections.push(`Ask input:\n${fencedText(askArguments, "json")}`);
 		}
 		if (result) {

--- a/packages/coding-agent/src/session/session-history-format.ts
+++ b/packages/coding-agent/src/session/session-history-format.ts
@@ -19,7 +19,7 @@ import type {
 	HookMessage,
 	PythonExecutionMessage,
 } from "./messages";
-import { truncateHeadBytes, truncateMiddle, truncateTailBytes } from "./streaming-output";
+import { truncateMiddle } from "./streaming-output";
 
 export interface HistoryFormatOptions {
 	/** Optional H1 prepended to the transcript. */
@@ -77,6 +77,8 @@ const PRIMARY_ARG_MAX = 120;
 /** Per-tool budget for expanded advisor input/output. */
 const EXPANDED_TOOL_IO_MAX_BYTES = 8 * 1024;
 const EXPANDED_TOOL_IO_MAX_LINES = 80;
+const EXPANDED_ASK_FIELD_MAX_BYTES = 2 * 1024;
+const EXPANDED_ASK_FIELD_MAX_LINES = 20;
 
 /** Per-tool preference order for the most informative scalar argument. */
 const PRIMARY_ARG_KEYS = [
@@ -206,23 +208,33 @@ function fenceDiff(diff: string): string {
 }
 
 function boundedToolContext(text: string): string {
-	const truncated = truncateMiddle(text, {
+	return truncateMiddle(text, {
 		maxBytes: EXPANDED_TOOL_IO_MAX_BYTES,
 		maxLines: EXPANDED_TOOL_IO_MAX_LINES,
-	});
-	if (!truncated.truncated || truncated.truncatedBy === "middle") return truncated.content;
-	const windowBytes = Math.floor((EXPANDED_TOOL_IO_MAX_BYTES - 64) / 2);
-	const head = truncateHeadBytes(text, windowBytes);
-	const tail = truncateTailBytes(text, windowBytes);
-	const omittedBytes = Math.max(0, truncated.totalBytes - head.bytes - tail.bytes);
-	return `${head.text}\n[…${omittedBytes}B elided…]\n${tail.text}`;
+	}).content;
+}
+
+function boundedAskJson(value: unknown): string {
+	return boundedToolContext(
+		JSON.stringify(
+			value,
+			(_key, nested) =>
+				typeof nested === "string"
+					? truncateMiddle(nested, {
+							maxBytes: EXPANDED_ASK_FIELD_MAX_BYTES,
+							maxLines: EXPANDED_ASK_FIELD_MAX_LINES,
+						}).content
+					: nested,
+			2,
+		),
+	);
 }
 
 function expandedAskArguments(args: Record<string, unknown> | undefined): string | undefined {
 	if (!args) return undefined;
 	const visibleArgs = Object.fromEntries(Object.entries(args).filter(([key]) => key !== INTENT_FIELD));
 	try {
-		return JSON.stringify(visibleArgs, undefined, 2);
+		return boundedAskJson(visibleArgs);
 	} catch {
 		return undefined;
 	}
@@ -248,7 +260,7 @@ function expandedAskDetails(result: ToolResultMessage | undefined): string | und
 			: typeof details.question === "string"
 				? [details.question]
 				: [];
-	return questions.length > 0 ? JSON.stringify({ questions }, undefined, 2) : undefined;
+	return questions.length > 0 ? boundedAskJson({ questions }) : undefined;
 }
 
 /** One line per tool call: `→ read(src/foo.ts:50-80) ⇒ ok · 31 lines`. */
@@ -297,7 +309,7 @@ function toolCallLine(
 		if (result) {
 			const resultText = expandedToolResultText(result);
 			if (resultText) {
-				const visibleResult = name === "ask" ? resultText : boundedToolContext(resultText);
+				const visibleResult = boundedToolContext(resultText);
 				sections.push(`Tool result:\n${fencedText(visibleResult, "text")}`);
 			}
 		}

--- a/packages/coding-agent/src/session/session-history-format.ts
+++ b/packages/coding-agent/src/session/session-history-format.ts
@@ -231,21 +231,9 @@ function expandedAskArguments(args: Record<string, unknown> | undefined): string
 
 /** One line per tool call: `→ read(src/foo.ts:50-80) ⇒ ok · 31 lines`. */
 
-function expandedToolResultText(result: ToolResultMessage, expandEditDiffs: boolean | undefined): string | undefined {
+function expandedToolResultText(result: ToolResultMessage): string | undefined {
 	const text = contentToText(result.content).trim();
-	if (!text) return undefined;
-	const details = result.details as { diff?: unknown; move?: unknown; perFileResults?: unknown } | undefined;
-	const diff = details?.diff;
-	if (!expandEditDiffs || result.isError || typeof diff !== "string" || !diff.trim()) return text;
-	const supplementary = text.split("\n").filter(line => line.startsWith("Moved to ") || line === "Warnings:");
-	const warningMarker = "\n\nWarnings:\n";
-	const warningIndex = text.indexOf(warningMarker);
-	if (warningIndex >= 0)
-		return [...supplementary.filter(line => line !== "Warnings:"), text.slice(warningIndex + 2)].join("\n");
-	if (typeof details?.move === "string" && !supplementary.some(line => line.startsWith("Moved to "))) {
-		supplementary.push(`Moved to ${details.move}`);
-	}
-	return supplementary.length > 0 ? supplementary.join("\n") : undefined;
+	return text || undefined;
 }
 function toolCallLine(
 	name: string,
@@ -285,7 +273,7 @@ function toolCallLine(
 			if (askArguments) sections.push(`Ask input:\n${fencedText(askArguments, "json")}`);
 		}
 		if (result) {
-			const resultText = expandedToolResultText(result, expandEditDiffs);
+			const resultText = expandedToolResultText(result);
 			if (resultText) {
 				const visibleResult = name === "ask" ? resultText : boundedToolContext(resultText);
 				sections.push(`Tool result:\n${fencedText(visibleResult)}`);

--- a/packages/coding-agent/src/session/session-history-format.ts
+++ b/packages/coding-agent/src/session/session-history-format.ts
@@ -269,7 +269,11 @@ function toolCallLine(
 		}
 		if (
 			result &&
-			!(expandEditDiffs && typeof (result.details as { diff?: unknown } | undefined)?.diff === "string")
+			!(
+				expandEditDiffs &&
+				!result.isError &&
+				typeof (result.details as { diff?: unknown } | undefined)?.diff === "string"
+			)
 		) {
 			const resultText = contentToText(result.content).trim();
 			const visibleResult = name === "ask" ? resultText : boundedToolContext(resultText);

--- a/packages/coding-agent/src/session/session-history-format.ts
+++ b/packages/coding-agent/src/session/session-history-format.ts
@@ -272,7 +272,8 @@ function toolCallLine(
 			!(
 				expandEditDiffs &&
 				!result.isError &&
-				typeof (result.details as { diff?: unknown } | undefined)?.diff === "string"
+				typeof (result.details as { diff?: unknown } | undefined)?.diff === "string" &&
+				(result.details as { diff: string }).diff.trim().length > 0
 			)
 		) {
 			const resultText = contentToText(result.content).trim();

--- a/packages/coding-agent/src/session/session-history-format.ts
+++ b/packages/coding-agent/src/session/session-history-format.ts
@@ -207,10 +207,13 @@ function fencedText(text: string, language = "text"): string {
 }
 
 function boundedToolContext(text: string): string {
-	return truncateMiddle(text, {
+	const truncated = truncateMiddle(text, {
 		maxBytes: EXPANDED_TOOL_IO_MAX_BYTES,
 		maxLines: EXPANDED_TOOL_IO_MAX_LINES,
-	}).content;
+	});
+	if (!truncated.truncated || truncated.content.includes(" elided…]")) return truncated.content;
+	const omittedBytes = Math.max(0, truncated.totalBytes - (truncated.outputBytes ?? 0));
+	return `[…${omittedBytes}B elided…]\n${truncated.content}`;
 }
 
 function expandedAskArguments(args: Record<string, unknown> | undefined): string | undefined {

--- a/packages/coding-agent/src/session/session-history-format.ts
+++ b/packages/coding-agent/src/session/session-history-format.ts
@@ -194,16 +194,15 @@ export function formatToolResultErrorPreview(content: string | readonly (TextCon
  * run inside it, so a diff that touches markdown (triple backticks) can't break
  * out of the fence. Info string `diff` for syntax highlighting.
  */
-function fenceDiff(diff: string): string {
-	const longest = diff.match(/`+/g)?.reduce((m, run) => Math.max(m, run.length), 0) ?? 0;
-	const fence = "`".repeat(Math.max(3, longest + 1));
-	return `${fence}diff\n${diff}\n${fence}`;
-}
-
-function fencedText(text: string, language = "text"): string {
+function fencedText(text: string, language: string): string {
 	const longest = text.match(/`+/g)?.reduce((max, run) => Math.max(max, run.length), 0) ?? 0;
 	const fence = "`".repeat(Math.max(3, longest + 1));
 	return `${fence}${language}\n${text}\n${fence}`;
+}
+
+/** Wrap a diff in the shared adaptive Markdown fence. */
+function fenceDiff(diff: string): string {
+	return fencedText(diff, "diff");
 }
 
 function boundedToolContext(text: string): string {
@@ -232,8 +231,8 @@ function expandedAskArguments(args: Record<string, unknown> | undefined): string
 /** One line per tool call: `→ read(src/foo.ts:50-80) ⇒ ok · 31 lines`. */
 
 function expandedToolResultText(result: ToolResultMessage): string | undefined {
-	const text = contentToText(result.content).trim();
-	return text || undefined;
+	const text = contentToText(result.content);
+	return text.trim() ? text : undefined;
 }
 function toolCallLine(
 	name: string,
@@ -276,7 +275,7 @@ function toolCallLine(
 			const resultText = expandedToolResultText(result);
 			if (resultText) {
 				const visibleResult = name === "ask" ? resultText : boundedToolContext(resultText);
-				sections.push(`Tool result:\n${fencedText(visibleResult)}`);
+				sections.push(`Tool result:\n${fencedText(visibleResult, "text")}`);
 			}
 		}
 		if (sections.length > 0) base = `${base}\n${sections.join("\n")}`;

--- a/packages/coding-agent/src/session/session-history-format.ts
+++ b/packages/coding-agent/src/session/session-history-format.ts
@@ -214,6 +214,20 @@ function boundedToolContext(text: string): string {
 	}).content;
 }
 
+function boundedFencedToolContext(text: string, language: string): string {
+	let bounded = boundedToolContext(text);
+	for (;;) {
+		const fenced = fencedText(bounded, language);
+		if (Buffer.byteLength(fenced, "utf-8") <= EXPANDED_TOOL_IO_MAX_BYTES) return fenced;
+		const longestFence = bounded.match(/`+/g)?.reduce((max, run) => Math.max(max, run.length), 0) ?? 0;
+		const fenceBytes = Math.max(3, longestFence + 1) * 2 + language.length + 2;
+		bounded = truncateMiddle(bounded, {
+			maxBytes: Math.max(1, EXPANDED_TOOL_IO_MAX_BYTES - fenceBytes),
+			maxLines: EXPANDED_TOOL_IO_MAX_LINES,
+		}).content;
+	}
+}
+
 function boundedAskJson(value: unknown): string {
 	return boundedToolContext(
 		JSON.stringify(
@@ -304,13 +318,12 @@ function toolCallLine(
 		const sections: string[] = [];
 		if (name === "ask") {
 			const askArguments = expandedAskArguments(args) ?? expandedAskDetails(result);
-			if (askArguments) sections.push(`Ask input:\n${fencedText(askArguments, "json")}`);
+			if (askArguments) sections.push(`Ask input:\n${boundedFencedToolContext(askArguments, "json")}`);
 		}
 		if (result) {
 			const resultText = expandedToolResultText(result);
 			if (resultText) {
-				const visibleResult = boundedToolContext(resultText);
-				sections.push(`Tool result:\n${fencedText(visibleResult, "text")}`);
+				sections.push(`Tool result:\n${boundedFencedToolContext(resultText, "text")}`);
 			}
 		}
 		if (sections.length > 0) base = `${base}\n${sections.join("\n")}`;

--- a/packages/coding-agent/src/session/session-history-format.ts
+++ b/packages/coding-agent/src/session/session-history-format.ts
@@ -238,11 +238,12 @@ function boundedFencedToolContext(text: string, language: string): string {
 	// Use indented code in that case: constant wrapper cost and no delimiter collision.
 	if (longestFence * 2 > EXPANDED_TOOL_IO_MAX_BYTES / 2) {
 		const marker = "[…content elided to fit advisor context…]";
-		const bounded = truncateMiddle(text, {
+		const truncated = truncateMiddle(text, {
 			maxBytes: EXPANDED_TOOL_IO_MAX_BYTES - Buffer.byteLength(marker) - 2,
 			maxLines: EXPANDED_TOOL_IO_MAX_LINES,
-		}).content;
-		return `${marker}\n${bounded}`.replace(/^/gm, "    ");
+		});
+		const bounded = truncated.truncated ? `${marker}\n${truncated.content}` : truncated.content;
+		return bounded.replace(/^/gm, "    ");
 	}
 	const fenceBytes = Math.max(3, longestFence + 1) * 2 + language.length + 2;
 	return fencedText(

--- a/packages/coding-agent/src/session/session-history-format.ts
+++ b/packages/coding-agent/src/session/session-history-format.ts
@@ -234,11 +234,18 @@ function expandedAskArguments(args: Record<string, unknown> | undefined): string
 function expandedToolResultText(result: ToolResultMessage, expandEditDiffs: boolean | undefined): string | undefined {
 	const text = contentToText(result.content).trim();
 	if (!text) return undefined;
-	const diff = (result.details as { diff?: unknown } | undefined)?.diff;
+	const details = result.details as { diff?: unknown; move?: unknown; perFileResults?: unknown } | undefined;
+	const diff = details?.diff;
 	if (!expandEditDiffs || result.isError || typeof diff !== "string" || !diff.trim()) return text;
+	const supplementary = text.split("\n").filter(line => line.startsWith("Moved to ") || line === "Warnings:");
 	const warningMarker = "\n\nWarnings:\n";
 	const warningIndex = text.indexOf(warningMarker);
-	return warningIndex < 0 ? undefined : text.slice(warningIndex + 2);
+	if (warningIndex >= 0)
+		return [...supplementary.filter(line => line !== "Warnings:"), text.slice(warningIndex + 2)].join("\n");
+	if (typeof details?.move === "string" && !supplementary.some(line => line.startsWith("Moved to "))) {
+		supplementary.push(`Moved to ${details.move}`);
+	}
+	return supplementary.length > 0 ? supplementary.join("\n") : undefined;
 }
 function toolCallLine(
 	name: string,

--- a/packages/coding-agent/src/session/session-history-format.ts
+++ b/packages/coding-agent/src/session/session-history-format.ts
@@ -53,6 +53,8 @@ export interface HistoryFormatOptions {
 	 * evidence returned by primary tools without admitting unbounded output.
 	 */
 	expandToolIO?: boolean;
+	/** Transform expanded tool input/output before any byte or line truncation. */
+	transformExpandedToolIO?: (text: string) => string;
 	/**
 	 * Chunked rendering support: a caller formatting one logical transcript in
 	 * several calls (the advisor's chunked delta render) passes a result index
@@ -214,17 +216,17 @@ function boundedToolContext(text: string): string {
 	}).content;
 }
 
-function boundedAskJson(value: unknown): string {
+function boundedAskJson(value: unknown, transform?: (text: string) => string): string {
 	return boundedToolContext(
 		JSON.stringify(
 			value,
-			(_key, nested) =>
-				typeof nested === "string"
-					? truncateMiddle(nested, {
-							maxBytes: EXPANDED_ASK_FIELD_MAX_BYTES,
-							maxLines: EXPANDED_ASK_FIELD_MAX_LINES,
-						}).content
-					: nested,
+			(_key, nested) => {
+				if (typeof nested !== "string") return nested;
+				return truncateMiddle(transform?.(nested) ?? nested, {
+					maxBytes: EXPANDED_ASK_FIELD_MAX_BYTES,
+					maxLines: EXPANDED_ASK_FIELD_MAX_LINES,
+				}).content;
+			},
 			2,
 		),
 	);
@@ -252,17 +254,23 @@ function boundedFencedToolContext(text: string, language: string): string {
 	);
 }
 
-function expandedAskArguments(args: Record<string, unknown> | undefined): string | undefined {
+function expandedAskArguments(
+	args: Record<string, unknown> | undefined,
+	transform?: (text: string) => string,
+): string | undefined {
 	if (!args) return undefined;
 	const visibleArgs = Object.fromEntries(Object.entries(args).filter(([key]) => key !== INTENT_FIELD));
 	try {
-		return boundedAskJson(visibleArgs);
+		return boundedAskJson(visibleArgs, transform);
 	} catch {
 		return undefined;
 	}
 }
 
-function expandedAskDetails(result: ToolResultMessage | undefined): string | undefined {
+function expandedAskDetails(
+	result: ToolResultMessage | undefined,
+	transform?: (text: string) => string,
+): string | undefined {
 	if (!result?.details || typeof result.details !== "object") return undefined;
 	const details = result.details as {
 		question?: unknown;
@@ -282,14 +290,13 @@ function expandedAskDetails(result: ToolResultMessage | undefined): string | und
 			: typeof details.question === "string"
 				? [details.question]
 				: [];
-	return questions.length > 0 ? boundedAskJson({ questions }) : undefined;
+	return questions.length > 0 ? boundedAskJson({ questions }, transform) : undefined;
 }
 
 /** One line per tool call: `→ read(src/foo.ts:50-80) ⇒ ok · 31 lines`. */
 
-function expandedToolResultText(result: ToolResultMessage): string | undefined {
-	const text = contentToText(result.content);
-	return text.trim() ? text : undefined;
+function expandedToolResultText(text: string | undefined): string | undefined {
+	return text?.trim() ? text : undefined;
 }
 function toolCallLine(
 	name: string,
@@ -298,17 +305,20 @@ function toolCallLine(
 	includeToolIntent?: boolean,
 	expandEditDiffs?: boolean,
 	expandToolIO?: boolean,
+	transformExpandedToolIO?: (text: string) => string,
 ): string {
 	const head = `→ ${name}(${formatToolCallPrimaryArg(name, args)})`;
+	const rawResultText = result ? contentToText(result.content) : undefined;
+	const visibleResultText =
+		rawResultText === undefined ? undefined : (transformExpandedToolIO?.(rawResultText) ?? rawResultText);
 	let base: string;
 	if (!result) {
 		base = `${head} ⇒ pending`;
 	} else {
-		const text = contentToText(result.content);
-		const lines = lineCount(text);
+		const lines = lineCount(rawResultText ?? "");
 		const count = `${lines} ${lines === 1 ? "line" : "lines"}`;
 		if (result.isError) {
-			const firstLine = formatToolResultErrorPreview(result.content);
+			const firstLine = formatToolResultErrorPreview(visibleResultText ?? "");
 			base = firstLine ? `${head} ⇒ error · ${count} — ${firstLine}` : `${head} ⇒ error · ${count}`;
 		} else {
 			base = `${head} ⇒ ok · ${count}`;
@@ -325,11 +335,12 @@ function toolCallLine(
 	if (expandToolIO) {
 		const sections: string[] = [];
 		if (name === "ask") {
-			const askArguments = expandedAskArguments(args) ?? expandedAskDetails(result);
+			const askArguments =
+				expandedAskArguments(args, transformExpandedToolIO) ?? expandedAskDetails(result, transformExpandedToolIO);
 			if (askArguments) sections.push(`Ask input:\n${boundedFencedToolContext(askArguments, "json")}`);
 		}
 		if (result) {
-			const resultText = expandedToolResultText(result);
+			const resultText = expandedToolResultText(visibleResultText);
 			if (resultText) {
 				sections.push(`Tool result:\n${boundedFencedToolContext(resultText, "text")}`);
 			}
@@ -489,6 +500,7 @@ export function formatSessionHistoryMarkdown(messages: unknown[], opts?: History
 								opts?.includeToolIntent,
 								opts?.expandEditDiffs,
 								opts?.expandToolIO,
+								opts?.transformExpandedToolIO,
 							),
 						);
 					} else if (opts?.includeThinking && block.type === "thinking" && block.thinking.trim()) {
@@ -521,6 +533,7 @@ export function formatSessionHistoryMarkdown(messages: unknown[], opts?: History
 						opts?.includeToolIntent,
 						opts?.expandEditDiffs,
 						opts?.expandToolIO,
+						opts?.transformExpandedToolIO,
 					),
 					"",
 				);

--- a/packages/coding-agent/src/session/session-history-format.ts
+++ b/packages/coding-agent/src/session/session-history-format.ts
@@ -230,6 +230,16 @@ function expandedAskArguments(args: Record<string, unknown> | undefined): string
 }
 
 /** One line per tool call: `→ read(src/foo.ts:50-80) ⇒ ok · 31 lines`. */
+
+function expandedToolResultText(result: ToolResultMessage, expandEditDiffs: boolean | undefined): string | undefined {
+	const text = contentToText(result.content).trim();
+	if (!text) return undefined;
+	const diff = (result.details as { diff?: unknown } | undefined)?.diff;
+	if (!expandEditDiffs || result.isError || typeof diff !== "string" || !diff.trim()) return text;
+	const warningMarker = "\n\nWarnings:\n";
+	const warningIndex = text.indexOf(warningMarker);
+	return warningIndex < 0 ? undefined : text.slice(warningIndex + 2);
+}
 function toolCallLine(
 	name: string,
 	args: Record<string, unknown> | undefined,
@@ -267,18 +277,12 @@ function toolCallLine(
 			const askArguments = expandedAskArguments(args);
 			if (askArguments) sections.push(`Ask input:\n${fencedText(askArguments, "json")}`);
 		}
-		if (
-			result &&
-			!(
-				expandEditDiffs &&
-				!result.isError &&
-				typeof (result.details as { diff?: unknown } | undefined)?.diff === "string" &&
-				(result.details as { diff: string }).diff.trim().length > 0
-			)
-		) {
-			const resultText = contentToText(result.content).trim();
-			const visibleResult = name === "ask" ? resultText : boundedToolContext(resultText);
-			if (visibleResult) sections.push(`Tool result:\n${fencedText(visibleResult)}`);
+		if (result) {
+			const resultText = expandedToolResultText(result, expandEditDiffs);
+			if (resultText) {
+				const visibleResult = name === "ask" ? resultText : boundedToolContext(resultText);
+				sections.push(`Tool result:\n${fencedText(visibleResult)}`);
+			}
 		}
 		if (sections.length > 0) base = `${base}\n${sections.join("\n")}`;
 	}

--- a/packages/coding-agent/src/session/session-history-format.ts
+++ b/packages/coding-agent/src/session/session-history-format.ts
@@ -211,7 +211,7 @@ function boundedToolContext(text: string): string {
 		maxBytes: EXPANDED_TOOL_IO_MAX_BYTES,
 		maxLines: EXPANDED_TOOL_IO_MAX_LINES,
 	});
-	if (!truncated.truncated || truncated.content.includes(" elided…]")) return truncated.content;
+	if (!truncated.truncated || truncated.truncatedBy === "middle") return truncated.content;
 	const windowBytes = Math.floor((EXPANDED_TOOL_IO_MAX_BYTES - 64) / 2);
 	const head = truncateHeadBytes(text, windowBytes);
 	const tail = truncateTailBytes(text, windowBytes);

--- a/packages/coding-agent/src/session/streaming-output.ts
+++ b/packages/coding-agent/src/session/streaming-output.ts
@@ -590,8 +590,9 @@ export function truncateMiddle(content: string, options: TruncationOptions = {})
 			firstLineExceedsLimit: false,
 		};
 	}
-	// Windows overlap → no meaningful elision; return content untruncated.
-	if (headLinesKept + tailLinesKept >= totalLines) {
+	// Fully retained line windows need no marker. A partial tail still omitted
+	// bytes from its source line even when the windows account for every line.
+	if (headLinesKept + tailLinesKept >= totalLines && !tail.lastLinePartial) {
 		return noTruncResult(content, totalLines, totalBytes);
 	}
 

--- a/packages/coding-agent/src/session/streaming-output.ts
+++ b/packages/coding-agent/src/session/streaming-output.ts
@@ -547,10 +547,42 @@ export function truncateMiddle(content: string, options: TruncationOptions = {})
 	const headBytesKept = head.outputBytes ?? Buffer.byteLength(head.content, "utf-8");
 	const tailBytesKept = tail.outputBytes ?? Buffer.byteLength(tail.content, "utf-8");
 
-	// Head unusable (first line exceeds budget) → tail-only.
-	if (headLinesKept === 0 || head.firstLineExceedsLimit) return tail;
-	// Tail unusable → head-only.
-	if (tailLinesKept === 0) return head;
+	// A giant first/last line cannot use one of the line-preserving windows. Use
+	// a byte window only for that side and retain the normal line cap on the other.
+	if (headLinesKept === 0 || head.firstLineExceedsLimit || tailLinesKept === 0) {
+		const byteHead =
+			headLinesKept === 0 || head.firstLineExceedsLimit
+				? truncateHeadBytes(content, Math.min(headBytes, totalBytes))
+				: { text: head.content, bytes: headBytesKept };
+		const remainingBytes = Math.max(0, totalBytes - byteHead.bytes);
+		const byteTail =
+			tailLinesKept === 0
+				? truncateTailBytes(content, Math.min(tailBytes, remainingBytes))
+				: (() => {
+						const limited = truncateTail(content, {
+							maxBytes: Math.min(tailBytes, remainingBytes),
+							maxLines: tailLines,
+						});
+						return { text: limited.content, bytes: limited.outputBytes ?? Buffer.byteLength(limited.content) };
+					})();
+		const elidedBytes = Math.max(0, totalBytes - byteHead.bytes - byteTail.bytes);
+		if (elidedBytes === 0) return noTruncResult(content, totalLines, totalBytes);
+		const marker = formatMiddleElisionMarker(0, elidedBytes);
+		const composed = `${byteHead.text}\n${marker}\n${byteTail.text}`;
+		return {
+			content: composed,
+			truncated: true,
+			truncatedBy: "middle",
+			totalLines,
+			totalBytes,
+			outputLines: countNewlines(composed) + 1,
+			outputBytes: Buffer.byteLength(composed, "utf-8"),
+			elidedLines: Math.max(0, totalLines - headLines - tailLines),
+			elidedBytes,
+			lastLinePartial: true,
+			firstLineExceedsLimit: false,
+		};
+	}
 	// Windows overlap → no meaningful elision; return content untruncated.
 	if (headLinesKept + tailLinesKept >= totalLines) {
 		return noTruncResult(content, totalLines, totalBytes);

--- a/packages/coding-agent/src/session/streaming-output.ts
+++ b/packages/coding-agent/src/session/streaming-output.ts
@@ -587,7 +587,7 @@ export function truncateMiddle(content: string, options: TruncationOptions = {})
 			elidedLines: Math.max(0, totalLines - actualHeadLines - actualTailLines),
 			headLines: actualHeadLines,
 			tailLines: actualTailLines,
-			partialByteWindows: useByteHead || useByteTail,
+			partialByteWindows: useByteHead || useByteTail || tail.lastLinePartial === true,
 			elidedBytes,
 			lastLinePartial: true,
 			firstLineExceedsLimit: false,

--- a/packages/coding-agent/src/session/streaming-output.ts
+++ b/packages/coding-agent/src/session/streaming-output.ts
@@ -103,6 +103,9 @@ export interface TruncationResult {
 	elidedBytes?: number;
 	/** Lines elided from the middle (truncateMiddle only). */
 	elidedLines?: number;
+	/** Exact source-line counts retained before/after the middle marker. */
+	headLines?: number;
+	tailLines?: number;
 	lastLinePartial?: boolean;
 	firstLineExceedsLimit?: boolean;
 }
@@ -550,21 +553,23 @@ export function truncateMiddle(content: string, options: TruncationOptions = {})
 	// A giant first/last line cannot use one of the line-preserving windows. Use
 	// a byte window only for that side and retain the normal line cap on the other.
 	if (headLinesKept === 0 || head.firstLineExceedsLimit || tailLinesKept === 0) {
-		const byteHead =
-			headLinesKept === 0 || head.firstLineExceedsLimit
-				? truncateHeadBytes(content, Math.min(headBytes, totalBytes))
-				: { text: head.content, bytes: headBytesKept };
+		const useByteHead = headLinesKept === 0 || head.firstLineExceedsLimit;
+		const byteHead = useByteHead
+			? truncateHeadBytes(content, Math.min(headBytes, totalBytes))
+			: { text: head.content, bytes: headBytesKept };
+		const actualHeadLines = useByteHead ? 1 : headLinesKept;
 		const remainingBytes = Math.max(0, totalBytes - byteHead.bytes);
-		const byteTail =
-			tailLinesKept === 0
-				? truncateTailBytes(content, Math.min(tailBytes, remainingBytes))
-				: (() => {
-						const limited = truncateTail(content, {
-							maxBytes: Math.min(tailBytes, remainingBytes),
-							maxLines: tailLines,
-						});
-						return { text: limited.content, bytes: limited.outputBytes ?? Buffer.byteLength(limited.content) };
-					})();
+		const useByteTail = tailLinesKept === 0;
+		const byteTail = useByteTail
+			? truncateTailBytes(content, Math.min(tailBytes, remainingBytes))
+			: (() => {
+					const limited = truncateTail(content, {
+						maxBytes: Math.min(tailBytes, remainingBytes),
+						maxLines: tailLines,
+					});
+					return { text: limited.content, bytes: limited.outputBytes ?? Buffer.byteLength(limited.content) };
+				})();
+		const actualTailLines = useByteTail ? 1 : Math.min(tailLinesKept, tailLines);
 		const elidedBytes = Math.max(0, totalBytes - byteHead.bytes - byteTail.bytes);
 		if (elidedBytes === 0) return noTruncResult(content, totalLines, totalBytes);
 		const marker = formatMiddleElisionMarker(0, elidedBytes);
@@ -575,9 +580,11 @@ export function truncateMiddle(content: string, options: TruncationOptions = {})
 			truncatedBy: "middle",
 			totalLines,
 			totalBytes,
-			outputLines: countNewlines(composed) + 1,
+			outputLines: actualHeadLines + actualTailLines + 1,
 			outputBytes: Buffer.byteLength(composed, "utf-8"),
-			elidedLines: Math.max(0, totalLines - headLines - tailLines),
+			elidedLines: Math.max(0, totalLines - actualHeadLines - actualTailLines),
+			headLines: actualHeadLines,
+			tailLines: actualTailLines,
 			elidedBytes,
 			lastLinePartial: true,
 			firstLineExceedsLimit: false,
@@ -606,6 +613,8 @@ export function truncateMiddle(content: string, options: TruncationOptions = {})
 		outputBytes: headBytesKept + tailBytesKept + markerBytes + 2,
 		elidedLines,
 		elidedBytes,
+		headLines: headLinesKept,
+		tailLines: tailLinesKept,
 		lastLinePartial: tail.lastLinePartial,
 		firstLineExceedsLimit: false,
 	};

--- a/packages/coding-agent/src/session/streaming-output.ts
+++ b/packages/coding-agent/src/session/streaming-output.ts
@@ -106,8 +106,8 @@ export interface TruncationResult {
 	/** Exact source-line counts retained before/after the middle marker. */
 	headLines?: number;
 	tailLines?: number;
-	/** True when both retained windows are partial byte ranges of one source line. */
-	singleLineByteWindows?: boolean;
+	/** True when either retained side is a partial byte range of a source line. */
+	partialByteWindows?: boolean;
 	lastLinePartial?: boolean;
 	firstLineExceedsLimit?: boolean;
 }
@@ -587,7 +587,7 @@ export function truncateMiddle(content: string, options: TruncationOptions = {})
 			elidedLines: Math.max(0, totalLines - actualHeadLines - actualTailLines),
 			headLines: actualHeadLines,
 			tailLines: actualTailLines,
-			singleLineByteWindows: totalLines === 1,
+			partialByteWindows: useByteHead || useByteTail,
 			elidedBytes,
 			lastLinePartial: true,
 			firstLineExceedsLimit: false,

--- a/packages/coding-agent/src/session/streaming-output.ts
+++ b/packages/coding-agent/src/session/streaming-output.ts
@@ -106,6 +106,8 @@ export interface TruncationResult {
 	/** Exact source-line counts retained before/after the middle marker. */
 	headLines?: number;
 	tailLines?: number;
+	/** True when both retained windows are partial byte ranges of one source line. */
+	singleLineByteWindows?: boolean;
 	lastLinePartial?: boolean;
 	firstLineExceedsLimit?: boolean;
 }
@@ -585,6 +587,7 @@ export function truncateMiddle(content: string, options: TruncationOptions = {})
 			elidedLines: Math.max(0, totalLines - actualHeadLines - actualTailLines),
 			headLines: actualHeadLines,
 			tailLines: actualTailLines,
+			singleLineByteWindows: totalLines === 1,
 			elidedBytes,
 			lastLinePartial: true,
 			firstLineExceedsLimit: false,

--- a/packages/coding-agent/src/tools/output-meta.ts
+++ b/packages/coding-agent/src/tools/output-meta.ts
@@ -461,8 +461,10 @@ export function formatTruncationMetaNotice(truncation: TruncationMeta): string {
 		const tailPart = tail ? `${tail.start}-${tail.end}` : "";
 		if (headPart && tailPart) {
 			notice = `Showing ${headPart} and ${tailPart} of ${totalLines}; ${elidedLines.toLocaleString()} middle line${elidedLines === 1 ? "" : "s"} (${formatBytes(elidedBytes)}) elided`;
+		} else if (totalLines === 1 && elidedBytes > 0) {
+			notice = `Showing head and tail bytes of 1 line; ${formatBytes(elidedBytes)} elided`;
 		} else {
-			notice = `Showing ${truncation.outputLines} of ${totalLines} lines; middle elided`;
+			notice = `Showing ${Math.min(truncation.outputLines, totalLines)} of ${totalLines} lines; middle elided`;
 		}
 		if (truncation.nextOffset != null) {
 			notice += `. Use :${truncation.nextOffset} to continue`;

--- a/packages/coding-agent/src/tools/output-meta.ts
+++ b/packages/coding-agent/src/tools/output-meta.ts
@@ -153,7 +153,7 @@ export class OutputMetaBuilder {
 				totalBytes: result.totalBytes,
 				outputLines,
 				outputBytes,
-				...(effectiveTotalLines > 1 && !result.singleLineByteWindows
+				...(effectiveTotalLines > 1 && !result.partialByteWindows
 					? {
 							headRange: headLines > 0 ? { start: 1, end: headLines } : undefined,
 							tailRange:
@@ -461,8 +461,8 @@ export function formatTruncationMetaNotice(truncation: TruncationMeta): string {
 		const tailPart = tail ? `${tail.start}-${tail.end}` : "";
 		if (headPart && tailPart) {
 			notice = `Showing ${headPart} and ${tailPart} of ${totalLines}; ${elidedLines.toLocaleString()} middle line${elidedLines === 1 ? "" : "s"} (${formatBytes(elidedBytes)}) elided`;
-		} else if (totalLines === 1 && elidedBytes > 0) {
-			notice = `Showing head and tail bytes of 1 line; ${formatBytes(elidedBytes)} elided`;
+		} else if (elidedBytes > 0) {
+			notice = `Showing head and tail bytes of ${totalLines.toLocaleString()} line${totalLines === 1 ? "" : "s"}; ${formatBytes(elidedBytes)} elided`;
 		} else {
 			notice = `Showing ${Math.min(truncation.outputLines, totalLines)} of ${totalLines} lines; middle elided`;
 		}
@@ -773,7 +773,7 @@ async function spillLargeResultToArtifact(
 			outputLines,
 			outputBytes,
 			maxBytes: headBytes + tailBytes,
-			...(truncated.totalLines > 1 && !truncated.singleLineByteWindows
+			...(truncated.totalLines > 1 && !truncated.partialByteWindows
 				? {
 						headRange: headLines > 0 ? { start: 1, end: headLines } : undefined,
 						tailRange:

--- a/packages/coding-agent/src/tools/output-meta.ts
+++ b/packages/coding-agent/src/tools/output-meta.ts
@@ -144,8 +144,8 @@ export class OutputMetaBuilder {
 			// `headLines` lines and the last `tailLines` lines of the source; lines
 			// in the middle (count == elidedLines) are dropped.
 			const keptLines = Math.max(0, outputLines - 1); // -1 for marker line
-			const headLines = Math.ceil(keptLines / 2);
-			const tailLines = keptLines - headLines;
+			const headLines = result.headLines ?? Math.ceil(keptLines / 2);
+			const tailLines = result.tailLines ?? keptLines - headLines;
 			this.#meta.truncation = {
 				direction: "middle",
 				truncatedBy: "middle",
@@ -755,8 +755,8 @@ async function spillLargeResultToArtifact(
 		const elidedLines = truncated.elidedLines ?? Math.max(0, truncated.totalLines - outputLines);
 		const elidedBytes = truncated.elidedBytes ?? Math.max(0, truncated.totalBytes - outputBytes);
 		const keptLines = Math.max(0, outputLines - 1); // -1 for marker line
-		const headLines = Math.ceil(keptLines / 2);
-		const tailLineCount = keptLines - headLines;
+		const headLines = truncated.headLines ?? Math.ceil(keptLines / 2);
+		const tailLineCount = truncated.tailLines ?? keptLines - headLines;
 		truncationMeta = {
 			direction: "middle",
 			truncatedBy: "middle",

--- a/packages/coding-agent/src/tools/output-meta.ts
+++ b/packages/coding-agent/src/tools/output-meta.ts
@@ -153,9 +153,15 @@ export class OutputMetaBuilder {
 				totalBytes: result.totalBytes,
 				outputLines,
 				outputBytes,
-				headRange: headLines > 0 ? { start: 1, end: headLines } : undefined,
-				tailRange:
-					tailLines > 0 ? { start: effectiveTotalLines - tailLines + 1, end: effectiveTotalLines } : undefined,
+				...(effectiveTotalLines > 1 && !result.singleLineByteWindows
+					? {
+							headRange: headLines > 0 ? { start: 1, end: headLines } : undefined,
+							tailRange:
+								tailLines > 0
+									? { start: effectiveTotalLines - tailLines + 1, end: effectiveTotalLines }
+									: undefined,
+						}
+					: {}),
 				elidedLines,
 				elidedBytes,
 				artifactId,

--- a/packages/coding-agent/src/tools/output-meta.ts
+++ b/packages/coding-agent/src/tools/output-meta.ts
@@ -765,11 +765,15 @@ async function spillLargeResultToArtifact(
 			outputLines,
 			outputBytes,
 			maxBytes: headBytes + tailBytes,
-			headRange: headLines > 0 ? { start: 1, end: headLines } : undefined,
-			tailRange:
-				tailLineCount > 0
-					? { start: truncated.totalLines - tailLineCount + 1, end: truncated.totalLines }
-					: undefined,
+			...(truncated.totalLines > 1 && !truncated.singleLineByteWindows
+				? {
+						headRange: headLines > 0 ? { start: 1, end: headLines } : undefined,
+						tailRange:
+							tailLineCount > 0
+								? { start: truncated.totalLines - tailLineCount + 1, end: truncated.totalLines }
+								: undefined,
+					}
+				: {}),
 			elidedLines,
 			elidedBytes,
 			artifactId,

--- a/packages/coding-agent/test/advisor/advisor.test.ts
+++ b/packages/coding-agent/test/advisor/advisor.test.ts
@@ -408,6 +408,23 @@ describe("advisor", () => {
 			expect(Buffer.byteLength(expanded)).toBeLessThan(9 * 1024);
 		});
 
+		it("still adds its own head-tail marker when retained output contains an upstream elision marker", () => {
+			const result = {
+				role: "toolResult",
+				toolCallId: "read-1",
+				toolName: "read",
+				content: [{ type: "text", text: `head-${"x".repeat(20_000)}-[…9B elided…]-tail` }],
+				isError: false,
+				timestamp: 2,
+			} as unknown as AgentMessage;
+
+			const expanded = formatSessionHistoryMarkdown([result], { expandToolIO: true });
+
+			expect(expanded).toContain("head-");
+			expect(expanded).toContain("-tail");
+			expect(expanded.match(/elided/g)).toHaveLength(2);
+		});
+
 		it("keeps failure details alongside a partial edit diff", () => {
 			const result = {
 				role: "toolResult",

--- a/packages/coding-agent/test/advisor/advisor.test.ts
+++ b/packages/coding-agent/test/advisor/advisor.test.ts
@@ -1961,6 +1961,37 @@ describe("advisor", () => {
 			expect(promptText(promptInputs[0])).toContain("$$");
 			expect(promptText(promptInputs[0])).not.toContain("tok_abc123");
 		});
+
+		it("redacts expanded tool results before middle truncation", async () => {
+			const secret = `BEGIN_SECRET_${"x".repeat(5_000)}_END_SECRET`;
+			const obfuscator = new SecretObfuscator([{ type: "plain", content: secret }]);
+			const placeholder = obfuscator.obfuscate(secret);
+			const promptInputs: Array<string | AgentMessage[]> = [];
+			const agent = makeAgent(promptInputs);
+			const messages: AgentMessage[] = [
+				{
+					role: "toolResult",
+					toolCallId: "c1",
+					toolName: "read",
+					content: `${"head".repeat(1_000)}${secret}${"tail".repeat(1_000)}`,
+					isError: false,
+					timestamp: 1,
+				} as unknown as AgentMessage,
+			];
+			const runtime = new AdvisorRuntime(agent, {
+				snapshotMessages: () => messages,
+				enqueueAdvice: () => {},
+				obfuscator,
+			});
+
+			runtime.onTurnEnd();
+			await runtime.waitForCatchup(1_000, 1);
+
+			const rendered = promptText(promptInputs[0]);
+			expect(rendered).toContain(placeholder);
+			expect(rendered).not.toContain("BEGIN_SECRET_");
+			expect(rendered).not.toContain("_END_SECRET");
+		});
 		it("does not scan tool-call arguments hidden by the primary-argument preview", async () => {
 			const obfuscator = new SecretObfuscator([
 				{ type: "plain", content: "OTHERSECRET", friendlyName: "TOKABC123" },

--- a/packages/coding-agent/test/advisor/advisor.test.ts
+++ b/packages/coding-agent/test/advisor/advisor.test.ts
@@ -466,6 +466,26 @@ describe("advisor", () => {
 			expect(expanded).toContain("+++ b/a.ts");
 			expect(expanded).toContain("Warnings:\nMatched ambiguous context.");
 		});
+
+		it("keeps rename metadata alongside a successful edit diff", () => {
+			const result = {
+				role: "toolResult",
+				toolCallId: "edit-1",
+				toolName: "edit",
+				content: [{ type: "text", text: "[src/old.ts]\nMoved to src/new.ts\n-old\n+new" }],
+				details: { diff: "@@\n-old\n+new", move: "src/new.ts" },
+				isError: false,
+				timestamp: 2,
+			} as unknown as AgentMessage;
+
+			const expanded = formatSessionHistoryMarkdown([result], {
+				expandEditDiffs: true,
+				expandToolIO: true,
+			});
+
+			expect(expanded).toContain("@@\n-old\n+new");
+			expect(expanded).toContain("Moved to src/new.ts");
+		});
 	});
 
 	describe("advisor yield-queue dispatcher", () => {

--- a/packages/coding-agent/test/advisor/advisor.test.ts
+++ b/packages/coding-agent/test/advisor/advisor.test.ts
@@ -446,6 +446,26 @@ describe("advisor", () => {
 
 			expect(expanded).toContain("Moved to src/new-name.ts");
 		});
+
+		it("keeps warnings alongside a successful edit diff", () => {
+			const result = {
+				role: "toolResult",
+				toolCallId: "edit-1",
+				toolName: "edit",
+				content: [{ type: "text", text: "[a.ts]\n-old\n+new\n\nWarnings:\nMatched ambiguous context." }],
+				details: { diff: "--- a/a.ts\n+++ b/a.ts\n@@\n-old\n+new" },
+				isError: false,
+				timestamp: 2,
+			} as unknown as AgentMessage;
+
+			const expanded = formatSessionHistoryMarkdown([result], {
+				expandEditDiffs: true,
+				expandToolIO: true,
+			});
+
+			expect(expanded).toContain("+++ b/a.ts");
+			expect(expanded).toContain("Warnings:\nMatched ambiguous context.");
+		});
 	});
 
 	describe("advisor yield-queue dispatcher", () => {
@@ -1824,7 +1844,7 @@ describe("advisor", () => {
 			expect(promptText(promptInputs[0])).toContain("$$TOKABC123_");
 			expect(promptText(promptInputs[0])).not.toContain("tok_abc123");
 		});
-		it("does not scan advisor-hidden successful tool-result bodies", async () => {
+		it("obfuscates advisor-visible successful tool-result bodies", async () => {
 			const obfuscator = new SecretObfuscator([
 				{ type: "plain", content: "OTHERSECRET", friendlyName: "TOKABC123" },
 				{ type: "regex", content: "tok_[a-z0-9]+" },
@@ -1853,7 +1873,7 @@ describe("advisor", () => {
 			await Promise.resolve();
 
 			expect(promptInputs).toHaveLength(1);
-			expect(promptText(promptInputs[0])).toContain("$$TOKABC123_");
+			expect(promptText(promptInputs[0])).toContain("$$");
 			expect(promptText(promptInputs[0])).not.toContain("tok_abc123");
 		});
 		it("does not scan tool-call arguments hidden by the primary-argument preview", async () => {
@@ -1884,7 +1904,7 @@ describe("advisor", () => {
 			expect(promptText(promptInputs[0])).not.toContain("tok_abc123");
 		});
 
-		it("does not scan failed tool-result text beyond its visible preview", async () => {
+		it("obfuscates failed tool-result text beyond its one-line preview", async () => {
 			const obfuscator = new SecretObfuscator([
 				{ type: "plain", content: "OTHERSECRET", friendlyName: "TOKABC123" },
 				{ type: "regex", content: "tok_[a-z0-9]+", mode: "replace" },
@@ -1909,7 +1929,7 @@ describe("advisor", () => {
 			});
 			runtime.onTurnEnd();
 			await runtime.waitForCatchup(1000, 1);
-			expect(promptText(promptInputs[0])).toContain("$$TOKABC123_");
+			expect(promptText(promptInputs[0])).toContain("$$");
 			expect(promptText(promptInputs[0])).not.toContain("tok_abc123");
 		});
 

--- a/packages/coding-agent/test/advisor/advisor.test.ts
+++ b/packages/coding-agent/test/advisor/advisor.test.ts
@@ -298,6 +298,99 @@ describe("advisor", () => {
 		});
 	});
 
+	describe("formatSessionHistoryMarkdown expandToolIO", () => {
+		const askCall = {
+			role: "assistant",
+			content: [
+				{
+					type: "toolCall",
+					id: "ask-1",
+					name: "ask",
+					arguments: {
+						questions: [
+							{
+								id: "deploy",
+								question: "Authorize deployment?",
+								options: [{ label: "Yes" }, { label: "No" }],
+							},
+						],
+					},
+				},
+			],
+			timestamp: 1,
+		} as unknown as AgentMessage;
+		const askResult = {
+			role: "toolResult",
+			toolCallId: "ask-1",
+			toolName: "ask",
+			content: [{ type: "text", text: "User selected: Yes" }],
+			details: { selectedOptions: ["Yes"] },
+			isError: false,
+			timestamp: 2,
+		} as unknown as AgentMessage;
+
+		it("includes the full ask question and user answer for advisor reviews", () => {
+			const compact = formatSessionHistoryMarkdown([askCall, askResult], { watchedRoles: true });
+			const expanded = formatSessionHistoryMarkdown([askCall, askResult], {
+				watchedRoles: true,
+				expandToolIO: true,
+			});
+
+			expect(compact).not.toContain("User selected: Yes");
+			expect(expanded).toContain('"question": "Authorize deployment?"');
+			expect(expanded).toContain('"label": "Yes"');
+			expect(expanded).toContain("User selected: Yes");
+		});
+
+		it("does not truncate long ask questions or custom answers", () => {
+			const marker = "authorization-at-end";
+			const longQuestion = {
+				...(askCall as unknown as { content: { arguments: { questions: unknown[] } }[] }),
+				content: [
+					{
+						...(askCall as unknown as { content: Record<string, unknown>[] }).content[0],
+						arguments: {
+							questions: [
+								{
+									id: "deploy",
+									question: `${"context ".repeat(1200)}${marker}`,
+									options: [{ label: "Custom" }],
+								},
+							],
+						},
+					},
+				],
+			} as unknown as AgentMessage;
+			const longAnswer = {
+				...(askResult as unknown as Record<string, unknown>),
+				content: [{ type: "text", text: `${"detail ".repeat(1200)}${marker}` }],
+			} as unknown as AgentMessage;
+
+			const expanded = formatSessionHistoryMarkdown([longQuestion, longAnswer], { expandToolIO: true });
+
+			expect(expanded.split(marker)).toHaveLength(3);
+			expect(expanded).not.toContain("elided");
+		});
+
+		it("bounds expanded tool results with visible head and tail context", () => {
+			const result = {
+				role: "toolResult",
+				toolCallId: "read-1",
+				toolName: "read",
+				content: [{ type: "text", text: `first\n${"middle\n".repeat(2000)}last` }],
+				isError: false,
+				timestamp: 2,
+			} as unknown as AgentMessage;
+
+			const expanded = formatSessionHistoryMarkdown([result], { expandToolIO: true });
+
+			expect(expanded).toContain("first");
+			expect(expanded).toContain("last");
+			expect(expanded).toContain("elided");
+			expect(Buffer.byteLength(expanded)).toBeLessThan(9 * 1024);
+		});
+	});
+
 	describe("advisor yield-queue dispatcher", () => {
 		it("batches advice notes into one custom message", async () => {
 			const injected: AgentMessage[] = [];

--- a/packages/coding-agent/test/advisor/advisor.test.ts
+++ b/packages/coding-agent/test/advisor/advisor.test.ts
@@ -427,6 +427,25 @@ describe("advisor", () => {
 			expect(expanded).toContain("+++ b/first.ts");
 			expect(expanded).toContain("Failed to match second file");
 		});
+
+		it("keeps successful edit results when no textual diff was rendered", () => {
+			const result = {
+				role: "toolResult",
+				toolCallId: "edit-1",
+				toolName: "edit",
+				content: [{ type: "text", text: "Moved to src/new-name.ts" }],
+				details: { diff: "" },
+				isError: false,
+				timestamp: 2,
+			} as unknown as AgentMessage;
+
+			const expanded = formatSessionHistoryMarkdown([result], {
+				expandEditDiffs: true,
+				expandToolIO: true,
+			});
+
+			expect(expanded).toContain("Moved to src/new-name.ts");
+		});
 	});
 
 	describe("advisor yield-queue dispatcher", () => {

--- a/packages/coding-agent/test/advisor/advisor.test.ts
+++ b/packages/coding-agent/test/advisor/advisor.test.ts
@@ -389,6 +389,23 @@ describe("advisor", () => {
 			expect(expanded).toContain("elided");
 			expect(Buffer.byteLength(expanded)).toBeLessThan(9 * 1024);
 		});
+
+		it("marks oversized single-line results as incomplete", () => {
+			const result = {
+				role: "toolResult",
+				toolCallId: "read-1",
+				toolName: "read",
+				content: [{ type: "text", text: `head-${"x".repeat(20_000)}-tail` }],
+				isError: false,
+				timestamp: 2,
+			} as unknown as AgentMessage;
+
+			const expanded = formatSessionHistoryMarkdown([result], { expandToolIO: true });
+
+			expect(expanded).toContain("elided");
+			expect(expanded).toContain("-tail");
+			expect(Buffer.byteLength(expanded)).toBeLessThan(9 * 1024);
+		});
 	});
 
 	describe("advisor yield-queue dispatcher", () => {

--- a/packages/coding-agent/test/advisor/advisor.test.ts
+++ b/packages/coding-agent/test/advisor/advisor.test.ts
@@ -422,6 +422,22 @@ describe("advisor", () => {
 			expect(Buffer.byteLength(expanded)).toBeLessThan(9 * 1024);
 		});
 
+		it("counts adaptive Markdown fences inside the result budget", () => {
+			const result = {
+				role: "toolResult",
+				toolCallId: "read-fence",
+				toolName: "read",
+				content: [{ type: "text", text: "`".repeat(8_000) }],
+				isError: false,
+				timestamp: 2,
+			} as unknown as AgentMessage;
+
+			const expanded = formatSessionHistoryMarkdown([result], { expandToolIO: true });
+
+			expect(expanded).toContain("Tool result:");
+			expect(Buffer.byteLength(expanded)).toBeLessThan(9 * 1024);
+		});
+
 		it("preserves head and tail for oversized single-line results", () => {
 			const result = {
 				role: "toolResult",

--- a/packages/coding-agent/test/advisor/advisor.test.ts
+++ b/packages/coding-agent/test/advisor/advisor.test.ts
@@ -407,6 +407,26 @@ describe("advisor", () => {
 			expect(expanded).toContain("-tail");
 			expect(Buffer.byteLength(expanded)).toBeLessThan(9 * 1024);
 		});
+
+		it("keeps failure details alongside a partial edit diff", () => {
+			const result = {
+				role: "toolResult",
+				toolCallId: "edit-1",
+				toolName: "edit",
+				content: [{ type: "text", text: "Applied first file.\nFailed to match second file; no later edits ran." }],
+				details: { diff: "--- a/first.ts\n+++ b/first.ts\n@@\n-old\n+new" },
+				isError: true,
+				timestamp: 2,
+			} as unknown as AgentMessage;
+
+			const expanded = formatSessionHistoryMarkdown([result], {
+				expandEditDiffs: true,
+				expandToolIO: true,
+			});
+
+			expect(expanded).toContain("+++ b/first.ts");
+			expect(expanded).toContain("Failed to match second file");
+		});
 	});
 
 	describe("advisor yield-queue dispatcher", () => {

--- a/packages/coding-agent/test/advisor/advisor.test.ts
+++ b/packages/coding-agent/test/advisor/advisor.test.ts
@@ -342,8 +342,9 @@ describe("advisor", () => {
 			expect(expanded).toContain("User selected: Yes");
 		});
 
-		it("does not truncate long ask questions or custom answers", () => {
-			const marker = "authorization-at-end";
+		it("bounds long ask questions and custom answers with visible head and tail context", () => {
+			const questionEnd = "question-at-end";
+			const answerEnd = "answer-at-end";
 			const longQuestion = {
 				...(askCall as unknown as { content: { arguments: { questions: unknown[] } }[] }),
 				content: [
@@ -353,7 +354,7 @@ describe("advisor", () => {
 							questions: [
 								{
 									id: "deploy",
-									question: `${"context ".repeat(1200)}${marker}`,
+									question: `question-start ${"context ".repeat(1200)}${questionEnd}`,
 									options: [{ label: "Custom" }],
 								},
 							],
@@ -363,13 +364,17 @@ describe("advisor", () => {
 			} as unknown as AgentMessage;
 			const longAnswer = {
 				...(askResult as unknown as Record<string, unknown>),
-				content: [{ type: "text", text: `${"detail ".repeat(1200)}${marker}` }],
+				content: [{ type: "text", text: `answer-start ${"detail ".repeat(1200)}${answerEnd}` }],
 			} as unknown as AgentMessage;
 
 			const expanded = formatSessionHistoryMarkdown([longQuestion, longAnswer], { expandToolIO: true });
 
-			expect(expanded.split(marker)).toHaveLength(3);
-			expect(expanded).not.toContain("elided");
+			expect(expanded).toContain("question-start");
+			expect(expanded).toContain(questionEnd);
+			expect(expanded).toContain("answer-start");
+			expect(expanded).toContain(answerEnd);
+			expect(expanded.match(/elided/g)?.length).toBeGreaterThanOrEqual(2);
+			expect(Buffer.byteLength(expanded)).toBeLessThan(18 * 1024);
 		});
 
 		it("recovers questions from orphaned ask result details", () => {

--- a/packages/coding-agent/test/advisor/advisor.test.ts
+++ b/packages/coding-agent/test/advisor/advisor.test.ts
@@ -438,6 +438,22 @@ describe("advisor", () => {
 			expect(Buffer.byteLength(expanded)).toBeLessThan(9 * 1024);
 		});
 
+		it("does not mark complete pathological fence content as elided", () => {
+			const result = {
+				role: "toolResult",
+				toolCallId: "read-fence-complete",
+				toolName: "read",
+				content: [{ type: "text", text: "`".repeat(3_000) }],
+				isError: false,
+				timestamp: 2,
+			} as unknown as AgentMessage;
+
+			const expanded = formatSessionHistoryMarkdown([result], { expandToolIO: true });
+
+			expect(expanded).not.toContain("elided");
+			expect(expanded).toContain("`".repeat(3_000));
+		});
+
 		it("preserves head and tail for oversized single-line results", () => {
 			const result = {
 				role: "toolResult",

--- a/packages/coding-agent/test/advisor/advisor.test.ts
+++ b/packages/coding-agent/test/advisor/advisor.test.ts
@@ -372,6 +372,33 @@ describe("advisor", () => {
 			expect(expanded).not.toContain("elided");
 		});
 
+		it("recovers questions from orphaned ask result details", () => {
+			const orphan = {
+				role: "toolResult",
+				toolCallId: "ask-orphan",
+				toolName: "ask",
+				content: [{ type: "text", text: "deploy: Yes" }],
+				details: {
+					results: [
+						{
+							id: "deploy",
+							question: "Authorize production deployment?",
+							options: ["Yes", "No"],
+							multi: false,
+							selectedOptions: ["Yes"],
+						},
+					],
+				},
+				isError: false,
+				timestamp: 2,
+			} as unknown as AgentMessage;
+
+			const expanded = formatSessionHistoryMarkdown([orphan], { expandToolIO: true });
+
+			expect(expanded).toContain("Authorize production deployment?");
+			expect(expanded).toContain("deploy: Yes");
+		});
+
 		it("bounds expanded tool results with visible head and tail context", () => {
 			const result = {
 				role: "toolResult",

--- a/packages/coding-agent/test/advisor/advisor.test.ts
+++ b/packages/coding-agent/test/advisor/advisor.test.ts
@@ -390,7 +390,7 @@ describe("advisor", () => {
 			expect(Buffer.byteLength(expanded)).toBeLessThan(9 * 1024);
 		});
 
-		it("marks oversized single-line results as incomplete", () => {
+		it("preserves head and tail for oversized single-line results", () => {
 			const result = {
 				role: "toolResult",
 				toolCallId: "read-1",
@@ -402,6 +402,7 @@ describe("advisor", () => {
 
 			const expanded = formatSessionHistoryMarkdown([result], { expandToolIO: true });
 
+			expect(expanded).toContain("head-");
 			expect(expanded).toContain("elided");
 			expect(expanded).toContain("-tail");
 			expect(Buffer.byteLength(expanded)).toBeLessThan(9 * 1024);

--- a/packages/coding-agent/test/advisor/delta-split.test.ts
+++ b/packages/coding-agent/test/advisor/delta-split.test.ts
@@ -42,6 +42,7 @@ const OPTS = {
 	watchedRoles: true,
 	expandPrimaryContext: true,
 	expandEditDiffs: true,
+	expandToolIO: true,
 	includeThinking: true,
 } as const;
 

--- a/packages/coding-agent/test/streaming-output.test.ts
+++ b/packages/coding-agent/test/streaming-output.test.ts
@@ -648,6 +648,15 @@ describe("truncateMiddle", () => {
 		expect(result.outputBytes).toBeLessThanOrEqual(8192 + 64);
 	});
 
+	test("marks single-line byte windows so line ranges can be omitted", () => {
+		const result = truncateMiddle("x".repeat(20_000), { maxBytes: 8192, maxLines: 80 });
+
+		expect(result.truncatedBy).toBe("middle");
+		expect(result.singleLineByteWindows).toBe(true);
+		expect(result.headLines).toBe(1);
+		expect(result.tailLines).toBe(1);
+	});
+
 	test("formatMiddleElisionMarker uses lines, falling back to bytes for <=1 line", () => {
 		expect(formatMiddleElisionMarker(0, 512)).toBe("[…512B elided…]");
 		expect(formatMiddleElisionMarker(1, 100)).toBe("[…100B elided…]");

--- a/packages/coding-agent/test/streaming-output.test.ts
+++ b/packages/coding-agent/test/streaming-output.test.ts
@@ -621,6 +621,8 @@ describe("truncateMiddle", () => {
 		expect(result.content.endsWith("short-3")).toBe(true);
 		expect(result.content).toContain("elided");
 		expect(result.elidedBytes).toBeGreaterThan(0);
+		expect(result.headLines).toBe(1);
+		expect(result.tailLines).toBe(2);
 	});
 
 	test("does not duplicate overlapping fallback windows", () => {
@@ -630,7 +632,8 @@ describe("truncateMiddle", () => {
 		expect(result.truncatedBy).toBe("middle");
 		expect(result.elidedBytes).toBeGreaterThan(0);
 		expect(result.content).not.toContain("[…0B elided…]");
-		expect(result.outputLines).toBeLessThanOrEqual(42);
+		expect(result.headLines).toBe(1);
+		expect(result.tailLines).toBeLessThanOrEqual(40);
 		expect(result.outputBytes).toBeLessThanOrEqual(8192 + 64);
 	});
 

--- a/packages/coding-agent/test/streaming-output.test.ts
+++ b/packages/coding-agent/test/streaming-output.test.ts
@@ -637,6 +637,17 @@ describe("truncateMiddle", () => {
 		expect(result.outputBytes).toBeLessThanOrEqual(8192 + 64);
 	});
 
+	test("keeps a giant trailing line within budget", () => {
+		const content = `label\n${"x".repeat(20_000)}`;
+		const result = truncateMiddle(content, { maxBytes: 8192, maxLines: 80 });
+
+		expect(result.truncated).toBe(true);
+		expect(result.truncatedBy).toBe("middle");
+		expect(result.content.startsWith("label\n")).toBe(true);
+		expect(result.content).toContain("elided");
+		expect(result.outputBytes).toBeLessThanOrEqual(8192 + 64);
+	});
+
 	test("formatMiddleElisionMarker uses lines, falling back to bytes for <=1 line", () => {
 		expect(formatMiddleElisionMarker(0, 512)).toBe("[…512B elided…]");
 		expect(formatMiddleElisionMarker(1, 100)).toBe("[…100B elided…]");

--- a/packages/coding-agent/test/streaming-output.test.ts
+++ b/packages/coding-agent/test/streaming-output.test.ts
@@ -637,6 +637,15 @@ describe("truncateMiddle", () => {
 		expect(result.outputBytes).toBeLessThanOrEqual(8192 + 64);
 	});
 
+	test("marks multi-line partial byte windows so exact ranges are omitted", () => {
+		const content = `${"x".repeat(20_000)}\n${"y".repeat(20_000)}`;
+		const result = truncateMiddle(content, { maxBytes: 8192, maxLines: 80 });
+
+		expect(result.truncatedBy).toBe("middle");
+		expect(result.partialByteWindows).toBe(true);
+		expect(result.elidedBytes).toBeGreaterThan(0);
+	});
+
 	test("keeps a giant trailing line within budget", () => {
 		const content = `label\n${"x".repeat(20_000)}`;
 		const result = truncateMiddle(content, { maxBytes: 8192, maxLines: 80 });
@@ -652,7 +661,7 @@ describe("truncateMiddle", () => {
 		const result = truncateMiddle("x".repeat(20_000), { maxBytes: 8192, maxLines: 80 });
 
 		expect(result.truncatedBy).toBe("middle");
-		expect(result.singleLineByteWindows).toBe(true);
+		expect(result.partialByteWindows).toBe(true);
 		expect(result.headLines).toBe(1);
 		expect(result.tailLines).toBe(1);
 	});

--- a/packages/coding-agent/test/streaming-output.test.ts
+++ b/packages/coding-agent/test/streaming-output.test.ts
@@ -607,17 +607,31 @@ describe("truncateMiddle", () => {
 		expect(result.elidedBytes).toBeGreaterThan(0);
 	});
 
-	test("falls back to tail-only when head budget cannot accept the first line", () => {
+	test("uses non-overlapping byte windows when the first line exceeds the head budget", () => {
 		const giantFirstLine = `${"x".repeat(200)}\nshort-2\nshort-3`;
 		const result = truncateMiddle(giantFirstLine, {
 			maxBytes: 40,
 			maxLines: 10,
-			maxHeadBytes: 8, // first line is 200 bytes — exceeds head budget
+			maxHeadBytes: 8,
 			maxHeadLines: 1,
 		});
 		expect(result.truncated).toBe(true);
-		// Should not contain the elision marker; it's a regular tail truncation.
-		expect(result.content).not.toContain("elided");
+		expect(result.truncatedBy).toBe("middle");
+		expect(result.content.startsWith("xxxxxxxx")).toBe(true);
+		expect(result.content.endsWith("short-3")).toBe(true);
+		expect(result.content).toContain("elided");
+		expect(result.elidedBytes).toBeGreaterThan(0);
+	});
+
+	test("does not duplicate overlapping fallback windows", () => {
+		const content = `${"x".repeat(5000)}\n${Array.from({ length: 100 }, (_, i) => `line-${i}`).join("\n")}`;
+		const result = truncateMiddle(content, { maxBytes: 8192, maxLines: 80 });
+
+		expect(result.truncatedBy).toBe("middle");
+		expect(result.elidedBytes).toBeGreaterThan(0);
+		expect(result.content).not.toContain("[…0B elided…]");
+		expect(result.outputLines).toBeLessThanOrEqual(42);
+		expect(result.outputBytes).toBeLessThanOrEqual(8192 + 64);
 	});
 
 	test("formatMiddleElisionMarker uses lines, falling back to bytes for <=1 line", () => {

--- a/packages/coding-agent/test/tools/strip-output-notice.test.ts
+++ b/packages/coding-agent/test/tools/strip-output-notice.test.ts
@@ -130,7 +130,7 @@ describe("stripOutputNotice", () => {
 					elidedLines: 0,
 					headLines: 1,
 					tailLines: 1,
-					singleLineByteWindows: true,
+					partialByteWindows: true,
 				},
 				{ direction: "middle" },
 			)

--- a/packages/coding-agent/test/tools/strip-output-notice.test.ts
+++ b/packages/coding-agent/test/tools/strip-output-notice.test.ts
@@ -8,7 +8,12 @@
  * string twice — once from the body content, once as the styled warning line.
  */
 import { describe, expect, it } from "bun:test";
-import { formatOutputNotice, type OutputMeta, stripOutputNotice } from "@oh-my-pi/pi-coding-agent/tools/output-meta";
+import {
+	formatOutputNotice,
+	type OutputMeta,
+	outputMeta,
+	stripOutputNotice,
+} from "@oh-my-pi/pi-coding-agent/tools/output-meta";
 
 const truncation: OutputMeta = {
 	truncation: {
@@ -108,5 +113,32 @@ describe("stripOutputNotice", () => {
 		// command literally printed it) must be preserved when not at the tail.
 		const body = `prefix${noticeText} middle suffix`;
 		expect(stripOutputNotice(body, truncation)).toBe(body);
+	});
+
+	it("formats single-line byte windows without impossible line counts", () => {
+		const meta = outputMeta()
+			.truncation(
+				{
+					content: "head\n[…100B elided…]\ntail",
+					truncated: true,
+					truncatedBy: "middle",
+					totalLines: 1,
+					totalBytes: 200,
+					outputLines: 3,
+					outputBytes: 100,
+					elidedBytes: 100,
+					elidedLines: 0,
+					headLines: 1,
+					tailLines: 1,
+					singleLineByteWindows: true,
+				},
+				{ direction: "middle" },
+			)
+			.get();
+
+		const notice = formatOutputNotice(meta);
+
+		expect(notice).toContain("Showing head and tail bytes of 1 line");
+		expect(notice).not.toContain("Showing 3 of 1 lines");
 	});
 });


### PR DESCRIPTION
## Summary
- expose bounded `ask` questions and answers to advisor reviews, including orphaned ask results
- include bounded head/tail excerpts for ordinary primary-agent tool results
- preserve edit outcomes, warnings, moves, and partial-failure diagnostics alongside expanded diffs
- preserve compact rendering for non-advisor transcript consumers and keep expanded bytes on the existing secret-obfuscation path

## Why
Advisor currently receives only `ok · N lines` for successful primary tool calls. That hides user decisions returned by `ask` and evidence returned by tools, which can produce advice that contradicts the user.

Fixes #5266.

## Verification
- `bun test packages/coding-agent/test/advisor/advisor.test.ts` — 174 passed
- `bun test packages/coding-agent/test/advisor/delta-split.test.ts` — 7 passed
- `bun test packages/coding-agent/test/streaming-output.test.ts -t "truncateMiddle"` — 6 passed
- `bun --cwd=packages/coding-agent run check`
- `git diff --check`