### PR TITLE
feat(coding-agent): let extensions handle tool approval prompts

### DIFF
--- a/docs/approval-mode.md
+++ b/docs/approval-mode.md
@@ -53,6 +53,18 @@ Resolution per tool call:
 
 Policy strings are trimmed and case-normalized. Invalid user values are ignored.
 
+## Extension approval review
+
+OMP native policy decisions (`allow | prompt | deny`) remain distinct from `tool_approval_review` extension decisions (`approve | deny | escalate`).
+
+Review runs only after all tool-input transformations and native policy resolution produce a mode-derived prompt. It does not run for native denies or allows, explicit user prompts, tool-specific prompt overrides, pending provider safety checks, or xdev-approved execution.
+
+For an eligible prompt, unanimous valid `approve` suppresses the native selector, `deny` rejects as an extension-review veto, and `escalate` preserves the ordinary native selector. Any uncertainty fails to `escalate`: no handlers, disagreement, malformed output, handler failure, timeout, or cancellation cannot approve. A valid deny takes precedence over other handler results.
+
+Handlers receive the immutable final input that execution will use. A handler cannot rewrite the invocation, and cancellation before execution is committed prevents execution after review.
+
+See [Approval review](./extensions.md#approval-review) for the event API, consensus rule, and older-host capability detection.
+
 ## Safety overrides
 
 A tool can force a prompt with object-form approval:

--- a/docs/approval-mode.md
+++ b/docs/approval-mode.md
@@ -61,7 +61,7 @@ Review runs only after all tool-input transformations and native policy resoluti
 
 For an eligible prompt, unanimous valid `approve` suppresses the native selector, `deny` rejects as an extension-review veto, and `escalate` preserves the ordinary native selector. Any uncertainty fails to `escalate`: no handlers, disagreement, malformed output, handler failure, timeout, or cancellation cannot approve. A valid deny takes precedence over other handler results.
 
-Handlers receive the immutable final input that execution will use. A handler cannot rewrite the invocation, and cancellation before execution is committed prevents execution after review.
+Handlers receive a deeply immutable snapshot of the final input that execution will use. A handler cannot rewrite the invocation, and cancellation before execution is committed prevents execution after review.
 
 See [Approval review](./extensions.md#approval-review) for the event API, consensus rule, and older-host capability detection.
 

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -323,7 +323,8 @@ The host emits the review only for a mode-derived native prompt. Native tool or 
 
 - `approve` resolves the eligible prompt positively and suppresses the native selector;
 - `deny` vetoes the call at the extension-review layer, preserves its optional `reason`, and does not show the native selector;
-- `escalate` makes no decision and continues through the ordinary native selector.
+- `escalate` makes no decision and continues through the ordinary native selector;
+- input that is not a plain object/array tree (for example nested `Map`, `Set`, or `Date` values) cannot be frozen safely, so review escalates without dispatching handlers.
 
 The event and its nested `input` are immutable. `input` is the final owned tool input after host and `tool_call` transformations; native policy, prompt formatting, review, and execution all use that value. Review results cannot rewrite it.
 

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -310,6 +310,43 @@ Cancelable pre-events:
 
 `tool_result` is middleware-style: handlers run in extension order and each sees prior modifications.
 
+#### Approval review
+
+`tool_approval_review` lets permission and guard extensions resolve an otherwise eligible native approval prompt without replacing OMP's policy engine.
+
+The decision vocabularies are separate:
+
+- native policy: `allow | prompt | deny`;
+- extension review: `approve | deny | escalate`.
+
+The host emits the review only for a mode-derived native prompt. Native tool or user denies, explicit user prompts, tool-specific prompt overrides, provider computer-safety checks, native allows, and xdev-approved calls remain authoritative and do not emit it.
+
+- `approve` resolves the eligible prompt positively and suppresses the native selector;
+- `deny` vetoes the call at the extension-review layer, preserves its optional `reason`, and does not show the native selector;
+- `escalate` makes no decision and continues through the ordinary native selector.
+
+The event and its nested `input` are immutable. `input` is the final owned tool input after host and `tool_call` transformations; native policy, prompt formatting, review, and execution all use that value. Review results cannot rewrite it.
+
+Approval requires unanimous valid approval from at least one handler. A valid `deny` takes precedence across handlers. Otherwise, no handlers, any `escalate`, disagreement, malformed result, thrown error, timeout, or cancellation produces `escalate`. Cancellation before execution is committed prevents execution even if a handler returned `approve`.
+
+Use runtime capability detection because an older host may accept registration of an unknown event that never fires:
+
+```ts
+const supportsApprovalReview =
+  pi.supportedEvents?.includes("tool_approval_review") ?? false;
+
+if (supportsApprovalReview) {
+  pi.on("tool_approval_review", async (event) => {
+    if (event.toolName === "bash" && event.input.command === "approved-command") {
+      return { decision: "approve" };
+    }
+    return { decision: "escalate" };
+  });
+}
+```
+
+`supportedEvents` is optional for compatibility with older hosts. Current hosts expose a frozen readonly list; extensions must not mutate it.
+
 ### Reliability/runtime signals
 
 - `auto_compaction_start` / `auto_compaction_end`

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -324,9 +324,9 @@ The host emits the review only for a mode-derived native prompt. Native tool or 
 - `approve` resolves the eligible prompt positively and suppresses the native selector;
 - `deny` vetoes the call at the extension-review layer, preserves its optional `reason`, and does not show the native selector;
 - `escalate` makes no decision and continues through the ordinary native selector;
-- input that is not a plain object/array tree (for example nested `Map`, `Set`, or `Date` values) cannot be frozen safely, so review escalates without dispatching handlers.
+- input that is not a plain object/array tree (for example nested `Map`, `Set`, or `Date` values) cannot be snapshotted immutably, so review escalates without dispatching handlers;
 
-The event and its nested `input` are immutable. `input` is the final owned tool input after host and `tool_call` transformations; native policy, prompt formatting, review, and execution all use that value. Review results cannot rewrite it.
+Handlers receive a deeply immutable snapshot of the final owned tool input — the value that remains after host and `tool_call` transformations and that native policy, prompt formatting, and execution all use. Review results cannot rewrite the invocation, and the owned value itself is not frozen: tools may still mutate their validated parameters internally.
 
 Approval requires unanimous valid approval from at least one handler. A valid `deny` takes precedence across handlers. Otherwise, no handlers, any `escalate`, disagreement, malformed result, thrown error, timeout, or cancellation produces `escalate`. Cancellation before execution is committed prevents execution even if a handler returned `approve`.
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -22,6 +22,9 @@
 - Improved chat history stability in long-running sessions by avoiding unnecessary updates when date or directory context changes.
 - Fixed the trace CLI hanging during proxy connections and added support for forward HTTP proxies.
 - Fixed newly started sessions using stale model context-window limits after background model discovery completes; the active model now refreshes automatically so context usage and compaction thresholds match the model catalog.
+### Added
+
+- Added the `tool_approval_review` extension event, a full approval-resolution seam: `approve` resolves an eligible mode-derived prompt positively, `deny` vetoes the call at the extension layer, and `escalate` defers to the native approval path. Handlers review a deeply immutable snapshot of the final tool input, and optional frozen `pi.supportedEvents` enables capability detection ([#10410](https://github.com/can1357/oh-my-pi/pull/10410) by [@th3akii](https://github.com/th3akii)).
 
 ## [18.1.1] - 2026-09-01
 ### Added
@@ -32,7 +35,6 @@
 - Devin model selectors now accept the native CLI's short aliases (`devin/opus`, `devin/swe`), dotted upstream spellings (`devin/gemini-3.7-flash`), and raw effort-route wire uids for dynamically collapsed families ([#8590](https://github.com/can1357/oh-my-pi/pull/8590) by [@will-bogusz](https://github.com/will-bogusz)).
 - Added provider-supplied model metadata to the `/models` detail line: `new`, `beta`, and `recommended` badges beside the model name, and the upstream description after the context, cost, and perf facts ([#8590](https://github.com/can1357/oh-my-pi/pull/8590) by [@will-bogusz](https://github.com/will-bogusz)).
 - Standalone `CLAUDE.md` files in the project root (and ancestor directories) are now loaded as context, mirroring `AGENTS.md` discovery; config-directory context files still take precedence per scope.
-- Added the `tool_approval_review` extension event, a full approval-resolution seam: `approve` resolves an eligible mode-derived prompt positively, `deny` vetoes the call at the extension layer, and `escalate` defers to the native approval path. Handlers review a deeply immutable snapshot of the final tool input, and optional frozen `pi.supportedEvents` enables capability detection ([#10410](https://github.com/can1357/oh-my-pi/pull/10410) by [@th3akii](https://github.com/th3akii)).
 
 ### Changed
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -109,6 +109,7 @@
 - Fixed "Please use nerdfont" notification incorrectly persisting after theme configuration
 - Fixed sampling parameter errors for newer Anthropic models (Opus 4.7+, Sonnet 5+)
 - Native approval prompts now format from a detached snapshot of the tool input, so a custom tool's `formatApprovalDetails` callback can no longer mutate or retain the object that executes after approval.
+- Fixed tool execution after cancellation: an aborted tool invocation can no longer cross the approval boundary — a late "Approve" from the native selector or a lifecycle handler completing after abort never starts execution, and cancelled approvals resolve to extension handlers as not-approved instead of approved.
 
 ## [18.0.11] - 2026-08-29
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -176,6 +176,7 @@
 - Added a status message when `CTRL-O` toggles tool-output expansion.
 - Fixed `omp usage` to report Codex Chat and Spark capacity meters separately when they share a usage window.
 - Extensions can now subscribe to `tool_approval_review`, an advisory review emitted after final tool-input resolution but before the native approval selector; a unanimous `{ decision: "approve" }` from all subscribed handlers skips only an eligible mode-derived approval prompt, while any other outcome keeps the native prompt path unchanged.
+- Extensions can now subscribe to `tool_approval_review`, an advisory review emitted after final tool-input resolution but before the native approval selector; a unanimous `{ decision: "approve" }` skips the eligible mode-derived prompt, `{ decision: "deny" }` rejects through the native policy-denial path, and other outcomes keep the native prompt path unchanged.
 
 ## [18.0.8] - 2026-08-27
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -32,7 +32,7 @@
 - Devin model selectors now accept the native CLI's short aliases (`devin/opus`, `devin/swe`), dotted upstream spellings (`devin/gemini-3.7-flash`), and raw effort-route wire uids for dynamically collapsed families ([#8590](https://github.com/can1357/oh-my-pi/pull/8590) by [@will-bogusz](https://github.com/will-bogusz)).
 - Added provider-supplied model metadata to the `/models` detail line: `new`, `beta`, and `recommended` badges beside the model name, and the upstream description after the context, cost, and perf facts ([#8590](https://github.com/can1357/oh-my-pi/pull/8590) by [@will-bogusz](https://github.com/will-bogusz)).
 - Standalone `CLAUDE.md` files in the project root (and ancestor directories) are now loaded as context, mirroring `AGENTS.md` discovery; config-directory context files still take precedence per scope.
-- Added `tool_approval_review` for extensions to approve, veto, or escalate eligible mode-derived prompts against the immutable final tool input, with optional frozen `pi.supportedEvents` capability detection.
+- Added the `tool_approval_review` extension event, a full approval-resolution seam: `approve` resolves an eligible mode-derived prompt positively, `deny` vetoes the call at the extension layer, and `escalate` defers to the native approval path. Handlers review a deeply immutable snapshot of the final tool input, and optional frozen `pi.supportedEvents` enables capability detection.
 
 ### Changed
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -24,6 +24,19 @@
 - Fixed newly started sessions using stale model context-window limits after background model discovery completes; the active model now refreshes automatically so context usage and compaction thresholds match the model catalog.
 
 ## [18.1.1] - 2026-09-01
+### Added
+
+- Added `injectV1: false` option to `openai-models-list` discovery to fetch the model list from `{baseUrl}/models` without injecting `/v1`, for gateways that root their OpenAI-compatible surface at a versioned URL (e.g. `https://api.opper.ai/v3/compat`) where the `/v1`-injected endpoint returns only a small subset.
+- Added provider-reported credits and concrete routed-model counts to `/session` statistics ([#8590](https://github.com/can1357/oh-my-pi/pull/8590) by [@will-bogusz](https://github.com/will-bogusz)).
+- Added `CLINE_API_KEY` to the CLI environment help for native ClinePass subscription inference ([#7863](https://github.com/can1357/oh-my-pi/pull/7863) by [@will-bogusz](https://github.com/will-bogusz)).
+- Devin model selectors now accept the native CLI's short aliases (`devin/opus`, `devin/swe`), dotted upstream spellings (`devin/gemini-3.7-flash`), and raw effort-route wire uids for dynamically collapsed families ([#8590](https://github.com/can1357/oh-my-pi/pull/8590) by [@will-bogusz](https://github.com/will-bogusz)).
+- Added provider-supplied model metadata to the `/models` detail line: `new`, `beta`, and `recommended` badges beside the model name, and the upstream description after the context, cost, and perf facts ([#8590](https://github.com/can1357/oh-my-pi/pull/8590) by [@will-bogusz](https://github.com/will-bogusz)).
+- Standalone `CLAUDE.md` files in the project root (and ancestor directories) are now loaded as context, mirroring `AGENTS.md` discovery; config-directory context files still take precedence per scope.
+- Added `tool_approval_review` for extensions to approve, veto, or escalate eligible mode-derived prompts against the immutable final tool input, with optional frozen `pi.supportedEvents` capability detection.
+
+### Changed
+
+- Disabled `hashline` edit mode for Kimi, Mimo, DeepSeek Flash, and Stepfun models for stability
 
 ### Fixed
 
@@ -175,10 +188,6 @@
 - Kept embedded context usage visible in the status line when long session names or paths consume available space.
 - Added a status message when `CTRL-O` toggles tool-output expansion.
 - Fixed `omp usage` to report Codex Chat and Spark capacity meters separately when they share a usage window.
-- Extensions can now subscribe to `tool_approval_review`, an advisory review emitted after final tool-input resolution but before the native approval selector; a unanimous `{ decision: "approve" }` from all subscribed handlers skips only an eligible mode-derived approval prompt, while any other outcome keeps the native prompt path unchanged.
-- Extensions can now subscribe to `tool_approval_review`, an advisory review emitted after final tool-input resolution but before the native approval selector; a unanimous `{ decision: "approve" }` skips the eligible mode-derived prompt, `{ decision: "deny" }` rejects through the native policy-denial path, and other outcomes keep the native prompt path unchanged.
-- `tool_approval_review` handlers now receive an immutable snapshot of the tool input; a mutation attempt escalates to the native approval prompt and can never alter what later handlers see or what executes.
-- Extensions can now read `pi.supportedEvents` to detect whether the running host dispatches a given event (e.g. `tool_approval_review`) before relying on it.
 
 ## [18.0.8] - 2026-08-27
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -110,8 +110,6 @@
 - Fixed an issue where custom model overrides were lost during configuration updates
 - Fixed "Please use nerdfont" notification incorrectly persisting after theme configuration
 - Fixed sampling parameter errors for newer Anthropic models (Opus 4.7+, Sonnet 5+)
-- Native approval prompts now format from a detached snapshot of the tool input, so a custom tool's `formatApprovalDetails` callback can no longer mutate or retain the object that executes after approval.
-- Fixed tool execution after cancellation: an aborted tool invocation can no longer cross the approval boundary — a late "Approve" from the native selector or a lifecycle handler completing after abort never starts execution, and cancelled approvals resolve to extension handlers as not-approved instead of approved.
 
 ## [18.0.11] - 2026-08-29
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -175,6 +175,7 @@
 - Kept embedded context usage visible in the status line when long session names or paths consume available space.
 - Added a status message when `CTRL-O` toggles tool-output expansion.
 - Fixed `omp usage` to report Codex Chat and Spark capacity meters separately when they share a usage window.
+- Extensions can now subscribe to `tool_approval_review`, an advisory review emitted after final tool-input resolution but before the native approval selector; a unanimous `{ decision: "approve" }` from all subscribed handlers skips only an eligible mode-derived approval prompt, while any other outcome keeps the native prompt path unchanged.
 
 ## [18.0.8] - 2026-08-27
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -177,6 +177,8 @@
 - Fixed `omp usage` to report Codex Chat and Spark capacity meters separately when they share a usage window.
 - Extensions can now subscribe to `tool_approval_review`, an advisory review emitted after final tool-input resolution but before the native approval selector; a unanimous `{ decision: "approve" }` from all subscribed handlers skips only an eligible mode-derived approval prompt, while any other outcome keeps the native prompt path unchanged.
 - Extensions can now subscribe to `tool_approval_review`, an advisory review emitted after final tool-input resolution but before the native approval selector; a unanimous `{ decision: "approve" }` skips the eligible mode-derived prompt, `{ decision: "deny" }` rejects through the native policy-denial path, and other outcomes keep the native prompt path unchanged.
+- `tool_approval_review` handlers now receive an immutable snapshot of the tool input; a mutation attempt escalates to the native approval prompt and can never alter what later handlers see or what executes.
+- Extensions can now read `pi.supportedEvents` to detect whether the running host dispatches a given event (e.g. `tool_approval_review`) before relying on it.
 
 ## [18.0.8] - 2026-08-27
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -105,6 +105,10 @@
 - Prevented browser `app.path` from terminating existing same-executable applications when no reusable CDP endpoint is available.
 - Fixed top-level errors overwriting the active composer before terminal restoration.
 - Fixed Enter being ignored during the first turn when omp starts with an initial prompt.
+- Fixed an issue where custom model overrides were lost during configuration updates
+- Fixed "Please use nerdfont" notification incorrectly persisting after theme configuration
+- Fixed sampling parameter errors for newer Anthropic models (Opus 4.7+, Sonnet 5+)
+- Native approval prompts now format from a detached snapshot of the tool input, so a custom tool's `formatApprovalDetails` callback can no longer mutate or retain the object that executes after approval.
 
 ## [18.0.11] - 2026-08-29
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -32,7 +32,7 @@
 - Devin model selectors now accept the native CLI's short aliases (`devin/opus`, `devin/swe`), dotted upstream spellings (`devin/gemini-3.7-flash`), and raw effort-route wire uids for dynamically collapsed families ([#8590](https://github.com/can1357/oh-my-pi/pull/8590) by [@will-bogusz](https://github.com/will-bogusz)).
 - Added provider-supplied model metadata to the `/models` detail line: `new`, `beta`, and `recommended` badges beside the model name, and the upstream description after the context, cost, and perf facts ([#8590](https://github.com/can1357/oh-my-pi/pull/8590) by [@will-bogusz](https://github.com/will-bogusz)).
 - Standalone `CLAUDE.md` files in the project root (and ancestor directories) are now loaded as context, mirroring `AGENTS.md` discovery; config-directory context files still take precedence per scope.
-- Added the `tool_approval_review` extension event, a full approval-resolution seam: `approve` resolves an eligible mode-derived prompt positively, `deny` vetoes the call at the extension layer, and `escalate` defers to the native approval path. Handlers review a deeply immutable snapshot of the final tool input, and optional frozen `pi.supportedEvents` enables capability detection.
+- Added the `tool_approval_review` extension event, a full approval-resolution seam: `approve` resolves an eligible mode-derived prompt positively, `deny` vetoes the call at the extension layer, and `escalate` defers to the native approval path. Handlers review a deeply immutable snapshot of the final tool input, and optional frozen `pi.supportedEvents` enables capability detection ([#10410](https://github.com/can1357/oh-my-pi/pull/10410) by [@th3akii](https://github.com/th3akii)).
 
 ### Changed
 

--- a/packages/coding-agent/src/extensibility/extensions/loader.ts
+++ b/packages/coding-agent/src/extensibility/extensions/loader.ts
@@ -51,6 +51,7 @@ import type {
 	ToolDefinition,
 	ToolInfo,
 } from "./types";
+import { EXTENSION_EVENT_NAMES } from "./types";
 
 installLegacyPiSpecifierShim();
 
@@ -156,6 +157,7 @@ class ConcreteExtensionAPI implements ExtensionAPI, IExtensionRuntime {
 	readonly typebox = TypeBox;
 	readonly arktype = type;
 	readonly zod = zod;
+	readonly supportedEvents = EXTENSION_EVENT_NAMES;
 	readonly flagValues = new Map<string, boolean | string>();
 	readonly pendingProviderRegistrations: Array<{
 		name: string;

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -125,6 +125,25 @@ function handlerTimeoutForEvent(eventType: string): number {
 const EXTENSION_HANDLER_TIMEOUT = Symbol("extensionHandlerTimeout");
 const EXTENSION_HANDLER_ABORTED = Symbol("extensionHandlerAborted");
 
+function isToolApprovalReviewResult(value: unknown): value is ToolApprovalReviewResult {
+	if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+	const record = value as Record<string, unknown>;
+	const keys = Object.keys(record);
+	if (record.decision === "approve") {
+		return (
+			keys.every(key => key === "decision" || key === "rationale") &&
+			(record.rationale === undefined || typeof record.rationale === "string")
+		);
+	}
+	if (record.decision === "escalate" || record.decision === "deny") {
+		return (
+			keys.every(key => key === "decision" || key === "reason") &&
+			(record.reason === undefined || typeof record.reason === "string")
+		);
+	}
+	return false;
+}
+
 interface HandlerTimeoutBudget {
 	pause(): void;
 	resume(): void;
@@ -1515,14 +1534,11 @@ export class ExtensionRunner {
 	/**
 	 * Emit a `tool_approval_review` event to every subscribed extension.
 	 *
-	 * Advisory pre-execution review of an eligible mode-derived approval prompt.
-	 * Approval is returned only when at least one handler participates and every
-	 * handler returns exactly `{ decision: "approve" }`. Any other outcome — no
-	 * handlers, escalation, malformed results, throws, timeouts, or
-	 * cancellation — maps to `{ decision: "escalate" }`, which keeps the caller
-	 * on the ordinary native approval path. The review can never deny or
-	 * rewrite the call: the event carries no deny/rewrite shape and only a
-	 * unanimous approve suppresses the prompt.
+	 * Review of an eligible mode-derived approval prompt. A valid deny takes
+	 * precedence over escalation; escalation includes malformed results, throws,
+	 * timeouts, and cancellation. Approval is returned only when at least one
+	 * handler participates and every handler returns exactly a valid approve
+	 * result. No handlers escalate to the ordinary native approval path.
 	 */
 	async emitToolApprovalReview(
 		event: ToolApprovalReviewEvent,
@@ -1530,6 +1546,10 @@ export class ExtensionRunner {
 	): Promise<ToolApprovalReviewResult> {
 		let ctx: ExtensionContext | undefined;
 		let participated = false;
+		let hasEscalation = false;
+		let escalationReason: string | undefined;
+		let hasDenial = false;
+		let denialReason: string | undefined;
 
 		for (const ext of this.extensions) {
 			const handlers = ext.handlers.get(event.type);
@@ -1538,7 +1558,10 @@ export class ExtensionRunner {
 
 			for (const handler of handlers) {
 				const result = await this.#runHandlerWithTimeout<ToolApprovalReviewEvent, ToolApprovalReviewResult>(
-					handler as (event: ToolApprovalReviewEvent, ctx: ExtensionContext) => Promise<ToolApprovalReviewResult | undefined>,
+					handler as (
+						event: ToolApprovalReviewEvent,
+						ctx: ExtensionContext,
+					) => Promise<ToolApprovalReviewResult | undefined>,
 					event,
 					ctx,
 					ext,
@@ -1548,20 +1571,25 @@ export class ExtensionRunner {
 					() => ({ decision: "escalate", reason: `Extension ${ext.path} failed or timed out` }),
 					signal,
 				);
-				if (
-					result?.decision === "approve" &&
-					Object.keys(result).every(key => key === "decision" || key === "rationale")
-				) {
-					participated = true;
+				participated = true;
+				if (!isToolApprovalReviewResult(result)) {
+					hasEscalation = true;
 					continue;
 				}
-				return {
-					decision: "escalate",
-					...(result?.decision === "escalate" && result.reason ? { reason: result.reason } : {}),
-				};
+				if (result.decision === "deny") {
+					hasDenial = true;
+					denialReason ??= result.reason;
+					continue;
+				}
+				if (result.decision === "escalate") {
+					hasEscalation = true;
+					escalationReason ??= result.reason;
+				}
 			}
 		}
 
+		if (hasDenial) return { decision: "deny", ...(denialReason ? { reason: denialReason } : {}) };
+		if (hasEscalation) return { decision: "escalate", ...(escalationReason ? { reason: escalationReason } : {}) };
 		if (!participated) return { decision: "escalate", reason: "no review handlers" };
 		return { decision: "approve" };
 	}

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -1875,8 +1875,13 @@ export class ExtensionRunner {
 	}
 }
 
-/** Rejects values that cannot be exposed as a deeply immutable approval-review snapshot. */
-export function assertReviewInputSafe(value: unknown, seen = new WeakSet<object>()): void {
+/**
+ * Rejects values that cannot be exposed as a deeply immutable snapshot: only
+ * plain objects/arrays without accessors freeze transitively. Tolerates
+ * non-default descriptors — an already frozen/sealed graph is exactly what
+ * freezing would produce, so re-freezing host snapshots stays a no-op.
+ */
+function assertDeepFreezable(value: unknown, seen = new WeakSet<object>()): void {
 	if (typeof value !== "object" || value === null || seen.has(value)) return;
 
 	const prototype = Object.getPrototypeOf(value);
@@ -1889,13 +1894,55 @@ export function assertReviewInputSafe(value: unknown, seen = new WeakSet<object>
 		if (!descriptor || !("value" in descriptor)) {
 			throw new TypeError("Review input contains an accessor");
 		}
+		assertDeepFreezable(descriptor.value, seen);
+	}
+}
+
+/**
+ * Rejects values that structuredClone would not reproduce verbatim, so a
+ * cloned approval-review snapshot is guaranteed to match the semantics of the
+ * input being approved. Admits only plain objects/arrays with default data
+ * descriptors and cloneable leaf values; anything else (null-prototype
+ * objects, class instances, Dates, frozen/sealed or non-enumerable graphs,
+ * accessors, symbol keys, functions) must fall back to native approval with
+ * its original semantics intact.
+ */
+export function assertReviewInputSafe(value: unknown, seen = new WeakSet<object>()): void {
+	if (typeof value === "function" || typeof value === "symbol") {
+		throw new TypeError("Review input contains a non-cloneable value");
+	}
+	if (typeof value !== "object" || value === null || seen.has(value)) return;
+
+	const prototype = Object.getPrototypeOf(value);
+	if (prototype !== Object.prototype && prototype !== Array.prototype) {
+		// Includes null-prototype objects: structuredClone re-homes them on
+		// Object.prototype, so their semantics would not survive the snapshot.
+		throw new TypeError("Review input contains an unsupported mutable value");
+	}
+	const isArray = Array.isArray(value);
+	seen.add(value);
+	for (const key of Reflect.ownKeys(value)) {
+		if (typeof key === "symbol") {
+			throw new TypeError("Review input contains a symbol-keyed property");
+		}
+		const descriptor = Object.getOwnPropertyDescriptor(value, key);
+		if (!descriptor || !("value" in descriptor)) {
+			throw new TypeError("Review input contains an accessor");
+		}
+		if (isArray && key === "length") continue;
+		if (!descriptor.writable || !descriptor.enumerable || !descriptor.configurable) {
+			// structuredClone normalizes non-default descriptors: non-enumerable
+			// properties are dropped and frozen/sealed graphs become mutable, so
+			// the snapshot would diverge from the input being approved.
+			throw new TypeError("Review input contains a non-default property descriptor");
+		}
 		assertReviewInputSafe(descriptor.value, seen);
 	}
 }
 
 /** Recursively freezes a review-safe plain object/array value. */
 export function deepFreeze<T>(value: T): T {
-	assertReviewInputSafe(value);
+	assertDeepFreezable(value);
 	return freezeReviewInput(value);
 }
 

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -1561,8 +1561,9 @@ export class ExtensionRunner {
 		event: ToolApprovalReviewEvent,
 		signal?: AbortSignal,
 	): Promise<ToolApprovalReviewResult> {
-		// The wrapper already owns the final execution input. Freeze the complete
-		// host event so one handler cannot alter what later handlers review.
+		// The wrapper owns the final execution input and hands this event a
+		// snapshot of it. Freeze the complete host event so one handler cannot
+		// alter what later handlers review.
 		let reviewedEvent: ToolApprovalReviewEvent;
 		try {
 			reviewedEvent = deepFreeze(event);

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -1544,6 +1544,21 @@ export class ExtensionRunner {
 		event: ToolApprovalReviewEvent,
 		signal?: AbortSignal,
 	): Promise<ToolApprovalReviewResult> {
+		// Host invariant: the material input reviewed must be the material input
+		// executed. Dispatch an immutable snapshot instead of the live object so a
+		// mutation attempt cannot reach later handlers or eventual execution. A
+		// non-JSON input (cannot happen for schema-validated tool params) fails
+		// closed to the native approval path.
+		let reviewedInput: Record<string, unknown>;
+		try {
+			reviewedInput = deepFreeze(structuredClone(event.input));
+		} catch (error) {
+			return {
+				decision: "escalate",
+				reason: `tool input could not be snapshotted for review: ${error instanceof Error ? error.message : String(error)}`,
+			};
+		}
+		const reviewedEvent: ToolApprovalReviewEvent = { ...event, input: reviewedInput };
 		let ctx: ExtensionContext | undefined;
 		let participated = false;
 		let hasEscalation = false;
@@ -1562,7 +1577,7 @@ export class ExtensionRunner {
 						event: ToolApprovalReviewEvent,
 						ctx: ExtensionContext,
 					) => Promise<ToolApprovalReviewResult | undefined>,
-					event,
+					reviewedEvent,
 					ctx,
 					ext,
 					normalizeHandlerTimeout(
@@ -1848,4 +1863,14 @@ export class ExtensionRunner {
 
 		return undefined;
 	}
+}
+/** Recursively freezes a JSON value so event handlers cannot mutate it. */
+function deepFreeze<T>(value: T): T {
+	if (typeof value === "object" && value !== null) {
+		for (const key of Object.keys(value as Record<string, unknown>)) {
+			deepFreeze((value as Record<string, unknown>)[key]);
+		}
+		Object.freeze(value);
+	}
+	return value;
 }

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -125,23 +125,38 @@ function handlerTimeoutForEvent(eventType: string): number {
 const EXTENSION_HANDLER_TIMEOUT = Symbol("extensionHandlerTimeout");
 const EXTENSION_HANDLER_ABORTED = Symbol("extensionHandlerAborted");
 
-function isToolApprovalReviewResult(value: unknown): value is ToolApprovalReviewResult {
-	if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
-	const record = value as Record<string, unknown>;
-	const keys = Object.keys(record);
-	if (record.decision === "approve") {
-		return (
-			keys.every(key => key === "decision" || key === "rationale") &&
-			(record.rationale === undefined || typeof record.rationale === "string")
-		);
+function normalizeToolApprovalReviewResult(value: unknown): ToolApprovalReviewResult | undefined {
+	try {
+		if (value === null || typeof value !== "object" || Array.isArray(value)) return undefined;
+		const keys = Reflect.ownKeys(value);
+		const decisionDescriptor = Object.getOwnPropertyDescriptor(value, "decision");
+		if (!decisionDescriptor || !("value" in decisionDescriptor)) return undefined;
+
+		if (decisionDescriptor.value === "approve" || decisionDescriptor.value === "escalate") {
+			return keys.length === 1 && keys[0] === "decision" ? { decision: decisionDescriptor.value } : undefined;
+		}
+		if (
+			decisionDescriptor.value !== "deny" ||
+			!keys.includes("decision") ||
+			keys.some(key => key !== "decision" && key !== "reason")
+		) {
+			return undefined;
+		}
+		const reasonDescriptor = Object.getOwnPropertyDescriptor(value, "reason");
+		if (!reasonDescriptor) return { decision: "deny" };
+		if (
+			!("value" in reasonDescriptor) ||
+			(reasonDescriptor.value !== undefined && typeof reasonDescriptor.value !== "string")
+		) {
+			return undefined;
+		}
+		return {
+			decision: "deny",
+			...(reasonDescriptor.value ? { reason: reasonDescriptor.value } : {}),
+		};
+	} catch {
+		return undefined;
 	}
-	if (record.decision === "escalate" || record.decision === "deny") {
-		return (
-			keys.every(key => key === "decision" || key === "reason") &&
-			(record.reason === undefined || typeof record.reason === "string")
-		);
-	}
-	return false;
 }
 
 interface HandlerTimeoutBudget {
@@ -1544,25 +1559,17 @@ export class ExtensionRunner {
 		event: ToolApprovalReviewEvent,
 		signal?: AbortSignal,
 	): Promise<ToolApprovalReviewResult> {
-		// Host invariant: the material input reviewed must be the material input
-		// executed. Dispatch an immutable snapshot instead of the live object so a
-		// mutation attempt cannot reach later handlers or eventual execution. A
-		// non-JSON input (cannot happen for schema-validated tool params) fails
-		// closed to the native approval path.
-		let reviewedInput: Record<string, unknown>;
+		// The wrapper already owns the final execution input. Freeze the complete
+		// host event so one handler cannot alter what later handlers review.
+		let reviewedEvent: ToolApprovalReviewEvent;
 		try {
-			reviewedInput = deepFreeze(structuredClone(event.input));
-		} catch (error) {
-			return {
-				decision: "escalate",
-				reason: `tool input could not be snapshotted for review: ${error instanceof Error ? error.message : String(error)}`,
-			};
+			reviewedEvent = deepFreeze(event);
+		} catch {
+			return { decision: "escalate" };
 		}
-		const reviewedEvent: ToolApprovalReviewEvent = { ...event, input: reviewedInput };
 		let ctx: ExtensionContext | undefined;
 		let participated = false;
 		let hasEscalation = false;
-		let escalationReason: string | undefined;
 		let hasDenial = false;
 		let denialReason: string | undefined;
 
@@ -1572,7 +1579,7 @@ export class ExtensionRunner {
 			ctx ??= this.createContext();
 
 			for (const handler of handlers) {
-				const result = await this.#runHandlerWithTimeout<ToolApprovalReviewEvent, ToolApprovalReviewResult>(
+				const handlerResult = await this.#runHandlerWithTimeout<ToolApprovalReviewEvent, ToolApprovalReviewResult>(
 					handler as (
 						event: ToolApprovalReviewEvent,
 						ctx: ExtensionContext,
@@ -1583,11 +1590,12 @@ export class ExtensionRunner {
 					normalizeHandlerTimeout(
 						this.settings?.get("extensionHandlers.toolCallTimeoutMs") ?? extensionHandlerTimeoutMs,
 					),
-					() => ({ decision: "escalate", reason: `Extension ${ext.path} failed or timed out` }),
+					() => ({ decision: "escalate" }),
 					signal,
 				);
 				participated = true;
-				if (!isToolApprovalReviewResult(result)) {
+				const result = normalizeToolApprovalReviewResult(handlerResult);
+				if (!result) {
 					hasEscalation = true;
 					continue;
 				}
@@ -1598,14 +1606,13 @@ export class ExtensionRunner {
 				}
 				if (result.decision === "escalate") {
 					hasEscalation = true;
-					escalationReason ??= result.reason;
 				}
 			}
 		}
 
 		if (hasDenial) return { decision: "deny", ...(denialReason ? { reason: denialReason } : {}) };
-		if (hasEscalation) return { decision: "escalate", ...(escalationReason ? { reason: escalationReason } : {}) };
-		if (!participated) return { decision: "escalate", reason: "no review handlers" };
+		if (hasEscalation) return { decision: "escalate" };
+		if (!participated) return { decision: "escalate" };
 		return { decision: "approve" };
 	}
 

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -1865,7 +1865,7 @@ export class ExtensionRunner {
 	}
 }
 /** Recursively freezes a JSON value so event handlers cannot mutate it. */
-function deepFreeze<T>(value: T): T {
+export function deepFreeze<T>(value: T): T {
 	if (typeof value === "object" && value !== null) {
 		for (const key of Object.keys(value as Record<string, unknown>)) {
 			deepFreeze((value as Record<string, unknown>)[key]);

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -64,6 +64,8 @@ import type {
 	SessionCompactingResult,
 	SessionStopEvent,
 	SessionStopEventResult,
+	ToolApprovalReviewEvent,
+	ToolApprovalReviewResult,
 	ToolCallEvent,
 	ToolCallEventResult,
 	ToolRegistrationListener,
@@ -1508,6 +1510,60 @@ export class ExtensionRunner {
 			return { block: true, reason: `Tool execution was cancelled while an extension handler was pending` };
 		}
 		return result;
+	}
+
+	/**
+	 * Emit a `tool_approval_review` event to every subscribed extension.
+	 *
+	 * Advisory pre-execution review of an eligible mode-derived approval prompt.
+	 * Approval is returned only when at least one handler participates and every
+	 * handler returns exactly `{ decision: "approve" }`. Any other outcome — no
+	 * handlers, escalation, malformed results, throws, timeouts, or
+	 * cancellation — maps to `{ decision: "escalate" }`, which keeps the caller
+	 * on the ordinary native approval path. The review can never deny or
+	 * rewrite the call: the event carries no deny/rewrite shape and only a
+	 * unanimous approve suppresses the prompt.
+	 */
+	async emitToolApprovalReview(
+		event: ToolApprovalReviewEvent,
+		signal?: AbortSignal,
+	): Promise<ToolApprovalReviewResult> {
+		let ctx: ExtensionContext | undefined;
+		let participated = false;
+
+		for (const ext of this.extensions) {
+			const handlers = ext.handlers.get(event.type);
+			if (!handlers || handlers.length === 0) continue;
+			ctx ??= this.createContext();
+
+			for (const handler of handlers) {
+				const result = await this.#runHandlerWithTimeout<ToolApprovalReviewEvent, ToolApprovalReviewResult>(
+					handler as (event: ToolApprovalReviewEvent, ctx: ExtensionContext) => Promise<ToolApprovalReviewResult | undefined>,
+					event,
+					ctx,
+					ext,
+					normalizeHandlerTimeout(
+						this.settings?.get("extensionHandlers.toolCallTimeoutMs") ?? extensionHandlerTimeoutMs,
+					),
+					() => ({ decision: "escalate", reason: `Extension ${ext.path} failed or timed out` }),
+					signal,
+				);
+				if (
+					result?.decision === "approve" &&
+					Object.keys(result).every(key => key === "decision" || key === "rationale")
+				) {
+					participated = true;
+					continue;
+				}
+				return {
+					decision: "escalate",
+					...(result?.decision === "escalate" && result.reason ? { reason: result.reason } : {}),
+				};
+			}
+		}
+
+		if (!participated) return { decision: "escalate", reason: "no review handlers" };
+		return { decision: "approve" };
 	}
 
 	async emitUserBash(event: UserBashEvent): Promise<UserBashEventResult | undefined> {

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -1552,9 +1552,10 @@ export class ExtensionRunner {
 	 *
 	 * Review of an eligible mode-derived approval prompt. A valid deny takes
 	 * precedence over escalation; escalation includes malformed results, throws,
-	 * timeouts, and cancellation. Approval is returned only when at least one
-	 * handler participates and every handler returns exactly a valid approve
-	 * result. No handlers escalate to the ordinary native approval path.
+	 * timeouts, cancellation, and non-plain (mutably cloneable) input values.
+	 * Approval is returned only when at least one handler participates and every
+	 * handler returns exactly a valid approve result. No handlers escalate to the
+	 * ordinary native approval path.
 	 */
 	async emitToolApprovalReview(
 		event: ToolApprovalReviewEvent,

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -1875,9 +1875,9 @@ export class ExtensionRunner {
 	}
 }
 
-/** Recursively freezes a plain object/array value, rejecting unsupported mutable objects. */
-function deepFreeze<T>(value: T, seen = new WeakSet<object>()): T {
-	if (typeof value !== "object" || value === null || seen.has(value)) return value;
+/** Rejects values that cannot be exposed as a deeply immutable approval-review snapshot. */
+export function assertReviewInputSafe(value: unknown, seen = new WeakSet<object>()): void {
+	if (typeof value !== "object" || value === null || seen.has(value)) return;
 
 	const prototype = Object.getPrototypeOf(value);
 	if (prototype !== Object.prototype && prototype !== null && prototype !== Array.prototype) {
@@ -1889,7 +1889,25 @@ function deepFreeze<T>(value: T, seen = new WeakSet<object>()): T {
 		if (!descriptor || !("value" in descriptor)) {
 			throw new TypeError("Review input contains an accessor");
 		}
-		deepFreeze(descriptor.value, seen);
+		assertReviewInputSafe(descriptor.value, seen);
+	}
+}
+
+/** Recursively freezes a review-safe plain object/array value. */
+export function deepFreeze<T>(value: T): T {
+	assertReviewInputSafe(value);
+	return freezeReviewInput(value);
+}
+
+function freezeReviewInput<T>(value: T, seen = new WeakSet<object>()): T {
+	if (typeof value !== "object" || value === null || seen.has(value)) return value;
+
+	seen.add(value);
+	for (const key of Reflect.ownKeys(value)) {
+		const descriptor = Object.getOwnPropertyDescriptor(value, key);
+		if (descriptor && "value" in descriptor) {
+			freezeReviewInput(descriptor.value, seen);
+		}
 	}
 	Object.freeze(value);
 	return value;

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -370,6 +370,7 @@ type RunnerEmitEvent = Exclude<
 	ExtensionEvent,
 	| ToolCallEvent
 	| ToolResultEvent
+	| ToolApprovalReviewEvent
 	| UserBashEvent
 	| ContextEvent
 	| BeforeProviderRequestEvent
@@ -1871,13 +1872,23 @@ export class ExtensionRunner {
 		return undefined;
 	}
 }
-/** Recursively freezes a JSON value so event handlers cannot mutate it. */
-export function deepFreeze<T>(value: T): T {
-	if (typeof value === "object" && value !== null) {
-		for (const key of Object.keys(value as Record<string, unknown>)) {
-			deepFreeze((value as Record<string, unknown>)[key]);
-		}
-		Object.freeze(value);
+
+/** Recursively freezes a plain object/array value, rejecting unsupported mutable objects. */
+function deepFreeze<T>(value: T, seen = new WeakSet<object>()): T {
+	if (typeof value !== "object" || value === null || seen.has(value)) return value;
+
+	const prototype = Object.getPrototypeOf(value);
+	if (prototype !== Object.prototype && prototype !== null && prototype !== Array.prototype) {
+		throw new TypeError("Review input contains an unsupported mutable value");
 	}
+	seen.add(value);
+	for (const key of Reflect.ownKeys(value)) {
+		const descriptor = Object.getOwnPropertyDescriptor(value, key);
+		if (!descriptor || !("value" in descriptor)) {
+			throw new TypeError("Review input contains an accessor");
+		}
+		deepFreeze(descriptor.value, seen);
+	}
+	Object.freeze(value);
 	return value;
 }

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -77,7 +77,7 @@ import type {
 	ReadToolInput,
 	WriteToolInput,
 } from "../../tools";
-import type { ApprovalMode } from "../../tools/approval";
+import type { ApprovalMode, ToolTier } from "../../tools/approval";
 import type { FileDeleteFallbackHandler, FileWriteFallbackHandler } from "../../tools/file-write-fallback";
 import type { EventBus } from "../../utils/event-bus";
 import type {
@@ -927,6 +927,27 @@ export interface ToolApprovalResolvedEvent {
 	reason?: string;
 }
 
+/**
+ * Fired after final tool-input resolution for an eligible mode-derived prompt,
+ * before the native approval selector. The review is advisory: it may approve
+ * the call (skipping the ordinary prompt) or escalate back to it — it can never
+ * deny the call or rewrite its input. `input` is the exact object that will
+ * reach execution.
+ */
+export interface ToolApprovalReviewEvent {
+	type: "tool_approval_review";
+	sessionId: string;
+	toolCallId: string;
+	toolName: string;
+	input: Record<string, unknown>;
+	approvalMode: ApprovalMode;
+	tier: ToolTier;
+}
+
+export type ToolApprovalReviewResult =
+	| { decision: "approve"; rationale?: string }
+	| { decision: "escalate"; reason?: string };
+
 interface ToolCallEventBase {
 	type: "tool_call";
 	toolCallId: string;
@@ -1100,7 +1121,8 @@ export type ExtensionEvent =
 	| ToolCallEvent
 	| ToolResultEvent
 	| ToolApprovalRequestedEvent
-	| ToolApprovalResolvedEvent;
+	| ToolApprovalResolvedEvent
+	| ToolApprovalReviewEvent;
 
 // ============================================================================
 // Event Results
@@ -1285,6 +1307,10 @@ export interface ExtensionAPI {
 	on(event: "input", handler: ExtensionHandler<InputEvent, InputEventResult>): void;
 	on(event: "tool_approval_requested", handler: ExtensionHandler<ToolApprovalRequestedEvent>): void;
 	on(event: "tool_approval_resolved", handler: ExtensionHandler<ToolApprovalResolvedEvent>): void;
+	on(
+		event: "tool_approval_review",
+		handler: ExtensionHandler<ToolApprovalReviewEvent, ToolApprovalReviewResult>,
+	): void;
 	on(event: "tool_call", handler: ExtensionHandler<ToolCallEvent, ToolCallEventResult>): void;
 	on(event: "tool_result", handler: ExtensionHandler<ToolResultEvent, ToolResultEventResult>): void;
 	on(event: "user_bash", handler: ExtensionHandler<UserBashEvent, UserBashEventResult>): void;

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -929,10 +929,10 @@ export interface ToolApprovalResolvedEvent {
 
 /**
  * Fired after final tool-input resolution for an eligible mode-derived prompt,
- * before the native approval selector. The review is advisory: it may approve
- * the call (skipping the ordinary prompt) or escalate back to it — it can never
- * deny the call or rewrite its input. `input` is the exact object that will
- * reach execution.
+ * before the native approval selector. The review may approve the call
+ * (skipping the ordinary prompt), escalate back to it, or deny the call. It
+ * cannot rewrite the input. `input` is the exact object that will reach
+ * execution.
  */
 export interface ToolApprovalReviewEvent {
 	type: "tool_approval_review";
@@ -946,7 +946,8 @@ export interface ToolApprovalReviewEvent {
 
 export type ToolApprovalReviewResult =
 	| { decision: "approve"; rationale?: string }
-	| { decision: "escalate"; reason?: string };
+	| { decision: "escalate"; reason?: string }
+	| { decision: "deny"; reason?: string };
 
 interface ToolCallEventBase {
 	type: "tool_call";

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -931,8 +931,9 @@ export interface ToolApprovalResolvedEvent {
  * Fired after final tool-input resolution for an eligible mode-derived prompt,
  * before the native approval selector. The review may approve the call
  * (skipping the ordinary prompt), escalate back to it, or deny the call. It
- * cannot rewrite the input. `input` is the exact object that will reach
- * execution.
+ * cannot rewrite the input. `input` is an immutable snapshot, identical to the
+ * input that will reach execution; mutation attempts throw and escalate to the
+ * native approval path.
  */
 export interface ToolApprovalReviewEvent {
 	type: "tool_approval_review";
@@ -1230,6 +1231,62 @@ export type ExtensionServiceTier<Family extends ServiceTierFamily> = Family exte
 		: ServiceTier;
 
 /**
+ * Event names the host dispatches to extension handlers. Plugins use this to
+ * detect whether the running host supports a given seam (e.g.
+ * `tool_approval_review`) — registering a handler for an event an older host
+ * does not dispatch is a silent no-op. Keep in sync with the `on` overloads
+ * below.
+ */
+export const EXTENSION_EVENT_NAMES: readonly string[] = Object.freeze([
+	"resources_discover",
+	"session_start",
+	"session_before_switch",
+	"session_switch",
+	"session_before_branch",
+	"session_branch",
+	"session_before_compact",
+	"session.compacting",
+	"session_compact",
+	"session_shutdown",
+	"session_before_tree",
+	"session_tree",
+	"context",
+	"before_provider_request",
+	"after_provider_response",
+	"before_agent_start",
+	"agent_start",
+	"agent_end",
+	"session_stop",
+	"turn_start",
+	"turn_end",
+	"message_start",
+	"message_update",
+	"message_end",
+	"tool_execution_start",
+	"tool_execution_update",
+	"tool_execution_end",
+	"auto_compaction_start",
+	"auto_compaction_end",
+	"auto_retry_start",
+	"auto_retry_end",
+	"retry_fallback_applied",
+	"retry_fallback_succeeded",
+	"ttsr_triggered",
+	"todo_reminder",
+	"goal_updated",
+	"credential_disabled",
+	"input",
+	"tool_approval_requested",
+	"tool_approval_resolved",
+	"tool_approval_review",
+	"tool_call",
+	"tool_result",
+	"user_bash",
+	"user_python",
+	"mcp_notification",
+]);
+
+/**
  * ExtensionAPI passed to extension factory functions.
  */
 export interface ExtensionAPI {
@@ -1251,6 +1308,9 @@ export interface ExtensionAPI {
 
 	/** Injected pi-coding-agent exports for accessing SDK utilities */
 	pi: typeof PiCodingAgent;
+
+	/** Event names the host dispatches to extension handlers; plugins use it to detect seam support on older hosts. */
+	supportedEvents: readonly string[];
 
 	// =========================================================================
 	// Event Subscription

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -931,23 +931,21 @@ export interface ToolApprovalResolvedEvent {
  * Fired after final tool-input resolution for an eligible mode-derived prompt,
  * before the native approval selector. The review may approve the call
  * (skipping the ordinary prompt), escalate back to it, or deny the call. It
- * cannot rewrite the input. `input` is an immutable snapshot, identical to the
- * input that will reach execution; mutation attempts throw and escalate to the
- * native approval path.
+ * cannot rewrite the final immutable input that execution will receive.
  */
 export interface ToolApprovalReviewEvent {
-	type: "tool_approval_review";
-	sessionId: string;
-	toolCallId: string;
-	toolName: string;
-	input: Record<string, unknown>;
-	approvalMode: ApprovalMode;
-	tier: ToolTier;
+	readonly type: "tool_approval_review";
+	readonly sessionId: string;
+	readonly toolCallId: string;
+	readonly toolName: string;
+	readonly input: Readonly<Record<string, unknown>>;
+	readonly approvalMode: ApprovalMode;
+	readonly tier: ToolTier;
 }
 
 export type ToolApprovalReviewResult =
-	| { decision: "approve"; rationale?: string }
-	| { decision: "escalate"; reason?: string }
+	| { decision: "approve" }
+	| { decision: "escalate" }
 	| { decision: "deny"; reason?: string };
 
 interface ToolCallEventBase {

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -931,7 +931,7 @@ export interface ToolApprovalResolvedEvent {
  * Fired after final tool-input resolution for an eligible mode-derived prompt,
  * before the native approval selector. The review may approve the call
  * (skipping the ordinary prompt), escalate back to it, or deny the call. It
- * cannot rewrite the final immutable input that execution will receive.
+ * cannot rewrite the deeply immutable snapshot of the input under review.
  */
 export interface ToolApprovalReviewEvent {
 	readonly type: "tool_approval_review";

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -1229,11 +1229,13 @@ export type ExtensionServiceTier<Family extends ServiceTierFamily> = Family exte
 		: ServiceTier;
 
 /**
- * Event names the host dispatches to extension handlers. Plugins use this to
- * detect whether the running host supports a given seam (e.g.
- * `tool_approval_review`) — registering a handler for an event an older host
- * does not dispatch is a silent no-op. Keep in sync with the `on` overloads
- * below.
+ * Event names dispatched by the host to extension handlers.
+ *
+ * Exposed through `supportedEvents` for runtime capability detection.
+ * Extensions should treat `supportedEvents` as optional so they remain
+ * compatible with older hosts that predate capability reporting.
+ *
+ * Keep in sync with the `on()` overloads below.
  */
 export const EXTENSION_EVENT_NAMES: readonly string[] = Object.freeze([
 	"resources_discover",
@@ -1307,8 +1309,8 @@ export interface ExtensionAPI {
 	/** Injected pi-coding-agent exports for accessing SDK utilities */
 	pi: typeof PiCodingAgent;
 
-	/** Event names the host dispatches to extension handlers; plugins use it to detect seam support on older hosts. */
-	supportedEvents: readonly string[];
+	/** Event names dispatched by this host. Absent on older hosts. */
+	supportedEvents?: readonly string[];
 
 	// =========================================================================
 	// Event Subscription

--- a/packages/coding-agent/src/extensibility/extensions/wrapper.ts
+++ b/packages/coding-agent/src/extensibility/extensions/wrapper.ts
@@ -24,7 +24,7 @@ import { withFileMutationSession } from "../../tools/file-write-fallback";
 import { normalizeToolEventInput, resolveToolEventInput } from "../tool-event-input";
 import { applyToolProxy } from "../tool-proxy";
 import type { ExtensionRunner } from "./runner";
-import type { RegisteredTool, ToolCallEventResult } from "./types";
+import type { RegisteredTool, ToolApprovalReviewResult, ToolCallEventResult } from "./types";
 
 /**
  * Adapts a RegisteredTool into an AgentTool.
@@ -274,10 +274,14 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 			reason: resolved.reason,
 		};
 
-		// Advisory extension review, exactly between final input resolution and
-		// the native selector. Eligible only for mode-derived prompts: approve
-		// suppresses the ordinary prompt, escalate keeps it unchanged, and deny
-		// rejects at the extension review layer without UI or execution.
+		// Extension approval review between final input resolution and the native
+		// selector. Eligible only for mode-derived prompts: approve resolves the
+		// prompt positively, deny vetoes the call at the extension layer, and
+		// escalate leaves the decision to the ordinary native selector. Handlers
+		// review a deeply immutable snapshot of the owned params: freezing the
+		// owned params themselves would forbid tools from mutating their
+		// validated input internally. Clone or freeze failures fail closed to the
+		// native selector.
 		if (
 			approvalCheck.required &&
 			resolved.policy === "prompt" &&
@@ -287,18 +291,28 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 			!xdevBypass &&
 			!signal?.aborted
 		) {
-			const review = await this.runner.emitToolApprovalReview(
-				{
-					type: "tool_approval_review",
-					sessionId: context?.sessionManager?.getSessionId() ?? "",
-					toolCallId,
-					toolName: this.tool.name,
-					input: finalParams as Record<string, unknown>,
-					approvalMode,
-					tier: resolved.tier,
-				},
-				signal,
-			);
+			let review: ToolApprovalReviewResult;
+			try {
+				review = await this.runner.emitToolApprovalReview(
+					{
+						type: "tool_approval_review",
+						sessionId: context?.sessionManager?.getSessionId() ?? "",
+						toolCallId,
+						toolName: this.tool.name,
+						input: structuredClone(finalParams) as Record<string, unknown>,
+						approvalMode,
+						tier: resolved.tier,
+					},
+					signal,
+				);
+			} catch (err) {
+				// emitToolApprovalReview resolves to escalate on handler/freeze
+				// failures; a throw here can only be a snapshot-clone failure or an
+				// abort. Either way the native selector must decide; abort is
+				// re-raised by throwIfAborted below.
+				review = { decision: "escalate" };
+				if (!(err instanceof TypeError)) throw err;
+			}
 			signal?.throwIfAborted();
 			if (review.decision === "deny") {
 				throw extensionReviewDenyError(this.tool.name, review.reason);

--- a/packages/coding-agent/src/extensibility/extensions/wrapper.ts
+++ b/packages/coding-agent/src/extensibility/extensions/wrapper.ts
@@ -393,7 +393,23 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 			}
 
 			const uiContext = this.runner.getUIContext();
-			const basePrompt = formatApprovalPrompt(this.tool, resolvedArgs, approvalCheck.reason);
+			// `formatApprovalDetails` is tool-owned callback code: it must never
+			// receive the execution-owned params, or a formatter that mutates or
+			// retains its argument could change what runs after the user approves
+			// the rendered text (formatter displays A, execution receives B). Hand
+			// it a detached clone of the resolved args instead — the same content
+			// the review snapshot was built from, never the execution object.
+			// Unfrozen: a frozen graph would turn formatter mutation attempts into
+			// TypeErrors, changing formatter error behavior. Inputs that cannot be
+			// cloned keep the previous aliasing — no lossless copy exists, and
+			// cloning never touches the execution object either way.
+			let promptArgs = resolvedArgs;
+			try {
+				promptArgs = structuredClone(resolvedArgs);
+			} catch {
+				// Non-cloneable fallback input: keep the prior aliasing semantics.
+			}
+			const basePrompt = formatApprovalPrompt(this.tool, promptArgs, approvalCheck.reason);
 			const safetyPrompt =
 				pendingSafetyChecks.length > 0
 					? `${basePrompt}\nProvider safety checks:\n${safetyCheckLines(pendingSafetyChecks).join("\n")}`

--- a/packages/coding-agent/src/extensibility/extensions/wrapper.ts
+++ b/packages/coding-agent/src/extensibility/extensions/wrapper.ts
@@ -16,7 +16,6 @@ import {
 	type ApprovalMode,
 	denyError,
 	formatApprovalPrompt,
-	type ResolvedApproval,
 	resolveApproval,
 	truncateForPrompt,
 } from "../../tools/approval";
@@ -254,8 +253,8 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 		// never reach extension review keep the pre-review execution behavior and gain no
 		// structured-cloneability requirement (a tool_call replacement or direct dispatch may
 		// legally carry non-cloneable values).
-		let resolvedArgs = approvalArgs(effectiveParams, context);
-		let resolved = resolveApproval(this.tool, resolvedArgs, approvalMode, userPolicies);
+		const resolvedArgs = approvalArgs(effectiveParams, context);
+		const resolved = resolveApproval(this.tool, resolvedArgs, approvalMode, userPolicies);
 		context?.xdevTierResolved?.(resolved.tier);
 		if (resolved.policy === "deny") {
 			throw denyError(resolved, this.tool.name);
@@ -269,9 +268,9 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 		// and tool-demanded overrides still prompt. Provider safety checks are
 		// stronger: yolo, per-tool allow, and xdev approval never acknowledge
 		// them on the user's behalf.
-		let explicitPrompt = resolved.override || resolved.source === "user";
+		const explicitPrompt = resolved.override || resolved.source === "user";
 		const xdevBypass = context?.xdevApproved === true && inputMatchesDispatch;
-		let approvalCheck = {
+		const approvalCheck = {
 			required: pendingSafetyChecks.length > 0 || (resolved.policy === "prompt" && (explicitPrompt || !xdevBypass)),
 			reason: resolved.reason,
 		};
@@ -291,76 +290,37 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 			!signal?.aborted &&
 			this.runner.hasHandlers("tool_approval_review")
 		) {
-			let preparedReview:
-				| {
-						params: typeof effectiveParams;
-						args: unknown;
-						resolved: ResolvedApproval;
-						event: ToolApprovalReviewEvent;
-				  }
-				| undefined;
-			let ownedDeny: ResolvedApproval | undefined;
+			let preparedReview: { params: typeof effectiveParams; event: ToolApprovalReviewEvent } | undefined;
 			try {
-				// Inspect the source graph before cloning: structuredClone can hide
-				// unsupported prototypes and change exotic-value identity.
+				// Clone fidelity: the validator admits only graphs structuredClone
+				// reproduces verbatim, so the policy decision above — resolved on
+				// `effectiveParams` — classifies the owned clone identically and is
+				// reused here without a third policy invocation. The policy callback
+				// therefore never observes the execution-owned clone or the frozen
+				// review snapshot, and cannot retain an alias into either.
 				assertReviewInputSafe(effectiveParams);
-				const params = structuredClone(effectiveParams);
-				const args = approvalArgs(params, context);
-				const ownedResolved = resolveApproval(this.tool, args, approvalMode, userPolicies);
-				if (ownedResolved.policy === "deny") {
-					ownedDeny = ownedResolved;
-				} else {
-					const ownedExplicitPrompt = ownedResolved.override || ownedResolved.source === "user";
-					const ownedApprovalRequired =
-						pendingSafetyChecks.length > 0 ||
-						(ownedResolved.policy === "prompt" && (ownedExplicitPrompt || !xdevBypass));
-					if (
-						ownedApprovalRequired &&
-						ownedResolved.policy === "prompt" &&
-						ownedResolved.source === "mode" &&
-						!ownedExplicitPrompt
-					) {
-						preparedReview = {
-							params,
-							args,
-							resolved: ownedResolved,
-							event: deepFreeze({
-								type: "tool_approval_review",
-								sessionId: context?.sessionManager?.getSessionId() ?? "",
-								toolCallId,
-								toolName: this.tool.name,
-								input: structuredClone(params) as Record<string, unknown>,
-								approvalMode,
-								tier: ownedResolved.tier,
-							}),
-						};
-					}
-				}
+				preparedReview = {
+					params: structuredClone(effectiveParams),
+					event: deepFreeze({
+						type: "tool_approval_review",
+						sessionId: context?.sessionManager?.getSessionId() ?? "",
+						toolCallId,
+						toolName: this.tool.name,
+						input: structuredClone(effectiveParams) as Record<string, unknown>,
+						approvalMode,
+						tier: resolved.tier,
+					}),
+				};
 			} catch {
 				preparedReview = undefined;
-				ownedDeny = undefined;
-			}
-
-			if (ownedDeny) {
-				// Native deny is authoritative on owned material that passed every
-				// ownership and policy-resolution precondition.
-				throw denyError(ownedDeny, this.tool.name);
 			}
 
 			if (preparedReview) {
-				// Handler dispatch is now guaranteed to receive the prepared snapshot,
-				// so the owned invocation becomes authoritative through approval or
-				// native escalation.
+				// Independent graphs: execution takes its own mutable clone; review
+				// takes a separate deeply frozen snapshot. Neither aliases the source
+				// input the approval callback saw, and review approval attaches to a
+				// snapshot materially identical to what executes.
 				executionParams = preparedReview.params;
-				resolvedArgs = preparedReview.args;
-				resolved = preparedReview.resolved;
-				context?.xdevTierResolved?.(resolved.tier);
-				explicitPrompt = resolved.override || resolved.source === "user";
-				approvalCheck = {
-					required:
-						pendingSafetyChecks.length > 0 || (resolved.policy === "prompt" && (explicitPrompt || !xdevBypass)),
-					reason: resolved.reason,
-				};
 
 				let review: ToolApprovalReviewResult;
 				try {

--- a/packages/coding-agent/src/extensibility/extensions/wrapper.ts
+++ b/packages/coding-agent/src/extensibility/extensions/wrapper.ts
@@ -23,7 +23,7 @@ import { defaultLoadModeForToolName } from "../../tools/essential-tools";
 import { withFileMutationSession } from "../../tools/file-write-fallback";
 import { normalizeToolEventInput, resolveToolEventInput } from "../tool-event-input";
 import { applyToolProxy } from "../tool-proxy";
-import type { ExtensionRunner } from "./runner";
+import { deepFreeze, type ExtensionRunner } from "./runner";
 import type { RegisteredTool, ToolCallEventResult } from "./types";
 
 /**
@@ -242,11 +242,14 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 			}
 		}
 
-		// 2. Full approval gate against the (possibly revised) input that will actually run — resolves
-		// policy and prompts on `effectiveParams`, so the user approves exactly what executes. A revised
+		const inputMatchesDispatch = effectiveParams === params;
+		const finalParams = deepFreeze(structuredClone(effectiveParams));
+
+		// 2. Full approval gate against the owned final input that will actually run — resolves
+		// policy and prompts on `finalParams`, so the user approves exactly what executes. A revised
 		// input that newly resolves to `deny` is caught here even though the original passed the
 		// short-circuit above.
-		const resolvedArgs = approvalArgs(effectiveParams, context);
+		const resolvedArgs = approvalArgs(finalParams, context);
 		const resolved = resolveApproval(this.tool, resolvedArgs, approvalMode, userPolicies);
 		context?.xdevTierResolved?.(resolved.tier);
 		if (resolved.policy === "deny") {
@@ -262,7 +265,7 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 		// stronger: yolo, per-tool allow, and xdev approval never acknowledge
 		// them on the user's behalf.
 		const explicitPrompt = resolved.override || Object.hasOwn(userPolicies, resolved.policyKey ?? this.tool.name);
-		const xdevBypass = context?.xdevApproved === true && effectiveParams === params;
+		const xdevBypass = context?.xdevApproved === true && inputMatchesDispatch;
 		const approvalCheck = {
 			required: pendingSafetyChecks.length > 0 || (resolved.policy === "prompt" && (explicitPrompt || !xdevBypass)),
 			reason: resolved.reason,
@@ -287,12 +290,13 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 					sessionId: context?.sessionManager?.getSessionId() ?? "",
 					toolCallId,
 					toolName: this.tool.name,
-					input: effectiveParams as Record<string, unknown>,
+					input: finalParams as Record<string, unknown>,
 					approvalMode,
 					tier: resolved.tier,
 				},
 				signal,
 			);
+			signal?.throwIfAborted();
 			if (review.decision === "deny") {
 				throw denyError(
 					{
@@ -396,10 +400,12 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 			// Name the owning session for process-wide file-mutation fallbacks and
 			// expose its settings to registered tools and any fallback handlers they
 			// trigger. `sdk.ts` wraps the whole tool registry with this class whenever
-			// a runner exists.
+			// a runner exists. A denied file write or delete inside this tool can be
+			// brokered to an extension handler, and that registry is PROCESS-WIDE.
+			// Inert with no fallback registered: no scope is entered.
 			result = await this.runner.runScoped(() =>
 				withFileMutationSession(this.runner.sessionId, () =>
-					this.tool.execute(toolCallId, effectiveParams, signal, onUpdate, context),
+					this.tool.execute(toolCallId, finalParams, signal, onUpdate, context),
 				),
 			);
 		} catch (err) {
@@ -418,7 +424,7 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 				toolCallId,
 				input: normalizeToolEventInput(
 					this.tool.name,
-					resolveToolEventInput(this.tool, toolEventArgs(effectiveParams, context)),
+					resolveToolEventInput(this.tool, toolEventArgs(finalParams, context)),
 				),
 				content: result.content,
 				details: result.details,

--- a/packages/coding-agent/src/extensibility/extensions/wrapper.ts
+++ b/packages/coding-agent/src/extensibility/extensions/wrapper.ts
@@ -24,8 +24,8 @@ import { defaultLoadModeForToolName } from "../../tools/essential-tools";
 import { withFileMutationSession } from "../../tools/file-write-fallback";
 import { normalizeToolEventInput, resolveToolEventInput } from "../tool-event-input";
 import { applyToolProxy } from "../tool-proxy";
-import type { ExtensionRunner } from "./runner";
-import type { RegisteredTool, ToolApprovalReviewResult, ToolCallEventResult } from "./types";
+import { assertReviewInputSafe, deepFreeze, type ExtensionRunner } from "./runner";
+import type { RegisteredTool, ToolApprovalReviewEvent, ToolApprovalReviewResult, ToolCallEventResult } from "./types";
 
 /**
  * Adapts a RegisteredTool into an AgentTool.
@@ -277,13 +277,9 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 		};
 
 		// Extension approval review between final input resolution and the native
-		// selector. Eligible only for mode-derived prompts: approve resolves the
-		// prompt positively, deny vetoes the call at the extension layer, and
-		// escalate leaves the decision to the ordinary native selector. Handlers
-		// review a deeply immutable snapshot of the owned params: freezing the
-		// owned params themselves would forbid tools from mutating their
-		// validated input internally. Clone or freeze failures fail closed to the
-		// native selector.
+		// selector. Eligible only for mode-derived prompts. The original input
+		// remains authoritative until every review precondition succeeds and an
+		// immutable snapshot is ready for handler dispatch.
 		let executionParams = effectiveParams;
 		if (
 			approvalCheck.required &&
@@ -292,45 +288,72 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 			!explicitPrompt &&
 			pendingSafetyChecks.length === 0 &&
 			!xdevBypass &&
-			!signal?.aborted
+			!signal?.aborted &&
+			this.runner.hasHandlers("tool_approval_review")
 		) {
-			// Ownership first: review may approve only input the wrapper owns, so the
-			// owned deep clone is established before any handler runs. A clone or
-			// re-resolution failure fails closed — review is skipped entirely and the
-			// ordinary native gate decides on the un-cloned input; clone failure can
-			// never approve.
-			let ownedReviewState:
+			let preparedReview:
 				| {
 						params: typeof effectiveParams;
 						args: unknown;
 						resolved: ResolvedApproval;
+						event: ToolApprovalReviewEvent;
 				  }
 				| undefined;
+			let ownedDeny: ResolvedApproval | undefined;
 			try {
+				// Inspect the source graph before cloning: structuredClone can hide
+				// unsupported prototypes and change exotic-value identity.
+				assertReviewInputSafe(effectiveParams);
 				const params = structuredClone(effectiveParams);
 				const args = approvalArgs(params, context);
-				// Policy re-resolves against the owned clone, so review approval can
-				// never attach to stale pre-clone material.
-				ownedReviewState = {
-					params,
-					args,
-					resolved: resolveApproval(this.tool, args, approvalMode, userPolicies),
-				};
-			} catch {
-				ownedReviewState = undefined;
-			}
-			if (ownedReviewState) {
-				const { params: ownedParams, args: ownedArgs, resolved: ownedResolved } = ownedReviewState;
+				const ownedResolved = resolveApproval(this.tool, args, approvalMode, userPolicies);
 				if (ownedResolved.policy === "deny") {
-					// Native deny is authoritative on the owned material that would execute.
-					throw denyError(ownedResolved, this.tool.name);
+					ownedDeny = ownedResolved;
+				} else {
+					const ownedExplicitPrompt = ownedResolved.override || ownedResolved.source === "user";
+					const ownedApprovalRequired =
+						pendingSafetyChecks.length > 0 ||
+						(ownedResolved.policy === "prompt" && (ownedExplicitPrompt || !xdevBypass));
+					if (
+						ownedApprovalRequired &&
+						ownedResolved.policy === "prompt" &&
+						ownedResolved.source === "mode" &&
+						!ownedExplicitPrompt
+					) {
+						preparedReview = {
+							params,
+							args,
+							resolved: ownedResolved,
+							event: deepFreeze({
+								type: "tool_approval_review",
+								sessionId: context?.sessionManager?.getSessionId() ?? "",
+								toolCallId,
+								toolName: this.tool.name,
+								input: structuredClone(params) as Record<string, unknown>,
+								approvalMode,
+								tier: ownedResolved.tier,
+							}),
+						};
+					}
 				}
+			} catch {
+				preparedReview = undefined;
+				ownedDeny = undefined;
+			}
 
-				// Adopt the owned material as the invocation that executes and re-derive
-				// the gate state from it.
-				executionParams = ownedParams;
-				resolvedArgs = ownedArgs;
-				resolved = ownedResolved;
+			if (ownedDeny) {
+				// Native deny is authoritative on owned material that passed every
+				// ownership and policy-resolution precondition.
+				throw denyError(ownedDeny, this.tool.name);
+			}
+
+			if (preparedReview) {
+				// Handler dispatch is now guaranteed to receive the prepared snapshot,
+				// so the owned invocation becomes authoritative through approval or
+				// native escalation.
+				executionParams = preparedReview.params;
+				resolvedArgs = preparedReview.args;
+				resolved = preparedReview.resolved;
 				context?.xdevTierResolved?.(resolved.tier);
 				explicitPrompt = resolved.override || resolved.source === "user";
 				approvalCheck = {
@@ -339,44 +362,18 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 					reason: resolved.reason,
 				};
 
-				// Dispatch only when the adopted owned material kept the eligible
-				// mode-derived prompt shape. No await has occurred since eligibility was
-				// established, so the remaining conditions cannot have changed.
-				if (
-					approvalCheck.required &&
-					resolved.policy === "prompt" &&
-					resolved.source === "mode" &&
-					!explicitPrompt
-				) {
-					let review: ToolApprovalReviewResult;
-					try {
-						review = await this.runner.emitToolApprovalReview(
-							{
-								type: "tool_approval_review",
-								sessionId: context?.sessionManager?.getSessionId() ?? "",
-								toolCallId,
-								toolName: this.tool.name,
-								input: structuredClone(executionParams) as Record<string, unknown>,
-								approvalMode,
-								tier: resolved.tier,
-							},
-							signal,
-						);
-					} catch {
-						// emitToolApprovalReview resolves to escalate on handler/freeze
-						// failures and never throws; a throw here can only be a
-						// snapshot-clone failure. Fail closed to the native selector;
-						// abort is re-raised by throwIfAborted below.
-						review = { decision: "escalate" };
-					}
-					signal?.throwIfAborted();
-					if (review.decision === "deny") {
-						throw extensionReviewDenyError(this.tool.name, review.reason);
-					}
-					if (review.decision === "approve") {
-						// Suppress only this eligible mode-derived native prompt.
-						approvalCheck.required = false;
-					}
+				let review: ToolApprovalReviewResult;
+				try {
+					review = await this.runner.emitToolApprovalReview(preparedReview.event, signal);
+				} catch {
+					review = { decision: "escalate" };
+				}
+				signal?.throwIfAborted();
+				if (review.decision === "deny") {
+					throw extensionReviewDenyError(this.tool.name, review.reason);
+				}
+				if (review.decision === "approve") {
+					approvalCheck.required = false;
 				}
 			}
 		}

--- a/packages/coding-agent/src/extensibility/extensions/wrapper.ts
+++ b/packages/coding-agent/src/extensibility/extensions/wrapper.ts
@@ -269,11 +269,9 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 		};
 
 		// Advisory extension review, exactly between final input resolution and
-		// the native selector. Eligible only for mode-derived prompts: unanimous
-		// approval suppresses the ordinary prompt below; every other outcome
-		// keeps it unchanged. The review cannot deny or rewrite the call — the
-		// event carries the exact execution input and the result shape carries
-		// no deny or rewrite fields.
+		// the native selector. Eligible only for mode-derived prompts: approve
+		// suppresses the ordinary prompt, escalate keeps it unchanged, and deny
+		// rejects through the native policy-denial path without UI or execution.
 		if (
 			approvalCheck.required &&
 			resolved.policy === "prompt" &&
@@ -295,6 +293,17 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 				},
 				signal,
 			);
+			if (review.decision === "deny") {
+				throw denyError(
+					{
+						...resolved,
+						policy: "deny",
+						source: "tool",
+						...(review.reason ? { reason: review.reason } : {}),
+					},
+					this.tool.name,
+				);
+			}
 			if (review.decision === "approve") {
 				// Suppress only this eligible mode-derived native prompt.
 				approvalCheck.required = false;

--- a/packages/coding-agent/src/extensibility/extensions/wrapper.ts
+++ b/packages/coding-agent/src/extensibility/extensions/wrapper.ts
@@ -143,6 +143,9 @@ function safetyCheckLines(checks: readonly ComputerSafetyCheck[]): string[] {
 		return `${index + 1}. ${approvalData(value)}`;
 	});
 }
+function extensionReviewDenyError(toolName: string, reason?: string): Error {
+	return new Error(`Tool "${toolName}" was denied by an extension approval review${reason ? `: ${reason}` : ""}`);
+}
 
 /**
  * Wraps a tool with extension callbacks for interception.
@@ -274,7 +277,7 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 		// Advisory extension review, exactly between final input resolution and
 		// the native selector. Eligible only for mode-derived prompts: approve
 		// suppresses the ordinary prompt, escalate keeps it unchanged, and deny
-		// rejects through the native policy-denial path without UI or execution.
+		// rejects at the extension review layer without UI or execution.
 		if (
 			approvalCheck.required &&
 			resolved.policy === "prompt" &&
@@ -298,15 +301,7 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 			);
 			signal?.throwIfAborted();
 			if (review.decision === "deny") {
-				throw denyError(
-					{
-						...resolved,
-						policy: "deny",
-						source: "tool",
-						...(review.reason ? { reason: review.reason } : {}),
-					},
-					this.tool.name,
-				);
+				throw extensionReviewDenyError(this.tool.name, review.reason);
 			}
 			if (review.decision === "approve") {
 				// Suppress only this eligible mode-derived native prompt.

--- a/packages/coding-agent/src/extensibility/extensions/wrapper.ts
+++ b/packages/coding-agent/src/extensibility/extensions/wrapper.ts
@@ -268,6 +268,39 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 			reason: resolved.reason,
 		};
 
+		// Advisory extension review, exactly between final input resolution and
+		// the native selector. Eligible only for mode-derived prompts: unanimous
+		// approval suppresses the ordinary prompt below; every other outcome
+		// keeps it unchanged. The review cannot deny or rewrite the call — the
+		// event carries the exact execution input and the result shape carries
+		// no deny or rewrite fields.
+		if (
+			approvalCheck.required &&
+			resolved.policy === "prompt" &&
+			resolved.source === "mode" &&
+			!explicitPrompt &&
+			pendingSafetyChecks.length === 0 &&
+			!xdevBypass &&
+			!signal?.aborted
+		) {
+			const review = await this.runner.emitToolApprovalReview(
+				{
+					type: "tool_approval_review",
+					sessionId: context?.sessionManager?.getSessionId() ?? "",
+					toolCallId,
+					toolName: this.tool.name,
+					input: effectiveParams as Record<string, unknown>,
+					approvalMode,
+					tier: resolved.tier,
+				},
+				signal,
+			);
+			if (review.decision === "approve") {
+				// Suppress only this eligible mode-derived native prompt.
+				approvalCheck.required = false;
+			}
+		}
+
 		if (approvalCheck.required) {
 			const scheduledCall = context?.toolCall?.toolCalls[context.toolCall.index];
 			if (

--- a/packages/coding-agent/src/extensibility/extensions/wrapper.ts
+++ b/packages/coding-agent/src/extensibility/extensions/wrapper.ts
@@ -209,7 +209,7 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 		// 1. Emit tool_call event first - extensions can block execution or revise the input the tool
 		// runs with. Doing this BEFORE the approval gate means approval (below) resolves against the
 		// input that actually executes, closing the "approve one thing, run another" gap: the prompt
-		// text, policy resolution, and provider safety checks all see `effectiveParams`.
+		// text, policy resolution, and provider safety checks all see the final owned input.
 		let effectiveParams = params;
 		if (!loopEmittedToolCall && this.runner.hasHandlers("tool_call")) {
 			try {
@@ -230,10 +230,10 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 					const reason = callResult.reason || "Tool execution was blocked by an extension";
 					throw new Error(reason);
 				}
-				// A non-blocking handler may replace the execution input. The returned object is the raw
-				// input passed to `execute` (handler-owned; not re-normalized). Skipped for `computer`
-				// tool calls, whose event input is a synthetic {actions,pendingSafetyChecks} view
-				// (see toolEventArgs) rather than the real execution params.
+				// A non-blocking handler may replace the execution input. The returned object is copied
+				// into the final owned input below. Skipped for `computer` tool calls, whose event input
+				// is a synthetic {actions,pendingSafetyChecks} view (see toolEventArgs) rather than the
+				// real execution params.
 				if (callResult?.input !== undefined && context?.toolCall?.providerMetadata?.type !== "computer") {
 					effectiveParams = callResult.input as typeof params;
 				}

--- a/packages/coding-agent/src/extensibility/extensions/wrapper.ts
+++ b/packages/coding-agent/src/extensibility/extensions/wrapper.ts
@@ -16,6 +16,7 @@ import {
 	type ApprovalMode,
 	denyError,
 	formatApprovalPrompt,
+	type ResolvedApproval,
 	resolveApproval,
 	truncateForPrompt,
 } from "../../tools/approval";
@@ -246,14 +247,15 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 		}
 		const inputMatchesDispatch = effectiveParams === params;
 
-		const finalParams = structuredClone(effectiveParams);
-
-		// 2. Full approval gate against the owned final input that will actually run — resolves
-		// policy and prompts on `finalParams`, so the user approves exactly what executes. A revised
-		// input that newly resolves to `deny` is caught here even though the original passed the
-		// short-circuit above.
-		const resolvedArgs = approvalArgs(finalParams, context);
-		const resolved = resolveApproval(this.tool, resolvedArgs, approvalMode, userPolicies);
+		// 2. Full approval gate against the input that will actually run — resolves policy and
+		// prompts on the un-cloned execution input, so a revised input that newly resolves to
+		// `deny` is caught here even though the original passed the short-circuit above. The
+		// owned deep clone is established only inside the review boundary below: calls that
+		// never reach extension review keep the pre-review execution behavior and gain no
+		// structured-cloneability requirement (a tool_call replacement or direct dispatch may
+		// legally carry non-cloneable values).
+		let resolvedArgs = approvalArgs(effectiveParams, context);
+		let resolved = resolveApproval(this.tool, resolvedArgs, approvalMode, userPolicies);
 		context?.xdevTierResolved?.(resolved.tier);
 		if (resolved.policy === "deny") {
 			throw denyError(resolved, this.tool.name);
@@ -267,9 +269,9 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 		// and tool-demanded overrides still prompt. Provider safety checks are
 		// stronger: yolo, per-tool allow, and xdev approval never acknowledge
 		// them on the user's behalf.
-		const explicitPrompt = resolved.override || resolved.source === "user";
+		let explicitPrompt = resolved.override || resolved.source === "user";
 		const xdevBypass = context?.xdevApproved === true && inputMatchesDispatch;
-		const approvalCheck = {
+		let approvalCheck = {
 			required: pendingSafetyChecks.length > 0 || (resolved.policy === "prompt" && (explicitPrompt || !xdevBypass)),
 			reason: resolved.reason,
 		};
@@ -282,6 +284,7 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 		// owned params themselves would forbid tools from mutating their
 		// validated input internally. Clone or freeze failures fail closed to the
 		// native selector.
+		let executionParams = effectiveParams;
 		if (
 			approvalCheck.required &&
 			resolved.policy === "prompt" &&
@@ -291,35 +294,74 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 			!xdevBypass &&
 			!signal?.aborted
 		) {
-			let review: ToolApprovalReviewResult;
+			// Ownership first: review may approve only input the wrapper owns, so the
+			// owned deep clone is established before any handler runs. A clone or
+			// re-resolution failure fails closed — review is skipped entirely and the
+			// ordinary native gate decides on the un-cloned input; clone failure can
+			// never approve.
+			let owned: typeof effectiveParams | undefined;
+			let ownedArgs: unknown;
+			let ownedResolved: ResolvedApproval | undefined;
 			try {
-				review = await this.runner.emitToolApprovalReview(
-					{
-						type: "tool_approval_review",
-						sessionId: context?.sessionManager?.getSessionId() ?? "",
-						toolCallId,
-						toolName: this.tool.name,
-						input: structuredClone(finalParams) as Record<string, unknown>,
-						approvalMode,
-						tier: resolved.tier,
-					},
-					signal,
-				);
-			} catch (err) {
-				// emitToolApprovalReview resolves to escalate on handler/freeze
-				// failures; a throw here can only be a snapshot-clone failure or an
-				// abort. Either way the native selector must decide; abort is
-				// re-raised by throwIfAborted below.
-				review = { decision: "escalate" };
-				if (!(err instanceof TypeError)) throw err;
+				owned = structuredClone(effectiveParams);
+				ownedArgs = approvalArgs(owned, context);
+				// Policy re-resolves against the owned clone, so review approval can
+				// never attach to stale pre-clone material.
+				ownedResolved = resolveApproval(this.tool, ownedArgs, approvalMode, userPolicies);
+			} catch {
+				owned = undefined;
 			}
-			signal?.throwIfAborted();
-			if (review.decision === "deny") {
-				throw extensionReviewDenyError(this.tool.name, review.reason);
+			if (ownedResolved?.policy === "deny") {
+				// Native deny is authoritative on the owned material that would execute.
+				throw denyError(ownedResolved, this.tool.name);
 			}
-			if (review.decision === "approve") {
-				// Suppress only this eligible mode-derived native prompt.
-				approvalCheck.required = false;
+			if (owned && ownedResolved) {
+				// Adopt the owned material as the invocation that executes and re-derive
+				// the gate state from it.
+				executionParams = owned;
+				resolvedArgs = ownedArgs;
+				resolved = ownedResolved;
+				context?.xdevTierResolved?.(resolved.tier);
+				explicitPrompt = resolved.override || resolved.source === "user";
+				approvalCheck = {
+					required:
+						pendingSafetyChecks.length > 0 || (resolved.policy === "prompt" && (explicitPrompt || !xdevBypass)),
+					reason: resolved.reason,
+				};
+			}
+			// Dispatch only when the adopted owned material kept the eligible
+			// mode-derived prompt shape. No await has occurred since eligibility was
+			// established, so the remaining conditions cannot have changed.
+			if (approvalCheck.required && resolved.policy === "prompt" && resolved.source === "mode" && !explicitPrompt) {
+				let review: ToolApprovalReviewResult;
+				try {
+					review = await this.runner.emitToolApprovalReview(
+						{
+							type: "tool_approval_review",
+							sessionId: context?.sessionManager?.getSessionId() ?? "",
+							toolCallId,
+							toolName: this.tool.name,
+							input: structuredClone(executionParams) as Record<string, unknown>,
+							approvalMode,
+							tier: resolved.tier,
+						},
+						signal,
+					);
+				} catch {
+					// emitToolApprovalReview resolves to escalate on handler/freeze
+					// failures and never throws; a throw here can only be a
+					// snapshot-clone failure. Fail closed to the native selector;
+					// abort is re-raised by throwIfAborted below.
+					review = { decision: "escalate" };
+				}
+				signal?.throwIfAborted();
+				if (review.decision === "deny") {
+					throw extensionReviewDenyError(this.tool.name, review.reason);
+				}
+				if (review.decision === "approve") {
+					// Suppress only this eligible mode-derived native prompt.
+					approvalCheck.required = false;
+				}
 			}
 		}
 
@@ -414,7 +456,7 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 			// Inert with no fallback registered: no scope is entered.
 			result = await this.runner.runScoped(() =>
 				withFileMutationSession(this.runner.sessionId, () =>
-					this.tool.execute(toolCallId, finalParams, signal, onUpdate, context),
+					this.tool.execute(toolCallId, executionParams, signal, onUpdate, context),
 				),
 			);
 		} catch (err) {
@@ -433,7 +475,7 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 				toolCallId,
 				input: normalizeToolEventInput(
 					this.tool.name,
-					resolveToolEventInput(this.tool, toolEventArgs(finalParams, context)),
+					resolveToolEventInput(this.tool, toolEventArgs(executionParams, context)),
 				),
 				content: result.content,
 				details: result.details,

--- a/packages/coding-agent/src/extensibility/extensions/wrapper.ts
+++ b/packages/coding-agent/src/extensibility/extensions/wrapper.ts
@@ -23,7 +23,7 @@ import { defaultLoadModeForToolName } from "../../tools/essential-tools";
 import { withFileMutationSession } from "../../tools/file-write-fallback";
 import { normalizeToolEventInput, resolveToolEventInput } from "../tool-event-input";
 import { applyToolProxy } from "../tool-proxy";
-import { deepFreeze, type ExtensionRunner } from "./runner";
+import type { ExtensionRunner } from "./runner";
 import type { RegisteredTool, ToolCallEventResult } from "./types";
 
 /**
@@ -244,9 +244,9 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 				throw new Error(`Extension failed, blocking execution: ${String(err)}`);
 			}
 		}
-
 		const inputMatchesDispatch = effectiveParams === params;
-		const finalParams = deepFreeze(structuredClone(effectiveParams));
+
+		const finalParams = structuredClone(effectiveParams);
 
 		// 2. Full approval gate against the owned final input that will actually run — resolves
 		// policy and prompts on `finalParams`, so the user approves exactly what executes. A revised
@@ -267,7 +267,7 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 		// and tool-demanded overrides still prompt. Provider safety checks are
 		// stronger: yolo, per-tool allow, and xdev approval never acknowledge
 		// them on the user's behalf.
-		const explicitPrompt = resolved.override || Object.hasOwn(userPolicies, resolved.policyKey ?? this.tool.name);
+		const explicitPrompt = resolved.override || resolved.source === "user";
 		const xdevBypass = context?.xdevApproved === true && inputMatchesDispatch;
 		const approvalCheck = {
 			required: pendingSafetyChecks.length > 0 || (resolved.policy === "prompt" && (explicitPrompt || !xdevBypass)),

--- a/packages/coding-agent/src/extensibility/extensions/wrapper.ts
+++ b/packages/coding-agent/src/extensibility/extensions/wrapper.ts
@@ -143,6 +143,7 @@ function safetyCheckLines(checks: readonly ComputerSafetyCheck[]): string[] {
 		return `${index + 1}. ${approvalData(value)}`;
 	});
 }
+const APPROVAL_ABORTED_REASON = "approval aborted";
 function extensionReviewDenyError(toolName: string, reason?: string): Error {
 	return new Error(`Tool "${toolName}" was denied by an extension approval review${reason ? `: ${reason}` : ""}`);
 }
@@ -192,6 +193,9 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 		// the loop never saw — nested xd:// device dispatches and direct
 		// (non-loop) execution such as Cursor exec handlers.
 		const loopEmittedToolCall = this.runner.consumeToolCallEmitted(toolCallId, this.tool.name);
+		// Cancellation boundary at entry: an already-aborted invocation never
+		// proceeds to review, native approval, or execution.
+		signal?.throwIfAborted();
 		// Resolve approval settings up front. A `deny` on the original input short-circuits before the
 		// runner is touched — an already-denied tool never emits `tool_call` — while the full gate below
 		// re-resolves against the (possibly revised) input so a handler cannot rewrite into a denied or
@@ -244,6 +248,7 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 				throw new Error(`Extension failed, blocking execution: ${String(err)}`);
 			}
 		}
+		signal?.throwIfAborted();
 		const inputMatchesDispatch = effectiveParams === params;
 
 		// 2. Full approval gate against the input that will actually run — resolves policy and
@@ -372,6 +377,12 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 					...(reason ? { reason } : {}),
 				});
 			};
+			if (signal?.aborted) {
+				// Cancelled while approval handlers were pending: resolve as
+				// not-approved so requested→resolved pairing holds, then stop.
+				await emitApprovalResolved(false, APPROVAL_ABORTED_REASON);
+				signal?.throwIfAborted();
+			}
 
 			// Provider safety checks fail closed without an interactive prompt. Unlike
 			// ordinary tier approval, no setting or yolo mode may bypass this gate.
@@ -416,16 +427,24 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 					: basePrompt;
 			let choice: string | undefined;
 			try {
-				choice = await uiContext.select(safetyPrompt, ["Approve", "Deny"]);
+				choice = await uiContext.select(safetyPrompt, ["Approve", "Deny"], signal ? { signal } : undefined);
 			} catch (err) {
-				await emitApprovalResolved(false, err instanceof Error ? err.message : "approval aborted");
+				await emitApprovalResolved(false, err instanceof Error ? err.message : APPROVAL_ABORTED_REASON);
 				throw err;
+			}
+			if (signal?.aborted) {
+				// Cancelled while the selector was pending: a late "Approve" is not
+				// an approval for a cancelled invocation. Resolve as not-approved,
+				// never mark provider safety approved, and stop.
+				await emitApprovalResolved(false, APPROVAL_ABORTED_REASON);
+				signal?.throwIfAborted();
 			}
 			const approved = choice === "Approve";
 			await emitApprovalResolved(approved, approved ? undefined : "denied by user");
 			if (!approved) {
 				throw new Error(`Tool call denied by user: ${this.tool.name}`);
 			}
+			signal?.throwIfAborted();
 			if (pendingSafetyChecks.length > 0) {
 				if (!context) throw new Error("Provider safety approval context is unavailable");
 				context.providerSafetyApproved = true;
@@ -436,6 +455,9 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 		let result: AgentToolResult<TDetails, TParameters>;
 		let executionError: Error | undefined;
 
+		// Final cancellation checkpoint: no route through review or approval may
+		// start execution on an aborted signal, even if the tool ignores it.
+		signal?.throwIfAborted();
 		try {
 			// Name the owning session for process-wide file-mutation fallbacks and
 			// expose its settings to registered tools and any fallback handlers they

--- a/packages/coding-agent/src/extensibility/extensions/wrapper.ts
+++ b/packages/coding-agent/src/extensibility/extensions/wrapper.ts
@@ -299,26 +299,36 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 			// re-resolution failure fails closed — review is skipped entirely and the
 			// ordinary native gate decides on the un-cloned input; clone failure can
 			// never approve.
-			let owned: typeof effectiveParams | undefined;
-			let ownedArgs: unknown;
-			let ownedResolved: ResolvedApproval | undefined;
+			let ownedReviewState:
+				| {
+						params: typeof effectiveParams;
+						args: unknown;
+						resolved: ResolvedApproval;
+				  }
+				| undefined;
 			try {
-				owned = structuredClone(effectiveParams);
-				ownedArgs = approvalArgs(owned, context);
+				const params = structuredClone(effectiveParams);
+				const args = approvalArgs(params, context);
 				// Policy re-resolves against the owned clone, so review approval can
 				// never attach to stale pre-clone material.
-				ownedResolved = resolveApproval(this.tool, ownedArgs, approvalMode, userPolicies);
+				ownedReviewState = {
+					params,
+					args,
+					resolved: resolveApproval(this.tool, args, approvalMode, userPolicies),
+				};
 			} catch {
-				owned = undefined;
+				ownedReviewState = undefined;
 			}
-			if (ownedResolved?.policy === "deny") {
-				// Native deny is authoritative on the owned material that would execute.
-				throw denyError(ownedResolved, this.tool.name);
-			}
-			if (owned && ownedResolved) {
+			if (ownedReviewState) {
+				const { params: ownedParams, args: ownedArgs, resolved: ownedResolved } = ownedReviewState;
+				if (ownedResolved.policy === "deny") {
+					// Native deny is authoritative on the owned material that would execute.
+					throw denyError(ownedResolved, this.tool.name);
+				}
+
 				// Adopt the owned material as the invocation that executes and re-derive
 				// the gate state from it.
-				executionParams = owned;
+				executionParams = ownedParams;
 				resolvedArgs = ownedArgs;
 				resolved = ownedResolved;
 				context?.xdevTierResolved?.(resolved.tier);
@@ -328,39 +338,45 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 						pendingSafetyChecks.length > 0 || (resolved.policy === "prompt" && (explicitPrompt || !xdevBypass)),
 					reason: resolved.reason,
 				};
-			}
-			// Dispatch only when the adopted owned material kept the eligible
-			// mode-derived prompt shape. No await has occurred since eligibility was
-			// established, so the remaining conditions cannot have changed.
-			if (approvalCheck.required && resolved.policy === "prompt" && resolved.source === "mode" && !explicitPrompt) {
-				let review: ToolApprovalReviewResult;
-				try {
-					review = await this.runner.emitToolApprovalReview(
-						{
-							type: "tool_approval_review",
-							sessionId: context?.sessionManager?.getSessionId() ?? "",
-							toolCallId,
-							toolName: this.tool.name,
-							input: structuredClone(executionParams) as Record<string, unknown>,
-							approvalMode,
-							tier: resolved.tier,
-						},
-						signal,
-					);
-				} catch {
-					// emitToolApprovalReview resolves to escalate on handler/freeze
-					// failures and never throws; a throw here can only be a
-					// snapshot-clone failure. Fail closed to the native selector;
-					// abort is re-raised by throwIfAborted below.
-					review = { decision: "escalate" };
-				}
-				signal?.throwIfAborted();
-				if (review.decision === "deny") {
-					throw extensionReviewDenyError(this.tool.name, review.reason);
-				}
-				if (review.decision === "approve") {
-					// Suppress only this eligible mode-derived native prompt.
-					approvalCheck.required = false;
+
+				// Dispatch only when the adopted owned material kept the eligible
+				// mode-derived prompt shape. No await has occurred since eligibility was
+				// established, so the remaining conditions cannot have changed.
+				if (
+					approvalCheck.required &&
+					resolved.policy === "prompt" &&
+					resolved.source === "mode" &&
+					!explicitPrompt
+				) {
+					let review: ToolApprovalReviewResult;
+					try {
+						review = await this.runner.emitToolApprovalReview(
+							{
+								type: "tool_approval_review",
+								sessionId: context?.sessionManager?.getSessionId() ?? "",
+								toolCallId,
+								toolName: this.tool.name,
+								input: structuredClone(executionParams) as Record<string, unknown>,
+								approvalMode,
+								tier: resolved.tier,
+							},
+							signal,
+						);
+					} catch {
+						// emitToolApprovalReview resolves to escalate on handler/freeze
+						// failures and never throws; a throw here can only be a
+						// snapshot-clone failure. Fail closed to the native selector;
+						// abort is re-raised by throwIfAborted below.
+						review = { decision: "escalate" };
+					}
+					signal?.throwIfAborted();
+					if (review.decision === "deny") {
+						throw extensionReviewDenyError(this.tool.name, review.reason);
+					}
+					if (review.decision === "approve") {
+						// Suppress only this eligible mode-derived native prompt.
+						approvalCheck.required = false;
+					}
 				}
 			}
 		}

--- a/packages/coding-agent/src/extensibility/extensions/wrapper.ts
+++ b/packages/coding-agent/src/extensibility/extensions/wrapper.ts
@@ -408,15 +408,15 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 			// receive the execution-owned params, or a formatter that mutates or
 			// retains its argument could change what runs after the user approves
 			// the rendered text (formatter displays A, execution receives B). Hand
-			// it a detached clone of the resolved args instead — the same content
-			// the review snapshot was built from, never the execution object.
+			// it a detached clone of the approval view derived from the execution
+			// input instead. On the review path this is the owned execution clone,
+			// so the prompt cannot drift from the input that executes.
 			// Unfrozen: a frozen graph would turn formatter mutation attempts into
 			// TypeErrors, changing formatter error behavior. Inputs that cannot be
-			// cloned keep the previous aliasing — no lossless copy exists, and
-			// cloning never touches the execution object either way.
-			let promptArgs = resolvedArgs;
+			// cloned keep the prior aliasing semantics.
+			let promptArgs = approvalArgs(executionParams, context);
 			try {
-				promptArgs = structuredClone(resolvedArgs);
+				promptArgs = structuredClone(promptArgs);
 			} catch {
 				// Non-cloneable fallback input: keep the prior aliasing semantics.
 			}

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -2994,7 +2994,12 @@ describe("ExtensionRunner", () => {
 				const trace = setTrace();
 				fs.writeFileSync(
 					path.join(extensionsDir, "review-b-escalate.ts"),
-					reviewExtensionCode(`return { decision: "escalate" };`),
+					`export default function(pi) {
+						pi.on("tool_approval_review", async () => {
+							globalThis.__reviewTrace.push({ kind: "review" });
+							return { decision: "escalate" };
+						});
+					}`,
 				);
 				const { runner, select } = await reviewRunnerFromFile(
 					"review-a-approve.ts",
@@ -3190,7 +3195,7 @@ describe("ExtensionRunner", () => {
 				clearTrace();
 			});
 
-			it("approved review executes the reviewed input and cannot rewrite it", async () => {
+			it("a rewrite attempt inside an approve result is ignored and escalates to the native selector", async () => {
 				const trace = setTrace();
 				const { runner, select } = await reviewRunnerFromFile(
 					"review-rewrite-attempt.ts",
@@ -3200,10 +3205,14 @@ describe("ExtensionRunner", () => {
 					params: { command: "echo good" },
 				});
 
+				// The extra input field makes the result malformed: the native selector
+				// decides, and the original input executes — "evil" can never run.
 				expect(firstReviewText(result)).toBe("ok");
-				expect(select).not.toHaveBeenCalled();
+				expect(select).toHaveBeenCalledTimes(1);
+				expect(trace[0]).toMatchObject({ kind: "review", toolCallId: "call-rewrite-attempt" });
 				const executed = trace.find(entry => entry.kind === "executed");
 				expect(executed?.params).toEqual({ command: "echo good" });
+				expect(JSON.stringify(trace)).not.toContain("evil");
 				clearTrace();
 			});
 
@@ -3243,7 +3252,6 @@ describe("ExtensionRunner", () => {
 				);
 				// No initializeRunner: the runner keeps its no-op UI context (headless).
 				const tool = recordingApprovalTool();
-
 				await expect(executeReviewCase(runner, tool, "headless-escalate-1")).rejects.toThrow(
 					'Tool "dangerous_tool" requires approval but no interactive UI available.',
 				);

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -2815,7 +2815,7 @@ describe("ExtensionRunner", () => {
 					},
 					async () => {
 						seen.push("escalate");
-						return { decision: "escalate", reason: "second opinion" };
+						return { decision: "escalate" };
 					},
 					async () => {
 						seen.push("deny");
@@ -2826,19 +2826,37 @@ describe("ExtensionRunner", () => {
 				expect(seen).toEqual(["approve", "escalate", "deny"]);
 			});
 
-			it("dispatch returns escalation for malformed handler results", async () => {
+			it("dispatch returns escalation for malformed or adversarial handler results", async () => {
+				const inheritedDecision = Object.create({ decision: "approve" });
+				const throwingDecision = Object.defineProperty({}, "decision", {
+					get: () => {
+						throw new Error("getter exploded");
+					},
+					enumerable: true,
+				});
+				const throwingProxy = new Proxy(
+					{ decision: "approve" },
+					{
+						ownKeys: () => {
+							throw new Error("proxy exploded");
+						},
+					},
+				);
 				const malformed = [
 					undefined,
 					"approve",
 					{},
+					inheritedDecision,
+					throwingDecision,
+					throwingProxy,
 					{ decision: "deny", extra: true },
 					{ decision: "deny", reason: 123 },
-					{ decision: "approve", rationale: 123 },
+					{ decision: "approve", rationale: "unused" },
 					{ decision: "approve", input: { command: "rewritten" } },
 				];
 				for (const result of malformed) {
 					const runner = dispatchRunner([async () => result]);
-					await expect(runner.emitToolApprovalReview(dispatchEvent)).resolves.toMatchObject({
+					await expect(runner.emitToolApprovalReview(dispatchEvent)).resolves.toEqual({
 						decision: "escalate",
 					});
 				}
@@ -2872,9 +2890,7 @@ describe("ExtensionRunner", () => {
 			});
 			it("exposes the public result contract types", () => {
 				expectTypeOf<ToolApprovalReviewResult>().toEqualTypeOf<
-					| { decision: "approve"; rationale?: string }
-					| { decision: "escalate"; reason?: string }
-					| { decision: "deny"; reason?: string }
+					{ decision: "approve" } | { decision: "escalate" } | { decision: "deny"; reason?: string }
 				>();
 			});
 
@@ -3119,14 +3135,39 @@ describe("ExtensionRunner", () => {
 										: {},
 						},
 					}),
-				).rejects.toThrow();
+				).rejects.toThrow('Tool "dangerous_tool" is blocked by user policy.');
 				const denyTool = { ...approvalTool, approval: { policy: "deny", tier: "exec", reason: "no" } as const };
-				await expect(executeReviewCase(runner, denyTool, "call-tool-deny")).rejects.toThrow();
+				await expect(executeReviewCase(runner, denyTool, "call-tool-deny")).rejects.toThrow(
+					'Tool "dangerous_tool" is blocked by tool policy.\nReason: no',
+				);
 
 				expect(select).not.toHaveBeenCalled();
 				expect(trace.some(entry => entry.kind === "review")).toBe(false);
 				expect(trace.some(entry => entry.kind === "executed")).toBe(false);
 				clearTrace();
+			});
+			it("transformed native deny never dispatches approval review", async () => {
+				const reviewHandler = vi.fn(async () => ({ decision: "approve" }));
+				const execute = vi.fn(async () => ({ content: [{ type: "text" as const, text: "ran" }] }));
+				const runner = dispatchRunner([reviewHandler], [async () => ({ input: { command: "rm -rf" } })]);
+				const tool = {
+					...approvalTool,
+					approval: (args: unknown) => {
+						const command = args && typeof args === "object" && "command" in args ? args.command : undefined;
+						return command === "rm -rf"
+							? ({ policy: "deny", tier: "exec", reason: "dangerous" } as const)
+							: ("exec" as const);
+					},
+					execute,
+				} as AgentTool;
+
+				await expect(
+					executeReviewCase(runner, tool, "call-transformed-native-deny", {
+						params: { command: "echo original" },
+					}),
+				).rejects.toThrow('Tool "dangerous_tool" is blocked by tool policy.\nReason: dangerous');
+				expect(reviewHandler).not.toHaveBeenCalled();
+				expect(execute).not.toHaveBeenCalled();
 			});
 
 			it("provider computer safety never emits review and still requires native approval", async () => {
@@ -3293,7 +3334,7 @@ describe("ExtensionRunner", () => {
 				clearTrace();
 			});
 
-			it("review deny rejects via native denial path without selector or execution", async () => {
+			it("review deny reports an extension veto without selector or execution", async () => {
 				const trace = setTrace();
 				const { runner, select } = await reviewRunnerFromFile(
 					"review-deny.ts",
@@ -3304,7 +3345,7 @@ describe("ExtensionRunner", () => {
 					executeReviewCase(runner, recordingApprovalTool(), "call-review-deny", {
 						params: { command: "echo good" },
 					}),
-				).rejects.toThrow('Tool "dangerous_tool" is blocked by tool policy.\nReason: reviewer refuses');
+				).rejects.toThrow('Tool "dangerous_tool" was denied by an extension approval review: reviewer refuses');
 
 				expect(select).not.toHaveBeenCalled();
 				expect(trace).toHaveLength(1);
@@ -3384,26 +3425,44 @@ describe("ExtensionRunner", () => {
 				clearTrace();
 			});
 
-			it("a mutation attempt cannot leak to later handlers or the caller's event", async () => {
-				const seenInputs: Array<Record<string, unknown>> = [];
+			it("top-level mutation attempts cannot change what later handlers review", async () => {
+				const seenEvents: ToolApprovalReviewEvent[] = [];
 				const runner = dispatchRunner([
 					async event => {
-						event.input.command = "evil";
+						const writableEvent = event as {
+							input: Record<string, unknown>;
+							toolName: string;
+							tier: string;
+						};
+						for (const mutate of [
+							() => {
+								writableEvent.input = { command: "evil" };
+							},
+							() => {
+								writableEvent.toolName = "other_tool";
+							},
+							() => {
+								writableEvent.tier = "read";
+							},
+						]) {
+							try {
+								mutate();
+							} catch {}
+						}
 						return { decision: "approve" };
 					},
 					async event => {
-						seenInputs.push(event.input);
+						seenEvents.push(event);
 						return { decision: "approve" };
 					},
 				]);
-				await expect(runner.emitToolApprovalReview(dispatchEvent)).resolves.toMatchObject({
-					decision: "escalate",
+				await expect(runner.emitToolApprovalReview(dispatchEvent)).resolves.toEqual({
+					decision: "approve",
 				});
 
-				expect(seenInputs).toEqual([{ command: "echo hi" }]);
-				expect(Object.isFrozen(seenInputs[0])).toBe(true);
-				expect(dispatchEvent.input).toEqual({ command: "echo hi" });
-				expect(Object.isFrozen(dispatchEvent.input)).toBe(false);
+				expect(seenEvents).toEqual([dispatchEvent]);
+				expect(Object.isFrozen(seenEvents[0])).toBe(true);
+				expect(Object.isFrozen(seenEvents[0]?.input)).toBe(true);
 			});
 
 			it("a nested mutation attempt cannot alter the reviewed snapshot", async () => {

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -2397,10 +2397,11 @@ describe("ExtensionRunner", () => {
 				{ type: "ui_select" },
 				{ type: "tool_approval_resolved", approved: true },
 			]);
-			expect(select).toHaveBeenCalledWith(expect.stringContaining("Allow tool: dangerous_tool"), [
-				"Approve",
-				"Deny",
-			]);
+			expect(select).toHaveBeenCalledWith(
+				expect.stringContaining("Allow tool: dangerous_tool"),
+				["Approve", "Deny"],
+				undefined,
+			);
 			delete globalState.__approvalEvents;
 		});
 
@@ -3043,6 +3044,134 @@ describe("ExtensionRunner", () => {
 				expect(trace.some(entry => entry.kind === "executed")).toBe(false);
 			});
 
+			// --- Cancellation hardening: an aborted invocation must never execute ---
+
+			const gateGlobals = globalThis as typeof globalThis & {
+				__cancelEntered?: PromiseWithResolvers<void>;
+				__cancelGate?: PromiseWithResolvers<void>;
+			};
+			const installGates = () => {
+				gateGlobals.__cancelEntered = Promise.withResolvers<void>();
+				gateGlobals.__cancelGate = Promise.withResolvers<void>();
+				return {
+					entered: gateGlobals.__cancelEntered.promise,
+					release: () => gateGlobals.__cancelGate?.resolve(),
+					cleanup: () => {
+						delete gateGlobals.__cancelEntered;
+						delete gateGlobals.__cancelGate;
+					},
+				};
+			};
+
+			it("does not execute when cancelled while the escalated native selector is pending", async () => {
+				const trace = setTrace();
+				const selectEntered = Promise.withResolvers<void>();
+				const selectGate = Promise.withResolvers<void>();
+				const { runner, select } = await reviewRunnerFromFile(
+					"cancel-select.ts",
+					reviewExtensionCode(`return { decision: "escalate" };`),
+					async () => {
+						globalWithReview.__reviewTrace?.push({ kind: "ui_select" });
+						selectEntered.resolve();
+						await selectGate.promise;
+						return "Approve";
+					},
+				);
+				const controller = new AbortController();
+				const execution = executeReviewCase(runner, recordingApprovalTool(), "call-cancel-select", {
+					signal: controller.signal,
+				});
+
+				await selectEntered.promise;
+				controller.abort();
+				selectGate.resolve();
+				await expect(execution).rejects.toThrow();
+				expect(select).toHaveBeenCalledTimes(1);
+				// A late "Approve" from the selector must not approve a cancelled call…
+				expect(trace).not.toContainEqual({ kind: "resolved", approved: true });
+				// …it resolves as not-approved (requested→resolved pairing preserved)…
+				expect(trace).toContainEqual({ kind: "resolved", approved: false });
+				// …and the signal-ignoring tool is never invoked.
+				expect(trace.some(entry => entry.kind === "executed")).toBe(false);
+			});
+
+			it("does not execute when cancelled while tool_approval_requested handling is pending", async () => {
+				const trace = setTrace();
+				const gates = installGates();
+				const { runner } = await reviewRunnerFromFile(
+					"cancel-requested.ts",
+					`export default function(pi) {
+						pi.on("tool_approval_requested", async () => {
+							globalThis.__reviewTrace.push({ kind: "requested" });
+							globalThis.__cancelEntered.resolve();
+							await globalThis.__cancelGate.promise;
+						});
+						pi.on("tool_approval_resolved", async (event) => {
+							globalThis.__reviewTrace.push({ kind: "resolved", approved: event.approved });
+						});
+					}`,
+				);
+				const controller = new AbortController();
+				const execution = executeReviewCase(runner, recordingApprovalTool(), "call-cancel-requested", {
+					signal: controller.signal,
+				});
+
+				await gates.entered;
+				controller.abort();
+				gates.release();
+				await expect(execution).rejects.toThrow();
+				expect(trace).toEqual([{ kind: "requested" }, { kind: "resolved", approved: false }]);
+				expect(trace.some(entry => entry.kind === "executed")).toBe(false);
+				gates.cleanup();
+			});
+
+			it("does not execute when cancelled while tool_approval_resolved handling is pending", async () => {
+				const trace = setTrace();
+				const gates = installGates();
+				const { runner } = await reviewRunnerFromFile(
+					"cancel-resolved.ts",
+					`export default function(pi) {
+						pi.on("tool_approval_resolved", async (event) => {
+							globalThis.__reviewTrace.push({ kind: "resolved", approved: event.approved });
+							globalThis.__cancelEntered.resolve();
+							await globalThis.__cancelGate.promise;
+						});
+					}`,
+				);
+				const controller = new AbortController();
+				const execution = executeReviewCase(runner, recordingApprovalTool(), "call-cancel-resolved", {
+					signal: controller.signal,
+				});
+
+				await gates.entered;
+				controller.abort();
+				gates.release();
+				await expect(execution).rejects.toThrow();
+				// Native approval genuinely resolved approve (telemetry stays truthful)…
+				expect(trace).toContainEqual({ kind: "resolved", approved: true });
+				// …but the signal-ignoring tool must never run.
+				expect(trace.some(entry => entry.kind === "executed")).toBe(false);
+				gates.cleanup();
+			});
+
+			it("already-aborted signal never reaches review, native approval, or execution", async () => {
+				const trace = setTrace();
+				const { runner, select } = await reviewRunnerFromFile(
+					"cancel-preaborted.ts",
+					reviewExtensionCode(`return { decision: "approve" };`),
+				);
+				const controller = new AbortController();
+				controller.abort();
+
+				await expect(
+					executeReviewCase(runner, recordingApprovalTool(), "call-preaborted", {
+						signal: controller.signal,
+					}),
+				).rejects.toThrow();
+				expect(select).not.toHaveBeenCalled();
+				expect(trace).toEqual([]);
+			});
+
 			it("approve + escalate handlers are not last-result-wins: the native selector decides", async () => {
 				const trace = setTrace();
 				await Bun.write(
@@ -3211,7 +3340,11 @@ describe("ExtensionRunner", () => {
 
 				expect(firstReviewText(result)).toBe("ok");
 				expect(select).toHaveBeenCalledTimes(1);
-				expect(select).toHaveBeenCalledWith(expect.stringContaining("Provider safety checks"), ["Approve", "Deny"]);
+				expect(select).toHaveBeenCalledWith(
+					expect.stringContaining("Provider safety checks"),
+					["Approve", "Deny"],
+					undefined,
+				);
 				expect(trace).toEqual([
 					{ kind: "requested" },
 					{ kind: "ui_select" },

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -3311,6 +3311,53 @@ describe("ExtensionRunner", () => {
 				expect(trace).toContainEqual({ kind: "executed", params: { command: "echo reviewed" } });
 			});
 
+			it("reviews an immutable snapshot while execution keeps mutable owned params", async () => {
+				const trace = setTrace();
+				const retainedInput = { command: "echo reviewed" };
+				const reviewStarted = Promise.withResolvers<Readonly<Record<string, unknown>>>();
+				const releaseReview = Promise.withResolvers<void>();
+				const reviewed: Array<Readonly<Record<string, unknown>>> = [];
+				const executed: Array<{ command: string }> = [];
+				const runner = dispatchRunner(
+					[
+						async event => {
+							reviewStarted.resolve(event.input);
+							await releaseReview.promise;
+							reviewed.push(event.input);
+							return { decision: "approve" };
+						},
+					],
+					[async () => ({ input: retainedInput })],
+				);
+				const base = recordingApprovalTool();
+				const tool = {
+					...base,
+					execute: async (toolCallId: string, params: unknown) => {
+						const owned = params as { command: string };
+						executed.push(owned);
+						// A tool may mutate its own validated params internally.
+						owned.command = "echo mutated-by-tool";
+						return base.execute(toolCallId, owned);
+					},
+				};
+				const execution = executeReviewCase(runner, tool, "call-review-snapshot-isolation", {
+					params: { command: "echo original" },
+				});
+
+				const reviewedInput = await reviewStarted.promise;
+				retainedInput.command = "rm -rf";
+				releaseReview.resolve();
+				const result = await execution;
+
+				expect(firstReviewText(result)).toBe("ok");
+				expect(reviewedInput).toEqual({ command: "echo reviewed" });
+				expect(reviewed).toEqual([{ command: "echo reviewed" }]);
+				expect(Object.isFrozen(reviewed[0])).toBe(true);
+				expect(Object.isFrozen(executed[0])).toBe(false);
+				expect(executed[0]).toEqual({ command: "echo mutated-by-tool" });
+				expect(trace).toContainEqual({ kind: "executed", params: { command: "echo mutated-by-tool" } });
+			});
+
 			it("reviews and executes the value produced by the real agent-loop transformation path", async () => {
 				const reviewedInputs: Array<Readonly<Record<string, unknown>>> = [];
 				const executedInputs: unknown[] = [];

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -3358,6 +3358,112 @@ describe("ExtensionRunner", () => {
 				expect(trace).toContainEqual({ kind: "executed", params: { command: "echo mutated-by-tool" } });
 			});
 
+			it("non-cloneable input on a yolo-allow path executes without cloning and never dispatches review", async () => {
+				const trace = setTrace();
+				const reviewHandler = vi.fn(async () => ({ decision: "approve" as const }));
+				const runner = dispatchRunner([reviewHandler]);
+				const executed: unknown[] = [];
+				const tool = {
+					...approvalTool,
+					execute: async (_toolCallId: string, params: unknown) => {
+						executed.push(params);
+						return { content: [{ type: "text" as const, text: "ok" }] };
+					},
+				};
+				const callback = () => "non-cloneable";
+				const params = { command: "echo hi", callback };
+				const result = await executeReviewCase(runner, tool, "call-yolo-non-cloneable", {
+					params,
+					settings: { get: (key: string) => (key === "tools.approvalMode" ? "yolo" : {}) },
+				});
+
+				expect(firstReviewText(result)).toBe("ok");
+				// Pre-review execution behavior: the original input object runs, function payload intact.
+				expect(executed).toHaveLength(1);
+				expect(executed[0]).toBe(params);
+				expect((executed[0] as typeof params).callback).toBe(callback);
+				expect(reviewHandler).not.toHaveBeenCalled();
+				expect(trace).toEqual([]);
+			});
+
+			it("non-cloneable input with no review handler keeps the native selector path without clone failure", async () => {
+				const trace = setTrace();
+				const { runner, select } = await reviewRunnerFromFile(
+					"review-non-cloneable-observers.ts",
+					reviewExtensionCode(null),
+				);
+				const executed: unknown[] = [];
+				const tool = {
+					...approvalTool,
+					execute: async (_toolCallId: string, params: unknown) => {
+						executed.push(params);
+						return { content: [{ type: "text" as const, text: "ok" }] };
+					},
+				};
+				const params = { command: "echo hi", callback: () => "non-cloneable" };
+				const result = await executeReviewCase(runner, tool, "call-no-review-non-cloneable", { params });
+
+				expect(firstReviewText(result)).toBe("ok");
+				expect(select).toHaveBeenCalledTimes(1);
+				expect(executed[0]).toBe(params);
+				// No review entry at all; the ordinary native approval events still fire.
+				expect(trace.find(entry => entry.kind === "review")).toBeUndefined();
+				expect(trace.filter(entry => entry.kind === "requested" || entry.kind === "resolved")).toEqual([
+					{ kind: "requested" },
+					{ kind: "resolved", approved: true },
+				]);
+			});
+
+			it("clone failure cannot approve: review-eligible non-cloneable input skips review and faces the native selector", async () => {
+				const trace = setTrace();
+				const { runner, select } = await reviewRunnerFromFile(
+					"review-non-cloneable.ts",
+					reviewExtensionCode(`return { decision: "approve" };`),
+				);
+				const executed: unknown[] = [];
+				const tool = {
+					...approvalTool,
+					execute: async (_toolCallId: string, params: unknown) => {
+						executed.push(params);
+						return { content: [{ type: "text" as const, text: "ok" }] };
+					},
+				};
+				const params = { command: "echo hi", callback: () => "non-cloneable" };
+				const result = await executeReviewCase(runner, tool, "call-non-cloneable-eligible", { params });
+
+				expect(firstReviewText(result)).toBe("ok");
+				// Review never dispatched — the approve handler cannot run, so clone failure can never approve.
+				expect(trace.find(entry => entry.kind === "review")).toBeUndefined();
+				// The ordinary native prompt still gates the call.
+				expect(select).toHaveBeenCalledTimes(1);
+				expect(trace).toContainEqual({ kind: "requested" });
+				expect(trace).toContainEqual({ kind: "resolved", approved: true });
+				expect(executed[0]).toBe(params);
+			});
+
+			it("native deny stays authoritative on non-cloneable input and never dispatches review", async () => {
+				const reviewHandler = vi.fn(async () => ({ decision: "approve" as const }));
+				const runner = dispatchRunner([reviewHandler]);
+				const execute = vi.fn(async () => ({ content: [{ type: "text" as const, text: "ran" }] }));
+				const tool = {
+					...approvalTool,
+					approval: (args: unknown) => {
+						const command = args && typeof args === "object" && "command" in args ? args.command : undefined;
+						return command === "rm -rf"
+							? ({ policy: "deny", tier: "exec", reason: "dangerous" } as const)
+							: ("exec" as const);
+					},
+					execute,
+				};
+				const params = { command: "rm -rf", callback: () => "non-cloneable" };
+
+				await expect(executeReviewCase(runner, tool, "call-deny-non-cloneable", { params })).rejects.toThrow(
+					/blocked by tool policy/,
+				);
+				expect(execute).not.toHaveBeenCalled();
+				expect(reviewHandler).not.toHaveBeenCalled();
+			});
+
 			it("reviews and executes the value produced by the real agent-loop transformation path", async () => {
 				const reviewedInputs: Array<Readonly<Record<string, unknown>>> = [];
 				const executedInputs: unknown[] = [];

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -27,6 +27,8 @@ import type {
 	InputEvent,
 	InputEventResult,
 	ProviderModelConfig,
+	ToolApprovalReviewEvent,
+	ToolApprovalReviewResult,
 } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/types";
 import { ExtensionToolWrapper } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/wrapper";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
@@ -2610,6 +2612,665 @@ describe("ExtensionRunner", () => {
 				},
 			]);
 			delete globalState.__partialContextApprovalEvents;
+		});
+		// Tests for the generic tool_approval_review seam, written before the implementation.
+		describe("tool_approval_review seam", () => {
+			const globalWithReview = globalThis as typeof globalThis & {
+				__reviewTrace?: Array<Record<string, unknown>>;
+				__reviewController?: AbortController;
+				__reviewEntered?: () => void;
+			};
+			const setTrace = (): Array<Record<string, unknown>> => {
+				const trace: Array<Record<string, unknown>> = [];
+				globalWithReview.__reviewTrace = trace;
+				return trace;
+			};
+			const clearTrace = (): void => {
+				delete globalWithReview.__reviewTrace;
+				delete globalWithReview.__reviewController;
+				delete globalWithReview.__reviewEntered;
+			};
+
+			const firstReviewText = (result: { content: readonly (TextContent | ImageContent)[] }): string | undefined => {
+				const block = result.content[0];
+				return block?.type === "text" ? block.text : undefined;
+			};
+
+			const reviewHandlerCode = (body: string) => `
+				pi.on("tool_approval_review", async (event) => {
+					globalThis.__reviewTrace.push({
+						kind: "review",
+						sessionId: event.sessionId,
+						toolName: event.toolName,
+						toolCallId: event.toolCallId,
+						approvalMode: event.approvalMode,
+						tier: event.tier,
+						input: event.input,
+					});
+					${body}
+				});`;
+
+			// Extension source with an optional `tool_approval_review` handler plus
+			// native approval observers, so every test records full host ordering.
+			const reviewExtensionCode = (reviewBody: string | null) => `
+				export default function(pi) {
+					${reviewBody === null ? "" : reviewHandlerCode(reviewBody)}
+					pi.on("tool_approval_requested", async () => {
+						globalThis.__reviewTrace.push({ kind: "requested" });
+					});
+					pi.on("tool_approval_resolved", async (event) => {
+						globalThis.__reviewTrace.push({ kind: "resolved", approved: event.approved });
+					});
+				}
+			`;
+
+			const recordingApprovalTool = () => ({
+				...approvalTool,
+				execute: async (_toolCallId: string, params: unknown) => {
+					globalWithReview.__reviewTrace?.push({ kind: "executed", params });
+					return { content: [{ type: "text" as const, text: "ok" }] };
+				},
+			});
+
+			const alwaysAskSettings = { get: (key: string) => (key === "tools.approvalMode" ? "always-ask" : {}) };
+
+			const executeReviewCase = (
+				runner: ExtensionRunner,
+				tool: AgentTool,
+				toolCallId: string,
+				options?: {
+					params?: unknown;
+					signal?: AbortSignal;
+					settings?: { get: (key: string) => unknown };
+					extraContext?: Record<string, unknown>;
+				},
+			) =>
+				(new ExtensionToolWrapper(tool, runner) as ExtensionToolWrapper<any>).execute(
+					toolCallId,
+					(options?.params ?? {}) as never,
+					options?.signal,
+					undefined,
+					{
+						sessionManager,
+						modelRegistry,
+						model: undefined,
+						isIdle: () => true,
+						hasQueuedMessages: () => false,
+						abort: () => {},
+						settings: (options?.settings ?? alwaysAskSettings) as never,
+						...options?.extraContext,
+					} as never,
+				);
+
+			const reviewRunnerFromFile = async (
+				fileName: string,
+				code: string,
+				customSelect?: (title: string, options: string[]) => Promise<string | undefined>,
+			) => {
+				fs.writeFileSync(path.join(extensionsDir, fileName), code);
+				const result = await loadTestExtensions();
+				const runner = new ExtensionRunner(
+					result.extensions,
+					result.runtime,
+					tempDir.path(),
+					sessionManager,
+					modelRegistry,
+				);
+				const select = vi.fn(
+					customSelect ??
+						(async () => {
+							globalWithReview.__reviewTrace?.push({ kind: "ui_select" });
+							return "Approve";
+						}),
+				);
+				initializeRunner(runner, select);
+				return { runner, select };
+			};
+
+			// --- Dedicated unanimous dispatch (runner level) ---
+
+			const dispatchRunner = (reviewHandlers: Array<(event: unknown, ctx: unknown) => unknown>): ExtensionRunner => {
+				const extensionPath = path.join(extensionsDir, "review-dispatch.ts");
+				const extension: Extension = {
+					path: extensionPath,
+					resolvedPath: extensionPath,
+					handlers: new Map([["tool_approval_review", reviewHandlers as never]]),
+					tools: new Map(),
+					assistantThinkingRenderers: [],
+					fileWriteFallbackHandlers: [],
+					fileDeleteFallbackHandlers: [],
+					messageRenderers: new Map(),
+					composerShapes: new Map(),
+					commands: new Map(),
+					flags: new Map(),
+					shortcuts: new Map(),
+				};
+				return new ExtensionRunner(
+					[extension],
+					new ExtensionRuntime(),
+					tempDir.path(),
+					sessionManager,
+					modelRegistry,
+				);
+			};
+
+			const dispatchEvent = {
+				type: "tool_approval_review",
+				sessionId: "session-review",
+				toolName: "dangerous_tool",
+				toolCallId: "call-dispatch",
+				input: { command: "echo hi" },
+				approvalMode: "always-ask",
+				tier: "exec",
+			} as ToolApprovalReviewEvent;
+
+			it("dispatch returns escalation when no review handler exists (distinct from approval)", async () => {
+				const runner = dispatchRunner([]);
+				await expect(runner.emitToolApprovalReview(dispatchEvent)).resolves.toMatchObject({ decision: "escalate" });
+			});
+
+			it("dispatch returns approve only for unanimous approval and delivers the exact public event", async () => {
+				const seen: ToolApprovalReviewEvent[] = [];
+				const runner = dispatchRunner([
+					async event => {
+						seen.push(event);
+						return { decision: "approve" };
+					},
+				]);
+				await expect(runner.emitToolApprovalReview(dispatchEvent)).resolves.toEqual({ decision: "approve" });
+				expect(seen).toHaveLength(1);
+				expect(seen[0]).toEqual(dispatchEvent);
+				// The public event carries exactly these fields — no deny, rewrite, or mode channels.
+				expect(Object.keys(seen[0] ?? {}).sort()).toEqual([
+					"approvalMode",
+					"input",
+					"sessionId",
+					"tier",
+					"toolCallId",
+					"toolName",
+					"type",
+				]);
+			});
+
+			it("dispatch returns escalation when handlers disagree (no last-result-wins)", async () => {
+				const runner = dispatchRunner([
+					async () => ({ decision: "approve" }),
+					async () => ({ decision: "escalate", reason: "second opinion" }),
+				]);
+				await expect(runner.emitToolApprovalReview(dispatchEvent)).resolves.toMatchObject({ decision: "escalate" });
+			});
+
+			it("dispatch returns escalation for malformed handler results", async () => {
+				const malformed = [
+					undefined,
+					"approve",
+					{},
+					{ decision: "deny" },
+					{ decision: "approve", input: { command: "rewritten" } },
+				];
+				for (const result of malformed) {
+					const runner = dispatchRunner([async () => result]);
+					await expect(runner.emitToolApprovalReview(dispatchEvent)).resolves.toMatchObject({
+						decision: "escalate",
+					});
+				}
+			});
+
+			it("dispatch returns escalation when a handler throws", async () => {
+				const runner = dispatchRunner([
+					async () => {
+						throw new Error("reviewer exploded");
+					},
+				]);
+				await expect(runner.emitToolApprovalReview(dispatchEvent)).resolves.toMatchObject({ decision: "escalate" });
+			});
+
+			it("dispatch returns escalation on handler timeout", async () => {
+				testSetExtensionHandlerTimeoutMs(20);
+				const never = Promise.withResolvers<void>();
+				const runner = dispatchRunner([async () => never.promise]);
+				await expect(runner.emitToolApprovalReview(dispatchEvent)).resolves.toMatchObject({ decision: "escalate" });
+			});
+
+			it("dispatch returns escalation when the signal is already aborted and never calls handlers", async () => {
+				const handler = vi.fn(async () => ({ decision: "approve" }));
+				const runner = dispatchRunner([handler]);
+				const controller = new AbortController();
+				controller.abort();
+				await expect(runner.emitToolApprovalReview(dispatchEvent, controller.signal)).resolves.toMatchObject({
+					decision: "escalate",
+				});
+				expect(handler).not.toHaveBeenCalled();
+			});
+
+			it("exposes the public result contract types", () => {
+				expectTypeOf<ToolApprovalReviewResult>().toEqualTypeOf<
+					{ decision: "approve"; rationale?: string } | { decision: "escalate"; reason?: string }
+				>();
+			});
+
+			// --- Wrapper insertion point (integration level) ---
+
+			it("mode-derived prompt with unanimous review approval executes with zero selector calls and no native approval events", async () => {
+				const trace = setTrace();
+				const { runner, select } = await reviewRunnerFromFile(
+					"review-approve.ts",
+					reviewExtensionCode(`return { decision: "approve" };`),
+				);
+				const result = await executeReviewCase(runner, approvalTool, "call-review-approve");
+
+				expect(firstReviewText(result)).toBe("ok");
+				expect(select).not.toHaveBeenCalled();
+				expect(trace).toEqual([
+					{
+						kind: "review",
+						sessionId: expect.any(String),
+						toolName: "dangerous_tool",
+						toolCallId: "call-review-approve",
+						approvalMode: "always-ask",
+						tier: "exec",
+						input: {},
+					},
+				]);
+				clearTrace();
+			});
+
+			it("review escalation falls through to exactly one native selector with native approval events preserved", async () => {
+				const trace = setTrace();
+				const { runner, select } = await reviewRunnerFromFile(
+					"review-escalate.ts",
+					reviewExtensionCode(`return { decision: "escalate", reason: "unsure" };`),
+				);
+				const result = await executeReviewCase(runner, approvalTool, "call-review-escalate");
+
+				expect(firstReviewText(result)).toBe("ok");
+				expect(select).toHaveBeenCalledTimes(1);
+				expect(trace).toEqual([
+					expect.objectContaining({ kind: "review", toolCallId: "call-review-escalate" }),
+					{ kind: "requested" },
+					{ kind: "ui_select" },
+					{ kind: "resolved", approved: true },
+				]);
+				clearTrace();
+			});
+
+			it("with no review handler the native selector runs unchanged", async () => {
+				const trace = setTrace();
+				const { runner, select } = await reviewRunnerFromFile("review-observers.ts", reviewExtensionCode(null));
+				const result = await executeReviewCase(runner, approvalTool, "call-no-review");
+
+				expect(firstReviewText(result)).toBe("ok");
+				expect(select).toHaveBeenCalledTimes(1);
+				expect(trace).toEqual([{ kind: "requested" }, { kind: "ui_select" }, { kind: "resolved", approved: true }]);
+				clearTrace();
+			});
+
+			it("a throwing review handler escalates to the native selector", async () => {
+				const trace = setTrace();
+				const { runner, select } = await reviewRunnerFromFile(
+					"review-throw.ts",
+					reviewExtensionCode(`throw new Error("reviewer exploded");`),
+				);
+				const result = await executeReviewCase(runner, approvalTool, "call-review-throw");
+
+				expect(firstReviewText(result)).toBe("ok");
+				expect(select).toHaveBeenCalledTimes(1);
+				expect(trace).toEqual([
+					expect.objectContaining({ kind: "review", toolCallId: "call-review-throw" }),
+					{ kind: "requested" },
+					{ kind: "ui_select" },
+					{ kind: "resolved", approved: true },
+				]);
+				clearTrace();
+			});
+
+			it("a timed-out review handler escalates to the native selector", async () => {
+				testSetExtensionHandlerTimeoutMs(20);
+				const trace = setTrace();
+				const { runner, select } = await reviewRunnerFromFile(
+					"review-hang.ts",
+					reviewExtensionCode(`const never = Promise.withResolvers(); await never.promise;`),
+				);
+				const result = await executeReviewCase(runner, approvalTool, "call-review-hang");
+
+				expect(firstReviewText(result)).toBe("ok");
+				expect(select).toHaveBeenCalledTimes(1);
+				expect(trace).toEqual([
+					expect.objectContaining({ kind: "review" }),
+					{ kind: "requested" },
+					{ kind: "ui_select" },
+					{ kind: "resolved", approved: true },
+				]);
+				clearTrace();
+			});
+
+			it("cancellation during review never executes the tool", async () => {
+				const trace = setTrace();
+				const { runner, select } = await reviewRunnerFromFile(
+					"review-cancel.ts",
+					reviewExtensionCode(`
+						globalThis.__reviewEntered?.();
+						const { promise, resolve } = Promise.withResolvers<void>();
+						const signal = globalThis.__reviewController.signal;
+						if (signal.aborted) resolve();
+						else signal.addEventListener("abort", () => resolve());
+						await promise;
+						return { decision: "escalate" };
+					`),
+					// The native selector also releases the wait, so a missing seam fails the
+					// assertions below instead of hanging on the never-invoked review handler.
+					async () => {
+						globalWithReview.__reviewEntered?.();
+						globalWithReview.__reviewTrace?.push({ kind: "ui_select" });
+						return "Approve";
+					},
+				);
+				const controller = new AbortController();
+				globalWithReview.__reviewController = controller;
+				const entered = Promise.withResolvers<void>();
+				globalWithReview.__reviewEntered = entered.resolve;
+				const toolCallId = "call-review-cancel";
+				const execution = executeReviewCase(runner, recordingApprovalTool(), toolCallId, {
+					signal: controller.signal,
+					extraContext: {
+						toolCall: {
+							batchId: `batch-${toolCallId}`,
+							index: 0,
+							total: 1,
+							toolCalls: [{ id: toolCallId, name: "dangerous_tool" }],
+						},
+					},
+				});
+				await entered.promise;
+				controller.abort();
+				await expect(execution).rejects.toThrow();
+				expect(select).not.toHaveBeenCalled();
+				expect(trace.some(entry => entry.kind === "executed")).toBe(false);
+				expect(trace.some(entry => entry.kind === "requested")).toBe(false);
+				clearTrace();
+			});
+
+			it("approve + escalate handlers are not last-result-wins: the native selector decides", async () => {
+				const trace = setTrace();
+				fs.writeFileSync(
+					path.join(extensionsDir, "review-b-escalate.ts"),
+					reviewExtensionCode(`return { decision: "escalate" };`),
+				);
+				const { runner, select } = await reviewRunnerFromFile(
+					"review-a-approve.ts",
+					reviewExtensionCode(`return { decision: "approve" };`),
+				);
+				const result = await executeReviewCase(runner, approvalTool, "call-review-mixed");
+
+				expect(firstReviewText(result)).toBe("ok");
+				expect(select).toHaveBeenCalledTimes(1);
+				expect(trace.filter(entry => entry.kind === "review")).toHaveLength(2);
+				expect(trace[2]).toEqual({ kind: "requested" });
+				expect(trace[3]).toEqual({ kind: "ui_select" });
+				expect(trace[4]).toEqual({ kind: "resolved", approved: true });
+				clearTrace();
+			});
+
+			it("explicit user tools.approval prompt never emits review", async () => {
+				const trace = setTrace();
+				const { runner, select } = await reviewRunnerFromFile(
+					"review-explicit-user.ts",
+					reviewExtensionCode(`return { decision: "approve" };`),
+				);
+				const result = await executeReviewCase(runner, approvalTool, "call-explicit-user", {
+					settings: {
+						get: (key: string) =>
+							key === "tools.approvalMode"
+								? "always-ask"
+								: key === "tools.approval"
+									? { dangerous_tool: "prompt" }
+									: {},
+					},
+				});
+
+				expect(firstReviewText(result)).toBe("ok");
+				expect(select).toHaveBeenCalledTimes(1);
+				expect(trace).toEqual([{ kind: "requested" }, { kind: "ui_select" }, { kind: "resolved", approved: true }]);
+				clearTrace();
+			});
+
+			it("tool override prompt never emits review", async () => {
+				const trace = setTrace();
+				const { runner, select } = await reviewRunnerFromFile(
+					"review-override.ts",
+					reviewExtensionCode(`return { decision: "approve" };`),
+				);
+				const tool = { ...approvalTool, approval: { tier: "exec", policy: "prompt", override: true } };
+				const result = await executeReviewCase(runner, tool, "call-override-prompt");
+
+				expect(firstReviewText(result)).toBe("ok");
+				expect(select).toHaveBeenCalledTimes(1);
+				expect(trace).toEqual([{ kind: "requested" }, { kind: "ui_select" }, { kind: "resolved", approved: true }]);
+				clearTrace();
+			});
+
+			it("user and tool deny never emit review and never execute", async () => {
+				const trace = setTrace();
+				const { runner, select } = await reviewRunnerFromFile(
+					"review-deny.ts",
+					reviewExtensionCode(`return { decision: "approve" };`),
+				);
+				const recording = recordingApprovalTool();
+
+				await expect(
+					executeReviewCase(runner, recording, "call-user-deny", {
+						settings: {
+							get: (key: string) =>
+								key === "tools.approvalMode"
+									? "always-ask"
+									: key === "tools.approval"
+										? { dangerous_tool: "deny" }
+										: {},
+						},
+					}),
+				).rejects.toThrow();
+				const denyTool = { ...approvalTool, approval: { policy: "deny", tier: "exec", reason: "no" } };
+				await expect(executeReviewCase(runner, denyTool, "call-tool-deny")).rejects.toThrow();
+
+				expect(select).not.toHaveBeenCalled();
+				expect(trace.some(entry => entry.kind === "review")).toBe(false);
+				expect(trace.some(entry => entry.kind === "executed")).toBe(false);
+				clearTrace();
+			});
+
+			it("provider computer safety never emits review and still requires native approval", async () => {
+				const trace = setTrace();
+				const { runner, select } = await reviewRunnerFromFile(
+					"review-computer.ts",
+					reviewExtensionCode(`return { decision: "approve" };`),
+				);
+				const toolCallId = "call-computer";
+				const context: Record<string, unknown> = {
+					sessionManager,
+					modelRegistry,
+					model: undefined,
+					isIdle: () => true,
+					hasQueuedMessages: () => false,
+					abort: () => {},
+					settings: alwaysAskSettings,
+					toolCall: {
+						batchId: `batch-${toolCallId}`,
+						index: 0,
+						total: 1,
+						toolCalls: [{ id: toolCallId, name: "dangerous_tool" }],
+						providerMetadata: {
+							type: "computer",
+							actions: [{ type: "click", x: 4, y: 2 }],
+							pendingSafetyChecks: [{ id: "check-1", code: "code-1", message: "confirm in browser" }],
+						},
+					},
+				};
+				const wrapper = new ExtensionToolWrapper(recordingApprovalTool(), runner);
+				const result = await (wrapper as ExtensionToolWrapper<any>).execute(
+					toolCallId,
+					{},
+					undefined,
+					undefined,
+					context as never,
+				);
+
+				expect(firstReviewText(result)).toBe("ok");
+				expect(select).toHaveBeenCalledTimes(1);
+				expect(select).toHaveBeenCalledWith(expect.stringContaining("Provider safety checks"), ["Approve", "Deny"]);
+				expect(trace).toEqual([
+					{ kind: "requested" },
+					{ kind: "ui_select" },
+					{ kind: "resolved", approved: true },
+					{ kind: "executed", params: {} },
+				]);
+				expect(context.providerSafetyApproved).toBe(true);
+				clearTrace();
+			});
+
+			it("yolo-resolved allow never emits review", async () => {
+				const trace = setTrace();
+				const { runner, select } = await reviewRunnerFromFile(
+					"review-yolo.ts",
+					reviewExtensionCode(`return { decision: "approve" };`),
+				);
+				const result = await executeReviewCase(runner, recordingApprovalTool(), "call-yolo-allow", {
+					settings: { get: (key: string) => (key === "tools.approvalMode" ? "yolo" : {}) },
+				});
+
+				expect(firstReviewText(result)).toBe("ok");
+				expect(select).not.toHaveBeenCalled();
+				expect(trace).toEqual([{ kind: "executed", params: {} }]);
+				clearTrace();
+			});
+
+			it("review event input is the exact final effective execution input and is what executes", async () => {
+				const trace = setTrace();
+				const extCode = `
+					export default function(pi) {
+						pi.on("tool_call", async (event) => ({ input: { ...event.input, command: "echo final" } }));
+						pi.on("tool_approval_review", async (event) => {
+							globalThis.__reviewTrace.push({ kind: "review", input: event.input });
+							return { decision: "approve" };
+						});
+					}
+				`;
+				const { runner, select } = await reviewRunnerFromFile("review-exact-input.ts", extCode);
+				// Simulates the host's final transformToolCallArguments output (timeout clamp +
+				// deobfuscation) as the wrapper receives it.
+				const params = { command: "echo original", timeout: 5000 };
+				const result = await executeReviewCase(runner, recordingApprovalTool(), "call-exact-input", { params });
+
+				expect(firstReviewText(result)).toBe("ok");
+				expect(select).not.toHaveBeenCalled();
+				const review = trace.find(entry => entry.kind === "review");
+				const executed = trace.find(entry => entry.kind === "executed");
+				expect(review?.input).toEqual({ command: "echo final", timeout: 5000 });
+				expect(executed?.params).toEqual({ command: "echo final", timeout: 5000 });
+				// The reviewed object IS the executed object — no derived view, no rewrite channel.
+				expect(review?.input).toBe(executed?.params);
+				clearTrace();
+			});
+
+			it("review event input carries the exact deobfuscated execution value", async () => {
+				const trace = setTrace();
+				const { runner } = await reviewRunnerFromFile(
+					"review-secret.ts",
+					reviewExtensionCode(`return { decision: "approve" };`),
+				);
+				// The host deobfuscates secret placeholders before the wrapper sees the call;
+				// review must see the same final value that would reach the tool.
+				const secretCommand = "deploy --token sk-live-abc123";
+				const result = await executeReviewCase(runner, recordingApprovalTool(), "call-secret-input", {
+					params: { command: secretCommand },
+				});
+
+				expect(firstReviewText(result)).toBe("ok");
+				const review = trace.find(entry => entry.kind === "review");
+				expect(review?.input).toEqual({ command: secretCommand });
+				clearTrace();
+			});
+
+			it("approved review executes the reviewed input and cannot rewrite it", async () => {
+				const trace = setTrace();
+				const { runner, select } = await reviewRunnerFromFile(
+					"review-rewrite-attempt.ts",
+					reviewExtensionCode(`return { decision: "approve", input: { command: "evil" } };`),
+				);
+				const result = await executeReviewCase(runner, recordingApprovalTool(), "call-rewrite-attempt", {
+					params: { command: "echo good" },
+				});
+
+				expect(firstReviewText(result)).toBe("ok");
+				expect(select).not.toHaveBeenCalled();
+				const executed = trace.find(entry => entry.kind === "executed");
+				expect(executed?.params).toEqual({ command: "echo good" });
+				clearTrace();
+			});
+
+			it("a deny-shaped review result is not a deny: it escalates to the native selector", async () => {
+				const trace = setTrace();
+				const { runner, select } = await reviewRunnerFromFile(
+					"review-deny-shape.ts",
+					reviewExtensionCode(`return { decision: "deny", reason: "reviewer refuses" };`),
+				);
+				const result = await executeReviewCase(runner, recordingApprovalTool(), "call-deny-shape", {
+					params: { command: "echo good" },
+				});
+
+				expect(firstReviewText(result)).toBe("ok");
+				expect(select).toHaveBeenCalledTimes(1);
+				expect(trace[0]).toMatchObject({ kind: "review", toolCallId: "call-deny-shape" });
+				expect(trace.some(entry => entry.kind === "executed")).toBe(true);
+				clearTrace();
+			});
+
+			it("headless review escalation keeps the no-UI failure while headless review approval executes", async () => {
+				const trace = setTrace();
+				fs.writeFileSync(
+					path.join(extensionsDir, "review-headless.ts"),
+					reviewExtensionCode(`
+						if (event.toolCallId.startsWith("headless-escalate")) return { decision: "escalate" };
+						return { decision: "approve" };
+					`),
+				);
+				const result = await loadTestExtensions();
+				const runner = new ExtensionRunner(
+					result.extensions,
+					result.runtime,
+					tempDir.path(),
+					sessionManager,
+					modelRegistry,
+				);
+				// No initializeRunner: the runner keeps its no-op UI context (headless).
+				const tool = recordingApprovalTool();
+
+				await expect(executeReviewCase(runner, tool, "headless-escalate-1")).rejects.toThrow(
+					'Tool "dangerous_tool" requires approval but no interactive UI available.',
+				);
+				const approved = await executeReviewCase(runner, tool, "headless-approve-1");
+
+				expect(firstReviewText(approved)).toBe("ok");
+				expect(trace.filter(entry => entry.kind === "review")).toHaveLength(2);
+				expect(trace.some(entry => entry.kind === "ui_select")).toBe(false);
+				expect(trace.some(entry => entry.kind === "executed")).toBe(true);
+				clearTrace();
+			});
+
+			it("xdev-bypassed dispatch is neither reviewed nor re-prompted", async () => {
+				const trace = setTrace();
+				const { runner, select } = await reviewRunnerFromFile(
+					"review-xdev.ts",
+					reviewExtensionCode(`return { decision: "approve" };`),
+				);
+				const result = await executeReviewCase(runner, recordingApprovalTool(), "call-xdev-bypass", {
+					extraContext: { xdevApproved: true, xdevTierResolved: () => {} },
+				});
+
+				expect(firstReviewText(result)).toBe("ok");
+				expect(select).not.toHaveBeenCalled();
+				expect(trace).toEqual([{ kind: "executed", params: {} }]);
+				clearTrace();
+			});
 		});
 	});
 

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -2623,6 +2623,14 @@ describe("ExtensionRunner", () => {
 				__reviewController?: AbortController;
 				__reviewEntered?: () => void;
 			};
+			class PrototypeSensitiveInput {
+				command: string;
+
+				constructor(command: string) {
+					this.command = command;
+				}
+			}
+
 			const setTrace = (): Array<Record<string, unknown>> => {
 				const trace: Array<Record<string, unknown>> = [];
 				globalWithReview.__reviewTrace = trace;
@@ -3418,6 +3426,68 @@ describe("ExtensionRunner", () => {
 				expect(trace).toContainEqual({ kind: "requested" });
 				expect(trace).toContainEqual({ kind: "resolved", approved: true });
 				expect(executed[0]).toBe(params);
+			});
+
+			it("owned policy re-resolution failure skips review and uses native approval", async () => {
+				const reviewHandler = vi.fn(async () => ({ decision: "approve" as const }));
+				const transformedInput = new PrototypeSensitiveInput("echo hi");
+				const runner = dispatchRunner([reviewHandler], [async () => ({ input: transformedInput })]);
+				const select = vi.fn(async () => "Approve");
+				initializeRunner(runner, select);
+				const executed: unknown[] = [];
+				const tool = {
+					...approvalTool,
+					approval: (args: unknown) => {
+						const command = args && typeof args === "object" && "command" in args ? args.command : undefined;
+						if (command !== "echo original" && !(args instanceof PrototypeSensitiveInput)) {
+							throw new Error("Approval input lost its prototype");
+						}
+						return "exec" as const;
+					},
+					execute: async (_toolCallId: string, params: unknown) => {
+						executed.push(params);
+						return { content: [{ type: "text" as const, text: "ok" }] };
+					},
+				};
+
+				const result = await executeReviewCase(runner, tool, "call-owned-resolution-failure", {
+					params: { command: "echo original" },
+				});
+
+				expect(firstReviewText(result)).toBe("ok");
+				expect(reviewHandler).not.toHaveBeenCalled();
+				expect(select).toHaveBeenCalledTimes(1);
+				expect(executed).toEqual([transformedInput]);
+				expect(executed[0]).toBe(transformedInput);
+			});
+
+			it("owned policy re-resolution deny is authoritative before review", async () => {
+				const reviewHandler = vi.fn(async () => ({ decision: "approve" as const }));
+				const transformedInput = new PrototypeSensitiveInput("echo hi");
+				const runner = dispatchRunner([reviewHandler], [async () => ({ input: transformedInput })]);
+				const select = vi.fn(async () => "Approve");
+				initializeRunner(runner, select);
+				const execute = vi.fn(async () => ({ content: [{ type: "text" as const, text: "ran" }] }));
+				const tool = {
+					...approvalTool,
+					approval: (args: unknown) => {
+						const command = args && typeof args === "object" && "command" in args ? args.command : undefined;
+						if (command === "echo original" || args instanceof PrototypeSensitiveInput) {
+							return "exec" as const;
+						}
+						return { policy: "deny", tier: "exec", reason: "owned clone denied" } as const;
+					},
+					execute,
+				};
+
+				await expect(
+					executeReviewCase(runner, tool, "call-owned-resolution-deny", {
+						params: { command: "echo original" },
+					}),
+				).rejects.toThrow('Tool "dangerous_tool" is blocked by tool policy.\nReason: owned clone denied');
+				expect(reviewHandler).not.toHaveBeenCalled();
+				expect(select).not.toHaveBeenCalled();
+				expect(execute).not.toHaveBeenCalled();
 			});
 
 			it("native deny stays authoritative on non-cloneable input and never dispatches review", async () => {

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -7,7 +7,10 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { Type } from "@oh-my-pi/omptype/typebox";
 import type { AgentMessage, AgentTool } from "@oh-my-pi/pi-agent-core";
-import type { ImageContent, TextContent } from "@oh-my-pi/pi-ai";
+import { agentLoop } from "@oh-my-pi/pi-agent-core/agent-loop";
+import type { AgentContext, AgentLoopConfig } from "@oh-my-pi/pi-agent-core/types";
+import type { ImageContent, Message, TextContent } from "@oh-my-pi/pi-ai";
+import { createMockModel } from "@oh-my-pi/pi-ai/providers/mock";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
@@ -2630,6 +2633,10 @@ describe("ExtensionRunner", () => {
 				delete globalWithReview.__reviewController;
 				delete globalWithReview.__reviewEntered;
 			};
+			afterEach(() => {
+				clearTrace();
+				vi.restoreAllMocks();
+			});
 
 			const firstReviewText = (result: { content: readonly (TextContent | ImageContent)[] }): string | undefined => {
 				const block = result.content[0];
@@ -2685,7 +2692,7 @@ describe("ExtensionRunner", () => {
 					extraContext?: Record<string, unknown>;
 				},
 			) =>
-				(new ExtensionToolWrapper(tool, runner) as ExtensionToolWrapper<any>).execute(
+				new ExtensionToolWrapper(tool, runner).execute(
 					toolCallId,
 					(options?.params ?? {}) as never,
 					options?.signal,
@@ -2707,7 +2714,7 @@ describe("ExtensionRunner", () => {
 				code: string,
 				customSelect?: (title: string, options: string[]) => Promise<string | undefined>,
 			) => {
-				fs.writeFileSync(path.join(extensionsDir, fileName), code);
+				await Bun.write(path.join(extensionsDir, fileName), code);
 				const result = await loadTestExtensions();
 				const runner = new ExtensionRunner(
 					result.extensions,
@@ -2917,7 +2924,6 @@ describe("ExtensionRunner", () => {
 						input: {},
 					},
 				]);
-				clearTrace();
 			});
 
 			it("review escalation falls through to exactly one native selector with native approval events preserved", async () => {
@@ -2936,7 +2942,6 @@ describe("ExtensionRunner", () => {
 					{ kind: "ui_select" },
 					{ kind: "resolved", approved: true },
 				]);
-				clearTrace();
 			});
 
 			it("with no review handler the native selector runs unchanged", async () => {
@@ -2947,7 +2952,6 @@ describe("ExtensionRunner", () => {
 				expect(firstReviewText(result)).toBe("ok");
 				expect(select).toHaveBeenCalledTimes(1);
 				expect(trace).toEqual([{ kind: "requested" }, { kind: "ui_select" }, { kind: "resolved", approved: true }]);
-				clearTrace();
 			});
 
 			it("a throwing review handler escalates to the native selector", async () => {
@@ -2966,7 +2970,6 @@ describe("ExtensionRunner", () => {
 					{ kind: "ui_select" },
 					{ kind: "resolved", approved: true },
 				]);
-				clearTrace();
 			});
 
 			it("a timed-out review handler escalates to the native selector", async () => {
@@ -2986,7 +2989,6 @@ describe("ExtensionRunner", () => {
 					{ kind: "ui_select" },
 					{ kind: "resolved", approved: true },
 				]);
-				clearTrace();
 			});
 
 			it("cancellation during review never executes the tool", async () => {
@@ -3032,7 +3034,6 @@ describe("ExtensionRunner", () => {
 				expect(select).not.toHaveBeenCalled();
 				expect(trace.some(entry => entry.kind === "executed")).toBe(false);
 				expect(trace.some(entry => entry.kind === "requested")).toBe(false);
-				clearTrace();
 			});
 			it("cancellation after an approve result still prevents execution", async () => {
 				const trace = setTrace();
@@ -3049,12 +3050,11 @@ describe("ExtensionRunner", () => {
 					}),
 				).rejects.toThrow();
 				expect(trace.some(entry => entry.kind === "executed")).toBe(false);
-				clearTrace();
 			});
 
 			it("approve + escalate handlers are not last-result-wins: the native selector decides", async () => {
 				const trace = setTrace();
-				fs.writeFileSync(
+				await Bun.write(
 					path.join(extensionsDir, "review-b-escalate.ts"),
 					`export default function(pi) {
 						pi.on("tool_approval_review", async () => {
@@ -3075,7 +3075,6 @@ describe("ExtensionRunner", () => {
 				expect(trace[2]).toEqual({ kind: "requested" });
 				expect(trace[3]).toEqual({ kind: "ui_select" });
 				expect(trace[4]).toEqual({ kind: "resolved", approved: true });
-				clearTrace();
 			});
 
 			it("explicit user tools.approval prompt never emits review", async () => {
@@ -3098,7 +3097,6 @@ describe("ExtensionRunner", () => {
 				expect(firstReviewText(result)).toBe("ok");
 				expect(select).toHaveBeenCalledTimes(1);
 				expect(trace).toEqual([{ kind: "requested" }, { kind: "ui_select" }, { kind: "resolved", approved: true }]);
-				clearTrace();
 			});
 
 			it("tool override prompt never emits review", async () => {
@@ -3113,7 +3111,6 @@ describe("ExtensionRunner", () => {
 				expect(firstReviewText(result)).toBe("ok");
 				expect(select).toHaveBeenCalledTimes(1);
 				expect(trace).toEqual([{ kind: "requested" }, { kind: "ui_select" }, { kind: "resolved", approved: true }]);
-				clearTrace();
 			});
 
 			it("user and tool deny never emit review and never execute", async () => {
@@ -3144,7 +3141,6 @@ describe("ExtensionRunner", () => {
 				expect(select).not.toHaveBeenCalled();
 				expect(trace.some(entry => entry.kind === "review")).toBe(false);
 				expect(trace.some(entry => entry.kind === "executed")).toBe(false);
-				clearTrace();
 			});
 			it("transformed native deny never dispatches approval review", async () => {
 				const reviewHandler = vi.fn(async () => ({ decision: "approve" }));
@@ -3198,13 +3194,7 @@ describe("ExtensionRunner", () => {
 					},
 				};
 				const wrapper = new ExtensionToolWrapper(recordingApprovalTool(), runner);
-				const result = await (wrapper as ExtensionToolWrapper<any>).execute(
-					toolCallId,
-					{},
-					undefined,
-					undefined,
-					context as never,
-				);
+				const result = await wrapper.execute(toolCallId, {} as never, undefined, undefined, context as never);
 
 				expect(firstReviewText(result)).toBe("ok");
 				expect(select).toHaveBeenCalledTimes(1);
@@ -3216,7 +3206,6 @@ describe("ExtensionRunner", () => {
 					{ kind: "executed", params: {} },
 				]);
 				expect(context.providerSafetyApproved).toBe(true);
-				clearTrace();
 			});
 
 			it("yolo-resolved allow never emits review", async () => {
@@ -3232,7 +3221,6 @@ describe("ExtensionRunner", () => {
 				expect(firstReviewText(result)).toBe("ok");
 				expect(select).not.toHaveBeenCalled();
 				expect(trace).toEqual([{ kind: "executed", params: {} }]);
-				clearTrace();
 			});
 
 			it("review event input is the exact final effective execution input and is what executes", async () => {
@@ -3262,7 +3250,6 @@ describe("ExtensionRunner", () => {
 				// executes — no derived view, no rewrite channel.
 				expect(review?.input).toEqual(executed?.params);
 				expect(Object.isFrozen(review?.input)).toBe(true);
-				clearTrace();
 			});
 
 			it("owns transformed input before review so a retained alias cannot change execution", async () => {
@@ -3291,26 +3278,80 @@ describe("ExtensionRunner", () => {
 
 				expect(reviewedInput).toEqual({ command: "echo reviewed" });
 				expect(trace).toContainEqual({ kind: "executed", params: { command: "echo reviewed" } });
-				clearTrace();
 			});
 
-			it("review event input carries the exact deobfuscated execution value", async () => {
-				const trace = setTrace();
-				const { runner } = await reviewRunnerFromFile(
-					"review-secret.ts",
-					reviewExtensionCode(`return { decision: "approve" };`),
-				);
-				// The host deobfuscates secret placeholders before the wrapper sees the call;
-				// review must see the same final value that would reach the tool.
-				const secretCommand = "deploy --token sk-live-abc123";
-				const result = await executeReviewCase(runner, recordingApprovalTool(), "call-secret-input", {
-					params: { command: secretCommand },
+			it("reviews and executes the value produced by the real agent-loop transformation path", async () => {
+				const reviewedInputs: Array<Readonly<Record<string, unknown>>> = [];
+				const executedInputs: unknown[] = [];
+				const runner = dispatchRunner([
+					async event => {
+						reviewedInputs.push(event.input);
+						return { decision: "approve" };
+					},
+				]);
+				const parameters = Type.Object({ command: Type.String(), timeout: Type.Number() });
+				const tool: AgentTool<typeof parameters> = {
+					name: "dangerous_tool",
+					label: "Dangerous Tool",
+					description: "Test tool",
+					parameters,
+					approval: "exec",
+					execute: async (_toolCallId, params) => {
+						executedInputs.push(params);
+						return { content: [{ type: "text", text: "ok" }] };
+					},
+				};
+				const wrapped = new ExtensionToolWrapper(tool, runner);
+				const context: AgentContext = { systemPrompt: [""], messages: [], tools: [wrapped] };
+				const rawArguments = { command: "$$secret-command$$", timeout: 10_000 };
+				const transformedArguments = { command: "deploy --token sk-live-abc123", timeout: 5_000 };
+				const mock = createMockModel({
+					responses: [
+						{
+							content: [
+								{
+									type: "toolCall",
+									id: "call-transformed-input",
+									name: "dangerous_tool",
+									arguments: rawArguments,
+								},
+							],
+						},
+						{ content: ["done"] },
+					],
 				});
+				const config: AgentLoopConfig = {
+					model: mock.model,
+					convertToLlm: messages =>
+						messages.filter(
+							message =>
+								message.role === "user" || message.role === "assistant" || message.role === "toolResult",
+						) as Message[],
+					transformToolCallArguments: () => transformedArguments,
+					getToolContext: toolCall =>
+						({
+							sessionManager,
+							modelRegistry,
+							model: undefined,
+							isIdle: () => true,
+							hasQueuedMessages: () => false,
+							abort: () => {},
+							settings: alwaysAskSettings,
+							toolCall,
+						}) as never,
+				};
 
-				expect(firstReviewText(result)).toBe("ok");
-				const review = trace.find(entry => entry.kind === "review");
-				expect(review?.input).toEqual({ command: secretCommand });
-				clearTrace();
+				await agentLoop(
+					[{ role: "user", content: "deploy", timestamp: Date.now() }],
+					context,
+					config,
+					undefined,
+					mock.stream,
+				).result();
+
+				expect(reviewedInputs).toEqual([transformedArguments]);
+				expect(executedInputs).toEqual([transformedArguments]);
+				expect(reviewedInputs[0]).not.toEqual(rawArguments);
 			});
 
 			it("a rewrite attempt inside an approve result is ignored and escalates to the native selector", async () => {
@@ -3331,7 +3372,6 @@ describe("ExtensionRunner", () => {
 				const executed = trace.find(entry => entry.kind === "executed");
 				expect(executed?.params).toEqual({ command: "echo good" });
 				expect(JSON.stringify(trace)).not.toContain("evil");
-				clearTrace();
 			});
 
 			it("review deny reports an extension veto without selector or execution", async () => {
@@ -3351,12 +3391,11 @@ describe("ExtensionRunner", () => {
 				expect(trace).toHaveLength(1);
 				expect(trace[0]).toMatchObject({ kind: "review", toolCallId: "call-review-deny" });
 				expect(trace.some(entry => entry.kind === "executed")).toBe(false);
-				clearTrace();
 			});
 
 			it("headless review escalation keeps the no-UI failure while headless review approval executes", async () => {
 				const trace = setTrace();
-				fs.writeFileSync(
+				await Bun.write(
 					path.join(extensionsDir, "review-headless.ts"),
 					reviewExtensionCode(`
 						if (event.toolCallId.startsWith("headless-escalate")) return { decision: "escalate" };
@@ -3382,7 +3421,6 @@ describe("ExtensionRunner", () => {
 				expect(trace.filter(entry => entry.kind === "review")).toHaveLength(2);
 				expect(trace.some(entry => entry.kind === "ui_select")).toBe(false);
 				expect(trace.some(entry => entry.kind === "executed")).toBe(true);
-				clearTrace();
 			});
 
 			it("xdev-bypassed dispatch is neither reviewed nor re-prompted", async () => {
@@ -3398,8 +3436,6 @@ describe("ExtensionRunner", () => {
 				expect(firstReviewText(result)).toBe("ok");
 				expect(select).not.toHaveBeenCalled();
 				expect(trace).toEqual([{ kind: "executed", params: {} }]);
-
-				clearTrace();
 			});
 
 			it("a handler mutation attempt escalates and the pristine input executes", async () => {
@@ -3422,7 +3458,6 @@ describe("ExtensionRunner", () => {
 				const executed = trace.find(entry => entry.kind === "executed");
 				expect(executed?.params).toEqual({ command: "echo good", nested: { flag: "keep" } });
 				expect(JSON.stringify(trace)).not.toContain("evil");
-				clearTrace();
 			});
 
 			it("top-level mutation attempts cannot change what later handlers review", async () => {
@@ -3466,7 +3501,7 @@ describe("ExtensionRunner", () => {
 			});
 
 			it("a nested mutation attempt cannot alter the reviewed snapshot", async () => {
-				const seenInputs: Array<Record<string, unknown>> = [];
+				const seenInputs: Array<Readonly<Record<string, unknown>>> = [];
 				const runner = dispatchRunner([
 					async event => {
 						(event.input.nested as Record<string, unknown>).flag = "evil";
@@ -3518,7 +3553,6 @@ describe("ExtensionRunner", () => {
 					mutationBlocked: true,
 					unchanged: true,
 				});
-				clearTrace();
 			});
 
 			it("treats missing supportedEvents on older hosts as unsupported", () => {

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -3488,22 +3488,42 @@ describe("ExtensionRunner", () => {
 				expect(seenInputs).toEqual([{ command: "echo hi", nested: { flag: "keep" } }]);
 			});
 
-			it("extensions detect tool_approval_review support via pi.supportedEvents", async () => {
+			it("exposes immutable approval review capability metadata", async () => {
 				setTrace();
-				fs.writeFileSync(
+				await Bun.write(
 					path.join(extensionsDir, "review-capability.ts"),
 					`export default function(pi) {
+						const supportedEvents = pi.supportedEvents;
+						let mutationBlocked = false;
+						try {
+							supportedEvents.push("invented_event");
+						} catch {
+							mutationBlocked = true;
+						}
 						globalThis.__reviewTrace.push({
 							kind: "capability",
-							supported: pi.supportedEvents.includes("tool_approval_review"),
+							supported: supportedEvents?.includes("tool_approval_review") ?? false,
+							frozen: Object.isFrozen(supportedEvents),
+							mutationBlocked,
+							unchanged: !supportedEvents?.includes("invented_event"),
 						});
 					}`,
 				);
 				await loadTestExtensions();
 
 				const entry = (globalWithReview.__reviewTrace ?? []).find(item => item.kind === "capability");
-				expect(entry?.supported).toBe(true);
+				expect(entry).toMatchObject({
+					supported: true,
+					frozen: true,
+					mutationBlocked: true,
+					unchanged: true,
+				});
 				clearTrace();
+			});
+
+			it("treats missing supportedEvents on older hosts as unsupported", () => {
+				const legacyApi: { supportedEvents?: readonly string[] } = {};
+				expect(legacyApi.supportedEvents?.includes("tool_approval_review") ?? false).toBe(false);
 			});
 		});
 	});

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -2777,11 +2777,6 @@ describe("ExtensionRunner", () => {
 				tier: "exec",
 			} as ToolApprovalReviewEvent;
 
-			it("dispatch returns escalation when no review handler exists (distinct from approval)", async () => {
-				const runner = dispatchRunner([]);
-				await expect(runner.emitToolApprovalReview(dispatchEvent)).resolves.toMatchObject({ decision: "escalate" });
-			});
-
 			it("dispatch returns approve only for unanimous approval and delivers the exact public event", async () => {
 				const seen: ToolApprovalReviewEvent[] = [];
 				const runner = dispatchRunner([
@@ -2867,22 +2862,6 @@ describe("ExtensionRunner", () => {
 						decision: "escalate",
 					});
 				}
-			});
-
-			it("dispatch returns escalation when a handler throws", async () => {
-				const runner = dispatchRunner([
-					async () => {
-						throw new Error("reviewer exploded");
-					},
-				]);
-				await expect(runner.emitToolApprovalReview(dispatchEvent)).resolves.toMatchObject({ decision: "escalate" });
-			});
-
-			it("dispatch returns escalation on handler timeout", async () => {
-				testSetExtensionHandlerTimeoutMs(20);
-				const never = Promise.withResolvers<void>();
-				const runner = dispatchRunner([async () => never.promise]);
-				await expect(runner.emitToolApprovalReview(dispatchEvent)).resolves.toMatchObject({ decision: "escalate" });
 			});
 
 			it("dispatch returns escalation when the signal is already aborted and never calls handlers", async () => {

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -2731,12 +2731,16 @@ describe("ExtensionRunner", () => {
 
 			const dispatchRunner = (
 				reviewHandlers: Array<(event: ToolApprovalReviewEvent, ctx: unknown) => unknown>,
+				toolCallHandlers: Array<(event: unknown, ctx: unknown) => unknown> = [],
 			): ExtensionRunner => {
 				const extensionPath = path.join(extensionsDir, "review-dispatch.ts");
 				const extension: Extension = {
 					path: extensionPath,
 					resolvedPath: extensionPath,
-					handlers: new Map([["tool_approval_review", reviewHandlers as never]]),
+					handlers: new Map([
+						["tool_approval_review", reviewHandlers as never],
+						["tool_call", toolCallHandlers as never],
+					]),
 					tools: new Map(),
 					assistantThinkingRenderers: [],
 					fileWriteFallbackHandlers: [],
@@ -3014,6 +3018,23 @@ describe("ExtensionRunner", () => {
 				expect(trace.some(entry => entry.kind === "requested")).toBe(false);
 				clearTrace();
 			});
+			it("cancellation after an approve result still prevents execution", async () => {
+				const trace = setTrace();
+				const runner = dispatchRunner([]);
+				const controller = new AbortController();
+				vi.spyOn(runner, "emitToolApprovalReview").mockImplementation(async () => {
+					controller.abort();
+					return { decision: "approve" };
+				});
+
+				await expect(
+					executeReviewCase(runner, recordingApprovalTool(), "call-review-approve-abort", {
+						signal: controller.signal,
+					}),
+				).rejects.toThrow();
+				expect(trace.some(entry => entry.kind === "executed")).toBe(false);
+				clearTrace();
+			});
 
 			it("approve + escalate handlers are not last-result-wins: the native selector decides", async () => {
 				const trace = setTrace();
@@ -3200,6 +3221,35 @@ describe("ExtensionRunner", () => {
 				// executes — no derived view, no rewrite channel.
 				expect(review?.input).toEqual(executed?.params);
 				expect(Object.isFrozen(review?.input)).toBe(true);
+				clearTrace();
+			});
+
+			it("owns transformed input before review so a retained alias cannot change execution", async () => {
+				const trace = setTrace();
+				const retainedInput = { command: "echo reviewed" };
+				const reviewStarted = Promise.withResolvers<Readonly<Record<string, unknown>>>();
+				const releaseReview = Promise.withResolvers<void>();
+				const runner = dispatchRunner(
+					[
+						async event => {
+							reviewStarted.resolve(event.input);
+							await releaseReview.promise;
+							return { decision: "approve" };
+						},
+					],
+					[async () => ({ input: retainedInput })],
+				);
+				const execution = executeReviewCase(runner, recordingApprovalTool(), "call-review-owned-input", {
+					params: { command: "echo original" },
+				});
+
+				const reviewedInput = await reviewStarted.promise;
+				retainedInput.command = "rm -rf";
+				releaseReview.resolve();
+				await execution;
+
+				expect(reviewedInput).toEqual({ command: "echo reviewed" });
+				expect(trace).toContainEqual({ kind: "executed", params: { command: "echo reviewed" } });
 				clearTrace();
 			});
 

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -2613,7 +2613,7 @@ describe("ExtensionRunner", () => {
 			]);
 			delete globalState.__partialContextApprovalEvents;
 		});
-		// Tests for the generic tool_approval_review seam, written before the implementation.
+		// Tests for the generic tool_approval_review seam.
 		describe("tool_approval_review seam", () => {
 			const globalWithReview = globalThis as typeof globalThis & {
 				__reviewTrace?: Array<Record<string, unknown>>;
@@ -2729,7 +2729,9 @@ describe("ExtensionRunner", () => {
 
 			// --- Dedicated unanimous dispatch (runner level) ---
 
-			const dispatchRunner = (reviewHandlers: Array<(event: unknown, ctx: unknown) => unknown>): ExtensionRunner => {
+			const dispatchRunner = (
+				reviewHandlers: Array<(event: ToolApprovalReviewEvent, ctx: unknown) => unknown>,
+			): ExtensionRunner => {
 				const extensionPath = path.join(extensionsDir, "review-dispatch.ts");
 				const extension: Extension = {
 					path: extensionPath,
@@ -2780,7 +2782,7 @@ describe("ExtensionRunner", () => {
 				await expect(runner.emitToolApprovalReview(dispatchEvent)).resolves.toEqual({ decision: "approve" });
 				expect(seen).toHaveLength(1);
 				expect(seen[0]).toEqual(dispatchEvent);
-				// The public event carries exactly these fields — no deny, rewrite, or mode channels.
+				// The public event carries exactly these fields — no input rewrite channel.
 				expect(Object.keys(seen[0] ?? {}).sort()).toEqual([
 					"approvalMode",
 					"input",
@@ -2792,12 +2794,32 @@ describe("ExtensionRunner", () => {
 				]);
 			});
 
-			it("dispatch returns escalation when handlers disagree (no last-result-wins)", async () => {
+			it("dispatch returns a valid deny result with its reason", async () => {
+				const runner = dispatchRunner([async () => ({ decision: "deny", reason: "policy refusal" })]);
+				await expect(runner.emitToolApprovalReview(dispatchEvent)).resolves.toEqual({
+					decision: "deny",
+					reason: "policy refusal",
+				});
+			});
+
+			it("dispatch gives deny precedence over escalation and approval", async () => {
+				const seen: string[] = [];
 				const runner = dispatchRunner([
-					async () => ({ decision: "approve" }),
-					async () => ({ decision: "escalate", reason: "second opinion" }),
+					async () => {
+						seen.push("approve");
+						return { decision: "approve" };
+					},
+					async () => {
+						seen.push("escalate");
+						return { decision: "escalate", reason: "second opinion" };
+					},
+					async () => {
+						seen.push("deny");
+						return { decision: "deny" };
+					},
 				]);
-				await expect(runner.emitToolApprovalReview(dispatchEvent)).resolves.toMatchObject({ decision: "escalate" });
+				await expect(runner.emitToolApprovalReview(dispatchEvent)).resolves.toEqual({ decision: "deny" });
+				expect(seen).toEqual(["approve", "escalate", "deny"]);
 			});
 
 			it("dispatch returns escalation for malformed handler results", async () => {
@@ -2805,7 +2827,9 @@ describe("ExtensionRunner", () => {
 					undefined,
 					"approve",
 					{},
-					{ decision: "deny" },
+					{ decision: "deny", extra: true },
+					{ decision: "deny", reason: 123 },
+					{ decision: "approve", rationale: 123 },
 					{ decision: "approve", input: { command: "rewritten" } },
 				];
 				for (const result of malformed) {
@@ -2842,10 +2866,11 @@ describe("ExtensionRunner", () => {
 				});
 				expect(handler).not.toHaveBeenCalled();
 			});
-
 			it("exposes the public result contract types", () => {
 				expectTypeOf<ToolApprovalReviewResult>().toEqualTypeOf<
-					{ decision: "approve"; rationale?: string } | { decision: "escalate"; reason?: string }
+					| { decision: "approve"; rationale?: string }
+					| { decision: "escalate"; reason?: string }
+					| { decision: "deny"; reason?: string }
 				>();
 			});
 
@@ -3045,7 +3070,7 @@ describe("ExtensionRunner", () => {
 					"review-override.ts",
 					reviewExtensionCode(`return { decision: "approve" };`),
 				);
-				const tool = { ...approvalTool, approval: { tier: "exec", policy: "prompt", override: true } };
+				const tool = { ...approvalTool, approval: { tier: "exec", policy: "prompt", override: true } as const };
 				const result = await executeReviewCase(runner, tool, "call-override-prompt");
 
 				expect(firstReviewText(result)).toBe("ok");
@@ -3074,7 +3099,7 @@ describe("ExtensionRunner", () => {
 						},
 					}),
 				).rejects.toThrow();
-				const denyTool = { ...approvalTool, approval: { policy: "deny", tier: "exec", reason: "no" } };
+				const denyTool = { ...approvalTool, approval: { policy: "deny", tier: "exec", reason: "no" } as const };
 				await expect(executeReviewCase(runner, denyTool, "call-tool-deny")).rejects.toThrow();
 
 				expect(select).not.toHaveBeenCalled();
@@ -3216,20 +3241,23 @@ describe("ExtensionRunner", () => {
 				clearTrace();
 			});
 
-			it("a deny-shaped review result is not a deny: it escalates to the native selector", async () => {
+			it("review deny rejects via native denial path without selector or execution", async () => {
 				const trace = setTrace();
 				const { runner, select } = await reviewRunnerFromFile(
-					"review-deny-shape.ts",
+					"review-deny.ts",
 					reviewExtensionCode(`return { decision: "deny", reason: "reviewer refuses" };`),
 				);
-				const result = await executeReviewCase(runner, recordingApprovalTool(), "call-deny-shape", {
-					params: { command: "echo good" },
-				});
 
-				expect(firstReviewText(result)).toBe("ok");
-				expect(select).toHaveBeenCalledTimes(1);
-				expect(trace[0]).toMatchObject({ kind: "review", toolCallId: "call-deny-shape" });
-				expect(trace.some(entry => entry.kind === "executed")).toBe(true);
+				await expect(
+					executeReviewCase(runner, recordingApprovalTool(), "call-review-deny", {
+						params: { command: "echo good" },
+					}),
+				).rejects.toThrow('Tool "dangerous_tool" is blocked by tool policy.\nReason: reviewer refuses');
+
+				expect(select).not.toHaveBeenCalled();
+				expect(trace).toHaveLength(1);
+				expect(trace[0]).toMatchObject({ kind: "review", toolCallId: "call-review-deny" });
+				expect(trace.some(entry => entry.kind === "executed")).toBe(false);
 				clearTrace();
 			});
 

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -3713,6 +3713,54 @@ describe("ExtensionRunner", () => {
 				expect(executed[0]).toEqual({ command: "echo safe" });
 			});
 
+			it("uses the owned execution snapshot for an escalated native prompt", async () => {
+				const reviewStarted = Promise.withResolvers<Readonly<Record<string, unknown>>>();
+				const releaseReview = Promise.withResolvers<void>();
+				let retainedApprovalArg: { command?: string } | undefined;
+				let selectedPrompt = "";
+				const runner = dispatchRunner([
+					async event => {
+						reviewStarted.resolve(event.input);
+						await releaseReview.promise;
+						return { decision: "escalate" };
+					},
+				]);
+				const select = vi.fn(async (title: string) => {
+					selectedPrompt = title;
+					return "Approve";
+				});
+				initializeRunner(runner, select);
+				const executed: unknown[] = [];
+				const tool = {
+					...approvalTool,
+					approval: (args: unknown) => {
+						retainedApprovalArg = args as { command?: string };
+						return "exec" as const;
+					},
+					formatApprovalDetails: (args: unknown) =>
+						`Command: ${(args as { command?: string }).command ?? "(missing)"}`,
+					execute: async (_toolCallId: string, params: unknown) => {
+						executed.push(params);
+						return { content: [{ type: "text" as const, text: "ok" }] };
+					},
+				};
+				const execution = executeReviewCase(runner, tool, "call-approval-escalate-owned", {
+					params: { command: "echo safe" },
+				});
+
+				const reviewedInput = await reviewStarted.promise;
+				if (!retainedApprovalArg) throw new Error("approval callback did not receive input");
+				retainedApprovalArg.command = "rm -rf";
+				releaseReview.resolve();
+				const result = await execution;
+
+				expect(firstReviewText(result)).toBe("ok");
+				expect(reviewedInput).toEqual({ command: "echo safe" });
+				expect(selectedPrompt).toContain("Command: echo safe");
+				expect(selectedPrompt).not.toContain("Command: rm -rf");
+				expect(executed).toEqual([{ command: "echo safe" }]);
+			});
+
 			it("approval policy runs exactly the two upstream resolutions and never sees the execution clone", async () => {
 				const reviewHandler = vi.fn(async () => ({ decision: "approve" as const }));
 				const runner = dispatchRunner([reviewHandler]);

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -3196,8 +3196,10 @@ describe("ExtensionRunner", () => {
 				const executed = trace.find(entry => entry.kind === "executed");
 				expect(review?.input).toEqual({ command: "echo final", timeout: 5000 });
 				expect(executed?.params).toEqual({ command: "echo final", timeout: 5000 });
-				// The reviewed object IS the executed object — no derived view, no rewrite channel.
-				expect(review?.input).toBe(executed?.params);
+				// The reviewed input is an immutable snapshot materially identical to what
+				// executes — no derived view, no rewrite channel.
+				expect(review?.input).toEqual(executed?.params);
+				expect(Object.isFrozen(review?.input)).toBe(true);
 				clearTrace();
 			});
 
@@ -3305,6 +3307,93 @@ describe("ExtensionRunner", () => {
 				expect(firstReviewText(result)).toBe("ok");
 				expect(select).not.toHaveBeenCalled();
 				expect(trace).toEqual([{ kind: "executed", params: {} }]);
+
+				clearTrace();
+			});
+
+			it("a handler mutation attempt escalates and the pristine input executes", async () => {
+				const trace = setTrace();
+				const { runner, select } = await reviewRunnerFromFile(
+					"review-mutate.ts",
+					reviewExtensionCode(`
+						event.input.command = "evil";
+						return { decision: "approve" };
+					`),
+				);
+				const result = await executeReviewCase(runner, recordingApprovalTool(), "call-review-mutate", {
+					params: { command: "echo good", nested: { flag: "keep" } },
+				});
+
+				// Frozen snapshot makes the strict-mode assignment throw: escalation wins,
+				// the native selector decides, and the reviewed input is what executes.
+				expect(firstReviewText(result)).toBe("ok");
+				expect(select).toHaveBeenCalledTimes(1);
+				const executed = trace.find(entry => entry.kind === "executed");
+				expect(executed?.params).toEqual({ command: "echo good", nested: { flag: "keep" } });
+				expect(JSON.stringify(trace)).not.toContain("evil");
+				clearTrace();
+			});
+
+			it("a mutation attempt cannot leak to later handlers or the caller's event", async () => {
+				const seenInputs: Array<Record<string, unknown>> = [];
+				const runner = dispatchRunner([
+					async event => {
+						event.input.command = "evil";
+						return { decision: "approve" };
+					},
+					async event => {
+						seenInputs.push(event.input);
+						return { decision: "approve" };
+					},
+				]);
+				await expect(runner.emitToolApprovalReview(dispatchEvent)).resolves.toMatchObject({
+					decision: "escalate",
+				});
+
+				expect(seenInputs).toEqual([{ command: "echo hi" }]);
+				expect(Object.isFrozen(seenInputs[0])).toBe(true);
+				expect(dispatchEvent.input).toEqual({ command: "echo hi" });
+				expect(Object.isFrozen(dispatchEvent.input)).toBe(false);
+			});
+
+			it("a nested mutation attempt cannot alter the reviewed snapshot", async () => {
+				const seenInputs: Array<Record<string, unknown>> = [];
+				const runner = dispatchRunner([
+					async event => {
+						(event.input.nested as Record<string, unknown>).flag = "evil";
+						return { decision: "approve" };
+					},
+					async event => {
+						seenInputs.push(event.input);
+						return { decision: "approve" };
+					},
+				]);
+				const nestedEvent = {
+					...dispatchEvent,
+					input: { command: "echo hi", nested: { flag: "keep" } },
+				} as ToolApprovalReviewEvent;
+				await expect(runner.emitToolApprovalReview(nestedEvent)).resolves.toMatchObject({
+					decision: "escalate",
+				});
+
+				expect(seenInputs).toEqual([{ command: "echo hi", nested: { flag: "keep" } }]);
+			});
+
+			it("extensions detect tool_approval_review support via pi.supportedEvents", async () => {
+				setTrace();
+				fs.writeFileSync(
+					path.join(extensionsDir, "review-capability.ts"),
+					`export default function(pi) {
+						globalThis.__reviewTrace.push({
+							kind: "capability",
+							supported: pi.supportedEvents.includes("tool_approval_review"),
+						});
+					}`,
+				);
+				await loadTestExtensions();
+
+				const entry = (globalWithReview.__reviewTrace ?? []).find(item => item.kind === "capability");
+				expect(entry?.supported).toBe(true);
 				clearTrace();
 			});
 		});

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -3895,6 +3895,112 @@ describe("ExtensionRunner", () => {
 				expect(JSON.stringify(trace)).not.toContain("evil");
 			});
 
+			it("a mutating formatter cannot change the executed input after escalation", async () => {
+				const trace = setTrace();
+				const { runner, select } = await reviewRunnerFromFile(
+					"review-formatter-mutate.ts",
+					reviewExtensionCode(`return { decision: "escalate" };`),
+				);
+				let formatterArg: unknown;
+				const formatterTool = {
+					...approvalTool,
+					formatApprovalDetails: (args: unknown) => {
+						formatterArg = args;
+						// Test-owned input: the dispatch params are always { command: string }.
+						const record = args as { command?: string };
+						const displayed = record.command;
+						record.command = "dangerous";
+						return `Command: ${displayed}`;
+					},
+					execute: async (_toolCallId: string, params: unknown) => {
+						globalWithReview.__reviewTrace?.push({ kind: "executed", params });
+						return { content: [{ type: "text" as const, text: "ok" }] };
+					},
+				};
+				const result = await executeReviewCase(runner, formatterTool, "call-formatter-mutate", {
+					params: { command: "safe" },
+				});
+
+				expect(firstReviewText(result)).toBe("ok");
+				// The native selector approved a prompt describing the authorized input.
+				expect(String(select.mock.calls[0]?.[0])).toContain("Command: safe");
+				expect(String(select.mock.calls[0]?.[0])).not.toContain("Command: dangerous");
+				const executed = trace.find(entry => entry.kind === "executed");
+				expect(executed?.params).toEqual({ command: "safe" });
+				// The formatter observed a detached snapshot, not the execution-owned object.
+				expect(formatterArg).not.toBe(executed?.params);
+			});
+
+			it("a retained formatter argument mutated while the selector is pending cannot reach execution", async () => {
+				const trace = setTrace();
+				let retained: { command?: string } | undefined;
+				let promptText = "";
+				const { runner } = await reviewRunnerFromFile(
+					"review-formatter-retain.ts",
+					reviewExtensionCode(`return { decision: "escalate" };`),
+					async title => {
+						promptText = title;
+						// Mutate the retained observation while ui.select is pending.
+						if (retained) retained.command = "dangerous";
+						return "Approve";
+					},
+				);
+				const retainingTool = {
+					...approvalTool,
+					formatApprovalDetails: (args: unknown) => {
+						// Test-owned input: the dispatch params are always { command: string }.
+						const record = args as { command?: string };
+						retained = record;
+						return `Command: ${record.command}`;
+					},
+					execute: async (_toolCallId: string, params: unknown) => {
+						globalWithReview.__reviewTrace?.push({ kind: "executed", params });
+						return { content: [{ type: "text" as const, text: "ok" }] };
+					},
+				};
+				const result = await executeReviewCase(runner, retainingTool, "call-formatter-retain", {
+					params: { command: "safe" },
+				});
+
+				expect(firstReviewText(result)).toBe("ok");
+				expect(promptText).toContain("Command: safe");
+				const executed = trace.find(entry => entry.kind === "executed");
+				expect(executed?.params).toEqual({ command: "safe" });
+			});
+
+			it("a mutating formatter cannot reach execution on the native fallback path", async () => {
+				const trace = setTrace();
+				// No tool_approval_review handler anywhere: no owned review clone is
+				// prepared and the native selector decides. This is the path where the
+				// execution input and the formatter argument used to be the same object.
+				const { runner, select } = await reviewRunnerFromFile("formatter-fallback.ts", reviewExtensionCode(null));
+				let formatterArg: unknown;
+				const formatterTool = {
+					...approvalTool,
+					formatApprovalDetails: (args: unknown) => {
+						formatterArg = args;
+						// Test-owned input: the dispatch params are always { command: string }.
+						const record = args as { command?: string };
+						const displayed = record.command;
+						record.command = "dangerous";
+						return `Command: ${displayed}`;
+					},
+					execute: async (_toolCallId: string, params: unknown) => {
+						globalWithReview.__reviewTrace?.push({ kind: "executed", params });
+						return { content: [{ type: "text" as const, text: "ok" }] };
+					},
+				};
+				const result = await executeReviewCase(runner, formatterTool, "call-formatter-fallback", {
+					params: { command: "safe" },
+				});
+
+				expect(firstReviewText(result)).toBe("ok");
+				expect(String(select.mock.calls[0]?.[0])).toContain("Command: safe");
+				const executed = trace.find(entry => entry.kind === "executed");
+				expect(executed?.params).toEqual({ command: "safe" });
+				expect(formatterArg).not.toBe(executed?.params);
+			});
+
 			it("top-level mutation attempts cannot change what later handlers review", async () => {
 				const seenEvents: ToolApprovalReviewEvent[] = [];
 				const runner = dispatchRunner([

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -3267,7 +3267,16 @@ describe("ExtensionRunner", () => {
 					],
 					[async () => ({ input: retainedInput })],
 				);
-				const execution = executeReviewCase(runner, recordingApprovalTool(), "call-review-owned-input", {
+				const tool = {
+					...recordingApprovalTool(),
+					approval: (args: unknown) => {
+						const command = args && typeof args === "object" && "command" in args ? args.command : undefined;
+						return command === "rm -rf"
+							? ({ policy: "deny", tier: "exec", reason: "dangerous" } as const)
+							: ("exec" as const);
+					},
+				};
+				const execution = executeReviewCase(runner, tool, "call-review-owned-input", {
 					params: { command: "echo original" },
 				});
 

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -3098,6 +3098,28 @@ describe("ExtensionRunner", () => {
 				expect(select).toHaveBeenCalledTimes(1);
 				expect(trace).toEqual([{ kind: "requested" }, { kind: "ui_select" }, { kind: "resolved", approved: true }]);
 			});
+			it("invalid user policies do not suppress eligible approval review", async () => {
+				const trace = setTrace();
+				const { runner, select } = await reviewRunnerFromFile(
+					"review-invalid-user-policy.ts",
+					reviewExtensionCode(`return { decision: "approve" };`),
+				);
+				const result = await executeReviewCase(runner, recordingApprovalTool(), "call-invalid-user-policy", {
+					settings: {
+						get: (key: string) =>
+							key === "tools.approvalMode"
+								? "always-ask"
+								: key === "tools.approval"
+									? { dangerous_tool: "not-a-policy" }
+									: {},
+					},
+				});
+
+				expect(firstReviewText(result)).toBe("ok");
+				expect(select).not.toHaveBeenCalled();
+				expect(trace).toContainEqual(expect.objectContaining({ kind: "review" }));
+				expect(trace).toContainEqual(expect.objectContaining({ kind: "executed" }));
+			});
 
 			it("tool override prompt never emits review", async () => {
 				const trace = setTrace();
@@ -3531,6 +3553,17 @@ describe("ExtensionRunner", () => {
 
 				expect(seenInputs).toEqual([{ command: "echo hi", nested: { flag: "keep" } }]);
 			});
+			it("unsupported mutable input escalates without dispatching a handler", async () => {
+				const handler = vi.fn(async () => ({ decision: "approve" as const }));
+				const runner = dispatchRunner([handler]);
+				const event = {
+					...dispatchEvent,
+					input: { commands: new Map([["command", "echo hi"]]) },
+				} as ToolApprovalReviewEvent;
+
+				await expect(runner.emitToolApprovalReview(event)).resolves.toEqual({ decision: "escalate" });
+				expect(handler).not.toHaveBeenCalled();
+			});
 
 			it("exposes immutable approval review capability metadata", async () => {
 				setTrace();
@@ -3564,9 +3597,22 @@ describe("ExtensionRunner", () => {
 				});
 			});
 
-			it("treats missing supportedEvents on older hosts as unsupported", () => {
-				const legacyApi: { supportedEvents?: readonly string[] } = {};
-				expect(legacyApi.supportedEvents?.includes("tool_approval_review") ?? false).toBe(false);
+			it("the documented capability pattern stays false without throwing when supportedEvents is absent", async () => {
+				setTrace();
+				await Bun.write(
+					path.join(extensionsDir, "review-capability-legacy.ts"),
+					`export default function(pi) {
+						delete pi.supportedEvents;
+						globalThis.__reviewTrace.push({
+							kind: "legacy-capability",
+							supported: pi.supportedEvents?.includes("tool_approval_review") ?? false,
+						});
+					}`,
+				);
+				await loadTestExtensions();
+
+				const entry = (globalWithReview.__reviewTrace ?? []).find(item => item.kind === "legacy-capability");
+				expect(entry).toEqual({ kind: "legacy-capability", supported: false });
 			});
 		});
 	});

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -3542,20 +3542,22 @@ describe("ExtensionRunner", () => {
 				expect(executed[0]).toEqual({ command: "echo reviewed" });
 			});
 
-			it("owned policy re-resolution failure skips review and uses native approval", async () => {
-				const reviewHandler = vi.fn(async () => ({ decision: "approve" as const }));
-				const transformedInput = { command: "echo hi" };
-				const runner = dispatchRunner([reviewHandler], [async () => ({ input: transformedInput })]);
-				const select = vi.fn(async () => "Approve");
-				initializeRunner(runner, select);
+			it("a retained approval argument cannot mutate the reviewed input into execution", async () => {
+				const reviewStarted = Promise.withResolvers<Readonly<Record<string, unknown>>>();
+				const releaseReview = Promise.withResolvers<void>();
+				let retainedApprovalArg: { command?: string } | undefined;
+				const runner = dispatchRunner([
+					async event => {
+						reviewStarted.resolve(event.input);
+						await releaseReview.promise;
+						return { decision: "approve" };
+					},
+				]);
 				const executed: unknown[] = [];
 				const tool = {
 					...approvalTool,
 					approval: (args: unknown) => {
-						const command = args && typeof args === "object" && "command" in args ? args.command : undefined;
-						if (command !== "echo original" && args !== transformedInput) {
-							throw new Error("Approval input lost its source identity");
-						}
+						retainedApprovalArg = args as { command?: string };
 						return "exec" as const;
 					},
 					execute: async (_toolCallId: string, params: unknown) => {
@@ -3564,44 +3566,130 @@ describe("ExtensionRunner", () => {
 					},
 				};
 
-				const result = await executeReviewCase(runner, tool, "call-owned-resolution-failure", {
-					params: { command: "echo original" },
+				const execution = executeReviewCase(runner, tool, "call-approval-alias", {
+					params: { command: "echo safe" },
 				});
+
+				// Review is pending while the retained approval alias flips safe → dangerous.
+				await reviewStarted.promise;
+				if (retainedApprovalArg) retainedApprovalArg.command = "rm -rf";
+				releaseReview.resolve();
+				const result = await execution;
+
+				expect(firstReviewText(result)).toBe("ok");
+				expect(executed[0]).toEqual({ command: "echo safe" });
+			});
+
+			it("approval policy runs exactly the two upstream resolutions and never sees the execution clone", async () => {
+				const reviewHandler = vi.fn(async () => ({ decision: "approve" as const }));
+				const runner = dispatchRunner([reviewHandler]);
+				const observed: unknown[] = [];
+				const executed: unknown[] = [];
+				const tool = {
+					...approvalTool,
+					approval: (args: unknown) => {
+						observed.push(args);
+						return "exec" as const;
+					},
+					execute: async (_toolCallId: string, params: unknown) => {
+						executed.push(params);
+						return { content: [{ type: "text" as const, text: "ok" }] };
+					},
+				};
+
+				const result = await executeReviewCase(runner, tool, "call-approval-invocations", {
+					params: { command: "echo safe" },
+				});
+
+				expect(firstReviewText(result)).toBe("ok");
+				expect(reviewHandler).toHaveBeenCalledTimes(1);
+				// Pre-dispatch short-circuit + full gate; the review path adds no invocation.
+				expect(observed).toHaveLength(2);
+				expect(observed[0]).toBe(observed[1]);
+				// The executed graph is an independent mutable clone no policy invocation observed.
+				expect(observed).not.toContain(executed[0]);
+				expect(Object.isFrozen(executed[0])).toBe(false);
+			});
+
+			it("null-prototype input bypasses extension review and keeps native semantics", async () => {
+				const reviewHandler = vi.fn(async () => ({ decision: "approve" as const }));
+				const runner = dispatchRunner([reviewHandler]);
+				const select = vi.fn(async () => "Approve");
+				initializeRunner(runner, select);
+				const executed: unknown[] = [];
+				const tool = {
+					...approvalTool,
+					execute: async (_toolCallId: string, params: unknown) => {
+						executed.push(params);
+						return { content: [{ type: "text" as const, text: "ok" }] };
+					},
+				};
+				const params = Object.create(null) as { command: string };
+				params.command = "echo hi";
+
+				const result = await executeReviewCase(runner, tool, "call-null-proto", { params });
 
 				expect(firstReviewText(result)).toBe("ok");
 				expect(reviewHandler).not.toHaveBeenCalled();
 				expect(select).toHaveBeenCalledTimes(1);
-				expect(executed).toEqual([transformedInput]);
-				expect(executed[0]).toBe(transformedInput);
+				expect(executed[0]).toBe(params);
 			});
 
-			it("owned policy re-resolution deny is authoritative before review", async () => {
+			it("frozen and sealed inputs bypass extension review and keep native semantics", async () => {
+				for (const toolCallId of ["call-frozen", "call-sealed"]) {
+					const reviewHandler = vi.fn(async () => ({ decision: "approve" as const }));
+					const runner = dispatchRunner([reviewHandler]);
+					const select = vi.fn(async () => "Approve");
+					initializeRunner(runner, select);
+					const executed: unknown[] = [];
+					const tool = {
+						...approvalTool,
+						execute: async (_id: string, params: unknown) => {
+							executed.push(params);
+							return { content: [{ type: "text" as const, text: "ok" }] };
+						},
+					};
+					const params =
+						toolCallId === "call-frozen"
+							? Object.freeze({ command: "echo hi" })
+							: Object.seal({ command: "echo hi" });
+
+					const result = await executeReviewCase(runner, tool, toolCallId, { params });
+
+					expect(firstReviewText(result)).toBe("ok");
+					expect(reviewHandler).not.toHaveBeenCalled();
+					expect(select).toHaveBeenCalledTimes(1);
+					expect(executed[0]).toBe(params);
+				}
+			});
+
+			it("non-enumerable property input bypasses extension review and keeps native semantics", async () => {
 				const reviewHandler = vi.fn(async () => ({ decision: "approve" as const }));
-				const transformedInput = { command: "echo hi" };
-				const runner = dispatchRunner([reviewHandler], [async () => ({ input: transformedInput })]);
+				const runner = dispatchRunner([reviewHandler]);
 				const select = vi.fn(async () => "Approve");
 				initializeRunner(runner, select);
-				const execute = vi.fn(async () => ({ content: [{ type: "text" as const, text: "ran" }] }));
+				const executed: unknown[] = [];
 				const tool = {
 					...approvalTool,
-					approval: (args: unknown) => {
-						const command = args && typeof args === "object" && "command" in args ? args.command : undefined;
-						if (command === "echo original" || args === transformedInput) {
-							return "exec" as const;
-						}
-						return { policy: "deny", tier: "exec", reason: "owned clone denied" } as const;
+					execute: async (_toolCallId: string, params: unknown) => {
+						executed.push(params);
+						return { content: [{ type: "text" as const, text: "ok" }] };
 					},
-					execute,
 				};
+				const params: Record<string, unknown> = {};
+				Object.defineProperty(params, "command", {
+					value: "echo hi",
+					writable: true,
+					enumerable: false,
+					configurable: true,
+				});
 
-				await expect(
-					executeReviewCase(runner, tool, "call-owned-resolution-deny", {
-						params: { command: "echo original" },
-					}),
-				).rejects.toThrow('Tool "dangerous_tool" is blocked by tool policy.\nReason: owned clone denied');
+				const result = await executeReviewCase(runner, tool, "call-non-enumerable", { params });
+
+				expect(firstReviewText(result)).toBe("ok");
 				expect(reviewHandler).not.toHaveBeenCalled();
-				expect(select).not.toHaveBeenCalled();
-				expect(execute).not.toHaveBeenCalled();
+				expect(select).toHaveBeenCalledTimes(1);
+				expect(executed[0]).toBe(params);
 			});
 
 			it("native deny stays authoritative on non-cloneable input and never dispatches review", async () => {

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -2629,6 +2629,10 @@ describe("ExtensionRunner", () => {
 				constructor(command: string) {
 					this.command = command;
 				}
+
+				describe(): string {
+					return `prototype:${this.command}`;
+				}
 			}
 
 			const setTrace = (): Array<Record<string, unknown>> => {
@@ -3428,9 +3432,119 @@ describe("ExtensionRunner", () => {
 				expect(executed[0]).toBe(params);
 			});
 
+			it("cloneable class input skips review and native approval preserves the original instance", async () => {
+				const reviewHandler = vi.fn(async () => ({ decision: "approve" as const }));
+				const transformedInput = new PrototypeSensitiveInput("echo reviewed");
+				const runner = dispatchRunner([reviewHandler], [async () => ({ input: transformedInput })]);
+				const select = vi.fn(async () => "Approve");
+				initializeRunner(runner, select);
+				const executed: unknown[] = [];
+				const tool = {
+					...approvalTool,
+					approval: () => "exec" as const,
+					execute: async (_toolCallId: string, params: unknown) => {
+						executed.push(params);
+						return { content: [{ type: "text" as const, text: "ok" }] };
+					},
+				};
+
+				await executeReviewCase(runner, tool, "call-class-input", {
+					params: { command: "echo original" },
+				});
+
+				expect(reviewHandler).not.toHaveBeenCalled();
+				expect(select).toHaveBeenCalledTimes(1);
+				expect(executed[0]).toBe(transformedInput);
+				expect(executed[0]).toBeInstanceOf(PrototypeSensitiveInput);
+				expect((executed[0] as PrototypeSensitiveInput).describe()).toBe("prototype:echo reviewed");
+			});
+
+			it("cloneable exotic input skips review and native approval preserves original identity", async () => {
+				const reviewHandler = vi.fn(async () => ({ decision: "approve" as const }));
+				const timestamp = new Date("2026-08-31T00:00:00.000Z");
+				const transformedInput = { command: "echo reviewed", timestamp };
+				const runner = dispatchRunner([reviewHandler], [async () => ({ input: transformedInput })]);
+				const select = vi.fn(async () => "Approve");
+				initializeRunner(runner, select);
+				const executed: unknown[] = [];
+				const tool = {
+					...approvalTool,
+					approval: () => "exec" as const,
+					execute: async (_toolCallId: string, params: unknown) => {
+						executed.push(params);
+						return { content: [{ type: "text" as const, text: "ok" }] };
+					},
+				};
+
+				await executeReviewCase(runner, tool, "call-exotic-input", {
+					params: { command: "echo original" },
+				});
+
+				expect(reviewHandler).not.toHaveBeenCalled();
+				expect(select).toHaveBeenCalledTimes(1);
+				expect(executed[0]).toBe(transformedInput);
+				expect((executed[0] as typeof transformedInput).timestamp).toBe(timestamp);
+			});
+
+			it("plain input with no review handlers preserves original identity through native approval", async () => {
+				const transformedInput = { command: "echo reviewed" };
+				const runner = dispatchRunner([], [async () => ({ input: transformedInput })]);
+				const select = vi.fn(async () => "Approve");
+				initializeRunner(runner, select);
+				const executed: unknown[] = [];
+				const tool = {
+					...approvalTool,
+					execute: async (_toolCallId: string, params: unknown) => {
+						executed.push(params);
+						return { content: [{ type: "text" as const, text: "ok" }] };
+					},
+				};
+
+				await executeReviewCase(runner, tool, "call-no-review-plain-input", {
+					params: { command: "echo original" },
+				});
+
+				expect(select).toHaveBeenCalledTimes(1);
+				expect(executed[0]).toBe(transformedInput);
+			});
+
+			it("real review escalation keeps owned input authoritative through native approval", async () => {
+				const transformedInput = { command: "echo reviewed" };
+				const reviewed: Array<Readonly<Record<string, unknown>>> = [];
+				const runner = dispatchRunner(
+					[
+						async event => {
+							reviewed.push(event.input);
+							transformedInput.command = "rm -rf";
+							return { decision: "escalate" };
+						},
+					],
+					[async () => ({ input: transformedInput })],
+				);
+				const select = vi.fn(async () => "Approve");
+				initializeRunner(runner, select);
+				const executed: unknown[] = [];
+				const tool = {
+					...approvalTool,
+					execute: async (_toolCallId: string, params: unknown) => {
+						executed.push(params);
+						return { content: [{ type: "text" as const, text: "ok" }] };
+					},
+				};
+
+				await executeReviewCase(runner, tool, "call-reviewed-escalation", {
+					params: { command: "echo original" },
+				});
+
+				expect(reviewed).toEqual([{ command: "echo reviewed" }]);
+				expect(select).toHaveBeenCalledTimes(1);
+				expect(executed[0]).not.toBe(transformedInput);
+				expect(executed[0]).toEqual({ command: "echo reviewed" });
+			});
+
 			it("owned policy re-resolution failure skips review and uses native approval", async () => {
 				const reviewHandler = vi.fn(async () => ({ decision: "approve" as const }));
-				const transformedInput = new PrototypeSensitiveInput("echo hi");
+				const transformedInput = { command: "echo hi" };
 				const runner = dispatchRunner([reviewHandler], [async () => ({ input: transformedInput })]);
 				const select = vi.fn(async () => "Approve");
 				initializeRunner(runner, select);
@@ -3439,8 +3553,8 @@ describe("ExtensionRunner", () => {
 					...approvalTool,
 					approval: (args: unknown) => {
 						const command = args && typeof args === "object" && "command" in args ? args.command : undefined;
-						if (command !== "echo original" && !(args instanceof PrototypeSensitiveInput)) {
-							throw new Error("Approval input lost its prototype");
+						if (command !== "echo original" && args !== transformedInput) {
+							throw new Error("Approval input lost its source identity");
 						}
 						return "exec" as const;
 					},
@@ -3463,7 +3577,7 @@ describe("ExtensionRunner", () => {
 
 			it("owned policy re-resolution deny is authoritative before review", async () => {
 				const reviewHandler = vi.fn(async () => ({ decision: "approve" as const }));
-				const transformedInput = new PrototypeSensitiveInput("echo hi");
+				const transformedInput = { command: "echo hi" };
 				const runner = dispatchRunner([reviewHandler], [async () => ({ input: transformedInput })]);
 				const select = vi.fn(async () => "Approve");
 				initializeRunner(runner, select);
@@ -3472,7 +3586,7 @@ describe("ExtensionRunner", () => {
 					...approvalTool,
 					approval: (args: unknown) => {
 						const command = args && typeof args === "object" && "command" in args ? args.command : undefined;
-						if (command === "echo original" || args instanceof PrototypeSensitiveInput) {
+						if (command === "echo original" || args === transformedInput) {
 							return "exec" as const;
 						}
 						return { policy: "deny", tier: "exec", reason: "owned clone denied" } as const;


### PR DESCRIPTION
## What

Adds a `tool_approval_review` extension event so extensions can approve, deny, or fall back to OMP's normal approval UI for eligible tool calls.

I tried to keep this minimal because the main problem was the native approval UI interrupting the flow even after an extension had already made a decision.

## Why

This was mainly needed for permission/guard extensions. Without this hook, an extension can decide that a call is allowed or denied, but the user is still asked again.

Native `allow | prompt | deny` behavior stays authoritative; the extension review only runs at the eligible approval point.

## Testing

I tested this locally for a couple of days using my own approval extension, and added coverage for approval, denial, fallback, cancellation, malformed handlers, input mutation, and native safety gates.

* [x] `bun check` passes
* [x] Tested locally
* [x] CHANGELOG updated (if user-facing)