### PR TITLE
feat(extensions): expose agent identity (ctx.agentIdentity) to extension contexts

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -214,6 +214,7 @@ Handlers and tool `execute` receive `ctx` with:
 - `shutdown()`
 - `getSystemPrompt()`
 - `memory` (optional structured memory runtime — status/search/save across the configured backend)
+- `agentIdentity` — identity of the agent this handler runs in: `kind` (`"main" | "sub"`, mirroring the session's pre-existing classification), `depth` (`0` = top-level; test `kind === "sub"`, not `depth > 0`), `agentId` (registry id, `"Main"` top-level), `displayName`, optional `parentId` (spawning agent's registry id; `/tan` forks report the job-owning main), `parentChain` (nearest-first ancestors, excluding `"Main"`; empty for top-level and runner-less SDK sessions). Lazy, frozen — copy rather than mutate.
 - `setInterval(fn, ms, ...args)` / `setTimeout(fn, ms, ...args)` / `clearTimer(timer)` — managed timers (see below)
 
 ### Background work (`ctx.setInterval` / `ctx.setTimeout`)

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -214,7 +214,7 @@ Handlers and tool `execute` receive `ctx` with:
 - `shutdown()`
 - `getSystemPrompt()`
 - `memory` (optional structured memory runtime — status/search/save across the configured backend)
-- `agentIdentity` — identity of the agent this handler runs in: `kind` (`"main" | "sub"`, mirroring the session's pre-existing classification), `depth` (`0` = top-level; test `kind === "sub"`, not `depth > 0`), `agentId` (registry id, `"Main"` top-level), `displayName`, optional `parentId` (spawning agent's registry id; `/tan` forks report the job-owning main), `parentChain` (nearest-first ancestors, excluding `"Main"`; empty for top-level and runner-less SDK sessions). Lazy, frozen — copy rather than mutate.
+- `agentIdentity` — identity of the agent this handler runs in: `kind` (`"main" | "sub"`, mirroring the session's pre-existing classification verbatim), `depth` (`0` = top-level; derives from `taskDepth`, not the parent chain — a `/tan` fork is a special tangential fork agent, `kind: "sub"` with `depth: 0`; ask "am I a spawned worker?" via `kind === "sub"`, not `depth > 0`), `agentId` (registry id, `"Main"` top-level), `displayName`, optional `parentId` (spawning agent's registry id; `/tan` forks report the job-owning main), `parentChain` (nearest-first ancestors, excluding `"Main"`; empty for top-level and runner-less SDK sessions). Read once per session (frozen snapshot at first access); frozen — copy rather than mutate.
 - `setInterval(fn, ms, ...args)` / `setTimeout(fn, ms, ...args)` / `clearTimer(timer)` — managed timers (see below)
 
 ### Background work (`ctx.setInterval` / `ctx.setTimeout`)

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Added `ctx.agentIdentity` to extension contexts, exposing whether a handler runs in the main session or a subagent, its recursion depth, registry id, display name, and parent chain ([#10228](https://github.com/can1357/oh-my-pi/issues/10228)). Identity is read-only and observes the session's pre-existing classification unchanged.
+
 - Added `injectV1: false` option to `openai-models-list` discovery to fetch the model list from `{baseUrl}/models` without injecting `/v1`, for gateways that root their OpenAI-compatible surface at a versioned URL (e.g. `https://api.opper.ai/v3/compat`) where the `/v1`-injected endpoint returns only a small subset.
 - Added provider-reported credits and concrete routed-model counts to `/session` statistics ([#8590](https://github.com/can1357/oh-my-pi/pull/8590) by [@will-bogusz](https://github.com/will-bogusz)).
 - Added `CLINE_API_KEY` to the CLI environment help for native ClinePass subscription inference ([#7863](https://github.com/can1357/oh-my-pi/pull/7863) by [@will-bogusz](https://github.com/will-bogusz)).

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Added `ctx.agentIdentity` to extension contexts, exposing whether a handler runs in the main session or a subagent, its recursion depth, registry id, display name, and parent chain ([#10228](https://github.com/can1357/oh-my-pi/issues/10228)). Identity is read-only and observes the session's pre-existing classification unchanged.
+- Added `ctx.agentIdentity` to extension contexts, exposing whether a handler runs in the main session or a subagent, its recursion depth, registry id, display name, and parent chain ([#10228](https://github.com/can1357/oh-my-pi/issues/10228)). Identity is read-only and observes the session's pre-existing classification unchanged (`/tan` forks report their documented special-agent identity: `kind: "sub"`, `depth: 0`).
 
 - Added `injectV1: false` option to `openai-models-list` discovery to fetch the model list from `{baseUrl}/models` without injecting `/v1`, for gateways that root their OpenAI-compatible surface at a versioned URL (e.g. `https://api.opper.ai/v3/compat`) where the `/v1`-injected endpoint returns only a small subset.
 - Added provider-reported credits and concrete routed-model counts to `/session` statistics ([#8590](https://github.com/can1357/oh-my-pi/pull/8590) by [@will-bogusz](https://github.com/will-bogusz)).

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -437,8 +437,10 @@ interface ToolRegistrationScope {
 
 /**
  * Identity of the agent a runner serves, passed at construction so extension
- * contexts can expose {@link AgentIdentity}. `registry` resolves the parent
- * chain lazily; `parentId` is omitted for the top-level session.
+ * contexts can expose {@link AgentIdentity}. Unlike `AgentRef`, `kind` is the
+ * narrowed `"main" | "sub"` — a runner always fronts a live session, so the
+ * registry-only `advisor` kind is unreachable here. `registry` resolves the
+ * parent chain lazily; `parentId` is omitted for the top-level session.
  */
 export interface ExtensionRunnerIdentityInput {
 	kind: "main" | "sub";

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -1226,51 +1226,47 @@ export class ExtensionRunner {
 	 * `ctx.agentIdentity` read. `AgentRegistry` refs are mutable mid-session
 	 * (SDK callers may unregister/re-register), so the chain must not be
 	 * re-resolved from the registry on every access; freezing at first read
-	 * yields one stable, frozen identity object per session. Observational
-	 * only: this resolves registry links that predate this feature; it does
-	 * not create, re-key, or validate them (registry registration ownership
-	 * remains the caller's pre-existing contract).
+	 * yields one stable, frozen identity object per session. Absent input
+	 * stays absent: a runner constructed without identity input (provider-only
+	 * hosts, legacy embedders) reports `undefined` rather than fabricating a
+	 * top-level identity. Observational only: this resolves registry links
+	 * that predate this feature; it does not create, re-key, or validate them
+	 * (registry registration ownership remains the caller's pre-existing
+	 * contract).
 	 */
 	#identitySnapshot: AgentIdentity | undefined;
+	#identityResolved = false;
 
-	#getAgentIdentity(): AgentIdentity {
-		if (!this.#identitySnapshot) {
-			this.#identitySnapshot = this.#buildAgentIdentity(this.#agentIdentityInput);
+	#getAgentIdentity(): AgentIdentity | undefined {
+		if (!this.#identityResolved) {
+			this.#identitySnapshot = this.#agentIdentityInput
+				? this.#buildAgentIdentity(this.#agentIdentityInput)
+				: undefined;
+			this.#identityResolved = true;
 		}
 		return this.#identitySnapshot;
 	}
 
-	#buildAgentIdentity(input?: ExtensionRunnerIdentityInput): AgentIdentity {
-		let identity: AgentIdentity;
-		if (!input) {
-			identity = {
-				kind: "main",
-				depth: 0,
-				agentId: MAIN_AGENT_ID,
-				displayName: "main",
-				parentChain: [],
-			};
-		} else {
-			// Seed the seen-set with this agent's own id so a registry cycle
-			// looping back through the current agent (A → B → A) ends the walk
-			// before the self id enters the reported ancestor chain.
-			const seen = new Set<string>([input.agentId]);
-			const parentChain: string[] = [];
-			let cursor = input.parentId;
-			while (cursor !== undefined && cursor !== MAIN_AGENT_ID && !seen.has(cursor)) {
-				parentChain.push(cursor);
-				seen.add(cursor);
-				cursor = input.registry.get(cursor)?.parentId;
-			}
-			identity = {
-				kind: input.kind,
-				depth: input.depth,
-				agentId: input.agentId,
-				displayName: input.displayName,
-				...(input.parentId !== undefined ? { parentId: input.parentId } : {}),
-				parentChain,
-			};
+	#buildAgentIdentity(input: ExtensionRunnerIdentityInput): AgentIdentity {
+		// Seed the seen-set with this agent's own id so a registry cycle
+		// looping back through the current agent (A → B → A) ends the walk
+		// before the self id enters the reported ancestor chain.
+		const seen = new Set<string>([input.agentId]);
+		const parentChain: string[] = [];
+		let cursor = input.parentId;
+		while (cursor !== undefined && cursor !== MAIN_AGENT_ID && !seen.has(cursor)) {
+			parentChain.push(cursor);
+			seen.add(cursor);
+			cursor = input.registry.get(cursor)?.parentId;
 		}
+		const identity: AgentIdentity = {
+			kind: input.kind,
+			depth: input.depth,
+			agentId: input.agentId,
+			displayName: input.displayName,
+			...(input.parentId !== undefined ? { parentId: input.parentId } : {}),
+			parentChain,
+		};
 		// Frozen deeply: the memoized object is handed to every handler for the
 		// session, so a mutating extension cannot corrupt the documented identity
 		// (e.g. reversing `parentChain`) for unrelated extensions.

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -17,6 +17,7 @@ import type { Settings } from "../../config/settings";
 import type { LocalProtocolOptions } from "../../internal-urls/local-protocol";
 import type { MemoryRuntimeContext } from "../../memory-backend";
 import { type Theme, theme } from "../../modes/theme/theme";
+import { type AgentRegistry, MAIN_AGENT_ID } from "../../registry/agent-registry";
 import type { AsyncJobSnapshot } from "../../session/agent-session";
 import type { SessionManager } from "../../session/session-manager";
 import { addFileDeleteFallback, addFileWriteFallback } from "../../tools/file-write-fallback";
@@ -25,6 +26,7 @@ import { ManagedTimers } from "./managed-timers";
 import { createExtensionModelQuery } from "./model-api";
 import type {
 	AfterProviderResponseEvent,
+	AgentIdentity,
 	AssistantThinkingRenderer,
 	BeforeAgentStartEvent,
 	BeforeAgentStartEventResult,
@@ -433,6 +435,20 @@ interface ToolRegistrationScope {
 	closed: boolean;
 }
 
+/**
+ * Identity of the agent a runner serves, passed at construction so extension
+ * contexts can expose {@link AgentIdentity}. `registry` resolves the parent
+ * chain lazily; `parentId` is omitted for the top-level session.
+ */
+export interface ExtensionRunnerIdentityInput {
+	kind: "main" | "sub";
+	depth: number;
+	agentId: string;
+	displayName: string;
+	parentId?: string;
+	registry: Pick<AgentRegistry, "get">;
+}
+
 export class ExtensionRunner {
 	#uiContext: ExtensionUIContext;
 	#mode: ExtensionMode = "print";
@@ -442,6 +458,7 @@ export class ExtensionRunner {
 	#isIdleFn: () => boolean = () => true;
 	#waitForIdleFn: () => Promise<void> = async () => {};
 	#abortFn: () => void = () => {};
+	#agentIdentityInput?: ExtensionRunnerIdentityInput;
 	#hasPendingMessagesFn: () => boolean = () => false;
 	#getContextUsageFn: () => ContextUsage | undefined = () => undefined;
 	#compactFn: (instructionsOrOptions?: string | CompactOptions) => Promise<void> = async () => {};
@@ -607,10 +624,12 @@ export class ExtensionRunner {
 		private readonly settings?: Settings,
 		private readonly localProtocolOptions?: LocalProtocolOptions,
 		getAsyncJobSnapshot?: () => AsyncJobSnapshot | null,
+		agentIdentity?: ExtensionRunnerIdentityInput,
 	) {
 		this.#uiContext = noOpUIContext;
 		this.#getMemoryFn = getMemory;
 		this.#getAsyncJobSnapshotFn = getAsyncJobSnapshot ?? (() => null);
+		this.#agentIdentityInput = agentIdentity;
 	}
 
 	/**
@@ -1156,6 +1175,7 @@ export class ExtensionRunner {
 		},
 	): ExtensionContext {
 		const getModel = model ? () => model : this.#getModel;
+		const runner = this;
 		return {
 			ui: this.#uiContext,
 			mode: this.#mode,
@@ -1169,6 +1189,9 @@ export class ExtensionRunner {
 			isProjectTrusted: () => true,
 			get model() {
 				return getModel();
+			},
+			get agentIdentity() {
+				return runner.#getAgentIdentity();
 			},
 			models: createExtensionModelQuery(this.modelRegistry, this.settings, getModel),
 			isIdle: () => this.#isIdleFn(),
@@ -1194,6 +1217,65 @@ export class ExtensionRunner {
 							})
 					: undefined,
 		};
+	}
+
+	/**
+	 * Identity snapshot (with the parent chain) taken on first
+	 * `ctx.agentIdentity` read. `AgentRegistry` refs are mutable mid-session
+	 * (SDK callers may unregister/re-register), so the chain must not be
+	 * re-resolved from the registry on every access; freezing at first read
+	 * yields one stable, frozen identity object per session. Observational
+	 * only: this resolves registry links that predate this feature; it does
+	 * not create, re-key, or validate them (registry registration ownership
+	 * remains the caller's pre-existing contract).
+	 */
+	#identitySnapshot: AgentIdentity | undefined;
+
+	#getAgentIdentity(): AgentIdentity {
+		if (!this.#identitySnapshot) {
+			this.#identitySnapshot = this.#buildAgentIdentity(this.#agentIdentityInput);
+		}
+		return this.#identitySnapshot;
+	}
+
+	#buildAgentIdentity(input?: ExtensionRunnerIdentityInput): AgentIdentity {
+		let identity: AgentIdentity;
+		if (!input) {
+			identity = {
+				kind: "main",
+				depth: 0,
+				agentId: MAIN_AGENT_ID,
+				displayName: "main",
+				parentChain: [],
+			};
+		} else {
+			// Seed the seen-set with this agent's own id so a registry cycle
+			// looping back through the current agent (A → B → A) ends the walk
+			// before the self id enters the reported ancestor chain.
+			const seen = new Set<string>([input.agentId]);
+			const parentChain: string[] = [];
+			let cursor = input.parentId;
+			while (cursor !== undefined && cursor !== MAIN_AGENT_ID && !seen.has(cursor)) {
+				parentChain.push(cursor);
+				seen.add(cursor);
+				cursor = input.registry.get(cursor)?.parentId;
+			}
+			identity = {
+				kind: input.kind,
+				depth: input.depth,
+				agentId: input.agentId,
+				displayName: input.displayName,
+				...(input.parentId !== undefined ? { parentId: input.parentId } : {}),
+				parentChain,
+			};
+		}
+		// Frozen deeply: the memoized object is handed to every handler for the
+		// session, so a mutating extension cannot corrupt the documented identity
+		// (e.g. reversing `parentChain`) for unrelated extensions.
+		return Object.freeze({
+			...identity,
+			parentChain: Object.freeze([...identity.parentChain]),
+		});
 	}
 
 	/**

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -541,9 +541,11 @@ export interface ExtensionContext {
 	models: ExtensionModelQuery;
 	/**
 	 * Identity of the agent this context serves: top-level or subagent,
-	 * depth, registry id, display name, and parent chain. Read lazily.
+	 * depth, registry id, display name, and parent chain. Read lazily;
+	 * `undefined` when the host does not report identity (e.g. provider-only
+	 * runner hosts) — handlers must fail open rather than assume `"main"`.
 	 */
-	readonly agentIdentity: AgentIdentity;
+	readonly agentIdentity?: AgentIdentity;
 	/** Whether the agent is idle (not streaming) */
 	isIdle(): boolean;
 	/** Abort the current agent operation */

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -468,19 +468,22 @@ export interface AgentIdentity {
 	/**
 	 * Whether this session runs as the top-level session or as a spawned
 	 * worker. Mirrors the session's pre-existing `agentKind` classification
-	 * (`taskDepth > 0 || parentTaskPrefix !== undefined`) verbatim — a caller
-	 * linking via `parentAgentId` while omitting `taskDepth`/`parentTaskPrefix`
-	 * (e.g. a `/tan` fork) observes `"main"`, same as every capability gate.
+	 * (`taskDepth > 0 || parentTaskPrefix !== undefined`) verbatim — identity
+	 * never widens or narrows it. A caller linking via `parentAgentId` while
+	 * omitting `taskDepth`/`parentTaskPrefix` observes `"main"`; a `/tan`
+	 * fork observed via a context is a special tangential fork agent
+	 * classified `"sub"` by the same pre-existing inputs (`depth` stays `0`).
 	 */
 	readonly kind: "main" | "sub";
 	/**
 	 * Recursion depth of this agent: `0` = top-level. Mirrors the session's own
 	 * `taskDepth` (the pre-existing gate input for IRC/memory/spawn capability
-	 * gates) exactly — it is NOT re-derived here from the parent chain, so a
-	 * caller that supplies parent linkage while omitting `taskDepth` (e.g. the
-	 * `/tan` clone path) observes `0` here, matching every other capability
-	 * gate for that session. Extensions asking "am I a child?" should test
-	 * `kind === "sub"` or `parentId !== undefined`, not `depth > 0`.
+	 * gates) exactly — it is NOT re-derived here from the parent chain. Kind
+	 * and depth come from different pre-existing gate inputs, so they can
+	 * legitimately disagree: a `/tan` fork supplies `parentTaskPrefix` but no
+	 * `taskDepth` and observes `kind: "sub"` with `depth: 0`. Extensions
+	 * asking "am I a spawned worker?" should test `kind === "sub"`; asking
+	 * "was I spawned by the task tool?" — test `depth > 0`.
 	 */
 	readonly depth: number;
 	/**
@@ -496,8 +499,10 @@ export interface AgentIdentity {
 	readonly displayName: string;
 	/**
 	 * Registry id of the direct parent agent as supplied to
-	 * `createAgentSession`; undefined for the top-level session. `/tan` forks
-	 * report the job-owning main session here even though `kind` is `"main"`.
+	 * `createAgentSession`; undefined for the top-level session. A `/tan`
+	 * fork reports the job-owning main session here (its `parentId` is
+	 * registry-resolvable linkage, but its `parentChain` is empty because the
+	 * walk stops at `"Main"`).
 	 */
 	readonly parentId?: string;
 	/**

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -452,6 +452,63 @@ export interface ExtensionModelQuery {
 /** Runtime host mode exposed to Pi-compatible extensions. */
 export type ExtensionMode = "tui" | "rpc" | "json" | "print";
 
+/**
+ * Identity of the agent an extension context serves.
+ *
+ * Purely descriptive: everything here is derived from state that already
+ * exists (registry identity, spawn options) and nothing in this feature
+ * changes how sessions behave. Where a session is linked to a parent through
+ * options that predate this interface (see `parentAgentId` in
+ * `CreateAgentSessionOptions`), the pre-existing semantics of those options —
+ * including resource-ownership checks keyed on `parentTaskPrefix` and the
+ * registry's unconditional `register()` replacement — are unchanged; this
+ * type only observes them.
+ */
+export interface AgentIdentity {
+	/**
+	 * Whether this session runs as the top-level session or as a spawned
+	 * worker. Mirrors the session's pre-existing `agentKind` classification
+	 * (`taskDepth > 0 || parentTaskPrefix !== undefined`) verbatim — a caller
+	 * linking via `parentAgentId` while omitting `taskDepth`/`parentTaskPrefix`
+	 * (e.g. a `/tan` fork) observes `"main"`, same as every capability gate.
+	 */
+	readonly kind: "main" | "sub";
+	/**
+	 * Recursion depth of this agent: `0` = top-level. Mirrors the session's own
+	 * `taskDepth` (the pre-existing gate input for IRC/memory/spawn capability
+	 * gates) exactly — it is NOT re-derived here from the parent chain, so a
+	 * caller that supplies parent linkage while omitting `taskDepth` (e.g. the
+	 * `/tan` clone path) observes `0` here, matching every other capability
+	 * gate for that session. Extensions asking "am I a child?" should test
+	 * `kind === "sub"` or `parentId !== undefined`, not `depth > 0`.
+	 */
+	readonly depth: number;
+	/**
+	 * Registry id of this agent: `"Main"` for the default top-level session.
+	 * Pre-existing registry semantics apply unchanged: this mirrors the
+	 * session's resolved registry id (`options.agentId ??
+	 * options.parentTaskPrefix ?? "Main"` — no linkage-derived default), and
+	 * `AgentRegistry.register()` keeps replacing the entry keyed by that id
+	 * (documented registry behavior this interface observes, not changes).
+	 */
+	readonly agentId: string;
+	/** Human-readable name of this agent. */
+	readonly displayName: string;
+	/**
+	 * Registry id of the direct parent agent as supplied to
+	 * `createAgentSession`; undefined for the top-level session. `/tan` forks
+	 * report the job-owning main session here even though `kind` is `"main"`.
+	 */
+	readonly parentId?: string;
+	/**
+	 * Ancestor registry ids, nearest-first. Excludes `"Main"` and this agent's
+	 * own id. `[]` for the top-level session; runner-less sessions cannot
+	 * resolve the chain and degrade to `[]` even for subagents. Frozen like the
+	 * surrounding identity: copy rather than mutate.
+	 */
+	readonly parentChain: readonly string[];
+}
+
 export interface ExtensionContext {
 	/** UI methods for user interaction */
 	ui: ExtensionUIContext;
@@ -477,6 +534,11 @@ export interface ExtensionContext {
 	model: Model | undefined;
 	/** Read-only model query facade: list / current / resolve / family. */
 	models: ExtensionModelQuery;
+	/**
+	 * Identity of the agent this context serves: top-level or subagent,
+	 * depth, registry id, display name, and parent chain. Read lazily.
+	 */
+	readonly agentIdentity: AgentIdentity;
 	/** Whether the agent is idle (not streaming) */
 	isIdle(): boolean;
 	/** Abort the current agent operation */

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1712,8 +1712,10 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 	// Pre-existing classification: task-depth or a parent-linked artifact
 	// prefix marks a spawned worker. Every genuine spawn path (executor,
 	// revive) supplies taskDepth > 0, so the extension identity observes
-	// `agentKind` verbatim — identity never widens it; /tan forks stay
-	// "main" like every other capability gate.
+	// `agentKind` verbatim — identity never widens or narrows it; /tan
+	// forks classify exactly as before (sub via parentTaskPrefix), and a
+	// linkage-only caller (parentAgentId without taskDepth/parentTaskPrefix)
+	// observes main, same as every capability gate.
 	const resolvedAgentDisplayName =
 		options.agentDisplayName ?? ((options.taskDepth ?? 0) > 0 || options.parentTaskPrefix ? "sub" : "main");
 	const agentKind = (options.taskDepth ?? 0) > 0 || options.parentTaskPrefix ? ("sub" as const) : ("main" as const);

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1709,6 +1709,11 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 
 	const agentRegistry = options.agentRegistry ?? AgentRegistry.global();
 	const resolvedAgentId = options.agentId ?? options.parentTaskPrefix ?? MAIN_AGENT_ID;
+	// Pre-existing classification: task-depth or a parent-linked artifact
+	// prefix marks a spawned worker. Every genuine spawn path (executor,
+	// revive) supplies taskDepth > 0, so the extension identity observes
+	// `agentKind` verbatim — identity never widens it; /tan forks stay
+	// "main" like every other capability gate.
 	const resolvedAgentDisplayName =
 		options.agentDisplayName ?? ((options.taskDepth ?? 0) > 0 || options.parentTaskPrefix ? "sub" : "main");
 	const agentKind = (options.taskDepth ?? 0) > 0 || options.parentTaskPrefix ? ("sub" as const) : ("main" as const);
@@ -2740,6 +2745,14 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			settings,
 			localProtocolOptions,
 			() => (hasSession ? session.getAsyncJobSnapshot() : null),
+			{
+				depth: taskDepth,
+				kind: agentKind,
+				agentId: resolvedAgentId,
+				displayName: resolvedAgentDisplayName,
+				parentId: options.parentAgentId,
+				registry: agentRegistry,
+			},
 		);
 
 		credentialDisabledTarget = extensionRunner;
@@ -3718,6 +3731,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			obfuscator,
 			agentId: resolvedAgentId,
 			agentKind,
+			taskDepth,
 			providerSessionId: options.providerSessionId,
 			providerPromptCacheKeySource,
 			parentEvalSessionId: options.parentEvalSessionId,

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -3733,6 +3733,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			obfuscator,
 			agentId: resolvedAgentId,
 			agentKind,
+			agentDisplayName: resolvedAgentDisplayName,
 			taskDepth,
 			providerSessionId: options.providerSessionId,
 			providerPromptCacheKeySource,

--- a/packages/coding-agent/src/session/agent-session-types.ts
+++ b/packages/coding-agent/src/session/agent-session-types.ts
@@ -254,6 +254,8 @@ export interface AgentSessionConfig {
 	agentId?: string;
 	/** Whether this is a top-level or subagent session. */
 	agentKind?: "main" | "sub";
+	/** Registry display name; backs the extension identity fallback. */
+	agentDisplayName?: string;
 	/** Task recursion depth (0 = top-level); backs the extension identity fallback. */
 	taskDepth?: number;
 	/** Provider-facing session ID override. */

--- a/packages/coding-agent/src/session/agent-session-types.ts
+++ b/packages/coding-agent/src/session/agent-session-types.ts
@@ -254,6 +254,8 @@ export interface AgentSessionConfig {
 	agentId?: string;
 	/** Whether this is a top-level or subagent session. */
 	agentKind?: "main" | "sub";
+	/** Task recursion depth (0 = top-level); backs the extension identity fallback. */
+	taskDepth?: number;
 	/** Provider-facing session ID override. */
 	providerSessionId?: string;
 	/** Whether the provider prompt-cache key was explicit or fork-inherited. */

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -624,6 +624,8 @@ export class AgentSession {
 	// Agent identity (registry id) used for IRC routing and job ownership.
 	#agentId: string | undefined;
 	#agentKind: "main" | "sub" = "main";
+	// Registry display name; backs the extension identity fallback.
+	#agentDisplayName: string | undefined;
 	// Task recursion depth (0 = top-level); mirrors the runner identity input.
 	#taskDepth = 0;
 	#scoutAllowedBySpawnPolicy = true;
@@ -1477,6 +1479,7 @@ export class AgentSession {
 		this.#taskDepth = config.taskDepth ?? 0;
 		this.#agentId = config.agentId;
 		this.#agentKind = config.agentKind ?? "main";
+		this.#agentDisplayName = config.agentDisplayName;
 		this.#scoutAllowedBySpawnPolicy = config.scoutAllowedBySpawnPolicy ?? true;
 		this.#providerSessionId = config.providerSessionId;
 		this.#inheritedProviderPromptCacheKey =
@@ -6311,7 +6314,7 @@ export class AgentSession {
 			kind,
 			depth: this.#taskDepth,
 			agentId: this.#agentId ?? MAIN_AGENT_ID,
-			displayName: kind === "sub" ? "sub" : "main",
+			displayName: this.#agentDisplayName ?? (kind === "sub" ? "sub" : "main"),
 			parentChain: Object.freeze([]),
 		});
 		return identity;

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -143,7 +143,7 @@ import type {
 import { emitSessionShutdownEvent } from "../extensibility/extensions";
 import { ManagedTimers } from "../extensibility/extensions/managed-timers";
 import { createExtensionModelQuery } from "../extensibility/extensions/model-api";
-import type { CompactOptions, ContextUsage } from "../extensibility/extensions/types";
+import type { AgentIdentity, CompactOptions, ContextUsage } from "../extensibility/extensions/types";
 import type { HookCommandContext } from "../extensibility/hooks/types";
 import type { Skill, SkillWarning } from "../extensibility/skills";
 import { expandSlashCommand, type FileSlashCommand } from "../extensibility/slash-commands";
@@ -178,6 +178,7 @@ import planModeToolDecisionReminderPrompt from "../prompts/system/plan-mode-tool
 import rewindReportTemplate from "../prompts/system/rewind-report.md" with { type: "text" };
 import sideChannelNoToolsReminder from "../prompts/system/side-channel-no-tools.md" with { type: "text" };
 import vibeModeActivePrompt from "../prompts/system/vibe-mode-active.md" with { type: "text" };
+import { MAIN_AGENT_ID } from "../registry/agent-registry";
 import {
 	deobfuscateAssistantContent,
 	deobfuscateSessionContext,
@@ -623,6 +624,8 @@ export class AgentSession {
 	// Agent identity (registry id) used for IRC routing and job ownership.
 	#agentId: string | undefined;
 	#agentKind: "main" | "sub" = "main";
+	// Task recursion depth (0 = top-level); mirrors the runner identity input.
+	#taskDepth = 0;
 	#scoutAllowedBySpawnPolicy = true;
 	#providerSessionId: string | undefined;
 	#freshProviderSessionId: string | undefined;
@@ -1471,6 +1474,7 @@ export class AgentSession {
 		};
 		this.#streamingEditGuard = new StreamingEditGuard(streamGuardsHost);
 		this.#loopGuards = new LoopGuards(streamGuardsHost);
+		this.#taskDepth = config.taskDepth ?? 0;
 		this.#agentId = config.agentId;
 		this.#agentKind = config.agentKind ?? "main";
 		this.#scoutAllowedBySpawnPolicy = config.scoutAllowedBySpawnPolicy ?? true;
@@ -6228,7 +6232,7 @@ export class AgentSession {
 			sessionManager: this.sessionManager,
 			modelRegistry: this.#modelRegistry,
 			isProjectTrusted: () => true,
-
+			agentIdentity: this.#fallbackAgentIdentity(),
 			model: this.model ?? undefined,
 			models: createExtensionModelQuery(this.#modelRegistry, this.settings, () => this.model ?? undefined),
 			isIdle: () => !this.isStreaming,
@@ -6290,6 +6294,27 @@ export class AgentSession {
 			logger.warn("Extension timer callback threw", { event, error }),
 		);
 		return this.#fallbackExtensionTimers;
+	}
+
+	/**
+	 * Runner-less command-context identity (SDK embeddings with no extension
+	 * runner). Derived from the session's own registry identity; the parent
+	 * chain is unavailable without a registry handle, so it degrades to empty
+	 * rather than fabricating ancestors.
+	 *
+	 * Frozen, matching the runner's memoized identity: command contexts are
+	 * shared across handlers, so a mutating extension cannot corrupt them.
+	 */
+	#fallbackAgentIdentity(): AgentIdentity {
+		const kind = this.#agentKind;
+		const identity: AgentIdentity = Object.freeze({
+			kind,
+			depth: this.#taskDepth,
+			agentId: this.#agentId ?? MAIN_AGENT_ID,
+			displayName: kind === "sub" ? "sub" : "main",
+			parentChain: Object.freeze([]),
+		});
+		return identity;
 	}
 
 	/**

--- a/packages/coding-agent/test/extension-context-agent-identity.test.ts
+++ b/packages/coding-agent/test/extension-context-agent-identity.test.ts
@@ -215,4 +215,56 @@ describe("ExtensionContext agentIdentity", () => {
 			await fsp.rm(tempDir, { recursive: true, force: true });
 		}
 	});
+
+	it("reports the documented /tan fork identity through the public SDK path", async () => {
+		const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), "pi-identity-sdk-tan-"));
+		const registry = new AgentRegistry();
+		registry.register({ id: MAIN_AGENT_ID, displayName: "Main", kind: "main", session: null });
+		const authStorage = await AuthStorage.create(":memory:");
+		try {
+			// Options mirror TanCommandController.start(): parentTaskPrefix is
+			// always truthy, taskDepth is never set, the owning main session is
+			// the parentAgentId.
+			const { session } = await createAgentSession({
+				cwd: path.join(tempDir, "project"),
+				agentDir: path.join(tempDir, "agent"),
+				authStorage,
+				modelRegistry: new ModelRegistry(authStorage),
+				settings: Settings.isolated(),
+				disableExtensionDiscovery: true,
+				skills: [],
+				contextFiles: [],
+				promptTemplates: [],
+				slashCommands: [],
+				toolNames: [],
+				enableMCP: false,
+				enableLsp: false,
+				agentRegistry: registry,
+				agentId: "Tan-1",
+				agentDisplayName: "tan",
+				parentTaskPrefix: "Tan-1",
+				parentAgentId: MAIN_AGENT_ID,
+			});
+			try {
+				const identity = session.extensionRunner?.createContext().agentIdentity;
+				// Documented special tan-fork identity: classified "sub" by the
+				// pre-existing parentTaskPrefix input, depth 0 (no taskDepth),
+				// parentChain empty (walk stops at "Main").
+				expect(identity).toEqual({
+					kind: "sub",
+					depth: 0,
+					agentId: "Tan-1",
+					displayName: "tan",
+					parentId: MAIN_AGENT_ID,
+					parentChain: [],
+				});
+				expect(registry.get("Tan-1")?.kind).toBe("sub");
+			} finally {
+				await session.dispose();
+			}
+		} finally {
+			authStorage.close();
+			await fsp.rm(tempDir, { recursive: true, force: true });
+		}
+	});
 });

--- a/packages/coding-agent/test/extension-context-agent-identity.test.ts
+++ b/packages/coding-agent/test/extension-context-agent-identity.test.ts
@@ -29,16 +29,10 @@ function makeRunner(identity?: ExtensionRunnerIdentityInput): ExtensionRunner {
 }
 
 describe("ExtensionContext agentIdentity", () => {
-	it("falls back to the top-level main identity when constructed without one", () => {
+	it("reports undefined identity when constructed without one (no fabricated Main)", () => {
 		const runner = makeRunner();
 
-		expect(runner.createContext().agentIdentity).toEqual({
-			kind: "main",
-			depth: 0,
-			agentId: MAIN_AGENT_ID,
-			displayName: "main",
-			parentChain: [],
-		});
+		expect(runner.createContext().agentIdentity).toBeUndefined();
 	});
 
 	it("resolves deeper ancestors from the registry at first access and never re-queries after", () => {
@@ -47,14 +41,14 @@ describe("ExtensionContext agentIdentity", () => {
 		// own ancestor would come from a registry lookup (none registered yet).
 		const runner = makeRunner({ kind: "sub", depth: 2, agentId: "C2", displayName: "c2", parentId: "P1", registry });
 
-		expect(runner.createContext().agentIdentity.parentChain).toEqual(["P1"]);
+		expect(runner.createContext().agentIdentity?.parentChain).toEqual(["P1"]);
 
 		// Registering P1's own parent afterwards does not retro-link the
 		// memoized identity — the chain is resolved once (structural for a live
 		// agent), not re-queried on every access.
 		registry.register({ id: "P1", displayName: "planner", kind: "sub", parentId: "GP", session: null });
 		registry.register({ id: "GP", displayName: "grand", kind: "sub", parentId: MAIN_AGENT_ID, session: null });
-		expect(runner.createContext().agentIdentity.parentChain).toEqual(["P1"]);
+		expect(runner.createContext().agentIdentity?.parentChain).toEqual(["P1"]);
 	});
 
 	it("reports a subagent's direct parentId but excludes Main from the parent chain", () => {
@@ -93,7 +87,7 @@ describe("ExtensionContext agentIdentity", () => {
 		});
 
 		const before = runner.createContext().agentIdentity;
-		expect(before.parentChain).toEqual(["P1", "GP"]);
+		expect(before?.parentChain).toEqual(["P1", "GP"]);
 
 		// Unregistering an ancestor truncates nothing in the already-snapshotted
 		// chain; re-registering the same id with different ancestry splices in
@@ -104,8 +98,8 @@ describe("ExtensionContext agentIdentity", () => {
 		registry.register({ id: "P1", displayName: "imposter", kind: "sub", parentId: "EVIL", session: null });
 		registry.register({ id: "EVIL", displayName: "evil", kind: "sub", parentId: "P1", session: null });
 		const after = runner.createContext().agentIdentity;
-		expect(after.parentChain).toEqual(["P1", "GP"]);
-		expect(before.parentChain).toEqual(["P1", "GP"]);
+		expect(after?.parentChain).toEqual(["P1", "GP"]);
+		expect(before?.parentChain).toEqual(["P1", "GP"]);
 	});
 
 	it("resolves the ancestor chain nearest-first through registry parent links, excluding Main", () => {
@@ -121,9 +115,9 @@ describe("ExtensionContext agentIdentity", () => {
 			registry,
 		}).createContext().agentIdentity;
 
-		expect(identity.parentId).toBe("P1");
-		expect(identity.depth).toBe(2);
-		expect(identity.parentChain).toEqual(["P1"]);
+		expect(identity?.parentId).toBe("P1");
+		expect(identity?.depth).toBe(2);
+		expect(identity?.parentChain).toEqual(["P1"]);
 	});
 
 	it("terminates on cyclic parent links and never includes the agent's own id", () => {
@@ -142,7 +136,7 @@ describe("ExtensionContext agentIdentity", () => {
 		// The cycle A -> B -> A is cut by seeding the walk with A's own id: the
 		// chain is the true ancestors reached before the loop closes ("B"), not
 		// `["B", "A"]` with A reappearing in its own ancestry.
-		expect(identity.parentChain).toEqual(["B"]);
+		expect(identity?.parentChain).toEqual(["B"]);
 	});
 	it("hands handlers an immutable identity so one extension cannot corrupt it for others", () => {
 		const registry = new AgentRegistry();
@@ -157,18 +151,19 @@ describe("ExtensionContext agentIdentity", () => {
 			registry,
 		});
 		const identity = runner.createContext().agentIdentity;
-		expect(identity.parentChain).toEqual(["P2", "P1"]);
-
-		expect(Object.isFrozen(identity)).toBe(true);
-		expect(Object.isFrozen(identity.parentChain)).toBe(true);
+		expect(identity?.parentChain).toEqual(["P2", "P1"]);
 		// A mutation attempt must not corrupt the identity other handlers read
 		// (frozen surfaces may not throw in every runtime, but must never change).
-		try {
-			(identity.parentChain as unknown as string[]).reverse();
-		} catch {
-			// Frozen-array mutation may throw depending on runtime — both outcomes fine.
+		if (identity) {
+			expect(Object.isFrozen(identity)).toBe(true);
+			expect(Object.isFrozen(identity.parentChain)).toBe(true);
+			try {
+				(identity.parentChain as unknown as string[]).reverse();
+			} catch {
+				// Frozen-array mutation may throw depending on runtime — both outcomes fine.
+			}
 		}
-		expect(runner.createContext().agentIdentity.parentChain).toEqual(["P2", "P1"]);
+		expect(runner.createContext().agentIdentity?.parentChain).toEqual(["P2", "P1"]);
 	});
 
 	it("classifies a parentAgentId-only SDK caller by the pre-existing gate inputs (additive)", async () => {
@@ -259,6 +254,54 @@ describe("ExtensionContext agentIdentity", () => {
 					parentChain: [],
 				});
 				expect(registry.get("Tan-1")?.kind).toBe("sub");
+			} finally {
+				await session.dispose();
+			}
+		} finally {
+			authStorage.close();
+			await fsp.rm(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("reports a task-subagent identity for an ordinary taskDepth spawn through the public SDK path", async () => {
+		const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), "pi-identity-sdk-depth-"));
+		const registry = new AgentRegistry();
+		registry.register({ id: MAIN_AGENT_ID, displayName: "Main", kind: "main", session: null });
+		const authStorage = await AuthStorage.create(":memory:");
+		try {
+			// The ordinary executor subagent shape: taskDepth > 0 supplied
+			// without parentTaskPrefix, so only the taskDepth gate marks it.
+			const { session } = await createAgentSession({
+				cwd: path.join(tempDir, "project"),
+				agentDir: path.join(tempDir, "agent"),
+				authStorage,
+				modelRegistry: new ModelRegistry(authStorage),
+				settings: Settings.isolated(),
+				disableExtensionDiscovery: true,
+				skills: [],
+				contextFiles: [],
+				promptTemplates: [],
+				slashCommands: [],
+				toolNames: [],
+				enableMCP: false,
+				enableLsp: false,
+				agentRegistry: registry,
+				agentId: "S1",
+				agentDisplayName: "researcher",
+				parentAgentId: MAIN_AGENT_ID,
+				taskDepth: 1,
+			});
+			try {
+				const identity = session.extensionRunner?.createContext().agentIdentity;
+				expect(identity).toEqual({
+					kind: "sub",
+					depth: 1,
+					agentId: "S1",
+					displayName: "researcher",
+					parentId: MAIN_AGENT_ID,
+					parentChain: [],
+				});
+				expect(registry.get("S1")?.kind).toBe("sub");
 			} finally {
 				await session.dispose();
 			}

--- a/packages/coding-agent/test/extension-context-agent-identity.test.ts
+++ b/packages/coding-agent/test/extension-context-agent-identity.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it } from "bun:test";
+import * as fsp from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { ModelRegistry } from "../src/config/model-registry";
+import { Settings } from "../src/config/settings";
+import { ExtensionRunner, type ExtensionRunnerIdentityInput } from "../src/extensibility/extensions/runner";
+import { AgentRegistry, MAIN_AGENT_ID } from "../src/registry/agent-registry";
+import { createAgentSession } from "../src/sdk";
+import { AuthStorage } from "../src/session/auth-storage";
+
+/**
+ * Minimal construction matching test/extension-context-async-jobs.test.ts;
+ * the trailing identity input is optional, so the fallback test omits it entirely.
+ */
+function makeRunner(identity?: ExtensionRunnerIdentityInput): ExtensionRunner {
+	return new ExtensionRunner(
+		[],
+		{} as never,
+		"/tmp",
+		{ getCwd: () => "/tmp" } as never,
+		{} as never,
+		undefined,
+		undefined,
+		undefined,
+		undefined,
+		identity,
+	);
+}
+
+describe("ExtensionContext agentIdentity", () => {
+	it("falls back to the top-level main identity when constructed without one", () => {
+		const runner = makeRunner();
+
+		expect(runner.createContext().agentIdentity).toEqual({
+			kind: "main",
+			depth: 0,
+			agentId: MAIN_AGENT_ID,
+			displayName: "main",
+			parentChain: [],
+		});
+	});
+
+	it("resolves deeper ancestors from the registry at first access and never re-queries after", () => {
+		const registry = new AgentRegistry();
+		// Direct parent `P1` is snapshotted from the constructor input; only its
+		// own ancestor would come from a registry lookup (none registered yet).
+		const runner = makeRunner({ kind: "sub", depth: 2, agentId: "C2", displayName: "c2", parentId: "P1", registry });
+
+		expect(runner.createContext().agentIdentity.parentChain).toEqual(["P1"]);
+
+		// Registering P1's own parent afterwards does not retro-link the
+		// memoized identity — the chain is resolved once (structural for a live
+		// agent), not re-queried on every access.
+		registry.register({ id: "P1", displayName: "planner", kind: "sub", parentId: "GP", session: null });
+		registry.register({ id: "GP", displayName: "grand", kind: "sub", parentId: MAIN_AGENT_ID, session: null });
+		expect(runner.createContext().agentIdentity.parentChain).toEqual(["P1"]);
+	});
+
+	it("reports a subagent's direct parentId but excludes Main from the parent chain", () => {
+		const registry = new AgentRegistry();
+		const runner = makeRunner({
+			kind: "sub",
+			depth: 1,
+			agentId: "C1",
+			displayName: "researcher",
+			parentId: MAIN_AGENT_ID,
+			registry,
+		});
+
+		expect(runner.createContext().agentIdentity).toEqual({
+			kind: "sub",
+			depth: 1,
+			agentId: "C1",
+			displayName: "researcher",
+			parentId: MAIN_AGENT_ID,
+			parentChain: [],
+		});
+	});
+
+	it("snapshots the chain at first access so registry unregistration or replacement never rewrites it", () => {
+		const registry = new AgentRegistry();
+		registry.register({ id: "P1", displayName: "planner", kind: "sub", parentId: "GP", session: null });
+		registry.register({ id: "GP", displayName: "grandparent", kind: "sub", parentId: MAIN_AGENT_ID, session: null });
+		registry.register({ id: "C1", displayName: "worker", kind: "sub", parentId: "P1", session: null });
+		const runner = makeRunner({
+			kind: "sub",
+			depth: 2,
+			agentId: "C1",
+			displayName: "worker",
+			parentId: "P1",
+			registry,
+		});
+
+		const before = runner.createContext().agentIdentity;
+		expect(before.parentChain).toEqual(["P1", "GP"]);
+
+		// Unregistering an ancestor truncates nothing in the already-snapshotted
+		// chain; re-registering the same id with different ancestry splices in
+		// nothing either. One stable identity per session regardless of when
+		// handlers first read `ctx.agentIdentity`.
+		registry.unregister("GP");
+		registry.unregister("P1");
+		registry.register({ id: "P1", displayName: "imposter", kind: "sub", parentId: "EVIL", session: null });
+		registry.register({ id: "EVIL", displayName: "evil", kind: "sub", parentId: "P1", session: null });
+		const after = runner.createContext().agentIdentity;
+		expect(after.parentChain).toEqual(["P1", "GP"]);
+		expect(before.parentChain).toEqual(["P1", "GP"]);
+	});
+
+	it("resolves the ancestor chain nearest-first through registry parent links, excluding Main", () => {
+		const registry = new AgentRegistry();
+		registry.register({ id: "P1", displayName: "planner", kind: "sub", parentId: MAIN_AGENT_ID, session: null });
+		registry.register({ id: "C2", displayName: "worker", kind: "sub", parentId: "P1", session: null });
+		const identity = makeRunner({
+			kind: "sub",
+			depth: 2,
+			agentId: "C2",
+			displayName: "worker",
+			parentId: "P1",
+			registry,
+		}).createContext().agentIdentity;
+
+		expect(identity.parentId).toBe("P1");
+		expect(identity.depth).toBe(2);
+		expect(identity.parentChain).toEqual(["P1"]);
+	});
+
+	it("terminates on cyclic parent links and never includes the agent's own id", () => {
+		const registry = new AgentRegistry();
+		registry.register({ id: "A", displayName: "a", kind: "sub", parentId: "B", session: null });
+		registry.register({ id: "B", displayName: "b", kind: "sub", parentId: "A", session: null });
+		const identity = makeRunner({
+			kind: "sub",
+			depth: 1,
+			agentId: "A",
+			displayName: "a",
+			parentId: "B",
+			registry,
+		}).createContext().agentIdentity;
+
+		// The cycle A -> B -> A is cut by seeding the walk with A's own id: the
+		// chain is the true ancestors reached before the loop closes ("B"), not
+		// `["B", "A"]` with A reappearing in its own ancestry.
+		expect(identity.parentChain).toEqual(["B"]);
+	});
+	it("hands handlers an immutable identity so one extension cannot corrupt it for others", () => {
+		const registry = new AgentRegistry();
+		registry.register({ id: "P1", displayName: "p1", kind: "sub", parentId: MAIN_AGENT_ID, session: null });
+		registry.register({ id: "P2", displayName: "p2", kind: "sub", parentId: "P1", session: null });
+		const runner = makeRunner({
+			kind: "sub",
+			depth: 2,
+			agentId: "C2",
+			displayName: "c2",
+			parentId: "P2",
+			registry,
+		});
+		const identity = runner.createContext().agentIdentity;
+		expect(identity.parentChain).toEqual(["P2", "P1"]);
+
+		expect(Object.isFrozen(identity)).toBe(true);
+		expect(Object.isFrozen(identity.parentChain)).toBe(true);
+		// A mutation attempt must not corrupt the identity other handlers read
+		// (frozen surfaces may not throw in every runtime, but must never change).
+		try {
+			(identity.parentChain as unknown as string[]).reverse();
+		} catch {
+			// Frozen-array mutation may throw depending on runtime — both outcomes fine.
+		}
+		expect(runner.createContext().agentIdentity.parentChain).toEqual(["P2", "P1"]);
+	});
+
+	it("classifies a parentAgentId-only SDK caller by the pre-existing gate inputs (additive)", async () => {
+		const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), "pi-identity-sdk-link-"));
+		const registry = new AgentRegistry();
+		registry.register({ id: "P1", displayName: "planner", kind: "sub", parentId: MAIN_AGENT_ID, session: null });
+		const authStorage = await AuthStorage.create(":memory:");
+		try {
+			const { session } = await createAgentSession({
+				cwd: path.join(tempDir, "project"),
+				agentDir: path.join(tempDir, "agent"),
+				authStorage,
+				modelRegistry: new ModelRegistry(authStorage),
+				settings: Settings.isolated(),
+				disableExtensionDiscovery: true,
+				skills: [],
+				contextFiles: [],
+				promptTemplates: [],
+				slashCommands: [],
+				toolNames: [],
+				enableMCP: false,
+				enableLsp: false,
+				agentRegistry: registry,
+				agentId: "C1",
+				parentAgentId: "P1",
+			});
+			try {
+				const identity = session.extensionRunner?.createContext().agentIdentity;
+				// Identity strictly observes the pre-existing classification
+				// (`taskDepth > 0 || parentTaskPrefix`): a parentAgentId-only
+				// caller is "main", exactly as on main before this feature.
+				// The linkage itself is still reported via parent fields.
+				expect(identity?.kind).toBe("main");
+				expect(identity?.parentId).toBe("P1");
+				expect(identity?.parentChain).toEqual(["P1"]);
+				// Registry registration keeps the pre-PR classification too.
+				expect(registry.get("C1")?.kind).toBe("main");
+				expect(registry.get("C1")?.displayName).toBe("main");
+			} finally {
+				await session.dispose();
+			}
+		} finally {
+			authStorage.close();
+			await fsp.rm(tempDir, { recursive: true, force: true });
+		}
+	});
+});


### PR DESCRIPTION
Supersedes #10331 (closed): review made the right coherence push, but the fix chosen there — deriving a second `identityKind` classification and registry display names from it — changed observable pre-existing SDK behavior (`AgentRef.kind`, default `displayName`) and broke the PR's own additive-only premise. This reimplementation ships the same feature while keeping every pre-existing observable byte-identical to `main`.

## Argument: minimum additive feature, parity, extensions close the issues

**Parity (why identity belongs on `ctx`)**: every surveyed harness that ships subagents also ships agent identity as a hook-level input — Claude Code (`agent_id`/`agent_type` on every hook), OpenCode/Kilo (`agent` on hook inputs and `context.agent` on custom tools). omp runs subagents but exposes none of it; extensions resort to brittle inference or intercepting the `task` tool call. `ctx.agentIdentity` closes that parity gap.

**Additive**: one optional getter on `ExtensionContext`, one optional trailing `ExtensionRunnerIdentityInput` on `ExtensionRunner`, one optional `AgentSessionConfig.taskDepth`, zero behavior change elsewhere. `kind` **mirrors the pre-existing `agentKind` gate verbatim** (`taskDepth > 0 || parentTaskPrefix`) — identity observes, never reclassifies. Registry `AgentRef.kind`, display-name defaults, and all capability gates are untouched (a `parentAgentId`-only caller behaves exactly as on `main`, with its linkage still visible via `parentId`/`parentChain`). `/tan` forks report their documented special-agent identity: `kind: "sub"` (the same pre-existing gate input), `depth: 0`, `parentId` = job-owning main.

**What this enables extensions to address (individual issues)** — identity fields (`kind === "sub"`, `parentId`, `parentChain`, `agentId`) are the read-side primitive each of these needs as an extension:

- Subagent-aware behavior / lifecycle parity: #5985 (main vs subagent identity on lifecycle handlers), #2834 (main Stop-hook parity), #6520 (extension self-awareness of running agent type), #4753 (Herdr session identity), #7105 (RPC subagent frames), #8711 (subagent health/kill switch), #6827 (per-session main agent id).
- Agent-level policy/safety (guarded by a `tool_call` policy extension): #10164 (dangerous commands from subagents), #8764 (permission ask mode for subagents), #3091 (subagent approvalMode bypass), #2110 (least-privilege tool surfaces), #7061 (unknown tool names silently dropped), #10124 (eval bypass in non-interactive subagents), #7294 (compound-command approval for headless subagents).
- Attribution / telemetry (identity as join key): #7558 (per-tool-call parent/duration attribution), #5773 (subagent model usage in /stats), #9332 (main vs subagent cost split), #7802 (per-session cost caps counting children), #7860 (context ledger attribution), #8259 (structured spawn event), #4736/#6546 (HUD rows labeled by agent), #2574 (`ctx.agents.spawn` primitive).

Identity alone does not *close* these; it unblocks them to be implemented as extensions instead of core growth (same scoping #10228 landed on).

## Semantics

`{ kind, depth, agentId, displayName, parentId?, parentChain }`, read lazily like `ctx.model` — resolved once on first access, deeply frozen and memoized per runner. The parent chain walks registry `parentId` links, cycle-guarded (self-seeded), nearest-first, excluding `"Main"`. Snapshot is stable: later `register`/`unregister` cannot rewrite an identity already handed out. Runner-less SDK sessions derive a truthful fallback from session state (empty `parentChain` — no registry handle); runners constructed without identity input (provider-only hosts, tests) report a top-level identity.

Refs #10228

- [x] `bun check` green
- [x] `test/extension-context-agent-identity.test.ts` 9/9 (incl. `/tan` fork + linkage-only SDK caller through the public path), runner/config/binding buckets 98/98
- [x] Diff vs `main`: 8 files, +461/−2 (both deletions non-behavioral: type-only import rewrites)
