### PR TITLE
feat(coding-agent): add openai-models-list-bare discovery no norm

### DIFF
--- a/docs/models.md
+++ b/docs/models.md
@@ -106,6 +106,7 @@ providers:
 
 - `auth`: `apiKey` (default), `none`, or `oauth`; for `models.yml` custom models, `oauth` is accepted by schema but does not waive the `apiKey` requirement
 - `discovery.type`: `ollama`, `llama.cpp`, `lm-studio`, `openai-models-list`, `proxy`, or `litellm`
+- `discovery.injectV1`: optional boolean, default `true`, for `openai-models-list`. Set `false` to fetch the model list from `{baseUrl}/models` without injecting `/v1` — for gateways that root their OpenAI-compatible surface at a versioned path (e.g. `https://api.opper.ai/v3/compat`) where the forced `/v1/models` returns a different, smaller model list. Query strings in `baseUrl` are ignored, matching the default mode.
 - `transport`: `pi-native` only. When set, every model under that provider is sent to an `omp auth-gateway` compatible `baseUrl` via `POST /v1/pi/stream`; `apiKey` is the gateway bearer.
 - `imageInputDecoder`: `stb` only. Set this on a custom model or `modelOverrides` entry when the serving backend uses an STB-compatible image decoder that cannot accept WebP; OMP converts attached and historical WebP images before provider dispatch.
 - `tokenizer`: opt into a specific embedded local tokenizer when a proxy's model id is ambiguous or noncanonical. Allowed values: `claude-v3`, `claude-v47`, `claude-v5`, `claude-v5-sonnet`, `qwen3`, `deepseek-v3`, `kimi-k2`, and `glm5`. Omit it to use catalog identity policy; unknown models retain the fast local estimate.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Added `injectV1: false` option to `openai-models-list` discovery to fetch the model list from `{baseUrl}/models` without injecting `/v1`, for gateways that root their OpenAI-compatible surface at a versioned URL (e.g. `https://api.opper.ai/v3/compat`) where the `/v1`-injected endpoint returns only a small subset.
 - Added provider-reported credits and concrete routed-model counts to `/session` statistics ([#8590](https://github.com/can1357/oh-my-pi/pull/8590) by [@will-bogusz](https://github.com/will-bogusz)).
 - Added `CLINE_API_KEY` to the CLI environment help for native ClinePass subscription inference ([#7863](https://github.com/can1357/oh-my-pi/pull/7863) by [@will-bogusz](https://github.com/will-bogusz)).
 - Devin model selectors now accept the native CLI's short aliases (`devin/opus`, `devin/swe`), dotted upstream spellings (`devin/gemini-3.7-flash`), and raw effort-route wire uids for dynamically collapsed families ([#8590](https://github.com/can1357/oh-my-pi/pull/8590) by [@will-bogusz](https://github.com/will-bogusz)).

--- a/packages/coding-agent/src/config/model-discovery.ts
+++ b/packages/coding-agent/src/config/model-discovery.ts
@@ -808,8 +808,17 @@ export async function discoverOpenAIModelsList(
 	providerConfig: DiscoveryProviderConfig,
 	ctx: DiscoveryContext,
 ): Promise<Model<Api>[]> {
-	const baseUrl = normalizeOpenAIModelsListBaseUrl(providerConfig.baseUrl);
-	const modelsUrl = `${baseUrl}/models`;
+	const injectV1 = providerConfig.discovery.injectV1 ?? true;
+	// `injectV1: false` resolves `/models` against the configured base URL
+	// verbatim — no `/v1` suffix is injected. Gateways that root their
+	// OpenAI-compatible surface at a versioned path (e.g.
+	// `https://api.opper.ai/v3/compat`) serve a different, often much smaller,
+	// model list under a forced `/v1/models`; discovery must match the chat
+	// base URL exactly so the full catalog is surfaced.
+	const baseUrl = injectV1
+		? normalizeOpenAIModelsListBaseUrl(providerConfig.baseUrl)
+		: normalizeBareDiscoveryBaseUrl(providerConfig.baseUrl);
+	const modelsUrl = appendModelsPath(baseUrl);
 
 	const baseHeaders: Record<string, string> = { ...(providerConfig.headers ?? {}) };
 	let headers = baseHeaders;
@@ -1123,6 +1132,43 @@ export function normalizeOpenAIModelsListBaseUrl(baseUrl?: string): string {
 		return `${parsed.protocol}//${parsed.host}${parsed.pathname}`;
 	} catch {
 		return raw;
+	}
+}
+
+/**
+ * Bare-shape discovery root: the configured base URL with trailing slashes
+ * trimmed and any query/hash dropped. Unlike
+ * {@link normalizeOpenAIModelsListBaseUrl} it never appends `/v1` — the
+ * configured URL is the full OpenAI-compatible root (e.g.
+ * `https://api.opper.ai/v3/compat`), and injecting `/v1` would point discovery
+ * at a different endpoint than chat. Query strings are stripped exactly like
+ * the default normalizer does: chat appends `/chat/completions` to the base
+ * string, so a retained query would corrupt the inference URL.
+ */
+export function normalizeBareDiscoveryBaseUrl(baseUrl: string | undefined): string {
+	const raw = baseUrl || "http://127.0.0.1:1234";
+	try {
+		const parsed = new URL(raw);
+		parsed.search = "";
+		parsed.hash = "";
+		return `${parsed.protocol}//${parsed.host}${parsed.pathname.replace(/\/+$/g, "")}`;
+	} catch {
+		return raw.replace(/\/+$/g, "");
+	}
+}
+
+/**
+ * Build the `/models` discovery URL by appending to the parsed pathname so
+ * query parameters survive (`https://host/root?token=x` must become
+ * `https://host/root/models?token=x`, not `https://host/root?token=x/models`).
+ */
+function appendModelsPath(baseUrl: string): string {
+	try {
+		const url = new URL(baseUrl);
+		url.pathname = `${url.pathname.replace(/\/+$/g, "")}/models`;
+		return url.toString();
+	} catch {
+		return `${baseUrl}/models`;
 	}
 }
 

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -71,6 +71,7 @@ import {
 	ensureLlamaCppV1BaseUrl,
 	getImplicitOllamaBaseUrl,
 	getOllamaContextLengthOverride,
+	normalizeBareDiscoveryBaseUrl,
 	normalizeLiteLLMDiscoveryBaseUrl,
 	normalizeLlamaCppBaseUrl,
 } from "./model-discovery";
@@ -1331,7 +1332,10 @@ export class ModelRegistry {
 					baseUrl:
 						providerConfig.discovery?.type === "litellm"
 							? normalizeLiteLLMDiscoveryBaseUrl(providerConfig.baseUrl)
-							: providerConfig.baseUrl,
+							: providerConfig.discovery?.type === "openai-models-list" &&
+									providerConfig.discovery.injectV1 === false
+								? normalizeBareDiscoveryBaseUrl(providerConfig.baseUrl)
+								: providerConfig.baseUrl,
 					headers: providerConfig.headers,
 					apiKey: providerConfig.apiKey,
 					authHeader: providerConfig.authHeader,
@@ -1512,7 +1516,12 @@ export class ModelRegistry {
 			// context-v3 invalidates rows cached before server-advertised input
 			// modalities were parsed from `/v1/models`; warm v2 rows pinned
 			// vision-capable ids at `input: ["text"]` until a forced refresh.
-			return `${providerConfig.provider}:openai-models-list-context-v3`;
+			// `injectV1: false` additionally splits off its own namespace: rows
+			// cached from the `/v1`-injected URL can hold a different (smaller)
+			// model set and must never satisfy a bare provider's cache read.
+			return providerConfig.discovery.injectV1 === false
+				? `${providerConfig.provider}:openai-models-list-bare-context-v3`
+				: `${providerConfig.provider}:openai-models-list-context-v3`;
 		}
 		if (providerConfig.discovery.type === "litellm") {
 			// rich-v4 invalidates rows whose `compatConfig` retained a colliding

--- a/packages/coding-agent/src/config/models-config-schema-bundle.ts
+++ b/packages/coding-agent/src/config/models-config-schema-bundle.ts
@@ -270,7 +270,18 @@ export const getModelsConfigSchemaBundle = once(() => {
 	const ProviderDiscoverySchema = type({
 		type: '"ollama" | "llama.cpp" | "lm-studio" | "openai-models-list" | "proxy" | "litellm"',
 		"timeoutMs?": "number",
+		/**
+		 * Defaults to `true`. Set `false` to fetch the model list from
+		 * `{baseUrl}/models` without injecting `/v1` — for gateways that root
+		 * their OpenAI-compatible surface at a versioned path (e.g.
+		 * `https://api.opper.ai/v3/compat`) where the forced `/v1/models`
+		 * returns a different, smaller model list.
+		 */
+		"injectV1?": "boolean",
 	}).narrow((value, ctx) => {
+		if (value.injectV1 !== undefined && value.type !== "openai-models-list") {
+			return ctx.mustBe("injectV1 only on openai-models-list discovery");
+		}
 		if (
 			value.timeoutMs !== undefined &&
 			(typeof value.timeoutMs !== "number" || value.timeoutMs <= 0 || !Number.isFinite(value.timeoutMs))

--- a/packages/coding-agent/test/model-discovery.test.ts
+++ b/packages/coding-agent/test/model-discovery.test.ts
@@ -1553,6 +1553,12 @@ providers:
 		expect(ProviderDiscoverySchema.allows({ type: "llama.cpp", timeoutMs: Number.NaN })).toBe(false);
 		expect(ProviderDiscoverySchema.allows({ type: "llama.cpp", timeoutMs: "30000" as any })).toBe(false);
 	});
+	test("ProviderDiscoverySchema restricts injectV1 to openai-models-list", () => {
+		expect(ProviderDiscoverySchema.allows({ type: "openai-models-list", injectV1: false })).toBe(true);
+		expect(ProviderDiscoverySchema.allows({ type: "openai-models-list", injectV1: true })).toBe(true);
+		expect(ProviderDiscoverySchema.allows({ type: "lm-studio", injectV1: false })).toBe(false);
+		expect(ProviderDiscoverySchema.allows({ type: "proxy", injectV1: false })).toBe(false);
+	});
 	test("llama.cpp discovery marks per-model architecture image modalities as vision-capable", async () => {
 		const fetchMock: FetchImpl = async input => {
 			const url = String(input);
@@ -2398,6 +2404,65 @@ providers:
 		expect(registry.find("openai-test", "low")?.input).toEqual(["text"]);
 		// Silent server → default text-only fallback.
 		expect(registry.find("openai-test", "medium")?.input).toEqual(["text"]);
+	});
+
+	test("openai-models-list with injectV1: false hits {baseUrl}/models verbatim", async () => {
+		// Gateways like opper.ai root their OpenAI-compatible surface at a
+		// versioned path (`https://api.opper.ai/v3/compat`); the default
+		// normalizer would force `/v1/models` onto that root and land on a
+		// different (much smaller) model list than chat uses.
+		writeRawModelsJson({
+			"opper-test": {
+				baseUrl: "https://api.opper.ai/v3/compat",
+				api: "openai-completions",
+				auth: "none",
+				discovery: { type: "openai-models-list", injectV1: false },
+			},
+		});
+		const fetchMock: FetchImpl = async input => {
+			const url = String(input);
+			if (url === "https://api.opper.ai/v3/compat/models") {
+				return new Response(JSON.stringify({ data: [{ id: "opper-full-a" }, { id: "opper-full-b" }] }), {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				});
+			}
+			throw new Error(`Unexpected URL: ${url}`);
+		};
+		const registry = new ModelRegistry(authStorage, modelsJsonPath, { fetch: fetchMock });
+		await registry.refresh();
+		// Discovered models carry the configured URL as their chat base —
+		// discovery and chat share the same endpoint root.
+		expect(registry.find("opper-test", "opper-full-a")?.baseUrl).toBe("https://api.opper.ai/v3/compat");
+		expect(registry.find("opper-test", "opper-full-b")?.baseUrl).toBe("https://api.opper.ai/v3/compat");
+	});
+
+	test("openai-models-list with injectV1: false strips query strings from the base URL", async () => {
+		// Chat builds the inference URL by appending `/chat/completions` to the
+		// base string, so a query in `baseUrl` would corrupt it
+		// (`?token=x/chat/completions`). The bare normalizer drops queries and
+		// hashes, matching the default mode's normalizer.
+		writeRawModelsJson({
+			"opper-test": {
+				baseUrl: "https://api.opper.ai/v3/compat?token=gateway",
+				api: "openai-completions",
+				auth: "none",
+				discovery: { type: "openai-models-list", injectV1: false },
+			},
+		});
+		const fetchMock: FetchImpl = async input => {
+			const url = String(input);
+			if (url === "https://api.opper.ai/v3/compat/models") {
+				return new Response(JSON.stringify({ data: [{ id: "opper-full-a" }] }), {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				});
+			}
+			throw new Error(`Unexpected URL: ${url}`);
+		};
+		const registry = new ModelRegistry(authStorage, modelsJsonPath, { fetch: fetchMock });
+		await registry.refresh();
+		expect(registry.find("opper-test", "opper-full-a")?.baseUrl).toBe("https://api.opper.ai/v3/compat");
 	});
 
 	test("lm-studio discovery keeps native VLM modalities over a thin OpenAI row", async () => {


### PR DESCRIPTION
What

Adds a new openai-models-list-bare discovery type for custom providers in models.yml. It fetches {baseUrl}/models
exactly as configured — no /v1 path segment is injected — and stamps discovered models with the configured URL as their
chat base, so discovery and chat always target the same endpoint root.

Root cause this addresses: normalizeOpenAIModelsListBaseUrl unconditionally appends /v1 to any base URL not already
ending in /v1. Gateways that root their OpenAI-compatible surface at a versioned path (e.g.
https://api.opper.ai/v3/compat) therefore had discovery hit /v3/compat/v1/models — a different, drastically smaller
surface (opper returns ~20 models there vs. the full catalog at /v3/compat/models). No existing discovery type
(openai-models-list, proxy, litellm, lm-studio) avoids the normalization.

Changes:
- config/models-config-schema-bundle.ts — add "openai-models-list-bare" to the discovery type union
- config/model-discovery.ts — dispatch case; discoverOpenAIModelsList refactored into a shared { bare } core; new
  exported discoverOpenAIModelsListBare; normalizeBareDiscoveryBaseUrl (trims trailing slashes only)
- config/model-registry.ts — dedicated openai-models-list-bare-context-v3 cache namespace so rows cached from the
  /v1-subset URL never satisfy a bare provider's cache read (prevents re-serving the truncated list for the 24h TTL
  after switching types)
- docs/models.md — document the new type
- packages/coding-agent/CHANGELOG.md — Added entry

Why

Bug report: configuring opper.ai (https://api.opper.ai/v3/compat, api: openai-completions, discoverModels: true) only
pulled 20 models. Opper's compat endpoint returns the full catalog at /v3/compat/models (no pagination, per their API
docs), while the /v1-normalized URL the old discovery types hit serves a small featured subset. Opper's own integration
docs confirm the plain provider block gets only a subset; their first-party provider package exists to work around it.

Reported usage:

```yaml
providers:
  custom-opper-ai:
    baseUrl: "https://api.opper.ai/v3/compat"
    api: openai-completions
    apiKey: op-...
    discoverModels: true
    discovery:
      timeoutMs: 30000
      type: openai-models-list-bare
```

Testing

- bun check passes (biome + tsgo, 2860 files)
- bun test test/model-discovery.test.ts → 73 pass / 0 fail, including the new contract test: bare discovery fetches
  {baseUrl}/models verbatim (mock rejects any /v1-injected URL) and discovered models carry the configured URL as
  baseUrl
- Live opper probe: /v3/compat/models and /v3/compat/v1/models are both live routes (401 unauthenticated); full-catalog
  count on the bare route pending an API key — docs-backed, not yet key-verified