### PR TITLE
fix(ai): recognized Bedrock thinking-signature rejections

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Anthropic-compatible endpoints backed by Amazon Bedrock permanently rejecting a session once an unsigned thinking block entered its history. The transport now recognizes Bedrock's `ValidationException … thinking.signature: Field required` as the same unsigned-thinking rejection it already heals for other signing proxies, so it demotes the unsigned block to text, retries once, and remembers the endpoint for the rest of the session instead of failing every turn and walking the model fallback chain.
+
 ## [18.1.2] - 2026-09-01
 
 ### Added

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -424,12 +424,11 @@ type AnthropicProviderSessionState = ProviderSessionState & {
 	strictToolsDisabled: boolean;
 	fastModeDisabled: boolean;
 	/**
-	 * Runtime-learned: this endpoint returned `400 Invalid signature in
-	 * thinking block` for a replayed unsigned thinking block, so it must be
-	 * treated as a signing proxy from now on. All subsequent requests demote
-	 * unsigned thinking to text for this (baseUrl, modelId), same behavior as
-	 * an explicit `compat.replayUnsignedThinking: false`. Cleared on session
-	 * close.
+	 * Runtime-learned: this endpoint rejected a replayed unsigned thinking
+	 * block, so it must be treated as a signing proxy from now on. All
+	 * subsequent requests demote unsigned thinking to text for this (baseUrl,
+	 * modelId), same behavior as an explicit
+	 * `compat.replayUnsignedThinking: false`. Cleared on session close.
 	 */
 	replayUnsignedThinkingDisabled: boolean;
 	/** Thinking blocks the API permanently dropped after a prefix mismatch. */
@@ -1863,11 +1862,20 @@ function calculateFallbackTurnCost(
 }
 
 /**
- * Detects the Anthropic `400 Invalid `signature` in `thinking` block` failure
- * a signing proxy returns when a stripped/unsigned prior thinking block is
- * replayed as `signature: ""`. Exported for the compat tests.
+ * Detects the two shapes a signature-enforcing endpoint uses to reject a
+ * replayed unsigned thinking block (sent as `signature: ""`):
+ *
+ * - Anthropic and Anthropic-fronting proxies: `400 Invalid `signature` in
+ *   `thinking` block`.
+ * - Bedrock-backed proxies: the empty string fails schema validation before
+ *   signature checking, so it comes back as `ValidationException: The model
+ *   returned the following errors: messages.N.content.M.thinking.signature:
+ *   Field required`.
+ *
+ * Exported for the compat tests.
  */
 const INVALID_THINKING_SIGNATURE_PATTERN = /invalid\s+`?signature`?\s+in\s+`?thinking`?(?:\s+block)?/i;
+const MISSING_THINKING_SIGNATURE_PATTERN = /thinking\.signature\b[^"\n]{0,32}\brequired\b/i;
 const THINKING_PREFIX_BINDING_PATTERN =
 	/(?:bound to a different conversation|block_binding\.prefix_mismatch_behavior|prefix_mismatch_behavior)/i;
 
@@ -1877,7 +1885,7 @@ export function isThinkingPrefixBindingError(message: string): boolean {
 }
 
 export function isInvalidThinkingSignatureError(message: string): boolean {
-	return INVALID_THINKING_SIGNATURE_PATTERN.test(message);
+	return INVALID_THINKING_SIGNATURE_PATTERN.test(message) || MISSING_THINKING_SIGNATURE_PATTERN.test(message);
 }
 
 const INPUT_TRANSFORMATION_PATH_PATTERN = /^messages\.(\d+)\.content\.(\d+)$/;
@@ -1956,8 +1964,8 @@ function applyReportedInputTransformations(
 }
 
 /**
- * Prepend a pointed remediation to Anthropic's `Invalid signature in thinking
- * block` 400 when the model looks like an unmarked custom signing proxy
+ * Prepend a pointed remediation to a thinking-signature rejection 400 when the
+ * model looks like an unmarked custom signing proxy
  * (opaque baseUrl, `spec.reasoning: true`, no explicit
  * `compat.replayUnsignedThinking` override). The default is native replay for
  * the 3p reasoning majority (#2005); this hint turns the misconfigured-proxy
@@ -2968,7 +2976,7 @@ const streamAnthropicOnce = (
 						isInvalidThinkingSignatureError(streamFailureMessage)
 					) {
 						logger.warn(
-							"anthropic: signing proxy detected (Invalid signature in thinking block), demoting unsigned thinking and retrying",
+							"anthropic: signing proxy detected (thinking signature rejected), demoting unsigned thinking and retrying",
 							{
 								provider: model.provider,
 								model: model.id,

--- a/packages/ai/test/anthropic-signature-auto-mark.test.ts
+++ b/packages/ai/test/anthropic-signature-auto-mark.test.ts
@@ -67,6 +67,19 @@ function createSignatureRejection(): Error {
 	return error;
 }
 
+/**
+ * Bedrock-backed anthropic-messages proxies reject the same `signature: ""`
+ * replay in schema validation instead of the signature check, so the wording is
+ * a missing required field rather than an invalid signature.
+ */
+function createBedrockSignatureRejection(): Error {
+	const error = new Error(
+		'400 {"type":"error","error":{"type":"ValidationException","message":"The model returned the following errors: messages.1.content.0.thinking.signature: Field required"}}',
+	);
+	Object.assign(error, { status: 400 });
+	return error;
+}
+
 interface AnthropicWireBlock {
 	type: string;
 	thinking?: string;
@@ -197,6 +210,42 @@ describe("#4297 anthropic-messages runtime signing auto-mark", () => {
 
 		expect(readReplayUnsignedThinkingDisabled(providerSessionState)).toBe(true);
 		expect(result.disabledFeatures).toContain("unsigned-thinking-replay");
+	});
+
+	it("also heals the Bedrock missing-signature wording", async () => {
+		const providerSessionState = new Map<string, ProviderSessionState>();
+		const capturedPayloads: unknown[] = [];
+		let attempt = 0;
+		vi.spyOn(AnthropicMessages.prototype, "create").mockImplementation((params: unknown) => {
+			attempt += 1;
+			capturedPayloads.push(params);
+			if (attempt === 1) {
+				return {
+					async withResponse() {
+						throw createBedrockSignatureRejection();
+					},
+				} as never;
+			}
+			return successRequest() as never;
+		});
+
+		const stream = streamAnthropic(model, priorTurnContext, {
+			apiKey: "sk-ant-test",
+			providerSessionState,
+		});
+		for await (const _ of stream) {
+			/* drain */
+		}
+		const result = await stream.result();
+
+		expect(attempt).toBe(2);
+		expect(result.stopReason).toBe("stop");
+		expect(result.errorMessage).toBeUndefined();
+
+		const retryBlocks = extractPriorAssistantBlocks(capturedPayloads[1]);
+		expect(retryBlocks.find(block => block.type === "thinking")).toBeUndefined();
+		expect(retryBlocks.find(block => block.type === "text")?.text).toContain("Read the file, then summarise.");
+		expect(readReplayUnsignedThinkingDisabled(providerSessionState)).toBe(true);
 	});
 
 	it("pre-demotes unsigned thinking on subsequent turns once the session is pinned", async () => {

--- a/packages/ai/test/anthropic-signature-hint.test.ts
+++ b/packages/ai/test/anthropic-signature-hint.test.ts
@@ -34,6 +34,11 @@ const SIGNATURE_400 =
 const PREFIX_BINDING_400 =
 	'400 {"message":"messages.1.content.0: Invalid `signature` in `thinking` block. The block is bound to a different conversation. Remove the block, or set `thinking.block_binding.prefix_mismatch_behavior` to \\"drop_block\\".","type":"invalid_request_error"}';
 
+// Bedrock-backed proxies fail `signature: ""` in schema validation, before the
+// signature check, so the same replay comes back as a missing required field.
+const BEDROCK_SIGNATURE_400 =
+	'400 {"type":"error","error":{"type":"ValidationException","message":"The model returned the following errors: messages.369.content.0.thinking.signature: Field required"}}';
+
 describe("#4297 anthropic-messages replay-unsigned-thinking hint", () => {
 	it("recognises the Anthropic 400 invalid-thinking-signature body", () => {
 		expect(isInvalidThinkingSignatureError(SIGNATURE_400)).toBe(true);
@@ -52,9 +57,17 @@ describe("#4297 anthropic-messages replay-unsigned-thinking hint", () => {
 		expect(maybeAddReplayUnsignedThinkingHint(model, PREFIX_BINDING_400)).toBe(PREFIX_BINDING_400);
 	});
 
+	it("recognises the Bedrock ValidationException missing-signature body", () => {
+		expect(isInvalidThinkingSignatureError(BEDROCK_SIGNATURE_400)).toBe(true);
+		expect(isInvalidThinkingSignatureError("messages.0.content.0.thinking.signature: Field required")).toBe(true);
+		expect(isInvalidThinkingSignatureError("content.2.thinking.signature is required")).toBe(true);
+	});
+
 	it("does not fire on unrelated errors", () => {
 		expect(isInvalidThinkingSignatureError("400 rate_limit_error")).toBe(false);
 		expect(isInvalidThinkingSignatureError("Bad Request: missing 'model'")).toBe(false);
+		// Names a different required field on a thinking block, not its signature.
+		expect(isInvalidThinkingSignatureError("messages.1.content.0.thinking.thinking: Field required")).toBe(false);
 	});
 
 	it("prepends a provider-scoped remediation on unmarked custom signing proxies", () => {
@@ -65,6 +78,12 @@ describe("#4297 anthropic-messages replay-unsigned-thinking hint", () => {
 		expect(surfaced).toContain("compat.replayUnsignedThinking: false");
 		expect(surfaced).toContain("providers.cf-anthropic");
 		expect(surfaced).toContain(SIGNATURE_400);
+	});
+
+	it("prepends the same remediation on the Bedrock wording", () => {
+		const surfaced = maybeAddReplayUnsignedThinkingHint(buildAnthropicMessagesModel(), BEDROCK_SIGNATURE_400);
+		expect(surfaced).toContain("compat.replayUnsignedThinking: false");
+		expect(surfaced).toContain(BEDROCK_SIGNATURE_400);
 	});
 
 	it("passes through when the user already set `compat.replayUnsignedThinking`", () => {


### PR DESCRIPTION
I'm a human and I approve this LLM output! 

## Problem

An `anthropic-messages` endpoint that sits in front of Amazon Bedrock permanently breaks a session as soon as one unsigned thinking block lands in its history.

History thinking blocks that carry no signature are replayed as `signature: ""`. Signature-enforcing endpoints reject that, and the transport already self-heals: `isInvalidThinkingSignatureError` spots the rejection, unsigned thinking is demoted to text, the request is retried once, and the `(baseUrl, modelId)` is pinned as signing so later turns skip the round trip.

Bedrock fails the empty string in schema validation, before the signature check, so its wording is a missing field rather than an invalid signature:

```
400 {"type":"error","error":{"type":"ValidationException","message":"The model returned the following errors: messages.369.content.0.thinking.signature: Field required"}}
```

The detector only matched `Invalid `signature` in `thinking` block`, so the heal never ran. Consequences, all observed in one session against a Bedrock-fronting proxy:

- Every turn on every Claude model 400s on the same history message. Deterministic, so backoff cannot clear it.
- The only way forward is `hardErrorFallback` walking the model chain to a non-Anthropic model.
- That makes it worse: the fallback model's reasoning blocks are also unsigned, so returning to Claude is now guaranteed to fail. One poisoned block grew to 72 over a few hours.

## Change

`isInvalidThinkingSignatureError` also matches the Bedrock shape (`thinking.signature … required`). Everything downstream — demote, single retry, session pin, the `compat.replayUnsignedThinking: false` remediation hint — is unchanged and now fires for these endpoints.

The two neighbouring comments and the detection log line no longer quote just the Anthropic wording.

## Tests

- `anthropic-signature-hint.test.ts`: the Bedrock body is recognised and gets the same remediation; a `ValidationException` naming a different required field on a thinking block does not match.
- `anthropic-signature-auto-mark.test.ts`: a Bedrock rejection on the first attempt demotes the unsigned block, retries once, succeeds, and pins the session.

`packages/ai` suite: 4360 pass, 3 fail. The 3 failures (`AuthStorage OAuth refresh race` ×2, `getProxyForProvider`) reproduce identically on `main` at 7523a2d7c6 and pass in isolation.

Also replayed all 20 captured 400 bodies from the affected session through the new detector: 20/20 recognised.
