### PR TITLE
fix(session): honor no-title during replan refresh

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- `--no-title` now also disables todo-init title refreshes; when automatic titles are enabled, their provider session identity is isolated from the foreground request ([#10619](https://github.com/can1357/oh-my-pi/issues/10619)).
 - Provider errors in the transcript and the pinned error banner now wrap to the terminal width instead of being cut at a fixed column with no way to read the rest; long bodies keep a bounded number of rows and end with the `Ctrl+O to expand` hint.
 - Gemini `MALFORMED_FUNCTION_CALL` turns where the model wrote the call as text (`call:default_api:read{…}`) no longer stop on a pinned error: the session keeps the turn, tells the model the call was rejected, and continues (bounded to three attempts per prompt).
 - Auto-compaction recovery no longer loops indefinitely when a model repeatedly returns an empty `response.incomplete` (`length`) turn: the length-stop recovery path is now bounded and surfaces an actionable error after a few failed attempts instead of scheduling `shake-retry` forever and persisting hundreds of empty assistant turns ([#10594](https://github.com/can1357/oh-my-pi/issues/10594)).

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Fixed
 
-- `--no-title` now also disables todo-init title refreshes; when automatic titles are enabled, their provider session identity is isolated from the foreground request ([#10619](https://github.com/can1357/oh-my-pi/issues/10619)).
+- `--no-title` now also disables todo-init title refreshes; when automatic titles are enabled, their provider session identity is isolated from the foreground request while retaining its selected OAuth account ([#10619](https://github.com/can1357/oh-my-pi/issues/10619)).
 - Provider errors in the transcript and the pinned error banner now wrap to the terminal width instead of being cut at a fixed column with no way to read the rest; long bodies keep a bounded number of rows and end with the `Ctrl+O to expand` hint.
 - Gemini `MALFORMED_FUNCTION_CALL` turns where the model wrote the call as text (`call:default_api:read{…}`) no longer stop on a pinned error: the session keeps the turn, tells the model the call was rejected, and continues (bounded to three attempts per prompt).
 - Auto-compaction recovery no longer loops indefinitely when a model repeatedly returns an empty `response.incomplete` (`length`) turn: the length-stop recovery path is now bounded and surfaces an actionable error after a few failed attempts instead of scheduling `shake-retry` forever and persisting hundreds of empty assistant turns ([#10594](https://github.com/can1357/oh-my-pi/issues/10594)).

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -7170,8 +7170,7 @@ export class AgentSession {
 			});
 	}
 
-	#resolveTitleProviderSessionId(): string {
-		const parentSessionId = this.sessionId;
+	#resolveTitleProviderSessionId(parentSessionId: string): string {
 		if (this.#titleProviderParentSessionId === parentSessionId && this.#titleProviderSessionId) {
 			return this.#titleProviderSessionId;
 		}
@@ -7191,7 +7190,8 @@ export class AgentSession {
 	 * (e.g. plan-save filename topics) without touching the session override.
 	 */
 	generateTitle(firstMessage: string, customSystemPrompt?: string): Promise<string | null> {
-		const sessionId = this.#resolveTitleProviderSessionId();
+		const parentSessionId = this.sessionId;
+		const sessionId = this.#resolveTitleProviderSessionId(parentSessionId);
 		return generateSessionTitle(
 			firstMessage,
 			this.#modelRegistry,
@@ -7201,6 +7201,7 @@ export class AgentSession {
 			provider => buildSessionMetadata(sessionId, provider, this.#modelRegistry.authStorage),
 			customSystemPrompt ?? this.#titleSystemPrompt,
 			this.#titleGenerationAbortController.signal,
+			parentSessionId,
 		);
 	}
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -610,6 +610,8 @@ export class AgentSession {
 	#titleSystemPrompt: string | undefined;
 	#titleGenerationStart: (() => void) | undefined;
 	#titleGenerationInFlightFor: string | undefined;
+	#titleProviderSessionId: string | undefined;
+	#titleProviderParentSessionId: string | undefined;
 	/** Host hook invoked when a typed user prompt is dropped before dispatch;
 	 *  see {@link setPromptDropped}. */
 	#promptDropped: ((prompt: DroppedPrompt) => void) | undefined;
@@ -7083,6 +7085,7 @@ export class AgentSession {
 	}
 
 	#scheduleReplanTitleRefresh(): void {
+		if ($env.PI_NO_TITLE) return;
 		// Headless subagent sessions have no operator-visible title, so a todo-init
 		// replan refresh only burns a tiny-model call whose result lands in JSONL
 		// and is never shown (issue #5910). In an interactive host the operator can
@@ -7167,21 +7170,35 @@ export class AgentSession {
 			});
 	}
 
+	#resolveTitleProviderSessionId(): string {
+		const parentSessionId = this.sessionId;
+		if (this.#titleProviderParentSessionId === parentSessionId && this.#titleProviderSessionId) {
+			return this.#titleProviderSessionId;
+		}
+		const titleSessionId = Bun.randomUUIDv7();
+		this.#titleProviderParentSessionId = parentSessionId;
+		this.#titleProviderSessionId = titleSessionId;
+		return titleSessionId;
+	}
+
 	/**
 	 * Generate an automatic session title tied to this session's lifecycle.
 	 * Input and replan callers share the signal so disposal cancels provider and
 	 * local-worker requests instead of leaving background inference alive.
+	 * Online calls use a stable side-request identity so they cannot advance the
+	 * foreground provider session while its request is waiting.
 	 * `customSystemPrompt` swaps the title prompt for special-purpose titling
 	 * (e.g. plan-save filename topics) without touching the session override.
 	 */
 	generateTitle(firstMessage: string, customSystemPrompt?: string): Promise<string | null> {
+		const sessionId = this.#resolveTitleProviderSessionId();
 		return generateSessionTitle(
 			firstMessage,
 			this.#modelRegistry,
 			this.settings,
-			this.sessionId,
+			sessionId,
 			this.model,
-			provider => this.agent.metadataForProvider(provider),
+			provider => buildSessionMetadata(sessionId, provider, this.#modelRegistry.authStorage),
 			customSystemPrompt ?? this.#titleSystemPrompt,
 			this.#titleGenerationAbortController.signal,
 		);

--- a/packages/coding-agent/src/utils/title-generator.ts
+++ b/packages/coding-agent/src/utils/title-generator.ts
@@ -136,6 +136,8 @@ function getTitleModel(registry: ModelRegistry, settings: Settings, currentModel
  *   reflects the credential actually selected for this request.
  * @param customSystemPrompt Optional title-specific system prompt override
  * @param signal Session-lifecycle cancellation for background title requests
+ * @param credentialSourceSessionId Optional foreground session whose selected
+ *   OAuth credential should seed an isolated title-request session.
  */
 export async function generateSessionTitle(
 	firstMessage: string,
@@ -146,6 +148,7 @@ export async function generateSessionTitle(
 	metadataResolver?: (provider: string) => Record<string, unknown> | undefined,
 	customSystemPrompt?: string,
 	signal?: AbortSignal,
+	credentialSourceSessionId?: string,
 ): Promise<string | null> {
 	// Defer titling for greetings / acknowledgements / empty input. The default
 	// tiny title model can't reliably decline trivial input, so this happens
@@ -168,6 +171,7 @@ export async function generateSessionTitle(
 			metadataResolver,
 			signal,
 			titleSystemPrompt,
+			credentialSourceSessionId,
 		);
 	}
 
@@ -226,6 +230,7 @@ export async function generateTitleOnline(
 	metadataResolver?: (provider: string) => Record<string, unknown> | undefined,
 	signal?: AbortSignal,
 	customSystemPrompt?: string,
+	credentialSourceSessionId?: string,
 ): Promise<string | null> {
 	const model = getTitleModel(registry, settings, currentModel);
 	if (!model) {
@@ -251,6 +256,14 @@ export async function generateTitleOnline(
 	logger.debug("title-generator: start", modelContext);
 
 	try {
+		if (credentialSourceSessionId && sessionId && credentialSourceSessionId !== sessionId) {
+			const foregroundCredential = registry.authStorage
+				.listOAuthAccounts(model.provider, credentialSourceSessionId)
+				.find(account => account.active);
+			if (foregroundCredential) {
+				registry.authStorage.pinSessionOAuthAccount(model.provider, sessionId, foregroundCredential.credentialId);
+			}
+		}
 		const apiKey = await registry.getApiKey(model, sessionId);
 		if (!apiKey) {
 			logger.warn("title-generator: no API key", { ...modelContext, reason: "missing-api-key" });

--- a/packages/coding-agent/test/agent-session-eager-todo.test.ts
+++ b/packages/coding-agent/test/agent-session-eager-todo.test.ts
@@ -102,6 +102,7 @@ describe("AgentSession eager todo enforcement", () => {
 	let sharedDir: TempDir;
 	let sharedAuthStorage: AuthStorage;
 	let sharedModelRegistry: ModelRegistry;
+	let previousNoTitle: string | undefined;
 	const observedCalls: ObservedPromptCall[] = [];
 
 	async function createSession(
@@ -226,6 +227,8 @@ describe("AgentSession eager todo enforcement", () => {
 	});
 
 	beforeEach(async () => {
+		previousNoTitle = Bun.env.PI_NO_TITLE;
+		delete Bun.env.PI_NO_TITLE;
 		tempDir = TempDir.createSync("@pi-agent-session-eager-todo-");
 		streamCallCount = 0;
 		scriptedResponses = [];
@@ -238,6 +241,8 @@ describe("AgentSession eager todo enforcement", () => {
 			await session.dispose();
 		}
 		vi.restoreAllMocks();
+		if (previousNoTitle === undefined) delete Bun.env.PI_NO_TITLE;
+		else Bun.env.PI_NO_TITLE = previousNoTitle;
 		tempDir.removeSync();
 	});
 
@@ -326,6 +331,15 @@ describe("AgentSession eager todo enforcement", () => {
 		expect(titleInput).toContain("I found the parser recovery path.");
 		expect(titleInput).toContain("The recovery heuristic should drive the replan title.");
 		expect(titleInput).toContain("replan parser diagnostics");
+		const metadata = completeSimpleMock.mock.calls[0]?.[2]?.metadata;
+		if (!metadata || typeof metadata.user_id !== "string") {
+			throw new Error("Expected title request metadata.user_id");
+		}
+		const userId: unknown = JSON.parse(metadata.user_id);
+		if (!userId || typeof userId !== "object" || !("session_id" in userId) || typeof userId.session_id !== "string") {
+			throw new Error("Expected title request metadata.user_id.session_id");
+		}
+		expect(userId.session_id).not.toBe(session.sessionId);
 	});
 
 	it("forwards the configured title system prompt to the replan refresh path", async () => {
@@ -452,6 +466,25 @@ describe("AgentSession eager todo enforcement", () => {
 	it("does not refresh todo-init titles when title refresh on replan is disabled", async () => {
 		const completeSimpleMock = vi.spyOn(ai, "completeSimple");
 		await session.setSessionName("Old auto title", "auto");
+		scriptedResponses = [
+			createToolCallAssistantMessage("todo", {
+				op: "init",
+				list: [{ phase: "Parser", items: ["Replan parser diagnostics"] }],
+			}),
+			createAssistantMessage("todo initialized"),
+		];
+
+		await session.prompt("replan parser diagnostics");
+
+		expect(completeSimpleMock).not.toHaveBeenCalled();
+		expect(session.sessionManager.getSessionName()).toBe("Old auto title");
+	});
+
+	it("does not refresh todo-init titles when automatic titles are disabled", async () => {
+		Bun.env.PI_NO_TITLE = "1";
+		await recreateSession({ "title.refreshOnReplan": true });
+		await session.setSessionName("Old auto title", "auto");
+		const completeSimpleMock = vi.spyOn(ai, "completeSimple");
 		scriptedResponses = [
 			createToolCallAssistantMessage("todo", {
 				op: "init",

--- a/packages/coding-agent/test/agent-session-title-generation-dispose.test.ts
+++ b/packages/coding-agent/test/agent-session-title-generation-dispose.test.ts
@@ -1,3 +1,4 @@
+import { Database } from "bun:sqlite";
 import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import { Agent } from "@oh-my-pi/pi-agent-core";
 import * as ai from "@oh-my-pi/pi-ai";
@@ -6,7 +7,7 @@ import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
-import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { AuthStorage, SqliteAuthCredentialStore } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import { createAssistantMessage } from "./helpers/agent-session-setup";
 
@@ -33,9 +34,25 @@ afterEach(async () => {
 });
 
 describe("AgentSession title generation disposal", () => {
-	it("uses an isolated provider session and aborts an in-flight title request during disposal", async () => {
-		authStorage = await AuthStorage.create(":memory:");
-		authStorage.setRuntimeApiKey("anthropic", "test-key");
+	it("isolates the title provider session without changing credentials and aborts it during disposal", async () => {
+		const store = new SqliteAuthCredentialStore(new Database(":memory:"));
+		store.saveOAuth("anthropic", {
+			access: "account-a-token",
+			refresh: "account-a-refresh",
+			expires: Date.now() + 60_000,
+			accountId: "account-a",
+		});
+		store.saveOAuth("anthropic", {
+			access: "account-b-token",
+			refresh: "account-b-refresh",
+			expires: Date.now() + 60_000,
+			accountId: "account-b",
+		});
+		const storage = new AuthStorage(store);
+		authStorage = storage;
+		const modelRegistry = new ModelRegistry(storage);
+		await storage.reload();
+		storage.clearConfigApiKeys();
 		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
 		if (!model) throw new Error("Expected claude-sonnet-4-5 model to exist");
 		const providerSessionId = "provider-session";
@@ -50,8 +67,18 @@ describe("AgentSession title generation disposal", () => {
 			initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] },
 			streamFn: createMockModel({ responses: [{ content: ["Done"] }] }).stream,
 		});
-		const modelRegistry = new ModelRegistry(authStorage);
-		const getApiKey = vi.spyOn(modelRegistry, "getApiKey");
+		const pinnedAccount = storage.listOAuthAccounts("anthropic").find(account => account.accountId === "account-b");
+		if (!pinnedAccount) throw new Error("Expected account-b credential");
+		expect(storage.pinSessionOAuthAccount("anthropic", providerSessionId, pinnedAccount.credentialId)).toBe(true);
+		let titleProvider: string | undefined;
+		let titleCredentialId: number | undefined;
+		const getApiKey = vi.spyOn(modelRegistry, "getApiKey").mockImplementation(async (requestModel, sessionId) => {
+			titleProvider = requestModel.provider;
+			titleCredentialId = storage
+				.listOAuthAccounts(requestModel.provider, sessionId)
+				.find(account => account.active)?.credentialId;
+			return "test-key";
+		});
 		const resolver = vi.spyOn(modelRegistry, "resolver");
 		session = new AgentSession({
 			agent,
@@ -60,6 +87,9 @@ describe("AgentSession title generation disposal", () => {
 			modelRegistry,
 			providerSessionId,
 		});
+		expect(
+			storage.listOAuthAccounts("anthropic", providerSessionId).find(account => account.active)?.credentialId,
+		).toBe(pinnedAccount.credentialId);
 		const started = Promise.withResolvers<void>();
 		const response = Promise.withResolvers<ai.AssistantMessage>();
 		let requestSignal: AbortSignal | undefined;
@@ -76,6 +106,8 @@ describe("AgentSession title generation disposal", () => {
 		expect(titleSessionId).toBeTruthy();
 		expect(titleSessionId).not.toBe(providerSessionId);
 		expect(resolver.mock.calls[0]?.[1]).toBe(titleSessionId);
+		expect(titleProvider).toBe("anthropic");
+		expect(titleCredentialId).toBe(pinnedAccount.credentialId);
 		session.beginDispose();
 
 		expect(requestSignal?.aborted).toBe(true);

--- a/packages/coding-agent/test/agent-session-title-generation-dispose.test.ts
+++ b/packages/coding-agent/test/agent-session-title-generation-dispose.test.ts
@@ -33,7 +33,7 @@ afterEach(async () => {
 });
 
 describe("AgentSession title generation disposal", () => {
-	it("uses the active provider session and aborts an in-flight title request during disposal", async () => {
+	it("uses an isolated provider session and aborts an in-flight title request during disposal", async () => {
 		authStorage = await AuthStorage.create(":memory:");
 		authStorage.setRuntimeApiKey("anthropic", "test-key");
 		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
@@ -72,8 +72,10 @@ describe("AgentSession title generation disposal", () => {
 
 		const generation = session.generateTitle("Investigate shutdown");
 		await started.promise;
-		expect(getApiKey.mock.calls[0]?.[1]).toBe(providerSessionId);
-		expect(resolver.mock.calls[0]?.[1]).toBe(providerSessionId);
+		const titleSessionId = getApiKey.mock.calls[0]?.[1];
+		expect(titleSessionId).toBeTruthy();
+		expect(titleSessionId).not.toBe(providerSessionId);
+		expect(resolver.mock.calls[0]?.[1]).toBe(titleSessionId);
 		session.beginDispose();
 
 		expect(requestSignal?.aborted).toBe(true);


### PR DESCRIPTION
## Repro
With `PI_NO_TITLE=1` (the runtime state set by `omp --no-title`), `title.refreshOnReplan=true`, and an auto-generated session title, run `bun test packages/coding-agent/test/agent-session-eager-todo.test.ts`; before the fix, the todo-init regression case invoked `completeSimple` once instead of zero times.

## Cause
`AgentSession.maybeStartTitleGeneration()` in `packages/coding-agent/src/session/agent-session.ts` honored `PI_NO_TITLE`, but `AgentSession.#scheduleReplanTitleRefresh()` independently scheduled the todo-init background request without that gate. `generateTitle()` then propagated the foreground session ID and provider metadata into the concurrent title request.

## Fix
- Stop replan title scheduling when automatic titles are disabled.
- Cover todo initialization under `PI_NO_TITLE` while preserving enabled refresh behavior.
- Document the corrected `--no-title` behavior in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/agent-session-eager-todo.test.ts` — 13 passed, 0 failed, 44 assertions. The pre-publish `bun run fix` and `bun check` gate passed.

Fixes #10619