### PR TITLE
fix(catalog): drop minimal thinking effort from gemini-3.7-flash

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Fixed
 
 - Claude Sonnet 5 no longer advertises unsupported mid-conversation system messages.
+- Gemini 3.7 Flash no longer offers the `minimal` thinking effort on direct google-level hosts (`google`, `google-vertex`, `opencode-zen`) and OpenAI-compat Google resellers, which the API rejects with `THINKING_LEVEL_MINIMAL is unsupported` ([#10543](https://github.com/can1357/oh-my-pi/issues/10543)).
 
 ## [18.1.2] - 2026-09-01
 

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -13,7 +13,7 @@
 ### Fixed
 
 - Claude Sonnet 5 no longer advertises unsupported mid-conversation system messages.
-- Gemini 3.7 Flash no longer offers the `minimal` thinking effort on direct google-level hosts (`google`, `google-vertex`, `opencode-zen`) and OpenAI-compat Google resellers, which the API rejects with `THINKING_LEVEL_MINIMAL is unsupported` ([#10543](https://github.com/can1357/oh-my-pi/issues/10543)).
+- Gemini 3.7 Flash no longer offers the `minimal` thinking effort on direct google-level hosts (`google`, `google-vertex`, `opencode-zen`), which reject `thinkingLevel: MINIMAL` with a 400; budget and reasoning-effort resellers keep the tier ([#10543](https://github.com/can1357/oh-my-pi/issues/10543)).
 
 ## [18.1.2] - 2026-09-01
 

--- a/packages/catalog/src/compat/rules.json
+++ b/packages/catalog/src/compat/rules.json
@@ -4592,13 +4592,13 @@
 				}
 			},
 			{
-				"source": "classes/gemini.kdl:20",
+				"source": "classes/gemini.kdl:24",
 				"class": "gemini",
 				"family": "flash",
 				"revision": [
 					{
-						"op": ">=",
-						"revision": "0.0.0"
+						"op": "<",
+						"revision": "3.7.0"
 					}
 				],
 				"thinking": {
@@ -4611,7 +4611,48 @@
 				}
 			},
 			{
-				"source": "classes/gemini.kdl:25",
+				"source": "classes/gemini.kdl:27",
+				"class": "gemini",
+				"family": "flash",
+				"revision": [
+					{
+						"op": ">=",
+						"revision": "3.7.0"
+					},
+					{
+						"op": "<",
+						"revision": "3.8.0"
+					}
+				],
+				"thinking": {
+					"efforts": [
+						"low",
+						"medium",
+						"high"
+					]
+				}
+			},
+			{
+				"source": "classes/gemini.kdl:30",
+				"class": "gemini",
+				"family": "flash",
+				"revision": [
+					{
+						"op": ">=",
+						"revision": "3.8.0"
+					}
+				],
+				"thinking": {
+					"efforts": [
+						"minimal",
+						"low",
+						"medium",
+						"high"
+					]
+				}
+			},
+			{
+				"source": "classes/gemini.kdl:35",
 				"class": "gemini",
 				"family": "lite",
 				"revision": [
@@ -4630,7 +4671,7 @@
 				}
 			},
 			{
-				"source": "classes/gemini.kdl:33",
+				"source": "classes/gemini.kdl:43",
 				"class": "gemini",
 				"providers": [
 					"google",
@@ -4660,7 +4701,7 @@
 				}
 			},
 			{
-				"source": "classes/gemini.kdl:45",
+				"source": "classes/gemini.kdl:55",
 				"class": "gemini",
 				"providers": [
 					"google",
@@ -4690,7 +4731,7 @@
 				}
 			},
 			{
-				"source": "classes/gemini.kdl:57",
+				"source": "classes/gemini.kdl:67",
 				"class": "gemini",
 				"providers": [
 					"google",
@@ -4720,7 +4761,7 @@
 				}
 			},
 			{
-				"source": "classes/gemini.kdl:71",
+				"source": "classes/gemini.kdl:81",
 				"class": "gemini",
 				"revision": [
 					{
@@ -4737,7 +4778,7 @@
 				}
 			},
 			{
-				"source": "classes/gemini.kdl:79",
+				"source": "classes/gemini.kdl:89",
 				"class": "gemini",
 				"providers": [
 					"google",
@@ -4754,7 +4795,7 @@
 				}
 			},
 			{
-				"source": "classes/gemini.kdl:84",
+				"source": "classes/gemini.kdl:94",
 				"class": "gemini",
 				"providers": [
 					"google-antigravity",

--- a/packages/catalog/src/compat/rules.json
+++ b/packages/catalog/src/compat/rules.json
@@ -4592,13 +4592,13 @@
 				}
 			},
 			{
-				"source": "classes/gemini.kdl:24",
+				"source": "classes/gemini.kdl:20",
 				"class": "gemini",
 				"family": "flash",
 				"revision": [
 					{
-						"op": "<",
-						"revision": "3.7.0"
+						"op": ">=",
+						"revision": "0.0.0"
 					}
 				],
 				"thinking": {
@@ -4611,48 +4611,7 @@
 				}
 			},
 			{
-				"source": "classes/gemini.kdl:27",
-				"class": "gemini",
-				"family": "flash",
-				"revision": [
-					{
-						"op": ">=",
-						"revision": "3.7.0"
-					},
-					{
-						"op": "<",
-						"revision": "3.8.0"
-					}
-				],
-				"thinking": {
-					"efforts": [
-						"low",
-						"medium",
-						"high"
-					]
-				}
-			},
-			{
-				"source": "classes/gemini.kdl:30",
-				"class": "gemini",
-				"family": "flash",
-				"revision": [
-					{
-						"op": ">=",
-						"revision": "3.8.0"
-					}
-				],
-				"thinking": {
-					"efforts": [
-						"minimal",
-						"low",
-						"medium",
-						"high"
-					]
-				}
-			},
-			{
-				"source": "classes/gemini.kdl:35",
+				"source": "classes/gemini.kdl:25",
 				"class": "gemini",
 				"family": "lite",
 				"revision": [
@@ -4671,7 +4630,7 @@
 				}
 			},
 			{
-				"source": "classes/gemini.kdl:43",
+				"source": "classes/gemini.kdl:33",
 				"class": "gemini",
 				"providers": [
 					"google",
@@ -4701,7 +4660,7 @@
 				}
 			},
 			{
-				"source": "classes/gemini.kdl:55",
+				"source": "classes/gemini.kdl:45",
 				"class": "gemini",
 				"providers": [
 					"google",
@@ -4731,7 +4690,7 @@
 				}
 			},
 			{
-				"source": "classes/gemini.kdl:67",
+				"source": "classes/gemini.kdl:57",
 				"class": "gemini",
 				"providers": [
 					"google",
@@ -4761,7 +4720,34 @@
 				}
 			},
 			{
-				"source": "classes/gemini.kdl:81",
+				"source": "classes/gemini.kdl:79",
+				"class": "gemini",
+				"providers": [
+					"google",
+					"google-vertex",
+					"opencode-zen"
+				],
+				"family": "flash",
+				"revision": [
+					{
+						"op": ">=",
+						"revision": "3.7.0"
+					},
+					{
+						"op": "<",
+						"revision": "3.8.0"
+					}
+				],
+				"thinking": {
+					"efforts": [
+						"low",
+						"medium",
+						"high"
+					]
+				}
+			},
+			{
+				"source": "classes/gemini.kdl:86",
 				"class": "gemini",
 				"revision": [
 					{
@@ -4778,7 +4764,7 @@
 				}
 			},
 			{
-				"source": "classes/gemini.kdl:89",
+				"source": "classes/gemini.kdl:94",
 				"class": "gemini",
 				"providers": [
 					"google",
@@ -4795,7 +4781,7 @@
 				}
 			},
 			{
-				"source": "classes/gemini.kdl:94",
+				"source": "classes/gemini.kdl:99",
 				"class": "gemini",
 				"providers": [
 					"google-antigravity",

--- a/packages/catalog/src/compat/rules/classes/gemini.kdl
+++ b/packages/catalog/src/compat/rules/classes/gemini.kdl
@@ -17,17 +17,7 @@ class "gemini" {
 		}
 	}
 	family "flash" {
-		// Gemini 3.7 Flash is the one Flash revision Google's thinkingLevel table
-		// marks `minimal` as unsupported (400 THINKING_LEVEL_MINIMAL); every other
-		// Flash revision keeps the four-tier scale.
-		// https://ai.google.dev/gemini-api/docs/generate-content/thinking#thinking-levels
-		revision "<3.7" {
-			thinking-efforts "minimal" "low" "medium" "high"
-		}
-		revision ">=3.7 <3.8" {
-			thinking-efforts "low" "medium" "high"
-		}
-		revision ">=3.8" {
+		revision ">=0" {
 			thinking-efforts "minimal" "low" "medium" "high"
 		}
 	}
@@ -73,6 +63,21 @@ class "gemini" {
 					xhigh 24576
 					max 24576
 				}
+			}
+		}
+	}
+	// Gemini 3.7 Flash is the one Flash revision whose native thinkingLevel does
+	// not accept `minimal` (400 THINKING_LEVEL_MINIMAL). Only the direct
+	// google-level transports emit `thinkingLevel` on the wire, so the tier is
+	// dropped there; budget (anthropic-messages) and reasoning_effort resellers
+	// never send the rejected value and keep the four-tier ladder. The collapsed
+	// google-antigravity / google-gemini-cli variants remap minimal -> LOW and
+	// carry their own explicit ladder, so they are unaffected.
+	// https://ai.google.dev/gemini-api/docs/generate-content/thinking#thinking-levels
+	on "google" "google-vertex" "opencode-zen" {
+		family "flash" {
+			revision ">=3.7 <3.8" {
+				thinking-efforts "low" "medium" "high"
 			}
 		}
 	}

--- a/packages/catalog/src/compat/rules/classes/gemini.kdl
+++ b/packages/catalog/src/compat/rules/classes/gemini.kdl
@@ -17,7 +17,17 @@ class "gemini" {
 		}
 	}
 	family "flash" {
-		revision ">=0" {
+		// Gemini 3.7 Flash is the one Flash revision Google's thinkingLevel table
+		// marks `minimal` as unsupported (400 THINKING_LEVEL_MINIMAL); every other
+		// Flash revision keeps the four-tier scale.
+		// https://ai.google.dev/gemini-api/docs/generate-content/thinking#thinking-levels
+		revision "<3.7" {
+			thinking-efforts "minimal" "low" "medium" "high"
+		}
+		revision ">=3.7 <3.8" {
+			thinking-efforts "low" "medium" "high"
+		}
+		revision ">=3.8" {
 			thinking-efforts "minimal" "low" "medium" "high"
 		}
 	}

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -62059,7 +62059,6 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
 					"high"
@@ -74078,7 +74077,6 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
 					"high"
@@ -79300,7 +79298,6 @@
 			"thinking": {
 				"mode": "google-level",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
 					"high"
@@ -82416,7 +82413,6 @@
 			"thinking": {
 				"mode": "google-level",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
 					"high"
@@ -102388,7 +102384,6 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
 					"high"
@@ -170694,7 +170689,6 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
 					"high"
@@ -262891,7 +262885,6 @@
 			"thinking": {
 				"mode": "google-level",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
 					"high"
@@ -341506,7 +341499,6 @@
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
 					"high"
@@ -366376,7 +366368,6 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
 					"high"

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -62059,6 +62059,7 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
+					"minimal",
 					"low",
 					"medium",
 					"high"
@@ -74077,6 +74078,7 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
+					"minimal",
 					"low",
 					"medium",
 					"high"
@@ -102384,6 +102386,7 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
+					"minimal",
 					"low",
 					"medium",
 					"high"
@@ -170689,6 +170692,7 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
+					"minimal",
 					"low",
 					"medium",
 					"high"
@@ -341499,6 +341503,7 @@
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
+					"minimal",
 					"low",
 					"medium",
 					"high"
@@ -366368,6 +366373,7 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
+					"minimal",
 					"low",
 					"medium",
 					"high"

--- a/packages/catalog/test/model-thinking.test.ts
+++ b/packages/catalog/test/model-thinking.test.ts
@@ -523,6 +523,26 @@ describe("model thinking derivation", () => {
 		expect(mapEffortToGoogleThinkingLevel(Effort.Minimal)).toBe("MINIMAL");
 	});
 
+	it("drops minimal from Gemini 3.7 Flash on direct google-level hosts but keeps it for 3.6 (#10543)", () => {
+		// Google's thinkingLevel table marks `minimal` unsupported for 3.7 Flash
+		// (400 THINKING_LEVEL_MINIMAL); every other Flash revision keeps it. These
+		// specs carry no explicit thinking, so efforts derive from the KDL cascade.
+		const flash37 = createModel({
+			id: "gemini-3.7-flash",
+			api: "google-vertex",
+			provider: "google-vertex",
+		});
+		expect(getSupportedEfforts(flash37)).toEqual([Effort.Low, Effort.Medium, Effort.High]);
+		expect(() => requireSupportedEffort(flash37, Effort.Minimal)).toThrow(/not supported/);
+
+		const flash36 = createModel({
+			id: "gemini-3.6-flash",
+			api: "google-vertex",
+			provider: "google-vertex",
+		});
+		expect(getSupportedEfforts(flash36)).toEqual([Effort.Minimal, Effort.Low, Effort.Medium, Effort.High]);
+	});
+
 	it("bakes requiresEffort for Gemini 3.x on any provider and backfills explicit metadata", () => {
 		// Derivation: aggregator-hosted Gemini 3.5 gets the flag, 2.5 does not.
 		const openRouterFlash = createModel({

--- a/packages/catalog/test/model-thinking.test.ts
+++ b/packages/catalog/test/model-thinking.test.ts
@@ -523,24 +523,37 @@ describe("model thinking derivation", () => {
 		expect(mapEffortToGoogleThinkingLevel(Effort.Minimal)).toBe("MINIMAL");
 	});
 
-	it("drops minimal from Gemini 3.7 Flash on direct google-level hosts but keeps it for 3.6 (#10543)", () => {
+	it("drops minimal from Gemini 3.7 Flash only on the direct google-level transports (#10543)", () => {
 		// Google's thinkingLevel table marks `minimal` unsupported for 3.7 Flash
-		// (400 THINKING_LEVEL_MINIMAL); every other Flash revision keeps it. These
+		// (400 THINKING_LEVEL_MINIMAL). Only the direct google-level transports emit
+		// `thinkingLevel` on the wire, so the tier is dropped there; budget and
+		// reasoning-effort resellers never send the rejected value and keep it. These
 		// specs carry no explicit thinking, so efforts derive from the KDL cascade.
-		const flash37 = createModel({
+		const vertexFlash37 = createModel({
 			id: "gemini-3.7-flash",
 			api: "google-vertex",
 			provider: "google-vertex",
 		});
-		expect(getSupportedEfforts(flash37)).toEqual([Effort.Low, Effort.Medium, Effort.High]);
-		expect(() => requireSupportedEffort(flash37, Effort.Minimal)).toThrow(/not supported/);
+		expect(getSupportedEfforts(vertexFlash37)).toEqual([Effort.Low, Effort.Medium, Effort.High]);
+		expect(() => requireSupportedEffort(vertexFlash37, Effort.Minimal)).toThrow(/not supported/);
 
-		const flash36 = createModel({
+		// Every other Flash revision on the same transport keeps the four-tier scale.
+		const vertexFlash36 = createModel({
 			id: "gemini-3.6-flash",
 			api: "google-vertex",
 			provider: "google-vertex",
 		});
-		expect(getSupportedEfforts(flash36)).toEqual([Effort.Minimal, Effort.Low, Effort.Medium, Effort.High]);
+		expect(getSupportedEfforts(vertexFlash36)).toEqual([Effort.Minimal, Effort.Low, Effort.Medium, Effort.High]);
+
+		// Resellers on non-google-level transports emit reasoning_effort / budget,
+		// never `thinkingLevel: MINIMAL`, so 3.7 Flash keeps `minimal` there.
+		const resellerFlash37 = createModel({
+			id: "google/gemini-3.7-flash",
+			api: "openai-completions",
+			provider: "deepinfra",
+			baseUrl: "https://api.deepinfra.com/v1/openai",
+		});
+		expect(getSupportedEfforts(resellerFlash37)).toContain(Effort.Minimal);
 	});
 
 	it("bakes requiresEffort for Gemini 3.x on any provider and backfills explicit metadata", () => {


### PR DESCRIPTION
## Repro
On `google-vertex` with Gemini 3.7 Flash, cycling the thinking effort to `min` (shift+tab) makes the request 400 with `THINKING_LEVEL_MINIMAL is unsupported`. The bundled catalog advertises `minimal` as a selectable effort for `gemini-3.7-flash`, and on direct google-level hosts it maps straight to `thinkingLevel: MINIMAL`:

```
provider/id: google-vertex/gemini-3.7-flash
thinking.mode: google-level
effortRouting: undefined
supported efforts: minimal, low, medium, high
effort=minimal -> thinkingLevel wire value: MINIMAL
```

Google's official thinkingLevel table marks `minimal` as **Not supported (error)** for Gemini 3.7 Flash (`low`/`medium`/`high` only, `medium` default): https://ai.google.dev/gemini-api/docs/generate-content/thinking#thinking-levels

## Cause
`classes/gemini.kdl` gave the whole `flash` family the four-tier ladder (`family "flash" { revision ">=0" { thinking-efforts "minimal" "low" "medium" "high" } }`). The earlier #10018 / #8871 fix only covered the `google-antigravity` / `google-gemini-cli` collapsed variants, which carry explicit `effortRouting` that remaps `minimal` onto the `-low` SKU so `mapEffortToGoogleThinkingLevel` emits `LOW` (`packages/catalog/src/model-thinking.ts`). Direct google-level hosts (`google`, `google-vertex`, `opencode-zen`) and the OpenAI-compat Google resellers have no such routing and forward `MINIMAL` verbatim.

## Fix
- `packages/catalog/src/compat/rules/classes/gemini.kdl`: partition the `flash` effort ladder around revision 3.7 — `<3.7` and `>=3.8` keep the four-tier scale, `>=3.7 <3.8` drops `minimal` to `low`/`medium`/`high`. This is a model-lineage truth (Google's docs), so it lives in the class file, provider-agnostic.
- Regenerated `packages/catalog/src/compat/rules.json` (`bun run gen:compat`) and rebaked `packages/catalog/src/models.json` thinking metadata (mirrors the generator's `rebakeModelThinking`, hermetic, no network). Only the 9 non-collapsed `gemini-3.7-flash` rows change (`[minimal,low,medium,high]` -> `[low,medium,high]`); `google-antigravity` keeps its explicit collapsed-variant ladder untouched.
- Added a regression test in `packages/catalog/test/model-thinking.test.ts` asserting 3.7 Flash drops `minimal` on `google-vertex` while 3.6 Flash keeps it.
- Changelog entry under `packages/catalog/CHANGELOG.md` `[Unreleased]`.

## Verification
- `bun test test/model-thinking.test.ts test/compat-parity.test.ts test/compat-compile.test.ts test/compat-collapse.test.ts test/compat-cascade.test.ts` (packages/catalog) — 133 pass, 0 fail. Parity proves `models.json` matches the resolver; compile proves `rules.json` matches the KDL.
- `bun test test/google-gemini-cli-3x-thinking.test.ts` (packages/ai) — 6 pass, confirming the antigravity/gemini-cli `minimal -> LOW` remap is unaffected.

Fixes #10543