### PR TITLE
fix(compaction): bound response.incomplete recovery retries

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Auto-compaction recovery no longer loops indefinitely when a model repeatedly returns an empty `response.incomplete` (`length`) turn: the length-stop recovery path is now bounded and surfaces an actionable error after a few failed attempts instead of scheduling `shake-retry` forever and persisting hundreds of empty assistant turns ([#10594](https://github.com/can1357/oh-my-pi/issues/10594)).
+
 ## [18.1.3] - 2026-09-02
 
 ### Changed

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -762,6 +762,7 @@ export class AgentSession {
 
 	#resetPromptMaintenanceState(): void {
 		this.#recovery.resetForNewPrompt();
+		this.#maintenance.resetForNewPrompt();
 		this.#yieldTerminationPending = false;
 	}
 

--- a/packages/coding-agent/src/session/session-maintenance.ts
+++ b/packages/coding-agent/src/session/session-maintenance.ts
@@ -1999,7 +1999,12 @@ export class SessionMaintenance {
 				if (this.#incompleteRecoveryAttempts >= INCOMPLETE_RECOVERY_MAX_RETRIES) {
 					const attempts = this.#incompleteRecoveryAttempts;
 					this.#incompleteRecoveryAttempts = 0;
-					await this.#host.dropPersistedAssistantTurn(assistantMessage);
+					const droppedEntryId = await this.#host.dropPersistedAssistantTurn(assistantMessage);
+					// Reparenting the live branch is insufficient when this terminal path
+					// appends no successor: on restart, the loader selects the last physical
+					// journal entry and revives the discarded length turn. Persist the branch
+					// marker/rewrite before blocking further continuation.
+					if (droppedEntryId) await this.#host.sessionManager.discardEntryDurably(droppedEntryId);
 					const finalError = `Compaction recovery gave up after ${attempts} consecutive empty \`length\` responses from ${assistantMessage.provider}/${assistantMessage.model}; the model produced no output. Try switching models or raising the model's max output tokens.`;
 					logger.warn("response.incomplete recovery cap reached; halting retries", {
 						model: `${assistantMessage.provider}/${assistantMessage.model}`,

--- a/packages/coding-agent/src/session/session-maintenance.ts
+++ b/packages/coding-agent/src/session/session-maintenance.ts
@@ -77,7 +77,7 @@ import {
 	resolveMethodSettings,
 	resolveSpeculationMethod,
 } from "./compaction-methods";
-import { convertToLlm, stripImagesFromMessage } from "./messages";
+import { assistantTurnProducedOutput, convertToLlm, stripImagesFromMessage } from "./messages";
 import { isTerminalTextAssistantAnswer } from "./queued-messages";
 import {
 	resolveCompactionConfiguredTarget,
@@ -116,6 +116,17 @@ const COMPACTION_CHECK_BLOCK_AUTOMATIC_CONTINUATION: CompactionCheckResult = {
 	continuationScheduled: false,
 	automaticContinuationBlocked: true,
 };
+
+/**
+ * Consecutive `response.incomplete` (length-stop) recoveries that produce no
+ * actionable output before recovery gives up. A model that keeps returning an
+ * empty `length` turn (seen with `zai/glm-4.5-flash`, #10594) would otherwise
+ * re-trigger compaction + `shake-retry` forever, persisting an empty assistant
+ * turn on every attempt. Mirrors the empty-stop / unexpected-stop retry caps in
+ * {@link TurnRecovery}; any turn that produces actionable output resets the
+ * counter, so legitimate multi-step recoveries are never cut short.
+ */
+export const INCOMPLETE_RECOVERY_MAX_RETRIES = 3;
 
 /** Whether a configured preference list contains at least one automatic method. */
 function hasConfiguredCompactionMethod(settings: ConfiguredCompactionSettings): boolean {
@@ -365,6 +376,13 @@ export class SessionMaintenance {
 	/** In-flight or armed background speculative compaction, if any. */
 	#speculation: SpeculationRun | undefined;
 	#skipPostTurnMaintenanceAssistantTimestamp: number | undefined;
+	/**
+	 * Consecutive no-progress `response.incomplete` (length-stop) recoveries in
+	 * the current continuation loop. Bounded by {@link INCOMPLETE_RECOVERY_MAX_RETRIES};
+	 * reset by any turn that produces actionable output and on every new user
+	 * prompt ({@link resetForNewPrompt}).
+	 */
+	#incompleteRecoveryAttempts = 0;
 	readonly #host: SessionMaintenanceHost;
 
 	get #model(): Model | undefined {
@@ -381,6 +399,11 @@ export class SessionMaintenance {
 
 	constructor(host: SessionMaintenanceHost) {
 		this.#host = host;
+	}
+
+	/** Clears per-prompt recovery counters when a new user prompt starts. */
+	resetForNewPrompt(): void {
+		this.#incompleteRecoveryAttempts = 0;
 	}
 
 	/** Whether manual or automatic context maintenance is active. */
@@ -1803,6 +1826,10 @@ export class SessionMaintenance {
 		if (skipAbortedCheck && assistantMessage.stopReason === "aborted") return COMPACTION_CHECK_NONE;
 		const contextWindow = this.#model?.contextWindow ?? 0;
 		const generation = this.#host.promptGeneration();
+		// A turn that produced actionable output means the incomplete-recovery loop
+		// broke through: clear the counter so a later isolated `length` stop starts
+		// fresh rather than inheriting a stale count from an earlier loop.
+		if (assistantTurnProducedOutput(assistantMessage)) this.#incompleteRecoveryAttempts = 0;
 		// Skip overflow check if the message came from a different model.
 		// This handles the case where user switched from a smaller-context model (e.g. opus)
 		// to a larger-context model (e.g. codex) - the overflow error from the old model
@@ -1947,6 +1974,7 @@ export class SessionMaintenance {
 			const promoted = await this.#tryContextPromotion(assistantMessage);
 			if (promoted) {
 				await this.#host.dropPersistedAssistantTurn(assistantMessage);
+				this.#incompleteRecoveryAttempts = 0;
 				logger.debug("Context promotion triggered by response.incomplete (length stop)", {
 					from: `${assistantMessage.provider}/${assistantMessage.model}`,
 				});
@@ -1960,9 +1988,31 @@ export class SessionMaintenance {
 
 			const incompleteCompactionSettings = this.#host.settings.getGroup("compaction");
 			if (incompleteCompactionSettings.enabled && hasConfiguredCompactionMethod(incompleteCompactionSettings)) {
+				// Bound the loop: a model that keeps returning an empty `length` turn
+				// (zero usage, no content) re-triggers compaction + shake-retry forever
+				// otherwise, persisting an empty assistant turn each pass (#10594). Count
+				// no-progress incomplete recoveries; past the cap, drop the dead turn,
+				// surface an actionable error, and stop scheduling continuations. Any
+				// turn that produced actionable output already reset the counter at the
+				// top of checkCompaction, so a genuinely truncated turn that resumes
+				// after compaction is never cut short.
+				if (this.#incompleteRecoveryAttempts >= INCOMPLETE_RECOVERY_MAX_RETRIES) {
+					const attempts = this.#incompleteRecoveryAttempts;
+					this.#incompleteRecoveryAttempts = 0;
+					await this.#host.dropPersistedAssistantTurn(assistantMessage);
+					const finalError = `Compaction recovery gave up after ${attempts} consecutive empty \`length\` responses from ${assistantMessage.provider}/${assistantMessage.model}; the model produced no output. Try switching models or raising the model's max output tokens.`;
+					logger.warn("response.incomplete recovery cap reached; halting retries", {
+						model: `${assistantMessage.provider}/${assistantMessage.model}`,
+						attempts,
+					});
+					this.#host.emitNotice("error", finalError, "compaction");
+					return COMPACTION_CHECK_BLOCK_AUTOMATIC_CONTINUATION;
+				}
+				this.#incompleteRecoveryAttempts++;
 				logger.debug("Compaction triggered by response.incomplete (length stop, no promotion target)", {
 					model: `${assistantMessage.provider}/${assistantMessage.model}`,
 					methods: resolveCompactionMethodOrder(incompleteCompactionSettings.methodOrder),
+					attempt: this.#incompleteRecoveryAttempts,
 				});
 				return await this.#host.runRecoveryCompactionWithRollback("incomplete", assistantMessage, allowDefer, {
 					autoContinue,

--- a/packages/coding-agent/test/agent-session-auto-compaction-progress-guard.test.ts
+++ b/packages/coding-agent/test/agent-session-auto-compaction-progress-guard.test.ts
@@ -1,10 +1,12 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as path from "node:path";
 import { scheduler } from "node:timers/promises";
 import { Agent } from "@oh-my-pi/pi-agent-core";
 import * as compactionModule from "@oh-my-pi/pi-agent-core/compaction";
 import { type CompactionPreparation, resolveThresholdTokens, shouldCompact } from "@oh-my-pi/pi-agent-core/compaction";
 import type { AssistantMessage } from "@oh-my-pi/pi-ai";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { TempDir } from "@oh-my-pi/pi-utils";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
@@ -53,6 +55,7 @@ describe("AgentSession auto-compaction progress guard", () => {
 	let authStorage: AuthStorage;
 	let modelRegistry: ModelRegistry;
 	let compactHookEnabled = true;
+	const tempDirs: TempDir[] = [];
 
 	const NOTICE_SOURCE = "compaction";
 	const NO_PROGRESS_FRAGMENT = "Compaction freed too little context to make progress";
@@ -63,10 +66,7 @@ describe("AgentSession auto-compaction progress guard", () => {
 		modelRegistry = new ModelRegistry(authStorage);
 	});
 
-	beforeEach(() => {
-		compactHookEnabled = true;
-		sessionManager = SessionManager.inMemory();
-
+	function createTestSession(manager: SessionManager): AgentSession {
 		// The progress-guard tests exercise AgentSession's post-compaction state
 		// transitions, not extension discovery. Keep the production hook boundary
 		// while returning the same short-circuit result without compiling a
@@ -106,16 +106,9 @@ describe("AgentSession auto-compaction progress guard", () => {
 			},
 		});
 
-		// Seed a minimal branch so prepareCompaction() returns a preparation.
-		sessionManager.appendMessage({
-			role: "user",
-			content: "hello",
-			timestamp: Date.now(),
-		});
-
-		session = new AgentSession({
+		return new AgentSession({
 			agent,
-			sessionManager,
+			sessionManager: manager,
 			settings: Settings.isolated({
 				// Auto-continue ON so the guarded auto-continue path is exercised.
 				"compaction.autoContinue": true,
@@ -123,10 +116,24 @@ describe("AgentSession auto-compaction progress guard", () => {
 			modelRegistry,
 			extensionRunner: extensionRunner as never,
 		});
+	}
+
+	beforeEach(() => {
+		compactHookEnabled = true;
+		sessionManager = SessionManager.inMemory();
+
+		// Seed a minimal branch so prepareCompaction() returns a preparation.
+		sessionManager.appendMessage({
+			role: "user",
+			content: "hello",
+			timestamp: Date.now(),
+		});
+		session = createTestSession(sessionManager);
 	});
 
 	afterEach(async () => {
 		await session?.dispose();
+		await Promise.all(tempDirs.splice(0).map(dir => dir.remove()));
 		vi.restoreAllMocks();
 	});
 
@@ -938,11 +945,25 @@ describe("AgentSession auto-compaction progress guard", () => {
 		);
 	});
 
-	it("caps repeated empty length-stop recovery instead of looping forever", async () => {
+	it("durably caps repeated empty length-stop recovery across restart", async () => {
 		// #10594: a model (zai/glm-4.5-flash) kept returning an empty zero-token
 		// `length` turn. Handoff generation produced no document, so recovery fell
 		// to shake-retry, which re-entered the same empty turn ~once/second for 20
 		// minutes and persisted hundreds of empty assistant turns until manual abort.
+		await session.dispose();
+		const tempDir = TempDir.createSync("@pi-incomplete-recovery-cap-");
+		tempDirs.push(tempDir);
+		const cwd = tempDir.path();
+		const sessionDir = path.join(cwd, "sessions");
+		sessionManager = SessionManager.create(cwd, sessionDir);
+		const sessionFile = sessionManager.getSessionFile();
+		if (!sessionFile) throw new Error("Expected a persisted session file path");
+		sessionManager.appendMessage({
+			role: "user",
+			content: "hello",
+			timestamp: Date.now(),
+		});
+		session = createTestSession(sessionManager);
 		session.settings.set("compaction.methodOrder", ["shake"]);
 		session.settings.set("compaction.enabled", true);
 		session.settings.set("compaction.keepRecentTokens", 1);
@@ -997,13 +1018,25 @@ describe("AgentSession auto-compaction progress guard", () => {
 		expect(attempts).toBe(INCOMPLETE_RECOVERY_MAX_RETRIES + 1);
 		expect(continueSpy).toHaveBeenCalledTimes(INCOMPLETE_RECOVERY_MAX_RETRIES);
 		expect(errorNotices.some(message => /length/i.test(message))).toBe(true);
-		// The pathological empty turn must not be left persisted on the branch.
 		expect(sessionManager.getBranch()).not.toContainEqual(
 			expect.objectContaining({
 				type: "message",
 				message: expect.objectContaining({ role: "assistant", stopReason: "length" }),
 			}),
 		);
+
+		// The capped path appends no successor after dropping the failed turn. Reopen
+		// the journal to prove the durable branch marker, rather than the discarded
+		// physical leaf, selects the active branch after a process restart.
+		await session.dispose();
+		const reloaded = await SessionManager.open(sessionFile, sessionDir);
+		expect(reloaded.getBranch()).not.toContainEqual(
+			expect.objectContaining({
+				type: "message",
+				message: expect.objectContaining({ role: "assistant", stopReason: "length" }),
+			}),
+		);
+		await reloaded.close();
 	});
 
 	it("settles an overlapping successful stop but resumes a thinking-only length stop", async () => {

--- a/packages/coding-agent/test/agent-session-auto-compaction-progress-guard.test.ts
+++ b/packages/coding-agent/test/agent-session-auto-compaction-progress-guard.test.ts
@@ -11,6 +11,7 @@ import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import type { CompactionEntry } from "@oh-my-pi/pi-coding-agent/session/session-entries";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { INCOMPLETE_RECOVERY_MAX_RETRIES } from "@oh-my-pi/pi-coding-agent/session/session-maintenance";
 
 it("clamps a reserve exceeding the window for small-window threshold recovery bands", () => {
 	const settings = {
@@ -933,6 +934,74 @@ describe("AgentSession auto-compaction progress guard", () => {
 					role: "assistant",
 					stopReason: "length",
 				}),
+			}),
+		);
+	});
+
+	it("caps repeated empty length-stop recovery instead of looping forever", async () => {
+		// #10594: a model (zai/glm-4.5-flash) kept returning an empty zero-token
+		// `length` turn. Handoff generation produced no document, so recovery fell
+		// to shake-retry, which re-entered the same empty turn ~once/second for 20
+		// minutes and persisted hundreds of empty assistant turns until manual abort.
+		session.settings.set("compaction.methodOrder", ["shake"]);
+		session.settings.set("compaction.enabled", true);
+		session.settings.set("compaction.keepRecentTokens", 1);
+		session.settings.set("contextPromotion.enabled", false);
+		compactHookEnabled = false;
+		// Shake schedules a `shake-retry` continuation each pass (nothing to reclaim,
+		// but the incomplete turn is not over threshold), re-entering Case 3 on the
+		// next empty length turn — the loop the report hit. Without a cap it never
+		// terminates.
+		vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined as never);
+		const continueSpy = vi.spyOn(session.agent, "continue").mockResolvedValue();
+
+		const errorNotices: string[] = [];
+		session.subscribe(event => {
+			if (event.type === "notice" && event.level === "error") errorNotices.push(event.message);
+		});
+
+		const emptyLengthStop = (offset: number): AssistantMessage => ({
+			role: "assistant",
+			content: [],
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: "claude-sonnet-4-5",
+			stopReason: "length",
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			timestamp: Date.now() + offset,
+		});
+
+		// Drive the shake-retry loop: each retry produces another empty length turn.
+		// Stop the moment recovery declines to schedule a continuation — that is the
+		// point where a real session would yield instead of re-prompting the model.
+		let attempts = 0;
+		for (let i = 0; i < 20; i++) {
+			const before = continueSpy.mock.calls.length;
+			const msg = emptyLengthStop(i);
+			sessionManager.appendMessage(msg);
+			session.agent.emitExternalEvent({ type: "message_end", message: msg });
+			session.agent.emitExternalEvent({ type: "agent_end", messages: [msg] });
+			await session.waitForIdle();
+			attempts++;
+			if (continueSpy.mock.calls.length === before) break;
+		}
+
+		// Bounded: one blocked attempt past the retry cap, not an unbounded loop.
+		expect(attempts).toBe(INCOMPLETE_RECOVERY_MAX_RETRIES + 1);
+		expect(continueSpy).toHaveBeenCalledTimes(INCOMPLETE_RECOVERY_MAX_RETRIES);
+		expect(errorNotices.some(message => /length/i.test(message))).toBe(true);
+		// The pathological empty turn must not be left persisted on the branch.
+		expect(sessionManager.getBranch()).not.toContainEqual(
+			expect.objectContaining({
+				type: "message",
+				message: expect.objectContaining({ role: "assistant", stopReason: "length" }),
 			}),
 		);
 	});


### PR DESCRIPTION
## Repro
On a long `zai/glm-4.5-flash` session near the compaction threshold, the model returned an assistant turn with `stopReason: "length"`, no content, and zero usage. `checkCompaction` Case 3 ran recovery compaction; handoff produced no document, so recovery fell to shake, which found nothing to reclaim but was not over threshold, so it emitted `auto_compaction_end{action:shake, willRetry:true}` and scheduled `agent.continue{source:shake-retry}`. The continuation yielded another empty `length` turn and the cycle repeated ~once/second for ~20 minutes (890 `shake-retry` continuations / empty length turns) until manual abort. Reproduced via the session harness in `agent-session-auto-compaction-progress-guard.test.ts`: with the cap removed the loop schedules one `shake-retry` per pass indefinitely, bounded only by the test's arbitrary 20-iteration ceiling.

## Cause
`SessionMaintenance.checkCompaction` Case 3 (`packages/coding-agent/src/session/session-maintenance.ts`) — the `response.incomplete` / `length`-stop recovery path — had no retry cap, unlike the sibling `EMPTY_STOP_MAX_RETRIES` / `UNEXPECTED_STOP_MAX_RETRIES` paths in `turn-recovery.ts`. Each empty length turn re-entered Case 3 and unconditionally called `runRecoveryCompactionWithRollback("incomplete", …)`, which schedules a continuation, so a model stuck emitting empty length turns looped forever.

## Fix
- Add `INCOMPLETE_RECOVERY_MAX_RETRIES` and an `#incompleteRecoveryAttempts` counter to `SessionMaintenance`.
- In Case 3, increment the counter before running recovery; past the cap, drop the dead turn (`dropPersistedAssistantTurn`), emit an actionable `error` notice, and return `COMPACTION_CHECK_BLOCK_AUTOMATIC_CONTINUATION` instead of scheduling another retry.
- Reset the counter at the top of `checkCompaction` whenever a turn produced actionable output (`assistantTurnProducedOutput`), and on context promotion (model change), so legitimate multi-step truncation recoveries are never cut short.
- Add `SessionMaintenance.resetForNewPrompt()`, wired into `AgentSession.#resetPromptMaintenanceState`, so a new user prompt starts fresh.

## Verification
`bun test test/agent-session-auto-compaction-progress-guard.test.ts` (32 pass) plus `agent-session-context-promotion`, `agent-session-compaction`, `compaction-lifecycle`, `shake`, and `agent-session-unexpected-stop-guard` (38 pass, 4 skip). The new test `caps repeated empty length-stop recovery instead of looping forever` fails before the fix (unbounded `shake-retry` scheduling) and passes after (3 retries, then a blocking error notice; no empty `length` turn left persisted). Pre-publish `bun run fix` + `bun check` passed. Fixes #10594