### PR TITLE
fix(stats): theme trace search inputs and checkbox to match dashboard

### DIFF
--- a/packages/stats/CHANGELOG.md
+++ b/packages/stats/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Traces search inputs and checkbox using unthemed browser defaults, and iOS viewport zoom on search focus.
+
 ## [18.1.3] - 2026-09-02
 
 ### Changed

--- a/packages/stats/src/client/styles.css
+++ b/packages/stats/src/client/styles.css
@@ -1509,8 +1509,33 @@
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
   color: var(--text);
+  font-family: inherit;
   font-size: 12px;
   padding: 6px 10px;
+}
+
+/* Prevent iOS from zooming the viewport when a search input receives focus
+   (mirrors the .stats-select coarse-pointer treatment). */
+@media (pointer: coarse) {
+  .stats-trace-input {
+    font-size: 16px;
+  }
+}
+
+/* Native clear button is a dark glyph in WebKit; keep it visible in the dark
+   theme by inverting it (no-op in light). */
+.stats-trace-input::-webkit-search-cancel-button {
+  filter: invert(1);
+}
+
+@media (prefers-color-scheme: light) {
+  :root:not([data-theme]) .stats-trace-input::-webkit-search-cancel-button {
+    filter: none;
+  }
+}
+
+[data-theme="light"] .stats-trace-input::-webkit-search-cancel-button {
+  filter: none;
 }
 
 .stats-trace-input:focus-visible {
@@ -1530,6 +1555,11 @@
   color: var(--muted);
   cursor: pointer;
   user-select: none;
+}
+
+/* Brand-tint the native checkbox instead of leaving the browser default. */
+.stats-trace-check input[type="checkbox"] {
+  accent-color: var(--accent);
 }
 
 .stats-trace-icon-btn {


### PR DESCRIPTION
I reviewed the full diff; it is a CSS-only follow-up to #10393 that themes the
native form controls introduced with the Traces dashboard.

## Problem

The new Traces dashboard (trace visualizer) ships three native controls that escape the dashboard's theme:

- The session filter (TracesRoute) and span search (TraceView) inputs use
  `.stats-trace-input`, which sets colors but omits `font-family: inherit`,
  so the text renders in the browser default font instead of the UI font.
- On touch devices, both search fields inherit the same issue fixed for
  selects in ce4dbc75: iOS Safari auto-zooms the viewport when focusing a
  form control with font-size < 16px.
- The WebKit search-cancel button (×) is a dark glyph — nearly invisible in
  the dark theme once you type.
- The "Compress idle" checkbox has no `accent-color`, so its checked state is
  the browser default instead of the brand accent.

## Fix

- `.stats-trace-input`: add `font-family: inherit`; add a
  `@media (pointer: coarse)` 16px override mirroring the maintainer's
  `.stats-select` treatment (ce4dbc75).
- Invert the `::-webkit-search-cancel-button` glyph in the dark theme
  (default dark, system-light fallback, and explicit `[data-theme="light"]`
  all covered — same three-block pattern as the rest of the file).
- `.stats-trace-check input[type="checkbox"]`: `accent-color: var(--accent)`
  so the checked state follows the theme's brand token in both palettes.

CSS-only change, no behavior change.

## Verification

Ran the dashboard locally (`bun run src/index.ts`, port 3847) against the
rebuilt bundle and exercised the Traces route in a real browser:

- Dark theme: checkbox checked state renders brand pink
  `oklch(0.674 0.23 341)`; typed text in both search fields shows a visible
  inverted × clear button; focus rings are the brand cyan in both themes.
- Light theme (`data-theme="light"`): checkbox follows the light accent
  `oklch(0.62 0.23 341)`, clear button returns to the native dark glyph,
  search surfaces use the light tokens.
- TraceView toolbar: span search and checkbox verified with computed styles
  (`accent-color`, `font-family` resolved to `ui-sans-serif, system-ui, …`).
- `bun run check` (oxlint + oxfmt + both tsconfig type checks) passes in
  `packages/stats`.
