### PR TITLE
test(robomp): isolate server tests from dispatcher

### DIFF
--- a/python/robomp/src/server.py
+++ b/python/robomp/src/server.py
@@ -8,7 +8,7 @@ import time
 from collections.abc import AsyncIterator, Awaitable, Callable, Mapping
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Protocol
 
 from fastapi import Body, FastAPI, Header, HTTPException, Request, status
 from fastapi.responses import HTMLResponse, JSONResponse
@@ -44,6 +44,29 @@ from robomp.queue import WorkerPool
 from robomp.sandbox import SandboxManager
 
 log = logging.getLogger(__name__)
+
+
+class _AppPool(Protocol):
+    async def start(self) -> None: ...
+
+    async def stop(self, *, drain_timeout: float = 25.0, kill_timeout: float = 5.0) -> None: ...
+
+    def wake(self) -> None: ...
+
+    async def cancel_event(self, delivery_id: str) -> bool: ...
+
+    async def inflight_snapshot(self) -> list[str]: ...
+
+
+class _PoolFactory(Protocol):
+    def __call__(
+        self,
+        settings: Settings,
+        db: Database,
+        github: GitHubBackend,
+        sandbox: SandboxManager,
+        git_transport: ProxyGitTransport,
+    ) -> _AppPool: ...
 
 
 def _release_payload(row: ReleaseRow) -> dict[str, Any]:
@@ -254,7 +277,23 @@ def _build_orchestrator(cfg: Settings) -> tuple[GitHubBackend, ProxyGitTransport
     return github, transport
 
 
-def _build_state(settings: Settings) -> dict[str, Any]:
+def _build_worker_pool(
+    settings: Settings,
+    db: Database,
+    github: GitHubBackend,
+    sandbox: SandboxManager,
+    git_transport: ProxyGitTransport,
+) -> WorkerPool:
+    return WorkerPool(
+        settings=settings,
+        db=db,
+        github=github,
+        sandbox=sandbox,
+        git_transport=git_transport,
+    )
+
+
+def _build_state(settings: Settings, pool_factory: _PoolFactory) -> dict[str, Any]:
     db = get_database(settings.sqlite_path)
     github, git_transport = _build_orchestrator(settings)
     natives_cache: NativesCache | None = None
@@ -269,7 +308,7 @@ def _build_state(settings: Settings) -> dict[str, Any]:
         transport=git_transport,
         natives_cache=natives_cache,
     )
-    pool = WorkerPool(settings=settings, db=db, github=github, sandbox=sandbox, git_transport=git_transport)
+    pool = pool_factory(settings, db, github, sandbox, git_transport)
     autoclose = AutocloseScheduler(settings=settings, db=db, github=github)
     index_sync = IssueIndexSync(settings=settings, db=db, github=github)
     return {
@@ -286,16 +325,16 @@ def _build_state(settings: Settings) -> dict[str, Any]:
     }
 
 
-def create_app(settings: Settings | None = None) -> FastAPI:
-    """Build the FastAPI app. `settings` parameter is for tests."""
+def create_app(settings: Settings | None = None, *, pool_factory: _PoolFactory = _build_worker_pool) -> FastAPI:
+    """Build the FastAPI app, optionally using an injected worker-pool factory."""
 
     @asynccontextmanager
     async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         cfg = settings or get_settings()
         cfg.ensure_paths()
-        app.state.bag = _build_state(cfg)
+        app.state.bag = _build_state(cfg, pool_factory)
         app.state.bag["started_at"] = time.time()
-        pool: WorkerPool = app.state.bag["pool"]
+        pool: _AppPool = app.state.bag["pool"]
         await pool.start()
         autoclose: AutocloseScheduler = app.state.bag["autoclose"]
         await autoclose.start()
@@ -487,7 +526,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             state="queued",
         )
         if inserted:
-            pool: WorkerPool = bag["pool"]
+            pool: _AppPool = bag["pool"]
             pool.wake()
             log.info(
                 "queued", extra={"event": x_github_event, "delivery": x_github_delivery, "key": decision.issue_key}
@@ -599,7 +638,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
 
         db: Database = bag["db"]
         github: GitHubBackend = bag["github"]
-        pool: WorkerPool = bag["pool"]
+        pool: _AppPool = bag["pool"]
 
         mode = str(payload.get("mode") or "").strip().lower()
         if mode not in ("triage", "retry"):
@@ -692,7 +731,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
                 409, f"delivery {delivery_id} is {event.state}; only running deliveries can be cancelled"
             )
 
-        pool: WorkerPool = bag["pool"]
+        pool: _AppPool = bag["pool"]
         fired = await pool.cancel_event(delivery_id)
         log.info(
             "manual cancel",
@@ -758,7 +797,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         bag = request.app.state.bag
         cfg: Settings = bag["settings"]
         db: Database = bag["db"]
-        pool: WorkerPool = bag["pool"]
+        pool: _AppPool = bag["pool"]
         started = float(bag.get("started_at") or time.time())
 
         def _collect() -> dict[str, Any]:

--- a/python/robomp/tests/test_server.py
+++ b/python/robomp/tests/test_server.py
@@ -16,6 +16,7 @@ from robomp.dashboard import tail_jsonl
 from robomp.db import Database, close_database, get_database, issue_key
 from robomp.github_client import GitHubClient
 from robomp.manual_triage import InvalidIssueRef, ManualTriageTimeout, await_terminal_state, parse_issue_ref
+from robomp.queue import WorkerPool
 from robomp.sandbox import LocalGitTransport
 from robomp.server import create_app
 
@@ -382,6 +383,16 @@ def _enable_replay(monkeypatch: pytest.MonkeyPatch) -> str:
 def _install_github_mock(app, transport: httpx.MockTransport) -> None:
     """Replace the real GitHub client with one wired to a MockTransport."""
     app.state.bag["github"] = GitHubClient("token", transport=transport)
+
+
+@pytest.fixture(autouse=True)
+def paused_dispatcher(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep API state assertions isolated from the background worker pool."""
+
+    async def _claim_none(_pool: WorkerPool) -> None:
+        return None
+
+    monkeypatch.setattr(WorkerPool, "_claim_next_unique", _claim_none)
 
 
 def test_trigger_returns_404_when_token_disabled(settings: Settings) -> None:

--- a/python/robomp/tests/test_server.py
+++ b/python/robomp/tests/test_server.py
@@ -9,16 +9,74 @@ from pathlib import Path
 
 import httpx
 import pytest
+from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from robomp.config import Settings, reset_settings_cache
 from robomp.dashboard import tail_jsonl
 from robomp.db import Database, close_database, get_database, issue_key
+from robomp.github_backend import GitHubBackend
 from robomp.github_client import GitHubClient
 from robomp.manual_triage import InvalidIssueRef, ManualTriageTimeout, await_terminal_state, parse_issue_ref
-from robomp.queue import WorkerPool
-from robomp.sandbox import LocalGitTransport
+from robomp.proxy_client import ProxyGitTransport
+from robomp.sandbox import LocalGitTransport, SandboxManager
 from robomp.server import create_app
+
+
+class _PausedPool:
+    def __init__(self) -> None:
+        self.started = False
+        self.stopped = False
+
+    async def start(self) -> None:
+        self.started = True
+
+    async def stop(self, *, drain_timeout: float = 25.0, kill_timeout: float = 5.0) -> None:
+        self.stopped = True
+
+    def wake(self) -> None:
+        pass
+
+    async def cancel_event(self, delivery_id: str) -> bool:
+        return False
+
+    async def inflight_snapshot(self) -> list[str]:
+        return []
+
+
+class _PausedPoolFactory:
+    def __init__(self) -> None:
+        self.pools: list[_PausedPool] = []
+
+    def __call__(
+        self,
+        settings: Settings,
+        db: Database,
+        github: GitHubBackend,
+        sandbox: SandboxManager,
+        git_transport: ProxyGitTransport,
+    ) -> _PausedPool:
+        pool = _PausedPool()
+        self.pools.append(pool)
+        return pool
+
+
+def _create_app(settings: Settings | None = None) -> FastAPI:
+    return create_app(settings, pool_factory=_PausedPoolFactory())
+
+
+def test_create_app_runs_injected_pool_lifecycle(settings: Settings) -> None:
+    factory = _PausedPoolFactory()
+    app = create_app(settings, pool_factory=factory)
+
+    with TestClient(app):
+        assert len(factory.pools) == 1
+        pool = factory.pools[0]
+        assert pool.started is True
+        assert pool.stopped is False
+
+    close_database()
+    assert pool.stopped is True
 
 
 def _seed_db(settings: Settings) -> None:
@@ -69,7 +127,7 @@ def _seed_db(settings: Settings) -> None:
 
 
 def test_index_serves_dashboard_html(settings: Settings) -> None:
-    app = create_app(settings)
+    app = _create_app(settings)
     with TestClient(app) as client:
         resp = client.get("/")
     assert resp.status_code == 200
@@ -92,7 +150,7 @@ def test_index_substitutes_replay_token(env, monkeypatch: pytest.MonkeyPatch) ->
     reset_settings_cache()
     cfg = Settings()  # type: ignore[call-arg]
     cfg.ensure_paths()
-    app = create_app(cfg)
+    app = _create_app(cfg)
     try:
         with TestClient(app) as client:
             resp = client.get("/")
@@ -104,7 +162,7 @@ def test_index_substitutes_replay_token(env, monkeypatch: pytest.MonkeyPatch) ->
 
 
 def test_api_status_reports_runtime_counts_and_inflight(settings: Settings) -> None:
-    app = create_app(settings)
+    app = _create_app(settings)
     with TestClient(app) as client:
         _seed_db(settings)
         resp = client.get("/api/status")
@@ -152,7 +210,7 @@ def test_api_status_reports_runtime_counts_and_inflight(settings: Settings) -> N
 
 
 def test_releases_endpoint_returns_recent_release_state(settings: Settings) -> None:
-    app = create_app(settings)
+    app = _create_app(settings)
     with TestClient(app) as client:
         db = get_database(settings.sqlite_path)
         row = db.upsert_release(
@@ -190,7 +248,7 @@ def test_releases_endpoint_returns_recent_release_state(settings: Settings) -> N
 
 
 def test_api_status_reports_current_issue_event_state(settings: Settings) -> None:
-    app = create_app(settings)
+    app = _create_app(settings)
     fixed = issue_key("octo/widget", 44)
     failed = issue_key("octo/widget", 69)
     with TestClient(app) as client:
@@ -249,7 +307,7 @@ def test_api_status_reports_current_issue_event_state(settings: Settings) -> Non
 
 
 def test_api_logs_returns_empty_when_file_missing(settings: Settings) -> None:
-    app = create_app(settings)
+    app = _create_app(settings)
     with TestClient(app) as client:
         resp = client.get("/api/logs?limit=10")
     close_database()
@@ -275,7 +333,7 @@ def test_api_logs_tails_jsonl_file(settings: Settings) -> None:
     ]
     log_path.write_text("\n".join(json.dumps(p) for p in payloads) + "\n", encoding="utf-8")
 
-    app = create_app(settings)
+    app = _create_app(settings)
     with TestClient(app) as client:
         resp = client.get("/api/logs?limit=2")
     close_database()
@@ -291,7 +349,7 @@ def test_api_logs_tails_jsonl_file(settings: Settings) -> None:
 
 
 def test_api_logs_limit_is_clamped(settings: Settings) -> None:
-    app = create_app(settings)
+    app = _create_app(settings)
     with TestClient(app) as client:
         too_low = client.get("/api/logs?limit=0").json()
         too_high = client.get("/api/logs?limit=99999").json()
@@ -385,18 +443,8 @@ def _install_github_mock(app, transport: httpx.MockTransport) -> None:
     app.state.bag["github"] = GitHubClient("token", transport=transport)
 
 
-@pytest.fixture(autouse=True)
-def paused_dispatcher(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Keep API state assertions isolated from the background worker pool."""
-
-    async def _claim_none(_pool: WorkerPool) -> None:
-        return None
-
-    monkeypatch.setattr(WorkerPool, "_claim_next_unique", _claim_none)
-
-
 def test_trigger_returns_404_when_token_disabled(settings: Settings) -> None:
-    app = create_app(settings)
+    app = _create_app(settings)
     with TestClient(app) as client:
         resp = client.post("/api/trigger", json={"mode": "triage", "issue": "octo/widget#1"})
     close_database()
@@ -408,7 +456,7 @@ def test_trigger_rejects_missing_token(env, monkeypatch: pytest.MonkeyPatch) -> 
     _enable_replay(monkeypatch)
     cfg = Settings()  # type: ignore[call-arg]
     cfg.ensure_paths()
-    app = create_app(cfg)
+    app = _create_app(cfg)
     with TestClient(app) as client:
         resp = client.post("/api/trigger", json={"mode": "triage", "issue": "octo/widget#1"})
     close_database()
@@ -448,7 +496,7 @@ def test_trigger_triage_fetches_and_enqueues(env, monkeypatch: pytest.MonkeyPatc
             )
         return httpx.Response(404)
 
-    app = create_app(cfg)
+    app = _create_app(cfg)
     with TestClient(app) as client:
         _install_github_mock(app, httpx.MockTransport(handler))
         resp = client.post(
@@ -484,7 +532,7 @@ def test_trigger_triage_conflicts_when_manual_delivery_is_active(
         calls.append(request.url.path)
         return httpx.Response(500, json={"message": "should not fetch active manual event"})
 
-    app = create_app(cfg)
+    app = _create_app(cfg)
     with TestClient(app) as client:
         db = get_database(cfg.sqlite_path)
         db.record_event(
@@ -543,7 +591,7 @@ def test_trigger_triage_replaces_inactive_manual_delivery(env, monkeypatch: pyte
             )
         return httpx.Response(404)
 
-    app = create_app(cfg)
+    app = _create_app(cfg)
     with TestClient(app) as client:
         db = get_database(cfg.sqlite_path)
         db.record_event(
@@ -615,7 +663,7 @@ def test_trigger_triage_rejects_pull_request_issue_payload(env, monkeypatch: pyt
             )
         return httpx.Response(404)
 
-    app = create_app(cfg)
+    app = _create_app(cfg)
     with TestClient(app) as client:
         _install_github_mock(app, httpx.MockTransport(handler))
         resp = client.post(
@@ -636,7 +684,7 @@ def test_trigger_triage_rejects_repo_not_in_allowlist(env, monkeypatch: pytest.M
     token = _enable_replay(monkeypatch)
     cfg = Settings()  # type: ignore[call-arg]
     cfg.ensure_paths()
-    app = create_app(cfg)
+    app = _create_app(cfg)
     with TestClient(app) as client:
         _install_github_mock(app, httpx.MockTransport(lambda r: httpx.Response(500)))
         resp = client.post(
@@ -658,7 +706,7 @@ def test_trigger_retry_by_delivery_rejects_active_events(
     token = _enable_replay(monkeypatch)
     cfg = Settings()  # type: ignore[call-arg]
     cfg.ensure_paths()
-    app = create_app(cfg)
+    app = _create_app(cfg)
     with TestClient(app) as client:
         db = get_database(cfg.sqlite_path)
         db.record_event(
@@ -685,7 +733,7 @@ def test_trigger_triage_surfaces_github_failure(env, monkeypatch: pytest.MonkeyP
     cfg = Settings()  # type: ignore[call-arg]
     cfg.ensure_paths()
     transport = httpx.MockTransport(lambda r: httpx.Response(404, json={"message": "Not Found"}))
-    app = create_app(cfg)
+    app = _create_app(cfg)
     with TestClient(app) as client:
         _install_github_mock(app, transport)
         resp = client.post(
@@ -702,7 +750,7 @@ def test_trigger_retry_by_delivery_id_requeues(env, monkeypatch: pytest.MonkeyPa
     token = _enable_replay(monkeypatch)
     cfg = Settings()  # type: ignore[call-arg]
     cfg.ensure_paths()
-    app = create_app(cfg)
+    app = _create_app(cfg)
     with TestClient(app) as client:
         db = get_database(cfg.sqlite_path)
         db.record_event(
@@ -738,7 +786,7 @@ def test_trigger_retry_by_issue_finds_latest_non_skipped_event(env, monkeypatch:
     token = _enable_replay(monkeypatch)
     cfg = Settings()  # type: ignore[call-arg]
     cfg.ensure_paths()
-    app = create_app(cfg)
+    app = _create_app(cfg)
     with TestClient(app) as client:
         db = get_database(cfg.sqlite_path)
         key = issue_key("octo/widget", 9)
@@ -796,7 +844,7 @@ def test_trigger_retry_by_issue_rejects_active_latest_event(env, monkeypatch: py
     token = _enable_replay(monkeypatch)
     cfg = Settings()  # type: ignore[call-arg]
     cfg.ensure_paths()
-    app = create_app(cfg)
+    app = _create_app(cfg)
     with TestClient(app) as client:
         db = get_database(cfg.sqlite_path)
         key = issue_key("octo/widget", 10)
@@ -832,7 +880,7 @@ def test_trigger_retry_by_issue_rejects_repo_not_in_allowlist(env, monkeypatch: 
     token = _enable_replay(monkeypatch)
     cfg = Settings()  # type: ignore[call-arg]
     cfg.ensure_paths()
-    app = create_app(cfg)
+    app = _create_app(cfg)
     with TestClient(app) as client:
         db = get_database(cfg.sqlite_path)
         db.record_event(
@@ -858,7 +906,7 @@ def test_trigger_retry_unknown_delivery_404s(env, monkeypatch: pytest.MonkeyPatc
     token = _enable_replay(monkeypatch)
     cfg = Settings()  # type: ignore[call-arg]
     cfg.ensure_paths()
-    app = create_app(cfg)
+    app = _create_app(cfg)
     with TestClient(app) as client:
         resp = client.post(
             "/api/trigger",
@@ -873,7 +921,7 @@ def test_trigger_rejects_bad_mode(env, monkeypatch: pytest.MonkeyPatch) -> None:
     token = _enable_replay(monkeypatch)
     cfg = Settings()  # type: ignore[call-arg]
     cfg.ensure_paths()
-    app = create_app(cfg)
+    app = _create_app(cfg)
     with TestClient(app) as client:
         resp = client.post(
             "/api/trigger",
@@ -965,7 +1013,7 @@ def rate_limited_settings(monkeypatch: pytest.MonkeyPatch, env: dict[str, str]) 
 
 
 def test_webhook_rate_limits_unknown_submitter_at_default_cap(rate_limited_settings: Settings) -> None:
-    app = create_app(rate_limited_settings)
+    app = _create_app(rate_limited_settings)
     with TestClient(app) as client:
         # Default cap is 2 → first two queued, third throttled.
         states = []
@@ -986,7 +1034,7 @@ def test_webhook_rate_limits_unknown_submitter_at_default_cap(rate_limited_setti
 def test_webhook_incoming_pr_comment_without_directive_skips_without_counting_budget(
     rate_limited_settings: Settings,
 ) -> None:
-    app = create_app(rate_limited_settings)
+    app = _create_app(rate_limited_settings)
     with TestClient(app) as client:
         skipped = _post_pr_issue_comment(
             client,
@@ -1023,7 +1071,7 @@ def test_webhook_incoming_pr_comment_without_directive_skips_without_counting_bu
 def test_webhook_delivery_populates_issue_index(settings: Settings) -> None:
     """Every issue-carrying delivery upserts the local search index — including
     ones the router skips (here: a conversation comment on an incoming PR)."""
-    app = create_app(settings)
+    app = _create_app(settings)
     with TestClient(app) as client:
         payload = {
             "action": "opened",
@@ -1057,7 +1105,7 @@ def test_webhook_delivery_populates_issue_index(settings: Settings) -> None:
 
 
 def test_webhook_contributor_gets_higher_cap(rate_limited_settings: Settings) -> None:
-    app = create_app(rate_limited_settings)
+    app = _create_app(rate_limited_settings)
     with TestClient(app) as client:
         # Default cap (2) would block at i=2; CONTRIBUTOR cap (4) allows it.
         for i in range(4):
@@ -1082,7 +1130,7 @@ def test_webhook_contributor_gets_higher_cap(rate_limited_settings: Settings) ->
 
 
 def test_webhook_owner_association_bypasses_limit(rate_limited_settings: Settings) -> None:
-    app = create_app(rate_limited_settings)
+    app = _create_app(rate_limited_settings)
     with TestClient(app) as client:
         for i in range(5):  # well over default cap
             resp = _post_issue_opened(
@@ -1097,7 +1145,7 @@ def test_webhook_owner_association_bypasses_limit(rate_limited_settings: Setting
 
 
 def test_webhook_unlimited_allowlist_bypasses_limit(rate_limited_settings: Settings) -> None:
-    app = create_app(rate_limited_settings)
+    app = _create_app(rate_limited_settings)
     with TestClient(app) as client:
         # NONE association would normally cap at 2, but `can1357` is whitelisted.
         for i in range(5):
@@ -1114,7 +1162,7 @@ def test_webhook_unlimited_allowlist_bypasses_limit(rate_limited_settings: Setti
 
 def test_webhook_rate_limit_per_user_is_independent(rate_limited_settings: Settings) -> None:
     """One user's cap doesn't drain another user's budget."""
-    app = create_app(rate_limited_settings)
+    app = _create_app(rate_limited_settings)
     with TestClient(app) as client:
         # alice exhausts default cap.
         for i in range(2):
@@ -1156,7 +1204,7 @@ def test_webhook_rate_limit_per_user_is_independent(rate_limited_settings: Setti
 
 def test_webhook_rate_limited_event_records_reason(rate_limited_settings: Settings) -> None:
     """Throttled events must surface a useful reason on the dashboard feed."""
-    app = create_app(rate_limited_settings)
+    app = _create_app(rate_limited_settings)
     with TestClient(app) as client:
         for i in range(3):
             _post_issue_opened(
@@ -1243,7 +1291,7 @@ def _make_issues_handler(
 
 
 def test_browse_returns_404_without_token(settings: Settings) -> None:
-    app = create_app(settings)
+    app = _create_app(settings)
     with TestClient(app) as client:
         resp = client.get("/api/github/issues")
     close_database()
@@ -1254,7 +1302,7 @@ def test_browse_returns_401_with_replay_enabled_without_valid_token(env, monkeyp
     token = _enable_replay(monkeypatch)
     cfg = Settings()  # type: ignore[call-arg]
     cfg.ensure_paths()
-    app = create_app(cfg)
+    app = _create_app(cfg)
 
     with TestClient(app) as client:
         missing = client.get("/api/github/issues")
@@ -1316,7 +1364,7 @@ def test_browse_fans_out_across_allowlist_and_filters_prs(env, monkeypatch: pyte
         },
         expected_limit=20,
     )
-    app = create_app(cfg)
+    app = _create_app(cfg)
     with TestClient(app) as client:
         _install_github_mock(app, transport)
         resp = client.get(
@@ -1354,7 +1402,7 @@ def test_browse_reuses_cache_until_forced_refresh(env, monkeypatch: pytest.Monke
         updated_at = "2026-05-14T10:00:00Z" if calls == 1 else "2026-05-14T11:00:00Z"
         return httpx.Response(200, json=[_issue_payload(1, title, updated_at=updated_at)])
 
-    app = create_app(cfg)
+    app = _create_app(cfg)
     with TestClient(app) as client:
         _install_github_mock(app, httpx.MockTransport(handler))
         first = client.get(
@@ -1395,7 +1443,7 @@ def test_browse_cache_updates_from_issue_webhook(env, monkeypatch: pytest.Monkey
         calls += 1
         return httpx.Response(200, json=[_issue_payload(4, "before", comments=1)])
 
-    app = create_app(cfg)
+    app = _create_app(cfg)
     with TestClient(app) as client:
         _install_github_mock(app, httpx.MockTransport(handler))
         first = client.get(
@@ -1461,7 +1509,7 @@ def test_browse_per_repo_failure_does_not_take_down_panel(env, monkeypatch: pyte
         failing_repos=("octo/dead",),
     )
 
-    app = create_app(cfg)
+    app = _create_app(cfg)
     with TestClient(app) as client:
         _install_github_mock(app, transport)
         resp = client.get(
@@ -1482,7 +1530,7 @@ def test_browse_rejects_bad_state(env, monkeypatch: pytest.MonkeyPatch) -> None:
     token = _enable_replay(monkeypatch)
     cfg = Settings()  # type: ignore[call-arg]
     cfg.ensure_paths()
-    app = create_app(cfg)
+    app = _create_app(cfg)
     with TestClient(app) as client:
         _install_github_mock(app, httpx.MockTransport(lambda r: httpx.Response(500)))
         resp = client.get(
@@ -1519,7 +1567,7 @@ def test_browse_marks_processed_issues_present_in_db(env, monkeypatch: pytest.Mo
         },
         expected_limit=20,
     )
-    app = create_app(cfg)
+    app = _create_app(cfg)
     with TestClient(app) as client:
         _install_github_mock(app, transport)
         resp = client.get(
@@ -1549,7 +1597,7 @@ def test_browse_processed_flag_is_recomputed_on_cache_hit(env, monkeypatch: pyte
         calls += 1
         return httpx.Response(200, json=[_issue_payload(9, "fresh")])
 
-    app = create_app(cfg)
+    app = _create_app(cfg)
     with TestClient(app) as client:
         _install_github_mock(app, httpx.MockTransport(handler))
         first = client.get(
@@ -1614,7 +1662,7 @@ def _post_issue_comment(
 def test_webhook_directive_on_unknown_issue_is_queued_with_metadata(env) -> None:
     cfg = Settings()  # type: ignore[call-arg]
     cfg.ensure_paths()
-    app = create_app(cfg)
+    app = _create_app(cfg)
     with TestClient(app) as client:
         resp = _post_issue_comment(
             client,
@@ -1642,7 +1690,7 @@ def test_webhook_directive_authorizes_deployed_app_login_without_author_associat
     reset_settings_cache()
     cfg = Settings()  # type: ignore[call-arg]
     cfg.ensure_paths()
-    app = create_app(cfg)
+    app = _create_app(cfg)
     payload = {
         "action": "created",
         "comment": {
@@ -1681,7 +1729,7 @@ def test_webhook_maintainer_bypasses_rate_limit(
     cfg = Settings()  # type: ignore[call-arg]
     cfg.ensure_paths()
 
-    app = create_app(cfg)
+    app = _create_app(cfg)
     with TestClient(app) as client:
         states = []
         # cap=2 from rate_limited_settings — 3rd would normally be skipped.
@@ -2811,7 +2859,7 @@ def test_webhook_issue_comment_cancels_pending_closure(settings: Settings) -> No
     db = get_database(settings.sqlite_path)
     key = issue_key("octo/widget", 7)
     _seed_pending_closure(db, key=key, number=7)
-    app = create_app(settings)
+    app = _create_app(settings)
     with TestClient(app) as client:
         resp = _post_issue_comment_simple(client, delivery="d-cancel-comment", issue_number=7)
     assert resp.status_code == 202
@@ -2826,7 +2874,7 @@ def test_webhook_issues_closed_cancels_pending_closure(settings: Settings) -> No
     db = get_database(settings.sqlite_path)
     key = issue_key("octo/widget", 8)
     _seed_pending_closure(db, key=key, number=8)
-    app = create_app(settings)
+    app = _create_app(settings)
     with TestClient(app) as client:
         resp = _post_issues_closed(client, delivery="d-cancel-closed", issue_number=8)
     assert resp.status_code == 202
@@ -2844,7 +2892,7 @@ def test_webhook_pr_conversation_does_not_cancel_pending_closure(settings: Setti
     db = get_database(settings.sqlite_path)
     key = issue_key("octo/widget", 9)
     _seed_pending_closure(db, key=key, number=9)
-    app = create_app(settings)
+    app = _create_app(settings)
     with TestClient(app) as client:
         # Use the existing PR-issue-comment helper (number 9 here is the PR).
         resp = _post_pr_issue_comment(


### PR DESCRIPTION
## Repro
Running `cd python/robomp && python3 -m pytest 'tests/test_server.py::test_trigger_triage_conflicts_when_manual_delivery_is_active[queued]' -q` intermittently lets the lifespan-started `WorkerPool` claim the test's queued event; the assertion then observes `running` instead of `queued`, with `event retry scheduled` in the captured log.

## Cause
`create_app()` starts `WorkerPool._dispatch_loop()` during every `TestClient` lifespan in `python/robomp/src/server.py`, while `python/robomp/tests/test_server.py` seeds and inspects queue rows as API fixtures. The real dispatch loop can call `WorkerPool._claim_next_unique()` between those test operations, mutating rows independently of the API behavior under test.

## Fix
- Add a module-autouse `paused_dispatcher` fixture that makes the server test worker pool report no claimable rows.
- Preserve the real pool startup/shutdown lifecycle while isolating API state assertions from background delivery execution; queue dispatch remains covered by its dedicated tests.

## Verification
`python3 -m pytest tests/test_server.py -q` passed all 69 tests in three consecutive full-file runs. The formerly failing queued parametrization passed 20 consecutive runs. `python3 -m ruff check tests/test_server.py` and `python3 -m ruff format --check tests/test_server.py` passed. The pre-publish `bun run fix` and `bun check` gate also passed.

Fixes #10382