### PR TITLE
feat(advisor): add configurable interrupt timing

### DIFF
--- a/docs/advisor-watchdog.md
+++ b/docs/advisor-watchdog.md
@@ -133,6 +133,11 @@ Two session/client constraints can still preserve a note whose normal delivery p
 
 So the advisor can steer and resume a run the agent ended on its own **while it is running or yielded mid-work and the current mode/client permits steering**. When steering is blocked instead, the note is either preserved as a card (the terminal-answer, plan-mode, and deferred-ACP cases above) or downgraded to a non-interrupting aside (the `advisor.immuneTurns` cooldown below); either way it waits for the next step boundary or resume rather than waking the agent.
 
+`advisor.interruptMode` controls live `concern`/`blocker` delivery without changing their severity:
+
+- `immediate` (default) uses steering. During a tool batch this may signal the running tool and skip sibling calls that have not started.
+- `wait` queues the note as a non-interrupting aside while the primary loop is streaming. The current tool batch finishes, then the advice is injected before the next model step. Idle delivery, terminal-answer handling, deliberate-interrupt preservation, and plan/ACP constraints keep their existing behavior.
+
 `advisor.immuneTurns` limits interruption frequency. After the advisor successfully delivers a `concern` or `blocker` through the steering channel, later concerns/blockers are routed as non-interrupting asides until the configured number of primary turns has completed. The default is `3`. `nit` notes are unchanged, and advice raised while user-interrupt auto-resume suppression is active is still preserved instead of restarting a stopped run.
 
 While an advisor update is reviewing work still in progress, `AdviseTool` withholds `nit` and `concern` calls; only a `blocker` may interrupt partial work. The tool also suppresses the same whitespace-normalized note at an equal or lower severity while allowing a real escalation (`nit` → `concern` → `blocker`).

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -2760,6 +2760,14 @@ async function executeToolCalls(
 					);
 					if (!(await Promise.race([steeringChecked, watchAbortedFalse]))) return;
 					if (steeringWatchSignal.aborted || interruptState.triggered) return;
+					if (!globalInterruptsImmediate) {
+						const state = await hasSteeringMessages?.();
+						if (typeof state === "boolean" || state?.immediate !== true) {
+							if (!(await Promise.race([steeringQueued, watchAbortedFalse]))) return;
+							if (!steeringWatchSignal.aborted) await Bun.sleep(STEERING_INTERRUPT_POLL_MS);
+							continue;
+						}
+					}
 					if (!(await Promise.race([steeringQueued, watchAbortedFalse]))) return;
 				}
 			})()

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -2332,7 +2332,7 @@ async function executeToolCalls(
 	const emittedToolResults: ToolResultMessage[] = [];
 	const toolCallInfos = toolCalls.map(call => ({ id: call.id, name: call.name }));
 	const batchId = `${assistantMessage.timestamp ?? Date.now()}_${toolCalls[0]?.id ?? "batch"}`;
-	const shouldInterruptImmediately = interruptMode !== "wait";
+	const globalInterruptsImmediate = interruptMode !== "wait";
 	const steeringAbortController = new AbortController();
 	const ircAbortController = new AbortController();
 	// Cooperative channel: aborted when queued steering (or an interrupting
@@ -2401,7 +2401,7 @@ async function executeToolCalls(
 	const checkIrcInterrupts = async (): Promise<void> => {
 		// IRC only fires once: a peer interrupt already recorded on interruptState
 		// must not re-abort, and (unlike steering) never re-consumes a queue.
-		if (!shouldInterruptImmediately || signal?.aborted || interruptState.triggered) return;
+		if (!globalInterruptsImmediate || signal?.aborted || interruptState.triggered) return;
 		if (hasIrcInterrupts && (await hasIrcInterrupts())) {
 			// Peer IRC hard-aborts interruptible waits only; foreground tools keep
 			// running (no partial side effects) but get the cooperative soft
@@ -2417,14 +2417,13 @@ async function executeToolCalls(
 		// `signal` (external/user abort) is checked separately from the internal
 		// abort controllers: once the run is externally aborted it is unwinding
 		// and the interrupt would be redundant.
-		if (!shouldInterruptImmediately || signal?.aborted) {
-			return;
-		}
+		if (signal?.aborted) return;
 		// Mid-batch steering detection must be non-consuming. If a direct
 		// integration only provides getSteeringMessages(), the queue drains at the
 		// injection boundary below; polling it here would strand or drop messages.
 		let steeringQueued = false;
 		let steeringSource: SteeringInterruptSource | undefined;
+		let forceImmediate = false;
 		if (hasSteeringMessages) {
 			const queuedState = await hasSteeringMessages();
 			if (typeof queuedState === "boolean") {
@@ -2434,8 +2433,10 @@ async function executeToolCalls(
 				const state: SteeringQueueState = queuedState;
 				steeringQueued = state.queued;
 				steeringSource = state.source ?? (state.queued ? "unknown" : undefined);
+				forceImmediate = state.immediate === true;
 			}
 		}
+		if (!globalInterruptsImmediate && !forceImmediate) return;
 		if (steeringQueued) {
 			// Queued steering hard-aborts only interruptible waits and raises the
 			// cooperative soft signal for everything else: the boundary dequeue
@@ -2724,7 +2725,7 @@ async function executeToolCalls(
 	// dequeue below injects the message promptly. Gated on immediate-interrupt
 	// mode; checkSteering is idempotent (no-op once triggered).
 	const watchSteeringWhileRunning =
-		shouldInterruptImmediately && (hasSteeringMessages !== undefined || hasIrcInterrupts !== undefined);
+		hasSteeringMessages !== undefined || (globalInterruptsImmediate && hasIrcInterrupts !== undefined);
 	const eventDrivenSteeringWatch =
 		watchSteeringWhileRunning && config.waitForSteeringMessages !== undefined && hasSteeringMessages !== undefined;
 	const steeringWatchAbortController = new AbortController();

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -2314,6 +2314,7 @@ async function executeToolCalls(
 	const tools = currentContext.tools;
 	const {
 		hasSteeringMessages,
+		waitForImmediateSteeringMessages,
 		hasIrcInterrupts,
 		interruptMode = "immediate",
 		getToolContext,
@@ -2724,10 +2725,13 @@ async function executeToolCalls(
 	// (auto-background bash), and skips not-yet-started tools, so the boundary
 	// dequeue below injects the message promptly. Gated on immediate-interrupt
 	// mode; checkSteering is idempotent (no-op once triggered).
+	const waitForInterruptingSteering = globalInterruptsImmediate
+		? config.waitForSteeringMessages
+		: waitForImmediateSteeringMessages;
 	const watchSteeringWhileRunning =
 		hasSteeringMessages !== undefined || (globalInterruptsImmediate && hasIrcInterrupts !== undefined);
 	const eventDrivenSteeringWatch =
-		watchSteeringWhileRunning && config.waitForSteeringMessages !== undefined && hasSteeringMessages !== undefined;
+		watchSteeringWhileRunning && waitForInterruptingSteering !== undefined && hasSteeringMessages !== undefined;
 	const steeringWatchAbortController = new AbortController();
 	const steeringWatchSignal = signal
 		? AbortSignal.any([signal, steeringWatchAbortController.signal])
@@ -2750,7 +2754,7 @@ async function executeToolCalls(
 					// race where a steer arrives after a check but before listener
 					// registration: the subsequent check observes queued state,
 					// while later arrivals resolve this already-installed wait.
-					const steeringQueued = config.waitForSteeringMessages?.(steeringWatchSignal).then(
+					const steeringQueued = waitForInterruptingSteering?.(steeringWatchSignal).then(
 						() => true,
 						() => false,
 					);
@@ -2760,14 +2764,6 @@ async function executeToolCalls(
 					);
 					if (!(await Promise.race([steeringChecked, watchAbortedFalse]))) return;
 					if (steeringWatchSignal.aborted || interruptState.triggered) return;
-					if (!globalInterruptsImmediate) {
-						const state = await hasSteeringMessages?.();
-						if (typeof state === "boolean" || state?.immediate !== true) {
-							if (!(await Promise.race([steeringQueued, watchAbortedFalse]))) return;
-							if (!steeringWatchSignal.aborted) await Bun.sleep(STEERING_INTERRUPT_POLL_MS);
-							continue;
-						}
-					}
 					if (!(await Promise.race([steeringQueued, watchAbortedFalse]))) return;
 				}
 			})()

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -54,7 +54,7 @@ import type {
 	ToolCallContext,
 	ToolChoiceDirective,
 } from "./types";
-import { isSoftToolRequirement } from "./types";
+import { isSoftToolRequirement, STEERING_MESSAGE_IMMEDIATE } from "./types";
 import { EventLoopKeepalive } from "./utils/yield";
 
 /**
@@ -1497,20 +1497,28 @@ export class Agent {
 				}
 				const messageCount = this.#steeringMode === "one-at-a-time" ? 1 : this.#steeringQueue.length;
 				let hasAgentSteering = false;
+				let hasImmediateSteering = false;
 				for (let i = 0; i < messageCount; i++) {
 					const message = this.#steeringQueue[i];
+					if ((message as AgentMessage & { [STEERING_MESSAGE_IMMEDIATE]?: boolean })[STEERING_MESSAGE_IMMEDIATE]) {
+						hasImmediateSteering = true;
+					}
 					const role = "role" in message ? message.role : undefined;
 					const attribution = "attribution" in message ? message.attribution : undefined;
 					if (attribution === "user") {
-						return { queued: true, source: "user" };
+						return { queued: true, source: "user", immediate: hasImmediateSteering };
 					}
 					if (role !== "user") continue;
 					if (attribution !== "agent") {
-						return { queued: true, source: "user" };
+						return { queued: true, source: "user", immediate: hasImmediateSteering };
 					}
 					hasAgentSteering = true;
 				}
-				return { queued: true, source: hasAgentSteering ? "agent" : "system" };
+				return {
+					queued: true,
+					source: hasAgentSteering ? "agent" : "system",
+					immediate: hasImmediateSteering,
+				};
 			},
 			waitForSteeringMessages: signal => this.#waitForSteeringMessages(signal),
 			hasIrcInterrupts: this.hasIrcInterrupts,

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -937,7 +937,11 @@ export class Agent {
 	}
 
 	setSteeringMode(mode: "all" | "one-at-a-time") {
+		const hadImmediateSteering = this.#hasImmediateSteeringInWindow();
 		this.#steeringMode = mode;
+		if (!hadImmediateSteering && this.#hasImmediateSteeringInWindow()) {
+			this.#notifySteeringWaiters(true);
+		}
 	}
 
 	getSteeringMode(): "all" | "one-at-a-time" {

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -373,7 +373,7 @@ export class Agent {
 	#transformProviderContext?: (context: Context, model: Model) => Context | Promise<Context>;
 	#steeringQueue: AgentMessage[] = [];
 	#followUpQueue: AgentMessage[] = [];
-	#steeringWaiters = new Set<() => void>();
+	#steeringWaiters = new Set<{ immediateOnly: boolean; resolve: () => void }>();
 
 	#steeringMode: "all" | "one-at-a-time";
 	#followUpMode: "all" | "one-at-a-time";
@@ -994,7 +994,7 @@ export class Agent {
 	 */
 	steer(m: AgentMessage) {
 		this.#steeringQueue.push(m);
-		this.#notifySteeringWaiters();
+		this.#notifySteeringWaiters(this.#isImmediateSteering(m));
 	}
 
 	/**
@@ -1109,26 +1109,35 @@ export class Agent {
 	}
 
 	/**
-	 * Wait for a steering message without consuming the steering queue.
-	 *
-	 * The signal releases the waiter when the prompt ends, so an in-flight
-	 * tool watcher never survives the tool batch that owns it.
+	 * Wait for steering that can interrupt the active batch without consuming it.
+	 * Global wait mode ignores ordinary queued steering and wakes only for a
+	 * message carrying the per-message immediate override.
 	 */
+	#isImmediateSteering(message: AgentMessage): boolean {
+		return (
+			(message as AgentMessage & { [STEERING_MESSAGE_IMMEDIATE]?: boolean })[STEERING_MESSAGE_IMMEDIATE] === true
+		);
+	}
+
 	#waitForSteeringMessages(signal?: AbortSignal): Promise<void> {
-		if (this.#steeringQueue.length > 0 || signal?.aborted) return Promise.resolve();
+		if (this.#steeringQueue.some(message => this.#isImmediateSteering(message)) || signal?.aborted) {
+			return Promise.resolve();
+		}
 		const { promise, resolve } = Promise.withResolvers<void>();
+		const waiter = { immediateOnly: this.#interruptMode === "wait", resolve };
 		const onAbort = (): void => resolve();
-		this.#steeringWaiters.add(resolve);
+		this.#steeringWaiters.add(waiter);
 		signal?.addEventListener("abort", onAbort, { once: true });
 		return promise.finally(() => {
-			this.#steeringWaiters.delete(resolve);
+			this.#steeringWaiters.delete(waiter);
 			signal?.removeEventListener("abort", onAbort);
 		});
 	}
 
-	#notifySteeringWaiters(): void {
-		const waiters = [...this.#steeringWaiters];
-		for (const resolve of waiters) resolve();
+	#notifySteeringWaiters(immediate = true): void {
+		for (const waiter of [...this.#steeringWaiters]) {
+			if (!waiter.immediateOnly || immediate) waiter.resolve();
+		}
 	}
 
 	reset() {
@@ -1492,31 +1501,22 @@ export class Agent {
 				return this.#dequeueSteeringMessagesAfterHooks(signal);
 			},
 			hasSteeringMessages: () => {
-				if (this.#steeringQueue.length === 0) {
-					return { queued: false };
-				}
+				if (this.#steeringQueue.length === 0) return { queued: false };
 				const messageCount = this.#steeringMode === "one-at-a-time" ? 1 : this.#steeringQueue.length;
 				let hasAgentSteering = false;
+				let hasUserSteering = false;
 				let hasImmediateSteering = false;
 				for (let i = 0; i < messageCount; i++) {
 					const message = this.#steeringQueue[i];
-					if ((message as AgentMessage & { [STEERING_MESSAGE_IMMEDIATE]?: boolean })[STEERING_MESSAGE_IMMEDIATE]) {
-						hasImmediateSteering = true;
-					}
+					if (this.#isImmediateSteering(message)) hasImmediateSteering = true;
 					const role = "role" in message ? message.role : undefined;
 					const attribution = "attribution" in message ? message.attribution : undefined;
-					if (attribution === "user") {
-						return { queued: true, source: "user", immediate: hasImmediateSteering };
-					}
-					if (role !== "user") continue;
-					if (attribution !== "agent") {
-						return { queued: true, source: "user", immediate: hasImmediateSteering };
-					}
-					hasAgentSteering = true;
+					if (attribution === "user" || (role === "user" && attribution !== "agent")) hasUserSteering = true;
+					else if (role === "user" && attribution === "agent") hasAgentSteering = true;
 				}
 				return {
 					queued: true,
-					source: hasAgentSteering ? "agent" : "system",
+					source: hasUserSteering ? "user" : hasAgentSteering ? "agent" : "system",
 					immediate: hasImmediateSteering,
 				};
 			},

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -994,7 +994,7 @@ export class Agent {
 	 */
 	steer(m: AgentMessage) {
 		this.#steeringQueue.push(m);
-		this.#notifySteeringWaiters(this.#isImmediateSteering(m));
+		this.#notifySteeringWaiters(this.#hasImmediateSteeringInWindow());
 	}
 
 	/**
@@ -1119,8 +1119,16 @@ export class Agent {
 		);
 	}
 
+	#hasImmediateSteeringInWindow(): boolean {
+		if (this.#steeringMode === "one-at-a-time") {
+			const first = this.#steeringQueue[0];
+			return first !== undefined && this.#isImmediateSteering(first);
+		}
+		return this.#steeringQueue.some(message => this.#isImmediateSteering(message));
+	}
+
 	#waitForSteeringMessages(signal?: AbortSignal): Promise<void> {
-		if (this.#steeringQueue.some(message => this.#isImmediateSteering(message)) || signal?.aborted) {
+		if (this.#hasImmediateSteeringInWindow() || signal?.aborted) {
 			return Promise.resolve();
 		}
 		const { promise, resolve } = Promise.withResolvers<void>();

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -1127,12 +1127,12 @@ export class Agent {
 		return this.#steeringQueue.some(message => this.#isImmediateSteering(message));
 	}
 
-	#waitForSteeringMessages(signal?: AbortSignal): Promise<void> {
-		if (this.#hasImmediateSteeringInWindow() || signal?.aborted) {
+	#waitForSteeringMessages(signal?: AbortSignal, immediateOnly = false): Promise<void> {
+		if ((immediateOnly ? this.#hasImmediateSteeringInWindow() : this.#steeringQueue.length > 0) || signal?.aborted) {
 			return Promise.resolve();
 		}
 		const { promise, resolve } = Promise.withResolvers<void>();
-		const waiter = { immediateOnly: this.#interruptMode === "wait", resolve };
+		const waiter = { immediateOnly, resolve };
 		const onAbort = (): void => resolve();
 		this.#steeringWaiters.add(waiter);
 		signal?.addEventListener("abort", onAbort, { once: true });
@@ -1529,6 +1529,7 @@ export class Agent {
 				};
 			},
 			waitForSteeringMessages: signal => this.#waitForSteeringMessages(signal),
+			waitForImmediateSteeringMessages: signal => this.#waitForSteeringMessages(signal, true),
 			hasIrcInterrupts: this.hasIrcInterrupts,
 			getFollowUpMessages: signal => this.#dequeueFollowUpMessagesAfterHooks(signal),
 			getAsideMessages: async () => (await this.#asideMessageProvider?.()) ?? [],

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -1147,7 +1147,7 @@ export class Agent {
 	}
 
 	#notifySteeringWaiters(immediate = true): void {
-		for (const waiter of [...this.#steeringWaiters]) {
+		for (const waiter of this.#steeringWaiters) {
 			if (!waiter.immediateOnly || immediate) waiter.resolve();
 		}
 	}

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -35,6 +35,8 @@ export type StreamFn = (
 export const ASIDE_MESSAGE_COMMIT = Symbol("aside-message-commit");
 /** Called when an aside was drained but the agent loop ended before inserting it. */
 export const ASIDE_MESSAGE_DISCARD = Symbol("aside-message-discard");
+/** Forces one queued steering message to interrupt even when the global mode waits. */
+export const STEERING_MESSAGE_IMMEDIATE = Symbol("steering-message-immediate");
 
 export type CommittableAsideMessage = AgentMessage & {
 	[ASIDE_MESSAGE_COMMIT]?: () => void;
@@ -139,6 +141,8 @@ export interface SteeringQueueState {
 	queued: boolean;
 	/** Best-effort origin used only to word synthetic skipped-tool results. */
 	source?: SteeringInterruptSource;
+	/** True when a marked message overrides global wait mode for this batch. */
+	immediate?: boolean;
 }
 
 /**

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -266,12 +266,15 @@ export interface AgentLoopConfig extends SimpleStreamOptions {
 	hasSteeringMessages?: () => boolean | SteeringQueueState | Promise<boolean | SteeringQueueState>;
 
 	/**
-	 * Wakes the in-flight tool interrupt watcher when a steering message is queued.
-	 * The callback must not consume the queue; the loop still calls
-	 * {@link hasSteeringMessages} before aborting and injects through
-	 * {@link getSteeringMessages}.
+	 * Wakes the in-flight tool interrupt watcher when any steering message is
+	 * queued. Used only when global interrupt mode is `immediate`.
 	 */
 	waitForSteeringMessages?: (signal?: AbortSignal) => Promise<void>;
+	/**
+	 * Wakes only when steering marked as an immediate override enters the active
+	 * dequeue window. Used when global interrupt mode is `wait`.
+	 */
+	waitForImmediateSteeringMessages?: (signal?: AbortSignal) => Promise<void>;
 
 	/**
 	 * Peeks whether IRC messages should interrupt an interruptible waiting tool.

--- a/packages/agent/test/agent-loop.test.ts
+++ b/packages/agent/test/agent-loop.test.ts
@@ -1718,6 +1718,56 @@ describe("agentLoop with AgentMessage", () => {
 		expect(advisorInjected).toBe(true);
 	});
 
+	it("marked advisor steering interrupts even when global interrupt mode waits", async () => {
+		const toolSchema = type({ value: "string" });
+		const executed: string[] = [];
+		const tool: AgentTool<typeof toolSchema, { value: string }> = {
+			name: "echo",
+			label: "Echo",
+			description: "Echo tool",
+			parameters: toolSchema,
+			concurrency: "exclusive",
+			async execute(_toolCallId, params) {
+				executed.push(params.value);
+				return { content: [{ type: "text", text: params.value }], details: { value: params.value } };
+			},
+		};
+		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [tool] };
+		let delivered = false;
+		const mock = createMockModel({
+			responses: [
+				{
+					content: [
+						{ type: "toolCall", id: "tool-1", name: "echo", arguments: { value: "first" } },
+						{ type: "toolCall", id: "tool-2", name: "echo", arguments: { value: "second" } },
+					],
+				},
+				{ content: ["done"] },
+			],
+		});
+		const config: AgentLoopConfig = {
+			model: mock.model,
+			convertToLlm: identityConverter,
+			interruptMode: "wait",
+			hasSteeringMessages: () =>
+				executed.length >= 1 && !delivered
+					? { queued: true, source: "system", immediate: true }
+					: { queued: false },
+			getSteeringMessages: async () => {
+				if (executed.length < 1 || delivered) return [];
+				delivered = true;
+				return [createUserMessage("immediate advisor")];
+			},
+		};
+
+		for await (const _event of agentLoop([createUserMessage("start")], context, config, undefined, mock.stream)) {
+			// drain
+		}
+
+		expect(executed).toEqual(["first"]);
+		expect(delivered).toBe(true);
+	});
+
 	it("drains queued steering by aborting an interruptible tool mid-wait", async () => {
 		const toolSchema = type({});
 		let steerReady = false;

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it } from "bun:test";
 import { type } from "@oh-my-pi/omptype";
-import { Agent, AgentBusyError, type AgentEvent, type AgentTool, ThinkingLevel } from "@oh-my-pi/pi-agent-core";
+import {
+	Agent,
+	AgentBusyError,
+	type AgentEvent,
+	type AgentMessage,
+	type AgentTool,
+	STEERING_MESSAGE_IMMEDIATE,
+	ThinkingLevel,
+} from "@oh-my-pi/pi-agent-core";
 import type { SimpleStreamOptions, ToolResultMessage } from "@oh-my-pi/pi-ai";
 import { createMockModel } from "@oh-my-pi/pi-ai/providers/mock";
 import { kCursorExecResolved } from "@oh-my-pi/pi-ai/utils/block-symbols";
@@ -151,6 +159,90 @@ describe("Agent", () => {
 		if (skippedContent?.type !== "text") throw new Error("skipped tool result must be text");
 		expect(skippedContent.text).toContain("Skipped due to queued user message");
 		expect(skippedContent.text).not.toContain("pending system advisory");
+	});
+
+	it("finds an immediate advisor steer behind ordinary steering in all mode", async () => {
+		const toolSchema = type({ value: type("string") });
+		const executed: string[] = [];
+		let agent: Agent;
+		const tool: AgentTool<typeof toolSchema, { value: string }> = {
+			name: "echo",
+			label: "Echo",
+			description: "Echo tool",
+			parameters: toolSchema,
+			concurrency: "exclusive",
+			async execute(_toolCallId, params) {
+				executed.push(params.value);
+				if (params.value === "first") {
+					agent.steer(createUserMessage("ordinary steer"));
+					const advisor = createUserMessage("immediate advisor") as AgentMessage & {
+						[STEERING_MESSAGE_IMMEDIATE]?: boolean;
+					};
+					advisor[STEERING_MESSAGE_IMMEDIATE] = true;
+					agent.steer(advisor);
+				}
+				return { content: [{ type: "text", text: params.value }], details: params };
+			},
+		};
+		const mock = createMockModel({
+			responses: [
+				{
+					content: [
+						{ type: "toolCall", id: "tool-1", name: "echo", arguments: { value: "first" } },
+						{ type: "toolCall", id: "tool-2", name: "echo", arguments: { value: "second" } },
+					],
+				},
+				{ content: ["done"] },
+			],
+		});
+		agent = new Agent({
+			initialState: { model: mock.model, systemPrompt: ["Test"], tools: [tool], messages: [] },
+			streamFn: mock.stream,
+			steeringMode: "all",
+			interruptMode: "wait",
+		});
+
+		await agent.prompt("start");
+
+		expect(executed).toEqual(["first"]);
+	});
+
+	it("global wait mode does not spin on an ordinary queued steer", async () => {
+		const toolSchema = type({});
+		const release = Promise.withResolvers<void>();
+		let started = false;
+		let agent: Agent;
+		const tool: AgentTool<typeof toolSchema, Record<string, never>> = {
+			name: "wait",
+			label: "Wait",
+			description: "Wait tool",
+			parameters: toolSchema,
+			async execute() {
+				started = true;
+				agent.steer(createUserMessage("ordinary steer"));
+				await release.promise;
+				return { content: [{ type: "text", text: "done" }], details: {} };
+			},
+		};
+		const mock = createMockModel({
+			responses: [
+				{ content: [{ type: "toolCall", id: "tool-1", name: "wait", arguments: {} }] },
+				{ content: ["done"] },
+			],
+		});
+		agent = new Agent({
+			initialState: { model: mock.model, systemPrompt: ["Test"], tools: [tool], messages: [] },
+			streamFn: mock.stream,
+			interruptMode: "wait",
+		});
+
+		const running = agent.prompt("start");
+		while (!started) await Bun.sleep(0);
+		await Bun.sleep(10);
+		release.resolve();
+		await running;
+
+		expect(agent.peekSteeringQueue()).toEqual([]);
 	});
 	it("continue() re-executes a trailing assistant's unpaired tool calls before the next model call", async () => {
 		const toolSchema = type({ value: type("string") });

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -164,7 +164,6 @@ describe("Agent", () => {
 	it("finds an immediate advisor steer behind ordinary steering in all mode", async () => {
 		const toolSchema = type({ value: type("string") });
 		const executed: string[] = [];
-		let agent: Agent;
 		const tool: AgentTool<typeof toolSchema, { value: string }> = {
 			name: "echo",
 			label: "Echo",
@@ -195,7 +194,7 @@ describe("Agent", () => {
 				{ content: ["done"] },
 			],
 		});
-		agent = new Agent({
+		const agent = new Agent({
 			initialState: { model: mock.model, systemPrompt: ["Test"], tools: [tool], messages: [] },
 			streamFn: mock.stream,
 			steeringMode: "all",
@@ -211,7 +210,6 @@ describe("Agent", () => {
 		const toolSchema = type({});
 		const release = Promise.withResolvers<void>();
 		let started = false;
-		let agent: Agent;
 		const tool: AgentTool<typeof toolSchema, Record<string, never>> = {
 			name: "wait",
 			label: "Wait",
@@ -230,7 +228,7 @@ describe("Agent", () => {
 				{ content: ["done"] },
 			],
 		});
-		agent = new Agent({
+		const agent = new Agent({
 			initialState: { model: mock.model, systemPrompt: ["Test"], tools: [tool], messages: [] },
 			streamFn: mock.stream,
 			interruptMode: "wait",
@@ -249,7 +247,6 @@ describe("Agent", () => {
 		const toolSchema = type({});
 		const release = Promise.withResolvers<void>();
 		let started = false;
-		let agent: Agent;
 		const tool: AgentTool<typeof toolSchema, Record<string, never>> = {
 			name: "wait",
 			label: "Wait",
@@ -274,7 +271,7 @@ describe("Agent", () => {
 				{ content: ["advisor handled"] },
 			],
 		});
-		agent = new Agent({
+		const agent = new Agent({
 			initialState: { model: mock.model, systemPrompt: ["Test"], tools: [tool], messages: [] },
 			streamFn: mock.stream,
 			steeringMode: "one-at-a-time",

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -289,6 +289,67 @@ describe("Agent", () => {
 
 		expect(agent.peekSteeringQueue()).toEqual([]);
 	});
+
+	it("wakes immediate steering when one-at-a-time mode widens to all", async () => {
+		const toolSchema = type({});
+		const started = Promise.withResolvers<void>();
+		let observedAbort = false;
+		let resolvedByTimeout = false;
+		const tool: AgentTool<typeof toolSchema, Record<string, never>> = {
+			name: "wait",
+			label: "Wait",
+			description: "Wait tool",
+			parameters: toolSchema,
+			interruptible: true,
+			async execute(_toolCallId, _params, signal) {
+				if (!signal) throw new Error("missing tool abort signal");
+				started.resolve();
+				const { promise, resolve } = Promise.withResolvers<void>();
+				const timer = setTimeout(() => {
+					resolvedByTimeout = true;
+					resolve();
+				}, 500);
+				signal.addEventListener(
+					"abort",
+					() => {
+						clearTimeout(timer);
+						resolve();
+					},
+					{ once: true },
+				);
+				await promise;
+				observedAbort = signal.aborted;
+				return { content: [{ type: "text", text: "done" }], details: {} };
+			},
+		};
+		const mock = createMockModel({
+			responses: [
+				{ content: [{ type: "toolCall", id: "tool-1", name: "wait", arguments: {} }] },
+				{ content: ["done"] },
+				{ content: ["done"] },
+			],
+		});
+		const agent = new Agent({
+			initialState: { model: mock.model, systemPrompt: ["Test"], tools: [tool], messages: [] },
+			streamFn: mock.stream,
+			steeringMode: "one-at-a-time",
+			interruptMode: "wait",
+		});
+
+		const running = agent.prompt("start");
+		await started.promise;
+		agent.steer(createUserMessage("ordinary steer"));
+		const advisor = createUserMessage("immediate advisor") as AgentMessage & {
+			[STEERING_MESSAGE_IMMEDIATE]?: boolean;
+		};
+		advisor[STEERING_MESSAGE_IMMEDIATE] = true;
+		agent.steer(advisor);
+		agent.setSteeringMode("all");
+		await running;
+
+		expect(observedAbort).toBe(true);
+		expect(resolvedByTimeout).toBe(false);
+	});
 	it("continue() re-executes a trailing assistant's unpaired tool calls before the next model call", async () => {
 		const toolSchema = type({ value: type("string") });
 		const executed: string[] = [];

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -244,6 +244,51 @@ describe("Agent", () => {
 
 		expect(agent.peekSteeringQueue()).toEqual([]);
 	});
+
+	it("one-at-a-time wait mode does not wake for an immediate steer behind an ordinary steer", async () => {
+		const toolSchema = type({});
+		const release = Promise.withResolvers<void>();
+		let started = false;
+		let agent: Agent;
+		const tool: AgentTool<typeof toolSchema, Record<string, never>> = {
+			name: "wait",
+			label: "Wait",
+			description: "Wait tool",
+			parameters: toolSchema,
+			async execute() {
+				started = true;
+				agent.steer(createUserMessage("ordinary steer"));
+				const advisor = createUserMessage("immediate advisor") as AgentMessage & {
+					[STEERING_MESSAGE_IMMEDIATE]?: boolean;
+				};
+				advisor[STEERING_MESSAGE_IMMEDIATE] = true;
+				agent.steer(advisor);
+				await release.promise;
+				return { content: [{ type: "text", text: "done" }], details: {} };
+			},
+		};
+		const mock = createMockModel({
+			responses: [
+				{ content: [{ type: "toolCall", id: "tool-1", name: "wait", arguments: {} }] },
+				{ content: ["ordinary handled"] },
+				{ content: ["advisor handled"] },
+			],
+		});
+		agent = new Agent({
+			initialState: { model: mock.model, systemPrompt: ["Test"], tools: [tool], messages: [] },
+			streamFn: mock.stream,
+			steeringMode: "one-at-a-time",
+			interruptMode: "wait",
+		});
+
+		const running = agent.prompt("start");
+		while (!started) await Bun.sleep(0);
+		await Bun.sleep(10);
+		release.resolve();
+		await running;
+
+		expect(agent.peekSteeringQueue()).toEqual([]);
+	});
 	it("continue() re-executes a trailing assistant's unpaired tool calls before the next model call", async () => {
 		const toolSchema = type({ value: type("string") });
 		const executed: string[] = [];

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -14,6 +14,12 @@
 
 - Recover stray <SM:EDIT> payloads emitted as plain text into real edit tool calls, with support for disabling this behavior through the edit.recoverInlineEdits setting.
 - Advisors now receive context from the active memory backend, including project decisions and recalled instructions; advisors also gain the recall tool when supported by the backend.
+- Added provider-reported credits and concrete routed-model counts to `/session` statistics ([#8590](https://github.com/can1357/oh-my-pi/pull/8590) by [@will-bogusz](https://github.com/will-bogusz)).
+- Added `CLINE_API_KEY` to the CLI environment help for native ClinePass subscription inference ([#7863](https://github.com/can1357/oh-my-pi/pull/7863) by [@will-bogusz](https://github.com/will-bogusz)).
+- Devin model selectors now accept the native CLI's short aliases (`devin/opus`, `devin/swe`), dotted upstream spellings (`devin/gemini-3.7-flash`), and raw effort-route wire uids for dynamically collapsed families ([#8590](https://github.com/can1357/oh-my-pi/pull/8590) by [@will-bogusz](https://github.com/will-bogusz)).
+- Added provider-supplied model metadata to the `/models` detail line: `new`, `beta`, and `recommended` badges beside the model name, and the upstream description after the context, cost, and perf facts ([#8590](https://github.com/can1357/oh-my-pi/pull/8590) by [@will-bogusz](https://github.com/will-bogusz)).
+- Standalone `CLAUDE.md` files in the project root (and ancestor directories) are now loaded as context, mirroring `AGENTS.md` discovery; config-directory context files still take precedence per scope.
+- Added an Advisor interrupt mode that can defer concern and blocker delivery until the active tool batch completes.
 
 ### Changed
 

--- a/packages/coding-agent/src/advisor/advise-tool.ts
+++ b/packages/coding-agent/src/advisor/advise-tool.ts
@@ -35,6 +35,8 @@ export interface AdvisorNote {
 	severity?: AdvisorSeverity;
 	/** Which configured advisor produced this note (omitted for the default advisor). */
 	advisor?: string;
+	/** True only when wait mode deferred an otherwise interrupting note. */
+	deferredInterrupt?: boolean;
 }
 
 /** Details payload on the batched `advisor` custom message rendered in the transcript. */

--- a/packages/coding-agent/src/advisor/advise-tool.ts
+++ b/packages/coding-agent/src/advisor/advise-tool.ts
@@ -88,6 +88,11 @@ export function isAdvisorInterruptImmuneTurnActive(opts: {
 	return opts.completedTurns < opts.immuneTurnStart + opts.immuneTurns;
 }
 
+/** Plan mode keeps its stronger preserve-only contract even when wait mode is selected. */
+export function shouldDeferAdvisorInterrupt(mode: "immediate" | "wait", planModeEnabled: boolean): boolean {
+	return mode === "wait" && !planModeEnabled;
+}
+
 /**
  * Decide how one advisor note reaches the primary agent.
  *

--- a/packages/coding-agent/src/advisor/advise-tool.ts
+++ b/packages/coding-agent/src/advisor/advise-tool.ts
@@ -115,6 +115,9 @@ export function isAdvisorInterruptImmuneTurnActive(opts: {
  *   downgraded to asides; preservation still wins. A `blocker` is exempt: it
  *   means the agent handed off broken or unexercised work, so it still steers a
  *   triggered turn even right after a prior interrupt (#5628).
+ * When `deferInterruptingAdvice` is active during a live turn, concern and
+ * blocker notes use the aside channel so the active tool batch completes before
+ * the next model step receives them. Idle and aborting policy remains unchanged.
  */
 export function resolveAdvisorDeliveryChannel(opts: {
 	severity: AdvisorSeverity | undefined;
@@ -123,11 +126,13 @@ export function resolveAdvisorDeliveryChannel(opts: {
 	aborting: boolean;
 	terminalAnswerNoQueuedWork?: boolean;
 	interruptImmuneTurnActive?: boolean;
+	deferInterruptingAdvice?: boolean;
 	preserveOnly?: boolean;
 }): AdvisorDeliveryChannel {
 	if (opts.preserveOnly && !opts.streaming) return "preserve";
 	if (!isInterruptingSeverity(opts.severity)) return "aside";
 	if (opts.autoResumeSuppressed && (opts.aborting || !opts.streaming)) return "preserve";
+	if (opts.deferInterruptingAdvice && opts.streaming && !opts.aborting) return "aside";
 	if (opts.terminalAnswerNoQueuedWork && opts.severity !== "blocker" && !opts.streaming && !opts.aborting)
 		return "preserve";
 	if (opts.interruptImmuneTurnActive && opts.severity !== "blocker") return "aside";

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -564,6 +564,31 @@ export const SETTINGS_SCHEMA = {
 			condition: "advisorEnabled",
 		},
 	},
+	"advisor.interruptMode": {
+		type: "enum",
+		values: ["immediate", "wait"] as const,
+		default: "immediate",
+		ui: {
+			tab: "model",
+			group: "Advisor",
+			label: "Advisor Interrupt Mode",
+			description:
+				"Choose whether concern/blocker advice interrupts a running tool batch or waits until the batch completes. Idle delivery and terminal blockers are unchanged.",
+			options: [
+				{
+					value: "immediate",
+					label: "Immediate",
+					description: "Interrupt the active tool batch and skip sibling calls that have not started.",
+				},
+				{
+					value: "wait",
+					label: "Wait for Tool Batch",
+					description: "Let the active tool batch finish, then deliver advice before the next model step.",
+				},
+			],
+			condition: "advisorEnabled",
+		},
+	},
 	"advisor.immuneTurns": {
 		type: "number",
 		default: 3,

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1609,6 +1609,7 @@ export class AgentSession {
 			onSseEvent: this.#onSseEvent,
 			isDisposed: () => this.#isDisposed,
 			abortInProgress: () => this.#abortInProgress,
+			isAgentConnected: () => this.#unsubscribeAgent !== undefined,
 			allowAgentInitiatedTurns: () => this.#allowAcpAgentInitiatedTurns,
 			planModeState: () => this.#planModeState,
 			clientBridge: () => this.#clientBridge,
@@ -4096,6 +4097,7 @@ export class AgentSession {
 	#reconnectToAgent(): void {
 		if (this.#unsubscribeAgent) return; // Already connected
 		this.#unsubscribeAgent = this.agent.subscribe(this.#handleAgentEvent);
+		this.#preserveSettledDeferredAdvice();
 	}
 
 	#activeProviderSessionId(sessionId?: string): string {

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -39,6 +39,7 @@ import {
 	type BeforeToolCallResult,
 	EventLoopKeepalive,
 	resolveTelemetry,
+	STEERING_MESSAGE_IMMEDIATE,
 	type StreamFn,
 	TERMINAL_TOOL_RESULT_ABORT_REASON,
 	type ThinkingLevel,
@@ -6791,6 +6792,7 @@ export class AgentSession {
 			deliverAs?: "steer" | "followUp" | "nextTurn";
 			queueChipText?: string;
 			acceptTerminalEmptyStop?: boolean;
+			immediateInterrupt?: boolean;
 		},
 	): Promise<boolean> {
 		const normalizedPayload = normalizeCustomMessagePayload<T>(message);
@@ -6813,6 +6815,9 @@ export class AgentSession {
 			timestamp: Date.now(),
 		};
 		const normalizedAppMessage = await this.#normalizeAgentMessageImages(appMessage);
+		if (options?.immediateInterrupt) {
+			Object.defineProperty(normalizedAppMessage, STEERING_MESSAGE_IMMEDIATE, { value: true });
+		}
 		if (this.isStreaming) {
 			if (options?.deliverAs === "nextTurn") {
 				this.#queueHiddenNextTurnMessage(normalizedAppMessage, options?.triggerTurn ?? false);

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -802,8 +802,7 @@ export class AgentSession {
 	}
 
 	#preserveSettledDeferredAdvice(): void {
-		if (this.agent.state.isStreaming || this.#abortInProgress) return;
-		for (const card of this.#advisors.drainDeferredAdvice()) this.#preserveAdvisorCard(card);
+		this.#advisors.preserveDeferredAdviceAfterSettle();
 	}
 	#endInFlight(onSettled?: () => void | Promise<void>): void {
 		if (onSettled) this.#inFlightSettledCallbacks.push(onSettled);

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -801,11 +801,16 @@ export class AgentSession {
 		}
 	}
 
+	#preserveSettledDeferredAdvice(): void {
+		if (this.agent.state.isStreaming || this.#abortInProgress) return;
+		for (const card of this.#advisors.drainDeferredAdvice()) this.#preserveAdvisorCard(card);
+	}
 	#endInFlight(onSettled?: () => void | Promise<void>): void {
 		if (onSettled) this.#inFlightSettledCallbacks.push(onSettled);
 		this.#promptInFlightCount = Math.max(0, this.#promptInFlightCount - 1);
 		if (this.#promptInFlightCount !== 0) return;
 		this.yieldQueue.requestIdleFlush();
+		this.#preserveSettledDeferredAdvice();
 		this.#releasePowerAssertion();
 		this.#flushPendingAgentEnd();
 		if (this.#inFlightSettledCallbacks.length === 0) {
@@ -998,6 +1003,7 @@ export class AgentSession {
 	#resetInFlight(): void {
 		this.#promptInFlightCount = 0;
 		this.yieldQueue.requestIdleFlush();
+		this.#preserveSettledDeferredAdvice();
 		this.#releasePowerAssertion();
 		this.#flushPendingAgentEnd();
 		if (this.#inFlightSettledCallbacks.length === 0) {

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -7188,7 +7188,9 @@ export class AgentSession {
 		// Pull advisor concerns out of the steer/follow-up queues before any await so
 		// the post-abort stranded-message drain can't auto-resume the run on them.
 		// They are re-recorded as visible advice once the agent settles (below).
-		const strandedAdvisorCards = userInterrupt ? this.#extractQueuedAdvisorCards() : [];
+		const strandedAdvisorCards = userInterrupt
+			? [...this.#extractQueuedAdvisorCards(), ...this.#advisors.drainDeferredAdvice()]
+			: [];
 		// Session switch/compact paths disconnect first; explicit aborts should
 		// leave any queued steer/follow-up visible for the user rather than
 		// auto-starting a fresh turn during cleanup.

--- a/packages/coding-agent/src/session/session-advisors.ts
+++ b/packages/coding-agent/src/session/session-advisors.ts
@@ -247,6 +247,7 @@ export interface SessionAdvisorsHost {
 	onSseEvent: SimpleStreamOptions["onSseEvent"] | undefined;
 	isDisposed(): boolean;
 	abortInProgress(): boolean;
+	isAgentConnected(): boolean;
 	allowAgentInitiatedTurns(): boolean;
 	planModeState(): PlanModeState | undefined;
 	clientBridge(): ClientBridge | undefined;
@@ -628,7 +629,7 @@ export class SessionAdvisors {
 
 	/** Testable settle transition: preserve deferred notes once the primary loop is idle. */
 	preserveDeferredAdviceNow(): void {
-		if (this.#host.agent.state.isStreaming || this.#host.abortInProgress()) return;
+		if (!this.#host.isAgentConnected() || this.#host.agent.state.isStreaming || this.#host.abortInProgress()) return;
 		for (const card of this.drainDeferredAdvice()) this.#host.preserveAdvisorCard(card);
 	}
 

--- a/packages/coding-agent/src/session/session-advisors.ts
+++ b/packages/coding-agent/src/session/session-advisors.ts
@@ -336,6 +336,7 @@ export class SessionAdvisors {
 	#advisorPrimaryTurnsCompleted = 0;
 	#advisorInterruptImmuneTurnStart: number | undefined;
 	#pendingAdvisorCardEvents = new Set<Promise<void>>();
+	#deferredAdviceDrainScheduled = false;
 	#advisorYieldQueueUnsubscribe: (() => void) | undefined;
 
 	constructor(host: SessionAdvisorsHost, options: SessionAdvisorsOptions) {
@@ -612,6 +613,17 @@ export class SessionAdvisors {
 			entry => (entry as AdvisorNote).deferredInterrupt === true,
 		);
 		return message && isAdvisorCard(message) ? [message] : [];
+	}
+
+	/** Reclassify wait-mode advice that arrived after the loop's final aside poll. */
+	preserveDeferredAdviceAfterSettle(): void {
+		if (this.#deferredAdviceDrainScheduled) return;
+		this.#deferredAdviceDrainScheduled = true;
+		queueMicrotask(() => {
+			this.#deferredAdviceDrainScheduled = false;
+			if (this.#host.agent.state.isStreaming || this.#host.abortInProgress()) return;
+			for (const card of this.drainDeferredAdvice()) this.#host.preserveAdvisorCard(card);
+		});
 	}
 
 	// Advisor runtime lifecycle

--- a/packages/coding-agent/src/session/session-advisors.ts
+++ b/packages/coding-agent/src/session/session-advisors.ts
@@ -227,6 +227,7 @@ export interface SessionAdvisorsOptions {
 export interface AdvisorMessageDeliveryOptions {
 	triggerTurn?: boolean;
 	deliverAs?: "steer" | "followUp" | "nextTurn";
+	immediateInterrupt?: boolean;
 	queueChipText?: string;
 	acceptTerminalEmptyStop?: boolean;
 }
@@ -621,9 +622,14 @@ export class SessionAdvisors {
 		this.#deferredAdviceDrainScheduled = true;
 		queueMicrotask(() => {
 			this.#deferredAdviceDrainScheduled = false;
-			if (this.#host.agent.state.isStreaming || this.#host.abortInProgress()) return;
-			for (const card of this.drainDeferredAdvice()) this.#host.preserveAdvisorCard(card);
+			this.preserveDeferredAdviceNow();
 		});
+	}
+
+	/** Testable settle transition: preserve deferred notes once the primary loop is idle. */
+	preserveDeferredAdviceNow(): void {
+		if (this.#host.agent.state.isStreaming || this.#host.abortInProgress()) return;
+		for (const card of this.drainDeferredAdvice()) this.#host.preserveAdvisorCard(card);
 	}
 
 	// Advisor runtime lifecycle
@@ -1317,7 +1323,11 @@ export class SessionAdvisors {
 		void this.#host
 			.sendCustomMessage(
 				{ customType: "advisor", content, display: true, attribution: "agent", details },
-				{ deliverAs: "steer", triggerTurn: true },
+				{
+					deliverAs: "steer",
+					triggerTurn: true,
+					immediateInterrupt: this.#host.settings.get("advisor.interruptMode") === "immediate",
+				},
 			)
 			.catch(err => logger.debug("advisor delivery failed", { err: String(err) }));
 	}

--- a/packages/coding-agent/src/session/session-advisors.ts
+++ b/packages/coding-agent/src/session/session-advisors.ts
@@ -605,9 +605,12 @@ export class SessionAdvisors {
 		await Promise.allSettled(this.#pendingAdvisorCardEvents);
 	}
 
-	/** Remove deferred advice from the aside queue for explicit preservation. */
+	/** Remove wait-deferred interrupting advice for explicit preservation. */
 	drainDeferredAdvice(): CustomMessage[] {
-		const message = this.#host.yieldQueue.drainKind("advisor");
+		const message = this.#host.yieldQueue.drainKind(
+			"advisor",
+			entry => (entry as AdvisorNote).deferredInterrupt === true,
+		);
 		return message && isAdvisorCard(message) ? [message] : [];
 	}
 
@@ -1229,6 +1232,10 @@ export class SessionAdvisors {
 		const source = advisor.slug ? advisor.name : undefined;
 		const interrupting = isInterruptingSeverity(severity);
 		const planModeEnabled = this.#host.planModeState()?.enabled === true;
+		const deferInterruptingAdvice = shouldDeferAdvisorInterrupt(
+			this.#host.settings.get("advisor.interruptMode"),
+			planModeEnabled,
+		);
 		const channel = resolveAdvisorDeliveryChannel({
 			severity,
 			autoResumeSuppressed: this.#advisorAutoResumeSuppressed,
@@ -1240,13 +1247,15 @@ export class SessionAdvisors {
 			aborting: this.#host.abortInProgress(),
 			terminalAnswerNoQueuedWork: this.#hasTerminalTextAnswerWithoutQueuedWork(),
 			interruptImmuneTurnActive: interrupting && this.#isAdvisorInterruptImmuneTurnActive(),
-			deferInterruptingAdvice: shouldDeferAdvisorInterrupt(
-				this.#host.settings.get("advisor.interruptMode"),
-				planModeEnabled,
-			),
+			deferInterruptingAdvice,
 		});
 		if (channel === "aside") {
-			this.#host.yieldQueue.enqueue("advisor", { note, severity, advisor: source });
+			this.#host.yieldQueue.enqueue("advisor", {
+				note,
+				severity,
+				advisor: source,
+				...(deferInterruptingAdvice && interrupting ? { deferredInterrupt: true } : {}),
+			});
 			return;
 		}
 		const notes: AdvisorNote[] = [{ note, severity, advisor: source }];
@@ -1768,6 +1777,7 @@ export class SessionAdvisors {
 	prepareForTerminalYieldAdvisorDrain(): void {
 		this.#preserveAdvisorAdvice = true;
 		this.#preserveTerminalYieldAdvice = true;
+		for (const card of this.drainDeferredAdvice()) this.#host.preserveAdvisorCard(card);
 	}
 
 	/** Restore normal advisor routing when a kept-alive subagent starts new work. */

--- a/packages/coding-agent/src/session/session-advisors.ts
+++ b/packages/coding-agent/src/session/session-advisors.ts
@@ -1184,16 +1184,15 @@ export class SessionAdvisors {
 
 	/**
 	 * Route one accepted advice note from `advisor` to the primary. Concern and
-	 * blocker interrupt the running agent through the steering channel; once the
-	 * loop has yielded, `triggerTurn` resumes it. After a terminal text answer with
-	 * no queued work, a concern is preserved as a visible advisor card, while a
-	 * blocker wakes the primary to acknowledge work it handed off incorrectly.
+	 * blocker normally interrupt through steering; `advisor.interruptMode: wait`
+	 * instead queues them while the primary is streaming so the current tool batch
+	 * completes before the next model step receives the advice. Once the loop has
+	 * yielded, the existing terminal/trigger/preserve policy remains unchanged.
 	 * After a deliberate user interrupt auto-resume is suppressed while idle/unwinding
-	 * (the note becomes a preserved card re-entering on resume); a live-streaming turn is
-	 * steered in directly. A plain nit always rides the non-interrupting YieldQueue
-	 * aside. Suppression by the per-advisor emission guard drops the note silently —
-	 * the model still saw `Recorded.`, so it isn't tempted to rephrase the same note
-	 * past the dedupe.
+	 * (the note becomes a preserved card re-entering on resume). A plain nit always
+	 * rides the non-interrupting YieldQueue aside. Suppression by the per-advisor
+	 * emission guard drops the note silently — the model still saw `Recorded.`, so
+	 * it isn't tempted to rephrase the same note past the dedupe.
 	 */
 	#hasTerminalTextAnswerWithoutQueuedWork(): boolean {
 		if (this.#host.agent.hasQueuedMessages() || this.#host.hasPendingNextTurnMessages()) return false;
@@ -1222,6 +1221,7 @@ export class SessionAdvisors {
 		// agent-facing `<advisory>` bytes stay identical to the pre-multi-advisor path.
 		const source = advisor.slug ? advisor.name : undefined;
 		const interrupting = isInterruptingSeverity(severity);
+		const planModeEnabled = this.#host.planModeState()?.enabled === true;
 		const channel = resolveAdvisorDeliveryChannel({
 			severity,
 			autoResumeSuppressed: this.#advisorAutoResumeSuppressed,
@@ -1233,6 +1233,7 @@ export class SessionAdvisors {
 			aborting: this.#host.abortInProgress(),
 			terminalAnswerNoQueuedWork: this.#hasTerminalTextAnswerWithoutQueuedWork(),
 			interruptImmuneTurnActive: interrupting && this.#isAdvisorInterruptImmuneTurnActive(),
+			deferInterruptingAdvice: this.#host.settings.get("advisor.interruptMode") === "wait" && !planModeEnabled,
 		});
 		if (channel === "aside") {
 			this.#host.yieldQueue.enqueue("advisor", { note, severity, advisor: source });
@@ -1265,7 +1266,7 @@ export class SessionAdvisors {
 			!this.#host.agent.state.isStreaming &&
 			this.#host.clientBridge()?.deferAgentInitiatedTurns === true &&
 			!this.#host.allowAgentInitiatedTurns();
-		if (this.#host.planModeState()?.enabled || cannotAutoTrigger) {
+		if (planModeEnabled || cannotAutoTrigger) {
 			this.#host.preserveAdvisorCard({
 				role: "custom",
 				customType: "advisor",

--- a/packages/coding-agent/src/session/session-advisors.ts
+++ b/packages/coding-agent/src/session/session-advisors.ts
@@ -58,6 +58,7 @@ import {
 	isInterruptingSeverity,
 	quarantineAdvisorUnsafeOutput,
 	resolveAdvisorDeliveryChannel,
+	shouldDeferAdvisorInterrupt,
 	slugifyAdvisorName,
 } from "../advisor";
 import type { ModelRegistry } from "../config/model-registry";
@@ -1239,7 +1240,10 @@ export class SessionAdvisors {
 			aborting: this.#host.abortInProgress(),
 			terminalAnswerNoQueuedWork: this.#hasTerminalTextAnswerWithoutQueuedWork(),
 			interruptImmuneTurnActive: interrupting && this.#isAdvisorInterruptImmuneTurnActive(),
-			deferInterruptingAdvice: this.#host.settings.get("advisor.interruptMode") === "wait" && !planModeEnabled,
+			deferInterruptingAdvice: shouldDeferAdvisorInterrupt(
+				this.#host.settings.get("advisor.interruptMode"),
+				planModeEnabled,
+			),
 		});
 		if (channel === "aside") {
 			this.#host.yieldQueue.enqueue("advisor", { note, severity, advisor: source });

--- a/packages/coding-agent/src/session/session-advisors.ts
+++ b/packages/coding-agent/src/session/session-advisors.ts
@@ -627,10 +627,17 @@ export class SessionAdvisors {
 		});
 	}
 
-	/** Testable settle transition: preserve deferred notes once the primary loop is idle. */
+	/** Testable settle transition: route deferred notes once the primary loop is idle. */
 	preserveDeferredAdviceNow(): void {
 		if (!this.#host.isAgentConnected() || this.#host.agent.state.isStreaming || this.#host.abortInProgress()) return;
-		for (const card of this.drainDeferredAdvice()) this.#host.preserveAdvisorCard(card);
+		for (const card of this.drainDeferredAdvice()) {
+			const notes = (card.details as AdvisorMessageDetails | undefined)?.notes;
+			if (!Array.isArray(notes)) {
+				this.#host.preserveAdvisorCard(card);
+				continue;
+			}
+			for (const note of notes) this.#deliverAcceptedAdvice(note.note, note.severity, note.advisor);
+		}
 	}
 
 	// Advisor runtime lifecycle
@@ -1248,7 +1255,10 @@ export class SessionAdvisors {
 	#routeAdvice(advisor: ActiveAdvisor, note: string, severity?: AdvisorSeverity): void {
 		// The implicit single ("default") advisor stamps no source name, so its
 		// agent-facing `<advisory>` bytes stay identical to the pre-multi-advisor path.
-		const source = advisor.slug ? advisor.name : undefined;
+		this.#deliverAcceptedAdvice(note, severity, advisor.slug ? advisor.name : undefined);
+	}
+
+	#deliverAcceptedAdvice(note: string, severity?: AdvisorSeverity, source?: string): void {
 		const interrupting = isInterruptingSeverity(severity);
 		const planModeEnabled = this.#host.planModeState()?.enabled === true;
 		const deferInterruptingAdvice = shouldDeferAdvisorInterrupt(

--- a/packages/coding-agent/src/session/session-advisors.ts
+++ b/packages/coding-agent/src/session/session-advisors.ts
@@ -604,6 +604,12 @@ export class SessionAdvisors {
 		await Promise.allSettled(this.#pendingAdvisorCardEvents);
 	}
 
+	/** Remove deferred advice from the aside queue for explicit preservation. */
+	drainDeferredAdvice(): CustomMessage[] {
+		const message = this.#host.yieldQueue.drainKind("advisor");
+		return message && isAdvisorCard(message) ? [message] : [];
+	}
+
 	// Advisor runtime lifecycle
 	// -------------------------------------------------------------------------
 	#advisorImmuneTurnLimit(): number {

--- a/packages/coding-agent/src/session/yield-queue.ts
+++ b/packages/coding-agent/src/session/yield-queue.ts
@@ -179,13 +179,17 @@ export class YieldQueue {
 		return thunks;
 	}
 
-	/** Build and remove all queued entries for one kind without injecting them. */
-	drainKind(kind: string): AgentMessage | null {
+	/** Build and remove matching queued entries for one kind without injecting them. */
+	drainKind(kind: string, include: (entry: unknown) => boolean = () => true): AgentMessage | null {
 		const dispatcher = this.#dispatchers.get(kind);
 		if (!dispatcher) return null;
 		const entries = this.#drain(kind);
 		if (entries.length === 0) return null;
-		const built = this.#build(kind, dispatcher, entries);
+		const included: StoredEntry[] = [];
+		const retained: StoredEntry[] = [];
+		for (const entry of entries) (include(entry.value) ? included : retained).push(entry);
+		if (retained.length > 0) this.#entries.set(kind, retained);
+		const built = this.#build(kind, dispatcher, included);
 		if (!built) return null;
 		this.#resolveEntries(built.entries);
 		return built.message;

--- a/packages/coding-agent/src/session/yield-queue.ts
+++ b/packages/coding-agent/src/session/yield-queue.ts
@@ -179,6 +179,18 @@ export class YieldQueue {
 		return thunks;
 	}
 
+	/** Build and remove all queued entries for one kind without injecting them. */
+	drainKind(kind: string): AgentMessage | null {
+		const dispatcher = this.#dispatchers.get(kind);
+		if (!dispatcher) return null;
+		const entries = this.#drain(kind);
+		if (entries.length === 0) return null;
+		const built = this.#build(kind, dispatcher, entries);
+		if (!built) return null;
+		this.#resolveEntries(built.entries);
+		return built.message;
+	}
+
 	/** Drop queued entries. With `kind`, drop only that kind's entries (leaving
 	 *  any pending idle-flush for other kinds intact); otherwise drop everything. */
 	clear(kind?: string): void {

--- a/packages/coding-agent/test/acp-lazy-startup.test.ts
+++ b/packages/coding-agent/test/acp-lazy-startup.test.ts
@@ -257,6 +257,7 @@ describe("ACP lazy startup", () => {
 			"memories.enabled": true,
 			"advisor.enabled": true,
 			"advisor.syncBacklog": "5",
+			"advisor.interruptMode": "wait",
 			"advisor.immuneTurns": 7,
 			"todo.enabled": false,
 			"todo.reminders": false,

--- a/packages/coding-agent/test/advisor/advisor.test.ts
+++ b/packages/coding-agent/test/advisor/advisor.test.ts
@@ -6021,6 +6021,41 @@ describe("advisor", () => {
 			}
 		});
 
+		it("defers concern and blocker to the next tool-batch boundary when configured", () => {
+			for (const severity of ["concern", "blocker"] as const) {
+				expect(
+					resolveAdvisorDeliveryChannel({
+						severity,
+						autoResumeSuppressed: false,
+						streaming: true,
+						aborting: false,
+						deferInterruptingAdvice: true,
+					}),
+				).toBe("aside");
+			}
+		});
+
+		it("keeps idle and aborting delivery policy unchanged in after-tool mode", () => {
+			expect(
+				resolveAdvisorDeliveryChannel({
+					severity: "blocker",
+					autoResumeSuppressed: false,
+					streaming: false,
+					aborting: false,
+					deferInterruptingAdvice: true,
+				}),
+			).toBe("steer");
+			expect(
+				resolveAdvisorDeliveryChannel({
+					severity: "blocker",
+					autoResumeSuppressed: true,
+					streaming: true,
+					aborting: true,
+					deferInterruptingAdvice: true,
+				}),
+			).toBe("preserve");
+		});
+
 		it("preserves a late concern when the primary already ended with a terminal answer", () => {
 			expect(
 				resolveAdvisorDeliveryChannel({

--- a/packages/coding-agent/test/advisor/advisor.test.ts
+++ b/packages/coding-agent/test/advisor/advisor.test.ts
@@ -23,6 +23,7 @@ import {
 	isInterruptingSeverity,
 	quarantineAdvisorUnsafeOutput,
 	resolveAdvisorDeliveryChannel,
+	shouldDeferAdvisorInterrupt,
 	type WatchdogConfigDoc,
 } from "../../src/advisor";
 import type { ModelRegistry } from "../../src/config/model-registry";
@@ -6054,6 +6055,12 @@ describe("advisor", () => {
 					deferInterruptingAdvice: true,
 				}),
 			).toBe("preserve");
+		});
+
+		it("keeps plan mode on preserve routing when wait mode is configured", () => {
+			expect(shouldDeferAdvisorInterrupt("wait", false)).toBe(true);
+			expect(shouldDeferAdvisorInterrupt("wait", true)).toBe(false);
+			expect(shouldDeferAdvisorInterrupt("immediate", false)).toBe(false);
 		});
 
 		it("preserves a late concern when the primary already ended with a terminal answer", () => {

--- a/packages/coding-agent/test/agent-session-advisor-suppression.test.ts
+++ b/packages/coding-agent/test/agent-session-advisor-suppression.test.ts
@@ -316,6 +316,75 @@ describe("AgentSession advisor auto-resume suppression", () => {
 		expect(advisorCards[0].content).toContain("Final yield needs correction");
 	});
 
+	it("preserves wait-mode advice through the live session route in plan mode", async () => {
+		const started = Promise.withResolvers<void>();
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5")!;
+		const mock = createMockModel({
+			responses: [
+				() => {
+					started.resolve();
+					return { content: ["working"], delayMs: 60_000 };
+				},
+			],
+		});
+		const advisorMock = createMockModel({
+			responses: [
+				{
+					content: [
+						{
+							type: "toolCall",
+							name: "advise",
+							arguments: { note: "Plan needs correction", severity: "blocker" },
+						},
+					],
+				},
+				{ content: [], stopReason: "stop" },
+			],
+		});
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model, systemPrompt: ["Test"], tools: [] },
+			streamFn: mock.stream,
+		});
+		const sessionManager = SessionManager.inMemory();
+		const settings = Settings.isolated({
+			"advisor.interruptMode": "wait",
+			"compaction.enabled": false,
+			"retry.enabled": false,
+		});
+		settings.setModelRole("advisor", "anthropic/claude-sonnet-4-5");
+		const authStorage = await AuthStorage.create(":memory:");
+		authStorages.push(authStorage);
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		const modelRegistry = new ModelRegistry(authStorage, tempDir.join("models.yml"));
+		session = new AgentSession({
+			agent,
+			sessionManager,
+			settings,
+			modelRegistry,
+			advisorTools: [],
+			advisorStreamFn: advisorMock.stream,
+		});
+		const persisted = capturePersistedAdvice(sessionManager);
+		session.setPlanModeState({ enabled: true, planFilePath: "local://PLAN.md" });
+		expect(session.setAdvisorEnabled(true)).toBe(true);
+
+		const running = session.prompt("inspect the plan");
+		await started.promise;
+		const advisor = session.getAdvisorAgent();
+		if (!advisor) throw new Error("Expected advisor agent to be live");
+		await advisor.prompt("review the active plan");
+		await session.waitForAdvisorCatchup(1000);
+
+		expect(session.yieldQueue.has("advisor")).toBe(false);
+		expect(session.agent.state.messages.filter(isAdvisorCard)).toHaveLength(1);
+		expect(persisted.at(-1)).toContain("Plan needs correction");
+		expect(mock.calls).toHaveLength(1);
+
+		await session.abort({ reason: USER_INTERRUPT_LABEL });
+		await running.catch(() => {});
+	});
+
 	it("preserves a late advisor concern after a terminal answer without waking the primary", async () => {
 		const { session, sessionManager, mock, advisorMock } = await createCompletedAdvisorSession();
 		const persisted = capturePersistedAdvice(sessionManager);

--- a/packages/coding-agent/test/agent-session-advisor-suppression.test.ts
+++ b/packages/coding-agent/test/agent-session-advisor-suppression.test.ts
@@ -514,6 +514,37 @@ describe("AgentSession advisor auto-resume suppression", () => {
 		await running.catch(() => {});
 	});
 
+	it("preserves wait-mode advice queued before a user interrupt", async () => {
+		const { session, sessionManager, mock, streamStarted } = await createParkedSession();
+		const persisted = capturePersistedAdvice(sessionManager);
+		session.settings.set("advisor.interruptMode", "wait");
+		session.yieldQueue.register<{ note: string; severity: "blocker" }>("advisor", {
+			build: entries =>
+				({
+					role: "custom",
+					...advisorCard(entries.map(entry => entry.note).join("\n")),
+					timestamp: Date.now(),
+				}) as AgentMessage,
+			skipIdleFlush: true,
+		});
+
+		const running = session.prompt("do the thing");
+		await streamStarted;
+		// The production wait-mode route uses this same skip-idle-flush advisor queue.
+		session.yieldQueue.enqueue("advisor", {
+			note: "deferred mid-tool",
+			severity: "blocker",
+		});
+
+		await session.abort({ reason: USER_INTERRUPT_LABEL });
+		await session.waitForIdle();
+
+		expect(session.agent.state.messages.filter(isAdvisorCard)).toHaveLength(1);
+		expect(persisted.at(-1)).toContain("deferred mid-tool");
+		expect(mock.calls.length).toBe(1);
+		await running.catch(() => {});
+	});
+
 	it("keeps advisor auto-resume for a non-user (internal) abort", async () => {
 		const { session, mock, streamStarted } = await createParkedSession([{ content: ["resumed after advice"] }]);
 

--- a/packages/coding-agent/test/agent-session-advisor-suppression.test.ts
+++ b/packages/coding-agent/test/agent-session-advisor-suppression.test.ts
@@ -587,7 +587,7 @@ describe("AgentSession advisor auto-resume suppression", () => {
 		const { session, sessionManager, mock, streamStarted } = await createParkedSession();
 		const persisted = capturePersistedAdvice(sessionManager);
 		session.settings.set("advisor.interruptMode", "wait");
-		session.yieldQueue.register<{ note: string; severity: "blocker" }>("advisor", {
+		session.yieldQueue.register<{ note: string; severity: "blocker"; deferredInterrupt: true }>("advisor", {
 			build: entries =>
 				({
 					role: "custom",
@@ -603,6 +603,7 @@ describe("AgentSession advisor auto-resume suppression", () => {
 		session.yieldQueue.enqueue("advisor", {
 			note: "deferred mid-tool",
 			severity: "blocker",
+			deferredInterrupt: true,
 		});
 
 		await session.abort({ reason: USER_INTERRUPT_LABEL });

--- a/packages/coding-agent/test/agent-session-auto-compaction-queue.test.ts
+++ b/packages/coding-agent/test/agent-session-auto-compaction-queue.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
 import { scheduler } from "node:timers/promises";
-import { Agent } from "@oh-my-pi/pi-agent-core";
+import { Agent, type AgentMessage } from "@oh-my-pi/pi-agent-core";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
@@ -321,6 +321,54 @@ describe("AgentSession auto-compaction queue resume", () => {
 
 		// compact()'s finally re-drained the stranded queue after reconnecting.
 		expect(continueSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it("preserves deferred advisor advice after manual compaction reconnects", async () => {
+		session.settings.set("compaction.keepRecentTokens", 1);
+		sessionManager.appendMessage({
+			role: "assistant",
+			content: [{ type: "text", text: "previous answer" }],
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: "claude-sonnet-4-5",
+			stopReason: "stop",
+			usage: {
+				input: 1_000,
+				output: 100,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 1_100,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			timestamp: Date.now(),
+		});
+		sessionManager.appendMessage({ role: "user", content: "second turn", timestamp: Date.now() });
+		session.yieldQueue.register<{ note: string; deferredInterrupt: true }>("advisor", {
+			build: entries =>
+				({
+					role: "custom",
+					customType: "advisor",
+					content: entries.map(entry => entry.note).join("\n"),
+					display: true,
+					attribution: "agent",
+					timestamp: Date.now(),
+				}) as AgentMessage,
+			skipIdleFlush: true,
+		});
+		const persisted: string[] = [];
+		sessionManager.onEntryAppended = entry => {
+			if (entry.type === "custom_message" && entry.customType === "advisor") {
+				persisted.push(typeof entry.content === "string" ? entry.content : JSON.stringify(entry.content));
+			}
+		};
+		session.yieldQueue.enqueue("advisor", { note: "deferred during compact", deferredInterrupt: true });
+
+		await session.compact();
+		await Promise.resolve();
+		await session.waitForIdle();
+
+		expect(persisted).toEqual(["deferred during compact"]);
+		expect(session.yieldQueue.has("advisor")).toBe(false);
 	});
 
 	it("cancels an in-flight auto-compaction when manual compact startup aborts", async () => {

--- a/packages/coding-agent/test/agent-session-auto-compaction-queue.test.ts
+++ b/packages/coding-agent/test/agent-session-auto-compaction-queue.test.ts
@@ -323,7 +323,7 @@ describe("AgentSession auto-compaction queue resume", () => {
 		expect(continueSpy).toHaveBeenCalledTimes(1);
 	});
 
-	it("preserves deferred advisor advice after manual compaction reconnects", async () => {
+	it("preserves a deferred concern after manual compaction reconnects", async () => {
 		session.settings.set("compaction.keepRecentTokens", 1);
 		sessionManager.appendMessage({
 			role: "assistant",
@@ -342,8 +342,12 @@ describe("AgentSession auto-compaction queue resume", () => {
 			},
 			timestamp: Date.now(),
 		});
-		sessionManager.appendMessage({ role: "user", content: "second turn", timestamp: Date.now() });
-		session.yieldQueue.register<{ note: string; deferredInterrupt: true }>("advisor", {
+		type DeferredAdvice = {
+			note: string;
+			severity: "concern" | "blocker";
+			deferredInterrupt: true;
+		};
+		session.yieldQueue.register<DeferredAdvice>("advisor", {
 			build: entries =>
 				({
 					role: "custom",
@@ -351,6 +355,7 @@ describe("AgentSession auto-compaction queue resume", () => {
 					content: entries.map(entry => entry.note).join("\n"),
 					display: true,
 					attribution: "agent",
+					details: { notes: entries },
 					timestamp: Date.now(),
 				}) as AgentMessage,
 			skipIdleFlush: true,
@@ -361,13 +366,69 @@ describe("AgentSession auto-compaction queue resume", () => {
 				persisted.push(typeof entry.content === "string" ? entry.content : JSON.stringify(entry.content));
 			}
 		};
-		session.yieldQueue.enqueue("advisor", { note: "deferred during compact", deferredInterrupt: true });
+		session.yieldQueue.enqueue("advisor", {
+			note: "deferred concern during compact",
+			severity: "concern",
+			deferredInterrupt: true,
+		});
+
+		await session.compact();
+		await session.waitForIdle();
+
+		expect(persisted).toEqual([expect.stringContaining("deferred concern during compact")]);
+		expect(session.yieldQueue.has("advisor")).toBe(false);
+	});
+
+	it("restarts after manual compaction to acknowledge a deferred blocker", async () => {
+		session.settings.set("compaction.keepRecentTokens", 1);
+		sessionManager.appendMessage({
+			role: "assistant",
+			content: [{ type: "text", text: "previous answer" }],
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: "claude-sonnet-4-5",
+			stopReason: "stop",
+			usage: {
+				input: 1_000,
+				output: 100,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 1_100,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			timestamp: Date.now(),
+		});
+		session.yieldQueue.register<{ note: string; severity: "blocker"; deferredInterrupt: true }>("advisor", {
+			build: entries =>
+				({
+					role: "custom",
+					customType: "advisor",
+					content: entries.map(entry => entry.note).join("\n"),
+					display: true,
+					attribution: "agent",
+					details: { notes: entries },
+					timestamp: Date.now(),
+				}) as AgentMessage,
+			skipIdleFlush: true,
+		});
+		const sendCustomMessage = vi.spyOn(session, "sendCustomMessage").mockResolvedValue(false);
+		session.yieldQueue.enqueue("advisor", {
+			note: "deferred blocker during compact",
+			severity: "blocker",
+			deferredInterrupt: true,
+		});
 
 		await session.compact();
 		await Promise.resolve();
-		await session.waitForIdle();
 
-		expect(persisted).toEqual(["deferred during compact"]);
+		expect(sendCustomMessage).toHaveBeenCalledWith(
+			expect.objectContaining({
+				customType: "advisor",
+				content: expect.stringContaining("deferred blocker during compact"),
+			}),
+			expect.objectContaining({ deliverAs: "steer", triggerTurn: true }),
+		);
+		expect(session.agent.state.messages.some(message => message.role === "custom")).toBe(false);
 		expect(session.yieldQueue.has("advisor")).toBe(false);
 	});
 

--- a/packages/coding-agent/test/modes/components/settings-layout.test.ts
+++ b/packages/coding-agent/test/modes/components/settings-layout.test.ts
@@ -81,7 +81,11 @@ describe("settings layout", () => {
 	});
 
 	it("hides advisor dependent settings when advisor is disabled", () => {
-		const advisorDependentPaths: SettingPath[] = ["advisor.syncBacklog", "advisor.immuneTurns"];
+		const advisorDependentPaths: SettingPath[] = [
+			"advisor.syncBacklog",
+			"advisor.interruptMode",
+			"advisor.immuneTurns",
+		];
 		const advisorDependentPathSet = new Set(advisorDependentPaths);
 		const defs = getSettingsForTab("model").filter(def => advisorDependentPathSet.has(def.path));
 

--- a/packages/coding-agent/test/session/yield-queue.test.ts
+++ b/packages/coding-agent/test/session/yield-queue.test.ts
@@ -122,6 +122,22 @@ describe("YieldQueue", () => {
 		expect(message && messageText(message)).toBe("concern");
 		expect(harness.queue.has("advisor")).toBe(false);
 	});
+
+	test("drainKind retains entries rejected by its filter", () => {
+		const harness = createHarness(true);
+		harness.queue.register<Entry>("advisor", {
+			build: entries => userMessage(entries.map(entry => entry.id).join(",")),
+			skipIdleFlush: true,
+		});
+		harness.queue.enqueue("advisor", { id: "nit" });
+		harness.queue.enqueue("advisor", { id: "deferred" });
+
+		const message = harness.queue.drainKind("advisor", entry => (entry as Entry).id === "deferred");
+
+		expect(message && messageText(message)).toBe("deferred");
+		expect(harness.queue.has("advisor")).toBe(true);
+		expect(messageText(harness.queue.drainKind("advisor")!)).toBe("nit");
+	});
 	test("enqueue while idle schedules one debounced idle flush", async () => {
 		const harness = createHarness(false);
 		harness.queue.register<Entry>("items", {

--- a/packages/coding-agent/test/session/yield-queue.test.ts
+++ b/packages/coding-agent/test/session/yield-queue.test.ts
@@ -108,6 +108,20 @@ describe("YieldQueue", () => {
 		expect(harness.idleBatches[0]?.map(messageText)).toEqual(["done"]);
 		expect(harness.queue.has("advisor")).toBe(true);
 	});
+
+	test("drainKind extracts skip-idle-flush entries for explicit preservation", () => {
+		const harness = createHarness(true);
+		harness.queue.register<Entry>("advisor", {
+			build: entries => userMessage(entries.map(entry => entry.id).join(",")),
+			skipIdleFlush: true,
+		});
+		harness.queue.enqueue("advisor", { id: "concern" });
+
+		const message = harness.queue.drainKind("advisor");
+
+		expect(message && messageText(message)).toBe("concern");
+		expect(harness.queue.has("advisor")).toBe(false);
+	});
 	test("enqueue while idle schedules one debounced idle flush", async () => {
 		const harness = createHarness(false);
 		harness.queue.register<Entry>("items", {

--- a/packages/coding-agent/test/session/yield-queue.test.ts
+++ b/packages/coding-agent/test/session/yield-queue.test.ts
@@ -138,6 +138,23 @@ describe("YieldQueue", () => {
 		expect(harness.queue.has("advisor")).toBe(true);
 		expect(messageText(harness.queue.drainKind("advisor")!)).toBe("nit");
 	});
+
+	test("drainKind extracts deferred interrupts while retaining ordinary advisor asides", () => {
+		const harness = createHarness(true);
+		type Advice = { id: string; deferredInterrupt?: boolean };
+		harness.queue.register<Advice>("advisor", {
+			build: entries => userMessage(entries.map(entry => entry.id).join(",")),
+			skipIdleFlush: true,
+		});
+		harness.queue.enqueue("advisor", { id: "nit" });
+		harness.queue.enqueue("advisor", { id: "blocker", deferredInterrupt: true });
+
+		const message = harness.queue.drainKind("advisor", entry => (entry as Advice).deferredInterrupt === true);
+
+		expect(message && messageText(message)).toBe("blocker");
+		expect(harness.queue.has("advisor")).toBe(true);
+		expect(messageText(harness.queue.drainKind("advisor")!)).toBe("nit");
+	});
 	test("enqueue while idle schedules one debounced idle flush", async () => {
 		const harness = createHarness(false);
 		harness.queue.register<Entry>("items", {

--- a/packages/coding-agent/test/session/yield-queue.test.ts
+++ b/packages/coding-agent/test/session/yield-queue.test.ts
@@ -155,6 +155,7 @@ describe("YieldQueue", () => {
 		expect(harness.queue.has("advisor")).toBe(true);
 		expect(messageText(harness.queue.drainKind("advisor")!)).toBe("nit");
 	});
+
 	test("enqueue while idle schedules one debounced idle flush", async () => {
 		const harness = createHarness(false);
 		harness.queue.register<Entry>("items", {


### PR DESCRIPTION
## Motivation / discussion

Today an advisor `concern` or `blocker` is delivered as steering while the primary loop is active. Under the default immediate interrupt policy, that can signal the running tool and skip sibling tool calls that have not started. This is useful when the advisor catches a destructive or fundamentally wrong action, but it is expensive for users who want the advisor to review work without repeatedly disrupting a planned tool batch.

The repository already has global `interruptMode: wait`, but that applies to all steering. Lowering advice severity is also the wrong abstraction: a blocker remains a blocker; only its insertion timing changes.

## Proposed setting

```yaml
advisor:
  interruptMode: immediate # current behavior and default
  # interruptMode: wait    # finish the active tool batch first
```

Semantics:

| State | `immediate` | `wait` |
| --- | --- | --- |
| Active tool batch | interrupts even when global `interruptMode` is `wait` | current batch completes; advice enters before next model step |
| Primary idle | existing terminal/trigger behavior | unchanged |
| User interrupt | existing preserve behavior | only wait-deferred concern/blocker notes are preserved; ordinary nits remain queued |
| Terminal yield | existing preserve behavior | queued wait-deferred advice is preserved |
| Plan mode | preserve | preserve |
| Nit | aside | aside |

The option is advisor-specific. Severity remains unchanged in the rendered `<advisory>`.

## Tradeoffs

- `wait` can allow one tool batch to finish after a serious blocker is discovered, so it is opt-in.
- `immediate` remains appropriate for safety-focused reviewers.
- `wait` avoids synthetic `interrupt_skipped` results and repeated replanning caused by partially executed batches.
- The implementation reuses existing aside/steering queues and adds a per-message immediate marker rather than changing user/system steering behavior.

Open to different naming (`after-tool-batch`, `deferred`) or per-advisor configuration in `WATCHDOG.yml`; this PR intentionally starts with one session-wide setting.

Related: #8888, #9074.

## Verification

- marked advisor steering overrides global wait: passed
- system advisory sibling skipping: passed
- wait-mode interrupt/plan-mode preservation: passed
- YieldQueue selective drain: 15 passed
- `bun --cwd=packages/coding-agent run check`
- `bun --cwd=packages/agent run check`
- `git diff --check`