### PR TITLE
fix(tui): avoid trailing space on directory at-completions

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Avoid inserting a trailing space when auto-completing directory paths with `@`.
+
 ## [18.1.9] - 2026-09-04
 
 ### Added
@@ -20,9 +24,6 @@
 
 - Fixed terminal query support in supervised PTY processes, including cursor position reports.
 - Fixed paste-and-submit handling so an Enter keypress received with a bracketed paste is delivered to the previously focused component; `Editor.onLargePaste` now receives `PasteOptions` describing the queued submit.
-### Fixed
-
-- Avoid inserting a trailing space when auto-completing directory paths with `@`.
 
 ## [18.1.3] - 2026-09-02
 

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -20,6 +20,9 @@
 
 - Fixed terminal query support in supervised PTY processes, including cursor position reports.
 - Fixed paste-and-submit handling so an Enter keypress received with a bracketed paste is delivered to the previously focused component; `Editor.onLargePaste` now receives `PasteOptions` describing the queued submit.
+### Fixed
+
+- Avoid inserting a trailing space when auto-completing directory paths with `@`.
 
 ## [18.1.3] - 2026-09-02
 

--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -738,14 +738,16 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 				beforePrefix = currentLine.slice(0, cursorCol - liveAtPrefix.length);
 			}
 			// This is a file attachment completion
-			const newLine = `${beforePrefix + item.value} ${afterCursor}`;
+			const isDirectory = /[\\/]["']?$/.test(item.value);
+			const suffix = isDirectory ? "" : " ";
+			const newLine = `${beforePrefix + item.value}${suffix}${afterCursor}`;
 			const newLines = [...lines];
 			newLines[cursorLine] = newLine;
 
 			return {
 				lines: newLines,
 				cursorLine,
-				cursorCol: beforePrefix.length + item.value.length + 1, // +1 for space
+				cursorCol: beforePrefix.length + item.value.length + suffix.length,
 			};
 		}
 

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -1467,7 +1467,8 @@ export class Editor implements Component, Focusable {
 						return;
 					}
 					if (selected && this.#autocompleteProvider) {
-						const shouldChainSlashCommandAutocomplete = this.#isSlashCommandNameAutocompleteSelection();
+						const shouldChainAutocomplete =
+							this.#isSlashCommandNameAutocompleteSelection() || /[\\/]["']?$/.test(selected.value);
 						const result = this.#autocompleteProvider.applyCompletion(
 							this.#state.lines,
 							this.#state.cursorLine,
@@ -1489,8 +1490,8 @@ export class Editor implements Component, Focusable {
 
 						result.onApplied?.();
 
-						if (shouldChainSlashCommandAutocomplete && this.#isCompletedSlashCommandAtCursor()) {
-							void this.#tryTriggerAutocomplete();
+						if (shouldChainAutocomplete) {
+							queueMicrotask(() => void this.#tryTriggerAutocomplete());
 						}
 					}
 					return;

--- a/packages/tui/test/autocomplete.test.ts
+++ b/packages/tui/test/autocomplete.test.ts
@@ -655,6 +655,62 @@ describe("CombinedAutocompleteProvider", () => {
 			expect(result.lines[0]).toBe("/model claude-sonnet");
 			expect(result.cursorCol).toBe("/model claude-sonnet".length);
 		});
+
+		it("does not add a trailing space when completing a directory with @", () => {
+			const provider = new CombinedAutocompleteProvider([], "/tmp");
+			const result = provider.applyCompletion(
+				["see @pack"],
+				0,
+				9,
+				{ value: "@packages/", label: "packages/" },
+				"@pack",
+			);
+
+			expect(result.lines[0]).toBe("see @packages/");
+			expect(result.cursorCol).toBe("see @packages/".length);
+		});
+
+		it("does not add a trailing space when completing a quoted directory with @", () => {
+			const provider = new CombinedAutocompleteProvider([], "/tmp");
+			const line = 'see @"my fold';
+			const result = provider.applyCompletion(
+				[line],
+				0,
+				line.length,
+				{ value: '@"my folder/', label: "my folder/" },
+				'@"my fold',
+			);
+			expect(result.lines[0]).toBe('see @"my folder/');
+			expect(result.cursorCol).toBe('see @"my folder/'.length);
+		});
+
+		it("does not add a trailing space when completing a directory with a Windows backslash", () => {
+			const provider = new CombinedAutocompleteProvider([], "/tmp");
+			const line = "see @packages\\";
+			const result = provider.applyCompletion(
+				[line],
+				0,
+				line.length,
+				{ value: "@packages\\", label: "packages\\" },
+				"@packages\\",
+			);
+			expect(result.lines[0]).toBe("see @packages\\");
+			expect(result.cursorCol).toBe("see @packages\\".length);
+		});
+
+		it("adds a trailing space when completing a file with @", () => {
+			const provider = new CombinedAutocompleteProvider([], "/tmp");
+			const result = provider.applyCompletion(
+				["see @inde"],
+				0,
+				9,
+				{ value: "@index.ts", label: "index.ts" },
+				"@inde",
+			);
+
+			expect(result.lines[0]).toBe("see @index.ts ");
+			expect(result.cursorCol).toBe("see @index.ts ".length);
+		});
 	});
 
 	describe("hidden paths", () => {

--- a/packages/tui/test/editor-autocomplete-actions.test.ts
+++ b/packages/tui/test/editor-autocomplete-actions.test.ts
@@ -200,6 +200,29 @@ describe("Editor slash autocomplete acceptance", () => {
 			fs.rmSync(baseDir, { recursive: true, force: true });
 		}
 	});
+
+	it("keeps autocomplete open after accepting an @ directory with Tab", async () => {
+		const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), "editor-at-directory-tab-"));
+		try {
+			fs.mkdirSync(path.join(baseDir, "packages", "tui"), { recursive: true });
+			fs.mkdirSync(path.join(baseDir, "packages", "utils"), { recursive: true });
+			const editor = new Editor(defaultEditorTheme);
+			editor.setAutocompleteProvider(new CombinedAutocompleteProvider([], baseDir));
+			editor.setText("@pack");
+
+			const autocompleteOpened = untilAutocompleteShown(editor);
+			editor.handleInput("\t");
+			await autocompleteOpened;
+
+			editor.handleInput("\t");
+			await untilAutocompleteShown(editor);
+
+			expect(editor.getText()).toBe("@packages/");
+			expect(editor.isShowingAutocomplete()).toBe(true);
+		} finally {
+			fs.rmSync(baseDir, { recursive: true, force: true });
+		}
+	});
 	it("shows a sole forced file suggestion before applying it", async () => {
 		const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), "editor-single-file-tab-"));
 		try {


### PR DESCRIPTION
## Problem

When autocompleting file attachments with `@` (e.g. `@src/` or `@"my folder/`), `CombinedAutocompleteProvider.applyCompletion` automatically appends a trailing space after the completion value.

While a trailing space is convenient when completing a full file (`@file.ts `), for directory paths it interrupts incremental path navigation: accepting a directory completion inserts a space, requiring backspacing to continue completing child paths.

## Solution

Check whether the completion value represents a directory (`item.value` ending with a trailing slash or backslash). If so, omit the trailing space so autocomplete can seamlessly continue drilling down directory trees. File completions continue to append a trailing space as before.