### PR TITLE
feat(coding-agent): gate Assignment mutations

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Devin model selectors now accept the native CLI's short aliases (`devin/opus`, `devin/swe`), dotted upstream spellings (`devin/gemini-3.7-flash`), and raw effort-route wire uids for dynamically collapsed families ([#8590](https://github.com/can1357/oh-my-pi/pull/8590) by [@will-bogusz](https://github.com/will-bogusz)).
 - Added provider-supplied model metadata to the `/models` detail line: `new`, `beta`, and `recommended` badges beside the model name, and the upstream description after the context, cost, and perf facts ([#8590](https://github.com/can1357/oh-my-pi/pull/8590) by [@will-bogusz](https://github.com/will-bogusz)).
 - Standalone `CLAUDE.md` files in the project root (and ancestor directories) are now loaded as context, mirroring `AGENTS.md` discovery; config-directory context files still take precedence per scope.
+- Added opt-in Assignment capability sessions that keep trusted reads local and broker `write`, `edit`, `ast_edit`, and mutating `lsp` calls through Juiz.
 
 ### Changed
 

--- a/packages/coding-agent/src/assignment-capability/canonical-json.ts
+++ b/packages/coding-agent/src/assignment-capability/canonical-json.ts
@@ -1,0 +1,16 @@
+type JsonRecord = Record<string, unknown>;
+
+function goJsonString(value: string): string {
+	return JSON.stringify(value).replaceAll("\u2028", "\\u2028").replaceAll("\u2029", "\\u2029");
+}
+
+/** Serialize a JSON-compatible value using Go's UTF-8 object-key ordering. */
+export function stableJson(value: unknown): string {
+	if (typeof value === "string") return goJsonString(value);
+	if (value === null || typeof value !== "object") return JSON.stringify(value);
+	if (Array.isArray(value)) return `[${value.map(stableJson).join(",")}]`;
+	const entries = Object.entries(value as JsonRecord)
+		.map(([key, entry]) => ({ key, entry, bytes: Buffer.from(key) }))
+		.sort((left, right) => left.bytes.compare(right.bytes));
+	return `{${entries.map(({ key, entry }) => `${goJsonString(key)}:${stableJson(entry)}`).join(",")}}`;
+}

--- a/packages/coding-agent/src/assignment-capability/complete-tool.ts
+++ b/packages/coding-agent/src/assignment-capability/complete-tool.ts
@@ -1,0 +1,21 @@
+import { type } from "@oh-my-pi/omptype";
+import type { AgentTool, AgentToolResult } from "@oh-my-pi/pi-agent-core";
+import description from "../prompts/tools/assignment-complete.md" with { type: "text" };
+
+const assignmentCompleteSchema = type({}).describe("complete the active Assignment");
+
+/** Explicit semantic boundary for an Assignment Session; the universal gate owns execution. */
+export class AssignmentCompleteTool implements AgentTool<typeof assignmentCompleteSchema> {
+	readonly name = "assignment_complete";
+	readonly approval = "write" as const;
+	readonly label = "Complete Assignment";
+	readonly summary = "Complete the Assignment and revoke mutation authority";
+	readonly description = description;
+	readonly parameters = assignmentCompleteSchema;
+	readonly concurrency = "exclusive";
+	readonly strict = true;
+
+	async execute(): Promise<AgentToolResult> {
+		throw new Error("Assignment completion requires the authenticated Assignment capability runtime");
+	}
+}

--- a/packages/coding-agent/src/assignment-capability/gate.ts
+++ b/packages/coding-agent/src/assignment-capability/gate.ts
@@ -1,0 +1,77 @@
+import type { ToolTier } from "@oh-my-pi/pi-agent-core";
+
+export type AssignmentToolTrust = "core" | "core-readonly" | "external";
+
+export type AssignmentToolClassification =
+	| { readonly kind: "read" }
+	| { readonly kind: "mutation"; readonly family: "write" | "edit" | "ast_edit" | "lsp" }
+	| { readonly kind: "completion" }
+	| { readonly kind: "denied" };
+
+const CORE_READ_TOOLS: Record<string, true> = {
+	read: true,
+	glob: true,
+	grep: true,
+	web_search: true,
+	ast_grep: true,
+	inspect_image: true,
+};
+const CORE_TIERED_READ_TOOLS: Record<string, true> = {
+	github: true,
+	debug: true,
+	computer: true,
+	lsp: true,
+};
+const PASSIVE_HUB_OPS: Record<string, true> = {
+	jobs: true,
+	inbox: true,
+	list: true,
+	ps: true,
+	logs: true,
+	describe: true,
+	wait: true,
+};
+const MUTATION_FAMILIES: Record<string, true> = { write: true, edit: true, ast_edit: true, lsp: true };
+const XDEV_PREFIX = "xd://";
+
+function record(value: unknown): Record<string, unknown> | undefined {
+	return typeof value === "object" && value !== null && !Array.isArray(value)
+		? (value as Record<string, unknown>)
+		: undefined;
+}
+
+function xdevTarget(args: unknown): string | undefined {
+	const raw = record(args)?.path;
+	if (typeof raw !== "string" || !raw.startsWith(XDEV_PREFIX)) return undefined;
+	const target = raw.slice(XDEV_PREFIX.length).split(/[/:?#]/, 1)[0];
+	return target || undefined;
+}
+
+/** Core registration and exact final arguments jointly determine whether a call is read-only. */
+export function classifyAssignmentTool(
+	toolName: string,
+	trust: AssignmentToolTrust,
+	tier: ToolTier,
+	args: unknown,
+): AssignmentToolClassification {
+	if (trust !== "core" && trust !== "core-readonly") return { kind: "denied" };
+	const xdTarget = toolName === "write" ? xdevTarget(args) : undefined;
+	if (xdTarget) {
+		// The discussion Session may not turn an admitted outer `write` transport
+		// into nested authority. Call the core tool directly; hidden workers also
+		// reject nested xd dispatch.
+		return { kind: "denied" };
+	}
+
+	if (tier === "read") {
+		if (CORE_READ_TOOLS[toolName] || CORE_TIERED_READ_TOOLS[toolName]) return { kind: "read" };
+		if (toolName === "hub" && PASSIVE_HUB_OPS[String(record(args)?.op ?? "")]) return { kind: "read" };
+		return { kind: "denied" };
+	}
+	if (tier !== "write") return { kind: "denied" };
+	if (trust === "core-readonly") return { kind: "denied" };
+	if (toolName === "assignment_complete") return { kind: "completion" };
+	return MUTATION_FAMILIES[toolName]
+		? { kind: "mutation", family: toolName as "write" | "edit" | "ast_edit" | "lsp" }
+		: { kind: "denied" };
+}

--- a/packages/coding-agent/src/assignment-capability/index.ts
+++ b/packages/coding-agent/src/assignment-capability/index.ts
@@ -1,3 +1,4 @@
+export * from "./canonical-json";
 export * from "./complete-tool";
 export * from "./gate";
 export * from "./runtime";

--- a/packages/coding-agent/src/assignment-capability/index.ts
+++ b/packages/coding-agent/src/assignment-capability/index.ts
@@ -1,0 +1,4 @@
+export * from "./complete-tool";
+export * from "./gate";
+export * from "./runtime";
+export * from "./types";

--- a/packages/coding-agent/src/assignment-capability/runtime.ts
+++ b/packages/coding-agent/src/assignment-capability/runtime.ts
@@ -1,3 +1,4 @@
+import { stableJson } from "./canonical-json";
 import type {
 	AssignmentCapabilityBinding,
 	AssignmentCapabilityLaunchOptions,
@@ -15,6 +16,8 @@ const CONNECT_TIMEOUT_MS = 5_000;
 const SAFE_CODE = /^[A-Z0-9_.-]{1,80}$/i;
 const MAX_RECONCILIATION_RESERVE_MS = 2_000;
 const MIN_RECONCILIATION_RESERVE_MS = 250;
+const TERMINATION_GRACE_MS = 50;
+const MIN_GATEWAY_ATTEMPT_MS = TERMINATION_GRACE_MS * 2 + 1;
 
 type JsonRecord = Record<string, unknown>;
 
@@ -77,18 +80,91 @@ function encodeFrame(value: unknown): Uint8Array {
 	return frame;
 }
 
-function goJsonString(value: string): string {
-	return JSON.stringify(value).replaceAll("\u2028", "\\u2028").replaceAll("\u2029", "\\u2029");
+class GatewayOutputOverflowError extends Error {}
+
+interface BoundedStreamRead {
+	readonly promise: Promise<string>;
+	cancel(): void;
 }
 
-function stableJson(value: unknown): string {
-	if (typeof value === "string") return goJsonString(value);
-	if (value === null || typeof value !== "object") return JSON.stringify(value);
-	if (Array.isArray(value)) return `[${value.map(stableJson).join(",")}]`;
-	const entries = Object.entries(value as JsonRecord).sort(([left], [right]) =>
-		Buffer.from(left).compare(Buffer.from(right)),
-	);
-	return `{${entries.map(([key, entry]) => `${goJsonString(key)}:${stableJson(entry)}`).join(",")}}`;
+function readBoundedGatewayStream(stream: ReadableStream<Uint8Array>, capture: boolean): BoundedStreamRead {
+	const reader = stream.getReader();
+	let settled = false;
+	const chunks: Uint8Array[] = [];
+	const promise = (async () => {
+		let bytes = 0;
+		try {
+			while (true) {
+				const { value, done } = await reader.read();
+				if (done) break;
+				if (bytes + value.byteLength > MAX_FRAME_BYTES) throw new GatewayOutputOverflowError();
+				bytes += value.byteLength;
+				if (capture) chunks.push(value);
+			}
+			if (!capture) return "";
+			const output = new Uint8Array(bytes);
+			let offset = 0;
+			for (const chunk of chunks) {
+				output.set(chunk, offset);
+				offset += chunk.byteLength;
+			}
+			return new TextDecoder().decode(output);
+		} finally {
+			settled = true;
+			reader.releaseLock();
+		}
+	})();
+	return {
+		promise,
+		cancel: () => {
+			if (settled) return;
+			try {
+				void reader.cancel().catch(() => undefined);
+			} catch {
+				// The stream settled between the state check and cancellation.
+			}
+		},
+	};
+}
+
+function deadlineTimer(deadlineMillis: number): {
+	readonly promise: Promise<void>;
+	cancel(): void;
+} {
+	const { promise, resolve } = Promise.withResolvers<void>();
+	const timer = setTimeout(resolve, Math.max(0, deadlineMillis - Date.now()));
+	return { promise, cancel: () => clearTimeout(timer) };
+}
+
+async function waitForProcessExit(exitPromise: Promise<number>, deadlineMillis: number): Promise<boolean> {
+	if (Date.now() >= deadlineMillis) return false;
+	const timer = deadlineTimer(deadlineMillis);
+	try {
+		return await Promise.race([exitPromise.then(() => true), timer.promise.then(() => false)]);
+	} finally {
+		timer.cancel();
+	}
+}
+
+async function terminateGatewayProcess(
+	process: Bun.Subprocess,
+	exitPromise: Promise<number>,
+	deadlineMillis: number,
+): Promise<void> {
+	if (process.exitCode !== null) return;
+	try {
+		process.kill("SIGTERM");
+	} catch {
+		// The process exited between the exit-code check and the signal.
+	}
+	const gracefulDeadline = Math.min(deadlineMillis, Date.now() + TERMINATION_GRACE_MS);
+	if (await waitForProcessExit(exitPromise, gracefulDeadline)) return;
+	try {
+		process.kill("SIGKILL");
+	} catch {
+		// The process exited between the grace period and escalation.
+	}
+	await waitForProcessExit(exitPromise, Math.min(deadlineMillis, Date.now() + TERMINATION_GRACE_MS));
 }
 
 function denial(code?: unknown): Error {
@@ -111,6 +187,9 @@ export async function callAssignmentGateway(
 		Math.max(MIN_RECONCILIATION_RESERVE_MS, Math.floor(remaining / 4)),
 	);
 	const firstAttemptTimeout = Math.max(1, remaining - reconciliationReserve);
+	if (firstAttemptTimeout < MIN_GATEWAY_ATTEMPT_MS) {
+		return callAssignmentGatewayOnce(argv, request, deadlineMillis - Date.now());
+	}
 	try {
 		return await callAssignmentGatewayOnce(argv, request, firstAttemptTimeout);
 	} catch (error) {
@@ -126,7 +205,9 @@ async function callAssignmentGatewayOnce(
 	request: Readonly<JsonRecord>,
 	timeoutMs: number,
 ): Promise<unknown> {
-	if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) throw denial("GATEWAY_TIMEOUT");
+	if (!Number.isFinite(timeoutMs) || timeoutMs < MIN_GATEWAY_ATTEMPT_MS) throw denial("GATEWAY_TIMEOUT");
+	const attemptDeadline = Date.now() + timeoutMs;
+	const ioDeadline = attemptDeadline - TERMINATION_GRACE_MS * 2;
 	const process = Bun.spawn([...argv], {
 		cwd: "/",
 		env: { PATH: Bun.env.PATH ?? "" },
@@ -134,23 +215,45 @@ async function callAssignmentGatewayOnce(
 		stdout: "pipe",
 		stderr: "pipe",
 	});
-	process.stdin.write(JSON.stringify(request));
-	process.stdin.end();
-	const stdoutPromise = new Response(process.stdout as ReadableStream<Uint8Array>).text();
-	const stderrPromise = new Response(process.stderr as ReadableStream<Uint8Array>).text();
+	const stdout = readBoundedGatewayStream(process.stdout as ReadableStream<Uint8Array>, true);
+	const stderr = readBoundedGatewayStream(process.stderr as ReadableStream<Uint8Array>, false);
 	const exitPromise = process.exited;
-	const timeout = Bun.sleep(Math.max(1, timeoutMs)).then(() => "timeout" as const);
-	const outcome = await Promise.race([exitPromise, timeout]);
-	if (outcome === "timeout") {
-		process.kill();
-		await Promise.allSettled([stdoutPromise, stderrPromise, exitPromise]);
-		throw new GatewayAmbiguityError("GATEWAY_TIMEOUT");
+	const completed = Promise.all([exitPromise, stdout.promise, stderr.promise]);
+	const timeout = deadlineTimer(ioDeadline);
+	let output: string;
+	try {
+		process.stdin.write(JSON.stringify(request));
+		process.stdin.end();
+		const outcome = await Promise.race([
+			completed.then(([exitCode, stdoutText]) => ({
+				kind: "complete" as const,
+				exitCode,
+				stdout: stdoutText,
+			})),
+			timeout.promise.then(() => ({ kind: "timeout" as const })),
+		]);
+		if (outcome.kind === "timeout") throw new GatewayAmbiguityError("GATEWAY_TIMEOUT");
+		if (outcome.exitCode !== 0) throw new GatewayAmbiguityError("GATEWAY_UNAVAILABLE");
+		output = outcome.stdout;
+	} catch (error) {
+		stdout.cancel();
+		stderr.cancel();
+		try {
+			process.stdin.end();
+		} catch {
+			// The subprocess may already have closed its input pipe.
+		}
+		await terminateGatewayProcess(process, exitPromise, attemptDeadline);
+		if (error instanceof GatewayOutputOverflowError) {
+			throw new GatewayAmbiguityError("GATEWAY_UNAVAILABLE");
+		}
+		throw error;
+	} finally {
+		timeout.cancel();
 	}
-	const [stdout] = await Promise.all([stdoutPromise, stderrPromise]);
-	if (outcome !== 0 || stdout.length > MAX_FRAME_BYTES) throw new GatewayAmbiguityError("GATEWAY_UNAVAILABLE");
 	let decoded: JsonRecord;
 	try {
-		decoded = object(JSON.parse(stdout));
+		decoded = object(JSON.parse(output));
 	} catch {
 		throw new GatewayAmbiguityError("GATEWAY_INVALID_RESPONSE");
 	}
@@ -321,15 +424,20 @@ class HerdrCapabilityClient {
 	async connect(): Promise<void> {
 		let settled = false;
 		const { promise, resolve, reject } = Promise.withResolvers<void>();
-		const timer = setTimeout(
-			() => reject(new Error("Assignment capability denied: Herdr unavailable")),
-			CONNECT_TIMEOUT_MS,
-		);
-		void promise.finally(() => clearTimeout(timer));
+		const unavailable = (): void => {
+			if (settled) return;
+			settled = true;
+			reject(new Error("Assignment capability denied: Herdr unavailable"));
+		};
+		const timer = setTimeout(unavailable, CONNECT_TIMEOUT_MS);
 		void Bun.connect({
 			unix: this.#options.herdrSocketPath,
 			socket: {
 				open: socket => {
+					if (settled) {
+						socket.end();
+						return;
+					}
 					this.#socket = socket;
 					settled = true;
 					resolve();
@@ -337,12 +445,16 @@ class HerdrCapabilityClient {
 				data: (_socket, data) => this.#receive(new Uint8Array(data)),
 				close: () => this.#failAll(new Error("Assignment capability denied: Herdr connection closed")),
 				error: (_socket, error) => {
-					if (!settled) reject(new Error("Assignment capability denied: Herdr unavailable"));
+					unavailable();
 					this.#failAll(error instanceof Error ? error : new Error(String(error)));
 				},
 			},
-		}).catch(() => reject(new Error("Assignment capability denied: Herdr unavailable")));
-		await promise;
+		}).catch(unavailable);
+		try {
+			await promise;
+		} finally {
+			clearTimeout(timer);
+		}
 		const requestId = crypto.randomUUID();
 		const response = await this.#request({
 			schema: ASSIGNMENT_CAPABILITY_SCHEMA,

--- a/packages/coding-agent/src/assignment-capability/runtime.ts
+++ b/packages/coding-agent/src/assignment-capability/runtime.ts
@@ -1,0 +1,713 @@
+import type {
+	AssignmentCapabilityBinding,
+	AssignmentCapabilityLaunchOptions,
+	AssignmentCapabilityNotice,
+	AssignmentCapabilityRecord,
+	AssignmentCapabilityScope,
+	AssignmentCompletionResult,
+	AssignmentExecuteInput,
+	AssignmentExecuteResult,
+} from "./types";
+import { ASSIGNMENT_CAPABILITY_SCHEMA } from "./types";
+
+const MAX_FRAME_BYTES = 2 * 1024 * 1024;
+const CONNECT_TIMEOUT_MS = 5_000;
+const SAFE_CODE = /^[A-Z0-9_.-]{1,80}$/i;
+const MAX_RECONCILIATION_RESERVE_MS = 2_000;
+const MIN_RECONCILIATION_RESERVE_MS = 250;
+
+type JsonRecord = Record<string, unknown>;
+
+interface PreparedAssignmentExecuteInput extends AssignmentExecuteInput {
+	readonly deadline: string;
+	readonly operationDigest: string;
+}
+
+interface PreparedAssignmentCompletionInput {
+	readonly toolCall: string;
+	readonly deadline: string;
+	readonly operationDigest: string;
+}
+
+class GatewayAmbiguityError extends Error {
+	constructor(code: string) {
+		super(denial(code).message);
+	}
+}
+
+function object(value: unknown): JsonRecord {
+	if (typeof value !== "object" || value === null || Array.isArray(value)) {
+		throw new Error("Assignment capability denied: invalid authorization response");
+	}
+	return value as JsonRecord;
+}
+
+function requireClosed(value: unknown, fields: readonly string[]): JsonRecord {
+	const result = object(value);
+	const keys = Object.keys(result);
+	if (keys.length !== fields.length || keys.some(key => !fields.includes(key))) {
+		throw new Error("Assignment capability denied: invalid authorization response");
+	}
+	return result;
+}
+
+function requireString(record: JsonRecord, field: string): string {
+	const value = record[field];
+	if (typeof value !== "string" || value.length === 0) {
+		throw new Error("Assignment capability denied: invalid authorization response");
+	}
+	return value;
+}
+
+function requireNumber(record: JsonRecord, field: string): number {
+	const value = record[field];
+	if (typeof value !== "number" || !Number.isFinite(value)) {
+		throw new Error("Assignment capability denied: invalid authorization response");
+	}
+	return value;
+}
+
+function encodeFrame(value: unknown): Uint8Array {
+	const payload = new TextEncoder().encode(JSON.stringify(value));
+	if (payload.byteLength > MAX_FRAME_BYTES)
+		throw new Error("Assignment capability denied: authorization request is too large");
+	const frame = new Uint8Array(4 + payload.byteLength);
+	new DataView(frame.buffer).setUint32(0, payload.byteLength, true);
+	frame.set(payload, 4);
+	return frame;
+}
+
+function goJsonString(value: string): string {
+	return JSON.stringify(value).replaceAll("\u2028", "\\u2028").replaceAll("\u2029", "\\u2029");
+}
+
+function stableJson(value: unknown): string {
+	if (typeof value === "string") return goJsonString(value);
+	if (value === null || typeof value !== "object") return JSON.stringify(value);
+	if (Array.isArray(value)) return `[${value.map(stableJson).join(",")}]`;
+	const entries = Object.entries(value as JsonRecord).sort(([left], [right]) =>
+		Buffer.from(left).compare(Buffer.from(right)),
+	);
+	return `{${entries.map(([key, entry]) => `${goJsonString(key)}:${stableJson(entry)}`).join(",")}}`;
+}
+
+function denial(code?: unknown): Error {
+	return new Error(
+		typeof code === "string" && SAFE_CODE.test(code)
+			? `Assignment capability denied (${code})`
+			: "Assignment capability denied",
+	);
+}
+
+export async function callAssignmentGateway(
+	argv: readonly string[],
+	request: Readonly<JsonRecord>,
+	deadlineMillis: number,
+): Promise<unknown> {
+	const remaining = deadlineMillis - Date.now();
+	if (!Number.isFinite(remaining) || remaining <= 0) throw denial("GATEWAY_TIMEOUT");
+	const reconciliationReserve = Math.min(
+		MAX_RECONCILIATION_RESERVE_MS,
+		Math.max(MIN_RECONCILIATION_RESERVE_MS, Math.floor(remaining / 4)),
+	);
+	const firstAttemptTimeout = Math.max(1, remaining - reconciliationReserve);
+	try {
+		return await callAssignmentGatewayOnce(argv, request, firstAttemptTimeout);
+	} catch (error) {
+		if (!(error instanceof GatewayAmbiguityError)) throw error;
+		// Re-submit only after an ambiguous transport outcome, reserving deadline
+		// budget before the first spawn. Go reconciles this exact requestId.
+		return callAssignmentGatewayOnce(argv, request, deadlineMillis - Date.now());
+	}
+}
+
+async function callAssignmentGatewayOnce(
+	argv: readonly string[],
+	request: Readonly<JsonRecord>,
+	timeoutMs: number,
+): Promise<unknown> {
+	if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) throw denial("GATEWAY_TIMEOUT");
+	const process = Bun.spawn([...argv], {
+		cwd: "/",
+		env: { PATH: Bun.env.PATH ?? "" },
+		stdin: "pipe",
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	process.stdin.write(JSON.stringify(request));
+	process.stdin.end();
+	const stdoutPromise = new Response(process.stdout as ReadableStream<Uint8Array>).text();
+	const stderrPromise = new Response(process.stderr as ReadableStream<Uint8Array>).text();
+	const exitPromise = process.exited;
+	const timeout = Bun.sleep(Math.max(1, timeoutMs)).then(() => "timeout" as const);
+	const outcome = await Promise.race([exitPromise, timeout]);
+	if (outcome === "timeout") {
+		process.kill();
+		await Promise.allSettled([stdoutPromise, stderrPromise, exitPromise]);
+		throw new GatewayAmbiguityError("GATEWAY_TIMEOUT");
+	}
+	const [stdout] = await Promise.all([stdoutPromise, stderrPromise]);
+	if (outcome !== 0 || stdout.length > MAX_FRAME_BYTES) throw new GatewayAmbiguityError("GATEWAY_UNAVAILABLE");
+	let decoded: JsonRecord;
+	try {
+		decoded = object(JSON.parse(stdout));
+	} catch {
+		throw new GatewayAmbiguityError("GATEWAY_INVALID_RESPONSE");
+	}
+	let envelope: JsonRecord;
+	try {
+		envelope =
+			decoded.ok === true
+				? requireClosed(decoded, ["schema", "requestId", "ok", "operation", "result"])
+				: requireClosed(decoded, ["schema", "requestId", "ok", "operation", "error"]);
+		if (
+			envelope.schema !== ASSIGNMENT_CAPABILITY_SCHEMA ||
+			envelope.requestId !== request.requestId ||
+			envelope.operation !== request.operation
+		) {
+			throw new Error("invalid gateway response identity");
+		}
+	} catch {
+		throw new GatewayAmbiguityError("GATEWAY_INVALID_RESPONSE");
+	}
+	if (envelope.ok !== true) {
+		const gatewayError = requireClosed(envelope.error, ["code", "message", "retryable"]);
+		if (gatewayError.retryable === true) throw new GatewayAmbiguityError(requireString(gatewayError, "code"));
+		throw denial(gatewayError.code);
+	}
+	return envelope.result;
+}
+function validateCapability(value: unknown): AssignmentCapabilityRecord {
+	const fields = [
+		"schema",
+		"capability",
+		"generation",
+		"thread",
+		"participant",
+		"session",
+		"leaseGeneration",
+		"delivery",
+		"resource",
+		"assignment",
+		"preparationDigest",
+		"scopes",
+		"authorityProvenance",
+		"issuedAt",
+		"expiresAt",
+		"renewalDeadline",
+		"maxOperationDurationMillis",
+		"revocationGeneration",
+		"herdrBinding",
+		"herdrGeneration",
+		"herdrProofKeyDigest",
+		"controllerPolicyDigest",
+	] as const;
+	const capability = requireClosed(value, fields);
+	if (capability.schema !== ASSIGNMENT_CAPABILITY_SCHEMA) {
+		throw new Error("Assignment capability denied: unsupported capability schema");
+	}
+	const validated = capability;
+	for (const field of [
+		"capability",
+		"thread",
+		"participant",
+		"session",
+		"delivery",
+		"resource",
+		"assignment",
+		"preparationDigest",
+		"authorityProvenance",
+		"issuedAt",
+		"expiresAt",
+		"renewalDeadline",
+		"herdrBinding",
+		"herdrProofKeyDigest",
+		"controllerPolicyDigest",
+	] as const) {
+		requireString(validated, field);
+	}
+	for (const field of ["generation", "leaseGeneration", "maxOperationDurationMillis", "herdrGeneration"] as const) {
+		const numeric = requireNumber(validated, field);
+		if (!Number.isSafeInteger(numeric) || numeric <= 0) {
+			throw new Error("Assignment capability denied: invalid authorization response");
+		}
+	}
+	const revocationGeneration = requireNumber(validated, "revocationGeneration");
+	const issuedAt = Date.parse(validated.issuedAt as string);
+	const expiresAt = Date.parse(validated.expiresAt as string);
+	const renewalDeadline = Date.parse(validated.renewalDeadline as string);
+	if (
+		!Number.isSafeInteger(revocationGeneration) ||
+		revocationGeneration < 0 ||
+		!Number.isFinite(issuedAt) ||
+		!Number.isFinite(expiresAt) ||
+		!Number.isFinite(renewalDeadline) ||
+		issuedAt >= renewalDeadline ||
+		renewalDeadline > expiresAt ||
+		!Array.isArray(validated.scopes) ||
+		!validated.scopes.includes("assignment.execution.request") ||
+		validated.scopes.some(
+			scope =>
+				scope !== "assignment.execution.request" &&
+				scope !== "assignment.complete" &&
+				scope !== "assignment.revoke",
+		)
+	) {
+		throw new Error("Assignment capability denied: invalid authorization response");
+	}
+	return validated as unknown as AssignmentCapabilityRecord;
+}
+
+function validateBinding(value: unknown, expected: AssignmentCapabilityLaunchOptions): AssignmentCapabilityBinding {
+	const binding = requireClosed(value, [
+		"schema",
+		"requestId",
+		"operation",
+		"binding",
+		"generation",
+		"workspace",
+		"pane",
+		"session",
+		"holderSecret",
+		"herdrProofKey",
+		"observedAt",
+	]);
+	if (
+		binding.schema !== ASSIGNMENT_CAPABILITY_SCHEMA ||
+		binding.operation !== "capability.session.bind" ||
+		binding.pane !== expected.pane ||
+		binding.session !== expected.session
+	) {
+		throw new Error("Assignment capability denied: Herdr binding mismatch");
+	}
+	return {
+		binding: requireString(binding, "binding"),
+		generation: requireNumber(binding, "generation"),
+		workspace: requireString(binding, "workspace"),
+		pane: requireString(binding, "pane"),
+		session: requireString(binding, "session"),
+		holderSecret: requireString(binding, "holderSecret"),
+		herdrProofKey: requireString(binding, "herdrProofKey"),
+		observedAt: requireString(binding, "observedAt"),
+	};
+}
+
+interface PendingFrame {
+	readonly resolve: (value: JsonRecord) => void;
+	readonly reject: (error: Error) => void;
+	readonly timer: Timer;
+}
+
+class HerdrCapabilityClient {
+	readonly #pending = new Map<string, PendingFrame>();
+	readonly #options: Readonly<AssignmentCapabilityLaunchOptions>;
+	#socket?: Bun.Socket<undefined>;
+	#buffer = new Uint8Array(0);
+	#notice?: AssignmentCapabilityNotice;
+	#binding?: AssignmentCapabilityBinding;
+	#closed = false;
+
+	constructor(options: AssignmentCapabilityLaunchOptions) {
+		this.#options = Object.freeze({
+			...options,
+			juizGatewayArgv: Object.freeze([...options.juizGatewayArgv]),
+		}) as Readonly<AssignmentCapabilityLaunchOptions>;
+	}
+
+	get binding(): AssignmentCapabilityBinding | undefined {
+		return this.#binding;
+	}
+
+	async connect(): Promise<void> {
+		let settled = false;
+		const { promise, resolve, reject } = Promise.withResolvers<void>();
+		const timer = setTimeout(
+			() => reject(new Error("Assignment capability denied: Herdr unavailable")),
+			CONNECT_TIMEOUT_MS,
+		);
+		void promise.finally(() => clearTimeout(timer));
+		void Bun.connect({
+			unix: this.#options.herdrSocketPath,
+			socket: {
+				open: socket => {
+					this.#socket = socket;
+					settled = true;
+					resolve();
+				},
+				data: (_socket, data) => this.#receive(new Uint8Array(data)),
+				close: () => this.#failAll(new Error("Assignment capability denied: Herdr connection closed")),
+				error: (_socket, error) => {
+					if (!settled) reject(new Error("Assignment capability denied: Herdr unavailable"));
+					this.#failAll(error instanceof Error ? error : new Error(String(error)));
+				},
+			},
+		}).catch(() => reject(new Error("Assignment capability denied: Herdr unavailable")));
+		await promise;
+		const requestId = crypto.randomUUID();
+		const response = await this.#request({
+			schema: ASSIGNMENT_CAPABILITY_SCHEMA,
+			requestId,
+			operation: "capability.session.bind",
+			pane: this.#options.pane,
+			session: this.#options.session,
+			clientNonce: crypto.randomUUID(),
+		});
+		this.#binding = validateBinding(response, this.#options);
+	}
+
+	close(): void {
+		this.#closed = true;
+		this.#socket?.end();
+		this.#failAll(new Error("Assignment capability denied: session closed"));
+		this.#notice = undefined;
+		this.#binding = undefined;
+	}
+
+	activeNotice(): AssignmentCapabilityNotice {
+		const notice = this.#notice;
+		if (!this.#binding || !notice || this.#closed) throw denial("CAPABILITY_UNAVAILABLE");
+		return notice;
+	}
+
+	clearNotice(capability: string): void {
+		if (this.#notice?.capability.capability === capability) this.#notice = undefined;
+	}
+
+	async prove(
+		input: PreparedAssignmentExecuteInput | PreparedAssignmentCompletionInput,
+		expectedNotice: AssignmentCapabilityNotice,
+		scope: AssignmentCapabilityScope,
+	): Promise<{ readonly notice: AssignmentCapabilityNotice; readonly holderProof: unknown }> {
+		const binding = this.#binding;
+		const notice = this.#notice;
+		if (!binding || !notice || notice !== expectedNotice || this.#closed) throw denial("CAPABILITY_UNAVAILABLE");
+		const capability = notice.capability;
+		if (
+			capability.session !== binding.session ||
+			capability.delivery !== notice.delivery ||
+			capability.herdrBinding !== binding.binding ||
+			capability.herdrGeneration !== binding.generation ||
+			!capability.scopes.includes(scope) ||
+			capability.revocationGeneration !== 0 ||
+			Date.parse(capability.expiresAt) <= Date.now() ||
+			Date.parse(capability.renewalDeadline) <= Date.now()
+		) {
+			throw denial("CAPABILITY_INVALID");
+		}
+		const response = await this.#request({
+			schema: ASSIGNMENT_CAPABILITY_SCHEMA,
+			requestId: crypto.randomUUID(),
+			operation: "capability.session.prove",
+			holderSecret: binding.holderSecret,
+			binding: binding.binding,
+			generation: binding.generation,
+			capability: capability.capability,
+			toolCall: input.toolCall,
+			operationDigest: input.operationDigest,
+			deadline: input.deadline,
+		});
+		const proof = requireClosed(response, [
+			"schema",
+			"requestId",
+			"operation",
+			"holderProof",
+			"herdrProofKey",
+			"deadline",
+		]);
+		if (
+			proof.schema !== ASSIGNMENT_CAPABILITY_SCHEMA ||
+			proof.operation !== "capability.session.prove" ||
+			proof.herdrProofKey !== binding.herdrProofKey ||
+			Date.parse(requireString(proof, "deadline")) !== Date.parse(input.deadline)
+		) {
+			throw denial("PROOF_INVALID");
+		}
+		return { notice, holderProof: proof.holderProof };
+	}
+
+	async #request(request: JsonRecord): Promise<JsonRecord> {
+		const socket = this.#socket;
+		const requestId = requireString(request, "requestId");
+		if (!socket || this.#closed) throw denial("HERDR_UNAVAILABLE");
+		const { promise, resolve, reject } = Promise.withResolvers<JsonRecord>();
+		const timer = setTimeout(() => {
+			this.#pending.delete(requestId);
+			reject(denial("HERDR_TIMEOUT"));
+		}, CONNECT_TIMEOUT_MS);
+		this.#pending.set(requestId, { resolve, reject, timer });
+		socket.write(encodeFrame(request));
+		return promise;
+	}
+
+	#receive(chunk: Uint8Array): void {
+		const joined = new Uint8Array(this.#buffer.byteLength + chunk.byteLength);
+		joined.set(this.#buffer);
+		joined.set(chunk, this.#buffer.byteLength);
+		this.#buffer = joined;
+		while (this.#buffer.byteLength >= 4) {
+			const length = new DataView(this.#buffer.buffer, this.#buffer.byteOffset, 4).getUint32(0, true);
+			if (length > MAX_FRAME_BYTES) {
+				this.close();
+				return;
+			}
+			if (this.#buffer.byteLength < 4 + length) return;
+			const payload = this.#buffer.slice(4, 4 + length);
+			this.#buffer = this.#buffer.slice(4 + length);
+			let frame: JsonRecord;
+			try {
+				frame = object(JSON.parse(new TextDecoder().decode(payload)));
+			} catch {
+				this.close();
+				return;
+			}
+			this.#dispatch(frame);
+		}
+	}
+
+	#dispatch(frame: JsonRecord): void {
+		if (frame.schema !== ASSIGNMENT_CAPABILITY_SCHEMA) {
+			this.close();
+			return;
+		}
+		if (frame.type === "capability.notice") {
+			try {
+				const pushed = requireClosed(frame, [
+					"schema",
+					"type",
+					"requestId",
+					"delivery",
+					"capability",
+					"capabilityToken",
+				]);
+				const notice = {
+					delivery: requireString(pushed, "delivery"),
+					capability: validateCapability(pushed.capability),
+					capabilityToken: requireString(pushed, "capabilityToken"),
+				};
+				const binding = this.#binding;
+				if (
+					!binding ||
+					notice.capability.delivery !== notice.delivery ||
+					notice.capability.session !== binding.session ||
+					notice.capability.herdrBinding !== binding.binding ||
+					notice.capability.herdrGeneration !== binding.generation
+				) {
+					return;
+				}
+				this.#notice = notice;
+				this.#socket?.write(
+					encodeFrame({
+						schema: ASSIGNMENT_CAPABILITY_SCHEMA,
+						requestId: pushed.requestId,
+						operation: "capability.notice.accept",
+						delivery: notice.delivery,
+						capability: notice.capability.capability,
+						binding: binding.binding,
+						generation: binding.generation,
+					}),
+				);
+			} catch {
+				this.close();
+			}
+			return;
+		}
+		const requestId = typeof frame.requestId === "string" ? frame.requestId : undefined;
+		if (!requestId) {
+			this.close();
+			return;
+		}
+		const pending = this.#pending.get(requestId);
+		if (!pending) return;
+		this.#pending.delete(requestId);
+		clearTimeout(pending.timer);
+		if (frame.error !== undefined) {
+			const error = object(frame.error);
+			pending.reject(denial(error.code));
+			return;
+		}
+		pending.resolve(frame);
+	}
+
+	#failAll(_error: Error): void {
+		this.#socket = undefined;
+		this.#notice = undefined;
+		for (const pending of this.#pending.values()) {
+			clearTimeout(pending.timer);
+			pending.reject(denial("HERDR_UNAVAILABLE"));
+		}
+		this.#pending.clear();
+	}
+}
+
+export class AssignmentCapabilityRuntime {
+	readonly #options: Readonly<AssignmentCapabilityLaunchOptions>;
+	readonly #herdr: HerdrCapabilityClient;
+
+	private constructor(options: AssignmentCapabilityLaunchOptions) {
+		this.#options = Object.freeze({
+			...options,
+			juizGatewayArgv: Object.freeze([...options.juizGatewayArgv]),
+		}) as Readonly<AssignmentCapabilityLaunchOptions>;
+		this.#herdr = new HerdrCapabilityClient(this.#options);
+	}
+
+	static async create(options: AssignmentCapabilityLaunchOptions): Promise<AssignmentCapabilityRuntime> {
+		if (
+			options.schema !== ASSIGNMENT_CAPABILITY_SCHEMA ||
+			!options.herdrSocketPath ||
+			!options.pane ||
+			!options.session ||
+			options.juizGatewayArgv.length === 0 ||
+			options.juizGatewayArgv.some(arg => typeof arg !== "string" || arg.length === 0)
+		) {
+			throw new Error("Invalid assignment capability launch options");
+		}
+		const runtime = new AssignmentCapabilityRuntime(options);
+		try {
+			await runtime.#herdr.connect();
+		} catch {
+			// Eligibility is immutable, while authorization is live. A failed bind leaves
+			// reads available and every mutation fail-closed for this session.
+		}
+		return runtime;
+	}
+
+	close(): void {
+		this.#herdr.close();
+	}
+
+	async digest(value: unknown): Promise<string> {
+		const wireValue = JSON.stringify(value);
+		if (wireValue === undefined) throw denial("EFFECTIVE_ARGS_INVALID");
+		const bytes = new TextEncoder().encode(stableJson(JSON.parse(wireValue)));
+		return `sha256:${Buffer.from(await crypto.subtle.digest("SHA-256", bytes)).toString("hex")}`;
+	}
+
+	async execute(input: AssignmentExecuteInput): Promise<AssignmentExecuteResult> {
+		const notice = this.#herdr.activeNotice();
+		const now = Date.now();
+		const expiresAt = Date.parse(notice.capability.expiresAt);
+		const renewalDeadline = Date.parse(notice.capability.renewalDeadline);
+		const operationCeiling = now + notice.capability.maxOperationDurationMillis;
+		const deadlineMillis = Math.min(expiresAt, renewalDeadline, operationCeiling);
+		if (!Number.isFinite(deadlineMillis) || deadlineMillis <= now) throw denial("CAPABILITY_INVALID");
+		const deadline = new Date(deadlineMillis).toISOString();
+		const operationDigest = await this.digest({
+			schema: ASSIGNMENT_CAPABILITY_SCHEMA,
+			toolCall: input.toolCall,
+			tool: input.tool,
+			tier: input.tier,
+			effectiveArgsDigest: input.effectiveArgsDigest,
+			deadline,
+		});
+		const prepared: PreparedAssignmentExecuteInput = { ...input, deadline, operationDigest };
+		const proof = await this.#herdr.prove(prepared, notice, "assignment.execution.request");
+		const requestId = crypto.randomUUID();
+		const request = {
+			schema: ASSIGNMENT_CAPABILITY_SCHEMA,
+			requestId,
+			operation: "attempt.execute",
+			capabilityToken: proof.notice.capabilityToken,
+			holderProof: proof.holderProof,
+			toolCall: input.toolCall,
+			tool: input.tool,
+			tier: input.tier,
+			effectiveArgs: input.effectiveArgs,
+			effectiveArgsDigest: input.effectiveArgsDigest,
+			operationDigest,
+			deadline,
+		};
+		const response = await callAssignmentGateway(this.#options.juizGatewayArgv, request, deadlineMillis);
+		const result = requireClosed(response, ["toolResult", "receipt"]);
+		requireClosed(result.receipt, [
+			"attempt",
+			"launchDigest",
+			"disposition",
+			"checkpointDigest",
+			"promotion",
+			"cleanup",
+			"fenceGeneration",
+			"fencePhase",
+			"reconciliation",
+		]);
+		const sensitive = [
+			proof.notice.capabilityToken,
+			this.#herdr.binding?.holderSecret,
+			this.#herdr.binding?.binding,
+			this.#herdr.binding?.herdrProofKey,
+		].filter((value): value is string => typeof value === "string" && value.length > 0);
+		const serializedToolResult = JSON.stringify(result.toolResult);
+		if (sensitive.some(value => serializedToolResult.includes(value))) {
+			throw denial("GATEWAY_SECRET_LEAK");
+		}
+		return result as unknown as AssignmentExecuteResult;
+	}
+
+	async complete(toolCall: string): Promise<AssignmentCompletionResult> {
+		const notice = this.#herdr.activeNotice();
+		const now = Date.now();
+		const expiresAt = Date.parse(notice.capability.expiresAt);
+		const renewalDeadline = Date.parse(notice.capability.renewalDeadline);
+		const operationCeiling = now + notice.capability.maxOperationDurationMillis;
+		const deadlineMillis = Math.min(expiresAt, renewalDeadline, operationCeiling);
+		if (!Number.isFinite(deadlineMillis) || deadlineMillis <= now) throw denial("CAPABILITY_INVALID");
+		const deadline = new Date(deadlineMillis).toISOString();
+		const operation = "assignment.complete";
+		const reason = "completed";
+		const operationDigest = await this.digest({
+			schema: ASSIGNMENT_CAPABILITY_SCHEMA,
+			operation,
+			toolCall,
+			reason,
+			deadline,
+		});
+		const prepared: PreparedAssignmentCompletionInput = { toolCall, deadline, operationDigest };
+		const proof = await this.#herdr.prove(prepared, notice, "assignment.complete");
+		const requestId = crypto.randomUUID();
+		const response = await callAssignmentGateway(
+			this.#options.juizGatewayArgv,
+			{
+				schema: ASSIGNMENT_CAPABILITY_SCHEMA,
+				requestId,
+				operation,
+				capabilityToken: proof.notice.capabilityToken,
+				holderProof: proof.holderProof,
+				toolCall,
+				operationDigest,
+				deadline,
+				reason,
+			},
+			deadlineMillis,
+		);
+		const result = requireClosed(response, ["toolResult", "completion"]);
+		const completion = requireClosed(result.completion, [
+			"capability",
+			"generation",
+			"revocationGeneration",
+			"state",
+			"assignmentState",
+			"denialProofDigest",
+			"requestAttempt",
+		]);
+		if (
+			completion.capability !== notice.capability.capability ||
+			completion.generation !== notice.capability.generation ||
+			completion.state !== "revoked" ||
+			completion.assignmentState !== "completed-unlanded" ||
+			completion.requestAttempt !== requestId
+		) {
+			throw denial("GATEWAY_INVALID_RESPONSE");
+		}
+		for (const field of ["denialProofDigest", "requestAttempt"] as const) requireString(completion, field);
+		for (const field of ["generation", "revocationGeneration"] as const) requireNumber(completion, field);
+		const sensitive = [
+			notice.capabilityToken,
+			this.#herdr.binding?.holderSecret,
+			this.#herdr.binding?.herdrProofKey,
+		].filter((value): value is string => typeof value === "string" && value.length > 0);
+		if (sensitive.some(value => JSON.stringify(result.toolResult).includes(value)))
+			throw denial("GATEWAY_SECRET_LEAK");
+		this.#herdr.clearNotice(notice.capability.capability);
+		return result as unknown as AssignmentCompletionResult;
+	}
+}

--- a/packages/coding-agent/src/assignment-capability/tool-worker-client.ts
+++ b/packages/coding-agent/src/assignment-capability/tool-worker-client.ts
@@ -1,0 +1,100 @@
+import { resolveWorkerSpawnCmd, SMOKE_TEST_TIMEOUT_MS, workerEnvFromParent } from "../subprocess/worker-client";
+import { ASSIGNMENT_TOOL_WORKER_ARG, ASSIGNMENT_TOOL_WORKER_SCHEMA } from "./tool-worker-protocol";
+
+const MAX_SMOKE_REQUEST_BYTES = 1024;
+
+type JsonRecord = Record<string, unknown>;
+
+function closedRecord(value: unknown, fields: readonly string[]): JsonRecord {
+	if (typeof value !== "object" || value === null || Array.isArray(value)) {
+		throw new Error("assignment worker smoke failed: response was not an object");
+	}
+	const record = value as JsonRecord;
+	const keys = Object.keys(record);
+	if (keys.length !== fields.length || keys.some(key => !fields.includes(key))) {
+		throw new Error("assignment worker smoke failed: response was not closed");
+	}
+	return record;
+}
+
+function validateDenial(source: string): void {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(source);
+	} catch {
+		throw new Error("assignment worker smoke failed: response was not JSON");
+	}
+	const response = closedRecord(parsed, ["schema", "requestId", "ok", "error"]);
+	if (response.schema !== ASSIGNMENT_TOOL_WORKER_SCHEMA || response.requestId !== "smoke" || response.ok !== false) {
+		throw new Error("assignment worker smoke failed: response was not a correlated worker denial");
+	}
+	const error = closedRecord(response.error, ["code", "message"]);
+	if (error.code !== "INVALID_SCHEMA" || typeof error.message !== "string" || error.message.length === 0) {
+		throw new Error("assignment worker smoke failed: invalid-schema denial was malformed");
+	}
+}
+
+/** Exercise the assignment selector without requiring a live Assignment capability. */
+export async function smokeTestAssignmentToolWorker({
+	timeoutMs = SMOKE_TEST_TIMEOUT_MS,
+}: {
+	timeoutMs?: number;
+} = {}): Promise<void> {
+	const request = JSON.stringify({
+		schema: "juiz.assignment-tool-worker/smoke-invalid",
+		requestId: "smoke",
+		attempt: null,
+		operationCredential: "",
+		tool: "",
+		effectiveArgs: null,
+		logicalPathMapping: null,
+		projection: "",
+	});
+	if (Buffer.byteLength(request) > MAX_SMOKE_REQUEST_BYTES) {
+		throw new Error("assignment worker smoke failed: invalid request exceeded its bound");
+	}
+
+	const spawn = resolveWorkerSpawnCmd(ASSIGNMENT_TOOL_WORKER_ARG);
+	const proc = Bun.spawn(spawn.cmd, {
+		cwd: spawn.cwd,
+		env: workerEnvFromParent(),
+		stdin: "pipe",
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	const stdout = new Response(proc.stdout).text();
+	const stderr = new Response(proc.stderr).text();
+	const timeout = Promise.withResolvers<"timeout">();
+	const timer = setTimeout(() => timeout.resolve("timeout"), timeoutMs);
+
+	try {
+		proc.stdin.write(request);
+		proc.stdin.end();
+		const outcome = await Promise.race([proc.exited, timeout.promise]);
+		if (outcome === "timeout") {
+			throw new Error(`assignment worker smoke failed: selector did not deny within ${timeoutMs}ms`);
+		}
+		const [response, diagnostics] = await Promise.all([stdout, stderr]);
+		if (outcome !== 1) {
+			throw new Error(
+				`assignment worker smoke failed: expected denial exit 1, got ${outcome} (${diagnostics.slice(-500) || "no stderr"})`,
+			);
+		}
+		validateDenial(response);
+	} finally {
+		clearTimeout(timer);
+		try {
+			proc.stdin.end();
+		} catch {
+			// Already closed.
+		}
+		if (proc.exitCode === null) {
+			try {
+				proc.kill("SIGKILL");
+			} catch {
+				// Already exited.
+			}
+		}
+		await Promise.allSettled([proc.exited, stdout, stderr]);
+	}
+}

--- a/packages/coding-agent/src/assignment-capability/tool-worker-protocol.ts
+++ b/packages/coding-agent/src/assignment-capability/tool-worker-protocol.ts
@@ -1,0 +1,2 @@
+export const ASSIGNMENT_TOOL_WORKER_ARG = "__omp_worker_assignment_tool";
+export const ASSIGNMENT_TOOL_WORKER_SCHEMA = "juiz.assignment-tool-worker/1" as const;

--- a/packages/coding-agent/src/assignment-capability/tool-worker.ts
+++ b/packages/coding-agent/src/assignment-capability/tool-worker.ts
@@ -1,0 +1,300 @@
+import * as path from "node:path";
+import type { AgentToolResult } from "@oh-my-pi/pi-agent-core";
+import { type Tool as AiTool, validateToolArguments } from "@oh-my-pi/pi-ai";
+import { Settings } from "../config/settings";
+import { EditTool } from "../edit";
+import { LspTool } from "../lsp/tool";
+import type { ToolSession } from "../tools";
+import { AstEditTool } from "../tools/ast-edit";
+import { WriteTool } from "../tools/write";
+import { ASSIGNMENT_TOOL_WORKER_SCHEMA } from "./tool-worker-protocol";
+
+const ASSIGNMENT_CAPABILITY_SCHEMA = "juiz.assignment-capability/1" as const;
+const MAX_REQUEST_BYTES = 2 * 1024 * 1024;
+
+type JsonRecord = Record<string, unknown>;
+type WorkerToolName = "write" | "edit" | "ast_edit" | "lsp";
+
+function object(value: unknown): JsonRecord {
+	if (typeof value !== "object" || value === null || Array.isArray(value)) throw new Error("INVALID_REQUEST");
+	return value as JsonRecord;
+}
+
+function closed(value: unknown, fields: readonly string[]): JsonRecord {
+	const result = object(value);
+	const keys = Object.keys(result);
+	if (keys.length !== fields.length || keys.some(key => !fields.includes(key))) throw new Error("INVALID_REQUEST");
+	return result;
+}
+
+function stringField(record: JsonRecord, field: string): string {
+	const value = record[field];
+	if (typeof value !== "string" || value.length === 0) throw new Error("INVALID_REQUEST");
+	return value;
+}
+
+async function sha256Hex(value: string): Promise<string> {
+	const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(value));
+	return Buffer.from(digest).toString("hex");
+}
+
+function stableJson(value: unknown): string {
+	if (value === null || typeof value !== "object") return JSON.stringify(value);
+	if (Array.isArray(value)) return `[${value.map(stableJson).join(",")}]`;
+	const entries = Object.entries(value as JsonRecord).sort(([left], [right]) => left.localeCompare(right));
+	return `{${entries.map(([key, entry]) => `${JSON.stringify(key)}:${stableJson(entry)}`).join(",")}}`;
+}
+
+async function effectiveArgsDigest(value: unknown): Promise<string> {
+	return `sha256:${await sha256Hex(stableJson(value))}`;
+}
+
+function remapPath(value: string, logicalPrefix: string, projectionPrefix: string): string {
+	if (/^[a-z][a-z0-9+.-]*:\/\//i.test(value)) throw new Error("PATH_NOT_FILESYSTEM");
+	const logical = path.normalize(logicalPrefix);
+	const absolute = path.isAbsolute(value) ? path.normalize(value) : path.resolve(logical, value);
+	if (absolute !== logical && !absolute.startsWith(`${logical}${path.sep}`))
+		throw new Error("PATH_OUTSIDE_ASSIGNMENT");
+	return path.normalize(projectionPrefix) + absolute.slice(logical.length);
+}
+
+function remapEditInput(input: string, logicalPrefix: string, projectionPrefix: string): string {
+	return input
+		.split("\n")
+		.map(line => {
+			const hashline = /^(\[)([^\]#]+)(#[0-9A-Fa-f]+\])$/.exec(line);
+			if (hashline) return `${hashline[1]}${remapPath(hashline[2], logicalPrefix, projectionPrefix)}${hashline[3]}`;
+			const sloppy = /^(\[)([^\]\n]+)(\])$/.exec(line);
+			if (sloppy) return `${sloppy[1]}${remapPath(sloppy[2], logicalPrefix, projectionPrefix)}${sloppy[3]}`;
+			const marker = /^(\*\*\* (?:Add|Delete|Update) File: )(.+)$/.exec(line);
+			if (marker) return marker[1] + remapPath(marker[2], logicalPrefix, projectionPrefix);
+			const move = /^(\*\*\* Move to: |MV )(.+)$/.exec(line);
+			if (move) return move[1] + remapPath(move[2], logicalPrefix, projectionPrefix);
+			return line;
+		})
+		.join("\n");
+}
+
+function remapArgs(tool: WorkerToolName, value: unknown, logicalPrefix: string, projectionPrefix: string): JsonRecord {
+	const args = object(value);
+	const output: JsonRecord = { ...args };
+	if (tool === "write") {
+		if (typeof args.path !== "string") throw new Error("INVALID_TOOL_ARGS");
+		output.path = remapPath(args.path, logicalPrefix, projectionPrefix);
+		return output;
+	}
+	if (tool === "ast_edit") {
+		if (!Array.isArray(args.paths) || !args.paths.every(entry => typeof entry === "string")) {
+			throw new Error("INVALID_TOOL_ARGS");
+		}
+		output.paths = args.paths.map(entry => remapPath(entry as string, logicalPrefix, projectionPrefix));
+		return output;
+	}
+	if (tool === "lsp") {
+		const action = typeof args.action === "string" ? args.action : "";
+		if (action !== "rename" && action !== "rename_file" && !(action === "code_actions" && args.apply === true)) {
+			throw new Error("INVALID_TOOL_ACTION");
+		}
+		if (typeof args.file !== "string") throw new Error("INVALID_TOOL_ARGS");
+		output.file = remapPath(args.file, logicalPrefix, projectionPrefix);
+		if (action === "rename_file") {
+			if (typeof args.new_name !== "string") throw new Error("INVALID_TOOL_ARGS");
+			output.new_name = remapPath(args.new_name, logicalPrefix, projectionPrefix);
+		}
+		return output;
+	}
+
+	if (typeof args.path === "string") output.path = remapPath(args.path, logicalPrefix, projectionPrefix);
+	if (Array.isArray(args.edits)) {
+		output.edits = args.edits.map(value => {
+			const edit = object(value);
+			return typeof edit.rename === "string"
+				? { ...edit, rename: remapPath(edit.rename, logicalPrefix, projectionPrefix) }
+				: { ...edit };
+		});
+	}
+	if (typeof args.input === "string") output.input = remapEditInput(args.input, logicalPrefix, projectionPrefix);
+	if (typeof output.path !== "string" && typeof output.input !== "string") throw new Error("INVALID_TOOL_ARGS");
+	return output;
+}
+
+function editMode(args: JsonRecord): "replace" | "patch" | "hashline" | "apply_patch" | "sloppy" {
+	if (typeof args.path === "string" && typeof args.old_string === "string") return "replace";
+	if (typeof args.path === "string" && Array.isArray(args.edits)) return "patch";
+	if (typeof args.input !== "string") throw new Error("INVALID_TOOL_ARGS");
+	if (/^\*\*\* Begin Patch\n\*\*\* (?:Add|Delete|Update) File:/m.test(args.input)) return "apply_patch";
+	if (/^\[[^\]\n]+#[0-9A-Fa-f]+\]$/m.test(args.input)) return "hashline";
+	return "sloppy";
+}
+
+function hideProjection<T>(value: T, logicalPrefix: string, projectionPrefix: string): T {
+	const visit = (entry: unknown): unknown => {
+		if (typeof entry === "string") return entry.split(projectionPrefix).join(logicalPrefix);
+		if (Array.isArray(entry)) return entry.map(visit);
+		if (typeof entry !== "object" || entry === null) return entry;
+		return Object.fromEntries(Object.entries(entry).map(([key, nested]) => [key, visit(nested)]));
+	};
+	return visit(value) as T;
+}
+
+function createWorkerTool(tool: WorkerToolName, args: JsonRecord, session: ToolSession) {
+	switch (tool) {
+		case "write":
+			return new WriteTool(session);
+		case "edit":
+			return new EditTool(session, editMode(args));
+		case "ast_edit":
+			return new AstEditTool(session);
+		case "lsp":
+			return new LspTool(session);
+	}
+}
+
+function launchPreimage(attempt: JsonRecord): JsonRecord {
+	return {
+		schema: attempt.schema,
+		requestId: attempt.requestId,
+		attempt: attempt.attempt,
+		thread: attempt.thread,
+		participant: attempt.participant,
+		session: attempt.session,
+		leaseGeneration: attempt.leaseGeneration,
+		delivery: attempt.delivery,
+		capability: attempt.capability,
+		capabilityGeneration: attempt.capabilityGeneration,
+		resource: attempt.resource,
+		assignment: attempt.assignment,
+		preparationDigest: attempt.preparationDigest,
+		toolCall: attempt.toolCall,
+		tool: attempt.tool,
+		effectiveArgsDigest: attempt.effectiveArgsDigest,
+		operationDigest: attempt.operationDigest,
+		tier: attempt.tier,
+		operationCredentialDigest: attempt.operationCredentialDigest,
+		writerFencePolicyDigest: attempt.writerFencePolicyDigest,
+		deadline: attempt.deadline,
+	};
+}
+
+export async function runAssignmentToolWorker(): Promise<void> {
+	let requestId = "unavailable";
+	try {
+		const source = await Bun.stdin.text();
+		if (Buffer.byteLength(source) > MAX_REQUEST_BYTES) throw new Error("REQUEST_TOO_LARGE");
+		const request = closed(JSON.parse(source), [
+			"schema",
+			"requestId",
+			"attempt",
+			"operationCredential",
+			"tool",
+			"effectiveArgs",
+			"logicalPathMapping",
+			"projection",
+		]);
+		requestId = stringField(request, "requestId");
+		if (request.schema !== ASSIGNMENT_TOOL_WORKER_SCHEMA) throw new Error("INVALID_SCHEMA");
+		const attempt = closed(request.attempt, [
+			"schema",
+			"requestId",
+			"attempt",
+			"thread",
+			"participant",
+			"session",
+			"leaseGeneration",
+			"delivery",
+			"capability",
+			"capabilityGeneration",
+			"resource",
+			"assignment",
+			"preparationDigest",
+			"toolCall",
+			"tool",
+			"effectiveArgsDigest",
+			"operationDigest",
+			"tier",
+			"operationCredentialDigest",
+			"writerFencePolicyDigest",
+			"deadline",
+			"launchDigest",
+			"fenceGeneration",
+		]);
+		if (attempt.schema !== ASSIGNMENT_CAPABILITY_SCHEMA || attempt.requestId !== requestId) {
+			throw new Error("INVALID_ATTEMPT");
+		}
+		const deadlineText = stringField(attempt, "deadline");
+		const deadline = Date.parse(deadlineText);
+		if (!Number.isFinite(deadline) || deadline <= Date.now()) throw new Error("ATTEMPT_EXPIRED");
+		const credential = stringField(request, "operationCredential");
+		if (`sha256:${await sha256Hex(credential)}` !== stringField(attempt, "operationCredentialDigest")) {
+			throw new Error("INVALID_OPERATION_CREDENTIAL");
+		}
+		if (
+			`sha256:${await sha256Hex(JSON.stringify(launchPreimage(attempt)))}` !== stringField(attempt, "launchDigest")
+		) {
+			throw new Error("INVALID_LAUNCH_DIGEST");
+		}
+		const tool = stringField(request, "tool");
+		if (tool !== "write" && tool !== "edit" && tool !== "ast_edit" && tool !== "lsp") {
+			throw new Error("INVALID_TOOL");
+		}
+		if (attempt.tool !== tool || attempt.tier !== "write") throw new Error("INVALID_ATTEMPT_TOOL");
+		if ((await effectiveArgsDigest(request.effectiveArgs)) !== attempt.effectiveArgsDigest) {
+			throw new Error("INVALID_EFFECTIVE_ARGS");
+		}
+		const mapping = closed(request.logicalPathMapping, ["logicalPrefix", "projectionPrefix"]);
+		const logicalPrefix = stringField(mapping, "logicalPrefix");
+		const projectionPrefix = stringField(mapping, "projectionPrefix");
+		const projection = stringField(request, "projection");
+		if (
+			!path.isAbsolute(logicalPrefix) ||
+			!path.isAbsolute(projectionPrefix) ||
+			path.normalize(projection) !== path.normalize(projectionPrefix)
+		) {
+			throw new Error("INVALID_PATH_MAPPING");
+		}
+		const mappedArgs = remapArgs(tool, request.effectiveArgs, logicalPrefix, projectionPrefix);
+		const settings = Settings.isolated({
+			"lsp.diagnosticsOnEdit": false,
+			"lsp.diagnosticsOnWrite": false,
+			"lsp.formatOnWrite": false,
+		});
+		const session: ToolSession = {
+			cwd: projectionPrefix,
+			hasUI: false,
+			canPromptUser: false,
+			enableIrc: false,
+			enableMCP: false,
+			enableLsp: true,
+			settings,
+			getSessionFile: () => null,
+			getSessionSpawns: () => null,
+		};
+		const executable = createWorkerTool(tool, mappedArgs, session);
+		const validated = validateToolArguments(executable as unknown as AiTool, {
+			type: "toolCall",
+			id: requestId,
+			name: tool,
+			arguments: mappedArgs,
+		});
+		const result = (await executable.execute(
+			requestId,
+			validated as never,
+			AbortSignal.timeout(deadline - Date.now()),
+		)) as AgentToolResult;
+		const sanitized = hideProjection(result, logicalPrefix, projectionPrefix);
+		process.stdout.write(
+			JSON.stringify({ schema: ASSIGNMENT_TOOL_WORKER_SCHEMA, requestId, ok: true, result: sanitized }),
+		);
+	} catch (error) {
+		const code = error instanceof Error && /^[A-Z0-9_]+$/.test(error.message) ? error.message : "WORKER_FAILED";
+		process.stdout.write(
+			JSON.stringify({
+				schema: ASSIGNMENT_TOOL_WORKER_SCHEMA,
+				requestId,
+				ok: false,
+				error: { code, message: "Assignment tool worker denied the request" },
+			}),
+		);
+		process.exitCode = 1;
+	}
+}

--- a/packages/coding-agent/src/assignment-capability/tool-worker.ts
+++ b/packages/coding-agent/src/assignment-capability/tool-worker.ts
@@ -7,6 +7,7 @@ import { LspTool } from "../lsp/tool";
 import type { ToolSession } from "../tools";
 import { AstEditTool } from "../tools/ast-edit";
 import { WriteTool } from "../tools/write";
+import { stableJson } from "./canonical-json";
 import { ASSIGNMENT_TOOL_WORKER_SCHEMA } from "./tool-worker-protocol";
 
 const ASSIGNMENT_CAPABILITY_SCHEMA = "juiz.assignment-capability/1" as const;
@@ -36,13 +37,6 @@ function stringField(record: JsonRecord, field: string): string {
 async function sha256Hex(value: string): Promise<string> {
 	const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(value));
 	return Buffer.from(digest).toString("hex");
-}
-
-function stableJson(value: unknown): string {
-	if (value === null || typeof value !== "object") return JSON.stringify(value);
-	if (Array.isArray(value)) return `[${value.map(stableJson).join(",")}]`;
-	const entries = Object.entries(value as JsonRecord).sort(([left], [right]) => left.localeCompare(right));
-	return `{${entries.map(([key, entry]) => `${JSON.stringify(key)}:${stableJson(entry)}`).join(",")}}`;
 }
 
 async function effectiveArgsDigest(value: unknown): Promise<string> {

--- a/packages/coding-agent/src/assignment-capability/types.ts
+++ b/packages/coding-agent/src/assignment-capability/types.ts
@@ -1,0 +1,94 @@
+export const ASSIGNMENT_CAPABILITY_SCHEMA = "juiz.assignment-capability/1" as const;
+
+/** Immutable launch inputs supplied by the runtime that owns the Herdr pane. */
+export interface AssignmentCapabilityLaunchOptions {
+	readonly schema: typeof ASSIGNMENT_CAPABILITY_SCHEMA;
+	readonly herdrSocketPath: string;
+	readonly pane: string;
+	readonly session: string;
+	readonly juizGatewayArgv: readonly [string, ...string[]];
+}
+
+export type AssignmentCapabilityScope = "assignment.execution.request" | "assignment.complete" | "assignment.revoke";
+
+export interface AssignmentCapabilityRecord {
+	readonly schema: typeof ASSIGNMENT_CAPABILITY_SCHEMA;
+	readonly capability: string;
+	readonly generation: number;
+	readonly thread: string;
+	readonly participant: string;
+	readonly session: string;
+	readonly leaseGeneration: number;
+	readonly delivery: string;
+	readonly resource: string;
+	readonly assignment: string;
+	readonly preparationDigest: string;
+	readonly scopes: readonly AssignmentCapabilityScope[];
+	readonly authorityProvenance: string;
+	readonly issuedAt: string;
+	readonly expiresAt: string;
+	readonly renewalDeadline: string;
+	readonly maxOperationDurationMillis: number;
+	readonly revocationGeneration: number;
+	readonly herdrBinding: string;
+	readonly herdrGeneration: number;
+	readonly herdrProofKeyDigest: string;
+	readonly controllerPolicyDigest: string;
+}
+
+export interface AssignmentCapabilityNotice {
+	readonly delivery: string;
+	readonly capability: AssignmentCapabilityRecord;
+	readonly capabilityToken: string;
+}
+
+export interface AssignmentCapabilityBinding {
+	readonly binding: string;
+	readonly generation: number;
+	readonly workspace: string;
+	readonly pane: string;
+	readonly session: string;
+	readonly holderSecret: string;
+	readonly herdrProofKey: string;
+	readonly observedAt: string;
+}
+
+export interface AssignmentExecuteInput {
+	readonly toolCall: string;
+	readonly tool: "write" | "edit" | "ast_edit" | "lsp";
+	readonly tier: "write";
+	readonly effectiveArgs: unknown;
+	readonly effectiveArgsDigest: string;
+}
+
+export interface AssignmentTerminalReceipt {
+	readonly attempt: string;
+	readonly launchDigest: string;
+	readonly disposition: "succeeded" | "failed" | "indeterminate";
+	readonly checkpointDigest: string;
+	readonly promotion: "promoted" | "quarantined" | "failed" | "indeterminate";
+	readonly cleanup: "completed" | "retained";
+	readonly fenceGeneration: number;
+	readonly fencePhase: string;
+	readonly reconciliation: unknown;
+}
+
+export interface AssignmentExecuteResult {
+	readonly toolResult: unknown;
+	readonly receipt: AssignmentTerminalReceipt;
+}
+
+export interface AssignmentCompletionReceipt {
+	readonly capability: string;
+	readonly generation: number;
+	readonly revocationGeneration: number;
+	readonly state: "revoked";
+	readonly assignmentState: "completed-unlanded";
+	readonly denialProofDigest: string;
+	readonly requestAttempt: string;
+}
+
+export interface AssignmentCompletionResult {
+	readonly toolResult: unknown;
+	readonly completion: AssignmentCompletionReceipt;
+}

--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -27,7 +27,6 @@ import {
 import { interceptUnhandledRejections } from "@oh-my-pi/pi-utils/postmortem";
 import { setProcessName } from "@oh-my-pi/pi-utils/process-name";
 import { declareWorkerHostEntry, installWorkerInbox, isWorkerHostSelector } from "@oh-my-pi/pi-utils/worker-host";
-import { runAssignmentToolWorker } from "./assignment-capability/tool-worker";
 import { ASSIGNMENT_TOOL_WORKER_ARG } from "./assignment-capability/tool-worker-protocol";
 import { BLOB_BROKER_WORKER_ARG } from "./blob-broker/protocol";
 import { installProfileAlias, resolveProfileAliasCommandFromProcess } from "./cli/profile-alias";
@@ -96,6 +95,7 @@ async function showHelp(config: CliConfig<CommandMetadata>): Promise<void> {
  */
 async function runSmokeTest(): Promise<void> {
 	const { smokeTestSyncWorker, startServer } = await import("@oh-my-pi/omp-stats");
+	const { smokeTestAssignmentToolWorker } = await import("./assignment-capability/tool-worker-client");
 	const { smokeTestTinyTitleWorker } = await import("./tiny/title-client");
 	const { smokeTestSttWorker } = await import("./stt/asr-client");
 	const { smokeTestTtsWorker } = await import("./tts/tts-client");
@@ -106,6 +106,7 @@ async function runSmokeTest(): Promise<void> {
 	const { smokeTestLspMux } = await import("./lsp/mux/daemon");
 	const { smokeTestBlobBroker } = await import("./blob-broker/daemon");
 	const { smokeTestTerminalOutputWorker } = await import("./launch/terminal-output-worker-client");
+	await smokeTestAssignmentToolWorker();
 	await smokeTestSyncWorker();
 
 	const statsServer = await startServer(0);
@@ -144,6 +145,9 @@ const MNEMOPI_EMBED_WORKER_ARG = "__omp_worker_mnemopi_embed";
 
 async function runWorkerEntrypoint(arg: string | undefined): Promise<boolean> {
 	if (arg === ASSIGNMENT_TOOL_WORKER_ARG) {
+		// This selector is the capability isolation boundary; keep its filesystem,
+		// LSP, and settings graph out of normal/profile-bootstrap CLI startup.
+		const { runAssignmentToolWorker } = await import("./assignment-capability/tool-worker");
 		await runAssignmentToolWorker();
 		return true;
 	}

--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -27,6 +27,8 @@ import {
 import { interceptUnhandledRejections } from "@oh-my-pi/pi-utils/postmortem";
 import { setProcessName } from "@oh-my-pi/pi-utils/process-name";
 import { declareWorkerHostEntry, installWorkerInbox, isWorkerHostSelector } from "@oh-my-pi/pi-utils/worker-host";
+import { runAssignmentToolWorker } from "./assignment-capability/tool-worker";
+import { ASSIGNMENT_TOOL_WORKER_ARG } from "./assignment-capability/tool-worker-protocol";
 import { BLOB_BROKER_WORKER_ARG } from "./blob-broker/protocol";
 import { installProfileAlias, resolveProfileAliasCommandFromProcess } from "./cli/profile-alias";
 import { extractProfileFlags } from "./cli/profile-bootstrap";
@@ -141,6 +143,10 @@ const TTS_WORKER_ARG = "__omp_worker_tts";
 const MNEMOPI_EMBED_WORKER_ARG = "__omp_worker_mnemopi_embed";
 
 async function runWorkerEntrypoint(arg: string | undefined): Promise<boolean> {
+	if (arg === ASSIGNMENT_TOOL_WORKER_ARG) {
+		await runAssignmentToolWorker();
+		return true;
+	}
 	if (arg === TINY_WORKER_ARG) {
 		await runTinyWorker();
 		return true;

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -61,6 +61,11 @@ export interface Args {
 	providerSessionId?: string;
 	providerPromptCacheKey?: string;
 	fork?: string;
+	assignmentCapabilitySchema?: string;
+	assignmentHerdrSocket?: string;
+	assignmentHerdrPane?: string;
+	assignmentSession?: string;
+	assignmentJuizGatewayArgv?: string;
 	/** Collab link to join at startup (set by the `join` subcommand; no CLI flag). */
 	join?: string;
 	models?: string[];

--- a/packages/coding-agent/src/cli/flag-tables.ts
+++ b/packages/coding-agent/src/cli/flag-tables.ts
@@ -128,6 +128,21 @@ export const STRING_SETTERS: Record<string, StringSetter> = {
 	"--fork": (result, value) => {
 		result.fork = value;
 	},
+	"--assignment-capability-schema": (result, value) => {
+		result.assignmentCapabilitySchema = value;
+	},
+	"--assignment-herdr-socket": (result, value) => {
+		result.assignmentHerdrSocket = value;
+	},
+	"--assignment-herdr-pane": (result, value) => {
+		result.assignmentHerdrPane = value;
+	},
+	"--assignment-session": (result, value) => {
+		result.assignmentSession = value;
+	},
+	"--assignment-juiz-gateway-argv": (result, value) => {
+		result.assignmentJuizGatewayArgv = value;
+	},
 	"--provider": (result, value) => {
 		result.provider = value;
 	},

--- a/packages/coding-agent/src/commands/launch-help.ts
+++ b/packages/coding-agent/src/commands/launch-help.ts
@@ -14,6 +14,14 @@ export const launchHelp = {
 		}),
 	},
 	flags: {
+		"assignment-capability-schema": Flags.string({
+			description: "Internal Assignment capability schema",
+			hidden: true,
+		}),
+		"assignment-herdr-socket": Flags.string({ description: "Internal Herdr capability socket", hidden: true }),
+		"assignment-herdr-pane": Flags.string({ description: "Internal Herdr pane binding", hidden: true }),
+		"assignment-session": Flags.string({ description: "Internal OMP Session binding", hidden: true }),
+		"assignment-juiz-gateway-argv": Flags.string({ description: "Internal Juiz gateway argv", hidden: true }),
 		model: Flags.string({
 			description: 'Model to use (fuzzy match: "opus", "gpt-5.2", or "openai/gpt-5.2")',
 		}),

--- a/packages/coding-agent/src/cursor-bridge-tools.ts
+++ b/packages/coding-agent/src/cursor-bridge-tools.ts
@@ -9,6 +9,7 @@
  */
 
 import type { AgentTool } from "@oh-my-pi/pi-agent-core";
+import type { AssignmentToolTrust } from "./assignment-capability";
 import { EditTool } from "./edit";
 import type { ExtensionRunner } from "./extensibility/extensions";
 import { ExtensionToolWrapper } from "./extensibility/extensions";
@@ -29,10 +30,11 @@ import { GrepTool } from "./tools";
 export function createBridgeGrepFactory(
 	session: ToolSession,
 	extensionRunner: ExtensionRunner,
+	assignmentTrust: AssignmentToolTrust = "core",
 ): (options: GrepToolOptions) => AgentTool {
 	return options => {
 		const grepTool: Tool = new GrepTool(session, options);
-		return new ExtensionToolWrapper(grepTool, extensionRunner);
+		return new ExtensionToolWrapper(grepTool, extensionRunner, assignmentTrust);
 	};
 }
 
@@ -49,9 +51,13 @@ export function createBridgeGrepFactory(
  * tool is constructed rather than looked up, so building one unconditionally
  * hands a restricted agent a mutating tool it was denied (issue #5680).
  */
-export function createBridgeEditTool(session: ToolSession, extensionRunner: ExtensionRunner): AgentTool {
+export function createBridgeEditTool(
+	session: ToolSession,
+	extensionRunner: ExtensionRunner,
+	assignmentTrust: AssignmentToolTrust = "core",
+): AgentTool {
 	const editTool: Tool = new EditTool(session, "replace");
-	return new ExtensionToolWrapper(editTool, extensionRunner);
+	return new ExtensionToolWrapper(editTool, extensionRunner, assignmentTrust);
 }
 
 /**

--- a/packages/coding-agent/src/cursor.ts
+++ b/packages/coding-agent/src/cursor.ts
@@ -97,6 +97,8 @@ interface CursorExecBridgeOptions {
 	 * policy is resolved separately, per call.
 	 */
 	allowDirectFileMutation?: boolean | (() => boolean);
+	/** True only for an immutable JIP-0065 discussion Session. */
+	assignmentCapabilityRuntime?: boolean;
 	/**
 	 * Mirror Cursor's server-owned todo list into local session state. Cursor
 	 * resolves `update_todos` / `read_todos` remotely, so without this bridge
@@ -336,6 +338,16 @@ async function executeDelete(options: CursorExecBridgeOptions, pathArg: string, 
 	const refusal = refuseByWritePolicy(options, toolName, pathArg);
 	if (refusal) {
 		return createToolResultMessage(toolCallId, toolName, buildToolErrorResult(refusal), true);
+	}
+	if (options.assignmentCapabilityRuntime) {
+		// JIP-0065 supports only the four core mutation families through a hidden
+		// worker. Cursor's direct delete frame has no such worker contract.
+		return createToolResultMessage(
+			toolCallId,
+			toolName,
+			buildToolErrorResult("Assignment capability denied: direct delete is not authorized by v1"),
+			true,
+		);
 	}
 
 	options.emitEvent?.({ type: "tool_execution_start", toolCallId, toolName, args: { path: pathArg } });
@@ -794,6 +806,9 @@ export class CursorExecHandlers implements ICursorExecHandlers {
 			}
 			const refusal = refuseByWritePolicy(this.options, "write", downloadPath);
 			if (refusal) throw new Error(refusal);
+			if (this.options.assignmentCapabilityRuntime) {
+				throw new Error("Assignment capability denied: MCP resource download is not authorized by v1");
+			}
 		}
 		const mcp = this.options.mcpResources;
 		if (!mcp) return null;

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -12,6 +12,7 @@ import type {
 import type { CredentialDisabledEvent, ImageContent, Model, ProviderResponseMetadata } from "@oh-my-pi/pi-ai";
 import type { KeyId } from "@oh-my-pi/pi-tui";
 import { logger } from "@oh-my-pi/pi-utils";
+import type { AssignmentCapabilityRuntime } from "../../assignment-capability";
 import type { ModelRegistry } from "../../config/model-registry";
 import type { Settings } from "../../config/settings";
 import type { LocalProtocolOptions } from "../../internal-urls/local-protocol";
@@ -395,6 +396,7 @@ export async function emitSessionShutdownEvent(extensionRunner: ExtensionRunner 
 	} finally {
 		extensionRunner.disposeFileFallbacks();
 		extensionRunner.clearManagedTimers();
+		extensionRunner.closeAssignmentCapability();
 	}
 }
 
@@ -607,10 +609,20 @@ export class ExtensionRunner {
 		private readonly settings?: Settings,
 		private readonly localProtocolOptions?: LocalProtocolOptions,
 		getAsyncJobSnapshot?: () => AsyncJobSnapshot | null,
+		private readonly assignmentCapability?: AssignmentCapabilityRuntime,
 	) {
 		this.#uiContext = noOpUIContext;
 		this.#getMemoryFn = getMemory;
 		this.#getAsyncJobSnapshotFn = getAsyncJobSnapshot ?? (() => null);
+	}
+
+	/** Session-owned immutable Assignment capability runtime, if launch opted in. */
+	getAssignmentCapability(): AssignmentCapabilityRuntime | undefined {
+		return this.assignmentCapability;
+	}
+
+	closeAssignmentCapability(): void {
+		this.assignmentCapability?.close();
 	}
 
 	/**

--- a/packages/coding-agent/src/extensibility/extensions/wrapper.ts
+++ b/packages/coding-agent/src/extensibility/extensions/wrapper.ts
@@ -10,6 +10,7 @@ import type {
 } from "@oh-my-pi/pi-agent-core";
 import type { ComputerSafetyCheck, ImageContent, Static, TextContent, TSchema } from "@oh-my-pi/pi-ai";
 import { sanitizeText, untilAborted } from "@oh-my-pi/pi-utils";
+import { type AssignmentToolTrust, classifyAssignmentTool } from "../../assignment-capability";
 import type { Settings } from "../../config/settings";
 import type { Theme } from "../../modes/theme/theme";
 import {
@@ -161,6 +162,7 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 	constructor(
 		private tool: AgentTool<TParameters, TDetails>,
 		private runner: ExtensionRunner,
+		private readonly assignmentTrust: AssignmentToolTrust = "external",
 	) {
 		applyToolProxy(tool, this);
 	}
@@ -345,26 +347,63 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 			}
 		}
 
-		// Execute the actual tool
+		// 3. Assignment capability gate. Sessions whose immutable launch record
+		// declares the gateway get one universal in-process gate. Ordinary OMP
+		// Sessions have no Assignment runtime and retain their existing tools.
+		// Approval establishes user intent only; it never supplies Assignment
+		// execution authority. Classification is after extension revision and
+		// final approval resolution, against the exact args that would execute.
+		const assignmentRuntime = this.runner.getAssignmentCapability();
+		const classification = assignmentRuntime
+			? classifyAssignmentTool(this.tool.name, this.assignmentTrust, resolved.tier, effectiveParams)
+			: undefined;
+		if (classification?.kind === "denied") {
+			throw new Error(`Assignment capability denied: tool "${this.tool.name}" is not authorized by v1`);
+		}
+
 		let result: AgentToolResult<TDetails, TParameters>;
 		let executionError: Error | undefined;
-
-		try {
-			// A denied file write or delete inside this tool can be brokered to an
-			// extension handler, and that registry is PROCESS-WIDE — so the session is
-			// named here, the one place where every tool's execution and the runner
-			// that owns the handlers are both in scope (`sdk.ts` wraps the whole tool
-			// registry with this class whenever a runner exists). Inert with no
-			// fallback registered: no scope is entered.
-			result = await withFileMutationSession(this.runner.sessionId, () =>
-				this.tool.execute(toolCallId, effectiveParams, signal, onUpdate, context),
-			);
-		} catch (err) {
-			executionError = err instanceof Error ? err : new Error(String(err));
-			result = {
-				content: [{ type: "text", text: executionError.message }],
-				details: undefined as TDetails,
-			};
+		if (classification?.kind === "mutation") {
+			const runtime = assignmentRuntime;
+			if (!runtime) throw new Error("Assignment capability runtime is unavailable");
+			const effectiveArgsDigest = await runtime.digest(effectiveParams);
+			const execution = await runtime.execute({
+				toolCall: toolCallId,
+				tool: classification.family,
+				tier: "write",
+				effectiveArgs: effectiveParams,
+				effectiveArgsDigest,
+			});
+			// The discussion Session is requester-only: the local mutating tool is
+			// deliberately not called. Go returns one already-sanitized tool result
+			// after the hidden worker attempt is terminal.
+			result = execution.toolResult as AgentToolResult<TDetails, TParameters>;
+		} else if (classification?.kind === "completion") {
+			const runtime = assignmentRuntime;
+			if (!runtime) throw new Error("Assignment capability runtime is unavailable");
+			const completion = await runtime.complete(toolCallId);
+			// Completion is an explicit authenticated Go lifecycle transition. The
+			// local placeholder tool never executes and final output/idle/close do
+			// not imply completion.
+			result = completion.toolResult as AgentToolResult<TDetails, TParameters>;
+		} else {
+			try {
+				// A denied file write or delete inside this tool can be brokered to an
+				// extension handler, and that registry is PROCESS-WIDE — so the session is
+				// named here, the one place where every tool's execution and the runner
+				// that owns the handlers are both in scope (`sdk.ts` wraps the whole tool
+				// registry with this class whenever a runner exists). Inert with no
+				// fallback registered: no scope is entered.
+				result = await withFileMutationSession(this.runner.sessionId, () =>
+					this.tool.execute(toolCallId, effectiveParams, signal, onUpdate, context),
+				);
+			} catch (err) {
+				executionError = err instanceof Error ? err : new Error(String(err));
+				result = {
+					content: [{ type: "text", text: executionError.message }],
+					details: undefined as TDetails,
+				};
+			}
 		}
 
 		// Emit tool_result event - extensions can modify the result and error status

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -23,6 +23,7 @@ import {
 	VERSION,
 } from "@oh-my-pi/pi-utils";
 import chalk from "@oh-my-pi/pi-utils/chalk";
+import { ASSIGNMENT_CAPABILITY_SCHEMA } from "./assignment-capability";
 import { reset as resetCapabilities } from "./capability";
 import { type Args, reportUnrecognizedFlags, validateToolNames } from "./cli/args";
 import { applyExtensionFlags, type ExtensionFlagSink } from "./cli/extension-flags";
@@ -1069,6 +1070,41 @@ export function applyResolvedSystemPromptInputs(
 	}
 }
 
+function assignmentCapabilityFromArgs(parsed: Args): CreateAgentSessionOptions["assignmentCapability"] {
+	const values = [
+		parsed.assignmentCapabilitySchema,
+		parsed.assignmentHerdrSocket,
+		parsed.assignmentHerdrPane,
+		parsed.assignmentSession,
+		parsed.assignmentJuizGatewayArgv,
+	];
+	const supplied = values.filter(value => value !== undefined).length;
+	if (supplied === 0) return undefined;
+	if (supplied !== values.length || parsed.assignmentCapabilitySchema !== ASSIGNMENT_CAPABILITY_SCHEMA) {
+		throw new Error("Assignment capability launch requires the exact v1 schema and every hidden transport option");
+	}
+	let gatewayArgv: unknown;
+	try {
+		gatewayArgv = JSON.parse(Buffer.from(parsed.assignmentJuizGatewayArgv!, "base64url").toString("utf8"));
+	} catch {
+		throw new Error("Assignment capability gateway argv is invalid");
+	}
+	if (
+		!Array.isArray(gatewayArgv) ||
+		gatewayArgv.length === 0 ||
+		!gatewayArgv.every(value => typeof value === "string" && value.length > 0)
+	) {
+		throw new Error("Assignment capability gateway argv is invalid");
+	}
+	return Object.freeze({
+		schema: ASSIGNMENT_CAPABILITY_SCHEMA,
+		herdrSocketPath: parsed.assignmentHerdrSocket!,
+		pane: parsed.assignmentHerdrPane!,
+		session: parsed.assignmentSession!,
+		juizGatewayArgv: Object.freeze(gatewayArgv) as readonly [string, ...string[]],
+	});
+}
+
 /** Builds startup session options from parsed CLI flags, scoped models, and resolved session lineage. */
 export async function buildSessionOptions(
 	parsed: Args,
@@ -1081,6 +1117,7 @@ export async function buildSessionOptions(
 		cwd: parsed.cwd ?? getProjectDir(),
 		autoApprove: parsed.autoApprove ?? false,
 	};
+	options.assignmentCapability = assignmentCapabilityFromArgs(parsed);
 	const restoringSession = Boolean(parsed.continue || parsed.resume || isForeignSessionImport(parsed));
 	if (parsed.serviceTier !== undefined) {
 		options.openAIServiceTier = serviceTierSettingToTier(parsed.serviceTier) ?? null;

--- a/packages/coding-agent/src/prompts/tools/assignment-complete.md
+++ b/packages/coding-agent/src/prompts/tools/assignment-complete.md
@@ -1,0 +1,3 @@
+Complete the active Assignment through Juiz's authenticated lifecycle boundary.
+
+Call this only after every requested repository mutation is finished and verified. A successful call records the Assignment as completed-unlanded and revokes this Session's mutation authority. It is not inferred from final output, idle state, or Session closure.

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -47,6 +47,11 @@ import {
 	formatActiveRepoWatchdogPrompt,
 	formatAdvisorContextPrompt,
 } from "./advisor";
+import {
+	type AssignmentCapabilityLaunchOptions,
+	AssignmentCapabilityRuntime,
+	AssignmentCompleteTool,
+} from "./assignment-capability";
 import { AsyncJobManager } from "./async";
 import { AutoLearnController, buildAutoLearnInstructions } from "./autolearn/controller";
 import { createAutoresearchExtension } from "./autoresearch";
@@ -433,6 +438,12 @@ export interface CreateAgentSessionOptions {
 	providerPromptCacheKeySource?: "explicit" | "fork";
 	/** Absolute wall-clock deadline in Unix epoch milliseconds. */
 	deadline?: number;
+	/**
+	 * Immutable JIP-0065 launch eligibility. The holder secret and live notices
+	 * are acquired from Herdr and remain in process memory; this option contains
+	 * only caller-owned transport addressing.
+	 */
+	assignmentCapability?: Readonly<AssignmentCapabilityLaunchOptions>;
 
 	/** Custom tools to register (in addition to built-in tools). Accepts both CustomTool and ToolDefinition. */
 	customTools?: (CustomTool | ToolDefinition)[];
@@ -675,6 +686,7 @@ export function resolveDialect(
 
 // Re-exports
 
+export type { AssignmentCapabilityLaunchOptions } from "./assignment-capability";
 export type { PromptTemplate } from "./config/prompt-templates";
 export { Settings, type SkillsSettings } from "./config/settings";
 export type { CustomCommand, CustomCommandFactory } from "./extensibility/custom-commands/types";
@@ -2730,6 +2742,9 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 		// (The builtin autoresearch extension is unconditionally loaded above, so this scenario
 		// is unreachable; unconditional runner construction keeps that invariant explicit and
 		// prevents future optional extensions from silently re-opening the hole.)
+		const assignmentCapabilityRuntime = options.assignmentCapability
+			? await AssignmentCapabilityRuntime.create(options.assignmentCapability)
+			: undefined;
 		const extensionRunner: ExtensionRunner = new ExtensionRunner(
 			extensionsResult.extensions,
 			extensionsResult.runtime,
@@ -2740,6 +2755,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			settings,
 			localProtocolOptions,
 			() => (hasSession ? session.getAsyncJobSnapshot() : null),
+			assignmentCapabilityRuntime,
 		);
 
 		credentialDisabledTarget = extensionRunner;
@@ -2830,6 +2846,12 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			toolRegistry.set(tool.name, tool);
 			builtInRegistryToolNames.delete(tool.name);
 		}
+		if (assignmentCapabilityRuntime) {
+			const assignmentCompleteTool = wrapToolWithMetaNotice(new AssignmentCompleteTool());
+			toolRegistry.set(assignmentCompleteTool.name, assignmentCompleteTool);
+			builtInRegistryToolNames.add(assignmentCompleteTool.name);
+			nativeToolsByName.set(assignmentCompleteTool.name, assignmentCompleteTool);
+		}
 		// Expose the native built-ins to same-tool `ctx.invokeTool` on re-registered tools. Set after
 		// the override loop so the map holds the natives, not the extension replacements. The context
 		// factory is the loop's own tool context, so a delegated native call sees ordinary session state.
@@ -2850,7 +2872,14 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 		// call site, regardless of whether any user extensions are loaded. See the runner-construction
 		// comment above for the safety invariant this enforces.
 		for (const tool of toolRegistry.values()) {
-			toolRegistry.set(tool.name, new ExtensionToolWrapper(tool, extensionRunner));
+			toolRegistry.set(
+				tool.name,
+				new ExtensionToolWrapper(
+					tool,
+					extensionRunner,
+					builtInRegistryToolNames.has(tool.name) ? "core" : "external",
+				),
+			);
 		}
 		// Hashline `edit` stays in the registry so Cursor can call it as MCP.
 		// Native StrReplace arrives as `editToolCall` and materializes through
@@ -2886,7 +2915,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 				const writeTool = await logger.time("createTools:write:session", BUILTIN_TOOLS.write, toolSession);
 				if (!writeTool || toolRegistry.has("write")) return builtInRegistryToolNames.has("write");
 				const nativeWrite = wrapToolWithMetaNotice(writeTool);
-				toolRegistry.set(writeTool.name, new ExtensionToolWrapper(nativeWrite, extensionRunner) as Tool);
+				toolRegistry.set(writeTool.name, new ExtensionToolWrapper(nativeWrite, extensionRunner, "core") as Tool);
 				builtInRegistryToolNames.add(writeTool.name);
 				nativeToolsByName.set(writeTool.name, nativeWrite);
 				return true;
@@ -2911,7 +2940,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 				const goalTool = await logger.time("createTools:goal:session", HIDDEN_TOOLS.goal, toolSession);
 				if (!goalTool || toolRegistry.has("goal")) return toolRegistry.has("goal");
 				const nativeGoal = wrapToolWithMetaNotice(goalTool);
-				toolRegistry.set(goalTool.name, new ExtensionToolWrapper(nativeGoal, extensionRunner) as Tool);
+				toolRegistry.set(goalTool.name, new ExtensionToolWrapper(nativeGoal, extensionRunner, "core") as Tool);
 				builtInRegistryToolNames.add(goalTool.name);
 				nativeToolsByName.set(goalTool.name, nativeGoal);
 				return true;
@@ -2974,6 +3003,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			getEditReplaceTool: getCursorBridgeEditTool,
 			getToolContext: () => toolContextStore.getContext(),
 			mcpResources: cursorMcpResources,
+			assignmentCapabilityRuntime: assignmentCapabilityRuntime !== undefined,
 			emitEvent: event => cursorEventEmitter?.(event),
 			getTodoPhases: () => session.getTodoPhases(),
 			setTodoPhases: phases => session.setTodoPhases(phases),
@@ -3597,7 +3627,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 		// first, matching the registry's wrap order.
 		const advisorTools: Tool[] = built
 			.filter((tool): tool is Tool => tool != null)
-			.map(tool => new ExtensionToolWrapper(wrapToolWithMetaNotice(tool), extensionRunner) as Tool);
+			.map(tool => new ExtensionToolWrapper(wrapToolWithMetaNotice(tool), extensionRunner, "core-readonly") as Tool);
 
 		const advisorWatchdogPrompts = [...watchdogFiles];
 		if (initialActiveRepoContext) {
@@ -3722,13 +3752,10 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			providerPromptCacheKeySource,
 			parentEvalSessionId: options.parentEvalSessionId,
 			advisorTools,
-			// Same per-call `grep` seam the primary bridge gets, built against the
+			advisorCreateGrepTool: createBridgeGrepFactory(advisorToolSession, extensionRunner, "core-readonly"),
 			// advisor's own tool session so a `pi_grep` frame's context width and
 			// match cap are honored there too.
-			advisorCreateGrepTool: createBridgeGrepFactory(advisorToolSession, extensionRunner),
-			// Same `replace`-mode requirement as the primary bridge; the advisor
-			// path gates it on the advisor's own `edit` grant.
-			advisorCreateEditTool: () => createBridgeEditTool(advisorToolSession, extensionRunner),
+			advisorCreateEditTool: () => createBridgeEditTool(advisorToolSession, extensionRunner, "core-readonly"),
 			// The advisor's bridge tools are wrapped for approval, but the wrapper
 			// reads the mode and per-tool policies only from the execute-time
 			// context — the primary bridge passes the same store.

--- a/packages/coding-agent/src/session/session-tools.ts
+++ b/packages/coding-agent/src/session/session-tools.ts
@@ -559,9 +559,11 @@ export class SessionTools {
 	}
 
 	#wrapRuntimeTool(tool: AgentTool): AgentTool {
-		const wrapped = wrapToolWithMetaNotice(tool);
 		const extensionRunner = this.#host.extensionRunner();
-		return extensionRunner ? new ExtensionToolWrapper(wrapped, extensionRunner) : wrapped;
+		if (!extensionRunner) {
+			throw new Error(`Cannot register runtime tool "${tool.name}" without the universal capability gate`);
+		}
+		return new ExtensionToolWrapper(wrapToolWithMetaNotice(tool), extensionRunner);
 	}
 
 	/** Installs and activates the ephemeral vibe tool set. */
@@ -1777,7 +1779,7 @@ export class SessionTools {
 		const extensionRunner = this.#host.extensionRunner();
 		const managerTools = deduplicateMCPToolsByName(mcpTools).map(customTool => {
 			const wrapped = wrapToolWithMetaNotice(CustomToolAdapter.wrap(customTool, getCustomToolContext) as AgentTool);
-			return (extensionRunner ? new ExtensionToolWrapper(wrapped, extensionRunner) : wrapped) as AgentTool;
+			return extensionRunner ? (new ExtensionToolWrapper(wrapped, extensionRunner) as AgentTool) : wrapped;
 		});
 		const managerToolSet = new Set(managerTools);
 		const reconciledTools = deduplicateMCPToolsByName([...this.#extensionMcpTools.values(), ...managerTools]);
@@ -1847,9 +1849,9 @@ export class SessionTools {
 		const extensionRunner = this.#host.extensionRunner();
 		for (const tool of rpcTools) {
 			const metaWrapped = wrapToolWithMetaNotice(tool);
-			const finalTool = (
-				extensionRunner ? new ExtensionToolWrapper(metaWrapped, extensionRunner) : metaWrapped
-			) as AgentTool;
+			const finalTool = extensionRunner
+				? (new ExtensionToolWrapper(metaWrapped, extensionRunner) as AgentTool)
+				: metaWrapped;
 			this.#toolRegistry.set(finalTool.name, finalTool);
 			this.#rpcHostToolNames.add(finalTool.name);
 		}

--- a/packages/coding-agent/src/session/session-tools.ts
+++ b/packages/coding-agent/src/session/session-tools.ts
@@ -559,11 +559,9 @@ export class SessionTools {
 	}
 
 	#wrapRuntimeTool(tool: AgentTool): AgentTool {
+		const wrapped = wrapToolWithMetaNotice(tool);
 		const extensionRunner = this.#host.extensionRunner();
-		if (!extensionRunner) {
-			throw new Error(`Cannot register runtime tool "${tool.name}" without the universal capability gate`);
-		}
-		return new ExtensionToolWrapper(wrapToolWithMetaNotice(tool), extensionRunner);
+		return extensionRunner ? new ExtensionToolWrapper(wrapped, extensionRunner) : wrapped;
 	}
 
 	/** Installs and activates the ephemeral vibe tool set. */
@@ -863,7 +861,9 @@ export class SessionTools {
 
 	async #applyActiveToolsByName(toolNames: string[], forcePromptRefresh = false, signal?: AbortSignal): Promise<void> {
 		signal?.throwIfAborted();
-		toolNames = normalizeToolNames(toolNames);
+		toolNames = normalizeToolNames(
+			this.#toolRegistry.has("assignment_complete") ? [...toolNames, "assignment_complete"] : toolNames,
+		);
 		const codeMode = resolveCodeMode({
 			provider: this.#host.model()?.provider ?? "",
 			toolMode: this.#host.model()?.toolMode,

--- a/packages/coding-agent/test/agent-session-memory-backend.test.ts
+++ b/packages/coding-agent/test/agent-session-memory-backend.test.ts
@@ -89,10 +89,11 @@ describe("AgentSession memory backend lifecycle", () => {
 		return session;
 	}
 
-	it("switches runtime state, memory tools, and prompt in one apply", async () => {
+	it("switches runner-less memory runtime state, tools, and prompt in one apply", async () => {
 		const current = createSession(async () =>
 			settings.get("memory.backend") === "mnemopi" ? [createTool("retain"), createTool("memory_edit")] : [],
 		);
+		expect(current.extensionRunner).toBeUndefined();
 
 		settings.override("memory.backend", "mnemopi");
 		await current.applyMemoryBackend();

--- a/packages/coding-agent/test/assignment-capability-gate.test.ts
+++ b/packages/coding-agent/test/assignment-capability-gate.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from "bun:test";
+import { Type } from "@oh-my-pi/omptype/typebox";
+import type { AgentTool } from "@oh-my-pi/pi-agent-core";
+import { classifyAssignmentTool } from "@oh-my-pi/pi-coding-agent/assignment-capability/gate";
+import type { AssignmentCapabilityRuntime } from "@oh-my-pi/pi-coding-agent/assignment-capability/runtime";
+import type { AssignmentExecuteInput } from "@oh-my-pi/pi-coding-agent/assignment-capability/types";
+import type { ExtensionRunner } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/runner";
+import { ExtensionToolWrapper } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/wrapper";
+
+function tool(name: string, tier: "read" | "write", calls: unknown[]): AgentTool {
+	return {
+		name,
+		label: name,
+		description: `${name} test tool`,
+		parameters: Type.Object({ value: Type.String() }),
+		strict: true,
+		approval: tier,
+		execute: async (_id: string, params: unknown) => {
+			calls.push(params);
+			return { content: [{ type: "text", text: "local" }] };
+		},
+	} as AgentTool;
+}
+
+function runner(runtime?: AssignmentCapabilityRuntime): ExtensionRunner {
+	return {
+		sessionId: "discussion-session",
+		consumeToolCallEmitted: () => false,
+		hasHandlers: () => false,
+		getAssignmentCapability: () => runtime,
+	} as unknown as ExtensionRunner;
+}
+
+function capabilityRuntime(
+	requests: AssignmentExecuteInput[],
+	completions: string[] = [],
+): AssignmentCapabilityRuntime {
+	return {
+		digest: async () => "digest",
+		execute: async (input: AssignmentExecuteInput) => {
+			requests.push(input);
+			return {
+				toolResult: { content: [{ type: "text", text: "brokered" }] },
+				receipt: {
+					attempt: "attempt-1",
+					launchDigest: "digest",
+					disposition: "succeeded",
+					checkpointDigest: "digest",
+					promotion: "promoted",
+					cleanup: "completed",
+					fenceGeneration: 1,
+					fencePhase: "released",
+					reconciliation: {},
+				},
+			};
+		},
+		complete: async (toolCall: string) => {
+			completions.push(toolCall);
+			return {
+				toolResult: { content: [{ type: "text", text: "completed" }] },
+				completion: {
+					capability: "capability-1",
+					generation: 1,
+					revocationGeneration: 1,
+					state: "revoked",
+					assignmentState: "completed-unlanded",
+					denialProofDigest: "sha256:proof",
+					requestAttempt: "request-1",
+				},
+			};
+		},
+	} as unknown as AssignmentCapabilityRuntime;
+}
+
+describe("Assignment capability classification", () => {
+	it("keeps trusted reads available and denies mutating or unknown bypasses", () => {
+		expect(classifyAssignmentTool("read", "core", "read", { path: "x" })).toEqual({ kind: "read" });
+		expect(classifyAssignmentTool("hub", "core", "read", { op: "jobs" })).toEqual({ kind: "read" });
+		expect(classifyAssignmentTool("hub", "core", "write", { op: "send" })).toEqual({ kind: "denied" });
+		expect(classifyAssignmentTool("write", "core-readonly", "write", { path: "x" })).toEqual({ kind: "denied" });
+		expect(classifyAssignmentTool("custom", "external", "read", {})).toEqual({ kind: "denied" });
+		expect(classifyAssignmentTool("bash", "core", "exec", { command: "true" })).toEqual({ kind: "denied" });
+		expect(classifyAssignmentTool("write", "core", "write", { path: "xd://browser" })).toEqual({ kind: "denied" });
+		for (const [name, trust, tier, args] of [
+			["eval", "core", "exec", { code: "write()" }],
+			["github", "core", "write", { op: "pr_create" }],
+			["browser", "external", "write", { action: "run" }],
+			["mcp_tool", "external", "write", {}],
+			["host_tool_call", "external", "write", {}],
+			["task", "core", "exec", { tasks: [] }],
+		] as const) {
+			expect(classifyAssignmentTool(name, trust, tier, args)).toEqual({ kind: "denied" });
+		}
+	});
+
+	it("admits only the four v1 mutation families at write tier", () => {
+		for (const name of ["write", "edit", "ast_edit", "lsp"] as const) {
+			expect(classifyAssignmentTool(name, "core", "write", {})).toEqual({ kind: "mutation", family: name });
+		}
+	});
+
+	it("admits only the trusted explicit completion boundary", () => {
+		expect(classifyAssignmentTool("assignment_complete", "core", "write", {})).toEqual({ kind: "completion" });
+		expect(classifyAssignmentTool("assignment_complete", "external", "write", {})).toEqual({ kind: "denied" });
+		expect(classifyAssignmentTool("assignment_complete", "core", "read", {})).toEqual({ kind: "denied" });
+	});
+});
+
+describe("Assignment capability wrapper", () => {
+	it("brokers a final-argument mutation without executing the discussion Session tool", async () => {
+		const localCalls: unknown[] = [];
+		const requests: AssignmentExecuteInput[] = [];
+		const wrapped = new ExtensionToolWrapper(
+			tool("write", "write", localCalls),
+			runner(capabilityRuntime(requests)),
+			"core",
+		);
+
+		const result = await wrapped.execute("call-1", { value: "final" } as never);
+
+		expect(result.content).toEqual([{ type: "text", text: "brokered" }]);
+		expect(localCalls).toEqual([]);
+		expect(requests).toHaveLength(1);
+		expect(requests[0]?.effectiveArgs).toEqual({ value: "final" });
+		expect(requests[0]?.tool).toBe("write");
+		expect(requests[0]?.effectiveArgsDigest).toBe("digest");
+	});
+
+	it("routes explicit completion to the authenticated runtime without executing locally", async () => {
+		const localCalls: unknown[] = [];
+		const completions: string[] = [];
+		const wrapped = new ExtensionToolWrapper(
+			tool("assignment_complete", "write", localCalls),
+			runner(capabilityRuntime([], completions)),
+			"core",
+		);
+
+		const result = await wrapped.execute("complete-call-1", { value: "complete" } as never);
+
+		expect(result.content).toEqual([{ type: "text", text: "completed" }]);
+		expect(localCalls).toEqual([]);
+		expect(completions).toEqual(["complete-call-1"]);
+	});
+
+	it("denies external mutation even in yolo mode", async () => {
+		const localCalls: unknown[] = [];
+		const wrapped = new ExtensionToolWrapper(tool("custom", "write", localCalls), runner(capabilityRuntime([])));
+
+		await expect(wrapped.execute("call-2", { value: "no" } as never)).rejects.toThrow("not authorized by v1");
+		expect(localCalls).toEqual([]);
+	});
+
+	it("executes trusted reads locally while an Assignment is active", async () => {
+		const localCalls: unknown[] = [];
+		const wrapped = new ExtensionToolWrapper(tool("read", "read", localCalls), runner(capabilityRuntime([])), "core");
+
+		const result = await wrapped.execute("call-3", { value: "read" } as never);
+
+		expect(result.content).toEqual([{ type: "text", text: "local" }]);
+		expect(localCalls).toEqual([{ value: "read" }]);
+	});
+
+	it("leaves ordinary non-Assignment Sessions unchanged", async () => {
+		const localCalls: unknown[] = [];
+		const wrapped = new ExtensionToolWrapper(tool("write", "write", localCalls), runner(), "core");
+
+		const result = await wrapped.execute("call-4", { value: "ordinary" } as never);
+
+		expect(result.content).toEqual([{ type: "text", text: "local" }]);
+		expect(localCalls).toEqual([{ value: "ordinary" }]);
+	});
+});

--- a/packages/coding-agent/test/assignment-capability-runtime.test.ts
+++ b/packages/coding-agent/test/assignment-capability-runtime.test.ts
@@ -2,47 +2,69 @@ import { describe, expect, it } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
+import { stableJson } from "@oh-my-pi/pi-coding-agent/assignment-capability/canonical-json";
 import {
 	AssignmentCapabilityRuntime,
 	callAssignmentGateway,
 } from "@oh-my-pi/pi-coding-agent/assignment-capability/runtime";
 import { ASSIGNMENT_CAPABILITY_SCHEMA } from "@oh-my-pi/pi-coding-agent/assignment-capability/types";
 
+type GatewayBehavior =
+	| "denial"
+	| "malformed"
+	| "retryable"
+	| "timeout"
+	| "stdout-overflow"
+	| "stderr-overflow"
+	| "ignore-sigterm";
+
 interface GatewayFixture {
 	readonly argv: readonly string[];
 	readonly attempts: string;
 	readonly root: string;
+	readonly termination: string;
 }
 
-async function gatewayFixture(first: "denial" | "malformed" | "retryable" | "timeout"): Promise<GatewayFixture> {
+async function gatewayFixture(first: GatewayBehavior): Promise<GatewayFixture> {
 	const root = await fs.mkdtemp(path.join(os.tmpdir(), "omp-assignment-gateway-"));
 	const script = path.join(root, "gateway.ts");
 	const attempts = path.join(root, "attempts");
+	const termination = path.join(root, "termination");
 	await Bun.write(
 		script,
-		`const attempts = Bun.argv[2];
+		`import * as fs from "node:fs";
+const attempts = Bun.argv[2];
+const termination = Bun.argv[3];
 const input = JSON.parse(await Bun.stdin.text());
+const behavior = ${JSON.stringify(first)};
 let count = 0;
 try { count = Number(await Bun.file(attempts).text()); } catch {}
 await Bun.write(attempts, String(count + 1));
-if (count === 0 && ${JSON.stringify(first)} === "timeout") {
+if (count === 0 && behavior === "timeout") {
 	// This integration fixture must exercise a real child-process timeout;
 	// fake timers cannot advance the spawned process's independent clock.
 	await Bun.sleep(1_700);
 }
-if (count === 0 && ${JSON.stringify(first)} === "malformed") {
+if (count === 0 && (behavior === "stdout-overflow" || behavior === "stderr-overflow" || behavior === "ignore-sigterm")) {
+	process.on("SIGTERM", () => fs.writeFileSync(termination, "SIGTERM"));
+	if (behavior === "stdout-overflow") process.stdout.write("x".repeat(2 * 1024 * 1024 + 1));
+	if (behavior === "stderr-overflow") process.stderr.write("x".repeat(2 * 1024 * 1024 + 1));
+	const blocked = Promise.withResolvers<void>();
+	await blocked.promise;
+}
+if (count === 0 && behavior === "malformed") {
 	process.stdout.write("{");
 	process.exit(0);
 }
 if (count === 0) {
-	const retryable = ${JSON.stringify(first)} === "retryable";
+	const retryable = behavior === "retryable";
 	process.stdout.write(JSON.stringify({ schema: ${JSON.stringify(ASSIGNMENT_CAPABILITY_SCHEMA)}, requestId: input.requestId, ok: false, operation: input.operation, error: { code: retryable ? "RECONCILE" : "EXPLICIT_DENIAL", message: "denied", retryable } }));
 	process.exit(0);
 }
 process.stdout.write(JSON.stringify({ schema: ${JSON.stringify(ASSIGNMENT_CAPABILITY_SCHEMA)}, requestId: input.requestId, ok: true, operation: input.operation, result: { disposition: "reconciled" } }));
 `,
 	);
-	return { argv: [process.execPath, script, attempts], attempts, root };
+	return { argv: [process.execPath, script, attempts, termination], attempts, root, termination };
 }
 
 const request = {
@@ -54,10 +76,11 @@ const request = {
 describe("Assignment capability digest", () => {
 	it("matches Go stable JSON for HTML-sensitive and Unicode-key arguments", async () => {
 		const runtime = Object.create(AssignmentCapabilityRuntime.prototype) as AssignmentCapabilityRuntime;
-		const value = { z: "<>&\u2028", "\uE000": 1, "😀": 2, omitted: undefined };
-		const canonical = `{"z":"<>&\\u2028","":1,"😀":2}`;
+		const value = { z: "<>&\u2028\u2029", "\uE000": 1, "😀": 2, omitted: undefined };
+		const canonical = `{"z":"<>&\\u2028\\u2029","":1,"😀":2}`;
 		const expected = `sha256:${new Bun.CryptoHasher("sha256").update(canonical).digest("hex")}`;
 
+		expect(stableJson(JSON.parse(JSON.stringify(value)))).toBe(canonical);
 		await expect(runtime.digest(value)).resolves.toBe(expected);
 	});
 });
@@ -107,6 +130,35 @@ describe("Assignment capability gateway retry", () => {
 				disposition: "reconciled",
 			});
 			expect(await Bun.file(fixture.attempts).text()).toBe("2");
+		} finally {
+			await fs.rm(fixture.root, { recursive: true, force: true });
+		}
+	});
+
+	it.each(["stdout", "stderr"] as const)(
+		"terminates and reconciles as soon as bounded %s output overflows",
+		async stream => {
+			const fixture = await gatewayFixture(`${stream}-overflow`);
+			try {
+				await expect(callAssignmentGateway(fixture.argv, request, Date.now() + 10_000)).resolves.toEqual({
+					disposition: "reconciled",
+				});
+				expect(await Bun.file(fixture.attempts).text()).toBe("2");
+				expect(await Bun.file(fixture.termination).text()).toBe("SIGTERM");
+			} finally {
+				await fs.rm(fixture.root, { recursive: true, force: true });
+			}
+		},
+	);
+
+	it("escalates to SIGKILL within the deadline when the gateway ignores SIGTERM", async () => {
+		const fixture = await gatewayFixture("ignore-sigterm");
+		try {
+			await expect(callAssignmentGateway(fixture.argv, request, Date.now() + 3_000)).resolves.toEqual({
+				disposition: "reconciled",
+			});
+			expect(await Bun.file(fixture.attempts).text()).toBe("2");
+			expect(await Bun.file(fixture.termination).text()).toBe("SIGTERM");
 		} finally {
 			await fs.rm(fixture.root, { recursive: true, force: true });
 		}

--- a/packages/coding-agent/test/assignment-capability-runtime.test.ts
+++ b/packages/coding-agent/test/assignment-capability-runtime.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+	AssignmentCapabilityRuntime,
+	callAssignmentGateway,
+} from "@oh-my-pi/pi-coding-agent/assignment-capability/runtime";
+import { ASSIGNMENT_CAPABILITY_SCHEMA } from "@oh-my-pi/pi-coding-agent/assignment-capability/types";
+
+interface GatewayFixture {
+	readonly argv: readonly string[];
+	readonly attempts: string;
+	readonly root: string;
+}
+
+async function gatewayFixture(first: "denial" | "malformed" | "retryable" | "timeout"): Promise<GatewayFixture> {
+	const root = await fs.mkdtemp(path.join(os.tmpdir(), "omp-assignment-gateway-"));
+	const script = path.join(root, "gateway.ts");
+	const attempts = path.join(root, "attempts");
+	await Bun.write(
+		script,
+		`const attempts = Bun.argv[2];
+const input = JSON.parse(await Bun.stdin.text());
+let count = 0;
+try { count = Number(await Bun.file(attempts).text()); } catch {}
+await Bun.write(attempts, String(count + 1));
+if (count === 0 && ${JSON.stringify(first)} === "timeout") {
+	// This integration fixture must exercise a real child-process timeout;
+	// fake timers cannot advance the spawned process's independent clock.
+	await Bun.sleep(1_700);
+}
+if (count === 0 && ${JSON.stringify(first)} === "malformed") {
+	process.stdout.write("{");
+	process.exit(0);
+}
+if (count === 0) {
+	const retryable = ${JSON.stringify(first)} === "retryable";
+	process.stdout.write(JSON.stringify({ schema: ${JSON.stringify(ASSIGNMENT_CAPABILITY_SCHEMA)}, requestId: input.requestId, ok: false, operation: input.operation, error: { code: retryable ? "RECONCILE" : "EXPLICIT_DENIAL", message: "denied", retryable } }));
+	process.exit(0);
+}
+process.stdout.write(JSON.stringify({ schema: ${JSON.stringify(ASSIGNMENT_CAPABILITY_SCHEMA)}, requestId: input.requestId, ok: true, operation: input.operation, result: { disposition: "reconciled" } }));
+`,
+	);
+	return { argv: [process.execPath, script, attempts], attempts, root };
+}
+
+const request = {
+	schema: ASSIGNMENT_CAPABILITY_SCHEMA,
+	requestId: "gateway-request-1",
+	operation: "attempt.execute",
+};
+
+describe("Assignment capability digest", () => {
+	it("matches Go stable JSON for HTML-sensitive and Unicode-key arguments", async () => {
+		const runtime = Object.create(AssignmentCapabilityRuntime.prototype) as AssignmentCapabilityRuntime;
+		const value = { z: "<>&\u2028", "\uE000": 1, "😀": 2, omitted: undefined };
+		const canonical = `{"z":"<>&\\u2028","":1,"😀":2}`;
+		const expected = `sha256:${new Bun.CryptoHasher("sha256").update(canonical).digest("hex")}`;
+
+		await expect(runtime.digest(value)).resolves.toBe(expected);
+	});
+});
+
+describe("Assignment capability gateway retry", () => {
+	it("does not replay an explicit gateway denial", async () => {
+		const fixture = await gatewayFixture("denial");
+		try {
+			await expect(callAssignmentGateway(fixture.argv, request, Date.now() + 10_000)).rejects.toThrow(
+				"EXPLICIT_DENIAL",
+			);
+			expect(await Bun.file(fixture.attempts).text()).toBe("1");
+		} finally {
+			await fs.rm(fixture.root, { recursive: true, force: true });
+		}
+	});
+
+	it("replays the exact request once after an ambiguous response", async () => {
+		const fixture = await gatewayFixture("malformed");
+		try {
+			await expect(callAssignmentGateway(fixture.argv, request, Date.now() + 10_000)).resolves.toEqual({
+				disposition: "reconciled",
+			});
+			expect(await Bun.file(fixture.attempts).text()).toBe("2");
+		} finally {
+			await fs.rm(fixture.root, { recursive: true, force: true });
+		}
+	});
+
+	it("reserves deadline budget to reconcile after a gateway timeout", async () => {
+		const fixture = await gatewayFixture("timeout");
+		try {
+			await expect(callAssignmentGateway(fixture.argv, request, Date.now() + 2_000)).resolves.toEqual({
+				disposition: "reconciled",
+			});
+			expect(await Bun.file(fixture.attempts).text()).toBe("2");
+		} finally {
+			await fs.rm(fixture.root, { recursive: true, force: true });
+		}
+	});
+
+	it("retries one retryable semantic completion response under the same identity", async () => {
+		const fixture = await gatewayFixture("retryable");
+		const completionRequest = { ...request, operation: "assignment.complete" };
+		try {
+			await expect(callAssignmentGateway(fixture.argv, completionRequest, Date.now() + 10_000)).resolves.toEqual({
+				disposition: "reconciled",
+			});
+			expect(await Bun.file(fixture.attempts).text()).toBe("2");
+		} finally {
+			await fs.rm(fixture.root, { recursive: true, force: true });
+		}
+	});
+});

--- a/packages/coding-agent/test/cursor-exec.test.ts
+++ b/packages/coding-agent/test/cursor-exec.test.ts
@@ -59,6 +59,7 @@ function passthroughRunner(seen: string[] = []): ExtensionRunner {
 	return {
 		hasHandlers: () => true,
 		consumeToolCallEmitted: () => false,
+		getAssignmentCapability: () => undefined,
 		emitToolCall: async (event: { toolName: string }) => {
 			seen.push(event.toolName);
 			return undefined;
@@ -1322,6 +1323,17 @@ describe("CursorExecHandlers mounted tool bridge", () => {
 				denied.readMcpResource({ server: "files", uri: "files://x", downloadPath: "out.txt" }),
 			).rejects.toThrow(/blocked by user policy/);
 
+			const capabilityBound = new CursorExecHandlers({
+				cwd: workspace,
+				tools: new Map(),
+				allowDirectFileMutation: true,
+				assignmentCapabilityRuntime: true,
+				mcpResources,
+			});
+			await expect(
+				capabilityBound.readMcpResource({ server: "files", uri: "files://x", downloadPath: "out.txt" }),
+			).rejects.toThrow(/Assignment capability denied/);
+
 			expect(reads).toBe(0);
 			expect(await Bun.file(path.join(workspace, "out.txt")).exists()).toBe(false);
 
@@ -1540,6 +1552,25 @@ describe("CursorExecHandlers native delete gating (issue #5680)", () => {
 
 		expect(result.isError).toBe(false);
 		expect(await Bun.file(target).exists()).toBe(false);
+	});
+
+	it("denies native delete only in an Assignment capability Session", async () => {
+		const target = path.join(cwd, "victim.txt");
+		await Bun.write(target, "preserve under broker");
+		const handlers = new CursorExecHandlers({
+			cwd,
+			tools: new Map(),
+			allowDirectFileMutation: true,
+			assignmentCapabilityRuntime: true,
+		});
+
+		const result = await handlers.delete(create(DeleteArgsSchema, { toolCallId: "call-del", path: target }));
+
+		expect(result.isError).toBe(true);
+		expect(result.content).toEqual([
+			{ type: "text", text: "Assignment capability denied: direct delete is not authorized by v1" },
+		]);
+		expect(await Bun.file(target).exists()).toBe(true);
 	});
 
 	it("rechecks a live mutation grant after runtime tool activation", async () => {

--- a/packages/coding-agent/test/interactive-mode-vibe-toggle.test.ts
+++ b/packages/coding-agent/test/interactive-mode-vibe-toggle.test.ts
@@ -143,7 +143,8 @@ describe("InteractiveMode vibe mode toggle", () => {
 		tempDir.removeSync();
 	});
 
-	it("preserves the parent Todo tool and restores the exact pre-vibe toolset on exit", async () => {
+	it("runs the runner-less vibe lifecycle and restores the exact pre-vibe toolset on exit", async () => {
+		expect(session.extensionRunner).toBeUndefined();
 		expect(session.getAllToolNames().toSorted()).toEqual(["read", "todo"]);
 		expect(session.getActiveToolNames()).toEqual([]);
 

--- a/packages/coding-agent/test/sdk-tool-activation.test.ts
+++ b/packages/coding-agent/test/sdk-tool-activation.test.ts
@@ -543,6 +543,57 @@ describe("createAgentSession defaultInactive tool activation", () => {
 		}
 	});
 
+	it("keeps registered Assignment completion active across direct and lifecycle tool selections", async () => {
+		const tempDir = makeTempDir();
+		const assignmentSelectionExtension: ExtensionFactory = pi => {
+			pi.registerTool({
+				name: "assignment_complete",
+				label: "Complete Assignment",
+				description: "Complete the active Assignment.",
+				parameters: type({}),
+				loadMode: "essential",
+				async execute() {
+					return { content: [{ type: "text", text: "complete" }] };
+				},
+			});
+			pi.on("session_start", async () => {
+				await pi.setActiveTools(["read"]);
+			});
+		};
+		const { session } = await createAgentSession({
+			...baseOptions(tempDir),
+			extensions: [assignmentSelectionExtension],
+		});
+
+		try {
+			expect(session.getActiveToolNames()).toContain("assignment_complete");
+
+			await session.setActiveToolsByName(["read"]);
+			expect(session.getActiveToolNames()).toEqual(["read", "assignment_complete"]);
+
+			const runner = session.extensionRunner;
+			if (!runner) throw new Error("expected extension runner");
+			await runner.emit({ type: "session_start" });
+			expect(session.getActiveToolNames()).toEqual(["read", "assignment_complete"]);
+		} finally {
+			await session.dispose();
+		}
+	});
+
+	it("does not inject Assignment completion into ordinary explicit tool selections", async () => {
+		const tempDir = makeTempDir();
+		const { session } = await createAgentSession(baseOptions(tempDir));
+
+		try {
+			await session.setActiveToolsByName(["read"]);
+
+			expect(session.getAllToolNames()).not.toContain("assignment_complete");
+			expect(session.getActiveToolNames()).toEqual(["read"]);
+		} finally {
+			await session.dispose();
+		}
+	});
+
 	it("deactivates an enabled tool when a late replacement is default-inactive", async () => {
 		const tempDir = makeTempDir();
 		const lateInactiveReplacement: ExtensionFactory = pi => {


### PR DESCRIPTION
## Summary
- add an immutable Assignment-capability runtime to an existing OMP Session
- enforce the capability at the universal tool wrapper after final argument resolution, broker the authorized core mutation, and deny unscoped external effects
- add explicit authenticated Assignment completion and worker-host dispatch without replacing the discussion Session

## Verification
- `bun check`
- `bun test packages/coding-agent/test/assignment-capability-gate.test.ts packages/coding-agent/test/assignment-capability-runtime.test.ts packages/coding-agent/test/cursor-exec.test.ts` — 82 passed
- `bun run build` and `packages/coding-agent/dist/omp --smoke-test`
- `bun run ci:test:full` reached 4324 passed and 331 skipped; its sole failure was the existing llama.cpp context-overflow case receiving `404 page not found` from the configured local endpoint
