### PR TITLE
fix(ai): strip compaction statuses from replay

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -23,7 +23,7 @@
 
 ### Fixed
 
-- Fixed OpenAI remote-compaction replay sending output-only `status` fields on `compaction` and `compaction_summary` items, allowing already-persisted sessions to resume without `input[N].status` request failures.
+- Fixed OpenAI remote-compaction replay sending output-only `status` fields on `compaction` and `compaction_summary` items, allowing already-persisted sessions to resume without `input[N].status` request failures. ([#10415](https://github.com/can1357/oh-my-pi/pull/10415) by [@spgsroot](https://github.com/spgsroot))
 - Fixed Z.AI (GLM Coding Plan) browser sign-in being rejected with "Redirect URI not registered for this client": the flow now advertises the ZCode-registered CLI callback `http://127.0.0.1:9999/callback` instead of the unregistered `localhost:54548` ([#10245](https://github.com/can1357/oh-my-pi/issues/10245)).
 
 ## [18.0.11] - 2026-08-29

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 ### Fixed
 
+- Fixed OpenAI remote-compaction replay sending output-only `status` fields on `compaction` and `compaction_summary` items, allowing already-persisted sessions to resume without `input[N].status` request failures.
 - Fixed Z.AI (GLM Coding Plan) browser sign-in being rejected with "Redirect URI not registered for this client": the flow now advertises the ZCode-registered CLI callback `http://127.0.0.1:9999/callback` instead of the unregistered `localhost:54548` ([#10245](https://github.com/can1357/oh-my-pi/issues/10245)).
 
 ## [18.0.11] - 2026-08-29

--- a/packages/ai/src/utils.ts
+++ b/packages/ai/src/utils.ts
@@ -84,7 +84,11 @@ export function stripOpenAIResponsesOutputOnlyStatusesForReplay<TItem extends { 
 	for (let index = 0; index < items.length; index++) {
 		const item = items[index]!;
 		const rejectsOutputStatus =
-			item.type === "message" || item.type === "function_call" || item.type === "custom_tool_call";
+			item.type === "message" ||
+			item.type === "function_call" ||
+			item.type === "custom_tool_call" ||
+			item.type === "compaction" ||
+			item.type === "compaction_summary";
 		if (!rejectsOutputStatus || !Object.hasOwn(item, "status")) {
 			sanitized?.push(item);
 			continue;

--- a/packages/ai/test/openai-responses-history-payload.test.ts
+++ b/packages/ai/test/openai-responses-history-payload.test.ts
@@ -1220,6 +1220,16 @@ describe("OpenAI responses history payload", () => {
 				call_id: opaqueCustomCallId,
 				output: "patch applied",
 			},
+			{
+				type: "compaction",
+				encrypted_content: "encrypted-compaction",
+				status: "completed",
+			},
+			{
+				type: "compaction_summary",
+				summary: "compacted context",
+				status: "completed",
+			},
 			{ type: "item_reference", id: opaqueMessageId },
 		];
 		const context: Context = {
@@ -1237,6 +1247,8 @@ describe("OpenAI responses history payload", () => {
 		const functionCallOutputItem = findResponsesInputItem(payload.input, "function_call_output");
 		const customToolCallItem = findResponsesInputItem(payload.input, "custom_tool_call");
 		const itemReference = findResponsesInputItem(payload.input, "item_reference");
+		const compactionItem = findResponsesInputItem(payload.input, "compaction");
+		const compactionSummaryItem = findResponsesInputItem(payload.input, "compaction_summary");
 		const expectedCallId = truncateResponseItemId(opaqueCallId, "call");
 
 		expect(reasoningItem).toBeDefined();
@@ -1253,12 +1265,16 @@ describe("OpenAI responses history payload", () => {
 		expect(messageItem).not.toHaveProperty("status");
 		expect(functionCallItem).not.toHaveProperty("status");
 		expect(customToolCallItem).not.toHaveProperty("status");
+		expect(compactionItem).not.toHaveProperty("status");
+		expect(compactionSummaryItem).not.toHaveProperty("status");
 		expect(
 			(payload.input ?? []).some(
 				item => item && typeof item === "object" && "id" in (item as Record<string, unknown>),
 			),
 		).toBe(false);
 		expect(reasoningItem?.encrypted_content).toBe("enc_opaque");
+		expect(compactionItem?.encrypted_content).toBe("encrypted-compaction");
+		expect(compactionSummaryItem?.summary).toBe("compacted context");
 		expect(functionCallItem).toBeDefined();
 		expect(functionCallItem!.call_id).toBe(expectedCallId);
 		expect(functionCallOutputItem?.call_id).toBe(expectedCallId);
@@ -1274,7 +1290,9 @@ describe("OpenAI responses history payload", () => {
 		expect(replayHistoryItems[3]?.id).toBe("fco_should_be_removed");
 		expect(replayHistoryItems[3]?.call_id).toBe(opaqueCallId);
 		expect(replayHistoryItems[4]?.status).toBe("completed");
-		expect(replayHistoryItems[6]?.id).toBe(opaqueMessageId);
+		expect(replayHistoryItems[6]?.status).toBe("completed");
+		expect(replayHistoryItems[7]?.status).toBe("completed");
+		expect(replayHistoryItems[8]?.id).toBe(opaqueMessageId);
 	});
 
 	it("preserves the reasoning ID linked to a native computer call in the next request", async () => {


### PR DESCRIPTION
## Summary

- strip output-only `status` from replayed `compaction` and `compaction_summary` Responses items
- preserve the original persisted provider payload so existing session history is not mutated
- extend the final request-payload regression and document the fix in the AI changelog

## Why

Remote compaction can persist `{ type: "compaction", status: "completed", ... }` in `openaiRemoteCompaction.replacementHistory`. Replaying that output item as input makes Codex reject every resumed turn with `Unknown parameter: input[N].status`. This is a follow-up to #6513 for the compaction item types introduced on the remote-compaction replay path.

## Verification

- `bun test packages/ai/test/openai-responses-history-payload.test.ts` — 33 pass, 0 fail
- `bun run check:ts` — passed across the workspace
- `bun --cwd=packages/ai run check` — passed
- exercised the source CLI against a copy of a real persisted session containing `compaction.status`; `bun run dev --resume <copy> --no-session --model openai-codex/gpt-5.6-sol -p "Ответь только OK"` returned `OK` instead of `input[N].status`

`bun check` reached the Rust workspace after adding Visual Studio's Ninja to `PATH`, then stopped on pre-existing `pi-walker` Clippy `-D warnings` failures (`missing_const_for_fn`, `unused_self`, `manual_is_multiple_of`, `chunks_exact_to_as_chunks`, `unnecessary_wraps`). The TypeScript workspace check above passed.