### PR TITLE
fix(coding-agent): deliver structured output for background task spawns

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -119,6 +119,10 @@
 ### Removed
 
 - Removed the bundled `designer` subagent and `designer` model role; `modelRoles.designer` and `@designer` are no longer built in.
+### Fixed
+
+- Background (non-blocking) `task` spawns with an `outputSchema` now deliver their parsed structured output and expose it at `agent://<id>`.
+
 ## [18.1.5] - 2026-09-03
 
 ### Added
@@ -148,9 +152,6 @@
 ### Removed
 
 - Removed the bundled `designer` subagent and `designer` model role; `modelRoles.designer` and `@designer` are no longer built in.
-### Fixed
-
-- Background (non-blocking) `task` spawns with an `outputSchema` now deliver their parsed structured output and expose it at `agent://<id>`.
 
 ## [18.1.3] - 2026-09-02
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -11,6 +11,7 @@
 - A detached background `task` that fails without valid structured output now keeps its temporary artifacts until eviction instead of deleting them immediately, so the failed agent stays interrogable via `agent://<id>`/`history://<id>`.
 - Fixed a stale `<id>.json` structured-output sidecar surviving when the serialized payload was `undefined`.
 - `AsyncJobManager.dispose()` no longer sleeps out the full retained-artifacts grace period on shutdown.
+- Retained-artifacts cleanup for a background task now gives up waiting on a hung delivery sink after a bounded timeout, instead of waiting on it forever and leaking the retained temp directory for the process lifetime.
 
 ## [18.1.7] - 2026-09-03
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -119,6 +119,38 @@
 ### Removed
 
 - Removed the bundled `designer` subagent and `designer` model role; `modelRoles.designer` and `@designer` are no longer built in.
+## [18.1.5] - 2026-09-03
+
+### Added
+
+- Added Abliteration provider support to `/login`, including `ABLITERATION_API_KEY` configuration and help text.
+- Added clone-first Git worktree support that carries over ignored build artifacts when creating worktrees, with a configurable `worktree.clone` setting and fallback to a standard checkout. This is supported by `github pr_checkout`, `omp worktree add`, and `git worktree add` commands entered through the Bash tool.
+- Added the `omp worktree add` command with Git-compatible branch, detach, path, and commit options.
+- Added `/wt` (alias `/worktree`) to create a linked worktree with uncommitted changes and move the current session into it while leaving the original checkout untouched.
+
+### Changed
+
+- Foreign user-level configuration sources (`~/.cursor`, `~/.codex`, `~/.claude`, `~/.gemini`, `~/.config/opencode`, `~/.codeium/windsurf`) are now opt-in via `enabledProviders`, while project-level configurations in CWD and `.agents` continue to load by default.
+- Split subagent isolation configuration into `task.isolation.enabled` and `isolation.backend`; existing `task.isolation.mode` settings are migrated automatically.
+- Updated the built-in `smol` and `slow` model priority chains to favor newer recommended models and remove older model generations.
+- Improved unsupported-model error messages by removing retry guidance that does not apply.
+
+### Fixed
+
+- Fixed automatic title generation so `--no-title` also prevents todo-initialization title refreshes, while automatic titles retain the selected OAuth account without sharing foreground request identity.
+- Fixed provider errors so they wrap to the terminal width and remain readable in the transcript and pinned error banner, with long messages available through the expansion hint.
+- Fixed Gemini malformed function-call turns so textual tool-call output is rejected conversationally and the session can continue instead of stopping with a pinned error.
+- Fixed auto-compaction recovery getting stuck in repeated retries when models return empty length-limited responses; it now stops with an actionable error.
+- Fixed MCP servers failing to reconnect after transient startup handshake timeouts.
+- Fixed programs supervised by `hub start` hanging when querying terminal capabilities.
+- Fixed large pastes followed immediately by Enter so the input is submitted with the pasted content instead of being left in the large-paste menu.
+
+### Removed
+
+- Removed the bundled `designer` subagent and `designer` model role; `modelRoles.designer` and `@designer` are no longer built in.
+### Fixed
+
+- Background (non-blocking) `task` spawns with an `outputSchema` now deliver their parsed structured output and expose it at `agent://<id>`.
 
 ## [18.1.3] - 2026-09-02
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Preserved the full parsed payload of a schema-invalid background task result: it is now persisted to the `<id>.json` sidecar and advertised via `agent://<id>` alongside the inline preview, instead of only showing a size-capped, unrecoverable inline JSON block.
+- Delayed retained-artifact cleanup for background task spawns by a grace period after delivery settles, so the model's next turn has time to read the advertised `agent://` pointer before the backing files are removed.
+- Background (non-blocking) `task` spawns with an `outputSchema` now deliver their parsed structured output and expose it at `agent://<id>`.
+- `hub wait`/`jobs` no longer inlines a truncated (and potentially invalid) JSON block for schema-valid background job results; it now points to `agent://<id>` instead, matching the async-result follow-up.
+- A detached background `task` that fails without valid structured output now keeps its temporary artifacts until eviction instead of deleting them immediately, so the failed agent stays interrogable via `agent://<id>`/`history://<id>`.
+- Fixed a stale `<id>.json` structured-output sidecar surviving when the serialized payload was `undefined`.
+- `AsyncJobManager.dispose()` no longer sleeps out the full retained-artifacts grace period on shutdown.
+
 ## [18.1.7] - 2026-09-03
 
 ### Breaking Changes
@@ -33,10 +43,6 @@
 - Fixed bracketed hashline edit targets being reported as undefined to extension path allowlists.
 - Fixed MCP tools discovered during startup disappearing after plan-mode approval or when leaving default-on plan mode.
 - Fixed ACP clients receiving invalid file locations or updates for released terminals, preventing invalid worktree scans and terminal errors on Windows.
-### Fixed
-
-- Preserved the full parsed payload of a schema-invalid background task result: it is now persisted to the `<id>.json` sidecar and advertised via `agent://<id>` alongside the inline preview, instead of only showing a size-capped, unrecoverable inline JSON block.
-- Delayed retained-artifact cleanup for background task spawns by a grace period after delivery settles, so the model's next turn has time to read the advertised `agent://` pointer before the backing files are removed.
 
 ## [18.1.6] - 2026-09-03
 
@@ -93,39 +99,6 @@
 - Fixed messages typed while an edit or write tool was streaming from discarding the completed tool call and triggering unnecessary regeneration.
 - Fixed self-hosted Firecrawl URLs with origin-only base URLs from gaining an extra slash.
 - Fixed omp commit auto-staging from including macOS Unicode-normalization duplicates or files ignored by nested .gitignore rules.
-
-## [18.1.5] - 2026-09-03
-
-### Added
-
-- Added Abliteration provider support to `/login`, including `ABLITERATION_API_KEY` configuration and help text.
-- Added clone-first Git worktree support that carries over ignored build artifacts when creating worktrees, with a configurable `worktree.clone` setting and fallback to a standard checkout. This is supported by `github pr_checkout`, `omp worktree add`, and `git worktree add` commands entered through the Bash tool.
-- Added the `omp worktree add` command with Git-compatible branch, detach, path, and commit options.
-- Added `/wt` (alias `/worktree`) to create a linked worktree with uncommitted changes and move the current session into it while leaving the original checkout untouched.
-
-### Changed
-
-- Foreign user-level configuration sources (`~/.cursor`, `~/.codex`, `~/.claude`, `~/.gemini`, `~/.config/opencode`, `~/.codeium/windsurf`) are now opt-in via `enabledProviders`, while project-level configurations in CWD and `.agents` continue to load by default.
-- Split subagent isolation configuration into `task.isolation.enabled` and `isolation.backend`; existing `task.isolation.mode` settings are migrated automatically.
-- Updated the built-in `smol` and `slow` model priority chains to favor newer recommended models and remove older model generations.
-- Improved unsupported-model error messages by removing retry guidance that does not apply.
-
-### Fixed
-
-- Fixed automatic title generation so `--no-title` also prevents todo-initialization title refreshes, while automatic titles retain the selected OAuth account without sharing foreground request identity.
-- Fixed provider errors so they wrap to the terminal width and remain readable in the transcript and pinned error banner, with long messages available through the expansion hint.
-- Fixed Gemini malformed function-call turns so textual tool-call output is rejected conversationally and the session can continue instead of stopping with a pinned error.
-- Fixed auto-compaction recovery getting stuck in repeated retries when models return empty length-limited responses; it now stops with an actionable error.
-- Fixed MCP servers failing to reconnect after transient startup handshake timeouts.
-- Fixed programs supervised by `hub start` hanging when querying terminal capabilities.
-- Fixed large pastes followed immediately by Enter so the input is submitted with the pasted content instead of being left in the large-paste menu.
-
-### Removed
-
-- Removed the bundled `designer` subagent and `designer` model role; `modelRoles.designer` and `@designer` are no longer built in.
-### Fixed
-
-- Background (non-blocking) `task` spawns with an `outputSchema` now deliver their parsed structured output and expose it at `agent://<id>`.
 
 ## [18.1.5] - 2026-09-03
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -33,6 +33,10 @@
 - Fixed bracketed hashline edit targets being reported as undefined to extension path allowlists.
 - Fixed MCP tools discovered during startup disappearing after plan-mode approval or when leaving default-on plan mode.
 - Fixed ACP clients receiving invalid file locations or updates for released terminals, preventing invalid worktree scans and terminal errors on Windows.
+### Fixed
+
+- Preserved the full parsed payload of a schema-invalid background task result: it is now persisted to the `<id>.json` sidecar and advertised via `agent://<id>` alongside the inline preview, instead of only showing a size-capped, unrecoverable inline JSON block.
+- Delayed retained-artifact cleanup for background task spawns by a grace period after delivery settles, so the model's next turn has time to read the advertised `agent://` pointer before the backing files are removed.
 
 ## [18.1.6] - 2026-09-03
 

--- a/packages/coding-agent/src/async/job-manager.ts
+++ b/packages/coding-agent/src/async/job-manager.ts
@@ -727,20 +727,50 @@ export class AsyncJobManager {
 	}
 
 	/**
-	 * Fire a retained temporary artifacts cleanup exactly once. Errors are
-	 * logged, not thrown — a failed disposal must not block job eviction or
-	 * manager teardown.
+	 * Fire a retained temporary artifacts cleanup exactly once, deferred
+	 * until this job's `async-result` delivery has settled (delivered,
+	 * dead-lettered, or given up retrying). Job-row eviction happens on its
+	 * own timer independent of delivery — a still-streaming owner session
+	 * can leave a delivery in flight (its sink awaits
+	 * `yieldQueue.enqueueWithReceipt()`) well past the retention window, and
+	 * deleting the retained directory before that receipt commits would
+	 * advertise an `agent://` URL whose backing files are already gone.
+	 * Errors are logged, not thrown — a failed disposal must not block job
+	 * eviction or manager teardown.
 	 */
 	#runRetainedArtifactsCleanup(job: AsyncJob): void {
 		const cleanup = job.retainedArtifactsCleanup;
 		if (!cleanup) return;
 		job.retainedArtifactsCleanup = undefined;
-		void cleanup().catch(error => {
-			logger.warn("Async job retained artifacts cleanup failed", {
-				jobId: job.id,
-				error: error instanceof Error ? error.message : String(error),
+		const jobId = job.id;
+		void this.#waitForJobDeliverySettled(jobId)
+			.then(cleanup)
+			.catch(error => {
+				logger.warn("Async job retained artifacts cleanup failed", {
+					jobId,
+					error: error instanceof Error ? error.message : String(error),
+				});
 			});
-		});
+	}
+
+	/**
+	 * Resolve once no delivery for `jobId` is queued or in flight. Loops
+	 * because a failed in-flight attempt may requeue itself for retry;
+	 * terminates once the delivery succeeds, is dead-lettered (no live
+	 * sink), or stops retrying (job already evicted from `#jobs`).
+	 */
+	async #waitForJobDeliverySettled(jobId: string): Promise<void> {
+		for (;;) {
+			const inFlight = this.#inFlightDeliveries.find(delivery => delivery.jobId === jobId);
+			if (inFlight) {
+				await inFlight.promise?.catch(() => {});
+				continue;
+			}
+			const queued = this.#deliveries.find(delivery => delivery.jobId === jobId);
+			if (!queued) return;
+			this.#ensureDeliveryLoop();
+			await this.#waitForDeliveryQueueChange(Math.max(50, queued.nextAttemptAt - Date.now()));
+		}
 	}
 
 	#evictJob(jobId: string): boolean {

--- a/packages/coding-agent/src/async/job-manager.ts
+++ b/packages/coding-agent/src/async/job-manager.ts
@@ -5,6 +5,15 @@ const DELIVERY_RETRY_BASE_MS = 500;
 const DELIVERY_RETRY_MAX_MS = 30_000;
 const DELIVERY_RETRY_JITTER_MS = 200;
 const DEFAULT_RETENTION_MS = 5 * 60 * 1000;
+/**
+ * Extra delay after an `async-result` delivery settles (its `ASIDE_MESSAGE_COMMIT`
+ * hook fires, resolving `enqueueWithReceipt()`) before retained artifacts are
+ * removed. The commit hook fires when the follow-up is inserted into the
+ * transcript, not after the model's next provider call has actually read it —
+ * this window gives that round trip time to complete before the backing
+ * `<id>.md`/`.json` files disappear out from under an advertised `agent://` URL.
+ */
+const RETAINED_ARTIFACTS_CLEANUP_GRACE_MS = 60_000;
 const DEFAULT_MAX_RUNNING_JOBS = 15;
 /** Abort reason used only when the owning session shuts down the entire manager. */
 export const ASYNC_JOB_MANAGER_SHUTDOWN_REASON = Symbol("AsyncJobManager shutdown");
@@ -117,6 +126,13 @@ export interface AsyncJobManagerOptions {
 	onJobComplete?: AsyncJobDeliverySink;
 	maxRunningJobs?: number;
 	retentionMs?: number;
+	/**
+	 * Delay after a job's `async-result` delivery settles before its retained
+	 * artifacts are removed (see {@link RETAINED_ARTIFACTS_CLEANUP_GRACE_MS}).
+	 * Defaults to that constant; tests override to `0` to assert cleanup
+	 * without a real-time wait.
+	 */
+	retainedArtifactsCleanupGraceMs?: number;
 }
 
 interface AsyncJobDelivery {
@@ -201,6 +217,7 @@ export class AsyncJobManager {
 	readonly #onJobComplete: AsyncJobManagerOptions["onJobComplete"];
 	readonly #maxRunningJobs: number;
 	readonly #retentionMs: number;
+	readonly #retainedArtifactsCleanupGraceMs: number;
 	#deliveryLoop: Promise<void> | undefined;
 	#deliveryQueueChanged = Promise.withResolvers<void>();
 	#disposed = false;
@@ -219,6 +236,10 @@ export class AsyncJobManager {
 		this.#onJobComplete = options.onJobComplete;
 		this.#maxRunningJobs = Math.max(1, Math.floor(options.maxRunningJobs ?? DEFAULT_MAX_RUNNING_JOBS));
 		this.#retentionMs = Math.max(0, Math.floor(options.retentionMs ?? DEFAULT_RETENTION_MS));
+		this.#retainedArtifactsCleanupGraceMs = Math.max(
+			0,
+			Math.floor(options.retainedArtifactsCleanupGraceMs ?? RETAINED_ARTIFACTS_CLEANUP_GRACE_MS),
+		);
 	}
 
 	/** True when the running-job count has reached the configured cap. */
@@ -729,12 +750,20 @@ export class AsyncJobManager {
 	/**
 	 * Fire a retained temporary artifacts cleanup exactly once, deferred
 	 * until this job's `async-result` delivery has settled (delivered,
-	 * dead-lettered, or given up retrying). Job-row eviction happens on its
-	 * own timer independent of delivery — a still-streaming owner session
-	 * can leave a delivery in flight (its sink awaits
-	 * `yieldQueue.enqueueWithReceipt()`) well past the retention window, and
-	 * deleting the retained directory before that receipt commits would
-	 * advertise an `agent://` URL whose backing files are already gone.
+	 * dead-lettered, or given up retrying) plus a grace period. Job-row
+	 * eviction happens on its own timer independent of delivery — a still-
+	 * streaming owner session can leave a delivery in flight (its sink
+	 * awaits `yieldQueue.enqueueWithReceipt()`) well past the retention
+	 * window, and deleting the retained directory before that receipt
+	 * settles would advertise an `agent://` URL whose backing files are
+	 * already gone.
+	 * The receipt itself resolves at `ASIDE_MESSAGE_COMMIT` — when the
+	 * follow-up is inserted into the transcript, but *before* the next
+	 * provider call that actually shows it to the model (agent-loop fires
+	 * the commit hook, then starts the call). Running cleanup immediately
+	 * on settlement would delete the artifacts before the model's very next
+	 * turn has any chance to read the pointer via a tool call, so a grace
+	 * period covers that round trip.
 	 * Errors are logged, not thrown — a failed disposal must not block job
 	 * eviction or manager teardown.
 	 */
@@ -744,6 +773,9 @@ export class AsyncJobManager {
 		job.retainedArtifactsCleanup = undefined;
 		const jobId = job.id;
 		void this.#waitForJobDeliverySettled(jobId)
+			.then(() =>
+				this.#retainedArtifactsCleanupGraceMs > 0 ? Bun.sleep(this.#retainedArtifactsCleanupGraceMs) : undefined,
+			)
 			.then(cleanup)
 			.catch(error => {
 				logger.warn("Async job retained artifacts cleanup failed", {

--- a/packages/coding-agent/src/async/job-manager.ts
+++ b/packages/coding-agent/src/async/job-manager.ts
@@ -1,4 +1,5 @@
 import { logger } from "@oh-my-pi/pi-utils";
+import type { StructuredSubagentOutput } from "../task/types";
 
 const DELIVERY_RETRY_BASE_MS = 500;
 const DELIVERY_RETRY_MAX_MS = 30_000;
@@ -32,6 +33,26 @@ interface PollEscalationState {
 /** Kind of work a managed job runs; drives job-row badges and delivery labels. */
 export type AsyncJobType = "bash" | "task" | "eval";
 
+/** Settled job-body payload: delivery text plus its parsed structured output. */
+export interface AsyncJobRunResult {
+	text: string;
+	structured?: StructuredSubagentOutput;
+}
+
+/**
+ * Job-body failure that still carries the run's structured output, so a
+ * strict-mode schema violation fails the job without dropping the parsed
+ * (invalid) payload.
+ */
+export class AsyncJobError extends Error {
+	constructor(
+		message: string,
+		readonly structured?: StructuredSubagentOutput,
+	) {
+		super(message);
+	}
+}
+
 export interface AsyncJob {
 	id: string;
 	type: AsyncJobType;
@@ -42,6 +63,13 @@ export interface AsyncJob {
 	promise: Promise<void>;
 	resultText?: string;
 	errorText?: string;
+	/**
+	 * Parsed structured completion for a job whose work selected an output
+	 * schema. Set from the body's {@link AsyncJobRunResult} or from an
+	 * {@link AsyncJobError}. The job row is the carrier — every delivery
+	 * attempt, redelivery, and `hub` snapshot reads it from here.
+	 */
+	structured?: StructuredSubagentOutput;
 	/** Latest tool-render details reported by the running job. */
 	latestDetails?: Record<string, unknown>;
 	/**
@@ -195,7 +223,7 @@ export class AsyncJobManager {
 			reportProgress: (text: string, details?: Record<string, unknown>) => Promise<void>;
 			/** Clear the queued flag once the job actually starts executing. */
 			markRunning: () => void;
-		}) => Promise<string>,
+		}) => Promise<string | AsyncJobRunResult>,
 		options?: AsyncJobRegisterOptions,
 	): string {
 		if (this.#disposed) {
@@ -246,7 +274,7 @@ export class AsyncJobManager {
 		};
 		job.promise = (async () => {
 			try {
-				const text = await run({
+				const outcome = await run({
 					jobId: id,
 					signal: abortController.signal,
 					reportProgress,
@@ -254,6 +282,9 @@ export class AsyncJobManager {
 						job.queued = false;
 					},
 				});
+				const text = typeof outcome === "string" ? outcome : outcome.text;
+				const structured = typeof outcome === "string" ? undefined : outcome.structured;
+				if (structured) job.structured = structured;
 				if (job.status === "cancelled") {
 					job.resultText = text;
 					this.#scheduleEviction(id);
@@ -264,6 +295,7 @@ export class AsyncJobManager {
 				this.#enqueueDelivery(id, text);
 				this.#scheduleEviction(id);
 			} catch (error) {
+				if (error instanceof AsyncJobError && error.structured) job.structured = error.structured;
 				if (job.status === "cancelled") {
 					job.errorText = error instanceof Error ? error.message : String(error);
 					this.#scheduleEviction(id);

--- a/packages/coding-agent/src/async/job-manager.ts
+++ b/packages/coding-agent/src/async/job-manager.ts
@@ -135,7 +135,7 @@ interface AsyncJobDelivery {
 	 * retrying) — without it, a recovered delivery would silently drop
 	 * `structured` even though `text` survives on the delivery itself.
 	 */
-	jobSnapshot?: Pick<AsyncJob, "type" | "status" | "startTime" | "label" | "structured">;
+	jobSnapshot?: Pick<AsyncJob, "type" | "status" | "startTime" | "label" | "structured" | "agentId">;
 }
 
 export interface AsyncJobDeliveryState {
@@ -881,6 +881,7 @@ export class AsyncJobManager {
 						startTime: job.startTime,
 						label: job.label,
 						structured: job.structured,
+						agentId: job.agentId,
 					}
 				: undefined,
 		});
@@ -1009,6 +1010,7 @@ export class AsyncJobManager {
 			promise: Promise.resolve(),
 			resultText: delivery.text,
 			structured: snapshot.structured,
+			agentId: snapshot.agentId,
 		};
 	}
 

--- a/packages/coding-agent/src/async/job-manager.ts
+++ b/packages/coding-agent/src/async/job-manager.ts
@@ -118,6 +118,15 @@ interface AsyncJobDelivery {
 	lastError?: string;
 	ownerId?: string;
 	promise?: Promise<void>;
+	/**
+	 * Job-body metadata a sink needs to render the delivered result,
+	 * snapshotted at enqueue time. `#deliverDelivery` falls back to
+	 * reconstructing an `AsyncJob`-shaped record from this when the live job
+	 * row has already been evicted (retention elapsed while delivery kept
+	 * retrying) — without it, a recovered delivery would silently drop
+	 * `structured` even though `text` survives on the delivery itself.
+	 */
+	jobSnapshot?: Pick<AsyncJob, "type" | "status" | "startTime" | "label" | "structured">;
 }
 
 export interface AsyncJobDeliveryState {
@@ -799,12 +808,22 @@ export class AsyncJobManager {
 		if (this.isDeliverySuppressed(jobId)) {
 			return;
 		}
+		const job = this.#jobs.get(jobId);
 		this.#queueDelivery({
 			jobId,
 			text,
 			attempt: 0,
 			nextAttemptAt: Date.now(),
-			ownerId: this.#jobs.get(jobId)?.ownerId,
+			ownerId: job?.ownerId,
+			jobSnapshot: job
+				? {
+						type: job.type,
+						status: job.status,
+						startTime: job.startTime,
+						label: job.label,
+						structured: job.structured,
+					}
+				: undefined,
 		});
 		this.#ensureDeliveryLoop();
 	}
@@ -881,7 +900,11 @@ export class AsyncJobManager {
 		const promise = (async () => {
 			this.#inFlightDeliveries.push(delivery);
 			try {
-				await sink(delivery.jobId, delivery.text, this.#jobs.get(delivery.jobId));
+				await sink(
+					delivery.jobId,
+					delivery.text,
+					this.#jobs.get(delivery.jobId) ?? this.#reconstructEvictedJob(delivery),
+				);
 				this.#consumeJobResult(delivery.jobId);
 			} catch (error) {
 				delivery.attempt += 1;
@@ -904,6 +927,30 @@ export class AsyncJobManager {
 		})();
 		delivery.promise = promise;
 		return promise;
+	}
+
+	/**
+	 * Rebuild a minimal {@link AsyncJob} from a delivery's enqueue-time
+	 * snapshot when the live job row was already evicted by the time this
+	 * delivery attempt runs (retention elapsed while delivery kept retrying).
+	 * Lets the sink still render `type`/`label`/`structured` instead of
+	 * silently losing them, matching what `job.resultText` would have carried
+	 * had the row survived.
+	 */
+	#reconstructEvictedJob(delivery: AsyncJobDelivery): AsyncJob | undefined {
+		const snapshot = delivery.jobSnapshot;
+		if (!snapshot) return undefined;
+		return {
+			id: delivery.jobId,
+			type: snapshot.type,
+			status: snapshot.status,
+			startTime: snapshot.startTime,
+			label: snapshot.label,
+			abortController: new AbortController(),
+			promise: Promise.resolve(),
+			resultText: delivery.text,
+			structured: snapshot.structured,
+		};
 	}
 
 	#queueDelivery(delivery: AsyncJobDelivery): void {

--- a/packages/coding-agent/src/async/job-manager.ts
+++ b/packages/coding-agent/src/async/job-manager.ts
@@ -91,6 +91,15 @@ export interface AsyncJob {
 	 * until the caller invokes `markRunning()` from the run context.
 	 */
 	queued?: boolean;
+	/**
+	 * Disposal closure for a detached spawn's temporary artifacts directory
+	 * that `runStructuredSubagent()` retained past completion (so a
+	 * delayed `agent://<id>` handle in an `async-result` delivery still
+	 * resolves). The manager invokes and clears this exactly once — on
+	 * eviction or manager disposal — so the retained directory does not
+	 * outlive the job row it was kept alive for.
+	 */
+	retainedArtifactsCleanup?: () => Promise<void>;
 }
 
 /** Delivery callback for a settled job's result text. */
@@ -671,6 +680,7 @@ export class AsyncJobManager {
 		const jobsSettled = await this.#waitForAllUntil(deadline);
 		const drained = await this.drainDeliveries({ timeoutMs: Math.max(deadline - Date.now(), 0) });
 		this.#clearEvictionTimers();
+		for (const job of this.#jobs.values()) this.#runRetainedArtifactsCleanup(job);
 		this.#jobs.clear();
 		this.#deliveries.length = 0;
 		this.#notifyDeliveryQueueChanged();
@@ -716,12 +726,31 @@ export class AsyncJobManager {
 		return candidate;
 	}
 
+	/**
+	 * Fire a retained temporary artifacts cleanup exactly once. Errors are
+	 * logged, not thrown — a failed disposal must not block job eviction or
+	 * manager teardown.
+	 */
+	#runRetainedArtifactsCleanup(job: AsyncJob): void {
+		const cleanup = job.retainedArtifactsCleanup;
+		if (!cleanup) return;
+		job.retainedArtifactsCleanup = undefined;
+		void cleanup().catch(error => {
+			logger.warn("Async job retained artifacts cleanup failed", {
+				jobId: job.id,
+				error: error instanceof Error ? error.message : String(error),
+			});
+		});
+	}
+
 	#evictJob(jobId: string): boolean {
 		clearTimeout(this.#evictionTimers.get(jobId));
 		this.#evictionTimers.delete(jobId);
 		this.#suppressedDeliveries.delete(jobId);
 		this.#watchedJobs.delete(jobId);
 		this.#consumedJobResults.delete(jobId);
+		const job = this.#jobs.get(jobId);
+		if (job) this.#runRetainedArtifactsCleanup(job);
 		return this.#jobs.delete(jobId);
 	}
 

--- a/packages/coding-agent/src/async/job-manager.ts
+++ b/packages/coding-agent/src/async/job-manager.ts
@@ -14,6 +14,16 @@ const DEFAULT_RETENTION_MS = 5 * 60 * 1000;
  * `<id>.md`/`.json` files disappear out from under an advertised `agent://` URL.
  */
 const RETAINED_ARTIFACTS_CLEANUP_GRACE_MS = 60_000;
+/**
+ * Upper bound on how long retained-artifacts cleanup waits for a hung
+ * delivery sink before giving up and running cleanup anyway. Without this,
+ * a sink that never settles (e.g. a yield-queue receipt whose owning
+ * session is gone) would leak the temp directory for the process lifetime
+ * (PR #10625 review). Matches {@link DEFAULT_RETENTION_MS}: by the time a
+ * job would have been evicted anyway, there is no realistic path left for
+ * the model to still read the advertised `agent://` pointer.
+ */
+const RETAINED_ARTIFACTS_CLEANUP_MAX_WAIT_MS = DEFAULT_RETENTION_MS;
 const DEFAULT_MAX_RUNNING_JOBS = 15;
 /** Abort reason used only when the owning session shuts down the entire manager. */
 export const ASYNC_JOB_MANAGER_SHUTDOWN_REASON = Symbol("AsyncJobManager shutdown");
@@ -133,6 +143,14 @@ export interface AsyncJobManagerOptions {
 	 * without a real-time wait.
 	 */
 	retainedArtifactsCleanupGraceMs?: number;
+	/**
+	 * Upper bound on how long retained-artifacts cleanup waits for a job's
+	 * delivery to settle before giving up and running cleanup anyway (see
+	 * {@link RETAINED_ARTIFACTS_CLEANUP_MAX_WAIT_MS}). Defaults to that
+	 * constant; tests override to a small value to assert the bound without
+	 * a real-time wait.
+	 */
+	retainedArtifactsCleanupMaxWaitMs?: number;
 }
 
 interface AsyncJobDelivery {
@@ -218,6 +236,7 @@ export class AsyncJobManager {
 	readonly #maxRunningJobs: number;
 	readonly #retentionMs: number;
 	readonly #retainedArtifactsCleanupGraceMs: number;
+	readonly #retainedArtifactsCleanupMaxWaitMs: number;
 	#deliveryLoop: Promise<void> | undefined;
 	#deliveryQueueChanged = Promise.withResolvers<void>();
 	#disposed = false;
@@ -239,6 +258,10 @@ export class AsyncJobManager {
 		this.#retainedArtifactsCleanupGraceMs = Math.max(
 			0,
 			Math.floor(options.retainedArtifactsCleanupGraceMs ?? RETAINED_ARTIFACTS_CLEANUP_GRACE_MS),
+		);
+		this.#retainedArtifactsCleanupMaxWaitMs = Math.max(
+			0,
+			Math.floor(options.retainedArtifactsCleanupMaxWaitMs ?? RETAINED_ARTIFACTS_CLEANUP_MAX_WAIT_MS),
 		);
 	}
 
@@ -778,7 +801,7 @@ export class AsyncJobManager {
 		job.retainedArtifactsCleanup = undefined;
 		const jobId = job.id;
 		const bypassGrace = options?.bypassGrace === true;
-		void this.#waitForJobDeliverySettled(jobId)
+		void this.#waitForJobDeliverySettledBounded(jobId)
 			.then(() =>
 				!bypassGrace && this.#retainedArtifactsCleanupGraceMs > 0
 					? Bun.sleep(this.#retainedArtifactsCleanupGraceMs)
@@ -791,6 +814,38 @@ export class AsyncJobManager {
 					error: error instanceof Error ? error.message : String(error),
 				});
 			});
+	}
+
+	/**
+	 * Bounded variant of {@link #waitForJobDeliverySettled}: gives up and
+	 * resolves after {@link #retainedArtifactsCleanupMaxWaitMs} even if the
+	 * delivery sink never settles (e.g. a yield-queue receipt whose owning
+	 * session is gone) so a hung sink cannot leak the retained temp
+	 * directory for the process lifetime (PR #10625 review). The unbounded
+	 * wait keeps running in the background after the bound trips; it is
+	 * harmless once orphaned since cleanup no longer depends on it.
+	 */
+	async #waitForJobDeliverySettledBounded(jobId: string): Promise<void> {
+		const timedOut = Promise.withResolvers<true>();
+		const timer = setTimeout(() => timedOut.resolve(true), this.#retainedArtifactsCleanupMaxWaitMs);
+		timer.unref();
+		try {
+			const timedOutFirst = await Promise.race([
+				this.#waitForJobDeliverySettled(jobId).then(() => false as const),
+				timedOut.promise,
+			]);
+			if (timedOutFirst) {
+				logger.warn(
+					"Async job delivery did not settle before the retained artifacts cleanup bound; running cleanup anyway",
+					{
+						jobId,
+						maxWaitMs: this.#retainedArtifactsCleanupMaxWaitMs,
+					},
+				);
+			}
+		} finally {
+			clearTimeout(timer);
+		}
 	}
 
 	/**

--- a/packages/coding-agent/src/async/job-manager.ts
+++ b/packages/coding-agent/src/async/job-manager.ts
@@ -701,7 +701,12 @@ export class AsyncJobManager {
 		const jobsSettled = await this.#waitForAllUntil(deadline);
 		const drained = await this.drainDeliveries({ timeoutMs: Math.max(deadline - Date.now(), 0) });
 		this.#clearEvictionTimers();
-		for (const job of this.#jobs.values()) this.#runRetainedArtifactsCleanup(job);
+		// Bypass the grace-period sleep: dispose has already drained/cancelled
+		// deliveries above, so there is nothing left for the model to read via
+		// `agent://<id>` — sleeping the retention window here would only leak
+		// temp dirs for up to `retainedArtifactsCleanupGraceMs` (or past
+		// process exit, since dispose does not await these cleanups).
+		for (const job of this.#jobs.values()) this.#runRetainedArtifactsCleanup(job, { bypassGrace: true });
 		this.#jobs.clear();
 		this.#deliveries.length = 0;
 		this.#notifyDeliveryQueueChanged();
@@ -767,14 +772,17 @@ export class AsyncJobManager {
 	 * Errors are logged, not thrown — a failed disposal must not block job
 	 * eviction or manager teardown.
 	 */
-	#runRetainedArtifactsCleanup(job: AsyncJob): void {
+	#runRetainedArtifactsCleanup(job: AsyncJob, options?: { bypassGrace?: boolean }): void {
 		const cleanup = job.retainedArtifactsCleanup;
 		if (!cleanup) return;
 		job.retainedArtifactsCleanup = undefined;
 		const jobId = job.id;
+		const bypassGrace = options?.bypassGrace === true;
 		void this.#waitForJobDeliverySettled(jobId)
 			.then(() =>
-				this.#retainedArtifactsCleanupGraceMs > 0 ? Bun.sleep(this.#retainedArtifactsCleanupGraceMs) : undefined,
+				!bypassGrace && this.#retainedArtifactsCleanupGraceMs > 0
+					? Bun.sleep(this.#retainedArtifactsCleanupGraceMs)
+					: undefined,
 			)
 			.then(cleanup)
 			.catch(error => {

--- a/packages/coding-agent/src/internal-urls/agent-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/agent-protocol.ts
@@ -104,13 +104,26 @@ export class AgentProtocolHandler implements ProtocolHandler {
 		// Extraction applies only when the URL did NOT resolve to a nested output
 		// (a slash that named a real child is a hierarchy hop, not a jq path).
 		const extract = hasQueryExtraction || (hasPathExtraction && scan.matchedId !== nestedId);
+		let extractedFrom = scan.foundPath;
 		if (extract) {
 			let jsonValue: unknown;
-			try {
-				jsonValue = JSON.parse(rawContent);
-			} catch (err) {
-				const message = err instanceof Error ? err.message : String(err);
-				throw new Error(`Output ${scan.matchedId} is not valid JSON: ${message}`);
+			let parsed = false;
+			if (scan.jsonPath) {
+				try {
+					jsonValue = JSON.parse(await Bun.file(scan.jsonPath).text());
+					extractedFrom = scan.jsonPath;
+					parsed = true;
+				} catch {
+					// Corrupt or partially written sidecar: fall back to <id>.md.
+				}
+			}
+			if (!parsed) {
+				try {
+					jsonValue = JSON.parse(rawContent);
+				} catch (err) {
+					const message = err instanceof Error ? err.message : String(err);
+					throw new Error(`Output ${scan.matchedId} is not valid JSON: ${message}`);
+				}
 			}
 
 			const query = hasQueryExtraction ? queryParam! : pathToQuery(urlPath);
@@ -133,6 +146,7 @@ export class AgentProtocolHandler implements ProtocolHandler {
 				content = JSON.stringify(jsonValue, null, 2);
 				contentType = "application/json";
 			}
+			if (parsed) notes.push(`Source: ${path.basename(extractedFrom!)}`);
 		}
 
 		return {
@@ -140,7 +154,7 @@ export class AgentProtocolHandler implements ProtocolHandler {
 			content,
 			contentType,
 			size: Buffer.byteLength(content, "utf-8"),
-			sourcePath: scan.foundPath,
+			sourcePath: extractedFrom,
 			notes,
 		};
 	}
@@ -154,11 +168,18 @@ export class AgentProtocolHandler implements ProtocolHandler {
 	async #findOutput(
 		dirs: string[],
 		candidateIds: string[],
-	): Promise<{ foundPath?: string; matchedId?: string; anyDirExists: boolean; availableIds: Set<string> }> {
+	): Promise<{
+		foundPath?: string;
+		matchedId?: string;
+		jsonPath?: string;
+		anyDirExists: boolean;
+		availableIds: Set<string>;
+	}> {
 		// Build a full id→path map across every registered dir before picking, so
 		// candidate priority is global: a nested id in a deeper dir must win over
 		// the base id even when the base id's dir is scanned first.
 		const byId = new Map<string, string>();
+		const jsonById = new Map<string, string>();
 		let anyDirExists = false;
 		for (const dir of dirs) {
 			let files: string[];
@@ -170,6 +191,11 @@ export class AgentProtocolHandler implements ProtocolHandler {
 			}
 			anyDirExists = true;
 			for (const f of files) {
+				if (f.endsWith(".json")) {
+					const jsonId = f.slice(0, -5);
+					if (!jsonById.has(jsonId)) jsonById.set(jsonId, path.join(dir, f));
+					continue;
+				}
 				if (!f.endsWith(".md")) continue;
 				const id = f.slice(0, -3);
 				if (!byId.has(id)) byId.set(id, path.join(dir, f));
@@ -178,7 +204,19 @@ export class AgentProtocolHandler implements ProtocolHandler {
 		for (const id of candidateIds) {
 			const foundPath = byId.get(id);
 			if (foundPath) {
-				return { foundPath, matchedId: id, anyDirExists, availableIds: new Set(byId.keys()) };
+				// Pair the sidecar with the SAME dir as the matched `<id>.md`: two
+				// coexisting roots can both hold `Worker`, and a first-hit sidecar
+				// from the other root would answer with a foreign agent's payload
+				// (see the `preferredDir` comment above and caller-root-ab.test.ts).
+				const sidecar = jsonById.get(id);
+				const jsonPath = sidecar && path.dirname(sidecar) === path.dirname(foundPath) ? sidecar : undefined;
+				return {
+					foundPath,
+					matchedId: id,
+					jsonPath,
+					anyDirExists,
+					availableIds: new Set(byId.keys()),
+				};
 			}
 		}
 		return { anyDirExists, availableIds: new Set(byId.keys()) };

--- a/packages/coding-agent/src/prompts/tools/async-result.md
+++ b/packages/coding-agent/src/prompts/tools/async-result.md
@@ -5,7 +5,7 @@
 {{/if}}{{#each jobs}}{{#if @root.multiple}}── Job {{this.jobId}}{{#if this.label}} ({{this.label}}){{/if}} ──
 {{/if}}{{this.result}}{{#if this.schemaStatus}}
 
-Structured output: schema {{this.schemaStatus}}{{#if this.schemaError}}: {{this.schemaError}}{{/if}}{{#if this.schemaValid}}; full payload at agent://{{this.jobId}}, fields via agent://{{this.jobId}}/<field>{{/if}}{{#if this.structuredJson}}; payload inline only:
+Structured output: schema {{this.schemaStatus}}{{#if this.schemaError}}: {{this.schemaError}}{{/if}}{{#if this.schemaValid}}; full payload at agent://{{this.jobId}}, fields via agent://{{this.jobId}}?q=.<field>{{/if}}{{#if this.structuredJson}}; payload inline only:
 ```json
 {{this.structuredJson}}
 ```{{/if}}{{/if}}{{#unless @last}}

--- a/packages/coding-agent/src/prompts/tools/async-result.md
+++ b/packages/coding-agent/src/prompts/tools/async-result.md
@@ -5,9 +5,9 @@
 {{/if}}{{#each jobs}}{{#if @root.multiple}}── Job {{this.jobId}}{{#if this.label}} ({{this.label}}){{/if}} ──
 {{/if}}{{this.result}}{{#if this.schemaStatus}}
 
-Structured output: schema {{this.schemaStatus}}{{#if this.schemaError}}: {{this.schemaError}}{{/if}}{{#if this.schemaValid}}; full payload at agent://{{this.agentUrlId}}, fields via agent://{{this.agentUrlId}}?q=.<field>{{/if}}{{#if this.structuredJson}}; payload inline only:
+Structured output: schema {{this.schemaStatus}}{{#if this.schemaError}}: {{this.schemaError}}{{/if}}{{#if this.hasStructuredData}}; full payload at agent://{{this.agentUrlId}}, fields via agent://{{this.agentUrlId}}?q=.<field>{{/if}}{{#unless this.schemaValid}}{{#if this.structuredJson}}; preview:
 ```json
 {{this.structuredJson}}
-```{{/if}}{{/if}}{{#unless @last}}
+```{{/if}}{{/unless}}{{/if}}{{#unless @last}}
 {{/unless}}{{/each}}
 </system-notice>

--- a/packages/coding-agent/src/prompts/tools/async-result.md
+++ b/packages/coding-agent/src/prompts/tools/async-result.md
@@ -5,7 +5,7 @@
 {{/if}}{{#each jobs}}{{#if @root.multiple}}── Job {{this.jobId}}{{#if this.label}} ({{this.label}}){{/if}} ──
 {{/if}}{{this.result}}{{#if this.schemaStatus}}
 
-Structured output: schema {{this.schemaStatus}}{{#if this.schemaError}}: {{this.schemaError}}{{/if}}{{#if this.schemaValid}}; full payload at agent://{{this.jobId}}, fields via agent://{{this.jobId}}?q=.<field>{{/if}}{{#if this.structuredJson}}; payload inline only:
+Structured output: schema {{this.schemaStatus}}{{#if this.schemaError}}: {{this.schemaError}}{{/if}}{{#if this.schemaValid}}; full payload at agent://{{this.agentUrlId}}, fields via agent://{{this.agentUrlId}}?q=.<field>{{/if}}{{#if this.structuredJson}}; payload inline only:
 ```json
 {{this.structuredJson}}
 ```{{/if}}{{/if}}{{#unless @last}}

--- a/packages/coding-agent/src/prompts/tools/async-result.md
+++ b/packages/coding-agent/src/prompts/tools/async-result.md
@@ -3,6 +3,11 @@
 
 {{else}}Background job {{jobs.[0].jobId}} has completed. Resume your work using the result below.
 {{/if}}{{#each jobs}}{{#if @root.multiple}}── Job {{this.jobId}}{{#if this.label}} ({{this.label}}){{/if}} ──
-{{/if}}{{this.result}}{{#unless @last}}
+{{/if}}{{this.result}}{{#if this.schemaStatus}}
+
+Structured output: schema {{this.schemaStatus}}{{#if this.schemaError}}: {{this.schemaError}}{{/if}}{{#if this.schemaValid}}; full payload at agent://{{this.jobId}}, fields via agent://{{this.jobId}}/<field>{{/if}}{{#if this.structuredJson}}; payload inline only:
+```json
+{{this.structuredJson}}
+```{{/if}}{{/if}}{{#unless @last}}
 {{/unless}}{{/each}}
 </system-notice>

--- a/packages/coding-agent/src/prompts/tools/task.md
+++ b/packages/coding-agent/src/prompts/tools/task.md
@@ -7,7 +7,7 @@ Agents marked BLOCKING run inline — results return in this call; non-blocking 
 # Async Job Contract
 - Results auto-deliver. A settled `hub jobs`/`hub wait` snapshot is the delivery; no duplicate `async-result` follows.
 - Job IDs are process-local and expire roughly five minutes after settlement. Afterward, use the agent ID with `hub send`, `agent://<id>`, or `history://<id>`.
-- With `outputSchema`, a schema-valid result's payload is served at `agent://<id>` (fields via `agent://<id>/<field>`); a schema-violating (invalid) result delivers its parsed payload inline only, in the auto-delivered follow-up.
+- With `outputSchema`, a schema-valid result's payload is served at `agent://<id>` (fields via `agent://<id>?q=.<field>`); a schema-violating (invalid) result delivers its parsed payload inline only, in the auto-delivered follow-up.
 - `completed` means successful yield/job exit, not artifact acceptance. Verify claimed changes.
 {{/if}}
 

--- a/packages/coding-agent/src/prompts/tools/task.md
+++ b/packages/coding-agent/src/prompts/tools/task.md
@@ -7,6 +7,7 @@ Agents marked BLOCKING run inline — results return in this call; non-blocking 
 # Async Job Contract
 - Results auto-deliver. A settled `hub jobs`/`hub wait` snapshot is the delivery; no duplicate `async-result` follows.
 - Job IDs are process-local and expire roughly five minutes after settlement. Afterward, use the agent ID with `hub send`, `agent://<id>`, or `history://<id>`.
+- With `outputSchema`, a schema-valid result's payload is served at `agent://<id>` (fields via `agent://<id>/<field>`); a schema-violating (invalid) result delivers its parsed payload inline only, in the auto-delivered follow-up.
 - `completed` means successful yield/job exit, not artifact acceptance. Verify claimed changes.
 {{/if}}
 

--- a/packages/coding-agent/src/prompts/tools/task.md
+++ b/packages/coding-agent/src/prompts/tools/task.md
@@ -7,7 +7,7 @@ Agents marked BLOCKING run inline — results return in this call; non-blocking 
 # Async Job Contract
 - Results auto-deliver. A settled `hub jobs`/`hub wait` snapshot is the delivery; no duplicate `async-result` follows.
 - Job IDs are process-local and expire roughly five minutes after settlement. Afterward, use the agent ID with `hub send`, `agent://<id>`, or `history://<id>`.
-- With `outputSchema`, a schema-valid result's payload is served at `agent://<id>` (fields via `agent://<id>?q=.<field>`); a schema-violating (invalid) result delivers its parsed payload inline only, in the auto-delivered follow-up.
+- With `outputSchema`, a result's parsed payload — when present — is served at `agent://<id>` (fields via `agent://<id>?q=.<field>`) regardless of validity; a schema-violating (invalid) result also previews the payload inline in the auto-delivered follow-up.
 - `completed` means successful yield/job exit, not artifact acceptance. Verify claimed changes.
 {{/if}}
 

--- a/packages/coding-agent/src/session/async-job-delivery.ts
+++ b/packages/coding-agent/src/session/async-job-delivery.ts
@@ -78,6 +78,13 @@ export function buildAsyncResultBatchMessage(entries: AsyncResultEntry[]): Custo
 		const structuredJson = structured && structured.status !== "valid" ? renderStructuredJson(structured) : undefined;
 		return {
 			jobId: entry.jobId,
+			// The job manager disambiguates a requested job id when it collides
+			// with another live job (e.g. a task job reusing a vibe turn's job
+			// id), suffixing `jobId` — but the task's artifacts are still
+			// written under its own agent id (`AsyncJob.agentId`). Build the
+			// advertised `agent://` URL from that, or the delivery would point
+			// at an id with no backing `<id>.md`/`.json` on disk.
+			agentUrlId: entry.job?.agentId ?? entry.jobId,
 			result: entry.result,
 			type: entry.job?.type,
 			label: entry.job?.label,

--- a/packages/coding-agent/src/session/async-job-delivery.ts
+++ b/packages/coding-agent/src/session/async-job-delivery.ts
@@ -46,7 +46,8 @@ type AsyncResultJobDetails = {
 	type?: AsyncJobType;
 	label?: string;
 	durationMs?: number;
-	schema?: { status: StructuredSubagentOutput["status"]; error?: string };
+	/** Full structured payload (source/mode/status/data/error), when the job used an output schema. */
+	schema?: StructuredSubagentOutput;
 };
 
 export type AsyncResultDetails = {
@@ -94,7 +95,7 @@ export function buildAsyncResultBatchMessage(entries: AsyncResultEntry[]): Custo
 			type: job.type,
 			label: job.label,
 			durationMs: job.durationMs,
-			...(job.structured ? { schema: { status: job.structured.status, error: job.structured.error } } : {}),
+			...(job.structured ? { schema: job.structured } : {}),
 		})),
 	};
 	return {

--- a/packages/coding-agent/src/session/async-job-delivery.ts
+++ b/packages/coding-agent/src/session/async-job-delivery.ts
@@ -75,6 +75,7 @@ export function buildAsyncResultBatchMessage(entries: AsyncResultEntry[]): Custo
 	if (entries.length === 0) return null;
 	const jobs = entries.map(entry => {
 		const structured = entry.job?.structured;
+		const hasStructuredData = structured ? Object.hasOwn(structured, "data") : false;
 		const structuredJson = structured && structured.status !== "valid" ? renderStructuredJson(structured) : undefined;
 		return {
 			jobId: entry.jobId,
@@ -91,6 +92,7 @@ export function buildAsyncResultBatchMessage(entries: AsyncResultEntry[]): Custo
 			durationMs: entry.durationMs,
 			structured,
 			structuredJson,
+			hasStructuredData,
 			schemaStatus: structured?.status,
 			schemaError: structured?.error,
 			schemaValid: structured?.status === "valid",

--- a/packages/coding-agent/src/session/async-job-delivery.ts
+++ b/packages/coding-agent/src/session/async-job-delivery.ts
@@ -11,7 +11,9 @@
 import { prompt } from "@oh-my-pi/pi-utils";
 import type { AsyncJob, AsyncJobType } from "../async";
 import asyncResultTemplate from "../prompts/tools/async-result.md" with { type: "text" };
+import type { StructuredSubagentOutput } from "../task/types";
 import type { CustomMessage } from "./messages";
+import { truncateMiddle } from "./streaming-output";
 
 /**
  * `customType` of the injected async-result follow-up message. The task
@@ -44,27 +46,55 @@ type AsyncResultJobDetails = {
 	type?: AsyncJobType;
 	label?: string;
 	durationMs?: number;
+	schema?: { status: StructuredSubagentOutput["status"]; error?: string };
 };
 
 export type AsyncResultDetails = {
 	jobs: AsyncResultJobDetails[];
 };
 
+/**
+ * Compact, size-capped JSON block for the delivery text, used only for
+ * schema-invalid/error results (valid results point to `agent://<jobId>`
+ * instead, since the sidecar's `<output>` block already carries the full
+ * JSON — no need to duplicate it here).
+ */
+export function renderStructuredJson(structured: StructuredSubagentOutput): string | undefined {
+	if (!Object.hasOwn(structured, "data")) return undefined;
+	let serialized: string;
+	try {
+		serialized = JSON.stringify(structured.data, null, 2) ?? "null";
+	} catch {
+		return undefined;
+	}
+	return truncateMiddle(serialized, { maxBytes: ASYNC_PREVIEW_MAX_CHARS }).content;
+}
+
 export function buildAsyncResultBatchMessage(entries: AsyncResultEntry[]): CustomMessage<AsyncResultDetails> | null {
 	if (entries.length === 0) return null;
-	const jobs = entries.map(entry => ({
-		jobId: entry.jobId,
-		result: entry.result,
-		type: entry.job?.type,
-		label: entry.job?.label,
-		durationMs: entry.durationMs,
-	}));
+	const jobs = entries.map(entry => {
+		const structured = entry.job?.structured;
+		const structuredJson = structured && structured.status !== "valid" ? renderStructuredJson(structured) : undefined;
+		return {
+			jobId: entry.jobId,
+			result: entry.result,
+			type: entry.job?.type,
+			label: entry.job?.label,
+			durationMs: entry.durationMs,
+			structured,
+			structuredJson,
+			schemaStatus: structured?.status,
+			schemaError: structured?.error,
+			schemaValid: structured?.status === "valid",
+		};
+	});
 	const details: AsyncResultDetails = {
 		jobs: jobs.map(job => ({
 			jobId: job.jobId,
 			type: job.type,
 			label: job.label,
 			durationMs: job.durationMs,
+			...(job.structured ? { schema: { status: job.structured.status, error: job.structured.error } } : {}),
 		})),
 	};
 	return {

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -2311,7 +2311,13 @@ async function finalizeRunResult(args: FinalizeRunArgs): Promise<SingleResult> {
 		if (outputPath && structured && Object.hasOwn(structured, "data")) {
 			try {
 				const serialized = JSON.stringify(structured.data, null, 2);
+				// `structured.data === undefined` (an own "data" key holding
+				// `undefined`) makes JSON.stringify return `undefined` too —
+				// neither a write nor a removal, which would leave a stale
+				// sidecar from an earlier turn answering agent://<id>/<field>
+				// with superseded data (PR #10625 review).
 				if (serialized !== undefined) await writeArtifact(sidecarPath, `${serialized}\n`);
+				else await fs.rm(sidecarPath, { force: true });
 			} catch (error) {
 				logger.warn("Failed to persist subagent structured output sidecar", {
 					agentId: id,

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -4,6 +4,7 @@
  * Runs each subagent on the main thread and forwards AgentEvents for progress tracking.
  */
 
+import * as fs from "node:fs/promises";
 import path from "node:path";
 import type { AgentEvent, AgentIdentity, AgentMessage, AgentTelemetryConfig } from "@oh-my-pi/pi-agent-core";
 import { EventLoopKeepalive, recordHandoff, resolveTelemetry } from "@oh-my-pi/pi-agent-core";
@@ -2287,6 +2288,33 @@ async function finalizeRunResult(args: FinalizeRunArgs): Promise<SingleResult> {
 				path: candidatePath,
 				error: error instanceof Error ? error.message : String(error),
 			});
+		}
+		const structured = finalized.structuredOutput;
+		const sidecarPath = path.join(args.artifactsDir, `${id}.json`);
+		if (outputPath && structured?.status === "valid" && Object.hasOwn(structured, "data")) {
+			try {
+				const serialized = JSON.stringify(structured.data, null, 2);
+				if (serialized !== undefined) await writeArtifact(sidecarPath, `${serialized}\n`);
+			} catch (error) {
+				logger.warn("Failed to persist subagent structured output sidecar", {
+					agentId: id,
+					path: sidecarPath,
+					error: error instanceof Error ? error.message : String(error),
+				});
+			}
+		} else if (outputPath) {
+			// This turn republished <id>.md; a stale sidecar from an earlier
+			// turn would keep answering agent://<id>/<field> with the
+			// superseded payload, so it must not outlive its <id>.md.
+			try {
+				await fs.rm(sidecarPath, { force: true });
+			} catch (error) {
+				logger.warn("Failed to drop stale subagent structured output sidecar", {
+					agentId: id,
+					path: sidecarPath,
+					error: error instanceof Error ? error.message : String(error),
+				});
+			}
 		}
 	}
 

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -2308,7 +2308,7 @@ async function finalizeRunResult(args: FinalizeRunArgs): Promise<SingleResult> {
 		}
 		const structured = finalized.structuredOutput;
 		const sidecarPath = path.join(args.artifactsDir, `${id}.json`);
-		if (outputPath && structured?.status === "valid" && Object.hasOwn(structured, "data")) {
+		if (outputPath && structured && Object.hasOwn(structured, "data")) {
 			try {
 				const serialized = JSON.stringify(structured.data, null, 2);
 				if (serialized !== undefined) await writeArtifact(sidecarPath, `${serialized}\n`);

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -692,6 +692,20 @@ export function finalizeSubprocessOutput(args: FinalizeSubprocessOutputArgs): Fi
 				if (includeStructuredOutput) {
 					structuredOutput = { source, mode, status: "invalid", error: SUBAGENT_WARNING_NULL_YIELD };
 				}
+				// Strict mode promises a schema violation fails the run, not a
+				// warning-decorated success (exitCode 0); build the same
+				// non-zero-exit outcome the validated-data path uses below so
+				// async job delivery marks the job failed instead of completed.
+				if (mode === "strict" && includeStructuredOutput) {
+					const { validator } = buildOutputValidator(outputSchema);
+					const outcome = buildSchemaViolationOutcome(
+						{ message: SUBAGENT_WARNING_NULL_YIELD, missingRequired: [...(validator?.requiredFields ?? [])] },
+						undefined,
+					);
+					rawOutput = outcome.rawOutput;
+					stderr = outcome.stderr;
+					exitCode = outcome.exitCode;
+				}
 			} else {
 				const { validator, error: schemaError, normalized } = buildOutputValidator(outputSchema);
 				const completeData = assembled.rawText ? assembled.data : parseStringifiedJson(assembled.data ?? null);

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -689,6 +689,9 @@ export function finalizeSubprocessOutput(args: FinalizeSubprocessOutputArgs): Fi
 			const assembled = assembleYieldResult(yieldItems, lastAssistantText, arrayValuedLabels(outputSchema));
 			if (!assembled || assembled.missingData) {
 				rawOutput = rawOutput ? `${SUBAGENT_WARNING_NULL_YIELD}\n\n${rawOutput}` : SUBAGENT_WARNING_NULL_YIELD;
+				if (includeStructuredOutput) {
+					structuredOutput = { source, mode, status: "invalid", error: SUBAGENT_WARNING_NULL_YIELD };
+				}
 			} else {
 				const { validator, error: schemaError, normalized } = buildOutputValidator(outputSchema);
 				const completeData = assembled.rawText ? assembled.data : parseStringifiedJson(assembled.data ?? null);
@@ -2301,6 +2304,18 @@ async function finalizeRunResult(args: FinalizeRunArgs): Promise<SingleResult> {
 					path: sidecarPath,
 					error: error instanceof Error ? error.message : String(error),
 				});
+				// A stale sidecar from an earlier turn must not outlive this
+				// turn's <id>.md just because the replacement write failed —
+				// agent://<id>/<field> would keep answering with superseded data.
+				try {
+					await fs.rm(sidecarPath, { force: true });
+				} catch (rmError) {
+					logger.warn("Failed to drop stale subagent structured output sidecar", {
+						agentId: id,
+						path: sidecarPath,
+						error: rmError instanceof Error ? rmError.message : String(rmError),
+					});
+				}
 			}
 		} else if (outputPath) {
 			// This turn republished <id>.md; a stale sidecar from an earlier

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -1458,6 +1458,12 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 				index: spawnIndex,
 				parentToolCallId: toolCallId,
 				detached,
+				// Detached (async) spawns advertise `agent://<id>` handles in the
+				// eventual async-result delivery, which can land well after this
+				// call returns. Without this, a temporary (in-memory session)
+				// artifacts directory is deleted immediately on completion and the
+				// advertised URL 404s by the time delivery happens.
+				retainArtifacts: detached,
 				invokedAt: launchTiming?.invokedAt,
 				acquiredAt: launchTiming?.acquiredAt,
 				...("isolated" in params ? { isolation: { requested: params.isolated } } : {}),

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -1184,6 +1184,15 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 						progress.index,
 						true,
 						{ invokedAt: startedAt, acquiredAt },
+						cleanup => {
+							// Tie the retained temp directory's lifetime to this job
+							// row: the manager runs `cleanup` exactly once, on
+							// eviction or manager disposal, instead of it leaking
+							// for the process lifetime.
+							const job = manager.getJob(agentId);
+							if (job) job.retainedArtifactsCleanup = cleanup;
+							else void cleanup();
+						},
 					);
 					const finalText = result.content.find(part => part.type === "text")?.text ?? "(no output)";
 					const singleResult = result.details?.results[0];
@@ -1415,8 +1424,19 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		spawnIndex = 0,
 		detached = false,
 		launchTiming?: { invokedAt: number; acquiredAt: number },
+		onArtifactsRetained?: (cleanup: () => Promise<void>) => void,
 	): Promise<AgentToolResult<TaskToolDetails>> {
-		return this.#runSpawn(toolCallId, params, signal, onUpdate, preAllocatedId, spawnIndex, detached, launchTiming);
+		return this.#runSpawn(
+			toolCallId,
+			params,
+			signal,
+			onUpdate,
+			preAllocatedId,
+			spawnIndex,
+			detached,
+			launchTiming,
+			onArtifactsRetained,
+		);
 	}
 
 	/** Spawn a fresh subagent and run it to completion. */
@@ -1429,6 +1449,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		spawnIndex = 0,
 		detached = false,
 		launchTiming?: { invokedAt: number; acquiredAt: number },
+		onArtifactsRetained?: (cleanup: () => Promise<void>) => void,
 	): Promise<AgentToolResult<TaskToolDetails>> {
 		const startTime = Date.now();
 		const assignment = (params.task ?? "").trim();
@@ -1464,6 +1485,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 				// artifacts directory is deleted immediately on completion and the
 				// advertised URL 404s by the time delivery happens.
 				retainArtifacts: detached,
+				...(onArtifactsRetained ? { onArtifactsRetained } : {}),
 				invokedAt: launchTiming?.invokedAt,
 				acquiredAt: launchTiming?.acquiredAt,
 				...("isolated" in params ? { isolation: { requested: params.isolated } } : {}),

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -42,7 +42,7 @@ import {
 } from "./types";
 // Import review tools for side effects (registers subagent tool handlers)
 import "../tools/review";
-import type { AsyncJobManager } from "../async";
+import { AsyncJobError, type AsyncJobManager } from "../async";
 import { hasResolvableTranscript } from "../internal-urls/registry-helpers";
 import { AgentRegistry } from "../registry/agent-registry";
 import { type DiscoveryResult, discoverAgents } from "./discovery";
@@ -433,7 +433,7 @@ export function composeSpawnAdvisory(args: {
 }
 
 /** Sentinel for async jobs whose subagent finished with a failing result; progress is already updated. */
-class TaskJobError extends Error {}
+class TaskJobError extends AsyncJobError {}
 
 /**
  * Process-level create-time discovery memo and published reload snapshots,
@@ -1215,11 +1215,12 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 						: `Background task ${agentId} complete.`;
 					await reportProgress(statusText, buildDetails() as unknown as Record<string, unknown>);
 					const deliveryText = `${finalText}${await buildFollowUpHint(singleResult?.aborted === true)}`;
+					const structured = singleResult?.structuredOutput;
 					if (resultFailed) {
 						// Mark the job itself failed; the failed agent stays interrogable.
-						throw new TaskJobError(deliveryText);
+						throw new TaskJobError(deliveryText, structured);
 					}
-					return deliveryText;
+					return structured ? { text: deliveryText, structured } : deliveryText;
 				} catch (error) {
 					if (error instanceof TaskJobError) {
 						throw error;

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -1108,7 +1108,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		return manager.register(
 			"task",
 			agentId,
-			async ({ signal: runSignal, reportProgress, markRunning }) => {
+			async ({ jobId, signal: runSignal, reportProgress, markRunning }) => {
 				const startedAt = Date.now();
 				const semaphore = this.#getSpawnSemaphore();
 				let semaphoreHeld = false;
@@ -1188,8 +1188,11 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 							// Tie the retained temp directory's lifetime to this job
 							// row: the manager runs `cleanup` exactly once, on
 							// eviction or manager disposal, instead of it leaking
-							// for the process lifetime.
-							const job = manager.getJob(agentId);
+							// for the process lifetime. Look up by the resolved
+							// `jobId`, not the requested `agentId` — `register()`
+							// suffixes `jobId` on collision, and looking up the
+							// requested id would hit an unrelated pre-existing row.
+							const job = manager.getJob(jobId);
 							if (job) job.retainedArtifactsCleanup = cleanup;
 							else void cleanup();
 						},

--- a/packages/coding-agent/src/task/structured-subagent.ts
+++ b/packages/coding-agent/src/task/structured-subagent.ts
@@ -689,6 +689,7 @@ export async function runStructuredSubagent(request: StructuredSubagentRequest):
 		);
 	} finally {
 		const shouldRetainArtifacts =
+			request.detached === true ||
 			(request.retainArtifacts && (completedSuccessfully || hasValidStructuredOutput)) ||
 			(policy.isIsolated && (!policy.applyChanges || changesApplied === false || requiresRecoveryArtifacts));
 		const shouldCleanup = lease.temporary && !shouldRetainArtifacts;

--- a/packages/coding-agent/src/task/structured-subagent.ts
+++ b/packages/coding-agent/src/task/structured-subagent.ts
@@ -579,6 +579,7 @@ export async function runStructuredSubagent(request: StructuredSubagentRequest):
 	let mergeSummary = "";
 	let requiresRecoveryArtifacts = false;
 	let completedSuccessfully = false;
+	let hasValidStructuredOutput = false;
 	let deferredCleanup: Promise<void> | undefined;
 	const onSubprocessResult =
 		request.invocationKind === "eval"
@@ -626,6 +627,7 @@ export async function runStructuredSubagent(request: StructuredSubagentRequest):
 			});
 		}
 		attachStructuredOutputMetadata(result, policy.schema);
+		hasValidStructuredOutput = result.structuredOutput?.status === "valid";
 		requiresRecoveryArtifacts =
 			policy.isIsolated &&
 			(result.exitCode !== 0 || result.error !== undefined || result.aborted === true) &&
@@ -687,7 +689,7 @@ export async function runStructuredSubagent(request: StructuredSubagentRequest):
 		);
 	} finally {
 		const shouldRetainArtifacts =
-			(request.retainArtifacts && completedSuccessfully) ||
+			(request.retainArtifacts && (completedSuccessfully || hasValidStructuredOutput)) ||
 			(policy.isIsolated && (!policy.applyChanges || changesApplied === false || requiresRecoveryArtifacts));
 		const shouldCleanup = lease.temporary && !shouldRetainArtifacts;
 		const cleanupArtifacts = async (): Promise<void> => {

--- a/packages/coding-agent/src/task/structured-subagent.ts
+++ b/packages/coding-agent/src/task/structured-subagent.ts
@@ -104,6 +104,14 @@ export interface StructuredSubagentRequest {
 	blockedAgent?: string;
 	/** Preserve a completed temporary artifacts directory for an agent:// handle. */
 	retainArtifacts?: boolean;
+	/**
+	 * Invoked instead of immediate cleanup when a temporary artifacts
+	 * directory is retained (`retainArtifacts`). Callers that outlive this
+	 * call — e.g. an async job body — take ownership of the returned
+	 * disposal closure and MUST eventually run it once the retained handle
+	 * is no longer needed, or the directory leaks for the process lifetime.
+	 */
+	onArtifactsRetained?: (cleanup: () => Promise<void>) => void;
 	/** Task UI agents keep live registry references; eval one-shots normally do not. */
 	keepAlive?: boolean;
 	/** Task subagents share their parent's eval kernel; eval bridge children must not. */
@@ -682,11 +690,11 @@ export async function runStructuredSubagent(request: StructuredSubagentRequest):
 			(request.retainArtifacts && completedSuccessfully) ||
 			(policy.isIsolated && (!policy.applyChanges || changesApplied === false || requiresRecoveryArtifacts));
 		const shouldCleanup = lease.temporary && !shouldRetainArtifacts;
+		const cleanupArtifacts = async (): Promise<void> => {
+			await fs.rm(lease.artifactsDir, { recursive: true, force: true });
+			lease.unregister?.();
+		};
 		if (shouldCleanup) {
-			const cleanupArtifacts = async (): Promise<void> => {
-				await fs.rm(lease.artifactsDir, { recursive: true, force: true });
-				lease.unregister?.();
-			};
 			if (deferredCleanup) {
 				trackLateCleanup(deferredCleanup.then(cleanupArtifacts), {
 					resource: "artifacts",
@@ -695,6 +703,11 @@ export async function runStructuredSubagent(request: StructuredSubagentRequest):
 			} else {
 				await cleanupArtifacts();
 			}
+		} else if (lease.temporary && request.onArtifactsRetained) {
+			// Retained rather than cleaned up now: the caller (e.g. an async
+			// job body) owns disposing it once the retained handle is no
+			// longer needed, instead of it leaking for the process lifetime.
+			request.onArtifactsRetained(cleanupArtifacts);
 		}
 	}
 }

--- a/packages/coding-agent/src/tools/hub/jobs.ts
+++ b/packages/coding-agent/src/tools/hub/jobs.ts
@@ -12,7 +12,9 @@ import { settings } from "../../config/settings";
 import type { RenderResultOptions } from "../../extensibility/custom-tools/types";
 import { shimmerEnabled, shimmerText } from "../../modes/theme/shimmer";
 import type { Theme } from "../../modes/theme/theme";
+import { renderStructuredJson } from "../../session/async-job-delivery";
 import { USER_INTERRUPT_LABEL } from "../../session/messages";
+import type { StructuredSubagentOutput } from "../../task/types";
 import { Ellipsis, Hasher, type RenderCache, renderStatusLine, renderTreeList, truncateToWidth } from "../../tui";
 import type { ToolSession } from "..";
 import {
@@ -152,6 +154,7 @@ interface TrackedJobLike {
 	latestDetails?: Record<string, unknown>;
 	resultText?: string;
 	errorText?: string;
+	structured?: StructuredSubagentOutput;
 }
 
 export function snapshotJobs(session: ToolSession, jobs: TrackedJobLike[]): JobSnapshot[] {
@@ -190,6 +193,7 @@ export function snapshotJobs(session: ToolSession, jobs: TrackedJobLike[]): JobS
 			...(resolvedModel ? { resolvedModel } : {}),
 			...(!resultConsumed && latest.resultText ? { resultText: latest.resultText } : {}),
 			...(!resultConsumed && latest.errorText ? { errorText: latest.errorText } : {}),
+			...(!resultConsumed && latest.structured ? { structured: latest.structured } : {}),
 		};
 	});
 }
@@ -242,6 +246,10 @@ export function buildJobResult(
 			}
 			if (j.errorText) {
 				lines.push(`Error: ${j.errorText}`);
+			}
+			if (j.structured) {
+				const block = renderStructuredJson(j.structured);
+				if (block) lines.push(`Structured output (schema ${j.structured.status}):`, "```json", block, "```");
 			}
 			lines.push("");
 		}

--- a/packages/coding-agent/src/tools/hub/jobs.ts
+++ b/packages/coding-agent/src/tools/hub/jobs.ts
@@ -193,7 +193,9 @@ export function snapshotJobs(session: ToolSession, jobs: TrackedJobLike[]): JobS
 			...(resolvedModel ? { resolvedModel } : {}),
 			...(!resultConsumed && latest.resultText ? { resultText: latest.resultText } : {}),
 			...(!resultConsumed && latest.errorText ? { errorText: latest.errorText } : {}),
-			...(!resultConsumed && latest.structured ? { structured: latest.structured } : {}),
+			...(!resultConsumed && latest.structured
+				? { structured: latest.structured, agentUrlId: current?.agentId ?? latest.id }
+				: {}),
 		};
 	});
 }
@@ -248,8 +250,20 @@ export function buildJobResult(
 				lines.push(`Error: ${j.errorText}`);
 			}
 			if (j.structured) {
-				const block = renderStructuredJson(j.structured);
-				if (block) lines.push(`Structured output (schema ${j.structured.status}):`, "```json", block, "```");
+				const hasData = Object.hasOwn(j.structured, "data");
+				let header = `Structured output: schema ${j.structured.status}`;
+				if (j.structured.error) header += `: ${j.structured.error}`;
+				// Valid results never inline the JSON here — it duplicates the
+				// `<output>` block above (or breaks mid-JSON once truncated at
+				// 4k), which contradicts async-result.md's contract of pointing
+				// to `agent://<id>` instead (PR #10625 review).
+				if (hasData)
+					header += `; full payload at agent://${j.agentUrlId}, fields via agent://${j.agentUrlId}?q=.<field>`;
+				lines.push(header);
+				if (j.structured.status !== "valid") {
+					const block = renderStructuredJson(j.structured);
+					if (block) lines.push("```json", block, "```");
+				}
 			}
 			lines.push("");
 		}

--- a/packages/coding-agent/src/tools/hub/types.ts
+++ b/packages/coding-agent/src/tools/hub/types.ts
@@ -68,6 +68,12 @@ export interface JobSnapshot {
 	resultText?: string;
 	errorText?: string;
 	structured?: StructuredSubagentOutput;
+	/**
+	 * `agent://<id>` handle backing this job's artifacts — the job-row's
+	 * registry `agentId` when the manager disambiguated a requested job id
+	 * on collision, else the job id itself. See {@link AsyncJob.agentId}.
+	 */
+	agentUrlId?: string;
 }
 
 export type CancelStatus = "cancelled" | "not_found" | "already_completed";

--- a/packages/coding-agent/src/tools/hub/types.ts
+++ b/packages/coding-agent/src/tools/hub/types.ts
@@ -7,6 +7,7 @@
 import type { AgentToolResult } from "@oh-my-pi/pi-agent-core";
 import type { AsyncJobType } from "../../async";
 import type { IrcDeliveryReceipt, IrcMessage } from "../../irc/bus";
+import type { StructuredSubagentOutput } from "../../task/types";
 import type { LaunchParams, LaunchToolDetails } from "./launch";
 
 /**
@@ -66,6 +67,7 @@ export interface JobSnapshot {
 	resolvedModel?: string;
 	resultText?: string;
 	errorText?: string;
+	structured?: StructuredSubagentOutput;
 }
 
 export type CancelStatus = "cancelled" | "not_found" | "already_completed";

--- a/packages/coding-agent/test/agent-session-async-delivery.test.ts
+++ b/packages/coding-agent/test/agent-session-async-delivery.test.ts
@@ -10,11 +10,15 @@ import { Agent } from "@oh-my-pi/pi-agent-core";
 import { createMockModel } from "@oh-my-pi/pi-ai/providers/mock";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { AsyncJobManager } from "@oh-my-pi/pi-coding-agent/async";
+import type { AsyncJob } from "@oh-my-pi/pi-coding-agent/async/job-manager";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import type { DaemonCompletionNotification } from "@oh-my-pi/pi-coding-agent/launch/protocol";
 import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
-import type { AsyncResultEntry } from "@oh-my-pi/pi-coding-agent/session/async-job-delivery";
+import {
+	buildAsyncResultBatchMessage,
+	type AsyncResultEntry,
+} from "@oh-my-pi/pi-coding-agent/session/async-job-delivery";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { convertToLlm } from "@oh-my-pi/pi-coding-agent/session/messages";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
@@ -93,6 +97,67 @@ describe("AgentSession owner-routed async delivery", () => {
 			}),
 		);
 		expect(sawResult).toBe(true);
+	});
+
+	it("carries a schema-valid background task's structured output as a pointer only", () => {
+		const job: AsyncJob = {
+			id: "SchemaProbe",
+			type: "task",
+			status: "completed",
+			startTime: Date.now(),
+			label: "SchemaProbe",
+			abortController: new AbortController(),
+			promise: Promise.resolve(),
+			resultText: "done",
+			structured: { source: "caller", mode: "permissive", status: "valid", data: { summary: "ok", count: 7 } },
+		};
+		const entry: AsyncResultEntry = {
+			jobId: "SchemaProbe",
+			result: "done",
+			job,
+			durationMs: 1000,
+			epoch: 0,
+		};
+		const message = buildAsyncResultBatchMessage([entry]);
+		expect(message?.details?.jobs[0]?.schema).toEqual({ status: "valid" });
+		expect(message?.content).toContain("schema valid");
+		expect(message?.content).toContain("agent://SchemaProbe");
+		expect(message?.content).not.toContain("```json");
+	});
+
+	it("carries a schema-invalid background task's parsed payload inline only", () => {
+		const job: AsyncJob = {
+			id: "SchemaProbe",
+			type: "task",
+			status: "completed",
+			startTime: Date.now(),
+			label: "SchemaProbe",
+			abortController: new AbortController(),
+			promise: Promise.resolve(),
+			resultText: "done",
+			structured: {
+				source: "caller",
+				mode: "strict",
+				status: "invalid",
+				error: "missing required field 'count'",
+				data: { summary: "ok" },
+			},
+		};
+		const entry: AsyncResultEntry = {
+			jobId: "SchemaProbe",
+			result: "done",
+			job,
+			durationMs: 1000,
+			epoch: 0,
+		};
+		const message = buildAsyncResultBatchMessage([entry]);
+		expect(message?.details?.jobs[0]?.schema).toEqual({
+			status: "invalid",
+			error: "missing required field 'count'",
+		});
+		expect(message?.content).toMatch(/```json[\s\S]*"summary": "ok"[\s\S]*```/);
+		expect(message?.content).toContain("missing required field 'count'");
+		expect(message?.content).not.toContain("full payload at agent://SchemaProbe");
 	});
 
 	it("routes an advisor-owned launch completion through the session", async () => {

--- a/packages/coding-agent/test/agent-session-async-delivery.test.ts
+++ b/packages/coding-agent/test/agent-session-async-delivery.test.ts
@@ -130,6 +130,36 @@ describe("AgentSession owner-routed async delivery", () => {
 		expect(message?.content).not.toContain("```json");
 	});
 
+	it("advertises the agent:// URL using the task's agent id, not a disambiguated job id", () => {
+		// Regression: AsyncJobManager suffixes a requested job id when it
+		// collides with another live job (e.g. a task id reusing a vibe turn's
+		// job id), but the task's artifacts are still written under its own
+		// unsuffixed agent id. Advertising the suffixed job id points at a
+		// handle with no backing `<id>.md`/`.json` on disk (PR #10625 review).
+		const job: AsyncJob = {
+			id: "Foo-t1-2",
+			agentId: "Foo-t1",
+			type: "task",
+			status: "completed",
+			startTime: Date.now(),
+			label: "Foo-t1",
+			abortController: new AbortController(),
+			promise: Promise.resolve(),
+			resultText: "done",
+			structured: { source: "caller", mode: "permissive", status: "valid", data: { summary: "ok" } },
+		};
+		const entry: AsyncResultEntry = {
+			jobId: "Foo-t1-2",
+			result: "done",
+			job,
+			durationMs: 1000,
+			epoch: 0,
+		};
+		const message = buildAsyncResultBatchMessage([entry]);
+		expect(message?.content).toContain("agent://Foo-t1,");
+		expect(message?.content).not.toContain("agent://Foo-t1-2");
+	});
+
 	it("carries a schema-invalid background task's parsed payload inline only", () => {
 		const job: AsyncJob = {
 			id: "SchemaProbe",

--- a/packages/coding-agent/test/agent-session-async-delivery.test.ts
+++ b/packages/coding-agent/test/agent-session-async-delivery.test.ts
@@ -119,7 +119,12 @@ describe("AgentSession owner-routed async delivery", () => {
 			epoch: 0,
 		};
 		const message = buildAsyncResultBatchMessage([entry]);
-		expect(message?.details?.jobs[0]?.schema).toEqual({ status: "valid" });
+		expect(message?.details?.jobs[0]?.schema).toEqual({
+			source: "caller",
+			mode: "permissive",
+			status: "valid",
+			data: { summary: "ok", count: 7 },
+		});
 		expect(message?.content).toContain("schema valid");
 		expect(message?.content).toContain("agent://SchemaProbe");
 		expect(message?.content).not.toContain("```json");
@@ -152,8 +157,11 @@ describe("AgentSession owner-routed async delivery", () => {
 		};
 		const message = buildAsyncResultBatchMessage([entry]);
 		expect(message?.details?.jobs[0]?.schema).toEqual({
+			source: "caller",
+			mode: "strict",
 			status: "invalid",
 			error: "missing required field 'count'",
+			data: { summary: "ok" },
 		});
 		expect(message?.content).toMatch(/```json[\s\S]*"summary": "ok"[\s\S]*```/);
 		expect(message?.content).toContain("missing required field 'count'");

--- a/packages/coding-agent/test/agent-session-async-delivery.test.ts
+++ b/packages/coding-agent/test/agent-session-async-delivery.test.ts
@@ -160,7 +160,12 @@ describe("AgentSession owner-routed async delivery", () => {
 		expect(message?.content).not.toContain("agent://Foo-t1-2");
 	});
 
-	it("carries a schema-invalid background task's parsed payload inline only", () => {
+	it("carries a schema-invalid background task's parsed payload as both a pointer and an inline preview", () => {
+		// Regression: an invalid result's data is now also persisted to the
+		// `<id>.json` sidecar (PR #10625 review), so the delivery must
+		// advertise the same `agent://` recovery pointer as a valid result,
+		// not just the size-capped inline preview (which alone would be the
+		// only model-visible copy for oversized payloads).
 		const job: AsyncJob = {
 			id: "SchemaProbe",
 			type: "task",
@@ -195,7 +200,36 @@ describe("AgentSession owner-routed async delivery", () => {
 		});
 		expect(message?.content).toMatch(/```json[\s\S]*"summary": "ok"[\s\S]*```/);
 		expect(message?.content).toContain("missing required field 'count'");
-		expect(message?.content).not.toContain("full payload at agent://SchemaProbe");
+		expect(message?.content).toContain("full payload at agent://SchemaProbe");
+	});
+
+	it("omits the agent:// pointer for an invalid result with no data to recover", () => {
+		const job: AsyncJob = {
+			id: "SchemaProbe",
+			type: "task",
+			status: "completed",
+			startTime: Date.now(),
+			label: "SchemaProbe",
+			abortController: new AbortController(),
+			promise: Promise.resolve(),
+			resultText: "done",
+			structured: {
+				source: "caller",
+				mode: "strict",
+				status: "invalid",
+				error: "subagent yielded no data",
+			},
+		};
+		const entry: AsyncResultEntry = {
+			jobId: "SchemaProbe",
+			result: "done",
+			job,
+			durationMs: 1000,
+			epoch: 0,
+		};
+		const message = buildAsyncResultBatchMessage([entry]);
+		expect(message?.content).not.toContain("agent://SchemaProbe");
+		expect(message?.content).toContain("subagent yielded no data");
 	});
 
 	it("routes an advisor-owned launch completion through the session", async () => {

--- a/packages/coding-agent/test/async-job-manager.test.ts
+++ b/packages/coding-agent/test/async-job-manager.test.ts
@@ -10,6 +10,14 @@ async function waitForJobEviction(manager: AsyncJobManager, jobId: string): Prom
 	}
 }
 
+async function waitForCondition(predicate: () => boolean, timeoutMs = 2_000): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (!predicate()) {
+		if (Date.now() >= deadline) throw new Error("Timed out waiting for condition");
+		await scheduler.yield();
+	}
+}
+
 describe("AsyncJobManager", () => {
 	test("forwards progress updates and delivers completion", async () => {
 		const progressEvents: Array<{ text: string; details?: Record<string, unknown> }> = [];
@@ -139,6 +147,43 @@ describe("AsyncJobManager", () => {
 		expect(delivered).toEqual([
 			{ jobId, structured: { source: "caller", mode: "permissive", status: "valid", data: { count: 7 } } },
 		]);
+	});
+
+	test("defers retained artifacts cleanup until this job's delivery settles", async () => {
+		// Regression: job-row eviction runs on its own retention timer,
+		// independent of delivery — a still-in-flight delivery sink (e.g. one
+		// awaiting a yield-queue receipt) must not have its retained
+		// artifacts deleted out from under it before the sink resolves (PR
+		// #10625 review).
+		const cleanupCalls: string[] = [];
+		const deliveryGate = Promise.withResolvers<void>();
+		const manager = new AsyncJobManager({
+			retentionMs: 0,
+			onJobComplete: async () => {
+				await deliveryGate.promise;
+			},
+		});
+
+		const jobId = manager.register("task", "agent task", async () => "task done");
+		const job = manager.getJob(jobId);
+		job!.retainedArtifactsCleanup = async () => {
+			cleanupCalls.push(jobId);
+		};
+
+		await manager.waitForAll();
+		await waitForJobEviction(manager, jobId);
+
+		// The job row is gone (retentionMs: 0), but the delivery sink is still
+		// blocked on the gate — cleanup must not have run yet.
+		await scheduler.yield();
+		await scheduler.yield();
+		expect(cleanupCalls).toEqual([]);
+
+		deliveryGate.resolve();
+		await manager.drainDeliveries({ timeoutMs: 2_000 });
+		await waitForCondition(() => cleanupCalls.length > 0);
+
+		expect(cleanupCalls).toEqual([jobId]);
 	});
 
 	test("fails the job but keeps structured output from AsyncJobError", async () => {

--- a/packages/coding-agent/test/async-job-manager.test.ts
+++ b/packages/coding-agent/test/async-job-manager.test.ts
@@ -149,6 +149,38 @@ describe("AsyncJobManager", () => {
 		]);
 	});
 
+	test("preserves agentId in a delayed delivery rebuilt after eviction", async () => {
+		// Regression: a collision-suffixed job id (e.g. `Foo-t1` -> `Foo-t1-2`)
+		// still writes artifacts under the unsuffixed `agentId`. When the row
+		// is evicted before a retried delivery lands, the delivery must be
+		// rebuilt from a snapshot that still carries `agentId`, or the
+		// reconstructed job falls back to the suffixed `jobId` and the
+		// advertised `agent://` URL points at nothing on disk (PR #10625
+		// review).
+		let sinkCalls = 0;
+		const delivered: Array<{ jobId: string; agentId: string | undefined }> = [];
+		const manager = new AsyncJobManager({
+			retentionMs: 25,
+			onJobComplete: async (jobId, _text, job) => {
+				sinkCalls += 1;
+				if (sinkCalls === 1) throw new Error("simulated delivery failure");
+				delivered.push({ jobId, agentId: job?.agentId });
+			},
+		});
+
+		const jobId = manager.register("task", "agent task", async () => "task done", {
+			id: "Foo-t1-2",
+			agentId: "Foo-t1",
+		});
+
+		await manager.waitForAll();
+		await waitForJobEviction(manager, jobId);
+		await manager.drainDeliveries({ timeoutMs: 2_000 });
+
+		expect(sinkCalls).toBe(2);
+		expect(delivered).toEqual([{ jobId: "Foo-t1-2", agentId: "Foo-t1" }]);
+	});
+
 	test("defers retained artifacts cleanup until this job's delivery settles", async () => {
 		// Regression: job-row eviction runs on its own retention timer,
 		// independent of delivery — a still-in-flight delivery sink (e.g. one

--- a/packages/coding-agent/test/async-job-manager.test.ts
+++ b/packages/coding-agent/test/async-job-manager.test.ts
@@ -261,6 +261,34 @@ describe("AsyncJobManager", () => {
 		expect(sleepSpy.mock.calls.some(([duration]) => duration === 45_000)).toBe(true);
 	});
 
+	test("bypasses the retained-artifacts grace period during dispose", async () => {
+		// Regression: dispose() previously ran retained-artifacts cleanup
+		// through the full configured grace-period sleep even though every
+		// delivery has already been drained/cancelled by that point —
+		// leaking temp dirs for up to the grace window, or past process
+		// exit since dispose does not await these cleanups (PR #10625
+		// review).
+		const cleanupCalls: string[] = [];
+		const sleepSpy = mockPositiveSleepsImmediate();
+		const manager = new AsyncJobManager({
+			retainedArtifactsCleanupGraceMs: 45_000,
+			onJobComplete: async () => {},
+		});
+
+		const jobId = manager.register("task", "agent task", async () => "task done");
+		const job = manager.getJob(jobId);
+		job!.retainedArtifactsCleanup = async () => {
+			cleanupCalls.push(jobId);
+		};
+
+		await manager.waitForAll();
+		await manager.dispose();
+		await waitForCondition(() => cleanupCalls.length > 0);
+
+		expect(cleanupCalls).toEqual([jobId]);
+		expect(sleepSpy.mock.calls.some(([duration]) => duration === 45_000)).toBe(false);
+	});
+
 	test("fails the job but keeps structured output from AsyncJobError", async () => {
 		const manager = new AsyncJobManager({
 			onJobComplete: async () => {},

--- a/packages/coding-agent/test/async-job-manager.test.ts
+++ b/packages/coding-agent/test/async-job-manager.test.ts
@@ -289,6 +289,36 @@ describe("AsyncJobManager", () => {
 		expect(sleepSpy.mock.calls.some(([duration]) => duration === 45_000)).toBe(false);
 	});
 
+	test("bounds the wait for a hung delivery sink so retained artifacts cleanup still runs", async () => {
+		// Regression: #waitForJobDeliverySettled loops forever awaiting an
+		// in-flight delivery promise. A sink that never settles (e.g. a
+		// yield-queue receipt whose owning session is gone) would leak the
+		// retained temp directory for the process lifetime without a bound
+		// (PR #10625 review).
+		const cleanupCalls: string[] = [];
+		const manager = new AsyncJobManager({
+			retentionMs: 0,
+			retainedArtifactsCleanupGraceMs: 0,
+			retainedArtifactsCleanupMaxWaitMs: 20,
+			onJobComplete: () => {},
+		});
+		manager.registerDeliverySink("Main", async () => {
+			await Promise.withResolvers<never>().promise;
+		});
+
+		const jobId = manager.register("task", "agent task", async () => "task done", { ownerId: "Main" });
+		const job = manager.getJob(jobId);
+		job!.retainedArtifactsCleanup = async () => {
+			cleanupCalls.push(jobId);
+		};
+
+		await manager.waitForAll();
+		await waitForJobEviction(manager, jobId);
+		await waitForCondition(() => cleanupCalls.length > 0, 2_000);
+
+		expect(cleanupCalls).toEqual([jobId]);
+	});
+
 	test("fails the job but keeps structured output from AsyncJobError", async () => {
 		const manager = new AsyncJobManager({
 			onJobComplete: async () => {},

--- a/packages/coding-agent/test/async-job-manager.test.ts
+++ b/packages/coding-agent/test/async-job-manager.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test, vi } from "bun:test";
 import { scheduler } from "node:timers/promises";
 import { AsyncJobError, AsyncJobManager } from "@oh-my-pi/pi-coding-agent/async/job-manager";
 
@@ -18,7 +18,20 @@ async function waitForCondition(predicate: () => boolean, timeoutMs = 2_000): Pr
 	}
 }
 
+/** Resolve positive-duration sleeps immediately so grace-period waits don't cost real wall-clock time. */
+function mockPositiveSleepsImmediate() {
+	const realSleep = Bun.sleep.bind(Bun);
+	return vi.spyOn(Bun, "sleep").mockImplementation((duration?: number | Date) => {
+		if (typeof duration === "number" && duration > 0) return Promise.resolve();
+		return realSleep(duration ?? 0);
+	});
+}
+
 describe("AsyncJobManager", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
 	test("forwards progress updates and delivers completion", async () => {
 		const progressEvents: Array<{ text: string; details?: Record<string, unknown> }> = [];
 		const completions: Array<{ jobId: string; text: string }> = [];
@@ -191,6 +204,7 @@ describe("AsyncJobManager", () => {
 		const deliveryGate = Promise.withResolvers<void>();
 		const manager = new AsyncJobManager({
 			retentionMs: 0,
+			retainedArtifactsCleanupGraceMs: 0,
 			onJobComplete: async () => {
 				await deliveryGate.promise;
 			},
@@ -216,6 +230,35 @@ describe("AsyncJobManager", () => {
 		await waitForCondition(() => cleanupCalls.length > 0);
 
 		expect(cleanupCalls).toEqual([jobId]);
+	});
+
+	test("waits out a grace period after delivery settles before cleanup, using the configured duration", async () => {
+		// Regression: the settlement receipt resolves at `ASIDE_MESSAGE_COMMIT`
+		// — when the follow-up is inserted into the transcript, but *before*
+		// the next provider call that actually shows it to the model. Running
+		// cleanup immediately on settlement raced ahead of the model's next
+		// turn reading the advertised `agent://` pointer (PR #10625 review).
+		const cleanupCalls: string[] = [];
+		const sleepSpy = mockPositiveSleepsImmediate();
+		const manager = new AsyncJobManager({
+			retentionMs: 0,
+			retainedArtifactsCleanupGraceMs: 45_000,
+			onJobComplete: async () => {},
+		});
+
+		const jobId = manager.register("task", "agent task", async () => "task done");
+		const job = manager.getJob(jobId);
+		job!.retainedArtifactsCleanup = async () => {
+			cleanupCalls.push(jobId);
+		};
+
+		await manager.waitForAll();
+		await waitForJobEviction(manager, jobId);
+		await manager.drainDeliveries({ timeoutMs: 2_000 });
+		await waitForCondition(() => cleanupCalls.length > 0);
+
+		expect(cleanupCalls).toEqual([jobId]);
+		expect(sleepSpy.mock.calls.some(([duration]) => duration === 45_000)).toBe(true);
 	});
 
 	test("fails the job but keeps structured output from AsyncJobError", async () => {

--- a/packages/coding-agent/test/async-job-manager.test.ts
+++ b/packages/coding-agent/test/async-job-manager.test.ts
@@ -111,6 +111,36 @@ describe("AsyncJobManager", () => {
 		expect(manager.getJob(jobId)?.structured?.data).toEqual({ count: 7 });
 	});
 
+	test("keeps structured output for a delivery that only succeeds after the job row is evicted", async () => {
+		let sinkCalls = 0;
+		const delivered: Array<{ jobId: string; structured: unknown }> = [];
+		const manager = new AsyncJobManager({
+			retentionMs: 25,
+			onJobComplete: async (jobId, _text, job) => {
+				sinkCalls += 1;
+				if (sinkCalls === 1) throw new Error("simulated delivery failure");
+				delivered.push({ jobId, structured: job?.structured });
+			},
+		});
+
+		const jobId = manager.register("task", "agent task", async () => ({
+			text: "task done",
+			structured: { source: "caller", mode: "permissive", status: "valid", data: { count: 7 } },
+		}));
+
+		await manager.waitForAll();
+		await waitForJobEviction(manager, jobId);
+		await manager.drainDeliveries({ timeoutMs: 2_000 });
+
+		// The job row is gone by the time the retried delivery lands, but the
+		// delivery must still carry the structured payload it snapshotted at
+		// enqueue time — not silently drop it because the row was evicted.
+		expect(sinkCalls).toBe(2);
+		expect(delivered).toEqual([
+			{ jobId, structured: { source: "caller", mode: "permissive", status: "valid", data: { count: 7 } } },
+		]);
+	});
+
 	test("fails the job but keeps structured output from AsyncJobError", async () => {
 		const manager = new AsyncJobManager({
 			onJobComplete: async () => {},

--- a/packages/coding-agent/test/async-job-manager.test.ts
+++ b/packages/coding-agent/test/async-job-manager.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { scheduler } from "node:timers/promises";
-import { AsyncJobManager } from "@oh-my-pi/pi-coding-agent/async/job-manager";
+import { AsyncJobError, AsyncJobManager } from "@oh-my-pi/pi-coding-agent/async/job-manager";
 
 async function waitForJobEviction(manager: AsyncJobManager, jobId: string): Promise<void> {
 	const deadline = Date.now() + 2_000;
@@ -89,6 +89,50 @@ describe("AsyncJobManager", () => {
 		expect(completions).toEqual([{ jobId, text: "command failed" }]);
 		expect(manager.getJob(jobId)?.status).toBe("failed");
 		expect(manager.getJob(jobId)?.errorText).toBe("command failed");
+	});
+
+	test("retains structured output from a job body result", async () => {
+		const completions: Array<{ jobId: string; text: string }> = [];
+		const manager = new AsyncJobManager({
+			onJobComplete: async (jobId, text) => {
+				completions.push({ jobId, text });
+			},
+		});
+
+		const jobId = manager.register("task", "agent task", async () => ({
+			text: "task done",
+			structured: { source: "caller", mode: "permissive", status: "valid", data: { count: 7 } },
+		}));
+
+		await manager.waitForAll();
+		await manager.drainDeliveries({ timeoutMs: 2_000 });
+
+		expect(completions).toEqual([{ jobId, text: "task done" }]);
+		expect(manager.getJob(jobId)?.structured?.data).toEqual({ count: 7 });
+	});
+
+	test("fails the job but keeps structured output from AsyncJobError", async () => {
+		const manager = new AsyncJobManager({
+			onJobComplete: async () => {},
+		});
+
+		const jobId = manager.register("task", "agent task", async () => {
+			throw new AsyncJobError("schema_violation: missing required fields: count", {
+				source: "caller",
+				mode: "strict",
+				status: "invalid",
+				error: "missing required fields: count",
+				data: { summary: "ok" },
+			});
+		});
+
+		await manager.waitForAll();
+		await manager.drainDeliveries({ timeoutMs: 2_000 });
+
+		const job = manager.getJob(jobId);
+		expect(job?.status).toBe("failed");
+		expect(job?.errorText).toBe("schema_violation: missing required fields: count");
+		expect(job?.structured?.status).toBe("invalid");
 	});
 
 	test("cancels a running job by id", async () => {

--- a/packages/coding-agent/test/internal-urls/agent-protocol-nested.test.ts
+++ b/packages/coding-agent/test/internal-urls/agent-protocol-nested.test.ts
@@ -139,3 +139,41 @@ it("agent:// path form falls back to JSON extraction when no nested output match
 	expect(extracted.contentType).toBe("application/json");
 	expect(JSON.parse(extracted.content)).toEqual({ ok: true });
 });
+
+it("agent:// path extraction prefers the <id>.json sidecar over the markdown body", async () => {
+	const root = tempDir.path();
+	const rootSessionFile = path.join(root, "sidecar-session.jsonl");
+	const rootArtifactsDir = rootSessionFile.slice(0, -6);
+	await fs.mkdir(rootArtifactsDir, { recursive: true });
+	const sharedArtifactManager = new ArtifactManager(rootArtifactsDir);
+	// Non-JSON body proves the fallback path could not have produced the answer.
+	await fs.writeFile(path.join(rootArtifactsDir, "Worker.md"), "schema_violation summary text");
+	await fs.writeFile(path.join(rootArtifactsDir, "Worker.json"), JSON.stringify({ summary: "ok", count: 7 }));
+
+	const fakeSession = {
+		sessionManager: { getArtifactsDir: () => sharedArtifactManager.dir },
+	} as unknown as AgentSession;
+	const registry = AgentRegistry.global();
+	registry.register({
+		id: "Main",
+		displayName: "main",
+		kind: "main",
+		session: fakeSession,
+		sessionFile: rootSessionFile,
+	});
+
+	const handler = new AgentProtocolHandler();
+	const resource = await handler.resolve(new URL("agent://Worker/count") as never);
+	expect(resource.contentType).toBe("application/json");
+	expect(JSON.parse(resource.content)).toBe(7);
+	expect(resource.sourcePath?.endsWith("Worker.json")).toBe(true);
+
+	// A bare id keeps serving the markdown body, never the sidecar.
+	const bare = await handler.resolve(new URL("agent://Worker") as never);
+	expect(bare.contentType).toBe("text/markdown");
+	expect(bare.content).toBe("schema_violation summary text");
+
+	// A corrupt sidecar falls back to <id>.md instead of surfacing its own parse error.
+	await fs.writeFile(path.join(rootArtifactsDir, "Worker.json"), "{not json");
+	await expect(handler.resolve(new URL("agent://Worker/count") as never)).rejects.toThrow(/Worker is not valid JSON/);
+});

--- a/packages/coding-agent/test/internal-urls/caller-root-ab.test.ts
+++ b/packages/coding-agent/test/internal-urls/caller-root-ab.test.ts
@@ -274,4 +274,20 @@ describe("internal URL tools resolve against the caller root (A/B same ids)", ()
 		const agent = await tool.execute("grep-agent-c", { pattern: "B OUTPUT", path: "agent://Worker" });
 		expect(getResultText(agent)).toContain("B OUTPUT");
 	});
+
+	it("agent://Worker/<field> pairs the sidecar with the SAME root as the matched Worker.md", async () => {
+		const registry = AgentRegistry.global();
+		await installGlobalMainB(registry, rootB);
+
+		// Root A has no sidecar; root B has one with a different payload. A's
+		// caller must never answer with B's sidecar.
+		await fsp.writeFile(path.join(dir, "a", "main", "Worker.md"), JSON.stringify({ count: 1 }));
+		await fsp.writeFile(path.join(dir, "b", "main", "Worker.md"), JSON.stringify({ count: 2 }));
+		await fsp.writeFile(path.join(dir, "b", "main", "Worker.json"), JSON.stringify({ count: 2 }));
+
+		const router = InternalUrlRouter.instance();
+		const resource = await router.resolve("agent://Worker/count", { sessionFile: rootA });
+		expect(JSON.parse(resource.content)).toBe(1);
+		expect(resource.sourcePath?.endsWith(path.join("a", "main", "Worker.md"))).toBe(true);
+	});
 });

--- a/packages/coding-agent/test/task/executor-structured-sidecar.test.ts
+++ b/packages/coding-agent/test/task/executor-structured-sidecar.test.ts
@@ -134,6 +134,54 @@ describe("structured output sidecar lifecycle", () => {
 		await expect(fs.stat(sidecarPath)).rejects.toThrow();
 	});
 
+	it("removes a stale sidecar instead of leaving it when the serialized data is undefined", async () => {
+		// Regression: `Object.hasOwn(structured, "data")` can be true while
+		// `JSON.stringify(structured.data, null, 2)` itself returns
+		// `undefined` (e.g. `structured.data === undefined`) — previously
+		// neither a write nor a removal happened, leaving a stale sidecar
+		// from an earlier turn behind (PR #10625 review).
+		artifactsDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-sidecar-test-"));
+		const id = "UndefinedDataProbe";
+		const sidecarPath = path.join(artifactsDir, `${id}.json`);
+		await fs.writeFile(sidecarPath, JSON.stringify({ summary: "stale from an earlier turn" }));
+
+		const session = yieldEmittingSession({ ok: true });
+		vi.spyOn(sdkModule, "createAgentSession").mockResolvedValue(createSessionResult(session));
+
+		const originalStringify = JSON.stringify.bind(JSON);
+		vi.spyOn(JSON, "stringify").mockImplementation(((value: unknown, ...rest: unknown[]) => {
+			// Narrowly target only the yielded `{ ok: true }` payload so other
+			// concurrent JSON.stringify calls in the pipeline are unaffected.
+			if (
+				value !== null &&
+				typeof value === "object" &&
+				!Array.isArray(value) &&
+				Object.keys(value).length === 1 &&
+				"ok" in value &&
+				value.ok === true
+			) {
+				return undefined as unknown as string;
+			}
+			return (originalStringify as (...args: unknown[]) => unknown)(value, ...rest) as string;
+		}) as typeof JSON.stringify);
+
+		const result = await runSubprocess({
+			cwd: "/tmp",
+			agent: baseAgent,
+			task: "do work",
+			index: 0,
+			id,
+			settings: Settings.isolated(),
+			modelRegistry: { refresh: async () => {} } as unknown as ModelRegistry,
+			enableLsp: false,
+			artifactsDir,
+			outputSchema: { type: "object", properties: { ok: { type: "boolean" } }, required: ["ok"] },
+		});
+
+		expect(result.structuredOutput?.data).toEqual({ ok: true });
+		await expect(fs.stat(sidecarPath)).rejects.toThrow();
+	});
+
 	it("persists the sidecar for a schema-invalid yield that still carries parsed data", async () => {
 		// Regression: previously the sidecar was written only for
 		// `status === "valid"`, so an oversized invalid payload had no

--- a/packages/coding-agent/test/task/executor-structured-sidecar.test.ts
+++ b/packages/coding-agent/test/task/executor-structured-sidecar.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Regression coverage for the `<id>.json` structured-output sidecar
+ * lifecycle: a replacement write failure must not leave a stale sidecar from
+ * an earlier turn answering `agent://<id>/<field>` with superseded data (PR
+ * #10625 review).
+ */
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import type { CreateAgentSessionResult } from "@oh-my-pi/pi-coding-agent/sdk";
+import type { LoadExtensionsResult } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/types";
+import * as sdkModule from "@oh-my-pi/pi-coding-agent/sdk";
+import type { AgentSession, AgentSessionEvent, PromptOptions } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { runSubprocess } from "@oh-my-pi/pi-coding-agent/task/executor";
+import type { AgentDefinition } from "@oh-my-pi/pi-coding-agent/task/types";
+import { EventBus } from "@oh-my-pi/pi-coding-agent/utils/event-bus";
+
+function createMockSession(onPrompt: (params: { emit: (event: AgentSessionEvent) => void }) => void): AgentSession {
+	const listeners: Array<(event: AgentSessionEvent) => void> = [];
+	const emit = (event: AgentSessionEvent) => {
+		for (const listener of listeners) listener(event);
+	};
+	const session = {
+		state: { messages: [] },
+		agent: { state: { systemPrompt: ["test"] } },
+		model: undefined,
+		extensionRunner: undefined,
+		sessionManager: { appendSessionInit: () => {} },
+		getActiveToolNames: () => ["read", "yield"],
+		getEnabledToolNames: () => ["read", "yield"],
+		setActiveToolsByName: async (_toolNames: string[]) => {},
+		subscribe: (listener: (event: AgentSessionEvent) => void) => {
+			listeners.push(listener);
+			return () => {
+				const index = listeners.indexOf(listener);
+				if (index >= 0) listeners.splice(index, 1);
+			};
+		},
+		prompt: async (_text: string, _options?: PromptOptions) => {
+			onPrompt({ emit });
+		},
+		waitForIdle: async () => {},
+		prepareForHeadlessAdvisorDrain: () => {},
+		waitForAdvisorCatchup: async () => true,
+		getLastAssistantMessage: () => undefined,
+		abort: async () => {},
+		dispose: async () => {},
+		setIrcWakeTurnObserver: () => {},
+		subscribeRunState: () => () => {},
+	};
+	return session as unknown as AgentSession;
+}
+
+function yieldEmittingSession(data: unknown): AgentSession {
+	return createMockSession(({ emit }) => {
+		emit({
+			type: "tool_execution_end",
+			toolCallId: "tool-sidecar",
+			toolName: "yield",
+			result: {
+				content: [{ type: "text", text: "Result submitted." }],
+				details: { status: "success", data },
+			},
+			isError: false,
+		});
+	});
+}
+
+function createSessionResult(session: AgentSession): CreateAgentSessionResult {
+	return {
+		session,
+		extensionsResult: { extensions: [], errors: [], runtime: {} as unknown } as unknown as LoadExtensionsResult,
+		setToolUIContext: () => {},
+		eventBus: new EventBus(),
+	};
+}
+
+const baseAgent: AgentDefinition = {
+	name: "task",
+	description: "test",
+	systemPrompt: "test",
+	source: "bundled",
+};
+
+describe("structured output sidecar lifecycle", () => {
+	let artifactsDir: string | undefined;
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		if (artifactsDir) await fs.rm(artifactsDir, { recursive: true, force: true });
+		artifactsDir = undefined;
+	});
+
+	it("drops a stale sidecar instead of leaving it behind when the replacement write fails", async () => {
+		artifactsDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-sidecar-test-"));
+		const id = "SidecarProbe";
+		const sidecarPath = path.join(artifactsDir, `${id}.json`);
+		await fs.writeFile(sidecarPath, JSON.stringify({ summary: "stale from an earlier turn" }));
+
+		const session = yieldEmittingSession({ ok: true });
+		vi.spyOn(sdkModule, "createAgentSession").mockResolvedValue(createSessionResult(session));
+
+		const originalWrite = Bun.write.bind(Bun);
+		vi.spyOn(Bun, "write").mockImplementation(((dest: unknown, ...rest: unknown[]) => {
+			if (typeof dest === "string" && dest.includes(`${id}.json.tmp-`)) {
+				return Promise.reject(new Error("simulated disk failure"));
+			}
+			return (originalWrite as (...args: unknown[]) => unknown)(dest, ...rest);
+		}) as typeof Bun.write);
+
+		const result = await runSubprocess({
+			cwd: "/tmp",
+			agent: baseAgent,
+			task: "do work",
+			index: 0,
+			id,
+			settings: Settings.isolated(),
+			modelRegistry: { refresh: async () => {} } as unknown as ModelRegistry,
+			enableLsp: false,
+			artifactsDir,
+			outputSchema: { type: "object", properties: { ok: { type: "boolean" } }, required: ["ok"] },
+		});
+
+		expect(result.exitCode).toBe(0);
+		expect(result.structuredOutput).toMatchObject({ status: "valid", data: { ok: true } });
+		// The <id>.md artifact republished successfully...
+		expect(result.outputPath).toBe(path.join(artifactsDir, `${id}.md`));
+		// ...but the sidecar write failed, so the stale sidecar must not survive
+		// to keep answering agent://<id>/<field> with the superseded payload.
+		await expect(fs.stat(sidecarPath)).rejects.toThrow();
+	});
+});

--- a/packages/coding-agent/test/task/executor-structured-sidecar.test.ts
+++ b/packages/coding-agent/test/task/executor-structured-sidecar.test.ts
@@ -1,8 +1,9 @@
 /**
  * Regression coverage for the `<id>.json` structured-output sidecar
  * lifecycle: a replacement write failure must not leave a stale sidecar from
- * an earlier turn answering `agent://<id>/<field>` with superseded data (PR
- * #10625 review).
+ * an earlier turn answering `agent://<id>/<field>` with superseded data, and
+ * a schema-invalid yield with parsed data must still get a sidecar so its
+ * full payload stays recoverable via `agent://<id>` (PR #10625 review).
  */
 import { afterEach, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs/promises";
@@ -131,5 +132,37 @@ describe("structured output sidecar lifecycle", () => {
 		// ...but the sidecar write failed, so the stale sidecar must not survive
 		// to keep answering agent://<id>/<field> with the superseded payload.
 		await expect(fs.stat(sidecarPath)).rejects.toThrow();
+	});
+
+	it("persists the sidecar for a schema-invalid yield that still carries parsed data", async () => {
+		// Regression: previously the sidecar was written only for
+		// `status === "valid"`, so an oversized invalid payload had no
+		// recovery path beyond the truncated inline preview.
+		artifactsDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-sidecar-test-"));
+		const id = "InvalidSidecarProbe";
+
+		// `ok` is a string, not a boolean — violates the schema below, but the
+		// data still parses and must be preserved.
+		const session = yieldEmittingSession({ ok: "not-a-boolean" });
+		vi.spyOn(sdkModule, "createAgentSession").mockResolvedValue(createSessionResult(session));
+
+		const result = await runSubprocess({
+			cwd: "/tmp",
+			agent: baseAgent,
+			task: "do work",
+			index: 0,
+			id,
+			settings: Settings.isolated(),
+			modelRegistry: { refresh: async () => {} } as unknown as ModelRegistry,
+			enableLsp: false,
+			artifactsDir,
+			outputSchema: { type: "object", properties: { ok: { type: "boolean" } }, required: ["ok"] },
+		});
+
+		expect(result.structuredOutput?.status).toBe("invalid");
+		const sidecarPath = path.join(artifactsDir, `${id}.json`);
+		await expect(fs.stat(sidecarPath)).resolves.toBeDefined();
+		const sidecar = JSON.parse(await fs.readFile(sidecarPath, "utf-8"));
+		expect(sidecar).toEqual({ ok: "not-a-boolean" });
 	});
 });

--- a/packages/coding-agent/test/task/executor-warnings.test.ts
+++ b/packages/coding-agent/test/task/executor-warnings.test.ts
@@ -38,6 +38,28 @@ describe("subagent warning injection", () => {
 		expect(result.structuredOutput?.status).toBe("invalid");
 		expect(result.structuredOutput?.error).toBe(SUBAGENT_WARNING_NULL_YIELD);
 		expect(result.structuredOutput?.data).toBeUndefined();
+		// Strict mode promises a schema violation fails the run; a null yield
+		// with an exit code left at 0 previously let the async task path
+		// report the job "completed" despite an invalid structured payload
+		// (PR #10625 review).
+		expect(result.exitCode).not.toBe(0);
+	});
+
+	it("leaves the exit code untouched for a null yield in permissive mode", () => {
+		const result = finalizeSubprocessOutput({
+			rawOutput: "partial output",
+			exitCode: 0,
+			stderr: "",
+			doneAborted: false,
+			signalAborted: false,
+			yieldItems: [{ status: "success" }],
+			outputSchema: { type: "object", properties: { count: { type: "number" } }, required: ["count"] },
+			outputSchemaSource: "caller",
+			outputSchemaMode: "permissive",
+		});
+
+		expect(result.structuredOutput?.status).toBe("invalid");
+		expect(result.exitCode).toBe(0);
 	});
 
 	it("injects missing-submit warning when subagent exits cleanly without yield", () => {

--- a/packages/coding-agent/test/task/executor-warnings.test.ts
+++ b/packages/coding-agent/test/task/executor-warnings.test.ts
@@ -22,6 +22,24 @@ describe("subagent warning injection", () => {
 		expect(result.hasYield).toBe(true);
 	});
 
+	it("marks structured output invalid, not silently valid, when a schema-bearing yield has no data", () => {
+		const result = finalizeSubprocessOutput({
+			rawOutput: "partial output",
+			exitCode: 0,
+			stderr: "",
+			doneAborted: false,
+			signalAborted: false,
+			yieldItems: [{ status: "success" }],
+			outputSchema: { type: "object", properties: { count: { type: "number" } }, required: ["count"] },
+			outputSchemaSource: "caller",
+			outputSchemaMode: "strict",
+		});
+
+		expect(result.structuredOutput?.status).toBe("invalid");
+		expect(result.structuredOutput?.error).toBe(SUBAGENT_WARNING_NULL_YIELD);
+		expect(result.structuredOutput?.data).toBeUndefined();
+	});
+
 	it("injects missing-submit warning when subagent exits cleanly without yield", () => {
 		const result = finalizeSubprocessOutput({
 			rawOutput: "",

--- a/packages/coding-agent/test/task/structured-subagent.test.ts
+++ b/packages/coding-agent/test/task/structured-subagent.test.ts
@@ -366,6 +366,30 @@ describe("structured subagent primitive", () => {
 		expect(path.basename(settled.artifactsDir)).toStartWith("omp-task-");
 		await fs.rm(settled.artifactsDir, { recursive: true, force: true });
 	});
+
+	it("retains temporary artifacts when the run failed but yielded schema-valid structured output", async () => {
+		// Regression: a task can produce schema-valid data and then fail (or
+		// exceed its runtime limit). The async notice still advertises the
+		// full payload at `agent://<id>` for schema-valid output, so
+		// retention must not require `exitCode === 0` too — otherwise the
+		// directory is already gone by the time the model follows that URL
+		// (PR #10625 review).
+		mockDiscovery();
+		vi.spyOn(executorModule, "runSubprocess").mockImplementation(async () => {
+			return {
+				...result(),
+				exitCode: 1,
+				error: "runtime limit exceeded",
+				structuredOutput: { source: "agent", mode: "permissive", status: "valid", data: { ok: true } },
+			};
+		});
+
+		const settled = await runStructuredSubagent(request({ retainArtifacts: true }));
+		expect(settled.result.exitCode).toBe(1);
+		expect(settled.result.structuredOutput?.status).toBe("valid");
+		await expect(fs.stat(settled.artifactsDir)).resolves.toBeDefined();
+		await fs.rm(settled.artifactsDir, { recursive: true, force: true });
+	});
 	it("uses identical non-plan LSP and IRC policy for task and eval invocations", async () => {
 		mockDiscovery();
 		const taskPolicy = await resolveEffectiveSubagentPolicy(request());

--- a/packages/coding-agent/test/task/structured-subagent.test.ts
+++ b/packages/coding-agent/test/task/structured-subagent.test.ts
@@ -634,6 +634,28 @@ describe("structured subagent primitive", () => {
 		await expect(fs.stat(artifactsDir ?? "")).rejects.toThrow();
 	});
 
+	it("retains a detached task's artifacts on failure even without valid structured output", async () => {
+		// Regression: a detached (async) task job that fails with schema
+		// status "invalid" (not "valid") previously had its temp dir wiped
+		// immediately, breaking the "failed agent stays interrogable"
+		// invariant (task/index.ts) — the model could no longer read the
+		// failure via agent://<id> or history://<id> (PR #10625 review).
+		mockDiscovery();
+		let artifactsDir: string | undefined;
+		vi.spyOn(executorModule, "runSubprocess").mockImplementation(async options => {
+			artifactsDir = options.artifactsDir;
+			return { ...result(), exitCode: 1, error: "agent failed" };
+		});
+
+		const settled = await runStructuredSubagent(request({ retainArtifacts: true, detached: true }));
+
+		expect(settled.result.exitCode).toBe(1);
+		expect(settled.result.structuredOutput?.status).toBe("invalid");
+		expect(artifactsDirsFromRegistry()).toContain(settled.artifactsDir);
+		await expect(fs.stat(artifactsDir ?? "")).resolves.toBeDefined();
+		await fs.rm(settled.artifactsDir, { recursive: true, force: true });
+	});
+
 	it("retains isolated failure artifacts needed for recovery", async () => {
 		mockDiscovery();
 		let artifactsDir: string | undefined;

--- a/packages/coding-agent/test/task/task-spawn.test.ts
+++ b/packages/coding-agent/test/task/task-spawn.test.ts
@@ -236,6 +236,61 @@ describe("task spawn routing", () => {
 		await expect(fs.stat(capturedArtifactsDir!)).rejects.toThrow();
 	});
 
+	it("attaches retained-artifacts cleanup to the collision-suffixed job, not the pre-existing row", async () => {
+		// Regression: `AsyncJobManager.register()` suffixes the requested job
+		// id when it collides with another live job (e.g. a task id reusing a
+		// vibe turn's job id). The cleanup wiring looked the job back up by
+		// the *requested* id, which — after a collision — resolves to the
+		// unrelated pre-existing row instead of the newly registered task, so
+		// cleanup attached to (and could later delete artifacts alongside)
+		// the wrong job (PR #10625 review).
+		vi.spyOn(discoveryModule, "discoverAgents").mockResolvedValue({
+			agents: [taskAgent],
+			projectAgentsDir: null,
+		});
+		let capturedArtifactsDir: string | undefined;
+		vi.spyOn(executorModule, "runSubprocess").mockImplementation(async options => {
+			capturedArtifactsDir = options.artifactsDir;
+			return makeResult(options.id ?? "?");
+		});
+
+		const manager = createManager();
+		// Placeholder job occupying "Foo", the id the fresh task would
+		// otherwise be allocated — its own agent output id is unique per
+		// AgentOutputManager, independent of the job manager's id map, so
+		// this simulates the collision without needing a second spawn.
+		const placeholderGate = deferred();
+		manager.register(
+			"bash",
+			"placeholder",
+			async () => {
+				await placeholderGate.promise;
+				return "placeholder done";
+			},
+			{ id: "Foo" },
+		);
+
+		const tool = await TaskTool.create(createSession({ manager }));
+		const result = await tool.execute("tc-collide", {
+			agent: "task",
+			name: "Foo",
+			task: "Do the thing.",
+		} as TaskParams);
+
+		const jobId = result.details?.async?.jobId;
+		expect(jobId).toBe("Foo-2");
+		const job = manager.getJob(jobId!);
+		await job!.promise;
+
+		expect(job!.status).toBe("completed");
+		expect(job!.retainedArtifactsCleanup).toBeDefined();
+		const placeholder = manager.getJob("Foo");
+		expect(placeholder!.retainedArtifactsCleanup).toBeUndefined();
+
+		placeholderGate.resolve();
+		if (capturedArtifactsDir) await fs.rm(capturedArtifactsDir, { recursive: true, force: true });
+	});
+
 	it("bounds concurrent job bodies with the session spawn semaphore", async () => {
 		vi.spyOn(discoveryModule, "discoverAgents").mockResolvedValue({
 			agents: [taskAgent],

--- a/packages/coding-agent/test/task/task-spawn.test.ts
+++ b/packages/coding-agent/test/task/task-spawn.test.ts
@@ -186,6 +186,56 @@ describe("task spawn routing", () => {
 		await fs.rm(capturedArtifactsDir!, { recursive: true, force: true });
 	});
 
+	it("cleans up the retained artifacts directory once the job is evicted", async () => {
+		// Regression: retainArtifacts kept the temp directory alive past
+		// completion, but nothing ever deleted it afterward — a long-running
+		// SDK process accumulated every detached task's transcript forever.
+		// Cleanup must run once the job actually leaves the manager (eviction
+		// or disposal), not never (PR #10625 review).
+		vi.spyOn(discoveryModule, "discoverAgents").mockResolvedValue({
+			agents: [taskAgent],
+			projectAgentsDir: null,
+		});
+		let capturedArtifactsDir: string | undefined;
+		vi.spyOn(executorModule, "runSubprocess").mockImplementation(async options => {
+			capturedArtifactsDir = options.artifactsDir;
+			return makeResult(options.id ?? "?");
+		});
+
+		// Cleanup runs fire-and-forget off the job's own settle chain; spy on
+		// the real `fs.rm` call to await its actual completion instead of
+		// guessing a wait duration.
+		const rmCalled = deferred();
+		const realRm = fs.rm.bind(fs);
+		vi.spyOn(fs, "rm").mockImplementation(async (target, opts) => {
+			const outcome = await realRm(target as Parameters<typeof fs.rm>[0], opts as Parameters<typeof fs.rm>[1]);
+			if (capturedArtifactsDir && target === capturedArtifactsDir) rmCalled.resolve();
+			return outcome;
+		});
+
+		// retentionMs: 0 evicts synchronously once the job settles so the
+		// test does not have to wait out the real 5-minute default
+		// retention window.
+		const manager = new AsyncJobManager({ onJobComplete: () => {}, retentionMs: 0 });
+		managers.push(manager);
+		const tool = await TaskTool.create(createSession({ manager }));
+
+		const result = await tool.execute("tc-evict", {
+			agent: "task",
+			name: "Evictling",
+			task: "Do the thing.",
+		} as TaskParams);
+
+		const jobId = result.details?.async?.jobId;
+		const job = manager.getJob(jobId!);
+		await job!.promise;
+
+		expect(capturedArtifactsDir).toBeTruthy();
+		expect(manager.getJob(jobId!)).toBeUndefined();
+		await rmCalled.promise;
+		await expect(fs.stat(capturedArtifactsDir!)).rejects.toThrow();
+	});
+
 	it("bounds concurrent job bodies with the session spawn semaphore", async () => {
 		vi.spyOn(discoveryModule, "discoverAgents").mockResolvedValue({
 			agents: [taskAgent],

--- a/packages/coding-agent/test/task/task-spawn.test.ts
+++ b/packages/coding-agent/test/task/task-spawn.test.ts
@@ -12,6 +12,7 @@
  * test/task/task-schema.test.ts.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs/promises";
 import { type AsyncJob, AsyncJobManager } from "@oh-my-pi/pi-coding-agent/async/job-manager";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { AgentLifecycleManager } from "@oh-my-pi/pi-coding-agent/registry/agent-lifecycle";
@@ -146,6 +147,43 @@ describe("task spawn routing", () => {
 		expect(job!.resultText).toContain("history://Spawnling");
 		expect(runSpy).toHaveBeenCalledTimes(1);
 		expect(runSpy.mock.calls[0]?.[0].modelOverride).toEqual(["openai/gpt-4.1-mini"]);
+	});
+
+	it("retains the temporary artifacts directory for a completed async spawn (in-memory session)", async () => {
+		// Regression: with no session file (in-memory session), leaseArtifacts()
+		// allocates a temporary directory that runStructuredSubagent() deletes
+		// on completion unless retainArtifacts is requested. Detached (async)
+		// spawns advertise `agent://<id>` handles in the eventual async-result
+		// delivery, so the directory must survive past this call returning
+		// (PR #10625 review).
+		vi.spyOn(discoveryModule, "discoverAgents").mockResolvedValue({
+			agents: [taskAgent],
+			projectAgentsDir: null,
+		});
+		let capturedArtifactsDir: string | undefined;
+		const runSpy = vi.spyOn(executorModule, "runSubprocess").mockImplementation(async options => {
+			capturedArtifactsDir = options.artifactsDir;
+			return makeResult(options.id ?? "?");
+		});
+
+		const manager = createManager();
+		const tool = await TaskTool.create(createSession({ manager }));
+
+		const result = await tool.execute("tc-retain", {
+			agent: "task",
+			name: "Retainling",
+			task: "Do the thing.",
+		} as TaskParams);
+
+		const jobId = result.details?.async?.jobId;
+		const job = manager.getJob(jobId!);
+		await job!.promise;
+
+		expect(job!.status).toBe("completed");
+		expect(runSpy).toHaveBeenCalledTimes(1);
+		expect(capturedArtifactsDir).toBeTruthy();
+		await expect(fs.stat(capturedArtifactsDir!)).resolves.toBeDefined();
+		await fs.rm(capturedArtifactsDir!, { recursive: true, force: true });
 	});
 
 	it("bounds concurrent job bodies with the session spawn semaphore", async () => {

--- a/packages/coding-agent/test/task/task-spawn.test.ts
+++ b/packages/coding-agent/test/task/task-spawn.test.ts
@@ -216,7 +216,11 @@ describe("task spawn routing", () => {
 		// retentionMs: 0 evicts synchronously once the job settles so the
 		// test does not have to wait out the real 5-minute default
 		// retention window.
-		const manager = new AsyncJobManager({ onJobComplete: () => {}, retentionMs: 0 });
+		const manager = new AsyncJobManager({
+			onJobComplete: () => {},
+			retentionMs: 0,
+			retainedArtifactsCleanupGraceMs: 0,
+		});
 		managers.push(manager);
 		const tool = await TaskTool.create(createSession({ manager }));
 

--- a/packages/coding-agent/test/tools/hub-jobs-structured.test.ts
+++ b/packages/coding-agent/test/tools/hub-jobs-structured.test.ts
@@ -1,0 +1,121 @@
+/**
+ * `buildJobResult` structured-output rendering (`hub wait`/`jobs`/`cancel`
+ * text). Regression coverage: valid results must not inline a truncated JSON
+ * block (breaks async-result.md's contract of pointing to `agent://<id>`
+ * instead, and can emit invalid JSON once truncated at 4k), and any result
+ * carrying data must advertise the `agent://<id>` handle (PR #10625 review).
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { AsyncJobManager } from "@oh-my-pi/pi-coding-agent/async/job-manager";
+import type { AsyncJobRunResult } from "@oh-my-pi/pi-coding-agent/async/job-manager";
+import { IrcBus } from "@oh-my-pi/pi-coding-agent/irc/bus";
+import { AgentRegistry } from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
+import type { StructuredSubagentOutput } from "@oh-my-pi/pi-coding-agent/task/types";
+import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+import { HubTool } from "@oh-my-pi/pi-coding-agent/tools/hub";
+
+const SELF_ID = "Main";
+
+function makeSession(manager: AsyncJobManager): ToolSession {
+	const stub = {
+		cwd: process.cwd(),
+		settings: {
+			get(key: string): unknown {
+				if (key === "async.pollWaitDuration") return "5m";
+				if (key === "irc.timeoutMs") return 120_000;
+				return undefined;
+			},
+		},
+		agentRegistry: AgentRegistry.global(),
+		asyncJobManager: manager,
+		getAgentId: () => SELF_ID,
+	};
+	// Structurally-partial test session: HubTool only touches the fields above.
+	return stub as unknown as ToolSession;
+}
+
+/** Register a job that immediately settles with the given text + structured payload. */
+function registerSettledJob(
+	manager: AsyncJobManager,
+	label: string,
+	text: string,
+	structured: StructuredSubagentOutput,
+	agentId?: string,
+): string {
+	return manager.register("task", label, async () => ({ text, structured }), { ownerId: SELF_ID, agentId });
+}
+
+describe("hub jobs structured output rendering", () => {
+	beforeEach(() => {
+		AgentRegistry.resetGlobalForTests();
+		IrcBus.resetGlobalForTests();
+	});
+	afterEach(() => {
+		AgentRegistry.resetGlobalForTests();
+		IrcBus.resetGlobalForTests();
+	});
+
+	test("a schema-valid result advertises the agent:// pointer instead of inlining JSON", async () => {
+		const manager = new AsyncJobManager({ onJobComplete: () => {} });
+		const jobId = registerSettledJob(
+			manager,
+			"ValidJob",
+			"<task-result>done</task-result>",
+			{ source: "agent", mode: "permissive", status: "valid", data: { ok: true, count: 7 } },
+			"ValidJob",
+		);
+		const tool = new HubTool(makeSession(manager));
+
+		const result = await tool.execute("call_1", { op: "wait", ids: [jobId] });
+		const text = result.content[0]?.type === "text" ? result.content[0].text : "";
+
+		expect(text).toContain("Structured output: schema valid");
+		expect(text).toContain("full payload at agent://ValidJob");
+		expect(text).toContain("fields via agent://ValidJob?q=.<field>");
+		// The truncated inline JSON block must not appear for a valid result.
+		expect(text).not.toContain("```json");
+	});
+
+	test("a schema-invalid result keeps the truncated JSON preview alongside the pointer", async () => {
+		const manager = new AsyncJobManager({ onJobComplete: () => {} });
+		const jobId = registerSettledJob(
+			manager,
+			"InvalidJob",
+			"<task-result>done</task-result>",
+			{ source: "agent", mode: "permissive", status: "invalid", data: { wrong: "shape" }, error: "missing field" },
+			"InvalidJob",
+		);
+		const tool = new HubTool(makeSession(manager));
+
+		const result = await tool.execute("call_2", { op: "wait", ids: [jobId] });
+		const text = result.content[0]?.type === "text" ? result.content[0].text : "";
+
+		expect(text).toContain("Structured output: schema invalid: missing field");
+		expect(text).toContain("full payload at agent://InvalidJob");
+		expect(text).toContain("```json");
+		expect(text).toContain('"wrong": "shape"');
+	});
+
+	test("advertises the disambiguated agentId, not the collision-suffixed job id", async () => {
+		// A task job can reuse a vibe turn's job id, forcing the manager to
+		// suffix `jobId` (e.g. `Foo` -> `Foo-2`) while the task's artifacts
+		// are still written under its own agent id.
+		const manager = new AsyncJobManager({ onJobComplete: () => {} });
+		const { promise: hangs } = Promise.withResolvers<AsyncJobRunResult>();
+		manager.register("task", "collider", async () => hangs, { ownerId: SELF_ID, id: "Foo" });
+		const jobId = registerSettledJob(
+			manager,
+			"Foo",
+			"<task-result>done</task-result>",
+			{ source: "agent", mode: "permissive", status: "valid", data: { ok: true } },
+			"Foo",
+		);
+		expect(jobId).not.toBe("Foo");
+		const tool = new HubTool(makeSession(manager));
+
+		const result = await tool.execute("call_3", { op: "wait", ids: [jobId] });
+		const text = result.content[0]?.type === "text" ? result.content[0].text : "";
+
+		expect(text).toContain(`full payload at agent://Foo,`);
+	});
+});


### PR DESCRIPTION
## What
Background (`async`) `task` spawns now carry their schema-validated structured output through to delivery. Previously `task/index.ts` collapsed the finished job to plain text before `AsyncJobManager` saw it, so `outputSchema` only worked on blocking spawns.

- `AsyncJob` gains an optional structured payload; it survives redelivery and dead-letter.
- The `async-result` message includes the parsed data in `details.jobs[]`.
- `finalizeRunResult()` writes a `<id>.json` sidecar next to `<id>.md`; `agent://<id>/<field>` and `?q=` read the sidecar first.
- `schemaMode: "strict"` failure on an async job marks the job failed with the validation error, mirroring the existing blocking behaviour.

No change to `schemaMode` semantics or to the `eval` `agent()` bridge, which already returned `data`.

## Why
In the extension I'm building, every subagent returns a structured JSON result that my extension validates and then turns into an actual state mutation. Since the agent is readonly and doesn't have access to any write tools, the structured payload is the actual work product. `structuredOutput` only reaches the main agent on the task tool's `tool_result`, so I had to declare `blocking: true` on all six agents and dispatch them in batches so I could get multiple results from one blocking call. This works, but a single slow item holds every finished item's writes hostage, and one failed item means we have to retry everything in the batch. If a background spawn's `async-result` carried the same validated payload, I would be able to fire each item independently and apply them as they finish.

## Testing
- Spawned a non-blocking task with an `outputSchema` and waited for auto-delivery. The `async-result` details contained parsed JSON and `agent://<id>/<field>` resolved.
- Confirmed that a strict-mode task returning invalid JSON results in a job status of `failed` and error text shows the validation message.
- Tests: job-manager/async-job-delivery (structured delivery + strict failure), agent-protocol (sidecar resolution).
- The task tool prompt no longer implies blocking is required; CHANGELOG under Unreleased/Fixed.

---
- [X] `bun check` passes
- [X] Tested locally
- [X] CHANGELOG updated