### PR TITLE
feat(tui): display.layout setting with an opencode-style transcript

### DIFF
--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -700,6 +700,12 @@ export interface RenderResultOptions {
 	isPartial: boolean;
 	/** Current spinner frame index for animated elements (optional) */
 	spinnerFrame?: number;
+	/**
+	 * Host-supplied render context. The coding agent's transcript always sets
+	 * `flat: boolean` (opencode-layout flag) and tools may receive extra fields
+	 * (bash output, edit previews, …).
+	 */
+	renderContext?: Record<string, unknown>;
 }
 
 /** Capability tier a tool exercises. Determines which approval modes auto-approve it. */

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `display.layout` setting (Appearance → Display) with an `opencode` option: a flat, opencode-style transcript where collapsed tool calls render as one status line (Ctrl+O expands), framed tool output renders without borders, and user messages get a left accent gutter. A new setup-wizard scene offers the choice on first run and on upgrade.
+
 ### Fixed
 
 - Anthropic sessions now keep tool-roster changes and warm-prefix pruning from invalidating preserved thinking or the prompt cache.
@@ -969,9 +973,6 @@
 - Fixed retry-fallback selection switching to a fallback model with a context window too small to hold the current session context.
 - Fixed OpenCode discovery ignoring `opencode.jsonc` files and rejecting comments in `opencode.json`.
 - Fixed WSL2 startup hanging forever when the Windows interop pipe is wedged: the WSL host-home discovery probes (`cmd.exe`, `wslpath`) now run under a 500ms hard timeout and fall back to the Linux `$HOME`/`~/.omp` candidates ([#8402](https://github.com/can1357/oh-my-pi/issues/8402)).
-### Added
-
-- Added `display.layout` setting (Appearance → Display) with an `opencode` option: a flat, opencode-style transcript where collapsed tool calls render as one status line (Ctrl+O expands), framed tool output renders without borders, and user messages get a left accent gutter. A new setup-wizard scene offers the choice on first run and on upgrade.
 
 ## [17.2.15] - 2026-08-12
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -969,6 +969,9 @@
 - Fixed retry-fallback selection switching to a fallback model with a context window too small to hold the current session context.
 - Fixed OpenCode discovery ignoring `opencode.jsonc` files and rejecting comments in `opencode.json`.
 - Fixed WSL2 startup hanging forever when the Windows interop pipe is wedged: the WSL host-home discovery probes (`cmd.exe`, `wslpath`) now run under a 500ms hard timeout and fall back to the Linux `$HOME`/`~/.omp` candidates ([#8402](https://github.com/can1357/oh-my-pi/issues/8402)).
+### Added
+
+- Added `display.layout` setting (Appearance → Display) with an `opencode` option: a flat, opencode-style transcript where collapsed tool calls render as one status line (Ctrl+O expands), framed tool output renders without borders, and user messages get a left accent gutter. A new setup-wizard scene offers the choice on first run and on upgrade.
 
 ## [17.2.15] - 2026-08-12
 

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1252,6 +1252,26 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	"display.layout": {
+		type: "enum",
+		values: ["omp", "opencode"] as const,
+		default: "omp",
+		ui: {
+			tab: "appearance",
+			group: "Display",
+			label: "Layout Style",
+			description: "Transcript style: omp's detailed tool cards, or an opencode-style flat transcript",
+			options: [
+				{ value: "omp", label: "OMP", description: "Tool cards with framed output previews" },
+				{
+					value: "opencode",
+					label: "OpenCode",
+					description: "Flat transcript; collapsed tool calls render as one line (Ctrl+O expands)",
+				},
+			],
+		},
+	},
+
 	"display.shimmer": {
 		type: "enum",
 		values: ["classic", "kitt", "disabled"] as const,

--- a/packages/coding-agent/src/edit/renderer.ts
+++ b/packages/coding-agent/src/edit/renderer.ts
@@ -167,6 +167,8 @@ export interface EditRenderContext {
 	editStreamingFallback?: string;
 	/** Function to render diff text with syntax highlighting */
 	renderDiff?: (diffText: string, options?: { filePath?: string }) => string;
+	/** Flat opencode layout (owning mode); forwarded to renderOutputBlock. */
+	flat?: boolean;
 }
 
 const EDIT_STREAMING_PREVIEW_LINES = 12;
@@ -919,6 +921,7 @@ export const editToolRenderer = {
 				borderColor: applyPatchError ? "error" : "borderMuted",
 				width,
 				contentPaddingLeft: 0,
+				flat: options.renderContext?.flat === true,
 			};
 		});
 	},
@@ -1092,6 +1095,7 @@ function renderSingleFileResult(
 			borderColor: isError ? "error" : "borderMuted",
 			width,
 			contentPaddingLeft: 0,
+			flat: renderContext?.flat === true,
 		};
 	});
 }

--- a/packages/coding-agent/src/extensibility/custom-tools/types.ts
+++ b/packages/coding-agent/src/extensibility/custom-tools/types.ts
@@ -170,8 +170,13 @@ export interface RenderResultOptions {
 	 * Streamed `xd://` previews stay queued until this is set.
 	 */
 	executionStarted?: boolean;
+	/**
+	 * Tool-specific render context built by ToolExecutionComponent. Always
+	 * carries `flat: boolean` (the owning mode's opencode-layout flag) for
+	 * framed renderers; tools like bash/eval add their own fields.
+	 */
+	renderContext?: Record<string, unknown>;
 }
-
 export type CustomToolResult<TDetails = any> = AgentToolResult<TDetails>;
 
 /**

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -588,6 +588,8 @@ export interface ToolRenderResultOptions {
 	isPartial: boolean;
 	/** Current spinner frame index for animated elements (optional) */
 	spinnerFrame?: number;
+	/** Tool-specific render context built by ToolExecutionComponent. */
+	renderContext?: Record<string, unknown>;
 }
 
 /** Session event for tool onSession lifecycle */

--- a/packages/coding-agent/src/extensibility/extensions/wrapper.ts
+++ b/packages/coding-agent/src/extensibility/extensions/wrapper.ts
@@ -59,7 +59,12 @@ export class RegisteredToolAdapter implements AgentTool<any, any, any> {
 			this.renderResult = (result: any, options: any, theme: any, args?: any) =>
 				registeredTool.definition.renderResult!(
 					result,
-					{ expanded: options.expanded, isPartial: options.isPartial, spinnerFrame: options.spinnerFrame },
+					{
+						expanded: options.expanded,
+						isPartial: options.isPartial,
+						spinnerFrame: options.spinnerFrame,
+						renderContext: options.renderContext,
+					},
 					theme as Theme,
 					args,
 				);

--- a/packages/coding-agent/src/goals/tools/goal-tool.ts
+++ b/packages/coding-agent/src/goals/tools/goal-tool.ts
@@ -178,7 +178,7 @@ export const goalToolRenderer = {
 
 	renderResult(
 		result: { content: Array<{ type: string; text?: string }>; details?: GoalToolDetails; isError?: boolean },
-		_options: RenderResultOptions,
+		options: RenderResultOptions,
 		uiTheme: Theme,
 		args?: GoalRenderArgs,
 	): Component {
@@ -195,6 +195,7 @@ export const goalToolRenderer = {
 				state: "error",
 				borderColor: "error",
 				width,
+				flat: options.renderContext?.flat === true,
 			}));
 		}
 
@@ -244,6 +245,7 @@ export const goalToolRenderer = {
 			state: "success",
 			borderColor: "borderMuted",
 			width,
+			flat: options.renderContext?.flat === true,
 		}));
 	},
 

--- a/packages/coding-agent/src/lsp/render.ts
+++ b/packages/coding-agent/src/lsp/render.ts
@@ -188,6 +188,7 @@ export function renderResult(
 					],
 					width,
 					applyBg: false,
+					flat: options.renderContext?.flat === true,
 				},
 				theme,
 			);

--- a/packages/coding-agent/src/modes/components/agent-hub.ts
+++ b/packages/coding-agent/src/modes/components/agent-hub.ts
@@ -44,6 +44,7 @@ import { USER_INTERRUPT_LABEL } from "../../session/messages";
 import { shortenPath, truncateToWidth } from "../../tools/render-utils";
 import { formatLocalDateTimeWithOffset } from "../../utils/local-date";
 import type { ObservableSession, SessionObserverRegistry } from "../session-observer-registry";
+import type { LayoutMode } from "../layout-mode";
 import { theme } from "../theme/theme";
 import { matchesSelectDown, matchesSelectUp } from "../utils/keybinding-matchers";
 import {
@@ -172,6 +173,8 @@ export interface AgentHubDeps {
 	/** Mirrors the main transcript's thinking-block visibility. */
 	hideThinkingBlock?: () => boolean;
 	proseOnlyThinking?: () => boolean;
+	/** Owning mode's transcript layout accessor (viewer transcripts match the live look). */
+	layout?: () => LayoutMode;
 	/** Keys toggling tool output expansion (app.tools.expand). */
 	expandKeys?: KeyId[];
 	/** Focus the main view on this agent's live session (ctx.focusAgentSession). When absent (collab guest, tests), Enter opens the in-hub chat view instead. */
@@ -270,6 +273,7 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 	#cwd: string;
 	#hideThinkingBlock: (() => boolean) | undefined;
 	#proseOnlyThinking: (() => boolean) | undefined;
+	#layout: (() => LayoutMode) | undefined;
 	#expandKeys: KeyId[];
 	#focusAgent: ((id: string) => Promise<void>) | undefined;
 
@@ -306,6 +310,7 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 		this.#cwd = deps.cwd ?? getProjectDir();
 		this.#hideThinkingBlock = deps.hideThinkingBlock;
 		this.#proseOnlyThinking = deps.proseOnlyThinking;
+		this.#layout = deps.layout;
 		this.#expandKeys = deps.expandKeys ?? ["ctrl+o"];
 		this.#focusAgent = deps.focusAgent;
 
@@ -450,6 +455,7 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 			cwd: this.#cwd,
 			hideThinkingBlock: this.#hideThinkingBlock,
 			proseOnlyThinking: this.#proseOnlyThinking,
+			layout: this.#layout,
 			expandKeys: this.#expandKeys,
 			hubKeys: this.#hubKeys,
 			requestRender: this.#requestRender,

--- a/packages/coding-agent/src/modes/components/agent-transcript-viewer.ts
+++ b/packages/coding-agent/src/modes/components/agent-transcript-viewer.ts
@@ -24,6 +24,7 @@ import type { AgentRegistry, AgentStatus } from "../../registry/agent-registry";
 import type { FileEntry, SessionMessageEntry } from "../../session/session-entries";
 import { parseSessionEntries } from "../../session/session-loader";
 import { replaceTabs, shortenPath, truncateToWidth } from "../../tools/render-utils";
+import type { LayoutMode } from "../layout-mode";
 import type { ObservableSession, SessionObserverRegistry } from "../session-observer-registry";
 import { getEditorTheme, theme } from "../theme/theme";
 import { matchesSelectDown, matchesSelectUp } from "../utils/keybinding-matchers";
@@ -51,6 +52,8 @@ export interface AgentTranscriptViewerDeps {
 	cwd: string;
 	hideThinkingBlock?: () => boolean;
 	proseOnlyThinking?: () => boolean;
+	/** Owning mode's transcript layout accessor. */
+	layout?: () => LayoutMode;
 	expandKeys: KeyId[];
 	/** Keys that toggle the whole hub closed (app.agents.hub + app.session.observe). */
 	hubKeys: KeyId[];
@@ -172,6 +175,7 @@ export class AgentTranscriptViewer implements Component {
 			cwd: deps.cwd,
 			hideThinkingBlock: deps.hideThinkingBlock,
 			proseOnlyThinking: deps.proseOnlyThinking,
+			layout: deps.layout,
 			requestRender: deps.requestRender,
 		});
 		this.#scrollView = new ScrollView([], {

--- a/packages/coding-agent/src/modes/components/chat-transcript-builder.ts
+++ b/packages/coding-agent/src/modes/components/chat-transcript-builder.ts
@@ -29,6 +29,7 @@ import {
 } from "../../session/messages";
 import type { SessionMessageEntry } from "../../session/session-entries";
 import { theme } from "../theme/theme";
+import type { LayoutMode } from "../layout-mode";
 import {
 	assistantHasVisibleContent,
 	assistantUsageIsBilled,
@@ -62,6 +63,8 @@ import { createUsageRowBlock, turnElapsedMs } from "./usage-row";
 import { CollapsedSyntheticMessageComponent, UserMessageComponent } from "./user-message";
 
 export interface ChatTranscriptBuilderDeps {
+	/** Owning mode's transcript layout accessor; omitted surfaces render the default omp look. */
+	layout?: () => LayoutMode;
 	ui: TUI;
 	getTool?: (name: string) => AgentTool | undefined;
 	/** Whether the active registry entry came from a built-in factory. */
@@ -218,6 +221,7 @@ export class ChatTranscriptBuilder {
 		if (!this.#readGroup) {
 			this.#readGroup = new ReadToolGroupComponent({
 				showContentPreview: settings.get("read.toolResultPreview"),
+				layout: this.deps.layout,
 			});
 			this.#trackExpandable(this.#readGroup);
 			this.container.addChild(this.#readGroup);
@@ -305,11 +309,11 @@ export class ChatTranscriptBuilder {
 					// collapse them behind a compact summary that builds Markdown only on
 					// ctrl+o expand. Real user prompts stay fully rendered.
 					if (isSynthetic) {
-						const collapsed = new CollapsedSyntheticMessageComponent(textContent);
+						const collapsed = new CollapsedSyntheticMessageComponent(textContent, undefined, this.deps.layout);
 						this.#trackExpandable(collapsed);
 						this.container.addChild(collapsed);
 					} else {
-						this.container.addChild(new UserMessageComponent(textContent, false));
+						this.container.addChild(new UserMessageComponent(textContent, false, undefined, this.deps.layout));
 					}
 				}
 				break;
@@ -456,6 +460,7 @@ export class ChatTranscriptBuilder {
 					showImages: settings.get("terminal.showImages"),
 					editFuzzyThreshold: settings.get("edit.fuzzyThreshold"),
 					editAllowFuzzy: settings.get("edit.fuzzyMatch"),
+					layout: this.deps.layout,
 				},
 				this.deps.getTool?.(content.name),
 				this.deps.ui,

--- a/packages/coding-agent/src/modes/components/copy-selector.ts
+++ b/packages/coding-agent/src/modes/components/copy-selector.ts
@@ -21,6 +21,7 @@ import {
 import type { MessageRenderer } from "../../extensibility/extensions/types";
 import type { SessionMessageEntry } from "../../session/session-entries";
 import { replaceTabs } from "../../tools/render-utils";
+import type { LayoutMode } from "../layout-mode";
 import { highlightCode, type ThemeColor, theme } from "../theme/theme";
 import { commandFromToolCall, extractBlocks } from "../utils/copy-targets";
 import {
@@ -42,6 +43,8 @@ import {
 } from "./transcript-outline";
 
 export interface CopySelectorDeps {
+	/** Owning mode's transcript layout accessor (replicated transcript matches the live one). */
+	layout?: () => LayoutMode;
 	ui: TUI;
 	getTool?: (name: string) => AgentTool | undefined;
 	/** Whether the active registry entry came from a built-in factory. */
@@ -100,6 +103,7 @@ export class CopySelectorComponent implements Component {
 			hideThinkingBlock: deps.hideThinkingBlock,
 			proseOnlyThinking: deps.proseOnlyThinking,
 			requestRender: deps.requestRender,
+			layout: deps.layout,
 		});
 		this.#targets = appendOutlineEntries(this.#builder, entries);
 		this.#selected = Math.max(0, this.#targets.length - 1);

--- a/packages/coding-agent/src/modes/components/read-tool-group.ts
+++ b/packages/coding-agent/src/modes/components/read-tool-group.ts
@@ -1,3 +1,4 @@
+import { stripVTControlCharacters } from "node:util";
 import * as path from "node:path";
 import type { AssistantMessage, Usage } from "@oh-my-pi/pi-ai";
 import type { Component } from "@oh-my-pi/pi-tui";
@@ -543,6 +544,26 @@ export class ReadToolGroupComponent extends Container implements ToolExecutionHa
 		// Clear previous children and rebuild the summary and preview blocks.
 		this.clear();
 		this.#text = new Text("", 0, 0);
+
+		// Opencode layout (collapsed): every read renders as its own flat dim
+		// `→ Read path` row — no group header, tree connectors, usage rows, or
+		// previews. Errors keep their status mark so failures stay visible.
+		// Ctrl+O (`setExpanded`) restores the full grouped view.
+		if (isOpencodeLayout() && !this.#expanded && displayRows.length > 0) {
+			const flat: string[] = [];
+			for (const row of displayRows) {
+				const status = this.#statusForTargets(row.targets);
+				const pathText = stripVTControlCharacters(this.#formatRowPath(row));
+				flat.push(
+					status === "error" || status === "warning"
+						? ` ${this.#formatStatus(status)} ${theme.fg("dim", `Read ${pathText}`)}`
+						: theme.fg("dim", ` → Read ${pathText}`),
+				);
+			}
+			this.#text.setText(flat.join("\n"));
+			this.addChild(this.#text);
+			return;
+		}
 
 		if (displayRows.length === 0) {
 			this.#text.setText(` ${theme.format.bullet} ${theme.fg("toolTitle", theme.bold("Read"))}`);

--- a/packages/coding-agent/src/modes/components/read-tool-group.ts
+++ b/packages/coding-agent/src/modes/components/read-tool-group.ts
@@ -547,20 +547,23 @@ export class ReadToolGroupComponent extends Container implements ToolExecutionHa
 
 		// Opencode layout (collapsed): every read renders as its own flat dim
 		// `→ Read path` row — no group header, tree connectors, usage rows, or
-		// previews. Errors keep their status mark so failures stay visible.
-		// Ctrl+O (`setExpanded`) restores the full grouped view.
-		if (isOpencodeLayout() && !this.#expanded && displayRows.length > 0) {
+		// previews. Non-success statuses (pending, warning, error) keep their
+		// status mark so liveness and failures stay visible, and rows keep their
+		// OSC-8 file hyperlink. Ctrl+O (`setExpanded`) restores the grouped view.
+		if (isOpencodeLayout() && !this.#expanded) {
 			const flat: string[] = [];
 			for (const row of displayRows) {
 				const status = this.#statusForTargets(row.targets);
-				const pathText = stripVTControlCharacters(this.#formatRowPath(row));
+				const plain = stripVTControlCharacters(this.#formatRowPath(row));
+				const linkPath = row.targets[0]?.linkPath;
+				const pathText = linkPath ? fileHyperlink(linkPath, plain) : plain;
 				flat.push(
-					status === "error" || status === "warning"
-						? ` ${this.#formatStatus(status)} ${theme.fg("dim", `Read ${pathText}`)}`
-						: theme.fg("dim", ` → Read ${pathText}`),
+					status === "success"
+						? theme.fg("dim", ` → Read ${pathText}`)
+						: ` ${this.#formatStatus(status)} ${theme.fg("dim", `Read ${pathText}`)}`,
 				);
 			}
-			this.#text.setText(flat.join("\n"));
+			this.#text.setText(flat.length > 0 ? flat.join("\n") : theme.fg("dim", " → Read"));
 			this.addChild(this.#text);
 			return;
 		}

--- a/packages/coding-agent/src/modes/components/read-tool-group.ts
+++ b/packages/coding-agent/src/modes/components/read-tool-group.ts
@@ -598,7 +598,7 @@ export class ReadToolGroupComponent extends Container implements ToolExecutionHa
 					: plain;
 				flatRows.push(
 					status === "success"
-						? theme.fg("dim", ` → Read ${pathText}`)
+						? theme.fg("dim", ` ${theme.symbol("oc.read")} Read ${pathText}`)
 						: ` ${this.#formatStatus(status)} ${theme.fg("dim", `Read ${pathText}`)}`,
 				);
 				if (status !== "error") continue;
@@ -612,7 +612,7 @@ export class ReadToolGroupComponent extends Container implements ToolExecutionHa
 				}
 			}
 			if (flatRows.length === 0 && this.children.length === 0) {
-				flatRows.push(theme.fg("dim", " → Read"));
+				flatRows.push(theme.fg("dim", ` ${theme.symbol("oc.read")} Read`));
 			}
 			flushFlatRows();
 			return;

--- a/packages/coding-agent/src/modes/components/read-tool-group.ts
+++ b/packages/coding-agent/src/modes/components/read-tool-group.ts
@@ -8,6 +8,7 @@ import { parseLineRanges, selectorLineRanges, splitPathAndSel } from "../../tool
 import { PREVIEW_LIMITS, shortenPath } from "../../tools/render-utils";
 import { fileHyperlink, renderCodeCell, tryResolveInternalUrlSync } from "../../tui";
 import { canonicalizeMessage } from "../../utils/thinking-display";
+import { isOpencodeLayout } from "../layout-mode";
 import type { ToolExecutionHandle } from "./tool-execution";
 import { formatUsageRow } from "./usage-row";
 
@@ -871,6 +872,9 @@ export class ReadToolGroupComponent extends Container implements ToolExecutionHa
 	}
 
 	#shouldRenderPreview(entry: ReadEntry): boolean {
+		// Opencode layout: no framed content-preview boxes while collapsed — the
+		// group stays a flat list of one-line reads (Ctrl+O restores previews).
+		if (isOpencodeLayout() && !this.#expanded) return false;
 		return this.#showContentPreview && entry.contentText !== undefined;
 	}
 

--- a/packages/coding-agent/src/modes/components/read-tool-group.ts
+++ b/packages/coding-agent/src/modes/components/read-tool-group.ts
@@ -6,10 +6,10 @@ import { Container, Text } from "@oh-my-pi/pi-tui";
 import { InternalUrlRouter, XD_URL_PREFIX } from "../../internal-urls";
 import { getLanguageFromPath, theme } from "../../modes/theme/theme";
 import { parseLineRanges, selectorLineRanges, splitPathAndSel } from "../../tools/path-utils";
-import { PREVIEW_LIMITS, shortenPath } from "../../tools/render-utils";
-import { fileHyperlink, renderCodeCell, tryResolveInternalUrlSync } from "../../tui";
+import { PREVIEW_LIMITS, replaceTabs, shortenPath } from "../../tools/render-utils";
+import { fileHyperlink, renderCodeCell, tryResolveInternalUrlSync, truncateToWidth } from "../../tui";
 import { canonicalizeMessage } from "../../utils/thinking-display";
-import { isOpencodeLayout } from "../layout-mode";
+import type { LayoutMode } from "../layout-mode";
 import type { ToolExecutionHandle } from "./tool-execution";
 import { formatUsageRow } from "./usage-row";
 
@@ -104,6 +104,8 @@ type ReadToolResultDetails = {
 
 type ReadToolGroupOptions = {
 	showContentPreview?: boolean;
+	/** Owning mode's transcript layout; captured at construction (per-instance, never global). */
+	layout?: () => LayoutMode;
 };
 
 function getSuffixResolution(details: ReadToolResultDetails | undefined): ReadToolSuffixResolution | undefined {
@@ -337,6 +339,8 @@ export class ReadToolGroupComponent extends Container implements ToolExecutionHa
 	#expanded = false;
 	#toolActivityVisible = true;
 	#showContentPreview: boolean;
+	/** Owning mode's transcript layout accessor (per-instance, never global). */
+	#layout: (() => LayoutMode) | undefined;
 	// A read group accretes entries across multiple assistant completions for as
 	// long as the run of reads is uninterrupted. It remains active while its
 	// header can change from `Read <path>` to `Read (N)` plus a tree. The
@@ -355,9 +359,15 @@ export class ReadToolGroupComponent extends Container implements ToolExecutionHa
 	constructor(options: ReadToolGroupOptions = {}) {
 		super();
 		this.#showContentPreview = options.showContentPreview ?? false;
+		this.#layout = options.layout;
 		this.#text = new Text("", 0, 0);
 		this.addChild(this.#text);
 		this.#updateDisplay();
+	}
+
+	/** Flat opencode layout, resolved through the owning mode's accessor. */
+	#isFlat(): boolean {
+		return this.#layout?.() === "opencode";
 	}
 
 	override render(width: number): readonly string[] {
@@ -546,25 +556,65 @@ export class ReadToolGroupComponent extends Container implements ToolExecutionHa
 		this.#text = new Text("", 0, 0);
 
 		// Opencode layout (collapsed): every read renders as its own flat dim
-		// `→ Read path` row — no group header, tree connectors, usage rows, or
-		// previews. Non-success statuses (pending, warning, error) keep their
-		// status mark so liveness and failures stay visible, and rows keep their
-		// OSC-8 file hyperlink. Ctrl+O (`setExpanded`) restores the grouped view.
-		if (isOpencodeLayout() && !this.#expanded) {
-			const flat: string[] = [];
+		// `→ Read path` row (no group header, tree connectors, usage rows, or
+		// previews). Non-success statuses (pending, warning, error) keep their
+		// status mark so liveness stays visible, and rows keep their OSC-8 file
+		// hyperlink with its first selector line target. Error rows additionally
+		// keep their full content preview below the mark row: the entry's
+		// contentText is the actionable error message, and a one-line row would
+		// hide it (same "errors stay full-size" contract as tool cards).
+		// Ctrl+O (`setExpanded`) restores the grouped view.
+		if (this.#isFlat() && !this.#expanded) {
+			let flatRows: string[] = [];
+			const flushFlatRows = () => {
+				if (flatRows.length === 0) return;
+				// Rows carry hyperlinks/styling and arbitrary path text, so bound
+				// them to the render width (one advertised line per read) via a
+				// width-aware child instead of a plain Text that would wrap.
+				const rows = flatRows;
+				flatRows = [];
+				let cachedWidth: number | undefined;
+				let cachedLines: string[] | undefined;
+				this.addChild({
+					render: (width: number) => {
+						if (cachedLines && cachedWidth === width) return cachedLines;
+						cachedWidth = width;
+						cachedLines = rows.map(row => truncateToWidth(row, Math.max(1, width)));
+						return cachedLines;
+					},
+					invalidate: () => {
+						cachedWidth = undefined;
+						cachedLines = undefined;
+					},
+				});
+			};
 			for (const row of displayRows) {
 				const status = this.#statusForTargets(row.targets);
-				const plain = stripVTControlCharacters(this.#formatRowPath(row));
-				const linkPath = row.targets[0]?.linkPath;
-				const pathText = linkPath ? fileHyperlink(linkPath, plain) : plain;
-				flat.push(
+				const plain = replaceTabs(stripVTControlCharacters(this.#formatRowPath(row)));
+				const linkPath = linkPathForTargets(row.targets);
+				const line = firstSelectorLineForTargets(row.targets);
+				const pathText = linkPath
+					? fileHyperlink(linkPath, plain, line !== undefined ? { line } : undefined)
+					: plain;
+				flatRows.push(
 					status === "success"
 						? theme.fg("dim", ` → Read ${pathText}`)
 						: ` ${this.#formatStatus(status)} ${theme.fg("dim", `Read ${pathText}`)}`,
 				);
+				if (status !== "error") continue;
+				flushFlatRows();
+				const seen = new Set<string>();
+				for (const target of row.targets) {
+					const entry = target.entry;
+					if (entry.status !== "error" || entry.contentText === undefined || seen.has(entry.toolCallId)) continue;
+					seen.add(entry.toolCallId);
+					this.#addContentPreview(entry);
+				}
 			}
-			this.#text.setText(flat.length > 0 ? flat.join("\n") : theme.fg("dim", " → Read"));
-			this.addChild(this.#text);
+			if (flatRows.length === 0 && this.children.length === 0) {
+				flatRows.push(theme.fg("dim", " → Read"));
+			}
+			flushFlatRows();
 			return;
 		}
 
@@ -846,6 +896,7 @@ export class ReadToolGroupComponent extends Container implements ToolExecutionHa
 		let cachedWidth: number | undefined;
 		let cachedLines: string[] | undefined;
 		const expanded = this.#expanded;
+		const flat = this.#isFlat();
 		const component: Component = {
 			render: (width: number) => {
 				if (cachedLines && cachedWidth === width) return cachedLines;
@@ -860,6 +911,7 @@ export class ReadToolGroupComponent extends Container implements ToolExecutionHa
 						codeStartLine: entry.codeStartLine,
 						codeLineNumbers: entry.codeLineNumbers,
 						width,
+						flat,
 					},
 					theme,
 				);
@@ -898,7 +950,8 @@ export class ReadToolGroupComponent extends Container implements ToolExecutionHa
 	#shouldRenderPreview(entry: ReadEntry): boolean {
 		// Opencode layout: no framed content-preview boxes while collapsed — the
 		// group stays a flat list of one-line reads (Ctrl+O restores previews).
-		if (isOpencodeLayout() && !this.#expanded) return false;
+		// Error entries bypass this in #updateDisplay's flat branch directly.
+		if (this.#isFlat() && !this.#expanded) return false;
 		return this.#showContentPreview && entry.contentText !== undefined;
 	}
 

--- a/packages/coding-agent/src/modes/components/rewind-selector.ts
+++ b/packages/coding-agent/src/modes/components/rewind-selector.ts
@@ -35,6 +35,7 @@ import {
 } from "@oh-my-pi/pi-tui";
 import type { MessageRenderer } from "../../extensibility/extensions/types";
 import type { SessionMessageEntry } from "../../session/session-entries";
+import type { LayoutMode } from "../layout-mode";
 import { theme } from "../theme/theme";
 import {
 	matchesAppToolsExpand,
@@ -64,6 +65,8 @@ export interface BranchVariantPath {
 }
 
 export interface RewindSelectorDeps {
+	/** Owning mode's transcript layout accessor (replicated transcript matches the live one). */
+	layout?: () => LayoutMode;
 	ui: TUI;
 	getTool?: (name: string) => AgentTool | undefined;
 	/** Whether the active registry entry came from a built-in factory. */
@@ -149,6 +152,7 @@ export class RewindSelectorComponent implements Component {
 			hideThinkingBlock: this.deps.hideThinkingBlock,
 			proseOnlyThinking: this.deps.proseOnlyThinking,
 			requestRender: this.deps.requestRender,
+			layout: this.deps.layout,
 		});
 	}
 

--- a/packages/coding-agent/src/modes/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/components/tool-execution.ts
@@ -34,6 +34,7 @@ import type { XdevState } from "../../tools/xdev";
 import { isFramedBlockComponent, markFramedBlockComponent, renderStatusLine, WidthAwareText } from "../../tui";
 import { convertImageToPng } from "../../utils/image-loading";
 import { sanitizeWithOptionalSixelPassthrough } from "../../utils/sixel";
+import { isOpencodeLayout } from "../layout-mode";
 import { renderDiff } from "./diff";
 import { type AnimationFrame, trimBlankEdges } from "./transcript-container";
 
@@ -429,6 +430,12 @@ export class ToolExecutionComponent extends Container {
 	// the terminal never triggers an unnecessary full-viewport replay.
 	#firstResultViewportRepaintShapePainted = false;
 	#partialResultShapePainted = false;
+	// Memoized opencode-layout collapse: the derived single-line slice keyed on
+	// the underlying container render (same source ref => identical rows =>
+	// reuse), mirroring UserMessageComponent's OSC-zone memo so this component
+	// stays reference-stable for the transcript's incremental assembly.
+	#collapsedSource: readonly string[] | undefined;
+	#collapsedLines: readonly string[] | undefined;
 	#renderState: {
 		spinnerFrame?: number;
 		expanded: boolean;
@@ -971,7 +978,7 @@ export class ToolExecutionComponent extends Container {
 		// TUI startup, so a result rendered before it lands must re-shape once it
 		// does (it gates Image children vs text fallback in #rebuildDisplay); keyed
 		// here for the same reason markdown.ts keys its render cache on it.
-		const key = `${this.#resultVersion}|${this.#expanded}|${this.#isPartial}|${this.#argsComplete ? "1" : "0"}|${this.#executionStarted ? "1" : "0"}|${this.#spinnerFrame ?? "-"}|${this.#showImages}|${getThemeEpoch()}|${this.#displayInputVersion}|${TERMINAL.imageProtocol ?? "-"}|${this.#imageSizeKey()}`;
+		const key = `${this.#resultVersion}|${this.#expanded}|${this.#isPartial}|${this.#argsComplete ? "1" : "0"}|${this.#executionStarted ? "1" : "0"}|${this.#spinnerFrame ?? "-"}|${this.#showImages}|${getThemeEpoch()}|${this.#displayInputVersion}|${TERMINAL.imageProtocol ?? "-"}|${this.#imageSizeKey()}|${isOpencodeLayout() ? "oc" : "omp"}`;
 		if (key === this.#lastDisplayKey && this.#displayBuilt) return;
 		this.#lastDisplayKey = key;
 
@@ -1028,7 +1035,23 @@ export class ToolExecutionComponent extends Container {
 		}
 		this.#firstResultViewportRepaintShapePainted = this.#needsFirstResultViewportRepaintAtRender();
 		this.#partialResultShapePainted = this.#result !== undefined && this.#isPartial;
-		return lines;
+		// Opencode layout: a collapsed tool block renders as its status line only
+		// (renderOutputBlock draws flat in this mode, so the first visible row is
+		// the header even for self-framing renderers). Errors stay full-size —
+		// a one-line error hides the message the user needs — and Ctrl+O
+		// (`setExpanded`) restores the complete card.
+		const collapse = isOpencodeLayout() && !this.#expanded && !(this.#result?.isError && !this.#isBenignSkip());
+		if (!collapse) return lines;
+		if (this.#collapsedSource === lines && this.#collapsedLines !== undefined) {
+			return this.#collapsedLines;
+		}
+		// First row with visible content — the status one-liner every renderer
+		// emits first (rows above it are paddingY blanks, which carry no ANSI in
+		// this mode because the state bg is disabled).
+		const first = lines.find(line => /\S/.test(line));
+		this.#collapsedSource = lines;
+		this.#collapsedLines = first === undefined ? [] : [first];
+		return this.#collapsedLines;
 	}
 
 	#renderCompact(width: number): readonly string[] {
@@ -1111,7 +1134,7 @@ export class ToolExecutionComponent extends Container {
 		const benignSkip = this.#isBenignSkip();
 		const stateBgKey =
 			this.#isPartial || benignSkip ? "toolPendingBg" : this.#result?.isError ? "toolErrorBg" : "toolSuccessBg";
-		const stateBgFn = (t: string) => theme.bg(stateBgKey, t);
+		const stateBgFn = isOpencodeLayout() ? undefined : (t: string) => theme.bg(stateBgKey, t);
 
 		// A benign skip is a synthetic placeholder for a call that never executed,
 		// so bypass any bespoke error frame and draw the neutral generic card —
@@ -1548,7 +1571,7 @@ export class ToolExecutionComponent extends Container {
 	 * only need the neutral tint. Bespoke-renderer tools get their content box
 	 * swapped for the same neutral card.
 	 */
-	#renderBenignSkipCard(stateBgFn: (text: string) => string): void {
+	#renderBenignSkipCard(stateBgFn: ((text: string) => string) | undefined): void {
 		if (!this.#usesContentBox) {
 			this.#contentText.setCustomBgFn(stateBgFn);
 			this.#contentText.invalidate();

--- a/packages/coding-agent/src/modes/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/components/tool-execution.ts
@@ -517,7 +517,7 @@ export class ToolExecutionComponent extends Container {
 	// the terminal never triggers an unnecessary full-viewport replay.
 	#firstResultViewportRepaintShapePainted = false;
 	#partialResultShapePainted = false;
-	// Memoized opencode-layout collapse: the derived single-line slice keyed on
+	// Memoized opencode-layout collapse: the derived status-row slice keyed on
 	// the underlying container render (same source ref => identical rows =>
 	// reuse), mirroring UserMessageComponent's OSC-zone memo so this component
 	// stays reference-stable for the transcript's incremental assembly.
@@ -1146,21 +1146,29 @@ export class ToolExecutionComponent extends Container {
 		// live calls keep their native styling (spinner/accent) so activity
 		// stays legible, matching opencode's emphasized in-flight rows.
 		if (this.#result !== undefined && !this.#isPartial && !this.#result.isError) {
-			// Tabs are legal in filenames and custom status details; normalize
-			// them before measuring so the advertised single row truncates
-			// predictably instead of wrapping or leaving visual holes.
-			let plain = replaceTabs(stripVTControlCharacters(first)).trim();
-			if (this.#renderer !== undefined && !this.#tool?.renderCall && !this.#tool?.renderResult) {
-				plain = plain.replace(headerIconStrip(), "");
-			}
+			const headers = this.#multiFileBoxes.flatMap(box => {
+				if (!(box instanceof Box)) return [];
+				const header = box.render(width).find(line => /\S/.test(line));
+				return header === undefined ? [] : [header];
+			});
+			const sourceRows = headers.length > 1 ? headers : [first];
 			const glyph = theme.symbol(OPENCODE_TOOL_GLYPHS[this.#toolName] ?? "oc.search");
-			const row = ` ${glyph} ${plain}`;
-			this.#collapsedLines = [
-				theme.fg(
+			const collapsedRows = sourceRows.slice(0, 8).map(source => {
+				// Tabs are legal in filenames and custom status details; normalize
+				// them before measuring so the advertised single row truncates
+				// predictably instead of wrapping or leaving visual holes.
+				let plain = replaceTabs(stripVTControlCharacters(source)).trim();
+				if (this.#renderer !== undefined && !this.#tool?.renderCall && !this.#tool?.renderResult) {
+					plain = plain.replace(headerIconStrip(), "");
+				}
+				const row = ` ${glyph} ${plain}`;
+				return theme.fg(
 					"dim",
-					restoreHyperlinks(truncateToWidth(row.replace(OSC8_LINK_REGEX, "$2"), Math.max(1, width)), first),
-				),
-			];
+					restoreHyperlinks(truncateToWidth(row.replace(OSC8_LINK_REGEX, "$2"), Math.max(1, width)), source),
+				);
+			});
+			if (sourceRows.length > 8) collapsedRows.push(theme.fg("dim", ` ... +${sourceRows.length - 8} more`));
+			this.#collapsedLines = collapsedRows;
 		} else {
 			this.#collapsedLines = [
 				restoreHyperlinks(

--- a/packages/coding-agent/src/modes/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/components/tool-execution.ts
@@ -35,7 +35,7 @@ import type { XdevState } from "../../tools/xdev";
 import { isFramedBlockComponent, markFramedBlockComponent, renderStatusLine, WidthAwareText } from "../../tui";
 import { convertImageToPng } from "../../utils/image-loading";
 import { sanitizeWithOptionalSixelPassthrough } from "../../utils/sixel";
-import { isOpencodeLayout } from "../layout-mode";
+import type { LayoutMode } from "../layout-mode";
 
 import { renderDiff } from "./diff";
 import { type AnimationFrame, trimBlankEdges } from "./transcript-container";
@@ -259,6 +259,8 @@ export interface ToolExecutionOptions {
 	useBuiltInRenderer?: boolean;
 	editFuzzyThreshold?: number;
 	editAllowFuzzy?: boolean;
+	/** Owning mode's transcript layout; captured at construction (per-instance, never global). */
+	layout?: () => LayoutMode;
 }
 
 export interface ToolExecutionHandle extends Component {
@@ -371,6 +373,7 @@ export class ToolExecutionComponent extends Container {
 	#showImages: boolean;
 	#editFuzzyThreshold: number | undefined;
 	#editAllowFuzzy: boolean | undefined;
+	#layout: (() => LayoutMode) | undefined;
 	#snapshots?: SnapshotStore;
 	#clipboard?: Clipboard;
 	#isPartial = true;
@@ -484,6 +487,7 @@ export class ToolExecutionComponent extends Container {
 		this.#showImages = options.showImages ?? true;
 		this.#editFuzzyThreshold = options.editFuzzyThreshold;
 		this.#editAllowFuzzy = options.editAllowFuzzy;
+		this.#layout = options.layout;
 		this.#snapshots = options.snapshots;
 		this.#clipboard = options.clipboard;
 		this.#tool = tool;
@@ -996,7 +1000,7 @@ export class ToolExecutionComponent extends Container {
 		// TUI startup, so a result rendered before it lands must re-shape once it
 		// does (it gates Image children vs text fallback in #rebuildDisplay); keyed
 		// here for the same reason markdown.ts keys its render cache on it.
-		const key = `${this.#resultVersion}|${this.#expanded}|${this.#isPartial}|${this.#argsComplete ? "1" : "0"}|${this.#executionStarted ? "1" : "0"}|${this.#spinnerFrame ?? "-"}|${this.#showImages}|${getThemeEpoch()}|${this.#displayInputVersion}|${TERMINAL.imageProtocol ?? "-"}|${this.#imageSizeKey()}|${isOpencodeLayout() ? "oc" : "omp"}`;
+		const key = `${this.#resultVersion}|${this.#expanded}|${this.#isPartial}|${this.#argsComplete ? "1" : "0"}|${this.#executionStarted ? "1" : "0"}|${this.#spinnerFrame ?? "-"}|${this.#showImages}|${getThemeEpoch()}|${this.#displayInputVersion}|${TERMINAL.imageProtocol ?? "-"}|${this.#imageSizeKey()}|${this.#isFlat() ? "oc" : "omp"}`;
 		if (key === this.#lastDisplayKey && this.#displayBuilt) return;
 		this.#lastDisplayKey = key;
 
@@ -1058,7 +1062,7 @@ export class ToolExecutionComponent extends Container {
 		// the header even for self-framing renderers). Errors stay full-size —
 		// a one-line error hides the message the user needs — and Ctrl+O
 		// (`setExpanded`) restores the complete card.
-		const collapse = isOpencodeLayout() && !this.#expanded && !(this.#result?.isError && !this.#isBenignSkip());
+		const collapse = this.#isFlat() && !this.#expanded && !(this.#result?.isError && !this.#isBenignSkip());
 		if (!collapse) return lines;
 		if (this.#collapsedSource === lines && this.#collapsedLines !== undefined) {
 			return this.#collapsedLines;
@@ -1105,7 +1109,7 @@ export class ToolExecutionComponent extends Container {
 		);
 		// Opencode layout stays flat even under viewport squeeze: the 2-row
 		// `╭─`/`╰` frame is the omp look, so always use the one-line form there.
-		if (this.#allocation === 1 || isOpencodeLayout()) {
+		if (this.#allocation === 1 || this.#isFlat()) {
 			const glyph = this.#spinnerFrame === undefined ? "•" : (theme.spinnerFrames[this.#spinnerFrame] ?? "•");
 			const styledGlyph = theme.fg(this.#spinnerFrame === undefined ? "dim" : "muted", glyph);
 			return [truncateToWidth(`${styledGlyph} ${text}`, width)];
@@ -1169,7 +1173,7 @@ export class ToolExecutionComponent extends Container {
 		const benignSkip = this.#isBenignSkip();
 		const stateBgKey =
 			this.#isPartial || benignSkip ? "toolPendingBg" : this.#result?.isError ? "toolErrorBg" : "toolSuccessBg";
-		const stateBgFn = isOpencodeLayout() ? undefined : (t: string) => theme.bg(stateBgKey, t);
+		const stateBgFn = this.#isFlat() ? undefined : (t: string) => theme.bg(stateBgKey, t);
 
 		// A benign skip is a synthetic placeholder for a call that never executed,
 		// so bypass any bespoke error frame and draw the neutral generic card —
@@ -1473,11 +1477,18 @@ export class ToolExecutionComponent extends Container {
 		return { ...(renderArgs as Record<string, unknown>), previewDiff: first.diff };
 	}
 
+	/** Flat opencode layout, resolved through the owning mode's accessor. */
+	#isFlat(): boolean {
+		return this.#layout?.() === "opencode";
+	}
 	/**
 	 * Build render context for tools that need extra state (bash, python, edit)
 	 */
 	#buildRenderContext(): Record<string, unknown> {
 		const context: Record<string, unknown> = {};
+		// Every framed renderer folds this into its `renderOutputBlock` options —
+		// the flat/framed choice must come from the owning mode, never a global.
+		context.flat = this.#isFlat();
 		const normalizeTimeoutSeconds = (value: unknown, maxSeconds: number): number | undefined => {
 			if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
 			return Math.max(1, Math.min(maxSeconds, value));

--- a/packages/coding-agent/src/modes/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/components/tool-execution.ts
@@ -1103,7 +1103,9 @@ export class ToolExecutionComponent extends Container {
 			`${theme.fg("toolTitle", theme.bold(summary.label))}${detail}${elapsed}`,
 			Math.max(1, width - 4),
 		);
-		if (this.#allocation === 1) {
+		// Opencode layout stays flat even under viewport squeeze: the 2-row
+		// `╭─`/`╰` frame is the omp look, so always use the one-line form there.
+		if (this.#allocation === 1 || isOpencodeLayout()) {
 			const glyph = this.#spinnerFrame === undefined ? "•" : (theme.spinnerFrames[this.#spinnerFrame] ?? "•");
 			const styledGlyph = theme.fg(this.#spinnerFrame === undefined ? "dim" : "muted", glyph);
 			return [truncateToWidth(`${styledGlyph} ${text}`, width)];

--- a/packages/coding-agent/src/modes/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/components/tool-execution.ts
@@ -17,6 +17,7 @@ import {
 } from "@oh-my-pi/pi-tui";
 import { getProjectDir, isRecord, logger, sanitizeText } from "@oh-my-pi/pi-utils";
 import { EDIT_MODE_STRATEGIES, type EditMode, type PerFileDiffPreview } from "../../edit";
+import { hasTaskResultError } from "../../task/render";
 import type { SymbolKey, Theme } from "../../modes/theme/theme";
 import { SYMBOL_PRESETS } from "../../modes/theme/symbols";
 import { getThemeEpoch, theme } from "../../modes/theme/theme";
@@ -89,6 +90,7 @@ function headerIconStrip(): RegExp {
 // OSC 8 hyperlink span: `ESC ] 8 ; params ; uri (BEL|ST) text ESC ] 8 ; ; (BEL|ST)`.
 // The opener requires a non-empty URI so a stray closer can never match.
 const OSC8_LINK_REGEX = /(\x1b\]8;[^;\x07\x1b]*;[^\x07\x1b]+(?:\x07|\x1b\\))([\s\S]*?)(\x1b\]8;;(?:\x07|\x1b\\))/g;
+const OSC8_OPEN_REGEX = /\x1b]8;[^;\x07\x1b]*;[^\x07\x1b]+(?:\x07|\x1b\\)/g;
 
 /**
  * Re-attach every OSC-8 hyperlink from `source` (the renderer's fully styled
@@ -115,9 +117,49 @@ function restoreHyperlinks(row: string, source: string): string {
 			at = out.indexOf(linkedPlain, from);
 			matched = linkedPlain;
 		}
+		if (at === -1) {
+			const linkedPrefix = linkedPlain.endsWith("…") ? linkedPlain.slice(0, -1) : linkedPlain;
+			const prefix = linkedPrefix.slice(0, 3);
+			for (
+				let candidate = out.indexOf(prefix, from);
+				candidate !== -1;
+				candidate = out.indexOf(prefix, candidate + 1)
+			) {
+				let length = 3;
+				while (length < linkedPrefix.length && out[candidate + length] === linkedPrefix[length]) length++;
+				if (out.startsWith("…", candidate + length)) {
+					at = candidate;
+					matched = linkedPrefix.slice(0, length);
+					break;
+				}
+			}
+		}
 		if (at === -1) continue;
 		out = `${out.slice(0, at)}${opener}${matched}${closer}${out.slice(at + matched.length)}`;
 		from = at + opener!.length + matched.length + closer!.length;
+	}
+	// renderOutputBlock may itself truncate a flat header, leaving the OSC-8
+	// opener and a clipped label without its closer. Reuse that surviving target
+	// around its visible prefix rather than dropping the link entirely.
+	for (const openerMatch of source.matchAll(OSC8_OPEN_REGEX)) {
+		const opener = openerMatch[0];
+		const remaining = source.slice(openerMatch.index! + opener.length);
+		if (remaining.includes("\x1b]8;;")) continue;
+		const linkedPlain = stripVTControlCharacters(remaining);
+		const ellipsis = linkedPlain.indexOf("…");
+		const linkedPrefix = (ellipsis === -1 ? linkedPlain : linkedPlain.slice(0, ellipsis)).trimEnd();
+		const prefix = linkedPrefix.slice(0, 3);
+		if (prefix.length < 3) continue;
+		for (let at = out.indexOf(prefix, from); at !== -1; at = out.indexOf(prefix, at + 1)) {
+			let length = 3;
+			while (length < linkedPrefix.length && out[at + length] === linkedPrefix[length]) length++;
+			if (!out.startsWith("…", at + length)) continue;
+			const matched = linkedPrefix.slice(0, length);
+			const closer = "\x1b]8;;\x07";
+			out = `${out.slice(0, at)}${opener}${matched}${closer}${out.slice(at + matched.length)}`;
+			from = at + opener.length + matched.length + closer.length;
+			break;
+		}
 	}
 	return out;
 }
@@ -1107,6 +1149,16 @@ export class ToolExecutionComponent extends Container {
 			this.#ui.requestRender();
 		}
 	}
+	/**
+	 * The custom-tool branch wins when a tool exposes renderer callbacks. A
+	 * built-in such as TaskTool legitimately does so, but delegates its result
+	 * renderer to the registry. Only that case owns the built-in status icon.
+	 */
+	#usesBuiltInResultRenderer(): boolean {
+		if (!this.#renderer) return false;
+		if (!this.#tool?.renderCall && !this.#tool?.renderResult) return true;
+		return this.#tool?.renderResult === this.#renderer.renderResult;
+	}
 
 	override render(width: number): readonly string[] {
 		if (!this.#toolActivityVisible || this.#allocation === 0) return [];
@@ -1128,7 +1180,9 @@ export class ToolExecutionComponent extends Container {
 		// the header even for self-framing renderers). Errors stay full-size —
 		// a one-line error hides the message the user needs — and Ctrl+O
 		// (`setExpanded`) restores the complete card.
-		const collapse = this.#isFlat() && !this.#expanded && !(this.#result?.isError && !this.#isBenignSkip());
+		const taskResultError = this.#toolName === "task" && hasTaskResultError(this.#result?.details);
+		const resultIsError = this.#result?.isError === true || taskResultError;
+		const collapse = this.#isFlat() && !this.#expanded && !(resultIsError && !this.#isBenignSkip());
 		if (!collapse) return lines;
 		if (this.#collapsedSource === lines && this.#collapsedLines !== undefined) {
 			return this.#collapsedLines;
@@ -1145,7 +1199,7 @@ export class ToolExecutionComponent extends Container {
 		// Settled success restyles to opencode's dim `<glyph> Tool detail` row;
 		// live calls keep their native styling (spinner/accent) so activity
 		// stays legible, matching opencode's emphasized in-flight rows.
-		if (this.#result !== undefined && !this.#isPartial && !this.#result.isError) {
+		if (this.#result !== undefined && !this.#isPartial && !resultIsError) {
 			const headers = this.#multiFileBoxes.flatMap(box => {
 				if (!(box instanceof Box)) return [];
 				const header = box.render(width).find(line => /\S/.test(line));
@@ -1153,12 +1207,13 @@ export class ToolExecutionComponent extends Container {
 			});
 			const sourceRows = headers.length > 1 ? headers : [first];
 			const glyph = theme.symbol(OPENCODE_TOOL_GLYPHS[this.#toolName] ?? "oc.search");
+			const usesBuiltInResultRenderer = this.#usesBuiltInResultRenderer();
 			const collapsedRows = sourceRows.slice(0, 8).map(source => {
 				// Tabs are legal in filenames and custom status details; normalize
 				// them before measuring so the advertised single row truncates
 				// predictably instead of wrapping or leaving visual holes.
 				let plain = replaceTabs(stripVTControlCharacters(source)).trim();
-				if (this.#renderer !== undefined && !this.#tool?.renderCall && !this.#tool?.renderResult) {
+				if (usesBuiltInResultRenderer) {
 					plain = plain.replace(headerIconStrip(), "");
 				}
 				const row = ` ${glyph} ${plain}`;

--- a/packages/coding-agent/src/modes/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/components/tool-execution.ts
@@ -60,14 +60,14 @@ const OPENCODE_TOOL_GLYPHS: Record<string, SymbolKey> = {
 	todo: "oc.todo",
 };
 
-// Settled collapse restyles `<icon> Tool detail` headers into opencode's
-// `<glyph> Tool detail`, so the native leading icon must be removed. Headers
-// start with a status icon (formatStatusIcon/renderStatusLine) or a per-tool
-// identity glyph, and under symbolPreset "ascii" many of those are
-// alphanumeric ("+f", "lsp", "web", "[ok]") — no character class can tell
-// them apart from real text. Strip by the active theme's known icon strings
-// instead, longest first so "[!!]" wins over "[!]"; glyphs from custom
-// renderers outside the symbol table keep the symbol-ish 1-2 char fallback.
+// Built-in settled collapse restyles `<icon> Tool detail` headers into
+// opencode's `<glyph> Tool detail`, so the native leading icon must be
+// removed. Built-in headers start with a status icon (formatStatusIcon/
+// renderStatusLine) or a per-tool identity glyph, and under symbolPreset
+// "ascii" many are alphanumeric ("+f", "lsp", "web", "[ok]") — no character
+// class can tell them apart from real text. Strip by the active theme's known
+// icon strings instead, longest first so "[!!]" wins over "[!]"; custom
+// renderer output is ordinary tool text and must stay verbatim.
 const HEADER_ICON_KEYS = (Object.keys(SYMBOL_PRESETS.unicode) as SymbolKey[]).filter(
 	key => key.startsWith("status.") || key.startsWith("tool."),
 );
@@ -106,15 +106,22 @@ function restoreHyperlinks(row: string, source: string): string {
 	let from = 0;
 	for (const match of source.matchAll(OSC8_LINK_REGEX)) {
 		const [, opener, linked, closer] = match;
-		const linkedPlain = replaceTabs(stripVTControlCharacters(linked!));
+		const linkedStyled = replaceTabs(linked!);
+		const linkedPlain = stripVTControlCharacters(linkedStyled);
 		if (!linkedPlain) continue;
-		const at = out.indexOf(linkedPlain, from);
+		let at = out.indexOf(linkedStyled, from);
+		let matched = linkedStyled;
+		if (at === -1) {
+			at = out.indexOf(linkedPlain, from);
+			matched = linkedPlain;
+		}
 		if (at === -1) continue;
-		out = `${out.slice(0, at)}${opener}${linkedPlain}${closer}${out.slice(at + linkedPlain.length)}`;
-		from = at + opener!.length + linkedPlain.length + closer!.length;
+		out = `${out.slice(0, at)}${opener}${matched}${closer}${out.slice(at + matched.length)}`;
+		from = at + opener!.length + matched.length + closer!.length;
 	}
 	return out;
 }
+
 /** Resolves the canonical renderer key while retaining the provider's wire name in message history. */
 export function toolRenderName(wireName: string, tool: AgentTool | undefined): string {
 	return tool?.name ?? wireName;
@@ -1142,12 +1149,25 @@ export class ToolExecutionComponent extends Container {
 			// Tabs are legal in filenames and custom status details; normalize
 			// them before measuring so the advertised single row truncates
 			// predictably instead of wrapping or leaving visual holes.
-			const plain = replaceTabs(stripVTControlCharacters(first)).trim().replace(headerIconStrip(), "");
+			let plain = replaceTabs(stripVTControlCharacters(first)).trim();
+			if (this.#renderer !== undefined && !this.#tool?.renderCall && !this.#tool?.renderResult) {
+				plain = plain.replace(headerIconStrip(), "");
+			}
 			const glyph = theme.symbol(OPENCODE_TOOL_GLYPHS[this.#toolName] ?? "oc.search");
-			const row = restoreHyperlinks(` ${glyph} ${plain}`, first);
-			this.#collapsedLines = [theme.fg("dim", truncateToWidth(row, Math.max(1, width)))];
+			const row = ` ${glyph} ${plain}`;
+			this.#collapsedLines = [
+				theme.fg(
+					"dim",
+					restoreHyperlinks(truncateToWidth(row.replace(OSC8_LINK_REGEX, "$2"), Math.max(1, width)), first),
+				),
+			];
 		} else {
-			this.#collapsedLines = [first];
+			this.#collapsedLines = [
+				restoreHyperlinks(
+					truncateToWidth(replaceTabs(first).replace(OSC8_LINK_REGEX, "$2"), Math.max(1, width)),
+					first,
+				),
+			];
 		}
 		return this.#collapsedLines;
 	}

--- a/packages/coding-agent/src/modes/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/components/tool-execution.ts
@@ -56,6 +56,29 @@ const OPENCODE_TOOL_GLYPHS: Record<string, string> = {
 	task: "◆",
 	todo: "▪",
 };
+
+// OSC 8 hyperlink span: `ESC ] 8 ; params ; uri (BEL|ST) text ESC ] 8 ; ; (BEL|ST)`.
+// The opener requires a non-empty URI so a stray closer can never match.
+const OSC8_LINK_REGEX = /(\x1b\]8;[^;\x07\x1b]*;[^\x07\x1b]+(?:\x07|\x1b\\))([\s\S]*?)(\x1b\]8;;(?:\x07|\x1b\\))/;
+
+/**
+ * Re-attach the first OSC-8 hyperlink from `source` (the renderer's fully
+ * styled status row) onto the matching plain-text segment of `row` (its
+ * stripped opencode restyle). The opener/closer bytes are reused verbatim, so
+ * the link target is exactly the renderer's own resolution (e.g. write links
+ * `details.resolvedPath`, read keeps its selector line) — no relative-vs-
+ * absolute guessing from raw args. Rows without a link pass through unchanged.
+ */
+function restoreFirstHyperlink(row: string, source: string): string {
+	const match = OSC8_LINK_REGEX.exec(source);
+	if (!match) return row;
+	const [, opener, linked, closer] = match;
+	const linkedPlain = replaceTabs(stripVTControlCharacters(linked!));
+	if (!linkedPlain) return row;
+	const at = row.indexOf(linkedPlain);
+	if (at === -1) return row;
+	return `${row.slice(0, at)}${opener}${linkedPlain}${closer}${row.slice(at + linkedPlain.length)}`;
+}
 /** Resolves the canonical renderer key while retaining the provider's wire name in message history. */
 export function toolRenderName(wireName: string, tool: AgentTool | undefined): string {
 	return tool?.name ?? wireName;
@@ -1080,11 +1103,15 @@ export class ToolExecutionComponent extends Container {
 		// live calls keep their native styling (spinner/accent) so activity
 		// stays legible, matching opencode's emphasized in-flight rows.
 		if (this.#result !== undefined && !this.#isPartial && !this.#result.isError) {
-			const plain = stripVTControlCharacters(first)
+			// Tabs are legal in filenames and custom status details; normalize
+			// them before measuring so the advertised single row truncates
+			// predictably instead of wrapping or leaving visual holes.
+			const plain = replaceTabs(stripVTControlCharacters(first))
 				.trim()
 				.replace(/^[^\p{L}\p{N}]{1,2}\s+/u, "");
 			const glyph = OPENCODE_TOOL_GLYPHS[this.#toolName] ?? "∗";
-			this.#collapsedLines = [theme.fg("dim", truncateToWidth(` ${glyph} ${plain}`, Math.max(1, width)))];
+			const row = restoreFirstHyperlink(` ${glyph} ${plain}`, first);
+			this.#collapsedLines = [theme.fg("dim", truncateToWidth(row, Math.max(1, width)))];
 		} else {
 			this.#collapsedLines = [first];
 		}

--- a/packages/coding-agent/src/modes/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/components/tool-execution.ts
@@ -1,3 +1,4 @@
+import { stripVTControlCharacters } from "node:util";
 import type { Clipboard, SnapshotStore } from "@oh-my-pi/hashline";
 import type { AgentTool } from "@oh-my-pi/pi-agent-core";
 import {
@@ -35,9 +36,26 @@ import { isFramedBlockComponent, markFramedBlockComponent, renderStatusLine, Wid
 import { convertImageToPng } from "../../utils/image-loading";
 import { sanitizeWithOptionalSixelPassthrough } from "../../utils/sixel";
 import { isOpencodeLayout } from "../layout-mode";
+
 import { renderDiff } from "./diff";
 import { type AnimationFrame, trimBlankEdges } from "./transcript-container";
 
+// Opencode-layout tool row glyphs, mirroring opencode's iconography: reads →,
+// searches ∗, shell $, writes ←, subagents ◆. Anything unlisted falls back ∗.
+const OPENCODE_TOOL_GLYPHS: Record<string, string> = {
+	read: "→",
+	fetch: "→",
+	grep: "∗",
+	glob: "∗",
+	ast_grep: "∗",
+	bash: "$",
+	eval: "$",
+	write: "←",
+	edit: "←",
+	ast_edit: "←",
+	task: "◆",
+	todo: "▪",
+};
 /** Resolves the canonical renderer key while retaining the provider's wire name in message history. */
 export function toolRenderName(wireName: string, tool: AgentTool | undefined): string {
 	return tool?.name ?? wireName;
@@ -1050,7 +1068,22 @@ export class ToolExecutionComponent extends Container {
 		// this mode because the state bg is disabled).
 		const first = lines.find(line => /\S/.test(line));
 		this.#collapsedSource = lines;
-		this.#collapsedLines = first === undefined ? [] : [first];
+		if (first === undefined) {
+			this.#collapsedLines = [];
+			return this.#collapsedLines;
+		}
+		// Settled success restyles to opencode's dim `<glyph> Tool detail` row;
+		// live calls keep their native styling (spinner/accent) so activity
+		// stays legible, matching opencode's emphasized in-flight rows.
+		if (this.#result !== undefined && !this.#isPartial && !this.#result.isError) {
+			const plain = stripVTControlCharacters(first)
+				.trim()
+				.replace(/^[^\p{L}\p{N}]{1,2}\s+/u, "");
+			const glyph = OPENCODE_TOOL_GLYPHS[this.#toolName] ?? "∗";
+			this.#collapsedLines = [theme.fg("dim", truncateToWidth(` ${glyph} ${plain}`, Math.max(1, width)))];
+		} else {
+			this.#collapsedLines = [first];
+		}
 		return this.#collapsedLines;
 	}
 

--- a/packages/coding-agent/src/modes/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/components/tool-execution.ts
@@ -59,25 +59,32 @@ const OPENCODE_TOOL_GLYPHS: Record<string, string> = {
 
 // OSC 8 hyperlink span: `ESC ] 8 ; params ; uri (BEL|ST) text ESC ] 8 ; ; (BEL|ST)`.
 // The opener requires a non-empty URI so a stray closer can never match.
-const OSC8_LINK_REGEX = /(\x1b\]8;[^;\x07\x1b]*;[^\x07\x1b]+(?:\x07|\x1b\\))([\s\S]*?)(\x1b\]8;;(?:\x07|\x1b\\))/;
+const OSC8_LINK_REGEX = /(\x1b\]8;[^;\x07\x1b]*;[^\x07\x1b]+(?:\x07|\x1b\\))([\s\S]*?)(\x1b\]8;;(?:\x07|\x1b\\))/g;
 
 /**
- * Re-attach the first OSC-8 hyperlink from `source` (the renderer's fully
- * styled status row) onto the matching plain-text segment of `row` (its
- * stripped opencode restyle). The opener/closer bytes are reused verbatim, so
- * the link target is exactly the renderer's own resolution (e.g. write links
+ * Re-attach every OSC-8 hyperlink from `source` (the renderer's fully styled
+ * status row) onto the matching plain-text segments of `row` (its stripped
+ * opencode restyle). The opener/closer bytes are reused verbatim, so each
+ * link target is exactly the renderer's own resolution (e.g. write links
  * `details.resolvedPath`, read keeps its selector line) — no relative-vs-
- * absolute guessing from raw args. Rows without a link pass through unchanged.
+ * absolute guessing from raw args. Segments are bound in order, each search
+ * resuming past the previous restored span, so a rename/move header with
+ * duplicate path substrings links source and destination correctly. Rows
+ * without a link pass through unchanged.
  */
-function restoreFirstHyperlink(row: string, source: string): string {
-	const match = OSC8_LINK_REGEX.exec(source);
-	if (!match) return row;
-	const [, opener, linked, closer] = match;
-	const linkedPlain = replaceTabs(stripVTControlCharacters(linked!));
-	if (!linkedPlain) return row;
-	const at = row.indexOf(linkedPlain);
-	if (at === -1) return row;
-	return `${row.slice(0, at)}${opener}${linkedPlain}${closer}${row.slice(at + linkedPlain.length)}`;
+function restoreHyperlinks(row: string, source: string): string {
+	let out = row;
+	let from = 0;
+	for (const match of source.matchAll(OSC8_LINK_REGEX)) {
+		const [, opener, linked, closer] = match;
+		const linkedPlain = replaceTabs(stripVTControlCharacters(linked!));
+		if (!linkedPlain) continue;
+		const at = out.indexOf(linkedPlain, from);
+		if (at === -1) continue;
+		out = `${out.slice(0, at)}${opener}${linkedPlain}${closer}${out.slice(at + linkedPlain.length)}`;
+		from = at + opener!.length + linkedPlain.length + closer!.length;
+	}
+	return out;
 }
 /** Resolves the canonical renderer key while retaining the provider's wire name in message history. */
 export function toolRenderName(wireName: string, tool: AgentTool | undefined): string {
@@ -1110,7 +1117,7 @@ export class ToolExecutionComponent extends Container {
 				.trim()
 				.replace(/^[^\p{L}\p{N}]{1,2}\s+/u, "");
 			const glyph = OPENCODE_TOOL_GLYPHS[this.#toolName] ?? "∗";
-			const row = restoreFirstHyperlink(` ${glyph} ${plain}`, first);
+			const row = restoreHyperlinks(` ${glyph} ${plain}`, first);
 			this.#collapsedLines = [theme.fg("dim", truncateToWidth(row, Math.max(1, width)))];
 		} else {
 			this.#collapsedLines = [first];

--- a/packages/coding-agent/src/modes/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/components/tool-execution.ts
@@ -17,7 +17,7 @@ import {
 } from "@oh-my-pi/pi-tui";
 import { getProjectDir, isRecord, logger, sanitizeText } from "@oh-my-pi/pi-utils";
 import { EDIT_MODE_STRATEGIES, type EditMode, type PerFileDiffPreview } from "../../edit";
-import type { Theme } from "../../modes/theme/theme";
+import type { SymbolKey, Theme } from "../../modes/theme/theme";
 import { getThemeEpoch, theme } from "../../modes/theme/theme";
 import { BASH_DEFAULT_PREVIEW_LINES } from "../../tools/bash";
 import { formatDefaultToolExecution } from "../../tools/default-renderer";
@@ -41,20 +41,22 @@ import { renderDiff } from "./diff";
 import { type AnimationFrame, trimBlankEdges } from "./transcript-container";
 
 // Opencode-layout tool row glyphs, mirroring opencode's iconography: reads →,
-// searches ∗, shell $, writes ←, subagents ◆. Anything unlisted falls back ∗.
-const OPENCODE_TOOL_GLYPHS: Record<string, string> = {
-	read: "→",
-	fetch: "→",
-	grep: "∗",
-	glob: "∗",
-	ast_grep: "∗",
-	bash: "$",
-	eval: "$",
-	write: "←",
-	edit: "←",
-	ast_edit: "←",
-	task: "◆",
-	todo: "▪",
+// searches ∗, shell $, writes ←, subagents ◆. Anything unlisted falls back to
+// the search glyph. Resolved through the theme symbol table so symbolPreset
+// "ascii" renders ASCII fallbacks (->, *, <-, #, -) instead of Unicode.
+const OPENCODE_TOOL_GLYPHS: Record<string, SymbolKey> = {
+	read: "oc.read",
+	fetch: "oc.read",
+	grep: "oc.search",
+	glob: "oc.search",
+	ast_grep: "oc.search",
+	bash: "oc.shell",
+	eval: "oc.shell",
+	write: "oc.write",
+	edit: "oc.write",
+	ast_edit: "oc.write",
+	task: "oc.subagent",
+	todo: "oc.todo",
 };
 
 // OSC 8 hyperlink span: `ESC ] 8 ; params ; uri (BEL|ST) text ESC ] 8 ; ; (BEL|ST)`.
@@ -1116,7 +1118,7 @@ export class ToolExecutionComponent extends Container {
 			const plain = replaceTabs(stripVTControlCharacters(first))
 				.trim()
 				.replace(/^[^\p{L}\p{N}]{1,2}\s+/u, "");
-			const glyph = OPENCODE_TOOL_GLYPHS[this.#toolName] ?? "∗";
+			const glyph = theme.symbol(OPENCODE_TOOL_GLYPHS[this.#toolName] ?? "oc.search");
 			const row = restoreHyperlinks(` ${glyph} ${plain}`, first);
 			this.#collapsedLines = [theme.fg("dim", truncateToWidth(row, Math.max(1, width)))];
 		} else {

--- a/packages/coding-agent/src/modes/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/components/tool-execution.ts
@@ -18,6 +18,7 @@ import {
 import { getProjectDir, isRecord, logger, sanitizeText } from "@oh-my-pi/pi-utils";
 import { EDIT_MODE_STRATEGIES, type EditMode, type PerFileDiffPreview } from "../../edit";
 import type { SymbolKey, Theme } from "../../modes/theme/theme";
+import { SYMBOL_PRESETS } from "../../modes/theme/symbols";
 import { getThemeEpoch, theme } from "../../modes/theme/theme";
 import { BASH_DEFAULT_PREVIEW_LINES } from "../../tools/bash";
 import { formatDefaultToolExecution } from "../../tools/default-renderer";
@@ -58,6 +59,32 @@ const OPENCODE_TOOL_GLYPHS: Record<string, SymbolKey> = {
 	task: "oc.subagent",
 	todo: "oc.todo",
 };
+
+// Settled collapse restyles `<icon> Tool detail` headers into opencode's
+// `<glyph> Tool detail`, so the native leading icon must be removed. Headers
+// start with a status icon (formatStatusIcon/renderStatusLine) or a per-tool
+// identity glyph, and under symbolPreset "ascii" many of those are
+// alphanumeric ("+f", "lsp", "web", "[ok]") — no character class can tell
+// them apart from real text. Strip by the active theme's known icon strings
+// instead, longest first so "[!!]" wins over "[!]"; glyphs from custom
+// renderers outside the symbol table keep the symbol-ish 1-2 char fallback.
+const HEADER_ICON_KEYS = (Object.keys(SYMBOL_PRESETS.unicode) as SymbolKey[]).filter(
+	key => key.startsWith("status.") || key.startsWith("tool."),
+);
+let headerIconStripCache: { theme: Theme; regex: RegExp } | undefined;
+function headerIconStrip(): RegExp {
+	if (headerIconStripCache?.theme !== theme) {
+		const icons = [...new Set(HEADER_ICON_KEYS.map(key => theme.symbol(key)))]
+			.filter(icon => icon.length > 0)
+			.sort((a, b) => b.length - a.length)
+			.map(icon => RegExp.escape(icon));
+		headerIconStripCache = {
+			theme,
+			regex: new RegExp(`^(?:${icons.join("|")}|[^\\p{L}\\p{N}]{1,2})\\s+`, "u"),
+		};
+	}
+	return headerIconStripCache.regex;
+}
 
 // OSC 8 hyperlink span: `ESC ] 8 ; params ; uri (BEL|ST) text ESC ] 8 ; ; (BEL|ST)`.
 // The opener requires a non-empty URI so a stray closer can never match.
@@ -1115,9 +1142,7 @@ export class ToolExecutionComponent extends Container {
 			// Tabs are legal in filenames and custom status details; normalize
 			// them before measuring so the advertised single row truncates
 			// predictably instead of wrapping or leaving visual holes.
-			const plain = replaceTabs(stripVTControlCharacters(first))
-				.trim()
-				.replace(/^[^\p{L}\p{N}]{1,2}\s+/u, "");
+			const plain = replaceTabs(stripVTControlCharacters(first)).trim().replace(headerIconStrip(), "");
 			const glyph = theme.symbol(OPENCODE_TOOL_GLYPHS[this.#toolName] ?? "oc.search");
 			const row = restoreHyperlinks(` ${glyph} ${plain}`, first);
 			this.#collapsedLines = [theme.fg("dim", truncateToWidth(row, Math.max(1, width)))];
@@ -1146,7 +1171,14 @@ export class ToolExecutionComponent extends Container {
 		// Opencode layout stays flat even under viewport squeeze: the 2-row
 		// `╭─`/`╰` frame is the omp look, so always use the one-line form there.
 		if (this.#allocation === 1 || this.#isFlat()) {
-			const glyph = this.#spinnerFrame === undefined ? "•" : (theme.spinnerFrames[this.#spinnerFrame] ?? "•");
+			// Settled marker rides the theme symbol table instead of a hardcoded
+			// `•` so a squeezed settled row matches the active preset (ascii stays
+			// ASCII): opencode takes the same oc.* accessor as the collapse row,
+			// omp keeps its bullet (`status.done` is `•` outside ascii).
+			const marker = this.#isFlat()
+				? theme.symbol(OPENCODE_TOOL_GLYPHS[this.#toolName] ?? "oc.search")
+				: theme.symbol("status.done");
+			const glyph = this.#spinnerFrame === undefined ? marker : (theme.spinnerFrames[this.#spinnerFrame] ?? marker);
 			const styledGlyph = theme.fg(this.#spinnerFrame === undefined ? "dim" : "muted", glyph);
 			return [truncateToWidth(`${styledGlyph} ${text}`, width)];
 		}

--- a/packages/coding-agent/src/modes/components/user-message.ts
+++ b/packages/coding-agent/src/modes/components/user-message.ts
@@ -3,6 +3,7 @@ import { formatBytes } from "@oh-my-pi/pi-utils";
 import { getMarkdownTheme, theme } from "../../modes/theme/theme";
 import { attachmentSgr, collapseImageMarkers, renderPlaceholders } from "../composer-attachments";
 import { imageReferenceHyperlink } from "../image-references";
+import { isOpencodeLayout } from "../layout-mode";
 import { highlightMagicKeywords } from "../magic-keywords";
 
 // OSC 133 shell integration: marks prompt zones for terminal multiplexers.
@@ -77,14 +78,24 @@ export class UserMessageComponent extends Container {
 	}
 
 	override render(width: number): readonly string[] {
-		const lines = super.render(width);
+		// Opencode layout: prefix a left accent gutter (opencode's signature user
+		// message chrome). Children render 2 columns narrower to make room, and
+		// the derived array is memoized on the source ref like the OSC zone wrap.
+		const gutter = isOpencodeLayout();
+		const lines = super.render(gutter ? Math.max(1, width - 2) : width);
 		if (lines.length === 0) {
 			return lines;
 		}
 		if (this.#zoneSource === lines && this.#zoneLines !== undefined) {
 			return this.#zoneLines;
 		}
-		const wrapped = lines.slice();
+		let wrapped: string[];
+		if (gutter) {
+			const bar = `${theme.fg("borderAccent", theme.boxRound.vertical)} `;
+			wrapped = lines.map(line => bar + line);
+		} else {
+			wrapped = lines.slice();
+		}
 		wrapped[0] = OSC133_ZONE_START + wrapped[0];
 		wrapped[wrapped.length - 1] = wrapped[wrapped.length - 1] + OSC133_ZONE_CLOSE;
 		this.#zoneSource = lines;

--- a/packages/coding-agent/src/modes/components/user-message.ts
+++ b/packages/coding-agent/src/modes/components/user-message.ts
@@ -3,7 +3,7 @@ import { formatBytes } from "@oh-my-pi/pi-utils";
 import { getMarkdownTheme, theme } from "../../modes/theme/theme";
 import { attachmentSgr, collapseImageMarkers, renderPlaceholders } from "../composer-attachments";
 import { imageReferenceHyperlink } from "../image-references";
-import { isOpencodeLayout } from "../layout-mode";
+import type { LayoutMode } from "../layout-mode";
 import { highlightMagicKeywords } from "../magic-keywords";
 
 // OSC 133 shell integration: marks prompt zones for terminal multiplexers.
@@ -38,9 +38,17 @@ export class UserMessageComponent extends Container {
 	// never mutates the container's cached array.
 	#zoneSource: readonly string[] | undefined;
 	#zoneLines: string[] | undefined;
+	/** Owning mode's transcript layout; captured at construction (per-instance, never global). */
+	readonly #layout: (() => LayoutMode) | undefined;
 
-	constructor(text: string, synthetic = false, imageLinks?: readonly (string | undefined)[]) {
+	constructor(
+		text: string,
+		synthetic = false,
+		imageLinks?: readonly (string | undefined)[],
+		layout?: () => LayoutMode,
+	) {
 		super();
+		this.#layout = layout;
 		// Display-only collapse: the stored/wire text carries bracketed `[Image #N, WxH]` markers,
 		// but the transcript shows the same compact `<icon> #N` chip the composer used. Runs before
 		// Markdown layout so wrapping and bubble padding are computed on the visible text.
@@ -81,7 +89,7 @@ export class UserMessageComponent extends Container {
 		// Opencode layout: prefix a left accent gutter (opencode's signature user
 		// message chrome). Children render 2 columns narrower to make room, and
 		// the derived array is memoized on the source ref like the OSC zone wrap.
-		const gutter = isOpencodeLayout();
+		const gutter = this.#layout?.() === "opencode";
 		const lines = super.render(gutter ? Math.max(1, width - 2) : width);
 		if (lines.length === 0) {
 			return lines;
@@ -126,6 +134,7 @@ export class CollapsedSyntheticMessageComponent implements Component {
 	constructor(
 		private readonly text: string,
 		private readonly imageLinks?: readonly (string | undefined)[],
+		private readonly layout?: () => LayoutMode,
 	) {
 		this.#summary = summarizeSyntheticInput(text);
 	}
@@ -155,7 +164,7 @@ export class CollapsedSyntheticMessageComponent implements Component {
 	}
 
 	#renderExpanded(width: number): readonly string[] {
-		if (!this.#body) this.#body = new UserMessageComponent(this.text, true, this.imageLinks);
+		if (!this.#body) this.#body = new UserMessageComponent(this.text, true, this.imageLinks, this.layout);
 		return [` ${this.#summaryRow(width)}`, ...this.#body.render(width)];
 	}
 

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -413,6 +413,7 @@ export class EventController {
 		if (!this.#lastReadGroup) {
 			const group = new ReadToolGroupComponent({
 				showContentPreview: this.ctx.settings.get("read.toolResultPreview"),
+				layout: () => this.ctx.layoutMode,
 			});
 			group.setExpanded(this.ctx.toolOutputExpanded);
 			this.ctx.chatContainer.addChild(group);
@@ -1278,6 +1279,7 @@ export class EventController {
 							showImages: settings.get("terminal.showImages"),
 							editFuzzyThreshold: settings.get("edit.fuzzyThreshold"),
 							editAllowFuzzy: settings.get("edit.fuzzyMatch"),
+							layout: () => this.ctx.layoutMode,
 						},
 						tool,
 						this.ctx.ui,
@@ -1538,6 +1540,7 @@ export class EventController {
 					snapshots: getFileSnapshotStore(this.ctx.viewSession),
 					clipboard: getEditClipboard(this.ctx.viewSession),
 					showImages: settings.get("terminal.showImages"),
+					layout: () => this.ctx.layoutMode,
 				},
 				tool,
 				this.ctx.ui,

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -111,7 +111,7 @@ import { TranscriptBlock } from "../components/transcript-container";
 import { TreeSelectorComponent } from "../components/tree-selector";
 import { UsageDashboardComponent } from "../components/usage-dashboard";
 import { renderUsageReports } from "./command-controller";
-import { type LayoutMode, setLayoutMode } from "../layout-mode";
+import type { LayoutMode } from "../layout-mode";
 import type { SessionObserverRegistry } from "../session-observer-registry";
 
 const MANUAL_LOGIN_PROMPT = "Paste the authorization code (or full redirect URL), then press Enter:";
@@ -672,7 +672,7 @@ export class SelectorController {
 				this.ctx.ui.requestRender();
 				break;
 			case "display.layout":
-				setLayoutMode(value as LayoutMode);
+				this.ctx.layoutMode = value as LayoutMode;
 				// Rebuild re-creates every transcript component under the new layout
 				// (tool blocks, read groups, user gutters); full reset retires blocks
 				// already committed to native scrollback (mirrors collapseCompacted).
@@ -1283,6 +1283,7 @@ export class SelectorController {
 			hideThinkingBlock: () => this.ctx.effectiveHideThinkingBlock,
 			proseOnlyThinking: () => this.ctx.proseOnlyThinking,
 			requestRender: () => this.ctx.ui.requestRender(),
+			layout: () => this.ctx.layoutMode,
 			siblingPaths: entryId => this.#siblingBranchPaths(entryId),
 			onSelect: entryId => void this.#rewindFromTranscript(entryId, done),
 			onCancel: done,
@@ -1440,6 +1441,7 @@ export class SelectorController {
 			hideThinkingBlock: () => this.ctx.effectiveHideThinkingBlock,
 			proseOnlyThinking: () => this.ctx.proseOnlyThinking,
 			requestRender: () => this.ctx.ui.requestRender(),
+			layout: () => this.ctx.layoutMode,
 			onPick: (content, label) => {
 				done();
 				if (!content.trim()) {
@@ -2360,6 +2362,7 @@ export class SelectorController {
 			cwd: this.ctx.sessionManager.getCwd(),
 			hideThinkingBlock: () => this.ctx.effectiveHideThinkingBlock,
 			proseOnlyThinking: () => this.ctx.proseOnlyThinking,
+			layout: () => this.ctx.layoutMode,
 			focusAgent: id => this.ctx.focusAgentSession(id),
 			sessionFile: this.ctx.sessionManager.getSessionFile() ?? null,
 		});

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -111,6 +111,7 @@ import { TranscriptBlock } from "../components/transcript-container";
 import { TreeSelectorComponent } from "../components/tree-selector";
 import { UsageDashboardComponent } from "../components/usage-dashboard";
 import { renderUsageReports } from "./command-controller";
+import { type LayoutMode, setLayoutMode } from "../layout-mode";
 import type { SessionObserverRegistry } from "../session-observer-registry";
 
 const MANUAL_LOGIN_PROMPT = "Paste the authorization code (or full redirect URL), then press Enter:";
@@ -669,6 +670,14 @@ export class SelectorController {
 				this.ctx.statusLine.invalidate();
 				this.ctx.ui.invalidate();
 				this.ctx.ui.requestRender();
+				break;
+			case "display.layout":
+				setLayoutMode(value as LayoutMode);
+				// Rebuild re-creates every transcript component under the new layout
+				// (tool blocks, read groups, user gutters); full reset retires blocks
+				// already committed to native scrollback (mirrors collapseCompacted).
+				this.ctx.rebuildChatFromMessages();
+				this.ctx.ui.resetDisplay();
 				break;
 			case "tui.resizeScrollback":
 				this.ctx.ui.setResizeScrollback(value as ResizeScrollbackMode);

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -196,7 +196,7 @@ import { SSHCommandController } from "./controllers/ssh-command-controller";
 import { TanCommandController } from "./controllers/tan-command-controller";
 import { TodoCommandController } from "./controllers/todo-command-controller";
 import { imageReferenceHyperlink, materializeImageReferenceLinks } from "./image-references";
-import { setLayoutMode } from "./layout-mode";
+import type { LayoutMode } from "./layout-mode";
 import {
 	consumeLoopLimitIteration,
 	createLoopLimitRuntime,
@@ -618,6 +618,8 @@ export class InteractiveMode implements InteractiveModeContext {
 	 */
 	#todoPhasesOwner?: AgentSession;
 	hideThinkingBlock = false;
+	/** Per-mode transcript layout (`display.layout`); see InteractiveModeContext.layoutMode. */
+	layoutMode: LayoutMode = "omp";
 	#sessionsWithDisplayableThinkingContent = new WeakSet<AgentSession>();
 	/** Whether the visible session has produced thinking content the user can reveal. */
 	get hasDisplayableThinkingContent(): boolean {
@@ -924,7 +926,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		}
 
 		setTuiTight(settings.get("tui.tight"));
-		setLayoutMode(settings.get("display.layout"));
+		this.layoutMode = settings.get("display.layout");
 		setMarkdownMermaidRendering(settings.get("tui.renderMermaid"));
 		// A cold-start composer already owns the terminal. Reuse it so input
 		// buffered during startup remains in the same editor instance.

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -196,6 +196,7 @@ import { SSHCommandController } from "./controllers/ssh-command-controller";
 import { TanCommandController } from "./controllers/tan-command-controller";
 import { TodoCommandController } from "./controllers/todo-command-controller";
 import { imageReferenceHyperlink, materializeImageReferenceLinks } from "./image-references";
+import { setLayoutMode } from "./layout-mode";
 import {
 	consumeLoopLimitIteration,
 	createLoopLimitRuntime,
@@ -923,6 +924,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		}
 
 		setTuiTight(settings.get("tui.tight"));
+		setLayoutMode(settings.get("display.layout"));
 		setMarkdownMermaidRendering(settings.get("tui.renderMermaid"));
 		// A cold-start composer already owns the terminal. Reuse it so input
 		// buffered during startup remains in the same editor instance.

--- a/packages/coding-agent/src/modes/layout-mode.ts
+++ b/packages/coding-agent/src/modes/layout-mode.ts
@@ -1,0 +1,27 @@
+/**
+ * Transcript layout style. `omp` is the default look: tool cards with framed
+ * output previews and state-tinted backgrounds. `opencode` is a flat,
+ * opencode-style transcript: collapsed tool calls render as a single status
+ * line (Ctrl+O still expands the full card) and the user message gets a left
+ * accent gutter instead of relying on background fill alone.
+ *
+ * Module-level flag mirroring the `setTuiTight` precedent in pi-tui: set once
+ * at InteractiveMode construction from `display.layout` and live-updated by
+ * the settings selector. Components read it at render/rebuild time and fold it
+ * into their memo keys, so a toggle only needs invalidate + repaint.
+ */
+export type LayoutMode = "omp" | "opencode";
+
+let layoutMode: LayoutMode = "omp";
+
+export function setLayoutMode(mode: LayoutMode): void {
+	layoutMode = mode;
+}
+
+export function getLayoutMode(): LayoutMode {
+	return layoutMode;
+}
+
+export function isOpencodeLayout(): boolean {
+	return layoutMode === "opencode";
+}

--- a/packages/coding-agent/src/modes/layout-mode.ts
+++ b/packages/coding-agent/src/modes/layout-mode.ts
@@ -5,19 +5,15 @@
  * line (Ctrl+O still expands the full card) and the user message gets a left
  * accent gutter instead of relying on background fill alone.
  *
- * Module-level flag mirroring the `setTuiTight` precedent in pi-tui: set once
- * at InteractiveMode construction from `display.layout` and live-updated by
- * the settings selector. Components read it at render/rebuild time and fold it
- * into their memo keys, so a toggle only needs invalidate + repaint.
+ * The value is per-mode state: `InteractiveMode` owns it (`ctx.layoutMode`,
+ * seeded from `display.layout` and live-updated by the settings selector and
+ * setup wizard). Transcript components capture a {@link LayoutAccessor} at
+ * construction and fold the value into their memo keys, so two concurrently
+ * live modes never share layout state and a toggle only needs invalidate +
+ * repaint. Framed tool renderers receive the resolved flag as `flat` on their
+ * render context and pass it through to `renderOutputBlock`.
  */
 export type LayoutMode = "omp" | "opencode";
 
-let layoutMode: LayoutMode = "omp";
-
-export function setLayoutMode(mode: LayoutMode): void {
-	layoutMode = mode;
-}
-
-export function isOpencodeLayout(): boolean {
-	return layoutMode === "opencode";
-}
+/** Reads the owning mode's current layout at render/rebuild time. */
+export type LayoutAccessor = () => LayoutMode;

--- a/packages/coding-agent/src/modes/layout-mode.ts
+++ b/packages/coding-agent/src/modes/layout-mode.ts
@@ -18,10 +18,6 @@ export function setLayoutMode(mode: LayoutMode): void {
 	layoutMode = mode;
 }
 
-export function getLayoutMode(): LayoutMode {
-	return layoutMode;
-}
-
 export function isOpencodeLayout(): boolean {
 	return layoutMode === "opencode";
 }

--- a/packages/coding-agent/src/modes/setup-version.ts
+++ b/packages/coding-agent/src/modes/setup-version.ts
@@ -8,4 +8,4 @@
  * the overlay component and their TUI deps. MUST equal `max(scene.minVersion)`
  * across `ALL_SCENES`; the `setup-wizard` barrel and test suite guard it.
  */
-export const CURRENT_SETUP_VERSION = 2;
+export const CURRENT_SETUP_VERSION = 3;

--- a/packages/coding-agent/src/modes/setup-wizard/index.ts
+++ b/packages/coding-agent/src/modes/setup-wizard/index.ts
@@ -3,6 +3,7 @@ import { CURRENT_SETUP_VERSION } from "../setup-version";
 import type { InteractiveModeContext } from "../types";
 import { composerSetupScene } from "./scenes/composer";
 import { glyphSetupScene } from "./scenes/glyph";
+import { layoutSetupScene } from "./scenes/layout";
 import { modelSetupScene } from "./scenes/model";
 import { providersSetupScene } from "./scenes/providers";
 import { themeSetupScene } from "./scenes/theme";
@@ -20,6 +21,7 @@ export const ALL_SCENES = [
 	glyphSetupScene,
 	composerSetupScene,
 	themeSetupScene,
+	layoutSetupScene,
 ] as const satisfies readonly SetupScene[];
 
 export interface SetupSceneSelectionOptions {

--- a/packages/coding-agent/src/modes/setup-wizard/scenes/layout.ts
+++ b/packages/coding-agent/src/modes/setup-wizard/scenes/layout.ts
@@ -1,0 +1,95 @@
+import { routeSelectListMouse, type SelectItem, SelectList, type SgrMouseEvent } from "@oh-my-pi/pi-tui";
+import { formatStatusIcon } from "../../../tools/render-utils";
+import { type LayoutMode, setLayoutMode } from "../../layout-mode";
+import { getSelectListTheme, theme } from "../../theme/theme";
+import type { SetupScene, SetupSceneController, SetupSceneHost } from "./types";
+
+const ITEMS: readonly SelectItem[] = [
+	{ value: "omp", label: "OMP", description: "Tool cards with framed output previews" },
+	{
+		value: "opencode",
+		label: "OpenCode",
+		description: "Flat transcript; collapsed tool calls render as one line (Ctrl+O expands)",
+	},
+];
+
+/**
+ * Decorative side-by-side sample of the same tool call in both styles. The
+ * wizard holds the alternate screen, so unlike the theme scene there is no
+ * live transcript to preview against — a static mock is the honest option.
+ */
+function renderLayoutPreview(): string[] {
+	const header = `${formatStatusIcon("success", theme)} ${theme.fg("toolTitle", theme.bold("Grep"))} ${theme.fg(
+		"muted",
+		`"Home"${theme.sep.dot}18 matches`,
+	)}`;
+	return [
+		theme.fg("accent", theme.bold("OMP")),
+		header,
+		theme.fg("dim", "  src/routes/404.tsx:12: <Home />"),
+		theme.fg("dim", "  src/components/header.tsx:8: Home"),
+		theme.fg("dim", "  Ctrl+O: Expand"),
+		"",
+		theme.fg("accent", theme.bold("OpenCode")),
+		header,
+	];
+}
+
+class LayoutSceneController implements SetupSceneController {
+	title = "Pick a layout";
+	subtitle = "How tool calls render in the transcript; Enter saves the highlighted choice.";
+	#selectList: SelectList;
+	/** Render line where the select list began, or -1 while it is not shown. */
+	#listRowStart = -1;
+
+	constructor(private readonly host: SetupSceneHost) {
+		const current = host.ctx.settings.get("display.layout");
+		this.#selectList = new SelectList(ITEMS, ITEMS.length, getSelectListTheme());
+		this.#selectList.setSelectedIndex(
+			Math.max(
+				0,
+				ITEMS.findIndex(item => item.value === current),
+			),
+		);
+		this.#selectList.onSelect = item => {
+			const mode = item.value as LayoutMode;
+			this.host.ctx.settings.set("display.layout", mode);
+			setLayoutMode(mode);
+			this.host.finish("done");
+		};
+		this.#selectList.onCancel = () => this.host.finish("skipped");
+	}
+
+	invalidate(): void {
+		this.#selectList.invalidate();
+	}
+
+	handleInput(data: string): void {
+		this.#selectList.handleInput(data);
+	}
+
+	routeMouse(event: SgrMouseEvent, line: number, _col: number): void {
+		const listLine = this.#listRowStart >= 0 ? line - this.#listRowStart : Number.NEGATIVE_INFINITY;
+		routeSelectListMouse(this.#selectList, event, listLine);
+	}
+
+	render(width: number, maxLines?: number): readonly string[] {
+		const budget = maxLines ?? Number.POSITIVE_INFINITY;
+		const lines: string[] = [theme.fg("dim", "Changeable any time in /settings under Appearance."), ""];
+		// The mock is decorative — it yields to the list when the window is small.
+		const preview = renderLayoutPreview();
+		if (budget - lines.length - (preview.length + 1) - 1 >= ITEMS.length) {
+			lines.push(...preview, "");
+		}
+		this.#listRowStart = lines.length;
+		lines.push(...this.#selectList.render(width));
+		return lines;
+	}
+}
+
+export const layoutSetupScene: SetupScene = {
+	id: "layout",
+	title: "Pick a layout",
+	minVersion: 3,
+	mount: host => new LayoutSceneController(host),
+};

--- a/packages/coding-agent/src/modes/setup-wizard/scenes/layout.ts
+++ b/packages/coding-agent/src/modes/setup-wizard/scenes/layout.ts
@@ -1,6 +1,6 @@
 import { routeSelectListMouse, type SelectItem, SelectList, type SgrMouseEvent } from "@oh-my-pi/pi-tui";
 import { formatStatusIcon } from "../../../tools/render-utils";
-import { type LayoutMode, setLayoutMode } from "../../layout-mode";
+import type { LayoutMode } from "../../layout-mode";
 import { getSelectListTheme, theme } from "../../theme/theme";
 import type { SetupScene, SetupSceneController, SetupSceneHost } from "./types";
 
@@ -54,7 +54,7 @@ class LayoutSceneController implements SetupSceneController {
 		this.#selectList.onSelect = item => {
 			const mode = item.value as LayoutMode;
 			this.host.ctx.settings.set("display.layout", mode);
-			setLayoutMode(mode);
+			this.host.ctx.layoutMode = mode;
 			this.host.finish("done");
 		};
 		this.#selectList.onCancel = () => this.host.finish("skipped");

--- a/packages/coding-agent/src/modes/theme/symbols.ts
+++ b/packages/coding-agent/src/modes/theme/symbols.ts
@@ -277,7 +277,14 @@ export type SymbolKey =
 	| "tool.goal"
 	| "tool.irc"
 	| "tool.delete"
-	| "tool.move";
+	| "tool.move"
+	// Opencode-layout collapsed tool row glyphs (flat one-line transcript rows)
+	| "oc.read"
+	| "oc.search"
+	| "oc.shell"
+	| "oc.write"
+	| "oc.subagent"
+	| "oc.todo";
 
 export type SymbolMap = Record<SymbolKey, string>;
 /**
@@ -629,6 +636,13 @@ const UNICODE_SYMBOLS: SymbolMap = {
 	"tool.irc": "✉",
 	"tool.delete": "🗑",
 	"tool.move": "➜",
+	// Opencode-layout collapsed tool row glyphs
+	"oc.read": "→",
+	"oc.search": "∗",
+	"oc.shell": "$",
+	"oc.write": "←",
+	"oc.subagent": "◆",
+	"oc.todo": "▪",
 };
 
 const NERD_SYMBOLS: SymbolMap = {
@@ -1059,6 +1073,13 @@ const NERD_SYMBOLS: SymbolMap = {
 	"tool.irc": "\uF086",
 	"tool.delete": "\uf12d",
 	"tool.move": "\uf061",
+	// Opencode-layout collapsed tool row glyphs
+	"oc.read": "→",
+	"oc.search": "∗",
+	"oc.shell": "$",
+	"oc.write": "←",
+	"oc.subagent": "◆",
+	"oc.todo": "▪",
 };
 
 const ASCII_SYMBOLS: SymbolMap = {
@@ -1328,6 +1349,13 @@ const ASCII_SYMBOLS: SymbolMap = {
 	"tool.irc": "irc",
 	"tool.delete": "rm",
 	"tool.move": "mv",
+	// Opencode-layout collapsed tool row glyphs
+	"oc.read": "->",
+	"oc.search": "*",
+	"oc.shell": "$",
+	"oc.write": "<-",
+	"oc.subagent": "#",
+	"oc.todo": "-",
 };
 
 export const SYMBOL_PRESETS: Record<SymbolPreset, SymbolMap> = {

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -41,6 +41,7 @@ import type { TranscriptContainer } from "./components/transcript-container";
 import type { RecentSession } from "./components/welcome";
 import type { EventController } from "./controllers/event-controller";
 import type { LoopLimitRuntime } from "./loop-limit";
+import type { LayoutMode } from "./layout-mode";
 import type { OAuthManualInputManager } from "./oauth-manual-input";
 import type { Theme } from "./theme/theme";
 
@@ -191,6 +192,13 @@ export interface InteractiveModeContext {
 	loopLimit?: LoopLimitRuntime;
 	planModePlanFilePath?: string;
 	hideThinkingBlock: boolean;
+	/**
+	 * Per-mode transcript layout (`display.layout`). Owned by the mode instance:
+	 * seeded from settings at construction, mutated by the settings selector and
+	 * the setup wizard. Components capture `() => ctx.layoutMode` at
+	 * construction, so two live modes never share layout state.
+	 */
+	layoutMode: LayoutMode;
 	/**
 	 * Effective thinking-block visibility: true when hidden by user setting OR
 	 * thinking level is "off" before the session has produced displayable

--- a/packages/coding-agent/src/modes/utils/ui-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/ui-helpers.ts
@@ -290,7 +290,12 @@ export class UiHelpers {
 								message,
 								this.ctx.viewSession.sessionManager.putBlobSync.bind(this.ctx.viewSession.sessionManager),
 							);
-						userComponent = new UserMessageComponent(textContent, isSynthetic, imageLinks);
+						userComponent = new UserMessageComponent(
+							textContent,
+							isSynthetic,
+							imageLinks,
+							() => this.ctx.layoutMode,
+						);
 						this.ctx.transcriptMessageComponents.set(message, userComponent);
 					}
 					this.ctx.chatContainer.addChild(userComponent);
@@ -530,6 +535,7 @@ export class UiHelpers {
 							if (!readGroup) {
 								readGroup = new ReadToolGroupComponent({
 									showContentPreview: this.ctx.settings.get("read.toolResultPreview"),
+									layout: () => this.ctx.layoutMode,
 								});
 								readGroup.setExpanded(this.ctx.toolOutputExpanded);
 								this.ctx.chatContainer.addChild(readGroup);
@@ -544,6 +550,7 @@ export class UiHelpers {
 							if (!readGroup) {
 								readGroup = new ReadToolGroupComponent({
 									showContentPreview: this.ctx.settings.get("read.toolResultPreview"),
+									layout: () => this.ctx.layoutMode,
 								});
 								readGroup.setExpanded(this.ctx.toolOutputExpanded);
 								this.ctx.chatContainer.addChild(readGroup);
@@ -590,6 +597,7 @@ export class UiHelpers {
 							showImages: settings.get("terminal.showImages"),
 							editFuzzyThreshold: settings.get("edit.fuzzyThreshold"),
 							editAllowFuzzy: settings.get("edit.fuzzyMatch"),
+							layout: () => this.ctx.layoutMode,
 						},
 						tool,
 						this.ctx.ui,
@@ -657,6 +665,7 @@ export class UiHelpers {
 						if (!readGroup) {
 							readGroup = new ReadToolGroupComponent({
 								showContentPreview: this.ctx.settings.get("read.toolResultPreview"),
+								layout: () => this.ctx.layoutMode,
 							});
 							readGroup.setExpanded(this.ctx.toolOutputExpanded);
 							this.ctx.chatContainer.addChild(readGroup);

--- a/packages/coding-agent/src/task/render.ts
+++ b/packages/coding-agent/src/task/render.ts
@@ -1469,13 +1469,26 @@ function selectCollapsedResults(ordered: readonly SingleResult[]): readonly Sing
 	const picked = new Set<SingleResult>();
 	for (const result of ordered) {
 		if (picked.size >= COLLAPSED_AGENT_LIMIT) break;
-		if (result.aborted || result.exitCode !== 0 || result.error) picked.add(result);
+		if (isTaskResultError(result) || result.error) picked.add(result);
 	}
 	for (const result of ordered) {
 		if (picked.size >= COLLAPSED_AGENT_LIMIT) break;
 		picked.add(result);
 	}
 	return ordered.filter(result => picked.has(result));
+}
+/**
+ * Whether a settled task result makes the task card an error. Kept shared with
+ * transcript collapse so aggregate task failures cannot be hidden as success.
+ */
+export function isTaskResultError(result: Pick<SingleResult, "aborted" | "exitCode">): boolean {
+	return result.aborted === true || result.exitCode !== 0;
+}
+
+export function hasTaskResultError(
+	details: { results?: readonly Pick<SingleResult, "aborted" | "exitCode">[] } | undefined,
+): boolean {
+	return details?.results?.some(isTaskResultError) ?? false;
 }
 
 /**
@@ -1533,9 +1546,10 @@ export function renderResult(
 	if (hasResults) {
 		for (const r of details.results) {
 			requestTotal += r.requests ?? 0;
-			if (r.aborted) abortedCount++;
-			else if (r.exitCode !== 0) failCount++;
-			else if (r.error) mergeFailedCount++;
+			if (isTaskResultError(r)) {
+				if (r.aborted) abortedCount++;
+				else failCount++;
+			} else if (r.error) mergeFailedCount++;
 			else successCount++;
 		}
 	}

--- a/packages/coding-agent/src/task/render.ts
+++ b/packages/coding-agent/src/task/render.ts
@@ -878,6 +878,7 @@ export function renderCall(args: TaskParams, options: TaskRenderOptions, theme: 
 			state: "pending",
 			borderColor: "borderMuted",
 			width,
+			flat: options.renderContext?.flat === true,
 		};
 	});
 }
@@ -1515,6 +1516,7 @@ export function renderResult(
 			state: errored ? "error" : "success",
 			borderColor: errored ? "error" : "borderMuted",
 			width,
+			flat: options.renderContext?.flat === true,
 		}));
 	}
 
@@ -1682,6 +1684,7 @@ export function renderResult(
 			state,
 			borderColor,
 			width,
+			flat: options.renderContext?.flat === true,
 		};
 	});
 }

--- a/packages/coding-agent/src/tools/ask.ts
+++ b/packages/coding-agent/src/tools/ask.ts
@@ -1285,7 +1285,9 @@ export const askToolRenderer = {
 		const accentStyle = { color: (t: string) => uiTheme.fg("accent", t) };
 		const flat = options.renderContext?.flat === true;
 		const md = (text: string, width: number) =>
-			new Markdown(text, 1, 0, mdTheme, accentStyle).render(Math.max(1, outputBlockContentWidth(width, flat) + 1));
+			new Markdown(text, 1, 0, mdTheme, accentStyle).render(
+				Math.max(1, outputBlockContentWidth(width, undefined, undefined, flat) + 1),
+			);
 
 		// Multi-part questions: one divider-labelled section per question.
 		// Call args are untrusted (partially streamed or model-mangled) and a
@@ -1357,7 +1359,9 @@ export const askToolRenderer = {
 		const accentStyle = { color: (t: string) => uiTheme.fg("accent", t) };
 		const flat = options.renderContext?.flat === true;
 		const md = (text: string, width: number) =>
-			new Markdown(text, 1, 0, mdTheme, accentStyle).render(Math.max(1, outputBlockContentWidth(width, flat) + 1));
+			new Markdown(text, 1, 0, mdTheme, accentStyle).render(
+				Math.max(1, outputBlockContentWidth(width, undefined, undefined, flat) + 1),
+			);
 
 		if (!details) {
 			const txt = result.content[0];

--- a/packages/coding-agent/src/tools/ask.ts
+++ b/packages/coding-agent/src/tools/ask.ts
@@ -1279,12 +1279,13 @@ function renderAnswerOptionLines(
 
 export const askToolRenderer = {
 	mergeCallAndResult: true,
-	renderCall(args: AskRenderArgs, _options: RenderResultOptions, uiTheme: Theme): Component {
+	renderCall(args: AskRenderArgs, options: RenderResultOptions, uiTheme: Theme): Component {
 		const label = formatTitle("Ask", uiTheme);
 		const mdTheme = getMarkdownTheme();
 		const accentStyle = { color: (t: string) => uiTheme.fg("accent", t) };
+		const flat = options.renderContext?.flat === true;
 		const md = (text: string, width: number) =>
-			new Markdown(text, 1, 0, mdTheme, accentStyle).render(Math.max(1, outputBlockContentWidth(width) + 1));
+			new Markdown(text, 1, 0, mdTheme, accentStyle).render(Math.max(1, outputBlockContentWidth(width, flat) + 1));
 
 		// Multi-part questions: one divider-labelled section per question.
 		// Call args are untrusted (partially streamed or model-mangled) and a
@@ -1305,7 +1306,7 @@ export const askToolRenderer = {
 						: mdLines;
 					return { label: `${uiTheme.fg("dim", `[${q.id}]`)}${metaStr}`, lines };
 				});
-				return { header, sections, state: "pending", borderColor: "borderMuted", width };
+				return { header, sections, state: "pending", borderColor: "borderMuted", width, flat };
 			});
 		}
 
@@ -1318,6 +1319,7 @@ export const askToolRenderer = {
 				state: "error",
 				borderColor: "error",
 				width,
+				flat,
 			}));
 		}
 
@@ -1346,14 +1348,15 @@ export const askToolRenderer = {
 
 	renderResult(
 		result: { content: Array<{ type: string; text?: string }>; details?: AskToolDetails },
-		_options: RenderResultOptions,
+		options: RenderResultOptions,
 		uiTheme: Theme,
 	): Component {
 		const { details } = result;
 		const mdTheme = getMarkdownTheme();
 		const accentStyle = { color: (t: string) => uiTheme.fg("accent", t) };
+		const flat = options.renderContext?.flat === true;
 		const md = (text: string, width: number) =>
-			new Markdown(text, 1, 0, mdTheme, accentStyle).render(Math.max(1, outputBlockContentWidth(width) + 1));
+			new Markdown(text, 1, 0, mdTheme, accentStyle).render(Math.max(1, outputBlockContentWidth(width, flat) + 1));
 
 		if (!details) {
 			const txt = result.content[0];
@@ -1373,6 +1376,7 @@ export const askToolRenderer = {
 				state: "warning",
 				borderColor: "borderMuted",
 				width,
+				flat,
 			}));
 		}
 
@@ -1417,6 +1421,7 @@ export const askToolRenderer = {
 					state: hasAnySelection ? "success" : "warning",
 					borderColor: "borderMuted",
 					width,
+					flat,
 				};
 			});
 		}
@@ -1461,6 +1466,7 @@ export const askToolRenderer = {
 				state: hasSelection ? "success" : "warning",
 				borderColor: "borderMuted",
 				width,
+				flat,
 			};
 		});
 	},

--- a/packages/coding-agent/src/tools/ask.ts
+++ b/packages/coding-agent/src/tools/ask.ts
@@ -1342,6 +1342,7 @@ export const askToolRenderer = {
 				state: "pending",
 				borderColor: "borderMuted",
 				width,
+				flat,
 			};
 		});
 	},

--- a/packages/coding-agent/src/tools/ast-edit.ts
+++ b/packages/coding-agent/src/tools/ast-edit.ts
@@ -706,7 +706,7 @@ export const astEditToolRenderer = {
 		}
 		return framedBlock(uiTheme, width => {
 			const changeLines = buildChangeBody(changeGroups, Boolean(options.expanded), COLLAPSED_CHANGE_LIMIT, uiTheme);
-			const innerWidth = outputBlockContentWidth(width, flat);
+			const innerWidth = outputBlockContentWidth(width, undefined, undefined, flat);
 			const bodyLines = [...changeLines, ...extraLines].map(l => truncateToWidth(l, innerWidth, Ellipsis.Omit));
 			while (bodyLines.length > 0 && bodyLines[0].trim() === "") bodyLines.shift();
 			return {

--- a/packages/coding-agent/src/tools/ast-edit.ts
+++ b/packages/coding-agent/src/tools/ast-edit.ts
@@ -610,6 +610,7 @@ export const astEditToolRenderer = {
 		args?: AstEditRenderArgs,
 	): Component {
 		const details = result.details;
+		const flat = options.renderContext?.flat === true;
 
 		if (result.isError) {
 			const errorText = result.content?.find(c => c.type === "text")?.text || "Unknown error";
@@ -620,6 +621,7 @@ export const astEditToolRenderer = {
 				state: "error",
 				borderColor: "error",
 				width,
+				flat,
 			}));
 		}
 
@@ -646,6 +648,7 @@ export const astEditToolRenderer = {
 				state: "warning",
 				borderColor: "borderMuted",
 				width,
+				flat,
 			}));
 		}
 
@@ -703,7 +706,7 @@ export const astEditToolRenderer = {
 		}
 		return framedBlock(uiTheme, width => {
 			const changeLines = buildChangeBody(changeGroups, Boolean(options.expanded), COLLAPSED_CHANGE_LIMIT, uiTheme);
-			const innerWidth = outputBlockContentWidth(width);
+			const innerWidth = outputBlockContentWidth(width, flat);
 			const bodyLines = [...changeLines, ...extraLines].map(l => truncateToWidth(l, innerWidth, Ellipsis.Omit));
 			while (bodyLines.length > 0 && bodyLines[0].trim() === "") bodyLines.shift();
 			return {
@@ -712,6 +715,7 @@ export const astEditToolRenderer = {
 				state: options.isPartial ? "pending" : "success",
 				borderColor: "borderMuted",
 				width,
+				flat,
 			};
 		});
 	},

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -1470,6 +1470,8 @@ export interface BashRenderContext {
 	previewLines?: number;
 	/** Timeout in seconds */
 	timeout?: number;
+	/** Flat opencode layout (owning mode); forwarded to renderOutputBlock. */
+	flat?: boolean;
 }
 
 export interface ShellRendererConfig<TArgs> {
@@ -1550,6 +1552,7 @@ export function createShellRenderer<TArgs>(config: ShellRendererConfig<TArgs>) {
 							state: options.spinnerFrame !== undefined ? "running" : "pending",
 							sections: [{ lines: capPreviewLines(cmdLines, uiTheme, { expanded: options.expanded }) }],
 							width,
+							flat: options.renderContext?.flat === true,
 						},
 						uiTheme,
 					);
@@ -1610,6 +1613,7 @@ export function createShellRenderer<TArgs>(config: ShellRendererConfig<TArgs>) {
 			let cachedIsPartial: boolean | undefined;
 			let cachedLines: readonly string[] | undefined;
 			let cachedPreviewWindow: number | undefined;
+			let cachedFlat: boolean | undefined;
 
 			return markFramedBlockComponent({
 				render: (width: number): readonly string[] => {
@@ -1626,6 +1630,7 @@ export function createShellRenderer<TArgs>(config: ShellRendererConfig<TArgs>) {
 					const isPartial = options.isPartial === true;
 					const previewWindow = previewWindowRows();
 
+					const flat = renderContext?.flat === true;
 					if (
 						cachedLines !== undefined &&
 						cachedWidth === width &&
@@ -1633,7 +1638,8 @@ export function createShellRenderer<TArgs>(config: ShellRendererConfig<TArgs>) {
 						cachedExpanded === expanded &&
 						cachedRawOutput === rawOutput &&
 						cachedIsPartial === isPartial &&
-						cachedPreviewWindow === previewWindow
+						cachedPreviewWindow === previewWindow &&
+						cachedFlat === flat
 					) {
 						return cachedLines;
 					}
@@ -1713,7 +1719,11 @@ export function createShellRenderer<TArgs>(config: ShellRendererConfig<TArgs>) {
 							// spraying duplicate "… ctrl+o to expand" banners into native
 							// scrollback (the box never overflows the viewport now).
 							const previewBudget = Math.min(previewLines, previewWindow);
-							const result = truncateToVisualLines(textContent, previewBudget, outputBlockContentWidth(width));
+							const result = truncateToVisualLines(
+								textContent,
+								previewBudget,
+								outputBlockContentWidth(width, flat),
+							);
 							if (result.skippedCount > 0) {
 								outputLines.push(
 									uiTheme.fg(
@@ -1741,11 +1751,13 @@ export function createShellRenderer<TArgs>(config: ShellRendererConfig<TArgs>) {
 								{ label: uiTheme.fg("toolTitle", "Output"), lines: outputLines },
 							],
 							width,
+							flat,
 						},
 						uiTheme,
 					);
 
 					cachedWidth = width;
+					cachedFlat = flat;
 					cachedPreviewLines = previewLines;
 					cachedExpanded = expanded;
 					cachedRawOutput = rawOutput;

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -1722,7 +1722,7 @@ export function createShellRenderer<TArgs>(config: ShellRendererConfig<TArgs>) {
 							const result = truncateToVisualLines(
 								textContent,
 								previewBudget,
-								outputBlockContentWidth(width, flat),
+								outputBlockContentWidth(width, undefined, undefined, flat),
 							);
 							if (result.skippedCount > 0) {
 								outputLines.push(

--- a/packages/coding-agent/src/tools/browser/render.ts
+++ b/packages/coding-agent/src/tools/browser/render.ts
@@ -109,8 +109,10 @@ function renderRunCell(
 		render: (width: number): readonly string[] => {
 			const expanded = options.renderContext?.expanded ?? options.expanded;
 			const previewLines = options.renderContext?.previewLines ?? BROWSER_DEFAULT_PREVIEW_LINES;
+			const flat = options.renderContext?.flat === true;
 			const key = new Hasher()
 				.bool(expanded)
+				.bool(flat)
 				.bool(isError)
 				.u32(previewLines)
 				.u32(options.spinnerFrame ?? 0)
@@ -134,6 +136,7 @@ function renderRunCell(
 					codeMaxLines: expanded ? Number.POSITIVE_INFINITY : previewLines,
 					expanded,
 					width,
+					flat,
 				},
 				theme,
 			);

--- a/packages/coding-agent/src/tools/computer-renderer.ts
+++ b/packages/coding-agent/src/tools/computer-renderer.ts
@@ -125,6 +125,7 @@ function renderComputerCell(
 			borderColor: isError ? "error" : "borderMuted",
 			applyBg: false,
 			width,
+			flat: options.renderContext?.flat === true,
 		};
 	});
 }

--- a/packages/coding-agent/src/tools/debug.ts
+++ b/packages/coding-agent/src/tools/debug.ts
@@ -662,6 +662,7 @@ export const debugToolRenderer = {
 						],
 						width,
 						applyBg: false,
+						flat: options.renderContext?.flat === true,
 					},
 					theme,
 				);

--- a/packages/coding-agent/src/tools/eval-render.ts
+++ b/packages/coding-agent/src/tools/eval-render.ts
@@ -458,6 +458,7 @@ function formatCellOutputLines(
 	previewLines: number,
 	theme: Theme,
 	width: number,
+	flat: boolean,
 ): { lines: readonly string[]; hiddenCount: number } {
 	if (!cell.output) {
 		return { lines: [], hiddenCount: 0 };
@@ -468,7 +469,7 @@ function formatCellOutputLines(
 	// at that width so a long-line tail can't wrap into more rows than budgeted
 	// and scroll its mutating preview above the live-region window — the
 	// duplicate "ctrl+o to expand" scrollback spray.
-	const innerWidth = outputBlockContentWidth(width);
+	const innerWidth = outputBlockContentWidth(width, flat);
 
 	if (cell.hasMarkdown && cell.status !== "error") {
 		const md = new Markdown(cell.output, 0, 0, getMarkdownTheme());
@@ -508,7 +509,8 @@ export const evalToolRenderer = {
 
 		return markFramedBlockComponent({
 			render: (width: number): readonly string[] => {
-				const key = `${options.expanded ? 1 : 0}|${options.spinnerFrame ?? "-"}|${previewWindowRows()}|${cells.map(c => `${c.language}:${c.title ?? ""}:${c.code.length}`).join("|")}`;
+				const flat = options.renderContext?.flat === true;
+				const key = `${options.expanded ? 1 : 0}|${options.spinnerFrame ?? "-"}|${flat ? 1 : 0}|${previewWindowRows()}|${cells.map(c => `${c.language}:${c.title ?? ""}:${c.code.length}`).join("|")}`;
 				if (cached && cached.key === key && cached.width === width) {
 					return cached.result;
 				}
@@ -527,6 +529,7 @@ export const evalToolRenderer = {
 							status: options.spinnerFrame !== undefined ? "running" : "pending",
 							spinnerFrame: options.spinnerFrame,
 							width,
+							flat,
 							// Viewport-sized tail window following the newest streamed code
 							// line; renderResult keeps the same cap so the cell never snaps
 							// open on completion. Only ctrl+o uncaps.
@@ -606,7 +609,8 @@ export const evalToolRenderer = {
 						options.renderContext?.previewLines ?? EVAL_DEFAULT_PREVIEW_LINES,
 						previewWindowRows(),
 					);
-					const key = `${expanded}|${previewLines}|${options.spinnerFrame}|${previewWindowRows()}`;
+					const flat = options.renderContext?.flat === true;
+					const key = `${expanded}|${previewLines}|${options.spinnerFrame}|${flat ? 1 : 0}|${previewWindowRows()}`;
 					if (cached && cached.key === key && cached.width === width) {
 						return cached.result;
 					}
@@ -618,7 +622,7 @@ export const evalToolRenderer = {
 						const agentEvents = allEvents.filter(e => e.op === "agent");
 						const otherEvents = agentEvents.length > 0 ? allEvents.filter(e => e.op !== "agent") : allEvents;
 						const statusLines = renderStatusEvents(otherEvents, uiTheme, expanded);
-						const outputContent = formatCellOutputLines(cell, expanded, previewLines, uiTheme, width);
+						const outputContent = formatCellOutputLines(cell, expanded, previewLines, uiTheme, width, flat);
 						const outputLines = [...outputContent.lines];
 						if (!expanded && outputContent.hiddenCount > 0) {
 							outputLines.push(
@@ -651,6 +655,7 @@ export const evalToolRenderer = {
 								codeMaxLines: previewWindowRows(),
 								expanded,
 								width,
+								flat,
 							},
 							uiTheme,
 						);

--- a/packages/coding-agent/src/tools/eval-render.ts
+++ b/packages/coding-agent/src/tools/eval-render.ts
@@ -469,7 +469,7 @@ function formatCellOutputLines(
 	// at that width so a long-line tail can't wrap into more rows than budgeted
 	// and scroll its mutating preview above the live-region window — the
 	// duplicate "ctrl+o to expand" scrollback spray.
-	const innerWidth = outputBlockContentWidth(width, flat);
+	const innerWidth = outputBlockContentWidth(width, undefined, undefined, flat);
 
 	if (cell.hasMarkdown && cell.status !== "error") {
 		const md = new Markdown(cell.output, 0, 0, getMarkdownTheme());

--- a/packages/coding-agent/src/tools/fetch.ts
+++ b/packages/coding-agent/src/tools/fetch.ts
@@ -1815,7 +1815,16 @@ export function renderReadUrlResult(
 		const outputBlock = new CachedOutputBlock();
 		return markFramedBlockComponent({
 			render: (width: number) =>
-				outputBlock.render({ header, state: "error", sections: [{ lines: errorLines }], width }, uiTheme),
+				outputBlock.render(
+					{
+						header,
+						state: "error",
+						sections: [{ lines: errorLines }],
+						width,
+						flat: options.renderContext?.flat === true,
+					},
+					uiTheme,
+				),
 			invalidate: () => outputBlock.invalidate(),
 		});
 	}
@@ -1898,6 +1907,7 @@ export function renderReadUrlResult(
 					],
 					width,
 					applyBg: false,
+					flat: options.renderContext?.flat === true,
 				},
 				uiTheme,
 			);

--- a/packages/coding-agent/src/tools/gh-renderer.ts
+++ b/packages/coding-agent/src/tools/gh-renderer.ts
@@ -364,7 +364,8 @@ function renderFallbackComponent(
 	}
 
 	return framedBlock(theme, width => {
-		const lineWidth = outputBlockContentWidth(width || FALLBACK_WIDTH);
+		const flat = options.renderContext?.flat === true;
+		const lineWidth = outputBlockContentWidth(width || FALLBACK_WIDTH, flat);
 		const expanded = options.expanded;
 		const limit = expanded ? allLines.length : Math.min(allLines.length, PREVIEW_LIMITS.OUTPUT_EXPANDED);
 		const visible = allLines.slice(0, limit);
@@ -386,6 +387,7 @@ function renderFallbackComponent(
 			state: isError ? "error" : "success",
 			borderColor: isError ? "error" : "borderMuted",
 			applyBg: false,
+			flat,
 			width,
 		};
 	});
@@ -464,7 +466,8 @@ export const githubToolRenderer = {
 				uiTheme,
 			);
 			return framedBlock(uiTheme, width => {
-				const innerWidth = outputBlockContentWidth(width || FALLBACK_WIDTH);
+				const flat = options.renderContext?.flat === true;
+				const innerWidth = outputBlockContentWidth(width || FALLBACK_WIDTH, flat);
 				const sections = buildWatchSections(watch, uiTheme, options, innerWidth);
 				return {
 					header,
@@ -472,6 +475,7 @@ export const githubToolRenderer = {
 					state: isError ? "error" : "success",
 					borderColor: isError ? "error" : "borderMuted",
 					applyBg: false,
+					flat,
 					width,
 				};
 			});

--- a/packages/coding-agent/src/tools/gh-renderer.ts
+++ b/packages/coding-agent/src/tools/gh-renderer.ts
@@ -365,7 +365,7 @@ function renderFallbackComponent(
 
 	return framedBlock(theme, width => {
 		const flat = options.renderContext?.flat === true;
-		const lineWidth = outputBlockContentWidth(width || FALLBACK_WIDTH, flat);
+		const lineWidth = outputBlockContentWidth(width || FALLBACK_WIDTH, undefined, undefined, flat);
 		const expanded = options.expanded;
 		const limit = expanded ? allLines.length : Math.min(allLines.length, PREVIEW_LIMITS.OUTPUT_EXPANDED);
 		const visible = allLines.slice(0, limit);
@@ -467,7 +467,7 @@ export const githubToolRenderer = {
 			);
 			return framedBlock(uiTheme, width => {
 				const flat = options.renderContext?.flat === true;
-				const innerWidth = outputBlockContentWidth(width || FALLBACK_WIDTH, flat);
+				const innerWidth = outputBlockContentWidth(width || FALLBACK_WIDTH, undefined, undefined, flat);
 				const sections = buildWatchSections(watch, uiTheme, options, innerWidth);
 				return {
 					header,

--- a/packages/coding-agent/src/tools/hub/launch.ts
+++ b/packages/coding-agent/src/tools/hub/launch.ts
@@ -656,7 +656,8 @@ export function launchRenderResult(
 
 	if (op === "logs") {
 		return framedBlock(theme, width => {
-			const innerWidth = outputBlockContentWidth(width);
+			const flat = options.renderContext?.flat === true;
+			const innerWidth = outputBlockContentWidth(width, flat);
 			const rows = body.map(line => truncateToWidth(line, innerWidth));
 			return {
 				header,
@@ -671,6 +672,7 @@ export function launchRenderResult(
 					},
 				],
 				width,
+				flat,
 			};
 		});
 	}

--- a/packages/coding-agent/src/tools/hub/launch.ts
+++ b/packages/coding-agent/src/tools/hub/launch.ts
@@ -657,7 +657,7 @@ export function launchRenderResult(
 	if (op === "logs") {
 		return framedBlock(theme, width => {
 			const flat = options.renderContext?.flat === true;
-			const innerWidth = outputBlockContentWidth(width, flat);
+			const innerWidth = outputBlockContentWidth(width, undefined, undefined, flat);
 			const rows = body.map(line => truncateToWidth(line, innerWidth));
 			return {
 				header,

--- a/packages/coding-agent/src/tools/inspect-image-renderer.ts
+++ b/packages/coding-agent/src/tools/inspect-image-renderer.ts
@@ -85,6 +85,7 @@ export const inspectImageToolRenderer = {
 					borderColor: "error",
 					applyBg: false,
 					width,
+					flat: options.renderContext?.flat === true,
 				};
 			});
 		}
@@ -126,6 +127,7 @@ export const inspectImageToolRenderer = {
 				borderColor: "borderMuted",
 				applyBg: false,
 				width,
+				flat: options.renderContext?.flat === true,
 			};
 		});
 	},

--- a/packages/coding-agent/src/tools/read-renderer.ts
+++ b/packages/coding-agent/src/tools/read-renderer.ts
@@ -142,7 +142,16 @@ export const readToolRenderer = {
 			const outputBlock = new CachedOutputBlock();
 			return markFramedBlockComponent({
 				render: (width: number) =>
-					outputBlock.render({ header, state: "error", sections: [{ lines: errorLines }], width }, uiTheme),
+					outputBlock.render(
+						{
+							header,
+							state: "error",
+							sections: [{ lines: errorLines }],
+							width,
+							flat: options.renderContext?.flat === true,
+						},
+						uiTheme,
+					),
 				invalidate: () => outputBlock.invalidate(),
 			});
 		}
@@ -207,6 +216,7 @@ export const readToolRenderer = {
 								},
 							],
 							width,
+							flat: options.renderContext?.flat === true,
 						},
 						uiTheme,
 					),
@@ -244,10 +254,13 @@ export const readToolRenderer = {
 		let cachedWidth: number | undefined;
 		let cachedExpanded: boolean | undefined;
 		let cachedLines: string[] | undefined;
+		let cachedFlat: boolean | undefined;
 		return markFramedBlockComponent({
 			render: (width: number) => {
 				const expanded = options.expanded;
-				if (cachedLines && cachedWidth === width && cachedExpanded === expanded) return cachedLines;
+				const flat = options.renderContext?.flat === true;
+				if (cachedLines && cachedWidth === width && cachedExpanded === expanded && cachedFlat === flat)
+					return cachedLines;
 				cachedLines = isMarkdown
 					? renderMarkdownCell(
 							{
@@ -257,6 +270,7 @@ export const readToolRenderer = {
 								output: warningLines.length > 0 ? warningLines.join("\n") : undefined,
 								expanded,
 								width,
+								flat,
 							},
 							uiTheme,
 						)
@@ -271,16 +285,19 @@ export const readToolRenderer = {
 								codeStartLine: details?.displayContent?.startLine,
 								codeLineNumbers: details?.displayContent?.lineNumbers,
 								width,
+								flat,
 							},
 							uiTheme,
 						);
 				cachedWidth = width;
 				cachedExpanded = expanded;
+				cachedFlat = flat;
 				return cachedLines;
 			},
 			invalidate: () => {
 				cachedWidth = undefined;
 				cachedExpanded = undefined;
+				cachedFlat = undefined;
 				cachedLines = undefined;
 			},
 		});

--- a/packages/coding-agent/src/tools/todo.ts
+++ b/packages/coding-agent/src/tools/todo.ts
@@ -1167,6 +1167,7 @@ export const todoToolRenderer = {
 				state: "error",
 				borderColor: "error",
 				width,
+				flat: options.renderContext?.flat === true,
 			}));
 		}
 
@@ -1266,6 +1267,7 @@ export const todoToolRenderer = {
 				borderColor: "borderMuted",
 				applyBg: false,
 				width,
+				flat: options.renderContext?.flat === true,
 			};
 		});
 	},

--- a/packages/coding-agent/src/tools/write.ts
+++ b/packages/coding-agent/src/tools/write.ts
@@ -1592,6 +1592,8 @@ function renderContentPreview(
 /** Render context for the write tool: resolves an `xd://`-mounted tool so its live renderer drives device dispatch previews. */
 export interface WriteRenderContext {
 	resolveXdevMounted?: (name: string) => AgentTool | undefined;
+	/** Flat opencode layout (owning mode); forwarded to renderOutputBlock. */
+	flat?: boolean;
 }
 
 export const writeToolRenderer = {
@@ -1680,6 +1682,7 @@ export const writeToolRenderer = {
 				state: "pending",
 				borderColor: "borderMuted",
 				width,
+				flat: options?.renderContext?.flat === true,
 			};
 		});
 	},
@@ -1723,6 +1726,7 @@ export const writeToolRenderer = {
 				state: "error",
 				borderColor: "error",
 				width,
+				flat: options.renderContext?.flat === true,
 			}));
 		}
 
@@ -1776,6 +1780,7 @@ export const writeToolRenderer = {
 				state: isPartial ? "pending" : "success",
 				borderColor: "borderMuted",
 				width,
+				flat: options.renderContext?.flat === true,
 			};
 		});
 	},

--- a/packages/coding-agent/src/tui/code-cell.ts
+++ b/packages/coding-agent/src/tui/code-cell.ts
@@ -42,6 +42,8 @@ export interface CodeCellOptions {
 	width: number;
 	codeStartLine?: number;
 	codeLineNumbers?: Array<number | null>;
+	/** Render flat (opencode layout); forwarded to {@link renderOutputBlock}. */
+	flat?: boolean;
 }
 
 function getState(status?: CodeCellOptions["status"]): State | undefined {
@@ -197,7 +199,7 @@ export function renderCodeCell(options: CodeCellOptions, theme: Theme): string[]
 		sections.push({ label: theme.fg("toolTitle", "Output"), lines: outputLines });
 	}
 
-	return renderOutputBlock({ header: title, headerMeta: meta, state, sections, width }, theme);
+	return renderOutputBlock({ header: title, headerMeta: meta, state, sections, width, flat: options.flat }, theme);
 }
 
 export interface MarkdownCellOptions {
@@ -213,6 +215,8 @@ export interface MarkdownCellOptions {
 	contentMaxLines?: number;
 	expanded?: boolean;
 	width: number;
+	/** Render flat (opencode layout); forwarded to {@link renderOutputBlock}. */
+	flat?: boolean;
 }
 
 export function renderMarkdownCell(options: MarkdownCellOptions, theme: Theme): string[] {
@@ -226,13 +230,14 @@ export function renderMarkdownCell(options: MarkdownCellOptions, theme: Theme): 
 		spinnerFrame: options.spinnerFrame,
 		duration: options.duration,
 		width,
+		flat: options.flat,
 	};
 	const { title, meta } = formatHeader(codeOptions, theme);
 	const state = getState(options.status);
 
 	// Markdown component manages its own wrapping at the same inner width as
 	// `renderOutputBlock`, so collapsed row caps are applied after final wrapping.
-	const innerWidth = Math.max(20, outputBlockContentWidth(width));
+	const innerWidth = Math.max(20, outputBlockContentWidth(width, options.flat));
 	const allLines = content.trim() ? new Markdown(content, 0, 0, getMarkdownTheme()).render(innerWidth) : [];
 	const maxContentLines = expanded ? allLines.length : Math.min(allLines.length, contentMaxLines);
 	const contentLines = allLines.slice(0, maxContentLines);
@@ -264,5 +269,5 @@ export function renderMarkdownCell(options: MarkdownCellOptions, theme: Theme): 
 		sections.push({ label: theme.fg("toolTitle", "Output"), lines: outputLines });
 	}
 
-	return renderOutputBlock({ header: title, headerMeta: meta, state, sections, width }, theme);
+	return renderOutputBlock({ header: title, headerMeta: meta, state, sections, width, flat: options.flat }, theme);
 }

--- a/packages/coding-agent/src/tui/code-cell.ts
+++ b/packages/coding-agent/src/tui/code-cell.ts
@@ -237,7 +237,7 @@ export function renderMarkdownCell(options: MarkdownCellOptions, theme: Theme): 
 
 	// Markdown component manages its own wrapping at the same inner width as
 	// `renderOutputBlock`, so collapsed row caps are applied after final wrapping.
-	const innerWidth = Math.max(20, outputBlockContentWidth(width, options.flat));
+	const innerWidth = Math.max(20, outputBlockContentWidth(width, undefined, undefined, options.flat));
 	const allLines = content.trim() ? new Markdown(content, 0, 0, getMarkdownTheme()).render(innerWidth) : [];
 	const maxContentLines = expanded ? allLines.length : Math.min(allLines.length, contentMaxLines);
 	const contentLines = allLines.slice(0, maxContentLines);

--- a/packages/coding-agent/src/tui/output-block.ts
+++ b/packages/coding-agent/src/tui/output-block.ts
@@ -2,7 +2,7 @@
  * Bordered output container with optional header and sections.
  */
 import type { Component } from "@oh-my-pi/pi-tui";
-import { ImageProtocol, padding, TERMINAL, visibleWidth, wrapTextWithAnsi } from "@oh-my-pi/pi-tui";
+import { ImageProtocol, padding, replaceTabs, TERMINAL, visibleWidth, wrapTextWithAnsi } from "@oh-my-pi/pi-tui";
 import type { Theme, ThemeColor } from "../modes/theme/theme";
 import { getSixelLineMask } from "../utils/sixel";
 import type { State } from "./types";
@@ -82,13 +82,17 @@ export function renderOutputBlock(options: OutputBlockOptions, theme: Theme): st
 	if (options.flat) {
 		const flatWidth = Math.max(0, options.width);
 		const lines: string[] = [];
-		const labelText = [options.header, options.headerMeta].filter(Boolean).join(theme.sep.dot);
+		const labelText = [options.header, options.headerMeta]
+			.filter((value): value is string => Boolean(value))
+			.map(replaceTabs)
+			.join(theme.sep.dot);
 		if (labelText) lines.push(truncateToWidth(labelText, flatWidth));
 		const indent = padding(2);
 		const flatContentWidth = Math.max(1, flatWidth - 2);
 		const flatSections = options.sections ?? [];
 		for (const section of flatSections) {
-			if (section.label) lines.push(`${indent}${theme.fg("dim", truncateToWidth(section.label, flatContentWidth))}`);
+			if (section.label)
+				lines.push(`${indent}${theme.fg("dim", truncateToWidth(replaceTabs(section.label), flatContentWidth))}`);
 			const sectionLines = section.lines.flatMap(l => l.split("\n"));
 			const sixelMask = TERMINAL.imageProtocol === ImageProtocol.Sixel ? getSixelLineMask(sectionLines) : undefined;
 			for (let i = 0; i < sectionLines.length; i++) {

--- a/packages/coding-agent/src/tui/output-block.ts
+++ b/packages/coding-agent/src/tui/output-block.ts
@@ -85,7 +85,7 @@ export function renderOutputBlock(options: OutputBlockOptions, theme: Theme): st
 		const flatContentWidth = Math.max(1, flatWidth - 2);
 		const flatSections = options.sections ?? [];
 		for (const section of flatSections) {
-			if (section.label) lines.push(`${indent}${theme.fg("dim", section.label)}`);
+			if (section.label) lines.push(`${indent}${theme.fg("dim", truncateToWidth(section.label, flatContentWidth))}`);
 			const sectionLines = section.lines.flatMap(l => l.split("\n"));
 			const sixelMask = TERMINAL.imageProtocol === ImageProtocol.Sixel ? getSixelLineMask(sectionLines) : undefined;
 			for (let i = 0; i < sectionLines.length; i++) {

--- a/packages/coding-agent/src/tui/output-block.ts
+++ b/packages/coding-agent/src/tui/output-block.ts
@@ -56,12 +56,15 @@ function normalizeContentPaddingLeft(value: number | undefined): number {
  * content padding. Flat (opencode layout): the two-column indent only. An
  * explicit left padding of zero keeps legacy flush blocks flush on both sides
  * unless a right padding is provided separately.
+ *
+ * `flat` is deliberately the LAST parameter: the padding parameters keep their
+ * pre-opencode positions so precompiled extension callers stay compatible.
  */
 export function outputBlockContentWidth(
 	width: number,
-	flat?: boolean,
 	contentPaddingLeft?: number,
 	contentPaddingRight?: number,
+	flat?: boolean,
 ): number {
 	if (flat) return Math.max(1, width - 2);
 	const left = normalizeContentPaddingLeft(contentPaddingLeft);

--- a/packages/coding-agent/src/tui/output-block.ts
+++ b/packages/coding-agent/src/tui/output-block.ts
@@ -3,6 +3,7 @@
  */
 import type { Component } from "@oh-my-pi/pi-tui";
 import { ImageProtocol, padding, TERMINAL, visibleWidth, wrapTextWithAnsi } from "@oh-my-pi/pi-tui";
+import { isOpencodeLayout } from "../modes/layout-mode";
 import type { Theme, ThemeColor } from "../modes/theme/theme";
 import { getSixelLineMask } from "../utils/sixel";
 import type { State } from "./types";
@@ -64,6 +65,36 @@ export function outputBlockContentWidth(
 }
 
 export function renderOutputBlock(options: OutputBlockOptions, theme: Theme): string[] {
+	// Opencode layout: no frame at all. The header renders as a plain status
+	// row (ToolExecutionComponent's collapsed view slices exactly this row) and
+	// section content renders flat, indented two columns, with no background
+	// tint. Every framed tool (bash, eval, read, fetch, task, …) routes through
+	// here, so this single branch is what makes the whole transcript flat.
+	if (isOpencodeLayout()) {
+		const flatWidth = Math.max(0, options.width);
+		const lines: string[] = [];
+		const labelText = [options.header, options.headerMeta].filter(Boolean).join(theme.sep.dot);
+		if (labelText) lines.push(truncateToWidth(labelText, flatWidth));
+		const indent = padding(2);
+		const flatContentWidth = Math.max(1, flatWidth - 2);
+		const flatSections = options.sections ?? [];
+		for (const section of flatSections) {
+			if (section.label) lines.push(`${indent}${theme.fg("dim", section.label)}`);
+			const sectionLines = section.lines.flatMap(l => l.split("\n"));
+			const sixelMask = TERMINAL.imageProtocol === ImageProtocol.Sixel ? getSixelLineMask(sectionLines) : undefined;
+			for (let i = 0; i < sectionLines.length; i++) {
+				const line = sectionLines[i]!;
+				if (sixelMask?.[i]) {
+					lines.push(line);
+					continue;
+				}
+				for (const wrapped of wrapTextWithAnsi(line.trimEnd(), flatContentWidth)) {
+					lines.push(`${indent}${wrapped}`);
+				}
+			}
+		}
+		return lines;
+	}
 	const { header, headerMeta, state, sections = [], width, applyBg = true } = options;
 	const h = theme.boxRound.horizontal;
 	const v = theme.boxRound.vertical;
@@ -226,6 +257,8 @@ export class CachedOutputBlock {
 	#buildKey(options: OutputBlockOptions): bigint {
 		const h = new Hasher();
 		h.u32(options.width);
+		// A live layout toggle changes the rendered shape for identical options.
+		h.bool(isOpencodeLayout());
 		h.u32(normalizeContentPaddingLeft(options.contentPaddingLeft));
 		h.u32(
 			normalizeContentPaddingLeft(

--- a/packages/coding-agent/src/tui/output-block.ts
+++ b/packages/coding-agent/src/tui/output-block.ts
@@ -3,7 +3,6 @@
  */
 import type { Component } from "@oh-my-pi/pi-tui";
 import { ImageProtocol, padding, TERMINAL, visibleWidth, wrapTextWithAnsi } from "@oh-my-pi/pi-tui";
-import { isOpencodeLayout } from "../modes/layout-mode";
 import type { Theme, ThemeColor } from "../modes/theme/theme";
 import { getSixelLineMask } from "../utils/sixel";
 import type { State } from "./types";
@@ -19,6 +18,9 @@ export interface OutputBlockOptions {
 	applyBg?: boolean;
 	contentPaddingLeft?: number;
 	contentPaddingRight?: number;
+	/** Render flat (opencode layout): no frame, no borders, no state background.
+	 * Tool renderers resolve this from their render context's `flat` flag. */
+	flat?: boolean;
 	/** Override the state-derived border color. Used for muted "legacy" tool
 	 * frames that should not visually compete with framed-output tools. */
 	borderColor?: ThemeColor;
@@ -50,27 +52,31 @@ function normalizeContentPaddingLeft(value: number | undefined): number {
 
 /**
  * Inner content width that {@link renderOutputBlock} wraps its body to, for a
- * given outer `width`: both vertical borders plus symmetric content padding.
- * An explicit left padding of zero keeps legacy flush blocks flush on both
- * sides unless a right padding is provided separately.
+ * given outer `width`. Framed (default): both vertical borders plus symmetric
+ * content padding. Flat (opencode layout): the two-column indent only. An
+ * explicit left padding of zero keeps legacy flush blocks flush on both sides
+ * unless a right padding is provided separately.
  */
 export function outputBlockContentWidth(
 	width: number,
+	flat?: boolean,
 	contentPaddingLeft?: number,
 	contentPaddingRight?: number,
 ): number {
+	if (flat) return Math.max(1, width - 2);
 	const left = normalizeContentPaddingLeft(contentPaddingLeft);
 	const right = normalizeContentPaddingLeft(contentPaddingRight ?? left);
 	return Math.max(1, width - 2 - left - right);
 }
 
 export function renderOutputBlock(options: OutputBlockOptions, theme: Theme): string[] {
-	// Opencode layout: no frame at all. The header renders as a plain status
-	// row (ToolExecutionComponent's collapsed view slices exactly this row) and
-	// section content renders flat, indented two columns, with no background
-	// tint. Every framed tool (bash, eval, read, fetch, task, …) routes through
-	// here, so this single branch is what makes the whole transcript flat.
-	if (isOpencodeLayout()) {
+	// Flat (opencode layout): no frame at all. The header renders as a plain
+	// status row (ToolExecutionComponent's collapsed view slices exactly this
+	// row) and section content renders flat, indented two columns, with no
+	// background tint. Every framed tool (bash, eval, read, fetch, task, …)
+	// routes through here, so this single branch is what makes the whole
+	// transcript flat.
+	if (options.flat) {
 		const flatWidth = Math.max(0, options.width);
 		const lines: string[] = [];
 		const labelText = [options.header, options.headerMeta].filter(Boolean).join(theme.sep.dot);
@@ -258,7 +264,7 @@ export class CachedOutputBlock {
 		const h = new Hasher();
 		h.u32(options.width);
 		// A live layout toggle changes the rendered shape for identical options.
-		h.bool(isOpencodeLayout());
+		h.bool(options.flat ?? false);
 		h.u32(normalizeContentPaddingLeft(options.contentPaddingLeft));
 		h.u32(
 			normalizeContentPaddingLeft(

--- a/packages/coding-agent/src/web/search/render.ts
+++ b/packages/coding-agent/src/web/search/render.ts
@@ -165,7 +165,7 @@ export function renderSearchResult(
 
 			// Answer lines: full markdown when expanded, capped markdown preview when collapsed.
 			const flat = options.renderContext?.flat === true;
-			const answerWidth = outputBlockContentWidth(width, flat);
+			const answerWidth = outputBlockContentWidth(width, undefined, undefined, flat);
 			const renderedAnswer = answerMarkdown ? answerMarkdown.render(answerWidth) : [];
 			let answerLines: readonly string[];
 			if (renderedAnswer.length === 0) {

--- a/packages/coding-agent/src/web/search/render.ts
+++ b/packages/coding-agent/src/web/search/render.ts
@@ -60,13 +60,18 @@ export interface SearchRenderDetails {
 }
 
 /** Render a web search failure as a framed error panel, matching the success layout. */
-function renderSearchErrorPanel(message: string, providerLabel: string | undefined, theme: Theme): Component {
+function renderSearchErrorPanel(
+	message: string,
+	providerLabel: string | undefined,
+	theme: Theme,
+	flat: boolean,
+): Component {
 	const header = renderStatusLine({ icon: "error", title: "Web Search", description: providerLabel }, theme);
 	const body = theme.fg("error", `Error: ${replaceTabs(message)}`);
 	const outputBlock = new CachedOutputBlock();
 	return markFramedBlockComponent({
 		render(width: number): readonly string[] {
-			return outputBlock.render({ header, state: "error", sections: [{ lines: [body] }], width }, theme);
+			return outputBlock.render({ header, state: "error", sections: [{ lines: [body] }], width, flat }, theme);
 		},
 		invalidate() {
 			outputBlock.invalidate();
@@ -91,7 +96,7 @@ export function renderSearchResult(
 		const errorProvider = details.response?.provider;
 		const errorProviderLabel =
 			errorProvider && errorProvider !== "none" ? getSearchProviderLabel(errorProvider) : undefined;
-		return renderSearchErrorPanel(details.error, errorProviderLabel, theme);
+		return renderSearchErrorPanel(details.error, errorProviderLabel, theme, options.renderContext?.flat === true);
 	}
 
 	const rawText = result.content?.find(block => block.type === "text")?.text?.trim() ?? "";
@@ -159,7 +164,8 @@ export function renderSearchResult(
 			const { expanded } = options;
 
 			// Answer lines: full markdown when expanded, capped markdown preview when collapsed.
-			const answerWidth = outputBlockContentWidth(width);
+			const flat = options.renderContext?.flat === true;
+			const answerWidth = outputBlockContentWidth(width, flat);
 			const renderedAnswer = answerMarkdown ? answerMarkdown.render(answerWidth) : [];
 			let answerLines: readonly string[];
 			if (renderedAnswer.length === 0) {
@@ -234,6 +240,7 @@ export function renderSearchResult(
 						{ label: theme.fg("toolTitle", "Metadata"), lines: metaLines },
 					],
 					width,
+					flat,
 				},
 				theme,
 			);

--- a/packages/coding-agent/test/extensions-render-context.typecheck.ts
+++ b/packages/coding-agent/test/extensions-render-context.typecheck.ts
@@ -1,0 +1,6 @@
+import type { ToolRenderResultOptions } from "@oh-my-pi/pi-coding-agent/extensibility/extensions";
+
+type Assert<T extends true> = T;
+type _RenderContext = Assert<
+	[ToolRenderResultOptions["renderContext"]] extends [Record<string, unknown> | undefined] ? true : false
+>;

--- a/packages/coding-agent/test/opencode-layout.test.ts
+++ b/packages/coding-agent/test/opencode-layout.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, beforeAll, describe, expect, it } from "bun:test";
+import { stripVTControlCharacters } from "node:util";
+import type { AgentTool } from "@oh-my-pi/pi-agent-core";
+import { ToolExecutionComponent } from "@oh-my-pi/pi-coding-agent/modes/components/tool-execution";
+import { UserMessageComponent } from "@oh-my-pi/pi-coding-agent/modes/components/user-message";
+import { setLayoutMode } from "@oh-my-pi/pi-coding-agent/modes/layout-mode";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { Text, type TUI } from "@oh-my-pi/pi-tui";
+
+/**
+ * Contract under test (`display.layout: "opencode"`):
+ *
+ * - A collapsed tool block renders as exactly one row — its status line (the
+ *   first visible row of the card) — instead of the full card.
+ * - `setExpanded(true)` (Ctrl+O) restores the complete card.
+ * - An error result never collapses: the message must stay readable.
+ * - The default `omp` layout is untouched by the flag round-trip.
+ * - User messages gain a left gutter column in opencode layout.
+ */
+describe("opencode layout", () => {
+	beforeAll(async () => {
+		await initTheme();
+	});
+
+	afterEach(() => {
+		// Full-suite safety: never leak the layout flag into other test files.
+		setLayoutMode("omp");
+	});
+
+	const ui = { requestRender() {}, requestComponentRender() {} } as unknown as TUI;
+
+	interface MultiLineTool {
+		name: string;
+		label: string;
+		/** Mirror the built-in renderers: the result's first row is the status header. */
+		mergeCallAndResult: boolean;
+		renderResult(result: { content: Array<{ type: string; text?: string }> }): Text;
+	}
+
+	function makeMultiLineTool(): MultiLineTool {
+		return {
+			name: "custom_render",
+			label: "Custom",
+			mergeCallAndResult: true,
+			renderResult(result) {
+				const joined = result.content.map(c => c.text ?? "").join("");
+				return new Text(`HEADLINE ${joined}\nDETAIL-1\nDETAIL-2`, 0, 0);
+			},
+		};
+	}
+
+	function makeComponent(tool: MultiLineTool): ToolExecutionComponent {
+		return new ToolExecutionComponent("custom_render", {}, {}, tool as unknown as AgentTool, ui, process.cwd());
+	}
+
+	function visibleRows(component: ToolExecutionComponent, width = 80): string[] {
+		return component
+			.render(width)
+			.map(line => stripVTControlCharacters(line))
+			.filter(line => /\S/.test(line));
+	}
+
+	it("collapses a finalized tool block to its status line; expand restores the card", () => {
+		setLayoutMode("opencode");
+		const component = makeComponent(makeMultiLineTool());
+		component.updateResult({ content: [{ type: "text", text: "ok" }] }, false);
+
+		const collapsed = visibleRows(component);
+		expect(collapsed).toHaveLength(1);
+		expect(collapsed[0]).toContain("HEADLINE ok");
+		expect(collapsed[0]).not.toContain("DETAIL-1");
+
+		component.setExpanded(true);
+		const expanded = visibleRows(component).join("\n");
+		expect(expanded).toContain("DETAIL-1");
+		expect(expanded).toContain("DETAIL-2");
+	});
+
+	it("never collapses an error result", () => {
+		setLayoutMode("opencode");
+		const component = makeComponent(makeMultiLineTool());
+		component.updateResult({ content: [{ type: "text", text: "boom" }], isError: true }, false);
+
+		const rows = visibleRows(component).join("\n");
+		expect(rows).toContain("DETAIL-2");
+	});
+
+	it("keeps the full card in the default omp layout after a flag round-trip", () => {
+		setLayoutMode("opencode");
+		setLayoutMode("omp");
+		const component = makeComponent(makeMultiLineTool());
+		component.updateResult({ content: [{ type: "text", text: "ok" }] }, false);
+
+		expect(visibleRows(component).join("\n")).toContain("DETAIL-2");
+	});
+
+	it("prefixes user messages with a left gutter only in opencode layout", () => {
+		setLayoutMode("opencode");
+		const withGutter = stripVTControlCharacters(new UserMessageComponent("hello world").render(60)[0]!);
+		expect(withGutter.trimStart().startsWith("│")).toBe(true);
+
+		setLayoutMode("omp");
+		const plain = stripVTControlCharacters(new UserMessageComponent("hello world").render(60)[0]!);
+		expect(plain).not.toContain("│");
+	});
+});

--- a/packages/coding-agent/test/opencode-layout.test.ts
+++ b/packages/coding-agent/test/opencode-layout.test.ts
@@ -6,6 +6,8 @@ import type { AgentTool } from "@oh-my-pi/pi-agent-core";
 import { resetSettingsForTest, Settings, settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { ToolExecutionComponent } from "@oh-my-pi/pi-coding-agent/modes/components/tool-execution";
 import { UserMessageComponent } from "@oh-my-pi/pi-coding-agent/modes/components/user-message";
+import { taskToolRenderer } from "@oh-my-pi/pi-coding-agent/task/renderer";
+import type { TaskToolDetails } from "@oh-my-pi/pi-coding-agent/task/types";
 import type { LayoutMode } from "@oh-my-pi/pi-coding-agent/modes/layout-mode";
 import { loadTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/loader";
 import { getThemeByName, initTheme, setThemeInstance, theme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
@@ -239,6 +241,36 @@ describe("opencode layout", () => {
 		}
 	});
 
+	it("keeps the OSC-8 link around a truncated collapsed write path", () => {
+		settings.override("tui.hyperlinks", "always");
+		try {
+			const filePath = "src/a-directory-with-a-long-name/example.ts";
+			const resolvedPath = path.resolve("/workspace", filePath);
+			const component = new ToolExecutionComponent(
+				"write",
+				{ file_path: filePath, content: "hello\n" },
+				{ layout: opencode },
+				undefined,
+				ui,
+				process.cwd(),
+			);
+			component.updateResult(
+				{ content: [{ type: "text", text: "Wrote 1 lines" }], details: { resolvedPath } },
+				false,
+			);
+
+			const [row] = component.render(48).filter(line => /\S/.test(stripVTControlCharacters(line)));
+			const open = row!.search(/\x1b]8;[^;]*;/);
+			const close = row!.indexOf("\x1b]8;;", open + 1);
+			expect(open).toBeGreaterThanOrEqual(0);
+			expect(close).toBeGreaterThan(open);
+			expect(row!.slice(open, close)).toContain("src/a");
+			expect(stripVTControlCharacters(row!)).toContain("…");
+		} finally {
+			settings.clearOverride("tui.hyperlinks");
+		}
+	});
+
 	it("keeps both OSC-8 links, in order, in a collapsed rename header", () => {
 		// A rename/move edit header carries two links: source and destination.
 		// The collapse restyle must re-wrap every span, not just the first.
@@ -423,6 +455,75 @@ describe("opencode layout", () => {
 		} finally {
 			setThemeInstance(baseTheme);
 		}
+	});
+
+	it("strips TaskTool's built-in ascii done icon but preserves custom renderer text", async () => {
+		const baseTheme = await getThemeByName("dark");
+		if (!baseTheme) throw new Error("theme unavailable");
+		setThemeInstance(await loadTheme("dark", { symbolPresetOverride: "ascii" }));
+		try {
+			const taskTool = {
+				name: "task",
+				label: "Task",
+				mergeCallAndResult: true,
+				renderResult: taskToolRenderer.renderResult,
+			};
+			const component = new ToolExecutionComponent(
+				"task",
+				{},
+				{ layout: opencode },
+				taskTool as unknown as AgentTool,
+				ui,
+				process.cwd(),
+			);
+			component.updateResult({ content: [] }, false);
+
+			const [row] = visibleRows(component);
+			expect(row).toBe(" # Task");
+			expect(row).not.toContain("* Task");
+		} finally {
+			setThemeInstance(baseTheme);
+		}
+	});
+
+	it("keeps aggregate task failures expanded", () => {
+		const taskTool = {
+			name: "task",
+			label: "Task",
+			mergeCallAndResult: true,
+			renderResult: taskToolRenderer.renderResult,
+		};
+		const details: TaskToolDetails = {
+			projectAgentsDir: null,
+			totalDurationMs: 0,
+			results: [
+				{
+					index: 0,
+					id: "worker",
+					agent: "task",
+					agentSource: "bundled",
+					task: "fails",
+					exitCode: 1,
+					output: "failure",
+					stderr: "boom",
+					truncated: false,
+					durationMs: 0,
+					tokens: 0,
+					requests: 0,
+				},
+			],
+		};
+		const component = new ToolExecutionComponent(
+			"task",
+			{},
+			{ layout: opencode },
+			taskTool as unknown as AgentTool,
+			ui,
+			process.cwd(),
+		);
+		component.updateResult({ content: [], details }, false);
+
+		expect(visibleRows(component).join("\n")).toContain("failure");
 	});
 
 	it("renders an ascii squeezed settled row through the oc.* marker, not `•`", async () => {

--- a/packages/coding-agent/test/opencode-layout.test.ts
+++ b/packages/coding-agent/test/opencode-layout.test.ts
@@ -1,12 +1,15 @@
-import { beforeAll, describe, expect, it } from "bun:test";
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import * as path from "node:path";
+import * as url from "node:url";
 import { stripVTControlCharacters } from "node:util";
 import type { AgentTool } from "@oh-my-pi/pi-agent-core";
+import { resetSettingsForTest, Settings, settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { ToolExecutionComponent } from "@oh-my-pi/pi-coding-agent/modes/components/tool-execution";
 import { UserMessageComponent } from "@oh-my-pi/pi-coding-agent/modes/components/user-message";
 import type { LayoutMode } from "@oh-my-pi/pi-coding-agent/modes/layout-mode";
 import { initTheme, theme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
-import { CachedOutputBlock } from "@oh-my-pi/pi-coding-agent/tui/output-block";
-import { Text, type TUI } from "@oh-my-pi/pi-tui";
+import { CachedOutputBlock, markFramedBlockComponent } from "@oh-my-pi/pi-coding-agent/tui/output-block";
+import { replaceTabs, Text, type TUI } from "@oh-my-pi/pi-tui";
 
 /**
  * Contract under test (`display.layout: "opencode"`):
@@ -24,7 +27,13 @@ import { Text, type TUI } from "@oh-my-pi/pi-tui";
  */
 describe("opencode layout", () => {
 	beforeAll(async () => {
+		resetSettingsForTest();
+		await Settings.init({ inMemory: true });
 		await initTheme();
+	});
+
+	afterAll(() => {
+		resetSettingsForTest();
 	});
 
 	const ui = { requestRender() {}, requestComponentRender() {} } as unknown as TUI;
@@ -143,6 +152,59 @@ describe("opencode layout", () => {
 			new UserMessageComponent("hello world", false, undefined, omp).render(60)[0]!,
 		);
 		expect(plain).not.toContain("│");
+	});
+
+	it("keeps the OSC-8 file link in a collapsed write row", () => {
+		settings.override("tui.hyperlinks", "always");
+		try {
+			const resolvedPath = path.resolve("/workspace/src/example.ts");
+			const component = new ToolExecutionComponent(
+				"write",
+				{ file_path: "src/example.ts", content: "hello\n" },
+				{ layout: opencode },
+				undefined,
+				ui,
+				process.cwd(),
+			);
+			component.updateResult(
+				{ content: [{ type: "text", text: "Wrote 1 lines" }], details: { resolvedPath } },
+				false,
+			);
+
+			const rows = component.render(120).filter(line => /\S/.test(stripVTControlCharacters(line)));
+			expect(rows).toHaveLength(1);
+			// The dim restyle must retain the renderer's own OSC-8 link — same
+			// URI the framed header carried (write links details.resolvedPath).
+			expect(rows[0]).toContain(url.pathToFileURL(resolvedPath).href);
+			expect(rows[0]).toContain("\x1b]8;;");
+			expect(stripVTControlCharacters(rows[0]!)).toContain("example.ts");
+		} finally {
+			settings.clearOverride("tui.hyperlinks");
+		}
+	});
+
+	it("normalizes tabs so a collapsed row stays one clean line", () => {
+		// Framed (self-drawing) renderers pass their rows through verbatim —
+		// truncateToWidth's short-string fast path preserves a raw `\t` — so the
+		// collapse restyle is the last place that can normalize it.
+		const tool: MultiLineTool = {
+			name: "custom_render",
+			label: "Custom",
+			mergeCallAndResult: true,
+			renderResult() {
+				return markFramedBlockComponent({
+					render: () => ["HEAD\tLINE ok", "DETAIL-1"],
+					invalidate() {},
+				}) as unknown as Text;
+			},
+		};
+		const component = makeComponent(tool, opencode);
+		component.updateResult({ content: [{ type: "text", text: "ok" }] }, false);
+
+		const rows = component.render(80).filter(line => /\S/.test(stripVTControlCharacters(line)));
+		expect(rows).toHaveLength(1);
+		expect(rows[0]).not.toContain("\t");
+		expect(stripVTControlCharacters(rows[0]!)).toContain(replaceTabs("HEAD\tLINE ok"));
 	});
 
 	it("keys CachedOutputBlock on the explicit flat option", () => {

--- a/packages/coding-agent/test/opencode-layout.test.ts
+++ b/packages/coding-agent/test/opencode-layout.test.ts
@@ -94,6 +94,61 @@ describe("opencode layout", () => {
 		expect(expanded).toContain("DETAIL-2");
 	});
 
+	it("collapses a multi-file edit to one dim status row per file", () => {
+		settings.override("tui.hyperlinks", "always");
+		try {
+			const paths = ["alpha.ts", "beta.ts", "gamma.ts"].map(name => path.resolve("/workspace/src", name));
+			const component = new ToolExecutionComponent(
+				"edit",
+				{ edits: paths.map(path => ({ path, oldText: "before", newText: "after" })) },
+				{ layout: opencode },
+				undefined,
+				ui,
+				process.cwd(),
+			);
+			component.updateResult(
+				{
+					content: [],
+					details: { perFileResults: paths.map(path => ({ path, diff: "" })) },
+				},
+				false,
+			);
+
+			const rows = component.render(80).filter(line => /\S/.test(stripVTControlCharacters(line)));
+			expect(rows).toHaveLength(3);
+			for (const [index, row] of rows.entries()) {
+				expect(row).toContain(theme.getFgAnsi("dim"));
+				expect(row).toContain(url.pathToFileURL(paths[index]!).href);
+				expect(stripVTControlCharacters(row)).toContain(paths[index]!);
+			}
+		} finally {
+			settings.clearOverride("tui.hyperlinks");
+		}
+	});
+
+	it("bounds collapsed multi-file edits with a remaining-files row", () => {
+		const paths = Array.from({ length: 10 }, (_, index) => `src/file-${index}.ts`);
+		const component = new ToolExecutionComponent(
+			"edit",
+			{ edits: paths.map(path => ({ path, oldText: "before", newText: "after" })) },
+			{ layout: opencode },
+			undefined,
+			ui,
+			process.cwd(),
+		);
+		component.updateResult(
+			{
+				content: [],
+				details: { perFileResults: paths.map(path => ({ path, diff: "" })) },
+			},
+			false,
+		);
+
+		const rows = visibleRows(component);
+		expect(rows).toHaveLength(9);
+		expect(rows.at(-1)).toContain("... +2 more");
+	});
+
 	it("never collapses an error result", () => {
 		const component = makeComponent(makeMultiLineTool(), opencode);
 		component.updateResult({ content: [{ type: "text", text: "boom" }], isError: true }, false);

--- a/packages/coding-agent/test/opencode-layout.test.ts
+++ b/packages/coding-agent/test/opencode-layout.test.ts
@@ -7,7 +7,8 @@ import { resetSettingsForTest, Settings, settings } from "@oh-my-pi/pi-coding-ag
 import { ToolExecutionComponent } from "@oh-my-pi/pi-coding-agent/modes/components/tool-execution";
 import { UserMessageComponent } from "@oh-my-pi/pi-coding-agent/modes/components/user-message";
 import type { LayoutMode } from "@oh-my-pi/pi-coding-agent/modes/layout-mode";
-import { initTheme, theme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { loadTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/loader";
+import { getThemeByName, initTheme, setThemeInstance, theme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import { CachedOutputBlock, markFramedBlockComponent } from "@oh-my-pi/pi-coding-agent/tui/output-block";
 import { replaceTabs, Text, type TUI } from "@oh-my-pi/pi-tui";
 
@@ -257,5 +258,34 @@ describe("opencode layout", () => {
 		expect(stripVTControlCharacters(framed)).toContain(theme.boxRound.topLeft);
 		expect(stripVTControlCharacters(flat)).not.toContain(theme.boxRound.topLeft);
 		expect(framedAgain).toBe(framed);
+	});
+
+	it("renders ascii-preset collapsed rows without Unicode glyphs", async () => {
+		const baseTheme = await getThemeByName("dark");
+		if (!baseTheme) throw new Error("theme unavailable");
+		setThemeInstance(await loadTheme("dark", { symbolPresetOverride: "ascii" }));
+		try {
+			// One mapped name per glyph family plus an unmapped fallback.
+			const rows = ["write", "task", "custom_render"].map(name => {
+				const tool = { ...makeMultiLineTool(), name };
+				const component = new ToolExecutionComponent(
+					name,
+					{},
+					{ layout: opencode },
+					tool as unknown as AgentTool,
+					ui,
+					process.cwd(),
+				);
+				component.updateResult({ content: [{ type: "text", text: "ok" }] }, false);
+				return stripVTControlCharacters(component.render(80).join("\n"));
+			});
+			expect(rows[0]).toContain("<- HEADLINE ok");
+			expect(rows[1]).toContain("# HEADLINE ok");
+			// Unmapped tools fall back to the search glyph.
+			expect(rows[2]).toContain("* HEADLINE ok");
+			for (const row of rows) expect(row).toMatch(/^[\x20-\x7E]*$/);
+		} finally {
+			setThemeInstance(baseTheme);
+		}
 	});
 });

--- a/packages/coding-agent/test/opencode-layout.test.ts
+++ b/packages/coding-agent/test/opencode-layout.test.ts
@@ -8,6 +8,7 @@ import { ToolExecutionComponent } from "@oh-my-pi/pi-coding-agent/modes/componen
 import { UserMessageComponent } from "@oh-my-pi/pi-coding-agent/modes/components/user-message";
 import type { LayoutMode } from "@oh-my-pi/pi-coding-agent/modes/layout-mode";
 import { loadTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/loader";
+import { SYMBOL_PRESETS, type SymbolKey } from "@oh-my-pi/pi-coding-agent/modes/theme/symbols";
 import { getThemeByName, initTheme, setThemeInstance, theme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import { CachedOutputBlock, markFramedBlockComponent } from "@oh-my-pi/pi-coding-agent/tui/output-block";
 import { replaceTabs, Text, type TUI } from "@oh-my-pi/pi-tui";
@@ -284,6 +285,55 @@ describe("opencode layout", () => {
 			// Unmapped tools fall back to the search glyph.
 			expect(rows[2]).toContain("* HEADLINE ok");
 			for (const row of rows) expect(row).toMatch(/^[\x20-\x7E]*$/);
+		} finally {
+			setThemeInstance(baseTheme);
+		}
+	});
+
+	it("strips every ascii status/tool icon from a settled collapsed header", async () => {
+		const baseTheme = await getThemeByName("dark");
+		if (!baseTheme) throw new Error("theme unavailable");
+		setThemeInstance(await loadTheme("dark", { symbolPresetOverride: "ascii" }));
+		try {
+			// Sweep the full ascii inventory of icons that can lead a settled
+			// header (formatStatusIcon + per-tool identity glyphs). Many are
+			// alphanumeric ("+f", "lsp", "web", "[ok]"), which the old
+			// `[^\p{L}\p{N}]{1,2}` guess never removed.
+			const iconKeys = (Object.keys(SYMBOL_PRESETS.ascii) as SymbolKey[]).filter(
+				key => key.startsWith("status.") || key.startsWith("tool."),
+			);
+			expect(iconKeys.length).toBeGreaterThan(0);
+			for (const key of iconKeys) {
+				const icon = theme.symbol(key);
+				const tool = {
+					...makeMultiLineTool(),
+					renderResult: () => new Text(`${icon} Label detail\nDETAIL-1`, 0, 0),
+				};
+				const component = makeComponent(tool, opencode);
+				component.updateResult({ content: [{ type: "text", text: "ok" }] }, false);
+				const rows = visibleRows(component);
+				expect(rows).toHaveLength(1);
+				// The native icon is gone; only the opencode glyph leads the row.
+				expect(rows[0]).toBe(" * Label detail");
+			}
+		} finally {
+			setThemeInstance(baseTheme);
+		}
+	});
+
+	it("renders an ascii squeezed settled row through the oc.* marker, not `•`", async () => {
+		const baseTheme = await getThemeByName("dark");
+		if (!baseTheme) throw new Error("theme unavailable");
+		setThemeInstance(await loadTheme("dark", { symbolPresetOverride: "ascii" }));
+		try {
+			const component = makeComponent(makeMultiLineTool(), opencode);
+			component.updateResult({ content: [{ type: "text", text: "ok" }] }, false);
+			component.setTranscriptAllocation(1, { tick: 0, now: 0 });
+			const rows = component.render(80).map(line => stripVTControlCharacters(line));
+			expect(rows).toHaveLength(1);
+			// Unmapped tools take the oc.search marker; ascii preset renders "*".
+			expect(rows[0]).toBe("* Custom");
+			expect(rows[0]).toMatch(/^[\x20-\x7E]*$/);
 		} finally {
 			setThemeInstance(baseTheme);
 		}

--- a/packages/coding-agent/test/opencode-layout.test.ts
+++ b/packages/coding-agent/test/opencode-layout.test.ts
@@ -183,6 +183,38 @@ describe("opencode layout", () => {
 		}
 	});
 
+	it("keeps both OSC-8 links, in order, in a collapsed rename header", () => {
+		// A rename/move edit header carries two links: source and destination.
+		// The collapse restyle must re-wrap every span, not just the first.
+		const srcUri = url.pathToFileURL(path.resolve("/workspace/src/old.ts")).href;
+		const dstUri = url.pathToFileURL(path.resolve("/workspace/lib/new.ts")).href;
+		const link = (uri: string, text: string) => `\x1b]8;;${uri}\x07${text}\x1b]8;;\x07`;
+		const header = `← Move ${link(srcUri, "src/old.ts")} → ${link(dstUri, "lib/new.ts")}`;
+		const tool: MultiLineTool = {
+			name: "custom_render",
+			label: "Custom",
+			mergeCallAndResult: true,
+			renderResult() {
+				return markFramedBlockComponent({
+					render: () => [header, "DETAIL-1"],
+					invalidate() {},
+				}) as unknown as Text;
+			},
+		};
+		const component = makeComponent(tool, opencode);
+		component.updateResult({ content: [{ type: "text", text: "ok" }] }, false);
+
+		const rows = component.render(120).filter(line => /\S/.test(stripVTControlCharacters(line)));
+		expect(rows).toHaveLength(1);
+		const row = rows[0]!;
+		expect(row).toContain(srcUri);
+		expect(row).toContain(dstUri);
+		expect(row.indexOf(srcUri)).toBeLessThan(row.indexOf(dstUri));
+		const plain = stripVTControlCharacters(row);
+		expect(plain).toContain("src/old.ts");
+		expect(plain).toContain("lib/new.ts");
+	});
+
 	it("normalizes tabs so a collapsed row stays one clean line", () => {
 		// Framed (self-drawing) renderers pass their rows through verbatim —
 		// truncateToWidth's short-string fast path preserves a raw `\t` — so the

--- a/packages/coding-agent/test/opencode-layout.test.ts
+++ b/packages/coding-agent/test/opencode-layout.test.ts
@@ -1,33 +1,35 @@
-import { afterEach, beforeAll, describe, expect, it } from "bun:test";
+import { beforeAll, describe, expect, it } from "bun:test";
 import { stripVTControlCharacters } from "node:util";
 import type { AgentTool } from "@oh-my-pi/pi-agent-core";
 import { ToolExecutionComponent } from "@oh-my-pi/pi-coding-agent/modes/components/tool-execution";
 import { UserMessageComponent } from "@oh-my-pi/pi-coding-agent/modes/components/user-message";
-import { setLayoutMode } from "@oh-my-pi/pi-coding-agent/modes/layout-mode";
-import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import type { LayoutMode } from "@oh-my-pi/pi-coding-agent/modes/layout-mode";
+import { initTheme, theme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { CachedOutputBlock } from "@oh-my-pi/pi-coding-agent/tui/output-block";
 import { Text, type TUI } from "@oh-my-pi/pi-tui";
 
 /**
  * Contract under test (`display.layout: "opencode"`):
  *
+ * - The layout is per-mode state: components capture a layout accessor at
+ *   construction, so two live modes with different settings render
+ *   independently in the same process (no module-global flag).
  * - A collapsed tool block renders as exactly one row — its status line (the
  *   first visible row of the card) — instead of the full card.
  * - `setExpanded(true)` (Ctrl+O) restores the complete card.
  * - An error result never collapses: the message must stay readable.
- * - The default `omp` layout is untouched by the flag round-trip.
+ * - The default `omp` layout (no accessor) is untouched.
  * - User messages gain a left gutter column in opencode layout.
+ * - `renderOutputBlock`/`CachedOutputBlock` key on the explicit `flat` option.
  */
 describe("opencode layout", () => {
 	beforeAll(async () => {
 		await initTheme();
 	});
 
-	afterEach(() => {
-		// Full-suite safety: never leak the layout flag into other test files.
-		setLayoutMode("omp");
-	});
-
 	const ui = { requestRender() {}, requestComponentRender() {} } as unknown as TUI;
+	const opencode = (): LayoutMode => "opencode";
+	const omp = (): LayoutMode => "omp";
 
 	interface MultiLineTool {
 		name: string;
@@ -49,8 +51,15 @@ describe("opencode layout", () => {
 		};
 	}
 
-	function makeComponent(tool: MultiLineTool): ToolExecutionComponent {
-		return new ToolExecutionComponent("custom_render", {}, {}, tool as unknown as AgentTool, ui, process.cwd());
+	function makeComponent(tool: MultiLineTool, layout?: () => LayoutMode): ToolExecutionComponent {
+		return new ToolExecutionComponent(
+			"custom_render",
+			{},
+			{ layout },
+			tool as unknown as AgentTool,
+			ui,
+			process.cwd(),
+		);
 	}
 
 	function visibleRows(component: ToolExecutionComponent, width = 80): string[] {
@@ -61,8 +70,7 @@ describe("opencode layout", () => {
 	}
 
 	it("collapses a finalized tool block to its status line; expand restores the card", () => {
-		setLayoutMode("opencode");
-		const component = makeComponent(makeMultiLineTool());
+		const component = makeComponent(makeMultiLineTool(), opencode);
 		component.updateResult({ content: [{ type: "text", text: "ok" }] }, false);
 
 		const collapsed = visibleRows(component);
@@ -77,30 +85,83 @@ describe("opencode layout", () => {
 	});
 
 	it("never collapses an error result", () => {
-		setLayoutMode("opencode");
-		const component = makeComponent(makeMultiLineTool());
+		const component = makeComponent(makeMultiLineTool(), opencode);
 		component.updateResult({ content: [{ type: "text", text: "boom" }], isError: true }, false);
 
 		const rows = visibleRows(component).join("\n");
 		expect(rows).toContain("DETAIL-2");
 	});
 
-	it("keeps the full card in the default omp layout after a flag round-trip", () => {
-		setLayoutMode("opencode");
-		setLayoutMode("omp");
+	it("keeps the full card when no layout accessor is supplied (default omp)", () => {
 		const component = makeComponent(makeMultiLineTool());
 		component.updateResult({ content: [{ type: "text", text: "ok" }] }, false);
 
 		expect(visibleRows(component).join("\n")).toContain("DETAIL-2");
 	});
 
+	it("isolates two live modes with different layouts in the same process", () => {
+		// Regression for the module-global layout flag: constructing/rendering a
+		// second InteractiveMode's components must not change the first mode's
+		// transcript. Each component reads its own mode's accessor at render time.
+		const ompMode = { layout: "omp" as LayoutMode };
+		const ocMode = { layout: "opencode" as LayoutMode };
+
+		const framed = makeComponent(makeMultiLineTool(), () => ompMode.layout);
+		const flat = makeComponent(makeMultiLineTool(), () => ocMode.layout);
+		framed.updateResult({ content: [{ type: "text", text: "ok" }] }, false);
+		flat.updateResult({ content: [{ type: "text", text: "ok" }] }, false);
+
+		// Interleave renders in both orders: neither construction nor render of
+		// one mode's component may leak into the other's output.
+		expect(visibleRows(flat)).toHaveLength(1);
+		expect(visibleRows(framed).join("\n")).toContain("DETAIL-2");
+		expect(visibleRows(flat)).toHaveLength(1);
+
+		const gutterMsg = stripVTControlCharacters(
+			new UserMessageComponent("hello world", false, undefined, () => ocMode.layout).render(60)[0]!,
+		);
+		const plainMsg = stripVTControlCharacters(
+			new UserMessageComponent("hello world", false, undefined, () => ompMode.layout).render(60)[0]!,
+		);
+		expect(gutterMsg.trimStart().startsWith("│")).toBe(true);
+		expect(plainMsg).not.toContain("│");
+
+		// A live toggle on one mode re-renders that mode only.
+		ocMode.layout = "omp";
+		flat.invalidate();
+		expect(visibleRows(flat).join("\n")).toContain("DETAIL-2");
+		expect(visibleRows(framed).join("\n")).toContain("DETAIL-2");
+	});
+
 	it("prefixes user messages with a left gutter only in opencode layout", () => {
-		setLayoutMode("opencode");
-		const withGutter = stripVTControlCharacters(new UserMessageComponent("hello world").render(60)[0]!);
+		const withGutter = stripVTControlCharacters(
+			new UserMessageComponent("hello world", false, undefined, opencode).render(60)[0]!,
+		);
 		expect(withGutter.trimStart().startsWith("│")).toBe(true);
 
-		setLayoutMode("omp");
-		const plain = stripVTControlCharacters(new UserMessageComponent("hello world").render(60)[0]!);
+		const plain = stripVTControlCharacters(
+			new UserMessageComponent("hello world", false, undefined, omp).render(60)[0]!,
+		);
 		expect(plain).not.toContain("│");
+	});
+
+	it("keys CachedOutputBlock on the explicit flat option", () => {
+		const block = new CachedOutputBlock();
+		const options = {
+			header: "Tool header",
+			state: "success" as const,
+			sections: [{ lines: ["body line"] }],
+			width: 60,
+		};
+
+		const framed = block.render({ ...options, flat: false }, theme).join("\n");
+		const flat = block.render({ ...options, flat: true }, theme).join("\n");
+		const framedAgain = block.render({ ...options, flat: false }, theme).join("\n");
+
+		// Framed draws the omp box glyphs; flat draws none. Identical options that
+		// differ only in `flat` MUST NOT collide in the memo.
+		expect(stripVTControlCharacters(framed)).toContain(theme.boxRound.topLeft);
+		expect(stripVTControlCharacters(flat)).not.toContain(theme.boxRound.topLeft);
+		expect(framedAgain).toBe(framed);
 	});
 });

--- a/packages/coding-agent/test/opencode-layout.test.ts
+++ b/packages/coding-agent/test/opencode-layout.test.ts
@@ -8,10 +8,9 @@ import { ToolExecutionComponent } from "@oh-my-pi/pi-coding-agent/modes/componen
 import { UserMessageComponent } from "@oh-my-pi/pi-coding-agent/modes/components/user-message";
 import type { LayoutMode } from "@oh-my-pi/pi-coding-agent/modes/layout-mode";
 import { loadTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/loader";
-import { SYMBOL_PRESETS, type SymbolKey } from "@oh-my-pi/pi-coding-agent/modes/theme/symbols";
 import { getThemeByName, initTheme, setThemeInstance, theme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import { CachedOutputBlock, markFramedBlockComponent } from "@oh-my-pi/pi-coding-agent/tui/output-block";
-import { replaceTabs, Text, type TUI } from "@oh-my-pi/pi-tui";
+import { replaceTabs, Text, type TUI, visibleWidth } from "@oh-my-pi/pi-tui";
 
 /**
  * Contract under test (`display.layout: "opencode"`):
@@ -241,6 +240,38 @@ describe("opencode layout", () => {
 		expect(stripVTControlCharacters(rows[0]!)).toContain(replaceTabs("HEAD\tLINE ok"));
 	});
 
+	it("bounds a live custom row without dropping its styling", () => {
+		const uri = "file:///tmp/live.ts";
+		const link = `\x1b]8;;${uri}\x07${theme.fg("accent", "live.ts")}\x1b]8;;\x07`;
+		const longUri = "file:///tmp/long.ts";
+		const longLink = `\x1b]8;;${longUri}\x07${"long".repeat(75)}\x1b]8;;\x07`;
+		const styled = theme.fg("toolTitle", `first\t${link} ${longLink}`);
+		const tool = {
+			name: "custom_render",
+			label: "Custom",
+			parameters: { type: "object", additionalProperties: true },
+			renderCall: () =>
+				markFramedBlockComponent({
+					render: () => [styled, "DETAIL-1"],
+					invalidate() {},
+				}) as unknown as Text,
+			async execute() {
+				return { content: [] };
+			},
+		} as unknown as AgentTool;
+		const component = new ToolExecutionComponent("custom_render", {}, { layout: opencode }, tool, ui, process.cwd());
+
+		const rows = component.render(40).filter(line => /\S/.test(stripVTControlCharacters(line)));
+		expect(rows).toHaveLength(1);
+		expect(rows[0]).not.toContain("\t");
+		expect(visibleWidth(rows[0]!)).toBeLessThanOrEqual(40);
+		expect(rows[0]).toContain(theme.getFgAnsi("toolTitle"));
+		expect(rows[0]).toContain(theme.getFgAnsi("accent"));
+		expect(rows[0]).toContain(uri);
+		expect(rows[0]).not.toContain(longUri);
+		expect(rows[0]!.match(/\x1b\]8;;\x07/g)).toHaveLength(1);
+	});
+
 	it("keys CachedOutputBlock on the explicit flat option", () => {
 		const block = new CachedOutputBlock();
 		const options = {
@@ -290,32 +321,50 @@ describe("opencode layout", () => {
 		}
 	});
 
-	it("strips every ascii status/tool icon from a settled collapsed header", async () => {
+	it("keeps ascii icon words from custom settled headers", async () => {
 		const baseTheme = await getThemeByName("dark");
 		if (!baseTheme) throw new Error("theme unavailable");
 		setThemeInstance(await loadTheme("dark", { symbolPresetOverride: "ascii" }));
 		try {
-			// Sweep the full ascii inventory of icons that can lead a settled
-			// header (formatStatusIcon + per-tool identity glyphs). Many are
-			// alphanumeric ("+f", "lsp", "web", "[ok]"), which the old
-			// `[^\p{L}\p{N}]{1,2}` guess never removed.
-			const iconKeys = (Object.keys(SYMBOL_PRESETS.ascii) as SymbolKey[]).filter(
-				key => key.startsWith("status.") || key.startsWith("tool."),
+			const tool = {
+				...makeMultiLineTool(),
+				name: "write",
+				renderResult: () => new Text("web result detail\nDETAIL-1", 0, 0),
+			};
+			const component = new ToolExecutionComponent(
+				"write",
+				{},
+				{ layout: opencode },
+				tool as unknown as AgentTool,
+				ui,
+				process.cwd(),
 			);
-			expect(iconKeys.length).toBeGreaterThan(0);
-			for (const key of iconKeys) {
-				const icon = theme.symbol(key);
-				const tool = {
-					...makeMultiLineTool(),
-					renderResult: () => new Text(`${icon} Label detail\nDETAIL-1`, 0, 0),
-				};
-				const component = makeComponent(tool, opencode);
-				component.updateResult({ content: [{ type: "text", text: "ok" }] }, false);
-				const rows = visibleRows(component);
-				expect(rows).toHaveLength(1);
-				// The native icon is gone; only the opencode glyph leads the row.
-				expect(rows[0]).toBe(" * Label detail");
-			}
+			component.updateResult({ content: [{ type: "text", text: "ok" }] }, false);
+
+			expect(visibleRows(component)).toEqual([" <- web result detail"]);
+		} finally {
+			setThemeInstance(baseTheme);
+		}
+	});
+
+	it("strips the +f icon from a built-in ascii write header", async () => {
+		const baseTheme = await getThemeByName("dark");
+		if (!baseTheme) throw new Error("theme unavailable");
+		setThemeInstance(await loadTheme("dark", { symbolPresetOverride: "ascii" }));
+		try {
+			const component = new ToolExecutionComponent(
+				"write",
+				{ file_path: "src/example.ts", content: "hello\n" },
+				{ layout: opencode },
+				undefined,
+				ui,
+				process.cwd(),
+			);
+			component.updateResult({ content: [{ type: "text", text: "Wrote 1 lines" }] }, false);
+
+			const [row] = visibleRows(component);
+			expect(row).toMatch(/^ <- /);
+			expect(row).not.toContain("+f");
 		} finally {
 			setThemeInstance(baseTheme);
 		}

--- a/packages/coding-agent/test/read-tool-group.test.ts
+++ b/packages/coding-agent/test/read-tool-group.test.ts
@@ -356,6 +356,77 @@ describe("ReadToolGroupComponent", () => {
 		expect(extractLinkTexts(rendered)).toContain("src/preview.ts");
 		expect(extractLinkTexts(rendered)).not.toContain("src/preview.ts:20-22");
 	});
+	it("keeps failed grouped reads full-detail in the flat opencode layout", () => {
+		const component = new ReadToolGroupComponent({ layout: () => "opencode" });
+		component.updateArgs({ path: "/tmp/ok.ts" }, "read-ok");
+		component.updateResult({ content: [{ type: "text", text: "line 1\nline 2" }] }, false, "read-ok");
+		component.updateArgs({ path: "/tmp/missing.ts" }, "read-fail");
+		component.updateResult(
+			{ content: [{ type: "text", text: "ENOENT: no such file or directory" }], isError: true },
+			false,
+			"read-fail",
+		);
+
+		const rendered = Bun.stripANSI(component.render(120).join("\n"));
+
+		// Successful reads collapse to their one-line flat row…
+		expect(rendered).toContain("→ Read /tmp/ok.ts");
+		expect(rendered).not.toContain("line 1");
+		// …but a failed read keeps its actionable error message visible.
+		expect(rendered).toContain("Read /tmp/missing.ts");
+		expect(rendered).toContain("ENOENT: no such file or directory");
+	});
+
+	it("keeps selector line targets on flat opencode row hyperlinks", () => {
+		settings.override("tui.hyperlinks", "always");
+		const component = new ReadToolGroupComponent({ layout: () => "opencode" });
+		const examplePath = path.resolve("/workspace/src/example.ts");
+		component.updateArgs({ path: "src/example.ts:50-70" }, "read-flat-link");
+		component.updateResult(
+			{
+				content: [{ type: "text", text: "line 50" }],
+				details: { meta: { source: { type: "path", value: examplePath } } },
+			},
+			false,
+			"read-flat-link",
+		);
+
+		const rendered = component.render(120).join("\n");
+
+		const exampleUri = new URL(url.pathToFileURL(examplePath).href);
+		exampleUri.searchParams.set("line", "50");
+		expect(Bun.stripANSI(rendered)).toContain("Read src/example.ts:50-70");
+		expect(extractLinkUris(rendered)).toContain(exampleUri.href);
+	});
+
+	it("truncates over-wide flat opencode rows to a single line", () => {
+		const component = new ReadToolGroupComponent({ layout: () => "opencode" });
+		const longPath = `/tmp/${"deeply-nested-".repeat(12)}dir/file\twith-tabs.ts`;
+		component.updateArgs({ path: longPath }, "read-wide");
+		component.updateResult({ content: [{ type: "text", text: "content" }] }, false, "read-wide");
+
+		const lines = component.render(40);
+
+		// The advertised one-line entry stays one line at the render width, with
+		// tabs sanitized so a pathological path cannot wrap or corrupt the row.
+		expect(lines).toHaveLength(1);
+		expect(Bun.stringWidth(Bun.stripANSI(lines[0]!))).toBeLessThanOrEqual(40);
+		expect(lines[0]!).not.toContain("\t");
+	});
+
+	it("restores the grouped view when the flat group is expanded", () => {
+		const component = new ReadToolGroupComponent({ layout: () => "opencode" });
+		component.updateArgs({ path: "/tmp/a.ts" }, "read-a");
+		component.updateResult({ content: [{ type: "text", text: "alpha" }] }, false, "read-a");
+		component.updateArgs({ path: "/tmp/b.ts" }, "read-b");
+		component.updateResult({ content: [{ type: "text", text: "beta" }] }, false, "read-b");
+
+		expect(Bun.stripANSI(component.render(120).join("\n"))).toContain("→ Read /tmp/a.ts");
+
+		component.setExpanded(true);
+		const grouped = Bun.stripANSI(component.render(120).join("\n"));
+		expect(grouped).toContain("Read (2)");
+	});
 });
 
 describe("readArgsCollapseIntoGroup", () => {

--- a/packages/coding-agent/test/read-tool-group.test.ts
+++ b/packages/coding-agent/test/read-tool-group.test.ts
@@ -7,6 +7,7 @@ import {
 	ReadToolGroupComponent,
 	readArgsCollapseIntoGroup,
 } from "@oh-my-pi/pi-coding-agent/modes/components/read-tool-group";
+import { loadTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/loader";
 import * as themeModule from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 
 function extractLinkUris(text: string): string[] {
@@ -426,6 +427,23 @@ describe("ReadToolGroupComponent", () => {
 		component.setExpanded(true);
 		const grouped = Bun.stripANSI(component.render(120).join("\n"));
 		expect(grouped).toContain("Read (2)");
+	});
+
+	it("renders ascii-preset flat rows with the ascii read glyph", async () => {
+		const baseTheme = await themeModule.getThemeByName("dark");
+		if (!baseTheme) throw new Error("theme unavailable");
+		themeModule.setThemeInstance(await loadTheme("dark", { symbolPresetOverride: "ascii" }));
+		try {
+			const component = new ReadToolGroupComponent({ layout: () => "opencode" });
+			component.updateArgs({ path: "/tmp/a.ts" }, "read-ascii");
+			component.updateResult({ content: [{ type: "text", text: "alpha" }] }, false, "read-ascii");
+
+			const rendered = Bun.stripANSI(component.render(120).join("\n"));
+			expect(rendered).toContain("-> Read /tmp/a.ts");
+			expect(rendered).toMatch(/^[\x20-\x7E\n]*$/);
+		} finally {
+			themeModule.setThemeInstance(baseTheme);
+		}
 	});
 });
 

--- a/packages/coding-agent/test/tools/ask.test.ts
+++ b/packages/coding-agent/test/tools/ask.test.ts
@@ -1476,6 +1476,31 @@ describe("AskTool option markers", () => {
 	});
 });
 
+describe("askToolRenderer opencode flat layout", () => {
+	it("renders the single-question call flat (no frame glyphs)", async () => {
+		const theme = darkTheme;
+		const args = { question: "Continue with the plan?", options: [{ label: "Yes" }, { label: "No" }] };
+		const framed = stripAnsi(
+			askToolRenderer.renderCall(args, { expanded: true, isPartial: false }, theme!).render(120).join("\n"),
+		);
+		const flatLines = askToolRenderer
+			.renderCall(args, { expanded: true, isPartial: false, renderContext: { flat: true } }, theme!)
+			.render(120)
+			.map(stripAnsi);
+
+		// Sanity: the default layout draws the frame these assertions key on.
+		expect(framed).toContain(theme!.boxRound.topLeft);
+		// Flat: no border rows anywhere, and the first visible row is the Ask
+		// status line — the one-line preview a collapsed pending question shows.
+		const flat = flatLines.join("\n");
+		expect(flat).not.toContain(theme!.boxRound.topLeft);
+		expect(flat).not.toContain(theme!.boxRound.vertical);
+		expect(flat).not.toContain(theme!.boxRound.bottomLeft);
+		expect(flatLines.find(line => /\S/.test(line))).toContain("Ask");
+		expect(flat).toContain("Continue with the plan?");
+	});
+});
+
 describe("askToolRenderer malformed call args", () => {
 	it("renders double-encoded questions string instead of crashing the TUI", async () => {
 		const theme = darkTheme;

--- a/packages/coding-agent/test/tui/output-block.test.ts
+++ b/packages/coding-agent/test/tui/output-block.test.ts
@@ -69,6 +69,22 @@ describe("renderOutputBlock", () => {
 		expect(lines).toEqual(["  ask quest…"]);
 	});
 
+	it("removes tabs from flat header and section labels", async () => {
+		const theme = (await getThemeByName("dark"))!;
+		const lines = renderOutputBlock(
+			{
+				width: 80,
+				flat: true,
+				header: "Edit\tfile.ts",
+				headerMeta: "2\tchanges",
+				sections: [{ label: "Changed\tlines", lines: ["body"] }],
+			},
+			theme,
+		).map(line => stripVTControlCharacters(line));
+
+		expect(lines).toEqual(["Edit   file.ts · 2   changes", "  Changed   lines", "  body"]);
+	});
+
 	it("keeps the original positional contract of outputBlockContentWidth", () => {
 		// Pre-opencode signature: (width, contentPaddingLeft?, contentPaddingRight?).
 		// Precompiled JS extension callers rely on these positions.

--- a/packages/coding-agent/test/tui/output-block.test.ts
+++ b/packages/coding-agent/test/tui/output-block.test.ts
@@ -54,4 +54,18 @@ describe("renderOutputBlock", () => {
 		expect(lines[1]).toBe(`│ ${"x".repeat(26)} │`);
 		expect(lines[2]).toStartWith("│ … 1 more line");
 	});
+
+	it("truncates flat section labels to their indented width", async () => {
+		const theme = (await getThemeByName("dark"))!;
+		const lines = renderOutputBlock(
+			{
+				width: 12,
+				flat: true,
+				sections: [{ label: "ask questions[].id", lines: [] }],
+			},
+			theme,
+		).map(line => stripVTControlCharacters(line));
+
+		expect(lines).toEqual(["  ask quest…"]);
+	});
 });

--- a/packages/coding-agent/test/tui/output-block.test.ts
+++ b/packages/coding-agent/test/tui/output-block.test.ts
@@ -2,7 +2,7 @@ import { beforeAll, describe, expect, it } from "bun:test";
 import { stripVTControlCharacters } from "node:util";
 import { getThemeByName, initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import { renderMarkdownCell } from "@oh-my-pi/pi-coding-agent/tui/code-cell";
-import { renderOutputBlock } from "@oh-my-pi/pi-coding-agent/tui/output-block";
+import { outputBlockContentWidth, renderOutputBlock } from "@oh-my-pi/pi-coding-agent/tui/output-block";
 
 describe("renderOutputBlock", () => {
 	beforeAll(async () => {
@@ -67,5 +67,15 @@ describe("renderOutputBlock", () => {
 		).map(line => stripVTControlCharacters(line));
 
 		expect(lines).toEqual(["  ask quest…"]);
+	});
+
+	it("keeps the original positional contract of outputBlockContentWidth", () => {
+		// Pre-opencode signature: (width, contentPaddingLeft?, contentPaddingRight?).
+		// Precompiled JS extension callers rely on these positions.
+		expect(outputBlockContentWidth(40)).toBe(36);
+		expect(outputBlockContentWidth(40, 0)).toBe(38);
+		expect(outputBlockContentWidth(40, 2, 3)).toBe(33);
+		// The opencode `flat` flag is appended LAST so the positions above never shift.
+		expect(outputBlockContentWidth(40, undefined, undefined, true)).toBe(38);
 	});
 });


### PR DESCRIPTION
## Summary

Adds `display.layout` (Appearance -> Display, `omp` | `opencode`) selecting how the transcript renders. `omp` is the existing look and stays the default. `opencode` is a flat, opencode-style transcript:

- Collapsed tool calls render as one dim status line behind a per-tool glyph (reads `→`, searches `∗`, shell `$`, writes `←`, subagents `◆`); Ctrl+O still expands the full card. Live calls keep native spinner styling; errors stay full-size.
- `renderOutputBlock` draws flat (no borders, no state background) so every framed tool routes through one branch.
- Read groups flatten to per-file dim rows, keeping OSC-8 file hyperlinks and non-success status marks.
- User messages get a left accent gutter.
- A setup-wizard scene (setup version 2 -> 3) offers the choice on first run and once on upgrade; live toggle via /settings rebuilds the transcript (`rebuildChatFromMessages` + `resetDisplay`, mirroring `collapseCompacted`).

Implementation is a module-level flag (`src/modes/layout-mode.ts`) mirroring the `setTuiTight` precedent; render paths fold it into their memo keys.

Pairs well with `composer.shape: rail` for the opencode-style input, but is independent of it.

## Verification

- `bun run check` clean (oxlint, oxfmt, tsgo).
- 94 tests across opencode-layout, setup-wizard, tool-execution memoization/repaint, read-tool-group, selector side-effects; includes new coverage for the flat collapse, wizard scene selection, and setup-version guard (max(minVersion) == CURRENT_SETUP_VERSION).
- tmux smoke against a real session transcript: zero frame glyphs in opencode mode, glyphed dim tool rows, omp mode unchanged; live /settings toggle exercised both directions.
- Independent adversarial review pass; its findings (pending-read liveness cue, hyperlink loss, squeezed-row frame glyphs, changelog placement) are fixed in the last commit.