### PR TITLE
fix(browser): reject x86 chromium download on linux arm64

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -17,6 +17,8 @@
 
 ### Fixed
 
+- Browser startup on Linux ARM64 now reports that managed Chrome-for-Testing builds are unavailable and directs users to a system Chromium or `PUPPETEER_EXECUTABLE_PATH`.
+
 - Fixed an issue where custom model overrides were lost during configuration updates
 - Fixed "Please use nerdfont" notification incorrectly persisting after theme configuration
 - Fixed sampling parameter errors for newer Anthropic models (Opus 4.7+, Sonnet 5+)

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Managed Chrome-for-Testing downloads now reject unsupported Linux ARM64 hosts instead of installing an x86_64 browser.
+
 ## [18.0.11] - 2026-08-29
 
 ### Fixed

--- a/packages/utils/src/browsers.ts
+++ b/packages/utils/src/browsers.ts
@@ -39,6 +39,13 @@ export enum BrowserPlatform {
 	WIN32 = "win32",
 	WIN64 = "win64",
 }
+type ChromeForTestingPlatform = Exclude<BrowserPlatform, BrowserPlatform.LINUX_ARM>;
+
+function requireChromeForTestingPlatform(platform: BrowserPlatform): ChromeForTestingPlatform {
+	if (platform === BrowserPlatform.LINUX_ARM)
+		throw new Error("Chrome for Testing does not provide linux/arm64 builds");
+	return platform;
+}
 
 const BROWSERS = [
 	Browser.CHROME,
@@ -163,13 +170,13 @@ export function getDownloadUrl(
 
 /** Compute the executable path in Puppeteer's cache layout. */
 export function computeExecutablePath(options: ComputeExecutablePathOptions): string {
-	const platform = options.platform ?? detectBrowserPlatform();
-	if (!platform) throw new Error("Cannot determine a browser platform for this host");
+	const detectedPlatform = options.platform ?? detectBrowserPlatform();
+	if (!detectedPlatform) throw new Error("Cannot determine a browser platform for this host");
 	if (options.browser !== Browser.CHROME) throw new Error(`Unsupported browser executable: ${options.browser}`);
+	const platform = requireChromeForTestingPlatform(detectedPlatform);
 	const installDir = installationDir(options.cacheDir, options.browser, platform, options.buildId);
 	switch (platform) {
 		case BrowserPlatform.LINUX:
-		case BrowserPlatform.LINUX_ARM:
 			return path.join(installDir, "chrome-linux64", "chrome");
 		case BrowserPlatform.MAC:
 			return path.join(
@@ -292,9 +299,8 @@ async function fetchMetadata<T>(filename: string): Promise<T> {
 }
 
 function chromeArchivePlatform(platform: BrowserPlatform): string {
-	switch (platform) {
+	switch (requireChromeForTestingPlatform(platform)) {
 		case BrowserPlatform.LINUX:
-		case BrowserPlatform.LINUX_ARM:
 			return "linux64";
 		case BrowserPlatform.MAC:
 			return "mac-x64";

--- a/packages/utils/test/browsers.test.ts
+++ b/packages/utils/test/browsers.test.ts
@@ -34,11 +34,6 @@ describe("Chrome-for-Testing layout goldens", () => {
 			executable: `/cache/chrome/linux-${BUILD_ID}/chrome-linux64/chrome`,
 		},
 		{
-			platform: BrowserPlatform.LINUX_ARM,
-			url: `https://storage.googleapis.com/chrome-for-testing-public/${BUILD_ID}/linux64/chrome-linux64.zip`,
-			executable: `/cache/chrome/linux_arm-${BUILD_ID}/chrome-linux64/chrome`,
-		},
-		{
 			platform: BrowserPlatform.MAC,
 			url: `https://storage.googleapis.com/chrome-for-testing-public/${BUILD_ID}/mac-x64/chrome-mac-x64.zip`,
 			executable: `/cache/chrome/mac-${BUILD_ID}/chrome-mac-x64/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing`,
@@ -73,6 +68,28 @@ describe("Chrome-for-Testing layout goldens", () => {
 			).toBe(golden.executable);
 		});
 	}
+});
+
+test("Chrome-for-Testing rejects linux/arm64 before producing archive or cache paths", async () => {
+	const unsupported = "Chrome for Testing does not provide linux/arm64 builds";
+	expect(() => getDownloadUrl(Browser.CHROME, BrowserPlatform.LINUX_ARM, BUILD_ID)).toThrow(unsupported);
+	expect(() =>
+		computeExecutablePath({
+			browser: Browser.CHROME,
+			platform: BrowserPlatform.LINUX_ARM,
+			buildId: BUILD_ID,
+			cacheDir: "/cache",
+		}),
+	).toThrow(unsupported);
+	await expect(
+		install({
+			browser: Browser.CHROME,
+			platform: BrowserPlatform.LINUX_ARM,
+			buildId: BUILD_ID,
+			cacheDir: "/cache",
+			baseUrl: "http://127.0.0.1:1",
+		}),
+	).rejects.toThrow(unsupported);
 });
 
 test("detectBrowserPlatform maps the current supported host", () => {


### PR DESCRIPTION
## Repro
On current `main`, run `bun -e 'import { Browser, BrowserPlatform, computeExecutablePath, getDownloadUrl } from \"./packages/utils/src/browsers.ts\"; const platform = BrowserPlatform.LINUX_ARM; console.log(getDownloadUrl(Browser.CHROME, platform, \"123.0.0.0\").href); console.log(computeExecutablePath({ browser: Browser.CHROME, platform, buildId: \"123.0.0.0\", cacheDir: \"/tmp/omp-puppeteer\" }));'`; it emits the `linux64/chrome-linux64.zip` URL and a `chrome-linux64/chrome` cache path for the ARM64 platform.

## Cause
`packages/utils/src/browsers.ts` treated `BrowserPlatform.LINUX_ARM` as equivalent to `BrowserPlatform.LINUX` in both `chromeArchivePlatform()` and `computeExecutablePath()`. Chrome-for-Testing publishes no Linux ARM64 archive, so `ensureChromiumExecutable()` selected and cached the x86_64 artifact before the shared browser daemon attempted to launch it.

## Fix
- Reject `BrowserPlatform.LINUX_ARM` before computing a Chrome-for-Testing URL or executable path, which also prevents stale x86_64 cache entries from being selected.
- Cover URL generation, cache-path computation, and installation with a Linux ARM64 regression test.
- Document the actionable browser-startup behavior in the affected package changelogs.

## Verification
`bun test packages/utils/test/browsers.test.ts` passed with 11 tests and 1 skipped network test. The original one-line reproduction now exits with `Chrome for Testing does not provide linux/arm64 builds` instead of producing x86_64 paths. `bun check` passed across all packages.

Fixes #10403