### PR TITLE
fix(auth): heal scoped Anthropic usage blocks

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Preserved Anthropic thinking now survives side requests, tool-description drift, turn-scoped reminders, and recoverable prefix mismatches without corrupting the conversation prefix.
+- Recovered Anthropic Fable and Mythos OAuth credentials when a fresh, identity-matched usage report shows that a stale tier block is no longer exhausted, matching the existing Codex self-heal without clearing unrelated scopes.
 
 ## [18.1.2] - 2026-09-01
 

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -3414,7 +3414,7 @@ export class AuthStorage {
 				// times decorrelate within a few cycles.
 				this.#usageCache.set(cacheKey, { value: report, expiresAt: Date.now() + USAGE_REPORT_TTL_MS + ttlJitter });
 				this.#recordUsageHistory(request, report);
-				this.#reconcileCodexUsageBlock(request, report);
+				this.#reconcileUsageBlock(request, report);
 				return report;
 			}
 			// Failure: apply a short jittered cool-down so the credential doesn't
@@ -3903,10 +3903,7 @@ export class AuthStorage {
 			if (storeHook) {
 				const report = await storeHook(provider, credential, options?.signal);
 				if (report) {
-					this.#reconcileCodexUsageBlock(
-						this.#buildUsageRequestForOauth(provider, credential, options?.baseUrl),
-						report,
-					);
+					this.#reconcileUsageBlock(this.#buildUsageRequestForOauth(provider, credential, options?.baseUrl), report);
 				}
 				return report;
 			}
@@ -4009,7 +4006,7 @@ export class AuthStorage {
 				const credentialType = entry.credential.type;
 				const providerKey = this.#getProviderTypeKey(provider, credentialType);
 				let blockedUntil = this.#getCredentialBlockedUntil(provider, providerKey, index, blockScopes);
-				if (blockedUntil !== undefined && provider !== "openai-codex") {
+				if (blockedUntil !== undefined && !this.#supportsUsageBlockReconciliation(provider)) {
 					return {
 						credentialId: entry.id,
 						credentialType,
@@ -4036,7 +4033,7 @@ export class AuthStorage {
 					planEligibilityByCredential.set(entry.id, getOpenAICodexPlanEligibility(report, planRequirement));
 				}
 
-				if (provider === "openai-codex") {
+				if (this.#supportsUsageBlockReconciliation(provider)) {
 					blockedUntil = this.#getCredentialBlockedUntil(provider, providerKey, index, blockScopes);
 				}
 				if (blockedUntil !== undefined) {
@@ -4178,7 +4175,7 @@ export class AuthStorage {
 				this.#usageReportsInFlight.set(overrideKey, shared);
 			}
 			const reports = await raceUsageWithSignal(shared, options?.signal);
-			if (shouldReconcileStoreHookReports && reports) this.#reconcileCodexUsageBlocksFromReports(reports);
+			if (shouldReconcileStoreHookReports && reports) this.#reconcileUsageBlocksFromReports(reports);
 			return reports;
 		}
 		if (!this.#usageProviderResolver && this.#runtimeUsageProviderOverrides.size === 0) return null;
@@ -4734,7 +4731,7 @@ export class AuthStorage {
 				);
 				let usage: UsageReport | null = null;
 				let usageChecked = false;
-				if (blockedUntil !== undefined && args.provider === "openai-codex") {
+				if (blockedUntil !== undefined && this.#supportsUsageBlockReconciliation(args.provider)) {
 					usage = await this.#getUsageReport(args.provider, selection.credential, {
 						...args.options,
 						timeoutMs: this.#usageRequestTimeoutMs,
@@ -6161,28 +6158,38 @@ export class AuthStorage {
 		}
 	}
 
+	#supportsUsageBlockReconciliation(provider: string): boolean {
+		return provider === "openai-codex" || provider === "anthropic";
+	}
+
 	/**
-	 * Self-heal a stale Codex usage-limit block: when a fresh live usage report
-	 * says the account is allowed and below every reported limit, drop the
-	 * persisted and in-memory `openai-codex:oauth` blocks so credential selection
-	 * can re-include recovered seats before a stale block naturally expires.
-	 */
-	/**
-	 * Narrow a usage report to the limits a backoff scope covers, so a scope is
-	 * judged only by the meters it gates. A legacy scope that meant "block
-	 * everything" keeps the whole report.
+	 * Narrow a usage report to the meters one persisted backoff scope gates.
+	 * Scoped healing must never let an unrelated healthy meter erase a live
+	 * block.
 	 */
 	#scopeUsageReportToBlockScope(
 		report: UsageReport,
 		blockScope: string | undefined,
 		strategy: CredentialRankingStrategy | undefined,
 	): UsageReport {
-		if (!blockScope || !strategy?.scopeLimits || !strategy.blockScopes) return report;
-		// Find a request context whose scope set leads with this scope; its scoped
-		// limits are the ones this block gates.
-		const modelId = blockScope === "spark" ? "gpt-5.3-codex-spark" : "gpt-5.3-codex";
-		if (strategy.blockScopes({ modelId })[0] !== blockScope) return report;
-		const scopedLimits = strategy.scopeLimits(report, { modelId });
+		const scopeLimits =
+			report.provider === "anthropic" ? strategy?.scopeLimitsForReserve : strategy?.scopeLimits;
+		if (!blockScope || !scopeLimits) return report;
+		let modelId: string | undefined;
+		if (report.provider === "openai-codex") {
+			const blockScopes = strategy?.blockScopes;
+			if (!blockScopes) return report;
+			modelId = blockScope === "spark" ? "gpt-5.3-codex-spark" : "gpt-5.3-codex";
+			if (blockScopes({ modelId })[0] !== blockScope) return report;
+		} else if (report.provider === "anthropic" && blockScope.startsWith("tier:")) {
+			const tier = blockScope.slice("tier:".length);
+			if (tier !== "fable" && tier !== "mythos") return report;
+			modelId = `claude-${tier}-5`;
+		} else {
+			return report;
+		}
+
+		const scopedLimits = scopeLimits(report, { modelId });
 		const meterStates = report.metadata?.meterStates;
 		const meterState =
 			meterStates !== null && typeof meterStates === "object"
@@ -6192,7 +6199,7 @@ export class AuthStorage {
 			...report,
 			limits: scopedLimits,
 			metadata:
-				meterState || blockScope === "spark"
+				report.provider === "openai-codex" && (meterState || blockScope === "spark")
 					? {
 							...report.metadata,
 							allowed: meterState?.allowed,
@@ -6202,14 +6209,7 @@ export class AuthStorage {
 		};
 	}
 
-	/**
-	 * Clear one backoff scope. The in-memory backoff is per scope so it is
-	 * dropped directly; the persisted store deletes a credential's blocks as a
-	 * unit, so it is only purged once no other scope still holds a live block.
-	 * Leaving a persisted row behind is safe: the scope it belongs to is
-	 * unblocked in memory, and the row heals on the pass where its own meter
-	 * recovers.
-	 */
+	/** Clear one exact in-memory and persisted backoff scope. */
 	#clearCredentialBlockScope(
 		provider: string,
 		credentialId: number,
@@ -6231,29 +6231,86 @@ export class AuthStorage {
 		}
 	}
 
-	#isHealthyCodexUsageReport(report: UsageReport): boolean {
-		if (report.provider !== "openai-codex") return false;
-		const metadata = report.metadata;
-		if (metadata?.allowed !== true || metadata.limitReached !== false) return false;
-		return !this.#isUsageLimitReached(report.limits);
+	#isHealthyUsageReportForBlock(report: UsageReport, blockScope: string | undefined): boolean {
+		if (report.provider === "openai-codex") {
+			const metadata = report.metadata;
+			if (metadata?.allowed !== true || metadata.limitReached !== false) return false;
+			return !this.#isUsageLimitReached(report.limits);
+		}
+		if (report.provider !== "anthropic" || report.limits.length === 0) return false;
+		const tier = blockScope?.startsWith("tier:") ? blockScope.slice("tier:".length) : undefined;
+		if (tier && !report.limits.some(limit => limit.scope.tier === tier)) return false;
+		return report.limits.every(limit => {
+			const usedFraction = resolveUsedFraction(limit);
+			return (
+				limit.status !== "unknown" &&
+				usedFraction !== undefined &&
+				Number.isFinite(usedFraction) &&
+				!this.#isUsageLimitExhausted(limit)
+			);
+		});
 	}
 
-	#reconcileCodexUsageBlockForCredential(provider: Provider, credentialId: number, report: UsageReport): void {
+	#credentialBlockReconcilePending(
+		credentialId: number,
+		credentialIndex: number,
+		providerKey: string,
+		blockScope: string | undefined,
+		nowMs: number,
+	): boolean {
+		const scopedBackoffKey = this.#toScopedBackoffKey(providerKey, blockScope);
+		const globalProbeAfterMs = this.#credentialBackoffProbeAfter.get(providerKey)?.get(credentialIndex) ?? 0;
+		const scopedProbeAfterMs = this.#credentialBackoffProbeAfter.get(scopedBackoffKey)?.get(credentialIndex) ?? 0;
+		const storeGlobalProbeAfterMs = this.#readPersistedCredentialBlockReconcileAfter(credentialId, providerKey, "");
+		const storeScopedProbeAfterMs = this.#readPersistedCredentialBlockReconcileAfter(
+			credentialId,
+			providerKey,
+			blockScope ?? "",
+		);
+		return Math.max(globalProbeAfterMs, scopedProbeAfterMs, storeGlobalProbeAfterMs, storeScopedProbeAfterMs) > nowMs;
+	}
+
+	#healUsageBlockScope(
+		provider: Provider,
+		providerKey: string,
+		credentialId: number,
+		credentialIndex: number,
+		blockScope: string | undefined,
+		report: UsageReport,
+		strategy: CredentialRankingStrategy | undefined,
+	): void {
+		const scopedReport = this.#scopeUsageReportToBlockScope(report, blockScope, strategy);
+		if (!this.#isHealthyUsageReportForBlock(scopedReport, blockScope)) return;
+		const blockedUntilMs = this.#getCredentialBlockedUntil(provider, providerKey, credentialIndex, blockScope);
+		if (blockedUntilMs === undefined) return;
+		// Provider usage can lag the request path that just returned 429. Give a
+		// fresh local or broker-sourced block one full usage-cache window before a
+		// healthy report may clear it.
+		if (this.#credentialBlockReconcilePending(credentialId, credentialIndex, providerKey, blockScope, Date.now())) {
+			return;
+		}
+		this.#clearCredentialBlockScope(provider, credentialId, credentialIndex, providerKey, blockScope);
+		logger.info("Cleared stale usage-limit block after healthy live usage report", {
+			credentialId,
+			provider,
+			blockScope,
+			clearedBlockedUntilMs: blockedUntilMs,
+		});
+	}
+
+	#reconcileUsageBlockForCredential(provider: Provider, credentialId: number, report: UsageReport): void {
+		if (!this.#supportsUsageBlockReconciliation(provider)) return;
 		const providerKey = this.#getProviderTypeKey(provider, "oauth");
 		const credentialIndex = this.#getStoredCredentials(provider).findIndex(entry => entry.id === credentialId);
 		if (credentialIndex < 0) return;
-		// Mirror selection: consult the same strategy scope `markUsageLimitReached`
-		// persists under, else a scoped block is invisible here and never healed.
-		// Reconciliation has no request context, so it cannot know which scope a
-		// block was written under. Heal every scope the strategy can produce, plus
-		// any legacy scope it still lists, or a block persisted under one scope
-		// stays invisible here forever.
 		const strategy = this.#rankingStrategyResolver?.(provider);
 		const blockScopes =
-			strategy?.blockScopes?.() ?? [strategy?.blockScope?.({})].filter(scope => scope !== undefined);
+			provider === "anthropic"
+				? ["tier:fable", "tier:mythos"]
+				: (strategy?.blockScopes?.() ?? [strategy?.blockScope?.({})].filter(scope => scope !== undefined));
 		const scopesToHeal = blockScopes.length > 0 ? blockScopes : [undefined];
 		for (const blockScope of scopesToHeal) {
-			this.#healCodexUsageBlockScope(
+			this.#healUsageBlockScope(
 				provider,
 				providerKey,
 				credentialId,
@@ -6265,92 +6322,49 @@ export class AuthStorage {
 		}
 	}
 
-	/**
-	 * Heal one backoff scope against the limits that scope actually covers.
-	 *
-	 * Judging a scope by the whole report is wrong once scopes are per-meter: an
-	 * exhausted Spark meter would keep a recovered chat block alive, and healing
-	 * would then delete every scope including a block that is still valid. So
-	 * each scope is evaluated against its own limits and cleared on its own.
-	 */
-	#healCodexUsageBlockScope(
-		provider: Provider,
-		providerKey: string,
-		credentialId: number,
-		credentialIndex: number,
-		blockScope: string | undefined,
-		report: UsageReport,
-		strategy: CredentialRankingStrategy | undefined,
-	): void {
-		const scopedReport = this.#scopeUsageReportToBlockScope(report, blockScope, strategy);
-		if (!this.#isHealthyCodexUsageReport(scopedReport)) return;
-		const blockedUntilMs = this.#getCredentialBlockedUntil(provider, providerKey, credentialIndex, blockScope);
-		if (blockedUntilMs === undefined) return;
-		// `/usage` can lag the request path that just returned 429. Fresh local or
-		// broker-sourced blocks get one usage-cache window before healthy reports may
-		// clear them.
-		const nowMs = Date.now();
-		const scopedBackoffKey = this.#toScopedBackoffKey(providerKey, blockScope);
-		const globalProbeAfterMs = this.#credentialBackoffProbeAfter.get(providerKey)?.get(credentialIndex) ?? 0;
-		const scopedProbeAfterMs = this.#credentialBackoffProbeAfter.get(scopedBackoffKey)?.get(credentialIndex) ?? 0;
-		const storeGlobalProbeAfterMs = this.#readPersistedCredentialBlockReconcileAfter(credentialId, providerKey, "");
-		const storeScopedProbeAfterMs = this.#readPersistedCredentialBlockReconcileAfter(
-			credentialId,
-			providerKey,
-			blockScope ?? "",
-		);
-		if (Math.max(globalProbeAfterMs, scopedProbeAfterMs, storeGlobalProbeAfterMs, storeScopedProbeAfterMs) > nowMs) {
-			return;
-		}
-		this.#clearCredentialBlockScope(provider, credentialId, credentialIndex, providerKey, blockScope);
-		logger.info("Cleared stale Codex usage-limit block after healthy live usage report", {
-			credentialId,
-			provider,
-			blockScope,
-			clearedBlockedUntilMs: blockedUntilMs,
-		});
-	}
-
-	#reconcileCodexUsageBlock(request: UsageRequestDescriptor, report: UsageReport): void {
-		if (request.provider !== "openai-codex") return;
-		const credentialId = this.#findStoredCredentialIdForUsageCredential(request.provider, request.credential);
-		if (credentialId === undefined) return;
-		this.#reconcileCodexUsageBlockForCredential(request.provider, credentialId, report);
-	}
-
-	#findStoredCredentialIdsForUsageReport(report: UsageReport): number[] {
-		if (report.provider !== "openai-codex") return [];
+	#usageReportMatchesCredential(report: UsageReport, credential: AuthCredential): boolean {
+		if (credential.type !== "oauth") return false;
 		const email = this.#getUsageReportMetadataValue(report, "email")?.toLowerCase();
 		const accountId = (
 			this.#getUsageReportMetadataValue(report, "accountId") ?? this.#getUsageReportScopeAccountId(report)
 		)?.toLowerCase();
-		if (!email && !accountId) return [];
-		const matches: number[] = [];
-		for (const entry of this.#getStoredCredentials(report.provider)) {
-			const credential = entry.credential;
-			if (credential.type !== "oauth") continue;
-			const credentialEmail = credential.email?.trim().toLowerCase();
-			const credentialAccountId = credential.accountId?.trim().toLowerCase();
-			// Every identity dimension present on BOTH sides must agree — the
-			// account id is shared workspace-wide and one email can span
-			// workspaces, so a single-dimension match can cross-link siblings.
-			const emailComparable = Boolean(email && credentialEmail);
-			const accountComparable = Boolean(accountId && credentialAccountId);
-			if (!emailComparable && !accountComparable) continue;
-			if (emailComparable && credentialEmail !== email) continue;
-			if (accountComparable && credentialAccountId !== accountId) continue;
-			matches.push(entry.id);
-		}
-		return matches;
+		const orgId = this.#getUsageReportMetadataValue(report, "orgId")?.toLowerCase();
+		if (!email && !accountId) return false;
+		if (report.provider === "anthropic" && (!orgId || credential.orgId?.trim().toLowerCase() !== orgId)) return false;
+		const credentialEmail = credential.email?.trim().toLowerCase();
+		const credentialAccountId = credential.accountId?.trim().toLowerCase();
+		const emailComparable = Boolean(email && credentialEmail);
+		const accountComparable = Boolean(accountId && credentialAccountId);
+		if (!emailComparable && !accountComparable) return false;
+		if (emailComparable && credentialEmail !== email) return false;
+		if (accountComparable && credentialAccountId !== accountId) return false;
+		return true;
 	}
 
-	#reconcileCodexUsageBlocksFromReports(reports: UsageReport[]): void {
-		const reconciled = new Set<number>();
+	#reconcileUsageBlock(request: UsageRequestDescriptor, report: UsageReport): void {
+		if (request.provider !== report.provider || !this.#supportsUsageBlockReconciliation(request.provider)) return;
+		const credentialId = this.#findStoredCredentialIdForUsageCredential(request.provider, request.credential);
+		if (credentialId === undefined) return;
+		const stored = this.#getStoredCredentials(request.provider).find(entry => entry.id === credentialId);
+		if (!stored || !this.#usageReportMatchesCredential(report, stored.credential)) return;
+		this.#reconcileUsageBlockForCredential(request.provider, credentialId, report);
+	}
+
+	#findStoredCredentialIdsForUsageReport(report: UsageReport): number[] {
+		if (!this.#supportsUsageBlockReconciliation(report.provider)) return [];
+		return this.#getStoredCredentials(report.provider)
+			.filter(entry => this.#usageReportMatchesCredential(report, entry.credential))
+			.map(entry => entry.id);
+	}
+
+	#reconcileUsageBlocksFromReports(reports: UsageReport[]): void {
+		const reconciled = new Set<string>();
 		for (const report of reports) {
 			for (const credentialId of this.#findStoredCredentialIdsForUsageReport(report)) {
-				if (reconciled.has(credentialId)) continue;
-				reconciled.add(credentialId);
-				this.#reconcileCodexUsageBlockForCredential(report.provider, credentialId, report);
+				const key = `${report.provider}:${credentialId}`;
+				if (reconciled.has(key)) continue;
+				reconciled.add(key);
+				this.#reconcileUsageBlockForCredential(report.provider, credentialId, report);
 			}
 		}
 	}

--- a/packages/ai/test/auth-storage-claude-fable-fallback.test.ts
+++ b/packages/ai/test/auth-storage-claude-fable-fallback.test.ts
@@ -4,16 +4,21 @@ import {
 	type AuthCredentialStore,
 	AuthStorage,
 	type StoredAuthCredential,
+	type StoredCredentialBlock,
 } from "@oh-my-pi/pi-ai/auth-storage";
 import type { UsageLimit, UsageReport } from "@oh-my-pi/pi-ai/usage";
 import * as claudeUsage from "@oh-my-pi/pi-ai/usage/claude";
 
 interface ObservableStore extends AuthCredentialStore {
 	cache: Map<string, { value: string; expiresAtSec: number }>;
+	blocks: Map<string, StoredCredentialBlock>;
+	reconcileAfter: Map<string, number>;
 }
 
 function makeStore(rows: StoredAuthCredential[]): ObservableStore {
 	const cache = new Map<string, { value: string; expiresAtSec: number }>();
+	const blocks = new Map<string, StoredCredentialBlock>();
+	const reconcileAfter = new Map<string, number>();
 	return {
 		cache,
 		close() {},
@@ -41,6 +46,36 @@ function makeStore(rows: StoredAuthCredential[]): ObservableStore {
 		setCache(key, value, expiresAtSec) {
 			cache.set(key, { value, expiresAtSec });
 		},
+		getCredentialBlock(credentialId, providerKey, blockScope) {
+			const block = blocks.get(`${credentialId}\0${providerKey}\0${blockScope}`);
+			return block && block.blockedUntilMs > Date.now() ? block.blockedUntilMs : undefined;
+		},
+		getCredentialBlockReconcileAfter(credentialId, providerKey, blockScope) {
+			return reconcileAfter.get(`${credentialId}\0${providerKey}\0${blockScope}`);
+		},
+		upsertCredentialBlock(block) {
+			blocks.set(`${block.credentialId}\0${block.providerKey}\0${block.blockScope}`, block);
+		},
+		deleteCredentialBlock(credentialId, providerKey, blockScope) {
+			blocks.delete(`${credentialId}\0${providerKey}\0${blockScope}`);
+			reconcileAfter.delete(`${credentialId}\0${providerKey}\0${blockScope}`);
+		},
+		deleteCredentialBlocks(credentialId) {
+			for (const key of blocks.keys()) {
+				if (key.startsWith(`${credentialId}\0`)) blocks.delete(key);
+			}
+		},
+		cleanExpiredCredentialBlocks(nowMs) {
+			for (const [key, block] of blocks) {
+				if (block.blockedUntilMs <= nowMs) blocks.delete(key);
+			}
+		},
+		listCredentialBlocks(credentialIds) {
+			const ids = new Set(credentialIds);
+			return [...blocks.values()].filter(block => ids.has(block.credentialId) && block.blockedUntilMs > Date.now());
+		},
+		blocks,
+		reconcileAfter,
 		cleanExpiredCache() {},
 	};
 }
@@ -53,6 +88,7 @@ function oauthRow(id: number, email: string, provider = "anthropic"): StoredAuth
 		expires: Date.now() + 3_600_000,
 		accountId: `account-${id}`,
 		email,
+		orgId: `org-${id}`,
 	};
 	return { id, provider, credential, disabledCause: null };
 }
@@ -389,6 +425,158 @@ describe("AuthStorage Claude Fable tier fallback", () => {
 
 		const retryKey = await storage.getApiKey("anthropic", "session-3", { modelId: "claude-fable-5" });
 		expect(retryKey).toBe("oat-2");
+	});
+
+	it("rechecks and clears a stale Fable block when live usage is healthy", async () => {
+		const startNow = Date.now();
+		vi.spyOn(Date, "now").mockReturnValue(startNow);
+		const blockedUntilMs = startNow + 24 * 60 * 60_000;
+		store.upsertCredentialBlock?.({
+			credentialId: 1,
+			providerKey: "anthropic:oauth",
+			blockScope: "tier:fable",
+			blockedUntilMs,
+		});
+		const reportsByAccess: Record<string, UsageReport> = {
+			"oat-1": withFable(baseReport("a@example.com"), 0, { resetsAt: blockedUntilMs }),
+			"oat-2": withFable(baseReport("b@example.com"), 0.2, { resetsAt: blockedUntilMs }),
+			"oat-3": withFable(baseReport("c@example.com"), 0.2, { resetsAt: blockedUntilMs }),
+		};
+		vi.spyOn(claudeUsage.claudeUsageProvider, "fetchUsage").mockImplementation(async params => {
+			const access = params.credential.type === "oauth" ? params.credential.accessToken : undefined;
+			return access ? (reportsByAccess[access] ?? null) : null;
+		});
+
+		const key = await storage.getApiKey("anthropic", "session-3", { modelId: "claude-fable-5" });
+
+		expect(key).toBe("oat-1");
+		expect(store.getCredentialBlock?.(1, "anthropic:oauth", "tier:fable")).toBeUndefined();
+	});
+
+	it("does not clear a fresh Fable block from a lagging healthy usage report", async () => {
+		const startNow = Date.now();
+		vi.spyOn(Date, "now").mockReturnValue(startNow);
+		const blockedUntilMs = startNow + 24 * 60 * 60_000;
+		store.upsertCredentialBlock?.({
+			credentialId: 1,
+			providerKey: "anthropic:oauth",
+			blockScope: "tier:fable",
+			blockedUntilMs,
+		});
+		store.reconcileAfter.set(`1\0anthropic:oauth\0tier:fable`, startNow + 5 * 60_000);
+		const reportsByAccess: Record<string, UsageReport> = {
+			"oat-1": withFable(baseReport("a@example.com"), 0, { resetsAt: blockedUntilMs }),
+			"oat-2": withFable(baseReport("b@example.com"), 0.2, { resetsAt: blockedUntilMs }),
+			"oat-3": withFable(baseReport("c@example.com"), 0.2, { resetsAt: blockedUntilMs }),
+		};
+		vi.spyOn(claudeUsage.claudeUsageProvider, "fetchUsage").mockImplementation(async params => {
+			const access = params.credential.type === "oauth" ? params.credential.accessToken : undefined;
+			return access ? (reportsByAccess[access] ?? null) : null;
+		});
+
+		const key = await storage.getApiKey("anthropic", "session-3", { modelId: "claude-fable-5" });
+
+		expect(key).toBe("oat-2");
+		expect(store.getCredentialBlock?.(1, "anthropic:oauth", "tier:fable")).toBe(blockedUntilMs);
+	});
+
+	it("keeps a Fable block while the scoped live meter is exhausted", async () => {
+		const startNow = Date.now();
+		vi.spyOn(Date, "now").mockReturnValue(startNow);
+		const blockedUntilMs = startNow + 24 * 60 * 60_000;
+		store.upsertCredentialBlock?.({
+			credentialId: 1,
+			providerKey: "anthropic:oauth",
+			blockScope: "tier:fable",
+			blockedUntilMs,
+		});
+		const reportsByAccess: Record<string, UsageReport> = {
+			"oat-1": withFable(baseReport("a@example.com"), 1, { resetsAt: blockedUntilMs }),
+			"oat-2": withFable(baseReport("b@example.com"), 0.2, { resetsAt: blockedUntilMs }),
+			"oat-3": withFable(baseReport("c@example.com"), 0.2, { resetsAt: blockedUntilMs }),
+		};
+		vi.spyOn(claudeUsage.claudeUsageProvider, "fetchUsage").mockImplementation(async params => {
+			const access = params.credential.type === "oauth" ? params.credential.accessToken : undefined;
+			return access ? (reportsByAccess[access] ?? null) : null;
+		});
+
+		const key = await storage.getApiKey("anthropic", "session-3", { modelId: "claude-fable-5" });
+
+		expect(key).toBe("oat-2");
+		expect(store.getCredentialBlock?.(1, "anthropic:oauth", "tier:fable")).toBe(blockedUntilMs);
+	});
+
+	it("heals the matching broker-sourced Anthropic grant without crossing organizations", async () => {
+		const blockedUntilMs = Date.now() + 24 * 60 * 60_000;
+		store.upsertCredentialBlock?.({
+			credentialId: 1,
+			providerKey: "anthropic:oauth",
+			blockScope: "tier:fable",
+			blockedUntilMs,
+		});
+		const report = withFable(baseReport("a@example.com"), 0, { resetsAt: blockedUntilMs });
+		report.metadata = {
+			...report.metadata,
+			email: "a@example.com",
+			accountId: "account-1",
+			orgId: "org-1",
+		};
+		store.fetchUsageReports = async () => [report];
+
+		await storage.fetchUsageReports();
+
+		expect(store.getCredentialBlock?.(1, "anthropic:oauth", "tier:fable")).toBeUndefined();
+	});
+
+	it("does not heal an Anthropic block from another organization's usage report", async () => {
+		const blockedUntilMs = Date.now() + 24 * 60 * 60_000;
+		store.upsertCredentialBlock?.({
+			credentialId: 1,
+			providerKey: "anthropic:oauth",
+			blockScope: "tier:fable",
+			blockedUntilMs,
+		});
+		const report = withFable(baseReport("a@example.com"), 0, { resetsAt: blockedUntilMs });
+		report.metadata = {
+			...report.metadata,
+			email: "a@example.com",
+			accountId: "account-1",
+			orgId: "other-org",
+		};
+		store.fetchUsageReports = async () => [report];
+
+		await storage.fetchUsageReports();
+
+		expect(store.getCredentialBlock?.(1, "anthropic:oauth", "tier:fable")).toBe(blockedUntilMs);
+	});
+
+	it("does not heal a requested Anthropic credential from a mismatched organization report", async () => {
+		const blockedUntilMs = Date.now() + 24 * 60 * 60_000;
+		store.upsertCredentialBlock?.({
+			credentialId: 1,
+			providerKey: "anthropic:oauth",
+			blockScope: "tier:fable",
+			blockedUntilMs,
+		});
+		const reportsByAccess: Record<string, UsageReport> = {
+			"oat-1": withFable(baseReport("a@example.com"), 0, { resetsAt: blockedUntilMs }),
+			"oat-2": withFable(baseReport("b@example.com"), 0.2, { resetsAt: blockedUntilMs }),
+			"oat-3": withFable(baseReport("c@example.com"), 0.2, { resetsAt: blockedUntilMs }),
+		};
+		reportsByAccess["oat-1"].metadata = {
+			email: "a@example.com",
+			accountId: "account-1",
+			orgId: "org-2",
+		};
+		vi.spyOn(claudeUsage.claudeUsageProvider, "fetchUsage").mockImplementation(async params => {
+			const access = params.credential.type === "oauth" ? params.credential.accessToken : undefined;
+			return access ? (reportsByAccess[access] ?? null) : null;
+		});
+
+		const key = await storage.getApiKey("anthropic", "session-3", { modelId: "claude-fable-5" });
+
+		expect(key).toBe("oat-2");
+		expect(store.getCredentialBlock?.(1, "anthropic:oauth", "tier:fable")).toBe(blockedUntilMs);
 	});
 
 	it("still blocks OAuth credentials with exhausted shared Anthropic limits", async () => {


### PR DESCRIPTION
Anthropic Fable/Mythos usage-limit blocks currently persist until their stale reset deadline even after a fresh, identity-matched usage report shows the scoped meter recovered. This extends the existing Codex reconciliation path to Anthropic tier scopes, requires account/org identity agreement, retains the freshness delay, and adds focused coverage for healthy, fresh, exhausted, broker-sourced, and cross-organization cases.\n\nFocused verification:\n- bun test test/auth-storage-claude-fable-fallback.test.ts\n- bun test test/auth-storage-codex-selection.test.ts\n- bun run check:types