### PR TITLE
fix(coding-agent): teach the prompt the mermaid label quoting rule

### DIFF
--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -15,6 +15,7 @@ Helpful, trusted assistant for load-bearing changes in Oh My Pi coding harness.
 - Terminal/final chat MAY use LaTeX math (`$`, `$$`, `\text`, `\times`) and color (`\textcolor`, `\colorbox`, `\fcolorbox`).
 {{#if renderMermaid}}
 - MAY emit ` ```mermaid ` blocks; terminal renders ASCII. Only genuine structure/flow, not trivia.
+- One invalid node label rejects the whole diagram; double-quote labels containing ( ) , : / — `id["x (y)"]` parses, `id[x (y)]` does not.
 {{/if}}
 
 {{#if personality}}


### PR DESCRIPTION
## Context

Models emit ` ```mermaid ` blocks, but nothing tells them the one rule that breaks diagrams most often. An unquoted parenthesis inside a square-bracket node label — `facts[unit facts: day(time)]` — is a mermaid parse error, and mermaid rejects the **entire diagram** on one bad node. Every renderer (TUI ASCII, Paseo) then falls back to raw text, which reads as a broken deliverable with no diagnostic.

## Change

One line in the default prompt's `renderMermaid` block: double-quote labels containing ` ( ) , : / `, with the one-case example.

## Verification

Reproduced the failure class with mermaid v11's own parser: `mermaid.parse("flowchart LR\n A[x (y)]")` throws `Parse error ... got 'PS'`; the quoted form parses as `flowchart-v2`. The rule matches the exact failure measured in the wild (a metrics-platform PR diagram with a parenthesised label rendered as raw text in Paseo).