### PR TITLE
feat(coding-agent): close advisor eye icon once its review has yielded

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,13 +12,7 @@
 - Added provider-supplied model metadata to `/models`, including new, beta, and recommended badges plus model descriptions.
 - Standalone `CLAUDE.md` files in project and ancestor directories are now loaded as context alongside `AGENTS.md`, while preserving config-directory precedence.
 - Added an Activity view to Agent Hub with searchable and filterable timelines spanning live progress and persisted transcripts; `/hub` is now the live-operations entry point while `/agents` retains Control Center behavior.
-- Added `injectV1: false` option to `openai-models-list` discovery to fetch the model list from `{baseUrl}/models` without injecting `/v1`, for gateways that root their OpenAI-compatible surface at a versioned URL (e.g. `https://api.opper.ai/v3/compat`) where the `/v1`-injected endpoint returns only a small subset.
-- Added provider-reported credits and concrete routed-model counts to `/session` statistics ([#8590](https://github.com/can1357/oh-my-pi/pull/8590) by [@will-bogusz](https://github.com/will-bogusz)).
-- Added `CLINE_API_KEY` to the CLI environment help for native ClinePass subscription inference ([#7863](https://github.com/can1357/oh-my-pi/pull/7863) by [@will-bogusz](https://github.com/will-bogusz)).
-- Devin model selectors now accept the native CLI's short aliases (`devin/opus`, `devin/swe`), dotted upstream spellings (`devin/gemini-3.7-flash`), and raw effort-route wire uids for dynamically collapsed families ([#8590](https://github.com/can1357/oh-my-pi/pull/8590) by [@will-bogusz](https://github.com/will-bogusz)).
-- Added provider-supplied model metadata to the `/models` detail line: `new`, `beta`, and `recommended` badges beside the model name, and the upstream description after the context, cost, and perf facts ([#8590](https://github.com/can1357/oh-my-pi/pull/8590) by [@will-bogusz](https://github.com/will-bogusz)).
-- Standalone `CLAUDE.md` files in the project root (and ancestor directories) are now loaded as context, mirroring `AGENTS.md` discovery; config-directory context files still take precedence per scope.
-- The advisor eye icon in the status line closes (`icon.advisorClosed` symbol-theme token) once the advisor has finished reviewing a yielded turn and will not add further comments.
+- Added an `icon.advisorClosed` symbol-theme token: the advisor eye in the status line now closes once the advisor has finished reviewing and will not add further comments.
 
 ### Changed
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,6 +12,13 @@
 - Added provider-supplied model metadata to `/models`, including new, beta, and recommended badges plus model descriptions.
 - Standalone `CLAUDE.md` files in project and ancestor directories are now loaded as context alongside `AGENTS.md`, while preserving config-directory precedence.
 - Added an Activity view to Agent Hub with searchable and filterable timelines spanning live progress and persisted transcripts; `/hub` is now the live-operations entry point while `/agents` retains Control Center behavior.
+- Added `injectV1: false` option to `openai-models-list` discovery to fetch the model list from `{baseUrl}/models` without injecting `/v1`, for gateways that root their OpenAI-compatible surface at a versioned URL (e.g. `https://api.opper.ai/v3/compat`) where the `/v1`-injected endpoint returns only a small subset.
+- Added provider-reported credits and concrete routed-model counts to `/session` statistics ([#8590](https://github.com/can1357/oh-my-pi/pull/8590) by [@will-bogusz](https://github.com/will-bogusz)).
+- Added `CLINE_API_KEY` to the CLI environment help for native ClinePass subscription inference ([#7863](https://github.com/can1357/oh-my-pi/pull/7863) by [@will-bogusz](https://github.com/will-bogusz)).
+- Devin model selectors now accept the native CLI's short aliases (`devin/opus`, `devin/swe`), dotted upstream spellings (`devin/gemini-3.7-flash`), and raw effort-route wire uids for dynamically collapsed families ([#8590](https://github.com/can1357/oh-my-pi/pull/8590) by [@will-bogusz](https://github.com/will-bogusz)).
+- Added provider-supplied model metadata to the `/models` detail line: `new`, `beta`, and `recommended` badges beside the model name, and the upstream description after the context, cost, and perf facts ([#8590](https://github.com/can1357/oh-my-pi/pull/8590) by [@will-bogusz](https://github.com/will-bogusz)).
+- Standalone `CLAUDE.md` files in the project root (and ancestor directories) are now loaded as context, mirroring `AGENTS.md` discovery; config-directory context files still take precedence per scope.
+- The advisor eye icon in the status line closes (`icon.advisorClosed` symbol-theme token) once the advisor has finished reviewing a yielded turn and will not add further comments.
 
 ### Changed
 

--- a/packages/coding-agent/src/advisor/runtime.ts
+++ b/packages/coding-agent/src/advisor/runtime.ts
@@ -1477,7 +1477,12 @@ export class AdvisorRuntime {
 		} finally {
 			this.#iterationAbort = undefined;
 			this.#busy = false;
-			if (!this.disposed && this.#backlog === 0 && this.#pending.length === 0) {
+			// Notify on EVERY path that lands the runtime in the yielded state —
+			// not just an empty backlog. The quota branch requeues the failed
+			// batch (backlog/pending stay non-empty) yet `yielded` is true via
+			// the quota latch, and the eye must close without waiting for an
+			// unrelated repaint. Same for halt.
+			if (!this.disposed && this.yielded) {
 				try {
 					this.host.notifyIdle?.();
 				} catch (err) {

--- a/packages/coding-agent/src/advisor/runtime.ts
+++ b/packages/coding-agent/src/advisor/runtime.ts
@@ -86,6 +86,10 @@ export interface AdvisorRuntimeHost {
 	notifyQuotaExhausted?(): void;
 	/** Stable identity for the live advisor model. Used to restore full transcript rendering after a model switch. */
 	getModelIdentity?(): string;
+	/** Called once the runtime finishes draining its review backlog (or
+	 *  hard-stops), so the host can repaint UI that reflects whether the
+	 *  advisor is still going to comment on the current yield. */
+	notifyIdle?(): void;
 }
 
 /**
@@ -353,6 +357,18 @@ export class AdvisorRuntime {
 	/** True after the runtime hard-stopped on repeated or permanent failures. */
 	get halted(): boolean {
 		return this.#halted;
+	}
+	/** True once the runtime has no queued or in-flight review work left and
+	 *  will not resume it on its own (finished, halted, or quota-paused): the
+	 *  advisor is not going to add any more comments until a new primary turn
+	 *  (or an explicit reset). Drives the status-line closed-eye state. */
+	get yielded(): boolean {
+		return (
+			this.disposed ||
+			this.#quotaExhausted ||
+			this.#halted ||
+			(!this.#busy && this.#backlog === 0 && this.#pending.length === 0)
+		);
 	}
 
 	/**
@@ -1449,6 +1465,13 @@ export class AdvisorRuntime {
 		} finally {
 			this.#iterationAbort = undefined;
 			this.#busy = false;
+			if (!this.disposed && this.#backlog === 0 && this.#pending.length === 0) {
+				try {
+					this.host.notifyIdle?.();
+				} catch (err) {
+					logger.debug("advisor idle notification failed", { err: String(err) });
+				}
+			}
 		}
 	}
 }

--- a/packages/coding-agent/src/advisor/runtime.ts
+++ b/packages/coding-agent/src/advisor/runtime.ts
@@ -319,6 +319,13 @@ export class AdvisorRuntime {
 	 * explicit {@link reset} (config rebuild, /new, session restart).
 	 */
 	#halted = false;
+	/**
+	 * Whether the runtime has completed at least one review (a drain batch that
+	 * ended in a successful advisor turn). Gates {@link yielded} so the
+	 * status-line eye stays open until a review actually completes — a fresh
+	 * runtime with an empty backlog has not "finished" anything yet.
+	 */
+	#hasReviewed = false;
 	/** True from the moment an advisor turn fails until one succeeds (or an
 	 *  explicit reset/seed). While set, {@link waitForCatchup} resolves
 	 *  immediately: the primary agent NEVER parks on a failing advisor. */
@@ -358,16 +365,20 @@ export class AdvisorRuntime {
 	get halted(): boolean {
 		return this.#halted;
 	}
-	/** True once the runtime has no queued or in-flight review work left and
-	 *  will not resume it on its own (finished, halted, or quota-paused): the
-	 *  advisor is not going to add any more comments until a new primary turn
-	 *  (or an explicit reset). Drives the status-line closed-eye state. */
+	/**
+	 * True once the runtime has completed at least one review and has no queued
+	 * or in-flight review work left, or has hard-stopped (halted/quota-paused/
+	 * disposed): the advisor is not going to add any more comments until a new
+	 * primary turn (or an explicit reset). A fresh runtime that has never
+	 * reviewed anything is NOT yielded — the eye stays open until the first
+	 * review completes. Drives the status-line closed-eye state.
+	 */
 	get yielded(): boolean {
 		return (
 			this.disposed ||
 			this.#quotaExhausted ||
 			this.#halted ||
-			(!this.#busy && this.#backlog === 0 && this.#pending.length === 0)
+			(this.#hasReviewed && !this.#busy && this.#backlog === 0 && this.#pending.length === 0)
 		);
 	}
 
@@ -1187,6 +1198,7 @@ export class AdvisorRuntime {
 					if (turnError) throw turnError;
 					success = true;
 					this.#seenContextInFlight = undefined;
+					this.#hasReviewed = true;
 					this.#failing = false;
 					this.#consecutiveFailures = 0;
 					this.#failureNotified = false;

--- a/packages/coding-agent/src/advisor/runtime.ts
+++ b/packages/coding-agent/src/advisor/runtime.ts
@@ -584,6 +584,10 @@ export class AdvisorRuntime {
 		this.#sessionTransitionPaused = false;
 		this.#quotaExhausted = false;
 		this.#halted = false;
+		// A re-primed advisor has not reviewed the (new) conversation yet — drop
+		// the latch so the eye stays open until the first post-reset review, and
+		// so an aborted prior drain cannot emit a stale advisor_yielded.
+		this.#hasReviewed = false;
 		this.#failing = false;
 		this.#droppedBacklogs = 0;
 		this.#consecutiveQuarantines = 0;

--- a/packages/coding-agent/src/cli/gallery-fixtures/preview-session.ts
+++ b/packages/coding-agent/src/cli/gallery-fixtures/preview-session.ts
@@ -6,6 +6,7 @@ export interface GallerySessionOptions {
 	contextTokens?: number;
 	fastMode?: boolean;
 	advisorStatus?: "running" | "quota_exhausted" | "error" | "paused";
+	advisorYielded?: boolean;
 	usingSubscription?: boolean;
 	cost?: number;
 	premiumRequests?: number;
@@ -69,7 +70,10 @@ export function createGallerySession(options: GallerySessionOptions = {}): Agent
 		}),
 		getAdvisorStatusOverview: () =>
 			options.advisorStatus
-				? { configured: true, advisors: [{ status: options.advisorStatus }] }
+				? {
+						configured: true,
+						advisors: [{ status: options.advisorStatus, yielded: options.advisorYielded ?? false }],
+					}
 				: { configured: false, advisors: [] },
 		getAdvisorCost: () => options.advisorCost ?? 0.08,
 		isAdvisorUsingSubscription: () => false,

--- a/packages/coding-agent/src/cli/gallery-fixtures/segments.ts
+++ b/packages/coding-agent/src/cli/gallery-fixtures/segments.ts
@@ -97,6 +97,7 @@ function variantsFor(id: StatusLineSegmentId): readonly SegmentVariantSpec[] {
 				{ label: "advisor warning", session: { advisorStatus: "quota_exhausted" } },
 				{ label: "advisor error", session: { advisorStatus: "error" } },
 				{ label: "advisor paused", session: { advisorStatus: "paused" } },
+				{ label: "advisor done (yielded)", session: { advisorStatus: "running", advisorYielded: true } },
 			];
 		case "mode":
 			return [

--- a/packages/coding-agent/src/modes/components/status-line/segments.ts
+++ b/packages/coding-agent/src/modes/components/status-line/segments.ts
@@ -212,9 +212,8 @@ const modelSegment: StatusLineSegment = {
 		// `/advisor status`.
 		// Optional chaining: lightweight session doubles (test mocks) that don't
 		// implement getAdvisorStatusOverview skip the badge instead of crashing.
-		const advisorIcon = theme.icon.advisor;
 		const advisorStats = ctx.session.getAdvisorStatusOverview?.();
-		if (advisorIcon && advisorStats?.configured && advisorStats.advisors.length > 0) {
+		if (advisorStats?.configured && advisorStats.advisors.length > 0) {
 			const statuses = advisorStats.advisors.map(a => a.status);
 			const badgeColor = statuses.includes("error")
 				? "error"
@@ -223,7 +222,11 @@ const modelSegment: StatusLineSegment = {
 					: statuses.includes("running")
 						? "success"
 						: "dim";
-			content += theme.fg(badgeColor, ` ${advisorIcon}`);
+			// Closed eye once every advisor has finished reviewing the yielded
+			// turn — no more comments until a new primary turn starts.
+			const allYielded = advisorStats.advisors.every(a => a.yielded);
+			const advisorIcon = allYielded ? theme.icon.advisorClosed || theme.icon.advisor : theme.icon.advisor;
+			if (advisorIcon) content += theme.fg(badgeColor, ` ${advisorIcon}`);
 		}
 		if (tail) {
 			content += accentFg(ctx, "statusLineModel", tail);

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -280,6 +280,12 @@ export class EventController {
 				this.ctx.statusLine.invalidate();
 				this.ctx.ui.requestRender();
 			},
+			advisor_yielded: async () => {
+				// The advisor finished reviewing the yielded primary turn (no more
+				// comments coming) — repaint so the closed-eye state lands.
+				this.ctx.statusLine.invalidate();
+				this.ctx.ui.requestRender();
+			},
 			thinking_level_changed: async () => {
 				this.ctx.statusLine.invalidate();
 				this.ctx.updateEditorBorderColor();

--- a/packages/coding-agent/src/modes/theme/symbols.ts
+++ b/packages/coding-agent/src/modes/theme/symbols.ts
@@ -96,6 +96,7 @@ export type SymbolKey =
 	| "icon.cost"
 	| "icon.subscription"
 	| "icon.advisor"
+	| "icon.advisorClosed"
 	| "icon.time"
 	| "icon.omp"
 	| "icon.esc"
@@ -447,6 +448,7 @@ const UNICODE_SYMBOLS: SymbolMap = {
 	"icon.cost": "💲",
 	"icon.subscription": "(sub)",
 	"icon.advisor": "👁",
+	"icon.advisorClosed": "🙈",
 	"icon.time": "⏱",
 	"icon.omp": "π",
 	"icon.esc": "⎋",
@@ -792,6 +794,8 @@ const NERD_SYMBOLS: SymbolMap = {
 	"icon.subscription": "\u{f067a}",
 	// pick:  (nf-cod-eye)
 	"icon.advisor": "\uea70",
+	// pick:  (nf-oct-eye_closed)
+	"icon.advisorClosed": "\ueae7",
 	// pick:  | alt: ◷ ◴
 	"icon.time": "\uf017",
 	// pick: 󰵗 (nf-md-pi) | alt:  π ∏ ∑
@@ -1146,6 +1150,7 @@ const ASCII_SYMBOLS: SymbolMap = {
 	"icon.cost": "$",
 	"icon.subscription": "(sub)",
 	"icon.advisor": "(adv)",
+	"icon.advisorClosed": "(adv)",
 	"icon.time": "t:",
 	"icon.omp": "pi",
 	"icon.esc": "esc",

--- a/packages/coding-agent/src/modes/theme/theme-class.ts
+++ b/packages/coding-agent/src/modes/theme/theme-class.ts
@@ -590,6 +590,7 @@ export class Theme {
 			cost: this.#symbols["icon.cost"],
 			subscription: this.#symbols["icon.subscription"],
 			advisor: this.#symbols["icon.advisor"],
+			advisorClosed: this.#symbols["icon.advisorClosed"],
 			time: this.#symbols["icon.time"],
 			omp: this.#symbols["icon.omp"],
 			esc: this.#symbols["icon.esc"],

--- a/packages/coding-agent/src/session/agent-session-events.ts
+++ b/packages/coding-agent/src/session/agent-session-events.ts
@@ -50,6 +50,7 @@ export type AgentSessionEvent =
 	| { type: "model_changed" }
 	| { type: "config_warnings_changed" }
 	| { type: "advisor_cost_changed" }
+	| { type: "advisor_yielded" }
 	| { type: "ttsr_triggered"; rules: Rule[] }
 	| { type: "todo_reminder"; todos: TodoItem[]; attempt: number; maxAttempts: number }
 	| { type: "todo_auto_clear" }

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -98,7 +98,7 @@ import {
 	stringProperty,
 	withTimeout,
 } from "@oh-my-pi/pi-utils";
-import { type AdvisorConfig, type AdvisorRuntimeStatus, loadAdvisorTranscriptCosts } from "../advisor";
+import { type AdvisorConfig, loadAdvisorTranscriptCosts } from "../advisor";
 import { ASYNC_JOB_MANAGER_SHUTDOWN_REASON, type AsyncJob, AsyncJobManager } from "../async";
 import { reset as resetCapabilities } from "../capability";
 import type { EffectiveExtensionRoots } from "../capability/types";
@@ -333,7 +333,12 @@ import {
 	toRestoredQueuedMessage,
 } from "./queued-messages";
 import type { ServingModel } from "./retry-fallback-chains";
-import { type AdvisorStats, SessionAdvisors, type SessionAdvisorsHost } from "./session-advisors";
+import {
+	type AdvisorStats,
+	type AdvisorStatusOverviewEntry,
+	SessionAdvisors,
+	type SessionAdvisorsHost,
+} from "./session-advisors";
 import type { BuildSessionContextOptions, SessionContext } from "./session-context";
 import { getRestorableSessionModels } from "./session-context";
 import { formatSessionDumpText } from "./session-dump-format";
@@ -360,7 +365,7 @@ import { YieldQueue } from "./yield-queue";
 
 export * from "./agent-session-events";
 export * from "./agent-session-types";
-export type { AdvisorStats, PerAdvisorStat } from "./session-advisors";
+export type { AdvisorStats, AdvisorStatusOverviewEntry, PerAdvisorStat } from "./session-advisors";
 
 const SESSION_STOP_CONTINUATION_CAP = 8;
 
@@ -10073,7 +10078,7 @@ export class AgentSession {
 	 * flag and per-advisor name/status without computing token/cost breakdowns.
 	 * Avoids re-tokenizing the advisor transcript on every render frame.
 	 */
-	getAdvisorStatusOverview(): { configured: boolean; advisors: { name: string; status: AdvisorRuntimeStatus }[] } {
+	getAdvisorStatusOverview(): { configured: boolean; advisors: AdvisorStatusOverviewEntry[] } {
 		return this.#advisors.getAdvisorStatusOverview();
 	}
 

--- a/packages/coding-agent/src/session/session-advisors.ts
+++ b/packages/coding-agent/src/session/session-advisors.ts
@@ -286,6 +286,17 @@ export interface SessionAdvisorsHost {
 	sessionId(): string;
 }
 
+/**
+ * One advisor's status-line slice: runtime status plus whether it has
+ * finished reviewing the current yield — i.e. it is not going to add any
+ * more comments until a new primary turn starts (or an explicit reset).
+ */
+export interface AdvisorStatusOverviewEntry {
+	name: string;
+	status: AdvisorRuntimeStatus;
+	yielded: boolean;
+}
+
 /** Owns advisor runtimes, delivery policy, context maintenance, and status reporting. */
 export class SessionAdvisors {
 	readonly #host: SessionAdvisorsHost;
@@ -1101,6 +1112,15 @@ export class SessionAdvisors {
 						"advisor",
 					);
 				},
+				notifyIdle: () => {
+					// Only surface the yield once the primary has stopped streaming:
+					// mid-turn drain completions keep the eye open (more deltas are
+					// coming), and the agent_end repaint already covered them.
+					if (this.#host.agent.state.isStreaming) return;
+					void this.#host
+						.emitSessionEvent({ type: "advisor_yielded" })
+						.catch(err => logger.debug("advisor yield notification failed", { err: String(err) }));
+				},
 			});
 
 			const advisorRef: ActiveAdvisor = {
@@ -1872,20 +1892,26 @@ export class SessionAdvisors {
 	 * flag and per-advisor name/status without computing token/cost breakdowns.
 	 * Avoids re-tokenizing the advisor transcript on every render frame.
 	 */
-	getAdvisorStatusOverview(): { configured: boolean; advisors: { name: string; status: AdvisorRuntimeStatus }[] } {
+	getAdvisorStatusOverview(): { configured: boolean; advisors: AdvisorStatusOverviewEntry[] } {
 		// Override stale map entries with live runtime status: failureNotified/quotaExhausted
 		// clear on reset() but #advisorStatuses lags until the next build.
-		const liveStatusBySlug = new Map<string, AdvisorRuntimeStatus>();
+		const liveStatusBySlug = new Map<string, { status: AdvisorRuntimeStatus; yielded: boolean }>();
 		for (const a of this.#advisors) {
-			liveStatusBySlug.set(
-				a.slug,
-				a.runtime.quotaExhausted ? "quota_exhausted" : a.runtime.failureNotified ? "error" : "running",
-			);
+			liveStatusBySlug.set(a.slug, {
+				status: a.runtime.quotaExhausted ? "quota_exhausted" : a.runtime.failureNotified ? "error" : "running",
+				yielded: a.runtime.yielded,
+			});
 		}
-		const advisors = [...this.#advisorStatuses.entries()].map(([slug, { name, status }]) => ({
-			name,
-			status: liveStatusBySlug.get(slug) ?? status,
-		}));
+		const advisors = [...this.#advisorStatuses.entries()].map(([slug, { name, status }]) => {
+			const live = liveStatusBySlug.get(slug);
+			return {
+				name,
+				status: live?.status ?? status,
+				// Roster entries without a live runtime (disabled, no model, paused)
+				// will never comment again — treat them as yielded.
+				yielded: live?.yielded ?? true,
+			};
+		});
 		return { configured: this.#advisorEnabled, advisors };
 	}
 

--- a/packages/coding-agent/src/session/session-advisors.ts
+++ b/packages/coding-agent/src/session/session-advisors.ts
@@ -1907,9 +1907,13 @@ export class SessionAdvisors {
 			return {
 				name,
 				status: live?.status ?? status,
-				// Roster entries without a live runtime (disabled, no model, paused)
-				// will never comment again — treat them as yielded.
-				yielded: live?.yielded ?? true,
+				// The eye only closes after the primary itself has yielded: while it
+				// is streaming, the advisor may still receive (and comment on) new
+				// deltas even when its current backlog is empty, so a mid-turn
+				// repaint must never show the closed eye. Roster entries without a
+				// live runtime (disabled, no model, paused) never comment again —
+				// treat them as yielded regardless.
+				yielded: this.#host.agent.state.isStreaming ? false : (live?.yielded ?? true),
 			};
 		});
 		return { configured: this.#advisorEnabled, advisors };

--- a/packages/coding-agent/src/session/session-advisors.ts
+++ b/packages/coding-agent/src/session/session-advisors.ts
@@ -1897,11 +1897,15 @@ export class SessionAdvisors {
 	getAdvisorStatusOverview(): { configured: boolean; advisors: AdvisorStatusOverviewEntry[] } {
 		// Override stale map entries with live runtime status: failureNotified/quotaExhausted
 		// clear on reset() but #advisorStatuses lags until the next build.
-		const liveStatusBySlug = new Map<string, { status: AdvisorRuntimeStatus; yielded: boolean }>();
+		const liveStatusBySlug = new Map<
+			string,
+			{ status: AdvisorRuntimeStatus; yielded: boolean; canReview: boolean }
+		>();
 		for (const a of this.#advisors) {
 			liveStatusBySlug.set(a.slug, {
 				status: a.runtime.quotaExhausted ? "quota_exhausted" : a.runtime.failureNotified ? "error" : "running",
 				yielded: a.runtime.yielded,
+				canReview: !a.runtime.quotaExhausted && !a.runtime.halted && !a.runtime.disposed,
 			});
 		}
 		const advisors = [...this.#advisorStatuses.entries()].map(([slug, { name, status }]) => {
@@ -1910,12 +1914,12 @@ export class SessionAdvisors {
 				name,
 				status: live?.status ?? status,
 				// The eye only closes after the primary itself has yielded: while it
-				// is streaming, the advisor may still receive (and comment on) new
-				// deltas even when its current backlog is empty, so a mid-turn
-				// repaint must never show the closed eye. Roster entries without a
-				// live runtime (disabled, no model, paused) never comment again —
-				// treat them as yielded regardless.
-				yielded: this.#host.agent.state.isStreaming ? false : (live?.yielded ?? true),
+				// is streaming, an advisor that can still accept review work may
+				// receive (and comment on) new deltas even when its backlog is
+				// empty. Advisors that cannot accept work — no live runtime
+				// (paused/no-model) or a quota-exhausted/halted runtime — stay
+				// yielded regardless of the primary's stream state.
+				yielded: live?.canReview && this.#host.agent.state.isStreaming ? false : (live?.yielded ?? true),
 			};
 		});
 		return { configured: this.#advisorEnabled, advisors };

--- a/packages/coding-agent/src/session/session-advisors.ts
+++ b/packages/coding-agent/src/session/session-advisors.ts
@@ -1113,10 +1113,12 @@ export class SessionAdvisors {
 					);
 				},
 				notifyIdle: () => {
-					// Only surface the yield once the primary has stopped streaming:
-					// mid-turn drain completions keep the eye open (more deltas are
-					// coming), and the agent_end repaint already covered them.
-					if (this.#host.agent.state.isStreaming) return;
+					// Repaint on every idle transition, streaming or not: the status
+					// line masks `yielded` back to open while the primary streams, so
+					// mid-turn drain completions stay open, while post-yield
+					// completions — including the quota/halt latches, which can land
+					// after the agent_end repaint — close the eye without waiting for
+					// an unrelated event.
 					void this.#host
 						.emitSessionEvent({ type: "advisor_yielded" })
 						.catch(err => logger.debug("advisor yield notification failed", { err: String(err) }));

--- a/packages/coding-agent/test/advisor-toggle.test.ts
+++ b/packages/coding-agent/test/advisor-toggle.test.ts
@@ -420,6 +420,22 @@ describe("AgentSession advisor toggle", () => {
 		expect(sid).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i);
 		expect(sid).not.toContain("-advisor");
 	});
+	it("keeps the advisor eye open until the primary has yielded", () => {
+		// Regression for the review note on #10463: a fresh/empty-backlog runtime
+		// reports `yielded`, but the status line must only close the eye once the
+		// primary itself has stopped streaming — mid-turn repaints (agent_start,
+		// message events) must keep showing the open eye.
+		enableAdvisor();
+
+		const overview = () => session.getAdvisorStatusOverview();
+		expect(overview().advisors[0]?.yielded).toBe(true);
+
+		session.agent.state.isStreaming = true;
+		expect(overview().advisors[0]?.yielded).toBe(false);
+
+		session.agent.state.isStreaming = false;
+		expect(overview().advisors[0]?.yielded).toBe(true);
+	});
 	it("retains cumulative advisor cost after the advisor is disabled", () => {
 		const advisor = enableAdvisor();
 

--- a/packages/coding-agent/test/advisor-toggle.test.ts
+++ b/packages/coding-agent/test/advisor-toggle.test.ts
@@ -420,21 +420,59 @@ describe("AgentSession advisor toggle", () => {
 		expect(sid).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i);
 		expect(sid).not.toContain("-advisor");
 	});
-	it("keeps the advisor eye open until the primary has yielded", () => {
-		// Regression for the review note on #10463: a fresh/empty-backlog runtime
-		// reports `yielded`, but the status line must only close the eye once the
-		// primary itself has stopped streaming — mid-turn repaints (agent_start,
-		// message events) must keep showing the open eye.
-		enableAdvisor();
+	it("closes the eye only after a review completes on a yielded primary", async () => {
+		// Review feedback on #10463: `yielded` must mean "finished reviewing, no
+		// more comments" — not merely "no queued work". A fresh runtime that has
+		// never reviewed anything stays open at rest, mid-turn repaints stay open
+		// while the primary streams, and only after a completed advisor review
+		// does the eye close.
+		const mock = createMockModel({ responses: [{ content: ["primary complete"] }] });
+		const primaryAgent = new Agent({
+			initialState: {
+				model,
+				systemPrompt: ["Test"],
+				tools: [],
+				messages: [],
+			},
+			streamFn: mock.stream,
+		});
+		const settings = Settings.isolated({ "compaction.enabled": false });
+		settings.setModelRole("advisor", `${model.provider}/${model.id}`);
+		const reviewSession = new AgentSession({
+			agent: primaryAgent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+			advisorTools: [],
+		});
 
-		const overview = () => session.getAdvisorStatusOverview();
-		expect(overview().advisors[0]?.yielded).toBe(true);
+		try {
+			expect(reviewSession.setAdvisorEnabled(true)).toBe(true);
+			const advisorAgent = reviewSession.getAdvisorAgent();
+			if (!advisorAgent) throw new Error("Expected advisor agent to exist");
+			// Deterministically complete the advisor review: append an assistant
+			// message so the runtime's turn-error check sees a finished turn.
+			vi.spyOn(advisorAgent, "prompt").mockImplementation(async () => {
+				advisorAgent.state.messages.push(advisorMessage(0.1, 1));
+			});
 
-		session.agent.state.isStreaming = true;
-		expect(overview().advisors[0]?.yielded).toBe(false);
+			const yielded = () => reviewSession.getAdvisorStatusOverview().advisors[0]?.yielded;
 
-		session.agent.state.isStreaming = false;
-		expect(overview().advisors[0]?.yielded).toBe(true);
+			// Fresh runtime, nothing reviewed yet — the eye stays open at rest.
+			expect(yielded()).toBe(false);
+
+			// Mid-turn — masked open even with an empty backlog.
+			reviewSession.agent.state.isStreaming = true;
+			expect(yielded()).toBe(false);
+			reviewSession.agent.state.isStreaming = false;
+
+			// A primary turn completes and the advisor reviews it — eye closes.
+			await reviewSession.agent.prompt("do work");
+			await reviewSession.waitForAdvisorCatchup(2000);
+			expect(yielded()).toBe(true);
+		} finally {
+			await reviewSession.dispose();
+		}
 	});
 	it("retains cumulative advisor cost after the advisor is disabled", () => {
 		const advisor = enableAdvisor();

--- a/packages/coding-agent/test/advisor-toggle.test.ts
+++ b/packages/coding-agent/test/advisor-toggle.test.ts
@@ -989,12 +989,24 @@ describe("AgentSession advisor toggle", () => {
 			const markUsageLimitReached = vi
 				.spyOn(authStorage, "markUsageLimitReached")
 				.mockResolvedValue({ switched: false });
+			// The quota latch makes `yielded` true even though the failed batch is
+			// requeued — the runtime must still emit advisor_yielded so the status
+			// line repaints the closed eye without waiting for unrelated activity.
+			const events: string[] = [];
+			const unsubscribe = quotaSession.subscribe(event => events.push(event.type));
 
 			await quotaSession.prompt("Trigger advisor");
 			await quotaSession.waitForIdle();
 
 			expect(markUsageLimitReached).toHaveBeenCalledTimes(1);
 			expect(markUsageLimitReached.mock.calls[0]?.[0]).toBe(model.provider);
+			expect(quotaSession.getAdvisorStatusOverview().advisors[0]?.yielded).toBe(true);
+			const deadline = Date.now() + 2000;
+			while (!events.includes("advisor_yielded") && Date.now() < deadline) {
+				await Bun.sleep(10);
+			}
+			unsubscribe();
+			expect(events).toContain("advisor_yielded");
 		} finally {
 			await quotaSession.dispose();
 			vi.restoreAllMocks();

--- a/packages/coding-agent/test/advisor-toggle.test.ts
+++ b/packages/coding-agent/test/advisor-toggle.test.ts
@@ -314,6 +314,18 @@ describe("AgentSession advisor toggle", () => {
 			"Advisor setting is enabled, but no model is assigned to the 'advisor' role.",
 		);
 	});
+	it("keeps advisors without a live runtime yielded during a primary turn", () => {
+		// A configured advisor with no resolvable model has no runtime and can
+		// never review — the streaming mask must not reopen its eye mid-turn.
+		session.settings.setModelRole("advisor", "nonexistent/advisor-model");
+		expect(session.setAdvisorEnabled(true)).toBe(false);
+
+		const yielded = () => session.getAdvisorStatusOverview().advisors[0]?.yielded;
+		expect(yielded()).toBe(true);
+		session.agent.state.isStreaming = true;
+		expect(yielded()).toBe(true);
+		session.agent.state.isStreaming = false;
+	});
 
 	it("activates an enabled advisor once background model discovery settles", async () => {
 		// Advisor role points at a valid model that is missing from the catalog at
@@ -989,11 +1001,10 @@ describe("AgentSession advisor toggle", () => {
 			const markUsageLimitReached = vi
 				.spyOn(authStorage, "markUsageLimitReached")
 				.mockResolvedValue({ switched: false });
-			// The quota latch makes `yielded` true even though the failed batch is
-			// requeued — the runtime must still emit advisor_yielded so the status
-			// line repaints the closed eye without waiting for unrelated activity.
-			const events: string[] = [];
-			const unsubscribe = quotaSession.subscribe(event => events.push(event.type));
+			const advisorYielded = Promise.withResolvers<void>();
+			const unsubscribe = quotaSession.subscribe(event => {
+				if (event.type === "advisor_yielded") advisorYielded.resolve();
+			});
 
 			await quotaSession.prompt("Trigger advisor");
 			await quotaSession.waitForIdle();
@@ -1001,12 +1012,16 @@ describe("AgentSession advisor toggle", () => {
 			expect(markUsageLimitReached).toHaveBeenCalledTimes(1);
 			expect(markUsageLimitReached.mock.calls[0]?.[0]).toBe(model.provider);
 			expect(quotaSession.getAdvisorStatusOverview().advisors[0]?.yielded).toBe(true);
-			const deadline = Date.now() + 2000;
-			while (!events.includes("advisor_yielded") && Date.now() < deadline) {
-				await Bun.sleep(10);
-			}
+			// A quota-paused runtime cannot accept work either — the streaming
+			// mask must not reopen its eye mid-turn.
+			quotaSession.agent.state.isStreaming = true;
+			expect(quotaSession.getAdvisorStatusOverview().advisors[0]?.yielded).toBe(true);
+			quotaSession.agent.state.isStreaming = false;
+
+			// Repaint contract: advisor_yielded must have fired even though the
+			// failed batch stays requeued (the quota latch makes yielded true).
+			await advisorYielded.promise;
 			unsubscribe();
-			expect(events).toContain("advisor_yielded");
 		} finally {
 			await quotaSession.dispose();
 			vi.restoreAllMocks();

--- a/packages/coding-agent/test/advisor/advisor.test.ts
+++ b/packages/coding-agent/test/advisor/advisor.test.ts
@@ -1379,6 +1379,50 @@ describe("advisor", () => {
 			expect(promptText(promptInputs[1])).toContain("second");
 		});
 
+		it("clears the review latch on reset so a re-primed advisor is not yielded", async () => {
+			// Review feedback on #10463: after a successful review the runtime is
+			// yielded, but reset() (/new, branch, session switch, rewrites) must
+			// drop the latch — the advisor has not reviewed the new conversation,
+			// so the eye stays open until its first post-reset review, and an
+			// aborted prior drain cannot emit a stale advisor_yielded.
+			const promptInputs: Array<string | AgentMessage[]> = [];
+			const idleNotifications: number[] = [];
+			const agent: AdvisorAgent = {
+				prompt: async input => {
+					promptInputs.push(input);
+					// Complete the review: an assistant message makes the runtime's
+					// turn-error check see a finished turn.
+					agent.state.messages.push({
+						role: "assistant",
+						content: [{ type: "text", text: "no issues" }],
+						stopReason: "stop",
+					} as AssistantMessage);
+				},
+				abort: () => {},
+				reset: () => {},
+				state: { messages: [] },
+			};
+			const messages: AgentMessage[] = [{ role: "user", content: "work", timestamp: 1 } as AgentMessage];
+			const host: AdvisorRuntimeHost = {
+				snapshotMessages: () => messages,
+				enqueueAdvice: () => {},
+				notifyIdle: () => idleNotifications.push(1),
+			};
+			const runtime = new AdvisorRuntime(agent, host);
+
+			expect(runtime.yielded).toBe(false); // nothing reviewed yet
+
+			runtime.onTurnEnd(messages);
+			await runtime.waitForCatchup(1000, 1);
+			expect(runtime.yielded).toBe(true); // review completed
+			expect(idleNotifications).toHaveLength(1);
+
+			runtime.reset("conversation-boundary");
+			expect(runtime.yielded).toBe(false); // re-primed: nothing reviewed in the new conversation
+			await Promise.resolve();
+			expect(idleNotifications).toHaveLength(1); // no stale idle notification after reset
+		});
+
 		it("waits for an in-flight review within the catch-up deadline", async () => {
 			const promptStarted = Promise.withResolvers<void>();
 			const releasePrompt = Promise.withResolvers<void>();

--- a/packages/coding-agent/test/status-line-model.test.ts
+++ b/packages/coding-agent/test/status-line-model.test.ts
@@ -18,7 +18,7 @@ function createModelContext(advisorActive: boolean): SegmentContext {
 			isAdvisorActive: () => advisorActive,
 			getAdvisorStatusOverview: () => ({
 				configured: advisorActive,
-				advisors: advisorActive ? [{ name: "default", status: "running" }] : [],
+				advisors: advisorActive ? [{ name: "default", status: "running", yielded: false }] : [],
 			}),
 		} as unknown as SegmentContext["session"],
 		width: 120,
@@ -71,19 +71,43 @@ describe("status line model segment advisor badge", () => {
 		ctx.session.getAdvisorStatusOverview = () => ({
 			configured: true,
 			advisors: [
-				{ name: "a", status: "running" },
-				{ name: "b", status: "quota_exhausted" },
+				{ name: "a", status: "running", yielded: false },
+				{ name: "b", status: "quota_exhausted", yielded: false },
 			],
 		});
 		expect(renderSegment("model", ctx).content).toContain(theme.fg("warning", ` ${theme.icon.advisor}`));
 		ctx.session.getAdvisorStatusOverview = () => ({
 			configured: true,
 			advisors: [
-				{ name: "a", status: "error" },
-				{ name: "b", status: "quota_exhausted" },
+				{ name: "a", status: "error", yielded: false },
+				{ name: "b", status: "quota_exhausted", yielded: false },
 			],
 		});
 		expect(renderSegment("model", ctx).content).toContain(theme.fg("error", ` ${theme.icon.advisor}`));
+	});
+	it("closes the eye once every advisor has yielded its review", () => {
+		const ctx = createModelContext(true);
+		ctx.session.getAdvisorStatusOverview = () => ({
+			configured: true,
+			advisors: [{ name: "default", status: "running", yielded: true }],
+		});
+		const rendered = renderSegment("model", ctx).content;
+		expect(rendered).toContain(theme.fg("success", ` ${theme.icon.advisorClosed}`));
+		expect(rendered).not.toContain(theme.icon.advisor);
+	});
+
+	it("keeps the eye open while any advisor may still comment", () => {
+		const ctx = createModelContext(true);
+		ctx.session.getAdvisorStatusOverview = () => ({
+			configured: true,
+			advisors: [
+				{ name: "a", status: "running", yielded: true },
+				{ name: "b", status: "running", yielded: false },
+			],
+		});
+		const rendered = renderSegment("model", ctx).content;
+		expect(rendered).toContain(theme.fg("success", ` ${theme.icon.advisor}`));
+		expect(rendered).not.toContain(theme.icon.advisorClosed);
 	});
 
 	it("omits the badge when the advisor is inactive", () => {

--- a/packages/coding-agent/test/status-line-model.test.ts
+++ b/packages/coding-agent/test/status-line-model.test.ts
@@ -93,7 +93,11 @@ describe("status line model segment advisor badge", () => {
 		});
 		const rendered = renderSegment("model", ctx).content;
 		expect(rendered).toContain(theme.fg("success", ` ${theme.icon.advisorClosed}`));
-		expect(rendered).not.toContain(theme.icon.advisor);
+		// ASCII mode resolves both icons to `(adv)`, so absence is only provable
+		// when the two tokens differ.
+		if (theme.icon.advisorClosed !== theme.icon.advisor) {
+			expect(rendered).not.toContain(theme.icon.advisor);
+		}
 	});
 
 	it("keeps the eye open while any advisor may still comment", () => {
@@ -107,7 +111,9 @@ describe("status line model segment advisor badge", () => {
 		});
 		const rendered = renderSegment("model", ctx).content;
 		expect(rendered).toContain(theme.fg("success", ` ${theme.icon.advisor}`));
-		expect(rendered).not.toContain(theme.icon.advisorClosed);
+		if (theme.icon.advisorClosed !== theme.icon.advisor) {
+			expect(rendered).not.toContain(theme.icon.advisorClosed);
+		}
 	});
 
 	it("omits the badge when the advisor is inactive", () => {

--- a/packages/coding-agent/test/theme-nerd-symbols.test.ts
+++ b/packages/coding-agent/test/theme-nerd-symbols.test.ts
@@ -57,6 +57,8 @@ it("resolves subscription and advisor icons in Nerd Font mode", async () => {
 	const theme = await getThemeByName(customThemeName);
 	expect(theme?.symbol("icon.subscription")).toBe("\u{f067a}");
 	expect(theme?.symbol("icon.advisor")).toBe("\uea70");
+	expect(theme?.symbol("icon.advisorClosed")).toBe("\ueae7");
 	expect(theme?.icon.subscription).toBe("\u{f067a}");
 	expect(theme?.icon.advisor).toBe("\uea70");
+	expect(theme?.icon.advisorClosed).toBe("\ueae7");
 });


### PR DESCRIPTION
The status-line advisor badge now switches from the open eye to the new icon.advisorClosed symbol once the primary has yielded and every advisor has finished draining its review backlog, so the closed eye means the advisor is not going to add any more comments until a new turn starts.

AdvisorRuntime gains a yielded state (no queued or in-flight review work, or halted/quota-paused) plus a notifyIdle host hook fired when a drain completes with an empty backlog; session-advisors turns that into a new advisor_yielded session event (gated on the primary not streaming), which repaints the status line. getAdvisorStatusOverview now reports per-advisor yielded, with roster entries lacking a live runtime (disabled/no-model) treated as yielded.

New icon.advisorClosed symbol-theme token: unicode see-no-evil monkey, Nerd Font nf-oct-eye_closed; ASCII keeps the (adv) text form.

