### PR TITLE
fix(mnemopi): respect disabled auto-retention on exit

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -20,7 +20,7 @@
 - Fixed an issue where custom model overrides were lost during configuration updates
 - Fixed "Please use nerdfont" notification incorrectly persisting after theme configuration
 - Fixed sampling parameter errors for newer Anthropic models (Opus 4.7+, Sonnet 5+)
-- Fixed Mnemopi storing session transcripts on exit when automatic retention is disabled.
+- Fixed Mnemopi storing session transcripts on exit when automatic retention is disabled ([#10408](https://github.com/can1357/oh-my-pi/pull/10408) by [@kml93](https://github.com/kml93)).
 
 ## [18.0.11] - 2026-08-29
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Fixed an issue where custom model overrides were lost during configuration updates
 - Fixed "Please use nerdfont" notification incorrectly persisting after theme configuration
 - Fixed sampling parameter errors for newer Anthropic models (Opus 4.7+, Sonnet 5+)
+- Fixed Mnemopi storing session transcripts on exit when automatic retention is disabled.
 
 ## [18.0.11] - 2026-08-29
 

--- a/packages/coding-agent/src/mnemopi/backend.ts
+++ b/packages/coding-agent/src/mnemopi/backend.ts
@@ -184,7 +184,7 @@ export const mnemopiBackend: MemoryBackend = {
 				await Promise.all([loadMnemopi(), loadMnemopiCore()]);
 				state = await installMnemopiState(session, config);
 			}
-			await state?.consolidate({ full: true });
+			await state?.consolidate({ full: true, retain: true });
 		} catch (error) {
 			logger.warn("Mnemopi: enqueue failed.", { error: String(error) });
 		}

--- a/packages/coding-agent/src/mnemopi/state.ts
+++ b/packages/coding-agent/src/mnemopi/state.ts
@@ -507,13 +507,13 @@ export class MnemopiSessionState {
 		this.lastRetainedTurn = userTurns;
 	}
 
-	async forceRetainCurrentSession(options: { extract?: boolean } = {}): Promise<void> {
-		if (this.aliasOf) return;
+	async forceRetainCurrentSession(options: { extract?: boolean; force?: boolean } = {}): Promise<void> {
+		if ((!this.config.autoRetain && !options.force) || this.aliasOf) return;
 		const flat = extractMessages(this.session.sessionManager);
 		this.#restoreRetainedTurnCursor();
 		const userTurns = flat.filter(message => message.role === "user").length;
 		await this.retainMessages(sliceUnretainedMessages(flat, this.lastRetainedTurn), this.sessionId, {
-			...options,
+			extract: options.extract,
 			retainedThroughUserTurn: userTurns,
 		});
 		this.lastRetainedTurn = Math.max(this.lastRetainedTurn, userTurns);
@@ -624,10 +624,11 @@ export class MnemopiSessionState {
 	}
 
 	/**
-	 * Capture the current transcript, drain in-flight fact extraction, and
-	 * optionally run beam consolidation on every owned bank. The explicit
-	 * `/memory enqueue` path requests full cross-session consolidation; disposal
-	 * composes the lighter retain-and-flush path with closing the DB handles.
+	 * Capture the current transcript when auto-retention is enabled or explicitly
+	 * requested, drain in-flight fact extraction, and optionally run beam
+	 * consolidation on every owned bank. The explicit `/memory enqueue` path
+	 * requests retention plus full cross-session consolidation; disposal composes
+	 * the lighter configured-retain-and-flush path with closing the DB handles.
 	 *
 	 * Aliased subagent states share `scoped` (and therefore the actual SQLite
 	 * banks) with their parent. `consolidate()` deliberately does NOT
@@ -645,12 +646,16 @@ export class MnemopiSessionState {
 	 * @param options.sleep - When false, skips the bank sleep step entirely.
 	 *  Used on the interactive shutdown path so `dispose` does not block on
 	 *  synchronous consolidation of old working rows from previous sessions.
-	 * @param options.extract - When false, the retained transcript is stored but
-	 *  no LLM fact extraction is scheduled. Used on the interactive shutdown path
-	 *  so `dispose` does not block on a fresh LLM round-trip.
+	 * @param options.extract - When false, any retained transcript is stored but no
+	 *  LLM fact extraction is scheduled. Used on the interactive shutdown path so
+	 *  `dispose` does not block on a fresh LLM round-trip.
+	 * @param options.retain - When true, explicitly retain the transcript even when
+	 *  automatic retention is disabled. Used by `/memory enqueue`.
 	 */
-	async consolidate(options: { full?: boolean; extract?: boolean; sleep?: boolean } = {}): Promise<void> {
-		await this.forceRetainCurrentSession({ extract: options.extract });
+	async consolidate(
+		options: { full?: boolean; extract?: boolean; sleep?: boolean; retain?: boolean } = {},
+	): Promise<void> {
+		await this.forceRetainCurrentSession({ extract: options.extract, force: options.retain });
 		for (const memory of this.scoped.owned) {
 			await memory.flushExtractions();
 			if (options.sleep === false) continue;
@@ -665,8 +670,9 @@ export class MnemopiSessionState {
 	/**
 	 * Release the per-session resources. Defaults to running a lighter
 	 * {@link consolidate} pass before closing handles: it retains the current
-	 * transcript and flushes in-flight extractions, but skips the synchronous
-	 * bank sleep so normal session shutdown returns promptly. Full age-gated
+	 * transcript only when auto-retention is enabled and flushes in-flight
+	 * extractions, but skips the synchronous bank sleep so normal session
+	 * shutdown returns promptly. Full age-gated
 	 * promotion of eligible working memory is still requested by the explicit
 	 * `/memory enqueue` and backend enqueue paths. Callers that are about to
 	 * delete the DB files — e.g. `mnemopiBackend.clear` — pass

--- a/packages/coding-agent/src/mnemopi/state.ts
+++ b/packages/coding-agent/src/mnemopi/state.ts
@@ -507,13 +507,13 @@ export class MnemopiSessionState {
 		this.lastRetainedTurn = userTurns;
 	}
 
-	async forceRetainCurrentSession(options: { extract?: boolean; force?: boolean } = {}): Promise<void> {
-		if ((!this.config.autoRetain && !options.force) || this.aliasOf) return;
+	async forceRetainCurrentSession(options: { extract?: boolean } = {}): Promise<void> {
+		if (this.aliasOf) return;
 		const flat = extractMessages(this.session.sessionManager);
 		this.#restoreRetainedTurnCursor();
 		const userTurns = flat.filter(message => message.role === "user").length;
 		await this.retainMessages(sliceUnretainedMessages(flat, this.lastRetainedTurn), this.sessionId, {
-			extract: options.extract,
+			...options,
 			retainedThroughUserTurn: userTurns,
 		});
 		this.lastRetainedTurn = Math.max(this.lastRetainedTurn, userTurns);
@@ -655,7 +655,9 @@ export class MnemopiSessionState {
 	async consolidate(
 		options: { full?: boolean; extract?: boolean; sleep?: boolean; retain?: boolean } = {},
 	): Promise<void> {
-		await this.forceRetainCurrentSession({ extract: options.extract, force: options.retain });
+		if (this.config.autoRetain || options.retain) {
+			await this.forceRetainCurrentSession({ extract: options.extract });
+		}
 		for (const memory of this.scoped.owned) {
 			await memory.flushExtractions();
 			if (options.sleep === false) continue;

--- a/packages/coding-agent/test/memory-tools.test.ts
+++ b/packages/coding-agent/test/memory-tools.test.ts
@@ -576,6 +576,24 @@ describe("Mnemopi backend lifecycle", () => {
 		expect(row?.count).toBe(0);
 	});
 
+	it("explicit force-retention stores the current session when auto-retain is disabled", async () => {
+		const entries = [{ type: "message", message: { role: "user", content: "explicitly forced turn" } }];
+		const state = registerMnemopiState(makeMnemopiConfig({ autoRetain: false }), {
+			entries: () => entries,
+		});
+
+		await state.forceRetainCurrentSession();
+
+		const row = state.memory.beam.db
+			.prepare<{ count: number }, []>(`
+				SELECT COUNT(*) AS count
+				FROM working_memory
+				WHERE source = 'coding-agent-transcript'
+			`)
+			.get();
+		expect(row?.count).toBe(1);
+	});
+
 	it("explicit enqueue retains the current session when auto-retain is disabled", async () => {
 		const entries = [{ type: "message", message: { role: "user", content: "explicitly retained turn" } }];
 		const state = registerMnemopiState(makeMnemopiConfig({ autoRetain: false }), {

--- a/packages/coding-agent/test/memory-tools.test.ts
+++ b/packages/coding-agent/test/memory-tools.test.ts
@@ -554,6 +554,49 @@ describe("Mnemopi backend lifecycle", () => {
 		expect(state.lastRetainedTurn).toBe(4);
 	});
 
+	it("does not retain the current session on dispose when auto-retain is disabled", async () => {
+		const entries = [{ type: "message", message: { role: "user", content: "private turn" } }];
+		const state = registerMnemopiState(makeMnemopiConfig({ autoRetain: false }), {
+			entries: () => entries,
+		});
+		const dbPath = state.memory.dbPath;
+		if (!dbPath) throw new Error("Expected a file-backed Mnemopi database");
+
+		await state.dispose();
+
+		const db = new Database(dbPath, { readonly: true });
+		const row = db
+			.prepare<{ count: number }, []>(`
+				SELECT COUNT(*) AS count
+				FROM working_memory
+				WHERE source = 'coding-agent-transcript'
+			`)
+			.get();
+		db.close();
+		expect(row?.count).toBe(0);
+	});
+
+	it("explicit enqueue retains the current session when auto-retain is disabled", async () => {
+		const entries = [{ type: "message", message: { role: "user", content: "explicitly retained turn" } }];
+		const state = registerMnemopiState(makeMnemopiConfig({ autoRetain: false }), {
+			entries: () => entries,
+		});
+		const retainMemory = state.getScopedRetainTarget().memory;
+		vi.spyOn(retainMemory, "sleepAllSessions");
+
+		await mnemopiBackend.enqueue(path.dirname(tempDbPath!), "/tmp", state.session);
+
+		const row = retainMemory.beam.db
+			.prepare<{ count: number }, []>(`
+				SELECT COUNT(*) AS count
+				FROM working_memory
+				WHERE source = 'coding-agent-transcript'
+			`)
+			.get();
+		expect(row?.count).toBe(1);
+		expect(retainMemory.sleepAllSessions).toHaveBeenCalledTimes(1);
+	});
+
 	it("does not re-store retained turns during consolidation or after resume", async () => {
 		const entries = Array.from({ length: 6 }, (_, index) => ({
 			type: "message",


### PR DESCRIPTION
## Summary

- prevent session disposal from retaining a transcript when `mnemopi.autoRetain` is disabled
- preserve the explicit retention contract of `forceRetainCurrentSession()` and `/memory enqueue`
- add regression coverage for shutdown, explicit enqueue, and direct force retention

## Problem

`MnemopiSessionState.dispose()` runs a lightweight consolidation pass before
closing its SQLite resources. That pass called `forceRetainCurrentSession()`
unconditionally, so closing a session stored a `coding-agent-transcript` row
even when `mnemopi.autoRetain` was disabled.

This made the setting ineffective for the final session transcript.

## Fix

`forceRetainCurrentSession()` keeps its explicit, unconditional contract
(only the existing `aliasOf` guard). The configuration gate lives in
`consolidate()`: retention runs when `config.autoRetain` is enabled or when
`options.retain` is passed. `dispose()` calls
`consolidate({ full: false, extract: false, sleep: false })`, so normal
shutdown respects a disabled setting, while `/memory enqueue` passes
`consolidate({ full: true, retain: true })` and still retains explicitly.

## Tests

- `bun test test/mnemopi* test/memory-tools.test.ts`
- `bun run check:ts`
- `bun run lint:ts`
