### PR TITLE
fix(config): resolve discovery-provider !command headers on inference path

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Fixed an issue where custom model overrides were lost during configuration updates
 - Fixed "Please use nerdfont" notification incorrectly persisting after theme configuration
 - Fixed sampling parameter errors for newer Anthropic models (Opus 4.7+, Sonnet 5+)
+- Fixed custom discovery providers sending unresolved `!command` header values (e.g. `!basename $PWD`) verbatim on inference requests; command-backed provider headers now resolve on discovered models too ([#10457](https://github.com/can1357/oh-my-pi/issues/10457)).
 
 ## [18.0.11] - 2026-08-29
 

--- a/packages/coding-agent/src/config/model-patch.ts
+++ b/packages/coding-agent/src/config/model-patch.ts
@@ -43,6 +43,11 @@ export interface ProviderOverride {
  * default openai-completions transport after the background catalog
  * refresh — so the first `/model` switch after boot hits the raw OpenAI
  * chat-completions URL instead of the gateway's `/v1/pi/stream` (#2555).
+ *
+ * Merged headers are wrapped in `createLiveConfigHeaders` so `!command`
+ * values keep resolving per request on the inference path, matching the
+ * `modelOverrides`/`applyModelPatch` behavior — otherwise a discovery
+ * provider would send the raw `!command` literal upstream (#10457).
  * See `xiaomi-tp-discovery-merge.test.ts` and the `refresh()` baseUrl-override
  * regression in `model-registry.test.ts`.
  */
@@ -56,7 +61,7 @@ export function mergeDiscoveredModel<TApi extends Api>(
 		return buildModel({
 			...toModelSpec(model),
 			baseUrl: providerOverride?.baseUrl ?? model.baseUrl ?? existing.baseUrl,
-			headers: existing.headers ? { ...existing.headers, ...model.headers } : model.headers,
+			headers: createLiveConfigHeaders([existing.headers, model.headers]),
 			transport: providerOverride?.transport ?? existing.transport ?? model.transport,
 			remoteCompaction: mergeProviderRemoteCompactionConfig(
 				mergeRemoteCompactionConfig(existing.remoteCompaction, model.remoteCompaction),
@@ -70,7 +75,7 @@ export function mergeDiscoveredModel<TApi extends Api>(
 		return buildModel({
 			...toModelSpec(model),
 			baseUrl: providerOverride.baseUrl ?? model.baseUrl,
-			headers: providerOverride.headers ? { ...model.headers, ...providerOverride.headers } : model.headers,
+			headers: createLiveConfigHeaders([model.headers, providerOverride.headers]),
 			...(providerOverride.transport !== undefined ? { transport: providerOverride.transport } : {}),
 			remoteCompaction: mergeProviderRemoteCompactionConfig(
 				model.remoteCompaction,

--- a/packages/coding-agent/src/config/model-patch.ts
+++ b/packages/coding-agent/src/config/model-patch.ts
@@ -61,7 +61,11 @@ export function mergeDiscoveredModel<TApi extends Api>(
 		return buildModel({
 			...toModelSpec(model),
 			baseUrl: providerOverride?.baseUrl ?? model.baseUrl ?? existing.baseUrl,
-			headers: createLiveConfigHeaders([existing.headers, model.headers]),
+			// providerOverride.headers (raw `!command`) must be the last live
+			// source: `model.headers` is a discovery-time resolved snapshot, so
+			// without this a rotated credential (401 → cache invalidation) would
+			// stay shadowed by the stale snapshot on the inference path (#10458).
+			headers: createLiveConfigHeaders([existing.headers, model.headers, providerOverride?.headers]),
 			transport: providerOverride?.transport ?? existing.transport ?? model.transport,
 			remoteCompaction: mergeProviderRemoteCompactionConfig(
 				mergeRemoteCompactionConfig(existing.remoteCompaction, model.remoteCompaction),

--- a/packages/coding-agent/test/xiaomi-tp-discovery-merge.test.ts
+++ b/packages/coding-agent/test/xiaomi-tp-discovery-merge.test.ts
@@ -110,4 +110,24 @@ describe("mergeDiscoveredModel", () => {
 		const merged = mergeDiscoveredModel(discovered, undefined);
 		expect(merged).toEqual(discovered);
 	});
+
+	test("resolves provider-override `!command` headers on the inference path (#10457)", () => {
+		const discovered = bundled(STANDARD);
+		const merged = mergeDiscoveredModel(discovered, undefined, {
+			headers: { "X-Project-Id": "!echo resolved-value" },
+		});
+		// Discovery providers previously carried the raw `!command` literal into
+		// the model's headers, leaking it verbatim to the upstream server.
+		expect(merged.headers?.["X-Project-Id"]).toBe("resolved-value");
+	});
+
+	test("resolves `!command` headers merged from a bundled entry (#10457)", () => {
+		const discovered = bundled(STANDARD);
+		const existing: Model<"openai-completions"> = {
+			...bundled(STANDARD),
+			headers: { "X-Project-Id": "!echo resolved-value" },
+		};
+		const merged = mergeDiscoveredModel(discovered, existing);
+		expect(merged.headers?.["X-Project-Id"]).toBe("resolved-value");
+	});
 });

--- a/packages/coding-agent/test/xiaomi-tp-discovery-merge.test.ts
+++ b/packages/coding-agent/test/xiaomi-tp-discovery-merge.test.ts
@@ -137,7 +137,12 @@ describe("mergeDiscoveredModel", () => {
 
 	test("raw provider `!command` headers win over the discovery snapshot and re-resolve on rotation (#10458)", async () => {
 		const tokenFile = path.join(os.tmpdir(), `omp-rot-${Date.now()}-${Math.random().toString(36).slice(2)}.txt`);
-		const command = `!cat ${tokenFile}`;
+		// Cross-platform + space-safe: re-invoke the running Bun to print the
+		// token file's contents. All paths are JSON-quoted so a temp dir with
+		// spaces survives both `/bin/sh -c` and `cmd.exe /c`, and the eval body
+		// carries no double quotes of its own.
+		const readScript = "process.stdout.write(await Bun.file(Bun.argv[1]).text())";
+		const command = `!${JSON.stringify(process.execPath)} -e "${readScript}" ${JSON.stringify(tokenFile)}`;
 		await Bun.write(tokenFile, "token-A");
 		try {
 			// The discovered model carries the discovery-time resolved snapshot,

--- a/packages/coding-agent/test/xiaomi-tp-discovery-merge.test.ts
+++ b/packages/coding-agent/test/xiaomi-tp-discovery-merge.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
 import type { Model } from "@oh-my-pi/pi-ai";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import { invalidateCommandConfig } from "@oh-my-pi/pi-coding-agent/config/model-config-values";
 import { mergeDiscoveredModel } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 
 /**
@@ -129,5 +133,34 @@ describe("mergeDiscoveredModel", () => {
 		};
 		const merged = mergeDiscoveredModel(discovered, existing);
 		expect(merged.headers?.["X-Project-Id"]).toBe("resolved-value");
+	});
+
+	test("raw provider `!command` headers win over the discovery snapshot and re-resolve on rotation (#10458)", async () => {
+		const tokenFile = path.join(os.tmpdir(), `omp-rot-${Date.now()}-${Math.random().toString(36).slice(2)}.txt`);
+		const command = `!cat ${tokenFile}`;
+		await Bun.write(tokenFile, "token-A");
+		try {
+			// The discovered model carries the discovery-time resolved snapshot,
+			// and the existing entry stands in for a prior-merge value — either
+			// would shadow the live provider header if ordered last.
+			const discovered: Model<"openai-completions"> = {
+				...bundled(STANDARD),
+				headers: { "X-Token": "stale-snapshot" },
+			};
+			const existing: Model<"openai-completions"> = {
+				...bundled(STANDARD),
+				headers: { "X-Token": "stale-snapshot" },
+			};
+			const merged = mergeDiscoveredModel(discovered, existing, { headers: { "X-Token": command } });
+			// Raw provider header wins over the discovery snapshot...
+			expect(merged.headers?.["X-Token"]).toBe("token-A");
+			// ...and a 401 auth-retry rotation (cache invalidation) reaches it.
+			await Bun.write(tokenFile, "token-B");
+			invalidateCommandConfig(command);
+			expect(merged.headers?.["X-Token"]).toBe("token-B");
+		} finally {
+			invalidateCommandConfig(command);
+			await fs.rm(tokenFile, { force: true });
+		}
 	});
 });


### PR DESCRIPTION
## Repro
A custom provider using `discovery:` with a command-backed header (`headers: { X-Project-Id: "!basename $PWD" }`) resolves the value on the discovery `GET /v1/models` fetch but sends the raw literal `!basename $PWD` on the `POST /v1/chat/completions` inference request. Reproduced in-process: `mergeDiscoveredModel(discovered, undefined, { headers: { "X-Project-Id": "!echo resolved-value" } })` returns `merged.headers["X-Project-Id"] === "!echo resolved-value"` instead of `"resolved-value"`.

## Cause
`mergeDiscoveredModel` (`packages/coding-agent/src/config/model-patch.ts`) merged provider-level and existing headers with a plain object spread, so discovered models carried the raw `!command` strings and never engaged `createLiveConfigHeaders`. The discovery GET path resolves values via `resolveConfigHeaders` (`model-registry.ts:1365`), but the inference path reads the model's raw `headers`. The `modelOverrides { headers: {} }` workaround worked only because `applyModelPatch` routes merged headers through `createLiveConfigHeaders` when `patch.headers` is present.

## Fix
- Route both `mergeDiscoveredModel` branches (existing-entry merge and provider-override-only) through `createLiveConfigHeaders`, so command-backed header values resolve live per request, matching `modelOverrides`/`applyModelPatch` semantics.
- Documented the header live-proxy behavior on `mergeDiscoveredModel`.
- Added two regression tests in `xiaomi-tp-discovery-merge.test.ts` covering the provider-override and bundled-entry merge paths.
- Changelog entry under `[Unreleased]`.

Scope note: this fixes Problem 2 only. Problem 1 (attaching client/project identity to outbound requests) and Problem 3 (`!command`/env expansion in `compat.extraBody`) are feature requests left for maintainer scoping.

## Verification
`bun test packages/coding-agent/test/xiaomi-tp-discovery-merge.test.ts` — 10 pass. `bun test packages/coding-agent/test/model-discovery.test.ts packages/coding-agent/test/model-registry.test.ts` — 173 pass. The pre-push `bun check` gate was skipped: `bun check` fails on `main` in `@oh-my-pi/pi-catalog` (`test/compat-compile.test.ts:65` TS2532), a file byte-identical to `origin/main` and untouched by this diff; `pi-coding-agent` typechecks clean.

Fixes #10457