### PR TITLE
fix(catalog): route opencode-go muse-spark-1.3 to openai-responses

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `opencode-go/muse-spark-1.3` (and `muse-spark-1.3-contributor`) failing every turn with `500 Internal server error`. The Go gateway serves these ids only at `/zen/go/v1/responses`, but the resolver fell through to `openai-completions`; both ids are now pinned to `openai-responses` like `muse-spark-1.2` ([#10610](https://github.com/can1357/oh-my-pi/issues/10610)).
+
 ## [18.1.4] - 2026-09-02
 
 ### Changed

--- a/packages/catalog/src/compat/rules.json
+++ b/packages/catalog/src/compat/rules.json
@@ -14161,7 +14161,9 @@
 							"exact": [
 								"deepseek-v4-flash",
 								"muse-spark-1.2",
-								"muse-spark-1.2-contributor"
+								"muse-spark-1.2-contributor",
+								"muse-spark-1.3",
+								"muse-spark-1.3-contributor"
 							]
 						}
 					},

--- a/packages/catalog/src/compat/rules/runtime/behavior.kdl
+++ b/packages/catalog/src/compat/rules/runtime/behavior.kdl
@@ -170,9 +170,10 @@ behavior {
 	}
 	// OpenCode Go: models.dev's npm hints misroute these (#887, #1617); the
 	// responses pins are gateway-verified (deepseek-v4-flash 2026-08-08;
-	// muse-spark per opencode.ai/docs/go/#endpoints, #8957).
+	// muse-spark per opencode.ai/docs/go/#endpoints, #8957, #10610).
 	api-routes provider="opencode-go" {
-		route "openai-responses" exact="deepseek-v4-flash" exact="muse-spark-1.2" exact="muse-spark-1.2-contributor"
+		route "openai-responses" exact="deepseek-v4-flash" exact="muse-spark-1.2" exact="muse-spark-1.2-contributor" \
+			exact="muse-spark-1.3" exact="muse-spark-1.3-contributor"
 		route "openai-completions" exact="minimax-m2.7" exact="minimax-m3" exact="minimax-m3-free" \
 			exact="qwen3.5-plus" exact="qwen3.6-plus"
 	}

--- a/packages/catalog/test/opencode-provider.test.ts
+++ b/packages/catalog/test/opencode-provider.test.ts
@@ -660,6 +660,19 @@ describe("OpenCode provider discovery", () => {
 		}
 	});
 
+	test("routes opencode-go muse-spark-1.3 to the responses API (#10610)", () => {
+		const descriptor = MODELS_DEV_PROVIDER_DESCRIPTORS.find(item => item.providerId === "opencode-go");
+		// Same failure class as #8957: the Go gateway serves muse-spark-1.3
+		// only at /zen/go/v1/responses (per opencode.ai/docs/go/#endpoints),
+		// but discovery falls through to openai-completions, which 500s.
+		for (const id of ["muse-spark-1.3", "muse-spark-1.3-contributor"]) {
+			expect(descriptor?.resolveApi?.(id, { tool_call: true })).toEqual({
+				api: "openai-responses",
+				baseUrl: "https://opencode.ai/zen/go/v1",
+			});
+		}
+	});
+
 	test("pins gateway-only muse-spark ids to responses in live discovery (#8957)", async () => {
 		// models.dev omits muse-spark-1.2[-contributor] under opencode-go, so
 		// there is no bundled reference row. Without the discovery-side pin the


### PR DESCRIPTION
I reviewed the full diff; this pins the two 1.3 Muse Spark ids to the Responses transport the Go gateway actually serves, mirroring the 1.2 fix.

Fixes #10610. Related #8957 / #8963 / #8980.

What changed:
- `packages/catalog/src/compat/rules/runtime/behavior.kdl`: added `exact="muse-spark-1.3"` and `exact="muse-spark-1.3-contributor"` to the `opencode-go` `openai-responses` route.
- Regenerated `packages/catalog/src/compat/rules.json` via `bun run gen:compat`.
- Added regression test for `resolveApi` on both 1.3 ids.
- CHANGELOG entry under Unreleased/Fixed.

Verification:
- `bun -e` against `apiRouteFor`: `opencode-go/muse-spark-1.3` and `muse-spark-1.3-contributor` now resolve to `{"api":"openai-responses"}` (was completions / fallback before).
- Live harness check (before fix): `opencode-go/muse-spark-1.3-contributor` on low/high/xhigh all 500 (`errorId 135168`, 0/11 successes in local sessions); a local custom provider forcing `openai-responses` on the same baseUrl/key succeeded on low, high, and xhigh.
- `oxlint` on the touched test file: 0 warnings, 0 errors.
- Note: full `bun test test/opencode-provider.test.ts` could not run locally due to missing `pi_natives.darwin-arm64.node` in this env; the resolver-level check above exercises the changed rule directly. `bun run gen:compat` wrote `rules.json (556 rules)`.
