### PR TITLE
fix(vibe): retract mode context on exit

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Claude marketplace MCP servers now resolve environment placeholders in stdio environment values instead of passing strings such as `${NAME:-}` literally ([#10481](https://github.com/can1357/oh-my-pi/pull/10481) by [@mrexodia](https://github.com/mrexodia)).
+- Exiting Vibe mode now removes its restrictions from subsequent model turns, including restored sessions ([#10500](https://github.com/can1357/oh-my-pi/issues/10500)).
 ## [18.1.2] - 2026-09-01
 
 ### Added

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -319,6 +319,7 @@ import {
 	SKILL_PROMPT_MESSAGE_TYPE,
 	sanitizeAssistantForReparentedHistory,
 	USER_INTERRUPT_LABEL,
+	VIBE_MODE_CONTEXT_MESSAGE_TYPE,
 } from "./messages";
 import { ModelControls, type ModelControlsHost } from "./model-controls";
 import { isPrewalkPlanNudge, PrewalkCoordinator, type PrewalkCoordinatorHost } from "./prewalk";
@@ -2571,9 +2572,9 @@ export class AgentSession {
 
 	#persistMessageEnd(message: AgentMessage): void {
 		if (message.role === "hookMessage" || message.role === "custom") {
-			// Prewalk's plan nudge is a one-run steering instruction. Persisting it would
-			// resurrect the consumed prompt on resume, fork, or any context rebuild.
-			if (!isPrewalkPlanNudge(message)) {
+			// One-run instructions must not return from persisted history: prewalk
+			// nudges are consumed once, and Vibe context is rebuilt only while active.
+			if (!isPrewalkPlanNudge(message) && message.customType !== VIBE_MODE_CONTEXT_MESSAGE_TYPE) {
 				this.sessionManager.appendCustomMessageEntry(
 					message.customType,
 					message.content,
@@ -5303,6 +5304,16 @@ export class AgentSession {
 
 	setVibeModeState(state: VibeModeState | undefined): void {
 		this.#vibeModeState = state;
+		if (state?.enabled) return;
+
+		const messages = this.agent.state.messages;
+		const filtered = messages.filter(
+			message => message.role !== "custom" || message.customType !== VIBE_MODE_CONTEXT_MESSAGE_TYPE,
+		);
+		if (filtered.length === messages.length) return;
+		this.agent.replaceMessages(filtered);
+		this.#advisors.resetAllRuntimes("vibe-mode-exit");
+		this.#closeCodexProviderSessionsForHistoryRewrite();
 	}
 
 	#assertVibeSessionTransitionAllowed(action: string): void {
@@ -5617,7 +5628,7 @@ export class AgentSession {
 		if (!this.#vibeModeState?.enabled) return null;
 		return {
 			role: "custom",
-			customType: "vibe-mode-context",
+			customType: VIBE_MODE_CONTEXT_MESSAGE_TYPE,
 			content: prompt.render(vibeModeActivePrompt, {
 				todoAvailable: this.getActiveToolNames().includes("todo"),
 			}),

--- a/packages/coding-agent/src/session/messages.ts
+++ b/packages/coding-agent/src/session/messages.ts
@@ -45,6 +45,9 @@ export const LSP_LATE_DIAGNOSTIC_MESSAGE_TYPE = "lsp-late-diagnostic";
 export const BACKGROUND_TAN_DISPATCH_MESSAGE_TYPE = "background-tan-dispatch";
 export const PREWALK_PLAN_MESSAGE_TYPE = "prewalk-plan";
 
+/** Custom message type for the transient Vibe mode directive. */
+export const VIBE_MODE_CONTEXT_MESSAGE_TYPE = "vibe-mode-context";
+
 /**
  * Logs provider-error turns so their actual cause is available outside the
  * session transcript. No-op for non-error stop reasons.

--- a/packages/coding-agent/src/session/session-context.ts
+++ b/packages/coding-agent/src/session/session-context.ts
@@ -15,6 +15,7 @@ import {
 	isEmptyErrorTurn,
 	normalizeCustomMessagePayload,
 	PREWALK_PLAN_MESSAGE_TYPE,
+	VIBE_MODE_CONTEXT_MESSAGE_TYPE,
 } from "./messages";
 import { type CompactionEntry, EPHEMERAL_MODEL_CHANGE_ROLE, type SessionEntry } from "./session-entries";
 
@@ -348,7 +349,12 @@ export function buildSessionContext(
 			}
 			pushMessage(entry.message);
 		} else if (entry.type === "custom_message") {
-			if (!options?.transcript && entry.customType === PREWALK_PLAN_MESSAGE_TYPE) return;
+			if (
+				!options?.transcript &&
+				(entry.customType === PREWALK_PLAN_MESSAGE_TYPE || entry.customType === VIBE_MODE_CONTEXT_MESSAGE_TYPE)
+			) {
+				return;
+			}
 			if (!isCustomMessageContent(entry.content)) return;
 			const normalized = normalizeCustomMessagePayload(entry);
 			const attribution = entry.attribution === undefined ? undefined : normalized.attribution;

--- a/packages/coding-agent/test/interactive-mode-vibe-toggle.test.ts
+++ b/packages/coding-agent/test/interactive-mode-vibe-toggle.test.ts
@@ -18,6 +18,7 @@ import { InteractiveMode } from "@oh-my-pi/pi-coding-agent/modes/interactive-mod
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import type { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { convertToLlm, VIBE_MODE_CONTEXT_MESSAGE_TYPE } from "@oh-my-pi/pi-coding-agent/session/messages";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import { FileSessionStorage, type WriteTextAtomicOptions } from "@oh-my-pi/pi-coding-agent/session/session-storage";
 import { VIBE_TOOL_NAMES } from "@oh-my-pi/pi-coding-agent/tools/vibe";
@@ -115,6 +116,7 @@ describe("InteractiveMode vibe mode toggle", () => {
 					tools: [],
 					messages: [],
 				},
+				convertToLlm,
 				streamFn: (...args) => {
 					if (!streamFn) throw new Error("No test stream configured");
 					return streamFn(...args);
@@ -164,6 +166,37 @@ describe("InteractiveMode vibe mode toggle", () => {
 		expect(mode.vibeModeEnabled).toBe(false);
 		expect(session.getActiveToolNames()).toEqual([]);
 		expect(session.getAllToolNames().toSorted()).toEqual(["read", "todo"]);
+	});
+
+	it("removes the Vibe directive from provider context on exit", async () => {
+		const vibeDirectivePerCall: boolean[] = [];
+		streamFn = (_model, context) => {
+			vibeDirectivePerCall.push(JSON.stringify(context).includes("<vibe-mode>"));
+			const stream = new AssistantMessageEventStream();
+			queueMicrotask(() => {
+				stream.push({ type: "done", reason: "stop", message: createAssistantMessage("Done") });
+			});
+			return stream;
+		};
+
+		await mode.handleVibeModeCommand();
+		await session.prompt("Delegate this");
+		await mode.handleVibeModeCommand();
+		await session.prompt("Use the restored tools");
+
+		expect(vibeDirectivePerCall).toEqual([true, false]);
+	});
+
+	it("omits persisted Vibe directives from restored model context", () => {
+		session.sessionManager.appendCustomMessageEntry(
+			VIBE_MODE_CONTEXT_MESSAGE_TYPE,
+			"<vibe-mode>stale</vibe-mode>",
+			false,
+		);
+
+		const restoredMessages = convertToLlm(session.sessionManager.buildSessionContext().messages);
+
+		expect(JSON.stringify(restoredMessages)).not.toContain("<vibe-mode>");
 	});
 
 	it("cancels an in-flight model turn before removing Vibe tools", async () => {


### PR DESCRIPTION
## Repro
Enable Vibe mode, complete a normal turn, toggle Vibe mode off without branching, then start another turn. `bun test packages/coding-agent/test/interactive-mode-vibe-toggle.test.ts -t 'removes the Vibe directive'` observed `<vibe-mode>` in both provider requests (`[true, true]`) instead of only the active-mode request (`[true, false]`).

## Cause
`AgentSession.#buildVibeModeMessage()` in `packages/coding-agent/src/session/agent-session.ts` injected `vibe-mode-context` as an ordinary custom message. The agent retained that message after `AgentSession.setVibeModeState(undefined)`, `#persistMessageEnd()` journaled it, and `buildSessionContext()` in `packages/coding-agent/src/session/session-context.ts` restored it as model context.

## Fix
- Remove live `vibe-mode-context` messages when Vibe state is disabled and reset provider/advisor context caches after the rewrite.
- Treat Vibe directives as transient: do not journal new copies, and omit legacy persisted copies from restored model context while retaining transcript reconstruction.
- Add live-exit and restored-session regression coverage plus an Unreleased changelog entry.

## Verification
`bun test packages/coding-agent/test/interactive-mode-vibe-toggle.test.ts` — 16 passed, 0 failed.

`bun --cwd=packages/coding-agent run check` — formatting, lint, and type checks passed.

Fixes #10500