### PR TITLE
fix(config): keep authHeader+apiKey discovery models' authorization live

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,7 @@
 - TypeScript code intelligence now works on TypeScript 7 projects: the built-in `typescript-native` server runs `tsc --lsp --stdio` when the resolved TypeScript install no longer ships `tsserver.js`, replacing `typescript-language-server` for that project.
 - Claude marketplace MCP servers now resolve environment placeholders in stdio environment values instead of passing strings such as `${NAME:-}` literally ([#10481](https://github.com/can1357/oh-my-pi/pull/10481) by [@mrexodia](https://github.com/mrexodia)).
 - Fixed prewalk conflicting with `todo.eager=always`: the forced eager-todo prelude ("call todo first this turn") was injected alongside the prewalk plan nudge ("write a complete plan first, then todo"), giving the model contradictory instructions; the eager-todo prelude is now suppressed only when prewalk will perform a handoff ([#10510](https://github.com/can1357/oh-my-pi/issues/10510)).
+- Fixed `authHeader: true` + command-backed `apiKey` discovery providers (no explicit `headers:` block) resending a stale bearer after a 401 force-refresh; discovered models now re-derive `Authorization` from the live `apiKey` each request ([#10551](https://github.com/can1357/oh-my-pi/issues/10551)).
 ## [18.1.2] - 2026-09-01
 
 ### Added

--- a/packages/coding-agent/src/config/model-patch.ts
+++ b/packages/coding-agent/src/config/model-patch.ts
@@ -48,13 +48,21 @@ export interface ProviderOverride {
  * values keep resolving per request on the inference path, matching the
  * `modelOverrides`/`applyModelPatch` behavior — otherwise a discovery
  * provider would send the raw `!command` literal upstream (#10457).
- * See `xiaomi-tp-discovery-merge.test.ts` and the `refresh()` baseUrl-override
- * regression in `model-registry.test.ts`.
+ * The `authHeader`/`apiKey` override fields are threaded into the live
+ * resolver too, so an `authHeader: true` + `apiKey` provider with no explicit
+ * `headers:` block re-derives `Authorization` from the current `apiKey`
+ * resolution each request — a 401 force-refresh (command-cache invalidation)
+ * reaches the retry instead of resending the discovery-time baked bearer
+ * (#10551). See `xiaomi-tp-discovery-merge.test.ts` and the `refresh()`
+ * baseUrl-override regression in `model-registry.test.ts`.
  */
 export function mergeDiscoveredModel<TApi extends Api>(
 	model: Model<TApi>,
 	existing: Model<Api> | undefined,
-	providerOverride?: Pick<ProviderOverride, "baseUrl" | "compat" | "headers" | "remoteCompaction" | "transport">,
+	providerOverride?: Pick<
+		ProviderOverride,
+		"baseUrl" | "compat" | "headers" | "remoteCompaction" | "transport" | "authHeader" | "apiKey"
+	>,
 ): Model<TApi> {
 	if (existing) {
 		const supportsTools = model.supportsTools ?? existing.supportsTools;
@@ -65,7 +73,10 @@ export function mergeDiscoveredModel<TApi extends Api>(
 			// source: `model.headers` is a discovery-time resolved snapshot, so
 			// without this a rotated credential (401 → cache invalidation) would
 			// stay shadowed by the stale snapshot on the inference path (#10458).
-			headers: createLiveConfigHeaders([existing.headers, model.headers, providerOverride?.headers]),
+			headers: createLiveConfigHeaders([existing.headers, model.headers, providerOverride?.headers], {
+				authHeader: providerOverride?.authHeader,
+				apiKeyConfig: providerOverride?.apiKey,
+			}),
 			transport: providerOverride?.transport ?? existing.transport ?? model.transport,
 			remoteCompaction: mergeProviderRemoteCompactionConfig(
 				mergeRemoteCompactionConfig(existing.remoteCompaction, model.remoteCompaction),
@@ -79,7 +90,10 @@ export function mergeDiscoveredModel<TApi extends Api>(
 		return buildModel({
 			...toModelSpec(model),
 			baseUrl: providerOverride.baseUrl ?? model.baseUrl,
-			headers: createLiveConfigHeaders([model.headers, providerOverride.headers]),
+			headers: createLiveConfigHeaders([model.headers, providerOverride.headers], {
+				authHeader: providerOverride.authHeader,
+				apiKeyConfig: providerOverride.apiKey,
+			}),
 			...(providerOverride.transport !== undefined ? { transport: providerOverride.transport } : {}),
 			remoteCompaction: mergeProviderRemoteCompactionConfig(
 				model.remoteCompaction,

--- a/packages/coding-agent/test/xiaomi-tp-discovery-merge.test.ts
+++ b/packages/coding-agent/test/xiaomi-tp-discovery-merge.test.ts
@@ -168,4 +168,31 @@ describe("mergeDiscoveredModel", () => {
 			await fs.rm(tokenFile, { force: true });
 		}
 	});
+
+	test("authHeader+apiKey provider (no explicit headers) re-derives Authorization live on rotation (#10551)", async () => {
+		const tokenFile = path.join(os.tmpdir(), `omp-ah-${Date.now()}-${Math.random().toString(36).slice(2)}.txt`);
+		const readScript = "process.stdout.write(await Bun.file(Bun.argv[1]).text())";
+		const apiKey = `!${JSON.stringify(process.execPath)} -e "${readScript}" ${JSON.stringify(tokenFile)}`;
+		await Bun.write(tokenFile, "token-A");
+		try {
+			// `discoverOpenAIModelsList` bakes a discovery-time resolved bearer
+			// into `model.headers.Authorization`; with `authHeader: true` + a
+			// command-backed `apiKey` and no explicit `headers:` block the merge
+			// must re-derive Authorization from the live `apiKey` instead.
+			const discovered: Model<"openai-completions"> = {
+				...bundled(STANDARD),
+				headers: { Authorization: "Bearer stale-token" },
+			};
+			const merged = mergeDiscoveredModel(discovered, undefined, { authHeader: true, apiKey });
+			// Live apiKey wins over the discovery-time baked bearer...
+			expect(merged.headers?.Authorization).toBe("Bearer token-A");
+			// ...and a 401 force-refresh (command-cache invalidation) reaches it.
+			await Bun.write(tokenFile, "token-B");
+			invalidateCommandConfig(apiKey);
+			expect(merged.headers?.Authorization).toBe("Bearer token-B");
+		} finally {
+			invalidateCommandConfig(apiKey);
+			await fs.rm(tokenFile, { force: true });
+		}
+	});
 });


### PR DESCRIPTION
## Repro
A custom `openai-completions` discovery provider configured with `authHeader: true` + a command-backed `apiKey` and no explicit `headers:` block sends a permanent `401` loop once the minted credential expires mid-session: the auth-retry policy correctly calls `getApiKeyForProvider({ forceRefresh: true })` (which re-runs the `!command` and returns a fresh token), but every retry resends the stale bearer. Reproduced in-process, mirroring `xiaomi-tp-discovery-merge.test.ts`:

```ts
const discovered = buildModel({ /* … */ headers: { Authorization: "Bearer stale-token" } });
const merged = mergeDiscoveredModel(discovered, undefined, { authHeader: true, apiKey: "!echo fresh-token" });
// merged.headers.Authorization === "Bearer stale-token"  // stays stale
```

## Cause
`discoverOpenAIModelsList` (`packages/coding-agent/src/config/model-discovery.ts`) bakes the discovery-time resolved bearer into each model's `headers.Authorization` as a plain string. `mergeDiscoveredModel` (`packages/coding-agent/src/config/model-patch.ts`) wraps merged headers in `createLiveConfigHeaders([existing.headers, model.headers, providerOverride?.headers])` but never passes the `{ authHeader, apiKeyConfig }` options, and `authHeader`/`apiKey` are excluded from its `providerOverride` `Pick`. For this config shape `providerOverride.headers` is `undefined`, so the merge falls through to the stale baked `model.headers`. Downstream, `resolveOpenAIRequestSetup`'s `headers.Authorization ??= \`Bearer ${apiKey}\`` is a no-op because `Authorization` is already populated — the freshly force-refreshed key is discarded. This is the same class of regression #10458 fixed for explicit `headers:` entries, uncovered for the `authHeader`/`apiKey`-derived shape.

## Fix
- Add `authHeader`/`apiKey` to `mergeDiscoveredModel`'s `providerOverride` `Pick`.
- Thread `{ authHeader: providerOverride?.authHeader, apiKeyConfig: providerOverride?.apiKey }` into both `createLiveConfigHeaders` calls (existing-merge and override-only paths), so `Authorization` re-derives from the current `apiKey` resolution each request. `materializeConfigHeaderSources` applies the `authHeader`-derived bearer last, so the live key wins over the baked discovery snapshot and a 401 command-cache invalidation reaches the retry.
- Add a `#10551` regression test and a changelog entry.

## Verification
`bun test test/xiaomi-tp-discovery-merge.test.ts` — 12 pass / 0 fail (including the new `#10551` case asserting the live apiKey wins over the baked bearer and re-derives on rotation). Also confirmed in-process that `mergeDiscoveredModel` returns `Bearer token-A` initially and `Bearer token-B` after `invalidateCommandConfig`. Fixes #10551