### PR TITLE
fix(cursor): scope schema projection to Fable models

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -17,7 +17,7 @@
 ### Fixed
 
 - Fixed OpenAI remote-compaction replay for persisted sessions, allowing sessions with previously stored compaction items to resume successfully.
-- Fixed Cursor Fable requests failing when advertised tools used JSON Schema composition keywords.
+- Fixed Cursor tool-schema composition failures by projecting unsupported keywords only for confirmed Fable models; Grok and other Cursor models retain canonical schemas.
 - Fixed Z.AI (GLM Coding Plan) browser sign-in by using the registered CLI callback address.
 - Fixed OpenAI Codex/Responses tool results being lost when composite call identifiers could not be paired with the corresponding assistant call.
 - Fixed native OpenAI Responses history replay becoming stuck on malformed or truncated function-call arguments; invalid history items are now discarded so the session can recover.

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -702,7 +702,10 @@ function streamCursorWithWireMode(
 			const { requestBytes, conversationState } = builtRequest;
 			serializedFallbackWireModelId = builtRequest.fallbackWireModelId;
 			conversationStateCache.set(conversationId, conversationState);
-			const requestContextTools = buildMcpToolDefinitions(context.tools);
+			const requestContextTools = buildMcpToolDefinitions(
+				context.tools,
+				model.requiresCursorToolSchemaProjection === true,
+			);
 			const requestContextRules = buildCursorRequestContextRules(context.systemPrompt);
 
 			const baseUrl = model.baseUrl || CURSOR_API_URL;
@@ -4612,7 +4615,10 @@ function isJsonValue(value: unknown): value is JsonValue {
 	return true;
 }
 
-export function buildMcpToolDefinitions(tools: Tool[] | undefined): McpToolDefinition[] {
+export function buildMcpToolDefinitions(
+	tools: Tool[] | undefined,
+	requiresCursorToolSchemaProjection = false,
+): McpToolDefinition[] {
 	if (!tools || tools.length === 0) {
 		return [];
 	}
@@ -4632,7 +4638,8 @@ export function buildMcpToolDefinitions(tools: Tool[] | undefined): McpToolDefin
 	const forwarded = writeTool ? [...advertisedTools, writeTool] : advertisedTools;
 
 	return forwarded.map(tool => {
-		const jsonSchema = sanitizeSchemaForCursor(toolWireSchema(tool));
+		const wireSchema = toolWireSchema(tool);
+		const jsonSchema = requiresCursorToolSchemaProjection ? sanitizeSchemaForCursor(wireSchema) : wireSchema;
 		const schemaValue: JsonValue =
 			jsonSchema !== null && !Array.isArray(jsonSchema) && isJsonValue(jsonSchema)
 				? jsonSchema

--- a/packages/ai/test/cursor-mcp-tool-catalog.test.ts
+++ b/packages/ai/test/cursor-mcp-tool-catalog.test.ts
@@ -70,7 +70,38 @@ describe("cursor buildMcpToolDefinitions", () => {
 		expect(defs.map(def => def.name)).not.toContain("read");
 	});
 
-	it("advertises no composition keyword and never mutates the canonical wire schema", () => {
+	it("preserves nested combiners by default and when projection is disabled", () => {
+		const schema = {
+			type: "object",
+			properties: {
+				where: {
+					oneOf: [
+						{ type: "object", properties: { element_token: { type: "string" } }, required: ["element_token"] },
+						{
+							type: "object",
+							properties: { x: { type: "number" }, y: { type: "number" } },
+							required: ["x", "y"],
+						},
+					],
+				},
+			},
+			required: ["where"],
+		};
+		const composedTool = tool("composed", schema);
+		const wireSchema = toolWireSchema(composedTool);
+
+		for (const definitions of [
+			buildMcpToolDefinitions([composedTool]),
+			buildMcpToolDefinitions([composedTool], false),
+		]) {
+			const advertised = decodeJsonValue(definitions[0].inputSchema);
+
+			expect(hasCompositionKeyword(advertised)).toBe(true);
+			expect(advertised).toEqual(wireSchema as typeof advertised);
+		}
+	});
+
+	it("projects nested combiners only when requested and leaves the canonical wire schema untouched", () => {
 		const schema = {
 			type: "object",
 			properties: {
@@ -91,14 +122,14 @@ describe("cursor buildMcpToolDefinitions", () => {
 		const wireSchema = toolWireSchema(composedTool);
 		const originalWireSchema = structuredClone(wireSchema);
 
-		const [definition] = buildMcpToolDefinitions([composedTool]);
+		const [definition] = buildMcpToolDefinitions([composedTool], true);
 		const advertised = decodeJsonValue(definition.inputSchema);
 
-		// The whole point of the projection: Cursor rejects the request outright
-		// if any composition keyword survives anywhere in an advertised schema.
+		// Cursor rejects the request outright if any composition keyword survives
+		// anywhere in an advertised schema for models that require projection.
 		expect(hasCompositionKeyword(advertised)).toBe(false);
 		// The canonical schema, which still validates arguments locally, is untouched.
-		expect(structuredClone(wireSchema)).toEqual(originalWireSchema);
+		expect(wireSchema).toEqual(originalWireSchema);
 	});
 });
 

--- a/packages/catalog/src/build.ts
+++ b/packages/catalog/src/build.ts
@@ -32,7 +32,8 @@ function isInputModalities(value: unknown): value is ("text" | "image")[] {
  * Applies resolved catalog-data axes onto the model: reviewed metadata
  * corrections (`cost-patch`, `limits-patch`, `long-context-cost`,
  * `context-window-floor`) overwrite upstream values; selection metadata
- * (`priority`, `apply-patch-tool-type`, `service-tier-cost`) is rule-owned;
+ * (`priority`, `apply-patch-tool-type`, `service-tier-cost`,
+ * `requires-cursor-tool-schema-projection`) is rule-owned;
  * `context-promotion-target` fills only when the spec left it unset.
  */
 function applyCatalogAssignments<TApi extends Api>(model: Model<TApi>, catalog: Record<string, unknown>): void {
@@ -50,6 +51,10 @@ function applyCatalogAssignments<TApi extends Api>(model: Model<TApi>, catalog: 
 	const applyPatchToolType = catalog.applyPatchToolType;
 	if (applyPatchToolType === "freeform" || applyPatchToolType === "function") {
 		model.applyPatchToolType = applyPatchToolType;
+	}
+	const requiresCursorToolSchemaProjection = catalog.requiresCursorToolSchemaProjection;
+	if (requiresCursorToolSchemaProjection === true) {
+		model.requiresCursorToolSchemaProjection = true;
 	}
 	const contextPromotionTarget = catalog.contextPromotionTarget;
 	if (typeof contextPromotionTarget === "string" && model.contextPromotionTarget === undefined) {

--- a/packages/catalog/src/build.ts
+++ b/packages/catalog/src/build.ts
@@ -55,6 +55,8 @@ function applyCatalogAssignments<TApi extends Api>(model: Model<TApi>, catalog: 
 	const requiresCursorToolSchemaProjection = catalog.requiresCursorToolSchemaProjection;
 	if (requiresCursorToolSchemaProjection === true) {
 		model.requiresCursorToolSchemaProjection = true;
+	} else {
+		delete model.requiresCursorToolSchemaProjection;
 	}
 	const contextPromotionTarget = catalog.contextPromotionTarget;
 	if (typeof contextPromotionTarget === "string" && model.contextPromotionTarget === undefined) {

--- a/packages/catalog/src/compat/axes.ts
+++ b/packages/catalog/src/compat/axes.ts
@@ -257,6 +257,11 @@ export const AXES: Readonly<Record<string, AxisDef>> = {
 	"limits-patch": { key: "limitsPatch", set: "catalog", shape: "object" },
 	"long-context-cost": { key: "longContext", set: "catalog", shape: "object" },
 	"long-usage-limit-fallback": { key: "longUsageLimitFallback", set: "catalog", shape: "scalar" },
+	"requires-cursor-tool-schema-projection": {
+		key: "requiresCursorToolSchemaProjection",
+		set: "catalog",
+		shape: "scalar",
+	},
 	priority: { key: "priority", set: "catalog", shape: "scalar" },
 	"service-tier-cost": { key: "serviceTierCost", set: "catalog", shape: "object" },
 };

--- a/packages/catalog/src/compat/rules.json
+++ b/packages/catalog/src/compat/rules.json
@@ -7305,7 +7305,18 @@
 				}
 			},
 			{
-				"source": "providers/cursor.kdl:9",
+				"source": "providers/cursor.kdl:6",
+				"class": "anthropic",
+				"providers": [
+					"cursor"
+				],
+				"family": "fable",
+				"catalog": {
+					"requiresCursorToolSchemaProjection": true
+				}
+			},
+			{
+				"source": "providers/cursor.kdl:14",
 				"class": "kimi",
 				"providers": [
 					"cursor"
@@ -7320,7 +7331,7 @@
 				}
 			},
 			{
-				"source": "providers/cursor.kdl:14",
+				"source": "providers/cursor.kdl:19",
 				"providers": [
 					"cursor"
 				],
@@ -7343,7 +7354,7 @@
 				}
 			},
 			{
-				"source": "providers/cursor.kdl:20",
+				"source": "providers/cursor.kdl:25",
 				"providers": [
 					"cursor"
 				],
@@ -7377,7 +7388,7 @@
 				}
 			},
 			{
-				"source": "providers/cursor.kdl:23",
+				"source": "providers/cursor.kdl:28",
 				"providers": [
 					"cursor"
 				],
@@ -7411,7 +7422,7 @@
 				}
 			},
 			{
-				"source": "providers/cursor.kdl:27",
+				"source": "providers/cursor.kdl:32",
 				"providers": [
 					"cursor"
 				],
@@ -7429,7 +7440,7 @@
 				}
 			},
 			{
-				"source": "providers/cursor.kdl:31",
+				"source": "providers/cursor.kdl:36",
 				"providers": [
 					"cursor"
 				],
@@ -7462,7 +7473,7 @@
 				}
 			},
 			{
-				"source": "providers/cursor.kdl:35",
+				"source": "providers/cursor.kdl:40",
 				"providers": [
 					"cursor"
 				],
@@ -7502,7 +7513,7 @@
 				}
 			},
 			{
-				"source": "providers/cursor.kdl:40",
+				"source": "providers/cursor.kdl:45",
 				"providers": [
 					"cursor"
 				],
@@ -7521,7 +7532,7 @@
 				}
 			},
 			{
-				"source": "providers/cursor.kdl:44",
+				"source": "providers/cursor.kdl:49",
 				"providers": [
 					"cursor"
 				],

--- a/packages/catalog/src/compat/rules/providers/cursor.kdl
+++ b/packages/catalog/src/compat/rules/providers/cursor.kdl
@@ -2,6 +2,11 @@
 
 provider "cursor" {
 	thinking-mode "effort"
+	class "anthropic" {
+		family "fable" {
+			requires-cursor-tool-schema-projection #true
+		}
+	}
 	// GetUsableModels advertises no input modalities or context windows.
 	// K3 (including the bare `k3` alias Cursor serves) is natively
 	// multimodal and 1M-context.

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -54701,6 +54701,7 @@
 				"effort": "high",
 				"logicalId": "claude-fable-5"
 			},
+			"requiresCursorToolSchemaProjection": true,
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
 		},
@@ -54749,6 +54750,7 @@
 				"effort": "low",
 				"logicalId": "claude-fable-5"
 			},
+			"requiresCursorToolSchemaProjection": true,
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
 		},
@@ -54797,6 +54799,7 @@
 				"effort": "max",
 				"logicalId": "claude-fable-5"
 			},
+			"requiresCursorToolSchemaProjection": true,
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
 		},
@@ -54845,6 +54848,7 @@
 				"effort": "medium",
 				"logicalId": "claude-fable-5"
 			},
+			"requiresCursorToolSchemaProjection": true,
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
 		},
@@ -54893,6 +54897,7 @@
 				"effort": "xhigh",
 				"logicalId": "claude-fable-5"
 			},
+			"requiresCursorToolSchemaProjection": true,
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
 		},

--- a/packages/catalog/src/types.ts
+++ b/packages/catalog/src/types.ts
@@ -1042,6 +1042,8 @@ export interface Model<TApi extends Api = Api> {
 	 * inferring it from the transport API.
 	 */
 	requiresGlyphTokenization?: boolean;
+	/** Whether this model requires Cursor's tool-schema combiner projection. */
+	requiresCursorToolSchemaProjection?: boolean;
 	/**
 	 * Model id to send on the wire when it differs from `id`. Used by catalog
 	 * variants that present one upstream model under several local entries —
@@ -1197,10 +1199,16 @@ export interface Model<TApi extends Api = Api> {
  * vocabulary of `buildModel`. Identical to `Model` except `compat` carries the
  * sparse override shape and nothing is resolved yet.
  */
-export interface ModelSpec<TApi extends Api = Api> extends Omit<
-	Model<TApi>,
-	"compat" | "identity" | "compatConfig" | "requiresGlyphTokenization" | "supportsComputerUseConfig"
-> {
+export interface ModelSpec<TApi extends Api = Api>
+	extends Omit<
+		Model<TApi>,
+		| "compat"
+		| "identity"
+		| "compatConfig"
+		| "requiresGlyphTokenization"
+		| "requiresCursorToolSchemaProjection"
+		| "supportsComputerUseConfig"
+	> {
 	/** Sparse compatibility overrides; resolved into `Model.compat` by `buildModel`. */
 	compat?: CompatConfigOf<TApi>;
 }

--- a/packages/catalog/test/generated-policies.test.ts
+++ b/packages/catalog/test/generated-policies.test.ts
@@ -105,6 +105,26 @@ describe("generated model policies", () => {
 		expect(built[3]?.priority).toBe(1);
 	});
 
+	it("projects Cursor tool schemas only for Anthropic Fable variants", () => {
+		const fableModels = [
+			"claude-fable-5-high",
+			"claude-fable-5-low",
+			"claude-fable-5-max",
+			"claude-fable-5-medium",
+			"claude-fable-5-xhigh",
+		].map(id => buildGenerated(createSpec({ id, api: "cursor-agent", provider: "cursor" })));
+		const grok = buildGenerated(createSpec({ id: "cursor-grok-4.6", api: "cursor-agent", provider: "cursor" }));
+		const otherCursorAnthropic = buildGenerated(
+			createSpec({ id: "claude-opus-4-7-high", api: "cursor-agent", provider: "cursor" }),
+		);
+
+		for (const model of fableModels) {
+			expect(model.requiresCursorToolSchemaProjection).toBe(true);
+		}
+		expect(grok.requiresCursorToolSchemaProjection).toBeUndefined();
+		expect(otherCursorAnthropic.requiresCursorToolSchemaProjection).toBeUndefined();
+	});
+
 	it("preserves OpenRouter's mandatory provider-authored effort ladder", () => {
 		const models: ModelSpec<Api>[] = [
 			createSpec({

--- a/packages/catalog/test/generated-policies.test.ts
+++ b/packages/catalog/test/generated-policies.test.ts
@@ -123,6 +123,13 @@ describe("generated model policies", () => {
 		}
 		expect(grok.requiresCursorToolSchemaProjection).toBeUndefined();
 		expect(otherCursorAnthropic.requiresCursorToolSchemaProjection).toBeUndefined();
+
+		const rebuiltGrok = buildModel({
+			...fableModels[0],
+			id: "cursor-grok-4.6",
+			name: "cursor-grok-4.6",
+		});
+		expect(rebuiltGrok.requiresCursorToolSchemaProjection).toBeUndefined();
 	});
 
 	it("preserves OpenRouter's mandatory provider-authored effort ladder", () => {


### PR DESCRIPTION
**Minimal-change rationale:** this is the smallest complete correction to #10433. It keeps the existing, tested projection implementation unchanged and changes only its policy gate: one structured KDL capability is enabled for the confirmed Cursor Anthropic/Fable family, threaded to the existing tool builder, and absent by default. No model-ID matching, second sanitizer, compatibility shim, or provider-wide behavior is added. Grok and unconfirmed Cursor families return to the canonical schema they already accept.

## Problem

#10433 applied `sanitizeSchemaForCursor()` to every `cursor/*` model. The available evidence is model-specific:

- Senpi #952/#953 reproduced and verified only `claude-fable-5-thinking-xhigh`.
- OMP #10432 reproduced `claude-fable-5-high` and `claude-fable-5-medium` failing before token 1 with provider HTTP 400 / error `528384`.
- On the same unpatched `omp/18.0.11` install and default tool inventory (which advertises the built-in `task.outputSchema` `anyOf`), `cursor-grok-4.6` completed repeated turns and real tool calls. The final success occurred 46 seconds before #10433 merged.

Flattening Grok's accepted schema is therefore unnecessary fidelity loss, not a required Cursor-wide compatibility fix.

## Change

- Add the catalog policy axis `requires-cursor-tool-schema-projection`.
- Enable it in `providers/cursor.kdl` for structured `class=anthropic`, `family=fable` models only.
- Materialize the resolved fact as `Model.requiresCursorToolSchemaProjection`; it is omitted from `ModelSpec` so KDL remains the sole policy owner.
- Pass that fact into `buildMcpToolDefinitions()`.
- Default the builder to canonical/pass-through schemas; call the existing sanitizer only when the capability is true.
- Bake the capability into the five current bundled Cursor Fable rows and preserve canonical schemas for Grok and other Cursor models.

```text
Cursor Fable  capability=true  -> projected combiner-free schema
Cursor Grok   capability=false -> canonical schema with combiners preserved
Other Cursor  capability=false -> canonical schema until reproduced
```

The permissive projection/soundness fixes from `86b825e` are unchanged.

## Verification

- `bun test packages/ai/test/cursor-mcp-tool-catalog.test.ts packages/catalog/test/generated-policies.test.ts packages/catalog/test/compat-compile.test.ts packages/catalog/test/compat-cascade.test.ts` — 65 pass, 0 fail.
- `bun --cwd=packages/catalog run check:types` — pass.
- `bun --cwd=packages/ai run check:types` — pass.
- Biome check on all changed TypeScript files — pass.
- Runtime builder smoke: Fable resolves `requiresCursorToolSchemaProjection=true` and advertises the union probe without `anyOf`; Grok resolves false and advertises the canonical `anyOf` unchanged.

`gen:compat` and `gen:models` were run. Unrelated live-catalog drift from model regeneration was intentionally excluded; `models.json` contains only the five capability fields derived from the new KDL policy. This keeps the patch aligned with the repository's smallest-complete-change rule.

Fixes #10464