### PR TITLE
fix(coding-agent): confirm before sharing sessions

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,10 @@
 - Devin model selectors now accept the native CLI's short aliases (`devin/opus`, `devin/swe`), dotted upstream spellings (`devin/gemini-3.7-flash`), and raw effort-route wire uids for dynamically collapsed families ([#8590](https://github.com/can1357/oh-my-pi/pull/8590) by [@will-bogusz](https://github.com/will-bogusz)).
 - Added provider-supplied model metadata to the `/models` detail line: `new`, `beta`, and `recommended` badges beside the model name, and the upstream description after the context, cost, and perf facts ([#8590](https://github.com/can1357/oh-my-pi/pull/8590) by [@will-bogusz](https://github.com/will-bogusz)).
 
+### Changed
+
+- Interactive `/share` now asks for confirmation before uploading the current session.
+
 ## [18.0.11] - 2026-08-29
 
 ### Added

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -215,6 +215,12 @@ export class CommandController {
 	}
 
 	async handleShareCommand(): Promise<void> {
+		const confirmed = await this.ctx.showHookConfirm(
+			"Share this session?",
+			"This uploads a copy of the current session. Anyone with the resulting link can read it.",
+		);
+		if (!confirmed) return;
+
 		let customShare: LoadedCustomShare | null;
 		try {
 			customShare = await loadCustomShare();

--- a/packages/coding-agent/test/modes/controllers/share-command.test.ts
+++ b/packages/coding-agent/test/modes/controllers/share-command.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import * as customShare from "@oh-my-pi/pi-coding-agent/export/custom-share";
+import * as share from "@oh-my-pi/pi-coding-agent/export/share";
+import { CommandController } from "@oh-my-pi/pi-coding-agent/modes/controllers/command-controller";
+import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
+
+function createContext(confirmed: boolean) {
+	const showHookConfirm = vi.fn(async () => confirmed);
+	const showError = vi.fn();
+	const ctx = {
+		showHookConfirm,
+		showError,
+	} as unknown as InteractiveModeContext;
+	return { ctx, showHookConfirm, showError };
+}
+
+describe("CommandController /share", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("does not load or upload session data when the operator declines", async () => {
+		const loadCustomShare = vi.spyOn(customShare, "loadCustomShare");
+		const shareSession = vi.spyOn(share, "shareSession");
+		const { ctx, showHookConfirm } = createContext(false);
+
+		await new CommandController(ctx).handleShareCommand();
+
+		expect(showHookConfirm).toHaveBeenCalledTimes(1);
+		expect(loadCustomShare).not.toHaveBeenCalled();
+		expect(shareSession).not.toHaveBeenCalled();
+	});
+
+	it("continues to the existing share flow after approval", async () => {
+		const loadCustomShare = vi
+			.spyOn(customShare, "loadCustomShare")
+			.mockRejectedValue(new Error("share setup reached"));
+		const shareSession = vi.spyOn(share, "shareSession");
+		const { ctx, showHookConfirm, showError } = createContext(true);
+
+		await new CommandController(ctx).handleShareCommand();
+
+		expect(showHookConfirm).toHaveBeenCalledTimes(1);
+		expect(loadCustomShare).toHaveBeenCalledTimes(1);
+		expect(shareSession).not.toHaveBeenCalled();
+		expect(showError).toHaveBeenCalledWith("share setup reached");
+	});
+});


### PR DESCRIPTION
## What

Added a confirmation prompt before /share uploads the current session.

## Why

I often use /shake, but /share can appear first when I type /sha.
It's too easy to select /share by accident and upload personal session data to the internet.

## Testing

Manually tested. 

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
