### PR TITLE
fix(dialect): strip orphan DSML close tags from healed text

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Preserved Anthropic thinking now survives side requests, tool-description drift, turn-scoped reminders, and recoverable prefix mismatches without corrupting the conversation prefix.
+- Fixed the DeepSeek DSML markup healer leaking orphan `</｜DSML｜parameter>`/`</｜DSML｜invoke>` close tags into visible text, which poisoned long-session history and reinforced the model's XML-protocol mimicry until tool calls stopped dispatching ([#10556](https://github.com/can1357/oh-my-pi/issues/10556)).
 
 ## [18.1.2] - 2026-09-01
 

--- a/packages/ai/src/dialect/deepseek.ts
+++ b/packages/ai/src/dialect/deepseek.ts
@@ -34,6 +34,10 @@ const DSML_TOOL_CALLS_OPEN_FULLWIDTH = "<｜DSML｜tool_calls>";
 const DSML_TOOL_CALLS_CLOSE_FULLWIDTH = "</｜DSML｜tool_calls>";
 const DSML_TOOL_CALLS_OPEN_ASCII = "<|DSML|tool_calls>";
 const DSML_TOOL_CALLS_CLOSE_ASCII = "</|DSML|tool_calls>";
+const DSML_INVOKE_CLOSE_FULLWIDTH = "</｜DSML｜invoke>";
+const DSML_INVOKE_CLOSE_ASCII = "</|DSML|invoke>";
+const DSML_PARAMETER_CLOSE_FULLWIDTH = "</｜DSML｜parameter>";
+const DSML_PARAMETER_CLOSE_ASCII = "</|DSML|parameter>";
 
 const CONTROL_TOKENS = [
 	DEEPSEEK_BOS,
@@ -53,6 +57,18 @@ const CONTROL_TOKENS = [
 	DEEPSEEK_TOOL_OUTPUT_END,
 ] as const;
 
+// Bare DSML invoke/parameter close tags with no matching open — leaked into
+// visible text once a session's history is poisoned (issue #10556). Stripped in
+// the `outside` state so they never reach stored assistant content and reinforce
+// the model's XML-protocol mimicry. Inside a well-formed envelope these closers
+// are consumed by the `dsmlInvoke`/`dsmlParam` states and never reach `outside`.
+const DSML_ORPHAN_CLOSE_TOKENS = [
+	DSML_INVOKE_CLOSE_FULLWIDTH,
+	DSML_INVOKE_CLOSE_ASCII,
+	DSML_PARAMETER_CLOSE_FULLWIDTH,
+	DSML_PARAMETER_CLOSE_ASCII,
+] as const;
+
 const OUTSIDE_TOKENS = [
 	DEEPSEEK_TOOL_CALLS_BEGIN,
 	DEEPSEEK_TOOL_CALLS_END,
@@ -63,6 +79,7 @@ const OUTSIDE_TOKENS = [
 	DSML_TOOL_CALLS_OPEN_ASCII,
 	DSML_TOOL_CALLS_CLOSE_FULLWIDTH,
 	DSML_TOOL_CALLS_CLOSE_ASCII,
+	...DSML_ORPHAN_CLOSE_TOKENS,
 	...CONTROL_TOKENS,
 ] as const;
 
@@ -73,8 +90,13 @@ const DSML_SECTION_TOKENS = [
 	"<｜DSML｜invoke",
 	"<|DSML|invoke",
 ] as const;
-const DSML_INVOKE_TOKENS = ["</｜DSML｜invoke>", "</|DSML|invoke>", "<｜DSML｜parameter", "<|DSML|parameter"] as const;
-const DSML_PARAMETER_CLOSE_TOKENS = ["</｜DSML｜parameter>", "</|DSML|parameter>"] as const;
+const DSML_INVOKE_TOKENS = [
+	DSML_INVOKE_CLOSE_FULLWIDTH,
+	DSML_INVOKE_CLOSE_ASCII,
+	"<｜DSML｜parameter",
+	"<|DSML|parameter",
+] as const;
+const DSML_PARAMETER_CLOSE_TOKENS = [DSML_PARAMETER_CLOSE_FULLWIDTH, DSML_PARAMETER_CLOSE_ASCII] as const;
 
 type State =
 	| "outside"
@@ -483,6 +505,9 @@ export class DeepSeekInbandScanner implements InbandScanner {
 		if (this.#buffer.startsWith(THINK_CLOSE)) return THINK_CLOSE;
 		if (this.#buffer.startsWith(DSML_TOOL_CALLS_CLOSE_FULLWIDTH)) return DSML_TOOL_CALLS_CLOSE_FULLWIDTH;
 		if (this.#buffer.startsWith(DSML_TOOL_CALLS_CLOSE_ASCII)) return DSML_TOOL_CALLS_CLOSE_ASCII;
+		for (const token of DSML_ORPHAN_CLOSE_TOKENS) {
+			if (this.#buffer.startsWith(token)) return token;
+		}
 		for (const token of CONTROL_TOKENS) {
 			if (this.#buffer.startsWith(token)) return token;
 		}

--- a/packages/ai/src/dialect/deepseek.ts
+++ b/packages/ai/src/dialect/deepseek.ts
@@ -238,6 +238,11 @@ export class DeepSeekInbandScanner implements InbandScanner {
 				this.#state = "dsmlSection";
 				return;
 			}
+			const orphanClose = this.#matchingOrphanDsmlClose();
+			if (orphanClose) {
+				this.#buffer = this.#buffer.slice(orphanClose.length);
+				continue;
+			}
 			const control = this.#matchingControlToken();
 			if (control) {
 				this.#buffer = this.#buffer.slice(control.length);
@@ -500,14 +505,18 @@ export class DeepSeekInbandScanner implements InbandScanner {
 		return "";
 	}
 
+	#matchingOrphanDsmlClose(): string | undefined {
+		for (const token of DSML_ORPHAN_CLOSE_TOKENS) {
+			if (this.#buffer.startsWith(token)) return token;
+		}
+		return undefined;
+	}
+
 	#matchingControlToken(): string | undefined {
 		if (this.#buffer.startsWith(DEEPSEEK_TOOL_CALLS_END)) return DEEPSEEK_TOOL_CALLS_END;
 		if (this.#buffer.startsWith(THINK_CLOSE)) return THINK_CLOSE;
 		if (this.#buffer.startsWith(DSML_TOOL_CALLS_CLOSE_FULLWIDTH)) return DSML_TOOL_CALLS_CLOSE_FULLWIDTH;
 		if (this.#buffer.startsWith(DSML_TOOL_CALLS_CLOSE_ASCII)) return DSML_TOOL_CALLS_CLOSE_ASCII;
-		for (const token of DSML_ORPHAN_CLOSE_TOKENS) {
-			if (this.#buffer.startsWith(token)) return token;
-		}
 		for (const token of CONTROL_TOKENS) {
 			if (this.#buffer.startsWith(token)) return token;
 		}

--- a/packages/ai/test/stream-markup-healing.test.ts
+++ b/packages/ai/test/stream-markup-healing.test.ts
@@ -444,6 +444,29 @@ describe("StreamMarkupHealing DSML envelope pattern", () => {
 		expect(healing.drainCompleted()).toHaveLength(1);
 	});
 
+	it("strips leaked orphan DSML close tags with no matching open (issue #10556)", () => {
+		// Long-session degradation: the model leaks bare closers into visible text.
+		// They must never survive into stored content, where replay reinforces the
+		// XML-protocol mimicry that drops subsequent tool calls.
+		const healing = new StreamMarkupHealing({ pattern: "dsml" });
+		const leaked = "分析文本。\n\n</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜tool_calls>";
+		const visible = healing.feed(leaked) + healing.flushPending();
+		expect(visible).not.toContain("DSML");
+		expect(visible).not.toContain("｜");
+		expect(visible.startsWith("分析文本。")).toBe(true);
+		expect(healing.drainCompleted()).toHaveLength(0);
+	});
+
+	it("strips orphan DSML closers split across chunk boundaries", () => {
+		const healing = new StreamMarkupHealing({ pattern: "dsml" });
+		const leaked = "text</｜DSML｜parameter></|DSML|invoke>more";
+		let visible = "";
+		for (let i = 0; i < leaked.length; i += 5) visible += healing.feed(leaked.slice(i, i + 5));
+		visible += healing.flushPending();
+		expect(visible).toBe("textmore");
+		expect(healing.drainCompleted()).toHaveLength(0);
+	});
+
 	it("heals a leaked thinking fence while still reconstructing the tool call", () => {
 		// The DSML grammar's xml scanner does not parse thinking; proving the fence
 		// is lifted shows the always-on thinking healer runs alongside it.

--- a/packages/ai/test/stream-markup-healing.test.ts
+++ b/packages/ai/test/stream-markup-healing.test.ts
@@ -451,19 +451,17 @@ describe("StreamMarkupHealing DSML envelope pattern", () => {
 		const healing = new StreamMarkupHealing({ pattern: "dsml" });
 		const leaked = "分析文本。\n\n</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜tool_calls>";
 		const visible = healing.feed(leaked) + healing.flushPending();
-		expect(visible).not.toContain("DSML");
-		expect(visible).not.toContain("｜");
-		expect(visible.startsWith("分析文本。")).toBe(true);
+		expect(visible).toBe("分析文本。\n\n\n\n");
 		expect(healing.drainCompleted()).toHaveLength(0);
 	});
 
-	it("strips orphan DSML closers split across chunk boundaries", () => {
+	it("preserves whitespace after orphan DSML closers split across chunk boundaries", () => {
 		const healing = new StreamMarkupHealing({ pattern: "dsml" });
-		const leaked = "text</｜DSML｜parameter></|DSML|invoke>more";
+		const leaked = "text</｜DSML｜parameter> \n  </|DSML|invoke>\n\tmore";
 		let visible = "";
 		for (let i = 0; i < leaked.length; i += 5) visible += healing.feed(leaked.slice(i, i + 5));
 		visible += healing.flushPending();
-		expect(visible).toBe("textmore");
+		expect(visible).toBe("text \n  \n\tmore");
 		expect(healing.drainCompleted()).toHaveLength(0);
 	});
 


### PR DESCRIPTION
## Repro
In 200+-turn `deepseek-v4-flash` sessions the reporter saw assistant turns degrade to `text` ending in orphan DSML closers (`</｜DSML｜parameter></｜DSML｜invoke></｜DSML｜tool_calls>`) with `tool_calls: null`, after which the session spun without dispatching tools. Feeding the residue through `StreamMarkupHealing({ pattern: "dsml" })` reproduces it:

```
=== orphan closers only ===
visible: "…分析文本…\n\n</｜DSML｜parameter>\n</｜DSML｜invoke>\n"
calls: []
```

The intermediate closers survive into visible text (only `</｜DSML｜tool_calls>` was stripped).

## Cause
`DeepSeekInbandScanner` in `packages/ai/src/dialect/deepseek.ts` recognizes the `<｜DSML｜tool_calls>` envelope open/close tokens in the `outside` state (`OUTSIDE_TOKENS` / `#matchingControlToken()`) but not the intermediate `</｜DSML｜parameter>` and `</｜DSML｜invoke>` closers. When a model leaks bare closers with no matching open — which happens once a long session's history is already poisoned — they fall through as visible text, get stored into the assistant turn, and on replay reinforce the model's XML-protocol mimicry so later turns emit only closer shells and drop the tool call. Same failure class as the previously-fixed #1462/#1463, on a new un-fixed path.

## Fix
- Add fullwidth/ASCII `</｜DSML｜invoke>` and `</｜DSML｜parameter>` close constants and a `DSML_ORPHAN_CLOSE_TOKENS` group in `packages/ai/src/dialect/deepseek.ts`.
- Include them in `OUTSIDE_TOKENS` and `#matchingControlToken()` so leaked orphan closers are stripped in the `outside` state exactly like the existing `</｜DSML｜tool_calls>` closer. Well-formed envelopes consume these closers in the `dsmlInvoke`/`dsmlParam` states and never reach `outside`, so the healthy parse path is unchanged.
- Reuse the new constants in `DSML_INVOKE_TOKENS` / `DSML_PARAMETER_CLOSE_TOKENS`.
- Add regression tests and a CHANGELOG entry.

## Verification
`bun test packages/ai/test/stream-markup-healing.test.ts` (61 pass) plus `packages/ai/test/inband-tools.test.ts` and `dialect-thinking.test.ts` (55 pass) — the new orphan-closer tests fail before the fix and pass after; the full-envelope and chunk-boundary tests confirm no regression to healthy DSML parsing. Fixes #10556