### PR TITLE
fix(coding-agent): honor skill invocation axes from plugin metadata

### DIFF
--- a/docs/skills.md
+++ b/docs/skills.md
@@ -57,7 +57,7 @@ Supported frontmatter fields on the skill type:
 - `alwaysApply?: boolean`
 - `hide?: boolean`
 - `disableModelInvocation?: boolean` — model axis; a Claude Code / Pi convention (not part of the agentskills.io schema), normalized from kebab-case `disable-model-invocation`; alias of `hide`. Agent Plugins skills carry this and the user axis through `metadata` string values, e.g. `metadata: { disable-model-invocation: "true" }` and `metadata: { user-invocable: "false" }`.
-- `userInvocable?: boolean` — user axis; normalized from kebab-case `user-invocable`; defaults to `true`; when `false` the skill is not registered, completed, or dispatched as `/skill:<name>`
+- `userInvocable?: boolean` — user axis; normalized from kebab-case `user-invocable`; defaults to `true`. Parsed and stored, not yet enforced: no registration or dispatch path reads it at this commit, so a skill setting it is still addressable as `/skill:<name>`.
 - additional keys are preserved as unknown metadata
 
 Current runtime behavior:

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -56,7 +56,8 @@ Supported frontmatter fields on the skill type:
 - `globs?: string[]`
 - `alwaysApply?: boolean`
 - `hide?: boolean`
-- `disableModelInvocation?: boolean` (Agent Skills equivalent of `hide`; normalized from kebab-case `disable-model-invocation`)
+- `disableModelInvocation?: boolean` — model axis; a Claude Code / Pi convention (not part of the agentskills.io schema), normalized from kebab-case `disable-model-invocation`; alias of `hide`. Agent Plugins skills carry this and the user axis through `metadata` string values, e.g. `metadata: { disable-model-invocation: "true" }` and `metadata: { user-invocable: "false" }`.
+- `userInvocable?: boolean` — user axis; normalized from kebab-case `user-invocable`; defaults to `true`; when `false` the skill is not registered, completed, or dispatched as `/skill:<name>`
 - additional keys are preserved as unknown metadata
 
 Current runtime behavior:

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,7 @@
 - TypeScript code intelligence now works on TypeScript 7 projects: the built-in `typescript-native` server runs `tsc --lsp --stdio` when the resolved TypeScript install no longer ships `tsserver.js`, replacing `typescript-language-server` for that project.
 - Claude marketplace MCP servers now resolve environment placeholders in stdio environment values instead of passing strings such as `${NAME:-}` literally ([#10481](https://github.com/can1357/oh-my-pi/pull/10481) by [@mrexodia](https://github.com/mrexodia)).
 - Fixed prewalk conflicting with `todo.eager=always`: the forced eager-todo prelude ("call todo first this turn") was injected alongside the prewalk plan nudge ("write a complete plan first, then todo"), giving the model contradictory instructions; the eager-todo prelude is now suppressed only when prewalk will perform a handoff ([#10510](https://github.com/can1357/oh-my-pi/issues/10510)).
+- Agent Plugin skills that set an invocation axis now load instead of being skipped as invalid: carry `disable-model-invocation`, `user-invocable`, or `hide` as `"true"`/`"false"` strings inside the standard `metadata` map ([#10505](https://github.com/can1357/oh-my-pi/issues/10505)).
 ## [18.1.2] - 2026-09-01
 
 ### Added

--- a/packages/coding-agent/src/capability/skill.ts
+++ b/packages/coding-agent/src/capability/skill.ts
@@ -29,9 +29,9 @@ export interface SkillFrontmatter {
 	 */
 	disableModelInvocation?: boolean;
 	/**
-	 * User axis. When `false`, the skill is not registered, completed, or
-	 * dispatched as `/skill:<name>`; it stays loadable via `skill://<name>`
-	 * and, unless the model axis also opts out, advertised to the model.
+	 * User axis, parsed and stored but not yet enforced: no registration or
+	 * dispatch path reads it at this commit, so a skill setting it is still
+	 * addressable as `/skill:<name>`. The consumers land with the axis feature.
 	 * Normalized from kebab-case `user-invocable`. Defaults to `true`.
 	 */
 	userInvocable?: boolean;

--- a/packages/coding-agent/src/capability/skill.ts
+++ b/packages/coding-agent/src/capability/skill.ts
@@ -22,12 +22,19 @@ export interface SkillFrontmatter {
 	 */
 	hide?: boolean;
 	/**
-	 * Agent Skills standard equivalent of `hide`.
-	 * When `true`, the skill is excluded from the system prompt listing.
-	 * Normalized from kebab-case `disable-model-invocation` in YAML frontmatter.
-	 * @see https://agentskills.io/specification
+	 * Claude Code / Pi convention (not part of the agentskills.io schema):
+	 * when `true`, the skill is excluded from the system prompt listing.
+	 * Normalized from kebab-case `disable-model-invocation` and honored through
+	 * `metadata` on the Agent Plugins path.
 	 */
 	disableModelInvocation?: boolean;
+	/**
+	 * User axis. When `false`, the skill is not registered, completed, or
+	 * dispatched as `/skill:<name>`; it stays loadable via `skill://<name>`
+	 * and, unless the model axis also opts out, advertised to the model.
+	 * Normalized from kebab-case `user-invocable`. Defaults to `true`.
+	 */
+	userInvocable?: boolean;
 	[key: string]: unknown;
 }
 

--- a/packages/coding-agent/src/discovery/agent-plugin-format.ts
+++ b/packages/coding-agent/src/discovery/agent-plugin-format.ts
@@ -95,6 +95,12 @@ const SKILL_FIELDS: Record<string, true> = {
 	metadata: true,
 	compatibility: true,
 };
+/** Invocation keys omp honors from the spec-sanctioned `metadata` map. */
+const METADATA_INVOCATION_KEYS: Record<string, true> = {
+	"user-invocable": true,
+	"disable-model-invocation": true,
+	hide: true,
+};
 /** Skill `name` characters: Unicode letters/digits (Python `str.isalnum`) and hyphens. */
 const SKILL_NAME_CHARS_RE = /^[\p{L}\p{N}-]+$/u;
 
@@ -113,19 +119,52 @@ function validateSkillName(raw: unknown, dirName: string): string | null {
 	return null;
 }
 
+/** Outcome of validating `SKILL.md` frontmatter under Agent Plugins §7.1. */
+export interface AgentSkillFrontmatterCheck {
+	/** First fatal violation, or `null` when the skill may load. */
+	violation: string | null;
+	/** Honored omp conventions carried in `metadata`, for reporting. */
+	warnings: string[];
+}
+
 /**
  * Validate `SKILL.md` frontmatter against the Agent Skills specification
  * (https://agentskills.io/specification), the source of truth for skill
- * validity under Agent Plugins §7.1, mirroring the official skills-ref
- * reference validator: the frontmatter schema is CLOSED to its six fields and
- * any unexpected key rejects the skill. Returns the first violation, or `null`
- * when the skill conforms. Frontmatter keys must be raw (unnormalized).
+ * validity under Agent Plugins §7.1. The spec schema is closed to its six
+ * fields; any unexpected top-level key still rejects the skill. The omp
+ * invocation keys `user-invocable`, `disable-model-invocation`, and `hide`
+ * are honored through the spec-sanctioned `metadata` map when they carry the
+ * exact string `"true"` or `"false"`, and are reported as non-standard
+ * conventions rather than treated as fatal. Frontmatter keys must be raw
+ * (unnormalized).
  */
-export function validateAgentSkillFrontmatter(frontmatter: Record<string, unknown>, dirName: string): string | null {
+export function validateAgentSkillFrontmatter(
+	frontmatter: Record<string, unknown>,
+	dirName: string,
+): AgentSkillFrontmatterCheck {
+	const warnings: string[] = [];
 	for (const key in frontmatter) {
-		if (!SKILL_FIELDS[key]) return `unexpected frontmatter field "${key}"`;
+		if (!SKILL_FIELDS[key]) return { violation: `unexpected frontmatter field "${key}"`, warnings };
 	}
+	const violation = validateSpecFields(frontmatter, dirName);
+	if (violation === null) {
+		const metadata = frontmatter.metadata;
+		if (isRecord(metadata)) {
+			for (const key in metadata) {
+				if (!METADATA_INVOCATION_KEYS[key]) continue;
+				const value = metadata[key];
+				if (value !== "true" && value !== "false") continue;
+				warnings.push(
+					`honored invocation setting "metadata.${key}" (omp convention; not part of the Agent Skills schema)`,
+				);
+			}
+		}
+	}
+	return { violation, warnings };
+}
 
+/** Spec-field checks shared by the wrapper; assumes top-level keys are known. */
+function validateSpecFields(frontmatter: Record<string, unknown>, dirName: string): string | null {
 	const nameViolation = validateSkillName(frontmatter.name, dirName);
 	if (nameViolation !== null) return nameViolation;
 

--- a/packages/coding-agent/src/discovery/agent-plugins.ts
+++ b/packages/coding-agent/src/discovery/agent-plugins.ts
@@ -17,7 +17,7 @@
 import type { Dirent, Stats } from "node:fs";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import { getPluginsDir, isEnoent, normalizeFrontmatterKeys, parseFrontmatter } from "@oh-my-pi/pi-utils";
+import { getPluginsDir, isEnoent, isRecord, normalizeFrontmatterKeys, parseFrontmatter } from "@oh-my-pi/pi-utils";
 import { registerProvider } from "../capability";
 import { readFile } from "../capability/fs";
 import { type MCPServer, mcpCapability } from "../capability/mcp";
@@ -166,12 +166,15 @@ async function scanStandardSkills(realRoot: string, level: "user" | "project"): 
 				return;
 			}
 			// §7.1: the Agent Skills specification is the source of truth for skill
-			// validity; the frontmatter schema is closed per skills-ref, so client
-			// conventions like `enabled` reject the skill as an unexpected field.
-			// Non-conforming skills are skipped without affecting other components.
-			const violation = validateAgentSkillFrontmatter(rawFrontmatter, entry.name);
-			if (violation !== null) {
-				warnings.push(`Skipping skill "${entry.name}": ${violation}`);
+			// validity. The spec schema is closed, so unknown top-level keys like
+			// `enabled` still reject the skill; the invocation keys omp documents
+			// arrive through the spec-sanctioned `metadata` map and are honored with
+			// a reported deviation instead. Non-conforming skills are skipped
+			// without affecting other components.
+			const check = validateAgentSkillFrontmatter(rawFrontmatter, entry.name);
+			for (const warning of check.warnings) warnings.push(`Skill "${entry.name}": ${warning}`);
+			if (check.violation !== null) {
+				warnings.push(`Skipping skill "${entry.name}": ${check.violation}`);
 				return;
 			}
 			// Validation guarantees the frontmatter name matches the directory
@@ -179,6 +182,29 @@ async function scanStandardSkills(realRoot: string, level: "user" | "project"): 
 			// Store with the codebase's camelCase key convention (skill:// consumers,
 			// prompt hiding via disableModelInvocation, …).
 			const frontmatter = normalizeFrontmatterKeys(rawFrontmatter) as SkillFrontmatter;
+			// Fold the honored `metadata` invocation strings into camel booleans so
+			// downstream consumers observe the axes. Only exact "true"/"false" map;
+			// anything else is left unset and reported rather than silently honored.
+			const rawMetadata = rawFrontmatter.metadata;
+			if (isRecord(rawMetadata)) {
+				const pairs: Array<[string, "userInvocable" | "disableModelInvocation" | "hide"]> = [
+					["user-invocable", "userInvocable"],
+					["disable-model-invocation", "disableModelInvocation"],
+					["hide", "hide"],
+				];
+				for (const [key, camel] of pairs) {
+					const value = rawMetadata[key];
+					if (value === "true") {
+						frontmatter[camel] = true;
+					} else if (value === "false") {
+						frontmatter[camel] = false;
+					} else if (value !== undefined) {
+						warnings.push(
+							`Skill "${entry.name}": unrecognized value for "metadata.${key}": expected "true" or "false"`,
+						);
+					}
+				}
+			}
 			items.push({
 				name: entry.name,
 				containRoot: realRoot,

--- a/packages/coding-agent/test/discovery/agent-plugins.test.ts
+++ b/packages/coding-agent/test/discovery/agent-plugins.test.ts
@@ -432,6 +432,54 @@ describe("agent-plugins discovery", () => {
 		expect(warned(`unexpected frontmatter field "enabled"`)).toBe(true);
 	});
 
+	test("honors invocation axes from skill metadata on the standard path", async () => {
+		await writeManifest();
+		await writeSkill(
+			"model-hidden",
+			'name: model-hidden\ndescription: ok\nmetadata:\n  disable-model-invocation: "true"',
+		);
+		await writeSkill("user-hidden", 'name: user-hidden\ndescription: ok\nmetadata:\n  user-invocable: "false"');
+		await writeSkill(
+			"all-hidden",
+			'name: all-hidden\ndescription: ok\nmetadata:\n  hide: "true"\n  user-invocable: "false"',
+		);
+		await writeRegistry(pluginPath);
+
+		const skills = await loadCapability<Skill>("skills", { cwd: tempDir });
+		const fromPlugin = skills.all.filter(skill => skill._source.provider === "agent-plugins");
+		expect(fromPlugin.map(skill => skill.name).sort()).toEqual(["all-hidden", "model-hidden", "user-hidden"]);
+
+		const modelHidden = skills.all.find(skill => skill.name === "model-hidden");
+		expect(modelHidden?.frontmatter?.disableModelInvocation).toBe(true);
+		expect(modelHidden?.frontmatter?.userInvocable).not.toBe(false);
+
+		const userHidden = skills.all.find(skill => skill.name === "user-hidden");
+		expect(userHidden?.frontmatter?.userInvocable).toBe(false);
+		expect(userHidden?.frontmatter?.disableModelInvocation).not.toBe(true);
+
+		const allHidden = skills.all.find(skill => skill.name === "all-hidden");
+		expect(allHidden?.frontmatter?.hide).toBe(true);
+		expect(allHidden?.frontmatter?.userInvocable).toBe(false);
+
+		const warned = (needle: string) => skills.warnings.some(warning => warning.includes(needle));
+		expect(warned(`metadata.disable-model-invocation`)).toBe(true);
+		expect(warned(`metadata.user-invocable`)).toBe(true);
+	});
+
+	test("warns and ignores an unrecognized invocation value in metadata", async () => {
+		await writeManifest();
+		await writeSkill("fuzzy", "name: fuzzy\ndescription: ok\nmetadata:\n  user-invocable: definitely");
+		await writeRegistry(pluginPath);
+
+		const skills = await loadCapability<Skill>("skills", { cwd: tempDir });
+		const fuzzy = skills.all.find(skill => skill.name === "fuzzy");
+		expect(fuzzy).toBeDefined();
+		expect(fuzzy?.frontmatter?.userInvocable).toBeUndefined();
+		expect(skills.warnings.some(warning => warning.includes(`expected "true" or "false"`))).toBe(true);
+		// One owner reports each outcome: an invalid value is never also "honored".
+		expect(skills.warnings.some(warning => warning.includes("honored invocation setting"))).toBe(false);
+	});
+
 	test("rejects an escaping plugin.json symlink without consuming outside content", async () => {
 		// A fully valid Agent Plugins manifest OUTSIDE the package: if the client
 		// read it through the symlink, classification would succeed and the


### PR DESCRIPTION
Answers the fork @roboomp asked to settle before implementation ([triage comment on #10505](https://github.com/can1357/oh-my-pi/issues/10505#issuecomment-5500157439)) and makes both invocation axes expressible on the Agent Plugins path.

Scope, precisely: a top-level invocation key stays fatal by design, so #10505's literal repro is still rejected. What changes is that the axes now have a supported spelling on that path, through the carrier the spec already sanctions.

## Fork decision

1. **Which fork:** the closed Agent Skills schema stays closed. No new accepted top-level key, so the spec conformance the validator was built for is intact.
2. **Top-level field or `metadata`:** `metadata`. The spec sanctions it for client data and already constrains its values to strings, so nothing about the schema bends to carry omp conventions. A plugin skill writes:

   ```yaml
   metadata:
     disable-model-invocation: "true"
     user-invocable: "false"
   ```

3. **`hide` on the plugin path:** honored, through the same carrier (`metadata: { hide: "true" }`). A top-level `hide:` stays fatal: it is omp's own field, not a spec field, and admitting it at top level is exactly the deviation the closed schema exists to reject.

## What changes

- `validateAgentSkillFrontmatter` returns `{ violation, warnings }` instead of `string | null`, mirroring `AgentPluginManifestResult`'s existing shape. Unknown top-level keys stay fatal; honored `metadata` conventions are reported, once each.
- The loader folds the three `metadata` invocation strings into the camelCase booleans downstream consumers already read. Exactly `"true"`/`"false"` map; any other value is reported as unrecognized and left unset, so one owner reports each outcome.
- `SkillFrontmatter.disableModelInvocation`'s doc comment no longer credits agentskills.io. It is a Claude Code / Pi convention; `docs/skills.md` now says the same, documents the `metadata` carrier, and states the quoting requirement (an unquoted YAML boolean fails the string check and skips the skill).

## Scope note

`user-invocable` is recognized and folded here, but nothing honors it yet: the user axis lands in the follow-up PR that adds its consumers. This PR alone changes no dispatch behavior.

## Verification

- `bun check` green in the worktree (oxlint, oxfmt, tsgo, cargo check), rebased on current `main`.
- `bun test packages/coding-agent/test/discovery/agent-plugins.test.ts` — 33 pass, 0 fail. Three new cases: axes honored from `metadata`, an unrecognized value reported and ignored without a contradictory "honored" line, and the existing closed-schema rejections unchanged.
