### PR TITLE
feat(collab): proto-4 guest system with identity, roles, and granular…

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Devin model selectors now accept the native CLI's short aliases (`devin/opus`, `devin/swe`), dotted upstream spellings (`devin/gemini-3.7-flash`), and raw effort-route wire uids for dynamically collapsed families ([#8590](https://github.com/can1357/oh-my-pi/pull/8590) by [@will-bogusz](https://github.com/will-bogusz)).
 - Added provider-supplied model metadata to the `/models` detail line: `new`, `beta`, and `recommended` badges beside the model name, and the upstream description after the context, cost, and perf facts ([#8590](https://github.com/can1357/oh-my-pi/pull/8590) by [@will-bogusz](https://github.com/will-bogusz)).
 - Standalone `CLAUDE.md` files in the project root (and ancestor directories) are now loaded as context, mirroring `AGENTS.md` discovery; config-directory context files still take precedence per scope.
+- Collab live sessions now speak the proto-4 guest system: persistent guest identities with stable IDs across reconnects, roles (`admin`/`member`/`viewer`), granular permission bits, invites, kicks, guest-to-guest chat, presence, and a permission audit log (`/collab` slash commands drive the new surface; legacy proto-3 guests keep the old surface).
 
 ### Changed
 
@@ -20,6 +21,7 @@
 - Fixed an issue where custom model overrides were lost during configuration updates
 - Fixed "Please use nerdfont" notification incorrectly persisting after theme configuration
 - Fixed sampling parameter errors for newer Anthropic models (Opus 4.7+, Sonnet 5+)
+- Fixed settled host UI requests replaying to guests that join later; only unanswered asks are now replayed, so late joiners no longer see already-answered prompts and answering them cannot strand the host's pending request.
 
 ## [18.0.11] - 2026-08-29
 
@@ -111,6 +113,7 @@
 - Transcript usage rows now show the total prompt-to-yield time (Δ + clock, including tool calls) after the turn timestamp, opt-in via `display.showTurnTime` (off by default).
 - `omp usage` now shows Z.AI GLM Coding Plan credit quotas (5h + weekly) with the subscribed plan tier.
 - The usage status line now labels untiered quota windows with the report's plan tier, surfacing Z.AI Coding Plan (`pro`) and Codex plan names next to the 5h/7d percentages.
+
 ### Fixed
 
 - Fixed corrupt session headers silently overwriting recoverable transcripts during resume ([#9915](https://github.com/can1357/oh-my-pi/issues/9915)).

--- a/packages/coding-agent/src/collab/crypto.ts
+++ b/packages/coding-agent/src/collab/crypto.ts
@@ -31,7 +31,7 @@ export function importRoomKey(raw: Uint8Array): Promise<CryptoKey> {
 	return crypto.subtle.importKey("raw", asStrict(raw), AES_ALGORITHM, false, ["encrypt", "decrypt"]);
 }
 
-export async function seal(key: CryptoKey, frame: CollabFrame): Promise<Uint8Array> {
+export async function seal(key: CryptoKey, frame: { t: string }): Promise<Uint8Array> {
 	const iv = new Uint8Array(IV_LENGTH);
 	crypto.getRandomValues(iv);
 	const plaintext = TEXT_ENCODER.encode(JSON.stringify(frame));
@@ -42,15 +42,21 @@ export async function seal(key: CryptoKey, frame: CollabFrame): Promise<Uint8Arr
 	return out;
 }
 
-/** Inverse of {@link seal}. Throws on auth failure or malformed input. */
-export async function open(key: CryptoKey, data: Uint8Array): Promise<CollabFrame> {
+/**
+ * Inverse of {@link seal}. Throws on auth failure or malformed input.
+ * Typed transports narrow the result to their direction's grammar.
+ */
+export async function open<Frame extends { t: string } = CollabFrame>(
+	key: CryptoKey,
+	data: Uint8Array,
+): Promise<Frame> {
 	if (data.byteLength <= IV_LENGTH) {
 		throw new Error("Sealed frame too short");
 	}
 	const iv = asStrict(data.subarray(0, IV_LENGTH));
 	const ciphertext = asStrict(data.subarray(IV_LENGTH));
 	const plaintext = new Uint8Array(await crypto.subtle.decrypt({ name: AES_ALGORITHM, iv }, key, ciphertext));
-	return JSON.parse(TEXT_DECODER.decode(plaintext)) as CollabFrame;
+	return JSON.parse(TEXT_DECODER.decode(plaintext)) as Frame;
 }
 
 function asStrict(bytes: Uint8Array): Uint8Array<ArrayBuffer> {

--- a/packages/coding-agent/src/collab/guest-manager.ts
+++ b/packages/coding-agent/src/collab/guest-manager.ts
@@ -1,0 +1,384 @@
+/**
+ * Host-side guest state machine for collab sessions.
+ *
+ * {@link GuestRegistry} owns every {@link GuestIdentity} in the room: attach
+ * on hello, detach on peer-left, role/permission mutations with an
+ * append-only audit trail (capped), and pending invitations consumed by the
+ * next matching hello. `CollabHost` maps registry events onto wire frames.
+ *
+ * Identity semantics: `guestId` is client-generated and survives reconnects
+ * within the same host session (host memory only — no disk persistence);
+ * `peerId` is the relay's ephemeral routing id and changes on reconnect.
+ * Legacy proto-3 guests get a synthesized `peer-<peerId>` id and the exact
+ * pre-4 permission surface, so upgrading the host never changes their
+ * behavior.
+ */
+import {
+	GUEST_PERMISSIONS,
+	type GuestCapabilities,
+	type GuestIdentity,
+	type GuestPermissionSet,
+	type GuestRole,
+	type GuestStatus,
+	LEGACY_FULL_PERMISSIONS,
+	type PermissionAuditEntry,
+	ROLE_DEFAULT_PERMISSIONS,
+} from "@oh-my-pi/pi-wire";
+
+const MAX_AUDIT_ENTRIES = 1000;
+const GUEST_ID_RE = /^[A-Za-z0-9][A-Za-z0-9_-]{7,63}$/;
+
+/** Every state change guests can observe, mirrored by the host as wire frames. */
+export type GuestRegistryEvent =
+	| { type: "guest-joined"; guest: GuestIdentity }
+	| { type: "guest-left"; guestId: string; reason?: string }
+	| { type: "guest-role-changed"; guestId: string; role: GuestRole; by: string }
+	| { type: "guest-permission-changed"; guestId: string; permissionsSet: GuestPermissionSet }
+	| { type: "guest-presence-changed"; guestId: string; status: GuestStatus };
+
+interface PendingInvite {
+	/** Matched case-insensitively against the joining guest's display name. */
+	nameKey: string;
+	role: GuestRole;
+	permissionsOverride?: GuestPermissionSet;
+	invitedBy: string;
+	at: number;
+}
+
+interface GuestOverrides {
+	grant: GuestPermissionSet;
+	revoke: GuestPermissionSet;
+}
+
+/** `"PROMPT|AGENT_CHAT"`-style detail strings for audit entries. */
+export function permissionNames(bits: GuestPermissionSet): string {
+	return Object.entries(GUEST_PERMISSIONS)
+		.filter(([, flag]) => (bits & flag) !== 0)
+		.map(([name]) => name)
+		.join("|");
+}
+
+export interface AttachResult {
+	identity: GuestIdentity;
+	/** True when this hello created a fresh identity (vs reattaching a known one). */
+	created: boolean;
+	/** True when the join consumed a pending invitation. */
+	invited: boolean;
+}
+
+export type AttachError = { error: "kicked" };
+
+export class GuestRegistry {
+	#guests = new Map<string, GuestIdentity>();
+	#peers = new Map<number, string>();
+	/** Role → default-permission override (host-only, affects future effective sets). */
+	#roleOverrides = new Map<GuestRole, GuestPermissionSet>();
+	#overrides = new Map<string, GuestOverrides>();
+	#invites = new Map<string, PendingInvite>();
+	#kicked = new Set<string>();
+	#audit: PermissionAuditEntry[] = [];
+	#handlers = new Set<(event: GuestRegistryEvent) => void>();
+
+	/** Subscribe to every registry event; returns an unsubscribe function. */
+	on(handler: (event: GuestRegistryEvent) => void): () => void {
+		this.#handlers.add(handler);
+		return () => {
+			this.#handlers.delete(handler);
+		};
+	}
+
+	#emit(event: GuestRegistryEvent): void {
+		for (const handler of this.#handlers) handler(event);
+	}
+
+	// ── Lookup ────────────────────────────────────────────────────────────────
+
+	byId(guestId: string): GuestIdentity | undefined {
+		return this.#guests.get(guestId);
+	}
+
+	byPeer(peerId: number): GuestIdentity | undefined {
+		const guestId = this.#peers.get(peerId);
+		return guestId ? this.#guests.get(guestId) : undefined;
+	}
+
+	list(): GuestIdentity[] {
+		return [...this.#guests.values()].sort((a, b) => a.joinedAt - b.joinedAt);
+	}
+
+	get size(): number {
+		return this.#guests.size;
+	}
+
+	/** Guests currently holding a relay peer (connected right now). */
+	onlineCount(): number {
+		let count = 0;
+		for (const identity of this.#guests.values()) {
+			if (identity.peerId >= 0) count++;
+		}
+		return count;
+	}
+
+	isKicked(guestId: string): boolean {
+		return this.#kicked.has(guestId);
+	}
+
+	hasPermissionForPeer(peerId: number, flag: GuestPermissionSet): boolean {
+		const identity = this.byPeer(peerId);
+		if (!identity) return false;
+		return (this.effectivePermissions(identity) & flag) !== 0;
+	}
+
+	/** Role defaults (with host overrides) plus per-guest grant/revoke bits. */
+	effectivePermissions(identity: GuestIdentity): GuestPermissionSet {
+		// Legacy proto-3 guests keep the exact pre-4 surface regardless of role
+		// plumbing: full-link = old mutating grammar, view-link = read-only.
+		if (identity.capabilities.protocolVersion < 4) {
+			return identity.canWrite ? LEGACY_FULL_PERMISSIONS : GUEST_PERMISSIONS.FETCH_TRANSCRIPT;
+		}
+		const base = this.#roleOverrides.get(identity.role) ?? ROLE_DEFAULT_PERMISSIONS[identity.role];
+		const override = this.#overrides.get(identity.id);
+		return (base | (override?.grant ?? 0)) & ~(override?.revoke ?? 0) & 0x1fffffff;
+	}
+
+	getRolePermissions(role: GuestRole): GuestPermissionSet {
+		return this.#roleOverrides.get(role) ?? ROLE_DEFAULT_PERMISSIONS[role];
+	}
+
+	// ── Join / leave ─────────────────────────────────────────────────────────
+
+	/**
+	 * Attach a relay peer to a guest identity. Reattaches when the client
+	 * presents a known `guestId` (reconnect: identity, role, and permission
+	 * overrides survive), otherwise consults pending invitations by name and
+	 * finally falls back to link-derived defaults (`member` for full links,
+	 * `viewer` for view links). Both paths emit `guest-joined` with the
+	 * final identity state, so subscribers never need to special-case
+	 * reconnects.
+	 */
+	attach(opts: {
+		peerId: number;
+		name: string;
+		proto: number;
+		canWrite: boolean;
+		guestId?: string;
+		capabilities?: GuestCapabilities;
+	}): AttachResult | AttachError {
+		const now = Date.now();
+		// No capability block in the hello: the client predates (or bypasses)
+		// the proto-4 handshake, so serve the pre-4 legacy surface regardless
+		// of the declared protocol version.
+		const capabilities: GuestCapabilities = opts.capabilities ?? {
+			protocolVersion: 3,
+			supportsGuestChat: false,
+			supportsPresence: false,
+			supportsCursors: false,
+		};
+		const guestId = opts.guestId && GUEST_ID_RE.test(opts.guestId) ? opts.guestId : this.#syntheticId(opts.peerId);
+
+		const existing = this.#guests.get(guestId);
+		if (existing) {
+			if (this.#kicked.has(guestId)) return { error: "kicked" };
+			// Reconnect: same identity, new pipe. The guest-joined event doubles
+			// as the "peer is back online" signal for other guests.
+			this.#peers.delete(existing.peerId);
+			existing.peerId = opts.peerId;
+			existing.name = opts.name;
+			existing.canWrite = opts.canWrite;
+			existing.capabilities = capabilities;
+			existing.status = "online";
+			existing.lastActive = now;
+			this.#peers.set(opts.peerId, guestId);
+			this.#emit({ type: "guest-joined", guest: existing });
+			return { identity: existing, created: false, invited: false };
+		}
+
+		const invite = this.#invites.get(opts.name.trim().toLowerCase());
+		const role: GuestRole = invite ? invite.role : opts.canWrite ? "member" : "viewer";
+		const identity: GuestIdentity = {
+			id: guestId,
+			peerId: opts.peerId,
+			name: opts.name,
+			role,
+			status: "online",
+			canWrite: opts.canWrite,
+			capabilities,
+			joinedAt: now,
+			lastActive: now,
+			...(invite?.invitedBy ? { invitedBy: invite.invitedBy } : {}),
+		};
+		this.#guests.set(guestId, identity);
+		this.#peers.set(opts.peerId, guestId);
+		if (invite) {
+			this.#invites.delete(invite.nameKey);
+			if (invite.permissionsOverride) {
+				this.#overrides.set(guestId, { grant: invite.permissionsOverride, revoke: 0 });
+			}
+		}
+		this.#emit({ type: "guest-joined", guest: identity });
+		return { identity, created: true, invited: !!invite };
+	}
+
+	/** Detach a relay peer; the identity stays for reconnect (status offline). */
+	detachPeer(peerId: number, reason?: string): GuestIdentity | null {
+		const guestId = this.#peers.get(peerId);
+		if (!guestId) return null;
+		this.#peers.delete(peerId);
+		const identity = this.#guests.get(guestId);
+		if (!identity || identity.peerId !== peerId) return null;
+		identity.peerId = -1;
+		identity.status = "offline";
+		identity.lastActive = Date.now();
+		this.#emit({ type: "guest-left", guestId, reason });
+		return identity;
+	}
+
+	/** Bump {@link GuestIdentity.lastActive} on any frame from the peer. */
+	touch(peerId: number): void {
+		const identity = this.byPeer(peerId);
+		if (identity) identity.lastActive = Date.now();
+	}
+
+	// ── Invitations ──────────────────────────────────────────────────────────
+
+	/**
+	 * Record a pending invitation. The next hello whose display name matches
+	 * (case-insensitive) joins with the invited role and permission bits.
+	 */
+	invite(name: string, role: GuestRole, actorId: string, permissionsOverride?: GuestPermissionSet): PendingInvite {
+		const nameKey = name.trim().toLowerCase();
+		const entry: PendingInvite = { nameKey, role, permissionsOverride, invitedBy: actorId, at: Date.now() };
+		this.#invites.set(nameKey, entry);
+		this.#pushAudit({ at: Date.now(), actorId, action: "invite", detail: `${name.trim()} as ${role}` });
+		return entry;
+	}
+
+	get pendingInviteCount(): number {
+		return this.#invites.size;
+	}
+
+	// ── Mutations ────────────────────────────────────────────────────────────
+
+	/** Disconnect and permanently reject a guestId for this session. */
+	kick(guestId: string, actorId: string, reason?: string): GuestIdentity | null {
+		const identity = this.#guests.get(guestId);
+		if (!identity) return null;
+		this.#kicked.add(guestId);
+		if (identity.peerId >= 0) this.detachPeer(identity.peerId, reason ?? "kicked");
+		this.#pushAudit({ at: Date.now(), actorId, action: "kick", target: guestId, detail: reason ?? "kicked" });
+		return identity;
+	}
+
+	setRole(guestId: string, role: GuestRole, actorId: string): GuestIdentity | null {
+		const identity = this.#guests.get(guestId);
+		if (!identity || identity.role === role) return identity ?? null;
+		const previous = identity.role;
+		identity.role = role;
+		this.#pushAudit({
+			at: Date.now(),
+			actorId,
+			action: "role-change",
+			target: guestId,
+			detail: `${previous} -> ${role}`,
+		});
+		this.#emit({ type: "guest-role-changed", guestId, role, by: actorId });
+		this.#emitPermissions(guestId);
+		return identity;
+	}
+
+	setRolePermissions(role: GuestRole, permissions: GuestPermissionSet): void {
+		this.#roleOverrides.set(role, permissions & 0x1fffffff);
+		// Re-broadcast effective sets for every guest whose role defaults moved.
+		for (const identity of this.#guests.values()) {
+			if (identity.role === role && identity.capabilities.protocolVersion >= 4) {
+				this.#emitPermissions(identity.id);
+			}
+		}
+	}
+
+	grantPermission(guestId: string, bits: GuestPermissionSet, actorId: string): GuestIdentity | null {
+		const identity = this.#guests.get(guestId);
+		if (!identity || bits === 0) return identity ?? null;
+		const override = this.#overrides.get(guestId) ?? { grant: 0, revoke: 0 };
+		override.grant |= bits;
+		override.revoke &= ~bits;
+		this.#overrides.set(guestId, override);
+		this.#pushAudit({ at: Date.now(), actorId, action: "grant", target: guestId, detail: permissionNames(bits) });
+		this.#emitPermissions(guestId);
+		return identity;
+	}
+
+	revokePermission(guestId: string, bits: GuestPermissionSet, actorId: string): GuestIdentity | null {
+		const identity = this.#guests.get(guestId);
+		if (!identity || bits === 0) return identity ?? null;
+		const override = this.#overrides.get(guestId) ?? { grant: 0, revoke: 0 };
+		override.revoke |= bits;
+		override.grant &= ~bits;
+		this.#overrides.set(guestId, override);
+		this.#pushAudit({ at: Date.now(), actorId, action: "revoke", target: guestId, detail: permissionNames(bits) });
+		this.#emitPermissions(guestId);
+		return identity;
+	}
+
+	/** Drop per-guest overrides; the guest falls back to its role defaults. */
+	clearGuestOverrides(guestId: string, actorId: string): GuestIdentity | null {
+		const identity = this.#guests.get(guestId);
+		if (!identity || !this.#overrides.delete(guestId)) return identity ?? null;
+		this.#pushAudit({ at: Date.now(), actorId, action: "revoke", target: guestId, detail: "overrides cleared" });
+		this.#emitPermissions(guestId);
+		return identity;
+	}
+
+	updateStatus(peerId: number, status: GuestStatus): GuestIdentity | null {
+		const identity = this.byPeer(peerId);
+		if (!identity) return null;
+		if (identity.status === status) return identity;
+		identity.status = status;
+		identity.lastActive = Date.now();
+		this.#emit({ type: "guest-presence-changed", guestId: identity.id, status });
+		return identity;
+	}
+
+	// ── Audit ────────────────────────────────────────────────────────────────
+
+	auditLog(guestId?: string, limit?: number): PermissionAuditEntry[] {
+		let entries = this.#audit;
+		if (guestId) entries = entries.filter(entry => entry.target === guestId || entry.actorId === guestId);
+		return limit !== undefined && limit < entries.length ? entries.slice(-limit) : [...entries];
+	}
+
+	/** JSONL export, oldest first. */
+	exportAuditLog(): string {
+		return this.#audit.map(entry => JSON.stringify(entry)).join("\n");
+	}
+
+	/** Drop every guest, invite, override, and audit record (session teardown). */
+	clear(): void {
+		this.#guests.clear();
+		this.#peers.clear();
+		this.#roleOverrides.clear();
+		this.#overrides.clear();
+		this.#invites.clear();
+		this.#kicked.clear();
+		this.#audit = [];
+	}
+
+	// ── Internals ────────────────────────────────────────────────────────────
+
+	#syntheticId(peerId: number): string {
+		return `peer-${peerId}`;
+	}
+
+	#emitPermissions(guestId: string): void {
+		const identity = this.#guests.get(guestId);
+		if (!identity) return;
+		this.#emit({ type: "guest-permission-changed", guestId, permissionsSet: this.effectivePermissions(identity) });
+	}
+
+	#pushAudit(entry: PermissionAuditEntry): void {
+		this.#audit.push(entry);
+		if (this.#audit.length > MAX_AUDIT_ENTRIES) {
+			this.#audit.splice(0, this.#audit.length - MAX_AUDIT_ENTRIES);
+		}
+	}
+}

--- a/packages/coding-agent/src/collab/guest.ts
+++ b/packages/coding-agent/src/collab/guest.ts
@@ -29,12 +29,21 @@ import { emitSubagentFrame } from "../utils/event-bus";
 import { setSessionTerminalTitle } from "../utils/title-generator";
 import { importRoomKey } from "./crypto";
 import { collabDisplayName } from "./display-name";
+import { permissionNames } from "./guest-manager";
 import {
 	type AgentSnapshot,
 	COLLAB_PROTO,
 	type CollabFrame,
+	type CollabGuestFrame,
+	type CollabHostFrame,
 	type CollabSessionState,
 	type CollabUiRequest,
+	GUEST_PERMISSIONS,
+	type GuestIdentity,
+	type GuestPermissionSet,
+	type GuestRole,
+	type GuestStatus,
+	LEGACY_FULL_PERMISSIONS,
 	parseCollabLink,
 } from "./protocol";
 import { CollabSocket } from "./relay-client";
@@ -78,6 +87,12 @@ interface PendingSnapshot {
 	state: WelcomeFrame["state"];
 	agents: AgentSnapshot[];
 	readOnly: boolean;
+	/** Proto-4 only: the identity the host assigned to this guest. */
+	self?: GuestIdentity;
+	/** Proto-4 only: every current guest in the room (including self). */
+	guests?: GuestIdentity[];
+	/** Proto-4 only: the host's effective permission bitmask for self. */
+	permissionsSet?: GuestPermissionSet;
 	entryCount: number;
 	entries: SessionEntry[];
 	isResync: boolean;
@@ -158,7 +173,7 @@ export function reconcileGuestSnapshotHostState(ctx: GuestSnapshotActivityReconc
 
 export class CollabGuestLink {
 	#ctx: InteractiveModeContext;
-	#socket: CollabSocket | null = null;
+	#socket: CollabSocket<CollabGuestFrame, CollabHostFrame> | null = null;
 	#roomId = "";
 	/** Previous session file to restore on leave; null = previous session was unsaved. */
 	#returnSessionFile: string | null = null;
@@ -184,8 +199,16 @@ export class CollabGuestLink {
 	#snapshotProgressTimer: Timer | null = null;
 	/** base64url write token from a full link; absent when joined via a view link. */
 	#writeToken: string | undefined;
-	/** True when the host marked this peer read-only (view link). */
+	/** True when the guest cannot prompt (view link, or a proto-4 role without PROMPT). */
 	#readOnly = false;
+	/** Client-generated identity; stable across reconnects within this link. */
+	readonly #guestId = `g-${crypto.randomUUID().replaceAll("-", "")}`;
+	/** Identity the host assigned (proto-4); null when talking to a legacy host. */
+	#self: GuestIdentity | null = null;
+	/** Local mirror of the room roster (proto-4). */
+	#guestsById = new Map<string, GuestIdentity>();
+	/** Effective permission bitmask from the latest welcome / permission frame. */
+	#permissions = 0;
 	/** False until the first assistant message_start (real or synthesized) since (re)sync. */
 	#assistantStreamSynced = false;
 	state: CollabSessionState | null = null;
@@ -199,15 +222,15 @@ export class CollabGuestLink {
 	#nextReqId = 1;
 	readonly #hubRemote: AgentHubRemote = {
 		chat: (id, text) => {
-			if (this.#rejectReadOnly()) return;
+			if (this.#requirePermission(GUEST_PERMISSIONS.AGENT_CHAT, "agent chat")) return;
 			this.#socket?.send({ t: "agent-cmd", cmd: "chat", agentId: id, text });
 		},
 		kill: id => {
-			if (this.#rejectReadOnly()) return;
+			if (this.#requirePermission(GUEST_PERMISSIONS.AGENT_KILL, "killing agents")) return;
 			this.#socket?.send({ t: "agent-cmd", cmd: "kill", agentId: id });
 		},
 		revive: id => {
-			if (this.#rejectReadOnly()) return;
+			if (this.#requirePermission(GUEST_PERMISSIONS.AGENT_REVIVE, "reviving agents")) return;
 			this.#socket?.send({ t: "agent-cmd", cmd: "revive", agentId: id });
 		},
 		readTranscript: (id, fromByte) => {
@@ -240,10 +263,13 @@ export class CollabGuestLink {
 		return this.#readOnly;
 	}
 
-	/** Shows the read-only status hint when applicable; true when the action must be dropped. */
-	#rejectReadOnly(): boolean {
-		if (!this.#readOnly) return false;
-		this.#ctx.showStatus("This collab link is read-only");
+	/**
+	 * Pre-flight a permission-gated action; true when it must be dropped. The
+	 * host re-checks every frame, so this only shapes local UX.
+	 */
+	#requirePermission(flag: GuestPermissionSet, action: string): boolean {
+		if ((this.#permissions & flag) !== 0) return false;
+		this.#ctx.showStatus(`${action} requires the ${permissionNames(flag)} permission`);
 		return true;
 	}
 
@@ -260,7 +286,7 @@ export class CollabGuestLink {
 
 		this.#returnSessionFile = this.#ctx.sessionManager.getSessionFile() ?? null;
 
-		const socket = new CollabSocket({ wsUrl: parsed.wsUrl, role: "guest", key });
+		const socket = new CollabSocket<CollabGuestFrame, CollabHostFrame>({ wsUrl: parsed.wsUrl, role: "guest", key });
 		this.#socket = socket;
 
 		const firstWelcome = Promise.withResolvers<void>();
@@ -287,6 +313,13 @@ export class CollabGuestLink {
 				proto: COLLAB_PROTO,
 				name: collabDisplayName(this.#ctx),
 				writeToken: this.#writeToken,
+				guestId: this.#guestId,
+				capabilities: {
+					protocolVersion: COLLAB_PROTO,
+					supportsGuestChat: true,
+					supportsPresence: true,
+					supportsCursors: false,
+				},
 			});
 		};
 		socket.onFrame = frame => {
@@ -377,13 +410,62 @@ export class CollabGuestLink {
 	}
 
 	sendPrompt(text: string, images?: ImageContent[]): void {
-		if (this.#rejectReadOnly()) return;
+		if (this.#requirePermission(GUEST_PERMISSIONS.PROMPT, "prompting the host")) return;
 		this.#socket?.send({ t: "prompt", text, images: images && images.length > 0 ? images : undefined });
 	}
 
 	sendAbort(): void {
-		if (this.#rejectReadOnly()) return;
+		if (this.#requirePermission(GUEST_PERMISSIONS.ABORT, "interrupting the host")) return;
 		this.#socket?.send({ t: "abort" });
+	}
+
+	// ── Guest management / inter-guest (proto-4) ────────────────────────────
+
+	/** Send a guest-to-guest chat message; `to` defaults to broadcast. */
+	sendGuestMessage(text: string, to: string | "broadcast" = "broadcast"): void {
+		if (this.#requirePermission(GUEST_PERMISSIONS.GUEST_CHAT, "guest chat")) return;
+		this.#socket?.send({ t: "guest-message", to, text });
+	}
+
+	/** Publish this guest's presence status. */
+	sendGuestPresence(status: GuestStatus): void {
+		this.#socket?.send({ t: "guest-presence", status });
+	}
+
+	/** Invite a display name; the host applies {@link role} when they join. */
+	inviteGuest(name: string, role: GuestRole): void {
+		if (this.#requirePermission(GUEST_PERMISSIONS.GUEST_INVITE, "inviting guests")) return;
+		this.#socket?.send({ t: "guest-invite", name, role });
+	}
+
+	kickGuest(guestId: string, reason?: string): void {
+		if (this.#requirePermission(GUEST_PERMISSIONS.GUEST_KICK, "kicking guests")) return;
+		this.#socket?.send({ t: "guest-kick", guestId, reason });
+	}
+
+	setGuestRole(guestId: string, role: GuestRole): void {
+		if (this.#requirePermission(GUEST_PERMISSIONS.GUEST_ROLE, "changing roles")) return;
+		this.#socket?.send({ t: "guest-role", guestId, role });
+	}
+
+	grantGuestPermissions(guestId: string, bits: GuestPermissionSet): void {
+		if (this.#requirePermission(GUEST_PERMISSIONS.PERMISSION_MANAGE, "permission changes")) return;
+		this.#socket?.send({ t: "guest-permission", guestId, grant: bits, revoke: 0 });
+	}
+
+	revokeGuestPermissions(guestId: string, bits: GuestPermissionSet): void {
+		if (this.#requirePermission(GUEST_PERMISSIONS.PERMISSION_MANAGE, "permission changes")) return;
+		this.#socket?.send({ t: "guest-permission", guestId, grant: 0, revoke: bits });
+	}
+
+	/** Room roster as of the latest welcome/join/left frames, oldest join first. */
+	get guests(): GuestIdentity[] {
+		return [...this.#guestsById.values()].sort((a, b) => a.joinedAt - b.joinedAt);
+	}
+
+	/** This guest's host-assigned identity (proto-4); null for legacy hosts. */
+	get self(): GuestIdentity | null {
+		return this.#self;
 	}
 
 	/**
@@ -402,6 +484,9 @@ export class CollabGuestLink {
 			entryCount: frame.entryCount,
 			entries: [],
 			isResync,
+			self: frame.self,
+			guests: frame.guests,
+			permissionsSet: frame.permissionsSet,
 		};
 		this.#armSnapshotProgressTimer();
 	}
@@ -457,12 +542,32 @@ export class CollabGuestLink {
 		await this.#ctx.renderInitialMessages({ clearTerminalHistory: true });
 		await this.#ctx.reloadTodos();
 		this.#updateStatusSegment();
-		this.#readOnly = pending.readOnly;
+		if (pending.self) {
+			this.#applyRoomIdentity(pending.self, pending.guests, pending.permissionsSet);
+		} else {
+			// Legacy host: exact pre-4 surface derived from the link variant.
+			this.#self = null;
+			this.#guestsById.clear();
+			this.#permissions = pending.readOnly ? GUEST_PERMISSIONS.FETCH_TRANSCRIPT : LEGACY_FULL_PERMISSIONS;
+			this.#readOnly = pending.readOnly;
+		}
 		this.#welcomed = true;
 		const suffix = this.#readOnly ? " (read-only)" : "";
 		this.#ctx.showStatus(
 			pending.isResync ? `Reconnected to collab session${suffix}` : `Joined collab session${suffix}`,
 		);
+	}
+
+	/** Latch the proto-4 welcome identity block and derive the local action surface. */
+	#applyRoomIdentity(
+		self: GuestIdentity,
+		guests: GuestIdentity[] | undefined,
+		permissionsSet: GuestPermissionSet | undefined,
+	): void {
+		this.#self = self;
+		this.#guestsById = new Map((guests ?? [self]).map(identity => [identity.id, identity]));
+		this.#permissions = permissionsSet ?? LEGACY_FULL_PERMISSIONS;
+		this.#readOnly = (this.#permissions & GUEST_PERMISSIONS.PROMPT) === 0;
 	}
 
 	#armWelcomeTimer(): void {
@@ -497,7 +602,7 @@ export class CollabGuestLink {
 		}
 	}
 
-	#applyFrame(frame: CollabFrame): void {
+	#applyFrame(frame: CollabHostFrame): void {
 		switch (frame.t) {
 			case "entry": {
 				// Entries are never rendered directly — rendering is events-only
@@ -554,6 +659,44 @@ export class CollabGuestLink {
 				}
 				break;
 			}
+			case "guest-joined":
+				this.#guestsById.set(frame.guest.id, frame.guest);
+				if (frame.guest.id !== this.#self?.id) {
+					this.#ctx.showStatus(`${frame.guest.name} joined the collab session`);
+				}
+				break;
+			case "guest-left": {
+				const left = this.#guestsById.get(frame.guestId);
+				if (left) left.status = "offline";
+				this.#ctx.showStatus(`${left?.name ?? frame.guestId} left the collab session`);
+				break;
+			}
+			case "guest-role-changed": {
+				const member = this.#guestsById.get(frame.guestId);
+				if (member) member.role = frame.role;
+				if (frame.guestId === this.#self?.id) {
+					this.#ctx.showStatus(`Your role is now ${frame.role} (changed by ${frame.by})`);
+				}
+				break;
+			}
+			case "guest-permission-changed":
+				if (frame.guestId === this.#self?.id) {
+					this.#permissions = frame.permissionsSet;
+					this.#readOnly = (frame.permissionsSet & GUEST_PERMISSIONS.PROMPT) === 0;
+					this.#ctx.showStatus(`Your permissions changed (${permissionNames(frame.permissionsSet) || "none"})`);
+				}
+				break;
+			case "guest-presence": {
+				const present = this.#guestsById.get(frame.guestId);
+				if (present) present.status = frame.status;
+				break;
+			}
+			case "guest-message":
+				this.#ctx.showStatus(`${frame.from.name}: ${frame.text}`, { dim: frame.kind === "system" });
+				break;
+			case "guest-cursor":
+				// The TUI has no cursor surface; cursors exist for the web client.
+				break;
 			case "bye": {
 				this.#ctx.showStatus(`Collab session ended (${frame.reason})`);
 				this.#socket?.close();
@@ -665,8 +808,9 @@ export class CollabGuestLink {
 	 * the host settled the request elsewhere; that path must NOT respond.
 	 */
 	#presentUiRequest(request: CollabUiRequest): void {
-		// The host only targets writable peers; drop defensively on a read-only link.
-		if (this.#readOnly || this.#pendingUiRequests.has(request.reqId)) return;
+		// The host only targets UI-response-capable peers; drop defensively.
+		if (this.#requirePermission(GUEST_PERMISSIONS.UI_RESPONSE, "answering host asks")) return;
+		if (this.#pendingUiRequests.has(request.reqId)) return;
 		const abort = new AbortController();
 		this.#pendingUiRequests.set(request.reqId, abort);
 		const dialog =

--- a/packages/coding-agent/src/collab/host.ts
+++ b/packages/coding-agent/src/collab/host.ts
@@ -30,17 +30,25 @@ import type { SessionEntry as StoredSessionEntry } from "../session/session-entr
 import { TASK_SUBAGENT_LIFECYCLE_CHANNEL, TASK_SUBAGENT_PROGRESS_CHANNEL } from "../task/types";
 import { generateRoomKey, generateWriteToken, importRoomKey } from "./crypto";
 import { collabDisplayName } from "./display-name";
+import { GuestRegistry, type GuestRegistryEvent, permissionNames } from "./guest-manager";
 import {
 	type AgentSnapshot,
 	COLLAB_PROMPT_MESSAGE_TYPE,
 	COLLAB_PROTO,
-	type CollabFrame,
+	type CollabGuestFrame,
+	type CollabHostFrame,
 	type CollabParticipant,
 	type CollabPromptDetails,
 	type CollabSessionState,
 	formatCollabLink,
 	formatCollabWebLink,
+	GUEST_PERMISSIONS,
+	type GuestIdentity,
+	type GuestPermissionSet,
+	type GuestRole,
+	type GuestStatus,
 	generateRoomId,
+	type PermissionAuditEntry,
 	parseCollabLink,
 } from "./protocol";
 import { CollabSocket } from "./relay-client";
@@ -122,7 +130,7 @@ export type CollabGuestUiResult = { kind: "answered"; value: CollabUiResponseVal
 
 export class CollabHost {
 	#ctx: InteractiveModeContext;
-	#socket: CollabSocket | null = null;
+	#socket: CollabSocket<CollabHostFrame, CollabGuestFrame> | null = null;
 	#link = "";
 	#webLink = "";
 	#viewLink = "";
@@ -130,7 +138,7 @@ export class CollabHost {
 	#writeToken: Uint8Array | null = null;
 	#sessionId = "";
 	#unsubscribe?: () => void;
-	#peers = new Map<number, { name: string; canWrite: boolean }>();
+	#guests = new GuestRegistry();
 	#uiReqSeq = 0;
 	#pendingUi = new Map<number, { request: CollabUiRequest; settle(result: CollabGuestUiResult): void }>();
 	#lastStateJson = "";
@@ -139,6 +147,7 @@ export class CollabHost {
 	#agentsDebounce: Timer | null = null;
 	#busUnsubscribers: (() => void)[] = [];
 	#registryUnsubscribe?: () => void;
+	#guestsUnsubscribe?: () => void;
 	#stopped = false;
 
 	constructor(ctx: InteractiveModeContext) {
@@ -163,17 +172,19 @@ export class CollabHost {
 	get webViewLink(): string {
 		return this.#webViewLink;
 	}
-
 	get participants(): CollabParticipant[] {
 		const list: CollabParticipant[] = [{ name: collabDisplayName(this.#ctx), role: "host" }];
-		for (const peer of this.#peers.values()) {
-			list.push({ name: peer.name, role: "guest", readOnly: peer.canWrite ? undefined : true });
+		for (const identity of this.#guests.list()) {
+			list.push({
+				name: identity.name,
+				role: "guest",
+				readOnly: (this.#guests.effectivePermissions(identity) & GUEST_PERMISSIONS.PROMPT) === 0 || undefined,
+			});
 		}
 		return list;
 	}
-
 	requestGuestUi(request: CollabUiRequestDraft, signal?: AbortSignal): Promise<CollabGuestUiResult> | null {
-		if (!this.#socket || !this.#hasWritablePeers()) return null;
+		if (!this.#socket || !this.#hasUiResponders()) return null;
 		const reqId = ++this.#uiReqSeq;
 		const fullRequest: CollabUiRequest = { ...request, reqId };
 		const { promise, resolve } = Promise.withResolvers<CollabGuestUiResult>();
@@ -181,31 +192,50 @@ export class CollabHost {
 		const settle = (result: CollabGuestUiResult): void => {
 			if (settled) return;
 			settled = true;
-			signal?.removeEventListener("abort", onAbort);
+			// Remove before the end-frame: a settled request must never replay
+			// to guests that join later (only unanswered asks stay queued).
 			this.#pendingUi.delete(reqId);
-			this.#sendWritablePeers({ t: "ui-request-end", reqId });
+			this.#sendUiCapable({ t: "ui-request-end", reqId });
 			resolve(result);
 		};
 		const onAbort = (): void => settle({ kind: "unavailable" });
 		if (signal?.aborted) return Promise.resolve({ kind: "unavailable" });
 		signal?.addEventListener("abort", onAbort, { once: true });
 		this.#pendingUi.set(reqId, { request: fullRequest, settle });
-		this.#sendWritablePeers({ t: "ui-request", request: fullRequest });
+		this.#sendUiCapable({ t: "ui-request", request: fullRequest });
 		return promise;
 	}
-
-	#hasWritablePeers(): boolean {
-		for (const peer of this.#peers.values()) {
-			if (peer.canWrite) return true;
+	/** True when at least one connected guest holds the UI_RESPONSE bit. */
+	#hasUiResponders(): boolean {
+		for (const identity of this.#guests.list()) {
+			if (identity.peerId < 0) continue;
+			if ((this.#guests.effectivePermissions(identity) & GUEST_PERMISSIONS.UI_RESPONSE) !== 0) return true;
 		}
 		return false;
 	}
 
-	#sendWritablePeers(frame: CollabFrame): void {
+	/** Target every connected guest holding the UI_RESPONSE bit (proto-3 guests included). */
+	#sendUiCapable(frame: CollabHostFrame): void {
 		const socket = this.#socket;
 		if (!socket) return;
-		for (const [peerId, peer] of this.#peers) {
-			if (peer.canWrite) socket.send(frame, peerId);
+		for (const identity of this.#guests.list()) {
+			if (identity.peerId < 0) continue;
+			if ((this.#guests.effectivePermissions(identity) & GUEST_PERMISSIONS.UI_RESPONSE) === 0) continue;
+			socket.send(frame, identity.peerId);
+		}
+	}
+
+	/**
+	 * Target a frame at every connected proto-4 guest. Legacy guests are never
+	 * sent guest-management/chat frames; `gate` narrows further by capability.
+	 */
+	#sendToGuests(frame: CollabHostFrame, gate?: (identity: GuestIdentity) => boolean): void {
+		const socket = this.#socket;
+		if (!socket) return;
+		for (const identity of this.#guests.list()) {
+			if (identity.peerId < 0 || identity.capabilities.protocolVersion < 4) continue;
+			if (gate && !gate(identity)) continue;
+			socket.send(frame, identity.peerId);
 		}
 	}
 
@@ -222,7 +252,7 @@ export class CollabHost {
 		if ("error" in parsed) throw new Error(parsed.error);
 		const key = await importRoomKey(rawKey);
 
-		const socket = new CollabSocket({ wsUrl: parsed.wsUrl, role: "host", key });
+		const socket = new CollabSocket<CollabHostFrame, CollabGuestFrame>({ wsUrl: parsed.wsUrl, role: "host", key });
 		this.#socket = socket;
 		this.#sessionId = this.#ctx.sessionManager.getSessionId();
 
@@ -285,6 +315,7 @@ export class CollabHost {
 			}
 		}
 		this.#registryUnsubscribe = AgentRegistry.global().onChange(() => this.#scheduleAgentsBroadcast());
+		this.#guestsUnsubscribe = this.#guests.on(event => this.#onGuestEvent(event));
 		this.#ctx.sessionManager.onEntryAppended = entry => {
 			if (isWireSessionEntry(entry)) this.#broadcast({ t: "entry", entry: shrinkForReplication(entry) });
 			// Model/thinking/title changes land as entries while idle; refresh
@@ -311,6 +342,8 @@ export class CollabHost {
 		this.#busUnsubscribers = [];
 		this.#registryUnsubscribe?.();
 		this.#registryUnsubscribe = undefined;
+		this.#guestsUnsubscribe?.();
+		this.#guestsUnsubscribe = undefined;
 		clearTimeout(this.#stateDebounce ?? undefined);
 		this.#stateDebounce = null;
 		clearTimeout(this.#agentsDebounce ?? undefined);
@@ -319,7 +352,6 @@ export class CollabHost {
 		this.#streamingInterval = null;
 		for (const pending of this.#pendingUi.values()) pending.settle({ kind: "unavailable" });
 		this.#pendingUi.clear();
-		this.#peers.clear();
 		this.#socket?.close();
 		this.#socket = null;
 		this.#ctx.collabHost = undefined;
@@ -327,7 +359,7 @@ export class CollabHost {
 		this.#ctx.ui.requestRender();
 	}
 
-	#broadcast(frame: CollabFrame): void {
+	#broadcast(frame: CollabHostFrame): void {
 		if (this.#stopped || !this.#socket) return;
 		if (this.#ctx.sessionManager.getSessionId() !== this.#sessionId) {
 			void this.stop("session switched");
@@ -337,10 +369,64 @@ export class CollabHost {
 		this.#socket.send(frame);
 	}
 
-	#handleFrame(frame: CollabFrame, fromPeer: number): void {
+	/**
+	 * Map a {@link GuestRegistryEvent} onto the wire for observing guests and
+	 * refresh the host's own surfaces. Guest frames go only to proto-4
+	 * guests; legacy guests are never invited into the newer grammar.
+	 */
+	#onGuestEvent(event: GuestRegistryEvent): void {
+		if (this.#stopped || !this.#socket) return;
+		switch (event.type) {
+			case "guest-joined": {
+				// Re-read on reattach: the event may carry the pre-reconnect peerId.
+				const guest = this.#guests.byId(event.guest.id) ?? event.guest;
+				const viewOnly = (this.#guests.effectivePermissions(guest) & GUEST_PERMISSIONS.PROMPT) === 0;
+				// The joining guest learns its identity from welcome; the event is
+				// for everyone else.
+				this.#sendToGuests({ t: "guest-joined", guest }, identity => identity.id !== guest.id);
+				this.#ctx.session.emitNotice(
+					"info",
+					`${guest.name} joined the collab session${viewOnly ? " (view-only)" : ""}`,
+					"collab",
+				);
+				this.#updateStatusSegment();
+				this.#scheduleStateBroadcast();
+				break;
+			}
+			case "guest-left": {
+				const name = this.#guests.byId(event.guestId)?.name ?? "a guest";
+				this.#sendToGuests({ t: "guest-left", guestId: event.guestId, reason: event.reason });
+				this.#ctx.session.emitNotice("info", `${name} left the collab session`, "collab");
+				this.#updateStatusSegment();
+				this.#scheduleStateBroadcast();
+				break;
+			}
+			case "guest-role-changed":
+				this.#sendToGuests({ t: "guest-role-changed", guestId: event.guestId, role: event.role, by: event.by });
+				this.#scheduleStateBroadcast();
+				break;
+			case "guest-permission-changed":
+				this.#sendToGuests({
+					t: "guest-permission-changed",
+					guestId: event.guestId,
+					permissionsSet: event.permissionsSet,
+				});
+				this.#scheduleStateBroadcast();
+				break;
+			case "guest-presence-changed":
+				this.#sendToGuests(
+					{ t: "guest-presence", guestId: event.guestId, status: event.status },
+					identity => identity.capabilities.supportsPresence,
+				);
+				break;
+		}
+	}
+
+	#handleFrame(frame: CollabGuestFrame, fromPeer: number): void {
+		if (frame.t !== "hello") this.#guests.touch(fromPeer);
 		switch (frame.t) {
 			case "hello":
-				this.#handleHello(frame.name, frame.proto, frame.writeToken, fromPeer);
+				this.#handleHello(frame, fromPeer);
 				break;
 			case "prompt":
 				this.#handlePrompt(frame.text, frame.images, fromPeer);
@@ -357,8 +443,34 @@ export class CollabHost {
 			case "fetch-transcript":
 				void this.#handleFetchTranscript(frame.reqId, frame.agentId, frame.fromByte, fromPeer);
 				break;
+			case "guest-invite":
+				this.#handleGuestInvite(frame.name, frame.role, frame.permissionsOverride, fromPeer);
+				break;
+			case "guest-kick":
+				this.#handleGuestKick(frame.guestId, frame.reason, fromPeer);
+				break;
+			case "guest-role":
+				this.#handleGuestRole(frame.guestId, frame.role, fromPeer);
+				break;
+			case "guest-permission":
+				this.#handleGuestPermission(frame.guestId, frame.grant, frame.revoke, fromPeer);
+				break;
+			case "guest-message":
+				this.#handleGuestMessage(frame.to, frame.text, frame.kind, fromPeer);
+				break;
+			case "guest-presence":
+				this.#handleGuestPresence(frame.status, fromPeer);
+				break;
+			case "guest-cursor":
+				this.#handleGuestCursor(frame.agentId, frame.position, fromPeer);
+				break;
+			case "permission-audit":
+				this.#handlePermissionAudit(frame.reqId, frame.guestId, frame.limit, fromPeer);
+				break;
 			default:
-				logger.debug("collab host ignoring unexpected frame", { type: frame.t, fromPeer });
+				// Default is unreachable for the declared grammar; reachable for
+				// runtime garbage, so log the frame itself instead of a field.
+				logger.debug("collab host ignoring unexpected frame", { frame, fromPeer });
 		}
 	}
 
@@ -370,22 +482,50 @@ export class CollabHost {
 		return bytes.byteLength === expected.byteLength && timingSafeEqual(bytes, expected);
 	}
 
-	/** Reject a mutating frame from a read-only peer with a targeted error. */
-	#rejectReadOnly(action: string, fromPeer: number): void {
-		this.#socket?.send({ t: "error", message: `${action} is disabled on a read-only link` }, fromPeer);
+	/**
+	 * Targeted denial when {@link fromPeer} lacks {@link flag}; true when the
+	 * action may proceed.
+	 */
+	#checkPermission(flag: GuestPermissionSet, action: string, fromPeer: number): boolean {
+		if (this.#guests.hasPermissionForPeer(fromPeer, flag)) return true;
+		this.#socket?.send(
+			{ t: "error", message: `${action} requires the ${permissionNames(flag)} permission` },
+			fromPeer,
+		);
+		return false;
 	}
 
-	#handleHello(name: string, proto: number, writeToken: string | undefined, fromPeer: number): void {
-		if (proto !== COLLAB_PROTO) {
+	#handleHello(frame: Extract<CollabGuestFrame, { t: "hello" }>, fromPeer: number): void {
+		// Proto-3 guests (pre-guest-management builds) speak a subset of the
+		// grammar and are served the legacy surface; only older-than-ui-request
+		// versions are rejected outright (their welcome would hang the ask
+		// flow — see the COLLAB_PROTO history in @oh-my-pi/pi-wire).
+		if (frame.proto < 3 || frame.proto > COLLAB_PROTO) {
 			this.#socket?.send(
-				{ t: "error", message: `protocol mismatch: host speaks v${COLLAB_PROTO}, guest sent v${proto}` },
+				{ t: "error", message: `protocol mismatch: host speaks v${COLLAB_PROTO}, guest sent v${frame.proto}` },
 				fromPeer,
 			);
 			return;
 		}
-		const cleanName = name.trim().slice(0, 64) || `guest-${fromPeer}`;
-		const canWrite = this.#verifyWriteToken(writeToken);
-		this.#peers.set(fromPeer, { name: cleanName, canWrite });
+		const cleanName = frame.name.trim().slice(0, 64) || `guest-${fromPeer}`;
+		const canWrite = this.#verifyWriteToken(frame.writeToken);
+		const attached = this.#guests.attach({
+			peerId: fromPeer,
+			name: cleanName,
+			proto: frame.proto,
+			canWrite,
+			guestId: frame.guestId,
+			capabilities: frame.capabilities,
+		});
+		const socket = this.#socket;
+		if (!socket) return;
+		if ("error" in attached) {
+			// Kicked identity rejoining: refuse with a targeted goodbye.
+			socket.send({ t: "bye", reason: "removed from this session" }, fromPeer);
+			return;
+		}
+		const identity = attached.identity;
+		const modern = identity.capabilities.protocolVersion >= 4;
 
 		// Snapshot and send synchronously: no awaits between snapshot, welcome,
 		// and chunk sends, so subsequent broadcast frames (entry/event/state/bus)
@@ -400,31 +540,33 @@ export class CollabHost {
 			logger.info("collab welcome exceeded size threshold; stripped images", { stripped });
 		}
 		const entries = snapshot.entries.filter(isWireSessionEntry);
-		const socket = this.#socket;
-		if (!socket) return;
 		socket.send(
 			{
 				t: "welcome",
-				proto: COLLAB_PROTO,
+				// Negotiated per-peer version: proto-3 guests are served the
+				// legacy grammar, so the welcome promises v3 to them.
+				proto: Math.min(frame.proto, COLLAB_PROTO),
 				header: snapshot.header,
 				state: this.#buildState(),
 				agents: this.#snapshotAgents(),
 				entryCount: entries.length,
 				readOnly: canWrite ? undefined : true,
+				...(modern
+					? {
+							self: identity,
+							guests: this.#guests.list(),
+							permissionsSet: this.#guests.effectivePermissions(identity),
+						}
+					: {}),
 			},
 			fromPeer,
 		);
 		this.#sendSnapshotChunks(entries, fromPeer);
-		if (canWrite) {
+		if ((this.#guests.effectivePermissions(identity) & GUEST_PERMISSIONS.UI_RESPONSE) !== 0) {
 			for (const pending of this.#pendingUi.values()) {
 				socket.send({ t: "ui-request", request: pending.request }, fromPeer);
 			}
 		}
-		this.#ctx.session.emitNotice(
-			"info",
-			`${cleanName} joined the collab session${canWrite ? "" : " (read-only)"}`,
-			"collab",
-		);
 		this.#updateStatusSegment();
 		this.#scheduleStateBroadcast();
 	}
@@ -465,21 +607,13 @@ export class CollabHost {
 	}
 
 	#handleUiResponse(reqId: number, value: CollabUiResponseValue, fromPeer: number): void {
-		const peer = this.#peers.get(fromPeer);
-		if (!peer?.canWrite) {
-			this.#rejectReadOnly("responding to ask", fromPeer);
-			return;
-		}
+		if (!this.#checkPermission(GUEST_PERMISSIONS.UI_RESPONSE, "responding to ask", fromPeer)) return;
 		this.#pendingUi.get(reqId)?.settle({ kind: "answered", value });
 	}
 
 	#handlePrompt(text: string, images: ImageContent[] | undefined, fromPeer: number): void {
-		const peer = this.#peers.get(fromPeer);
-		if (!peer?.canWrite) {
-			this.#rejectReadOnly("prompting", fromPeer);
-			return;
-		}
-		const name = peer.name;
+		if (!this.#checkPermission(GUEST_PERMISSIONS.PROMPT, "prompting", fromPeer)) return;
+		const name = this.#guests.byPeer(fromPeer)?.name ?? "a guest";
 		const content: string | (TextContent | ImageContent)[] =
 			images && images.length > 0 ? [{ type: "text", text }, ...images] : text;
 		const details: CollabPromptDetails = { from: name };
@@ -506,12 +640,8 @@ export class CollabHost {
 	}
 
 	#handleAbort(fromPeer: number): void {
-		const peer = this.#peers.get(fromPeer);
-		if (!peer?.canWrite) {
-			this.#rejectReadOnly("interrupting", fromPeer);
-			return;
-		}
-		const name = peer.name;
+		if (!this.#checkPermission(GUEST_PERMISSIONS.ABORT, "interrupting", fromPeer)) return;
+		const name = this.#guests.byPeer(fromPeer)?.name ?? "a guest";
 		void this.#ctx.session
 			.abort({ reason: USER_INTERRUPT_LABEL })
 			.then(() => this.#ctx.session.emitNotice("info", `${name} interrupted`, "collab"))
@@ -519,11 +649,9 @@ export class CollabHost {
 	}
 
 	#handlePeerLeft(peer: number): void {
-		const name = this.#peers.get(peer)?.name;
-		this.#peers.delete(peer);
-		if (name) this.#ctx.session.emitNotice("info", `${name} left the collab session`, "collab");
-		this.#updateStatusSegment();
-		this.#scheduleStateBroadcast();
+		// The registry emits guest-left (notice + guest frames) when a mapping
+		// exists; peers that never hello'd were never visible anyway.
+		this.#guests.detachPeer(peer);
 	}
 
 	#buildState(): CollabSessionState {
@@ -591,10 +719,13 @@ export class CollabHost {
 	}
 
 	#handleAgentCmd(cmd: "chat" | "kill" | "revive", agentId: string, text: string | undefined, fromPeer: number): void {
-		if (!this.#peers.get(fromPeer)?.canWrite) {
-			this.#rejectReadOnly("agent control", fromPeer);
-			return;
-		}
+		const flag =
+			cmd === "chat"
+				? GUEST_PERMISSIONS.AGENT_CHAT
+				: cmd === "kill"
+					? GUEST_PERMISSIONS.AGENT_KILL
+					: GUEST_PERMISSIONS.AGENT_REVIVE;
+		if (!this.#checkPermission(flag, "agent control", fromPeer)) return;
 		// Advisor refs are excluded from snapshots, but reject control by id defensively:
 		// a stale/malicious client must never chat/kill/revive a read-only advisor transcript.
 		if (AgentRegistry.global().get(agentId)?.kind === "advisor") {
@@ -639,6 +770,7 @@ export class CollabHost {
 
 	/** Incremental transcript read mirroring the hub's readFileIncremental contract. */
 	async #handleFetchTranscript(reqId: number, agentId: string, fromByte: number, fromPeer: number): Promise<void> {
+		if (!this.#checkPermission(GUEST_PERMISSIONS.FETCH_TRANSCRIPT, "transcript reads", fromPeer)) return;
 		const reply = (text: string, newSize: number, error?: string) =>
 			this.#socket?.send({ t: "transcript", reqId, text, newSize, error }, fromPeer);
 		const file = AgentRegistry.global().get(agentId)?.sessionFile;
@@ -679,6 +811,196 @@ export class CollabHost {
 		}
 	}
 
+	// ── Guest management (proto-4 frames) ───────────────────────────────────
+
+	#handleGuestInvite(
+		name: string,
+		role: GuestRole,
+		permissionsOverride: GuestPermissionSet | undefined,
+		fromPeer: number,
+	): void {
+		if (!this.#checkPermission(GUEST_PERMISSIONS.GUEST_INVITE, "inviting guests", fromPeer)) return;
+		const actor = this.#guests.byPeer(fromPeer);
+		if (!actor) return;
+		this.#guests.invite(name, role, actor.id, permissionsOverride);
+		this.#ctx.session.emitNotice("info", `${actor.name} invited ${name.trim()} as ${role}`, "collab");
+	}
+
+	#handleGuestKick(guestId: string, reason: string | undefined, fromPeer: number): void {
+		if (!this.#checkPermission(GUEST_PERMISSIONS.GUEST_KICK, "kicking guests", fromPeer)) return;
+		const actor = this.#guests.byPeer(fromPeer);
+		if (!actor) return;
+		const target = this.#guests.byId(guestId);
+		if (!target) {
+			this.#socket?.send({ t: "error", message: `no such guest: ${guestId}` }, fromPeer);
+			return;
+		}
+		const kickedPeer = target.peerId;
+		this.#guests.kick(guestId, actor.id, reason);
+		// The registry event broadcast guest-left (the kicked peer is already
+		// detached there); drop the pipe itself with a targeted goodbye.
+		if (kickedPeer >= 0) {
+			this.#socket?.send(
+				{ t: "bye", reason: reason ? `removed by ${actor.name}: ${reason}` : `removed by ${actor.name}` },
+				kickedPeer,
+			);
+		}
+	}
+
+	#handleGuestRole(guestId: string, role: GuestRole, fromPeer: number): void {
+		if (!this.#checkPermission(GUEST_PERMISSIONS.GUEST_ROLE, "changing roles", fromPeer)) return;
+		const actor = this.#guests.byPeer(fromPeer);
+		if (!actor) return;
+		if (!this.#guests.byId(guestId)) {
+			this.#socket?.send({ t: "error", message: `no such guest: ${guestId}` }, fromPeer);
+			return;
+		}
+		this.#guests.setRole(guestId, role, actor.id);
+	}
+
+	#handleGuestPermission(
+		guestId: string,
+		grant: GuestPermissionSet,
+		revoke: GuestPermissionSet,
+		fromPeer: number,
+	): void {
+		if (!this.#checkPermission(GUEST_PERMISSIONS.PERMISSION_MANAGE, "permission changes", fromPeer)) return;
+		const actor = this.#guests.byPeer(fromPeer);
+		if (!actor) return;
+		if (!this.#guests.byId(guestId)) {
+			this.#socket?.send({ t: "error", message: `no such guest: ${guestId}` }, fromPeer);
+			return;
+		}
+		if (grant) this.#guests.grantPermission(guestId, grant, actor.id);
+		if (revoke) this.#guests.revokePermission(guestId, revoke, actor.id);
+	}
+
+	#handleGuestMessage(
+		to: string | "broadcast",
+		text: string,
+		kind: "chat" | "system" | undefined,
+		fromPeer: number,
+	): void {
+		if (!this.#checkPermission(GUEST_PERMISSIONS.GUEST_CHAT, "guest chat", fromPeer)) return;
+		const sender = this.#guests.byPeer(fromPeer);
+		if (!sender) return;
+		const cleanText = text.trim();
+		if (!cleanText) {
+			this.#socket?.send({ t: "error", message: "empty guest message" }, fromPeer);
+			return;
+		}
+		const wireKind = kind ?? "chat";
+		if (to === "broadcast") {
+			this.#sendToGuests(
+				{ t: "guest-message", from: sender, to, text: cleanText, kind: wireKind },
+				identity => identity.capabilities.supportsGuestChat && identity.id !== sender.id,
+			);
+			return;
+		}
+		const target = this.#guests.byId(to);
+		if (!target || target.peerId < 0 || !target.capabilities.supportsGuestChat) {
+			this.#socket?.send({ t: "error", message: `guest ${to} is not available for chat` }, fromPeer);
+			return;
+		}
+		this.#socket?.send({ t: "guest-message", from: sender, to, text: cleanText, kind: wireKind }, target.peerId);
+	}
+
+	#handleGuestPresence(status: GuestStatus, fromPeer: number): void {
+		const sender = this.#guests.byPeer(fromPeer);
+		if (!sender?.capabilities.supportsPresence) return;
+		this.#guests.updateStatus(fromPeer, status);
+	}
+
+	#handleGuestCursor(
+		agentId: string | undefined,
+		position: { line: number; column: number } | undefined,
+		fromPeer: number,
+	): void {
+		const sender = this.#guests.byPeer(fromPeer);
+		if (!sender?.capabilities.supportsCursors) return;
+		this.#sendToGuests(
+			{ t: "guest-cursor", from: sender.id, agentId, position },
+			identity => identity.capabilities.supportsCursors && identity.id !== sender.id,
+		);
+	}
+
+	#handlePermissionAudit(
+		reqId: number,
+		guestId: string | undefined,
+		limit: number | undefined,
+		fromPeer: number,
+	): void {
+		if (!this.#checkPermission(GUEST_PERMISSIONS.PERMISSION_MANAGE, "reading the audit log", fromPeer)) return;
+		this.#socket?.send({ t: "permission-audit", reqId, entries: this.#guests.auditLog(guestId, limit) }, fromPeer);
+	}
+
+	// ── Host-side management API (slash commands, scripts) ──────────────────
+
+	/** Current guest identities, oldest join first. */
+	get guests(): GuestIdentity[] {
+		return this.#guests.list();
+	}
+
+	/** Queue a pending invitation; the next hello with that display name joins as {@link role}. */
+	inviteGuest(name: string, role: GuestRole, permissionsOverride?: GuestPermissionSet): void {
+		this.#guests.invite(name, role, "host", permissionsOverride);
+	}
+
+	/** Kick by guestId or unique display name; returns the kicked guestId or null. */
+	kickGuest(target: string, reason?: string): string | null {
+		const guest = this.#resolveGuest(target);
+		if (!guest) return null;
+		const kickedPeer = guest.peerId;
+		this.#guests.kick(guest.id, "host", reason);
+		if (kickedPeer >= 0) {
+			this.#socket?.send(
+				{ t: "bye", reason: reason ? `removed by the host: ${reason}` : "removed by the host" },
+				kickedPeer,
+			);
+		}
+		return guest.id;
+	}
+
+	/** Change a guest's role by guestId or unique display name. */
+	setGuestRole(target: string, role: GuestRole): GuestIdentity | null {
+		const guest = this.#resolveGuest(target);
+		if (!guest) return null;
+		return this.#guests.setRole(guest.id, role, "host");
+	}
+
+	grantGuestPermissions(target: string, bits: GuestPermissionSet): GuestIdentity | null {
+		const guest = this.#resolveGuest(target);
+		if (!guest) return null;
+		return this.#guests.grantPermission(guest.id, bits, "host");
+	}
+
+	revokeGuestPermissions(target: string, bits: GuestPermissionSet): GuestIdentity | null {
+		const guest = this.#resolveGuest(target);
+		if (!guest) return null;
+		return this.#guests.revokePermission(guest.id, bits, "host");
+	}
+
+	/** Drop per-guest overrides; the guest falls back to its role defaults. */
+	clearGuestPermissions(target: string): GuestIdentity | null {
+		const guest = this.#resolveGuest(target);
+		if (!guest) return null;
+		return this.#guests.clearGuestOverrides(guest.id, "host");
+	}
+
+	/** Guest permission audit trail, oldest first. */
+	auditLog(guestId?: string, limit?: number): PermissionAuditEntry[] {
+		return this.#guests.auditLog(guestId, limit);
+	}
+
+	/** Resolve a slash-command target: guestId first, then unique case-insensitive name. */
+	#resolveGuest(target: string): GuestIdentity | undefined {
+		const byId = this.#guests.byId(target);
+		if (byId) return byId;
+		const key = target.trim().toLowerCase();
+		const matches = this.#guests.list().filter(identity => identity.name.trim().toLowerCase() === key);
+		return matches.length === 1 ? matches[0] : undefined;
+	}
+
 	#scheduleStateBroadcast(): void {
 		if (this.#stopped || this.#stateDebounce) return;
 		this.#stateDebounce = setTimeout(() => {
@@ -692,7 +1014,7 @@ export class CollabHost {
 	}
 
 	#updateStatusSegment(): void {
-		this.#ctx.statusLine.setCollabStatus({ role: "host", participantCount: this.#peers.size + 1 });
+		this.#ctx.statusLine.setCollabStatus({ role: "host", participantCount: this.#guests.onlineCount() + 1 });
 		this.#ctx.statusLine.invalidate();
 		this.#ctx.ui.requestRender();
 	}

--- a/packages/coding-agent/src/collab/protocol.ts
+++ b/packages/coding-agent/src/collab/protocol.ts
@@ -12,6 +12,9 @@ import type {
 	BusChannel,
 	CollabUiRequest,
 	GuestFrame,
+	GuestIdentity,
+	GuestPermissionSet,
+	HostFrame,
 	ParsedCollabLink,
 	Participant,
 	SessionState,
@@ -34,12 +37,24 @@ export type {
 	CollabUiRequestDraft,
 	CollabUiResponseValue,
 	CollabUiSelectItem,
+	GuestCapabilities,
+	GuestIdentity,
+	GuestPermissionSet,
+	GuestRole,
+	GuestStatus,
 	ParsedCollabLink,
+	PermissionAuditEntry,
 	RelayControlMessage,
 	RelayControlToGuest,
 	RelayControlToHost,
 } from "@oh-my-pi/pi-wire";
-export { COLLAB_PROMPT_MESSAGE_TYPE, COLLAB_PROTO } from "@oh-my-pi/pi-wire";
+export {
+	COLLAB_PROMPT_MESSAGE_TYPE,
+	COLLAB_PROTO,
+	GUEST_PERMISSIONS,
+	LEGACY_FULL_PERMISSIONS,
+	ROLE_DEFAULT_PERMISSIONS,
+} from "@oh-my-pi/pi-wire";
 export { DEFAULT_RELAY_URL, ENVELOPE_HEADER_LENGTH, ROOM_ID_BYTES };
 
 export type CollabParticipant = Participant;
@@ -57,15 +72,32 @@ export type CollabSessionState = SessionState & {
 };
 
 /**
+ * Host → guest guest-management/chat frames, verbatim from the wire grammar
+ * (proto-4 only; legacy guests are never sent these).
+ */
+type GuestHostFrame = Extract<
+	HostFrame,
+	| { t: "guest-joined" }
+	| { t: "guest-left" }
+	| { t: "guest-role-changed" }
+	| { t: "guest-permission-changed" }
+	| { t: "guest-message" }
+	| { t: "guest-presence" }
+	| { t: "guest-cursor" }
+	| { t: "permission-audit" }
+>;
+
+/** Frames the host receives (guest → host); wire grammar verbatim except the rich prompt payload. */
+export type CollabGuestFrame =
+	| Exclude<GuestFrame, { t: "prompt" }>
+	| { t: "prompt"; text: string; images?: ImageContent[] };
+
+/**
  * Encrypted payload frames (inside AES-GCM, JSON). The wire package pins the
  * JSON skeleton (`WireFrame`); host-side frames carry the rich session types
  * that serialize into those shapes.
  */
-export type CollabFrame =
-	// guest -> host (hello/abort/agent-cmd/fetch-transcript/ui-response are taken verbatim from the wire grammar)
-	| Exclude<GuestFrame, { t: "prompt" }>
-	| { t: "prompt"; text: string; images?: ImageContent[] }
-	// host -> guest
+export type CollabHostFrame =
 	| {
 			t: "welcome";
 			proto: number;
@@ -81,6 +113,12 @@ export type CollabFrame =
 			entryCount: number;
 			/** True when this peer joined through a read-only (view) link. */
 			readOnly?: boolean;
+			/** Proto-4 guests only: the identity the host assigned to this guest. */
+			self?: GuestIdentity;
+			/** Proto-4 guests only: every current guest in the room (including self). */
+			guests?: GuestIdentity[];
+			/** Proto-4 guests only: the host's effective permission bitmask for this guest. */
+			permissionsSet?: GuestPermissionSet;
 	  }
 	/**
 	 * Targeted snapshot fragment delivered after `welcome`. Splits a large
@@ -103,7 +141,11 @@ export type CollabFrame =
 	/** Targeted reply to fetch-transcript; `error` marks a terminal read failure that guests must surface without hot retrying. */
 	| { t: "transcript"; reqId: number; text: string; newSize: number; error?: string }
 	| { t: "bye"; reason: string }
-	| { t: "error"; message: string };
+	| { t: "error"; message: string }
+	| GuestHostFrame;
+
+/** Either direction can travel the same sealed socket stream; typed transports narrow per side. */
+export type CollabFrame = CollabGuestFrame | CollabHostFrame;
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Wire envelope: [4B uint32 BE peerId][sealed payload]

--- a/packages/coding-agent/src/collab/relay-client.ts
+++ b/packages/coding-agent/src/collab/relay-client.ts
@@ -32,10 +32,15 @@ export interface CollabSocketOptions {
 	key: CryptoKey;
 }
 
-export class CollabSocket {
+/**
+ * Sealed frame transport. `Sent`/`Received` pin the grammar per direction:
+ * hosts use `<CollabHostFrame, CollabGuestFrame>`, guests the reverse;
+ * unparameterized callers get the full union (tests, tooling).
+ */
+export class CollabSocket<Sent extends { t: string } = CollabFrame, Received extends { t: string } = CollabFrame> {
 	/** Fires after every successful (re)connect. */
 	onOpen?: () => void;
-	onFrame?: (frame: CollabFrame, fromPeer: number) => void;
+	onFrame?: (frame: Received, fromPeer: number) => void;
 	onControl?: (msg: RelayControlMessage) => void;
 	/** Fires once per terminal close (intentional, fatal code, or bad key). willReconnect=true for transient drops that will retry. */
 	onClose?: (reason: string, willReconnect: boolean) => void;
@@ -69,7 +74,7 @@ export class CollabSocket {
 		this.#openSocket();
 	}
 
-	send(frame: CollabFrame, targetPeer = 0): void {
+	send(frame: Sent, targetPeer = 0): void {
 		this.#sendChain = this.#sendChain
 			.then(async () => {
 				if (this.#closed) {
@@ -106,7 +111,7 @@ export class CollabSocket {
 			});
 	}
 
-	#enqueuePendingSend(envelope: Uint8Array, frameType: CollabFrame["t"]): void {
+	#enqueuePendingSend(envelope: Uint8Array, frameType: string): void {
 		if (this.#pendingSends.length >= MAX_PENDING_SENDS) {
 			logger.debug("collab: dropping frame, reconnect buffer full", { t: frameType });
 			return;
@@ -214,9 +219,9 @@ export class CollabSocket {
 		this.#recvChain = this.#recvChain
 			.then(async () => {
 				if (this.#ws !== ws) return;
-				let frame: CollabFrame;
+				let frame: Received;
 				try {
-					frame = await open(this.#opts.key, envelope.payload);
+					frame = await open<Received>(this.#opts.key, envelope.payload);
 				} catch {
 					this.#failFatal("bad key or corrupted frame");
 					return;

--- a/packages/coding-agent/src/slash-commands/builtin-collaboration.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-collaboration.ts
@@ -1,7 +1,9 @@
 import { Spacer } from "@oh-my-pi/pi-tui";
 import { APP_NAME } from "@oh-my-pi/pi-utils";
 import { CollabGuestLink } from "../collab/guest";
+import { permissionNames } from "../collab/guest-manager";
 import { CollabHost } from "../collab/host";
+import { GUEST_PERMISSIONS, type GuestRole } from "../collab/protocol";
 import type { SettingPath, SettingValue } from "../config/settings";
 import { settings } from "../config/settings";
 import { parseExportArgs } from "../export/html/args";
@@ -46,6 +48,142 @@ function showCollabQrCode(ctx: InteractiveModeContext, webLink: string): void {
 function showCollabLink(ctx: InteractiveModeContext, host: CollabHost, heading: string, view = false): void {
 	ctx.showStatus(collabLinkHint(host, heading, view), { dim: false });
 	showCollabQrCode(ctx, view ? host.webViewLink : host.webLink);
+}
+
+const COLLAB_ROLES: readonly GuestRole[] = ["owner", "admin", "member", "viewer"];
+
+/** Parse comma-separated GUEST_PERMISSIONS keys ("PROMPT,ABORT") into a bitmask. */
+function parsePermissionBits(spec: string): number | { error: string } {
+	let bits = 0;
+	for (const piece of spec.split(/[,|]/)) {
+		const key = piece.trim().toUpperCase() as keyof typeof GUEST_PERMISSIONS;
+		if (!key) continue;
+		const flag = GUEST_PERMISSIONS[key];
+		if (flag === undefined) {
+			return {
+				error: `Unknown permission "${piece.trim()}" (valid: ${Object.keys(GUEST_PERMISSIONS).join(", ")})`,
+			};
+		}
+		bits |= flag;
+	}
+	return bits;
+}
+
+/** Shared management-argument validation for invite/role. */
+function parseRoleArg(parts: string[], verb: string): { name: string; role: GuestRole } | { usage: string } {
+	const role = (parts[1] as GuestRole | undefined) ?? "member";
+	if (!parts[0] || !COLLAB_ROLES.includes(role)) {
+		return { usage: `Usage: /collab ${verb} <name${verb === "invite" ? "" : "|id"}> [${COLLAB_ROLES.join("|")}]` };
+	}
+	return { name: parts[0], role };
+}
+
+/** Host-side dispatch for /collab invite|kick|role|grant|revoke. */
+function collabHostManage(host: CollabHost, verb: string, rest: string, ctx: InteractiveModeContext): void {
+	const parts = rest.split(/\s+/).filter(Boolean);
+	if (verb === "invite") {
+		const parsed = parseRoleArg(parts, verb);
+		if ("usage" in parsed) {
+			ctx.showStatus(parsed.usage);
+			return;
+		}
+		host.inviteGuest(parsed.name, parsed.role);
+		ctx.showStatus(`Invited ${parsed.name} as ${parsed.role} — they join with that display name`);
+		return;
+	}
+	const target = parts[0];
+	if (!target) {
+		ctx.showStatus(
+			`Usage: /collab ${verb} <name|id>${verb === "kick" ? " [reason]" : verb === "role" ? " <role>" : " <FLAGS>"}`,
+		);
+		return;
+	}
+	if (verb === "kick") {
+		const reason = rest.slice(target.length).trim();
+		ctx.showStatus(host.kickGuest(target, reason || undefined) ? `Kicked ${target}` : `No such guest: ${target}`);
+		return;
+	}
+	if (verb === "role") {
+		const parsed = parseRoleArg(parts, verb);
+		if ("usage" in parsed) {
+			ctx.showStatus(parsed.usage);
+			return;
+		}
+		ctx.showStatus(
+			host.setGuestRole(parsed.name, parsed.role)
+				? `${parsed.name} is now ${parsed.role}`
+				: `No such guest: ${parsed.name}`,
+		);
+		return;
+	}
+	const bits = parsePermissionBits(parts[1] ?? "");
+	if (typeof bits !== "number") {
+		ctx.showStatus(bits.error);
+		return;
+	}
+	if (bits === 0) {
+		ctx.showStatus(`Usage: /collab ${verb} <name|id> <FLAGS> (e.g. PROMPT,ABORT)`);
+		return;
+	}
+	const guest =
+		verb === "grant" ? host.grantGuestPermissions(target, bits) : host.revokeGuestPermissions(target, bits);
+	ctx.showStatus(
+		guest
+			? `${verb === "grant" ? "Granted" : "Revoked"} ${permissionNames(bits)} for ${guest.name}`
+			: `No such guest: ${target}`,
+	);
+}
+
+/** Guest-side dispatch for the same verbs; the host re-checks every permission. */
+function collabGuestManage(guest: CollabGuestLink, verb: string, rest: string, ctx: InteractiveModeContext): void {
+	const parts = rest.split(/\s+/).filter(Boolean);
+	const roster = guest.guests;
+	const resolveTarget = (target: string | undefined): string | null => {
+		if (!target) return null;
+		const byId = roster.find(identity => identity.id === target);
+		if (byId) return byId.id;
+		const key = target.toLowerCase();
+		const matches = roster.filter(identity => identity.name.toLowerCase() === key);
+		return matches.length === 1 ? matches[0].id : null;
+	};
+	if (verb === "invite") {
+		const parsed = parseRoleArg(parts, verb);
+		if ("usage" in parsed) {
+			ctx.showStatus(parsed.usage);
+			return;
+		}
+		guest.inviteGuest(parsed.name, parsed.role);
+		return;
+	}
+	const id = resolveTarget(parts[0]);
+	if (!id) {
+		ctx.showStatus(parts[0] ? `No such guest: ${parts[0]}` : `Usage: /collab ${verb} <name|id>`);
+		return;
+	}
+	if (verb === "kick") {
+		guest.kickGuest(id, rest.slice(parts[0].length).trim() || undefined);
+		return;
+	}
+	if (verb === "role") {
+		const parsed = parseRoleArg(parts, verb);
+		if ("usage" in parsed) {
+			ctx.showStatus(parsed.usage);
+			return;
+		}
+		guest.setGuestRole(id, parsed.role);
+		return;
+	}
+	const bits = parsePermissionBits(parts[1] ?? "");
+	if (typeof bits !== "number") {
+		ctx.showStatus(bits.error);
+		return;
+	}
+	if (bits === 0) {
+		ctx.showStatus(`Usage: /collab ${verb} <name|id> <FLAGS>`);
+		return;
+	}
+	if (verb === "grant") guest.grantGuestPermissions(id, bits);
+	else guest.revokeGuestPermissions(id, bits);
 }
 
 export const BUILTIN_COLLABORATION_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> = [
@@ -253,11 +391,18 @@ export const BUILTIN_COLLABORATION_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpe
 		name: "collab",
 		icon: "broadcast",
 		description: "Share this session live via a relay",
-		inlineHint: "[start|view|stop|status] [relayUrl]",
+		inlineHint: "[start|view|stop|status|guests|chat|invite|kick|role|grant|revoke]",
 		subcommands: [
 			{ name: "view", description: "Share a read-only link (guests can watch, not prompt)" },
 			{ name: "status", description: "Show link + participants" },
 			{ name: "stop", description: "Stop sharing" },
+			{ name: "guests", description: "List the guests in the room with roles" },
+			{ name: "chat", description: "Guest chat: /collab chat [@name] <message>" },
+			{ name: "invite", description: "Invite: /collab invite <name> [role] (host or GUEST_INVITE)" },
+			{ name: "kick", description: "Remove: /collab kick <name|id> [reason]" },
+			{ name: "role", description: "Change role: /collab role <name|id> <admin|member|viewer>" },
+			{ name: "grant", description: "Grant bits: /collab grant <name|id> PROMPT,ABORT" },
+			{ name: "revoke", description: "Revoke bits: /collab revoke <name|id> PROMPT,ABORT" },
 		],
 		allowArgs: true,
 		getTuiAutocompleteDescription: runtime => {
@@ -284,19 +429,88 @@ export const BUILTIN_COLLABORATION_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpe
 			}
 			if (verb === "status") {
 				if (ctx.collabHost) {
-					const names = ctx.collabHost.participants.map(p =>
-						p.role === "host" ? `${p.name} (host)` : p.readOnly ? `${p.name} (view-only)` : p.name,
+					const names = ctx.collabHost.guests.map(
+						g => `${g.name} [${g.role}]${g.status === "offline" ? " (offline)" : ""}`,
 					);
-					ctx.showStatus(`Collab: ${names.join(", ")} — ${collabBrowserLink(ctx.collabHost.webLink)}`);
-				} else if (ctx.collabGuest) {
 					ctx.showStatus(
-						ctx.collabGuest.readOnly
-							? "In a collab session as a read-only guest (/leave to exit)"
-							: "In a collab session as a guest (/leave to exit)",
+						`Collab: you (host)${names.length ? `, ${names.join(", ")}` : ""} — ${collabBrowserLink(ctx.collabHost.webLink)}`,
+					);
+				} else if (ctx.collabGuest) {
+					const guest = ctx.collabGuest;
+					ctx.showStatus(
+						`In a collab session as ${
+							guest.self ? `guest [${guest.self.role}]` : guest.readOnly ? "read-only guest" : "guest"
+						} (/leave to exit)`,
 					);
 				} else {
 					ctx.showStatus("Not in a collab session");
 				}
+				return;
+			}
+			if (verb === "guests") {
+				if (ctx.collabHost) {
+					const roster = ctx.collabHost.guests;
+					ctx.showStatus(
+						roster.length
+							? roster
+									.map(g => `${g.name} [${g.role}]${g.status === "offline" ? " (offline)" : ""} — ${g.id}`)
+									.join("\n")
+							: "No guests have joined yet",
+					);
+				} else if (ctx.collabGuest) {
+					const roster = ctx.collabGuest.guests;
+					ctx.showStatus(
+						roster.length
+							? roster.map(g => `${g.name} [${g.role}]${g.status === "offline" ? " (offline)" : ""}`).join("\n")
+							: "You are the only guest so far",
+					);
+				} else {
+					ctx.showStatus("Not in a collab session");
+				}
+				return;
+			}
+			if (verb === "chat") {
+				const guest = ctx.collabGuest;
+				if (!guest) {
+					ctx.showStatus(
+						ctx.collabHost
+							? "Guest chat runs between guests; the host sees every prompt"
+							: "Not in a collab session",
+					);
+					return;
+				}
+				const message = rest.trim();
+				if (!message) {
+					ctx.showStatus("Usage: /collab chat [@name] <message>");
+					return;
+				}
+				if (message.startsWith("@")) {
+					const space = message.indexOf(" ");
+					const target = space < 0 ? message.slice(1) : message.slice(1, space);
+					const text = space < 0 ? "" : message.slice(space + 1).trim();
+					const match = guest.guests.find(identity => identity.name.toLowerCase() === target.toLowerCase());
+					if (!text || !match) {
+						ctx.showStatus(match ? "Message is empty" : `No such guest: ${target}`);
+						return;
+					}
+					guest.sendGuestMessage(text, match.id);
+					ctx.showStatus(`→ ${match.name}: ${text}`);
+					return;
+				}
+				guest.sendGuestMessage(message);
+				ctx.showStatus(`→ room: ${message}`);
+				return;
+			}
+			if (verb === "invite" || verb === "kick" || verb === "role" || verb === "grant" || verb === "revoke") {
+				if (ctx.collabHost) {
+					collabHostManage(ctx.collabHost, verb, rest, ctx);
+					return;
+				}
+				if (ctx.collabGuest) {
+					collabGuestManage(ctx.collabGuest, verb, rest, ctx);
+					return;
+				}
+				ctx.showStatus("Not in a collab session");
 				return;
 			}
 			if (ctx.collabGuest) {

--- a/packages/coding-agent/test/collab/guest-registry.test.ts
+++ b/packages/coding-agent/test/collab/guest-registry.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Unit contract for the host-side {@link GuestRegistry}: identity attach /
+ * reconnect semantics, kick quarantine, invitation consumption, role and
+ * permission mutations with their event trail, and the legacy proto-3
+ * permission surface. Pure state machine — no transport involved.
+ */
+import { describe, expect, it } from "bun:test";
+import type { GuestRegistryEvent } from "@oh-my-pi/pi-coding-agent/collab/guest-manager";
+import { GuestRegistry } from "@oh-my-pi/pi-coding-agent/collab/guest-manager";
+import {
+	GUEST_PERMISSIONS,
+	LEGACY_FULL_PERMISSIONS,
+	ROLE_DEFAULT_PERMISSIONS,
+} from "@oh-my-pi/pi-coding-agent/collab/protocol";
+
+/** Minimal attach helper: modern chat-capable member by default. */
+function attach(
+	registry: GuestRegistry,
+	peerId: number,
+	name: string,
+	opts: { proto?: number; canWrite?: boolean; guestId?: string } = {},
+) {
+	return registry.attach({
+		peerId,
+		name,
+		proto: opts.proto ?? 4,
+		canWrite: opts.canWrite ?? true,
+		guestId: opts.guestId,
+		capabilities: {
+			protocolVersion: opts.proto ?? 4,
+			supportsGuestChat: true,
+			supportsPresence: true,
+			supportsCursors: false,
+		},
+	});
+}
+
+/** Collect registry events while `run` executes. */
+function collect(registry: GuestRegistry, run: () => unknown): GuestRegistryEvent[] {
+	const events: GuestRegistryEvent[] = [];
+	const off = registry.on(event => events.push(event));
+	try {
+		run();
+	} finally {
+		off();
+	}
+	return events;
+}
+
+describe("guest registry", () => {
+	it("attaches fresh identities with link-derived roles and emits guest-joined", () => {
+		const registry = new GuestRegistry();
+		const result = attach(registry, 11, "alice");
+		if ("error" in result) throw new Error("attach failed");
+		expect(result.created).toBe(true);
+		expect(result.identity.role).toBe("member");
+		expect(result.identity.peerId).toBe(11);
+		expect(result.identity.status).toBe("online");
+
+		const events = collect(registry, () => {
+			const view = attach(registry, 12, "bob", { canWrite: false });
+			if ("error" in view) throw new Error("attach failed");
+			expect(view.identity.role).toBe("viewer");
+		});
+		expect(events).toEqual([{ type: "guest-joined", guest: expect.objectContaining({ name: "bob" }) }]);
+	});
+
+	it("reattaches a known guestId: same identity, new pipe, guest-joined signal", () => {
+		const registry = new GuestRegistry();
+		const first = attach(registry, 11, "alice", { guestId: "alice-guest-01" });
+		if ("error" in first) throw new Error("attach failed");
+		const joinedAt = first.identity.joinedAt;
+
+		const events = collect(registry, () => {
+			const second = attach(registry, 42, "alice", { guestId: "alice-guest-01" });
+			if ("error" in second) throw new Error("attach failed");
+			expect(second.created).toBe(false);
+			expect(second.identity.peerId).toBe(42);
+			expect(second.identity.joinedAt).toBe(joinedAt);
+			expect(registry.byPeer(11)).toBeUndefined();
+			expect(registry.byPeer(42)?.id).toBe("alice-guest-01");
+		});
+		expect(events).toHaveLength(1);
+		expect(events[0]).toMatchObject({ type: "guest-joined", guest: { peerId: 42 } });
+	});
+
+	it("keeps role and permission overrides across reconnect", () => {
+		const registry = new GuestRegistry();
+		attach(registry, 11, "alice", { guestId: "alice-guest-01" });
+		registry.setRole("alice-guest-01", "viewer", "host");
+		registry.grantPermission("alice-guest-01", GUEST_PERMISSIONS.PROMPT, "host");
+		registry.detachPeer(11);
+
+		const again = attach(registry, 12, "alice", { guestId: "alice-guest-01" });
+		if ("error" in again) throw new Error("attach failed");
+		expect(again.identity.role).toBe("viewer");
+		expect(registry.effectivePermissions(again.identity) & GUEST_PERMISSIONS.PROMPT).toBe(GUEST_PERMISSIONS.PROMPT);
+	});
+
+	it("quarantines kicked ids across reconnects", () => {
+		const registry = new GuestRegistry();
+		attach(registry, 11, "alice", { guestId: "alice-guest-01" });
+		const events = collect(registry, () => registry.kick("alice-guest-01", "host", "spam"));
+		expect(events).toEqual([{ type: "guest-left", guestId: "alice-guest-01", reason: "spam" }]);
+		expect(registry.isKicked("alice-guest-01")).toBe(true);
+		expect(attach(registry, 12, "alice", { guestId: "alice-guest-01" })).toEqual({ error: "kicked" });
+	});
+
+	it("consumes a pending invite when the named guest joins", () => {
+		const registry = new GuestRegistry();
+		expect(collect(registry, () => registry.invite("Alice", "admin", "host"))).toEqual([]);
+		expect(registry.pendingInviteCount).toBe(1);
+
+		const joined = attach(registry, 11, "  alice ");
+		if ("error" in joined) throw new Error("attach failed");
+		expect(joined.created).toBe(true);
+		expect(joined.invited).toBe(true);
+		expect(joined.identity.role).toBe("admin");
+		expect(registry.pendingInviteCount).toBe(0);
+	});
+
+	it("serves legacy proto-3 guests the exact pre-4 permission surface", () => {
+		const registry = new GuestRegistry();
+		const full = attach(registry, 11, "writer", { proto: 3 });
+		const view = attach(registry, 12, "watcher", { proto: 3, canWrite: false });
+		if ("error" in full || "error" in view) throw new Error("attach failed");
+		expect(registry.effectivePermissions(full.identity)).toBe(LEGACY_FULL_PERMISSIONS);
+		expect(registry.effectivePermissions(view.identity)).toBe(GUEST_PERMISSIONS.FETCH_TRANSCRIPT);
+		// Role mutations must not leak into the legacy surface.
+		registry.setRole(full.identity.id, "viewer", "host");
+		expect(registry.effectivePermissions(full.identity)).toBe(LEGACY_FULL_PERMISSIONS);
+	});
+
+	it("emits role and permission changes with re-broadcast effective sets", () => {
+		const registry = new GuestRegistry();
+		const alice = attach(registry, 11, "alice", { guestId: "alice-guest-01" });
+		if ("error" in alice) throw new Error("attach failed");
+
+		const events = collect(registry, () => {
+			registry.setRole("alice-guest-01", "viewer", "host");
+			registry.grantPermission("alice-guest-01", GUEST_PERMISSIONS.PROMPT, "admin-1");
+			registry.revokePermission("alice-guest-01", GUEST_PERMISSIONS.GUEST_CHAT, "admin-1");
+		});
+		// setRole emits the role change plus a re-broadcast of the effective set;
+		// each grant/revoke re-broadcasts too.
+		expect(events.map(event => event.type)).toEqual([
+			"guest-role-changed",
+			"guest-permission-changed",
+			"guest-permission-changed",
+			"guest-permission-changed",
+		]);
+		const effective = registry.effectivePermissions(alice.identity);
+		expect(effective & GUEST_PERMISSIONS.PROMPT).toBe(GUEST_PERMISSIONS.PROMPT);
+		expect(effective & GUEST_PERMISSIONS.GUEST_CHAT).toBe(0);
+
+		registry.clearGuestOverrides("alice-guest-01", "host");
+		expect(registry.effectivePermissions(alice.identity)).toBe(ROLE_DEFAULT_PERMISSIONS.viewer);
+	});
+
+	it("tracks presence and detaches peers without dropping identity", () => {
+		const registry = new GuestRegistry();
+		const alice = attach(registry, 11, "alice");
+		if ("error" in alice) throw new Error("attach failed");
+		expect(registry.onlineCount()).toBe(1);
+
+		const events = collect(registry, () => {
+			expect(registry.updateStatus(11, "away")).not.toBeNull();
+			const detached = registry.detachPeer(11, "bye");
+			expect(detached?.id).toBe(alice.identity.id);
+		});
+		expect(events).toEqual([
+			{ type: "guest-presence-changed", guestId: alice.identity.id, status: "away" },
+			{ type: "guest-left", guestId: alice.identity.id, reason: "bye" },
+		]);
+		expect(registry.onlineCount()).toBe(0);
+		expect(registry.byId(alice.identity.id)?.status).toBe("offline");
+		expect(registry.size).toBe(1);
+	});
+
+	it("keeps an append-only audit trail for permission-affecting actions", () => {
+		const registry = new GuestRegistry();
+		attach(registry, 11, "alice", { guestId: "alice-guest-01" });
+		const bob = attach(registry, 12, "bob", { canWrite: false });
+		if ("error" in bob) throw new Error("attach failed");
+
+		registry.invite("carol", "member", "alice-guest-01");
+		registry.setRole("alice-guest-01", "admin", "host");
+		registry.grantPermission("alice-guest-01", GUEST_PERMISSIONS.ABORT, "host");
+		registry.kick(bob.identity.id, "alice-guest-01", "noise");
+
+		const entries = registry.auditLog();
+		expect(entries.map(entry => entry.action)).toEqual(["invite", "role-change", "grant", "kick"]);
+		expect(entries[2]).toMatchObject({ actorId: "host", target: "alice-guest-01", detail: "ABORT" });
+		expect(entries[3]).toMatchObject({ actorId: "alice-guest-01", target: bob.identity.id, detail: "noise" });
+		// Per-guest view: entries where alice is actor or target.
+		expect(registry.auditLog("alice-guest-01")).toHaveLength(4);
+	});
+});

--- a/packages/coding-agent/test/collab/guest-ui-request.test.ts
+++ b/packages/coding-agent/test/collab/guest-ui-request.test.ts
@@ -519,16 +519,19 @@ async function joinRawGuest(
 }
 
 describe("collab proto handshake (#4049)", () => {
-	it("host rejects a stale-proto hello with a protocol-mismatch error and never welcomes or admits the guest", async () => {
+	it("rejects a pre-ui-request proto hello with a protocol-mismatch error and never admits the guest", async () => {
+		// Proto 2 predates ui-request: its guests cannot answer host asks, so
+		// they are refused outright. Proto 3 (legacy) is still admitted — see
+		// the COLLAB_PROTO history in @oh-my-pi/pi-wire.
 		const host = new CollabHost(makeHostContext());
 		await host.start("ws://localhost:8787");
-		const guest = await joinRawGuest(host.link, COLLAB_PROTO - 1);
+		const guest = await joinRawGuest(host.link, 2);
 		try {
 			const reply = await guest.nextFrame();
 			if (reply.t !== "error") throw new Error(`expected error, got ${reply.t}`);
 			expect(reply.message).toContain("protocol mismatch");
 			expect(reply.message).toContain(`host speaks v${COLLAB_PROTO}`);
-			expect(reply.message).toContain(`guest sent v${COLLAB_PROTO - 1}`);
+			expect(reply.message).toContain("guest sent v2");
 			// The rejected guest was never admitted: no participant entry, and a
 			// host ask finds no writable peer to route to.
 			expect(host.participants.filter(p => p.role !== "host")).toEqual([]);
@@ -539,14 +542,18 @@ describe("collab proto handshake (#4049)", () => {
 		}
 	});
 
-	it("welcomes a current-proto guest at v3 and round-trips a ui-request", async () => {
+	it("welcomes a legacy proto-3 guest at v3 without the proto-4 fields and round-trips a ui-request", async () => {
 		const host = new CollabHost(makeHostContext());
 		await host.start("ws://localhost:8787");
-		const guest = await joinRawGuest(host.link, COLLAB_PROTO);
+		const guest = await joinRawGuest(host.link, 3);
 		try {
 			const welcome = await guest.nextFrame();
 			if (welcome.t !== "welcome") throw new Error(`expected welcome, got ${welcome.t}`);
+			// Negotiated down to the guest's grammar; no proto-4 identity block.
 			expect(welcome.proto).toBe(3);
+			expect(welcome.self).toBeUndefined();
+			expect(welcome.guests).toBeUndefined();
+			expect(welcome.permissionsSet).toBeUndefined();
 
 			const pending = host.requestGuestUi({ kind: "select", title: "Continue?", options: ["Yes"] });
 			if (!pending) throw new Error("expected writable guest UI request");

--- a/packages/coding-agent/test/collab/guests.test.ts
+++ b/packages/coding-agent/test/collab/guests.test.ts
@@ -1,0 +1,382 @@
+/**
+ * End-to-end contract for the proto-4 guest system over the in-memory relay:
+ * welcome identity/roster/permissions, permission-gated mutations, guest chat
+ * routing, invites, kicks, role/permission changes, the audit frame, legacy
+ * proto-3 interop (old surface, never sent guest frames), and reconnect
+ * identity stability. Real CollabHost + raw wire guests — only the TUI
+ * context and the network transport are stubbed. No wall-clock waits: the
+ * fake transport delivers on microtasks, so tests await real frames and
+ * reason about causal order instead of sleeping.
+ */
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
+import { importRoomKey } from "@oh-my-pi/pi-coding-agent/collab/crypto";
+import { CollabHost } from "@oh-my-pi/pi-coding-agent/collab/host";
+import {
+	COLLAB_PROTO,
+	type CollabFrame,
+	type CollabHostFrame,
+	GUEST_PERMISSIONS,
+	parseCollabLink,
+	ROLE_DEFAULT_PERMISSIONS,
+} from "@oh-my-pi/pi-coding-agent/collab/protocol";
+import { CollabSocket } from "@oh-my-pi/pi-coding-agent/collab/relay-client";
+import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
+import { installInMemoryRelay, uninstallInMemoryRelay } from "./helpers/in-memory-relay";
+
+// ── Host harness (mirrors read-only.test.ts) ────────────────────────────────
+
+interface HostHarness {
+	ctx: InteractiveModeContext;
+	prompts: { from?: string }[];
+	nextPrompt(): Promise<{ from?: string }>;
+}
+
+function makeHostContext(): HostHarness {
+	const prompts: { from?: string }[] = [];
+	const promptWaiters: ((details: { from?: string }) => void)[] = [];
+	const ctx = {
+		settings: { get: () => "" },
+		sessionManager: {
+			getSessionId: () => "sess-guests",
+			getCwd: () => "/tmp",
+			snapshotForReplication: () => ({
+				header: { type: "session", id: "sess-guests", timestamp: new Date().toISOString(), cwd: "/tmp" },
+				entries: [],
+			}),
+			onEntryAppended: undefined,
+		},
+		session: {
+			isStreaming: false,
+			queuedMessageCount: 0,
+			sessionName: "test",
+			model: undefined,
+			thinkingLevel: undefined,
+			subscribe: () => () => {},
+			emitNotice: () => {},
+			promptCustomMessage: (message: { details?: { from?: string } }) => {
+				const details = message.details ?? {};
+				prompts.push(details);
+				for (const waiter of promptWaiters.splice(0)) waiter(details);
+				return Promise.resolve();
+			},
+			abort: () => Promise.resolve(),
+		},
+		eventBus: undefined,
+		statusLine: {
+			setCollabStatus: () => {},
+			invalidate: () => {},
+			getCachedContextBreakdown: () => ({ usedTokens: 0, contextWindow: 0 }),
+		},
+		ui: { requestRender: () => {} },
+		showStatus: () => {},
+		collabHost: undefined,
+	} as unknown as InteractiveModeContext;
+	return {
+		ctx,
+		prompts,
+		nextPrompt(): Promise<{ from?: string }> {
+			const { promise, resolve } = Promise.withResolvers<{ from?: string }>();
+			promptWaiters.push(resolve);
+			return promise;
+		},
+	};
+}
+
+// ── Raw guest ───────────────────────────────────────────────────────────────
+
+const FILTERED_FRAME_TYPES: Record<string, true> = {
+	state: true,
+	agents: true,
+	entry: true,
+	event: true,
+	bus: true,
+	"snapshot-chunk": true,
+};
+
+interface TestGuest {
+	socket: CollabSocket;
+	guestId: string;
+	next<T extends CollabHostFrame["t"]>(type: T): Promise<Extract<CollabHostFrame, { t: T }>>;
+	/** Frames of `type` collected so far (inspect after a causally-later await). */
+	ofType<T extends CollabHostFrame["t"]>(type: T): Extract<CollabHostFrame, { t: T }>[];
+}
+
+function makeGuest(socket: CollabSocket, guestId: string): TestGuest {
+	const frames: CollabFrame[] = [];
+	const waiters: { type: string; resolve: (frame: CollabFrame) => void }[] = [];
+	socket.onFrame = frame => {
+		if (FILTERED_FRAME_TYPES[frame.t]) return;
+		const waiterIdx = waiters.findIndex(waiter => waiter.type === frame.t);
+		if (waiterIdx >= 0) waiters.splice(waiterIdx, 1)[0].resolve(frame);
+		else frames.push(frame);
+	};
+	return {
+		socket,
+		guestId,
+		next<T extends CollabHostFrame["t"]>(type: T): Promise<Extract<CollabHostFrame, { t: T }>> {
+			const idx = frames.findIndex(frame => frame.t === type);
+			if (idx >= 0) return Promise.resolve(frames.splice(idx, 1)[0] as Extract<CollabHostFrame, { t: T }>);
+			const { promise, resolve } = Promise.withResolvers<Extract<CollabHostFrame, { t: T }>>();
+			waiters.push({ type, resolve: frame => resolve(frame as Extract<CollabHostFrame, { t: T }>) });
+			return promise;
+		},
+		ofType<T extends CollabHostFrame["t"]>(type: T): Extract<CollabHostFrame, { t: T }>[] {
+			return frames.filter((frame): frame is Extract<CollabHostFrame, { t: T }> => frame.t === type);
+		},
+	};
+}
+
+async function joinGuest(
+	link: string,
+	name: string,
+	opts: { guestId?: string; proto?: number } = {},
+): Promise<TestGuest> {
+	const parsed = parseCollabLink(link);
+	if ("error" in parsed) throw new Error(parsed.error);
+	const proto = opts.proto ?? COLLAB_PROTO;
+	// Modern guests declare a stable client-generated id; legacy clients omit both fields.
+	const guestId =
+		proto >= 4 ? (opts.guestId ?? `g-${name.toLowerCase().replace(/[^a-z0-9_-]/g, "")}-0001`) : undefined;
+	const writeToken = parsed.writeToken ? Buffer.from(parsed.writeToken).toString("base64url") : undefined;
+	const key = await importRoomKey(parsed.key);
+	const socket = new CollabSocket({ wsUrl: parsed.wsUrl, role: "guest", key });
+	const guest = makeGuest(socket, guestId ?? name);
+	socket.onOpen = () => {
+		socket.send({
+			t: "hello",
+			proto,
+			name,
+			writeToken,
+			...(proto >= 4
+				? {
+						guestId,
+						capabilities: {
+							protocolVersion: proto,
+							supportsGuestChat: true,
+							supportsPresence: true,
+							supportsCursors: false,
+						},
+					}
+				: {}),
+		});
+	};
+	socket.connect();
+	return guest;
+}
+
+// ── Shared host/relay ───────────────────────────────────────────────────────
+
+let harness: HostHarness;
+let host: CollabHost;
+
+beforeAll(async () => {
+	installInMemoryRelay();
+	harness = makeHostContext();
+	host = new CollabHost(harness.ctx);
+	await host.start("ws://localhost:8788");
+});
+
+afterEach(() => {
+	harness.prompts.length = 0;
+});
+
+afterAll(async () => {
+	uninstallInMemoryRelay();
+	await host.stop("test done");
+});
+
+/** Welcome-frame accessor with a narrowing guard. */
+async function welcomeOf(guest: TestGuest): Promise<Extract<CollabHostFrame, { t: "welcome" }>> {
+	const frame = await guest.next("welcome");
+	if (frame.t !== "welcome") throw new Error(`expected welcome, got ${frame.t}`);
+	return frame;
+}
+
+describe("collab proto-4 guests", () => {
+	it("welcomes guests with identity, roster, and effective permissions", async () => {
+		const alice = await joinGuest(host.link, "alice");
+		const welcome = await welcomeOf(alice);
+		expect(welcome.readOnly).toBeUndefined();
+		expect(welcome.self?.name).toBe("alice");
+		expect(welcome.self?.role).toBe("member");
+		expect(welcome.permissionsSet).toBe(ROLE_DEFAULT_PERMISSIONS.member);
+		expect(welcome.guests?.some(identity => identity.id === welcome.self?.id)).toBe(true);
+		expect(host.participants.find(p => p.name === "alice")?.readOnly).toBeUndefined();
+	});
+
+	it("denies viewer prompts but still allows guest chat", async () => {
+		const viewer = await joinGuest(host.viewLink, "vera");
+		const welcome = await welcomeOf(viewer);
+		expect(welcome.self?.role).toBe("viewer");
+		expect(welcome.permissionsSet).toBe(ROLE_DEFAULT_PERMISSIONS.viewer);
+
+		// The chat goes out first; a prompt denial is the causally-later reply,
+		// so any chat error would have been queued before it.
+		viewer.socket.send({ t: "guest-message", to: "broadcast", text: "anyone there?" });
+		viewer.socket.send({ t: "prompt", text: "let me in" });
+		const denial = await viewer.next("error");
+		expect(denial.message).toContain("PROMPT");
+		expect(viewer.ofType("error")).toEqual([]);
+		expect(harness.prompts).toHaveLength(0);
+	});
+
+	it("routes guest chat without echoing the sender", async () => {
+		const alice = await joinGuest(host.link, "alicia");
+		const bob = await joinGuest(host.link, "bruno");
+		const aliceId = (await welcomeOf(alice)).self?.id;
+		const bobId = (await welcomeOf(bob)).self?.id;
+		if (!aliceId || !bobId) throw new Error("missing identities");
+		// alice also observes bruno's join broadcast.
+		expect((await alice.next("guest-joined")).guest.id).toBe(bobId);
+
+		alice.socket.send({ t: "guest-message", to: "broadcast", text: "hello room" });
+		const broadcast = await bob.next("guest-message");
+		expect(broadcast.from.name).toBe("alicia");
+		expect(broadcast.text).toBe("hello room");
+		expect(broadcast.kind).toBe("chat");
+		// bob's copy proves the host fanned the broadcast out; alice got none.
+		expect(alice.ofType("guest-message")).toEqual([]);
+
+		bob.socket.send({ t: "guest-message", to: aliceId, text: "hi alice" });
+		const direct = await alice.next("guest-message");
+		expect(direct.from.id).toBe(bobId);
+		expect(direct.to).toBe(aliceId);
+	});
+
+	it("applies a pending invite when the named guest joins", async () => {
+		host.inviteGuest("cara", "admin");
+		const cara = await joinGuest(host.link, "cara");
+		const welcome = await welcomeOf(cara);
+		expect(welcome.self?.role).toBe("admin");
+		expect(welcome.permissionsSet).toBe(ROLE_DEFAULT_PERMISSIONS.admin);
+		// Admins can kick: the frame is accepted past the permission gate.
+		cara.socket.send({ t: "guest-kick", guestId: "nobody-here-1" });
+		expect((await cara.next("error")).message).toContain("no such guest");
+	});
+
+	it("kicks guests, notifies the room, and quarantines the id", async () => {
+		const dave = await joinGuest(host.link, "dave");
+		const erin = await joinGuest(host.link, "erin");
+		const daveId = (await welcomeOf(dave)).self?.id;
+		await welcomeOf(erin);
+		if (!daveId) throw new Error("missing dave identity");
+
+		expect(host.kickGuest("dave", "spam")).toBe(daveId);
+		const bye = await dave.next("bye");
+		expect(bye.reason).toContain("removed by the host");
+		expect(bye.reason).toContain("spam");
+		const left = await erin.next("guest-left");
+		expect(left.guestId).toBe(daveId);
+
+		// Same id trying to rejoin is refused outright.
+		dave.socket.close();
+		const dave2 = await joinGuest(host.link, "dave", { guestId: daveId });
+		const refused = await dave2.next("bye");
+		expect(refused.reason).toBe("removed from this session");
+	});
+
+	it("propagates role changes and enforces them", async () => {
+		const frank = await joinGuest(host.link, "frank");
+		await welcomeOf(frank);
+		expect(host.setGuestRole("frank", "viewer")).not.toBeNull();
+
+		const roleFrame = await frank.next("guest-role-changed");
+		expect(roleFrame.role).toBe("viewer");
+		expect(roleFrame.by).toBe("host");
+		const permsFrame = await frank.next("guest-permission-changed");
+		expect(permsFrame.permissionsSet).toBe(ROLE_DEFAULT_PERMISSIONS.viewer);
+
+		frank.socket.send({ t: "prompt", text: "still allowed?" });
+		expect((await frank.next("error")).message).toContain("PROMPT");
+		expect(harness.prompts).toHaveLength(0);
+	});
+
+	it("grants and revokes individual permission bits", async () => {
+		const gina = await joinGuest(host.viewLink, "gina");
+		await welcomeOf(gina);
+
+		host.grantGuestPermissions("gina", GUEST_PERMISSIONS.PROMPT);
+		const granted = await gina.next("guest-permission-changed");
+		expect(granted.permissionsSet & GUEST_PERMISSIONS.PROMPT).toBe(GUEST_PERMISSIONS.PROMPT);
+
+		const prompted = harness.nextPrompt();
+		gina.socket.send({ t: "prompt", text: "granted prompt" });
+		expect(await prompted).toEqual({ from: "gina" });
+
+		host.revokeGuestPermissions("gina", GUEST_PERMISSIONS.PROMPT);
+		const revoked = await gina.next("guest-permission-changed");
+		expect(revoked.permissionsSet & GUEST_PERMISSIONS.PROMPT).toBe(0);
+		gina.socket.send({ t: "prompt", text: "revoked again" });
+		expect((await gina.next("error")).message).toContain("PROMPT");
+	});
+
+	it("serves the permission audit only to PERMISSION_MANAGE holders", async () => {
+		const hank = await joinGuest(host.link, "hank");
+		await welcomeOf(hank);
+
+		hank.socket.send({ t: "permission-audit", reqId: 1 });
+		expect((await hank.next("error")).message).toContain("PERMISSION_MANAGE");
+
+		host.grantGuestPermissions("hank", GUEST_PERMISSIONS.PERMISSION_MANAGE);
+		await hank.next("guest-permission-changed");
+		hank.socket.send({ t: "permission-audit", reqId: 2 });
+		const audit = await hank.next("permission-audit");
+		expect(audit.reqId).toBe(2);
+		expect(audit.entries.length).toBeGreaterThanOrEqual(1);
+	});
+
+	it("broadcasts presence updates to other guests", async () => {
+		const iris = await joinGuest(host.link, "iris");
+		const jack = await joinGuest(host.link, "jack");
+		const irisId = (await welcomeOf(iris)).self?.id;
+		await welcomeOf(jack);
+		if (!irisId) throw new Error("missing iris identity");
+
+		iris.socket.send({ t: "guest-presence", status: "away" });
+		const presence = await jack.next("guest-presence");
+		expect(presence.guestId).toBe(irisId);
+		expect(presence.status).toBe("away");
+	});
+
+	it("gives legacy proto-3 guests the old surface and never guest frames", async () => {
+		const kate = await joinGuest(host.link, "kate", { proto: 3 });
+		const welcome = await welcomeOf(kate);
+		expect(welcome.self).toBeUndefined();
+		expect(welcome.guests).toBeUndefined();
+		expect(welcome.permissionsSet).toBeUndefined();
+		expect(welcome.readOnly).toBeUndefined();
+
+		// A modern guest joins after her; the legacy guest must not observe it.
+		const leo = await joinGuest(host.link, "leo");
+		await welcomeOf(leo);
+
+		// Legacy full-link guests keep the pre-4 mutating surface. The prompt
+		// reply is causally after leo's hello, so its arrival also proves no
+		// guest-joined frame was ever routed to the legacy peer.
+		const prompted = harness.nextPrompt();
+		kate.socket.send({ t: "prompt", text: "legacy prompt" });
+		expect(await prompted).toEqual({ from: "kate" });
+		expect(kate.ofType("guest-joined")).toEqual([]);
+	});
+
+	it("keeps identity and role across reconnects", async () => {
+		const mia = await joinGuest(host.link, "mia");
+		const welcome = await welcomeOf(mia);
+		const miaId = welcome.self?.id;
+		if (!miaId) throw new Error("missing mia identity");
+
+		const nick = await joinGuest(host.link, "nick");
+		await welcomeOf(nick);
+
+		mia.socket.close();
+		expect(host.setGuestRole("mia", "admin")).not.toBeNull();
+
+		const mia2 = await joinGuest(host.link, "mia", { guestId: miaId });
+		const rejoin = await welcomeOf(mia2);
+		expect(rejoin.self?.id).toBe(miaId);
+		expect(rejoin.self?.role).toBe("admin");
+		// The room learns she is back online.
+		const back = await nick.next("guest-joined");
+		expect(back.guest.id).toBe(miaId);
+	});
+});

--- a/packages/coding-agent/test/collab/read-only.test.ts
+++ b/packages/coding-agent/test/collab/read-only.test.ts
@@ -182,7 +182,7 @@ describe("collab read-only links", () => {
 		guest.socket.send({ t: "prompt", text: "do something" });
 		const promptReply = await guest.nextFrame();
 		if (promptReply.t !== "error") throw new Error(`expected error, got ${promptReply.t}`);
-		expect(promptReply.message).toContain("read-only");
+		expect(promptReply.message).toContain("PROMPT");
 		expect(prompts).toHaveLength(0);
 
 		guest.socket.send({ t: "abort" });

--- a/packages/wire/CHANGELOG.md
+++ b/packages/wire/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+### Breaking Changes
+
+- Bumped `COLLAB_PROTO` to `4` for guest management and inter-guest communication. Hosts still accept proto-3 guests (served the legacy subset: no `self`/`guests`/`permissionsSet` in `welcome`, never sent guest frames), and guests ignore unknown frame types, so mixed versions interoperate.
+
+### Added
+
+- Added persistent guest identity and capability contracts: `GuestIdentity`, `GuestRole`, `GuestStatus`, `GuestCapabilities`, `guestId`/`capabilities` hello fields, and `self`/`guests`/`permissionsSet` in the `welcome` host frame.
+- Added granular guest permission flags (`GUEST_PERMISSIONS`), role defaults (`ROLE_DEFAULT_PERMISSIONS`), the legacy proto-3 surface (`LEGACY_FULL_PERMISSIONS`), and the append-only `PermissionAuditEntry` record.
+- Added guest-management frames (`guest-invite`, `guest-kick`, `guest-role`, `guest-permission`) and host notifications (`guest-joined`, `guest-left`, `guest-role-changed`, `guest-permission-changed`).
+- Added guest-to-guest communication frames: `guest-message` (direct or broadcast chat), `guest-presence`, `guest-cursor`, and the `permission-audit` request/reply pair.
+
 ## [16.3.0] - 2026-07-02
 
 ### Breaking Changes

--- a/packages/wire/src/index.ts
+++ b/packages/wire/src/index.ts
@@ -295,6 +295,140 @@ export interface SubagentLifecyclePayload {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
+// Guests (persistent identity, roles, granular permissions)
+// ═══════════════════════════════════════════════════════════════════════════
+
+/** Role ladder for collab guests; the human host is the de-facto `owner`. */
+export type GuestRole = "owner" | "admin" | "member" | "viewer";
+
+export type GuestStatus = "online" | "away" | "offline";
+
+/** Feature flags a guest declares in `hello`; the host gates broadcasts on them. */
+export interface GuestCapabilities {
+	/** Guest's wire protocol version. */
+	protocolVersion: number;
+	supportsGuestChat: boolean;
+	supportsPresence: boolean;
+	supportsCursors: boolean;
+}
+
+/**
+ * Stable per-guest identity (proto 4+). `id` survives reconnects within the
+ * same host session; `peerId` changes on every reconnect.
+ */
+export interface GuestIdentity {
+	id: string;
+	/** Current relay peerId; -1 while the guest is disconnected. */
+	peerId: number;
+	name: string;
+	role: GuestRole;
+	status: GuestStatus;
+	/** `data:` or https URL; rendered by guests when present. */
+	avatar?: string;
+	/** True when this guest's current hello proved write-token possession. */
+	canWrite: boolean;
+	capabilities: GuestCapabilities;
+	/** Epoch ms of the original join. */
+	joinedAt: number;
+	/** Epoch ms of the guest's most recent frame (or disconnect). */
+	lastActive: number;
+	/** guestId of the inviter, when the guest arrived through a pending invite. */
+	invitedBy?: string;
+}
+
+/**
+ * Granular guest permissions as bit flags over a `number` — deliberately NOT
+ * bigint: every collab frame is JSON.stringify'd inside the AES-GCM seal, and
+ * bigint throws on serialization. 13 flags stay far inside the 32-bit range.
+ */
+export const GUEST_PERMISSIONS = {
+	/** Send prompts. */
+	PROMPT: 1 << 0,
+	/** `agent-cmd: chat`. */
+	AGENT_CHAT: 1 << 1,
+	/** `agent-cmd: kill`. */
+	AGENT_KILL: 1 << 2,
+	/** `agent-cmd: revive`. */
+	AGENT_REVIVE: 1 << 3,
+	/** Answer host `ui-request` prompts (select/editor). */
+	UI_RESPONSE: 1 << 4,
+	/** `fetch-transcript`. */
+	FETCH_TRANSCRIPT: 1 << 5,
+	/** `abort`. */
+	ABORT: 1 << 6,
+	/** Guest-to-guest chat (send and receive). */
+	GUEST_CHAT: 1 << 7,
+	/** Invite new guests. */
+	GUEST_INVITE: 1 << 8,
+	/** Kick guests. */
+	GUEST_KICK: 1 << 9,
+	/** Change guest roles. */
+	GUEST_ROLE: 1 << 10,
+	/** Grant/revoke permission bits and read the audit log. */
+	PERMISSION_MANAGE: 1 << 11,
+	/** Change session settings (reserved for future frames). */
+	SESSION_CONFIG: 1 << 12,
+} as const satisfies Record<string, number>;
+
+export type GuestPermissionKey = keyof typeof GUEST_PERMISSIONS;
+
+/** Bitmask over {@link GUEST_PERMISSIONS}. */
+export type GuestPermissionSet = number;
+
+/**
+ * Effective surface of a legacy proto-3 guest holding a write token: exactly
+ * the pre-4 mutating grammar. Proto-3 clients have no chat/invite UI, so the
+ * guest-management bits never fire for them even when role defaults include
+ * them.
+ */
+export const LEGACY_FULL_PERMISSIONS: GuestPermissionSet =
+	GUEST_PERMISSIONS.PROMPT |
+	GUEST_PERMISSIONS.AGENT_CHAT |
+	GUEST_PERMISSIONS.AGENT_KILL |
+	GUEST_PERMISSIONS.AGENT_REVIVE |
+	GUEST_PERMISSIONS.UI_RESPONSE |
+	GUEST_PERMISSIONS.FETCH_TRANSCRIPT |
+	GUEST_PERMISSIONS.ABORT;
+
+/** Role → default permission bitmask. Hosts may override per role and per guest. */
+export const ROLE_DEFAULT_PERMISSIONS: Record<GuestRole, GuestPermissionSet> = {
+	owner:
+		LEGACY_FULL_PERMISSIONS |
+		GUEST_PERMISSIONS.GUEST_INVITE |
+		GUEST_PERMISSIONS.GUEST_KICK |
+		GUEST_PERMISSIONS.GUEST_ROLE |
+		GUEST_PERMISSIONS.PERMISSION_MANAGE |
+		GUEST_PERMISSIONS.SESSION_CONFIG,
+	admin:
+		LEGACY_FULL_PERMISSIONS |
+		GUEST_PERMISSIONS.GUEST_INVITE |
+		GUEST_PERMISSIONS.GUEST_KICK |
+		GUEST_PERMISSIONS.GUEST_ROLE,
+	member:
+		GUEST_PERMISSIONS.PROMPT |
+		GUEST_PERMISSIONS.AGENT_CHAT |
+		GUEST_PERMISSIONS.UI_RESPONSE |
+		GUEST_PERMISSIONS.FETCH_TRANSCRIPT |
+		GUEST_PERMISSIONS.ABORT |
+		GUEST_PERMISSIONS.GUEST_CHAT,
+	/** Watch the transcript and join guest chat; nothing else. */
+	viewer: GUEST_PERMISSIONS.FETCH_TRANSCRIPT | GUEST_PERMISSIONS.GUEST_CHAT,
+};
+
+/** Append-only audit record for permission-affecting actions (host caps the log). */
+export interface PermissionAuditEntry {
+	/** Epoch ms. */
+	at: number;
+	/** Actor guestId, or `"host"` for host-side actions. */
+	actorId: string;
+	action: "grant" | "revoke" | "role-change" | "invite" | "kick";
+	/** Affected guestId when the action targets one. */
+	target?: string;
+	/** Human-readable detail, e.g. `"PROMPT|AGENT_CHAT"` or `"member -> admin"`. */
+	detail: string;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
 // Frames (JSON inside the AES-GCM seal)
 // ═══════════════════════════════════════════════════════════════════════════
 
@@ -332,12 +466,38 @@ export type GuestFrame =
 			 * read-only and rejects their mutating frames.
 			 */
 			writeToken?: string;
+			/**
+			 * Persistent guest identity (proto 4+); survives reconnects within
+			 * the same host session. Absent on legacy proto-3 clients.
+			 */
+			guestId?: string;
+			/** Feature flags (proto 4+); absent flags default to false. */
+			capabilities?: GuestCapabilities;
 	  }
 	| { t: "prompt"; text: string; images?: ImageContent[] }
 	| { t: "ui-response"; reqId: number; value?: CollabUiResponseValue }
 	| { t: "abort" }
 	| { t: "agent-cmd"; cmd: "chat" | "kill" | "revive"; agentId: string; text?: string }
-	| { t: "fetch-transcript"; reqId: number; agentId: string; fromByte: number };
+	| { t: "fetch-transcript"; reqId: number; agentId: string; fromByte: number }
+	// ── Guest management (proto 4+) ──────────────────────────────────────────
+	/**
+	 * Invite a guest by display name; the host records a pending invitation
+	 * and applies `role` (plus optional permission bits) when a guest joins
+	 * under that name.
+	 */
+	| { t: "guest-invite"; name: string; role: GuestRole; permissionsOverride?: GuestPermissionSet }
+	/** Disconnect a guest and mark its identity kicked for this session. */
+	| { t: "guest-kick"; guestId: string; reason?: string }
+	| { t: "guest-role"; guestId: string; role: GuestRole }
+	/** Grant/revoke permission bits on top of the guest's role defaults. */
+	| { t: "guest-permission"; guestId: string; grant: GuestPermissionSet; revoke: GuestPermissionSet }
+	// ── Guest-to-guest communication (proto 4+) ─────────────────────────────
+	/** `"broadcast"` fans out to every chat-capable guest; a guestId targets one. */
+	| { t: "guest-message"; to: string | "broadcast"; text: string; kind?: "chat" | "system" }
+	| { t: "guest-presence"; status: GuestStatus }
+	| { t: "guest-cursor"; agentId?: string; position?: { line: number; column: number } }
+	/** Request the host's permission audit log (requires PERMISSION_MANAGE). */
+	| { t: "permission-audit"; reqId: number; guestId?: string; limit?: number };
 
 /** EventBus channels mirrored to guests (task subagent traffic only). */
 export type BusChannel = "task:subagent:progress" | "task:subagent:lifecycle";
@@ -358,6 +518,12 @@ export type HostFrame =
 			entryCount: number;
 			/** True when this peer joined through a read-only (view) link. */
 			readOnly?: boolean;
+			/** Proto-4 guests only: the identity the host assigned to this guest. */
+			self?: GuestIdentity;
+			/** Proto-4 guests only: every current guest in the room (including self). */
+			guests?: GuestIdentity[];
+			/** Proto-4 guests only: the host's effective permission bitmask for this guest. */
+			permissionsSet?: GuestPermissionSet;
 	  }
 	/**
 	 * Targeted snapshot fragment delivered after `welcome`. Hosts split the
@@ -377,7 +543,18 @@ export type HostFrame =
 	/** Targeted reply to fetch-transcript; `text` is decoded JSONL from `fromByte`, `newSize` the next offset base. */
 	| { t: "transcript"; reqId: number; text: string; newSize: number; error?: string }
 	| { t: "bye"; reason: string }
-	| { t: "error"; message: string };
+	| { t: "error"; message: string }
+	// ── Guest management (proto-4 guests only; legacy guests never receive these) ──
+	| { t: "guest-joined"; guest: GuestIdentity }
+	| { t: "guest-left"; guestId: string; reason?: string }
+	| { t: "guest-role-changed"; guestId: string; role: GuestRole; by: string }
+	| { t: "guest-permission-changed"; guestId: string; permissionsSet: GuestPermissionSet }
+	// ── Guest-to-guest communication ──
+	| { t: "guest-message"; from: GuestIdentity; to: string | "broadcast"; text: string; kind: "chat" | "system" }
+	| { t: "guest-presence"; guestId: string; status: GuestStatus }
+	| { t: "guest-cursor"; from: string; agentId?: string; position?: { line: number; column: number } }
+	/** Targeted reply to `permission-audit`. */
+	| { t: "permission-audit"; reqId: number; entries: PermissionAuditEntry[]; error?: string };
 
 export type WireFrame = GuestFrame | HostFrame;
 
@@ -393,8 +570,15 @@ export type WireFrame = GuestFrame | HostFrame;
  *   answered by the `ui-response` guest frame. Guests that predate the
  *   grammar would silently drop `ui-request` (asks hang forever on the
  *   host), so they must be rejected at hello.
+ * - `4`: guest management + inter-guest communication. Guests may declare a
+ *   persistent `guestId` and `capabilities` in `hello`; the host answers
+ *   with `self`/`guests`/`permissionsSet` in `welcome` and accepts the
+ *   `guest-*`/`permission-audit` frames. Hosts still accept proto-3 guests
+ *   (legacy subset: no self/guests/permissions in welcome, never sent guest
+ *   frames), and guests ignore unknown frame types, so mixed versions
+ *   interoperate.
  */
-export const COLLAB_PROTO = 3;
+export const COLLAB_PROTO = 4;
 
 /** Parameter key used for intent tracing (e.g. prompt explanation/reasoning) */
 export const INTENT_FIELD = "i";

--- a/packages/wire/test/constants.test.ts
+++ b/packages/wire/test/constants.test.ts
@@ -9,7 +9,7 @@ import {
 
 describe("collab wire constants", () => {
 	it("exports the protocol constants consumed by host, guest, and relay links", () => {
-		expect(COLLAB_PROTO).toBe(3);
+		expect(COLLAB_PROTO).toBe(4);
 		expect(COLLAB_PROMPT_MESSAGE_TYPE).toBe("collab-prompt");
 		expect(ENVELOPE_HEADER_LENGTH).toBe(4);
 		expect(ROOM_ID_BYTES).toBe(16);


### PR DESCRIPTION
 Title:

 ```
feat(collab): proto-4 guest system with identity, roles, and
granular permissions
 ```

 Base: can1357/oh-my-pi main ← Compare:
 unicornd47-afk/oh-my-pi-addons main (7d60ea7bfa)

 ```markdown
## What

Bump `COLLAB_PROTO` to 4 and add the proto-4 guest system to collab
live sessions:

- **Persistent guest identities** — stable `guestId` +
`GuestIdentity` that survive reconnects
  (peerId still changes); guests declare `capabilities` in `hello`,
host answers with
  `self`/`guests`/`permissionsSet` in `welcome`.
- **Roles & granular permissions** —
`owner`/`admin`/`member`/`viewer` with role-default
  bitmasks (`ROLE_DEFAULT_PERMISSIONS`), 13 permission flags
(`GUEST_PERMISSIONS`), per-guest
  grant/revoke on top of role defaults, and an append-only
permission audit log.
- **Guest management** — invites by display name (role applied on
join), kicks with session
  quarantine, role changes; host notifications
(`guest-joined`/`guest-left`/`guest-role-changed`/
  `guest-permission-changed`).
- **Guest-to-guest communication** — direct or broadcast
`guest-message` chat, presence, and a
  cursor frame + capability flag.
- **New `/collab` slash-command surface** driving the management
flows.

Legacy proto-3 guests keep the pre-4 surface (never sent guest
frames, welcome omits
`self`/`guests`/`permissionsSet`), and guests ignore unknown frame
types, so mixed-version
rooms interoperate. Bug fix included: `requestGuestUi` now deletes
its entry from
`#pendingUi` on settle — settled asks no longer replay to guests
that join later, and stale
answers can no longer strand a live pending request (the old
behavior also hung the collab
test suite outright). `guests.test.ts` frame helpers narrow to
`CollabHostFrame`; the wire
constants test pins `COLLAB_PROTO` to 4.

## Why

The pre-4 grammar had no guest identity or management: guests were
indistinguishable peers
gated by a single all-or-nothing write token, so multi-user
sessions could not be moderated
or partitioned. Proto 4 adds the identity/role/permission layer for
moderated multi-user
collab while keeping proto-3 clients working. The replay fix
repairs a real host bug: a
guest joining mid-ask would see already-answered prompts and
answering one would silently
swallow the host's live request.

## Testing

- `bun test packages/coding-agent/test/collab packages/wire/test` →
**100 pass / 0 fail**
  (17 files), including the new `guests.test.ts` (proto-4 contract:
identity, roles,
  permission gating, chat routing, invites, kicks, audit, proto-3
interop) and
  `guest-registry.test.ts`, run over the in-memory relay with real
AES-GCM sealing.
- `bun run check:ts` green (biome 4711 files + tsgo on every
package).
- Replay hang reproduced and bisected: `read-only.test.ts` tests
4+5 passed individually but
  hung together for >2 min; both pass after the `#pendingUi.delete`
fix, full file no longer
  wedges.
- `check:rs` fails on this machine compiling the `futures-util`
dependency (pre-existing
  local toolchain issue, 2805 errors in the dep itself); this PR
touches no Rust files.

---

- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
 ```

 Two things before you hit submit:

 1. CONTRIBUTING rule: AI-assisted PRs need at least one sentence
    written by you explaining the change + verification — "bun check
    passes" doesn't satisfy it. Add a sentence in Testing or What,
    e.g. what you saw when you ran a live session.
 2. The bun check box: check:ts is fully green; only the unrelated
    local futures-util build failure stops me from ticking it. If
    upstream CI (or your machine) compiles Rust clean, tick it
    before submitting.
