### PR TITLE
fix(coding-agent): stabilize Agent Hub roster ordering

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,7 @@
 - TypeScript code intelligence now works on TypeScript 7 projects: the built-in `typescript-native` server runs `tsc --lsp --stdio` when the resolved TypeScript install no longer ships `tsserver.js`, replacing `typescript-language-server` for that project.
 - Claude marketplace MCP servers now resolve environment placeholders in stdio environment values instead of passing strings such as `${NAME:-}` literally ([#10481](https://github.com/can1357/oh-my-pi/pull/10481) by [@mrexodia](https://github.com/mrexodia)).
 - Fixed prewalk conflicting with `todo.eager=always`: the forced eager-todo prelude ("call todo first this turn") was injected alongside the prewalk plan nudge ("write a complete plan first, then todo"), giving the model contradictory instructions; the eager-todo prelude is now suppressed only when prewalk will perform a handoff ([#10510](https://github.com/can1357/oh-my-pi/issues/10510)).
+- Fixed the Agent Hub roster shuffling erratically while open: rows no longer re-sort on every agent heartbeat, so the list stays stable and navigable with many active agents ([#10524](https://github.com/can1357/oh-my-pi/issues/10524)).
 ## [18.1.2] - 2026-09-01
 
 ### Added

--- a/packages/coding-agent/src/modes/components/agent-hub.ts
+++ b/packages/coding-agent/src/modes/components/agent-hub.ts
@@ -522,8 +522,10 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 					b.lastActivity - a.lastActivity ||
 					a.id.localeCompare(b.id),
 			);
-			this.#rowOrder = new Map();
-			for (const ref of ordered) this.#rowOrder.set(ref.id, this.#nextRowOrder++);
+			if (ordered.length > 0) {
+				this.#rowOrder = new Map();
+				for (const ref of ordered) this.#rowOrder.set(ref.id, this.#nextRowOrder++);
+			}
 		} else {
 			ordered = refs.sort(
 				(a, b) => (rowOrder.get(a.id) ?? Number.MAX_SAFE_INTEGER) - (rowOrder.get(b.id) ?? Number.MAX_SAFE_INTEGER),

--- a/packages/coding-agent/src/modes/components/agent-hub.ts
+++ b/packages/coding-agent/src/modes/components/agent-hub.ts
@@ -329,15 +329,17 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 			: registerPersistedSubagents(this.#registry, deps.sessionFile, {
 					shouldContinue: () => !this.#disposed,
 				})
-					.then(() => {
-						if (!this.#disposed) this.#refreshRows();
-					})
 					.catch((error: unknown) => {
 						logger.warn("Failed to register persisted subagents", { error });
 					})
 					.finally(() => {
+						// Clear the loading flag first so this refresh captures the
+						// full status/recency ranking rather than a partial roster.
 						this.#loadingPersistedSubagents = false;
-						if (!this.#disposed) this.#requestRender();
+						if (!this.#disposed) {
+							this.#refreshRows();
+							this.#requestRender();
+						}
 					});
 		this.#refreshRows();
 	}
@@ -513,6 +515,9 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 		// Stable roster order: capture the status+recency ranking once so keyboard
 		// navigation is not disrupted by heartbeats (issue #10524). Existing rows
 		// keep their rank while the hub is open; new agents append at the end.
+		// Defer the capture until persisted-subagent discovery settles so a
+		// mid-scan refresh cannot freeze a partial roster (the remaining agents
+		// would otherwise append in readdir order instead of being ranked).
 		const rowOrder = this.#rowOrder;
 		let ordered: AgentRef[];
 		if (!rowOrder) {
@@ -522,7 +527,7 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 					b.lastActivity - a.lastActivity ||
 					a.id.localeCompare(b.id),
 			);
-			if (ordered.length > 0) {
+			if (!this.#loadingPersistedSubagents && ordered.length > 0) {
 				this.#rowOrder = new Map();
 				for (const ref of ordered) this.#rowOrder.set(ref.id, this.#nextRowOrder++);
 			}

--- a/packages/coding-agent/src/modes/components/agent-hub.ts
+++ b/packages/coding-agent/src/modes/components/agent-hub.ts
@@ -222,6 +222,11 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 	#rows: AgentRef[] = [];
 	#statusCounts: Record<AgentStatus, number> = { running: 0, idle: 0, parked: 0, aborted: 0 };
 	#selectedRow = 0;
+	/** Stable roster order captured on first refresh: keyboard navigation must
+	 *  not jump as agents heartbeat. Existing rows keep their rank while the hub
+	 *  is open; newly appearing agents append at the end. */
+	#rowOrder: Map<string, number> | undefined;
+	#nextRowOrder = 0;
 	#hoveredRow: number | null = null;
 	/** Per-render screen-line to agent-row map, shared by click and hover routing. */
 	#hitRows: Array<number | undefined> = [];
@@ -505,17 +510,33 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 		const refs = this.#registry.list().filter(ref => ref.id !== MAIN_AGENT_ID);
 		this.#observedById = new Map();
 		for (const session of this.#observers.getSessions()) this.#observedById.set(session.id, session);
+		// Stable roster order: capture the status+recency ranking once so keyboard
+		// navigation is not disrupted by heartbeats (issue #10524). Existing rows
+		// keep their rank while the hub is open; new agents append at the end.
+		const rowOrder = this.#rowOrder;
+		let ordered: AgentRef[];
+		if (!rowOrder) {
+			ordered = refs.sort(
+				(a, b) =>
+					STATUS_ORDER[a.status] - STATUS_ORDER[b.status] ||
+					b.lastActivity - a.lastActivity ||
+					a.id.localeCompare(b.id),
+			);
+			this.#rowOrder = new Map();
+			for (const ref of ordered) this.#rowOrder.set(ref.id, this.#nextRowOrder++);
+		} else {
+			ordered = refs.sort(
+				(a, b) => (rowOrder.get(a.id) ?? Number.MAX_SAFE_INTEGER) - (rowOrder.get(b.id) ?? Number.MAX_SAFE_INTEGER),
+			);
+			for (const ref of ordered) {
+				if (!rowOrder.has(ref.id)) rowOrder.set(ref.id, this.#nextRowOrder++);
+			}
+		}
 		const query = this.#agentFilter.trim();
-		const filtered =
-			query.length > 0 ? refs.filter(ref => fuzzyAgentMatch(query, `${ref.id} ${ref.displayName ?? ""}`)) : refs;
-		// Live recency ordering: the most recently active agent surfaces first and
-		// rows move as activity changes, matching the recency-first tree summary.
-		const rosterRows = filtered.sort(
-			(a, b) =>
-				STATUS_ORDER[a.status] - STATUS_ORDER[b.status] ||
-				b.lastActivity - a.lastActivity ||
-				a.id.localeCompare(b.id),
-		);
+		const rosterRows =
+			query.length > 0
+				? ordered.filter(ref => fuzzyAgentMatch(query, `${ref.id} ${ref.displayName ?? ""}`))
+				: ordered;
 
 		if (this.#viewMode === "tree") {
 			const tree = projectAgentTree(rosterRows);

--- a/packages/coding-agent/test/agent-hub-activate.test.ts
+++ b/packages/coding-agent/test/agent-hub-activate.test.ts
@@ -92,6 +92,20 @@ function renderedRosterEntry(hub: AgentHubOverlayComponent, id: string, width: n
 	return entry.join("\n");
 }
 
+function renderedRosterIds(hub: AgentHubOverlayComponent, width: number): string[] {
+	const ids: string[] = [];
+	for (const raw of hub.render(width)) {
+		const line = Bun.stripANSI(raw);
+		if (!line.startsWith("│ ")) continue;
+		const divider = line.indexOf("│", Math.max(2, Math.floor(line.length / 3)));
+		if (divider < 0) continue;
+		const cell = line.slice(2, Math.max(2, divider - 1));
+		const match = ROSTER_ENTRY_PATTERN.exec(cell);
+		if (match?.[3]) ids.push(match[3]);
+	}
+	return ids;
+}
+
 describe("Agent hub Enter activation", () => {
 	beforeAll(() => {
 		initTheme();
@@ -206,6 +220,41 @@ describe("Agent hub Enter activation", () => {
 		const workerEntry = renderedRosterEntry(hub, "Worker", 120);
 		expect(workerEntry).toContain("○ Worker");
 		expect(agents.get("Worker")?.sessionFile).toBe(workerSessionFile);
+		hub.dispose();
+	});
+
+	it("ranks restored subagents by recency rather than readdir order", async () => {
+		using tempDir = TempDir.createSync("@omp-agent-hub-persisted-order-");
+		const sessionFile = path.join(tempDir.path(), "main.jsonl");
+		await Bun.write(sessionFile, "");
+		// Alphabetical readdir order (Aaa, Bbb, Ccc) is the reverse of recency:
+		// Ccc is the most recently active. The roster must apply the status/recency
+		// ranking to every restored agent, not append them in discovery order.
+		const workers: Array<[string, number]> = [
+			["Aaa", Date.parse("2026-07-30T01:00:00.000Z")],
+			["Bbb", Date.parse("2026-07-30T02:00:00.000Z")],
+			["Ccc", Date.parse("2026-07-30T03:00:00.000Z")],
+		];
+		for (const [id, mtime] of workers) {
+			const file = path.join(tempDir.path(), "main", `${id}.jsonl`);
+			await Bun.write(file, persistedChildJsonl(id));
+			await fs.utimes(file, new Date(mtime), new Date(mtime));
+		}
+		const agents = new AgentRegistry();
+		const hub = new AgentHubOverlayComponent({
+			settings: Settings.isolated(),
+			observers: new SessionObserverRegistry(),
+			hubKeys: [],
+			onDone: () => {},
+			requestRender: () => {},
+			registry: agents,
+			irc: new IrcBus(agents),
+			focusAgent: async () => {},
+			sessionFile,
+		});
+		await hub.persistedSubagentsReady;
+
+		expect(renderedRosterIds(hub, 120)).toEqual(["Ccc", "Bbb", "Aaa"]);
 		hub.dispose();
 	});
 

--- a/packages/coding-agent/test/agent-hub-ordering.test.ts
+++ b/packages/coding-agent/test/agent-hub-ordering.test.ts
@@ -153,7 +153,7 @@ describe("Agent hub row ordering", () => {
 		}
 	});
 
-	it("re-sorts rows by most-recent activity while the hub is open", () => {
+	it("keeps row order stable as agents heartbeat and appends new agents", () => {
 		vi.useFakeTimers();
 		let hub: AgentHubOverlayComponent | undefined;
 		try {
@@ -172,19 +172,23 @@ describe("Agent hub row ordering", () => {
 			agents.register({ id: "C", displayName: "Gamma", kind: "sub", session: sessionC });
 
 			hub = makeHub(agents);
+			// Captured once on open: status then recency (most-recent first).
 			expect(renderedAgentIds(hub)).toEqual(["C", "B", "A"]);
-			// Bump A's lastActivity far ahead of the others; recency wins live.
+
+			// A heartbeats far ahead of the others; a stable roster must NOT bubble
+			// it to the top while the hub is open (issue #10524).
 			setSystemTime(4000);
 			agents.setActivity("A", "still running");
 
-			// A parked agent sorts below live ones by status order.
+			// A new agent appears and forces a refresh: existing rows keep their
+			// captured order, and the newcomer appends at the end.
 			setSystemTime(5000);
 			const sessionD = {} as AgentSession;
 			agents.register({ id: "D", displayName: "Delta", kind: "sub", session: sessionD, status: "parked" });
 			// Renders coalesce: the immediate frame still shows the captured order.
 			expect(renderedAgentIds(hub)).toEqual(["C", "B", "A"]);
 			vi.advanceTimersByTime(100);
-			expect(renderedAgentIds(hub)).toEqual(["A", "C", "B", "D"]);
+			expect(renderedAgentIds(hub)).toEqual(["C", "B", "A", "D"]);
 		} finally {
 			hub?.dispose();
 			vi.useRealTimers();

--- a/packages/coding-agent/test/agent-hub-ordering.test.ts
+++ b/packages/coding-agent/test/agent-hub-ordering.test.ts
@@ -153,6 +153,35 @@ describe("Agent hub row ordering", () => {
 		}
 	});
 
+	it("captures initial ranking when agents load after empty construction", () => {
+		vi.useFakeTimers();
+		geometry = stubStdoutGeometry(120);
+		const agents = new AgentRegistry();
+		const hub = makeHub(agents);
+
+		try {
+			expect(renderedAgentIds(hub)).toEqual([]);
+
+			setSystemTime(3000);
+			agents.register({
+				id: "Parked",
+				displayName: "Parked",
+				kind: "sub",
+				session: null,
+				status: "parked",
+			});
+			setSystemTime(1000);
+			agents.register({ id: "Older", displayName: "Older", kind: "sub", session: {} as AgentSession });
+			setSystemTime(2000);
+			agents.register({ id: "Newer", displayName: "Newer", kind: "sub", session: {} as AgentSession });
+
+			vi.advanceTimersByTime(100);
+			expect(renderedAgentIds(hub)).toEqual(["Newer", "Older", "Parked"]);
+		} finally {
+			hub.dispose();
+		}
+	});
+
 	it("keeps row order stable as agents heartbeat and appends new agents", () => {
 		vi.useFakeTimers();
 		let hub: AgentHubOverlayComponent | undefined;


### PR DESCRIPTION
## Repro
With 5+ active agents, opening the Agent Hub (ALT+A) shows the roster shuffling/jumping erratically in both flat and tree modes, so the list can't be navigated. Replaying the roster comparator against a live `AgentRegistry` reproduces the churn — a single heartbeat yanks a different agent to the top on each refresh:

```
open  : E D C B A
A beat: A E D C B
C beat: C A E D B
B beat: B C A E D
```

## Cause
`AgentHubOverlayComponent.#refreshRows()` in `packages/coding-agent/src/modes/components/agent-hub.ts` re-sorted the whole roster on every registry/observer change (coalesced to ~100ms) with `b.lastActivity - a.lastActivity` as the tiebreak within a status group. `agent-registry` bumps `ref.lastActivity = Date.now()` on every running-agent heartbeat/tool-call, so active agents' timestamps constantly leapfrog and rows swap on each refresh. Tree mode churns too because `projectAgentTree` derives sibling order from the flat `lastActivity` order. This is a regression from 547aad7 ("polish Agent Hub roster UX"), which dropped the previous stable `#rowOrder` ranking.

## Fix
- Restore a `#rowOrder`/`#nextRowOrder` ranking captured on the first refresh: sort once by status then recency, then assign each agent a monotonic rank.
- Subsequent refreshes sort by the captured rank, so existing rows keep their position while the hub is open; newly-appearing agents get the next rank and append at the end.
- Apply the fuzzy `/` filter after ranking so filtering hides rows without reshuffling the stable order.
- Tree mode inherits the stable flat order through `projectAgentTree`, so it no longer churns either.

## Verification
`bun test test/agent-hub-ordering.test.ts` → 23 pass. The existing "re-sorts rows by most-recent activity" test (which encoded the regression) is rewritten to assert the roster stays stable across a heartbeat and appends new agents. Fixes #10524