### PR TITLE
fix(cursor): acknowledge auth-gateway tool handoffs

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Cursor models behind auth-gateway retrying client-declared tool calls after the gateway incorrectly reported them as missing.
+
 ## [18.1.3] - 2026-09-02
 
 ### Fixed

--- a/packages/ai/src/auth-gateway/server.ts
+++ b/packages/ai/src/auth-gateway/server.ts
@@ -129,7 +129,7 @@ function deriveSessionId(modelId: string, context: Context): string {
 }
 
 function buildStreamOptions(parsed: ParsedFormatRequest, api: Api, signal: AbortSignal): SimpleStreamOptions {
-	const opts: SimpleStreamOptions = { signal };
+	const opts: SimpleStreamOptions = { signal, cursorExternalToolExecutor: true };
 	const { options } = parsed;
 	// Codex backend rejects every sampling control with
 	// `Unsupported parameter: …` (#3117). Strip the full set for that one
@@ -662,7 +662,12 @@ async function handlePiNative(bootOpts: AuthGatewayBootOptions, req: Request, pe
 	// trust the client's options (already allow-listed by `parseRequest`) and
 	// only inject server-controlled fields. The codex sampling strip mirrors
 	// `buildStreamOptions` — Codex rejects every one with a 400 (#3117).
-	const streamOpts: SimpleStreamOptions = { ...parsed.options, apiKey, signal: controller.signal };
+	const streamOpts: SimpleStreamOptions = {
+		...parsed.options,
+		apiKey,
+		signal: controller.signal,
+		cursorExternalToolExecutor: true,
+	};
 	streamOpts.apiKey = buildGatewayApiKeyResolver(
 		bootOpts.storage,
 		model,

--- a/packages/ai/src/providers/cursor-external-tool-handoff.md
+++ b/packages/ai/src/providers/cursor-external-tool-handoff.md
@@ -1,0 +1,1 @@
+Tool call received and handed off to the external client for execution. Do not retry or call it again; end the turn. The result will be provided in the next request.

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -342,6 +342,8 @@ export interface CursorOptions extends StreamOptions {
 	conversationId?: string;
 	execHandlers?: CursorExecHandlers;
 	onToolResult?: CursorToolResultHandler;
+	/** Treat unhandled MCP calls as accepted handoffs to an external executor. */
+	externalToolExecutor?: boolean;
 	/** Wire model id selected after thinking-effort routing (`resolveWireModelId`). */
 	wireModelId?: string;
 }
@@ -871,6 +873,7 @@ function streamCursorWithWireMode(
 							requestContextTools,
 							requestContextRules,
 							onConversationCheckpoint,
+							options?.externalToolExecutor,
 						).catch(error => {
 							log("error", "handleServerMessage", { error: String(error) });
 						});
@@ -1157,6 +1160,7 @@ export async function handleServerMessage(
 	requestContextTools: McpToolDefinition[],
 	requestContextRules: CursorRule[] = [],
 	onConversationCheckpoint?: (checkpoint: ConversationStateStructure) => void,
+	externalToolExecutor = false,
 ): Promise<void> {
 	const msgCase = msg.message.case;
 
@@ -1182,6 +1186,7 @@ export async function handleServerMessage(
 				output,
 				stream,
 				state,
+				externalToolExecutor,
 			),
 		);
 	} else if (msgCase === "interactionQuery") {
@@ -1600,6 +1605,7 @@ async function handleExecServerMessage(
 	output: AssistantMessage,
 	stream: AssistantMessageEventStream,
 	state: BlockState,
+	externalToolExecutor: boolean,
 ): Promise<void> {
 	const execCase = execMsg.message.case;
 	log("exec", "dispatch", { execCase, execId: execMsg.execId, hasHandlers: !!execHandlers });
@@ -1948,7 +1954,10 @@ async function handleExecServerMessage(
 				execHandlers?.mcp?.bind(execHandlers),
 				onToolResult,
 				toolResult => buildMcpResultFromToolResult(mcpCall, toolResult),
-				_reason => buildMcpToolNotFoundResult(mcpCall),
+				_reason =>
+					externalToolExecutor && !execHandlers?.mcp
+						? buildMcpExternalHandoffResult()
+						: buildMcpToolNotFoundResult(mcpCall),
 				error => buildMcpErrorResult(error),
 				execHandlers?.mcp ? { toolCallId: mcpCall.toolCallId, toolName: mcpCall.toolName } : null,
 			);
@@ -4006,6 +4015,28 @@ function buildMcpResultFromToolResult(_mcpCall: CursorMcpCall, toolResult: ToolR
 			case: "success",
 			value: create(McpSuccessSchema, {
 				content,
+				isError: false,
+			}),
+		},
+	});
+}
+
+const MCP_EXTERNAL_HANDOFF_MESSAGE =
+	"Tool call received and handed off to the external client for execution. Do not retry or call it again; end the turn. The result will be provided in the next request.";
+
+function buildMcpExternalHandoffResult() {
+	return create(McpResultSchema, {
+		result: {
+			case: "success",
+			value: create(McpSuccessSchema, {
+				content: [
+					create(McpToolResultContentItemSchema, {
+						content: {
+							case: "text",
+							value: create(McpTextContentSchema, { text: MCP_EXTERNAL_HANDOFF_MESSAGE }),
+						},
+					}),
+				],
 				isError: false,
 			}),
 		},

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -211,6 +211,7 @@ import { connectProxiedSocket, getProxyForUrl } from "../utils/proxy";
 import { createRequestDebugSession, isRequestDebugEnabled, type RequestDebugResponseLog } from "../utils/request-debug";
 import { sanitizeSchemaForCursor, toolWireSchema } from "../utils/schema";
 import { formatConnectEndStreamError } from "./connect-error-detail";
+import mcpExternalHandoffMessage from "./cursor-external-tool-handoff.md" with { type: "text" };
 import {
 	buildMcpStateResult,
 	buildNeutralHookResult,
@@ -4021,8 +4022,7 @@ function buildMcpResultFromToolResult(_mcpCall: CursorMcpCall, toolResult: ToolR
 	});
 }
 
-const MCP_EXTERNAL_HANDOFF_MESSAGE =
-	"Tool call received and handed off to the external client for execution. Do not retry or call it again; end the turn. The result will be provided in the next request.";
+const MCP_EXTERNAL_HANDOFF_MESSAGE = mcpExternalHandoffMessage.trim();
 
 function buildMcpExternalHandoffResult() {
 	return create(McpResultSchema, {

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -2381,6 +2381,7 @@ function mapOptionsForApi<TApi extends Api>(
 				...base,
 				execHandlers,
 				onToolResult,
+				externalToolExecutor: options?.cursorExternalToolExecutor,
 				wireModelId: resolveWireModelId(cursorModel, effort),
 			});
 		}

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -646,6 +646,8 @@ export interface SimpleStreamOptions extends Omit<StreamOptions, "apiKey"> {
 	 * A rejecting transformer is swallowed and the reserved payload stands in.
 	 */
 	cursorOnToolResult?: CursorToolResultHandler;
+	/** Cursor hands unhandled MCP calls to an external executor instead of reporting them as missing. */
+	cursorExternalToolExecutor?: boolean;
 	/**
 	 * Amazon Bedrock Guardrail settings forwarded through transports that do not
 	 * dispatch directly to the Bedrock provider. Model-level values take

--- a/packages/ai/test/auth-gateway-response-headers.test.ts
+++ b/packages/ai/test/auth-gateway-response-headers.test.ts
@@ -78,6 +78,36 @@ describe("auth-gateway diagnostic response headers", () => {
 		}
 	});
 
+	it("marks client-declared tools for execution outside the gateway", async () => {
+		const gw = await bootGateway();
+		try {
+			gw.mock.push({ content: ["ok"] });
+			const res = await fetch(`${gw.url}/v1/chat/completions`, {
+				method: "POST",
+				headers: { "Content-Type": "application/json", Authorization: "Bearer t" },
+				body: JSON.stringify({
+					model: "mock/header-model",
+					messages: [{ role: "user", content: "send this" }],
+					tools: [
+						{
+							type: "function",
+							function: {
+								name: "send_message",
+								description: "Send a message",
+								parameters: { type: "object", properties: { text: { type: "string" } } },
+							},
+						},
+					],
+					stream: false,
+				}),
+			});
+			expect(res.status).toBe(200);
+			expect(gw.mock.calls[0]?.options?.cursorExternalToolExecutor).toBe(true);
+		} finally {
+			await gw.close();
+		}
+	});
+
 	it("streaming responses carry the model and request ids but no cost (unknown at header time)", async () => {
 		const gw = await bootGateway();
 		try {

--- a/packages/ai/test/cursor-exec-modern.test.ts
+++ b/packages/ai/test/cursor-exec-modern.test.ts
@@ -84,6 +84,7 @@ async function dispatchExec(
 		execHandlers?: CursorExecHandlers;
 		requestContextTools?: McpToolDefinition[];
 		requestContextRules?: CursorRule[];
+		externalToolExecutor?: boolean;
 	} = {},
 ): Promise<{ frames: AgentClientMessage[]; output: AssistantMessage; results: ToolResultMessage[] }> {
 	const output = cursorAssistantMessage();
@@ -113,6 +114,8 @@ async function dispatchExec(
 		{ sawTokenDelta: false },
 		options.requestContextTools ?? [],
 		options.requestContextRules,
+		undefined,
+		options.externalToolExecutor,
 	);
 
 	return { frames: written.map(decodeClientFrame), output, results };
@@ -1974,6 +1977,50 @@ describe("Cursor MCP frame: approval-only probes", () => {
 		const answer = soleResult(frames);
 		if (answer.case !== "mcpResult") throw new Error(`got ${answer.case}`);
 		expect(answer.value.result.case).toBe("success");
+	});
+});
+
+describe("Cursor MCP frame: external executor handoff", () => {
+	function mcpCall() {
+		return buildExecMessage({
+			case: "mcpArgs",
+			value: create(McpArgsSchema, {
+				name: "send_message",
+				toolName: "send_message",
+				toolCallId: "call-external-1",
+				providerIdentifier: "external-client",
+			}),
+		});
+	}
+
+	it("acknowledges a client-owned tool without claiming it is missing", async () => {
+		const { frames, results } = await dispatchExec(mcpCall(), { externalToolExecutor: true });
+		const answer = soleResult(frames);
+		if (answer.case !== "mcpResult") throw new Error(`got ${answer.case}`);
+		expect(answer.value.result.case).toBe("success");
+		if (answer.value.result.case !== "success") throw new Error(`got ${answer.value.result.case}`);
+		const content = answer.value.result.value.content[0]?.content;
+		expect(content?.case).toBe("text");
+		if (content?.case !== "text") throw new Error(`got ${content?.case}`);
+		expect(content.value.text).toContain("handed off to the external client");
+		expect(content.value.text).toContain("Do not retry");
+		expect(results).toEqual([]);
+	});
+
+	it("keeps the local no-handler path available to the outer agent loop", async () => {
+		const { frames } = await dispatchExec(mcpCall());
+		const answer = soleResult(frames);
+		if (answer.case !== "mcpResult") throw new Error(`got ${answer.case}`);
+		expect(answer.value.result.case).toBe("toolNotFound");
+	});
+
+	it("still rejects a present handler that returns no result", async () => {
+		const execHandlers: CursorExecHandlers = {};
+		Reflect.set(execHandlers, "mcp", async () => undefined);
+		const { frames } = await dispatchExec(mcpCall(), { execHandlers, externalToolExecutor: true });
+		const answer = soleResult(frames);
+		if (answer.case !== "mcpResult") throw new Error(`got ${answer.case}`);
+		expect(answer.value.result.case).toBe("toolNotFound");
 	});
 });
 


### PR DESCRIPTION
## Repro
A minimal Bun harness invoked `handleServerMessage` with an `mcpArgs` frame for client-owned `send_message` and `execHandlers` unset, then decoded the emitted `AgentClientMessage`; current main returned `{"resultCase":"toolNotFound","toolName":"send_message","availableTools":[]}`. The reporter's end-to-end command is `curl -s localhost:8899/v1/chat/completions -H 'content-type: application/json' -d '<request with cursor/cursor-grok-4.6-fast and send_message tool>'`.

## Cause
`packages/ai/src/auth-gateway/server.ts` called `streamSimple` without identifying the gateway as the external tool executor. In `packages/ai/src/providers/cursor.ts`, `handleExecServerMessage` therefore routed an unhandled `mcpArgs` frame through the generic `buildMcpToolNotFoundResult` callback, telling Cursor's server-side agent loop that a valid client-declared tool did not exist.

## Fix
- Add a Cursor-specific external-executor option and set it on both translated and pi-native auth-gateway requests.
- Return a successful MCP handoff only when that mode is active and no MCP handler exists.
- Preserve `toolNotFound` for ordinary no-handler calls and for installed handlers that return no result.
- Cover the gateway-to-provider option boundary and all three MCP result branches.

## Verification
`bun test packages/ai/test/cursor-exec-modern.test.ts packages/ai/test/auth-gateway-response-headers.test.ts` passed 83 tests with 0 failures. `bun run check` passed in `packages/ai`, and the repository pre-publish `bun check` gate passed. Re-running the decoded-frame harness in external-executor mode returned `success`, `isError: false`, and the handoff instruction instead of `toolNotFound`.

Fixes #10589