### PR TITLE
feat(coding-agent): add in-session rewind option

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- `/rewind` is now an alias for `/branch`, matching the rewind screen's name; a separate setting can keep rewound user prompts as branches of the current session instead of creating child sessions.
+
 ## [18.1.3] - 2026-09-02
 
 ### Changed

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -2001,6 +2001,29 @@ export const SETTINGS_SCHEMA = {
 				"What pressing Escape twice with an empty editor does: open the transcript rewind selector, open the session tree, or nothing",
 		},
 	},
+	rewindUserMessageAction: {
+		type: "enum",
+		values: ["new-session", "current-session"] as const,
+		default: "new-session",
+		ui: {
+			tab: "interaction",
+			group: "Input",
+			label: "Rewind User Message Action",
+			description: "Where rewinding to a user message goes",
+			options: [
+				{
+					value: "new-session",
+					label: "New Session",
+					description: "Create a child session and restore the selected user message as a draft",
+				},
+				{
+					value: "current-session",
+					label: "Current Session",
+					description: "Rewind within the current session and restore the selected user message as a draft",
+				},
+			],
+		},
+	},
 
 	treeFilterMode: {
 		type: "enum",

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -1332,11 +1332,11 @@ export class SelectorController {
 	}
 
 	/**
-	 * Complete an esc-esc rewind: user-message targets take the branch flow
-	 * (rewind past the prompt, hand its text back as an editor draft); every
-	 * other target lands the leaf on the entry via `navigateTree`. `done`
-	 * closes the fullscreen selector after the transcript is rebuilt so the
-	 * alternate screen never flashes a stale transcript.
+	 * Complete an esc-esc rewind: user-message targets either create a child
+	 * session or use the in-file tree flow, depending on the configured action.
+	 * Every other target lands the leaf on the entry via `navigateTree`.
+	 * `done` closes the fullscreen selector after the transcript is rebuilt so
+	 * the alternate screen never flashes a stale transcript.
 	 */
 	async #rewindFromTranscript(entryId: string, done: () => void): Promise<void> {
 		const entry = this.ctx.sessionManager.getEntry(entryId);
@@ -1344,8 +1344,9 @@ export class SelectorController {
 			done();
 			return;
 		}
+		const userMessageAction = settings.get("rewindUserMessageAction");
 
-		if (entry.message.role === "user") {
+		if (entry.message.role === "user" && userMessageAction === "new-session") {
 			// Branching rewinds to a strict prefix of the rendered transcript:
 			// the selected user message and everything after it are dropped.
 			// Capture the boundary before branch() so the tail can be dropped
@@ -1375,14 +1376,18 @@ export class SelectorController {
 		}
 
 		const realLeafId = this.ctx.sessionManager.getLeafId();
-		if (entryId === realLeafId) {
+		const isCurrentSessionUserTarget = entry.message.role === "user" && userMessageAction === "current-session";
+		if (entryId === realLeafId && !isCurrentSessionUserTarget) {
 			done();
 			this.ctx.showStatus("Already at this point");
 			return;
 		}
 		const treeRewind = this.#treeRewindBoundary(entryId, realLeafId);
 		try {
-			const result = await this.ctx.session.navigateTree(entryId, { summarize: false });
+			const result = await this.ctx.session.navigateTree(entryId, {
+				summarize: false,
+				...(isCurrentSessionUserTarget ? { allowCurrentLeafUserMessage: true } : {}),
+			});
 			if (result.cancelled) {
 				done();
 				this.ctx.showStatus("Navigation cancelled");
@@ -1396,7 +1401,7 @@ export class SelectorController {
 				await this.ctx.renderInitialMessages({ clearTerminalHistory: true });
 			}
 			await this.ctx.reloadTodos();
-			if (result.editorText && !this.ctx.editor.getText().trim()) {
+			if (result.editorText && (isCurrentSessionUserTarget || !this.ctx.editor.getText().trim())) {
 				this.ctx.editor.setDraft(result.editorText, result.editorImages);
 			}
 			done();

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -8991,6 +8991,7 @@ export class AgentSession {
 	 * @param targetId The entry ID to navigate to
 	 * @param options.summarize Whether user wants to summarize abandoned branch
 	 * @param options.customInstructions Custom instructions for summarizer
+	 * @param options.allowCurrentLeafUserMessage Opts into treating a current-leaf user message as an editable rewind target
 	 * @returns Result with editorText/editorImages (if user message) and cancelled status
 	 */
 	async navigateTree(
@@ -8998,6 +8999,12 @@ export class AgentSession {
 		options: {
 			summarize?: boolean;
 			customInstructions?: string;
+			/**
+			 * Allows a current-leaf user message to be treated as an editable
+			 * rewind target. Without this opt-in, navigating to the current user
+			 * leaf remains a no-op for public callers.
+			 */
+			allowCurrentLeafUserMessage?: boolean;
 			/**
 			 * Opts into the two-phase `ask` toolResult re-answer protocol
 			 * (issue #5642): set only by the interactive `/tree` selector, which
@@ -9057,15 +9064,20 @@ export class AgentSession {
 			targetEntry.type === "message" &&
 			targetEntry.message.role === "toolResult" &&
 			targetEntry.message.toolName === "ask";
-
-		// No-op if already at target — except mid-flight through the `ask`
-		// re-answer protocol (issue #5642): a probe or completion call can
-		// legitimately target the *current* leaf (e.g. the user interrupted
-		// right after answering `ask`, before a follow-up assistant message
-		// landed, or another caller navigated straight onto the ask result),
-		// and must still return `reopenAsk` / branch the new answer instead of
-		// silently reporting a no-op (chatgpt-codex review on #5895).
-		if (targetId === oldLeafId && !(options.allowAskReopen && targetIsAskResult)) {
+		const targetIsUserMessage = targetEntry.type === "message" && targetEntry.message.role === "user";
+		// No-op if already at target — except an explicitly opted-in current-leaf
+		// user rewind or mid-flight through the `ask` re-answer protocol (issue
+		// #5642): a probe or completion call can legitimately target the *current*
+		// leaf (e.g. the user interrupted right after answering `ask`, before a
+		// follow-up assistant message landed, or another caller navigated straight
+		// onto the ask result), and must still return `reopenAsk` / branch the new
+		// answer instead of silently reporting a no-op (chatgpt-codex review on
+		// #5895).
+		if (
+			targetId === oldLeafId &&
+			!(targetIsUserMessage && options.allowCurrentLeafUserMessage) &&
+			!(options.allowAskReopen && targetIsAskResult)
+		) {
 			return { cancelled: false };
 		}
 

--- a/packages/coding-agent/src/slash-commands/builtin-session.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-session.ts
@@ -482,8 +482,9 @@ export const BUILTIN_SESSION_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> = [
 	},
 	{
 		name: "branch",
+		aliases: ["rewind"],
 		icon: "branch",
-		description: "Create a new branch from a previous message",
+		description: "Open the fullscreen rewind selector",
 		handleTui: (_command, runtime) => {
 			runtime.ctx.showUserMessageSelector();
 			runtime.ctx.editor.setText("");

--- a/packages/coding-agent/test/agent-session-branching.test.ts
+++ b/packages/coding-agent/test/agent-session-branching.test.ts
@@ -204,6 +204,64 @@ describe("AgentSession branch title metadata", () => {
 	});
 });
 
+describe("AgentSession current-leaf user navigation", () => {
+	it("keeps current-leaf user navigation a no-op by default", async () => {
+		const ctx = await createTestSession({ inMemory: true });
+		try {
+			ctx.sessionManager.appendMessage({
+				role: "user",
+				content: "Earlier message",
+				timestamp: Date.now(),
+			});
+			ctx.sessionManager.appendMessage(assistantMsg("Earlier response"));
+			const targetId = ctx.sessionManager.appendMessage({
+				role: "user",
+				content: "Current draft",
+				timestamp: Date.now(),
+			});
+
+			expect(ctx.sessionManager.getLeafId()).toBe(targetId);
+
+			const result = await ctx.session.navigateTree(targetId);
+
+			expect(result).toEqual({ cancelled: false });
+			expect(ctx.sessionManager.getLeafId()).toBe(targetId);
+			expect(result.editorText).toBeUndefined();
+		} finally {
+			await ctx.cleanup();
+		}
+	});
+
+	it("moves to the user message parent and restores its draft when opted in", async () => {
+		const ctx = await createTestSession({ inMemory: true });
+		try {
+			ctx.sessionManager.appendMessage({
+				role: "user",
+				content: "Earlier message",
+				timestamp: Date.now(),
+			});
+			const parentId = ctx.sessionManager.appendMessage(assistantMsg("Earlier response"));
+			const targetId = ctx.sessionManager.appendMessage({
+				role: "user",
+				content: "Current draft",
+				timestamp: Date.now(),
+			});
+
+			expect(ctx.sessionManager.getLeafId()).toBe(targetId);
+
+			const result = await ctx.session.navigateTree(targetId, { allowCurrentLeafUserMessage: true });
+
+			expect(result).toMatchObject({
+				editorText: "Current draft",
+				cancelled: false,
+			});
+			expect(ctx.sessionManager.getLeafId()).toBe(parentId);
+		} finally {
+			await ctx.cleanup();
+		}
+	});
+});
+
 describe("AgentSession historical image prompts", () => {
 	it("returns the selected images when branching from a user prompt", async () => {
 		const ctx = await createTestSession({ inMemory: true });

--- a/packages/coding-agent/test/selector-controller-rewind.test.ts
+++ b/packages/coding-agent/test/selector-controller-rewind.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
+import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
+import { KeybindingsManager } from "@oh-my-pi/pi-coding-agent/config/keybindings";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { SelectorController } from "@oh-my-pi/pi-coding-agent/modes/controllers/selector-controller";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
+import type { SessionMessageEntry, SessionTreeNode } from "@oh-my-pi/pi-coding-agent/session/session-entries";
+import { setKeybindings } from "@oh-my-pi/pi-tui";
+
+const ENTER = "\r";
+
+function userEntry(): SessionMessageEntry {
+	return {
+		type: "message",
+		id: "user-1",
+		parentId: "parent-1",
+		timestamp: "2026-01-01T00:00:00.000Z",
+		message: { role: "user", content: "change this prompt", timestamp: 1 } as AgentMessage,
+	};
+}
+
+function createHarness({ currentLeaf = false, editorText = "" }: { currentLeaf?: boolean; editorText?: string } = {}) {
+	const entry = userEntry();
+	const branch = vi.fn(async () => ({
+		selectedText: "change this prompt",
+		selectedImages: [],
+		cancelled: false,
+	}));
+	const navigateTree = vi.fn(async () => ({
+		editorText: "change this prompt",
+		cancelled: false,
+	}));
+	const setDraft = vi.fn();
+	const navigationFinished = Promise.withResolvers<void>();
+	const showStatus = vi.fn((message: string) => {
+		if (message === "Branched to new session" || message === "Rewound to selected point") {
+			navigationFinished.resolve();
+		}
+	});
+	let selector: { handleInput(data: string): void; dispose(): void } | undefined;
+	const tree: SessionTreeNode[] = [{ entry, children: [] }];
+	const ctx = {
+		sessionManager: {
+			getBranch: () => [entry],
+			getEntry: (id: string) => (id === entry.id ? entry : undefined),
+			getTree: () => tree,
+			getCwd: () => "/tmp",
+			getLeafId: () => (currentLeaf ? entry.id : "later-entry"),
+		},
+		session: {
+			getToolByName: () => undefined,
+			hasBuiltInTool: () => false,
+			extensionRunner: undefined,
+			branch,
+			navigateTree,
+		},
+		ui: {
+			requestRender: vi.fn(),
+			setFocus: vi.fn(),
+			showOverlay: vi.fn((component: typeof selector) => {
+				selector = component;
+				return { hide: vi.fn() };
+			}),
+		},
+		editor: { getText: () => editorText, setDraft },
+		editorContainer: { children: [] },
+		activeDialog: undefined,
+		renderInitialMessages: vi.fn(async () => {}),
+		reloadTodos: vi.fn(async () => {}),
+		truncateTranscriptFromMessage: vi.fn(() => false),
+		showStatus,
+		showError: vi.fn(),
+		effectiveHideThinkingBlock: false,
+		proseOnlyThinking: false,
+	} as unknown as InteractiveModeContext;
+	const controller = new SelectorController(ctx);
+	controller.showUserMessageSelector();
+	if (!selector) throw new Error("Expected rewind selector overlay");
+	return { branch, navigateTree, navigationFinished: navigationFinished.promise, selector, setDraft };
+}
+
+describe("SelectorController rewind user-message behavior", () => {
+	beforeAll(async () => {
+		await initTheme();
+	});
+	beforeEach(async () => {
+		await Settings.init({ inMemory: true, cwd: process.cwd() });
+		setKeybindings(KeybindingsManager.inMemory());
+	});
+	afterEach(() => {
+		setKeybindings(KeybindingsManager.inMemory());
+		resetSettingsForTest();
+		vi.restoreAllMocks();
+	});
+
+	it("keeps the existing new-session behavior by default", async () => {
+		const harness = createHarness();
+		harness.selector.handleInput(ENTER);
+		await harness.navigationFinished;
+
+		expect(harness.branch).toHaveBeenCalledWith("user-1");
+		expect(harness.navigateTree).not.toHaveBeenCalled();
+	});
+
+	it("rewinds user prompts into the current session when configured", async () => {
+		Settings.instance.set("doubleEscapeAction", "tree");
+		Settings.instance.set("rewindUserMessageAction", "current-session");
+		const harness = createHarness();
+		harness.selector.handleInput(ENTER);
+		await harness.navigationFinished;
+
+		expect(harness.navigateTree).toHaveBeenCalledWith("user-1", {
+			summarize: false,
+			allowCurrentLeafUserMessage: true,
+		});
+		expect(harness.branch).not.toHaveBeenCalled();
+	});
+
+	it("replaces an existing editor draft with the selected user prompt", async () => {
+		Settings.instance.set("rewindUserMessageAction", "current-session");
+		const harness = createHarness({ editorText: "unrelated draft" });
+		harness.selector.handleInput(ENTER);
+		await harness.navigationFinished;
+
+		expect(harness.navigateTree).toHaveBeenCalledWith("user-1", {
+			summarize: false,
+			allowCurrentLeafUserMessage: true,
+		});
+		expect(harness.setDraft).toHaveBeenCalledWith("change this prompt", undefined);
+	});
+
+	it("allows a current-session rewind when the user prompt is the current leaf", async () => {
+		Settings.instance.set("rewindUserMessageAction", "current-session");
+		const harness = createHarness({ currentLeaf: true });
+		harness.selector.handleInput(ENTER);
+		await harness.navigationFinished;
+
+		expect(harness.navigateTree).toHaveBeenCalledWith("user-1", {
+			summarize: false,
+			allowCurrentLeafUserMessage: true,
+		});
+		expect(harness.branch).not.toHaveBeenCalled();
+		expect(harness.setDraft).toHaveBeenCalledWith("change this prompt", undefined);
+	});
+});

--- a/packages/coding-agent/test/slash-commands/branch.test.ts
+++ b/packages/coding-agent/test/slash-commands/branch.test.ts
@@ -1,7 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
-import { executeBuiltinSlashCommand } from "@oh-my-pi/pi-coding-agent/slash-commands/builtin-registry";
+import {
+	executeBuiltinSlashCommand,
+	lookupBuiltinSlashCommand,
+} from "@oh-my-pi/pi-coding-agent/slash-commands/builtin-registry";
 
 beforeEach(async () => {
 	resetSettingsForTest();
@@ -12,23 +15,40 @@ afterEach(() => {
 	resetSettingsForTest();
 });
 
-describe("/branch slash command", () => {
-	it("opens the branch selector even when double-Escape is disabled", async () => {
-		const showTreeSelector = vi.fn();
-		const showUserMessageSelector = vi.fn();
-		const setText = vi.fn();
-		const runtime = {
-			ctx: {
-				collabGuest: false,
-				showTreeSelector,
-				showUserMessageSelector,
-				editor: { setText },
-			} as unknown as InteractiveModeContext,
-		};
+function createRuntime() {
+	const showTreeSelector = vi.fn();
+	const showUserMessageSelector = vi.fn();
+	const setText = vi.fn();
+	const runtime = {
+		ctx: {
+			collabGuest: false,
+			showTreeSelector,
+			showUserMessageSelector,
+			editor: { setText },
+		} as unknown as InteractiveModeContext,
+	};
+	return { runtime, setText, showTreeSelector, showUserMessageSelector };
+}
 
+describe("/branch slash command", () => {
+	for (const doubleEscapeAction of ["tree", "none"] as const) {
+		it(`opens the fullscreen rewind selector when double-Escape is configured as ${doubleEscapeAction}`, async () => {
+			Settings.instance.override("doubleEscapeAction", doubleEscapeAction);
+			const { runtime, setText, showTreeSelector, showUserMessageSelector } = createRuntime();
+
+			expect(await executeBuiltinSlashCommand("/rewind", runtime)).toBe(true);
+			expect(showUserMessageSelector).toHaveBeenCalledTimes(1);
+			expect(showTreeSelector).not.toHaveBeenCalled();
+			expect(setText).toHaveBeenCalledWith("");
+		});
+	}
+
+	it("keeps /branch as the canonical command", async () => {
+		const { runtime, setText, showUserMessageSelector } = createRuntime();
+
+		expect(lookupBuiltinSlashCommand("rewind")?.name).toBe("branch");
 		expect(await executeBuiltinSlashCommand("/branch", runtime)).toBe(true);
 		expect(showUserMessageSelector).toHaveBeenCalledTimes(1);
-		expect(showTreeSelector).not.toHaveBeenCalled();
 		expect(setText).toHaveBeenCalledWith("");
 	});
 });


### PR DESCRIPTION
## Summary

- add an independent **Rewind User Message Action** setting for choosing child-session or current-session branches
- add `/rewind` as an alias for `/branch`, matching the fullscreen rewind screen's name
- preserve the separate Double-Escape Action choice between rewind, session tree, and disabled
- allow same-session rewinds when the selected user prompt is itself the current leaf, without changing `navigateTree()` behavior for other callers
- replace any pre-existing editor draft with the selected prompt after a current-session user-message rewind

## Verification

- `bun test test/selector-controller-rewind.test.ts test/agent-session-branching.test.ts test/slash-commands/branch.test.ts test/input-controller-escape.test.ts test/rewind-selector.test.ts test/agent-session-tree-navigation.test.ts` in `packages/coding-agent` — 57 passed, 13 skipped
- `bun run check` in `packages/coding-agent`
- LSP diagnostics clean for all changed TypeScript files
