### PR TITLE
fix(catalog): route Z.AI GLM-5.3-Flash through native API

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Fixed
 
 - Claude Sonnet 5 no longer advertises unsupported mid-conversation system messages.
+- Z.AI GLM-5.3-Flash now uses the native API instead of failing through the unsupported Anthropic-compatible route ([#10539](https://github.com/can1357/oh-my-pi/issues/10539)).
 
 ## [18.1.2] - 2026-09-01
 

--- a/packages/catalog/scripts/generate-models.ts
+++ b/packages/catalog/scripts/generate-models.ts
@@ -52,6 +52,7 @@ import {
 	mapModelsDevToModels,
 	OPENAI_DAYBREAK_CURATED_FALLBACK_MODELS,
 	projectOpenAIProReasoningAliases,
+	resolveZaiApi,
 	SAKANA_FUGU_STATIC_MODELS,
 	stripFireworksDeepSeekThinkingToggle,
 	YOLO_AUTO_STATIC_MODELS,
@@ -597,26 +598,26 @@ async function generateModels() {
 		contextWindow: 1_000_000,
 		maxTokens: 131_072,
 	} as ModelSpec<"anthropic-messages">);
-	// GLM-5.3-Flash ships on the same coding-plan endpoints and is likewise
-	// absent from `/v1/models`-derived upstream metadata. It is the first
-	// natively multimodal GLM coding SKU — its id carries no `v` marker, and
-	// base64 image blocks are accepted on `https://api.z.ai/api/anthropic` —
-	// so the seed declares image input directly instead of inheriting the
-	// text-only default. Use the documented list price from
+	// GLM-5.3-Flash is absent from `/v1/models`-derived upstream metadata.
+	// It is the first natively multimodal GLM coding SKU — its id carries no
+	// `v` marker — so the seed declares image input directly instead of
+	// inheriting the text-only default. Its API route is model-specific because
+	// Z.AI serves this SKU on the native endpoint rather than the Anthropic
+	// coding endpoint. Use the documented list price from
 	// https://docs.z.ai/guides/overview/pricing rather than the 50%-off launch
 	// promotion, which expires on 2026-09-09.
+	const zaiGlm53FlashApi = resolveZaiApi("glm-5.3-flash");
 	allModels.push({
 		id: "glm-5.3-flash",
 		name: "GLM-5.3-Flash",
-		api: "anthropic-messages",
+		...zaiGlm53FlashApi,
 		provider: "zai",
-		baseUrl: "https://api.z.ai/api/anthropic",
 		reasoning: true,
 		input: ["text", "image"],
 		cost: { input: 0.15, output: 0.5, cacheRead: 0.03, cacheWrite: 0 },
 		contextWindow: 1_000_000,
 		maxTokens: 131_072,
-	} as ModelSpec<"anthropic-messages">);
+	} satisfies ModelSpec<Api>);
 	// Seed Meta's documented Muse model so first-run selection does not depend on
 	// credentials or live discovery.
 	allModels.push(...META_MUSE_STATIC_MODELS);

--- a/packages/catalog/src/compat/rules.json
+++ b/packages/catalog/src/compat/rules.json
@@ -14149,6 +14149,20 @@
 				"default": "openai-completions"
 			},
 			{
+				"provider": "zai",
+				"routes": [
+					{
+						"api": "openai-completions",
+						"match": {
+							"exact": [
+								"glm-5.3-flash"
+							]
+						}
+					}
+				],
+				"default": "anthropic-messages"
+			},
+			{
 				"provider": "opencode-zen",
 				"routes": [
 					{

--- a/packages/catalog/src/compat/rules.json
+++ b/packages/catalog/src/compat/rules.json
@@ -13245,7 +13245,7 @@
 				}
 			},
 			{
-				"source": "providers/zai.kdl:29",
+				"source": "providers/zai.kdl:32",
 				"providers": [
 					"zai"
 				],
@@ -13255,6 +13255,9 @@
 						"value": "glm-5.3-flash"
 					}
 				],
+				"wire": {
+					"clampOutputToModelMax": true
+				},
 				"thinking": {
 					"mode": "anthropic-budget-effort"
 				}

--- a/packages/catalog/src/compat/rules/providers/zai.kdl
+++ b/packages/catalog/src/compat/rules/providers/zai.kdl
@@ -25,8 +25,12 @@ provider "zai" {
 	}
 	// GLM-5.3-Flash is the first mandatory-thinking flash SKU. Its exact
 	// deployment keeps the Anthropic budget+effort wire mode instead of the
-	// older optional-thinking flash family's budget-only mode.
+	// older optional-thinking flash family's budget-only mode. The SKU rides
+	// Z.AI's native OpenAI-completions endpoint, so clamp the sent max_tokens
+	// to the advertised 131K cap rather than the 64K OpenAI default (the
+	// axis is a no-op on the Anthropic route).
 	models "glm-5.3-flash" {
 		thinking-mode "anthropic-budget-effort"
+		clamp-output-to-model-max #true
 	}
 }

--- a/packages/catalog/src/compat/rules/runtime/behavior.kdl
+++ b/packages/catalog/src/compat/rules/runtime/behavior.kdl
@@ -158,6 +158,11 @@ behavior {
 	api-routes provider="zenmux" default="openai-completions" {
 		route "anthropic-messages" prefix="anthropic/"
 	}
+	// GLM-5.3-Flash is available on Z.AI's native chat-completions API but
+	// not its Anthropic-compatible coding endpoint (#10539).
+	api-routes provider="zai" default="anthropic-messages" {
+		route "openai-completions" exact="glm-5.3-flash"
+	}
 	// OpenCode Zen: models.dev declares these with `@ai-sdk/anthropic`, but the
 	// gateway serves them only at /v1/chat/completions (#1617).
 	api-routes provider="opencode-zen" {

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -362358,7 +362358,7 @@
 				"dropThinkingWhenReasoningEffort": false,
 				"nativeKimiK3Reasoning": false,
 				"zaiReasoningEffortDialect": false,
-				"clampOutputToModelMax": false,
+				"clampOutputToModelMax": true,
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -45774,7 +45774,7 @@
 		},
 		"z-ai/glm-5.3-flash": {
 			"id": "z-ai/glm-5.3-flash",
-			"name": "GLM 5.3 Flash (free)",
+			"name": "GLM-5.3-Flash (free)",
 			"api": "openai-completions",
 			"provider": "cline-pass",
 			"baseUrl": "https://api.cline.bot/api/v1",
@@ -362277,7 +362277,7 @@
 			"name": "GLM-5.3-Flash",
 			"api": "openai-completions",
 			"provider": "zai",
-			"baseUrl": "https://api.z.ai/api/paas/v4",
+			"baseUrl": "https://api.z.ai/api/coding/paas/v4",
 			"reasoning": true,
 			"input": [
 				"text",

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -16,7 +16,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048576,
+			"contextWindow": 1000000,
 			"maxTokens": 393216,
 			"thinking": {
 				"mode": "effort",
@@ -26,12 +26,13 @@
 					"max"
 				]
 			},
-			"requiresGlyphTokenization": false,
-			"tokenizer": "deepseek-v3",
 			"identity": {
 				"class": "deepseek",
 				"family": "flash"
 			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "deepseek-v3",
+			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -86,8 +87,7 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"deepseek-ai/deepseek-v4-pro": {
 			"id": "deepseek-ai/deepseek-v4-pro",
@@ -105,7 +105,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048576,
+			"contextWindow": 1000000,
 			"maxTokens": 393216,
 			"thinking": {
 				"mode": "effort",
@@ -115,12 +115,13 @@
 					"max"
 				]
 			},
-			"requiresGlyphTokenization": false,
-			"tokenizer": "deepseek-v3",
 			"identity": {
 				"class": "deepseek",
 				"family": "pro"
 			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "deepseek-v3",
+			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -175,8 +176,7 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"google/gemma-4-31b-it": {
 			"id": "google/gemma-4-31b-it",
@@ -196,7 +196,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 262144,
+			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -207,10 +207,11 @@
 					"xhigh"
 				]
 			},
-			"requiresGlyphTokenization": false,
 			"identity": {
 				"class": "gemma"
 			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -264,12 +265,11 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			},
-			"supportsComputerUse": false
+			}
 		},
-		"moonshotai/kimi-k2.7-code": {
-			"id": "moonshotai/kimi-k2.7-code",
-			"name": "Kimi K2.7 Code",
+		"moonshotai/kimi-k2.6": {
+			"id": "moonshotai/kimi-k2.6",
+			"name": "Kimi K2.6",
 			"api": "openai-completions",
 			"provider": "aiand",
 			"baseUrl": "https://api.aiand.com/v1",
@@ -279,7 +279,7 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.75,
+				"input": 0.85,
 				"output": 3.5,
 				"cacheRead": 0,
 				"cacheWrite": 0
@@ -296,12 +296,13 @@
 					"xhigh"
 				]
 			},
-			"requiresGlyphTokenization": false,
-			"tokenizer": "kimi-k2",
 			"identity": {
 				"class": "kimi",
-				"family": "k2.7-code"
+				"family": "k2.6"
 			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "kimi-k2",
+			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -356,8 +357,99 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
+			}
+		},
+		"moonshotai/kimi-k2.7-code": {
+			"id": "moonshotai/kimi-k2.7-code",
+			"name": "Kimi K2.7 Code",
+			"api": "openai-completions",
+			"provider": "aiand",
+			"baseUrl": "https://api.aiand.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.75,
+				"output": 3.5,
+				"cacheRead": 0,
+				"cacheWrite": 0
 			},
-			"supportsComputerUse": false
+			"contextWindow": 262144,
+			"maxTokens": 262144,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			},
+			"identity": {
+				"class": "kimi",
+				"family": "k2.7-code"
+			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "kimi-k2",
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": true,
+				"disableReasoningOnForcedToolChoice": true,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": true,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": true,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "moonshot-mfjs",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "kimi",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			}
 		},
 		"moonshotai/kimi-k3": {
 			"id": "moonshotai/kimi-k3",
@@ -573,11 +665,12 @@
 					"high"
 				]
 			},
-			"requiresGlyphTokenization": false,
 			"identity": {
 				"class": "gpt-oss",
 				"family": "120b"
 			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -631,8 +724,7 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"qwen/qwen3.6-27b": {
 			"id": "qwen/qwen3.6-27b",
@@ -646,13 +738,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.32,
-				"output": 3.2,
+				"input": 0,
+				"output": 0,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 262144,
+			"maxTokens": 235929,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -662,12 +754,13 @@
 					"high"
 				]
 			},
-			"requiresGlyphTokenization": false,
-			"tokenizer": "qwen3",
 			"identity": {
 				"class": "qwen",
 				"revision": "3.6.0"
 			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "qwen3",
+			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -721,8 +814,7 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"qwen/qwen3.8-27b": {
 			"id": "qwen/qwen3.8-27b",
@@ -814,9 +906,9 @@
 			},
 			"supportsComputerUse": false
 		},
-		"zai-org/glm-5.2": {
-			"id": "zai-org/glm-5.2",
-			"name": "GLM 5.2",
+		"zai-org/glm-5.1": {
+			"id": "zai-org/glm-5.1",
+			"name": "GLM 5.1",
 			"api": "openai-completions",
 			"provider": "aiand",
 			"baseUrl": "https://api.aiand.com/v1",
@@ -825,12 +917,12 @@
 				"text"
 			],
 			"cost": {
-				"input": 1,
-				"output": 4,
+				"input": 1.4,
+				"output": 4.4,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048576,
+			"contextWindow": 202752,
 			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
@@ -839,15 +931,16 @@
 					"low",
 					"medium",
 					"high",
-					"max"
+					"xhigh"
 				]
+			},
+			"identity": {
+				"class": "glm",
+				"revision": "5.1.0"
 			},
 			"requiresGlyphTokenization": false,
 			"tokenizer": "glm5",
-			"identity": {
-				"class": "glm",
-				"revision": "5.2.0"
-			},
+			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -901,8 +994,97 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
+			}
+		},
+		"zai-org/glm-5.2": {
+			"id": "zai-org/glm-5.2",
+			"name": "GLM 5.2",
+			"api": "openai-completions",
+			"provider": "aiand",
+			"baseUrl": "https://api.aiand.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 1,
+				"output": 4,
+				"cacheRead": 0,
+				"cacheWrite": 0
 			},
-			"supportsComputerUse": false
+			"contextWindow": 1000000,
+			"maxTokens": 131072,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"max"
+				]
+			},
+			"identity": {
+				"class": "glm",
+				"revision": "5.2.0"
+			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "glm5",
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			}
 		},
 		"zai-org/glm-5.3": {
 			"id": "zai-org/glm-5.3",
@@ -37316,13 +37498,14 @@
 				],
 				"supportsDisplay": true
 			},
-			"requiresGlyphTokenization": true,
-			"tokenizer": "claude-v5-sonnet",
 			"identity": {
 				"class": "anthropic",
 				"family": "mythos",
 				"revision": "5.0.0"
 			},
+			"requiresGlyphTokenization": true,
+			"tokenizer": "claude-v5-sonnet",
+			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": true,
 				"signingEndpoint": true,
@@ -37346,8 +37529,7 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"claude-opus-4-0": {
 			"id": "claude-opus-4-0",
@@ -45592,7 +45774,7 @@
 		},
 		"z-ai/glm-5.3-flash": {
 			"id": "z-ai/glm-5.3-flash",
-			"name": "GLM-5.3-Flash (free)",
+			"name": "GLM 5.3 Flash (free)",
 			"api": "openai-completions",
 			"provider": "cline-pass",
 			"baseUrl": "https://api.cline.bot/api/v1",
@@ -47525,7 +47707,6 @@
 		},
 		"claude-sonnet-4-5": {
 			"id": "claude-sonnet-4-5",
-			"requiresGlyphTokenization": true,
 			"name": "Claude Sonnet 4.5",
 			"api": "anthropic-messages",
 			"provider": "cloudflare-ai-gateway",
@@ -47541,7 +47722,7 @@
 				"cacheRead": 0.3,
 				"cacheWrite": 3.75
 			},
-			"contextWindow": 1000000,
+			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"thinking": {
 				"mode": "budget",
@@ -47553,12 +47734,13 @@
 					"xhigh"
 				]
 			},
-			"tokenizer": "claude-v3",
 			"identity": {
 				"class": "anthropic",
 				"family": "sonnet",
 				"revision": "4.5.0"
 			},
+			"requiresGlyphTokenization": true,
+			"tokenizer": "claude-v3",
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": true,
@@ -71216,7 +71398,7 @@
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
 				"supportsMultipleSystemMessages": true,
-				"supportsReasoningEffort": true,
+				"supportsReasoningEffort": false,
 				"supportsReasoningParams": true,
 				"supportsSamplingParams": true,
 				"supportsPenaltyAndStopParams": true,
@@ -71235,7 +71417,7 @@
 				"requiresMistralToolIds": false,
 				"thinkingFormat": "openai",
 				"reasoningDisableMode": "lowest-effort",
-				"omitReasoningEffort": false,
+				"omitReasoningEffort": true,
 				"includeEncryptedReasoning": true,
 				"filterReasoningHistory": false,
 				"reasoningContentField": "reasoning_content",
@@ -71268,7 +71450,10 @@
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"compatConfig": {
+				"supportsReasoningEffort": false
+			}
 		},
 		"kimi-k2.7-code": {
 			"id": "kimi-k2.7-code",
@@ -71410,7 +71595,7 @@
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
 				"supportsMultipleSystemMessages": true,
-				"supportsReasoningEffort": true,
+				"supportsReasoningEffort": false,
 				"supportsReasoningParams": true,
 				"supportsSamplingParams": true,
 				"supportsPenaltyAndStopParams": true,
@@ -71429,7 +71614,7 @@
 				"requiresMistralToolIds": false,
 				"thinkingFormat": "openai",
 				"reasoningDisableMode": "lowest-effort",
-				"omitReasoningEffort": false,
+				"omitReasoningEffort": true,
 				"includeEncryptedReasoning": true,
 				"filterReasoningHistory": false,
 				"reasoningContentField": "reasoning_content",
@@ -71461,7 +71646,10 @@
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"compatConfig": {
+				"supportsReasoningEffort": false
+			}
 		},
 		"kimi-k3": {
 			"id": "kimi-k3",
@@ -80025,7 +80213,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": true,
 				"requiresSkipThoughtSignature": false,
@@ -80037,7 +80224,8 @@
 				"antigravityClaudeToolMode": true,
 				"stripImageInput": false,
 				"antigravityUsageLabel": "true"
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-sonnet-4-5": {
 			"id": "claude-sonnet-4-5",
@@ -80131,7 +80319,6 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v3",
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": true,
 				"requiresSkipThoughtSignature": false,
@@ -80143,7 +80330,8 @@
 				"antigravityClaudeToolMode": true,
 				"stripImageInput": false,
 				"antigravityUsageLabel": "true"
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-2.5-flash": {
 			"id": "gemini-2.5-flash",
@@ -80186,7 +80374,6 @@
 				"revision": "2.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": false,
 				"requiresSkipThoughtSignature": false,
@@ -80199,7 +80386,8 @@
 				"stripImageInput": false,
 				"streamFirstEventTimeoutMs": 60000,
 				"thinkingLoopGuard": "gemini"
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-2.5-flash-lite": {
 			"id": "gemini-2.5-flash-lite",
@@ -80235,7 +80423,6 @@
 				"revision": "2.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": false,
 				"requiresSkipThoughtSignature": false,
@@ -80247,7 +80434,8 @@
 				"antigravityClaudeToolMode": false,
 				"stripImageInput": false,
 				"thinkingLoopGuard": "gemini"
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-2.5-pro": {
 			"id": "gemini-2.5-pro",
@@ -80348,7 +80536,6 @@
 				"revision": "3.0.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": false,
 				"requiresSkipThoughtSignature": true,
@@ -80361,7 +80548,8 @@
 				"stripImageInput": false,
 				"streamFirstEventTimeoutMs": 60000,
 				"thinkingLoopGuard": "gemini"
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-3-pro": {
 			"id": "gemini-3-pro",
@@ -80441,7 +80629,6 @@
 				"revision": "3.1.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": false,
 				"requiresSkipThoughtSignature": true,
@@ -80454,7 +80641,8 @@
 				"stripImageInput": false,
 				"streamFirstEventTimeoutMs": 60000,
 				"thinkingLoopGuard": "gemini"
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-3.1-flash-lite": {
 			"id": "gemini-3.1-flash-lite",
@@ -80491,7 +80679,6 @@
 				"revision": "3.1.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": false,
 				"requiresSkipThoughtSignature": true,
@@ -80503,7 +80690,8 @@
 				"antigravityClaudeToolMode": false,
 				"stripImageInput": false,
 				"thinkingLoopGuard": "gemini"
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-3.1-pro": {
 			"id": "gemini-3.1-pro",
@@ -80549,7 +80737,6 @@
 				"revision": "3.1.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": false,
 				"requiresSkipThoughtSignature": true,
@@ -80561,7 +80748,8 @@
 				"antigravityClaudeToolMode": false,
 				"stripImageInput": false,
 				"thinkingLoopGuard": "gemini"
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-3.5-flash": {
 			"id": "gemini-3.5-flash",
@@ -80613,7 +80801,6 @@
 				"revision": "3.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": false,
 				"requiresSkipThoughtSignature": true,
@@ -80626,7 +80813,8 @@
 				"stripImageInput": false,
 				"streamFirstEventTimeoutMs": 60000,
 				"thinkingLoopGuard": "gemini"
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-3.6-flash": {
 			"id": "gemini-3.6-flash",
@@ -80670,7 +80858,6 @@
 				"revision": "3.6.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": false,
 				"requiresSkipThoughtSignature": true,
@@ -80683,7 +80870,8 @@
 				"stripImageInput": false,
 				"streamFirstEventTimeoutMs": 60000,
 				"thinkingLoopGuard": "gemini"
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-3.7-flash": {
 			"id": "gemini-3.7-flash",
@@ -80727,7 +80915,6 @@
 				"revision": "3.7.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": false,
 				"requiresSkipThoughtSignature": true,
@@ -80740,7 +80927,8 @@
 				"stripImageInput": false,
 				"streamFirstEventTimeoutMs": 60000,
 				"thinkingLoopGuard": "gemini"
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gpt-oss-120b": {
 			"id": "gpt-oss-120b",
@@ -80775,7 +80963,6 @@
 				"family": "120b"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": false,
 				"requiresSkipThoughtSignature": false,
@@ -80786,7 +80973,8 @@
 				"claudeThinkingBetaHeader": false,
 				"antigravityClaudeToolMode": false,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"tab_flash_lite_preview": {
 			"id": "tab_flash_lite_preview",
@@ -80810,7 +80998,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": false,
 				"requiresSkipThoughtSignature": false,
@@ -80821,7 +81008,8 @@
 				"claudeThinkingBetaHeader": false,
 				"antigravityClaudeToolMode": false,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"tab_jump_flash_lite_preview": {
 			"id": "tab_jump_flash_lite_preview",
@@ -80845,7 +81033,6 @@
 				"class": "unknown"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
 			"compat": {
 				"supportsFunctionPartId": false,
 				"requiresSkipThoughtSignature": false,
@@ -80856,7 +81043,8 @@
 				"claudeThinkingBetaHeader": false,
 				"antigravityClaudeToolMode": false,
 				"stripImageInput": false
-			}
+			},
+			"supportsComputerUse": false
 		}
 	},
 	"google-gemini-cli": {
@@ -90976,13 +91164,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.04998,
-				"output": 0.09996,
-				"cacheRead": 0.009996,
+				"input": 0.05,
+				"output": 0.16,
+				"cacheRead": 0.013,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 131072,
+			"maxTokens": 393216,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -91593,6 +91781,96 @@
 				"clampOutputToModelMax": false,
 				"stripImageInput": false,
 				"thinkingLoopGuard": "xai",
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			}
+		},
+		"~z-ai/glm-flash-latest": {
+			"id": "~z-ai/glm-flash-latest",
+			"name": "GLM Flash Latest",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.075,
+				"output": 0.25,
+				"cacheRead": 0.015,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 131072,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			},
+			"identity": {
+				"class": "glm",
+				"family": "flash"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
@@ -98438,8 +98716,8 @@
 				"cacheRead": 0.135,
 				"cacheWrite": 0
 			},
-			"contextWindow": 161000,
-			"maxTokens": 144900,
+			"contextWindow": 163840,
+			"maxTokens": 32768,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -99817,7 +100095,7 @@
 				"cacheRead": 0.132,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048576,
+			"contextWindow": 1024000,
 			"maxTokens": 384000,
 			"thinking": {
 				"mode": "effort",
@@ -114479,8 +114757,8 @@
 				"cacheRead": 0.1,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
-			"maxTokens": 16384,
+			"contextWindow": 256000,
+			"maxTokens": 32768,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -128388,8 +128666,8 @@
 				"cacheRead": 0.25,
 				"cacheWrite": 2.5
 			},
-			"contextWindow": 1000000,
-			"maxTokens": 262144,
+			"contextWindow": 262144,
+			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -131242,9 +131520,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.0825,
-				"output": 0.33,
-				"cacheRead": 0.020625,
+				"input": 0.14,
+				"output": 0.58,
+				"cacheRead": 0.035,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -135937,7 +136215,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 262144,
+			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -145383,6 +145661,96 @@
 				"output": 0.47,
 				"cacheRead": 0.016,
 				"cacheWrite": 0.2
+			},
+			"contextWindow": 991808,
+			"maxTokens": 131072,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"identity": {
+				"class": "qwen",
+				"revision": "3.8.0"
+			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "qwen3",
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "qwen",
+				"reasoningDisableMode": "qwen-enable-thinking-false",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			}
+		},
+		"alibaba/qwen3.8-max-0902": {
+			"id": "alibaba/qwen3.8-max-0902",
+			"name": "Qwen3.8 Max 0902",
+			"api": "openai-completions",
+			"provider": "nanogpt",
+			"baseUrl": "https://nano-gpt.com/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2,
+				"output": 6,
+				"cacheRead": 0.17,
+				"cacheWrite": 2.5
 			},
 			"contextWindow": 991808,
 			"maxTokens": 131072,
@@ -228494,86 +228862,6 @@
 			},
 			"supportsComputerUse": false
 		},
-		"kwaipilot/kat-coder-pro": {
-			"id": "kwaipilot/kat-coder-pro",
-			"name": "KAT Coder Pro",
-			"api": "openai-completions",
-			"provider": "novita",
-			"baseUrl": "https://api.novita.ai/openai/v1",
-			"reasoning": false,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0.3,
-				"output": 1.2,
-				"cacheRead": 0.06,
-				"cacheWrite": 0
-			},
-			"contextWindow": 256000,
-			"maxTokens": 128000,
-			"supportsTools": true,
-			"requiresGlyphTokenization": false,
-			"identity": {
-				"class": "unknown"
-			},
-			"supportsComputerUse": false,
-			"compat": {
-				"supportsStore": true,
-				"supportsDeveloperRole": false,
-				"supportsMultipleSystemMessages": false,
-				"supportsReasoningEffort": true,
-				"supportsReasoningParams": true,
-				"supportsSamplingParams": true,
-				"supportsPenaltyAndStopParams": true,
-				"reasoningEffortMap": {},
-				"supportsUsageInStreaming": true,
-				"alwaysSendMaxTokens": false,
-				"disableReasoningOnForcedToolChoice": false,
-				"disableReasoningOnToolChoice": false,
-				"supportsToolChoice": true,
-				"supportsForcedToolChoice": true,
-				"supportsNamedToolChoice": true,
-				"maxTokensField": "max_completion_tokens",
-				"requiresToolResultName": false,
-				"requiresAssistantAfterToolResult": false,
-				"requiresThinkingAsText": false,
-				"requiresMistralToolIds": false,
-				"thinkingFormat": "openai",
-				"reasoningDisableMode": "lowest-effort",
-				"omitReasoningEffort": false,
-				"includeEncryptedReasoning": true,
-				"filterReasoningHistory": false,
-				"reasoningContentField": "reasoning_content",
-				"requiresReasoningContentForToolCalls": false,
-				"requiresReasoningContentForAllAssistantTurns": false,
-				"allowsSyntheticReasoningContentForToolCalls": true,
-				"replayReasoningContent": false,
-				"qwenPreserveThinking": false,
-				"qwenTemplateReasoningEffort": false,
-				"requiresAssistantContentForToolCalls": false,
-				"supportsPromptCacheBreakpoints": false,
-				"isOpenRouterHost": false,
-				"wireModelIdMode": "raw",
-				"isVercelGatewayHost": false,
-				"supportsStrictMode": false,
-				"toolStrictMode": "mixed",
-				"stripDeepseekSpecialTokens": false,
-				"streamMarkupHealingPattern": "thinking",
-				"reasoningDeltasMayBeCumulative": false,
-				"emptyLengthFinishIsContextError": false,
-				"usesOpenAIToolCallIdLimit": false,
-				"dropThinkingWhenReasoningEffort": false,
-				"nativeKimiK3Reasoning": false,
-				"zaiReasoningEffortDialect": false,
-				"clampOutputToModelMax": false,
-				"stripImageInput": false,
-				"rejectRootObjectUnion": false,
-				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
-			},
-			"supportsComputerUseConfig": false
-		},
 		"meta-llama/llama-3.1-8b-instruct": {
 			"id": "meta-llama/llama-3.1-8b-instruct",
 			"name": "Llama-3.1-8B-Instruct",
@@ -233221,13 +233509,14 @@
 		},
 		"qwen/qwen3.8-2.4t-a95b": {
 			"id": "qwen/qwen3.8-2.4t-a95b",
-			"name": "Qwen3.8 2.4T A95B",
+			"name": "Qwen3.8 2.4T A95B (Max)",
 			"api": "openai-completions",
 			"provider": "novita",
 			"baseUrl": "https://api.novita.ai/openai/v1",
-			"reasoning": true,
+			"reasoning": false,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 2,
@@ -233240,15 +233529,6 @@
 			"supportsTools": true,
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				]
-			},
 			"identity": {
 				"class": "qwen",
 				"revision": "3.8.2"
@@ -233761,7 +234041,7 @@
 			},
 			"contextWindow": 8192,
 			"maxTokens": 32000,
-			"supportsTools": true,
+			"supportsTools": false,
 			"requiresGlyphTokenization": false,
 			"identity": {
 				"class": "unknown"
@@ -233841,7 +234121,7 @@
 			},
 			"contextWindow": 8192,
 			"maxTokens": 8192,
-			"supportsTools": true,
+			"supportsTools": false,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -255974,7 +256254,11 @@
 				"revision": "5.3.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
+			"serviceTierCost": {
+				"flex": 0.5,
+				"priority": 2
+			},
+			"applyPatchToolType": "freeform",
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -256028,11 +256312,7 @@
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
 			},
-			"serviceTierCost": {
-				"flex": 0.5,
-				"priority": 2
-			},
-			"applyPatchToolType": "freeform"
+			"supportsComputerUse": false
 		},
 		"gpt-5.4": {
 			"id": "gpt-5.4",
@@ -256075,7 +256355,11 @@
 				"revision": "5.4.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
+			"serviceTierCost": {
+				"flex": 0.5,
+				"priority": 2
+			},
+			"applyPatchToolType": "freeform",
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -256129,11 +256413,7 @@
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
 			},
-			"serviceTierCost": {
-				"flex": 0.5,
-				"priority": 2
-			},
-			"applyPatchToolType": "freeform"
+			"supportsComputerUse": false
 		},
 		"gpt-5.4-mini": {
 			"id": "gpt-5.4-mini",
@@ -256176,7 +256456,11 @@
 				"revision": "5.4.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
+			"serviceTierCost": {
+				"flex": 0.5,
+				"priority": 2
+			},
+			"applyPatchToolType": "freeform",
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -256230,11 +256514,7 @@
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
 			},
-			"serviceTierCost": {
-				"flex": 0.5,
-				"priority": 2
-			},
-			"applyPatchToolType": "freeform"
+			"supportsComputerUse": false
 		},
 		"gpt-5.5": {
 			"id": "gpt-5.5",
@@ -256278,7 +256558,11 @@
 				"revision": "5.5.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
+			"serviceTierCost": {
+				"flex": 0.5,
+				"priority": 2.5
+			},
+			"applyPatchToolType": "freeform",
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -256332,11 +256616,7 @@
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
 			},
-			"serviceTierCost": {
-				"flex": 0.5,
-				"priority": 2.5
-			},
-			"applyPatchToolType": "freeform"
+			"supportsComputerUse": false
 		},
 		"gpt-5.6-luna": {
 			"id": "gpt-5.6-luna",
@@ -256389,7 +256669,11 @@
 				"revision": "5.6.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
+			"serviceTierCost": {
+				"flex": 0.5,
+				"priority": 2
+			},
+			"applyPatchToolType": "freeform",
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -256443,11 +256727,7 @@
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
 			},
-			"serviceTierCost": {
-				"flex": 0.5,
-				"priority": 2
-			},
-			"applyPatchToolType": "freeform"
+			"supportsComputerUse": false
 		},
 		"gpt-5.6-sol": {
 			"id": "gpt-5.6-sol",
@@ -256500,7 +256780,11 @@
 				"revision": "5.6.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
+			"serviceTierCost": {
+				"flex": 0.5,
+				"priority": 2
+			},
+			"applyPatchToolType": "freeform",
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -256554,11 +256838,7 @@
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
 			},
-			"serviceTierCost": {
-				"flex": 0.5,
-				"priority": 2
-			},
-			"applyPatchToolType": "freeform"
+			"supportsComputerUse": false
 		},
 		"gpt-5.6-terra": {
 			"id": "gpt-5.6-terra",
@@ -256611,7 +256891,11 @@
 				"revision": "5.6.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
+			"serviceTierCost": {
+				"flex": 0.5,
+				"priority": 2
+			},
+			"applyPatchToolType": "freeform",
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -256665,11 +256949,7 @@
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
 			},
-			"serviceTierCost": {
-				"flex": 0.5,
-				"priority": 2
-			},
-			"applyPatchToolType": "freeform"
+			"supportsComputerUse": false
 		},
 		"gpt-daybreak-blue-latest": {
 			"id": "gpt-daybreak-blue-latest",
@@ -256715,7 +256995,11 @@
 				"revision": "5.6.0"
 			},
 			"requiresGlyphTokenization": false,
-			"supportsComputerUse": false,
+			"serviceTierCost": {
+				"flex": 0.5,
+				"priority": 2
+			},
+			"applyPatchToolType": "freeform",
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -256769,11 +257053,7 @@
 				"emptyLengthFinishIsContextError": false,
 				"usesOpenAIToolCallIdLimit": false
 			},
-			"serviceTierCost": {
-				"flex": 0.5,
-				"priority": 2
-			},
-			"applyPatchToolType": "freeform"
+			"supportsComputerUse": false
 		}
 	},
 	"opencode-go": {
@@ -261438,6 +261718,7 @@
 			},
 			"requiresGlyphTokenization": true,
 			"tokenizer": "claude-v5-sonnet",
+			"supportsComputerUse": false,
 			"compat": {
 				"officialEndpoint": false,
 				"signingEndpoint": false,
@@ -261461,8 +261742,7 @@
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
 				"stripImageInput": false
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"claude-haiku-4-5": {
 			"id": "claude-haiku-4-5",
@@ -270690,13 +270970,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.049980000000000004,
-				"output": 0.09996000000000001,
-				"cacheRead": 0.009996000000000001,
+				"input": 0.049999999999999996,
+				"output": 0.16,
+				"cacheRead": 0.013000000000000001,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1310720,
-			"maxTokens": 131072,
+			"maxTokens": 393216,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -271379,6 +271659,105 @@
 				"supportsReasoningSummary": true
 			},
 			"supportsComputerUseConfig": false
+		},
+		"~z-ai/glm-flash-latest": {
+			"id": "~z-ai/glm-flash-latest",
+			"name": "GLM Flash Latest",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.075,
+				"output": 0.25,
+				"cacheRead": 0.015,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1310720,
+			"maxTokens": 131072,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"high",
+					"max"
+				],
+				"defaultLevel": "max",
+				"requiresEffort": true
+			},
+			"identity": {
+				"class": "glm",
+				"family": "flash"
+			},
+			"requiresGlyphTokenization": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openrouter",
+				"reasoningDisableMode": "openrouter-enabled-false",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": true,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": true,
+				"wireModelIdMode": "openrouter",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false,
+				"supportsLongPromptCacheRetention": false,
+				"strictResponsesPairing": false,
+				"supportsImageDetailOriginal": true,
+				"supportsObfuscationOptOut": false,
+				"supportsAllTurnsReasoningContext": false,
+				"officialEndpoint": false,
+				"harmonyLeakMitigation": false,
+				"requiresReasoningOffJuiceInstruction": false,
+				"supportsReasoningSummary": true
+			},
+			"supportsComputerUse": false
 		},
 		"~z-ai/glm-latest": {
 			"id": "~z-ai/glm-latest",
@@ -273313,6 +273692,111 @@
 			"compatConfig": {
 				"supportsToolChoice": false
 			}
+		},
+		"anthropic/claude-fable-5.1:batch": {
+			"id": "anthropic/claude-fable-5.1:batch",
+			"name": "Claude Fable 5.1 (batch)",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.125,
+				"cacheWrite": 6.25
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				],
+				"defaultLevel": "high",
+				"requiresEffort": true,
+				"prefixBinding": true
+			},
+			"identity": {
+				"class": "anthropic",
+				"family": "fable",
+				"revision": "5.1.0"
+			},
+			"requiresGlyphTokenization": true,
+			"tokenizer": "claude-v5-sonnet",
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": true,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openrouter",
+				"reasoningDisableMode": "openrouter-enabled-false",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": true,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": true,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"cacheControlFormat": "anthropic",
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": true,
+				"wireModelIdMode": "openrouter",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": true,
+				"supportsPromptCacheKey": false,
+				"supportsLongPromptCacheRetention": false,
+				"strictResponsesPairing": false,
+				"supportsImageDetailOriginal": true,
+				"supportsObfuscationOptOut": false,
+				"supportsAllTurnsReasoningContext": false,
+				"officialEndpoint": false,
+				"harmonyLeakMitigation": false,
+				"requiresReasoningOffJuiceInstruction": false,
+				"supportsReasoningSummary": true
+			},
+			"supportsComputerUse": false
 		},
 		"anthropic/claude-haiku-4.5": {
 			"id": "anthropic/claude-haiku-4.5",
@@ -278070,13 +278554,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.55,
-				"output": 1.6500000000000001,
-				"cacheRead": 0.55,
+				"input": 0.25,
+				"output": 0.95,
+				"cacheRead": 0.13,
 				"cacheWrite": 0
 			},
 			"contextWindow": 163840,
-			"maxTokens": 144900,
+			"maxTokens": 32768,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -278748,9 +279232,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.07168000000000001,
-				"output": 0.14336000000000002,
-				"cacheRead": 0.014336,
+				"input": 0.088606,
+				"output": 0.177212,
+				"cacheRead": 0.017721200000000003,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
@@ -279045,9 +279529,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.22,
-				"output": 0.66,
-				"cacheRead": 0.007,
+				"input": 0.44,
+				"output": 1.32,
+				"cacheRead": 0.014,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
@@ -279242,9 +279726,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 1.0274699999999999,
-				"output": 2.0549399999999998,
-				"cacheRead": 0.0856225,
+				"input": 1.04226,
+				"output": 2.08452,
+				"cacheRead": 0.086855,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
@@ -279339,9 +279823,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.66,
-				"output": 1.9800000000000002,
-				"cacheRead": 0.022,
+				"input": 1.1154,
+				"output": 3.3461999999999996,
+				"cacheRead": 0.03718,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
@@ -293161,13 +293645,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.5,
-				"output": 2.2,
-				"cacheRead": 0.09999999999999999,
+				"input": 0.625,
+				"output": 3.125,
+				"cacheRead": 0.1875,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 16384,
+			"maxTokens": 32768,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -310933,32 +311417,23 @@
 		},
 		"qwen/qwen3.8-2.4t-a95b": {
 			"id": "qwen/qwen3.8-2.4t-a95b",
-			"name": "Qwen3.8 2.4T A95B",
+			"name": "Qwen3.8 2.4T A95B (Max)",
 			"api": "openrouter",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
-			"reasoning": true,
+			"reasoning": false,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 2,
 				"output": 6,
-				"cacheRead": 0.25,
+				"cacheRead": 0.19999999999999998,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 262144,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"low",
-					"medium",
-					"xhigh"
-				],
-				"defaultLevel": "xhigh",
-				"requiresEffort": true
-			},
+			"maxTokens": 131072,
 			"tokenizer": "qwen3",
 			"requiresGlyphTokenization": false,
 			"identity": {
@@ -310993,7 +311468,7 @@
 				"includeEncryptedReasoning": true,
 				"filterReasoningHistory": false,
 				"reasoningContentField": "reasoning_content",
-				"requiresReasoningContentForToolCalls": true,
+				"requiresReasoningContentForToolCalls": false,
 				"requiresReasoningContentForAllAssistantTurns": false,
 				"allowsSyntheticReasoningContentForToolCalls": true,
 				"replayReasoningContent": false,
@@ -311042,9 +311517,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 2.5,
-				"output": 6.25,
-				"cacheRead": 0.5,
+				"input": 2,
+				"output": 6,
+				"cacheRead": 0.25,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1010000,
@@ -312574,9 +313049,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.0825,
-				"output": 0.33,
-				"cacheRead": 0.020625,
+				"input": 0.13199999999999998,
+				"output": 0.5279999999999999,
+				"cacheRead": 0.032999999999999995,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -317471,13 +317946,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 1.19,
-				"output": 3.74,
-				"cacheRead": 0.221,
+				"input": 0.966,
+				"output": 3.036,
+				"cacheRead": 0.1932,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 262144,
+			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -318673,9 +319148,191 @@
 		}
 	},
 	"synthetic": {
+		"hf:MiniMaxAI/MiniMax-M3": {
+			"id": "hf:MiniMaxAI/MiniMax-M3",
+			"name": "MiniMax-M3",
+			"api": "openai-completions",
+			"provider": "synthetic",
+			"baseUrl": "https://api.synthetic.new/openai/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.6,
+				"output": 1.2,
+				"cacheRead": 0.6,
+				"cacheWrite": 0
+			},
+			"contextWindow": 524288,
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			},
+			"identity": {
+				"class": "minimax",
+				"family": "m3"
+			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": true,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			}
+		},
+		"hf:moonshotai/Kimi-K2.7-Code": {
+			"id": "hf:moonshotai/Kimi-K2.7-Code",
+			"name": "Kimi K2.7 Code",
+			"api": "openai-completions",
+			"provider": "synthetic",
+			"baseUrl": "https://api.synthetic.new/openai/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.95,
+				"output": 4,
+				"cacheRead": 0.95,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			},
+			"identity": {
+				"class": "kimi",
+				"family": "k2.7-code"
+			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "kimi-k2",
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsStore": true,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": true,
+				"disableReasoningOnForcedToolChoice": true,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "lowest-effort",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": true,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": true,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"toolSchemaFlavor": "moonshot-mfjs",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "kimi",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			}
+		},
 		"hf:moonshotai/Kimi-K3": {
 			"id": "hf:moonshotai/Kimi-K3",
-			"name": "moonshotai/Kimi-K3",
+			"name": "Kimi K3",
 			"api": "openai-completions",
 			"provider": "synthetic",
 			"baseUrl": "https://api.synthetic.new/openai/v1",
@@ -318705,12 +319362,13 @@
 				},
 				"requiresEffort": true
 			},
-			"requiresGlyphTokenization": false,
-			"tokenizer": "kimi-k2",
 			"identity": {
 				"class": "kimi",
 				"family": "k3"
 			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "kimi-k2",
+			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -318770,12 +319428,11 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"hf:nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4": {
 			"id": "hf:nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
-			"name": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
+			"name": "Nemotron 3 Super 120B A12B",
 			"api": "openai-completions",
 			"provider": "synthetic",
 			"baseUrl": "https://api.synthetic.new/openai/v1",
@@ -318786,7 +319443,7 @@
 			"cost": {
 				"input": 0.3,
 				"output": 1,
-				"cacheRead": 0.06,
+				"cacheRead": 0.3,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -318801,10 +319458,11 @@
 					"xhigh"
 				]
 			},
-			"requiresGlyphTokenization": false,
 			"identity": {
 				"class": "unknown"
 			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -318858,12 +319516,11 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"hf:openai/gpt-oss-120b": {
 			"id": "hf:openai/gpt-oss-120b",
-			"name": "openai/gpt-oss-120b",
+			"name": "GPT OSS 120B",
 			"api": "openai-completions",
 			"provider": "synthetic",
 			"baseUrl": "https://api.synthetic.new/openai/v1",
@@ -318874,11 +319531,11 @@
 			"cost": {
 				"input": 0.1,
 				"output": 0.1,
-				"cacheRead": 0.02,
+				"cacheRead": 0.1,
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
-			"maxTokens": 65536,
+			"maxTokens": 32768,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -318887,11 +319544,12 @@
 					"high"
 				]
 			},
-			"requiresGlyphTokenization": false,
 			"identity": {
 				"class": "gpt-oss",
 				"family": "120b"
 			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -318945,8 +319603,97 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
+			}
+		},
+		"hf:Qwen/Qwen3.6-27B": {
+			"id": "hf:Qwen/Qwen3.6-27B",
+			"name": "Qwen3.6 27B",
+			"api": "openai-completions",
+			"provider": "synthetic",
+			"baseUrl": "https://api.synthetic.new/openai/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.45,
+				"output": 3.6,
+				"cacheRead": 0.45,
+				"cacheWrite": 0
 			},
-			"supportsComputerUse": false
+			"contextWindow": 262144,
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"identity": {
+				"class": "qwen",
+				"revision": "3.6.0"
+			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "qwen3",
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "qwen",
+				"reasoningDisableMode": "qwen-enable-thinking-false",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			}
 		},
 		"hf:Qwen/Qwen3.8-27B": {
 			"id": "hf:Qwen/Qwen3.8-27B",
@@ -319040,7 +319787,7 @@
 		},
 		"hf:zai-org/GLM-4.7-Flash": {
 			"id": "hf:zai-org/GLM-4.7-Flash",
-			"name": "zai-org/GLM-4.7-Flash",
+			"name": "GLM-4.7-Flash",
 			"api": "openai-completions",
 			"provider": "synthetic",
 			"baseUrl": "https://api.synthetic.new/openai/v1",
@@ -319051,7 +319798,7 @@
 			"cost": {
 				"input": 0.1,
 				"output": 0.5,
-				"cacheRead": 0.02,
+				"cacheRead": 0.1,
 				"cacheWrite": 0
 			},
 			"contextWindow": 196608,
@@ -319066,12 +319813,13 @@
 					"xhigh"
 				]
 			},
-			"requiresGlyphTokenization": false,
 			"identity": {
 				"class": "glm",
 				"family": "flash",
 				"revision": "4.7.0"
 			},
+			"requiresGlyphTokenization": false,
+			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -319125,12 +319873,11 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"hf:zai-org/GLM-5.2": {
 			"id": "hf:zai-org/GLM-5.2",
-			"name": "zai-org/GLM-5.2",
+			"name": "GLM-5.2",
 			"api": "openai-completions",
 			"provider": "synthetic",
 			"baseUrl": "https://api.synthetic.new/openai/v1",
@@ -319139,9 +319886,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 1,
-				"output": 3,
-				"cacheRead": 0.16,
+				"input": 1.4,
+				"output": 4.4,
+				"cacheRead": 1.4,
 				"cacheWrite": 0
 			},
 			"contextWindow": 524288,
@@ -319156,12 +319903,13 @@
 					"max"
 				]
 			},
-			"requiresGlyphTokenization": false,
-			"tokenizer": "glm5",
 			"identity": {
 				"class": "glm",
 				"revision": "5.2.0"
 			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "glm5",
+			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -319215,12 +319963,11 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"hf:zai-org/GLM-5.3-Flash": {
 			"id": "hf:zai-org/GLM-5.3-Flash",
-			"name": "zai-org/GLM-5.3-Flash",
+			"name": "GLM-5.3-Flash",
 			"api": "openai-completions",
 			"provider": "synthetic",
 			"baseUrl": "https://api.synthetic.new/openai/v1",
@@ -319247,13 +319994,14 @@
 				"defaultLevel": "max",
 				"requiresEffort": true
 			},
-			"requiresGlyphTokenization": false,
-			"tokenizer": "glm5",
 			"identity": {
 				"class": "glm",
 				"family": "flash",
 				"revision": "5.3.0"
 			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "glm5",
+			"supportsComputerUse": false,
 			"compat": {
 				"supportsStore": true,
 				"supportsDeveloperRole": false,
@@ -319307,8 +320055,7 @@
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
 				"supportsPromptCacheKey": false
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"syn:large:text": {
 			"id": "syn:large:text",
@@ -338013,6 +338760,67 @@
 			"identity": {
 				"class": "qwen",
 				"revision": "3.8.0"
+			},
+			"compat": {
+				"officialEndpoint": false,
+				"signingEndpoint": false,
+				"supportsContextManagement": true,
+				"supportsOutputEffort": true,
+				"disableStrictTools": false,
+				"disableAdaptiveThinking": false,
+				"allowAnthropicHeaderOverrides": false,
+				"supportsEagerToolInputStreaming": false,
+				"supportsLongCacheRetention": false,
+				"supportsMidConversationSystem": false,
+				"supportsTurnScopedSystem": false,
+				"supportsMidConversationToolChanges": false,
+				"supportsPerMessageEffort": false,
+				"supportsThinkingBindingControls": false,
+				"supportsForcedToolChoice": true,
+				"supportsSamplingParams": true,
+				"requiresToolResultId": false,
+				"requiresThinkingEnabled": false,
+				"replayUnsignedThinking": true,
+				"escapeBuiltinToolNames": false,
+				"injectClaudeCodeInstruction": true,
+				"stripImageInput": false
+			},
+			"supportsComputerUse": false
+		},
+		"alibaba/qwen3.8-max-0902": {
+			"id": "alibaba/qwen3.8-max-0902",
+			"name": "Qwen3.8 Max 0902",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2,
+				"output": 6,
+				"cacheRead": 0.25,
+				"cacheWrite": 2.5
+			},
+			"contextWindow": 991000,
+			"maxTokens": 128000,
+			"identity": {
+				"class": "qwen",
+				"revision": "3.8.0"
+			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "qwen3",
+			"thinking": {
+				"mode": "budget",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
 			},
 			"compat": {
 				"officialEndpoint": false,
@@ -357934,12 +358742,6 @@
 			},
 			"contextWindow": 2000000,
 			"maxTokens": 2000000,
-			"identity": {
-				"class": "xai",
-				"family": "grok",
-				"revision": "4.20.0"
-			},
-			"requiresGlyphTokenization": false,
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -357999,6 +358801,12 @@
 				"usesOpenAIToolCallIdLimit": false,
 				"promptCacheSessionHeader": "x-grok-conv-id"
 			},
+			"identity": {
+				"class": "xai",
+				"family": "grok",
+				"revision": "4.20.0"
+			},
+			"requiresGlyphTokenization": false,
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"includeEncryptedReasoning": true,
@@ -358035,12 +358843,6 @@
 			},
 			"contextWindow": 2000000,
 			"maxTokens": 2000000,
-			"identity": {
-				"class": "xai",
-				"family": "grok",
-				"revision": "4.20.0"
-			},
-			"requiresGlyphTokenization": false,
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -358100,6 +358902,12 @@
 				"usesOpenAIToolCallIdLimit": false,
 				"promptCacheSessionHeader": "x-grok-conv-id"
 			},
+			"identity": {
+				"class": "xai",
+				"family": "grok",
+				"revision": "4.20.0"
+			},
+			"requiresGlyphTokenization": false,
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"includeEncryptedReasoning": true,
@@ -358135,25 +358943,6 @@
 			},
 			"contextWindow": 2000000,
 			"maxTokens": 2000000,
-			"identity": {
-				"class": "xai",
-				"family": "grok",
-				"revision": "4.20.0"
-			},
-			"requiresGlyphTokenization": false,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high",
-					"xhigh"
-				],
-				"effortMap": {
-					"minimal": "low"
-				}
-			},
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -358211,6 +359000,25 @@
 				"usesOpenAIToolCallIdLimit": false,
 				"promptCacheSessionHeader": "x-grok-conv-id"
 			},
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				],
+				"effortMap": {
+					"minimal": "low"
+				}
+			},
+			"identity": {
+				"class": "xai",
+				"family": "grok",
+				"revision": "4.20.0"
+			},
+			"requiresGlyphTokenization": false,
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"reasoningEffortMap": {
@@ -358250,24 +359058,6 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 1000000,
-			"identity": {
-				"class": "xai",
-				"family": "grok",
-				"revision": "4.3.0"
-			},
-			"requiresGlyphTokenization": false,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				],
-				"effortMap": {
-					"minimal": "low"
-				}
-			},
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -358327,6 +359117,24 @@
 				"usesOpenAIToolCallIdLimit": false,
 				"promptCacheSessionHeader": "x-grok-conv-id"
 			},
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				],
+				"effortMap": {
+					"minimal": "low"
+				}
+			},
+			"identity": {
+				"class": "xai",
+				"family": "grok",
+				"revision": "4.3.0"
+			},
+			"requiresGlyphTokenization": false,
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"reasoningEffortMap": {
@@ -358368,24 +359176,6 @@
 			},
 			"contextWindow": 500000,
 			"maxTokens": 500000,
-			"identity": {
-				"class": "xai",
-				"family": "grok",
-				"revision": "4.5.0"
-			},
-			"requiresGlyphTokenization": false,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				],
-				"effortMap": {
-					"minimal": "low"
-				}
-			},
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -358445,6 +359235,24 @@
 				"usesOpenAIToolCallIdLimit": false,
 				"promptCacheSessionHeader": "x-grok-conv-id"
 			},
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				],
+				"effortMap": {
+					"minimal": "low"
+				}
+			},
+			"identity": {
+				"class": "xai",
+				"family": "grok",
+				"revision": "4.5.0"
+			},
+			"requiresGlyphTokenization": false,
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"reasoningEffortMap": {
@@ -358486,25 +359294,6 @@
 			},
 			"contextWindow": 500000,
 			"maxTokens": 500000,
-			"identity": {
-				"class": "xai",
-				"family": "grok",
-				"revision": "4.6.0"
-			},
-			"requiresGlyphTokenization": false,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high",
-					"xhigh"
-				],
-				"effortMap": {
-					"minimal": "low"
-				}
-			},
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -358562,6 +359351,25 @@
 				"usesOpenAIToolCallIdLimit": false,
 				"promptCacheSessionHeader": "x-grok-conv-id"
 			},
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				],
+				"effortMap": {
+					"minimal": "low"
+				}
+			},
+			"identity": {
+				"class": "xai",
+				"family": "grok",
+				"revision": "4.6.0"
+			},
+			"requiresGlyphTokenization": false,
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"reasoningEffortMap": {
@@ -358586,26 +359394,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 1.25,
-				"output": 2.5,
-				"cacheRead": 0.2,
-				"cacheWrite": 0,
-				"longContext": {
-					"inputThreshold": 200000,
-					"inputThresholdInclusive": true,
-					"input": 2.5,
-					"output": 5,
-					"cacheRead": 0.4,
-					"cacheWrite": 0
-				}
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
 			},
 			"contextWindow": 512000,
 			"maxTokens": 512000,
-			"identity": {
-				"class": "xai",
-				"family": "grok"
-			},
-			"requiresGlyphTokenization": false,
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -358665,6 +359460,11 @@
 				"usesOpenAIToolCallIdLimit": false,
 				"promptCacheSessionHeader": "x-grok-conv-id"
 			},
+			"identity": {
+				"class": "xai",
+				"family": "grok"
+			},
+			"requiresGlyphTokenization": false,
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"includeEncryptedReasoning": true,
@@ -358701,12 +359501,6 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 256000,
-			"identity": {
-				"class": "xai",
-				"family": "grok",
-				"revision": "0.1.0"
-			},
-			"requiresGlyphTokenization": false,
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -358766,6 +359560,12 @@
 				"usesOpenAIToolCallIdLimit": false,
 				"promptCacheSessionHeader": "x-grok-conv-id"
 			},
+			"identity": {
+				"class": "xai",
+				"family": "grok",
+				"revision": "0.1.0"
+			},
+			"requiresGlyphTokenization": false,
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"includeEncryptedReasoning": true,
@@ -358786,27 +359586,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 1.25,
-				"output": 2.5,
-				"cacheRead": 0.2,
-				"cacheWrite": 0,
-				"longContext": {
-					"inputThreshold": 200000,
-					"inputThresholdInclusive": true,
-					"input": 2.5,
-					"output": 5,
-					"cacheRead": 0.4,
-					"cacheWrite": 0
-				}
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
 			"maxTokens": 200000,
-			"identity": {
-				"class": "xai",
-				"family": "grok",
-				"revision": "2.5.0"
-			},
-			"requiresGlyphTokenization": false,
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsStrictMode": false,
@@ -358866,6 +359652,12 @@
 				"usesOpenAIToolCallIdLimit": false,
 				"promptCacheSessionHeader": "x-grok-conv-id"
 			},
+			"identity": {
+				"class": "xai",
+				"family": "grok",
+				"revision": "2.5.0"
+			},
+			"requiresGlyphTokenization": false,
 			"supportsComputerUse": false,
 			"compatConfig": {
 				"includeEncryptedReasoning": true,
@@ -361483,9 +362275,9 @@
 		"glm-5.3-flash": {
 			"id": "glm-5.3-flash",
 			"name": "GLM-5.3-Flash",
-			"api": "anthropic-messages",
+			"api": "openai-completions",
 			"provider": "zai",
-			"baseUrl": "https://api.z.ai/api/anthropic",
+			"baseUrl": "https://api.z.ai/api/paas/v4",
 			"reasoning": true,
 			"input": [
 				"text",
@@ -361518,28 +362310,59 @@
 			"tokenizer": "glm5",
 			"supportsComputerUse": false,
 			"compat": {
-				"officialEndpoint": false,
-				"signingEndpoint": false,
-				"supportsContextManagement": true,
-				"supportsOutputEffort": true,
-				"disableStrictTools": false,
-				"disableAdaptiveThinking": false,
-				"allowAnthropicHeaderOverrides": false,
-				"supportsEagerToolInputStreaming": false,
-				"supportsLongCacheRetention": false,
-				"supportsMidConversationSystem": false,
-				"supportsTurnScopedSystem": false,
-				"supportsMidConversationToolChanges": false,
-				"supportsPerMessageEffort": false,
-				"supportsThinkingBindingControls": false,
-				"supportsForcedToolChoice": true,
+				"supportsStore": false,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": true,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
 				"supportsSamplingParams": true,
-				"requiresToolResultId": true,
-				"requiresThinkingEnabled": false,
-				"replayUnsignedThinking": true,
-				"escapeBuiltinToolNames": false,
-				"injectClaudeCodeInstruction": true,
-				"stripImageInput": false
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "zai",
+				"reasoningDisableMode": "zai-thinking-disabled",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": false,
+				"toolStrictMode": "mixed",
+				"streamIdleTimeoutMs": 600000,
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
 			}
 		},
 		"glm-5v-turbo": {
@@ -361899,6 +362722,70 @@
 				"stripImageInput": false
 			},
 			"supportsComputerUseConfig": false
+		},
+		"anthropic/claude-fable-5.1": {
+			"id": "anthropic/claude-fable-5.1",
+			"name": "Claude Fable 5.1",
+			"api": "anthropic-messages",
+			"provider": "zenmux",
+			"baseUrl": "https://zenmux.ai/api/anthropic",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 10,
+				"output": 50,
+				"cacheRead": 0.25,
+				"cacheWrite": 20
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"identity": {
+				"class": "anthropic",
+				"family": "fable",
+				"revision": "5.1.0"
+			},
+			"requiresGlyphTokenization": true,
+			"tokenizer": "claude-v5-sonnet",
+			"thinking": {
+				"mode": "anthropic-adaptive",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				],
+				"supportsDisplay": true,
+				"prefixBinding": true
+			},
+			"compat": {
+				"officialEndpoint": false,
+				"signingEndpoint": true,
+				"supportsContextManagement": true,
+				"supportsOutputEffort": true,
+				"disableStrictTools": false,
+				"disableAdaptiveThinking": false,
+				"allowAnthropicHeaderOverrides": false,
+				"supportsEagerToolInputStreaming": false,
+				"supportsLongCacheRetention": false,
+				"supportsMidConversationSystem": false,
+				"supportsTurnScopedSystem": false,
+				"supportsMidConversationToolChanges": false,
+				"supportsPerMessageEffort": false,
+				"supportsThinkingBindingControls": false,
+				"supportsForcedToolChoice": false,
+				"supportsSamplingParams": false,
+				"requiresToolResultId": false,
+				"requiresThinkingEnabled": false,
+				"replayUnsignedThinking": false,
+				"escapeBuiltinToolNames": false,
+				"injectClaudeCodeInstruction": true,
+				"stripImageInput": false
+			},
+			"supportsComputerUse": false
 		},
 		"anthropic/claude-haiku-4.5": {
 			"id": "anthropic/claude-haiku-4.5",
@@ -375635,13 +376522,14 @@
 		},
 		"qwen/qwen3.8-2.4t-a95b": {
 			"id": "qwen/qwen3.8-2.4t-a95b",
-			"name": "Qwen3.8 2.4T A95B",
+			"name": "Qwen3.8 2.4T A95B (Max)",
 			"api": "openai-completions",
 			"provider": "zenmux",
 			"baseUrl": "https://zenmux.ai/api/v1",
-			"reasoning": true,
+			"reasoning": false,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 2,
@@ -375653,15 +376541,6 @@
 			"maxTokens": 262144,
 			"requiresGlyphTokenization": false,
 			"tokenizer": "qwen3",
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				]
-			},
 			"identity": {
 				"class": "qwen",
 				"revision": "3.8.2"
@@ -375935,6 +376814,96 @@
 			"identity": {
 				"class": "qwen",
 				"revision": "3.8.0"
+			},
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false,
+				"supportsMultipleSystemMessages": false,
+				"supportsReasoningEffort": true,
+				"supportsReasoningParams": true,
+				"supportsSamplingParams": true,
+				"supportsPenaltyAndStopParams": true,
+				"reasoningEffortMap": {},
+				"supportsUsageInStreaming": true,
+				"alwaysSendMaxTokens": false,
+				"disableReasoningOnForcedToolChoice": false,
+				"disableReasoningOnToolChoice": false,
+				"supportsToolChoice": true,
+				"supportsForcedToolChoice": true,
+				"supportsNamedToolChoice": true,
+				"maxTokensField": "max_completion_tokens",
+				"requiresToolResultName": false,
+				"requiresAssistantAfterToolResult": false,
+				"requiresThinkingAsText": false,
+				"requiresMistralToolIds": false,
+				"thinkingFormat": "qwen",
+				"reasoningDisableMode": "qwen-enable-thinking-false",
+				"omitReasoningEffort": false,
+				"includeEncryptedReasoning": true,
+				"filterReasoningHistory": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": false,
+				"requiresReasoningContentForAllAssistantTurns": false,
+				"allowsSyntheticReasoningContentForToolCalls": true,
+				"replayReasoningContent": false,
+				"qwenPreserveThinking": false,
+				"qwenTemplateReasoningEffort": false,
+				"requiresAssistantContentForToolCalls": false,
+				"supportsPromptCacheBreakpoints": false,
+				"isOpenRouterHost": false,
+				"wireModelIdMode": "raw",
+				"isVercelGatewayHost": false,
+				"supportsStrictMode": true,
+				"toolStrictMode": "mixed",
+				"stripDeepseekSpecialTokens": false,
+				"streamMarkupHealingPattern": "thinking",
+				"reasoningDeltasMayBeCumulative": false,
+				"emptyLengthFinishIsContextError": false,
+				"usesOpenAIToolCallIdLimit": false,
+				"dropThinkingWhenReasoningEffort": false,
+				"nativeKimiK3Reasoning": false,
+				"zaiReasoningEffortDialect": false,
+				"clampOutputToModelMax": false,
+				"stripImageInput": false,
+				"rejectRootObjectUnion": false,
+				"retryWithoutStrictOnGrammarError": false,
+				"supportsPromptCacheKey": false
+			},
+			"supportsComputerUse": false
+		},
+		"qwen/qwen3.8-max-0902": {
+			"id": "qwen/qwen3.8-max-0902",
+			"name": "Qwen3.8-Max-0902",
+			"api": "openai-completions",
+			"provider": "zenmux",
+			"baseUrl": "https://zenmux.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2,
+				"output": 6,
+				"cacheRead": 0.17,
+				"cacheWrite": 2.5
+			},
+			"contextWindow": 1000000,
+			"maxTokens": null,
+			"identity": {
+				"class": "qwen",
+				"revision": "3.8.0"
+			},
+			"requiresGlyphTokenization": false,
+			"tokenizer": "qwen3",
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
 			},
 			"compat": {
 				"supportsStore": false,

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -6495,6 +6495,22 @@ const OPENCODE_GO_API_RESOLUTION = createOpenCodeApiResolution("https://opencode
 
 const COPILOT_BASE_URL = "https://api.githubcopilot.com";
 
+const ZAI_ANTHROPIC_BASE_URL = "https://api.z.ai/api/anthropic";
+const ZAI_OPENAI_BASE_URL = "https://api.z.ai/api/paas/v4";
+
+/** Resolves the transport and endpoint for one Z.AI model catalog entry. */
+export function resolveZaiApi(modelId: string): { api: "anthropic-messages" | "openai-completions"; baseUrl: string } {
+	const api = apiRouteFor("zai", modelId)?.api ?? "anthropic-messages";
+	switch (api) {
+		case "anthropic-messages":
+			return { api, baseUrl: ZAI_ANTHROPIC_BASE_URL };
+		case "openai-completions":
+			return { api, baseUrl: ZAI_OPENAI_BASE_URL };
+		default:
+			throw new Error(`Unsupported Z.AI API route: ${api}`);
+	}
+}
+
 const COPILOT_DEFAULT_RESOLUTION = {
 	api: "openai-completions",
 	baseUrl: COPILOT_BASE_URL,
@@ -6772,7 +6788,9 @@ const MODELS_DEV_PROVIDER_DESCRIPTORS_CODING_PLANS: readonly ModelsDevProviderDe
 	// SKU as "Free" in `/models`. The PAYG key carries the real per-token rates for
 	// the identical model ids, so the enumerated token costs line up with the other
 	// subscription providers for comparison (issue #5598).
-	anthropicMessagesDescriptor("zai", "zai", "https://api.z.ai/api/anthropic"),
+	anthropicMessagesDescriptor("zai", "zai", ZAI_ANTHROPIC_BASE_URL, {
+		resolveApi: modelId => resolveZaiApi(modelId),
+	}),
 	// --- Umans AI ---
 	// Source the pay-as-you-go catalog: the coding-plan key publishes subscription
 	// costs as zero, while `/models/info` omits pricing entirely. The generator

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -6496,7 +6496,11 @@ const OPENCODE_GO_API_RESOLUTION = createOpenCodeApiResolution("https://opencode
 const COPILOT_BASE_URL = "https://api.githubcopilot.com";
 
 const ZAI_ANTHROPIC_BASE_URL = "https://api.z.ai/api/anthropic";
-const ZAI_OPENAI_BASE_URL = "https://api.z.ai/api/paas/v4";
+// The `zai` catalog provider is the GLM Coding Plan: `/login zai` validates and
+// stores credentials against the coding-plan endpoint (see registry/zai.ts), so
+// the native OpenAI transport must ride the coding-plan base rather than the
+// general PAYG `/api/paas/v4`, which would bypass plan quota or fail auth.
+const ZAI_OPENAI_BASE_URL = "https://api.z.ai/api/coding/paas/v4";
 
 /** Resolves the transport and endpoint for one Z.AI model catalog entry. */
 export function resolveZaiApi(modelId: string): { api: "anthropic-messages" | "openai-completions"; baseUrl: string } {

--- a/packages/catalog/src/provider-models/special.ts
+++ b/packages/catalog/src/provider-models/special.ts
@@ -389,6 +389,9 @@ const devinDiscovery = once(() => import("../discovery/devin"));
 
 export interface ZaiModelManagerConfig {}
 
-export function zaiModelManagerOptions(_config: ZaiModelManagerConfig = {}): ModelManagerOptions<"anthropic-messages"> {
+/** Creates model-manager options for Z.AI's mixed native and Anthropic transports. */
+export function zaiModelManagerOptions(
+	_config: ZaiModelManagerConfig = {},
+): ModelManagerOptions<"anthropic-messages" | "openai-completions"> {
 	return { providerId: "zai" };
 }

--- a/packages/catalog/test/issue-5598-repro.test.ts
+++ b/packages/catalog/test/issue-5598-repro.test.ts
@@ -54,3 +54,35 @@ describe("zai GLM pricing sources the PAYG stencil.so key (issue #5598)", () => 
 		expect(glm52?.cost).toEqual({ input: 1.4, output: 4.4, cacheRead: 0.26, cacheWrite: 0 });
 	});
 });
+
+describe("zai API routing", () => {
+	test("routes GLM-5.3-Flash through the native API without moving supported Anthropic models", () => {
+		const payload = {
+			zai: {
+				models: {
+					"glm-5.2": {
+						name: "GLM-5.2",
+						tool_call: true,
+					},
+					"glm-5.3-flash": {
+						name: "GLM-5.3-Flash",
+						tool_call: true,
+					},
+				},
+			},
+		};
+
+		const models = mapModelsDevToModels(payload, MODELS_DEV_PROVIDER_DESCRIPTORS);
+		const glm52 = models.find(model => model.provider === "zai" && model.id === "glm-5.2");
+		const glm53Flash = models.find(model => model.provider === "zai" && model.id === "glm-5.3-flash");
+
+		expect(glm52).toMatchObject({
+			api: "anthropic-messages",
+			baseUrl: "https://api.z.ai/api/anthropic",
+		});
+		expect(glm53Flash).toMatchObject({
+			api: "openai-completions",
+			baseUrl: "https://api.z.ai/api/paas/v4",
+		});
+	});
+});

--- a/packages/catalog/test/issue-5598-repro.test.ts
+++ b/packages/catalog/test/issue-5598-repro.test.ts
@@ -82,7 +82,7 @@ describe("zai API routing", () => {
 		});
 		expect(glm53Flash).toMatchObject({
 			api: "openai-completions",
-			baseUrl: "https://api.z.ai/api/paas/v4",
+			baseUrl: "https://api.z.ai/api/coding/paas/v4",
 		});
 	});
 });

--- a/packages/catalog/test/zai-bundled-catalog.test.ts
+++ b/packages/catalog/test/zai-bundled-catalog.test.ts
@@ -33,7 +33,7 @@ describe("zai bundled catalog", () => {
 
 		expect(model).toBeDefined();
 		expect(model.api).toBe("openai-completions");
-		expect(model.baseUrl).toBe("https://api.z.ai/api/paas/v4");
+		expect(model.baseUrl).toBe("https://api.z.ai/api/coding/paas/v4");
 		expect(model.contextWindow).toBe(1_000_000);
 		expect(model.maxTokens).toBe(131_072);
 		// Keep the permanent catalog on list price; the 50%-off launch

--- a/packages/catalog/test/zai-bundled-catalog.test.ts
+++ b/packages/catalog/test/zai-bundled-catalog.test.ts
@@ -32,15 +32,15 @@ describe("zai bundled catalog", () => {
 		const model = zaiModels["glm-5.3-flash"];
 
 		expect(model).toBeDefined();
-		expect(model.api).toBe("anthropic-messages");
-		expect(model.baseUrl).toBe("https://api.z.ai/api/anthropic");
+		expect(model.api).toBe("openai-completions");
+		expect(model.baseUrl).toBe("https://api.z.ai/api/paas/v4");
 		expect(model.contextWindow).toBe(1_000_000);
 		expect(model.maxTokens).toBe(131_072);
 		// Keep the permanent catalog on list price; the 50%-off launch
 		// promotion expires on 2026-09-09.
 		expect(model.cost).toEqual({ input: 0.15, output: 0.5, cacheRead: 0.03, cacheWrite: 0 });
-		// Natively multimodal: the id carries no `v` marker, but the Anthropic
-		// endpoint accepts image blocks.
+		// Natively multimodal: the id carries no `v` marker, but the native
+		// OpenAI-compatible endpoint accepts image input.
 		expect(model.input).toEqual(["text", "image"]);
 		expect(model.reasoning).toBe(true);
 		// Thinking cannot be disabled and defaults to `max`.

--- a/packages/catalog/test/zai-bundled-catalog.test.ts
+++ b/packages/catalog/test/zai-bundled-catalog.test.ts
@@ -11,6 +11,7 @@ interface BundledModel {
 	input?: readonly string[];
 	reasoning?: boolean;
 	thinking?: { efforts?: readonly string[]; defaultLevel?: string; requiresEffort?: boolean };
+	compat?: { clampOutputToModelMax?: boolean };
 }
 
 describe("zai bundled catalog", () => {
@@ -47,5 +48,9 @@ describe("zai bundled catalog", () => {
 		expect(model.thinking?.efforts).toEqual(["low", "high", "max"]);
 		expect(model.thinking?.requiresEffort).toBe(true);
 		expect(model.thinking?.defaultLevel).toBe("max");
+		// Native OpenAI-completions route: send the advertised 131K cap instead
+		// of the 64K OpenAI default (resolveOpenAICompletionsOutputClamp reads
+		// this wire field).
+		expect(model.compat?.clampOutputToModelMax).toBe(true);
 	});
 });


### PR DESCRIPTION
## Repro
On current `main`, `bun -e 'import { getBundledModels } from "./packages/catalog/src/models.ts"; const model = getBundledModels("zai").find(model => model.id === "glm-5.3-flash"); console.log(JSON.stringify({ api: model?.api, baseUrl: model?.baseUrl, requestUrl: `${model?.baseUrl}/v1/messages` }));'` resolves the model to `anthropic-messages` at `https://api.z.ai/api/anthropic/v1/messages`; the reporter’s authenticated `omp --model "zai/glm-5.3-flash" --mode text -p "say hello"` call then returns HTTP 404.

## Cause
`packages/catalog/scripts/generate-models.ts` seeded `glm-5.3-flash` with the same Anthropic transport as older Z.AI coding models, and `MODELS_DEV_PROVIDER_DESCRIPTORS` in `packages/catalog/src/provider-models/openai-compat.ts` had no per-model route override. Z.AI exposes this model on its native `/api/paas/v4/chat/completions` endpoint, not the configured Anthropic-compatible endpoint.

## Fix
- Declare the exact GLM-5.3-Flash native route in `compat/rules/runtime/behavior.kdl`.
- Resolve Z.AI transport and base URL through one shared `resolveZaiApi` path for generated fallback and models.dev entries.
- Regenerate compatibility rules and the bundled catalog, then cover both the native Flash route and the unchanged GLM-5.2 Anthropic route.
- Document the corrected route in the catalog changelog.

## Verification
`bun test packages/catalog/test/zai-bundled-catalog.test.ts packages/catalog/test/issue-5598-repro.test.ts` passes 5 tests with 26 assertions. `bun check` passes. The original metadata probe now resolves `glm-5.3-flash` to `openai-completions` at `https://api.z.ai/api/paas/v4/chat/completions`. Fixes #10539