### PR TITLE
fix(coding-agent): invalidate every gh mutation target

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Bash `gh issue` and `gh pr` cache invalidation so option values are not mistaken for targets and every positional issue or pull request is refreshed ([#10626](https://github.com/can1357/oh-my-pi/issues/10626)).
+
 ## [18.1.5] - 2026-09-03
 
 ### Added

--- a/packages/coding-agent/src/tools/gh-cache-invalidation.ts
+++ b/packages/coding-agent/src/tools/gh-cache-invalidation.ts
@@ -69,6 +69,7 @@ const VALUE_TAKING_FLAGS: ReadonlySet<string> = new Set([
 	"--body",
 	"-F",
 	"--body-file",
+	"--attach",
 	"-a",
 	"--assignee",
 	"--add-assignee",
@@ -81,6 +82,13 @@ const VALUE_TAKING_FLAGS: ReadonlySet<string> = new Set([
 	"--project",
 	"--add-project",
 	"--remove-project",
+	"--parent",
+	"--add-sub-issue",
+	"--remove-sub-issue",
+	"--add-blocked-by",
+	"--add-blocking",
+	"--remove-blocked-by",
+	"--remove-blocking",
 	"--add-reviewer",
 	"--remove-reviewer",
 	"-B",
@@ -90,20 +98,35 @@ const VALUE_TAKING_FLAGS: ReadonlySet<string> = new Set([
 	"-r",
 	"--reason",
 	"--branch",
+	"--worktree",
+	"--branch-repo",
+	"-n",
+	"--name",
 	"--subject",
 	"--match-head-commit",
 	"--author-email",
 ]);
+
+interface GhMutationTarget {
+	number: number;
+	repo?: string;
+}
+
+interface GhMutation {
+	repo?: string;
+	targets: GhMutationTarget[];
+}
+
 /**
  * Walk a single shell command's token stream looking for a top-level
- * `gh (issue|pr) <subcmd> [<id-or-url>]` invocation and return the
- * invalidation key when one is found. `number === undefined` means the
+ * `gh (issue|pr) <subcmd> [<id-or-url>...]` invocation and return every
+ * invalidation target when one is found. An empty target list means the
  * subcommand mutates state but names no identifier (gh defaults to the
  * current branch's PR), so the caller must fall back to repo-wide
  * invalidation. Returns `null` for non-matching commands so the caller can
  * iterate cheaply.
  */
-function detectGhMutation(tokens: readonly string[]): { number?: number; repo?: string } | null {
+function detectGhMutation(tokens: readonly string[]): GhMutation | null {
 	const ghIdx = tokens.indexOf("gh");
 	if (ghIdx === -1) return null;
 	const subject = tokens[ghIdx + 1];
@@ -129,6 +152,7 @@ function detectGhMutation(tokens: readonly string[]): { number?: number; repo?: 
 			repo = token.slice("--repo=".length);
 		}
 	}
+	const targets: GhMutationTarget[] = [];
 	for (let i = ghIdx + 3; i < tokens.length; i++) {
 		const token = tokens[i];
 		if (token === "-R" || token === "--repo" || VALUE_TAKING_FLAGS.has(token)) {
@@ -140,20 +164,21 @@ function detectGhMutation(tokens: readonly string[]): { number?: number; repo?: 
 		if (token.startsWith("-")) continue;
 		const direct = /^\d+$/.test(token) ? Number(token) : undefined;
 		if (direct !== undefined && Number.isSafeInteger(direct) && direct > 0) {
-			return repo !== undefined ? { number: direct, repo } : { number: direct };
+			targets.push(repo !== undefined ? { number: direct, repo } : { number: direct });
+			continue;
 		}
 		const urlMatch = (subject === "pr" ? PR_URL_PATTERN : ISSUE_URL_PATTERN).exec(token);
 		if (urlMatch) {
 			const num = Number(urlMatch[3]);
 			if (Number.isSafeInteger(num) && num > 0) {
-				// URL carries its own repo and wins over a stray --repo flag.
-				return { number: num, repo: formatRepoRef(urlMatch[1], urlMatch[2]) };
+				// A URL carries its own repo and wins over a stray --repo flag.
+				targets.push({ number: num, repo: formatRepoRef(urlMatch[1], urlMatch[2]) });
 			}
 		}
 	}
-	// Mutating subcommand with no identifier: gh operates on the current
-	// branch's PR, which we cannot resolve synchronously here.
-	return repo !== undefined ? { repo } : {};
+	// Mutating subcommand with no identifier falls back to repo-wide
+	// invalidation; otherwise every positional target is invalidated.
+	return repo !== undefined ? { repo, targets } : { targets };
 }
 
 /**
@@ -167,10 +192,12 @@ export function invalidateGithubCacheForBashCommand(command: string): void {
 	for (const segment of segments) {
 		const hit = detectGhMutation(segment);
 		if (!hit) continue;
-		if (hit.number !== undefined) {
-			invalidateAllForNumber(hit.number, hit.repo);
-		} else {
+		if (hit.targets.length === 0) {
 			invalidateAllForRepo(hit.repo);
+			continue;
+		}
+		for (const target of hit.targets) {
+			invalidateAllForNumber(target.number, target.repo);
 		}
 	}
 }

--- a/packages/coding-agent/test/tools/gh-cache-invalidation.test.ts
+++ b/packages/coding-agent/test/tools/gh-cache-invalidation.test.ts
@@ -188,6 +188,22 @@ describe("invalidateGithubCacheForBashCommand", () => {
 		expect(getCached(REPO, "pr", 3, true)?.rendered).toBe(`pr-${REPO}-3`);
 	});
 
+	it("skips relationship flag values before the positional issue number", () => {
+		seedIssue(23);
+		seedIssue(100);
+		invalidateGithubCacheForBashCommand("gh issue edit --parent 100 23");
+		expect(getCached(REPO, "issue", 23, true)).toBeNull();
+		expect(getCached(REPO, "issue", 100, true)?.rendered).toBe(`issue-${REPO}-100`);
+	});
+
+	it("drops cache for every positional issue number", () => {
+		seedIssue(23);
+		seedIssue(34);
+		invalidateGithubCacheForBashCommand("gh issue edit 23 34 --add-label bug");
+		expect(getCached(REPO, "issue", 23, true)).toBeNull();
+		expect(getCached(REPO, "issue", 34, true)).toBeNull();
+	});
+
 	it("falls back to repo-wide invalidation for current-branch `gh pr merge`", () => {
 		seedPr(7);
 		invalidateGithubCacheForBashCommand("gh pr merge --squash --delete-branch");


### PR DESCRIPTION
## Repro
Seed issue cache rows for #23/#100 and #23/#34, then run `bun test packages/coding-agent/test/tools/gh-cache-invalidation.test.ts`. Before the fix, `gh issue edit --parent 100 23` leaves #23 cached and `gh issue edit 23 34 --add-label bug` leaves #34 cached; the suite reports 16 pass and 2 fail.

## Cause
`detectGhMutation` in `packages/coding-agent/src/tools/gh-cache-invalidation.ts` returned immediately on the first positional target, while `VALUE_TAKING_FLAGS` omitted relationship, attachment, and issue-develop options whose numeric values were consequently parsed as target numbers.

## Fix
- Add the missing value-taking `gh` options so their arguments are skipped.
- Collect and invalidate every positional issue or pull request target, preserving URL-specific repository scoping.
- Add regressions for numeric relationship values and multi-target issue edits.
- Document the user-visible fix in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/tools/gh-cache-invalidation.test.ts` passes with 18 tests and 25 assertions. The pre-publish gate completed `bun run fix` and `bun check`.

Fixes #10626