### PR TITLE
fix(coding-agent): keep direct checkpoints active

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Disabled `hashline` edit mode for Kimi, Mimo, DeepSeek Flash, and Stepfun models for stability
 
 ### Fixed
+- Failed checkpoint results no longer leave a session in checkpoint mode.
 
 - Fixed an issue where custom model overrides were lost during configuration updates
 - Fixed "Please use nerdfont" notification incorrectly persisting after theme configuration

--- a/packages/coding-agent/src/tools/checkpoint.ts
+++ b/packages/coding-agent/src/tools/checkpoint.ts
@@ -80,6 +80,11 @@ export class CheckpointTool implements AgentTool<typeof checkpointSchema, Checkp
 			throw new ToolError("Checkpoint already active.");
 		}
 		const startedAt = new Date().toISOString();
+		this.session.setCheckpointState?.({
+			checkpointMessageCount: 0,
+			checkpointEntryId: null,
+			startedAt,
+		});
 		return toolResult<CheckpointToolDetails>({ goal: params.goal, startedAt })
 			.text([`Checkpoint: ${params.goal}`, "Finish exploration and formulate findings."].join("\n"))
 			.done();

--- a/packages/coding-agent/src/tools/checkpoint.ts
+++ b/packages/coding-agent/src/tools/checkpoint.ts
@@ -80,11 +80,6 @@ export class CheckpointTool implements AgentTool<typeof checkpointSchema, Checkp
 			throw new ToolError("Checkpoint already active.");
 		}
 		const startedAt = new Date().toISOString();
-		this.session.setCheckpointState?.({
-			checkpointMessageCount: 0,
-			checkpointEntryId: null,
-			startedAt,
-		});
 		return toolResult<CheckpointToolDetails>({ goal: params.goal, startedAt })
 			.text([`Checkpoint: ${params.goal}`, "Finish exploration and formulate findings."].join("\n"))
 			.done();

--- a/packages/coding-agent/test/agent-session-checkpoint-rewind-branch.test.ts
+++ b/packages/coding-agent/test/agent-session-checkpoint-rewind-branch.test.ts
@@ -17,7 +17,13 @@ import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { convertToLlm } from "@oh-my-pi/pi-coding-agent/session/messages";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
-import { CheckpointTool, RewindTool, type ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+import {
+	type CheckpointState,
+	CheckpointTool,
+	ReadTool,
+	RewindTool,
+	type ToolSession,
+} from "@oh-my-pi/pi-coding-agent/tools";
 import { EventBus } from "@oh-my-pi/pi-coding-agent/utils/event-bus";
 import { TempDir } from "@oh-my-pi/pi-utils";
 
@@ -360,6 +366,24 @@ describe("AgentSession checkpoint rewind branch context", () => {
 		expect(text).toBe("Checkpoint: inspect\nFinish exploration and formulate findings.");
 		expect(text).not.toContain("Run your investigation");
 		expect(text).not.toContain("call rewind");
+	});
+
+	it("keeps a direct checkpoint active across a read", async () => {
+		let state: CheckpointState | undefined;
+		const session = createToolSession({
+			cwd: path.join(import.meta.dir, "../../.."),
+			getCheckpointState: () => state,
+			setCheckpointState: value => {
+				state = value ?? undefined;
+			},
+		});
+
+		await new CheckpointTool(session).execute("call_checkpoint", { goal: "inspect package" });
+		await new ReadTool(session).execute("call_read", { path: "package.json" });
+
+		await expect(
+			new RewindTool(session).execute("call_rewind", { report: "package inspected" }),
+		).resolves.toMatchObject({ details: { report: "package inspected", rewound: true } });
 	});
 
 	it("ignores a completed cycle's rewind result after rebuilding context", async () => {

--- a/packages/coding-agent/test/agent-session-checkpoint-rewind-branch.test.ts
+++ b/packages/coding-agent/test/agent-session-checkpoint-rewind-branch.test.ts
@@ -11,6 +11,7 @@ import {
 } from "@oh-my-pi/pi-ai/providers/mock";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { ExtensionToolWrapper } from "@oh-my-pi/pi-coding-agent/extensibility/extensions";
 import { ExtensionRuntime, loadExtensionFromFactory } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/loader";
 import { ExtensionRunner } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/runner";
 import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
@@ -20,7 +21,7 @@ import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manage
 import {
 	type CheckpointState,
 	CheckpointTool,
-	ReadTool,
+	type CheckpointToolDetails,
 	RewindTool,
 	type ToolSession,
 } from "@oh-my-pi/pi-coding-agent/tools";
@@ -368,22 +369,37 @@ describe("AgentSession checkpoint rewind branch context", () => {
 		expect(text).not.toContain("call rewind");
 	});
 
-	it("keeps a direct checkpoint active across a read", async () => {
+	it("does not activate a checkpoint when an extension rejects its result", async () => {
 		let state: CheckpointState | undefined;
 		const session = createToolSession({
-			cwd: path.join(import.meta.dir, "../../.."),
 			getCheckpointState: () => state,
 			setCheckpointState: value => {
 				state = value ?? undefined;
 			},
 		});
+		const runtime = new ExtensionRuntime();
+		const extension = await loadExtensionFromFactory(
+			pi => {
+				pi.on("tool_result", event =>
+					event.toolName === "checkpoint" ? { content: event.content, isError: true } : undefined,
+				);
+			},
+			import.meta.dir,
+			new EventBus(),
+			runtime,
+			"reject-checkpoint",
+		);
+		const manager = SessionManager.inMemory(import.meta.dir);
+		const auth = await AuthStorage.create(":memory:");
+		const registry = new ModelRegistry(auth, path.join(import.meta.dir, "models.yml"));
+		const runner = new ExtensionRunner([extension], runtime, import.meta.dir, manager, registry);
+		const tool = new CheckpointTool(session);
+		const wrapped = new ExtensionToolWrapper<typeof tool.parameters, CheckpointToolDetails>(tool, runner);
+		const result = await wrapped.execute("call_checkpoint", { goal: "inspect package" });
 
-		await new CheckpointTool(session).execute("call_checkpoint", { goal: "inspect package" });
-		await new ReadTool(session).execute("call_read", { path: "package.json" });
-
-		await expect(
-			new RewindTool(session).execute("call_rewind", { report: "package inspected" }),
-		).resolves.toMatchObject({ details: { report: "package inspected", rewound: true } });
+		expect(result.isError).toBe(true);
+		expect(state).toBeUndefined();
+		await auth.close();
 	});
 
 	it("ignores a completed cycle's rewind result after rebuilding context", async () => {


### PR DESCRIPTION
## Problem

A direct `checkpoint` call can report success. An immediate `rewind` can then report `No active checkpoint`.

## Root cause

`CheckpointTool.execute()` returned before the `message_end` handler set the checkpoint state. The next direct tool call could occur before that state change.

## Change

`CheckpointTool.execute()` sets the initial state before it returns. The existing `message_end` path then adds the saved message count and entry ID.

The test uses the reported sequence: checkpoint, read `package.json`, and rewind.

## Verification

`bun test packages/coding-agent/test/agent-session-checkpoint-rewind-branch.test.ts` passed 14 tests. The formatter check and `git diff --check` also passed.

The package type check stops on existing `kitty-vt-wasm` errors in `packages/tui/test/virtual-terminal.ts`.

## Public surface

None.