### PR TITLE
fix(coding-agent): forward parent extensions to /tan child so provider auth survives

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Fixed an issue where custom model overrides were lost during configuration updates
 - Fixed "Please use nerdfont" notification incorrectly persisting after theme configuration
 - Fixed sampling parameter errors for newer Anthropic models (Opus 4.7+, Sonnet 5+)
+- Fixed `/tan` background agents failing with "No API key found" when the active provider comes from an extension; the tangent now inherits the parent session's loaded extensions so its provider credentials resolve.
 
 ## [18.0.11] - 2026-08-29
 

--- a/packages/coding-agent/src/modes/controllers/tan-command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/tan-command-controller.ts
@@ -77,6 +77,17 @@ export class TanCommandController {
 		const systemPrompt = [...session.systemPrompt];
 		const toolNames = session.getEnabledToolNames();
 		const modelRegistry = session.modelRegistry;
+		// Snapshot the parent's rebindable extensions and root policy at dispatch.
+		// The child rebinds these (skipping discovery) so it re-registers the
+		// parent's runtime providers on the shared model registry before the SDK's
+		// syncExtensionSources prune runs — without this the child builds an empty
+		// extension set and unregisters the parent's provider auth (no-key error).
+		const parentPreparedExtensions = session.preparedExtensions;
+		// Path-list fallback for the (rare) parent build path that produced no
+		// prepared factories; the child rebinds from paths so it still re-registers
+		// providers rather than pruning the shared registry from an empty set.
+		const parentExtensionPaths = session.extensionPaths;
+		const parentExtensionRoots = session.effectiveExtensionRoots;
 		const ownerId = session.getAgentId() ?? MAIN_AGENT_ID;
 		const mcpManager = this.ctx.mcpManager;
 		const cwd = this.ctx.sessionManager.getCwd();
@@ -146,6 +157,13 @@ export class TanCommandController {
 							parentAgentId: ownerId,
 							agentRegistry,
 							disableExtensionDiscovery: true,
+							// `[]` is truthy and would make the child pick bindPreparedExtensions([])
+							// over a populated path fallback, so collapse an empty list to undefined.
+							preloadedPreparedExtensions: parentPreparedExtensions?.length
+								? parentPreparedExtensions
+								: undefined,
+							preloadedExtensionPaths: parentExtensionPaths?.length ? [...parentExtensionPaths] : undefined,
+							extensionRoots: () => parentExtensionRoots,
 							localProtocolOptions,
 						});
 						clone = created.session;

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -3633,6 +3633,8 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			settings,
 			additionalExtensionPaths: options.additionalExtensionPaths,
 			extensionRoots: buildSessionExtensionRoots,
+			preparedExtensions: extensionsResult.preparedExtensions,
+			extensionPaths,
 			disableExtensionDiscovery: options.disableExtensionDiscovery,
 			autoApprove: options.autoApprove,
 			scoutAllowedBySpawnPolicy: isScoutSpawnable(undefined, options.spawns ?? "*"),

--- a/packages/coding-agent/src/session/agent-session-types.ts
+++ b/packages/coding-agent/src/session/agent-session-types.ts
@@ -29,7 +29,7 @@ import type { CursorMcpResourceAdapter } from "../cursor";
 import type { RawSseDebugBuffer } from "../debug/raw-sse-buffer";
 import type { TtsrManager } from "../export/ttsr";
 import type { LoadedCustomCommand } from "../extensibility/custom-commands";
-import type { ExtensionRunner } from "../extensibility/extensions";
+import type { ExtensionRunner, PreparedExtension } from "../extensibility/extensions";
 import type { ContextUsage } from "../extensibility/extensions/types";
 import type { Skill, SkillWarning } from "../extensibility/skills";
 import type { FileSlashCommand } from "../extensibility/slash-commands";
@@ -132,6 +132,20 @@ export interface AgentSessionConfig {
 	 * provenance survive recursive task discovery.
 	 */
 	extensionRoots?: () => EffectiveExtensionRoots;
+	/**
+	 * Parent-imported extension factories rebound to this session's own
+	 * ExtensionAPI. Forwarded by session forks (e.g. `/tan`) so the child
+	 * re-registers the parent's runtime providers before the SDK's
+	 * `syncExtensionSources` prune runs against the shared model registry.
+	 */
+	preparedExtensions?: readonly PreparedExtension[];
+	/**
+	 * Source paths of the parent's loaded extensions. Forwarded alongside
+	 * {@link preparedExtensions} as the fallback the child rebinds from when a
+	 * parent construction path produced no prepared factories (mirrors the task
+	 * subagent forward) — keeps the child from building an empty extension set.
+	 */
+	extensionPaths?: readonly string[];
 	/** Raw SDK `additionalExtensionPaths`; used when no inherited root provider exists. */
 	additionalExtensionPaths?: readonly string[];
 	/** Mirror of `disableExtensionDiscovery`; used when no inherited root provider exists. */

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -128,6 +128,7 @@ import type {
 	MessageEndEvent,
 	MessageStartEvent,
 	MessageUpdateEvent,
+	PreparedExtension,
 	SessionBeforeBranchResult,
 	SessionBeforeSwitchResult,
 	SessionBeforeTreeResult,
@@ -512,6 +513,26 @@ export class AgentSession {
 	 */
 	get effectiveExtensionRoots(): EffectiveExtensionRoots {
 		return this.#extensionRoots();
+	}
+
+	/** Parent-imported extension factories, forwarded to session forks (`/tan`) to rebind runtime providers. */
+	readonly #preparedExtensions: readonly PreparedExtension[] | undefined;
+
+	/**
+	 * Session-independent imported extension factories safe to rebind in child
+	 * sessions. A `/tan` fork forwards these as `preloadedPreparedExtensions`
+	 * so the child re-registers the parent's runtime providers.
+	 */
+	get preparedExtensions(): readonly PreparedExtension[] | undefined {
+		return this.#preparedExtensions;
+	}
+
+	/** Source paths of the parent's loaded extensions; forwarded to `/tan` forks as the prepared-extension fallback. */
+	readonly #extensionPaths: readonly string[] | undefined;
+
+	/** Source paths of loaded extensions, forwarded to child sessions when prepared factories are unavailable. */
+	get extensionPaths(): readonly string[] | undefined {
+		return this.#extensionPaths;
 	}
 
 	#powerAssertion: MacOSPowerAssertion | undefined;
@@ -1061,6 +1082,8 @@ export class AgentSession {
 				configured: this.settings.get("extensions") ?? [],
 				configuredLevel: this.settings.extensionsSourceLevel(),
 			}));
+		this.#preparedExtensions = config.preparedExtensions;
+		this.#extensionPaths = config.extensionPaths;
 		this.#codexResetCoordinator = config.codexResetCoordinator ?? defaultCodexAutoRedeemCoordinator;
 		const bashHost: BashRunnerHost = {
 			agent: this.agent,

--- a/packages/coding-agent/test/modes/controllers/tan-command-controller.test.ts
+++ b/packages/coding-agent/test/modes/controllers/tan-command-controller.test.ts
@@ -2,7 +2,9 @@ import { afterEach, describe, expect, it, vi } from "bun:test";
 import * as path from "node:path";
 import type { AssistantMessage, Model } from "@oh-my-pi/pi-ai";
 import type { AsyncJobRegisterOptions } from "@oh-my-pi/pi-coding-agent/async/job-manager";
+import type { EffectiveExtensionRoots } from "@oh-my-pi/pi-coding-agent/capability/types";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import type { PreparedExtension } from "@oh-my-pi/pi-coding-agent/extensibility/extensions";
 import { resolveLocalRoot } from "@oh-my-pi/pi-coding-agent/internal-urls/local-protocol";
 import { TanCommandController } from "@oh-my-pi/pi-coding-agent/modes/controllers/tan-command-controller";
 import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
@@ -94,6 +96,9 @@ function createContext(overrides?: {
 	register?: (run: CapturedJobRun, options?: AsyncJobRegisterOptions) => string;
 	activeToolNames?: string[];
 	enabledToolNames?: string[];
+	preparedExtensions?: unknown;
+	effectiveExtensionRoots?: unknown;
+	extensionPaths?: unknown;
 }) {
 	const tempDir = TempDir.createSync("@omp-tan-controller-");
 	const parentFile = path.join(tempDir.path(), "parent.jsonl");
@@ -121,6 +126,9 @@ function createContext(overrides?: {
 		getActiveToolNames: vi.fn(() => overrides?.activeToolNames ?? ["read", "bash"]),
 		getEnabledToolNames: vi.fn(() => overrides?.enabledToolNames ?? overrides?.activeToolNames ?? ["read", "bash"]),
 		modelRegistry: { authStorage: { marker: "auth" } },
+		preparedExtensions: overrides?.preparedExtensions,
+		effectiveExtensionRoots: overrides?.effectiveExtensionRoots,
+		extensionPaths: overrides?.extensionPaths,
 		getAgentId: vi.fn(() => overrides?.agentId),
 		sendCustomMessage: vi.fn(async () => {
 			sequence.push("sendCustomMessage");
@@ -265,6 +273,75 @@ describe("TanCommandController", () => {
 		// The local mapping keys off the session-manager id (not `session.sessionId`,
 		// still "parent-session"), matching the parent's large-paste / local:// writes.
 		expect(opts.getSessionId?.()).toBe("parent-local-session");
+	});
+
+	it("forwards the parent's prepared extensions and root policy so the tan child rebinds runtime providers", async () => {
+		// Regression: the tan clone reuses the parent's shared ModelRegistry. If it
+		// is built without the parent's extensions, the SDK's syncExtensionSources
+		// prune unregisters extension-provided providers from that shared registry,
+		// so the child fails its API-key check ("No API key found for <provider>")
+		// and the parent loses the registration too. The child MUST rebind the
+		// parent's prepared extensions before that prune runs.
+		const preparedExtensions: PreparedExtension[] = [
+			{ path: "/ext/provider.ts", resolvedPath: "/ext/provider.ts", factory: null, error: null },
+		];
+		const effectiveExtensionRoots: EffectiveExtensionRoots = {
+			explicit: ["/ext/provider.ts"],
+			mode: "explicit-only",
+			configured: [],
+			configuredLevel: "user",
+		};
+		const extensionPaths = ["/ext/provider.ts"];
+		const harness = createContext({ preparedExtensions, effectiveExtensionRoots, extensionPaths });
+		vi.spyOn(SessionManager, "forkFrom").mockResolvedValue(harness.cloneManager);
+		const { clone } = createCloneStub({ lastAssistantText: "done" });
+		let capturedOptions: CreateAgentSessionOptions | undefined;
+		vi.spyOn(sdkModule, "createAgentSession").mockImplementation(async options => {
+			capturedOptions = options;
+			return { session: clone } as unknown as CreateAgentSessionResult;
+		});
+		const controller = new TanCommandController(harness.ctx);
+
+		await controller.start("chase the tangent");
+		const capturedRun = harness.capturedRun;
+		if (!capturedRun) throw new Error("run function was not captured");
+		await capturedRun({ jobId: "job-123", signal: new AbortController().signal, reportProgress: async () => {} });
+
+		expect(capturedOptions?.preloadedPreparedExtensions).toBe(preparedExtensions);
+		// Path-list fallback is forwarded (fresh copy) for parent builds without prepared factories.
+		expect(capturedOptions?.preloadedExtensionPaths).toEqual(extensionPaths);
+		expect(capturedOptions?.extensionRoots?.()).toBe(effectiveExtensionRoots);
+		expect(capturedOptions?.disableExtensionDiscovery).toBe(true);
+	});
+
+	it("collapses an empty prepared-extensions list to undefined so the child selects the path fallback", async () => {
+		// `[]` is truthy: if forwarded verbatim the child would bind an empty
+		// factory list and skip the populated path fallback, then prune the shared
+		// registry from an empty source set — the exact failure the fix prevents.
+		const effectiveExtensionRoots: EffectiveExtensionRoots = {
+			explicit: ["/ext/provider.ts"],
+			mode: "explicit-only",
+			configured: [],
+			configuredLevel: "user",
+		};
+		const extensionPaths = ["/ext/provider.ts"];
+		const harness = createContext({ preparedExtensions: [], effectiveExtensionRoots, extensionPaths });
+		vi.spyOn(SessionManager, "forkFrom").mockResolvedValue(harness.cloneManager);
+		const { clone } = createCloneStub({ lastAssistantText: "done" });
+		let capturedOptions: CreateAgentSessionOptions | undefined;
+		vi.spyOn(sdkModule, "createAgentSession").mockImplementation(async options => {
+			capturedOptions = options;
+			return { session: clone } as unknown as CreateAgentSessionResult;
+		});
+		const controller = new TanCommandController(harness.ctx);
+
+		await controller.start("chase the tangent");
+		const capturedRun = harness.capturedRun;
+		if (!capturedRun) throw new Error("run function was not captured");
+		await capturedRun({ jobId: "job-123", signal: new AbortController().signal, reportProgress: async () => {} });
+
+		expect(capturedOptions?.preloadedPreparedExtensions).toBeUndefined();
+		expect(capturedOptions?.preloadedExtensionPaths).toEqual(extensionPaths);
 	});
 
 	it("aborts the cloned agent when the background job signal aborts", async () => {

--- a/packages/coding-agent/test/tan-extension-auth.test.ts
+++ b/packages/coding-agent/test/tan-extension-auth.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Regression: a `/tan` background fork reuses the parent's live ModelRegistry
+ * instance. The fix forwards the parent's `preparedExtensions` (and root policy)
+ * so the child rebinds the extension and re-registers its provider before the
+ * SDK's `syncExtensionSources` prune runs against that shared registry.
+ *
+ * This is the behavior contract behind the controller-level plumbing test:
+ * after a tan-like child is created on the shared registry, the extension
+ * provider's credential MUST still resolve (both for the child and the parent).
+ * Without the forward the prune sees an empty active-source set and unregisters
+ * the provider, so the pre-send API-key check fails with "No API key found".
+ */
+import { describe, expect, it } from "bun:test";
+import * as path from "node:path";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { createAgentSession } from "@oh-my-pi/pi-coding-agent/sdk";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+const PROVIDER = "tan-fixture-gw";
+const MODEL_ID = "tan-fixture-model";
+const SENTINEL = "tan-fixture-sentinel-key";
+
+// No streamSimple / oauth: registration mutates only this ModelRegistry
+// instance, never a process-global custom-API/OAuth table.
+const EXTENSION_SOURCE = `export default function (pi) {
+	pi.registerProvider(${JSON.stringify(PROVIDER)}, {
+		baseUrl: "https://tan-fixture.example.invalid/v1",
+		apiKey: ${JSON.stringify(SENTINEL)},
+		api: "openai-completions",
+		models: [{
+			id: ${JSON.stringify(MODEL_ID)},
+			name: "Tan Fixture Model",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 128000,
+			maxTokens: 8192,
+		}],
+	});
+}
+`;
+
+function baseOptions(cwd: string) {
+	return {
+		cwd,
+		agentDir: cwd,
+		settings: Settings.isolated({ "marketplace.autoUpdate": "off", "compaction.enabled": false }),
+		skills: [],
+		contextFiles: [],
+		promptTemplates: [],
+		slashCommands: [],
+		enableMCP: false,
+		enableLsp: false,
+		skipPythonPreflight: true as const,
+	};
+}
+
+describe("/tan extension auth over a shared registry", () => {
+	it("keeps the extension provider's credential resolvable after a forwarded tan-like child is created", async () => {
+		using tempDir = TempDir.createSync("omp-tan-ext-auth-");
+		const cwd = path.resolve(tempDir.path());
+		const extPath = path.join(cwd, "provider-ext.ts");
+		await Bun.write(extPath, EXTENSION_SOURCE);
+
+		const authStorage = await AuthStorage.create(tempDir.join("auth.db"));
+		const modelRegistry = new ModelRegistry(authStorage, tempDir.join("models.yml"));
+		const base = baseOptions(cwd);
+
+		try {
+			const { session: parent } = await createAgentSession({
+				...base,
+				sessionManager: SessionManager.inMemory(cwd),
+				authStorage,
+				modelRegistry,
+				additionalExtensionPaths: [extPath],
+				disableExtensionDiscovery: true,
+			});
+
+			const model = modelRegistry.find(PROVIDER, MODEL_ID);
+			expect(model).toBeDefined();
+			expect(await modelRegistry.getApiKey(model!)).toBe(SENTINEL);
+			expect(parent.preparedExtensions?.length).toBeGreaterThan(0);
+
+			// Tan child: forwards the parent's prepared extensions + root policy, so
+			// bindPreparedExtensions re-registers the provider before the prune.
+			const { session: tanChild } = await createAgentSession({
+				...base,
+				sessionManager: SessionManager.inMemory(cwd),
+				authStorage,
+				modelRegistry,
+				disableExtensionDiscovery: true,
+				preloadedPreparedExtensions: parent.preparedExtensions,
+				extensionRoots: () => parent.effectiveExtensionRoots,
+			});
+
+			// Child request auth resolves AND the parent's registration survives on
+			// the shared registry instance.
+			expect(await tanChild.modelRegistry.getApiKey(model!)).toBe(SENTINEL);
+			expect(await modelRegistry.getApiKey(model!)).toBe(SENTINEL);
+
+			await tanChild.dispose();
+			await parent.dispose();
+		} finally {
+			authStorage.close();
+		}
+	}, 20_000);
+
+	it("preserves auth via the extension-paths fallback when no prepared factories are forwarded", async () => {
+		using tempDir = TempDir.createSync("omp-tan-ext-auth-fallback-");
+		const cwd = path.resolve(tempDir.path());
+		const extPath = path.join(cwd, "provider-ext.ts");
+		await Bun.write(extPath, EXTENSION_SOURCE);
+
+		const authStorage = await AuthStorage.create(tempDir.join("auth.db"));
+		const modelRegistry = new ModelRegistry(authStorage, tempDir.join("models.yml"));
+		const base = baseOptions(cwd);
+
+		try {
+			const { session: parent } = await createAgentSession({
+				...base,
+				sessionManager: SessionManager.inMemory(cwd),
+				authStorage,
+				modelRegistry,
+				additionalExtensionPaths: [extPath],
+				disableExtensionDiscovery: true,
+			});
+			const model = modelRegistry.find(PROVIDER, MODEL_ID);
+			expect(model).toBeDefined();
+			expect(await modelRegistry.getApiKey(model!)).toBe(SENTINEL);
+
+			// Simulate the rare parent build path that yields no prepared factories:
+			// the child rebinds from source paths (SDK branch: preloadedExtensionPaths)
+			// and must still re-register the provider before the prune.
+			const { session: tanChild } = await createAgentSession({
+				...base,
+				sessionManager: SessionManager.inMemory(cwd),
+				authStorage,
+				modelRegistry,
+				disableExtensionDiscovery: true,
+				preloadedExtensionPaths: [extPath],
+				extensionRoots: () => parent.effectiveExtensionRoots,
+			});
+
+			expect(await tanChild.modelRegistry.getApiKey(model!)).toBe(SENTINEL);
+			expect(await modelRegistry.getApiKey(model!)).toBe(SENTINEL);
+
+			await tanChild.dispose();
+			await parent.dispose();
+		} finally {
+			authStorage.close();
+		}
+	}, 20_000);
+});


### PR DESCRIPTION
## What was broken

`/tan` runs its background clone in-process and reuses the parent session's live `ModelRegistry`. The clone was built with `disableExtensionDiscovery: true` and no forwarded extensions, so it reached `syncExtensionSources([])` with an empty active-source set. That call ran `clearSourceRegistrations` on the shared registry and dropped any extension-provided provider's `apiKey` resolver and `streamSimple` handler.

The visible symptom: when the active provider comes from an extension, the tangent fails its pre-send API-key check with `No API key found for <provider>`. Because the registry instance is shared, the parent's registration got wiped too.

`task` and structured subagents avoid this. They forward `preloadedPreparedExtensions`, `preloadedExtensionPaths`, and `extensionRoots`, so their active-source set is non-empty and the prune re-registers the provider.

## The fix

Forward the parent's rebindable extensions into the tan clone, the same way subagents do:

- `AgentSession` now exposes `preparedExtensions` and `extensionPaths`, populated during session construction in the SDK.
- `TanCommandController` snapshots and forwards `preloadedPreparedExtensions`, `preloadedExtensionPaths` (as a fallback), and `extensionRoots` to `createAgentSession`. It keeps `disableExtensionDiscovery: true`, so the child takes the rebind branch, re-registers the provider before the prune, and stays focused (no custom-command or MCP load).
- An empty prepared list collapses to `undefined`. Otherwise `[]` is truthy and the child would bind an empty factory set, skip a populated path fallback, and prune the shared registry anyway.

## Tests

- `tan-command-controller.test.ts`: the clone is built with the parent's prepared extensions, path fallback, and root callback; an empty prepared list falls back to the path list.
- `tan-extension-auth.test.ts`: over a shared registry, the extension provider's credential still resolves for both child and parent after a forwarded tan-like build, through both the prepared-factory branch and the extension-paths fallback.

Both tests fail if the forwarding is removed.
