### PR TITLE
fix(catalog): route opencode muse-spark-1.3 over responses api

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- `opencode-go/muse-spark-1.3-contributor` and `opencode-zen/muse-spark-1.3-contributor-free` now route over the Responses API like their 1.2 siblings, instead of 500ing on every request because they fell through to chat completions ([#10610](https://github.com/can1357/oh-my-pi/issues/10610)).
+
 ## [18.1.4] - 2026-09-02
 
 ### Changed

--- a/packages/catalog/src/compat/rules.json
+++ b/packages/catalog/src/compat/rules.json
@@ -14142,6 +14142,14 @@
 				"provider": "opencode-zen",
 				"routes": [
 					{
+						"api": "openai-responses",
+						"match": {
+							"exact": [
+								"muse-spark-1.3-contributor-free"
+							]
+						}
+					},
+					{
 						"api": "openai-completions",
 						"match": {
 							"exact": [
@@ -14161,7 +14169,8 @@
 							"exact": [
 								"deepseek-v4-flash",
 								"muse-spark-1.2",
-								"muse-spark-1.2-contributor"
+								"muse-spark-1.2-contributor",
+								"muse-spark-1.3-contributor"
 							]
 						}
 					},

--- a/packages/catalog/src/compat/rules/runtime/behavior.kdl
+++ b/packages/catalog/src/compat/rules/runtime/behavior.kdl
@@ -163,16 +163,20 @@ behavior {
 	api-routes provider="zai" default="anthropic-messages" {
 		route "openai-completions" exact="glm-5.3-flash"
 	}
-	// OpenCode Zen: models.dev declares these with `@ai-sdk/anthropic`, but the
-	// gateway serves them only at /v1/chat/completions (#1617).
+	// OpenCode Zen: models.dev declares minimax-m3 with `@ai-sdk/anthropic`, but
+	// the gateway serves it only at /v1/chat/completions (#1617). models.dev
+	// omits muse-spark-1.3-contributor-free entirely, so pin its Responses route
+	// per opencode.ai/docs/zen/#endpoints (#10610).
 	api-routes provider="opencode-zen" {
+		route "openai-responses" exact="muse-spark-1.3-contributor-free"
 		route "openai-completions" exact="minimax-m3" exact="minimax-m3-free"
 	}
 	// OpenCode Go: models.dev's npm hints misroute these (#887, #1617); the
 	// responses pins are gateway-verified (deepseek-v4-flash 2026-08-08;
-	// muse-spark per opencode.ai/docs/go/#endpoints, #8957).
+	// muse-spark per opencode.ai/docs/go/#endpoints, #8957, #10610).
 	api-routes provider="opencode-go" {
-		route "openai-responses" exact="deepseek-v4-flash" exact="muse-spark-1.2" exact="muse-spark-1.2-contributor"
+		route "openai-responses" exact="deepseek-v4-flash" exact="muse-spark-1.2" \
+			exact="muse-spark-1.2-contributor" exact="muse-spark-1.3-contributor"
 		route "openai-completions" exact="minimax-m2.7" exact="minimax-m3" exact="minimax-m3-free" \
 			exact="qwen3.5-plus" exact="qwen3.6-plus"
 	}

--- a/packages/catalog/test/opencode-provider.test.ts
+++ b/packages/catalog/test/opencode-provider.test.ts
@@ -660,6 +660,24 @@ describe("OpenCode provider discovery", () => {
 		}
 	});
 
+	test("routes muse-spark-1.3 contributor ids to the responses API (#10610)", () => {
+		// models.dev omits the muse-spark-1.3 ids under both gateways, so without
+		// an override they fall through to openai-completions even though the Go
+		// and Zen gateways serve them only at /v1/responses
+		// (opencode.ai/docs/go/#endpoints, opencode.ai/docs/zen/#endpoints).
+		// Sending completions requests 500s on every turn.
+		const goDescriptor = MODELS_DEV_PROVIDER_DESCRIPTORS.find(item => item.providerId === "opencode-go");
+		expect(goDescriptor?.resolveApi?.("muse-spark-1.3-contributor", { tool_call: true })).toEqual({
+			api: "openai-responses",
+			baseUrl: "https://opencode.ai/zen/go/v1",
+		});
+		const zenDescriptor = MODELS_DEV_PROVIDER_DESCRIPTORS.find(item => item.providerId === "opencode-zen");
+		expect(zenDescriptor?.resolveApi?.("muse-spark-1.3-contributor-free", { tool_call: true })).toEqual({
+			api: "openai-responses",
+			baseUrl: "https://opencode.ai/zen/v1",
+		});
+	});
+
 	test("pins gateway-only muse-spark ids to responses in live discovery (#8957)", async () => {
 		// models.dev omits muse-spark-1.2[-contributor] under opencode-go, so
 		// there is no bundled reference row. Without the discovery-side pin the


### PR DESCRIPTION
## Repro
`opencode-go/muse-spark-1.3-contributor` (and `opencode-zen/muse-spark-1.3-contributor-free`) 500 on every request regardless of thinking level. The catalog's `api-routes` rule for the OpenCode gateways only pins the 1.2 muse-spark ids, so `apiRouteFor` returns nothing for the 1.3 ids and they fall through to the `openai-completions` default:

```
opencode-go/muse-spark-1.2-contributor       -> openai-responses
opencode-go/muse-spark-1.3-contributor       -> (none -> openai-completions default)
opencode-zen/muse-spark-1.3-contributor-free -> (none -> openai-completions default)
```

Both gateways serve those ids only at `/v1/responses` (opencode.ai/docs/go/#endpoints, opencode.ai/docs/zen/#endpoints), so chat-completions requests fail with `500 Internal server error`.

## Cause
The `api-routes provider="opencode-go"` and `provider="opencode-zen"` rules in `packages/catalog/src/compat/rules/runtime/behavior.kdl` list `muse-spark-1.2[-contributor]` on the `openai-responses` route but never added the 1.3 ids. models.dev omits the 1.3 ids entirely, so there is no bundled reference row and the discovery mapper / descriptor resolver (`apiRouteFor`, `openCodeModelManagerOptions`, `createOpenCodeApiResolution` in `openai-compat.ts`) default them to `openai-completions`. Same class as #8957/#8980, which covered 1.2 but not 1.3.

## Fix
- Add `muse-spark-1.3-contributor` to the `opencode-go` `openai-responses` route in `behavior.kdl`.
- Add a `muse-spark-1.3-contributor-free` `openai-responses` route to the `opencode-zen` rule.
- Regenerate `packages/catalog/src/compat/rules.json` via `bun run gen:compat`.
- Add a regression test in `opencode-provider.test.ts` asserting both 1.3 ids resolve to `openai-responses`.

## Verification
`bun test packages/catalog/test/opencode-provider.test.ts` → 22 pass / 0 fail. Post-fix `apiRouteFor` returns `openai-responses` for both `opencode-go/muse-spark-1.3-contributor` and `opencode-zen/muse-spark-1.3-contributor-free`, while `minimax-m2.7` still resolves to `openai-completions` (no regression). Fixes #10610