### PR TITLE
fix(mcp): surface structuredContent in tool results

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,7 @@
 - TypeScript code intelligence now works on TypeScript 7 projects: the built-in `typescript-native` server runs `tsc --lsp --stdio` when the resolved TypeScript install no longer ships `tsserver.js`, replacing `typescript-language-server` for that project.
 - Claude marketplace MCP servers now resolve environment placeholders in stdio environment values instead of passing strings such as `${NAME:-}` literally ([#10481](https://github.com/can1357/oh-my-pi/pull/10481) by [@mrexodia](https://github.com/mrexodia)).
 - Fixed prewalk conflicting with `todo.eager=always`: the forced eager-todo prelude ("call todo first this turn") was injected alongside the prewalk plan nudge ("write a complete plan first, then todo"), giving the model contradictory instructions; the eager-todo prelude is now suppressed only when prewalk will perform a handoff ([#10510](https://github.com/can1357/oh-my-pi/issues/10510)).
+- MCP tool results now surface `structuredContent`: servers that return their payload in the structured channel while keeping `content` a terse ack (e.g. rhizome-mcp) are no longer data-less to the model ([#10522](https://github.com/can1357/oh-my-pi/issues/10522)).
 ## [18.1.2] - 2026-09-01
 
 ### Added

--- a/packages/coding-agent/src/mcp/render.ts
+++ b/packages/coding-agent/src/mcp/render.ts
@@ -114,7 +114,11 @@ export function renderMCPResult(
 	args?: Record<string, unknown>,
 ): Component {
 	const { expanded } = options;
-	const textContent = result.content?.find(c => c.type === "text")?.text ?? "";
+	const textContent = (result.content ?? [])
+		.filter(block => block.type === "text")
+		.map(block => block.text ?? "")
+		.filter(text => text.length > 0)
+		.join("\n\n");
 	const trimmedOutput = stripOutputNotice(textContent, result.details?.meta).trimEnd();
 	const truncationWarning = result.details?.meta?.truncation
 		? formatStyledTruncationWarning(result.details.meta, theme)

--- a/packages/coding-agent/src/mcp/tool-bridge.ts
+++ b/packages/coding-agent/src/mcp/tool-bridge.ts
@@ -238,6 +238,43 @@ function formatMCPContent(content: MCPContent[]): Array<TextContent | ImageConte
 	return blocks.length > 0 ? blocks : [{ type: "text", text: "" }];
 }
 
+/**
+ * Serialize an MCP result's structured payload as a fenced JSON block so it
+ * reaches the model through the standard content channel — and the eval
+ * `tool.*` and subagent proxy bridges that read the same result. Subject to the
+ * usual spill/byte-cap machinery like any other text block.
+ */
+function formatStructuredContent(structured: Record<string, unknown>): string {
+	let json: string;
+	try {
+		json = JSON.stringify(structured, null, 2);
+	} catch {
+		return "";
+	}
+	return `\`\`\`json\n${json}\n\`\`\``;
+}
+
+/**
+ * True when a text block already carries the structured payload verbatim. A
+ * spec-compliant server duplicates `structuredContent` into a TextContent block
+ * for back-compat; detecting that avoids emitting the JSON twice.
+ */
+function structuredContentAlreadyInText(structured: Record<string, unknown>, content: MCPContent[]): boolean {
+	for (const item of content) {
+		if (item.type !== "text") continue;
+		const trimmed = item.text.trim();
+		if (trimmed.length === 0) continue;
+		let parsed: unknown;
+		try {
+			parsed = JSON.parse(trimmed);
+		} catch {
+			continue;
+		}
+		if (Bun.deepEquals(parsed, structured)) return true;
+	}
+	return false;
+}
+
 /** Build a CustomToolResult from a callTool response. */
 function buildResult(
 	result: MCPToolCallResult,
@@ -261,6 +298,13 @@ function buildResult(
 			content[0] = { type: "text", text: `Error: ${content[0].text}` };
 		} else {
 			content.unshift({ type: "text", text: "Error:" });
+		}
+	}
+	const structured = result.structuredContent;
+	if (structured !== undefined && !structuredContentAlreadyInText(structured, result.content)) {
+		const rendered = formatStructuredContent(structured);
+		if (rendered.length > 0) {
+			content.push({ type: "text", text: rendered });
 		}
 	}
 	const toolResult: CustomToolResult<MCPToolDetails> = { content, details };

--- a/packages/coding-agent/src/mcp/types.ts
+++ b/packages/coding-agent/src/mcp/types.ts
@@ -294,6 +294,12 @@ export interface MCPAuthChallenge {
 export interface MCPToolCallResult {
 	content: MCPContent[];
 	isError?: boolean;
+	/**
+	 * Machine-readable payload channel (MCP spec 2025-06-18, Tools → Structured
+	 * Content). Servers may return their data here while keeping `content`
+	 * minimal; the bridge surfaces it so it reaches the model.
+	 */
+	structuredContent?: Record<string, unknown>;
 	_meta?: Record<string, unknown>;
 }
 

--- a/packages/coding-agent/test/mcp/tool-bridge-structured-content.test.ts
+++ b/packages/coding-agent/test/mcp/tool-bridge-structured-content.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "bun:test";
+
+import type { CustomToolContext } from "../../src/extensibility/custom-tools/types";
+import { MCPTool } from "../../src/mcp/tool-bridge";
+import type { MCPServerConnection, MCPToolCallResult, MCPToolDefinition } from "../../src/mcp/types";
+
+function toolFor(result: MCPToolCallResult): MCPTool {
+	const connection = {
+		name: "rhizome-mcp",
+		transport: {
+			request: async (method: string) => {
+				if (method === "tools/call") return result as unknown;
+				throw new Error(`unexpected method ${method}`);
+			},
+			close: async () => {},
+		},
+	} as unknown as MCPServerConnection;
+	const definition: MCPToolDefinition = { name: "list_issues", inputSchema: { type: "object" } };
+	return new MCPTool(connection, definition);
+}
+
+async function modelText(result: MCPToolCallResult): Promise<string> {
+	const tool = toolFor(result);
+	const built = await tool.execute("call-1", {}, undefined, {} as CustomToolContext);
+	return built.content.map(block => (block.type === "text" ? block.text : `[${block.type}]`)).join("\n");
+}
+
+describe("MCP bridge structuredContent", () => {
+	it("surfaces structuredContent when content is a minimal ack", async () => {
+		// rhizome-mcp shape: terse ack in content, real payload in structuredContent.
+		const text = await modelText({
+			content: [{ type: "text", text: "issues listed" }],
+			structuredContent: {
+				items: [],
+				next_cursor: null,
+				next_actions: ["Inspect a claimable issue with get_work_context."],
+			},
+		});
+
+		expect(text).toContain("issues listed");
+		expect(text).toContain("next_actions");
+		expect(text).toContain("Inspect a claimable issue with get_work_context.");
+	});
+
+	it("does not duplicate structuredContent already echoed verbatim in a text block", async () => {
+		const payload = { lease_token: "abc123", expires_in: 900 };
+		const text = await modelText({
+			content: [{ type: "text", text: JSON.stringify(payload, null, 2) }],
+			structuredContent: payload,
+		});
+
+		// The token must be reachable exactly once — not appended a second time.
+		const occurrences = text.split("abc123").length - 1;
+		expect(occurrences).toBe(1);
+	});
+
+	it("leaves results without structuredContent untouched", async () => {
+		const text = await modelText({ content: [{ type: "text", text: "plain result" }] });
+		expect(text).toBe("plain result");
+	});
+});

--- a/packages/coding-agent/test/mcp/tool-bridge-structured-content.test.ts
+++ b/packages/coding-agent/test/mcp/tool-bridge-structured-content.test.ts
@@ -1,8 +1,11 @@
-import { describe, expect, it } from "bun:test";
+import { beforeAll, describe, expect, it } from "bun:test";
 
-import type { CustomToolContext } from "../../src/extensibility/custom-tools/types";
-import { MCPTool } from "../../src/mcp/tool-bridge";
+import { resetSettingsForTest, Settings } from "../../src/config/settings";
+import { renderMCPResult } from "../../src/mcp/render";
+import { MCPTool, type MCPToolDetails } from "../../src/mcp/tool-bridge";
 import type { MCPServerConnection, MCPToolCallResult, MCPToolDefinition } from "../../src/mcp/types";
+import { getThemeByName, initTheme } from "../../src/modes/theme/theme";
+import type { CustomToolContext, CustomToolResult } from "../../src/extensibility/custom-tools/types";
 
 function toolFor(result: MCPToolCallResult): MCPTool {
 	const connection = {
@@ -19,9 +22,12 @@ function toolFor(result: MCPToolCallResult): MCPTool {
 	return new MCPTool(connection, definition);
 }
 
+function build(result: MCPToolCallResult): Promise<CustomToolResult<MCPToolDetails>> {
+	return toolFor(result).execute("call-1", {}, undefined, {} as CustomToolContext);
+}
+
 async function modelText(result: MCPToolCallResult): Promise<string> {
-	const tool = toolFor(result);
-	const built = await tool.execute("call-1", {}, undefined, {} as CustomToolContext);
+	const built = await build(result);
 	return built.content.map(block => (block.type === "text" ? block.text : `[${block.type}]`)).join("\n");
 }
 
@@ -57,5 +63,41 @@ describe("MCP bridge structuredContent", () => {
 	it("leaves results without structuredContent untouched", async () => {
 		const text = await modelText({ content: [{ type: "text", text: "plain result" }] });
 		expect(text).toBe("plain result");
+	});
+});
+
+describe("MCP result rendering with structuredContent", () => {
+	beforeAll(async () => {
+		resetSettingsForTest();
+		await Settings.init({ inMemory: true, cwd: process.cwd() });
+		await initTheme(false, undefined, undefined, "dark", "light");
+	}, 15_000);
+
+	async function renderText(result: MCPToolCallResult): Promise<string> {
+		const theme = await getThemeByName("dark");
+		if (!theme) throw new Error("dark theme missing");
+		const built = await build(result);
+		return Bun.stripANSI(renderMCPResult(built, { expanded: true, isPartial: false }, theme).render(160).join("\n"));
+	}
+
+	it("renders the appended structured payload, not just the ack", async () => {
+		const rendered = await renderText({
+			content: [{ type: "text", text: "issues listed" }],
+			structuredContent: { next_actions: ["Inspect a claimable issue with get_work_context."] },
+		});
+
+		expect(rendered).toContain("issues listed");
+		expect(rendered).toContain("next_actions");
+	});
+
+	it("renders a structured-only result instead of showing (no output)", async () => {
+		const rendered = await renderText({
+			content: [],
+			structuredContent: { lease_token: "abc123" },
+		});
+
+		expect(rendered).not.toContain("(no output)");
+		expect(rendered).toContain("lease_token");
+		expect(rendered).toContain("abc123");
 	});
 });


### PR DESCRIPTION
## Repro
An MCP server that returns its payload in `result.structuredContent` while keeping `content` a terse ack (e.g. rhizome-mcp, whose read calls return only `issues listed`) appears data-less to the model. Driving `MCPTool.execute` with a fake transport that returns `content: [{text: "issues listed"}]` plus a `structuredContent` object yields tool output containing only the ack:

```
$ bun run repro-structured.ts
=== content the model sees ===
issues listed
=== structuredContent reachable in output? ===
NO — DATA DROPPED
```

## Cause
`buildResult()` in `packages/coding-agent/src/mcp/tool-bridge.ts` builds the model-visible `CustomToolResult` from `result.content` and `result._meta` only. `MCPToolCallResult` (`src/mcp/types.ts`) did not even declare `structuredContent` — the MCP spec 2025-06-18 machine-readable payload channel — so it was silently discarded on the single funnel all three consumers (main-session tools, eval `tool.*`, subagent proxy) share.

## Fix
- `MCPToolCallResult` gains `structuredContent?: Record<string, unknown>` (`src/mcp/types.ts`); the field was already on the runtime object (`callTool` bare-casts the wire response).
- `buildResult()` appends `structuredContent` as a fenced JSON text block, so it reaches the model / eval / subagent bridges alike and rides the existing spill/byte-cap machinery like any other text block.
- Duplication guard: `structuredContentAlreadyInText` skips the append when a text block already carries the payload verbatim (spec-compliant servers duplicate it for back-compat), so those results are not double-sent.

## Verification
`bun test test/mcp/tool-bridge-structured-content.test.ts` — 3 pass (minimal-ack surfaces payload, verbatim echo not duplicated, no-structuredContent untouched). Full `test/mcp/` run is green except two pre-existing failures in `transports/stdio.test.ts` that are environmental (`ps` binary missing in `$PATH`) and unrelated to this change.

Fixes #10522