### PR TITLE
fix(read): batch known targets into one call

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Disabled hashline editing for Kimi, Mimo, DeepSeek Flash, and Stepfun models for improved stability.
 - Reworked transcript navigation with a fullscreen rewind selector opened by double-Escape, supporting rendered-item navigation, user-turn jumps, branching rewinds, and alternate session-tree branch selection.
 - Updated `/copy` to use the fullscreen transcript selector, allowing users to copy a turn or navigate into nested content such as code, quotes, commands, and tool output.
+- Read now batches known non-HTTP targets in one tool call instead of requesting them across model turns.
 
 ### Fixed
 
@@ -55,6 +56,7 @@
 - Prevented browser `app.path` from terminating existing same-executable applications when no reusable CDP endpoint is available.
 - Fixed top-level errors overwriting the active composer before terminal restoration.
 - Fixed Enter being ignored during the first turn when omp starts with an initial prompt.
+- Fixed semicolon-delimited Read calls failing when an internal URI is combined with filesystem targets.
 
 ## [18.0.11] - 2026-08-29
 

--- a/packages/coding-agent/src/internal-urls/mcp-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/mcp-protocol.ts
@@ -2,6 +2,13 @@ import { MCPManager } from "../mcp/manager";
 import type { MCPResourceReadResult } from "../mcp/types";
 import type { InternalResource, InternalUrl, ProtocolHandler } from "./types";
 
+export class McpResourceNotFoundError extends Error {
+	constructor(uri: string, availableResources: string) {
+		super(`No MCP server has resource "${uri}".\n\nAvailable resources:\n${availableResources}`);
+		this.name = "McpResourceNotFoundError";
+	}
+}
+
 function escapeRegex(text: string): string {
 	return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
@@ -130,9 +137,7 @@ export class McpProtocolHandler implements ProtocolHandler {
 			targetServer = resolveTargetServer(mcpManager, uri);
 		}
 		if (!targetServer) {
-			throw new Error(
-				`No MCP server has resource "${uri}".\n\nAvailable resources:\n${formatAvailableResources(mcpManager)}`,
-			);
+			throw new McpResourceNotFoundError(uri, formatAvailableResources(mcpManager));
 		}
 
 		let result: MCPResourceReadResult | undefined;

--- a/packages/coding-agent/src/internal-urls/mcp-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/mcp-protocol.ts
@@ -2,13 +2,6 @@ import { MCPManager } from "../mcp/manager";
 import type { MCPResourceReadResult } from "../mcp/types";
 import type { InternalResource, InternalUrl, ProtocolHandler } from "./types";
 
-export class McpResourceNotFoundError extends Error {
-	constructor(uri: string, availableResources: string) {
-		super(`No MCP server has resource "${uri}".\n\nAvailable resources:\n${availableResources}`);
-		this.name = "McpResourceNotFoundError";
-	}
-}
-
 function escapeRegex(text: string): string {
 	return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
@@ -47,15 +40,18 @@ function extractResourceUri(url: InternalUrl): string {
 	return uri;
 }
 
-function resolveTargetServer(mcpManager: MCPManager, uri: string): string | undefined {
-	const servers = mcpManager.getConnectedServers();
-	for (const name of servers) {
+function resolveConcreteTargetServer(mcpManager: MCPManager, uri: string): string | undefined {
+	for (const name of mcpManager.getConnectedServers()) {
 		const serverResources = mcpManager.getServerResources(name);
-		if (serverResources?.resources.some(r => r.uri === uri)) {
-			return name;
-		}
+		if (serverResources?.resources.some(resource => resource.uri === uri)) return name;
 	}
+	return undefined;
+}
 
+function resolveTargetServer(mcpManager: MCPManager, uri: string): string | undefined {
+	const concreteTarget = resolveConcreteTargetServer(mcpManager, uri);
+	if (concreteTarget) return concreteTarget;
+	const servers = mcpManager.getConnectedServers();
 	let bestTemplateMatch:
 		| {
 				serverName: string;
@@ -99,6 +95,26 @@ function resolveTargetServer(mcpManager: MCPManager, uri: string): string | unde
 	return bestTemplateMatch?.serverName;
 }
 
+/**
+ * Whether an advertised concrete MCP resource exactly owns this URL.
+ *
+ * Template matches are deliberately excluded: a broad template can also match
+ * a semicolon-joined batch, but only a concrete URI proves the semicolon is
+ * resource data rather than the Read batch delimiter.
+ */
+export async function hasExactMcpResource(url: InternalUrl): Promise<boolean> {
+	const mcpManager = MCPManager.instance();
+	if (!mcpManager) return false;
+
+	const uri = extractResourceUri(url);
+	let targetServer = resolveConcreteTargetServer(mcpManager, uri);
+	if (!targetServer) {
+		await Promise.allSettled(mcpManager.getConnectedServers().map(name => mcpManager.ensureServerResources(name)));
+		targetServer = resolveConcreteTargetServer(mcpManager, uri);
+	}
+	return targetServer !== undefined;
+}
+
 function formatAvailableResources(mcpManager: MCPManager): string {
 	const available = mcpManager
 		.getConnectedServers()
@@ -137,7 +153,9 @@ export class McpProtocolHandler implements ProtocolHandler {
 			targetServer = resolveTargetServer(mcpManager, uri);
 		}
 		if (!targetServer) {
-			throw new McpResourceNotFoundError(uri, formatAvailableResources(mcpManager));
+			throw new Error(
+				`No MCP server has resource "${uri}".\n\nAvailable resources:\n${formatAvailableResources(mcpManager)}`,
+			);
 		}
 
 		let result: MCPResourceReadResult | undefined;

--- a/packages/coding-agent/src/modes/components/read-tool-group.ts
+++ b/packages/coding-agent/src/modes/components/read-tool-group.ts
@@ -6,6 +6,7 @@ import { InternalUrlRouter, XD_URL_PREFIX } from "../../internal-urls";
 import { getLanguageFromPath, theme } from "../../modes/theme/theme";
 import {
 	parseLineRanges,
+	preservePathSelector,
 	selectorLineRanges,
 	splitPathAndSel,
 	splitSemicolonPathTargets,
@@ -176,9 +177,7 @@ function getDisplayReadTargets(details: ReadToolResultDetails | undefined): stri
 }
 
 function displayPathWithSuffixResolution(currentPath: string, suffixResolution: ReadToolSuffixResolution): string {
-	const currentSelector = splitPathAndSel(currentPath).sel;
-	if (!currentSelector || splitPathAndSel(suffixResolution.to).sel) return suffixResolution.to;
-	return `${suffixResolution.to}:${currentSelector}`;
+	return preservePathSelector(currentPath, suffixResolution.to);
 }
 
 function readSourceFsPath(details: ReadToolResultDetails | undefined): string | undefined {

--- a/packages/coding-agent/src/modes/components/read-tool-group.ts
+++ b/packages/coding-agent/src/modes/components/read-tool-group.ts
@@ -46,7 +46,7 @@ export function readArgsCollapseIntoGroup(args: unknown): boolean {
 	if (target === undefined) return false;
 	const router = InternalUrlRouter.instance();
 	const targets = splitSemicolonPathTargets(target) ?? [target];
-	return targets.every(candidate => candidate.startsWith(XD_URL_PREFIX) || !router.canHandle(candidate));
+	return targets.every(candidate => candidate.startsWith(XD_URL_PREFIX) || !router.canResolve(candidate));
 }
 
 /**

--- a/packages/coding-agent/src/modes/components/read-tool-group.ts
+++ b/packages/coding-agent/src/modes/components/read-tool-group.ts
@@ -4,7 +4,12 @@ import type { Component } from "@oh-my-pi/pi-tui";
 import { Container, Text } from "@oh-my-pi/pi-tui";
 import { InternalUrlRouter, XD_URL_PREFIX } from "../../internal-urls";
 import { getLanguageFromPath, theme } from "../../modes/theme/theme";
-import { parseLineRanges, selectorLineRanges, splitPathAndSel } from "../../tools/path-utils";
+import {
+	parseLineRanges,
+	selectorLineRanges,
+	splitPathAndSel,
+	splitSemicolonPathTargets,
+} from "../../tools/path-utils";
 import { PREVIEW_LIMITS, shortenPath } from "../../tools/render-utils";
 import { fileHyperlink, renderCodeCell, tryResolveInternalUrlSync } from "../../tui";
 import { canonicalizeMessage } from "../../utils/thinking-display";
@@ -39,7 +44,9 @@ export function readArgsHaveTarget(args: unknown): boolean {
 export function readArgsCollapseIntoGroup(args: unknown): boolean {
 	const target = readArgsTarget(args);
 	if (target === undefined) return false;
-	return target.startsWith(XD_URL_PREFIX) || !InternalUrlRouter.instance().canHandle(target);
+	const router = InternalUrlRouter.instance();
+	const targets = splitSemicolonPathTargets(target) ?? [target];
+	return targets.every(candidate => candidate.startsWith(XD_URL_PREFIX) || !router.canHandle(candidate));
 }
 
 /**

--- a/packages/coding-agent/src/prompts/tools/read.md
+++ b/packages/coding-agent/src/prompts/tools/read.md
@@ -22,9 +22,12 @@ Read files, directories, archives, SQLite, images, documents, internal resources
 - Archives (`.zip` family incl. `.jar`/`.apk`/`.whl`, `.tar` incl. `.tar.{gz,bz2,xz,zst}`, `.rar`, `.7z`, `.iso`, `.cab`, `.deb`/`.rpm`/`.cpio`/`.ar`/`.a`, `.lzh`/`.arj`, `.asar`; single-stream `.gz`/`.bz2`/`.xz`/`.zst`): `archive.ext:path/inside/archive` reads a member.
 - Documents → extracted text. Notebooks → editable cells. Images → {{#if INSPECT_IMAGE_ENABLED}}metadata; call `inspect_image`{{else}}decoded inline{{/if}}. SVGs read as text unless `:img` is specified. `:raw` bypasses converters.
 - URLs → reader-mode clean text/markdown; `:raw` → untouched HTML. Bare `host:port` needs trailing slash.
-- Internal URIs — all schemes take selectors. `artifact://<id>` recovers spilled output; page with `:N-M`/`:raw:N-M`.
-- `ssh://host/<path>` reads remote file/dir (UTF-8, ≤1 MiB); bare `ssh://` lists hosts; writable with `write` and searchable with `grep`.
-  Literal `:`, `?`, `#` → percent-encode (`%3A`/`%3F`/`%23`). Requires a verified POSIX shell on the remote host. For Windows or other unsupported hosts, use `bash` with a remote SSH command or mount with `sshfs`.
+- Internal URIs — all schemes take selectors.
+- `artifact://<id>` recovers spilled output; page with `:N-M`/`:raw:N-M`.
+- Literal `;`, `:`, `?`, `#` in internal URIs → percent-encode as `%3B`, `%3A`, `%3F`, `%23`.
+- `ssh://host/<path>` reads remote file/dir (UTF-8, ≤1 MiB); bare `ssh://` lists hosts.
+- SSH URLs are writable with `write` and searchable with `grep`; they require a verified POSIX shell.
+- On Windows or another unsupported host, use `bash` with a remote SSH command or mount with `sshfs`.
 
 <critical>
 Summary footer names elided ranges? Re-issue ONLY those ranges. NEVER guess `..`/`…` content.

--- a/packages/coding-agent/src/prompts/tools/read.md
+++ b/packages/coding-agent/src/prompts/tools/read.md
@@ -1,7 +1,10 @@
 Read files, directories, archives, SQLite, images, documents, internal resources, and web URLs via `path`.
 
 <instruction>
-- SHOULD parallelize independent reads.
+- Before each `read`, collect every bounded target already required for the current step.
+- MUST batch independent known non-HTTP(S) complete `path[:selector]` targets in one semicolon-joined call.
+- Issue independent HTTP(S) URLs as separate `read` calls; NEVER semicolon-join them.
+- NEVER read known non-HTTP(S) targets one per assistant turn.
 - SHOULD use `read` (not browser) for web content; browser only when `read` can't deliver.
 </instruction>
 

--- a/packages/coding-agent/src/tools/path-utils.ts
+++ b/packages/coding-agent/src/tools/path-utils.ts
@@ -862,10 +862,22 @@ function isDelimitedPathSeparator(ch: string, mode: DelimitedPathSplitMode): boo
 
 function hasTopLevelPathDelimiter(entry: string): boolean {
 	let braceDepth = 0;
+	let quote: "'" | '"' | null = null;
 	for (let i = 0; i < entry.length; i++) {
 		const ch = entry[i];
 		if (ch === "\\" && i + 1 < entry.length) {
 			i++;
+			continue;
+		}
+		if (quote) {
+			if (ch === quote) {
+				if (entry[i + 1] === quote) i++;
+				else quote = null;
+			}
+			continue;
+		}
+		if (ch === "'" || ch === '"') {
+			quote = ch;
 			continue;
 		}
 		if (ch === "{") {
@@ -887,10 +899,22 @@ function splitTopLevelDelimitedPath(entry: string, mode: DelimitedPathSplitMode)
 	const parts: string[] = [];
 	let braceDepth = 0;
 	let start = 0;
+	let quote: "'" | '"' | null = null;
 	for (let i = 0; i < entry.length; i++) {
 		const ch = entry[i];
 		if (ch === "\\" && i + 1 < entry.length) {
 			i++;
+			continue;
+		}
+		if (quote) {
+			if (ch === quote) {
+				if (entry[i + 1] === quote) i++;
+				else quote = null;
+			}
+			continue;
+		}
+		if (ch === "'" || ch === '"') {
+			quote = ch;
 			continue;
 		}
 		if (ch === "{") {

--- a/packages/coding-agent/src/tools/path-utils.ts
+++ b/packages/coding-agent/src/tools/path-utils.ts
@@ -862,22 +862,10 @@ function isDelimitedPathSeparator(ch: string, mode: DelimitedPathSplitMode): boo
 
 function hasTopLevelPathDelimiter(entry: string): boolean {
 	let braceDepth = 0;
-	let quote: "'" | '"' | null = null;
 	for (let i = 0; i < entry.length; i++) {
 		const ch = entry[i];
 		if (ch === "\\" && i + 1 < entry.length) {
 			i++;
-			continue;
-		}
-		if (quote) {
-			if (ch === quote) {
-				if (entry[i + 1] === quote) i++;
-				else quote = null;
-			}
-			continue;
-		}
-		if (ch === "'" || ch === '"') {
-			quote = ch;
 			continue;
 		}
 		if (ch === "{") {
@@ -899,22 +887,10 @@ function splitTopLevelDelimitedPath(entry: string, mode: DelimitedPathSplitMode)
 	const parts: string[] = [];
 	let braceDepth = 0;
 	let start = 0;
-	let quote: "'" | '"' | null = null;
 	for (let i = 0; i < entry.length; i++) {
 		const ch = entry[i];
 		if (ch === "\\" && i + 1 < entry.length) {
 			i++;
-			continue;
-		}
-		if (quote) {
-			if (ch === quote) {
-				if (entry[i + 1] === quote) i++;
-				else quote = null;
-			}
-			continue;
-		}
-		if (ch === "'" || ch === '"') {
-			quote = ch;
 			continue;
 		}
 		if (ch === "{") {

--- a/packages/coding-agent/src/tools/path-utils.ts
+++ b/packages/coding-agent/src/tools/path-utils.ts
@@ -860,6 +860,22 @@ function isDelimitedPathSeparator(ch: string, mode: DelimitedPathSplitMode): boo
 	return ch === "," || ch === ";" || TOP_LEVEL_WHITESPACE_RE.test(ch);
 }
 
+function unescapeSemicolonPathSeparator(part: string, mode: DelimitedPathSplitMode): string {
+	if (mode !== "semicolon" && mode !== "mixed") return part;
+	let unescaped = "";
+	for (let index = 0; index < part.length; index++) {
+		const char = part[index];
+		const next = part[index + 1];
+		if (char === "\\" && next === ";") {
+			unescaped += next;
+			index++;
+			continue;
+		}
+		unescaped += char;
+	}
+	return unescaped;
+}
+
 function hasTopLevelPathDelimiter(entry: string): boolean {
 	let braceDepth = 0;
 	for (let i = 0; i < entry.length; i++) {
@@ -902,10 +918,10 @@ function splitTopLevelDelimitedPath(entry: string, mode: DelimitedPathSplitMode)
 			continue;
 		}
 		if (braceDepth !== 0 || !isDelimitedPathSeparator(ch, mode)) continue;
-		parts.push(entry.slice(start, i));
+		parts.push(unescapeSemicolonPathSeparator(entry.slice(start, i), mode));
 		start = i + 1;
 	}
-	parts.push(entry.slice(start));
+	parts.push(unescapeSemicolonPathSeparator(entry.slice(start), mode));
 	return parts;
 }
 
@@ -926,6 +942,12 @@ function normalizeDelimitedPathParts(rawParts: string[]): string[] | null {
  */
 export function splitSemicolonPathTargets(entry: string): string[] | null {
 	return normalizeDelimitedPathParts(splitTopLevelDelimitedPath(normalizePathLikeInput(entry), "semicolon"));
+}
+
+export function preservePathSelector(originalPath: string, resolvedPath: string): string {
+	const originalSelector = splitPathAndSel(originalPath).sel;
+	if (!originalSelector || splitPathAndSel(resolvedPath).sel) return resolvedPath;
+	return `${resolvedPath}:${originalSelector}`;
 }
 
 async function delimitedPathPartResolves(entry: string, cwd: string, splitter: PathEntrySplitter): Promise<boolean> {

--- a/packages/coding-agent/src/tools/path-utils.ts
+++ b/packages/coding-agent/src/tools/path-utils.ts
@@ -909,6 +909,25 @@ function splitTopLevelDelimitedPath(entry: string, mode: DelimitedPathSplitMode)
 	return parts;
 }
 
+function normalizeDelimitedPathParts(rawParts: string[]): string[] | null {
+	if (rawParts.length < 2) return null;
+	const parts = rawParts.map(normalizePathLikeInput).filter(part => part.length > 0);
+	if (parts.length === 0) return null;
+	if (parts.length < 2 && rawParts.length === parts.length) return null;
+	return parts;
+}
+
+/**
+ * Syntactically split the documented semicolon batch grammar.
+ *
+ * Callers that execute paths must still apply literal-resource precedence.
+ * Display routing uses this conservative form so any internal target keeps the
+ * full result visible before asynchronous path resolution completes.
+ */
+export function splitSemicolonPathTargets(entry: string): string[] | null {
+	return normalizeDelimitedPathParts(splitTopLevelDelimitedPath(normalizePathLikeInput(entry), "semicolon"));
+}
+
 async function delimitedPathPartResolves(entry: string, cwd: string, splitter: PathEntrySplitter): Promise<boolean> {
 	if (isInternalUrlPath(entry)) return true;
 	const peeled = splitPathAndSel(entry).path;
@@ -942,12 +961,8 @@ async function tryDelimitedPathSplit(
 	mode: DelimitedPathSplitMode,
 	requirement: DelimitedResolveRequirement,
 ): Promise<string[] | null> {
-	const rawParts = splitTopLevelDelimitedPath(entry, mode);
-	if (rawParts.length < 2) return null;
-
-	const parts = rawParts.map(normalizePathLikeInput).filter(part => part.length > 0);
-	if (parts.length === 0) return null;
-	if (parts.length < 2 && rawParts.length === parts.length) return null;
+	const parts = normalizeDelimitedPathParts(splitTopLevelDelimitedPath(entry, mode));
+	if (!parts) return null;
 
 	if (requirement !== "none") {
 		const resolved = await Promise.all(parts.map(part => delimitedPathPartResolves(part, cwd, splitter)));

--- a/packages/coding-agent/src/tools/path-utils.ts
+++ b/packages/coding-agent/src/tools/path-utils.ts
@@ -961,23 +961,26 @@ async function tryDelimitedPathSplit(
  * Split one path-like entry whose multiple targets were flattened into one
  * string. Existing paths are kept intact, so real filenames containing spaces,
  * commas, or semicolons win over delimiter recovery.
+ *
+ * Internal URLs preserve raw semicolons unless their caller explicitly enables
+ * the documented semicolon-batch grammar. Literal internal-URL semicolons must
+ * remain percent-encoded while splitting occurs.
  */
 export async function splitDelimitedPathEntry(
 	entry: string,
 	cwd: string,
 	options: {
 		splitter?: PathEntrySplitter;
-		routedUrlPredicate?: (entry: string) => boolean;
+		splitInternalUrlSemicolons?: boolean;
 	} = {},
 ): Promise<string[] | null> {
 	const normalizedEntry = normalizePathLikeInput(entry);
 	if (!hasTopLevelPathDelimiter(normalizedEntry)) return null;
 	const splitter = options.splitter ?? parseSearchPath;
-	if (options.routedUrlPredicate?.(normalizedEntry)) {
-		const parts = await tryDelimitedPathSplit(normalizedEntry, cwd, splitter, "semicolon", "none");
-		return parts?.every(options.routedUrlPredicate) ? parts : null;
+	if (isInternalUrlPath(normalizedEntry)) {
+		if (!options.splitInternalUrlSemicolons) return null;
+		return tryDelimitedPathSplit(normalizedEntry, cwd, splitter, "semicolon", "none");
 	}
-	if (isInternalUrlPath(normalizedEntry)) return null;
 	// A real POSIX file may contain the delimiter and a selector-shaped tail
 	// (`a;b:1-2`, `a b:1-2`). Preserve the raw entry whenever the full literal
 	// resolves — or is only ambiguous — so downstream literal-preferring

--- a/packages/coding-agent/src/tools/read-archive.ts
+++ b/packages/coding-agent/src/tools/read-archive.ts
@@ -1,6 +1,7 @@
 import type { AgentToolResult } from "@oh-my-pi/pi-agent-core";
 import type { TextContent } from "@oh-my-pi/pi-ai";
 import {
+	ArchiveError,
 	type ArchiveReader,
 	formatArchiveEntryLines,
 	openArchive,
@@ -29,7 +30,7 @@ import { formatBytes } from "./render-utils";
 import { ToolError, throwIfAborted } from "./tool-errors";
 import { toolResult } from "./tool-result";
 
-interface ResolvedArchiveReadPath {
+export interface ResolvedArchiveReadPath {
 	absolutePath: string;
 	archiveSubPath: string;
 	suffixResolution?: { from: string; to: string };
@@ -79,6 +80,21 @@ export async function resolveArchiveReadPath(
 	}
 
 	return null;
+}
+export async function hasExactArchiveMember(
+	resolvedArchivePath: ResolvedArchiveReadPath,
+	signal?: AbortSignal,
+): Promise<boolean> {
+	if (resolvedArchivePath.archiveSubPath.length === 0) return false;
+	throwIfAborted(signal);
+	try {
+		const archive = await openArchive(resolvedArchivePath.absolutePath);
+		throwIfAborted(signal);
+		return archive.getNode(resolvedArchivePath.archiveSubPath) !== undefined;
+	} catch (error) {
+		if (error instanceof ArchiveError) return false;
+		throw error;
+	}
 }
 async function readArchiveDirectory(
 	archive: ArchiveReader,

--- a/packages/coding-agent/src/tools/read-sqlite.ts
+++ b/packages/coding-agent/src/tools/read-sqlite.ts
@@ -95,9 +95,9 @@ export async function hasExactSqliteSelector(
 	signal?: AbortSignal,
 ): Promise<boolean> {
 	throwIfAborted(signal);
-	const selector = parseSqliteSelector(resolvedSqlitePath.sqliteSubPath, resolvedSqlitePath.queryString);
 	let db: Database | null = null;
 	try {
+		const selector = parseSqliteSelector(resolvedSqlitePath.sqliteSubPath, resolvedSqlitePath.queryString);
 		db = await openSqliteReadConnection(resolvedSqlitePath.absolutePath);
 		throwIfAborted(signal);
 		switch (selector.kind) {

--- a/packages/coding-agent/src/tools/read-sqlite.ts
+++ b/packages/coding-agent/src/tools/read-sqlite.ts
@@ -90,6 +90,41 @@ export async function resolveSqliteReadPath(
 
 	return null;
 }
+export async function hasExactSqliteSelector(
+	resolvedSqlitePath: ResolvedSqliteReadPath,
+	signal?: AbortSignal,
+): Promise<boolean> {
+	throwIfAborted(signal);
+	const selector = parseSqliteSelector(resolvedSqlitePath.sqliteSubPath, resolvedSqlitePath.queryString);
+	let db: Database | null = null;
+	try {
+		db = await openSqliteReadConnection(resolvedSqlitePath.absolutePath);
+		throwIfAborted(signal);
+		switch (selector.kind) {
+			case "schema":
+			case "query":
+				getTableSchema(db, selector.table);
+				return true;
+			case "row": {
+				const lookup = resolveTableRowLookup(db, selector.table);
+				return (
+					(lookup.kind === "pk"
+						? getRowByKey(db, selector.table, lookup, selector.key)
+						: getRowByRowId(db, selector.table, selector.key)) !== null
+				);
+			}
+			case "list":
+			case "raw":
+				return false;
+		}
+	} catch (error) {
+		if (error instanceof ToolError) return false;
+		throw error;
+	} finally {
+		db?.close();
+	}
+	return false;
+}
 export async function readSqlite(
 	resolvedSqlitePath: ResolvedSqliteReadPath,
 	signal?: AbortSignal,

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -42,6 +42,7 @@ import {
 	truncateHeadBytes,
 	truncateLine,
 } from "../session/streaming-output";
+import { mapWithConcurrencyLimit } from "../task/parallel";
 import { buildLineEntriesWithBlockContext, lineEntriesToPlainText } from "../utils/block-context";
 import { isCpuProfilePath, renderCpuProfile } from "../utils/cpuprofile";
 import { resolveFileDisplayMode } from "../utils/file-display-mode";
@@ -82,6 +83,7 @@ import {
 	splitInternalUrlSel,
 	splitPathAndSel,
 	splitPathAndSelPreferringLiteral,
+	splitSemicolonPathTargets,
 } from "./path-utils";
 import { readArchive, resolveArchiveReadPath } from "./read-archive";
 import {
@@ -578,6 +580,11 @@ type ReadParams = ReadToolInput;
 const REPEAT_READ_HINT_THRESHOLD = 3;
 /** Per-session cap on tracked read keys; the map resets when exceeded. */
 const REPEAT_READ_TRACKER_CAP = 64;
+/** Bound fan-out so large model-generated batches cannot exhaust descriptors or remote connections. */
+const DELIMITED_READ_MAX_CONCURRENCY = 8;
+/** Preserve SQLite statement-like selectors so its parser rejects them instead of treating them as path batches. */
+const SQLITE_STATEMENT_AFTER_SEMICOLON_RE =
+	/;\s*(?:alter|attach|create|delete|detach|drop|insert|pragma|reindex|replace|select|update|vacuum)\b/i;
 
 const kRepeatReadTracker = Symbol("read.repeatTracker");
 
@@ -759,20 +766,27 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 			pendingText = pendingText.length > 0 ? `${pendingText}\n\n${text}` : text;
 		};
 
-		const outcomes = await Promise.all(
-			parts.map(async part => {
+		const { results } = await mapWithConcurrencyLimit(
+			parts,
+			DELIMITED_READ_MAX_CONCURRENCY,
+			async (part, _index, workerSignal) => {
 				try {
-					const result = await this.execute("read-delimited-part", { path: part }, signal);
+					const result = await this.execute("read-delimited-part", { path: part }, workerSignal);
 					return { ok: true as const, part, result };
 				} catch (error) {
-					if (error instanceof ToolAbortError || signal?.aborted) throw error;
+					if (error instanceof ToolAbortError || workerSignal.aborted) throw error;
 					const message = error instanceof Error ? error.message : String(error);
 					return { ok: false as const, part, errorNote: `Could not read ${part}: ${message}` };
 				}
-			}),
+			},
+			signal,
 		);
+		throwIfAborted(signal);
 
-		for (const outcome of outcomes) {
+		for (const outcome of results) {
+			if (!outcome) {
+				throw new ToolError("Batched Read execution stopped before every target completed.");
+			}
 			if (!outcome.ok) {
 				notes.push(outcome.errorNote);
 				displayReadTargets.push(outcome.part);
@@ -1128,18 +1142,34 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 		// One suffix-glob memo per read call — archive, SQLite, and plain-path
 		// resolution share misses instead of re-globbing the workspace.
 		const suffixCache: SuffixMatchCache = new Map();
-		const hasSemicolon = readPath.includes(";");
-		const preflightArchivePath = hasSemicolon
-			? await resolveArchiveReadPath(this.session, readPath, suffixCache, signal)
-			: null;
+		const semicolonTargets = splitSemicolonPathTargets(readPath);
+		const internalRouter = InternalUrlRouter.instance();
+		const firstSemicolonTarget = semicolonTargets?.[0];
+		const startsWithInternalTarget =
+			firstSemicolonTarget !== undefined && internalRouter.canResolve(firstSemicolonTarget);
 		const preflightSqlitePath =
-			hasSemicolon && !preflightArchivePath
+			semicolonTargets && !startsWithInternalTarget
 				? await resolveSqliteReadPath(this.session, readPath, suffixCache, signal)
 				: null;
+		const preserveSqliteInput =
+			preflightSqlitePath !== null &&
+			(preflightSqlitePath.queryString.includes(";") ||
+				SQLITE_STATEMENT_AFTER_SEMICOLON_RE.test(preflightSqlitePath.sqliteSubPath));
 
-		const internalRouter = InternalUrlRouter.instance();
-		if (hasSemicolon && !preflightArchivePath && !preflightSqlitePath) {
+		let preserveStandaloneHttpUrl = false;
+		if (semicolonTargets && parseReadUrlTarget(readPath)) {
+			const siblingStates = await Promise.all(
+				semicolonTargets.slice(1).map(async target => {
+					if (internalRouter.canResolve(target) || parseConflictUri(target)) return true;
+					return (await probeLiteralPathExists(splitPathAndSel(target).path, this.session.cwd)) === "exists";
+				}),
+			);
+			preserveStandaloneHttpUrl = siblingStates.every(state => !state);
+		}
+
+		if (semicolonTargets && !preserveSqliteInput && !preserveStandaloneHttpUrl) {
 			const routesThroughMcp =
+				startsWithInternalTarget &&
 				internalRouter.canResolve(readPath) &&
 				(readPath.toLowerCase().startsWith("mcp://") || !internalRouter.canHandle(readPath));
 			const exactMcpResource = routesThroughMcp && (await hasExactMcpResource(parseInternalUrl(readPath)));
@@ -1254,8 +1284,7 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 		let pdfImageRead: PdfImageReadTarget | null = null;
 
 		if (!rawPathIsLiteral) {
-			const archivePath =
-				preflightArchivePath ?? (await resolveArchiveReadPath(this.session, readPath, suffixCache, signal));
+			const archivePath = await resolveArchiveReadPath(this.session, readPath, suffixCache, signal);
 			if (archivePath) {
 				const archiveSubPath =
 					promotedSelector === undefined

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -585,7 +585,7 @@ const REPEAT_READ_TRACKER_CAP = 64;
 const DELIMITED_READ_MAX_CONCURRENCY = 8;
 /** Preserve SQLite statement-like selectors so its parser rejects them instead of treating them as path batches. */
 const SQLITE_STATEMENT_AFTER_SEMICOLON_RE =
-	/;\s*(?:alter|attach|create|delete|detach|drop|insert|pragma|reindex|replace|select|update|vacuum)\b/i;
+	/;\s*(?:alter|attach|create|delete|detach|drop|insert|pragma|reindex|replace|select|update|vacuum)(?=\s|$)/i;
 function hasQuotedSqliteSemicolon(queryString: string): boolean {
 	let quote: "'" | '"' | undefined;
 	for (let index = 0; index < queryString.length; index++) {
@@ -1164,7 +1164,9 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 		const semicolonTargets = splitSemicolonPathTargets(readPath);
 		const internalRouter = InternalUrlRouter.instance();
 		const firstSemicolonTarget = semicolonTargets?.[0];
-		const startsWithInternalTarget = firstSemicolonTarget !== undefined && isInternalUrlPath(firstSemicolonTarget);
+		const startsWithInternalTarget =
+			firstSemicolonTarget !== undefined &&
+			(isInternalUrlPath(firstSemicolonTarget) || internalRouter.canResolve(firstSemicolonTarget));
 		const preflightArchivePath =
 			semicolonTargets && !startsWithInternalTarget
 				? await resolveArchiveReadPath(this.session, readPath, suffixCache, signal)
@@ -1195,7 +1197,6 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 
 		if (semicolonTargets && !preserveArchiveInput && !preserveSqliteInput && !preserveStandaloneHttpUrl) {
 			const routesThroughMcp =
-				startsWithInternalTarget &&
 				internalRouter.canResolve(readPath) &&
 				(readPath.toLowerCase().startsWith("mcp://") || !internalRouter.canHandle(readPath));
 			const exactMcpResource = routesThroughMcp && (await hasExactMcpResource(parseInternalUrl(readPath)));

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -1160,7 +1160,8 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 		if (semicolonTargets && parseReadUrlTarget(readPath)) {
 			const siblingStates = await Promise.all(
 				semicolonTargets.slice(1).map(async target => {
-					if (internalRouter.canResolve(target) || parseConflictUri(target)) return true;
+					if (isReadableUrlPath(target) || internalRouter.canResolve(target) || parseConflictUri(target))
+						return true;
 					return (await probeLiteralPathExists(splitPathAndSel(target).path, this.session.cwd)) === "exists";
 				}),
 			);

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -28,7 +28,12 @@ import {
 } from "../edit/file-snapshot-store";
 import { normalizeToLF } from "../edit/normalize";
 import { isNotebookPath, readEditableNotebookText } from "../edit/notebook";
-import { InternalUrlRouter, resolveLocalUrlToFile, resolveLocalUrlToPath } from "../internal-urls";
+import {
+	InternalUrlRouter,
+	McpResourceNotFoundError,
+	resolveLocalUrlToFile,
+	resolveLocalUrlToPath,
+} from "../internal-urls";
 import { type ResolvedArtifactFile, resolveArtifactFile } from "../internal-urls/artifact-protocol";
 import { parseInternalUrl } from "../internal-urls/parse";
 import type { InternalUrl } from "../internal-urls/types";
@@ -1165,6 +1170,20 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 
 		// Handle native OMP URLs and custom-scheme resources advertised by MCP servers.
 		const internalRouter = InternalUrlRouter.instance();
+		// MCP resource URIs are opaque and may contain literal semicolons.
+		// Preserve an advertised exact resource; only a genuine MCP miss may fall
+		// through to the documented multi-target delimiter grammar.
+		if (
+			readPath.includes(";") &&
+			internalRouter.canResolve(readPath) &&
+			(readPath.toLowerCase().startsWith("mcp://") || !internalRouter.canHandle(readPath))
+		) {
+			try {
+				return await this.#handleInternalUrl(readPath, parseSel(undefined), signal);
+			} catch (error) {
+				if (!(error instanceof McpResourceNotFoundError)) throw error;
+			}
+		}
 		const delimitedInternalResult = internalRouter.canResolve(readPath)
 			? await this.#tryReadDelimitedPaths(readPath, signal, {
 					splitInternalUrlSemicolons: true,

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -759,25 +759,34 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 			pendingText = pendingText.length > 0 ? `${pendingText}\n\n${text}` : text;
 		};
 
-		for (const part of parts) {
-			try {
-				const result = await this.execute("read-delimited-part", { path: part }, signal);
-				displayReadTargets.push(result.details?.suffixResolution?.to ?? part);
-				for (const block of result.content) {
-					if (block.type === "text") {
-						appendText(block.text);
-						continue;
-					}
-					flushText();
-					content.push(block);
+		const outcomes = await Promise.all(
+			parts.map(async part => {
+				try {
+					const result = await this.execute("read-delimited-part", { path: part }, signal);
+					return { ok: true as const, part, result };
+				} catch (error) {
+					if (error instanceof ToolAbortError || signal?.aborted) throw error;
+					const message = error instanceof Error ? error.message : String(error);
+					return { ok: false as const, part, errorNote: `Could not read ${part}: ${message}` };
 				}
-			} catch (error) {
-				if (error instanceof ToolAbortError || signal?.aborted) throw error;
-				const message = error instanceof Error ? error.message : String(error);
-				const errorNote = `Could not read ${part}: ${message}`;
-				notes.push(errorNote);
-				displayReadTargets.push(part);
-				appendText(`[${errorNote}]`);
+			}),
+		);
+
+		for (const outcome of outcomes) {
+			if (!outcome.ok) {
+				notes.push(outcome.errorNote);
+				displayReadTargets.push(outcome.part);
+				appendText(`[${outcome.errorNote}]`);
+				continue;
+			}
+			displayReadTargets.push(outcome.result.details?.suffixResolution?.to ?? outcome.part);
+			for (const block of outcome.result.content) {
+				if (block.type === "text") {
+					appendText(block.text);
+					continue;
+				}
+				flushText();
+				content.push(block);
 			}
 		}
 		flushText();

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -1162,20 +1162,23 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 		// resolution share misses instead of re-globbing the workspace.
 		const suffixCache: SuffixMatchCache = new Map();
 		const semicolonTargets = splitSemicolonPathTargets(readPath);
+		// A parsed HTTP(S) target owns the complete scalar because raw semicolons are valid URL data.
+		// Mixed URL inputs use separate sibling Read calls rather than the path batch grammar.
+		const parsedUrlTarget = parseReadUrlTarget(readPath);
 		const internalRouter = InternalUrlRouter.instance();
 		const firstSemicolonTarget = semicolonTargets?.[0];
 		const startsWithInternalTarget =
 			firstSemicolonTarget !== undefined &&
 			(isInternalUrlPath(firstSemicolonTarget) || internalRouter.canResolve(firstSemicolonTarget));
 		const preflightArchivePath =
-			semicolonTargets && !startsWithInternalTarget
+			semicolonTargets && !startsWithInternalTarget && !parsedUrlTarget
 				? await resolveArchiveReadPath(this.session, readPath, suffixCache, signal)
 				: null;
 		const preserveArchiveInput =
 			preflightArchivePath?.archiveSubPath.includes(";") &&
 			(await hasExactArchiveMember(preflightArchivePath, signal));
 		const preflightSqlitePath =
-			semicolonTargets && !startsWithInternalTarget
+			semicolonTargets && !startsWithInternalTarget && !parsedUrlTarget
 				? await resolveSqliteReadPath(this.session, readPath, suffixCache, signal)
 				: null;
 		const preserveSqliteInput =
@@ -1186,24 +1189,7 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 				(preflightSqlitePath.sqliteSubPath.includes(";") &&
 					(await hasExactSqliteSelector(preflightSqlitePath, signal))));
 
-		let preserveStandaloneHttpUrl = false;
-		if (semicolonTargets && parseReadUrlTarget(readPath)) {
-			const siblingStates = await Promise.all(
-				semicolonTargets.slice(1).map(async target => {
-					if (isReadableUrlPath(target) || internalRouter.canResolve(target) || parseConflictUri(target))
-						return true;
-					if ((await probeLiteralPathExists(splitPathAndSel(target).path, this.session.cwd)) === "exists")
-						return true;
-					return (
-						(await resolveArchiveReadPath(this.session, target, suffixCache, signal)) !== null ||
-						(await resolveSqliteReadPath(this.session, target, suffixCache, signal)) !== null
-					);
-				}),
-			);
-			preserveStandaloneHttpUrl = siblingStates.every(state => !state);
-		}
-
-		if (semicolonTargets && !preserveArchiveInput && !preserveSqliteInput && !preserveStandaloneHttpUrl) {
+		if (semicolonTargets && !parsedUrlTarget && !preserveArchiveInput && !preserveSqliteInput) {
 			const routesThroughMcp =
 				internalRouter.canResolve(readPath) &&
 				(readPath.toLowerCase().startsWith("mcp://") || !internalRouter.canHandle(readPath));
@@ -1227,7 +1213,6 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 		}
 		const displayMode = resolveFileDisplayMode(this.session);
 
-		const parsedUrlTarget = parseReadUrlTarget(readPath);
 		if (parsedUrlTarget) {
 			if (!this.session.settings.get("fetch.enabled")) {
 				throw new ToolError("URL reads are disabled by settings.");

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -74,6 +74,7 @@ import { type OutputMeta, resolveOutputMaxColumns } from "./output-meta";
 import {
 	expandPath,
 	formatPathRelativeToCwd,
+	isInternalUrlPath,
 	isReadableUrlPath,
 	type LineRange,
 	pathTargetsSsh,
@@ -85,7 +86,7 @@ import {
 	splitPathAndSelPreferringLiteral,
 	splitSemicolonPathTargets,
 } from "./path-utils";
-import { readArchive, resolveArchiveReadPath } from "./read-archive";
+import { hasExactArchiveMember, readArchive, resolveArchiveReadPath } from "./read-archive";
 import {
 	BRACKET_CONTEXT_ELLIPSIS,
 	buildInMemoryMultiRangeResult,
@@ -585,6 +586,24 @@ const DELIMITED_READ_MAX_CONCURRENCY = 8;
 /** Preserve SQLite statement-like selectors so its parser rejects them instead of treating them as path batches. */
 const SQLITE_STATEMENT_AFTER_SEMICOLON_RE =
 	/;\s*(?:alter|attach|create|delete|detach|drop|insert|pragma|reindex|replace|select|update|vacuum)\b/i;
+function hasQuotedSqliteSemicolon(queryString: string): boolean {
+	let quote: "'" | '"' | undefined;
+	for (let index = 0; index < queryString.length; index++) {
+		const char = queryString[index];
+		if (quote === undefined) {
+			if (char === "'" || char === '"') quote = char;
+			continue;
+		}
+		if (char === ";") return true;
+		if (char !== quote) continue;
+		if (queryString[index + 1] === quote) {
+			index++;
+			continue;
+		}
+		quote = undefined;
+	}
+	return false;
+}
 
 const kRepeatReadTracker = Symbol("read.repeatTracker");
 
@@ -1145,15 +1164,21 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 		const semicolonTargets = splitSemicolonPathTargets(readPath);
 		const internalRouter = InternalUrlRouter.instance();
 		const firstSemicolonTarget = semicolonTargets?.[0];
-		const startsWithInternalTarget =
-			firstSemicolonTarget !== undefined && internalRouter.canResolve(firstSemicolonTarget);
+		const startsWithInternalTarget = firstSemicolonTarget !== undefined && isInternalUrlPath(firstSemicolonTarget);
+		const preflightArchivePath =
+			semicolonTargets && !startsWithInternalTarget
+				? await resolveArchiveReadPath(this.session, readPath, suffixCache, signal)
+				: null;
+		const preserveArchiveInput =
+			preflightArchivePath?.archiveSubPath.includes(";") &&
+			(await hasExactArchiveMember(preflightArchivePath, signal));
 		const preflightSqlitePath =
 			semicolonTargets && !startsWithInternalTarget
 				? await resolveSqliteReadPath(this.session, readPath, suffixCache, signal)
 				: null;
 		const preserveSqliteInput =
 			preflightSqlitePath !== null &&
-			(preflightSqlitePath.queryString.includes(";") ||
+			(hasQuotedSqliteSemicolon(preflightSqlitePath.queryString) ||
 				SQLITE_STATEMENT_AFTER_SEMICOLON_RE.test(preflightSqlitePath.sqliteSubPath));
 
 		let preserveStandaloneHttpUrl = false;
@@ -1168,7 +1193,7 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 			preserveStandaloneHttpUrl = siblingStates.every(state => !state);
 		}
 
-		if (semicolonTargets && !preserveSqliteInput && !preserveStandaloneHttpUrl) {
+		if (semicolonTargets && !preserveArchiveInput && !preserveSqliteInput && !preserveStandaloneHttpUrl) {
 			const routesThroughMcp =
 				startsWithInternalTarget &&
 				internalRouter.canResolve(readPath) &&
@@ -1285,7 +1310,8 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 		let pdfImageRead: PdfImageReadTarget | null = null;
 
 		if (!rawPathIsLiteral) {
-			const archivePath = await resolveArchiveReadPath(this.session, readPath, suffixCache, signal);
+			const archivePath =
+				preflightArchivePath ?? (await resolveArchiveReadPath(this.session, readPath, suffixCache, signal));
 			if (archivePath) {
 				const archiveSubPath =
 					promotedSelector === undefined

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -73,6 +73,7 @@ import { type OutputMeta, resolveOutputMaxColumns } from "./output-meta";
 import {
 	expandPath,
 	formatPathRelativeToCwd,
+	isReadableUrlPath,
 	type LineRange,
 	pathTargetsSsh,
 	probeLiteralPathExists,
@@ -529,12 +530,14 @@ const MAX_IMAGE_SIZE = MAX_IMAGE_INPUT_BYTES;
 
 const readSchema = type({
 	path: type("string").describe(
-		"Local path, internal URI (e.g. memory://, skill://), or URL. Inline selectors are supported.",
+		"Local path, internal URI (e.g. memory://, skill://), or URL. Join independent non-HTTP(S) `path[:selector]` targets with `;`; use separate calls for HTTP(S) URLs.",
 	),
 });
 
 const readSchemaWithoutMemory = type({
-	path: type("string").describe("Local path, internal URI (e.g. skill://), or URL. Inline selectors are supported."),
+	path: type("string").describe(
+		"Local path, internal URI (e.g. skill://), or URL. Join independent non-HTTP(S) `path[:selector]` targets with `;`; use separate calls for HTTP(S) URLs.",
+	),
 });
 
 export type ReadToolInput = typeof readSchema.infer;
@@ -725,10 +728,22 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 	async #tryReadDelimitedPaths(
 		readPath: string,
 		signal?: AbortSignal,
-		routedUrlPredicate?: (entry: string) => boolean,
+		options: {
+			splitInternalUrlSemicolons?: boolean;
+		} = {},
 	): Promise<AgentToolResult<ReadToolDetails> | null> {
-		const parts = await splitDelimitedPathEntry(readPath, this.session.cwd, { routedUrlPredicate });
+		const parts = await splitDelimitedPathEntry(readPath, this.session.cwd, {
+			splitInternalUrlSemicolons: options.splitInternalUrlSemicolons,
+		});
 		if (!parts) return null;
+		// Raw semicolons are valid URL data, so treating them as batch delimiters is ambiguous.
+		// HTTP(S) targets therefore use sibling calls instead of the path batch grammar.
+		const httpTarget = parts.find(isReadableUrlPath);
+		if (httpTarget) {
+			throw new ToolError(
+				`HTTP(S) URL '${httpTarget}' cannot be included in a multi-target Read call. Issue separate sibling read calls for HTTP(S) URLs.`,
+			);
+		}
 
 		const notice = `Note: interpreted as ${parts.length} paths: ${parts.join(", ")}`;
 		const notes = [notice];
@@ -1151,7 +1166,9 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 		// Handle native OMP URLs and custom-scheme resources advertised by MCP servers.
 		const internalRouter = InternalUrlRouter.instance();
 		const delimitedInternalResult = internalRouter.canResolve(readPath)
-			? await this.#tryReadDelimitedPaths(readPath, signal, entry => internalRouter.canResolve(entry))
+			? await this.#tryReadDelimitedPaths(readPath, signal, {
+					splitInternalUrlSemicolons: true,
+				})
 			: null;
 		if (delimitedInternalResult) return delimitedInternalResult;
 

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -1189,7 +1189,12 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 				semicolonTargets.slice(1).map(async target => {
 					if (isReadableUrlPath(target) || internalRouter.canResolve(target) || parseConflictUri(target))
 						return true;
-					return (await probeLiteralPathExists(splitPathAndSel(target).path, this.session.cwd)) === "exists";
+					if ((await probeLiteralPathExists(splitPathAndSel(target).path, this.session.cwd)) === "exists")
+						return true;
+					return (
+						(await resolveArchiveReadPath(this.session, target, suffixCache, signal)) !== null ||
+						(await resolveSqliteReadPath(this.session, target, suffixCache, signal)) !== null
+					);
 				}),
 			);
 			preserveStandaloneHttpUrl = siblingStates.every(state => !state);

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -78,6 +78,7 @@ import {
 	isReadableUrlPath,
 	type LineRange,
 	pathTargetsSsh,
+	preservePathSelector,
 	probeLiteralPathExists,
 	resolveReadPath,
 	splitDelimitedPathEntry,
@@ -812,7 +813,8 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 				appendText(`[${outcome.errorNote}]`);
 				continue;
 			}
-			displayReadTargets.push(outcome.result.details?.suffixResolution?.to ?? outcome.part);
+			const resolvedTarget = outcome.result.details?.suffixResolution?.to;
+			displayReadTargets.push(resolvedTarget ? preservePathSelector(outcome.part, resolvedTarget) : outcome.part);
 			for (const block of outcome.result.content) {
 				if (block.type === "text") {
 					appendText(block.text);

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -1180,7 +1180,8 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 				: null;
 		const preserveSqliteInput =
 			preflightSqlitePath !== null &&
-			(hasQuotedSqliteSemicolon(preflightSqlitePath.queryString) ||
+			(new URLSearchParams(preflightSqlitePath.queryString).has("q") ||
+				hasQuotedSqliteSemicolon(preflightSqlitePath.queryString) ||
 				SQLITE_STATEMENT_AFTER_SEMICOLON_RE.test(preflightSqlitePath.sqliteSubPath) ||
 				(preflightSqlitePath.sqliteSubPath.includes(";") &&
 					(await hasExactSqliteSelector(preflightSqlitePath, signal))));

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -117,7 +117,7 @@ import {
 } from "./read-path-resolution";
 import { type PdfImageReadTarget, renderPdfPageScreenshot, splitPdfImageReadPath } from "./read-pdf";
 import { isMultiRange, isRawSelector, type ParsedSelector, parseSel, selToOffsetLimit } from "./read-selector";
-import { readSqlite, resolveSqliteReadPath } from "./read-sqlite";
+import { hasExactSqliteSelector, readSqlite, resolveSqliteReadPath } from "./read-sqlite";
 import { isProseSummaryPath, renderSummary, routeReadThroughBridge, trySummarize } from "./read-summary";
 import { formatBytes, shortenPath } from "./render-utils";
 import { REPORT_ISSUE_DEVICE_NAME, reportIssueDeviceUsage } from "./report-tool-issue";
@@ -1181,7 +1181,9 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 		const preserveSqliteInput =
 			preflightSqlitePath !== null &&
 			(hasQuotedSqliteSemicolon(preflightSqlitePath.queryString) ||
-				SQLITE_STATEMENT_AFTER_SEMICOLON_RE.test(preflightSqlitePath.sqliteSubPath));
+				SQLITE_STATEMENT_AFTER_SEMICOLON_RE.test(preflightSqlitePath.sqliteSubPath) ||
+				(preflightSqlitePath.sqliteSubPath.includes(";") &&
+					(await hasExactSqliteSelector(preflightSqlitePath, signal))));
 
 		let preserveStandaloneHttpUrl = false;
 		if (semicolonTargets && parseReadUrlTarget(readPath)) {

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -28,12 +28,7 @@ import {
 } from "../edit/file-snapshot-store";
 import { normalizeToLF } from "../edit/normalize";
 import { isNotebookPath, readEditableNotebookText } from "../edit/notebook";
-import {
-	InternalUrlRouter,
-	McpResourceNotFoundError,
-	resolveLocalUrlToFile,
-	resolveLocalUrlToPath,
-} from "../internal-urls";
+import { hasExactMcpResource, InternalUrlRouter, resolveLocalUrlToFile, resolveLocalUrlToPath } from "../internal-urls";
 import { type ResolvedArtifactFile, resolveArtifactFile } from "../internal-urls/artifact-protocol";
 import { parseInternalUrl } from "../internal-urls/parse";
 import type { InternalUrl } from "../internal-urls/types";
@@ -1121,6 +1116,20 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 			readPath = attachment.sourcePath;
 		}
 
+		const internalRouter = InternalUrlRouter.instance();
+		if (readPath.includes(";")) {
+			const routesThroughMcp =
+				internalRouter.canResolve(readPath) &&
+				(readPath.toLowerCase().startsWith("mcp://") || !internalRouter.canHandle(readPath));
+			const exactMcpResource = routesThroughMcp && (await hasExactMcpResource(parseInternalUrl(readPath)));
+			if (!exactMcpResource) {
+				const delimitedResult = await this.#tryReadDelimitedPaths(readPath, signal, {
+					splitInternalUrlSemicolons: true,
+				});
+				if (delimitedResult) return delimitedResult;
+			}
+		}
+
 		const conflictUri = parseConflictUri(readPath);
 		if (conflictUri) {
 			if (conflictUri.id === "*") {
@@ -1169,27 +1178,6 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 		}
 
 		// Handle native OMP URLs and custom-scheme resources advertised by MCP servers.
-		const internalRouter = InternalUrlRouter.instance();
-		// MCP resource URIs are opaque and may contain literal semicolons.
-		// Preserve an advertised exact resource; only a genuine MCP miss may fall
-		// through to the documented multi-target delimiter grammar.
-		if (
-			readPath.includes(";") &&
-			internalRouter.canResolve(readPath) &&
-			(readPath.toLowerCase().startsWith("mcp://") || !internalRouter.canHandle(readPath))
-		) {
-			try {
-				return await this.#handleInternalUrl(readPath, parseSel(undefined), signal);
-			} catch (error) {
-				if (!(error instanceof McpResourceNotFoundError)) throw error;
-			}
-		}
-		const delimitedInternalResult = internalRouter.canResolve(readPath)
-			? await this.#tryReadDelimitedPaths(readPath, signal, {
-					splitInternalUrlSemicolons: true,
-				})
-			: null;
-		if (delimitedInternalResult) return delimitedInternalResult;
 
 		// Peel malformed selectors through the internal-URL-aware parser before routing.
 		let promotedSelector: string | undefined;

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -1116,8 +1116,20 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 			readPath = attachment.sourcePath;
 		}
 
+		// One suffix-glob memo per read call — archive, SQLite, and plain-path
+		// resolution share misses instead of re-globbing the workspace.
+		const suffixCache: SuffixMatchCache = new Map();
+		const hasSemicolon = readPath.includes(";");
+		const preflightArchivePath = hasSemicolon
+			? await resolveArchiveReadPath(this.session, readPath, suffixCache, signal)
+			: null;
+		const preflightSqlitePath =
+			hasSemicolon && !preflightArchivePath
+				? await resolveSqliteReadPath(this.session, readPath, suffixCache, signal)
+				: null;
+
 		const internalRouter = InternalUrlRouter.instance();
-		if (readPath.includes(";")) {
+		if (hasSemicolon && !preflightArchivePath && !preflightSqlitePath) {
 			const routesThroughMcp =
 				internalRouter.canResolve(readPath) &&
 				(readPath.toLowerCase().startsWith("mcp://") || !internalRouter.canHandle(readPath));
@@ -1217,10 +1229,6 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 			}
 		}
 
-		// One suffix-glob memo per read call — archive, sqlite, and plain-path
-		// resolution share misses instead of re-globbing the workspace.
-		const suffixCache: SuffixMatchCache = new Map();
-
 		// Prefer a literal filesystem match over selector interpretation so real
 		// POSIX filenames containing selector-looking suffixes win over structured
 		// archive / sqlite / unsupported PDF-image dispatch. A selector promoted from local://
@@ -1237,7 +1245,8 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 		let pdfImageRead: PdfImageReadTarget | null = null;
 
 		if (!rawPathIsLiteral) {
-			const archivePath = await resolveArchiveReadPath(this.session, readPath, suffixCache, signal);
+			const archivePath =
+				preflightArchivePath ?? (await resolveArchiveReadPath(this.session, readPath, suffixCache, signal));
 			if (archivePath) {
 				const archiveSubPath =
 					promotedSelector === undefined
@@ -1253,7 +1262,8 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 				);
 			}
 
-			const sqlitePath = await resolveSqliteReadPath(this.session, readPath, suffixCache, signal);
+			const sqlitePath =
+				preflightSqlitePath ?? (await resolveSqliteReadPath(this.session, readPath, suffixCache, signal));
 			if (sqlitePath) {
 				return readSqlite(sqlitePath, signal);
 			}

--- a/packages/coding-agent/test/internal-urls/mcp-protocol.test.ts
+++ b/packages/coding-agent/test/internal-urls/mcp-protocol.test.ts
@@ -131,6 +131,33 @@ describe("McpProtocolHandler", () => {
 		expect(output.text).not.toContain("interpreted as");
 	});
 
+	it("falls back to semicolon batching when no exact MCP resource matches", async () => {
+		const resources = new Map<string, { resources: MCPResource[]; templates: MCPResourceTemplate[] }>();
+		resources.set("catalog", {
+			resources: [
+				{ uri: "catalog://first", name: "first" },
+				{ uri: "catalog://second", name: "second" },
+			],
+			templates: [],
+		});
+		const manager = createMockManager({
+			servers: ["catalog"],
+			resources,
+			readResult: { contents: [{ uri: "catalog://item", text: "catalog item" }] },
+		});
+		MCPManager.setInstance(manager);
+
+		const result = await new ReadTool(createToolSession()).execute("read-semicolon-batch", {
+			path: "mcp://catalog://first;mcp://catalog://second",
+		});
+		const output = result.content.find(block => block.type === "text");
+
+		expect(output?.type).toBe("text");
+		if (output?.type !== "text") throw new Error("Expected text output");
+		expect(output.text).toContain("Note: interpreted as 2 paths: mcp://catalog://first, mcp://catalog://second");
+		expect(output.text.match(/catalog item/g)).toHaveLength(2);
+	});
+
 	it("lets read consume a native URI advertised by an MCP server", async () => {
 		const resources = new Map<string, { resources: MCPResource[]; templates: MCPResourceTemplate[] }>();
 		resources.set("ags", {

--- a/packages/coding-agent/test/internal-urls/mcp-protocol.test.ts
+++ b/packages/coding-agent/test/internal-urls/mcp-protocol.test.ts
@@ -138,7 +138,7 @@ describe("McpProtocolHandler", () => {
 				{ uri: "catalog://first", name: "first" },
 				{ uri: "catalog://second", name: "second" },
 			],
-			templates: [],
+			templates: [{ uriTemplate: "catalog://{id}", name: "catalog-item" }],
 		});
 		const manager = createMockManager({
 			servers: ["catalog"],

--- a/packages/coding-agent/test/internal-urls/mcp-protocol.test.ts
+++ b/packages/coding-agent/test/internal-urls/mcp-protocol.test.ts
@@ -158,29 +158,29 @@ describe("McpProtocolHandler", () => {
 		expect(output.text.match(/catalog item/g)).toHaveLength(2);
 	});
 
-	it("lets read consume a native URI advertised by an MCP server", async () => {
+	it("lets read consume an exact native MCP URI containing a semicolon", async () => {
+		const uri = "ags://capabilities/current;host";
 		const resources = new Map<string, { resources: MCPResource[]; templates: MCPResourceTemplate[] }>();
 		resources.set("ags", {
-			resources: [{ uri: "ags://capabilities/current-host", name: "current-host" }],
+			resources: [{ uri, name: "current-host" }],
 			templates: [],
 		});
 		const manager = createMockManager({
 			servers: ["ags"],
 			resources,
 			readResult: {
-				contents: [{ uri: "ags://capabilities/current-host", text: "host capabilities" }],
+				contents: [{ uri, text: "host capabilities" }],
 			},
 		});
 		MCPManager.setInstance(manager);
 
-		const result = await new ReadTool(createToolSession()).execute("read-ags-resource", {
-			path: "ags://capabilities/current-host",
-		});
+		const result = await new ReadTool(createToolSession()).execute("read-ags-resource", { path: uri });
 		const output = result.content.find(block => block.type === "text");
 
 		expect(output?.type).toBe("text");
 		if (output?.type !== "text") throw new Error("Expected text output");
 		expect(output.text).toContain("host capabilities");
+		expect(output.text).not.toContain("interpreted as");
 	});
 
 	it("waits for the MCP resource catalog before rejecting a native URI", async () => {

--- a/packages/coding-agent/test/read-tool-group.test.ts
+++ b/packages/coding-agent/test/read-tool-group.test.ts
@@ -376,6 +376,11 @@ describe("readArgsCollapseIntoGroup", () => {
 		expect(readArgsCollapseIntoGroup({ file_path: target })).toBe(false);
 	});
 
+	it("keeps mixed filesystem and internal batches as full tool executions", () => {
+		expect(readArgsCollapseIntoGroup({ path: "./local.txt;skill://my-skill" })).toBe(false);
+		expect(readArgsCollapseIntoGroup({ path: "skill://my-skill;./local.txt" })).toBe(false);
+	});
+
 	it.each([
 		[path.resolve("/tmp/example.ts")],
 		["./relative/path.md"],

--- a/packages/coding-agent/test/read-tool-group.test.ts
+++ b/packages/coding-agent/test/read-tool-group.test.ts
@@ -381,6 +381,10 @@ describe("readArgsCollapseIntoGroup", () => {
 		expect(readArgsCollapseIntoGroup({ path: "skill://my-skill;./local.txt" })).toBe(false);
 	});
 
+	it("keeps custom MCP scheme batches as full tool executions", () => {
+		expect(readArgsCollapseIntoGroup({ path: "ags://capabilities/current-host;./local.txt" })).toBe(false);
+	});
+
 	it.each([
 		[path.resolve("/tmp/example.ts")],
 		["./relative/path.md"],

--- a/packages/coding-agent/test/skill-protocol-customdirs.test.ts
+++ b/packages/coding-agent/test/skill-protocol-customdirs.test.ts
@@ -102,6 +102,7 @@ describe("skill:// resolution honors skills.customDirectories (#7190)", () => {
 		await fs.mkdir(skillDir, { recursive: true });
 		await Bun.write(path.join(skillDir, "SKILL.md"), makeSkillMd("mixed-skill", tempDir));
 		await Bun.write(path.join(skillDir, "reference;guide.md"), "encoded semicolon resource\n");
+		await Bun.write(path.join(skillDir, "reference.zip"), "internal zip-shaped resource\n");
 
 		const localFile = path.join(tempDir, "local.txt");
 		await Bun.write(localFile, "local file content\n");
@@ -143,9 +144,29 @@ describe("skill:// resolution honors skills.customDirectories (#7190)", () => {
 
 		expect(encodedText).toContain("encoded semicolon resource");
 		expect(encodedText).not.toContain("Note: interpreted as");
+
+		const archiveShapedInternalResult = await readTool.execute("read-archive-shaped-internal-first", {
+			path: `skill://mixed-skill/reference.zip:raw;${localFile}`,
+		});
+		const archiveShapedInternalText = archiveShapedInternalResult.content
+			.flatMap(block => (block.type === "text" ? [block.text] : []))
+			.join("\n");
+		expect(archiveShapedInternalText).toContain("internal zip-shaped resource");
+		expect(archiveShapedInternalText).toContain("local file content");
+
+		const invalidArchivePath = path.join(tempDir, "docs.zip");
+		await Bun.write(invalidArchivePath, "not an archive");
+		const archiveFirstResult = await readTool.execute("read-archive-first-batch", {
+			path: `${invalidArchivePath}:README.md;${localFile}`,
+		});
+		const archiveFirstText = archiveFirstResult.content
+			.flatMap(block => (block.type === "text" ? [block.text] : []))
+			.join("\n");
+		expect(archiveFirstText).toContain("Note: interpreted as 2 paths:");
+		expect(archiveFirstText).toContain("local file content");
 	});
 
-	it("starts independent routed reads concurrently while preserving target order", async () => {
+	it("bounds concurrent routed reads while preserving target order", async () => {
 		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-parallel-delimited-"));
 		tempDirs.push(tempDir);
 		const releaseReads = Promise.withResolvers<void>();
@@ -178,8 +199,12 @@ describe("skill:// resolution honors skills.customDirectories (#7190)", () => {
 				getSessionSpawns: () => "*",
 				settings: Settings.isolated(),
 			};
+			const targets = Array.from(
+				{ length: 12 },
+				(_, index) => `parallel-read-test://target-${String(index).padStart(2, "0")}`,
+			);
 			const execution = new ReadTool(session).execute("read-parallel-delimited", {
-				path: "parallel-read-test://first;parallel-read-test://second",
+				path: targets.join(";"),
 			});
 			await firstReadStarted.promise;
 			const activeBeforeRelease = maxActive;
@@ -187,8 +212,9 @@ describe("skill:// resolution honors skills.customDirectories (#7190)", () => {
 			const result = await execution;
 			const text = result.content.flatMap(block => (block.type === "text" ? [block.text] : [])).join("\n");
 
-			expect(activeBeforeRelease).toBe(2);
-			expect(text.indexOf("resolved first")).toBeLessThan(text.indexOf("resolved second"));
+			expect(activeBeforeRelease).toBeGreaterThan(1);
+			expect(activeBeforeRelease).toBeLessThan(targets.length);
+			expect(text.indexOf("resolved target-00")).toBeLessThan(text.indexOf("resolved target-11"));
 		} finally {
 			releaseReads.resolve();
 			router.unregister("parallel-read-test");

--- a/packages/coding-agent/test/skill-protocol-customdirs.test.ts
+++ b/packages/coding-agent/test/skill-protocol-customdirs.test.ts
@@ -94,6 +94,56 @@ describe("skill:// resolution honors skills.customDirectories (#7190)", () => {
 		expect(historyText).toContain("Could not read history://missing-second:1-3");
 	});
 
+	it("distinguishes mixed target delimiters from encoded internal URL semicolons", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-mixed-delimited-skills-"));
+		tempDirs.push(tempDir);
+		const skillDir = path.join(tempDir, "mixed-skill");
+		await fs.mkdir(skillDir, { recursive: true });
+		await Bun.write(path.join(skillDir, "SKILL.md"), makeSkillMd("mixed-skill", tempDir));
+		await Bun.write(path.join(skillDir, "reference;guide.md"), "encoded semicolon resource\n");
+
+		const localFile = path.join(tempDir, "local.txt");
+		await Bun.write(localFile, "local file content\n");
+
+		const { skills } = await loadSkills({
+			...ALL_DEFAULT_SOURCES_DISABLED,
+			customDirectories: [tempDir],
+		});
+		setActiveSkills(skills);
+
+		const session: ToolSession = {
+			cwd: tempDir,
+			hasUI: false,
+			getSessionFile: () => null,
+			getSessionSpawns: () => "*",
+			settings: Settings.isolated(),
+		};
+		const readTool = new ReadTool(session);
+		const mixedTargets = [
+			["read-mixed-internal-first", `skill://mixed-skill;${localFile}`],
+			["read-mixed-file-first", `${localFile};skill://mixed-skill`],
+		] as const;
+
+		for (const [toolCallId, readPath] of mixedTargets) {
+			const result = await readTool.execute(toolCallId, { path: readPath });
+			const text = result.content.flatMap(block => (block.type === "text" ? [block.text] : [])).join("\n");
+
+			expect(text).toContain("Note: interpreted as 2 paths:");
+			expect(text).toContain("mixed-skill skill.");
+			expect(text).toContain("local file content");
+		}
+
+		const encodedResult = await readTool.execute("read-encoded-internal-semicolon", {
+			path: "skill://mixed-skill/reference%3Bguide.md",
+		});
+		const encodedText = encodedResult.content
+			.flatMap(block => (block.type === "text" ? [block.text] : []))
+			.join("\n");
+
+		expect(encodedText).toContain("encoded semicolon resource");
+		expect(encodedText).not.toContain("Note: interpreted as");
+	});
+
 	it("keeps first-wins across multiple custom directories", async () => {
 		const dirA = await fs.mkdtemp(path.join(os.tmpdir(), "pi-custom-a-"));
 		tempDirs.push(dirA);

--- a/packages/coding-agent/test/skill-protocol-customdirs.test.ts
+++ b/packages/coding-agent/test/skill-protocol-customdirs.test.ts
@@ -5,6 +5,7 @@ import * as path from "node:path";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { loadSkills, resetActiveSkillsForTests, setActiveSkills } from "@oh-my-pi/pi-coding-agent/extensibility/skills";
 import { parseInternalUrl } from "@oh-my-pi/pi-coding-agent/internal-urls/parse";
+import { InternalUrlRouter } from "@oh-my-pi/pi-coding-agent/internal-urls/router";
 import { SkillProtocolHandler } from "@oh-my-pi/pi-coding-agent/internal-urls/skill-protocol";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
 import { ReadTool } from "@oh-my-pi/pi-coding-agent/tools/read";
@@ -142,6 +143,56 @@ describe("skill:// resolution honors skills.customDirectories (#7190)", () => {
 
 		expect(encodedText).toContain("encoded semicolon resource");
 		expect(encodedText).not.toContain("Note: interpreted as");
+	});
+
+	it("starts independent routed reads concurrently while preserving target order", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-parallel-delimited-"));
+		tempDirs.push(tempDir);
+		const releaseReads = Promise.withResolvers<void>();
+		const firstReadStarted = Promise.withResolvers<void>();
+		let active = 0;
+		let maxActive = 0;
+		const router = InternalUrlRouter.instance();
+		router.register({
+			scheme: "parallel-read-test",
+			immutable: true,
+			async resolve(url) {
+				active++;
+				maxActive = Math.max(maxActive, active);
+				firstReadStarted.resolve();
+				await releaseReads.promise;
+				active--;
+				return {
+					url: url.rawHref ?? url.href,
+					content: `resolved ${url.rawHost}`,
+					contentType: "text/plain",
+				};
+			},
+		});
+
+		try {
+			const session: ToolSession = {
+				cwd: tempDir,
+				hasUI: false,
+				getSessionFile: () => null,
+				getSessionSpawns: () => "*",
+				settings: Settings.isolated(),
+			};
+			const execution = new ReadTool(session).execute("read-parallel-delimited", {
+				path: "parallel-read-test://first;parallel-read-test://second",
+			});
+			await firstReadStarted.promise;
+			const activeBeforeRelease = maxActive;
+			releaseReads.resolve();
+			const result = await execution;
+			const text = result.content.flatMap(block => (block.type === "text" ? [block.text] : [])).join("\n");
+
+			expect(activeBeforeRelease).toBe(2);
+			expect(text.indexOf("resolved first")).toBeLessThan(text.indexOf("resolved second"));
+		} finally {
+			releaseReads.resolve();
+			router.unregister("parallel-read-test");
+		}
 	});
 
 	it("keeps first-wins across multiple custom directories", async () => {

--- a/packages/coding-agent/test/tools/conflict-integration.test.ts
+++ b/packages/coding-agent/test/tools/conflict-integration.test.ts
@@ -187,6 +187,23 @@ describe("read surfaces conflicts as a warning footer", () => {
 		expect(text).not.toContain("⚠");
 	});
 
+	it("reads conflict-first semicolon batches before parsing a single conflict URI", async () => {
+		await Bun.write(path.join(tempDir, "batch-conflict.ts"), TWO_WAY);
+		await Bun.write(path.join(tempDir, "batch-peer.txt"), "batch peer\n");
+		const session = createTestSession(tempDir);
+		const read = await getTool(session, "read");
+
+		await read.execute("read-batch-conflict-init", { path: "batch-conflict.ts" });
+		const result = await read.execute("read-conflict-first-batch", {
+			path: "conflict://1;batch-peer.txt",
+		});
+		const text = getText(result);
+
+		expect(text).toContain("Note: interpreted as 2 paths: conflict://1, batch-peer.txt");
+		expect(text).toContain("oldApi(x)");
+		expect(text).toContain("batch peer");
+	});
+
 	it("renders only the theirs body via reads of `conflict://<N>/theirs`", async () => {
 		const filePath = path.join(tempDir, "theirs.ts");
 		await Bun.write(filePath, TWO_WAY);

--- a/packages/coding-agent/test/tools/glob-validate-paths.test.ts
+++ b/packages/coding-agent/test/tools/glob-validate-paths.test.ts
@@ -9,7 +9,6 @@ import {
 	parseFindPattern,
 	resolveToolSearchScope,
 	splitDelimitedPathEntry,
-	splitSemicolonPathTargets,
 } from "@oh-my-pi/pi-coding-agent/tools/path-utils";
 import type { Component } from "@oh-my-pi/pi-tui";
 import { removeWithRetries } from "@oh-my-pi/pi-utils";
@@ -86,9 +85,10 @@ describe("delimited path expansion", () => {
 		expect(await splitDelimitedPathEntry("folder\\ with\\ spaces/file.txt packages/b.txt", tempDir)).toBeNull();
 	});
 
-	it("does not split semicolons inside quoted selector values", () => {
-		expect(splitSemicolonPathTargets("data.sqlite:notes?where=body LIKE '%;%'&limit=5")).toBeNull();
-		expect(splitSemicolonPathTargets('data.sqlite:notes?where=body = "a;b"&limit=5')).toBeNull();
+	it("splits existing filesystem targets containing apostrophes", async () => {
+		await Bun.write(path.join(tempDir, "john's.txt"), "john\n");
+		await Bun.write(path.join(tempDir, "peer.txt"), "peer\n");
+		expect(await splitDelimitedPathEntry("john's.txt;peer.txt", tempDir)).toEqual(["john's.txt", "peer.txt"]);
 	});
 
 	it("uses strong delimiters leniently and whitespace delimiters conservatively", async () => {

--- a/packages/coding-agent/test/tools/glob-validate-paths.test.ts
+++ b/packages/coding-agent/test/tools/glob-validate-paths.test.ts
@@ -9,6 +9,7 @@ import {
 	parseFindPattern,
 	resolveToolSearchScope,
 	splitDelimitedPathEntry,
+	splitSemicolonPathTargets,
 } from "@oh-my-pi/pi-coding-agent/tools/path-utils";
 import type { Component } from "@oh-my-pi/pi-tui";
 import { removeWithRetries } from "@oh-my-pi/pi-utils";
@@ -83,6 +84,11 @@ describe("delimited path expansion", () => {
 		expect(await splitDelimitedPathEntry("apps/a.txt\\,packages/b.txt", tempDir)).toBeNull();
 		expect(await splitDelimitedPathEntry("apps/a.txt\\;packages/b.txt", tempDir)).toBeNull();
 		expect(await splitDelimitedPathEntry("folder\\ with\\ spaces/file.txt packages/b.txt", tempDir)).toBeNull();
+	});
+
+	it("does not split semicolons inside quoted selector values", () => {
+		expect(splitSemicolonPathTargets("data.sqlite:notes?where=body LIKE '%;%'&limit=5")).toBeNull();
+		expect(splitSemicolonPathTargets('data.sqlite:notes?where=body = "a;b"&limit=5')).toBeNull();
 	});
 
 	it("uses strong delimiters leniently and whitespace delimiters conservatively", async () => {

--- a/packages/coding-agent/test/tools/grep-path-lists.test.ts
+++ b/packages/coding-agent/test/tools/grep-path-lists.test.ts
@@ -592,6 +592,7 @@ describe("tool path arrays", () => {
 		for (const readPath of [
 			"apps/grep.txt;https://example.com/reference",
 			"https://example.com/reference;apps/grep.txt",
+			"https://a.example/doc;https://b.example/doc",
 		]) {
 			await expect(tool.execute("read-mixed-http-batch", { path: readPath })).rejects.toThrow(
 				"cannot be included in a multi-target Read call",

--- a/packages/coding-agent/test/tools/grep-path-lists.test.ts
+++ b/packages/coding-agent/test/tools/grep-path-lists.test.ts
@@ -564,6 +564,23 @@ describe("tool path arrays", () => {
 		}
 	});
 
+	it("unescapes semicolons inside filenames within an explicit batch", async () => {
+		await Bun.write(path.join(tempDir, "escaped;target.txt"), "escaped semicolon target\n");
+		const tools = await createTools(createTestSession(tempDir));
+		const tool = tools.find(entry => entry.name === "read");
+		expect(tool).toBeDefined();
+		if (!tool) throw new Error("Missing read tool");
+
+		const result = await tool.execute("read-escaped-semicolon-batch", {
+			path: "escaped\\;target.txt;packages/grep.txt",
+		});
+		const text = getText(result);
+
+		expect(text).toContain("Note: interpreted as 2 paths: escaped;target.txt, packages/grep.txt");
+		expect(text).toContain("escaped semicolon target");
+		expect(text).toContain("shared-needle packages");
+	});
+
 	it("splits an explicit semicolon batch before an overlong joined path can reach stat", async () => {
 		const names = Array.from({ length: 20 }, (_, index) => `batch-target-${index.toString().padStart(2, "0")}.txt`);
 		for (const [index, name] of names.entries()) {
@@ -583,6 +600,27 @@ describe("tool path arrays", () => {
 		for (let index = 0; index < names.length; index++) {
 			expect(text).toContain(`batch marker ${index}`);
 		}
+	});
+
+	it("preserves selectors on suffix-resolved batch display targets", async () => {
+		const resolvedDir = path.join(tempDir, "resolved", "missing");
+		await fs.mkdir(resolvedDir, { recursive: true });
+		await Bun.write(
+			path.join(resolvedDir, "suffix-selector.ts"),
+			Array.from({ length: 70 }, (_, index) => `selector line ${index + 1}`).join("\n"),
+		);
+		const tools = await createTools(createTestSession(tempDir));
+		const tool = tools.find(entry => entry.name === "read");
+		expect(tool).toBeDefined();
+		if (!tool) throw new Error("Missing read tool");
+
+		const result = await tool.execute("read-suffix-selector-batch", {
+			path: "missing/suffix-selector.ts:50-60;packages/grep.txt",
+		});
+		const details = result.details as { displayReadTargets?: string[] } | undefined;
+
+		expect(getText(result)).toContain("selector line 50");
+		expect(details?.displayReadTargets).toEqual(["resolved/missing/suffix-selector.ts:50-60", "packages/grep.txt"]);
 	});
 	it("preserves exact archive members containing semicolons", async () => {
 		const archivePath = path.join(tempDir, "semicolon-member.zip");

--- a/packages/coding-agent/test/tools/grep-path-lists.test.ts
+++ b/packages/coding-agent/test/tools/grep-path-lists.test.ts
@@ -599,6 +599,21 @@ describe("tool path arrays", () => {
 		}
 	});
 
+	it("preserves standalone HTTP URLs containing raw semicolons", async () => {
+		const tools = await createTools(
+			createTestSession(tempDir, { settings: Settings.isolated({ "fetch.enabled": false }) }),
+		);
+		const tool = tools.find(entry => entry.name === "read");
+		expect(tool).toBeDefined();
+		if (!tool) throw new Error("Missing read tool");
+
+		for (const readPath of ["https://example.com/items;active", "https://example.com/?a=1;b=2"]) {
+			await expect(tool.execute("read-http-semicolon", { path: readPath })).rejects.toThrow(
+				"URL reads are disabled by settings",
+			);
+		}
+	});
+
 	it("read keeps readable delimited paths when peers are missing", async () => {
 		const tools = await createTools(createTestSession(tempDir));
 		const tool = tools.find(entry => entry.name === "read");

--- a/packages/coding-agent/test/tools/grep-path-lists.test.ts
+++ b/packages/coding-agent/test/tools/grep-path-lists.test.ts
@@ -562,17 +562,41 @@ describe("tool path arrays", () => {
 		}
 	});
 
-	it("rejects HTTP URLs inside multi-target read calls", async () => {
+	it("splits an explicit semicolon batch before an overlong joined path can reach stat", async () => {
+		const names = Array.from({ length: 20 }, (_, index) => `batch-target-${index.toString().padStart(2, "0")}.txt`);
+		for (const [index, name] of names.entries()) {
+			await Bun.write(path.join(tempDir, name), `batch marker ${index}\n`);
+		}
 		const tools = await createTools(createTestSession(tempDir));
 		const tool = tools.find(entry => entry.name === "read");
 		expect(tool).toBeDefined();
 		if (!tool) throw new Error("Missing read tool");
 
-		await expect(
-			tool.execute("read-mixed-http-batch", {
-				path: "apps/grep.txt;https://example.com/reference",
-			}),
-		).rejects.toThrow("HTTP(S) URL 'https://example.com/reference' cannot be included in a multi-target Read call");
+		const joinedPath = names.join(";");
+		expect(joinedPath.length).toBeGreaterThan(255);
+		const result = await tool.execute("read-overlong-semicolon-batch", { path: joinedPath });
+		const text = getText(result);
+
+		expect(text).toContain(`Note: interpreted as ${names.length} paths:`);
+		for (let index = 0; index < names.length; index++) {
+			expect(text).toContain(`batch marker ${index}`);
+		}
+	});
+
+	it("rejects HTTP URLs in either position of a multi-target Read call", async () => {
+		const tools = await createTools(createTestSession(tempDir));
+		const tool = tools.find(entry => entry.name === "read");
+		expect(tool).toBeDefined();
+		if (!tool) throw new Error("Missing read tool");
+
+		for (const readPath of [
+			"apps/grep.txt;https://example.com/reference",
+			"https://example.com/reference;apps/grep.txt",
+		]) {
+			await expect(tool.execute("read-mixed-http-batch", { path: readPath })).rejects.toThrow(
+				"cannot be included in a multi-target Read call",
+			);
+		}
 	});
 
 	it("read keeps readable delimited paths when peers are missing", async () => {

--- a/packages/coding-agent/test/tools/grep-path-lists.test.ts
+++ b/packages/coding-agent/test/tools/grep-path-lists.test.ts
@@ -1,3 +1,4 @@
+import { Database } from "bun:sqlite";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
@@ -606,11 +607,19 @@ describe("tool path arrays", () => {
 		const tool = tools.find(entry => entry.name === "read");
 		expect(tool).toBeDefined();
 		if (!tool) throw new Error("Missing read tool");
+		const archivePath = path.join(tempDir, "http-sibling.zip");
+		await writeArchive(archivePath, "zip", [["README.md", "archive sibling\n"]]);
+		const sqlitePath = path.join(tempDir, "http-sibling.sqlite");
+		const db = new Database(sqlitePath);
+		db.run("CREATE TABLE users (id INTEGER PRIMARY KEY)");
+		db.close();
 
 		for (const readPath of [
 			"apps/grep.txt;https://example.com/reference",
 			"https://example.com/reference;apps/grep.txt",
 			"https://a.example/doc;https://b.example/doc",
+			`https://example.com/reference;${archivePath}:README.md`,
+			`https://example.com/reference;${sqlitePath}:users`,
 		]) {
 			await expect(tool.execute("read-mixed-http-batch", { path: readPath })).rejects.toThrow(
 				"cannot be included in a multi-target Read call",

--- a/packages/coding-agent/test/tools/grep-path-lists.test.ts
+++ b/packages/coding-agent/test/tools/grep-path-lists.test.ts
@@ -602,11 +602,21 @@ describe("tool path arrays", () => {
 		expect(text).not.toContain("Note: interpreted as");
 	});
 
-	it("rejects HTTP URLs in either position of a multi-target Read call", async () => {
+	it("rejects an HTTP URL after a filesystem batch target", async () => {
 		const tools = await createTools(createTestSession(tempDir));
 		const tool = tools.find(entry => entry.name === "read");
 		expect(tool).toBeDefined();
 		if (!tool) throw new Error("Missing read tool");
+
+		await expect(
+			tool.execute("read-mixed-http-batch", {
+				path: "apps/grep.txt;https://example.com/reference",
+			}),
+		).rejects.toThrow("cannot be included in a multi-target Read call");
+	});
+
+	it("preserves HTTP-first scalars as URLs independently of cwd contents", async () => {
+		await Bun.write(path.join(tempDir, "active"), "URL suffix collision\n");
 		const archivePath = path.join(tempDir, "http-sibling.zip");
 		await writeArchive(archivePath, "zip", [["README.md", "archive sibling\n"]]);
 		const sqlitePath = path.join(tempDir, "http-sibling.sqlite");
@@ -614,20 +624,6 @@ describe("tool path arrays", () => {
 		db.run("CREATE TABLE users (id INTEGER PRIMARY KEY)");
 		db.close();
 
-		for (const readPath of [
-			"apps/grep.txt;https://example.com/reference",
-			"https://example.com/reference;apps/grep.txt",
-			"https://a.example/doc;https://b.example/doc",
-			`https://example.com/reference;${archivePath}:README.md`,
-			`https://example.com/reference;${sqlitePath}:users`,
-		]) {
-			await expect(tool.execute("read-mixed-http-batch", { path: readPath })).rejects.toThrow(
-				"cannot be included in a multi-target Read call",
-			);
-		}
-	});
-
-	it("preserves standalone HTTP URLs containing raw semicolons", async () => {
 		const tools = await createTools(
 			createTestSession(tempDir, { settings: Settings.isolated({ "fetch.enabled": false }) }),
 		);
@@ -635,7 +631,14 @@ describe("tool path arrays", () => {
 		expect(tool).toBeDefined();
 		if (!tool) throw new Error("Missing read tool");
 
-		for (const readPath of ["https://example.com/items;active", "https://example.com/?a=1;b=2"]) {
+		for (const readPath of [
+			"https://example.com/items;active",
+			"https://example.com/?a=1;b=2",
+			"https://example.com/reference;apps/grep.txt",
+			"https://a.example/doc;https://b.example/doc",
+			`https://example.com/reference;${archivePath}:README.md`,
+			`https://example.com/reference;${sqlitePath}:users`,
+		]) {
 			await expect(tool.execute("read-http-semicolon", { path: readPath })).rejects.toThrow(
 				"URL reads are disabled by settings",
 			);

--- a/packages/coding-agent/test/tools/grep-path-lists.test.ts
+++ b/packages/coding-agent/test/tools/grep-path-lists.test.ts
@@ -562,6 +562,19 @@ describe("tool path arrays", () => {
 		}
 	});
 
+	it("rejects HTTP URLs inside multi-target read calls", async () => {
+		const tools = await createTools(createTestSession(tempDir));
+		const tool = tools.find(entry => entry.name === "read");
+		expect(tool).toBeDefined();
+		if (!tool) throw new Error("Missing read tool");
+
+		await expect(
+			tool.execute("read-mixed-http-batch", {
+				path: "apps/grep.txt;https://example.com/reference",
+			}),
+		).rejects.toThrow("HTTP(S) URL 'https://example.com/reference' cannot be included in a multi-target Read call");
+	});
+
 	it("read keeps readable delimited paths when peers are missing", async () => {
 		const tools = await createTools(createTestSession(tempDir));
 		const tool = tools.find(entry => entry.name === "read");

--- a/packages/coding-agent/test/tools/grep-path-lists.test.ts
+++ b/packages/coding-agent/test/tools/grep-path-lists.test.ts
@@ -21,6 +21,7 @@ import { ToolChoiceQueue } from "@oh-my-pi/pi-coding-agent/session/tool-choice-q
 import { createTools, type ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
 import type { Text } from "@oh-my-pi/pi-tui";
 import { removeWithRetries } from "@oh-my-pi/pi-utils";
+import { writeArchive } from "@oh-my-pi/pi-utils/ar";
 import { grepToolRenderer } from "../../src/tools/grep";
 
 function createTestSession(cwd: string, overrides: Partial<ToolSession> = {}): ToolSession {
@@ -581,6 +582,23 @@ describe("tool path arrays", () => {
 		for (let index = 0; index < names.length; index++) {
 			expect(text).toContain(`batch marker ${index}`);
 		}
+	});
+	it("preserves exact archive members containing semicolons", async () => {
+		const archivePath = path.join(tempDir, "semicolon-member.zip");
+		const member = "docs/reference;guide.md";
+		await writeArchive(archivePath, "zip", [[member, "archive semicolon member\n"]]);
+		const tools = await createTools(createTestSession(tempDir));
+		const tool = tools.find(entry => entry.name === "read");
+		expect(tool).toBeDefined();
+		if (!tool) throw new Error("Missing read tool");
+
+		const result = await tool.execute("read-archive-semicolon-member", {
+			path: `${archivePath}:${member}`,
+		});
+		const text = getText(result);
+
+		expect(text).toContain("archive semicolon member");
+		expect(text).not.toContain("Note: interpreted as");
 	});
 
 	it("rejects HTTP URLs in either position of a multi-target Read call", async () => {

--- a/packages/coding-agent/test/tools/read-guidance.test.ts
+++ b/packages/coding-agent/test/tools/read-guidance.test.ts
@@ -14,26 +14,6 @@ function createSession(): ToolSession {
 }
 
 describe("Read guidance", () => {
-	it("requires one call for independent known targets before another assistant turn", () => {
-		const description = new ReadTool(createSession()).description;
-
-		expect(description).toContain("Before each `read`, collect every bounded target");
-		expect(description).toContain("MUST batch independent known non-HTTP(S)");
-		expect(description).toContain("HTTP(S) URLs as separate `read` calls");
-		expect(description).toContain("NEVER semicolon-join them");
-		expect(description).toContain("NEVER read known non-HTTP(S) targets one per assistant turn");
-	});
-
-	it("limits semicolon batching in the wire schema to non-HTTP targets", () => {
-		const schema = new ReadTool(createSession()).parameters.toJsonSchema() as {
-			properties?: { path?: { description?: string } };
-		};
-		const description = schema.properties?.path?.description;
-
-		expect(description).toContain("Join independent non-HTTP(S)");
-		expect(description).toContain("use separate calls for HTTP(S) URLs");
-	});
-
 	it("advertises grep and current SSH fallbacks instead of retired tool names", () => {
 		const description = new ReadTool(createSession()).description;
 

--- a/packages/coding-agent/test/tools/read-guidance.test.ts
+++ b/packages/coding-agent/test/tools/read-guidance.test.ts
@@ -13,7 +13,27 @@ function createSession(): ToolSession {
 	};
 }
 
-describe("Read SSH guidance", () => {
+describe("Read guidance", () => {
+	it("requires one call for independent known targets before another assistant turn", () => {
+		const description = new ReadTool(createSession()).description;
+
+		expect(description).toContain("Before each `read`, collect every bounded target");
+		expect(description).toContain("MUST batch independent known non-HTTP(S)");
+		expect(description).toContain("HTTP(S) URLs as separate `read` calls");
+		expect(description).toContain("NEVER semicolon-join them");
+		expect(description).toContain("NEVER read known non-HTTP(S) targets one per assistant turn");
+	});
+
+	it("limits semicolon batching in the wire schema to non-HTTP targets", () => {
+		const schema = new ReadTool(createSession()).parameters.toJsonSchema() as {
+			properties?: { path?: { description?: string } };
+		};
+		const description = schema.properties?.path?.description;
+
+		expect(description).toContain("Join independent non-HTTP(S)");
+		expect(description).toContain("use separate calls for HTTP(S) URLs");
+	});
+
 	it("advertises grep and current SSH fallbacks instead of retired tool names", () => {
 		const description = new ReadTool(createSession()).description;
 

--- a/packages/coding-agent/test/tools/sqlite.test.ts
+++ b/packages/coding-agent/test/tools/sqlite.test.ts
@@ -358,6 +358,18 @@ describe("SQLite tool support", () => {
 		expect(text).toContain("Alice");
 		expect(text).toContain("sqlite batch peer");
 	});
+	it("splits a batch after a SQLite query selector", async () => {
+		const siblingPath = path.join(tmpDir, "sqlite-query-batch-peer.txt");
+		await Bun.write(siblingPath, "sqlite query batch peer\n");
+		const result = await readTool.execute("sqlite-query-first-batch", {
+			path: `${sqlitePath}:users?limit=5;${siblingPath}`,
+		});
+		const text = getText(result);
+
+		expect(text).toContain("Note: interpreted as 2 paths:");
+		expect(text).toContain("Alice");
+		expect(text).toContain("sqlite query batch peer");
+	});
 
 	it("rejects SQLite where clauses that try to override pagination control syntax", async () => {
 		await expect(

--- a/packages/coding-agent/test/tools/sqlite.test.ts
+++ b/packages/coding-agent/test/tools/sqlite.test.ts
@@ -358,6 +358,19 @@ describe("SQLite tool support", () => {
 		expect(text).toContain("Alice");
 		expect(text).toContain("sqlite batch peer");
 	});
+
+	it("splits a SQLite-first batch when a sibling filename contains a question mark", async () => {
+		const siblingPath = path.join(tmpDir, "notes.txt?draft");
+		await Bun.write(siblingPath, "question-mark sibling\n");
+		const result = await readTool.execute("sqlite-question-mark-sibling", {
+			path: `${sqlitePath}:users;${siblingPath}`,
+		});
+		const text = getText(result);
+
+		expect(text).toContain("Note: interpreted as 2 paths:");
+		expect(text).toContain("Alice");
+		expect(text).toContain("question-mark sibling");
+	});
 	it("splits a SQLite-first batch when the peer starts with a SQL verb", async () => {
 		await Bun.write(path.join(tmpDir, "select.md"), "SQL-named peer\n");
 		const result = await readTool.execute("sqlite-sql-named-peer", {

--- a/packages/coding-agent/test/tools/sqlite.test.ts
+++ b/packages/coding-agent/test/tools/sqlite.test.ts
@@ -369,6 +369,29 @@ describe("SQLite tool support", () => {
 		expect(text).toContain("Alice");
 		expect(text).toContain("SQL-named peer");
 	});
+
+	it("preserves semicolons in exact SQLite table names and row keys", async () => {
+		const exactDbPath = path.join(tmpDir, "semicolon-identifiers.sqlite");
+		const db = new Database(exactDbPath);
+		try {
+			db.run('CREATE TABLE "users;active" (id INTEGER PRIMARY KEY, name TEXT NOT NULL)');
+			db.run("CREATE TABLE slugs (slug TEXT PRIMARY KEY, title TEXT NOT NULL)");
+			db.prepare('INSERT INTO "users;active" (name) VALUES (?)').run("Semicolon table");
+			db.prepare("INSERT INTO slugs (slug, title) VALUES (?, ?)").run("legal;terms", "Semicolon key");
+		} finally {
+			db.close();
+		}
+
+		const tableResult = await readTool.execute("sqlite-semicolon-table", {
+			path: `${exactDbPath}:users;active`,
+		});
+		expect(getText(tableResult)).toContain("Semicolon table");
+
+		const rowResult = await readTool.execute("sqlite-semicolon-row", {
+			path: `${exactDbPath}:slugs:legal;terms`,
+		});
+		expect(getText(rowResult)).toContain("title: Semicolon key");
+	});
 	it("splits a batch after a SQLite query selector", async () => {
 		const siblingPath = path.join(tmpDir, "sqlite-query-batch-peer.txt");
 		await Bun.write(siblingPath, "sqlite query batch peer\n");

--- a/packages/coding-agent/test/tools/sqlite.test.ts
+++ b/packages/coding-agent/test/tools/sqlite.test.ts
@@ -405,6 +405,16 @@ describe("SQLite tool support", () => {
 		expect(text).toContain("sqlite query batch peer");
 	});
 
+	it("preserves semicolon terminators in raw SQLite queries", async () => {
+		const result = await readTool.execute("sqlite-raw-semicolon", {
+			path: `${sqlitePath}?q=SELECT+name+FROM+users+WHERE+id=1;`,
+		});
+		const text = getText(result);
+
+		expect(text).toContain("Alice");
+		expect(text).not.toContain("Note: interpreted as");
+	});
+
 	it("rejects SQLite where clauses that try to override pagination control syntax", async () => {
 		await expect(
 			readTool.execute("sqlite-where-pagination-bypass", {

--- a/packages/coding-agent/test/tools/sqlite.test.ts
+++ b/packages/coding-agent/test/tools/sqlite.test.ts
@@ -358,6 +358,17 @@ describe("SQLite tool support", () => {
 		expect(text).toContain("Alice");
 		expect(text).toContain("sqlite batch peer");
 	});
+	it("splits a SQLite-first batch when the peer starts with a SQL verb", async () => {
+		await Bun.write(path.join(tmpDir, "select.md"), "SQL-named peer\n");
+		const result = await readTool.execute("sqlite-sql-named-peer", {
+			path: `${sqlitePath}:users;select.md`,
+		});
+		const text = getText(result);
+
+		expect(text).toContain("Note: interpreted as 2 paths:");
+		expect(text).toContain("Alice");
+		expect(text).toContain("SQL-named peer");
+	});
 	it("splits a batch after a SQLite query selector", async () => {
 		const siblingPath = path.join(tmpDir, "sqlite-query-batch-peer.txt");
 		await Bun.write(siblingPath, "sqlite query batch peer\n");

--- a/packages/coding-agent/test/tools/sqlite.test.ts
+++ b/packages/coding-agent/test/tools/sqlite.test.ts
@@ -346,6 +346,19 @@ describe("SQLite tool support", () => {
 		expect(text).toContain("Third; note");
 	});
 
+	it("splits a SQLite-first batch without absorbing its sibling into the selector", async () => {
+		const siblingPath = path.join(tmpDir, "sqlite-batch-peer.txt");
+		await Bun.write(siblingPath, "sqlite batch peer\n");
+		const result = await readTool.execute("sqlite-first-batch", {
+			path: `${sqlitePath}:users;${siblingPath}`,
+		});
+		const text = getText(result);
+
+		expect(text).toContain("Note: interpreted as 2 paths:");
+		expect(text).toContain("Alice");
+		expect(text).toContain("sqlite batch peer");
+	});
+
 	it("rejects SQLite where clauses that try to override pagination control syntax", async () => {
 		await expect(
 			readTool.execute("sqlite-where-pagination-bypass", {


### PR DESCRIPTION
## What

- Teach Read to collect already-known, bounded non-HTTP(S) targets before calling the tool.
- Require those targets in one semicolon-delimited scalar `path`, and expose that grammar in the JSON schema.
- Keep HTTP(S) URLs as separate calls because raw semicolons are valid URL data.
- Support mixed internal URI and filesystem batches while preserving `%3B` as literal internal-URI data.
- Preserve exact advertised MCP resource URIs byte-for-byte before interpreting semicolons as delimiters.
- Execute independent batch targets with bounded concurrency while preserving result order.
- Preserve existing SQLite, archive, conflict, literal-path, selector, URL, and rendering behavior.

This has given me substantial speed and cache savings.

## Why

The current tool prompt only says to parallelize independent reads.
Its scalar `path` schema does not advertise the existing batch grammar.
Providers that emit one tool call per response therefore require another model continuation for every known target.
Prompt caching can discount a stable prefix, but it does not combine requests or remove new tool-result input.

This change uses the existing semicolon-delimited scalar runtime instead of adding a second path-array API.
The runtime executes independent entries with a concurrency limit of eight and preserves input order in the result.
Literal and structured targets retain precedence where a semicolon is valid source data.

I checked the relevant issues, comments, pull requests, and discussions.
This pull request is not a duplicate.

## Testing

- `bun test test/internal-urls/mcp-protocol.test.ts test/skill-protocol-customdirs.test.ts test/tools/conflict-integration.test.ts test/tools/glob-validate-paths.test.ts test/tools/grep-path-lists.test.ts test/tools/read-guidance.test.ts test/tools/sqlite.test.ts test/read-tool-group.test.ts` passed 184 tests with 0 failures.
- Two controlled baseline runs and two candidate runs each returned all ten distinct target payloads.
- `git diff --check` passed.
- [OMP Nix](https://github.com/can1357/oh-my-pi/actions/runs/33507290968) passed.
- [Lint, type checking, and web build](https://github.com/can1357/oh-my-pi/actions/runs/33507290957) passed.
- Runtime, singleton, UI/TUI, CLI, installation, and native integration jobs passed.
- The two remaining failed CI buckets match [current upstream failures](https://github.com/can1357/oh-my-pi/actions/runs/33504655040).

Local `bun check` on the contribution branch reaches the existing `VirtualTerminal` export error outside this change.
The current PR merge-ref type-check job passes.

### Measured impact

I compared `upstream/main@38fe5c4628a12a6b556a602b4c0592218560f75e` with the candidate.
Both variants used the same controlled scenario.

- Model: `openai-codex/gpt-5.6-sol`.
- Thinking level: `low`.
- Enabled tools: Read only.
- Input: the same ten already-known files, each bounded to line 1.
- Runs: two independent runs per variant.
- Guardrail: every run returned all ten distinct file payloads.

| Variant | Run | Provider requests | Read turns | Conversation tokens | Wall time |
| --- | ---: | ---: | ---: | ---: | ---: |
| Upstream | 1 | 11 | 10 | 57,480 | 25.21 s |
| Upstream | 2 | 11 | 10 | 57,380 | 26.69 s |
| Candidate | 1 | 2 | 1 | 10,656 | 9.21 s |
| Candidate | 2 | 2 | 1 | 10,656 | 8.74 s |

Average observed change:

- Provider requests: 11 to 2 (`-81.8%`).
- Conversation tokens: 57,430 to 10,656 (`-81.4%`).
- Wall time: 25.95 seconds to 8.98 seconds (`-65.4%`).
- Uncached input tokens: 15,266.5 to 5,567 (`-63.5%`).
- Cache-read tokens: 41,728 to 4,864 (`-88.3%`).
- Output tokens: 435.5 to 225 (`-48.3%`).

Conversation tokens include uncached input, cache reads, cache writes, and output across provider requests.
The upstream runs issued ten sequential Read turns.
Both candidate runs issued one semicolon-delimited Read call covering all ten targets.
The measurement does not claim universal performance across providers or workloads.

- [x] Tested locally.
- [x] CHANGELOG updated.

### Disclosure

Investigated thoroughly with GPT-5.6 Sol (extra high reasoning effort), using [Oh My Pi](https://github.com/can1357/oh-my-pi) as the agent framework.

This report is not generic or unreviewed AI-generated output.
Its claims were checked against the cited evidence.
It includes the relevant detail intended to help maintainers resolve the issue.

If reports like this are not useful to the project, please let me know.
I will refrain from submitting similar ones.
My intent is to help without wasting maintainer time or energy or discouraging their work.

Thank you for your work.
