### PR TITLE
fix(theme): use a generic window glyph for the context icon

### DIFF
--- a/packages/coding-agent/src/modes/theme/symbols.ts
+++ b/packages/coding-agent/src/modes/theme/symbols.ts
@@ -786,8 +786,8 @@ const NERD_SYMBOLS: SymbolMap = {
 	"icon.pin": "\uf08d",
 	// pick:  | alt: ⊛ ◍ 
 	"icon.tokens": "\ue26b",
-	// pick:  | alt: ◫ ▦
-	"icon.context": "\ue70f",
+	// pick:  (nf-cod-window) | alt:  (nf-cod-empty_window) ◫ ▦
+	"icon.context": "\ueb7f",
 	// pick:  | alt: $ ¢
 	"icon.cost": "\uf155",
 	// pick: 󰙺 (nf-md-currency_usd_off)


### PR DESCRIPTION
The nerd symbol preset draws the status-line context segment with `\ue70f`. The Nerd Fonts registry names that codepoint `dev-windows` — it is the Microsoft Windows logo, not a generic window:

```
$ curl -s https://raw.githubusercontent.com/ryanoasis/nerd-fonts/master/glyphnames.json | jq -r 'to_entries[] | select(.value.code == "e70f") | .key'
dev-windows
```

So a session on Linux or macOS renders a Microsoft logo next to `12.4%/1M`, which reads as a platform badge rather than as "context window". The pun only lands if you already know the glyph is meant to be the second word of "context window".

This swaps it for `\ueb7f` (`cod-window`), a plain window outline. Codicons are already the house style for neighbouring picks in the same block — `icon.pr` is `\uea64` (`nf-cod-git_pull_request`) and `icon.advisor` is `\uea70` (`nf-cod-eye`) — so the weight and stroke match rather than importing a second icon family's look.

The `unicode` and `ascii` presets are untouched; they already use `◫` and `ctx:`.

### Scope

`icon.context` has one definition per preset and five consumers (`status-line/segments.ts` for `context_pct` and `context_total`, `compaction-summary-message.ts`, `model-browser.ts`, `setup-wizard/scenes/theme.ts`). No test or snapshot asserts the literal, so this is a two-line change with no call-site work.

### Verification

Rendered the status line through a real PTY before and after, counting the UTF-8 bytes of `U+E70F` (`EE 9C 8F`) in the captured output:

| | occurrences | segment |
|---|---|---|
| before | 1 | `· <logo> 4.5%/1M` |
| after | 0 | `· <window> 4.6%/1M` |

The percentage readout is unchanged; only the leading glyph differs.
