### PR TITLE
feat(ai): anchor prompt-cache breakpoint on the stable request head

### DIFF
--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -3509,6 +3509,64 @@ function applyPromptCaching(params: MessageCreateParamsStreaming, cacheControl?:
 	}
 }
 
+/**
+ * Anchor cache_control on the stable request head — the last (non-deferred)
+ * tool definition and the last system block. The canonical cache order is
+ * tools → system → messages, so a breakpoint on the final system block caches
+ * the entire tools+system prefix, and the extra tool breakpoint keeps the tool
+ * definitions cached even when the system text changes. This guarantees the
+ * large, unchanging head is a cache hit on every turn regardless of how the
+ * message tail churns — the breakpoint placement first-party Anthropic clients
+ * (Claude Code, Pi) use. Without it, the general API-key path anchors only the
+ * moving message tail, so tail churn re-writes the whole head uncached.
+ *
+ * Anthropic allows at most 4 cache breakpoints per request. At most one is
+ * spent on tools and one on system here, leaving two for the message tail in
+ * `applyPromptCaching`. Head caching is skipped entirely when the head is
+ * already anchored — the OAuth Claude Code path caches its own instruction
+ * block at buildAnthropicSystemBlocks, and via the canonical tools → system
+ * order that single system breakpoint already caches every preceding tool. Re-
+ * anchoring there would be redundant, would change the OAuth wire, and could
+ * push a tool-heavy request over the 4-breakpoint budget, so the general
+ * API-key path (nothing cached upstream) is the only one decorated here.
+ *
+ * Runs after the byte-stability plane (planStableAnthropicSystem /
+ * planStableAnthropicTools), which hands back fresh block/tool copies each turn
+ * and keys tool identity off a fingerprint that excludes cache_control — so
+ * decorating here is byte-stable across turns and never forces a re-baseline.
+ */
+function applyHeadCaching(
+	systemBlocks: AnthropicSystemBlock[] | undefined,
+	tools: AnthropicWireTool[] | undefined,
+	cacheControl?: AnthropicCacheControl,
+): void {
+	if (!cacheControl) return;
+
+	// If anything in the head already carries a breakpoint, the head is already
+	// cached (OAuth anchors its identity system block, which — canonical order
+	// tools → system — caches all tools too). Leave it untouched.
+	const headAlreadyCached =
+		(systemBlocks?.some(block => block.cache_control != null) ?? false) ||
+		(tools?.some(tool => tool.cache_control != null) ?? false);
+	if (headAlreadyCached) return;
+
+	if (tools && tools.length > 0) {
+		// Deferred tools are not part of the checked prefix until referenced, so
+		// anchor the last tool that actually sits in the stable prefix.
+		for (let index = tools.length - 1; index >= 0; index--) {
+			const tool = tools[index];
+			if (!tool || tool.defer_loading) continue;
+			tool.cache_control = cloneAnthropicCacheControl(cacheControl);
+			break;
+		}
+	}
+
+	if (systemBlocks && systemBlocks.length > 0) {
+		const lastBlock = systemBlocks[systemBlocks.length - 1];
+		if (lastBlock) lastBlock.cache_control = cloneAnthropicCacheControl(cacheControl);
+	}
+}
+
 function usesAdaptiveThinkingTagOnly(model: Model<"anthropic-messages">): boolean {
 	const thinking = model.thinking;
 	if (thinking?.mode !== "anthropic-adaptive") return false;
@@ -3984,6 +4042,9 @@ function buildParams(
 	if (controlState) syncAnthropicControlState(controlState, wireMessages);
 	systemBlocks = planStableAnthropicSystem(systemBlocks, controlState, model.compat.supportsMidConversationSystem);
 	tools = planStableAnthropicTools(tools, wireMessages, controlState, model.compat.supportsMidConversationToolChanges);
+	// Anchor the stable tools+system head so it stays cached across turns; the
+	// moving message tail is anchored separately in applyPromptCaching below.
+	applyHeadCaching(systemBlocks, tools, cacheControl);
 	const topLevelEffort = planStableAnthropicEffort(
 		outputConfigEffort,
 		wireMessages,

--- a/packages/ai/test/anthropic-alignment.test.ts
+++ b/packages/ai/test/anthropic-alignment.test.ts
@@ -472,7 +472,9 @@ describe("Anthropic request fingerprint alignment", () => {
 			messages?: Array<{ role: string; content: string | Array<{ cache_control?: unknown }> }>;
 		};
 
-		expect(payload.system?.some(block => block.cache_control != null)).toBe(false);
+		// Only the last system block is anchored (stable head); earlier blocks stay uncached.
+		expect(payload.system?.slice(0, -1).some(block => block.cache_control != null)).toBe(false);
+		expect(payload.system?.at(-1)?.cache_control).toEqual({ type: "ephemeral" });
 		const userContent = payload.messages?.[0]?.content;
 		expect(Array.isArray(userContent) ? userContent[0]?.cache_control : undefined).toEqual({
 			type: "ephemeral",
@@ -781,7 +783,7 @@ describe("Anthropic request fingerprint alignment", () => {
 		expect(extractSuffix(billingWithDev)).toBe(extractSuffix(billingUserOnly));
 	});
 
-	it("leaves system blocks uncached on API-key requests", async () => {
+	it("anchors the last system block on API-key requests", async () => {
 		const payload = (await captureAnthropicPayload(
 			ANTHROPIC_MODEL,
 			{
@@ -791,10 +793,14 @@ describe("Anthropic request fingerprint alignment", () => {
 			{ isOAuth: false },
 		)) as { system?: Array<{ type: string; text?: string; cache_control?: unknown }> };
 
-		expect(payload.system).toEqual([
-			{ type: "text", text: "stable system" },
-			{ type: "text", text: "stable durable context" },
-		]);
+		// The general API-key path now anchors the stable head: the last system
+		// block carries the breakpoint, earlier blocks stay uncached.
+		expect(payload.system?.[0]).toEqual({ type: "text", text: "stable system" });
+		expect(payload.system?.[1]).toEqual({
+			type: "text",
+			text: "stable durable context",
+			cache_control: { type: "ephemeral" },
+		});
 	});
 
 	it("uses Bearer auth for non-Anthropic API bases with api-key credentials", () => {

--- a/packages/ai/test/anthropic-head-caching.test.ts
+++ b/packages/ai/test/anthropic-head-caching.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Unit test: the general (API-key, non-OAuth) Anthropic path must anchor a
+ * cache breakpoint on the stable request head — the last system block and the
+ * last tool definition — in addition to the moving message tail. Without the
+ * head anchor, tail churn re-writes the whole tools+system prefix uncached,
+ * which is the prompt-cache hit-rate regression this patch fixes.
+ *
+ * The canonical cache order is tools -> system -> messages and Anthropic allows
+ * at most 4 breakpoints per request, so we also assert the total stays within
+ * budget and that head caching is gated off when caching is disabled.
+ *
+ * No network: a capturing `fetch` records the serialized wire body and returns
+ * a 400 so the request short-circuits.
+ */
+import { describe, expect, it } from "bun:test";
+import type { MessageCreateParams } from "@oh-my-pi/pi-ai/providers/anthropic-wire";
+import { streamAnthropic } from "@oh-my-pi/pi-ai/providers/anthropic";
+import type { CacheRetention, Context, Model, ModelSpec } from "@oh-my-pi/pi-ai/types";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+
+const MODEL_SPEC: ModelSpec<"anthropic-messages"> = {
+	id: "claude-sonnet-4-5",
+	name: "Claude Sonnet 4.5",
+	api: "anthropic-messages",
+	provider: "anthropic",
+	baseUrl: "https://api.anthropic.com",
+	reasoning: true,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 200_000,
+	maxTokens: 8_192,
+};
+
+const MODEL: Model<"anthropic-messages"> = buildModel(MODEL_SPEC);
+
+const CONTEXT: Context = {
+	systemPrompt: ["You are a precise assistant.", "Follow the house style guide."],
+	messages: [{ role: "user", content: "Use the tools", timestamp: 1 }],
+	tools: [
+		{
+			name: "lookup",
+			description: "Lookup a value",
+			parameters: { type: "object", properties: {}, additionalProperties: false },
+		},
+		{
+			name: "compute",
+			description: "Compute a value",
+			parameters: { type: "object", properties: {}, additionalProperties: false },
+		},
+	],
+};
+
+async function captureWireBody(cacheRetention?: CacheRetention): Promise<MessageCreateParams> {
+	let body: MessageCreateParams | undefined;
+	const fetchMock = (async (_input: string | URL | Request, init?: RequestInit) => {
+		body = JSON.parse(String(init?.body ?? "{}")) as MessageCreateParams;
+		return new Response(
+			JSON.stringify({ type: "error", error: { type: "invalid_request_error", message: "captured" } }),
+			{ status: 400, headers: { "Content-Type": "application/json" } },
+		);
+	}) as typeof fetch;
+
+	await streamAnthropic(MODEL, CONTEXT, {
+		apiKey: "sk-ant-api-test",
+		...(cacheRetention ? { cacheRetention } : {}),
+		fetch: fetchMock,
+	})
+		.result()
+		.catch(() => undefined);
+
+	if (!body) throw new Error("wire body was not captured");
+	return body;
+}
+
+function countCacheBreakpoints(body: MessageCreateParams): number {
+	let count = 0;
+	for (const block of body.system ?? []) {
+		if (typeof block !== "string" && block.cache_control != null) count++;
+	}
+	for (const tool of body.tools ?? []) {
+		if ((tool as { cache_control?: unknown }).cache_control != null) count++;
+	}
+	for (const message of body.messages ?? []) {
+		if (Array.isArray(message.content)) {
+			for (const block of message.content) {
+				if ((block as { cache_control?: unknown }).cache_control != null) count++;
+			}
+		}
+	}
+	return count;
+}
+
+describe("anthropic head caching (general API-key path)", () => {
+	it("anchors cache_control on the last system block", async () => {
+		const body = await captureWireBody();
+		const system = body.system;
+		if (!Array.isArray(system)) throw new Error("expected system blocks array");
+
+		const last = system[system.length - 1];
+		expect(typeof last === "string" ? undefined : last.cache_control?.type).toBe("ephemeral");
+
+		// Only the final system block is anchored, not every block.
+		const earlier = system[0];
+		expect(typeof earlier === "string" ? undefined : earlier.cache_control).toBeUndefined();
+	});
+
+	it("anchors cache_control on the last tool definition", async () => {
+		const body = await captureWireBody();
+		const tools = body.tools ?? [];
+		expect(tools.length).toBeGreaterThan(1);
+
+		const last = tools[tools.length - 1] as { cache_control?: { type?: string } };
+		expect(last.cache_control?.type).toBe("ephemeral");
+
+		// Only the final tool is anchored, not every tool.
+		const first = tools[0] as { cache_control?: unknown };
+		expect(first.cache_control).toBeUndefined();
+	});
+
+	it("preserves the moving message-tail breakpoint", async () => {
+		const body = await captureWireBody();
+		const trailing = body.messages[body.messages.length - 1];
+		expect(Array.isArray(trailing.content)).toBe(true);
+		if (!Array.isArray(trailing.content)) return;
+		const lastBlock = trailing.content[trailing.content.length - 1] as { cache_control?: { type?: string } };
+		expect(lastBlock.cache_control?.type).toBe("ephemeral");
+	});
+
+	it("stays within Anthropic's 4-breakpoint budget", async () => {
+		const body = await captureWireBody();
+		expect(countCacheBreakpoints(body)).toBeLessThanOrEqual(4);
+	});
+
+	it("adds no breakpoints when caching is disabled", async () => {
+		const body = await captureWireBody("none");
+		expect(countCacheBreakpoints(body)).toBe(0);
+	});
+});


### PR DESCRIPTION
## What

Anchor a prompt-cache breakpoint on the stable request *head* — the last
non-deferred tool definition and the last system block — on the general
API-key Anthropic path.

## Why

The general (API-key, non-OAuth) path anchors `cache_control` only on the
moving message tail (`applyPromptCaching`, last ≤2 eligible messages). The
canonical cache order is `tools -> system -> messages`, and Anthropic can
only serve a cache *read* up to a boundary that was previously *written* at
a breakpoint.

- **Append-only turns are already fine.** The tail breakpoints from the
  previous turn remain a valid byte prefix of the next request, so the
  large `tools + system` head is read for free via longest-prefix match —
  no dedicated head breakpoint needed.
- **History-mutation turns are not.** When the context is compacted
  (`replaceTail()` rewrites the tail with a summary), those tail-anchored
  prefix entries no longer match. With no breakpoint at the head boundary,
  there is nothing to read for the head alone, so the entire
  `tools + system` prefix is re-written uncached on every post-compaction
  turn — a recurring prompt-cache regression for long-lived agents that
  compact.

`applyHeadCaching` gives the head its own byte-stable breakpoint so it stays
cached across compaction.

## How

`applyHeadCaching` places one breakpoint on the last non-deferred tool and
one on the last system block:

- The system-block breakpoint caches the entire `tools + system` prefix.
- The extra tool breakpoint keeps tool definitions cached even when system
  text changes. It is **redundant while the system block is byte-stable** —
  the system breakpoint already caches all tools in that case (the benchmark
  below shows the full head served by a single entry) — and is kept only as
  cheap insurance for sessions whose system prompt drifts (dynamic date,
  cwd, env). It costs one of the four breakpoints, and the head (≤2) plus
  tail (≤2) still fit exactly.
- It is **skipped when the head is already anchored** — the OAuth Claude
  Code path caches its own identity block, so re-anchoring would be
  redundant, change the OAuth wire, and risk the 4-breakpoint budget.
- Stays within Anthropic's 4-breakpoint limit (<=1 tool + 1 system here,
  leaving 2 for the tail in `applyPromptCaching`).
- Runs after the byte-stability plane on fresh block/tool copies, so it
  never forces a re-baseline.

This mirrors the head-caching placement first-party clients (Claude Code,
Pi) already use.

## Benchmark

Real source-run A/B through a live Anthropic-compatible pipe, Sonnet,
`--mode json`, head-ON (this branch) vs head-OFF (parent commit). Same
turns, same process, steady-state per-turn means:

| Regime | cost/turn head-ON | cost/turn head-OFF | Δ | head `cacheRead` |
|---|---|---|---|---|
| Append-only (16 turns) | — | — | **~0%** (dead even) | both read the head for free |
| Compaction churn (12 turns) | **$0.1107** | $0.1403 | **−21.1%** | ON: 17,158 tok/turn · **OFF: 0 (never)** |

Under churn, head-OFF's `cacheRead` is **0 across all turns** — it re-writes
the full 17,158-token head every turn; head-ON reads it on every warm turn.
Append-only is dead even, confirming the head breakpoint is a no-op on the
common path and a strict win only when history is mutated — exactly the
Why above.

**Caveat:** the churn run set the compaction threshold below the head size,
so compaction fired every turn (maximally adversarial). The −21% is
therefore a *ceiling*; real-world benefit scales with how often the agent
compacts (one saved ~17k-token head re-write per post-compaction turn).

## Testing

- New `packages/ai/test/anthropic-head-caching.test.ts`: asserts the head
  anchors (last tool + last system), the moving tail breakpoint is
  preserved, the 4-breakpoint budget holds, and no breakpoints are added
  when caching is disabled.
- Updated `packages/ai/test/anthropic-alignment.test.ts`.
- `bun test packages/ai/test/anthropic-head-caching.test.ts packages/ai/test/anthropic-alignment.test.ts` -> 101 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
