### PR TITLE
fix(coding-agent): surface exhausted unexpected-stop retries

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Unexpected-stop recovery now surfaces an explicit terminal error when its retry cap is exhausted instead of ending the turn silently ([#10614](https://github.com/can1357/oh-my-pi/issues/10614)).
 - Provider errors in the transcript and the pinned error banner now wrap to the terminal width instead of being cut at a fixed column with no way to read the rest; long bodies keep a bounded number of rows and end with the `Ctrl+O to expand` hint.
 - Gemini `MALFORMED_FUNCTION_CALL` turns where the model wrote the call as text (`call:default_api:read{…}`) no longer stop on a pinned error: the session keeps the turn, tells the model the call was rejected, and continues (bounded to three attempts per prompt).
 - Auto-compaction recovery no longer loops indefinitely when a model repeatedly returns an empty `response.incomplete` (`length`) turn: the length-stop recovery path is now bounded and surfaces an actionable error after a few failed attempts instead of scheduling `shake-retry` forever and persisting hundreds of empty assistant turns ([#10594](https://github.com/can1357/oh-my-pi/issues/10594)).

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -3268,6 +3268,13 @@ export class AgentSession {
 				return;
 			}
 			if (unexpectedStopOutcome === "terminal") {
+				// agent-core finalizes `message_end` and `agent_end.messages` as
+				// separate objects. Propagate the synthetic cap failure into the
+				// public terminal event so RPC/ACP/notification consumers see it.
+				if (fallbackAssistant) {
+					fallbackAssistant.stopReason = msg.stopReason;
+					fallbackAssistant.errorMessage = msg.errorMessage;
+				}
 				// The retry cap already marked the turn as an error and emitted
 				// auto_retry_end. Skip the retry/fallback gates below so the
 				// advertised terminal cap never switches models or issues another

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -3261,72 +3261,81 @@ export class AgentSession {
 				}
 			}
 
-			if (await this.#recovery.handleUnexpectedAssistantStop(msg)) {
+			const unexpectedStopOutcome = await this.#recovery.handleUnexpectedAssistantStop(msg);
+			if (unexpectedStopOutcome === "continue") {
 				maintenanceRoute("unexpected-stop-handled");
 				await emitAgentEndNotification({ willContinue: true });
 				return;
 			}
+			if (unexpectedStopOutcome === "terminal") {
+				// The retry cap already marked the turn as an error and emitted
+				// auto_retry_end. Skip the retry/fallback gates below so the
+				// advertised terminal cap never switches models or issues another
+				// request on this replay-safe thinking-only stop, then settle through
+				// the standard error tail (session_stop hooks, agent_end).
+				maintenanceRoute("unexpected-stop-retry-cap");
+			} else {
+				const resolvedInterruptedToolTurn = this.#recovery.classifyResolvedInterruptedToolTurn(msg);
+				if (this.#recovery.isRetryableReasonlessAbort(msg) || resolvedInterruptedToolTurn === "reasonless-abort") {
+					const didRetry = await this.#recovery.handleRetryableError(
+						msg,
+						resolvedInterruptedToolTurn === "reasonless-abort"
+							? { allowModelFallback: false, preserveFailedTurn: true }
+							: { allowModelFallback: false },
+					);
+					if (didRetry) {
+						await emitAgentEndNotification({ willContinue: true });
+						return;
+					}
+				}
 
-			const resolvedInterruptedToolTurn = this.#recovery.classifyResolvedInterruptedToolTurn(msg);
-			if (this.#recovery.isRetryableReasonlessAbort(msg) || resolvedInterruptedToolTurn === "reasonless-abort") {
-				const didRetry = await this.#recovery.handleRetryableError(
-					msg,
-					resolvedInterruptedToolTurn === "reasonless-abort"
-						? { allowModelFallback: false, preserveFailedTurn: true }
-						: { allowModelFallback: false },
-				);
-				if (didRetry) {
-					await emitAgentEndNotification({ willContinue: true });
+				// A deliberate abort should settle the current turn, not trigger queued
+				// continuations — except TTSR self-repair, which already scheduled a
+				// hidden retry while #ttsrAbortPending is still true.
+				if (msg.stopReason === "aborted") {
+					this.#recovery.resolveRetry();
+					this.#resetSessionStopContinuationState();
+					await emitAgentEndNotification(ttsrAbortPendingAtAgentEnd ? { willContinue: true } : undefined);
 					return;
 				}
-			}
-
-			// A deliberate abort should settle the current turn, not trigger queued
-			// continuations — except TTSR self-repair, which already scheduled a
-			// hidden retry while #ttsrAbortPending is still true.
-			if (msg.stopReason === "aborted") {
-				this.#recovery.resolveRetry();
-				this.#resetSessionStopContinuationState();
-				await emitAgentEndNotification(ttsrAbortPendingAtAgentEnd ? { willContinue: true } : undefined);
-				return;
-			}
-			// Fireworks Fast variants degrade to their base model on a failed turn —
-			// including hard router errors the generic retry classifier rejects — so
-			// run this gate before the standard retryability check.
-			if (this.#recovery.isFireworksFastFallbackEligible(msg)) {
-				const didRetry = await this.#recovery.handleRetryableError(msg, { fireworksFastFallback: true });
-				if (didRetry) {
-					await emitAgentEndNotification({ willContinue: true });
-					return;
+				// Fireworks Fast variants degrade to their base model on a failed turn —
+				// including hard router errors the generic retry classifier rejects — so
+				// run this gate before the standard retryability check.
+				if (this.#recovery.isFireworksFastFallbackEligible(msg)) {
+					const didRetry = await this.#recovery.handleRetryableError(msg, { fireworksFastFallback: true });
+					if (didRetry) {
+						await emitAgentEndNotification({ willContinue: true });
+						return;
+					}
 				}
-			}
-			const resumeResolvedStreamStall = resolvedInterruptedToolTurn === "stream-stall";
-			if (resumeResolvedStreamStall || this.#recovery.isRetryableError(msg)) {
-				const didRetry = await this.#recovery.handleRetryableError(
-					msg,
-					resumeResolvedStreamStall ? { preserveFailedTurn: true } : undefined,
-				);
-				if (didRetry) {
+				const resumeResolvedStreamStall = resolvedInterruptedToolTurn === "stream-stall";
+				if (resumeResolvedStreamStall || this.#recovery.isRetryableError(msg)) {
+					const didRetry = await this.#recovery.handleRetryableError(
+						msg,
+						resumeResolvedStreamStall ? { preserveFailedTurn: true } : undefined,
+					);
+					if (didRetry) {
+						await emitAgentEndNotification({ willContinue: true });
+						return;
+					}
+				} else if (this.#recovery.handleMalformedFunctionCallStop(msg)) {
+					// A malformed call with committed text cannot be replayed, but it
+					// never executed anything either: keep the turn and continue with a
+					// corrective reminder rather than stopping on a pinned error.
+					maintenanceRoute("malformed-function-call-handled");
 					await emitAgentEndNotification({ willContinue: true });
 					return;
-				}
-			} else if (this.#recovery.handleMalformedFunctionCallStop(msg)) {
-				// A malformed call with committed text cannot be replayed, but it
-				// never executed anything either: keep the turn and continue with a
-				// corrective reminder rather than stopping on a pinned error.
-				maintenanceRoute("malformed-function-call-handled");
-				await emitAgentEndNotification({ willContinue: true });
-				return;
-			} else if (this.#recovery.isHardErrorFallbackEligible(msg)) {
-				// A non-retryable hard error on a model covered by a configured
-				// fallback chain: retrying the SAME model is pointless, but a
-				// DIFFERENT model is a fresh chance — consult the chain before
-				// surfacing the failure. #handleRetryableError bails out (no
-				// backoff-retry of the failing model) when no switch happens.
-				const didRetry = await this.#recovery.handleRetryableError(msg, { hardErrorFallback: true });
-				if (didRetry) {
-					await emitAgentEndNotification({ willContinue: true });
-					return;
+				} else if (this.#recovery.isHardErrorFallbackEligible(msg)) {
+					// A non-retryable hard error on a model covered by a configured
+					// fallback chain: retrying the SAME model is pointless, but a
+					// DIFFERENT model is a fresh chance — consult the chain before
+					// surfacing the failure. #handleRetryableError bails out (no
+					// backoff-retry of the failing model) when no switch happens.
+					const didRetry = await this.#recovery.handleRetryableError(msg, { hardErrorFallback: true });
+					if (didRetry) {
+						await emitAgentEndNotification({ willContinue: true });
+						return;
+					}
 				}
 			}
 			// Classifier refusals are persisted-skipped above; also prune the trailing

--- a/packages/coding-agent/src/session/turn-recovery.ts
+++ b/packages/coding-agent/src/session/turn-recovery.ts
@@ -933,11 +933,22 @@ export class TurnRecovery {
 
 		this.#unexpectedStopRetryCount++;
 		if (this.#unexpectedStopRetryCount > UNEXPECTED_STOP_MAX_RETRIES) {
-			logger.warn("Assistant returned unexpected stop after retry cap", {
-				attempts: this.#unexpectedStopRetryCount - 1,
+			const attempts = this.#unexpectedStopRetryCount - 1;
+			const finalError = `Assistant stopped unexpectedly after ${attempts} recovery retries; try compacting context or switching models`;
+			assistantMessage.stopReason = "error";
+			assistantMessage.errorMessage = finalError;
+			logger.warn(finalError, {
+				attempts,
 				model: assistantMessage.model,
 				provider: assistantMessage.provider,
 			});
+			await this.#host.emitSessionEvent({
+				type: "auto_retry_end",
+				success: false,
+				attempt: attempts,
+				finalError,
+			});
+			await this.#host.sessionManager.rewriteEntries();
 			this.#unexpectedStopRetryCount = 0;
 			return false;
 		}

--- a/packages/coding-agent/src/session/turn-recovery.ts
+++ b/packages/coding-agent/src/session/turn-recovery.ts
@@ -479,7 +479,7 @@ export class TurnRecovery {
 	}
 
 	/** Classifies suspicious terminal stops and schedules bounded recovery. */
-	handleUnexpectedAssistantStop(message: AssistantMessage): Promise<boolean> {
+	handleUnexpectedAssistantStop(message: AssistantMessage): Promise<"continue" | "terminal" | undefined> {
 		return this.#handleUnexpectedAssistantStop(message);
 	}
 
@@ -878,14 +878,16 @@ export class TurnRecovery {
 			maxRetries: EMPTY_STOP_MAX_RETRIES,
 		});
 	}
-	async #handleUnexpectedAssistantStop(assistantMessage: AssistantMessage): Promise<boolean> {
+	async #handleUnexpectedAssistantStop(
+		assistantMessage: AssistantMessage,
+	): Promise<"continue" | "terminal" | undefined> {
 		const mode = this.#host.settings.get("features.unexpectedStopDetection");
 		if (mode === "none") {
-			return false;
+			return undefined;
 		}
 		if (!isUnexpectedStopCandidate(assistantMessage)) {
 			this.#unexpectedStopRetryCount = 0;
-			return false;
+			return undefined;
 		}
 
 		let text = assistantMessage.content
@@ -904,11 +906,11 @@ export class TurnRecovery {
 				.join("\n");
 			if (!hasNonWhitespace(text)) {
 				this.#unexpectedStopRetryCount = 0;
-				return false;
+				return undefined;
 			}
 		} else if (mode === "mechanical") {
 			this.#unexpectedStopRetryCount = 0;
-			return false;
+			return undefined;
 		} else {
 			const controller = new AbortController();
 			const timeout = setTimeout(() => controller.abort(), UNEXPECTED_STOP_TIMEOUT_MS);
@@ -927,7 +929,7 @@ export class TurnRecovery {
 
 			if (classification !== true) {
 				this.#unexpectedStopRetryCount = 0;
-				return false;
+				return undefined;
 			}
 		}
 
@@ -935,6 +937,12 @@ export class TurnRecovery {
 		if (this.#unexpectedStopRetryCount > UNEXPECTED_STOP_MAX_RETRIES) {
 			const attempts = this.#unexpectedStopRetryCount - 1;
 			const finalError = `Assistant stopped unexpectedly after ${attempts} recovery retries; try compacting context or switching models`;
+			// Mark the turn as a terminal error so every settle surface (TUI error
+			// row, headless stderr, session_stop hooks) treats it as a failure. The
+			// caller MUST short-circuit the retry/fallback gates on the "terminal"
+			// outcome: thinking-only output is replay-safe, so leaving this synthetic
+			// error to fall through would let the hard-error / Fireworks-fast fallback
+			// gates issue another model request past the advertised retry cap.
 			assistantMessage.stopReason = "error";
 			assistantMessage.errorMessage = finalError;
 			logger.warn(finalError, {
@@ -950,7 +958,7 @@ export class TurnRecovery {
 			});
 			await this.#host.sessionManager.rewriteEntries();
 			this.#unexpectedStopRetryCount = 0;
-			return false;
+			return "terminal";
 		}
 
 		this.#host.agent.appendMessage({
@@ -963,7 +971,7 @@ export class TurnRecovery {
 			source: "unexpected-stop-retry",
 			generation: this.#host.promptGeneration(),
 		});
-		return true;
+		return "continue";
 	}
 
 	#unexpectedStopRetryReminder(): string {

--- a/packages/coding-agent/test/agent-session-unexpected-stop-guard.test.ts
+++ b/packages/coding-agent/test/agent-session-unexpected-stop-guard.test.ts
@@ -5,7 +5,7 @@ import { createMockModel, type MockModel, type MockResponse } from "@oh-my-pi/pi
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { type SettingPath, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
-import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AgentSession, type AgentSessionEvent } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { convertToLlm } from "@oh-my-pi/pi-coding-agent/session/messages";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import * as unexpectedStopClassifier from "@oh-my-pi/pi-coding-agent/session/unexpected-stop-classifier";
@@ -269,21 +269,25 @@ describe("AgentSession unexpected stop guard", () => {
 		expect(reminderMessages(session.agent.state.messages)).toHaveLength(0);
 	});
 
-	it("caps unexpected stop retries at three attempts", async () => {
+	it("surfaces an error when unexpected stop recovery exhausts three retries", async () => {
 		const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
 		const spy = vi.spyOn(unexpectedStopClassifier, "classifyUnexpectedStop").mockResolvedValue(true);
 		const { session, mock } = await createHarness(
 			[
-				unexpectedStop("I should fix this next."),
-				unexpectedStop("I should fix this next."),
-				unexpectedStop("I should fix this next."),
-				unexpectedStop("I should fix this next."),
+				unexpectedStop("I should inspect the first failing branch."),
+				unexpectedStop("Next I should compare the terminal event path."),
+				unexpectedStop("Then I should verify print mode behavior."),
+				unexpectedStop("Finally I should report the completed fix."),
 			],
 			{
 				"features.unexpectedStopDetection": "smart",
 				"providers.unexpectedStopModel": "online",
 			},
 		);
+		let retryEnd: Extract<AgentSessionEvent, { type: "auto_retry_end" }> | undefined;
+		session.subscribe(event => {
+			if (event.type === "auto_retry_end") retryEnd = event;
+		});
 
 		await session.prompt("do the thing");
 		await session.waitForIdle();
@@ -292,6 +296,16 @@ describe("AgentSession unexpected stop guard", () => {
 		expect(mock.calls).toHaveLength(4);
 		expect(reminderMessages(session.agent.state.messages)).toHaveLength(3);
 		expect(warnSpy).toHaveBeenCalled();
+		expect(session.getLastAssistantMessage()).toMatchObject({
+			stopReason: "error",
+			errorMessage: expect.stringContaining("stopped unexpectedly after 3 recovery retries"),
+		});
+		expect(retryEnd).toMatchObject({
+			type: "auto_retry_end",
+			success: false,
+			attempt: 3,
+			finalError: expect.stringContaining("stopped unexpectedly after 3 recovery retries"),
+		});
 	});
 
 	it("does not classify a message that contains a tool call", async () => {

--- a/packages/coding-agent/test/agent-session-unexpected-stop-guard.test.ts
+++ b/packages/coding-agent/test/agent-session-unexpected-stop-guard.test.ts
@@ -285,8 +285,10 @@ describe("AgentSession unexpected stop guard", () => {
 			},
 		);
 		let retryEnd: Extract<AgentSessionEvent, { type: "auto_retry_end" }> | undefined;
+		let terminalAgentEnd: Extract<AgentSessionEvent, { type: "agent_end" }> | undefined;
 		session.subscribe(event => {
 			if (event.type === "auto_retry_end") retryEnd = event;
+			if (event.type === "agent_end" && event.isTerminal) terminalAgentEnd = event;
 		});
 
 		await session.prompt("do the thing");
@@ -297,6 +299,10 @@ describe("AgentSession unexpected stop guard", () => {
 		expect(reminderMessages(session.agent.state.messages)).toHaveLength(3);
 		expect(warnSpy).toHaveBeenCalled();
 		expect(session.getLastAssistantMessage()).toMatchObject({
+			stopReason: "error",
+			errorMessage: expect.stringContaining("stopped unexpectedly after 3 recovery retries"),
+		});
+		expect(terminalAgentEnd?.messages.findLast(message => message.role === "assistant")).toMatchObject({
 			stopReason: "error",
 			errorMessage: expect.stringContaining("stopped unexpectedly after 3 recovery retries"),
 		});


### PR DESCRIPTION
## Repro
A four-response mock session reproduces the cap with `bun test packages/coding-agent/test/agent-session-unexpected-stop-guard.test.ts -t "surfaces an error when unexpected stop recovery exhausts three retries"`: before the fix, recovery issued three reminders and logged the cap, but the terminal message remained `stopReason: "stop"` with no `errorMessage` or `auto_retry_end` failure.

## Cause
`TurnRecovery.#handleUnexpectedAssistantStop` in `packages/coding-agent/src/session/turn-recovery.ts` reset `#unexpectedStopRetryCount` and returned `false` after logging the exhausted cap. That left the terminal assistant message success-shaped, so the agent-end, notification, persistence, and print-mode paths had no failure state to surface.

## Fix
- Mark the capped assistant turn as an error with an actionable retry-exhaustion message.
- Emit the failed `auto_retry_end` event and rewrite the mutated session entry.
- Replace the warning-only cap test with assertions for the terminal message and retry event; document the user-visible fix.

## Verification
`bun test packages/coding-agent/test/agent-session-unexpected-stop-guard.test.ts` passes: 10 tests, 36 assertions. The pre-publish `bun run fix` and `bun check` gate passed.

Fixes #10614