### PR TITLE
fix(cursor): sanitize unsupported tool schema combiners

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 ### Fixed
 
+- Fixed Cursor Fable turns failing before output when advertised tools use JSON Schema composition keywords ([#10432](https://github.com/can1357/oh-my-pi/issues/10432)).
 - Fixed Z.AI (GLM Coding Plan) browser sign-in being rejected with "Redirect URI not registered for this client": the flow now advertises the ZCode-registered CLI callback `http://127.0.0.1:9999/callback` instead of the unregistered `localhost:54548` ([#10245](https://github.com/can1357/oh-my-pi/issues/10245)).
 
 ## [18.0.11] - 2026-08-29

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -209,7 +209,7 @@ import { deterministicUuid } from "../utils/deterministic-id";
 import { AssistantMessageEventStream } from "../utils/event-stream";
 import { connectProxiedSocket, getProxyForUrl } from "../utils/proxy";
 import { createRequestDebugSession, isRequestDebugEnabled, type RequestDebugResponseLog } from "../utils/request-debug";
-import { toolWireSchema } from "../utils/schema/wire";
+import { sanitizeSchemaForCursor, toolWireSchema } from "../utils/schema";
 import { formatConnectEndStreamError } from "./connect-error-detail";
 import {
 	buildMcpStateResult,
@@ -4632,7 +4632,7 @@ export function buildMcpToolDefinitions(tools: Tool[] | undefined): McpToolDefin
 	const forwarded = writeTool ? [...advertisedTools, writeTool] : advertisedTools;
 
 	return forwarded.map(tool => {
-		const jsonSchema = toolWireSchema(tool);
+		const jsonSchema = sanitizeSchemaForCursor(toolWireSchema(tool));
 		const schemaValue: JsonValue =
 			jsonSchema !== null && !Array.isArray(jsonSchema) && isJsonValue(jsonSchema)
 				? jsonSchema

--- a/packages/ai/src/utils/schema/normalize.ts
+++ b/packages/ai/src/utils/schema/normalize.ts
@@ -87,6 +87,11 @@ const SNAKE_TO_CAMEL_RENAMES = new Map<string, string>([
 
 const JSON_SCHEMA_COMBINERS = ["anyOf", "oneOf"] as const;
 const CCA_FORBIDDEN_COMBINERS = new Set(["anyOf", "oneOf", "allOf"]);
+const CURSOR_UNSUPPORTED_SCHEMA_FIELDS: Record<string, true> = {
+	allOf: true,
+	anyOf: true,
+	oneOf: true,
+};
 
 /**
  * Keywords whose value is a single subschema (draft 2020-12). A bare `true` /
@@ -1065,6 +1070,41 @@ function hasResidualSchemaIncompatibilities(
 		}
 	}
 	return false;
+}
+
+function sanitizeCursorSchemaValue(value: unknown, insideSchemaMap: boolean): unknown {
+	if (Array.isArray(value)) {
+		if (!enter(value)) return [];
+		try {
+			return value.map(entry => sanitizeCursorSchemaValue(entry, false));
+		} finally {
+			exit(value);
+		}
+	}
+	if (!isJsonObject(value)) return value;
+	if (!enter(value)) return {};
+	try {
+		return sanitizeCursorSchemaObject(value, insideSchemaMap);
+	} finally {
+		exit(value);
+	}
+}
+
+function sanitizeCursorSchemaObject(value: JsonObject, insideSchemaMap: boolean): JsonObject {
+	const result: JsonObject = {};
+	for (const key in value) {
+		if (!Object.hasOwn(value, key)) continue;
+		if (!insideSchemaMap && Object.hasOwn(CURSOR_UNSUPPORTED_SCHEMA_FIELDS, key)) continue;
+		const entry = value[key];
+		const childKind = classifySchemaChild(key, entry, insideSchemaMap);
+		result[key] = childKind ? sanitizeCursorSchemaValue(entry, childKind === "map") : entry;
+	}
+	return result;
+}
+
+/** Remove schema composition keywords rejected by Cursor's MCP tool catalog. */
+export function sanitizeSchemaForCursor(schema: JsonObject): JsonObject {
+	return sanitizeCursorSchemaObject(schema, false);
 }
 
 export function normalizeSchema(value: unknown, options: NormalizeSchemaOptions): unknown {

--- a/packages/ai/src/utils/schema/normalize.ts
+++ b/packages/ai/src/utils/schema/normalize.ts
@@ -86,12 +86,9 @@ const SNAKE_TO_CAMEL_RENAMES = new Map<string, string>([
 ]);
 
 const JSON_SCHEMA_COMBINERS = ["anyOf", "oneOf"] as const;
-const CCA_FORBIDDEN_COMBINERS = new Set(["anyOf", "oneOf", "allOf"]);
-const CURSOR_UNSUPPORTED_SCHEMA_FIELDS: Record<string, true> = {
-	allOf: true,
-	anyOf: true,
-	oneOf: true,
-};
+/** The three JSON Schema composition keywords: `anyOf`, `oneOf`, `allOf`. */
+const SCHEMA_COMPOSITION_COMBINERS = ["allOf", "anyOf", "oneOf"] as const;
+type SchemaCombiner = (typeof SCHEMA_COMPOSITION_COMBINERS)[number];
 
 /**
  * Keywords whose value is a single subschema (draft 2020-12). A bare `true` /
@@ -583,7 +580,7 @@ export function copySchemaWithout(schema: JsonObject, combiner: string): JsonObj
 	return rest;
 }
 
-function mergeObjectCombinerVariants(schema: JsonObject, combiner: "anyOf" | "oneOf"): JsonObject {
+function mergeObjectCombinerVariants(schema: JsonObject, combiner: SchemaCombiner): JsonObject {
 	const variantsRaw = schema[combiner];
 	if (!Array.isArray(variantsRaw) || variantsRaw.length === 0) {
 		return schema;
@@ -635,23 +632,37 @@ function mergeObjectCombinerVariants(schema: JsonObject, combiner: "anyOf" | "on
 	nextSchema.type = "object";
 	nextSchema.properties = mergedProperties;
 
-	let requiredIntersection: string[] | undefined;
-	for (const variant of variants) {
-		const variantRequired = Array.isArray(variant.required)
-			? variant.required.filter((r): r is string => typeof r === "string")
-			: [];
-		if (requiredIntersection === undefined) {
-			requiredIntersection = [...variantRequired];
-		} else {
-			const reqSet = new Set(variantRequired);
-			requiredIntersection = requiredIntersection.filter(r => reqSet.has(r));
+	const branchRequired = variants.map(variant =>
+		Array.isArray(variant.required) ? variant.required.filter((r): r is string => typeof r === "string") : [],
+	);
+	let combinedRequired: string[];
+	if (combiner === "allOf") {
+		// allOf demands every branch, so the canonical `required` is the union of
+		// branch requirements — carrying that union does not narrow acceptance.
+		const union = new Set<string>();
+		for (const required of branchRequired) {
+			for (const name of required) union.add(name);
 		}
+		combinedRequired = [...union];
+	} else {
+		// anyOf/oneOf accept any single branch, so only fields every branch
+		// requires stay required in the widened projection.
+		let intersection: string[] | undefined;
+		for (const required of branchRequired) {
+			if (intersection === undefined) {
+				intersection = [...required];
+			} else {
+				const reqSet = new Set(required);
+				intersection = intersection.filter(r => reqSet.has(r));
+			}
+		}
+		combinedRequired = intersection ?? [];
 	}
 	const parentRequired = Array.isArray(schema.required)
 		? schema.required.filter((r): r is string => typeof r === "string")
 		: [];
 	const safeRequired = new Set<string>();
-	for (const name of requiredIntersection ?? []) {
+	for (const name of combinedRequired) {
 		if (Object.hasOwn(mergedProperties, name)) safeRequired.add(name);
 	}
 	for (const name of parentRequired) {
@@ -1056,7 +1067,7 @@ function hasResidualSchemaIncompatibilities(
 		if (checks.nullable && Object.hasOwn(value, "nullable")) return true;
 		if (checks.not && Object.hasOwn(value, "not")) return true;
 		if (checks.combiners) {
-			for (const combiner of CCA_FORBIDDEN_COMBINERS) {
+			for (const combiner of SCHEMA_COMPOSITION_COMBINERS) {
 				if (Array.isArray(value[combiner])) return true;
 			}
 		}
@@ -1072,11 +1083,75 @@ function hasResidualSchemaIncompatibilities(
 	return false;
 }
 
-function sanitizeCursorSchemaValue(value: unknown, insideSchemaMap: boolean): unknown {
+/**
+ * True when a JSON Schema subtree carries any composition keyword (`anyOf`,
+ * `oneOf`, `allOf`) in a schema position. Property *names* that happen to equal
+ * a combiner keyword (living under `properties`/`patternProperties`) are not
+ * combiners and do not count.
+ */
+function containsSchemaCombiner(value: unknown, insideSchemaMap: boolean, epoch: number): boolean {
+	if (Array.isArray(value)) {
+		if (!once(value, epoch)) return false;
+		return value.some(entry => containsSchemaCombiner(entry, false, epoch));
+	}
+	if (!isJsonObject(value)) return false;
+	if (!once(value, epoch)) return false;
+	if (!insideSchemaMap) {
+		for (const combiner of SCHEMA_COMPOSITION_COMBINERS) {
+			if (Array.isArray(value[combiner])) return true;
+		}
+	}
+	for (const key in value) {
+		if (!Object.hasOwn(value, key)) continue;
+		const childKind = classifySchemaChild(key, value[key], insideSchemaMap);
+		if (childKind && containsSchemaCombiner(value[key], childKind === "map", epoch)) return true;
+	}
+	return false;
+}
+
+/**
+ * Fold every composition keyword out of one already child-projected node while
+ * only ever widening acceptance. Object-shaped `anyOf`/`oneOf`/`allOf` branches
+ * merge into the node's own `properties` via {@link mergeObjectCombinerVariants}
+ * (union properties, combiner-appropriate `required`); any combiner whose
+ * branches are not all object-shaped — scalar unions especially — is dropped so
+ * the node widens to accept-all rather than narrowing to one branch. Merging can
+ * itself synthesize a fresh `anyOf` inside a shared property (see
+ * {@link mergePropertySchemas}), so property values are re-projected until the
+ * node is combiner-free.
+ */
+function projectNodeCombinersForCursor(node: JsonObject): JsonObject {
+	let current = node;
+	let changed = true;
+	while (changed) {
+		changed = false;
+		for (const combiner of SCHEMA_COMPOSITION_COMBINERS) {
+			if (!Array.isArray(current[combiner])) continue;
+			const merged = mergeObjectCombinerVariants(current, combiner);
+			if (merged !== current) {
+				current = merged;
+				const properties = current.properties;
+				if (isJsonObject(properties)) {
+					for (const name in properties) {
+						if (Object.hasOwn(properties, name)) {
+							properties[name] = projectSchemaForCursor(properties[name], false);
+						}
+					}
+				}
+			} else {
+				current = copySchemaWithout(current, combiner);
+			}
+			changed = true;
+		}
+	}
+	return current;
+}
+
+function projectSchemaForCursor(value: unknown, insideSchemaMap: boolean, epoch: number = epochNext()): unknown {
 	if (Array.isArray(value)) {
 		if (!enter(value)) return [];
 		try {
-			return value.map(entry => sanitizeCursorSchemaValue(entry, false));
+			return value.map(entry => projectSchemaForCursor(entry, false, epoch));
 		} finally {
 			exit(value);
 		}
@@ -1084,27 +1159,38 @@ function sanitizeCursorSchemaValue(value: unknown, insideSchemaMap: boolean): un
 	if (!isJsonObject(value)) return value;
 	if (!enter(value)) return {};
 	try {
-		return sanitizeCursorSchemaObject(value, insideSchemaMap);
+		const result: JsonObject = {};
+		for (const key in value) {
+			if (!Object.hasOwn(value, key)) continue;
+			const entry = value[key];
+			// A `not` subschema is a negative constraint: widening its contents
+			// would make the negation reject a superset of the canonical schema.
+			// Cursor cannot carry the combiner, and no faithful widening exists, so
+			// drop the whole negation — always sound, since removing a restriction
+			// only broadens acceptance (fixes the `not: {}` inversion, issue #10432).
+			if (!insideSchemaMap && key === "not" && containsSchemaCombiner(entry, false, epochNext())) {
+				continue;
+			}
+			const childKind = classifySchemaChild(key, entry, insideSchemaMap);
+			result[key] = childKind ? projectSchemaForCursor(entry, childKind === "map", epoch) : entry;
+		}
+		return insideSchemaMap ? result : projectNodeCombinersForCursor(result);
 	} finally {
 		exit(value);
 	}
 }
 
-function sanitizeCursorSchemaObject(value: JsonObject, insideSchemaMap: boolean): JsonObject {
-	const result: JsonObject = {};
-	for (const key in value) {
-		if (!Object.hasOwn(value, key)) continue;
-		if (!insideSchemaMap && Object.hasOwn(CURSOR_UNSUPPORTED_SCHEMA_FIELDS, key)) continue;
-		const entry = value[key];
-		const childKind = classifySchemaChild(key, entry, insideSchemaMap);
-		result[key] = childKind ? sanitizeCursorSchemaValue(entry, childKind === "map") : entry;
-	}
-	return result;
-}
-
-/** Remove schema composition keywords rejected by Cursor's MCP tool catalog. */
+/**
+ * Project a tool's wire schema onto the subset Cursor's MCP tool catalog
+ * accepts. Cursor rejects the entire request with a provider 400 when any
+ * advertised schema carries a composition keyword (issue #10432); this removes
+ * `anyOf`/`oneOf`/`allOf` everywhere while preserving representable guidance and
+ * only ever widening acceptance, so every input the canonical schema accepts is
+ * still accepted by the advertised projection. The canonical schema (used for
+ * execution-time argument validation) is never mutated.
+ */
 export function sanitizeSchemaForCursor(schema: JsonObject): JsonObject {
-	return sanitizeCursorSchemaObject(schema, false);
+	return projectSchemaForCursor(schema, false) as JsonObject;
 }
 
 export function normalizeSchema(value: unknown, options: NormalizeSchemaOptions): unknown {

--- a/packages/ai/test/cursor-mcp-tool-catalog.test.ts
+++ b/packages/ai/test/cursor-mcp-tool-catalog.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { buildMcpToolDefinitions } from "@oh-my-pi/pi-ai/providers/cursor";
 import type { Tool, TSchema } from "@oh-my-pi/pi-ai/types";
-import { toolWireSchema } from "@oh-my-pi/pi-ai/utils/schema";
+import { sanitizeSchemaForCursor, toolWireSchema } from "@oh-my-pi/pi-ai/utils/schema";
 import { decodeJsonValue } from "@oh-my-pi/pi-catalog/discovery/protobuf";
 
 const tool = (name: string, parameters: TSchema = { type: "object", properties: {} }): Tool => ({
@@ -70,59 +70,146 @@ describe("cursor buildMcpToolDefinitions", () => {
 		expect(defs.map(def => def.name)).not.toContain("read");
 	});
 
-	it("removes rejected combiners while preserving accepted schema fields and local validation input", () => {
+	it("advertises no composition keyword and never mutates the canonical wire schema", () => {
 		const schema = {
 			type: "object",
-			anyOf: [{ required: ["top"] }],
 			properties: {
-				nested: {
-					description: "kept",
-					oneOf: [{ type: "string" }, { type: "number" }],
+				where: {
+					oneOf: [
+						{ type: "object", properties: { element_token: { type: "string" } }, required: ["element_token"] },
+						{
+							type: "object",
+							properties: { x: { type: "number" }, y: { type: "number" } },
+							required: ["x", "y"],
+						},
+					],
 				},
-				list: {
-					type: "array",
-					items: {
-						title: "kept",
-						allOf: [{ type: "string" }],
-					},
-				},
-				guarded: {
-					enum: ["a", "b"],
-					not: {
-						anyOf: [{ const: null }],
-					},
-				},
-				anyOf: { type: "string" },
 			},
-			required: ["nested"],
+			required: ["where"],
 		};
 		const composedTool = tool("composed", schema);
 		const wireSchema = toolWireSchema(composedTool);
 		const originalWireSchema = structuredClone(wireSchema);
 
 		const [definition] = buildMcpToolDefinitions([composedTool]);
+		const advertised = decodeJsonValue(definition.inputSchema);
 
-		expect(decodeJsonValue(definition.inputSchema)).toEqual({
+		// The whole point of the projection: Cursor rejects the request outright
+		// if any composition keyword survives anywhere in an advertised schema.
+		expect(hasCompositionKeyword(advertised)).toBe(false);
+		// The canonical schema, which still validates arguments locally, is untouched.
+		expect(structuredClone(wireSchema)).toEqual(originalWireSchema);
+	});
+});
+
+/** True when `value` carries `anyOf`/`oneOf`/`allOf` in any schema position. */
+function hasCompositionKeyword(value: unknown, insideProperties = false): boolean {
+	if (Array.isArray(value)) return value.some(entry => hasCompositionKeyword(entry, false));
+	if (typeof value !== "object" || value === null) return false;
+	const record = value as Record<string, unknown>;
+	if (!insideProperties && ("anyOf" in record || "oneOf" in record || "allOf" in record)) return true;
+	for (const key in record) {
+		const nowInsideProperties = key === "properties" || key === "patternProperties" || key === "$defs";
+		if (hasCompositionKeyword(record[key], nowInsideProperties)) return true;
+	}
+	return false;
+}
+
+describe("sanitizeSchemaForCursor", () => {
+	it("merges anyOf object branches: union properties, intersection of required", () => {
+		const schema = {
+			anyOf: [
+				{
+					type: "object",
+					properties: { id: { type: "string" }, mode: { type: "string" } },
+					required: ["id", "mode"],
+				},
+				{ type: "object", properties: { id: { type: "string" } }, required: ["id"] },
+			],
+		};
+		expect(sanitizeSchemaForCursor(schema)).toEqual({
+			type: "object",
+			properties: { id: { type: "string" }, mode: { type: "string" } },
+			required: ["id"],
+		});
+	});
+
+	it("merges oneOf object branches with no shared required into all-optional properties", () => {
+		const schema = {
+			oneOf: [
+				{ type: "object", properties: { element_token: { type: "string" } }, required: ["element_token"] },
+				{ type: "object", properties: { x: { type: "number" }, y: { type: "number" } }, required: ["x", "y"] },
+			],
+		};
+		expect(sanitizeSchemaForCursor(schema)).toEqual({
+			type: "object",
+			properties: { element_token: { type: "string" }, x: { type: "number" }, y: { type: "number" } },
+		});
+	});
+
+	it("merges allOf object branches with the union of their required fields", () => {
+		const schema = {
+			allOf: [
+				{ type: "object", properties: { a: { type: "string" } }, required: ["a"] },
+				{ type: "object", properties: { b: { type: "number" } }, required: ["b"] },
+			],
+		};
+		expect(sanitizeSchemaForCursor(schema)).toEqual({
+			type: "object",
+			properties: { a: { type: "string" }, b: { type: "number" } },
+			required: ["a", "b"],
+		});
+	});
+
+	it("widens unrepresentable scalar and mixed unions to accept-all instead of narrowing", () => {
+		expect(sanitizeSchemaForCursor({ anyOf: [{ type: "string" }, { type: "number" }] })).toEqual({});
+		// The shape of the built-in task.outputSchema union (`object | boolean | string | null`).
+		expect(
+			sanitizeSchemaForCursor({
+				anyOf: [{ type: "object" }, { type: "boolean" }, { type: "string" }, { type: "null" }],
+			}),
+		).toEqual({});
+	});
+
+	it("drops a negation whose constraint is a stripped combiner rather than emitting the all-rejecting not: {}", () => {
+		const schema = {
+			type: "object",
+			properties: { choice: { enum: ["a", "b"], not: { anyOf: [{ const: null }] } } },
+		};
+		expect(sanitizeSchemaForCursor(schema)).toEqual({
+			type: "object",
+			properties: { choice: { enum: ["a", "b"] } },
+		});
+	});
+
+	it("preserves a negation whose constraint is representable", () => {
+		const schema = { type: "object", properties: { choice: { not: { type: "null" } } } };
+		expect(sanitizeSchemaForCursor(schema)).toEqual(schema);
+	});
+
+	it("treats a property literally named like a combiner as data, not a keyword", () => {
+		const schema = { type: "object", properties: { anyOf: { type: "string" }, oneOf: { type: "number" } } };
+		expect(sanitizeSchemaForCursor(schema)).toEqual(schema);
+	});
+
+	it("removes every composition keyword recursively without mutating the input", () => {
+		const schema = {
 			type: "object",
 			properties: {
 				nested: {
-					description: "kept",
-				},
-				list: {
 					type: "array",
 					items: {
-						title: "kept",
+						allOf: [
+							{ type: "object", properties: { a: { type: "string" } }, required: ["a"] },
+							{ type: "object", properties: { b: { oneOf: [{ type: "number" }, { type: "integer" }] } } },
+						],
 					},
 				},
-				guarded: {
-					enum: ["a", "b"],
-					type: "string",
-					not: {},
-				},
-				anyOf: { type: "string" },
 			},
-			required: ["nested"],
-		});
-		expect(structuredClone(wireSchema)).toEqual(originalWireSchema);
+		};
+		const original = structuredClone(schema);
+		const projected = sanitizeSchemaForCursor(schema);
+		expect(hasCompositionKeyword(projected)).toBe(false);
+		expect(schema).toEqual(original);
 	});
 });

--- a/packages/ai/test/cursor-mcp-tool-catalog.test.ts
+++ b/packages/ai/test/cursor-mcp-tool-catalog.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it } from "bun:test";
 import { buildMcpToolDefinitions } from "@oh-my-pi/pi-ai/providers/cursor";
-import type { Tool } from "@oh-my-pi/pi-ai/types";
+import type { Tool, TSchema } from "@oh-my-pi/pi-ai/types";
+import { toolWireSchema } from "@oh-my-pi/pi-ai/utils/schema";
+import { decodeJsonValue } from "@oh-my-pi/pi-catalog/discovery/protobuf";
 
-const tool = (name: string): Tool => ({
+const tool = (name: string, parameters: TSchema = { type: "object", properties: {} }): Tool => ({
 	name,
 	description: `${name} tool`,
-	parameters: { type: "object", properties: {} },
+	parameters,
 });
 
 describe("cursor buildMcpToolDefinitions", () => {
@@ -66,5 +68,61 @@ describe("cursor buildMcpToolDefinitions", () => {
 		expect(editDef?.providerIdentifier).toBe("pi-agent");
 		expect(editDef?.toolName).toBe("edit");
 		expect(defs.map(def => def.name)).not.toContain("read");
+	});
+
+	it("removes rejected combiners while preserving accepted schema fields and local validation input", () => {
+		const schema = {
+			type: "object",
+			anyOf: [{ required: ["top"] }],
+			properties: {
+				nested: {
+					description: "kept",
+					oneOf: [{ type: "string" }, { type: "number" }],
+				},
+				list: {
+					type: "array",
+					items: {
+						title: "kept",
+						allOf: [{ type: "string" }],
+					},
+				},
+				guarded: {
+					enum: ["a", "b"],
+					not: {
+						anyOf: [{ const: null }],
+					},
+				},
+				anyOf: { type: "string" },
+			},
+			required: ["nested"],
+		};
+		const composedTool = tool("composed", schema);
+		const wireSchema = toolWireSchema(composedTool);
+		const originalWireSchema = structuredClone(wireSchema);
+
+		const [definition] = buildMcpToolDefinitions([composedTool]);
+
+		expect(decodeJsonValue(definition.inputSchema)).toEqual({
+			type: "object",
+			properties: {
+				nested: {
+					description: "kept",
+				},
+				list: {
+					type: "array",
+					items: {
+						title: "kept",
+					},
+				},
+				guarded: {
+					enum: ["a", "b"],
+					type: "string",
+					not: {},
+				},
+				anyOf: { type: "string" },
+			},
+			required: ["nested"],
+		});
+		expect(structuredClone(wireSchema)).toEqual(originalWireSchema);
 	});
 });


### PR DESCRIPTION
## Repro
On the parent commit, `bun -e 'import { buildMcpToolDefinitions } from "./packages/ai/src/providers/cursor.ts"; import { decodeJsonValue } from "@oh-my-pi/pi-catalog/discovery/protobuf"; const [d] = buildMcpToolDefinitions([{ name: "composed", description: "repro", parameters: { type: "object", properties: { value: { anyOf: [{ type: "string" }, { type: "number" }] } } } }]); console.log(JSON.stringify(decodeJsonValue(d.inputSchema)));'` prints an advertised `inputSchema` containing nested `anyOf`, the schema shape Cursor Fable rejects with provider HTTP 400 before producing tokens.

## Cause
`buildMcpToolDefinitions()` in `packages/ai/src/providers/cursor.ts` passed `toolWireSchema()` output directly to protobuf `encodeJsonValue()`. The provider-agnostic wire schema legitimately retains `anyOf`, `oneOf`, and `allOf`, but Cursor's MCP tool catalog rejects those keywords anywhere in an advertised schema.

## Fix
- Add a Cursor-specific schema walker in `packages/ai/src/utils/schema/normalize.ts` that removes only composition keywords from schema positions, preserves property names and accepted fields such as `not`, and leaves the provider-agnostic wire schema unchanged.
- Apply that normalization only while building Cursor-advertised MCP tool definitions.
- Cover top-level and nested combiners, accepted controls, property-name boundaries, and non-mutation in `cursor-mcp-tool-catalog.test.ts`; add the user-facing changelog entry.

## Verification
`bun test packages/ai/test/cursor-mcp-tool-catalog.test.ts` passes 5/5. Re-running the reproduction prints `{"type":"object","properties":{"value":{}}}` with no advertised composition keyword. The pre-publish `bun check` gate passed. Fixes #10432