### PR TITLE
fix(tools): translate windows drive paths to /mnt mounts on WSL

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Fixed an issue where custom model overrides were lost during configuration updates
 - Fixed "Please use nerdfont" notification incorrectly persisting after theme configuration
 - Fixed sampling parameter errors for newer Anthropic models (Opus 4.7+, Sonnet 5+)
+- Fixed pasting a Windows drive path (e.g. `C:\Users\me\pic.png`) into omp under WSL failing with "Image not found"; drive paths now resolve to their `/mnt/<drive>` mount for image paste and all file reads ([#10426](https://github.com/can1357/oh-my-pi/issues/10426))
 
 ## [18.0.11] - 2026-08-29
 

--- a/packages/coding-agent/src/discovery/agents.ts
+++ b/packages/coding-agent/src/discovery/agents.ts
@@ -6,6 +6,7 @@
  * Project-level discovery walks up from cwd to repoRoot.
  */
 import * as path from "node:path";
+import { isWsl } from "@oh-my-pi/pi-utils";
 import { registerProvider } from "../capability";
 import { type ContextFile, contextFileCapability } from "../capability/context-file";
 import { readFile } from "../capability/fs";
@@ -36,10 +37,6 @@ interface UserPathCandidateOptions {
 }
 
 const WINDOWS_DRIVE_PROFILE_PATTERN = /^([A-Za-z]):[\\/](.*)$/;
-
-function isWsl(platform: NodeJS.Platform, env: NodeJS.ProcessEnv): boolean {
-	return platform === "linux" && Boolean(env.WSL_DISTRO_NAME || env.WSL_INTEROP);
-}
 
 function convertWindowsPathToDefaultWslMount(windowsPath: string): string | undefined {
 	const trimmed = windowsPath.trim();

--- a/packages/coding-agent/src/discovery/agents.ts
+++ b/packages/coding-agent/src/discovery/agents.ts
@@ -6,7 +6,7 @@
  * Project-level discovery walks up from cwd to repoRoot.
  */
 import * as path from "node:path";
-import { isWsl } from "@oh-my-pi/pi-utils";
+import { isWsl, windowsPathToWslMount } from "@oh-my-pi/pi-utils";
 import { registerProvider } from "../capability";
 import { type ContextFile, contextFileCapability } from "../capability/context-file";
 import { readFile } from "../capability/fs";
@@ -34,21 +34,6 @@ interface UserPathCandidateOptions {
 	env?: NodeJS.ProcessEnv;
 	windowsUserProfile?: () => string | undefined;
 	wslPath?: (windowsPath: string) => string | undefined;
-}
-
-const WINDOWS_DRIVE_PROFILE_PATTERN = /^([A-Za-z]):[\\/](.*)$/;
-
-function convertWindowsPathToDefaultWslMount(windowsPath: string): string | undefined {
-	const trimmed = windowsPath.trim();
-	if (trimmed.length === 0) return undefined;
-	// The result is always a WSL (POSIX) path, so build it with posix
-	// semantics regardless of the host platform.
-	if (path.posix.isAbsolute(trimmed)) return path.posix.normalize(trimmed);
-	const match = WINDOWS_DRIVE_PROFILE_PATTERN.exec(trimmed);
-	if (!match) return undefined;
-	const [, drive, rest] = match;
-	const segments = rest.replace(/\\/g, "/").split("/").filter(Boolean);
-	return path.posix.join("/mnt", drive.toLowerCase(), ...segments);
 }
 
 /**
@@ -102,7 +87,10 @@ export function getWslWindowsHomeCandidate(options: UserPathCandidateOptions = {
 	if (!isWsl(platform, env)) return undefined;
 	const userProfile = env.USERPROFILE ?? (options.windowsUserProfile ?? resolveWindowsUserProfile)();
 	if (!userProfile) return undefined;
-	return (options.wslPath ?? resolveWithWslPath)(userProfile) ?? convertWindowsPathToDefaultWslMount(userProfile);
+	const interopPath = (options.wslPath ?? resolveWithWslPath)(userProfile);
+	if (interopPath !== undefined) return interopPath;
+	const trimmed = userProfile.trim();
+	return path.posix.isAbsolute(trimmed) ? path.posix.normalize(trimmed) : windowsPathToWslMount(trimmed);
 }
 
 /**

--- a/packages/coding-agent/src/tools/path-utils.ts
+++ b/packages/coding-agent/src/tools/path-utils.ts
@@ -3,7 +3,14 @@ import * as os from "node:os";
 import * as path from "node:path";
 import * as url from "node:url";
 import { glob } from "@oh-my-pi/pi-natives";
-import { hasFsCode, isEnoent, isEnotdir, isWsl, stripWindowsExtendedLengthPathPrefix } from "@oh-my-pi/pi-utils";
+import {
+	hasFsCode,
+	isEnoent,
+	isEnotdir,
+	isWsl,
+	stripWindowsExtendedLengthPathPrefix,
+	windowsPathToWslMount,
+} from "@oh-my-pi/pi-utils";
 import type { Skill } from "../extensibility/skills";
 import { InternalUrlRouter, type LocalProtocolOptions } from "../internal-urls";
 import { ToolAbortError, ToolError } from "./tool-errors";
@@ -197,18 +204,6 @@ function windowsDriveAliasPath(filePath: string): string | undefined {
 	return tail ? `${drive}:\\${tail}` : `${drive}:\\`;
 }
 
-/** `C:\Users\me` / `C:/Users/me` → `/mnt/c/Users/me` (the default WSL drive mount). */
-const WINDOWS_DRIVE_PATH_RE = /^([A-Za-z]):[\\/](.*)$/;
-
-function wslWindowsDrivePath(filePath: string): string | undefined {
-	const normalized = path.win32.normalize(filePath);
-	const match = WINDOWS_DRIVE_PATH_RE.exec(normalized);
-	if (!match) return undefined;
-	const [, drive, rest] = match;
-	const segments = rest.split("\\").filter(Boolean);
-	return path.posix.join("/mnt", drive!.toLowerCase(), ...segments);
-}
-
 /**
  * Reconcile a drive-alias path with the current host so filesystem reads land
  * on the same bytes the user meant, in either translation direction:
@@ -225,7 +220,7 @@ export function normalizeWindowsDriveAliasPath(
 	env: NodeJS.ProcessEnv = process.env,
 ): string {
 	if (platform === "win32") return windowsDriveAliasPath(filePath) ?? filePath;
-	if (isWsl(platform, env)) return wslWindowsDrivePath(filePath) ?? filePath;
+	if (isWsl(platform, env)) return windowsPathToWslMount(filePath) ?? filePath;
 	return filePath;
 }
 

--- a/packages/coding-agent/src/tools/path-utils.ts
+++ b/packages/coding-agent/src/tools/path-utils.ts
@@ -3,7 +3,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import * as url from "node:url";
 import { glob } from "@oh-my-pi/pi-natives";
-import { hasFsCode, isEnoent, isEnotdir, stripWindowsExtendedLengthPathPrefix } from "@oh-my-pi/pi-utils";
+import { hasFsCode, isEnoent, isEnotdir, isWsl, stripWindowsExtendedLengthPathPrefix } from "@oh-my-pi/pi-utils";
 import type { Skill } from "../extensibility/skills";
 import { InternalUrlRouter, type LocalProtocolOptions } from "../internal-urls";
 import { ToolAbortError, ToolError } from "./tool-errors";
@@ -197,9 +197,35 @@ function windowsDriveAliasPath(filePath: string): string | undefined {
 	return tail ? `${drive}:\\${tail}` : `${drive}:\\`;
 }
 
-export function normalizeWindowsDriveAliasPath(filePath: string, platform: NodeJS.Platform = process.platform): string {
-	if (platform !== "win32") return filePath;
-	return windowsDriveAliasPath(filePath) ?? filePath;
+/** `C:\Users\me` / `C:/Users/me` → `/mnt/c/Users/me` (the default WSL drive mount). */
+const WINDOWS_DRIVE_PATH_RE = /^([A-Za-z]):[\\/](.*)$/;
+
+function wslWindowsDrivePath(filePath: string): string | undefined {
+	const match = WINDOWS_DRIVE_PATH_RE.exec(filePath);
+	if (!match) return undefined;
+	const [, drive, rest] = match;
+	const segments = rest.replace(/\\/g, "/").split("/").filter(Boolean);
+	return path.posix.join("/mnt", drive!.toLowerCase(), ...segments);
+}
+
+/**
+ * Reconcile a drive-alias path with the current host so filesystem reads land
+ * on the same bytes the user meant, in either translation direction:
+ *
+ * - On native Windows (`win32`), MSYS/WSL mount roots (`/c/...`, `/mnt/c/...`)
+ *   map to native drive paths (`C:\...`).
+ * - Under WSL, pasted Windows drive paths (`C:\...`, `C:/...`) map to their
+ *   `/mnt/<drive>/...` mount so the file resolves on the Linux side instead of
+ *   being `path.resolve`d into a nonexistent path under cwd (issue #10426).
+ */
+export function normalizeWindowsDriveAliasPath(
+	filePath: string,
+	platform: NodeJS.Platform = process.platform,
+	env: NodeJS.ProcessEnv = process.env,
+): string {
+	if (platform === "win32") return windowsDriveAliasPath(filePath) ?? filePath;
+	if (isWsl(platform, env)) return wslWindowsDrivePath(filePath) ?? filePath;
+	return filePath;
 }
 
 /**

--- a/packages/coding-agent/src/tools/path-utils.ts
+++ b/packages/coding-agent/src/tools/path-utils.ts
@@ -201,10 +201,11 @@ function windowsDriveAliasPath(filePath: string): string | undefined {
 const WINDOWS_DRIVE_PATH_RE = /^([A-Za-z]):[\\/](.*)$/;
 
 function wslWindowsDrivePath(filePath: string): string | undefined {
-	const match = WINDOWS_DRIVE_PATH_RE.exec(filePath);
+	const normalized = path.win32.normalize(filePath);
+	const match = WINDOWS_DRIVE_PATH_RE.exec(normalized);
 	if (!match) return undefined;
 	const [, drive, rest] = match;
-	const segments = rest.replace(/\\/g, "/").split("/").filter(Boolean);
+	const segments = rest.split("\\").filter(Boolean);
 	return path.posix.join("/mnt", drive!.toLowerCase(), ...segments);
 }
 

--- a/packages/coding-agent/src/utils/clipboard.ts
+++ b/packages/coding-agent/src/utils/clipboard.ts
@@ -3,6 +3,7 @@ import {
 	copyToClipboard as nativeCopyToClipboard,
 	readImageFromClipboard as nativeReadImageFromClipboard,
 } from "@oh-my-pi/pi-natives/clipboard";
+import { isWsl } from "@oh-my-pi/pi-utils";
 import * as logger from "@oh-my-pi/pi-utils/logger";
 import { SUPPORTED_IMAGE_MIME_TYPES } from "@oh-my-pi/pi-utils/mime";
 import MAC_FILE_URL_SCRIPT from "./mac-file-urls.applescript" with { type: "text" };
@@ -60,10 +61,6 @@ async function spawnCapture(
 
 function hasDisplay(): boolean {
 	return process.platform !== "linux" || Boolean(process.env.DISPLAY || process.env.WAYLAND_DISPLAY);
-}
-
-function isWsl(): boolean {
-	return process.platform === "linux" && Boolean(process.env.WSL_DISTRO_NAME || process.env.WSL_INTEROP);
 }
 
 /**

--- a/packages/coding-agent/src/utils/open.ts
+++ b/packages/coding-agent/src/utils/open.ts
@@ -1,16 +1,12 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as url from "node:url";
-import { $which, logger } from "@oh-my-pi/pi-utils";
+import { $which, isWsl, logger } from "@oh-my-pi/pi-utils";
 
 const URL_SCHEME_PATTERN = /^[a-zA-Z][a-zA-Z\d+.-]*:/;
 
 function getExistingWslLocalPath(urlOrPath: string): string | undefined {
-	if (
-		process.platform !== "linux" ||
-		!(process.env.WSL_DISTRO_NAME || process.env.WSL_INTEROP) ||
-		!$which("wslview")
-	) {
+	if (!isWsl() || !$which("wslview")) {
 		return undefined;
 	}
 

--- a/packages/coding-agent/test/tools/windows-drive-alias.test.ts
+++ b/packages/coding-agent/test/tools/windows-drive-alias.test.ts
@@ -31,6 +31,11 @@ describe("Windows drive alias paths", () => {
 		expect(normalizeWindowsDriveAliasPath("C:\\", "linux", wsl)).toBe("/mnt/c");
 	});
 
+	it("clamps parent traversal at the Windows drive root", () => {
+		const wsl = { WSL_INTEROP: "/run/WSL/1_interop" } as NodeJS.ProcessEnv;
+		expect(normalizeWindowsDriveAliasPath("C:\\..\\Windows\\x", "linux", wsl)).toBe("/mnt/c/Windows/x");
+	});
+
 	it("leaves paths untranslated on plain linux without WSL interop vars", () => {
 		const plain = {} as NodeJS.ProcessEnv;
 		expect(normalizeWindowsDriveAliasPath("C:\\Users\\me\\pic.png", "linux", plain)).toBe("C:\\Users\\me\\pic.png");

--- a/packages/coding-agent/test/tools/windows-drive-alias.test.ts
+++ b/packages/coding-agent/test/tools/windows-drive-alias.test.ts
@@ -21,4 +21,21 @@ describe("Windows drive alias paths", () => {
 		expect(normalizeWindowsDriveAliasPath("\\d\\logs", "win32")).toBe("\\d\\logs");
 		expect(normalizeWindowsDriveAliasPath("\\mnt\\d\\logs", "win32")).toBe("\\mnt\\d\\logs");
 	});
+
+	it("maps Windows drive paths to their /mnt mount under WSL (#10426)", () => {
+		const wsl = { WSL_DISTRO_NAME: "Ubuntu" } as NodeJS.ProcessEnv;
+		expect(normalizeWindowsDriveAliasPath("C:\\Users\\MyUser\\Pictures\\MyPic.jpg", "linux", wsl)).toBe(
+			"/mnt/c/Users/MyUser/Pictures/MyPic.jpg",
+		);
+		expect(normalizeWindowsDriveAliasPath("D:/data/report.png", "linux", wsl)).toBe("/mnt/d/data/report.png");
+		expect(normalizeWindowsDriveAliasPath("C:\\", "linux", wsl)).toBe("/mnt/c");
+	});
+
+	it("leaves paths untranslated on plain linux without WSL interop vars", () => {
+		const plain = {} as NodeJS.ProcessEnv;
+		expect(normalizeWindowsDriveAliasPath("C:\\Users\\me\\pic.png", "linux", plain)).toBe("C:\\Users\\me\\pic.png");
+		expect(
+			normalizeWindowsDriveAliasPath("/home/me/pic.png", "linux", { WSL_INTEROP: "/run/x" } as NodeJS.ProcessEnv),
+		).toBe("/home/me/pic.png");
+	});
 });

--- a/packages/coding-agent/test/tools/windows-drive-alias.test.ts
+++ b/packages/coding-agent/test/tools/windows-drive-alias.test.ts
@@ -31,11 +31,6 @@ describe("Windows drive alias paths", () => {
 		expect(normalizeWindowsDriveAliasPath("C:\\", "linux", wsl)).toBe("/mnt/c");
 	});
 
-	it("clamps parent traversal at the Windows drive root", () => {
-		const wsl = { WSL_INTEROP: "/run/WSL/1_interop" } as NodeJS.ProcessEnv;
-		expect(normalizeWindowsDriveAliasPath("C:\\..\\Windows\\x", "linux", wsl)).toBe("/mnt/c/Windows/x");
-	});
-
 	it("leaves paths untranslated on plain linux without WSL interop vars", () => {
 		const plain = {} as NodeJS.ProcessEnv;
 		expect(normalizeWindowsDriveAliasPath("C:\\Users\\me\\pic.png", "linux", plain)).toBe("C:\\Users\\me\\pic.png");

--- a/packages/tui/src/terminal-capabilities.ts
+++ b/packages/tui/src/terminal-capabilities.ts
@@ -1,5 +1,5 @@
 import { encodeSixel } from "@oh-my-pi/pi-natives";
-import { $env, isBunTestRuntime, isTerminalHeadless } from "@oh-my-pi/pi-utils";
+import { $env, isBunTestRuntime, isTerminalHeadless, isWsl } from "@oh-my-pi/pi-utils";
 import { sendDesktopNotification, shouldDeliverDesktopNotification } from "./desktop-notify";
 import {
 	detectKittyUnicodePlaceholdersSupport,
@@ -469,8 +469,7 @@ export function resolveWarpImageProtocol(
 	platform: NodeJS.Platform = process.platform,
 	env: NodeJS.ProcessEnv = Bun.env,
 ): ImageProtocol | null {
-	const windowsHost =
-		platform === "win32" || (platform === "linux" && Boolean(env.WSL_DISTRO_NAME || env.WSL_INTEROP));
+	const windowsHost = platform === "win32" || isWsl(platform, env);
 	return windowsHost ? null : ImageProtocol.Kitty;
 }
 

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -5,6 +5,7 @@ import {
 	$env,
 	isBunTestRuntime,
 	isTerminalHeadless,
+	isWsl,
 	logger,
 	postmortem,
 	restoreTerminalStderr,
@@ -542,9 +543,9 @@ export interface Terminal {
  * single predicate.
  */
 export function isConPTYHosted(): boolean {
-	if (process.platform === "win32") return true;
-	// WSL: stdout still crosses into ConPTY at the `wslhost` boundary.
-	return process.platform === "linux" && (!!$env.WSL_DISTRO_NAME || !!$env.WSL_INTEROP);
+	// win32 always hosts through ConPTY; under WSL stdout still crosses into
+	// ConPTY at the `wslhost` boundary.
+	return process.platform === "win32" || isWsl(process.platform, $env);
 }
 
 /** Discriminated owner of an outstanding DA1 sentinel in the unified probe FIFO. */

--- a/packages/utils/src/env.ts
+++ b/packages/utils/src/env.ts
@@ -36,6 +36,18 @@ export function isMacosMallocStackLoggingEnvName(name: string): boolean {
 	return name === "MallocStackLogging" || name === "MallocStackLoggingNoCompact";
 }
 
+/**
+ * True when running inside a WSL (Windows Subsystem for Linux) distribution.
+ *
+ * WSL reports `linux` for `process.platform`, so the only reliable signal is
+ * the `WSL_DISTRO_NAME`/`WSL_INTEROP` variables the interop layer injects.
+ * Callers use this to translate Windows drive paths to their `/mnt/<drive>`
+ * mounts and to route clipboard access through `powershell.exe`.
+ */
+export function isWsl(platform: NodeJS.Platform = process.platform, env: NodeJS.ProcessEnv = process.env): boolean {
+	return platform === "linux" && Boolean(env.WSL_DISTRO_NAME || env.WSL_INTEROP);
+}
+
 export function filterProcessEnv(env: Record<string, string | undefined>): Record<string, string> {
 	const result: Record<string, string> = {};
 	for (const key in env) {

--- a/packages/utils/src/path.ts
+++ b/packages/utils/src/path.ts
@@ -1,3 +1,17 @@
+import * as path from "node:path";
+
+const WINDOWS_DRIVE_PATH = /^([A-Za-z]):[\\/](.*)$/;
+
+/** Maps an absolute Windows drive path to the drive's default WSL mount. */
+export function windowsPathToWslMount(filePath: string): string | undefined {
+	const normalized = path.win32.normalize(filePath.trim());
+	const match = WINDOWS_DRIVE_PATH.exec(normalized);
+	if (!match) return undefined;
+	const [, drive, rest] = match;
+	const segments = rest.split("\\").filter(Boolean);
+	return path.posix.join("/mnt", drive!.toLowerCase(), ...segments);
+}
+
 const WINDOWS_DRIVE_EXTENDED_PREFIX = /^\\\\[?]\\([A-Za-z]:[\\/].*)$/;
 const WINDOWS_UNC_EXTENDED_PREFIX = /^\\\\[?]\\UNC[\\/]([^\\/]+)[\\/](.+)$/i;
 const WINDOWS_DRIVE_EXTENDED_FORWARD_PREFIX = /^\/\/[?]\/([A-Za-z]:\/.*)$/;

--- a/packages/utils/test/path.test.ts
+++ b/packages/utils/test/path.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { stripWindowsExtendedLengthPathPrefix } from "../src/path";
+import { stripWindowsExtendedLengthPathPrefix, windowsPathToWslMount } from "../src/path";
 
 describe("stripWindowsExtendedLengthPathPrefix", () => {
 	it("removes drive and UNC extended-length prefixes on Windows", () => {
@@ -14,5 +14,15 @@ describe("stripWindowsExtendedLengthPathPrefix", () => {
 	it("leaves non-Windows paths unchanged", () => {
 		const path = "\\\\?\\C:\\Users\\Shi Xin\\omp.exe";
 		expect(stripWindowsExtendedLengthPathPrefix(path, "linux")).toBe(path);
+	});
+});
+
+describe("windowsPathToWslMount", () => {
+	it("clamps parent traversal at the Windows drive root", () => {
+		expect(windowsPathToWslMount("C:\\..\\Windows\\x")).toBe("/mnt/c/Windows/x");
+	});
+
+	it("rejects paths without an absolute Windows drive", () => {
+		expect(windowsPathToWslMount("/home/me/file.txt")).toBeUndefined();
 	});
 });


### PR DESCRIPTION
## Repro
Pasting a Windows image path such as `C:\Users\MyUser\Pictures\MyPic.jpg` into omp running under WSL fails with `Image not found at C:\Users\...` and nothing is pasted. Reproduced with a focused unit test asserting the resolver translates the drive path:
`cd packages/coding-agent && bun test test/tools/windows-drive-alias.test.ts` — before the fix `normalizeWindowsDriveAliasPath("C:\\Users\\MyUser\\Pictures\\MyPic.jpg", "linux", { WSL_DISTRO_NAME })` returned the string unchanged instead of `/mnt/c/Users/MyUser/Pictures/MyPic.jpg`.

## Cause
`normalizeWindowsDriveAliasPath` in `packages/coding-agent/src/tools/path-utils.ts` only handled the win32 direction (`/mnt/c/...` → `C:\...`) and short-circuited (`if (platform !== "win32") return filePath`) for every other platform. Under WSL (which reports `linux`), a pasted `C:\...` path therefore passed through untranslated; `resolveToCwd`/`resolveReadPath` then `path.resolve`d it under the session cwd into a nonexistent path, `readImageMetadata` threw ENOENT, and `handleImagePathPaste` surfaced `Image not found`. The reverse mapping already existed for host discovery (`convertWindowsPathToDefaultWslMount` in `discovery/agents.ts`) but was never applied on the read path.

## Fix
- Added `isWsl(platform, env)` to `packages/utils/src/env.ts` as the single WSL-detection helper.
- Extended `normalizeWindowsDriveAliasPath` (path-utils.ts) with an `env` argument and a WSL branch that maps `C:\...`/`C:/...` → `/mnt/<drive>/...`, so image paste and every other `resolveReadPath` consumer resolve WSL drive paths correctly.
- Migrated the three duplicated `isWsl` copies (`discovery/agents.ts`, `utils/clipboard.ts`, `utils/open.ts`) to the central helper.
- Added a changelog entry under `[Unreleased]`.

## Verification
`cd packages/coding-agent && bun test test/tools/windows-drive-alias.test.ts test/tools/root-path-alias.test.ts test/tools/path-literal-colon-selector.test.ts test/skills.test.ts test/utils/open.test.ts test/utils/clipboard.test.ts test/issue-2375-repro.test.ts` — all pass (the ENOENT paste behavior from #2375 is unchanged). `cd packages/utils && bun test` — 857 pass. New WSL-direction regression tests added to `windows-drive-alias.test.ts`.
Fixes #10426