### PR TITLE
fix(edit): fail closed on pattern-only sloppy blocks

### DIFF
--- a/packages/coding-agent/src/edit/sloppy.md
+++ b/packages/coding-agent/src/edit/sloppy.md
@@ -6,12 +6,12 @@ Sparse edit format: name distinctive current fragments, elide the rest with `…
 One rewrite form per operation:
 - Inline: `⟪current│desired⟫` — changes inside lines (renames, operator flips, argument tweaks), several per operation, across lines; a selection MAY span lines for a contained replace. `⟪old│⟫` deletes.
 - Add line: `＋final text` on its own line inserts that line at its position; consecutive `＋` lines insert together. Mixes freely with inline selections.
-- Block: MATCH lines, `»`, REWRITE lines stating the final text — for moves and large restructures. Empty REWRITE deletes the whole MATCH.
+- Block: MATCH lines, `»`, REWRITE lines stating the final text — for moves and large restructures. Empty REWRITE deletes the whole MATCH (deprecated — prefer `⟪old│⟫` or `－`; a pattern-only block with no `»` fails closed with a fill-in skeleton).
 
 In MATCH: `…` = gap/capture — stays on its line between fragments, spans lines at line end. No markers → REWRITE replaces the whole MATCH.
 In REWRITE or a desired side: `…` re-emits captured gaps in order — one MATCH gap each; a `…` with no MATCH gap left to claim mid-line is written as a literal `…`, and alone on its line is an error (context elision — type the lines out).
 
-Move code by deleting it where it is (MATCH + `»` + empty REWRITE, or `⟪old lines│⟫`) and re-stating it with `＋` lines at its destination.
+Move code by deleting it where it is (`⟪old lines│⟫`, or MATCH + `»` + `»N` re-emit at the destination) and re-stating it with `＋` lines at its destination.
 </ops>
 
 <rules>

--- a/packages/coding-agent/src/edit/sloppy.md
+++ b/packages/coding-agent/src/edit/sloppy.md
@@ -11,7 +11,7 @@ One rewrite form per operation:
 In MATCH: `…` = gap/capture — stays on its line between fragments, spans lines at line end. No markers → REWRITE replaces the whole MATCH.
 In REWRITE or a desired side: `…` re-emits captured gaps in order — one MATCH gap each; a `…` with no MATCH gap left to claim mid-line is written as a literal `…`, and alone on its line is an error (context elision — type the lines out).
 
-Move code by deleting it where it is (`⟪old lines│⟫`, or MATCH + `»` + `»N` re-emit at the destination) and re-stating it with `＋` lines at its destination.
+Move code by deleting it where it is with `⟪old lines│⟫` and re-stating it with `＋` lines at its destination — or, to re-emit the deleted block verbatim, delete it with `⟪old lines│⟫` and reference it from the destination with a `»N` REWRITE line (`MATCH` + `»` + `»N`).
 </ops>
 
 <rules>

--- a/packages/coding-agent/src/edit/sloppy.test.ts
+++ b/packages/coding-agent/src/edit/sloppy.test.ts
@@ -1002,23 +1002,40 @@ describe("sloppy v8", () => {
 		expect(variant.apply(content, input, context)).toBe(`async function ensureMigrationsTable() {\n${block}\n}\n`);
 	});
 
-	test("applies a pattern-only block as the delete half of a move", () => {
+	test("rejects a pattern-only multi-line block even when a sibling op re-emits its text", () => {
 		const block = [
 			"  const parseAnsiRgb = (ansi: string): [number, number, number] | null => {",
 			"    return null;",
 			"  };",
 		].join("\n");
 		const content = `  const first = 0;\n\n${block}\n\n  const other = 1;\n\n  const getContrast = () => 2;\n`;
+		// The old move shape: op1 is a pattern-only block (no »), op2 re-emits its
+		// text. Deletion must be explicit now, so this fails closed.
 		const input = [
 			`${M.open}\n${block}`,
 			`${M.open}\n  const getContrast = () => 2;\n${M.put}\n${block}\n\n  const getContrast = () => 2;`,
 		].join("\n");
-		const notes: string[] = [];
 
-		expect(variant.apply(content, input, { path: context.path, notes })).toBe(
+		expect(() => variant.apply(content, input, context)).toThrow(/needs »/);
+	});
+
+	test("moves a block with an explicit deletion and a »N re-emit", () => {
+		const block = [
+			"  const parseAnsiRgb = (ansi: string): [number, number, number] | null => {",
+			"    return null;",
+			"  };",
+		].join("\n");
+		const content = `  const first = 0;\n\n${block}\n\n  const other = 1;\n\n  const getContrast = () => 2;\n`;
+		// Documented move idiom: delete explicitly with ⟪block│⟫, re-emit at the
+		// destination with »1 as the sole REWRITE line.
+		const input = [
+			`${M.open}\n${M.selectOpen}${block}${M.selectDivider}${M.selectClose}`,
+			`${M.open}\n  const getContrast = () => 2;\n${M.put}\n${M.put}1`,
+		].join("\n");
+
+		expect(variant.apply(content, input, context)).toBe(
 			`  const first = 0;\n\n  const other = 1;\n\n${block}\n\n  const getContrast = () => 2;\n`,
 		);
-		expect(notes.join("\n")).toContain("move deletion");
 	});
 
 	test("never adopts a gap-only remainder as rewrite text", () => {

--- a/packages/coding-agent/src/edit/sloppy.ts
+++ b/packages/coding-agent/src/edit/sloppy.ts
@@ -273,8 +273,6 @@ interface Operation {
 	sourcePatternText: string;
 	rewrite: OperationRewrite;
 	all: boolean;
-	/** Pattern-only op applied as a deletion; justified only when another op re-emits the block. */
-	assumedDeletion?: boolean;
 	/** Marker-less op read as desired text; a no-op means the assertion already holds. */
 	desiredState?: boolean;
 	/** Post-apply advisory for a formally invalid payload recovered at parse time. */
@@ -1179,7 +1177,6 @@ function parseOperations(input: string, content: string): Operation[] {
 		}
 		operations.push(createOperation(sourcePatternText, rewriteText, allMatches, operations.length + 1, true));
 	};
-	const pendingSeparatorErrors = new Map<number, string>();
 	const finishPattern = (endIndex: number) => {
 		const sourcePatternText = normalizeBlock(patternLines, false);
 		if (
@@ -1291,17 +1288,15 @@ function parseOperations(input: string, content: string): Operation[] {
 				return;
 			}
 		}
-		const needsSeparator = `Operation ${operations.length + 1} needs ${REWRITE_HEADER}.\nCopy-ready corrected payload (fill in the new text):\n${[...lines.slice(0, endIndex), REWRITE_HEADER, "<new text>", ...lines.slice(endIndex)].join("\n")}`;
-		// A multiline pattern-only block may be the delete half of a move; assume
-		// deletion now, justified post-parse only when another op re-emits it.
-		const normalizedPattern = normalizeText(sourcePatternText).text;
-		if (!sourcePatternText.includes("\n") || normalizedPattern.length < 24) {
-			throw new Error(needsSeparator);
-		}
-		const operation = createOperation(sourcePatternText, "", allMatches, operations.length + 1, true);
-		operation.assumedDeletion = true;
-		pendingSeparatorErrors.set(operations.length, needsSeparator);
-		operations.push(operation);
+		// An empty REWRITE is a whole-MATCH deletion; a pattern-only block with no
+		// separator never states a rewrite, so always fail closed with the fill-in
+		// skeleton. Multiline blocks used to be queued as assumed deletions
+		// (justified only when a sibling op re-emits them); that implicit-deletion
+		// ambiguity is the footgun behind accidental block deletions — deletion must
+		// be explicit (⟪old│⟫ / －).
+		throw new Error(
+			`Operation ${operations.length + 1} needs ${REWRITE_HEADER}.\nAn empty REWRITE deletes the whole MATCH; to delete, mark it explicitly with ${SELECT_OPEN}old${SELECT_DIVIDER}${SELECT_CLOSE} or ${REMOVE_LINE} lines.\nCopy-ready corrected payload (fill in the new text):\n${[...lines.slice(0, endIndex), REWRITE_HEADER, "<new text>", ...lines.slice(endIndex)].join("\n")}`,
+		);
 	};
 
 	for (let index = 0; index < lines.length; index++) {
@@ -1417,19 +1412,6 @@ function parseOperations(input: string, content: string): Operation[] {
 				}
 			}
 		}
-	}
-	for (const [index, message] of pendingSeparatorErrors) {
-		const patternNormalized = normalizeText(operations[index].patternText).text;
-		const justified = operations.some((other, otherIndex) => {
-			if (otherIndex === index) return false;
-			const rewrites = other.rewrite.kind === "explicit" ? [other.rewrite.text] : other.rewrite.replacements;
-			return rewrites.some(
-				rewrite =>
-					normalizeText(rewrite).text.includes(patternNormalized) ||
-					rewrite.split("\n").some(line => line.trim() === `${REWRITE_HEADER}${index + 1}`),
-			);
-		});
-		if (!justified) throw new Error(message);
 	}
 	return operations;
 }
@@ -3804,9 +3786,7 @@ function applyOperations(content: string, input: string, context: SloppyApplyCon
 				const deletedLines = prepared.deletedText.split("\n").filter(entry => entry.trim() !== "").length;
 				deletionNotes.set(
 					operationNumber,
-					operation.assumedDeletion
-						? `Note: operation ${operationNumber} had no ${REWRITE_HEADER} REWRITE and was applied as a move deletion (a later operation re-emits its block).`
-						: `Note: operation ${operationNumber} deleted ${deletedLines} line(s); an empty REWRITE means deletion — resend with the final text if you meant to replace.`,
+					`Note: operation ${operationNumber} deleted ${deletedLines} line(s); an empty REWRITE means deletion — resend with the final text if you meant to replace, or mark deletion explicitly with ${SELECT_OPEN}old${SELECT_DIVIDER}${SELECT_CLOSE} / ${REMOVE_LINE} lines.`,
 				);
 			}
 			lastMatchOffset = candidate.matchStart;


### PR DESCRIPTION
## Background from the author

While using OMP I noticed the edit flow was often slow and costly. Digging into it, I found the root cause was a loop: the tool would delete, then mis-delete again in a cycle, and then keep re-filling those mis-deleted blocks — that repeated cycle is what produced this bug. This change stops it at the source by failing closed on ambiguous pattern-only blocks.

## Summary

The sloppy edit dialect could silently delete whole MATCH blocks. When a payload contained a **multi-line pattern-only block with no `»` REWRITE separator** (≥24 normalized chars), the parser parked it as an *assumed deletion* and applied it whenever a sibling operation re-emitted the same text. A model that was merely quoting a block — or that intended a single-line change but emitted the block with nothing after it — would get that block deleted from the file, requiring manual recovery. Reported 6+ times in one session (issue #10470).

This PR makes that path fail closed:

- **Pattern-only blocks always throw.** A MATCH with no `»` separator now unconditionally raises `Operation N needs ».` regardless of line count, length, or whether a sibling op re-emits the text. The error message now also warns explicitly that an empty REWRITE deletes the whole MATCH, and that deletion must be stated explicitly with `⟪old│⟫` or `－` lines.
- **Removed the assumed-deletion machinery**: the `assumedDeletion` flag, the `pendingSeparatorErrors` parking map, and the post-parse justification loop are gone.
- **The documented move idiom survives unchanged** via the explicit form: `⟪block│⟫` deletion + `»N` re-emit at the destination produces byte-identical results (covered by the new test).

## Behavior preserved (not removed)

- Explicit empty REWRITE (`MATCH` + `»` + nothing) still deletes — intentional, documented semantics; this PR deprecates the *implicit* deletion path only.
- `»N` re-emit, `⟪old│⟫` / `－` inline deletions, and `expandFullLineDeletion` are untouched.

## Tests

- `packages/coding-agent/src/edit/sloppy.test.ts`: 181 pass (the old move test rewritten into two — rejects the implicit form, asserts the explicit `»N` move form is byte-identical).
- Manual repro against the compiled binary: a multi-line pattern-only block now returns the `needs »` error with the empty-REWRITE warning and applies nothing.

## Checklist

- [x] `bun test packages/coding-agent/src/edit/sloppy.test.ts` — 181 pass / 0 fail
- [x] `tsgo` type-check, `oxfmt`, `oxlint` — clean
- [x] Only 3 files changed (+33/−36), no unrelated churn
