### PR TITLE
fix(stats): collapse provider-polluted tool names at ingest

### DIFF
--- a/packages/stats/CHANGELOG.md
+++ b/packages/stats/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed garbage tool names from provider-side parse failures (e.g. a gateway returning the model's whole invocation text as the tool name) polluting the tools dashboard's per-tool rows and filter dropdown; such names now collapse to their leading identifier, and existing databases re-ingest cleaned on next sync.
+
 ## [18.1.3] - 2026-09-02
 
 ### Changed

--- a/packages/stats/src/db.ts
+++ b/packages/stats/src/db.ts
@@ -120,7 +120,10 @@ const USER_MESSAGE_LINKS_REPAIR_KEY = "user_message_links_v1";
 const PRIORITY_PREMIUM_REQUESTS_BACKFILL_KEY = "premium_requests_priority_v1";
 const AGENT_TYPE_BACKFILL_KEY = "agent_type_v1";
 const FORK_DEDUPE_KEY = "fork_dedupe_v1";
-const TOOL_CALLS_BACKFILL_KEY = "tool_calls_v1";
+// v2: tool-name sanitization at ingest (see `sanitizeToolName` in parser.ts)
+// collapses provider-side garbage names; a full re-parse replaces the polluted
+// rows already stored in existing databases.
+const TOOL_CALLS_BACKFILL_KEY = "tool_calls_v2";
 // Older ingests dropped `Usage.orchestration` (never a stored column) when
 // pricing, so subscription models billed on orchestration tokens — multi-agent
 // Grok most notably — were priced from conversation buckets alone and could not

--- a/packages/stats/src/parser.ts
+++ b/packages/stats/src/parser.ts
@@ -29,6 +29,9 @@ import { computeUserMessageMetrics } from "./user-metrics";
 /** Basename of an advisor agent's transcript inside a session artifacts dir. */
 const ADVISOR_TRANSCRIPT_BASENAME = "__advisor.jsonl";
 
+/** Characters a persisted tool name may consist of without sanitization. */
+const TOOL_NAME_PATTERN = /^[\w.:-]+$/;
+
 /**
  * Classify which agent produced a transcript from its path within the sessions
  * directory. Layout: `<sessionsDir>/<project>/<file>.jsonl` is the `main`
@@ -292,27 +295,51 @@ function extractToolCalls(
 	);
 	if (blocks.length === 0) return [];
 
-	return blocks.map(block => {
+	const calls: ToolCallStats[] = [];
+	for (const block of blocks) {
+		// Names reduced to nothing by sanitization carry no tool identity:
+		// skip them rather than attributing usage to garbage (see
+		// sanitizeToolName). callsInTurn still counts the raw block total.
+		const toolName = sanitizeToolName(block.name);
+		if (toolName === null) continue;
 		let argsChars = 0;
 		try {
 			argsChars = JSON.stringify(block.arguments ?? {}).length;
 		} catch {
 			// Non-serializable arguments (shouldn't happen in persisted JSONL); size unknown.
 		}
-		return {
+		calls.push({
 			sessionFile,
 			entryId: entry.id,
 			toolCallId: block.id,
 			folder,
-			toolName: block.name,
+			toolName,
 			model: msg.model,
 			provider: msg.provider,
 			timestamp: coerceEntryTimestamp(msg.timestamp, entry),
 			agentType,
 			callsInTurn: blocks.length,
 			argsChars,
-		};
-	});
+		});
+	}
+	return calls;
+}
+
+/**
+ * Tool names as persisted can be polluted by provider-side parse garbage — a
+ * gateway may hand the model's whole invocation text back as the function
+ * name (e.g. `bash command="ls -la …"` with a stray in-band closer), which
+ * then shows up verbatim in every `GROUP BY tool_name` aggregate and the
+ * dashboard tool filter. Reduce such names to their leading identifier token;
+ * names that yield no identifier at all carry no tool identity and are
+ * returned as `null` so the row is skipped.
+ */
+function sanitizeToolName(name: string): string | null {
+	const trimmed = name.trim();
+	if (trimmed.length === 0) return null;
+	if (TOOL_NAME_PATTERN.test(trimmed)) return trimmed;
+	const candidate = trimmed.split(/[^\w.:-]/)[0] ?? "";
+	return candidate.length > 0 ? candidate : null;
 }
 
 /**

--- a/packages/stats/test/behavior-backfill.test.ts
+++ b/packages/stats/test/behavior-backfill.test.ts
@@ -104,14 +104,14 @@ describe("behavior backfill", () => {
 		const database = new Database(getStatsDbPath(), { readonly: true });
 		const rows = database
 			.query(
-				"SELECT key, value FROM meta WHERE key IN ('user_messages_v8', 'tool_calls_v1', 'user_message_links_v1', 'premium_requests_priority_v1') ORDER BY key",
+				"SELECT key, value FROM meta WHERE key IN ('user_messages_v8', 'tool_calls_v2', 'user_message_links_v1', 'premium_requests_priority_v1') ORDER BY key",
 			)
 			.all() as { key: string; value: string }[];
 		database.close();
 
 		expect(rows).toEqual([
 			{ key: "premium_requests_priority_v1", value: "complete" },
-			{ key: "tool_calls_v1", value: "complete" },
+			{ key: "tool_calls_v2", value: "complete" },
 			{ key: "user_message_links_v1", value: "complete" },
 			{ key: "user_messages_v8", value: "complete" },
 		]);

--- a/packages/stats/test/tool-stats.test.ts
+++ b/packages/stats/test/tool-stats.test.ts
@@ -343,4 +343,61 @@ describe("tool usage stats pipeline", () => {
 		await syncAllSessions({ workers: 1 });
 		expect(getToolStats()).toEqual(first);
 	});
+
+	it("collapses provider-polluted tool names and skips nameless calls", async () => {
+		// Real-world shapes observed when a gateway hands the model's whole
+		// invocation text back as the function name (see sanitizeToolName):
+		// inlined `key=value` args, parenthesized args, a shell command in
+		// the name slot with a stray in-band closer, and whitespace-only
+		// noise that carries no tool identity at all.
+		await writeSessionFile("session.jsonl", { id: "sess0004" }, [
+			buildAssistantEntry({
+				entryId: "asst-1",
+				timestamp: TS1,
+				toolCalls: [
+					{ id: "call-1", name: 'bash command="ls -la /repo" i="List repo"', arguments: {} },
+					{
+						id: "call-2",
+						name: 'bash(i="Probe repo", timeout=30)</arg-value>',
+						arguments: {},
+					},
+					{
+						id: "call-3",
+						name: "curl --resolve oracle.example:443:127.0.0.1 -k https://oracle.example --max-time 5</arg-value>",
+						arguments: { i: "Comparing cert routes" },
+					},
+					{ id: "call-4", name: 'grep -rn "token" --include=*.go . | head -10', arguments: {} },
+					{ id: "call-5", name: "  \u0000\t  ", arguments: {} },
+				],
+				totalTokens: TURN1_TOTAL_TOKENS,
+				outputTokens: TURN1_OUTPUT_TOKENS,
+				costTotal: TURN1_COST,
+			}),
+			buildToolResultEntry({
+				entryId: "tr-1",
+				parentId: "asst-1",
+				timestamp: TS1,
+				toolCallId: "call-3",
+				toolName: "curl --resolve oracle.example:443:127.0.0.1 -k https://oracle.example --max-time 5</arg-value>",
+				text: "000",
+				isError: true,
+			}),
+		]);
+		await syncAllSessions({ workers: 1 });
+
+		const stats = getToolStats();
+		// Surviving rows collapse onto their leading identifier token; the
+		// nameless call is dropped entirely.
+		expect(stats.map(row => row.tool).sort()).toEqual(["bash", "curl", "grep"]);
+		expect(toolRow(stats, "bash").calls).toBe(2);
+		expect(toolRow(stats, "curl").calls).toBe(1);
+		expect(toolRow(stats, "curl").errors).toBe(1);
+
+		// The dashboard's per-model rows - the source of the tool filter
+		// dropdown - see the same collapsed names.
+		const byModel = getToolStatsByModel()
+			.map(row => row.tool)
+			.sort();
+		expect(byModel).toEqual(["bash", "curl", "grep"]);
+	});
 });


### PR DESCRIPTION
I ran into this with my own GLM setup — my gateway sometimes returns the model's whole invocation text as the function name, and those commands ended up as entries in the stats tool filter. I reviewed the full diff and re-synced my session data to confirm the dropdown is clean now.

## Problem

When a provider-side parse goes wrong (observed with an OpenAI-compatible gateway serving GLM, which returned the model's whole invocation text — e.g. `bash command="ls -la …"` with a stray in-band `</arg-value>` closer — as the native `function.name`), the garbage name flows through omp unvalidated: the call is persisted in the session JSONL, `extractToolCalls` ingests `tool_name` verbatim, and every `GROUP BY tool_name` aggregate shows it. On the Tools dashboard this surfaced as multi-line shell commands (including private hostnames) as entries in the "Tool" filter dropdown.

## Change

- `packages/stats/src/parser.ts`: `extractToolCalls` now runs each `toolCall.name` through `sanitizeToolName`. Names consisting solely of `[A-Za-z0-9_.:-]` pass through untouched (covers `read`, `mcp__srv__tool`, dotted/colon names). Anything else collapses to its leading identifier token (`bash command="…"` → `bash`, `curl --resolve …` → `curl`); names with no leading identifier at all are skipped — they carry no tool identity to attribute usage to.
- `packages/stats/src/db.ts`: bump `TOOL_CALLS_BACKFILL_KEY` to `tool_calls_v2` so existing databases wipe and re-parse `tool_calls` once, replacing already-polluted rows.

Usage attribution (calls, tokens, cost, error rates) is preserved for every collapsed name; only rows with no recoverable tool identity are dropped.

## Verification

- Reproduced on my real session data (4 sessions that produced 12 garbage tool names in a copied, isolated `PI_CONFIG_DIR`):
  - before: 12 malformed names in the `GROUP BY tool_name` output;
  - after: 0 malformed names; the affected rows collapse onto `bash`/`curl` with their calls, error, and token attribution intact.
- New regression test in `packages/stats/test/tool-stats.test.ts` covers the observed shapes (inline `key=value` args, parenthesized args, shell command with a stray in-band closer, whitespace/control-char noise) and asserts the per-model rows that feed the dropdown are clean.
- `packages/stats`: `bun run check` (oxlint + oxfmt + tsgo) passes; targeted tests 8/8. The 2 pre-existing failures in the full suite (`db-cost`, `fork-dedup`) also fail on unmodified `main` — unrelated.
