### PR TITLE
docs(coding-agent): clarify default task delegation policy

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -18,6 +18,7 @@
 ### Fixed
 
 - Fixed an issue where custom model overrides were lost during configuration updates
+- Clarified that the default task-delegation setting follows the selected model's policy.
 - Fixed "Please use nerdfont" notification incorrectly persisting after theme configuration
 - Fixed sampling parameter errors for newer Anthropic models (Opus 4.7+, Sonnet 5+)
 

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -4946,7 +4946,11 @@ export const SETTINGS_SCHEMA = {
 			label: "Prefer Task Delegation",
 			description: "How strongly to push delegating work to subagents",
 			options: [
-				{ value: "default", label: "Default", description: "Model decides when to delegate" },
+				{
+					value: "default",
+					label: "Default",
+					description: "Uses the selected model's policy; some models require an explicit delegation request",
+				},
 				{ value: "preferred", label: "Preferred", description: "Adds delegation guidance to the system prompt" },
 				{ value: "always", label: "Always", description: "Prompt guidance plus a first-turn delegation reminder" },
 			],


### PR DESCRIPTION
## Repro

With `gpt-5.6-sol` selected and `task.eager=default`, the settings schema advertised model discretion while the rendered prompt enforced explicit-request-only delegation. Reproduced with `bun -e 'import { SETTINGS_SCHEMA } from "./packages/coding-agent/src/config/settings-schema.ts"; import { buildSystemPrompt } from "./packages/coding-agent/src/system-prompt.ts"; /* render gpt-5.6-sol with eagerTasks: false and print both values */'`, which printed `UI: Model decides when to delegate` beside `Prompt: No subagents unless user or applicable AGENTS.md/skill explicitly requests subagents, delegation, or parallel agent work.`

## Cause

`packages/coding-agent/src/config/settings-schema.ts` gave the `task.eager` default option a model-agnostic description, while `buildSystemPrompt()` selects the intentional GPT-5.6 policy through `usesCodexTaskPrompt()` in `packages/coding-agent/src/task/prompt-policy.ts`.

## Fix

- Describe the default as following the selected model's policy and disclose that some models require an explicit delegation request.
- Record the user-facing clarification in `packages/coding-agent/CHANGELOG.md`.

## Verification

Re-ran the reproduction against `gpt-5.6-sol`; the UI now prints `Uses the selected model's policy; some models require an explicit delegation request`, while the existing explicit-request-only prompt remains unchanged. The pre-publish `bun run fix` and `bun check` gate passed.

Fixes #10404