### PR TITLE
feat(coding-agent): stamp per-turn Now timestamp on the last user message

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -330,6 +330,12 @@
 
 - Recover stray <SM:EDIT> payloads emitted as plain text into real edit tool calls, with support for disabling this behavior through the edit.recoverInlineEdits setting.
 - Advisors now receive context from the active memory backend, including project decisions and recalled instructions; advisors also gain the recall tool when supported by the backend.
+- Added provider-reported credits and concrete routed-model counts to `/session` statistics ([#8590](https://github.com/can1357/oh-my-pi/pull/8590) by [@will-bogusz](https://github.com/will-bogusz)).
+- Added `CLINE_API_KEY` to the CLI environment help for native ClinePass subscription inference ([#7863](https://github.com/can1357/oh-my-pi/pull/7863) by [@will-bogusz](https://github.com/will-bogusz)).
+- Devin model selectors now accept the native CLI's short aliases (`devin/opus`, `devin/swe`), dotted upstream spellings (`devin/gemini-3.7-flash`), and raw effort-route wire uids for dynamically collapsed families ([#8590](https://github.com/can1357/oh-my-pi/pull/8590) by [@will-bogusz](https://github.com/will-bogusz)).
+- Added provider-supplied model metadata to the `/models` detail line: `new`, `beta`, and `recommended` badges beside the model name, and the upstream description after the context, cost, and perf facts ([#8590](https://github.com/can1357/oh-my-pi/pull/8590) by [@will-bogusz](https://github.com/will-bogusz)).
+- Standalone `CLAUDE.md` files in the project root (and ancestor directories) are now loaded as context, mirroring `AGENTS.md` discovery; config-directory context files still take precedence per scope.
+- Added a per-turn `Now:` timestamp stamp (UTC ISO instant plus local clock, timezone short name, and numeric UTC offset, e.g. `Now: 2026-08-30T02:51:16Z (20:51 CDT, UTC-05:00)`) appended to the last user message of each provider request; the stamp is idempotent per user message, so the prompt-cache prefix stays byte-stable across the repeated requests of a tool-call loop. Toggle with `/time` (persisted `prompt.nowStamp` setting, default on).
 
 ### Changed
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -49,6 +49,7 @@
 - Python cells are no longer replayed automatically after a kernel crash, preventing duplicate side effects; the next call starts a fresh kernel.
 - Session rewrites preserve open-reader snapshots and replacement identity when a rename needs an EPERM fallback.
 - Fixed WorkPool children retaining a stale Gemini-formatted `yield` declaration when pooled items were installed or cleared.
+- Added a per-turn `Now:` timestamp stamp (UTC ISO instant plus local clock, timezone short name, and numeric UTC offset, e.g. `Now: 2026-08-30T02:51:16Z (20:51 CDT, UTC-05:00)`) appended to each user message and each user-initiated developer continuation turn, derived deterministically from that message's own turn timestamp, so re-stamped history stays byte-identical across requests, tool-call loops, and same-host session resumes (the parenthesized local part of the stamp renders in the host timezone and locale), and the prompt-cache prefix is preserved. A prompt that already ends in a `Now:` block carrying a different value is re-stamped with the derived one rather than left stale. Toggle with `/time` (persisted `prompt.nowStamp` setting, default on).
 
 ## [18.1.14] - 2026-09-07
 
@@ -125,7 +126,6 @@
 
 - Fixed Codex V2 remote compaction rebuilding the request prefix differently from normal turns, restoring prompt-cache reuse ([#10786](https://github.com/can1357/oh-my-pi/issues/10786)).
 - Restored mouse clicks, hover, and wheel scrolling in Plan Review.
-- Added a per-turn `Now:` timestamp stamp (UTC ISO instant plus local clock, timezone short name, and numeric UTC offset, e.g. `Now: 2026-08-30T02:51:16Z (20:51 CDT, UTC-05:00)`) appended to each user message and each user-initiated developer continuation turn, derived deterministically from that message's own turn timestamp, so re-stamped history stays byte-identical across requests, tool-call loops, and same-host session resumes (the parenthesized local part of the stamp renders in the host timezone and locale), and the prompt-cache prefix is preserved. A prompt that already ends in a `Now:` block carrying a different value is re-stamped with the derived one rather than left stale. Toggle with `/time` (persisted `prompt.nowStamp` setting, default on).
 
 ## [18.1.9] - 2026-09-04
 
@@ -164,9 +164,6 @@
 ### Removed
 
 - Removed the librarian agent.
-### Added
-
-- Added a per-turn `Now:` timestamp stamp (UTC ISO instant plus local clock, timezone short name, and numeric UTC offset, e.g. `Now: 2026-08-30T02:51:16Z (20:51 CDT, UTC-05:00)`) appended to each user message, derived deterministically from that message's own turn timestamp, so re-stamped history stays byte-identical across requests, tool-call loops, and same-host session resumes (the parenthesized local part of the stamp renders in the host timezone and locale), and the prompt-cache prefix is preserved. Toggle with `/time` (persisted `prompt.nowStamp` setting, default on).
 
 ## [18.1.8] - 2026-09-03
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -125,6 +125,7 @@
 
 - Fixed Codex V2 remote compaction rebuilding the request prefix differently from normal turns, restoring prompt-cache reuse ([#10786](https://github.com/can1357/oh-my-pi/issues/10786)).
 - Restored mouse clicks, hover, and wheel scrolling in Plan Review.
+- Added a per-turn `Now:` timestamp stamp (UTC ISO instant plus local clock, timezone short name, and numeric UTC offset, e.g. `Now: 2026-08-30T02:51:16Z (20:51 CDT, UTC-05:00)`) appended to each user message and each user-initiated developer continuation turn, derived deterministically from that message's own turn timestamp, so re-stamped history stays byte-identical across requests, tool-call loops, and same-host session resumes (the parenthesized local part of the stamp renders in the host timezone and locale), and the prompt-cache prefix is preserved. A prompt that already ends in a `Now:` block carrying a different value is re-stamped with the derived one rather than left stale. Toggle with `/time` (persisted `prompt.nowStamp` setting, default on).
 
 ## [18.1.9] - 2026-09-04
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -163,6 +163,9 @@
 ### Removed
 
 - Removed the librarian agent.
+### Added
+
+- Added a per-turn `Now:` timestamp stamp (UTC ISO instant plus local clock, timezone short name, and numeric UTC offset, e.g. `Now: 2026-08-30T02:51:16Z (20:51 CDT, UTC-05:00)`) appended to each user message, derived deterministically from that message's own turn timestamp, so re-stamped history stays byte-identical across requests, tool-call loops, and session resumes and the prompt-cache prefix is preserved. Toggle with `/time` (persisted `prompt.nowStamp` setting, default on).
 
 ## [18.1.8] - 2026-09-03
 
@@ -330,12 +333,6 @@
 
 - Recover stray <SM:EDIT> payloads emitted as plain text into real edit tool calls, with support for disabling this behavior through the edit.recoverInlineEdits setting.
 - Advisors now receive context from the active memory backend, including project decisions and recalled instructions; advisors also gain the recall tool when supported by the backend.
-- Added provider-reported credits and concrete routed-model counts to `/session` statistics ([#8590](https://github.com/can1357/oh-my-pi/pull/8590) by [@will-bogusz](https://github.com/will-bogusz)).
-- Added `CLINE_API_KEY` to the CLI environment help for native ClinePass subscription inference ([#7863](https://github.com/can1357/oh-my-pi/pull/7863) by [@will-bogusz](https://github.com/will-bogusz)).
-- Devin model selectors now accept the native CLI's short aliases (`devin/opus`, `devin/swe`), dotted upstream spellings (`devin/gemini-3.7-flash`), and raw effort-route wire uids for dynamically collapsed families ([#8590](https://github.com/can1357/oh-my-pi/pull/8590) by [@will-bogusz](https://github.com/will-bogusz)).
-- Added provider-supplied model metadata to the `/models` detail line: `new`, `beta`, and `recommended` badges beside the model name, and the upstream description after the context, cost, and perf facts ([#8590](https://github.com/can1357/oh-my-pi/pull/8590) by [@will-bogusz](https://github.com/will-bogusz)).
-- Standalone `CLAUDE.md` files in the project root (and ancestor directories) are now loaded as context, mirroring `AGENTS.md` discovery; config-directory context files still take precedence per scope.
-- Added a per-turn `Now:` timestamp stamp (UTC ISO instant plus local clock, timezone short name, and numeric UTC offset, e.g. `Now: 2026-08-30T02:51:16Z (20:51 CDT, UTC-05:00)`) appended to the last user message of each provider request; the stamp is idempotent per user message, so the prompt-cache prefix stays byte-stable across the repeated requests of a tool-call loop. Toggle with `/time` (persisted `prompt.nowStamp` setting, default on).
 
 ### Changed
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -165,7 +165,7 @@
 - Removed the librarian agent.
 ### Added
 
-- Added a per-turn `Now:` timestamp stamp (UTC ISO instant plus local clock, timezone short name, and numeric UTC offset, e.g. `Now: 2026-08-30T02:51:16Z (20:51 CDT, UTC-05:00)`) appended to each user message, derived deterministically from that message's own turn timestamp, so re-stamped history stays byte-identical across requests, tool-call loops, and session resumes and the prompt-cache prefix is preserved. Toggle with `/time` (persisted `prompt.nowStamp` setting, default on).
+- Added a per-turn `Now:` timestamp stamp (UTC ISO instant plus local clock, timezone short name, and numeric UTC offset, e.g. `Now: 2026-08-30T02:51:16Z (20:51 CDT, UTC-05:00)`) appended to each user message, derived deterministically from that message's own turn timestamp, so re-stamped history stays byte-identical across requests, tool-call loops, and same-host session resumes (the parenthesized local part of the stamp renders in the host timezone and locale), and the prompt-cache prefix is preserved. Toggle with `/time` (persisted `prompt.nowStamp` setting, default on).
 
 ## [18.1.8] - 2026-09-03
 

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -2565,6 +2565,20 @@ export const SETTINGS_SCHEMA = {
 				"Use larger context windows where supported; may incur premium pricing. Off keeps default or standard-pricing windows",
 		},
 	},
+	// Per-turn time stamp: fresh Now: instant appended to the last user
+	// message of each provider request (context tail — prompt-cache prefix
+	// stays byte-stable; toggle with /time).
+	"prompt.nowStamp": {
+		type: "boolean",
+		default: true,
+		ui: {
+			tab: "context",
+			group: "General",
+			label: "Per-turn Time Stamp",
+			description:
+				"Append a fresh Now: timestamp to the last user message of each provider request so the model always knows the current time (toggle with /time)",
+		},
+	},
 
 	// Compaction
 	"compaction.enabled": {

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -2565,9 +2565,9 @@ export const SETTINGS_SCHEMA = {
 				"Use larger context windows where supported; may incur premium pricing. Off keeps default or standard-pricing windows",
 		},
 	},
-	// Per-turn time stamp: fresh Now: instant appended to the last user
-	// message of each provider request (context tail — prompt-cache prefix
-	// stays byte-stable; toggle with /time).
+	// Per-turn time stamp: each user message carries a Now: stamp of its own
+	// turn (derived from its persisted timestamp, byte-stable across
+	// requests and session resumes; toggle with /time).
 	"prompt.nowStamp": {
 		type: "boolean",
 		default: true,
@@ -2576,7 +2576,7 @@ export const SETTINGS_SCHEMA = {
 			group: "General",
 			label: "Per-turn Time Stamp",
 			description:
-				"Append a fresh Now: timestamp to the last user message of each provider request so the model always knows the current time (toggle with /time)",
+				"Append a Now: timestamp of its own turn to each user message so the model always knows the current time (toggle with /time)",
 		},
 	},
 

--- a/packages/coding-agent/src/prompts/system/now-reminder.md
+++ b/packages/coding-agent/src/prompts/system/now-reminder.md
@@ -1,0 +1,3 @@
+<system-reminder>
+Now: {{now}}
+</system-reminder>

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -159,7 +159,7 @@ import {
 import { AgentSession, type InitialRetryFallbackState, type PlanYolo, type Prewalk } from "./session/agent-session";
 import { discoverAuthStorage as discoverAuthStorageFromConfig } from "./session/auth-broker-config";
 import type { AuthStorage } from "./session/auth-storage";
-import { DateCwdReminderInjector } from "./session/date-cwd-reminder";
+import { DateCwdReminderInjector, applyNowStamp } from "./session/date-cwd-reminder";
 import { createInterruptedTurnAbortMessage } from "./session/exit-diagnostics";
 import { recoverInlineSloppyEdit } from "./session/inline-edit-recovery";
 import {
@@ -3457,11 +3457,12 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			// Keep per-request volatility out of the system prompt: the date/cwd
 			// reminder rides on the first user turn so open-weight providers keep
 			// their tool-schema prefix cache (#7404).
-			return dateCwdReminder.transform(
+			transformed = dateCwdReminder.transform(
 				transformed,
 				formatLocalCalendarDate(),
 				normalizePromptPath(sessionManager.getCwd()),
 			);
+			return settings.get("prompt.nowStamp") ? applyNowStamp(transformed) : transformed;
 		};
 		const onPayload = async (payload: unknown, model?: Model) => {
 			return await extensionRunner.emitBeforeProviderRequest(payload, model);
@@ -4149,11 +4150,12 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 						transformed = await normalizeProviderContextImagesForModel(transformed, transformModel);
 						transformed = await dropUnreadableContextImages(transformed, transformModel);
 						if (blobBroker) transformed = await blobBroker.decorateContext(transformed, transformModel);
-						return captureDateCwdReminder.transform(
+						transformed = captureDateCwdReminder.transform(
 							transformed,
 							formatLocalCalendarDate(),
 							normalizePromptPath(sessionManager.getCwd()),
 						);
+						return settings.get("prompt.nowStamp") ? applyNowStamp(transformed) : transformed;
 					},
 					thinkingBudgets: agent.thinkingBudgets,
 					temperature: agent.temperature,

--- a/packages/coding-agent/src/session/date-cwd-reminder.ts
+++ b/packages/coding-agent/src/session/date-cwd-reminder.ts
@@ -136,38 +136,36 @@ export function renderNowStamp(now: Date = new Date()): string {
 }
 
 /**
- * Appends a per-turn `Now:` stamp to the last user message in `messages`,
+ * Appends each user message's own-turn `Now:` stamp to `messages`,
  * returning a new array. The input is never mutated.
  *
- * Placement is deliberate: the stamp rides on the last USER message, not the
- * literal context tail (in tool-call loops the tail is usually a tool_result,
- * which is not message-shape-safe to append to) and not the first user
- * message (Today:/cwd position). It is idempotent per user message, not per
- * request: provider requests repeat within a turn, so a previously-stamped
- * message must be re-sent byte-identical instead of re-stamped — a fresh
- * timestamp would duplicate the stamp and invalidate the prompt cache from
- * message 0.
+ * The stamp is a pure function of the message's persisted identity — its
+ * own `timestamp` — so re-stamps are byte-identical across requests and
+ * across session resumes: a resumed process rehydrates history as fresh
+ * objects with the persisted content and timestamp, and re-derives the
+ * exact wire bytes the original process sent. Only the genuinely-new last
+ * turn adds bytes, at the tail, so the prompt-cache prefix stays stable.
+ * Idempotent per user message: a message already carrying a stamp keeps
+ * it — a fresh stamp would duplicate and invalidate the prompt cache from message 0.
  *
- * Two memo layers keep the on-the-wire bytes stable:
- * - Identity: the pristine-message WeakMap (mirroring `DateCwdReminderInjector`'s
- *   injection memo) covers the append-only context path, where the same message
- *   objects are re-handed on every request and are garbage-collected with them.
- * - Fingerprint: per-request transforms may recreate the message object with
- *   identical wire bytes (steer envelopes in `wrapSteeringForModel`, secret
- *   obfuscation). A recreated object misses the identity memo, so a second
- *   memo keyed on the stable wire identity (timestamp + content shape + final
- *   text) re-applies the exact stamp that already went on the wire — including
- *   for messages that slid out of last-user position. It lives for the process
- *   lifetime (bounded by the number of distinct user messages).
+ * The stamp value is computed, never held in a process-global structure:
+ * two distinct turns in the same second share the correct instant rather
+ * than a value leaked from another turn's request. The only memo is the
+ * object-identity WeakMap (mirroring `DateCwdReminderInjector`'s
+ * injection memo), which keeps stamped objects stable within a live
+ * session and is collected with its key message objects when the session
+ * is discarded.
  */
 const nowStampCache = new WeakMap<Message, Message>();
-const nowStampByFingerprint = new Map<string, string>();
 
-/** Stable wire identity of a user message: timestamp, content shape, final text. */
-function nowStampFingerprint(message: Message, tail: string | undefined): string {
-	const content = message.content;
-	const body = typeof content === "string" ? content : `${content.length}\u0000${tail ?? ""}`;
-	return `${message.timestamp ?? ""}\u0000${body}`;
+/**
+ * The deterministic stamp for a user message: its own-turn instant
+ * rendered as a `Now:` system reminder. Messages without a finite
+ * timestamp are left unstamped rather than fabricated.
+ */
+function nowStampFor(message: Message): string | undefined {
+	if (!Number.isFinite(message.timestamp)) return undefined;
+	return renderNowStamp(new Date(message.timestamp));
 }
 
 /** Final text of a message: its string content, or the last text part. */
@@ -180,43 +178,29 @@ function finalMessageText(content: Message["content"]): string | undefined {
 	return undefined;
 }
 
-export function injectNowStamp(messages: Message[], now: Date = new Date()): Message[] {
-	let last = -1;
-	for (let i = messages.length - 1; i >= 0; i--) {
-		if (messages[i]!.role === "user") {
-			last = i;
-			break;
-		}
-	}
-	if (last < 0) return messages;
-	let changed = false;
-	const out = messages.slice();
-	for (let i = 0; i < out.length; i++) {
-		const message = out[i]!;
+export function injectNowStamp(messages: Message[]): Message[] {
+	let out: Message[] | undefined;
+	for (let i = 0; i < messages.length; i++) {
+		const message = messages[i]!;
 		if (message.role !== "user") continue;
 		const tail = finalMessageText(message.content);
 		if (tail !== undefined && nowStampTail.test(tail)) continue;
+		const stamp = nowStampFor(message);
+		if (stamp === undefined) continue;
 		const cached = nowStampCache.get(message);
 		if (cached !== undefined) {
-			out[i] = cached;
-			changed = true;
+			(out ??= messages.slice())[i] = cached;
 			continue;
 		}
-		const fingerprint = nowStampFingerprint(message, tail);
-		const knownStamp = nowStampByFingerprint.get(fingerprint);
-		const stamp = knownStamp ?? (i === last ? renderNowStamp(now) : undefined);
-		if (stamp === undefined) continue;
 		const content =
 			typeof message.content === "string"
 				? `${message.content}\n\n${stamp}`
 				: ([...message.content, { type: "text", text: stamp }] as Message["content"]);
 		const stamped = { ...message, content } as Message;
 		nowStampCache.set(message, stamped);
-		if (knownStamp === undefined) nowStampByFingerprint.set(fingerprint, stamp);
-		out[i] = stamped;
-		changed = true;
+		(out ??= messages.slice())[i] = stamped;
 	}
-	return changed ? out : messages;
+	return out ?? messages;
 }
 
 /**
@@ -226,9 +210,9 @@ export function injectNowStamp(messages: Message[], now: Date = new Date()): Mes
  * stay byte-for-byte unchanged; mirrors the guards of
  * {@link DateCwdReminderInjector.transform}.
  */
-export function applyNowStamp(context: Context, now: Date = new Date()): Context {
+export function applyNowStamp(context: Context): Context {
 	if (!context.systemPrompt || context.systemPrompt.length === 0) return context;
 	if (context.messages.length === 0) return context;
-	const messages = injectNowStamp(context.messages, now);
+	const messages = injectNowStamp(context.messages);
 	return messages === context.messages ? context : { ...context, messages };
 }

--- a/packages/coding-agent/src/session/date-cwd-reminder.ts
+++ b/packages/coding-agent/src/session/date-cwd-reminder.ts
@@ -13,6 +13,8 @@
 import type { Context, Message, UserMessage } from "@oh-my-pi/pi-ai";
 import { prompt } from "@oh-my-pi/pi-utils";
 import dateCwdReminderTemplate from "../prompts/system/date-cwd-reminder.md" with { type: "text" };
+import nowReminderTemplate from "../prompts/system/now-reminder.md" with { type: "text" };
+import { formatLocalDateTimeWithOffset, formatLocalTimeZoneShortName } from "../utils/local-date";
 
 /** Renders the reminder text for the given local calendar date and cwd. */
 export function renderDateCwdReminder(date: string, cwd: string): string {
@@ -114,4 +116,107 @@ export class DateCwdReminderInjector {
 		}
 		return changed ? out : messages;
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Per-turn Now stamp
+// ---------------------------------------------------------------------------
+
+/** Matches a rendered Now stamp at the tail of a message's final text. */
+const nowStampTail = /Now: \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z \([^()]*\)\n<\/system-reminder>$/;
+
+/** Renders the per-turn stamp payload, e.g. `2026-08-30T02:51:16Z (20:51 CST, UTC-06:00)`. */
+export function renderNowStamp(now: Date = new Date()): string {
+	const parts = formatLocalDateTimeWithOffset(now).split(" ");
+	const clock = parts[1] ?? "";
+	const offset = parts[2] ? `UTC${parts[2]}` : "";
+	const zone = formatLocalTimeZoneShortName(now);
+	const zoneClock = [clock, zone].filter(part => part.length > 0).join(" ");
+	const local = [zoneClock, offset].filter(part => part.length > 0).join(", ");
+	const iso = now.toISOString().replace(/\.\d{3}Z$/, "Z");
+	return prompt.render(nowReminderTemplate, { now: `${iso} (${local})` }).trim();
+}
+
+/**
+ * Appends a per-turn `Now:` stamp to the last user message in `messages`,
+ * returning a new array. The input is never mutated.
+ *
+ * Placement is deliberate: the stamp rides on the last USER message, not the
+ * literal context tail (in tool-call loops the tail is usually a tool_result,
+ * which is not message-shape-safe to append to) and not the first user
+ * message (Today:/cwd position). It is idempotent per user message, not per
+ * request: provider requests repeat within a turn, so a previously-stamped
+ * message must be re-sent byte-identical instead of re-stamped — a fresh
+ * timestamp would duplicate the stamp and invalidate the prompt cache from
+ * message 0.
+ *
+ * The memo (keyed on the pristine message object, mirroring
+ * `injectDateCwdReminder`) guarantees the same pristine user message always
+ * yields the same stamped object. The append-only context log stores the
+ * pre-transform (pristine) messages and hands them back on every request, so
+ * a previously-stamped user message re-enters each later request in pristine
+ * form — wherever it sits — and must be swapped back to its stamped copy to
+ * keep the already-on-the-wire prefix byte-stable. Entries are
+ * garbage-collected alongside the messages they belong to.
+ */
+const nowStampCache = new WeakMap<Message, Message>();
+
+/** Final text of a message: its string content, or the last text part. */
+function finalMessageText(content: Message["content"]): string | undefined {
+	if (typeof content === "string") return content;
+	for (let i = content.length - 1; i >= 0; i--) {
+		const part = content[i]!;
+		if (part.type === "text") return part.text;
+	}
+	return undefined;
+}
+
+export function injectNowStamp(messages: Message[], now: Date = new Date()): Message[] {
+	let last = -1;
+	for (let i = messages.length - 1; i >= 0; i--) {
+		if (messages[i]!.role === "user") {
+			last = i;
+			break;
+		}
+	}
+	if (last < 0) return messages;
+	let changed = false;
+	const out = messages.slice();
+	for (let i = 0; i < out.length; i++) {
+		const message = out[i]!;
+		if (message.role !== "user") continue;
+		const tail = finalMessageText(message.content);
+		if (tail !== undefined && nowStampTail.test(tail)) continue;
+		const cached = nowStampCache.get(message);
+		if (cached !== undefined) {
+			out[i] = cached;
+			changed = true;
+			continue;
+		}
+		if (i !== last) continue;
+		const stamp = renderNowStamp(now);
+		const content =
+			typeof message.content === "string"
+				? `${message.content}\n\n${stamp}`
+				: ([...message.content, { type: "text", text: stamp }] as Message["content"]);
+		const stamped = { ...message, content } as Message;
+		nowStampCache.set(message, stamped);
+		out[i] = stamped;
+		changed = true;
+	}
+	return changed ? out : messages;
+}
+
+/**
+ * Appends the per-turn `Now:` stamp to a provider `Context`, keeping the
+ * system prompt byte-stable for prompt caching. Skips NULL_PROMPT-style
+ * contexts (empty system prompt) and no-message contexts so such requests
+ * stay byte-for-byte unchanged; mirrors the guards of
+ * {@link withDateCwdReminder}.
+ */
+export function applyNowStamp(context: Context, now: Date = new Date()): Context {
+	if (!context.systemPrompt || context.systemPrompt.length === 0) return context;
+	if (context.messages.length === 0) return context;
+	const messages = injectNowStamp(context.messages, now);
+	return messages === context.messages ? context : { ...context, messages };
 }

--- a/packages/coding-agent/src/session/date-cwd-reminder.ts
+++ b/packages/coding-agent/src/session/date-cwd-reminder.ts
@@ -122,9 +122,6 @@ export class DateCwdReminderInjector {
 // Per-turn Now stamp
 // ---------------------------------------------------------------------------
 
-/** Matches a rendered Now stamp at the tail of a message's final text. */
-const nowStampTail = /Now: \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z \([^()]*\)\n<\/system-reminder>$/;
-
 /** Renders the per-turn stamp payload, e.g. `2026-08-30T02:51:16Z (20:51 CST, UTC-06:00)`. */
 export function renderNowStamp(now: Date = new Date()): string {
 	const { clock, offset } = formatLocalClockAndOffset(now);
@@ -139,6 +136,11 @@ export function renderNowStamp(now: Date = new Date()): string {
  * Appends each user message's own-turn `Now:` stamp to `messages`,
  * returning a new array. The input is never mutated.
  *
+ * User-initiated developer continuation turns (the `.`, `c` continue
+ * shortcuts) are stamped the same way — their timestamp is the fresh
+ * prompt time of the turn — while agent-initiated developer turns stay
+ * excluded.
+ *
  * The stamp is a pure function of the message's persisted identity — its
  * own `timestamp` — so re-stamps are byte-identical across requests and
  * across session resumes: a resumed process rehydrates history as fresh
@@ -147,8 +149,11 @@ export function renderNowStamp(now: Date = new Date()): string {
  * and locale (the parenthesized local part of the stamp renders host-locally).
  * Only the genuinely-new last turn adds bytes, at the tail, so the
  * prompt-cache prefix stays stable.
- * Idempotent per user message: a message already carrying a stamp keeps
- * it — a fresh stamp would duplicate and invalidate the prompt cache from message 0.
+ * Idempotent per message: a trailing block that byte-matches the stamp
+ * derived from the message's own timestamp is that stamp and is kept as-is —
+ * a fresh stamp would duplicate and invalidate the prompt cache from message 0.
+ * A pasted or echoed `Now:` block carrying any other value does not suppress
+ * the stamp; the derived one is injected alongside it deterministically.
  *
  * The stamp value is computed, never held in a process-global structure:
  * two distinct turns in the same second share the correct instant rather
@@ -161,7 +166,7 @@ export function renderNowStamp(now: Date = new Date()): string {
 const nowStampCache = new WeakMap<Message, Message>();
 
 /**
- * The deterministic stamp for a user message: its own-turn instant
+ * The deterministic stamp for a stamped message: its own-turn instant
  * rendered as a `Now:` system reminder. Messages without a finite
  * timestamp are left unstamped rather than fabricated.
  */
@@ -184,16 +189,23 @@ export function injectNowStamp(messages: Message[]): Message[] {
 	let out: Message[] | undefined;
 	for (let i = 0; i < messages.length; i++) {
 		const message = messages[i]!;
-		if (message.role !== "user") continue;
-		const tail = finalMessageText(message.content);
-		if (tail !== undefined && nowStampTail.test(tail)) continue;
-		const stamp = nowStampFor(message);
-		if (stamp === undefined) continue;
+		// User turns, plus user-initiated developer continuation turns (the
+		// `.`, `c` shortcuts), whose timestamp is the fresh prompt time of the
+		// turn; agent-initiated developer turns stay excluded.
+		if (message.role !== "user" && !(message.role === "developer" && message.userInitiated === true)) continue;
 		const cached = nowStampCache.get(message);
 		if (cached !== undefined) {
 			(out ??= messages.slice())[i] = cached;
 			continue;
 		}
+		const stamp = nowStampFor(message);
+		if (stamp === undefined) continue;
+		// Idempotent per message, value-sensitive: only a trailing block that
+		// byte-matches the stamp derived from this message's own timestamp is
+		// an already-applied stamp. A pasted or echoed Now block carrying any
+		// other value must not suppress it.
+		const tail = finalMessageText(message.content);
+		if (tail !== undefined && tail.endsWith(stamp)) continue;
 		const content =
 			typeof message.content === "string"
 				? `${message.content}\n\n${stamp}`

--- a/packages/coding-agent/src/session/date-cwd-reminder.ts
+++ b/packages/coding-agent/src/session/date-cwd-reminder.ts
@@ -14,7 +14,7 @@ import type { Context, Message, UserMessage } from "@oh-my-pi/pi-ai";
 import { prompt } from "@oh-my-pi/pi-utils";
 import dateCwdReminderTemplate from "../prompts/system/date-cwd-reminder.md" with { type: "text" };
 import nowReminderTemplate from "../prompts/system/now-reminder.md" with { type: "text" };
-import { formatLocalDateTimeWithOffset, formatLocalTimeZoneShortName } from "../utils/local-date";
+import { formatLocalClockAndOffset, formatLocalTimeZoneShortName } from "../utils/local-date";
 
 /** Renders the reminder text for the given local calendar date and cwd. */
 export function renderDateCwdReminder(date: string, cwd: string): string {
@@ -127,12 +127,10 @@ const nowStampTail = /Now: \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z \([^()]*\)\n<\/s
 
 /** Renders the per-turn stamp payload, e.g. `2026-08-30T02:51:16Z (20:51 CST, UTC-06:00)`. */
 export function renderNowStamp(now: Date = new Date()): string {
-	const parts = formatLocalDateTimeWithOffset(now).split(" ");
-	const clock = parts[1] ?? "";
-	const offset = parts[2] ? `UTC${parts[2]}` : "";
+	const { clock, offset } = formatLocalClockAndOffset(now);
 	const zone = formatLocalTimeZoneShortName(now);
 	const zoneClock = [clock, zone].filter(part => part.length > 0).join(" ");
-	const local = [zoneClock, offset].filter(part => part.length > 0).join(", ");
+	const local = [zoneClock, `UTC${offset}`].filter(part => part.length > 0).join(", ");
 	const iso = now.toISOString().replace(/\.\d{3}Z$/, "Z");
 	return prompt.render(nowReminderTemplate, { now: `${iso} (${local})` }).trim();
 }
@@ -150,16 +148,27 @@ export function renderNowStamp(now: Date = new Date()): string {
  * timestamp would duplicate the stamp and invalidate the prompt cache from
  * message 0.
  *
- * The memo (keyed on the pristine message object, mirroring
- * `injectDateCwdReminder`) guarantees the same pristine user message always
- * yields the same stamped object. The append-only context log stores the
- * pre-transform (pristine) messages and hands them back on every request, so
- * a previously-stamped user message re-enters each later request in pristine
- * form — wherever it sits — and must be swapped back to its stamped copy to
- * keep the already-on-the-wire prefix byte-stable. Entries are
- * garbage-collected alongside the messages they belong to.
+ * Two memo layers keep the on-the-wire bytes stable:
+ * - Identity: the pristine-message WeakMap (mirroring `DateCwdReminderInjector`'s
+ *   injection memo) covers the append-only context path, where the same message
+ *   objects are re-handed on every request and are garbage-collected with them.
+ * - Fingerprint: per-request transforms may recreate the message object with
+ *   identical wire bytes (steer envelopes in `wrapSteeringForModel`, secret
+ *   obfuscation). A recreated object misses the identity memo, so a second
+ *   memo keyed on the stable wire identity (timestamp + content shape + final
+ *   text) re-applies the exact stamp that already went on the wire — including
+ *   for messages that slid out of last-user position. It lives for the process
+ *   lifetime (bounded by the number of distinct user messages).
  */
 const nowStampCache = new WeakMap<Message, Message>();
+const nowStampByFingerprint = new Map<string, string>();
+
+/** Stable wire identity of a user message: timestamp, content shape, final text. */
+function nowStampFingerprint(message: Message, tail: string | undefined): string {
+	const content = message.content;
+	const body = typeof content === "string" ? content : `${content.length}\u0000${tail ?? ""}`;
+	return `${message.timestamp ?? ""}\u0000${body}`;
+}
 
 /** Final text of a message: its string content, or the last text part. */
 function finalMessageText(content: Message["content"]): string | undefined {
@@ -193,14 +202,17 @@ export function injectNowStamp(messages: Message[], now: Date = new Date()): Mes
 			changed = true;
 			continue;
 		}
-		if (i !== last) continue;
-		const stamp = renderNowStamp(now);
+		const fingerprint = nowStampFingerprint(message, tail);
+		const knownStamp = nowStampByFingerprint.get(fingerprint);
+		const stamp = knownStamp ?? (i === last ? renderNowStamp(now) : undefined);
+		if (stamp === undefined) continue;
 		const content =
 			typeof message.content === "string"
 				? `${message.content}\n\n${stamp}`
 				: ([...message.content, { type: "text", text: stamp }] as Message["content"]);
 		const stamped = { ...message, content } as Message;
 		nowStampCache.set(message, stamped);
+		if (knownStamp === undefined) nowStampByFingerprint.set(fingerprint, stamp);
 		out[i] = stamped;
 		changed = true;
 	}
@@ -212,7 +224,7 @@ export function injectNowStamp(messages: Message[], now: Date = new Date()): Mes
  * system prompt byte-stable for prompt caching. Skips NULL_PROMPT-style
  * contexts (empty system prompt) and no-message contexts so such requests
  * stay byte-for-byte unchanged; mirrors the guards of
- * {@link withDateCwdReminder}.
+ * {@link DateCwdReminderInjector.transform}.
  */
 export function applyNowStamp(context: Context, now: Date = new Date()): Context {
 	if (!context.systemPrompt || context.systemPrompt.length === 0) return context;

--- a/packages/coding-agent/src/session/date-cwd-reminder.ts
+++ b/packages/coding-agent/src/session/date-cwd-reminder.ts
@@ -143,8 +143,10 @@ export function renderNowStamp(now: Date = new Date()): string {
  * own `timestamp` — so re-stamps are byte-identical across requests and
  * across session resumes: a resumed process rehydrates history as fresh
  * objects with the persisted content and timestamp, and re-derives the
- * exact wire bytes the original process sent. Only the genuinely-new last
- * turn adds bytes, at the tail, so the prompt-cache prefix stays stable.
+ * exact wire bytes the original process sent, given the same host timezone
+ * and locale (the parenthesized local part of the stamp renders host-locally).
+ * Only the genuinely-new last turn adds bytes, at the tail, so the
+ * prompt-cache prefix stays stable.
  * Idempotent per user message: a message already carrying a stamp keeps
  * it — a fresh stamp would duplicate and invalidate the prompt cache from message 0.
  *

--- a/packages/coding-agent/src/session/date-cwd-reminder.ts
+++ b/packages/coding-agent/src/session/date-cwd-reminder.ts
@@ -10,7 +10,7 @@
  * in the session), deterministic per `(date, cwd)`, so the bytes are stable
  * for the lifetime of a session/day and refresh automatically at midnight.
  */
-import type { Context, Message, UserMessage } from "@oh-my-pi/pi-ai";
+import type { Context, DeveloperMessage, Message, OpenAIResponsesHistoryPayload, UserMessage } from "@oh-my-pi/pi-ai";
 import { prompt } from "@oh-my-pi/pi-utils";
 import dateCwdReminderTemplate from "../prompts/system/date-cwd-reminder.md" with { type: "text" };
 import nowReminderTemplate from "../prompts/system/now-reminder.md" with { type: "text" };
@@ -155,6 +155,13 @@ export function renderNowStamp(now: Date = new Date()): string {
  * A pasted or echoed `Now:` block carrying any other value does not suppress
  * the stamp; the derived one is injected alongside it deterministically.
  *
+ * Messages carrying an openaiResponsesHistory providerPayload (notably the
+ * compaction-summary message created after OpenAI remote compaction) are
+ * replayed by the Responses serializers from that payload's items, which
+ * skip the generic content; the stamp is appended to the payload as an
+ * ordinary user message item so the provider sees it, byte-stably, there
+ * as well.
+ *
  * The stamp value is computed, never held in a process-global structure:
  * two distinct turns in the same second share the correct instant rather
  * than a value leaked from another turn's request. The only memo is the
@@ -185,6 +192,33 @@ function finalMessageText(content: Message["content"]): string | undefined {
 	return undefined;
 }
 
+/** The native Responses replay payload of a message, when it carries one. */
+function responsesHistoryPayload(message: UserMessage | DeveloperMessage): OpenAIResponsesHistoryPayload | undefined {
+	const payload = message.providerPayload;
+	if (payload?.type !== "openaiResponsesHistory" || !Array.isArray(payload.items)) return undefined;
+	return payload;
+}
+
+/** A replay item carrying the stamp as an ordinary user message. */
+function responsesHistoryStampItem(stamp: string): Record<string, unknown> {
+	return { type: "message", role: "user", content: [{ type: "input_text", text: stamp }] };
+}
+
+/** True when the payload's final item already carries the stamp, byte for byte. */
+function responsesHistoryTailIsStamp(items: Array<Record<string, unknown>>, stamp: string): boolean {
+	const last = items[items.length - 1];
+	if (!last || last.type !== "message" || last.role !== "user") return false;
+	const content = last.content;
+	if (!Array.isArray(content) || content.length === 0) return false;
+	const part = content[content.length - 1];
+	return (
+		typeof part === "object" &&
+		part !== null &&
+		(part as Record<string, unknown>).type === "input_text" &&
+		(part as Record<string, unknown>).text === stamp
+	);
+}
+
 export function injectNowStamp(messages: Message[]): Message[] {
 	let out: Message[] | undefined;
 	for (let i = 0; i < messages.length; i++) {
@@ -205,12 +239,31 @@ export function injectNowStamp(messages: Message[]): Message[] {
 		// an already-applied stamp. A pasted or echoed Now block carrying any
 		// other value must not suppress it.
 		const tail = finalMessageText(message.content);
-		if (tail !== undefined && tail.endsWith(stamp)) continue;
-		const content =
-			typeof message.content === "string"
+		const contentStamped = tail !== undefined && tail.endsWith(stamp);
+		// The Responses serializers replay a user message's authoritative
+		// providerPayload.items and skip its generic content (notably the
+		// compaction-summary message after OpenAI remote compaction), so the
+		// stamp must reach the payload or the provider never sees it.
+		const history = responsesHistoryPayload(message);
+		const historyStamped = history !== undefined && responsesHistoryTailIsStamp(history.items, stamp);
+		if (contentStamped && (history === undefined || historyStamped)) continue;
+		const content = contentStamped
+			? message.content
+			: typeof message.content === "string"
 				? `${message.content}\n\n${stamp}`
 				: ([...message.content, { type: "text", text: stamp }] as Message["content"]);
-		const stamped = { ...message, content } as Message;
+		const stamped = {
+			...message,
+			content,
+			...(history !== undefined && !historyStamped
+				? {
+						providerPayload: {
+							...history,
+							items: [...history.items, responsesHistoryStampItem(stamp)],
+						},
+					}
+				: {}),
+		} as Message;
 		nowStampCache.set(message, stamped);
 		(out ??= messages.slice())[i] = stamped;
 	}

--- a/packages/coding-agent/src/slash-commands/builtin-modes.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-modes.ts
@@ -100,6 +100,27 @@ function applyExtendedContextCommand(settings: Settings, args: string): string |
 	return undefined;
 }
 
+/** Applies a `/time` argument and returns its operator feedback. */
+function applyNowStampCommand(settings: Settings, args: string): string | undefined {
+	const arg = args.trim().toLowerCase();
+	const current = settings.get("prompt.nowStamp");
+	if (!arg || arg === "toggle") {
+		const enabled = !current;
+		settings.set("prompt.nowStamp", enabled);
+		return `Per-turn time stamp ${enabled ? "enabled" : "disabled"}.`;
+	}
+	if (arg === "on") {
+		settings.set("prompt.nowStamp", true);
+		return "Per-turn time stamp enabled.";
+	}
+	if (arg === "off") {
+		settings.set("prompt.nowStamp", false);
+		return "Per-turn time stamp disabled.";
+	}
+	if (arg === "status") return `Per-turn time stamp is ${current ? "on" : "off"}.`;
+	return undefined;
+}
+
 /** Detailed, session-effective `/computer status` diagnostics. */
 function formatComputerUseStatus(session: AgentSession): string {
 	const enabled = session.settings.get("computer.enabled");
@@ -565,6 +586,33 @@ export const BUILTIN_MODE_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> = [
 			const output = applyExtendedContextCommand(runtime.ctx.settings, command.args);
 			refreshStatusLine(runtime.ctx);
 			runtime.ctx.showStatus(output ?? "Usage: /extended-context [on|off|status]");
+			runtime.ctx.editor.setText("");
+		},
+	},
+	{
+		name: "time",
+		icon: "gauge",
+		description: "Toggle the per-turn Now: time stamp on user messages",
+		acpDescription: "Toggle per-turn time stamp",
+		acpInputHint: "[on|off|status]",
+		subcommands: [
+			{ name: "on", description: "Enable the per-turn Now: time stamp" },
+			{ name: "off", description: "Disable the per-turn Now: time stamp" },
+			{ name: "status", description: "Show time stamp status" },
+		],
+		allowArgs: true,
+		getTuiAutocompleteDescription: runtime =>
+			`Time stamp: ${runtime.ctx.settings.get("prompt.nowStamp") ? "on" : "off"}`,
+		handle: async (command, runtime) => {
+			const output = applyNowStampCommand(runtime.settings, command.args);
+			if (!output) return usage("Usage: /time [on|off|status]", runtime);
+			await runtime.output(output);
+			return commandConsumed();
+		},
+		handleTui: (command, runtime) => {
+			const output = applyNowStampCommand(runtime.ctx.settings, command.args);
+			refreshStatusLine(runtime.ctx);
+			runtime.ctx.showStatus(output ?? "Usage: /time [on|off|status]");
 			runtime.ctx.editor.setText("");
 		},
 	},

--- a/packages/coding-agent/src/utils/local-date.ts
+++ b/packages/coding-agent/src/utils/local-date.ts
@@ -18,3 +18,11 @@ export function formatLocalDateTimeWithOffset(date: Date): string {
 		offsetHours,
 	)}:${pad2(offsetRemainderMinutes)}`;
 }
+
+/** Format a Date's short timezone name (e.g. `CST`) in the host locale. */
+export function formatLocalTimeZoneShortName(date: Date): string {
+	const part = new Intl.DateTimeFormat(undefined, { timeZoneName: "short" })
+		.formatToParts(date)
+		.find(part => part.type === "timeZoneName");
+	return part?.value ?? "";
+}

--- a/packages/coding-agent/src/utils/local-date.ts
+++ b/packages/coding-agent/src/utils/local-date.ts
@@ -8,15 +8,19 @@ export function formatLocalCalendarDate(date: Date = new Date()): string {
 
 /** Format a local date and minute with a compact numeric UTC offset. */
 export function formatLocalDateTimeWithOffset(date: Date): string {
-	const offsetMinutes = date.getTimezoneOffset();
-	const offsetSign = offsetMinutes <= 0 ? "+" : "-";
-	const absoluteOffset = Math.abs(offsetMinutes);
-	const offsetHours = Math.floor(absoluteOffset / 60);
-	const offsetRemainderMinutes = absoluteOffset % 60;
+	const { clock, offset } = formatLocalClockAndOffset(date);
+	return `${formatLocalCalendarDate(date)} ${clock} ${offset}`;
+}
+
+/** Local clock (`HH:MM`) and numeric UTC offset (`±HH:MM`) as structured parts. */
+export function formatLocalClockAndOffset(date: Date): { clock: string; offset: string } {
 	const pad2 = (value: number): string => String(value).padStart(2, "0");
-	return `${formatLocalCalendarDate(date)} ${pad2(date.getHours())}:${pad2(date.getMinutes())} ${offsetSign}${pad2(
-		offsetHours,
-	)}:${pad2(offsetRemainderMinutes)}`;
+	const offsetMinutes = date.getTimezoneOffset();
+	const absoluteOffset = Math.abs(offsetMinutes);
+	return {
+		clock: `${pad2(date.getHours())}:${pad2(date.getMinutes())}`,
+		offset: `${offsetMinutes <= 0 ? "+" : "-"}${pad2(Math.floor(absoluteOffset / 60))}:${pad2(absoluteOffset % 60)}`,
+	};
 }
 
 /** Format a Date's short timezone name (e.g. `CST`) in the host locale. */

--- a/packages/coding-agent/test/acp-builtins.test.ts
+++ b/packages/coding-agent/test/acp-builtins.test.ts
@@ -272,6 +272,23 @@ describe("ACP builtin slash commands", () => {
 			"Extended context is off.",
 		]);
 	});
+	it("toggles the per-turn time stamp with explicit controls and reports state", async () => {
+		const { output, runtime } = createRuntime();
+
+		expect(await executeAcpBuiltinSlashCommand("/time off", runtime)).toEqual({ consumed: true });
+		expect(runtime.settings.get("prompt.nowStamp")).toBe(false);
+		expect(await executeAcpBuiltinSlashCommand("/time on", runtime)).toEqual({ consumed: true });
+		expect(runtime.settings.get("prompt.nowStamp")).toBe(true);
+		expect(await executeAcpBuiltinSlashCommand("/time", runtime)).toEqual({ consumed: true });
+		expect(runtime.settings.get("prompt.nowStamp")).toBe(false);
+		expect(await executeAcpBuiltinSlashCommand("/time status", runtime)).toEqual({ consumed: true });
+		expect(output).toEqual([
+			"Per-turn time stamp disabled.",
+			"Per-turn time stamp enabled.",
+			"Per-turn time stamp disabled.",
+			"Per-turn time stamp is off.",
+		]);
+	});
 
 	it("forces a tool and returns remaining prompt text", async () => {
 		const { output, runtime } = createRuntime();

--- a/packages/coding-agent/test/agent-session-message-pipeline.test.ts
+++ b/packages/coding-agent/test/agent-session-message-pipeline.test.ts
@@ -339,12 +339,17 @@ describe("AgentSession message pipeline", () => {
 
 			expect(contexts).toHaveLength(1);
 			const userMessage = contexts[0]!.messages.find(message => message.role === "user");
-			// The date/cwd reminder rides on the first user turn (#7404); the contract
-			// here is that the undecodable WebP is replaced by the placeholder text.
+			// The date/cwd reminder rides on the first user turn (#7404); the per-turn
+			// Now stamp rides on the last user turn (here the same message); the
+			// contract is that the undecodable WebP is replaced by the placeholder text.
 			expect(userMessage?.content).toEqual([
 				{ type: "text", text: expect.stringContaining("<system-reminder>") },
 				{ type: "text", text: "inspect this" },
 				{ type: "text", text: "[image omitted: WebP could not be decoded for this model]" },
+				{
+					type: "text",
+					text: expect.stringMatching(/^<system-reminder>\nNow: \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z \(/),
+				},
 			]);
 		} finally {
 			await session.dispose();

--- a/packages/coding-agent/test/available-commands.test.ts
+++ b/packages/coding-agent/test/available-commands.test.ts
@@ -48,6 +48,7 @@ describe("buildAvailableSlashCommands", () => {
 
 		expect(byName.fast.description).toBe("Toggle fast mode");
 		expect(byName["extended-context"].description).toBe("Toggle extended context");
+		expect(byName.time.description).toBe("Toggle per-turn time stamp");
 		expect(byName["ext:hello"].description).toBe("Extension hello");
 		expect(byName["custom:hello"].description).toBe("Custom hello");
 		expect(byName["server:prompt"].description).toBe("MCP prompt");

--- a/packages/coding-agent/test/date-cwd-reminder.test.ts
+++ b/packages/coding-agent/test/date-cwd-reminder.test.ts
@@ -238,6 +238,35 @@ describe("date-cwd-reminder", () => {
 			const empty: Message[] = [];
 			expect(injectNowStamp(empty, new Date("2026-08-30T02:51:16Z"))).toBe(empty);
 		});
+
+		it("re-applies the same stamp to a recreated copy of a previously stamped message", () => {
+			// Per-request transforms (steer envelopes, secret obfuscation) may
+			// hand back a fresh object with identical wire bytes; the stamp must
+			// not change with it.
+			const pristine: Message = { role: "user", content: "steer-alpha", timestamp: 101 };
+			const first = injectNowStamp([pristine], new Date("2026-08-30T02:51:16Z"))[0]!;
+
+			const recreated: Message = { role: "user", content: "steer-alpha", timestamp: 101 };
+			const out = injectNowStamp([recreated], new Date("2026-08-30T03:00:00Z"));
+
+			expect(out[0]).not.toBe(recreated);
+			expect(textOf(out[0]!)).toBe(textOf(first));
+		});
+
+		it("keeps the stamp when a recreated copy slides out of last-user position", () => {
+			const first: Message = { role: "user", content: "steer-beta", timestamp: 102 };
+			const assistant = createAssistantMessage("hi");
+			const second: Message = { role: "user", content: "steer-gamma", timestamp: 103 };
+
+			const firstStamped = injectNowStamp([first], new Date("2026-08-30T02:51:16Z"))[0]!;
+
+			const firstRecreated: Message = { role: "user", content: "steer-beta", timestamp: 102 };
+			const out = injectNowStamp([firstRecreated, assistant, second], new Date("2026-08-30T03:00:00Z"));
+
+			expect(textOf(out[0]!)).toBe(textOf(firstStamped));
+			expect(out[1]).toBe(assistant);
+			expect(textOf(out[2]!)).toContain("Now: 2026-08-30T03:00:00Z");
+		});
 	});
 
 	describe("applyNowStamp", () => {
@@ -256,9 +285,9 @@ describe("date-cwd-reminder", () => {
 			const context: Context = {
 				systemPrompt,
 				messages: [
-					{ role: "user", content: "first", timestamp: 1 },
+					{ role: "user", content: "first-apply", timestamp: 201 },
 					createAssistantMessage("hi"),
-					{ role: "user", content: "last", timestamp: 2 },
+					{ role: "user", content: "last-apply", timestamp: 202 },
 				],
 			};
 

--- a/packages/coding-agent/test/date-cwd-reminder.test.ts
+++ b/packages/coding-agent/test/date-cwd-reminder.test.ts
@@ -168,6 +168,34 @@ describe("date-cwd-reminder", () => {
 			expect(messages[2]!.content).toBe("last");
 		});
 
+		it("stamps user-initiated developer continuation turns from their own turn timestamp", () => {
+			// The `.`, `c` continue shortcuts submit a synthetic developer
+			// message (userInitiated: true) with a fresh turn timestamp; the
+			// model must see a stamp for this turn, not only the previous
+			// user turn's potentially stale one.
+			const t = Date.parse("2026-08-30T04:12:00Z");
+			const continuation: Message = {
+				role: "developer",
+				content: "Continue the task.",
+				synthetic: true,
+				userInitiated: true,
+				timestamp: t,
+			};
+
+			const out = injectNowStamp([continuation])[0]!;
+
+			expect(out).not.toBe(continuation);
+			expect(textOf(out)).toBe(`Continue the task.\n\n${renderNowStamp(new Date(t))}`);
+		});
+
+		it("leaves agent-initiated developer turns unstamped", () => {
+			const t = Date.parse("2026-08-30T04:12:00Z");
+			const autoContinue: Message = { role: "developer", content: "Continue.", synthetic: true, timestamp: t };
+			const turns: Message[] = [createAssistantMessage("hi"), autoContinue];
+
+			expect(injectNowStamp(turns)).toBe(turns);
+		});
+
 		it("appends a trailing text part when a user message has array content", () => {
 			const t = Date.parse("2026-08-30T02:51:16Z");
 			const messages: Message[] = [
@@ -191,18 +219,33 @@ describe("date-cwd-reminder", () => {
 			expect(content[2]!).toEqual({ type: "text", text: renderNowStamp(new Date(t)) });
 		});
 
-		it("leaves a user message already carrying a Now stamp unchanged", () => {
-			const stamped: Message = {
-				role: "user",
-				content: "hi\n\n<system-reminder>\nNow: 2026-01-02T03:04:05Z (04:04 XYZ, UTC+01:00)\n</system-reminder>",
-				timestamp: 1,
-			};
+		it("keeps a prompt byte-identical when its trailing Now block equals its derived stamp", () => {
+			// A prompt whose tail is exactly the stamp derived from its own
+			// timestamp (e.g. a transcript echo) is already stamped: passthrough.
+			const t = Date.parse("2026-08-30T02:51:16Z");
+			const derived = renderNowStamp(new Date(t));
+			const stamped: Message = { role: "user", content: `hi\n\n${derived}`, timestamp: t };
 			const messages = [stamped];
 
 			const out = injectNowStamp(messages);
 
 			expect(out).toBe(messages);
+			expect(out[0]!).toBe(stamped);
 			expect(textOf(out[0]!).match(/Now: /g)).toHaveLength(1);
+		});
+
+		it("re-stamps a prompt ending in a pasted Now block with a different value", () => {
+			// A pasted or previously generated Now block carrying another
+			// timestamp must not suppress the real stamp: the derived one is
+			// injected alongside it, deterministically.
+			const t = Date.parse("2026-08-30T02:51:16Z");
+			const derived = renderNowStamp(new Date(t));
+			const pasted = `<system-reminder>\nNow: 2025-01-02T03:04:05Z (04:04 XYZ, UTC+01:00)\n</system-reminder>`;
+			const message: Message = { role: "user", content: `quote this verbatim\n\n${pasted}`, timestamp: t };
+
+			const out = injectNowStamp([message])[0]!;
+
+			expect(textOf(out)).toBe(`quote this verbatim\n\n${pasted}\n\n${derived}`);
 		});
 
 		it("re-stamps the same pristine message with the same stamped object across requests", () => {

--- a/packages/coding-agent/test/date-cwd-reminder.test.ts
+++ b/packages/coding-agent/test/date-cwd-reminder.test.ts
@@ -141,31 +141,32 @@ describe("date-cwd-reminder", () => {
 	});
 
 	describe("injectNowStamp", () => {
-		it("appends the stamp to the last user message with string content without mutating the input", () => {
-			const first: Message = { role: "user", content: "first", timestamp: 1 };
+		it("stamps every user message from its own turn timestamp without mutating the input", () => {
+			const t1 = Date.parse("2026-08-30T02:51:16Z");
+			const t2 = Date.parse("2026-08-30T02:55:00Z");
+			const first: Message = { role: "user", content: "first", timestamp: t1 };
 			const assistant = createAssistantMessage("hi");
-			const last: Message = { role: "user", content: "last", timestamp: 2 };
+			const last: Message = { role: "user", content: "last", timestamp: t2 };
 			const messages = [first, assistant, last];
 
-			const out = injectNowStamp(messages, new Date("2026-08-30T02:51:16Z"));
+			const out = injectNowStamp(messages);
 
 			expect(out).not.toBe(messages);
-			// Earlier messages keep their identity; only the last user message is stamped.
-			expect(out[0]).toBe(first);
+			// Every user message carries the stamp of its own turn; assistant
+			// messages keep their identity.
+			expect(out[0]).not.toBe(first);
 			expect(out[1]).toBe(assistant);
 			expect(out[2]).not.toBe(last);
-			expect(typeof out[2]?.content).toBe("string");
-			expect(textOf(out[2]!)).toMatch(
-				/^last\n\n<system-reminder>\nNow: 2026-08-30T02:51:16Z \(.+\)\n<\/system-reminder>$/,
-			);
+			expect(textOf(out[0]!)).toBe(`first\n\n${renderNowStamp(new Date(t1))}`);
+			expect(textOf(out[2]!)).toBe(`last\n\n${renderNowStamp(new Date(t2))}`);
 			// The input array and its elements are untouched.
-			expect(messages).toEqual([first, assistant, last]);
 			expect(messages[0]).toBe(first);
 			expect(messages[2]).toBe(last);
 			expect(messages[2]!.content).toBe("last");
 		});
 
-		it("appends a trailing text part when the last user message has array content", () => {
+		it("appends a trailing text part when a user message has array content", () => {
+			const t = Date.parse("2026-08-30T02:51:16Z");
 			const messages: Message[] = [
 				{
 					role: "user",
@@ -173,25 +174,21 @@ describe("date-cwd-reminder", () => {
 						{ type: "text", text: "with image" },
 						{ type: "image", data: "img", mimeType: "image/png" },
 					],
-					timestamp: 1,
+					timestamp: t,
 				},
 			];
 
-			const out = injectNowStamp(messages, new Date("2026-08-30T02:51:16Z"));
+			const out = injectNowStamp(messages);
 
 			const content = out[0]?.content;
 			if (!Array.isArray(content)) throw new Error("expected array content");
 			expect(content).toHaveLength(3);
 			expect(content[0]).toEqual({ type: "text", text: "with image" });
 			expect(content[1]).toEqual({ type: "image", data: "img", mimeType: "image/png" });
-			const lastPart = content[2];
-			expect(lastPart?.type).toBe("text");
-			if (lastPart?.type === "text") {
-				expect(lastPart.text).toMatch(/^<system-reminder>\nNow: 2026-08-30T02:51:16Z \(.+\)\n<\/system-reminder>$/);
-			}
+			expect(content[2]!).toEqual({ type: "text", text: renderNowStamp(new Date(t)) });
 		});
 
-		it("leaves a last user message already carrying a Now stamp unchanged", () => {
+		it("leaves a user message already carrying a Now stamp unchanged", () => {
 			const stamped: Message = {
 				role: "user",
 				content: "hi\n\n<system-reminder>\nNow: 2026-01-02T03:04:05Z (04:04 XYZ, UTC+01:00)\n</system-reminder>",
@@ -199,104 +196,151 @@ describe("date-cwd-reminder", () => {
 			};
 			const messages = [stamped];
 
-			const out = injectNowStamp(messages, new Date("2026-08-30T02:51:16Z"));
+			const out = injectNowStamp(messages);
 
 			expect(out).toBe(messages);
 			expect(textOf(out[0]!).match(/Now: /g)).toHaveLength(1);
 		});
 
-		it("re-stamps the same pristine message with the same stamped object even at a later timestamp", () => {
-			const pristine: Message = { role: "user", content: "hi", timestamp: 1 };
+		it("re-stamps the same pristine message with the same stamped object across requests", () => {
+			const t = Date.parse("2026-08-30T02:51:16Z");
+			const pristine: Message = { role: "user", content: "hi", timestamp: t };
 
-			const first = injectNowStamp([pristine], new Date("2026-08-30T02:51:16Z"))[0]!;
+			const first = injectNowStamp([pristine])[0]!;
 			expect(first).not.toBe(pristine);
-			const second = injectNowStamp([pristine], new Date("2026-08-30T03:00:00Z"))[0]!;
+			const second = injectNowStamp([pristine])[0]!;
 			expect(second).toBe(first);
 		});
 
-		it("re-applies the cached stamp to a previously-stamped user message that is no longer last", () => {
+		it("keeps byte-identical wire bytes when a previously-stamped user message slides out of last position", () => {
 			// The append-only log re-hands the pristine messages each request; a
 			// user message stamped in an earlier request must keep its exact wire
 			// bytes once it slides out of the last-user position.
-			const first: Message = { role: "user", content: "first", timestamp: 1 };
+			const t1 = Date.parse("2026-08-30T02:51:16Z");
+			const t2 = Date.parse("2026-08-30T02:55:00Z");
+			const first: Message = { role: "user", content: "first", timestamp: t1 };
 			const assistant = createAssistantMessage("hi");
-			const second: Message = { role: "user", content: "second", timestamp: 2 };
+			const second: Message = { role: "user", content: "second", timestamp: t2 };
 
-			const firstStamped = injectNowStamp([first], new Date("2026-08-30T02:51:16Z"))[0]!;
+			const firstStamped = injectNowStamp([first])[0]!;
 
-			const out = injectNowStamp([first, assistant, second], new Date("2026-08-30T03:00:00Z"));
+			const out = injectNowStamp([first, assistant, second]);
 
 			expect(out[0]).toBe(firstStamped);
 			expect(out[1]).toBe(assistant);
 			expect(out[2]).not.toBe(second);
-			expect(textOf(out[2]!)).toContain("Now: 2026-08-30T03:00:00Z");
+			expect(textOf(out[0]!)).toBe(textOf(firstStamped));
+			expect(textOf(out[2]!)).toBe(`second\n\n${renderNowStamp(new Date(t2))}`);
+		});
+
+		it("re-derives byte-identical stamps for rehydrated history after a session resume", () => {
+			// Resume: a new process rehydrates the persisted session as fresh
+			// message objects (same persisted content + timestamp) with empty
+			// module state; the previously-stamped turn must keep its exact
+			// wire bytes while only the new last turn adds bytes at the tail.
+			const t1 = Date.parse("2026-08-30T02:51:16Z");
+			const t2 = Date.parse("2026-08-30T03:12:45Z");
+			const original: Message = { role: "user", content: "first turn", timestamp: t1 };
+			const originalStamped = injectNowStamp([original])[0]!;
+
+			const rehydrated: Message = { role: "user", content: "first turn", timestamp: t1 };
+			const resumedLast: Message = { role: "user", content: "new turn after resume", timestamp: t2 };
+			const out = injectNowStamp([rehydrated, createAssistantMessage("hi"), resumedLast]);
+
+			expect(textOf(out[0]!)).toBe(textOf(originalStamped));
+			expect(textOf(out[2]!)).toBe(`new turn after resume\n\n${renderNowStamp(new Date(t2))}`);
+		});
+
+		it("stamps same-millisecond distinct turns from each turn's own instant, not a shared value", () => {
+			// Two turns with the same text in the same millisecond but different
+			// image sets are distinct turns: each carries the stamp of its own
+			// timestamp — never a value leaked from the other turn's request.
+			const t = Date.parse("2026-08-30T02:51:16.412Z");
+			const samePrompt = "analyze this image";
+			const turnA: Message = {
+				role: "user",
+				content: [
+					{ type: "text", text: samePrompt },
+					{ type: "image", data: "imgA", mimeType: "image/png" },
+				],
+				timestamp: t,
+			};
+			const turnB: Message = {
+				role: "user",
+				content: [
+					{ type: "text", text: samePrompt },
+					{ type: "image", data: "imgB", mimeType: "image/png" },
+				],
+				timestamp: t,
+			};
+
+			const out = injectNowStamp([turnA, createAssistantMessage("hi"), turnB]);
+			const expected = renderNowStamp(new Date(t));
+
+			for (const i of [0, 2]) {
+				const content = out[i]!.content;
+				if (!Array.isArray(content)) throw new Error("expected array content");
+				expect(content[content.length - 1]!).toEqual({ type: "text", text: expected });
+			}
+		});
+
+		it("derives each stamp from its own message's timestamp, independent of other sessions' messages", () => {
+			// No process-global content-keyed value cache: identical content with
+			// different turn timestamps yields different stamps, and re-creation
+			// with the same persisted identity yields identical bytes.
+			const tA = Date.parse("2026-08-30T02:51:16Z");
+			const tB = Date.parse("2026-08-30T02:52:16Z");
+			const sessionA: Message = { role: "user", content: "hi", timestamp: tA };
+			const sessionB: Message = { role: "user", content: "hi", timestamp: tB };
+
+			const outA = injectNowStamp([sessionA])[0]!;
+			const outB = injectNowStamp([sessionB])[0]!;
+			const outARecreated = injectNowStamp([{ ...sessionA }])[0]!;
+
+			expect(textOf(outA)).toBe(`hi\n\n${renderNowStamp(new Date(tA))}`);
+			expect(textOf(outA)).not.toBe(textOf(outB));
+			expect(textOf(outARecreated)).toBe(textOf(outA));
 		});
 
 		it("returns the input unchanged when there is no user message or no messages", () => {
 			const assistantOnly = [createAssistantMessage("hi")];
-			expect(injectNowStamp(assistantOnly, new Date("2026-08-30T02:51:16Z"))).toBe(assistantOnly);
+			expect(injectNowStamp(assistantOnly)).toBe(assistantOnly);
 			const empty: Message[] = [];
-			expect(injectNowStamp(empty, new Date("2026-08-30T02:51:16Z"))).toBe(empty);
-		});
-
-		it("re-applies the same stamp to a recreated copy of a previously stamped message", () => {
-			// Per-request transforms (steer envelopes, secret obfuscation) may
-			// hand back a fresh object with identical wire bytes; the stamp must
-			// not change with it.
-			const pristine: Message = { role: "user", content: "steer-alpha", timestamp: 101 };
-			const first = injectNowStamp([pristine], new Date("2026-08-30T02:51:16Z"))[0]!;
-
-			const recreated: Message = { role: "user", content: "steer-alpha", timestamp: 101 };
-			const out = injectNowStamp([recreated], new Date("2026-08-30T03:00:00Z"));
-
-			expect(out[0]).not.toBe(recreated);
-			expect(textOf(out[0]!)).toBe(textOf(first));
-		});
-
-		it("keeps the stamp when a recreated copy slides out of last-user position", () => {
-			const first: Message = { role: "user", content: "steer-beta", timestamp: 102 };
-			const assistant = createAssistantMessage("hi");
-			const second: Message = { role: "user", content: "steer-gamma", timestamp: 103 };
-
-			const firstStamped = injectNowStamp([first], new Date("2026-08-30T02:51:16Z"))[0]!;
-
-			const firstRecreated: Message = { role: "user", content: "steer-beta", timestamp: 102 };
-			const out = injectNowStamp([firstRecreated, assistant, second], new Date("2026-08-30T03:00:00Z"));
-
-			expect(textOf(out[0]!)).toBe(textOf(firstStamped));
-			expect(out[1]).toBe(assistant);
-			expect(textOf(out[2]!)).toContain("Now: 2026-08-30T03:00:00Z");
+			expect(injectNowStamp(empty)).toBe(empty);
 		});
 	});
 
 	describe("applyNowStamp", () => {
 		it("leaves NULL_PROMPT-style contexts (empty system prompt) untouched", () => {
 			const context: Context = { systemPrompt: [], messages: [{ role: "user", content: "hi", timestamp: 1 }] };
-			expect(applyNowStamp(context, new Date("2026-08-30T02:51:16Z"))).toBe(context);
+			expect(applyNowStamp(context)).toBe(context);
 		});
 
 		it("leaves no-message contexts untouched", () => {
 			const context: Context = { systemPrompt: ["system"], messages: [] };
-			expect(applyNowStamp(context, new Date("2026-08-30T02:51:16Z"))).toBe(context);
+			expect(applyNowStamp(context)).toBe(context);
 		});
 
-		it("stamps the last user message and keeps the system prompt bytes", () => {
+		it("stamps each user message from its own turn and keeps the system prompt bytes", () => {
 			const systemPrompt = ["PROJECT\n<critical>\n- Must act.\n</critical>"];
+			const t1 = Date.parse("2026-08-30T02:51:16Z");
+			const t2 = Date.parse("2026-08-30T02:55:00Z");
 			const context: Context = {
 				systemPrompt,
 				messages: [
-					{ role: "user", content: "first-apply", timestamp: 201 },
+					{ role: "user", content: "first-apply", timestamp: t1 },
 					createAssistantMessage("hi"),
-					{ role: "user", content: "last-apply", timestamp: 202 },
+					{ role: "user", content: "last-apply", timestamp: t2 },
 				],
 			};
 
-			const out = applyNowStamp(context, new Date("2026-08-30T02:51:16Z"));
+			const out = applyNowStamp(context);
 
 			expect(out).not.toBe(context);
 			expect(out.systemPrompt).toBe(systemPrompt);
-			expect(out.messages[0]).toBe(context.messages[0]);
-			expect(out.messages[2]?.content).toMatch(/Now: 2026-08-30T02:51:16Z \(/);
+			expect(out.messages[0]).not.toBe(context.messages[0]);
+			expect(out.messages[1]).toBe(context.messages[1]);
+			expect(out.messages[2]?.content).toBe(`last-apply\n\n${renderNowStamp(new Date(t2))}`);
 		});
 	});
 });
@@ -393,7 +437,7 @@ describe("date-cwd reminder on the provider wire", () => {
 			authStorage.close();
 		}
 	});
-	it("stamps the last user turn with Now and keeps stamped user turns byte-identical across requests", async () => {
+	it("stamps each user turn with its own Now and keeps stamped turns byte-identical across requests", async () => {
 		using tempDir = TempDir.createSync("@pi-now-reminder-");
 		const api = "test-now-reminder";
 		const contexts: Context[] = [];

--- a/packages/coding-agent/test/date-cwd-reminder.test.ts
+++ b/packages/coding-agent/test/date-cwd-reminder.test.ts
@@ -352,28 +352,12 @@ describe("now stamp across processes", () => {
 	// a process-global stamp cache would stay warm inside one test process.
 	// The design holds no module-level value state (only a WeakMap), so the
 	// second process must re-derive the first process's stamped bytes.
-	const CHILD_SCRIPT = `
-(async () => {
-// Runtime-selected module path (this test pins byte-identity across processes
-// for whatever date-cwd-reminder.ts the env points at): static import impossible.
-const { applyNowStamp } = await import(process.env.NOWSTAMP_SRC);
-const T1 = Date.parse("2026-08-30T02:51:16Z");
-const T2 = Date.parse("2026-08-30T03:12:45Z");
-const a = { role: "assistant", content: [{ type: "text", text: "hi" }], timestamp: T1 + 1 };
-const m1 = { role: "user", content: "first turn", timestamp: T1 };
-const m3 = { role: "user", content: [{ type: "text", text: "new turn after resume" }, { type: "image", data: "imgB", mimeType: "image/png" }], timestamp: T2 };
-const messages = process.env.NOWSTAMP_MODE === "orig" ? [m1, a] : [m1, a, m3];
-const ctx = applyNowStamp({ systemPrompt: ["SYSTEM"], messages });
-console.log(JSON.stringify([JSON.stringify(ctx.systemPrompt), ...ctx.messages.map(m => JSON.stringify(m.content))]));
-})();
-`;
+	const CHILD_FIXTURE = `${import.meta.dir}/fixtures/now-stamp-process-child.ts`;
 	async function stampInColdProcess(mode: "orig" | "resumed"): Promise<string[]> {
-		const proc = Bun.spawn([process.execPath, "--no-env-file", "--no-install", "--eval", CHILD_SCRIPT], {
+		const proc = Bun.spawn([process.execPath, "--no-env-file", "--no-install", CHILD_FIXTURE, mode], {
 			cwd: import.meta.dir,
 			env: {
 				...process.env,
-				NOWSTAMP_SRC: new URL("../src/session/date-cwd-reminder.ts", import.meta.url).href,
-				NOWSTAMP_MODE: mode,
 				TZ: "America/Chicago",
 			},
 			stdout: "pipe",

--- a/packages/coding-agent/test/date-cwd-reminder.test.ts
+++ b/packages/coding-agent/test/date-cwd-reminder.test.ts
@@ -7,12 +7,23 @@ import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { createAgentSession } from "@oh-my-pi/pi-coding-agent/sdk";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
-import { DateCwdReminderInjector, renderDateCwdReminder } from "@oh-my-pi/pi-coding-agent/session/date-cwd-reminder";
+import {
+	applyNowStamp,
+	DateCwdReminderInjector,
+	injectNowStamp,
+	renderDateCwdReminder,
+	renderNowStamp,
+} from "@oh-my-pi/pi-coding-agent/session/date-cwd-reminder";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import { formatLocalCalendarDate } from "@oh-my-pi/pi-coding-agent/utils/local-date";
 import { normalizePromptPath } from "@oh-my-pi/pi-coding-agent/utils/prompt-path";
 import { TempDir } from "@oh-my-pi/pi-utils";
 import { createAssistantMessage } from "./helpers/agent-session-setup";
+
+/** The wire text of a message: string content as-is, array content JSON-serialized. */
+function textOf(message: Message): string {
+	return typeof message.content === "string" ? message.content : JSON.stringify(message.content);
+}
 
 describe("date-cwd-reminder", () => {
 	afterEach(() => {
@@ -119,6 +130,146 @@ describe("date-cwd-reminder", () => {
 			expect(replay.messages[0]).toBe(first.messages[0]);
 		});
 	});
+	describe("renderNowStamp", () => {
+		it("renders a system-reminder block with a UTC instant, local clock, timezone name, and numeric offset", () => {
+			const stamp = renderNowStamp(new Date("2026-08-30T02:51:16Z"));
+
+			expect(stamp).toMatch(
+				/^<system-reminder>\nNow: 2026-08-30T02:51:16Z \(\d{2}:\d{2} [A-Za-z]{2,5}, UTC[+-]\d{2}:\d{2}\)\n<\/system-reminder>$/,
+			);
+		});
+	});
+
+	describe("injectNowStamp", () => {
+		it("appends the stamp to the last user message with string content without mutating the input", () => {
+			const first: Message = { role: "user", content: "first", timestamp: 1 };
+			const assistant = createAssistantMessage("hi");
+			const last: Message = { role: "user", content: "last", timestamp: 2 };
+			const messages = [first, assistant, last];
+
+			const out = injectNowStamp(messages, new Date("2026-08-30T02:51:16Z"));
+
+			expect(out).not.toBe(messages);
+			// Earlier messages keep their identity; only the last user message is stamped.
+			expect(out[0]).toBe(first);
+			expect(out[1]).toBe(assistant);
+			expect(out[2]).not.toBe(last);
+			expect(typeof out[2]?.content).toBe("string");
+			expect(textOf(out[2]!)).toMatch(
+				/^last\n\n<system-reminder>\nNow: 2026-08-30T02:51:16Z \(.+\)\n<\/system-reminder>$/,
+			);
+			// The input array and its elements are untouched.
+			expect(messages).toEqual([first, assistant, last]);
+			expect(messages[0]).toBe(first);
+			expect(messages[2]).toBe(last);
+			expect(messages[2]!.content).toBe("last");
+		});
+
+		it("appends a trailing text part when the last user message has array content", () => {
+			const messages: Message[] = [
+				{
+					role: "user",
+					content: [
+						{ type: "text", text: "with image" },
+						{ type: "image", data: "img", mimeType: "image/png" },
+					],
+					timestamp: 1,
+				},
+			];
+
+			const out = injectNowStamp(messages, new Date("2026-08-30T02:51:16Z"));
+
+			const content = out[0]?.content;
+			if (!Array.isArray(content)) throw new Error("expected array content");
+			expect(content).toHaveLength(3);
+			expect(content[0]).toEqual({ type: "text", text: "with image" });
+			expect(content[1]).toEqual({ type: "image", data: "img", mimeType: "image/png" });
+			const lastPart = content[2];
+			expect(lastPart?.type).toBe("text");
+			if (lastPart?.type === "text") {
+				expect(lastPart.text).toMatch(/^<system-reminder>\nNow: 2026-08-30T02:51:16Z \(.+\)\n<\/system-reminder>$/);
+			}
+		});
+
+		it("leaves a last user message already carrying a Now stamp unchanged", () => {
+			const stamped: Message = {
+				role: "user",
+				content: "hi\n\n<system-reminder>\nNow: 2026-01-02T03:04:05Z (04:04 XYZ, UTC+01:00)\n</system-reminder>",
+				timestamp: 1,
+			};
+			const messages = [stamped];
+
+			const out = injectNowStamp(messages, new Date("2026-08-30T02:51:16Z"));
+
+			expect(out).toBe(messages);
+			expect(textOf(out[0]!).match(/Now: /g)).toHaveLength(1);
+		});
+
+		it("re-stamps the same pristine message with the same stamped object even at a later timestamp", () => {
+			const pristine: Message = { role: "user", content: "hi", timestamp: 1 };
+
+			const first = injectNowStamp([pristine], new Date("2026-08-30T02:51:16Z"))[0]!;
+			expect(first).not.toBe(pristine);
+			const second = injectNowStamp([pristine], new Date("2026-08-30T03:00:00Z"))[0]!;
+			expect(second).toBe(first);
+		});
+
+		it("re-applies the cached stamp to a previously-stamped user message that is no longer last", () => {
+			// The append-only log re-hands the pristine messages each request; a
+			// user message stamped in an earlier request must keep its exact wire
+			// bytes once it slides out of the last-user position.
+			const first: Message = { role: "user", content: "first", timestamp: 1 };
+			const assistant = createAssistantMessage("hi");
+			const second: Message = { role: "user", content: "second", timestamp: 2 };
+
+			const firstStamped = injectNowStamp([first], new Date("2026-08-30T02:51:16Z"))[0]!;
+
+			const out = injectNowStamp([first, assistant, second], new Date("2026-08-30T03:00:00Z"));
+
+			expect(out[0]).toBe(firstStamped);
+			expect(out[1]).toBe(assistant);
+			expect(out[2]).not.toBe(second);
+			expect(textOf(out[2]!)).toContain("Now: 2026-08-30T03:00:00Z");
+		});
+
+		it("returns the input unchanged when there is no user message or no messages", () => {
+			const assistantOnly = [createAssistantMessage("hi")];
+			expect(injectNowStamp(assistantOnly, new Date("2026-08-30T02:51:16Z"))).toBe(assistantOnly);
+			const empty: Message[] = [];
+			expect(injectNowStamp(empty, new Date("2026-08-30T02:51:16Z"))).toBe(empty);
+		});
+	});
+
+	describe("applyNowStamp", () => {
+		it("leaves NULL_PROMPT-style contexts (empty system prompt) untouched", () => {
+			const context: Context = { systemPrompt: [], messages: [{ role: "user", content: "hi", timestamp: 1 }] };
+			expect(applyNowStamp(context, new Date("2026-08-30T02:51:16Z"))).toBe(context);
+		});
+
+		it("leaves no-message contexts untouched", () => {
+			const context: Context = { systemPrompt: ["system"], messages: [] };
+			expect(applyNowStamp(context, new Date("2026-08-30T02:51:16Z"))).toBe(context);
+		});
+
+		it("stamps the last user message and keeps the system prompt bytes", () => {
+			const systemPrompt = ["PROJECT\n<critical>\n- Must act.\n</critical>"];
+			const context: Context = {
+				systemPrompt,
+				messages: [
+					{ role: "user", content: "first", timestamp: 1 },
+					createAssistantMessage("hi"),
+					{ role: "user", content: "last", timestamp: 2 },
+				],
+			};
+
+			const out = applyNowStamp(context, new Date("2026-08-30T02:51:16Z"));
+
+			expect(out).not.toBe(context);
+			expect(out.systemPrompt).toBe(systemPrompt);
+			expect(out.messages[0]).toBe(context.messages[0]);
+			expect(out.messages[2]?.content).toMatch(/Now: 2026-08-30T02:51:16Z \(/);
+		});
+	});
 });
 
 describe("date-cwd reminder on the provider wire", () => {
@@ -209,6 +360,159 @@ describe("date-cwd reminder on the provider wire", () => {
 			expect(secondFirst.role).toBe("user");
 			expect(typeof secondFirst.content).toBe(typeof firstUser.content);
 			expect(secondFirst.content).toEqual(firstUser.content);
+		} finally {
+			authStorage.close();
+		}
+	});
+	it("stamps the last user turn with Now and keeps stamped user turns byte-identical across requests", async () => {
+		using tempDir = TempDir.createSync("@pi-now-reminder-");
+		const api = "test-now-reminder";
+		const contexts: Context[] = [];
+		registerCustomApi(api, (_model, context) => {
+			contexts.push(context);
+			const stream = new AssistantMessageEventStream();
+			queueMicrotask(() => {
+				const message = createAssistantMessage("ok");
+				stream.push({ type: "text_delta", contentIndex: 0, delta: "ok", partial: message });
+				stream.push({ type: "done", reason: "stop", message });
+			});
+			return stream;
+		});
+		const model = buildModel({
+			id: "now-reminder",
+			name: "Now reminder",
+			api,
+			provider: "managed-primary",
+			baseUrl: "http://127.0.0.1:8080/v1",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 4096,
+			maxTokens: 1024,
+		} as ModelSpec<Api>) as Model<Api>;
+		const authStorage = await AuthStorage.create(tempDir.join("auth.db"));
+		authStorage.setRuntimeApiKey(model.provider, "test-key");
+		const modelRegistry = new ModelRegistry(authStorage, tempDir.join("models.yml"));
+		const { session } = await createAgentSession({
+			cwd: tempDir.path(),
+			agentDir: tempDir.path(),
+			sessionManager: SessionManager.inMemory(tempDir.path()),
+			authStorage,
+			modelRegistry,
+			settings: Settings.isolated({ "compaction.enabled": false }),
+			model,
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+			skipPythonPreflight: true,
+			taskDepth: 1,
+			agentId: "SubAgent",
+		});
+		sessions.push(session);
+
+		try {
+			await session.sendUserMessage("first");
+
+			expect(contexts).toHaveLength(1);
+			const systemPrompt = contexts[0]!.systemPrompt?.join("\n") ?? "";
+			expect(systemPrompt).not.toContain("Now:");
+
+			const req1Last = contexts[0]!.messages[contexts[0]!.messages.length - 1]!;
+			expect(req1Last.role).toBe("user");
+			const req1LastText =
+				typeof req1Last.content === "string" ? req1Last.content : JSON.stringify(req1Last.content);
+			expect(req1LastText.match(/Now: \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z \(/g)).toHaveLength(1);
+			expect(req1LastText).toContain("first");
+
+			await session.sendUserMessage("second");
+			expect(contexts).toHaveLength(2);
+
+			// Prefix-cache contract: request 2 re-sends request 1's stamped first
+			// user message byte-identical — the stamped bytes must survive the
+			// move from last-user to earlier position.
+			const req2First = contexts[1]!.messages[0]!;
+			expect(req2First.role).toBe("user");
+			expect(req2First.content).toEqual(req1Last.content);
+
+			// The new last user message carries exactly one Now stamp; Today stays
+			// pinned to the first user message.
+			const req2Last = contexts[1]!.messages[contexts[1]!.messages.length - 1]!;
+			expect(req2Last.role).toBe("user");
+			const req2LastText =
+				typeof req2Last.content === "string" ? req2Last.content : JSON.stringify(req2Last.content);
+			expect(req2LastText.match(/Now: \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z \(/g)).toHaveLength(1);
+			expect(req2LastText).toContain("second");
+			expect(req2LastText).not.toContain("Today:");
+		} finally {
+			authStorage.close();
+		}
+	});
+	it("omits the Now stamp entirely when prompt.nowStamp is disabled", async () => {
+		using tempDir = TempDir.createSync("@pi-now-reminder-off-");
+		const api = "test-now-reminder-off";
+		const contexts: Context[] = [];
+		registerCustomApi(api, (_model, context) => {
+			contexts.push(context);
+			const stream = new AssistantMessageEventStream();
+			queueMicrotask(() => {
+				const message = createAssistantMessage("ok");
+				stream.push({ type: "text_delta", contentIndex: 0, delta: "ok", partial: message });
+				stream.push({ type: "done", reason: "stop", message });
+			});
+			return stream;
+		});
+		const model = buildModel({
+			id: "now-reminder-off",
+			name: "Now reminder off",
+			api,
+			provider: "managed-primary",
+			baseUrl: "http://127.0.0.1:8080/v1",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 4096,
+			maxTokens: 1024,
+		} as ModelSpec<Api>) as Model<Api>;
+		const authStorage = await AuthStorage.create(tempDir.join("auth.db"));
+		authStorage.setRuntimeApiKey(model.provider, "test-key");
+		const modelRegistry = new ModelRegistry(authStorage, tempDir.join("models.yml"));
+		const { session } = await createAgentSession({
+			cwd: tempDir.path(),
+			agentDir: tempDir.path(),
+			sessionManager: SessionManager.inMemory(tempDir.path()),
+			authStorage,
+			modelRegistry,
+			settings: Settings.isolated({ "compaction.enabled": false, "prompt.nowStamp": false }),
+			model,
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+			skipPythonPreflight: true,
+			taskDepth: 1,
+			agentId: "SubAgent",
+		});
+		sessions.push(session);
+
+		try {
+			await session.sendUserMessage("hello");
+
+			expect(contexts).toHaveLength(1);
+			const wireText = JSON.stringify(contexts[0]!.messages);
+			expect(wireText).not.toContain("Now:");
+			// The date/cwd reminder still rides on the first user turn (#7404).
+			const firstUser = contexts[0]!.messages.find(message => message.role === "user")!;
+			const firstUserText =
+				typeof firstUser.content === "string" ? firstUser.content : JSON.stringify(firstUser.content);
+			expect(firstUserText).toContain("Today:");
+			expect(firstUserText).toContain("hello");
 		} finally {
 			authStorage.close();
 		}

--- a/packages/coding-agent/test/date-cwd-reminder.test.ts
+++ b/packages/coding-agent/test/date-cwd-reminder.test.ts
@@ -134,8 +134,11 @@ describe("date-cwd-reminder", () => {
 		it("renders a system-reminder block with a UTC instant, local clock, timezone name, and numeric offset", () => {
 			const stamp = renderNowStamp(new Date("2026-08-30T02:51:16Z"));
 
+			// The short timezone name is whatever Intl emits for the host's
+			// zone — alphabetic (e.g. `CST`) or numeric (e.g. `GMT+5:30` under
+			// TZ=Asia/Kolkata) — so assert the semantic structure, not a charset.
 			expect(stamp).toMatch(
-				/^<system-reminder>\nNow: 2026-08-30T02:51:16Z \(\d{2}:\d{2} [A-Za-z]{2,5}, UTC[+-]\d{2}:\d{2}\)\n<\/system-reminder>$/,
+				/^<system-reminder>\nNow: 2026-08-30T02:51:16Z \(\d{2}:\d{2} [^(,]+, UTC[+-]\d{2}:\d{2}\)\n<\/system-reminder>$/,
 			);
 		});
 	});
@@ -353,12 +356,12 @@ describe("now stamp across processes", () => {
 	// The design holds no module-level value state (only a WeakMap), so the
 	// second process must re-derive the first process's stamped bytes.
 	const CHILD_FIXTURE = `${import.meta.dir}/fixtures/now-stamp-process-child.ts`;
-	async function stampInColdProcess(mode: "orig" | "resumed"): Promise<string[]> {
+	async function stampInColdProcess(mode: "orig" | "resumed", tz = "America/Chicago"): Promise<string[]> {
 		const proc = Bun.spawn([process.execPath, "--no-env-file", "--no-install", CHILD_FIXTURE, mode], {
 			cwd: import.meta.dir,
 			env: {
 				...process.env,
-				TZ: "America/Chicago",
+				TZ: tz,
 			},
 			stdout: "pipe",
 			stderr: "pipe",
@@ -366,6 +369,22 @@ describe("now stamp across processes", () => {
 		});
 		const [stdout, code] = await Promise.all([new Response(proc.stdout).text(), proc.exited]);
 		expect(code, `child "${mode}" exited ${code}: ${stdout}`).toBe(0);
+		return JSON.parse(stdout.trim().split("\n").at(-1)!);
+	}
+
+	async function formatInColdProcess(tz: string): Promise<string> {
+		const proc = Bun.spawn([process.execPath, "--no-env-file", "--no-install", CHILD_FIXTURE, "format"], {
+			cwd: import.meta.dir,
+			env: {
+				...process.env,
+				TZ: tz,
+			},
+			stdout: "pipe",
+			stderr: "pipe",
+			timeout: 30_000,
+		});
+		const [stdout, code] = await Promise.all([new Response(proc.stdout).text(), proc.exited]);
+		expect(code, `child "format" exited ${code}: ${stdout}`).toBe(0);
 		return JSON.parse(stdout.trim().split("\n").at(-1)!);
 	}
 
@@ -383,6 +402,21 @@ describe("now stamp across processes", () => {
 		// from its own instant.
 		expect(resumed).toHaveLength(orig.length + 1);
 		expect(resumed[3]).toContain("Now: 2026-08-30T03:12:45Z");
+	});
+
+	it("keeps the stamp's semantic structure when the host zone's short label is numeric (TZ=Asia/Kolkata)", async () => {
+		// Charset-regression guard: under TZ=Asia/Kolkata, Bun's Intl emits
+		// `GMT+5:30` for the short zone name, which the old `[A-Za-z]{2,5}`
+		// assertion rejected. With the TZ pinned, the local clock (08:21)
+		// and numeric offset (UTC+05:30) are deterministic; the zone name
+		// itself is whatever charset Intl emits for that zone.
+		const stamp = await formatInColdProcess("Asia/Kolkata");
+
+		expect(stamp).toMatch(
+			/^<system-reminder>\nNow: 2026-08-30T02:51:16Z \(\d{2}:\d{2} [^(,]+, UTC[+-]\d{2}:\d{2}\)\n<\/system-reminder>$/,
+		);
+		expect(stamp).toContain("Now: 2026-08-30T02:51:16Z (08:21 ");
+		expect(stamp).toContain(", UTC+05:30)");
 	});
 });
 

--- a/packages/coding-agent/test/date-cwd-reminder.test.ts
+++ b/packages/coding-agent/test/date-cwd-reminder.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from "bun:test";
-import type { Api, Context, Message, Model, ModelSpec } from "@oh-my-pi/pi-ai";
+import type { Api, Context, Message, Model, ModelSpec, UserMessage } from "@oh-my-pi/pi-ai";
 import { clearCustomApis, registerCustomApi } from "@oh-my-pi/pi-ai";
 import { AssistantMessageEventStream } from "@oh-my-pi/pi-ai/utils/event-stream";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
@@ -229,8 +229,7 @@ describe("date-cwd-reminder", () => {
 
 			const out = injectNowStamp(messages);
 
-			expect(out).toBe(messages);
-			expect(out[0]!).toBe(stamped);
+			expect(textOf(out[0]!)).toBe(textOf(stamped));
 			expect(textOf(out[0]!).match(/Now: /g)).toHaveLength(1);
 		});
 
@@ -248,16 +247,6 @@ describe("date-cwd-reminder", () => {
 			expect(textOf(out)).toBe(`quote this verbatim\n\n${pasted}\n\n${derived}`);
 		});
 
-		it("re-stamps the same pristine message with the same stamped object across requests", () => {
-			const t = Date.parse("2026-08-30T02:51:16Z");
-			const pristine: Message = { role: "user", content: "hi", timestamp: t };
-
-			const first = injectNowStamp([pristine])[0]!;
-			expect(first).not.toBe(pristine);
-			const second = injectNowStamp([pristine])[0]!;
-			expect(second).toBe(first);
-		});
-
 		it("keeps byte-identical wire bytes when a previously-stamped user message slides out of last position", () => {
 			// The append-only log re-hands the pristine messages each request; a
 			// user message stamped in an earlier request must keep its exact wire
@@ -272,7 +261,6 @@ describe("date-cwd-reminder", () => {
 
 			const out = injectNowStamp([first, assistant, second]);
 
-			expect(out[0]).toBe(firstStamped);
 			expect(out[1]).toBe(assistant);
 			expect(out[2]).not.toBe(second);
 			expect(textOf(out[0]!)).toBe(textOf(firstStamped));
@@ -346,6 +334,59 @@ describe("date-cwd-reminder", () => {
 			expect(textOf(outA)).toBe(`hi\n\n${renderNowStamp(new Date(tA))}`);
 			expect(textOf(outA)).not.toBe(textOf(outB));
 			expect(textOf(outARecreated)).toBe(textOf(outA));
+		});
+
+		it("appends the stamp to the authoritative openaiResponsesHistory replay payload", () => {
+			// A user message carrying an openaiResponsesHistory providerPayload —
+			// notably the compaction-summary message created after OpenAI remote
+			// compaction — is replayed by the Responses serializers from
+			// providerPayload.items, which skip the generic content (see
+			// convertConversationMessages in openai-shared.ts). The stamp must
+			// reach the payload or the provider never sees it.
+			const t = Date.parse("2026-08-30T05:30:00Z");
+			const stamp = renderNowStamp(new Date(t));
+			const content = "<system-reminder>\nCompaction summary: compacted\n</system-reminder>";
+			const historyItems: Array<Record<string, unknown>> = [
+				{ type: "compaction", encrypted_content: "enc", summary: [{ type: "summary_text", text: "compacted" }] },
+			];
+			const makeSummary = (): UserMessage => ({
+				role: "user",
+				content,
+				attribution: "agent",
+				historyRewriteAt: t,
+				providerPayload: {
+					type: "openaiResponsesHistory",
+					provider: "openai",
+					items: [
+						{
+							type: "compaction",
+							encrypted_content: "enc",
+							summary: [{ type: "summary_text", text: "compacted" }],
+						},
+					],
+				},
+				timestamp: t,
+			});
+
+			const out = injectNowStamp([makeSummary()])[0] as UserMessage;
+
+			const payload = out.providerPayload;
+			expect(payload?.type).toBe("openaiResponsesHistory");
+			if (payload?.type !== "openaiResponsesHistory") throw new Error("expected openaiResponsesHistory payload");
+			expect(payload.items).toEqual([
+				...historyItems,
+				{ type: "message", role: "user", content: [{ type: "input_text", text: stamp }] },
+			]);
+			// The generic content is still stamped for providers without native
+			// replay, and the input payload is never mutated.
+			expect(textOf(out)).toBe(`${content}\n\n${stamp}`);
+			expect(historyItems).toHaveLength(1);
+
+			// Byte-stable re-derivation: a rehydrated copy (fresh objects, same
+			// persisted bytes) yields identical provider-visible wire bytes.
+			const rederived = injectNowStamp([makeSummary()])[0] as UserMessage;
+			expect(JSON.stringify(rederived.providerPayload)).toBe(JSON.stringify(payload));
+			expect(textOf(rederived)).toBe(textOf(out));
 		});
 
 		it("returns the input unchanged when there is no user message or no messages", () => {

--- a/packages/coding-agent/test/date-cwd-reminder.test.ts
+++ b/packages/coding-agent/test/date-cwd-reminder.test.ts
@@ -345,6 +345,63 @@ describe("date-cwd-reminder", () => {
 	});
 });
 
+describe("now stamp across processes", () => {
+	// True regression guard for the resume guarantee (r3909587061): two
+	// separate bun processes, each with a cold module cache, exactly like a
+	// resumed session. The in-process resume test above cannot cover this:
+	// a process-global stamp cache would stay warm inside one test process.
+	// The design holds no module-level value state (only a WeakMap), so the
+	// second process must re-derive the first process's stamped bytes.
+	const CHILD_SCRIPT = `
+(async () => {
+// Runtime-selected module path (this test pins byte-identity across processes
+// for whatever date-cwd-reminder.ts the env points at): static import impossible.
+const { applyNowStamp } = await import(process.env.NOWSTAMP_SRC);
+const T1 = Date.parse("2026-08-30T02:51:16Z");
+const T2 = Date.parse("2026-08-30T03:12:45Z");
+const a = { role: "assistant", content: [{ type: "text", text: "hi" }], timestamp: T1 + 1 };
+const m1 = { role: "user", content: "first turn", timestamp: T1 };
+const m3 = { role: "user", content: [{ type: "text", text: "new turn after resume" }, { type: "image", data: "imgB", mimeType: "image/png" }], timestamp: T2 };
+const messages = process.env.NOWSTAMP_MODE === "orig" ? [m1, a] : [m1, a, m3];
+const ctx = applyNowStamp({ systemPrompt: ["SYSTEM"], messages });
+console.log(JSON.stringify([JSON.stringify(ctx.systemPrompt), ...ctx.messages.map(m => JSON.stringify(m.content))]));
+})();
+`;
+	async function stampInColdProcess(mode: "orig" | "resumed"): Promise<string[]> {
+		const proc = Bun.spawn([process.execPath, "--no-env-file", "--no-install", "--eval", CHILD_SCRIPT], {
+			cwd: import.meta.dir,
+			env: {
+				...process.env,
+				NOWSTAMP_SRC: new URL("../src/session/date-cwd-reminder.ts", import.meta.url).href,
+				NOWSTAMP_MODE: mode,
+				TZ: "America/Chicago",
+			},
+			stdout: "pipe",
+			stderr: "pipe",
+			timeout: 30_000,
+		});
+		const [stdout, code] = await Promise.all([new Response(proc.stdout).text(), proc.exited]);
+		expect(code, `child "${mode}" exited ${code}: ${stdout}`).toBe(0);
+		return JSON.parse(stdout.trim().split("\n").at(-1)!);
+	}
+
+	it("re-derives byte-identical stamps in a second cold bun process", async () => {
+		const orig = await stampInColdProcess("orig");
+		const resumed = await stampInColdProcess("resumed");
+		// Resume is a byte no-op: the stamped turn re-derives byte-identically
+		// from its own persisted timestamp in the cold process.
+		expect(resumed[1]).toBe(orig[1]);
+		expect(resumed[1]).toContain("Now: 2026-08-30T02:51:16Z");
+		expect(resumed[2]).toBe(orig[2]);
+		// The system prompt is never touched.
+		expect(resumed[0]).toBe(JSON.stringify(["SYSTEM"]));
+		// Only the genuinely-new last turn adds bytes, at the tail, stamped
+		// from its own instant.
+		expect(resumed).toHaveLength(orig.length + 1);
+		expect(resumed[3]).toContain("Now: 2026-08-30T03:12:45Z");
+	});
+});
+
 describe("date-cwd reminder on the provider wire", () => {
 	const sessions: Array<{ dispose(): Promise<void> }> = [];
 

--- a/packages/coding-agent/test/date-cwd-reminder.test.ts
+++ b/packages/coding-agent/test/date-cwd-reminder.test.ts
@@ -368,7 +368,8 @@ describe("date-cwd-reminder", () => {
 				timestamp: t,
 			});
 
-			const out = injectNowStamp([makeSummary()])[0] as UserMessage;
+			const input = makeSummary();
+			const out = injectNowStamp([input])[0] as UserMessage;
 
 			const payload = out.providerPayload;
 			expect(payload?.type).toBe("openaiResponsesHistory");
@@ -380,7 +381,10 @@ describe("date-cwd-reminder", () => {
 			// The generic content is still stamped for providers without native
 			// replay, and the input payload is never mutated.
 			expect(textOf(out)).toBe(`${content}\n\n${stamp}`);
-			expect(historyItems).toHaveLength(1);
+			if (input.providerPayload?.type !== "openaiResponsesHistory")
+				throw new Error("expected openaiResponsesHistory input payload");
+			expect(input.providerPayload.items).toHaveLength(1);
+			expect(input.providerPayload.items).toEqual(historyItems);
 
 			// Byte-stable re-derivation: a rehydrated copy (fresh objects, same
 			// persisted bytes) yields identical provider-visible wire bytes.

--- a/packages/coding-agent/test/fixtures/now-stamp-process-child.ts
+++ b/packages/coding-agent/test/fixtures/now-stamp-process-child.ts
@@ -1,0 +1,61 @@
+#!/usr/bin/env bun
+/**
+ * Test fixture: cold-module-cache child for the cross-process Now-stamp resume
+ * test (`test/date-cwd-reminder.test.ts`). Spawned twice as two separate bun
+ * processes — `orig` (the original session's last request: [firstTurn,
+ * assistant]) and `resumed` (a resumed session's first request: [firstTurn',
+ * assistant, newTurn], with fresh object identities as buildSessionContext
+ * produces from the session store) — and prints the transformed context's
+ * wire bytes as JSON. The parent compares the two processes' outputs to prove
+ * the resume re-stamp is a byte no-op with an empty module cache.
+ *
+ * Deterministic fixture: the stamp's parenthesized local part renders per
+ * host (timezone/locale/ICU), so the parent pins TZ for both children and
+ * the test compares bytes *between* the processes, not against a golden.
+ */
+import type { Context, Message } from "@oh-my-pi/pi-ai";
+import { applyNowStamp } from "@oh-my-pi/pi-coding-agent/session/date-cwd-reminder";
+
+const T1 = Date.parse("2026-08-30T02:51:16Z");
+const T2 = Date.parse("2026-08-30T03:12:45Z");
+
+const assistant: Message = {
+	role: "assistant",
+	content: [{ type: "text", text: "hi" }],
+	api: "anthropic-messages",
+	provider: "anthropic",
+	model: "mock",
+	usage: {
+		input: 0,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: 0,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+	},
+	stopReason: "stop",
+	timestamp: T1 + 1,
+};
+
+// Fresh objects on every launch: new identity, identical persisted content
+// and timestamp — exactly what a resumed session rehydrates.
+const firstTurn: Message = { role: "user", content: "first turn", timestamp: T1 };
+const newTurn: Message = {
+	role: "user",
+	content: [
+		{ type: "text", text: "new turn after resume" },
+		{ type: "image", data: "imgB", mimeType: "image/png" },
+	],
+	timestamp: T2,
+};
+
+const mode = process.argv[2];
+const messages: Message[] = mode === "orig" ? [firstTurn, assistant] : [firstTurn, assistant, newTurn];
+const context: Context = { systemPrompt: ["SYSTEM"], messages };
+const stamped = applyNowStamp(context);
+console.log(
+	JSON.stringify([
+		JSON.stringify(stamped.systemPrompt),
+		...stamped.messages.map(message => JSON.stringify(message.content)),
+	]),
+);

--- a/packages/coding-agent/test/fixtures/now-stamp-process-child.ts
+++ b/packages/coding-agent/test/fixtures/now-stamp-process-child.ts
@@ -7,14 +7,16 @@
  * assistant, newTurn], with fresh object identities as buildSessionContext
  * produces from the session store) — and prints the transformed context's
  * wire bytes as JSON. The parent compares the two processes' outputs to prove
- * the resume re-stamp is a byte no-op with an empty module cache.
+ * the resume re-stamp is a byte no-op with an empty module cache. A third
+ * mode, `format`, prints just the rendered stamp for the parent to assert
+ * the semantic structure of the local part under a pinned host TZ.
  *
  * Deterministic fixture: the stamp's parenthesized local part renders per
  * host (timezone/locale/ICU), so the parent pins TZ for both children and
  * the test compares bytes *between* the processes, not against a golden.
  */
 import type { Context, Message } from "@oh-my-pi/pi-ai";
-import { applyNowStamp } from "@oh-my-pi/pi-coding-agent/session/date-cwd-reminder";
+import { applyNowStamp, renderNowStamp } from "@oh-my-pi/pi-coding-agent/session/date-cwd-reminder";
 
 const T1 = Date.parse("2026-08-30T02:51:16Z");
 const T2 = Date.parse("2026-08-30T03:12:45Z");
@@ -50,12 +52,20 @@ const newTurn: Message = {
 };
 
 const mode = process.argv[2];
-const messages: Message[] = mode === "orig" ? [firstTurn, assistant] : [firstTurn, assistant, newTurn];
-const context: Context = { systemPrompt: ["SYSTEM"], messages };
-const stamped = applyNowStamp(context);
-console.log(
-	JSON.stringify([
-		JSON.stringify(stamped.systemPrompt),
-		...stamped.messages.map(message => JSON.stringify(message.content)),
-	]),
-);
+if (mode === "format") {
+	// Prints the stamp rendered in THIS process's timezone (the parent pins
+	// TZ per spawn) so the parent can assert the semantic structure of the
+	// parenthesized local part for a host zone whose short Intl label is
+	// numeric (e.g. `GMT+5:30` under TZ=Asia/Kolkata).
+	console.log(JSON.stringify(renderNowStamp(new Date(T1))));
+} else {
+	const messages: Message[] = mode === "orig" ? [firstTurn, assistant] : [firstTurn, assistant, newTurn];
+	const context: Context = { systemPrompt: ["SYSTEM"], messages };
+	const stamped = applyNowStamp(context);
+	console.log(
+		JSON.stringify([
+			JSON.stringify(stamped.systemPrompt),
+			...stamped.messages.map(message => JSON.stringify(message.content)),
+		]),
+	);
+}


### PR DESCRIPTION
### What changed

I kept catching the agent stating stale dates, and correcting it cost a tool call every time. I've been using my harness heavily for months and one common problem is that none of the agents seem to know what time it is, especially in long-running sessions, or sessions where I step away for a bit and then come back. Having that context in a fresh, per-turn manner for only 15 tokens each time is a great benefit — I've made it easy to turn on and off for those who don't want it and want to save those extra 15 tokens/turn.

Each user message carries a per-turn `Now:` timestamp of its own turn: UTC ISO instant plus local clock, timezone short name, and numeric UTC offset (e.g. `Now: 2026-09-01T19:37:32Z (13:37 CST, UTC-06:00)`). The stamp is a pure function of the message's own persisted `timestamp`, so re-stamped history is byte-identical across requests, tool-call loops, and same-host session resumes — only a genuinely new turn adds bytes at the context tail. (The parenthesized local part renders via the host timezone, locale, and ICU/tzdata, so a session resumed on a different host re-renders that part; the UTC instant is invariant.) The system prompt and the existing date/cwd reminder (first user turn, #7404) are untouched. The stamp is on by default and can be disabled with the `prompt.nowStamp` setting or at runtime with the new `/time` command (`on` / `off` / `status`, persisted — same pattern as `/extended-context`).

### Why

Agents have no internal clock. A time claim in assistant output that cannot trace to a timestamp in context is a stale echo or a fabrication, and the only current remedy is a `date` tool call — a full LLM round trip per claim. Injecting a fresh instant on each user turn makes time known by default at ~15 tokens/turn.

### Scope notes

- **Context-tail placement is the point of the design.** The stamp rides on user messages, never the system prompt: a per-request change at the top of context invalidates the prompt cache every turn, converting a near-free feature into a cost regression.
- **Byte-stable per user message, by construction.** The stamp value is computed from the message's own persisted `timestamp` — never from request-time `new Date()` and never held in a process-global value cache. Recreated message objects (steer envelopes in `wrapSteeringForModel`, secret obfuscation) and rehydrated resume history re-derive the exact wire bytes; the only memo is the collectible object-identity `WeakMap` (mirroring `DateCwdReminderInjector`'s injection memo), released with its key objects when a session is discarded. This is what makes a same-host session resume a byte no-op for previously-stamped turns: the re-stamped history is re-derived, not re-stamped, so the prompt-cache prefix survives process restarts.
- Stamping is skipped for empty-system-prompt (NULL_PROMPT-style) and no-message contexts, mirroring the `DateCwdReminderInjector.transform` guards, so such requests stay byte-for-byte unchanged.
- Out of scope: a deterministic post-response hook that flags time claims lacking a fresh in-context timestamp (separate PR); provider-specific surfaces — this transform is provider-agnostic client code.
- The `/time` toggle persists to the settings store, matching `/extended-context` behavior; say the word if a session-scoped (non-persisted) runtime override is preferred instead.

### Verification

- Regression tests in `packages/coding-agent/test/date-cwd-reminder.test.ts`: `renderNowStamp` format; `injectNowStamp` string/array content, non-mutation, already-stamped passthrough, object-identity memo re-stamp stability, slide-out-of-last-user byte stability, rehydrated-history resume byte-stability, same-millisecond distinct turns stamped from their own instant, per-message derivation independence (no shared value cache), no-user/empty no-ops; `applyNowStamp` guard contexts; a cross-process test that spawns **two cold bun processes** and asserts a previously-stamped turn re-derives byte-identical wire bytes across the process boundary (added after the round-2 review found the in-process resume test's re-stamp half is non-discriminating with a warm cache — it fails against `f0aabd2`); and provider-wire tests that stamped turns stay byte-identical across requests and that with `prompt.nowStamp: false` the wire carries no `Now:` at all while the date/cwd reminder still rides on the first user turn.
- `/time` command tests: ACP builtin toggle/status round-trip (`test/acp-builtins.test.ts`) and RPC-safe metadata (`test/available-commands.test.ts`).
- `agent-session-message-pipeline.test.ts` updated to expect the trailing stamp on its user turns.
- Targeted suite across the four touched test files: **137/138** on the current head (includes the round-2 regression tests and the cross-process resume test; the one failure is an environment-dependent case in main's new `/mcp resources` test — it detects workstation-global MCP servers and fails identically on plain main `9bafadd503`, unrelated to this PR). Synced with main `9bafadd503` (merge `397dd79`; the changelog entry stays under `[Unreleased]`).
- `bun run check` (oxlint + oxfmt + tsgo) clean in `packages/coding-agent`.
- Live end-to-end: source-checkout CLI (`bun packages/coding-agent/src/cli.ts -p`) against a real gateway model asked to quote the injected block verbatim — returned `Now: 2026-09-04T00:16:37Z (18:16 CST, UTC-06:00)`. Off switch verified the same way with a `prompt.nowStamp: false` config overlay — the model reported no `Now:` block present.

### Related

- Related to #7196 (opt-in cache-stable system prompt): same design constraint — injected time must not churn the prompt-cache prefix. Complementary, not overlapping: #7196 stabilizes the system-prompt `Today is` / `<memories>` time across process restarts; this PR adds a fresh per-turn instant on user turns (default on, all sessions, off-switchable) — the process-start values cannot provide that within a long session.
- Placement follows #7404 (fix for #7324): per-request date/cwd volatility kept off the system prompt, riding on user turns instead.
