### PR TITLE
fix(tools): allow opaque Codex image proxy credentials

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### Fixed
 
+- Fixed `generate_image` skipping opaque `openai-codex` credentials for custom provider endpoints when a non-OpenAI chat model is active ([#10459](https://github.com/can1357/oh-my-pi/issues/10459)).
 - Fixed an issue where custom model overrides were lost during configuration updates
 - Fixed "Please use nerdfont" notification incorrectly persisting after theme configuration
 - Fixed sampling parameter errors for newer Anthropic models (Opus 4.7+, Sonnet 5+)

--- a/packages/coding-agent/src/tools/image-gen.ts
+++ b/packages/coding-agent/src/tools/image-gen.ts
@@ -2,7 +2,15 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { type } from "@oh-my-pi/omptype";
 import type { AgentToolResult } from "@oh-my-pi/pi-agent-core";
-import { type ApiKey, type FetchImpl, getEnvApiKey, getOpenRouterHeaders, type Model, withAuth } from "@oh-my-pi/pi-ai";
+import {
+	type ApiKey,
+	type FetchImpl,
+	getEnvApiKey,
+	getOpenRouterHeaders,
+	isOfficialCodexApiUrl,
+	type Model,
+	withAuth,
+} from "@oh-my-pi/pi-ai";
 import { ProviderHttpError } from "@oh-my-pi/pi-ai/error";
 import {
 	applyCodexResidencyHeader,
@@ -706,7 +714,7 @@ async function findCodexSubscriptionImageCredentials(
 	if (!token) return null;
 	const model = resolveDefaultCodexImageModel(modelRegistry);
 	if (!model) return null;
-	const acceptsOpaqueCredentials = getOpenAIBaseUrl(model) !== CODEX_BASE_URL;
+	const acceptsOpaqueCredentials = !isOfficialCodexApiUrl(getOpenAIBaseUrl(model));
 	if (!acceptsOpaqueCredentials && !getCodexAccountId(token)) return null;
 	const apiKey = await modelRegistry.getApiKey(model, sessionId);
 	if (!isAuthenticated(apiKey) || (!acceptsOpaqueCredentials && !getCodexAccountId(apiKey))) return null;

--- a/packages/coding-agent/src/tools/image-gen.ts
+++ b/packages/coding-agent/src/tools/image-gen.ts
@@ -687,13 +687,11 @@ function resolveDefaultCodexImageModel(modelRegistry: ModelRegistry): Model | un
 }
 
 /**
- * Codex subscription (ChatGPT OAuth) image credentials — engages OpenAI's hosted
- * `image_generation` tool through a CONNECTED Codex account, independent of the
- * active chat model. This is what lets image generation run on a ChatGPT
- * subscription (no metered OPENAI_API_KEY) even when the active model is, e.g.,
- * Claude. The active-model-is-codex case is already served by
- * {@link findOpenAIHostedImageCredentials}, so it is skipped here to avoid a
- * duplicate resolution.
+ * Codex image credentials — engages OpenAI's hosted `image_generation` tool
+ * through a connected ChatGPT account or custom Codex-compatible endpoint,
+ * independent of the active chat model. The active-model-is-codex case is
+ * already served by {@link findOpenAIHostedImageCredentials}, so it is skipped
+ * here to avoid a duplicate resolution.
  */
 async function findCodexSubscriptionImageCredentials(
 	modelRegistry: ModelRegistry | undefined,
@@ -704,15 +702,14 @@ async function findCodexSubscriptionImageCredentials(
 	if (isOpenAIHostedImageModel(activeModel) && getOpenAIHostedImageProvider(activeModel) === "openai-codex") {
 		return null;
 	}
-	// A Codex subscription credential is an OAuth JWT with an account claim. API
-	// keys stored under this provider cannot use the ChatGPT backend and must not
-	// prevent fallback providers from being selected.
 	const token = await modelRegistry.getApiKeyForProvider("openai-codex", sessionId);
-	if (!token || !getCodexAccountId(token)) return null;
+	if (!token) return null;
 	const model = resolveDefaultCodexImageModel(modelRegistry);
 	if (!model) return null;
+	const acceptsOpaqueCredentials = getOpenAIBaseUrl(model) !== CODEX_BASE_URL;
+	if (!acceptsOpaqueCredentials && !getCodexAccountId(token)) return null;
 	const apiKey = await modelRegistry.getApiKey(model, sessionId);
-	if (!isAuthenticated(apiKey) || !getCodexAccountId(apiKey)) return null;
+	if (!isAuthenticated(apiKey) || (!acceptsOpaqueCredentials && !getCodexAccountId(apiKey))) return null;
 	return { provider: "openai-codex", apiKey, model };
 }
 

--- a/packages/coding-agent/test/tools/image-gen.test.ts
+++ b/packages/coding-agent/test/tools/image-gen.test.ts
@@ -339,7 +339,7 @@ describe("imageGenTool", () => {
 			provider: "openai-codex",
 			id: "gpt-5.5",
 			name: "GPT-5.5",
-			baseUrl: "https://chatgpt.com/backend-api",
+			baseUrl: "HTTPS://CHATGPT.COM/backend-api/",
 		} as Model;
 		let requestUrl: string | undefined;
 		const fetchMock: typeof fetch = (async (input: string | URL | Request) => {

--- a/packages/coding-agent/test/tools/image-gen.test.ts
+++ b/packages/coding-agent/test/tools/image-gen.test.ts
@@ -334,6 +334,13 @@ describe("imageGenTool", () => {
 
 	it("falls back when an openai-codex API key lacks a subscription account claim", async () => {
 		const antigravityCredentials = JSON.stringify({ token: "test-antigravity-token", projectId: "test-project" });
+		const codexModel = {
+			api: "openai-codex-responses",
+			provider: "openai-codex",
+			id: "gpt-5.5",
+			name: "GPT-5.5",
+			baseUrl: "https://chatgpt.com/backend-api",
+		} as Model;
 		let requestUrl: string | undefined;
 		const fetchMock: typeof fetch = (async (input: string | URL | Request) => {
 			requestUrl = input.toString();
@@ -366,6 +373,9 @@ describe("imageGenTool", () => {
 				getSessionId: () => "test-session",
 			} as unknown as ReadonlySessionManager,
 			modelRegistry: {
+				find: (provider: string, id: string) =>
+					provider === "openai-codex" && id === "gpt-5.5" ? codexModel : undefined,
+				getAll: () => [codexModel],
 				getApiKey: async () => "plain-openai-key",
 				getApiKeyForProvider: async (provider: string) => {
 					if (provider === "openai-codex") return "plain-openai-key";
@@ -438,7 +448,7 @@ describe("imageGenTool", () => {
 		expect(captured.authorization).toBe("Bearer test-xai-token");
 		expect(result.details?.provider).toBe("xai");
 	});
-	it("sends Codex hosted image requests with opaque proxy bearer keys", async () => {
+	it("uses opaque Codex proxy credentials when the active model is not OpenAI", async () => {
 		let requestUrl: string | undefined;
 		let requestHeaders: Headers | undefined;
 
@@ -475,6 +485,12 @@ describe("imageGenTool", () => {
 			name: "GPT Codex",
 			baseUrl: "https://example-proxy.invalid/backend-api",
 		} as Model;
+		const activeModel = {
+			api: "anthropic-messages",
+			provider: "anthropic",
+			id: "claude-opus-4",
+			name: "Claude",
+		} as Model;
 		const ctx: CustomToolContext = {
 			fetch: fetchMock,
 			sessionManager: {
@@ -482,12 +498,19 @@ describe("imageGenTool", () => {
 				getSessionId: () => "test-session",
 			} as unknown as ReadonlySessionManager,
 			modelRegistry: {
+				find: (provider: string, id: string) =>
+					provider === "openai-codex" && id === "gpt-5.5-codex" ? model : undefined,
+				getAll: () => [model],
 				getApiKey: async () => "opaque-proxy-key",
-				getApiKeyForProvider: async () => undefined,
-				authStorage: { rotateSessionCredential: async () => false },
+				getApiKeyForProvider: async (provider: string) =>
+					provider === "openai-codex" ? "opaque-proxy-key" : undefined,
+				authStorage: {
+					hasNonEnvCredential: () => false,
+					rotateSessionCredential: async () => false,
+				},
 				resolver: () => async () => "opaque-proxy-key",
 			} as unknown as ModelRegistry,
-			model,
+			model: activeModel,
 			isIdle: () => true,
 			hasQueuedMessages: () => false,
 			abort: () => {},


### PR DESCRIPTION
## Repro
With an Anthropic active model, an `openai-codex` model configured at a custom `baseUrl`, and an opaque provider key, `bun test packages/coding-agent/test/tools/image-gen.test.ts --test-name-pattern "uses opaque Codex proxy credentials"` failed because provider discovery exhausted its fallbacks without calling the proxy.

## Cause
`findCodexSubscriptionImageCredentials` in `packages/coding-agent/src/tools/image-gen.ts` required `getCodexAccountId` to succeed for both the provider credential and resolved model credential before considering the model endpoint, although `getOpenAIBaseUrl` and `buildOpenAIImageHeaders` already support custom Codex-compatible endpoints without `chatgpt-account-id`.

## Fix
- Resolve the default Codex image model before applying the account-claim gate.
- Accept opaque credentials only when that model resolves to a non-default Codex endpoint.
- Preserve fallback behavior for opaque credentials targeting the official ChatGPT backend and cover both paths with contract tests.
- Document the user-visible fix in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/tools/image-gen.test.ts` passes: 16 tests, 67 assertions. `bun check` fails on clean `main` with the identical unrelated `packages/catalog/test/compat-compile.test.ts:65` TS2532 error, so the pre-publish gate was skipped.

Fixes #10459