### PR TITLE
feat(coding-agent): add independent user and model skill invocation axes

### DIFF
--- a/docs/skills.md
+++ b/docs/skills.md
@@ -57,7 +57,7 @@ Supported frontmatter fields on the skill type:
 - `alwaysApply?: boolean`
 - `hide?: boolean`
 - `disableModelInvocation?: boolean` — model axis; a Claude Code / Pi convention (not part of the agentskills.io schema), normalized from kebab-case `disable-model-invocation`; alias of `hide`. Agent Plugins skills carry this and the user axis through `metadata` string values, e.g. `metadata: { disable-model-invocation: "true" }` and `metadata: { user-invocable: "false" }`.
-- `userInvocable?: boolean` — user axis; normalized from kebab-case `user-invocable`; defaults to `true`; when `false` the skill is not registered, completed, or dispatched as `/skill:<name>`
+- `userInvocable?: boolean` — user axis; normalized from kebab-case `user-invocable`; defaults to `true`. Parsed and stored, not yet enforced: no registration or dispatch path reads it at this commit, so a skill setting it is still addressable as `/skill:<name>`.
 - additional keys are preserved as unknown metadata
 
 Current runtime behavior:

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -57,8 +57,16 @@ Supported frontmatter fields on the skill type:
 - `alwaysApply?: boolean`
 - `hide?: boolean`
 - `disableModelInvocation?: boolean` — model axis; a Claude Code / Pi convention (not part of the agentskills.io schema), normalized from kebab-case `disable-model-invocation`; alias of `hide`. Agent Plugins skills carry this and the user axis through `metadata` string values, e.g. `metadata: { disable-model-invocation: "true" }` and `metadata: { user-invocable: "false" }`.
-- `userInvocable?: boolean` — user axis; normalized from kebab-case `user-invocable`; defaults to `true`. Parsed and stored, not yet enforced: no registration or dispatch path reads it at this commit, so a skill setting it is still addressable as `/skill:<name>`.
+- `userInvocable?: boolean` — user axis; normalized from kebab-case `user-invocable`; defaults to `true`; when `false` the skill is not registered, completed, or dispatched as `/skill:<name>`; stays model-advertised and `skill://`-loadable
 - additional keys are preserved as unknown metadata
+
+Skills carry two independent invocation axes:
+
+- Model axis (`hide: true` or `disable-model-invocation: true`): omitted from the rendered `<skills>` listing and its token accounting; still reachable via `skill://<name>` and `/skill:<name>`.
+- User axis (`user-invocable: false`): never registered, completed, or dispatched as `/skill:<name>` on any frontend; still advertised to the model and reachable via `skill://<name>`.
+- Both: the skill stays installed and listed in `/extensions`, invocable by neither.
+
+Generic loaders accept both keys as top-level frontmatter (kebab-case, normalized to camelCase on load). The Agent Plugins loader keeps its closed spec schema, so a plugin skill must carry them as string entries under `metadata`, e.g. `metadata: { user-invocable: "false" }`; a `metadata` value other than the exact strings `"true"`/`"false"` is reported and ignored rather than honored.
 
 Current runtime behavior:
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -56,7 +56,8 @@ Supported frontmatter fields on the skill type:
 - `globs?: string[]`
 - `alwaysApply?: boolean`
 - `hide?: boolean`
-- `disableModelInvocation?: boolean` (Agent Skills equivalent of `hide`; normalized from kebab-case `disable-model-invocation`)
+- `disableModelInvocation?: boolean` — model axis; a Claude Code / Pi convention (not part of the agentskills.io schema), normalized from kebab-case `disable-model-invocation`; alias of `hide`. Agent Plugins skills carry this and the user axis through `metadata` string values, e.g. `metadata: { disable-model-invocation: "true" }` and `metadata: { user-invocable: "false" }`.
+- `userInvocable?: boolean` — user axis; normalized from kebab-case `user-invocable`; defaults to `true`; when `false` the skill is not registered, completed, or dispatched as `/skill:<name>`
 - additional keys are preserved as unknown metadata
 
 Current runtime behavior:

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Skills now carry two independent invocation axes: `disable-model-invocation` (or `hide`) keeps a skill out of the model's advertised catalog, while `user-invocable: false` withholds its `/skill:<name>` command on every frontend ([#10062](https://github.com/can1357/oh-my-pi/issues/10062)).
+
 ### Fixed
 
 - Anthropic sessions now keep tool-roster changes and warm-prefix pruning from invalidating preserved thinking or the prompt cache.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,7 @@
 - TypeScript code intelligence now works on TypeScript 7 projects: the built-in `typescript-native` server runs `tsc --lsp --stdio` when the resolved TypeScript install no longer ships `tsserver.js`, replacing `typescript-language-server` for that project.
 - Claude marketplace MCP servers now resolve environment placeholders in stdio environment values instead of passing strings such as `${NAME:-}` literally ([#10481](https://github.com/can1357/oh-my-pi/pull/10481) by [@mrexodia](https://github.com/mrexodia)).
 - Fixed prewalk conflicting with `todo.eager=always`: the forced eager-todo prelude ("call todo first this turn") was injected alongside the prewalk plan nudge ("write a complete plan first, then todo"), giving the model contradictory instructions; the eager-todo prelude is now suppressed only when prewalk will perform a handoff ([#10510](https://github.com/can1357/oh-my-pi/issues/10510)).
+- Agent Plugin skills that set an invocation axis now load instead of being skipped as invalid: carry `disable-model-invocation`, `user-invocable`, or `hide` as `"true"`/`"false"` strings inside the standard `metadata` map ([#10505](https://github.com/can1357/oh-my-pi/issues/10505)).
 ## [18.1.2] - 2026-09-01
 
 ### Added

--- a/packages/coding-agent/src/capability/skill-invocation.ts
+++ b/packages/coding-agent/src/capability/skill-invocation.ts
@@ -1,0 +1,32 @@
+import type { SkillFrontmatter } from "./skill";
+
+/** The two independent invocation axes resolved from skill frontmatter. */
+export interface SkillInvocationAxes {
+	/** Model axis: `true` omits the skill from the rendered `<skills>` listing. */
+	hide: boolean;
+	/** User axis: `false` makes `/skill:<name>` refuse to resolve to this skill. */
+	userInvocable: boolean;
+}
+
+/**
+ * Resolve both invocation axes. `hide` and its Claude Code / Pi alias
+ * `disable-model-invocation` gate the model axis (default: advertised);
+ * `user-invocable` gates the user axis (default: invocable). The axes are
+ * independent: a skill may opt out of either, both, or neither.
+ */
+export function skillInvocationAxes(frontmatter: SkillFrontmatter | undefined): SkillInvocationAxes {
+	return {
+		hide: frontmatter?.hide === true || frontmatter?.disableModelInvocation === true,
+		userInvocable: frontmatter?.userInvocable !== false,
+	};
+}
+
+/** `true` when the skill belongs in the model-facing `<skills>` listing. */
+export function isModelInvocable(skill: { hide?: boolean }): boolean {
+	return skill.hide !== true;
+}
+
+/** `true` when the skill may be invoked as `/skill:<name>`. */
+export function isUserInvocable(skill: { userInvocable?: boolean }): boolean {
+	return skill.userInvocable !== false;
+}

--- a/packages/coding-agent/src/capability/skill.ts
+++ b/packages/coding-agent/src/capability/skill.ts
@@ -29,9 +29,9 @@ export interface SkillFrontmatter {
 	 */
 	disableModelInvocation?: boolean;
 	/**
-	 * User axis. When `false`, the skill is not registered, completed, or
-	 * dispatched as `/skill:<name>`; it stays loadable via `skill://<name>`
-	 * and, unless the model axis also opts out, advertised to the model.
+	 * User axis, parsed and stored but not yet enforced: no registration or
+	 * dispatch path reads it at this commit, so a skill setting it is still
+	 * addressable as `/skill:<name>`. The consumers land with the axis feature.
 	 * Normalized from kebab-case `user-invocable`. Defaults to `true`.
 	 */
 	userInvocable?: boolean;

--- a/packages/coding-agent/src/capability/skill.ts
+++ b/packages/coding-agent/src/capability/skill.ts
@@ -29,9 +29,9 @@ export interface SkillFrontmatter {
 	 */
 	disableModelInvocation?: boolean;
 	/**
-	 * User axis, parsed and stored but not yet enforced: no registration or
-	 * dispatch path reads it at this commit, so a skill setting it is still
-	 * addressable as `/skill:<name>`. The consumers land with the axis feature.
+	 * User axis. When `false`, the skill is not registered, completed, or
+	 * dispatched as `/skill:<name>`; it stays loadable via `skill://<name>`
+	 * and, unless the model axis also opts out, advertised to the model.
 	 * Normalized from kebab-case `user-invocable`. Defaults to `true`.
 	 */
 	userInvocable?: boolean;

--- a/packages/coding-agent/src/capability/skill.ts
+++ b/packages/coding-agent/src/capability/skill.ts
@@ -22,12 +22,19 @@ export interface SkillFrontmatter {
 	 */
 	hide?: boolean;
 	/**
-	 * Agent Skills standard equivalent of `hide`.
-	 * When `true`, the skill is excluded from the system prompt listing.
-	 * Normalized from kebab-case `disable-model-invocation` in YAML frontmatter.
-	 * @see https://agentskills.io/specification
+	 * Claude Code / Pi convention (not part of the agentskills.io schema):
+	 * when `true`, the skill is excluded from the system prompt listing.
+	 * Normalized from kebab-case `disable-model-invocation` and honored through
+	 * `metadata` on the Agent Plugins path.
 	 */
 	disableModelInvocation?: boolean;
+	/**
+	 * User axis. When `false`, the skill is not registered, completed, or
+	 * dispatched as `/skill:<name>`; it stays loadable via `skill://<name>`
+	 * and, unless the model axis also opts out, advertised to the model.
+	 * Normalized from kebab-case `user-invocable`. Defaults to `true`.
+	 */
+	userInvocable?: boolean;
 	[key: string]: unknown;
 }
 

--- a/packages/coding-agent/src/discovery/agent-plugin-format.ts
+++ b/packages/coding-agent/src/discovery/agent-plugin-format.ts
@@ -95,6 +95,12 @@ const SKILL_FIELDS: Record<string, true> = {
 	metadata: true,
 	compatibility: true,
 };
+/** Invocation keys omp honors from the spec-sanctioned `metadata` map. */
+const METADATA_INVOCATION_KEYS: Record<string, true> = {
+	"user-invocable": true,
+	"disable-model-invocation": true,
+	hide: true,
+};
 /** Skill `name` characters: Unicode letters/digits (Python `str.isalnum`) and hyphens. */
 const SKILL_NAME_CHARS_RE = /^[\p{L}\p{N}-]+$/u;
 
@@ -113,19 +119,52 @@ function validateSkillName(raw: unknown, dirName: string): string | null {
 	return null;
 }
 
+/** Outcome of validating `SKILL.md` frontmatter under Agent Plugins §7.1. */
+export interface AgentSkillFrontmatterCheck {
+	/** First fatal violation, or `null` when the skill may load. */
+	violation: string | null;
+	/** Honored omp conventions carried in `metadata`, for reporting. */
+	warnings: string[];
+}
+
 /**
  * Validate `SKILL.md` frontmatter against the Agent Skills specification
  * (https://agentskills.io/specification), the source of truth for skill
- * validity under Agent Plugins §7.1, mirroring the official skills-ref
- * reference validator: the frontmatter schema is CLOSED to its six fields and
- * any unexpected key rejects the skill. Returns the first violation, or `null`
- * when the skill conforms. Frontmatter keys must be raw (unnormalized).
+ * validity under Agent Plugins §7.1. The spec schema is closed to its six
+ * fields; any unexpected top-level key still rejects the skill. The omp
+ * invocation keys `user-invocable`, `disable-model-invocation`, and `hide`
+ * are honored through the spec-sanctioned `metadata` map when they carry the
+ * exact string `"true"` or `"false"`, and are reported as non-standard
+ * conventions rather than treated as fatal. Frontmatter keys must be raw
+ * (unnormalized).
  */
-export function validateAgentSkillFrontmatter(frontmatter: Record<string, unknown>, dirName: string): string | null {
+export function validateAgentSkillFrontmatter(
+	frontmatter: Record<string, unknown>,
+	dirName: string,
+): AgentSkillFrontmatterCheck {
+	const warnings: string[] = [];
 	for (const key in frontmatter) {
-		if (!SKILL_FIELDS[key]) return `unexpected frontmatter field "${key}"`;
+		if (!SKILL_FIELDS[key]) return { violation: `unexpected frontmatter field "${key}"`, warnings };
 	}
+	const violation = validateSpecFields(frontmatter, dirName);
+	if (violation === null) {
+		const metadata = frontmatter.metadata;
+		if (isRecord(metadata)) {
+			for (const key in metadata) {
+				if (!METADATA_INVOCATION_KEYS[key]) continue;
+				const value = metadata[key];
+				if (value !== "true" && value !== "false") continue;
+				warnings.push(
+					`honored invocation setting "metadata.${key}" (omp convention; not part of the Agent Skills schema)`,
+				);
+			}
+		}
+	}
+	return { violation, warnings };
+}
 
+/** Spec-field checks shared by the wrapper; assumes top-level keys are known. */
+function validateSpecFields(frontmatter: Record<string, unknown>, dirName: string): string | null {
 	const nameViolation = validateSkillName(frontmatter.name, dirName);
 	if (nameViolation !== null) return nameViolation;
 

--- a/packages/coding-agent/src/discovery/agent-plugins.ts
+++ b/packages/coding-agent/src/discovery/agent-plugins.ts
@@ -17,7 +17,7 @@
 import type { Dirent, Stats } from "node:fs";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import { getPluginsDir, isEnoent, normalizeFrontmatterKeys, parseFrontmatter } from "@oh-my-pi/pi-utils";
+import { getPluginsDir, isEnoent, isRecord, normalizeFrontmatterKeys, parseFrontmatter } from "@oh-my-pi/pi-utils";
 import { registerProvider } from "../capability";
 import { readFile } from "../capability/fs";
 import { type MCPServer, mcpCapability } from "../capability/mcp";
@@ -166,12 +166,15 @@ async function scanStandardSkills(realRoot: string, level: "user" | "project"): 
 				return;
 			}
 			// §7.1: the Agent Skills specification is the source of truth for skill
-			// validity; the frontmatter schema is closed per skills-ref, so client
-			// conventions like `enabled` reject the skill as an unexpected field.
-			// Non-conforming skills are skipped without affecting other components.
-			const violation = validateAgentSkillFrontmatter(rawFrontmatter, entry.name);
-			if (violation !== null) {
-				warnings.push(`Skipping skill "${entry.name}": ${violation}`);
+			// validity. The spec schema is closed, so unknown top-level keys like
+			// `enabled` still reject the skill; the invocation keys omp documents
+			// arrive through the spec-sanctioned `metadata` map and are honored with
+			// a reported deviation instead. Non-conforming skills are skipped
+			// without affecting other components.
+			const check = validateAgentSkillFrontmatter(rawFrontmatter, entry.name);
+			for (const warning of check.warnings) warnings.push(`Skill "${entry.name}": ${warning}`);
+			if (check.violation !== null) {
+				warnings.push(`Skipping skill "${entry.name}": ${check.violation}`);
 				return;
 			}
 			// Validation guarantees the frontmatter name matches the directory
@@ -179,6 +182,29 @@ async function scanStandardSkills(realRoot: string, level: "user" | "project"): 
 			// Store with the codebase's camelCase key convention (skill:// consumers,
 			// prompt hiding via disableModelInvocation, …).
 			const frontmatter = normalizeFrontmatterKeys(rawFrontmatter) as SkillFrontmatter;
+			// Fold the honored `metadata` invocation strings into camel booleans so
+			// downstream consumers observe the axes. Only exact "true"/"false" map;
+			// anything else is left unset and reported rather than silently honored.
+			const rawMetadata = rawFrontmatter.metadata;
+			if (isRecord(rawMetadata)) {
+				const pairs: Array<[string, "userInvocable" | "disableModelInvocation" | "hide"]> = [
+					["user-invocable", "userInvocable"],
+					["disable-model-invocation", "disableModelInvocation"],
+					["hide", "hide"],
+				];
+				for (const [key, camel] of pairs) {
+					const value = rawMetadata[key];
+					if (value === "true") {
+						frontmatter[camel] = true;
+					} else if (value === "false") {
+						frontmatter[camel] = false;
+					} else if (value !== undefined) {
+						warnings.push(
+							`Skill "${entry.name}": unrecognized value for "metadata.${key}": expected "true" or "false"`,
+						);
+					}
+				}
+			}
 			items.push({
 				name: entry.name,
 				containRoot: realRoot,

--- a/packages/coding-agent/src/extensibility/extensions/get-commands-handler.ts
+++ b/packages/coding-agent/src/extensibility/extensions/get-commands-handler.ts
@@ -14,6 +14,7 @@
  * surface extensions use to discover dynamic commands they did not register
  * themselves. Each frontend (interactive-mode, ACP) prepends its own builtins.
  */
+import { isUserInvocable } from "../../capability/skill-invocation";
 import type { SkillsSettings } from "../../config/settings";
 import { BUILTIN_SLASH_COMMAND_RESERVED_NAMES } from "../../slash-commands/builtin-registry";
 import type { CustomCommandSource, LoadedCustomCommand } from "../custom-commands";
@@ -54,6 +55,7 @@ export function getSessionSlashCommands(session: CommandsCapableSession): SlashC
 
 	if (session.skillsSettings?.enableSkillCommands) {
 		for (const skill of session.skills) {
+			if (!isUserInvocable(skill)) continue;
 			out.push({
 				name: getSkillSlashCommandName(skill),
 				description: skill.description || undefined,

--- a/packages/coding-agent/src/extensibility/skills.ts
+++ b/packages/coding-agent/src/extensibility/skills.ts
@@ -7,6 +7,7 @@ import {
 	sanitizeManagedDescription,
 } from "../autolearn/managed-skills";
 import { skillCapability } from "../capability/skill";
+import { isUserInvocable, skillInvocationAxes } from "../capability/skill-invocation";
 import type { EffectiveExtensionRoots, SourceMeta } from "../capability/types";
 import type { SkillsSettings } from "../config/settings";
 import { type Skill as CapabilitySkill, loadCapability } from "../discovery";
@@ -27,6 +28,11 @@ export interface Skill {
 	 * prompt's `<skills>` listing.
 	 */
 	hide?: boolean;
+	/**
+	 * When `false`, `/skill:<name>` does not resolve to this skill; it stays
+	 * reachable via `skill://<name>` and listed in `/extensions`.
+	 */
+	userInvocable?: boolean;
 	/**
 	 * Filesystem-resolved plugin root for Agent Plugin skills (spec §4.1):
 	 * every `skill://` resource access must realpath-resolve within it.
@@ -110,7 +116,7 @@ export async function loadSkillsFromDir(options: LoadSkillsFromDirOptions): Prom
 			baseDir: capSkill.path.replace(/[\\/]SKILL\.md$/, ""),
 			source: options.source,
 			...(capSkill.containRoot !== undefined && { containRoot: capSkill.containRoot }),
-			hide: capSkill.frontmatter?.hide === true || capSkill.frontmatter?.disableModelInvocation === true,
+			...skillInvocationAxes(capSkill.frontmatter),
 			_source: capSkill._source,
 		})),
 		warnings: (result.warnings ?? []).map(message => ({ skillPath: options.dir, message })),
@@ -257,7 +263,7 @@ export async function loadSkills(options: LoadSkillsOptions = {}): Promise<LoadS
 				baseDir: capSkill.path.replace(/[\\/]SKILL\.md$/, ""),
 				source: `${capSkill._source.provider}:${capSkill.level}`,
 				...(capSkill.containRoot !== undefined && { containRoot: capSkill.containRoot }),
-				hide: capSkill.frontmatter?.hide === true || capSkill.frontmatter?.disableModelInvocation === true,
+				...skillInvocationAxes(capSkill.frontmatter),
 				_source: capSkill._source,
 			});
 			realPathSet.add(resolvedPath);
@@ -295,7 +301,7 @@ export async function loadSkills(options: LoadSkillsOptions = {}): Promise<LoadS
 					baseDir: capSkill.path.replace(/[\\/]SKILL\.md$/, ""),
 					source: "custom:user",
 					...(capSkill.containRoot !== undefined && { containRoot: capSkill.containRoot }),
-					hide: capSkill.frontmatter?.hide === true || capSkill.frontmatter?.disableModelInvocation === true,
+					...skillInvocationAxes(capSkill.frontmatter),
 					_source: { ...capSkill._source, providerName: "Custom" },
 				},
 				path: capSkill.path,
@@ -396,7 +402,7 @@ export async function loadSkills(options: LoadSkillsOptions = {}): Promise<LoadS
 			baseDir: capSkill.path.replace(/[\\/]SKILL\.md$/, ""),
 			source: `${capSkill._source.provider}:${capSkill.level}`,
 			...(capSkill.containRoot !== undefined && { containRoot: capSkill.containRoot }),
-			hide: capSkill.frontmatter?.hide === true || capSkill.frontmatter?.disableModelInvocation === true,
+			...skillInvocationAxes(capSkill.frontmatter),
 			_source: capSkill._source,
 		});
 		realPathSet.add(resolvedPath);
@@ -418,6 +424,18 @@ export interface BuiltSkillPromptMessage {
 
 export function getSkillSlashCommandName(skill: Pick<Skill, "name">): string {
 	return `skill:${skill.name}`;
+}
+
+/**
+ * Resolve a parsed `/skill:<name>` token against the session skill list. A
+ * skill with `user-invocable: false` is not addressable, so the token falls
+ * through to ordinary prompt handling instead of dispatching.
+ */
+export function findUserInvocableSkill<T extends { name: string; userInvocable?: boolean }>(
+	skills: readonly T[],
+	name: string,
+): T | undefined {
+	return skills.find(skill => skill.name === name && isUserInvocable(skill));
 }
 
 /**

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -54,7 +54,7 @@ import {
 } from "../../extensibility/extensions";
 import { runExtensionCompact } from "../../extensibility/extensions/compact-handler";
 import { getSessionSlashCommands } from "../../extensibility/extensions/get-commands-handler";
-import { buildSkillPromptMessage, parseSkillInvocation } from "../../extensibility/skills";
+import { buildSkillPromptMessage, findUserInvocableSkill, parseSkillInvocation } from "../../extensibility/skills";
 import { loadSlashCommands } from "../../extensibility/slash-commands";
 import { resolveLocalUrlToPath } from "../../internal-urls";
 import { MCPManager } from "../../mcp/manager";
@@ -1046,7 +1046,7 @@ export class AcpAgent implements Agent {
 		if (!parsed) {
 			return false;
 		}
-		const skill = record.session.skills.find(candidate => candidate.name === parsed.name);
+		const skill = findUserInvocableSkill(record.session.skills, parsed.name);
 		if (!skill) {
 			return false;
 		}

--- a/packages/coding-agent/src/modes/components/extensions/inspector-model.ts
+++ b/packages/coding-agent/src/modes/components/extensions/inspector-model.ts
@@ -9,6 +9,8 @@ import * as path from "node:path";
 import { arkToWireSchema, isArkSchema } from "@oh-my-pi/pi-ai/utils/schema";
 import { normalizePathForComparison, parseFrontmatter } from "@oh-my-pi/pi-utils";
 import { parseRuleConditionAndScope } from "../../../capability/rule";
+import type { SkillFrontmatter } from "../../../capability/skill";
+import { skillInvocationAxes } from "../../../capability/skill-invocation";
 import { slashCommandFrontmatterDisplay } from "../../../capability/slash-command";
 import { isFilesystemSourcePath } from "../../../tools/path-utils";
 import {
@@ -377,7 +379,7 @@ export function skillInspectorData(ext: Extension): {
 } {
 	const raw = asRecord(ext.raw) ?? {};
 	const frontmatter = asRecord(raw.frontmatter) ?? {};
-	const hidden = frontmatter.hide === true || frontmatter.disableModelInvocation === true;
+	const hidden = skillInvocationAxes(frontmatter as SkillFrontmatter).hide;
 	const alwaysApply = frontmatter.alwaysApply === true;
 	const globs = stringArray(frontmatter.globs) ?? stringArray(raw.globs);
 	let runtimeDetail: string | undefined;

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -79,7 +79,8 @@ import type {
 	ExtensionWidgetOptions,
 } from "../extensibility/extensions";
 import type { CompactOptions } from "../extensibility/extensions/types";
-import type { Skill } from "../extensibility/skills";
+import { isUserInvocable } from "../capability/skill-invocation";
+import { getSkillSlashCommandName, type Skill } from "../extensibility/skills";
 import type { FileSlashCommand } from "../extensibility/slash-commands";
 import { loadSlashCommands } from "../extensibility/slash-commands";
 import type { Goal, GoalModeState } from "../goals/state";
@@ -1462,7 +1463,8 @@ export class InteractiveMode implements InteractiveModeContext {
 		if (this.session.skillsSettings?.enableSkillCommands !== false) {
 			const icon = getSlashCommandTypeIcon("skill");
 			for (const skill of this.session.skills) {
-				const commandName = `skill:${skill.name}`;
+				if (!isUserInvocable(skill)) continue;
+				const commandName = getSkillSlashCommandName(skill);
 				this.skillCommands.set(commandName, skill);
 				commands.push({ name: commandName, description: skill.description, icon });
 			}

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -23,7 +23,7 @@ import {
 	type ExtensionWidgetOptions,
 	getExtensionUISelectOptionLabel,
 } from "../../extensibility/extensions";
-import { buildSkillPromptMessage, parseSkillInvocation } from "../../extensibility/skills";
+import { buildSkillPromptMessage, findUserInvocableSkill, parseSkillInvocation } from "../../extensibility/skills";
 import { loadSlashCommands } from "../../extensibility/slash-commands";
 import { type Theme, theme } from "../../modes/theme/theme";
 import type { AgentSession } from "../../session/agent-session";
@@ -123,7 +123,7 @@ export async function tryRunRpcSkillCommand(
 	if (!session.skillsSettings?.enableSkillCommands) return false;
 	const parsed = parseSkillInvocation(text);
 	if (!parsed) return false;
-	const skill = session.skills.find(candidate => candidate.name === parsed.name);
+	const skill = findUserInvocableSkill(session.skills, parsed.name);
 	if (!skill) return false;
 	const built = await buildSkillPromptMessage(skill, parsed.args, "user");
 	await session.promptCustomMessage(

--- a/packages/coding-agent/src/modes/utils/context-usage.ts
+++ b/packages/coding-agent/src/modes/utils/context-usage.ts
@@ -4,6 +4,7 @@ import { effectiveReserveTokens, resolveThresholdTokens } from "@oh-my-pi/pi-age
 import type { Tool as AiTool, Model } from "@oh-my-pi/pi-ai";
 import { toolWireSchema } from "@oh-my-pi/pi-ai/utils/schema";
 import { formatNumber } from "@oh-my-pi/pi-utils";
+import { isModelInvocable } from "../../capability/skill-invocation";
 import type { Skill } from "../../extensibility/skills";
 import type { AgentSession } from "../../session/agent-session";
 import { resolveSpeculationMethod } from "../../session/compaction-methods";
@@ -98,8 +99,8 @@ const EMPTY_SKILLS: readonly Skill[] = [];
 /**
  * Skills actually rendered into the system prompt, mirroring the filter in
  * `buildSystemPrompt` (`system-prompt.ts`): the `read` tool must be present so
- * the model can fetch skill content, and skills with frontmatter `hide: true`
- * (or `disable-model-invocation`, normalized onto `hide`) are excluded.
+ * the model can fetch skill content, and skills that opted out of model
+ * invocation (`hide` / `disable-model-invocation`) are excluded.
  * Accounting must count only these so the Skills category and the System-prompt
  * subtraction stay aligned with the provider-facing prompt.
  */
@@ -108,7 +109,7 @@ function renderedSkills(
 	tools: ReadonlyArray<Pick<Tool, "name" | "description" | "parameters">>,
 ): readonly Skill[] {
 	if (!tools.some(tool => tool.name === "read")) return EMPTY_SKILLS;
-	return skills.filter(skill => skill.hide !== true);
+	return skills.filter(isModelInvocable);
 }
 
 export function estimateSkillsTokens(skills: readonly Skill[], tokenizer: Tokenizer): number {

--- a/packages/coding-agent/src/slash-commands/available-commands.ts
+++ b/packages/coding-agent/src/slash-commands/available-commands.ts
@@ -1,4 +1,5 @@
 import type { AvailableCommand } from "@oh-my-pi/pi-utils/acp";
+import { isUserInvocable } from "../capability/skill-invocation";
 import type { EffectiveExtensionRoots } from "../capability/types";
 import type { SkillsSettings } from "../config/settings";
 import type { LoadedCustomCommand } from "../extensibility/custom-commands";
@@ -58,6 +59,7 @@ export async function buildAvailableSlashCommands(
 
 	if (session.skillsSettings?.enableSkillCommands) {
 		for (const skill of session.skills) {
+			if (!isUserInvocable(skill)) continue;
 			appendCommand({
 				name: getSkillSlashCommandName(skill),
 				description: skill.description || `Run ${skill.name} skill`,

--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -18,6 +18,7 @@ import {
 	prompt,
 } from "@oh-my-pi/pi-utils";
 import { contextFileCapability } from "./capability/context-file";
+import { isModelInvocable } from "./capability/skill-invocation";
 import { systemPromptCapability } from "./capability/system-prompt";
 import { findConfigFile } from "./config";
 import type { Personality, SkillsSettings } from "./config/settings";
@@ -955,9 +956,9 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 
 	// Filter skills for the rendered system prompt:
 	// - require the `read` tool so the model can actually fetch skill content;
-	// - drop skills with frontmatter `hide: true` (still loadable via skill:// and /skill:<name>).
+	// - drop skills that opted out of model invocation (hide / disable-model-invocation); they stay loadable via skill:// and /skill:<name>.
 	const hasRead = toolNames.includes("read");
-	const filteredSkills = hasRead ? skills.filter(skill => skill.hide !== true) : [];
+	const filteredSkills = hasRead ? skills.filter(isModelInvocable) : [];
 
 	const effectiveSystemPromptCustomization = dedupePromptSource(systemPromptCustomization, [
 		resolvedCustomPrompt,

--- a/packages/coding-agent/test/acp-agent.test.ts
+++ b/packages/coding-agent/test/acp-agent.test.ts
@@ -140,7 +140,14 @@ class FakeAgentSession {
 	customMessages: Array<{ customType: string; content: string; details?: unknown }> = [];
 	customMessageOptions: Array<{ streamingBehavior?: "steer" | "followUp"; queueChipText?: string } | undefined> = [];
 	skillsSettings = { enableSkillCommands: true };
-	skills: Array<{ name: string; description: string; filePath: string; baseDir: string; source: string }> = [];
+	skills: Array<{
+		name: string;
+		description: string;
+		filePath: string;
+		baseDir: string;
+		source: string;
+		userInvocable?: boolean;
+	}> = [];
 	refreshSkillsCalls = 0;
 	async refreshSkills(): Promise<void> {
 		this.refreshSkillsCalls++;
@@ -1896,6 +1903,40 @@ describe("ACP agent", () => {
 
 		harness.abortController.abort();
 		await Bun.sleep(0);
+	});
+
+	it("falls through to ordinary prompting when the skill is not user-invocable", async () => {
+		const harness = await createHarness();
+		const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });
+		const session = harness.findSession(created.sessionId);
+		if (!session) throw new Error("expected ACP session to exist after newSession");
+		const skillDir = path.join(harness.cwdA, ".skills", "sample");
+		const skillPath = path.join(skillDir, "SKILL.md");
+		await fs.promises.mkdir(skillDir, { recursive: true });
+		await fs.promises.writeFile(skillPath, "---\ndescription: Sample skill\n---\n# Sample\nDo work.\n");
+		session.skills = [
+			{
+				name: "sample",
+				description: "Sample skill",
+				filePath: skillPath,
+				baseDir: skillDir,
+				source: "test",
+				userInvocable: false,
+			},
+		];
+
+		await harness.agent.prompt({
+			sessionId: created.sessionId,
+			messageId: "00000000-0000-4000-8000-000000000002",
+			prompt: [{ type: "text", text: "/skill:sample extra context" }],
+		} as PromptRequest);
+
+		// The token is not addressable, so it reaches the model as ordinary text.
+		expect(session.customMessages).toEqual([]);
+		expect(session.promptCalls).toEqual(["/skill:sample extra context"]);
+
+		harness.abortController.abort();
+		await Promise.resolve();
 	});
 
 	it("auto-cancels an in-progress turn and queues a new prompt when called mid-flight", async () => {

--- a/packages/coding-agent/test/available-commands.test.ts
+++ b/packages/coding-agent/test/available-commands.test.ts
@@ -124,4 +124,36 @@ describe("buildAvailableSlashCommands", () => {
 
 		expect(commands.find(command => command.name === "legacy")?.source).toBe("custom");
 	});
+
+	test("omits user-invocable: false skills but keeps model-hidden ones", async () => {
+		const commands = await buildAvailableSlashCommands(
+			{
+				customCommands: [],
+				skills: [
+					{ name: "plain", description: "Plain skill", filePath: "/tmp/plain/SKILL.md" },
+					{
+						name: "user-hidden",
+						description: "User axis off",
+						filePath: "/tmp/user-hidden/SKILL.md",
+						userInvocable: false,
+					},
+					{
+						name: "model-hidden",
+						description: "Model axis off",
+						filePath: "/tmp/model-hidden/SKILL.md",
+						hide: true,
+					},
+				],
+				skillsSettings: { enableSkillCommands: true },
+				sessionManager: { getCwd: () => process.cwd() },
+				setSlashCommands() {},
+			} as never,
+			async () => [],
+		);
+
+		const names = commands.map(command => command.name);
+		expect(names).toContain("skill:plain");
+		expect(names).toContain("skill:model-hidden");
+		expect(names).not.toContain("skill:user-hidden");
+	});
 });

--- a/packages/coding-agent/test/discovery/agent-plugins.test.ts
+++ b/packages/coding-agent/test/discovery/agent-plugins.test.ts
@@ -432,6 +432,54 @@ describe("agent-plugins discovery", () => {
 		expect(warned(`unexpected frontmatter field "enabled"`)).toBe(true);
 	});
 
+	test("honors invocation axes from skill metadata on the standard path", async () => {
+		await writeManifest();
+		await writeSkill(
+			"model-hidden",
+			'name: model-hidden\ndescription: ok\nmetadata:\n  disable-model-invocation: "true"',
+		);
+		await writeSkill("user-hidden", 'name: user-hidden\ndescription: ok\nmetadata:\n  user-invocable: "false"');
+		await writeSkill(
+			"all-hidden",
+			'name: all-hidden\ndescription: ok\nmetadata:\n  hide: "true"\n  user-invocable: "false"',
+		);
+		await writeRegistry(pluginPath);
+
+		const skills = await loadCapability<Skill>("skills", { cwd: tempDir });
+		const fromPlugin = skills.all.filter(skill => skill._source.provider === "agent-plugins");
+		expect(fromPlugin.map(skill => skill.name).sort()).toEqual(["all-hidden", "model-hidden", "user-hidden"]);
+
+		const modelHidden = skills.all.find(skill => skill.name === "model-hidden");
+		expect(modelHidden?.frontmatter?.disableModelInvocation).toBe(true);
+		expect(modelHidden?.frontmatter?.userInvocable).not.toBe(false);
+
+		const userHidden = skills.all.find(skill => skill.name === "user-hidden");
+		expect(userHidden?.frontmatter?.userInvocable).toBe(false);
+		expect(userHidden?.frontmatter?.disableModelInvocation).not.toBe(true);
+
+		const allHidden = skills.all.find(skill => skill.name === "all-hidden");
+		expect(allHidden?.frontmatter?.hide).toBe(true);
+		expect(allHidden?.frontmatter?.userInvocable).toBe(false);
+
+		const warned = (needle: string) => skills.warnings.some(warning => warning.includes(needle));
+		expect(warned(`metadata.disable-model-invocation`)).toBe(true);
+		expect(warned(`metadata.user-invocable`)).toBe(true);
+	});
+
+	test("warns and ignores an unrecognized invocation value in metadata", async () => {
+		await writeManifest();
+		await writeSkill("fuzzy", "name: fuzzy\ndescription: ok\nmetadata:\n  user-invocable: definitely");
+		await writeRegistry(pluginPath);
+
+		const skills = await loadCapability<Skill>("skills", { cwd: tempDir });
+		const fuzzy = skills.all.find(skill => skill.name === "fuzzy");
+		expect(fuzzy).toBeDefined();
+		expect(fuzzy?.frontmatter?.userInvocable).toBeUndefined();
+		expect(skills.warnings.some(warning => warning.includes(`expected "true" or "false"`))).toBe(true);
+		// One owner reports each outcome: an invalid value is never also "honored".
+		expect(skills.warnings.some(warning => warning.includes("honored invocation setting"))).toBe(false);
+	});
+
 	test("rejects an escaping plugin.json symlink without consuming outside content", async () => {
 		// A fully valid Agent Plugins manifest OUTSIDE the package: if the client
 		// read it through the symlink, classification would succeed and the

--- a/packages/coding-agent/test/rpc-skill-command.test.ts
+++ b/packages/coding-agent/test/rpc-skill-command.test.ts
@@ -132,4 +132,38 @@ describe("tryRunRpcSkillCommand", () => {
 			await removeWithRetries(dir);
 		}
 	});
+
+	test("refuses dispatch for user-invocable: false skills", async () => {
+		const dir = await fs.mkdtemp(path.join(os.tmpdir(), `omp-rpc-skill-${Snowflake.next()}-`));
+		const skillPath = path.join(dir, "SKILL.md");
+		await Bun.write(skillPath, "---\nname: internal\ndescription: Internal skill\n---\n\nInternal content.\n");
+
+		let message: Pick<CustomMessage, "customType"> | undefined;
+		try {
+			const handled = await tryRunRpcSkillCommand(
+				{
+					skillsSettings: { enableSkillCommands: true },
+					skills: [
+						{
+							name: "internal",
+							description: "Internal skill",
+							filePath: skillPath,
+							baseDir: dir,
+							source: "project",
+							userInvocable: false,
+						},
+					],
+					async promptCustomMessage(nextMessage) {
+						message = nextMessage;
+					},
+				},
+				"/skill:internal do it",
+			);
+
+			expect(handled).toBe(false);
+			expect(message).toBeUndefined();
+		} finally {
+			await removeWithRetries(dir);
+		}
+	});
 });

--- a/packages/coding-agent/test/skills.test.ts
+++ b/packages/coding-agent/test/skills.test.ts
@@ -449,6 +449,26 @@ enabled: false
 			}
 		});
 
+		it("should load user-invocable: false skills with axes independent", async () => {
+			const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-ui-skill-"));
+			const skillDir = path.join(tempDir, "user-hidden");
+			await fs.mkdir(skillDir, { recursive: true });
+			await fs.writeFile(
+				path.join(skillDir, "SKILL.md"),
+				`---\nname: user-hidden\ndescription: User axis opted out, model axis stays on.\nuser-invocable: false\n---\n\n# User-Hidden Skill\n`,
+			);
+
+			try {
+				const { skills } = await loadSkills({ ...DISABLE_ALL_BUILTIN_SKILLS, customDirectories: [tempDir] });
+				const skill = skills.find(s => s.name === "user-hidden");
+				expect(skill).toBeDefined();
+				expect(skill?.userInvocable).toBe(false);
+				expect(skill?.hide).toBe(false);
+			} finally {
+				await removeWithRetries(tempDir);
+			}
+		});
+
 		it("should let ignoredSkills override includeSkills", async () => {
 			const { skills } = await loadSkills({
 				...DISABLE_ALL_BUILTIN_SKILLS,

--- a/packages/coding-agent/test/system-prompt.test.ts
+++ b/packages/coding-agent/test/system-prompt.test.ts
@@ -281,3 +281,51 @@ describe("non-Linux system prompt CPU model", () => {
 		}
 	});
 });
+
+describe("skill invocation axes in rendered system prompt", () => {
+	it("keeps user-invocable: false skills in the listing but drops hide: true skills", async () => {
+		const systemPrompt = await buildSystemPrompt({
+			contextFiles: [],
+			skills: [
+				{
+					name: "user-hidden",
+					description: "User axis off",
+					filePath: "/tmp/a/SKILL.md",
+					baseDir: "/tmp/a",
+					source: "project",
+					userInvocable: false,
+				},
+				{
+					name: "model-hidden",
+					description: "Model axis off",
+					filePath: "/tmp/b/SKILL.md",
+					baseDir: "/tmp/b",
+					source: "project",
+					hide: true,
+				},
+				{
+					name: "plain",
+					description: "Plain skill",
+					filePath: "/tmp/c/SKILL.md",
+					baseDir: "/tmp/c",
+					source: "project",
+				},
+			],
+			toolNames: ["read"],
+			rules: [],
+			workspaceTree: {
+				rootPath: import.meta.dir,
+				rendered: "",
+				truncated: false,
+				totalLines: 0,
+				agentsMdFiles: [],
+			},
+			activeRepoContext: null,
+		});
+
+		const rendered = systemPrompt.systemPrompt.join("\n");
+		expect(rendered).toContain("user-hidden: User axis off");
+		expect(rendered).toContain("plain: Plain skill");
+		expect(rendered).not.toContain("model-hidden");
+	});
+});


### PR DESCRIPTION
Closes #10062.

Stacked on #10516 — its commit is the first of the two here, so review that one first and this diff shrinks to the axes work. Rebase or merge order: #10516, then this.

## The fault

A skill had one visibility control. `hide`, aliased by `disable-model-invocation`, removed it from the model's advertised catalog, and nothing could withhold the `/skill:<name>` command while keeping the skill in that catalog. The frontmatter-to-axis mapping was also duplicated inline at four sites in `extensibility/skills.ts`, which is why a second axis looked like a four-site edit rather than a one-line one. That duplication is the fault this change removes; the axis is what it buys.

## What lands

- `capability/skill-invocation.ts` owns the frontmatter-to-axes mapping. The four inline expressions and the inspector's fifth copy now call it.
- `user-invocable: false` withholds the command everywhere it could be reached: TUI registration (`interactive-mode`), the command lists (`available-commands`, `get-commands-handler`), and the ACP and RPC dispatch lookups, which each did a bare `skills.find(...)` and would otherwise have stayed invocable while vanishing from the TUI.
- The model-axis filter in `system-prompt.ts` and the mirror in `context-usage.ts` read one shared predicate, so the prompt listing and its token accounting cannot drift apart.

## The two axes

| frontmatter | model catalog | `/skill:<name>` | `skill://`, `/extensions` |
| --- | --- | --- | --- |
| default | advertised | dispatched | yes |
| `disable-model-invocation: true` (or `hide`) | omitted | dispatched | yes |
| `user-invocable: false` | advertised | refused | yes |
| both | omitted | refused | yes |

Autoload and `skill://` resolution are explicit named configuration rather than invocation, so neither axis gates them.

On the Agent Plugins path both axes travel through `metadata` string values, per #10516.

## Verification

- `bun check` green in the worktree (oxlint, oxfmt, tsgo, cargo check), rebased on current `main`.
- `bun test` on `discovery/agent-plugins`, `skills`, `available-commands`, `rpc-skill-command`, `system-prompt` — 100 pass, 3 fail. The three failures are pre-existing on untouched `main` with identical names (`skills.test.ts` custom-directory cases, sensitive to the ambient `$HOME` skill tree), not caused by this change.
- New cases: axis independence in `skills.test.ts`, a three-skill command-list case proving each axis affects only its own surface, an RPC fallthrough case proving a non-user-invocable skill is not dispatched, and a system-prompt assertion that the model axis alone controls the listing.