### PR TITLE
fix(ai): Retry vanished provider locks

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -66,6 +66,8 @@
 - Fixed Z.AI (GLM Coding Plan) browser sign-in by using the registered CLI callback address.
 - Fixed OpenAI Codex/Responses tool results being lost when composite call identifiers could not be paired with the corresponding assistant call.
 - Fixed native OpenAI Responses history replay becoming stuck on malformed or truncated function-call arguments; invalid history items are now discarded so the session can recover.
+- Fixed provider requests failing with `ENOENT` when another process removes a stale shared concurrency lock during acquisition.
+- Fixed Z.AI (GLM Coding Plan) browser sign-in being rejected with "Redirect URI not registered for this client": the flow now advertises the ZCode-registered CLI callback `http://127.0.0.1:9999/callback` instead of the unregistered `localhost:54548` ([#10245](https://github.com/can1357/oh-my-pi/issues/10245)).
 
 ## [18.0.11] - 2026-08-29
 

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -201,6 +201,7 @@ let providerInFlightHeartbeatWriterOverride:
 let providerInFlightLeaseRemoverOverride: ((leasePath: string) => Promise<void>) | undefined;
 let providerInFlightWaitObserverOverride: ((provider: string) => void) | undefined;
 let providerInFlightLockCreatedObserverOverride: ((lockDir: string) => Promise<void>) | undefined;
+let providerInFlightLockIdentifiedObserverOverride: ((lockDir: string) => Promise<void>) | undefined;
 
 export function configureProviderMaxInFlightRequests(limits: Record<string, number> | undefined): void {
 	configuredProviderMaxInFlightRequests = limits ?? {};
@@ -383,9 +384,11 @@ async function acquireProviderInFlightLock(provider: string, signal?: AbortSigna
 			}
 			const token = crypto.randomUUID();
 			try {
+				await providerInFlightLockIdentifiedObserverOverride?.(lockDir);
 				await writeProviderInFlightInfo(lockDir, token);
 			} catch (error) {
 				await releaseProviderInFlightLockDirIfSame(lockDir, lockIdentity);
+				if (isEnoent(error)) continue;
 				throw error;
 			}
 			return async () => {
@@ -640,6 +643,9 @@ export const __providerInFlightForTesting = {
 	},
 	setLockCreatedObserver(observer: ((lockDir: string) => Promise<void>) | undefined): void {
 		providerInFlightLockCreatedObserverOverride = observer;
+	},
+	setLockIdentifiedObserver(observer: ((lockDir: string) => Promise<void>) | undefined): void {
+		providerInFlightLockIdentifiedObserverOverride = observer;
 	},
 	providerDir(provider: string): string {
 		return providerInFlightDir(provider);

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -200,6 +200,7 @@ let providerInFlightHeartbeatWriterOverride:
 	| undefined;
 let providerInFlightLeaseRemoverOverride: ((leasePath: string) => Promise<void>) | undefined;
 let providerInFlightWaitObserverOverride: ((provider: string) => void) | undefined;
+let providerInFlightLockCreatedObserverOverride: ((lockDir: string) => Promise<void>) | undefined;
 
 export function configureProviderMaxInFlightRequests(limits: Record<string, number> | undefined): void {
 	configuredProviderMaxInFlightRequests = limits ?? {};
@@ -372,7 +373,14 @@ async function acquireProviderInFlightLock(provider: string, signal?: AbortSigna
 		if (signal?.aborted) throw signal.reason ?? new AIError.AbortError("Provider request aborted before dispatch");
 		try {
 			await fs.mkdir(lockDir);
-			const lockIdentity = await readProviderInFlightLockIdentity(lockDir);
+			await providerInFlightLockCreatedObserverOverride?.(lockDir);
+			let lockIdentity: ProviderInFlightLockIdentity;
+			try {
+				lockIdentity = await readProviderInFlightLockIdentity(lockDir);
+			} catch (error) {
+				if (isEnoent(error)) continue;
+				throw error;
+			}
 			const token = crypto.randomUUID();
 			try {
 				await writeProviderInFlightInfo(lockDir, token);
@@ -629,6 +637,9 @@ export const __providerInFlightForTesting = {
 	},
 	setWaitObserver(observer: ((provider: string) => void) | undefined): void {
 		providerInFlightWaitObserverOverride = observer;
+	},
+	setLockCreatedObserver(observer: ((lockDir: string) => Promise<void>) | undefined): void {
+		providerInFlightLockCreatedObserverOverride = observer;
 	},
 	providerDir(provider: string): string {
 		return providerInFlightDir(provider);

--- a/packages/ai/test/provider-inflight.test.ts
+++ b/packages/ai/test/provider-inflight.test.ts
@@ -29,6 +29,7 @@ afterEach(async () => {
 	__providerInFlightForTesting.setLeaseRemover(undefined);
 	__providerInFlightForTesting.setWaitObserver(undefined);
 	__providerInFlightForTesting.setLockCreatedObserver(undefined);
+	__providerInFlightForTesting.setLockIdentifiedObserver(undefined);
 	if (limiterRoot !== undefined) {
 		await fs.rm(limiterRoot, { recursive: true, force: true });
 		limiterRoot = undefined;
@@ -495,6 +496,20 @@ describe("provider in-flight request limits", () => {
 		__providerInFlightForTesting.setLockCreatedObserver(async lockDir => {
 			await fs.rm(lockDir, { recursive: true, force: true });
 			__providerInFlightForTesting.setLockCreatedObserver(undefined);
+		});
+
+		const result = await streamSimple(mock.model, context(), { maxInFlightRequests: { tests: 1 } }).result();
+
+		expect(result.content).toEqual([{ type: "text", text: "reply" }]);
+		expect(mock.calls).toHaveLength(1);
+	});
+
+	test("retries when another process removes an identified lock before its info write", async () => {
+		registerMockApi();
+		const mock = createMockModel({ provider: "tests", responses: [{ content: ["reply"] }] });
+		__providerInFlightForTesting.setLockIdentifiedObserver(async lockDir => {
+			await fs.rm(lockDir, { recursive: true, force: true });
+			__providerInFlightForTesting.setLockIdentifiedObserver(undefined);
 		});
 
 		const result = await streamSimple(mock.model, context(), { maxInFlightRequests: { tests: 1 } }).result();

--- a/packages/ai/test/provider-inflight.test.ts
+++ b/packages/ai/test/provider-inflight.test.ts
@@ -28,6 +28,7 @@ afterEach(async () => {
 	__providerInFlightForTesting.setHeartbeatWriter(undefined);
 	__providerInFlightForTesting.setLeaseRemover(undefined);
 	__providerInFlightForTesting.setWaitObserver(undefined);
+	__providerInFlightForTesting.setLockCreatedObserver(undefined);
 	if (limiterRoot !== undefined) {
 		await fs.rm(limiterRoot, { recursive: true, force: true });
 		limiterRoot = undefined;
@@ -486,6 +487,20 @@ describe("provider in-flight request limits", () => {
 
 		const remaining = JSON.parse(await Bun.file(path.join(lockDir, "info.json")).text()) as { token: string };
 		expect(remaining.token).toBe("fresh-lock");
+	});
+
+	test("retries when another process removes a newly created lock", async () => {
+		registerMockApi();
+		const mock = createMockModel({ provider: "tests", responses: [{ content: ["reply"] }] });
+		__providerInFlightForTesting.setLockCreatedObserver(async lockDir => {
+			await fs.rm(lockDir, { recursive: true, force: true });
+			__providerInFlightForTesting.setLockCreatedObserver(undefined);
+		});
+
+		const result = await streamSimple(mock.model, context(), { maxInFlightRequests: { tests: 1 } }).result();
+
+		expect(result.content).toEqual([{ type: "text", text: "reply" }]);
+		expect(mock.calls).toHaveLength(1);
 	});
 
 	test("does not dispatch when aborted immediately after slot acquisition", async () => {


### PR DESCRIPTION
## What

- Retry provider lock acquisition when another process removes the newly created lock directory.
- Add a deterministic regression for the cross-process lock deletion race.
- Document the user-visible provider failure fix.

## Why

A process can pause after creating the shared provider lock but before writing its ownership metadata. Another process can then classify the empty lock as stale and remove it. The first process currently resumes with an `ENOENT` from `stat()` and fails the provider request.

## Testing

- `bun test packages/ai/test/provider-inflight.test.ts`
- `bun check` in `packages/ai`
- `git diff --check`

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)