### PR TITLE
fix(ai): count repeated multi-call tool-call batches in the loop guard

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Preserved Anthropic thinking now survives side requests, tool-description drift, turn-scoped reminders, and recoverable prefix mismatches without corrupting the conversation prefix.
+- Fixed the tool-call loop guard counting multi-call turns: a model reissuing the same batch of parallel tool calls was previously invisible to the guard, which only tracked turns containing exactly one call; identical multi-call batches now accumulate toward the threshold, all-exempt batches reset it, and the redirect reports the first non-exempt call.
 
 ## [18.1.2] - 2026-09-01
 

--- a/packages/ai/src/utils/tool-call-loop-guard.ts
+++ b/packages/ai/src/utils/tool-call-loop-guard.ts
@@ -79,29 +79,38 @@ export class ToolCallLoopGuard {
 	/** Records one completed turn and returns the threshold hit, if any. */
 	recordTurn(turn: ToolCallLoopTurn): RepeatedToolCallDetection | null {
 		const toolCalls = turn.message.content.filter((part): part is ToolCall => part.type === "toolCall");
-		if (toolCalls.length !== 1 || this.#exemptTools.has(toolCalls[0]!.name)) {
+		if (toolCalls.length === 0) {
+			this.#lastHash = undefined;
+			this.#count = 0;
+			return null;
+		}
+		if (toolCalls.every(tc => this.#exemptTools.has(tc.name))) {
 			this.#lastHash = undefined;
 			this.#count = 0;
 			return null;
 		}
 
-		const toolCall = toolCalls[0]!;
-		const canonicalArgs = JSON.stringify(canonicalizeToolCallValue(toolCall.arguments));
-		const hash = `${toolCall.name}:${canonicalArgs}`;
-		if (hash === this.#lastHash) {
+		const turnHash = toolCalls
+			.map(tc => `${tc.name}:${JSON.stringify(canonicalizeToolCallValue(tc.arguments))}`)
+			.join("|");
+		if (turnHash === this.#lastHash) {
 			this.#count++;
 		} else {
-			this.#lastHash = hash;
+			this.#lastHash = turnHash;
 			this.#count = 1;
 		}
 
 		if (this.#count !== this.#threshold) return null;
+		const reportCall = toolCalls.find(tc => !this.#exemptTools.has(tc.name)) ?? toolCalls[0]!;
 		return {
 			kind: "repeated_tool_call",
-			toolName: toolCall.name,
+			toolName: reportCall.name,
 			count: this.#count,
-			resultSummary: summarizeToolResult(turn.toolResults, toolCall.id),
-			argumentsSummary: summarizeText(canonicalArgs, ARGUMENT_SUMMARY_LIMIT),
+			resultSummary: summarizeToolResult(turn.toolResults, reportCall.id),
+			argumentsSummary: summarizeText(
+				JSON.stringify(canonicalizeToolCallValue(reportCall.arguments)),
+				ARGUMENT_SUMMARY_LIMIT,
+			),
 		};
 	}
 }

--- a/packages/ai/test/tool-call-loop-guard.test.ts
+++ b/packages/ai/test/tool-call-loop-guard.test.ts
@@ -1,97 +1,300 @@
-import { describe, expect, it } from "bun:test";
-import type { AssistantMessage, ToolCall } from "../src/types";
-import { ToolCallLoopGuard } from "../src/utils/tool-call-loop-guard";
+import { describe, expect, test } from "bun:test";
+import type { AssistantMessage, ToolCall } from "@oh-my-pi/pi-ai";
+import { ToolCallLoopGuard } from "@oh-my-pi/pi-ai/utils/tool-call-loop-guard";
+import { INTENT_FIELD } from "@oh-my-pi/pi-wire";
 
-let nextId = 0;
-
-function toolCall(name: string, args: Record<string, unknown>): ToolCall {
-	return { type: "toolCall", id: `tc_${nextId++}`, name, arguments: args };
-}
-
-function turn(...calls: ToolCall[]): { message: AssistantMessage; toolResults: [] } {
-	return {
-		message: { role: "assistant", content: calls, stopReason: "toolUse" } as unknown as AssistantMessage,
-		toolResults: [],
-	};
-}
-
-function batchA(): ToolCall[] {
-	return [toolCall("bash", { command: "echo a" }), toolCall("read", { path: "a.ts" })];
-}
-
-function batchB(): ToolCall[] {
-	return [toolCall("bash", { command: "echo b" })];
-}
+const zeroUsage = {
+	input: 0,
+	output: 0,
+	cacheRead: 0,
+	cacheWrite: 0,
+	totalTokens: 0,
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+} satisfies AssistantMessage["usage"];
 
 describe("ToolCallLoopGuard", () => {
-	it("resets on a turn with no tool calls", () => {
+	test("detects the fifth consecutive identical tool call", () => {
+		const guard = new ToolCallLoopGuard({ threshold: 5, exemptTools: ["job", "irc"] });
+		let detection = null;
+		for (let index = 0; index < 5; index++) {
+			const toolCallId = `call-${index}`;
+			detection = guard.recordTurn({
+				message: {
+					role: "assistant",
+					content: [
+						{ type: "toolCall", id: toolCallId, name: "bash", arguments: { command: "pytest -q", timeout: 120 } },
+					],
+					api: "openai-responses",
+					provider: "openai",
+					model: "test-model",
+					usage: zeroUsage,
+					stopReason: "toolUse",
+					timestamp: Date.now(),
+				},
+				toolResults: [
+					{
+						role: "toolResult",
+						toolCallId,
+						toolName: "bash",
+						content: [{ type: "text", text: "1263 passed, 4 skipped" }],
+						isError: false,
+						timestamp: Date.now(),
+					},
+				],
+			});
+		}
+
+		expect(detection).toEqual({
+			kind: "repeated_tool_call",
+			toolName: "bash",
+			count: 5,
+			resultSummary: "1263 passed, 4 skipped",
+			argumentsSummary: '{"command":"pytest -q","timeout":120}',
+		});
+	});
+
+	test("canonicalizes argument key order and ignores harness intent fields", () => {
 		const guard = new ToolCallLoopGuard({ threshold: 2, exemptTools: [] });
-		expect(guard.recordTurn(turn(...batchA()))).toBeNull();
-		expect(guard.recordTurn(turn())).toBeNull();
-		expect(guard.recordTurn(turn(...batchA()))).toBeNull();
+		expect(
+			guard.recordTurn({
+				message: {
+					role: "assistant",
+					content: [
+						{ type: "toolCall", id: "first", name: "read", arguments: { path: "a.ts", [INTENT_FIELD]: "first" } },
+					],
+					api: "openai-responses",
+					provider: "openai",
+					model: "test-model",
+					usage: zeroUsage,
+					stopReason: "toolUse",
+					timestamp: Date.now(),
+				},
+				toolResults: [
+					{
+						role: "toolResult",
+						toolCallId: "first",
+						toolName: "read",
+						content: [{ type: "text", text: "1263 passed, 4 skipped" }],
+						isError: false,
+						timestamp: Date.now(),
+					},
+				],
+			}),
+		).toBeNull();
+		expect(
+			guard.recordTurn({
+				message: {
+					role: "assistant",
+					content: [
+						{
+							type: "toolCall",
+							id: "second",
+							name: "read",
+							arguments: { [INTENT_FIELD]: "second", path: "a.ts" },
+						},
+					],
+					api: "openai-responses",
+					provider: "openai",
+					model: "test-model",
+					usage: zeroUsage,
+					stopReason: "toolUse",
+					timestamp: Date.now(),
+				},
+				toolResults: [
+					{
+						role: "toolResult",
+						toolCallId: "second",
+						toolName: "read",
+						content: [{ type: "text", text: "1263 passed, 4 skipped" }],
+						isError: false,
+						timestamp: Date.now(),
+					},
+				],
+			}),
+		).toMatchObject({ toolName: "read", count: 2 });
 	});
 
-	it("detects consecutive identical multi-call turns at the threshold", () => {
+	test("resets the consecutive count on a different call", () => {
 		const guard = new ToolCallLoopGuard({ threshold: 3, exemptTools: [] });
-		expect(guard.recordTurn(turn(...batchA()))).toBeNull();
-		expect(guard.recordTurn(turn(...batchA()))).toBeNull();
-		const hit = guard.recordTurn(turn(...batchA()));
-		expect(hit).not.toBeNull();
-		expect(hit!.kind).toBe("repeated_tool_call");
-		expect(hit!.count).toBe(3);
+		expect(
+			guard.recordTurn({
+				message: {
+					role: "assistant",
+					content: [{ type: "toolCall", id: "first", name: "bash", arguments: { command: "pytest -q" } }],
+					api: "openai-responses",
+					provider: "openai",
+					model: "test-model",
+					usage: zeroUsage,
+					stopReason: "toolUse",
+					timestamp: Date.now(),
+				},
+				toolResults: [
+					{
+						role: "toolResult",
+						toolCallId: "first",
+						toolName: "bash",
+						content: [{ type: "text", text: "1263 passed, 4 skipped" }],
+						isError: false,
+						timestamp: Date.now(),
+					},
+				],
+			}),
+		).toBeNull();
+		expect(
+			guard.recordTurn({
+				message: {
+					role: "assistant",
+					content: [{ type: "toolCall", id: "second", name: "read", arguments: { path: "src/index.ts" } }],
+					api: "openai-responses",
+					provider: "openai",
+					model: "test-model",
+					usage: zeroUsage,
+					stopReason: "toolUse",
+					timestamp: Date.now(),
+				},
+				toolResults: [
+					{
+						role: "toolResult",
+						toolCallId: "second",
+						toolName: "read",
+						content: [{ type: "text", text: "1263 passed, 4 skipped" }],
+						isError: false,
+						timestamp: Date.now(),
+					},
+				],
+			}),
+		).toBeNull();
+		expect(
+			guard.recordTurn({
+				message: {
+					role: "assistant",
+					content: [{ type: "toolCall", id: "third", name: "bash", arguments: { command: "pytest -q" } }],
+					api: "openai-responses",
+					provider: "openai",
+					model: "test-model",
+					usage: zeroUsage,
+					stopReason: "toolUse",
+					timestamp: Date.now(),
+				},
+				toolResults: [
+					{
+						role: "toolResult",
+						toolCallId: "third",
+						toolName: "bash",
+						content: [{ type: "text", text: "1263 passed, 4 skipped" }],
+						isError: false,
+						timestamp: Date.now(),
+					},
+				],
+			}),
+		).toBeNull();
 	});
 
-	it("does not count a turn whose calls are all exempt", () => {
-		const guard = new ToolCallLoopGuard({ threshold: 2, exemptTools: ["read"] });
-		expect(guard.recordTurn(turn(toolCall("read", { path: "a.ts" })))).toBeNull();
-		const hit = guard.recordTurn(turn(toolCall("read", { path: "a.ts" })));
-		expect(hit).toBeNull();
+	test("ignores exempt polling tools", () => {
+		const guard = new ToolCallLoopGuard({ threshold: 2, exemptTools: ["job"] });
+		expect(
+			guard.recordTurn({
+				message: {
+					role: "assistant",
+					content: [{ type: "toolCall", id: "first", name: "job", arguments: { poll: ["abc"] } }],
+					api: "openai-responses",
+					provider: "openai",
+					model: "test-model",
+					usage: zeroUsage,
+					stopReason: "toolUse",
+					timestamp: Date.now(),
+				},
+				toolResults: [
+					{
+						role: "toolResult",
+						toolCallId: "first",
+						toolName: "job",
+						content: [{ type: "text", text: "1263 passed, 4 skipped" }],
+						isError: false,
+						timestamp: Date.now(),
+					},
+				],
+			}),
+		).toBeNull();
+		expect(
+			guard.recordTurn({
+				message: {
+					role: "assistant",
+					content: [{ type: "toolCall", id: "second", name: "job", arguments: { poll: ["abc"] } }],
+					api: "openai-responses",
+					provider: "openai",
+					model: "test-model",
+					usage: zeroUsage,
+					stopReason: "toolUse",
+					timestamp: Date.now(),
+				},
+				toolResults: [
+					{
+						role: "toolResult",
+						toolCallId: "second",
+						toolName: "job",
+						content: [{ type: "text", text: "1263 passed, 4 skipped" }],
+						isError: false,
+						timestamp: Date.now(),
+					},
+				],
+			}),
+		).toBeNull();
+	});
+});
+
+describe("ToolCallLoopGuard multi-call turns", () => {
+	let nextId = 0;
+
+	function toolCall(name: string, args: Record<string, unknown>): ToolCall {
+		return { type: "toolCall", id: `tc_${nextId++}`, name, arguments: args };
+	}
+
+	function turn(...calls: ToolCall[]) {
+		return {
+			message: { role: "assistant", content: calls } as unknown as AssistantMessage,
+			toolResults: [],
+		};
+	}
+
+	test("counts consecutive identical multi-call batches toward the threshold", () => {
+		const guard = new ToolCallLoopGuard({ threshold: 3, exemptTools: [] });
+		const batch = () => [toolCall("bash", { command: "echo a" }), toolCall("read", { path: "a.ts" })];
+		expect(guard.recordTurn(turn(...batch()))).toBeNull();
+		expect(guard.recordTurn(turn(...batch()))).toBeNull();
+		expect(guard.recordTurn(turn(...batch()))).toMatchObject({ toolName: "bash", count: 3 });
 	});
 
-	it("resets when every call in a multi-call turn is exempt", () => {
+	test("resets on a turn with no tool calls", () => {
+		const guard = new ToolCallLoopGuard({ threshold: 2, exemptTools: [] });
+		const batch = () => [toolCall("bash", { command: "echo a" }), toolCall("read", { path: "a.ts" })];
+		expect(guard.recordTurn(turn(...batch()))).toBeNull();
+		expect(guard.recordTurn(turn())).toBeNull();
+		expect(guard.recordTurn(turn(...batch()))).toBeNull();
+	});
+
+	test("resets when every call in a multi-call turn is exempt", () => {
 		const guard = new ToolCallLoopGuard({ threshold: 2, exemptTools: ["read"] });
-		expect(guard.recordTurn(turn(...batchA()))).toBeNull();
+		const batch = () => [toolCall("bash", { command: "echo a" }), toolCall("read", { path: "a.ts" })];
+		expect(guard.recordTurn(turn(...batch()))).toBeNull();
 		expect(guard.recordTurn(turn(toolCall("read", { path: "x.ts" }), toolCall("read", { path: "y.ts" })))).toBeNull();
-		expect(guard.recordTurn(turn(...batchA()))).toBeNull();
+		expect(guard.recordTurn(turn(...batch()))).toBeNull();
 	});
 
-	it("counts a mixed batch and reports the first non-exempt call", () => {
+	test("counts a mixed batch and reports the first non-exempt call", () => {
 		const guard = new ToolCallLoopGuard({ threshold: 2, exemptTools: ["read"] });
 		const mixed = () => [toolCall("read", { path: "a.ts" }), toolCall("bash", { command: "echo a" })];
 		expect(guard.recordTurn(turn(...mixed()))).toBeNull();
-		const hit = guard.recordTurn(turn(...mixed()));
-		expect(hit).not.toBeNull();
-		expect(hit!.toolName).toBe("bash");
+		expect(guard.recordTurn(turn(...mixed()))).toMatchObject({ toolName: "bash", count: 2 });
 	});
 
-	it("does not count alternating distinct batches", () => {
+	test("does not count alternating distinct batches", () => {
 		const guard = new ToolCallLoopGuard({ threshold: 2, exemptTools: [] });
-		expect(guard.recordTurn(turn(...batchA()))).toBeNull();
-		expect(guard.recordTurn(turn(...batchB()))).toBeNull();
-		expect(guard.recordTurn(turn(...batchA()))).toBeNull();
-		expect(guard.recordTurn(turn(...batchB()))).toBeNull();
-	});
-
-	it("keeps single-call behavior: identical single calls are detected", () => {
-		const guard = new ToolCallLoopGuard({ threshold: 2, exemptTools: [] });
-		expect(guard.recordTurn(turn(toolCall("bash", { command: "echo a" })))).toBeNull();
-		const hit = guard.recordTurn(turn(toolCall("bash", { command: "echo a" })));
-		expect(hit).not.toBeNull();
-		expect(hit!.toolName).toBe("bash");
-	});
-
-	it("keeps single-call behavior: differing args reset the counter", () => {
-		const guard = new ToolCallLoopGuard({ threshold: 2, exemptTools: [] });
-		expect(guard.recordTurn(turn(toolCall("bash", { command: "echo a" })))).toBeNull();
-		expect(guard.recordTurn(turn(toolCall("bash", { command: "echo b" })))).toBeNull();
-	});
-
-	it("canonicalizes argument key order across a multi-call batch", () => {
-		const guard = new ToolCallLoopGuard({ threshold: 2, exemptTools: [] });
-		const a = () => turn(toolCall("write", { path: "x.ts", content: "hi" }));
-		const reordered = () => turn(toolCall("write", { content: "hi", path: "x.ts" }));
-		expect(guard.recordTurn(a())).toBeNull();
-		const hit = guard.recordTurn(reordered());
-		expect(hit).not.toBeNull();
+		const a = () => [toolCall("bash", { command: "echo a" }), toolCall("read", { path: "a.ts" })];
+		const b = () => [toolCall("bash", { command: "echo b" })];
+		expect(guard.recordTurn(turn(...a()))).toBeNull();
+		expect(guard.recordTurn(turn(...b()))).toBeNull();
+		expect(guard.recordTurn(turn(...a()))).toBeNull();
+		expect(guard.recordTurn(turn(...b()))).toBeNull();
 	});
 });

--- a/packages/ai/test/tool-call-loop-guard.test.ts
+++ b/packages/ai/test/tool-call-loop-guard.test.ts
@@ -1,244 +1,97 @@
-import { describe, expect, test } from "bun:test";
-import type { AssistantMessage } from "@oh-my-pi/pi-ai";
-import { ToolCallLoopGuard } from "@oh-my-pi/pi-ai/utils/tool-call-loop-guard";
-import { INTENT_FIELD } from "@oh-my-pi/pi-wire";
+import { describe, expect, it } from "bun:test";
+import type { AssistantMessage, ToolCall } from "../src/types";
+import { ToolCallLoopGuard } from "../src/utils/tool-call-loop-guard";
 
-const zeroUsage = {
-	input: 0,
-	output: 0,
-	cacheRead: 0,
-	cacheWrite: 0,
-	totalTokens: 0,
-	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-} satisfies AssistantMessage["usage"];
+let nextId = 0;
+
+function toolCall(name: string, args: Record<string, unknown>): ToolCall {
+	return { type: "toolCall", id: `tc_${nextId++}`, name, arguments: args };
+}
+
+function turn(...calls: ToolCall[]): { message: AssistantMessage; toolResults: [] } {
+	return {
+		message: { role: "assistant", content: calls, stopReason: "toolUse" } as unknown as AssistantMessage,
+		toolResults: [],
+	};
+}
+
+function batchA(): ToolCall[] {
+	return [toolCall("bash", { command: "echo a" }), toolCall("read", { path: "a.ts" })];
+}
+
+function batchB(): ToolCall[] {
+	return [toolCall("bash", { command: "echo b" })];
+}
 
 describe("ToolCallLoopGuard", () => {
-	test("detects the fifth consecutive identical tool call", () => {
-		const guard = new ToolCallLoopGuard({ threshold: 5, exemptTools: ["job", "irc"] });
-		let detection = null;
-		for (let index = 0; index < 5; index++) {
-			const toolCallId = `call-${index}`;
-			detection = guard.recordTurn({
-				message: {
-					role: "assistant",
-					content: [
-						{ type: "toolCall", id: toolCallId, name: "bash", arguments: { command: "pytest -q", timeout: 120 } },
-					],
-					api: "openai-responses",
-					provider: "openai",
-					model: "test-model",
-					usage: zeroUsage,
-					stopReason: "toolUse",
-					timestamp: Date.now(),
-				},
-				toolResults: [
-					{
-						role: "toolResult",
-						toolCallId,
-						toolName: "bash",
-						content: [{ type: "text", text: "1263 passed, 4 skipped" }],
-						isError: false,
-						timestamp: Date.now(),
-					},
-				],
-			});
-		}
-
-		expect(detection).toEqual({
-			kind: "repeated_tool_call",
-			toolName: "bash",
-			count: 5,
-			resultSummary: "1263 passed, 4 skipped",
-			argumentsSummary: '{"command":"pytest -q","timeout":120}',
-		});
-	});
-
-	test("canonicalizes argument key order and ignores harness intent fields", () => {
+	it("resets on a turn with no tool calls", () => {
 		const guard = new ToolCallLoopGuard({ threshold: 2, exemptTools: [] });
-		expect(
-			guard.recordTurn({
-				message: {
-					role: "assistant",
-					content: [
-						{ type: "toolCall", id: "first", name: "read", arguments: { path: "a.ts", [INTENT_FIELD]: "first" } },
-					],
-					api: "openai-responses",
-					provider: "openai",
-					model: "test-model",
-					usage: zeroUsage,
-					stopReason: "toolUse",
-					timestamp: Date.now(),
-				},
-				toolResults: [
-					{
-						role: "toolResult",
-						toolCallId: "first",
-						toolName: "read",
-						content: [{ type: "text", text: "1263 passed, 4 skipped" }],
-						isError: false,
-						timestamp: Date.now(),
-					},
-				],
-			}),
-		).toBeNull();
-		expect(
-			guard.recordTurn({
-				message: {
-					role: "assistant",
-					content: [
-						{
-							type: "toolCall",
-							id: "second",
-							name: "read",
-							arguments: { [INTENT_FIELD]: "second", path: "a.ts" },
-						},
-					],
-					api: "openai-responses",
-					provider: "openai",
-					model: "test-model",
-					usage: zeroUsage,
-					stopReason: "toolUse",
-					timestamp: Date.now(),
-				},
-				toolResults: [
-					{
-						role: "toolResult",
-						toolCallId: "second",
-						toolName: "read",
-						content: [{ type: "text", text: "1263 passed, 4 skipped" }],
-						isError: false,
-						timestamp: Date.now(),
-					},
-				],
-			}),
-		).toMatchObject({ toolName: "read", count: 2 });
+		expect(guard.recordTurn(turn(...batchA()))).toBeNull();
+		expect(guard.recordTurn(turn())).toBeNull();
+		expect(guard.recordTurn(turn(...batchA()))).toBeNull();
 	});
 
-	test("resets the consecutive count on a different call", () => {
+	it("detects consecutive identical multi-call turns at the threshold", () => {
 		const guard = new ToolCallLoopGuard({ threshold: 3, exemptTools: [] });
-		expect(
-			guard.recordTurn({
-				message: {
-					role: "assistant",
-					content: [{ type: "toolCall", id: "first", name: "bash", arguments: { command: "pytest -q" } }],
-					api: "openai-responses",
-					provider: "openai",
-					model: "test-model",
-					usage: zeroUsage,
-					stopReason: "toolUse",
-					timestamp: Date.now(),
-				},
-				toolResults: [
-					{
-						role: "toolResult",
-						toolCallId: "first",
-						toolName: "bash",
-						content: [{ type: "text", text: "1263 passed, 4 skipped" }],
-						isError: false,
-						timestamp: Date.now(),
-					},
-				],
-			}),
-		).toBeNull();
-		expect(
-			guard.recordTurn({
-				message: {
-					role: "assistant",
-					content: [{ type: "toolCall", id: "second", name: "read", arguments: { path: "src/index.ts" } }],
-					api: "openai-responses",
-					provider: "openai",
-					model: "test-model",
-					usage: zeroUsage,
-					stopReason: "toolUse",
-					timestamp: Date.now(),
-				},
-				toolResults: [
-					{
-						role: "toolResult",
-						toolCallId: "second",
-						toolName: "read",
-						content: [{ type: "text", text: "1263 passed, 4 skipped" }],
-						isError: false,
-						timestamp: Date.now(),
-					},
-				],
-			}),
-		).toBeNull();
-		expect(
-			guard.recordTurn({
-				message: {
-					role: "assistant",
-					content: [{ type: "toolCall", id: "third", name: "bash", arguments: { command: "pytest -q" } }],
-					api: "openai-responses",
-					provider: "openai",
-					model: "test-model",
-					usage: zeroUsage,
-					stopReason: "toolUse",
-					timestamp: Date.now(),
-				},
-				toolResults: [
-					{
-						role: "toolResult",
-						toolCallId: "third",
-						toolName: "bash",
-						content: [{ type: "text", text: "1263 passed, 4 skipped" }],
-						isError: false,
-						timestamp: Date.now(),
-					},
-				],
-			}),
-		).toBeNull();
+		expect(guard.recordTurn(turn(...batchA()))).toBeNull();
+		expect(guard.recordTurn(turn(...batchA()))).toBeNull();
+		const hit = guard.recordTurn(turn(...batchA()));
+		expect(hit).not.toBeNull();
+		expect(hit!.kind).toBe("repeated_tool_call");
+		expect(hit!.count).toBe(3);
 	});
 
-	test("ignores exempt polling tools", () => {
-		const guard = new ToolCallLoopGuard({ threshold: 2, exemptTools: ["job"] });
-		expect(
-			guard.recordTurn({
-				message: {
-					role: "assistant",
-					content: [{ type: "toolCall", id: "first", name: "job", arguments: { poll: ["abc"] } }],
-					api: "openai-responses",
-					provider: "openai",
-					model: "test-model",
-					usage: zeroUsage,
-					stopReason: "toolUse",
-					timestamp: Date.now(),
-				},
-				toolResults: [
-					{
-						role: "toolResult",
-						toolCallId: "first",
-						toolName: "job",
-						content: [{ type: "text", text: "1263 passed, 4 skipped" }],
-						isError: false,
-						timestamp: Date.now(),
-					},
-				],
-			}),
-		).toBeNull();
-		expect(
-			guard.recordTurn({
-				message: {
-					role: "assistant",
-					content: [{ type: "toolCall", id: "second", name: "job", arguments: { poll: ["abc"] } }],
-					api: "openai-responses",
-					provider: "openai",
-					model: "test-model",
-					usage: zeroUsage,
-					stopReason: "toolUse",
-					timestamp: Date.now(),
-				},
-				toolResults: [
-					{
-						role: "toolResult",
-						toolCallId: "second",
-						toolName: "job",
-						content: [{ type: "text", text: "1263 passed, 4 skipped" }],
-						isError: false,
-						timestamp: Date.now(),
-					},
-				],
-			}),
-		).toBeNull();
+	it("does not count a turn whose calls are all exempt", () => {
+		const guard = new ToolCallLoopGuard({ threshold: 2, exemptTools: ["read"] });
+		expect(guard.recordTurn(turn(toolCall("read", { path: "a.ts" })))).toBeNull();
+		const hit = guard.recordTurn(turn(toolCall("read", { path: "a.ts" })));
+		expect(hit).toBeNull();
+	});
+
+	it("resets when every call in a multi-call turn is exempt", () => {
+		const guard = new ToolCallLoopGuard({ threshold: 2, exemptTools: ["read"] });
+		expect(guard.recordTurn(turn(...batchA()))).toBeNull();
+		expect(guard.recordTurn(turn(toolCall("read", { path: "x.ts" }), toolCall("read", { path: "y.ts" })))).toBeNull();
+		expect(guard.recordTurn(turn(...batchA()))).toBeNull();
+	});
+
+	it("counts a mixed batch and reports the first non-exempt call", () => {
+		const guard = new ToolCallLoopGuard({ threshold: 2, exemptTools: ["read"] });
+		const mixed = () => [toolCall("read", { path: "a.ts" }), toolCall("bash", { command: "echo a" })];
+		expect(guard.recordTurn(turn(...mixed()))).toBeNull();
+		const hit = guard.recordTurn(turn(...mixed()));
+		expect(hit).not.toBeNull();
+		expect(hit!.toolName).toBe("bash");
+	});
+
+	it("does not count alternating distinct batches", () => {
+		const guard = new ToolCallLoopGuard({ threshold: 2, exemptTools: [] });
+		expect(guard.recordTurn(turn(...batchA()))).toBeNull();
+		expect(guard.recordTurn(turn(...batchB()))).toBeNull();
+		expect(guard.recordTurn(turn(...batchA()))).toBeNull();
+		expect(guard.recordTurn(turn(...batchB()))).toBeNull();
+	});
+
+	it("keeps single-call behavior: identical single calls are detected", () => {
+		const guard = new ToolCallLoopGuard({ threshold: 2, exemptTools: [] });
+		expect(guard.recordTurn(turn(toolCall("bash", { command: "echo a" })))).toBeNull();
+		const hit = guard.recordTurn(turn(toolCall("bash", { command: "echo a" })));
+		expect(hit).not.toBeNull();
+		expect(hit!.toolName).toBe("bash");
+	});
+
+	it("keeps single-call behavior: differing args reset the counter", () => {
+		const guard = new ToolCallLoopGuard({ threshold: 2, exemptTools: [] });
+		expect(guard.recordTurn(turn(toolCall("bash", { command: "echo a" })))).toBeNull();
+		expect(guard.recordTurn(turn(toolCall("bash", { command: "echo b" })))).toBeNull();
+	});
+
+	it("canonicalizes argument key order across a multi-call batch", () => {
+		const guard = new ToolCallLoopGuard({ threshold: 2, exemptTools: [] });
+		const a = () => turn(toolCall("write", { path: "x.ts", content: "hi" }));
+		const reordered = () => turn(toolCall("write", { content: "hi", path: "x.ts" }));
+		expect(guard.recordTurn(a())).toBeNull();
+		const hit = guard.recordTurn(reordered());
+		expect(hit).not.toBeNull();
 	});
 });


### PR DESCRIPTION
## What

`ToolCallLoopGuard.recordTurn` currently disables itself for any turn that does not contain exactly one tool call: `toolCalls.length !== 1` resets the detector. This PR hashes the whole call set of a turn instead. Identical multi-call batches now accumulate toward the threshold, a turn whose calls are all exempt still resets the counter, and the detection reports the first non-exempt call so the corrective names the tool actually driving the loop. Single-call behavior is unchanged.

## Why

The guard exists to catch a model reissuing identical tool calls across turns, but as soon as the model emits parallel tool calls — a common pattern — the turn is dropped from detection entirely, so the loop it exists to bound goes unbounded. The change keeps the existing `threshold`/`exemptTools` settings and detection shape; only which turns are counted changes. The counter means "N consecutive turns with an identical call set"; alternating distinct batches still reset.

Awareness note: #6729 proposes broader no-progress/wandering detection in this same file. This PR is intentionally narrower — one behavior fix to `recordTurn` — and does not overlap its new detection kinds.

## Testing

- `packages/ai/test/tool-call-loop-guard.test.ts`: upstream tests kept intact (4 tests, including the fifth-consecutive-call and intent-field canonicalization cases), extended with a `ToolCallLoopGuard multi-call turns` block (5 tests): identical multi-call batches trip the threshold; empty-call turns reset; all-exempt multi-call turns reset; mixed exempt/non-exempt batches count and report the first non-exempt tool; alternating distinct batches reset.
- Existing `packages/coding-agent/test/advisor-tool-call-loop-guard.test.ts` (3 tests) passes unchanged — it is the only consumer of this class.
- `bun run check:types` in `packages/ai` clean; `oxfmt`/`oxlint` clean on touched files.
- I also build OMP from source with this patch for my own install; the guard's single consumer (the advisor loop guard) and its tests run green against the patched `recordTurn`.

In my own words: I hit this on my own install, where a model repeatedly re-sent the same two parallel calls and nothing ever stopped it — patching `recordTurn` to count the whole batch was the smallest change that made the existing guard actually fire, so I kept the settings and detection shape untouched and only widened what counts as a repeat.

- [x] `bun run check`
- [x] Tested locally
- [x] CHANGELOG updated (`packages/ai/CHANGELOG.md`)