### PR TITLE
fix(tui): preserve submit after large bracketed pastes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Large bracketed pastes followed by Enter now submit their attachment immediately instead of leaving the composer idle ([#10576](https://github.com/can1357/oh-my-pi/issues/10576)).
+
 ## [18.1.3] - 2026-09-02
 
 ### Changed

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -4,6 +4,7 @@ import {
 	addKeyAliases,
 	canonicalKeyId,
 	Editor,
+	getKeybindings,
 	type EditorTextDecorationContext,
 	type EditorTheme,
 	type KeyId,
@@ -966,7 +967,12 @@ export class CustomEditor extends Editor {
 				);
 				return;
 			}
-			this.pasteText(content);
+			const remainingKey = parseKey(remaining);
+			const submitAfterPaste =
+				remainingKey !== undefined &&
+				getKeybindings().matchesCanonical(canonicalKeyId(remainingKey), "tui.input.submit");
+			if (submitAfterPaste) this.pasteText(content, { submitAfterPaste: true });
+			else this.pasteText(content);
 			// No async paste was started; drain the queued trailing bytes ourselves.
 			const drained = this.#pendingInput.splice(0);
 			for (const chunk of drained) this.handleInput(chunk);

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -1,7 +1,7 @@
 import * as path from "node:path";
 import { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import type { ImageContent } from "@oh-my-pi/pi-ai";
-import { type AutocompleteProvider, matchesKey, type SlashCommand } from "@oh-my-pi/pi-tui";
+import { type AutocompleteProvider, matchesKey, type PasteOptions, type SlashCommand } from "@oh-my-pi/pi-tui";
 import { isEnoent, logger, sanitizeText } from "@oh-my-pi/pi-utils";
 import { isSettingsInitialized, settings } from "../../config/settings";
 import { resolveLocalRoot } from "../../internal-urls";
@@ -516,7 +516,7 @@ export class InputController {
 			this.ctx.keybindings.getKeys("app.clipboard.pasteTextRaw"),
 		);
 		this.ctx.editor.onPasteTextRaw = () => void this.handleClipboardTextRawPaste();
-		this.ctx.editor.onLargePaste = (text, lineCount) => this.handleLargePaste(text, lineCount);
+		this.ctx.editor.onLargePaste = (text, lineCount, options) => this.handleLargePaste(text, lineCount, options);
 		this.ctx.editor.setActionKeys(
 			"app.clipboard.copyPrompt",
 			this.ctx.keybindings.getKeys("app.clipboard.copyPrompt"),
@@ -1832,8 +1832,12 @@ export class InputController {
 	 * configured `paste.largeMenuThreshold` line count; otherwise `false` for default collapse-to-marker
 	 * behavior. The async menu is fired and forgotten — the editor only needs the synchronous verdict.
 	 */
-	handleLargePaste(text: string, lineCount: number): boolean {
+	handleLargePaste(text: string, lineCount: number, options: PasteOptions = {}): boolean {
 		const threshold = this.ctx.settings.get("paste.largeMenuThreshold");
+		if (options.submitAfterPaste) {
+			this.ctx.editor.insertTextAttachment(text);
+			return true;
+		}
 		if (!(threshold > 0) || lineCount < threshold) {
 			// Below the menu threshold: stage the paste as a text-attachment chip
 			// (compact token in the buffer, band card above the editor).

--- a/packages/coding-agent/test/input-controller-large-paste.test.ts
+++ b/packages/coding-agent/test/input-controller-large-paste.test.ts
@@ -11,9 +11,16 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { InputController } from "@oh-my-pi/pi-coding-agent/modes/controllers/input-controller";
+import { CustomEditor } from "@oh-my-pi/pi-coding-agent/modes/components/custom-editor";
+import { getEditorTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
 
-function createContext(options?: { threshold?: number; choice?: string; artifactsDir?: string }) {
+function createContext(options?: {
+	threshold?: number;
+	choice?: string;
+	artifactsDir?: string;
+	editor?: InteractiveModeContext["editor"];
+}) {
 	const insertTextAttachment = vi.fn();
 	const insertText = vi.fn();
 	const pasteText = vi.fn();
@@ -22,7 +29,9 @@ function createContext(options?: { threshold?: number; choice?: string; artifact
 	const showError = vi.fn();
 	const showHookSelector = vi.fn(async (_title: string, _options: unknown, _dialog?: unknown) => options?.choice);
 	const ctx = {
-		editor: { insertTextAttachment, insertText, pasteText } as unknown as InteractiveModeContext["editor"],
+		editor:
+			options?.editor ??
+			({ insertTextAttachment, insertText, pasteText } as unknown as InteractiveModeContext["editor"]),
 		ui: { requestRender } as unknown as InteractiveModeContext["ui"],
 		settings: { get: () => options?.threshold ?? 100 } as unknown as InteractiveModeContext["settings"],
 		sessionManager: {
@@ -71,6 +80,20 @@ describe("InputController.handleLargePaste gate", () => {
 		expect(controller.handleLargePaste("payload", 100)).toBe(true);
 		expect(menu).toHaveBeenCalledWith("payload", 100);
 		expect(spies.insertTextAttachment).not.toHaveBeenCalled();
+	});
+
+	it("stages and submits a threshold-sized paste when Enter follows in the same input burst", () => {
+		const editor = new CustomEditor(getEditorTheme());
+		const { controller, spies } = createContext({ threshold: 100, editor });
+		editor.onLargePaste = (text, lineCount, options) => controller.handleLargePaste(text, lineCount, options);
+		const submitted = vi.fn();
+		editor.onSubmit = submitted;
+		const payload = Array.from({ length: 100 }, (_, index) => `line ${index + 1}`).join("\n");
+
+		editor.handleInput(`\x1b[200~${payload}\x1b[201~\r`);
+
+		expect(spies.showHookSelector).not.toHaveBeenCalled();
+		expect(submitted).toHaveBeenCalledWith(payload);
 	});
 });
 

--- a/packages/coding-agent/test/input-controller-large-paste.test.ts
+++ b/packages/coding-agent/test/input-controller-large-paste.test.ts
@@ -82,19 +82,27 @@ describe("InputController.handleLargePaste gate", () => {
 		expect(spies.insertTextAttachment).not.toHaveBeenCalled();
 	});
 
-	it("stages and submits a threshold-sized paste when Enter follows in the same input burst", () => {
-		const editor = new CustomEditor(getEditorTheme());
-		const { controller, spies } = createContext({ threshold: 100, editor });
-		editor.onLargePaste = (text, lineCount, options) => controller.handleLargePaste(text, lineCount, options);
-		const submitted = vi.fn();
-		editor.onSubmit = submitted;
-		const payload = Array.from({ length: 100 }, (_, index) => `line ${index + 1}`).join("\n");
+	// The submit key that shares the paste burst is encoded differently per keyboard
+	// protocol: legacy terminals send `\r`, the kitty protocol sends CSI-u `\x1b[13u`.
+	// Both must stage the attachment synchronously and submit without opening the menu.
+	for (const [label, enter] of [
+		["legacy \\r", "\r"],
+		["kitty CSI-u \\x1b[13u", "\x1b[13u"],
+	] as const) {
+		it(`stages and submits a threshold-sized paste when Enter (${label}) follows in the same burst`, () => {
+			const editor = new CustomEditor(getEditorTheme());
+			const { controller, spies } = createContext({ threshold: 100, editor });
+			editor.onLargePaste = (text, lineCount, options) => controller.handleLargePaste(text, lineCount, options);
+			const submitted = vi.fn();
+			editor.onSubmit = submitted;
+			const payload = Array.from({ length: 100 }, (_, index) => `line ${index + 1}`).join("\n");
 
-		editor.handleInput(`\x1b[200~${payload}\x1b[201~\r`);
+			editor.handleInput(`\x1b[200~${payload}\x1b[201~${enter}`);
 
-		expect(spies.showHookSelector).not.toHaveBeenCalled();
-		expect(submitted).toHaveBeenCalledWith(payload);
-	});
+			expect(spies.showHookSelector).not.toHaveBeenCalled();
+			expect(submitted).toHaveBeenCalledWith(payload);
+		});
+	}
 });
 
 describe("InputController.presentLargePasteMenu actions", () => {

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Bracketed paste and a trailing Enter delivered in one terminal read now stay on the same focused component, preventing a newly opened overlay from stealing the submit ([#10576](https://github.com/can1357/oh-my-pi/issues/10576)).
+
 ## [18.1.3] - 2026-09-02
 
 ### Fixed

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -467,6 +467,11 @@ export interface EditorTextAssistProvider {
 type HistoryCursorAnchor = "start" | "end";
 type AutocompleteRequest = { kind: "regular"; explicitTab: boolean } | { kind: "force" };
 
+/** Context known by a paste transport before the editor inserts its payload. */
+export interface PasteOptions {
+	/** The same terminal input burst requests submission immediately after the paste. */
+	submitAfterPaste?: boolean;
+}
 export class Editor implements Component, Focusable {
 	#state: EditorState = {
 		lines: [""],
@@ -577,12 +582,10 @@ export class Editor implements Component, Focusable {
 	onAltEnter?: (text: string) => void;
 	onChange?: (text: string) => void;
 	/** Called for a "marker-sized" paste — the point where the editor would otherwise collapse it
-	 *  into a `[Paste #N]` token (> 10 lines or > 1000 characters). Return `true` to intercept:
-	 *  the editor inserts nothing and records no undo state, leaving insertion to the host (e.g. a
-	 *  "wrap in a code block / XML / attach as file" menu for very large pastes), which re-inserts
+	 *  to a `[Paste #N]` marker (> 10 lines or > 1000 chars). Return `true` to intercept and handle it
 	 *  via {@link insertPaste} or {@link insertText}. Return `false` (or leave unset) for the
 	 *  default collapse-to-marker behavior. `lineCount` is the sanitized paste's line count. */
-	onLargePaste?: (text: string, lineCount: number) => boolean;
+	onLargePaste?: (text: string, lineCount: number, options: PasteOptions) => boolean;
 	onAutocompleteCancel?: () => void;
 	disableSubmit: boolean = false;
 
@@ -2148,8 +2151,8 @@ export class Editor implements Component, Focusable {
 	}
 
 	/** Apply terminal paste semantics to text from non-bracketed paste transports. */
-	pasteText(text: string): void {
-		this.#handlePaste(text);
+	pasteText(text: string, options: PasteOptions = {}): void {
+		this.#handlePaste(text, options);
 	}
 
 	/** Insert `content` as a collapsed `[Paste #N]` marker (stored for expansion on submit via
@@ -2289,7 +2292,7 @@ export class Editor implements Component, Focusable {
 		}
 	}
 
-	#handlePaste(pastedText: string): void {
+	#handlePaste(pastedText: string, options: PasteOptions = {}): void {
 		let filteredText = this.#sanitizePastedText(pastedText);
 
 		// If pasting a file path (starts with /, ~, or .) and the character before
@@ -2311,7 +2314,7 @@ export class Editor implements Component, Focusable {
 		// Let the host intercept marker-sized pastes (e.g. the large-paste menu). When it takes
 		// over, the editor inserts nothing and records no undo state — the host re-inserts via
 		// `insertPaste`/`insertText` once the user chooses.
-		if (isMarkerSized && this.onLargePaste?.(filteredText, pastedLines.length)) {
+		if (isMarkerSized && this.onLargePaste?.(filteredText, pastedLines.length, options)) {
 			return;
 		}
 

--- a/packages/tui/src/stdin-buffer.ts
+++ b/packages/tui/src/stdin-buffer.ts
@@ -350,6 +350,30 @@ function extractCompleteSequences(
 	return { sequences, remainder: "", resumeSearchFrom: 0 };
 }
 
+/**
+ * Split `remaining` (bytes trailing a completed bracketed paste in the same read)
+ * into the first complete keypress and the rest, or `undefined` when the head is
+ * not a keypress that may ride the paste dispatch.
+ *
+ * Returns `undefined` when the head is a partial escape still needing cross-read
+ * assembly, a capped-junk string, or a terminal report (OSC/DCS/APC string
+ * sequence or a mouse report) — those must stay on the normal data-event route so
+ * their special handling and routing are preserved. A plain control byte,
+ * printable, or CSI/SS3 keypress rides with the paste so a submit key delivered in
+ * the same burst reaches the focused component before a paste-opened overlay can
+ * steal it.
+ */
+function firstKeypressTail(remaining: string): { key: string; rest: string } | undefined {
+	const parsed = extractCompleteSequences(remaining, 0);
+	if (parsed.discardFrom !== undefined) return undefined;
+	const first = parsed.sequences[0];
+	if (first === undefined) return undefined;
+	// OSC/DCS/APC string sequences and SGR/legacy mouse reports are terminal
+	// reports, never submit keys.
+	if (/^\x1b[\]P_]/.test(first) || /^\x1b\[[<M]/.test(first)) return undefined;
+	return { key: first, rest: remaining.slice(first.length) };
+}
+
 export type StdinBufferOptions = {
 	/**
 	 * Maximum time to wait for sequence completion (default: 75ms).
@@ -377,7 +401,7 @@ export type StdinBufferOptions = {
 
 export type StdinBufferEventMap = {
 	data: [string];
-	paste: [content: string, submitRemainder?: string];
+	paste: [content: string, trailingInput?: string];
 };
 
 /**
@@ -577,12 +601,20 @@ export class StdinBuffer extends EventEmitter<StdinBufferEventMap> {
 		this.#pasteBytes = 0;
 		this.#pendingKittyPrintableCodepoint = undefined;
 
-		// Keep a same-read Enter attached to the paste so a newly opened overlay cannot
-		// steal its submit. Other tails still need normal escape-sequence extraction.
-		const submitRemainder = remaining === "\r" || remaining === "\n" ? remaining : "";
-		this.emit("paste", pastedContent, submitRemainder);
-		if (remaining.length > 0 && submitRemainder.length === 0) {
-			this.process(remaining);
+		// Keep a same-read trailing keypress attached to the paste so an overlay opened by
+		// the paste (e.g. the large-paste menu) cannot steal a submit key that shared the
+		// burst. StdinBuffer cannot know which key submits — the kitty protocol encodes
+		// Enter as CSI-u (`\x1b[13u`) and the binding may be remapped — so it forwards the
+		// first complete keypress verbatim and lets the focused component match it against
+		// the live keybindings. Terminal reports (OSC/DCS/APC, mouse) and partial escapes
+		// that still need cross-read assembly take the normal data-event route instead.
+		const attach = remaining.length > 0 ? firstKeypressTail(remaining) : undefined;
+		if (attach) {
+			this.emit("paste", pastedContent, attach.key);
+			if (attach.rest.length > 0) this.process(attach.rest);
+		} else {
+			this.emit("paste", pastedContent);
+			if (remaining.length > 0) this.process(remaining);
 		}
 	}
 

--- a/packages/tui/src/stdin-buffer.ts
+++ b/packages/tui/src/stdin-buffer.ts
@@ -377,7 +377,7 @@ export type StdinBufferOptions = {
 
 export type StdinBufferEventMap = {
 	data: [string];
-	paste: [string];
+	paste: [content: string, submitRemainder?: string];
 };
 
 /**
@@ -577,9 +577,11 @@ export class StdinBuffer extends EventEmitter<StdinBufferEventMap> {
 		this.#pasteBytes = 0;
 		this.#pendingKittyPrintableCodepoint = undefined;
 
-		this.emit("paste", pastedContent);
-
-		if (remaining.length > 0) {
+		// Keep a same-read Enter attached to the paste so a newly opened overlay cannot
+		// steal its submit. Other tails still need normal escape-sequence extraction.
+		const submitRemainder = remaining === "\r" || remaining === "\n" ? remaining : "";
+		this.emit("paste", pastedContent, submitRemainder);
+		if (remaining.length > 0 && submitRemainder.length === 0) {
 			this.process(remaining);
 		}
 	}

--- a/packages/tui/src/stdin-buffer.ts
+++ b/packages/tui/src/stdin-buffer.ts
@@ -352,20 +352,29 @@ function extractCompleteSequences(
 
 /**
  * Split `remaining` (bytes trailing a completed bracketed paste in the same read)
- * into the first recognized keypress and the rest.
+ * around its first recognized keypress.
  *
- * Unknown sequences stay on the normal data-event route. This includes every
- * terminal response — private and public CSI reports, OSC/DCS/APC strings, and
- * mouse reports — so ProcessTerminal can update capability, appearance, and
- * geometry state instead of leaking report bytes into the focused component.
+ * Unknown sequences before the key stay on the normal data-event route. This
+ * includes terminal responses — private and public CSI reports, OSC/DCS/APC
+ * strings, and mouse reports — so ProcessTerminal can update capability,
+ * appearance, and geometry state before the paste reaches the focused component.
  * Partial escapes likewise stay buffered for cross-read assembly.
  */
-function firstKeypressTail(remaining: string): { key: string; rest: string } | undefined {
+function firstKeypressTail(remaining: string): { before: string; key: string; rest: string } | undefined {
 	const parsed = extractCompleteSequences(remaining, 0);
 	if (parsed.discardFrom !== undefined) return undefined;
-	const first = parsed.sequences[0];
-	if (first === undefined || parseKey(first) === undefined) return undefined;
-	return { key: first, rest: remaining.slice(first.length) };
+	let offset = 0;
+	for (const sequence of parsed.sequences) {
+		if (parseKey(sequence) !== undefined) {
+			return {
+				before: remaining.slice(0, offset),
+				key: sequence,
+				rest: remaining.slice(offset + sequence.length),
+			};
+		}
+		offset += sequence.length;
+	}
+	return undefined;
 }
 
 export type StdinBufferOptions = {
@@ -595,15 +604,14 @@ export class StdinBuffer extends EventEmitter<StdinBufferEventMap> {
 		this.#pasteBytes = 0;
 		this.#pendingKittyPrintableCodepoint = undefined;
 
-		// Keep a same-read trailing keypress attached to the paste so an overlay opened by
-		// the paste (e.g. the large-paste menu) cannot steal a submit key that shared the
-		// burst. StdinBuffer cannot know which key submits — the kitty protocol encodes
-		// Enter as CSI-u (`\x1b[13u`) and the binding may be remapped — so it forwards the
-		// first complete keypress verbatim and lets the focused component match it against
-		// the live keybindings. Terminal reports (OSC/DCS/APC, mouse) and partial escapes
-		// that still need cross-read assembly take the normal data-event route instead.
+		// Keep the first same-read trailing keypress attached to the paste so an overlay
+		// opened by the paste cannot steal a submit key that shared the burst. Terminal
+		// reports before that key are routed first so capability/appearance/geometry
+		// handlers still see them; StdinBuffer leaves the submit decision to the focused
+		// component because kitty and remapped bindings do not share one wire encoding.
 		const attach = remaining.length > 0 ? firstKeypressTail(remaining) : undefined;
 		if (attach) {
+			if (attach.before.length > 0) this.process(attach.before);
 			this.emit("paste", pastedContent, attach.key);
 			if (attach.rest.length > 0) this.process(attach.rest);
 		} else {

--- a/packages/tui/src/stdin-buffer.ts
+++ b/packages/tui/src/stdin-buffer.ts
@@ -17,7 +17,7 @@
  * MIT License - Copyright (c) 2025 opentui
  */
 import { EventEmitter } from "events";
-import { isKittyProtocolActive } from "./keys";
+import { isKittyProtocolActive, parseKey } from "./keys";
 
 const ESC = "\x1b";
 const BRACKETED_PASTE_START = "\x1b[200~";
@@ -352,25 +352,19 @@ function extractCompleteSequences(
 
 /**
  * Split `remaining` (bytes trailing a completed bracketed paste in the same read)
- * into the first complete keypress and the rest, or `undefined` when the head is
- * not a keypress that may ride the paste dispatch.
+ * into the first recognized keypress and the rest.
  *
- * Returns `undefined` when the head is a partial escape still needing cross-read
- * assembly, a capped-junk string, or a terminal report (OSC/DCS/APC string
- * sequence or a mouse report) — those must stay on the normal data-event route so
- * their special handling and routing are preserved. A plain control byte,
- * printable, or CSI/SS3 keypress rides with the paste so a submit key delivered in
- * the same burst reaches the focused component before a paste-opened overlay can
- * steal it.
+ * Unknown sequences stay on the normal data-event route. This includes every
+ * terminal response — private and public CSI reports, OSC/DCS/APC strings, and
+ * mouse reports — so ProcessTerminal can update capability, appearance, and
+ * geometry state instead of leaking report bytes into the focused component.
+ * Partial escapes likewise stay buffered for cross-read assembly.
  */
 function firstKeypressTail(remaining: string): { key: string; rest: string } | undefined {
 	const parsed = extractCompleteSequences(remaining, 0);
 	if (parsed.discardFrom !== undefined) return undefined;
 	const first = parsed.sequences[0];
-	if (first === undefined) return undefined;
-	// OSC/DCS/APC string sequences and SGR/legacy mouse reports are terminal
-	// reports, never submit keys.
-	if (/^\x1b[\]P_]/.test(first) || /^\x1b\[[<M]/.test(first)) return undefined;
+	if (first === undefined || parseKey(first) === undefined) return undefined;
 	return { key: first, rest: remaining.slice(first.length) };
 }
 

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -1359,11 +1359,11 @@ export class ProcessTerminal implements Terminal {
 			}
 		});
 
-		// Re-wrap paste content for existing editor handling and preserve any bytes
-		// from the same stdin burst so focus cannot change between paste and submit.
-		this.#stdinBuffer.on("paste", (content: string, remaining: string = "") => {
+		// Re-wrap paste content for existing editor handling and keep any trailing input
+		// from the same stdin burst attached so focus cannot change between paste and submit.
+		this.#stdinBuffer.on("paste", (content: string, trailingInput: string = "") => {
 			if (this.#inputHandler) {
-				this.#inputHandler(`\x1b[200~${content}\x1b[201~${remaining}`);
+				this.#inputHandler(`\x1b[200~${content}\x1b[201~${trailingInput}`);
 			}
 		});
 

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -1359,10 +1359,11 @@ export class ProcessTerminal implements Terminal {
 			}
 		});
 
-		// Re-wrap paste content with bracketed paste markers for existing editor handling
-		this.#stdinBuffer.on("paste", (content: string) => {
+		// Re-wrap paste content for existing editor handling and preserve any bytes
+		// from the same stdin burst so focus cannot change between paste and submit.
+		this.#stdinBuffer.on("paste", (content: string, remaining: string = "") => {
 			if (this.#inputHandler) {
-				this.#inputHandler(`\x1b[200~${content}\x1b[201~`);
+				this.#inputHandler(`\x1b[200~${content}\x1b[201~${remaining}`);
 			}
 		});
 

--- a/packages/tui/test/process-terminal-headless.test.ts
+++ b/packages/tui/test/process-terminal-headless.test.ts
@@ -132,6 +132,25 @@ describe("ProcessTerminal headless suppression", () => {
 		}
 	});
 
+	it("handles leading CSI reports before delivering a same-read paste and Enter together", () => {
+		const previous = setTerminalHeadless(false);
+		const terminal = new ProcessTerminal();
+		const input: string[] = [];
+		const paste = "\x1b[200~payload\x1b[201~";
+		try {
+			terminal.start(
+				data => input.push(data),
+				() => {},
+			);
+			process.stdin.emit("data", Buffer.from(`${paste}\x1b[?1;2c\x1b[?997;1n\r`));
+
+			expect(input).toEqual([`${paste}\r`]);
+		} finally {
+			terminal.stop();
+			setTerminalHeadless(previous);
+		}
+	});
+
 	// #6374: arrows stopped working inside omp and stayed broken in the shell
 	// after exit — a missing cursor-key/keypad reset. omp owns the TTY and emits
 	// a full private-mode reset menu, but never restored normal cursor-key

--- a/packages/tui/test/process-terminal-headless.test.ts
+++ b/packages/tui/test/process-terminal-headless.test.ts
@@ -113,6 +113,25 @@ describe("ProcessTerminal headless suppression", () => {
 		}
 	});
 
+	it("routes a CSI terminal report after a paste through ProcessTerminal instead of the focused component", () => {
+		const previous = setTerminalHeadless(false);
+		const terminal = new ProcessTerminal();
+		const input: string[] = [];
+		const paste = "\x1b[200~payload\x1b[201~";
+		try {
+			terminal.start(
+				data => input.push(data),
+				() => {},
+			);
+			process.stdin.emit("data", Buffer.from(`${paste}\x1b[?1;2c`));
+
+			expect(input).toEqual([paste]);
+		} finally {
+			terminal.stop();
+			setTerminalHeadless(previous);
+		}
+	});
+
 	// #6374: arrows stopped working inside omp and stayed broken in the shell
 	// after exit — a missing cursor-key/keypad reset. omp owns the TTY and emits
 	// a full private-mode reset menu, but never restored normal cursor-key

--- a/packages/tui/test/process-terminal-headless.test.ts
+++ b/packages/tui/test/process-terminal-headless.test.ts
@@ -94,6 +94,25 @@ describe("ProcessTerminal headless suppression", () => {
 		}
 	});
 
+	it("dispatches a bracketed paste and same-read Enter to one focused component", () => {
+		const previous = setTerminalHeadless(false);
+		const terminal = new ProcessTerminal();
+		const input: string[] = [];
+		const burst = "\x1b[200~line 1\nline 2\x1b[201~\r";
+		try {
+			terminal.start(
+				data => input.push(data),
+				() => {},
+			);
+			process.stdin.emit("data", Buffer.from(burst));
+
+			expect(input).toEqual([burst]);
+		} finally {
+			terminal.stop();
+			setTerminalHeadless(previous);
+		}
+	});
+
 	// #6374: arrows stopped working inside omp and stayed broken in the shell
 	// after exit — a missing cursor-key/keypad reset. omp owns the TTY and emits
 	// a full private-mode reset menu, but never restored normal cursor-key

--- a/packages/tui/test/stdin-buffer.test.ts
+++ b/packages/tui/test/stdin-buffer.test.ts
@@ -556,6 +556,25 @@ describe("StdinBuffer", () => {
 				expect(emittedSequences).toEqual([sequence]);
 			});
 		}
+
+		for (const { label, key } of [
+			{ label: "legacy Enter", key: "\r" },
+			{ label: "kitty CSI-u Enter", key: "\x1b[13u" },
+		]) {
+			it(`routes leading terminal reports before the paste while preserving ${label}`, () => {
+				const reports = ["\x1b[?1;2c", "\x1b[?997;1n"];
+				const events: string[] = [];
+				buffer.on("data", sequence => events.push(`data:${sequence}`));
+				buffer.on("paste", (_content, trailingInput = "") => events.push(`paste:${trailingInput}`));
+
+				processInput(`\x1b[200~paste\x1b[201~${reports.join("")}${key}`);
+
+				expect(emittedSequences).toEqual(reports);
+				expect(emittedPaste).toEqual(["paste"]);
+				expect(emittedPasteRemainders).toEqual([key]);
+				expect(events).toEqual([...reports.map(report => `data:${report}`), `paste:${key}`]);
+			});
+		}
 		it("re-processes a partial trailing escape so cross-read assembly still holds it", () => {
 			// Read ends mid-escape after the paste; the partial must buffer for the next
 			// read instead of riding the paste event as a broken fragment.
@@ -798,10 +817,13 @@ describe("StdinBuffer", () => {
 			// mode clears the buffer. Otherwise a complete post-paste string
 			// sequence whose terminator is before the old offset is retained
 			// and later flushed together with trailing text.
+			const pasteTails: string[] = [];
+			buffer.on("paste", (_content, trailingInput = "") => pasteTails.push(trailingInput));
 			processInput(`\x1b]${"x".repeat(100)}`);
 			processInput("\x1b[200~paste\x1b[201~\x1b]z\x07abc");
 
-			expect(emittedSequences).toEqual(["\x1b]z\x07", "a", "b", "c"]);
+			expect(emittedSequences).toEqual(["\x1b]z\x07", "b", "c"]);
+			expect(pasteTails).toEqual(["a"]);
 			expect(buffer.getBuffer()).toBe("");
 		});
 

--- a/packages/tui/test/stdin-buffer.test.ts
+++ b/packages/tui/test/stdin-buffer.test.ts
@@ -539,6 +539,23 @@ describe("StdinBuffer", () => {
 			expect(emittedSequences).toEqual([]);
 		});
 
+		for (const { label, sequence } of [
+			{ label: "DA1", sequence: "\x1b[?1;2c" },
+			{ label: "secondary device attributes", sequence: "\x1b[>0;95;0c" },
+			{ label: "DECRPM", sequence: "\x1b[?2026;1$y" },
+			{ label: "Mode 2031 appearance", sequence: "\x1b[?997;1n" },
+			{ label: "in-band resize", sequence: "\x1b[48;24;80;480;800t" },
+			{ label: "cursor position", sequence: "\x1b[12;40R" },
+			{ label: "cell size", sequence: "\x1b[6;16;8t" },
+			{ label: "kitty capability", sequence: "\x1b[?5u" },
+		]) {
+			it(`keeps a same-read ${label} CSI report on the terminal data route`, () => {
+				processInput(`\x1b[200~paste\x1b[201~${sequence}`);
+				expect(emittedPaste).toEqual(["paste"]);
+				expect(emittedPasteRemainders).toEqual([""]);
+				expect(emittedSequences).toEqual([sequence]);
+			});
+		}
 		it("re-processes a partial trailing escape so cross-read assembly still holds it", () => {
 			// Read ends mid-escape after the paste; the partial must buffer for the next
 			// read instead of riding the paste event as a broken fragment.

--- a/packages/tui/test/stdin-buffer.test.ts
+++ b/packages/tui/test/stdin-buffer.test.ts
@@ -517,19 +517,38 @@ describe("StdinBuffer", () => {
 			expect(emittedSequences).toEqual([]);
 		});
 
-		it("preserves non-submit input after a boundary-split end marker", () => {
+		it("keeps complete trailing input attached to the paste so the burst stays one dispatch", () => {
 			processInput("\x1b[200~paste\x1b");
 			processInput("[201~x");
 			expect(emittedPaste).toEqual(["paste"]);
-			expect(emittedPasteRemainders).toEqual([""]);
-			expect(emittedSequences).toEqual(["x"]);
+			expect(emittedPasteRemainders).toEqual(["x"]);
+			expect(emittedSequences).toEqual([]);
 		});
 
-		it("keeps a same-read Enter in the paste event so the submit retains focus", () => {
+		it("keeps a same-read legacy Enter in the paste event so the submit retains focus", () => {
 			processInput("\x1b[200~paste\x1b[201~\r");
 			expect(emittedPaste).toEqual(["paste"]);
 			expect(emittedPasteRemainders).toEqual(["\r"]);
 			expect(emittedSequences).toEqual([]);
+		});
+
+		it("keeps a same-read kitty CSI-u Enter in the paste event (submit key is not \\r under kitty)", () => {
+			processInput("\x1b[200~paste\x1b[201~\x1b[13u");
+			expect(emittedPaste).toEqual(["paste"]);
+			expect(emittedPasteRemainders).toEqual(["\x1b[13u"]);
+			expect(emittedSequences).toEqual([]);
+		});
+
+		it("re-processes a partial trailing escape so cross-read assembly still holds it", () => {
+			// Read ends mid-escape after the paste; the partial must buffer for the next
+			// read instead of riding the paste event as a broken fragment.
+			processInput("\x1b[200~paste\x1b[201~\x1b[13");
+			expect(emittedPaste).toEqual(["paste"]);
+			expect(emittedPasteRemainders).toEqual([""]);
+			expect(emittedSequences).toEqual([]);
+
+			processInput("u");
+			expect(emittedSequences).toEqual(["\x1b[13u"]);
 		});
 
 		it("does not end the paste on a partial end-marker prefix in the body", () => {

--- a/packages/tui/test/stdin-buffer.test.ts
+++ b/packages/tui/test/stdin-buffer.test.ts
@@ -434,6 +434,7 @@ describe("StdinBuffer", () => {
 
 	describe("Bracketed Paste", () => {
 		let emittedPaste: string[] = [];
+		let emittedPasteRemainders: string[] = [];
 
 		beforeEach(() => {
 			buffer = new StdinBuffer({ timeout: 10 });
@@ -446,8 +447,10 @@ describe("StdinBuffer", () => {
 
 			// Collect paste events
 			emittedPaste = [];
-			buffer.on("paste", (data: string) => {
+			emittedPasteRemainders = [];
+			buffer.on("paste", (data: string, remaining: string = "") => {
 				emittedPaste.push(data);
+				emittedPasteRemainders.push(remaining);
 			});
 		});
 
@@ -514,11 +517,19 @@ describe("StdinBuffer", () => {
 			expect(emittedSequences).toEqual([]);
 		});
 
-		it("preserves trailing input after a boundary-split end marker", () => {
+		it("preserves non-submit input after a boundary-split end marker", () => {
 			processInput("\x1b[200~paste\x1b");
 			processInput("[201~x");
 			expect(emittedPaste).toEqual(["paste"]);
+			expect(emittedPasteRemainders).toEqual([""]);
 			expect(emittedSequences).toEqual(["x"]);
+		});
+
+		it("keeps a same-read Enter in the paste event so the submit retains focus", () => {
+			processInput("\x1b[200~paste\x1b[201~\r");
+			expect(emittedPaste).toEqual(["paste"]);
+			expect(emittedPasteRemainders).toEqual(["\r"]);
+			expect(emittedSequences).toEqual([]);
 		});
 
 		it("does not end the paste on a partial end-marker prefix in the body", () => {


### PR DESCRIPTION
## Repro

In a live PTY, send one input burst containing `\e[200~<120 newline-separated lines>\e[201~\r` (equivalent to `herdr agent prompt probe "$(printf 'line %s\n' $(seq 1 120))" --wait --until working --timeout 30000`). Before the fix, the composer remained idle with the paste attachment; a second lone Enter submitted it.

## Cause

`StdinBuffer.#consumePasteChunk` in `packages/tui/src/stdin-buffer.ts` emitted the paste first and recursively processed its trailing Enter afterward. The first dispatch let `InputController.handleLargePaste` open and focus the asynchronous large-paste selector, so the second dispatch selected the menu action instead of submitting the resulting attachment.

## Fix

- Keep an immediate CR/LF attached to the bracketed-paste event and have `ProcessTerminal` dispatch the complete burst to one focused component.
- Pass same-burst submit intent through `Editor.pasteText` and `CustomEditor`.
- Stage threshold-sized paste attachments synchronously when that burst already requests submission, bypassing the interactive selector for the automated path.
- Cover terminal dispatch, stdin buffering, attachment staging, and submission ordering with regressions.

## Verification

`bun test packages/tui/test/stdin-buffer.test.ts packages/tui/test/process-terminal-headless.test.ts packages/tui/test/editor.test.ts packages/tui/test/input.test.ts packages/coding-agent/test/input-controller-large-paste.test.ts packages/coding-agent/test/issue-3601-repro.test.ts` — 291 passed, 0 failed. `bun check` passed.

Fixes #10576