### PR TITLE
fix(prompts): make hub steering interrupts require a user-facing reply

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Fixed an issue where custom model overrides were lost during configuration updates
 - Fixed "Please use nerdfont" notification incorrectly persisting after theme configuration
 - Fixed sampling parameter errors for newer Anthropic models (Opus 4.7+, Sonnet 5+)
+- Fixed agents in a `hub` wait loop leaving a user's message unanswered: the tool prompt now separates a user steering message from the pollable wake reasons, and states that only a plain text block reaches the user ([#10437](https://github.com/can1357/oh-my-pi/pull/10437)).
 
 ## [18.0.11] - 2026-08-29
 

--- a/packages/coding-agent/src/prompts/tools/hub.md
+++ b/packages/coding-agent/src/prompts/tools/hub.md
@@ -11,7 +11,7 @@ Background jobs auto-deliver when they finish. You NEVER need to poll; if `jobs`
 - **Format**: plain prose ONLY. No JSON status objects. Share paths via `local://`/`artifact://` URLs, not pasted blobs.
 - **`wait`**: use ONLY when completely blocked with no other work. Returns on the FIRST of: an incoming message, a watched job finishing, the wait window elapsing, or a steering interrupt — NOT when all jobs finish; re-issue to keep waiting.
   - Bare `wait` watches every running job AND incoming messages. NEVER pass an array of every running ID; `ids` narrows to specific jobs, `from` to one peer (or use `await: true` on send).
-  - A steering interrupt is the user speaking, not a wake reason to poll past: answer in a text block BEFORE re-issuing `wait`.
+  - A **user** message arriving as steering is not a wake reason to poll past: answer it in a text block BEFORE re-issuing `wait`. Parent/peer steering is answered with `send`; advisor and budget steers need no reply.
 - **`inbox`**: drain queued messages without blocking.
 - **`cancel`**: kill background jobs by `ids` when they have hung, stalled, or are no longer needed. Returns immediately.
 - **`jobs`**: status snapshot of every job without waiting. A settled row consumes auto-delivery. Also names running subagents with no job entry — coordinate with those via `send`.

--- a/packages/coding-agent/src/prompts/tools/hub.md
+++ b/packages/coding-agent/src/prompts/tools/hub.md
@@ -5,11 +5,13 @@ Use `op: "list"` to discover live peers. Default is running+idle plus running/id
 
 Background jobs auto-deliver when they finish. You NEVER need to poll; if `jobs`/`wait` observes a settled job first, that snapshot is the delivery and suppresses duplicate `async-result`.
 
+- **The user is NOT a peer.** `Main` answers the user ONLY in a plain text block; a `send` shows them a 2-line preview at most. Thinking is not output either.
 - **`send`** (with `to`): fire-and-forget, NEVER blocks. Delivery receipts (`delivered`/`failed`) immediate; `failed` → peer gone, don't retry.
   Sending wakes `idle`/`parked` peers. Answering: lead with answer, NEVER quote, set `replyTo`.
 - **Format**: plain prose ONLY. No JSON status objects. Share paths via `local://`/`artifact://` URLs, not pasted blobs.
 - **`wait`**: use ONLY when completely blocked with no other work. Returns on the FIRST of: an incoming message, a watched job finishing, the wait window elapsing, or a steering interrupt — NOT when all jobs finish; re-issue to keep waiting.
   - Bare `wait` watches every running job AND incoming messages. NEVER pass an array of every running ID; `ids` narrows to specific jobs, `from` to one peer (or use `await: true` on send).
+  - A steering interrupt is the user speaking, not a wake reason to poll past: answer in a text block BEFORE re-issuing `wait`.
 - **`inbox`**: drain queued messages without blocking.
 - **`cancel`**: kill background jobs by `ids` when they have hung, stalled, or are no longer needed. Returns immediately.
 - **`jobs`**: status snapshot of every job without waiting. A settled row consumes auto-delivery. Also names running subagents with no job entry — coordinate with those via `send`.


### PR DESCRIPTION
Agents in a `hub` wait loop repeatedly fail to answer the user, then report — accurately, from their own context — that they already did. Two lines in `hub.md` make that the locally correct behavior.

## Steering is listed as one wake reason among four

```
- **`wait`**: ... Returns on the FIRST of: an incoming message, a watched job
  finishing, the wait window elapsing, or a steering interrupt — NOT when all
  jobs finish; re-issue to keep waiting.
```

Every wake reason carries the same instruction: re-issue. Nothing marks steering as categorically different — that a human is now blocked on a text reply. Agents follow it literally: steer, wait returns, re-issue, repeat.

## Every channel is framed as peer messaging

`hub.md` opens with `Main agent is Main` and demonstrates `send → "Main"`, but never states that the main agent's only channel to the user is a plain text block. Inside a loop where every act of communication is a `send`, treating the user as one more peer is the consistent move — so user-facing answers get addressed to a peer instead.

## Observed

From a session bundle, after the user asked a direct question mid-wait, the agent's next four calls were `wait`, `send`, `wait`, `wait`. The `send` was addressed to a subagent and contained:

> "That's the clear explained need the user demanded — I'll surface it for sign-off."

The user asked twice more ("Can you answer my question?", "Hello?") before any text block appeared. When one finally did, it opened by stating the question had already been answered three times. Nothing in the transcript or the raw SSE capture supports that, but it is a fair inference from the agent's own context: the reasoning happened, and with thinking now encrypted for most models it is replayed to the model and invisible to the user. In that bundle: 157 `thinking_delta` events against 24 `text_delta`.

So the agent is not confused about what it thought. It is confused about what reached the user — and the prompt does not draw that line.

## Change

Two lines:

- a `wait` sub-bullet separating a **user** message arriving as steering from the pollable wake reasons and requiring a text reply before re-issuing. Steering also carries advisor notes, goal-budget steers, and parent-to-subagent IRC, so the rule is scoped: parent/peer steering is answered with `send`, and internal advisories carry no reply obligation.
- a `Messaging & Jobs` bullet stating the user is not a peer: `Main` reaches them only through a text block, a `send` shows at most a 2-line preview, and reasoning an answer through does not deliver it

Prompt-only; no code paths touched. Changelog entry added under `## [Unreleased]` / `### Fixed`.

