### PR TITLE
fix(ai): heal Qwen3 prefilled-<think> inline reasoning

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed reasoning not showing for locally-hosted Qwen3 models over the `openai-completions` API when the host streams the chain-of-thought inline: Qwen3's chat template prefills the `<think>` opener into the prompt, so the model emits only the closing `</think>`, and omp dumped the entire reasoning into the visible reply. It's now healed back into a thinking block ([#10571](https://github.com/can1357/oh-my-pi/issues/10571)).
+
 ## [18.1.3] - 2026-09-02
 
 ### Fixed

--- a/packages/ai/src/dialect/thinking.ts
+++ b/packages/ai/src/dialect/thinking.ts
@@ -49,6 +49,20 @@ export class ThinkingInbandScanner implements InbandScanner {
 		return this.#consume(false);
 	}
 
+	/**
+	 * Enter thinking mode without a leading open tag, for chat templates that
+	 * prefill the opener into the prompt (Qwen3's `<think>\n` prefix) so the
+	 * model streams only the closing `</think>`. Subsequent {@link feed} content
+	 * is treated as reasoning until that close tag; an unterminated block still
+	 * flushes as thinking. No-op once a block is already open or inside a code
+	 * span/fence, so a genuine leading `<think>` still parses normally.
+	 */
+	beginImpliedThinking(): void {
+		if (this.#closeTag || this.#fenced || this.#codeTicks > 0) return;
+		this.#closeTag = "</think>";
+		this.#thinking = "";
+	}
+
 	flush(): InbandScanEvent[] {
 		const events = this.#consume(true);
 		if (this.#buffer.length === 0) return events;

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -1066,6 +1066,18 @@ const streamOpenAICompletionsOnce = (
 				: undefined;
 			const explicitReasoningDeltasMayBeCumulative = policy.stream.reasoningDeltasMayBeCumulative;
 			let suppressHealedThinking = false;
+			let impliedThinkingSeeded = false;
+			// Qwen3's chat template prefills the `<think>` opener into the prompt,
+			// so hosts that don't split reasoning into a separate field stream only
+			// the closing `</think>` and the in-band healer never sees an opener.
+			// When reasoning is active and no structured reasoning field has arrived,
+			// treat leaked content as reasoning until that close (issue #10571). Gated
+			// by the Qwen preserve-thinking compat fact so field-based hosts (recent
+			// Ollama /v1) and non-Qwen models are unaffected.
+			const impliedThinkingOpenEnabled =
+				streamMarkupHealing !== undefined &&
+				policy.reasoning.enabled &&
+				policy.compat.qwenPreserveThinking === true;
 			let healedToolCallEmitted = false;
 			const emitHealedToolCall = (call: HealedToolCall): void => {
 				finishCurrentBlock(currentBlock);
@@ -1220,6 +1232,14 @@ const streamOpenAICompletionsOnce = (
 							Array.isArray(choice.delta.tool_calls) && choice.delta.tool_calls.length > 0;
 
 						if (streamMarkupHealing) {
+							if (impliedThinkingOpenEnabled && !impliedThinkingSeeded && !suppressHealedThinking) {
+								impliedThinkingSeeded = true;
+								// Skip when the host actually emitted an opening tag — the
+								// normal healer handles a real `<think>…</think>` block.
+								if (!/^\s*<[a-zA-Z]/.test(normalizedDeltaText)) {
+									streamMarkupHealing.beginImpliedThinking();
+								}
+							}
 							const healingEvents = hasStructuredToolCalls
 								? streamMarkupHealing.feedEventsWithoutCalls(normalizedDeltaText)
 								: streamMarkupHealing.feedEvents(normalizedDeltaText);

--- a/packages/ai/src/utils/stream-markup-healing.ts
+++ b/packages/ai/src/utils/stream-markup-healing.ts
@@ -74,6 +74,16 @@ export class StreamMarkupHealing {
 	}
 
 	/**
+	 * Seed implied-open reasoning on the always-on thinking healer. Used by the
+	 * chat-completions parser for Qwen3-style chat templates that prefill the
+	 * `<think>` opener into the prompt, so the model streams only the closing
+	 * `</think>`. See {@link ThinkingInbandScanner.beginImpliedThinking}.
+	 */
+	beginImpliedThinking(): void {
+		this.#thinkingScanner.beginImpliedThinking();
+	}
+
+	/**
 	 * Feed a chunk and return visible text only. Reconstructed tool calls are
 	 * stored for {@link drainCompleted}; thinking blocks are intentionally not
 	 * returned by this compatibility helper. Use {@link feedEvents} when the caller

--- a/packages/ai/test/stream-markup-healing.test.ts
+++ b/packages/ai/test/stream-markup-healing.test.ts
@@ -259,6 +259,112 @@ describe("openai-completions leaked thinking healing", () => {
 	});
 });
 
+describe("openai-completions implied-open reasoning (Qwen3 prefilled <think>)", () => {
+	// Qwen3's chat template prefills the `<think>` opener into the prompt, so a
+	// host that streams reasoning inline (not in a `reasoning` field) emits only
+	// the closing `</think>`. The healer must treat the leaked chain-of-thought
+	// as reasoning instead of dumping it into the visible reply (issue #10571).
+	function qwenLocalModel(): Model<"openai-completions"> {
+		return buildModel({
+			id: "qwen3.8-27b-q4:latest",
+			name: "qwen3.8-27b-q4",
+			api: "openai-completions",
+			provider: "localai",
+			baseUrl: "http://localhost:11434/v1",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 262_144,
+			maxTokens: 16_384,
+			compat: { supportsReasoningEffort: true },
+		});
+	}
+
+	async function runContent(
+		contents: string[],
+		options: { reasoning?: "minimal" | "low" | "medium" | "high" | "xhigh" | "max"; disableReasoning?: boolean } = {},
+	): Promise<{ thinking: string; text: string }> {
+		const model = qwenLocalModel();
+		const fetchMock = mockFetch([
+			...contents.map(content => chunk(model.id, { content })),
+			chunk(model.id, {}, "stop"),
+			"[DONE]",
+		]);
+		const result = await streamOpenAICompletions(model, baseContext(), {
+			apiKey: "test",
+			reasoning: options.reasoning,
+			disableReasoning: options.disableReasoning,
+			fetch: fetchMock,
+		}).result();
+		const thinking = result.content
+			.filter((b): b is ThinkingContent => b.type === "thinking")
+			.map(b => b.thinking)
+			.join("");
+		const text = result.content
+			.filter((b): b is TextContent => b.type === "text")
+			.map(b => b.text)
+			.join("");
+		return { thinking, text };
+	}
+
+	it("lifts inline reasoning that streams only a closing </think> into a thinking block", async () => {
+		const { thinking, text } = await runContent(["Let me think. ", "2 plus 2.\n</think>\n\n", "The answer is 4."], {
+			reasoning: "low",
+		});
+		expect(thinking).toContain("Let me think. 2 plus 2.");
+		expect(text).not.toContain("</think>");
+		expect(text.trim()).toBe("The answer is 4.");
+	});
+
+	it("still parses a genuine <think> opener normally", async () => {
+		const { thinking, text } = await runContent(["<think>real reasoning</think>Answer."], { reasoning: "low" });
+		expect(thinking).toBe("real reasoning");
+		expect(text).toBe("Answer.");
+	});
+
+	it("leaves the reply as visible text when reasoning is disabled", async () => {
+		const { thinking, text } = await runContent(["Just the answer, no think tag."], { disableReasoning: true });
+		expect(thinking).toBe("");
+		expect(text).toBe("Just the answer, no think tag.");
+	});
+
+	it("does not consume the answer as reasoning when a structured reasoning field is present", async () => {
+		const model = qwenLocalModel();
+		const fetchMock = mockFetch([
+			chunk(model.id, { reasoning_content: "field reasoning" }),
+			chunk(model.id, { content: "Plain answer with no think tag." }),
+			chunk(model.id, {}, "stop"),
+			"[DONE]",
+		]);
+		const result = await streamOpenAICompletions(model, baseContext(), {
+			apiKey: "test",
+			reasoning: "low",
+			fetch: fetchMock,
+		}).result();
+		const thinking = result.content
+			.filter((b): b is ThinkingContent => b.type === "thinking")
+			.map(b => b.thinking)
+			.join("");
+		const text = result.content
+			.filter((b): b is TextContent => b.type === "text")
+			.map(b => b.text)
+			.join("");
+		expect(thinking).toBe("field reasoning");
+		expect(text).toBe("Plain answer with no think tag.");
+	});
+
+	it("beginImpliedThinking captures reasoning until the first close tag", () => {
+		const scanner = new ThinkingInbandScanner();
+		scanner.beginImpliedThinking();
+		const events: InbandScanEvent[] = [...scanner.feed("reasoning here\n</think>\nanswer"), ...scanner.flush()];
+		const thinking = events.map(e => (e.type === "thinkingDelta" ? e.delta : "")).join("");
+		const text = events.map(e => (e.type === "text" ? e.text : "")).join("");
+		expect(thinking).toBe("reasoning here\n");
+		expect(text).toBe("\nanswer");
+		expect(events.filter(e => e.type === "thinkingEnd")).toHaveLength(1);
+	});
+});
+
 describe("official OpenAI leaked thinking healing exemption", () => {
 	// The official OpenAI endpoint returns structured reasoning and never leaks
 	// fences, so neither the provider-local healer nor the central


### PR DESCRIPTION
## Repro
A locally-hosted Qwen3 model configured over the `openai-completions` API (`reasoning: true`, `thinking.mode: effort`) shows no thinking. Driving `streamOpenAICompletions` with the reporter's model config against realistic wire shapes: the request side is correct (omp sends `reasoning_effort` + `chat_template_kwargs.preserve_thinking`), and reasoning delivered in a `delta.reasoning`/`reasoning_content` field already renders as a thinking block. But when the reasoning is streamed *inline*, nothing surfaces:

```
content: "Let me think. 2 plus 2.\n</think>\n\nThe answer is 4."
  -> [{type:"text", text:"Let me think. 2 plus 2.\n</think>\n\nThe answer is 4."}]   // reasoning lost, stray </think> leaks
```

Qwen3's chat template prefills the `<think>\n` opener into the prompt, so the model streams only the closing `</think>`. (opencode shows reasoning for the same backend because it treats output as reasoning until the first close tag.)

## Cause
`ThinkingInbandScanner.scanVisible` (`packages/ai/src/dialect/thinking.ts`) starts a thinking block only when it finds an *opening* tag. A stream that begins mid-reasoning — no opener, only a closing `</think>` — is walked as plain visible text, so the openai-completions healer (`packages/ai/src/providers/openai-completions.ts`) emits the whole chain-of-thought as answer text and leaks the stray close tag. There was no "implied-open / reasoning-until-first-close" mode.

## Fix
- `ThinkingInbandScanner.beginImpliedThinking()` — enter thinking mode without a leading open tag (seeks `</think>`); no-op inside an open block or a code span/fence, and unterminated blocks still flush as thinking.
- `StreamMarkupHealing.beginImpliedThinking()` — delegate onto the always-on thinking healer.
- openai-completions parser seeds it on the first content delta, gated on the `qwenPreserveThinking` compat fact (a KDL-derived Qwen3 lineage truth) **plus** an active reasoning request **and** no structured reasoning field seen yet, and skips it when the host actually emitted an opener. This keeps field-based hosts (recent Ollama `/v1`, vLLM) and non-Qwen models untouched — no model-identity string matching in TS.

## Verification
`bun test packages/ai/test/stream-markup-healing.test.ts packages/ai/test/dialect-thinking.test.ts` (105 pass) plus the reasoning/disable suites (127 pass). New regression tests cover: inline prefilled-opener reasoning lifted into a thinking block; a genuine `<think>` opener still parsed normally; reasoning-disabled replies staying visible text; a structured reasoning field not letting implied-open consume the answer; and the scanner primitive. `bun check` passes. The one unrelated full-suite failure (`proxy.test.ts` env-var normalization) reproduces independently of this diff and passes in isolation. Fixes #10571