### PR TITLE
feat(coding-agent): add deliverAs "aside" for non-interrupting extension messages

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -190,9 +190,10 @@ Also exposed:
 - `deliverAs: "steer"` (default) — interrupts current run
 - `deliverAs: "followUp"` — queued to run after current run
 - `deliverAs: "nextTurn"` — stored and injected on the next user prompt
+- `deliverAs: "aside"` — injected at the next agent step boundary without interrupting the current tool batch; when idle it starts a turn (`triggerTurn` is ignored; plan mode folds it into context instead)
 - `triggerTurn: true` — starts a turn when idle (also honored with `deliverAs: "nextTurn"`: idle prompts immediately; while streaming the queued message schedules an internal continuation)
 
-`pi.sendUserMessage(content, { deliverAs })` always goes through prompt flow. Omit `deliverAs` to start a normal prompt when idle; while streaming, omitted `deliverAs` queues the message as a steer. Set `deliverAs: "followUp"` to wait until the current run finishes.
+`pi.sendUserMessage(content, { deliverAs })` always goes through prompt flow. Omit `deliverAs` to start a normal prompt when idle; while streaming, omitted `deliverAs` queues the message as a steer. Set `deliverAs: "followUp"` to wait until the current run finishes. Set `deliverAs: "aside"` to inject the prompt at the next step boundary while a run is live (idle sends start a turn as usual).
 
 Payloads passed to `pi.sendMessage` are normalized before delivery (`normalizeCustomMessagePayload` in `session/messages.ts`): non-object payloads are coerced to string content under the default custom type, missing `customType`/`attribution` fields are defaulted, and invalid content collapses to an empty string — malformed payloads no longer persist entries that crash later session resumes.
 

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -264,6 +264,8 @@ Related APIs:
 - `sendCustomMessage({ customType, content, ... }, { deliverAs?, triggerTurn? })`
 - `abort()`
 
+`deliverAs: "aside"` (both APIs) delivers at the next agent step boundary without interrupting the current tool batch, instead of steering (which skips remaining tools) or waiting for the run to finish. When the session is idle both start a turn instead (in plan mode the custom message is folded into context without a turn).
+
 ## `AgentSession` lifecycle and disposal
 
 Call `await session.dispose()` when the embedder is completely done with a session. `dispose()` starts disposal itself and is idempotent: repeated or concurrent calls receive the same teardown promise, so shutdown events and owned resources are not drained twice.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fixed a stranded extension/user aside surviving a `newSession()`/`switchSession()` transition and leaking into the new session's transcript on its first prompt.
 - Fixed a displayable custom aside folded into context after going stranded mid-stream never emitting the `message_end` its sender's UI rebuild-skip decision was waiting on, leaving the message invisible until an unrelated transcript rebuild.
 - Fixed `sendUserMessage(..., { deliverAs: "aside" })` degrading into a tool-batch-aborting steer when a turn started streaming during `prompt()`'s own setup (manual-compaction cleanup or image normalization), instead of staying non-interrupting.
+- Fixed `sendMessage(..., { deliverAs: "aside" })` remaining undelivered until an unrelated prompt if the active run settled while the custom aside awaited image normalization, instead of resuming into the documented idle wake turn.
 
 ## [18.1.5] - 2026-09-03
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -17,6 +17,9 @@
 - Fixed `IrcBridge.restorePending()` discarding IRC/extension records queued while a rolled-back `switchSession()` was still tearing down, instead of merging them back in delivery order.
 - Fixed `sendUserMessage(..., { deliverAs: "aside" })`/`sendMessage(..., { deliverAs: "aside" })` leaking a record into the wrong session's transcript when image normalization outlived a concurrent `newSession()`/`switchSession()`, instead of dropping it once the source session generation changes.
 - Fixed the plan-mode and post-interrupt fold branches for `sendCustomMessage(..., { deliverAs: "aside" })` appending directly to context instead of routing through the event-emitting fold path, so a displayable aside that began streaming again emits the `message_end` its sender's UI rebuild-skip decision expects.
+- Fixed `sendCustomMessage(..., { deliverAs: "aside" })`'s idle-session branch (plan-mode fold, post-interrupt fold, or an autonomous turn) never validating the source session generation, so an aside whose image normalization outlived a concurrent `newSession()`/`switchSession()` could still land in the newly selected session.
+- Fixed a user aside whose image normalization resolved after a `newSession()`/`switchSession()` had disconnected the agent but before it bumped the session generation, which could wake a fresh `agent.prompt()` on the disconnected agent and race the transition's own reset instead of being dropped like other stranded records.
+- Fixed the `#sessionGeneration` guard in `sendUserMessage(..., { deliverAs: "aside" })`/`sendMessage(..., { deliverAs: "aside" })` permanently discarding a record on any generation mismatch, even when a `switchSession()` that bumped the generation subsequently failed and rolled back to the exact same session — the record now waits out the in-flight transition and is preserved.
 
 ## [18.1.5] - 2026-09-03
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Fixed a stranded extension/user aside surviving a `newSession()`/`switchSession()` transition and leaking into the new session's transcript on its first prompt.
 - Fixed a displayable custom aside folded into context after going stranded mid-stream never emitting the `message_end` its sender's UI rebuild-skip decision was waiting on, leaving the message invisible until an unrelated transcript rebuild.
+- Fixed `sendUserMessage(..., { deliverAs: "aside" })` degrading into a tool-batch-aborting steer when a turn started streaming during `prompt()`'s own setup (manual-compaction cleanup or image normalization), instead of staying non-interrupting.
 
 ## [18.1.5] - 2026-09-03
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,6 +12,9 @@
 - Fixed a displayable custom aside folded into context after going stranded mid-stream never emitting the `message_end` its sender's UI rebuild-skip decision was waiting on, leaving the message invisible until an unrelated transcript rebuild.
 - Fixed `sendUserMessage(..., { deliverAs: "aside" })` degrading into a tool-batch-aborting steer when a turn started streaming during `prompt()`'s own setup (manual-compaction cleanup or image normalization), instead of staying non-interrupting.
 - Fixed `sendMessage(..., { deliverAs: "aside" })` remaining undelivered until an unrelated prompt if the active run settled while the custom aside awaited image normalization, instead of resuming into the documented idle wake turn.
+- Fixed `sendMessage(..., { deliverAs: "aside" })` starting a fresh autonomous turn and undoing a user's Esc interrupt when image normalization outlasted the interrupt, instead of folding the aside into context and staying user-driven.
+- Fixed `sendCustomMessage(..., { deliverAs: "aside" | "nextTurn", triggerTurn: true })` always reporting a started turn even when an abort or session-generation change raced the usage-aware preflight and the agent turn never actually dispatched, which could leave RPC callers waiting on agent events that never arrive.
+- Fixed `IrcBridge.restorePending()` discarding IRC/extension records queued while a rolled-back `switchSession()` was still tearing down, instead of merging them back in delivery order.
 
 ## [18.1.5] - 2026-09-03
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+### Added
+
+- Extensions can deliver messages without interrupting the agent: `pi.sendMessage`/`pi.sendUserMessage` now accept `deliverAs: "aside"`, which injects at the next step boundary instead of interrupting the current tool batch.
+
+### Fixed
+
+- Fixed a stranded extension/user aside surviving a `newSession()`/`switchSession()` transition and leaking into the new session's transcript on its first prompt.
+- Fixed a displayable custom aside folded into context after going stranded mid-stream never emitting the `message_end` its sender's UI rebuild-skip decision was waiting on, leaving the message invisible until an unrelated transcript rebuild.
+
 ## [18.1.5] - 2026-09-03
 
 ### Added
@@ -31,9 +40,6 @@
 ### Removed
 
 - Removed the bundled `designer` subagent and `designer` model role; `modelRoles.designer` and `@designer` are no longer built in.
-### Added
-
-- Extensions can deliver messages without interrupting the agent: `pi.sendMessage`/`pi.sendUserMessage` now accept `deliverAs: "aside"`, which injects at the next step boundary instead of interrupting the current tool batch.
 
 ## [18.1.3] - 2026-09-02
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -31,6 +31,9 @@
 ### Removed
 
 - Removed the bundled `designer` subagent and `designer` model role; `modelRoles.designer` and `@designer` are no longer built in.
+### Added
+
+- Extensions can deliver messages without interrupting the agent: `pi.sendMessage`/`pi.sendUserMessage` now accept `deliverAs: "aside"`, which injects at the next step boundary instead of interrupting the current tool batch.
 
 ## [18.1.3] - 2026-09-02
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -15,6 +15,8 @@
 - Fixed `sendMessage(..., { deliverAs: "aside" })` starting a fresh autonomous turn and undoing a user's Esc interrupt when image normalization outlasted the interrupt, instead of folding the aside into context and staying user-driven.
 - Fixed `sendCustomMessage(..., { deliverAs: "aside" | "nextTurn", triggerTurn: true })` always reporting a started turn even when an abort or session-generation change raced the usage-aware preflight and the agent turn never actually dispatched, which could leave RPC callers waiting on agent events that never arrive.
 - Fixed `IrcBridge.restorePending()` discarding IRC/extension records queued while a rolled-back `switchSession()` was still tearing down, instead of merging them back in delivery order.
+- Fixed `sendUserMessage(..., { deliverAs: "aside" })`/`sendMessage(..., { deliverAs: "aside" })` leaking a record into the wrong session's transcript when image normalization outlived a concurrent `newSession()`/`switchSession()`, instead of dropping it once the source session generation changes.
+- Fixed the plan-mode and post-interrupt fold branches for `sendCustomMessage(..., { deliverAs: "aside" })` appending directly to context instead of routing through the event-emitting fold path, so a displayable aside that began streaming again emits the `message_end` its sender's UI rebuild-skip decision expects.
 
 ## [18.1.5] - 2026-09-03
 

--- a/packages/coding-agent/src/extensibility/extensions/loader.ts
+++ b/packages/coding-agent/src/extensibility/extensions/loader.ts
@@ -258,14 +258,14 @@ class ConcreteExtensionAPI implements ExtensionAPI, IExtensionRuntime {
 
 	sendMessage<T = unknown>(
 		message: CustomMessagePayload<T>,
-		options?: { triggerTurn?: boolean; deliverAs?: "steer" | "followUp" | "nextTurn" },
+		options?: { triggerTurn?: boolean; deliverAs?: "steer" | "followUp" | "nextTurn" | "aside" },
 	): void {
 		this.runtime.sendMessage(message, options);
 	}
 
 	sendUserMessage(
 		content: string | (TextContent | ImageContent)[],
-		options?: { deliverAs?: "steer" | "followUp" },
+		options?: { deliverAs?: "steer" | "followUp" | "aside" },
 	): void {
 		this.runtime.sendUserMessage(content, options);
 	}

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -1422,16 +1422,22 @@ export interface ExtensionAPI {
 	 * `deliverAs: "nextTurn"` keeps the message hidden from the editable pending-message UI.
 	 * If `triggerTurn` is also true while the current turn is still unwinding, the session schedules
 	 * an internal continuation that consumes the message on the next turn.
+	 *
+	 * `deliverAs: "aside"` injects the message at the next agent step boundary without interrupting
+	 * the in-flight tool batch; when the session is idle it starts a turn regardless of `triggerTurn`
+	 * (plan mode folds it into context instead).
 	 */
 	sendMessage<T = unknown>(
 		message: CustomMessagePayload<T>,
-		options?: { triggerTurn?: boolean; deliverAs?: "steer" | "followUp" | "nextTurn" },
+		options?: { triggerTurn?: boolean; deliverAs?: "steer" | "followUp" | "nextTurn" | "aside" },
 	): void;
 
-	/** Send a user prompt: idle starts a turn; streaming queues as steer unless deliverAs is set. */
+	/** Send a user prompt: idle starts a turn; streaming queues as steer unless deliverAs is set.
+	 *  `deliverAs: "aside"` injects at the next step boundary without interrupting the in-flight tool
+	 *  batch while streaming; idle still starts a turn. */
 	sendUserMessage(
 		content: string | (TextContent | ImageContent)[],
-		options?: { deliverAs?: "steer" | "followUp" },
+		options?: { deliverAs?: "steer" | "followUp" | "aside" },
 	): void;
 
 	/** Append a custom entry to the session for state persistence (not sent to LLM). */
@@ -1643,13 +1649,17 @@ export type SendMessageHandler = <T = unknown>(
 	 * `deliverAs: "nextTurn"` queues hidden custom context for the next turn.
 	 * When paired with `triggerTurn: true` during prompt teardown, the session schedules
 	 * an internal continuation without surfacing the message in the editable pending queue.
+	 * `deliverAs: "aside"` injects at the next step boundary without interrupting the in-flight
+	 * tool batch; idle starts a turn regardless of `triggerTurn` (plan mode folds into context).
 	 */
-	options?: { triggerTurn?: boolean; deliverAs?: "steer" | "followUp" | "nextTurn" },
+	options?: { triggerTurn?: boolean; deliverAs?: "steer" | "followUp" | "nextTurn" | "aside" },
 ) => void;
 
+/** `deliverAs: "aside"` injects at the next step boundary without interrupting the in-flight tool
+ *  batch while streaming; idle still starts a turn. */
 export type SendUserMessageHandler = (
 	content: string | (TextContent | ImageContent)[],
-	options?: { deliverAs?: "steer" | "followUp" },
+	options?: { deliverAs?: "steer" | "followUp" | "aside" },
 ) => void;
 
 export type AppendEntryHandler = <T = unknown>(customType: string, data?: T) => void;

--- a/packages/coding-agent/src/modes/runtime-init.ts
+++ b/packages/coding-agent/src/modes/runtime-init.ts
@@ -58,11 +58,21 @@ export async function initializeExtensions(session: AgentSession, options: Initi
 		{
 			sendMessage: (message, sendOptions) => {
 				const sendTask = session.sendCustomMessage(message, sendOptions);
-				if (sendOptions?.triggerTurn) {
+				if (sendOptions?.triggerTurn || sendOptions?.deliverAs === "aside") {
+					// sendCustomMessage resolves `false` for outcomes that provably start no turn
+					// (streaming queue, idle plan-mode fold, deferred ACP turn) — only a `true`
+					// result should mark this send as agent-invoking, so downstream trackers (RPC's
+					// hasAgentMessageTask) don't wait on agent events that will never arrive.
+					const invokingTask = sendTask.then(started => {
+						if (!started) throw new Error("send did not invoke the agent");
+					});
 					if (trackAgentInvokingMessage) {
-						trackAgentInvokingMessage(sendTask);
+						trackAgentInvokingMessage(invokingTask);
 					} else {
-						markAgentInvokingMessage?.();
+						invokingTask.then(
+							() => markAgentInvokingMessage?.(),
+							() => {},
+						);
 					}
 				}
 				sendTask.catch(e => {

--- a/packages/coding-agent/src/session/agent-session-types.ts
+++ b/packages/coding-agent/src/session/agent-session-types.ts
@@ -329,8 +329,10 @@ export interface PromptOptions {
 	expandPromptTemplates?: boolean;
 	/** Image attachments. */
 	images?: ImageContent[];
-	/** Queue behavior while streaming. */
-	streamingBehavior?: "steer" | "followUp";
+	/** Queue behavior while streaming. `"aside"` is non-interrupting — it does not steer/follow-up
+	 *  an in-flight tool batch, injecting at the next step boundary instead (see
+	 *  AgentSession.sendUserMessage's `deliverAs: "aside"`). */
+	streamingBehavior?: "steer" | "followUp" | "aside";
 	/** Optional tool choice override for the next LLM call. */
 	toolChoice?: ToolChoice;
 	/** Send as a developer/system message instead of user. */

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -646,7 +646,7 @@ export class AgentSession {
 
 	readonly #irc: IrcBridge;
 	#ircWakeTurnObserver:
-		| ((records: CustomMessage[]) => ((error?: unknown) => void | Promise<void>) | undefined)
+		| ((records: AgentMessage[]) => ((error?: unknown) => void | Promise<void>) | undefined)
 		| undefined;
 	// Agent identity (registry id) used for IRC routing and job ownership.
 	#agentId: string | undefined;
@@ -879,7 +879,33 @@ export class AgentSession {
 		if (this.#planModeState?.enabled) {
 			// Plan mode: fold stranded IRC asides into context without waking an
 			// autonomous turn. Convergence to ask/resolve stays user-driven.
+			this.#foldStrandedIrcAsidesIntoContext(records);
+			return;
+		}
+		if (this.#advisors.autoResumeSuppressed) {
+			// A user interrupt is still in effect (clearQueue({ forInterrupt: true }) already
+			// dropped these same records from the agent-core queues to keep the run the user
+			// stopped from auto-resuming). Only a real peer IRC message justifies waking a fresh
+			// turn here; extension/user asides fold into context like the plan-mode branch above,
+			// staying user-driven until the next deliberate prompt.
+			const wake: AgentMessage[] = [];
+			const fold: AgentMessage[] = [];
 			for (const record of records) {
+				if (record.role === "custom" && record.customType === "irc:incoming") wake.push(record);
+				else fold.push(record);
+			}
+			this.#foldStrandedIrcAsidesIntoContext(fold);
+			if (wake.length > 0) this.#wakeForIrc(wake);
+			return;
+		}
+		this.#wakeForIrc(records);
+	}
+
+	/** Persist stranded IRC/extension asides into context without starting a turn — shared by the
+	 *  plan-mode branch and the post-interrupt fold branch of #resumeStrandedIrcAsides. */
+	#foldStrandedIrcAsidesIntoContext(records: AgentMessage[]): void {
+		for (const record of records) {
+			if (record.role === "custom") {
 				this.agent.appendMessage(record);
 				this.sessionManager.appendCustomMessageEntry(
 					record.customType,
@@ -888,10 +914,13 @@ export class AgentSession {
 					record.details,
 					record.attribution ?? "agent",
 				);
+				continue;
 			}
-			return;
+			// Non-custom asides (extension user-role sends) persist through #persistMessageEnd,
+			// same as IrcBridge.flushPending().
+			this.agent.emitExternalEvent({ type: "message_start", message: record });
+			this.agent.emitExternalEvent({ type: "message_end", message: record });
 		}
-		this.#wakeForIrc(records);
 	}
 
 	/** Fire-and-forget wake turn for incoming IRC — idle delivery and stranded-aside resume both
@@ -901,9 +930,9 @@ export class AgentSession {
 	 *  it, so park the follow-up queue across the wake and restore it after. It stays queued post-wake
 	 *  because #canAutoContinueForFollowUp suppresses follow-up auto-resume while a user interrupt is
 	 *  in effect, even though the wake left a provider-valid tail. */
-	#wakeForIrc(records: CustomMessage[]): void {
+	#wakeForIrc(records: AgentMessage[]): void {
 		if (this.#modeExitDrainSuppressionDepth > 0) {
-			this.#irc.deferWake(records);
+			this.#irc.queueAside(records);
 			return;
 		}
 		// Park only a *blocked* follow-up (one a user interrupt is intentionally holding); an
@@ -5474,7 +5503,7 @@ export class AgentSession {
 	/**
 	 * Inject the plan mode context message into the conversation history.
 	 */
-	async sendPlanModeContext(options?: { deliverAs?: "steer" | "followUp" | "nextTurn" }): Promise<void> {
+	async sendPlanModeContext(options?: { deliverAs?: "steer" | "followUp" | "nextTurn" | "aside" }): Promise<void> {
 		const message = await this.#buildPlanModeMessage();
 		if (!message) return;
 		await this.sendCustomMessage(
@@ -5488,7 +5517,7 @@ export class AgentSession {
 		);
 	}
 
-	async sendGoalModeContext(options?: { deliverAs?: "steer" | "followUp" | "nextTurn" }): Promise<void> {
+	async sendGoalModeContext(options?: { deliverAs?: "steer" | "followUp" | "nextTurn" | "aside" }): Promise<void> {
 		const message = this.#buildGoalModeMessage();
 		if (!message) return;
 		await this.sendCustomMessage(
@@ -5503,7 +5532,7 @@ export class AgentSession {
 		);
 	}
 
-	async sendVibeModeContext(options?: { deliverAs?: "steer" | "followUp" | "nextTurn" }): Promise<void> {
+	async sendVibeModeContext(options?: { deliverAs?: "steer" | "followUp" | "nextTurn" | "aside" }): Promise<void> {
 		const message = this.#buildVibeModeMessage();
 		if (!message) return;
 		await this.sendCustomMessage(
@@ -6563,7 +6592,7 @@ export class AgentSession {
 	async #queueUserMessage(
 		text: string,
 		images: ImageContent[] | undefined,
-		mode: "steer" | "followUp",
+		mode: "steer" | "followUp" | "aside",
 		timestamp?: number,
 		preprocessed?: { images: ImageContent[] | undefined; descriptionNotice: CustomMessage | undefined },
 	): Promise<void> {
@@ -6586,6 +6615,18 @@ export class AgentSession {
 			: normalizedImages?.length
 				? await this.#buildImageDescriptionNotice(normalizedImages)
 				: undefined;
+		if (mode === "aside") {
+			const records: AgentMessage[] = [];
+			if (imageDescriptionNotice) records.push(imageDescriptionNotice);
+			records.push({ role: "user", content, attribution: "user", timestamp: timestamp ?? Date.now() });
+			this.#irc.queueAside(records);
+			// The awaits above (image normalization / vision description) can span the run's
+			// settle, so the run may already be idle by the time the record lands in the aside
+			// queue with no loop left to drain it. Resuming here is a no-op while streaming and
+			// wakes/folds correctly once idle (see #resumeStrandedIrcAsides).
+			this.#resumeStrandedIrcAsides();
+			return;
+		}
 		this.#allowQueuedMessageDrainRetry();
 		if (mode === "followUp") {
 			if (imageDescriptionNotice) this.agent.followUp(imageDescriptionNotice);
@@ -6829,7 +6870,7 @@ export class AgentSession {
 	 * Send a custom message to the session. Creates a CustomMessageEntry.
 	 *
 	 * Handles three cases:
-	 * - Streaming: queue as steer/follow-up or store for next turn
+	 * - Streaming: queue as steer/follow-up, aside (next step boundary), or store for next turn
 	 * - Not streaming + triggerTurn: appends to state/session, starts new turn unless the client cannot own it
 	 * - Not streaming + no trigger: appends to state/session, no turn
 	 *
@@ -6843,14 +6884,15 @@ export class AgentSession {
 		message: CustomMessagePayload<T>,
 		options?: {
 			triggerTurn?: boolean;
-			deliverAs?: "steer" | "followUp" | "nextTurn";
+			deliverAs?: "steer" | "followUp" | "nextTurn" | "aside";
 			queueChipText?: string;
 			acceptTerminalEmptyStop?: boolean;
 		},
 	): Promise<boolean> {
 		const normalizedPayload = normalizeCustomMessagePayload<T>(message);
+		const suppressQueueChip = options?.deliverAs === "nextTurn" || options?.deliverAs === "aside";
 		const details =
-			options?.queueChipText && options.deliverAs !== "nextTurn"
+			options?.queueChipText && !suppressQueueChip
 				? ({
 						...((normalizedPayload.details && typeof normalizedPayload.details === "object"
 							? normalizedPayload.details
@@ -6871,6 +6913,14 @@ export class AgentSession {
 		if (this.isStreaming) {
 			if (options?.deliverAs === "nextTurn") {
 				this.#queueHiddenNextTurnMessage(normalizedAppMessage, options?.triggerTurn ?? false);
+				return false;
+			}
+			if (options?.deliverAs === "aside") {
+				// Non-interrupting: the agent loop's step-boundary poll (see the setAsideMessageProvider
+				// registration in the constructor) picks this up without interrupting the current tool
+				// batch. Not an agent-core queue entry, so no drain-retry latch and no idle-queue drain
+				// scheduling here.
+				this.#irc.queueAside([normalizedAppMessage]);
 				return false;
 			}
 			this.#allowQueuedMessageDrainRetry();
@@ -6906,6 +6956,30 @@ export class AgentSession {
 			return false;
 		}
 
+		if (options?.deliverAs === "aside") {
+			if (this.#planModeState?.enabled) {
+				// Plan mode stays user-driven: fold into context without an autonomous turn,
+				// same as IrcBridge.deliver()/#resumeStrandedIrcAsides do in plan mode.
+				this.agent.appendMessage(normalizedAppMessage);
+				this.sessionManager.appendCustomMessageEntry(
+					normalizedAppMessage.customType,
+					normalizedAppMessage.content,
+					normalizedAppMessage.display,
+					normalizedAppMessage.details,
+					normalizedAppMessage.attribution,
+				);
+				return false;
+			}
+			if (this.#clientBridge?.deferAgentInitiatedTurns && !this.#allowAcpAgentInitiatedTurns) {
+				this.#queueHiddenNextTurnMessage(normalizedAppMessage, false);
+				return false;
+			}
+			await this.#promptAgentInitiatedMessage(normalizedAppMessage, {
+				acceptTerminalEmptyStop: options.acceptTerminalEmptyStop === true,
+			});
+			return true;
+		}
+
 		if (options?.triggerTurn) {
 			if (this.#clientBridge?.deferAgentInitiatedTurns && !this.#allowAcpAgentInitiatedTurns) {
 				this.#queueHiddenNextTurnMessage(normalizedAppMessage, false);
@@ -6930,11 +7004,12 @@ export class AgentSession {
 	 * Send a user message through the prompt flow.
 	 *
 	 * Omitted `deliverAs` starts a turn when idle and queues as a steer while streaming.
-	 * Explicit `deliverAs` queues without starting a turn in either state.
+	 * Explicit `deliverAs` queues without starting a turn in either state; `aside` at
+	 * an idle session instead starts a turn, since there is no live run to inject into.
 	 */
 	async sendUserMessage(
 		content: string | (TextContent | ImageContent)[],
-		options?: { deliverAs?: "steer" | "followUp" },
+		options?: { deliverAs?: "steer" | "followUp" | "aside" },
 	): Promise<void> {
 		// Normalize content to text string + optional images
 		let text: string;
@@ -6956,12 +7031,27 @@ export class AgentSession {
 			if (images.length === 0) images = undefined;
 		}
 
-		if (options?.deliverAs === "followUp") {
+		let deliveredAsAside = false;
+		if (options?.deliverAs === "aside") {
+			if (this.isStreaming) {
+				await this.#queueUserMessage(text, images, "aside");
+				return;
+			}
+			// Idle: fall through to the prompt flow below (starts a turn, like an omitted
+			// deliverAs). Re-checked immediately before the prompt() call in case streaming
+			// starts in the gap — prompt()'s own re-check would otherwise degrade a
+			// non-interrupting aside into a tool-skipping steer.
+			deliveredAsAside = true;
+		} else if (options?.deliverAs === "followUp") {
 			await this.#queueUserMessage(text, images, "followUp");
 			return;
-		}
-		if (options?.deliverAs === "steer") {
+		} else if (options?.deliverAs === "steer") {
 			await this.#queueUserMessage(text, images, "steer");
+			return;
+		}
+
+		if (deliveredAsAside && this.isStreaming) {
+			await this.#queueUserMessage(text, images, "aside");
 			return;
 		}
 
@@ -8245,7 +8335,7 @@ export class AgentSession {
 
 	/** Installs task-executor monitoring around autonomous IRC wake turns. */
 	setIrcWakeTurnObserver(
-		observer: ((records: CustomMessage[]) => ((error?: unknown) => void | Promise<void>) | undefined) | undefined,
+		observer: ((records: AgentMessage[]) => ((error?: unknown) => void | Promise<void>) | undefined) | undefined,
 	): void {
 		this.#ircWakeTurnObserver = observer;
 	}

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -902,22 +902,14 @@ export class AgentSession {
 	}
 
 	/** Persist stranded IRC/extension asides into context without starting a turn — shared by the
-	 *  plan-mode branch and the post-interrupt fold branch of #resumeStrandedIrcAsides. */
+	 *  plan-mode branch and the post-interrupt fold branch of #resumeStrandedIrcAsides. All records
+	 *  (custom and non-custom alike) route through emitExternalEvent so message_end both appends to
+	 *  context and notifies event listeners — #persistMessageEnd handles custom-role persistence
+	 *  (sessionManager.appendCustomMessageEntry) from that event, and a displayable custom aside that
+	 *  went stranded mid-stream gets the message_end its sender's rebuild-skip decision expects
+	 *  (extension-ui-controller's #applyCustomMessageDisplay), matching IrcBridge.flushPending(). */
 	#foldStrandedIrcAsidesIntoContext(records: AgentMessage[]): void {
 		for (const record of records) {
-			if (record.role === "custom") {
-				this.agent.appendMessage(record);
-				this.sessionManager.appendCustomMessageEntry(
-					record.customType,
-					record.content,
-					record.display,
-					record.details,
-					record.attribution ?? "agent",
-				);
-				continue;
-			}
-			// Non-custom asides (extension user-role sends) persist through #persistMessageEnd,
-			// same as IrcBridge.flushPending().
 			this.agent.emitExternalEvent({ type: "message_start", message: record });
 			this.agent.emitExternalEvent({ type: "message_end", message: record });
 		}
@@ -6598,8 +6590,12 @@ export class AgentSession {
 	): Promise<void> {
 		// A queued user message (RPC/SDK/collab steer or follow-up, or a typed message
 		// while streaming) is a deliberate resume; re-enable advisor auto-resume that
-		// a user interrupt suppressed.
-		this.#advisors.autoResumeSuppressed = false;
+		// a user interrupt suppressed. An aside is non-interrupting by design — it must
+		// not re-enable auto-resume a user interrupt deliberately suppressed, so it stays
+		// user-driven (folds into context via #resumeStrandedIrcAsides's post-interrupt
+		// branch) until the next deliberate steer/follow-up/prompt, matching the
+		// sendCustomMessage aside path (queueAside), which never touches this flag.
+		if (mode !== "aside") this.#advisors.autoResumeSuppressed = false;
 		// The pre-dispatch re-check in prompt() arrives with normalization and the
 		// vision description already done — reuse them instead of paying a second
 		// vision-model request for the same attachment.
@@ -7492,6 +7488,11 @@ export class AgentSession {
 			this.#memory.rekeyForCurrentSessionId();
 			await this.#memory.resetContextForNewTranscript();
 			this.#pendingNextTurnMessages = [];
+			// The abort above may have skipped the loop's final aside poll (issue: stranded
+			// asides survive an aborted turn by design so a resumed session can still see
+			// them); discard here so they cannot leak into the new session's transcript via
+			// the first ordinary prompt's IrcBridge.flushPending().
+			this.#irc.clearPending();
 			this.#scheduledHiddenNextTurnGeneration = undefined;
 			this.#queuedMessageDrainBlocked = false;
 			this.#usagePreflightReadyForNextModelCall = false;
@@ -8597,6 +8598,10 @@ export class AgentSession {
 		const previousRewoundToolResultIds = new Set(this.#rewoundToolResultIds);
 
 		this.agent.clearAllQueues();
+		// Same rationale as newSession: an aborted turn can skip its final aside poll,
+		// stranding IRC/extension asides meant for the outgoing transcript. Snapshot so a
+		// rolled-back switch (catch block below) restores them for the still-live session.
+		const previousIrcPending = this.#irc.clearPending();
 		this.#pendingNextTurnMessages = [];
 		this.#scheduledHiddenNextTurnGeneration = undefined;
 		this.#queuedMessageDrainBlocked = false;
@@ -8790,6 +8795,7 @@ export class AgentSession {
 			this.agent.setSystemPrompt(previousSystemPrompt);
 			this.agent.replaceMessages(previousAgentMessages);
 			this.agent.replaceQueues(previousSteeringMessages, previousFollowUpMessages);
+			this.#irc.restorePending(previousIrcPending);
 			this.#pendingNextTurnMessages = previousPendingNextTurnMessages;
 			this.#scheduledHiddenNextTurnGeneration = previousScheduledHiddenNextTurnGeneration;
 			this.#queuedMessageDrainBlocked = previousQueuedMessageDrainBlocked;

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -6854,6 +6854,11 @@ export class AgentSession {
 			// sendCustomMessage's streaming aside branch — not an agent-core queue
 			// entry, so no drain-retry latch and no idle-queue drain scheduling.
 			this.#irc.queueAside([normalizedAppMessage]);
+			// The image-normalization await above can span the run's settle, so the run may
+			// already be idle by the time the record lands in the aside queue with no loop
+			// left to drain it. Resuming here is a no-op while streaming and wakes/folds
+			// correctly once idle, matching #queueUserMessage's aside branch.
+			this.#resumeStrandedIrcAsides();
 			return;
 		}
 		this.#allowQueuedMessageDrainRetry();

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -5886,21 +5886,17 @@ export class AgentSession {
 			this.#toolChoiceQueue.removeByLabel("plan-mode-decision");
 		}
 
-		// If streaming, queue via steer() or followUp() based on option
+		// If streaming, queue via steer()/followUp()/aside based on option
 		if (this.isStreaming) {
 			const streamingBehavior = options?.streamingBehavior;
 			if (!streamingBehavior) throw new AgentBusyError();
 
-			// Steer/follow-up the keyword notices BEFORE the queued user message so the
+			// Steer/follow-up/aside the keyword notices BEFORE the queued user message so the
 			// model reads the steering notice ahead of the prompt it modifies.
 			for (const notice of keywordNotices) {
 				await this.#queueCustomMessage(notice, streamingBehavior);
 			}
-			if (streamingBehavior === "followUp") {
-				await this.#queueUserMessage(expandedText, options?.images, "followUp", submittedAt);
-			} else {
-				await this.#queueUserMessage(expandedText, options?.images, "steer", submittedAt);
-			}
+			await this.#queueUserMessage(expandedText, options?.images, streamingBehavior, submittedAt);
 			return true;
 		}
 
@@ -6827,10 +6823,10 @@ export class AgentSession {
 		}
 	}
 
-	/** Queue a custom message without starting a turn, matching steer/follow-up delivery. */
+	/** Queue a custom message without starting a turn, matching steer/follow-up/aside delivery. */
 	async #queueCustomMessage<T = unknown>(
 		message: Pick<CustomMessage<T>, "customType" | "content" | "display" | "details" | "attribution">,
-		deliverAs: "steer" | "followUp",
+		deliverAs: "steer" | "followUp" | "aside",
 		queueChipText?: string,
 	): Promise<void> {
 		const details =
@@ -6853,6 +6849,13 @@ export class AgentSession {
 			timestamp: Date.now(),
 		};
 		const normalizedAppMessage = await this.#normalizeAgentMessageImages(appMessage);
+		if (deliverAs === "aside") {
+			// Non-interrupting: rides the same step-boundary aside poll as
+			// sendCustomMessage's streaming aside branch — not an agent-core queue
+			// entry, so no drain-retry latch and no idle-queue drain scheduling.
+			this.#irc.queueAside([normalizedAppMessage]);
+			return;
+		}
 		this.#allowQueuedMessageDrainRetry();
 		if (deliverAs === "followUp") {
 			this.agent.followUp(normalizedAppMessage);
@@ -7034,9 +7037,7 @@ export class AgentSession {
 				return;
 			}
 			// Idle: fall through to the prompt flow below (starts a turn, like an omitted
-			// deliverAs). Re-checked immediately before the prompt() call in case streaming
-			// starts in the gap — prompt()'s own re-check would otherwise degrade a
-			// non-interrupting aside into a tool-skipping steer.
+			// deliverAs) — there is no live run to inject an aside into.
 			deliveredAsAside = true;
 		} else if (options?.deliverAs === "followUp") {
 			await this.#queueUserMessage(text, images, "followUp");
@@ -7046,18 +7047,17 @@ export class AgentSession {
 			return;
 		}
 
-		if (deliveredAsAside && this.isStreaming) {
-			await this.#queueUserMessage(text, images, "aside");
-			return;
-		}
-
-		// Use prompt() with expandPromptTemplates: false to skip command handling and template expansion.
-		// `streamingBehavior: "steer"` preserves prompt-flow side effects during streaming while
-		// covering the narrow race where a stream starts before prompt() acquires the turn.
+		// Use prompt() with expandPromptTemplates: false to skip command handling and template
+		// expansion. prompt() awaits manual-compaction cleanup and (on the non-streaming path)
+		// image normalization/vision description before dispatching, so a stream can start in
+		// that gap; prompt() re-checks isStreaming at each await boundary and queues via
+		// `streamingBehavior` when it does. Passing "aside" through (instead of hard-coding
+		// "steer") keeps that race from degrading a non-interrupting aside into a
+		// tool-batch-aborting steer.
 		await this.prompt(text, {
 			expandPromptTemplates: false,
 			images,
-			streamingBehavior: "steer",
+			streamingBehavior: deliveredAsAside ? "aside" : "steer",
 		});
 	}
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -6802,13 +6802,17 @@ export class AgentSession {
 		}
 	}
 
+	/** @returns true iff `agent.prompt` was actually invoked. An abort or session-generation
+	 *  change racing the usage-aware preflight can return before dispatch — callers that treat
+	 *  this as proof of agent work (e.g. suppressing a local prompt_result because agent events
+	 *  are expected) must not assume dispatch happened just because this was awaited. */
 	async #promptAgentInitiatedMessage(
 		message: CustomMessage,
 		options?: { acceptTerminalEmptyStop?: boolean },
-	): Promise<void> {
+	): Promise<boolean> {
 		this.#beginInFlight();
 		try {
-			if (!(await this.#runUsageAwarePreflightForNextModelCall())) return;
+			if (!(await this.#runUsageAwarePreflightForNextModelCall())) return false;
 			const acceptTerminalEmptyStop = options?.acceptTerminalEmptyStop === true;
 			if (acceptTerminalEmptyStop) {
 				this.#resetPromptMaintenanceState();
@@ -6816,6 +6820,7 @@ export class AgentSession {
 			this.#recovery.setAcceptTerminalEmptyStop(acceptTerminalEmptyStop);
 			await this.agent.prompt(message);
 			await this.#waitForPostPromptRecovery();
+			return true;
 		} finally {
 			this.#usagePreflightReadyForNextModelCall = false;
 			this.#recovery.setAcceptTerminalEmptyStop(false);
@@ -6944,10 +6949,9 @@ export class AgentSession {
 					this.#queueHiddenNextTurnMessage(normalizedAppMessage, false);
 					return false;
 				}
-				await this.#promptAgentInitiatedMessage(normalizedAppMessage, {
+				return await this.#promptAgentInitiatedMessage(normalizedAppMessage, {
 					acceptTerminalEmptyStop: options.acceptTerminalEmptyStop === true,
 				});
-				return true;
 			}
 			this.agent.appendMessage(normalizedAppMessage);
 			this.sessionManager.appendCustomMessageEntry(
@@ -6974,14 +6978,29 @@ export class AgentSession {
 				);
 				return false;
 			}
+			if (this.#advisors.autoResumeSuppressed) {
+				// A user interrupt (Esc) is still in effect. isStreaming was true when this method
+				// was entered but image normalization above outlasted the interrupt, landing here
+				// instead of the streaming branch's queueAside — starting a fresh autonomous turn
+				// would undo the user's deliberate stop. Fold into context and stay user-driven,
+				// matching #resumeStrandedIrcAsides's post-interrupt fold branch.
+				this.agent.appendMessage(normalizedAppMessage);
+				this.sessionManager.appendCustomMessageEntry(
+					normalizedAppMessage.customType,
+					normalizedAppMessage.content,
+					normalizedAppMessage.display,
+					normalizedAppMessage.details,
+					normalizedAppMessage.attribution,
+				);
+				return false;
+			}
 			if (this.#clientBridge?.deferAgentInitiatedTurns && !this.#allowAcpAgentInitiatedTurns) {
 				this.#queueHiddenNextTurnMessage(normalizedAppMessage, false);
 				return false;
 			}
-			await this.#promptAgentInitiatedMessage(normalizedAppMessage, {
+			return await this.#promptAgentInitiatedMessage(normalizedAppMessage, {
 				acceptTerminalEmptyStop: options.acceptTerminalEmptyStop === true,
 			});
-			return true;
 		}
 
 		if (options?.triggerTurn) {
@@ -6989,8 +7008,7 @@ export class AgentSession {
 				this.#queueHiddenNextTurnMessage(normalizedAppMessage, false);
 				return false;
 			}
-			await this.#promptAgentInitiatedMessage(normalizedAppMessage);
-			return true;
+			return await this.#promptAgentInitiatedMessage(normalizedAppMessage);
 		}
 
 		this.agent.appendMessage(normalizedAppMessage);

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -744,6 +744,13 @@ export class AgentSession {
 	 *  enqueue and fold/resume normally across an in-session interrupt, only a session identity
 	 *  change should drop them. */
 	#sessionGeneration = 0;
+	/** Resolves when the currently in-flight `switchSession()` transition settles (success or
+	 *  rollback). newSession() never rolls #sessionGeneration back so it leaves this unset. An
+	 *  aside-queueing call that hits a #sessionGeneration mismatch awaits this (via
+	 *  #sessionGenerationChanged) before giving up, so a record for the still-live session isn't
+	 *  discarded moments before a rolled-back switchSession() restores the exact generation it
+	 *  was captured against. */
+	#sessionTransitionSettled: Promise<void> | undefined;
 	#promptSequence = 0;
 	#skippedPostTurnSpeculationCompletion: Promise<void> | undefined;
 	#pendingAgentEndEmit: AgentSessionEvent | undefined;
@@ -883,6 +890,12 @@ export class AgentSession {
 		if (this.#modeExitDrainSuppressionDepth > 0 || this.#isDisposed || this.isStreaming || !this.#irc.hasPending()) {
 			return;
 		}
+		// Session transitions call #disconnectFromAgent() BEFORE `await abort()`, and only bump
+		// #sessionGeneration/clear the IRC queue several awaits later once they reach agent.reset().
+		// A normalization await that resolves in that gap sees an unchanged generation and an idle,
+		// non-streaming session, so without this guard it would wake/fold into the still-old context
+		// and race the transition's own reset — same rationale as #drainStrandedQueuedMessages.
+		if (this.#unsubscribeAgent === undefined) return;
 		if (this.#canAutoContinueForFollowUp() && this.agent.hasQueuedMessages()) return;
 		const records = this.#irc.drainPending();
 		if (this.#planModeState?.enabled) {
@@ -922,6 +935,21 @@ export class AgentSession {
 			this.agent.emitExternalEvent({ type: "message_start", message: record });
 			this.agent.emitExternalEvent({ type: "message_end", message: record });
 		}
+	}
+
+	/** Re-validates a #sessionGeneration snapshot captured before an aside-queueing call's
+	 *  normalization await. A mismatch alone does not mean the record's source session is gone —
+	 *  switchSession() restores the exact prior generation on rollback — so wait out any in-flight
+	 *  transition (#sessionTransitionSettled) and recheck rather than discarding immediately.
+	 *  Returns true when the caller should drop its record (no in-flight transition to wait for, or
+	 *  the generation is still different once one settles); false once the generation matches again. */
+	async #sessionGenerationChanged(sessionGeneration: number): Promise<boolean> {
+		while (this.#sessionGeneration !== sessionGeneration) {
+			const settled = this.#sessionTransitionSettled;
+			if (!settled) return true;
+			await settled;
+		}
+		return false;
 	}
 
 	/** Fire-and-forget wake turn for incoming IRC — idle delivery and stranded-aside resume both
@@ -6622,7 +6650,7 @@ export class AgentSession {
 				? await this.#buildImageDescriptionNotice(normalizedImages)
 				: undefined;
 		if (mode === "aside") {
-			if (this.#sessionGeneration !== sessionGeneration) return;
+			if (await this.#sessionGenerationChanged(sessionGeneration)) return;
 			const records: AgentMessage[] = [];
 			if (imageDescriptionNotice) records.push(imageDescriptionNotice);
 			records.push({ role: "user", content, attribution: "user", timestamp: timestamp ?? Date.now() });
@@ -6872,7 +6900,7 @@ export class AgentSession {
 		};
 		const normalizedAppMessage = await this.#normalizeAgentMessageImages(appMessage);
 		if (deliverAs === "aside") {
-			if (this.#sessionGeneration !== sessionGeneration) return;
+			if (await this.#sessionGenerationChanged(sessionGeneration)) return;
 			// Non-interrupting: rides the same step-boundary aside poll as
 			// sendCustomMessage's streaming aside branch — not an agent-core queue
 			// entry, so no drain-retry latch and no idle-queue drain scheduling.
@@ -6945,7 +6973,7 @@ export class AgentSession {
 				return false;
 			}
 			if (options?.deliverAs === "aside") {
-				if (this.#sessionGeneration !== sessionGeneration) return false;
+				if (await this.#sessionGenerationChanged(sessionGeneration)) return false;
 				// Non-interrupting: the agent loop's step-boundary poll (see the setAsideMessageProvider
 				// registration in the constructor) picks this up without interrupting the current tool
 				// batch. Not an agent-core queue entry, so no drain-retry latch and no idle-queue drain
@@ -6986,6 +7014,7 @@ export class AgentSession {
 		}
 
 		if (options?.deliverAs === "aside") {
+			if (await this.#sessionGenerationChanged(sessionGeneration)) return false;
 			if (this.#planModeState?.enabled) {
 				// Plan mode stays user-driven: fold into context without an autonomous turn, same as
 				// IrcBridge.deliver()/#resumeStrandedIrcAsides do in plan mode. Routed through the
@@ -8642,6 +8671,9 @@ export class AgentSession {
 		// record on success but stays valid if the switch is rolled back to this same session.
 		const previousIrcPending = this.#irc.clearPending();
 		const previousSessionGeneration = this.#sessionGeneration++;
+		const transitionSettled = Promise.withResolvers<void>();
+		const previousSessionTransitionSettled = this.#sessionTransitionSettled;
+		this.#sessionTransitionSettled = transitionSettled.promise;
 		this.#pendingNextTurnMessages = [];
 		this.#scheduledHiddenNextTurnGeneration = undefined;
 		this.#queuedMessageDrainBlocked = false;
@@ -8823,6 +8855,8 @@ export class AgentSession {
 			if (previousSessionState.sessionId !== this.sessionManager.getSessionId()) {
 				this.#notifySessionChangeCallbacks();
 			}
+			transitionSettled.resolve();
+			this.#sessionTransitionSettled = previousSessionTransitionSettled;
 			return true;
 		} catch (error) {
 			this.sessionManager.restoreState(previousSessionState);
@@ -8837,6 +8871,8 @@ export class AgentSession {
 			this.agent.replaceQueues(previousSteeringMessages, previousFollowUpMessages);
 			this.#irc.restorePending(previousIrcPending);
 			this.#sessionGeneration = previousSessionGeneration;
+			transitionSettled.resolve();
+			this.#sessionTransitionSettled = previousSessionTransitionSettled;
 			this.#pendingNextTurnMessages = previousPendingNextTurnMessages;
 			this.#scheduledHiddenNextTurnGeneration = previousScheduledHiddenNextTurnGeneration;
 			this.#queuedMessageDrainBlocked = previousQueuedMessageDrainBlocked;

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -735,6 +735,15 @@ export class AgentSession {
 	// Cursor exec, TUI listeners) is held back. Without this, a client that resumes
 	// on `agent_end` can fire its next `prompt` before #promptWithMessage's finally
 	#promptGeneration = 0;
+	/** Bumped by newSession()/switchSession() at the same point they clear the pending IRC/aside
+	 *  queue (restored on a rolled-back switchSession()). A message-queueing call that spans an
+	 *  await (image normalization, vision description) captures this before the await and checks
+	 *  it again right before enqueueing into IrcBridge, so a record started for the outgoing
+	 *  session cannot land in a different session's queue after the transition. Deliberately
+	 *  distinct from #promptGeneration, which also changes on a plain abort() — asides must still
+	 *  enqueue and fold/resume normally across an in-session interrupt, only a session identity
+	 *  change should drop them. */
+	#sessionGeneration = 0;
 	#promptSequence = 0;
 	#skippedPostTurnSpeculationCompletion: Promise<void> | undefined;
 	#pendingAgentEndEmit: AgentSessionEvent | undefined;
@@ -6584,6 +6593,11 @@ export class AgentSession {
 		timestamp?: number,
 		preprocessed?: { images: ImageContent[] | undefined; descriptionNotice: CustomMessage | undefined },
 	): Promise<void> {
+		// Captured before any await below so the aside branch can detect a
+		// newSession()/switchSession() that completed while normalization/vision
+		// description was in flight and drop a record that would otherwise land in a
+		// different session's queue.
+		const sessionGeneration = this.#sessionGeneration;
 		// A queued user message (RPC/SDK/collab steer or follow-up, or a typed message
 		// while streaming) is a deliberate resume; re-enable advisor auto-resume that
 		// a user interrupt suppressed. An aside is non-interrupting by design — it must
@@ -6608,6 +6622,7 @@ export class AgentSession {
 				? await this.#buildImageDescriptionNotice(normalizedImages)
 				: undefined;
 		if (mode === "aside") {
+			if (this.#sessionGeneration !== sessionGeneration) return;
 			const records: AgentMessage[] = [];
 			if (imageDescriptionNotice) records.push(imageDescriptionNotice);
 			records.push({ role: "user", content, attribution: "user", timestamp: timestamp ?? Date.now() });
@@ -6834,6 +6849,8 @@ export class AgentSession {
 		deliverAs: "steer" | "followUp" | "aside",
 		queueChipText?: string,
 	): Promise<void> {
+		// Captured before the normalization await below — see #sessionGeneration's doc comment.
+		const sessionGeneration = this.#sessionGeneration;
 		const details =
 			queueChipText !== undefined
 				? ({
@@ -6855,6 +6872,7 @@ export class AgentSession {
 		};
 		const normalizedAppMessage = await this.#normalizeAgentMessageImages(appMessage);
 		if (deliverAs === "aside") {
+			if (this.#sessionGeneration !== sessionGeneration) return;
 			// Non-interrupting: rides the same step-boundary aside poll as
 			// sendCustomMessage's streaming aside branch — not an agent-core queue
 			// entry, so no drain-retry latch and no idle-queue drain scheduling.
@@ -6898,6 +6916,8 @@ export class AgentSession {
 			acceptTerminalEmptyStop?: boolean;
 		},
 	): Promise<boolean> {
+		// Captured before the normalization await below — see #sessionGeneration's doc comment.
+		const sessionGeneration = this.#sessionGeneration;
 		const normalizedPayload = normalizeCustomMessagePayload<T>(message);
 		const suppressQueueChip = options?.deliverAs === "nextTurn" || options?.deliverAs === "aside";
 		const details =
@@ -6925,6 +6945,7 @@ export class AgentSession {
 				return false;
 			}
 			if (options?.deliverAs === "aside") {
+				if (this.#sessionGeneration !== sessionGeneration) return false;
 				// Non-interrupting: the agent loop's step-boundary poll (see the setAsideMessageProvider
 				// registration in the constructor) picks this up without interrupting the current tool
 				// batch. Not an agent-core queue entry, so no drain-retry latch and no idle-queue drain
@@ -6966,32 +6987,21 @@ export class AgentSession {
 
 		if (options?.deliverAs === "aside") {
 			if (this.#planModeState?.enabled) {
-				// Plan mode stays user-driven: fold into context without an autonomous turn,
-				// same as IrcBridge.deliver()/#resumeStrandedIrcAsides do in plan mode.
-				this.agent.appendMessage(normalizedAppMessage);
-				this.sessionManager.appendCustomMessageEntry(
-					normalizedAppMessage.customType,
-					normalizedAppMessage.content,
-					normalizedAppMessage.display,
-					normalizedAppMessage.details,
-					normalizedAppMessage.attribution,
-				);
+				// Plan mode stays user-driven: fold into context without an autonomous turn, same as
+				// IrcBridge.deliver()/#resumeStrandedIrcAsides do in plan mode. Routed through the
+				// event-emitting fold path (not a direct append) so a displayable aside that began
+				// streaming still gets the message_end its sender's rebuild-skip decision expects.
+				this.#foldStrandedIrcAsidesIntoContext([normalizedAppMessage]);
 				return false;
 			}
 			if (this.#advisors.autoResumeSuppressed) {
 				// A user interrupt (Esc) is still in effect. isStreaming was true when this method
 				// was entered but image normalization above outlasted the interrupt, landing here
 				// instead of the streaming branch's queueAside — starting a fresh autonomous turn
-				// would undo the user's deliberate stop. Fold into context and stay user-driven,
-				// matching #resumeStrandedIrcAsides's post-interrupt fold branch.
-				this.agent.appendMessage(normalizedAppMessage);
-				this.sessionManager.appendCustomMessageEntry(
-					normalizedAppMessage.customType,
-					normalizedAppMessage.content,
-					normalizedAppMessage.display,
-					normalizedAppMessage.details,
-					normalizedAppMessage.attribution,
-				);
+				// would undo the user's deliberate stop. Fold into context (same event-emitting path
+				// as the plan-mode branch above) and stay user-driven, matching
+				// #resumeStrandedIrcAsides's post-interrupt fold branch.
+				this.#foldStrandedIrcAsidesIntoContext([normalizedAppMessage]);
 				return false;
 			}
 			if (this.#clientBridge?.deferAgentInitiatedTurns && !this.#allowAcpAgentInitiatedTurns) {
@@ -7514,8 +7524,11 @@ export class AgentSession {
 			// The abort above may have skipped the loop's final aside poll (issue: stranded
 			// asides survive an aborted turn by design so a resumed session can still see
 			// them); discard here so they cannot leak into the new session's transcript via
-			// the first ordinary prompt's IrcBridge.flushPending().
+			// the first ordinary prompt's IrcBridge.flushPending(). Bump #sessionGeneration in
+			// the same breath so an aside-queueing call still awaiting normalization for the
+			// outgoing session also drops its record instead of landing in this new one.
 			this.#irc.clearPending();
+			this.#sessionGeneration++;
 			this.#scheduledHiddenNextTurnGeneration = undefined;
 			this.#queuedMessageDrainBlocked = false;
 			this.#usagePreflightReadyForNextModelCall = false;
@@ -8624,7 +8637,11 @@ export class AgentSession {
 		// Same rationale as newSession: an aborted turn can skip its final aside poll,
 		// stranding IRC/extension asides meant for the outgoing transcript. Snapshot so a
 		// rolled-back switch (catch block below) restores them for the still-live session.
+		// #sessionGeneration bumps in the same breath (and rolls back with it) so an
+		// aside-queueing call still awaiting normalization when the switch started drops its
+		// record on success but stays valid if the switch is rolled back to this same session.
 		const previousIrcPending = this.#irc.clearPending();
+		const previousSessionGeneration = this.#sessionGeneration++;
 		this.#pendingNextTurnMessages = [];
 		this.#scheduledHiddenNextTurnGeneration = undefined;
 		this.#queuedMessageDrainBlocked = false;
@@ -8819,6 +8836,7 @@ export class AgentSession {
 			this.agent.replaceMessages(previousAgentMessages);
 			this.agent.replaceQueues(previousSteeringMessages, previousFollowUpMessages);
 			this.#irc.restorePending(previousIrcPending);
+			this.#sessionGeneration = previousSessionGeneration;
 			this.#pendingNextTurnMessages = previousPendingNextTurnMessages;
 			this.#scheduledHiddenNextTurnGeneration = previousScheduledHiddenNextTurnGeneration;
 			this.#queuedMessageDrainBlocked = previousQueuedMessageDrainBlocked;

--- a/packages/coding-agent/src/session/irc-bridge.ts
+++ b/packages/coding-agent/src/session/irc-bridge.ts
@@ -71,10 +71,14 @@ export class IrcBridge {
 		return snapshot;
 	}
 
-	/** Restores a snapshot taken by `clearPending`, for a rolled-back session transition. */
+	/** Restores a snapshot taken by `clearPending`, for a rolled-back session transition. Merges
+	 *  ahead of whatever queued in the meantime (e.g. an in-flight IRC auto-reply appending while
+	 *  the rolled-back switch's async load/hooks were still running) instead of overwriting it, so
+	 *  those newly arrived records aren't silently discarded — snapshot records precede them since
+	 *  they arrived first. */
 	restorePending(snapshot: { interrupts: AgentMessage[]; asides: AgentMessage[] }): void {
-		this.#interrupts = snapshot.interrupts;
-		this.#asides = snapshot.asides;
+		this.#interrupts = [...snapshot.interrupts, ...this.#interrupts];
+		this.#asides = [...snapshot.asides, ...this.#asides];
 	}
 
 	/** Queues records for the next step-boundary aside injection: IRC wakes deferred by a

--- a/packages/coding-agent/src/session/irc-bridge.ts
+++ b/packages/coding-agent/src/session/irc-bridge.ts
@@ -59,6 +59,24 @@ export class IrcBridge {
 		return records;
 	}
 
+	/** Snapshots and discards every queued IRC record — used when a session-boundary transition
+	 *  (new/switch) begins, since an aborted turn skips its final aside poll and would otherwise
+	 *  leak the outgoing transcript's extension/peer content into the next session via the first
+	 *  ordinary prompt's `flushPending()`. Pass the snapshot to `restorePending` to undo the clear
+	 *  if the transition is rolled back. */
+	clearPending(): { interrupts: AgentMessage[]; asides: AgentMessage[] } {
+		const snapshot = { interrupts: this.#interrupts, asides: this.#asides };
+		this.#interrupts = [];
+		this.#asides = [];
+		return snapshot;
+	}
+
+	/** Restores a snapshot taken by `clearPending`, for a rolled-back session transition. */
+	restorePending(snapshot: { interrupts: AgentMessage[]; asides: AgentMessage[] }): void {
+		this.#interrupts = snapshot.interrupts;
+		this.#asides = snapshot.asides;
+	}
+
 	/** Queues records for the next step-boundary aside injection: IRC wakes deferred by a
 	 *  session transition, and extension `deliverAs: "aside"` sends. */
 	queueAside(records: AgentMessage[]): void {

--- a/packages/coding-agent/src/session/irc-bridge.ts
+++ b/packages/coding-agent/src/session/irc-bridge.ts
@@ -1,4 +1,4 @@
-import type { Agent } from "@oh-my-pi/pi-agent-core";
+import type { Agent, AgentMessage } from "@oh-my-pi/pi-agent-core";
 import { logger, prompt } from "@oh-my-pi/pi-utils";
 import type { Settings } from "../config/settings";
 import { IrcBus, type IrcMessage } from "../irc/bus";
@@ -19,15 +19,15 @@ export interface IrcBridgeHost {
 	isStreaming(): boolean;
 	planModeEnabled(): boolean;
 	emitSessionEvent(event: AgentSessionEvent): Promise<void>;
-	wakeForIrc(records: CustomMessage[]): void;
+	wakeForIrc(records: AgentMessage[]): void;
 	runEphemeralTurn(args: { promptText: string }): Promise<{ replyText: string }>;
 }
 
-/** Owns incoming IRC queues, injection, and side-channel auto-replies. */
+/** Owns incoming IRC queues, the session's non-interrupting aside queue, injection, and side-channel auto-replies. */
 export class IrcBridge {
 	readonly #host: IrcBridgeHost;
-	#interrupts: CustomMessage[] = [];
-	#asides: CustomMessage[] = [];
+	#interrupts: AgentMessage[] = [];
+	#asides: AgentMessage[] = [];
 	readonly #autoReplies = new Set<Promise<void>>();
 
 	constructor(host: IrcBridgeHost) {
@@ -52,29 +52,34 @@ export class IrcBridge {
 	}
 
 	/** Takes every queued IRC record in interrupt-before-aside order. */
-	drainPending(): CustomMessage[] {
+	drainPending(): AgentMessage[] {
 		const records = [...this.#interrupts, ...this.#asides];
 		this.#interrupts = [];
 		this.#asides = [];
 		return records;
 	}
 
-	/** Queues records whose idle wake must wait for a session transition to finish. */
-	deferWake(records: CustomMessage[]): void {
+	/** Queues records for the next step-boundary aside injection: IRC wakes deferred by a
+	 *  session transition, and extension `deliverAs: "aside"` sends. */
+	queueAside(records: AgentMessage[]): void {
 		this.#asides.push(...records);
 	}
 
 	/** Surfaces and consumes queued incoming records before automatic injection. */
 	drainInboxMessages(agentId: string, opts?: { from?: string; limit?: number }): IrcMessage[] {
 		const messages: IrcMessage[] = [];
-		const remainingInterrupts: CustomMessage[] = [];
-		const remainingAsides: CustomMessage[] = [];
+		const remainingInterrupts: AgentMessage[] = [];
+		const remainingAsides: AgentMessage[] = [];
 		const queues = [
 			{ records: this.#interrupts, remaining: remainingInterrupts },
 			{ records: this.#asides, remaining: remainingAsides },
 		];
 		for (const queue of queues) {
 			for (const record of queue.records) {
+				if (record.role !== "custom") {
+					queue.remaining.push(record);
+					continue;
+				}
 				if (record.customType !== "irc:incoming") {
 					queue.remaining.push(record);
 					continue;

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -2384,6 +2384,16 @@ export interface IrcWakeTurnMonitorOptions {
  * subagents are not blind spots. The observer runs after the session has
  * flushed its post-prompt settle (see {@link AgentSession.setIrcWakeTurnObserver}).
  */
+/** Extracts display text from an IRC/aside record's content, shared by the custom-role and
+ *  user-role branches below (both fields share the same string | text-part-array shape). */
+function extractIrcRecordText(content: string | ReadonlyArray<{ type: string; text?: string }>): string {
+	if (typeof content === "string") return content;
+	return content
+		.filter(part => part.type === "text")
+		.map(part => part.text ?? "")
+		.join("\n");
+}
+
 export function attachIrcWakeTurnMonitor(session: AgentSession, options: IrcWakeTurnMonitorOptions): void {
 	const { id, agent } = options;
 	const index = options.index ?? 0;
@@ -2392,11 +2402,16 @@ export function attachIrcWakeTurnMonitor(session: AgentSession, options: IrcWake
 		const ircTask =
 			records
 				.map(record => {
-					const body =
-						record.details && typeof record.details === "object"
-							? Reflect.get(record.details, "message")
-							: undefined;
-					return typeof body === "string" ? body : record.content;
+					if (record.role === "custom") {
+						const body =
+							record.details && typeof record.details === "object"
+								? Reflect.get(record.details, "message")
+								: undefined;
+						if (typeof body === "string") return body;
+						return extractIrcRecordText(record.content);
+					}
+					if (record.role === "user") return extractIrcRecordText(record.content);
+					return "";
 				})
 				.filter(Boolean)
 				.join("\n\n") || "IRC follow-up";

--- a/packages/coding-agent/test/agent-session-aside-delivery.test.ts
+++ b/packages/coding-agent/test/agent-session-aside-delivery.test.ts
@@ -335,4 +335,121 @@ describe("AgentSession aside delivery", () => {
 		expect(contexts).toHaveLength(1);
 		expect(JSON.stringify(contexts[0]!.messages)).toContain("IDLE_ASIDE_BODY");
 	});
+
+	it("a stranded aside queued during an aborted turn does not leak into a fresh session (newSession)", async () => {
+		const modelRegistry = new ModelRegistry(authStorage);
+		const started = Promise.withResolvers<void>();
+		const contexts: Context[] = [];
+		const mock = createMockModel({
+			provider: "openai",
+			id: "gpt-test",
+			responses: [
+				() => {
+					started.resolve();
+					return { content: ["working"], delayMs: 60_000 };
+				},
+				context => {
+					contexts.push(context);
+					return { content: ["fresh reply"] };
+				},
+			],
+		});
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model: mock.model, systemPrompt: ["Test"], tools: [], messages: [] },
+			convertToLlm,
+			streamFn: mock.stream,
+		});
+		const settings = Settings.isolated({ "compaction.enabled": false, "todo.enabled": false });
+		settings.setModelRole("default", `${mock.model.provider}/${mock.model.id}`);
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(tempDir.path()),
+			settings,
+			modelRegistry,
+			toolRegistry: new Map(),
+		});
+
+		const run = session.prompt("go");
+		await started.promise;
+		await session.sendUserMessage("LEAK_CANDIDATE_ASIDE", { deliverAs: "aside" });
+
+		// newSession() aborts the run first; the abort skips the loop's final aside poll, so
+		// without a clear the queued aside would still be sitting in IrcBridge and would flush
+		// into the new session's transcript at the first ordinary prompt below.
+		expect(await session.newSession()).toBe(true);
+		await run.catch(() => {});
+		await session.waitForIdle();
+
+		expect(
+			session.agent.state.messages.some(message => JSON.stringify(message).includes("LEAK_CANDIDATE_ASIDE")),
+		).toBe(false);
+
+		await session.prompt("ping");
+		await session.waitForIdle();
+
+		expect(contexts).toHaveLength(1);
+		expect(JSON.stringify(contexts[0]!.messages)).not.toContain("LEAK_CANDIDATE_ASIDE");
+	});
+
+	it("a stranded aside queued during an aborted turn does not leak into the target session (switchSession)", async () => {
+		const sessionDir = path.join(tempDir.path(), "sessions");
+		const modelRegistry = new ModelRegistry(authStorage);
+		const started = Promise.withResolvers<void>();
+		const contexts: Context[] = [];
+		const mock = createMockModel({
+			provider: "openai",
+			id: "gpt-test",
+			responses: [
+				() => {
+					started.resolve();
+					return { content: ["working"], delayMs: 60_000 };
+				},
+				context => {
+					contexts.push(context);
+					return { content: ["target reply"] };
+				},
+			],
+		});
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model: mock.model, systemPrompt: ["Test"], tools: [], messages: [] },
+			convertToLlm,
+			streamFn: mock.stream,
+		});
+		const settings = Settings.isolated({ "compaction.enabled": false, "todo.enabled": false });
+		settings.setModelRole("default", `${mock.model.provider}/${mock.model.id}`);
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.create(tempDir.path(), sessionDir),
+			settings,
+			modelRegistry,
+			toolRegistry: new Map(),
+		});
+
+		const targetManager = SessionManager.create(tempDir.path(), sessionDir);
+		targetManager.appendMessage({ role: "user", content: "target", timestamp: Date.now() });
+		await targetManager.ensureOnDisk();
+		const targetFile = targetManager.getSessionFile();
+		if (!targetFile) throw new Error("Expected target session file");
+		await targetManager.close();
+
+		const run = session.prompt("go");
+		await started.promise;
+		await session.sendUserMessage("LEAK_CANDIDATE_ASIDE", { deliverAs: "aside" });
+
+		expect(await session.switchSession(targetFile)).toBe(true);
+		await run.catch(() => {});
+		await session.waitForIdle();
+
+		expect(
+			session.agent.state.messages.some(message => JSON.stringify(message).includes("LEAK_CANDIDATE_ASIDE")),
+		).toBe(false);
+
+		await session.prompt("ping");
+		await session.waitForIdle();
+
+		expect(contexts).toHaveLength(1);
+		expect(JSON.stringify(contexts[0]!.messages)).not.toContain("LEAK_CANDIDATE_ASIDE");
+	});
 });

--- a/packages/coding-agent/test/agent-session-aside-delivery.test.ts
+++ b/packages/coding-agent/test/agent-session-aside-delivery.test.ts
@@ -551,4 +551,68 @@ describe("AgentSession aside delivery", () => {
 		expect(JSON.stringify(contexts[1]!.messages)).toContain("SLOW_DONE");
 		expect(JSON.stringify(contexts[1]!.messages)).toContain("RACE_ASIDE_TEXT");
 	});
+
+	it("#queueCustomMessage resumes a stranded aside instead of leaving it queued with no loop to drain it", async () => {
+		// Regression for the race Codex flagged in #queueCustomMessage: it awaits image
+		// normalization before calling IrcBridge.queueAside, so the active run can settle to
+		// idle during that await. If the queueAside call doesn't also resume stranded asides
+		// (as #queueUserMessage's aside branch already does), the record sits in the queue with
+		// no loop left to drain it until an unrelated prompt happens to flush it. Exercising
+		// promptCustomMessage's queueOnly path (used by main.ts's synthetic-continue queue) on an
+		// already-idle session hits the exact same #queueCustomMessage code path this covers.
+		const model = createMockModel({ provider: "openai", id: "gpt-test" }).model;
+		const modelRegistry = new ModelRegistry(authStorage);
+		const contexts: Context[] = [];
+
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] },
+			convertToLlm,
+			streamFn: (_model, context) => {
+				contexts.push(context);
+				const message: AssistantMessage = {
+					role: "assistant",
+					content: [{ type: "text", text: "Acknowledged." }],
+					api: model.api,
+					provider: model.provider,
+					model: model.id,
+					usage: zeroUsage,
+					stopReason: "stop",
+					timestamp: Date.now(),
+				};
+				const stream = new AssistantMessageEventStream();
+				queueMicrotask(() => {
+					stream.push({ type: "start", partial: message });
+					stream.push({ type: "done", reason: "stop", message });
+				});
+				return stream;
+			},
+		});
+		const settings = Settings.isolated({ "compaction.enabled": false, "todo.enabled": false });
+		settings.setModelRole("default", `${model.provider}/${model.id}`);
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(tempDir.path()),
+			settings,
+			modelRegistry,
+			toolRegistry: new Map(),
+		});
+
+		let observedRecords: unknown[] | undefined;
+		session.setIrcWakeTurnObserver(records => {
+			observedRecords = records;
+			return undefined;
+		});
+
+		await session.promptCustomMessage(
+			{ customType: "ext-aside", content: "SETTLED_RACE_ASIDE", display: false, attribution: "agent" },
+			{ streamingBehavior: "aside", queueOnly: true },
+		);
+		await session.waitForIdle();
+
+		expect(observedRecords).toBeDefined();
+		expect(JSON.stringify(observedRecords)).toContain("SETTLED_RACE_ASIDE");
+		expect(contexts).toHaveLength(1);
+		expect(JSON.stringify(contexts[0]!.messages)).toContain("SETTLED_RACE_ASIDE");
+	});
 });

--- a/packages/coding-agent/test/agent-session-aside-delivery.test.ts
+++ b/packages/coding-agent/test/agent-session-aside-delivery.test.ts
@@ -1,0 +1,338 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as path from "node:path";
+import { type } from "@oh-my-pi/omptype";
+import { Agent, type AgentTool } from "@oh-my-pi/pi-agent-core";
+import type { AssistantMessage, Context } from "@oh-my-pi/pi-ai";
+import { createMockModel } from "@oh-my-pi/pi-ai/providers/mock";
+import { AssistantMessageEventStream } from "@oh-my-pi/pi-ai/utils/event-stream";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { convertToLlm } from "@oh-my-pi/pi-coding-agent/session/messages";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+const zeroUsage = {
+	input: 0,
+	output: 0,
+	cacheRead: 0,
+	cacheWrite: 0,
+	totalTokens: 0,
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+} satisfies AssistantMessage["usage"];
+
+describe("AgentSession aside delivery", () => {
+	let tempDir: TempDir;
+	let authStorage: AuthStorage;
+	let session: AgentSession | undefined;
+
+	beforeEach(async () => {
+		tempDir = TempDir.createSync("@pi-aside-delivery-");
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "auth.db"));
+		authStorage.setRuntimeApiKey("openai", "openai-test-key");
+	});
+
+	afterEach(async () => {
+		await session?.dispose();
+		authStorage.close();
+		tempDir.removeSync();
+	});
+
+	it("an aside delivered mid-run neither aborts the in-flight tool nor waits for the run to end", async () => {
+		const model = createMockModel({ provider: "openai", id: "gpt-test" }).model;
+		const modelRegistry = new ModelRegistry(authStorage);
+		const contexts: Context[] = [];
+
+		const started = Promise.withResolvers<void>();
+		const release = Promise.withResolvers<void>();
+		let abortedDuringTool = false;
+		let abortSeen = false;
+
+		const slowTool: AgentTool = {
+			name: "slow",
+			label: "Slow",
+			description: "Blocks until released",
+			parameters: type({}),
+			execute: async (_id, _params, signal) => {
+				started.resolve();
+				abortedDuringTool = signal?.aborted ?? false;
+				signal?.addEventListener("abort", () => {
+					abortSeen = true;
+				});
+				await release.promise;
+				return { content: [{ type: "text", text: "SLOW_DONE" }] };
+			},
+		};
+
+		let callCount = 0;
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model, systemPrompt: ["Test"], tools: [slowTool], messages: [] },
+			convertToLlm,
+			streamFn: (_model, context) => {
+				contexts.push(context);
+				const isFirstCall = callCount === 0;
+				callCount++;
+				const message: AssistantMessage = isFirstCall
+					? {
+							role: "assistant",
+							content: [{ type: "toolCall", id: "tc-0", name: "slow", arguments: {} }],
+							api: model.api,
+							provider: model.provider,
+							model: model.id,
+							usage: zeroUsage,
+							stopReason: "toolUse",
+							timestamp: Date.now(),
+						}
+					: {
+							role: "assistant",
+							content: [{ type: "text", text: "Done." }],
+							api: model.api,
+							provider: model.provider,
+							model: model.id,
+							usage: zeroUsage,
+							stopReason: "stop",
+							timestamp: Date.now(),
+						};
+				const stream = new AssistantMessageEventStream();
+				queueMicrotask(() => {
+					stream.push({ type: "start", partial: message });
+					stream.push({ type: "done", reason: isFirstCall ? "toolUse" : "stop", message });
+				});
+				return stream;
+			},
+		});
+		const settings = Settings.isolated({ "compaction.enabled": false, "todo.enabled": false });
+		settings.setModelRole("default", `${model.provider}/${model.id}`);
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(tempDir.path()),
+			settings,
+			modelRegistry,
+			toolRegistry: new Map([[slowTool.name, slowTool]]),
+		});
+
+		const run = session.prompt("go");
+		await started.promise;
+
+		await session.sendCustomMessage(
+			{ customType: "ext-aside", content: "ASIDE_BODY", display: false, attribution: "agent" },
+			{ deliverAs: "aside" },
+		);
+
+		expect(abortSeen).toBe(false);
+		expect(session.agent.hasQueuedMessages()).toBe(false);
+		expect(session.agent.peekSteeringQueue()).toHaveLength(0);
+
+		release.resolve();
+		await run;
+		await session.waitForIdle();
+
+		expect(abortedDuringTool).toBe(false);
+		expect(JSON.stringify(contexts[1]!.messages)).toContain("SLOW_DONE");
+		expect(JSON.stringify(contexts[1]!.messages)).toContain("ASIDE_BODY");
+		const asides = session.agent.state.messages.filter(
+			message => message.role === "custom" && message.customType === "ext-aside",
+		);
+		expect(asides).toHaveLength(1);
+	});
+
+	it("sendUserMessage delivered as an aside mid-run injects at the next step boundary without draining agent-core queues", async () => {
+		const model = createMockModel({ provider: "openai", id: "gpt-test" }).model;
+		const modelRegistry = new ModelRegistry(authStorage);
+		const contexts: Context[] = [];
+
+		const started = Promise.withResolvers<void>();
+		const release = Promise.withResolvers<void>();
+
+		const slowTool: AgentTool = {
+			name: "slow",
+			label: "Slow",
+			description: "Blocks until released",
+			parameters: type({}),
+			execute: async () => {
+				started.resolve();
+				await release.promise;
+				return { content: [{ type: "text", text: "SLOW_DONE" }] };
+			},
+		};
+
+		let callCount = 0;
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model, systemPrompt: ["Test"], tools: [slowTool], messages: [] },
+			convertToLlm,
+			streamFn: (_model, context) => {
+				contexts.push(context);
+				const isFirstCall = callCount === 0;
+				callCount++;
+				const message: AssistantMessage = isFirstCall
+					? {
+							role: "assistant",
+							content: [{ type: "toolCall", id: "tc-0", name: "slow", arguments: {} }],
+							api: model.api,
+							provider: model.provider,
+							model: model.id,
+							usage: zeroUsage,
+							stopReason: "toolUse",
+							timestamp: Date.now(),
+						}
+					: {
+							role: "assistant",
+							content: [{ type: "text", text: "Done." }],
+							api: model.api,
+							provider: model.provider,
+							model: model.id,
+							usage: zeroUsage,
+							stopReason: "stop",
+							timestamp: Date.now(),
+						};
+				const stream = new AssistantMessageEventStream();
+				queueMicrotask(() => {
+					stream.push({ type: "start", partial: message });
+					stream.push({ type: "done", reason: isFirstCall ? "toolUse" : "stop", message });
+				});
+				return stream;
+			},
+		});
+		const settings = Settings.isolated({ "compaction.enabled": false, "todo.enabled": false });
+		settings.setModelRole("default", `${model.provider}/${model.id}`);
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(tempDir.path()),
+			settings,
+			modelRegistry,
+			toolRegistry: new Map([[slowTool.name, slowTool]]),
+		});
+
+		const run = session.prompt("go");
+		await started.promise;
+
+		await session.sendUserMessage("USER_ASIDE_BODY", { deliverAs: "aside" });
+
+		// Not a steer/follow-up: neither agent-core queue drained the aside, so the tool batch
+		// keeps running uninterrupted.
+		expect(session.agent.hasQueuedMessages()).toBe(false);
+		expect(session.agent.peekSteeringQueue()).toHaveLength(0);
+		expect(session.agent.peekFollowUpQueue()).toHaveLength(0);
+
+		release.resolve();
+		await run;
+		await session.waitForIdle();
+
+		expect(JSON.stringify(contexts[1]!.messages)).toContain("SLOW_DONE");
+		expect(JSON.stringify(contexts[1]!.messages)).toContain("USER_ASIDE_BODY");
+		const userAsides = session.agent.state.messages.filter(
+			message => message.role === "user" && JSON.stringify(message.content).includes("USER_ASIDE_BODY"),
+		);
+		expect(userAsides).toHaveLength(1);
+	});
+
+	it("a user aside stranded past run completion resumes as a wake turn carrying the user text", async () => {
+		const modelRegistry = new ModelRegistry(authStorage);
+		const started = Promise.withResolvers<void>();
+		const mock = createMockModel({
+			provider: "openai",
+			id: "gpt-test",
+			responses: [
+				() => {
+					started.resolve();
+					return { content: ["working"], delayMs: 60_000 };
+				},
+				{ content: ["peer reply"] },
+			],
+		});
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model: mock.model, systemPrompt: ["Test"], tools: [], messages: [] },
+			convertToLlm,
+			streamFn: mock.stream,
+		});
+		const settings = Settings.isolated({ "compaction.enabled": false, "todo.enabled": false });
+		settings.setModelRole("default", `${mock.model.provider}/${mock.model.id}`);
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(tempDir.path()),
+			settings,
+			modelRegistry,
+			toolRegistry: new Map(),
+		});
+
+		let observedRecords: unknown[] | undefined;
+		session.setIrcWakeTurnObserver(records => {
+			observedRecords = records;
+			return undefined;
+		});
+
+		const run = session.prompt("go");
+		await started.promise;
+		await session.sendUserMessage("STRANDED_USER_ASIDE", { deliverAs: "aside" });
+
+		// A non-user abort (e.g. an internal mode transition) does not suppress auto-resume like
+		// a user Esc does; it just skips the loop's final aside poll on the way out, stranding the
+		// aside with no loop left to drain it — exactly the settle race #resumeStrandedIrcAsides /
+		// #queueUserMessage's post-queueAside call cover.
+		await session.abort({ reason: "internal" });
+		await session.waitForIdle();
+		await run.catch(() => {});
+
+		expect(observedRecords).toBeDefined();
+		expect(JSON.stringify(observedRecords)).toContain("STRANDED_USER_ASIDE");
+		const persisted = session.agent.state.messages.some(
+			message => message.role === "user" && JSON.stringify(message.content).includes("STRANDED_USER_ASIDE"),
+		);
+		expect(persisted).toBe(true);
+		expect(mock.calls.length).toBe(2);
+	});
+
+	it("an idle session receiving an aside starts a turn", async () => {
+		const model = createMockModel({ provider: "openai", id: "gpt-test" }).model;
+		const modelRegistry = new ModelRegistry(authStorage);
+		const contexts: Context[] = [];
+
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] },
+			convertToLlm,
+			streamFn: (_model, context) => {
+				contexts.push(context);
+				const message: AssistantMessage = {
+					role: "assistant",
+					content: [{ type: "text", text: "Acknowledged." }],
+					api: model.api,
+					provider: model.provider,
+					model: model.id,
+					usage: zeroUsage,
+					stopReason: "stop",
+					timestamp: Date.now(),
+				};
+				const stream = new AssistantMessageEventStream();
+				queueMicrotask(() => {
+					stream.push({ type: "start", partial: message });
+					stream.push({ type: "done", reason: "stop", message });
+				});
+				return stream;
+			},
+		});
+		const settings = Settings.isolated({ "compaction.enabled": false, "todo.enabled": false });
+		settings.setModelRole("default", `${model.provider}/${model.id}`);
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(tempDir.path()),
+			settings,
+			modelRegistry,
+			toolRegistry: new Map(),
+		});
+
+		const startedTurn = await session.sendCustomMessage(
+			{ customType: "ext-aside", content: "IDLE_ASIDE_BODY", display: false, attribution: "agent" },
+			{ deliverAs: "aside" },
+		);
+		await session.waitForIdle();
+
+		expect(startedTurn).toBe(true);
+		expect(contexts).toHaveLength(1);
+		expect(JSON.stringify(contexts[0]!.messages)).toContain("IDLE_ASIDE_BODY");
+	});
+});

--- a/packages/coding-agent/test/agent-session-aside-delivery.test.ts
+++ b/packages/coding-agent/test/agent-session-aside-delivery.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import * as path from "node:path";
 import { type } from "@oh-my-pi/omptype";
-import { Agent, type AgentTool } from "@oh-my-pi/pi-agent-core";
+import { Agent, type AgentMessage, type AgentTool } from "@oh-my-pi/pi-agent-core";
 import type { AssistantMessage, Context } from "@oh-my-pi/pi-ai";
 import { createMockModel } from "@oh-my-pi/pi-ai/providers/mock";
 import { AssistantMessageEventStream } from "@oh-my-pi/pi-ai/utils/event-stream";
@@ -9,7 +9,8 @@ import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
-import { convertToLlm } from "@oh-my-pi/pi-coding-agent/session/messages";
+import { IrcBridge, type IrcBridgeHost } from "@oh-my-pi/pi-coding-agent/session/irc-bridge";
+import { convertToLlm, USER_INTERRUPT_LABEL } from "@oh-my-pi/pi-coding-agent/session/messages";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import { TempDir } from "@oh-my-pi/pi-utils";
 
@@ -614,5 +615,195 @@ describe("AgentSession aside delivery", () => {
 		expect(JSON.stringify(observedRecords)).toContain("SETTLED_RACE_ASIDE");
 		expect(contexts).toHaveLength(1);
 		expect(JSON.stringify(contexts[0]!.messages)).toContain("SETTLED_RACE_ASIDE");
+	});
+
+	it("sendCustomMessage(deliverAs: 'aside') folds into context instead of starting a turn when a user interrupt outlasted normalization", async () => {
+		// Regression: this branch is only reached once isStreaming reads false — which can happen
+		// either because the session was already idle, or because image normalization above
+		// outlasted a user Esc that settled the run in the meantime. The old code treated both
+		// cases identically and always started a fresh autonomous turn, undoing a deliberate
+		// interrupt. Simulate the second case directly: abort with a user interrupt (which sets
+		// autoResumeSuppressed), then send the aside on the now-idle session.
+		const model = createMockModel({ provider: "openai", id: "gpt-test" }).model;
+		const modelRegistry = new ModelRegistry(authStorage);
+		const contexts: Context[] = [];
+
+		const started = Promise.withResolvers<void>();
+		const release = Promise.withResolvers<void>();
+		const slowTool: AgentTool = {
+			name: "slow",
+			label: "Slow",
+			description: "Blocks until released",
+			parameters: type({}),
+			execute: async (_id, _params, _signal) => {
+				started.resolve();
+				await release.promise;
+				return { content: [{ type: "text", text: "SLOW_DONE" }] };
+			},
+		};
+
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model, systemPrompt: ["Test"], tools: [slowTool], messages: [] },
+			convertToLlm,
+			streamFn: (_model, context) => {
+				contexts.push(context);
+				const message: AssistantMessage = {
+					role: "assistant",
+					content: [{ type: "toolCall", id: "tc-0", name: "slow", arguments: {} }],
+					api: model.api,
+					provider: model.provider,
+					model: model.id,
+					usage: zeroUsage,
+					stopReason: "toolUse",
+					timestamp: Date.now(),
+				};
+				const stream = new AssistantMessageEventStream();
+				queueMicrotask(() => {
+					stream.push({ type: "start", partial: message });
+					stream.push({ type: "done", reason: "toolUse", message });
+				});
+				return stream;
+			},
+		});
+		const settings = Settings.isolated({ "compaction.enabled": false, "todo.enabled": false });
+		settings.setModelRole("default", `${model.provider}/${model.id}`);
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(tempDir.path()),
+			settings,
+			modelRegistry,
+			toolRegistry: new Map([[slowTool.name, slowTool]]),
+		});
+
+		const run = session.prompt("go");
+		await started.promise;
+		release.resolve();
+		await session.abort({ reason: USER_INTERRUPT_LABEL });
+		await run.catch(() => {});
+		await session.waitForIdle();
+		contexts.length = 0;
+
+		const dispatched = await session.sendCustomMessage(
+			{ customType: "ext-aside", content: "SUPPRESSED_ASIDE", display: false, attribution: "agent" },
+			{ deliverAs: "aside" },
+		);
+
+		expect(dispatched).toBe(false);
+		expect(contexts).toHaveLength(0);
+		const persisted = session.agent.state.messages.some(
+			message => message.role === "custom" && message.customType === "ext-aside",
+		);
+		expect(persisted).toBe(true);
+	});
+
+	it("sendCustomMessage(deliverAs: 'aside'/'nextTurn') reports false when the agent-initiated turn never dispatches", async () => {
+		// Regression: #promptAgentInitiatedMessage used to return void, so its callers hard-coded
+		// `return true` unconditionally. If an abort races the usage-aware preflight (which
+		// registers an AbortController and captures the prompt generation before its first real
+		// await), the helper returns before ever calling agent.prompt — callers that treat the
+		// boolean as proof of dispatched agent work (e.g. RPC's hasAgentMessageTask gate) must see
+		// `false`, not a stale `true` that leaves them waiting on events that never arrive.
+		const model = createMockModel({ provider: "openai", id: "gpt-test" }).model;
+		const modelRegistry = new ModelRegistry(authStorage);
+		const contexts: Context[] = [];
+
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] },
+			convertToLlm,
+			streamFn: (_model, context) => {
+				contexts.push(context);
+				const message: AssistantMessage = {
+					role: "assistant",
+					content: [{ type: "text", text: "Acknowledged." }],
+					api: model.api,
+					provider: model.provider,
+					model: model.id,
+					usage: zeroUsage,
+					stopReason: "stop",
+					timestamp: Date.now(),
+				};
+				const stream = new AssistantMessageEventStream();
+				queueMicrotask(() => {
+					stream.push({ type: "start", partial: message });
+					stream.push({ type: "done", reason: "stop", message });
+				});
+				return stream;
+			},
+		});
+		const settings = Settings.isolated({ "compaction.enabled": false, "todo.enabled": false });
+		settings.setModelRole("default", `${model.provider}/${model.id}`);
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(tempDir.path()),
+			settings,
+			modelRegistry,
+			toolRegistry: new Map(),
+		});
+
+		const dispatchedPromise = session.sendCustomMessage(
+			{ customType: "ext-aside", content: "PREFLIGHT_RACE_ASIDE", display: false, attribution: "agent" },
+			{ deliverAs: "aside" },
+		);
+		// #beginInFlight() (which flips isStreaming) and the usage-aware preflight's abort
+		// controller registration + generation capture run synchronously together with no
+		// intervening await; poll until the first observable side effect (isStreaming) confirms
+		// that stretch has run, then abort — landing inside the preflight's own first await,
+		// exactly the race the fix covers.
+		while (!session.isStreaming) {
+			await Promise.resolve();
+		}
+		await session.abort({ reason: "internal" });
+
+		expect(await dispatchedPromise).toBe(false);
+		await session.waitForIdle();
+		expect(contexts).toHaveLength(0);
+	});
+
+	it("IrcBridge.restorePending merges a rolled-back snapshot ahead of records queued during the rollback instead of discarding them", () => {
+		// Regression: restorePending used to overwrite the queues wholesale, silently dropping any
+		// record queued between clearPending() and restorePending() (e.g. an in-flight IRC
+		// auto-reply appending while a rolled-back switchSession's async load/hooks were still
+		// running). Exercise the bridge directly with a minimal host stub — the queue ops under
+		// test never touch the host.
+		const host: IrcBridgeHost = {
+			agent: {} as Agent,
+			sessionManager: {} as SessionManager,
+			settings: {} as Settings,
+			isDisposed: () => false,
+			isStreaming: () => false,
+			planModeEnabled: () => false,
+			emitSessionEvent: async () => {},
+			wakeForIrc: () => {},
+			runEphemeralTurn: async () => ({ replyText: "" }),
+		};
+		const irc = new IrcBridge(host);
+
+		const original: AgentMessage = {
+			role: "user",
+			content: [{ type: "text", text: "ORIGINAL" }],
+			attribution: "user",
+			timestamp: Date.now(),
+		};
+		irc.queueAside([original]);
+		const snapshot = irc.clearPending();
+		expect(irc.hasPending()).toBe(false);
+
+		// Simulates a record arriving while the rolled-back transition's async work was in flight.
+		const duringRollback: AgentMessage = {
+			role: "user",
+			content: [{ type: "text", text: "DURING_ROLLBACK" }],
+			attribution: "user",
+			timestamp: Date.now(),
+		};
+		irc.queueAside([duringRollback]);
+
+		irc.restorePending(snapshot);
+
+		const drained = irc.drainPending();
+		expect(drained).toHaveLength(2);
+		expect(drained[0]).toBe(original);
+		expect(drained[1]).toBe(duringRollback);
 	});
 });

--- a/packages/coding-agent/test/agent-session-aside-delivery.test.ts
+++ b/packages/coding-agent/test/agent-session-aside-delivery.test.ts
@@ -452,4 +452,103 @@ describe("AgentSession aside delivery", () => {
 		expect(contexts).toHaveLength(1);
 		expect(JSON.stringify(contexts[0]!.messages)).not.toContain("LEAK_CANDIDATE_ASIDE");
 	});
+
+	it("prompt()'s internal streaming re-check queues streamingBehavior 'aside' as a non-interrupting aside, not a steer", async () => {
+		// Regression for the race sendUserMessage(..., { deliverAs: "aside" }) hands to prompt():
+		// prompt() awaits manual-compaction cleanup / image normalization between its idle
+		// observation and dispatch, so a turn can start streaming in that gap. Its internal
+		// isStreaming re-check must honor the caller's original "aside" intent (via
+		// `streamingBehavior: "aside"`) instead of degrading it into a tool-aborting steer.
+		const model = createMockModel({ provider: "openai", id: "gpt-test" }).model;
+		const modelRegistry = new ModelRegistry(authStorage);
+		const contexts: Context[] = [];
+
+		const started = Promise.withResolvers<void>();
+		const release = Promise.withResolvers<void>();
+		let abortSeen = false;
+
+		const slowTool: AgentTool = {
+			name: "slow",
+			label: "Slow",
+			description: "Blocks until released",
+			parameters: type({}),
+			execute: async (_id, _params, signal) => {
+				started.resolve();
+				signal?.addEventListener("abort", () => {
+					abortSeen = true;
+				});
+				await release.promise;
+				return { content: [{ type: "text", text: "SLOW_DONE" }] };
+			},
+		};
+
+		let callCount = 0;
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model, systemPrompt: ["Test"], tools: [slowTool], messages: [] },
+			convertToLlm,
+			streamFn: (_model, context) => {
+				contexts.push(context);
+				const isFirstCall = callCount === 0;
+				callCount++;
+				const message: AssistantMessage = isFirstCall
+					? {
+							role: "assistant",
+							content: [{ type: "toolCall", id: "tc-0", name: "slow", arguments: {} }],
+							api: model.api,
+							provider: model.provider,
+							model: model.id,
+							usage: zeroUsage,
+							stopReason: "toolUse",
+							timestamp: Date.now(),
+						}
+					: {
+							role: "assistant",
+							content: [{ type: "text", text: "Done." }],
+							api: model.api,
+							provider: model.provider,
+							model: model.id,
+							usage: zeroUsage,
+							stopReason: "stop",
+							timestamp: Date.now(),
+						};
+				const stream = new AssistantMessageEventStream();
+				queueMicrotask(() => {
+					stream.push({ type: "start", partial: message });
+					stream.push({ type: "done", reason: isFirstCall ? "toolUse" : "stop", message });
+				});
+				return stream;
+			},
+		});
+		const settings = Settings.isolated({ "compaction.enabled": false, "todo.enabled": false });
+		settings.setModelRole("default", `${model.provider}/${model.id}`);
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(tempDir.path()),
+			settings,
+			modelRegistry,
+			toolRegistry: new Map([[slowTool.name, slowTool]]),
+		});
+
+		const run = session.prompt("go");
+		await started.promise;
+
+		// Simulates prompt()'s own internal isStreaming re-check landing while the tool is still
+		// running — exactly what sendUserMessage's race threads through as streamingBehavior: "aside".
+		await session.prompt("RACE_ASIDE_TEXT", {
+			expandPromptTemplates: false,
+			streamingBehavior: "aside",
+		});
+
+		expect(abortSeen).toBe(false);
+		expect(session.agent.hasQueuedMessages()).toBe(false);
+		expect(session.agent.peekSteeringQueue()).toHaveLength(0);
+
+		release.resolve();
+		await run;
+		await session.waitForIdle();
+
+		expect(JSON.stringify(contexts[1]!.messages)).toContain("SLOW_DONE");
+		expect(JSON.stringify(contexts[1]!.messages)).toContain("RACE_ASIDE_TEXT");
+	});
 });

--- a/packages/coding-agent/test/agent-session-aside-delivery.test.ts
+++ b/packages/coding-agent/test/agent-session-aside-delivery.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
 import * as path from "node:path";
 import { type } from "@oh-my-pi/omptype";
 import { Agent, type AgentMessage, type AgentTool } from "@oh-my-pi/pi-agent-core";
-import type { AssistantMessage, Context } from "@oh-my-pi/pi-ai";
+import type { AssistantMessage, Context, ImageContent } from "@oh-my-pi/pi-ai";
 import { createMockModel } from "@oh-my-pi/pi-ai/providers/mock";
 import { AssistantMessageEventStream } from "@oh-my-pi/pi-ai/utils/event-stream";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
@@ -11,6 +11,7 @@ import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { IrcBridge, type IrcBridgeHost } from "@oh-my-pi/pi-coding-agent/session/irc-bridge";
 import { convertToLlm, USER_INTERRUPT_LABEL } from "@oh-my-pi/pi-coding-agent/session/messages";
+import { SessionAdvisors } from "@oh-my-pi/pi-coding-agent/session/session-advisors";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import * as imageLoading from "@oh-my-pi/pi-coding-agent/utils/image-loading";
 import { TempDir } from "@oh-my-pi/pi-utils";
@@ -922,5 +923,239 @@ describe("AgentSession aside delivery", () => {
 			message => message.role === "custom" && message.customType === "ext-aside",
 		);
 		expect(persisted).toBe(true);
+	});
+
+	it("validates the session generation before an idle sendCustomMessage aside dispatch", async () => {
+		// Regression: the streaming branch of sendCustomMessage's aside delivery checks
+		// #sessionGeneration before enqueueing (#queueCustomMessage), but the idle branch (plan
+		// mode fold / post-interrupt fold / #promptAgentInitiatedMessage) never compared its own
+		// captured generation. An image attachment whose normalization outlives a concurrent
+		// newSession() used to prompt or fold the stale message into the newly created session.
+		const modelRegistry = new ModelRegistry(authStorage);
+		const mock = createMockModel({ provider: "openai", id: "gpt-test" });
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model: mock.model, systemPrompt: ["Test"], tools: [], messages: [] },
+			convertToLlm,
+			streamFn: mock.stream,
+		});
+		const settings = Settings.isolated({ "compaction.enabled": false, "todo.enabled": false });
+		settings.setModelRole("default", `${mock.model.provider}/${mock.model.id}`);
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(tempDir.path()),
+			settings,
+			modelRegistry,
+			toolRegistry: new Map(),
+		});
+
+		const normalizeStarted = Promise.withResolvers<void>();
+		const releaseNormalize = Promise.withResolvers<void>();
+		const normalizeSpy = spyOn(imageLoading, "normalizeModelContextImages").mockImplementation(async images => {
+			normalizeStarted.resolve();
+			await releaseNormalize.promise;
+			return images;
+		});
+		try {
+			expect(session.isStreaming).toBe(false);
+			const image: ImageContent = { type: "image", data: "aW1hZ2U=", mimeType: "image/png" };
+			const dispatched = session.sendCustomMessage(
+				{
+					customType: "ext-aside",
+					content: [{ type: "text", text: "IDLE_GENERATION_ASIDE" }, image],
+					display: true,
+					attribution: "agent",
+				},
+				{ deliverAs: "aside" },
+			);
+			await normalizeStarted.promise;
+
+			await session.newSession();
+			releaseNormalize.resolve();
+
+			expect(await dispatched).toBe(false);
+			expect(JSON.stringify(session.agent.state.messages)).not.toContain("IDLE_GENERATION_ASIDE");
+		} finally {
+			normalizeSpy.mockRestore();
+		}
+	});
+
+	it("does not wake a stranded aside into an agent disconnected by an in-flight newSession()", async () => {
+		// Regression: #disconnectFromAgent() runs at the very top of newSession(), well before
+		// #sessionGeneration bumps (which happens only after agent.reset() and
+		// sessionManager.newSession() complete). A user aside's normalization that resolves in
+		// that gap sees an unchanged generation and a non-streaming agent, so
+		// #resumeStrandedIrcAsides used to wake a fresh agent.prompt() on the disconnected agent,
+		// racing the transition's own reset.
+		const modelRegistry = new ModelRegistry(authStorage);
+		const started = Promise.withResolvers<void>();
+		let callCount = 0;
+		const mock = createMockModel({
+			provider: "openai",
+			id: "gpt-test",
+			responses: [
+				() => {
+					started.resolve();
+					callCount++;
+					return { content: ["working"], delayMs: 60_000 };
+				},
+				() => {
+					callCount++;
+					return { content: ["woken reply"] };
+				},
+			],
+		});
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model: mock.model, systemPrompt: ["Test"], tools: [], messages: [] },
+			convertToLlm,
+			streamFn: mock.stream,
+		});
+		const settings = Settings.isolated({ "compaction.enabled": false, "todo.enabled": false });
+		settings.setModelRole("default", `${mock.model.provider}/${mock.model.id}`);
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(tempDir.path()),
+			settings,
+			modelRegistry,
+			toolRegistry: new Map(),
+		});
+
+		const run = session.prompt("go");
+		await started.promise;
+
+		const advisorsGateReached = Promise.withResolvers<void>();
+		const releaseAdvisorsGate = Promise.withResolvers<void>();
+		const originalDrainAndDetachRecorders = SessionAdvisors.prototype.drainAndDetachRecorders;
+		const advisorsSpy = spyOn(SessionAdvisors.prototype, "drainAndDetachRecorders").mockImplementation(
+			async function (this: SessionAdvisors) {
+				advisorsGateReached.resolve();
+				await releaseAdvisorsGate.promise;
+				return originalDrainAndDetachRecorders.call(this);
+			},
+		);
+		const normalizeStarted = Promise.withResolvers<void>();
+		const releaseNormalize = Promise.withResolvers<void>();
+		const normalizeSpy = spyOn(imageLoading, "normalizeModelContextImages").mockImplementation(async images => {
+			normalizeStarted.resolve();
+			await releaseNormalize.promise;
+			return images;
+		});
+
+		try {
+			const asidePromise = session.sendUserMessage("DISCONNECTED_ASIDE", { deliverAs: "aside" });
+			await normalizeStarted.promise;
+
+			const newSessionPromise = session.newSession();
+			// #disconnectFromAgent()/abort() have run; agent.reset() and the generation bump have not.
+			await advisorsGateReached.promise;
+
+			releaseNormalize.resolve();
+			await asidePromise;
+			// Flush any fire-and-forget microtask chain a stray #wakeForIrc call would have started
+			// (agent.prompt() is invoked asynchronously, not synchronously, from #wakeForIrc).
+			for (let i = 0; i < 5; i++) await Promise.resolve();
+
+			expect(callCount).toBe(1);
+
+			releaseAdvisorsGate.resolve();
+			expect(await newSessionPromise).toBe(true);
+			await run.catch(() => {});
+			await session.waitForIdle();
+
+			expect(JSON.stringify(session.agent.state.messages)).not.toContain("DISCONNECTED_ASIDE");
+		} finally {
+			normalizeSpy.mockRestore();
+			advisorsSpy.mockRestore();
+		}
+	});
+
+	it("preserves a normalized aside across a rolled-back switchSession()", async () => {
+		// Regression: the #sessionGeneration guard in #queueUserMessage's aside branch used to
+		// discard a record outright on any generation mismatch. switchSession() bumps the
+		// generation before its transition and only rolls it back to the exact prior value in its
+		// catch block, so a record whose normalization resolved during that window was lost even
+		// though the switch ultimately failed and the original session stayed live.
+		const sessionDir = path.join(tempDir.path(), "sessions");
+		const modelRegistry = new ModelRegistry(authStorage);
+		const started = Promise.withResolvers<void>();
+		const contexts: Context[] = [];
+		const mock = createMockModel({
+			provider: "openai",
+			id: "gpt-test",
+			responses: [
+				() => {
+					started.resolve();
+					return { content: ["working"], delayMs: 60_000 };
+				},
+				context => {
+					contexts.push(context);
+					return { content: ["woken reply"] };
+				},
+			],
+		});
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model: mock.model, systemPrompt: ["Test"], tools: [], messages: [] },
+			convertToLlm,
+			streamFn: mock.stream,
+		});
+		const settings = Settings.isolated({ "compaction.enabled": false, "todo.enabled": false });
+		settings.setModelRole("default", `${mock.model.provider}/${mock.model.id}`);
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.create(tempDir.path(), sessionDir),
+			settings,
+			modelRegistry,
+			toolRegistry: new Map(),
+		});
+
+		const targetManager = SessionManager.create(tempDir.path(), sessionDir);
+		targetManager.appendMessage({ role: "user", content: "target", timestamp: Date.now() });
+		await targetManager.ensureOnDisk();
+		const targetFile = targetManager.getSessionFile();
+		if (!targetFile) throw new Error("Expected target session file");
+		await targetManager.close();
+
+		const run = session.prompt("go");
+		await started.promise;
+
+		const normalizeStarted = Promise.withResolvers<void>();
+		const releaseNormalize = Promise.withResolvers<void>();
+		const normalizeSpy = spyOn(imageLoading, "normalizeModelContextImages").mockImplementation(async images => {
+			normalizeStarted.resolve();
+			await releaseNormalize.promise;
+			return images;
+		});
+		const setSessionFileReached = Promise.withResolvers<void>();
+		const releaseSetSessionFileFailure = Promise.withResolvers<void>();
+		const setSessionFileSpy = spyOn(SessionManager.prototype, "setSessionFile").mockImplementation(async () => {
+			setSessionFileReached.resolve();
+			await releaseSetSessionFileFailure.promise;
+			throw new Error("forced switchSession failure");
+		});
+
+		try {
+			const asidePromise = session.sendUserMessage("ROLLBACK_ASIDE", { deliverAs: "aside" });
+			await normalizeStarted.promise;
+
+			const switchedPromise = session.switchSession(targetFile);
+			// #sessionGeneration has bumped by now; setSessionFile is paused before it fails.
+			await setSessionFileReached.promise;
+
+			releaseNormalize.resolve();
+			releaseSetSessionFileFailure.resolve();
+
+			await expect(switchedPromise).rejects.toThrow("forced switchSession failure");
+			await asidePromise;
+			await run.catch(() => {});
+			await session.waitForIdle();
+
+			expect(contexts).toHaveLength(1);
+			expect(JSON.stringify(contexts[0]!.messages)).toContain("ROLLBACK_ASIDE");
+		} finally {
+			normalizeSpy.mockRestore();
+			setSessionFileSpy.mockRestore();
+		}
 	});
 });

--- a/packages/coding-agent/test/agent-session-aside-delivery.test.ts
+++ b/packages/coding-agent/test/agent-session-aside-delivery.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
 import * as path from "node:path";
 import { type } from "@oh-my-pi/omptype";
 import { Agent, type AgentMessage, type AgentTool } from "@oh-my-pi/pi-agent-core";
@@ -12,6 +12,7 @@ import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { IrcBridge, type IrcBridgeHost } from "@oh-my-pi/pi-coding-agent/session/irc-bridge";
 import { convertToLlm, USER_INTERRUPT_LABEL } from "@oh-my-pi/pi-coding-agent/session/messages";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import * as imageLoading from "@oh-my-pi/pi-coding-agent/utils/image-loading";
 import { TempDir } from "@oh-my-pi/pi-utils";
 
 const zeroUsage = {
@@ -805,5 +806,121 @@ describe("AgentSession aside delivery", () => {
 		expect(drained).toHaveLength(2);
 		expect(drained[0]).toBe(original);
 		expect(drained[1]).toBe(duringRollback);
+	});
+
+	it("drops a queued aside whose normalization outlives a concurrent newSession()", async () => {
+		// Regression: #queueUserMessage's aside branch used to enqueue into IrcBridge
+		// unconditionally after its normalization/vision-description awaits. If a
+		// newSession()/switchSession() completes (clearing the queue and, per the earlier
+		// stranded-aside fix, discarding whatever was queued at that instant) WHILE this
+		// call's own normalization is still in flight, the record lands in the queue only
+		// after the clear already ran — leaking the outgoing session's aside into the new
+		// session's transcript. Gate normalizeImagesForModel (always awaited, even without
+		// images) to force that exact interleaving.
+		const modelRegistry = new ModelRegistry(authStorage);
+		const started = Promise.withResolvers<void>();
+		const mock = createMockModel({
+			provider: "openai",
+			id: "gpt-test",
+			responses: [
+				() => {
+					started.resolve();
+					return { content: ["working"], delayMs: 60_000 };
+				},
+			],
+		});
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model: mock.model, systemPrompt: ["Test"], tools: [], messages: [] },
+			convertToLlm,
+			streamFn: mock.stream,
+		});
+		const settings = Settings.isolated({ "compaction.enabled": false, "todo.enabled": false });
+		settings.setModelRole("default", `${mock.model.provider}/${mock.model.id}`);
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(tempDir.path()),
+			settings,
+			modelRegistry,
+			toolRegistry: new Map(),
+		});
+
+		const run = session.prompt("go");
+		await started.promise;
+
+		const normalizeStarted = Promise.withResolvers<void>();
+		const releaseNormalize = Promise.withResolvers<void>();
+		const normalizeSpy = spyOn(imageLoading, "normalizeModelContextImages").mockImplementation(async images => {
+			normalizeStarted.resolve();
+			await releaseNormalize.promise;
+			return images;
+		});
+		try {
+			const asidePromise = session.sendUserMessage("GENERATION_RACE_ASIDE", { deliverAs: "aside" });
+			await normalizeStarted.promise;
+
+			// The session transition completes (clearing the queue and bumping
+			// #sessionGeneration) while the aside above is still gated in normalization.
+			await session.newSession();
+			await run.catch(() => {});
+
+			releaseNormalize.resolve();
+			await asidePromise;
+			await session.waitForIdle();
+
+			expect(JSON.stringify(session.agent.state.messages)).not.toContain("GENERATION_RACE_ASIDE");
+		} finally {
+			normalizeSpy.mockRestore();
+		}
+	});
+
+	it("routes a custom aside folded in plan mode through the event-emitting path so message_end fires", async () => {
+		// Regression: the plan-mode (and adjacent post-Esc-suppression) fold branches in
+		// sendCustomMessage used to append directly to agent state + session storage, emitting
+		// no message_end. The interactive extension sender skips its own transcript rebuild
+		// when the send began while streaming because it expects that event — without it the
+		// persisted message stays invisible until an unrelated rebuild. Plan mode is the
+		// deterministic way to reach the fold branch without racing a real stream settle.
+		const model = createMockModel({ provider: "openai", id: "gpt-test" }).model;
+		const modelRegistry = new ModelRegistry(authStorage);
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] },
+			convertToLlm,
+			streamFn: () => new AssistantMessageEventStream(),
+		});
+		const settings = Settings.isolated({ "compaction.enabled": false, "todo.enabled": false });
+		settings.setModelRole("default", `${model.provider}/${model.id}`);
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(tempDir.path()),
+			settings,
+			modelRegistry,
+			toolRegistry: new Map(),
+		});
+		session.setPlanModeState({ enabled: true, planFilePath: "local://PLAN.md" });
+
+		const messageEndTypes: string[] = [];
+		const messageEndSeen = Promise.withResolvers<void>();
+		session.subscribe(event => {
+			if (event.type === "message_end" && event.message.role === "custom") {
+				messageEndTypes.push(event.message.customType);
+				messageEndSeen.resolve();
+			}
+		});
+
+		expect(session.isStreaming).toBe(false);
+		const dispatched = await session.sendCustomMessage(
+			{ customType: "ext-aside", content: "PLAN_MODE_FOLD_ASIDE", display: true, attribution: "agent" },
+			{ deliverAs: "aside" },
+		);
+		await messageEndSeen.promise;
+
+		expect(dispatched).toBe(false);
+		expect(messageEndTypes).toContain("ext-aside");
+		const persisted = session.agent.state.messages.some(
+			message => message.role === "custom" && message.customType === "ext-aside",
+		);
+		expect(persisted).toBe(true);
 	});
 });

--- a/packages/coding-agent/test/rpc-prompt-result.test.ts
+++ b/packages/coding-agent/test/rpc-prompt-result.test.ts
@@ -121,6 +121,7 @@ describe("reportLocalOnlyPromptResult", () => {
 			},
 			sendCustomMessage: async (_message: unknown, options?: { triggerTurn?: boolean }) => {
 				sentOptions = options;
+				return true;
 			},
 		} as unknown as AgentSession;
 
@@ -145,9 +146,117 @@ describe("reportLocalOnlyPromptResult", () => {
 			},
 			{ triggerTurn: true },
 		);
+		// markAgentInvokingMessage now fires off the tracked send's resolution (gated on the
+		// boolean result) rather than synchronously, so let it settle.
+		await Promise.resolve();
+		await Promise.resolve();
 
 		expect(markCount).toBe(1);
 		expect(sentOptions).toEqual({ triggerTurn: true });
+	});
+
+	test("does not suppress prompt_result when an aside sendMessage starts no turn (e.g. idle plan-mode fold)", async () => {
+		let extensionActions: ExtensionActions | undefined;
+		const output: object[] = [];
+		const extensionUserMessages = new RpcExtensionUserMessageTracker();
+		const session = {
+			extensionRunner: {
+				initialize: (actions: ExtensionActions) => {
+					extensionActions = actions;
+				},
+				onError: () => {},
+				emit: async () => {},
+			},
+			// Mirrors AgentSession.sendCustomMessage's aside contract: `false` iff no turn started.
+			sendCustomMessage: async () => false,
+		} as unknown as AgentSession;
+
+		await initializeExtensions(session, {
+			reportSendError: (_action, error) => {
+				throw error;
+			},
+			reportRuntimeError: error => {
+				throw error.error;
+			},
+			trackAgentInvokingMessage: task => {
+				extensionUserMessages.trackAgentMessageTask(task);
+			},
+		});
+
+		const trackedPrompt = extensionUserMessages.watchPrompt(() => {
+			if (!extensionActions) throw new Error("extensions not initialized");
+			extensionActions.sendMessage(
+				{ customType: "test", content: "context", display: true, details: "context", attribution: "agent" },
+				{ deliverAs: "aside" },
+			);
+			return Promise.resolve(false);
+		});
+		reportLocalOnlyPromptResult({
+			id: "req_aside_no_turn",
+			prompt: trackedPrompt.prompt,
+			output: frame => output.push(frame),
+			onError: error => {
+				throw error;
+			},
+			hasExtensionAgentMessageTask: trackedPrompt.hasAgentMessageTask,
+			waitForExtensionAgentMessageTasks: trackedPrompt.waitForAgentMessageTasks,
+		});
+		await waitForTrackedPromptHandlers(trackedPrompt);
+
+		// A `false` result means sendCustomMessage provably started no turn — the RPC host must
+		// still get its completion signal instead of waiting forever on agent events that never
+		// arrive.
+		expect(output).toEqual([{ type: "prompt_result", id: "req_aside_no_turn", agentInvoked: false }]);
+	});
+
+	test("suppresses prompt_result when an aside sendMessage starts a turn", async () => {
+		let extensionActions: ExtensionActions | undefined;
+		const output: object[] = [];
+		const extensionUserMessages = new RpcExtensionUserMessageTracker();
+		const session = {
+			extensionRunner: {
+				initialize: (actions: ExtensionActions) => {
+					extensionActions = actions;
+				},
+				onError: () => {},
+				emit: async () => {},
+			},
+			sendCustomMessage: async () => true,
+		} as unknown as AgentSession;
+
+		await initializeExtensions(session, {
+			reportSendError: (_action, error) => {
+				throw error;
+			},
+			reportRuntimeError: error => {
+				throw error.error;
+			},
+			trackAgentInvokingMessage: task => {
+				extensionUserMessages.trackAgentMessageTask(task);
+			},
+		});
+
+		const trackedPrompt = extensionUserMessages.watchPrompt(() => {
+			if (!extensionActions) throw new Error("extensions not initialized");
+			extensionActions.sendMessage(
+				{ customType: "test", content: "context", display: true, details: "context", attribution: "agent" },
+				{ deliverAs: "aside" },
+			);
+			return Promise.resolve(false);
+		});
+		reportLocalOnlyPromptResult({
+			id: "req_aside_turn",
+			prompt: trackedPrompt.prompt,
+			output: frame => output.push(frame),
+			onError: error => {
+				throw error;
+			},
+			hasExtensionAgentMessageTask: trackedPrompt.hasAgentMessageTask,
+			waitForExtensionAgentMessageTasks: trackedPrompt.waitForAgentMessageTasks,
+		});
+		await waitForTrackedPromptHandlers(trackedPrompt);
+
+		expect(output).toEqual([]);
 	});
 
 	test("suppresses prompt_result when extension sendUserMessage succeeds", async () => {

--- a/packages/coding-agent/test/rpc-skill-command.test.ts
+++ b/packages/coding-agent/test/rpc-skill-command.test.ts
@@ -20,7 +20,7 @@ describe("tryRunRpcSkillCommand", () => {
 		);
 
 		let message: Pick<CustomMessage, "attribution" | "content" | "customType" | "details" | "display"> | undefined;
-		let options: { streamingBehavior?: "steer" | "followUp" } | undefined;
+		let options: { streamingBehavior?: "steer" | "followUp" | "aside" } | undefined;
 
 		const handled = await tryRunRpcSkillCommand(
 			{
@@ -57,7 +57,7 @@ describe("tryRunRpcSkillCommand", () => {
 			"---\nname: reviewer\ndescription: Review code\n---\n\nReview the supplied code carefully.\n",
 		);
 
-		let options: { streamingBehavior?: "steer" | "followUp" } | undefined;
+		let options: { streamingBehavior?: "steer" | "followUp" | "aside" } | undefined;
 		try {
 			const handled = await tryRunRpcSkillCommand(
 				{

--- a/packages/coding-agent/test/task/task-guards.test.ts
+++ b/packages/coding-agent/test/task/task-guards.test.ts
@@ -27,7 +27,7 @@ import { EventBus } from "@oh-my-pi/pi-coding-agent/utils/event-bus";
 
 interface SteerCall {
 	content: string;
-	options?: { deliverAs?: "steer" | "followUp" };
+	options?: { deliverAs?: "steer" | "followUp" | "aside" };
 }
 
 interface FakeSessionConfig {


### PR DESCRIPTION
## What
Adds `deliverAs: "aside"` to the extension `sendMessage`/`sendUserMessage` API. An aside is injected at the recipient's next step boundary: it does not abort the in-flight tool call (unlike `steer`) and does not wait for the run to finish (unlike `followUp`). On an idle session it behaves like `followUp`.

Delivery rides the existing aside path (`Agent.setAsideMessageProvider()` / `AgentLoopConfig.getAsideMessages()`) that hub `irc:incoming` messages already use, so no new queue or loop hook is introduced.

## Why
Extensions had no non-interrupting way to add context to a running agent, and one of the tools I'm working on needs to inject events from an external, async process. The hub tool has had this internally for a while, it just wasn't exposed. An example use-case for this might be notifying the running agent of CI progress, or nudges that aren't emergencies like approaching a token budget – you don't want to interrupt any in-flight tool-calls for these things, but you *also* don't want to wait for the entire turn to complete.

## Testing
- Created a temporary extension that called `ctx.sendMessage(..., { deliverAs: "aside" })` while the agent "slept" for 10 seconds using the bash tool, and the bash tool completed. The message was present at the start of the next step.
- Used the same temporary extension call on an idle session, and the new turn started with the message.
- Tests were added for both paths.
- Docs: extension API reference updated; CHANGELOG under Unreleased/Added.

---
- [X] `bun check` passes
- [X] Tested locally
- [X] CHANGELOG updated