### PR TITLE
fix(coding-agent): rebind active model after background discovery

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed a fresh session keeping a stale pre-discovery context window (e.g. GitHub Copilot `gpt-5.6-sol` running at 1.05M instead of 400K) when background discovery re-clamps a selector after startup; the active model now rebinds to its refreshed catalog entry once discovery settles, so context usage and compaction thresholds match the catalog without a manual re-selection ([#10488](https://github.com/can1357/oh-my-pi/issues/10488)).
+
 ## [18.1.1] - 2026-09-01
 
 ### Fixed

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -1169,6 +1169,7 @@ export async function buildSessionOptions(
 			}
 		} else if (resolved.model) {
 			options.model = resolved.model;
+			options.rebindModelAfterDiscovery = true;
 			// The recorded role must carry the effort the session actually starts
 			// at, or the first cycle back into `default` overrides it.
 			activeSettings.overrideModelRoles({
@@ -1202,6 +1203,7 @@ export async function buildSessionOptions(
 				: scopedModels.find(scopedModel => scopedModel.model.id.toLowerCase() === remembered.toLowerCase());
 			if (rememberedModel) {
 				options.model = rememberedModel.model;
+				options.rebindModelAfterDiscovery = true;
 				// Apply explicit thinking level from remembered role value
 				if (!parsed.thinking && rememberedSpec.explicitThinkingLevel && rememberedSpec.thinkingLevel) {
 					options.thinkingLevel = rememberedSpec.thinkingLevel;
@@ -1221,7 +1223,10 @@ export async function buildSessionOptions(
 		// deferring under an explicit CLI scope would let the saved default
 		// escape it — keep pinning the first scoped model there.
 		deferredDefaultRole = !options.model && Boolean(remembered) && !((parsed.models?.length ?? 0) > 0);
-		if (!options.model && !deferredDefaultRole) options.model = scopedModels[0].model;
+		if (!options.model && !deferredDefaultRole) {
+			options.model = scopedModels[0].model;
+			options.rebindModelAfterDiscovery = true;
+		}
 	} else if ((parsed.models?.length ?? 0) > 0 && !restoringSession) {
 		// A CLI `--models` scope that resolved to zero models at startup: its
 		// selectors name only models supplied by extension providers (or discovery)

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -386,6 +386,13 @@ export interface CreateAgentSessionOptions {
 
 	/** Model to use. Default: from settings, else first available */
 	model?: Model;
+	/**
+	 * Allow an explicit {@link model} to be rebound to its same-selector registry
+	 * entry after initial background discovery. The CLI enables this for models
+	 * it resolved from the registry; SDK-supplied model objects default to false
+	 * so caller-owned routing and limits remain authoritative.
+	 */
+	rebindModelAfterDiscovery?: boolean;
 	/** Raw model pattern(s) (e.g. from --model CLI flag) to resolve after extensions load.
 	 * Used when model lookup is deferred because extension-provided models aren't registered yet. */
 	modelPattern?: string | string[];
@@ -3668,6 +3675,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			skillsReloadable: options.skills === undefined,
 			skillsSettings: settings.getGroup("skills"),
 			modelRegistry,
+			rebindModelAfterDiscovery: options.model === undefined || options.rebindModelAfterDiscovery === true,
 			toolRegistry,
 			memoryAgentDir: agentDir,
 			memoryTaskDepth: taskDepth,

--- a/packages/coding-agent/src/session/agent-session-types.ts
+++ b/packages/coding-agent/src/session/agent-session-types.ts
@@ -197,6 +197,8 @@ export interface AgentSessionConfig {
 	createInspectImageTool?: () => Promise<AgentTool | null>;
 	/** Model registry for API key resolution and model discovery. */
 	modelRegistry: ModelRegistry;
+	/** Whether the startup model may be replaced by refreshed same-selector registry metadata. */
+	rebindModelAfterDiscovery?: boolean;
 	/** Tool registry for LSP and settings. */
 	toolRegistry?: Map<string, AgentTool>;
 	/** Creates tools registered only while vibe mode is active. */

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -7843,7 +7843,6 @@ export class AgentSession {
 	async #setModelWithProviderSessionReset(model: Model): Promise<void> {
 		const currentModel = this.model;
 		const isChanging = !currentModel || !modelsAreEqual(currentModel, model);
-		const codeModeChanged = this.#tools.codeModeChangesBetween(currentModel, model);
 		if (currentModel) {
 			this.#closeProviderSessionsForModelSwitch(currentModel, model);
 			if (isChanging) {
@@ -7868,10 +7867,14 @@ export class AgentSession {
 			this.#emit({ type: "model_changed" });
 		}
 
+		await this.#reconcileModelDependentState(currentModel, model);
+	}
+
+	async #reconcileModelDependentState(previousModel: Model | undefined, model: Model): Promise<void> {
 		// Re-evaluate append-only context mode — provider or setting may have changed
 		this.#syncAppendOnlyContext(model);
 
-		if (codeModeChanged || this.#tools.codeModeDirectWireMetadataChanged()) {
+		if (this.#tools.codeModeChangesBetween(previousModel, model) || this.#tools.codeModeDirectWireMetadataChanged()) {
 			try {
 				await this.#tools.reconcileCodeMode();
 			} catch (error) {
@@ -7880,9 +7883,8 @@ export class AgentSession {
 		}
 
 		// inspect_image auto mode keys off model image capability. Reconcile
-		// centrally here so retry-fallback model changes (turn-recovery.ts),
-		// which bypass syncAfterModelChange, cannot leave the tool set stale —
-		// callers await, so a scheduled retry never races the reconciled slate.
+		// centrally here so retry-fallback and metadata-only model changes cannot
+		// leave the tool set stale.
 		try {
 			await this.#tools.reconcileInspectImageAfterModelChange();
 		} catch (error) {
@@ -10009,13 +10011,14 @@ export class AgentSession {
 	 * 400K catalog value until the user re-selects the same model. Re-look-up the
 	 * active selector post-discovery and, when its context window changed, fold
 	 * the refreshed spec into the live model. Same selector, so this is a metadata
-	 * refresh (compaction thresholds, context display, `get_state`) — no
-	 * provider-session reset — mirroring `#refreshLazyLocalContext`;
-	 * `model_changed` notifies the status line and RPC subscribers. Issue #10488.
+	 * refresh with no provider-session reset; reconcile model-dependent tools and
+	 * append-only state before `model_changed` notifies the status line and RPC
+	 * subscribers. Issue #10488.
 	 */
 	async #rebindActiveModelAfterModelDiscovery(): Promise<void> {
 		const boundAtStartup = this.model;
 		if (this.#isDisposed || !boundAtStartup) return;
+		if (typeof this.#modelRegistry.awaitInitialBackgroundRefresh !== "function") return;
 		await this.#modelRegistry.awaitInitialBackgroundRefresh(this.#modelDiscoveryAbortController.signal);
 		if (this.#isDisposed) return;
 		// Only silently re-metadata the startup-bound selector: bail if the user
@@ -10025,6 +10028,8 @@ export class AgentSession {
 		const refreshed = this.#modelRegistry.find(current.provider, current.id);
 		if (!refreshed || refreshed.contextWindow === current.contextWindow) return;
 		this.agent.setModel(refreshed);
+		await this.#reconcileModelDependentState(current, refreshed);
+		if (this.#isDisposed) return;
 		this.#emit({ type: "model_changed" });
 	}
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -655,7 +655,7 @@ export class AgentSession {
 	#autolearnCaptureAbortController: AbortController | undefined;
 	#autolearnCaptureTask: Promise<void> | undefined;
 	#isDisposed = false;
-	#fallbackDiscoveryRevalidationAbortController = new AbortController();
+	#modelDiscoveryAbortController = new AbortController();
 	/** Process-wide by default (double-spend safety across sessions); injectable for tests. */
 	#codexResetCoordinator: CodexAutoRedeemCoordinator;
 	// Extension system
@@ -1757,10 +1757,12 @@ export class AgentSession {
 		// fire-and-forget (before the session in the SDK path, right after it in
 		// the CLI path), so discovery-backed providers (e.g. GitHub Copilot, or a
 		// models.yml LiteLLM provider with a cold cache) may not be populated yet.
-		// Reactivate a `no_model` advisor (#9010) and retract stale
-		// retry.fallbackChains warnings (#10048) once discovery settles.
+		// Reactivate a `no_model` advisor (#9010), retract stale
+		// retry.fallbackChains warnings (#10048), and rebind the active model to
+		// its refreshed same-selector entry (#10488) once discovery settles.
 		void this.#retryInactiveAdvisorAfterModelDiscovery();
 		void this.#revalidateFallbackChainsAfterModelDiscovery();
+		void this.#rebindActiveModelAfterModelDiscovery();
 	}
 	/** Model registry for API key resolution and model discovery */
 	get modelRegistry(): ModelRegistry {
@@ -4218,7 +4220,7 @@ export class AgentSession {
 	 */
 	beginDispose(): void {
 		this.#isDisposed = true;
-		this.#fallbackDiscoveryRevalidationAbortController.abort();
+		this.#modelDiscoveryAbortController.abort();
 		this.#queuedMessageDrainBlocked = false;
 		this.#usagePreflightReadyForNextModelCall = false;
 		this.#detachUsageBeforeQueueDequeue?.();
@@ -9985,13 +9987,45 @@ export class AgentSession {
 	 */
 	async #revalidateFallbackChainsAfterModelDiscovery(): Promise<void> {
 		if (this.#isDisposed || !this.#recovery.hasPendingDiscoveryDeferredFallbackValidation()) return;
-		await this.#modelRegistry.awaitInitialBackgroundRefresh(
-			this.#fallbackDiscoveryRevalidationAbortController.signal,
-		);
+		await this.#modelRegistry.awaitInitialBackgroundRefresh(this.#modelDiscoveryAbortController.signal);
 		if (this.#isDisposed) return;
 		if (this.#recovery.revalidateRetryFallbackChainsAfterDiscovery()) {
 			this.#emit({ type: "config_warnings_changed" });
 		}
+	}
+
+	/**
+	 * Rebind the active model to its refreshed registry entry once the initial
+	 * background discovery settles.
+	 *
+	 * Startup resolves the active model from the pre-discovery catalog snapshot
+	 * (`main.ts` fires `refreshInBackground` only after the session is built), so
+	 * a discovery-backed provider that re-clamps or splits a selector after the
+	 * fact leaves the live model holding stale metadata. GitHub Copilot caps a
+	 * tiered base selector (e.g. `github-copilot/gpt-5.6-sol`) to its default-tier
+	 * context window and synthesizes a separate `-1m` sibling only during live
+	 * discovery; the bundled base entry still carries the full long-context
+	 * window, so a fresh session runs with the 1.05M window that contradicts the
+	 * 400K catalog value until the user re-selects the same model. Re-look-up the
+	 * active selector post-discovery and, when its context window changed, fold
+	 * the refreshed spec into the live model. Same selector, so this is a metadata
+	 * refresh (compaction thresholds, context display, `get_state`) — no
+	 * provider-session reset — mirroring `#refreshLazyLocalContext`;
+	 * `model_changed` notifies the status line and RPC subscribers. Issue #10488.
+	 */
+	async #rebindActiveModelAfterModelDiscovery(): Promise<void> {
+		const boundAtStartup = this.model;
+		if (this.#isDisposed || !boundAtStartup) return;
+		await this.#modelRegistry.awaitInitialBackgroundRefresh(this.#modelDiscoveryAbortController.signal);
+		if (this.#isDisposed) return;
+		// Only silently re-metadata the startup-bound selector: bail if the user
+		// switched models while discovery was in flight.
+		const current = this.model;
+		if (!current || !modelsAreEqual(current, boundAtStartup)) return;
+		const refreshed = this.#modelRegistry.find(current.provider, current.id);
+		if (!refreshed || refreshed.contextWindow === current.contextWindow) return;
+		this.agent.setModel(refreshed);
+		this.#emit({ type: "model_changed" });
 	}
 
 	/**

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1762,7 +1762,7 @@ export class AgentSession {
 		// its refreshed same-selector entry (#10488) once discovery settles.
 		void this.#retryInactiveAdvisorAfterModelDiscovery();
 		void this.#revalidateFallbackChainsAfterModelDiscovery();
-		void this.#rebindActiveModelAfterModelDiscovery();
+		if (config.rebindModelAfterDiscovery) void this.#rebindActiveModelAfterModelDiscovery();
 	}
 	/** Model registry for API key resolution and model discovery */
 	get modelRegistry(): ModelRegistry {

--- a/packages/coding-agent/test/agent-session-retry-fallback.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-fallback.test.ts
@@ -5434,6 +5434,7 @@ describe("AgentSession retry fallback", () => {
 			sessionManager: SessionManager.inMemory(),
 			settings,
 			modelRegistry: registry,
+			rebindModelAfterDiscovery: true,
 			toolRegistry: new Map([[inspectImageTool.name, inspectImageTool]]),
 		});
 

--- a/packages/coding-agent/test/agent-session-retry-fallback.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-fallback.test.ts
@@ -5375,6 +5375,88 @@ describe("AgentSession retry fallback", () => {
 		await registry.awaitInitialBackgroundRefresh();
 	});
 
+	it("rebinds the active model to its post-discovery same-selector window (#10488)", async () => {
+		// A discovery-backed provider whose live catalog caps a selector below the
+		// window the pre-discovery snapshot carried at startup — the same class as
+		// the GitHub Copilot gpt-5.6-sol split, where the bundled base ships the
+		// full long-context window and discovery caps it to the default tier.
+		authStorage.setRuntimeApiKey("ollama-cloud", "ollama-cloud-test-key");
+		const buildTieredModel = (contextWindow: number): Model<"ollama-chat"> =>
+			buildModel({
+				id: "deepseek-v4-tiered",
+				name: "DeepSeek V4 Tiered",
+				api: "ollama-chat",
+				provider: "ollama-cloud",
+				baseUrl: "https://ollama.com",
+				reasoning: true,
+				input: ["text"],
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+				contextWindow,
+				maxTokens: 32_000,
+			});
+		// Post-discovery catalog: the capped entry the registry resolves for the
+		// selector once background discovery settles.
+		writeModelCache(
+			"ollama-cloud",
+			Date.now(),
+			[buildTieredModel(400_000)],
+			true,
+			"",
+			path.join(tempDir.path(), "models.db"),
+		);
+		const registry = new ModelRegistry(authStorage, path.join(tempDir.path(), "models.json"));
+
+		// The startup-bound model is the pre-discovery snapshot for the SAME
+		// selector with the full long-context window — what buildSessionOptions
+		// pins as options.model before discovery runs.
+		const staleModel = buildTieredModel(1_050_000);
+		const settings = Settings.isolated({ "compaction.enabled": false });
+		const agent = new Agent({
+			getApiKey: model => `${model.provider}-test-key`,
+			initialState: { model: staleModel, systemPrompt: ["Test"], tools: [], messages: [] },
+			streamFn: () => {
+				throw new Error("Not exercised");
+			},
+		});
+
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry: registry,
+		});
+
+		// Stale until discovery settles: the active model and its context-usage
+		// derivation both carry the 1.05M window that contradicts the catalog.
+		expect(session.model?.contextWindow).toBe(1_050_000);
+		expect(session.getContextUsage()?.contextWindow).toBe(1_050_000);
+
+		const modelChanged = new Promise<void>(resolve => {
+			const unsubscribe = session!.subscribe(event => {
+				if (event.type === "model_changed") {
+					unsubscribe();
+					resolve();
+				}
+			});
+		});
+
+		// The CLI starts discovery only after the session is built; the rebind
+		// waiter armed in the constructor resolves once this settles.
+		registry.refreshInBackground("offline");
+		await Promise.race([
+			modelChanged,
+			scheduler.wait(5_000).then(() => {
+				throw new Error("model_changed was not emitted after discovery settled");
+			}),
+		]);
+
+		// Rebound to the same selector's refreshed 400K window without a manual
+		// re-selection; get_state / contextUsage now agree with the catalog.
+		expect(session.model?.id).toBe("deepseek-v4-tiered");
+		expect(session.model?.contextWindow).toBe(400_000);
+		expect(session.getContextUsage()?.contextWindow).toBe(400_000);
+	});
+
 	it("warns on unknown or malformed model-selector chain keys at startup", () => {
 		const primaryModel = getBundledModel("openai", "gpt-4o-mini");
 		if (!primaryModel) {

--- a/packages/coding-agent/test/agent-session-retry-fallback.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-fallback.test.ts
@@ -5443,13 +5443,13 @@ describe("AgentSession retry fallback", () => {
 		expect(session.getContextUsage()?.contextWindow).toBe(1_050_000);
 		expect(session.inspectImageState().active).toBe(false);
 
-		const inspectImageActiveAtNotification = new Promise<boolean>(resolve => {
-			const unsubscribe = session!.subscribe(event => {
-				if (event.type === "model_changed") {
-					unsubscribe();
-					resolve(session!.inspectImageState().active);
-				}
-			});
+		const { promise: inspectImageActiveAtNotification, resolve: resolveInspectImageActiveAtNotification } =
+			Promise.withResolvers<boolean>();
+		const unsubscribe = session.subscribe(event => {
+			if (event.type === "model_changed") {
+				unsubscribe();
+				resolveInspectImageActiveAtNotification(session!.inspectImageState().active);
+			}
 		});
 
 		// The CLI starts discovery only after the session is built; the rebind

--- a/packages/coding-agent/test/agent-session-retry-fallback.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-fallback.test.ts
@@ -5381,7 +5381,7 @@ describe("AgentSession retry fallback", () => {
 		// the GitHub Copilot gpt-5.6-sol split, where the bundled base ships the
 		// full long-context window and discovery caps it to the default tier.
 		authStorage.setRuntimeApiKey("ollama-cloud", "ollama-cloud-test-key");
-		const buildTieredModel = (contextWindow: number): Model<"ollama-chat"> =>
+		const buildTieredModel = (contextWindow: number, input: Model<"ollama-chat">["input"]): Model<"ollama-chat"> =>
 			buildModel({
 				id: "deepseek-v4-tiered",
 				name: "DeepSeek V4 Tiered",
@@ -5389,7 +5389,7 @@ describe("AgentSession retry fallback", () => {
 				provider: "ollama-cloud",
 				baseUrl: "https://ollama.com",
 				reasoning: true,
-				input: ["text"],
+				input,
 				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 				contextWindow,
 				maxTokens: 32_000,
@@ -5399,7 +5399,7 @@ describe("AgentSession retry fallback", () => {
 		writeModelCache(
 			"ollama-cloud",
 			Date.now(),
-			[buildTieredModel(400_000)],
+			[buildTieredModel(400_000, ["text"])],
 			true,
 			"",
 			path.join(tempDir.path(), "models.db"),
@@ -5409,7 +5409,7 @@ describe("AgentSession retry fallback", () => {
 		// The startup-bound model is the pre-discovery snapshot for the SAME
 		// selector with the full long-context window — what buildSessionOptions
 		// pins as options.model before discovery runs.
-		const staleModel = buildTieredModel(1_050_000);
+		const staleModel = buildTieredModel(1_050_000, ["text", "image"]);
 		const settings = Settings.isolated({ "compaction.enabled": false });
 		const agent = new Agent({
 			getApiKey: model => `${model.provider}-test-key`,
@@ -5418,24 +5418,36 @@ describe("AgentSession retry fallback", () => {
 				throw new Error("Not exercised");
 			},
 		});
+		const inspectImageTool: AgentTool = {
+			name: "inspect_image",
+			label: "Inspect Image",
+			description: "Inspect an image",
+			parameters: type({ value: "string" }),
+			strict: true,
+			async execute() {
+				return { content: [{ type: "text", text: "inspected" }] };
+			},
+		};
 
 		session = new AgentSession({
 			agent,
 			sessionManager: SessionManager.inMemory(),
 			settings,
 			modelRegistry: registry,
+			toolRegistry: new Map([[inspectImageTool.name, inspectImageTool]]),
 		});
 
 		// Stale until discovery settles: the active model and its context-usage
 		// derivation both carry the 1.05M window that contradicts the catalog.
 		expect(session.model?.contextWindow).toBe(1_050_000);
 		expect(session.getContextUsage()?.contextWindow).toBe(1_050_000);
+		expect(session.inspectImageState().active).toBe(false);
 
-		const modelChanged = new Promise<void>(resolve => {
+		const inspectImageActiveAtNotification = new Promise<boolean>(resolve => {
 			const unsubscribe = session!.subscribe(event => {
 				if (event.type === "model_changed") {
 					unsubscribe();
-					resolve();
+					resolve(session!.inspectImageState().active);
 				}
 			});
 		});
@@ -5443,8 +5455,8 @@ describe("AgentSession retry fallback", () => {
 		// The CLI starts discovery only after the session is built; the rebind
 		// waiter armed in the constructor resolves once this settles.
 		registry.refreshInBackground("offline");
-		await Promise.race([
-			modelChanged,
+		const activeAtNotification = await Promise.race([
+			inspectImageActiveAtNotification,
 			scheduler.wait(5_000).then(() => {
 				throw new Error("model_changed was not emitted after discovery settled");
 			}),
@@ -5455,6 +5467,8 @@ describe("AgentSession retry fallback", () => {
 		expect(session.model?.id).toBe("deepseek-v4-tiered");
 		expect(session.model?.contextWindow).toBe(400_000);
 		expect(session.getContextUsage()?.contextWindow).toBe(400_000);
+		expect(activeAtNotification).toBe(true);
+		expect(session.inspectImageState().active).toBe(true);
 	});
 
 	it("warns on unknown or malformed model-selector chain keys at startup", () => {

--- a/packages/coding-agent/test/main-rebuild-scoped-models.test.ts
+++ b/packages/coding-agent/test/main-rebuild-scoped-models.test.ts
@@ -206,6 +206,7 @@ describe("buildSessionOptions --models scope selection", () => {
 
 		expect(options.modelPattern).toBeUndefined();
 		expect(options.model?.id).toBe("a");
+		expect(options.rebindModelAfterDiscovery).toBe(true);
 		expect(options.scopedModels?.map(entry => entry.model.id)).toEqual(["a"]);
 	});
 });

--- a/packages/coding-agent/test/sdk-model-selection.test.ts
+++ b/packages/coding-agent/test/sdk-model-selection.test.ts
@@ -247,6 +247,61 @@ describe("createAgentSession deferred model pattern resolution", () => {
 		}
 	});
 
+	test("preserves an explicit model when a reused registry already finished discovery", async () => {
+		const authStorage = createInMemoryAuthStorage();
+		authStoragesToClose.push(authStorage);
+		authStorage.setRuntimeApiKey("anthropic", "anthropic-test-key");
+		const modelRegistry = new ModelRegistry(authStorage, path.join(tempDir, "models.yml"));
+		modelRegistry.refreshInBackground("offline");
+		await modelRegistry.awaitInitialBackgroundRefresh();
+
+		const catalogModel = modelRegistry.find("anthropic", "claude-sonnet-4-5");
+		if (!catalogModel) throw new Error("missing bundled registry model");
+		const explicitModel = buildModel({
+			id: catalogModel.id,
+			name: "Explicit Claude endpoint",
+			api: catalogModel.api,
+			provider: catalogModel.provider,
+			baseUrl: "https://explicit-sdk-endpoint.example/v1",
+			reasoning: catalogModel.reasoning,
+			input: [...catalogModel.input],
+			cost: catalogModel.cost,
+			contextWindow: 321_000,
+			maxTokens: 12_345,
+		});
+
+		const { session } = await createAgentSession({
+			cwd: tempDir,
+			agentDir: tempDir,
+			authStorage,
+			modelRegistry,
+			model: explicitModel,
+			sessionManager: SessionManager.inMemory(),
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+			skipPythonPreflight: true,
+			rules: [],
+			preloadedCustomToolPaths: [],
+			toolNames: ["read"],
+		});
+
+		try {
+			// Flush a reconciler armed against the already-settled refresh; an
+			// incorrect explicit-model opt-in would replace the model here.
+			await Promise.resolve();
+			expect(session.model?.baseUrl).toBe("https://explicit-sdk-endpoint.example/v1");
+			expect(session.model?.contextWindow).toBe(321_000);
+			expect(session.model?.maxTokens).toBe(12_345);
+		} finally {
+			await session.dispose();
+		}
+	});
+
 	test("hydrates credential-scoped model caches before fallback validation", async () => {
 		const authStorage = createInMemoryAuthStorage();
 		authStoragesToClose.push(authStorage);


### PR DESCRIPTION
## Repro
With `extendedContext=false` and `github-copilot/gpt-5.6-sol` (shown as 400K in `/models`) as the Default role, a fresh session runs at `contextWindow: 1050000`. RPC `get_state` reports `model.contextWindow` and `contextUsage.contextWindow` both at 1050000 while `get_available_models` splits the selector into a 400000 base and a separate `github-copilot/gpt-5.6-sol-1m` at 1050000. Re-selecting the same base selector after startup repairs it to 400000. Deterministic repro: `omp --mode rpc --no-session --model github-copilot/gpt-5.6-sol`, then `get_state`. Captured as a regression test in `agent-session-retry-fallback.test.ts`: with the rebind kickoff disabled the active model stays 1050000 and never self-corrects (test times out waiting for `model_changed`).

## Cause
Startup binds the active model from the pre-discovery catalog snapshot. `main.ts` `buildSessionOptions` resolves `options.model` from `modelRegistry.getAvailable()`, and `createSession` fires `refreshInBackground()` only *after* the session is built. The bundled `github-copilot/gpt-5.6-sol` entry ships the full long-context window (`contextWindow: 1050000`) with no `-1m` sibling because the tier boundary lives in upstream `billing.token_prices` metadata fetched only during live discovery (`packages/catalog/src/provider-models/openai-compat.ts`). Background discovery then caps the base entry to the default tier (400000) and synthesizes the `-1m` sibling in the registry, but nothing rebinds the already-active session model. `session-stats.ts` `getContextBreakdown`/`getContextUsage` read `agent.state.model.contextWindow` directly, so `get_state` and compaction thresholds carry the stale window. The two existing post-discovery reconcilers (`#retryInactiveAdvisorAfterModelDiscovery`, `#revalidateFallbackChainsAfterModelDiscovery`) never touched the active model, and `main.ts` `rebuildScopedModelsAfterDiscovery` only refreshes the Ctrl+P/picker scope. `set_model` repairs the state only because it re-looks-up the selector post-discovery and funnels through `agent.setModel`.

## Fix
- Add `AgentSession.#rebindActiveModelAfterModelDiscovery`, kicked off in the constructor alongside the two existing post-discovery reconcilers. It awaits `ModelRegistry.awaitInitialBackgroundRefresh` (arms a waiter even though the CLI starts discovery after construction), re-resolves the startup-bound selector via `modelRegistry.find`, and — when its context window changed and the user has not switched models — folds the refreshed spec into the live model via `agent.setModel`, emitting `model_changed` for the status line and RPC subscribers. Same selector, so this is a metadata refresh with no provider-session reset, mirroring `#refreshLazyLocalContext`.
- Rename the dispose-scoped abort controller `#fallbackDiscoveryRevalidationAbortController` -> `#modelDiscoveryAbortController` now that two hooks share it.
- Changelog entry under `[Unreleased]`.

## Verification
`bun test packages/coding-agent/test/agent-session-retry-fallback.test.ts` -> 88 pass. New test `rebinds the active model to its post-discovery same-selector window (#10488)` fails (times out, active model stuck at 1050000) with the constructor kickoff disabled and passes with it (active model + `getContextUsage()` settle to 400000). Adjacent suites green: `model-discovery`, `agent-session-model-persistence`, `agent-session-model-switch-auth`, `status-line-model`, `agent-session-context-promotion`, `main-rebuild-scoped-models` (122 pass). `bun run fix` + `bun check` clean via the publish gate.

Fixes #10488