### PR TITLE
test(coding-agent): isolate default model regression fixture

### DIFF
--- a/packages/coding-agent/test/default-model-ambient-bedrock.test.ts
+++ b/packages/coding-agent/test/default-model-ambient-bedrock.test.ts
@@ -54,13 +54,16 @@ describe("issue #9967 default model with ambient Bedrock credentials", () => {
 		else process.env.AWS_BEARER_TOKEN_BEDROCK = savedBearerToken;
 		fs.rmSync(tempDir, { recursive: true, force: true });
 	});
+	function getRelevantModels() {
+		return registry
+			.getAvailable()
+			.filter(model => model.provider === "amazon-bedrock" || model.provider === "anthropic");
+	}
 
 	test("prefers the concretely-authed provider over an ambient Bedrock default", () => {
 		// Without any AWS credentials, Bedrock is not available and Anthropic wins.
 		expect(authStorage.hasAuth("amazon-bedrock")).toBe(false);
-		const baseline = pickDefaultAvailableModel(registry.getAvailable(), provider =>
-			registry.hasConcreteAuth(provider),
-		);
+		const baseline = pickDefaultAvailableModel(getRelevantModels(), provider => registry.hasConcreteAuth(provider));
 		expect(baseline?.provider).toBe("anthropic");
 
 		// Ambient AWS source with no usable Bedrock access (would 403 on request).
@@ -72,7 +75,7 @@ describe("issue #9967 default model with ambient Bedrock credentials", () => {
 		expect(registry.hasConcreteAuth("amazon-bedrock")).toBe(false);
 		expect(registry.hasConcreteAuth("anthropic")).toBe(true);
 
-		const available = registry.getAvailable();
+		const available = getRelevantModels();
 		const bedrockIdx = available.findIndex(model => model.provider === "amazon-bedrock");
 		const anthropicIdx = available.findIndex(model => model.provider === "anthropic");
 		// Catalog order leads with Bedrock — the ordering that produced the bug.
@@ -94,7 +97,7 @@ describe("issue #9967 default model with ambient Bedrock credentials", () => {
 		expect(authStorage.hasAuth("amazon-bedrock")).toBe(true);
 		expect(registry.hasConcreteAuth("amazon-bedrock")).toBe(true);
 
-		const picked = pickDefaultAvailableModel(registry.getAvailable(), provider => registry.hasConcreteAuth(provider));
+		const picked = pickDefaultAvailableModel(getRelevantModels(), provider => registry.hasConcreteAuth(provider));
 		expect(picked?.provider).toBe("amazon-bedrock");
 	});
 });


### PR DESCRIPTION
## Repro
With an unrelated catalog credential in the process environment, `env ALIBABA_TOKEN_PLAN_API_KEY=test-ambient-key bun test packages/coding-agent/test/default-model-ambient-bedrock.test.ts` made both issue #9967 regression cases select `alibaba-token-plan` and fail (`0 pass, 2 fail`).

## Cause
`packages/coding-agent/test/default-model-ambient-bedrock.test.ts` passed every model returned by `ModelRegistry.getAvailable()` into `pickDefaultAvailableModel()`. Its setup removed only Bedrock’s AWS variables, so any unrelated provider made available by a real ambient key remained a concrete-auth candidate and could win catalog-order selection.

## Fix
- Restrict the fixture’s candidate set to the `amazon-bedrock` and `anthropic` providers whose precedence the regression exercises.
- Use the isolated candidate set for the baseline, ambient Bedrock, and bearer-token assertions.

## Verification
`env ALIBABA_TOKEN_PLAN_API_KEY=test-ambient-key bun test packages/coding-agent/test/default-model-ambient-bedrock.test.ts` passes with `2 pass, 0 fail`; `bun run check` in `packages/coding-agent` passes Biome and `tsgo -p tsconfig.json --noEmit`.

Fixes #10383