### PR TITLE
feat(status-line): render extension statuses inline

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -685,7 +685,7 @@ tui:
 | `tui.hyperlinks`            | enum    | `auto`           | `off`, `auto`, `always`.                                                  |
 | `tui.resizeScrollback`      | enum    | `rebuild`        | How a settled width resize refreshes transcript rows kept in terminal scrollback: `append` replays the transcript at the new width below retained history, `rebuild` erases pane scrollback then replays one current-width copy, `preserve` repaints only the viewport. |
 
-For a custom status line, set `statusLine.preset: custom` and configure `statusLine.leftSegments`, `statusLine.rightSegments`, and `statusLine.segmentOptions`.
+For a custom status line, set `statusLine.preset: custom` and configure `statusLine.leftSegments`, `statusLine.rightSegments`, and `statusLine.segmentOptions`. Include `status` in either segment list to render extension statuses registered through `ctx.ui.setStatus()`, ordered by key and joined inline. Set `statusLine.showHookStatus: false` to suppress the same statuses in the footer.
 
 ### Interaction
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,7 +12,7 @@
 - Added `/wt` (alias `/worktree`) to create a linked worktree with uncommitted changes and move the current session into it while leaving the original checkout untouched.
 ### Added
 
-- Added an opt-in `status` custom status-line segment for rendering extension statuses inline.
+- Added an opt-in `status` custom status-line segment for rendering extension statuses inline ([#10622](https://github.com/can1357/oh-my-pi/pull/10622) by [@Visvaldis](https://github.com/Visvaldis)).
 
 ### Changed
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,9 @@
 - Added clone-first Git worktree support that carries over ignored build artifacts when creating worktrees, with a configurable `worktree.clone` setting and fallback to a standard checkout. This is supported by `github pr_checkout`, `omp worktree add`, and `git worktree add` commands entered through the Bash tool.
 - Added the `omp worktree add` command with Git-compatible branch, detach, path, and commit options.
 - Added `/wt` (alias `/worktree`) to create a linked worktree with uncommitted changes and move the current session into it while leaving the original checkout untouched.
+### Added
+
+- Added an opt-in `status` custom status-line segment for rendering extension statuses inline.
 
 ### Changed
 

--- a/packages/coding-agent/src/cli/gallery-fixtures/segments.ts
+++ b/packages/coding-agent/src/cli/gallery-fixtures/segments.ts
@@ -90,6 +90,10 @@ function variantsFor(id: StatusLineSegmentId): readonly SegmentVariantSpec[] {
 				{ label: "active", context: { turnElapsedMs: 92_000 } },
 				{ label: "focused subagent", context: { focusedAgentId: "Scout" } },
 			];
+		case "status":
+			return [
+				{ label: "multiple extension statuses", context: { hookStatuses: ["Indexer ready", "Tests passing"] } },
+			];
 		case "model":
 			return [
 				{ label: "normal" },

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -238,6 +238,7 @@ export const TAB_GROUPS: Record<SettingTab, readonly string[]> = {
 /** Status line segment identifiers */
 export type StatusLineSegmentId =
 	| "pi"
+	| "status"
 	| "model"
 	| "mode"
 	| "path"

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -403,6 +403,7 @@ export class StatusLineComponent implements Component {
 	/** Frame timer driving repaints while the brand fade is unsettled. */
 	#brandFadeTimer: NodeJS.Timeout | undefined;
 	#hookStatuses: Map<string, string> = new Map();
+	#sortedHookStatuses: readonly string[] = [];
 	#subagentCount: number = 0;
 	#runningSubagentIds = new Set<string>();
 	/**
@@ -722,10 +723,14 @@ export class StatusLineComponent implements Component {
 
 	setHookStatus(key: string, text: string | undefined): void {
 		if (text === undefined) {
-			this.#hookStatuses.delete(key);
+			if (!this.#hookStatuses.delete(key)) return;
 		} else {
+			if (this.#hookStatuses.get(key) === text) return;
 			this.#hookStatuses.set(key, text);
 		}
+		this.#sortedHookStatuses = Array.from(this.#hookStatuses.entries())
+			.sort(([a], [b]) => a.localeCompare(b))
+			.map(([, status]) => status);
 	}
 
 	watchBranch(onBranchChange: () => void): void {
@@ -1812,6 +1817,7 @@ export class StatusLineComponent implements Component {
 			width,
 			options: segmentOptions ?? {},
 			compactThinkingLevel: this.#resolveSettings().compactThinkingLevel ?? false,
+			hookStatuses: this.#sortedHookStatuses,
 			planMode: this.#planModeStatus,
 			loopMode: this.#loopModeStatus,
 			prewalk:
@@ -2427,11 +2433,8 @@ export class StatusLineComponent implements Component {
 			}
 		}
 		const showHooks = this.#settings.showHookStatus ?? true;
-		if (showHooks && this.#hookStatuses.size > 0) {
-			const hookLines = Array.from(this.#hookStatuses.entries())
-				.sort(([a], [b]) => a.localeCompare(b))
-				.map(([, text]) => truncateToWidth(sanitizeStatusText(text), width));
-			lines.push(...hookLines);
+		if (showHooks && this.#sortedHookStatuses.length > 0) {
+			lines.push(...this.#sortedHookStatuses.map(text => truncateToWidth(sanitizeStatusText(text), width)));
 		}
 		return lines;
 	}

--- a/packages/coding-agent/src/modes/components/status-line/segments.ts
+++ b/packages/coding-agent/src/modes/components/status-line/segments.ts
@@ -154,6 +154,22 @@ function brandTimer(elapsedMs: number): string {
 	return `${Math.min(99, Math.floor(seconds / 3600))}h`;
 }
 
+const statusSegment: StatusLineSegment = {
+	id: "status",
+	render(ctx) {
+		let text = "";
+		for (const status of ctx.hookStatuses ?? []) {
+			const sanitized = sanitizeStatusText(status);
+			if (!sanitized) continue;
+			text += text ? `${theme.sep.dot}${sanitized}` : sanitized;
+		}
+		return {
+			content: text ? accentFg(ctx, "accent", text) : "",
+			visible: text.length > 0,
+		};
+	},
+};
+
 const modelSegment: StatusLineSegment = {
 	id: "model",
 	render(ctx) {
@@ -794,6 +810,7 @@ const usageSegment: StatusLineSegment = {
 
 export const SEGMENTS: Record<StatusLineSegmentId, StatusLineSegment> = {
 	pi: piSegment,
+	status: statusSegment,
 	model: modelSegment,
 	mode: modeSegment,
 	path: pathSegment,

--- a/packages/coding-agent/src/modes/components/status-line/types.ts
+++ b/packages/coding-agent/src/modes/components/status-line/types.ts
@@ -74,6 +74,8 @@ export interface SegmentContext {
 	options: StatusLineSegmentOptions;
 	/** Render the model segment's thinking level as a compact leading glyph. */
 	compactThinkingLevel: boolean;
+	/** Key-sorted extension/hook status values. Segment renderers sanitize before display. */
+	hookStatuses?: readonly string[];
 	planMode: {
 		enabled: boolean;
 		paused: boolean;

--- a/packages/coding-agent/test/status-line-settings-cache.test.ts
+++ b/packages/coding-agent/test/status-line-settings-cache.test.ts
@@ -7,6 +7,7 @@ import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { StatusLineComponent, type StatusLineSettings } from "@oh-my-pi/pi-coding-agent/modes/components/status-line";
 import { STATUS_LINE_PRESETS } from "@oh-my-pi/pi-coding-agent/modes/components/status-line/presets";
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { visibleWidth } from "@oh-my-pi/pi-tui";
 import * as vcs from "@oh-my-pi/pi-natives/vcs";
 import { removeSyncWithRetries, setProjectDir } from "@oh-my-pi/pi-utils";
 import { beginSettingsTest, restoreSettingsTestState, type SettingsTestState } from "./helpers/settings-test-state";
@@ -184,6 +185,36 @@ describe("StatusLineComponent effective settings cache", () => {
 		component.setHookStatus("hook", "hook done");
 		expect(component.render(80)).toEqual(["hook done"]);
 		expect(component.getEffectiveSettingsForTest()).toBe(effective);
+	});
+
+	it("renders arbitrary extension statuses in deterministic segment order", () => {
+		const component = makeComponent({
+			preset: "custom",
+			leftSegments: ["pi", "status", "model"],
+			rightSegments: [],
+			separator: "powerline-thin",
+			showHookStatus: false,
+			sessionAccent: false,
+			segmentOptions: { model: { showThinkingLevel: false } },
+		});
+
+		component.setHookStatus("z-tests", "Tests passing");
+		component.setHookStatus("a-indexer", "\x1b]8;;https://example.com\x07Indexer ready\x1b]8;;\x07");
+
+		const border = component.getTopBorder(120).content;
+		const content = stripVTControlCharacters(border);
+		expect(border).not.toContain("https://example.com");
+		expect(content.indexOf("Indexer ready")).toBeGreaterThanOrEqual(0);
+		expect(content.indexOf("Indexer ready")).toBeLessThan(content.indexOf("Tests passing"));
+		expect(content.indexOf("Tests passing")).toBeLessThan(content.indexOf("Test Model"));
+		expect(component.render(120)).toEqual([]);
+		expect(visibleWidth(component.getTopBorder(24).content)).toBeLessThanOrEqual(24);
+
+		component.setHookStatus("a-indexer", undefined);
+		component.setHookStatus("z-tests", undefined);
+		const cleared = stripVTControlCharacters(component.getTopBorder(120).content);
+		expect(cleared).not.toContain("Indexer ready");
+		expect(cleared).not.toContain("Tests passing");
 	});
 
 	it("does not mutate shared preset segment options during narrow renders", () => {


### PR DESCRIPTION
## What

Adds an opt-in `status` segment to custom status-line layouts. It renders text published through the existing `ctx.ui.setStatus(key, text)` extension API alongside built-in segments such as `pi`, `model`, and `git`.

- Keeps every built-in status-line preset unchanged.
- Preserves the existing footer behavior when `statusLine.showHookStatus` is enabled.
- Orders multiple extension statuses deterministically by key and sanitizes terminal control sequences before rendering.
- Reuses the existing segment composition and narrow-width overflow behavior.
- Caches the sorted status values when they change instead of sorting on every repaint.

Example:

```yaml
statusLine:
  preset: custom
  leftSegments: [pi, status, model]
  showHookStatus: false
```

```text
π > Daily > GPT-5.6 Luna
```

## Why

Extensions can already publish short persistent state with `ctx.ui.setStatus()`, but that state is otherwise rendered as separate footer rows. A generic `status` segment lets users place extension state in the normal status line without requiring custom footer implementations or extension-specific host changes.

> Submitter rationale (verbatim): “I want to see active role within the status line (above prompt) and not separated below.”

## Testing

- `npx --yes bun@1.4.0 run check` from `packages/coding-agent`
- `npx --yes bun@1.4.0 test packages/coding-agent/test/status-line-settings-cache.test.ts packages/coding-agent/test/gallery-cli.test.ts` — 23 passed
- Launched the coding-agent TUI from this branch with `leftSegments: [pi, status, model, ...]` and `showHookStatus: false`; observed the extension value inline between `pi` and `model` with no duplicate footer row.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (user-facing)
