### PR TITLE
fix(eval): resolve project node_modules by bare specifier in compiled binary

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Claude marketplace MCP servers now resolve environment placeholders in stdio environment values instead of passing strings such as `${NAME:-}` literally ([#10481](https://github.com/can1357/oh-my-pi/pull/10481) by [@mrexodia](https://github.com/mrexodia)).
+- eval JS cells now resolve project `node_modules` dependencies by bare specifier (`require('pkg')` / `import('pkg')`) in the compiled binary, walking the on-disk `node_modules` chain from the cwd instead of the binary's embedded filesystem ([#10496](https://github.com/can1357/oh-my-pi/issues/10496)).
 ## [18.1.2] - 2026-09-01
 
 ### Added

--- a/packages/coding-agent/src/eval/js/shared/local-module-loader.ts
+++ b/packages/coding-agent/src/eval/js/shared/local-module-loader.ts
@@ -4,6 +4,7 @@ import * as path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import * as vm from "node:vm";
 import { collectModuleSourceSpecifiers, stripTypeScriptSyntax } from "./rewrite-imports";
+import { IMPORT_CONDITIONS, REQUIRE_CONDITIONS, resolveBareSpecifier } from "./node-modules-resolver";
 
 interface LocalModuleEntry {
 	version: number;
@@ -307,7 +308,52 @@ export class LocalModuleLoader {
 
 function buildRequire(fromPath: string): NodeJS.Require {
 	const basePath = path.extname(fromPath) ? fromPath : path.join(fromPath, "[eval]");
-	return createRequire(pathToFileURL(basePath).href);
+	const base = createRequire(pathToFileURL(basePath).href);
+	return wrapRequireWithOnDiskFallback(base, path.dirname(basePath));
+}
+
+// In a `bun build --compile` binary, Bun's own require/resolver roots resolution at
+// the embedded `$bunfs` and never sees the project's on-disk `node_modules` (#10496).
+// Fall back to an on-disk walk that resolves the bare specifier to an absolute file
+// path, which the compiled runtime can load; dev builds resolve via `base` and never
+// hit the fallback.
+function wrapRequireWithOnDiskFallback(base: NodeJS.Require, baseDir: string): NodeJS.Require {
+	const req = ((id: string) => {
+		try {
+			return base(id);
+		} catch (err) {
+			const fallback = onDiskFallback(err, id, baseDir, REQUIRE_CONDITIONS);
+			if (fallback) return base(fallback);
+			throw err;
+		}
+	}) as NodeJS.Require;
+	const resolve = ((id: string, options?: { paths?: string[] }) => {
+		try {
+			return base.resolve(id, options);
+		} catch (err) {
+			const fallback = onDiskFallback(err, id, baseDir, REQUIRE_CONDITIONS);
+			if (fallback) return fallback;
+			throw err;
+		}
+	}) as NodeJS.RequireResolve;
+	resolve.paths = request => base.resolve.paths(request);
+	req.resolve = resolve;
+	req.cache = base.cache;
+	req.extensions = base.extensions;
+	req.main = base.main;
+	return req;
+}
+
+// Attempt on-disk resolution for a specifier the primary resolver could not find.
+// Only bare specifiers on genuine not-found errors qualify — relative/absolute/URL
+// specifiers and other failures (e.g. errors thrown while loading the module) pass
+// through unchanged.
+function onDiskFallback(err: unknown, id: string, baseDir: string, conditions: string[]): string | null {
+	if (!(err && typeof err === "object" && "code" in err)) return null;
+	const code = err.code;
+	if (code !== "MODULE_NOT_FOUND" && code !== "ERR_MODULE_NOT_FOUND") return null;
+	if (isLocalPathSpecifier(id) || /^[a-z][a-z0-9+.-]*:/i.test(id)) return null;
+	return resolveBareSpecifier(id, baseDir, conditions);
 }
 
 function buildModuleSource(source: string, modulePath: string): string {
@@ -325,7 +371,8 @@ function resolveImportSpecifier(cwd: string, source: string): string {
 	try {
 		return Bun.resolveSync(source, cwd);
 	} catch {
-		return source;
+		if (isLocalPathSpecifier(source)) return source;
+		return resolveBareSpecifier(source, cwd, IMPORT_CONDITIONS) ?? source;
 	}
 }
 

--- a/packages/coding-agent/src/eval/js/shared/local-module-loader.ts
+++ b/packages/coding-agent/src/eval/js/shared/local-module-loader.ts
@@ -406,6 +406,10 @@ function isManagedLocalModulePath(target: string): boolean {
 }
 
 function normalizeImportTarget(target: string): string {
-	if (path.isAbsolute(target)) return pathToFileURL(target).href;
-	return target;
+	if (!path.isAbsolute(target)) return target;
+	// Preserve a `?query`/`#fragment` suffix through file-URL conversion; pathToFileURL
+	// would otherwise percent-encode `?`/`#` into the pathname and break the query.
+	const cut = target.search(/[?#]/);
+	if (cut === -1) return pathToFileURL(target).href;
+	return pathToFileURL(target.slice(0, cut)).href + target.slice(cut);
 }

--- a/packages/coding-agent/src/eval/js/shared/node-modules-resolver.test.ts
+++ b/packages/coding-agent/src/eval/js/shared/node-modules-resolver.test.ts
@@ -67,6 +67,16 @@ beforeAll(() => {
 			"src/thing.js": "module.exports = 'scoped-feature';",
 		},
 	);
+	// Overlapping wildcard patterns: the most-specific (longest-prefix) key must win.
+	writePackage(
+		projNm,
+		"overlap",
+		{ exports: { "./*": "./general/*.js", "./feature/*": "./specific/*.js" } },
+		{
+			"general/other.js": "module.exports = 'general';",
+			"specific/x.js": "module.exports = 'specific';",
+		},
+	);
 	// Package resolvable only by walking up: installed in a nested dependency's node_modules.
 	writePackage(
 		path.join(nestedDir, "node_modules"),
@@ -117,6 +127,17 @@ describe("resolveBareSpecifier", () => {
 		);
 		expect(resolveBareSpecifier("@scope/pkg/feature/thing", projectDir, IMPORT_CONDITIONS)).toBe(
 			path.join(projectDir, "node_modules", "@scope", "pkg", "src", "thing.js"),
+		);
+	});
+
+	test("selects the most-specific overlapping wildcard pattern", () => {
+		// `./feature/*` (longer prefix) must beat `./*` for `overlap/feature/x`.
+		expect(resolveBareSpecifier("overlap/feature/x", projectDir, IMPORT_CONDITIONS)).toBe(
+			path.join(projectDir, "node_modules", "overlap", "specific", "x.js"),
+		);
+		// A subpath only the broad `./*` matches still resolves through it.
+		expect(resolveBareSpecifier("overlap/other", projectDir, IMPORT_CONDITIONS)).toBe(
+			path.join(projectDir, "node_modules", "overlap", "general", "other.js"),
 		);
 	});
 

--- a/packages/coding-agent/src/eval/js/shared/node-modules-resolver.test.ts
+++ b/packages/coding-agent/src/eval/js/shared/node-modules-resolver.test.ts
@@ -1,0 +1,110 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { IMPORT_CONDITIONS, REQUIRE_CONDITIONS, resolveBareSpecifier } from "./node-modules-resolver";
+
+/**
+ * Fixture layout (a project `node_modules` tree, one nested scope) exercising the
+ * resolver branches that the compiled-binary fallback depends on. See issue #10496.
+ */
+let root: string;
+let projectDir: string;
+let nestedDir: string;
+
+function writePackage(nmDir: string, name: string, pkg: Record<string, unknown>, files: Record<string, string>): void {
+	const pkgDir = path.join(nmDir, ...name.split("/"));
+	fs.mkdirSync(pkgDir, { recursive: true });
+	fs.writeFileSync(path.join(pkgDir, "package.json"), JSON.stringify({ name, version: "1.0.0", ...pkg }));
+	for (const rel in files) {
+		const filePath = path.join(pkgDir, rel);
+		fs.mkdirSync(path.dirname(filePath), { recursive: true });
+		fs.writeFileSync(filePath, files[rel]);
+	}
+}
+
+beforeAll(() => {
+	root = fs.mkdtempSync(path.join(os.tmpdir(), "omp-resolver-"));
+	projectDir = path.join(root, "project");
+	const projNm = path.join(projectDir, "node_modules");
+	nestedDir = path.join(projNm, "outer");
+	fs.mkdirSync(projNm, { recursive: true });
+
+	// Dual condition + legacy fields: import/require must select different files.
+	writePackage(
+		projNm,
+		"dual",
+		{ main: "cjs.js", module: "esm.mjs", exports: { ".": { import: "./esm.mjs", require: "./cjs.js" } } },
+		{
+			"esm.mjs": "export default 'esm';",
+			"cjs.js": "module.exports = 'cjs';",
+		},
+	);
+	// Legacy fields only, no exports.
+	writePackage(projNm, "legacy", { main: "lib/entry.js" }, { "lib/entry.js": "module.exports = 'legacy';" });
+	// No entry fields at all: index.js fallback.
+	writePackage(projNm, "indexonly", {}, { "index.js": "module.exports = 'index';" });
+	// Scoped package with subpath pattern exports.
+	writePackage(
+		projNm,
+		"@scope/pkg",
+		{ exports: { ".": "./main.js", "./feature/*": "./src/*.js" } },
+		{
+			"main.js": "module.exports = 'scoped-main';",
+			"src/thing.js": "module.exports = 'scoped-feature';",
+		},
+	);
+	// Package resolvable only by walking up: installed in a nested dependency's node_modules.
+	writePackage(
+		path.join(nestedDir, "node_modules"),
+		"shared",
+		{ main: "index.js" },
+		{ "index.js": "module.exports = 'shared';" },
+	);
+});
+
+afterAll(() => {
+	fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe("resolveBareSpecifier", () => {
+	test("selects the export target matching the active condition", () => {
+		expect(resolveBareSpecifier("dual", projectDir, IMPORT_CONDITIONS)).toBe(
+			path.join(projectDir, "node_modules", "dual", "esm.mjs"),
+		);
+		expect(resolveBareSpecifier("dual", projectDir, REQUIRE_CONDITIONS)).toBe(
+			path.join(projectDir, "node_modules", "dual", "cjs.js"),
+		);
+	});
+
+	test("falls back to legacy main and index when exports is absent", () => {
+		expect(resolveBareSpecifier("legacy", projectDir, IMPORT_CONDITIONS)).toBe(
+			path.join(projectDir, "node_modules", "legacy", "lib", "entry.js"),
+		);
+		expect(resolveBareSpecifier("indexonly", projectDir, IMPORT_CONDITIONS)).toBe(
+			path.join(projectDir, "node_modules", "indexonly", "index.js"),
+		);
+	});
+
+	test("resolves scoped root and subpath-pattern exports", () => {
+		expect(resolveBareSpecifier("@scope/pkg", projectDir, IMPORT_CONDITIONS)).toBe(
+			path.join(projectDir, "node_modules", "@scope", "pkg", "main.js"),
+		);
+		expect(resolveBareSpecifier("@scope/pkg/feature/thing", projectDir, IMPORT_CONDITIONS)).toBe(
+			path.join(projectDir, "node_modules", "@scope", "pkg", "src", "thing.js"),
+		);
+	});
+
+	test("walks the node_modules chain upward from the base directory", () => {
+		// `shared` lives only in outer/node_modules; resolving from outer's own dir finds it.
+		expect(resolveBareSpecifier("shared", nestedDir, IMPORT_CONDITIONS)).toBe(
+			path.join(nestedDir, "node_modules", "shared", "index.js"),
+		);
+	});
+
+	test("returns null for unresolvable specifiers", () => {
+		expect(resolveBareSpecifier("does-not-exist", projectDir, IMPORT_CONDITIONS)).toBeNull();
+		// exports omits this subpath -> no resolution, no legacy leak for non-root subpaths.
+		expect(resolveBareSpecifier("@scope/pkg/nope", projectDir, IMPORT_CONDITIONS)).toBeNull();
+	});
+});

--- a/packages/coding-agent/src/eval/js/shared/node-modules-resolver.test.ts
+++ b/packages/coding-agent/src/eval/js/shared/node-modules-resolver.test.ts
@@ -57,6 +57,13 @@ beforeAll(() => {
 			"default.js": "module.exports = 'default';",
 		},
 	);
+	// `bun` condition mapped to null: an explicit block. Must not fall through to default.
+	writePackage(
+		projNm,
+		"excluded",
+		{ exports: { ".": { bun: null, default: "./fallback.js" } } },
+		{ "fallback.js": "module.exports = 'fallback';" },
+	);
 	// Scoped package with subpath pattern exports.
 	writePackage(
 		projNm,
@@ -119,6 +126,15 @@ describe("resolveBareSpecifier", () => {
 		const bunTarget = path.join(projectDir, "node_modules", "runtimecond", "bun.js");
 		expect(resolveBareSpecifier("runtimecond", projectDir, IMPORT_CONDITIONS)).toBe(bunTarget);
 		expect(resolveBareSpecifier("runtimecond", projectDir, REQUIRE_CONDITIONS)).toBe(bunTarget);
+	});
+
+	test("treats an explicit null export condition as excluded", () => {
+		// `bun` is active and maps to null -> hard block; must NOT fall through to default.
+		expect(resolveBareSpecifier("excluded", projectDir, IMPORT_CONDITIONS)).toBeNull();
+		// When `bun` is not an active condition, the null key is skipped and default wins.
+		expect(resolveBareSpecifier("excluded", projectDir, ["node", "import", "default"])).toBe(
+			path.join(projectDir, "node_modules", "excluded", "fallback.js"),
+		);
 	});
 
 	test("resolves scoped root and subpath-pattern exports", () => {

--- a/packages/coding-agent/src/eval/js/shared/node-modules-resolver.test.ts
+++ b/packages/coding-agent/src/eval/js/shared/node-modules-resolver.test.ts
@@ -46,6 +46,17 @@ beforeAll(() => {
 	writePackage(projNm, "indexonly", {}, { "index.js": "module.exports = 'index';" });
 	// Extensionless legacy main backed by a TypeScript file (Bun resolves/loads it natively).
 	writePackage(projNm, "tsentry", { main: "entry" }, { "entry.ts": "export default 42;" });
+	// `bun` condition listed ahead of `node`: must win under both import and require, matching native Bun.
+	writePackage(
+		projNm,
+		"runtimecond",
+		{ exports: { ".": { bun: "./bun.js", node: "./node.js", default: "./default.js" } } },
+		{
+			"bun.js": "module.exports = 'bun';",
+			"node.js": "module.exports = 'node';",
+			"default.js": "module.exports = 'default';",
+		},
+	);
 	// Scoped package with subpath pattern exports.
 	writePackage(
 		projNm,
@@ -92,6 +103,12 @@ describe("resolveBareSpecifier", () => {
 		expect(resolveBareSpecifier("tsentry", projectDir, IMPORT_CONDITIONS)).toBe(
 			path.join(projectDir, "node_modules", "tsentry", "entry.ts"),
 		);
+	});
+
+	test("activates the bun export condition over node", () => {
+		const bunTarget = path.join(projectDir, "node_modules", "runtimecond", "bun.js");
+		expect(resolveBareSpecifier("runtimecond", projectDir, IMPORT_CONDITIONS)).toBe(bunTarget);
+		expect(resolveBareSpecifier("runtimecond", projectDir, REQUIRE_CONDITIONS)).toBe(bunTarget);
 	});
 
 	test("resolves scoped root and subpath-pattern exports", () => {

--- a/packages/coding-agent/src/eval/js/shared/node-modules-resolver.test.ts
+++ b/packages/coding-agent/src/eval/js/shared/node-modules-resolver.test.ts
@@ -64,6 +64,31 @@ beforeAll(() => {
 		{ exports: { ".": { bun: null, default: "./fallback.js" } } },
 		{ "fallback.js": "module.exports = 'fallback';" },
 	);
+	// A non-null exports field encapsulates the package root, even when legacy main exists.
+	writePackage(
+		projNm,
+		"subpathonly",
+		{ main: "./main.js", exports: { "./feature": "./feature.js" } },
+		{
+			"main.js": "module.exports = 'legacy-main';",
+			"feature.js": "module.exports = 'feature';",
+		},
+	);
+	writePackage(
+		projNm,
+		"inactivecond",
+		{ main: "./main.js", exports: { ".": { deno: "./deno.js" } } },
+		{
+			"main.js": "module.exports = 'legacy-main';",
+			"deno.js": "module.exports = 'deno';",
+		},
+	);
+	writePackage(
+		projNm,
+		"missingtarget",
+		{ main: "./main.js", exports: { ".": "./missing.js" } },
+		{ "main.js": "module.exports = 'legacy-main';" },
+	);
 	// Scoped package with subpath pattern exports.
 	writePackage(
 		projNm,
@@ -135,6 +160,12 @@ describe("resolveBareSpecifier", () => {
 		expect(resolveBareSpecifier("excluded", projectDir, ["node", "import", "default"])).toBe(
 			path.join(projectDir, "node_modules", "excluded", "fallback.js"),
 		);
+	});
+
+	test("does not bypass a non-null exports boundary with legacy root fallbacks", () => {
+		expect(resolveBareSpecifier("subpathonly", projectDir, IMPORT_CONDITIONS)).toBeNull();
+		expect(resolveBareSpecifier("inactivecond", projectDir, IMPORT_CONDITIONS)).toBeNull();
+		expect(resolveBareSpecifier("missingtarget", projectDir, IMPORT_CONDITIONS)).toBeNull();
 	});
 
 	test("resolves scoped root and subpath-pattern exports", () => {

--- a/packages/coding-agent/src/eval/js/shared/node-modules-resolver.test.ts
+++ b/packages/coding-agent/src/eval/js/shared/node-modules-resolver.test.ts
@@ -44,6 +44,8 @@ beforeAll(() => {
 	writePackage(projNm, "legacy", { main: "lib/entry.js" }, { "lib/entry.js": "module.exports = 'legacy';" });
 	// No entry fields at all: index.js fallback.
 	writePackage(projNm, "indexonly", {}, { "index.js": "module.exports = 'index';" });
+	// Extensionless legacy main backed by a TypeScript file (Bun resolves/loads it natively).
+	writePackage(projNm, "tsentry", { main: "entry" }, { "entry.ts": "export default 42;" });
 	// Scoped package with subpath pattern exports.
 	writePackage(
 		projNm,
@@ -83,6 +85,12 @@ describe("resolveBareSpecifier", () => {
 		);
 		expect(resolveBareSpecifier("indexonly", projectDir, IMPORT_CONDITIONS)).toBe(
 			path.join(projectDir, "node_modules", "indexonly", "index.js"),
+		);
+	});
+
+	test("probes TypeScript extensions for an extensionless main", () => {
+		expect(resolveBareSpecifier("tsentry", projectDir, IMPORT_CONDITIONS)).toBe(
+			path.join(projectDir, "node_modules", "tsentry", "entry.ts"),
 		);
 	});
 

--- a/packages/coding-agent/src/eval/js/shared/node-modules-resolver.test.ts
+++ b/packages/coding-agent/src/eval/js/shared/node-modules-resolver.test.ts
@@ -188,6 +188,16 @@ describe("resolveBareSpecifier", () => {
 		);
 	});
 
+	test("preserves a query/fragment suffix on the resolved path", () => {
+		// `?raw` is stripped for subpath matching, then re-appended to the resolved file.
+		expect(resolveBareSpecifier("@scope/pkg/feature/thing?raw", projectDir, IMPORT_CONDITIONS)).toBe(
+			`${path.join(projectDir, "node_modules", "@scope", "pkg", "src", "thing.js")}?raw`,
+		);
+		expect(resolveBareSpecifier("dual?v=1", projectDir, IMPORT_CONDITIONS)).toBe(
+			`${path.join(projectDir, "node_modules", "dual", "esm.mjs")}?v=1`,
+		);
+	});
+
 	test("walks the node_modules chain upward from the base directory", () => {
 		// `shared` lives only in outer/node_modules; resolving from outer's own dir finds it.
 		expect(resolveBareSpecifier("shared", nestedDir, IMPORT_CONDITIONS)).toBe(

--- a/packages/coding-agent/src/eval/js/shared/node-modules-resolver.ts
+++ b/packages/coding-agent/src/eval/js/shared/node-modules-resolver.ts
@@ -32,11 +32,16 @@ const INDEX_FILES = [
 	"index.json",
 ];
 
+// Condition sets mirror `extensibility/plugins/legacy-pi-compat.ts`
+// (`SUPPORTED_PACKAGE_{IMPORT,REQUIRE}_CONDITIONS`): Bun activates the `bun`
+// condition ahead of `node`, and the non-standard `module` condition is not a
+// runtime condition (declaration order in `exports` still decides ties).
+
 /** Condition preference for `import()`-shaped resolution. */
-export const IMPORT_CONDITIONS = ["node", "import", "module", "default"];
+export const IMPORT_CONDITIONS = ["bun", "node", "import", "default"];
 
 /** Condition preference for `require()`-shaped resolution. */
-export const REQUIRE_CONDITIONS = ["node", "require", "default"];
+export const REQUIRE_CONDITIONS = ["bun", "node", "require", "default"];
 
 interface PackageJson {
 	main?: unknown;

--- a/packages/coding-agent/src/eval/js/shared/node-modules-resolver.ts
+++ b/packages/coding-agent/src/eval/js/shared/node-modules-resolver.ts
@@ -1,0 +1,232 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+/**
+ * On-disk `node_modules` resolver for eval JS bare specifiers.
+ *
+ * `bun build --compile` roots module resolution at the embedded `$bunfs`, so
+ * `Bun.resolveSync`, `createRequire`, and bare `import()` never consult the real
+ * project `node_modules` even when the kernel cwd is correct (issue #10496). This
+ * walks the on-disk `node_modules` chain from a base directory and resolves a bare
+ * specifier to an absolute file path, which the compiled runtime *can* load. It is
+ * only used as a fallback when Bun's own resolver fails.
+ */
+
+/** File extensions probed when a specifier or exports target has none. */
+const FILE_EXTENSIONS = [".js", ".mjs", ".cjs", ".json", ".node"];
+
+/** Directory index filenames probed when a target resolves to a directory. */
+const INDEX_FILES = ["index.js", "index.mjs", "index.cjs", "index.json"];
+
+/** Condition preference for `import()`-shaped resolution. */
+export const IMPORT_CONDITIONS = ["node", "import", "module", "default"];
+
+/** Condition preference for `require()`-shaped resolution. */
+export const REQUIRE_CONDITIONS = ["node", "require", "default"];
+
+interface PackageJson {
+	main?: unknown;
+	module?: unknown;
+	exports?: unknown;
+}
+
+/**
+ * Resolve a bare specifier against on-disk `node_modules` starting from `baseDir`,
+ * honoring `exports` (conditions + subpath patterns) and `main`/`module`/index
+ * fallbacks. Returns an absolute file path, or `null` when nothing resolves.
+ *
+ * @param specifier bare package specifier, e.g. `xlsx`, `@scope/pkg`, `pkg/sub`.
+ * @param baseDir directory the resolution walks up from.
+ * @param conditions ordered export-condition preference (see {@link IMPORT_CONDITIONS}).
+ */
+export function resolveBareSpecifier(specifier: string, baseDir: string, conditions: string[]): string | null {
+	const { name, subpath } = splitSpecifier(specifier);
+	if (!name) return null;
+	const pkgDir = findPackageDir(name, baseDir);
+	if (!pkgDir) return null;
+	const pkg = readJson(path.join(pkgDir, "package.json"));
+
+	if (pkg && pkg.exports != null) {
+		const target = resolveExports(pkg.exports, subpath, conditions);
+		if (target && (target.startsWith("./") || target.startsWith("../"))) {
+			const resolved = finalizeFile(path.resolve(pkgDir, target));
+			if (resolved) return resolved;
+		}
+		// `exports` present but no usable match: fall through to legacy fields only for
+		// the package root, mirroring Node's leniency for missing subpath maps.
+	}
+
+	if (subpath === ".") {
+		for (const field of mainFields(pkg, conditions)) {
+			const resolved = finalizeFile(path.resolve(pkgDir, field));
+			if (resolved) return resolved;
+		}
+		return finalizeDir(pkgDir);
+	}
+
+	const abs = path.resolve(pkgDir, subpath);
+	return finalizeFile(abs) ?? finalizeDir(abs);
+}
+
+/** Split `@scope/pkg/sub` or `pkg/sub` into package name and `.`-rooted subpath. */
+function splitSpecifier(specifier: string): { name: string; subpath: string } {
+	const parts = specifier.split("/");
+	let name: string;
+	let rest: string[];
+	if (specifier.startsWith("@")) {
+		name = parts.slice(0, 2).join("/");
+		rest = parts.slice(2);
+	} else {
+		name = parts[0] ?? "";
+		rest = parts.slice(1);
+	}
+	return { name, subpath: rest.length > 0 ? `./${rest.join("/")}` : "." };
+}
+
+/** Walk up from `baseDir` looking for `<dir>/node_modules/<name>`. */
+function findPackageDir(name: string, baseDir: string): string | null {
+	let dir = path.resolve(baseDir);
+	for (;;) {
+		if (path.basename(dir) !== "node_modules") {
+			const candidate = path.join(dir, "node_modules", name);
+			if (isDir(candidate)) return candidate;
+		}
+		const parent = path.dirname(dir);
+		if (parent === dir) return null;
+		dir = parent;
+	}
+}
+
+/** Ordered legacy entry candidates for the package root. */
+function mainFields(pkg: PackageJson | null, conditions: string[]): string[] {
+	if (!pkg) return [];
+	const main = typeof pkg.main === "string" ? pkg.main : null;
+	const module = typeof pkg.module === "string" ? pkg.module : null;
+	const preferModule = conditions.includes("import");
+	const ordered = preferModule ? [module, main] : [main, module];
+	return ordered.filter((value): value is string => value !== null);
+}
+
+/**
+ * Resolve an `exports` value for `subpath` under `conditions`. Handles string
+ * targets, condition maps, subpath maps, and `*` patterns per the Node exports spec.
+ */
+function resolveExports(exports: unknown, subpath: string, conditions: string[]): string | null {
+	if (typeof exports === "string") return subpath === "." ? exports : null;
+	if (Array.isArray(exports)) {
+		for (const entry of exports) {
+			const resolved = resolveExports(entry, subpath, conditions);
+			if (resolved) return resolved;
+		}
+		return null;
+	}
+	if (!exports || typeof exports !== "object") return null;
+
+	const record = exports as Record<string, unknown>;
+	let isSubpathMap = false;
+	for (const key in record) {
+		if (key === "." || key.startsWith("./")) {
+			isSubpathMap = true;
+			break;
+		}
+	}
+	if (!isSubpathMap) {
+		// Bare condition map applies only to the package root.
+		return subpath === "." ? resolveConditional(record, conditions) : null;
+	}
+
+	if (subpath in record) return resolveConditional(record[subpath], conditions);
+	for (const key in record) {
+		if (!key.includes("*")) continue;
+		const captured = matchStar(key, subpath);
+		if (captured === null) continue;
+		const target = resolveConditional(record[key], conditions);
+		if (target) return target.replace(/\*/g, captured);
+	}
+	return null;
+}
+
+/**
+ * Collapse a conditional export value to a string target. Object keys are evaluated
+ * in declaration order — the first key active in `conditions` (or `default`) wins,
+ * matching Node's condition-resolution semantics.
+ */
+function resolveConditional(value: unknown, conditions: string[]): string | null {
+	if (typeof value === "string") return value;
+	if (Array.isArray(value)) {
+		for (const entry of value) {
+			const resolved = resolveConditional(entry, conditions);
+			if (resolved) return resolved;
+		}
+		return null;
+	}
+	if (!value || typeof value !== "object") return null;
+	const record = value as Record<string, unknown>;
+	for (const key in record) {
+		if (key !== "default" && !conditions.includes(key)) continue;
+		const resolved = resolveConditional(record[key], conditions);
+		if (resolved) return resolved;
+	}
+	return null;
+}
+
+/** Match a single-`*` exports pattern against `subpath`, returning the captured segment. */
+function matchStar(pattern: string, subpath: string): string | null {
+	const star = pattern.indexOf("*");
+	if (star === -1) return null;
+	const prefix = pattern.slice(0, star);
+	const suffix = pattern.slice(star + 1);
+	if (!subpath.startsWith(prefix) || !subpath.endsWith(suffix)) return null;
+	if (subpath.length < prefix.length + suffix.length) return null;
+	return subpath.slice(prefix.length, subpath.length - suffix.length);
+}
+
+/** Resolve `candidate` to an existing file, probing extensions when it has none. */
+function finalizeFile(candidate: string): string | null {
+	if (isFile(candidate)) return candidate;
+	if (path.extname(candidate) === "") {
+		for (const ext of FILE_EXTENSIONS) {
+			if (isFile(candidate + ext)) return candidate + ext;
+		}
+	}
+	return null;
+}
+
+/** Resolve a directory to its package `main` or an index file. */
+function finalizeDir(dir: string): string | null {
+	if (!isDir(dir)) return null;
+	const pkg = readJson(path.join(dir, "package.json"));
+	if (pkg && typeof pkg.main === "string") {
+		const resolved = finalizeFile(path.resolve(dir, pkg.main));
+		if (resolved) return resolved;
+	}
+	for (const index of INDEX_FILES) {
+		const candidate = path.join(dir, index);
+		if (isFile(candidate)) return candidate;
+	}
+	return null;
+}
+
+function readJson(file: string): PackageJson | null {
+	try {
+		return JSON.parse(fs.readFileSync(file, "utf8")) as PackageJson;
+	} catch {
+		return null;
+	}
+}
+
+function isDir(target: string): boolean {
+	try {
+		return fs.statSync(target).isDirectory();
+	} catch {
+		return false;
+	}
+}
+
+function isFile(target: string): boolean {
+	try {
+		return fs.statSync(target).isFile();
+	} catch {
+		return false;
+	}
+}

--- a/packages/coding-agent/src/eval/js/shared/node-modules-resolver.ts
+++ b/packages/coding-agent/src/eval/js/shared/node-modules-resolver.ts
@@ -59,6 +59,18 @@ interface PackageJson {
  * @param conditions ordered export-condition preference (see {@link IMPORT_CONDITIONS}).
  */
 export function resolveBareSpecifier(specifier: string, baseDir: string, conditions: string[]): string | null {
+	// A trailing `?query`/`#fragment` (e.g. `pkg/feature?raw`) is not part of the
+	// package subpath: strip it for resolution and re-append it to the resolved path,
+	// matching how `Bun.resolveSync` retains the suffix on the resolved module URL.
+	const cut = specifier.search(/[?#]/);
+	const bare = cut === -1 ? specifier : specifier.slice(0, cut);
+	const suffix = cut === -1 ? "" : specifier.slice(cut);
+	const resolved = resolveBarePath(bare, baseDir, conditions);
+	return resolved === null ? null : resolved + suffix;
+}
+
+/** Resolve the query-free bare specifier to an absolute file path (see {@link resolveBareSpecifier}). */
+function resolveBarePath(specifier: string, baseDir: string, conditions: string[]): string | null {
 	const { name, subpath } = splitSpecifier(specifier);
 	if (!name) return null;
 	const pkgDir = findPackageDir(name, baseDir);

--- a/packages/coding-agent/src/eval/js/shared/node-modules-resolver.ts
+++ b/packages/coding-agent/src/eval/js/shared/node-modules-resolver.ts
@@ -155,12 +155,31 @@ function resolveExports(exports: unknown, subpath: string, conditions: string[])
 	}
 
 	if (subpath in record) return resolveConditional(record[subpath], conditions);
+	// Node/Bun select the most-specific `*` pattern: longest literal prefix, then
+	// longest key — not the first declared. Rank all matches before resolving.
+	let best: { prefixLength: number; keyLength: number; captured: string; value: unknown } | null = null;
 	for (const key in record) {
-		if (!key.includes("*")) continue;
-		const captured = matchStar(key, subpath);
-		if (captured === null) continue;
-		const target = resolveConditional(record[key], conditions);
-		if (target) return target.replace(/\*/g, captured);
+		const star = key.indexOf("*");
+		if (star === -1) continue;
+		const prefix = key.slice(0, star);
+		const suffix = key.slice(star + 1);
+		if (!subpath.startsWith(prefix) || !subpath.endsWith(suffix)) continue;
+		if (subpath.length < prefix.length + suffix.length) continue;
+		const better =
+			!best ||
+			prefix.length > best.prefixLength ||
+			(prefix.length === best.prefixLength && key.length > best.keyLength);
+		if (!better) continue;
+		best = {
+			prefixLength: prefix.length,
+			keyLength: key.length,
+			captured: subpath.slice(prefix.length, subpath.length - suffix.length),
+			value: record[key],
+		};
+	}
+	if (best) {
+		const target = resolveConditional(best.value, conditions);
+		if (target) return target.replace(/\*/g, best.captured);
 	}
 	return null;
 }
@@ -187,17 +206,6 @@ function resolveConditional(value: unknown, conditions: string[]): string | null
 		if (resolved) return resolved;
 	}
 	return null;
-}
-
-/** Match a single-`*` exports pattern against `subpath`, returning the captured segment. */
-function matchStar(pattern: string, subpath: string): string | null {
-	const star = pattern.indexOf("*");
-	if (star === -1) return null;
-	const prefix = pattern.slice(0, star);
-	const suffix = pattern.slice(star + 1);
-	if (!subpath.startsWith(prefix) || !subpath.endsWith(suffix)) return null;
-	if (subpath.length < prefix.length + suffix.length) return null;
-	return subpath.slice(prefix.length, subpath.length - suffix.length);
 }
 
 /** Resolve `candidate` to an existing file, probing extensions when it has none. */

--- a/packages/coding-agent/src/eval/js/shared/node-modules-resolver.ts
+++ b/packages/coding-agent/src/eval/js/shared/node-modules-resolver.ts
@@ -12,11 +12,25 @@ import * as path from "node:path";
  * only used as a fallback when Bun's own resolver fails.
  */
 
+// Bun resolves and loads TypeScript/JSX entries at runtime (even in a compiled
+// binary), so the fallback must probe them too — e.g. a dep with `"main": "entry"`
+// backed by `entry.ts`. Ordered JS-family first, then TS/JSX, then data/native.
+
 /** File extensions probed when a specifier or exports target has none. */
-const FILE_EXTENSIONS = [".js", ".mjs", ".cjs", ".json", ".node"];
+const FILE_EXTENSIONS = [".js", ".mjs", ".cjs", ".jsx", ".ts", ".tsx", ".mts", ".cts", ".json", ".node"];
 
 /** Directory index filenames probed when a target resolves to a directory. */
-const INDEX_FILES = ["index.js", "index.mjs", "index.cjs", "index.json"];
+const INDEX_FILES = [
+	"index.js",
+	"index.mjs",
+	"index.cjs",
+	"index.jsx",
+	"index.ts",
+	"index.tsx",
+	"index.mts",
+	"index.cts",
+	"index.json",
+];
 
 /** Condition preference for `import()`-shaped resolution. */
 export const IMPORT_CONDITIONS = ["node", "import", "module", "default"];

--- a/packages/coding-agent/src/eval/js/shared/node-modules-resolver.ts
+++ b/packages/coding-agent/src/eval/js/shared/node-modules-resolver.ts
@@ -67,13 +67,10 @@ export function resolveBareSpecifier(specifier: string, baseDir: string, conditi
 
 	if (pkg && pkg.exports != null) {
 		const target = resolveExports(pkg.exports, subpath, conditions);
-		if (target === EXCLUDED) return null;
-		if (typeof target === "string" && (target.startsWith("./") || target.startsWith("../"))) {
-			const resolved = finalizeFile(path.resolve(pkgDir, target));
-			if (resolved) return resolved;
-		}
-		// `exports` present but no usable match: fall through to legacy fields only for
-		// the package root, mirroring Node's leniency for missing subpath maps.
+		if (typeof target !== "string" || (!target.startsWith("./") && !target.startsWith("../"))) return null;
+		// A non-null `exports` field encapsulates the package. An unmatched target
+		// or a target whose file is missing must not fall through to `main`/index.
+		return finalizeFile(path.resolve(pkgDir, target));
 	}
 
 	if (subpath === ".") {

--- a/packages/coding-agent/src/eval/js/shared/node-modules-resolver.ts
+++ b/packages/coding-agent/src/eval/js/shared/node-modules-resolver.ts
@@ -67,7 +67,8 @@ export function resolveBareSpecifier(specifier: string, baseDir: string, conditi
 
 	if (pkg && pkg.exports != null) {
 		const target = resolveExports(pkg.exports, subpath, conditions);
-		if (target && (target.startsWith("./") || target.startsWith("../"))) {
+		if (target === EXCLUDED) return null;
+		if (typeof target === "string" && (target.startsWith("./") || target.startsWith("../"))) {
 			const resolved = finalizeFile(path.resolve(pkgDir, target));
 			if (resolved) return resolved;
 		}
@@ -127,19 +128,33 @@ function mainFields(pkg: PackageJson | null, conditions: string[]): string[] {
 }
 
 /**
+ * A resolved `exports` target: a relative target string, the {@link EXCLUDED}
+ * sentinel when an active condition maps to `null`, or `null` when nothing matched.
+ */
+type ExportTarget = string | typeof EXCLUDED | null;
+
+/**
+ * Sentinel for an explicitly excluded export (`"exports": { "bun": null }`). Node/Bun
+ * treat a `null` target as a hard block: resolution stops and does NOT fall through to
+ * `default`, a sibling condition, or the legacy `main`/index fields.
+ */
+const EXCLUDED: unique symbol = Symbol("excluded-export");
+
+/**
  * Resolve an `exports` value for `subpath` under `conditions`. Handles string
  * targets, condition maps, subpath maps, and `*` patterns per the Node exports spec.
  */
-function resolveExports(exports: unknown, subpath: string, conditions: string[]): string | null {
+function resolveExports(exports: unknown, subpath: string, conditions: string[]): ExportTarget {
 	if (typeof exports === "string") return subpath === "." ? exports : null;
+	if (exports === null) return subpath === "." ? EXCLUDED : null;
 	if (Array.isArray(exports)) {
 		for (const entry of exports) {
 			const resolved = resolveExports(entry, subpath, conditions);
-			if (resolved) return resolved;
+			if (resolved !== null) return resolved;
 		}
 		return null;
 	}
-	if (!exports || typeof exports !== "object") return null;
+	if (typeof exports !== "object") return null;
 
 	const record = exports as Record<string, unknown>;
 	let isSubpathMap = false;
@@ -179,31 +194,33 @@ function resolveExports(exports: unknown, subpath: string, conditions: string[])
 	}
 	if (best) {
 		const target = resolveConditional(best.value, conditions);
-		if (target) return target.replace(/\*/g, best.captured);
+		return typeof target === "string" ? target.replace(/\*/g, best.captured) : target;
 	}
 	return null;
 }
 
 /**
- * Collapse a conditional export value to a string target. Object keys are evaluated
- * in declaration order — the first key active in `conditions` (or `default`) wins,
- * matching Node's condition-resolution semantics.
+ * Collapse a conditional export value to a target. Object keys are evaluated in
+ * declaration order — the first key active in `conditions` (or `default`) wins,
+ * matching Node's condition-resolution semantics. A matched condition whose target is
+ * `null` yields {@link EXCLUDED} and stops the search.
  */
-function resolveConditional(value: unknown, conditions: string[]): string | null {
+function resolveConditional(value: unknown, conditions: string[]): ExportTarget {
+	if (value === null) return EXCLUDED;
 	if (typeof value === "string") return value;
 	if (Array.isArray(value)) {
 		for (const entry of value) {
 			const resolved = resolveConditional(entry, conditions);
-			if (resolved) return resolved;
+			if (resolved !== null) return resolved;
 		}
 		return null;
 	}
-	if (!value || typeof value !== "object") return null;
+	if (typeof value !== "object") return null;
 	const record = value as Record<string, unknown>;
 	for (const key in record) {
 		if (key !== "default" && !conditions.includes(key)) continue;
 		const resolved = resolveConditional(record[key], conditions);
-		if (resolved) return resolved;
+		if (resolved !== null) return resolved;
 	}
 	return null;
 }

--- a/packages/coding-agent/test/core/js-executor.test.ts
+++ b/packages/coding-agent/test/core/js-executor.test.ts
@@ -93,6 +93,24 @@ describe("executeJs", () => {
 		expect(resetResult.output.trim()).toBe("undefined");
 	});
 
+	it("resolves a bare package subpath import that carries a query suffix", async () => {
+		const pkgDir = path.join(tempDir.path(), "node_modules", "qpkg");
+		await Bun.write(
+			path.join(pkgDir, "package.json"),
+			JSON.stringify({ name: "qpkg", version: "1.0.0", exports: { "./feature": "./feature.js" } }),
+		);
+		await Bun.write(path.join(pkgDir, "feature.js"), "export const marker = 'feature-loaded';");
+
+		const result = await executeJs("const m = await import('qpkg/feature?v=1'); return m.marker;", {
+			sessionId,
+			session,
+			sessionFile,
+			reset: true,
+		});
+		expect(result.exitCode).toBe(0);
+		expect(result.output.trim()).toBe("feature-loaded");
+	});
+
 	it("parallel() barriers until every thunk settles and throws the lowest-index error", async () => {
 		const result = await executeJs(
 			[


### PR DESCRIPTION
## Repro
In the compiled `omp` binary, an eval JS cell cannot resolve a project dependency by bare specifier even though the kernel's `process.cwd()` is the project directory and the package is installed there; the same calls work under `node -e` / `bun -e`. Reproduced with a minimal `bun build --compile` binary mirroring `local-module-loader`'s resolution, run from a project dir containing `node_modules/xlsx`:

```
$ ./omp-test $PROJ
{
  "resolveSync": "ERR Cannot find package 'xlsx' from '.../proj'",
  "require":     "ERR Cannot find package 'xlsx' from '.../proj/[eval]/[eval]'",
  "import":      "ERR Cannot find package 'xlsx' from '/$bunfs/root/omp-test'",
  "importAbs":   "object"          // import() of the absolute xlsx.mjs works
}
$ bun entry.ts $PROJ   # same code, uncompiled -> all resolve
```

Confirmed compiled-binary specific (reproduced on Linux x64, not macOS-only).

## Cause
`bun build --compile` roots module resolution at the embedded `$bunfs`, so `Bun.resolveSync`, `createRequire`, and bare `import()` never consult the project's on-disk `node_modules`. `local-module-loader.ts`'s `resolveImportSpecifier` calls `Bun.resolveSync(source, cwd)`; when it throws (always, for a bare project dep in the compiled binary) the code fell back to passing the bare specifier straight to `import()`, which then resolved against `$bunfs`. The `require()` path (`buildRequire` -> `createRequire`) failed the same way. Absolute-**file** imports do work in the compiled binary, so resolving the specifier to an absolute path ourselves is sufficient.

## Fix
- Add `src/eval/js/shared/node-modules-resolver.ts`: `resolveBareSpecifier(specifier, baseDir, conditions)` walks the on-disk `node_modules` chain from `baseDir` and resolves the package entry to an absolute file path, honoring `exports` conditions + subpath `*` patterns and `main`/`module`/index fallbacks. `IMPORT_CONDITIONS` / `REQUIRE_CONDITIONS` pick the right condition per call site.
- `local-module-loader.ts`: `resolveImportSpecifier` now falls back to the on-disk resolver when `Bun.resolveSync` fails (import path); `buildRequire` wraps the native require so a `MODULE_NOT_FOUND`/`ERR_MODULE_NOT_FOUND` on a bare specifier retries via the on-disk resolver + `require(absPath)`. Dev builds resolve via Bun and never hit the fallback.
- Add `node-modules-resolver.test.ts` covering condition selection, legacy `main`/index fallback, scoped packages, subpath-pattern exports, chain walk-up, and unresolvable specifiers.

## Verification
`bun test src/eval/js/shared/node-modules-resolver.test.ts` -> 5 pass / 9 expect(). `bun run check:types` and `bun run lint` clean on the changed files. Also verified in a fresh `bun build --compile` binary that `resolveBareSpecifier` + `require(absPath)` / `import(fileURL)` load `xlsx`, a scoped package, a subpath-pattern export, and a `main`-only package from on-disk `node_modules`, and returns `null` for a missing package. Fixes #10496