### PR TITLE
fix(catalog): resolve namespaced family ambiguity

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Discovered Bedrock-style `mistral.mixtral-*` models no longer abort startup with an ambiguous family classification ([#10598](https://github.com/can1357/oh-my-pi/issues/10598)).
+
 ## [18.1.4] - 2026-09-02
 
 ### Changed

--- a/packages/catalog/src/compat/rules/README.md
+++ b/packages/catalog/src/compat/rules/README.md
@@ -69,7 +69,7 @@ family "flash" glob="*flash*"
 family "lite" glob="*flash-lite*" priority=10
 ```
 
-The glob is anchored, ASCII-case-insensitive, and matched against the lowercased bare name. Matching families rank by `(priority, non-wildcard byte count in the glob)`. Equal ranks belonging to different family IDs are an ambiguity error. No match produces no family. Repeating rules for the same family ID is allowed, as in the checked-in `o-series` taxonomy.
+The glob is anchored, ASCII-case-insensitive, and matched against the lowercased bare name. Matching families rank by `(priority, non-wildcard byte count in the glob)`. When equal-ranked family globs tie, a leading `class.` or `class:` namespace matching one of the selected class's tokens is removed and family matching is retried; a remaining tie is an ambiguity error. No match produces no family. Repeating rules for the same family ID is allowed, as in the checked-in `o-series` taxonomy.
 
 ### Revision extraction
 

--- a/packages/catalog/src/compat/taxonomy.ts
+++ b/packages/catalog/src/compat/taxonomy.ts
@@ -88,11 +88,16 @@ function nonWildcardBytes(glob: string): number {
 	return count;
 }
 
-function classifyFamily(cls: CompiledClass, bare: string, model: string, lenient: boolean): string | undefined {
+interface FamilyRanking {
+	winner?: { rank: readonly [number, number]; id: string };
+	tied?: readonly [string, string];
+}
+
+function rankFamilies(cls: CompiledClass, subject: string): FamilyRanking {
 	let winner: { rank: readonly [number, number]; id: string } | undefined;
 	let tied: readonly [string, string] | undefined;
 	for (const family of cls.families) {
-		if (!globMatch(family.glob, bare)) continue;
+		if (!globMatch(family.glob, subject)) continue;
 		const rank = [family.priority, nonWildcardBytes(family.glob)] as const;
 		if (winner && winner.rank[0] === rank[0] && winner.rank[1] === rank[1] && winner.id !== family.id) {
 			tied = [winner.id, family.id];
@@ -101,11 +106,31 @@ function classifyFamily(cls: CompiledClass, bare: string, model: string, lenient
 			tied = undefined;
 		}
 	}
-	if (tied) {
-		if (lenient) return undefined;
-		throw new AmbiguousIdentityError(model, tied[0], tied[1], "family");
+	return { winner, tied };
+}
+
+function stripClassNamespace(cls: CompiledClass, bare: string): string | undefined {
+	const separator = bare.search(/[.:]/);
+	if (separator <= 0 || separator === bare.length - 1) return undefined;
+	const namespace = bare.slice(0, separator);
+	if (!cls.matchers.some(matcher => matcher.token === namespace)) return undefined;
+	return bare.slice(separator + 1);
+}
+
+function classifyFamily(cls: CompiledClass, bare: string, model: string, lenient: boolean): string | undefined {
+	const initial = rankFamilies(cls, bare);
+	const tied = initial.tied;
+	if (!tied) return initial.winner?.id;
+
+	// A Bedrock-style `vendor.model` id names the product after the class
+	// namespace. Rescore only ambiguities so existing classifications stay put.
+	const scoped = stripClassNamespace(cls, bare);
+	if (scoped !== undefined) {
+		const rescored = rankFamilies(cls, scoped);
+		if (rescored.winner && !rescored.tied) return rescored.winner.id;
 	}
-	return winner?.id;
+	if (lenient) return undefined;
+	throw new AmbiguousIdentityError(model, tied[0], tied[1], "family");
 }
 
 function extractRevision(cls: CompiledClass, bare: string): string | undefined {

--- a/packages/catalog/test/compat-taxonomy.test.ts
+++ b/packages/catalog/test/compat-taxonomy.test.ts
@@ -19,6 +19,17 @@ describe("classifyModel", () => {
 		});
 	});
 
+	test("class namespace does not compete with the product family", () => {
+		expect(classifyModel("litellm", "mistral.mixtral-8x7b-instruct-v0:1")).toEqual({
+			class: "mistral",
+			family: "mixtral",
+		});
+		expect(classifyModel("litellm", "mistral.mistral-large-2402-v1:0")).toEqual({
+			class: "mistral",
+			family: "mistral",
+		});
+	});
+
 	test("bare o-series names carry no revision", () => {
 		expect(classifyModel("openai", "o3")).toEqual({ class: "openai", family: "o-series" });
 		expect(classifyModel("openai", "o3-mini")).toEqual({


### PR DESCRIPTION
## Repro

On current `main`, `bun -e 'import { classifyModel } from "./packages/catalog/src/compat/taxonomy.ts"; console.log(classifyModel("litellm", "mistral.mixtral-8x7b-instruct-v0:1"))'` exits with `AmbiguousIdentityError` before a discovered model can be built.

## Cause

`classifyFamily` in `packages/catalog/src/compat/taxonomy.ts` ranked family globs over the entire bare id. For `mistral.mixtral-*`, the `mistral` namespace and `mixtral` product token matched equal-rank rules from `packages/catalog/src/compat/rules/taxonomy/mistral.kdl`, so strict discovery-time policy resolution threw.

## Fix

- Split family ranking from ambiguity handling.
- Rescore only equal-rank ties after removing a leading class-token `.` or `:` namespace.
- Add regression coverage for Mixtral and unaffected Mistral Bedrock-style ids, plus taxonomy documentation and a changelog entry.

## Verification

`bun test packages/catalog/test/compat-taxonomy.test.ts packages/catalog/test/compat-conformance.test.ts packages/catalog/test/compat-parity.test.ts` passed: 18 tests, 0 failures. Re-running the classifier command returns `{"class":"mistral","family":"mixtral"}`.

Fixes #10598