### PR TITLE
fix(coding-agent): hide foreground-wait bash jobs

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -20,6 +20,9 @@
 - Fixed an issue where custom model overrides were lost during configuration updates
 - Fixed "Please use nerdfont" notification incorrectly persisting after theme configuration
 - Fixed sampling parameter errors for newer Anthropic models (Opus 4.7+, Sonnet 5+)
+### Fixed
+
+- Kept auto-managed Bash jobs out of public async snapshots while they are still foreground-waited, publishing them only when they actually transition to background execution.
 
 ## [18.0.11] - 2026-08-29
 

--- a/packages/coding-agent/src/async/job-manager.ts
+++ b/packages/coding-agent/src/async/job-manager.ts
@@ -58,6 +58,11 @@ export interface AsyncJob {
 	 */
 	agentId?: string;
 	/**
+	 * Whether this job is exposed through public session snapshots. Jobs hidden
+	 * during a foreground wait can only transition to visible via `publishJob`.
+	 */
+	publiclyVisible: boolean;
+	/**
 	 * Job is registered but parked behind a caller-managed gate (e.g. a task
 	 * batch semaphore). Queued jobs do not count toward the running-job limit
 	 * until the caller invokes `markRunning()` from the run context.
@@ -89,6 +94,7 @@ interface AsyncJobDelivery {
 	nextAttemptAt: number;
 	lastError?: string;
 	ownerId?: string;
+	publiclyVisible: boolean;
 	promise?: Promise<void>;
 }
 
@@ -112,17 +118,21 @@ export interface AsyncJobRegisterOptions {
 	/** Registry id of the subagent this job runs; see {@link AsyncJob.agentId}. */
 	agentId?: string;
 	onProgress?: (text: string, details?: Record<string, unknown>) => void | Promise<void>;
+	/** Expose the job through public session snapshots immediately. Defaults to true. */
+	publiclyVisible?: boolean;
 	/** Register the job in queued state; see {@link AsyncJob.queued}. */
 	queued?: boolean;
 }
 
 /**
- * Filter applied to job query/cancel APIs. With `ownerId`, results are
- * restricted to jobs registered by that agent (registry id from
- * `AgentRegistry`, e.g. "Main", "AuthLoader").
+ * Filter applied to job query/cancel APIs. `ownerId` restricts jobs to the
+ * registering agent (registry id from `AgentRegistry`, e.g. "Main",
+ * "AuthLoader"); `publiclyVisible` restricts public snapshot visibility.
  */
 export interface AsyncJobFilter {
 	ownerId?: string;
+	/** Restrict results to jobs with this public snapshot visibility. */
+	publiclyVisible?: boolean;
 }
 
 export class AsyncJobManager {
@@ -161,10 +171,13 @@ export class AsyncJobManager {
 
 	#filterJobs(jobs: Iterable<AsyncJob>, filter?: AsyncJobFilter): AsyncJob[] {
 		const ownerId = filter?.ownerId;
-		if (!ownerId) return Array.from(jobs);
+		const publiclyVisible = filter?.publiclyVisible;
+		if (!ownerId && publiclyVisible === undefined) return Array.from(jobs);
 		const out: AsyncJob[] = [];
 		for (const job of jobs) {
-			if (job.ownerId === ownerId) out.push(job);
+			if (ownerId && job.ownerId !== ownerId) continue;
+			if (publiclyVisible !== undefined && job.publiclyVisible !== publiclyVisible) continue;
+			out.push(job);
 		}
 		return out;
 	}
@@ -229,6 +242,7 @@ export class AsyncJobManager {
 			promise: Promise.resolve(),
 			ownerId: options?.ownerId,
 			agentId: options?.agentId,
+			publiclyVisible: options?.publiclyVisible !== false,
 			queued: options?.queued === true,
 		};
 
@@ -299,6 +313,23 @@ export class AsyncJobManager {
 
 	getJob(id: string): AsyncJob | undefined {
 		return this.#jobs.get(id);
+	}
+
+	/**
+	 * Publish a hidden job to public session snapshots. Publication is one-way;
+	 * missing and already-public jobs are safe no-ops.
+	 */
+	publishJob(id: string): boolean {
+		const job = this.#jobs.get(id);
+		if (!job || job.publiclyVisible) return false;
+		job.publiclyVisible = true;
+		for (const delivery of this.#deliveries) {
+			if (delivery.jobId === id) delivery.publiclyVisible = true;
+		}
+		for (const delivery of this.#inFlightDeliveries) {
+			if (delivery.jobId === id) delivery.publiclyVisible = true;
+		}
+		return true;
 	}
 
 	getRunningJobs(filter?: AsyncJobFilter): AsyncJob[] {
@@ -708,19 +739,20 @@ export class AsyncJobManager {
 		this.#evictionTimers.clear();
 	}
 
+	#deliveryMatchesFilter(delivery: AsyncJobDelivery, filter?: AsyncJobFilter): boolean {
+		if (filter?.ownerId && delivery.ownerId !== filter.ownerId) return false;
+		return filter?.publiclyVisible === undefined || delivery.publiclyVisible === filter.publiclyVisible;
+	}
+
 	#filterDeliveries(filter?: AsyncJobFilter): AsyncJobDelivery[] {
-		const ownerId = filter?.ownerId;
-		if (!ownerId) return this.#deliveries.filter(delivery => !this.isDeliverySuppressed(delivery.jobId));
 		return this.#deliveries.filter(
-			delivery => delivery.ownerId === ownerId && !this.isDeliverySuppressed(delivery.jobId),
+			delivery => this.#deliveryMatchesFilter(delivery, filter) && !this.isDeliverySuppressed(delivery.jobId),
 		);
 	}
 
 	#filterInFlightDeliveries(filter?: AsyncJobFilter): AsyncJobDelivery[] {
-		const ownerId = filter?.ownerId;
-		if (!ownerId) return this.#inFlightDeliveries.filter(delivery => !this.isDeliverySuppressed(delivery.jobId));
 		return this.#inFlightDeliveries.filter(
-			delivery => delivery.ownerId === ownerId && !this.isDeliverySuppressed(delivery.jobId),
+			delivery => this.#deliveryMatchesFilter(delivery, filter) && !this.isDeliverySuppressed(delivery.jobId),
 		);
 	}
 
@@ -728,7 +760,7 @@ export class AsyncJobManager {
 		while (true) {
 			let selected: AsyncJobDelivery | undefined;
 			for (const delivery of this.#deliveries) {
-				if (delivery.ownerId !== filter.ownerId) continue;
+				if (!this.#deliveryMatchesFilter(delivery, filter)) continue;
 				if (this.isDeliverySuppressed(delivery.jobId)) continue;
 				if (!selected || delivery.nextAttemptAt < selected.nextAttemptAt) {
 					selected = delivery;
@@ -773,6 +805,7 @@ export class AsyncJobManager {
 			attempt: 0,
 			nextAttemptAt: Date.now(),
 			ownerId: this.#jobs.get(jobId)?.ownerId,
+			publiclyVisible: this.#jobs.get(jobId)?.publiclyVisible ?? true,
 		});
 		this.#ensureDeliveryLoop();
 	}

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1915,8 +1915,8 @@ export class AgentSession {
 	getAsyncJobSnapshot(options?: { recentLimit?: number }): AsyncJobSnapshot | null {
 		const manager = this.#asyncJobManager;
 		if (!manager) return null;
-		const ownerFilter = this.#agentId ? { ownerId: this.#agentId } : undefined;
-		const running = manager.getRunningJobs(ownerFilter).map(job => ({
+		const snapshotFilter = { ownerId: this.#agentId, publiclyVisible: true };
+		const running = manager.getRunningJobs(snapshotFilter).map(job => ({
 			id: job.id,
 			type: job.type,
 			status: job.status,
@@ -1924,7 +1924,7 @@ export class AgentSession {
 			startTime: job.startTime,
 			agentId: job.agentId,
 		}));
-		const recent = manager.getRecentJobs(options?.recentLimit ?? 5, ownerFilter).map(job => ({
+		const recent = manager.getRecentJobs(options?.recentLimit ?? 5, snapshotFilter).map(job => ({
 			id: job.id,
 			type: job.type,
 			status: job.status,
@@ -1932,7 +1932,7 @@ export class AgentSession {
 			startTime: job.startTime,
 			agentId: job.agentId,
 		}));
-		const delivery = manager.getDeliveryState(ownerFilter);
+		const delivery = manager.getDeliveryState(snapshotFilter);
 		return { running, recent, delivery };
 	}
 

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -810,6 +810,8 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 		resolvedEnv?: Record<string, string>;
 		onUpdate?: AgentToolUpdateCallback<BashToolDetails>;
 		forwardUpdates: boolean;
+		/** Expose the managed job through public async snapshots immediately. */
+		publiclyVisible?: boolean;
 	}): ManagedBashJobHandle {
 		const manager = this.session.asyncJobManager;
 		if (!manager) {
@@ -874,6 +876,7 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 			},
 			{
 				ownerId: this.session.getAgentId?.() ?? undefined,
+				publiclyVisible: options.publiclyVisible,
 				onProgress: async text => {
 					latestText = text;
 					if (!forwardUpdates) return;
@@ -1061,6 +1064,7 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 				resolvedEnv,
 				onUpdate,
 				forwardUpdates: !startBackgrounded,
+				publiclyVisible: startBackgrounded,
 			});
 			if (startBackgrounded) {
 				return this.#buildBackgroundStartResult(job.jobId, "", timeoutSec, {
@@ -1089,6 +1093,7 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 				throw new ToolAbortError(job.getLatestText() || "Command aborted");
 			}
 			job.stopUpdates();
+			autoBgManager.publishJob(job.jobId);
 			autoBgManager.resumeDeliveries([job.jobId]);
 			// "steer": a queued user/peer message arrived mid-wait — background
 			// the command (it keeps running) so the message injects promptly.

--- a/packages/coding-agent/test/async-job-manager.test.ts
+++ b/packages/coding-agent/test/async-job-manager.test.ts
@@ -42,6 +42,65 @@ describe("AsyncJobManager", () => {
 		expect(manager.getJob(jobId)?.status).toBe("completed");
 	});
 
+	test("defaults jobs to public and publishes hidden jobs one-way", async () => {
+		const manager = new AsyncJobManager({ onJobComplete: async () => {} });
+		const release = Promise.withResolvers<void>();
+		const publicJobId = manager.register("bash", "public", async () => {
+			await release.promise;
+			return "public done";
+		});
+		const hiddenJobId = manager.register(
+			"bash",
+			"hidden",
+			async () => {
+				await release.promise;
+				return "hidden done";
+			},
+			{ publiclyVisible: false },
+		);
+
+		expect(manager.getRunningJobs({ publiclyVisible: true }).map(job => job.id)).toEqual([publicJobId]);
+		expect(manager.getRunningJobs({ publiclyVisible: false }).map(job => job.id)).toEqual([hiddenJobId]);
+		expect(manager.publishJob("missing")).toBe(false);
+		expect(manager.publishJob(publicJobId)).toBe(false);
+		expect(manager.publishJob(hiddenJobId)).toBe(true);
+		expect(manager.publishJob(hiddenJobId)).toBe(false);
+		expect(manager.getRunningJobs({ publiclyVisible: true }).map(job => job.id)).toEqual([publicJobId, hiddenJobId]);
+
+		release.resolve();
+		await manager.waitForAll();
+		await manager.drainDeliveries({ timeoutMs: 2_000 });
+	});
+
+	test("keeps hidden deliveries out of public delivery state until publication", async () => {
+		const deliveryStarted = Promise.withResolvers<void>();
+		const releaseDelivery = Promise.withResolvers<void>();
+		const manager = new AsyncJobManager({
+			onJobComplete: async () => {
+				deliveryStarted.resolve();
+				await releaseDelivery.promise;
+			},
+		});
+		const jobId = manager.register("bash", "hidden delivery", async () => "done", {
+			publiclyVisible: false,
+		});
+
+		await manager.waitForAll();
+		await deliveryStarted.promise;
+		expect(manager.getDeliveryState({ publiclyVisible: true })).toEqual({
+			queued: 0,
+			delivering: false,
+			nextRetryAt: undefined,
+			pendingJobIds: [],
+		});
+		expect(manager.getDeliveryState({ publiclyVisible: false }).pendingJobIds).toEqual([jobId]);
+
+		expect(manager.publishJob(jobId)).toBe(true);
+		expect(manager.getDeliveryState({ publiclyVisible: true }).pendingJobIds).toEqual([jobId]);
+		releaseDelivery.resolve();
+		await manager.drainDeliveries({ timeoutMs: 2_000 });
+	});
+
 	test("swallows progress callback errors without failing the job", async () => {
 		const completions: Array<{ jobId: string; text: string }> = [];
 		const manager = new AsyncJobManager({

--- a/packages/coding-agent/test/sdk-async-job-manager-singleton.test.ts
+++ b/packages/coding-agent/test/sdk-async-job-manager-singleton.test.ts
@@ -169,6 +169,58 @@ describe("AsyncJobManager singleton across concurrent top-level sessions", () =>
 		}
 	}, 60000);
 
+	it("keeps fast auto-managed foreground Bash out of the public async snapshot", async () => {
+		const session = await spawnTopLevelSession({ "bash.autoBackground.thresholdMs": 60_000 });
+		const manager = AsyncJobManager.instance();
+		expect(manager).toBeDefined();
+		const releaseMarker = Promise.withResolvers<string>();
+		const markerId = manager!.register("task", "visible recent marker", async () => releaseMarker.promise, {
+			ownerId: "Main",
+		});
+		manager!.acknowledgeDeliveries([markerId]);
+		releaseMarker.resolve("done");
+		await manager!.waitForAll();
+		manager!.getJob(markerId)!.startTime = 0;
+		const before = session.getAsyncJobSnapshot({ recentLimit: 1 });
+		expect(before?.recent.map(job => job.id)).toEqual([markerId]);
+
+		try {
+			const bashTool = session.getToolByName("bash");
+			expect(bashTool).toBeDefined();
+			const result = await bashTool!.execute("call-fast-foreground", { command: "printf 'fast foreground'" });
+			await manager!.waitForAll();
+
+			expect(result.content.find(block => block.type === "text")?.text).toContain("fast foreground");
+			expect(session.getAsyncJobSnapshot({ recentLimit: 1 })).toEqual(before);
+		} finally {
+			await session.dispose();
+		}
+	}, 60000);
+
+	it("publishes auto-managed Bash when it actually backgrounds", async () => {
+		const session = await spawnTopLevelSession({ "bash.autoBackground.thresholdMs": 10 });
+		const manager = AsyncJobManager.instance();
+		expect(manager).toBeDefined();
+
+		try {
+			const bashTool = session.getToolByName("bash");
+			expect(bashTool).toBeDefined();
+			// This exercises the real threshold race through BashTool, so the
+			// command must remain alive long enough for the platform timer to win.
+			const result = await bashTool!.execute("call-auto-background", {
+				command: "sleep 30",
+			});
+			const snapshot = session.getAsyncJobSnapshot();
+
+			expect(snapshot?.running).toHaveLength(1);
+			expect(snapshot?.running[0]?.type).toBe("bash");
+			const resultText = result.content.find(block => block.type === "text")?.text;
+			expect(resultText).toContain(`Backgrounded as job ${snapshot!.running[0]!.id}`);
+		} finally {
+			await session.dispose();
+		}
+	}, 60000);
+
 	it("refuses async bash from a secondary session instead of routing it to the primary's manager", async () => {
 		const primary = await spawnTopLevelSession({ "async.enabled": true });
 		try {


### PR DESCRIPTION
## What

- Add one-way public visibility to async jobs and their queued deliveries.
- Keep auto-managed Bash jobs out of `getAsyncJobSnapshot()` while the tool is still foreground-waiting.
- Publish those jobs immediately when they actually transition to background execution.
- Cover default visibility, publication, foreground completion, and auto-background behavior with regression tests.

## Why

A Bash command that finishes during the foreground wait is returned synchronously as a normal tool result. Exposing it through the public async snapshot at the same time leaks foreground-only work into async job state. Explicitly backgrounded jobs and jobs that cross the auto-background threshold remain visible as before.

## Testing

- `mise exec bun@1.4.0 -- bun test --only-failures test/async-job-manager.test.ts test/sdk-async-job-manager-singleton.test.ts --parallel=1 --timeout=30000` (32 pass)
- `mise exec bun@1.4.0 -- bun run check:ts`
- The full local suite passed through the changed async-job coverage and stopped later on the WSL-only visible-browser worker startup test (`[object ErrorEvent]`).
- Full `bun check` completed the TypeScript checks; the Rust check could not build `audiopus_sys` because this machine does not have `cmake` installed.

---

- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)