### PR TITLE
feat(copy): clickable copy/open controls and link blocks in /copy, plus /copy link and /open

### DIFF
--- a/docs/collab.md
+++ b/docs/collab.md
@@ -90,7 +90,7 @@ Guests with a full link can:
 
 Guests with a view-only link can read everything live — back-transcript, streaming text, tool cards, subagent transcripts — but the host rejects prompting, interrupting, and agent control from them.
 
-Everything that mutates the host session or machine is host-only: `/model`, `/compact`, `/resume`, `/branch`, bash (`!`), python (`$`), skills, etc. Guests keep a small local allowlist (`/dump`, `/export`, `/copy`, `/help`, `/hotkeys`, `/theme`, `/settings`, `/leave`, `/collab`, `/exit`, `/quit`).
+Everything that mutates the host session or machine is host-only: `/model`, `/compact`, `/resume`, `/branch`, bash (`!`), python (`$`), skills, etc. Guests keep a small local allowlist (`/dump`, `/export`, `/copy`, `/open`, `/help`, `/hotkeys`, `/theme`, `/settings`, `/leave`, `/collab`, `/exit`, `/quit`).
 
 When a guest joins during an assistant turn, that in-flight turn appears on the first subsequent `message_update`: the guest synthesizes the missing `message_start` from the update's full accumulating message before forwarding the delta. If the host emits no further update for that turn after the guest joins, there is no update from which to synthesize the live component. The durable entry still reaches the replica's message state, but entry frames are intentionally not rendered, so that edge case can remain absent from the live TUI.
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- `/copy` block view: every block caption now carries a clickable `⧉ copy` control, and a turn's links are listed as blocks with `⧉ copy` and `↗ open`. Click the icon (the overlay receives mouse input) or use Enter / `o`; a URL that wrapped across terminal rows needs neither a careful selection nor cmd-click. `/copy link` copies the last link; new `/open` opens it. Link detection uses the renderer's own markdown lexer (`extractMarkdownLinks` in `@oh-my-pi/pi-tui`).
+
 ## [18.1.3] - 2026-09-02
 
 ### Changed

--- a/packages/coding-agent/src/collab/guest.ts
+++ b/packages/coding-agent/src/collab/guest.ts
@@ -44,6 +44,8 @@ export const COLLAB_GUEST_ALLOWED_COMMANDS: Record<string, true> = {
 	dump: true,
 	export: true,
 	copy: true,
+	// Opens a link in the guest's own browser; nothing reaches the host.
+	open: true,
 	help: true,
 	hotkeys: true,
 	theme: true,

--- a/packages/coding-agent/src/modes/components/copy-selector.ts
+++ b/packages/coding-agent/src/modes/components/copy-selector.ts
@@ -5,9 +5,14 @@
  * alternate screen and moves the same dotted outline the esc-esc rewind
  * selector uses over the rendered items; Enter copies the outlined turn's
  * text. Right descends into the turn's inner blocks — fenced code, `>`-quotes,
- * bash/eval commands, tool output — replacing the turn's rendered region with
- * a stacked, syntax-highlighted block view whose outline steps per block;
- * Left/Esc ascend back to the transcript.
+ * bash/eval commands, tool output, and links — replacing the turn's rendered
+ * region with a stacked, syntax-highlighted block view whose outline steps per
+ * block; Left/Esc ascend back to the transcript. Every block caption carries a
+ * clickable `⧉ copy` control and link blocks add `↗ open`; the overlay is
+ * fullscreen, so the terminal reports clicks here (SGR mouse) even though the
+ * main transcript never captures the mouse. Keyboard: Enter copies, `o` opens.
+ * A URL that wrapped across terminal rows therefore needs neither a careful
+ * mouse selection nor cmd-click.
  */
 import type { AgentTool } from "@oh-my-pi/pi-agent-core";
 import {
@@ -17,12 +22,13 @@ import {
 	ScrollView,
 	type TUI,
 	truncateToWidth,
+	visibleWidth,
 } from "@oh-my-pi/pi-tui";
 import type { MessageRenderer } from "../../extensibility/extensions/types";
 import type { SessionMessageEntry } from "../../session/session-entries";
 import { replaceTabs } from "../../tools/render-utils";
 import { highlightCode, type ThemeColor, theme } from "../theme/theme";
-import { commandFromToolCall, extractBlocks } from "../utils/copy-targets";
+import { commandFromToolCall, extractBlocks, extractLinks } from "../utils/copy-targets";
 import {
 	matchesAppToolsExpand,
 	matchesSelectCancel,
@@ -53,6 +59,8 @@ export interface CopySelectorDeps {
 	requestRender: () => void;
 	/** The outlined content was chosen — copy it. `label` feeds the status line. */
 	onPick: (content: string, label: string) => void;
+	/** `o` on a link block — open `href` with the system opener. Absent: `o` is ignored. */
+	onOpen?: (href: string, label: string) => void;
 	onCancel: () => void;
 }
 
@@ -64,6 +72,8 @@ interface CopyBlock {
 	content: string;
 	/** Highlight language for the block preview. */
 	language?: string;
+	/** Set for link blocks: the URL `o` opens. `content` is the same URL. */
+	href?: string;
 }
 
 /** Rows the frame chrome occupies: top rule, header, rule, footer hint, bottom rule. */
@@ -72,6 +82,16 @@ const CHROME_ROWS = 5;
 const BLOCK_PREVIEW_LINES = 12;
 /** The copy picker's outline stroke — green, distinct from the rewind selector's accent. */
 const OUTLINE_COLOR: ThemeColor = "success";
+/** Rows above the scroll view: top rule, header, rule. Mouse rows map through this offset. */
+const CONTENT_TOP = 3;
+
+/** A clickable control on a block caption, in composed-column columns. */
+interface ControlRegion {
+	action: "copy" | "open";
+	blockIndex: number;
+	start: number;
+	end: number;
+}
 
 export class CopySelectorComponent implements Component {
 	#builder: ChatTranscriptBuilder;
@@ -86,6 +106,8 @@ export class CopySelectorComponent implements Component {
 	#blocks: CopyBlock[] | undefined;
 	#blockSelected = 0;
 	#blockCache = new Map<string, CopyBlock[]>();
+	/** Click targets of the last render, keyed by composed-column line index. */
+	#controls = new Map<number, ControlRegion[]>();
 
 	constructor(
 		entries: SessionMessageEntry[],
@@ -141,7 +163,9 @@ export class CopySelectorComponent implements Component {
 				if (event.wheel !== null) {
 					this.#scrollView.scroll(event.wheel * 3);
 					this.deps.requestRender();
+					return true;
 				}
+				if (event.leftClick) this.#click(event.row, event.col);
 				return true;
 			});
 			return;
@@ -181,6 +205,11 @@ export class CopySelectorComponent implements Component {
 			if (this.#blocks) this.#ascend();
 			return;
 		}
+		if (data === "o" || data === "O") {
+			const block = this.#blocks?.[this.#blockSelected];
+			if (block?.href && this.deps.onOpen) this.deps.onOpen(block.href, block.label);
+			return;
+		}
 		if (matchesKey(data, "enter") || matchesKey(data, "return") || data === "\n") {
 			if (this.#blocks) {
 				const block = this.#blocks[this.#blockSelected];
@@ -204,6 +233,24 @@ export class CopySelectorComponent implements Component {
 		this.#blockSelected = 0;
 		this.#scrollToSelection = true;
 		this.deps.requestRender();
+	}
+
+	/** A left click at terminal (row, col): act if it lands on a caption control. */
+	#click(row: number, col: number): void {
+		if (!this.#blocks) return;
+		const line = row - CONTENT_TOP + this.#scrollView.getScrollOffset();
+		const regions = this.#controls.get(line);
+		if (!regions) return;
+		const hit = regions.find(region => col >= region.start && col < region.end);
+		if (!hit) return;
+		const block = this.#blocks[hit.blockIndex];
+		if (!block) return;
+		this.#blockSelected = hit.blockIndex;
+		if (hit.action === "open") {
+			if (block.href && this.deps.onOpen) this.deps.onOpen(block.href, block.label);
+			return;
+		}
+		this.deps.onPick(block.content, block.label);
 	}
 
 	#moveVertical(delta: -1 | 1): void {
@@ -253,10 +300,11 @@ export class CopySelectorComponent implements Component {
 		const target = this.#targets[this.#selected];
 		const blocks = target ? this.#blocksFor(target) : [];
 		let composed: ComposedColumn;
+		this.#controls = new Map();
 		if (this.#blocks && target) {
 			// Descended: the turn's rendered region is replaced by its block stack.
 			const before = composeOutlineColumn(childRows, 0, target.start, [], -1, contentWidth, undefined);
-			const stack = this.#composeBlocks(this.#blocks, contentWidth);
+			const stack = this.#composeBlocks(this.#blocks, contentWidth, before.lines.length);
 			const after = composeOutlineColumn(childRows, target.end, children.length, [], -1, contentWidth, undefined);
 			composed = {
 				lines: [...before.lines, ...stack.lines, ...after.lines],
@@ -299,16 +347,23 @@ export class CopySelectorComponent implements Component {
 		);
 		output.push(...this.#border.render(width));
 		output.push(...this.#scrollView.render(width));
+		const selectedBlock = this.#blocks?.[this.#blockSelected];
+		const openHint = selectedBlock?.href && this.deps.onOpen ? "  o open" : "";
 		const hint = this.#blocks
-			? `${this.#blockSelected + 1}/${this.#blocks.length}  ↑/↓ block  ←/esc back  enter copy`
+			? `${this.#blockSelected + 1}/${this.#blocks.length}  ↑/↓ block  ←/esc back  enter copy${openHint}  click ${theme.cmd.copy}/${theme.cmd.share}`
 			: `${this.#targets.length > 0 ? `${this.#selected + 1}/${this.#targets.length}  ` : ""}↑/↓ step  ${blocks.length > 0 ? "→ blocks  " : ""}enter copy  ctrl+o expand  esc close`;
 		output.push(` ${theme.fg("dim", hint)}`);
 		output.push(...this.#border.render(width));
 		return output;
 	}
 
-	/** The selected turn exploded into captioned block previews, selected one outlined. */
-	#composeBlocks(blocks: CopyBlock[], columnWidth: number): ComposedColumn {
+	/**
+	 * The selected turn exploded into captioned block previews, selected one
+	 * outlined. Each caption ends with clickable controls; their column spans
+	 * are recorded in `#controls` under the composed line index
+	 * (`lineOffset` + local index) so {@link #click} can resolve a mouse hit.
+	 */
+	#composeBlocks(blocks: CopyBlock[], columnWidth: number, lineOffset: number): ComposedColumn {
 		const inner = Math.max(10, columnWidth - 4);
 		const lines: string[] = [];
 		let selStart = -1;
@@ -322,18 +377,41 @@ export class CopySelectorComponent implements Component {
 			if (raw.length > shown.length) {
 				rows.push(theme.fg("dim", `… +${raw.length - shown.length} more lines`));
 			}
-			const caption = truncateToWidth(
+			const selected = index === this.#blockSelected;
+			const captionColor: ThemeColor = selected ? OUTLINE_COLOR : "dim";
+			const controls: Array<{ action: ControlRegion["action"]; text: string }> = [
+				{ action: "copy", text: `${theme.cmd.copy} copy` },
+			];
+			if (block.href && this.deps.onOpen) controls.push({ action: "open", text: `${theme.cmd.share} open` });
+			const controlsWidth = controls.reduce((sum, control) => sum + visibleWidth(control.text) + 2, 0);
+			const summary = truncateToWidth(
 				`${index + 1}/${blocks.length}${theme.sep.dot}${block.label}${theme.sep.dot}${raw.length} line${raw.length === 1 ? "" : "s"}`,
-				inner,
+				Math.max(4, inner - controlsWidth),
 			);
+			// Caption: two-space gutter, summary, then the controls, each preceded by two spaces.
+			let caption = theme.fg(captionColor, summary);
+			let cursor = 2 + visibleWidth(summary);
+			const regions: ControlRegion[] = [];
+			for (const control of controls) {
+				cursor += 2;
+				regions.push({
+					action: control.action,
+					blockIndex: index,
+					start: cursor,
+					end: cursor + visibleWidth(control.text),
+				});
+				caption += `  ${theme.fg("accent", control.text)}`;
+				cursor += visibleWidth(control.text);
+			}
 			lines.push("");
-			if (index === this.#blockSelected) {
+			this.#controls.set(lineOffset + lines.length, regions);
+			if (selected) {
 				selStart = lines.length;
-				lines.push(`  ${theme.fg(OUTLINE_COLOR, caption)}`);
+				lines.push(`  ${caption}`);
 				lines.push(...outlineRows(rows, inner, { color: OUTLINE_COLOR }));
 				selEnd = lines.length;
 			} else {
-				lines.push(`  ${theme.fg("dim", caption)}`);
+				lines.push(`  ${caption}`);
 				for (const row of rows) lines.push(row ? `  ${row}` : row);
 			}
 		}
@@ -380,6 +458,15 @@ function pushMarkdownBlocks(blocks: CopyBlock[], text: string): void {
 		} else {
 			blocks.push({ label: "quote", content: block.text });
 		}
+	}
+	// Links follow the message's blocks. The preview shows the whole URL on one
+	// row, so a link the transcript wrapped is copied or opened intact.
+	for (const link of extractLinks(text)) {
+		blocks.push({
+			label: link.text !== link.href ? `link${theme.sep.dot}${link.text}` : "link",
+			content: link.href,
+			href: link.href,
+		});
 	}
 }
 

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -84,6 +84,7 @@ import { shortenPath } from "../../tools/render-utils";
 import { ToolAbortError } from "../../tools/tool-errors";
 import { applyHyperlinkSetting } from "../../tui/hyperlink";
 import { copyToClipboard } from "../../utils/clipboard";
+import { openPath } from "../../utils/open";
 import { setSessionTerminalTitle } from "../../utils/title-generator";
 import { type AdvisorConfigDeps, AdvisorConfigOverlayComponent } from "../components/advisor-config";
 import { AgentHubOverlayComponent } from "../components/agent-hub";
@@ -1413,6 +1414,11 @@ export class SelectorController {
 				}
 				void copyToClipboard(content);
 				this.ctx.showStatus(`Copied ${label} to clipboard`);
+			},
+			onOpen: (href, label) => {
+				done();
+				openPath(href);
+				this.ctx.showStatus(`Opening ${label}: ${href}`);
 			},
 			onCancel: done,
 		});

--- a/packages/coding-agent/src/modes/utils/copy-targets.ts
+++ b/packages/coding-agent/src/modes/utils/copy-targets.ts
@@ -1,5 +1,6 @@
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
 import type { ToolCall } from "@oh-my-pi/pi-ai";
+import { extractMarkdownLinks } from "@oh-my-pi/pi-tui";
 
 /** A fenced code block extracted from assistant markdown. */
 export interface CodeBlock {
@@ -103,6 +104,45 @@ export function extractQuoteBlocks(text: string): QuoteBlock[] {
 	return extractBlocks(text)
 		.filter((b): b is { kind: "quote" } & QuoteBlock => b.kind === "quote")
 		.map(b => ({ text: b.text }));
+}
+
+/** A hyperlink found in assistant markdown: inline `[text](href)`, `<autolink>`, bare URL, or reference link. */
+export interface LinkTarget {
+	/** Visible link text; equals `href` for autolinks and bare URLs. */
+	text: string;
+	/** Absolute http(s) URL as marked resolved it. */
+	href: string;
+}
+
+/**
+ * Hyperlinks the renderer would draw for `text`, in document order and
+ * deduplicated by href. Tokenization is the renderer's own
+ * ({@link extractMarkdownLinks}), so fenced code, code spans, escapes,
+ * reference definitions and GFM autolink rules agree with the screen. Only
+ * http(s) targets qualify: the result feeds both the clipboard and the system
+ * opener, and a `mailto:`/`file:` destination is not something to hand to
+ * either from a transcript.
+ */
+export function extractLinks(text: string): LinkTarget[] {
+	const seen = new Set<string>();
+	const links: LinkTarget[] = [];
+	for (const link of extractMarkdownLinks(text)) {
+		if (!/^https?:\/\//i.test(link.href) || seen.has(link.href)) continue;
+		seen.add(link.href);
+		links.push({ text: link.text, href: link.href });
+	}
+	return links;
+}
+
+/** Walk the transcript backwards for the most recent link in an assistant message. */
+export function extractLastLink(messages: readonly AgentMessage[]): LinkTarget | undefined {
+	for (let i = messages.length - 1; i >= 0; i--) {
+		const text = assistantText(messages[i]);
+		if (!text) continue;
+		const links = extractLinks(text);
+		if (links.length > 0) return links[links.length - 1];
+	}
+	return undefined;
 }
 
 function extractEvalCode(args: unknown): { code: string; language: string } | undefined {

--- a/packages/coding-agent/src/slash-commands/builtin-collaboration.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-collaboration.ts
@@ -8,7 +8,8 @@ import { parseExportArgs } from "../export/html/args";
 import { shareSession } from "../export/share";
 import { theme } from "../modes/theme/theme";
 import type { InteractiveModeContext } from "../modes/types";
-import { extractLastCodeBlock, extractLastCommand } from "../modes/utils/copy-targets";
+import { extractLastCodeBlock, extractLastCommand, extractLastLink } from "../modes/utils/copy-targets";
+import { openPath } from "../utils/open";
 import { copyToClipboard } from "../utils/clipboard";
 import { refreshStatusLine } from "./builtin-modes";
 import { CollabQrCodeComponent, collabBrowserLink } from "./helpers/collab-qrcode";
@@ -528,7 +529,42 @@ export const BUILTIN_COLLABORATION_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpe
 				runtime.ctx.editor.setText("");
 				return;
 			}
-			runtime.ctx.showStatus("Usage: /copy [code|cmd]");
+			if (arg === "link" || arg === "url") {
+				const link = extractLastLink(runtime.ctx.session.messages);
+				if (!link) {
+					runtime.ctx.showStatus("No link to copy.");
+					runtime.ctx.editor.setText("");
+					return;
+				}
+				await copyToClipboard(link.href);
+				runtime.ctx.showStatus("Copied link to clipboard");
+				runtime.ctx.editor.setText("");
+				return;
+			}
+			runtime.ctx.showStatus("Usage: /copy [code|cmd|link]");
+			runtime.ctx.editor.setText("");
+		},
+	},
+	{
+		name: "open",
+		icon: "globe",
+		description: "Open the last link from the conversation in your browser (or pick one with /copy)",
+		allowArgs: true,
+		handleTui: async (command, runtime) => {
+			const arg = command.args.trim().toLowerCase();
+			if (arg && arg !== "link" && arg !== "url") {
+				runtime.ctx.showStatus("Usage: /open [link]  (pick a specific link: /copy, → blocks, o)");
+				runtime.ctx.editor.setText("");
+				return;
+			}
+			const link = extractLastLink(runtime.ctx.session.messages);
+			if (!link) {
+				runtime.ctx.showStatus("No link to open.");
+				runtime.ctx.editor.setText("");
+				return;
+			}
+			openPath(link.href);
+			runtime.ctx.showStatus(`Opening ${link.href}`);
 			runtime.ctx.editor.setText("");
 		},
 	},

--- a/packages/coding-agent/test/modes/components/copy-selector.test.ts
+++ b/packages/coding-agent/test/modes/components/copy-selector.test.ts
@@ -10,7 +10,7 @@ import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
 import { KeybindingsManager } from "@oh-my-pi/pi-coding-agent/config/keybindings";
 import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { CopySelectorComponent } from "@oh-my-pi/pi-coding-agent/modes/components/copy-selector";
-import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { initTheme, theme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import type { SessionMessageEntry } from "@oh-my-pi/pi-coding-agent/session/session-entries";
 import { setKeybindings, type TUI } from "@oh-my-pi/pi-tui";
 
@@ -21,7 +21,8 @@ const ENTER = "\r";
 const ESC = "\x1b";
 
 const CODE = "const answer = 42;\nconsole.log(answer);";
-const ASSISTANT_TEXT = `Here is the fix:\n\`\`\`ts\n${CODE}\n\`\`\`\nDone.`;
+const LINK = "https://github.com/can1357/oh-my-pi/pull/10503";
+const ASSISTANT_TEXT = `Here is the fix:\n\`\`\`ts\n${CODE}\n\`\`\`\nDone. See [the PR](${LINK}).`;
 
 function entry(id: string, parentId: string | null, message: AgentMessage): SessionMessageEntry {
 	return { type: "message", id, parentId, timestamp: "2024-01-01T00:00:00Z", message };
@@ -62,12 +63,17 @@ function makeEntries(): SessionMessageEntry[] {
 	];
 }
 
-function makeSelector(picks: Array<{ content: string; label: string }>, onCancel = () => {}): CopySelectorComponent {
+function makeSelector(
+	picks: Array<{ content: string; label: string }>,
+	onCancel = () => {},
+	opens?: Array<{ href: string; label: string }>,
+): CopySelectorComponent {
 	return new CopySelectorComponent(makeEntries(), {
 		ui: { requestRender: () => {}, requestComponentRender: () => {} } as unknown as TUI,
 		cwd: "/tmp",
 		requestRender: () => {},
 		onPick: (content, label) => picks.push({ content, label }),
+		onOpen: opens ? (href, label) => opens.push({ href, label }) : undefined,
 		onCancel,
 	});
 }
@@ -118,18 +124,134 @@ describe("CopySelectorComponent", () => {
 
 		selector.handleInput(RIGHT);
 		selector.handleInput("\x1b[B");
+		selector.handleInput("\x1b[B");
 		selector.handleInput(ENTER);
 		selector.handleInput(RIGHT);
+		selector.handleInput("\x1b[B");
 		selector.handleInput("\x1b[B");
 		selector.handleInput("\x1b[B");
 		selector.handleInput(ENTER);
 		selector.dispose();
 
-		// Block order within the turn: code fence, bash command, bash result.
+		// Block order within the turn: code fence, link, bash command, bash result.
 		expect(picks).toEqual([
 			{ content: "bun test", label: "bash command" },
 			{ content: "12 pass", label: "bash result" },
 		]);
+	});
+
+	it("lists the turn's links as blocks after code and commands; Enter copies the URL, o opens it", () => {
+		const picks: Array<{ content: string; label: string }> = [];
+		const opens: Array<{ href: string; label: string }> = [];
+		const selector = makeSelector(picks, () => {}, opens);
+		selector.render(100);
+
+		selector.handleInput(RIGHT);
+		// Blocks: ts code, link, bash command, bash result — the link follows the message's own blocks.
+		selector.handleInput("\x1b[B");
+		selector.handleInput(ENTER);
+		selector.handleInput("o");
+		// o on a non-link block is ignored.
+		selector.handleInput("\x1b[B");
+		selector.handleInput("o");
+		const rows = selector.render(100);
+		selector.dispose();
+
+		expect(picks).toEqual([{ content: LINK, label: `link${theme.sep.dot}the PR` }]);
+		expect(opens).toEqual([{ href: LINK, label: `link${theme.sep.dot}the PR` }]);
+		expect(rows.join("\n")).not.toContain("o open");
+	});
+
+	it("advertises o open only while a link block is outlined and an opener exists", () => {
+		const opens: Array<{ href: string; label: string }> = [];
+		const withOpener = makeSelector([], () => {}, opens);
+		withOpener.render(100);
+		withOpener.handleInput(RIGHT);
+		withOpener.handleInput("\x1b[B");
+		expect(withOpener.render(100).join("\n")).toContain("o open");
+		withOpener.dispose();
+
+		const withoutOpener = makeSelector([]);
+		withoutOpener.render(100);
+		withoutOpener.handleInput(RIGHT);
+		withoutOpener.handleInput("\x1b[B");
+		withoutOpener.handleInput("o");
+		expect(withoutOpener.render(100).join("\n")).not.toContain("o open");
+		withoutOpener.dispose();
+	});
+
+	/** SGR left-press at a 0-based (row, col) of the rendered frame. */
+	const click = (row: number, col: number) => `\x1b[<0;${col + 1};${row + 1}M`;
+
+	/** Locate `needle` in the rendered frame: 0-based row and the visible column where it starts. */
+	function locate(lines: readonly string[], needle: string): { row: number; col: number } {
+		for (let row = 0; row < lines.length; row++) {
+			const plain = Bun.stripANSI(lines[row]!);
+			const at = plain.indexOf(needle);
+			if (at !== -1) return { row, col: at };
+		}
+		throw new Error(`"${needle}" not rendered`);
+	}
+
+	it("renders clickable controls on every block caption; a left click on ⧉ copy copies that block", () => {
+		const picks: Array<{ content: string; label: string }> = [];
+		const opens: Array<{ href: string; label: string }> = [];
+		const selector = makeSelector(picks, () => {}, opens);
+		selector.render(100);
+		selector.handleInput(RIGHT);
+		const frame = selector.render(100);
+		const plain = frame.map(line => Bun.stripANSI(line));
+
+		// The bash command is block 3 of 4 and is not the outlined block; its own control still targets it.
+		const captionRow = plain.findIndex(line => line.includes("3/4 · bash command"));
+		expect(captionRow).toBeGreaterThan(0);
+		const copyCol = plain[captionRow]!.indexOf(`${theme.cmd.copy} copy`);
+		expect(copyCol).toBeGreaterThan(0);
+		selector.handleInput(click(captionRow, copyCol + 1));
+		selector.dispose();
+
+		expect(picks).toEqual([{ content: "bun test", label: "bash command" }]);
+		expect(opens).toEqual([]);
+	});
+
+	it("a left click on ↗ open opens that link; non-link captions render no open control", () => {
+		const picks: Array<{ content: string; label: string }> = [];
+		const opens: Array<{ href: string; label: string }> = [];
+		const selector = makeSelector(picks, () => {}, opens);
+		selector.render(100);
+		selector.handleInput(RIGHT);
+		const frame = selector.render(100);
+		const plain = frame.map(line => Bun.stripANSI(line));
+
+		const linkRow = plain.findIndex(line => line.includes("2/4 · link · the PR"));
+		const codeRow = plain.findIndex(line => line.includes("1/4 · ts code"));
+		expect(plain[linkRow]).toContain(`${theme.cmd.share} open`);
+		expect(plain[codeRow]).not.toContain(`${theme.cmd.share} open`);
+
+		const openCol = plain[linkRow]!.indexOf(`${theme.cmd.share} open`);
+		selector.handleInput(click(linkRow, openCol + 2));
+		// Clicks beside a control (the summary text, or the gap) do nothing.
+		selector.handleInput(click(linkRow, 4));
+		selector.handleInput(click(linkRow + 1, openCol));
+		selector.dispose();
+
+		expect(opens).toEqual([{ href: LINK, label: `link${theme.sep.dot}the PR` }]);
+		expect(picks).toEqual([]);
+	});
+
+	it("click positions follow the scroll offset", () => {
+		const picks: Array<{ content: string; label: string }> = [];
+		const selector = makeSelector(picks);
+		selector.render(100);
+		selector.handleInput(RIGHT);
+		// Scroll the view down by one wheel notch (3 lines) and re-render so the map reflects it.
+		selector.handleInput("\x1b[<65;1;10M");
+		const frame = selector.render(100);
+		const { row, col } = locate(frame, `${theme.cmd.copy} copy`);
+		selector.handleInput(click(row, col));
+		selector.dispose();
+
+		expect(picks).toEqual([{ content: CODE, label: "ts code" }]);
 	});
 
 	it("Esc ascends from the block view before it cancels the picker", () => {
@@ -166,16 +288,18 @@ describe("CopySelectorComponent", () => {
 		const selector = makeSelector([]);
 		const itemView = selector.render(100).map(line => Bun.stripANSI(line));
 		// The outline advertises the descent affordance before Right is pressed.
-		expect(itemView.join("\n")).toContain("3 blocks →");
+		expect(itemView.join("\n")).toContain("4 blocks →");
 		selector.handleInput(RIGHT);
 		const lines = selector.render(100).map(line => Bun.stripANSI(line));
 		selector.handleInput(LEFT);
 		selector.dispose();
 
 		const joined = lines.join("\n");
-		expect(joined).toContain("1/3 · ts code");
-		expect(joined).toContain("2/3 · bash command");
-		expect(joined).toContain("3/3 · bash result");
+		expect(joined).toContain("1/4 · ts code");
+		expect(joined).toContain("2/4 · link · the PR");
+		expect(joined).toContain(LINK);
+		expect(joined).toContain("3/4 · bash command");
+		expect(joined).toContain("4/4 · bash result");
 		// The selected block sits inside the dotted outline; the rest are plain.
 		const boxed = lines.filter(line => line.startsWith("┆")).join("\n");
 		expect(boxed).toContain("const answer = 42;");

--- a/packages/coding-agent/test/modes/utils/copy-targets.test.ts
+++ b/packages/coding-agent/test/modes/utils/copy-targets.test.ts
@@ -3,6 +3,8 @@ import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
 import {
 	extractCodeBlocks,
 	extractLastCommand,
+	extractLastLink,
+	extractLinks,
 	extractQuoteBlocks,
 } from "@oh-my-pi/pi-coding-agent/modes/utils/copy-targets";
 
@@ -76,5 +78,68 @@ describe("extractLastCommand", () => {
 			]),
 		] as unknown as AgentMessage[];
 		expect(extractLastCommand(py)).toEqual({ kind: "eval", code: "print(1)\n\nprint(2)", language: "python" });
+	});
+});
+
+describe("extractLinks", () => {
+	it("finds inline links, autolinks, and bare URLs in document order, deduplicated by href", () => {
+		const text = [
+			'See [the docs](https://example.com/docs "Docs") and <https://example.com/auto>.',
+			"Bare: https://example.com/bare/path?x=1&y=2 then again https://example.com/docs.",
+		].join("\n");
+		expect(extractLinks(text)).toEqual([
+			{ text: "the docs", href: "https://example.com/docs" },
+			{ text: "https://example.com/auto", href: "https://example.com/auto" },
+			{ text: "https://example.com/bare/path?x=1&y=2", href: "https://example.com/bare/path?x=1&y=2" },
+		]);
+	});
+
+	it("trims sentence punctuation but keeps a paren that belongs to the URL", () => {
+		expect(extractLinks("(https://en.wikipedia.org/wiki/Foo_(bar)).")).toEqual([
+			{ text: "https://en.wikipedia.org/wiki/Foo_(bar)", href: "https://en.wikipedia.org/wiki/Foo_(bar)" },
+		]);
+		expect(extractLinks("Try https://example.com/a, https://example.com/b; or https://example.com/c?")).toEqual([
+			{ text: "https://example.com/a", href: "https://example.com/a" },
+			{ text: "https://example.com/b", href: "https://example.com/b" },
+			{ text: "https://example.com/c", href: "https://example.com/c" },
+		]);
+	});
+
+	it("ignores URLs inside fenced code and inline code, because it uses the renderer's lexer", () => {
+		const text =
+			"Run `curl https://example.com/in-code` then:\n```bash\ncurl https://example.com/fenced\n```\nDocs: https://example.com/prose";
+		expect(extractLinks(text)).toEqual([{ text: "https://example.com/prose", href: "https://example.com/prose" }]);
+	});
+
+	it("keeps a URL that the terminal would wrap as one target", () => {
+		const long = `https://github.com/dalilshorja/dalilshorja/actions/runs/33654874668/job/100330811133?check_suite_focus=true&pr=4`;
+		expect(extractLinks(`Run: ${long}`)).toEqual([{ text: long, href: long }]);
+	});
+
+	it("only http(s) targets qualify", () => {
+		expect(extractLinks("[file](file:///tmp/x) [mail](mailto:a@b.c) ftp://x.y/z a@b.c")).toEqual([]);
+	});
+
+	it("resolves reference links and GFM www autolinks through the renderer's lexer", () => {
+		expect(extractLinks("[ref link][r] and www.example.com/www\n\n[r]: https://example.com/ref")).toEqual([
+			{ text: "ref link", href: "https://example.com/ref" },
+			{ text: "www.example.com/www", href: "http://www.example.com/www" },
+		]);
+	});
+});
+
+describe("extractLastLink", () => {
+	it("returns the last link of the most recent assistant message that has one", () => {
+		const messages = [
+			{ role: "assistant", content: [{ type: "text", text: "old https://example.com/old" }] },
+			{
+				role: "assistant",
+				content: [{ type: "text", text: "a https://example.com/a and b https://example.com/b" }],
+			},
+			{ role: "user", content: "thanks https://example.com/user-link" },
+			{ role: "assistant", content: [{ type: "text", text: "no links here" }] },
+		] as unknown as AgentMessage[];
+		expect(extractLastLink(messages)).toEqual({ text: "https://example.com/b", href: "https://example.com/b" });
+		expect(extractLastLink(messages.slice(3))).toBeUndefined();
 	});
 });

--- a/packages/coding-agent/test/slash-commands/copy.test.ts
+++ b/packages/coding-agent/test/slash-commands/copy.test.ts
@@ -3,6 +3,7 @@ import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
 import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
 import { executeBuiltinSlashCommand } from "@oh-my-pi/pi-coding-agent/slash-commands/builtin-registry";
 import * as clipboard from "@oh-my-pi/pi-coding-agent/utils/clipboard";
+import * as opener from "@oh-my-pi/pi-coding-agent/utils/open";
 
 function assistantText(text: string): AgentMessage {
 	return { role: "assistant", content: [{ type: "text", text }] } as unknown as AgentMessage;
@@ -72,6 +73,30 @@ describe("/copy slash command", () => {
 		expect(harness.setText).toHaveBeenCalledWith("");
 	});
 
+	it("copies the last link's URL with /copy link", async () => {
+		const copySpy = spyOn(clipboard, "copyToClipboard").mockResolvedValue(undefined);
+		const harness = createRuntimeHarness([
+			assistantText("first https://example.com/old"),
+			assistantText("see [docs](https://example.com/docs) and https://example.com/last."),
+		]);
+
+		expect(await executeBuiltinSlashCommand("/copy link", harness.runtime)).toBe(true);
+
+		expect(copySpy).toHaveBeenCalledWith("https://example.com/last");
+		expect(harness.showStatus).toHaveBeenCalledWith("Copied link to clipboard");
+		expect(harness.showCopySelector).not.toHaveBeenCalled();
+	});
+
+	it("reports when there is no link to copy", async () => {
+		const copySpy = spyOn(clipboard, "copyToClipboard").mockResolvedValue(undefined);
+		const harness = createRuntimeHarness([assistantText("no links")]);
+
+		expect(await executeBuiltinSlashCommand("/copy link", harness.runtime)).toBe(true);
+
+		expect(copySpy).not.toHaveBeenCalled();
+		expect(harness.showStatus).toHaveBeenCalledWith("No link to copy.");
+	});
+
 	it("keeps bare /copy on the picker", async () => {
 		const copySpy = spyOn(clipboard, "copyToClipboard").mockResolvedValue(undefined);
 		const harness = createRuntimeHarness([assistantText("answer")]);
@@ -81,5 +106,37 @@ describe("/copy slash command", () => {
 		expect(harness.showCopySelector).toHaveBeenCalledTimes(1);
 		expect(copySpy).not.toHaveBeenCalled();
 		expect(harness.setText).toHaveBeenCalledWith("");
+	});
+});
+
+describe("/open slash command", () => {
+	it("opens the last assistant link with the system opener", async () => {
+		const openSpy = spyOn(opener, "openPath").mockImplementation(() => {});
+		const harness = createRuntimeHarness([
+			assistantText("older https://example.com/old"),
+			assistantText(
+				"CI: https://github.com/dalilshorja/dalilshorja/actions/runs/1 and the PR https://github.com/dalilshorja/dalilshorja/pull/4.",
+			),
+		]);
+
+		expect(await executeBuiltinSlashCommand("/open", harness.runtime)).toBe(true);
+
+		expect(openSpy).toHaveBeenCalledWith("https://github.com/dalilshorja/dalilshorja/pull/4");
+		expect(harness.showStatus).toHaveBeenCalledWith("Opening https://github.com/dalilshorja/dalilshorja/pull/4");
+		expect(harness.setText).toHaveBeenCalledWith("");
+	});
+
+	it("reports when there is no link and rejects unknown arguments", async () => {
+		const openSpy = spyOn(opener, "openPath").mockImplementation(() => {});
+		const harness = createRuntimeHarness([assistantText("no links")]);
+
+		expect(await executeBuiltinSlashCommand("/open", harness.runtime)).toBe(true);
+		expect(harness.showStatus).toHaveBeenCalledWith("No link to open.");
+
+		expect(await executeBuiltinSlashCommand("/open code", harness.runtime)).toBe(true);
+		expect(harness.showStatus).toHaveBeenLastCalledWith(
+			"Usage: /open [link]  (pick a specific link: /copy, → blocks, o)",
+		);
+		expect(openSpy).not.toHaveBeenCalled();
 	});
 });

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -1254,6 +1254,52 @@ function lexDocument(text: string): Token[] {
 	return lexWindowed(text);
 }
 
+/** A hyperlink as the renderer sees it: inline `[text](href)`, `<autolink>`, bare GFM URL, or reference link. */
+export interface MarkdownLink {
+	/** Visible link text (equals `href` for autolinks and bare URLs). */
+	text: string;
+	/** Destination exactly as marked resolved it (references resolved, no normalization). */
+	href: string;
+}
+
+/**
+ * Every link token in `text`, in document order, from the same configured
+ * lexer the renderer uses — so fenced code, code spans, escapes, reference
+ * definitions and the GFM autolink rules agree with what is drawn on screen.
+ * Duplicate hrefs are kept; callers decide how to fold them.
+ */
+export function extractMarkdownLinks(text: string): MarkdownLink[] {
+	const links: MarkdownLink[] = [];
+	const walk = (tokens: readonly Token[] | undefined): void => {
+		if (!tokens) return;
+		for (const token of tokens) {
+			if (token.type === "link") {
+				const link = token as Tokens.Link;
+				if (typeof link.href === "string" && link.href.length > 0) {
+					links.push({
+						text: typeof link.text === "string" && link.text.length > 0 ? link.text : link.href,
+						href: link.href,
+					});
+				}
+				continue;
+			}
+			// Containers: paragraphs, emphasis, lists, blockquotes, table cells.
+			const any = token as {
+				tokens?: Token[];
+				items?: Token[];
+				header?: Array<{ tokens?: Token[] }>;
+				rows?: Array<Array<{ tokens?: Token[] }>>;
+			};
+			walk(any.tokens);
+			walk(any.items);
+			if (any.header) for (const cell of any.header) walk(cell.tokens);
+			if (any.rows) for (const row of any.rows) for (const cell of row) walk(cell.tokens);
+		}
+	};
+	walk(lexDocument(text));
+	return links;
+}
+
 /** Drop all L2 cache entries. Call on theme change to prevent stale styled output. */
 export function clearRenderCache(): void {
 	renderCache.clear();


### PR DESCRIPTION
## Why
A URL that wraps across terminal rows cannot be cmd-clicked or selected cleanly, and a multi-line command is awkward to select by mouse. The `/copy` overlay is fullscreen, so the terminal already reports mouse clicks to it; this puts icons there to click.

## What
- **CopySelector block view**: every block caption ends with a clickable `⧉ copy` control; link blocks add `↗ open`. Controls record their column spans per composed line and a left click (SGR) resolves through the scroll offset to the block it belongs to, outlined or not. Keyboard remains: Enter copies, `o` opens; the hint advertises both.
- A turn's **links appear as blocks** after its code, quotes and commands, each previewed as the whole URL on one row.
- **`pi-tui` exports `extractMarkdownLinks()`**: a link-token walker over the renderer's configured lexer, so fenced code, code spans, escapes, reference links and GFM autolinks agree with what is drawn. `copy-targets.extractLinks()` filters to http(s) hrefs, deduplicated in document order; `extractLastLink()` walks the transcript backwards.
- `selector-controller` wires `onOpen` to `utils/open.ts` `openPath`.
- **`/copy link`** copies the most recent link; new **`/open`** opens it. Collab guests may run `/open` locally.

## Tests
- extractor: order, dedupe, punctuation, code masking, long URL, reference links, `www.` autolinks, non-http rejected
- picker: link blocks, Enter vs `o`, hint gating, SGR clicks on both controls including a non-outlined block, clicks beside a control ignored, scroll-offset mapping
- slash: `/copy link`, `/open`, usage
- `bun run check` clean in `coding-agent` and `tui`; `check:tools` clean; tui markdown suite 146/146

## Manual verification
Ran the TUI through a byte-exact pty: a real left click on `↗ open` opened the URL in the browser (status `Opening link · CI run: https://…`), a click on `⧉ copy` put a two-line command on the system clipboard; `/open` and `/copy link` likewise.
