### PR TITLE
fix(coding-agent): skip stale lockfile-only plugin entries

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed stale `omp-plugins.lock.json` entries loading leftover `node_modules` trees for plugins no longer declared in `package.json` — the orphaned copy double-loaded its extensions. Lockfile-only plugins now load only when they are symlinks (`omp plugin link`, marketplace runtime packages); stale entries are skipped with a warning.
+
 ## [18.0.10] - 2026-08-28
 
 ### Added

--- a/packages/coding-agent/src/extensibility/plugins/loader.ts
+++ b/packages/coding-agent/src/extensibility/plugins/loader.ts
@@ -6,7 +6,7 @@
  */
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { getPluginsDir, getPluginsLockfile, isEnoent } from "@oh-my-pi/pi-utils";
+import { getPluginsDir, getPluginsLockfile, isEnoent, logger } from "@oh-my-pi/pi-utils";
 import { getConfigDirPaths } from "../../config";
 import { registerPluginCacheInvalidator, resolveActiveProjectRegistryPath } from "../../discovery/helpers";
 import { installLegacyPiSpecifierShim } from "./legacy-pi-compat";
@@ -110,8 +110,29 @@ async function collectPluginsAtRoot(
 		names.add(name);
 	}
 
+	const isSymlink = async (target: string): Promise<boolean> => {
+		try {
+			return (await fs.promises.lstat(target)).isSymbolicLink();
+		} catch (err) {
+			if (isEnoent(err)) return false;
+			throw err;
+		}
+	};
 	const plugins: ScopedInstalledPlugin[] = [];
 	for (const name of names) {
+		// A lockfile entry without a declared dependency is legitimate only for
+		// linked plugins (`omp plugin link`, marketplace runtime registration),
+		// which are always symlinks into node_modules. A lockfile-only entry
+		// backed by a real directory is a stale leftover — the package was
+		// removed from package.json outside `omp plugin remove`, and loading
+		// whatever tree bun left behind double-loads extensions.
+		if (!depsKeys.includes(name) && !(await isSymlink(path.join(nodeModulesPath, name)))) {
+			logger.warn("plugins: skipping stale lockfile entry not declared in package.json", {
+				name,
+				root,
+			});
+			continue;
+		}
 		const pluginPkgPath = path.join(nodeModulesPath, name, "package.json");
 		let pluginPkg: { version: string; omp?: PluginManifest; pi?: PluginManifest };
 		try {

--- a/packages/coding-agent/test/plugin-stale-lockfile-entry.test.ts
+++ b/packages/coding-agent/test/plugin-stale-lockfile-entry.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { clearClaudePluginRootsCache } from "@oh-my-pi/pi-coding-agent/discovery/helpers";
+import { getEnabledPlugins } from "@oh-my-pi/pi-coding-agent/extensibility/plugins/loader";
+import { removeWithRetries } from "@oh-my-pi/pi-utils";
+
+const tempRoots: string[] = [];
+
+afterEach(async () => {
+	clearClaudePluginRootsCache();
+	for (const root of tempRoots.splice(0)) {
+		await removeWithRetries(root);
+	}
+});
+
+async function writeJson(filePath: string, value: unknown): Promise<void> {
+	await Bun.write(filePath, `${JSON.stringify(value)}\n`);
+}
+
+// Regression: a package removed from the plugins package.json outside
+// `omp plugin remove` leaves its lockfile entry and (because bun install
+// never prunes undeclared directories) its node_modules tree behind. The
+// loader must not load that orphan — doing so double-loads its extensions
+// (every envoy message was delivered twice). Lockfile-only entries are
+// legitimate only as symlinks (`omp plugin link`, marketplace runtime
+// registration), which must keep loading.
+test("stale lockfile-only directory plugin is skipped while declared and linked plugins load", async () => {
+	const root = await fs.mkdtemp(path.join(os.tmpdir(), "omp-plugin-stale-"));
+	tempRoots.push(root);
+	const home = path.join(root, "home");
+	const cwd = path.join(root, "project");
+	const pluginsDir = path.join(home, ".omp", "plugins");
+	const nodeModules = path.join(pluginsDir, "node_modules");
+	await fs.mkdir(cwd, { recursive: true });
+
+	// Declared dependency backed by a real directory: loads.
+	const declaredDir = path.join(nodeModules, "declared-plugin");
+	await fs.mkdir(declaredDir, { recursive: true });
+	await writeJson(path.join(declaredDir, "package.json"), {
+		name: "declared-plugin",
+		version: "1.0.0",
+		omp: { extensions: ["ext.ts"] },
+	});
+
+	// Lockfile-only entry backed by a real directory: the stale orphan; must be skipped.
+	const staleDir = path.join(nodeModules, "stale-plugin");
+	await fs.mkdir(staleDir, { recursive: true });
+	await writeJson(path.join(staleDir, "package.json"), {
+		name: "stale-plugin",
+		version: "0.1.0",
+		omp: { extensions: ["ext.ts"] },
+	});
+
+	// Lockfile-only entry backed by a symlink (omp plugin link): loads.
+	const linkedSource = path.join(root, "linked-plugin-src");
+	await fs.mkdir(linkedSource, { recursive: true });
+	await writeJson(path.join(linkedSource, "package.json"), {
+		name: "linked-plugin",
+		version: "0.2.0",
+		omp: { extensions: ["ext.ts"] },
+	});
+	await fs.symlink(linkedSource, path.join(nodeModules, "linked-plugin"));
+
+	await writeJson(path.join(pluginsDir, "package.json"), {
+		dependencies: { "declared-plugin": "1.0.0" },
+	});
+	await writeJson(path.join(pluginsDir, "omp-plugins.lock.json"), {
+		plugins: {
+			"declared-plugin": { version: "1.0.0", enabled: true, enabledFeatures: null },
+			"stale-plugin": { version: "0.1.0", enabled: true, enabledFeatures: null },
+			"linked-plugin": { version: "0.2.0", enabled: true, enabledFeatures: null },
+		},
+		settings: {},
+	});
+
+	const plugins = await getEnabledPlugins(cwd, { home });
+	const names = plugins.map(plugin => plugin.name).sort();
+
+	expect(names).toEqual(["declared-plugin", "linked-plugin"]);
+});


### PR DESCRIPTION
## What

The plugin loader now skips `omp-plugins.lock.json` entries that are neither declared in the plugins `package.json` nor backed by a symlink in `node_modules`, logging a warning instead of loading them.

## Why

Removing a plugin from the plugins `package.json` outside `omp plugin remove` (a manual manifest edit followed by `bun install`) leaves two things behind: the plugin's `omp-plugins.lock.json` entry, and its `node_modules` tree — bun install never prunes undeclared directories. Because the loader unions declared dependencies with lockfile entries, the orphaned copy kept loading alongside its replacement package. We hit this in production: the same extension loaded twice and every message it subscribed to was delivered twice, for hours, with nothing in the logs.

Lockfile-only entries are legitimate exactly when they are symlinks — `omp plugin link` and marketplace runtime registration both symlink into `node_modules` (`installer.ts` `linkPlugin`, `marketplace/manager.ts` `#registerRuntimePlugin`). A lockfile-only entry backed by a real directory can only be a stale leftover, so it is now skipped with a `logger.warn`.

Written with AI assistance; scoped, reviewed, and tested by the submitter.

## Testing

- New regression test `test/plugin-stale-lockfile-entry.test.ts`: a lockfile-only real-directory plugin does not load, while a declared dependency and a lockfile-only symlinked (linked) plugin both still load. Verified it fails against the unfixed loader.
- `bun check` TS surface passes across workspaces (`check:rs` has a pre-existing rustfmt diff on the base commit, untouched by this change).

---

- [x] `bun check` passes (TS; see note)
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
