### PR TITLE
fix(catalog): honor Copilot base context limits

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Fixed
 
+- GitHub Copilot base model variants now use the provider's default prompt budget instead of inheriting the 1M context tier ([#10616](https://github.com/can1357/oh-my-pi/issues/10616)).
 - GitHub Copilot discovery now uses the Copilot CLI identity so account-eligible enterprise and experimental models are returned
 - Discovered Bedrock-style `mistral.mixtral-*` models no longer abort startup with an ambiguous family classification ([#10598](https://github.com/can1357/oh-my-pi/issues/10598)).
 

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -6136,7 +6136,18 @@ export function githubCopilotModelManagerOptions(config?: GithubCopilotModelMana
 						// prompt tokens. Cap the base entry to the default tier — the long
 						// tier is the opt-in `-1m` sibling below.
 						const tokenPrices = extractCopilotTokenPrices(entry);
-						const defaultContextMax = tokenPrices.defaultTier?.contextMax;
+						let defaultContextMax = tokenPrices.defaultTier?.contextMax;
+						// Tiered rows use max_prompt_tokens as the base lane's prompt
+						// ceiling. Keep the tighter signal when billing.default overlaps
+						// the long-context lane, or both selectable rows become 1M.
+						if (
+							tokenPrices.longContext?.contextMax !== undefined &&
+							copilotLimits.maxPromptTokens !== undefined &&
+							copilotLimits.maxPromptTokens > 0 &&
+							(defaultContextMax === undefined || copilotLimits.maxPromptTokens < defaultContextMax)
+						) {
+							defaultContextMax = copilotLimits.maxPromptTokens;
+						}
 						const defaultTierWindow =
 							defaultContextMax !== undefined &&
 							defaultContextMax > 0 &&

--- a/packages/catalog/test/github-copilot-model-limits.test.ts
+++ b/packages/catalog/test/github-copilot-model-limits.test.ts
@@ -501,6 +501,7 @@ function tieredCopilotEntry(overrides: {
 	window: number;
 	maxOutput: number;
 	defaultContextMax?: number;
+	maxPrompt?: number;
 	longContextMax?: number;
 	defaultPrices?: { input: number; output: number; cache: number };
 	longPrices?: { input: number; output: number; cache: number };
@@ -514,6 +515,7 @@ function tieredCopilotEntry(overrides: {
 			type: overrides.type ?? "chat",
 			limits: {
 				max_context_window_tokens: overrides.window,
+				...(overrides.maxPrompt !== undefined && { max_prompt_tokens: overrides.maxPrompt }),
 				max_output_tokens: overrides.maxOutput,
 			},
 			...(overrides.vision !== undefined && { supports: { vision: overrides.vision } }),
@@ -602,6 +604,27 @@ describe("github copilot tiered context windows", () => {
 		expect(variant?.contextWindow).toBe(1_000_000);
 		expect(variant?.maxTokens).toBe(64_000);
 		expect(variant?.contextPromotionTarget).toBeUndefined();
+	});
+
+	it("uses the base prompt budget when billing's default ceiling overlaps the 1M lane", async () => {
+		const { models } = await discoverCopilotModels({
+			data: [
+				tieredCopilotEntry({
+					id: "gpt-5.6-luna",
+					name: "GPT-5.6 Luna",
+					window: 1_050_000,
+					maxPrompt: 272_000,
+					maxOutput: 56_000,
+					defaultContextMax: 950_000,
+					longContextMax: 994_000,
+				}),
+			],
+		});
+
+		const base = models.find(candidate => candidate.id === "gpt-5.6-luna");
+		expect(base?.contextWindow).toBe(328_000);
+		const variant = models.find(candidate => candidate.id === "gpt-5.6-luna-1m");
+		expect(variant?.contextWindow).toBe(1_050_000);
 	});
 
 	it("prices the long-context variant from its own tier", async () => {


### PR DESCRIPTION
## Repro
A Copilot `/models` fixture with `max_context_window_tokens=1050000`, `max_prompt_tokens=272000`, `max_output_tokens=56000`, and overlapping default/long-context billing ceilings made `githubCopilotModelManagerOptions` resolve `gpt-5.6-luna` at 1,006,000 tokens and `gpt-5.6-luna-1m` at 1,050,000. Reproduced with `bun -e '<invoke githubCopilotModelManagerOptions with the tiered fixture>'`.

## Cause
`packages/catalog/src/provider-models/openai-compat.ts` derived the base row's `defaultTierWindow` exclusively from `billing.token_prices.default.context_max`. When that billing ceiling overlaps the long-context lane, it ignored the tighter `capabilities.limits.max_prompt_tokens` default-lane budget and made both selectable rows effectively 1M.

## Fix
- Use the tighter reported prompt ceiling for tiered Copilot base rows while leaving legacy non-tiered rows unchanged.
- Add a regression fixture proving a 272K prompt budget plus 56K output resolves the base row to 328K and preserves the 1.05M sibling.
- Document the corrected user-visible behavior in the catalog changelog.

## Verification
`bun test packages/catalog/test/github-copilot-model-limits.test.ts` passed: 36 tests, 270 assertions. Re-running the reproduction resolved the base row to 328,000 and the `-1m` row to 1,050,000. The publish gate also completed `bun run fix` and `bun check`.

Fixes #10616