### PR TITLE
fix(coding-agent): resolve all-sessions listing and resume from active sessions directory

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Improved chat history stability during long-running sessions by preventing unnecessary message modification when date or directory context changes
 - Fixed `bun claude:trace` hanging due to a TLS ClientHello race condition in the proxy MITM bridge and added forward HTTP proxy support.
 - Fixed an invalid Lark grammar error in sloppy edit constrained decoding caused by unsupported regex lookahead.
+- Fixed all-sessions listing (`Tab` in session picker) and cross-project resume failing when sessions are stored under `XDG_DATA_HOME`; `listAllSessions` now scans the active `getSessionsDir()` root instead of hardcoding `~/.omp/agent/sessions`.
 
 ## [18.1.1] - 2026-09-01
 

--- a/packages/coding-agent/src/session/session-listing.ts
+++ b/packages/coding-agent/src/session/session-listing.ts
@@ -1,7 +1,7 @@
 import * as os from "node:os";
 import * as path from "node:path";
 import type { Message } from "@oh-my-pi/pi-ai";
-import { getAgentDir as getDefaultAgentDir, logger, parseJsonlLenient, toError } from "@oh-my-pi/pi-utils";
+import { getSessionsDir, logger, parseJsonlLenient, toError } from "@oh-my-pi/pi-utils";
 import { LRUCache } from "@oh-my-pi/pi-utils/lru";
 import { computeDefaultSessionDir } from "./session-paths";
 import { FileSessionStorage, type SessionStorage, type SessionStorageStat } from "./session-storage";
@@ -619,8 +619,10 @@ export function listSessionsReadOnly(sessionDir: string, storage: SessionStorage
 }
 
 /** List all sessions across all project directories (newest first). */
-export async function listAllSessions(storage: SessionStorage = new FileSessionStorage()): Promise<SessionInfo[]> {
-	const sessionsRoot = path.join(getDefaultAgentDir(), "sessions");
+export async function listAllSessions(
+	storage: SessionStorage = new FileSessionStorage(),
+	sessionsRoot: string = getSessionsDir(),
+): Promise<SessionInfo[]> {
 	try {
 		const files = await Array.fromAsync(new Bun.Glob("*/*.jsonl").scan(sessionsRoot), name =>
 			path.join(sessionsRoot, name),

--- a/packages/coding-agent/test/slash-commands/resume.test.ts
+++ b/packages/coding-agent/test/slash-commands/resume.test.ts
@@ -3,11 +3,11 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
-import { resolveResumableSession } from "@oh-my-pi/pi-coding-agent/session/session-listing";
+import { listAllSessions, resolveResumableSession } from "@oh-my-pi/pi-coding-agent/session/session-listing";
 import { computeDefaultSessionDir } from "@oh-my-pi/pi-coding-agent/session/session-paths";
 import { FileSessionStorage } from "@oh-my-pi/pi-coding-agent/session/session-storage";
 import { executeBuiltinSlashCommand } from "@oh-my-pi/pi-coding-agent/slash-commands/builtin-registry";
-import { getConfigRootDir, setAgentDir } from "@oh-my-pi/pi-utils";
+import { getConfigRootDir, refreshDirsFromEnv, setAgentDir } from "@oh-my-pi/pi-utils";
 
 let tempDir: string;
 const originalAgentDir = process.env.PI_CODING_AGENT_DIR;
@@ -168,5 +168,43 @@ describe("/resume slash command", () => {
 		expect(harness.setText).toHaveBeenCalledWith("");
 		expect(harness.showError).toHaveBeenCalledWith('Session "missing-session" not found');
 		expect(harness.handleResumeSession).not.toHaveBeenCalled();
+	});
+
+	it("lists and resumes sessions stored in XDG_DATA_HOME", async () => {
+		const xdgDataDir = path.join(tempDir, "xdg-data");
+		const xdgOmpDir = path.join(xdgDataDir, "omp");
+		await fs.mkdir(xdgOmpDir, { recursive: true });
+
+		const originalXdgData = process.env.XDG_DATA_HOME;
+		const originalPiCodingAgentDir = process.env.PI_CODING_AGENT_DIR;
+		delete process.env.PI_CODING_AGENT_DIR;
+		process.env.XDG_DATA_HOME = xdgDataDir;
+		refreshDirsFromEnv();
+
+		try {
+			const projA = path.join(tempDir, "projA");
+			const projB = path.join(tempDir, "projB");
+			await fs.mkdir(projA, { recursive: true });
+			await fs.mkdir(projB, { recursive: true });
+
+			const sessionDirA = computeDefaultSessionDir(projA, storage);
+			const sessionPathA = await writeSession("019ed999-02fb-7000-8dac-396e2f84d484", projA, sessionDirA);
+
+			expect(sessionPathA.startsWith(xdgOmpDir)).toBe(true);
+
+			const allSessions = await listAllSessions(storage);
+			expect(allSessions.some(s => s.id === "019ed999-02fb-7000-8dac-396e2f84d484")).toBe(true);
+
+			const harness = createRuntime(projB);
+			const handled = await executeBuiltinSlashCommand("/resume 019ed999", harness.runtime);
+			expect(handled).toBe(true);
+			expect(harness.showError).not.toHaveBeenCalled();
+			expect(harness.handleResumeSession).toHaveBeenCalledWith(sessionPathA);
+		} finally {
+			if (originalXdgData !== undefined) process.env.XDG_DATA_HOME = originalXdgData;
+			else delete process.env.XDG_DATA_HOME;
+			if (originalPiCodingAgentDir !== undefined) process.env.PI_CODING_AGENT_DIR = originalPiCodingAgentDir;
+			refreshDirsFromEnv();
+		}
 	});
 });


### PR DESCRIPTION
I compiled and tested tab and resume started worknig with XDG based omp dirs 

### Context & Problem
When using XDG directories (`XDG_DATA_HOME` / `omp config init-xdg`), sessions are saved to `$XDG_DATA_HOME/omp/sessions/<project-dir-slug>/*.jsonl`. While local cwd session listing works via `getSessionsDir()`, `listAllSessions()` hardcoded `path.join(getDefaultAgentDir(), "sessions")` (`~/.omp/agent/sessions`). As a result:
- Pressing `Tab` in `/resume` (or CLI `omp --resume`) to browse all sessions returned an empty list.
- Cross-project resume fallback (`/resume <session-id>` targeting a session created in another project root) failed to find sessions stored under XDG paths.

### Changes
- Updated `listAllSessions()` in `packages/coding-agent/src/session/session-listing.ts` to scan `getSessionsDir()` by default.
- Added regression test in `packages/coding-agent/test/slash-commands/resume.test.ts` covering session listing and `/resume` resolution when `XDG_DATA_HOME` is set.
- Updated `packages/coding-agent/CHANGELOG.md`.

### Verification
I compiled and tested tab and resume started worknig with XDG based omp dirs 