### PR TITLE
fix(catalog): break glm-5.2 effort overlap on blanket-glm providers

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Fixed
 
 - Claude Sonnet 5 no longer advertises unsupported mid-conversation system messages.
+- Custom GLM 5.2 models on `alibaba-coding-plan` (and other blanket-GLM hosts) no longer crash startup with `AmbiguousOverlapError` ([#10553](https://github.com/can1357/oh-my-pi/issues/10553)).
 
 ## [18.1.2] - 2026-09-01
 

--- a/packages/catalog/src/compat/rules.json
+++ b/packages/catalog/src/compat/rules.json
@@ -4847,7 +4847,7 @@
 				}
 			},
 			{
-				"source": "classes/glm.kdl:13",
+				"source": "classes/glm.kdl:16",
 				"class": "glm",
 				"revision": [
 					{
@@ -4859,6 +4859,7 @@
 						"revision": "5.3.0"
 					}
 				],
+				"priority": 10,
 				"thinking": {
 					"efforts": [
 						"minimal",
@@ -4870,7 +4871,7 @@
 				}
 			},
 			{
-				"source": "classes/glm.kdl:17",
+				"source": "classes/glm.kdl:20",
 				"class": "glm",
 				"providers": [
 					"zai",
@@ -4892,7 +4893,7 @@
 				}
 			},
 			{
-				"source": "classes/glm.kdl:23",
+				"source": "classes/glm.kdl:26",
 				"class": "glm",
 				"providers": [
 					"zai",
@@ -4919,7 +4920,7 @@
 				}
 			},
 			{
-				"source": "classes/glm.kdl:29",
+				"source": "classes/glm.kdl:32",
 				"class": "glm",
 				"providers": [
 					"vercel-ai-gateway"
@@ -4945,7 +4946,7 @@
 				}
 			},
 			{
-				"source": "classes/glm.kdl:36",
+				"source": "classes/glm.kdl:39",
 				"class": "glm",
 				"providers": [
 					"zai",
@@ -4973,7 +4974,7 @@
 				}
 			},
 			{
-				"source": "classes/glm.kdl:46",
+				"source": "classes/glm.kdl:49",
 				"class": "glm",
 				"providers": [
 					"zai"
@@ -4994,7 +4995,7 @@
 				}
 			},
 			{
-				"source": "classes/glm.kdl:58",
+				"source": "classes/glm.kdl:61",
 				"class": "glm",
 				"providers": [
 					"zai",
@@ -5014,7 +5015,7 @@
 				}
 			},
 			{
-				"source": "classes/glm.kdl:62",
+				"source": "classes/glm.kdl:65",
 				"class": "glm",
 				"providers": [
 					"alibaba-coding-plan",
@@ -5026,7 +5027,7 @@
 				}
 			},
 			{
-				"source": "classes/glm.kdl:66",
+				"source": "classes/glm.kdl:69",
 				"class": "glm",
 				"providers": [
 					"openrouter",
@@ -5043,7 +5044,7 @@
 				}
 			},
 			{
-				"source": "classes/glm.kdl:77",
+				"source": "classes/glm.kdl:80",
 				"class": "glm",
 				"models": [
 					{

--- a/packages/catalog/src/compat/rules/classes/glm.kdl
+++ b/packages/catalog/src/compat/rules/classes/glm.kdl
@@ -10,7 +10,10 @@ class "glm" {
 	// GLM-5.2 exposes the default lower tiers plus a genuine max on generic
 	// OpenAI-compatible hosts; the zai-dialect and Anthropic-route hosts
 	// (Z.ai, Zhipu, Umans, Ollama Cloud, Baseten) serve only high/max.
-	revision ">=5.2 <5.3" {
+	// priority breaks the intentional overlap with provider-level blanket GLM
+	// ladders authored for the pre-5.2 census (e.g. alibaba-coding-plan.kdl),
+	// so the 5.2 lineage ladder wins on generic hosts that lack a 5.2 residue.
+	revision ">=5.2 <5.3" priority=10 {
 		thinking-efforts "minimal" "low" "medium" "high" "max"
 	}
 	on "zai" "zhipu-coding-plan" {

--- a/packages/catalog/test/compat-cascade.test.ts
+++ b/packages/catalog/test/compat-cascade.test.ts
@@ -122,6 +122,20 @@ describe("resolveCascade over committed rules", () => {
 		expect(resolved.thinking.mode).toBeDefined();
 	});
 
+	test("glm-5.2 on a blanket-glm provider resolves without overlapping the class ladder", () => {
+		// Regression: providers/alibaba-coding-plan.kdl has a direct `class "glm"`
+		// efforts block and no exact glm-5.2 residue, so it used to tie with the
+		// classes/glm.kdl revision >=5.2 ladder and throw AmbiguousOverlapError.
+		const resolved = resolveCascade({
+			provider: "alibaba-coding-plan",
+			class: "glm",
+			model: "glm-5.2",
+			revision: "5.2",
+			reasoning: true,
+		});
+		expect(resolved.thinking.efforts).toEqual(["minimal", "low", "medium", "high", "max"]);
+	});
+
 	test("glob matching is anchored and case-insensitive", () => {
 		expect(globMatch("gpt-*-codex", "gpt-5.2-codex")).toBe(true);
 		expect(globMatch("gpt-*-codex", "xgpt-5.2-codex")).toBe(false);


### PR DESCRIPTION
## Repro
Adding a custom GLM 5.2 model under the bundled `alibaba-coding-plan` provider in `models.yml` with `reasoning: true` crashes OMP at startup with `AmbiguousOverlapError`. Confirmed against `main` end-to-end:

```
buildModel({ provider: 'alibaba-coding-plan', id: 'glm-5.2', api: 'openai-completions', reasoning: true, ... })
// AmbiguousOverlapError: ambiguous overlap for `alibaba-coding-plan/glm-5.2` on axis `efforts`:
//   rules `classes/glm.kdl:13` and `providers/alibaba-coding-plan.kdl:9` tie; add an explicit priority
```

## Cause
Two committed KDL rules tie on the `efforts` axis at identical rank `(exactness=0, dimensions=2, priority=0)` for a `glm-5.2` target with reasoning on:

- `classes/glm.kdl:13` — `class "glm"` + `revision ">=5.2 <5.3"` → `[minimal, low, medium, high, max]`
- `providers/alibaba-coding-plan.kdl:9` — `provider "alibaba-coding-plan"` + `class "glm"` → `[minimal, low, medium, high]`

`resolveCascade` (`packages/catalog/src/compat/cascade.ts`) treats an equal-rank same-axis overlap as unresolvable and throws. `alibaba-coding-plan` is the only provider with a direct `class "glm"` thinking-efforts block *and* no exact `glm-5.2` residue rule; every other 5.2 host pins a `models "…glm-5.2…"` residue (exactness ≥ 1) that outranks both, which is why the CI parity sweep never covered this pair.

## Fix
- Add `priority=10` to the `revision ">=5.2 <5.3"` block in `classes/glm.kdl`. The class file already documents that generic OpenAI-compatible hosts (which `alibaba-coding-plan` is — deliberately not in the high/max-only list) expose the full ladder including a genuine `max`; the provider's blanket ladder was authored for the pre-5.2 census GLM on that host. Giving the 5.2 lineage rule precedence resolves the intentional overlap, mirroring the existing `priority=10` precedent in the same file (line 77).
- Regenerate `packages/catalog/src/compat/rules.json` via `bun run gen:compat`.
- Add a regression test in `compat-cascade.test.ts` asserting `alibaba-coding-plan/glm-5.2` resolves to `[minimal, low, medium, high, max]` instead of throwing.
- Changelog entry under `packages/catalog` `[Unreleased]`.

## Verification
`bun test test/compat-cascade.test.ts test/compat-compile.test.ts test/compat-conformance.test.ts test/compat-parity.test.ts` — 25 pass, 0 fail. Parity proves no bundled model's resolved values changed; compile proves `rules.json` matches the KDL. Manual resolve sweep confirms `alibaba-coding-plan/glm-5.2` now yields the full ladder while `opencode-zen/glm-5.2`, `zai/glm-5.2`, `vercel-ai-gateway/glm-5.2`, and `alibaba-coding-plan/glm-4.7` are all unchanged (their residues and dimension-3 `on` rules still win; no new tie).

Fixes #10553