### PR TITLE
fix(mcp): retry transient startup handshake timeouts

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- MCP servers now retry after transient startup handshake timeouts instead of remaining disconnected for the session ([#10478](https://github.com/can1357/oh-my-pi/issues/10478)).
+
 ## [18.1.0] - 2026-09-01
 
 ### Added

--- a/packages/coding-agent/src/mcp/client.ts
+++ b/packages/coding-agent/src/mcp/client.ts
@@ -129,6 +129,19 @@ async function initializeConnection(
 	return result;
 }
 
+/** Identifies an MCP server whose initial handshake exceeded its configured timeout. */
+export class MCPConnectionTimeoutError extends Error {
+	readonly serverName: string;
+	readonly timeoutMs: number;
+
+	constructor(serverName: string, timeoutMs: number) {
+		super(`Connection to MCP server "${serverName}" timed out after ${describeMCPTimeout(timeoutMs)}`);
+		this.name = "MCPConnectionTimeoutError";
+		this.serverName = serverName;
+		this.timeoutMs = timeoutMs;
+	}
+}
+
 /**
  * Connect to an MCP server.
  * Has a 30 second timeout by default to prevent blocking startup.
@@ -144,6 +157,7 @@ export async function connectToServer(
 	},
 ): Promise<MCPServerConnection> {
 	const timeoutMs = resolveMCPTimeoutMs(config.timeout);
+	const timeoutError = new MCPConnectionTimeoutError(name, timeoutMs);
 	let transport: MCPTransport | undefined;
 
 	const connect = async (): Promise<MCPServerConnection> => {
@@ -187,12 +201,7 @@ export async function connectToServer(
 		if (!isMCPTimeoutEnabled(timeoutMs)) {
 			return await connect();
 		}
-		return await withTimeout(
-			connect(),
-			timeoutMs,
-			`Connection to MCP server "${name}" timed out after ${describeMCPTimeout(timeoutMs)}`,
-			options?.signal,
-		);
+		return await withTimeout(connect(), timeoutMs, timeoutError, options?.signal);
 	} catch (error) {
 		// If withTimeout rejected (timeout/abort) while connect() was still pending,
 		// the transport may be alive with an open SSE listener. Close it.

--- a/packages/coding-agent/src/mcp/manager.ts
+++ b/packages/coding-agent/src/mcp/manager.ts
@@ -602,7 +602,7 @@ export class MCPManager {
 					// network interruption).
 					connection.transport.onClose = () => {
 						logger.debug("MCP transport lost, triggering reconnect", { path: `mcp:${name}` });
-						this.#emitConnectionStatus({ type: "connecting", serverNames: [name] });
+						this.#emitConnectionStatus({ type: "reconnecting", serverName: name });
 						void this.reconnectServer(name);
 					};
 
@@ -660,7 +660,7 @@ export class MCPManager {
 						logger.error("MCP tool load failed", { path: `mcp:${name}`, error: message });
 					}
 					if (error instanceof MCPConnectionTimeoutError) {
-						notify({ type: "connecting", serverNames: [name] });
+						notify({ type: "reconnecting", serverName: name });
 						void this.reconnectServer(name);
 					}
 				});
@@ -1232,7 +1232,7 @@ export class MCPManager {
 		}
 		connection.transport.onClose = () => {
 			logger.debug("MCP transport lost, triggering reconnect", { path: `mcp:${name}` });
-			this.#emitConnectionStatus({ type: "connecting", serverNames: [name] });
+			this.#emitConnectionStatus({ type: "reconnecting", serverName: name });
 			void this.reconnectServer(name);
 		};
 		try {

--- a/packages/coding-agent/src/mcp/manager.ts
+++ b/packages/coding-agent/src/mcp/manager.ts
@@ -661,7 +661,16 @@ export class MCPManager {
 					}
 					if (error instanceof MCPConnectionTimeoutError) {
 						notify({ type: "reconnecting", serverName: name });
-						void this.reconnectServer(name);
+						const stopForwarding = onStatus
+							? this.addConnectionStatusListener(event => {
+									if ((event.type === "connected" || event.type === "failed") && event.serverName === name) {
+										onStatus(event);
+									}
+								})
+							: undefined;
+						const retry = this.reconnectServer(name);
+						if (stopForwarding) void retry.then(stopForwarding, stopForwarding);
+						else void retry;
 					}
 				});
 		}

--- a/packages/coding-agent/src/mcp/manager.ts
+++ b/packages/coding-agent/src/mcp/manager.ts
@@ -13,6 +13,7 @@ import { resolveConfigValue } from "../config/resolve-config-value";
 import type { CustomTool } from "../extensibility/custom-tools/types";
 import type { AuthStorage } from "../session/auth-storage";
 import {
+	MCPConnectionTimeoutError,
 	connectToServer,
 	disconnectServer,
 	getPrompt,
@@ -655,8 +656,13 @@ export class MCPManager {
 					this.#pendingToolLoads.delete(name);
 					const message = error instanceof Error ? error.message : String(error);
 					notify(createMcpStartupFailure(name, message, sources[name]));
-					if (!allowBackgroundLogging || reportedErrors.has(name)) return;
-					logger.error("MCP tool load failed", { path: `mcp:${name}`, error: message });
+					if (allowBackgroundLogging && !reportedErrors.has(name)) {
+						logger.error("MCP tool load failed", { path: `mcp:${name}`, error: message });
+					}
+					if (error instanceof MCPConnectionTimeoutError) {
+						notify({ type: "connecting", serverNames: [name] });
+						void this.reconnectServer(name);
+					}
 				});
 		}
 

--- a/packages/coding-agent/src/mcp/startup-events.ts
+++ b/packages/coding-agent/src/mcp/startup-events.ts
@@ -11,6 +11,7 @@ export type McpConnectionFailure = {
 
 export type McpConnectionStatusEvent =
 	| { type: "connecting"; serverNames: string[] }
+	| { type: "reconnecting"; serverName: string }
 	| { type: "connected"; serverName: string }
 	| ({ type: "failed" } & McpConnectionFailure);
 
@@ -115,6 +116,8 @@ export function isMcpConnectionStatusEvent(data: unknown): data is McpConnection
 	switch (data.type) {
 		case "connecting":
 			return isStringArray(data.serverNames);
+		case "reconnecting":
+			return typeof data.serverName === "string";
 		case "connected":
 			return typeof data.serverName === "string";
 		case "failed":

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -1059,6 +1059,11 @@ export class InteractiveMode implements InteractiveModeContext {
 				this.#trackMcpStatusServer(serverName);
 				this.#mcpPendingServers.add(serverName);
 			}
+		} else if (event.type === "reconnecting") {
+			this.#trackMcpStatusServer(event.serverName);
+			this.#mcpConnectedServers.delete(event.serverName);
+			this.#mcpFailedServers.delete(event.serverName);
+			this.#mcpPendingServers.add(event.serverName);
 		} else if (event.type === "connected") {
 			this.#trackMcpStatusServer(event.serverName);
 			this.#mcpPendingServers.delete(event.serverName);

--- a/packages/coding-agent/test/fixtures/delayed-tool-mcp.ts
+++ b/packages/coding-agent/test/fixtures/delayed-tool-mcp.ts
@@ -1,13 +1,13 @@
 #!/usr/bin/env bun
 /**
  * Test fixture: a well-behaved stdio MCP server that answers `initialize`
- * only after a deliberate delay exceeding `MCPManager`'s `STARTUP_TIMEOUT_MS`
- * (250 ms), then responds normally to `tools/list`.
+ * only after a deliberate delay exceeding `MCPManager`'s
+ * `STARTUP_TIMEOUT_MS` (250 ms), then responds normally to `tools/list`.
  *
- * Models a server that eventually connects successfully but not within the
- * manager's startup race window (`Promise.race([Promise.allSettled(...),
- * delay(STARTUP_TIMEOUT_MS)])`), so its tools only land via the background
- * `#onToolsChanged` path instead of the initial `connectServers` result.
+ * Without arguments every launch delays, exercising late background binding.
+ * With a marker-file argument only the first launch delays; it writes the
+ * marker before waiting so a reconnect responds immediately. This models a
+ * transient startup timeout followed by recovery.
  *
  * Speaks newline-delimited JSON-RPC 2.0 (the wire format of `StdioTransport`):
  * one JSON object per line on stdin, one JSON response per line on stdout.
@@ -52,7 +52,11 @@ function buildResult(method: string): Record<string, unknown> {
 	}
 }
 
-function startServer(): void {
+async function startServer(): Promise<void> {
+	const markerPath = process.argv[2];
+	const delayInitialize = !markerPath || !(await Bun.file(markerPath).exists());
+	if (markerPath && delayInitialize) await Bun.write(markerPath, "");
+
 	const rl = readline.createInterface({ input: process.stdin });
 	rl.on("line", line => {
 		void (async () => {
@@ -65,7 +69,7 @@ function startServer(): void {
 				return;
 			}
 			if (msg.id === undefined || msg.id === null) return;
-			if (msg.method === "initialize") {
+			if (msg.method === "initialize" && delayInitialize) {
 				await Bun.sleep(INITIALIZE_DELAY_MS);
 			}
 			const response = { jsonrpc: "2.0" as const, id: msg.id, result: buildResult(msg.method) };
@@ -76,5 +80,5 @@ function startServer(): void {
 }
 
 if (import.meta.main) {
-	startServer();
+	void startServer();
 }

--- a/packages/coding-agent/test/interactive-mode-mcp-connecting.test.ts
+++ b/packages/coding-agent/test/interactive-mode-mcp-connecting.test.ts
@@ -142,6 +142,37 @@ describe("InteractiveMode MCP connection status", () => {
 		]);
 	});
 
+	it("retries one server without erasing other startup outcomes", () => {
+		const showStatusSpy = vi.spyOn(mode, "showStatus").mockImplementation(() => {});
+
+		eventBus.emit(MCP_CONNECTION_STATUS_EVENT_CHANNEL, {
+			type: "connecting",
+			serverNames: ["alpha", "retry", "broken"],
+		} satisfies McpConnectionStatusEvent);
+		eventBus.emit(MCP_CONNECTION_STATUS_EVENT_CHANNEL, {
+			type: "connected",
+			serverName: "alpha",
+		} satisfies McpConnectionStatusEvent);
+		eventBus.emit(MCP_CONNECTION_STATUS_EVENT_CHANNEL, {
+			type: "failed",
+			serverName: "broken",
+			error: "bad config",
+		} satisfies McpConnectionStatusEvent);
+		eventBus.emit(MCP_CONNECTION_STATUS_EVENT_CHANNEL, {
+			type: "failed",
+			serverName: "retry",
+			error: "timed out",
+		} satisfies McpConnectionStatusEvent);
+		eventBus.emit(MCP_CONNECTION_STATUS_EVENT_CHANNEL, {
+			type: "reconnecting",
+			serverName: "retry",
+		} satisfies McpConnectionStatusEvent);
+
+		expect(showStatusSpy).toHaveBeenLastCalledWith(
+			"Connected: alpha. Failed: broken: bad config. Still connecting: retry…",
+		);
+	});
+
 	it("rejects a malformed mcp:connection-status payload via the guard instead of letting it throw", () => {
 		const showStatusSpy = vi.spyOn(mode, "showStatus").mockImplementation(() => {});
 		const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});

--- a/packages/coding-agent/test/mcp-incremental-connect.test.ts
+++ b/packages/coding-agent/test/mcp-incremental-connect.test.ts
@@ -112,7 +112,7 @@ describe("MCP incremental connectServers", () => {
 		const connection = manager.getConnection(SERVER_A);
 		expect(connection).toBeDefined();
 		connection?.transport.onClose?.();
-		expect(events.some(event => event.type === "connecting" && event.name === SERVER_A)).toBe(true);
+		expect(events.some(event => event.type === "reconnecting" && event.name === SERVER_A)).toBe(true);
 		stop();
 	}, 20_000);
 });

--- a/packages/coding-agent/test/mcp-manager-initial-connection-cleanup.test.ts
+++ b/packages/coding-agent/test/mcp-manager-initial-connection-cleanup.test.ts
@@ -95,6 +95,7 @@ describe("MCPManager initial connection ownership", () => {
 		const manager = new MCPManager(workDir);
 		const rebound = Promise.withResolvers<void>();
 		const statusTypes: string[] = [];
+		const statusSettled = Promise.withResolvers<void>();
 		const marker = path.join(workDir, "first-start");
 		const config: MCPStdioServerConfig = {
 			type: "stdio",
@@ -107,14 +108,17 @@ describe("MCPManager initial connection ownership", () => {
 		});
 
 		try {
-			const result = await manager.connectServers({ server: config }, {}, event => statusTypes.push(event.type));
+			const result = await manager.connectServers({ server: config }, {}, event => {
+				statusTypes.push(event.type);
+				if (event.type === "connected") statusSettled.resolve();
+			});
 			expect(result.errors.get("server")).toBe('Connection to MCP server "server" timed out after 100ms');
 			await rebound.promise;
+			await statusSettled.promise;
 
 			expect(manager.getConnectionStatus("server")).toBe("connected");
 			expect(manager.getTools().map(tool => tool.name)).toEqual([`mcp__server_${DELAYED_TOOL_NAME}`]);
-			expect(statusTypes.filter(type => type === "connecting")).toHaveLength(1);
-			expect(statusTypes).toContain("reconnecting");
+			expect(statusTypes).toEqual(["connecting", "failed", "reconnecting", "connected"]);
 		} finally {
 			await manager.disconnectAll();
 			await removeWithRetries(workDir);

--- a/packages/coding-agent/test/mcp-manager-initial-connection-cleanup.test.ts
+++ b/packages/coding-agent/test/mcp-manager-initial-connection-cleanup.test.ts
@@ -94,6 +94,7 @@ describe("MCPManager initial connection ownership", () => {
 		const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "omp-mcp-initial-recovery-"));
 		const manager = new MCPManager(workDir);
 		const rebound = Promise.withResolvers<void>();
+		const statusTypes: string[] = [];
 		const marker = path.join(workDir, "first-start");
 		const config: MCPStdioServerConfig = {
 			type: "stdio",
@@ -106,12 +107,14 @@ describe("MCPManager initial connection ownership", () => {
 		});
 
 		try {
-			const result = await manager.connectServers({ server: config }, {});
+			const result = await manager.connectServers({ server: config }, {}, event => statusTypes.push(event.type));
 			expect(result.errors.get("server")).toBe('Connection to MCP server "server" timed out after 100ms');
 			await rebound.promise;
 
 			expect(manager.getConnectionStatus("server")).toBe("connected");
 			expect(manager.getTools().map(tool => tool.name)).toEqual([`mcp__server_${DELAYED_TOOL_NAME}`]);
+			expect(statusTypes.filter(type => type === "connecting")).toHaveLength(1);
+			expect(statusTypes).toContain("reconnecting");
 		} finally {
 			await manager.disconnectAll();
 			removeSyncWithRetries(workDir);

--- a/packages/coding-agent/test/mcp-manager-initial-connection-cleanup.test.ts
+++ b/packages/coding-agent/test/mcp-manager-initial-connection-cleanup.test.ts
@@ -1,7 +1,12 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 import * as mcpClient from "@oh-my-pi/pi-coding-agent/mcp/client";
 import { MCPManager } from "@oh-my-pi/pi-coding-agent/mcp/manager";
 import type { MCPServerConnection, MCPStdioServerConfig, MCPTransport } from "@oh-my-pi/pi-coding-agent/mcp/types";
+import { removeSyncWithRetries } from "@oh-my-pi/pi-utils";
+import { TOOL_NAME as DELAYED_TOOL_NAME } from "./fixtures/delayed-tool-mcp";
 
 const CONFIG: MCPStdioServerConfig = {
 	type: "stdio",
@@ -84,6 +89,34 @@ describe("MCPManager initial connection ownership", () => {
 		expect(failed.transport.closeCalls).toBe(1);
 		expect(manager.getConnectedServers()).toEqual([]);
 	});
+
+	it("recovers tools after an initial handshake timeout", async () => {
+		const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "omp-mcp-initial-recovery-"));
+		const manager = new MCPManager(workDir);
+		const rebound = Promise.withResolvers<void>();
+		const marker = path.join(workDir, "first-start");
+		const config: MCPStdioServerConfig = {
+			type: "stdio",
+			command: process.execPath,
+			args: [path.join(import.meta.dir, "fixtures", "delayed-tool-mcp.ts"), marker],
+			timeout: 100,
+		};
+		manager.setOnToolsChanged(tools => {
+			if (tools.some(tool => tool.name === `mcp__server_${DELAYED_TOOL_NAME}`)) rebound.resolve();
+		});
+
+		try {
+			const result = await manager.connectServers({ server: config }, {});
+			expect(result.errors.get("server")).toBe('Connection to MCP server "server" timed out after 100ms');
+			await rebound.promise;
+
+			expect(manager.getConnectionStatus("server")).toBe("connected");
+			expect(manager.getTools().map(tool => tool.name)).toEqual([`mcp__server_${DELAYED_TOOL_NAME}`]);
+		} finally {
+			await manager.disconnectAll();
+			removeSyncWithRetries(workDir);
+		}
+	}, 5_000);
 
 	it("does not close a newer connection while cleaning up a stale result", async () => {
 		const manager = new MCPManager(process.cwd());

--- a/packages/coding-agent/test/mcp-manager-initial-connection-cleanup.test.ts
+++ b/packages/coding-agent/test/mcp-manager-initial-connection-cleanup.test.ts
@@ -1,11 +1,11 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
-import * as fs from "node:fs";
+import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import * as mcpClient from "@oh-my-pi/pi-coding-agent/mcp/client";
 import { MCPManager } from "@oh-my-pi/pi-coding-agent/mcp/manager";
 import type { MCPServerConnection, MCPStdioServerConfig, MCPTransport } from "@oh-my-pi/pi-coding-agent/mcp/types";
-import { removeSyncWithRetries } from "@oh-my-pi/pi-utils";
+import { removeWithRetries } from "@oh-my-pi/pi-utils";
 import { TOOL_NAME as DELAYED_TOOL_NAME } from "./fixtures/delayed-tool-mcp";
 
 const CONFIG: MCPStdioServerConfig = {
@@ -91,7 +91,7 @@ describe("MCPManager initial connection ownership", () => {
 	});
 
 	it("recovers tools after an initial handshake timeout", async () => {
-		const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "omp-mcp-initial-recovery-"));
+		const workDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-mcp-initial-recovery-"));
 		const manager = new MCPManager(workDir);
 		const rebound = Promise.withResolvers<void>();
 		const statusTypes: string[] = [];
@@ -117,7 +117,7 @@ describe("MCPManager initial connection ownership", () => {
 			expect(statusTypes).toContain("reconnecting");
 		} finally {
 			await manager.disconnectAll();
-			removeSyncWithRetries(workDir);
+			await removeWithRetries(workDir);
 		}
 	}, 5_000);
 

--- a/packages/coding-agent/test/mcp-startup-events.test.ts
+++ b/packages/coding-agent/test/mcp-startup-events.test.ts
@@ -139,6 +139,7 @@ describe("mcp/startup-events — connection-status cross-module contract", () =>
 	it("accepts well-formed payloads and rejects malformed ones", () => {
 		expect(isMcpConnectionStatusEvent({ type: "connecting", serverNames: ["a", "b"] })).toBe(true);
 		expect(isMcpConnectionStatusEvent({ type: "connecting", serverNames: [] })).toBe(true);
+		expect(isMcpConnectionStatusEvent({ type: "reconnecting", serverName: "a" })).toBe(true);
 		expect(isMcpConnectionStatusEvent({ type: "connected", serverName: "a" })).toBe(true);
 		expect(isMcpConnectionStatusEvent({ type: "failed", serverName: "a", error: "boom" })).toBe(true);
 		expect(
@@ -156,6 +157,7 @@ describe("mcp/startup-events — connection-status cross-module contract", () =>
 		expect(isMcpConnectionStatusEvent({})).toBe(false);
 		expect(isMcpConnectionStatusEvent({ type: "connecting", serverNames: "alpha" })).toBe(false);
 		expect(isMcpConnectionStatusEvent({ type: "connecting", serverNames: ["ok", 3] })).toBe(false);
+		expect(isMcpConnectionStatusEvent({ type: "reconnecting", serverName: 1 })).toBe(false);
 		expect(isMcpConnectionStatusEvent({ type: "connected", serverName: 1 })).toBe(false);
 		expect(isMcpConnectionStatusEvent({ type: "failed", serverName: "a" })).toBe(false);
 		expect(

--- a/packages/utils/src/async.ts
+++ b/packages/utils/src/async.ts
@@ -1,9 +1,14 @@
 /**
  * Wrap a promise with a timeout and optional abort signal.
- * Rejects with the given message if the timeout fires first.
- * Cleans up all listeners on settlement.
+ * Rejects with the given error or a new error containing the given message if
+ * the timeout fires first. Cleans up all listeners on settlement.
  */
-export function withTimeout<T>(promise: Promise<T>, ms: number, message: string, signal?: AbortSignal): Promise<T> {
+export function withTimeout<T>(
+	promise: Promise<T>,
+	ms: number,
+	timeout: string | Error,
+	signal?: AbortSignal,
+): Promise<T> {
 	if (signal?.aborted) {
 		const reason = signal.reason instanceof Error ? signal.reason : new Error("Aborted");
 		return Promise.reject(reason);
@@ -15,7 +20,7 @@ export function withTimeout<T>(promise: Promise<T>, ms: number, message: string,
 		if (settled) return;
 		settled = true;
 		if (signal) signal.removeEventListener("abort", onAbort);
-		reject(new Error(message));
+		reject(typeof timeout === "string" ? new Error(timeout) : timeout);
 	}, ms);
 
 	const onAbort = () => {


### PR DESCRIPTION
## Repro
Configure a real stdio MCP server whose first `initialize` response exceeds its per-server timeout, then allows a subsequent launch to initialize normally. `cd packages/coding-agent && bun test test/mcp-manager-initial-connection-cleanup.test.ts -t "recovers tools after an initial handshake timeout"` reproduces the old terminal state: the initial timeout leaves the manager disconnected and no tool-refresh callback ever fires.

## Cause
`connectToServer()` in `packages/coding-agent/src/mcp/client.ts` surfaced initial handshake timeouts as generic errors. `MCPManager.connectServers()` in `packages/coding-agent/src/mcp/manager.ts` therefore treated them like permanent startup failures; the existing bounded `reconnectServer()` path was only entered after a previously successful transport closed.

## Fix
- Preserve a typed `MCPConnectionTimeoutError` through the shared `withTimeout()` helper.
- Route only initial handshake timeouts into the existing bounded MCP reconnect/backoff path; protocol, auth, and `tools/list` failures remain terminal.
- Extend the delayed stdio fixture and add a regression proving a first-launch timeout recovers and binds tools on retry.
- Document the restored session behavior in the coding-agent changelog.

## Verification
`cd packages/coding-agent && bun test test/mcp-manager-initial-connection-cleanup.test.ts test/mcp-timeout.test.ts test/mcp-reconnect.test.ts test/mcp-reconnect-storm.test.ts test/mcp-startup-no-block.test.ts test/sdk-mcp-defer.test.ts test/acp-agent.test.ts` — 140 passed, 0 failed. `cd packages/coding-agent && bun check` completed successfully. Pre-publish `bun run fix` and `bun check` also passed.

Fixes #10478