### PR TITLE
fix(coding-agent/edit): fall back from hashline to sloppy for GLM Flash models

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 ### Changed
 
-- Disabled `hashline` edit mode for Kimi, Mimo, DeepSeek Flash, and Stepfun models for stability
+- Disabled `hashline` edit mode for Kimi, Mimo, DeepSeek Flash, Stepfun, and GLM Flash models for stability
 
 ### Fixed
 

--- a/packages/coding-agent/src/utils/edit-mode.ts
+++ b/packages/coding-agent/src/utils/edit-mode.ts
@@ -36,7 +36,8 @@ function modelSupportsHashlineEdits(modelId: string): boolean {
 		identity.class === "kimi" ||
 		identity.class === "mimo" ||
 		(identity.class === "deepseek" && identity.family === "flash") ||
-		identity.class === "stepfun"
+		identity.class === "stepfun" ||
+		(identity.class === "glm" && identity.family === "flash")
 	);
 }
 

--- a/packages/coding-agent/test/edit-mode.test.ts
+++ b/packages/coding-agent/test/edit-mode.test.ts
@@ -67,6 +67,19 @@ describe("resolveEditMode", () => {
 		expect(resolveEditMode(createSession({ activeModel: "kilo/stepfun/step-3.7-flash:free" }))).toBe("sloppy");
 	});
 
+	test("falls back from hashline to sloppy for GLM Flash models", () => {
+		delete Bun.env.PI_EDIT_VARIANT;
+
+		expect(resolveEditMode(createSession({ activeModel: "zai/glm-5.3-flash" }))).toBe("sloppy");
+		expect(resolveEditMode(createSession({ activeModel: "glm-4.5-flashx" }))).toBe("sloppy");
+	});
+
+	test("does not exclude non-Flash GLM models", () => {
+		delete Bun.env.PI_EDIT_VARIANT;
+
+		expect(resolveEditMode(createSession({ activeModel: "zai/glm-5.3" }))).toBe("hashline");
+	});
+
 	test("does not exclude non-Kimi Moonshot models", () => {
 		delete Bun.env.PI_EDIT_VARIANT;
 


### PR DESCRIPTION
## Problem

GLM Flash SKUs (`glm-5.3-flash`, `glm-4.5-flashx`) frequently over-edit, under-edit, or anchor the wrong lines in hashline mode — the same failure class as the already-excluded DeepSeek V4 Flash and Step 3.7 Flash budget tiers. Refs #2241 (the glm-5.1 report; #2243's hardcoded per-id fallback was closed, but the taxonomy now has a principled `class`/`family` check to hang this on).

## Change

One clause in `modelSupportsHashlineEdits`: exclude `class === "glm" && family === "flash"`. Non-Flash GLM (`glm-5.3`, `glm-4.5`) are unaffected. Explicit opt-ins (`edit.modelVariants`, `PI_EDIT_VARIANT`, `PI_STRICT_EDIT_MODE`) still win.

## Verification

Reproduced the resolution path directly: `resolveEditMode` returned `hashline` for `zai/glm-5.3-flash` before the change and `sloppy` after; `zai/glm-5.3` stays `hashline` in both. `bun test packages/coding-agent/test/edit-mode.test.ts` passes 11/11 (9 existing + 2 new), `biome check` and `tsgo --noEmit` are clean.

I reviewed the full diff; I hit this daily with glm-5.3-flash on z.ai and confirmed the fallback resolves it.