### PR TITLE
feat(coding-agent): hide zero-use supplemental usage meters

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added a `display.showZeroUsageMeters` setting to hide untouched supplemental model and tier quota meters from live usage reports ([#10423](https://github.com/can1357/oh-my-pi/pull/10423) by [@mvid](https://github.com/mvid)).
+
 ## [18.1.17] - 2026-09-10
 
 ### Added
@@ -133,17 +137,6 @@
 
 - Added the `retry.waitForUsageReset` setting: when a provider reports usage-limit exhaustion with a reset time (5-hour or weekly quota windows on any provider), the session sleeps until the reset instead of failing fast past `retry.maxDelayMs`.
 - Added opt-in `bash.allowCompoundCommands` approval for conservative literal `&&` chains, with ordered per-segment rules and normal bash policy fallback for unmatched segments. The opt-in requires a positively classified POSIX-quoting shell; incompatible and unknown shells retain legacy approval. Whole-chain denies take precedence over earlier prompts.
-- Added `injectV1: false` option to `openai-models-list` discovery to fetch the model list from `{baseUrl}/models` without injecting `/v1`, for gateways that root their OpenAI-compatible surface at a versioned URL (e.g. `https://api.opper.ai/v3/compat`) where the `/v1`-injected endpoint returns only a small subset.
-- Added provider-reported credits and concrete routed-model counts to `/session` statistics ([#8590](https://github.com/can1357/oh-my-pi/pull/8590) by [@will-bogusz](https://github.com/will-bogusz)).
-- Added `CLINE_API_KEY` to the CLI environment help for native ClinePass subscription inference ([#7863](https://github.com/can1357/oh-my-pi/pull/7863) by [@will-bogusz](https://github.com/will-bogusz)).
-- Devin model selectors now accept the native CLI's short aliases (`devin/opus`, `devin/swe`), dotted upstream spellings (`devin/gemini-3.7-flash`), and raw effort-route wire uids for dynamically collapsed families ([#8590](https://github.com/can1357/oh-my-pi/pull/8590) by [@will-bogusz](https://github.com/will-bogusz)).
-- Added provider-supplied model metadata to the `/models` detail line: `new`, `beta`, and `recommended` badges beside the model name, and the upstream description after the context, cost, and perf facts ([#8590](https://github.com/can1357/oh-my-pi/pull/8590) by [@will-bogusz](https://github.com/will-bogusz)).
-- Standalone `CLAUDE.md` files in the project root (and ancestor directories) are now loaded as context, mirroring `AGENTS.md` discovery; config-directory context files still take precedence per scope.
-- Added a `display.showZeroUsageMeters` setting to hide untouched supplemental model and tier quota meters from live usage reports ([#10423](https://github.com/can1357/oh-my-pi/pull/10423) by [@mvid](https://github.com/mvid)).
-
-### Changed
-
-- Disabled `hashline` edit mode for Kimi, Mimo, DeepSeek Flash, and Stepfun models for stability
 
 ### Fixed
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -133,6 +133,17 @@
 
 - Added the `retry.waitForUsageReset` setting: when a provider reports usage-limit exhaustion with a reset time (5-hour or weekly quota windows on any provider), the session sleeps until the reset instead of failing fast past `retry.maxDelayMs`.
 - Added opt-in `bash.allowCompoundCommands` approval for conservative literal `&&` chains, with ordered per-segment rules and normal bash policy fallback for unmatched segments. The opt-in requires a positively classified POSIX-quoting shell; incompatible and unknown shells retain legacy approval. Whole-chain denies take precedence over earlier prompts.
+- Added `injectV1: false` option to `openai-models-list` discovery to fetch the model list from `{baseUrl}/models` without injecting `/v1`, for gateways that root their OpenAI-compatible surface at a versioned URL (e.g. `https://api.opper.ai/v3/compat`) where the `/v1`-injected endpoint returns only a small subset.
+- Added provider-reported credits and concrete routed-model counts to `/session` statistics ([#8590](https://github.com/can1357/oh-my-pi/pull/8590) by [@will-bogusz](https://github.com/will-bogusz)).
+- Added `CLINE_API_KEY` to the CLI environment help for native ClinePass subscription inference ([#7863](https://github.com/can1357/oh-my-pi/pull/7863) by [@will-bogusz](https://github.com/will-bogusz)).
+- Devin model selectors now accept the native CLI's short aliases (`devin/opus`, `devin/swe`), dotted upstream spellings (`devin/gemini-3.7-flash`), and raw effort-route wire uids for dynamically collapsed families ([#8590](https://github.com/can1357/oh-my-pi/pull/8590) by [@will-bogusz](https://github.com/will-bogusz)).
+- Added provider-supplied model metadata to the `/models` detail line: `new`, `beta`, and `recommended` badges beside the model name, and the upstream description after the context, cost, and perf facts ([#8590](https://github.com/can1357/oh-my-pi/pull/8590) by [@will-bogusz](https://github.com/will-bogusz)).
+- Standalone `CLAUDE.md` files in the project root (and ancestor directories) are now loaded as context, mirroring `AGENTS.md` discovery; config-directory context files still take precedence per scope.
+- Added a `display.showZeroUsageMeters` setting to hide untouched supplemental model and tier quota meters from live usage reports.
+
+### Changed
+
+- Disabled `hashline` edit mode for Kimi, Mimo, DeepSeek Flash, and Stepfun models for stability
 
 ### Fixed
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -139,7 +139,7 @@
 - Devin model selectors now accept the native CLI's short aliases (`devin/opus`, `devin/swe`), dotted upstream spellings (`devin/gemini-3.7-flash`), and raw effort-route wire uids for dynamically collapsed families ([#8590](https://github.com/can1357/oh-my-pi/pull/8590) by [@will-bogusz](https://github.com/will-bogusz)).
 - Added provider-supplied model metadata to the `/models` detail line: `new`, `beta`, and `recommended` badges beside the model name, and the upstream description after the context, cost, and perf facts ([#8590](https://github.com/can1357/oh-my-pi/pull/8590) by [@will-bogusz](https://github.com/will-bogusz)).
 - Standalone `CLAUDE.md` files in the project root (and ancestor directories) are now loaded as context, mirroring `AGENTS.md` discovery; config-directory context files still take precedence per scope.
-- Added a `display.showZeroUsageMeters` setting to hide untouched supplemental model and tier quota meters from live usage reports.
+- Added a `display.showZeroUsageMeters` setting to hide untouched supplemental model and tier quota meters from live usage reports ([#10423](https://github.com/can1357/oh-my-pi/pull/10423) by [@mvid](https://github.com/mvid)).
 
 ### Changed
 

--- a/packages/coding-agent/src/cli/usage-cli.ts
+++ b/packages/coding-agent/src/cli/usage-cli.ts
@@ -22,8 +22,10 @@ import type { ClientUsageClientSummary } from "@oh-my-pi/pi-ai/usage";
 import { formatDuration, formatNumber, sanitizeText } from "@oh-my-pi/pi-utils";
 import chalk from "@oh-my-pi/pi-utils/chalk";
 import { ModelRegistry } from "../config/model-registry";
+import { Settings } from "../config/settings";
 import { discoverAuthStorage } from "../sdk";
 import { resolveAuthBrokerConfig } from "../session/auth-broker-config";
+import { filterUsageReportsForDisplay, type UsageDisplayOptions } from "../utils/usage-display";
 
 const BAR_WIDTH = 28;
 
@@ -633,12 +635,14 @@ function disabledIdentityLabel(summary: DisabledCredentialSummary, redaction?: M
  * each provider section as "no usage data" rows.
  */
 export function formatUsageBreakdown(
-	reports: UsageReport[],
+	inputReports: UsageReport[],
 	accounts: UsageAccountIdentity[],
 	nowMs: number,
 	redaction?: Map<string, string>,
 	disabled: DisabledCredentialSummary[] = [],
+	options: UsageDisplayOptions = {},
 ): string {
+	const reports = filterUsageReportsForDisplay(inputReports, options);
 	const reportsByProvider = new Map<string, UsageReport[]>();
 	for (const report of reports) {
 		const list = reportsByProvider.get(report.provider) ?? [];
@@ -1198,7 +1202,12 @@ export async function runUsageCommand(cmd: UsageCommandArgs): Promise<void> {
 			return;
 		}
 
-		process.stdout.write(`${formatUsageBreakdown(filteredReports, accounts, Date.now(), redaction, disabled)}\n`);
+		const settings = await Settings.loadReadOnly();
+		process.stdout.write(
+			`${formatUsageBreakdown(filteredReports, accounts, Date.now(), redaction, disabled, {
+				showZeroUsageMeters: settings.get("display.showZeroUsageMeters"),
+			})}\n`,
+		);
 	} finally {
 		authStorage.close();
 	}

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1348,6 +1348,17 @@ export const SETTINGS_SCHEMA = {
 			description: "Show the total prompt-to-yield time (including tool calls) on assistant message usage rows",
 		},
 	},
+
+	"display.showZeroUsageMeters": {
+		type: "boolean",
+		default: true,
+		ui: {
+			tab: "appearance",
+			group: "Display",
+			label: "Show Zero-Usage Meters",
+			description: "Show supplemental model or tier quota meters that currently report zero usage in /usage",
+		},
+	},
 	"display.cacheMissMarker": {
 		type: "boolean",
 		default: false,

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -85,6 +85,7 @@ import { applyHyperlinkSetting } from "../../tui/hyperlink";
 import { copyToClipboard } from "../../utils/clipboard";
 import { openPath } from "../../utils/open";
 import { setSessionTerminalTitle } from "../../utils/title-generator";
+import { filterUsageReportsForDisplay } from "../../utils/usage-display";
 import { getAssistantMessageLinkTargets } from "../utils/interactive-context-helpers";
 import { type AdvisorConfigDeps, AdvisorConfigOverlayComponent } from "../components/advisor-config";
 import { AgentHubOverlayComponent } from "../components/agent-hub";
@@ -287,17 +288,20 @@ export class SelectorController {
 					this.ctx.session.sessionId,
 				)
 			: undefined;
-		const usageModelSelectors = this.ctx.session.getUsageReportingModelSelectors(reports);
+		const displayReports = filterUsageReportsForDisplay(reports, {
+			showZeroUsageMeters: this.ctx.settings.get("display.showZeroUsageMeters"),
+		});
+		const usageModelSelectors = this.ctx.session.getUsageReportingModelSelectors(displayReports);
 		const done = () => {
 			overlayHandle?.hide();
 			this.focusActiveEditorArea();
 			this.ctx.ui.requestRender();
 		};
 		const dashboard = new UsageDashboardComponent({
-			reports,
+			reports: displayReports,
 			renderDetail: width =>
 				renderUsageReports(
-					reports,
+					displayReports,
 					theme,
 					Date.now(),
 					width,

--- a/packages/coding-agent/src/slash-commands/helpers/usage-report.ts
+++ b/packages/coding-agent/src/slash-commands/helpers/usage-report.ts
@@ -1,6 +1,7 @@
 import type { UsageLimit, UsageReport } from "@oh-my-pi/pi-ai";
 import { sanitizeText } from "@oh-my-pi/pi-utils";
 import type { OAuthAccountIdentity } from "../../session/auth-storage";
+import { filterUsageReportsForDisplay } from "../../utils/usage-display";
 import type { SlashCommandRuntime } from "../types";
 import { reportMatchesActiveAccount } from "./active-oauth-account";
 import { formatDuration, formatProviderName, renderAsciiBar } from "./format";
@@ -165,9 +166,12 @@ export async function buildUsageReportText(runtime: SlashCommandRuntime): Promis
 						runtime.session.sessionId,
 					)
 				: undefined;
-			const usageModelSelectors = provider.getUsageReportingModelSelectors?.(reports) ?? [];
+			const displayReports = filterUsageReportsForDisplay(reports, {
+				showZeroUsageMeters: runtime.settings.get("display.showZeroUsageMeters"),
+			});
+			const usageModelSelectors = provider.getUsageReportingModelSelectors?.(displayReports) ?? [];
 			return renderUsageReports(
-				reports,
+				displayReports,
 				Date.now(),
 				providerId => (providerId === currentProvider ? activeAccount : undefined),
 				usageModelSelectors,

--- a/packages/coding-agent/src/utils/usage-display.ts
+++ b/packages/coding-agent/src/utils/usage-display.ts
@@ -1,5 +1,6 @@
 import { resolveUsedFraction, type UsageLimit, type UsageReport } from "@oh-my-pi/pi-ai";
 
+/** Controls whether untouched supplemental model and tier meters remain visible in formatted usage reports. */
 export interface UsageDisplayOptions {
 	showZeroUsageMeters?: boolean;
 }

--- a/packages/coding-agent/src/utils/usage-display.ts
+++ b/packages/coding-agent/src/utils/usage-display.ts
@@ -1,0 +1,49 @@
+import { resolveUsedFraction, type UsageLimit, type UsageReport } from "@oh-my-pi/pi-ai";
+
+export interface UsageDisplayOptions {
+	showZeroUsageMeters?: boolean;
+}
+
+interface MeterState {
+	allZero: boolean;
+	supplemental: boolean;
+}
+
+function meterKey(report: UsageReport, limit: UsageLimit): string | undefined {
+	const modelId = limit.scope.modelId?.trim().toLowerCase();
+	if (modelId) return `${report.provider}\0model:${modelId}`;
+	const tier = limit.scope.tier?.trim().toLowerCase();
+	if (tier) return `${report.provider}\0tier:${tier}`;
+	return undefined;
+}
+
+/** Hide zeroed supplemental meters without changing provider reports used for routing. */
+export function filterUsageReportsForDisplay(reports: UsageReport[], options: UsageDisplayOptions = {}): UsageReport[] {
+	if (options.showZeroUsageMeters !== false) return reports;
+
+	const meters = new Map<string, MeterState>();
+	for (const report of reports) {
+		const hasBaseLimit = report.limits.some(limit => meterKey(report, limit) === undefined);
+		for (const limit of report.limits) {
+			const key = meterKey(report, limit);
+			if (!key) continue;
+			const state = meters.get(key) ?? { allZero: true, supplemental: true };
+			state.allZero &&= resolveUsedFraction(limit) === 0;
+			state.supplemental &&= hasBaseLimit;
+			meters.set(key, state);
+		}
+	}
+
+	const hidden = new Set(
+		[...meters.entries()].filter(([, state]) => state.allZero && state.supplemental).map(([key]) => key),
+	);
+	if (hidden.size === 0) return reports;
+
+	return reports.map(report => {
+		const limits = report.limits.filter(limit => {
+			const key = meterKey(report, limit);
+			return key === undefined || !hidden.has(key);
+		});
+		return limits.length === report.limits.length ? report : { ...report, limits };
+	});
+}

--- a/packages/coding-agent/test/pr-3318-repro.test.ts
+++ b/packages/coding-agent/test/pr-3318-repro.test.ts
@@ -18,6 +18,7 @@ describe("PR 3318 repro", () => {
 			metadata: { email: "", accountId: "", projectId: "" },
 		};
 		const text = await buildUsageReportText({
+			settings: { get: () => undefined },
 			session: {
 				model: undefined,
 				fetchUsageReports: async () => [report],

--- a/packages/coding-agent/test/usage-cli.test.ts
+++ b/packages/coding-agent/test/usage-cli.test.ts
@@ -643,6 +643,28 @@ describe("formatUsageBreakdown", () => {
 		const occurrences = text.split(note).length - 1;
 		expect(occurrences).toBe(2);
 	});
+
+	it("filters zero supplemental meters before expanding multi-account templates", () => {
+		const provider = "meter-provider";
+		const reports = [
+			makeReport(provider, "account-a@example.test", [
+				makeLimit({ id: "base", provider, usedFraction: 0.2, windowId: "weekly" }),
+				makeLimit({ id: "supplemental", provider, tier: "unused-tier", usedFraction: 0, windowId: "weekly" }),
+			]),
+			makeReport(provider, "account-b@example.test", [
+				makeLimit({ id: "base", provider, usedFraction: 0.3, windowId: "weekly" }),
+			]),
+		];
+		const visible = stripVTControlCharacters(formatUsageBreakdown(reports, [], Date.now()));
+		const hidden = stripVTControlCharacters(
+			formatUsageBreakdown(reports, [], Date.now(), undefined, [], { showZeroUsageMeters: false }),
+		);
+
+		expect(visible).toContain("supplemental");
+		expect(hidden).toContain("base");
+		expect(hidden).not.toContain("supplemental");
+		expect(hidden).not.toContain("not reported");
+	});
 });
 
 describe("formatUsageHistory", () => {

--- a/packages/coding-agent/test/usage-cli.test.ts
+++ b/packages/coding-agent/test/usage-cli.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, vi } from "bun:test";
 import { stripVTControlCharacters } from "node:util";
 import type { UsageReport } from "@oh-my-pi/pi-ai";
 import {
@@ -7,8 +7,12 @@ import {
 	computeProviderWindowStats,
 	formatUsageBreakdown,
 	formatUsageHistory,
+	runUsageCommand,
 	type UsageAccountIdentity,
 } from "@oh-my-pi/pi-coding-agent/cli/usage-cli";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import * as sdkModule from "@oh-my-pi/pi-coding-agent/sdk";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 
 const HOUR = 3_600_000;
 const FIVE_HOURS = 5 * HOUR;
@@ -45,6 +49,36 @@ function makeLimit(opts: {
 function makeReport(provider: string, email: string, limits: UsageReport["limits"], notes?: string[]): UsageReport {
 	return { provider, fetchedAt: Date.now(), limits, ...(notes ? { notes } : {}), metadata: { email } };
 }
+describe("runUsageCommand", () => {
+	it("reads display.showZeroUsageMeters for standalone text output", async () => {
+		const provider = "meter-provider";
+		const report = makeReport(provider, "user@example.test", [
+			makeLimit({ id: "Base quota", provider, usedFraction: 0.2 }),
+			makeLimit({ id: "Unused tier", provider, tier: "unused-tier", usedFraction: 0 }),
+		]);
+		const authStorage = await AuthStorage.create(":memory:");
+		vi.spyOn(authStorage, "fetchUsageReports").mockResolvedValue([report]);
+		const discover = vi.spyOn(sdkModule, "discoverAuthStorage").mockResolvedValue(authStorage);
+		const loadSettings = vi.spyOn(Settings, "loadReadOnly").mockResolvedValue({
+			get: (key: string) => (key === "display.showZeroUsageMeters" ? false : undefined),
+		} as unknown as Settings);
+		let output = "";
+		const write = vi.spyOn(process.stdout, "write").mockImplementation(chunk => {
+			output += String(chunk);
+			return true;
+		});
+
+		try {
+			await runUsageCommand({});
+			expect(output).toContain("Base quota");
+			expect(output).not.toContain("Unused tier");
+		} finally {
+			write.mockRestore();
+			loadSettings.mockRestore();
+			discover.mockRestore();
+		}
+	});
+});
 
 describe("buildRedactionMap", () => {
 	it("masks everything past a two-char anchor when the anchor is unique", () => {

--- a/packages/coding-agent/test/usage-zero-meters-toggle.test.ts
+++ b/packages/coding-agent/test/usage-zero-meters-toggle.test.ts
@@ -1,10 +1,12 @@
-import { beforeAll, describe, expect, it, vi } from "bun:test";
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { stripVTControlCharacters } from "node:util";
 import type { UsageLimit, UsageReport } from "@oh-my-pi/pi-ai";
-import { CommandController } from "@oh-my-pi/pi-coding-agent/modes/controllers/command-controller";
-import { getThemeByName, setThemeInstance } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
-import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
+import { renderUsageReports } from "@oh-my-pi/pi-coding-agent/modes/controllers/command-controller";
+import { getThemeByName, setThemeInstance, type Theme, theme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import { buildUsageReportText } from "@oh-my-pi/pi-coding-agent/slash-commands/helpers/usage-report";
+import { filterUsageReportsForDisplay } from "@oh-my-pi/pi-coding-agent/utils/usage-display";
+
+let priorTheme: Theme | undefined;
 
 function limit(id: string, label: string, usedFraction: number | undefined, scope: UsageLimit["scope"]): UsageLimit {
 	return {
@@ -46,14 +48,6 @@ function settingsDouble(showZeroUsageMeters: boolean) {
 	};
 }
 
-interface RenderableBlock {
-	render(width: number): string[];
-}
-
-function isRenderableBlock(value: unknown): value is RenderableBlock {
-	return value !== null && typeof value === "object" && "render" in value && typeof value.render === "function";
-}
-
 async function buildAcpText(showZeroUsageMeters: boolean, reports = usageReports()): Promise<string> {
 	return await buildUsageReportText({
 		settings: settingsDouble(showZeroUsageMeters),
@@ -65,30 +59,21 @@ async function buildAcpText(showZeroUsageMeters: boolean, reports = usageReports
 	} as never);
 }
 
-async function buildTuiText(showZeroUsageMeters: boolean, reports = usageReports()): Promise<string> {
-	const present = vi.fn();
-	const ctx = {
-		settings: settingsDouble(showZeroUsageMeters),
-		session: { getUsageReportingModelSelectors: () => [] },
-		ui: { terminal: { columns: 100 } },
-		presentCommandOutput: present,
-		showWarning: vi.fn(),
-		showError: vi.fn(),
-	} as unknown as InteractiveModeContext;
-	await new CommandController(ctx).handleUsageCommand(reports);
-	const blocks = present.mock.calls[0]?.[0];
-	const rendered = (Array.isArray(blocks) ? blocks : [blocks])
-		.filter(isRenderableBlock)
-		.flatMap(block => block.render(120))
-		.join("\n");
-	return stripVTControlCharacters(rendered);
+/** Mirrors `showUsageDashboard`: the detail view renders the filtered reports. */
+function buildTuiText(showZeroUsageMeters: boolean, reports = usageReports()): string {
+	const displayReports = filterUsageReportsForDisplay(reports, { showZeroUsageMeters });
+	return stripVTControlCharacters(renderUsageReports(displayReports, theme, Date.now(), 120));
 }
 
 describe("display.showZeroUsageMeters", () => {
 	beforeAll(async () => {
-		const theme = await getThemeByName("dark");
-		if (!theme) throw new Error("Expected dark theme");
-		setThemeInstance(theme);
+		priorTheme = theme;
+		const darkTheme = await getThemeByName("dark");
+		if (!darkTheme) throw new Error("Expected dark theme");
+		setThemeInstance(darkTheme);
+	});
+	afterAll(() => {
+		if (priorTheme) setThemeInstance(priorTheme);
 	});
 
 	for (const [label, build] of [

--- a/packages/coding-agent/test/usage-zero-meters-toggle.test.ts
+++ b/packages/coding-agent/test/usage-zero-meters-toggle.test.ts
@@ -1,0 +1,127 @@
+import { beforeAll, describe, expect, it, vi } from "bun:test";
+import { stripVTControlCharacters } from "node:util";
+import type { UsageLimit, UsageReport } from "@oh-my-pi/pi-ai";
+import { CommandController } from "@oh-my-pi/pi-coding-agent/modes/controllers/command-controller";
+import { getThemeByName, setThemeInstance } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
+import { buildUsageReportText } from "@oh-my-pi/pi-coding-agent/slash-commands/helpers/usage-report";
+
+function limit(id: string, label: string, usedFraction: number | undefined, scope: UsageLimit["scope"]): UsageLimit {
+	return {
+		id,
+		label,
+		scope,
+		window: { id, label: "quota window" },
+		amount: { usedFraction, unit: "percent" },
+		status: "ok",
+	};
+}
+
+function usageReports(): UsageReport[] {
+	const provider = "meter-provider";
+	const accountId = "account-1";
+	return [
+		{
+			provider,
+			fetchedAt: 1_700_000_000_000,
+			limits: [
+				limit("base", "Base quota", 0.2, { provider, accountId }),
+				limit("zero-model-short", "Unused model short", 0, { provider, accountId, modelId: "unused-model" }),
+				limit("zero-model-long", "Unused model long", 0, { provider, accountId, modelId: "unused-model" }),
+				limit("zero-tier", "Unused tier", 0, { provider, accountId, tier: "unused-tier" }),
+				limit("active-model", "Active model", 0.1, { provider, accountId, modelId: "active-model" }),
+				limit("unknown-tier", "Unknown tier", undefined, { provider, accountId, tier: "unknown-tier" }),
+			],
+			metadata: { email: "user@example.test" },
+		},
+	];
+}
+
+function settingsDouble(showZeroUsageMeters: boolean) {
+	return {
+		get: (key: string) => {
+			if (key === "display.showZeroUsageMeters") return showZeroUsageMeters;
+			return undefined;
+		},
+	};
+}
+
+interface RenderableBlock {
+	render(width: number): string[];
+}
+
+function isRenderableBlock(value: unknown): value is RenderableBlock {
+	return value !== null && typeof value === "object" && "render" in value && typeof value.render === "function";
+}
+
+async function buildAcpText(showZeroUsageMeters: boolean, reports = usageReports()): Promise<string> {
+	return await buildUsageReportText({
+		settings: settingsDouble(showZeroUsageMeters),
+		session: {
+			model: undefined,
+			fetchUsageReports: async () => reports,
+			getUsageReportingModelSelectors: () => [],
+		},
+	} as never);
+}
+
+async function buildTuiText(showZeroUsageMeters: boolean, reports = usageReports()): Promise<string> {
+	const present = vi.fn();
+	const ctx = {
+		settings: settingsDouble(showZeroUsageMeters),
+		session: { getUsageReportingModelSelectors: () => [] },
+		ui: { terminal: { columns: 100 } },
+		presentCommandOutput: present,
+		showWarning: vi.fn(),
+		showError: vi.fn(),
+	} as unknown as InteractiveModeContext;
+	await new CommandController(ctx).handleUsageCommand(reports);
+	const blocks = present.mock.calls[0]?.[0];
+	const rendered = (Array.isArray(blocks) ? blocks : [blocks])
+		.filter(isRenderableBlock)
+		.flatMap(block => block.render(120))
+		.join("\n");
+	return stripVTControlCharacters(rendered);
+}
+
+describe("display.showZeroUsageMeters", () => {
+	beforeAll(async () => {
+		const theme = await getThemeByName("dark");
+		if (!theme) throw new Error("Expected dark theme");
+		setThemeInstance(theme);
+	});
+
+	for (const [label, build] of [
+		["ACP text", buildAcpText],
+		["TUI aggregate", buildTuiText],
+	] as const) {
+		it(`${label}: disabled hides only zero supplemental model and tier meters`, async () => {
+			const text = await build(false);
+			expect(text).toContain("Base quota");
+			expect(text).toContain("Active model");
+			expect(text).toContain("Unknown tier");
+			expect(text).not.toContain("Unused model short");
+			expect(text).not.toContain("Unused model long");
+			expect(text).not.toContain("Unused tier");
+		});
+
+		it(`${label}: enabled preserves zero supplemental meters`, async () => {
+			const text = await build(true);
+			expect(text).toContain("Unused model short");
+			expect(text).toContain("Unused model long");
+			expect(text).toContain("Unused tier");
+		});
+
+		it(`${label}: disabled preserves a provider's sole scoped meter`, async () => {
+			const provider = "scoped-provider";
+			const reports: UsageReport[] = [
+				{
+					provider,
+					fetchedAt: 1_700_000_000_000,
+					limits: [limit("only", "Only quota", 0, { provider, tier: "core" })],
+				},
+			];
+			expect(await build(false, reports)).toContain("Only quota");
+		});
+	}
+});


### PR DESCRIPTION
## What

Add `display.showZeroUsageMeters`, defaulting to `true`, so users can hide untouched supplemental model and tier quota meters from `/usage` without changing reports used for routing.

The display filter is shared by the standalone CLI, TUI command, and ACP report path. A provider's sole scoped meter remains visible.

## Why

Providers can return separate quota meters for optional tiers such as Codex Spark even when they have never been used. On accounts with a primary quota, those zero-use supplemental meters add noise to `/usage`.

## Testing

- `bun test packages/coding-agent/test/usage-zero-meters-toggle.test.ts packages/coding-agent/test/usage-cli.test.ts packages/coding-agent/test/modes/controllers/usage-command.test.ts packages/coding-agent/test/usage-models-toggle.test.ts` (38 pass)
- `bun check`

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
