### PR TITLE
fix(tui): preserve task boards across focus rebuilds

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### Fixed
 
+- Fixed returning from a focused Agent Hub session collapsing live task boards to summary rows ([#10446](https://github.com/can1357/oh-my-pi/issues/10446)).
 - Fixed an issue where custom model overrides were lost during configuration updates
 - Fixed "Please use nerdfont" notification incorrectly persisting after theme configuration
 - Fixed sampling parameter errors for newer Anthropic models (Opus 4.7+, Sonnet 5+)

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -1084,6 +1084,19 @@ export class EventController {
 		if (turnStartedAt !== undefined) this.#turnStartedAt = turnStartedAt;
 	}
 
+	/**
+	 * Re-register parked background task cards after a transcript rebuild so a
+	 * detached task's replayed and live progress frames keep routing to the
+	 * preserved component. Focus attach clears {@link #backgroundTaskCallIds}
+	 * via {@link resetTranscriptAnchors} before the rebuild repopulates it.
+	 * Ids whose component did not survive into `pendingTools` are skipped.
+	 */
+	markBackgroundTaskCalls(toolCallIds: Iterable<string>): void {
+		for (const toolCallId of toolCallIds) {
+			if (this.ctx.pendingTools.has(toolCallId)) this.#backgroundTaskCallIds.add(toolCallId);
+		}
+	}
+
 	async #handleNotice(event: Extract<AgentSessionEvent, { type: "notice" }>): Promise<void> {
 		const message = event.source ? `${event.source}: ${event.message}` : event.message;
 		if (event.level === "error") {

--- a/packages/coding-agent/src/modes/controllers/session-focus-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/session-focus-controller.ts
@@ -119,6 +119,13 @@ export class SessionFocusController {
 		this.ctx.statusLine.setSession(target, this.#focusedAgentId);
 		await this.ctx.renderInitialMessages({ clearTerminalHistory: true });
 		if (generation !== this.#attachGeneration) return false;
+		// Partial tool results are display events, not persisted messages. Replay
+		// each target's latest snapshot after rebuilding so focus navigation does
+		// not collapse a live task board back to its bare call arguments (#10446).
+		for (const event of target.activeToolExecutionUpdates()) {
+			await this.ctx.eventController.handleEvent(event);
+			if (generation !== this.#attachGeneration) return false;
+		}
 		// Retarget the sticky Todo HUD too. While a subagent is focused the main
 		// session's `todo` completions never reach this controller; returning to
 		// main must therefore reload its current state instead of retaining the

--- a/packages/coding-agent/src/modes/utils/ui-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/ui-helpers.ts
@@ -454,6 +454,11 @@ export class UiHelpers {
 			todoSnapshot = null;
 			previous.seal();
 		};
+		// Detached task calls persist their initial `async.state === "running"`
+		// result, but the job keeps streaming progress afterwards. Parked here
+		// (not finalized) so replayed and live frames still route to the card;
+		// the ids are handed back to the controller after the loop (#10447).
+		const backgroundTaskCallIds = new Set<string>();
 		const messages = sessionContext.messages;
 		const count = messages.length;
 		for (let i = 0; i < count; i++) {
@@ -666,24 +671,35 @@ export class UiHelpers {
 				// Match tool results to pending tool components
 				const component = this.ctx.pendingTools.get(message.toolCallId);
 				if (component) {
-					component.updateResult(message, false, message.toolCallId);
-					this.ctx.pendingTools.delete(message.toolCallId);
-					if (
-						message.toolName === "hub" &&
-						component instanceof ToolExecutionComponent &&
-						component.isDisplaceableBlock()
-					) {
-						waitingPoll = component;
-					} else if (
-						message.toolName === "todo" &&
-						component instanceof ToolExecutionComponent &&
-						component.canBeDisplacedBy("todo")
-					) {
-						// A successful todo result supersedes the prior live snapshot. Failed
-						// follow-ups return false from canBeDisplacedBy("todo"), so the
-						// last-good panel stays on screen.
-						resolveTodoSnapshot("todo");
-						todoSnapshot = component;
+					const asyncState = (message.details as { async?: { state?: string } } | undefined)?.async?.state;
+					const isBackgroundTask = message.toolName === "task" && asyncState === "running";
+					// A detached task's persisted result is only its "still running"
+					// snapshot. Keep the card partial, parked, and in `pendingTools` so
+					// the snapshot replay and later live progress frames land on it
+					// instead of hitting the no-pending-component early return (#10447).
+					component.updateResult(message, isBackgroundTask, message.toolCallId);
+					if (isBackgroundTask) {
+						component.parkAsBackground();
+						backgroundTaskCallIds.add(message.toolCallId);
+					} else {
+						this.ctx.pendingTools.delete(message.toolCallId);
+						if (
+							message.toolName === "hub" &&
+							component instanceof ToolExecutionComponent &&
+							component.isDisplaceableBlock()
+						) {
+							waitingPoll = component;
+						} else if (
+							message.toolName === "todo" &&
+							component instanceof ToolExecutionComponent &&
+							component.canBeDisplacedBy("todo")
+						) {
+							// A successful todo result supersedes the prior live snapshot. Failed
+							// follow-ups return false from canBeDisplacedBy("todo"), so the
+							// last-good panel stays on screen.
+							resolveTodoSnapshot("todo");
+							todoSnapshot = component;
+						}
 					}
 				}
 			} else {
@@ -739,6 +755,14 @@ export class UiHelpers {
 		if (this.ctx.viewSession.isStreaming) {
 			this.ctx.eventController?.inheritTurnStart(turnStartedAt);
 		}
+		// Re-register parked background task cards with the controller: focus
+		// attach resets its `#backgroundTaskCallIds` before replaying, and unlike
+		// the todo/turn handoffs this must run whether or not the session streams
+		// — a detached task keeps running while the main session sits idle
+		// (#10447). Membership is re-checked against `pendingTools`.
+		if (backgroundTaskCallIds.size > 0) {
+			this.ctx.eventController?.markBackgroundTaskCalls(backgroundTaskCallIds);
+		}
 
 		// Entries still in `pendingTools` are toolCalls whose result never landed
 		// during the replay — with `keepDanglingToolCalls` these are exactly the
@@ -760,10 +784,17 @@ export class UiHelpers {
 				}
 			}
 		} else {
-			for (const component of this.ctx.pendingTools.values()) {
+			for (const [toolCallId, component] of this.ctx.pendingTools) {
+				// A parked background task keeps running even while the main session
+				// is idle, so leave its card pending — sealing and clearing it would
+				// drop the replayed snapshot and every later job frame (#10447).
+				if (backgroundTaskCallIds.has(toolCallId)) {
+					component.setArgsComplete(toolCallId);
+					continue;
+				}
 				component.seal();
+				this.ctx.pendingTools.delete(toolCallId);
 			}
-			this.ctx.pendingTools.clear();
 		}
 		this.ctx.ui.requestRender();
 	}

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -2203,7 +2203,18 @@ export class AgentSession {
 
 	async #emitSessionEvent(event: AgentSessionEvent, options: { detachExtensions?: boolean } = {}): Promise<void> {
 		if (event.type === "tool_execution_update") {
-			this.#activeToolExecutionUpdates.set(event.toolCallId, event);
+			// A detached background task streams its terminal snapshot as a
+			// tool_execution_update carrying async.state "completed"/"failed" — not a
+			// second tool_execution_end — so evict on a settled async state. Otherwise
+			// each finished board lingers in the cache (unbounded retention) and a
+			// later focus rebuild could replay it into a reused tool-call id (#10447).
+			const asyncState = (event.partialResult as { details?: { async?: { state?: string } } } | undefined)?.details
+				?.async?.state;
+			if (asyncState === "completed" || asyncState === "failed") {
+				this.#activeToolExecutionUpdates.delete(event.toolCallId);
+			} else {
+				this.#activeToolExecutionUpdates.set(event.toolCallId, event);
+			}
 		} else if (event.type === "tool_execution_end") {
 			this.#activeToolExecutionUpdates.delete(event.toolCallId);
 		}
@@ -5324,6 +5335,10 @@ export class AgentSession {
 		this.#toolChoiceQueue.clear();
 		this.#tools.clearAcpPermissionDecisions();
 		this.#tools.resetAnnouncedMounts();
+		// A `/new`, session switch, or tree navigation reuses tool-call ids, so a
+		// still-cached background-task snapshot from the old conversation must not
+		// survive to be replayed by a focus rebuild in the reset session (#10447).
+		this.#activeToolExecutionUpdates.clear();
 	}
 
 	/**

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -539,6 +539,7 @@ export class AgentSession {
 	#lastAppendOnlyResolution?: { enable: boolean; providerId: string | undefined };
 	#eventListeners: AgentSessionEventListener[] = [];
 	#activeToolExecutionUpdates = new Map<string, Extract<AgentSessionEvent, { type: "tool_execution_update" }>>();
+	#returnedBackgroundToolCallIds = new Set<string>();
 	#runStateListeners = new Set<(state: "running" | "idle") => void>();
 	#commandMetadataChangedListeners: CommandMetadataChangedListener[] = [];
 	#sessionChangeCallbacks = new Set<() => void>();
@@ -2203,19 +2204,27 @@ export class AgentSession {
 
 	async #emitSessionEvent(event: AgentSessionEvent, options: { detachExtensions?: boolean } = {}): Promise<void> {
 		if (event.type === "tool_execution_update") {
-			// A detached background task streams its terminal snapshot as a
-			// tool_execution_update carrying async.state "completed"/"failed" — not a
-			// second tool_execution_end — so evict on a settled async state. Otherwise
-			// each finished board lingers in the cache (unbounded retention) and a
-			// later focus rebuild could replay it into a reused tool-call id (#10447).
 			const asyncState = (event.partialResult as { details?: { async?: { state?: string } } } | undefined)?.details
 				?.async?.state;
-			if (asyncState === "completed" || asyncState === "failed") {
+			const asyncSettled = asyncState === "completed" || asyncState === "failed";
+			// A final async snapshot is terminal only after the original call
+			// returned its parked-background result. Mixed blocking+async task
+			// calls can reach the same async state while their blocking subset is
+			// still running; retain that frame until tool_execution_end so a focus
+			// rebuild keeps the full live board (#10447 review).
+			if (asyncSettled && this.#returnedBackgroundToolCallIds.delete(event.toolCallId)) {
 				this.#activeToolExecutionUpdates.delete(event.toolCallId);
 			} else {
 				this.#activeToolExecutionUpdates.set(event.toolCallId, event);
 			}
 		} else if (event.type === "tool_execution_end") {
+			const asyncState = (event.result as { details?: { async?: { state?: string } } } | undefined)?.details?.async
+				?.state;
+			if (event.toolName === "task" && asyncState === "running") {
+				this.#returnedBackgroundToolCallIds.add(event.toolCallId);
+			} else {
+				this.#returnedBackgroundToolCallIds.delete(event.toolCallId);
+			}
 			this.#activeToolExecutionUpdates.delete(event.toolCallId);
 		}
 		if (event.type === "message_update") {
@@ -5339,6 +5348,7 @@ export class AgentSession {
 		// still-cached background-task snapshot from the old conversation must not
 		// survive to be replayed by a focus rebuild in the reset session (#10447).
 		this.#activeToolExecutionUpdates.clear();
+		this.#returnedBackgroundToolCallIds.clear();
 	}
 
 	/**

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -538,6 +538,7 @@ export class AgentSession {
 	/** Last (enable, providerId) tuple resolved by `#syncAppendOnlyContext` — used to skip no-op invalidations. */
 	#lastAppendOnlyResolution?: { enable: boolean; providerId: string | undefined };
 	#eventListeners: AgentSessionEventListener[] = [];
+	#activeToolExecutionUpdates = new Map<string, Extract<AgentSessionEvent, { type: "tool_execution_update" }>>();
 	#runStateListeners = new Set<(state: "running" | "idle") => void>();
 	#commandMetadataChangedListeners: CommandMetadataChangedListener[] = [];
 	#sessionChangeCallbacks = new Set<() => void>();
@@ -2201,6 +2202,11 @@ export class AgentSession {
 	#subscriberEmitGate: Promise<void> = Promise.resolve();
 
 	async #emitSessionEvent(event: AgentSessionEvent, options: { detachExtensions?: boolean } = {}): Promise<void> {
+		if (event.type === "tool_execution_update") {
+			this.#activeToolExecutionUpdates.set(event.toolCallId, event);
+		} else if (event.type === "tool_execution_end") {
+			this.#activeToolExecutionUpdates.delete(event.toolCallId);
+		}
 		if (event.type === "message_update") {
 			this.#emit(event);
 			void this.#queueExtensionEvent(event);
@@ -3985,6 +3991,14 @@ export class AgentSession {
 				this.#eventListeners.splice(index, 1);
 			}
 		};
+	}
+
+	/**
+	 * Snapshot the latest partial result for each tool that is still executing.
+	 * Focus rebuilds replay these after reconstructing persisted transcript state.
+	 */
+	activeToolExecutionUpdates(): readonly Extract<AgentSessionEvent, { type: "tool_execution_update" }>[] {
+		return [...this.#activeToolExecutionUpdates.values()];
 	}
 
 	/**

--- a/packages/coding-agent/test/agent-session-active-tool-updates.test.ts
+++ b/packages/coding-agent/test/agent-session-active-tool-updates.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Focus rebuilds replay `AgentSession.activeToolExecutionUpdates()` to restore a
+ * live task board (#10446). These transient snapshots must not accumulate: a
+ * detached background task streams its terminal state as a `tool_execution_update`
+ * (async.state completed/failed) with no second `tool_execution_end`, and `/new`
+ * or a session switch reuses tool-call ids. Both would otherwise let a finished
+ * board linger and replay into an unrelated call (#10447 review).
+ */
+import { afterEach, describe, expect, it } from "bun:test";
+import { Agent, type AgentEvent } from "@oh-my-pi/pi-agent-core";
+import { createMockModel } from "@oh-my-pi/pi-ai/providers/mock";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { convertToLlm } from "@oh-my-pi/pi-coding-agent/session/messages";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+
+function taskUpdate(state: "running" | "completed" | "failed"): AgentEvent {
+	return {
+		type: "tool_execution_update",
+		toolCallId: "task-1",
+		toolName: "task",
+		args: {},
+		partialResult: {
+			content: [{ type: "text", text: `Task ${state}` }],
+			details: {
+				projectAgentsDir: null,
+				results: [],
+				totalDurationMs: 5,
+				progress: [],
+				async: { state, jobId: "job-1", type: "task" },
+			},
+		},
+	} as AgentEvent;
+}
+
+describe("AgentSession.activeToolExecutionUpdates cache lifecycle", () => {
+	let session: AgentSession;
+	const authStorages: AuthStorage[] = [];
+
+	afterEach(async () => {
+		if (session) await session.dispose();
+		for (const authStorage of authStorages.splice(0)) authStorage.close();
+	});
+
+	async function makeSession(): Promise<AgentSession> {
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5")!;
+		const mock = createMockModel({ handler: () => ({ content: ["Done"] }) });
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model, systemPrompt: ["Test"], tools: [] },
+			convertToLlm,
+			streamFn: mock.stream,
+		});
+		const authStorage = await AuthStorage.create(":memory:");
+		authStorages.push(authStorage);
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		return new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated(),
+			modelRegistry: new ModelRegistry(authStorage),
+			agentId: "Main",
+		});
+	}
+
+	it("evicts a background task snapshot once its async state settles", async () => {
+		session = await makeSession();
+
+		session.agent.emitExternalEvent(taskUpdate("running"));
+		expect(session.activeToolExecutionUpdates().map(event => event.toolCallId)).toEqual(["task-1"]);
+
+		session.agent.emitExternalEvent(taskUpdate("completed"));
+		expect(session.activeToolExecutionUpdates()).toHaveLength(0);
+	});
+
+	it("clears cached snapshots across a new session so a reused id cannot replay", async () => {
+		session = await makeSession();
+
+		session.agent.emitExternalEvent(taskUpdate("running"));
+		expect(session.activeToolExecutionUpdates()).toHaveLength(1);
+		expect(await session.newSession()).toBe(true);
+		expect(session.activeToolExecutionUpdates()).toHaveLength(0);
+	});
+});

--- a/packages/coding-agent/test/agent-session-active-tool-updates.test.ts
+++ b/packages/coding-agent/test/agent-session-active-tool-updates.test.ts
@@ -1,10 +1,10 @@
 /**
  * Focus rebuilds replay `AgentSession.activeToolExecutionUpdates()` to restore a
- * live task board (#10446). These transient snapshots must not accumulate: a
- * detached background task streams its terminal state as a `tool_execution_update`
- * (async.state completed/failed) with no second `tool_execution_end`, and `/new`
- * or a session switch reuses tool-call ids. Both would otherwise let a finished
- * board linger and replay into an unrelated call (#10447 review).
+ * live task board (#10446). Snapshots stay cached until the overall call ends:
+ * mixed blocking+async calls can report a settled async subset while blocking
+ * work continues, while an already-returned background call uses that same
+ * settled update as its terminal frame. Logical session transitions must clear
+ * both snapshots and returned-background lifecycle markers.
  */
 import { afterEach, describe, expect, it } from "bun:test";
 import { Agent, type AgentEvent } from "@oh-my-pi/pi-agent-core";
@@ -17,10 +17,10 @@ import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { convertToLlm } from "@oh-my-pi/pi-coding-agent/session/messages";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 
-function taskUpdate(state: "running" | "completed" | "failed"): AgentEvent {
+function taskUpdate(state: "running" | "completed" | "failed", toolCallId = "task-1"): AgentEvent {
 	return {
 		type: "tool_execution_update",
-		toolCallId: "task-1",
+		toolCallId,
 		toolName: "task",
 		args: {},
 		partialResult: {
@@ -33,7 +33,19 @@ function taskUpdate(state: "running" | "completed" | "failed"): AgentEvent {
 				async: { state, jobId: "job-1", type: "task" },
 			},
 		},
-	} as AgentEvent;
+	} satisfies AgentEvent;
+}
+
+function taskEnd(state: "running" | "completed" | "failed", toolCallId = "task-1"): AgentEvent {
+	return {
+		type: "tool_execution_end",
+		toolCallId,
+		toolName: "task",
+		result: {
+			content: [{ type: "text", text: `Task ${state}` }],
+			details: { async: { state, jobId: "job-1", type: "task" } },
+		},
+	} satisfies AgentEvent;
 }
 
 describe("AgentSession.activeToolExecutionUpdates cache lifecycle", () => {
@@ -66,22 +78,36 @@ describe("AgentSession.activeToolExecutionUpdates cache lifecycle", () => {
 		});
 	}
 
-	it("evicts a background task snapshot once its async state settles", async () => {
+	it("retains a settled async subset until its mixed task call ends", async () => {
 		session = await makeSession();
 
 		session.agent.emitExternalEvent(taskUpdate("running"));
+		session.agent.emitExternalEvent(taskUpdate("completed"));
 		expect(session.activeToolExecutionUpdates().map(event => event.toolCallId)).toEqual(["task-1"]);
 
+		session.agent.emitExternalEvent(taskEnd("completed"));
+		expect(session.activeToolExecutionUpdates()).toHaveLength(0);
+	});
+
+	it("evicts a terminal background snapshot after the original task call returned", async () => {
+		session = await makeSession();
+
+		session.agent.emitExternalEvent(taskEnd("running"));
 		session.agent.emitExternalEvent(taskUpdate("completed"));
 		expect(session.activeToolExecutionUpdates()).toHaveLength(0);
 	});
 
-	it("clears cached snapshots across a new session so a reused id cannot replay", async () => {
+	it("clears snapshots and returned-background markers across a new session", async () => {
 		session = await makeSession();
 
-		session.agent.emitExternalEvent(taskUpdate("running"));
+		session.agent.emitExternalEvent(taskUpdate("running", "cached-call"));
+		session.agent.emitExternalEvent(taskEnd("running", "returned-call"));
 		expect(session.activeToolExecutionUpdates()).toHaveLength(1);
+
 		expect(await session.newSession()).toBe(true);
 		expect(session.activeToolExecutionUpdates()).toHaveLength(0);
+
+		session.agent.emitExternalEvent(taskUpdate("completed", "returned-call"));
+		expect(session.activeToolExecutionUpdates().map(event => event.toolCallId)).toEqual(["returned-call"]);
 	});
 });

--- a/packages/coding-agent/test/issue-9816-hub-inflight-focus-rebuild.test.ts
+++ b/packages/coding-agent/test/issue-9816-hub-inflight-focus-rebuild.test.ts
@@ -25,6 +25,7 @@ import { AgentLifecycleManager } from "@oh-my-pi/pi-coding-agent/registry/agent-
 import { AgentRegistry, MAIN_AGENT_ID } from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
 import type { AgentSession, AgentSessionEvent } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import type { SessionContext } from "@oh-my-pi/pi-coding-agent/session/session-context";
+import type { AgentProgress, TaskToolDetails } from "@oh-my-pi/pi-coding-agent/task/types";
 
 const usage = {
 	input: 1,
@@ -67,9 +68,79 @@ const completedHubWait = {
 	timestamp: Date.now(),
 } as ToolResultMessage;
 
+const danglingTask = {
+	role: "assistant",
+	content: [
+		{
+			type: "toolCall",
+			id: "task-1",
+			name: "task",
+			arguments: {
+				tasks: [{ name: "Parent", agent: "task", task: "Inspect the focus rebuild" }],
+			},
+		},
+	],
+	api: "anthropic-messages",
+	provider: "anthropic",
+	model: "claude-sonnet-4-5",
+	stopReason: "toolUse",
+	usage,
+	timestamp: Date.now(),
+} as unknown as AgentMessage;
+
+function runningProgress(id: string, description: string, overrides: Partial<AgentProgress> = {}): AgentProgress {
+	return {
+		index: 0,
+		id,
+		agent: "task",
+		agentSource: "bundled",
+		status: "running",
+		task: description,
+		description,
+		currentTool: "read",
+		currentToolArgs: "packages/coding-agent/src/modes",
+		recentTools: [],
+		recentOutput: [],
+		toolCount: 4,
+		requests: 3,
+		tokens: 1200,
+		cost: 0.04,
+		durationMs: 2500,
+		...overrides,
+	};
+}
+
+const nestedProgress: TaskToolDetails = {
+	projectAgentsDir: null,
+	results: [],
+	totalDurationMs: 2500,
+	progress: [runningProgress("Parent.Child", "Inspect child layout")],
+};
+
+const taskProgressUpdate = {
+	type: "tool_execution_update",
+	toolCallId: "task-1",
+	toolName: "task",
+	args: { tasks: [{ name: "Parent", agent: "task", task: "Inspect the focus rebuild" }] },
+	partialResult: {
+		content: [{ type: "text", text: "Running 1 agent..." }],
+		details: {
+			projectAgentsDir: null,
+			results: [],
+			totalDurationMs: 2500,
+			progress: [
+				runningProgress("Parent", "Inspect parent layout", {
+					inflightTaskDetails: nestedProgress,
+				}),
+			],
+		} satisfies TaskToolDetails,
+	},
+} satisfies Extract<AgentSessionEvent, { type: "tool_execution_update" }>;
+
 interface SessionStub {
 	session: AgentSession;
 	hasListener(): boolean;
+	emitToolUpdate(event: Extract<AgentSessionEvent, { type: "tool_execution_update" }>): Promise<void>;
 	stagePersistedCompletion(): () => void;
 }
 
@@ -78,6 +149,7 @@ function makeSession(initialMessages: AgentMessage[], initialStreaming: boolean)
 	let streaming = initialStreaming;
 	let listener: ((event: AgentSessionEvent) => Promise<void> | void) | undefined;
 	let persistence = Promise.resolve();
+	const activeToolUpdates = new Map<string, Extract<AgentSessionEvent, { type: "tool_execution_update" }>>();
 
 	const stub = {
 		get isStreaming() {
@@ -97,6 +169,7 @@ function makeSession(initialMessages: AgentMessage[], initialStreaming: boolean)
 			return { messages } as SessionContext;
 		},
 		getToolByName: () => undefined,
+		activeToolExecutionUpdates: () => [...activeToolUpdates.values()],
 		hasBuiltInTool: () => true,
 		sessionManager: {
 			getCwd: () => process.cwd(),
@@ -107,6 +180,10 @@ function makeSession(initialMessages: AgentMessage[], initialStreaming: boolean)
 	return {
 		session: stub as unknown as AgentSession,
 		hasListener: () => listener !== undefined,
+		emitToolUpdate: async event => {
+			activeToolUpdates.set(event.toolCallId, event);
+			await listener?.(event);
+		},
 		stagePersistedCompletion: () => {
 			streaming = false;
 			const pending = Promise.withResolvers<void>();
@@ -119,8 +196,7 @@ function makeSession(initialMessages: AgentMessage[], initialStreaming: boolean)
 	};
 }
 
-function createFixture() {
-	const main = makeSession([danglingHubWait], true);
+function createFixture(main = makeSession([danglingHubWait], true)) {
 	const worker = makeSession([], false);
 	const registry = new AgentRegistry();
 	registry.register({
@@ -171,6 +247,7 @@ function createFixture() {
 		setTodos: vi.fn(),
 		showStatus: vi.fn(),
 		showWarning: vi.fn(),
+		clearPinnedError: vi.fn(),
 		clearTransientSessionUi: () => {
 			pendingMessagesContainer.disposeChildren();
 			pendingTools.clear();
@@ -188,17 +265,17 @@ function createFixture() {
 	return { ctx, focus, main };
 }
 
+beforeAll(async () => {
+	resetSettingsForTest();
+	await Settings.init({ inMemory: true });
+	await initTheme();
+});
+
+afterAll(() => {
+	resetSettingsForTest();
+});
+
 describe("#9816 focus blackout across an in-flight hub wait", () => {
-	beforeAll(async () => {
-		resetSettingsForTest();
-		await Settings.init({ inMemory: true });
-		await initTheme();
-	});
-
-	afterAll(() => {
-		resetSettingsForTest();
-	});
-
 	it("drains a lost completion into the transcript before rebuilding the main session", async () => {
 		const { ctx, focus, main } = createFixture();
 		await ctx.renderInitialMessages();
@@ -220,5 +297,25 @@ describe("#9816 focus blackout across an in-flight hub wait", () => {
 		expect(rendered).toContain("Sleeper1");
 		expect(rendered).not.toContain("all running jobs");
 		expect(ctx.pendingTools.has("hub-1")).toBe(false);
+	});
+});
+
+describe("#10446 task progress across a focus rebuild", () => {
+	it("restores the latest in-flight task board after returning to main", async () => {
+		const main = makeSession([danglingTask], true);
+		const fixture = createFixture(main);
+
+		await fixture.ctx.renderInitialMessages();
+		await main.emitToolUpdate(taskProgressUpdate);
+		const before = Bun.stripANSI(fixture.ctx.chatContainer.render(120).join("\n"));
+		expect(before).toContain("Parent>Child");
+		expect(before).toContain("packages/coding-agent/src/modes");
+
+		await fixture.focus.focusAgent("Worker");
+		await fixture.focus.unfocus();
+
+		const after = Bun.stripANSI(fixture.ctx.chatContainer.render(120).join("\n"));
+		expect(after).toContain("Parent>Child");
+		expect(after).toContain("packages/coding-agent/src/modes");
 	});
 });

--- a/packages/coding-agent/test/issue-9816-hub-inflight-focus-rebuild.test.ts
+++ b/packages/coding-agent/test/issue-9816-hub-inflight-focus-rebuild.test.ts
@@ -137,6 +137,61 @@ const taskProgressUpdate = {
 	},
 } satisfies Extract<AgentSessionEvent, { type: "tool_execution_update" }>;
 
+const backgroundTaskCall = {
+	role: "assistant",
+	content: [
+		{
+			type: "toolCall",
+			id: "task-bg",
+			name: "task",
+			arguments: { tasks: [{ name: "Bg", agent: "task", task: "background work" }] },
+		},
+	],
+	api: "anthropic-messages",
+	provider: "anthropic",
+	model: "claude-sonnet-4-5",
+	stopReason: "toolUse",
+	usage,
+	timestamp: Date.now(),
+} as unknown as AgentMessage;
+
+// The initial `async.state === "running"` snapshot the detached call persists:
+// a bare parent row, no current-tool line to distinguish it from a later frame.
+const backgroundTaskRunningResult = {
+	role: "toolResult",
+	toolCallId: "task-bg",
+	toolName: "task",
+	content: [{ type: "text", text: "Spawned agent `Bg`..." }],
+	details: {
+		projectAgentsDir: null,
+		results: [],
+		totalDurationMs: 10,
+		progress: [runningProgress("Bg", "Background work", { currentTool: undefined, currentToolArgs: undefined })],
+		async: { state: "running", jobId: "job-bg", type: "task" },
+	},
+	isError: false,
+	timestamp: Date.now(),
+} as unknown as ToolResultMessage;
+
+function backgroundProgressUpdate(marker: string): Extract<AgentSessionEvent, { type: "tool_execution_update" }> {
+	return {
+		type: "tool_execution_update",
+		toolCallId: "task-bg",
+		toolName: "task",
+		args: { tasks: [{ name: "Bg", agent: "task", task: "background work" }] },
+		partialResult: {
+			content: [{ type: "text", text: "Running background task Bg..." }],
+			details: {
+				projectAgentsDir: null,
+				results: [],
+				totalDurationMs: 20,
+				progress: [runningProgress("Bg", "Background work", { currentTool: "grep", currentToolArgs: marker })],
+				async: { state: "running", jobId: "job-bg", type: "task" },
+			} satisfies TaskToolDetails,
+		},
+	} satisfies Extract<AgentSessionEvent, { type: "tool_execution_update" }>;
+}
+
 interface SessionStub {
 	session: AgentSession;
 	hasListener(): boolean;
@@ -317,5 +372,33 @@ describe("#10446 task progress across a focus rebuild", () => {
 		const after = Bun.stripANSI(fixture.ctx.chatContainer.render(120).join("\n"));
 		expect(after).toContain("Parent>Child");
 		expect(after).toContain("packages/coding-agent/src/modes");
+	});
+});
+
+describe("#10447 persisted background task board across a focus rebuild", () => {
+	it("keeps a returned detached task parked so cached and later progress land after return", async () => {
+		// Detached task: its call already returned an async.state "running" result
+		// (persisted), and the main session is idle while the job keeps streaming.
+		const main = makeSession([backgroundTaskCall, backgroundTaskRunningResult], false);
+		const fixture = createFixture(main);
+
+		await fixture.ctx.renderInitialMessages();
+		await main.emitToolUpdate(backgroundProgressUpdate("cached-progress-marker"));
+		const before = Bun.stripANSI(fixture.ctx.chatContainer.render(120).join("\n"));
+		expect(before).toContain("cached-progress-marker");
+
+		await fixture.focus.focusAgent("Worker");
+		await fixture.focus.unfocus();
+
+		// The rebuilt board replays the cached snapshot instead of collapsing to
+		// the persisted "running" result, and the card is still parked as pending.
+		const after = Bun.stripANSI(fixture.ctx.chatContainer.render(120).join("\n"));
+		expect(after).toContain("cached-progress-marker");
+		expect(fixture.ctx.pendingTools.has("task-bg")).toBe(true);
+
+		// A live frame emitted after return still routes to the preserved card.
+		await main.emitToolUpdate(backgroundProgressUpdate("post-return-marker"));
+		const live = Bun.stripANSI(fixture.ctx.chatContainer.render(120).join("\n"));
+		expect(live).toContain("post-return-marker");
 	});
 });

--- a/packages/coding-agent/test/session-focus-controller.test.ts
+++ b/packages/coding-agent/test/session-focus-controller.test.ts
@@ -25,6 +25,7 @@ function makeSessionStub(opts: { isStreaming?: boolean } = {}): SessionStub {
 			};
 		},
 		async settleInFlightMessagePersistence() {},
+		activeToolExecutionUpdates: () => [],
 	};
 	return {
 		session: stub as unknown as AgentSession,


### PR DESCRIPTION
## Repro
With a main-session `task` call still emitting partial progress, focus a worker from Agent Hub and return to Main. `bun test packages/coding-agent/test/issue-9816-hub-inflight-focus-rebuild.test.ts` previously rebuilt the card from persisted call arguments only, changing nested `Parent>Child` and current-tool rows into one short summary row.

## Cause
`SessionFocusController.#attach()` rebuilt the transcript from persisted messages, but `tool_execution_update` partial results are transient display events. `AgentSession` did not retain their latest state, so `UiHelpers.renderInitialMessages()` could reconstruct only the bare `task` call after focus navigation.

## Fix
- Retain the latest partial update for each active tool execution in `AgentSession`, removing it when execution ends.
- Replay active partial snapshots after `SessionFocusController` reconstructs the target transcript.
- Cover nested task rows and current-tool details across focus/unfocus, and document the user-visible fix.

## Verification
`bun test packages/coding-agent/test/issue-9816-hub-inflight-focus-rebuild.test.ts packages/coding-agent/test/session-focus-controller.test.ts` passes: 8 tests, 38 assertions. `bun run check` in `packages/coding-agent` passes. A 120×24 PTY probe rendered the restored parent row, nested `Parent>Child` row, request/cost metadata, and both current-tool rows without stale lower-pane content. Skipped the repository-wide pre-publish gate because `bun check` fails identically on a clean `origin/main` archive at `packages/catalog/test/compat-compile.test.ts:65` with TS2532. Fixes #10446