### PR TITLE
fix(coding-agent): tombstone before awaiting sidecar write in release

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,7 @@
 - TypeScript code intelligence now works on TypeScript 7 projects: the built-in `typescript-native` server runs `tsc --lsp --stdio` when the resolved TypeScript install no longer ships `tsserver.js`, replacing `typescript-language-server` for that project.
 - Claude marketplace MCP servers now resolve environment placeholders in stdio environment values instead of passing strings such as `${NAME:-}` literally ([#10481](https://github.com/can1357/oh-my-pi/pull/10481) by [@mrexodia](https://github.com/mrexodia)).
 - Fixed prewalk conflicting with `todo.eager=always`: the forced eager-todo prelude ("call todo first this turn") was injected alongside the prewalk plan nudge ("write a complete plan first, then todo"), giving the model contradictory instructions; the eager-todo prelude is now suppressed only when prewalk will perform a handoff ([#10510](https://github.com/can1357/oh-my-pi/issues/10510)).
+- Fixed hard-killed subagents vanishing from the agent registry under concurrent fan-out: `AgentLifecycleManager.release` now applies the terminal `aborted` transition before awaiting the tombstone sidecar write, closing a race where the dying session's own dispose-path unregister deleted the ref instead of leaving it as a tombstone ([#10531](https://github.com/can1357/oh-my-pi/issues/10531)).
 ## [18.1.2] - 2026-09-01
 
 ### Added

--- a/packages/coding-agent/src/registry/agent-lifecycle.ts
+++ b/packages/coding-agent/src/registry/agent-lifecycle.ts
@@ -451,13 +451,18 @@ export class AgentLifecycleManager {
 				logger.warn("AgentLifecycleManager.release: terminal transition rejected", { id });
 			}
 			this.#registry.detachSession(id, ref);
-			if (ref.sessionFile) await persistAgentTombstone(ref.sessionFile);
 		}
-		if (live) {
-			try {
-				await live.dispose();
-			} catch (error) {
-				logger.warn("AgentLifecycleManager.release: session dispose failed", { id, error: String(error) });
+		try {
+			if (options?.tombstone && ref.sessionFile) await persistAgentTombstone(ref.sessionFile);
+		} finally {
+			// Detaching removes the registry's only route to the live session. Always
+			// dispose the captured session, even when tombstone persistence fails.
+			if (live) {
+				try {
+					await live.dispose();
+				} catch (error) {
+					logger.warn("AgentLifecycleManager.release: session dispose failed", { id, error: String(error) });
+				}
 			}
 		}
 		if (!options?.tombstone) this.#registry.unregister(id, ref);

--- a/packages/coding-agent/src/registry/agent-lifecycle.ts
+++ b/packages/coding-agent/src/registry/agent-lifecycle.ts
@@ -435,15 +435,24 @@ export class AgentLifecycleManager {
 			await park.promise;
 		}
 
-		if (options?.tombstone) {
-			// Persist the terminal decision before detaching the session. The
-			// sidecar prevents a later discovery pass from reviving this transcript
-			// as a fresh parked ref.
-			if (ref.sessionFile) await persistAgentTombstone(ref.sessionFile);
-			this.#registry.setStatus(id, "aborted", ref);
-		}
 		const live = this.#registry.get(id) === ref ? ref.session : null;
-		if (options?.tombstone) this.#registry.detachSession(id, ref);
+		if (options?.tombstone) {
+			// Apply the terminal transition synchronously, before any await. The
+			// dying session's own dispose path calls unregisterUnlessParked
+			// (sdk.ts), which spares a ref only when it is already `aborted` AND
+			// already detached; awaiting persistAgentTombstone before this
+			// transition left a window in which that unregister deleted the ref
+			// (issue #10531). Persisting the sidecar afterward is safe: within the
+			// process the still-registered `aborted` row already blocks re-adoption
+			// via the `if (!registry.get(id))` discovery guard, and the sidecar
+			// only needs to exist before a later cross-restart discovery pass —
+			// release awaits the write below before returning.
+			if (!this.#registry.setStatus(id, "aborted", ref)) {
+				logger.warn("AgentLifecycleManager.release: terminal transition rejected", { id });
+			}
+			this.#registry.detachSession(id, ref);
+			if (ref.sessionFile) await persistAgentTombstone(ref.sessionFile);
+		}
 		if (live) {
 			try {
 				await live.dispose();

--- a/packages/coding-agent/src/registry/agent-lifecycle.ts
+++ b/packages/coding-agent/src/registry/agent-lifecycle.ts
@@ -447,10 +447,11 @@ export class AgentLifecycleManager {
 			// via the `if (!registry.get(id))` discovery guard, and the sidecar
 			// only needs to exist before a later cross-restart discovery pass —
 			// release awaits the write below before returning.
-			if (!this.#registry.setStatus(id, "aborted", ref)) {
+			// Detach before publishing `aborted`: setStatus emits synchronously, so
+			// every subscriber must observe a terminal ref with session === null.
+			if (!this.#registry.detachSession(id, ref) || !this.#registry.setStatus(id, "aborted", ref)) {
 				logger.warn("AgentLifecycleManager.release: terminal transition rejected", { id });
 			}
-			this.#registry.detachSession(id, ref);
 		}
 		try {
 			if (options?.tombstone && ref.sessionFile) await persistAgentTombstone(ref.sessionFile);

--- a/packages/coding-agent/test/registry/agent-lifecycle.test.ts
+++ b/packages/coding-agent/test/registry/agent-lifecycle.test.ts
@@ -754,6 +754,27 @@ describe("AgentLifecycleManager", () => {
 		expect(await Bun.file(`${workerSessionFile}.tombstone`).exists()).toBe(true);
 	});
 
+	it("tombstone release disposes the detached session when sidecar persistence fails", async () => {
+		const stub = makeSessionStub();
+		const ref = registry.register({
+			id: "Persist-Failure",
+			displayName: "task",
+			kind: "sub",
+			session: stub.session,
+			sessionFile: "/tmp/Persist-Failure.jsonl",
+			status: "running",
+		});
+		const failure = Object.assign(new Error("no space left on device"), { code: "ENOSPC" });
+		vi.spyOn(fsp, "writeFile").mockRejectedValueOnce(failure);
+
+		await expect(lifecycle.release("Persist-Failure", ref, { tombstone: true })).rejects.toBe(failure);
+
+		// Persistence still surfaces to the caller, but the detached session cannot
+		// leak its MCP, kernel, browser, or nested-job resources.
+		expect(stub.disposeCalls()).toBe(1);
+		expect(registry.get("Persist-Failure")).toMatchObject({ status: "aborted", session: null });
+	});
+
 	it("a cold revive whose factory resolves after dispose rejects without adopting or arming a TTL", async () => {
 		vi.useFakeTimers();
 		const gate = deferred();

--- a/packages/coding-agent/test/registry/agent-lifecycle.test.ts
+++ b/packages/coding-agent/test/registry/agent-lifecycle.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as fsp from "node:fs/promises";
 import * as path from "node:path";
 import { AgentLifecycleManager } from "@oh-my-pi/pi-coding-agent/registry/agent-lifecycle";
 import { AgentRegistry, MAIN_AGENT_ID } from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
@@ -700,6 +701,57 @@ describe("AgentLifecycleManager", () => {
 		const restoredRegistry = new AgentRegistry();
 		await registerPersistedSubagents(restoredRegistry, rootSessionFile);
 		expect(restoredRegistry.get(workerId)?.status).toBe("aborted");
+	});
+
+	it("tombstone release survives the dispose-path unregister racing the sidecar write (#10531)", async () => {
+		using tempDir = TempDir.createSync("@omp-lifecycle-tombstone-race-");
+		const workerId = "Raced-Sub";
+		const workerSessionFile = path.join(tempDir.path(), `${workerId}.jsonl`);
+		await Bun.write(workerSessionFile, "");
+
+		let disposeCalls = 0;
+		const session = {
+			dispose: async () => {
+				disposeCalls++;
+			},
+		} as unknown as AgentSession;
+		const ref = registry.register({
+			id: workerId,
+			displayName: "task",
+			kind: "sub",
+			session,
+			sessionFile: workerSessionFile,
+			status: "running",
+		});
+
+		// The dying subagent's own dispose finally-block runs unregisterUnlessParked
+		// (sdk.ts) on a separate async chain. Fire it during the sidecar write await —
+		// the exact window the reporter observed — mirroring its real bail-out guard:
+		// spare a ref only when it is already parked, or aborted AND detached.
+		const disposePathUnregister = () => {
+			const cur = registry.get(workerId);
+			if (!cur) return;
+			if (cur.status === "parked" || (cur.status === "aborted" && !cur.session)) return;
+			registry.unregister(workerId, cur);
+		};
+		let injected = false;
+		vi.spyOn(fsp, "writeFile").mockImplementation((async (target: string) => {
+			if (!injected && target.endsWith(".tombstone")) {
+				injected = true;
+				disposePathUnregister();
+				await Bun.write(target, "");
+			}
+		}) as typeof fsp.writeFile);
+
+		expect(await lifecycle.release(workerId, ref, { tombstone: true })).toBe(true);
+		expect(injected).toBe(true);
+		// The terminal transition ran before the await, so the racing unregister
+		// saw an aborted, detached ref and bailed: the row survives as `aborted`
+		// instead of vanishing from the registry.
+		expect(registry.get(workerId)?.status).toBe("aborted");
+		expect(registry.get(workerId)?.session).toBeNull();
+		expect(disposeCalls).toBe(1);
+		expect(await Bun.file(`${workerSessionFile}.tombstone`).exists()).toBe(true);
 	});
 
 	it("a cold revive whose factory resolves after dispose rejects without adopting or arming a TTL", async () => {

--- a/packages/coding-agent/test/registry/agent-lifecycle.test.ts
+++ b/packages/coding-agent/test/registry/agent-lifecycle.test.ts
@@ -703,6 +703,29 @@ describe("AgentLifecycleManager", () => {
 		expect(restoredRegistry.get(workerId)?.status).toBe("aborted");
 	});
 
+	it("publishes an aborted status only after the session is detached", async () => {
+		const stub = makeSessionStub();
+		const ref = registry.register({
+			id: "Published-Aborted",
+			displayName: "task",
+			kind: "sub",
+			session: stub.session,
+			sessionFile: null,
+			status: "running",
+		});
+		let observed: { status: string; session: AgentSession | null } | undefined;
+		const unsubscribe = registry.onChange(event => {
+			if (event.type === "status_changed" && event.ref.id === ref.id) {
+				observed = { status: event.ref.status, session: event.ref.session };
+			}
+		});
+
+		await lifecycle.release(ref.id, ref, { tombstone: true });
+		unsubscribe();
+
+		expect(observed).toEqual({ status: "aborted", session: null });
+	});
+
 	it("tombstone release survives the dispose-path unregister racing the sidecar write (#10531)", async () => {
 		using tempDir = TempDir.createSync("@omp-lifecycle-tombstone-race-");
 		const workerId = "Raced-Sub";


### PR DESCRIPTION
## Repro
Under concurrent subagent fan-out, hard-killing a subagent frequently deleted its registry row entirely instead of leaving a terminal `aborted` tombstone (reporter saw 21/22 `missing-ref` status-update rejections each preceded 10-90 ms by that agent's own `agent_end` dispose). Driving the exact window with an `fs.writeFile` seam — the dying session's dispose-path unregister fires during the sidecar-write await — against the pre-fix ordering reproduces it deterministically: `bun test test/registry/agent-lifecycle.test.ts -t "racing the sidecar write"` asserts the row stays `aborted` but gets `undefined` (ref gone), while `release()` still returns `true`.

## Cause
`AgentLifecycleManager.release` (`packages/coding-agent/src/registry/agent-lifecycle.ts`) `await`ed `persistAgentTombstone(ref.sessionFile)` *before* applying the terminal `setStatus("aborted")` + `detachSession` transition. During that filesystem await the dying subagent's own dispose path runs `unregisterUnlessParked` (`src/sdk.ts:1735-1741`), whose guard spares a ref only when it is already `aborted` **and** detached. The ref was still `running`/session-held, so it was unregistered and removed. Control returned to `release()`: `setStatus` hit the `missing-ref` path in `agent-registry.ts:189-190` and returned `false` (ignored), `live` computed to `null` so dispose was skipped, and `release()` still returned `true`. The surviving on-disk transcript then passes the `if (!registry.get(id))` discovery guard and can be re-adopted as a fresh `parked` row — the exact outcome the tombstone path exists to prevent.

## Fix
- Capture `live` before mutating, then apply `setStatus("aborted")` + `detachSession` synchronously, *before* the `await persistAgentTombstone`. The racing unregister now sees an `aborted`+detached ref and bails, matching the executor's own fallback pairing at `task/executor.ts:2570-2571`. Persisting the sidecar afterward is safe: within-process the still-registered `aborted` row already blocks re-adoption, and `release` awaits the write before returning so the sidecar exists before any later cross-restart discovery pass.
- Log when the terminal transition is rejected so a future regression fails loudly instead of silently reporting success.
- Add a regression test that fires the dispose-path unregister inside the sidecar-write await; it fails on the old ordering and passes on the fix.

## Verification
`bun test test/registry/agent-lifecycle.test.ts` — 30 pass / 0 fail. The new test `tombstone release survives the dispose-path unregister racing the sidecar write (#10531)` fails (`Received: undefined`) when the ordering is reverted, confirming it guards the race. `gh_push_branch` ran `bun run fix` + `bun check` clean.

Fixes #10531