### PR TITLE
perf(read): batch known targets to cut round trips

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- Known local and internal Read targets now share one semicolon-delimited call while HTTP URLs stay separate.
+- Read batches known local, file-URL, and non-MCP internal targets while keeping HTTP and opaque MCP resources separate.
 
 ## [18.1.3] - 2026-09-02
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Known local and internal Read targets now share one semicolon-delimited call while HTTP URLs stay separate.
+
 ## [18.1.3] - 2026-09-02
 
 ### Changed

--- a/packages/coding-agent/src/internal-urls/mcp-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/mcp-protocol.ts
@@ -24,7 +24,7 @@ function extractResourceUri(url: InternalUrl): string {
 	const scheme = url.protocol.replace(/:$/, "").toLowerCase();
 	if (scheme !== "mcp") {
 		// Server-advertised native URI (hierarchical or opaque). Preserve the
-		// input byte-for-byte: `resolveTargetServer` matches by exact string
+		// input byte-for-byte: `resolveConcreteTargetServer` matches by exact string
 		// equality, so e.g. `catalog://root/` must keep its trailing slash.
 		return url.rawHref ?? url.href;
 	}
@@ -40,14 +40,18 @@ function extractResourceUri(url: InternalUrl): string {
 	return uri;
 }
 
-function resolveTargetServer(mcpManager: MCPManager, uri: string): string | undefined {
-	const servers = mcpManager.getConnectedServers();
-	for (const name of servers) {
+function resolveConcreteTargetServer(mcpManager: MCPManager, uri: string): string | undefined {
+	for (const name of mcpManager.getConnectedServers()) {
 		const serverResources = mcpManager.getServerResources(name);
-		if (serverResources?.resources.some(r => r.uri === uri)) {
-			return name;
-		}
+		if (serverResources?.resources.some(resource => resource.uri === uri)) return name;
 	}
+	return undefined;
+}
+
+function resolveTargetServer(mcpManager: MCPManager, uri: string): string | undefined {
+	const concreteTarget = resolveConcreteTargetServer(mcpManager, uri);
+	if (concreteTarget) return concreteTarget;
+	const servers = mcpManager.getConnectedServers();
 
 	let bestTemplateMatch:
 		| {
@@ -90,6 +94,26 @@ function resolveTargetServer(mcpManager: MCPManager, uri: string): string | unde
 	}
 
 	return bestTemplateMatch?.serverName;
+}
+
+/**
+ * Whether an advertised concrete MCP resource exactly owns this URL.
+ *
+ * Template matches are deliberately excluded: a broad template can also match
+ * a semicolon-joined batch, but only a concrete URI proves the semicolon is
+ * resource data rather than the Read batch delimiter.
+ */
+export async function hasExactMcpResource(url: InternalUrl): Promise<boolean> {
+	const mcpManager = MCPManager.instance();
+	if (!mcpManager) return false;
+
+	const uri = extractResourceUri(url);
+	let targetServer = resolveConcreteTargetServer(mcpManager, uri);
+	if (!targetServer) {
+		await Promise.allSettled(mcpManager.getConnectedServers().map(name => mcpManager.ensureServerResources(name)));
+		targetServer = resolveConcreteTargetServer(mcpManager, uri);
+	}
+	return targetServer !== undefined;
 }
 
 function formatAvailableResources(mcpManager: MCPManager): string {

--- a/packages/coding-agent/src/internal-urls/mcp-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/mcp-protocol.ts
@@ -7,18 +7,25 @@ function escapeRegex(text: string): string {
 	return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-function getUriTemplateMatchScore(
-	uri: string,
-	uriTemplate: string,
-): { literalChars: number; expressionCount: number } | undefined {
+type UriTemplateMatchScore = {
+	literalChars: number;
+	expressionCount: number;
+	expressionContainsSemicolon: boolean;
+};
+
+function getUriTemplateMatchScore(uri: string, uriTemplate: string): UriTemplateMatchScore | undefined {
 	const expressionPattern = /\{[^}]+\}/g;
 	const literalSegments = uriTemplate.split(expressionPattern);
 	const expressionCount = (uriTemplate.match(expressionPattern) ?? []).length;
 	const pattern = literalSegments.map(escapeRegex).join("(.*?)");
-	const regex = new RegExp(`^${pattern}$`);
-	if (!regex.test(uri)) return undefined;
+	const match = new RegExp(`^${pattern}$`).exec(uri);
+	if (!match) return undefined;
 	const literalChars = literalSegments.reduce((total, segment) => total + segment.length, 0);
-	return { literalChars, expressionCount };
+	return {
+		literalChars,
+		expressionCount,
+		expressionContainsSemicolon: match.slice(1).some(value => value.includes(";")),
+	};
 }
 
 function extractResourceUri(url: InternalUrl): string {
@@ -41,7 +48,11 @@ function extractResourceUri(url: InternalUrl): string {
 	return uri;
 }
 
-function resolveTargetServer(mcpManager: MCPManager, uri: string): string | undefined {
+function resolveTargetServer(
+	mcpManager: MCPManager,
+	uri: string,
+	acceptTemplateMatch: (match: UriTemplateMatchScore) => boolean = () => true,
+): string | undefined {
 	const servers = mcpManager.getConnectedServers();
 	for (const name of servers) {
 		const serverResources = mcpManager.getServerResources(name);
@@ -66,7 +77,7 @@ function resolveTargetServer(mcpManager: MCPManager, uri: string): string | unde
 
 		for (const [templateIndex, template] of serverResources.templates.entries()) {
 			const match = getUriTemplateMatchScore(uri, template.uriTemplate);
-			if (!match) continue;
+			if (!match || !acceptTemplateMatch(match)) continue;
 
 			const isBetterMatch =
 				!bestTemplateMatch ||
@@ -93,12 +104,19 @@ function resolveTargetServer(mcpManager: MCPManager, uri: string): string | unde
 	return bestTemplateMatch?.serverName;
 }
 
-/** Whether current MCP catalogs claim this exact native URI or a matching template. */
-export function hasMatchingMcpResource(input: string): boolean {
+/**
+ * Whether loaded MCP catalogs unambiguously claim this exact native URI.
+ *
+ * Template expressions that capture semicolons are excluded because the same
+ * input may instead be a valid semicolon-delimited Read batch.
+ */
+export async function hasUnambiguousMcpResourceMatch(input: string): Promise<boolean> {
 	const mcpManager = MCPManager.instance();
 	if (!mcpManager) return false;
 	try {
-		return resolveTargetServer(mcpManager, extractResourceUri(parseInternalUrl(input))) !== undefined;
+		const uri = extractResourceUri(parseInternalUrl(input));
+		await Promise.allSettled(mcpManager.getConnectedServers().map(name => mcpManager.ensureServerResources(name)));
+		return resolveTargetServer(mcpManager, uri, match => !match.expressionContainsSemicolon) !== undefined;
 	} catch {
 		return false;
 	}

--- a/packages/coding-agent/src/internal-urls/mcp-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/mcp-protocol.ts
@@ -1,5 +1,6 @@
 import { MCPManager } from "../mcp/manager";
 import type { MCPResourceReadResult } from "../mcp/types";
+import { parseInternalUrl } from "./parse";
 import type { InternalResource, InternalUrl, ProtocolHandler } from "./types";
 
 function escapeRegex(text: string): string {
@@ -90,6 +91,17 @@ function resolveTargetServer(mcpManager: MCPManager, uri: string): string | unde
 	}
 
 	return bestTemplateMatch?.serverName;
+}
+
+/** Whether current MCP catalogs claim this exact native URI or a matching template. */
+export function hasMatchingMcpResource(input: string): boolean {
+	const mcpManager = MCPManager.instance();
+	if (!mcpManager) return false;
+	try {
+		return resolveTargetServer(mcpManager, extractResourceUri(parseInternalUrl(input))) !== undefined;
+	} catch {
+		return false;
+	}
 }
 
 function formatAvailableResources(mcpManager: MCPManager): string {

--- a/packages/coding-agent/src/internal-urls/mcp-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/mcp-protocol.ts
@@ -24,7 +24,7 @@ function extractResourceUri(url: InternalUrl): string {
 	const scheme = url.protocol.replace(/:$/, "").toLowerCase();
 	if (scheme !== "mcp") {
 		// Server-advertised native URI (hierarchical or opaque). Preserve the
-		// input byte-for-byte: `resolveConcreteTargetServer` matches by exact string
+		// input byte-for-byte: `resolveTargetServer` matches by exact string
 		// equality, so e.g. `catalog://root/` must keep its trailing slash.
 		return url.rawHref ?? url.href;
 	}
@@ -40,18 +40,14 @@ function extractResourceUri(url: InternalUrl): string {
 	return uri;
 }
 
-function resolveConcreteTargetServer(mcpManager: MCPManager, uri: string): string | undefined {
-	for (const name of mcpManager.getConnectedServers()) {
-		const serverResources = mcpManager.getServerResources(name);
-		if (serverResources?.resources.some(resource => resource.uri === uri)) return name;
-	}
-	return undefined;
-}
-
 function resolveTargetServer(mcpManager: MCPManager, uri: string): string | undefined {
-	const concreteTarget = resolveConcreteTargetServer(mcpManager, uri);
-	if (concreteTarget) return concreteTarget;
 	const servers = mcpManager.getConnectedServers();
+	for (const name of servers) {
+		const serverResources = mcpManager.getServerResources(name);
+		if (serverResources?.resources.some(r => r.uri === uri)) {
+			return name;
+		}
+	}
 
 	let bestTemplateMatch:
 		| {
@@ -94,26 +90,6 @@ function resolveTargetServer(mcpManager: MCPManager, uri: string): string | unde
 	}
 
 	return bestTemplateMatch?.serverName;
-}
-
-/**
- * Whether an advertised concrete MCP resource exactly owns this URL.
- *
- * Template matches are deliberately excluded: a broad template can also match
- * a semicolon-joined batch, but only a concrete URI proves the semicolon is
- * resource data rather than the Read batch delimiter.
- */
-export async function hasExactMcpResource(url: InternalUrl): Promise<boolean> {
-	const mcpManager = MCPManager.instance();
-	if (!mcpManager) return false;
-
-	const uri = extractResourceUri(url);
-	let targetServer = resolveConcreteTargetServer(mcpManager, uri);
-	if (!targetServer) {
-		await Promise.allSettled(mcpManager.getConnectedServers().map(name => mcpManager.ensureServerResources(name)));
-		targetServer = resolveConcreteTargetServer(mcpManager, uri);
-	}
-	return targetServer !== undefined;
 }
 
 function formatAvailableResources(mcpManager: MCPManager): string {

--- a/packages/coding-agent/src/internal-urls/mcp-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/mcp-protocol.ts
@@ -105,20 +105,30 @@ function resolveTargetServer(
 }
 
 /**
- * Whether loaded MCP catalogs unambiguously claim this exact native URI.
+ * Find the longest unambiguous MCP resource at the start of this input.
  *
  * Template expressions that capture semicolons are excluded because the same
- * input may instead be a valid semicolon-delimited Read batch.
+ * input may instead be a valid semicolon-delimited Read batch. Prefix
+ * candidates must themselves contain a semicolon so a broad template such as
+ * `attachment://{id}` cannot claim built-in `attachment://1`.
  */
-export async function hasUnambiguousMcpResourceMatch(input: string): Promise<boolean> {
+export async function findUnambiguousMcpResourceMatch(input: string): Promise<string | undefined> {
 	const mcpManager = MCPManager.instance();
-	if (!mcpManager) return false;
+	if (!mcpManager) return undefined;
 	try {
-		const uri = extractResourceUri(parseInternalUrl(input));
 		await Promise.allSettled(mcpManager.getConnectedServers().map(name => mcpManager.ensureServerResources(name)));
-		return resolveTargetServer(mcpManager, uri, match => !match.expressionContainsSemicolon) !== undefined;
+		const candidates = [input];
+		for (let delimiter = input.lastIndexOf(";"); delimiter > 0; delimiter = input.lastIndexOf(";", delimiter - 1)) {
+			const prefix = input.slice(0, delimiter);
+			if (prefix.includes(";")) candidates.push(prefix);
+		}
+		for (const candidate of candidates) {
+			const uri = extractResourceUri(parseInternalUrl(candidate));
+			if (resolveTargetServer(mcpManager, uri, match => !match.expressionContainsSemicolon)) return candidate;
+		}
+		return undefined;
 	} catch {
-		return false;
+		return undefined;
 	}
 }
 

--- a/packages/coding-agent/src/prompts/tools/read.md
+++ b/packages/coding-agent/src/prompts/tools/read.md
@@ -1,7 +1,17 @@
 Read files, directories, archives, SQLite, images, documents, internal resources, and web URLs via `path`.
 
 <instruction>
-- SHOULD parallelize independent reads.
+- MUST collect every bounded target already required for the current step before calling `read`.
+- MUST batch independent known local paths and internal URIs in one semicolon-delimited call.
+- Join complete `path[:selector]` targets with `;`; keep each target otherwise unchanged.
+- NEVER read known independent targets one per assistant turn.
+- Read again only for a target discovered by a result or for a failed or truncated target.
+- For independent HTTP(S) URLs, issue one separate `read` call per URL in the same assistant turn.
+- NEVER combine an HTTP(S) URL with another target in a semicolon-delimited `path`.
+- SQLite semicolons in SQL, table names, or row keys remain target data.
+- Ambiguous literal semicolons → use separate calls instead of corrupting a target.
+- Literal semicolons inside authored internal URIs must be percent-encoded as `%3B`; pass advertised MCP resource URIs exactly.
+- Example: `artifact://abc123;package.json;src/main.ts:1-200`.
 - SHOULD use `read` (not browser) for web content; browser only when `read` can't deliver.
 </instruction>
 

--- a/packages/coding-agent/src/prompts/tools/read.md
+++ b/packages/coding-agent/src/prompts/tools/read.md
@@ -2,15 +2,18 @@ Read files, directories, archives, SQLite, images, documents, internal resources
 
 <instruction>
 - MUST collect every bounded target already required for the current step before calling `read`.
-- MUST batch independent known local paths and internal URIs in one semicolon-delimited call.
+- MUST batch independent known local paths, file URLs, and internal URIs in one semicolon-delimited call.
 - Join complete `path[:selector]` targets with `;`; keep each target otherwise unchanged.
-- NEVER read known independent targets one per assistant turn.
+- NEVER spread known independent targets across assistant turns.
 - Read again only for a target discovered by a result or for a failed or truncated target.
-- For independent HTTP(S) URLs, issue one separate `read` call per URL in the same assistant turn.
+- For independent MCP resources, issue separate sibling `read` calls in the same assistant turn.
+- MCP resources include `mcp://` and MCP-advertised custom URIs.
+- Preserve MCP resource URIs exactly; NEVER split or percent-encode server-provided semicolons.
+- For independent HTTP(S) URLs, issue separate sibling `read` calls in the same assistant turn.
 - NEVER combine an HTTP(S) URL with another target in a semicolon-delimited `path`.
 - SQLite semicolons in SQL, table names, or row keys remain target data.
-- Ambiguous literal semicolons → use separate calls instead of corrupting a target.
-- Literal semicolons inside authored internal URIs must be percent-encoded as `%3B`; pass advertised MCP resource URIs exactly.
+- Ambiguous literal semicolons → use separate sibling calls instead of corrupting a target.
+- Literal semicolons inside batch-compatible internal URIs MUST use `%3B`.
 - Example: `artifact://abc123;package.json;src/main.ts:1-200`.
 - SHOULD use `read` (not browser) for web content; browser only when `read` can't deliver.
 </instruction>

--- a/packages/coding-agent/src/tools/path-utils.ts
+++ b/packages/coding-agent/src/tools/path-utils.ts
@@ -947,6 +947,22 @@ async function tryDelimitedPathSplit(
 
 	const parts = rawParts.map(normalizePathLikeInput).filter(part => part.length > 0);
 	if (parts.some(isReadableUrlPath)) return null;
+	// Unknown schemes may be MCP-advertised opaque resources whose payload includes
+	// later semicolons. Reject the tentative batch rather than corrupting the URI.
+	if (
+		parts.some(part => {
+			const scheme = INTERNAL_URL_SCHEME_RE.exec(part)?.[1]?.toLowerCase();
+			return (
+				scheme !== undefined &&
+				scheme !== "attachment" &&
+				scheme !== "conflict" &&
+				scheme !== "file" &&
+				INTERNAL_SCHEMES_WITH_SELECTORS[scheme] !== true
+			);
+		})
+	) {
+		return null;
+	}
 	if (parts.length === 0) return null;
 	if (parts.length < 2 && rawParts.length === parts.length) return null;
 

--- a/packages/coding-agent/src/tools/path-utils.ts
+++ b/packages/coding-agent/src/tools/path-utils.ts
@@ -947,18 +947,24 @@ async function tryDelimitedPathSplit(
 
 	const parts = rawParts.map(normalizePathLikeInput).filter(part => part.length > 0);
 	if (parts.some(isReadableUrlPath)) return null;
-	// Unknown schemes may be MCP-advertised opaque resources whose payload includes
-	// later semicolons. Reject the tentative batch rather than corrupting the URI.
+	const internalRouter = InternalUrlRouter.instance();
+	// Unregistered schemes may be MCP-advertised opaque resources whose payload
+	// includes later semicolons. Reject the tentative batch rather than corrupting
+	// the URI, while preserving custom protocol handlers registered in this process.
 	if (
 		parts.some(part => {
 			const scheme = INTERNAL_URL_SCHEME_RE.exec(part)?.[1]?.toLowerCase();
-			return (
-				scheme !== undefined &&
-				scheme !== "attachment" &&
-				scheme !== "conflict" &&
-				scheme !== "file" &&
-				INTERNAL_SCHEMES_WITH_SELECTORS[scheme] !== true
-			);
+			if (scheme === undefined) return false;
+			if (scheme === "mcp") return true;
+			if (
+				scheme === "attachment" ||
+				scheme === "conflict" ||
+				scheme === "file" ||
+				INTERNAL_SCHEMES_WITH_SELECTORS[scheme] === true
+			) {
+				return false;
+			}
+			return !internalRouter.canHandle(part);
 		})
 	) {
 		return null;

--- a/packages/coding-agent/src/tools/path-utils.ts
+++ b/packages/coding-agent/src/tools/path-utils.ts
@@ -12,7 +12,7 @@ import {
 	windowsPathToWslMount,
 } from "@oh-my-pi/pi-utils";
 import type { Skill } from "../extensibility/skills";
-import { InternalUrlRouter, type LocalProtocolOptions } from "../internal-urls";
+import { extractUriScheme, InternalUrlRouter, type LocalProtocolOptions } from "../internal-urls";
 import { ToolAbortError, ToolError } from "./tool-errors";
 
 const UNICODE_SPACES = /[\u00A0\u2000-\u200A\u202F\u205F\u3000]/g;
@@ -953,7 +953,7 @@ async function tryDelimitedPathSplit(
 	// the URI, while preserving custom protocol handlers registered in this process.
 	if (
 		parts.some(part => {
-			const scheme = INTERNAL_URL_SCHEME_RE.exec(part)?.[1]?.toLowerCase();
+			const scheme = extractUriScheme(part);
 			if (scheme === undefined) return false;
 			if (scheme === "mcp") return true;
 			if (

--- a/packages/coding-agent/src/tools/path-utils.ts
+++ b/packages/coding-agent/src/tools/path-utils.ts
@@ -946,28 +946,26 @@ async function tryDelimitedPathSplit(
 	if (rawParts.length < 2) return null;
 
 	const parts = rawParts.map(normalizePathLikeInput).filter(part => part.length > 0);
-	if (parts.some(isReadableUrlPath)) return null;
 	const internalRouter = InternalUrlRouter.instance();
 	// Unregistered schemes may be MCP-advertised opaque resources whose payload
 	// includes later semicolons. Reject the tentative batch rather than corrupting
-	// the URI, while preserving custom protocol handlers registered in this process.
-	if (
-		parts.some(part => {
-			const scheme = extractUriScheme(part);
-			if (scheme === undefined) return false;
-			if (scheme === "mcp") return true;
-			if (
-				scheme === "attachment" ||
-				scheme === "conflict" ||
-				scheme === "file" ||
-				INTERNAL_SCHEMES_WITH_SELECTORS[scheme] === true
-			) {
-				return false;
-			}
-			return !internalRouter.canHandle(part);
-		})
-	) {
-		return null;
+	// the URI, while preserving registered handlers and existing POSIX names that
+	// merely resemble scheme-less or opaque URLs.
+	for (const part of parts) {
+		const readableUrl = isReadableUrlPath(part);
+		const scheme = extractUriScheme(part);
+		if (!readableUrl && scheme === undefined) continue;
+		if (!part.includes("://") && (await probeLiteralPathExists(part, cwd)) !== "missing") continue;
+		if (readableUrl || scheme === "mcp") return null;
+		if (
+			scheme === "attachment" ||
+			scheme === "conflict" ||
+			scheme === "file" ||
+			(scheme !== undefined && INTERNAL_SCHEMES_WITH_SELECTORS[scheme] === true)
+		) {
+			continue;
+		}
+		if (!internalRouter.canHandle(part)) return null;
 	}
 	if (parts.length === 0) return null;
 	if (parts.length < 2 && rawParts.length === parts.length) return null;

--- a/packages/coding-agent/src/tools/path-utils.ts
+++ b/packages/coding-agent/src/tools/path-utils.ts
@@ -942,6 +942,7 @@ async function tryDelimitedPathSplit(
 	mode: DelimitedPathSplitMode,
 	requirement: DelimitedResolveRequirement,
 	rejectExternalOrOpaqueUrlChildren: boolean,
+	isBatchablePseudoUrl: ((value: string) => boolean) | undefined,
 ): Promise<string[] | null> {
 	const rawParts = splitTopLevelDelimitedPath(entry, mode);
 	if (rawParts.length < 2) return null;
@@ -959,12 +960,11 @@ async function tryDelimitedPathSplit(
 			if (!readableUrl && scheme === undefined) continue;
 			if (!part.includes("://") && (await probeLiteralPathExists(part, cwd)) !== "missing") continue;
 			if (readableUrl || scheme === "mcp") return null;
-			if (
-				scheme === "attachment" ||
-				scheme === "conflict" ||
-				scheme === "file" ||
-				(scheme !== undefined && INTERNAL_SCHEMES_WITH_SELECTORS[scheme] === true)
-			) {
+			if (scheme === "attachment" || scheme === "conflict") {
+				if (isBatchablePseudoUrl?.(part)) continue;
+				return null;
+			}
+			if (scheme === "file" || (scheme !== undefined && INTERNAL_SCHEMES_WITH_SELECTORS[scheme] === true)) {
 				continue;
 			}
 			if (!internalRouter.canHandle(part)) return null;
@@ -997,6 +997,7 @@ export async function splitDelimitedPathEntry(
 		splitter?: PathEntrySplitter;
 		splitInternalUrlSemicolons?: boolean;
 		rejectExternalOrOpaqueUrlChildren?: boolean;
+		isBatchablePseudoUrl?: (value: string) => boolean;
 	} = {},
 ): Promise<string[] | null> {
 	const normalizedEntry = normalizePathLikeInput(entry);
@@ -1011,6 +1012,7 @@ export async function splitDelimitedPathEntry(
 			"semicolon",
 			"none",
 			options.rejectExternalOrOpaqueUrlChildren ?? false,
+			options.isBatchablePseudoUrl,
 		);
 	}
 	// A real POSIX file may contain the delimiter and a selector-shaped tail
@@ -1032,6 +1034,7 @@ export async function splitDelimitedPathEntry(
 			"semicolon",
 			"none",
 			options.rejectExternalOrOpaqueUrlChildren ?? false,
+			options.isBatchablePseudoUrl,
 		)) ??
 		(await tryDelimitedPathSplit(
 			normalizedEntry,
@@ -1040,6 +1043,7 @@ export async function splitDelimitedPathEntry(
 			"comma",
 			"some",
 			options.rejectExternalOrOpaqueUrlChildren ?? false,
+			options.isBatchablePseudoUrl,
 		)) ??
 		(await tryDelimitedPathSplit(
 			normalizedEntry,
@@ -1048,6 +1052,7 @@ export async function splitDelimitedPathEntry(
 			"whitespace",
 			"all",
 			options.rejectExternalOrOpaqueUrlChildren ?? false,
+			options.isBatchablePseudoUrl,
 		)) ??
 		(await tryDelimitedPathSplit(
 			normalizedEntry,
@@ -1056,6 +1061,7 @@ export async function splitDelimitedPathEntry(
 			"mixed",
 			"all",
 			options.rejectExternalOrOpaqueUrlChildren ?? false,
+			options.isBatchablePseudoUrl,
 		))
 	);
 }

--- a/packages/coding-agent/src/tools/path-utils.ts
+++ b/packages/coding-agent/src/tools/path-utils.ts
@@ -941,31 +941,34 @@ async function tryDelimitedPathSplit(
 	splitter: PathEntrySplitter,
 	mode: DelimitedPathSplitMode,
 	requirement: DelimitedResolveRequirement,
+	rejectExternalOrOpaqueUrlChildren: boolean,
 ): Promise<string[] | null> {
 	const rawParts = splitTopLevelDelimitedPath(entry, mode);
 	if (rawParts.length < 2) return null;
 
 	const parts = rawParts.map(normalizePathLikeInput).filter(part => part.length > 0);
-	const internalRouter = InternalUrlRouter.instance();
-	// Unregistered schemes may be MCP-advertised opaque resources whose payload
-	// includes later semicolons. Reject the tentative batch rather than corrupting
-	// the URI, while preserving registered handlers and existing POSIX names that
-	// merely resemble scheme-less or opaque URLs.
-	for (const part of parts) {
-		const readableUrl = isReadableUrlPath(part);
-		const scheme = extractUriScheme(part);
-		if (!readableUrl && scheme === undefined) continue;
-		if (!part.includes("://") && (await probeLiteralPathExists(part, cwd)) !== "missing") continue;
-		if (readableUrl || scheme === "mcp") return null;
-		if (
-			scheme === "attachment" ||
-			scheme === "conflict" ||
-			scheme === "file" ||
-			(scheme !== undefined && INTERNAL_SCHEMES_WITH_SELECTORS[scheme] === true)
-		) {
-			continue;
+	if (rejectExternalOrOpaqueUrlChildren) {
+		const internalRouter = InternalUrlRouter.instance();
+		// Unregistered schemes may be MCP-advertised opaque resources whose payload
+		// includes later semicolons. Reject the tentative batch rather than corrupting
+		// the URI, while preserving registered handlers and existing POSIX names that
+		// merely resemble scheme-less or opaque URLs.
+		for (const part of parts) {
+			const readableUrl = isReadableUrlPath(part);
+			const scheme = extractUriScheme(part);
+			if (!readableUrl && scheme === undefined) continue;
+			if (!part.includes("://") && (await probeLiteralPathExists(part, cwd)) !== "missing") continue;
+			if (readableUrl || scheme === "mcp") return null;
+			if (
+				scheme === "attachment" ||
+				scheme === "conflict" ||
+				scheme === "file" ||
+				(scheme !== undefined && INTERNAL_SCHEMES_WITH_SELECTORS[scheme] === true)
+			) {
+				continue;
+			}
+			if (!internalRouter.canHandle(part)) return null;
 		}
-		if (!internalRouter.canHandle(part)) return null;
 	}
 	if (parts.length === 0) return null;
 	if (parts.length < 2 && rawParts.length === parts.length) return null;
@@ -993,6 +996,7 @@ export async function splitDelimitedPathEntry(
 	options: {
 		splitter?: PathEntrySplitter;
 		splitInternalUrlSemicolons?: boolean;
+		rejectExternalOrOpaqueUrlChildren?: boolean;
 	} = {},
 ): Promise<string[] | null> {
 	const normalizedEntry = normalizePathLikeInput(entry);
@@ -1000,7 +1004,14 @@ export async function splitDelimitedPathEntry(
 	const splitter = options.splitter ?? parseSearchPath;
 	if (isInternalUrlPath(normalizedEntry)) {
 		if (!options.splitInternalUrlSemicolons) return null;
-		return tryDelimitedPathSplit(normalizedEntry, cwd, splitter, "semicolon", "none");
+		return tryDelimitedPathSplit(
+			normalizedEntry,
+			cwd,
+			splitter,
+			"semicolon",
+			"none",
+			options.rejectExternalOrOpaqueUrlChildren ?? false,
+		);
 	}
 	// A real POSIX file may contain the delimiter and a selector-shaped tail
 	// (`a;b:1-2`, `a b:1-2`). Preserve the raw entry whenever the full literal
@@ -1014,10 +1025,38 @@ export async function splitDelimitedPathEntry(
 	}
 
 	return (
-		(await tryDelimitedPathSplit(normalizedEntry, cwd, splitter, "semicolon", "none")) ??
-		(await tryDelimitedPathSplit(normalizedEntry, cwd, splitter, "comma", "some")) ??
-		(await tryDelimitedPathSplit(normalizedEntry, cwd, splitter, "whitespace", "all")) ??
-		(await tryDelimitedPathSplit(normalizedEntry, cwd, splitter, "mixed", "all"))
+		(await tryDelimitedPathSplit(
+			normalizedEntry,
+			cwd,
+			splitter,
+			"semicolon",
+			"none",
+			options.rejectExternalOrOpaqueUrlChildren ?? false,
+		)) ??
+		(await tryDelimitedPathSplit(
+			normalizedEntry,
+			cwd,
+			splitter,
+			"comma",
+			"some",
+			options.rejectExternalOrOpaqueUrlChildren ?? false,
+		)) ??
+		(await tryDelimitedPathSplit(
+			normalizedEntry,
+			cwd,
+			splitter,
+			"whitespace",
+			"all",
+			options.rejectExternalOrOpaqueUrlChildren ?? false,
+		)) ??
+		(await tryDelimitedPathSplit(
+			normalizedEntry,
+			cwd,
+			splitter,
+			"mixed",
+			"all",
+			options.rejectExternalOrOpaqueUrlChildren ?? false,
+		))
 	);
 }
 

--- a/packages/coding-agent/src/tools/path-utils.ts
+++ b/packages/coding-agent/src/tools/path-utils.ts
@@ -946,6 +946,7 @@ async function tryDelimitedPathSplit(
 	if (rawParts.length < 2) return null;
 
 	const parts = rawParts.map(normalizePathLikeInput).filter(part => part.length > 0);
+	if (parts.some(isReadableUrlPath)) return null;
 	if (parts.length === 0) return null;
 	if (parts.length < 2 && rawParts.length === parts.length) return null;
 
@@ -979,8 +980,7 @@ export async function splitDelimitedPathEntry(
 	const splitter = options.splitter ?? parseSearchPath;
 	if (isInternalUrlPath(normalizedEntry)) {
 		if (!options.splitInternalUrlSemicolons) return null;
-		const parts = await tryDelimitedPathSplit(normalizedEntry, cwd, splitter, "semicolon", "none");
-		return parts?.some(isReadableUrlPath) ? null : parts;
+		return tryDelimitedPathSplit(normalizedEntry, cwd, splitter, "semicolon", "none");
 	}
 	// A real POSIX file may contain the delimiter and a selector-shaped tail
 	// (`a;b:1-2`, `a b:1-2`). Preserve the raw entry whenever the full literal

--- a/packages/coding-agent/src/tools/path-utils.ts
+++ b/packages/coding-agent/src/tools/path-utils.ts
@@ -983,7 +983,7 @@ async function tryDelimitedPathSplit(
 			const readableUrl = isReadableUrlPath(part);
 			const scheme = extractUriScheme(part);
 			if (!readableUrl && scheme === undefined) continue;
-			if (!part.includes("://") && (await probeLiteralPathExists(part, cwd)) !== "missing") continue;
+			if (!part.includes("://") && (await probeLiteralPathOrSelectorBase(part, cwd)) !== "missing") continue;
 			if (readableUrl || scheme === "mcp") return null;
 			if (scheme === "attachment" || scheme === "conflict") {
 				if (isBatchablePseudoUrl?.(part)) continue;

--- a/packages/coding-agent/src/tools/path-utils.ts
+++ b/packages/coding-agent/src/tools/path-utils.ts
@@ -979,7 +979,8 @@ export async function splitDelimitedPathEntry(
 	const splitter = options.splitter ?? parseSearchPath;
 	if (isInternalUrlPath(normalizedEntry)) {
 		if (!options.splitInternalUrlSemicolons) return null;
-		return tryDelimitedPathSplit(normalizedEntry, cwd, splitter, "semicolon", "none");
+		const parts = await tryDelimitedPathSplit(normalizedEntry, cwd, splitter, "semicolon", "none");
+		return parts?.some(isReadableUrlPath) ? null : parts;
 	}
 	// A real POSIX file may contain the delimiter and a selector-shaped tail
 	// (`a;b:1-2`, `a b:1-2`). Preserve the raw entry whenever the full literal

--- a/packages/coding-agent/src/tools/path-utils.ts
+++ b/packages/coding-agent/src/tools/path-utils.ts
@@ -961,23 +961,26 @@ async function tryDelimitedPathSplit(
  * Split one path-like entry whose multiple targets were flattened into one
  * string. Existing paths are kept intact, so real filenames containing spaces,
  * commas, or semicolons win over delimiter recovery.
+ *
+ * Internal URLs preserve raw semicolons unless their caller explicitly enables
+ * the documented semicolon-batch grammar. Literal internal-URL semicolons must
+ * remain percent-encoded while splitting occurs.
  */
 export async function splitDelimitedPathEntry(
 	entry: string,
 	cwd: string,
 	options: {
 		splitter?: PathEntrySplitter;
-		routedUrlPredicate?: (entry: string) => boolean;
+		splitInternalUrlSemicolons?: boolean;
 	} = {},
 ): Promise<string[] | null> {
 	const normalizedEntry = normalizePathLikeInput(entry);
 	if (!hasTopLevelPathDelimiter(normalizedEntry)) return null;
 	const splitter = options.splitter ?? parseSearchPath;
-	if (options.routedUrlPredicate?.(normalizedEntry)) {
-		const parts = await tryDelimitedPathSplit(normalizedEntry, cwd, splitter, "semicolon", "none");
-		return parts?.every(options.routedUrlPredicate) ? parts : null;
+	if (isInternalUrlPath(normalizedEntry)) {
+		if (!options.splitInternalUrlSemicolons) return null;
+		return tryDelimitedPathSplit(normalizedEntry, cwd, splitter, "semicolon", "none");
 	}
-	if (isInternalUrlPath(normalizedEntry)) return null;
 	// A real POSIX file may contain the delimiter and a selector-shaped tail
 	// (`a;b:1-2`, `a b:1-2`). Preserve the raw entry whenever the full literal
 	// resolves — or is only ambiguous — so downstream literal-preferring

--- a/packages/coding-agent/src/tools/path-utils.ts
+++ b/packages/coding-agent/src/tools/path-utils.ts
@@ -383,6 +383,17 @@ export async function probeLiteralPathExists(filePath: string, cwd: string): Pro
 	}
 }
 
+/** Probe the literal target, then its selector-free base when it has a valid selector. */
+export async function probeLiteralPathOrSelectorBase(
+	filePath: string,
+	cwd: string,
+): Promise<"exists" | "missing" | "unknown"> {
+	const literal = await probeLiteralPathExists(filePath, cwd);
+	if (literal !== "missing") return literal;
+	const selected = splitPathAndSel(filePath);
+	return selected.sel === undefined ? "missing" : probeLiteralPathExists(selected.path, cwd);
+}
+
 /**
  * Async sibling of {@link splitPathAndSel} that prefers a literal filesystem
  * path over selector interpretation. Filenames whose tail matches the selector
@@ -935,6 +946,19 @@ async function delimitedPathPartResolves(entry: string, cwd: string, splitter: P
  */
 type DelimitedResolveRequirement = "all" | "some" | "none";
 
+async function hasLiteralSemicolonFileUrl(rawParts: readonly string[], cwd: string): Promise<boolean> {
+	for (const [index, rawPart] of rawParts.entries()) {
+		const firstPart = normalizePathLikeInput(rawPart);
+		if (extractUriScheme(firstPart) !== "file") continue;
+		let candidate = firstPart;
+		for (let tailIndex = index + 1; tailIndex < rawParts.length; tailIndex++) {
+			candidate += `;${normalizePathLikeInput(rawParts[tailIndex] ?? "")}`;
+			if ((await probeLiteralPathOrSelectorBase(candidate, cwd)) !== "missing") return true;
+		}
+	}
+	return false;
+}
+
 async function tryDelimitedPathSplit(
 	entry: string,
 	cwd: string,
@@ -947,6 +971,7 @@ async function tryDelimitedPathSplit(
 	const rawParts = splitTopLevelDelimitedPath(entry, mode);
 	if (rawParts.length < 2) return null;
 
+	if (rejectExternalOrOpaqueUrlChildren && (await hasLiteralSemicolonFileUrl(rawParts, cwd))) return null;
 	const parts = rawParts.map(normalizePathLikeInput).filter(part => part.length > 0);
 	if (rejectExternalOrOpaqueUrlChildren) {
 		const internalRouter = InternalUrlRouter.instance();

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -78,6 +78,7 @@ import {
 	isReadableUrlPath,
 	pathTargetsSsh,
 	probeLiteralPathExists,
+	probeLiteralPathOrSelectorBase,
 	resolveReadPath,
 	splitDelimitedPathEntry,
 	splitInternalUrlSel,
@@ -1108,17 +1109,13 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 	): Promise<AgentToolResult<ReadToolDetails>> {
 		let { path: readPath } = params;
 		const isFileUrl = readPath.toLowerCase().startsWith("file://");
-		if (isFileUrl && readPath.includes(";")) {
-			const literalProbe = await probeLiteralPathExists(readPath, this.session.cwd);
-			const selectedTarget = splitPathAndSel(readPath);
-			const selectedTargetProbe =
-				selectedTarget.sel === undefined
-					? literalProbe
-					: await probeLiteralPathExists(selectedTarget.path, this.session.cwd);
-			if (literalProbe === "missing" && selectedTargetProbe === "missing") {
-				const delimitedResult = await this.#tryReadDelimitedPaths(readPath, signal);
-				if (delimitedResult) return delimitedResult;
-			}
+		if (
+			isFileUrl &&
+			readPath.includes(";") &&
+			(await probeLiteralPathOrSelectorBase(readPath, this.session.cwd)) === "missing"
+		) {
+			const delimitedResult = await this.#tryReadDelimitedPaths(readPath, signal);
+			if (delimitedResult) return delimitedResult;
 		}
 		if (isFileUrl) {
 			readPath = expandPath(readPath);

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -30,7 +30,7 @@ import { normalizeToLF } from "../edit/normalize";
 import { isNotebookPath, readEditableNotebookText } from "../edit/notebook";
 import { InternalUrlRouter, resolveLocalUrlToFile, resolveLocalUrlToPath } from "../internal-urls";
 import { type ResolvedArtifactFile, resolveArtifactFile } from "../internal-urls/artifact-protocol";
-import { hasMatchingMcpResource } from "../internal-urls/mcp-protocol";
+import { hasUnambiguousMcpResourceMatch } from "../internal-urls/mcp-protocol";
 import { parseInternalUrl } from "../internal-urls/parse";
 import type { InternalUrl } from "../internal-urls/types";
 import readDescription from "../prompts/tools/read.md" with { type: "text" };
@@ -1135,7 +1135,7 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 		if (
 			readPath.includes(";") &&
 			(readPath.startsWith("attachment://") || readPath.startsWith("conflict://")) &&
-			hasMatchingMcpResource(readPath)
+			(await hasUnambiguousMcpResourceMatch(readPath))
 		) {
 			return this.#handleInternalUrl(readPath, parseSel(undefined), signal);
 		}

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -524,6 +524,15 @@ async function streamLinesFromFile(
 
 const IMAGE_ATTACHMENT_URI_REGEX = /^attachment:\/\/[1-9]\d*$/;
 
+function isBatchableReadPseudoUrl(value: string): boolean {
+	if (IMAGE_ATTACHMENT_URI_REGEX.test(value)) return true;
+	try {
+		return parseConflictUri(value) !== null;
+	} catch {
+		return false;
+	}
+}
+
 // Maximum image file size (20MB) - larger images will be rejected to prevent OOM during serialization
 const MAX_IMAGE_SIZE = MAX_IMAGE_INPUT_BYTES;
 
@@ -732,6 +741,7 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 		const parts = await splitDelimitedPathEntry(readPath, this.session.cwd, {
 			splitInternalUrlSemicolons: options.splitInternalUrlSemicolons,
 			rejectExternalOrOpaqueUrlChildren: true,
+			isBatchablePseudoUrl: isBatchableReadPseudoUrl,
 		});
 		if (!parts) return null;
 
@@ -1090,11 +1100,12 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 		_toolContext?: AgentToolContext,
 	): Promise<AgentToolResult<ReadToolDetails>> {
 		let { path: readPath } = params;
-		if (readPath.startsWith("file://") && readPath.includes(";")) {
+		const isFileUrl = readPath.toLowerCase().startsWith("file://");
+		if (isFileUrl && readPath.includes(";")) {
 			const delimitedResult = await this.#tryReadDelimitedPaths(readPath, signal);
 			if (delimitedResult) return delimitedResult;
 		}
-		if (readPath.startsWith("file://")) {
+		if (isFileUrl) {
 			readPath = expandPath(readPath);
 		}
 
@@ -1110,11 +1121,19 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 			readPath = attachment.sourcePath;
 		}
 		if (readPath.startsWith("attachment://") && readPath.includes(";")) {
+			const firstTarget = readPath.slice(0, readPath.indexOf(";"));
+			if (!isBatchableReadPseudoUrl(firstTarget)) {
+				return this.#handleInternalUrl(readPath, parseSel(undefined), signal);
+			}
 			const delimitedResult = await this.#tryReadDelimitedPaths(readPath, signal);
 			if (delimitedResult) return delimitedResult;
 		}
 
 		if (readPath.startsWith("conflict://") && readPath.includes(";")) {
+			const firstTarget = readPath.slice(0, readPath.indexOf(";"));
+			if (!isBatchableReadPseudoUrl(firstTarget)) {
+				return this.#handleInternalUrl(readPath, parseSel(undefined), signal);
+			}
 			const delimitedResult = await this.#tryReadDelimitedPaths(readPath, signal);
 			if (delimitedResult) return delimitedResult;
 		}

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -30,6 +30,7 @@ import { normalizeToLF } from "../edit/normalize";
 import { isNotebookPath, readEditableNotebookText } from "../edit/notebook";
 import { InternalUrlRouter, resolveLocalUrlToFile, resolveLocalUrlToPath } from "../internal-urls";
 import { type ResolvedArtifactFile, resolveArtifactFile } from "../internal-urls/artifact-protocol";
+import { hasMatchingMcpResource } from "../internal-urls/mcp-protocol";
 import { parseInternalUrl } from "../internal-urls/parse";
 import type { InternalUrl } from "../internal-urls/types";
 import readDescription from "../prompts/tools/read.md" with { type: "text" };
@@ -1133,6 +1134,13 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 				);
 			}
 			readPath = attachment.sourcePath;
+		}
+		if (
+			readPath.includes(";") &&
+			(readPath.startsWith("attachment://") || readPath.startsWith("conflict://")) &&
+			hasMatchingMcpResource(readPath)
+		) {
+			return this.#handleInternalUrl(readPath, parseSel(undefined), signal);
 		}
 		if (readPath.startsWith("attachment://") && readPath.includes(";")) {
 			const firstTarget = readPath.slice(0, readPath.indexOf(";"));

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -1107,13 +1107,17 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 	): Promise<AgentToolResult<ReadToolDetails>> {
 		let { path: readPath } = params;
 		const isFileUrl = readPath.toLowerCase().startsWith("file://");
-		if (
-			isFileUrl &&
-			readPath.includes(";") &&
-			(await probeLiteralPathExists(readPath, this.session.cwd)) === "missing"
-		) {
-			const delimitedResult = await this.#tryReadDelimitedPaths(readPath, signal);
-			if (delimitedResult) return delimitedResult;
+		if (isFileUrl && readPath.includes(";")) {
+			const literalProbe = await probeLiteralPathExists(readPath, this.session.cwd);
+			const selectedTarget = splitPathAndSel(readPath);
+			const selectedTargetProbe =
+				selectedTarget.sel === undefined
+					? literalProbe
+					: await probeLiteralPathExists(selectedTarget.path, this.session.cwd);
+			if (literalProbe === "missing" && selectedTargetProbe === "missing") {
+				const delimitedResult = await this.#tryReadDelimitedPaths(readPath, signal);
+				if (delimitedResult) return delimitedResult;
+			}
 		}
 		if (isFileUrl) {
 			readPath = expandPath(readPath);

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -767,7 +767,7 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 				const isUrlShapedLocalPath =
 					!part.includes("://") &&
 					isReadableUrlPath(part) &&
-					(await probeLiteralPathExists(part, this.session.cwd)) === "exists";
+					(await probeLiteralPathOrSelectorBase(part, this.session.cwd)) === "exists";
 				const executionPath = isUrlShapedLocalPath ? path.resolve(this.session.cwd, part) : part;
 				const result = await this.execute("read-delimited-part", { path: executionPath }, signal);
 				displayReadTargets.push(isUrlShapedLocalPath ? part : (result.details?.suffixResolution?.to ?? part));
@@ -1172,7 +1172,7 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 			const startsWithUrlShapedLocalPath =
 				!firstTarget.includes("://") &&
 				isReadableUrlPath(firstTarget) &&
-				(await probeLiteralPathExists(firstTarget, this.session.cwd)) === "exists";
+				(await probeLiteralPathOrSelectorBase(firstTarget, this.session.cwd)) === "exists";
 			if (startsWithUrlShapedLocalPath) {
 				const delimitedResult = await this.#tryReadDelimitedPaths(readPath, signal);
 				if (delimitedResult) return delimitedResult;

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -28,7 +28,7 @@ import {
 } from "../edit/file-snapshot-store";
 import { normalizeToLF } from "../edit/normalize";
 import { isNotebookPath, readEditableNotebookText } from "../edit/notebook";
-import { hasExactMcpResource, InternalUrlRouter, resolveLocalUrlToFile, resolveLocalUrlToPath } from "../internal-urls";
+import { InternalUrlRouter, resolveLocalUrlToFile, resolveLocalUrlToPath } from "../internal-urls";
 import { type ResolvedArtifactFile, resolveArtifactFile } from "../internal-urls/artifact-protocol";
 import { parseInternalUrl } from "../internal-urls/parse";
 import type { InternalUrl } from "../internal-urls/types";
@@ -1104,6 +1104,15 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 			}
 			readPath = attachment.sourcePath;
 		}
+		if (readPath.startsWith("attachment://") && readPath.includes(";")) {
+			const delimitedResult = await this.#tryReadDelimitedPaths(readPath, signal);
+			if (delimitedResult) return delimitedResult;
+		}
+
+		if (readPath.startsWith("conflict://") && readPath.includes(";")) {
+			const delimitedResult = await this.#tryReadDelimitedPaths(readPath, signal);
+			if (delimitedResult) return delimitedResult;
+		}
 
 		const conflictUri = parseConflictUri(readPath);
 		if (conflictUri) {
@@ -1152,19 +1161,20 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 			return executeReadUrl(this.session, { path: parsedUrlTarget.path, raw: urlRaw }, signal);
 		}
 
-		// Handle native OMP URLs and custom-scheme resources advertised by MCP servers.
+		// MCP resource URIs are opaque and may contain literal semicolons. Route
+		// them exactly before interpreting semicolons as the Read batch delimiter.
 		const internalRouter = InternalUrlRouter.instance();
 		const canResolveInternal = internalRouter.canResolve(readPath);
-		const routesThroughMcp =
-			canResolveInternal && (readPath.toLowerCase().startsWith("mcp://") || !internalRouter.canHandle(readPath));
-		const exactMcpResource =
-			routesThroughMcp && readPath.includes(";") && (await hasExactMcpResource(parseInternalUrl(readPath)));
-		const delimitedInternalResult =
-			canResolveInternal && !exactMcpResource
-				? await this.#tryReadDelimitedPaths(readPath, signal, {
-						splitInternalUrlSemicolons: true,
-					})
-				: null;
+		const isOpaqueMcpResource =
+			readPath.toLowerCase().startsWith("mcp://") || (canResolveInternal && !internalRouter.canHandle(readPath));
+		if (isOpaqueMcpResource) {
+			return this.#handleInternalUrl(readPath, parseSel(undefined), signal);
+		}
+		const delimitedInternalResult = canResolveInternal
+			? await this.#tryReadDelimitedPaths(readPath, signal, {
+					splitInternalUrlSemicolons: true,
+				})
+			: null;
 		if (delimitedInternalResult) return delimitedInternalResult;
 
 		// Peel malformed selectors through the internal-URL-aware parser before routing.

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -1089,6 +1089,10 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 		_toolContext?: AgentToolContext,
 	): Promise<AgentToolResult<ReadToolDetails>> {
 		let { path: readPath } = params;
+		if (readPath.startsWith("file://") && readPath.includes(";")) {
+			const delimitedResult = await this.#tryReadDelimitedPaths(readPath, signal);
+			if (delimitedResult) return delimitedResult;
+		}
 		if (readPath.startsWith("file://")) {
 			readPath = expandPath(readPath);
 		}

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -28,7 +28,7 @@ import {
 } from "../edit/file-snapshot-store";
 import { normalizeToLF } from "../edit/normalize";
 import { isNotebookPath, readEditableNotebookText } from "../edit/notebook";
-import { InternalUrlRouter, resolveLocalUrlToFile, resolveLocalUrlToPath } from "../internal-urls";
+import { hasExactMcpResource, InternalUrlRouter, resolveLocalUrlToFile, resolveLocalUrlToPath } from "../internal-urls";
 import { type ResolvedArtifactFile, resolveArtifactFile } from "../internal-urls/artifact-protocol";
 import { parseInternalUrl } from "../internal-urls/parse";
 import type { InternalUrl } from "../internal-urls/types";
@@ -725,9 +725,13 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 	async #tryReadDelimitedPaths(
 		readPath: string,
 		signal?: AbortSignal,
-		routedUrlPredicate?: (entry: string) => boolean,
+		options: {
+			splitInternalUrlSemicolons?: boolean;
+		} = {},
 	): Promise<AgentToolResult<ReadToolDetails> | null> {
-		const parts = await splitDelimitedPathEntry(readPath, this.session.cwd, { routedUrlPredicate });
+		const parts = await splitDelimitedPathEntry(readPath, this.session.cwd, {
+			splitInternalUrlSemicolons: options.splitInternalUrlSemicolons,
+		});
 		if (!parts) return null;
 
 		const notice = `Note: interpreted as ${parts.length} paths: ${parts.join(", ")}`;
@@ -1150,14 +1154,22 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 
 		// Handle native OMP URLs and custom-scheme resources advertised by MCP servers.
 		const internalRouter = InternalUrlRouter.instance();
-		const delimitedInternalResult = internalRouter.canResolve(readPath)
-			? await this.#tryReadDelimitedPaths(readPath, signal, entry => internalRouter.canResolve(entry))
-			: null;
+		const canResolveInternal = internalRouter.canResolve(readPath);
+		const routesThroughMcp =
+			canResolveInternal && (readPath.toLowerCase().startsWith("mcp://") || !internalRouter.canHandle(readPath));
+		const exactMcpResource =
+			routesThroughMcp && readPath.includes(";") && (await hasExactMcpResource(parseInternalUrl(readPath)));
+		const delimitedInternalResult =
+			canResolveInternal && !exactMcpResource
+				? await this.#tryReadDelimitedPaths(readPath, signal, {
+						splitInternalUrlSemicolons: true,
+					})
+				: null;
 		if (delimitedInternalResult) return delimitedInternalResult;
 
 		// Peel malformed selectors through the internal-URL-aware parser before routing.
 		let promotedSelector: string | undefined;
-		if (internalRouter.canResolve(readPath)) {
+		if (canResolveInternal) {
 			const internalTarget = splitInternalUrlSel(readPath);
 			const parsed = parseSel(internalTarget.sel);
 			if (internalTarget.sel !== undefined && parsed.kind === "none") {

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -30,7 +30,7 @@ import { normalizeToLF } from "../edit/normalize";
 import { isNotebookPath, readEditableNotebookText } from "../edit/notebook";
 import { InternalUrlRouter, resolveLocalUrlToFile, resolveLocalUrlToPath } from "../internal-urls";
 import { type ResolvedArtifactFile, resolveArtifactFile } from "../internal-urls/artifact-protocol";
-import { hasUnambiguousMcpResourceMatch } from "../internal-urls/mcp-protocol";
+import { findUnambiguousMcpResourceMatch } from "../internal-urls/mcp-protocol";
 import { parseInternalUrl } from "../internal-urls/parse";
 import type { InternalUrl } from "../internal-urls/types";
 import readDescription from "../prompts/tools/read.md" with { type: "text" };
@@ -1132,12 +1132,16 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 			}
 			readPath = attachment.sourcePath;
 		}
-		if (
-			readPath.includes(";") &&
-			(readPath.startsWith("attachment://") || readPath.startsWith("conflict://")) &&
-			(await hasUnambiguousMcpResourceMatch(readPath))
-		) {
+		const hasPseudoScheme = readPath.startsWith("attachment://") || readPath.startsWith("conflict://");
+		const mcpPseudoResource =
+			readPath.includes(";") && hasPseudoScheme ? await findUnambiguousMcpResourceMatch(readPath) : undefined;
+		if (mcpPseudoResource === readPath) {
 			return this.#handleInternalUrl(readPath, parseSel(undefined), signal);
+		}
+		if (mcpPseudoResource) {
+			throw new ToolError(
+				`Cannot batch MCP resource "${mcpPseudoResource}" with other targets. Issue separate sibling Read calls.`,
+			);
 		}
 		if (readPath.startsWith("attachment://") && readPath.includes(";")) {
 			const firstTarget = readPath.slice(0, readPath.indexOf(";"));

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -74,6 +74,7 @@ import {
 	expandPath,
 	formatPathRelativeToCwd,
 	type LineRange,
+	isReadableUrlPath,
 	pathTargetsSsh,
 	probeLiteralPathExists,
 	resolveReadPath,
@@ -761,8 +762,13 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 
 		for (const part of parts) {
 			try {
-				const result = await this.execute("read-delimited-part", { path: part }, signal);
-				displayReadTargets.push(result.details?.suffixResolution?.to ?? part);
+				const isUrlShapedLocalPath =
+					!part.includes("://") &&
+					isReadableUrlPath(part) &&
+					(await probeLiteralPathExists(part, this.session.cwd)) === "exists";
+				const executionPath = isUrlShapedLocalPath ? path.resolve(this.session.cwd, part) : part;
+				const result = await this.execute("read-delimited-part", { path: executionPath }, signal);
+				displayReadTargets.push(isUrlShapedLocalPath ? part : (result.details?.suffixResolution?.to ?? part));
 				for (const block of result.content) {
 					if (block.type === "text") {
 						appendText(block.text);
@@ -1148,6 +1154,17 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 			return this.#readConflictRegion(conflictUri.id, conflictUri.scope);
 		}
 		const displayMode = resolveFileDisplayMode(this.session);
+		if (readPath.includes(";")) {
+			const firstTarget = readPath.slice(0, readPath.indexOf(";"));
+			const startsWithUrlShapedLocalPath =
+				!firstTarget.includes("://") &&
+				isReadableUrlPath(firstTarget) &&
+				(await probeLiteralPathExists(firstTarget, this.session.cwd)) === "exists";
+			if (startsWithUrlShapedLocalPath) {
+				const delimitedResult = await this.#tryReadDelimitedPaths(readPath, signal);
+				if (delimitedResult) return delimitedResult;
+			}
+		}
 
 		const parsedUrlTarget = parseReadUrlTarget(readPath);
 		if (parsedUrlTarget) {

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -1107,7 +1107,11 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 	): Promise<AgentToolResult<ReadToolDetails>> {
 		let { path: readPath } = params;
 		const isFileUrl = readPath.toLowerCase().startsWith("file://");
-		if (isFileUrl && readPath.includes(";")) {
+		if (
+			isFileUrl &&
+			readPath.includes(";") &&
+			(await probeLiteralPathExists(readPath, this.session.cwd)) === "missing"
+		) {
 			const delimitedResult = await this.#tryReadDelimitedPaths(readPath, signal);
 			if (delimitedResult) return delimitedResult;
 		}

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -731,6 +731,7 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 	): Promise<AgentToolResult<ReadToolDetails> | null> {
 		const parts = await splitDelimitedPathEntry(readPath, this.session.cwd, {
 			splitInternalUrlSemicolons: options.splitInternalUrlSemicolons,
+			rejectExternalOrOpaqueUrlChildren: true,
 		});
 		if (!parts) return null;
 

--- a/packages/coding-agent/test/internal-urls/mcp-protocol.test.ts
+++ b/packages/coding-agent/test/internal-urls/mcp-protocol.test.ts
@@ -207,6 +207,21 @@ describe("McpProtocolHandler", () => {
 		expect(output.text).not.toContain("interpreted as");
 	});
 
+	it("rejects a sibling target after an MCP-owned pseudo-URI prefix", async () => {
+		const uri = "attachment://1;view";
+		const resources = new Map<string, { resources: MCPResource[]; templates: MCPResourceTemplate[] }>();
+		resources.set("pseudo", {
+			resources: [{ uri, name: "pseudo-resource" }],
+			templates: [],
+		});
+		MCPManager.setInstance(createMockManager({ servers: ["pseudo"], resources }));
+
+		await expect(
+			new ReadTool(createToolSession()).execute("read-pseudo-resource-batch", {
+				path: `${uri};package.json`,
+			}),
+		).rejects.toThrow(`Cannot batch MCP resource "${uri}" with other targets`);
+	});
 	it("does not let a broad MCP template swallow a valid pseudo-URI batch", async () => {
 		const resources = new Map<string, { resources: MCPResource[]; templates: MCPResourceTemplate[] }>();
 		resources.set("pseudo", {

--- a/packages/coding-agent/test/internal-urls/mcp-protocol.test.ts
+++ b/packages/coding-agent/test/internal-urls/mcp-protocol.test.ts
@@ -154,7 +154,7 @@ describe("McpProtocolHandler", () => {
 		expect(output.text).not.toContain("interpreted as");
 	});
 
-	it.each(["attachment://doc;view", "conflict://doc;view"])(
+	it.each(["attachment://1;view", "conflict://1;view"])(
 		"preserves an exact MCP resource using the %s pseudo-scheme",
 		async uri => {
 			const resources = new Map<string, { resources: MCPResource[]; templates: MCPResourceTemplate[] }>();

--- a/packages/coding-agent/test/internal-urls/mcp-protocol.test.ts
+++ b/packages/coding-agent/test/internal-urls/mcp-protocol.test.ts
@@ -131,6 +131,29 @@ describe("McpProtocolHandler", () => {
 		expect(output.text).not.toContain("interpreted as");
 	});
 
+	it("preserves a literal semicolon in a native MCP resource URI", async () => {
+		const uri = "catalog://items;active";
+		const resources = new Map<string, { resources: MCPResource[]; templates: MCPResourceTemplate[] }>();
+		resources.set("catalog", {
+			resources: [{ uri, name: "active-items" }],
+			templates: [],
+		});
+		const manager = createMockManager({
+			servers: ["catalog"],
+			resources,
+			readResult: { contents: [{ uri, text: "active items" }] },
+		});
+		MCPManager.setInstance(manager);
+
+		const result = await new ReadTool(createToolSession()).execute("read-native-semicolon-resource", { path: uri });
+		const output = result.content.find(block => block.type === "text");
+
+		expect(output?.type).toBe("text");
+		if (output?.type !== "text") throw new Error("Expected text output");
+		expect(output.text).toContain("active items");
+		expect(output.text).not.toContain("interpreted as");
+	});
+
 	it("lets read consume a native URI advertised by an MCP server", async () => {
 		const resources = new Map<string, { resources: MCPResource[]; templates: MCPResourceTemplate[] }>();
 		resources.set("ags", {

--- a/packages/coding-agent/test/internal-urls/mcp-protocol.test.ts
+++ b/packages/coding-agent/test/internal-urls/mcp-protocol.test.ts
@@ -154,6 +154,31 @@ describe("McpProtocolHandler", () => {
 		expect(output.text).not.toContain("interpreted as");
 	});
 
+	it.each(["attachment://doc;view", "conflict://doc;view"])(
+		"preserves an exact MCP resource using the %s pseudo-scheme",
+		async uri => {
+			const resources = new Map<string, { resources: MCPResource[]; templates: MCPResourceTemplate[] }>();
+			resources.set("pseudo", {
+				resources: [{ uri, name: "pseudo-resource" }],
+				templates: [],
+			});
+			const manager = createMockManager({
+				servers: ["pseudo"],
+				resources,
+				readResult: { contents: [{ uri, text: "pseudo payload" }] },
+			});
+			MCPManager.setInstance(manager);
+
+			const result = await new ReadTool(createToolSession()).execute("read-pseudo-resource", { path: uri });
+			const output = result.content.find(block => block.type === "text");
+
+			expect(output?.type).toBe("text");
+			if (output?.type !== "text") throw new Error("Expected text output");
+			expect(output.text).toContain("pseudo payload");
+			expect(output.text).not.toContain("interpreted as");
+		},
+	);
+
 	it("lets read consume a native URI advertised by an MCP server", async () => {
 		const resources = new Map<string, { resources: MCPResource[]; templates: MCPResourceTemplate[] }>();
 		resources.set("ags", {

--- a/packages/coding-agent/test/internal-urls/mcp-protocol.test.ts
+++ b/packages/coding-agent/test/internal-urls/mcp-protocol.test.ts
@@ -179,6 +179,81 @@ describe("McpProtocolHandler", () => {
 		},
 	);
 
+	it("awaits the MCP catalog before classifying a pseudo-scheme URI", async () => {
+		const uri = "attachment://1;view";
+		const resources = new Map<string, { resources: MCPResource[]; templates: MCPResourceTemplate[] }>();
+		let catalogLoaded = false;
+		const manager = createMockManager({
+			servers: ["pseudo"],
+			resources,
+			ensureResources: async name => {
+				catalogLoaded = true;
+				resources.set(name, {
+					resources: [{ uri, name: "pseudo-resource" }],
+					templates: [],
+				});
+			},
+			readResult: { contents: [{ uri, text: "loaded pseudo payload" }] },
+		});
+		MCPManager.setInstance(manager);
+
+		const result = await new ReadTool(createToolSession()).execute("read-loading-pseudo-resource", { path: uri });
+		const output = result.content.find(block => block.type === "text");
+
+		expect(catalogLoaded).toBeTrue();
+		expect(output?.type).toBe("text");
+		if (output?.type !== "text") throw new Error("Expected text output");
+		expect(output.text).toContain("loaded pseudo payload");
+		expect(output.text).not.toContain("interpreted as");
+	});
+
+	it("does not let a broad MCP template swallow a valid pseudo-URI batch", async () => {
+		const resources = new Map<string, { resources: MCPResource[]; templates: MCPResourceTemplate[] }>();
+		resources.set("pseudo", {
+			resources: [],
+			templates: [{ uriTemplate: "attachment://{id}", name: "attachment-template" }],
+		});
+		const manager = createMockManager({
+			servers: ["pseudo"],
+			resources,
+			readResult: { contents: [{ uri: "attachment://1;attachment://2", text: "template payload" }] },
+		});
+		MCPManager.setInstance(manager);
+
+		const result = await new ReadTool(createToolSession()).execute("read-pseudo-batch", {
+			path: "attachment://1;attachment://2",
+		});
+		const output = result.content.find(block => block.type === "text");
+
+		expect(output?.type).toBe("text");
+		if (output?.type !== "text") throw new Error("Expected text output");
+		expect(output.text).toContain("interpreted as 2 paths");
+		expect(output.text).not.toContain("template payload");
+	});
+
+	it("preserves a pseudo-scheme template URI whose semicolon is literal", async () => {
+		const uri = "attachment://1;view";
+		const resources = new Map<string, { resources: MCPResource[]; templates: MCPResourceTemplate[] }>();
+		resources.set("pseudo", {
+			resources: [],
+			templates: [{ uriTemplate: "attachment://{id};view", name: "pseudo-template" }],
+		});
+		const manager = createMockManager({
+			servers: ["pseudo"],
+			resources,
+			readResult: { contents: [{ uri, text: "literal template payload" }] },
+		});
+		MCPManager.setInstance(manager);
+
+		const result = await new ReadTool(createToolSession()).execute("read-pseudo-template", { path: uri });
+		const output = result.content.find(block => block.type === "text");
+
+		expect(output?.type).toBe("text");
+		if (output?.type !== "text") throw new Error("Expected text output");
+		expect(output.text).toContain("literal template payload");
+		expect(output.text).not.toContain("interpreted as");
+	});
+
 	it("lets read consume a native URI advertised by an MCP server", async () => {
 		const resources = new Map<string, { resources: MCPResource[]; templates: MCPResourceTemplate[] }>();
 		resources.set("ags", {

--- a/packages/coding-agent/test/read-tool.test.ts
+++ b/packages/coding-agent/test/read-tool.test.ts
@@ -11,7 +11,7 @@ import { removeSyncWithRetries } from "@oh-my-pi/pi-utils";
 const TINY_PNG_BASE64 =
 	"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg==";
 
-function createSession(cwd: string, sourcePath: string): ToolSession {
+function createSession(cwd: string, sourcePath: string, attachmentCount = 1): ToolSession {
 	const image: ImageContent = { type: "image", data: TINY_PNG_BASE64, mimeType: "image/png" };
 	return {
 		cwd,
@@ -19,7 +19,13 @@ function createSession(cwd: string, sourcePath: string): ToolSession {
 		getSessionFile: () => null,
 		getSessionSpawns: () => "*",
 		settings: Settings.isolated({ "images.autoResize": false, "inspect_image.enabled": false }),
-		getImageAttachments: () => [{ label: "Image #1", uri: "attachment://1", image, sourcePath }],
+		getImageAttachments: () =>
+			Array.from({ length: attachmentCount }, (_, index) => ({
+				label: `Image #${index + 1}`,
+				uri: `attachment://${index + 1}`,
+				image,
+				sourcePath,
+			})),
 	};
 }
 
@@ -48,6 +54,18 @@ describe("read attachment URLs", () => {
 			data: TINY_PNG_BASE64,
 			mimeType: "image/png",
 		});
+	});
+
+	it("reads several attachment URLs from one semicolon-delimited path", async () => {
+		const result = await new ReadTool(createSession(testDir, imagePath, 2)).execute("read-attachment-batch", {
+			path: "attachment://1;attachment://2",
+		});
+		const text = result.content.flatMap(block => (block.type === "text" ? [block.text] : [])).join("\n");
+		const images = result.content.filter(block => block.type === "image");
+
+		expect(text).toContain("Note: interpreted as 2 paths: attachment://1, attachment://2");
+		expect(images).toHaveLength(2);
+		expect(result.details?.displayReadTargets).toEqual(["attachment://1", "attachment://2"]);
 	});
 
 	it("reports unknown attachment URLs with the available URIs", async () => {

--- a/packages/coding-agent/test/read-tool.test.ts
+++ b/packages/coding-agent/test/read-tool.test.ts
@@ -116,18 +116,23 @@ describe("read attachment URLs", () => {
 		expect(text).not.toContain("interpreted as");
 	});
 
-	it("reads a URL-shaped local first target before URL dispatch", async () => {
+	it("reads a selected URL-shaped local target before URL dispatch in either batch position", async () => {
 		await Bun.write(path.join(testDir, "www.example"), "local domain path\n");
 		await Bun.write(path.join(testDir, "second.txt"), "second file\n");
 
-		const result = await new ReadTool(createSession(testDir, imagePath)).execute("read-local-url-shaped-batch", {
-			path: "www.example;second.txt",
-		});
-		const text = result.content.flatMap(block => (block.type === "text" ? [block.text] : [])).join("\n");
+		for (const targets of [
+			["www.example:1-1", "second.txt"],
+			["second.txt", "www.example:1-1"],
+		]) {
+			const result = await new ReadTool(createSession(testDir, imagePath)).execute("read-local-url-shaped-batch", {
+				path: targets.join(";"),
+			});
+			const text = result.content.flatMap(block => (block.type === "text" ? [block.text] : [])).join("\n");
 
-		expect(text).toContain("local domain path");
-		expect(text).toContain("second file");
-		expect(result.details?.displayReadTargets).toEqual(["www.example", "second.txt"]);
+			expect(text).toContain("local domain path");
+			expect(text).toContain("second file");
+			expect(result.details?.displayReadTargets).toEqual(targets);
+		}
 	});
 
 	it("reports unknown attachment URLs with the available URIs", async () => {

--- a/packages/coding-agent/test/read-tool.test.ts
+++ b/packages/coding-agent/test/read-tool.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import * as url from "node:url";
 import type { ImageContent } from "@oh-my-pi/pi-ai";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
@@ -66,6 +67,24 @@ describe("read attachment URLs", () => {
 		expect(text).toContain("Note: interpreted as 2 paths: attachment://1, attachment://2");
 		expect(images).toHaveLength(2);
 		expect(result.details?.displayReadTargets).toEqual(["attachment://1", "attachment://2"]);
+	});
+
+	it("splits file URL batches before decoding encoded semicolons", async () => {
+		const firstPath = path.join(testDir, "first;file.txt");
+		const secondPath = path.join(testDir, "second.txt");
+		await Bun.write(firstPath, "first file\n");
+		await Bun.write(secondPath, "second file\n");
+		const firstUrl = url.pathToFileURL(firstPath).href.replace(";", "%3B");
+		const secondUrl = url.pathToFileURL(secondPath).href;
+
+		const result = await new ReadTool(createSession(testDir, imagePath)).execute("read-file-url-batch", {
+			path: `${firstUrl};${secondUrl}`,
+		});
+		const text = result.content.flatMap(block => (block.type === "text" ? [block.text] : [])).join("\n");
+
+		expect(text).toContain("first file");
+		expect(text).toContain("second file");
+		expect(result.details?.displayReadTargets).toEqual([firstUrl, secondUrl]);
 	});
 
 	it("reports unknown attachment URLs with the available URIs", async () => {

--- a/packages/coding-agent/test/read-tool.test.ts
+++ b/packages/coding-agent/test/read-tool.test.ts
@@ -74,8 +74,8 @@ describe("read attachment URLs", () => {
 		const secondPath = path.join(testDir, "second.txt");
 		await Bun.write(firstPath, "first file\n");
 		await Bun.write(secondPath, "second file\n");
-		const firstUrl = url.pathToFileURL(firstPath).href.replace(";", "%3B");
-		const secondUrl = url.pathToFileURL(secondPath).href;
+		const firstUrl = url.pathToFileURL(firstPath).href.replace("file:", "FILE:").replace(";", "%3B");
+		const secondUrl = url.pathToFileURL(secondPath).href.replace("file:", "FILE:");
 
 		const result = await new ReadTool(createSession(testDir, imagePath)).execute("read-file-url-batch", {
 			path: `${firstUrl};${secondUrl}`,

--- a/packages/coding-agent/test/read-tool.test.ts
+++ b/packages/coding-agent/test/read-tool.test.ts
@@ -101,6 +101,21 @@ describe("read attachment URLs", () => {
 		expect(text).not.toContain("interpreted as");
 	});
 
+	it("preserves a selected file URL containing a literal semicolon", async () => {
+		const filePath = path.join(testDir, "selected;file.txt");
+		await Bun.write(filePath, "selected file\nsecond line\n");
+		const fileUrl = `${url.pathToFileURL(filePath).href}:1-1`;
+
+		const result = await new ReadTool(createSession(testDir, imagePath)).execute("read-selected-file-url", {
+			path: fileUrl,
+		});
+		const text = result.content.flatMap(block => (block.type === "text" ? [block.text] : [])).join("\n");
+
+		expect(text).toContain("selected file");
+		expect(text).toContain("[selected;file.txt#");
+		expect(text).not.toContain("interpreted as");
+	});
+
 	it("reads a URL-shaped local first target before URL dispatch", async () => {
 		await Bun.write(path.join(testDir, "www.example"), "local domain path\n");
 		await Bun.write(path.join(testDir, "second.txt"), "second file\n");

--- a/packages/coding-agent/test/read-tool.test.ts
+++ b/packages/coding-agent/test/read-tool.test.ts
@@ -87,6 +87,20 @@ describe("read attachment URLs", () => {
 		expect(result.details?.displayReadTargets).toEqual([firstUrl, secondUrl]);
 	});
 
+	it("preserves one file URL containing a literal semicolon", async () => {
+		const filePath = path.join(testDir, "single;file.txt");
+		await Bun.write(filePath, "single file\n");
+		const fileUrl = url.pathToFileURL(filePath).href;
+
+		const result = await new ReadTool(createSession(testDir, imagePath)).execute("read-single-file-url", {
+			path: fileUrl,
+		});
+		const text = result.content.flatMap(block => (block.type === "text" ? [block.text] : [])).join("\n");
+
+		expect(text).toContain("single file");
+		expect(text).not.toContain("interpreted as");
+	});
+
 	it("reads a URL-shaped local first target before URL dispatch", async () => {
 		await Bun.write(path.join(testDir, "www.example"), "local domain path\n");
 		await Bun.write(path.join(testDir, "second.txt"), "second file\n");

--- a/packages/coding-agent/test/read-tool.test.ts
+++ b/packages/coding-agent/test/read-tool.test.ts
@@ -87,6 +87,20 @@ describe("read attachment URLs", () => {
 		expect(result.details?.displayReadTargets).toEqual([firstUrl, secondUrl]);
 	});
 
+	it("reads a URL-shaped local first target before URL dispatch", async () => {
+		await Bun.write(path.join(testDir, "www.example"), "local domain path\n");
+		await Bun.write(path.join(testDir, "second.txt"), "second file\n");
+
+		const result = await new ReadTool(createSession(testDir, imagePath)).execute("read-local-url-shaped-batch", {
+			path: "www.example;second.txt",
+		});
+		const text = result.content.flatMap(block => (block.type === "text" ? [block.text] : [])).join("\n");
+
+		expect(text).toContain("local domain path");
+		expect(text).toContain("second file");
+		expect(result.details?.displayReadTargets).toEqual(["www.example", "second.txt"]);
+	});
+
 	it("reports unknown attachment URLs with the available URIs", async () => {
 		const tool = new ReadTool(createSession(testDir, imagePath));
 

--- a/packages/coding-agent/test/skill-protocol-customdirs.test.ts
+++ b/packages/coding-agent/test/skill-protocol-customdirs.test.ts
@@ -94,6 +94,56 @@ describe("skill:// resolution honors skills.customDirectories (#7190)", () => {
 		expect(historyText).toContain("Could not read history://missing-second:1-3");
 	});
 
+	it("distinguishes mixed target delimiters from encoded internal URL semicolons", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-mixed-delimited-skills-"));
+		tempDirs.push(tempDir);
+		const skillDir = path.join(tempDir, "mixed-skill");
+		await fs.mkdir(skillDir, { recursive: true });
+		await Bun.write(path.join(skillDir, "SKILL.md"), makeSkillMd("mixed-skill", tempDir));
+		await Bun.write(path.join(skillDir, "reference;guide.md"), "encoded semicolon resource\n");
+
+		const localFile = path.join(tempDir, "local.txt");
+		await Bun.write(localFile, "local file content\n");
+
+		const { skills } = await loadSkills({
+			...ALL_DEFAULT_SOURCES_DISABLED,
+			customDirectories: [tempDir],
+		});
+		setActiveSkills(skills);
+
+		const session: ToolSession = {
+			cwd: tempDir,
+			hasUI: false,
+			getSessionFile: () => null,
+			getSessionSpawns: () => "*",
+			settings: Settings.isolated(),
+		};
+		const readTool = new ReadTool(session);
+		const mixedTargets = [
+			["read-mixed-internal-first", `skill://mixed-skill;${localFile}`],
+			["read-mixed-file-first", `${localFile};skill://mixed-skill`],
+		] as const;
+
+		for (const [toolCallId, readPath] of mixedTargets) {
+			const result = await readTool.execute(toolCallId, { path: readPath });
+			const text = result.content.flatMap(block => (block.type === "text" ? [block.text] : [])).join("\n");
+
+			expect(text).toContain("Note: interpreted as 2 paths:");
+			expect(text).toContain("mixed-skill skill.");
+			expect(text).toContain("local file content");
+		}
+
+		const encodedResult = await readTool.execute("read-encoded-internal-semicolon", {
+			path: "skill://mixed-skill/reference%3Bguide.md",
+		});
+		const encodedText = encodedResult.content
+			.flatMap(block => (block.type === "text" ? [block.text] : []))
+			.join("\n");
+
+		expect(encodedText).toContain("encoded semicolon resource");
+		expect(encodedText).not.toContain("Note: interpreted as");
+	});
+
 	it("keeps first-wins across multiple custom directories", async () => {
 		const dirA = await fs.mkdtemp(path.join(os.tmpdir(), "pi-custom-a-"));
 		tempDirs.push(dirA);

--- a/packages/coding-agent/test/tools/conflict-integration.test.ts
+++ b/packages/coding-agent/test/tools/conflict-integration.test.ts
@@ -143,6 +143,21 @@ describe("read surfaces conflicts as a warning footer", () => {
 		expect(session.conflictHistory?.get(2)?.oursLines).toEqual(["b-ours"]);
 	});
 
+	it("reads several registered conflicts from one semicolon-delimited path", async () => {
+		const filePath = path.join(tempDir, "batched-conflicts.ts");
+		await Bun.write(filePath, TWO_BLOCKS);
+		const session = createTestSession(tempDir);
+		const read = await getTool(session, "read");
+
+		await read.execute("register-batched-conflicts", { path: "batched-conflicts.ts:conflicts" });
+		const result = await read.execute("read-batched-conflicts", { path: "conflict://1;conflict://2" });
+		const text = getText(result);
+		expect(text).toContain("Note: interpreted as 2 paths: conflict://1, conflict://2");
+		expect(text).toContain("a-ours");
+		expect(text).toContain("b-ours");
+		expect(result.details?.displayReadTargets).toEqual(["conflict://1", "conflict://2"]);
+	});
+
 	it("emits no warning on clean files and does not touch the history", async () => {
 		const filePath = path.join(tempDir, "clean.ts");
 		await Bun.write(filePath, "const a = 1;\nconst b = 2;\n");

--- a/packages/coding-agent/test/tools/glob-validate-paths.test.ts
+++ b/packages/coding-agent/test/tools/glob-validate-paths.test.ts
@@ -69,6 +69,15 @@ describe("delimited path expansion", () => {
 		expect(await splitDelimitedPathEntry("artifact://abc123;https://example.com/a;b", tempDir, options)).toBeNull();
 		expect(await splitDelimitedPathEntry("conflict://1;https://example.com/a", tempDir, options)).toBeNull();
 		expect(await splitDelimitedPathEntry("artifact://abc123;catalog://items;active", tempDir, options)).toBeNull();
+		expect(await splitDelimitedPathEntry("artifact://abc123;urn:example;view", tempDir, options)).toBeNull();
+	});
+
+	it("keeps registered device URIs batchable", async () => {
+		expect(
+			await splitDelimitedPathEntry("xd://resolve;packages/b.txt", tempDir, {
+				splitInternalUrlSemicolons: true,
+			}),
+		).toEqual(["xd://resolve", "packages/b.txt"]);
 	});
 
 	it("keeps an existing path with spaces intact", async () => {

--- a/packages/coding-agent/test/tools/glob-validate-paths.test.ts
+++ b/packages/coding-agent/test/tools/glob-validate-paths.test.ts
@@ -40,9 +40,11 @@ describe("delimited path expansion", () => {
 		await fs.mkdir(path.join(tempDir, "packages"), { recursive: true });
 		await fs.mkdir(path.join(tempDir, "src"), { recursive: true });
 		await fs.mkdir(path.join(tempDir, "folder with spaces"), { recursive: true });
+		await fs.mkdir(path.join(tempDir, "www.example"), { recursive: true });
 		await Bun.write(path.join(tempDir, "apps", "a.txt"), "apps\n");
 		await Bun.write(path.join(tempDir, "packages", "b.txt"), "packages\n");
 		await Bun.write(path.join(tempDir, "folder with spaces", "file.txt"), "spaces\n");
+		await Bun.write(path.join(tempDir, "notes:detail"), "colon\n");
 	});
 
 	afterEach(async () => {
@@ -78,6 +80,17 @@ describe("delimited path expansion", () => {
 				splitInternalUrlSemicolons: true,
 			}),
 		).toEqual(["xd://resolve", "packages/b.txt"]);
+	});
+
+	it("keeps URL-shaped existing local children batchable", async () => {
+		expect(await splitDelimitedPathEntry("www.example;packages/b.txt", tempDir)).toEqual([
+			"www.example",
+			"packages/b.txt",
+		]);
+		expect(await splitDelimitedPathEntry("notes:detail;packages/b.txt", tempDir)).toEqual([
+			"notes:detail",
+			"packages/b.txt",
+		]);
 	});
 
 	it("keeps an existing path with spaces intact", async () => {

--- a/packages/coding-agent/test/tools/glob-validate-paths.test.ts
+++ b/packages/coding-agent/test/tools/glob-validate-paths.test.ts
@@ -64,12 +64,10 @@ describe("delimited path expansion", () => {
 		]);
 	});
 
-	it("rejects HTTP children from internal semicolon batches", async () => {
-		expect(
-			await splitDelimitedPathEntry("artifact://abc123;https://example.com/a;b", tempDir, {
-				splitInternalUrlSemicolons: true,
-			}),
-		).toBeNull();
+	it("rejects HTTP children from every semicolon batch route", async () => {
+		const options = { splitInternalUrlSemicolons: true };
+		expect(await splitDelimitedPathEntry("artifact://abc123;https://example.com/a;b", tempDir, options)).toBeNull();
+		expect(await splitDelimitedPathEntry("conflict://1;https://example.com/a", tempDir, options)).toBeNull();
 	});
 
 	it("keeps an existing path with spaces intact", async () => {

--- a/packages/coding-agent/test/tools/glob-validate-paths.test.ts
+++ b/packages/coding-agent/test/tools/glob-validate-paths.test.ts
@@ -67,7 +67,10 @@ describe("delimited path expansion", () => {
 	});
 
 	it("rejects external or opaque URL children from every semicolon batch route", async () => {
-		const options = { splitInternalUrlSemicolons: true };
+		const options = {
+			rejectExternalOrOpaqueUrlChildren: true,
+			splitInternalUrlSemicolons: true,
+		};
 		expect(await splitDelimitedPathEntry("artifact://abc123;https://example.com/a;b", tempDir, options)).toBeNull();
 		expect(await splitDelimitedPathEntry("conflict://1;https://example.com/a", tempDir, options)).toBeNull();
 		expect(await splitDelimitedPathEntry("artifact://abc123;catalog://items;active", tempDir, options)).toBeNull();
@@ -78,16 +81,18 @@ describe("delimited path expansion", () => {
 		expect(
 			await splitDelimitedPathEntry("xd://resolve;packages/b.txt", tempDir, {
 				splitInternalUrlSemicolons: true,
+				rejectExternalOrOpaqueUrlChildren: true,
 			}),
 		).toEqual(["xd://resolve", "packages/b.txt"]);
 	});
 
 	it("keeps URL-shaped existing local children batchable", async () => {
-		expect(await splitDelimitedPathEntry("www.example;packages/b.txt", tempDir)).toEqual([
+		const options = { rejectExternalOrOpaqueUrlChildren: true };
+		expect(await splitDelimitedPathEntry("www.example;packages/b.txt", tempDir, options)).toEqual([
 			"www.example",
 			"packages/b.txt",
 		]);
-		expect(await splitDelimitedPathEntry("notes:detail;packages/b.txt", tempDir)).toEqual([
+		expect(await splitDelimitedPathEntry("notes:detail;packages/b.txt", tempDir, options)).toEqual([
 			"notes:detail",
 			"packages/b.txt",
 		]);

--- a/packages/coding-agent/test/tools/glob-validate-paths.test.ts
+++ b/packages/coding-agent/test/tools/glob-validate-paths.test.ts
@@ -64,10 +64,11 @@ describe("delimited path expansion", () => {
 		]);
 	});
 
-	it("rejects HTTP children from every semicolon batch route", async () => {
+	it("rejects external or opaque URL children from every semicolon batch route", async () => {
 		const options = { splitInternalUrlSemicolons: true };
 		expect(await splitDelimitedPathEntry("artifact://abc123;https://example.com/a;b", tempDir, options)).toBeNull();
 		expect(await splitDelimitedPathEntry("conflict://1;https://example.com/a", tempDir, options)).toBeNull();
+		expect(await splitDelimitedPathEntry("artifact://abc123;catalog://items;active", tempDir, options)).toBeNull();
 	});
 
 	it("keeps an existing path with spaces intact", async () => {

--- a/packages/coding-agent/test/tools/glob-validate-paths.test.ts
+++ b/packages/coding-agent/test/tools/glob-validate-paths.test.ts
@@ -64,6 +64,14 @@ describe("delimited path expansion", () => {
 		]);
 	});
 
+	it("rejects HTTP children from internal semicolon batches", async () => {
+		expect(
+			await splitDelimitedPathEntry("artifact://abc123;https://example.com/a;b", tempDir, {
+				splitInternalUrlSemicolons: true,
+			}),
+		).toBeNull();
+	});
+
 	it("keeps an existing path with spaces intact", async () => {
 		expect(await splitDelimitedPathEntry("folder with spaces/file.txt", tempDir)).toBeNull();
 		expect(await expandDelimitedPathEntries(["folder with spaces/file.txt"], tempDir)).toEqual([

--- a/packages/coding-agent/test/tools/glob-validate-paths.test.ts
+++ b/packages/coding-agent/test/tools/glob-validate-paths.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
+import * as url from "node:url";
 import type { RenderResultOptions } from "@oh-my-pi/pi-coding-agent/extensibility/custom-tools/types";
 import { getThemeByName, initTheme, type Theme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import {
@@ -75,6 +76,10 @@ describe("delimited path expansion", () => {
 		expect(await splitDelimitedPathEntry("conflict://1;https://example.com/a", tempDir, options)).toBeNull();
 		expect(await splitDelimitedPathEntry("artifact://abc123;catalog://items;active", tempDir, options)).toBeNull();
 		expect(await splitDelimitedPathEntry("artifact://abc123;urn:example;view", tempDir, options)).toBeNull();
+		const filePath = path.join(tempDir, "nested;file.txt");
+		await Bun.write(filePath, "nested\n");
+		const fileUrl = url.pathToFileURL(filePath).href;
+		expect(await splitDelimitedPathEntry(`artifact://abc123;${fileUrl}`, tempDir, options)).toBeNull();
 	});
 
 	it("keeps registered device URIs batchable", async () => {

--- a/packages/coding-agent/test/tools/read-guidance.test.ts
+++ b/packages/coding-agent/test/tools/read-guidance.test.ts
@@ -13,22 +13,7 @@ function createSession(): ToolSession {
 	};
 }
 
-describe("Read guidance", () => {
-	it("batches compatible targets while preserving opaque resource semicolons", () => {
-		const description = new ReadTool(createSession()).description;
-
-		expect(description).toContain("MUST collect every bounded target");
-		expect(description).toContain("MUST batch independent known local paths, file URLs, and internal URIs");
-		expect(description).toContain("For independent MCP resources, issue separate sibling `read` calls");
-		expect(description).toContain("Preserve MCP resource URIs exactly");
-		expect(description).toContain("NEVER split or percent-encode server-provided semicolons");
-		expect(description).toContain("For independent HTTP(S) URLs, issue separate sibling `read` calls");
-		expect(description).toContain("NEVER combine an HTTP(S) URL with another target");
-		expect(description).toContain("SQLite semicolons in SQL, table names, or row keys remain target data");
-		expect(description).toContain("Literal semicolons inside batch-compatible internal URIs MUST use `%3B`");
-		expect(description).toContain("artifact://abc123;package.json;src/main.ts:1-200");
-	});
-
+describe("Read SSH guidance", () => {
 	it("advertises grep and current SSH fallbacks instead of retired tool names", () => {
 		const description = new ReadTool(createSession()).description;
 

--- a/packages/coding-agent/test/tools/read-guidance.test.ts
+++ b/packages/coding-agent/test/tools/read-guidance.test.ts
@@ -13,7 +13,22 @@ function createSession(): ToolSession {
 	};
 }
 
-describe("Read SSH guidance", () => {
+describe("Read guidance", () => {
+	it("batches compatible targets while preserving opaque resource semicolons", () => {
+		const description = new ReadTool(createSession()).description;
+
+		expect(description).toContain("MUST collect every bounded target");
+		expect(description).toContain("MUST batch independent known local paths, file URLs, and internal URIs");
+		expect(description).toContain("For independent MCP resources, issue separate sibling `read` calls");
+		expect(description).toContain("Preserve MCP resource URIs exactly");
+		expect(description).toContain("NEVER split or percent-encode server-provided semicolons");
+		expect(description).toContain("For independent HTTP(S) URLs, issue separate sibling `read` calls");
+		expect(description).toContain("NEVER combine an HTTP(S) URL with another target");
+		expect(description).toContain("SQLite semicolons in SQL, table names, or row keys remain target data");
+		expect(description).toContain("Literal semicolons inside batch-compatible internal URIs MUST use `%3B`");
+		expect(description).toContain("artifact://abc123;package.json;src/main.ts:1-200");
+	});
+
 	it("advertises grep and current SSH fallbacks instead of retired tool names", () => {
 		const description = new ReadTool(createSession()).description;
 


### PR DESCRIPTION
## What

- Require one semicolon-delimited Read call for bounded known local paths and internal resources.
- Make mixed internal and local batches work in either target order through the existing scalar batch owner.
- Keep HTTP(S) URLs separate and preserve ambiguous literal semicolons as target data.
- Preserve exact MCP resource URIs containing literal semicolons.

## Why

Local file access is cheap, but every additional Read decision can trigger another expensive Main continuation.
The current prompt only recommends parallel reads and does not expose the existing single-call grammar.

### Measured impact

- One observed five-file Read returned 3,422 selected tokens in 22 ms.
- Its following Main continuation processed 212,450 tokens, including 207,616 cached tokens.
- That continuation carried a $0.1139344 API price proxy; ChatGPT Pro covered the actual usage.
- Four serial cache replays would add at least $0.3321856 under the same fixed-prefix assumption.
- The estimated five-Read proxy is $0.46–$0.49 versus $0.1139 batched, saving about $0.35–$0.38.

The serial figures are a conservative counterfactual, not an observed control run.
Batching preserves the same selected file content; it removes four intermediate model decisions.

## Scope

This preserves the scalar `path` API and existing serial target execution.
It does not add native arrays, internal concurrency, renderer changes, or structured-selector heuristics.
PR #10465 attempted that broader scalar expansion and was withdrawn.
PR #7000 proposes a substantially larger native-array API and consumer closure.

## Testing

- Focused Read suite: 172 tests passed with 605 assertions.
- Final mixed-batch and MCP regression rerun: 30 tests passed with 72 assertions.
- Coding-agent and complete workspace checks passed.
- Rendered Read prompt and final diff inspected.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated