### PR TITLE
fix(advisor): preserve prior advice across context resets

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Fixed an issue where custom model overrides were lost during configuration updates
 - Fixed "Please use nerdfont" notification incorrectly persisting after theme configuration
 - Fixed sampling parameter errors for newer Anthropic models (Opus 4.7+, Sonnet 5+)
+- Advisors now retain a bounded ledger of previously delivered advice across private context resets, reducing repeated guidance after long-session recovery.
 
 ## [18.0.11] - 2026-08-29
 

--- a/packages/coding-agent/src/advisor/advise-tool.ts
+++ b/packages/coding-agent/src/advisor/advise-tool.ts
@@ -7,8 +7,9 @@ import type {
 	AgentToolResult,
 	AgentToolUpdateCallback,
 } from "@oh-my-pi/pi-agent-core";
-import { escapeXmlAttribute, escapeXmlText } from "@oh-my-pi/pi-utils";
+import { escapeXmlAttribute, escapeXmlText, prompt } from "@oh-my-pi/pi-utils";
 import adviseDescription from "../prompts/advisor/advise-tool.md" with { type: "text" };
+import priorAdviceTemplate from "../prompts/advisor/prior-advice.md" with { type: "text" };
 
 const adviseSchema = type({
 	note: type("string").describe(
@@ -159,6 +160,23 @@ export function deriveAdvisorTelemetry(
  */
 export const ADVISOR_DEFAULT_TOOL_NAMES: ReadonlySet<string> = new Set(["read", "grep", "glob"]);
 
+interface DeliveredAdvice {
+	note: string;
+	severity?: AdvisorSeverity;
+	rank: number;
+}
+const PRIOR_ADVICE_LIMIT = 32;
+
+/** Render the durable advice ledger injected after advisor-context resets. */
+export function formatPriorAdviceHistory(notes: readonly AdvisorNote[]): string | undefined {
+	if (notes.length === 0) return undefined;
+	return prompt
+		.render(priorAdviceTemplate, {
+			notes: notes.map(note => ({ note: escapeXmlText(note.note), severity: note.severity ?? "nit" })),
+		})
+		.trim();
+}
+
 function advisorNoteDedupeKey(note: string): string {
 	return note.trim().replace(/\s+/g, " ");
 }
@@ -177,17 +195,15 @@ export class AdviseTool implements AgentTool<typeof adviseSchema, AdviseDetails>
 	readonly description = adviseDescription;
 	readonly parameters = adviseSchema;
 	readonly intent = "omit" as const;
-	/** Highest delivered severity rank per normalized note. A new call passes
-	 *  through only when its rank strictly exceeds the recorded one (a real
-	 *  escalation: nit → concern → blocker), so an advisor cannot bypass dedupe
-	 *  by retagging the same text at a lower or equal severity. */
-	#deliveredNoteSeverities = new Map<string, number>();
+	/** Delivered advice is both the exact-text dedupe index and the durable
+	 *  ledger replayed after this advisor's private model context resets. */
+	#deliveredNotes = new Map<string, DeliveredAdvice>();
 	#inProgressUpdate = false;
 	/** Notes withheld while the primary was mid-turn, in arrival order. Flushed
 	 *  deterministically on the first `beginUpdate(false)` so delivery does not
 	 *  depend on the advisor model choosing to re-raise (it may not, since the
 	 *  tool previously returned "Recorded." for a note that was never routed).
-	 *  Cleared on `resetDeliveredNotes` alongside the delivered-rank map. */
+	 *  Cleared on `resetDeliveredNotes` alongside the durable ledger. */
 	#deferredNotes: { key: string; note: string; severity?: AdviseDetails["severity"] }[] = [];
 
 	constructor(private readonly onAdvice: (note: string, severity?: AdviseDetails["severity"]) => void) {}
@@ -211,9 +227,14 @@ export class AdviseTool implements AgentTool<typeof adviseSchema, AdviseDetails>
 		}
 	}
 
+	/** Advice already delivered in this conversation, in first-delivery order. */
+	deliveredNotes(): AdvisorNote[] {
+		return [...this.#deliveredNotes.values()].map(({ note, severity }) => ({ note, severity }));
+	}
+
 	/** Clear delivered-note memory when the advisor starts a fresh conversation. */
 	resetDeliveredNotes(): void {
-		this.#deliveredNoteSeverities.clear();
+		this.#deliveredNotes.clear();
 		this.#inProgressUpdate = false;
 		this.#deferredNotes = [];
 	}
@@ -253,7 +274,7 @@ export class AdviseTool implements AgentTool<typeof adviseSchema, AdviseDetails>
 		return {
 			content: [{ type: "text", text: delivered ? "Recorded." : "Duplicate advice ignored." }],
 			details: { note: args.note, severity: args.severity },
-			useless: true,
+			...(delivered ? {} : { useless: true }),
 		};
 	}
 
@@ -263,9 +284,16 @@ export class AdviseTool implements AgentTool<typeof adviseSchema, AdviseDetails>
 	#deliver(note: string, severity?: AdviseDetails["severity"]): boolean {
 		const key = advisorNoteDedupeKey(note);
 		const rank = advisorSeverityRank(severity);
-		const previousRank = this.#deliveredNoteSeverities.get(key) ?? 0;
-		if (rank <= previousRank) return false;
-		this.#deliveredNoteSeverities.set(key, rank);
+		const previous = this.#deliveredNotes.get(key);
+		if (rank <= (previous?.rank ?? 0)) return false;
+		// Map order is delivery order. Refresh escalations so a newly delivered
+		// blocker stays in the recent ledger rather than retaining its old slot.
+		if (previous) this.#deliveredNotes.delete(key);
+		this.#deliveredNotes.set(key, { note, severity, rank });
+		if (this.#deliveredNotes.size > PRIOR_ADVICE_LIMIT) {
+			const oldest = this.#deliveredNotes.keys().next().value;
+			if (oldest !== undefined) this.#deliveredNotes.delete(oldest);
+		}
 		this.onAdvice(note, severity);
 		return true;
 	}

--- a/packages/coding-agent/src/advisor/runtime.ts
+++ b/packages/coding-agent/src/advisor/runtime.ts
@@ -31,6 +31,7 @@ export interface AdvisorAgent {
 	 * turn `Agent.#runLoop` records on its internal state.
 	 */
 	rollbackTo?(count: number): void;
+	appendContextMessage?(message: AgentMessage): void;
 	readonly state: { messages: AgentMessage[]; error?: string };
 }
 
@@ -54,6 +55,8 @@ export interface AdvisorRuntimeHost {
 	 * Optional: hosts that omit it get no proactive maintenance.
 	 */
 	maintainContext?(incoming: AgentMessage, signal: AbortSignal): Promise<boolean>;
+	/** Previously delivered notes to preserve when private advisor context resets. */
+	priorAdvice?(): string | undefined;
 	/**
 	 * Called immediately before each `agent.prompt(batch)` cycle. Lets the host
 	 * clear per-update advisor state and apply the in-progress delivery policy.
@@ -470,6 +473,12 @@ export class AdvisorRuntime {
 		this.#clearSeenContext();
 		try {
 			this.agent.reset();
+			const priorAdvice = this.host.priorAdvice?.();
+			if (priorAdvice) {
+				const message = { role: "user", content: priorAdvice, timestamp: Date.now() } as AgentMessage;
+				if (this.agent.appendContextMessage) this.agent.appendContextMessage(message);
+				else this.agent.state.messages.push(message);
+			}
 		} catch {}
 		try {
 			this.agent.abort("advisor reset");

--- a/packages/coding-agent/src/prompts/advisor/prior-advice.md
+++ b/packages/coding-agent/src/prompts/advisor/prior-advice.md
@@ -1,0 +1,6 @@
+<prior-advice>
+The following advice was already delivered during this conversation. Treat it as durable history: do not repeat or rephrase a point unless new transcript evidence materially changes it. If it has been addressed, stay silent.
+{{#each notes}}
+<advice severity="{{severity}}">{{{note}}}</advice>
+{{/each}}
+</prior-advice>

--- a/packages/coding-agent/src/session/session-advisors.ts
+++ b/packages/coding-agent/src/session/session-advisors.ts
@@ -53,6 +53,7 @@ import {
 	advisorTranscriptFilename,
 	buildAdvisorQuarantineSourceText,
 	formatAdvisorBatchContent,
+	formatPriorAdviceHistory,
 	getOrCreateAdvisorProviderSessionId,
 	isAdvisorInterruptImmuneTurnActive,
 	isInterruptingSeverity,
@@ -670,9 +671,9 @@ export class SessionAdvisors {
 		for (const a of this.#advisors) {
 			a.agentUnsubscribe?.();
 			a.agentUnsubscribe = undefined;
-			a.runtime.reset("conversation-boundary");
 			a.adviseTool.resetDeliveredNotes();
 			a.emissionGuard.reset();
+			a.runtime.reset("conversation-boundary");
 			this.#attachAdvisorRecorderFeed(a);
 		}
 		this.#advisorPrimaryTurnsCompleted = 0;
@@ -1019,6 +1020,10 @@ export class SessionAdvisors {
 					if (quarantined) throw new AdvisorOutputQuarantinedError(quarantined);
 				},
 				abort: reason => advisorAgent.abort(reason),
+				appendContextMessage: message => {
+					advisorAgent.state.messages.push(message);
+					appendOnlyContext.resetSyncCursor();
+				},
 				reset: () => {
 					advisorLoopGuard.reset();
 					advisorLoopGuardStopped = false;
@@ -1055,6 +1060,7 @@ export class SessionAdvisors {
 				snapshotMessages: () => this.#host.agent.state.messages,
 				enqueueAdvice: (note, severity) => this.#routeAdvice(advisorRef, note, severity),
 				maintainContext: (incoming, signal) => this.#maintainAdvisorContext(advisorRef, incoming, signal),
+				priorAdvice: () => formatPriorAdviceHistory(advisorRef.adviseTool.deliveredNotes()),
 				obfuscator: this.#host.obfuscator,
 				getModelIdentity: () => formatModelString(advisorRef.agent.state.model),
 				beginAdvisorUpdate: inProgress => {

--- a/packages/coding-agent/test/advisor/advisor.test.ts
+++ b/packages/coding-agent/test/advisor/advisor.test.ts
@@ -17,6 +17,7 @@ import {
 	deriveAdvisorTelemetry,
 	formatAdvisorBatchContent,
 	formatAdvisorContextPrompt,
+	formatPriorAdviceHistory,
 	isAdvisorInterruptImmuneTurnActive,
 	isAdvisorTranscriptName,
 	isInterruptingSeverity,
@@ -393,7 +394,7 @@ describe("advisor", () => {
 			const result = await tool.execute("tc-1", { note: "x", severity: "concern" });
 			expect(onAdvice).toHaveBeenCalledWith("x", "concern");
 			expect(result.details).toEqual({ note: "x", severity: "concern" });
-			expect(result.useless).toBe(true);
+			expect(result.useless).toBeUndefined();
 		});
 
 		it("suppresses duplicate advice notes from the same advisor session", async () => {
@@ -406,6 +407,8 @@ describe("advisor", () => {
 
 			expect(onAdvice).toHaveBeenCalledTimes(1);
 			expect(onAdvice).toHaveBeenCalledWith(note, "nit");
+			const duplicate = await tool.execute("tc-3", { note, severity: "nit" });
+			expect(duplicate.useless).toBe(true);
 		});
 
 		it("allows the same advice after delivered-note memory resets", async () => {
@@ -420,6 +423,36 @@ describe("advisor", () => {
 			expect(onAdvice).toHaveBeenCalledTimes(2);
 			expect(onAdvice).toHaveBeenNthCalledWith(1, note, "nit");
 			expect(onAdvice).toHaveBeenNthCalledWith(2, note, "nit");
+		});
+
+		it("exposes delivered advice as durable history and clears it only at conversation boundaries", async () => {
+			const tool = new AdviseTool(() => {});
+			await tool.execute("tc-1", { note: "Cover the retry boundary.", severity: "concern" });
+			await tool.execute("tc-2", { note: "Cover the retry boundary.", severity: "blocker" });
+
+			expect(tool.deliveredNotes()).toEqual([{ note: "Cover the retry boundary.", severity: "blocker" }]);
+			expect(formatPriorAdviceHistory(tool.deliveredNotes())).toContain(
+				'<advice severity="blocker">Cover the retry boundary.</advice>',
+			);
+
+			tool.resetDeliveredNotes();
+			expect(tool.deliveredNotes()).toEqual([]);
+			expect(formatPriorAdviceHistory(tool.deliveredNotes())).toBeUndefined();
+		});
+
+		it("bounds durable history and keeps a newly delivered escalation", async () => {
+			const tool = new AdviseTool(() => {});
+			await tool.execute("tc-original", { note: "Original issue.", severity: "nit" });
+			for (let i = 0; i < 32; i++) {
+				await tool.execute(`tc-${i}`, { note: `Distinct issue ${i}.`, severity: "nit" });
+			}
+			expect(tool.deliveredNotes()).toHaveLength(32);
+			expect(tool.deliveredNotes().some(({ note }) => note === "Original issue.")).toBe(false);
+
+			await tool.execute("tc-escalated", { note: "Distinct issue 0.", severity: "blocker" });
+
+			expect(tool.deliveredNotes()).toHaveLength(32);
+			expect(tool.deliveredNotes().at(-1)).toEqual({ note: "Distinct issue 0.", severity: "blocker" });
 		});
 
 		it("forwards escalations of an already-delivered note and suppresses downgrades", async () => {
@@ -2499,6 +2532,40 @@ describe("advisor", () => {
 			expect(promptText(promptInputs[1])).toContain("bbb");
 			expect(promptText(promptInputs[1])).not.toContain("aaa");
 			expect(resetCount).toBe(1);
+		});
+
+		it("reinjects delivered advice after private advisor context recovery", async () => {
+			const promptInputs: Array<string | AgentMessage[]> = [];
+			let resetCount = 0;
+			const agent: AdvisorAgent = {
+				prompt: async input => {
+					promptInputs.push(input);
+				},
+				abort: () => {},
+				reset: () => {
+					resetCount++;
+					agent.state.messages.length = 0;
+				},
+				state: { messages: [] },
+				appendContextMessage: message => {
+					agent.state.messages.push(message);
+				},
+			};
+			const messages: AgentMessage[] = [{ role: "user", content: "new evidence", timestamp: 1 } as AgentMessage];
+			const runtime = new AdvisorRuntime(agent, {
+				snapshotMessages: () => messages,
+				enqueueAdvice: () => {},
+				maintainContext: async () => true,
+				priorAdvice: () => '<prior-advice><advice severity="concern">Do not repeat this.</advice></prior-advice>',
+			});
+
+			runtime.onTurnEnd(messages);
+			await settleUntil(() => promptInputs.length === 1);
+
+			expect(resetCount).toBe(1);
+			expect(agent.state.messages[0]).toMatchObject({ role: "user" });
+			expect(promptText(agent.state.messages)).toContain("Do not repeat this.");
+			expect(promptText(promptInputs[0])).toContain("new evidence");
 		});
 
 		it("preserves updates queued while async maintenance resets the advisor context", async () => {


### PR DESCRIPTION
## Summary
- retain accepted `advise` calls in the advisor model transcript instead of marking them immediately prunable
- maintain a bounded 32-note delivered-advice ledger with escalation ordering
- re-inject that ledger when only the private advisor context is reset, while clearing it at real conversation boundaries

## Why
An advisor normally sees its own recent turns, but context-maintenance recovery clears the private transcript without replaying prior advice. That lets the same themes recur after long-session compaction or overflow recovery. The ledger makes that history explicit without replaying the full primary transcript or growing without bound.

## Verification
- `bun test packages/coding-agent/test/advisor/advisor.test.ts -t "AdviseTool|reinjects delivered advice after private advisor context recovery|clears advisor context without replaying primary history when maintenance requests recovery"`
- `bun --cwd=packages/coding-agent run check`
- `git diff --check`

## Discussion
This PR intentionally does not claim that advisor history was always absent: continuous sessions already retain private advisor turns. It addresses the concrete loss boundary during private context reset and keeps conversation-boundary resets clean.