### PR TITLE
fix(shell): iterate all operands for command -v/-V

### DIFF
--- a/crates/pi-builtins/src/command.rs
+++ b/crates/pi-builtins/src/command.rs
@@ -40,37 +40,51 @@ impl builtins::Command for CommandCommand {
 		&self,
 		context: brush_core::ExecutionContext<'_, SE>,
 	) -> Result<ExecutionResult, Self::Error> {
-		// Silently exit if no command was provided.
-		if let Some(command_name) = self.command() {
-			if self.print_description || self.print_verbose_description {
-				if let Some(found_cmd) =
-					Self::try_find_command(context.shell, command_name.as_str(), self.use_default_path)
-				{
-					if self.print_description {
-						writeln!(context.stdout(), "{found_cmd}")?;
-					} else {
-						match found_cmd {
-							FoundCommand::Builtin(_name) => {
-								writeln!(context.stdout(), "{command_name} is a shell builtin")?;
-							},
-							FoundCommand::External(path) => {
-								writeln!(context.stdout(), "{command_name} is {path}")?;
-							},
-						}
-					}
-					Ok(ExecutionResult::success())
-				} else {
+		if self.print_description || self.print_verbose_description {
+			// bash and zsh iterate over every operand, printing one line per name
+			// that resolves (`-v` prints the path/name, `-V` a description); `-V`
+			// also reports misses on stderr. Exit status is success when at least
+			// one name resolved, and success as well when no operand was given.
+			if self.command_and_args.is_empty() {
+				return Ok(ExecutionResult::success());
+			}
+			let mut any_found = false;
+			for command_name in &self.command_and_args {
+				let Some(found_cmd) = Self::try_find_command(
+					context.shell,
+					command_name.as_str(),
+					self.use_default_path,
+				) else {
 					if self.print_verbose_description {
 						writeln!(context.stderr(), "command: {command_name}: not found")?;
 					}
-					Ok(ExecutionResult::general_error())
+					continue;
+				};
+				any_found = true;
+				if self.print_description {
+					writeln!(context.stdout(), "{found_cmd}")?;
+				} else {
+					match found_cmd {
+						FoundCommand::Builtin(_name) => {
+							writeln!(context.stdout(), "{command_name} is a shell builtin")?;
+						},
+						FoundCommand::External(path) => {
+							writeln!(context.stdout(), "{command_name} is {path}")?;
+						},
+					}
 				}
-			} else {
-				self
-					.execute_command(context, command_name, self.use_default_path)
-					.await
 			}
+			if any_found {
+				Ok(ExecutionResult::success())
+			} else {
+				Ok(ExecutionResult::general_error())
+			}
+		} else if let Some(command_name) = self.command() {
+			self
+				.execute_command(context, command_name, self.use_default_path)
+				.await
 		} else {
+			// Silently exit if no command was provided.
 			Ok(ExecutionResult::success())
 		}
 	}

--- a/crates/pi-shell/src/shell.rs
+++ b/crates/pi-shell/src/shell.rs
@@ -3250,6 +3250,56 @@ mod tests {
 		let _ = std::fs::remove_dir_all(&tmp);
 	}
 
+	/// `command -v`/`-V` must iterate over every operand like bash/zsh, printing
+	/// one line per name that resolves and skipping the misses, rather than
+	/// honoring only the first operand. Regression test for silently dropped
+	/// operands in `command -v a b c` (issue #10544).
+	#[tokio::test(flavor = "multi_thread")]
+	async fn command_v_iterates_all_operands() {
+		let tmp = std::env::temp_dir().join(format!("pi-command-v-{}", std::process::id()));
+		let _ = std::fs::remove_dir_all(&tmp);
+		std::fs::create_dir_all(&tmp).expect("temp dir");
+		let tmp_str = tmp.to_str().expect("utf8 temp path");
+
+		let config = ShellConfig { session_env: None, snapshot_path: None, minimizer: None };
+		let mut session = create_session(&config).await.expect("create_session");
+		session.shell.set_working_dir(tmp_str).expect("set cwd");
+
+		let mut params = session.shell.default_exec_params();
+		params.set_fd(OpenFiles::STDIN_FD, null_file().expect("null"));
+		params.set_fd(OpenFiles::STDOUT_FD, null_file().expect("null"));
+		params.set_fd(OpenFiles::STDERR_FD, null_file().expect("null"));
+
+		let source_info = SourceInfo::from("pi-natives:test");
+
+		// Three always-registered builtins plus a name that never resolves. bash
+		// prints one line per resolved builtin and skips the miss, exiting 0.
+		let exec = session
+			.shell
+			.run_string("command -v true false pwd nope-xyz-10544 > out.txt", &source_info, &params)
+			.await
+			.expect("run_string");
+		assert_eq!(exit_code(&exec), 0, "command -v exit code with a resolvable name");
+
+		let out = std::fs::read_to_string(tmp.join("out.txt")).expect("out.txt");
+		let lines: Vec<&str> = out.lines().collect();
+		assert_eq!(
+			lines,
+			vec!["true", "false", "pwd"],
+			"command -v must print one line per resolved operand and skip misses: {out:?}"
+		);
+
+		// When no operand resolves, the exit status is a general error.
+		let exec = session
+			.shell
+			.run_string("command -v nope-a-10544 nope-b-10544", &source_info, &params)
+			.await
+			.expect("run_string");
+		assert_eq!(exit_code(&exec), 1, "command -v exit code when nothing resolves");
+
+		let _ = std::fs::remove_dir_all(&tmp);
+	}
+
 	/// Every utility `pi-builtins` offers must actually be dispatchable in
 	/// process, under the name it is registered as.
 	///

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,7 @@
 - TypeScript code intelligence now works on TypeScript 7 projects: the built-in `typescript-native` server runs `tsc --lsp --stdio` when the resolved TypeScript install no longer ships `tsserver.js`, replacing `typescript-language-server` for that project.
 - Claude marketplace MCP servers now resolve environment placeholders in stdio environment values instead of passing strings such as `${NAME:-}` literally ([#10481](https://github.com/can1357/oh-my-pi/pull/10481) by [@mrexodia](https://github.com/mrexodia)).
 - Fixed prewalk conflicting with `todo.eager=always`: the forced eager-todo prelude ("call todo first this turn") was injected alongside the prewalk plan nudge ("write a complete plan first, then todo"), giving the model contradictory instructions; the eager-todo prelude is now suppressed only when prewalk will perform a handoff ([#10510](https://github.com/can1357/oh-my-pi/issues/10510)).
+- Fixed the embedded shell's `command -v`/`-V` honoring only the first operand: it now iterates every name like bash/zsh, printing one line per resolved name and skipping misses ([#10544](https://github.com/can1357/oh-my-pi/issues/10544)).
 ## [18.1.2] - 2026-09-01
 
 ### Added


### PR DESCRIPTION
## Repro
In the embedded shell, `command -v cat ls echo` printed only `/usr/bin/cat` and exited 0, silently dropping `ls` and `echo`; `command -v nonexistent cat` printed nothing and exited 1, never consulting `cat`. bash 5.3 and zsh 5.9 both iterate every operand, printing one line per resolved name. Captured with the new `pi-shell` test against the unpatched builtin (`command -v true false pwd nope` produced `["true"]` instead of `["true", "false", "pwd"]`).

## Cause
`crates/pi-builtins/src/command.rs` — the `-v`/`-V` branch of `CommandCommand::execute` looked up only `self.command()` (i.e. `command_and_args.first()`) via `try_find_command` and never iterated the remaining operands. The shell advertises bash compatibility (exports `BASH_VERSION`), so multi-operand checks such as `command -v pnpm pnpx node code` returned incomplete output with `rc=0`, hinting at nothing dropped.

## Fix
- In the `-v`/`-V` branch, iterate over every element of `command_and_args`: print one line per resolved name (`-v` prints path/bare builtin name, `-V` prints a description), skip misses, and with `-V` report each miss on stderr.
- Exit success when at least one name resolves, general error when none do, and success when no operand is given (matching bash `command -v`/`-V`).
- Exec path (no `-v`/`-V`) is unchanged: still runs the first operand with the rest as arguments.
- Added `pi-shell` regression test `command_v_iterates_all_operands` asserting one line per resolved builtin, skipped misses, and the exit-code contract.
- Changelog entry under `packages/coding-agent` `[Unreleased]`.

## Verification
`cargo nextest run -p pi-builtins -p pi-shell` — 1969 passed, 1 skipped. The new test fails on the pre-fix builtin (`["true"]`) and passes after the fix (`["true", "false", "pwd"]`).

Fixes #10544