### PR TITLE
fix(discovery): isolate CLAUDE_CONFIG_DIR in test suites

### DIFF
--- a/packages/coding-agent/test/autolearn-discovery.test.ts
+++ b/packages/coding-agent/test/autolearn-discovery.test.ts
@@ -7,6 +7,7 @@ import "@oh-my-pi/pi-coding-agent/discovery";
 import { loadSkills } from "@oh-my-pi/pi-coding-agent/extensibility/skills";
 import { removeWithRetries } from "@oh-my-pi/pi-utils";
 import { getAgentDir, setAgentDir } from "@oh-my-pi/pi-utils/dirs";
+import { restoreEnvValue } from "./helpers/settings-test-state";
 
 async function writeSkill(dir: string, name: string, description: string): Promise<void> {
 	const file = path.join(dir, name, "SKILL.md");
@@ -19,9 +20,13 @@ describe("managed-skills discovery", () => {
 	let tempCwd: string;
 	let managedDir: string;
 	let authoredDir: string;
+	let originalClaudeConfigDir: string | undefined;
 
 	let originalAgentDir: string;
 	beforeEach(async () => {
+		originalClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR;
+		delete process.env.CLAUDE_CONFIG_DIR;
+		delete Bun.env.CLAUDE_CONFIG_DIR;
 		originalAgentDir = getAgentDir();
 		tempHome = await fs.mkdtemp(path.join(os.tmpdir(), "omp-managed-disco-home-"));
 		// cwd MUST live under the fake home so loadSkills' ancestor walk is bounded
@@ -36,6 +41,7 @@ describe("managed-skills discovery", () => {
 	});
 
 	afterEach(async () => {
+		restoreEnvValue("CLAUDE_CONFIG_DIR", originalClaudeConfigDir);
 		spyOn(os, "homedir").mockRestore();
 		setAgentDir(originalAgentDir);
 		await removeWithRetries(tempHome);

--- a/packages/coding-agent/test/discovery/agent-discovery-disabled-providers.test.ts
+++ b/packages/coding-agent/test/discovery/agent-discovery-disabled-providers.test.ts
@@ -11,7 +11,7 @@ import { clearCache as clearFsCache } from "@oh-my-pi/pi-coding-agent/capability
 import { clearClaudePluginRootsCache } from "@oh-my-pi/pi-coding-agent/discovery/helpers";
 import { discoverAgents } from "@oh-my-pi/pi-coding-agent/task/discovery";
 import { removeSyncWithRetries } from "@oh-my-pi/pi-utils";
-
+import { restoreEnvValue } from "../helpers/settings-test-state";
 const PLUGIN_AGENT_MD = [
 	"---",
 	"name: simplifier",
@@ -22,8 +22,12 @@ const PLUGIN_AGENT_MD = [
 
 describe("discoverAgents — claude-plugins disabled provider", () => {
 	let tempHome: string;
+	let originalClaudeConfigDir: string | undefined;
 
 	beforeEach(() => {
+		originalClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR;
+		delete process.env.CLAUDE_CONFIG_DIR;
+		delete Bun.env.CLAUDE_CONFIG_DIR;
 		tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "pi-agent-disco-home-"));
 
 		// Build a fake Claude plugin install with an agents/ subdirectory.
@@ -62,6 +66,7 @@ describe("discoverAgents — claude-plugins disabled provider", () => {
 	afterEach(() => {
 		removeSyncWithRetries(tempHome);
 		// Restore global state so other tests in the suite are not affected.
+		restoreEnvValue("CLAUDE_CONFIG_DIR", originalClaudeConfigDir);
 		enableProvider("claude-plugins");
 		clearFsCache();
 		clearClaudePluginRootsCache();

--- a/packages/coding-agent/test/discovery/agent-plugins.test.ts
+++ b/packages/coding-agent/test/discovery/agent-plugins.test.ts
@@ -17,7 +17,7 @@ import {
 	listClaudePluginRoots,
 } from "@oh-my-pi/pi-coding-agent/discovery/helpers";
 import { getPluginsDir, removeWithRetries } from "@oh-my-pi/pi-utils";
-import "@oh-my-pi/pi-coding-agent/discovery/agent-plugins";
+import { restoreEnvValue } from "../helpers/settings-test-state";
 import "@oh-my-pi/pi-coding-agent/discovery/claude-plugins";
 import type { MCPServer } from "@oh-my-pi/pi-coding-agent/capability/mcp";
 import type { Skill } from "@oh-my-pi/pi-coding-agent/capability/skill";
@@ -255,6 +255,7 @@ describe("parseAgentPluginMcp", () => {
 describe("agent-plugins discovery", () => {
 	let tempDir: string;
 	let pluginPath: string;
+	let originalClaudeConfigDir: string | undefined;
 
 	const writeRegistry = async (installPath: string, id = "std-plugin@market") => {
 		const pluginsDir = path.join(tempDir, ".claude", "plugins");
@@ -295,6 +296,9 @@ describe("agent-plugins discovery", () => {
 		clearClaudePluginRootsCache();
 		clearAgentPluginRootCache();
 		clearFsCache();
+		originalClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR;
+		delete process.env.CLAUDE_CONFIG_DIR;
+		delete Bun.env.CLAUDE_CONFIG_DIR;
 		tempDir = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "agent-plugins-test-")));
 		pluginPath = path.join(tempDir, "plugins", "std-plugin");
 		await fs.mkdir(pluginPath, { recursive: true });
@@ -306,6 +310,7 @@ describe("agent-plugins discovery", () => {
 		clearAgentPluginRootCache();
 		clearFsCache();
 		vi.restoreAllMocks();
+		restoreEnvValue("CLAUDE_CONFIG_DIR", originalClaudeConfigDir);
 		await removeWithRetries(tempDir);
 	});
 

--- a/packages/coding-agent/test/discovery/disabled-extensions.test.ts
+++ b/packages/coding-agent/test/discovery/disabled-extensions.test.ts
@@ -25,9 +25,13 @@ describe("disabledExtensions runtime filtering", () => {
 	let originalOmpProfileEnv: string | undefined;
 	let originalPiProfileEnv: string | undefined;
 	let originalUserProfile: string | undefined;
+	let originalClaudeConfigDir: string | undefined;
 
 	beforeEach(async () => {
 		resetSettingsForTest();
+		originalClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR;
+		delete process.env.CLAUDE_CONFIG_DIR;
+		delete Bun.env.CLAUDE_CONFIG_DIR;
 		originalAgentDirEnv = process.env.PI_CODING_AGENT_DIR;
 		originalOmpProfileEnv = process.env.OMP_PROFILE;
 		originalPiProfileEnv = process.env.PI_PROFILE;
@@ -60,6 +64,7 @@ describe("disabledExtensions runtime filtering", () => {
 		restoreEnvValue("PI_PROFILE", originalPiProfileEnv);
 		restoreEnvValue("PI_CODING_AGENT_DIR", originalAgentDirEnv);
 		restoreEnvValue("USERPROFILE", originalUserProfile);
+		restoreEnvValue("CLAUDE_CONFIG_DIR", originalClaudeConfigDir);
 		__resetDirsFromEnvForTests();
 		await removeWithRetries(tempHomeDir);
 		await removeWithRetries(tempDir);

--- a/packages/coding-agent/test/issue-851-repro.test.ts
+++ b/packages/coding-agent/test/issue-851-repro.test.ts
@@ -6,16 +6,20 @@ import { loadCapability } from "@oh-my-pi/pi-coding-agent/capability";
 import { clearCache as clearFsCache } from "@oh-my-pi/pi-coding-agent/capability/fs";
 import { clearClaudePluginRootsCache } from "@oh-my-pi/pi-coding-agent/discovery/helpers";
 import { removeWithRetries } from "@oh-my-pi/pi-utils";
-import "@oh-my-pi/pi-coding-agent/discovery/claude-plugins";
+import { restoreEnvValue } from "./helpers/settings-test-state";
 import type { MCPServer } from "@oh-my-pi/pi-coding-agent/capability/mcp";
 
 describe("issue-851: claude-plugins loads flat .mcp.json shape", () => {
 	let tempDir: string;
 	let originalHome: string | undefined;
+	let originalClaudeConfigDir: string | undefined;
 
 	beforeEach(async () => {
 		clearClaudePluginRootsCache();
 		clearFsCache();
+		originalClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR;
+		delete process.env.CLAUDE_CONFIG_DIR;
+		delete Bun.env.CLAUDE_CONFIG_DIR;
 		originalHome = process.env.HOME;
 		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "issue-851-"));
 		process.env.HOME = tempDir;
@@ -26,8 +30,8 @@ describe("issue-851: claude-plugins loads flat .mcp.json shape", () => {
 		clearClaudePluginRootsCache();
 		clearFsCache();
 		vi.restoreAllMocks();
-		if (originalHome === undefined) delete process.env.HOME;
-		else process.env.HOME = originalHome;
+		restoreEnvValue("HOME", originalHome);
+		restoreEnvValue("CLAUDE_CONFIG_DIR", originalClaudeConfigDir);
 		await removeWithRetries(tempDir);
 	});
 

--- a/packages/coding-agent/test/skills.test.ts
+++ b/packages/coding-agent/test/skills.test.ts
@@ -13,7 +13,7 @@ import {
 	type Skill,
 } from "@oh-my-pi/pi-coding-agent/extensibility/skills";
 import { removeWithRetries } from "@oh-my-pi/pi-utils";
-
+import { restoreEnvValue } from "./helpers/settings-test-state";
 const fixturesDir = path.resolve(import.meta.dirname, "fixtures/skills");
 const collisionFixturesDir = path.resolve(import.meta.dirname, "fixtures/skills-collision");
 
@@ -185,6 +185,9 @@ describe("skills", () => {
 		});
 
 		it("should keep user Claude skills when project .claude/skills is missing", async () => {
+			const originalClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR;
+			delete process.env.CLAUDE_CONFIG_DIR;
+			delete Bun.env.CLAUDE_CONFIG_DIR;
 			const tempHomeDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-claude-home-"));
 			const tempProjectDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-claude-project-"));
 
@@ -211,6 +214,7 @@ describe("skills", () => {
 				const result = await claudeProvider!.load({ cwd: tempProjectDir, home: tempHomeDir, repoRoot: null });
 				expect(result.items.some(skill => skill.name === "user-only-skill" && skill.level === "user")).toBe(true);
 			} finally {
+				restoreEnvValue("CLAUDE_CONFIG_DIR", originalClaudeConfigDir);
 				await removeWithRetries(tempProjectDir);
 				await removeWithRetries(tempHomeDir);
 			}

--- a/packages/coding-agent/test/tools/lsp-regressions.test.ts
+++ b/packages/coding-agent/test/tools/lsp-regressions.test.ts
@@ -7,6 +7,7 @@ import type { AgentToolResult, RenderResultOptions } from "@oh-my-pi/pi-agent-co
 import { arkToWireSchema } from "@oh-my-pi/pi-ai/utils/schema";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { preloadPluginRoots } from "@oh-my-pi/pi-coding-agent/discovery/helpers";
+import { restoreEnvValue } from "../helpers/settings-test-state";
 import { LspTool } from "@oh-my-pi/pi-coding-agent/lsp";
 import * as lspClient from "@oh-my-pi/pi-coding-agent/lsp/client";
 import * as lspConfig from "@oh-my-pi/pi-coding-agent/lsp/config";
@@ -2295,6 +2296,9 @@ describe("lsp regressions", () => {
 	});
 
 	it("loads config-only marketplace LSP servers from Claude plugin cache", async () => {
+		const originalClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR;
+		delete process.env.CLAUDE_CONFIG_DIR;
+		delete Bun.env.CLAUDE_CONFIG_DIR;
 		const tempDir = TempDir.createSync("@omp-lsp-marketplace-config-");
 		const home = path.join(tempDir.path(), "home");
 		const cwd = path.join(tempDir.path(), "repo");
@@ -2375,6 +2379,7 @@ describe("lsp regressions", () => {
 			expect(config.servers["csharp-ls"]?.rootMarkers).toEqual(["."]);
 			expect(whichSpy).toHaveBeenCalledWith("csharp-ls");
 		} finally {
+			restoreEnvValue("CLAUDE_CONFIG_DIR", originalClaudeConfigDir);
 			await preloadPluginRoots(path.join(tempDir.path(), "empty-home"), cwd);
 			tempDir.removeSync();
 		}


### PR DESCRIPTION
## Problem

When `CLAUDE_CONFIG_DIR` is set in the developer's environment (e.g. `export CLAUDE_CONFIG_DIR=~/.config/claude`), `resolveClaudePaths()` prioritizes the environment variable over any temporary `home` path passed by test runners.

While test files like `claude-plugins.test.ts` and `claude-commands.test.ts` already isolate `process.env.CLAUDE_CONFIG_DIR`, several other test suites omitted this cleanup:
- `skills.test.ts`
- `disabled-extensions.test.ts`
- `agent-plugins.test.ts`
- `agent-discovery-disabled-providers.test.ts`
- `autolearn-discovery.test.ts`
- `issue-851-repro.test.ts`
- `tools/lsp-regressions.test.ts`

As a result, tests in these suites read real files from the host's `$CLAUDE_CONFIG_DIR` (such as user `CLAUDE.md`, skills, and installed plugins) instead of the isolated temporary directories created for the tests.

## Solution

Isolate `process.env.CLAUDE_CONFIG_DIR` and `Bun.env.CLAUDE_CONFIG_DIR` in `beforeEach` / `afterEach` (or per-test `try / finally`) across all affected test suites using `restoreEnvValue`.