### PR TITLE
fix(hooks): align HookUIContext.custom with runtime keybindings arity

### DIFF
--- a/docs/tui.md
+++ b/docs/tui.md
@@ -130,41 +130,25 @@ Behavior in interactive mode (`extension-ui-controller.ts`):
 - On `done(result)`: calls `component.dispose?.()`, hides the overlay if present, restores editor + text for non-overlay flows, focuses editor, resolves promise.
   So `done(...)` is mandatory for completion.
 
-## 2) Hook/custom-tool UI context (runtime/type mismatch)
+## 2) Hook/custom-tool UI context (`HookUIContext`)
 
-`HookUIContext.custom` is still typed as `(tui, theme, done)`, but the
-interactive controller invokes the factory as
-`(tui, theme, keybindings, done)`. The third runtime argument is therefore a
-`KeybindingsManager`, **not** the completion callback. A three-argument factory
-that calls its third parameter will fail at runtime and leave the custom UI
-unresolved.
-
-Until the hook/custom-tool type is aligned with the controller, do not copy the
-legacy three-argument examples from the type declaration. Runtime-safe
-interactive code must obtain the completion callback from the fourth positional
-argument, for example with a rest-argument adapter, and should guard the flow
-with `pi.hasUI`:
+Current signature (`extensibility/hooks/types.ts`) matches the interactive
+controller and `ExtensionUIContext.custom`:
 
 ```ts
-const picked = await pi.ui.custom<string | undefined>(
-  (...runtimeArgs: unknown[]) => {
-    const done = runtimeArgs[3];
-    if (typeof done !== "function") {
-      throw new Error(
-        "Interactive custom UI completion callback is unavailable",
-      );
-    }
-    return new MyPickerComponent(
-      done as (value: string | undefined) => void,
-      signal,
-    );
-  },
-);
+custom<T>(
+  factory: (
+    tui: TUI,
+    theme: Theme,
+    keybindings: KeybindingsManager,
+    done: (result: T) => void,
+  ) => (Component & { dispose?(): void }) | Promise<Component & { dispose?(): void }>,
+): Promise<T>
 ```
 
-This is a compatibility workaround for the current implementation, not a
-stable four-argument hook type. `ExtensionUIContext.custom`, described above,
-has the supported four-argument contract.
+Use the fourth argument as `done`. The third argument is a `KeybindingsManager`
+(interactive mode uses an in-memory instance with the default bindings). Guard
+terminal-only UI with `pi.hasUI` when the hook may also run headless.
 
 ## 3) Custom tool call/result renderers
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### Fixed
 
+- Fixed `HookUIContext.custom` types and docs so custom hook UI factories receive the `keybindings` argument the runner already passes ([#10424](https://github.com/can1357/oh-my-pi/pull/10424) by [@kvnloo](https://github.com/kvnloo)).
 - Fixed an issue where custom model overrides were lost during configuration updates
 - Fixed "Please use nerdfont" notification incorrectly persisting after theme configuration
 - Fixed sampling parameter errors for newer Anthropic models (Opus 4.7+, Sonnet 5+)
@@ -1722,3 +1723,4 @@
 - Fixed MCP sessions dropping tools from servers that finished connecting after the initial startup window.
 
 Older entries are archived in [packages/coding-agent/CHANGELOG.md@9f06f7133fbe](https://github.com/can1357/oh-my-pi/blob/9f06f7133fbe877f89fc04cb4843472dc06988e9/packages/coding-agent/CHANGELOG.md).
+

--- a/packages/coding-agent/src/extensibility/hooks/types.ts
+++ b/packages/coding-agent/src/extensibility/hooks/types.ts
@@ -4,6 +4,7 @@ import type * as zod from "@oh-my-pi/omptype/zod";
 import type { ImageContent, Message, Model, TextContent } from "@oh-my-pi/pi-ai";
 import type { Component, TUI } from "@oh-my-pi/pi-tui";
 import type { logger as PiLogger } from "@oh-my-pi/pi-utils";
+import type { KeybindingsManager } from "../../config/keybindings";
 import type { ModelRegistry } from "../../config/model-registry";
 import type { EditToolDetails } from "../../edit";
 import type { ExecOptions, ExecResult } from "../../exec/exec";
@@ -96,7 +97,8 @@ export interface HookUIContext {
 
 	/**
 	 * Show a custom component with keyboard focus.
-	 * The factory receives TUI, theme, and a done() callback to close the component.
+	 * The factory receives TUI, theme, keybindings, and a done() callback to close the component.
+	 * Matches the interactive controller call shape (same arity as ExtensionUIContext.custom).
 	 * Can be async for fire-and-forget work (don't await the work, just start it).
 	 *
 	 * @param factory - Function that creates the component. Call done() when finished.
@@ -104,14 +106,14 @@ export interface HookUIContext {
 	 *
 	 * @example
 	 * // Sync factory
-	 * const result = await ctx.ui.custom((tui, theme, done) => {
+	 * const result = await ctx.ui.custom((tui, theme, keybindings, done) => {
 	 *   const component = new MyComponent(tui, theme);
 	 *   component.onFinish = (value) => done(value);
 	 *   return component;
 	 * });
 	 *
 	 * // Async factory with fire-and-forget work
-	 * const result = await ctx.ui.custom(async (tui, theme, done) => {
+	 * const result = await ctx.ui.custom(async (tui, theme, keybindings, done) => {
 	 *   const loader = new CancellableLoader(tui, theme.fg("accent"), theme.fg("muted"), "Working...");
 	 *   loader.onAbort = () => done(null);
 	 *   doWork(loader.signal).then(done);  // Don't await - fire and forget
@@ -122,6 +124,7 @@ export interface HookUIContext {
 		factory: (
 			tui: TUI,
 			theme: Theme,
+			keybindings: KeybindingsManager,
 			done: (result: T) => void,
 		) => (Component & { dispose?(): void }) | Promise<Component & { dispose?(): void }>,
 	): Promise<T>;


### PR DESCRIPTION
made some small types + docs fix so that custom hook UI factories properly get the keybindings arg that the runner passes

## What

`HookUIContext.custom` was typed as `(tui, theme, done)` while the interactive controller already calls factories as `(tui, theme, keybindings, done)`. Three-arg factories that treat the third param as `done` hang.

## Changes

- Update `HookUIContext.custom` to match `ExtensionUIContext.custom` / `showHookCustom` (add `KeybindingsManager` before `done`).
- Rewrite `docs/tui.md` section 2 so it documents the aligned signature instead of the rest-arg workaround.

No runtime behavior change — controller already passed four args.