### PR TITLE
fix(session): suppress eager-todo prelude while prewalk is armed

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - TypeScript code intelligence now works on TypeScript 7 projects: the built-in `typescript-native` server runs `tsc --lsp --stdio` when the resolved TypeScript install no longer ships `tsserver.js`, replacing `typescript-language-server` for that project.
 - Claude marketplace MCP servers now resolve environment placeholders in stdio environment values instead of passing strings such as `${NAME:-}` literally ([#10481](https://github.com/can1357/oh-my-pi/pull/10481) by [@mrexodia](https://github.com/mrexodia)).
-- Fixed prewalk conflicting with `todo.eager=always`: the forced eager-todo prelude ("call todo first this turn") was injected alongside the prewalk plan nudge ("write a complete plan first, then todo"), giving the model contradictory instructions; the eager-todo prelude is now suppressed while a prewalk is armed ([#10510](https://github.com/can1357/oh-my-pi/issues/10510)).
+- Fixed prewalk conflicting with `todo.eager=always`: the forced eager-todo prelude ("call todo first this turn") was injected alongside the prewalk plan nudge ("write a complete plan first, then todo"), giving the model contradictory instructions; the eager-todo prelude is now suppressed only when prewalk will perform a handoff ([#10510](https://github.com/can1357/oh-my-pi/issues/10510)).
 ## [18.1.2] - 2026-09-01
 
 ### Added

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - TypeScript code intelligence now works on TypeScript 7 projects: the built-in `typescript-native` server runs `tsc --lsp --stdio` when the resolved TypeScript install no longer ships `tsserver.js`, replacing `typescript-language-server` for that project.
 - Claude marketplace MCP servers now resolve environment placeholders in stdio environment values instead of passing strings such as `${NAME:-}` literally ([#10481](https://github.com/can1357/oh-my-pi/pull/10481) by [@mrexodia](https://github.com/mrexodia)).
+- Fixed prewalk conflicting with `todo.eager=always`: the forced eager-todo prelude ("call todo first this turn") was injected alongside the prewalk plan nudge ("write a complete plan first, then todo"), giving the model contradictory instructions; the eager-todo prelude is now suppressed while a prewalk is armed ([#10510](https://github.com/can1357/oh-my-pi/issues/10510)).
 ## [18.1.2] - 2026-09-01
 
 ### Added

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1166,6 +1166,7 @@ export class AgentSession {
 			getEnabledToolNames: () => this.getEnabledToolNames(),
 			toolRegistry: () => this.#tools.registry,
 			planModeEnabled: () => this.#planModeState?.enabled === true,
+			prewalkArmed: () => this.#prewalk.state !== undefined,
 			consumeLastServedToolChoiceLabel: () => this.#toolChoiceQueue.consumeLastServedLabel(),
 		};
 		this.#todo = new TodoTracker(todoHost);

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1166,7 +1166,7 @@ export class AgentSession {
 			getEnabledToolNames: () => this.getEnabledToolNames(),
 			toolRegistry: () => this.#tools.registry,
 			planModeEnabled: () => this.#planModeState?.enabled === true,
-			prewalkArmed: () => this.#prewalk.state !== undefined,
+			prewalkWillHandoff: () => this.#prewalk.willHandoff,
 			consumeLastServedToolChoiceLabel: () => this.#toolChoiceQueue.consumeLastServedLabel(),
 		};
 		this.#todo = new TodoTracker(todoHost);

--- a/packages/coding-agent/src/session/prewalk.ts
+++ b/packages/coding-agent/src/session/prewalk.ts
@@ -109,6 +109,12 @@ export class PrewalkCoordinator {
 		return this.#prewalk;
 	}
 
+	/** Whether the armed prewalk would perform a model or thinking-level handoff. */
+	get willHandoff(): boolean {
+		const prewalk = this.#prewalk;
+		return prewalk !== undefined && !this.#isNoop(prewalk);
+	}
+
 	#isNoop(prewalk: Prewalk): boolean {
 		return prewalkWouldBeNoop(
 			this.#host.model(),

--- a/packages/coding-agent/src/session/todo-tracker.ts
+++ b/packages/coding-agent/src/session/todo-tracker.ts
@@ -57,6 +57,8 @@ export interface TodoTrackerHost {
 	getEnabledToolNames(): string[];
 	toolRegistry(): Map<string, AgentTool>;
 	planModeEnabled(): boolean;
+	/** Whether a one-way prewalk switch is armed; its plan nudge owns todo creation. */
+	prewalkArmed(): boolean;
 	consumeLastServedToolChoiceLabel(): string | undefined;
 }
 
@@ -134,6 +136,9 @@ export class TodoTracker {
 		const mode = this.#host.settings.get("todo.eager");
 		if (mode === "default" || !this.#host.settings.get("todo.enabled")) return undefined;
 		if (this.#host.planModeEnabled() || this.#phases.length > 0) return undefined;
+		// A prewalk plan nudge drives todo creation in a plan-first-then-todo order;
+		// the forced eager prelude's "call todo first this turn" contradicts it (#10510).
+		if (this.#host.prewalkArmed()) return undefined;
 		if (promptText !== undefined) {
 			if (this.#host.agent.state.messages.some(message => message.role === "user")) return undefined;
 			const trimmedPromptText = promptText.trimEnd();

--- a/packages/coding-agent/src/session/todo-tracker.ts
+++ b/packages/coding-agent/src/session/todo-tracker.ts
@@ -57,8 +57,8 @@ export interface TodoTrackerHost {
 	getEnabledToolNames(): string[];
 	toolRegistry(): Map<string, AgentTool>;
 	planModeEnabled(): boolean;
-	/** Whether a one-way prewalk switch is armed; its plan nudge owns todo creation. */
-	prewalkArmed(): boolean;
+	/** Whether prewalk will hand off after its plan nudge owns todo creation. */
+	prewalkWillHandoff(): boolean;
 	consumeLastServedToolChoiceLabel(): string | undefined;
 }
 
@@ -136,9 +136,9 @@ export class TodoTracker {
 		const mode = this.#host.settings.get("todo.eager");
 		if (mode === "default" || !this.#host.settings.get("todo.enabled")) return undefined;
 		if (this.#host.planModeEnabled() || this.#phases.length > 0) return undefined;
-		// A prewalk plan nudge drives todo creation in a plan-first-then-todo order;
+		// An actionable prewalk drives todo creation in a plan-first-then-todo order;
 		// the forced eager prelude's "call todo first this turn" contradicts it (#10510).
-		if (this.#host.prewalkArmed()) return undefined;
+		if (this.#host.prewalkWillHandoff()) return undefined;
 		if (promptText !== undefined) {
 			if (this.#host.agent.state.messages.some(message => message.role === "user")) return undefined;
 			const trimmedPromptText = promptText.trimEnd();

--- a/packages/coding-agent/test/issue-10510-repro.test.ts
+++ b/packages/coding-agent/test/issue-10510-repro.test.ts
@@ -73,9 +73,11 @@ describe("issue #10510: prewalk + eager-todo conflict", () => {
 	}
 
 	/** Runs a first-turn prompt and returns every hidden/visible text sent to the model. */
-	async function collectInjectedText(options: { prewalk: boolean }): Promise<string> {
+	async function collectInjectedText(options: { prewalk: "handoff" | "noop" | "off" }): Promise<string> {
 		const primary = modelOrThrow("claude-sonnet-4-5");
-		const target = modelOrThrow("claude-sonnet-4-6");
+		const handoffTarget = modelOrThrow("claude-sonnet-4-6");
+		const prewalkTarget =
+			options.prewalk === "handoff" ? handoffTarget : options.prewalk === "noop" ? primary : undefined;
 		const recordTool = mkTool("record", "ok");
 		const writeTool = mkTool("write", "wrote");
 		const todoTool = mkTool("todo", "listed");
@@ -116,7 +118,7 @@ describe("issue #10510: prewalk + eager-todo conflict", () => {
 			}),
 			modelRegistry,
 			toolRegistry,
-			...(options.prewalk ? { prewalk: { target } } : {}),
+			...(prewalkTarget ? { prewalk: { target: prewalkTarget } } : {}),
 		});
 
 		await session.prompt("do the task");
@@ -125,13 +127,19 @@ describe("issue #10510: prewalk + eager-todo conflict", () => {
 	}
 
 	it("suppresses the forced eager-todo prelude while prewalk is armed", async () => {
-		const text = await collectInjectedText({ prewalk: true });
+		const text = await collectInjectedText({ prewalk: "handoff" });
 		expect(text.includes("write complete plan")).toBe(true);
 		expect(text.includes("You MUST call") && text.includes("first in this turn")).toBe(false);
 	});
 
 	it("still injects the forced eager-todo prelude when prewalk is not armed", async () => {
-		const text = await collectInjectedText({ prewalk: false });
+		const text = await collectInjectedText({ prewalk: "off" });
+		expect(text.includes("write complete plan")).toBe(false);
+		expect(text.includes("You MUST call") && text.includes("first in this turn")).toBe(true);
+	});
+
+	it("keeps the forced eager-todo prelude when the armed prewalk is a no-op", async () => {
+		const text = await collectInjectedText({ prewalk: "noop" });
 		expect(text.includes("write complete plan")).toBe(false);
 		expect(text.includes("You MUST call") && text.includes("first in this turn")).toBe(true);
 	});

--- a/packages/coding-agent/test/issue-10510-repro.test.ts
+++ b/packages/coding-agent/test/issue-10510-repro.test.ts
@@ -1,0 +1,138 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import * as path from "node:path";
+import { type } from "@oh-my-pi/omptype";
+import { Agent, type AgentMessage, type AgentTool } from "@oh-my-pi/pi-agent-core";
+import { type Api, Effort, type Model } from "@oh-my-pi/pi-ai";
+import { createMockModel, type MockResponse } from "@oh-my-pi/pi-ai/providers/mock";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import type { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { convertToLlm } from "@oh-my-pi/pi-coding-agent/session/messages";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { TempDir } from "@oh-my-pi/pi-utils";
+import { createInMemoryAuthStorage } from "./helpers/agent-session-setup";
+
+/**
+ * Issue #10510: with prewalk armed and `todo.eager=always`, the session injected
+ * two contradictory hidden system messages — the forced eager-todo prelude
+ * ("call todo first this turn") and the prewalk plan nudge ("write a complete
+ * plan first, then todo"). Prewalk's plan flow already owns todo creation, so
+ * the eager prelude must yield to it while a prewalk is armed.
+ */
+describe("issue #10510: prewalk + eager-todo conflict", () => {
+	let tempDir: TempDir;
+	let authStorage: AuthStorage;
+	let modelRegistry: ModelRegistry;
+
+	beforeAll(() => {
+		tempDir = TempDir.createSync("@pi-issue-10510-");
+		authStorage = createInMemoryAuthStorage();
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		modelRegistry = new ModelRegistry(authStorage, path.join(tempDir.path(), "models.yml"));
+	});
+
+	afterAll(() => {
+		authStorage.close();
+		tempDir.removeSync();
+	});
+
+	function modelOrThrow(id: string): Model<Api> {
+		const model = getBundledModel("anthropic", id);
+		if (!model) throw new Error(`Expected bundled model ${id}`);
+		return model;
+	}
+
+	function messageText(message: AgentMessage): string {
+		if (!("content" in message)) return "";
+		const content = message.content;
+		if (typeof content === "string") return content;
+		if (!Array.isArray(content)) return "";
+		const parts: string[] = [];
+		for (const block of content) {
+			if (block && typeof block === "object" && "type" in block && block.type === "text" && "text" in block) {
+				if (typeof block.text === "string") parts.push(block.text);
+			}
+		}
+		return parts.join("\n");
+	}
+
+	const mkTool = (name: string, result: string): AgentTool => ({
+		name,
+		label: name,
+		description: name,
+		parameters: type({}),
+		async execute() {
+			return { content: [{ type: "text", text: result }], details: undefined };
+		},
+	});
+
+	function toolCall(id: string, name: string): MockResponse {
+		return { content: [{ type: "toolCall", id, name, arguments: {} }], stopReason: "toolUse" };
+	}
+
+	/** Runs a first-turn prompt and returns every hidden/visible text sent to the model. */
+	async function collectInjectedText(options: { prewalk: boolean }): Promise<string> {
+		const primary = modelOrThrow("claude-sonnet-4-5");
+		const target = modelOrThrow("claude-sonnet-4-6");
+		const recordTool = mkTool("record", "ok");
+		const writeTool = mkTool("write", "wrote");
+		const todoTool = mkTool("todo", "listed");
+		const toolRegistry = new Map<string, AgentTool>([
+			[recordTool.name, recordTool],
+			[writeTool.name, writeTool],
+			[todoTool.name, todoTool],
+		]);
+		const mock = createMockModel({
+			responses: [toolCall("t1", "todo"), toolCall("t2", "record"), toolCall("t3", "write"), { content: ["done"] }],
+		});
+
+		const injected: string[] = [];
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: {
+				model: primary,
+				systemPrompt: ["Test"],
+				tools: [recordTool, writeTool, todoTool],
+				messages: [],
+				thinkingLevel: Effort.Medium,
+			},
+			convertToLlm,
+			getToolChoice: () => session.nextToolChoiceDirective(),
+			streamFn: (model, context, streamOptions) => {
+				for (const message of context.messages) injected.push(messageText(message));
+				return mock.stream(model, context, streamOptions);
+			},
+		});
+		const session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(tempDir.path()),
+			settings: Settings.isolated({
+				"compaction.enabled": false,
+				"todo.enabled": true,
+				"todo.eager": "always",
+				"todo.reminders": false,
+			}),
+			modelRegistry,
+			toolRegistry,
+			...(options.prewalk ? { prewalk: { target } } : {}),
+		});
+
+		await session.prompt("do the task");
+		await session.dispose();
+		return injected.join("\n---\n");
+	}
+
+	it("suppresses the forced eager-todo prelude while prewalk is armed", async () => {
+		const text = await collectInjectedText({ prewalk: true });
+		expect(text.includes("write complete plan")).toBe(true);
+		expect(text.includes("You MUST call") && text.includes("first in this turn")).toBe(false);
+	});
+
+	it("still injects the forced eager-todo prelude when prewalk is not armed", async () => {
+		const text = await collectInjectedText({ prewalk: false });
+		expect(text.includes("write complete plan")).toBe(false);
+		expect(text.includes("You MUST call") && text.includes("first in this turn")).toBe(true);
+	});
+});


### PR DESCRIPTION
## Repro
With `prewalk` armed and `todo.eager=always`, the session injects two contradictory hidden system messages into the same context: the forced eager-todo prelude (`prompts/system/eager-todo.md`) — *"You MUST call `todo` first in this turn"* plus a pinned `tool_choice=todo` — and the prewalk plan nudge (`prompts/system/prewalk-plan.md`) — *"write complete plan ... Then, same reply and only after complete plan, use todo tool"*. The forced todo-first ordering directly contradicts prewalk's plan-first-then-todo ordering, which the reporter's model flagged in its thinking trace. Reproduced with `bun test test/issue-10510-repro.test.ts`, which asserted the injected context contained both directives at once.

## Cause
`AgentSession` (`src/session/agent-session.ts`) builds the eager preludes via `TodoTracker.createEagerTodoPrelude` (`src/session/todo-tracker.ts`) with no awareness of prewalk. Prewalk's plan flow already owns todo creation in the correct order (plan text first, then the todo `init`, then implementation before the hand-off), so the eager-todo prelude is both redundant and directly conflicting while a prewalk is pending.

## Fix
- Added `prewalkArmed()` to `TodoTrackerHost` and wired it in `AgentSession` to `this.#prewalk.state !== undefined`.
- `createEagerTodoPrelude` now returns `undefined` when a prewalk is armed, gating at the source so both the first-turn prompt path and the post-compaction nudge path (`buildPostCompactionEagerNudges`) are covered.
- Added `test/issue-10510-repro.test.ts` with both branches (prewalk armed → eager-todo suppressed, plan nudge present; prewalk off → eager-todo still forced, no plan nudge).
- Changelog entry under `[Unreleased] > Fixed`.

## Verification
`bun test test/issue-10510-repro.test.ts` → 2 pass. `bun test test/agent-session-prewalk.test.ts test/agent-session-eager-todo.test.ts test/agent-session-eager-task.test.ts` → 39 pass, confirming the existing prewalk hand-off and eager-todo behaviors are unchanged. `bun run fix` clean.

Fixes #10510