### PR TITLE
fix(ai): heal stale OAuth usage-limit blocks beyond Codex

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Preserved Anthropic thinking now survives side requests, tool-description drift, turn-scoped reminders, and recoverable prefix mismatches without corrupting the conversation prefix.
+- A rate-limit block on an OAuth account now lifts as soon as a live usage report shows that account has headroom again, instead of only when the provider's `retry-after` expires. Anthropic answers a Fable/Mythos 429 with a `retry-after` that can point at the weekly reset, which previously stranded an account with free quota for over a day and pushed every Claude turn onto a fallback provider.
 
 ## [18.1.2] - 2026-09-01
 

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -441,7 +441,11 @@ export interface AuthCredentialStore {
 	deleteCredentialBlocks?(credentialId: number): void;
 	/** Prune rows with blocked_until_ms <= nowMs. */
 	cleanExpiredCredentialBlocks?(nowMs: number): void;
-	/** List non-expired blocks for broker snapshots. */
+	/**
+	 * List non-expired blocks for broker snapshots and scoped reconciliation.
+	 * A store that persists scoped blocks SHOULD implement this; point lookup
+	 * alone cannot rediscover a provider-defined scope after process restart.
+	 */
 	listCredentialBlocks?(credentialIds: readonly number[]): StoredCredentialBlock[];
 	tryAcquireCredentialRefreshLease?(credentialId: number, owner: string, expiresAtMs: number): boolean;
 	getCredentialRefreshLeaseExpiresAt?(credentialId: number): number | undefined;
@@ -1782,6 +1786,20 @@ export class AuthStorage {
 			return undefined;
 		}
 		return blockedUntil;
+	}
+
+	/** Scopes this credential currently holds a live in-memory block under. */
+	#listInMemoryBlockScopes(providerKey: string, credentialIndex: number): string[] {
+		const prefix = `${providerKey}\0`;
+		const nowMs = Date.now();
+		const scopes: string[] = [];
+		for (const key of this.#credentialBackoff.keys()) {
+			if (!key.startsWith(prefix)) continue;
+			if (this.#getCredentialBlockedUntilForKey(key, credentialIndex, nowMs) !== undefined) {
+				scopes.push(key.slice(prefix.length));
+			}
+		}
+		return scopes;
 	}
 
 	#readPersistedCredentialBlock(
@@ -3393,8 +3411,14 @@ export class AuthStorage {
 
 		const now = Date.now();
 		const cached = forceRefresh ? undefined : this.#usageCache.get<UsageReport | null>(cacheKey);
-		// Fresh cache hit: return whatever's there (success or null fallback).
+		// Fresh cache hit: return whatever's there (success or null fallback). A
+		// cached report is still evidence, so it reconciles too — a block that
+		// outlived its cause otherwise survives in any process whose every read is
+		// a cache hit, and a warm shared cache makes that the norm for short-lived
+		// runs. Healing keeps its own freshness guard, so a block newer than the
+		// report cannot be cleared by it.
 		if (cached && cached.expiresAt > now) {
+			if (cached.value) this.#reconcileUsageBlock(request, cached.value);
 			return cached.value;
 		}
 
@@ -3404,6 +3428,11 @@ export class AuthStorage {
 		if (inFlight) return inFlight;
 		const promise = (async () => {
 			const report = await this.#fetchUsageUncached(request, timeoutMs);
+			// Healing one account invalidates the provider cache and advances the
+			// epoch. Sibling fetches already in flight are still fresh evidence:
+			// reconcile before the epoch guard so the first healed block cannot
+			// suppress every later account in the same parallel batch.
+			if (report !== null) this.#reconcileUsageBlock(request, report);
 			if (usageCacheEpoch !== this.#usageCacheEpoch) return report;
 			const ttlJitter = USAGE_REPORT_TTL_MS * (Math.random() * 0.5 - 0.25);
 			if (report !== null) {
@@ -3414,7 +3443,6 @@ export class AuthStorage {
 				// times decorrelate within a few cycles.
 				this.#usageCache.set(cacheKey, { value: report, expiresAt: Date.now() + USAGE_REPORT_TTL_MS + ttlJitter });
 				this.#recordUsageHistory(request, report);
-				this.#reconcileCodexUsageBlock(request, report);
 				return report;
 			}
 			// Failure: apply a short jittered cool-down so the credential doesn't
@@ -3903,7 +3931,7 @@ export class AuthStorage {
 			if (storeHook) {
 				const report = await storeHook(provider, credential, options?.signal);
 				if (report) {
-					this.#reconcileCodexUsageBlock(
+					this.#reconcileUsageBlock(
 						this.#buildUsageRequestForOauth(provider, credential, options?.baseUrl),
 						report,
 					);
@@ -4036,9 +4064,12 @@ export class AuthStorage {
 					planEligibilityByCredential.set(entry.id, getOpenAICodexPlanEligibility(report, planRequirement));
 				}
 
-				if (provider === "openai-codex") {
-					blockedUntil = this.#getCredentialBlockedUntil(provider, providerKey, index, blockScopes);
-				}
+				// The fetch above runs reconciliation, so re-read: a block the report
+				// just healed must not still report `depleted` here. The SDK and turn
+				// recovery use this preflight ahead of credential selection, so a
+				// stale read fails a recovered account closed before selection ever
+				// gets its own chance to heal it.
+				blockedUntil = this.#getCredentialBlockedUntil(provider, providerKey, index, blockScopes);
 				if (blockedUntil !== undefined) {
 					return {
 						credentialId: entry.id,
@@ -4178,7 +4209,7 @@ export class AuthStorage {
 				this.#usageReportsInFlight.set(overrideKey, shared);
 			}
 			const reports = await raceUsageWithSignal(shared, options?.signal);
-			if (shouldReconcileStoreHookReports && reports) this.#reconcileCodexUsageBlocksFromReports(reports);
+			if (shouldReconcileStoreHookReports && reports) this.#reconcileUsageBlocksFromReports(reports);
 			return reports;
 		}
 		if (!this.#usageProviderResolver && this.#runtimeUsageProviderOverrides.size === 0) return null;
@@ -4717,7 +4748,12 @@ export class AuthStorage {
 		const nowMs = Date.now();
 		const { strategy } = args;
 		const ranked: RankedOAuthCandidate[] = [];
-		// Pre-fetch usage reports in parallel for non-blocked credentials.
+		// Pre-fetch usage reports in parallel. Blocked credentials are probed too:
+		// the fetch runs live-usage reconciliation, so a block that outlived its
+		// cause is cleared before this very selection reads it back. Without the
+		// probe healing only reaches processes that poll usage on their own (the
+		// TUI widget), and print mode, subagents, and the gateway stay pinned to a
+		// stale block until it expires.
 		// Wrap with a timeout so slow/429'd fetches don't indefinitely block
 		// credential selection — better to pick a credential without usage data
 		// than to hang the agent waiting for rate-limited usage endpoints.
@@ -4734,7 +4770,7 @@ export class AuthStorage {
 				);
 				let usage: UsageReport | null = null;
 				let usageChecked = false;
-				if (blockedUntil !== undefined && args.provider === "openai-codex") {
+				if (blockedUntil !== undefined) {
 					usage = await this.#getUsageReport(args.provider, selection.credential, {
 						...args.options,
 						timeoutMs: this.#usageRequestTimeoutMs,
@@ -4767,13 +4803,21 @@ export class AuthStorage {
 		timer.unref?.();
 		const usageResults = await Promise.race([usagePromise, timeoutSignal.promise]).then(result => {
 			clearTimeout(timer);
-			return (
-				result ??
-				args.order.map(idx => {
-					const selection = args.credentials[idx];
-					return selection ? { selection, usage: null, usageChecked: false, blockedUntil: undefined } : null;
-				})
-			);
+			if (result) return result;
+			// Timeout. Blocked credentials are probed now, so a slow probe can be
+			// what trips this — re-read the block instead of reporting every
+			// candidate unblocked and handing the turn to a capped account.
+			return args.order.map(idx => {
+				const selection = args.credentials[idx];
+				if (!selection) return null;
+				const blockedUntil = this.#getCredentialBlockedUntil(
+					args.provider,
+					args.providerKey,
+					selection.index,
+					args.blockScopes ?? args.blockScope,
+				);
+				return { selection, usage: null, usageChecked: false, blockedUntil };
+			});
 		});
 
 		for (let orderPos = 0; orderPos < usageResults.length; orderPos += 1) {
@@ -6162,27 +6206,45 @@ export class AuthStorage {
 	}
 
 	/**
-	 * Self-heal a stale Codex usage-limit block: when a fresh live usage report
-	 * says the account is allowed and below every reported limit, drop the
-	 * persisted and in-memory `openai-codex:oauth` blocks so credential selection
-	 * can re-include recovered seats before a stale block naturally expires.
+	 * Self-heal a stale usage-limit block: when a fresh live usage report says
+	 * the account is below every limit the block's scope gates, drop the
+	 * persisted and in-memory blocks so credential selection can re-include
+	 * recovered seats before a stale block naturally expires. Providers hand out
+	 * `retry-after` values that can outlive the cap they describe (Anthropic
+	 * routinely answers a Fable 429 with the account's weekly reset), so expiry
+	 * alone is not a safe release condition.
 	 */
 	/**
+	 * Narrow a report to the meters a credential-wide block actually gates.
+	 * Judging that block against the raw report would let a meter the strategy
+	 * never gates on — a display-only or feature quota such as Z.AI's `zread` —
+	 * hold the credential blocked for ordinary requests until expiry.
+	 */
+	#scopeUsageReportToCredentialGating(
+		report: UsageReport,
+		strategy: CredentialRankingStrategy | undefined,
+	): UsageReport {
+		if (!strategy) return report;
+		const limits =
+			strategy.scopeLimitsForCredentialBlock?.(report) ?? strategy.scopeLimits?.(report, {}) ?? report.limits;
+		if (limits.length === report.limits.length) return report;
+		return { ...report, limits };
+	}
+
+	/**
 	 * Narrow a usage report to the limits a backoff scope covers, so a scope is
-	 * judged only by the meters it gates. A legacy scope that meant "block
-	 * everything" keeps the whole report.
+	 * judged only by the meters it gates.
 	 */
 	#scopeUsageReportToBlockScope(
 		report: UsageReport,
 		blockScope: string | undefined,
 		strategy: CredentialRankingStrategy | undefined,
 	): UsageReport {
-		if (!blockScope || !strategy?.scopeLimits || !strategy.blockScopes) return report;
-		// Find a request context whose scope set leads with this scope; its scoped
-		// limits are the ones this block gates.
-		const modelId = blockScope === "spark" ? "gpt-5.3-codex-spark" : "gpt-5.3-codex";
-		if (strategy.blockScopes({ modelId })[0] !== blockScope) return report;
-		const scopedLimits = strategy.scopeLimits(report, { modelId });
+		if (!blockScope) return this.#scopeUsageReportToCredentialGating(report, strategy);
+		// The strategy owns the mapping from its own persisted scope to the limits
+		// that scope gates; an unmapped scope is a catch-all and keeps the report.
+		const scopedLimits = strategy?.scopeLimitsForBlockScope?.(report, blockScope);
+		if (!scopedLimits) return report;
 		const meterStates = report.metadata?.meterStates;
 		const meterState =
 			meterStates !== null && typeof meterStates === "object"
@@ -6231,37 +6293,80 @@ export class AuthStorage {
 		}
 	}
 
-	#isHealthyCodexUsageReport(report: UsageReport): boolean {
-		if (report.provider !== "openai-codex") return false;
+	/**
+	 * True when a live report proves the credential has headroom for the scope it
+	 * describes. A provider that publishes an explicit verdict (Codex meter
+	 * states) must say allowed and not limit-reached. One that only publishes
+	 * counters must account for every row the scope gates: a row carrying `used`
+	 * with no cap (Kimi does this) yields no fraction and is not "exhausted"
+	 * either, so one healthy weekly row beside an unreadable 5-hour row would
+	 * otherwise clear the block and hand the turn straight back to a credential
+	 * whose short window may still be spent.
+	 */
+	#isHealthyUsageReport(report: UsageReport): boolean {
 		const metadata = report.metadata;
-		if (metadata?.allowed !== true || metadata.limitReached !== false) return false;
+		if (metadata && ("allowed" in metadata || "limitReached" in metadata)) {
+			if (metadata.allowed !== true || metadata.limitReached !== false) return false;
+		} else if (
+			report.limits.length === 0 ||
+			!report.limits.every(limit => limit.status === "ok" || resolveUsedFraction(limit) !== undefined)
+		) {
+			return false;
+		}
 		return !this.#isUsageLimitReached(report.limits);
 	}
 
-	#reconcileCodexUsageBlockForCredential(provider: Provider, credentialId: number, report: UsageReport): void {
+	/** Scopes this credential currently holds a live persisted block under. */
+	#listPersistedBlockScopes(credentialId: number, providerKey: string): string[] | undefined {
+		if (this.#persistedBlockStoreDamaged) return undefined;
+		const listCredentialBlocks = this.#store.listCredentialBlocks?.bind(this.#store);
+		if (!listCredentialBlocks) return undefined;
+		try {
+			return listCredentialBlocks([credentialId])
+				.filter(block => block.providerKey === providerKey && block.blockScope.length > 0)
+				.map(block => block.blockScope);
+		} catch (err) {
+			if (this.#handlePersistedBlockStoreError(err)) return undefined;
+			logger.debug("Failed to list credential blocks for reconciliation", { err, credentialId, providerKey });
+			return undefined;
+		}
+	}
+
+	#reconcileUsageBlockForCredential(provider: Provider, credentialId: number, report: UsageReport): void {
 		const providerKey = this.#getProviderTypeKey(provider, "oauth");
 		const credentialIndex = this.#getStoredCredentials(provider).findIndex(entry => entry.id === credentialId);
 		if (credentialIndex < 0) return;
-		// Mirror selection: consult the same strategy scope `markUsageLimitReached`
-		// persists under, else a scoped block is invisible here and never healed.
 		// Reconciliation has no request context, so it cannot know which scope a
-		// block was written under. Heal every scope the strategy can produce, plus
-		// any legacy scope it still lists, or a block persisted under one scope
-		// stays invisible here forever.
+		// block was written under. Enumerate the scopes the credential actually
+		// holds, persisted or in memory. That makes an Antigravity
+		// `counter:<backend>` block and a future Claude `tier:<family>` block
+		// healable without maintaining a second model-family registry here.
 		const strategy = this.#rankingStrategyResolver?.(provider);
-		const blockScopes =
-			strategy?.blockScopes?.() ?? [strategy?.blockScope?.({})].filter(scope => scope !== undefined);
-		const scopesToHeal = blockScopes.length > 0 ? blockScopes : [undefined];
+		const persistedScopes = this.#listPersistedBlockScopes(credentialId, providerKey);
+		const inMemoryScopes = this.#listInMemoryBlockScopes(providerKey, credentialIndex);
+		// Preserve the pre-existing strategy fallback for custom stores that can
+		// point-read blocks but cannot enumerate them. Built-in SQLite and remote
+		// stores enumerate, so dynamic tier/counter scopes come from actual rows.
+		const fallbackScopes =
+			persistedScopes === undefined
+				? (strategy?.blockScopes?.() ?? [strategy?.blockScope?.({})].filter(scope => scope !== undefined))
+				: [];
+		if (
+			(persistedScopes?.length ?? 0) === 0 &&
+			inMemoryScopes.length === 0 &&
+			fallbackScopes.length === 0 &&
+			this.#getCredentialBlockedUntil(provider, providerKey, credentialIndex) === undefined
+		) {
+			return;
+		}
+		const scopesToHeal = new Set<string | undefined>([
+			...(persistedScopes ?? []),
+			...inMemoryScopes,
+			...fallbackScopes,
+			undefined,
+		]);
 		for (const blockScope of scopesToHeal) {
-			this.#healCodexUsageBlockScope(
-				provider,
-				providerKey,
-				credentialId,
-				credentialIndex,
-				blockScope,
-				report,
-				strategy,
-			);
+			this.#healUsageBlockScope(provider, providerKey, credentialId, credentialIndex, blockScope, report, strategy);
 		}
 	}
 
@@ -6273,7 +6378,7 @@ export class AuthStorage {
 	 * would then delete every scope including a block that is still valid. So
 	 * each scope is evaluated against its own limits and cleared on its own.
 	 */
-	#healCodexUsageBlockScope(
+	#healUsageBlockScope(
 		provider: Provider,
 		providerKey: string,
 		credentialId: number,
@@ -6283,7 +6388,7 @@ export class AuthStorage {
 		strategy: CredentialRankingStrategy | undefined,
 	): void {
 		const scopedReport = this.#scopeUsageReportToBlockScope(report, blockScope, strategy);
-		if (!this.#isHealthyCodexUsageReport(scopedReport)) return;
+		if (!this.#isHealthyUsageReport(scopedReport)) return;
 		const blockedUntilMs = this.#getCredentialBlockedUntil(provider, providerKey, credentialIndex, blockScope);
 		if (blockedUntilMs === undefined) return;
 		// `/usage` can lag the request path that just returned 429. Fresh local or
@@ -6303,7 +6408,22 @@ export class AuthStorage {
 			return;
 		}
 		this.#clearCredentialBlockScope(provider, credentialId, credentialIndex, providerKey, blockScope);
-		logger.info("Cleared stale Codex usage-limit block after healthy live usage report", {
+		// A store may refuse the scoped delete — the broker protocol has no scoped
+		// deletion, so RemoteAuthCredentialStore keeps the row and the next
+		// snapshot restores it. The in-memory backoff is still gone, but claiming
+		// the block was cleared would send anyone debugging that case down the
+		// wrong path.
+		const persistedAfterClear = this.#readPersistedCredentialBlock(credentialId, providerKey, blockScope ?? "");
+		if (persistedAfterClear !== undefined) {
+			logger.debug("Live usage report healed a block the credential store would not drop", {
+				credentialId,
+				provider,
+				blockScope,
+				persistedBlockedUntilMs: persistedAfterClear,
+			});
+			return;
+		}
+		logger.info("Cleared stale usage-limit block after healthy live usage report", {
 			credentialId,
 			provider,
 			blockScope,
@@ -6311,46 +6431,79 @@ export class AuthStorage {
 		});
 	}
 
-	#reconcileCodexUsageBlock(request: UsageRequestDescriptor, report: UsageReport): void {
-		if (request.provider !== "openai-codex") return;
+	#reconcileUsageBlock(request: UsageRequestDescriptor, report: UsageReport): void {
 		const credentialId = this.#findStoredCredentialIdForUsageCredential(request.provider, request.credential);
 		if (credentialId === undefined) return;
-		this.#reconcileCodexUsageBlockForCredential(request.provider, credentialId, report);
+		this.#reconcileUsageBlockForCredential(request.provider, credentialId, report);
 	}
 
-	#findStoredCredentialIdsForUsageReport(report: UsageReport): number[] {
-		if (report.provider !== "openai-codex") return [];
+	#findStoredCredentialIdsForUsageReport(report: UsageReport, sameOrgReportCount: number): number[] {
 		const email = this.#getUsageReportMetadataValue(report, "email")?.toLowerCase();
 		const accountId = (
 			this.#getUsageReportMetadataValue(report, "accountId") ?? this.#getUsageReportScopeAccountId(report)
 		)?.toLowerCase();
-		if (!email && !accountId) return [];
+		// One Anthropic login can own several organization subscriptions, each a
+		// separate row with its own quota. Email and account id alone would let a
+		// healthy org's report clear an exhausted sibling org's block.
+		const orgId = this.#getUsageReportMetadataValue(report, "orgId")?.toLowerCase();
+		const projectId = this.#getUsageReportMetadataValue(report, "projectId")?.toLowerCase();
+		if (!email && !accountId && !orgId && !projectId) return [];
 		const matches: number[] = [];
 		for (const entry of this.#getStoredCredentials(report.provider)) {
 			const credential = entry.credential;
 			if (credential.type !== "oauth") continue;
+			// Organization presence is itself an identity gate: a report
+			// attributed to one subscription must not heal an org-less legacy row,
+			// and an unattributed aggregate must not heal an org-scoped row. Mirror
+			// RemoteAuthCredentialStore.usageReportMatchesCredential.
+			const credentialOrg = credential.orgId?.trim().toLowerCase();
+			if (credentialOrg !== orgId) continue;
+			// Every remaining identity dimension present on BOTH sides must agree
+			// — account ids can be workspace-wide and one email can span projects,
+			// so a single-dimension match can cross-link siblings. Org uniqueness
+			// is a complete match only for an org-only credential; if the row has
+			// a base identity, the report must carry and match one of its fields.
 			const credentialEmail = credential.email?.trim().toLowerCase();
 			const credentialAccountId = credential.accountId?.trim().toLowerCase();
-			// Every identity dimension present on BOTH sides must agree — the
-			// account id is shared workspace-wide and one email can span
-			// workspaces, so a single-dimension match can cross-link siblings.
-			const emailComparable = Boolean(email && credentialEmail);
-			const accountComparable = Boolean(accountId && credentialAccountId);
-			if (!emailComparable && !accountComparable) continue;
-			if (emailComparable && credentialEmail !== email) continue;
-			if (accountComparable && credentialAccountId !== accountId) continue;
+			const credentialProjectId = credential.projectId?.trim().toLowerCase();
+			const dimensions: Array<[string | undefined, string | undefined]> = [
+				[email, credentialEmail],
+				[accountId, credentialAccountId],
+				[projectId, credentialProjectId],
+			];
+			const hasCredentialBaseIdentity = Boolean(credentialEmail || credentialAccountId || credentialProjectId);
+			let comparable = orgId !== undefined && sameOrgReportCount === 1 && !hasCredentialBaseIdentity;
+			let mismatched = false;
+			for (const [reported, stored] of dimensions) {
+				if (!reported || !stored) continue;
+				comparable = true;
+				if (reported !== stored) {
+					mismatched = true;
+					break;
+				}
+			}
+			if (!comparable || mismatched) continue;
 			matches.push(entry.id);
 		}
 		return matches;
 	}
 
-	#reconcileCodexUsageBlocksFromReports(reports: UsageReport[]): void {
+	#reconcileUsageBlocksFromReports(reports: UsageReport[]): void {
+		const reportsByProviderOrg = new Map<string, number>();
+		for (const report of reports) {
+			const orgId = this.#getUsageReportMetadataValue(report, "orgId")?.toLowerCase();
+			if (!orgId) continue;
+			const key = `${report.provider}\0${orgId}`;
+			reportsByProviderOrg.set(key, (reportsByProviderOrg.get(key) ?? 0) + 1);
+		}
 		const reconciled = new Set<number>();
 		for (const report of reports) {
-			for (const credentialId of this.#findStoredCredentialIdsForUsageReport(report)) {
+			const orgId = this.#getUsageReportMetadataValue(report, "orgId")?.toLowerCase();
+			const sameOrgReportCount = orgId ? (reportsByProviderOrg.get(`${report.provider}\0${orgId}`) ?? 0) : 0;
+			for (const credentialId of this.#findStoredCredentialIdsForUsageReport(report, sameOrgReportCount)) {
 				if (reconciled.has(credentialId)) continue;
 				reconciled.add(credentialId);
-				this.#reconcileCodexUsageBlockForCredential(report.provider, credentialId, report);
+				this.#reconcileUsageBlockForCredential(report.provider, credentialId, report);
 			}
 		}
 	}

--- a/packages/ai/src/usage.ts
+++ b/packages/ai/src/usage.ts
@@ -400,15 +400,30 @@ export interface CredentialRankingStrategy {
 	 */
 	blockScope?(context?: CredentialRankingContext): string | undefined;
 	/**
-	 * Scopes that apply to a request, most specific first. With a context, the
-	 * request's own scope plus any legacy catch-all scope whose blocks still
-	 * apply to everything. Without one — reconciliation runs with no request —
-	 * every scope whose blocks must be healed.
+	 * Scopes that apply to a request, most specific first: the request's own
+	 * scope plus any legacy catch-all scope whose blocks still apply to it.
 	 *
 	 * A provider that scopes backoff by model family must implement this, or a
-	 * block written under one scope is invisible to requests and to healing.
+	 * block written under one scope is invisible to request-time selection.
+	 * Reconciliation separately enumerates the blocks a credential actually
+	 * holds, so this never doubles as a provider model-family registry.
 	 */
 	blockScopes?(context?: CredentialRankingContext): string[];
+	/**
+	 * Limits a credential-wide block actually gates. Falls back to
+	 * {@link scopeLimits} without a request context. Providers whose unscoped
+	 * errors can cover model-tier counters should include those counters here.
+	 */
+	scopeLimitsForCredentialBlock?(report: UsageReport): UsageLimit[];
+	/**
+	 * Limits a persisted block scope actually gates, used to judge whether that
+	 * one block may be healed from a live report. Reconciliation has no request
+	 * context, so a scope that cannot be narrowed is judged against the whole
+	 * report — and one unrelated exhausted counter would then pin it until
+	 * expiry. Return `undefined` for a catch-all scope that really does gate
+	 * everything, or for a scope this strategy does not own.
+	 */
+	scopeLimitsForBlockScope?(report: UsageReport, blockScope: string): UsageLimit[] | undefined;
 	/** Fallback window durations (ms) when limits don't specify durationMs. */
 	windowDefaults: {
 		primaryMs: number;

--- a/packages/ai/src/usage/claude.ts
+++ b/packages/ai/src/usage/claude.ts
@@ -718,11 +718,14 @@ function getClaudeModelKind(context: CredentialRankingContext | undefined): Clau
  * opt-in reserve-health scope (`scopeLimitsForReserve`); credential-wide hard
  * blocks use {@link scopeClaudeLimitsForModelHardBlock} instead.
  */
-function scopeClaudeLimitsForModel(report: UsageReport, context: CredentialRankingContext | undefined): UsageLimit[] {
-	const kind = getClaudeModelKind(context);
+function scopeClaudeLimitsForKind(report: UsageReport, kind: string | undefined): UsageLimit[] {
 	return report.limits.filter(
 		limit => limit.scope.shared === true || (kind !== undefined && limit.scope.tier === kind),
 	);
+}
+
+function scopeClaudeLimitsForModel(report: UsageReport, context: CredentialRankingContext | undefined): UsageLimit[] {
+	return scopeClaudeLimitsForKind(report, getClaudeModelKind(context));
 }
 
 /**
@@ -748,11 +751,7 @@ function isConfirmedExhaustedTierRow(limit: UsageLimit, nowMs: number): boolean 
  * while unconfirmed rows remain ranking pressure and opt-in reserve health via
  * scopeClaudeLimitsForModel.
  */
-function scopeClaudeLimitsForModelHardBlock(
-	report: UsageReport,
-	context: CredentialRankingContext | undefined,
-): UsageLimit[] {
-	const kind = getClaudeModelKind(context);
+function scopeClaudeLimitsForKindHardBlock(report: UsageReport, kind: ClaudeModelKind | undefined): UsageLimit[] {
 	const requireConfirmedTierRow = kind === "fable" || kind === "mythos";
 	const nowMs = Date.now();
 	return report.limits.filter(limit => {
@@ -760,6 +759,13 @@ function scopeClaudeLimitsForModelHardBlock(
 		if (kind === undefined || limit.scope.tier !== kind) return false;
 		return !requireConfirmedTierRow || isConfirmedExhaustedTierRow(limit, nowMs);
 	});
+}
+
+function scopeClaudeLimitsForModelHardBlock(
+	report: UsageReport,
+	context: CredentialRankingContext | undefined,
+): UsageLimit[] {
+	return scopeClaudeLimitsForKindHardBlock(report, getClaudeModelKind(context));
 }
 
 function rankingUsedFraction(limit: UsageLimit): number {
@@ -806,6 +812,11 @@ function findClaudeSecondaryLimit(
 		.reduce<UsageLimit | undefined>((selected, limit) => morePressuredLimit(selected, limit, nowMs), undefined);
 }
 
+function claudeTierBlockScope(context: CredentialRankingContext | undefined): string | undefined {
+	const kind = getClaudeModelKind(context);
+	return kind === "fable" || kind === "mythos" ? `tier:${kind}` : undefined;
+}
+
 export const claudeRankingStrategy: CredentialRankingStrategy = {
 	findWindowLimits(report, context) {
 		const primary = report.limits.find(limit => limit.id === "anthropic:5h");
@@ -818,14 +829,45 @@ export const claudeRankingStrategy: CredentialRankingStrategy = {
 	// Fable/Mythos weekly cap inside the reserve margin should move the turn to
 	// a healthy candidate rather than serve until 100%.
 	scopeLimitsForReserve: scopeClaudeLimitsForModel,
+	// Opus/Sonnet 429s still use the credential-wide bucket, while their usage
+	// reports can carry tier rows. Preserve every published Claude tier as
+	// evidence when healing that global block; extra-usage/display rows remain
+	// unrelated.
+	scopeLimitsForCredentialBlock(report) {
+		return report.limits.filter(limit => limit.scope.shared === true || limit.scope.tier !== undefined);
+	},
 	/**
 	 * Fable/Mythos usage-limit errors map to tier-local weekly counters. Scope
 	 * reactive backoff blocks for those tiers, mirroring the per-counter
 	 * precedent in packages/ai/src/usage/google-antigravity.ts:466-497.
 	 */
-	blockScope(context) {
-		const kind = getClaudeModelKind(context);
-		return kind === "fable" || kind === "mythos" ? `tier:${kind}` : undefined;
+	blockScope: claudeTierBlockScope,
+	/**
+	 * Opus/Sonnet requests keep backing off under the credential-wide bucket, so
+	 * a request context yields at most its own tier scope. Context-free healing
+	 * enumerates the blocks that actually exist instead of a family list here.
+	 */
+	blockScopes(context) {
+		const scope = claudeTierBlockScope(context);
+		return scope ? [scope] : [];
+	},
+	/**
+	 * Map a persisted tier scope straight to the limits it gates. Going through a
+	 * synthetic model id would put Anthropic naming back into TypeScript and make
+	 * healing depend on it; the tier is already the fact the scope encodes.
+	 *
+	 * Deliberately NOT the hard-block scoper. Gating hides an unconfirmed tier row
+	 * (100% used but no live reset) because it must not block on a counter that
+	 * lies below the cap; healing has the opposite bias, and hiding that row would
+	 * read "no evidence" as "recovered" and clear the very block the row justifies.
+	 * A report with no row for the tier still heals on the shared windows — the
+	 * provider simply does not publish that counter for the account.
+	 */
+	scopeLimitsForBlockScope(report, blockScope) {
+		if (!blockScope.startsWith("tier:")) return undefined;
+		const tier = blockScope.slice("tier:".length);
+		if (!tier) return undefined;
+		return scopeClaudeLimitsForKind(report, tier);
 	},
 	windowDefaults: { primaryMs: 5 * 60 * 60 * 1000, secondaryMs: 7 * 24 * 60 * 60 * 1000 },
 };

--- a/packages/ai/src/usage/google-antigravity.ts
+++ b/packages/ai/src/usage/google-antigravity.ts
@@ -485,6 +485,24 @@ export const antigravityRankingStrategy: CredentialRankingStrategy = {
 		const counterKey = getAntigravityCounterKeyForModel(context?.modelId);
 		return `counter:${counterKey ?? "unknown"}`;
 	},
+	/**
+	 * Reactive blocks land under `counter:<backend>`, so healing has to resolve
+	 * that scope back to its own counter rows. Reading the counter out of the
+	 * scope keeps this free of model ids and of a hard-coded backend list — the
+	 * counter key is whatever the catalog mapped the request's model to.
+	 *
+	 * Mirrors the request scoper's legacy fallback: an endpoint that publishes
+	 * only `default` rows would otherwise narrow to nothing, and an empty scope
+	 * reads as "unknown", pinning the block until its original expiry.
+	 */
+	scopeLimitsForBlockScope(report, blockScope) {
+		if (!blockScope.startsWith("counter:")) return undefined;
+		const counterKey = blockScope.slice("counter:".length);
+		if (!counterKey || counterKey === "unknown") return undefined;
+		const backendLimits = getAntigravityCounterLimits(report, counterKey);
+		if (backendLimits.length > 0) return backendLimits;
+		return getAntigravityCounterLimits(report, "default");
+	},
 	// Antigravity windows carry `durationMs` when the response identifies them
 	// as daily/weekly. Fall back to daily for legacy unlabelled quotaInfo
 	// entries from `daily-cloudcode-pa.googleapis.com`.

--- a/packages/ai/src/usage/openai-codex.ts
+++ b/packages/ai/src/usage/openai-codex.ts
@@ -566,16 +566,19 @@ export const openaiCodexUsageProvider: UsageProvider = {
 // the 5h/weekly chat windows. Scoping the gating set this way keeps an exhausted
 // Spark meter from blocking a normal chat request (and vice versa), instead of
 // OR-ing every window and meter in the report into one provider-wide block.
-function scopeCodexLimitsForRequest(report: UsageReport, context?: CredentialRankingContext): UsageLimit[] {
-	const isSparkRequest = isCodexSparkRequest(context);
+function scopeCodexLimitsForMeter(report: UsageReport, isSparkMeter: boolean): UsageLimit[] {
 	return report.limits.filter(limit => {
 		if (limit.id === "openai-codex:primary" || limit.id === "openai-codex:secondary") {
-			return !isSparkRequest;
+			return !isSparkMeter;
 		}
 		// Additional metered features have ids of the form `openai-codex:<slug>:<key>`.
 		const slug = limit.id.split(":")[1];
-		return slug === "spark" ? isSparkRequest : false;
+		return slug === "spark" ? isSparkMeter : false;
 	});
+}
+
+function scopeCodexLimitsForRequest(report: UsageReport, context?: CredentialRankingContext): UsageLimit[] {
+	return scopeCodexLimitsForMeter(report, isCodexSparkRequest(context));
 }
 
 /** True when the requested model spends the separate Spark meter. */
@@ -598,6 +601,12 @@ export const codexRankingStrategy: CredentialRankingStrategy = {
 	blockScopes(context) {
 		if (!context) return ["chat", "spark", "shared"];
 		return [isCodexSparkRequest(context) ? "spark" : "chat", "shared"];
+	},
+	// "shared" is deliberately unmapped: it gates every meter, so healing judges
+	// it against the whole report rather than one meter's limits.
+	scopeLimitsForBlockScope(report, blockScope) {
+		if (blockScope !== "chat" && blockScope !== "spark") return undefined;
+		return scopeCodexLimitsForMeter(report, blockScope === "spark");
 	},
 	findWindowLimits(report, context) {
 		const limits = scopeCodexLimitsForRequest(report, context);

--- a/packages/ai/test/auth-storage-antigravity-selection.test.ts
+++ b/packages/ai/test/auth-storage-antigravity-selection.test.ts
@@ -9,6 +9,7 @@
  * credentials and could pin a session to the exhausted account.
  */
 import { afterEach, beforeEach, describe, expect, test, vi } from "bun:test";
+import { Database } from "bun:sqlite";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -19,6 +20,7 @@ import type { UsageLimit, UsageProvider, UsageReport } from "@oh-my-pi/pi-ai/usa
 import { removeWithRetries } from "../../utils/src/temp";
 
 const HOUR_MS = 60 * 60 * 1000;
+const RECONCILE_GRACE_MS = 5 * 60_000;
 
 type AntigravityWindowSpec = {
 	counter: "google" | "anthropic" | "openai" | "default";
@@ -257,5 +259,68 @@ describe("AuthStorage google-antigravity oauth ranking", () => {
 		const fresh = counts.get("api-acct-fresh") ?? 0;
 		const loaded = counts.get("api-acct-loaded") ?? 0;
 		expect(fresh).toBeGreaterThan(loaded);
+	});
+
+	// Antigravity persists reactive blocks as `counter:<backend>`, a scope no
+	// context-free strategy call can name. Reconciliation therefore enumerates the
+	// scopes the credential actually holds; without that the account stays
+	// excluded until the original retry-after expires even though live usage says
+	// the counter recovered.
+	test("clears a persisted Antigravity counter block once its own counter recovers", async () => {
+		if (!authStorage || !store?.upsertCredentialBlock || !store.getCredentialBlock) {
+			throw new Error("test setup failed");
+		}
+		await authStorage.set("google-antigravity", [
+			{ type: "oauth", ...createCredential("acct-blocked", "proj-blocked", "blocked@example.com") },
+			{ type: "oauth", ...createCredential("acct-other", "proj-other", "other@example.com") },
+		]);
+		const blockedRow = store
+			.listAuthCredentials("google-antigravity")
+			.find(row => row.credential.type === "oauth" && row.credential.accountId === "acct-blocked");
+		if (!blockedRow) throw new Error("expected blocked credential row");
+
+		store.upsertCredentialBlock({
+			credentialId: blockedRow.id,
+			providerKey: "google-antigravity:oauth",
+			blockScope: "counter:google",
+			blockedUntilMs: Date.now() + 24 * HOUR_MS,
+		});
+		// A fresh block gets one usage-cache window of grace before a healthy report
+		// may clear it. Age it so this test exercises healing, not the guard.
+		const blockDb = new Database(path.join(tempDir, "agent.db"));
+		try {
+			blockDb
+				.prepare("UPDATE auth_credential_blocks SET updated_at = ? WHERE credential_id = ?")
+				.run(Math.floor((Date.now() - RECONCILE_GRACE_MS - 1000) / 1000), blockedRow.id);
+		} finally {
+			blockDb.close();
+		}
+		store.cleanExpiredCredentialBlocks?.(Date.now() + RECONCILE_GRACE_MS);
+		usageByAccount.set(
+			"acct-blocked",
+			createAntigravityReport({
+				accountId: "acct-blocked",
+				projectId: "proj-blocked",
+				windows: [
+					{ counter: "google", usedFraction: 0.1, resetInMs: 20 * HOUR_MS },
+					// A sibling counter still at its cap must not keep the recovered
+					// Gemini counter's block alive.
+					{ counter: "anthropic", usedFraction: 1, resetInMs: 20 * HOUR_MS },
+				],
+			}),
+		);
+		usageByAccount.set(
+			"acct-other",
+			createAntigravityReport({
+				accountId: "acct-other",
+				projectId: "proj-other",
+				windows: [{ counter: "google", usedFraction: 1, resetInMs: 20 * HOUR_MS }],
+			}),
+		);
+
+		expect(
+			await authStorage.getApiKey("google-antigravity", "session-antigravity-heal", { modelId: "gemini-3-flash" }),
+		).toBe("api-acct-blocked");
+		expect(store.getCredentialBlock(blockedRow.id, "google-antigravity:oauth", "counter:google")).toBeUndefined();
 	});
 });

--- a/packages/ai/test/auth-storage-claude-fable-fallback.test.ts
+++ b/packages/ai/test/auth-storage-claude-fable-fallback.test.ts
@@ -4,18 +4,26 @@ import {
 	type AuthCredentialStore,
 	AuthStorage,
 	type StoredAuthCredential,
+	type StoredCredentialBlock,
 } from "@oh-my-pi/pi-ai/auth-storage";
 import type { UsageLimit, UsageReport } from "@oh-my-pi/pi-ai/usage";
 import * as claudeUsage from "@oh-my-pi/pi-ai/usage/claude";
 
+const ANTHROPIC_PROVIDER_KEY = "anthropic:oauth";
+
 interface ObservableStore extends AuthCredentialStore {
 	cache: Map<string, { value: string; expiresAtSec: number }>;
+	blocks: Map<string, StoredCredentialBlock>;
 }
 
 function makeStore(rows: StoredAuthCredential[]): ObservableStore {
 	const cache = new Map<string, { value: string; expiresAtSec: number }>();
+	const blocks = new Map<string, StoredCredentialBlock>();
+	const blockKey = (credentialId: number, providerKey: string, blockScope: string) =>
+		`${credentialId}\0${providerKey}\0${blockScope}`;
 	return {
 		cache,
+		blocks,
 		close() {},
 		listAuthCredentials() {
 			return rows;
@@ -42,6 +50,25 @@ function makeStore(rows: StoredAuthCredential[]): ObservableStore {
 			cache.set(key, { value, expiresAtSec });
 		},
 		cleanExpiredCache() {},
+		getCredentialBlock(credentialId, providerKey, blockScope) {
+			const block = blocks.get(blockKey(credentialId, providerKey, blockScope));
+			if (!block || block.blockedUntilMs <= Date.now()) return undefined;
+			return block.blockedUntilMs;
+		},
+		upsertCredentialBlock(block) {
+			blocks.set(blockKey(block.credentialId, block.providerKey, block.blockScope), block);
+		},
+		deleteCredentialBlock(credentialId, providerKey, blockScope) {
+			blocks.delete(blockKey(credentialId, providerKey, blockScope));
+		},
+		deleteCredentialBlocks(credentialId) {
+			for (const [key, block] of blocks) {
+				if (block.credentialId === credentialId) blocks.delete(key);
+			}
+		},
+		listCredentialBlocks(credentialIds) {
+			return [...blocks.values()].filter(block => credentialIds.includes(block.credentialId));
+		},
 	};
 }
 
@@ -407,5 +434,436 @@ describe("AuthStorage Claude Fable tier fallback", () => {
 		const key = await storage.getApiKey("anthropic", "session-3", { modelId: "claude-fable-5" });
 
 		expect(key).toBe("oat-3");
+	});
+
+	// Anthropic answers a Fable 429 with a `retry-after` that can point at the
+	// account's weekly reset (~37h observed) even when only a short window is
+	// spent. The reactive block persists under `tier:fable`, so without healing
+	// every later Fable turn skips a recovered account and falls off-provider.
+	it("clears a persisted Fable block when a usage poll shows the account recovered", async () => {
+		const blockedUntilMs = Date.now() + 36 * 60 * 60_000;
+		store.upsertCredentialBlock?.({
+			credentialId: 1,
+			providerKey: ANTHROPIC_PROVIDER_KEY,
+			blockScope: "tier:fable",
+			blockedUntilMs,
+		});
+		const reportsByAccess: Record<string, UsageReport> = {
+			"oat-1": withFable(baseReport("a@example.com"), 0),
+			"oat-2": withSharedUsage(baseReport("b@example.com"), "5h", 1.0),
+			"oat-3": withSharedUsage(baseReport("c@example.com"), "5h", 1.0),
+		};
+		vi.spyOn(claudeUsage.claudeUsageProvider, "fetchUsage").mockImplementation(async params => {
+			const access = params.credential.type === "oauth" ? params.credential.accessToken : undefined;
+			if (!access) return null;
+			return reportsByAccess[access] ?? null;
+		});
+
+		await storage.fetchUsageReports();
+
+		expect(store.getCredentialBlock?.(1, ANTHROPIC_PROVIDER_KEY, "tier:fable")).toBeUndefined();
+		expect(await storage.getApiKey("anthropic", "session-heal", { modelId: "claude-fable-5" })).toBe("oat-1");
+	});
+
+	// Only the TUI polls usage on its own. Print mode, subagents, and the gateway
+	// reach healing exclusively through selection, so a blocked credential has to
+	// be re-probed there or those callers stay pinned until the block expires.
+	it("clears a persisted Fable block during selection without a separate usage poll", async () => {
+		store.upsertCredentialBlock?.({
+			credentialId: 1,
+			providerKey: ANTHROPIC_PROVIDER_KEY,
+			blockScope: "tier:fable",
+			blockedUntilMs: Date.now() + 36 * 60 * 60_000,
+		});
+		const reportsByAccess: Record<string, UsageReport> = {
+			"oat-1": withFable(baseReport("a@example.com"), 0),
+			"oat-2": withSharedUsage(baseReport("b@example.com"), "5h", 1.0),
+			"oat-3": withSharedUsage(baseReport("c@example.com"), "5h", 1.0),
+		};
+		vi.spyOn(claudeUsage.claudeUsageProvider, "fetchUsage").mockImplementation(async params => {
+			const access = params.credential.type === "oauth" ? params.credential.accessToken : undefined;
+			if (!access) return null;
+			return reportsByAccess[access] ?? null;
+		});
+
+		expect(await storage.getApiKey("anthropic", "session-select", { modelId: "claude-fable-5" })).toBe("oat-1");
+		expect(store.getCredentialBlock?.(1, ANTHROPIC_PROVIDER_KEY, "tier:fable")).toBeUndefined();
+	});
+
+	// Usage reports are cached per credential for five minutes and the cache is
+	// shared across processes, so a short run's every read is typically a hit. A
+	// block written by another process is never accompanied by a local refetch,
+	// so healing has to accept cached evidence or it never runs at all here.
+	it("clears a persisted Fable block from a cached usage report when refetching fails", async () => {
+		const reportsByAccess: Record<string, UsageReport> = {
+			"oat-1": withFable(baseReport("a@example.com"), 0),
+			"oat-2": withSharedUsage(baseReport("b@example.com"), "5h", 1.0),
+			"oat-3": withSharedUsage(baseReport("c@example.com"), "5h", 1.0),
+		};
+		const fetchUsage = vi.spyOn(claudeUsage.claudeUsageProvider, "fetchUsage").mockImplementation(async params => {
+			const access = params.credential.type === "oauth" ? params.credential.accessToken : undefined;
+			if (!access) return null;
+			return reportsByAccess[access] ?? null;
+		});
+
+		await storage.fetchUsageReports();
+		expect(fetchUsage.mock.calls.length).toBeGreaterThan(0);
+
+		// Another process 429s and persists the block; this process only has the
+		// report it already cached, and Anthropic rate-limits `/usage` for exactly
+		// the account that just hit its cap, so a refetch yields nothing.
+		store.upsertCredentialBlock?.({
+			credentialId: 1,
+			providerKey: ANTHROPIC_PROVIDER_KEY,
+			blockScope: "tier:fable",
+			blockedUntilMs: Date.now() + 36 * 60 * 60_000,
+		});
+		fetchUsage.mockResolvedValue(null);
+
+		expect(await storage.getApiKey("anthropic", "session-cached", { modelId: "claude-fable-5" })).toBe("oat-1");
+		expect(store.getCredentialBlock?.(1, ANTHROPIC_PROVIDER_KEY, "tier:fable")).toBeUndefined();
+	});
+
+	it("keeps a persisted Fable block while the shared window the tier spends is exhausted", async () => {
+		const blockedUntilMs = Date.now() + 36 * 60 * 60_000;
+		store.upsertCredentialBlock?.({
+			credentialId: 1,
+			providerKey: ANTHROPIC_PROVIDER_KEY,
+			blockScope: "tier:fable",
+			blockedUntilMs,
+		});
+		const reportsByAccess: Record<string, UsageReport> = {
+			"oat-1": withSharedUsage(withFable(baseReport("a@example.com"), 0), "5h", 1.0),
+			"oat-2": withFable(baseReport("b@example.com"), 0),
+			"oat-3": withFable(baseReport("c@example.com"), 0),
+		};
+		vi.spyOn(claudeUsage.claudeUsageProvider, "fetchUsage").mockImplementation(async params => {
+			const access = params.credential.type === "oauth" ? params.credential.accessToken : undefined;
+			if (!access) return null;
+			return reportsByAccess[access] ?? null;
+		});
+
+		await storage.fetchUsageReports();
+
+		expect(store.getCredentialBlock?.(1, ANTHROPIC_PROVIDER_KEY, "tier:fable")).toBe(blockedUntilMs);
+	});
+
+	// Gating deliberately ignores a tier row at 100% with no live reset, because
+	// the counter is unreliable below the cap and must not hard-block on its own.
+	// Healing must not inherit that: reusing the gating scope would hide the row,
+	// leave only the healthy shared windows, and clear the block the row justifies.
+	it("keeps a persisted Fable block when the tier row reads exhausted without a reset", async () => {
+		const blockedUntilMs = Date.now() + 36 * 60 * 60_000;
+		store.upsertCredentialBlock?.({
+			credentialId: 1,
+			providerKey: ANTHROPIC_PROVIDER_KEY,
+			blockScope: "tier:fable",
+			blockedUntilMs,
+		});
+		const reportsByAccess: Record<string, UsageReport> = {
+			"oat-1": withFable(baseReport("a@example.com"), 1.0),
+			"oat-2": withFable(baseReport("b@example.com"), 0),
+			"oat-3": withFable(baseReport("c@example.com"), 0),
+		};
+		vi.spyOn(claudeUsage.claudeUsageProvider, "fetchUsage").mockImplementation(async params => {
+			const access = params.credential.type === "oauth" ? params.credential.accessToken : undefined;
+			if (!access) return null;
+			return reportsByAccess[access] ?? null;
+		});
+
+		await storage.fetchUsageReports();
+
+		expect(store.getCredentialBlock?.(1, ANTHROPIC_PROVIDER_KEY, "tier:fable")).toBe(blockedUntilMs);
+	});
+
+	// A row that reports `used` with no cap (Kimi's parser emits these) proves
+	// nothing about remaining quota. Counting it as evidence would clear the block
+	// and hand the turn straight back to a still-exhausted credential.
+	it("keeps a persisted Fable block when the report quantifies no limit", async () => {
+		const blockedUntilMs = Date.now() + 36 * 60 * 60_000;
+		store.upsertCredentialBlock?.({
+			credentialId: 1,
+			providerKey: ANTHROPIC_PROVIDER_KEY,
+			blockScope: "tier:fable",
+			blockedUntilMs,
+		});
+		const unquantified: UsageReport = {
+			provider: "anthropic",
+			fetchedAt: Date.now(),
+			limits: [
+				{
+					id: "anthropic:5h",
+					label: "Claude 5 Hour",
+					scope: { provider: "anthropic", windowId: "5h", shared: true },
+					window: { id: "5h", label: "5 Hour" },
+					amount: { used: 5, unit: "requests" },
+					status: "unknown",
+				},
+			],
+			metadata: { email: "a@example.com", accountId: "a@example.com" },
+		};
+		const reportsByAccess: Record<string, UsageReport> = {
+			"oat-1": unquantified,
+			"oat-2": withFable(baseReport("b@example.com"), 0),
+			"oat-3": withFable(baseReport("c@example.com"), 0),
+		};
+		vi.spyOn(claudeUsage.claudeUsageProvider, "fetchUsage").mockImplementation(async params => {
+			const access = params.credential.type === "oauth" ? params.credential.accessToken : undefined;
+			if (!access) return null;
+			return reportsByAccess[access] ?? null;
+		});
+
+		await storage.fetchUsageReports();
+
+		expect(store.getCredentialBlock?.(1, ANTHROPIC_PROVIDER_KEY, "tier:fable")).toBe(blockedUntilMs);
+	});
+
+	// One readable row is not enough: an unreadable sibling still gates the same
+	// scope, so healing on the readable one alone releases a credential whose
+	// other window may be spent.
+	it("keeps a persisted Fable block when only some gated limits are quantified", async () => {
+		const blockedUntilMs = Date.now() + 36 * 60 * 60_000;
+		store.upsertCredentialBlock?.({
+			credentialId: 1,
+			providerKey: ANTHROPIC_PROVIDER_KEY,
+			blockScope: "tier:fable",
+			blockedUntilMs,
+		});
+		const partiallyQuantified: UsageReport = {
+			...withFable(baseReport("a@example.com"), 0),
+			limits: [
+				{
+					id: "anthropic:5h",
+					label: "Claude 5 Hour",
+					scope: { provider: "anthropic", windowId: "5h", shared: true },
+					window: { id: "5h", label: "5 Hour" },
+					amount: { used: 5, unit: "requests" },
+					status: "unknown",
+				},
+				{
+					id: "anthropic:7d",
+					label: "Claude 7 Day",
+					scope: { provider: "anthropic", windowId: "7d", shared: true },
+					window: { id: "7d", label: "7 Day" },
+					amount: { used: 20, limit: 100, usedFraction: 0.2, unit: "percent" },
+					status: "ok",
+				},
+			],
+		};
+		const reportsByAccess: Record<string, UsageReport> = {
+			"oat-1": partiallyQuantified,
+			"oat-2": withFable(baseReport("b@example.com"), 0),
+			"oat-3": withFable(baseReport("c@example.com"), 0),
+		};
+		vi.spyOn(claudeUsage.claudeUsageProvider, "fetchUsage").mockImplementation(async params => {
+			const access = params.credential.type === "oauth" ? params.credential.accessToken : undefined;
+			if (!access) return null;
+			return reportsByAccess[access] ?? null;
+		});
+
+		await storage.fetchUsageReports();
+
+		expect(store.getCredentialBlock?.(1, ANTHROPIC_PROVIDER_KEY, "tier:fable")).toBe(blockedUntilMs);
+	});
+
+	// Opus/Sonnet errors use the credential-wide bucket, but their usage reports
+	// can carry tier rows. Healthy shared windows cannot prove recovery while one
+	// of those tier counters remains exhausted.
+	it("keeps a credential-wide block while a Claude tier remains exhausted", async () => {
+		const blockedUntilMs = Date.now() + 36 * 60 * 60_000;
+		store.upsertCredentialBlock?.({
+			credentialId: 1,
+			providerKey: ANTHROPIC_PROVIDER_KEY,
+			blockScope: "",
+			blockedUntilMs,
+		});
+		const withExhaustedOpusMeter: UsageReport = {
+			...baseReport("a@example.com"),
+			limits: [
+				...baseReport("a@example.com").limits,
+				{
+					id: "anthropic:7d:opus",
+					label: "Claude 7 Day (Opus)",
+					scope: { provider: "anthropic", windowId: "7d", tier: "opus" },
+					window: { id: "7d", label: "7 Day", resetsAt: Date.now() + 36 * 60 * 60_000 },
+					amount: { used: 100, limit: 100, usedFraction: 1, unit: "percent" },
+					status: "exhausted",
+				},
+			],
+		};
+		const reportsByAccess: Record<string, UsageReport> = {
+			"oat-1": withExhaustedOpusMeter,
+			"oat-2": withSharedUsage(baseReport("b@example.com"), "5h", 1.0),
+			"oat-3": withSharedUsage(baseReport("c@example.com"), "5h", 1.0),
+		};
+		vi.spyOn(claudeUsage.claudeUsageProvider, "fetchUsage").mockImplementation(async params => {
+			const access = params.credential.type === "oauth" ? params.credential.accessToken : undefined;
+			if (!access) return null;
+			return reportsByAccess[access] ?? null;
+		});
+
+		await storage.fetchUsageReports();
+
+		expect(store.getCredentialBlock?.(1, ANTHROPIC_PROVIDER_KEY, "")).toBe(blockedUntilMs);
+	});
+
+	it("does not heal an org-less sibling from an org-attributed broker report", async () => {
+		storage.close();
+		const email = "shared@example.com";
+		const legacyRow = oauthRow(1, email);
+		const orgRow = oauthRow(2, email);
+		if (orgRow.credential.type !== "oauth") throw new Error("expected OAuth fixture");
+		orgRow.credential.orgId = "org-team";
+		store = makeStore([legacyRow, orgRow]);
+		const report = baseReport(email);
+		report.metadata = { email, orgId: "org-team" };
+		store.fetchUsageReports = async () => [report];
+		const blockedUntilMs = Date.now() + 36 * 60 * 60_000;
+		for (const credentialId of [legacyRow.id, orgRow.id]) {
+			store.upsertCredentialBlock?.({
+				credentialId,
+				providerKey: ANTHROPIC_PROVIDER_KEY,
+				blockScope: "",
+				blockedUntilMs,
+			});
+		}
+		storage = new AuthStorage(store);
+		await storage.reload();
+
+		await storage.fetchUsageReports();
+
+		expect(store.getCredentialBlock?.(legacyRow.id, ANTHROPIC_PROVIDER_KEY, "")).toBe(blockedUntilMs);
+		expect(store.getCredentialBlock?.(orgRow.id, ANTHROPIC_PROVIDER_KEY, "")).toBeUndefined();
+	});
+
+	it("heals an org-only credential from the matching org-attributed broker report", async () => {
+		storage.close();
+		const orgOnly = oauthRow(1, "unused@example.com");
+		if (orgOnly.credential.type !== "oauth") throw new Error("expected OAuth fixture");
+		orgOnly.credential.orgId = "org-only";
+		delete orgOnly.credential.email;
+		delete orgOnly.credential.accountId;
+		store = makeStore([orgOnly]);
+		const report = baseReport("unused@example.com");
+		report.metadata = { orgId: "org-only" };
+		store.fetchUsageReports = async () => [report];
+		store.upsertCredentialBlock?.({
+			credentialId: orgOnly.id,
+			providerKey: ANTHROPIC_PROVIDER_KEY,
+			blockScope: "",
+			blockedUntilMs: Date.now() + 36 * 60 * 60_000,
+		});
+		storage = new AuthStorage(store);
+		await storage.reload();
+
+		await storage.fetchUsageReports();
+
+		expect(store.getCredentialBlock?.(orgOnly.id, ANTHROPIC_PROVIDER_KEY, "")).toBeUndefined();
+	});
+
+	it("keeps an org-only block when several broker reports share that organization", async () => {
+		storage.close();
+		const orgOnly = oauthRow(1, "unused@example.com");
+		if (orgOnly.credential.type !== "oauth") throw new Error("expected OAuth fixture");
+		orgOnly.credential.orgId = "org-team";
+		delete orgOnly.credential.email;
+		delete orgOnly.credential.accountId;
+		store = makeStore([orgOnly]);
+		const aliceReport = baseReport("alice@example.com");
+		aliceReport.metadata = { email: "alice@example.com", orgId: "org-team" };
+		const bobReport = baseReport("bob@example.com");
+		bobReport.metadata = { email: "bob@example.com", orgId: "org-team" };
+		store.fetchUsageReports = async () => [aliceReport, bobReport];
+		const blockedUntilMs = Date.now() + 36 * 60 * 60_000;
+		store.upsertCredentialBlock?.({
+			credentialId: orgOnly.id,
+			providerKey: ANTHROPIC_PROVIDER_KEY,
+			blockScope: "",
+			blockedUntilMs,
+		});
+		storage = new AuthStorage(store);
+		await storage.reload();
+
+		await storage.fetchUsageReports();
+
+		expect(store.getCredentialBlock?.(orgOnly.id, ANTHROPIC_PROVIDER_KEY, "")).toBe(blockedUntilMs);
+	});
+
+	it("keeps a base-identified credential blocked when the broker report identifies only its organization", async () => {
+		storage.close();
+		const identified = oauthRow(1, "alice@example.com");
+		if (identified.credential.type !== "oauth") throw new Error("expected OAuth fixture");
+		identified.credential.orgId = "org-team";
+		store = makeStore([identified]);
+		const report = baseReport("unused@example.com");
+		report.metadata = { orgId: "org-team" };
+		store.fetchUsageReports = async () => [report];
+		const blockedUntilMs = Date.now() + 36 * 60 * 60_000;
+		store.upsertCredentialBlock?.({
+			credentialId: identified.id,
+			providerKey: ANTHROPIC_PROVIDER_KEY,
+			blockScope: "",
+			blockedUntilMs,
+		});
+		storage = new AuthStorage(store);
+		await storage.reload();
+
+		await storage.fetchUsageReports();
+
+		expect(store.getCredentialBlock?.(identified.id, ANTHROPIC_PROVIDER_KEY, "")).toBe(blockedUntilMs);
+	});
+
+	it("reconciles every successful report in a parallel fetch after the first block clears", async () => {
+		for (const credentialId of [1, 2]) {
+			store.upsertCredentialBlock?.({
+				credentialId,
+				providerKey: ANTHROPIC_PROVIDER_KEY,
+				blockScope: "tier:fable",
+				blockedUntilMs: Date.now() + 36 * 60 * 60_000,
+			});
+		}
+		vi.spyOn(claudeUsage.claudeUsageProvider, "fetchUsage").mockImplementation(async params => {
+			const access = params.credential.type === "oauth" ? params.credential.accessToken : undefined;
+			if (!access) return null;
+			return withFable(baseReport(`${access}@example.com`), 0);
+		});
+
+		await storage.fetchUsageReports();
+
+		expect(store.getCredentialBlock?.(1, ANTHROPIC_PROVIDER_KEY, "tier:fable")).toBeUndefined();
+		expect(store.getCredentialBlock?.(2, ANTHROPIC_PROVIDER_KEY, "tier:fable")).toBeUndefined();
+	});
+
+	it("preserves a blocked credential when its healing probe outlives selection", async () => {
+		storage.close();
+		store = makeStore([oauthRow(1, "blocked@example.com"), oauthRow(2, "healthy@example.com")]);
+		store.upsertCredentialBlock?.({
+			credentialId: 1,
+			providerKey: ANTHROPIC_PROVIDER_KEY,
+			blockScope: "tier:fable",
+			blockedUntilMs: Date.now() + 36 * 60 * 60_000,
+		});
+		const stalled = Promise.withResolvers<UsageReport | null>();
+		vi.spyOn(claudeUsage.claudeUsageProvider, "fetchUsage").mockImplementation(async params => {
+			const access = params.credential.type === "oauth" ? params.credential.accessToken : undefined;
+			if (access === "oat-1") return stalled.promise;
+			return baseReport("healthy@example.com");
+		});
+		storage = new AuthStorage(store, {
+			usageProviderResolver: provider => (provider === "anthropic" ? claudeUsage.claudeUsageProvider : undefined),
+			usageRequestTimeoutMs: 10,
+		});
+		await storage.reload();
+		vi.useFakeTimers();
+		try {
+			const selecting = storage.getApiKey("anthropic", "session-probe-timeout", { modelId: "claude-fable-5" });
+			await Promise.resolve();
+			await Promise.resolve();
+			vi.advanceTimersByTime(5_001);
+			expect(await selecting).toBe("oat-2");
+		} finally {
+			stalled.resolve(null);
+			vi.useRealTimers();
+		}
 	});
 });

--- a/packages/ai/test/claude-usage-headers.test.ts
+++ b/packages/ai/test/claude-usage-headers.test.ts
@@ -933,6 +933,26 @@ describe("claude ranking strategy", () => {
 		expect(claudeRankingStrategy.blockScope?.({ modelId: "claude-mythos-5" })).toBe("tier:mythos");
 		expect(claudeRankingStrategy.blockScope?.({ modelId: "claude-opus-4-8" })).toBeUndefined();
 		expect(claudeRankingStrategy.blockScope?.({})).toBeUndefined();
+		// Reconciliation enumerates persisted/in-memory blocks directly rather
+		// than using this as a second model-family registry.
+		expect(claudeRankingStrategy.blockScopes?.()).toEqual([]);
+		expect(claudeRankingStrategy.blockScopes?.({ modelId: "claude-mythos-5" })).toEqual(["tier:mythos"]);
+		expect(claudeRankingStrategy.blockScopes?.({ modelId: "claude-opus-4-8" })).toEqual([]);
+		// Healing narrows a persisted scope through the strategy. Unlike gating it
+		// keeps the scope's own tier row — an exhausted counter must veto healing
+		// even when gating would not trust it — while still excluding the sibling
+		// tier, whose exhaustion says nothing about this block. An unmapped scope
+		// is a catch-all and falls back to the whole report.
+		expect(claudeRankingStrategy.scopeLimitsForBlockScope?.(report, "tier:fable")?.map(limit => limit.id)).toEqual([
+			"anthropic:5h",
+			"anthropic:7d",
+			"anthropic:7d:fable",
+		]);
+		expect(claudeRankingStrategy.scopeLimitsForBlockScope?.(report, "tier:future")?.map(limit => limit.id)).toEqual([
+			"anthropic:5h",
+			"anthropic:7d",
+		]);
+		expect(claudeRankingStrategy.scopeLimitsForBlockScope?.(report, "shared")).toBeUndefined();
 	});
 
 	it("uses the Fable weekly cap as secondary when it is more used than the shared weekly cap", () => {


### PR DESCRIPTION
I hit this with two Claude Max subscriptions: one account was genuinely capped, the other showed 0% Fable usage, yet every Fable turn still fell through to my fallback provider. I reproduced it from the persisted block through an actual `omp -p` turn and reviewed the full diff; this makes the existing usage-block healing work for OAuth providers instead of only Codex.

## Failure

Anthropic returned a Fable 429 with:

```
retry-after: 132241   # 36h44m
```

OMP persisted that verbatim as `anthropic:oauth / tier:fable`. Later, the same account reported:

```
5h 17% · 7d 3% · Fable 0%
```

but remained excluded until the 36-hour block expired. With the sibling account genuinely 5h-capped, every Claude turn 429ed and fell off-provider.

The existing self-healing path was Codex-specific at several points: provider gates in reconciliation, blocked-credential probing, and usage-health preflight; cache hits also skipped reconciliation entirely.

## Design

`AuthStorage` now owns provider-independent OAuth block lifecycle; provider quota semantics stay in `CredentialRankingStrategy`:

- `scopeLimitsForBlockScope(report, scope)` lets each strategy map its persisted scope to the exact meters it gates. No synthetic model IDs or duplicate family registry.
- Reconciliation enumerates scopes the credential actually holds in the persisted store and in-memory backoff map. This covers Claude `tier:*`, Antigravity `counter:*`, Codex meter scopes, and future scopes without a central list.
- Blocked OAuth credentials are re-probed during selection for every provider, and `getModelUsageHealth()` re-reads the block after that probe. Print mode, subagents, gateway, SDK preflight, RPC, and the TUI therefore share one behavior.
- Fresh and cached reports can heal. Cache evidence is bounded by the same five-minute freshness window as the existing reconcile grace.
- A report heals only when every applicable counter is explicitly `ok` or quantitatively readable and none is exhausted. Empty, partially unreadable, or ambiguous reports remain unknown and preserve the block.
- Selection timeouts re-read block state rather than synthesizing every candidate as unblocked.
- Aggregate broker reports match organization presence exactly; org-only identity is accepted only when its provider/org report is unique. Email/account/project dimensions must agree when comparable.
- Credential-wide blocks are judged against the strategy's credential-wide gating set, not unrelated display/feature counters.

The existing five-minute grace after a 429 is unchanged, protecting against `/usage` lag.

## Scope

This PR intentionally remains OAuth-only. API-key pool healing is separate pre-existing behavior and needs its own change.

`RemoteAuthCredentialStore` still cannot durably delete one scoped broker block because the broker wire protocol has no scoped-delete operation. That limitation predates this change (including Codex healing); this PR now logs the retained persisted row honestly instead of claiming it was cleared. Durable broker-side healing should be a focused protocol change.

## Verification

Real-account before/after using a locally compiled 18.1.2 binary:

1. Seeded the observed `tier:fable` block 36 hours ahead and aged it past the five-minute grace.
2. Kept account A's legitimate 100% 5h block.
3. Ran one headless `omp -p` turn, without a separate usage poll.
4. Account B's stale Fable block cleared; account A's genuine blocks remained; the turn answered on Anthropic with no 429/fallback.

Automated:

- `bun run check:ts` — pass.
- `bun test packages/ai/test` — **4391 pass, 0 fail, 332 skip**.
- CI — lint/typecheck, all TS buckets, CLI/install smoke, native build, and flake evaluation pass.
- Regression coverage includes usage-poll, selection, warm-cache/refetch-failure, selection-timeout, shared/tier exhaustion, unreadable counters, ungated meters, Antigravity counter/default fallback, and organization identity/ambiguity paths.
