### PR TITLE
fix(collab): show latest message after reconnect

### DIFF
--- a/docs/superpowers/plans/2026-09-01-collab-latest-on-rejoin.md
+++ b/docs/superpowers/plans/2026-09-01-collab-latest-on-rejoin.md
@@ -174,14 +174,16 @@ Start the local web app:
 bun run --cwd packages/collab-web dev
 ```
 
-Use the Mayor room fragment with `http://localhost:3000/#<roomId>.<key>`. In a browser:
+Create a verified live Mayor collab link, preserve its `#<roomId>.<key>` fragment, and open `http://localhost:3000/#<roomId>.<key>` with the browser tool. Keep the Mayor host connected so the relay retains the room. Then:
 
-1. Confirm that the transcript opens at the latest message.
-2. Scroll more than 40 pixels upward and confirm that new content does not move the viewport.
-3. Use the existing rejoin action after a disconnect.
-4. Confirm that the transcript returns to the latest message without manual scrolling.
+1. Wait until the `reconnecting…` status banner is absent.
+2. Read `.tr-root` geometry and confirm that `scrollHeight - scrollTop - clientHeight <= 40`.
+3. Set `.tr-root.scrollTop = 0`, dispatch a `scroll` event, and confirm that the distance from the bottom exceeds 40 pixels.
+4. Call Puppeteer's `page.setOfflineMode(true)` and wait for the `reconnecting…` status banner.
+5. Call `page.setOfflineMode(false)` and wait until the status banner disappears, which proves that the same room returned from `reconnecting` to `live`.
+6. Read `.tr-root` geometry again and confirm that `scrollHeight - scrollTop - clientHeight <= 40`.
 
-Expected: Initial join and rejoin show the latest message, while manual scrolling still pauses tail-follow between connections.
+Expected: The initial live connection opens at the tail, manual scrolling releases the bottom lock, and reconnecting the same live room restores the tail without an explicit **Rejoin** action.
 
 - [ ] **Step 4: Commit the changelog**
 

--- a/docs/superpowers/plans/2026-09-01-collab-latest-on-rejoin.md
+++ b/docs/superpowers/plans/2026-09-01-collab-latest-on-rejoin.md
@@ -1,0 +1,195 @@
+# Collab latest-message rejoin implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the main collab transcript open at its latest message whenever the connection first reaches or returns to `live`.
+
+**Architecture:** Pass the existing `GuestSnapshot.phase` into the main transcript through an optional prop. Reuse the current bottom lock through two small exported scroll operations so focused Bun tests can exercise browser geometry without adding a DOM dependency. Keep the compact agent transcript and manual upward scrolling unchanged.
+
+**Tech Stack:** TypeScript, React, Bun test, OMP collab web
+
+---
+
+### Task 1: Reset transcript tail-follow on live connections
+
+**Files:**
+- Modify: `packages/collab-web/test/transcript.test.tsx`
+- Modify: `packages/collab-web/src/components/transcript/Transcript.tsx:1-21,241-290`
+- Modify: `packages/collab-web/src/app.tsx:122-177`
+
+- [ ] **Step 1: Write the failing scroll behavior test**
+
+Add imports for the two scroll operations from `Transcript.tsx`. Add one test that uses a mutable fake element and lock reference:
+
+```tsx
+import {
+	followTranscriptTail,
+	Transcript,
+	updateTranscriptTailLock,
+} from "../src/components/transcript/Transcript";
+
+it("restores tail-follow when a connection becomes live", () => {
+	const element = { scrollTop: 0, scrollHeight: 1_000, clientHeight: 200 };
+	const lock = { current: false };
+
+	followTranscriptTail(element, lock, true);
+	expect(lock.current).toBe(true);
+	expect(element.scrollTop).toBe(1_000);
+
+	element.scrollTop = 600;
+	updateTranscriptTailLock(element, lock);
+	expect(lock.current).toBe(false);
+
+	element.scrollHeight = 1_200;
+	followTranscriptTail(element, lock);
+	expect(element.scrollTop).toBe(600);
+
+	followTranscriptTail(element, lock, true);
+	expect(lock.current).toBe(true);
+	expect(element.scrollTop).toBe(1_200);
+});
+```
+
+This sequence represents the initial `live` transition, manual scrolling more than 40 pixels from the bottom, a content update while unlocked, and the next `reconnecting` to `live` transition.
+
+- [ ] **Step 2: Run the focused test and verify that it fails**
+
+Run:
+
+```bash
+bun test packages/collab-web/test/transcript.test.tsx
+```
+
+Expected: FAIL because `followTranscriptTail` and `updateTranscriptTailLock` do not exist.
+
+- [ ] **Step 3: Add the minimal scroll operations**
+
+In `Transcript.tsx`, import `ConnectionPhase` with `ActiveTool`. Add structural types and exported functions near `TranscriptProps`:
+
+```tsx
+import type { ActiveTool, ConnectionPhase } from "../../lib/client";
+
+interface ScrollGeometry {
+	scrollTop: number;
+	readonly scrollHeight: number;
+	readonly clientHeight: number;
+}
+
+interface TailLock {
+	current: boolean;
+}
+
+export function followTranscriptTail(element: ScrollGeometry, lock: TailLock, force = false): void {
+	if (force) lock.current = true;
+	if (lock.current) element.scrollTop = element.scrollHeight;
+}
+
+export function updateTranscriptTailLock(element: ScrollGeometry, lock: TailLock): void {
+	lock.current = element.scrollHeight - element.scrollTop - element.clientHeight <= 40;
+}
+```
+
+Add the optional prop so `AgentDrawer` remains compatible:
+
+```tsx
+phase?: ConnectionPhase;
+```
+
+Destructure `phase` in `Transcript`. Replace the existing entry-update body and scroll-handler arithmetic with the two operations. Add a separate phase effect:
+
+```tsx
+useEffect(() => {
+	const el = rootRef.current;
+	if (el !== null) followTranscriptTail(el, lockRef);
+}, [entries, stream, activeTools, working]);
+
+useEffect(() => {
+	const el = rootRef.current;
+	if (phase === "live" && el !== null) followTranscriptTail(el, lockRef, true);
+}, [phase]);
+```
+
+The phase guard prevents the optional prop from changing compact agent transcripts.
+
+- [ ] **Step 4: Pass the main connection phase**
+
+In the `Transcript` call in `app.tsx`, add:
+
+```tsx
+phase={snap.phase}
+```
+
+Do not pass a phase from `AgentDrawer`.
+
+- [ ] **Step 5: Run the focused test and type check**
+
+Run:
+
+```bash
+bun test packages/collab-web/test/transcript.test.tsx
+bun run --cwd packages/collab-web check:types
+```
+
+Expected: Both commands exit with status 0. The transcript test includes the existing Markdown and live-tool cases plus the new scroll sequence.
+
+- [ ] **Step 6: Commit the behavior change**
+
+```bash
+git add packages/collab-web/test/transcript.test.tsx packages/collab-web/src/components/transcript/Transcript.tsx packages/collab-web/src/app.tsx
+git commit -m "fix(collab): show latest message after rejoin"
+```
+
+### Task 2: Document and verify the user-visible behavior
+
+**Files:**
+- Modify: `packages/collab-web/CHANGELOG.md:3-5`
+
+- [ ] **Step 1: Add the changelog entry**
+
+Under `## [Unreleased]`, add:
+
+```markdown
+### Fixed
+
+- The guest transcript now returns to the latest message after an initial connection or reconnect.
+```
+
+- [ ] **Step 2: Run package verification**
+
+Run:
+
+```bash
+bun test packages/collab-web/test/transcript.test.tsx
+bun run --cwd packages/collab-web check:types
+bun run --cwd packages/collab-web build
+```
+
+Expected: All commands exit with status 0.
+
+- [ ] **Step 3: Verify the actual collab surface**
+
+Start the local web app:
+
+```bash
+bun run --cwd packages/collab-web dev
+```
+
+Use the Mayor room fragment with `http://localhost:3000/#<roomId>.<key>`. In a browser:
+
+1. Confirm that the transcript opens at the latest message.
+2. Scroll more than 40 pixels upward and confirm that new content does not move the viewport.
+3. Use the existing rejoin action after a disconnect.
+4. Confirm that the transcript returns to the latest message without manual scrolling.
+
+Expected: Initial join and rejoin show the latest message, while manual scrolling still pauses tail-follow between connections.
+
+- [ ] **Step 4: Commit the changelog**
+
+```bash
+git add packages/collab-web/CHANGELOG.md
+git commit -m "docs(collab): note latest-message rejoin fix"
+```
+
+- [ ] **Step 5: Inspect the final change**
+
+Review the committed changes against `docs/superpowers/specs/2026-09-01-collab-latest-on-rejoin-design.md`. Confirm that no setting, storage, control, dependency, or `AgentDrawer` behavior changed.

--- a/docs/superpowers/specs/2026-09-01-collab-latest-on-rejoin-design.md
+++ b/docs/superpowers/specs/2026-09-01-collab-latest-on-rejoin-design.md
@@ -16,28 +16,29 @@ This behavior applies automatically. It does not add a preference, local storage
 
 ## Design
 
-`Session` passes `snap.phase` from `app.tsx` to `Transcript`. `Transcript` watches that connection phase. When the phase changes to `live`, it enables the existing bottom lock and sets the transcript element's `scrollTop` to its `scrollHeight`.
+`Session` passes `snap.phase` from `app.tsx` to the main `Transcript`. The new `phase?: ConnectionPhase` prop remains optional because `AgentDrawer` also renders `Transcript` without a session connection phase. When the main transcript's phase changes to `live`, it enables the existing bottom lock and sets the transcript element's `scrollTop` to its `scrollHeight`. The compact agent transcript remains unchanged.
 
-The existing transcript-update effect continues to follow entries, streaming messages, active tools, and working-state changes while the bottom lock remains enabled. The existing scroll handler continues to disable the lock when you move more than 40 pixels from the bottom.
+`Transcript.tsx` exposes the two small scroll operations that the component already needs: follow the tail when locked, with an explicit force option for a `live` transition, and update the lock from the current scroll geometry. The entry-update effect, phase effect, and scroll handler use these operations. This test seam accepts a scroll element and the existing lock reference; it does not add a controller, state machine, or dependency.
 
 An empty transcript requires no special branch. Setting `scrollTop` to an empty element's `scrollHeight` is safe.
 
 ## Files
 
 - `packages/collab-web/src/app.tsx`: Pass the connection phase to the transcript.
-- `packages/collab-web/src/components/transcript/Transcript.tsx`: Reset tail-follow when the connection reaches `live`.
-- `packages/collab-web/test/transcript.test.tsx`: Cover join, reconnect, and manual scrolling behavior.
+- `packages/collab-web/src/components/transcript/Transcript.tsx`: Add the optional connection phase, reset tail-follow when it reaches `live`, and expose the existing scroll operations for focused tests.
+- `packages/collab-web/test/transcript.test.tsx`: Exercise the scroll operations with a fake element.
 - `packages/collab-web/CHANGELOG.md`: Record the user-visible fix.
 
 ## Verification
 
-Add focused transcript tests that prove:
+Add focused transcript tests that use a fake scroll element and prove this sequence:
 
-1. An initial connection opens at the latest message.
-2. A reconnect opens at the latest message after you previously scrolled upward.
-3. Manual upward scrolling still disables automatic following after the reconnect jump.
+1. Entering `live` enables the lock and moves to the latest message.
+2. Scrolling more than 40 pixels upward disables the lock.
+3. A subsequent content update leaves the scroll position unchanged.
+4. A `reconnecting` to `live` transition enables the lock and returns to the latest message.
 
-Run the collab web transcript test and the package type check. Then open a live collab link, scroll upward, disconnect and rejoin, and confirm that the latest message appears without manual scrolling.
+Run the collab web transcript test and the package type check. Then open a live collab link, scroll upward, disconnect and rejoin, and confirm that the latest message appears without manual scrolling. The live-link smoke check verifies the React effect wiring that the current static-render test environment cannot execute.
 
 ## Risk and rollback
 

--- a/docs/superpowers/specs/2026-09-01-collab-latest-on-rejoin-design.md
+++ b/docs/superpowers/specs/2026-09-01-collab-latest-on-rejoin-design.md
@@ -1,0 +1,44 @@
+# Show the latest message after collab rejoin
+
+## Problem
+
+The collab web transcript preserves its bottom-lock state when `App` replaces a disconnected `GuestClient`. If you scroll upward before a disconnect, `Transcript` keeps `lockRef` disabled after the replacement client reaches `live`. The refreshed transcript therefore opens at the previous scroll position instead of the latest message.
+
+## Behavior
+
+When a collab connection first reaches `live`, or reaches `live` after a reconnect, the transcript jumps to its latest message once. After that jump, the existing bottom-lock behavior remains unchanged:
+
+- If you stay near the bottom, new content remains visible.
+- If you scroll upward, automatic following stops.
+- If you reconnect, the transcript returns to the latest message regardless of the prior scroll position.
+
+This behavior applies automatically. It does not add a preference, local storage, or a new control.
+
+## Design
+
+`Session` passes `snap.phase` from `app.tsx` to `Transcript`. `Transcript` watches that connection phase. When the phase changes to `live`, it enables the existing bottom lock and sets the transcript element's `scrollTop` to its `scrollHeight`.
+
+The existing transcript-update effect continues to follow entries, streaming messages, active tools, and working-state changes while the bottom lock remains enabled. The existing scroll handler continues to disable the lock when you move more than 40 pixels from the bottom.
+
+An empty transcript requires no special branch. Setting `scrollTop` to an empty element's `scrollHeight` is safe.
+
+## Files
+
+- `packages/collab-web/src/app.tsx`: Pass the connection phase to the transcript.
+- `packages/collab-web/src/components/transcript/Transcript.tsx`: Reset tail-follow when the connection reaches `live`.
+- `packages/collab-web/test/transcript.test.tsx`: Cover join, reconnect, and manual scrolling behavior.
+- `packages/collab-web/CHANGELOG.md`: Record the user-visible fix.
+
+## Verification
+
+Add focused transcript tests that prove:
+
+1. An initial connection opens at the latest message.
+2. A reconnect opens at the latest message after you previously scrolled upward.
+3. Manual upward scrolling still disables automatic following after the reconnect jump.
+
+Run the collab web transcript test and the package type check. Then open a live collab link, scroll upward, disconnect and rejoin, and confirm that the latest message appears without manual scrolling.
+
+## Risk and rollback
+
+The change affects only collab web transcript positioning. The main risk is overriding intentional reading position during a reconnect; the approved behavior requires that override. Reverting the phase-driven lock reset restores the current behavior without changing stored data or protocol state.

--- a/packages/collab-web/CHANGELOG.md
+++ b/packages/collab-web/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- The guest transcript now returns to the latest message after an initial connection or reconnect.
+
 ## [18.0.8] - 2026-08-27
 
 ### Added

--- a/packages/collab-web/src/app.tsx
+++ b/packages/collab-web/src/app.tsx
@@ -173,6 +173,7 @@ function Session({ client, onLeave, onRejoin }: SessionProps): ReactNode {
 							activeTools={snap.activeTools}
 							working={snap.working}
 							host={toolHost}
+							phase={snap.phase}
 						/>
 					</div>
 				</section>

--- a/packages/collab-web/src/components/transcript/Transcript.tsx
+++ b/packages/collab-web/src/components/transcript/Transcript.tsx
@@ -2,7 +2,7 @@ import type { AssistantMessage, ImageContent, SessionEntry, TextContent, ToolRes
 import { ChevronRight } from "lucide-react";
 import type { ReactNode } from "react";
 import { memo, useEffect, useMemo, useRef, useState } from "react";
-import type { ActiveTool } from "../../lib/client";
+import type { ActiveTool, ConnectionPhase } from "../../lib/client";
 import { fmtTokens } from "../../lib/format";
 import type { ToolRenderHost } from "../../tool-render";
 import { Markdown } from "./Markdown";
@@ -18,6 +18,29 @@ export interface TranscriptProps {
 	compact?: boolean; // dense variant for the agent drawer
 	/** Sub-session drill-down capabilities forwarded to tool renderers. */
 	host?: ToolRenderHost;
+	/** Main connection phase; absent for the agent drawer's compact transcript. */
+	phase?: ConnectionPhase;
+}
+
+interface ScrollGeometry {
+	scrollTop: number;
+	readonly scrollHeight: number;
+	readonly clientHeight: number;
+}
+
+interface TailLock {
+	current: boolean;
+}
+
+/** Scroll to the tail while locked; `force` re-arms the lock for a `live` transition. */
+export function followTranscriptTail(element: ScrollGeometry, lock: TailLock, force = false): void {
+	if (force) lock.current = true;
+	if (lock.current) element.scrollTop = element.scrollHeight;
+}
+
+/** Re-derive the lock from current scroll geometry (locked within 40px of the bottom). */
+export function updateTranscriptTailLock(element: ScrollGeometry, lock: TailLock): void {
+	lock.current = element.scrollHeight - element.scrollTop - element.clientHeight <= 40;
 }
 
 function Row({
@@ -239,7 +262,7 @@ const EntryRow = memo(function EntryRow({ entry, results, active, host }: EntryR
 }, entryRowEqual);
 
 export function Transcript(props: TranscriptProps): ReactNode {
-	const { entries, stream, streamDone, activeTools, working, compact, host } = props;
+	const { entries, stream, streamDone, activeTools, working, compact, host, phase } = props;
 
 	const results = useMemo(() => {
 		const map = new Map<string, ToolResultMessage>();
@@ -257,8 +280,15 @@ export function Transcript(props: TranscriptProps): ReactNode {
 	// Follow the tail while bottom-locked; releasing/re-arming happens in onScroll.
 	useEffect(() => {
 		const el = rootRef.current;
-		if (el !== null && lockRef.current) el.scrollTop = el.scrollHeight;
+		if (el !== null) followTranscriptTail(el, lockRef);
 	}, [entries, stream, activeTools, working]);
+
+	// A `live` transition (initial connect or reconnect) jumps to the latest message
+	// regardless of the prior scroll position. Absent for the agent drawer's compact transcript.
+	useEffect(() => {
+		const el = rootRef.current;
+		if (phase === "live" && el !== null) followTranscriptTail(el, lockRef, true);
+	}, [phase]);
 
 	// Active tools not already represented as toolCall blocks in committed rows or the stream ghost.
 	const renderedToolIds = new Set<string>();
@@ -284,9 +314,7 @@ export function Transcript(props: TranscriptProps): ReactNode {
 			className={`tr-root${compact === true ? " tr-root--compact" : ""}`}
 			onScroll={() => {
 				const el = rootRef.current;
-				if (el !== null) {
-					lockRef.current = el.scrollHeight - el.scrollTop - el.clientHeight <= 40;
-				}
+				if (el !== null) updateTranscriptTailLock(el, lockRef);
 			}}
 		>
 			{entries.length === 0 && stream === null && !working && <div className="tr-empty">no activity yet</div>}

--- a/packages/collab-web/test/transcript.test.tsx
+++ b/packages/collab-web/test/transcript.test.tsx
@@ -2,7 +2,11 @@ import { describe, expect, it } from "bun:test";
 import type { AssistantMessage, SessionEntry } from "@oh-my-pi/pi-wire";
 import { renderToStaticMarkup } from "react-dom/server";
 import "./transcript-dom-shim";
-import { Transcript } from "../src/components/transcript/Transcript";
+import {
+	followTranscriptTail,
+	Transcript,
+	updateTranscriptTailLock,
+} from "../src/components/transcript/Transcript";
 import type { ActiveTool } from "../src/lib/client";
 
 const TOOL_CALL_ID = "call-running-tool";
@@ -143,5 +147,28 @@ describe("Transcript message Markdown", () => {
 
 		expect(countElements(html, ".tr-row--user .tr-md code")).toBe(1);
 		expect(countElements(html, ".tr-row--user .tr-md strong")).toBe(1);
+	});
+});
+
+describe("Transcript tail-follow scroll operations", () => {
+	it("restores tail-follow when a connection becomes live", () => {
+		const element = { scrollTop: 0, scrollHeight: 1_000, clientHeight: 200 };
+		const lock = { current: false };
+
+		followTranscriptTail(element, lock, true);
+		expect(lock.current).toBe(true);
+		expect(element.scrollTop).toBe(1_000);
+
+		element.scrollTop = 600;
+		updateTranscriptTailLock(element, lock);
+		expect(lock.current).toBe(false);
+
+		element.scrollHeight = 1_200;
+		followTranscriptTail(element, lock);
+		expect(element.scrollTop).toBe(600);
+
+		followTranscriptTail(element, lock, true);
+		expect(lock.current).toBe(true);
+		expect(element.scrollTop).toBe(1_200);
 	});
 });


### PR DESCRIPTION
## Summary
- Return the guest transcript to the latest message when the initial connection or a reconnect becomes live.
- Preserve manual scroll position during ordinary transcript updates.
- Add focused regression coverage and document the behavior change.

## Test plan
- `bun test packages/collab-web/test` — 94 passed, 0 failed.
- `bun run --cwd packages/collab-web check:types` — passed.
- `bun run --cwd packages/collab-web build` — passed.
- Browser smoke check — scrolled away, observed `reconnecting…`, and returned to the transcript tail after reconnect.