### PR TITLE
rpc: structured approvals, advisor events, streaming pages, titles, approval rules, subagent steer

### DIFF
--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -181,14 +181,36 @@ correlate it via `id`. Ordering across concurrent commands is not guaranteed
 - `{ id?, type: "get_branch_messages" }`
 - `{ id?, type: "get_last_assistant_text" }`
 - `{ id?, type: "set_session_name", name: string }`
+- `{ id?, type: "generate_title", customInstructions?: string }`
 - `{ id?, type: "handoff", customInstructions?: string }`
+
+### Titles
+
+`generate_title` wraps the session's public title generator: it computes a
+candidate name from the session's first user message (the same anchor
+auto-titling uses) and responds `{ title }` — `null` when the session has no
+user message yet or the input is too low-signal to name. The optional
+`customInstructions` swaps the title-generation system prompt. The generated
+name is **not** applied automatically; hosts persist it with `set_session_name`
+when appropriate. Where the mode already applies a name (builtin/auto title
+paths such as `notifyTitleChanged`), the change is reported through
+`session_info_update` (`{ type: "session_info_update", title, sessionId }`).
+
+Separately, the `prompt` command starts background auto-titling of the first
+user message when the agent is launched with `PI_RPC_TITLES=1` (default off,
+preserving the historical no-title behavior). The auto path applies the name
+directly (mirroring the interactive bootstrap); `maybeStartTitleGeneration`
+self-guards on an existing name, low-signal input, and an in-flight
+generation, so the flag is safe to enable for unattended hosts. Hosts observe
+the applied name via `get_state` (`sessionName`); builtin-command title
+changes continue to stream through `session_info_update`.
 
 ### Messages
 
 - `{ id?, type: "get_messages" }`
 - `{ id?, type: "get_messages_page", cursor?: string, limit?: number }`
 
-`get_messages_page` returns a stable chronological page with `messages`, `totalMessages`, and an opaque `nextCursor` when more messages remain. Cursors are bound to the session ID, durable leaf, and message count. The server rejects stale cursors if the session changes between requests, and refuses to start a paging walk while the session is streaming or compacting. Failed page requests carry a machine-readable `code` on the error response — `session_busy` (session is streaming or compacting) or `stale_cursor` (the snapshot behind the cursor changed, e.g. a background bash appended a message between pages) — so clients can react without matching error-message text. Pages contain at most 256 messages and normally stay below the v1 physical-frame ceiling. A v1 caller can page ordinary histories, but an individual message whose response exceeds that ceiling produces an overflow error; retrieving it losslessly requires negotiated v2 framing.
+`get_messages_page` returns a stable chronological page with `messages`, `totalMessages`, and an opaque `nextCursor` when more messages remain. Cursors are bound to the session ID, durable leaf, and message count. The server rejects stale cursors if the session changes between requests, and refuses to start a paging walk while the session is compacting. While a turn streams, paging is allowed: the first request of a walk freezes a snapshot of the current messages and binds every cursor in that walk to the frozen length, so a growing live array cannot shift offsets under the client. Once the session settles, a new snapshot is taken; a cursor that outlived the streaming epoch (or crossed a session switch) fails with `stale_cursor`. Failed page requests carry a machine-readable `code` on the error response — `session_busy` (session is compacting) or `stale_cursor` (the snapshot behind the cursor changed, e.g. a background bash appended a message between pages) — so clients can react without matching error-message text. Pages contain at most 256 messages and normally stay below the v1 physical-frame ceiling. A v1 caller can page ordinary histories, but an individual message whose response exceeds that ceiling produces an overflow error; retrieving it losslessly requires negotiated v2 framing.
 
 The bundled TypeScript `RpcClient.getMessages()` and Python `RpcClient.get_messages()` drain this paged endpoint automatically after negotiating v2. They retain the legacy monolithic command when connected to a v1 server, and on either `session_busy` or `stale_cursor` they discard partial pages and fall back to the legacy best-effort snapshot. Direct `getMessagesPage()` and `get_messages_page()` calls remain strict so incremental hosts never mix snapshots silently.
 
@@ -484,7 +506,25 @@ Common event types:
 - `model_changed`, `thinking_level_changed`
 - `ttsr_triggered`
 - `todo_reminder`, `todo_auto_clear`
-- `irc_message`, `notice`, `goal_updated`
+- `irc_message`, `advisor_note`, `notice`, `goal_updated`
+
+`advisor_note` is a structured mirror of one advisor note routed to the
+primary session:
+
+```ts
+{
+  type: "advisor_note";
+  advisor?: string;              // omitted for the default advisor
+  severity?: "nit" | "concern" | "blocker";
+  note: string;
+  deliveredAs: "card" | "steer" | "custom"; // how the note reached the primary
+}
+```
+
+It is emitted alongside the legacy advisor card / steered custom message (same
+`note` and `severity`), so hosts can surface the advisory without parsing
+`<advisory>` tags out of transcript text. Best-effort: a host that ignores it
+loses nothing — the legacy delivery remains authoritative.
 
 Extension runner errors are emitted separately as:
 

--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -133,6 +133,7 @@ Important edge behavior from runtime:
 - `{ id?, type: "set_subagent_subscription", level: "off" | "progress" | "events" }`
 - `{ id?, type: "get_subagents" }`
 - `{ id?, type: "get_subagent_messages", subagentId?: string, sessionFile?: string, fromByte?: number }`
+- `{ id?, type: "steer_subagent", subagentId: string, message: string }`
 
 ### Approval rules
 
@@ -638,6 +639,37 @@ Subagent forwarding defaults to `"off"`. `set_subagent_subscription` selects:
 `fromByte`, `nextByte`, `reset`, raw transcript `entries`, and converted
 `messages`. If `fromByte` exceeds the current file size, reading restarts at
 byte zero and reports `reset: true`.
+
+### Steering subagents
+
+`steer_subagent` delivers a direct-message to a live **in-process** subagent
+over the same hub/IRC path the `hub` send tool uses (`IrcBus.global().send`):
+idle subagents are woken with a real turn, busy ones receive the message as a
+non-interrupting aside at their next step boundary, and parked ones are
+revived through the lifecycle manager. The sender is attributed to the session
+owner (`Main`), so the subagent sees a normal steering DM.
+
+```json
+{ "id": "req_1", "type": "steer_subagent", "subagentId": "OmpWorker", "message": "Drop the glob, keep the direct path." }
+```
+
+Failure responses include a machine-readable `code` when the cause is
+actionable:
+
+- unknown `subagentId` → `error: "Unknown subagent: <id>"` (no code)
+- subagent completed/released → `error: "Subagent not running: <id>"` (no code)
+- subagent runs in an isolation worktree (not steerable this pass) →
+  `error` with `code: "unsupported_isolated"`
+
+Success responses carry delivery metadata:
+
+```json
+{ "id": "req_1", "type": "response", "command": "steer_subagent", "success": true, "data": { "to": "OmpWorker", "outcome": "injected" } }
+```
+
+`outcome` is the hub delivery receipt: `"injected"` (aside into a busy agent or
+consumed waiter), `"woken"` (idle agent woke for a real turn), or `"revived"`
+(parked agent restored before delivery).
 
 ## Prompt/Queue Concurrency and Ordering
 

--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -81,6 +81,7 @@ Legacy clients may ignore the added ready fields and remain on v1. V1 retains it
 9. Prompt lifecycle hints (`{ type: "prompt_result", id?, agentInvoked }`) for scheduled prompts that later resolve without invoking the agent
 10. Subagent frames (`subagent_lifecycle`, `subagent_progress`, `subagent_event`), gated by `set_subagent_subscription`
 11. Builtin slash-command side channels (`command_output`, `session_info_update`, `config_update`)
+12. Tool approval frames (`tool_approval_request`, `tool_approval_resolved`), see the [Tool Approval Sub-Protocol](#tool-approval-sub-protocol)
 
 ### Inbound frame categories (stdin)
 
@@ -132,6 +133,36 @@ Important edge behavior from runtime:
 - `{ id?, type: "set_subagent_subscription", level: "off" | "progress" | "events" }`
 - `{ id?, type: "get_subagents" }`
 - `{ id?, type: "get_subagent_messages", subagentId?: string, sessionFile?: string, fromByte?: number }`
+
+### Approval rules
+
+- `{ id?, type: "add_approval_rule", rule: { tool, match?, approval, reason? } }`
+- `{ id?, type: "list_approval_rules" }`
+- `{ id?, type: "remove_approval_rule", index: number }`
+
+`tools.approvalRules` is an ordered list of generic approval rules evaluated
+ahead of per-tool policy and approval mode; the first matching rule wins and
+is authoritative in every mode, including `yolo`. Each rule carries:
+
+- `tool` (string, required): the tool name the rule applies to.
+- `approval` (`"allow" | "deny" | "prompt"`, required).
+- `match` (string, optional): a `*`-wildcard glob (same syntax as
+  `bash.patterns`) matched against the tool's **primary string argument** —
+  the bash `command`, or the write/edit `path` (falling back to
+  `file_path`). Tools without a primary string argument match on tool name
+  alone; any `match` they carry is ignored. A rule with a `match` is skipped
+  when a primary-arg tool call carries no primary string (e.g. a sloppy edit
+  without a path). Bash commands are matched with shell-aware semantics:
+  `allow` must vouch for the entire command (never rides a compound line),
+  while `deny`/`prompt` fire on any matching shell segment.
+- `reason` (string, optional): surfaced when the rule prompts or denies.
+
+`add_approval_rule` validates the rule, appends it to the session settings,
+persists through the existing settings write path, and returns the full
+normalized list. `remove_approval_rule` removes the rule at `index`
+(0-based) and returns the remaining list; an out-of-range index is an error.
+Malformed entries in a hand-edited config are dropped on read and never
+reported by `list_approval_rules`.
 
 ### Model
 
@@ -380,6 +411,38 @@ The corresponding `get_state` result reports the same computed state:
   "fastModeActive": true
 }
 ```
+
+### `add_approval_rule` / `list_approval_rules` / `remove_approval_rule` payload
+
+All three commands return the full ordered, normalized rule list. They
+persist through the existing session-settings write path.
+
+Example round trip — add a deny rule for destructive bash commands:
+
+```json
+{ "id": "rule-1", "type": "add_approval_rule", "rule": { "tool": "bash", "match": "rm -rf /*", "approval": "deny", "reason": "destructive" } }
+```
+
+Response:
+
+```json
+{
+  "id": "rule-1",
+  "type": "response",
+  "command": "add_approval_rule",
+  "success": true,
+  "data": {
+    "rules": [
+      { "tool": "bash", "match": "rm -rf /*", "approval": "deny", "reason": "destructive" }
+    ]
+  }
+}
+```
+
+`remove_approval_rule` uses the 0-based index from the returned list. Invalid
+rules (missing/empty `tool`, or an `approval` other than
+`allow`/`deny`/`prompt`) and out-of-range removals fail with `success: false`
+and a human-readable `error`.
 
 ### `set_todos` payload
 
@@ -665,6 +728,73 @@ Example:
 - `{ type: "extension_ui_response", id: string, cancelled: true, timedOut?: boolean }`
 
 If a dialog has a timeout, RPC mode resolves to a default value when timeout/abort fires.
+
+## Tool Approval Sub-Protocol
+
+When a tool call requires approval, RPC mode emits a structured
+`tool_approval_request` frame **synchronously before** the paired legacy
+`extension_ui_request` select, and a `tool_approval_resolved` frame the moment
+that select resolves. The legacy select remains authoritative for the verdict:
+approve or deny it exactly as before, and the resolved frame reports the
+outcome without replacing the UI flow. Denying, aborting, or timing out the
+select still blocks the tool call through the existing semantics.
+
+### Outbound request
+
+`tool_approval_request` (`{ "type": "tool_approval_request" }`):
+
+```json
+{
+  "type": "tool_approval_request",
+  "id": "call_abc123",
+  "sessionId": "…",
+  "toolCallId": "call_abc123",
+  "toolName": "bash",
+  "tier": "exec",
+  "policy": "prompt",
+  "source": "tool",
+  "reason": "requires manual review",
+  "approvalMode": "always-ask",
+  "details": ["$ git reset --hard", "Deletes local changes."]
+}
+```
+
+- `tier`: resolved capability tier (`"read" | "write" | "exec"`).
+- `policy`: resolved policy that triggered the prompt (`"allow" | "deny" | "prompt"`).
+- `source`: origin of the resolved policy (`"tool" | "user" | "mode" | "rule"`).
+- `approvalMode`: the active approval mode (`"always-ask" | "write" | "yolo"`).
+- `details`: untruncated `formatApprovalDetails` lines when the tool declares any.
+- `reason`: present when the approval resolution carried one.
+
+### Outbound resolution
+
+`tool_approval_resolved` (`{ "type": "tool_approval_resolved" }`):
+
+```json
+{
+  "type": "tool_approval_resolved",
+  "id": "call_abc123",
+  "toolCallId": "call_abc123",
+  "approved": true,
+  "by": "user"
+}
+```
+
+`approved` mirrors the select outcome; `by` is `"user"` after an interactive
+decision or `"system"` when approval failed closed (no interactive UI, or the
+dialog was cancelled/aborted).
+
+### Correlation
+
+`tool_approval_request` is emitted inside the approval gate, **before** the RPC
+select request id exists, so the request frame's `id` carries the `toolCallId`
+as the documented 1:1 join key. Hosts MUST pair a `tool_approval_request` with
+the select `extension_ui_request` that arrives immediately after it, and join
+the verdict by `toolCallId` from the paired `tool_approval_resolved`. `details`
+may contain arbitrary tool output; treat it as untrusted text.
+
+The `RpcClient` exposes these as `onToolApproval(listener)` and
+`onToolApprovalResolved(listener)` subscriptions.
 
 ## Host Tool Sub-Protocol
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Added
 
+- Added a structured `advisor_note` session event mirroring every routed advisor delivery (preserved card or steered message), so headless RPC/ACP hosts can surface advisories without parsing transcript text.
+- RPC `get_messages_page` now pages a frozen snapshot while a turn streams (compaction still refuses with `session_busy`); cursors stay bound to the frozen length and stale cursors across epochs/session switches still fail.
+- Added the RPC `generate_title` command wrapping the session title generator, plus opt-in auto-titling on `prompt` via `PI_RPC_TITLES=1`.
 - Added `injectV1: false` option to `openai-models-list` discovery to fetch the model list from `{baseUrl}/models` without injecting `/v1`, for gateways that root their OpenAI-compatible surface at a versioned URL (e.g. `https://api.opper.ai/v3/compat`) where the `/v1`-injected endpoint returns only a small subset.
 - Added provider-reported credits and concrete routed-model counts to `/session` statistics ([#8590](https://github.com/can1357/oh-my-pi/pull/8590) by [@will-bogusz](https://github.com/will-bogusz)).
 - Added `CLINE_API_KEY` to the CLI environment help for native ClinePass subscription inference ([#7863](https://github.com/can1357/oh-my-pi/pull/7863) by [@will-bogusz](https://github.com/will-bogusz)).

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Added the RPC `steer_subagent` command, delivering a steering DM to a live in-process subagent over the hub/IRC bus (isolated worktree runs are rejected with error code `unsupported_isolated`).
 - Added a structured `advisor_note` session event mirroring every routed advisor delivery (preserved card or steered message), so headless RPC/ACP hosts can surface advisories without parsing transcript text.
 - RPC `get_messages_page` now pages a frozen snapshot while a turn streams (compaction still refuses with `session_busy`); cursors stay bound to the frozen length and stale cursors across epochs/session switches still fail.
 - Added the RPC `generate_title` command wrapping the session title generator, plus opt-in auto-titling on `prompt` via `PI_RPC_TITLES=1`.

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -37,6 +37,7 @@ import {
 	TINY_TITLE_MODEL_OPTIONS,
 	TINY_TITLE_MODEL_VALUES,
 } from "../tiny/models";
+import type { ApprovalRule } from "../tools/approval-rules";
 import { IMAGE_PROVIDER_CHOICES, type ImageProvider } from "../tools/image-providers";
 import {
 	DEFAULT_TTS_LOCAL_MODEL_KEY,
@@ -4051,6 +4052,24 @@ export const SETTINGS_SCHEMA = {
 			label: "Tool Approval Policies",
 			description:
 				"Per-tool approval policies. Set to 'allow' to auto-approve, 'prompt' to require confirmation, or 'deny' to block. Overrides are honored in every approval mode.",
+		},
+	},
+
+	// Generic approval rules, evaluated BEFORE per-tool policy and any mode
+	// comparison. First match wins and is authoritative in every approval mode,
+	// including yolo. `match` uses the same glob syntax as bash.patterns (only
+	// `*` wildcards) and applies to a tool's primary string argument — the bash
+	// command, or the write/edit path. Tools without a primary string argument
+	// match on tool name alone; any `match` they carry is ignored.
+	"tools.approvalRules": {
+		type: "array",
+		default: [] as ApprovalRule[],
+		ui: {
+			tab: "interaction",
+			group: "Approvals",
+			label: "Approval Rules",
+			description:
+				"Ordered generic approval rules evaluated before per-tool policies and modes. Each item has tool and approval fields (allow | prompt | deny), an optional match glob ('*' wildcards only; matched against the bash command or write/edit path; ignored for other tools), and an optional reason. First match wins and overrides every approval mode.",
 		},
 	},
 

--- a/packages/coding-agent/src/cursor.ts
+++ b/packages/coding-agent/src/cursor.ts
@@ -313,11 +313,15 @@ function refuseByWritePolicy(options: CursorExecBridgeOptions, toolName: string,
 		{ path: pathArg },
 		approvalMode,
 		(settings?.get("tools.approval") ?? {}) as Record<string, unknown>,
+		settings?.get("tools.approvalRules"),
 	);
 	if (approval.policy === "allow") return null;
-	return approval.policy === "deny"
-		? `Tool "${toolName}" is blocked by user policy.`
-		: `Tool "${toolName}" requires approval, which this channel cannot request.`;
+	if (approval.policy === "deny") {
+		return approval.source === "rule"
+			? `Tool "${toolName}" is blocked by an approval rule.`
+			: `Tool "${toolName}" is blocked by user policy.`;
+	}
+	return `Tool "${toolName}" requires approval, which this channel cannot request.`;
 }
 
 async function executeDelete(options: CursorExecBridgeOptions, pathArg: string, toolCallId: string) {
@@ -977,6 +981,7 @@ export class CursorExecHandlers implements ICursorExecHandlers {
 			preferReplace ? normalizeCursorReplaceArgs(args) : args,
 			approvalMode,
 			(settings?.get("tools.approval") ?? {}) as Record<string, unknown>,
+			settings?.get("tools.approvalRules"),
 		);
 		return approval.policy === "allow";
 	}

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -49,6 +49,7 @@ import type {
 	ExtensionShortcut,
 	ExtensionUIContext,
 	ExtensionUIDialogOptions,
+	HandlerFn,
 	InputEvent,
 	InputEventResult,
 	McpNotificationEvent,
@@ -427,6 +428,15 @@ const noOpUIContext: ExtensionUIContext = {
 	setToolsExpanded: () => {},
 };
 
+/**
+ * Synthetic `extensionPath` value used to attribute timeouts and errors from
+ * host-registered handlers (see {@link ExtensionRunner.registerHostHandler}).
+ */
+const HOST_EXTENSION_PATH = "<host>";
+
+/** Minimal extension identity for host-handler dispatch (only `path` is consulted). */
+const HOST_EXTENSION: Pick<Extension, "path"> = { path: HOST_EXTENSION_PATH };
+
 interface ToolRegistrationScope {
 	pending: Set<Promise<void>>;
 	signal?: AbortSignal;
@@ -458,6 +468,12 @@ export class ExtensionRunner {
 	#toolRegistrationScope = new AsyncLocalStorage<ToolRegistrationScope>();
 	#toolRegistrationBarrier: Promise<void> | undefined;
 	#initialized = false;
+	/**
+	 * Handlers registered by the host (mode controller) via {@link registerHostHandler},
+	 * keyed by event type. Dispatched through the same isolation as extension handlers;
+	 * consulted by {@link hasHandlers} so hosts can observe events no extension subscribes to.
+	 */
+	#hostHandlers: Map<string, HandlerFn[]> = new Map();
 	/**
 	 * Buffer for `credential_disabled` events received via {@link emitCredentialDisabled}
 	 * before {@link initialize} has run. Drained through {@link emit} once initialize sets
@@ -1075,6 +1091,34 @@ export class ExtensionRunner {
 		}
 	}
 
+	/**
+	 * Register a host-owned handler for an extension event type.
+	 *
+	 * Host handlers belong to the mode controller (not an extension): they are
+	 * dispatched through the same timeout and error-isolation machinery as
+	 * extension handlers but receive only the event (no `ExtensionContext`).
+	 * `hasHandlers` accounts for them, so hosts can observe events no extension
+	 * subscribes to — e.g. RPC mode serializing approval events onto its wire.
+	 *
+	 * Returns a disposer that removes the handler.
+	 */
+	registerHostHandler<TEvent extends { type: string }>(
+		eventType: TEvent["type"],
+		handler: (event: TEvent) => void | Promise<void>,
+	): () => void {
+		let handlers = this.#hostHandlers.get(eventType);
+		if (!handlers) {
+			handlers = [];
+			this.#hostHandlers.set(eventType, handlers);
+		}
+		const wrapped: HandlerFn = (event: unknown) => Promise.resolve(handler(event as TEvent));
+		handlers.push(wrapped);
+		return () => {
+			const index = handlers.indexOf(wrapped);
+			if (index !== -1) handlers.splice(index, 1);
+		};
+	}
+
 	hasHandlers(eventType: string): boolean {
 		for (const ext of this.extensions) {
 			const handlers = ext.handlers.get(eventType);
@@ -1082,7 +1126,8 @@ export class ExtensionRunner {
 				return true;
 			}
 		}
-		return false;
+		const hostHandlers = this.#hostHandlers.get(eventType);
+		return hostHandlers !== undefined && hostHandlers.length > 0;
 	}
 
 	getMessageRenderer(customType: string): MessageRenderer | undefined {
@@ -1252,7 +1297,7 @@ export class ExtensionRunner {
 		handler: (event: TEvent, ctx: ExtensionContext) => Promise<TResult | undefined> | TResult | undefined,
 		event: TEvent,
 		ctx: ExtensionContext,
-		ext: Extension,
+		ext: Pick<Extension, "path">,
 		timeoutMs: number,
 		onFailure?: (kind: "timeout" | "error", message: string) => TResult,
 		outerSignal?: AbortSignal,
@@ -1333,6 +1378,19 @@ export class ExtensionRunner {
 		return handlerResult as TResult | undefined;
 	}
 
+	/**
+	 * Dispatch host-registered handlers (see {@link registerHostHandler}) for an event
+	 * through the same timeout/error isolation as extension handlers. Returns without
+	 * doing anything when no host handler is registered for `event.type`.
+	 */
+	async #dispatchHostHandlers<TEvent extends RunnerEmitEvent>(event: TEvent, ctx: ExtensionContext): Promise<void> {
+		const handlers = this.#hostHandlers.get(event.type);
+		if (!handlers || handlers.length === 0) return;
+		for (const handler of handlers) {
+			await this.#runHandlerWithTimeout(handler, event, ctx, HOST_EXTENSION, handlerTimeoutForEvent(event.type));
+		}
+	}
+
 	async emit<TEvent extends RunnerEmitEvent>(event: TEvent): Promise<RunnerEmitResult<TEvent>> {
 		// Defer the per-event context allocation (and the Promise.race/Bun.sleep
 		// timeout machinery) to the first matching handler. Streaming sessions emit
@@ -1350,6 +1408,12 @@ export class ExtensionRunner {
 				ctx ??= this.createContext();
 				for (const handler of handlers) {
 					promises.push(this.#runHandlerWithTimeout(handler, event, ctx, ext, timeoutMs));
+				}
+			}
+			if (this.#hostHandlers.get(event.type)?.length) {
+				ctx ??= this.createContext();
+				for (const handler of this.#hostHandlers.get(event.type)!) {
+					promises.push(this.#runHandlerWithTimeout(handler, event, ctx, HOST_EXTENSION, timeoutMs));
 				}
 			}
 			if (promises.length > 0) await Promise.all(promises);
@@ -1391,6 +1455,11 @@ export class ExtensionRunner {
 					}
 				}
 			}
+		}
+
+		if (this.#hostHandlers.get(event.type)?.length) {
+			ctx ??= this.createContext();
+			await this.#dispatchHostHandlers(event, ctx);
 		}
 
 		return result as RunnerEmitResult<TEvent>;

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -77,7 +77,7 @@ import type {
 	ReadToolInput,
 	WriteToolInput,
 } from "../../tools";
-import type { ApprovalMode } from "../../tools/approval";
+import type { ApprovalMode, ApprovalPolicy, ToolTier } from "../../tools/approval";
 import type { FileDeleteFallbackHandler, FileWriteFallbackHandler } from "../../tools/file-write-fallback";
 import type { EventBus } from "../../utils/event-bus";
 import type {
@@ -914,8 +914,16 @@ export interface ToolApprovalRequestedEvent {
 	sessionId: string;
 	toolCallId: string;
 	toolName: string;
+	/** Resolved capability tier of the pending approval (enriched at emission time). */
+	tier?: ToolTier;
+	/** Resolved approval policy that triggered the prompt ("prompt" when requiring approval). */
+	policy?: ApprovalPolicy;
+	/** Origin of the resolved policy: the tool, user configuration, an approval rule, or the active mode. */
+	source?: "tool" | "user" | "mode" | "rule";
 	reason?: string;
 	approvalMode: ApprovalMode;
+	/** `formatApprovalDetails` lines, untruncated, when the tool declares any. */
+	details?: string[];
 }
 
 export interface ToolApprovalResolvedEvent {
@@ -925,6 +933,8 @@ export interface ToolApprovalResolvedEvent {
 	toolName: string;
 	approved: boolean;
 	reason?: string;
+	/** Who resolved the approval: "user" after an interactive decision, "system" when it failed closed. */
+	by?: "user" | "system";
 }
 
 interface ToolCallEventBase {
@@ -1635,7 +1645,7 @@ export interface ExtensionShortcut {
 	extensionPath: string;
 }
 
-type HandlerFn = (...args: unknown[]) => Promise<unknown>;
+export type HandlerFn = (...args: unknown[]) => Promise<unknown>;
 
 export type SendMessageHandler = <T = unknown>(
 	message: CustomMessagePayload<T>,

--- a/packages/coding-agent/src/extensibility/extensions/wrapper.ts
+++ b/packages/coding-agent/src/extensibility/extensions/wrapper.ts
@@ -145,6 +145,23 @@ function safetyCheckLines(checks: readonly ComputerSafetyCheck[]): string[] {
 }
 
 /**
+ * Normalize a tool's `formatApprovalDetails` output into untruncated detail
+ * lines for structured approval events, omitting empty entries. Returns
+ * `undefined` when the tool declares no details.
+ */
+function approvalDetailsLines(tool: AgentTool, args: unknown): string[] | undefined {
+	const details = tool.formatApprovalDetails?.(args);
+	if (typeof details === "string") {
+		return details.length > 0 ? [details] : undefined;
+	}
+	if (Array.isArray(details)) {
+		const lines = details.filter(line => line.length > 0);
+		return lines.length > 0 ? lines : undefined;
+	}
+	return undefined;
+}
+
+/**
  * Wraps a tool with extension callbacks for interception.
  * - Emits tool_call event before execution (can block)
  * - Emits tool_result event after execution (can modify result)
@@ -197,7 +214,14 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 		const configuredMode = (settings?.get("tools.approvalMode") ?? "yolo") as ApprovalMode;
 		const approvalMode: ApprovalMode = cliAutoApprove ? "yolo" : configuredMode;
 		const userPolicies = (settings?.get("tools.approval") ?? {}) as Record<string, unknown>;
-		const preResolved = resolveApproval(this.tool, approvalArgs(params, context), approvalMode, userPolicies);
+		const approvalRules = settings?.get("tools.approvalRules");
+		const preResolved = resolveApproval(
+			this.tool,
+			approvalArgs(params, context),
+			approvalMode,
+			userPolicies,
+			approvalRules,
+		);
 		if (preResolved.policy === "deny") {
 			throw denyError(preResolved, this.tool.name);
 		}
@@ -246,7 +270,7 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 		// input that newly resolves to `deny` is caught here even though the original passed the
 		// short-circuit above.
 		const resolvedArgs = approvalArgs(effectiveParams, context);
-		const resolved = resolveApproval(this.tool, resolvedArgs, approvalMode, userPolicies);
+		const resolved = resolveApproval(this.tool, resolvedArgs, approvalMode, userPolicies, approvalRules);
 		context?.xdevTierResolved?.(resolved.tier);
 		if (resolved.policy === "deny") {
 			throw denyError(resolved, this.tool.name);
@@ -280,17 +304,22 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 				this.runner.hasHandlers("tool_approval_requested") || this.runner.hasHandlers("tool_approval_resolved");
 			const sessionId = context?.sessionManager?.getSessionId() ?? "";
 			if (hasApprovalHandlers) {
+				const approvalDetails = approvalDetailsLines(this.tool, resolvedArgs);
 				await this.runner.emit({
 					type: "tool_approval_requested",
 					sessionId,
 					toolName: this.tool.name,
 					toolCallId,
+					tier: resolved.tier,
+					policy: resolved.policy,
+					source: resolved.source ?? "mode",
 					...(approvalCheck.reason ? { reason: approvalCheck.reason } : {}),
 					approvalMode,
+					...(approvalDetails ? { details: approvalDetails } : {}),
 				});
 			}
 
-			const emitApprovalResolved = async (approved: boolean, reason?: string) => {
+			const emitApprovalResolved = async (approved: boolean, reason?: string, by: "user" | "system" = "user") => {
 				if (!hasApprovalHandlers) return;
 				await this.runner.emit({
 					type: "tool_approval_resolved",
@@ -298,6 +327,7 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 					toolName: this.tool.name,
 					toolCallId,
 					approved,
+					by,
 					...(reason ? { reason } : {}),
 				});
 			};
@@ -306,7 +336,7 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 			// ordinary tier approval, no setting or yolo mode may bypass this gate.
 			if (!this.runner.hasUI()) {
 				const reason = "no interactive UI available";
-				await emitApprovalResolved(false, reason);
+				await emitApprovalResolved(false, reason, "system");
 				if (pendingSafetyChecks.length > 0) {
 					throw new Error(
 						`Tool "${this.tool.name}" has pending provider safety checks but no interactive UI is available.`,
@@ -331,7 +361,7 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 			try {
 				choice = await uiContext.select(safetyPrompt, ["Approve", "Deny"]);
 			} catch (err) {
-				await emitApprovalResolved(false, err instanceof Error ? err.message : "approval aborted");
+				await emitApprovalResolved(false, err instanceof Error ? err.message : "approval aborted", "system");
 				throw err;
 			}
 			const approved = choice === "Approve";

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -1561,7 +1561,7 @@ export class EventController {
 		if (!tool) return false;
 		const mode = (settings.get("tools.approvalMode") ?? "yolo") as ApprovalMode;
 		const userPolicies = (settings.get("tools.approval") ?? {}) as Record<string, unknown>;
-		return resolveApproval(tool, args, mode, userPolicies).policy === "prompt";
+		return resolveApproval(tool, args, mode, userPolicies, settings.get("tools.approvalRules")).policy === "prompt";
 	}
 
 	async #handleToolExecutionUpdate(

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -265,6 +265,10 @@ export class EventController {
 			todo_auto_clear: e => this.#handleTodoAutoClear(e),
 			irc_message: e => this.#handleIrcMessage(e),
 			notice: e => this.#handleNotice(e),
+			// The advisor card itself is rendered from the transcript message
+			// events; this structured notification exists for headless hosts
+			// (RPC/ACP), so the interactive TUI has nothing to add here.
+			advisor_note: async () => {},
 			model_changed: async () => {
 				this.ctx.statusLine.invalidate();
 				this.ctx.ui.requestRender();

--- a/packages/coding-agent/src/modes/rpc/rpc-approval-rules.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-approval-rules.ts
@@ -1,0 +1,60 @@
+/**
+ * RPC command handlers for `tools.approvalRules` (contract item 5).
+ *
+ * add_approval_rule / list_approval_rules / remove_approval_rule operate on the
+ * session settings key through a minimal store so rpc-mode stays thin and the
+ * pure logic is unit-testable without an AgentSession. The store's `write`
+ * funnels into the existing settings write path, which persists the change.
+ */
+import { type ApprovalRule, normalizeApprovalRule, normalizeApprovalRules } from "../../tools/approval-rules";
+
+/** Minimal persistence seam over the `tools.approvalRules` session setting. */
+export interface RpcApprovalRuleStore {
+	/** Raw `tools.approvalRules` value (untrusted; normalized on read). */
+	read(): unknown;
+	/** Persist a normalized, ordered rule list. */
+	write(rules: ApprovalRule[]): void;
+}
+
+export type RpcApprovalRuleAddResult = { ok: true; rules: ApprovalRule[] } | { ok: false; error: string };
+export type RpcApprovalRuleRemoveResult = { ok: true; rules: ApprovalRule[] } | { ok: false; error: string };
+
+function currentRules(store: RpcApprovalRuleStore): ApprovalRule[] {
+	return normalizeApprovalRules(store.read());
+}
+
+/** Validate and append a rule; returns the full normalized list. */
+export function addRpcApprovalRule(store: RpcApprovalRuleStore, ruleInput: unknown): RpcApprovalRuleAddResult {
+	const rule = normalizeApprovalRule(ruleInput);
+	if (!rule) {
+		return {
+			ok: false,
+			error: 'Invalid approval rule. Expected an object with a non-empty `tool` string and an `approval` of "allow", "deny", or "prompt".',
+		};
+	}
+	const rules = [...currentRules(store), rule];
+	store.write(rules);
+	return { ok: true, rules };
+}
+
+/** Return the current normalized rule list. */
+export function listRpcApprovalRules(store: RpcApprovalRuleStore): { rules: ApprovalRule[] } {
+	return { rules: currentRules(store) };
+}
+
+/** Remove the rule at `index` (0-based); errors when out of range. */
+export function removeRpcApprovalRule(store: RpcApprovalRuleStore, indexInput: unknown): RpcApprovalRuleRemoveResult {
+	if (typeof indexInput !== "number" || !Number.isInteger(indexInput)) {
+		return { ok: false, error: `Approval rule index must be an integer, got: ${String(indexInput)}` };
+	}
+	const rules = currentRules(store);
+	if (indexInput < 0 || indexInput >= rules.length) {
+		return {
+			ok: false,
+			error: `Approval rule index out of range: ${indexInput} (${rules.length} rule(s) configured)`,
+		};
+	}
+	const next = rules.filter((_, index) => index !== indexInput);
+	store.write(next);
+	return { ok: true, rules: next };
+}

--- a/packages/coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client.ts
@@ -151,6 +151,7 @@ const sessionEventTypes = new Set<AgentSessionEvent["type"]>([
 	"todo_reminder",
 	"todo_auto_clear",
 	"irc_message",
+	"advisor_note",
 	"notice",
 	"thinking_level_changed",
 	"model_changed",
@@ -855,6 +856,18 @@ export class RpcClient {
 	async getLastAssistantText(): Promise<string | null> {
 		const response = await this.#send({ type: "get_last_assistant_text" });
 		return this.#getData<{ text: string | null }>(response).text;
+	}
+
+	/**
+	 * Generate a session title candidate from the first user message.
+	 * `customInstructions` optionally swaps the title-generation system prompt.
+	 * Returns `null` when the session has no user message yet or the input was
+	 * deemed too low-signal to title. The generated name is not applied
+	 * automatically — hosts persist it via `setSessionName` when appropriate.
+	 */
+	async generateTitle(customInstructions?: string): Promise<string | null> {
+		const response = await this.#send({ type: "generate_title", customInstructions });
+		return this.#getData<{ title: string | null }>(response).title;
 	}
 
 	/**

--- a/packages/coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client.ts
@@ -767,6 +767,23 @@ export class RpcClient {
 	}
 
 	/**
+	 * Steer a live in-process subagent over the hub/IRC bus. The message is
+	 * delivered as a normal DM attributed to the session owner, injecting an
+	 * aside into busy agents or waking idle ones. Resolves with the delivery
+	 * outcome once the bus hand-off completes.
+	 *
+	 * Rejects when the `subagentId` is unknown, no longer running, or confined
+	 * to an isolation worktree (error `code: "unsupported_isolated"`).
+	 */
+	async steerSubagent(
+		subagentId: string,
+		message: string,
+	): Promise<{ to: string; outcome: "injected" | "woken" | "revived" }> {
+		const response = await this.#send({ type: "steer_subagent", subagentId, message });
+		return this.#getData<{ to: string; outcome: "injected" | "woken" | "revived" }>(response);
+	}
+
+	/**
 	 * Set model by provider and ID.
 	 */
 	async setModel(provider: string, modelId: string): Promise<{ provider: string; id: string }> {

--- a/packages/coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client.ts
@@ -12,6 +12,7 @@ import { isRecord, ptree, readJsonl } from "@oh-my-pi/pi-utils";
 import type { FileSink } from "bun";
 import type { BashResult } from "../../exec/bash-executor";
 import type { AgentSessionEvent, SessionStats } from "../../session/agent-session";
+import type { ApprovalRule } from "../../tools/approval-rules";
 import { MAX_RPC_FRAME_BYTES, MAX_RPC_REASSEMBLED_BYTES, RpcFrameDecoder, type RpcProtocolVersion } from "./rpc-frame";
 import {
 	RPC_MESSAGES_PAGE_BUSY_ERROR,
@@ -39,6 +40,8 @@ import type {
 	RpcSubagentProgressFrame,
 	RpcSubagentSnapshot,
 	RpcSubagentSubscriptionLevel,
+	RpcToolApprovalRequestFrame,
+	RpcToolApprovalResolvedFrame,
 } from "./rpc-types";
 
 /** Distributive Omit that works with union types */
@@ -99,6 +102,8 @@ export type RpcSubagentLifecycleListener = (payload: RpcSubagentLifecycleFrame["
 export type RpcSubagentProgressListener = (payload: RpcSubagentProgressFrame["payload"]) => void;
 export type RpcSubagentEventListener = (payload: RpcSubagentEventFrame["payload"]) => void;
 export type RpcAvailableCommandsUpdateListener = (commands: RpcAvailableSlashCommand[]) => void;
+export type RpcToolApprovalRequestListener = (frame: RpcToolApprovalRequestFrame) => void;
+export type RpcToolApprovalResolvedListener = (frame: RpcToolApprovalResolvedFrame) => void;
 
 export interface RpcClientToolContext<TDetails = unknown> {
 	toolCallId: string;
@@ -235,6 +240,26 @@ function isRpcExtensionUiRequest(value: unknown): value is RpcExtensionUIRequest
 	return value.type === "extension_ui_request" && typeof value.id === "string" && typeof value.method === "string";
 }
 
+function isRpcToolApprovalRequestFrame(value: unknown): value is RpcToolApprovalRequestFrame {
+	if (!isRecord(value)) return false;
+	return (
+		value.type === "tool_approval_request" &&
+		typeof value.id === "string" &&
+		typeof value.toolCallId === "string" &&
+		typeof value.toolName === "string"
+	);
+}
+
+function isRpcToolApprovalResolvedFrame(value: unknown): value is RpcToolApprovalResolvedFrame {
+	if (!isRecord(value)) return false;
+	return (
+		value.type === "tool_approval_resolved" &&
+		typeof value.id === "string" &&
+		typeof value.toolCallId === "string" &&
+		typeof value.approved === "boolean"
+	);
+}
+
 function normalizeToolResult<TDetails>(result: RpcClientToolResult<TDetails>): AgentToolResult<TDetails> {
 	if (typeof result === "string") {
 		return {
@@ -284,6 +309,8 @@ export class RpcClient {
 	#requestId = 0;
 	#protocolVersion: RpcProtocolVersion = 1;
 	#extensionUiListeners: Set<(req: RpcExtensionUIRequest) => void> = new Set();
+	#toolApprovalRequestListeners = new Set<RpcToolApprovalRequestListener>();
+	#toolApprovalResolvedListeners = new Set<RpcToolApprovalResolvedListener>();
 	#abortController = new AbortController();
 
 	constructor(private options: RpcClientOptions = {}) {
@@ -569,6 +596,27 @@ export class RpcClient {
 	}
 
 	/**
+	 * Subscribe to structured tool-approval requests. Each frame is emitted
+	 * synchronously before the paired `extension_ui_request` select; both are
+	 * correlated 1:1 by `toolCallId` (also carried in `id`). The select remains
+	 * authoritative for the verdict — approve or deny it and the server emits a
+	 * matching `tool_approval_resolved` frame.
+	 */
+	onToolApproval(listener: RpcToolApprovalRequestListener): () => void {
+		this.#toolApprovalRequestListeners.add(listener);
+		return () => this.#toolApprovalRequestListeners.delete(listener);
+	}
+
+	/**
+	 * Subscribe to structured tool-approval verdicts. A resolved frame reports
+	 * the outcome of the paired select (by `toolCallId`) without replacing it.
+	 */
+	onToolApprovalResolved(listener: RpcToolApprovalResolvedListener): () => void {
+		this.#toolApprovalResolvedListeners.add(listener);
+		return () => this.#toolApprovalResolvedListeners.delete(listener);
+	}
+
+	/**
 	 * Get collected stderr output (useful for debugging).
 	 */
 	getStderr(): string {
@@ -655,6 +703,33 @@ export class RpcClient {
 	async setFastMode(enabled: boolean): Promise<{ enabled: boolean; active: boolean }> {
 		const response = await this.#send({ type: "set_fast_mode", enabled });
 		return this.#getData(response);
+	}
+
+	/**
+	 * Append an approval rule to `tools.approvalRules` (persisted). Returns the
+	 * full normalized rule list.
+	 */
+	async addApprovalRule(rule: ApprovalRule): Promise<ApprovalRule[]> {
+		const response = await this.#send({ type: "add_approval_rule", rule });
+		return this.#getData<{ rules: ApprovalRule[] }>(response).rules;
+	}
+
+	/**
+	 * List the current `tools.approvalRules` (normalized; malformed entries are
+	 * dropped).
+	 */
+	async listApprovalRules(): Promise<ApprovalRule[]> {
+		const response = await this.#send({ type: "list_approval_rules" });
+		return this.#getData<{ rules: ApprovalRule[] }>(response).rules;
+	}
+
+	/**
+	 * Remove the approval rule at `index` (0-based) from `tools.approvalRules`
+	 * (persisted). Returns the full remaining list.
+	 */
+	async removeApprovalRule(index: number): Promise<ApprovalRule[]> {
+		const response = await this.#send({ type: "remove_approval_rule", index });
+		return this.#getData<{ rules: ApprovalRule[] }>(response).rules;
 	}
 
 	/**
@@ -1119,6 +1194,20 @@ export class RpcClient {
 		if (isRpcAvailableCommandsUpdateFrame(data)) {
 			for (const listener of this.#availableCommandsUpdateListeners) {
 				listener(data.commands);
+			}
+			return;
+		}
+
+		if (isRpcToolApprovalRequestFrame(data)) {
+			for (const listener of this.#toolApprovalRequestListeners) {
+				listener(data);
+			}
+			return;
+		}
+
+		if (isRpcToolApprovalResolvedFrame(data)) {
+			for (const listener of this.#toolApprovalResolvedListeners) {
+				listener(data);
 			}
 			return;
 		}

--- a/packages/coding-agent/src/modes/rpc/rpc-messages.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-messages.ts
@@ -89,6 +89,48 @@ function sameSnapshot(cursor: RpcMessageCursorPayload, snapshot: RpcMessageSnaps
 	);
 }
 
+/** A frozen message array and the snapshot cursors are bound to. */
+export interface RpcMessagePageSource {
+	messages: AgentMessage[];
+	snapshot: RpcMessageSnapshot;
+}
+
+/** The live-session inputs `resolveRpcMessagePageSource` needs. */
+export interface RpcMessagePageSessionState {
+	isStreaming: boolean;
+	sessionId: string;
+	messages: readonly AgentMessage[];
+	getLeafId(): string | null;
+}
+
+/**
+ * Resolve the message page source for one `get_messages_page` request.
+ *
+ * While the session is settling, every request takes a fresh frozen snapshot,
+ * so a cursor that outlived the epoch (or crossed a session switch) fails
+ * `stale_cursor` on the next page — the pre-existing strictness is preserved.
+ * While a turn is streaming, the first request of a walk freezes once and later
+ * requests in the same epoch reuse the same frozen array, keeping the cursor
+ * (messageCount/leafId) coherent against a live array that keeps growing.
+ */
+export function resolveRpcMessagePageSource(
+	cache: RpcMessagePageSource | undefined,
+	session: RpcMessagePageSessionState,
+): RpcMessagePageSource {
+	if (!session.isStreaming || cache?.snapshot.sessionId !== session.sessionId) {
+		const frozen = [...session.messages];
+		return {
+			messages: frozen,
+			snapshot: {
+				sessionId: session.sessionId,
+				leafId: session.getLeafId(),
+				messageCount: frozen.length,
+			},
+		};
+	}
+	return cache;
+}
+
 /** Page one stable in-memory message snapshot without crossing the v1 frame budget. */
 export function pageRpcMessages(
 	messages: readonly AgentMessage[],

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -28,7 +28,9 @@ import {
 import type { ToolApprovalRequestedEvent, ToolApprovalResolvedEvent } from "../../extensibility/extensions/types";
 import { buildSkillPromptMessage, parseSkillInvocation } from "../../extensibility/skills";
 import { loadSlashCommands } from "../../extensibility/slash-commands";
+import { IrcBus, type IrcDeliveryReceipt } from "../../irc/bus";
 import { type Theme, theme } from "../../modes/theme/theme";
+import { MAIN_AGENT_ID } from "../../registry/agent-registry";
 import type { AgentSession } from "../../session/agent-session";
 import { SKILL_PROMPT_MESSAGE_TYPE, USER_INTERRUPT_LABEL } from "../../session/messages";
 import { executeAcpBuiltinSlashCommand } from "../../slash-commands/acp-builtins";
@@ -483,6 +485,59 @@ export class RpcShutdownCoordinator {
 }
 
 export type RpcSubagentResetRegistry = Pick<RpcSubagentRegistry, "clear">;
+
+type RpcSteerSubagentErrorCode = "unsupported_isolated";
+export type RpcSteerSubagentResult =
+	| { kind: "delivered"; to: string; outcome: IrcDeliveryReceipt["outcome"] }
+	| { kind: "error"; message: string; code?: RpcSteerSubagentErrorCode };
+
+/**
+ * Steer an in-process subagent over the hub/IRC bus (RPC `steer_subagent`).
+ *
+ * The `subagentId` is resolved through the RPC subagent registry, whose
+ * snapshot ids ARE the hub/IRC recipient ids: the task executor emits
+ * lifecycle frames with the same agent id it registers in the global
+ * `AgentRegistry` (see sdk.ts `createAgentSession`), so a "running"
+ * resolution addresses the live subagent directly.
+ *
+ * Delivery reuses the exact primitive the `hub` send tool executes
+ * (`IrcBus.global().send`, see tools/hub/messaging.ts `executeSend`): idle
+ * peers are woken, parked ones revived through the lifecycle manager, and
+ * busy ones receive the message as a non-interrupting aside at their next
+ * step boundary. The sender is attributed to the session owner so the
+ * subagent sees a normal steering DM rather than an anonymous peer.
+ *
+ * Only in-process subagents are steerable this pass: isolated worktree runs
+ * are rejected with error code `unsupported_isolated`.
+ */
+export async function handleRpcSteerSubagent(
+	subagentRegistry: RpcSubagentRegistry,
+	subagentId: string,
+	message: string,
+): Promise<RpcSteerSubagentResult> {
+	const resolution = subagentRegistry.resolveForSteer(subagentId);
+	switch (resolution.kind) {
+		case "unknown":
+			return { kind: "error", message: `Unknown subagent: ${subagentId}` };
+		case "not-running":
+			return { kind: "error", message: `Subagent not running: ${subagentId}` };
+		case "running":
+			if (resolution.snapshot.isolated === true) {
+				return {
+					kind: "error",
+					message: `Subagent ${subagentId} runs in an isolation worktree and cannot be steered over the hub yet.`,
+					code: "unsupported_isolated",
+				};
+			}
+			break;
+	}
+
+	const receipt = await IrcBus.global().send({ from: MAIN_AGENT_ID, to: subagentId, body: message });
+	if (receipt.outcome === "failed") {
+		return { kind: "error", message: `Delivery failed: ${receipt.error ?? "unknown error"}` };
+	}
+	return { kind: "delivered", to: receipt.to, outcome: receipt.outcome };
+}
 
 export type RpcGenerateTitleSession = Pick<AgentSession, "messages" | "generateTitle">;
 
@@ -1391,6 +1446,21 @@ export async function runRpcMode(
 				} catch (err) {
 					return error(id, "get_subagent_messages", err instanceof Error ? err.message : String(err));
 				}
+			}
+
+			case "steer_subagent": {
+				if (!subagentRegistry) {
+					return error(id, "steer_subagent", "Subagent event bus is unavailable");
+				}
+				const message = command.message.trim();
+				if (!message) {
+					return error(id, "steer_subagent", "`message` is required for steer_subagent.");
+				}
+				const result = await handleRpcSteerSubagent(subagentRegistry, command.subagentId, message);
+				if (result.kind === "error") {
+					return error(id, "steer_subagent", result.message, result.code);
+				}
+				return success(id, "steer_subagent", { to: result.to, outcome: result.outcome });
 			}
 
 			// =================================================================

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -11,6 +11,7 @@
  * - Extension UI: Extension UI requests are emitted, client responds with extension_ui_response
  */
 import { once } from "node:events";
+import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
 import { getOAuthProviders } from "@oh-my-pi/pi-ai/oauth";
 import { toolWireSchema } from "@oh-my-pi/pi-ai/utils/schema";
 import { $env, isRecord, Snowflake } from "@oh-my-pi/pi-utils";
@@ -38,7 +39,13 @@ import { isRpcHostToolResult, isRpcHostToolUpdate, RpcHostToolBridge } from "./h
 import { isRpcHostUriResult, RpcHostUriBridge } from "./host-uris";
 import { MAX_RPC_FRAME_BYTES, MAX_RPC_REASSEMBLED_BYTES, RpcFrameEncoder } from "./rpc-frame";
 import { claimRpcInput, readRpcInputFrames } from "./rpc-input";
-import { pageRpcMessages, RPC_MESSAGES_PAGE_BUSY_ERROR, RpcMessagesPageError } from "./rpc-messages";
+import {
+	pageRpcMessages,
+	RPC_MESSAGES_PAGE_BUSY_ERROR,
+	type RpcMessageSnapshot,
+	RpcMessagesPageError,
+	resolveRpcMessagePageSource,
+} from "./rpc-messages";
 import { RpcSubagentRegistry, readRpcSubagentTranscript } from "./rpc-subagents";
 import type {
 	RpcCommand,
@@ -466,6 +473,39 @@ export class RpcShutdownCoordinator {
 
 export type RpcSubagentResetRegistry = Pick<RpcSubagentRegistry, "clear">;
 
+export type RpcGenerateTitleSession = Pick<AgentSession, "messages" | "generateTitle">;
+
+/**
+ * Handle the RPC `generate_title` command: wrap the session's public title
+ * generator, anchored on the first user message, with an optional
+ * title-prompt override. Returns `{ title: null }` when the session has no
+ * user message yet or the input is too low-signal to name. Extracted (like the
+ * other `handleRpc*` helpers) so the wire contract is testable without
+ * launching the full RPC mode.
+ */
+export async function handleRpcGenerateTitle(
+	id: string | undefined,
+	session: RpcGenerateTitleSession,
+	customInstructions: string | undefined,
+): Promise<RpcResponse> {
+	const firstUserText = firstRpcUserMessageText(session.messages);
+	if (firstUserText === undefined) {
+		return { id, type: "response", command: "generate_title", success: true, data: { title: null } };
+	}
+	try {
+		const title = await session.generateTitle(firstUserText, customInstructions);
+		return { id, type: "response", command: "generate_title", success: true, data: { title } };
+	} catch (titleError) {
+		return {
+			id,
+			type: "response",
+			command: "generate_title",
+			success: false,
+			error: titleError instanceof Error ? titleError.message : String(titleError),
+		};
+	}
+}
+
 export async function handleRpcSessionChange(
 	session: RpcSessionChangeSession,
 	command: RpcSessionChangeCommand,
@@ -536,6 +576,36 @@ function shouldEmitRpcTitles(): boolean {
 	if (!raw) return false;
 	const normalized = raw.trim().toLowerCase();
 	return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on";
+}
+
+/** Opt-in auto session-title generation on `prompt` (default off preserves the historical no-title behavior). */
+function shouldAutoGenerateRpcTitles(): boolean {
+	const raw = $env.PI_RPC_TITLES;
+	if (!raw) return false;
+	const normalized = raw.trim().toLowerCase();
+	return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on";
+}
+
+/**
+ * Plain-text content of the session's first user-attributed message — the same
+ * anchor auto-titling and `generate_title` use for naming a session. Returns
+ * undefined for a fresh session that has no user message yet.
+ */
+function firstRpcUserMessageText(messages: readonly AgentMessage[]): string | undefined {
+	for (const message of messages) {
+		if (message.role !== "user") continue;
+		const content = message.content;
+		const text =
+			typeof content === "string"
+				? content
+				: content
+						.filter((block): block is { type: "text"; text: string } => block.type === "text")
+						.map(block => block.text)
+						.join("\n");
+		const trimmed = text.trim();
+		if (trimmed) return trimmed;
+	}
+	return undefined;
 }
 
 function isSubagentSubscriptionLevel(value: unknown): value is RpcSubagentSubscriptionLevel {
@@ -739,6 +809,17 @@ export async function runRpcMode(
 			frameEncoder.setProtocolVersion(2);
 	};
 	const emitRpcTitles = shouldEmitRpcTitles();
+
+	/**
+	 * Frozen-snapshot cache backing `get_messages_page` while a turn streams.
+	 * The first page request in a streaming epoch freezes `session.messages`
+	 * once; later requests in the same epoch reuse the same frozen array so the
+	 * cursor stays coherent (messageCount and leafId cannot drift under the
+	 * walk). Once the session settles the cache is dropped on the next request,
+	 * which re-arms `stale_cursor` protection for any walk that outlived the
+	 * epoch.
+	 */
+	let messagePageCache: { messages: AgentMessage[]; snapshot: RpcMessageSnapshot } | undefined;
 
 	const success = <T extends RpcCommand["type"]>(
 		id: string | undefined,
@@ -1018,6 +1099,13 @@ export async function runRpcMode(
 			// =================================================================
 
 			case "prompt": {
+				// Opt-in auto-titling (PI_RPC_TITLES=1): mirrors the interactive
+				// bootstrap path so a headless first prompt can still name the
+				// session; session.maybeStartTitleGeneration self-guards on an
+				// existing name, low-signal input, and in-flight generation.
+				if (shouldAutoGenerateRpcTitles()) {
+					session.maybeStartTitleGeneration(command.message);
+				}
 				const skillResult = await tryRunRpcSkillCommand(session, command.message, command.streamingBehavior);
 				if (skillResult) {
 					return success(id, "prompt", skillResult);
@@ -1366,6 +1454,16 @@ export async function runRpcMode(
 				return success(id, "set_session_name");
 			}
 
+			case "generate_title": {
+				// Wrap the public session title generator, anchored on the first
+				// user message. The optional `customInstructions` swaps the title
+				// system prompt (the same override `generateTitle` exposes for
+				// special-purpose titling). The command only computes and returns
+				// the candidate; hosts persist it via `set_session_name` (or rely
+				// on `get_state.sessionName` / builtin `session_info_update`).
+				return await handleRpcGenerateTitle(id, session, command.customInstructions);
+			}
+
 			case "handoff": {
 				// Resetting the agent mid-stream lets the live turn keep emitting into a
 				// session that handoff has already torn down. Refuse while a prompt is in
@@ -1386,22 +1484,29 @@ export async function runRpcMode(
 			}
 
 			case "get_messages_page": {
-				if (session.isStreaming || session.isCompacting)
+				// Compaction rewrites the transcript mid-walk, so it still refuses
+				// the page with `session_busy`. Streaming is now allowed: each walk
+				// pages one frozen snapshot, and cursors are bound to that frozen
+				// length so a growing live array cannot shift offsets under the
+				// client. A cursor from before the current epoch (or across a
+				// session switch) still fails with `stale_cursor`.
+				if (session.isCompacting)
 					return error(id, "get_messages_page", RPC_MESSAGES_PAGE_BUSY_ERROR, "session_busy");
-				const messages = session.messages;
+				const cached = resolveRpcMessagePageSource(messagePageCache, {
+					isStreaming: session.isStreaming,
+					sessionId: session.sessionId,
+					messages: session.messages,
+					getLeafId: () => session.sessionManager.getLeafId(),
+				});
+				messagePageCache = cached;
 				try {
 					return success(
 						id,
 						"get_messages_page",
-						pageRpcMessages(
-							messages,
-							{
-								sessionId: session.sessionId,
-								leafId: session.sessionManager.getLeafId(),
-								messageCount: messages.length,
-							},
-							{ cursor: command.cursor, limit: command.limit },
-						),
+						pageRpcMessages(cached.messages, cached.snapshot, {
+							cursor: command.cursor,
+							limit: command.limit,
+						}),
 					);
 				} catch (pageError) {
 					return error(

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -18,12 +18,14 @@ import { $env, isRecord, Snowflake } from "@oh-my-pi/pi-utils";
 import { reset as resetCapabilities } from "../../capability";
 import { clearPluginRootsAndCaches, resolveActiveProjectRegistryPath } from "../../discovery/helpers";
 import {
+	type ExtensionRunner,
 	type ExtensionUIContext,
 	type ExtensionUIDialogOptions,
 	type ExtensionUISelectItem,
 	type ExtensionWidgetOptions,
 	getExtensionUISelectOptionLabel,
 } from "../../extensibility/extensions";
+import type { ToolApprovalRequestedEvent, ToolApprovalResolvedEvent } from "../../extensibility/extensions/types";
 import { buildSkillPromptMessage, parseSkillInvocation } from "../../extensibility/skills";
 import { loadSlashCommands } from "../../extensibility/slash-commands";
 import { type Theme, theme } from "../../modes/theme/theme";
@@ -37,6 +39,12 @@ import { calculateTokensPerSecond } from "../../utils/token-rate";
 import { initializeExtensions } from "../runtime-init";
 import { isRpcHostToolResult, isRpcHostToolUpdate, RpcHostToolBridge } from "./host-tools";
 import { isRpcHostUriResult, RpcHostUriBridge } from "./host-uris";
+import {
+	addRpcApprovalRule,
+	listRpcApprovalRules,
+	type RpcApprovalRuleStore,
+	removeRpcApprovalRule,
+} from "./rpc-approval-rules";
 import { MAX_RPC_FRAME_BYTES, MAX_RPC_REASSEMBLED_BYTES, RpcFrameEncoder } from "./rpc-frame";
 import { claimRpcInput, readRpcInputFrames } from "./rpc-input";
 import {
@@ -63,6 +71,9 @@ import type {
 	RpcResponse,
 	RpcSessionState,
 	RpcSubagentSubscriptionLevel,
+	RpcToolApprovalFrame,
+	RpcToolApprovalRequestFrame,
+	RpcToolApprovalResolvedFrame,
 } from "./rpc-types";
 
 // Re-export types for consumers
@@ -762,6 +773,68 @@ export function requestRpcDialog<T>(
 	output({ type: "extension_ui_request", id, ...request } as RpcExtensionUIRequest);
 	return promise;
 }
+
+// ============================================================================
+// Structured tool approval frames
+// ============================================================================
+
+/**
+ * Serialize a `tool_approval_requested` extension event into the contract-1
+ * `tool_approval_request` wire frame. Emitted synchronously before the paired
+ * select UI request; the select's own request id is generated later inside
+ * `requestRpcDialog`, so `toolCallId` (also carried in `id`) is the documented
+ * 1:1 correlation key between the approval request, its select, and the
+ * eventual `tool_approval_resolved` verdict.
+ */
+function toRpcToolApprovalRequest(event: ToolApprovalRequestedEvent): RpcToolApprovalRequestFrame {
+	return {
+		type: "tool_approval_request",
+		id: event.toolCallId,
+		...(event.sessionId ? { sessionId: event.sessionId } : {}),
+		toolCallId: event.toolCallId,
+		toolName: event.toolName,
+		// Enriched at the emission site (ExtensionToolWrapper); the fallbacks keep a
+		// frame well-formed if an un-enriched event ever reaches a host handler.
+		tier: event.tier ?? "exec",
+		policy: event.policy ?? "prompt",
+		source: event.source ?? "mode",
+		...(event.reason ? { reason: event.reason } : {}),
+		approvalMode: event.approvalMode,
+		...(event.details && event.details.length > 0 ? { details: event.details } : {}),
+	};
+}
+
+/** Serialize a `tool_approval_resolved` extension event into the contract-1 verdict frame. */
+function toRpcToolApprovalResolved(event: ToolApprovalResolvedEvent): RpcToolApprovalResolvedFrame {
+	return {
+		type: "tool_approval_resolved",
+		id: event.toolCallId,
+		toolCallId: event.toolCallId,
+		approved: event.approved,
+		...(event.by ? { by: event.by } : {}),
+	};
+}
+
+/**
+ * Register the structured tool-approval host handlers on an extension runner.
+ *
+ * Used by {@link runRpcMode}; exported so the exact RPC-mode wire path can be
+ * exercised in tests without booting a full agent session. Each emitted frame
+ * is serialized from the enriched `tool_approval_requested`/`tool_approval_resolved`
+ * extension events and delivered through `output`.
+ */
+export function registerRpcApprovalHandlers(
+	runner: Pick<ExtensionRunner, "registerHostHandler">,
+	output: (frame: RpcToolApprovalFrame) => void,
+): void {
+	runner.registerHostHandler<ToolApprovalRequestedEvent>("tool_approval_requested", event => {
+		output(toRpcToolApprovalRequest(event));
+	});
+	runner.registerHostHandler<ToolApprovalResolvedEvent>("tool_approval_resolved", event => {
+		output(toRpcToolApprovalResolved(event));
+	});
+}
+
 /**
  * Run in RPC mode.
  * Listens for JSON commands on stdin, outputs events and responses on stdout.
@@ -1037,6 +1110,18 @@ export async function runRpcMode(
 	const rpcUiContext = new RpcExtensionUIContext(pendingExtensionRequests, output);
 	setToolUIContext?.(rpcUiContext, true);
 
+	// Serialize structured tool-approval frames for hosts that cannot render the
+	// legacy select presentation. The host handlers run through the extension
+	// runner, so `tool_approval_request` is emitted synchronously inside the
+	// approval gate — immediately before the paired `extension_ui_request`
+	// select (the select's request id is generated later, so `toolCallId` in
+	// `id` is the documented 1:1 correlation key) — and `tool_approval_resolved`
+	// fires the moment the select resolves. The legacy select flow stays
+	// authoritative for the verdict and is otherwise untouched.
+	if (session.extensionRunner) {
+		registerRpcApprovalHandlers(session.extensionRunner, output);
+	}
+
 	// Set up extensions with RPC-based UI context
 	await initializeExtensions(session, {
 		mode: "rpc",
@@ -1082,6 +1167,13 @@ export async function runRpcMode(
 		void emitAvailableCommandsUpdate();
 	});
 	await emitAvailableCommandsUpdate();
+
+	// Approval-rule commands persist through the existing session settings
+	// write path (`settings.set`), which queues a background save.
+	const approvalRuleStore = (): RpcApprovalRuleStore => ({
+		read: () => session.settings.get("tools.approvalRules"),
+		write: rules => session.settings.set("tools.approvalRules", rules),
+	});
 
 	// Handle a single command
 	const handleCommand = async (command: RpcCommand): Promise<RpcResponse> => {
@@ -1299,6 +1391,26 @@ export async function runRpcMode(
 				} catch (err) {
 					return error(id, "get_subagent_messages", err instanceof Error ? err.message : String(err));
 				}
+			}
+
+			// =================================================================
+			// Approval rules
+			// =================================================================
+
+			case "add_approval_rule": {
+				const result = addRpcApprovalRule(approvalRuleStore(), command.rule);
+				if (!result.ok) return error(id, "add_approval_rule", result.error);
+				return success(id, "add_approval_rule", { rules: result.rules });
+			}
+
+			case "list_approval_rules": {
+				return success(id, "list_approval_rules", listRpcApprovalRules(approvalRuleStore()));
+			}
+
+			case "remove_approval_rule": {
+				const result = removeRpcApprovalRule(approvalRuleStore(), command.index);
+				if (!result.ok) return error(id, "remove_approval_rule", result.error);
+				return success(id, "remove_approval_rule", { rules: result.rules });
 			}
 
 			// =================================================================

--- a/packages/coding-agent/src/modes/rpc/rpc-subagents.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-subagents.ts
@@ -26,6 +26,17 @@ export interface RpcSubagentTranscriptSelector {
 	fromByte?: number;
 }
 
+/**
+ * Result of {@link RpcSubagentRegistry.resolveForSteer}. `"running"` means a
+ * live in-process subagent whose id maps 1:1 to a hub/IRC recipient;
+ * `"not-running"` means a completed/released subagent whose snapshot was
+ * pruned; `"unknown"` means the id was never seen.
+ */
+export type RpcSubagentSteerResolution =
+	| { kind: "running"; snapshot: RpcSubagentSnapshot }
+	| { kind: "not-running" }
+	| { kind: "unknown" };
+
 type RpcSubagentOutput = (frame: RpcSubagentFrame) => void;
 
 const MAX_RETAINED_TRANSCRIPT_REFERENCES = 256;
@@ -158,6 +169,34 @@ export class RpcSubagentRegistry {
 		return [...this.#subagents.values()].sort((a, b) => a.index - b.index || a.id.localeCompare(b.id));
 	}
 
+	/**
+	 * Resolve a subagent id for steering (RPC `steer_subagent`).
+	 *
+	 * The snapshot `id` is the same agent id the task executor registers in the
+	 * process-global {@link AgentRegistry}: the executor emits lifecycle frames
+	 * with the identical `id` it passes to `createAgentSession` (whose
+	 * registration key becomes the `AgentRegistry` ref key, see sdk.ts), so a
+	 * "running" resolution can be handed straight to the hub/IRC bus as the
+	 * recipient id. Terminal ids are never pruned from `#staleSubagentIds` /
+	 * `#transcriptSessionFilesBySubagentId` until `clear()`, so a released or
+	 * completed subagent stays distinguishable from a genuinely unknown id.
+	 */
+	resolveForSteer(subagentId: string): RpcSubagentSteerResolution {
+		const snapshot = this.#subagents.get(subagentId);
+		if (snapshot) {
+			if (snapshot.status === "running" || snapshot.status === "pending") {
+				return { kind: "running", snapshot };
+			}
+			// Progress can briefly report a terminal status before the terminal
+			// lifecycle frame prunes the snapshot; treat that as not running.
+			return { kind: "not-running" };
+		}
+		if (this.#staleSubagentIds.has(subagentId) || this.#transcriptSessionFilesBySubagentId.has(subagentId)) {
+			return { kind: "not-running" };
+		}
+		return { kind: "unknown" };
+	}
+
 	#rememberTranscriptSession(subagentId: string, sessionFile: string | undefined): void {
 		if (!sessionFile) return;
 		this.#transcriptSessionFilesBySubagentId.delete(subagentId);
@@ -200,6 +239,7 @@ export class RpcSubagentRegistry {
 			parentToolCallId: payload.parentToolCallId ?? existing?.parentToolCallId,
 			lastUpdate: Date.now(),
 			progress: existing?.progress,
+			isolated: payload.isolated ?? existing?.isolated,
 		};
 		this.#rememberTranscriptSession(payload.id, sessionFile);
 		if (isTerminalLifecycleStatus(payload.status)) {
@@ -233,6 +273,9 @@ export class RpcSubagentRegistry {
 			lastUpdate: Date.now(),
 			parentToolCallId: payload.parentToolCallId ?? existing?.parentToolCallId,
 			progress,
+			// Progress payloads do not carry the isolation marker; only lifecycle
+			// start does (set by the executor for worktree-confined runs).
+			isolated: existing?.isolated,
 		});
 		if (this.#subscriptionLevel !== "off") {
 			this.#output({ type: "subagent_progress", payload });

--- a/packages/coding-agent/src/modes/rpc/rpc-types.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-types.ts
@@ -9,6 +9,7 @@ import type { CompactionResult } from "@oh-my-pi/pi-agent-core/compaction";
 import type { Effort, ImageContent, Model, ToolExample } from "@oh-my-pi/pi-ai";
 import type { BashResult } from "../../exec/bash-executor";
 import type { ContextUsage } from "../../extensibility/extensions/types";
+import type { IrcDeliveryReceipt } from "../../irc/bus";
 import type { AgentSessionEvent, SessionStats } from "../../session/agent-session";
 import type { FileEntry } from "../../session/session-entries";
 import type { AvailableSlashCommandSource } from "../../slash-commands/available-commands";
@@ -54,6 +55,7 @@ export type RpcCommand =
 	| { id?: string; type: "add_approval_rule"; rule: ApprovalRule }
 	| { id?: string; type: "list_approval_rules" }
 	| { id?: string; type: "remove_approval_rule"; index: number }
+	| { id?: string; type: "steer_subagent"; subagentId: string; message: string }
 
 	// Model
 	| { id?: string; type: "set_model"; provider: string; modelId: string }
@@ -185,6 +187,12 @@ export interface RpcSubagentSnapshot {
 	lastUpdate: number;
 	progress?: AgentProgress;
 	parentToolCallId?: string;
+	/**
+	 * True when the subagent runs inside an isolation worktree
+	 * (task.isolation.*). Such runs cannot be steered over the hub/IRC bus;
+	 * steering them fails with error code `unsupported_isolated`.
+	 */
+	isolated?: boolean;
 }
 
 export interface RpcSubagentMessagesResult {
@@ -281,6 +289,13 @@ export type RpcResponse =
 			command: "remove_approval_rule";
 			success: true;
 			data: { rules: ApprovalRule[] };
+	  }
+	| {
+			id?: string;
+			type: "response";
+			command: "steer_subagent";
+			success: true;
+			data: { to: string; outcome: IrcDeliveryReceipt["outcome"] };
 	  }
 
 	// Model

--- a/packages/coding-agent/src/modes/rpc/rpc-types.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-types.ts
@@ -82,6 +82,7 @@ export type RpcCommand =
 	| { id?: string; type: "get_branch_messages" }
 	| { id?: string; type: "get_last_assistant_text" }
 	| { id?: string; type: "set_session_name"; name: string }
+	| { id?: string; type: "generate_title"; customInstructions?: string }
 	| { id?: string; type: "handoff"; customInstructions?: string }
 
 	// Messages
@@ -322,6 +323,7 @@ export type RpcResponse =
 			data: { text: string | null };
 	  }
 	| { id?: string; type: "response"; command: "set_session_name"; success: true }
+	| { id?: string; type: "response"; command: "generate_title"; success: true; data: { title: string | null } }
 	| { id?: string; type: "response"; command: "handoff"; success: true; data: RpcHandoffResult | null }
 
 	// Messages

--- a/packages/coding-agent/src/modes/rpc/rpc-types.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-types.ts
@@ -4,7 +4,7 @@
  * Commands are sent as JSON lines on stdin.
  * Responses and events are emitted as JSON lines on stdout.
  */
-import type { AgentMessage, AgentToolResult, ThinkingLevel, ToolLoadMode } from "@oh-my-pi/pi-agent-core";
+import type { AgentMessage, AgentToolResult, ThinkingLevel, ToolLoadMode, ToolTier } from "@oh-my-pi/pi-agent-core";
 import type { CompactionResult } from "@oh-my-pi/pi-agent-core/compaction";
 import type { Effort, ImageContent, Model, ToolExample } from "@oh-my-pi/pi-ai";
 import type { BashResult } from "../../exec/bash-executor";
@@ -18,6 +18,8 @@ import type {
 	SubagentLifecyclePayload,
 	SubagentProgressPayload,
 } from "../../task";
+import type { ApprovalMode, ApprovalPolicy } from "../../tools/approval";
+import type { ApprovalRule } from "../../tools/approval-rules";
 import type { TodoPhase } from "../../tools/todo";
 import type { RpcMessagesPage } from "./rpc-messages";
 
@@ -47,6 +49,11 @@ export type RpcCommand =
 	| { id?: string; type: "set_subagent_subscription"; level: RpcSubagentSubscriptionLevel }
 	| { id?: string; type: "get_subagents" }
 	| { id?: string; type: "get_subagent_messages"; subagentId?: string; sessionFile?: string; fromByte?: number }
+
+	// Approval rules
+	| { id?: string; type: "add_approval_rule"; rule: ApprovalRule }
+	| { id?: string; type: "list_approval_rules" }
+	| { id?: string; type: "remove_approval_rule"; index: number }
 
 	// Model
 	| { id?: string; type: "set_model"; provider: string; modelId: string }
@@ -253,6 +260,29 @@ export type RpcResponse =
 			data: RpcSubagentMessagesResult;
 	  }
 
+	// Approval rules
+	| {
+			id?: string;
+			type: "response";
+			command: "add_approval_rule";
+			success: true;
+			data: { rules: ApprovalRule[] };
+	  }
+	| {
+			id?: string;
+			type: "response";
+			command: "list_approval_rules";
+			success: true;
+			data: { rules: ApprovalRule[] };
+	  }
+	| {
+			id?: string;
+			type: "response";
+			command: "remove_approval_rule";
+			success: true;
+			data: { rules: ApprovalRule[] };
+	  }
+
 	// Model
 	| {
 			id?: string;
@@ -365,6 +395,46 @@ export interface RpcSubagentEventFrame {
 export type RpcSubagentFrame = RpcSubagentLifecycleFrame | RpcSubagentProgressFrame | RpcSubagentEventFrame;
 
 export type RpcSessionEventFrame = AgentSessionEvent | RpcSubagentFrame;
+
+// ============================================================================
+// Tool Approval Frames (stdout)
+// ============================================================================
+/**
+ * Emitted when a tool call requires approval, synchronously before the paired
+ * legacy select {@link RpcExtensionUIRequest}. The select UI request that
+ * immediately follows carries its own generated `id`; the approval request's
+ * `id` therefore carries the `toolCallId` as the documented 1:1 correlation
+ * key — pair a `tool_approval_request` with the select request that arrives
+ * right after it, and join verdicts by `toolCallId`.
+ */
+export interface RpcToolApprovalRequestFrame {
+	type: "tool_approval_request";
+	/** Correlation id — always equal to `toolCallId` (see the type doc). */
+	id: string;
+	sessionId?: string;
+	toolCallId: string;
+	toolName: string;
+	tier: ToolTier;
+	policy: ApprovalPolicy;
+	source: "tool" | "user" | "mode" | "rule";
+	reason?: string;
+	approvalMode: ApprovalMode;
+	/** Untruncated `formatApprovalDetails` lines when the tool declares any. */
+	details?: string[];
+}
+
+/** Emitted when a pending {@link RpcToolApprovalRequestFrame} has been resolved. */
+export interface RpcToolApprovalResolvedFrame {
+	type: "tool_approval_resolved";
+	/** Correlation id — always equal to `toolCallId` (see the request type doc). */
+	id: string;
+	toolCallId: string;
+	approved: boolean;
+	/** Who resolved the approval: `"user"` or `"system"` (failed closed). */
+	by?: "user" | "system";
+}
+
+export type RpcToolApprovalFrame = RpcToolApprovalRequestFrame | RpcToolApprovalResolvedFrame;
 
 // ============================================================================
 // Extension UI Events (stdout)

--- a/packages/coding-agent/src/session/agent-session-events.ts
+++ b/packages/coding-agent/src/session/agent-session-events.ts
@@ -54,6 +54,15 @@ export type AgentSessionEvent =
 	| { type: "todo_reminder"; todos: TodoItem[]; attempt: number; maxAttempts: number }
 	| { type: "todo_auto_clear" }
 	| { type: "irc_message"; message: CustomMessage }
+	| {
+			type: "advisor_note";
+			/** Which configured advisor produced the note (omitted for the default advisor). */
+			advisor?: string;
+			severity?: "nit" | "concern" | "blocker";
+			note: string;
+			/** How the note reached the primary: a preserved visible card, a live steer, or a custom delivery. */
+			deliveredAs: "card" | "steer" | "custom";
+	  }
 	| { type: "notice"; level: "info" | "warning" | "error"; message: string; source?: string }
 	| {
 			type: "thinking_level_changed";

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -3684,7 +3684,10 @@ export class AgentSession {
 		// the wrapper still enforces the mode-accurate gate before execution.
 		const userPolicies = (this.settings.get("tools.approval") ?? {}) as Record<string, unknown>;
 		const approvalArgs = computer ? { actions: computer.actions } : ctx.args;
-		if (resolveApproval(ctx.tool, approvalArgs, "yolo", userPolicies).policy === "deny") {
+		if (
+			resolveApproval(ctx.tool, approvalArgs, "yolo", userPolicies, this.settings.get("tools.approvalRules"))
+				.policy === "deny"
+		) {
 			return undefined;
 		}
 		const eventArgs = computer

--- a/packages/coding-agent/src/session/session-advisors.ts
+++ b/packages/coding-agent/src/session/session-advisors.ts
@@ -1193,6 +1193,7 @@ export class SessionAdvisors {
 		const content = formatAdvisorBatchContent(notes);
 		const details = { notes } satisfies AdvisorMessageDetails;
 		if (channel === "preserve") {
+			this.#emitAdvisorDeliveryNote(source, severity, note, "card");
 			this.#host.preserveAdvisorCard({
 				role: "custom",
 				customType: "advisor",
@@ -1217,6 +1218,7 @@ export class SessionAdvisors {
 			this.#host.clientBridge()?.deferAgentInitiatedTurns === true &&
 			!this.#host.allowAgentInitiatedTurns();
 		if (this.#host.planModeState()?.enabled || cannotAutoTrigger) {
+			this.#emitAdvisorDeliveryNote(source, severity, note, "card");
 			this.#host.preserveAdvisorCard({
 				role: "custom",
 				customType: "advisor",
@@ -1233,12 +1235,30 @@ export class SessionAdvisors {
 		// arming earlier would downgrade the next `advisor.immuneTurns` worth of
 		// real concerns/blockers to skip-idle-flush asides (#5628 review).
 		this.#recordAdvisorInterruptDelivered();
+		this.#emitAdvisorDeliveryNote(source, severity, note, "steer");
 		void this.#host
 			.sendCustomMessage(
 				{ customType: "advisor", content, display: true, attribution: "agent", details },
 				{ deliverAs: "steer", triggerTurn: true },
 			)
 			.catch(err => logger.debug("advisor delivery failed", { err: String(err) }));
+	}
+
+	/**
+	 * Surface one routed advice note to session-event subscribers (RPC hosts,
+	 * ACP bridge, TUI debuggers) mirroring the delivery path that just handled
+	 * it. Best-effort only: a subscriber that throws must never break the real
+	 * deliverable (the preserved card or steered message) it duplicates.
+	 */
+	#emitAdvisorDeliveryNote(
+		advisor: string | undefined,
+		severity: AdvisorSeverity | undefined,
+		note: string,
+		deliveredAs: "card" | "steer",
+	): void {
+		void this.#host
+			.emitSessionEvent({ type: "advisor_note", advisor, severity, note, deliveredAs })
+			.catch(err => logger.debug("advisor_note event emission failed", { err: String(err) }));
 	}
 
 	/** Re-prime every advisor's transcript view after an in-conversation history rewrite. */

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -3322,6 +3322,10 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				description: options.description,
 				status: "started" as const,
 				sessionFile: subtaskSessionFile,
+				// Only the isolation runner (runIsolatedSubprocess) sets `worktree`;
+				// any worktree-backed run is confined to its sandbox and cannot be
+				// steered over the hub/IRC bus. Consumers surface `unsupported_isolated`.
+				isolated: worktree !== undefined,
 				index,
 			};
 			emitSubagentFrame(options.eventBus, options.subagentEventBus, TASK_SUBAGENT_LIFECYCLE_CHANNEL, startedPayload);

--- a/packages/coding-agent/src/task/types.ts
+++ b/packages/coding-agent/src/task/types.ts
@@ -101,6 +101,14 @@ export interface SubagentLifecyclePayload {
 	 * unset — surfaces like the subagent HUD only list detached spawns.
 	 */
 	detached?: boolean;
+	/**
+	 * Spawn runs inside an isolation worktree (task.isolation.*). Isolated runs
+	 * cannot be steered through the hub/IRC bus — their session is confined to
+	 * the sandbox and there is no live in-process recipient — so consumers
+	 * (RPC steer_subagent) reject them with `unsupported_isolated` instead of
+	 * attempting delivery.
+	 */
+	isolated?: boolean;
 }
 
 /** Display cap for a normalized one-line label (roster line, registry `displayName`, prompt field). */

--- a/packages/coding-agent/src/tools/approval-rules.ts
+++ b/packages/coding-agent/src/tools/approval-rules.ts
@@ -1,0 +1,294 @@
+/**
+ * Shared approval-rule pattern machinery.
+ *
+ * ONE implementation of the glob match syntax used by both `bash.patterns`
+ * (evaluated inside BashTool.approval) and the generic `tools.approvalRules`
+ * settings (evaluated in resolveApproval before per-tool policy). Lifted out of
+ * tools/bash.ts so the two surfaces can never drift apart.
+ *
+ * Pattern syntax: `*` is the only wildcard; every other character is literal.
+ * A pattern matches the normalized (whitespace-collapsed) input as a whole.
+ *
+ * Primary-string-arg mapping (contract 5):
+ * - bash   → the `command` argument
+ * - write/edit → the `path` argument (falling back to `file_path`)
+ * - every other tool → matched on tool name alone; any `match` a rule carries
+ *   for such a tool is ignored.
+ */
+import type { ApprovalPolicy } from "./approval";
+import { tokenizeShellSegments } from "./shell-tokenize";
+
+/** A `bash.patterns` entry: a match glob plus the approval it forces. */
+export interface ApprovalPatternRule {
+	match: string;
+	approval: ApprovalPolicy;
+}
+
+/** A `tools.approvalRules` entry: tool-scoped; `match` is optional. */
+export interface ApprovalRule {
+	tool: string;
+	match?: string;
+	approval: ApprovalPolicy;
+	reason?: string;
+}
+
+export interface MatchedApprovalRule {
+	rule: ApprovalRule;
+	index: number;
+}
+
+/** Tools whose approval rules pattern-match a primary string argument. */
+const TOOLS_WITH_PRIMARY_STRING_ARG: Record<string, true> = {
+	bash: true,
+	write: true,
+	edit: true,
+};
+
+const POLICY_VALUES: Record<ApprovalPolicy, true> = {
+	allow: true,
+	deny: true,
+	prompt: true,
+};
+
+function normalizeMatchPattern(value: string): string {
+	return value.trim().replace(/\s+/gu, " ");
+}
+
+/** Convert a `*`-wildcard match pattern to an anchored whole-string RegExp. */
+export function matchPatternToRegExp(pattern: string): RegExp {
+	const escaped = normalizeMatchPattern(pattern)
+		.split("*")
+		.map(part => part.replace(/[\\^$+?.()|[\]{}]/gu, "\\$&"))
+		.join(".*");
+	return new RegExp(`^${escaped}$`, "u");
+}
+
+function normalizeApprovalPolicy(value: unknown): ApprovalPolicy | undefined {
+	if (typeof value !== "string") return undefined;
+	const lowered = value.trim().toLowerCase();
+	return lowered in POLICY_VALUES ? (lowered as ApprovalPolicy) : undefined;
+}
+
+/** Normalize an optional `match` field; a present-but-empty value is treated as absent. */
+function normalizeMatch(value: unknown): string | undefined {
+	if (typeof value !== "string") return undefined;
+	const normalized = normalizeMatchPattern(value);
+	return normalized.length > 0 ? normalized : undefined;
+}
+
+/**
+ * Parse a `bash.patterns` value (array of `{ match, approval }`) into normalized
+ * rules. Malformed entries are dropped, exactly as before the shared module.
+ */
+export function normalizeApprovalPatternRules(value: unknown): ApprovalPatternRule[] {
+	if (!Array.isArray(value)) return [];
+	return value
+		.map(item => {
+			if (!item || typeof item !== "object" || Array.isArray(item)) return undefined;
+			const record = item as Record<string, unknown>;
+			const match = normalizeMatch(record.match);
+			const approval = normalizeApprovalPolicy(record.approval);
+			return match && approval ? { match, approval } : undefined;
+		})
+		.filter((rule): rule is ApprovalPatternRule => !!rule);
+}
+
+/** Normalize a single `tools.approvalRules` entry, or `undefined` when invalid. */
+export function normalizeApprovalRule(value: unknown): ApprovalRule | undefined {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+	const record = value as Record<string, unknown>;
+	if (typeof record.tool !== "string") return undefined;
+	const tool = record.tool.trim();
+	if (tool.length === 0) return undefined;
+	const approval = normalizeApprovalPolicy(record.approval);
+	if (!approval) return undefined;
+	const match = normalizeMatch(record.match);
+	const reason =
+		typeof record.reason === "string" && record.reason.trim().length > 0 ? record.reason.trim() : undefined;
+	return {
+		tool,
+		approval,
+		...(match ? { match } : {}),
+		...(reason ? { reason } : {}),
+	};
+}
+
+/**
+ * Parse a `tools.approvalRules` value (array of
+ * `{ tool, match?, approval, reason? }`) into normalized rules. Malformed
+ * entries are dropped; ordering is preserved for first-match-wins evaluation.
+ */
+export function normalizeApprovalRules(value: unknown): ApprovalRule[] {
+	if (!Array.isArray(value)) return [];
+	const rules: ApprovalRule[] = [];
+	for (const item of value) {
+		const rule = normalizeApprovalRule(item);
+		if (rule) rules.push(rule);
+	}
+	return rules;
+}
+
+/** True when the whole normalized input matches the glob. */
+export function stringMatchesPattern(input: string, pattern: string): boolean {
+	const normalized = normalizeMatchPattern(input);
+	if (normalized.length === 0) return false;
+	return matchPatternToRegExp(pattern).test(normalized);
+}
+
+function shellSegments(input: string): string[] {
+	return tokenizeShellSegments(input)
+		.map(segment => segment.join(" "))
+		.filter(segment => segment.length > 0);
+}
+
+/**
+ * True when the normalized input or any shell segment of it matches the glob.
+ * Reuses the shared shell tokenizer so compound-command matching stays in one
+ * place and honors every command boundary.
+ */
+export function segmentMatchesPattern(input: string, pattern: string): boolean {
+	const regex = matchPatternToRegExp(pattern);
+	const normalized = normalizeMatchPattern(input);
+	if (normalized.length === 0) return false;
+	if (regex.test(normalized)) return true;
+	return shellSegments(input).some(segment => regex.test(segment));
+}
+
+const SHELL_CONTROL_CHARS: Record<string, true> = {
+	"\n": true,
+	";": true,
+	"&": true,
+	"|": true,
+	"<": true,
+	">": true,
+	"`": true,
+	$: true,
+	"(": true,
+	")": true,
+};
+const REINTERPRETED_ARGUMENT_RE = /(?:^|[ \t])(?:-[^-]*[ce]|--(?:command|eval))(?:[= \t]|$)/u;
+
+/**
+ * True when the input contains shell control syntax that an `allow` rule must
+ * not ride over. `allow` must vouch for the ENTIRE command: shell control
+ * syntax could smuggle an unsafe segment past a narrow allow. Also flags
+ * quoted/escaped arguments (`git -c alias.x='!…'`, `sh -c "…"`) that another
+ * shell would reinterpret as executable code.
+ */
+export function hasShellControl(input: string): boolean {
+	let quote: "'" | '"' | undefined;
+	let hasReinterpretableShellControl = false;
+	for (let i = 0; i < input.length; i++) {
+		const ch = input[i];
+		if (quote === "'") {
+			if (ch === "'") {
+				quote = undefined;
+			} else if (Object.hasOwn(SHELL_CONTROL_CHARS, ch)) {
+				hasReinterpretableShellControl = true;
+			}
+			continue;
+		}
+		if (ch === "\\") {
+			const escaped = input[i + 1];
+			if (escaped && Object.hasOwn(SHELL_CONTROL_CHARS, escaped)) {
+				hasReinterpretableShellControl = true;
+			}
+			i++;
+			continue;
+		}
+		if (quote === '"') {
+			if (ch === '"') {
+				quote = undefined;
+				continue;
+			}
+			// Expansion is active inside double quotes even in the original line.
+			if (ch === "`" || ch === "$") return true;
+			// Other control characters are literal here but become executable if a
+			// `-c`/`-e` option reinterprets the argument through another shell.
+			if (Object.hasOwn(SHELL_CONTROL_CHARS, ch)) hasReinterpretableShellControl = true;
+			continue;
+		}
+		if (ch === "'" || ch === '"') {
+			quote = ch;
+			continue;
+		}
+		if (Object.hasOwn(SHELL_CONTROL_CHARS, ch)) return true;
+	}
+	// Options such as `git -c alias.x='!...'` and `sh -c "..."` reinterpret
+	// otherwise literal quoted or escaped arguments as executable code.
+	return hasReinterpretableShellControl && REINTERPRETED_ARGUMENT_RE.test(input);
+}
+
+/**
+ * Whether a rule's glob applies to a primary string under approval-specific
+ * matching: `allow` must vouch for the ENTIRE string (and, for shell-aware
+ * inputs, must not ride a compound line), while `deny`/`prompt` fire on any
+ * matching shell segment of a shell-aware input.
+ */
+export function ruleMatchesPrimary(primary: string, rule: ApprovalPatternRule, shellAware: boolean): boolean {
+	if (rule.approval === "allow") {
+		if (shellAware && hasShellControl(primary)) return false;
+		return stringMatchesPattern(primary, rule.match);
+	}
+	if (shellAware) return segmentMatchesPattern(primary, rule.match);
+	return stringMatchesPattern(primary, rule.match);
+}
+
+/** First `bash.patterns`-shaped rule whose glob matches `primary`. */
+export function findApprovalPatternRule(
+	primary: string,
+	rules: readonly ApprovalPatternRule[],
+	shellAware: boolean,
+): ApprovalPatternRule | undefined {
+	return rules.find(rule => ruleMatchesPrimary(primary, rule, shellAware));
+}
+
+function primaryStringArg(args: unknown, key: string): string | undefined {
+	if (!args || typeof args !== "object" || Array.isArray(args)) return undefined;
+	const value = (args as Record<string, unknown>)[key];
+	return typeof value === "string" ? value : undefined;
+}
+
+/** Whether a tool's rules can pattern-match a primary string argument. */
+export function toolMatchesOnPrimaryStringArg(toolName: string): boolean {
+	return toolName in TOOLS_WITH_PRIMARY_STRING_ARG;
+}
+
+/**
+ * Extract the primary string a tool call operates on for rule matching.
+ * Only tools that act on a single free-form string support pattern matching:
+ * bash → `command`; write/edit → `path` (falling back to `file_path`). Every
+ * other tool returns `undefined` and matches approval rules on tool name alone.
+ */
+export function primaryStringArgForTool(toolName: string, args: unknown): string | undefined {
+	if (toolName === "bash") return primaryStringArg(args, "command");
+	if (toolName === "write" || toolName === "edit") {
+		return primaryStringArg(args, "path") ?? primaryStringArg(args, "file_path");
+	}
+	return undefined;
+}
+
+/**
+ * Apply ordered `tools.approvalRules` to a tool call: the first matching rule
+ * wins. Rules for primary-arg tools with a `match` glob match that string
+ * (bash commands with shell-aware semantics); any other rule matches on tool
+ * name alone. A rule with a `match` for a primary-arg tool is skipped when the
+ * call carries no primary string (e.g. a sloppy edit without a path).
+ */
+export function findApprovalRule(
+	toolName: string,
+	args: unknown,
+	rules: readonly ApprovalRule[],
+): MatchedApprovalRule | undefined {
+	const primaryTool = toolMatchesOnPrimaryStringArg(toolName);
+	for (let index = 0; index < rules.length; index++) {
+		const rule = rules[index];
+		if (rule.tool !== toolName) continue;
+		if (!primaryTool || rule.match === undefined) return { rule, index };
+		const primary = primaryStringArgForTool(toolName, args);
+		if (primary === undefined) continue;
+		const pattern: ApprovalPatternRule = { match: rule.match, approval: rule.approval };
+		if (ruleMatchesPrimary(primary, pattern, toolName === "bash")) return { rule, index };
+	}
+	return undefined;
+}

--- a/packages/coding-agent/src/tools/approval.ts
+++ b/packages/coding-agent/src/tools/approval.ts
@@ -2,11 +2,13 @@
  * Tool approval resolution.
  *
  * Approval policy is declared by each tool. This module only knows how to:
+ * - apply ordered user `tools.approvalRules` entries ahead of per-tool policy,
  * - normalize user `tools.approval.<tool>: allow | deny | prompt` overrides,
  * - compare a tool capability tier against the active approval mode,
  * - format the generic approval prompt body.
  */
 import type { AgentTool, ToolApprovalDecision, ToolTier } from "@oh-my-pi/pi-agent-core";
+import { findApprovalRule, normalizeApprovalRules } from "./approval-rules";
 
 export type { ToolApproval, ToolApprovalDecision, ToolTier } from "@oh-my-pi/pi-agent-core";
 
@@ -20,7 +22,7 @@ export interface ResolvedApproval {
 	tier: ToolTier;
 	reason?: string;
 	override: boolean;
-	source?: "tool" | "user" | "mode";
+	source?: "tool" | "user" | "mode" | "rule";
 	/** User-policy key that produced `source: "user"` (defaults to the tool name). */
 	policyKey?: string;
 }
@@ -105,14 +107,18 @@ function modeApprovesTier(mode: ApprovalMode, tier: ToolTier): boolean {
  * Resolve approval policy for a tool call.
  *
  * Resolution order:
- *  1. Tool `approval(args)` decision, defaulting to tier "exec" when omitted.
+ *  1. Ordered `tools.approvalRules` — the first rule whose tool matches (and,
+ *     for bash/write/edit, whose `match` glob hits the primary string arg)
+ *     wins outright, before any per-tool or mode-derived policy. Rules are
+ *     authoritative in every approval mode, including yolo.
+ *  2. Tool `approval(args)` decision, defaulting to tier "exec" when omitted.
  *     A decision may carry a `policyKey` — `tools.approval.<policyKey>` is then
  *     the user override consulted instead of `tools.approval.<tool.name>`, with
  *     the invoking tool's own policy as the fallback when the user set none for
  *     the keyed sub-tool (e.g. an `xd://` device dispatch without a device
  *     policy still honors `tools.approval.write`).
- *  2. User per-tool override, if set and valid.
- *  3. Active mode tier comparison.
+ *  3. User per-tool override, if set and valid.
+ *  4. Active mode tier comparison.
  *
  * In yolo mode, override-based tool prompts are ignored; user `tools.approval`
  * settings remain authoritative.
@@ -122,7 +128,22 @@ export function resolveApproval(
 	args: unknown,
 	mode: ApprovalMode,
 	userConfig: Record<string, unknown> = {},
+	approvalRulesConfig: unknown = [],
 ): ResolvedApproval {
+	const ruleHit = findApprovalRule(tool.name, args, normalizeApprovalRules(approvalRulesConfig));
+	if (ruleHit) {
+		const { rule, index } = ruleHit;
+		// A rule forces its approval regardless of tier, per-tool policy, or
+		// mode. `policyKey` identifies the rule for diagnostics/deny messages.
+		return {
+			policy: rule.approval,
+			tier: "exec",
+			override: true,
+			source: "rule",
+			policyKey: `tools.approvalRules[${index}]`,
+			...(rule.reason ? { reason: rule.reason } : {}),
+		};
+	}
 	const decision = getToolDecision(tool, args);
 	const policyKey = decision.policyKey ?? tool.name;
 	const userPolicy = Object.hasOwn(userConfig, policyKey) ? normalizePolicy(userConfig[policyKey]) : undefined;
@@ -219,12 +240,19 @@ export function resolveApproval(
 }
 
 /**
- * Error for a resolved deny. Distinguishes tool-owned policy from user config.
+ * Error for a resolved deny. Distinguishes tool-owned policy, approval-rule
+ * overrides, and user config.
  */
 export function denyError(resolved: ResolvedApproval, toolName: string): Error {
 	const { source, reason, policyKey } = resolved;
 	if (source === "tool") {
 		return new Error(`Tool "${toolName}" is blocked by tool policy.${reason ? `\nReason: ${reason}` : ""}`);
+	}
+	if (source === "rule") {
+		return new Error(
+			`Tool "${toolName}" is blocked by an approval rule.${reason ? `\nReason: ${reason}` : ""}\n` +
+				`To allow: remove or change the matching rule in "tools.approvalRules".`,
+		);
 	}
 	return new Error(
 		`Tool "${policyKey ?? toolName}" is blocked by user policy.\n` +
@@ -243,8 +271,9 @@ export function requiresApproval(
 	args: unknown,
 	mode: ApprovalMode,
 	userConfig: Record<string, unknown> = {},
+	approvalRulesConfig: unknown = [],
 ): { required: boolean; reason?: string } {
-	const resolved = resolveApproval(tool, args, mode, userConfig);
+	const resolved = resolveApproval(tool, args, mode, userConfig, approvalRulesConfig);
 	const { policy, reason } = resolved;
 
 	if (policy === "deny") {

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -34,6 +34,7 @@ import { CachedOutputBlock, markFramedBlockComponent, outputBlockContentWidth } 
 import { getSixelLineMask } from "../utils/sixel";
 import type { ToolSession } from ".";
 import { truncateForPrompt } from "./approval";
+import { findApprovalPatternRule, normalizeApprovalPatternRules } from "./approval-rules";
 import { type BashInteractiveResult, runInteractiveBashPty } from "./bash-interactive";
 import { checkBashInterception } from "./bash-interceptor";
 import { canUseInteractiveBashPty } from "./bash-pty-selection";
@@ -55,7 +56,7 @@ import {
 	previewWindowRows,
 	replaceTabs,
 } from "./render-utils";
-import { extractLeadingCdTarget, tokenizeShellSegments } from "./shell-tokenize";
+import { extractLeadingCdTarget } from "./shell-tokenize";
 import { ToolAbortError, ToolError } from "./tool-errors";
 import { toolResult } from "./tool-result";
 import { clampTimeout, TOOL_TIMEOUTS } from "./tool-timeouts";
@@ -63,66 +64,6 @@ import { clampTimeout, TOOL_TIMEOUTS } from "./tool-timeouts";
 export const BASH_DEFAULT_PREVIEW_LINES = DEFAULT_TERMINAL_PREVIEW_LINES;
 
 const BASH_ENV_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
-const BASH_APPROVAL_SHELL_CONTROL_CHARS: Record<string, true> = {
-	"\n": true,
-	"\r": true,
-	";": true,
-	"&": true,
-	"|": true,
-	"<": true,
-	">": true,
-	"`": true,
-	$: true,
-	"(": true,
-	")": true,
-};
-const BASH_APPROVAL_REINTERPRETED_ARGUMENT_RE = /(?:^|[ \t])(?:-[^-]*[ce]|--(?:command|eval))(?:[= \t]|$)/u;
-
-function hasBashApprovalShellControl(command: string): boolean {
-	let quote: "'" | '"' | undefined;
-	let hasReinterpretableShellControl = false;
-	for (let i = 0; i < command.length; i++) {
-		const ch = command[i];
-		if (quote === "'") {
-			if (ch === "'") {
-				quote = undefined;
-			} else if (Object.hasOwn(BASH_APPROVAL_SHELL_CONTROL_CHARS, ch)) {
-				hasReinterpretableShellControl = true;
-			}
-			continue;
-		}
-		if (ch === "\\") {
-			const escaped = command[i + 1];
-			if (escaped && Object.hasOwn(BASH_APPROVAL_SHELL_CONTROL_CHARS, escaped)) {
-				hasReinterpretableShellControl = true;
-			}
-			i++;
-			continue;
-		}
-		if (quote === '"') {
-			if (ch === '"') {
-				quote = undefined;
-				continue;
-			}
-			// Expansion is active inside double quotes even in the original line.
-			if (ch === "`" || ch === "$") return true;
-			// Other control characters are literal here but become executable if a
-			// `-c`/`-e` option reinterprets the argument through another shell.
-			if (Object.hasOwn(BASH_APPROVAL_SHELL_CONTROL_CHARS, ch)) hasReinterpretableShellControl = true;
-			continue;
-		}
-		if (ch === "'" || ch === '"') {
-			quote = ch;
-			continue;
-		}
-		if (Object.hasOwn(BASH_APPROVAL_SHELL_CONTROL_CHARS, ch)) return true;
-	}
-	// Options such as `git -c alias.x='!...'` and `sh -c "..."` reinterpret
-	// otherwise literal quoted or escaped arguments as executable code.
-	return hasReinterpretableShellControl && BASH_APPROVAL_REINTERPRETED_ARGUMENT_RE.test(command);
-}
-
-const BASH_PATTERN_APPROVAL_VALUES = new Set(["allow", "deny", "prompt"]);
 
 /**
  * Shape a shell command line for an ACP-conformant `terminal/create` request.
@@ -215,90 +156,6 @@ export const CRITICAL_BASH_PATTERNS = [
 	// Network-shell exfil.
 	/\bnc\b[^|;]*\s-[a-zA-Z]*[ec][a-zA-Z]*\s/i, // `nc -e` / `nc -c`.
 ] as const;
-
-type BashPatternApproval = "allow" | "deny" | "prompt";
-
-interface BashApprovalPatternRule {
-	match: string;
-	approval: BashPatternApproval;
-}
-
-function normalizeBashApprovalPattern(value: string): string {
-	return value.trim().replace(/\s+/gu, " ");
-}
-
-function bashApprovalPatternToRegExp(pattern: string): RegExp {
-	const escaped = normalizeBashApprovalPattern(pattern)
-		.split("*")
-		.map(part => part.replace(/[\\^$+?.()|[\]{}]/gu, "\\$&"))
-		.join(".*");
-	return new RegExp(`^${escaped}$`, "u");
-}
-
-function normalizeBashPatternApproval(value: unknown): BashPatternApproval | undefined {
-	if (typeof value !== "string") return undefined;
-	const normalized = value.trim().toLowerCase();
-	return BASH_PATTERN_APPROVAL_VALUES.has(normalized) ? (normalized as BashPatternApproval) : undefined;
-}
-
-function getBashApprovalPatternRules(value: unknown): BashApprovalPatternRule[] {
-	if (!Array.isArray(value)) return [];
-	return value
-		.map(item => {
-			if (!item || typeof item !== "object" || Array.isArray(item)) return undefined;
-			const record = item as Record<string, unknown>;
-			if (typeof record.match !== "string") return undefined;
-			const match = normalizeBashApprovalPattern(record.match);
-			const approval = normalizeBashPatternApproval(record.approval);
-			return match.length > 0 && approval ? { match, approval } : undefined;
-		})
-		.filter((rule): rule is BashApprovalPatternRule => !!rule);
-}
-
-function commandMatchesBashApprovalPattern(command: string, pattern: string): boolean {
-	const normalizedCommand = normalizeBashApprovalPattern(command);
-	if (normalizedCommand.length === 0) return false;
-	return bashApprovalPatternToRegExp(pattern).test(normalizedCommand);
-}
-
-// `deny`/`prompt` rules are matched per segment so a dangerous command buried in
-// a compound line (`cd x && rm -rf /`, `sleep 1 & rm -rf /`) is still caught.
-// Reuse the shared shell tokenizer so segmentation stays in one place and honors
-// every command boundary (`;`, `&&`, `||`, `|`, `&`, subshells, newlines).
-function bashCommandSegments(command: string): string[] {
-	return tokenizeShellSegments(command)
-		.map(segment => segment.join(" "))
-		.filter(segment => segment.length > 0);
-}
-
-// `deny`/`prompt` matching: the rule fires when its glob matches the whole
-// command or any single segment of a compound command.
-function commandSegmentMatchesBashApprovalPattern(command: string, pattern: string): boolean {
-	const regex = bashApprovalPatternToRegExp(pattern);
-	const normalizedCommand = normalizeBashApprovalPattern(command);
-	if (normalizedCommand.length === 0) return false;
-	if (regex.test(normalizedCommand)) return true;
-	return bashCommandSegments(command).some(segment => regex.test(segment));
-}
-
-// A rule "applies" to a command under approval-specific semantics: `allow` must
-// vouch for the ENTIRE command and never rides a compound line (shell control
-// syntax could smuggle an unsafe segment past a narrow allow), while `deny` and
-// `prompt` fire on any matching segment so they mean what they appear to.
-function bashApprovalRuleMatches(command: string, rule: BashApprovalPatternRule): boolean {
-	if (rule.approval === "allow") {
-		if (hasBashApprovalShellControl(command)) return false;
-		return commandMatchesBashApprovalPattern(command, rule.match);
-	}
-	return commandSegmentMatchesBashApprovalPattern(command, rule.match);
-}
-
-function findBashApprovalPatternRule(
-	command: string,
-	rules: readonly BashApprovalPatternRule[],
-): BashApprovalPatternRule | undefined {
-	return rules.find(rule => bashApprovalRuleMatches(command, rule));
-}
 
 async function saveBashOriginalArtifact(session: ToolSession, originalText: string): Promise<string | undefined> {
 	try {
@@ -553,8 +410,8 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 	readonly approval = (args: unknown): ToolApprovalDecision => {
 		const rawCommand = (args as Partial<BashToolInput>).command;
 		const command = typeof rawCommand === "string" ? rawCommand : "";
-		const patternRules = getBashApprovalPatternRules(this.session.settings.get("bash.patterns"));
-		const patternRule = findBashApprovalPatternRule(command, patternRules);
+		const patternRules = normalizeApprovalPatternRules(this.session.settings.get("bash.patterns"));
+		const patternRule = findApprovalPatternRule(command, patternRules, true);
 		if (patternRule?.approval === "deny") {
 			return {
 				tier: "exec",

--- a/packages/coding-agent/test/agent-session-advisor-note.test.ts
+++ b/packages/coding-agent/test/agent-session-advisor-note.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Contract: every routed advisor note is mirrored as a structured
+ * `advisor_note` session event alongside the legacy delivery (preserved card
+ * or steered custom message). The event is best-effort — a host that ignores
+ * it loses nothing — but when it is emitted, its `deliveredAs` must match the
+ * actual delivery path so headless hosts (RPC/ACP) can surface the advisory
+ * without parsing transcript text.
+ *
+ * Two deterministic delivery seams, driven exactly like the existing advisor
+ * suppression suite:
+ *   - a late `concern` after a terminal text answer is preserved as a card
+ *     (channel "preserve") → `deliveredAs: "card"`;
+ *   - a late `blocker` after a terminal text answer still steers a corrective
+ *     primary turn (blocker is exempt from terminal-answer preservation) →
+ *     `deliveredAs: "steer"`.
+ */
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
+import { Agent, type AgentMessage } from "@oh-my-pi/pi-agent-core";
+import { createMockModel, type MockModel } from "@oh-my-pi/pi-ai/providers/mock";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { AgentSession, type AgentSessionEvent } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import type { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { TempDir } from "@oh-my-pi/pi-utils";
+import { createInMemoryAuthStorage } from "./helpers/agent-session-setup";
+
+type AdvisorNoteEvent = Extract<AgentSessionEvent, { type: "advisor_note" }>;
+
+interface AdvisorNoteHarness {
+	session: AgentSession;
+	mock: MockModel;
+	advisorMock: MockModel;
+	/** Resolves when the first `advisor_note` event is emitted to subscribers. */
+	noteArrived: Promise<void>;
+	noteEvents: AdvisorNoteEvent[];
+}
+
+function isAdvisorCard(message: AgentMessage): message is AgentMessage & { content: string } {
+	if (message.role !== "custom") return false;
+	if (!("content" in message) || typeof message.content !== "string") return false;
+	if (!("customType" in message) || typeof message.customType !== "string") return false;
+	return message.customType === "advisor";
+}
+
+describe("AgentSession advisor_note session event", () => {
+	let tempDir: TempDir;
+	let session: AgentSession;
+	const authStorages: AuthStorage[] = [];
+
+	beforeAll(() => {
+		tempDir = TempDir.createSync("@pi-advisor-note-");
+	});
+
+	afterEach(async () => {
+		try {
+			await session?.dispose();
+		} finally {
+			for (const authStorage of authStorages.splice(0)) authStorage.close();
+		}
+	});
+
+	afterAll(async () => {
+		await tempDir?.remove();
+	});
+
+	/** Primary completes one terminal text turn; the advisor then raises one note. */
+	async function createAdvisorNoteHarness(severity: "concern" | "blocker"): Promise<AdvisorNoteHarness> {
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5")!;
+		const mock = createMockModel({
+			responses: [
+				{ content: ["EXACT VERDICT"], stopReason: "stop" },
+				{ content: ["CHANGED VERDICT"], stopReason: "stop" },
+			],
+		});
+		const advisorMock = createMockModel({
+			responses: [
+				{
+					content: [
+						{
+							type: "toolCall",
+							name: "advise",
+							arguments: { note: "Fixture verdict needs review", severity },
+						},
+					],
+				},
+				{ content: [], stopReason: "stop" },
+			],
+		});
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model, systemPrompt: ["Test"], tools: [] },
+			streamFn: mock.stream,
+		});
+		const sessionManager = SessionManager.inMemory();
+		const settings = Settings.isolated({ "compaction.enabled": false, "retry.enabled": false });
+		settings.setModelRole("advisor", "anthropic/claude-sonnet-4-5");
+		const authStorage = createInMemoryAuthStorage();
+		authStorages.push(authStorage);
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		const modelRegistry = new ModelRegistry(authStorage, tempDir.join("models.yml"));
+		const harnessSession = new AgentSession({
+			agent,
+			sessionManager,
+			settings,
+			modelRegistry,
+			advisorTools: [],
+			advisorStreamFn: advisorMock.stream,
+		});
+		session = harnessSession;
+
+		const noteEvents: AdvisorNoteEvent[] = [];
+		const noteArrived = Promise.withResolvers<void>();
+		harnessSession.subscribe(event => {
+			if (event.type !== "advisor_note") return;
+			noteEvents.push(event);
+			noteArrived.resolve();
+		});
+
+		// Complete a terminal primary turn BEFORE enabling the advisor, so no
+		// advisor auto-review can race the primary (mirrors the advisor
+		// suppression suite). The advisor then raises one note on demand.
+		await harnessSession.prompt("read five fixture files and answer with exactly one line");
+		await harnessSession.waitForIdle();
+		expect(mock.calls).toHaveLength(1);
+
+		expect(harnessSession.setAdvisorEnabled(true)).toBe(true);
+		const advisor = harnessSession.getAdvisorAgent();
+		if (!advisor) throw new Error("Expected advisor agent to be live");
+		await advisor.prompt("inspect the completed turn");
+		await harnessSession.waitForIdle();
+
+		return { session: harnessSession, mock, advisorMock, noteArrived: noteArrived.promise, noteEvents };
+	}
+
+	it("mirrors a preserved advisor concern as advisor_note deliveredAs card", async () => {
+		const { session: s, mock, noteArrived, noteEvents } = await createAdvisorNoteHarness("concern");
+		await noteArrived;
+
+		// Structured mirror of the preserved card.
+		expect(noteEvents[0]).toMatchObject({
+			type: "advisor_note",
+			severity: "concern",
+			note: "Fixture verdict needs review",
+			deliveredAs: "card",
+		});
+		// The legacy delivery is still authoritative.
+		const advisorCards = s.agent.state.messages.filter(isAdvisorCard);
+		expect(advisorCards).toHaveLength(1);
+		expect(advisorCards[0]!.content).toContain("Fixture verdict needs review");
+		// A preserved concern must not wake the primary.
+		expect(mock.calls).toHaveLength(1);
+	});
+
+	it("mirrors a steered advisor blocker as advisor_note deliveredAs steer", async () => {
+		const { session: s, mock, noteArrived, noteEvents } = await createAdvisorNoteHarness("blocker");
+		await noteArrived;
+
+		expect(noteEvents[0]).toMatchObject({
+			type: "advisor_note",
+			severity: "blocker",
+			note: "Fixture verdict needs review",
+			deliveredAs: "steer",
+		});
+		// The steered blocker wakes the primary for a corrective turn.
+		expect(mock.calls).toHaveLength(2);
+		expect(s.agent.state.messages.filter(message => message.role === "custom")).toHaveLength(1);
+	});
+
+	it("never emits advisor_note for advisor notes dropped by the emission guard", async () => {
+		const noteEvents: AdvisorNoteEvent[] = [];
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5")!;
+		const mock = createMockModel({
+			responses: [{ content: ["ONLY VERDICT"], stopReason: "stop" }],
+		});
+		// The advisor never raises: its only turn is a plain stop with no advise call.
+		const advisorMock = createMockModel({ responses: [{ content: [], stopReason: "stop" }] });
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model, systemPrompt: ["Test"], tools: [] },
+			streamFn: mock.stream,
+		});
+		const sessionManager = SessionManager.inMemory();
+		const settings = Settings.isolated({ "compaction.enabled": false, "retry.enabled": false });
+		settings.setModelRole("advisor", "anthropic/claude-sonnet-4-5");
+		const authStorage = createInMemoryAuthStorage();
+		authStorages.push(authStorage);
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		const modelRegistry = new ModelRegistry(authStorage, tempDir.join("models.yml"));
+		session = new AgentSession({
+			agent,
+			sessionManager,
+			settings,
+			modelRegistry,
+			advisorTools: [],
+			advisorStreamFn: advisorMock.stream,
+		});
+		session.subscribe(event => {
+			if (event.type === "advisor_note") noteEvents.push(event);
+		});
+		expect(session.setAdvisorEnabled(true)).toBe(true);
+		await session.prompt("answer exactly one line");
+		await session.waitForIdle();
+		expect(await session.waitForAdvisorCatchup(1000)).toBe(true);
+
+		expect(session.agent.state.messages.filter(isAdvisorCard)).toHaveLength(0);
+		expect(noteEvents).toEqual([]);
+	});
+});

--- a/packages/coding-agent/test/rpc-approval-rules.test.ts
+++ b/packages/coding-agent/test/rpc-approval-rules.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "bun:test";
+import {
+	addRpcApprovalRule,
+	listRpcApprovalRules,
+	type RpcApprovalRuleStore,
+	removeRpcApprovalRule,
+} from "@oh-my-pi/pi-coding-agent/modes/rpc/rpc-approval-rules";
+import type { ApprovalRule } from "@oh-my-pi/pi-coding-agent/tools/approval-rules";
+
+/**
+ * In-memory stand-in for the `tools.approvalRules` session setting. Mirrors
+ * `Settings.isolated`: `read()` returns whatever was written (or seeded to
+ * simulate a hand-edited config file), `write()` stores the persisted value.
+ */
+function createStore(seed: unknown = []): RpcApprovalRuleStore & { current: () => unknown } {
+	let raw: unknown = seed;
+	return {
+		read: () => raw,
+		write: (rules: ApprovalRule[]) => {
+			raw = rules;
+		},
+		current: () => raw,
+	};
+}
+
+describe("RPC approval-rule commands (round trip)", () => {
+	it("add → list → remove returns the persisted normalized list", () => {
+		const store = createStore();
+		const added = addRpcApprovalRule(store, {
+			tool: "bash",
+			match: "rm -rf /*",
+			approval: "deny",
+			reason: "destructive",
+		});
+		expect(added.ok).toBe(true);
+		if (!added.ok) return;
+		expect(added.rules).toEqual([{ tool: "bash", match: "rm -rf /*", approval: "deny", reason: "destructive" }]);
+		// The write path persists the exact list.
+		expect(store.current()).toEqual(added.rules);
+
+		const second = addRpcApprovalRule(store, { tool: "write", approval: "allow" });
+		expect(second.ok).toBe(true);
+		if (!second.ok) return;
+		expect(store.current()).toHaveLength(2);
+
+		expect(listRpcApprovalRules(store).rules).toEqual(second.rules);
+
+		const removed = removeRpcApprovalRule(store, 0);
+		expect(removed.ok).toBe(true);
+		if (!removed.ok) return;
+		expect(removed.rules).toEqual([{ tool: "write", approval: "allow" }]);
+		expect(store.current()).toEqual(removed.rules);
+	});
+
+	it("rejects invalid rule inputs without mutating the store", () => {
+		const store = createStore();
+		const badApproval = addRpcApprovalRule(store, { tool: "bash", approval: "maybe" });
+		expect(badApproval).toMatchObject({ ok: false });
+		if (badApproval.ok) return;
+		expect(badApproval.error).toContain("approval");
+		expect(store.current()).toEqual([]);
+
+		const missingTool = addRpcApprovalRule(store, { approval: "deny" });
+		expect(missingTool.ok).toBe(false);
+		expect(store.current()).toEqual([]);
+	});
+
+	it("normalizes the input before persisting", () => {
+		const store = createStore();
+		const result = addRpcApprovalRule(store, { tool: "  bash  ", match: "  rm   -rf *  ", approval: "prompt" });
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(store.current()).toEqual([{ tool: "bash", match: "rm -rf *", approval: "prompt" }]);
+	});
+
+	it("removing by index rejects non-integers and out-of-range indices", () => {
+		const store = createStore([{ tool: "bash", approval: "allow" }]);
+		expect(removeRpcApprovalRule(store, "x")).toMatchObject({ ok: false });
+		expect(removeRpcApprovalRule(store, 1.5)).toMatchObject({ ok: false });
+		const outOfRange = removeRpcApprovalRule(store, 3);
+		expect(outOfRange.ok).toBe(false);
+		if (!outOfRange.ok) expect(outOfRange.error).toContain("out of range");
+		// Failed removals leave the persisted list untouched.
+		expect(store.current()).toEqual([{ tool: "bash", approval: "allow" }]);
+	});
+
+	it("lists only valid rules when the store holds hand-edited junk", () => {
+		const store = createStore([
+			{ tool: "bash", match: "git *", approval: "allow" },
+			{ tool: "write", approval: "bogus" },
+			"not an object",
+		]);
+		expect(listRpcApprovalRules(store).rules).toEqual([{ tool: "bash", match: "git *", approval: "allow" }]);
+	});
+
+	it("round-trips through dedup of a rule list persisted by an earlier add", () => {
+		const store = createStore();
+		const first = addRpcApprovalRule(store, { tool: "grep", approval: "allow" });
+		if (!first.ok) throw new Error("expected add to succeed");
+		const second = addRpcApprovalRule(store, { tool: "glob", approval: "deny" });
+		if (!second.ok) throw new Error("expected add to succeed");
+		// A fresh store seeded with the persisted list sees the same rules.
+		const reloaded = createStore(store.current());
+		expect(listRpcApprovalRules(reloaded).rules).toEqual([
+			{ tool: "grep", approval: "allow" },
+			{ tool: "glob", approval: "deny" },
+		]);
+	});
+});

--- a/packages/coding-agent/test/rpc-approval.test.ts
+++ b/packages/coding-agent/test/rpc-approval.test.ts
@@ -1,0 +1,332 @@
+import { Database } from "bun:sqlite";
+import { afterAll, beforeAll, describe, expect, it, vi } from "bun:test";
+import path from "node:path";
+import type { AgentTool, AgentToolContext, AgentToolResult } from "@oh-my-pi/pi-agent-core";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { ExtensionRuntime } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/loader";
+import { ExtensionRunner } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/runner";
+import type {
+	ExtensionActions,
+	ExtensionContextActions,
+	ExtensionUIContext,
+} from "@oh-my-pi/pi-coding-agent/extensibility/extensions/types";
+import { ExtensionToolWrapper } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/wrapper";
+import type { PendingExtensionRequest } from "@oh-my-pi/pi-coding-agent/modes/rpc/rpc-mode";
+import { registerRpcApprovalHandlers, requestRpcSelect } from "@oh-my-pi/pi-coding-agent/modes/rpc/rpc-mode";
+import { theme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { AuthStorage, SqliteAuthCredentialStore } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+const TOOL_CALL_ID = "call_abc123";
+
+/** Captured output callback receiving every RPC frame the harness emits. */
+type OutputFn = (obj: object) => void;
+
+function noOpExtensionActions(): ExtensionActions {
+	return {
+		sendMessage: () => {},
+		sendUserMessage: () => {},
+		appendEntry: () => {},
+		getActiveTools: () => [],
+		getAllTools: () => [],
+		setActiveTools: async () => {},
+		getCommands: () => [],
+		setModel: () => {},
+		getThinkingLevel: () => "off",
+		setThinkingLevel: () => {},
+		getServiceTiers: () => [],
+		setServiceTier: () => {},
+		getSessionName: () => undefined,
+		setSessionName: () => {},
+		registerProvider: () => {},
+		unregisterProvider: () => {},
+	} as unknown as ExtensionActions;
+}
+
+function noOpExtensionContextActions(): ExtensionContextActions {
+	return {
+		getModel: () => undefined,
+		isIdle: () => false,
+		abort: () => {},
+		hasPendingMessages: () => false,
+		shutdown: () => {},
+		getContextUsage: () => undefined,
+		compact: async () => {},
+		getSystemPrompt: () => [],
+	} as unknown as ExtensionContextActions;
+}
+
+function noOpUiMethod(): void {}
+
+/** ExtensionUIContext stub whose `select` drives the real RPC select wire path. */
+function rpcUiContextStub(pendingRequests: Map<string, PendingExtensionRequest>, output: OutputFn): ExtensionUIContext {
+	return {
+		select: (title, options, dialogOptions) =>
+			requestRpcSelect(pendingRequests, output, title, options, dialogOptions),
+		confirm: async () => false,
+		input: async () => undefined,
+		notify: noOpUiMethod,
+		onTerminalInput: () => () => {},
+		setStatus: noOpUiMethod,
+		setWorkingMessage: noOpUiMethod,
+		setWidget: noOpUiMethod,
+		setFooter: noOpUiMethod,
+		setHeader: noOpUiMethod,
+		setTitle: noOpUiMethod,
+		custom: async () => undefined as never,
+		setEditorText: noOpUiMethod,
+		pasteToEditor: noOpUiMethod,
+		getEditorText: () => "",
+		editor: async () => undefined,
+		addAutocompleteProvider: noOpUiMethod,
+		setEditorComponent: noOpUiMethod,
+		get theme() {
+			return theme;
+		},
+		getAllThemes: async () => [],
+		getTheme: async () => undefined,
+		setTheme: async () => ({ success: false, error: "UI not available" }),
+		getToolsExpanded: () => false,
+		setToolsExpanded: noOpUiMethod,
+	};
+}
+
+function mockExecTool(options: { approvedDetails?: string[] | string; reason?: string } = {}): AgentTool {
+	return {
+		name: "mock_exec",
+		description: "Mock exec-tier tool",
+		parameters: {},
+		label: "Mock Exec",
+		strict: false,
+		approval: {
+			tier: "exec",
+			policy: "prompt",
+			...(options.reason ? { reason: options.reason } : {}),
+		},
+		...(options.approvedDetails ? { formatApprovalDetails: () => options.approvedDetails } : {}),
+		async execute(_toolCallId: string, _params: Record<string, unknown>): Promise<AgentToolResult> {
+			return { content: [{ type: "text", text: "executed" }] };
+		},
+	} as unknown as AgentTool;
+}
+
+let tempDir: TempDir;
+let sessionManager: SessionManager;
+let output = vi.fn<OutputFn>();
+let pendingRequests: Map<string, PendingExtensionRequest> = new Map();
+
+beforeAll(() => {
+	tempDir = TempDir.createSync("@pi-rpc-approval-");
+	sessionManager = SessionManager.inMemory(tempDir.path());
+});
+
+afterAll(() => {
+	tempDir.remove();
+});
+
+function setupRunner(): ExtensionRunner {
+	const modelRegistry = new ModelRegistry(
+		new AuthStorage(new SqliteAuthCredentialStore(new Database(":memory:"))),
+		path.join(tempDir.path(), "models.yml"),
+	);
+	const runner = new ExtensionRunner([], new ExtensionRuntime(), tempDir.path(), sessionManager, modelRegistry);
+	output = vi.fn<OutputFn>();
+	pendingRequests = new Map();
+	runner.initialize(
+		noOpExtensionActions(),
+		noOpExtensionContextActions(),
+		undefined,
+		rpcUiContextStub(pendingRequests, output),
+		"rpc",
+	);
+	registerRpcApprovalHandlers(runner, output);
+	return runner;
+}
+
+function approvalContext(): AgentToolContext {
+	return {
+		settings: Settings.isolated({ "tools.approvalMode": "yolo" }),
+		sessionManager,
+	} as unknown as AgentToolContext;
+}
+
+function emittedFrames(): object[] {
+	return output.mock.calls.map(call => call[0] as object);
+}
+
+/** Poll until at least `count` frames have been emitted (approval gate emission is async). */
+async function waitForEmittedFrames(count: number): Promise<void> {
+	for (let attempt = 0; attempt < 200; attempt++) {
+		if (emittedFrames().length >= count) return;
+		await Bun.sleep(1);
+	}
+	throw new Error(`Timed out waiting for ${count} RPC frames`);
+}
+
+function emittedSelectFrame(frame: object): { id: string } {
+	if (!("type" in frame) || !("method" in frame) || !("id" in frame)) {
+		throw new Error("Expected an extension_ui_request select frame");
+	}
+	if (frame.type !== "extension_ui_request" || frame.method !== "select" || typeof frame.id !== "string") {
+		throw new Error("Expected an extension_ui_request select frame");
+	}
+	return { id: frame.id };
+}
+
+function resolveSelect(id: string, value: string): void {
+	const pending = pendingRequests.get(id);
+	if (!pending) throw new Error(`Expected pending select request ${id}`);
+	pending.resolve({ type: "extension_ui_response", id, value });
+}
+
+describe("RPC structured tool approval frames", () => {
+	it("emits tool_approval_request before the paired select and tool_approval_resolved on approval", async () => {
+		const runner = setupRunner();
+		const wrapper = new ExtensionToolWrapper(
+			mockExecTool({
+				approvedDetails: ["detail line one", "", "detail line two"],
+				reason: "requires manual review",
+			}),
+			runner,
+		);
+
+		const executePromise = wrapper.execute(
+			TOOL_CALL_ID,
+			{ command: "echo hi" },
+			undefined,
+			undefined,
+			approvalContext(),
+		);
+
+		// The approval gate emits tool_approval_request, then the paired select on
+		// subsequent microtasks. Wait for both so the frame-sequence assertion below
+		// is deterministic; the mock preserves emission order.
+		await waitForEmittedFrames(2);
+		const early = emittedFrames();
+		expect(early).toHaveLength(2);
+		expect(early[0]).toEqual({
+			type: "tool_approval_request",
+			id: TOOL_CALL_ID,
+			sessionId: sessionManager.getSessionId(),
+			toolCallId: TOOL_CALL_ID,
+			toolName: "mock_exec",
+			tier: "exec",
+			policy: "prompt",
+			source: "tool",
+			reason: "requires manual review",
+			approvalMode: "yolo",
+			details: ["detail line one", "detail line two"],
+		});
+		const selectFrame = emittedSelectFrame(early[1]!);
+		expect(early[1]).toMatchObject({ type: "extension_ui_request", method: "select", options: ["Approve", "Deny"] });
+
+		resolveSelect(selectFrame.id, "Approve");
+		await executePromise;
+
+		const all = emittedFrames();
+		expect(all).toHaveLength(3);
+		expect(all[2]).toEqual({
+			type: "tool_approval_resolved",
+			id: TOOL_CALL_ID,
+			toolCallId: TOOL_CALL_ID,
+			approved: true,
+			by: "user",
+		});
+	});
+
+	it("reports a user denial via tool_approval_resolved and blocks execution", async () => {
+		const runner = setupRunner();
+		const wrapper = new ExtensionToolWrapper(mockExecTool(), runner);
+
+		const executePromise = wrapper.execute(TOOL_CALL_ID, {}, undefined, undefined, approvalContext());
+
+		await waitForEmittedFrames(2);
+		const early = emittedFrames();
+		expect(early).toHaveLength(2);
+		const selectFrame = emittedSelectFrame(early[1]!);
+
+		resolveSelect(selectFrame.id, "Deny");
+		await expect(executePromise).rejects.toThrow("Tool call denied by user: mock_exec");
+
+		const all = emittedFrames();
+		expect(all).toHaveLength(3);
+		expect(all[2]).toEqual({
+			type: "tool_approval_resolved",
+			id: TOOL_CALL_ID,
+			toolCallId: TOOL_CALL_ID,
+			approved: false,
+			by: "user",
+		});
+	});
+});
+
+describe("ExtensionRunner.registerHostHandler", () => {
+	it("is visible to hasHandlers and reverts on dispose", () => {
+		const runner = setupRunner();
+		expect(runner.hasHandlers("tool_approval_requested")).toBe(true);
+		expect(runner.hasHandlers("tool_approval_resolved")).toBe(true);
+		expect(runner.hasHandlers("session_start")).toBe(false);
+		const dispose = runner.registerHostHandler("custom_wire_event", () => {});
+		expect(runner.hasHandlers("custom_wire_event")).toBe(true);
+		dispose();
+		expect(runner.hasHandlers("custom_wire_event")).toBe(false);
+	});
+
+	it("dispatches host handlers through emit with the enriched event payload", async () => {
+		const runner = setupRunner();
+		const received: unknown[] = [];
+		const dispose = runner.registerHostHandler("tool_approval_requested", event => {
+			received.push(event);
+		});
+		try {
+			await runner.emit({
+				type: "tool_approval_requested",
+				sessionId: "test-session",
+				toolCallId: TOOL_CALL_ID,
+				toolName: "mock_exec",
+				tier: "exec",
+				policy: "prompt",
+				source: "tool",
+				approvalMode: "yolo",
+				details: ["line"],
+			});
+			expect(received).toEqual([
+				{
+					type: "tool_approval_requested",
+					sessionId: "test-session",
+					toolCallId: TOOL_CALL_ID,
+					toolName: "mock_exec",
+					tier: "exec",
+					policy: "prompt",
+					source: "tool",
+					approvalMode: "yolo",
+					details: ["line"],
+				},
+			]);
+		} finally {
+			dispose();
+		}
+	});
+
+	it("does not dispatch after the handler is disposed", async () => {
+		const runner = setupRunner();
+		const received: unknown[] = [];
+		const dispose = runner.registerHostHandler("tool_approval_requested", event => {
+			received.push(event);
+		});
+		dispose();
+		await runner.emit({
+			type: "tool_approval_requested",
+			sessionId: "test-session",
+			toolCallId: TOOL_CALL_ID,
+			toolName: "mock_exec",
+			tier: "exec",
+			policy: "prompt",
+			source: "tool",
+			approvalMode: "yolo",
+		});
+		expect(received).toHaveLength(0);
+	});
+});

--- a/packages/coding-agent/test/rpc-generate-title.test.ts
+++ b/packages/coding-agent/test/rpc-generate-title.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi } from "bun:test";
+import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
+import { handleRpcGenerateTitle, type RpcGenerateTitleSession } from "../src/modes/rpc/rpc-mode";
+
+function userMessage(text: string, timestamp = Date.now()): AgentMessage {
+	return { role: "user", content: text, timestamp };
+}
+
+function sessionWith(
+	messages: AgentMessage[],
+	generateTitle: RpcGenerateTitleSession["generateTitle"] = async firstMessage =>
+		firstMessage.trim() ? "Generated Title" : null,
+): RpcGenerateTitleSession {
+	return { messages, generateTitle };
+}
+
+describe("RPC generate_title command", () => {
+	it("responds with a title generated from the first user message", async () => {
+		const generateTitle = vi.fn(async () => "Deploy fix");
+		const session = sessionWith(
+			[
+				userMessage("Deploy the fix"),
+				{
+					role: "assistant",
+					content: [{ type: "text", text: "Done" }],
+					timestamp: 1,
+					api: "anthropic-messages",
+					provider: "anthropic",
+					model: "test",
+					usage: {
+						input: 1,
+						output: 1,
+						cacheRead: 0,
+						cacheWrite: 0,
+						totalTokens: 2,
+						cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+					},
+					stopReason: "stop",
+				},
+			],
+			generateTitle,
+		);
+
+		const response = await handleRpcGenerateTitle("t-1", session, undefined);
+
+		expect(response).toEqual({
+			id: "t-1",
+			type: "response",
+			command: "generate_title",
+			success: true,
+			data: { title: "Deploy fix" },
+		});
+		expect(generateTitle).toHaveBeenCalledWith("Deploy the fix", undefined);
+	});
+
+	it("forwards custom instructions as the title prompt override", async () => {
+		const generateTitle = vi.fn(async () => "Ops ticket");
+		const session = sessionWith([userMessage("Deploy the fix")], generateTitle);
+
+		await handleRpcGenerateTitle("t-2", session, "Name it like an ops ticket");
+
+		expect(generateTitle).toHaveBeenCalledWith("Deploy the fix", "Name it like an ops ticket");
+	});
+
+	it("responds title null without calling the generator when there is no user message yet", async () => {
+		const generateTitle = vi.fn();
+		const session = sessionWith([], generateTitle);
+
+		const response = await handleRpcGenerateTitle("t-3", session, undefined);
+
+		expect(response).toEqual({
+			id: "t-3",
+			type: "response",
+			command: "generate_title",
+			success: true,
+			data: { title: null },
+		});
+		expect(generateTitle).not.toHaveBeenCalled();
+	});
+
+	it("skips empty user messages when locating the title anchor", async () => {
+		const generateTitle = vi.fn(async () => "Deploy fix");
+		const session = sessionWith([userMessage("   "), userMessage("Deploy the fix")], generateTitle);
+
+		await handleRpcGenerateTitle("t-4", session, undefined);
+
+		expect(generateTitle).toHaveBeenCalledWith("Deploy the fix", undefined);
+	});
+
+	it("propagates generator failure as a failed response", async () => {
+		const session = sessionWith([userMessage("Deploy the fix")], async () => {
+			throw new Error("title model unavailable");
+		});
+
+		const response = await handleRpcGenerateTitle("t-5", session, undefined);
+
+		expect(response).toEqual({
+			id: "t-5",
+			type: "response",
+			command: "generate_title",
+			success: false,
+			error: "title model unavailable",
+		});
+	});
+});

--- a/packages/coding-agent/test/rpc-messages.test.ts
+++ b/packages/coding-agent/test/rpc-messages.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, it } from "bun:test";
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
 import { encodeRpcFrame, MAX_RPC_FRAME_BYTES } from "../src/modes/rpc/rpc-frame";
-import { pageRpcMessages, type RpcMessageSnapshot } from "../src/modes/rpc/rpc-messages";
+import {
+	pageRpcMessages,
+	RPC_MESSAGES_PAGE_STALE_ERROR,
+	type RpcMessagePageSessionState,
+	type RpcMessageSnapshot,
+	resolveRpcMessagePageSource,
+} from "../src/modes/rpc/rpc-messages";
 
 function message(index: number, bytes = 32 * 1024): AgentMessage {
 	return { role: "user", content: `${index}:${"x".repeat(bytes)}`, timestamp: index };
@@ -60,5 +66,85 @@ describe("RPC message pagination", () => {
 
 		expect(first.messages).toEqual([messages[0]]);
 		expect(first.nextCursor).toBeDefined();
+	});
+});
+
+describe("RPC message pagination during streaming", () => {
+	function liveSession(
+		initialCount: number,
+		streaming = true,
+		leafId = "leaf-live",
+	): RpcMessagePageSessionState & {
+		messages: AgentMessage[];
+		append(): void;
+	} {
+		const messages = Array.from({ length: initialCount }, (_, index) => message(index, 1024));
+		return {
+			isStreaming: streaming,
+			sessionId: "session-live",
+			messages,
+			getLeafId: () => leafId,
+			append() {
+				messages.push(message(messages.length, 1024));
+			},
+		};
+	}
+
+	it("pages one frozen snapshot while streaming without stale cursors within the epoch", () => {
+		const live = liveSession(10);
+		const source = resolveRpcMessagePageSource(undefined, live);
+		const page1 = pageRpcMessages(source.messages, source.snapshot, { limit: 5 });
+		expect(page1.messages).toHaveLength(5);
+		expect(page1.nextCursor).toBeDefined();
+
+		// The live array keeps growing, but the walk stays bound to the frozen length.
+		live.append();
+		live.append();
+		live.append();
+		// Re-resolving inside the same streaming epoch must reuse the same frozen source.
+		const reused = resolveRpcMessagePageSource(source, live);
+		expect(reused).toBe(source);
+
+		let cursor: string | undefined = page1.nextCursor;
+		const pages: AgentMessage[][] = [page1.messages];
+		do {
+			const page = pageRpcMessages(reused.messages, reused.snapshot, { cursor, limit: 5 });
+			pages.push(page.messages);
+			cursor = page.nextCursor;
+		} while (cursor);
+
+		expect(pages.flat()).toHaveLength(10);
+		expect(pages.flat()).toEqual(live.messages.slice(0, 10));
+		expect(reused.snapshot.messageCount).toBe(10);
+	});
+
+	it("re-freezes once the session settles, so a cursor that outlived the epoch goes stale", () => {
+		const live = liveSession(10, true);
+		let source = resolveRpcMessagePageSource(undefined, live);
+		const page1 = pageRpcMessages(source.messages, source.snapshot, { limit: 5 });
+
+		// The turn completes and more messages arrive before the client pages on.
+		live.append();
+		live.isStreaming = false;
+		source = resolveRpcMessagePageSource(source, live);
+
+		expect(() => pageRpcMessages(source.messages, source.snapshot, { cursor: page1.nextCursor, limit: 5 })).toThrow(
+			RPC_MESSAGES_PAGE_STALE_ERROR,
+		);
+	});
+
+	it("re-freezes when the session identity changes even mid-stream", () => {
+		const live = liveSession(5, true, "leaf-a");
+		const source = resolveRpcMessagePageSource(undefined, live);
+		const page1 = pageRpcMessages(source.messages, source.snapshot, { limit: 5 });
+		expect(page1.nextCursor).toBeUndefined();
+		expect(page1.totalMessages).toBe(5);
+
+		// Branch/switch lands on a different session while still streaming.
+		live.sessionId = "session-other";
+		const rebased = resolveRpcMessagePageSource(source, live);
+		expect(rebased).not.toBe(source);
+		expect(rebased.snapshot.sessionId).toBe("session-other");
+		expect(rebased.snapshot.messageCount).toBe(5);
 	});
 });

--- a/packages/coding-agent/test/rpc-steer-subagent.test.ts
+++ b/packages/coding-agent/test/rpc-steer-subagent.test.ts
@@ -1,0 +1,294 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as os from "node:os";
+import * as path from "node:path";
+import { IrcBus, type IrcMessage } from "@oh-my-pi/pi-coding-agent/irc/bus";
+import { RpcClient, RpcCommandError } from "@oh-my-pi/pi-coding-agent/modes/rpc/rpc-client";
+import { handleRpcSteerSubagent } from "@oh-my-pi/pi-coding-agent/modes/rpc/rpc-mode";
+import {
+	RpcSubagentRegistry,
+	type RpcSubagentSteerResolution,
+} from "@oh-my-pi/pi-coding-agent/modes/rpc/rpc-subagents";
+import { AgentLifecycleManager } from "@oh-my-pi/pi-coding-agent/registry/agent-lifecycle";
+import { AgentRegistry, MAIN_AGENT_ID } from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
+import { type SubagentLifecyclePayload, TASK_SUBAGENT_LIFECYCLE_CHANNEL } from "@oh-my-pi/pi-coding-agent/task/types";
+import { EventBus } from "@oh-my-pi/pi-coding-agent/utils/event-bus";
+import { removeSyncWithRetries, Snowflake } from "@oh-my-pi/pi-utils";
+
+describe("RPC steer_subagent resolution", () => {
+	let registry: RpcSubagentRegistry;
+	let eventBus: EventBus;
+
+	beforeEach(() => {
+		AgentRegistry.resetGlobalForTests();
+		IrcBus.resetGlobalForTests();
+		AgentLifecycleManager.resetGlobalForTests();
+		eventBus = new EventBus();
+		registry = new RpcSubagentRegistry(eventBus, () => {});
+	});
+
+	afterEach(() => {
+		registry.dispose();
+	});
+
+	function startSubagent(id: string, overrides: Partial<SubagentLifecyclePayload> = {}): void {
+		eventBus.emit(TASK_SUBAGENT_LIFECYCLE_CHANNEL, {
+			id,
+			index: 0,
+			agent: "task",
+			agentSource: "bundled",
+			status: "started",
+			sessionFile: `/tmp/${id}.jsonl`,
+			...overrides,
+		} satisfies SubagentLifecyclePayload);
+	}
+
+	function snapshotOf(id: string): RpcSubagentSteerResolution {
+		return registry.resolveForSteer(id);
+	}
+
+	test("resolves a live in-process subagent as running (id joins to the hub recipient)", () => {
+		startSubagent("SubagentA");
+		expect(snapshotOf("SubagentA")).toMatchObject({ kind: "running" });
+	});
+
+	test("resolves an unknown id as unknown", () => {
+		expect(snapshotOf("Nobody")).toEqual({ kind: "unknown" });
+	});
+
+	test("resolves a released subagent as not-running", () => {
+		startSubagent("SubagentA");
+		expect(snapshotOf("SubagentA")).toMatchObject({ kind: "running" });
+
+		eventBus.emit(TASK_SUBAGENT_LIFECYCLE_CHANNEL, {
+			id: "SubagentA",
+			index: 0,
+			agent: "task",
+			agentSource: "bundled",
+			status: "completed",
+			sessionFile: "/tmp/SubagentA.jsonl",
+		} satisfies SubagentLifecyclePayload);
+
+		expect(snapshotOf("SubagentA")).toEqual({ kind: "not-running" });
+	});
+
+	test("retains the isolated marker on progress updates", () => {
+		startSubagent("Iso", { isolated: true });
+		registry.handleProgress({
+			index: 0,
+			agent: "task",
+			agentSource: "bundled",
+			task: "Isolated work",
+			sessionFile: "/tmp/Iso.jsonl",
+			progress: {
+				index: 0,
+				id: "Iso",
+				agent: "task",
+				agentSource: "bundled",
+				status: "running",
+				task: "Isolated work",
+				recentTools: [],
+				recentOutput: [],
+				toolCount: 0,
+				requests: 0,
+				tokens: 0,
+				cost: 0,
+				durationMs: 0,
+			},
+		});
+		const resolution = snapshotOf("Iso");
+		expect(resolution).toMatchObject({ kind: "running" });
+		if (resolution.kind === "running") {
+			expect(resolution.snapshot.isolated).toBe(true);
+		}
+	});
+});
+
+describe("handleRpcSteerSubagent", () => {
+	let registry: RpcSubagentRegistry;
+	let eventBus: EventBus;
+	let received: IrcMessage | undefined;
+
+	beforeEach(() => {
+		AgentRegistry.resetGlobalForTests();
+		IrcBus.resetGlobalForTests();
+		AgentLifecycleManager.resetGlobalForTests();
+		received = undefined;
+		eventBus = new EventBus();
+		registry = new RpcSubagentRegistry(eventBus, () => {});
+	});
+
+	afterEach(() => {
+		registry.dispose();
+	});
+
+	function startSubagent(id: string, overrides: Partial<SubagentLifecyclePayload> = {}): void {
+		eventBus.emit(TASK_SUBAGENT_LIFECYCLE_CHANNEL, {
+			id,
+			index: 0,
+			agent: "task",
+			agentSource: "bundled",
+			status: "started",
+			sessionFile: `/tmp/${id}.jsonl`,
+			...overrides,
+		} satisfies SubagentLifecyclePayload);
+	}
+
+	/** Register an in-process fake agent whose session records IRC delivery. */
+	function registerInProcessAgent(id: string): number {
+		let delivered = 0;
+		AgentRegistry.global().register({
+			id,
+			displayName: id,
+			kind: "sub",
+			session: {
+				deliverIrcMessage: async (msg: IrcMessage) => {
+					received = msg;
+					delivered += 1;
+					return "injected";
+				},
+			} as never,
+			sessionFile: `/tmp/${id}.jsonl`,
+			status: "running",
+		});
+		return delivered;
+	}
+
+	test("delivers a steering DM attributed to the session owner to an in-process subagent", async () => {
+		startSubagent("SubagentA");
+		registerInProcessAgent("SubagentA");
+
+		const result = await handleRpcSteerSubagent(registry, "SubagentA", "Refocus on the direct path");
+
+		expect(result).toEqual({ kind: "delivered", to: "SubagentA", outcome: "injected" });
+		expect(received).toMatchObject({
+			from: MAIN_AGENT_ID,
+			to: "SubagentA",
+			body: "Refocus on the direct path",
+		});
+	});
+
+	test("errors with unknown subagent for an unregistered id", async () => {
+		await expect(handleRpcSteerSubagent(registry, "Nobody", "hi")).resolves.toEqual({
+			kind: "error",
+			message: "Unknown subagent: Nobody",
+		});
+	});
+
+	test("errors with subagent not running for a released id", async () => {
+		startSubagent("SubagentA");
+		eventBus.emit(TASK_SUBAGENT_LIFECYCLE_CHANNEL, {
+			id: "SubagentA",
+			index: 0,
+			agent: "task",
+			agentSource: "bundled",
+			status: "completed",
+			sessionFile: "/tmp/SubagentA.jsonl",
+		} satisfies SubagentLifecyclePayload);
+
+		await expect(handleRpcSteerSubagent(registry, "SubagentA", "hello")).resolves.toEqual({
+			kind: "error",
+			message: "Subagent not running: SubagentA",
+		});
+	});
+
+	test("errors with unsupported_isolated for an isolated worktree subagent without delivering", async () => {
+		startSubagent("Iso", { isolated: true });
+		registerInProcessAgent("Iso");
+
+		const result = await handleRpcSteerSubagent(registry, "Iso", "hello");
+
+		expect(result).toEqual({
+			kind: "error",
+			message: "Subagent Iso runs in an isolation worktree and cannot be steered over the hub yet.",
+			code: "unsupported_isolated",
+		});
+		expect(received).toBeUndefined();
+	});
+
+	test("reports a failed bus delivery as an error", async () => {
+		startSubagent("Ghost");
+		// Lifecycle says running, but no AgentRegistry ref (session already released):
+		// the bus cannot resolve a recipient and reports a failed receipt.
+		const result = await handleRpcSteerSubagent(registry, "Ghost", "hello");
+		expect(result).toMatchObject({ kind: "error", message: expect.stringContaining("Delivery failed") });
+	});
+});
+
+describe("RpcClient steerSubagent wrapper", () => {
+	const tempPaths: string[] = [];
+
+	afterEach(() => {
+		for (const tempPath of tempPaths.splice(0)) {
+			removeSyncWithRetries(tempPath);
+		}
+	});
+
+	function writeFakeCli(responder: string): string {
+		const scriptPath = path.join(os.tmpdir(), `omp-rpc-steer-client-${Snowflake.next()}.js`);
+		tempPaths.push(scriptPath);
+		Bun.write(
+			scriptPath,
+			`
+let buffer = "";
+function write(frame) {
+	process.stdout.write(JSON.stringify(frame) + "\\n");
+}
+write({ type: "ready" });
+process.stdin.on("data", chunk => {
+	buffer += chunk.toString("utf8");
+	let index = buffer.indexOf("\\n");
+	while (index !== -1) {
+		const line = buffer.slice(0, index).trim();
+		buffer = buffer.slice(index + 1);
+		if (line) handle(JSON.parse(line));
+		index = buffer.indexOf("\\n");
+	}
+});
+function handle(frame) {
+	if (frame.type === "steer_subagent") {
+		${responder}
+		return;
+	}
+	if (frame.type === "prompt") {
+		write({ id: frame.id, type: "response", command: "prompt", success: true });
+		write({ type: "agent_end", messages: [] });
+	}
+}
+`,
+		);
+		return scriptPath;
+	}
+
+	test("dispatches the steer_subagent wire frame and surfaces the delivery receipt", async () => {
+		const scriptPath = writeFakeCli(
+			`write({ id: frame.id, type: "response", command: "steer_subagent", success: true, data: { to: frame.subagentId, outcome: "injected" } });`,
+		);
+		using client = new RpcClient({ cliPath: scriptPath });
+		await client.start();
+
+		await expect(client.steerSubagent("OmpWorker", "Hold on")).resolves.toEqual({
+			to: "OmpWorker",
+			outcome: "injected",
+		});
+		await client.promptAndWait("done");
+	});
+
+	test("surfaces the server error code for isolated subagents", async () => {
+		const scriptPath = writeFakeCli(
+			`write({ id: frame.id, type: "response", command: "steer_subagent", success: false, error: "Subagent Iso runs in an isolation worktree", code: "unsupported_isolated" });`,
+		);
+		using client = new RpcClient({ cliPath: scriptPath });
+		await client.start();
+
+		const rejection = await client.steerSubagent("Iso", "hello").then(
+			() => null,
+			(error: unknown) => error,
+		);
+		expect(rejection).toBeInstanceOf(RpcCommandError);
+		if (rejection instanceof RpcCommandError) {
+			expect(rejection.code).toBe("unsupported_isolated");
+			expect(rejection.command).toBe("steer_subagent");
+		}
+		await client.promptAndWait("done");
+	});
+});

--- a/packages/coding-agent/test/tools/approval-rules.test.ts
+++ b/packages/coding-agent/test/tools/approval-rules.test.ts
@@ -1,0 +1,411 @@
+import { describe, expect, it } from "bun:test";
+import type { AgentTool, ToolApproval } from "@oh-my-pi/pi-agent-core";
+import { denyError, requiresApproval, resolveApproval } from "@oh-my-pi/pi-coding-agent/tools/approval";
+import {
+	findApprovalPatternRule,
+	normalizeApprovalPatternRules,
+	normalizeApprovalRules,
+	primaryStringArgForTool,
+} from "@oh-my-pi/pi-coding-agent/tools/approval-rules";
+
+type ApprovalTool = Pick<AgentTool, "name" | "approval" | "formatApprovalDetails">;
+
+function tool(name: string, approval?: ToolApproval): ApprovalTool {
+	return { name, approval };
+}
+
+/** RPC-style rule list as it would come from the settings file. */
+function rules(...entries: unknown[]): unknown {
+	return entries;
+}
+
+describe("tools.approvalRules precedence (rule > per-tool policy > mode)", () => {
+	it("a matching deny rule beats a per-tool allow policy and mode", () => {
+		const subject = tool("bash", { tier: "write", policy: "allow" });
+		const resolved = resolveApproval(
+			subject,
+			{ command: "rm -rf /tmp/junk" },
+			"yolo",
+			{ bash: "allow" },
+			rules({ tool: "bash", match: "rm -rf *", approval: "deny", reason: "destructive" }),
+		);
+		expect(resolved).toMatchObject({
+			policy: "deny",
+			source: "rule",
+			policyKey: "tools.approvalRules[0]",
+			reason: "destructive",
+			override: true,
+		});
+		expect(() =>
+			requiresApproval(
+				subject,
+				{ command: "rm -rf /tmp/junk" },
+				"yolo",
+				{ bash: "allow" },
+				rules({ tool: "bash", match: "rm -rf *", approval: "deny" }),
+			),
+		).toThrow('Tool "bash" is blocked by an approval rule.');
+	});
+
+	it("a matching allow rule beats a tool-sourced deny", () => {
+		const subject = tool("bash", {
+			tier: "exec",
+			override: true,
+			policy: "deny",
+			reason: "Blocked by bash pattern",
+		});
+		const resolved = resolveApproval(
+			subject,
+			{ command: "git status" },
+			"always-ask",
+			{},
+			rules({ tool: "bash", match: "git *", approval: "allow" }),
+		);
+		expect(resolved).toMatchObject({ policy: "allow", source: "rule" });
+	});
+
+	it("a matching prompt rule forces a prompt even in yolo mode", () => {
+		const subject = tool("bash", "read");
+		const resolved = resolveApproval(
+			subject,
+			{ command: "git status" },
+			"yolo",
+			{ bash: "allow" },
+			rules({ tool: "bash", match: "git *", approval: "prompt" }),
+		);
+		expect(resolved).toMatchObject({ policy: "prompt", source: "rule" });
+		expect(
+			requiresApproval(subject, { command: "git status" }, "yolo", {}, rules({ tool: "bash", approval: "prompt" }))
+				.required,
+		).toBe(true);
+	});
+
+	it("a tool-name-only allow rule covers every call of the tool regardless of mode", () => {
+		const subject = tool("bash", "exec");
+		expect(
+			resolveApproval(
+				subject,
+				{ command: "anything" },
+				"always-ask",
+				{},
+				rules({ tool: "bash", approval: "allow" }),
+			),
+		).toMatchObject({ policy: "allow", source: "rule" });
+	});
+
+	it("first matching rule wins over later ones", () => {
+		const subject = tool("bash", "exec");
+		const resolved = resolveApproval(
+			subject,
+			{ command: "git status" },
+			"yolo",
+			{},
+			rules(
+				{ tool: "bash", match: "git *", approval: "allow" },
+				{ tool: "bash", match: "git status", approval: "deny" },
+			),
+		);
+		expect(resolved).toMatchObject({ policy: "allow", policyKey: "tools.approvalRules[0]" });
+	});
+
+	it("does not apply rules for other tools", () => {
+		const subject = tool("global_or_tool", "exec");
+		expect(
+			resolveApproval(subject, {}, "yolo", {}, rules({ tool: "bash", match: "*", approval: "deny" })),
+		).toMatchObject({ policy: "allow", source: "mode" });
+	});
+
+	it("keeps per-tool policy authoritative over mode when no rule matches", () => {
+		const subject = tool("write", "write");
+		expect(
+			resolveApproval(
+				subject,
+				{ path: "a.txt" },
+				"yolo",
+				{ write: "deny" },
+				rules({ tool: "bash", approval: "allow" }),
+			),
+		).toMatchObject({ policy: "deny", source: "user" });
+	});
+
+	it("reports rule-denies distinctly from user-policy denies in denyError", () => {
+		const subject = tool("write", "write");
+		const resolved = resolveApproval(
+			subject,
+			{ path: "node_modules/x" },
+			"yolo",
+			{},
+			rules({ tool: "write", match: "node_modules/*", approval: "deny" }),
+		);
+		const message = (() => {
+			try {
+				throw denyError(resolved, "write");
+			} catch (error) {
+				return (error as Error).message;
+			}
+		})();
+		expect(message).toContain("blocked by an approval rule");
+		expect(message).toContain('"tools.approvalRules"');
+		expect(message).not.toContain("tools.approval.write");
+	});
+});
+
+describe("tools.approvalRules matching per tool kind", () => {
+	const alwaysEnableRule = { tool: "grep", match: "does-not-matter", approval: "allow" } as const;
+
+	it("matches bash rules against the command with shell-aware semantics", () => {
+		const subject = tool("bash", "exec");
+		// deny fires on a matching segment of a compound line.
+		expect(
+			resolveApproval(
+				subject,
+				{ command: "cd /tmp && rm -rf /var/x" },
+				"yolo",
+				{},
+				rules({ tool: "bash", match: "rm -rf /var/*", approval: "deny" }),
+			).policy,
+		).toBe("deny");
+		// allow must vouch for the entire command, never ride a compound line:
+		// the rule must NOT fire here, so the resolution falls through to mode.
+		expect(
+			resolveApproval(
+				subject,
+				{ command: "git status; rm file.txt" },
+				"yolo",
+				{},
+				rules({ tool: "bash", match: "git *", approval: "allow" }),
+			),
+		).toMatchObject({ policy: "allow", source: "mode" });
+		// A matching segment does not fire a deny rule.
+		expect(
+			resolveApproval(
+				subject,
+				{ command: "cd /tmp && ls -la" },
+				"yolo",
+				{},
+				rules({ tool: "bash", match: "rm -rf /var/*", approval: "deny" }),
+			).policy,
+		).toBe("allow");
+	});
+
+	it("matches write rules against the path argument", () => {
+		const subject = tool("write", "write");
+		expect(
+			resolveApproval(
+				subject,
+				{ path: "src/generated.ts", content: "x" },
+				"always-ask",
+				{},
+				rules({ tool: "write", match: "src/generated.*", approval: "allow" }),
+			).policy,
+		).toBe("allow");
+		expect(
+			resolveApproval(
+				subject,
+				{ path: "lib/other.ts", content: "x" },
+				"always-ask",
+				{},
+				rules({ tool: "write", match: "src/*", approval: "deny" }),
+			).policy,
+		).toBe("prompt");
+	});
+
+	it("matches write rules against the file_path fallback", () => {
+		const subject = tool("write", "write");
+		expect(
+			resolveApproval(
+				subject,
+				{ file_path: "docs/api.md", content: "x" },
+				"always-ask",
+				{},
+				rules({ tool: "write", match: "docs/*", approval: "allow" }),
+			).policy,
+		).toBe("allow");
+	});
+
+	it("matches edit rules against the path argument", () => {
+		const subject = tool("edit", "write");
+		expect(
+			resolveApproval(
+				subject,
+				{ path: "src/App.tsx" },
+				"always-ask",
+				{},
+				rules({ tool: "edit", match: "src/App.*", approval: "allow" }),
+			).policy,
+		).toBe("allow");
+	});
+
+	it("ignores the match field for tools without a primary string argument", () => {
+		const subject = tool("grep", "read");
+		// `grep` has no primary-arg mapping, so anything — including the carried
+		// `match` — is ignored and the tool name match alone applies.
+		expect(resolveApproval(subject, {}, "always-ask", {}, rules(alwaysEnableRule)).policy).toBe("allow");
+	});
+
+	it("skips a match-scoped rule when a primary-arg tool call carries no primary string", () => {
+		const subject = tool("edit", "exec");
+		// Sloppy edit input-only call: the match-scoped rule cannot be evaluated,
+		// so mode governs.
+		expect(
+			resolveApproval(
+				subject,
+				{ input: "§src/a.ts\n§\nold\n»\nnew" },
+				"write",
+				{},
+				rules({ tool: "edit", match: "src/generated.*", approval: "allow" }),
+			).policy,
+		).toBe("prompt");
+	});
+
+	it("parses the primary string per the documented mapping", () => {
+		expect(primaryStringArgForTool("bash", { command: "echo hi" })).toBe("echo hi");
+		expect(primaryStringArgForTool("write", { path: "a.ts", content: "x" })).toBe("a.ts");
+		expect(primaryStringArgForTool("write", { file_path: "b.ts", content: "x" })).toBe("b.ts");
+		expect(primaryStringArgForTool("edit", { file_path: "c.ts" })).toBe("c.ts");
+		expect(primaryStringArgForTool("grep", { path: "d.ts" })).toBeUndefined();
+		expect(primaryStringArgForTool("bash", {})).toBeUndefined();
+	});
+});
+
+describe("approval rule normalization", () => {
+	it("drops malformed rules while keeping ordering of valid ones", () => {
+		const parsed = normalizeApprovalRules(
+			rules(
+				{ tool: "bash", approval: "allow" },
+				{ tool: "", approval: "deny" },
+				{ tool: "write", approval: "maybe" },
+				{ tool: "edit" },
+				"not-an-object",
+				{ tool: "grep", match: "src/*", approval: "prompt", reason: "  review me  " },
+				{ tool: "read", match: "", approval: "deny" },
+			),
+		);
+		expect(parsed).toEqual([
+			{ tool: "bash", approval: "allow" },
+			{ tool: "grep", match: "src/*", approval: "prompt", reason: "review me" },
+			{ tool: "read", approval: "deny" },
+		]);
+	});
+
+	it("normalizes whitespace inside match globs", () => {
+		const parsed = normalizeApprovalRules(rules({ tool: "bash", match: "  rm   -rf   *  ", approval: "allow" }));
+		expect(parsed[0]?.match).toBe("rm -rf *");
+	});
+
+	it("treats non-array approvalRules config as empty", () => {
+		expect(normalizeApprovalRules(undefined)).toEqual([]);
+		expect(normalizeApprovalRules({ tool: "bash", approval: "deny" })).toEqual([]);
+	});
+
+	it("keeps bash.patterns normalization semantics in the shared module", () => {
+		const parsed = normalizeApprovalPatternRules([
+			{ match: "git *", approval: "allow" },
+			{ match: "", approval: "deny" },
+			{ match: "rm -rf *", approval: "maybe" },
+		]);
+		expect(parsed).toEqual([{ match: "git *", approval: "allow" }]);
+	});
+
+	it("finds the first matching bash-style pattern with shell-aware semantics", () => {
+		const parsed = normalizeApprovalPatternRules([
+			{ match: "rm -rf /*", approval: "deny" },
+			{ match: "git *", approval: "allow" },
+		]);
+		expect(findApprovalPatternRule("cd /tmp && rm -rf /var/x", parsed, true)).toEqual({
+			match: "rm -rf /*",
+			approval: "deny",
+		});
+		expect(findApprovalPatternRule("git status", parsed, true)).toEqual({ match: "git *", approval: "allow" });
+		expect(findApprovalPatternRule("echo hi", parsed, true)).toBeUndefined();
+	});
+});
+
+// Regression parity with the pre-extraction bash.patterns behavior (the vectors
+// from test/tools/approval.test.ts, rerun against the shared matcher that now
+// backs BashTool.approval). These run without the native addon, so they double
+// as natives-free coverage for the lifted shell-aware matching.
+describe("bash.patterns matcher parity (lifted from bash.ts)", () => {
+	const allowOnly = normalizeApprovalPatternRules([
+		{ match: "git *", approval: "allow" },
+		{ match: "rm -rf *", approval: "deny" },
+		{ match: "*", approval: "prompt" },
+	]);
+
+	it("classifies configured patterns exactly as before", () => {
+		for (const command of ["git diff packages/coding-agent/src/tools/bash.ts", "git status", "git log --oneline"]) {
+			expect(findApprovalPatternRule(command, allowOnly, true)).toEqual({ match: "git *", approval: "allow" });
+		}
+		expect(findApprovalPatternRule("rm -rf build", allowOnly, true)).toEqual({
+			match: "rm -rf *",
+			approval: "deny",
+		});
+		expect(
+			findApprovalPatternRule("git diff packages/coding-agent/src/tools/bash.ts && rm file.txt", allowOnly, true),
+		).toEqual({
+			match: "*",
+			approval: "prompt",
+		});
+		expect(findApprovalPatternRule("echo hello", allowOnly, true)).toEqual({ match: "*", approval: "prompt" });
+	});
+
+	it("applies the first matching pattern", () => {
+		const firstWins = normalizeApprovalPatternRules([
+			{ match: "*", approval: "allow" },
+			{ match: "git *", approval: "deny" },
+		]);
+		expect(findApprovalPatternRule("git status", firstWins, true)).toEqual({ match: "*", approval: "allow" });
+	});
+
+	it("denies a dangerous command buried in a compound line", () => {
+		const denied = normalizeApprovalPatternRules([{ match: "rm -rf /*", approval: "deny" }]);
+		for (const command of [
+			"rm -rf /tmp/scratch-a",
+			"cd /tmp && rm -rf /tmp/scratch-b && echo done",
+			"echo start; rm -rf /var/x",
+			"cat f | rm -rf /var/x",
+			"sleep 1 & rm -rf /tmp/scratch-b",
+			"(rm -rf /tmp/scratch-b)",
+			'cd /tmp && "rm" -rf /tmp/scratch-b',
+		]) {
+			expect(findApprovalPatternRule(command, denied, true)).toEqual({ match: "rm -rf /*", approval: "deny" });
+		}
+		// Segments that do not match the glob must not be denied by it.
+		expect(findApprovalPatternRule("cd /tmp && rm -rf relative-dir", denied, true)).toBeUndefined();
+		expect(findApprovalPatternRule("cd /tmp && ls -la /nope", denied, true)).toBeUndefined();
+	});
+
+	it("never auto-approves a command that only prefixes an allow pattern", () => {
+		const gitAllow = normalizeApprovalPatternRules([{ match: "git *", approval: "allow" }]);
+		for (const command of [
+			"git status; rm file.txt",
+			"git status && rm file.txt",
+			"git status | sh",
+			"git status\nrm file.txt",
+			"git status\r\nrm file.txt",
+			"git $(rm file.txt)",
+			"git `rm file.txt` status",
+			"git status > /etc/passwd",
+			"git -c alias.x='!touch /tmp/pwn; printf ok' x",
+			"git status < seed",
+			"FOO=1 git status",
+			"/usr/bin/git status",
+			'"git" status',
+			"gitx status",
+			"git",
+			"",
+		]) {
+			expect(findApprovalPatternRule(command, gitAllow, true)).toBeUndefined();
+		}
+		for (const command of ["git status", "git status --short", "git  status", "git\tstatus"]) {
+			expect(findApprovalPatternRule(command, gitAllow, true)).toEqual({ match: "git *", approval: "allow" });
+		}
+	});
+
+	it("allows literal shell metacharacters in quoted arguments", () => {
+		const cargoAllow = normalizeApprovalPatternRules([{ match: "cargo *", approval: "allow" }]);
+		const command =
+			"cargo bench --manifest-path layers/layer3/Cargo.toml --bench standardized_criterion -- --full '^layer3/write/file-wal/batch-(10|1000|10000)$'";
+		expect(findApprovalPatternRule(command, cargoAllow, true)).toEqual({ match: "cargo *", approval: "allow" });
+	});
+});


### PR DESCRIPTION
Six additive RPC-surface improvements for headless/remote hosts (motivated by building a native iOS remote over `--mode rpc`). Three independent commits, each typechecks and tests green on its own — reviewable or cherry-pickable separately.

## Commit 1 — advisor_note events, streaming message pages, title generation

- **`advisor_note` AgentSessionEvent** `{ advisor?, severity?, note, deliveredAs: "card"|"steer" }` emitted at both advisor delivery sites. Today the structured `AdvisorNote` dies at the transcript boundary and remote hosts must regex `<advisory>` blocks out of injected messages.
- **`get_messages_page` while streaming**: pages from a per-epoch frozen snapshot (`[...session.messages]`, cursor bound to frozen length) instead of `session_busy`. Clients reconnecting mid-turn can rebuild history exactly when they need it; `isCompacting` still returns `session_busy`; `stale_cursor` semantics preserved.
- **Titles in RPC mode**: `PI_RPC_TITLES=1` opts prompt-driven auto-generation back in, and a `generate_title` command wraps the existing public `generateTitle`. RPC sessions currently stay "Untitled" forever because nothing calls `maybeStartTitleGeneration`.

## Commit 2 — structured tool-approval frames and generic approval rules

- **`tool_approval_request` / `tool_approval_resolved` frames**: the gate already computes `ResolvedApproval { policy, tier, source, reason }` before flattening everything into a text `select` — this serializes it (plus untruncated detail lines) to the wire, emitted deterministically before the paired select. The select remains authoritative for the verdict; `toolCallId` is the join key. Remote clients currently reverse-parse `"Allow tool: …"` titles and guess risk tiers from heuristics.
- **`tools.approvalRules`**: ordered generic pattern rules (first match wins) evaluated ahead of per-tool policy, with `add/list/remove_approval_rule` commands. The matcher is lifted out of `bash.ts` into a shared module — `bash.patterns` behavior is byte-identical (bash suites all pass). This gives every surface (TUI, ACP, RPC hosts) one rule store instead of each client reinventing allow-always.

## Commit 3 — steer_subagent via hub bus

- **`steer_subagent { subagentId, message }`**: the RPC subagent registry id is already the hub/IRC agent id (verified join chain, documented in code), so delivery reuses `IrcBus.global().send` — inheriting wake/revive/inject-aside semantics. In-process subagents only; isolated/worktree runs answer with code `unsupported_isolated` (lifecycle frames now carry an additive `isolated` flag to detect this).

## Compatibility

Additions only: no existing frame, command, or default changes. Docs (`docs/rpc.md`), TS `RpcClient` wrappers, and changelog updated; Python client untouched. New tests: 42 across the six features, plus regression runs on `rpc-*` (118) and bash approval suites (244).
