### PR TITLE
fix(ai): use registered Z.AI OAuth redirect

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -20,6 +20,10 @@
 - Devin auth, model assignment, and chat requests now send the native Devin CLI identity (`ideName: devin-cli`, `ideType: chisel`, `extensionName: chisel`, mapped `os`) instead of the Windsurf IDE identity; `ideType: chisel` is what the backend requires for router assignment ([#8590](https://github.com/can1357/oh-my-pi/pull/8590) by [@will-bogusz](https://github.com/will-bogusz)).
 - Devin parallel tool calls follow `compat.supportsParallelToolCalls` instead of being disabled unconditionally, so natively discovered configs that support parallelism can use it ([#8590](https://github.com/can1357/oh-my-pi/pull/8590) by [@will-bogusz](https://github.com/will-bogusz)).
 
+### Fixed
+
+- Fixed bundled Z.AI browser sign-in to use the registered `zcode://zai-auth/callback` redirect and manual callback paste instead of an unregistered localhost callback, which caused authorization rejection.
+
 ## [18.0.11] - 2026-08-29
 
 ### Fixed

--- a/packages/ai/src/registry/oauth/zai.ts
+++ b/packages/ai/src/registry/oauth/zai.ts
@@ -27,8 +27,8 @@ const BIZ_BASE = env("ZAI_BIZ_BASE") ?? "https://api.z.ai";
 const BUSINESS_LOGIN_URL = env("ZAI_BUSINESS_LOGIN_URL") ?? "https://api.z.ai/api/auth/z/login";
 /** OMP's own key name so sign-in never mutates ZCode's `zcode-api-key`. */
 const KEY_NAME = "oh-my-pi";
-const CALLBACK_PORT = 54548;
-const CALLBACK_PATH = "/callback";
+/** Registered ZCode OAuth redirect; the custom scheme cannot reach a loopback listener. */
+const REDIRECT_URI = "zcode://zai-auth/callback";
 /** Durable minted key never expires; matches the perplexity NEVER_EXPIRES sentinel. */
 const NEVER_EXPIRES = 8.64e15;
 
@@ -218,9 +218,9 @@ export class ZaiOAuthFlow extends OAuthCallbackFlow {
 
 	constructor(ctrl: OAuthController) {
 		super(ctrl, {
-			preferredPort: CALLBACK_PORT,
-			callbackPath: CALLBACK_PATH,
-			allowPortFallback: false,
+			preferredPort: 0,
+			redirectUri: REDIRECT_URI,
+			manualInputOnly: true,
 		});
 		this.#fetch = ctrl.fetch ?? fetch;
 	}
@@ -236,7 +236,7 @@ export class ZaiOAuthFlow extends OAuthCallbackFlow {
 		return {
 			url: `${AUTHORIZE_URL}?${authParams.toString()}`,
 			instructions:
-				"Complete Z.ai login in your browser. If the browser cannot reach this machine, paste the final redirect URL or authorization code when prompted.",
+				"Complete Z.ai login in your browser. Copy the full final zcode:// callback URL or authorization code and paste it into OMP.",
 		};
 	}
 

--- a/packages/ai/src/registry/zai.ts
+++ b/packages/ai/src/registry/zai.ts
@@ -32,10 +32,8 @@ export const zaiCodingPlanProvider = {
 	// Minted key lives in creds.access; getOAuthApiKey returns it for the `zai`
 	// catalog provider verbatim, so store credentials under `zai`.
 	storeCredentialsAs: "zai",
-	// Loopback callback server on this port, plus the manual paste-code
-	// fallback (PASTE_CODE_LOGIN_PROVIDERS) for when the browser cannot reach
-	// this machine. Mirrors the Anthropic sign-in wiring.
-	callbackPort: 54548,
+	// Custom-scheme redirect (`zcode://zai-auth/callback`) cannot reach a
+	// loopback listener, so login is manual-paste only (PASTE_CODE_LOGIN_PROVIDERS).
 	pasteCodeFlow: true,
 	login: (cb: OAuthLoginCallbacks) => import("./oauth/zai").then(m => m.loginZaiOAuth(cb)),
 } as const satisfies ProviderDefinition;

--- a/packages/ai/test/zai-oauth.test.ts
+++ b/packages/ai/test/zai-oauth.test.ts
@@ -8,7 +8,7 @@ const TOKEN_URL = "https://zcode.z.ai/api/v1/oauth/token";
 const BUSINESS_LOGIN_URL = "https://api.z.ai/api/auth/z/login";
 const BIZ_BASE = "https://api.z.ai";
 const KEYS_URL = `${BIZ_BASE}/api/biz/v1/organization/org-1/projects/proj-1/api_keys`;
-const REDIRECT_URI = "http://localhost:54548/callback";
+const REDIRECT_URI = "zcode://zai-auth/callback";
 
 interface RecordedRequest {
 	url: string;
@@ -117,22 +117,49 @@ describe("zai oauth flow", () => {
 		expect(authUrl.searchParams.get("code_challenge_method")).toBeNull();
 	});
 
-	it("rejects an occupied fixed callback port before opening the browser", async () => {
-		const serveSpy = vi.spyOn(Bun, "serve").mockImplementation(() => {
-			throw Object.assign(new Error("EADDRINUSE"), { code: "EADDRINUSE" });
+	it("completes login from a pasted zcode:// callback using the registered redirect without binding Bun.serve", async () => {
+		const serveSpy = vi.spyOn(Bun, "serve");
+		const { fetchMock, requests } = makeBizFetch();
+		let capturedAuthUrl: string | undefined;
+		const flow = new ZaiOAuthFlow({
+			fetch: fetchMock as unknown as typeof fetch,
+			onAuth: info => {
+				capturedAuthUrl = info.url;
+			},
+			onManualCodeInput: async () => {
+				if (!capturedAuthUrl) {
+					throw new Error("onAuth did not capture the authorization URL");
+				}
+				const state = new URL(capturedAuthUrl).searchParams.get("state");
+				if (!state) {
+					throw new Error("authorization URL missing generated state");
+				}
+				return `${REDIRECT_URI}?code=auth-code&state=${encodeURIComponent(state)}`;
+			},
 		});
-		const onAuth = vi.fn();
-		const flow = new ZaiOAuthFlow({ onAuth });
 
-		const error = await flow.login().catch((caught: unknown) => caught);
+		const creds = await flow.login();
 
-		expect(error).toBeInstanceOf(AIError.ConfigurationError);
-		if (!(error instanceof AIError.ConfigurationError)) throw error;
-		expect(error.message).toContain(
-			"OAuth callback port 54548 is in use. The OAuth provider validates redirect URIs",
-		);
-		expect(onAuth).not.toHaveBeenCalled();
-		expect(serveSpy.mock.calls.every(([options]) => options.port === 54548)).toBe(true);
+		expect(serveSpy).not.toHaveBeenCalled();
+		expect(capturedAuthUrl).toBeDefined();
+		const authUrl = new URL(capturedAuthUrl ?? "");
+		const generatedState = authUrl.searchParams.get("state");
+		expect(generatedState).toBeTruthy();
+		expect(authUrl.origin + authUrl.pathname).toBe(AUTHORIZE_URL);
+		expect(authUrl.searchParams.get("client_id")).toBe(CLIENT_ID);
+		expect(authUrl.searchParams.get("redirect_uri")).toBe(REDIRECT_URI);
+
+		expect(creds.access).toBe("created-key.real-secret");
+		expect(creds.refresh).toBe("");
+		expect(creds.expires).toBe(8.64e15);
+
+		expect(requests[0]?.url).toBe(TOKEN_URL);
+		expect(requests[0]?.body).toEqual({
+			provider: "zai",
+			code: "auth-code",
+			redirect_uri: REDIRECT_URI,
+			state: generatedState,
+		});
 	});
 
 	it("exchanges the code, does business-login, then mints an id.secret key (create path)", async () => {

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Fixed an issue where custom model overrides were lost during configuration updates
 - Fixed "Please use nerdfont" notification incorrectly persisting after theme configuration
 - Fixed sampling parameter errors for newer Anthropic models (Opus 4.7+, Sonnet 5+)
+- Fixed `omp auth-broker login --via` for manual-paste OAuth providers such as Z.AI so remote login no longer requires a loopback SSH tunnel.
 
 ## [18.0.11] - 2026-08-29
 

--- a/packages/coding-agent/src/cli/auth-broker-cli.ts
+++ b/packages/coding-agent/src/cli/auth-broker-cli.ts
@@ -372,19 +372,18 @@ async function pickProviderInteractively(providers: readonly OAuthProviderInfo[]
 
 async function runRemoteLogin(provider: string, via: string, dryRun: boolean): Promise<void> {
 	const port = CALLBACK_PORTS[provider];
-	if (port === undefined) {
+	if (port === undefined && !PASTE_CODE_LOGIN_PROVIDERS.has(provider)) {
 		throw new Error(
 			`No known OAuth callback port for '${provider}'. Use device-code flow on the broker host directly.`,
 		);
 	}
-	const sshArgs = [
-		"-L",
-		`${port}:127.0.0.1:${port}`,
-		"-o",
-		"ExitOnForwardFailure=yes",
-		via,
-		`${APP_NAME} auth-broker login ${provider}`,
-	];
+	// Paste-code providers such as Z.AI use a non-loopback redirect, so remote
+	// login is a plain SSH session — no `-L` tunnel or ExitOnForwardFailure.
+	const remoteCommand = `${APP_NAME} auth-broker login ${provider}`;
+	const sshArgs =
+		port === undefined
+			? [via, remoteCommand]
+			: ["-L", `${port}:127.0.0.1:${port}`, "-o", "ExitOnForwardFailure=yes", via, remoteCommand];
 	if (dryRun) {
 		process.stdout.write(`ssh ${sshArgs.map(a => (a.includes(" ") ? `'${a}'` : a)).join(" ")}\n`);
 		return;

--- a/packages/coding-agent/test/auth-broker-remote-login.test.ts
+++ b/packages/coding-agent/test/auth-broker-remote-login.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { runAuthBrokerCommand } from "@oh-my-pi/pi-coding-agent/cli/auth-broker-cli";
+
+const ORIGINAL_STDOUT_WRITE = process.stdout.write.bind(process.stdout);
+
+async function captureStdout(fn: () => Promise<void>): Promise<string> {
+	let captured = "";
+	process.stdout.write = ((chunk: string | Uint8Array): boolean => {
+		captured += typeof chunk === "string" ? chunk : new TextDecoder().decode(chunk);
+		return true;
+	}) as typeof process.stdout.write;
+	try {
+		await fn();
+	} finally {
+		process.stdout.write = ORIGINAL_STDOUT_WRITE;
+	}
+	return captured;
+}
+
+describe("auth-broker login --via dry-run", () => {
+	afterEach(() => {
+		process.stdout.write = ORIGINAL_STDOUT_WRITE;
+	});
+
+	test("Z.AI paste-code OAuth SSHs without a loopback tunnel", async () => {
+		const output = await captureStdout(() =>
+			runAuthBrokerCommand({
+				action: "login",
+				flags: { provider: "zai-coding-plan", via: "user@broker", dryRun: true },
+			}),
+		);
+		expect(output).toBe("ssh user@broker 'omp auth-broker login zai-coding-plan'\n");
+		expect(output).not.toContain("-L");
+		expect(output).not.toContain("ExitOnForwardFailure");
+	});
+
+	test("loopback OAuth retains SSH port forwarding", async () => {
+		const output = await captureStdout(() =>
+			runAuthBrokerCommand({
+				action: "login",
+				flags: { provider: "anthropic", via: "user@broker", dryRun: true },
+			}),
+		);
+		expect(output).toBe(
+			"ssh -L 54545:127.0.0.1:54545 -o ExitOnForwardFailure=yes user@broker 'omp auth-broker login anthropic'\n",
+		);
+	});
+
+	test("device-code OAuth without a callback port is refused", async () => {
+		await expect(
+			runAuthBrokerCommand({
+				action: "login",
+				flags: { provider: "github-copilot", via: "user@broker", dryRun: true },
+			}),
+		).rejects.toThrow(
+			"No known OAuth callback port for 'github-copilot'. Use device-code flow on the broker host directly.",
+		);
+	});
+});


### PR DESCRIPTION
## Problem

OMP’s bundled Z.AI OAuth client is registered for `zcode://zai-auth/callback`, but browser sign-in advertised `http://localhost:54548/callback`. Z.AI rejected that redirect before authentication could complete.

## Change

- Use the registered `zcode://zai-auth/callback` redirect.
- Run the callback flow in manual-input-only mode because a custom URI scheme cannot reach OMP’s loopback server.
- Prompt the user to paste the final callback URL or authorization code.
- Remove the obsolete fixed callback-port metadata.
- Replace the occupied-port regression with coverage proving no listener is created and the registered redirect is used for authorization and token exchange.

## Human review

I hit Z.AI’s “Redirect URI not registered” error during OMP login, and this change uses ZCode’s registered callback so the browser flow can complete.

## Verification

- `bunx biome check packages/ai/CHANGELOG.md packages/ai/src/registry/oauth/zai.ts packages/ai/src/registry/zai.ts packages/ai/test/zai-oauth.test.ts`
- `bun --cwd=packages/ai run check:types`
- `bun test packages/ai/test/zai-oauth.test.ts packages/ai/test/provider-registry.test.ts packages/ai/test/auth-storage-manual-code-gate.test.ts` — 18 pass, 0 fail
- Built OMP and passed `omp --smoke-test`.
- Reproduced the original redirect rejection, then completed a real Z.AI browser login through the patched manual callback flow.