### PR TITLE
fix(launch): answer terminal queries in broker ptys

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Supervised PTY processes now answer terminal status and device-attribute queries instead of hanging before accepting input ([#10573](https://github.com/can1357/oh-my-pi/issues/10573)).
+
 ## [18.1.3] - 2026-09-02
 
 ### Changed

--- a/packages/coding-agent/src/launch/broker.ts
+++ b/packages/coding-agent/src/launch/broker.ts
@@ -4,6 +4,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { Process, type PtyRunResult, PtySession } from "@oh-my-pi/pi-natives";
 import { isEexist, isEnoent, logger, postmortem, procmgr, sanitizeText, setProcessName } from "@oh-my-pi/pi-utils";
+import { Terminal } from "@oh-my-pi/pi-utils/vterm";
 import { hostHasInheritableConsole } from "../eval/py/spawn-options";
 import { truncateHead, truncateHeadBytes, truncateTail, truncateTailBytes } from "../session/streaming-output";
 import { workerEnvFromParent } from "../subprocess/worker-client";
@@ -725,10 +726,26 @@ class DaemonBroker {
 			cols: DAEMON_PTY_COLUMNS,
 			rows: DAEMON_PTY_ROWS,
 		};
+		const terminal = new Terminal({
+			cols: options.cols,
+			rows: options.rows,
+			scrollback: 0,
+		});
+		terminal.onData(data => {
+			if (generation !== record.generation || record.pty !== session) return;
+			try {
+				session.write(data);
+			} catch {
+				// The PTY may exit between parsing its final output and sending the terminal reply.
+			}
+		});
 		const onChunk = (error: Error | null, chunk: string): void => {
 			if (generation !== record.generation) return;
 			if (error) record.log?.append(`PTY output error: ${error.message}\n`);
-			if (chunk) this.#onOutput(record, generation, chunk);
+			if (chunk) {
+				terminal.write(chunk);
+				this.#onOutput(record, generation, chunk);
+			}
 		};
 		const started = Promise.withResolvers<number | undefined>();
 		const onStart = (error: Error | null, pid: number): void => {
@@ -756,16 +773,23 @@ class DaemonBroker {
 			const shell = procmgr.getShellConfig().shell;
 			run = session.start({ command, shell, ...options }, onChunk, onStart);
 		}
-		void run.then(
-			async result => {
-				await this.#onPtyExit(record, generation, result);
-				started.resolve(undefined);
-			},
-			async error => {
-				await this.#settle(record, generation, undefined, error instanceof Error ? error.message : String(error));
-				started.resolve(undefined);
-			},
-		);
+		void run
+			.then(
+				async result => {
+					await this.#onPtyExit(record, generation, result);
+					started.resolve(undefined);
+				},
+				async error => {
+					await this.#settle(
+						record,
+						generation,
+						undefined,
+						error instanceof Error ? error.message : String(error),
+					);
+					started.resolve(undefined);
+				},
+			)
+			.finally(() => terminal.dispose());
 
 		const pid = await started.promise;
 		if (pid !== undefined && generation === record.generation) {

--- a/packages/coding-agent/test/launch/broker-output-snapshot.test.ts
+++ b/packages/coding-agent/test/launch/broker-output-snapshot.test.ts
@@ -17,6 +17,20 @@ function restoreEnv(name: string, value: string | undefined): void {
 	else process.env[name] = value;
 }
 
+function startBroker(projectDir: string, runtimeDir: string): Promise<void> {
+	const previousProjectDir = process.env[DAEMON_PROJECT_DIR_ENV];
+	const previousRuntimeDir = process.env[DAEMON_RUNTIME_DIR_ENV];
+	const previousGrace = process.env[DAEMON_IDLE_GRACE_ENV];
+	process.env[DAEMON_PROJECT_DIR_ENV] = projectDir;
+	process.env[DAEMON_RUNTIME_DIR_ENV] = runtimeDir;
+	process.env[DAEMON_IDLE_GRACE_ENV] = "5000";
+	const broker = startDaemonBrokerFromEnvironment();
+	restoreEnv(DAEMON_PROJECT_DIR_ENV, previousProjectDir);
+	restoreEnv(DAEMON_RUNTIME_DIR_ENV, previousRuntimeDir);
+	restoreEnv(DAEMON_IDLE_GRACE_ENV, previousGrace);
+	return broker;
+}
+
 describe("daemon broker log snapshots", () => {
 	it("returns the cursor captured with the PTY bytes rendered in the response", async () => {
 		using tempDir = TempDir.createSync("@omp-launch-cursor-");
@@ -43,17 +57,8 @@ process.stdin.on("data", () => process.stdout.write("AFTER-SNAPSHOT\\n"));
 			return renderTerminalOutput(output, options);
 		});
 
-		const previousProjectDir = process.env[DAEMON_PROJECT_DIR_ENV];
-		const previousRuntimeDir = process.env[DAEMON_RUNTIME_DIR_ENV];
-		const previousGrace = process.env[DAEMON_IDLE_GRACE_ENV];
 		const previousTitle = process.title;
-		process.env[DAEMON_PROJECT_DIR_ENV] = projectDir;
-		process.env[DAEMON_RUNTIME_DIR_ENV] = runtimeDir;
-		process.env[DAEMON_IDLE_GRACE_ENV] = "5000";
-		const broker = startDaemonBrokerFromEnvironment();
-		restoreEnv(DAEMON_PROJECT_DIR_ENV, previousProjectDir);
-		restoreEnv(DAEMON_RUNTIME_DIR_ENV, previousRuntimeDir);
-		restoreEnv(DAEMON_IDLE_GRACE_ENV, previousGrace);
+		const broker = startBroker(projectDir, runtimeDir);
 
 		try {
 			const started = await client.request({
@@ -121,6 +126,77 @@ process.stdin.on("data", () => process.stdout.write("AFTER-SNAPSHOT\\n"));
 			await broker;
 			setProcessName(previousTitle);
 			vi.restoreAllMocks();
+		}
+	}, 20_000);
+
+	it("answers terminal queries emitted by supervised PTYs", async () => {
+		using tempDir = TempDir.createSync("@omp-launch-terminal-query-");
+		const projectDir = path.join(tempDir.path(), "project");
+		const runtimeDir = path.join(tempDir.path(), "runtime");
+		await fs.mkdir(projectDir);
+		const scriptPath = path.join(projectDir, "terminal-query.ts");
+		await Bun.write(
+			scriptPath,
+			`process.stdin.setRawMode(true);
+process.stdin.setEncoding("utf8");
+let input = "";
+process.stdin.on("data", chunk => {
+	input += chunk;
+	const match = /\\x1b\\[(\\d+);(\\d+)R/.exec(input);
+	if (!match) return;
+	process.stdout.write("DSR:" + match[1] + ":" + match[2] + "\\n");
+	process.exit(0);
+});
+process.stdout.write("READY\\x1b[6n");
+`,
+		);
+
+		const client = await createDaemonBrokerClient(projectDir, { runtimeDir, idleGraceMs: 5_000 });
+		const previousTitle = process.title;
+		const broker = startBroker(projectDir, runtimeDir);
+		try {
+			const started = await client.request({
+				op: "start",
+				spec: {
+					name: "terminal-query",
+					application: process.execPath,
+					args: [scriptPath],
+					env: {},
+					cwd: projectDir,
+					pty: true,
+					restart: "no",
+					persist: false,
+					detached: false,
+				},
+			});
+			if (started.op !== "start") throw new Error("unexpected start result");
+
+			const completed = await client.request({
+				op: "wait",
+				name: "terminal-query",
+				for: "exit",
+				timeoutMs: 1_000,
+			});
+			if (completed.op !== "wait") throw new Error("unexpected wait result");
+			expect(completed.timedOut).toBeFalse();
+			expect(completed.daemon.exitCode).toBe(0);
+
+			const logs = await client.request({
+				op: "logs",
+				name: "terminal-query",
+				lines: 20,
+				head: false,
+				follow: false,
+				timeoutMs: 1_000,
+			});
+			if (logs.op !== "logs") throw new Error("unexpected logs result");
+			expect(logs.text).toContain("DSR:1:6");
+		} finally {
+			await client.request({ op: "stop", name: "terminal-query", timeoutMs: 2_000 }).catch(() => undefined);
+			await client.request({ op: "shutdown" }).catch(() => undefined);
+			client.close();
+			await broker;
+			setProcessName(previousTitle);
 		}
 	}, 20_000);
 });


### PR DESCRIPTION
## Repro

Start a supervised PTY with `hub start` whose child enters raw mode, writes `ESC[6n`, and exits only after receiving `ESC[row;colR`; then run `hub send` with text and Enter. Both sends report success, but before this change `hub describe` continues to show the child alive because no terminal response reaches it.

## Cause

`DaemonBroker.#launchPty` in `packages/coding-agent/src/launch/broker.ts` advertised `TERM=xterm-256color` and fixed dimensions, but sent each PTY output chunk directly to the log without a terminal parser, so DSR and DA queries had no terminal-side responder.

## Fix

- Feed supervised PTY output through the shared headless `Terminal` at the broker's fixed dimensions.
- Write terminal-generated replies back to the same PTY session and dispose the parser when that generation settles.
- Cover a raw-mode DSR probe with a broker integration regression and document the user-visible fix in the changelog.

## Verification

`bun test packages/coding-agent/test/launch/broker-output-snapshot.test.ts` passes (2 tests), `bun run --cwd packages/coding-agent check:types` passes, and the pre-publish `bun check` gate passes.

Fixes #10573