### PR TITLE
fix(coding-agent): add work-completion rules to codex code mode prompt

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Fixed an issue where custom model overrides were lost during configuration updates
 - Fixed "Please use nerdfont" notification incorrectly persisting after theme configuration
 - Fixed sampling parameter errors for newer Anthropic models (Opus 4.7+, Sonnet 5+)
+- Codex Code Mode now instructs the model to continue until the work is complete, to claim only tool-verified work, and to check changed behavior before the final answer ([#10453](https://github.com/can1357/oh-my-pi/pull/10453) by [@ephraimduncan](https://github.com/ephraimduncan))
 
 ## [18.0.11] - 2026-08-29
 

--- a/packages/coding-agent/src/prompts/tools/eval-code-mode.md
+++ b/packages/coding-agent/src/prompts/tools/eval-code-mode.md
@@ -18,5 +18,5 @@ declare const tool: {
 - NEVER give the final answer while requested work remains; a plan, a status report, or a partial result is not final.
 - NEVER claim work without a tool result that shows the work occurred.
 - Unsuccessful tool call → MUST correct the call or use a different tool; NEVER treat the intended call as done.
-- Before the final answer, MUST do a test or a check of the changed behavior.
+- If you changed behavior, MUST do a test or a check of the change before the final answer; read-only tasks need no test.
 </critical>

--- a/packages/coding-agent/src/prompts/tools/eval-code-mode.md
+++ b/packages/coding-agent/src/prompts/tools/eval-code-mode.md
@@ -2,12 +2,6 @@
 
 Codex Code Mode is active. Use this tool to call the other session tools. The direct tool set is restricted.
 
-For repository tasks, do not give the final answer before you complete the requested work:
-- Continue to call tools if work remains. A plan, a status report, or a partial result is not final.
-- Only make a work claim when a tool result shows that the work occurred.
-- If a tool call is not successful, correct the call or use a different tool.
-- Before the final answer, do a test or a check of the changed behavior.
-
 Put related operations in one cell when you know the next steps. Call session tools with `await tool.<name>(args)`.
 Use `parallel([() => tool.read(…), () => tool.grep(…)])` for independent calls.
 Use `tool.*` instead of raw `Bun.file` or `fs`. The session tool path records these operations.
@@ -19,3 +13,10 @@ declare const tool: {
 {{declarations}}
 };
 ```
+
+<critical>
+- NEVER give the final answer while requested work remains; a plan, a status report, or a partial result is not final.
+- NEVER claim work without a tool result that shows the work occurred.
+- Unsuccessful tool call → MUST correct the call or use a different tool; NEVER treat the intended call as done.
+- Before the final answer, MUST do a test or a check of the changed behavior.
+</critical>

--- a/packages/coding-agent/src/prompts/tools/eval-code-mode.md
+++ b/packages/coding-agent/src/prompts/tools/eval-code-mode.md
@@ -1,9 +1,17 @@
 {{baseDescription}}
 
-Codex Code Mode is active: this tool is your primary work surface and the direct tool surface is restricted.
-Plan multiple operations into ONE cell whenever the next steps are known, calling session tools via `await tool.<name>(args)`;
-use `parallel([() => tool.read(…), () => tool.grep(…)])` for independent calls. Prefer `tool.*` calls over raw `Bun.file`/fs so operations flow through the session tool pipeline.
-Reserve separate cells for steps that must inspect earlier results.
+Codex Code Mode is active. Use this tool to call the other session tools. The direct tool set is restricted.
+
+For repository tasks, do not give the final answer before you complete the requested work:
+- Continue to call tools if work remains. A plan, a status report, or a partial result is not final.
+- Only make a work claim when a tool result shows that the work occurred.
+- If a tool call is not successful, correct the call or use a different tool.
+- Before the final answer, do a test or a check of the changed behavior.
+
+Put related operations in one cell when you know the next steps. Call session tools with `await tool.<name>(args)`.
+Use `parallel([() => tool.read(…), () => tool.grep(…)])` for independent calls.
+Use `tool.*` instead of raw `Bun.file` or `fs`. The session tool path records these operations.
+Use a separate cell when a later step must use an earlier result.
 
 exec tool declarations:
 ```ts


### PR DESCRIPTION
In Codex Code Mode, the model often stopped early, made claims of tool calls that did not occur, and gave final answers without a check of the changed behavior. In this mode, most tools go through the eval bridge. Thus the eval tool description is the only per-tool text that controls the model, and it had no completion or evidence rules.

The Code Mode section of the eval tool description now tells the model to continue until the work is complete, to make a work claim only when a tool result shows it, to correct an unsuccessful call, and to do a check of the changed behavior before the final answer.

The 18 Code Mode and eval-description tests pass.