### PR TITLE
feat(coding-agent): support tree as a double-Escape action

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 - Disabled hashline editing for Kimi, Mimo, DeepSeek Flash, and Stepfun models for improved stability.
 - Reworked transcript navigation with a fullscreen rewind selector opened by double-Escape, supporting rendered-item navigation, user-turn jumps, branching rewinds, and alternate session-tree branch selection.
+- The `doubleEscapeAction` setting now accepts `tree`, so double-Escape can open the session tree instead of the rewind selector.
 - Updated `/copy` to use the fullscreen transcript selector, allowing users to copy a turn or navigate into nested content such as code, quotes, commands, and tool output.
 
 ### Fixed

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1991,13 +1991,14 @@ export const SETTINGS_SCHEMA = {
 	// Input and startup
 	doubleEscapeAction: {
 		type: "enum",
-		values: ["rewind", "none"] as const,
+		values: ["rewind", "tree", "none"] as const,
 		default: "rewind",
 		ui: {
 			tab: "interaction",
 			group: "Input",
 			label: "Double-Escape Action",
-			description: "Pressing Escape twice with an empty editor opens the transcript rewind selector",
+			description:
+				"What pressing Escape twice with an empty editor does: open the transcript rewind selector, open the session tree, or nothing",
 		},
 	},
 

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -1908,9 +1908,10 @@ export class Settings {
 			raw.steeringMode = raw.queueMode;
 			delete raw.queueMode;
 		}
-		// doubleEscapeAction: "branch"/"tree" -> "rewind". Both legacy actions are
-		// superseded by the in-transcript rewind selector; only "none" survives.
-		if (raw.doubleEscapeAction === "branch" || raw.doubleEscapeAction === "tree") {
+		// doubleEscapeAction: legacy "branch" -> "rewind". The old branch backtrack
+		// was superseded by the in-transcript rewind selector; "tree" survives as a
+		// current action (opens the session tree) beside "rewind" and "none".
+		if (raw.doubleEscapeAction === "branch") {
 			raw.doubleEscapeAction = "rewind";
 		}
 

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -442,12 +442,17 @@ export class InputController {
 				// Esc must not destroy an in-progress draft.
 				this.ctx.lastEscapeTime = 0;
 			} else {
-				// Double-interrupt with empty editor opens the transcript rewind
-				// selector unless disabled.
-				if (settings.get("doubleEscapeAction") !== "none") {
+				// Double-interrupt with an empty editor runs the configured action:
+				// the transcript rewind selector (default) or the session tree.
+				const doubleEscapeAction = settings.get("doubleEscapeAction");
+				if (doubleEscapeAction !== "none") {
 					const now = Date.now();
 					if (now - this.ctx.lastEscapeTime < 500) {
-						this.ctx.showUserMessageSelector();
+						if (doubleEscapeAction === "tree") {
+							this.ctx.showTreeSelector();
+						} else {
+							this.ctx.showUserMessageSelector();
+						}
 						// Forced viewport repaint only: `resetDisplay()` replays the whole
 						// committed transcript (and clears native scrollback on direct
 						// terminals), which blocks on PTY backpressure for tens of seconds

--- a/packages/coding-agent/test/input-controller-escape.test.ts
+++ b/packages/coding-agent/test/input-controller-escape.test.ts
@@ -710,6 +710,24 @@ describe("InputController escape behavior", () => {
 		expect(ctx.showTreeSelector).not.toHaveBeenCalled();
 		expect(spies.resetDisplay).not.toHaveBeenCalled();
 	});
+
+	it("opens the session tree on double-Esc when the action is tree", () => {
+		Settings.instance.override("doubleEscapeAction", "tree");
+		const { ctx, editor, spies } = createContext();
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+		editor.onEscape?.();
+		editor.onEscape?.();
+
+		expect(ctx.showTreeSelector).toHaveBeenCalledTimes(1);
+		expect(ctx.showUserMessageSelector).not.toHaveBeenCalled();
+		// Same forced viewport repaint as the rewind path: without it the
+		// overlay paint is deferred past the escape input grace and double-Esc
+		// reads as dead on long sessions.
+		expect(spies.requestRender).toHaveBeenCalledWith(true);
+		expect(spies.resetDisplay).not.toHaveBeenCalled();
+	});
 	it("preserves typed editor text on Esc without opening selectors or aborting", () => {
 		const { ctx, editor, spies } = createContext();
 		const controller = new InputController(ctx);


### PR DESCRIPTION
## What

Adds `tree` as a first-class `doubleEscapeAction` value. With an empty editor, pressing Escape twice now opens the session tree — the same selector `/tree` opens — in addition to the
existing `rewind` (default) and `none` options.

- `settings-schema.ts`: enum `["rewind", "tree", "none"]`; default stays `rewind`.
- `settings.ts`: legacy migration no longer rewrites `tree` → `rewind`; only the obsolete `branch` value still collapses. Configs already rewritten keep `rewind`; configs still holding
`tree` activate the live action.
- `input-controller.ts`: double-Esc dispatches on the action — `tree` → `showTreeSelector()`, otherwise the rewind selector. The forced viewport repaint (`requestRender(true)`) now
covers both paths: the first Esc arms the input-render grace, so without it the overlay paint defers and double-Esc reads as dead on long sessions.
- Test + CHANGELOG entry added.

## Why

The in-transcript rewind selector superseded the old double-Escape backtrack actions, leaving `none`/`rewind` as the only options and no keyboard path to session-tree navigation —
users had to type `/tree`. This restores direct Esc Esc access to the tree.

## Testing

- `bun test test/input-controller-escape.test.ts` → 36 pass / 0 fail. New case: `tree` action calls `showTreeSelector()` once, never the rewind selector, forces a viewport repaint, and
never calls `resetDisplay()`; `none` and default-`rewind` behavior unchanged.
- `biome check` on all touched files — clean.
- Package typecheck (`tsgo`): no errors in any touched file. One **pre-existing** error on `main` in `test/usage-row-placement.test.ts` (imports `VirtualTerminal`, which
`@oh-my-pi/pi-tui` source no longer exports — committed at `38fe5c4628`) — unrelated to this change, present on the base branch.
- Manual double-Esc run pending locally.