### PR TITLE
fix(pi-shell): make process tests independent of coreutils

### DIFF
--- a/crates/pi-shell/src/shell.rs
+++ b/crates/pi-shell/src/shell.rs
@@ -2087,9 +2087,32 @@ mod tests {
 		let dir = tempfile::tempdir().expect("process test directory");
 		let name = format!("{prefix}{}", std::process::id());
 		let command = dir.path().join(&name);
-		let sleep = test_executable("sleep");
-		std::os::unix::fs::symlink(sleep, &command).expect("sleep symlink");
+		let test_binary = std::env::current_exe().expect("current test executable");
+		std::os::unix::fs::symlink(test_binary, &command).expect("test executable symlink");
 		(dir, command, name)
+	}
+
+	#[cfg(unix)]
+	fn process_test_child(command: &std::path::Path, duration: Duration) -> Command {
+		let duration_ms = u64::try_from(duration.as_millis()).expect("test duration fits u64");
+		let mut child = Command::new(command);
+		child
+			.args(["--ignored", "--exact", "shell::tests::process_test_sleeper"])
+			.env("PI_SHELL_PROCESS_TEST_SLEEP_MS", duration_ms.to_string())
+			.stdout(std::process::Stdio::null())
+			.stderr(std::process::Stdio::null());
+		child
+	}
+
+	#[cfg(unix)]
+	#[test]
+	#[ignore = "spawned by process-control tests"]
+	fn process_test_sleeper() {
+		let duration_ms = std::env::var("PI_SHELL_PROCESS_TEST_SLEEP_MS")
+			.expect("process test sleep duration")
+			.parse()
+			.expect("valid process test sleep duration");
+		std::thread::sleep(Duration::from_millis(duration_ms));
 	}
 
 	#[cfg(unix)]
@@ -2114,8 +2137,7 @@ mod tests {
 	#[tokio::test(flavor = "multi_thread")]
 	async fn pgrep_matches_name_and_pkills_signal_probe() {
 		let (_dir, command, name) = process_test_command("opg");
-		let mut child = Command::new(command)
-			.arg("30")
+		let mut child = process_test_child(&command, Duration::from_secs(30))
 			.spawn()
 			.expect("matching process");
 		let pid = i32::try_from(child.id().expect("child pid")).expect("pid fits i32");
@@ -2171,8 +2193,8 @@ mod tests {
 	#[tokio::test(flavor = "multi_thread")]
 	async fn pkill_queue_option_consumes_its_value() {
 		let (_dir, command, name) = process_test_command("opq");
-		let mut command = Command::new(command);
-		command.arg("30").kill_on_drop(true);
+		let mut command = process_test_child(&command, Duration::from_secs(30));
+		command.kill_on_drop(true);
 		let mut child = command.spawn().expect("queue test process");
 		let pid = i32::try_from(child.id().expect("child pid")).expect("pid fits i32");
 		wait_for_process_name(pid, &name).await;
@@ -2190,8 +2212,8 @@ mod tests {
 	#[tokio::test(flavor = "multi_thread")]
 	async fn pkill_interactive_prompt_honors_cancellation() {
 		let (_dir, command, name) = process_test_command("opi");
-		let mut command = Command::new(command);
-		command.arg("30").kill_on_drop(true);
+		let mut command = process_test_child(&command, Duration::from_secs(30));
+		command.kill_on_drop(true);
 		let mut child = command.spawn().expect("interactive target");
 		let pid = i32::try_from(child.id().expect("child pid")).expect("pid fits i32");
 		wait_for_process_name(pid, &name).await;
@@ -2227,8 +2249,7 @@ mod tests {
 	#[tokio::test(flavor = "multi_thread")]
 	async fn pgrep_reads_pidfile_from_standard_input() {
 		let (_dir, command, name) = process_test_command("opf");
-		let mut child = Command::new(command)
-			.arg("30")
+		let mut child = process_test_child(&command, Duration::from_secs(30))
 			.spawn()
 			.expect("pidfile process");
 		let pid = i32::try_from(child.id().expect("child pid")).expect("pid fits i32");
@@ -2252,8 +2273,7 @@ mod tests {
 		}
 
 		let (_dir, command, name) = process_test_command("opl");
-		let mut child = Command::new(command)
-			.arg("30")
+		let mut child = process_test_child(&command, Duration::from_secs(30))
 			.spawn()
 			.expect("locked pidfile process");
 		let pid = i32::try_from(child.id().expect("child pid")).expect("pid fits i32");
@@ -2308,12 +2328,10 @@ mod tests {
 	#[tokio::test(flavor = "multi_thread")]
 	async fn pkill_signals_every_matching_process() {
 		let (_dir, command, name) = process_test_command("opk");
-		let mut first = Command::new(&command)
-			.arg("30")
+		let mut first = process_test_child(&command, Duration::from_secs(30))
 			.spawn()
 			.expect("first matching process");
-		let mut second = Command::new(command)
-			.arg("30")
+		let mut second = process_test_child(&command, Duration::from_secs(30))
 			.spawn()
 			.expect("second matching process");
 		let first_pid = i32::try_from(first.id().expect("first pid")).expect("pid fits i32");
@@ -2340,8 +2358,7 @@ mod tests {
 	#[tokio::test(flavor = "multi_thread")]
 	async fn pidwait_returns_after_the_matching_process_exits() {
 		let (_dir, command, name) = process_test_command("opw");
-		let mut child = Command::new(command)
-			.arg("0.25")
+		let mut child = process_test_child(&command, Duration::from_millis(250))
 			.spawn()
 			.expect("waited process");
 		let pid = i32::try_from(child.id().expect("child pid")).expect("pid fits i32");

--- a/crates/pi-shell/src/shell.rs
+++ b/crates/pi-shell/src/shell.rs
@@ -2108,8 +2108,10 @@ mod tests {
 	#[test]
 	#[ignore = "spawned by process-control tests"]
 	fn process_test_sleeper() {
-		let duration_ms = std::env::var("PI_SHELL_PROCESS_TEST_SLEEP_MS")
-			.expect("process test sleep duration")
+		let Ok(duration_ms) = std::env::var("PI_SHELL_PROCESS_TEST_SLEEP_MS") else {
+			return;
+		};
+		let duration_ms = duration_ms
 			.parse()
 			.expect("valid process test sleep duration");
 		std::thread::sleep(Duration::from_millis(duration_ms));


### PR DESCRIPTION
## Repro

With Ubuntu `rust-coreutils_0.8.0-0ubuntu3`'s `sleep` first on `PATH`, `PATH=/tmp/uutils-bin:$PATH cargo nextest run -p pi-shell -E 'test(=shell::tests::pkill_signals_every_matching_process)'` fails after two `coreutils: unknown program 'opk…'` errors and the 2s `wait_for_process_name` timeout.

## Cause

`process_test_command()` in `crates/pi-shell/src/shell.rs` created each synthetic process name as a symlink to the system `sleep`; Ubuntu's uutils multi-call binary dispatches from the executed path and rejects that synthetic basename before it can sleep.

## Fix

- Point synthetic process names at the current pi-shell test binary instead of the host `sleep`.
- Launch an ignored sleeper test through that path, preserving the controllable process name without depending on coreutils dispatch.

## Verification

`PATH=/tmp/uutils-bin:$PATH cargo nextest run -p pi-shell -E 'test(/(pgrep_|pkill_|pidwait_)/)' --status-level=fail --final-status-level=fail` passed all 9 process-control tests against the Ubuntu rust-coreutils fixture. The pre-publish `bun check` gate also passed.

Fixes #10381