### PR TITLE
feat(coding-agent): add repository-aware Git and Jujutsu conflict resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2627,9 +2627,8 @@ dependencies = [
 
 [[package]]
 name = "gix"
-version = "0.85.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa8b2e38ebfc4484dfef8580ddcaf8abb7285e6f3eb6413ff6775d104ae96ca6"
+version = "0.87.1"
+source = "git+https://github.com/0WD0/gitoxide.git?rev=d26d3b019fecc96100e4232cf0d8c22a8ce5101d#d26d3b019fecc96100e4232cf0d8c22a8ce5101d"
 dependencies = [
  "gix-actor",
  "gix-attributes",
@@ -2651,12 +2650,14 @@ dependencies = [
  "gix-index",
  "gix-lock",
  "gix-merge",
+ "gix-note",
  "gix-object",
  "gix-odb",
  "gix-pack",
  "gix-path",
  "gix-pathspec",
  "gix-protocol",
+ "gix-quote",
  "gix-ref",
  "gix-refspec",
  "gix-revision",
@@ -2674,6 +2675,7 @@ dependencies = [
  "gix-worktree",
  "gix-worktree-state",
  "gix-worktree-stream",
+ "gix-zlib",
  "nonempty",
  "smallvec",
  "thiserror 2.0.20",
@@ -2681,9 +2683,8 @@ dependencies = [
 
 [[package]]
 name = "gix-actor"
-version = "0.41.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33f9308ad6fd35b2a865cbe4117ac61b2be59e4a9ef1621c7a9794f7c8e52c5b"
+version = "0.42.0"
+source = "git+https://github.com/0WD0/gitoxide.git?rev=d26d3b019fecc96100e4232cf0d8c22a8ce5101d#d26d3b019fecc96100e4232cf0d8c22a8ce5101d"
 dependencies = [
  "bstr",
  "gix-date",
@@ -2692,16 +2693,15 @@ dependencies = [
 
 [[package]]
 name = "gix-attributes"
-version = "0.33.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39b40888d0ed415c0744a6cdc61eebf0304c9d26ab726725b718443c322e5ba4"
+version = "0.35.0"
+source = "git+https://github.com/0WD0/gitoxide.git?rev=d26d3b019fecc96100e4232cf0d8c22a8ce5101d#d26d3b019fecc96100e4232cf0d8c22a8ce5101d"
 dependencies = [
  "bstr",
+ "gix-features",
  "gix-glob",
  "gix-path",
  "gix-quote",
  "gix-trace",
- "kstring",
  "smallvec",
  "thiserror 2.0.20",
  "unicode-bom",
@@ -2709,40 +2709,35 @@ dependencies = [
 
 [[package]]
 name = "gix-bitmap"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd1d118d0f5d88b96e6f6e13b566475fef4797ead4a02c26fed36c1375066f7"
+version = "0.4.0"
+source = "git+https://github.com/0WD0/gitoxide.git?rev=d26d3b019fecc96100e4232cf0d8c22a8ce5101d#d26d3b019fecc96100e4232cf0d8c22a8ce5101d"
 dependencies = [
  "gix-error",
 ]
 
 [[package]]
 name = "gix-chunk"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a871e5cab12ba568845714473505deefffb3c04eb47f4708ce344cd459c1cc"
+version = "0.8.0"
+source = "git+https://github.com/0WD0/gitoxide.git?rev=d26d3b019fecc96100e4232cf0d8c22a8ce5101d#d26d3b019fecc96100e4232cf0d8c22a8ce5101d"
 dependencies = [
  "gix-error",
 ]
 
 [[package]]
 name = "gix-command"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4363accdf6ef7ba861871d2d521ab7418a04aaaed919fadb022af71d379b12"
+version = "0.10.0"
+source = "git+https://github.com/0WD0/gitoxide.git?rev=d26d3b019fecc96100e4232cf0d8c22a8ce5101d#d26d3b019fecc96100e4232cf0d8c22a8ce5101d"
 dependencies = [
  "bstr",
  "gix-path",
  "gix-quote",
  "gix-trace",
- "shell-words",
 ]
 
 [[package]]
 name = "gix-commitgraph"
-version = "0.37.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f675d0df484a7f6a47e64bd6f311af489d947c0323b0564f36d14f3d7762abb"
+version = "0.39.0"
+source = "git+https://github.com/0WD0/gitoxide.git?rev=d26d3b019fecc96100e4232cf0d8c22a8ce5101d#d26d3b019fecc96100e4232cf0d8c22a8ce5101d"
 dependencies = [
  "bstr",
  "gix-chunk",
@@ -2754,9 +2749,8 @@ dependencies = [
 
 [[package]]
 name = "gix-config"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a29bf266c4cdaf759e535c24ad4ce655b987aeb6911075643403cc7cc5ade583"
+version = "0.60.0"
+source = "git+https://github.com/0WD0/gitoxide.git?rev=d26d3b019fecc96100e4232cf0d8c22a8ce5101d#d26d3b019fecc96100e4232cf0d8c22a8ce5101d"
 dependencies = [
  "bstr",
  "gix-config-value",
@@ -2765,6 +2759,7 @@ dependencies = [
  "gix-path",
  "gix-ref",
  "gix-sec",
+ "gix-utils",
  "smallvec",
  "thiserror 2.0.20",
  "unicode-bom",
@@ -2772,9 +2767,8 @@ dependencies = [
 
 [[package]]
 name = "gix-config-value"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed42168329552f6c2e5df09665c104199d45d84bedb53683738a49b57fe1baab"
+version = "0.19.1"
+source = "git+https://github.com/0WD0/gitoxide.git?rev=d26d3b019fecc96100e4232cf0d8c22a8ce5101d#d26d3b019fecc96100e4232cf0d8c22a8ce5101d"
 dependencies = [
  "bitflags 2.13.1",
  "bstr",
@@ -2785,9 +2779,8 @@ dependencies = [
 
 [[package]]
 name = "gix-date"
-version = "0.15.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e47b9e8cdc688296609b706428de570f88b1e0eed7156dde7b4a89d26fa4567"
+version = "0.16.0"
+source = "git+https://github.com/0WD0/gitoxide.git?rev=d26d3b019fecc96100e4232cf0d8c22a8ce5101d#d26d3b019fecc96100e4232cf0d8c22a8ce5101d"
 dependencies = [
  "bstr",
  "gix-error",
@@ -2797,9 +2790,8 @@ dependencies = [
 
 [[package]]
 name = "gix-diff"
-version = "0.65.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92c6d56c94edf92d78203a1cd416f770e35e10b6955ede6b9d7d0c22ff88a5f3"
+version = "0.67.1"
+source = "git+https://github.com/0WD0/gitoxide.git?rev=d26d3b019fecc96100e4232cf0d8c22a8ce5101d#d26d3b019fecc96100e4232cf0d8c22a8ce5101d"
 dependencies = [
  "bstr",
  "gix-attributes",
@@ -2821,9 +2813,8 @@ dependencies = [
 
 [[package]]
 name = "gix-dir"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20098fba2b9c6e29361ccb4c0379d42dfb81fc7f86f7ab11f2dff4528c0bf01f"
+version = "0.29.1"
+source = "git+https://github.com/0WD0/gitoxide.git?rev=d26d3b019fecc96100e4232cf0d8c22a8ce5101d#d26d3b019fecc96100e4232cf0d8c22a8ce5101d"
 dependencies = [
  "bstr",
  "gix-discover",
@@ -2841,9 +2832,8 @@ dependencies = [
 
 [[package]]
 name = "gix-discover"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d624d5b23b10c1d85337645227abe353ac95ab8ff66a7bdd5ce689b2db33a722"
+version = "0.55.0"
+source = "git+https://github.com/0WD0/gitoxide.git?rev=d26d3b019fecc96100e4232cf0d8c22a8ce5101d#d26d3b019fecc96100e4232cf0d8c22a8ce5101d"
 dependencies = [
  "bstr",
  "dunce",
@@ -2856,18 +2846,16 @@ dependencies = [
 
 [[package]]
 name = "gix-error"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a9292309fd944e71b2a3c96d3c03a6feb8852db646febdde7cbb9f79cb5f329"
+version = "0.3.1"
+source = "git+https://github.com/0WD0/gitoxide.git?rev=d26d3b019fecc96100e4232cf0d8c22a8ce5101d#d26d3b019fecc96100e4232cf0d8c22a8ce5101d"
 dependencies = [
  "bstr",
 ]
 
 [[package]]
 name = "gix-features"
-version = "0.48.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1849ae154d38bc403185be14fa871e38e3c93ee606875d94e207fdb9fba52dbc"
+version = "0.49.1"
+source = "git+https://github.com/0WD0/gitoxide.git?rev=d26d3b019fecc96100e4232cf0d8c22a8ce5101d#d26d3b019fecc96100e4232cf0d8c22a8ce5101d"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -2879,16 +2867,13 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "prodash",
- "thiserror 2.0.20",
  "walkdir",
- "zlib-rs",
 ]
 
 [[package]]
 name = "gix-filter"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6644fb2ef97928c278675b239f366b457103d7e436f811d27331a8daf212759c"
+version = "0.34.0"
+source = "git+https://github.com/0WD0/gitoxide.git?rev=d26d3b019fecc96100e4232cf0d8c22a8ce5101d#d26d3b019fecc96100e4232cf0d8c22a8ce5101d"
 dependencies = [
  "bstr",
  "encoding_rs",
@@ -2907,12 +2892,10 @@ dependencies = [
 
 [[package]]
 name = "gix-fs"
-version = "0.21.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cdff46db8798e47e2f727d84b9379aac5add3dd3d9d0b07bb4d7d5d640771fe"
+version = "0.22.1"
+source = "git+https://github.com/0WD0/gitoxide.git?rev=d26d3b019fecc96100e4232cf0d8c22a8ce5101d#d26d3b019fecc96100e4232cf0d8c22a8ce5101d"
 dependencies = [
  "bstr",
- "fastrand",
  "gix-features",
  "gix-path",
  "gix-utils",
@@ -2921,9 +2904,8 @@ dependencies = [
 
 [[package]]
 name = "gix-glob"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1fcb8ef5b16bcf874abe9b68d8abb3c0493c876d367ab824151f30a0f3f3756"
+version = "0.27.1"
+source = "git+https://github.com/0WD0/gitoxide.git?rev=d26d3b019fecc96100e4232cf0d8c22a8ce5101d#d26d3b019fecc96100e4232cf0d8c22a8ce5101d"
 dependencies = [
  "bitflags 2.13.1",
  "bstr",
@@ -2933,9 +2915,8 @@ dependencies = [
 
 [[package]]
 name = "gix-hash"
-version = "0.25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb0926d3819c837750b4e03c7754901e73f68b8c9b690753a6372a1bed4eedce"
+version = "0.26.2"
+source = "git+https://github.com/0WD0/gitoxide.git?rev=d26d3b019fecc96100e4232cf0d8c22a8ce5101d#d26d3b019fecc96100e4232cf0d8c22a8ce5101d"
 dependencies = [
  "faster-hex",
  "gix-features",
@@ -2946,9 +2927,8 @@ dependencies = [
 
 [[package]]
 name = "gix-hashtable"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e261d54091f0d1c729bc83f54548c071bdec60a697de1e58e88bdfd7a99d24e"
+version = "0.16.0"
+source = "git+https://github.com/0WD0/gitoxide.git?rev=d26d3b019fecc96100e4232cf0d8c22a8ce5101d#d26d3b019fecc96100e4232cf0d8c22a8ce5101d"
 dependencies = [
  "gix-hash",
  "hashbrown 0.17.1",
@@ -2957,9 +2937,8 @@ dependencies = [
 
 [[package]]
 name = "gix-ignore"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d491bab9bf2c9f341dc754f425c31d5d3f63aca615312167b82e1deeaca97d8d"
+version = "0.22.1"
+source = "git+https://github.com/0WD0/gitoxide.git?rev=d26d3b019fecc96100e4232cf0d8c22a8ce5101d#d26d3b019fecc96100e4232cf0d8c22a8ce5101d"
 dependencies = [
  "bstr",
  "gix-glob",
@@ -2971,18 +2950,16 @@ dependencies = [
 [[package]]
 name = "gix-imara-diff"
 version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c91d8cffac8849493a82233811bd02b2b183b8cf39bf704de0fa0841b737595"
+source = "git+https://github.com/0WD0/gitoxide.git?rev=d26d3b019fecc96100e4232cf0d8c22a8ce5101d#d26d3b019fecc96100e4232cf0d8c22a8ce5101d"
 dependencies = [
  "bstr",
- "hashbrown 0.17.1",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
 name = "gix-index"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36d45f82ec5a4d7542ea595e9ad16e03e26c8cb4f221e5bc9fcdcf469f63a681"
+version = "0.55.0"
+source = "git+https://github.com/0WD0/gitoxide.git?rev=d26d3b019fecc96100e4232cf0d8c22a8ce5101d#d26d3b019fecc96100e4232cf0d8c22a8ce5101d"
 dependencies = [
  "bitflags 2.13.1",
  "bstr",
@@ -3008,9 +2985,8 @@ dependencies = [
 
 [[package]]
 name = "gix-lock"
-version = "23.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65c9dedd9e90b0d47624d2ed241d394e09294118364e87b9b7e5f1fe755f3c2c"
+version = "24.0.0"
+source = "git+https://github.com/0WD0/gitoxide.git?rev=d26d3b019fecc96100e4232cf0d8c22a8ce5101d#d26d3b019fecc96100e4232cf0d8c22a8ce5101d"
 dependencies = [
  "gix-tempfile",
  "gix-utils",
@@ -3018,10 +2994,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "gix-macros"
+version = "0.1.6"
+source = "git+https://github.com/0WD0/gitoxide.git?rev=d26d3b019fecc96100e4232cf0d8c22a8ce5101d#d26d3b019fecc96100e4232cf0d8c22a8ce5101d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "gix-merge"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b529a5dc509175fe277643a1c50b38de69f24b5a50f9c4e7f854c7fc7d1acc7"
+version = "0.20.1"
+source = "git+https://github.com/0WD0/gitoxide.git?rev=d26d3b019fecc96100e4232cf0d8c22a8ce5101d#d26d3b019fecc96100e4232cf0d8c22a8ce5101d"
 dependencies = [
  "bstr",
  "gix-command",
@@ -3044,17 +3029,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "gix-note"
+version = "0.1.1"
+source = "git+https://github.com/0WD0/gitoxide.git?rev=d26d3b019fecc96100e4232cf0d8c22a8ce5101d#d26d3b019fecc96100e4232cf0d8c22a8ce5101d"
+dependencies = [
+ "gix-error",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+]
+
+[[package]]
 name = "gix-object"
-version = "0.62.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "019b38afc3eac1e41f9fe09a327664b313ba4a120fa5f40e3678795d0e42783e"
+version = "0.64.1"
+source = "git+https://github.com/0WD0/gitoxide.git?rev=d26d3b019fecc96100e4232cf0d8c22a8ce5101d#d26d3b019fecc96100e4232cf0d8c22a8ce5101d"
 dependencies = [
  "bstr",
  "gix-actor",
+ "gix-command",
  "gix-date",
  "gix-features",
  "gix-hash",
  "gix-hashtable",
+ "gix-tempfile",
  "gix-utils",
  "gix-validate",
  "itoa",
@@ -3064,9 +3061,8 @@ dependencies = [
 
 [[package]]
 name = "gix-odb"
-version = "0.82.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fadc59f6fa0f9dd445eceee61060a2b59ca557f48da9fc677f567db535b782a"
+version = "0.84.0"
+source = "git+https://github.com/0WD0/gitoxide.git?rev=d26d3b019fecc96100e4232cf0d8c22a8ce5101d#d26d3b019fecc96100e4232cf0d8c22a8ce5101d"
 dependencies = [
  "arc-swap",
  "gix-features",
@@ -3077,6 +3073,7 @@ dependencies = [
  "gix-pack",
  "gix-path",
  "gix-quote",
+ "gix-zlib",
  "memmap2",
  "parking_lot",
  "tempfile",
@@ -3085,11 +3082,11 @@ dependencies = [
 
 [[package]]
 name = "gix-pack"
-version = "0.72.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3e7f1726cd2c0cd1cf1fc20be8a8e623f0b163f1f8d6fc836cfb9bc8cd758b"
+version = "0.74.2"
+source = "git+https://github.com/0WD0/gitoxide.git?rev=d26d3b019fecc96100e4232cf0d8c22a8ce5101d#d26d3b019fecc96100e4232cf0d8c22a8ce5101d"
 dependencies = [
  "clru",
+ "crossbeam-deque",
  "gix-chunk",
  "gix-error",
  "gix-features",
@@ -3097,6 +3094,7 @@ dependencies = [
  "gix-hashtable",
  "gix-object",
  "gix-path",
+ "gix-zlib",
  "memmap2",
  "smallvec",
  "thiserror 2.0.20",
@@ -3105,9 +3103,8 @@ dependencies = [
 
 [[package]]
 name = "gix-packetline"
-version = "0.21.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b217dd0ee0c4021ecf169a4a519b1b4f80d15e3f3765f3dc466223dc0ac891d7"
+version = "0.22.2"
+source = "git+https://github.com/0WD0/gitoxide.git?rev=d26d3b019fecc96100e4232cf0d8c22a8ce5101d#d26d3b019fecc96100e4232cf0d8c22a8ce5101d"
 dependencies = [
  "bstr",
  "faster-hex",
@@ -3118,8 +3115,7 @@ dependencies = [
 [[package]]
 name = "gix-path"
 version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b075e730586bba7341304d6fc1b4efc1d10cf64532622521c0e07f30e661046"
+source = "git+https://github.com/0WD0/gitoxide.git?rev=d26d3b019fecc96100e4232cf0d8c22a8ce5101d#d26d3b019fecc96100e4232cf0d8c22a8ce5101d"
 dependencies = [
  "bstr",
  "gix-trace",
@@ -3129,9 +3125,8 @@ dependencies = [
 
 [[package]]
 name = "gix-pathspec"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3050783b41ee11511e1e8fb35623df81806194f4030395f14f48ea37c2798c9f"
+version = "0.20.0"
+source = "git+https://github.com/0WD0/gitoxide.git?rev=d26d3b019fecc96100e4232cf0d8c22a8ce5101d#d26d3b019fecc96100e4232cf0d8c22a8ce5101d"
 dependencies = [
  "bitflags 2.13.1",
  "bstr",
@@ -3144,28 +3139,26 @@ dependencies = [
 
 [[package]]
 name = "gix-protocol"
-version = "0.63.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978468bae4ea2df20c72db3b20d0bdb548a0c1090b85a83643b553e6e0e041f2"
+version = "0.65.1"
+source = "git+https://github.com/0WD0/gitoxide.git?rev=d26d3b019fecc96100e4232cf0d8c22a8ce5101d#d26d3b019fecc96100e4232cf0d8c22a8ce5101d"
 dependencies = [
  "bstr",
  "gix-date",
  "gix-features",
  "gix-hash",
+ "gix-macros",
  "gix-ref",
  "gix-shallow",
  "gix-transport",
  "gix-utils",
- "maybe-async",
  "nonempty",
  "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "gix-quote"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6e541fc33cc2b783b7979040d445a0c86a2eca747c8faea4ca84230d06ae6ef"
+version = "0.8.0"
+source = "git+https://github.com/0WD0/gitoxide.git?rev=d26d3b019fecc96100e4232cf0d8c22a8ce5101d#d26d3b019fecc96100e4232cf0d8c22a8ce5101d"
 dependencies = [
  "bstr",
  "gix-error",
@@ -3174,9 +3167,8 @@ dependencies = [
 
 [[package]]
 name = "gix-ref"
-version = "0.65.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bbfbce1dfd7d7f8469ddef6d3518376aff664348f153cbe0fc3e58ef993d24e"
+version = "0.67.1"
+source = "git+https://github.com/0WD0/gitoxide.git?rev=d26d3b019fecc96100e4232cf0d8c22a8ce5101d#d26d3b019fecc96100e4232cf0d8c22a8ce5101d"
 dependencies = [
  "gix-actor",
  "gix-features",
@@ -3194,15 +3186,11 @@ dependencies = [
 
 [[package]]
 name = "gix-refspec"
-version = "0.43.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bc36a4fb1a1540b59cf2da498783080743fa274b02a3f19ca444fc4015a9d4f"
+version = "0.45.1"
+source = "git+https://github.com/0WD0/gitoxide.git?rev=d26d3b019fecc96100e4232cf0d8c22a8ce5101d#d26d3b019fecc96100e4232cf0d8c22a8ce5101d"
 dependencies = [
  "bstr",
- "gix-error",
- "gix-glob",
  "gix-hash",
- "gix-revision",
  "gix-validate",
  "smallvec",
  "thiserror 2.0.20",
@@ -3210,9 +3198,8 @@ dependencies = [
 
 [[package]]
 name = "gix-revision"
-version = "0.47.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "885075c3c21eb9c06e0be3b3728ba5932c04e1c1011dcee7c81801980e3e986f"
+version = "0.49.1"
+source = "git+https://github.com/0WD0/gitoxide.git?rev=d26d3b019fecc96100e4232cf0d8c22a8ce5101d#d26d3b019fecc96100e4232cf0d8c22a8ce5101d"
 dependencies = [
  "bitflags 2.13.1",
  "bstr",
@@ -3229,9 +3216,8 @@ dependencies = [
 
 [[package]]
 name = "gix-revwalk"
-version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f11fe7ca2585193d3d70bbe0be175a2008d883a704cc7a55e454e113e689455"
+version = "0.35.0"
+source = "git+https://github.com/0WD0/gitoxide.git?rev=d26d3b019fecc96100e4232cf0d8c22a8ce5101d#d26d3b019fecc96100e4232cf0d8c22a8ce5101d"
 dependencies = [
  "gix-commitgraph",
  "gix-date",
@@ -3246,8 +3232,7 @@ dependencies = [
 [[package]]
 name = "gix-sec"
 version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af4fe6c152c1d50aea36f299825702cd37e303307832fec1d0fdd5844e47ce2f"
+source = "git+https://github.com/0WD0/gitoxide.git?rev=d26d3b019fecc96100e4232cf0d8c22a8ce5101d#d26d3b019fecc96100e4232cf0d8c22a8ce5101d"
 dependencies = [
  "bitflags 2.13.1",
  "gix-path",
@@ -3257,9 +3242,8 @@ dependencies = [
 
 [[package]]
 name = "gix-shallow"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a292fc2fe548c5dfa575479d16b445b0ddf1dd2f56f1fec6aed386f82553cd97"
+version = "0.13.0"
+source = "git+https://github.com/0WD0/gitoxide.git?rev=d26d3b019fecc96100e4232cf0d8c22a8ce5101d#d26d3b019fecc96100e4232cf0d8c22a8ce5101d"
 dependencies = [
  "bstr",
  "gix-hash",
@@ -3270,9 +3254,8 @@ dependencies = [
 
 [[package]]
 name = "gix-status"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aec3293f75db1212f99217832cbc70c30faeb95cefc97c7f1a17fd3bcf13a72e"
+version = "0.34.1"
+source = "git+https://github.com/0WD0/gitoxide.git?rev=d26d3b019fecc96100e4232cf0d8c22a8ce5101d#d26d3b019fecc96100e4232cf0d8c22a8ce5101d"
 dependencies = [
  "bstr",
  "filetime",
@@ -3287,15 +3270,16 @@ dependencies = [
  "gix-path",
  "gix-pathspec",
  "gix-worktree",
+ "hashbrown 0.16.1",
  "portable-atomic",
  "thiserror 2.0.20",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "gix-submodule"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7f9f594f7cbda0b38ba6b633b3e9a7b7901acdc5d27bc186a16633800cd1ac8"
+version = "0.34.0"
+source = "git+https://github.com/0WD0/gitoxide.git?rev=d26d3b019fecc96100e4232cf0d8c22a8ce5101d#d26d3b019fecc96100e4232cf0d8c22a8ce5101d"
 dependencies = [
  "bstr",
  "gix-config",
@@ -3308,9 +3292,8 @@ dependencies = [
 
 [[package]]
 name = "gix-tempfile"
-version = "23.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ef60812443484e67bf84e444cc71b4c78ae62deb822221774a4fa0c57fdb17f"
+version = "24.0.0"
+source = "git+https://github.com/0WD0/gitoxide.git?rev=d26d3b019fecc96100e4232cf0d8c22a8ce5101d#d26d3b019fecc96100e4232cf0d8c22a8ce5101d"
 dependencies = [
  "dashmap",
  "gix-fs",
@@ -3322,19 +3305,18 @@ dependencies = [
 [[package]]
 name = "gix-trace"
 version = "0.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be3eb81d9dc914335923e50d52829c551feefd6a72d176c4130c546b67a60814"
+source = "git+https://github.com/0WD0/gitoxide.git?rev=d26d3b019fecc96100e4232cf0d8c22a8ce5101d#d26d3b019fecc96100e4232cf0d8c22a8ce5101d"
 
 [[package]]
 name = "gix-transport"
-version = "0.57.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "186874f7ad1fb2f9a2f2aa9c2dabc7f9dd087bef74c1a0eee2b4a9cf0248fcb3"
+version = "0.59.1"
+source = "git+https://github.com/0WD0/gitoxide.git?rev=d26d3b019fecc96100e4232cf0d8c22a8ce5101d#d26d3b019fecc96100e4232cf0d8c22a8ce5101d"
 dependencies = [
  "bstr",
  "gix-command",
  "gix-features",
  "gix-packetline",
+ "gix-path",
  "gix-quote",
  "gix-sec",
  "gix-url",
@@ -3343,9 +3325,8 @@ dependencies = [
 
 [[package]]
 name = "gix-traverse"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5062cca8f2977565bbaf666ec31dbdb9bc9d9293beb65f9bec52e6c1121b62a1"
+version = "0.61.0"
+source = "git+https://github.com/0WD0/gitoxide.git?rev=d26d3b019fecc96100e4232cf0d8c22a8ce5101d#d26d3b019fecc96100e4232cf0d8c22a8ce5101d"
 dependencies = [
  "bitflags 2.13.1",
  "gix-commitgraph",
@@ -3360,12 +3341,12 @@ dependencies = [
 
 [[package]]
 name = "gix-url"
-version = "0.36.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d68e70e96da0e5f9c871f1566349e0fd0e1a20bb483c7f54af1dd0b85b4b29"
+version = "0.38.0"
+source = "git+https://github.com/0WD0/gitoxide.git?rev=d26d3b019fecc96100e4232cf0d8c22a8ce5101d#d26d3b019fecc96100e4232cf0d8c22a8ce5101d"
 dependencies = [
  "bstr",
  "gix-path",
+ "gix-utils",
  "percent-encoding",
  "thiserror 2.0.20",
 ]
@@ -3373,8 +3354,7 @@ dependencies = [
 [[package]]
 name = "gix-utils"
 version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0da1c46491b49458a446cc76f0085860f8164c2290742e0aa8c653ce67240a97"
+source = "git+https://github.com/0WD0/gitoxide.git?rev=d26d3b019fecc96100e4232cf0d8c22a8ce5101d#d26d3b019fecc96100e4232cf0d8c22a8ce5101d"
 dependencies = [
  "bstr",
  "fastrand",
@@ -3385,20 +3365,19 @@ dependencies = [
 [[package]]
 name = "gix-validate"
 version = "0.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dae8780f63ed8a803b8bdabbd7aa5f5c5d74592c8b50eed875c1bb4f6545a6a"
+source = "git+https://github.com/0WD0/gitoxide.git?rev=d26d3b019fecc96100e4232cf0d8c22a8ce5101d#d26d3b019fecc96100e4232cf0d8c22a8ce5101d"
 dependencies = [
  "bstr",
 ]
 
 [[package]]
 name = "gix-worktree"
-version = "0.54.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92399ed66f259592050c6ed9dc80105e095a2f8e87e6b83d98aa2e21d8e27036"
+version = "0.56.0"
+source = "git+https://github.com/0WD0/gitoxide.git?rev=d26d3b019fecc96100e4232cf0d8c22a8ce5101d#d26d3b019fecc96100e4232cf0d8c22a8ce5101d"
 dependencies = [
  "bstr",
  "gix-attributes",
+ "gix-features",
  "gix-fs",
  "gix-glob",
  "gix-hash",
@@ -3411,9 +3390,8 @@ dependencies = [
 
 [[package]]
 name = "gix-worktree-state"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f926b6a249bdb0086b307c704b7abd9d643e08f98040efe6467f00bb6d2ef5"
+version = "0.34.1"
+source = "git+https://github.com/0WD0/gitoxide.git?rev=d26d3b019fecc96100e4232cf0d8c22a8ce5101d#d26d3b019fecc96100e4232cf0d8c22a8ce5101d"
 dependencies = [
  "bstr",
  "gix-features",
@@ -3429,9 +3407,8 @@ dependencies = [
 
 [[package]]
 name = "gix-worktree-stream"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55f3a878c89a05470ad98c644b0015777c530da24854dd29e41fe4f41176840f"
+version = "0.36.1"
+source = "git+https://github.com/0WD0/gitoxide.git?rev=d26d3b019fecc96100e4232cf0d8c22a8ce5101d#d26d3b019fecc96100e4232cf0d8c22a8ce5101d"
 dependencies = [
  "gix-attributes",
  "gix-error",
@@ -3443,6 +3420,15 @@ dependencies = [
  "gix-path",
  "gix-traverse",
  "parking_lot",
+]
+
+[[package]]
+name = "gix-zlib"
+version = "0.1.0"
+source = "git+https://github.com/0WD0/gitoxide.git?rev=d26d3b019fecc96100e4232cf0d8c22a8ce5101d#d26d3b019fecc96100e4232cf0d8c22a8ce5101d"
+dependencies = [
+ "thiserror 2.0.20",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -4490,10 +4476,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "jj-core"
+version = "0.44.0"
+source = "git+https://github.com/0WD0/jj.git?rev=d967d70207834d9400e483edd02b6f1f49924330#d967d70207834d9400e483edd02b6f1f49924330"
+dependencies = [
+ "blake2",
+ "bstr",
+ "digest 0.10.7",
+ "either",
+ "etcetera",
+ "futures",
+ "globset",
+ "hashbrown 0.17.1",
+ "indexmap",
+ "itertools 0.15.0",
+ "jj-core-proc-macros",
+ "ref-cast",
+ "regex",
+ "same-file",
+ "serde",
+ "smallvec",
+ "tempfile",
+ "thiserror 2.0.20",
+ "tracing",
+ "winreg 0.56.0",
+]
+
+[[package]]
+name = "jj-core-proc-macros"
+version = "0.44.0"
+source = "git+https://github.com/0WD0/jj.git?rev=d967d70207834d9400e483edd02b6f1f49924330#d967d70207834d9400e483edd02b6f1f49924330"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
+]
+
+[[package]]
 name = "jj-lib"
 version = "0.44.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d58fe15e3acbc89de606b7a10b284498ed908d09f3b7bdf560ca6f92e3a8d63"
+source = "git+https://github.com/0WD0/jj.git?rev=d967d70207834d9400e483edd02b6f1f49924330#d967d70207834d9400e483edd02b6f1f49924330"
 dependencies = [
  "async-trait",
  "blake2",
@@ -4508,11 +4530,10 @@ dependencies = [
  "gix",
  "gix-ignore",
  "globset",
- "hashbrown 0.17.1",
  "indexmap",
  "interim",
  "itertools 0.15.0",
- "jj-lib-proc-macros",
+ "jj-core",
  "maplit",
  "memchr",
  "once_cell",
@@ -4526,7 +4547,6 @@ dependencies = [
  "ref-cast",
  "regex",
  "rustix 1.1.4",
- "same-file",
  "serde",
  "smallvec",
  "strsim",
@@ -4534,18 +4554,6 @@ dependencies = [
  "thiserror 2.0.20",
  "toml_edit",
  "tracing",
- "winreg 0.56.0",
-]
-
-[[package]]
-name = "jj-lib-proc-macros"
-version = "0.44.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d68a9ec87af36ba808fa818f5f1f041cce01df9eb0e21690e854fe612640060e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 3.0.4",
 ]
 
 [[package]]
@@ -4612,15 +4620,6 @@ checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
 dependencies = [
  "bitflags 2.13.1",
  "libc",
-]
-
-[[package]]
-name = "kstring"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "558bf9508a558512042d3095138b1f7b8fe90c5467d94f9f1da28b3731c5dbd1"
-dependencies = [
- "static_assertions",
 ]
 
 [[package]]
@@ -4866,17 +4865,6 @@ dependencies = [
  "log",
  "tendril",
  "web_atoms",
-]
-
-[[package]]
-name = "maybe-async"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "746873a384ad60adc5db74471dfaba74bd278afbdcfd81db93fafcdfc8b5ca0c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
 ]
 
 [[package]]
@@ -6309,6 +6297,7 @@ name = "pi-vcs"
 version = "18.0.11"
 dependencies = [
  "gix",
+ "gix-zlib",
  "jj-lib",
  "libc",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -368,10 +368,9 @@ brush-parser = "0.3"
 # ──────────────────────────────────────────────────────────────────────────────
 # Version Control (in-process git + jujutsu)
 # ──────────────────────────────────────────────────────────────────────────────
-# gix is pinned to the minor jj-lib depends on so both VCS backends share one
-# gitoxide stack in the binary. No transport/credential features: network ops
-# (clone/fetch/push) deliberately shell out to the git CLI for auth parity.
-gix = { version = "0.85", default-features = false, features = [
+# Forks expose structured, range-aware materialized-conflict APIs that are not
+# yet available in the upstream releases.
+gix = { git = "https://github.com/0WD0/gitoxide.git", rev = "d26d3b019fecc96100e4232cf0d8c22a8ce5101d", default-features = false, features = [
    "attributes",
    "blob-diff",
    "dirwalk",
@@ -383,11 +382,10 @@ gix = { version = "0.85", default-features = false, features = [
    "sha1",
    "sha256",
    "status",
-   "tree-editor",
    "worktree-mutation",
-   "zlib-rs",
 ] }
-jj-lib = { version = "0.44", default-features = false, features = ["git"] }
+gix-zlib = { git = "https://github.com/0WD0/gitoxide.git", rev = "d26d3b019fecc96100e4232cf0d8c22a8ce5101d" }
+jj-lib = { git = "https://github.com/0WD0/jj.git", rev = "d967d70207834d9400e483edd02b6f1f49924330", default-features = false, features = ["git"] }
 
 # ──────────────────────────────────────────────────────────────────────────────
 # AST & Tree-Sitter

--- a/crates/pi-natives/src/vcs.rs
+++ b/crates/pi-natives/src/vcs.rs
@@ -97,6 +97,40 @@ pub struct VcsStatusSummary {
 	pub unstaged:  u32,
 	pub untracked: u32,
 }
+/// Broad kind of a repository-recorded conflict.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[napi(string_enum)]
+pub enum VcsConflictKind {
+	#[napi(value = "file")]
+	File,
+	#[napi(value = "other")]
+	Other,
+}
+/// One positive side or negative base term.
+#[napi(object)]
+pub struct VcsConflictTerm {
+	pub label:   Option<String>,
+	pub content: String,
+}
+/// One backend-validated materialized conflict block.
+#[napi(object)]
+pub struct VcsConflictRegion {
+	pub start_line:     u32,
+	pub separator_line: u32,
+	pub end_line:       u32,
+	pub base_line:      Option<u32>,
+	pub style:          String,
+	pub marker_length:  u32,
+	pub sides:          Vec<VcsConflictTerm>,
+	pub bases:          Vec<VcsConflictTerm>,
+}
+/// Metadata for one repository-recorded conflict.
+#[napi(object)]
+pub struct VcsConflictInfo {
+	pub path:    String,
+	pub kind:    VcsConflictKind,
+	pub regions: Vec<VcsConflictRegion>,
+}
 /// Resolved HEAD state.
 #[napi(object)]
 pub struct VcsHeadState {
@@ -296,6 +330,49 @@ impl From<core::NumstatEntry> for VcsNumstatEntry {
 	fn from(v: core::NumstatEntry) -> Self {
 		Self { path: v.path, added: v.added, removed: v.removed }
 	}
+}
+impl From<core::ConflictRegion> for VcsConflictRegion {
+	fn from(region: core::ConflictRegion) -> Self {
+		let style = match region.style {
+			core::MaterializedConflictStyle::Git => "git",
+			core::MaterializedConflictStyle::JjDiff => "jj-diff",
+			core::MaterializedConflictStyle::JjSnapshot => "jj-snapshot",
+		}
+		.to_owned();
+		let convert_term =
+			|term: core::ConflictTerm| VcsConflictTerm { label: term.label, content: term.content };
+		Self {
+			start_line: region.start_line,
+			separator_line: region.separator_line,
+			end_line: region.end_line,
+			base_line: region.base_line,
+			style,
+			marker_length: region.marker_length,
+			sides: region.sides.into_iter().map(convert_term).collect(),
+			bases: region.bases.into_iter().map(convert_term).collect(),
+		}
+	}
+}
+impl From<core::ConflictInfo> for VcsConflictInfo {
+	fn from(v: core::ConflictInfo) -> Self {
+		let kind = match v.kind {
+			core::ConflictKind::File => VcsConflictKind::File,
+			core::ConflictKind::Other => VcsConflictKind::Other,
+		};
+		Self { path: v.path, kind, regions: v.regions.into_iter().map(Into::into).collect() }
+	}
+}
+/// Parse standalone Git or Jujutsu marker content without repository authority.
+#[napi]
+pub fn parse_conflict_markers(
+	content: Buffer,
+	minimum_marker_length: Option<u32>,
+) -> Vec<VcsConflictRegion> {
+	let minimum = minimum_marker_length.unwrap_or(7).max(1) as usize;
+	pi_vcs::parse_conflict_regions(content.as_ref(), minimum)
+		.into_iter()
+		.map(Into::into)
+		.collect()
 }
 impl From<core::ShowResult> for VcsShowResult {
 	fn from(v: core::ShowResult) -> Self {
@@ -538,6 +615,20 @@ impl VcsRepo {
 	pub fn status_summary(&self, signal: Option<Unknown>) -> Promise<VcsStatusSummary> {
 		repo_blocking("vcs.statusSummary", self.inner.clone(), signal, |repo| {
 			repo.status_summary().map(Into::into)
+		})
+	}
+
+	/// Repository-recorded conflicts in the working copy.
+	#[napi]
+	pub fn conflicted_paths(
+		&self,
+		files: Vec<String>,
+		signal: Option<Unknown>,
+	) -> Promise<Vec<VcsConflictInfo>> {
+		repo_blocking("vcs.conflictedPaths", self.inner.clone(), signal, move |repo| {
+			repo
+				.conflicted_paths(&files)
+				.map(|paths| paths.into_iter().map(Into::into).collect())
 		})
 	}
 
@@ -1413,6 +1504,19 @@ impl VcsJjWorkspace {
 	pub fn status_summary(&self, signal: Option<Unknown>) -> Promise<VcsStatusSummary> {
 		jj_blocking("vcs.jjStatusSummary", self.inner.clone(), signal, |w| {
 			w.status_summary().map(Into::into)
+		})
+	}
+
+	/// Repository-recorded conflicts in the working-copy commit.
+	#[napi]
+	pub fn conflicted_paths(
+		&self,
+		files: Vec<String>,
+		signal: Option<Unknown>,
+	) -> Promise<Vec<VcsConflictInfo>> {
+		jj_blocking("vcs.jjConflictedPaths", self.inner.clone(), signal, move |w| {
+			w.conflicted_paths(&files)
+				.map(|paths| paths.into_iter().map(Into::into).collect())
 		})
 	}
 

--- a/crates/pi-vcs/Cargo.toml
+++ b/crates/pi-vcs/Cargo.toml
@@ -11,6 +11,7 @@ workspace = true
 
 [dependencies]
 gix.workspace = true
+gix-zlib.workspace = true
 jj-lib.workspace = true
 thiserror.workspace = true
 tokio.workspace = true

--- a/crates/pi-vcs/src/conflict.rs
+++ b/crates/pi-vcs/src/conflict.rs
@@ -1,0 +1,150 @@
+//! Adapters from fork-provided materialized-conflict APIs to VCS metadata.
+
+use gix::bstr::ByteSlice as _;
+use jj_lib::conflicts::{
+	ParsedConflictHunk, ParsedConflictStyle, parse_conflict_any_arity_with_ranges,
+	parse_conflict_with_ranges,
+};
+
+use crate::types::{ConflictRegion, ConflictTerm, MaterializedConflictStyle};
+
+fn line_number(input: &[u8], offset: usize) -> u32 {
+	input[..offset.min(input.len())].find_iter(b"\n").count() as u32 + 1
+}
+
+fn last_line_number(input: &[u8], end: usize) -> u32 {
+	line_number(input, end.saturating_sub(1))
+}
+
+fn term(label: Option<&gix::bstr::BStr>, content: &[u8]) -> ConflictTerm {
+	ConflictTerm {
+		label:   label.map(|label| label.to_str_lossy().into_owned()),
+		content: String::from_utf8_lossy(content).into_owned(),
+	}
+}
+
+fn git_region(
+	input: &[u8],
+	conflict: gix::merge::blob::builtin_driver::text::parse::Conflict<'_>,
+) -> ConflictRegion {
+	let other_offset = conflict.other.content.as_ptr() as usize - input.as_ptr() as usize;
+	let ancestor_offset = conflict
+		.ancestor
+		.as_ref()
+		.map(|ancestor| ancestor.content.as_ptr() as usize - input.as_ptr() as usize);
+	ConflictRegion {
+		start_line:     line_number(input, conflict.source.start),
+		separator_line: line_number(input, other_offset).saturating_sub(1),
+		end_line:       last_line_number(input, conflict.source.end),
+		base_line:      ancestor_offset.map(|offset| line_number(input, offset).saturating_sub(1)),
+		style:          MaterializedConflictStyle::Git,
+		marker_length:  conflict.marker_size as u32,
+		sides:          vec![
+			term(conflict.current.label, conflict.current.content),
+			term(conflict.other.label, conflict.other.content),
+		],
+		bases:          conflict
+			.ancestor
+			.into_iter()
+			.map(|ancestor| term(ancestor.label, ancestor.content))
+			.collect(),
+	}
+}
+
+/// Parse strict Git merge/diff3 materialization through gitoxide.
+pub(crate) fn git_regions(input: &[u8]) -> Vec<ConflictRegion> {
+	gix::merge::blob::builtin_driver::text::parse::conflicts(input, 1)
+		.into_iter()
+		.map(|conflict| git_region(input, conflict))
+		.collect()
+}
+
+fn jj_region(input: &[u8], hunk: ParsedConflictHunk) -> Option<ConflictRegion> {
+	let style = match hunk.style? {
+		ParsedConflictStyle::Git => MaterializedConflictStyle::Git,
+		ParsedConflictStyle::JjDiff => MaterializedConflictStyle::JjDiff,
+		ParsedConflictStyle::JjSnapshot => MaterializedConflictStyle::JjSnapshot,
+	};
+	let marker_length = hunk.marker_len? as u32;
+	let labels = hunk.labels?;
+	let start_line = line_number(input, hunk.source.start);
+	let end_line = last_line_number(input, hunk.source.end);
+	let sides = hunk
+		.value
+		.adds()
+		.enumerate()
+		.map(|(index, content)| {
+			let label = labels
+				.adds
+				.get(index)
+				.and_then(Option::as_ref)
+				.map(|label| label.as_bstr());
+			term(label, content.as_ref())
+		})
+		.collect();
+	let bases = hunk
+		.value
+		.removes()
+		.enumerate()
+		.map(|(index, content)| {
+			let label = labels
+				.removes
+				.get(index)
+				.and_then(Option::as_ref)
+				.map(|label| label.as_bstr());
+			term(label, content.as_ref())
+		})
+		.collect();
+	Some(ConflictRegion {
+		start_line,
+		separator_line: (start_line + 1).min(end_line),
+		end_line,
+		base_line: None,
+		style,
+		marker_length,
+		sides,
+		bases,
+	})
+}
+
+/// Parse Jujutsu materialization with jj-lib's repository-provided arity and
+/// marker length.
+pub(crate) fn jj_regions(
+	input: &[u8],
+	num_sides: usize,
+	expected_marker_length: usize,
+) -> Vec<ConflictRegion> {
+	parse_conflict_with_ranges(input, num_sides, expected_marker_length)
+		.into_iter()
+		.flatten()
+		.filter_map(|hunk| jj_region(input, hunk))
+		.collect()
+}
+
+/// Parse standalone marker files without repository authority. Git grammar is
+/// decoded by gitoxide and Jujutsu grammar by jj-lib; exact source ranges avoid
+/// downstream marker rescanning.
+pub fn standalone_regions(input: &[u8], minimum_marker_length: usize) -> Vec<ConflictRegion> {
+	let mut git =
+		gix::merge::blob::builtin_driver::text::parse::conflicts(input, minimum_marker_length)
+			.into_iter()
+			.map(|conflict| git_region(input, conflict))
+			.collect::<Vec<_>>();
+	let git_ranges = git
+		.iter()
+		.map(|region| (region.start_line, region.end_line))
+		.collect::<Vec<_>>();
+	git.extend(
+		parse_conflict_any_arity_with_ranges(input, minimum_marker_length)
+			.into_iter()
+			.flatten()
+			.filter_map(|hunk| jj_region(input, hunk))
+			.filter(|region| {
+				!git_ranges
+					.iter()
+					.any(|(start, end)| region.start_line <= *end && *start <= region.end_line)
+			}),
+	);
+	git.sort_by_key(|region| region.start_line);
+	git
+}

--- a/crates/pi-vcs/src/git/diff.rs
+++ b/crates/pi-vcs/src/git/diff.rs
@@ -1034,7 +1034,8 @@ const BASE85: &[u8; 85] =
 	b"0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+-;<=>?@^_`{|}~";
 
 fn zlib_compress(data: &[u8]) -> Result<Vec<u8>> {
-	let mut writer = gix::features::zlib::stream::deflate::Write::new(Vec::new());
+	let mut writer =
+		gix_zlib::stream::deflate::Write::new(Vec::new(), gix_zlib::Compression::default());
 	writer
 		.write_all(data)
 		.and_then(|()| writer.flush())

--- a/crates/pi-vcs/src/git/open.rs
+++ b/crates/pi-vcs/src/git/open.rs
@@ -151,6 +151,7 @@ fn open_options() -> Options {
 				objects:         Permission::Deny,
 				git_prefix:      Permission::Deny,
 				ssh_prefix:      Permission::Deny,
+				other:           Permission::Allow,
 			},
 			config:     permissions::Config::all(),
 			attributes: permissions::Attributes::all(),

--- a/crates/pi-vcs/src/git/patch.rs
+++ b/crates/pi-vcs/src/git/patch.rs
@@ -913,11 +913,11 @@ fn decode_binary_block(
 	}
 	let inflate_size = block.size;
 	let mut inflated = vec![0; inflate_size];
-	let mut decoder = gix::features::zlib::Inflate::default();
+	let mut decoder = gix_zlib::Inflate::default();
 	let (status, consumed, written) = decoder
 		.once(&compressed, &mut inflated)
 		.map_err(|err| ApplyFailure::Invalid(format!("invalid zlib stream: {err}")))?;
-	if status != gix::features::zlib::Status::StreamEnd || consumed != compressed.len() {
+	if status != gix_zlib::Status::StreamEnd || consumed != compressed.len() {
 		return Err(ApplyFailure::Invalid("incomplete zlib stream".into()));
 	}
 	inflated.truncate(written);

--- a/crates/pi-vcs/src/git/read.rs
+++ b/crates/pi-vcs/src/git/read.rs
@@ -14,8 +14,8 @@ use super::{
 use crate::{
 	error::{Error, Result},
 	types::{
-		CommitAuthor, CommitDetails, HeadState, ShowResult, StatusOptions, StatusSummary,
-		UntrackedMode, WorktreeEntry,
+		CommitAuthor, CommitDetails, ConflictInfo, ConflictKind, HeadState, ShowResult,
+		StatusOptions, StatusSummary, UntrackedMode, WorktreeEntry,
 	},
 };
 
@@ -118,6 +118,8 @@ impl GitRepo {
 			return Ok(Vec::new());
 		};
 		let repo = self.gix()?;
+		let target_id = gix::ObjectId::from_hex(target.as_bytes())
+			.map_err(|err| Error::backend("git tags", err))?;
 		let refs = repo
 			.references()
 			.map_err(|err| Error::backend("git tags", err))?;
@@ -128,7 +130,7 @@ impl GitRepo {
 			let id = reference
 				.peel_to_id()
 				.map_err(|err| Error::backend("git tags", err))?;
-			if id.to_string() == target
+			if id.detach() == target_id
 				&& let Some(name) = reference
 					.name()
 					.as_bstr()
@@ -383,6 +385,77 @@ impl GitRepo {
 			}
 		}
 		Ok(summary)
+	}
+
+	/// List paths with unresolved index entries.
+	pub fn conflicted_paths(&self, files: &[String]) -> Result<Vec<ConflictInfo>> {
+		let mut paths = BTreeMap::new();
+		let configured_marker_lengths = if self.is_reftable() {
+			let args = ["ls-files".to_owned(), "--unmerged".to_owned(), "-z".to_owned()];
+			for record in cli_text_owned(self.root(), &args)?.split('\0') {
+				let Some((metadata, path)) = record.split_once('\t') else {
+					continue;
+				};
+				if !files.is_empty() && !files.iter().any(|wanted| path_matches(path, wanted)) {
+					continue;
+				}
+				let Some(mode) = metadata.split_ascii_whitespace().next() else {
+					continue;
+				};
+				let kind = match mode {
+					"100644" | "100755" => ConflictKind::File,
+					_ => ConflictKind::Other,
+				};
+				insert_conflict_path(&mut paths, path.to_owned(), kind);
+			}
+			cli_conflict_marker_lengths(self.root(), &paths)?
+		} else {
+			let repo = self.gix()?;
+			let index = load_index_or_empty(&repo, "git conflicts")?;
+			for entry in index
+				.entries()
+				.iter()
+				.filter(|entry| entry.stage() != gix::index::entry::Stage::Unconflicted)
+			{
+				let path = bytes_to_path(entry.path(&index));
+				if !files.is_empty() && !files.iter().any(|wanted| path_matches(&path, wanted)) {
+					continue;
+				}
+				let kind = if entry.mode == gix::index::entry::Mode::FILE
+					|| entry.mode == gix::index::entry::Mode::FILE_EXECUTABLE
+				{
+					ConflictKind::File
+				} else {
+					ConflictKind::Other
+				};
+				insert_conflict_path(&mut paths, path, kind);
+			}
+			gix_conflict_marker_lengths(&repo, &index, &paths)?
+		};
+		Ok(paths
+			.into_iter()
+			.map(|(path, kind)| {
+				let disk_path = self.root().join(&path);
+				let regions = if kind == ConflictKind::File
+					&& disk_path
+						.symlink_metadata()
+						.is_ok_and(|metadata| metadata.file_type().is_file())
+				{
+					std::fs::read(disk_path).map_or_else(
+						|_| Vec::new(),
+						|content| {
+							select_git_regions(
+								crate::conflict::git_regions(&content),
+								configured_marker_lengths.get(&path).copied(),
+							)
+						},
+					)
+				} else {
+					Vec::new()
+				};
+				ConflictInfo { path, kind, regions }
+			})
+			.collect())
 	}
 
 	/// Read a scalar git config value.
@@ -1144,9 +1217,118 @@ fn parse_commit_details(raw: &str) -> CommitDetails {
 		.to_owned();
 	CommitDetails { sha, parents, author: CommitAuthor { name, email, date }, message }
 }
+
+const DEFAULT_CONFLICT_MARKER_LENGTH: u32 = 7;
+
+fn parse_conflict_marker_length(value: Option<&str>) -> u32 {
+	value
+		.and_then(|value| value.parse::<i32>().ok())
+		.filter(|value| *value > 0)
+		.map_or(DEFAULT_CONFLICT_MARKER_LENGTH, |value| value as u32)
+}
+
+fn select_git_regions(
+	mut regions: Vec<crate::types::ConflictRegion>,
+	configured_marker_length: Option<u32>,
+) -> Vec<crate::types::ConflictRegion> {
+	let lengths = regions
+		.iter()
+		.map(|region| region.marker_length)
+		.collect::<BTreeSet<_>>();
+	if let Some(configured) = configured_marker_length.filter(|length| lengths.contains(length)) {
+		regions.retain(|region| region.marker_length == configured);
+		return regions;
+	}
+	if lengths.len() == 1 {
+		regions
+	} else {
+		Vec::new()
+	}
+}
+
+fn gix_conflict_marker_lengths(
+	repo: &gix::Repository,
+	index: &gix::index::State,
+	paths: &BTreeMap<String, ConflictKind>,
+) -> Result<BTreeMap<String, u32>> {
+	let mut attributes = repo
+		.attributes_only(
+			index,
+			gix::worktree::stack::state::attributes::Source::WorktreeThenIdMapping,
+		)
+		.map_err(|err| Error::backend("git conflict marker attributes", err))?;
+	let mut matches = attributes.selected_attribute_matches(["conflict-marker-size"]);
+	let mut lengths = BTreeMap::new();
+	for (path, kind) in paths {
+		if *kind != ConflictKind::File {
+			continue;
+		}
+		attributes
+			.at_entry(path.as_str(), None)?
+			.matching_attributes(&mut matches);
+		let marker_length =
+			matches
+				.iter_selected()
+				.next()
+				.map_or(DEFAULT_CONFLICT_MARKER_LENGTH, |matched| {
+					let value = matched
+						.assignment
+						.state
+						.as_bstr()
+						.and_then(|value| value.to_str().ok());
+					parse_conflict_marker_length(value)
+				});
+		lengths.insert(path.clone(), marker_length);
+	}
+	Ok(lengths)
+}
+
+fn cli_conflict_marker_lengths(
+	root: &Path,
+	paths: &BTreeMap<String, ConflictKind>,
+) -> Result<BTreeMap<String, u32>> {
+	let file_paths = paths
+		.iter()
+		.filter_map(|(path, kind)| (*kind == ConflictKind::File).then_some(path));
+	let mut args = vec![
+		"check-attr".to_owned(),
+		"-z".to_owned(),
+		"conflict-marker-size".to_owned(),
+		"--".to_owned(),
+	];
+	args.extend(file_paths.cloned());
+	if args.len() == 4 {
+		return Ok(BTreeMap::new());
+	}
+	let output = cli_text_owned(root, &args)?;
+	let mut lengths = BTreeMap::new();
+	let mut fields = output.split('\0');
+	while let (Some(path), Some(_attribute), Some(value)) =
+		(fields.next(), fields.next(), fields.next())
+	{
+		lengths.insert(path.to_owned(), parse_conflict_marker_length(Some(value)));
+	}
+	Ok(lengths)
+}
+
+fn insert_conflict_path(
+	paths: &mut BTreeMap<String, ConflictKind>,
+	path: String,
+	kind: ConflictKind,
+) {
+	paths
+		.entry(path)
+		.and_modify(|current| {
+			if kind == ConflictKind::Other {
+				*current = ConflictKind::Other;
+			}
+		})
+		.or_insert(kind);
+}
 fn path_matches(path: &str, wanted: &str) -> bool {
 	let wanted = wanted.trim_end_matches('/');
-	path == wanted
+	wanted.is_empty()
+		|| path == wanted
 		|| path
 			.strip_prefix(wanted)
 			.is_some_and(|rest| rest.starts_with('/'))
@@ -1373,7 +1555,6 @@ mod tests {
 		git(dir.path(), &["update-ref", "refs/remotes/origin/main", "HEAD"])?;
 		git(dir.path(), &["symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main"])?;
 		assert_eq!(repo.default_branch()?, Some("main".to_owned()));
-
 		let linked = dir.path().join("linked");
 		let linked_text = linked.to_string_lossy().into_owned();
 		git(dir.path(), &["worktree", "add", "-b", "linked-branch", &linked_text])?;
@@ -1382,6 +1563,168 @@ mod tests {
 		assert_eq!(worktrees[0].path, dir.path());
 		assert_eq!(worktrees[1].path, linked.canonicalize()?);
 		assert_eq!(worktrees[1].branch.as_deref(), Some("refs/heads/linked-branch"));
+		Ok(())
+	}
+
+	#[test]
+	fn conflicted_paths_come_from_unmerged_index_entries() -> TestResult {
+		let (dir, repo) = repo()?;
+		commit(dir.path(), "file.txt", "base\n", "base")?;
+		git(dir.path(), &["checkout", "-b", "left"])?;
+		commit(dir.path(), "file.txt", "left\n", "left")?;
+		git(dir.path(), &["checkout", "main"])?;
+		commit(dir.path(), "file.txt", "right\n", "right")?;
+		let merge = Command::new("git")
+			.current_dir(dir.path())
+			.args(["merge", "left"])
+			.output()?;
+		assert!(!merge.status.success());
+
+		let conflicts = repo.conflicted_paths(&[])?;
+		assert_eq!(conflicts.len(), 1);
+		assert_eq!(conflicts[0].path, "file.txt");
+		assert_eq!(conflicts[0].kind, ConflictKind::File);
+		assert_eq!(conflicts[0].regions.len(), 1);
+		let region = &conflicts[0].regions[0];
+		assert_eq!((region.start_line, region.separator_line, region.end_line), (1, 5, 7));
+		assert_eq!(region.marker_length, 7);
+		assert_eq!(region.sides.len(), 2);
+		assert_eq!(region.bases.len(), 1);
+		assert_eq!(repo.conflicted_paths(&["/".to_owned()])?, conflicts);
+		assert!(repo.conflicted_paths(&["other.txt".to_owned()])?.is_empty());
+		Ok(())
+	}
+
+	#[test]
+	fn conflicted_paths_preserve_materialized_marker_length_after_attribute_change() -> TestResult {
+		let (dir, repo) = repo()?;
+		fs::write(dir.path().join(".gitattributes"), "file.txt conflict-marker-size=3\n")?;
+		commit(dir.path(), "file.txt", "base\n", "base")?;
+		git(dir.path(), &["checkout", "-b", "left"])?;
+		commit(dir.path(), "file.txt", "left\n", "left")?;
+		git(dir.path(), &["checkout", "main"])?;
+		commit(dir.path(), "file.txt", "right\n", "right")?;
+		let merge = Command::new("git")
+			.current_dir(dir.path())
+			.args(["merge", "left"])
+			.output()?;
+		assert!(!merge.status.success());
+		fs::write(dir.path().join(".gitattributes"), "file.txt conflict-marker-size=9\n")?;
+
+		let conflicts = repo.conflicted_paths(&["file.txt".to_owned()])?;
+		assert_eq!(conflicts.len(), 1);
+		assert_eq!(conflicts[0].regions.len(), 1);
+		assert_eq!(conflicts[0].regions[0].marker_length, 3);
+		Ok(())
+	}
+
+	#[test]
+	fn reftable_conflict_filters_treat_paths_literally() -> TestResult {
+		let dir = tempfile::tempdir()?;
+		let init = Command::new("git")
+			.current_dir(dir.path())
+			.args(["init", "--ref-format=reftable", "--initial-branch=main"])
+			.output()?;
+		if !init.status.success() {
+			return Ok(());
+		}
+		git(dir.path(), &["config", "user.name", "Test User"])?;
+		git(dir.path(), &["config", "user.email", "test@example.com"])?;
+		fs::write(dir.path().join("[x].txt"), "base\n")?;
+		git(dir.path(), &["add", "--all"])?;
+		git(dir.path(), &["commit", "-m", "base"])?;
+		git(dir.path(), &["checkout", "-b", "left"])?;
+		fs::write(dir.path().join("[x].txt"), "left\n")?;
+		git(dir.path(), &["commit", "-am", "left"])?;
+		git(dir.path(), &["checkout", "main"])?;
+		fs::write(dir.path().join("[x].txt"), "right\n")?;
+		git(dir.path(), &["commit", "-am", "right"])?;
+		let merge = Command::new("git")
+			.current_dir(dir.path())
+			.args(["merge", "left"])
+			.output()?;
+		assert!(!merge.status.success());
+
+		let repo = GitRepo::require(dir.path())?;
+		assert!(repo.is_reftable());
+		let conflicts = repo.conflicted_paths(&["[x].txt".to_owned()])?;
+		assert_eq!(conflicts.len(), 1);
+		assert_eq!(conflicts[0].path, "[x].txt");
+		assert_eq!(conflicts[0].kind, ConflictKind::File);
+		assert_eq!(conflicts[0].regions.len(), 1);
+		let region = &conflicts[0].regions[0];
+		assert_eq!((region.start_line, region.separator_line, region.end_line), (1, 5, 7));
+		assert_eq!(region.marker_length, 7);
+		assert_eq!(region.sides.len(), 2);
+		assert_eq!(region.bases.len(), 1);
+		assert!(repo.conflicted_paths(&["x.txt".to_owned()])?.is_empty());
+		Ok(())
+	}
+
+	#[cfg(unix)]
+	#[test]
+	fn conflicted_symlinks_are_non_file_conflicts() -> TestResult {
+		use std::os::unix::fs::symlink;
+
+		let (dir, repo) = repo()?;
+		symlink("base", dir.path().join("link"))?;
+		git(dir.path(), &["add", "link"])?;
+		git(dir.path(), &["commit", "-m", "base"])?;
+		git(dir.path(), &["checkout", "-b", "left"])?;
+		fs::remove_file(dir.path().join("link"))?;
+		symlink("left", dir.path().join("link"))?;
+		git(dir.path(), &["commit", "-am", "left"])?;
+		git(dir.path(), &["checkout", "main"])?;
+		fs::remove_file(dir.path().join("link"))?;
+		symlink("right", dir.path().join("link"))?;
+		git(dir.path(), &["commit", "-am", "right"])?;
+		let merge = Command::new("git")
+			.current_dir(dir.path())
+			.args(["merge", "left"])
+			.output()?;
+		assert!(!merge.status.success());
+
+		assert_eq!(repo.conflicted_paths(&[])?, vec![ConflictInfo {
+			path:    "link".to_owned(),
+			kind:    ConflictKind::Other,
+			regions: Vec::new(),
+		}]);
+		Ok(())
+	}
+
+	#[cfg(unix)]
+	#[test]
+	fn mixed_file_and_symlink_terms_are_non_file_conflicts() -> TestResult {
+		use std::os::unix::fs::symlink;
+
+		let (dir, repo) = repo()?;
+		git(dir.path(), &["commit", "--allow-empty", "-m", "base"])?;
+		git(dir.path(), &["checkout", "-b", "left"])?;
+		fs::write(dir.path().join("node"), "left\n")?;
+		git(dir.path(), &["add", "node"])?;
+		git(dir.path(), &["commit", "-m", "left"])?;
+		git(dir.path(), &["checkout", "main"])?;
+		symlink("right", dir.path().join("node"))?;
+		git(dir.path(), &["add", "node"])?;
+		git(dir.path(), &["commit", "-m", "right"])?;
+		let merge = Command::new("git")
+			.current_dir(dir.path())
+			.args(["merge", "left"])
+			.output()?;
+		assert!(!merge.status.success());
+
+		assert_eq!(repo.conflicted_paths(&[])?, vec![
+			ConflictInfo {
+				path:    "node".to_owned(),
+				kind:    ConflictKind::Other,
+				regions: Vec::new(),
+			},
+			ConflictInfo {
+				path:    "node~left".to_owned(),
+				kind:    ConflictKind::File,
+				regions: Vec::new(),
+			},
+		]);
 		Ok(())
 	}
 }

--- a/crates/pi-vcs/src/jj/ops.rs
+++ b/crates/pi-vcs/src/jj/ops.rs
@@ -10,18 +10,22 @@ use std::{
 };
 
 use jj_lib::{
-	backend::{CommitId, CopyId, TreeValue},
+	backend::{CommitId, MergedTreeValue, MergedTreeValueExt as _},
 	commit::Commit,
 	config::{ConfigSource, StackedConfig},
-	conflicts::{ConflictMarkerStyle, ConflictMaterializeOptions, materialize_tree_value},
+	conflicts::{
+		ConflictMarkerStyle, ConflictMaterializeOptions, MIN_CONFLICT_MARKER_LEN,
+		materialize_tree_value,
+	},
 	default_backend_factories::{default_backend_factories, default_working_copy_factories},
 	diff_presentation::{
 		LineCompareMode,
 		unified::{DiffLineType, GitDiffPart, git_diff_part, unified_diff_hunks},
 	},
 	gitignore::GitIgnoreFile,
+	local_working_copy::LocalWorkingCopy,
 	matchers::{EverythingMatcher, NothingMatcher},
-	merge::{Diff, MergedTreeValue},
+	merge::Diff,
 	merged_tree::MergedTree,
 	object_id::{HexPrefix, ObjectId as _, PrefixResolution},
 	repo::{ReadonlyRepo, Repo},
@@ -34,7 +38,10 @@ use jj_lib::{
 use super::JjWorkspace;
 use crate::{
 	error::{Error, Result},
-	types::{CommitAuthor, CommitDetails, NumstatEntry, StatusOptions, StatusSummary},
+	types::{
+		CommitAuthor, CommitDetails, ConflictInfo, ConflictKind, NumstatEntry, StatusOptions,
+		StatusSummary,
+	},
 };
 
 const DIFF_CONTEXT: usize = 3;
@@ -101,6 +108,7 @@ impl JjWorkspace {
 
 				let prefix_len = repo
 					.shortest_unique_change_id_prefix_len(wc_commit.change_id())
+					.await
 					.map_err(|err| Error::backend("jj log", err))?
 					.max(8);
 				let change_id = wc_commit.change_id().reverse_hex();
@@ -141,6 +149,68 @@ impl JjWorkspace {
 					}
 				}
 				Ok(summary)
+			})
+		})
+	}
+
+	/// List paths whose working-copy commit records unresolved tree values.
+	pub fn conflicted_paths(&self, files: &[String]) -> Result<Vec<ConflictInfo>> {
+		let files = files.to_vec();
+		self.with_current_repo("jj conflicts", move |workspace, repo| {
+			Box::pin(async move {
+				let Some(wc_id) = repo.view().get_wc_commit_id(workspace.workspace_name()) else {
+					return Ok(Vec::new());
+				};
+				let commit = repo
+					.store()
+					.get_commit_async(wc_id)
+					.await
+					.map_err(|err| Error::backend("jj conflicts", err))?;
+				let file_states = workspace
+					.working_copy()
+					.downcast_ref::<LocalWorkingCopy>()
+					.map(LocalWorkingCopy::file_states)
+					.transpose()
+					.map_err(|err| Error::backend("jj conflicts", err))?;
+				let mut conflicts = Vec::new();
+				for (path, value) in commit.tree().conflicts() {
+					if !files.is_empty()
+						&& !files.iter().any(|wanted| {
+							matches_path(path.as_internal_file_string(), wanted.trim_matches('/'))
+						}) {
+						continue;
+					}
+					let value = value.map_err(|err| Error::backend("jj conflicts", err))?;
+					let file_merge = value.to_file_merge();
+					let kind = if file_merge.is_some() {
+						ConflictKind::File
+					} else {
+						ConflictKind::Other
+					};
+					let marker_length = file_states
+						.as_ref()
+						.and_then(|states| states.get(&path))
+						.and_then(|state| state.materialized_conflict_data)
+						.map_or(MIN_CONFLICT_MARKER_LEN as u32, |data| data.conflict_marker_len);
+					let regions = if let Some(file_merge) = file_merge {
+						let disk_path = path.to_fs_path_unchecked(workspace.workspace_root());
+						let content = tokio::fs::read(disk_path).await.unwrap_or_default();
+						crate::conflict::jj_regions(
+							&content,
+							file_merge.num_sides(),
+							marker_length as usize,
+						)
+					} else {
+						Vec::new()
+					};
+					conflicts.push(ConflictInfo {
+						path: path.as_internal_file_string().to_owned(),
+						kind,
+						regions,
+					});
+				}
+				conflicts.sort_by(|left, right| left.path.cmp(&right.path));
+				Ok(conflicts)
 			})
 		})
 	}
@@ -234,6 +304,7 @@ impl JjWorkspace {
 				for commit in commits {
 					let prefix_len = repo
 						.shortest_unique_change_id_prefix_len(commit.change_id())
+						.await
 						.map_err(|err| Error::backend("jj log", err))?
 						.max(8);
 					let change_id = commit.change_id().reverse_hex();
@@ -250,7 +321,8 @@ impl JjWorkspace {
 		let rev = rev.to_owned();
 		self.with_current_repo("jj show", move |workspace, repo| {
 			Box::pin(async move {
-				let commit_id = resolve_commit_id(workspace, repo.as_ref(), &rev)?
+				let commit_id = resolve_commit_id(workspace, repo.as_ref(), &rev)
+					.await?
 					.ok_or_else(|| Error::ObjectNotFound { spec: rev.clone() })?;
 				let commit = repo
 					.store()
@@ -413,7 +485,11 @@ fn commit_subject(commit: &Commit) -> String {
 		.to_owned()
 }
 
-fn resolve_commit_id(
+#[allow(
+	clippy::future_not_send,
+	reason = "jj-lib index futures are local to the blocking workspace task"
+)]
+async fn resolve_commit_id(
 	workspace: &Workspace,
 	repo: &dyn Repo,
 	rev: &str,
@@ -427,6 +503,7 @@ fn resolve_commit_id(
 	if let Some(prefix) = HexPrefix::try_from_reverse_hex(rev) {
 		let resolution = repo
 			.resolve_change_id_prefix(&prefix)
+			.await
 			.map_err(|err| Error::backend("jj show", err))?;
 		if let PrefixResolution::SingleMatch(targets) = resolution {
 			let mut visible = targets.visible_with_offsets().map(|(_, id)| id.clone());
@@ -440,6 +517,7 @@ fn resolve_commit_id(
 		let resolution = repo
 			.index()
 			.resolve_commit_id_prefix(&prefix)
+			.await
 			.map_err(|err| Error::backend("jj show", err))?;
 		if let PrefixResolution::SingleMatch(id) = resolution {
 			return Ok(Some(id));
@@ -1217,5 +1295,77 @@ mod tests {
 		let details = workspace.commit_details("@").unwrap();
 		assert_eq!(details.sha, workspace.head_id().unwrap().unwrap());
 		assert_eq!(details.parents.len(), 1);
+	}
+	#[test]
+	fn conflicted_paths_read_first_class_working_copy_conflicts() {
+		if !jj_available() {
+			return;
+		}
+		let temp = tempfile::tempdir().unwrap();
+		run_jj(temp.path(), &["git", "init", "."]);
+		fs::write(temp.path().join("file.txt"), "base\n").unwrap();
+		run_jj(temp.path(), &["commit", "-m", "base"]);
+		run_jj(temp.path(), &["bookmark", "create", "base", "-r", "@-"]);
+
+		fs::write(temp.path().join("file.txt"), "left\n").unwrap();
+		run_jj(temp.path(), &["commit", "-m", "left"]);
+		run_jj(temp.path(), &["bookmark", "create", "left", "-r", "@-"]);
+
+		run_jj(temp.path(), &["new", "base"]);
+		fs::write(temp.path().join("file.txt"), "right\n").unwrap();
+		run_jj(temp.path(), &["commit", "-m", "right"]);
+		run_jj(temp.path(), &["bookmark", "create", "right", "-r", "@-"]);
+		run_jj(temp.path(), &["new", "left", "right"]);
+		let file_path = temp.path().join("file.txt");
+		let mut materialized = fs::read(&file_path).unwrap();
+		materialized.extend_from_slice(
+			b"\n<<<<<<< example\n+++++++ side 1\none\n+++++++ side 2\ntwo\n+++++++ side 3\nthree\n>>>>>>> example ends\n",
+		);
+		fs::write(file_path, materialized).unwrap();
+
+		let workspace = JjWorkspace::require(temp.path()).unwrap();
+		let conflicts = workspace.conflicted_paths(&[]).unwrap();
+		assert_eq!(conflicts.len(), 1);
+		assert_eq!(conflicts[0].path, "file.txt");
+		assert_eq!(conflicts[0].kind, ConflictKind::File);
+		assert_eq!(conflicts[0].regions.len(), 1);
+		assert_eq!(conflicts[0].regions[0].marker_length, 7);
+		assert_eq!(conflicts[0].regions[0].sides.len(), 2);
+		assert_eq!(conflicts[0].regions[0].bases.len(), 1);
+		assert!(
+			workspace
+				.conflicted_paths(&["other.txt".to_owned()])
+				.unwrap()
+				.is_empty()
+		);
+	}
+
+	#[test]
+	fn conflicted_paths_classify_non_file_tree_conflicts() {
+		if !jj_available() {
+			return;
+		}
+		let temp = tempfile::tempdir().unwrap();
+		run_jj(temp.path(), &["git", "init", "."]);
+		run_jj(temp.path(), &["commit", "-m", "base"]);
+		run_jj(temp.path(), &["bookmark", "create", "base", "-r", "@-"]);
+
+		fs::write(temp.path().join("node"), "file\n").unwrap();
+		run_jj(temp.path(), &["commit", "-m", "file"]);
+		run_jj(temp.path(), &["bookmark", "create", "file", "-r", "@-"]);
+
+		run_jj(temp.path(), &["new", "base"]);
+		fs::create_dir_all(temp.path().join("node")).unwrap();
+		fs::write(temp.path().join("node/child"), "child\n").unwrap();
+		run_jj(temp.path(), &["commit", "-m", "directory"]);
+		run_jj(temp.path(), &["bookmark", "create", "directory", "-r", "@-"]);
+		run_jj(temp.path(), &["new", "file", "directory"]);
+
+		let workspace = JjWorkspace::require(temp.path()).unwrap();
+		assert_eq!(workspace.conflicted_paths(&[]).unwrap(), vec![ConflictInfo {
+			path:    "node".to_owned(),
+			kind:    ConflictKind::Other,
+			regions: Vec::new(),
+		}]);
 	}
 }

--- a/crates/pi-vcs/src/lib.rs
+++ b/crates/pi-vcs/src/lib.rs
@@ -15,6 +15,7 @@
 //! [`GitRepo::discover`]: git::GitRepo::discover
 //! [`JjWorkspace::discover`]: jj::JjWorkspace::discover
 
+mod conflict;
 pub mod error;
 pub mod git;
 pub mod jj;
@@ -25,6 +26,7 @@ use std::{
 	sync::Arc,
 };
 
+pub use conflict::standalone_regions as parse_conflict_regions;
 pub use error::{Error, Result};
 pub use types::*;
 
@@ -125,6 +127,14 @@ impl Repo {
 		match self {
 			Self::Git(repo) => repo.status_summary(),
 			Self::Jj(workspace) => workspace.status_summary(),
+		}
+	}
+
+	/// List repository-recorded conflicts in the working copy.
+	pub fn conflicted_paths(&self, files: &[String]) -> Result<Vec<ConflictInfo>> {
+		match self {
+			Self::Git(repo) => repo.conflicted_paths(files),
+			Self::Jj(workspace) => workspace.conflicted_paths(files),
 		}
 	}
 

--- a/crates/pi-vcs/src/types.rs
+++ b/crates/pi-vcs/src/types.rs
@@ -15,6 +15,69 @@ pub enum VcsKind {
 	Jj,
 }
 
+/// Broad kind of a recorded VCS conflict.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConflictKind {
+	/// A conflict whose terms are files or file absence and may be materialized
+	/// as conflict markers in the working copy.
+	File,
+	/// A tree-value conflict (for example file versus directory or symlink)
+	/// which cannot be represented as an editable text marker block.
+	Other,
+}
+
+/// Materialized conflict marker grammar.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MaterializedConflictStyle {
+	/// Git merge or diff3 markers.
+	Git,
+	/// Jujutsu diff markers.
+	JjDiff,
+	/// Jujutsu snapshot markers.
+	JjSnapshot,
+}
+
+/// One positive side or negative base term in a materialized conflict.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConflictTerm {
+	/// Optional marker label.
+	pub label:   Option<String>,
+	/// Exact term content, including its original line endings.
+	pub content: String,
+}
+
+/// One complete materialized conflict block in the working-copy file.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConflictRegion {
+	/// One-indexed line containing the opening marker.
+	pub start_line:     u32,
+	/// One-indexed line containing the primary separator or first term marker.
+	pub separator_line: u32,
+	/// One-indexed line containing the closing marker.
+	pub end_line:       u32,
+	/// One-indexed line containing the first base marker.
+	pub base_line:      Option<u32>,
+	/// Marker grammar used by this block.
+	pub style:          MaterializedConflictStyle,
+	/// Marker length used by this materialized block.
+	pub marker_length:  u32,
+	/// Positive merge terms.
+	pub sides:          Vec<ConflictTerm>,
+	/// Negative merge terms.
+	pub bases:          Vec<ConflictTerm>,
+}
+
+/// Metadata for one unresolved repository path.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConflictInfo {
+	/// Worktree-relative path.
+	pub path:    String,
+	/// Whether the conflict can be represented as file contents.
+	pub kind:    ConflictKind,
+	/// Complete materialized marker blocks validated by the owning backend.
+	pub regions: Vec<ConflictRegion>,
+}
+
 /// Status counts shown by status displays.
 ///
 /// Jujutsu has no index, so its `staged` is always zero.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Devin model selectors now accept the native CLI's short aliases (`devin/opus`, `devin/swe`), dotted upstream spellings (`devin/gemini-3.7-flash`), and raw effort-route wire uids for dynamically collapsed families ([#8590](https://github.com/can1357/oh-my-pi/pull/8590) by [@will-bogusz](https://github.com/will-bogusz)).
 - Added provider-supplied model metadata to the `/models` detail line: `new`, `beta`, and `recommended` badges beside the model name, and the upstream description after the context, cost, and perf facts ([#8590](https://github.com/can1357/oh-my-pi/pull/8590) by [@will-bogusz](https://github.com/will-bogusz)).
 - Standalone `CLAUDE.md` files in the project root (and ancestor directories) are now loaded as context, mirroring `AGENTS.md` discovery; config-directory context files still take precedence per scope.
+- Added repository-aware Git and Jujutsu conflict resolution with native marker formats and merge terms.
 
 ### Changed
 

--- a/packages/coding-agent/src/prompts/tools/read.md
+++ b/packages/coding-agent/src/prompts/tools/read.md
@@ -8,7 +8,7 @@ Read files, directories, archives, SQLite, images, documents, internal resources
 ## Selectors — append `:<sel>` to `path` (e.g. `src/foo.ts:50-200`, `src/foo.ts:raw`, `db.sqlite:users:42`)
 - `:50` / `:50-` — from line 50 | `:50-200` — inclusive | `:50+150` — 150 lines from 50 | `:5-16,960-973` — multiple ranges
 - `:raw` — verbatim, no anchors/prefixes | `:2-4:raw` / `:raw:2-4` — range + verbatim
-- `:conflicts` — one line per unresolved git merge conflict block
+- `:conflicts` — repository-verified Git/Jujutsu conflict hunks; standalone marker files remain supported
 - `:img` — rasterize a local `.svg`/`.svgz` as a PNG image; use when visual layout matters
 
 ## Source kinds

--- a/packages/coding-agent/src/tools/conflict-detect.ts
+++ b/packages/coding-agent/src/tools/conflict-detect.ts
@@ -1,40 +1,52 @@
 /**
- * Detect and resolve unresolved git merge conflicts that surface in `read`
- * output.
+ * Detect and resolve materialized Git and Jujutsu conflicts surfaced by
+ * `read`.
  *
- * Workflow:
- *   1. `read` collects lines from disk as usual.
- *   2. `scanConflictLines` inspects those lines (no extra I/O) for
- *      well-formed `<<<<<<<` / `=======` / `>>>>>>>` blocks.
- *   3. Each completed block is registered with the session's
- *      `ConflictHistory`, which assigns it a stable id.
- *   4. The read output is returned verbatim with a short footer naming
- *      every conflict id surfaced, and the agent calls
- *      `write({ path: "conflict://<id>", content })` to splice the
- *      recorded region with the chosen content.
- *
- * Marker shape is strict: only column-0 markers of the exact prefix length
- * followed by either EOL or a single space + label count. Lines that
- * merely start with `<` or `=` never match.
+ * Marker parsing supports Git diff3 plus Jujutsu diff/snapshot styles,
+ * arbitrary side/base arity, CRLF, and dynamically lengthened markers. Inside
+ * a repository, marker blocks are exposed only when the owning VCS records the
+ * path as conflicted; standalone marker files remain usable. Registered hunks
+ * receive session-stable ids which `write conflict://N` resolves by exact
+ * marker-block replacement.
  */
 
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import type { VcsConflictRegion } from "@oh-my-pi/pi-natives";
+import * as vcs from "@oh-my-pi/pi-natives/vcs";
 import type { ToolSession } from "./index";
 import { ToolError } from "./tool-errors";
 
-const OURS_PREFIX = "<<<<<<<";
-const BASE_PREFIX = "|||||||";
-const SEPARATOR = "=======";
-const THEIRS_PREFIX = ">>>>>>>";
+const MIN_MARKER_LENGTH = 7;
+
+export type ConflictStyle = "git" | "jj-diff" | "jj-snapshot";
+export type ConflictGrammar = "all" | "git";
+
+export interface ConflictSection {
+	label?: string;
+	lines: string[];
+	/** Exact semantic term content, including its terminal EOL when present. */
+	content?: string;
+	/** 1-indexed file line of the first body line. */
+	startLine: number;
+}
 
 export interface ConflictBlock {
-	/** 1-indexed line of the `<<<<<<<` marker. */
+	/** 1-indexed line of the opening marker. */
 	startLine: number;
-	/** 1-indexed line of the `=======` separator. */
+	/** 1-indexed line of the Git separator, or first jj term marker. */
 	separatorLine: number;
-	/** 1-indexed line of the `>>>>>>>` marker. */
+	/** 1-indexed line of the closing marker. */
 	endLine: number;
-	/** 1-indexed line of the `|||||||` base marker (diff3 only). */
+	/** 1-indexed line of the first base marker, when present. */
 	baseLine?: number;
+	style?: ConflictStyle;
+	markerLength?: number;
+	/** Exact LF-normalized marker block, including its outer markers. */
+	rawLines?: string[];
+	sides?: ConflictSection[];
+	bases?: ConflictSection[];
+	/** Legacy two-side projection retained for callers constructing entries directly. */
 	oursLabel?: string;
 	baseLabel?: string;
 	theirsLabel?: string;
@@ -43,98 +55,91 @@ export interface ConflictBlock {
 	theirsLines: string[];
 }
 
+function contentLines(content: string): string[] {
+	const lines = content.split("\n").map(stripTrailingCr);
+	if (lines.at(-1) === "") lines.pop();
+	return lines;
+}
+
+function conflictStyle(style: string): ConflictStyle {
+	if (style === "git" || style === "jj-diff" || style === "jj-snapshot") return style;
+	throw new ToolError(`Native conflict parser returned unknown style '${style}'.`);
+}
+
+function buildConflictBlock(region: VcsConflictRegion, rawLines: string[], lineOffset: number): ConflictBlock {
+	const sides = region.sides.map((term, index) => ({
+		label: term.label,
+		lines: contentLines(term.content),
+		content: term.content,
+		startLine: (index === 0 ? region.startLine + 1 : region.separatorLine + 1) + lineOffset,
+	}));
+	const bases = region.bases.map(term => ({
+		label: term.label,
+		lines: contentLines(term.content),
+		content: term.content,
+		startLine: (region.baseLine ?? region.startLine) + 1 + lineOffset,
+	}));
+	const [ours, theirs = { label: undefined, lines: [], startLine: region.endLine + lineOffset }] = sides;
+	const base = bases[0];
+	return {
+		startLine: region.startLine + lineOffset,
+		separatorLine: region.separatorLine + lineOffset,
+		endLine: region.endLine + lineOffset,
+		baseLine: region.baseLine === undefined ? undefined : region.baseLine + lineOffset,
+		style: conflictStyle(region.style),
+		markerLength: region.markerLength,
+		rawLines,
+		sides,
+		bases,
+		oursLabel: ours?.label,
+		baseLabel: base?.label,
+		theirsLabel: theirs.label,
+		oursLines: ours?.lines ?? [],
+		baseLines: base?.lines,
+		theirsLines: theirs.lines,
+	};
+}
+
 /**
- * Scan an already-collected array of file lines for completed conflict
- * blocks. `firstLineNumber` is the 1-indexed line number of `lines[0]`
- * (so a windowed read starting at line 200 passes `firstLineNumber: 200`).
- *
- * Only fully-closed blocks (opener + separator + closer all present in
- * the window) are returned. A block whose closer is past the window's
- * tail is dropped — the agent will see the open marker and can widen
- * the read.
+ * Parse standalone marker content through the native Git grammar and jj-lib
+ * parser. Repository-backed callers use backend-validated regions instead.
  */
-export function scanConflictLines(lines: readonly string[], firstLineNumber: number): ConflictBlock[] {
-	const blocks: ConflictBlock[] = [];
-	let phase: "idle" | "ours" | "base" | "theirs" = "idle";
-	let partial: {
-		startLine: number;
-		oursLabel?: string;
-		oursLines: string[];
-		baseLine?: number;
-		baseLabel?: string;
-		baseLines?: string[];
-		separatorLine?: number;
-		theirsLines?: string[];
-	} | null = null;
+export function scanConflictLines(
+	lines: readonly string[],
+	firstLineNumber: number,
+	minimumMarkerLength = MIN_MARKER_LENGTH,
+	exactMarkerLength = false,
+	grammar: ConflictGrammar = "all",
+): ConflictBlock[] {
+	const normalized = lines.map(stripTrailingCr);
+	return vcs
+		.parseConflictMarkers(Buffer.from(normalized.join("\n")), minimumMarkerLength)
+		.filter(
+			region =>
+				(!exactMarkerLength || region.markerLength === minimumMarkerLength) &&
+				(grammar === "all" || region.style === "git"),
+		)
+		.map(region => {
+			const start = region.startLine - 1;
+			const end = region.endLine;
+			return buildConflictBlock(region, normalized.slice(start, end), firstLineNumber - 1);
+		});
+}
 
-	for (let i = 0; i < lines.length; i++) {
-		// Strip a trailing \r so CRLF checkouts match the same markers; stored
-		// section lines are LF-normalized (splice re-applies \r on write).
-		const line = stripTrailingCr(lines[i]);
-		const ln = firstLineNumber + i;
-
-		const oursLabel = matchMarker(line, OURS_PREFIX);
-		if (oursLabel !== null) {
-			partial = { startLine: ln, oursLabel: oursLabel || undefined, oursLines: [] };
-			phase = "ours";
-			continue;
-		}
-
-		if (phase === "idle" || partial === null) continue;
-
-		const baseLabel = matchMarker(line, BASE_PREFIX);
-		if (baseLabel !== null) {
-			if (phase !== "ours") {
-				partial = null;
-				phase = "idle";
-				continue;
-			}
-			partial.baseLine = ln;
-			partial.baseLabel = baseLabel || undefined;
-			partial.baseLines = [];
-			phase = "base";
-			continue;
-		}
-
-		if (line === SEPARATOR) {
-			if (phase === "ours" || phase === "base") {
-				partial.separatorLine = ln;
-				partial.theirsLines = [];
-				phase = "theirs";
-			} else {
-				partial = null;
-				phase = "idle";
-			}
-			continue;
-		}
-
-		const theirsLabel = matchMarker(line, THEIRS_PREFIX);
-		if (theirsLabel !== null) {
-			if (phase === "theirs" && partial.separatorLine !== undefined && partial.theirsLines) {
-				blocks.push({
-					startLine: partial.startLine,
-					separatorLine: partial.separatorLine,
-					endLine: ln,
-					baseLine: partial.baseLine,
-					oursLabel: partial.oursLabel,
-					baseLabel: partial.baseLabel,
-					theirsLabel: theirsLabel || undefined,
-					oursLines: partial.oursLines,
-					baseLines: partial.baseLines,
-					theirsLines: partial.theirsLines,
-				});
-			}
-			partial = null;
-			phase = "idle";
-			continue;
-		}
-
-		if (phase === "ours") partial.oursLines.push(line);
-		else if (phase === "base" && partial.baseLines) partial.baseLines.push(line);
-		else if (phase === "theirs" && partial.theirsLines) partial.theirsLines.push(line);
-	}
-
-	return blocks;
+export function scanRecordedConflictLines(
+	lines: readonly string[],
+	firstLineNumber: number,
+	authority: Extract<ConflictAuthority, { state: "recorded"; kind: "file" }>,
+): ConflictBlock[] {
+	const normalized = lines.map(stripTrailingCr);
+	const lastLineNumber = firstLineNumber + normalized.length - 1;
+	return authority.regions
+		.filter(region => region.startLine >= firstLineNumber && region.endLine <= lastLineNumber)
+		.map(region => {
+			const start = region.startLine - firstLineNumber;
+			const end = region.endLine - firstLineNumber + 1;
+			return buildConflictBlock(region, normalized.slice(start, end), 0);
+		});
 }
 
 const SCAN_FILE_DEFAULT_MAX_BYTES = 10 * 1024 * 1024;
@@ -149,7 +154,12 @@ const SCAN_FILE_DEFAULT_MAX_BYTES = 10 * 1024 * 1024;
  */
 export async function scanFileForConflicts(
 	absolutePath: string,
-	options: { maxBytes?: number } = {},
+	options: {
+		maxBytes?: number;
+		minimumMarkerLength?: number;
+		exactMarkerLength?: boolean;
+		authority?: Extract<ConflictAuthority, { state: "recorded"; kind: "file" }>;
+	} = {},
 ): Promise<{ blocks: ConflictBlock[]; scanTruncated: boolean }> {
 	const maxBytes = options.maxBytes ?? SCAN_FILE_DEFAULT_MAX_BYTES;
 	const file = Bun.file(absolutePath);
@@ -160,19 +170,12 @@ export async function scanFileForConflicts(
 	// `split("\n")` over a truncated read may leave a partial last line; the
 	// scanner already tolerates an unclosed opener, so no extra trimming.
 	const lines = text.split("\n");
-	return { blocks: scanConflictLines(lines, 1), scanTruncated: truncated };
-}
-
-/**
- * Return the label after a marker prefix when the line is a valid
- * column-0 marker, or `null` when it isn't. Strict shape: prefix alone,
- * or prefix + single space + label.
- */
-function matchMarker(line: string, prefix: string): string | null {
-	if (!line.startsWith(prefix)) return null;
-	if (line.length === prefix.length) return "";
-	if (line.charCodeAt(prefix.length) !== 32 /* space */) return null;
-	return line.slice(prefix.length + 1);
+	return {
+		blocks: options.authority
+			? scanRecordedConflictLines(lines, 1, options.authority)
+			: scanConflictLines(lines, 1, options.minimumMarkerLength, options.exactMarkerLength),
+		scanTruncated: truncated,
+	};
 }
 
 /**
@@ -184,6 +187,7 @@ export interface ConflictEntry extends ConflictBlock {
 	id: number;
 	absolutePath: string;
 	displayPath: string;
+	authority?: "git" | "jj" | "unverified";
 }
 
 /** Per-session log of conflict regions surfaced by `read`. */
@@ -242,10 +246,83 @@ export function getConflictHistory(session: ToolSession): ConflictHistory {
 	return session.conflictHistory;
 }
 
-/** A side of a conflict block that the `read` tool can render via `conflict://N/<scope>`. */
-export type ConflictScope = "ours" | "theirs" | "base";
+export type ConflictAuthorityRegion = VcsConflictRegion;
 
-const CONFLICT_SCOPES = new Set<ConflictScope>(["ours", "theirs", "base"]);
+export type ConflictAuthority =
+	| { state: "unverified" }
+	| { state: "clean"; backend: "git" | "jj" }
+	| { state: "recorded"; backend: "git" | "jj"; kind: "file"; regions: ConflictAuthorityRegion[] }
+	| { state: "recorded"; backend: "git" | "jj"; kind: "other" };
+
+/**
+ * Ask the owning VCS whether `absolutePath` is recorded as conflicted. A
+ * standalone file outside a repository remains marker-verifiable so conflict
+ * fixtures and exported merge results can still use the protocol.
+ */
+async function canonicalTrackedPath(absolutePath: string): Promise<string> {
+	const requested = path.resolve(absolutePath);
+	const parent = await fs.realpath(path.dirname(requested)).catch(() => path.dirname(requested));
+	const requestedName = path.basename(requested);
+	const entries = await fs.readdir(parent).catch(() => []);
+	const exactName = entries.find(name => name === requestedName);
+	const foldedNames = exactName ? [] : entries.filter(name => name.toLowerCase() === requestedName.toLowerCase());
+	const actualName = exactName ?? (foldedNames.length === 1 ? foldedNames[0]! : requestedName);
+	return path.join(parent, actualName);
+}
+
+export async function inspectConflictAuthority(absolutePath: string, signal?: AbortSignal): Promise<ConflictAuthority> {
+	const resolvedPath = await canonicalTrackedPath(absolutePath);
+	const directory = path.dirname(resolvedPath);
+	const repository = vcs.repo(directory);
+	const jjWorkspace = vcs.jj(directory);
+	if (!repository && !jjWorkspace) return { state: "unverified" };
+
+	const jjOwns =
+		jjWorkspace !== null &&
+		(repository === null ||
+			repository.kind() === "jj" ||
+			path.resolve(repository.root()) === path.resolve(jjWorkspace.root()));
+	const backend = jjOwns ? "jj" : "git";
+	const root = jjOwns ? jjWorkspace.root() : repository?.root();
+	if (!root) return { state: "unverified" };
+	const resolvedRoot = await fs.realpath(root).catch(() => path.resolve(root));
+	const relativePath = path.relative(resolvedRoot, resolvedPath).split(path.sep).join("/");
+	if (relativePath === ".." || relativePath.startsWith("../")) return { state: "clean", backend };
+
+	const conflicts = jjOwns
+		? await jjWorkspace.conflictedPaths([relativePath], signal)
+		: await repository!.conflictedPaths([relativePath], signal);
+	const conflict = conflicts.find(item => item.path === relativePath);
+	if (!conflict) return { state: "clean", backend };
+	if (conflict.kind === "other") return { state: "recorded", backend, kind: "other" };
+	const regions = conflict.regions;
+	if (
+		!Array.isArray(regions) ||
+		regions.some(
+			region =>
+				!Number.isInteger(region.startLine) ||
+				region.startLine < 1 ||
+				!Number.isInteger(region.separatorLine) ||
+				region.separatorLine <= region.startLine ||
+				!Number.isInteger(region.endLine) ||
+				region.endLine <= region.separatorLine ||
+				!Number.isInteger(region.markerLength) ||
+				region.markerLength < 1 ||
+				!Array.isArray(region.sides) ||
+				region.sides.length < 2 ||
+				!Array.isArray(region.bases),
+		)
+	) {
+		throw new ToolError(`The ${backend} conflict at '${relativePath}' has invalid materialized region metadata.`);
+	}
+	return { state: "recorded", backend, kind: "file", regions };
+}
+
+/** One indexed positive side or negative base. Git names normalize here. */
+export interface ConflictScope {
+	role: "side" | "base";
+	index: number;
+}
 
 /** Parsed `conflict://<N>` / `conflict://<N>/<scope>` / `conflict://*` URI. */
 export interface ParsedConflictUri {
@@ -267,16 +344,8 @@ export interface ParsedConflictUri {
 const CONFLICT_URI_RE = /^(?:(.+):)?conflict:\/\/(.+)$/;
 
 /**
- * Parse a `conflict://<N>`, `conflict://<N>/<scope>`, or `conflict://*` URI.
- *
- * Returns `null` for non-conflict paths; throws `ToolError` for a
- * well-formed scheme with an invalid id or scope so the agent gets a
- * clear actionable message rather than a confusing "not found" later.
- *
- * `*` is the bulk-write wildcard — only valid as `conflict://*` (no
- * scope segment). Use it with `write({ path: "conflict://*", content })`
- * to apply `content` (with optional `@ours` / `@theirs` / `@base` /
- * `@both` shorthand) to every currently-registered conflict in one shot.
+ * Parse a `conflict://<N>`, Git `/<ours|theirs|base>`, indexed
+ * Jujutsu `/side/<M>` or `/base/<M>`, or `conflict://*` URI.
  */
 export function parseConflictUri(raw: string): ParsedConflictUri | null {
 	const match = raw.match(CONFLICT_URI_RE);
@@ -289,16 +358,14 @@ export function parseConflictUri(raw: string): ParsedConflictUri | null {
 
 	if (idPart === "*") {
 		if (scopePart !== undefined) {
-			throw new ToolError(
-				`Invalid conflict URI '${raw}': wildcard 'conflict://*' does not accept a scope segment. Drop '/${scopePart}' or use a numeric id.`,
-			);
+			throw new ToolError(`Invalid conflict URI '${raw}': wildcard 'conflict://*' does not accept a scope segment.`);
 		}
 		return recoveredPrefix !== undefined ? { id: "*", recoveredPrefix } : { id: "*" };
 	}
 
 	if (!/^\d+$/.test(idPart)) {
 		throw new ToolError(
-			`Invalid conflict URI '${raw}': must be 'conflict://<N>', 'conflict://<N>/<scope>', or 'conflict://*' where N is a positive integer surfaced by a prior \`read\`.`,
+			`Invalid conflict URI '${raw}': use 'conflict://<N>', a Git '/ours', '/theirs', or '/base' scope, an indexed '/side/<M>' or '/base/<M>' scope, or 'conflict://*'.`,
 		);
 	}
 	const id = Number.parseInt(idPart, 10);
@@ -308,43 +375,35 @@ export function parseConflictUri(raw: string): ParsedConflictUri | null {
 
 	let scope: ConflictScope | undefined;
 	if (scopePart !== undefined) {
-		if (!CONFLICT_SCOPES.has(scopePart as ConflictScope)) {
-			throw new ToolError(
-				`Invalid conflict URI '${raw}': scope must be one of 'ours', 'theirs', 'base', or omitted (e.g. 'conflict://${id}/theirs').`,
-			);
+		if (scopePart === "ours") scope = { role: "side", index: 1 };
+		else if (scopePart === "theirs") scope = { role: "side", index: 2 };
+		else if (scopePart === "base") scope = { role: "base", index: 1 };
+		else {
+			const scopeMatch = scopePart.match(/^(side|base)\/([1-9]\d*)$/);
+			if (!scopeMatch) {
+				throw new ToolError(
+					`Invalid conflict URI '${raw}': use a Git 'ours', 'theirs', or 'base' scope, or an indexed 'side/<M>' or 'base/<M>' scope.`,
+				);
+			}
+			scope = {
+				role: scopeMatch[1] as ConflictScope["role"],
+				index: Number.parseInt(scopeMatch[2]!, 10),
+			};
 		}
-		scope = scopePart as ConflictScope;
 	}
 
 	return recoveredPrefix !== undefined ? { id, scope, recoveredPrefix } : { id, scope };
 }
 
-/** Result of {@link spliceConflict}: the new file text plus any boundary-echo repair applied. */
+/** Result of an exact marker-block replacement. */
 export interface ConflictSplice {
 	text: string;
-	/** Replacement lines dropped because they duplicated the context directly above the region. */
-	trimmedLeading: number;
-	/** Replacement lines dropped because they duplicated the context directly below the region. */
-	trimmedTrailing: number;
 }
 
 /**
- * Splice the conflict region recorded in `entry` out of `originalText`
- * and replace it with `replacement` (markers and all sides included).
- *
- * Works like the edit tool's patch infra: locates the recorded marker
- * block by content (anchored to `entry.startLine` as the preferred
- * match), so out-of-band edits earlier in the file that shift line
- * numbers don't break resolution. Throws clearly when the marker block
- * has actually been altered or removed.
- *
- * Boundary-echo repair (same philosophy as the edit tool's hashline
- * keeper repair): models frequently paste the "whole resolved function"
- * including the lines that live directly before/after the marker block,
- * which the verbatim splice would duplicate. Replacement lines that
- * exactly echo the adjacent context are dropped when the echo is
- * unambiguous — two or more consecutive lines, or a single line whose
- * removal fixes a delimiter-balance mismatch against the recorded sides.
+ * Locate the exact recorded marker block and replace it verbatim. Line numbers
+ * are only a preferred anchor; content identity tolerates unrelated edits
+ * earlier in the file without silently rewriting the supplied resolution.
  */
 export function spliceConflict(originalText: string, entry: ConflictEntry, replacement: string): ConflictSplice {
 	const lines = originalText.split("\n");
@@ -356,107 +415,36 @@ export function spliceConflict(originalText: string, entry: ConflictEntry, repla
 		);
 	}
 
-	const trimmed = normalizeTrailingNewline(replacement);
-	let replacementLines = trimmed.split("\n").map(stripTrailingCr);
-	const echo = trimBoundaryEcho(replacementLines, lines, match, entry);
-	replacementLines = echo.lines;
+	const hasFollowingLine = match.endIdx + 1 < lines.length;
+	const normalizedReplacement = hasFollowingLine ? normalizeTrailingNewline(replacement) : replacement;
+	let replacementLines = normalizedReplacement.split("\n").map(stripTrailingCr);
 	// Round-trip fidelity for CRLF files: recorded sections are LF-normalized,
 	// so re-apply \r to spliced lines when the matched region used CRLF. The
 	// final replacement line only carries \r when another line follows it.
 	if (lines[match.startIdx]!.endsWith("\r")) {
-		const hasFollowingLine = match.endIdx + 1 < lines.length;
+		// `hasFollowingLine` also preserves an intentional final EOL when the
+		// conflict itself occupies an unterminated EOF.
 		replacementLines = replacementLines.map((l, i) =>
 			i < replacementLines.length - 1 || hasFollowingLine ? `${l}\r` : l,
 		);
 	}
 	const next = [...lines.slice(0, match.startIdx), ...replacementLines, ...lines.slice(match.endIdx + 1)];
-	return { text: next.join("\n"), trimmedLeading: echo.leading, trimmedTrailing: echo.trailing };
-}
-
-const MAX_ECHO_LINES = 12;
-
-/**
- * Net `{}`/`()`/`[]` count over `lines`. Crude (string/comment-blind) —
- * used only to corroborate single-line echo trims, never alone.
- */
-function delimiterBalance(lines: readonly string[]): number {
-	let balance = 0;
-	for (const line of lines) {
-		for (let i = 0; i < line.length; i++) {
-			const ch = line.charCodeAt(i);
-			if (ch === 123 /* { */ || ch === 40 /* ( */ || ch === 91 /* [ */) balance++;
-			else if (ch === 125 /* } */ || ch === 41 /* ) */ || ch === 93 /* ] */) balance--;
-		}
-	}
-	return balance;
-}
-
-/**
- * Drop replacement lines that exactly echo the file lines adjacent to the
- * located region. A multi-line echo is trimmed unconditionally (a correct
- * resolution ending with the exact lines that already follow the region
- * would mean intentionally duplicated code — vanishingly unlikely, and the
- * untrimmed splice produces exactly that duplication). A single-line echo
- * is trimmed only when the recorded sides agree on the region's delimiter
- * balance and dropping the echo is what restores it.
- */
-function trimBoundaryEcho(
-	replacement: string[],
-	fileLines: readonly string[],
-	match: { startIdx: number; endIdx: number },
-	entry: ConflictBlock,
-): { lines: string[]; leading: number; trailing: number } {
-	const oursBalance = delimiterBalance(entry.oursLines);
-	const expectedBalance = oursBalance === delimiterBalance(entry.theirsLines) ? oursBalance : null;
-	const singleEchoJustified = (lines: string[], without: string[]) =>
-		expectedBalance !== null &&
-		delimiterBalance(lines) !== expectedBalance &&
-		delimiterBalance(without) === expectedBalance;
-
-	let lines = replacement;
-	let trailing = 0;
-	const after: string[] = [];
-	for (let i = match.endIdx + 1; i < fileLines.length && after.length < MAX_ECHO_LINES; i++) {
-		after.push(stripTrailingCr(fileLines[i]!));
-	}
-	for (let k = Math.min(after.length, lines.length - 1); k >= 1; k--) {
-		if (!after.slice(0, k).every((line, i) => lines[lines.length - k + i] === line)) continue;
-		if (k >= 2 || singleEchoJustified(lines, lines.slice(0, -1))) {
-			trailing = k;
-			lines = lines.slice(0, lines.length - k);
-		}
-		break;
-	}
-
-	let leading = 0;
-	const before: string[] = [];
-	for (let i = match.startIdx - 1; i >= 0 && before.length < MAX_ECHO_LINES; i--) {
-		before.unshift(stripTrailingCr(fileLines[i]!));
-	}
-	for (let k = Math.min(before.length, lines.length - 1); k >= 1; k--) {
-		if (!before.slice(before.length - k).every((line, i) => lines[i] === line)) continue;
-		if (k >= 2 || singleEchoJustified(lines, lines.slice(1))) {
-			leading = k;
-			lines = lines.slice(k);
-		}
-		break;
-	}
-
-	return { lines, leading, trailing };
+	return { text: next.join("\n") };
 }
 
 /** Reconstruct the recorded marker block as it should appear in the file. */
 function buildRecordedRegion(entry: ConflictBlock): string[] {
+	if (entry.rawLines) return [...entry.rawLines];
 	const out: string[] = [];
-	out.push(entry.oursLabel ? `${OURS_PREFIX} ${entry.oursLabel}` : OURS_PREFIX);
+	out.push(entry.oursLabel ? `<<<<<<< ${entry.oursLabel}` : "<<<<<<<");
 	out.push(...entry.oursLines);
 	if (entry.baseLines !== undefined) {
-		out.push(entry.baseLabel ? `${BASE_PREFIX} ${entry.baseLabel}` : BASE_PREFIX);
+		out.push(entry.baseLabel ? `||||||| ${entry.baseLabel}` : "|||||||");
 		out.push(...entry.baseLines);
 	}
-	out.push(SEPARATOR);
+	out.push("=======");
 	out.push(...entry.theirsLines);
-	out.push(entry.theirsLabel ? `${THEIRS_PREFIX} ${entry.theirsLabel}` : THEIRS_PREFIX);
+	out.push(entry.theirsLabel ? `>>>>>>> ${entry.theirsLabel}` : ">>>>>>>");
 	return out;
 }
 
@@ -539,133 +527,98 @@ function normalizeTrailingNewline(replacement: string): string {
 	return replacement;
 }
 
-/**
- * Expand `@ours` / `@theirs` / `@base` / `@both` line tokens against the
- * recorded sections of `entry`. A token only triggers when it is the
- * entire content of a line (after CRLF normalisation), so `@ours` inside
- * actual code is left alone. Other lines pass through verbatim.
- *
- * - `@ours`    → expands to the recorded `oursLines` (in order).
- * - `@theirs`  → expands to the recorded `theirsLines` (in order).
- * - `@base`    → expands to `baseLines`; throws if no base section was
- *               recorded (i.e. the conflict was 2-way, not diff3).
- * - `@both`    → expands to `oursLines` then `theirsLines`.
- */
+function conflictSides(entry: ConflictEntry): ConflictSection[] {
+	return (
+		entry.sides ?? [
+			{ label: entry.oursLabel, lines: entry.oursLines, startLine: entry.startLine + 1 },
+			{ label: entry.theirsLabel, lines: entry.theirsLines, startLine: entry.separatorLine + 1 },
+		]
+	);
+}
+
+function conflictBases(entry: ConflictEntry): ConflictSection[] {
+	if (entry.bases) return entry.bases;
+	if (entry.baseLines === undefined) return [];
+	return [{ label: entry.baseLabel, lines: entry.baseLines, startLine: (entry.baseLine ?? entry.startLine) + 1 }];
+}
+
+function usesGitConflictTerms(entry: ConflictEntry): boolean {
+	if (entry.authority === "jj") return false;
+	if (entry.authority === "git") return true;
+	return (entry.style ?? "git") === "git";
+}
+
+const GIT_CONFLICT_TERMS: Readonly<Record<string, ConflictScope>> = {
+	"@ours": { role: "side", index: 1 },
+	"@theirs": { role: "side", index: 2 },
+	"@base": { role: "base", index: 1 },
+};
+
+/** Expand Git named tokens or indexed Jujutsu term tokens. */
 export function expandContentTokens(content: string, entry: ConflictEntry): string {
-	const inputLines = content.split("\n");
+	const sides = conflictSides(entry);
+	const bases = conflictBases(entry);
 	const out: string[] = [];
-	for (const rawLine of inputLines) {
-		const line = rawLine.endsWith("\r") ? rawLine.slice(0, -1) : rawLine;
-		switch (line) {
-			case "@ours":
-				out.push(...entry.oursLines);
-				break;
-			case "@theirs":
-				out.push(...entry.theirsLines);
-				break;
-			case "@base":
-				if (!entry.baseLines) {
-					throw new ToolError(
-						`Conflict #${entry.id} has no base section (2-way merge). \`@base\` is only valid for diff3 conflicts.`,
-					);
-				}
-				out.push(...entry.baseLines);
-				break;
-			case "@both":
-				out.push(...entry.oursLines, ...entry.theirsLines);
-				break;
-			default:
-				out.push(rawLine);
-				break;
+	for (const rawLine of content.split("\n")) {
+		const line = stripTrailingCr(rawLine);
+		if (line === "@both") {
+			if (!usesGitConflictTerms(entry)) {
+				throw new ToolError(`Conflict #${entry.id} is a Jujutsu conflict; combine indexed terms explicitly.`);
+			}
+			const first = sides[0]!.content ?? sides[0]!.lines.join("\n");
+			const second = sides[1]!.content ?? sides[1]!.lines.join("\n");
+			out.push(first + (first.endsWith("\n") || second.length === 0 ? "" : "\n") + second);
+			continue;
 		}
+		const gitTerm = GIT_CONFLICT_TERMS[line];
+		const indexed = line.match(/^@(side|base)\/([1-9]\d*)$/);
+		const term =
+			gitTerm ??
+			(indexed
+				? {
+						role: indexed[1] as ConflictScope["role"],
+						index: Number.parseInt(indexed[2]!, 10),
+					}
+				: undefined);
+		if (!term) {
+			out.push(rawLine);
+			continue;
+		}
+		const { role, index } = term;
+		const section = (role === "side" ? sides : bases)[index - 1];
+		if (!section) {
+			const count = role === "side" ? sides.length : bases.length;
+			throw new ToolError(
+				`Conflict #${entry.id} has ${count} ${role}${count === 1 ? "" : "s"}; \`@${role}/${index}\` is out of range.`,
+			);
+		}
+		out.push(section.content ?? section.lines.join("\n"));
 	}
 	return out.join("\n");
 }
 
-/** Reconstruct a conflict-marker line from prefix and optional label. */
-function markerLine(prefix: string, label: string | undefined): string {
-	return label && label.length > 0 ? `${prefix} ${label}` : prefix;
-}
-
-/**
- * Materialise a conflict block for `conflict://<N>` reads (and their
- * `/ours` / `/theirs` / `/base` scopes).
- *
- * Returns:
- * - `lines`: the lines to render, ordered top-to-bottom.
- * - `startLine`: the 1-indexed file line number `lines[0]` corresponds
- *   to, so the read formatter can label hashline anchors with the
- *   original file positions.
- *
- * Bare (no scope) returns the full block including marker lines. A
- * scoped view returns only that side's body — `base` throws when the
- * recorded conflict is a 2-way merge with no base section.
- */
+/** Materialize a full marker block or one normalized conflict term. */
 export function renderConflictRegion(
 	entry: ConflictEntry,
 	scope: ConflictScope | undefined,
 ): { lines: string[]; startLine: number } {
-	if (scope === "ours") {
-		return { lines: [...entry.oursLines], startLine: entry.startLine + 1 };
+	if (!scope) return { lines: buildRecordedRegion(entry), startLine: entry.startLine };
+	const sections = scope.role === "side" ? conflictSides(entry) : conflictBases(entry);
+	const section = sections[scope.index - 1];
+	if (!section) {
+		throw new ToolError(
+			`Conflict #${entry.id} has ${sections.length} ${scope.role}${sections.length === 1 ? "" : "s"}; ` +
+				`\`conflict://${entry.id}/${scope.role}/${scope.index}\` is out of range.`,
+		);
 	}
-	if (scope === "theirs") {
-		return { lines: [...entry.theirsLines], startLine: entry.separatorLine + 1 };
-	}
-	if (scope === "base") {
-		if (entry.baseLines === undefined || entry.baseLine === undefined) {
-			throw new ToolError(
-				`Conflict #${entry.id} has no base section (2-way merge). 'conflict://${entry.id}/base' is only valid for diff3 conflicts.`,
-			);
-		}
-		return { lines: [...entry.baseLines], startLine: entry.baseLine + 1 };
-	}
-	const out: string[] = [];
-	out.push(markerLine("<<<<<<<", entry.oursLabel));
-	out.push(...entry.oursLines);
-	if (entry.baseLines !== undefined) {
-		out.push(markerLine("|||||||", entry.baseLabel));
-		out.push(...entry.baseLines);
-	}
-	out.push("=======");
-	out.push(...entry.theirsLines);
-	out.push(markerLine(">>>>>>>", entry.theirsLabel));
-	return { lines: out, startLine: entry.startLine };
+	return { lines: [...section.lines], startLine: section.startLine };
 }
 
 const PREVIEW_SIDE_LINES = 6;
 
-/**
- * Build a compact diff-style footer describing the conflicts registered
- * during a read. Designed to be appended after the file content.
- *
- * Format:
- *
- *     ⚠ N unresolved conflicts detected
- *     - ours = HEAD
- *     - theirs = feature/x
- *     NOTICE: …
- *
- *     ──── #1  L42-48 ────
- *     <<< ours
- *     …ours body…
- *     === base ≡ ours
- *     >>> theirs
- *     …theirs body…
- *
- * Labels are aggregated once at the top from the first entry that has
- * them; when a section body equals another section's body the redundant
- * body is collapsed to `≡ <other>`.
- */
 export interface FormatConflictWarningOptions {
-	/**
-	 * Total number of conflicts in the underlying file. If greater than
-	 * `entries.length` the header notes how many are visible vs the total
-	 * and points at `:conflicts` for the compact list.
-	 */
 	totalInFile?: number;
-	/** Display path used inside the `:conflicts` hint. */
 	displayPath?: string;
-	/** Whether the underlying file scan hit its byte cap. */
 	scanTruncated?: boolean;
 }
 
@@ -676,8 +629,7 @@ export function formatConflictWarning(
 	if (entries.length === 0) return "";
 	const total = options.totalInFile ?? entries.length;
 	const partial = total > entries.length;
-	const out: string[] = [];
-	out.push("");
+	const out: string[] = [""];
 	const word = total === 1 ? "conflict" : "conflicts";
 	if (partial) {
 		const hintPath = options.displayPath ?? "<file>";
@@ -690,65 +642,47 @@ export function formatConflictWarning(
 	if (options.scanTruncated) {
 		out.push("- note: file scan hit the byte cap; additional conflicts may exist beyond the scanned prefix.");
 	}
-
-	const oursLabel = pickLabel(entries, e => e.oursLabel);
-	const theirsLabel = pickLabel(entries, e => e.theirsLabel);
-	const baseLabel = pickLabel(entries, e => (e.baseLines !== undefined ? e.baseLabel : undefined));
-	const anyBase = entries.some(e => e.baseLines !== undefined);
-	if (oursLabel) out.push(`- ours = ${oursLabel}`);
-	if (theirsLabel) out.push(`- theirs = ${theirsLabel}`);
-	if (anyBase) out.push(`- base = ${baseLabel ?? "(no label)"}`);
+	const termNotice = usesGitConflictTerms(entries[0]!)
+		? "NOTICE: Git terms use `/ours` / `/theirs` / `/base` and `@ours` / `@theirs` / `@base` / `@both`."
+		: "NOTICE: Jujutsu terms use indexed `/side/<M>` / `/base/<M>` and `@side/<M>` / `@base/<M>`.";
 	out.push(
-		'NOTICE: Inspect a block by reading `conflict://<N>` (add `/ours` / `/theirs` / `/base` to render a single side). Resolve with `write({ path: "conflict://<N>", content })`, or bulk-resolve every registered conflict with `write({ path: "conflict://*", content })`. Writes replace ONLY the marker block (markers + all sides) — never repeat the lines before/after it; they stay in place.',
-	);
-	out.push(
-		'`content` shorthand: a line that is exactly `@ours` / `@theirs` / `@base` / `@both` expands to that recorded section. `@both` is ours-then-theirs with no separator — only for additive conflicts where each side adds something different; NEVER for competing edits of the same lines (pick a side or write the combined text). Lines that are not a token pass through verbatim, so `"// keep both\\n@ours\\n@theirs"` literally writes the comment, then ours, then theirs.',
-	);
-	out.push(
-		'Per-id bulk: `write({ path: "conflict://*", content: "1: @ours\\n2: @theirs\\n…" })` resolves each listed id with that side in ONE call — the cheapest way through many pick-one conflicts; unlisted ids stay registered.',
-	);
-	out.push(
-		"Resolve each block faithfully: keep one side (`@ours`/`@theirs`), or combine them when both intents apply — never invent content beyond the recorded sides, and never stack both sides of competing edits. Resolve several conflicts in a single turn by issuing multiple `write` calls at once; ids stay valid as earlier blocks are resolved.",
+		termNotice,
+		'Write one block with `write({ path: "conflict://<N>", content })`, or bulk pick terms with `write({ path: "conflict://*", content: "1: <term>\\n2: <term>" })`. Writes replace only marker blocks; unlisted ids remain registered.',
 	);
 
 	for (const entry of entries) {
 		const range = entry.startLine === entry.endLine ? `L${entry.startLine}` : `L${entry.startLine}-${entry.endLine}`;
-		out.push("");
-		out.push(`──── #${entry.id}  ${range} ────`);
-
-		const baseEqualsOurs = entry.baseLines !== undefined && sectionsEqual(entry.baseLines, entry.oursLines);
-		const baseEqualsTheirs = entry.baseLines !== undefined && sectionsEqual(entry.baseLines, entry.theirsLines);
-		const theirsEqualsOurs = sectionsEqual(entry.theirsLines, entry.oursLines);
-
-		out.push("<<< ours");
-		appendBody(out, entry.oursLines);
-
-		if (entry.baseLines !== undefined) {
-			if (baseEqualsOurs) {
-				out.push("=== base ≡ ours");
-			} else if (baseEqualsTheirs) {
-				out.push("=== base ≡ theirs");
-			} else {
-				out.push("=== base");
-				appendBody(out, entry.baseLines);
+		const sides = conflictSides(entry);
+		const bases = conflictBases(entry);
+		out.push("", `──── #${entry.id}  ${range}  ${entry.style ?? "git"} ────`);
+		if (usesGitConflictTerms(entry)) {
+			const [ours, theirs] = sides;
+			out.push(`<<< ours${ours?.label ? `  ${ours.label}` : ""}`);
+			appendBody(out, ours?.lines ?? []);
+			const base = bases[0];
+			if (base) {
+				out.push(`=== base${base.label ? `  ${base.label}` : ""}`);
+				appendBody(out, base.lines);
 			}
-		}
-
-		if (theirsEqualsOurs) {
-			out.push(">>> theirs ≡ ours");
+			out.push(`>>> theirs${theirs?.label ? `  ${theirs.label}` : ""}`);
+			appendBody(out, theirs?.lines ?? []);
 		} else {
-			out.push(">>> theirs");
-			appendBody(out, entry.theirsLines);
+			for (let i = 0; i < sides.length; i++) {
+				const section = sides[i]!;
+				out.push(`+++ side/${i + 1}${section.label ? `  ${section.label}` : ""}`);
+				appendBody(out, section.lines);
+			}
+			for (let i = 0; i < bases.length; i++) {
+				const section = bases[i]!;
+				out.push(`--- base/${i + 1}${section.label ? `  ${section.label}` : ""}`);
+				appendBody(out, section.lines);
+			}
 		}
 	}
 	return out.join("\n");
 }
 
-/**
- * Render a single-line-per-block index of every conflict in a file.
- * Used by the `<path>:conflicts` read selector to give the agent a cheap overview
- * of a heavily-conflicted file without dumping every body.
- */
+/** Render a one-line-per-hunk index for the `<path>:conflicts` selector. */
 export function formatConflictSummary(
 	entries: readonly ConflictEntry[],
 	options: { displayPath: string; scanTruncated?: boolean } = { displayPath: "" },
@@ -760,47 +694,25 @@ export function formatConflictSummary(
 	if (options.scanTruncated) {
 		lines.push("- note: file scan hit the byte cap; additional conflicts may exist beyond the scanned prefix.");
 	}
-	const oursLabel = pickLabel(entries, e => e.oursLabel);
-	const theirsLabel = pickLabel(entries, e => e.theirsLabel);
-	const baseLabel = pickLabel(entries, e => (e.baseLines !== undefined ? e.baseLabel : undefined));
-	const anyBase = entries.some(e => e.baseLines !== undefined);
-	if (oursLabel) lines.push(`- ours = ${oursLabel}`);
-	if (theirsLabel) lines.push(`- theirs = ${theirsLabel}`);
-	if (anyBase) lines.push(`- base = ${baseLabel ?? "(no label)"}`);
+	const termNotice = usesGitConflictTerms(entries[0]!)
+		? "NOTICE: Git uses `/ours` / `/theirs` / `/base`; resolve with `@ours` / `@theirs` / `@base` / `@both`."
+		: "NOTICE: Jujutsu uses indexed `/side/<M>` / `/base/<M>`; resolve with `@side/<M>` / `@base/<M>`.";
 	lines.push(
-		'NOTICE: Bulk-resolve with `write({ path: "conflict://*", content })`, or address a single block with `write({ path: "conflict://<N>", content })`. Inspect a block by reading `conflict://<N>` (add `/ours` / `/theirs` / `/base` for a single side).',
+		termNotice,
+		"Write one `conflict://<N>` block, or bulk-resolve with per-id `<id>: <term>` directives.",
+		"",
 	);
-	lines.push(
-		'`content` shorthand: `@ours` / `@theirs` / `@base` / `@both` lines expand to the recorded sections; `@both` = ours-then-theirs (additive conflicts only — never for competing edits of the same lines). Per-id bulk: content of `<id>: @side` lines (e.g. "1: @ours\\n2: @theirs") resolves each listed id in one call. Non-token lines pass through verbatim. Writes replace ONLY the marker block — never repeat the surrounding lines. Keep one side or combine faithfully; never invent content beyond the recorded sides.',
-	);
-	lines.push("");
 	const idWidth = String(entries[entries.length - 1]?.id ?? 1).length;
 	for (const entry of entries) {
 		const range = entry.startLine === entry.endLine ? `L${entry.startLine}` : `L${entry.startLine}-${entry.endLine}`;
 		const idCell = `#${String(entry.id).padStart(idWidth, " ")}`;
-		const kind = entry.baseLines !== undefined ? "  (3-way)" : "";
-		lines.push(`${idCell}  ${range}${kind}`);
+		const sides = conflictSides(entry).length;
+		const bases = conflictBases(entry).length;
+		lines.push(
+			`${idCell}  ${range}  (${sides} side${sides === 1 ? "" : "s"}, ${bases} base${bases === 1 ? "" : "s"}, ${entry.style ?? "git"})`,
+		);
 	}
 	return lines.join("\n");
-}
-
-function pickLabel(
-	entries: readonly ConflictEntry[],
-	get: (e: ConflictEntry) => string | undefined,
-): string | undefined {
-	for (const e of entries) {
-		const label = get(e);
-		if (label && label.trim().length > 0) return label;
-	}
-	return undefined;
-}
-
-function sectionsEqual(a: readonly string[], b: readonly string[]): boolean {
-	if (a.length !== b.length) return false;
-	for (let i = 0; i < a.length; i++) {
-		if (a[i] !== b[i]) return false;
-	}
-	return true;
 }
 
 function appendBody(out: string[], section: readonly string[]): void {

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -412,10 +412,10 @@ export interface ToolSession {
 	 *  calls. Lazily initialized by `getEditClipboard`. */
 	editClipboard?: Clipboard;
 
-	/** Per-session log of unresolved git merge conflict regions surfaced by
-	 *  `read`. Each entry gets a stable id N referenced by `write conflict://N`
-	 *  to splice the recorded region with replacement content. Lazily initialized
-	 *  by `getConflictHistory`. */
+	/** Per-session log of repository-verified Git/Jujutsu or standalone
+	 *  materialized conflict hunks surfaced by `read`. Each entry gets a stable
+	 *  id N referenced by `write conflict://N`. Lazily initialized by
+	 *  `getConflictHistory`. */
 	conflictHistory?: import("./conflict-detect").ConflictHistory;
 
 	/** Per-session ledger of post-edit LSP diagnostics already surfaced to the

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -58,15 +58,18 @@ import { CONVERTIBLE_EXTENSIONS, convertFileWithMarkit } from "../utils/markit";
 import { isSampleProfilePath, renderSampleProfile } from "../utils/sample-profile";
 import { buildDirectoryTree, type DirectoryTree } from "../workspace-tree";
 import {
+	type ConflictAuthority,
 	type ConflictEntry,
 	type ConflictScope,
 	formatConflictSummary,
 	formatConflictWarning,
 	getConflictHistory,
+	inspectConflictAuthority,
 	parseConflictUri,
 	renderConflictRegion,
 	scanConflictLines,
 	scanFileForConflicts,
+	scanRecordedConflictLines,
 } from "./conflict-detect";
 import { executeReadUrl, fetchReadUrl, parseReadUrlTarget } from "./fetch";
 import { type OutputMeta, resolveOutputMaxColumns } from "./output-meta";
@@ -1838,34 +1841,55 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 					}
 
 					if (!firstLineExceedsLimit && collectedLines.length > 0) {
-						const blocks = scanConflictLines(collectedLines, startLineDisplay);
-						if (blocks.length > 0) {
-							const history = getConflictHistory(this.session);
-							const displayPathForWarning = formatPathRelativeToCwd(absolutePath, this.session.cwd);
-							const entries = blocks.map(block =>
-								history.register({
-									absolutePath,
-									displayPath: displayPathForWarning,
-									...block,
-								}),
-							);
-							// Cheap full-file scan only when the window already showed
-							// at least one conflict — otherwise pay nothing on clean files.
-							let totalInFile = entries.length;
-							let scanTruncated = false;
+						const defaultBlocks = scanConflictLines(collectedLines, startLineDisplay);
+						const candidates =
+							defaultBlocks.length > 0 ? defaultBlocks : scanConflictLines(collectedLines, startLineDisplay, 1);
+						if (candidates.length > 0) {
+							let authority: ConflictAuthority | undefined;
 							try {
-								const fileScan = await scanFileForConflicts(absolutePath);
-								totalInFile = Math.max(entries.length, fileScan.blocks.length);
-								scanTruncated = fileScan.scanTruncated;
-							} catch {
-								// Best-effort enrichment; fall back to window-only count.
+								authority = await inspectConflictAuthority(absolutePath, signal);
+							} catch (error) {
+								logger.debug("Conflict authority lookup failed", {
+									path: absolutePath,
+									error: error instanceof Error ? error.message : String(error),
+								});
 							}
-							outputText += formatConflictWarning(entries, {
-								totalInFile,
-								displayPath: displayPathForWarning,
-								scanTruncated,
-							});
-							details.conflictCount = entries.length;
+							const blocks =
+								authority?.state === "recorded" && authority.kind === "file"
+									? scanRecordedConflictLines(collectedLines, startLineDisplay, authority)
+									: authority?.state === "unverified"
+										? defaultBlocks
+										: [];
+							if (authority && blocks.length > 0) {
+								const history = getConflictHistory(this.session);
+								const displayPathForWarning = formatPathRelativeToCwd(absolutePath, this.session.cwd);
+								const entries = blocks.map(block =>
+									history.register({
+										absolutePath,
+										displayPath: displayPathForWarning,
+										authority: authority.state === "recorded" ? authority.backend : "unverified",
+										...block,
+									}),
+								);
+								let totalInFile = entries.length;
+								let scanTruncated = false;
+								try {
+									const fileScan = await scanFileForConflicts(absolutePath, {
+										authority:
+											authority.state === "recorded" && authority.kind === "file" ? authority : undefined,
+									});
+									totalInFile = Math.max(entries.length, fileScan.blocks.length);
+									scanTruncated = fileScan.scanTruncated;
+								} catch {
+									// Best-effort enrichment; fall back to window-only count.
+								}
+								outputText += formatConflictWarning(entries, {
+									totalInFile,
+									displayPath: displayPathForWarning,
+									scanTruncated,
+								});
+								details.conflictCount = entries.length;
+							}
 						}
 					}
 
@@ -1946,22 +1970,68 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 		signal: AbortSignal | undefined,
 	): Promise<AgentToolResult<ReadToolDetails>> {
 		throwIfAborted(signal);
-		const scan = await scanFileForConflicts(absolutePath);
+		const authority = await inspectConflictAuthority(absolutePath, signal);
 		const displayPath = formatPathRelativeToCwd(absolutePath, this.session.cwd);
+		if (authority.state === "clean") {
+			return toolResult<ReadToolDetails>({
+				resolvedPath: absolutePath,
+				suffixResolution,
+				conflictCount: 0,
+			})
+				.text(`No repository-recorded conflicts in ${displayPath}.`)
+				.sourcePath(absolutePath)
+				.done();
+		}
+		if (authority.state === "recorded" && authority.kind === "other") {
+			return toolResult<ReadToolDetails>({
+				resolvedPath: absolutePath,
+				suffixResolution,
+				conflictCount: 1,
+			})
+				.text(
+					`The ${authority.backend} repository records a non-file conflict at ${displayPath}; it cannot be resolved by editing text markers.`,
+				)
+				.sourcePath(absolutePath)
+				.done();
+		}
+		if (await isProbablyBinary(absolutePath)) {
+			return toolResult<ReadToolDetails>({
+				resolvedPath: absolutePath,
+				suffixResolution,
+				conflictCount: authority.state === "recorded" ? 1 : 0,
+			})
+				.text(
+					authority.state === "recorded"
+						? `The ${authority.backend} repository records a file conflict at ${displayPath}, but its working-copy content is binary and cannot be resolved through text markers.`
+						: `No resolvable text conflict markers in binary file ${displayPath}.`,
+				)
+				.sourcePath(absolutePath)
+				.done();
+		}
+
+		const scan = await scanFileForConflicts(absolutePath, {
+			authority: authority.state === "recorded" && authority.kind === "file" ? authority : undefined,
+		});
 		const history = getConflictHistory(this.session);
 		const entries = scan.blocks.map(block =>
 			history.register({
 				absolutePath,
 				displayPath,
+				authority: authority.state === "recorded" ? authority.backend : "unverified",
 				...block,
 			}),
 		);
-
-		const summary =
-			entries.length === 0
-				? `No unresolved git merge conflicts in ${displayPath}.`
-				: formatConflictSummary(entries, { displayPath, scanTruncated: scan.scanTruncated });
-
+		let summary: string;
+		if (entries.length > 0) {
+			summary = formatConflictSummary(entries, { displayPath, scanTruncated: scan.scanTruncated });
+		} else if (authority.state === "recorded") {
+			summary =
+				authority.backend === "git"
+					? `${displayPath} is still recorded as conflicted by git, but its working-copy file has no valid conflict markers. The current file content will resolve it after staging the path.`
+					: `${displayPath} is still recorded as conflicted by jj, but its working-copy file has no valid conflict markers. The conflict cannot be resolved through \`conflict://\`; edit the working-copy file directly.`;
+		} else {
+			summary = `No unresolved conflict markers in ${displayPath}.`;
+		}
 		const details: ReadToolDetails = {
 			resolvedPath: absolutePath,
 			suffixResolution,

--- a/packages/coding-agent/src/tools/write.ts
+++ b/packages/coding-agent/src/tools/write.ts
@@ -45,6 +45,7 @@ import {
 	conflictRegionsEqual,
 	expandContentTokens,
 	getConflictHistory,
+	inspectConflictAuthority,
 	parseConflictUri,
 	spliceConflict,
 } from "./conflict-detect";
@@ -210,12 +211,9 @@ async function assertNotReadSelectorMisfire(target: string, content: string, cwd
 	throwReadSelectorMisfire(target, sel);
 }
 
-const BULK_DIRECTIVE_RE = /^#?(\d+)\s*[:=]\s*(@ours|@theirs|@base|@both)$/;
-/**
- * The head of a per-id directive line — `<id>:` / `<id>=` (optionally `#`-prefixed),
- * regardless of whether its value is a valid `@side` token. Used only to sharpen the
- * error message when a directive block is malformed (e.g. `15: some literal text`).
- */
+const CONFLICT_TERM_TOKEN = String.raw`@(?:(?:side|base)\/[1-9]\d*|ours|theirs|base|both)`;
+const CONFLICT_TERM_TOKEN_RE = new RegExp(`^${CONFLICT_TERM_TOKEN}$`);
+const BULK_DIRECTIVE_RE = new RegExp(String.raw`^#?(\d+)\s*[:=]\s*(${CONFLICT_TERM_TOKEN})$`);
 const BULK_DIRECTIVE_HEAD_RE = /^#?\d+\s*[:=]/;
 
 function truncateDirectiveLine(line: string): string {
@@ -223,18 +221,8 @@ function truncateDirectiveLine(line: string): string {
 }
 
 /**
- * Parse `conflict://*` per-id directive content: every non-empty line must be
- * `<id>: @side` (also accepted: `#<id> = @side`), where `@side` is one of
- * `@ours` / `@theirs` / `@base` / `@both`.
- *
- * Returns `null` only when NO line is directive-shaped (→ uniform bulk mode).
- * Throws on duplicate ids, and — critically — on a *partial* directive block:
- * content that mixes valid `<id>: @side` lines with lines that aren't. Without
- * that guard a per-id write carrying any non-token value (a literal or
- * multi-line replacement, e.g. `15: <multi-line content>`) fell through to
- * uniform bulk mode, which pasted the raw directive text verbatim into every
- * block and still reported success. Per-id bulk is token-only; literal or
- * multi-line replacements must go through individual `conflict://<N>` writes.
+ * Parse a token-only `conflict://*` directive block. Each non-empty line
+ * selects one Git named term or indexed Jujutsu term for one conflict id.
  */
 function parseBulkDirectives(content: string): Map<number, string> | null {
 	const map = new Map<number, string>();
@@ -260,13 +248,12 @@ function parseBulkDirectives(content: string): Map<number, string> | null {
 	if (stray.length > 0) {
 		const sample = stray[0]!;
 		const tokenHint = BULK_DIRECTIVE_HEAD_RE.test(sample)
-			? `Per-id bulk only accepts the tokens @ours/@theirs/@base/@both — one side per id, single line. `
+			? `Per-id bulk only accepts Git @ours/@theirs/@base/@both or Jujutsu @side/<N>/@base/<N> terms — one term per id, single line. `
 			: "";
 		throw new ToolError(
-			`Malformed \`conflict://*\` per-id block: ${stray.length} line(s) are not \`<id>: @side\` directives (first: \`${truncateDirectiveLine(sample)}\`). ` +
+			`Malformed \`conflict://*\` per-id block: ${stray.length} line(s) are not recognized \`<id>: <term>\` directives (first: \`${truncateDirectiveLine(sample)}\`). ` +
 				tokenHint +
-				`Literal or multi-line replacement content isn't supported in a per-id block — resolve those blocks with individual \`write({ path: "conflict://<N>", content })\` calls (you can issue several at once). ` +
-				`For a pure pick-a-side pass, make every non-empty line \`<id>: @ours\` (or @theirs/@base/@both).`,
+				`Resolve literal or combined text with individual \`conflict://<N>\` writes.`,
 		);
 	}
 	return map;
@@ -301,6 +288,30 @@ function resolveBulkDirectives(raw: string, stripped: string): Map<number, strin
 		throw rawError;
 	}
 	return rawResult ?? parseBulkDirectives(stripped);
+}
+
+async function assertConflictAuthorityCurrent(entry: ConflictEntry, signal: AbortSignal | undefined): Promise<void> {
+	if (entry.authority !== "git" && entry.authority !== "jj") return;
+	const recordedBackend = entry.authority;
+	const authority = await inspectConflictAuthority(entry.absolutePath, signal);
+	if (
+		authority.state === "recorded" &&
+		authority.kind === "file" &&
+		authority.backend === recordedBackend &&
+		authority.regions.some(
+			region =>
+				region.startLine === entry.startLine &&
+				region.endLine === entry.endLine &&
+				region.markerLength === entry.markerLength &&
+				region.sides.length === entry.sides?.length &&
+				region.bases.length === entry.bases?.length,
+		)
+	) {
+		return;
+	}
+	throw new ToolError(
+		`Conflict #${entry.id} is no longer recorded as an unresolved file conflict by ${recordedBackend}. Re-read '${entry.displayPath}' before writing.`,
+	);
 }
 
 const writeSchema = type({
@@ -853,6 +864,7 @@ export class WriteTool implements AgentTool<typeof writeSchema, WriteToolDetails
 		if (!(await fs.exists(absolutePath))) {
 			throw new ToolError(`Conflict #${entry.id} target '${entry.displayPath}' no longer exists.`);
 		}
+		await assertConflictAuthorityCurrent(entry, signal);
 
 		const expanded = expandContentTokens(replacementContent, entry);
 		const originalText = await Bun.file(absolutePath).text();
@@ -887,14 +899,13 @@ export class WriteTool implements AgentTool<typeof writeSchema, WriteToolDetails
 			entry.startLine === entry.endLine
 				? `line ${entry.startLine}`
 				: `lines ${entry.startLine}\u2013${entry.endLine}`;
-		const summary = `Resolved conflict #${entry.id} at ${range} in ${entry.displayPath}.`;
+		const summary = `Resolved materialized conflict hunk #${entry.id} at ${range} in ${entry.displayPath}.`;
 		let resultText = header ? `${header}\n${summary}` : summary;
+		if (entry.authority === "git") {
+			resultText += "\nThe Git index remains unmerged until the path is staged.";
+		}
 		if (stripped) {
 			resultText += `\nNote: auto-stripped hashline display prefixes from content before writing.`;
-		}
-		const echoTrimmed = splice.trimmedLeading + splice.trimmedTrailing;
-		if (echoTrimmed > 0) {
-			resultText += `\nNote: dropped ${echoTrimmed} content line(s) that duplicated the code adjacent to the conflict region — writes replace only the marker block; surrounding lines stay in place.`;
 		}
 
 		return {
@@ -926,16 +937,13 @@ export class WriteTool implements AgentTool<typeof writeSchema, WriteToolDetails
 	 * Bulk-resolve every registered conflict via `conflict://*`.
 	 *
 	 * Entries are grouped by file and applied bottom-up by recorded start
-	 * line so each splice keeps later anchors valid. `content` tokens are
-	 * expanded *per entry*, so `content: "@ours"` keeps each block's own
-	 * ours side rather than collapsing every conflict to the first
-	 * block's ours.
+	 * line so later anchors stay valid. Indexed side/base tokens expand per
+	 * entry, preserving each conflict's own arity and term contents.
 	 *
-	 * All-or-nothing semantics within a file: if any splice for a file
-	 * fails (stale anchors, missing base for `@base`, etc.), that file is
-	 * left untouched and the error is surfaced. Files that succeed are
-	 * still written. The result text reports per-file counts so the agent
-	 * can re-read the failed files and retry.
+	 * All-or-nothing semantics within a file: if any splice fails (stale
+	 * anchors, out-of-range term, etc.), that file is left untouched and the
+	 * error is surfaced. Files that succeed are still written, with per-file
+	 * counts in the result.
 	 */
 	async #resolveAllConflicts(
 		replacementContent: string,
@@ -951,13 +959,19 @@ export class WriteTool implements AgentTool<typeof writeSchema, WriteToolDetails
 			);
 		}
 
-		// Per-id directive mode: content made solely of `<id>: @side` lines
-		// resolves each listed conflict with that side in one call. Ideal for
+		// Per-id directive mode: content made solely of `<id>: <term>` lines
+		// resolves each listed conflict with that term in one call. Ideal for
 		// merge-hell files where dozens of pick-one blocks each need their own
 		// winner — one call instead of one write per conflict. Parsed from the
 		// PRE-strip content: hashline prefix stripping would otherwise eat the
 		// `<id>: ` heads as echoed line numbers.
 		const directives = resolveBulkDirectives(rawContent, replacementContent);
+		const sharedTerm = replacementContent.trim();
+		if (!directives && !CONFLICT_TERM_TOKEN_RE.test(sharedTerm)) {
+			throw new ToolError(
+				"`conflict://*` only accepts a shared Git @ours/@theirs/@base/@both or Jujutsu @side/<N>/@base/<N> term, or explicit `<id>: <term>` directives. Use individual conflict writes for literal or combined resolutions.",
+			);
+		}
 		if (directives) {
 			const known = new Set(allEntries.map(entry => entry.id));
 			const unknown = [...directives.keys()].filter(id => !known.has(id));
@@ -968,8 +982,6 @@ export class WriteTool implements AgentTool<typeof writeSchema, WriteToolDetails
 			}
 		}
 		const selectedEntries = directives ? allEntries.filter(entry => directives.has(entry.id)) : allEntries;
-		const contentFor = (entry: ConflictEntry): string =>
-			directives ? (directives.get(entry.id) as string) : replacementContent;
 
 		const byFile = new Map<string, ConflictEntry[]>();
 		for (const entry of selectedEntries) {
@@ -978,13 +990,13 @@ export class WriteTool implements AgentTool<typeof writeSchema, WriteToolDetails
 			byFile.set(entry.absolutePath, bucket);
 		}
 
-		const succeededFiles: { displayPath: string; count: number; header?: string }[] = [];
+		const succeededFiles: { displayPath: string; count: number; header?: string; authority?: "git" | "jj" }[] = [];
 		const failedFiles: { displayPath: string; count: number; error: string }[] = [];
 		let totalResolvedIds = 0;
-		let totalEchoTrimmed = 0;
 
 		for (const [absolutePath, fileEntries] of byFile) {
 			const sample = fileEntries[0]!;
+			const authoritativeEntry = fileEntries.find(entry => entry.authority === "git" || entry.authority === "jj");
 			if (!(await fs.exists(absolutePath))) {
 				failedFiles.push({
 					displayPath: sample.displayPath,
@@ -1001,6 +1013,7 @@ export class WriteTool implements AgentTool<typeof writeSchema, WriteToolDetails
 			const staleEntries: ConflictEntry[] = [];
 			let failure: string | undefined;
 			try {
+				if (authoritativeEntry) await assertConflictAuthorityCurrent(authoritativeEntry, signal);
 				text = await Bun.file(absolutePath).text();
 			} catch (error) {
 				failedFiles.push({
@@ -1012,10 +1025,10 @@ export class WriteTool implements AgentTool<typeof writeSchema, WriteToolDetails
 			}
 			for (const entry of fileEntries) {
 				try {
-					const expanded = expandContentTokens(contentFor(entry), entry);
+					const entryContent = directives ? directives.get(entry.id)! : sharedTerm;
+					const expanded = expandContentTokens(entryContent, entry);
 					const splice = spliceConflict(text, entry, expanded);
 					text = splice.text;
-					totalEchoTrimmed += splice.trimmedLeading + splice.trimmedTrailing;
 					resolvedEntries.push(entry);
 				} catch (error) {
 					// A locate-miss for a region an earlier entry already spliced
@@ -1045,7 +1058,12 @@ export class WriteTool implements AgentTool<typeof writeSchema, WriteToolDetails
 			for (const entry of resolvedEntries) history.invalidate(entry.id);
 			for (const entry of staleEntries) history.invalidate(entry.id);
 			const header = maybeWriteSnapshotHeader(this.session, absolutePath, text);
-			succeededFiles.push({ displayPath: sample.displayPath, count: resolvedEntries.length, header });
+			succeededFiles.push({
+				displayPath: sample.displayPath,
+				count: resolvedEntries.length,
+				header,
+				authority: authoritativeEntry?.authority === "unverified" ? undefined : authoritativeEntry?.authority,
+			});
 			totalResolvedIds += resolvedEntries.length;
 		}
 
@@ -1059,16 +1077,14 @@ export class WriteTool implements AgentTool<typeof writeSchema, WriteToolDetails
 			for (const file of succeededFiles) {
 				summaryLines.push(`  ${file.displayPath}: ${file.count} ${conflictWord(file.count)}`);
 			}
+			if (succeededFiles.some(file => file.authority === "git")) {
+				summaryLines.push("Git index entries remain unmerged until the resolved paths are staged.");
+			}
 		}
 		if (directives && selectedEntries.length < allEntries.length) {
 			const remaining = allEntries.filter(entry => !directives.has(entry.id)).map(entry => `#${entry.id}`);
 			summaryLines.push(
 				`Directive mode: ${remaining.length} unlisted ${conflictWord(remaining.length)} still registered (${remaining.join(", ")}).`,
-			);
-		}
-		if (totalEchoTrimmed > 0) {
-			summaryLines.push(
-				`Note: dropped ${totalEchoTrimmed} content line(s) that duplicated code adjacent to conflict regions — writes replace only the marker block; surrounding lines stay in place.`,
 			);
 		}
 		if (failedFiles.length > 0) {
@@ -1218,8 +1234,10 @@ export class WriteTool implements AgentTool<typeof writeSchema, WriteToolDetails
 			const conflictUri = parseConflictUri(path);
 			if (conflictUri) {
 				if (conflictUri.scope) {
+					const namedScope = path.match(/\/(ours|theirs|base)$/)?.[1];
+					const scope = namedScope ?? `${conflictUri.scope.role}/${conflictUri.scope.index}`;
 					throw new ToolError(
-						`Conflict URI scope '/${conflictUri.scope}' is read-only — read \`conflict://${conflictUri.id}/${conflictUri.scope}\` to inspect that side. To write, drop the scope (\`conflict://${conflictUri.id}\`) and put the chosen content (or shorthand like \`@${conflictUri.scope}\`) in \`content\`.`,
+						`Conflict URI scope '/${scope}' is read-only. Write to \`conflict://${conflictUri.id}\` and put \`@${scope}\` in content to choose that term.`,
 					);
 				}
 				emitWriteProgress(onUpdate, cleanContent, path);

--- a/packages/coding-agent/test/tools/conflict-detect.test.ts
+++ b/packages/coding-agent/test/tools/conflict-detect.test.ts
@@ -103,6 +103,160 @@ describe("scanConflictLines", () => {
 		expect(blocks[0].oursLines).toEqual(["ours"]);
 		expect(blocks[0].theirsLines).toEqual(["theirs"]);
 	});
+
+	it("parses Jujutsu diff markers into indexed sides and bases", () => {
+		const blocks = scanConflictLines(
+			[
+				"<<<<<<< conflict 1 of 1",
+				"%%%%%%% diff from: merge base",
+				`${"\\".repeat(7)}        to: commit A`,
+				" apple",
+				"-grape",
+				"+grapefruit",
+				" orange",
+				"+++++++ commit B",
+				"APPLE",
+				"GRAPE",
+				"ORANGE",
+				">>>>>>> conflict 1 of 1 ends",
+			],
+			1,
+		);
+		expect(blocks).toHaveLength(1);
+		expect(blocks[0].style).toBe("jj-diff");
+		expect(blocks[0].sides?.map(section => section.label)).toEqual(["commit A", "commit B"]);
+		expect(blocks[0].sides?.map(section => section.lines)).toEqual([
+			["apple", "grapefruit", "orange"],
+			["APPLE", "GRAPE", "ORANGE"],
+		]);
+		expect(blocks[0].bases?.map(section => section.label)).toEqual(["merge base"]);
+		expect(blocks[0].bases?.map(section => section.lines)).toEqual([["apple", "grape", "orange"]]);
+	});
+
+	it("parses multi-sided Jujutsu snapshot markers", () => {
+		const blocks = scanConflictLines(
+			[
+				"<<<<<<< conflict 1 of 1",
+				"+++++++ side one",
+				"one",
+				"------- base one",
+				"base-1",
+				"+++++++ side two",
+				"two",
+				"------- base two",
+				"base-2",
+				"+++++++ side three",
+				"three",
+				">>>>>>> conflict 1 of 1 ends",
+			],
+			1,
+		);
+		expect(blocks[0].style).toBe("jj-snapshot");
+		expect(blocks[0].sides?.map(section => section.lines)).toEqual([["one"], ["two"], ["three"]]);
+		expect(blocks[0].bases?.map(section => section.lines)).toEqual([["base-1"], ["base-2"]]);
+	});
+
+	it("accepts conflict markers longer than seven characters", () => {
+		const marker = 11;
+		const blocks = scanConflictLines(
+			[
+				`${"<".repeat(marker)} left`,
+				"ours",
+				`${"|".repeat(marker)} base`,
+				"ancestor",
+				"=".repeat(marker),
+				"theirs",
+				`${">".repeat(marker)} right`,
+			],
+			1,
+		);
+		expect(blocks[0].markerLength).toBe(marker);
+		expect(blocks[0].sides?.map(section => section.lines)).toEqual([["ours"], ["theirs"]]);
+	});
+
+	it("requires exact internal and closing marker lengths for Git conflicts", () => {
+		const blocks = scanConflictLines(
+			["<<<<<<< HEAD", "left", "========", "=======", "right", ">>>>>>>> literal", ">>>>>>> branch"],
+			1,
+		);
+		expect(blocks).toHaveLength(1);
+		expect(blocks[0].sides?.map(section => section.lines)).toEqual([
+			["left", "========"],
+			["right", ">>>>>>>> literal"],
+		]);
+	});
+
+	it("prefers a complete Git block when ours starts with a Jujutsu-looking marker", () => {
+		const blocks = scanConflictLines(
+			["<<<<<<< HEAD", "+++++++ patch", "left", "=======", "right", ">>>>>>> branch"],
+			1,
+		);
+		expect(blocks).toHaveLength(1);
+		expect(blocks[0].style).toBe("git");
+		expect(blocks[0].sides?.map(section => section.lines)).toEqual([["+++++++ patch", "left"], ["right"]]);
+	});
+
+	it("rejects Jujutsu grammar when repository authority allows Git only", () => {
+		const blocks = scanConflictLines(
+			["<<<<<<< conflict", "+++++++ side one", "left", "+++++++ side two", "right", ">>>>>>> conflict ends"],
+			1,
+			7,
+			true,
+			"git",
+		);
+		expect(blocks).toEqual([]);
+	});
+
+	it("keeps a shorter opener-looking line inside a lengthened Jujutsu term", () => {
+		const markerLength = 11;
+		const blocks = scanConflictLines(
+			[
+				`${"<".repeat(markerLength)} conflict 1 of 1`,
+				`${"+".repeat(markerLength)} left`,
+				"left body",
+				"<<<<<<< literal",
+				`${"-".repeat(markerLength)} base`,
+				"base body",
+				`${"+".repeat(markerLength)} right`,
+				"right body",
+				`${">".repeat(markerLength)} conflict 1 of 1 ends`,
+			],
+			1,
+		);
+		expect(blocks).toHaveLength(1);
+		expect(blocks[0].sides?.map(section => section.lines)).toEqual([
+			["left body", "<<<<<<< literal"],
+			["right body"],
+		]);
+		expect(blocks[0].bases?.map(section => section.lines)).toEqual([["base body"]]);
+	});
+
+	it("accepts Jujutsu term and closing markers longer than the opener", () => {
+		const blocks = scanConflictLines(
+			[
+				"<<<<<<< conflict 1 of 1",
+				"++++++++ left",
+				"left body",
+				"-------- base",
+				"base body",
+				"++++++++ right",
+				"right body",
+				">>>>>>>> conflict 1 of 1 ends",
+			],
+			1,
+		);
+		expect(blocks).toHaveLength(1);
+		expect(blocks[0].sides?.map(section => section.lines)).toEqual([["left body"], ["right body"]]);
+		expect(blocks[0].bases?.map(section => section.lines)).toEqual([["base body"]]);
+	});
+
+	it("accepts short marker sizes only when explicitly requested", () => {
+		const lines = ["<<< HEAD", "ours", "===", "theirs", ">>> branch"];
+		expect(scanConflictLines(lines, 1)).toEqual([]);
+		const [block] = scanConflictLines(lines, 1, 1);
+		expect(block.markerLength).toBe(3);
+		expect(block.sides?.map(section => section.lines)).toEqual([["ours"], ["theirs"]]);
+	});
 });
 
 describe("ConflictHistory", () => {
@@ -196,15 +350,18 @@ describe("parseConflictUri", () => {
 		expect(parseConflictUri("conflict://")).toBeNull();
 	});
 
-	it("parses an optional scope segment", () => {
-		expect(parseConflictUri("conflict://1/ours")).toEqual({ id: 1, scope: "ours" });
-		expect(parseConflictUri("conflict://2/theirs")).toEqual({ id: 2, scope: "theirs" });
-		expect(parseConflictUri("conflict://3/base")).toEqual({ id: 3, scope: "base" });
+	it("parses Git named and Jujutsu indexed scopes", () => {
+		expect(parseConflictUri("conflict://1/ours")).toEqual({ id: 1, scope: { role: "side", index: 1 } });
+		expect(parseConflictUri("conflict://2/theirs")).toEqual({ id: 2, scope: { role: "side", index: 2 } });
+		expect(parseConflictUri("conflict://3/base")).toEqual({ id: 3, scope: { role: "base", index: 1 } });
+		expect(parseConflictUri("conflict://1/side/1")).toEqual({ id: 1, scope: { role: "side", index: 1 } });
+		expect(parseConflictUri("conflict://2/side/3")).toEqual({ id: 2, scope: { role: "side", index: 3 } });
+		expect(parseConflictUri("conflict://3/base/2")).toEqual({ id: 3, scope: { role: "base", index: 2 } });
 	});
 
-	it("rejects unknown scope tokens", () => {
-		expect(() => parseConflictUri("conflict://1/both")).toThrow(/scope must be one of/);
-		expect(() => parseConflictUri("conflict://1/extras")).toThrow(/scope must be one of/);
+	it("rejects malformed scope tokens", () => {
+		expect(() => parseConflictUri("conflict://1/side/0")).toThrow(/scope/);
+		expect(() => parseConflictUri("conflict://1/mine")).toThrow(/scope/);
 	});
 
 	it("parses the bulk wildcard `conflict://*`", () => {
@@ -232,9 +389,9 @@ describe("parseConflictUri", () => {
 			id: "*",
 			recoveredPrefix: "packages/coding-agent/src/x.ts",
 		});
-		expect(parseConflictUri("a.ts:conflict://2/theirs")).toEqual({
+		expect(parseConflictUri("a.ts:conflict://2/side/2")).toEqual({
 			id: 2,
-			scope: "theirs",
+			scope: { role: "side", index: 2 },
 			recoveredPrefix: "a.ts",
 		});
 	});
@@ -314,159 +471,51 @@ describe("spliceConflict", () => {
 		const result = spliceConflict(crlfNoEof, entry, "resolved");
 		expect(result.text).toBe("before\r\nresolved");
 	});
-});
 
-describe("spliceConflict boundary-echo repair", () => {
-	// The 08-multi-file-rename shape: the two lines after the closer are the
-	// function tail models love to re-emit when they paste the "whole
-	// resolved function" as the replacement.
-	const fnLines = [
-		"const queue = [];",
-		"<<<<<<< HEAD",
-		"export function scheduleTask(task, priority = 0) {",
-		"\tif (dupe(task)) {",
-		"\t\treturn;",
-		"\t}",
-		"=======",
-		"export function enqueueTask(task) {",
-		"\tif (queued.has(task.id)) {",
-		"\t\treturn;",
-		"\t}",
-		">>>>>>> feature",
-		"\tqueue.push(task);",
-		"}",
-		"",
-	];
-	const fnEntry = makeEntry({
-		startLine: 2,
-		separatorLine: 7,
-		endLine: 12,
-		oursLabel: "HEAD",
-		theirsLabel: "feature",
-		oursLines: fnLines.slice(2, 6),
-		theirsLines: fnLines.slice(7, 11),
-	});
-
-	it("drops a multi-line trailing echo of the context below the region", () => {
-		const replacement = [
-			"export function scheduleTask(task, priority = 0) {",
-			"\tif (queued.has(task.id)) {",
-			"\t\treturn;",
-			"\t}",
-			"\tqueue.push(task);",
-			"}",
-		].join("\n");
-		const result = spliceConflict(fnLines.join("\n"), fnEntry, replacement);
-		expect(result.trimmedTrailing).toBe(2);
-		expect(result.trimmedLeading).toBe(0);
-		expect(result.text).toBe(
-			[
-				"const queue = [];",
-				"export function scheduleTask(task, priority = 0) {",
-				"\tif (queued.has(task.id)) {",
-				"\t\treturn;",
-				"\t}",
-				"\tqueue.push(task);",
-				"}",
-				"",
-			].join("\n"),
-		);
-	});
-
-	// The 02-rename-vs-limits shape: a lone `}` echoed after a body-only region.
-	const bodyLines = [
-		"function nextDelay(a) {",
-		"<<<<<<< HEAD",
-		"\tconst delay = BASE * 2 ** a;",
-		"\treturn Math.min(delay, 10_000);",
-		"=======",
-		"\tconst d = B * 2 ** a;",
-		"\treturn Math.min(d, 30_000);",
-		">>>>>>> tune",
-		"}",
-		"",
-	];
-	const bodyEntry = makeEntry({
-		startLine: 2,
-		separatorLine: 5,
-		endLine: 8,
-		oursLabel: "HEAD",
-		theirsLabel: "tune",
-		oursLines: bodyLines.slice(2, 4),
-		theirsLines: bodyLines.slice(5, 7),
-	});
-
-	it("drops a single-line echo when it fixes the region's delimiter balance", () => {
-		const replacement = ["\tconst delay = BASE * 2 ** a;", "\treturn Math.min(delay, 30_000);", "}"].join("\n");
-		const result = spliceConflict(bodyLines.join("\n"), bodyEntry, replacement);
-		expect(result.trimmedTrailing).toBe(1);
-		expect(result.text).toBe(
-			[
-				"function nextDelay(a) {",
-				"\tconst delay = BASE * 2 ** a;",
-				"\treturn Math.min(delay, 30_000);",
-				"}",
-				"",
-			].join("\n"),
-		);
-	});
-
-	it("keeps a single-line echo when the delimiter balance is already consistent", () => {
-		const file = ["start", "<<<<<<< HEAD", "a", "=======", "b", ">>>>>>> x", "done();", ""].join("\n");
-		const entry = makeEntry({
-			startLine: 2,
-			separatorLine: 4,
-			endLine: 6,
-			oursLabel: "HEAD",
-			theirsLabel: "x",
-			oursLines: ["a"],
-			theirsLines: ["b"],
-		});
-		const result = spliceConflict(file, entry, "merged\ndone();");
-		expect(result.trimmedTrailing).toBe(0);
-		expect(result.text).toBe("start\nmerged\ndone();\ndone();\n");
-	});
-
-	it("drops a multi-line leading echo of the context above the region", () => {
+	it("preserves a selected jj term's ending EOL at an unterminated conflict EOF", () => {
 		const file = [
-			"// header",
-			"const queue = [];",
-			"<<<<<<< HEAD",
-			"a",
-			"=======",
-			"b",
-			">>>>>>> x",
-			"tail",
-			"",
+			"<<<<<<< conflict 1 of 1",
+			"+++++++ side A (no terminating newline)",
+			"grapefruit",
+			"%%%%%%% diff from: base (no terminating newline)",
+			`${"\\".repeat(7)}        to: side B`,
+			" grape",
+			"+",
+			">>>>>>> conflict 1 of 1 ends",
 		].join("\n");
-		const entry = makeEntry({
-			startLine: 3,
-			separatorLine: 5,
-			endLine: 7,
-			oursLabel: "HEAD",
-			theirsLabel: "x",
-			oursLines: ["a"],
-			theirsLines: ["b"],
-		});
-		const result = spliceConflict(file, entry, "// header\nconst queue = [];\nmerged");
-		expect(result.trimmedLeading).toBe(2);
-		expect(result.text).toBe("// header\nconst queue = [];\nmerged\ntail\n");
-	});
+		const [block] = scanConflictLines(file.split("\n"), 1);
+		const entry: ConflictEntry = {
+			...block,
+			id: 1,
+			absolutePath: "/abs/file",
+			displayPath: "file",
+		};
+		const withEol = expandContentTokens("@side/2", entry);
+		expect(withEol).toBe("grape\n");
+		expect(spliceConflict(file, entry, withEol).text).toBe("grape\n");
+		expect(spliceConflict(file, entry, expandContentTokens("@side/1", entry)).text).toBe("grapefruit");
 
-	it("repairs echoes in CRLF files without breaking EOL round-trip", () => {
-		const crlf = bodyLines.join("\r\n");
-		const replacement = ["\tconst delay = BASE * 2 ** a;", "\treturn Math.min(delay, 30_000);", "}"].join("\n");
-		const result = spliceConflict(crlf, bodyEntry, replacement);
-		expect(result.trimmedTrailing).toBe(1);
-		expect(result.text).toBe(
-			[
-				"function nextDelay(a) {",
-				"\tconst delay = BASE * 2 ** a;",
-				"\treturn Math.min(delay, 30_000);",
-				"}",
-				"",
-			].join("\r\n"),
-		);
+		const snapshotWithEol = [
+			"<<<<<<< conflict 1 of 1",
+			"%%%%%%% diff from: base (no terminating newline)",
+			`${"\\".repeat(7)}        to: side A (no terminating newline)`,
+			"-grape",
+			"+grapefruit",
+			"+++++++ side B",
+			"GRAPE",
+			"",
+			">>>>>>> conflict 1 of 1 ends",
+		].join("\n");
+		const [snapshotBlock] = scanConflictLines(snapshotWithEol.split("\n"), 1);
+		const snapshotEntry: ConflictEntry = {
+			...snapshotBlock,
+			id: 2,
+			absolutePath: "/abs/file",
+			displayPath: "file",
+		};
+		const snapshotSide = expandContentTokens("@side/2", snapshotEntry);
+		expect(snapshotSide).toBe("GRAPE\n");
+		expect(spliceConflict(snapshotWithEol, snapshotEntry, snapshotSide).text).toBe("GRAPE\n");
 	});
 });
 
@@ -528,26 +577,12 @@ describe("renderConflictRegion", () => {
 		expect(region.lines[region.lines.length - 1]).toBe(">>>>>>>");
 	});
 
-	it("returns just the ours body with the line number after `<<<<<<<`", () => {
-		const region = renderConflictRegion(twoWay, "ours");
-		expect(region.startLine).toBe(11);
-		expect(region.lines).toEqual(["ours-1", "ours-2"]);
-	});
-
-	it("returns just the theirs body with the line number after `=======`", () => {
-		const region = renderConflictRegion(twoWay, "theirs");
-		expect(region.startLine).toBe(14);
-		expect(region.lines).toEqual(["theirs-1"]);
-	});
-
-	it("returns just the base body for a diff3 conflict", () => {
-		const region = renderConflictRegion(threeWay, "base");
-		expect(region.startLine).toBe(23);
-		expect(region.lines).toEqual(["b"]);
-	});
-
-	it("rejects `base` scope for a 2-way conflict", () => {
-		expect(() => renderConflictRegion(twoWay, "base")).toThrow(/no base section/);
+	it("returns normalized terms and rejects out-of-range terms", () => {
+		const second = renderConflictRegion(twoWay, { role: "side", index: 2 });
+		expect(second.startLine).toBe(14);
+		expect(second.lines).toEqual(["theirs-1"]);
+		expect(() => renderConflictRegion(twoWay, { role: "base", index: 1 })).toThrow(/0 bases/);
+		expect(() => renderConflictRegion(twoWay, { role: "side", index: 3 })).toThrow(/2 sides/);
 	});
 });
 
@@ -556,7 +591,7 @@ describe("formatConflictWarning", () => {
 		expect(formatConflictWarning([])).toBe("");
 	});
 
-	it("renders the compact diff-style block with labels aggregated at top", () => {
+	it("preserves Git ours/theirs/base terminology and resolution tokens", () => {
 		const entry = makeEntry({
 			id: 7,
 			startLine: 12,
@@ -566,99 +601,57 @@ describe("formatConflictWarning", () => {
 			theirsLabel: "feature/x",
 			oursLines: ["a", "b"],
 			theirsLines: ["c"],
+			baseLines: ["ancestor"],
+			baseLabel: "merge base",
 		});
 		const text = formatConflictWarning([entry]);
 		expect(text).toContain("⚠ 1 unresolved conflict detected");
-		expect(text).toContain("- ours = HEAD");
-		expect(text).toContain("- theirs = feature/x");
-		expect(text).toContain("──── #7  L12-16 ────");
-		expect(text).toContain("<<< ours");
-		expect(text).toContain("\na\n");
-		expect(text).toContain("\nb\n");
-		expect(text).toContain(">>> theirs");
-		expect(text).toContain("\nc");
-		// NOTICE line with shorthand tokens.
-		expect(text).toContain("NOTICE: Inspect a block by reading `conflict://<N>`");
-		expect(text).toContain('`write({ path: "conflict://<N>", content })`');
-		expect(text).toContain('`write({ path: "conflict://*", content })`');
+		expect(text).toContain("──── #7  L12-16  git ────");
+		expect(text).toContain("<<< ours  HEAD");
+		expect(text).toContain(">>> theirs  feature/x");
+		expect(text).toContain("=== base  merge base");
 		expect(text).toContain("@ours");
-		expect(text).toContain("@theirs");
-		// No per-block invocation; the old verbose header is gone.
-		expect(text).not.toContain('write({ path: "conflict://7"');
-		expect(text).not.toContain("--- ours");
-		expect(text).not.toContain("[conflict #7]");
+		expect(text).toContain("@both");
+		expect(text).not.toContain("@side/<M>");
 	});
 
-	it("pluralizes the summary count and emits one block per entry", () => {
-		const e1 = makeEntry({ id: 1 });
-		const e2 = makeEntry({ id: 2, startLine: 20, separatorLine: 22, endLine: 24 });
-		const text = formatConflictWarning([e1, e2]);
-		expect(text).toContain("⚠ 2 unresolved conflicts detected");
-		expect(text).toContain("──── #1  L2-6 ────");
-		expect(text).toContain("──── #2  L20-24 ────");
-	});
+	it("renders every side of a multi-sided Jujutsu conflict", () => {
+		const [block] = scanConflictLines(
+			[
+				"<<<<<<< conflict 1 of 1",
+				"+++++++ one",
+				"a",
+				"------- old",
+				"b",
+				"+++++++ two",
+				"c",
+				"------- older",
+				"d",
+				"+++++++ three",
+				"e",
+				">>>>>>> conflict 1 of 1 ends",
+			],
 
-	it("collapses base ≡ ours by skipping the redundant body", () => {
-		const entry = makeEntry({
-			id: 3,
-			baseLines: ["o"],
-			oursLines: ["o"],
-			theirsLines: ["t"],
-			baseLabel: "ancestor",
-		});
+			1,
+		);
+		const text = formatConflictWarning([{ ...block, id: 2, absolutePath: "/tmp/f", displayPath: "f" }]);
+		expect(text).toContain("+++ side/3  three");
+		expect(text).toContain("--- base/2  older");
+	});
+	it("uses indexed terms for Jujutsu authority with Git-style markers", () => {
+		const entry = makeEntry({ authority: "jj", style: "git" });
 		const text = formatConflictWarning([entry]);
-		expect(text).toContain("=== base ≡ ours");
-		// Base body should not be duplicated.
-		const baseHeaderIdx = text.indexOf("=== base ≡ ours");
-		const theirsHeaderIdx = text.indexOf(">>> theirs");
-		expect(theirsHeaderIdx).toBeGreaterThan(baseHeaderIdx);
-		const between = text.slice(baseHeaderIdx + "=== base ≡ ours".length, theirsHeaderIdx).trim();
-		expect(between).toBe("");
+		expect(text).toContain("+++ side/1");
+		expect(text).toContain("@side/<M>");
+		expect(text).not.toContain("@ours");
 	});
 
-	it("collapses base ≡ theirs the same way", () => {
-		const entry = makeEntry({
-			id: 4,
-			baseLines: ["t"],
-			oursLines: ["o"],
-			theirsLines: ["t"],
-		});
-		const text = formatConflictWarning([entry]);
-		expect(text).toContain("=== base ≡ theirs");
-	});
-
-	it("prints the base body when base differs from both sides", () => {
-		const entry = makeEntry({
-			id: 5,
-			baseLines: ["b"],
-			oursLines: ["o"],
-			theirsLines: ["t"],
-			baseLabel: "common ancestor",
-		});
-		const text = formatConflictWarning([entry]);
-		expect(text).toContain("- base = common ancestor");
-		expect(text).toContain("=== base");
-		expect(text).not.toContain("=== base ≡");
-		expect(text).toContain("\nb\n");
-	});
-
-	it("omits the ours/theirs label lines when no entry has labels", () => {
-		const entry = makeEntry({ oursLabel: undefined, theirsLabel: undefined });
-		const text = formatConflictWarning([entry]);
-		expect(text).not.toContain("- ours =");
-		expect(text).not.toContain("- theirs =");
-	});
-
-	it("caps the body preview at PREVIEW_SIDE_LINES with a `… N more lines` footer", () => {
-		const ours = Array.from({ length: 20 }, (_v, i) => `o${i}`);
-		const entry = makeEntry({ id: 6, oursLines: ours, theirsLines: ["t"] });
-		const text = formatConflictWarning([entry]);
-		expect(text).toContain("\no0\n");
-		expect(text).toContain("\no5\n");
-		// 6 lines shown, so 14 remain.
+	it("caps each term preview at six lines", () => {
+		const lines = Array.from({ length: 20 }, (_value, index) => `line-${index}`);
+		const text = formatConflictWarning([makeEntry({ oursLines: lines })]);
+		expect(text).toContain("line-5");
 		expect(text).toContain("… (14 more lines)");
-		// Lines past the cap are dropped from the preview.
-		expect(text).not.toContain("\no6\n");
+		expect(text).not.toContain("\nline-6\n");
 	});
 });
 
@@ -672,30 +665,38 @@ describe("expandContentTokens", () => {
 		expect(expandContentTokens("hand-written\nline\n", entry)).toBe("hand-written\nline\n");
 	});
 
-	it("expands a bare `@ours` token", () => {
-		expect(expandContentTokens("@ours", entry)).toBe("o1\no2");
-	});
-
-	it("expands `@theirs` and `@both` line tokens", () => {
-		expect(expandContentTokens("@theirs", entry)).toBe("t1");
-		expect(expandContentTokens("@both", entry)).toBe("o1\no2\nt1");
-	});
-
-	it("mixes tokens with literal lines", () => {
-		expect(expandContentTokens("// keep both\n@ours\n@theirs", entry)).toBe("// keep both\no1\no2\nt1");
-	});
-
-	it("expands `@base` only when the entry has a base section", () => {
-		const withBase = makeEntry({ baseLines: ["b1"], oursLines: ["o"], theirsLines: ["t"] });
+	it("expands Git named sides and base", () => {
+		const withBase = makeEntry({ baseLines: ["b1"], oursLines: ["o1", "o2"], theirsLines: ["t1"] });
+		expect(expandContentTokens("@ours", withBase)).toBe("o1\no2");
+		expect(expandContentTokens("@theirs", withBase)).toBe("t1");
 		expect(expandContentTokens("@base", withBase)).toBe("b1");
+		expect(expandContentTokens("@both", withBase)).toBe("o1\no2\nt1");
+	});
+
+	it("mixes Git named tokens with literal lines", () => {
+		expect(expandContentTokens("// merged\n@ours\n@theirs", entry)).toBe("// merged\no1\no2\nt1");
+	});
+
+	it("rejects an unavailable Git base", () => {
 		expect(() => expandContentTokens("@base", entry)).toThrow(ToolError);
 	});
 
-	it("leaves `@ours` inside a real code line literal (token must be the whole line)", () => {
+	it("uses indexed terms and lossless Git aliases for Jujutsu conflicts", () => {
+		const jj = makeEntry({ style: "jj-snapshot", baseLines: ["b1"], oursLines: ["o1", "o2"], theirsLines: ["t1"] });
+		expect(expandContentTokens("@side/1", jj)).toBe("o1\no2");
+		expect(expandContentTokens("@side/2", jj)).toBe("t1");
+		expect(expandContentTokens("@base/1", jj)).toBe("b1");
+		expect(expandContentTokens("@ours", jj)).toBe("o1\no2");
+		expect(expandContentTokens("@theirs", jj)).toBe("t1");
+		expect(expandContentTokens("@base", jj)).toBe("b1");
+		expect(() => expandContentTokens("@both", jj)).toThrow(/combine indexed terms explicitly/);
+	});
+
+	it("leaves token-like text inside code untouched", () => {
 		expect(expandContentTokens("const x = '@ours';", entry)).toBe("const x = '@ours';");
 	});
 
-	it("handles CRLF input lines", () => {
+	it("handles CRLF token lines", () => {
 		expect(expandContentTokens("@ours\r\n@theirs", entry)).toBe("o1\no2\nt1");
 	});
 });

--- a/packages/coding-agent/test/tools/conflict-integration.test.ts
+++ b/packages/coding-agent/test/tools/conflict-integration.test.ts
@@ -4,8 +4,9 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { createTools, type ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
-import { ConflictHistory } from "@oh-my-pi/pi-coding-agent/tools/conflict-detect";
+import { ConflictHistory, inspectConflictAuthority } from "@oh-my-pi/pi-coding-agent/tools/conflict-detect";
 import { removeWithRetries } from "@oh-my-pi/pi-utils";
+import { $ } from "bun";
 
 function createTestSession(cwd: string, overrides: Partial<ToolSession> = {}): ToolSession {
 	return {
@@ -70,6 +71,44 @@ const TWO_BLOCKS = [
 	"",
 ].join("\n");
 
+const JJ_DIFF = [
+	"before",
+	"<<<<<<< conflict 1 of 1",
+	"%%%%%%% diff from: merge base",
+	`${"\\".repeat(7)}        to: left change`,
+	" value = 1",
+	"-name = old",
+	"+name = left",
+	"+++++++ right change",
+	"value = 1",
+	"name = right",
+	">>>>>>> conflict 1 of 1 ends",
+	"after",
+	"",
+].join("\n");
+
+async function createGitConflict(root: string, fileName: string, markerSize?: number): Promise<string> {
+	await $`git init -q -b main`.cwd(root).quiet();
+	await $`git config user.name "Conflict Test"`.cwd(root).quiet();
+	await $`git config user.email conflict-test@example.test`.cwd(root).quiet();
+	const filePath = path.join(root, fileName);
+	await Bun.write(filePath, "base\n");
+	if (markerSize !== undefined) {
+		await Bun.write(path.join(root, ".gitattributes"), `${fileName} conflict-marker-size=${markerSize}\n`);
+	}
+	await $`git add --all`.cwd(root).quiet();
+	await $`git commit -qm base`.cwd(root).quiet();
+	await $`git checkout -qb left`.cwd(root).quiet();
+	await Bun.write(filePath, "left\n");
+	await $`git commit -qam left`.cwd(root).quiet();
+	await $`git checkout -q main`.cwd(root).quiet();
+	await Bun.write(filePath, "right\n");
+	await $`git commit -qam right`.cwd(root).quiet();
+	const merge = await $`git merge left`.cwd(root).quiet().nothrow();
+	if (merge.exitCode === 0) throw new Error("Expected Git merge conflict");
+	return filePath;
+}
+
 describe("read surfaces conflicts as a warning footer", () => {
 	let tempDir: string;
 
@@ -101,19 +140,31 @@ describe("read surfaces conflicts as a warning footer", () => {
 		// Warning footer is appended.
 		expect(text).toContain("⚠");
 		expect(text).toContain("⚠ 1 unresolved conflict detected");
-		expect(text).toContain("- ours = HEAD");
-		expect(text).toContain("- theirs = feature/x");
-		expect(text).toContain("──── #1  L2-6 ────");
-		expect(text).toContain("<<< ours");
-		expect(text).toContain(">>> theirs");
-		expect(text).toContain("NOTICE: Inspect a block by reading `conflict://<N>`");
+		expect(text).toContain("<<< ours  HEAD");
+		expect(text).toContain(">>> theirs  feature/x");
+		expect(text).toContain("──── #1  L2-6  git ────");
+		expect(text).toContain("NOTICE: Git terms");
 		expect(text).toContain('`write({ path: "conflict://<N>", content })`');
-		expect(text).toContain('`write({ path: "conflict://*", content })`');
 		expect(text).toContain("@ours");
 		// Registered on session.
 		const history = session.conflictHistory;
 		expect(history).toBeInstanceOf(ConflictHistory);
 		expect(history?.get(1)?.absolutePath).toBe(filePath);
+	});
+
+	it("recognizes Jujutsu diff-style markers and reconstructs both sides", async () => {
+		const filePath = path.join(tempDir, "jj.txt");
+		await Bun.write(filePath, JJ_DIFF);
+		const session = createTestSession(tempDir);
+		const read = await getTool(session, "read");
+
+		const result = await read.execute("read-jj", { path: "jj.txt" });
+		const text = getText(result);
+		expect(text).toContain("jj-diff");
+		expect(text).toContain("+++ side/1  left change");
+		expect(text).toContain("name = left");
+		expect(text).toContain("+++ side/2  right change");
+		expect(text).toContain("--- base/1  merge base");
 	});
 
 	it("registers diff3 conflicts with base section", async () => {
@@ -124,8 +175,7 @@ describe("read surfaces conflicts as a warning footer", () => {
 
 		const result = await read.execute("read-three", { path: "three.ts" });
 		const text = getText(result);
-		expect(text).toContain("- base = common ancestor");
-		expect(text).toContain("=== base");
+		expect(text).toContain("=== base  common ancestor");
 		expect(session.conflictHistory?.get(1)?.baseLines).toEqual(["base body"]);
 	});
 
@@ -137,8 +187,8 @@ describe("read surfaces conflicts as a warning footer", () => {
 
 		const result = await read.execute("read-two", { path: "two-blocks.ts" });
 		const text = getText(result);
-		expect(text).toContain("──── #1  L1-5 ────");
-		expect(text).toContain("──── #2  L7-11 ────");
+		expect(text).toContain("──── #1  L1-5  git ────");
+		expect(text).toContain("──── #2  L7-11  git ────");
 		expect(session.conflictHistory?.get(1)?.oursLines).toEqual(["a-ours"]);
 		expect(session.conflictHistory?.get(2)?.oursLines).toEqual(["b-ours"]);
 	});
@@ -155,6 +205,51 @@ describe("read surfaces conflicts as a warning footer", () => {
 		expect(text).not.toContain("conflict://");
 		expect(text).not.toContain("⚠");
 		expect(session.conflictHistory?.get(1)).toBeUndefined();
+	});
+
+	it("does not treat marker examples in a clean repository as conflicts", async () => {
+		await $`git init -q`.cwd(tempDir).quiet();
+		const filePath = path.join(tempDir, "example.md");
+		await Bun.write(filePath, `Example:\n\n${THREE_WAY}`);
+		const session = createTestSession(tempDir);
+		const read = await getTool(session, "read");
+
+		const result = await read.execute("read-marker-example", { path: "example.md" });
+		const text = getText(result);
+		expect(text).toContain("<<<<<<< HEAD");
+		expect(text).not.toContain("conflict://");
+		expect(session.conflictHistory).toBeUndefined();
+	});
+
+	it("keeps Git parsing when ours starts with a Jujutsu-looking marker", async () => {
+		const filePath = await createGitConflict(tempDir, "git-marker-content.txt");
+		await Bun.write(
+			filePath,
+			[
+				"<<<<<<< HEAD",
+				"+++++++ patch",
+				"left",
+				"=======",
+				"right",
+				">>>>>>> left",
+				"<<<<<<< conflict example",
+				"+++++++ side one",
+				"example left",
+				"+++++++ side two",
+				"example right",
+				">>>>>>> conflict example ends",
+				"",
+			].join("\n"),
+		);
+		const session = createTestSession(tempDir);
+		const read = await getTool(session, "read");
+
+		await read.execute("read-git-marker-content", { path: "git-marker-content.txt:conflicts" });
+		const entry = session.conflictHistory?.get(1);
+		expect(entry?.authority).toBe("git");
+		expect(entry?.style).toBe("git");
+		expect(entry?.sides?.map(section => section.lines)).toEqual([["+++++++ patch", "left"], ["right"]]);
+		expect(session.conflictHistory?.get(2)).toBeUndefined();
 	});
 
 	it("re-reading the same file reuses the existing id rather than inflating", async () => {
@@ -187,7 +282,7 @@ describe("read surfaces conflicts as a warning footer", () => {
 		expect(text).not.toContain("⚠");
 	});
 
-	it("renders only the theirs body via reads of `conflict://<N>/theirs`", async () => {
+	it("renders the Git theirs side via `conflict://<N>/theirs`", async () => {
 		const filePath = path.join(tempDir, "theirs.ts");
 		await Bun.write(filePath, TWO_WAY);
 		const session = createTestSession(tempDir);
@@ -203,7 +298,7 @@ describe("read surfaces conflicts as a warning footer", () => {
 		expect(text).not.toContain("oldApi(x)");
 	});
 
-	it("renders the base body for a diff3 conflict via `/base`", async () => {
+	it("renders the Git base via `/base`", async () => {
 		const filePath = path.join(tempDir, "base.ts");
 		await Bun.write(filePath, THREE_WAY);
 		const session = createTestSession(tempDir);
@@ -217,7 +312,7 @@ describe("read surfaces conflicts as a warning footer", () => {
 		expect(text).not.toContain("theirs body");
 	});
 
-	it("rejects `/base` on a 2-way conflict with a clear error", async () => {
+	it("rejects an unavailable Git base", async () => {
 		const filePath = path.join(tempDir, "no-base.ts");
 		await Bun.write(filePath, TWO_WAY);
 		const session = createTestSession(tempDir);
@@ -225,7 +320,7 @@ describe("read surfaces conflicts as a warning footer", () => {
 
 		await read.execute("read-no-base-init", { path: "no-base.ts" });
 		const promise = read.execute("read-no-base", { path: "conflict://1/base" });
-		await expect(promise).rejects.toThrow(/no base section/);
+		await expect(promise).rejects.toThrow(/0 bases/);
 	});
 
 	it("errors clearly when the conflict id is unknown", async () => {
@@ -260,7 +355,18 @@ describe("read surfaces conflicts as a warning footer", () => {
 		expect(session.conflictHistory?.get(2)).toBeDefined();
 	});
 
-	it("`:conflicts` marks 3-way blocks distinctly", async () => {
+	it("`:conflicts` refuses binary marker content", async () => {
+		const filePath = path.join(tempDir, "binary-conflict.bin");
+		await Bun.write(filePath, "<<<<<<<\nours\u0000bytes\n=======\ntheirs\n>>>>>>>\n");
+		const session = createTestSession(tempDir);
+		const read = await getTool(session, "read");
+
+		const result = await read.execute("read-binary-conflicts", { path: "binary-conflict.bin:conflicts" });
+		expect(getText(result)).toContain("binary file");
+		expect(session.conflictHistory).toBeUndefined();
+	});
+
+	it("`:conflicts` reports side/base arity", async () => {
 		const filePath = path.join(tempDir, "diff3.ts");
 		await Bun.write(filePath, THREE_WAY);
 		const session = createTestSession(tempDir);
@@ -268,7 +374,7 @@ describe("read surfaces conflicts as a warning footer", () => {
 
 		const result = await read.execute("read-diff3", { path: "diff3.ts:conflicts" });
 		const text = getText(result);
-		expect(text).toMatch(/#1\s+L2-8.*3-way/);
+		expect(text).toMatch(/#1\s+L2-8.*2 sides, 1 base, git/);
 	});
 
 	it("`:conflicts` on a clean file says so explicitly", async () => {
@@ -279,7 +385,7 @@ describe("read surfaces conflicts as a warning footer", () => {
 
 		const result = await read.execute("read-clean-conflicts", { path: "clean-conflicts.ts:conflicts" });
 		const text = getText(result);
-		expect(text).toContain("No unresolved git merge conflicts");
+		expect(text).toContain("No unresolved conflict markers");
 	});
 
 	it("window-mode warning shows visible-of-total when window misses some conflicts", async () => {
@@ -325,45 +431,109 @@ describe("write resolves conflicts via conflict://N", () => {
 			content: "newApi(x);\n",
 		});
 
-		expect(getText(result)).toContain("Resolved conflict #1");
+		expect(getText(result)).toContain("Resolved materialized conflict hunk #1");
 		const after = await Bun.file(filePath).text();
 		expect(after).toBe("line 1\nnewApi(x);\nline N\n");
 		// History is invalidated after resolve so the id no longer works.
 		expect(session.conflictHistory?.get(1)).toBeUndefined();
 	});
 
-	it("drops trailing lines that echo the context below the region and notes the repair", async () => {
-		const filePath = path.join(tempDir, "echo.ts");
-		const content = [
-			"function f() {",
-			"<<<<<<< HEAD",
-			"\tours();",
-			"=======",
-			"\ttheirs();",
-			">>>>>>> feature/x",
-			"\tdone();",
-			"}",
-			"",
-		].join("\n");
-		await Bun.write(filePath, content);
+	it("revalidates Git conflict authority immediately before writing", async () => {
+		const filePath = await createGitConflict(tempDir, "stale.txt");
 		const session = createTestSession(tempDir);
 		const read = await getTool(session, "read");
 		const write = await getTool(session, "write");
 
-		await read.execute("read-echo", { path: "echo.ts" });
-		// The classic failure: the model pastes the whole resolved function,
-		// including the two lines that live below the marker block.
-		const result = await write.execute("write-echo", {
-			path: "conflict://1",
-			content: "\tours();\n\ttheirs();\n\tdone();\n}\n",
-		});
+		await read.execute("read-stale-git", { path: "stale.txt" });
+		expect(session.conflictHistory?.get(1)?.authority).toBe("git");
+		await $`git add stale.txt`.cwd(tempDir).quiet();
 
-		const text = getText(result);
-		expect(text).toContain("Resolved conflict #1");
-		expect(text).toContain("dropped 2 content line(s)");
-		expect(await Bun.file(filePath).text()).toBe(
-			["function f() {", "\tours();", "\ttheirs();", "\tdone();", "}", ""].join("\n"),
+		await expect(write.execute("write-stale-git", { path: "conflict://1", content: "@ours" })).rejects.toThrow(
+			/no longer recorded/,
 		);
+		expect(await Bun.file(filePath).text()).toContain("<<<<<<<");
+	});
+
+	it.skipIf(process.platform === "win32")(
+		"preserves a conflicted tracked symlink path during authority lookup",
+		async () => {
+			await $`git init -q -b main`.cwd(tempDir).quiet();
+			await $`git config user.name "Conflict Test"`.cwd(tempDir).quiet();
+			await $`git config user.email conflict-test@example.test`.cwd(tempDir).quiet();
+			await Promise.all(["base", "left", "right"].map(name => Bun.write(path.join(tempDir, name), `${name}\n`)));
+			const linkPath = path.join(tempDir, "link");
+			await fs.symlink("base", linkPath);
+			await $`git add --all`.cwd(tempDir).quiet();
+			await $`git commit -qm base`.cwd(tempDir).quiet();
+			await $`git checkout -qb left`.cwd(tempDir).quiet();
+			await fs.unlink(linkPath);
+			await fs.symlink("left", linkPath);
+			await $`git commit -qam left`.cwd(tempDir).quiet();
+			await $`git checkout -q main`.cwd(tempDir).quiet();
+			await fs.unlink(linkPath);
+			await fs.symlink("right", linkPath);
+			await $`git commit -qam right`.cwd(tempDir).quiet();
+			expect((await $`git merge left`.cwd(tempDir).quiet().nothrow()).exitCode).not.toBe(0);
+
+			expect(await inspectConflictAuthority(linkPath)).toEqual({
+				state: "recorded",
+				backend: "git",
+				kind: "other",
+			});
+		},
+	);
+
+	it("reports the Git staging requirement after authoritative bulk resolution", async () => {
+		const filePath = await createGitConflict(tempDir, "bulk-git.txt");
+		const session = createTestSession(tempDir);
+		const read = await getTool(session, "read");
+		const write = await getTool(session, "write");
+
+		await read.execute("read-bulk-git", { path: "bulk-git.txt" });
+		const result = await write.execute("write-bulk-git", { path: "conflict://*", content: "@ours" });
+
+		expect(getText(result)).toContain("Git index entries remain unmerged");
+		expect(await Bun.file(filePath).text()).not.toContain("<<<<<<<");
+	});
+
+	it("uses the materialized Git marker size after attributes change", async () => {
+		const filePath = await createGitConflict(tempDir, "short-markers.txt", 3);
+		await Bun.write(path.join(tempDir, ".gitattributes"), "short-markers.txt conflict-marker-size=9\n");
+		const session = createTestSession(tempDir);
+		const read = await getTool(session, "read");
+		const write = await getTool(session, "write");
+
+		const readResult = await read.execute("read-short-git", { path: "short-markers.txt" });
+		expect(getText(readResult)).toContain("conflict://<N>");
+		expect(session.conflictHistory?.get(1)?.markerLength).toBe(3);
+		await write.execute("write-short-git", { path: "conflict://1", content: "@ours" });
+		expect(await Bun.file(filePath).text()).toBe("right\n");
+	});
+
+	it("ignores shorter marker-shaped content when Git uses the default marker length", async () => {
+		const filePath = await createGitConflict(tempDir, "marker-lookalike.txt");
+		const shortBlock = ["<<< example", "keep left", "===", "keep right", ">>> example"].join("\n");
+		await Bun.write(filePath, `${shortBlock}\n${await Bun.file(filePath).text()}`);
+		const session = createTestSession(tempDir);
+		const read = await getTool(session, "read");
+		const write = await getTool(session, "write");
+
+		await read.execute("read-marker-lookalike", { path: "marker-lookalike.txt:conflicts" });
+		expect(session.conflictHistory?.entries()).toHaveLength(1);
+		await write.execute("write-marker-lookalike", { path: "conflict://*", content: "@ours" });
+		expect(await Bun.file(filePath).text()).toBe(`${shortBlock}\nright\n`);
+	});
+
+	it("resolves a Jujutsu diff-style hunk by indexed side", async () => {
+		const filePath = path.join(tempDir, "jj.txt");
+		await Bun.write(filePath, JJ_DIFF);
+		const session = createTestSession(tempDir);
+		const read = await getTool(session, "read");
+		const write = await getTool(session, "write");
+
+		await read.execute("read-jj-write", { path: "jj.txt" });
+		await write.execute("write-jj-side", { path: "conflict://1", content: "@side/1" });
+		expect(await Bun.file(filePath).text()).toBe(["before", "value = 1", "name = left", "after", ""].join("\n"));
 	});
 
 	it("auto-recovers a `<file>:conflict://N` path and resolves the conflict", async () => {
@@ -378,11 +548,11 @@ describe("write resolves conflicts via conflict://N", () => {
 			// Malformed path mixing the `:conflicts` read selector with the
 			// `conflict://` scheme — the write tool MUST recover and resolve.
 			path: "prefix.ts:conflict://1",
-			content: "@theirs",
+			content: "@side/2",
 		});
 
 		const text = getText(result);
-		expect(text).toContain("Resolved conflict #1");
+		expect(text).toContain("Resolved materialized conflict hunk #1");
 		expect(text).toContain("stripped erroneous 'prefix.ts:' prefix");
 		expect(await Bun.file(filePath).text()).toBe("line 1\nnewApi(x)\nline N\n");
 	});
@@ -397,7 +567,7 @@ describe("write resolves conflicts via conflict://N", () => {
 		await read.execute("read-bulk-prefix", { path: "bulk-prefix.ts" });
 		const result = await write.execute("write-bulk-prefix", {
 			path: "bulk-prefix.ts:conflict://*",
-			content: "@ours",
+			content: "@side/1",
 		});
 
 		const text = getText(result);
@@ -477,7 +647,7 @@ describe("write resolves conflicts via conflict://N", () => {
 		// every block while reporting success. It must now hard-fail.
 		const promise = write.execute("write-directives-mixed", {
 			path: "conflict://*",
-			content: "1: @ours\n2: combined line A\ncombined line B\n",
+			content: "1: @side/1\n2: combined line A\ncombined line B\n",
 		});
 		await expect(promise).rejects.toThrow(/Malformed `conflict:\/\/\*` per-id block/);
 		// File untouched — the markers are still present, nothing leaked.
@@ -487,7 +657,7 @@ describe("write resolves conflicts via conflict://N", () => {
 		expect(session.conflictHistory?.get(2)).toBeDefined();
 	});
 
-	it("rejects a per-id line whose value is not a recognized @side token", async () => {
+	it("rejects a per-id line whose value is not a recognized term token", async () => {
 		const filePath = path.join(tempDir, "directives-badtoken.ts");
 		await Bun.write(filePath, TWO_BLOCKS);
 		const session = createTestSession(tempDir);
@@ -497,13 +667,13 @@ describe("write resolves conflicts via conflict://N", () => {
 		await read.execute("read-directives-badtoken", { path: "directives-badtoken.ts" });
 		const promise = write.execute("write-directives-badtoken", {
 			path: "conflict://*",
-			content: "1: @ours\n2: @mine",
+			content: "1: @side/1\n2: @mine",
 		});
-		await expect(promise).rejects.toThrow(/only accepts the tokens @ours\/@theirs\/@base\/@both/);
+		await expect(promise).rejects.toThrow(/Per-id bulk only accepts Git/);
 		expect(await Bun.file(filePath).text()).toBe(TWO_BLOCKS);
 	});
 
-	it("still treats pure-literal content as a uniform bulk write (no false directive rejection)", async () => {
+	it("rejects literal uniform bulk replacement", async () => {
 		const filePath = path.join(tempDir, "directives-literal.ts");
 		await Bun.write(filePath, TWO_WAY);
 		const session = createTestSession(tempDir);
@@ -511,13 +681,12 @@ describe("write resolves conflicts via conflict://N", () => {
 		const write = await getTool(session, "write");
 
 		await read.execute("read-directives-literal", { path: "directives-literal.ts" });
-		// No line is `<id>: @side`, so this is a uniform replacement, not a per-id block.
-		const result = await write.execute("write-directives-literal", {
+		const promise = write.execute("write-directives-literal", {
 			path: "conflict://*",
 			content: "resolvedApi(x)\n",
 		});
-		expect(getText(result)).toContain("Resolved 1 conflict");
-		expect(await Bun.file(filePath).text()).toBe("line 1\nresolvedApi(x)\nline N\n");
+		await expect(promise).rejects.toThrow(/only accepts a shared Git/);
+		expect(await Bun.file(filePath).text()).toBe(TWO_WAY);
 	});
 
 	it("can resolve two blocks in the same file by id, in either order", async () => {
@@ -545,7 +714,7 @@ describe("write resolves conflicts via conflict://N", () => {
 		expect(after).toBe("A-resolved\nmiddle\nB-resolved\ntail\n");
 	});
 
-	it("accepts `@ours`/`@theirs`/`@both` content tokens as shorthand", async () => {
+	it("accepts Git named tokens as shorthand", async () => {
 		const filePath = path.join(tempDir, "tokens.ts");
 		await Bun.write(filePath, TWO_WAY);
 		const session = createTestSession(tempDir);
@@ -559,21 +728,7 @@ describe("write resolves conflicts via conflict://N", () => {
 		expect(after).toBe("line 1\nnewApi(x)\nline N\n");
 	});
 
-	it("expands `@both` to ours then theirs without re-typing either side", async () => {
-		const filePath = path.join(tempDir, "both.ts");
-		await Bun.write(filePath, TWO_WAY);
-		const session = createTestSession(tempDir);
-		const read = await getTool(session, "read");
-		const write = await getTool(session, "write");
-
-		await read.execute("read-both", { path: "both.ts" });
-		await write.execute("write-both", { path: "conflict://1", content: "@both" });
-
-		const after = await Bun.file(filePath).text();
-		expect(after).toBe("line 1\noldApi(x)\nnewApi(x)\nline N\n");
-	});
-
-	it("rejects `@base` for a 2-way conflict with a clear error", async () => {
+	it("rejects an unavailable Git base token", async () => {
 		const filePath = path.join(tempDir, "nobase.ts");
 		await Bun.write(filePath, TWO_WAY);
 		const session = createTestSession(tempDir);
@@ -582,7 +737,7 @@ describe("write resolves conflicts via conflict://N", () => {
 
 		await read.execute("read-nobase", { path: "nobase.ts" });
 		const promise = write.execute("write-nobase", { path: "conflict://1", content: "@base" });
-		await expect(promise).rejects.toThrow(/no base section/);
+		await expect(promise).rejects.toThrow(/0 bases/);
 		// File untouched.
 		expect(await Bun.file(filePath).text()).toBe(TWO_WAY);
 	});
@@ -699,10 +854,26 @@ describe("write resolves conflicts via conflict://N", () => {
 		expect(session.conflictHistory?.entries()).toHaveLength(0);
 	});
 
+	it("normalizes surrounding whitespace on a shared bulk term", async () => {
+		const filePath = path.join(tempDir, "bulk-whitespace.ts");
+		await Bun.write(filePath, TWO_WAY);
+		const session = createTestSession(tempDir);
+		const read = await getTool(session, "read");
+		const write = await getTool(session, "write");
+
+		await read.execute("read-bulk-whitespace", { path: "bulk-whitespace.ts:conflicts" });
+		await write.execute("write-bulk-whitespace", {
+			path: "conflict://*",
+			content: " \n@ours\t ",
+		});
+
+		expect(await Bun.file(filePath).text()).toBe("line 1\noldApi(x)\nline N\n");
+	});
+
 	it("`write conflict://*` errors when no conflicts are registered", async () => {
 		const session = createTestSession(tempDir);
 		const write = await getTool(session, "write");
-		await expect(write.execute("write-bulk-empty", { path: "conflict://*", content: "@ours" })).rejects.toThrow(
+		await expect(write.execute("write-bulk-empty", { path: "conflict://*", content: "@side/1" })).rejects.toThrow(
 			/nothing to resolve/,
 		);
 	});
@@ -723,7 +894,7 @@ describe("write resolves conflicts via conflict://N", () => {
 			path: "conflict://1",
 			content: "@theirs",
 		});
-		expect(getText(result)).toContain("Resolved conflict #1");
+		expect(getText(result)).toContain("Resolved materialized conflict hunk #1");
 		const after = await Bun.file(filePath).text();
 		expect(after).toBe("// extra line\n// another extra\nline 1\nnewApi(x)\nline N\n");
 	});

--- a/packages/coding-agent/test/write-xdev-dispatch.test.ts
+++ b/packages/coding-agent/test/write-xdev-dispatch.test.ts
@@ -778,7 +778,7 @@ describe("device-only write transport for explicit lists omitting write", () => 
 			await expect(
 				write!.execute("write-device-only-plan-conflict", {
 					path: "conflict://1",
-					content: "@ours",
+					content: "@side/1",
 				}),
 			).rejects.toThrow("Filesystem writes are not available");
 		} finally {

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added backend-neutral conflict metadata queries for Git and Jujutsu, including backend-validated materialized regions and classification of editable files versus non-file tree conflicts.
+
 ## [18.0.11] - 2026-08-29
 
 ### Fixed

--- a/packages/natives/native/index.d.ts
+++ b/packages/natives/native/index.d.ts
@@ -478,6 +478,8 @@ export declare class VcsJjWorkspace {
   workingCopyLabel(signal?: unknown | undefined | null): Promise<string | undefined | null>
   /** Status counts. */
   statusSummary(signal?: unknown | undefined | null): Promise<VcsStatusSummary>
+  /** Repository-recorded conflicts in the working-copy commit. */
+  conflictedPaths(files: Array<string>, signal?: unknown | undefined | null): Promise<Array<VcsConflictInfo>>
   /** Render working-copy patch. */
   diffText(files: Array<string>, snapshot: boolean, signal?: unknown | undefined | null): Promise<string>
   /** List changed paths. */
@@ -508,6 +510,8 @@ export declare class VcsRepo {
   headId(signal?: unknown | undefined | null): Promise<string | undefined | null>
   /** Status counts. */
   statusSummary(signal?: unknown | undefined | null): Promise<VcsStatusSummary>
+  /** Repository-recorded conflicts in the working copy. */
+  conflictedPaths(files: Array<string>, signal?: unknown | undefined | null): Promise<Array<VcsConflictInfo>>
   /** Porcelain status. */
   statusPorcelain(options: VcsStatusOptions, signal?: unknown | undefined | null): Promise<string>
   /** Render a patch. */
@@ -1955,6 +1959,9 @@ export interface NodeSpan {
   kind: string
 }
 
+/** Parse standalone Git or Jujutsu marker content without repository authority. */
+export declare function parseConflictMarkers(content: Buffer, minimumMarkerLength?: number | undefined | null): Array<VcsConflictRegion>
+
 /** Parsed Kitty keyboard protocol sequence result for a Kitty input sequence. */
 export interface ParsedKittyResult {
   /** Primary codepoint associated with the key. */
@@ -2469,6 +2476,37 @@ export interface VcsCommitOptions {
   allowEmpty?: boolean
   amend?: boolean
   files?: Array<string>
+}
+
+/** Metadata for one repository-recorded conflict. */
+export interface VcsConflictInfo {
+  path: string
+  kind: VcsConflictKind
+  regions: Array<VcsConflictRegion>
+}
+
+/** Broad kind of a repository-recorded conflict. */
+export declare enum VcsConflictKind {
+  File = 'file',
+  Other = 'other'
+}
+
+/** One backend-validated materialized conflict block. */
+export interface VcsConflictRegion {
+  startLine: number
+  separatorLine: number
+  endLine: number
+  baseLine?: number
+  style: string
+  markerLength: number
+  sides: Array<VcsConflictTerm>
+  bases: Array<VcsConflictTerm>
+}
+
+/** One positive side or negative base term. */
+export interface VcsConflictTerm {
+  label?: string
+  content: string
 }
 
 /** Detach copied Git metadata. */

--- a/packages/natives/native/index.js
+++ b/packages/natives/native/index.js
@@ -81,6 +81,7 @@ export const matchesKittySequence = nativeBindings.matchesKittySequence;
 export const matchesLegacySequence = nativeBindings.matchesLegacySequence;
 export const mmrRerankIndices = nativeBindings.mmrRerankIndices;
 export const nodeChainAt = nativeBindings.nodeChainAt;
+export const parseConflictMarkers = nativeBindings.parseConflictMarkers;
 export const parseKey = nativeBindings.parseKey;
 export const parseKittySequence = nativeBindings.parseKittySequence;
 export const pdfToMarkdown = nativeBindings.pdfToMarkdown;
@@ -176,5 +177,9 @@ export const MacOSAppearance = {
 export const ProcessStatus = {
 	Running: "running",
 	Exited: "exited",
+};
+export const VcsConflictKind = {
+	File: "file",
+	Other: "other",
 };
 // --- end generated native exports ---

--- a/packages/natives/native/vcs.d.ts
+++ b/packages/natives/native/vcs.d.ts
@@ -1,5 +1,6 @@
 import type {
 	VcsCloneOptions,
+	VcsConflictRegion,
 	VcsGitRepo,
 	VcsGitRepoInfo,
 	VcsHunkSelection,
@@ -59,6 +60,12 @@ export declare function gitInfo(dir: string): VcsGitRepoInfo | null;
 
 /** Discover the Jujutsu workspace containing `dir`; `null` when absent. */
 export declare function jj(dir: string): VcsJjWorkspace | null;
+
+/** Parse standalone Git or Jujutsu conflict markers through the native grammars. */
+export declare function parseConflictMarkers(
+	content: Uint8Array,
+	minimumMarkerLength?: number,
+): VcsConflictRegion[];
 
 /** Whether jj is the nearest VCS ancestor, making git automation unsafe. */
 export declare function isPureJj(dir: string): boolean;

--- a/packages/natives/native/vcs.js
+++ b/packages/natives/native/vcs.js
@@ -75,6 +75,11 @@ export function jj(dir) {
 	return api().vcsJjDiscover(dir);
 }
 
+/** Parse standalone Git or Jujutsu conflict markers through the native grammars. */
+export function parseConflictMarkers(content, minimumMarkerLength) {
+	return api().parseConflictMarkers(content, minimumMarkerLength);
+}
+
 /** Whether jj is the nearest VCS ancestor, making git automation unsafe. */
 export function isPureJj(dir) {
 	return api().vcsIsPureJj(dir);

--- a/packages/natives/test/vcs.test.ts
+++ b/packages/natives/test/vcs.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { vcsDiscover, vcsGitClone, vcsGitDiscover, vcsGitRepoInfo } from "../native/index.js";
+import { VcsConflictKind, vcsDiscover, vcsGitClone, vcsGitDiscover, vcsGitRepoInfo } from "../native/index.js";
 import * as vcs from "../native/vcs.js";
 
 const roots: string[] = [];
@@ -149,6 +149,39 @@ describe("VcsRepo", () => {
 		const required = vcs.require(root, "stagedDiff");
 		expect(required.kind()).toBe("git");
 		expect(required.supports("revDiff")).toBe(true);
+	});
+	test("reports repository-recorded conflict paths", async () => {
+		const root = await repository();
+		await writeFile(join(root, ".gitattributes"), "tracked.txt conflict-marker-size=3\n");
+		await git(root, "add", ".gitattributes");
+		await git(root, "commit", "-m", "marker size");
+		await git(root, "checkout", "-b", "left");
+		await writeFile(join(root, "tracked.txt"), "left\n");
+		await git(root, "commit", "-am", "left");
+		await git(root, "checkout", "main");
+		await writeFile(join(root, "tracked.txt"), "right\n");
+		await git(root, "commit", "-am", "right");
+		const merge = Bun.spawn(["git", "merge", "left"], { cwd: root, stderr: "ignore", stdout: "ignore" });
+		expect(await merge.exited).not.toBe(0);
+		await writeFile(join(root, ".gitattributes"), "tracked.txt conflict-marker-size=9\n");
+
+		const repo = vcsDiscover(root)!;
+		const conflicts = await repo.conflictedPaths([]);
+		expect(conflicts).toHaveLength(1);
+		expect(conflicts[0]).toMatchObject({ path: "tracked.txt", kind: VcsConflictKind.File });
+		expect(conflicts[0].regions).toHaveLength(1);
+		const region = conflicts[0].regions[0];
+		expect(region).toMatchObject({
+			startLine: 1,
+			separatorLine: 6,
+			endLine: 8,
+			baseLine: 3,
+			style: "git",
+			markerLength: 3,
+		});
+		expect(region.sides.map(term => term.content)).toEqual(["right\n", "left\n"]);
+		expect(region.bases.map(term => term.content)).toEqual(["one\ntwo\n"]);
+		expect(await repo.conflictedPaths(["other.txt"])).toEqual([]);
 	});
 
 	test("discovers Jujutsu and rejects unsupported features", async () => {


### PR DESCRIPTION
## What

- Add backend-neutral conflict-path queries for Git unmerged index entries and Jujutsu first-class working-copy conflicts.
- Use repository state as the authority for repository conflicts while preserving marker-only conflict files outside repositories.
- Preserve the existing Git conflict protocol:
  - inspect with `/ours`, `/theirs`, and `/base`
  - resolve with `@ours`, `@theirs`, `@base`, and `@both`
- Use indexed `/side/<N>` / `/base/<N>` scopes and `@side/<N>` / `@base/<N>` tokens for Jujutsu’s arbitrary merge arity.
- Support Git diff3 plus Jujutsu Git/diff/snapshot marker styles, configurable marker lengths, CRLF, and unterminated conflict files.
- Revalidate repository authority immediately before writes and replace only the recorded marker block.
- Canonicalize working-copy and repository paths before authority lookup so filesystem aliases and case-insensitive path spellings resolve to the recorded conflict path.
- Classify symlink, gitlink, file/directory, and other non-materializable conflicts separately from editable text conflicts.

## Why

Marker parsing alone cannot distinguish a real unresolved conflict from documentation or source code that merely contains marker examples. Repository state provides that authority:

- Git: nonzero-stage index entries
- Jujutsu: first-class conflicts in the working-copy commit tree

Git’s existing ours/theirs protocol remains useful and backward-compatible. Jujutsu needs indexed positive sides and negative bases because its conflicts are not limited to Git’s two-side model.

Marker parsing also follows the backend-specific source semantics rather than applying one shared approximation:

- Git internal and closing markers must match the configured marker length exactly.
- Jujutsu accepts markers at least as long as its expected marker length and lengthens materialized markers when conflict terms already contain marker-looking lines.

## Testing

- `bun check`
- Coding-agent conflict tests: 108 passed
- Native VCS tests: 8 passed
- Focused Rust conflict-path tests: 3 passed
- Real Jujutsu smoke test:
  - created a first-class working-copy conflict
  - detected it through `read` with jj authority
  - resolved it through `write({ path: "conflict://1", content: "@side/1" })`
  - confirmed the repository reported no remaining conflict
- Full Rust run: 2417 passed, with one remaining failure in `jj_portable_status_log_and_numstat_match_cli_fixture` related to rename rendering.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)

Works fine in my real workflow locally.
