### PR TITLE
fix(edit): gate sloppy no-match anchor guess on confidence

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Fixed an issue where custom model overrides were lost during configuration updates
 - Fixed "Please use nerdfont" notification incorrectly persisting after theme configuration
 - Fixed sampling parameter errors for newer Anthropic models (Opus 4.7+, Sonnet 5+)
+- Fixed sloppy/SPARSE edit no-match guidance emitting a mislabeled "Copy-ready corrected operation" that guessed a fuzzy anchor and dropped sibling operations; low-confidence matches are now surfaced as non-copyable guidance ([#10411](https://github.com/can1357/oh-my-pi/issues/10411)).
 
 ## [18.0.11] - 2026-08-29
 

--- a/packages/coding-agent/src/edit/sloppy.test.ts
+++ b/packages/coding-agent/src/edit/sloppy.test.ts
@@ -1494,6 +1494,29 @@ describe("sloppy v8", () => {
 		);
 	});
 
+	test("labels a fuzzy no-match anchor as non-copyable instead of guessing a corrected operation", () => {
+		const content = "single: 1;\nreal: 2;\n";
+		const input = `${M.open}\nreal: ⟪2│TWO⟫;\n${M.open}\nnope: ⟪nothing│X⟫;`;
+
+		let message = "";
+		try {
+			variant.apply(content, input, { path: "bt.txt" });
+		} catch (error) {
+			message = (error as Error).message;
+		}
+
+		// The unmatched op is named and grounded in current file content.
+		expect(message).toMatch(/Operation 2 did not match bt\.txt\. Failed fragment: "nope:" has 0 occurrences\./);
+		// No fabricated retry: the guess `ngle:` (a sliver of `single:`) never appears,
+		// and the block is not mislabeled copy-ready when it would drop the sibling op.
+		expect(message).not.toContain(`ngle:${M.selectOpen}`);
+		expect(message).not.toContain("Copy-ready corrected operation:");
+		expect(message).toContain("No copy-ready correction");
+		expect(message).toContain(
+			"No operations were applied — ops apply atomically; re-send the full corrected payload.",
+		);
+	});
+
 	test("teaches insert intent when MATCH is text the author meant to add", () => {
 		const content = ["switch (event.type) {", "  case 'message':", "    handleMessage(event);", "}", ""].join("\n");
 		const input = operation("  case 'end_turn':", "  case 'end_turn':\n    finishTurn();");

--- a/packages/coding-agent/src/edit/sloppy.ts
+++ b/packages/coding-agent/src/edit/sloppy.ts
@@ -2097,7 +2097,7 @@ function closestFragment(
 	content: string,
 	token: LiteralToken,
 	centerOffset?: number,
-): { text: string; offset: number } {
+): { text: string; offset: number; score: number } {
 	const ranked: Array<{ line: string; offset: number; normalized: NormalizedText; score: number }> = [];
 	const centerLine = centerOffset === undefined ? undefined : lineNumberAt(content, centerOffset) - 1;
 	let offset = 0;
@@ -2117,7 +2117,7 @@ function closestFragment(
 	}
 	const first = ranked[0];
 	if (!first && centerOffset !== undefined) return closestFragment(content, token);
-	if (!first) return { text: token.text, offset: 0 };
+	if (!first) return { text: token.text, offset: 0, score: 1 };
 
 	let best = { text: first.line, offset: first.offset, score: first.score };
 	if (token.normalized.length <= 160) {
@@ -2141,7 +2141,7 @@ function closestFragment(
 			}
 		}
 	}
-	return { text: best.text, offset: best.offset };
+	return { text: best.text, offset: best.offset, score: best.score };
 }
 
 /**
@@ -2210,12 +2210,21 @@ function numberedPreview(content: string, offset: number): string {
 		.join("\n");
 }
 
+/**
+ * Normalized edit-distance ceiling below which `closestFragment`'s nearest
+ * text is trusted as a real correction of an unmatched fragment. Above it the
+ * closest match is a fuzzy sliver (e.g. `ngle:` cut from `single:`), so the
+ * guidance is presented as non-copyable rather than a fabricated retry. Mirrors
+ * the acceptance bound used by `closestDesiredBlock`.
+ */
+const CONFIDENT_CORRECTION_SCORE = 0.35;
+
 function noMatchGuidance(
 	content: string,
 	normalized: NormalizedText,
 	pattern: ParsedPattern,
 	operation: Operation,
-): { reason: string; previewOffset: number; correctedPattern: string; additionRetry?: string } {
+): { reason: string; previewOffset: number; correctedPattern: string; copyReady: boolean; additionRetry?: string } {
 	const literals = pattern.tokens.flatMap((token, index) =>
 		token.kind === "literal" ? [{ index, token, occurrences: occurrencesForLiteral(normalized, token) }] : [],
 	);
@@ -2231,12 +2240,16 @@ function noMatchGuidance(
 		const anchorOffset = anchor?.occurrences[0] ? sourceStart(normalized, anchor.occurrences[0].start, 0) : undefined;
 		const closest = closestFragment(content, missing.token, anchorOffset);
 		const at = operation.patternText.indexOf(missing.token.text);
-		const correctedPattern =
-			at >= 0 && closest.text !== ""
-				? operation.patternText.slice(0, at) +
-					closest.text +
-					operation.patternText.slice(at + missing.token.text.length)
-				: operation.patternText;
+		// Rewrite the unmatched fragment to the closest current text only when
+		// that text is a confident match. A low-confidence sliver would make the
+		// "corrected" operation target unintended text, so keep the original
+		// pattern and mark the guidance non-copyable instead.
+		const confidentCorrection = at >= 0 && closest.text !== "" && closest.score < CONFIDENT_CORRECTION_SCORE;
+		const correctedPattern = confidentCorrection
+			? operation.patternText.slice(0, at) +
+				closest.text +
+				operation.patternText.slice(at + missing.token.text.length)
+			: operation.patternText;
 		const lineStart = content.lastIndexOf("\n", Math.max(0, closest.offset - 1)) + 1;
 		const newline = content.indexOf("\n", closest.offset);
 		const neighborLine = content.slice(lineStart, newline === -1 ? content.length : newline);
@@ -2252,6 +2265,7 @@ function noMatchGuidance(
 				(anchor ? ` It broke relative to matched anchor ${displayFragment(anchor.token.text)}.` : ""),
 			previewOffset: anchorOffset ?? closest.offset,
 			correctedPattern,
+			copyReady: confidentCorrection,
 			additionRetry:
 				looksLikeAddition && additionText !== undefined && neighborLine.trim() !== ""
 					? `If you are ADDING this text: match the existing neighbor line it belongs next to, and put the new text in the REWRITE —\n${OPENER}\n${SELECT_OPEN}${SELECT_CLOSE}${neighborLine}\n${REWRITE_HEADER}\n${additionText}`
@@ -2285,6 +2299,7 @@ function noMatchGuidance(
 			reason: `Failed fragment: ${displayFragment(only?.token.text ?? operation.patternText)} could not align.`,
 			previewOffset: only?.occurrences[0] ? sourceStart(normalized, only.occurrences[0].start, 0) : 0,
 			correctedPattern: operation.patternText,
+			copyReady: false,
 		};
 	}
 
@@ -2302,6 +2317,7 @@ function noMatchGuidance(
 
 		previewOffset: sourceStart(normalized, broken.left.occurrences[0]?.start ?? 0, 0),
 		correctedPattern,
+		copyReady: correctedPattern !== operation.patternText,
 	};
 }
 function nonConsecutiveGuidance(
@@ -2514,8 +2530,14 @@ function locate(
 					: `Operation ${operationNumber} did not match ${path}. ${guidance.reason}`,
 				"Current file content near the closest match (no re-read needed):",
 				numberedPreview(content, guidance.previewOffset),
-				"Copy-ready corrected operation:",
-				operationPayload(operation, operation.all ? "*" : "", guidance.correctedPattern),
+				...(guidance.copyReady
+					? [
+							"Copy-ready corrected operation:",
+							operationPayload(operation, operation.all ? "*" : "", guidance.correctedPattern),
+						]
+					: [
+							"No copy-ready correction — the closest current text is only a fuzzy match. Re-read the region above and rebuild MATCH from the exact current text.",
+						]),
 				...(guidance.additionRetry ? [guidance.additionRetry] : []),
 			].join("\n"),
 		);


### PR DESCRIPTION
## Repro
In sloppy/SPARSE edit mode, a two-operation payload whose second op fails to match throws a diagnostic labeled `Copy-ready corrected operation`. Against fixture `single: 1;\nreal: 2;` and payload `real: ⟪2│TWO⟫;` then `nope: ⟪nothing│X⟫;`, the block swaps the unmatched `nope:` for the fuzzy sliver `ngle:` (cut from the middle of `single:`) and shows only the failing op, while the appended notice says `re-send the full corrected payload`. Reproduced with:

```
bun -e 'import { sloppyVariant as v, SLOPPY_MARKERS as M } from "./packages/coding-agent/src/edit/sloppy.ts"; const c="single: 1;\nreal: 2;\n"; const i=`${M.open}\nreal: ⟪2│TWO⟫;\n${M.open}\nnope: ⟪nothing│X⟫;`; try { v.apply(c, i, { path: "/tmp/bt_d1.txt" }); } catch (e) { console.log(e.message); }'
```

## Cause
`noMatchGuidance` (`packages/coding-agent/src/edit/sloppy.ts`) always rewrote the unmatched fragment to `closestFragment`'s best-effort nearest text with no confidence gate, then `locate` unconditionally emitted it under `Copy-ready corrected operation:`. `closestFragment` returns a nearest sliver regardless of edit distance, so a 40%-different match (`nope:` → `ngle:`) was presented as a copyable retry. Combined with the atomic `ATOMICITY_NOTICE`, the single-op block was both a guess and incomplete.

## Fix
- `closestFragment` now returns its normalized edit-distance `score`.
- `noMatchGuidance` rewrites the unmatched fragment only when `score` clears `CONFIDENT_CORRECTION_SCORE` (0.35, mirroring `closestDesiredBlock`'s bound); otherwise it keeps the original pattern. Each branch reports a `copyReady` flag.
- `locate` emits the `Copy-ready corrected operation:` block only when the correction is trustworthy; low-confidence cases surface non-copyable guidance directing a re-read. A confident single-token correction (e.g. `fetchLegacy` → `fetchCurrent`) still renders copy-ready.
- Changelog + regression test added.

## Verification
`bun test src/edit/sloppy.test.ts` → 179 pass / 0 fail (new test asserts the reported repro no longer emits a guessed/mislabeled copy-ready block, and the existing confident-correction test still asserts `Copy-ready corrected operation:`). `bun run fix` + `bun check:tools` clean. Fixes #10411