### PR TITLE
fix(agent): detach truncated strings from backing storage

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Active sessions now keep memory proportional to truncated raw SSE and tool outputs instead of retaining complete oversized backing strings ([#10547](https://github.com/can1357/oh-my-pi/issues/10547)).
 - Anthropic sessions now keep tool-roster changes and warm-prefix pruning from invalidating preserved thinking or the prompt cache.
 - TypeScript code intelligence now works on TypeScript 7 projects: the built-in `typescript-native` server runs `tsc --lsp --stdio` when the resolved TypeScript install no longer ships `tsserver.js`, replacing `typescript-language-server` for that project.
 - Claude marketplace MCP servers now resolve environment placeholders in stdio environment values instead of passing strings such as `${NAME:-}` literally ([#10481](https://github.com/can1357/oh-my-pi/pull/10481) by [@mrexodia](https://github.com/mrexodia)).

--- a/packages/coding-agent/src/debug/raw-sse-buffer.ts
+++ b/packages/coding-agent/src/debug/raw-sse-buffer.ts
@@ -1,4 +1,5 @@
 import type { Model, ProviderResponseMetadata, RawSseEvent } from "@oh-my-pi/pi-ai";
+import { materializeString } from "@oh-my-pi/pi-utils";
 
 const MAX_RAW_SSE_EVENTS = 1_000;
 const MAX_RAW_SSE_CHARS = 512_000;
@@ -206,6 +207,8 @@ function trimRawLines(raw: string[]): TrimResult {
 	} else if (lines === raw) {
 		lines = raw.slice();
 	}
+	// Kept windows outlive the incoming frame; detach them from its backing storage.
+	lines = lines.map(materializeString);
 	lines.push(`: omp-debug-truncated originalChars=${originalChars}`);
 	return { raw: lines, truncated: true, originalChars, chars: countLines(lines) + 1 };
 }
@@ -338,10 +341,8 @@ export class RawSseDebugBuffer {
 	/**
 	 * Drop every retained record and reset accounting. Called from
 	 * {@link AgentSession} teardown so a disposed (e.g. parked subagent) session
-	 * stops pinning captured wire frames — each trimmed record holds a
-	 * `slice()` of its parent SSE frame, which under JSC keeps the whole
-	 * multi-MB frame alive. Notifies subscribers so a live debug viewer redraws
-	 * empty.
+	 * releases its bounded captured wire records. Notifies subscribers so a live
+	 * debug viewer redraws empty.
 	 */
 	clear(): void {
 		this.#records = [];

--- a/packages/coding-agent/src/session/streaming-output.ts
+++ b/packages/coding-agent/src/session/streaming-output.ts
@@ -1,5 +1,5 @@
 import type { AgentToolUpdateCallback } from "@oh-my-pi/pi-agent-core";
-import { formatBytes, sanitizeText } from "@oh-my-pi/pi-utils";
+import { formatBytes, materializeString, sanitizeText } from "@oh-my-pi/pi-utils";
 import { sanitizeWithOptionalSixelPassthrough } from "../utils/sixel";
 
 // =============================================================================
@@ -272,7 +272,7 @@ export function truncateLine(
 	maxChars: number = DEFAULT_MAX_COLUMN,
 ): { text: string; wasTruncated: boolean } {
 	if (line.length <= maxChars) return { text: line, wasTruncated: false };
-	return { text: `${line.slice(0, maxChars)}…`, wasTruncated: true };
+	return { text: materializeString(`${line.slice(0, maxChars)}…`), wasTruncated: true };
 }
 
 // =============================================================================
@@ -380,7 +380,7 @@ export function truncateHead(content: string, options: TruncationOptions = {}): 
 	if (includedLines >= maxLines && bytesUsed <= maxBytes) truncatedBy = "lines";
 
 	return {
-		content: content.slice(0, cutIndex),
+		content: materializeString(content.slice(0, cutIndex)),
 		truncated: true,
 		truncatedBy,
 		totalLines,
@@ -486,7 +486,7 @@ export function truncateTail(content: string, options: TruncationOptions = {}): 
 	if (includedLines >= maxLines && bytesUsed <= maxBytes) truncatedBy = "lines";
 
 	return {
-		content: content.slice(startIndex),
+		content: materializeString(content.slice(startIndex)),
 		truncated: true,
 		truncatedBy,
 		totalLines,

--- a/packages/coding-agent/test/fixtures/truncated-string-retention-probe.ts
+++ b/packages/coding-agent/test/fixtures/truncated-string-retention-probe.ts
@@ -1,0 +1,51 @@
+import { RawSseDebugBuffer } from "@oh-my-pi/pi-coding-agent/debug/raw-sse-buffer";
+import { truncateHead, truncateTail } from "@oh-my-pi/pi-coding-agent/session/streaming-output";
+
+const EVENTS = 16;
+const PARENT_BYTES = 8 * 1024 * 1024;
+const WINDOW_BYTES = 32_000;
+
+async function liveBytes(): Promise<number> {
+	Bun.gc(true);
+	Bun.gc(true);
+	await Bun.sleep(50);
+	const memory = process.memoryUsage();
+	return Math.max(memory.heapUsed, memory.external);
+}
+
+function retainRawSse(): RawSseDebugBuffer {
+	const buffer = new RawSseDebugBuffer();
+	for (let index = 0; index < EVENTS; index++) {
+		const line = `data: ${Buffer.alloc(PARENT_BYTES, 65 + (index % 26)).toString("base64")}`;
+		buffer.recordEvent({ event: null, data: "{}", raw: [line] });
+	}
+	return buffer;
+}
+
+function retainToolOutput(): string[] {
+	const retained: string[] = [];
+	for (let index = 0; index < EVENTS; index++) {
+		const content = Buffer.alloc(PARENT_BYTES, 65 + (index % 26))
+			.toString("base64")
+			.replace(/.{1024}/g, "$&\n");
+		retained.push(truncateHead(content, { maxBytes: WINDOW_BYTES, maxLines: 32 }).content);
+		retained.push(truncateTail(content, { maxBytes: WINDOW_BYTES, maxLines: 32 }).content);
+	}
+	return retained;
+}
+
+const mode = process.argv.at(-1);
+const baseline = await liveBytes();
+let owner: RawSseDebugBuffer | string[];
+if (mode === "raw-sse") {
+	owner = retainRawSse();
+} else if (mode === "tool-output") {
+	owner = retainToolOutput();
+} else {
+	throw new Error(`unknown probe mode: ${mode}`);
+}
+
+const retainedBytes = Math.max(0, (await liveBytes()) - baseline);
+const retainedChars =
+	owner instanceof RawSseDebugBuffer ? owner.toRawText().length : owner.reduce((sum, text) => sum + text.length, 0);
+await Bun.write(Bun.stdout, `${retainedBytes}\n${retainedChars}\n`);

--- a/packages/coding-agent/test/truncated-string-retention.test.ts
+++ b/packages/coding-agent/test/truncated-string-retention.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+import * as path from "node:path";
+
+interface ProbeResult {
+	retainedBytes: number;
+	retainedChars: number;
+}
+
+const MAX_RETAINED_BYTES = 32 * 1024 * 1024;
+const probePath = path.resolve(import.meta.dir, "fixtures", "truncated-string-retention-probe.ts");
+
+async function runProbe(mode: "raw-sse" | "tool-output"): Promise<ProbeResult> {
+	const proc = Bun.spawn([process.execPath, "--smol", probePath, mode], {
+		cwd: path.resolve(import.meta.dir, "../.."),
+		stderr: "pipe",
+		stdout: "pipe",
+	});
+	const [stdout, stderr, exitCode] = await Promise.all([
+		new Response(proc.stdout).text(),
+		new Response(proc.stderr).text(),
+		proc.exited,
+	]);
+	expect(exitCode, stderr).toBe(0);
+	const [retainedBytes, retainedChars] = stdout.trim().split("\n").map(Number);
+	if (!Number.isFinite(retainedBytes) || !Number.isFinite(retainedChars)) {
+		throw new Error(`invalid retention probe output: ${stdout}`);
+	}
+	return { retainedBytes, retainedChars };
+}
+
+describe("truncated string ownership", () => {
+	test("raw SSE windows do not retain oversized event backing strings", async () => {
+		const result = await runProbe("raw-sse");
+		expect(result.retainedChars).toBeGreaterThan(0);
+		expect(result.retainedBytes, JSON.stringify(result)).toBeLessThan(MAX_RETAINED_BYTES);
+	});
+
+	test("tool-output windows do not retain oversized result backing strings", async () => {
+		const result = await runProbe("tool-output");
+		expect(result.retainedChars).toBeGreaterThan(0);
+		expect(result.retainedBytes, JSON.stringify(result)).toBeLessThan(MAX_RETAINED_BYTES);
+	});
+});

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -15,6 +15,7 @@ export * from "./json-parse";
 export * as logger from "./logger";
 export * from "./loop-phase";
 export * from "./math-delimiters";
+export * from "./materialize-string";
 export * from "./mermaid-ascii";
 export * from "./mime";
 export * from "./path";

--- a/packages/utils/src/materialize-string.ts
+++ b/packages/utils/src/materialize-string.ts
@@ -1,0 +1,10 @@
+/**
+ * Copy text into independent UTF-16 backing storage before a bounded substring outlives its source.
+ *
+ * The UTF-16 round trip preserves every JavaScript code unit, including lone
+ * surrogates that a UTF-8 round trip would replace.
+ */
+export function materializeString(text: string): string {
+	if (text.length === 0) return "";
+	return Buffer.from(text, "utf16le").toString("utf16le");
+}


### PR DESCRIPTION
## Repro

Running `bun /tmp/omp-10547-repro/repro.mjs` against the reporter’s reproduction retained 2,048,032 sliced characters but kept 172.0 MiB heap / 171.1 MiB external live after forced GC; the materialized-copy mode kept 3.3 MiB / 2.4 MiB.

## Cause

`headTailTrim` in `packages/coding-agent/src/debug/raw-sse-buffer.ts` and the multiline `truncateHead` / `truncateTail` paths in `packages/coding-agent/src/session/streaming-output.ts` returned slice-derived strings. `RawSseDebugBuffer` and `spillLargeResultToArtifact` then retained those bounded windows, which kept each oversized JavaScriptCore parent string reachable.

## Fix

- Add a UTF-16-preserving `materializeString` utility that gives bounded substrings independent backing storage.
- Materialize only truncated raw SSE records, multiline head/tail windows, and column-truncated lines; unchanged fast paths remain zero-copy.
- Add fresh-process memory regressions for active raw SSE and tool-output ownership.

## Verification

`bun test packages/coding-agent/test/truncated-string-retention.test.ts` passed 2 tests; the probes retained about 2.0 MiB for raw SSE and 12.7 MiB for tool-output parents, both below the 32 MiB guard. `bun test packages/coding-agent/test/debug/raw-sse-buffer.test.ts packages/coding-agent/test/streaming-output.test.ts` passed 71 tests. `bun --cwd=packages/utils run check`, `bun --cwd=packages/coding-agent run check`, and the pre-publish `bun check` gate passed.

Fixes #10547