### PR TITLE
feat(coding-agent): add agent scoping to ttsr rules

### DIFF
--- a/docs/rulebook-matching-pipeline.md
+++ b/docs/rulebook-matching-pipeline.md
@@ -255,7 +255,7 @@ After rule discovery in `createAgentSession` (`sdk.ts`), `bucketRules(...)` appl
 ### `agents`
 
 - Restricts a rule to matching agents. Accepts a YAML sequence, a single string, or a comma-separated string; patterns are lowercased glob patterns matched case-insensitively against the agent definition name (`scout`, `reviewer`, `foreman-*`). Whitespace around commas inside a `{a, b}` glob-brace group is tolerated and normalized away.
-- The literal `main` matches the top-level session; a subagent with no definition name falls back to `sub`.
+- The literal `main` matches the top-level session; a subagent with no definition name falls back to `sub`. Both `main` and `sub` are reserved: a custom agent definition cannot use either name (`parseAgentFields` rejects it), so neither sentinel can be shadowed by a real agent.
 - Omitted (or an empty list) means the rule applies to every agent — the pre-existing behavior.
 - Filtering happens once, in `bucketRules(...)` at session creation, before TTSR registration: an unmatched rule joins no bucket, is never compiled into `TtsrManager`, and is not addressable via `rule://` in that session.
 - Subagents receive the parent's unfiltered discovered rule list and re-evaluate `agents` under their own name, so a scout-only rule loads in scouts and nowhere else.

--- a/docs/rulebook-matching-pipeline.md
+++ b/docs/rulebook-matching-pipeline.md
@@ -10,6 +10,7 @@ It reflects the current implementation, including partial semantics and metadata
 ## Implementation files
 
 - [`packages/coding-agent/src/capability/rule.ts`](../packages/coding-agent/src/capability/rule.ts)
+- [`packages/coding-agent/src/cli/ttsr-cli.ts`](../packages/coding-agent/src/cli/ttsr-cli.ts)
 - [`packages/coding-agent/src/capability/rule-buckets.ts`](../packages/coding-agent/src/capability/rule-buckets.ts)
 - [`packages/coding-agent/src/capability/index.ts`](../packages/coding-agent/src/capability/index.ts)
 - [`packages/coding-agent/src/discovery/index.ts`](../packages/coding-agent/src/discovery/index.ts)
@@ -42,6 +43,7 @@ interface Rule {
   condition?: string[];
   astCondition?: string[];
   scope?: string[];
+  agents?: string[];
   interruptMode?: "never" | "prose-only" | "tool-only" | "always";
   _source: SourceMeta;
 }
@@ -80,7 +82,7 @@ Normalization:
 - `name` = filename without `.md`/`.mdc`
 - frontmatter parsed via `parseFrontmatter`
 - `content` = body (frontmatter stripped)
-- `globs`, `alwaysApply`, `description`, `condition`/legacy `ttsr_trigger`, `astCondition`, `scope`, and `interruptMode` are parsed by `buildRuleFromMarkdown`
+- `globs`, `alwaysApply`, `description`, `condition`/legacy `ttsr_trigger`, `astCondition`, `scope`, `agents`, and `interruptMode` are parsed by `buildRuleFromMarkdown`
 - top-level `RULES.md` is synthesized as rule name `RULES` and forced to `alwaysApply: true`
 
 Both sticky files use the fixed name `RULES`. Because native items are appended as project rules, user rules, user sticky `RULES.md`, then project sticky `RULES.md`, the first earlier item named `RULES` wins. Normally this means user sticky content shadows project sticky content; a regular `rules/RULES.md` can shadow both.
@@ -94,7 +96,7 @@ Loads from both `.agent` and `.agents` directories:
 - project: walk upward from `cwd` to repo root, loading `<ancestor>/.agent/rules/*.{md,mdc}` and `<ancestor>/.agents/rules/*.{md,mdc}`
 - user: `~/.agent/rules/*.{md,mdc}` and `~/.agents/rules/*.{md,mdc}`
 
-Normalization uses the shared `buildRuleFromMarkdown` path: filename-derived name, stripped frontmatter body, and parsed `globs`, `alwaysApply`, `description`, `condition`/legacy `ttsr_trigger`, `astCondition`, `scope`, and `interruptMode`.
+Normalization uses the shared `buildRuleFromMarkdown` path: filename-derived name, stripped frontmatter body, and parsed `globs`, `alwaysApply`, `description`, `condition`/legacy `ttsr_trigger`, `astCondition`, `scope`, `agents`, and `interruptMode`.
 
 ### Cursor provider (`cursor.ts`)
 
@@ -108,7 +110,7 @@ Normalization (`transformMDCRule`):
 - `description`: kept only if string
 - `alwaysApply`: normalized to a boolean — `true` only when frontmatter has `alwaysApply: true` (anything else becomes `false`)
 - `globs`: accepts array (string elements only) or single string
-- `condition`/legacy `ttsr_trigger`, `astCondition`, `scope`, and `interruptMode` are parsed by shared rule helpers
+- `condition`/legacy `ttsr_trigger`, `astCondition`, `scope`, `agents`, and `interruptMode` are parsed by shared rule helpers
 - `name` from filename without extension
 
 ### Windsurf provider (`windsurf.ts`)
@@ -121,7 +123,7 @@ Loads from:
 Normalization:
 
 - `globs`: array-of-string or single string
-- `alwaysApply`, `description`, `condition`/legacy `ttsr_trigger`, `astCondition`, `scope`, and `interruptMode` parsed by shared rule helpers
+- `alwaysApply`, `description`, `condition`/legacy `ttsr_trigger`, `astCondition`, `scope`, `agents`, and `interruptMode` parsed by shared rule helpers
 - `name` is fixed to `global_rules` for the user global file and derived from filename for project rules
 
 ### Cline provider (`cline.ts`)
@@ -134,7 +136,7 @@ Searches upward from `cwd` for nearest `.clinerules`:
 Normalization:
 
 - `globs`: array-of-string or single string
-- `alwaysApply`, `description`, `condition`/legacy `ttsr_trigger`, `astCondition`, `scope`, and `interruptMode` parsed by shared rule helpers
+- `alwaysApply`, `description`, `condition`/legacy `ttsr_trigger`, `astCondition`, `scope`, `agents`, and `interruptMode` parsed by shared rule helpers
 - `name` is fixed to `clinerules` for a `.clinerules` file and derived from filename for `.clinerules/*.md`
 
 ### GitHub provider (`github.ts`)
@@ -213,9 +215,10 @@ After rule discovery in `createAgentSession` (`sdk.ts`), `bucketRules(...)` appl
 
 1. Drop rules listed in `ttsr.disabledRules`.
 2. Drop rules from the `builtin-defaults` provider when `ttsr.builtinRules === false`.
-3. Register rules with a non-empty `condition` or `astCondition` into `TtsrManager`; if registration succeeds, the rule is TTSR-only.
-4. Put remaining `alwaysApply === true` rules into `alwaysApplyRules`.
-5. Put remaining rules with `description` into `rulebookRules`.
+3. Drop rules whose `agents` globs do not match the session's agent name (`main` for a top-level session, otherwise the agent definition name); rules without `agents` apply to every agent.
+4. Register rules with a non-empty `condition` or `astCondition` into `TtsrManager`; if registration succeeds, the rule is TTSR-only.
+5. Put remaining `alwaysApply === true` rules into `alwaysApplyRules`.
+6. Put remaining rules with `description` into `rulebookRules`.
 
 ### Bucket behavior
 
@@ -248,6 +251,23 @@ After rule discovery in `createAgentSession` (`sdk.ts`), `bucketRules(...)` appl
 - Used as an exclusion condition from `rulebookRules`.
 - **Full rule content is auto-injected into the system prompt** (before the rulebook rules section).
 - Rule is also addressable via `rule://<name>` for re-reading.
+
+### `agents`
+
+- Restricts a rule to matching agents. Accepts a YAML sequence, a single string, or a comma-separated string; patterns are lowercased glob patterns matched case-insensitively against the agent definition name (`scout`, `reviewer`, `foreman-*`).
+- The literal `main` matches the top-level session; a subagent with no definition name falls back to `sub`.
+- Omitted (or an empty list) means the rule applies to every agent — the pre-existing behavior.
+- Filtering happens once, in `bucketRules(...)` at session creation, before TTSR registration: an unmatched rule joins no bucket, is never compiled into `TtsrManager`, and is not addressable via `rule://` in that session.
+- Subagents receive the parent's unfiltered discovered rule list and re-evaluate `agents` under their own name, so a scout-only rule loads in scouts and nowhere else.
+
+  ```yaml
+  agents: [scout, "foreman-*"]
+  ```
+
+  ```yaml
+  # Main agent only; every subagent ignores this rule:
+  agents: main
+  ```
 
 ### `condition`, `astCondition`, `scope`, and `interruptMode`
 

--- a/docs/rulebook-matching-pipeline.md
+++ b/docs/rulebook-matching-pipeline.md
@@ -10,7 +10,6 @@ It reflects the current implementation, including partial semantics and metadata
 ## Implementation files
 
 - [`packages/coding-agent/src/capability/rule.ts`](../packages/coding-agent/src/capability/rule.ts)
-- [`packages/coding-agent/src/cli/ttsr-cli.ts`](../packages/coding-agent/src/cli/ttsr-cli.ts)
 - [`packages/coding-agent/src/capability/rule-buckets.ts`](../packages/coding-agent/src/capability/rule-buckets.ts)
 - [`packages/coding-agent/src/capability/index.ts`](../packages/coding-agent/src/capability/index.ts)
 - [`packages/coding-agent/src/discovery/index.ts`](../packages/coding-agent/src/discovery/index.ts)
@@ -26,6 +25,7 @@ It reflects the current implementation, including partial semantics and metadata
 - [`packages/coding-agent/src/sdk.ts`](../packages/coding-agent/src/sdk.ts)
 - [`packages/coding-agent/src/system-prompt.ts`](../packages/coding-agent/src/system-prompt.ts)
 - [`packages/coding-agent/src/internal-urls/rule-protocol.ts`](../packages/coding-agent/src/internal-urls/rule-protocol.ts)
+- [`packages/coding-agent/src/cli/ttsr-cli.ts`](../packages/coding-agent/src/cli/ttsr-cli.ts)
 - [`packages/utils/src/frontmatter.ts`](../packages/utils/src/frontmatter.ts)
 
 ## 1. Canonical rule shape
@@ -254,7 +254,7 @@ After rule discovery in `createAgentSession` (`sdk.ts`), `bucketRules(...)` appl
 
 ### `agents`
 
-- Restricts a rule to matching agents. Accepts a YAML sequence, a single string, or a comma-separated string; patterns are lowercased glob patterns matched case-insensitively against the agent definition name (`scout`, `reviewer`, `foreman-*`).
+- Restricts a rule to matching agents. Accepts a YAML sequence, a single string, or a comma-separated string; patterns are lowercased glob patterns matched case-insensitively against the agent definition name (`scout`, `reviewer`, `foreman-*`). Whitespace around commas inside a `{a, b}` glob-brace group is tolerated and normalized away.
 - The literal `main` matches the top-level session; a subagent with no definition name falls back to `sub`.
 - Omitted (or an empty list) means the rule applies to every agent — the pre-existing behavior.
 - Filtering happens once, in `bucketRules(...)` at session creation, before TTSR registration: an unmatched rule joins no bucket, is never compiled into `TtsrManager`, and is not addressable via `rule://` in that session.

--- a/docs/ttsr-injection-lifecycle.md
+++ b/docs/ttsr-injection-lifecycle.md
@@ -30,11 +30,12 @@ const { rulebookRules, alwaysApplyRules } = bucketRules(
   {
     builtinRules: ttsrSettings.builtinRules,
     disabledRules: ttsrSettings.disabledRules,
+    agentName: resolvedAgentName,
   },
 );
 ```
 
-`bucketRules(...)` drops names listed in `ttsr.disabledRules`, drops embedded `builtin-defaults` rules when `ttsr.builtinRules === false`, registers accepted TTSR rules, and then routes the remaining rules to always-apply/rulebook buckets.
+`bucketRules(...)` drops names listed in `ttsr.disabledRules`, drops embedded builtin-defaults rules when `ttsr.builtinRules === false`, drops rules whose `agents` globs do not match this session's agent, registers accepted TTSR rules, and then routes the remaining rules to always-apply/rulebook buckets.
 
 ### Pre-registration dedupe behavior
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Rules accept an `agents` frontmatter field so a rule applies only to matching agents (glob patterns against the agent name; `main` targets the top-level agent), surfaced in `omp ttsr list` and testable with `omp ttsr test --agent <name>`.
+
 ### Fixed
 
 - Fixed cold-revived subagents losing `agents`-scoped rules by restoring the persisted agent definition name instead of the registry's generated display label.
@@ -36,9 +40,6 @@
 ### Removed
 
 - Removed the bundled `designer` subagent and `designer` model role; `modelRoles.designer` and `@designer` are no longer built in.
-
-### Added
-- Rules accept an `agents` frontmatter field so a rule applies only to matching agents (glob patterns against the agent name; `main` targets the top-level agent), surfaced in `omp ttsr list` and testable with `omp ttsr test --agent <name>`.
 
 ## [18.1.3] - 2026-09-02
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,7 +12,7 @@
 - Fixed `rule://<name>` resolving `Unknown rule` inside a subagent whose rules are scoped away from the main session's snapshot; `rule://` now resolves against the calling session's own applicable rule set.
 - Fixed the rule inspector showing "(no apply conditions)" on rules that are scoped only by `agents`.
 - Fixed `rule://<name>` and other internal-URL resolution inside a bash command run by a subagent to use that subagent's scoped rule set instead of the top-level session's, so `cat rule://<scoped-rule>` resolves correctly.
-- Reserved `main` as a subagent definition name: a custom agent named `main` could previously masquerade as the top-level session for `agents`-scoped rule matching.
+- Reserved `main` as a subagent definition name: a custom agent named `main` could previously masquerade as the top-level session for `agents`-scoped rule matching, including a persisted transcript from before this reservation existed.
 
 ## [18.1.5] - 2026-09-03
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,7 +12,7 @@
 - Fixed `rule://<name>` resolving `Unknown rule` inside a subagent whose rules are scoped away from the main session's snapshot; `rule://` now resolves against the calling session's own applicable rule set.
 - Fixed the rule inspector showing "(no apply conditions)" on rules that are scoped only by `agents`.
 - Fixed `rule://<name>` and other internal-URL resolution inside a bash command run by a subagent to use that subagent's scoped rule set instead of the top-level session's, so `cat rule://<scoped-rule>` resolves correctly.
-- Reserved `main` as a subagent definition name: a custom agent named `main` could previously masquerade as the top-level session for `agents`-scoped rule matching, including a persisted transcript from before this reservation existed.
+- Reserved `main` and `sub` as subagent definition names: a custom agent named `main` or `sub` could previously masquerade as the corresponding session-kind sentinel for `agents`-scoped rule matching, including in a persisted transcript from before this reservation existed.
 
 ## [18.1.5] - 2026-09-03
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed cold-revived subagents losing `agents`-scoped rules by restoring the persisted agent definition name instead of the registry's generated display label.
+- Fixed `rule://<name>` resolving `Unknown rule` inside a subagent whose rules are scoped away from the main session's snapshot; `rule://` now resolves against the calling session's own applicable rule set.
+- Fixed the rule inspector showing "(no apply conditions)" on rules that are scoped only by `agents`.
+
 ## [18.1.5] - 2026-09-03
 
 ### Added

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -11,6 +11,8 @@
 - Fixed cold-revived subagents losing `agents`-scoped rules by restoring the persisted agent definition name instead of the registry's generated display label.
 - Fixed `rule://<name>` resolving `Unknown rule` inside a subagent whose rules are scoped away from the main session's snapshot; `rule://` now resolves against the calling session's own applicable rule set.
 - Fixed the rule inspector showing "(no apply conditions)" on rules that are scoped only by `agents`.
+- Fixed `rule://<name>` and other internal-URL resolution inside a bash command run by a subagent to use that subagent's scoped rule set instead of the top-level session's, so `cat rule://<scoped-rule>` resolves correctly.
+- Reserved `main` as a subagent definition name: a custom agent named `main` could previously masquerade as the top-level session for `agents`-scoped rule matching.
 
 ## [18.1.5] - 2026-09-03
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -33,7 +33,7 @@
 
 ### Added
 - Rules accept an `agents` frontmatter field so a rule applies only to matching agents (glob patterns against the agent name; `main` targets the top-level agent), surfaced in `omp ttsr list` and testable with `omp ttsr test --agent <name>`.
-- TTSR rules can now scope themselves to specific agent names via an `agents` frontmatter field. `omp ttsr test --agent <name>` and `omp ttsr list` now surface agent scoping in rule details
+
 ## [18.1.3] - 2026-09-02
 
 ### Changed

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -31,6 +31,9 @@
 
 - Removed the bundled `designer` subagent and `designer` model role; `modelRoles.designer` and `@designer` are no longer built in.
 
+### Added
+- Rules accept an `agents` frontmatter field so a rule applies only to matching agents (glob patterns against the agent name; `main` targets the top-level agent), surfaced in `omp ttsr list` and testable with `omp ttsr test --agent <name>`.
+- TTSR rules can now scope themselves to specific agent names via an `agents` frontmatter field. `omp ttsr test --agent <name>` and `omp ttsr list` now surface agent scoping in rule details
 ## [18.1.3] - 2026-09-02
 
 ### Changed

--- a/packages/coding-agent/src/capability/rule-buckets.ts
+++ b/packages/coding-agent/src/capability/rule-buckets.ts
@@ -5,13 +5,16 @@
  * session. It applies the user's disable levers, registers TTSR rules with the
  * manager, and splits the rest into the always-apply and rulebook buckets.
  *
- * Bucket precedence (matches docs/rulebook-matching-pipeline.md §5):
- *   1. TTSR     — non-empty `condition`/`astCondition` that `TtsrManager.addRule` accepts
- *   2. always   — `alwaysApply === true`
- *   3. rulebook — has a `description`
+ * Precedence (matches docs/rulebook-matching-pipeline.md §5):
+ *   1. disabledRules  — dropped before any bucket assignment
+ *   2. builtin drop   — `builtinRules === false` drops `builtin-defaults` rules
+ *   3. agents scope   — rules whose `agents` globs do not match `options.agentName` are dropped
+ *   4. TTSR           — non-empty `condition`/`astCondition` that `TtsrManager.addRule` accepts
+ *   5. always         — `alwaysApply === true`
+ *   6. rulebook       — has a `description`
  */
 import type { TtsrManager } from "../export/ttsr";
-import { BUILTIN_DEFAULTS_PROVIDER_ID, type Rule } from "./rule";
+import { BUILTIN_DEFAULTS_PROVIDER_ID, type Rule, ruleAppliesToAgent } from "./rule";
 
 export interface RuleBuckets {
 	rulebookRules: Rule[];
@@ -23,6 +26,12 @@ export interface BucketRulesOptions {
 	disabledRules?: readonly string[];
 	/** When false, drop every rule from the bundled `builtin-defaults` provider. */
 	builtinRules?: boolean;
+	/**
+	 * Agent this session runs as: `"main"` for a top-level session, otherwise the
+	 * agent definition name. Rules whose `agents` globs do not match are dropped
+	 * from every bucket. Omit to disable agent scoping (CLI inventory listings).
+	 */
+	agentName?: string;
 }
 
 /**
@@ -48,6 +57,7 @@ export function bucketRules(
 	for (const rule of rules) {
 		if (disabled.has(rule.name)) continue;
 		if (!includeBuiltin && rule._source?.provider === BUILTIN_DEFAULTS_PROVIDER_ID) continue;
+		if (!ruleAppliesToAgent(rule, options.agentName)) continue;
 
 		const hasTtsrCondition =
 			(rule.condition && rule.condition.length > 0) || (rule.astCondition && rule.astCondition.length > 0);

--- a/packages/coding-agent/src/capability/rule.ts
+++ b/packages/coding-agent/src/capability/rule.ts
@@ -30,6 +30,8 @@ export interface RuleFrontmatter {
 	astCondition?: string | string[];
 	/** New key for TTSR stream scope. */
 	scope?: string | string[];
+	/** Agent-name globs this rule applies to; absent = every agent. `main` targets the top-level session. */
+	agents?: string[] | string;
 	/** Per-rule TTSR interrupt mode override. */
 	interruptMode?: "never" | "prose-only" | "tool-only" | "always";
 	[key: string]: unknown;
@@ -57,6 +59,8 @@ export interface Rule {
 	astCondition?: string[];
 	/** Optional stream scope tokens (for example: text, thinking, tool:edit(*.ts)). */
 	scope?: string[];
+	/** Lowercased agent-name globs this rule applies to (absent = every agent). */
+	agents?: string[];
 	/** Per-rule TTSR interrupt mode override (falls back to global ttsr.interruptMode). */
 	interruptMode?: "never" | "prose-only" | "tool-only" | "always";
 	/** Source metadata */
@@ -174,6 +178,44 @@ function normalizeScopeField(value: unknown): string[] | undefined {
 		return undefined;
 	}
 	return Array.from(new Set(tokens));
+}
+
+/**
+ * Parse the `agents` frontmatter field into lowercased agent-name glob patterns.
+ * Reuses the scope tokenizer for comma-separated spellings; `{a,b}` groups survive.
+ */
+export function parseRuleAgents(value: unknown): string[] | undefined {
+	const tokens = normalizeScopeField(value);
+	if (!tokens) {
+		return undefined;
+	}
+	return Array.from(new Set(tokens.map(token => token.toLowerCase())));
+}
+
+/** Agent name used for the top-level (non-sub) session when evaluating `agents`. */
+export const MAIN_AGENT_RULE_NAME = "main";
+
+/**
+ * Whether a rule's `agents` scope admits `agentName`. A rule without `agents`
+ * applies everywhere; `agentName === undefined` disables scoping entirely
+ * (used by CLI inventory listings that must show every rule).
+ */
+export function ruleAppliesToAgent(rule: Pick<Rule, "agents">, agentName: string | undefined): boolean {
+	const patterns = rule.agents;
+	if (!patterns || patterns.length === 0 || agentName === undefined) {
+		return true;
+	}
+	const name = agentName.trim().toLowerCase();
+	return patterns.some(pattern => {
+		if (pattern === name) {
+			return true;
+		}
+		try {
+			return new Bun.Glob(pattern).match(name);
+		} catch {
+			return false;
+		}
+	});
 }
 /**
  * Heuristic for condition shorthand that looks like a file glob (for example `*.rs`).

--- a/packages/coding-agent/src/capability/rule.ts
+++ b/packages/coding-agent/src/capability/rule.ts
@@ -195,6 +195,9 @@ export function parseRuleAgents(value: unknown): string[] | undefined {
 /** Agent name used for the top-level (non-sub) session when evaluating `agents`. */
 export const MAIN_AGENT_RULE_NAME = "main";
 
+/** Fallback agent name used for a subagent session with no explicit `agentName` (see sdk.ts). */
+export const SUB_AGENT_RULE_NAME = "sub";
+
 /**
  * Whether a rule's `agents` scope admits `agentName`. A rule without `agents`
  * applies everywhere; `agentName === undefined` disables scoping entirely

--- a/packages/coding-agent/src/capability/rule.ts
+++ b/packages/coding-agent/src/capability/rule.ts
@@ -189,7 +189,7 @@ export function parseRuleAgents(value: unknown): string[] | undefined {
 	if (!tokens) {
 		return undefined;
 	}
-	return Array.from(new Set(tokens.map(token => token.toLowerCase())));
+	return Array.from(new Set(tokens.map(token => token.replace(/\s*,\s*/g, ",").toLowerCase())));
 }
 
 /** Agent name used for the top-level (non-sub) session when evaluating `agents`. */
@@ -210,11 +210,7 @@ export function ruleAppliesToAgent(rule: Pick<Rule, "agents">, agentName: string
 		if (pattern === name) {
 			return true;
 		}
-		try {
-			return new Bun.Glob(pattern).match(name);
-		} catch {
-			return false;
-		}
+		return new Bun.Glob(pattern).match(name);
 	});
 }
 /**

--- a/packages/coding-agent/src/cli/ttsr-cli.ts
+++ b/packages/coding-agent/src/cli/ttsr-cli.ts
@@ -21,6 +21,7 @@ import { getProjectDir } from "@oh-my-pi/pi-utils/dirs";
 import {
 	BUILTIN_DEFAULTS_PROVIDER_ID,
 	compileRuleCondition,
+	MAIN_AGENT_RULE_NAME,
 	ruleAppliesToAgent,
 	type Rule,
 	ruleCapability,
@@ -324,12 +325,16 @@ async function readIsolatedRule(rulePath: string): Promise<Rule> {
 	});
 }
 
-async function loadIsolatedRule(rulePath: string, agentName: string): Promise<{ rules: Rule[]; manager: TtsrManager }> {
+async function loadIsolatedRule(
+	rulePath: string,
+	agentName: string,
+): Promise<{ ok: true; rules: Rule[]; manager: TtsrManager } | { ok: false; unavailableMsg: string }> {
 	const rule = await readIsolatedRule(rulePath);
 	if (!ruleAppliesToAgent(rule, agentName)) {
-		throw new Error(
-			`Rule "${rule.name}" is scoped to agents [${(rule.agents ?? []).join(", ")}] and does not apply to agent "${agentName}". Re-run with --agent <one of those names>.`,
-		);
+		return {
+			ok: false,
+			unavailableMsg: `Rule "${rule.name}" is scoped to agents [${(rule.agents ?? []).join(", ")}] and does not apply to agent "${agentName}". Re-run with --agent <one of those names>.`,
+		};
 	}
 	const manager = await createTtsrManager({
 		enabled: true,
@@ -345,7 +350,7 @@ async function loadIsolatedRule(rulePath: string, agentName: string): Promise<{ 
 			`Rule "${rule.name}" has no usable TTSR condition. Add a \`condition\` (regex) or \`astCondition\` (ast-grep pattern) to its frontmatter.`,
 		);
 	}
-	return { rules: manager.getRules(), manager };
+	return { ok: true, rules: manager.getRules(), manager };
 }
 
 async function loadIsolatedScanRule(rulePath: string): Promise<Rule[]> {
@@ -382,15 +387,26 @@ async function runTest(args: TtsrTestArgs, json: boolean, cwd: string): Promise<
 		filePaths: filePath ? [filePath] : undefined,
 	};
 
-	const agent = (args.agent ?? "main").trim().toLowerCase();
-	const { rules, manager } = args.rule
+	const agent = (args.agent ?? "").trim().toLowerCase() || MAIN_AGENT_RULE_NAME;
+	const loaded = args.rule
 		? await loadIsolatedRule(args.rule, agent)
-		: await loadProjectTtsrRules(cwd, agent);
+		: { ok: true as const, ...(await loadProjectTtsrRules(cwd, agent)) };
+
+	if (!loaded.ok) {
+		if (json) {
+			process.stdout.write(`${JSON.stringify({ error: loaded.unavailableMsg })}\n`);
+		} else {
+			process.stderr.write(`${chalk.yellow(loaded.unavailableMsg)}\n`);
+		}
+		process.exit(1);
+	}
+
+	const { rules, manager } = loaded;
 
 	if (rules.length === 0) {
 		const msg = args.rule
 			? "Rule registered but produced no TTSR entry."
-			: "No TTSR rules registered for this project. Add a `condition` or `astCondition` to a rule file, then re-run.";
+			: `No TTSR rules registered for this project as agent "${agent}". Rules scoped to other agents via \`agents\` are excluded — run \`omp ttsr list\` to see every rule, or pass --agent <name>.`;
 		if (json) {
 			process.stdout.write(`${JSON.stringify({ error: msg })}\n`);
 		} else {

--- a/packages/coding-agent/src/cli/ttsr-cli.ts
+++ b/packages/coding-agent/src/cli/ttsr-cli.ts
@@ -9,13 +9,22 @@
  *
  * `omp ttsr list` — show every TTSR-registered rule the current project/user
  * config would load, with its conditions, scope, and source.
+ *
+ * `--agent <name>` on `omp ttsr test` evaluates the rule's `agents` frontmatter
+ * scoping as that agent (default "main"); `omp ttsr list`/`scan` stay unfiltered.
  */
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { AstMatchStrictness, astMatch, FileType, type GlobMatch, glob } from "@oh-my-pi/pi-natives";
 import chalk from "@oh-my-pi/pi-utils/chalk";
 import { getProjectDir } from "@oh-my-pi/pi-utils/dirs";
-import { BUILTIN_DEFAULTS_PROVIDER_ID, compileRuleCondition, type Rule, ruleCapability } from "../capability/rule";
+import {
+	BUILTIN_DEFAULTS_PROVIDER_ID,
+	compileRuleCondition,
+	ruleAppliesToAgent,
+	type Rule,
+	ruleCapability,
+} from "../capability/rule";
 import { bucketRules } from "../capability/rule-buckets";
 import { Settings } from "../config/settings";
 import type { TtsrSettings } from "../config/settings-schema";
@@ -52,6 +61,8 @@ export interface TtsrTestArgs {
 	filePath?: string;
 	/** Show every evaluated rule, not just triggered ones. */
 	verbose?: boolean;
+	/** Agent name to evaluate rule `agents` scoping as; defaults to "main". */
+	agent?: string;
 }
 
 export interface TtsrScanArgs {
@@ -83,6 +94,7 @@ interface RuleMatchDetail {
 	/** All conditions defined on the rule (for verbose display). */
 	defined: { regex: string[]; ast: string[] };
 	skippedAst?: string;
+	agents?: string[];
 }
 
 interface TestReport {
@@ -100,6 +112,7 @@ interface TestReport {
 	 * surface why a source file was evaluated against a prose context.
 	 */
 	inferenceNote?: string;
+	agent: string;
 }
 
 const STDIN_MARKER = "-";
@@ -238,6 +251,7 @@ async function evaluate(
 			sourceProvider: rule._source?.provider,
 			matched: { regex, ast },
 			defined: { regex: rule.condition ?? [], ast: rule.astCondition ?? [] },
+			agents: rule.agents,
 		};
 		if (!astEligible && (rule.astCondition ?? []).length > 0) {
 			detail.skippedAst = "astCondition requires --source tool and a --path with a file extension";
@@ -269,7 +283,7 @@ function filterTtsrRulesForScan(
 	});
 }
 
-async function loadProjectTtsrRules(cwd: string): Promise<{ rules: Rule[]; manager: TtsrManager }> {
+async function loadProjectTtsrRules(cwd: string, agentName?: string): Promise<{ rules: Rule[]; manager: TtsrManager }> {
 	const settingsInstance = await Settings.init({ cwd });
 	initializeWithSettings(settingsInstance);
 	const ttsrSettings = settingsInstance.getGroup("ttsr");
@@ -278,6 +292,7 @@ async function loadProjectTtsrRules(cwd: string): Promise<{ rules: Rule[]; manag
 	bucketRules(result.items, manager, {
 		builtinRules: ttsrSettings.builtinRules,
 		disabledRules: ttsrSettings.disabledRules,
+		agentName,
 	});
 	return { rules: manager.getRules(), manager };
 }
@@ -309,8 +324,13 @@ async function readIsolatedRule(rulePath: string): Promise<Rule> {
 	});
 }
 
-async function loadIsolatedRule(rulePath: string): Promise<{ rules: Rule[]; manager: TtsrManager }> {
+async function loadIsolatedRule(rulePath: string, agentName: string): Promise<{ rules: Rule[]; manager: TtsrManager }> {
 	const rule = await readIsolatedRule(rulePath);
+	if (!ruleAppliesToAgent(rule, agentName)) {
+		throw new Error(
+			`Rule "${rule.name}" is scoped to agents [${(rule.agents ?? []).join(", ")}] and does not apply to agent "${agentName}". Re-run with --agent <one of those names>.`,
+		);
+	}
 	const manager = await createTtsrManager({
 		enabled: true,
 		contextMode: "discard",
@@ -362,7 +382,10 @@ async function runTest(args: TtsrTestArgs, json: boolean, cwd: string): Promise<
 		filePaths: filePath ? [filePath] : undefined,
 	};
 
-	const { rules, manager } = args.rule ? await loadIsolatedRule(args.rule) : await loadProjectTtsrRules(cwd);
+	const agent = (args.agent ?? "main").trim().toLowerCase();
+	const { rules, manager } = args.rule
+		? await loadIsolatedRule(args.rule, agent)
+		: await loadProjectTtsrRules(cwd, agent);
 
 	if (rules.length === 0) {
 		const msg = args.rule
@@ -388,6 +411,7 @@ async function runTest(args: TtsrTestArgs, json: boolean, cwd: string): Promise<
 		triggered,
 		notTriggered,
 		inferenceNote,
+		agent,
 	};
 
 	if (json) {
@@ -402,7 +426,7 @@ function renderTestReport(report: TestReport, verbose: boolean, isolated: boolea
 	const ctxLabel = report.source === "tool" ? `tool:${report.tool ?? "?"}` : report.source;
 	const pathLabel = report.filePath ? ` path=${report.filePath}` : "";
 	process.stdout.write(
-		`${chalk.bold("TTSR test")} — source=${chalk.cyan(ctxLabel)}${pathLabel} snippet=${chalk.dim(`${report.snippetBytes}b`)}\n`,
+		`${chalk.bold("TTSR test")} — source=${chalk.cyan(ctxLabel)}${pathLabel} agent=${chalk.cyan(report.agent)} snippet=${chalk.dim(`${report.snippetBytes}b`)}\n`,
 	);
 	process.stdout.write(`${chalk.dim(`  "${report.snippetPreview}"`)}\n\n`);
 	if (report.inferenceNote) {
@@ -439,6 +463,9 @@ function renderRuleDetail(detail: RuleMatchDetail, hit: boolean): void {
 	if (ast.length > 0) {
 		condParts.push(`astCondition: ${ast.map(c => chalk.magenta(c)).join(", ")}`);
 	}
+	if ((detail.agents ?? []).length > 0) {
+		condParts.push(`agents: ${detail.agents!.join(", ")}`);
+	}
 	if (detail.skippedAst) {
 		condParts.push(chalk.dim(`astCondition: ${detail.skippedAst}`));
 	}
@@ -461,6 +488,7 @@ async function runList(json: boolean, cwd: string): Promise<void> {
 					astCondition: r.astCondition ?? [],
 					scope: r.scope ?? [],
 					globs: r.globs ?? [],
+					agents: r.agents ?? [],
 					description: r.description,
 				})),
 			)}\n`,
@@ -480,6 +508,7 @@ async function runList(json: boolean, cwd: string): Promise<void> {
 		if ((rule.astCondition ?? []).length > 0) condParts.push(`astCondition: ${rule.astCondition!.join(", ")}`);
 		if ((rule.scope ?? []).length > 0) condParts.push(`scope: ${rule.scope!.join(", ")}`);
 		if ((rule.globs ?? []).length > 0) condParts.push(`globs: ${rule.globs!.join(", ")}`);
+		if ((rule.agents ?? []).length > 0) condParts.push(`agents: ${rule.agents!.join(", ")}`);
 		const provider = rule._source?.provider ? chalk.dim(` [${rule._source.provider}]`) : "";
 		process.stdout.write(
 			`  ${chalk.bold(rule.name)}${provider} ${chalk.dim(condParts.join("  ") || "no conditions")}\n`,
@@ -696,6 +725,7 @@ async function scanRulePlanMatchesContent(
 		sourceProvider: plan.rule._source?.provider,
 		matched: { regex: matchedRegex, ast: matchedAst },
 		defined: { regex: plan.rule.condition ?? [], ast: plan.rule.astCondition ?? [] },
+		agents: plan.rule.agents,
 	};
 }
 

--- a/packages/coding-agent/src/commands/ttsr.ts
+++ b/packages/coding-agent/src/commands/ttsr.ts
@@ -50,6 +50,9 @@ export default class Ttsr extends Command {
 			char: "p",
 			description: "Candidate file path for scope/glob matching and AST language inference",
 		}),
+		agent: Flags.string({
+			description: "Agent name to evaluate rule `agents` scoping as; defaults to main (ttsr test)",
+		}),
 		verbose: Flags.boolean({ char: "v", description: "Show every evaluated rule, not just triggered ones" }),
 		json: Flags.boolean({ description: "Output JSON" }),
 		"no-gitignore": Flags.boolean({ description: "Include files excluded by .gitignore (ttsr scan)" }),
@@ -65,6 +68,7 @@ export default class Ttsr extends Command {
 		"omp ttsr test --file src/foo.ts",
 		"omp ttsr test --file src/foo.ts --source text",
 		"omp ttsr test --rule .omp/rules/no-any.md --source tool --path src/foo.ts 'const x: any = 1'",
+		"omp ttsr test --agent scout 'const x: any = 1'",
 		"echo 'Box::leak(&mut v)' | omp ttsr test --file - --path src/lib.rs",
 		"omp ttsr test --source tool --tool edit --path src/foo.ts 'const x: any = 1'",
 		"omp ttsr scan",
@@ -99,6 +103,7 @@ export default class Ttsr extends Command {
 						tool: flags.tool,
 						filePath: flags.path,
 						verbose: flags.verbose,
+						agent: flags.agent,
 					}
 				: undefined;
 

--- a/packages/coding-agent/src/commands/ttsr.ts
+++ b/packages/coding-agent/src/commands/ttsr.ts
@@ -51,7 +51,7 @@ export default class Ttsr extends Command {
 			description: "Candidate file path for scope/glob matching and AST language inference",
 		}),
 		agent: Flags.string({
-			description: "Agent name to evaluate rule `agents` scoping as; defaults to main (ttsr test)",
+			description: "Agent name to evaluate rule `agents` scoping as (ttsr test); defaults to main",
 		}),
 		verbose: Flags.boolean({ char: "v", description: "Show every evaluated rule, not just triggered ones" }),
 		json: Flags.boolean({ description: "Output JSON" }),

--- a/packages/coding-agent/src/discovery/helpers.ts
+++ b/packages/coding-agent/src/discovery/helpers.ts
@@ -14,7 +14,13 @@ import {
 import type { ContextFile } from "../capability/context-file";
 import type { ExtensionModule } from "../capability/extension-module";
 import { invalidate as invalidateFsCache, readDirEntries, readFile } from "../capability/fs";
-import { parseRuleAgents, parseRuleConditionAndScope, type Rule, type RuleFrontmatter } from "../capability/rule";
+import {
+	MAIN_AGENT_RULE_NAME,
+	parseRuleAgents,
+	parseRuleConditionAndScope,
+	type Rule,
+	type RuleFrontmatter,
+} from "../capability/rule";
 import type { Skill, SkillFrontmatter } from "../capability/skill";
 import type { LoadContext, LoadResult, SourceMeta } from "../capability/types";
 import { resolveClaudePaths } from "../config/claude-paths";
@@ -260,6 +266,13 @@ export function parseAgentFields(frontmatter: Record<string, unknown>): ParsedAg
 	const description = typeof frontmatter.description === "string" ? frontmatter.description : undefined;
 
 	if (!name || !description) {
+		return null;
+	}
+	// "main" is the sentinel `agentName` for the top-level session (see
+	// MAIN_AGENT_RULE_NAME). A subagent definition sharing that name would
+	// resolve to the same value, letting it load rules scoped `agents: [main]`
+	// that are documented as top-level-only.
+	if (name.trim().toLowerCase() === MAIN_AGENT_RULE_NAME) {
 		return null;
 	}
 

--- a/packages/coding-agent/src/discovery/helpers.ts
+++ b/packages/coding-agent/src/discovery/helpers.ts
@@ -14,7 +14,7 @@ import {
 import type { ContextFile } from "../capability/context-file";
 import type { ExtensionModule } from "../capability/extension-module";
 import { invalidate as invalidateFsCache, readDirEntries, readFile } from "../capability/fs";
-import { parseRuleConditionAndScope, type Rule, type RuleFrontmatter } from "../capability/rule";
+import { parseRuleAgents, parseRuleConditionAndScope, type Rule, type RuleFrontmatter } from "../capability/rule";
 import type { Skill, SkillFrontmatter } from "../capability/skill";
 import type { LoadContext, LoadResult, SourceMeta } from "../capability/types";
 import { resolveClaudePaths } from "../config/claude-paths";
@@ -217,6 +217,7 @@ export function buildRuleFromMarkdown(
 		condition,
 		astCondition,
 		scope,
+		agents: parseRuleAgents(frontmatter.agents),
 		interruptMode,
 		_source: source,
 	};

--- a/packages/coding-agent/src/discovery/helpers.ts
+++ b/packages/coding-agent/src/discovery/helpers.ts
@@ -20,6 +20,7 @@ import {
 	parseRuleConditionAndScope,
 	type Rule,
 	type RuleFrontmatter,
+	SUB_AGENT_RULE_NAME,
 } from "../capability/rule";
 import type { Skill, SkillFrontmatter } from "../capability/skill";
 import type { LoadContext, LoadResult, SourceMeta } from "../capability/types";
@@ -269,10 +270,13 @@ export function parseAgentFields(frontmatter: Record<string, unknown>): ParsedAg
 		return null;
 	}
 	// "main" is the sentinel `agentName` for the top-level session (see
-	// MAIN_AGENT_RULE_NAME). A subagent definition sharing that name would
-	// resolve to the same value, letting it load rules scoped `agents: [main]`
-	// that are documented as top-level-only.
-	if (name.trim().toLowerCase() === MAIN_AGENT_RULE_NAME) {
+	// MAIN_AGENT_RULE_NAME); "sub" is the fallback `agentName` for a subagent
+	// session with no explicit name (see SUB_AGENT_RULE_NAME / sdk.ts). A
+	// custom agent definition sharing either name would resolve to the same
+	// sentinel value, letting it load rules scoped `agents: [main]` or
+	// `agents: [sub]` that are documented to target only that session kind.
+	const normalizedName = name.trim().toLowerCase();
+	if (normalizedName === MAIN_AGENT_RULE_NAME || normalizedName === SUB_AGENT_RULE_NAME) {
 		return null;
 	}
 

--- a/packages/coding-agent/src/internal-urls/rule-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/rule-protocol.ts
@@ -5,14 +5,14 @@
  * - rule://<name> - Reads rule content
  */
 import { getActiveRules } from "../capability/rule";
-import type { InternalResource, InternalUrl, ProtocolHandler, UrlCompletion } from "./types";
+import type { InternalResource, InternalUrl, ProtocolHandler, ResolveContext, UrlCompletion } from "./types";
 
 export class RuleProtocolHandler implements ProtocolHandler {
 	readonly scheme = "rule";
 	readonly immutable = true;
 
-	async resolve(url: InternalUrl): Promise<InternalResource> {
-		const rules = getActiveRules();
+	async resolve(url: InternalUrl, context?: ResolveContext): Promise<InternalResource> {
+		const rules = context?.rules ?? getActiveRules();
 
 		const ruleName = url.rawHost || url.hostname;
 		if (!ruleName) {
@@ -36,8 +36,8 @@ export class RuleProtocolHandler implements ProtocolHandler {
 		};
 	}
 
-	async complete(): Promise<UrlCompletion[]> {
-		return getActiveRules().map(rule => ({
+	async complete(_query?: string, context?: ResolveContext): Promise<UrlCompletion[]> {
+		return (context?.rules ?? getActiveRules()).map(rule => ({
 			value: rule.name,
 			...(rule.description ? { description: rule.description } : {}),
 		}));

--- a/packages/coding-agent/src/internal-urls/types.ts
+++ b/packages/coding-agent/src/internal-urls/types.ts
@@ -5,6 +5,7 @@
  * providing access to agent outputs and server resources without exposing filesystem paths.
  */
 
+import type { Rule } from "../capability/rule";
 import type { Skill } from "../extensibility/skills";
 import type { LocalProtocolOptions } from "./local-protocol";
 
@@ -115,6 +116,15 @@ export interface ResolveContext {
 	localProtocolOptions?: LocalProtocolOptions;
 	/** Calling session's loaded skills. Prefer this over process-global skill state. */
 	skills?: readonly Skill[];
+	/**
+	 * Calling session's agent-scoped applicable rule set (rulebook + always-apply
+	 * + triggered TTSR rules, already bucketed by `agents` frontmatter). Prefer
+	 * this over the process-global snapshot — the global one reflects only the
+	 * top-level session, so a subagent-only rule is unresolvable through it
+	 * even though the subagent's own system prompt tells it to read
+	 * `rule://<name>`.
+	 */
+	rules?: readonly Rule[];
 	/** Session-bound `xd://` documentation resolver. */
 	xd?: {
 		read(name: string | null): Promise<string>;

--- a/packages/coding-agent/src/modes/components/extensions/inspector-model.ts
+++ b/packages/coding-agent/src/modes/components/extensions/inspector-model.ts
@@ -8,7 +8,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { arkToWireSchema, isArkSchema } from "@oh-my-pi/pi-ai/utils/schema";
 import { normalizePathForComparison, parseFrontmatter } from "@oh-my-pi/pi-utils";
-import { parseRuleConditionAndScope } from "../../../capability/rule";
+import { parseRuleAgents, parseRuleConditionAndScope } from "../../../capability/rule";
 import { slashCommandFrontmatterDisplay } from "../../../capability/slash-command";
 import { isFilesystemSourcePath } from "../../../tools/path-utils";
 import {
@@ -340,6 +340,7 @@ export function ruleInspectorData(ext: Extension): {
 	condition?: string[];
 	astCondition?: string[];
 	scope?: string[];
+	agents?: string[];
 	interruptMode?: string;
 	content: string;
 	runtimeDetail?: string;
@@ -352,6 +353,7 @@ export function ruleInspectorData(ext: Extension): {
 		astCondition: stringArray(raw.astCondition) ?? stringField(raw, "astCondition"),
 		scope: stringArray(raw.scope) ?? stringField(raw, "scope"),
 	});
+	const agents = parseRuleAgents(raw.agents);
 	const interruptMode = stringField(raw, "interruptMode");
 	const content = stringField(raw, "content") ?? "";
 	return {
@@ -361,6 +363,7 @@ export function ruleInspectorData(ext: Extension): {
 		condition: parsed.condition,
 		astCondition: parsed.astCondition,
 		scope: parsed.scope,
+		agents,
 		interruptMode,
 		content,
 		runtimeDetail: ext.trigger,

--- a/packages/coding-agent/src/modes/components/extensions/inspector-panel.ts
+++ b/packages/coding-agent/src/modes/components/extensions/inspector-panel.ts
@@ -329,6 +329,7 @@ export class InspectorPanel implements Component {
 		if (data.condition) this.#pushLabeledList(surface, "condition", data.condition, width);
 		if (data.astCondition) this.#pushLabeledList(surface, "ast", data.astCondition, width);
 		if (data.scope) this.#pushLabeledList(surface, "scope", data.scope, width);
+		if (data.agents) this.#pushLabeledList(surface, "agents", data.agents, width);
 		if (data.interruptMode) this.#pushLabeled(surface, "interrupt", data.interruptMode, width, "dim");
 		if (!data.alwaysApply && !data.globs && !data.condition && !data.astCondition) {
 			surface.push(theme.fg("dim", "  (no apply conditions)"));

--- a/packages/coding-agent/src/modes/components/extensions/inspector-panel.ts
+++ b/packages/coding-agent/src/modes/components/extensions/inspector-panel.ts
@@ -331,7 +331,7 @@ export class InspectorPanel implements Component {
 		if (data.scope) this.#pushLabeledList(surface, "scope", data.scope, width);
 		if (data.agents) this.#pushLabeledList(surface, "agents", data.agents, width);
 		if (data.interruptMode) this.#pushLabeled(surface, "interrupt", data.interruptMode, width, "dim");
-		if (!data.alwaysApply && !data.globs && !data.condition && !data.astCondition) {
+		if (!data.alwaysApply && !data.globs && !data.condition && !data.astCondition && !data.agents) {
 			surface.push(theme.fg("dim", "  (no apply conditions)"));
 		}
 		surface.push("");

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -52,7 +52,7 @@ import { AsyncJobManager } from "./async";
 import { AutoLearnController, buildAutoLearnInstructions } from "./autolearn/controller";
 import { createAutoresearchExtension } from "./autoresearch";
 import { loadCapability } from "./capability";
-import { MAIN_AGENT_RULE_NAME, type Rule, ruleCapability, setActiveRules } from "./capability/rule";
+import { MAIN_AGENT_RULE_NAME, type Rule, ruleCapability, setActiveRules, SUB_AGENT_RULE_NAME } from "./capability/rule";
 import { bucketRules } from "./capability/rule-buckets";
 import type { EffectiveExtensionRoots } from "./capability/types";
 import { shouldEnableAppendOnlyContext } from "./config/append-only-context-mode";
@@ -1643,7 +1643,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 	// Agent identity must resolve before rule discovery: `agents` frontmatter decides
 	// which rules are bucketed into this session at all.
 	const isSubagentSession = (options.taskDepth ?? 0) > 0 || Boolean(options.parentTaskPrefix);
-	const agentKind: AgentKind = isSubagentSession ? "sub" : MAIN_AGENT_RULE_NAME;
+	const agentKind: AgentKind = isSubagentSession ? SUB_AGENT_RULE_NAME : MAIN_AGENT_RULE_NAME;
 	const resolvedAgentName = (options.agentName ?? agentKind).trim().toLowerCase();
 
 	// Discover rules and bucket them in one pass to avoid repeated scans over large rule sets.

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -569,6 +569,11 @@ export interface CreateAgentSessionOptions {
 	agentId?: string;
 	/** Display name for the agent in IRC. Default: "main" or "sub". */
 	agentDisplayName?: string;
+	/**
+	 * Agent definition name used to evaluate rule `agents` scoping. Defaults to
+	 * `agentDisplayName`, else "main" for a top-level session / "sub" for a subagent.
+	 */
+	agentName?: string;
 	/** Optional shared agent registry for IRC routing. Default: AgentRegistry.global(). */
 	agentRegistry?: AgentRegistry;
 	/**
@@ -1635,6 +1640,12 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 		skillWarnings = discovered.warnings;
 	}
 
+	// Agent identity must resolve before rule discovery: `agents` frontmatter decides
+	// which rules are bucketed into this session at all.
+	const isSubagentSession = (options.taskDepth ?? 0) > 0 || Boolean(options.parentTaskPrefix);
+	const agentKind = isSubagentSession ? ("sub" as const) : ("main" as const);
+	const resolvedAgentName = (options.agentName ?? options.agentDisplayName ?? agentKind).trim().toLowerCase();
+
 	// Discover rules and bucket them in one pass to avoid repeated scans over large rule sets.
 	const { ttsrManager, rulebookRules, alwaysApplyRules, allRules } = await logger.time(
 		"discoverTtsrRules",
@@ -1649,6 +1660,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			const { rulebookRules, alwaysApplyRules } = bucketRules(rulesResult.items, ttsrManager, {
 				builtinRules: ttsrSettings.builtinRules,
 				disabledRules: ttsrSettings.disabledRules,
+				agentName: resolvedAgentName,
 			});
 			if (existingSession.injectedTtsrRules.length > 0) {
 				ttsrManager.restoreInjected(existingSession.injectedTtsrRules);
@@ -1718,9 +1730,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 
 	const agentRegistry = options.agentRegistry ?? AgentRegistry.global();
 	const resolvedAgentId = options.agentId ?? options.parentTaskPrefix ?? MAIN_AGENT_ID;
-	const resolvedAgentDisplayName =
-		options.agentDisplayName ?? ((options.taskDepth ?? 0) > 0 || options.parentTaskPrefix ? "sub" : "main");
-	const agentKind = (options.taskDepth ?? 0) > 0 || options.parentTaskPrefix ? ("sub" as const) : ("main" as const);
+	const resolvedAgentDisplayName = options.agentDisplayName ?? agentKind;
 	let registeredAgentRef: AgentRef | undefined;
 	/**
 	 * Forget the agent ref on teardown — unless it is a retained terminal ref.

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -52,7 +52,7 @@ import { AsyncJobManager } from "./async";
 import { AutoLearnController, buildAutoLearnInstructions } from "./autolearn/controller";
 import { createAutoresearchExtension } from "./autoresearch";
 import { loadCapability } from "./capability";
-import { type Rule, ruleCapability, setActiveRules } from "./capability/rule";
+import { MAIN_AGENT_RULE_NAME, type Rule, ruleCapability, setActiveRules } from "./capability/rule";
 import { bucketRules } from "./capability/rule-buckets";
 import type { EffectiveExtensionRoots } from "./capability/types";
 import { shouldEnableAppendOnlyContext } from "./config/append-only-context-mode";
@@ -141,7 +141,7 @@ import type { MnemopiSessionState } from "./mnemopi/state";
 import mcpXdevGuidanceTemplate from "./prompts/system/mcp-xdev-guidance.md" with { type: "text" };
 import lateDiagnosticTemplate from "./prompts/tools/lsp-late-diagnostic.md" with { type: "text" };
 import { AgentLifecycleManager } from "./registry/agent-lifecycle";
-import { type AgentRef, AgentRegistry, MAIN_AGENT_ID } from "./registry/agent-registry";
+import { type AgentKind, type AgentRef, AgentRegistry, MAIN_AGENT_ID } from "./registry/agent-registry";
 import {
 	buildSecretObfuscator,
 	deobfuscateSessionContext,
@@ -571,7 +571,7 @@ export interface CreateAgentSessionOptions {
 	agentDisplayName?: string;
 	/**
 	 * Agent definition name used to evaluate rule `agents` scoping. Defaults to
-	 * `agentDisplayName`, else "main" for a top-level session / "sub" for a subagent.
+	 * "main" for a top-level session / "sub" for a subagent.
 	 */
 	agentName?: string;
 	/** Optional shared agent registry for IRC routing. Default: AgentRegistry.global(). */
@@ -1643,8 +1643,8 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 	// Agent identity must resolve before rule discovery: `agents` frontmatter decides
 	// which rules are bucketed into this session at all.
 	const isSubagentSession = (options.taskDepth ?? 0) > 0 || Boolean(options.parentTaskPrefix);
-	const agentKind = isSubagentSession ? ("sub" as const) : ("main" as const);
-	const resolvedAgentName = (options.agentName ?? options.agentDisplayName ?? agentKind).trim().toLowerCase();
+	const agentKind: AgentKind = isSubagentSession ? "sub" : MAIN_AGENT_RULE_NAME;
+	const resolvedAgentName = (options.agentName ?? agentKind).trim().toLowerCase();
 
 	// Discover rules and bucket them in one pass to avoid repeated scans over large rule sets.
 	const { ttsrManager, rulebookRules, alwaysApplyRules, allRules } = await logger.time(

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1802,6 +1802,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			},
 			refreshSkills: () => session.refreshSkills(),
 			rules: allRules,
+			activeRules: [...rulebookRules, ...alwaysApplyRules, ...ttsrManager.getRules()],
 			eventBus,
 			subagentEventBus,
 			outputSchema: options.outputSchema,

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -3225,6 +3225,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				parentAgentId: options.parentAgentId,
 				agentId: id,
 				agentDisplayName: agent.name,
+				agentName: agent.name,
 				expectedAgentRef,
 				enableLsp: lspEnabled,
 				enableIrc: options.enableIrc,

--- a/packages/coding-agent/src/task/persisted-revive.ts
+++ b/packages/coding-agent/src/task/persisted-revive.ts
@@ -1,5 +1,6 @@
 import * as fs from "node:fs/promises";
 import { logger } from "@oh-my-pi/pi-utils";
+import { MAIN_AGENT_RULE_NAME } from "../capability/rule";
 import type { ModelRegistry } from "../config/model-registry";
 import { formatModelRoleAlias } from "../config/model-roles";
 import type { Settings } from "../config/settings";
@@ -140,8 +141,13 @@ export function createPersistedSubagentReviverFactory(
 				// register with `displayName: id` (registry/persisted-agents.ts), so a
 				// generated task id would silently drop every agent-scoped rule.
 				// `init.agent` carries the real name; only files predating that field
-				// fall back to the display label.
-				agentName: init.agent ?? ref.displayName,
+				// fall back to the display label. A parked transcript may also predate
+				// the `main`-as-definition-name reservation (discovery/helpers.ts): a
+				// persisted `init.agent === "main"` from such a legacy custom agent
+				// must not masquerade as the top-level sentinel here, so it falls back
+				// to the display label too, keeping it scoped as an ordinary subagent.
+				agentName:
+					init.agent && init.agent.trim().toLowerCase() !== MAIN_AGENT_RULE_NAME ? init.agent : ref.displayName,
 				parentTaskPrefix: ref.id,
 				parentAgentId: ref.parentId,
 				expectedAgentRef: expectedRef,

--- a/packages/coding-agent/src/task/persisted-revive.ts
+++ b/packages/coding-agent/src/task/persisted-revive.ts
@@ -1,6 +1,6 @@
 import * as fs from "node:fs/promises";
 import { logger } from "@oh-my-pi/pi-utils";
-import { MAIN_AGENT_RULE_NAME } from "../capability/rule";
+import { MAIN_AGENT_RULE_NAME, SUB_AGENT_RULE_NAME } from "../capability/rule";
 import type { ModelRegistry } from "../config/model-registry";
 import { formatModelRoleAlias } from "../config/model-roles";
 import type { Settings } from "../config/settings";
@@ -142,12 +142,18 @@ export function createPersistedSubagentReviverFactory(
 				// generated task id would silently drop every agent-scoped rule.
 				// `init.agent` carries the real name; only files predating that field
 				// fall back to the display label. A parked transcript may also predate
-				// the `main`-as-definition-name reservation (discovery/helpers.ts): a
-				// persisted `init.agent === "main"` from such a legacy custom agent
-				// must not masquerade as the top-level sentinel here, so it falls back
-				// to the display label too, keeping it scoped as an ordinary subagent.
+				// the `main`/`sub` definition-name reservation (discovery/helpers.ts): a
+				// persisted `init.agent` of either sentinel value from such a legacy
+				// custom agent must not masquerade as that sentinel here, so it falls
+				// back to the display label too, keeping it scoped as an ordinary
+				// subagent under its generated id instead of `main` or the shared `sub`
+				// bucket.
 				agentName:
-					init.agent && init.agent.trim().toLowerCase() !== MAIN_AGENT_RULE_NAME ? init.agent : ref.displayName,
+					init.agent &&
+					init.agent.trim().toLowerCase() !== MAIN_AGENT_RULE_NAME &&
+					init.agent.trim().toLowerCase() !== SUB_AGENT_RULE_NAME
+						? init.agent
+						: ref.displayName,
 				parentTaskPrefix: ref.id,
 				parentAgentId: ref.parentId,
 				expectedAgentRef: expectedRef,

--- a/packages/coding-agent/src/task/persisted-revive.ts
+++ b/packages/coding-agent/src/task/persisted-revive.ts
@@ -135,7 +135,13 @@ export function createPersistedSubagentReviverFactory(
 				sessionManager: reopened,
 				agentId: ref.id,
 				agentDisplayName: ref.displayName,
-				agentName: ref.displayName,
+				// `agents` rule scoping keys on the durable definition name (`scout`,
+				// `reviewer`, …), not the registry display label — cold-revived refs
+				// register with `displayName: id` (registry/persisted-agents.ts), so a
+				// generated task id would silently drop every agent-scoped rule.
+				// `init.agent` carries the real name; only files predating that field
+				// fall back to the display label.
+				agentName: init.agent ?? ref.displayName,
 				parentTaskPrefix: ref.id,
 				parentAgentId: ref.parentId,
 				expectedAgentRef: expectedRef,

--- a/packages/coding-agent/src/task/persisted-revive.ts
+++ b/packages/coding-agent/src/task/persisted-revive.ts
@@ -135,6 +135,7 @@ export function createPersistedSubagentReviverFactory(
 				sessionManager: reopened,
 				agentId: ref.id,
 				agentDisplayName: ref.displayName,
+				agentName: ref.displayName,
 				parentTaskPrefix: ref.id,
 				parentAgentId: ref.parentId,
 				expectedAgentRef: expectedRef,

--- a/packages/coding-agent/src/tools/ast-edit.ts
+++ b/packages/coding-agent/src/tools/ast-edit.ts
@@ -293,6 +293,7 @@ export class AstEditTool implements AgentTool<typeof astEditSchema, AstEditToolD
 				sessionFile: this.session.getSessionFile() ?? undefined,
 				localProtocolOptions: this.session.localProtocolOptions,
 				skills: this.session.skills,
+				rules: this.session.activeRules,
 				resolveExternalUrl: async rawPath => {
 					if (!parseReadUrlTarget(rawPath)) return undefined;
 					throw new ToolError(

--- a/packages/coding-agent/src/tools/ast-grep.ts
+++ b/packages/coding-agent/src/tools/ast-grep.ts
@@ -216,6 +216,7 @@ export class AstGrepTool implements AgentTool<typeof astGrepSchema, AstGrepToolD
 				sessionFile: this.session.getSessionFile() ?? undefined,
 				localProtocolOptions: this.session.localProtocolOptions,
 				skills: this.session.skills,
+				rules: this.session.activeRules,
 				resolveExternalUrl: async rawPath => {
 					const target = parseReadUrlTarget(rawPath);
 					if (!target) return undefined;

--- a/packages/coding-agent/src/tools/bash-skill-urls.ts
+++ b/packages/coding-agent/src/tools/bash-skill-urls.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { resolveContainedPathSync } from "../discovery/contained-path";
+import type { Rule } from "../capability/rule";
 import type { Skill } from "../extensibility/skills";
 import { type LocalProtocolOptions, resolveLocalUrlToPath } from "../internal-urls";
 import { validateRelativePath } from "../internal-urls/skill-protocol";
@@ -44,6 +45,8 @@ export interface InternalUrlExpansionOptions {
 	cwd?: string;
 	sessionFile?: string;
 	ensureLocalParentDirs?: boolean;
+	/** Calling session's agent-scoped applicable rules — lets rule:// resolve without process-global state. */
+	rules?: readonly Rule[];
 }
 
 /**
@@ -260,6 +263,7 @@ async function resolveInternalUrlToPath(
 	ensureLocalParentDirs?: boolean,
 	cwd?: string,
 	sessionFile?: string,
+	rules?: readonly Rule[],
 ): Promise<string> {
 	const url = normalizeLocalScheme(rawUrl);
 	const scheme = extractScheme(url);
@@ -301,7 +305,7 @@ async function resolveInternalUrlToPath(
 
 	let resource: InternalResource;
 	try {
-		resource = await internalRouter.resolve(url, { cwd, pathOnly: true, sessionFile });
+		resource = await internalRouter.resolve(url, { cwd, pathOnly: true, sessionFile, rules });
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);
 		throw new ToolError(`Failed to resolve ${scheme}:// URL in bash command: ${url}\n${message}`);
@@ -364,6 +368,7 @@ export async function expandInternalUrls(command: string, options: InternalUrlEx
 				options.ensureLocalParentDirs,
 				options.cwd,
 				options.sessionFile,
+				options.rules,
 			);
 		} catch {
 			continue;

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -955,6 +955,7 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 			internalRouter: InternalUrlRouter.instance(),
 			cwd: this.session.cwd,
 			sessionFile: this.session.getSessionFile() ?? undefined,
+			rules: this.session.activeRules,
 			localOptions: {
 				getArtifactsDir: this.session.getArtifactsDir,
 				getSessionId: this.session.getSessionId,

--- a/packages/coding-agent/src/tools/glob.ts
+++ b/packages/coding-agent/src/tools/glob.ts
@@ -227,6 +227,7 @@ export class GlobTool implements AgentTool<typeof findSchema, GlobToolDetails> {
 						sessionFile: this.session.getSessionFile() ?? undefined,
 						localProtocolOptions: this.session.localProtocolOptions,
 						skills: this.session.skills,
+						rules: this.session.activeRules,
 						pathOnly: true,
 					});
 					if (!resource.sourcePath) {
@@ -244,6 +245,7 @@ export class GlobTool implements AgentTool<typeof findSchema, GlobToolDetails> {
 					sessionFile: this.session.getSessionFile() ?? undefined,
 					localProtocolOptions: this.session.localProtocolOptions,
 					skills: this.session.skills,
+					rules: this.session.activeRules,
 					pathOnly: true,
 				});
 				if (!resource.sourcePath) {

--- a/packages/coding-agent/src/tools/grep.ts
+++ b/packages/coding-agent/src/tools/grep.ts
@@ -774,6 +774,7 @@ async function resolveInternalSearchInputs(opts: {
 	archiveDisplayMap: ReadonlyMap<string, string>;
 	localProtocolOptions?: LocalProtocolOptions;
 	skills?: ResolveContext["skills"];
+	rules?: ResolveContext["rules"];
 	sessionFile?: string;
 }): Promise<InternalSearchInputResolution> {
 	const internalRouter = InternalUrlRouter.instance();
@@ -790,6 +791,7 @@ async function resolveInternalSearchInputs(opts: {
 		sessionFile: opts.sessionFile,
 		localProtocolOptions: opts.localProtocolOptions,
 		skills: opts.skills,
+		rules: opts.rules,
 		skipDirectoryListing: true,
 		// Try path-only first so large artifacts (and any other handler that
 		// separates path from content) resolve without materializing bytes.
@@ -994,11 +996,12 @@ export class GrepTool implements AgentTool<typeof searchSchema, GrepToolDetails>
 					pathSpecs,
 					resolvedPaths,
 					cwd: this.session.cwd,
+					archiveDisplayMap,
 					settings: this.session.settings,
 					signal,
-					archiveDisplayMap,
 					localProtocolOptions: this.session.localProtocolOptions,
 					skills: this.session.skills,
+					rules: this.session.activeRules,
 					sessionFile: this.session.getSessionFile() ?? undefined,
 				});
 				const searchablePaths = internalResolution.paths;
@@ -1039,9 +1042,9 @@ export class GrepTool implements AgentTool<typeof searchSchema, GrepToolDetails>
 						cwd: this.session.cwd,
 						internalUrlAction: "search",
 						settings: this.session.settings,
-						signal,
 						localProtocolOptions: this.session.localProtocolOptions,
 						skills: this.session.skills,
+						rules: this.session.activeRules,
 						sessionFile: this.session.getSessionFile() ?? undefined,
 						resolveExternalUrl: materializeExternalUrlForSearch,
 						trackImmutableSources: true,

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -193,6 +193,15 @@ export interface ToolSession {
 	/** Pre-loaded rules (forwarded to subagents to skip re-discovery). */
 	rules?: Rule[];
 	/**
+	 * This session's agent-scoped applicable rule set — rulebook + always-apply
+	 * + triggered TTSR rules, already bucketed against this session's `agents`
+	 * frontmatter. Distinct from {@link rules} (the full unfiltered discovery
+	 * result forwarded to children): this is what `rule://` resolution needs so
+	 * a subagent-only rule stays readable from inside that subagent, instead of
+	 * only from the top-level session's process-global snapshot.
+	 */
+	activeRules?: readonly Rule[];
+	/**
 	 * Pre-discovered extension source paths. Forwarded to subagents so they
 	 * skip the FS scan but still re-bind extensions to their own session-scoped
 	 * `ExtensionAPI` (cwd, eventBus, runtime). Inline extension factories

--- a/packages/coding-agent/src/tools/path-utils.ts
+++ b/packages/coding-agent/src/tools/path-utils.ts
@@ -11,6 +11,7 @@ import {
 	stripWindowsExtendedLengthPathPrefix,
 	windowsPathToWslMount,
 } from "@oh-my-pi/pi-utils";
+import type { Rule } from "../capability/rule";
 import type { Skill } from "../extensibility/skills";
 import { InternalUrlRouter, type LocalProtocolOptions } from "../internal-urls";
 import { ToolAbortError, ToolError } from "./tool-errors";
@@ -1488,6 +1489,8 @@ export interface ToolScopeOptions {
 	localProtocolOptions?: LocalProtocolOptions;
 	/** Calling session's loaded skills — lets skill:// resolve without process-global state. */
 	skills?: readonly Skill[];
+	/** Calling session's agent-scoped applicable rules — lets rule:// resolve without process-global state. */
+	rules?: readonly Rule[];
 	/** Calling session's session file — lets history:///agent:// resolve against the caller's root. */
 	sessionFile?: string;
 	/** Materialize readable external URLs to local text files before scope derivation. */
@@ -1580,6 +1583,7 @@ export async function resolveToolSearchScope(opts: ToolScopeOptions): Promise<To
 			sessionFile: opts.sessionFile,
 			localProtocolOptions: opts.localProtocolOptions,
 			skills: opts.skills,
+			rules: opts.rules,
 			// Tool-scope resolution only needs `sourcePath`; skip content
 			// materialization so large artifacts (or any handler that separates
 			// path from content) stay searchable without OOM risk.

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -1178,6 +1178,7 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 					signal,
 					localProtocolOptions: this.session.localProtocolOptions,
 					skills: this.session.skills,
+					rules: this.session.activeRules,
 				});
 				if (localFile) {
 					readPath = localFile.path;
@@ -1993,6 +1994,7 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 			signal,
 			localProtocolOptions: this.session.localProtocolOptions,
 			skills: this.session.skills,
+			rules: this.session.activeRules,
 		});
 		const artifactUrl = `artifact://${artifact.id}`;
 		const details: ReadToolDetails = {
@@ -2223,6 +2225,7 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 			sessionFile: this.session.getSessionFile() ?? undefined,
 			localProtocolOptions: this.session.localProtocolOptions,
 			skills: this.session.skills,
+			rules: this.session.activeRules,
 			xd: {
 				read: async name => {
 					if (name === REPORT_ISSUE_DEVICE_NAME) return reportIssueDeviceUsage();

--- a/packages/coding-agent/test/capability/rule-agents.test.ts
+++ b/packages/coding-agent/test/capability/rule-agents.test.ts
@@ -1,29 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import type { Rule } from "@oh-my-pi/pi-coding-agent/capability/rule";
-import { bucketRules } from "@oh-my-pi/pi-coding-agent/capability/rule-buckets";
 import { buildRuleFromMarkdown, createSourceMeta } from "@oh-my-pi/pi-coding-agent/discovery/helpers";
-import { TtsrManager } from "@oh-my-pi/pi-coding-agent/export/ttsr";
-
-function source(provider: string): Rule["_source"] {
-	return { provider, providerName: provider, path: "/tmp/rule.md", level: "user" };
-}
-
-function makeRule(partial: Partial<Rule>): Rule {
-	return {
-		name: partial.name ?? "rule",
-		path: partial.path ?? "/tmp/rule.md",
-		content: partial.content ?? "body",
-		globs: partial.globs,
-		alwaysApply: partial.alwaysApply,
-		description: partial.description,
-		condition: partial.condition,
-		astCondition: partial.astCondition,
-		scope: partial.scope,
-		agents: partial.agents,
-		interruptMode: partial.interruptMode,
-		_source: partial._source ?? source("native"),
-	};
-}
 
 describe("agents frontmatter normalization", () => {
 	it("lowercases a YAML sequence", () => {
@@ -55,78 +31,14 @@ describe("agents frontmatter normalization", () => {
 		);
 		expect(rule.agents).toBeUndefined();
 	});
-});
 
-describe("bucketRules agent scoping", () => {
-	it("bucketes a scout-only TTSR rule for scout and leaves it inert for main", () => {
-		const rule = makeRule({
-			name: "scout-only",
-			condition: ["FORBIDDEN"],
-			description: "blocks foo",
-			agents: ["scout"],
-		});
-
-		const scoutMgr = new TtsrManager();
-		const { rulebookRules: scoutRulebook, alwaysApplyRules: scoutAlways } = bucketRules([rule], scoutMgr, {
-			agentName: "scout",
-		});
-		expect(scoutMgr.checkDelta("contains FORBIDDEN token", { source: "text" }).map(r => r.name)).toEqual([
-			"scout-only",
-		]);
-		expect(scoutRulebook).toHaveLength(0);
-		expect(scoutAlways).toHaveLength(0);
-
-		const mainMgr = new TtsrManager();
-		const { rulebookRules: mainRulebook, alwaysApplyRules: mainAlways } = bucketRules([rule], mainMgr, {
-			agentName: "main",
-		});
-		expect(mainMgr.hasRules()).toBe(false);
-		expect(mainRulebook).toHaveLength(0);
-		expect(mainAlways).toHaveLength(0);
-	});
-
-	it("`main` in the agents list includes the top-level session", () => {
-		const rule = makeRule({ name: "main-only", condition: ["FORBIDDEN"], agents: ["main"] });
-		const mgr = new TtsrManager();
-		bucketRules([rule], mgr, { agentName: "main" });
-		expect(mgr.checkDelta("contains FORBIDDEN token", { source: "text" }).map(r => r.name)).toEqual(["main-only"]);
-	});
-
-	it("matches a glob pattern against the agent name", () => {
-		const rule = makeRule({ name: "foreman-only", condition: ["FORBIDDEN"], agents: ["foreman-*"] });
-
-		const alphaMgr = new TtsrManager();
-		bucketRules([rule], alphaMgr, { agentName: "foreman-alpha" });
-		expect(alphaMgr.checkDelta("contains FORBIDDEN token", { source: "text" }).map(r => r.name)).toEqual([
-			"foreman-only",
-		]);
-
-		const foremanMgr = new TtsrManager();
-		bucketRules([rule], foremanMgr, { agentName: "foreman" });
-		expect(foremanMgr.hasRules()).toBe(false);
-	});
-
-	it("a rule with no `agents` field applies to every agent", () => {
-		const rule = makeRule({ name: "everyone", condition: ["FORBIDDEN"] });
-
-		const mainMgr = new TtsrManager();
-		bucketRules([rule], mainMgr, { agentName: "main" });
-		expect(mainMgr.hasRules()).toBe(true);
-
-		const scoutMgr = new TtsrManager();
-		bucketRules([rule], scoutMgr, { agentName: "scout" });
-		expect(scoutMgr.hasRules()).toBe(true);
-	});
-
-	it("gates the always-apply bucket too", () => {
-		const rule = makeRule({ name: "scout-always", alwaysApply: true, agents: ["scout"] });
-
-		const scoutMgr = new TtsrManager();
-		const { alwaysApplyRules: scoutAlways } = bucketRules([rule], scoutMgr, { agentName: "scout" });
-		expect(scoutAlways.map(r => r.name)).toEqual(["scout-always"]);
-
-		const mainMgr = new TtsrManager();
-		const { alwaysApplyRules: mainAlways } = bucketRules([rule], mainMgr, { agentName: "main" });
-		expect(mainAlways).toHaveLength(0);
+	it("tolerates whitespace around commas inside a brace group", () => {
+		const rule = buildRuleFromMarkdown(
+			"scoped.md",
+			`---\nagents: "{scout, reviewer}"\n---\nbody`,
+			"scoped.md",
+			createSourceMeta("test", "scoped.md", "project"),
+		);
+		expect(rule.agents).toEqual(["{scout,reviewer}"]);
 	});
 });

--- a/packages/coding-agent/test/capability/rule-agents.test.ts
+++ b/packages/coding-agent/test/capability/rule-agents.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "bun:test";
+import type { Rule } from "@oh-my-pi/pi-coding-agent/capability/rule";
+import { bucketRules } from "@oh-my-pi/pi-coding-agent/capability/rule-buckets";
+import { buildRuleFromMarkdown, createSourceMeta } from "@oh-my-pi/pi-coding-agent/discovery/helpers";
+import { TtsrManager } from "@oh-my-pi/pi-coding-agent/export/ttsr";
+
+function source(provider: string): Rule["_source"] {
+	return { provider, providerName: provider, path: "/tmp/rule.md", level: "user" };
+}
+
+function makeRule(partial: Partial<Rule>): Rule {
+	return {
+		name: partial.name ?? "rule",
+		path: partial.path ?? "/tmp/rule.md",
+		content: partial.content ?? "body",
+		globs: partial.globs,
+		alwaysApply: partial.alwaysApply,
+		description: partial.description,
+		condition: partial.condition,
+		astCondition: partial.astCondition,
+		scope: partial.scope,
+		agents: partial.agents,
+		interruptMode: partial.interruptMode,
+		_source: partial._source ?? source("native"),
+	};
+}
+
+describe("agents frontmatter normalization", () => {
+	it("lowercases a YAML sequence", () => {
+		const rule = buildRuleFromMarkdown(
+			"scoped.md",
+			`---\nagents: [Scout, "foreman-*"]\n---\nbody`,
+			"scoped.md",
+			createSourceMeta("test", "scoped.md", "project"),
+		);
+		expect(rule.agents).toEqual(["scout", "foreman-*"]);
+	});
+
+	it("splits a comma-separated string the same way", () => {
+		const rule = buildRuleFromMarkdown(
+			"scoped.md",
+			`---\nagents: "scout, foreman-*"\n---\nbody`,
+			"scoped.md",
+			createSourceMeta("test", "scoped.md", "project"),
+		);
+		expect(rule.agents).toEqual(["scout", "foreman-*"]);
+	});
+
+	it("normalizes an empty list to undefined", () => {
+		const rule = buildRuleFromMarkdown(
+			"scoped.md",
+			`---\nagents: []\n---\nbody`,
+			"scoped.md",
+			createSourceMeta("test", "scoped.md", "project"),
+		);
+		expect(rule.agents).toBeUndefined();
+	});
+});
+
+describe("bucketRules agent scoping", () => {
+	it("bucketes a scout-only TTSR rule for scout and leaves it inert for main", () => {
+		const rule = makeRule({
+			name: "scout-only",
+			condition: ["FORBIDDEN"],
+			description: "blocks foo",
+			agents: ["scout"],
+		});
+
+		const scoutMgr = new TtsrManager();
+		const { rulebookRules: scoutRulebook, alwaysApplyRules: scoutAlways } = bucketRules([rule], scoutMgr, {
+			agentName: "scout",
+		});
+		expect(scoutMgr.checkDelta("contains FORBIDDEN token", { source: "text" }).map(r => r.name)).toEqual([
+			"scout-only",
+		]);
+		expect(scoutRulebook).toHaveLength(0);
+		expect(scoutAlways).toHaveLength(0);
+
+		const mainMgr = new TtsrManager();
+		const { rulebookRules: mainRulebook, alwaysApplyRules: mainAlways } = bucketRules([rule], mainMgr, {
+			agentName: "main",
+		});
+		expect(mainMgr.hasRules()).toBe(false);
+		expect(mainRulebook).toHaveLength(0);
+		expect(mainAlways).toHaveLength(0);
+	});
+
+	it("`main` in the agents list includes the top-level session", () => {
+		const rule = makeRule({ name: "main-only", condition: ["FORBIDDEN"], agents: ["main"] });
+		const mgr = new TtsrManager();
+		bucketRules([rule], mgr, { agentName: "main" });
+		expect(mgr.checkDelta("contains FORBIDDEN token", { source: "text" }).map(r => r.name)).toEqual(["main-only"]);
+	});
+
+	it("matches a glob pattern against the agent name", () => {
+		const rule = makeRule({ name: "foreman-only", condition: ["FORBIDDEN"], agents: ["foreman-*"] });
+
+		const alphaMgr = new TtsrManager();
+		bucketRules([rule], alphaMgr, { agentName: "foreman-alpha" });
+		expect(alphaMgr.checkDelta("contains FORBIDDEN token", { source: "text" }).map(r => r.name)).toEqual([
+			"foreman-only",
+		]);
+
+		const foremanMgr = new TtsrManager();
+		bucketRules([rule], foremanMgr, { agentName: "foreman" });
+		expect(foremanMgr.hasRules()).toBe(false);
+	});
+
+	it("a rule with no `agents` field applies to every agent", () => {
+		const rule = makeRule({ name: "everyone", condition: ["FORBIDDEN"] });
+
+		const mainMgr = new TtsrManager();
+		bucketRules([rule], mainMgr, { agentName: "main" });
+		expect(mainMgr.hasRules()).toBe(true);
+
+		const scoutMgr = new TtsrManager();
+		bucketRules([rule], scoutMgr, { agentName: "scout" });
+		expect(scoutMgr.hasRules()).toBe(true);
+	});
+
+	it("gates the always-apply bucket too", () => {
+		const rule = makeRule({ name: "scout-always", alwaysApply: true, agents: ["scout"] });
+
+		const scoutMgr = new TtsrManager();
+		const { alwaysApplyRules: scoutAlways } = bucketRules([rule], scoutMgr, { agentName: "scout" });
+		expect(scoutAlways.map(r => r.name)).toEqual(["scout-always"]);
+
+		const mainMgr = new TtsrManager();
+		const { alwaysApplyRules: mainAlways } = bucketRules([rule], mainMgr, { agentName: "main" });
+		expect(mainAlways).toHaveLength(0);
+	});
+});

--- a/packages/coding-agent/test/capability/rule-buckets.test.ts
+++ b/packages/coding-agent/test/capability/rule-buckets.test.ts
@@ -18,6 +18,7 @@ function makeRule(partial: Partial<Rule>): Rule {
 		condition: partial.condition,
 		astCondition: partial.astCondition,
 		scope: partial.scope,
+		agents: partial.agents,
 		interruptMode: partial.interruptMode,
 		_source: partial._source ?? source("native"),
 	};
@@ -127,5 +128,95 @@ describe("bucketRules", () => {
 		expect(mgr.checkDelta("contains FORBIDDEN token", { source: "text" })).toEqual([]);
 		expect(alwaysApplyRules.map(r => r.name)).toEqual([]);
 		expect(rulebookRules.map(r => r.name)).toEqual(["no-foo"]);
+	});
+});
+
+describe("bucketRules agent scoping", () => {
+	it("scopes a scout-only TTSR rule to scout and leaves it inert for main", () => {
+		const rule = makeRule({
+			name: "scout-only",
+			condition: ["FORBIDDEN"],
+			description: "blocks foo",
+			agents: ["scout"],
+		});
+
+		const scoutMgr = new TtsrManager();
+		const { rulebookRules: scoutRulebook, alwaysApplyRules: scoutAlways } = bucketRules([rule], scoutMgr, {
+			agentName: "scout",
+		});
+		expect(scoutMgr.checkDelta("contains FORBIDDEN token", { source: "text" }).map(r => r.name)).toEqual([
+			"scout-only",
+		]);
+		expect(scoutRulebook).toHaveLength(0);
+		expect(scoutAlways).toHaveLength(0);
+
+		const mainMgr = new TtsrManager();
+		const { rulebookRules: mainRulebook, alwaysApplyRules: mainAlways } = bucketRules([rule], mainMgr, {
+			agentName: "main",
+		});
+		expect(mainMgr.hasRules()).toBe(false);
+		expect(mainRulebook).toHaveLength(0);
+		expect(mainAlways).toHaveLength(0);
+	});
+
+	it("`main` in the agents list includes the top-level session", () => {
+		const rule = makeRule({ name: "main-only", condition: ["FORBIDDEN"], agents: ["main"] });
+		const mgr = new TtsrManager();
+		bucketRules([rule], mgr, { agentName: "main" });
+		expect(mgr.checkDelta("contains FORBIDDEN token", { source: "text" }).map(r => r.name)).toEqual(["main-only"]);
+	});
+
+	it("matches a glob pattern against the agent name", () => {
+		const rule = makeRule({ name: "foreman-only", condition: ["FORBIDDEN"], agents: ["foreman-*"] });
+
+		const alphaMgr = new TtsrManager();
+		bucketRules([rule], alphaMgr, { agentName: "foreman-alpha" });
+		expect(alphaMgr.checkDelta("contains FORBIDDEN token", { source: "text" }).map(r => r.name)).toEqual([
+			"foreman-only",
+		]);
+
+		const foremanMgr = new TtsrManager();
+		bucketRules([rule], foremanMgr, { agentName: "foreman" });
+		expect(foremanMgr.hasRules()).toBe(false);
+	});
+
+	it("a rule with no `agents` field applies to every agent", () => {
+		const rule = makeRule({ name: "everyone", condition: ["FORBIDDEN"] });
+
+		const mainMgr = new TtsrManager();
+		bucketRules([rule], mainMgr, { agentName: "main" });
+		expect(mainMgr.hasRules()).toBe(true);
+
+		const scoutMgr = new TtsrManager();
+		bucketRules([rule], scoutMgr, { agentName: "scout" });
+		expect(scoutMgr.hasRules()).toBe(true);
+	});
+
+	it("gates the always-apply bucket too", () => {
+		const rule = makeRule({ name: "scout-always", alwaysApply: true, agents: ["scout"] });
+
+		const scoutMgr = new TtsrManager();
+		const { alwaysApplyRules: scoutAlways } = bucketRules([rule], scoutMgr, { agentName: "scout" });
+		expect(scoutAlways.map(r => r.name)).toEqual(["scout-always"]);
+
+		const mainMgr = new TtsrManager();
+		const { alwaysApplyRules: mainAlways } = bucketRules([rule], mainMgr, { agentName: "main" });
+		expect(mainAlways).toHaveLength(0);
+	});
+
+	it("bucketRules with no agentName keeps a scoped rule (list/scan contract)", () => {
+		const rule = makeRule({ name: "scout-only", condition: ["FORBIDDEN"], agents: ["scout"] });
+		const mgr = new TtsrManager();
+		const { rulebookRules, alwaysApplyRules } = bucketRules([rule], mgr);
+		expect(mgr.checkDelta("contains FORBIDDEN token", { source: "text" }).map(r => r.name)).toEqual(["scout-only"]);
+		expect(rulebookRules).toHaveLength(0);
+		expect(alwaysApplyRules).toHaveLength(0);
+	});
+
+	it("trims and lowercases agentName before matching a glob pattern", () => {
+		const rule = makeRule({ name: "scout-only", condition: ["FORBIDDEN"], agents: ["scout"] });
+		const mgr = new TtsrManager();
+		bucketRules([rule], mgr, { agentName: " Scout " });
+		expect(mgr.checkDelta("contains FORBIDDEN token", { source: "text" }).map(r => r.name)).toEqual(["scout-only"]);
 	});
 });

--- a/packages/coding-agent/test/cli/ttsr-cli.test.ts
+++ b/packages/coding-agent/test/cli/ttsr-cli.test.ts
@@ -70,8 +70,7 @@ async function run(args: TtsrCommandArgs): Promise<void> {
 async function writeTempRule(
 	condition: string,
 	scope: string[],
-	astCondition?: string,
-	agents?: string[],
+	options: { astCondition?: string; agents?: string[] } = {},
 ): Promise<string> {
 	// Stable basename "test-rule.md" so buildRuleFromMarkdown derives name
 	// "test-rule" — assertions rely on it. Each call uses a unique parent dir
@@ -80,9 +79,9 @@ async function writeTempRule(
 	fs.mkdirSync(dir, { recursive: true });
 	const tmp = path.join(dir, "test-rule.md");
 	const fm: string[] = [`description: test rule`, `condition: "${condition.replace(/"/g, '\\"')}"`];
-	if (astCondition) fm.push(`astCondition: "${astCondition.replace(/"/g, '\\"')}"`);
+	if (options.astCondition) fm.push(`astCondition: "${options.astCondition.replace(/"/g, '\\"')}"`);
 	fm.push(`scope: [${scope.map(s => `"${s}"`).join(", ")}]`);
-	if (agents) fm.push(`agents: [${agents.map(a => `"${a}"`).join(", ")}]`);
+	if (options.agents) fm.push(`agents: [${options.agents.map(a => `"${a}"`).join(", ")}]`);
 	await Bun.write(tmp, `---\n${fm.join("\n")}\n---\nbody\n`);
 	return tmp;
 }
@@ -174,11 +173,9 @@ describe("omp ttsr", () => {
 
 		it("astCondition matches via checkAstSnapshot with a tool + .ts path", async () => {
 			captureStreams();
-			const rulePath = await writeTempRule(
-				"never-matches-regex-zzz",
-				["tool:edit(*.ts)"],
-				"($X as { $$$BODY }).$PROP",
-			);
+			const rulePath = await writeTempRule("never-matches-regex-zzz", ["tool:edit(*.ts)"], {
+				astCondition: "($X as { $$$BODY }).$PROP",
+			});
 			const test: TtsrTestArgs = {
 				rule: rulePath,
 				source: "tool",
@@ -236,7 +233,7 @@ describe("omp ttsr", () => {
 
 		it("triggers for a matching --agent and rejects for a non-matching one", async () => {
 			captureStreams();
-			const rulePath = await writeTempRule(": any", ["tool:edit(*.ts)"], undefined, ["scout"]);
+			const rulePath = await writeTempRule(": any", ["tool:edit(*.ts)"], { agents: ["scout"] });
 			const test: TtsrTestArgs = {
 				rule: rulePath,
 				source: "tool",
@@ -248,9 +245,10 @@ describe("omp ttsr", () => {
 			expect(stdout).toContain("Triggered");
 			expect(stdout).toContain("agents: scout");
 
-			await expect(runTtsrCommand({ action: "test", test: { ...test, agent: "main" } })).rejects.toThrow(
-				/scoped to agents/,
-			);
+			captureStreams();
+			await run({ action: "test", test: { ...test, agent: "main" }, json: true });
+			const report = JSON.parse(stdout);
+			expect(report.error).toMatch(/scoped to agents/);
 		});
 	});
 
@@ -497,11 +495,9 @@ describe("omp ttsr", () => {
 			setProjectDir(projectDir);
 
 			await Bun.write(path.join(projectDir, "src/foo.ts"), "const y = (x as\n{ z }).z;");
-			const rulePath = await writeTempRule(
-				"never-matches-regex-zzz",
-				["tool:edit(src/**/*.ts)"],
-				"($X as { $$$BODY }).$PROP",
-			);
+			const rulePath = await writeTempRule("never-matches-regex-zzz", ["tool:edit(src/**/*.ts)"], {
+				astCondition: "($X as { $$$BODY }).$PROP",
+			});
 			const scan: TtsrScanArgs = {
 				directory: "src",
 				rule: rulePath,

--- a/packages/coding-agent/test/cli/ttsr-cli.test.ts
+++ b/packages/coding-agent/test/cli/ttsr-cli.test.ts
@@ -67,7 +67,12 @@ async function run(args: TtsrCommandArgs): Promise<void> {
 	}
 }
 
-async function writeTempRule(condition: string, scope: string[], astCondition?: string): Promise<string> {
+async function writeTempRule(
+	condition: string,
+	scope: string[],
+	astCondition?: string,
+	agents?: string[],
+): Promise<string> {
 	// Stable basename "test-rule.md" so buildRuleFromMarkdown derives name
 	// "test-rule" — assertions rely on it. Each call uses a unique parent dir
 	// to avoid collisions across tests.
@@ -77,6 +82,7 @@ async function writeTempRule(condition: string, scope: string[], astCondition?: 
 	const fm: string[] = [`description: test rule`, `condition: "${condition.replace(/"/g, '\\"')}"`];
 	if (astCondition) fm.push(`astCondition: "${astCondition.replace(/"/g, '\\"')}"`);
 	fm.push(`scope: [${scope.map(s => `"${s}"`).join(", ")}]`);
+	if (agents) fm.push(`agents: [${agents.map(a => `"${a}"`).join(", ")}]`);
 	await Bun.write(tmp, `---\n${fm.join("\n")}\n---\nbody\n`);
 	return tmp;
 }
@@ -226,6 +232,25 @@ describe("omp ttsr", () => {
 			await run({ action: "test", test: { rule: rulePath, file: snippetPath, source: "text" }, json: true });
 			const report = JSON.parse(stdout);
 			expect(report.inferenceNote).toBeUndefined();
+		});
+
+		it("triggers for a matching --agent and rejects for a non-matching one", async () => {
+			captureStreams();
+			const rulePath = await writeTempRule(": any", ["tool:edit(*.ts)"], undefined, ["scout"]);
+			const test: TtsrTestArgs = {
+				rule: rulePath,
+				source: "tool",
+				filePath: "src/foo.ts",
+				snippet: "const x: any = 1",
+				agent: "scout",
+			};
+			await run({ action: "test", test });
+			expect(stdout).toContain("Triggered");
+			expect(stdout).toContain("agents: scout");
+
+			await expect(runTtsrCommand({ action: "test", test: { ...test, agent: "main" } })).rejects.toThrow(
+				/scoped to agents/,
+			);
 		});
 	});
 

--- a/packages/coding-agent/test/discovery/agent-fields.test.ts
+++ b/packages/coding-agent/test/discovery/agent-fields.test.ts
@@ -4,6 +4,11 @@ import { parseAgentFields } from "@oh-my-pi/pi-coding-agent/discovery/helpers";
 import { AUTO_THINKING } from "@oh-my-pi/pi-coding-agent/thinking";
 
 describe("parseAgentFields", () => {
+	test("rejects the reserved `main` agent definition name", () => {
+		expect(parseAgentFields({ name: "main", description: "desc" })).toBeNull();
+		expect(parseAgentFields({ name: " Main ", description: "desc" })).toBeNull();
+	});
+
 	test("parses blocking from boolean frontmatter", () => {
 		const fields = parseAgentFields({
 			name: "reviewer",

--- a/packages/coding-agent/test/discovery/agent-fields.test.ts
+++ b/packages/coding-agent/test/discovery/agent-fields.test.ts
@@ -4,9 +4,11 @@ import { parseAgentFields } from "@oh-my-pi/pi-coding-agent/discovery/helpers";
 import { AUTO_THINKING } from "@oh-my-pi/pi-coding-agent/thinking";
 
 describe("parseAgentFields", () => {
-	test("rejects the reserved `main` agent definition name", () => {
+	test("rejects the reserved `main` and `sub` agent definition names", () => {
 		expect(parseAgentFields({ name: "main", description: "desc" })).toBeNull();
 		expect(parseAgentFields({ name: " Main ", description: "desc" })).toBeNull();
+		expect(parseAgentFields({ name: "sub", description: "desc" })).toBeNull();
+		expect(parseAgentFields({ name: " Sub ", description: "desc" })).toBeNull();
 	});
 
 	test("parses blocking from boolean frontmatter", () => {

--- a/packages/coding-agent/test/extension-inspector.test.ts
+++ b/packages/coding-agent/test/extension-inspector.test.ts
@@ -717,6 +717,24 @@ describe("rule inspector", () => {
 		expect(text).toContain("asynchronous coordination");
 		expect(text.indexOf("Applies")).toBeLessThan(text.indexOf("asynchronous coordination"));
 	});
+
+	test("does not show '(no apply conditions)' for a rule scoped only by agents", () => {
+		const panel = new InspectorPanel();
+		panel.setExtension({
+			...ruleExtension(),
+			trigger: "manual",
+			description: "Keep the implement subagent inside its plan.",
+			raw: {
+				name: "orchestration",
+				description: "Keep the implement subagent inside its plan.",
+				agents: ["implement"],
+				content: "stay on plan",
+			},
+		});
+		const text = render(panel);
+		expect(text).toContain("agents");
+		expect(text).not.toContain("no apply conditions");
+	});
 });
 
 describe("command inspector", () => {

--- a/packages/coding-agent/test/internal-urls/rule-protocol.test.ts
+++ b/packages/coding-agent/test/internal-urls/rule-protocol.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import type { Rule } from "@oh-my-pi/pi-coding-agent/capability/rule";
+import { resetActiveRulesForTests, setActiveRules } from "@oh-my-pi/pi-coding-agent/capability/rule";
+import type { InternalUrl } from "@oh-my-pi/pi-coding-agent/internal-urls/types";
+import { RuleProtocolHandler } from "@oh-my-pi/pi-coding-agent/internal-urls/rule-protocol";
+
+function makeRule(name: string, content: string): Rule {
+	return {
+		name,
+		path: `/tmp/${name}.md`,
+		content,
+		_source: { provider: "test", providerName: "test", path: `/tmp/${name}.md`, level: "user" },
+	};
+}
+
+function ruleUrl(name: string): InternalUrl {
+	return Object.assign(new URL(`rule://${name}`), { rawHost: name }) as InternalUrl;
+}
+
+describe("RuleProtocolHandler", () => {
+	afterEach(() => {
+		resetActiveRulesForTests();
+	});
+
+	it("resolves a rule scoped only to a subagent that never touched the main session's global snapshot", async () => {
+		// The main session's rule bucketing (setActiveRules) never included this
+		// rule because it is `agents: [scout]`-scoped; only the scout's own
+		// context carries it. A subagent must still be able to read its own
+		// `rule://<name>` even though the process-global snapshot excludes it —
+		// see PR #10624 (persisted-agents/sdk.ts scoping).
+		setActiveRules([makeRule("main-only", "main body")]);
+		const scoutRules = [makeRule("scout-only", "scout body")];
+
+		const resource = await new RuleProtocolHandler().resolve(ruleUrl("scout-only"), { rules: scoutRules });
+		expect(resource.content.trim()).toBe("scout body");
+	});
+
+	it("does not leak a subagent's scoped rule into a caller resolving without that context", async () => {
+		setActiveRules([makeRule("main-only", "main body")]);
+
+		await expect(new RuleProtocolHandler().resolve(ruleUrl("scout-only"))).rejects.toThrow("Unknown rule");
+	});
+
+	it("falls back to the process-global snapshot when no context rules are supplied", async () => {
+		setActiveRules([makeRule("legacy", "legacy body")]);
+
+		const resource = await new RuleProtocolHandler().resolve(ruleUrl("legacy"));
+		expect(resource.content.trim()).toBe("legacy body");
+	});
+
+	it("completes against the caller's scoped rule set instead of the global snapshot", async () => {
+		setActiveRules([makeRule("main-only", "main body")]);
+		const scoutRules = [makeRule("scout-only", "scout body")];
+
+		const completions = await new RuleProtocolHandler().complete(undefined, { rules: scoutRules });
+		expect(completions.map(c => c.value)).toEqual(["scout-only"]);
+	});
+});

--- a/packages/coding-agent/test/task/persisted-revive.test.ts
+++ b/packages/coding-agent/test/task/persisted-revive.test.ts
@@ -315,6 +315,29 @@ describe("persisted subagent revival", () => {
 		expect(capturedOptions?.agentName).toBe(ref.displayName);
 		expect(capturedOptions?.agentName).not.toBe("main");
 	});
+	it("treats a persisted legacy 'sub'-named subagent as scoped to the ref display name, not the shared sub sentinel", async () => {
+		const cwd = makeTempDir("@pi-revive-agent-name-legacy-sub-");
+		const sessionFile = await createPersistedSession(cwd, undefined, undefined, undefined, { agent: "sub" });
+		let capturedOptions: CreateAgentSessionOptions | undefined;
+		vi.spyOn(sdkModule, "createAgentSession").mockImplementation(async options => {
+			capturedOptions = options;
+			return { session: createRevivedSession([]).session } as CreateAgentSessionResult;
+		});
+
+		const ref = createRef(sessionFile);
+		const reviver = await createFactory(cwd)(ref);
+		if (!reviver) throw new Error("Expected a persisted reviver");
+		await reviver(ref);
+
+		// A parked transcript from before "sub" was reserved as a definition
+		// name could still carry `init.agent === "sub"`. That must not resolve
+		// to the shared subagent-fallback sentinel here, or `agents: [sub]`
+		// rules meant for that specific legacy definition would load into every
+		// unnamed subagent session.
+		expect(capturedOptions?.agentName).toBe(ref.displayName);
+		expect(capturedOptions?.agentName).not.toBe("sub");
+	});
+
 
 	it("restores the persisted per-agent advisor opt-in on cold revival", async () => {
 		const cwd = makeTempDir("@pi-advisor-revive-");

--- a/packages/coding-agent/test/task/persisted-revive.test.ts
+++ b/packages/coding-agent/test/task/persisted-revive.test.ts
@@ -294,6 +294,28 @@ describe("persisted subagent revival", () => {
 
 		expect(capturedOptions?.agentName).toBe(ref.displayName);
 	});
+	it("treats a persisted legacy 'main'-named subagent as scoped to the ref display name, not the top-level sentinel", async () => {
+		const cwd = makeTempDir("@pi-revive-agent-name-legacy-main-");
+		const sessionFile = await createPersistedSession(cwd, undefined, undefined, undefined, { agent: "main" });
+		let capturedOptions: CreateAgentSessionOptions | undefined;
+		vi.spyOn(sdkModule, "createAgentSession").mockImplementation(async options => {
+			capturedOptions = options;
+			return { session: createRevivedSession([]).session } as CreateAgentSessionResult;
+		});
+
+		const ref = createRef(sessionFile);
+		const reviver = await createFactory(cwd)(ref);
+		if (!reviver) throw new Error("Expected a persisted reviver");
+		await reviver(ref);
+
+		// A parked transcript from before "main" was reserved as a definition
+		// name could still carry `init.agent === "main"`. That must not resolve
+		// to the top-level sentinel here, or `agents: [main]` rules documented
+		// as top-level-only would load into this subagent.
+		expect(capturedOptions?.agentName).toBe(ref.displayName);
+		expect(capturedOptions?.agentName).not.toBe("main");
+	});
+
 	it("restores the persisted per-agent advisor opt-in on cold revival", async () => {
 		const cwd = makeTempDir("@pi-advisor-revive-");
 		const advisedFile = await createPersistedSession(cwd, undefined, undefined, "moonshot/k3");

--- a/packages/coding-agent/test/task/persisted-revive.test.ts
+++ b/packages/coding-agent/test/task/persisted-revive.test.ts
@@ -69,7 +69,7 @@ async function createPersistedSession(
 	restrictToolNames?: boolean,
 	modelRole?: string,
 	advisor?: string,
-	contract?: { tools?: string[]; readOnly?: boolean },
+	contract?: { tools?: string[]; readOnly?: boolean; agent?: string },
 ): Promise<string> {
 	const manager = SessionManager.create(cwd, path.join(cwd, "sessions"));
 	const sessionFile = manager.getSessionFile();
@@ -83,6 +83,7 @@ async function createPersistedSession(
 		resolvedModel: modelRole ? "anthropic/claude-sonnet-4-5" : undefined,
 		advisor,
 		readOnly: contract?.readOnly,
+		agent: contract?.agent,
 	});
 	manager.appendMessage({
 		role: "assistant",
@@ -255,6 +256,43 @@ describe("persisted subagent revival", () => {
 		expect(capturedOptions?.enableLsp).toBe(true);
 		expect(capturedOptions?.mcpManager).toBe(hostileMcp);
 		expect(capturedOptions?.customTools?.map(tool => tool.name)).toEqual(["mcp__server_read"]);
+	});
+
+	it("restores the persisted agent definition name on cold revival so agent-scoped rules keep matching", async () => {
+		const cwd = makeTempDir("@pi-revive-agent-name-");
+		const sessionFile = await createPersistedSession(cwd, undefined, undefined, undefined, { agent: "scout" });
+		let capturedOptions: CreateAgentSessionOptions | undefined;
+		vi.spyOn(sdkModule, "createAgentSession").mockImplementation(async options => {
+			capturedOptions = options;
+			return { session: createRevivedSession([]).session } as CreateAgentSessionResult;
+		});
+
+		const ref = createRef(sessionFile);
+		const reviver = await createFactory(cwd)(ref);
+		if (!reviver) throw new Error("Expected a persisted reviver");
+		await reviver(ref);
+
+		// `ref.displayName` is the registry's generated label ("Persisted
+		// Restricted") for a cold-revived ref, not the durable agent definition
+		// name. `agents: [scout]` rule scoping must key on the latter.
+		expect(capturedOptions?.agentName).toBe("scout");
+	});
+
+	it("falls back to the ref display name reviving a legacy session file without a persisted agent name", async () => {
+		const cwd = makeTempDir("@pi-revive-agent-name-legacy-");
+		const sessionFile = await createPersistedSession(cwd);
+		let capturedOptions: CreateAgentSessionOptions | undefined;
+		vi.spyOn(sdkModule, "createAgentSession").mockImplementation(async options => {
+			capturedOptions = options;
+			return { session: createRevivedSession([]).session } as CreateAgentSessionResult;
+		});
+
+		const ref = createRef(sessionFile);
+		const reviver = await createFactory(cwd)(ref);
+		if (!reviver) throw new Error("Expected a persisted reviver");
+		await reviver(ref);
+
+		expect(capturedOptions?.agentName).toBe(ref.displayName);
 	});
 	it("restores the persisted per-agent advisor opt-in on cold revival", async () => {
 		const cwd = makeTempDir("@pi-advisor-revive-");

--- a/packages/coding-agent/test/tools/bash-skill-urls.test.ts
+++ b/packages/coding-agent/test/tools/bash-skill-urls.test.ts
@@ -204,6 +204,37 @@ describe("expandInternalUrls", () => {
 		expect(observedPathOnly).toBe(true);
 	});
 
+	it("forwards the session's scoped rules to the router when expanding rule:// URLs", async () => {
+		const sourcePath = "/tmp/rules/scout-only.md";
+		const scopedRules = [
+			{
+				name: "scout-only",
+				path: sourcePath,
+				content: "stay on plan",
+				_source: { provider: "test", providerName: "test", path: sourcePath, level: "user" as const },
+			},
+		];
+		let observedRules: unknown;
+		const router = {
+			canHandle: (input: string) => input === "rule://scout-only",
+			resolve: async (input: string, context?: ResolveContext) => {
+				observedRules = context?.rules;
+				return {
+					url: input,
+					content: "",
+					contentType: "text/plain" as const,
+					sourcePath,
+					immutable: true,
+				};
+			},
+		};
+
+		await expect(
+			expandInternalUrls("cat rule://scout-only", { skills: [], internalRouter: router, rules: scopedRules }),
+		).resolves.toBe(`cat ${shellEscape(sourcePath)}`);
+		expect(observedRules).toBe(scopedRules);
+	});
+
 	it("expands quoted non-skill URLs and shell-escapes quotes in paths", async () => {
 		const router = createInternalRouter({
 			"artifact://7": { sourcePath: "/tmp/artifacts/with'quote.log" },


### PR DESCRIPTION
## What
TTSR rule frontmatter gains `agents: string[]`, which accepts glob patterns over the agent definition name. When present, the rule is only applied to sessions whose agent matches. If `agents` is not provided, the current behaviour is maintained.

Filtering happens at bucket time in `sdk.ts` (per-session `TtsrManager`), so unmatched rules are never compiled and there is zero per-delta cost. `AgentSessionConfig` now carries the agent definition name so the session knows what it is. `omp ttsr list/test` show the field; `ttsr test --agent <name>` evaluates as a given agent.

## Why
I'm working on an extension that uses TTSR rules as "guardrails" to keep subagents that manage a specific phase of a process from overstepping their responsibilities or expanding scope. Since rules currently apply to every session, strict rules that are intended to restrict only a specific subagent's behavior are triggered in sessions they shouldn't apply to.

For example, I may have a rule that matches on text patterns that imply the agent might be deviating from a plan in order to work around an issue (with conditions like "instead of" or "as an alternative"), and redirects it to instead yield to the main agent to rework the plan. A rule like this would only be intended for an "implement" subagent, but right now it also fires if the main agent produces text that matches the conditions...making it impossible for the main agent to do it's job.

## Testing
- Created a temporary rule in `.agents/rules` with `agents: ["scout"]` and a condition that matched "BANANABOAT" in text. The rule fired inside a spawned scout, and did not fire in the main agent.
- Updated the temporary rule with `agents: ["scout", "main"]`. The rule fired in both the spawned scout and the main agent.
- Removed `agents` from the rule's frontmatter. The rule fired in both the spawned scout and the main agent.
- Confirmed that `omp ttsr list` shows an `agents` column, and `omp ttsr test --agent main` / `--agent scout` give the expected results.
- Tests: rule parsing normalisation; bucket-time inclusion/exclusion.
- Rules doc updated; CHANGELOG under Unreleased/Added.

---
- [X] `bun check` passes
- [X] Tested locally
- [X] CHANGELOG updated