### PR TITLE
fix(github): preserve actionable API diagnostics

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- GitHub failures now retain structured API diagnostics, identify failed file reads, and clarify Boolean search syntax.
+
 ## [18.1.3] - 2026-09-02
 
 ### Changed

--- a/packages/coding-agent/src/prompts/tools/github.md
+++ b/packages/coding-agent/src/prompts/tools/github.md
@@ -10,6 +10,7 @@ Select via `op`.
 - `pr_push`: requires prior `op: pr_checkout`.
 - `search_issues`/`search_prs`/`search_commits`/`search_repos`: `query` optional with `since`/`until`; omit for date-only filter. `search_code`: `query` required; rejects `since`/`until`.
 - `search_*`: `repo` defaults current checkout's `owner/repo`; search elsewhere with `repo:`/`org:`/`user:` in `query`. `search_repos`: ignores `repo`; scope via `org:`/`language:` in `query`.
+- Boolean `AND`/`OR`/`NOT` combine text terms, not qualifiers; never place them between qualifiers.
 - `since`/`until`: relative `<n>` + `m`/`h`/`d`/`w`/`mo`/`y` (e.g. `3d`, `2w`), ISO date `YYYY-MM-DD`, or ISO datetime. `dateField: "updated"`: update time (issues/PRs), push time (repos), never creation.
 - `run_watch`: omit `run` → every run for current HEAD; `branch` defaults current. Fast-fails first job failure.
 </instruction>

--- a/packages/coding-agent/src/tools/gh.ts
+++ b/packages/coding-agent/src/tools/gh.ts
@@ -286,10 +286,21 @@ async function executeFileRead(
 	if (branch) {
 		args.push("-f", `ref=${branch}`);
 	}
-	const response = await github.json<GitHubContentsResponse>(session.cwd, args, signal, {
-		repoProvided: true,
-		trimOutput: false,
-	});
+	let response: GitHubContentsResponse;
+	try {
+		response = await github.json<GitHubContentsResponse>(session.cwd, args, signal, {
+			repoProvided: true,
+			trimOutput: false,
+		});
+	} catch (error) {
+		if (!(error instanceof ToolError)) throw error;
+		// Contents API 404s conflate repository, revision, path, and access failures; identify the request without guessing.
+		const revision = branch ?? "HEAD";
+		throw new ToolError(
+			`GitHub file read failed for '${repo}@${revision}:${filePath}': ${error.message}`,
+			error.context,
+		);
+	}
 	if (!isGitHubContentsFile(response)) {
 		throw new ToolError(`GitHub path '${filePath}' is not a file.`);
 	}

--- a/packages/coding-agent/src/utils/github.ts
+++ b/packages/coding-agent/src/utils/github.ts
@@ -1,4 +1,4 @@
-import { $which } from "@oh-my-pi/pi-utils";
+import { $which, isRecord } from "@oh-my-pi/pi-utils";
 import { REJECT_PROMPT_COMMAND } from "../exec/non-interactive-env";
 import { ToolAbortError, ToolError, throwIfAborted } from "../tools/tool-errors";
 
@@ -73,6 +73,54 @@ function formatGhFailure(args: readonly string[], stdout: string, stderr: string
 	return `GitHub CLI command failed: gh ${args.join(" ")}`;
 }
 
+function describeGitHubApiError(value: unknown): string | undefined {
+	if (typeof value === "string") return value.trim() || undefined;
+	if (!isRecord(value)) return undefined;
+	if (typeof value.message === "string") return value.message.trim() || undefined;
+
+	const resource = typeof value.resource === "string" ? value.resource.trim() : "";
+	const field = typeof value.field === "string" ? value.field.trim() : "";
+	const target = [resource, field].filter(Boolean).join(".");
+	const code = typeof value.code === "string" ? value.code.trim() : "";
+	if (target && code) return `${target}: ${code}`;
+	return target || code || undefined;
+}
+
+function parseGitHubApiErrorMessages(stdout: string): string[] {
+	let payload: unknown;
+	try {
+		payload = JSON.parse(stdout);
+	} catch {
+		return [];
+	}
+	if (!isRecord(payload)) return [];
+
+	const messages = new Set<string>();
+	const summary = describeGitHubApiError(payload.message);
+	if (summary) messages.add(summary);
+	if (Array.isArray(payload.errors)) {
+		for (const error of payload.errors) {
+			const message = describeGitHubApiError(error);
+			if (message) messages.add(message);
+		}
+	}
+	return [...messages];
+}
+
+function formatGhJsonFailure(
+	args: readonly string[],
+	stdout: string,
+	stderr: string,
+	options?: GhCommandOptions,
+): string {
+	const rawMessage = (stderr || stdout).trim();
+	const fallback = formatGhFailure(args, stdout, stderr, options);
+	if (fallback !== rawMessage) return fallback;
+	const details = parseGitHubApiErrorMessages(stdout).filter(message => !fallback.includes(message));
+	if (details.length === 0) return fallback;
+	return `${fallback}\nGitHub details:\n${details.map(message => `- ${message}`).join("\n")}`;
+}
+
 /** The sanctioned `gh` CLI runner: non-interactive env, bounded capture, deadline. */
 export const github = {
 	/** Check if the `gh` CLI is installed. */
@@ -123,7 +171,9 @@ export const github = {
 	/** Run `gh` and parse stdout as JSON. Throws on non-zero exit or invalid JSON. */
 	async json<T>(cwd: string, args: string[], signal?: AbortSignal, options?: GhCommandOptions): Promise<T> {
 		const result = await github.run(cwd, args, signal, options);
-		if (result.exitCode !== 0) throw new ToolError(formatGhFailure(args, result.stdout, result.stderr, options));
+		if (result.exitCode !== 0) {
+			throw new ToolError(formatGhJsonFailure(args, result.stdout, result.stderr, options));
+		}
 		if (!result.stdout) throw new ToolError("GitHub CLI returned empty output.");
 		try {
 			return JSON.parse(result.stdout) as T;

--- a/packages/coding-agent/test/tools/gh.test.ts
+++ b/packages/coding-agent/test/tools/gh.test.ts
@@ -17,6 +17,7 @@ import {
 } from "@oh-my-pi/pi-coding-agent/tools/gh";
 import { parseIssueUrl, parsePullRequestUrl } from "@oh-my-pi/pi-coding-agent/tools/gh-common";
 import { github } from "@oh-my-pi/pi-coding-agent/utils/github";
+import { ToolError } from "@oh-my-pi/pi-coding-agent/tools/tool-errors";
 import { withRepoLock } from "@oh-my-pi/pi-coding-agent/utils/repo-lock";
 import type { VcsGitRepo } from "@oh-my-pi/pi-natives";
 import * as vcs from "@oh-my-pi/pi-natives/vcs";
@@ -393,6 +394,84 @@ describe("getOrFetchPrDiff diff-too-large fallback", () => {
 	});
 });
 
+describe("GitHub command runner", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("preserves structured API validation details hidden by generic stderr", async () => {
+		vi.spyOn(github, "run").mockResolvedValue({
+			exitCode: 1,
+			stdout: JSON.stringify({
+				message: "Validation Failed",
+				errors: [
+					{
+						message:
+							"The search contains only logical operators without search terms. " +
+							"Logical operators only apply to text, not to qualifiers.",
+					},
+				],
+			}),
+			stderr: "gh: Validation Failed (HTTP 422)",
+		});
+
+		await expect(github.json("/tmp", ["api", "-X", "GET", "/search/issues"])).rejects.toThrow(
+			"gh: Validation Failed (HTTP 422)\n" +
+				"GitHub details:\n" +
+				"- The search contains only logical operators without search terms. " +
+				"Logical operators only apply to text, not to qualifiers.",
+		);
+	});
+
+	it("formats structured API field errors that carry no message", async () => {
+		vi.spyOn(github, "run").mockResolvedValue({
+			exitCode: 1,
+			stdout: JSON.stringify({
+				message: "Validation Failed",
+				errors: [{ resource: "Search", field: "q", code: "missing" }],
+			}),
+			stderr: "gh: Validation Failed (HTTP 422)",
+		});
+
+		await expect(github.json("/tmp", ["api", "-X", "GET", "/search/issues"])).rejects.toThrow(
+			"gh: Validation Failed (HTTP 422)\nGitHub details:\n- Search.q: missing",
+		);
+	});
+
+	it("does not duplicate structured details already rendered by gh", async () => {
+		const detail = "Field 'fieldThatDoesNotExist' doesn't exist on type 'Repository'";
+		vi.spyOn(github, "run").mockResolvedValue({
+			exitCode: 1,
+			stdout: JSON.stringify({ errors: [{ message: detail }] }),
+			stderr: `gh: ${detail}`,
+		});
+
+		await expect(github.json("/tmp", ["api", "graphql"])).rejects.toThrow(new RegExp(`^gh: ${detail}$`));
+	});
+
+	it("retains the existing error when stdout is not structured JSON", async () => {
+		vi.spyOn(github, "run").mockResolvedValue({
+			exitCode: 1,
+			stdout: "upstream proxy returned HTML",
+			stderr: "gh: request failed (HTTP 502)",
+		});
+
+		await expect(github.json("/tmp", ["api", "-X", "GET", "/user"])).rejects.toThrow("gh: request failed (HTTP 502)");
+	});
+
+	it("preserves translated authentication failures without extra API details", async () => {
+		vi.spyOn(github, "run").mockResolvedValue({
+			exitCode: 1,
+			stdout: JSON.stringify({ message: "Bad credentials" }),
+			stderr: "gh: To authenticate, run gh auth login",
+		});
+
+		await expect(github.json("/tmp", ["api", "/user"])).rejects.toThrow(
+			/^GitHub CLI is not authenticated\. Run `gh auth login`\.$/,
+		);
+	});
+});
+
 describe("github tool", () => {
 	beforeAll(async () => {
 		prFixtureTemplate = await buildPrFixtureTemplate();
@@ -474,6 +553,20 @@ describe("github tool", () => {
 			undefined,
 			{ repoProvided: true, trimOutput: false },
 		);
+	});
+
+	it("adds repository, revision, and path context to file-read failures", async () => {
+		vi.spyOn(github, "json").mockRejectedValue(new ToolError("gh: Not Found (HTTP 404)"));
+		const tool = new GithubTool(createSession());
+
+		await expect(
+			tool.execute("file-read", {
+				op: "file_read",
+				repo: "openai/codex",
+				branch: "main",
+				path: "Cargo.toml",
+			}),
+		).rejects.toThrow("GitHub file read failed for 'openai/codex@main:Cargo.toml': gh: Not Found (HTTP 404)");
 	});
 
 	it("returns GitHub images as model image content", async () => {


### PR DESCRIPTION
## What

Preserve structured GitHub API diagnostics when `gh` writes a generic summary to stderr and useful details to stdout.
Add repository, revision, and path context to failed `file_read` operations without guessing which Contents API segment failed.
Clarify that GitHub Boolean operators combine text terms rather than qualifiers.

## Why

`github.json()` previously selected `stderr || stdout`.
An HTTP 422 could therefore expose only `gh: Validation Failed` while hiding the API explanation needed to correct the request.
Contents API errors also omitted the repository, revision, and path needed to recover from a generic 404.
Successful JSON responses, text commands, authentication translation, and GitHub's ambiguous 404 meaning remain unchanged.
The complete five-file diff was reviewed, and the real HTTP 422 path plus focused regression cases were exercised.

## Testing

- `bun test packages/coding-agent/test/tools/gh.test.ts --test-name-pattern 'GitHub command runner|adds repository, revision, and path context'` — 6 passed.
- `bun --cwd=packages/coding-agent run check` — passed.
- Live source-runner HTTP 422 reproduction — retained the concise summary and appended the Boolean-operator explanation.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)

### Disclosure

Investigated thoroughly with GPT-5.6 (extra high reasoning effort), using [Oh My Pi](https://github.com/can1357/oh-my-pi) as the agent framework.

This report is not generic or unreviewed AI-generated output.
Its claims were checked against the cited evidence, and it includes the relevant detail intended to help maintainers resolve the issue.

If reports like this are not useful to the project, please let me know and I will refrain from submitting similar ones.
My intent is to help without wasting maintainer time or energy or discouraging their work.

Thank you for your work.