### PR TITLE
fix(ai): preserve message-level Gemini thought signatures

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed OpenAI-compatible Gemini gateways losing message-level thought signatures when replaying tool-call history.
+
 ## [18.1.5] - 2026-09-03
 
 ### Added

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -131,6 +131,13 @@ type OpenAICompletionsDeltaWithReasoningDetails = ChatCompletionChunk.Choice["de
 	reasoning_details?: unknown;
 };
 
+type GeminiMessageThoughtSignatureField = "thinking_signature" | "thought_signature";
+
+type GeminiMessageThoughtSignature = {
+	field: GeminiMessageThoughtSignatureField;
+	signature: string;
+};
+
 type GeminiThoughtSignatureNamespace = "google" | "vertex";
 
 type GeminiThoughtSignatureExtraContent = Partial<
@@ -142,6 +149,11 @@ type OpenAICompletionsFunctionToolCall = ChatCompletionMessageFunctionToolCall &
 };
 
 const GEMINI_THOUGHT_SIGNATURE_NAMESPACES: readonly GeminiThoughtSignatureNamespace[] = ["google", "vertex"];
+
+const GEMINI_MESSAGE_THOUGHT_SIGNATURE_FIELDS: readonly GeminiMessageThoughtSignatureField[] = [
+	"thinking_signature",
+	"thought_signature",
+];
 
 function getGeminiThoughtSignatureExtraContent(value: unknown): GeminiThoughtSignatureExtraContent | undefined {
 	if (typeof value !== "object" || value === null) return undefined;
@@ -157,20 +169,26 @@ function getGeminiThoughtSignatureExtraContent(value: unknown): GeminiThoughtSig
 	return undefined;
 }
 
-function parseGeminiThoughtSignatureExtraContent(
-	thoughtSignature: string | undefined,
-): GeminiThoughtSignatureExtraContent | undefined {
+function getGeminiMessageThoughtSignature(value: unknown): GeminiMessageThoughtSignature | undefined {
+	if (typeof value !== "object" || value === null) return undefined;
+	for (const field of GEMINI_MESSAGE_THOUGHT_SIGNATURE_FIELDS) {
+		const signature = Reflect.get(value, field);
+		if (typeof signature === "string" && signature.length > 0) return { field, signature };
+	}
+	return undefined;
+}
+
+function parseStoredThoughtSignature(thoughtSignature: string | undefined): unknown {
 	if (!thoughtSignature) return undefined;
 	try {
-		const parsed: unknown = JSON.parse(thoughtSignature);
-		return getGeminiThoughtSignatureExtraContent(parsed);
+		return JSON.parse(thoughtSignature);
 	} catch {
 		return undefined;
 	}
 }
 
 type OpenAICompletionsAssistantMessageParam = ChatCompletionAssistantMessageParam &
-	Partial<Record<OpenAICompletionsReasoningField, string>> & {
+	Partial<Record<OpenAICompletionsReasoningField | GeminiMessageThoughtSignatureField, string>> & {
 		reasoning_details?: unknown[];
 	};
 
@@ -886,6 +904,7 @@ const streamOpenAICompletionsOnce = (
 				}
 			};
 			let currentBlock: OpenAIStreamBlock | undefined;
+			let messageThoughtSignature: GeminiMessageThoughtSignature | undefined;
 			const blockIndex = (block: OpenAIStreamBlock | undefined): number => {
 				if (!block) return Math.max(0, output.content.length - 1);
 				return output.content.indexOf(block);
@@ -1359,6 +1378,18 @@ const streamOpenAICompletionsOnce = (
 									matchingToolCall.thoughtSignature = JSON.stringify(detailObject);
 								}
 							}
+						}
+					}
+
+					const incomingMessageThoughtSignature = getGeminiMessageThoughtSignature(choice.delta);
+					if (incomingMessageThoughtSignature) messageThoughtSignature = incomingMessageThoughtSignature;
+					if (messageThoughtSignature) {
+						for (const block of output.content) {
+							if (block.type !== "toolCall") continue;
+							block.thoughtSignature = JSON.stringify({
+								[messageThoughtSignature.field]: messageThoughtSignature.signature,
+							});
+							break;
 						}
 					}
 				}
@@ -2279,19 +2310,30 @@ export function convertMessages(
 							arguments: serializeToolArguments(tc.arguments),
 						},
 					};
-					const extraContent = parseGeminiThoughtSignatureExtraContent(tc.thoughtSignature);
+					const extraContent = getGeminiThoughtSignatureExtraContent(
+						parseStoredThoughtSignature(tc.thoughtSignature),
+					);
 					if (extraContent) replayedToolCall.extra_content = extraContent;
 					return replayedToolCall;
 				});
+				for (const toolCall of toolCalls) {
+					const messageSignature = getGeminiMessageThoughtSignature(
+						parseStoredThoughtSignature(toolCall.thoughtSignature),
+					);
+					if (!messageSignature) continue;
+					assistantMsg[messageSignature.field] = messageSignature.signature;
+					break;
+				}
 				const reasoningDetails = toolCalls.flatMap(tc => {
-					const thoughtSignature = tc.thoughtSignature;
-					if (!thoughtSignature) return [];
-					try {
-						const parsed: unknown = JSON.parse(thoughtSignature);
-						return getGeminiThoughtSignatureExtraContent(parsed) ? [] : [parsed];
-					} catch {
+					const parsed = parseStoredThoughtSignature(tc.thoughtSignature);
+					if (
+						parsed === undefined ||
+						getGeminiThoughtSignatureExtraContent(parsed) ||
+						getGeminiMessageThoughtSignature(parsed)
+					) {
 						return [];
 					}
+					return [parsed];
 				});
 				if (reasoningDetails.length > 0) {
 					assistantMsg.reasoning_details = reasoningDetails;

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -187,6 +187,46 @@ function parseStoredThoughtSignature(thoughtSignature: string | undefined): unkn
 	}
 }
 
+// A single tool-call turn on an OpenAI-compatible Gemini wire can carry two
+// independent signatures: a per-call one (`extra_content.google|vertex` or an
+// encrypted `reasoning_details` entry) and a message-level `thinking_signature`
+// / `thought_signature`. Both are stashed together on the originating tool
+// call's `thoughtSignature` so persistence and replay preserve each field.
+// `perCall` holds the raw extra_content object or reasoning detail; `message`
+// holds the message-level signature in its wire shape.
+type StoredGeminiSignature = {
+	perCall?: unknown;
+	message?: Partial<Record<GeminiMessageThoughtSignatureField, string>>;
+};
+
+// Reads the stored envelope, also accepting the legacy raw shapes emitted before
+// the envelope existed (a bare extra_content object, reasoning detail, or
+// message-level signature) so persisted history keeps replaying.
+function normalizeStoredGeminiSignature(value: unknown): StoredGeminiSignature | undefined {
+	if (typeof value !== "object" || value === null) return undefined;
+	const perCall = Reflect.get(value, "perCall");
+	const envelopeMessage = getGeminiMessageThoughtSignature(Reflect.get(value, "message"));
+	if (perCall !== undefined || envelopeMessage) {
+		const normalized: StoredGeminiSignature = {};
+		if (perCall !== undefined) normalized.perCall = perCall;
+		if (envelopeMessage) normalized.message = { [envelopeMessage.field]: envelopeMessage.signature };
+		return normalized;
+	}
+	const legacyMessage = getGeminiMessageThoughtSignature(value);
+	if (legacyMessage) return { message: { [legacyMessage.field]: legacyMessage.signature } };
+	return { perCall: value };
+}
+
+// Merges a new per-call or message-level signature into whatever is already
+// stored, so a later message-level signature never clobbers an earlier per-call
+// one (and vice versa).
+function mergeStoredGeminiSignature(existing: string | undefined, update: StoredGeminiSignature): string {
+	const merged = normalizeStoredGeminiSignature(parseStoredThoughtSignature(existing)) ?? {};
+	if (update.perCall !== undefined) merged.perCall = update.perCall;
+	if (update.message) merged.message = update.message;
+	return JSON.stringify(merged);
+}
+
 type OpenAICompletionsAssistantMessageParam = ChatCompletionAssistantMessageParam &
 	Partial<Record<OpenAICompletionsReasoningField | GeminiMessageThoughtSignatureField, string>> & {
 		reasoning_details?: unknown[];
@@ -1312,7 +1352,11 @@ const streamOpenAICompletionsOnce = (
 							if (toolCall.id) block.id = toolCall.id;
 							if (incomingName) block.name = incomingName;
 							const extraContent = getGeminiThoughtSignatureExtraContent(Reflect.get(toolCall, "extra_content"));
-							if (extraContent) block.thoughtSignature = JSON.stringify(extraContent);
+							if (extraContent) {
+								block.thoughtSignature = mergeStoredGeminiSignature(block.thoughtSignature, {
+									perCall: extraContent,
+								});
+							}
 							let delta = "";
 							// The OpenAI SDK types `function.arguments` as a JSON string, but MiniMax-compatible
 							// hosts stream a fully-formed object instead. Model both shapes so the branches below
@@ -1375,7 +1419,10 @@ const streamOpenAICompletionsOnce = (
 									b => b.type === "toolCall" && b.id === detailObject.id,
 								) as ToolCall | undefined;
 								if (matchingToolCall) {
-									matchingToolCall.thoughtSignature = JSON.stringify(detailObject);
+									matchingToolCall.thoughtSignature = mergeStoredGeminiSignature(
+										matchingToolCall.thoughtSignature,
+										{ perCall: detailObject },
+									);
 								}
 							}
 						}
@@ -1386,8 +1433,10 @@ const streamOpenAICompletionsOnce = (
 					if (messageThoughtSignature) {
 						for (const block of output.content) {
 							if (block.type !== "toolCall") continue;
-							block.thoughtSignature = JSON.stringify({
-								[messageThoughtSignature.field]: messageThoughtSignature.signature,
+							block.thoughtSignature = mergeStoredGeminiSignature(block.thoughtSignature, {
+								message: {
+									[messageThoughtSignature.field]: messageThoughtSignature.signature,
+								},
 							});
 							break;
 						}
@@ -2310,30 +2359,23 @@ export function convertMessages(
 							arguments: serializeToolArguments(tc.arguments),
 						},
 					};
-					const extraContent = getGeminiThoughtSignatureExtraContent(
-						parseStoredThoughtSignature(tc.thoughtSignature),
-					);
+					const stored = normalizeStoredGeminiSignature(parseStoredThoughtSignature(tc.thoughtSignature));
+					const extraContent = getGeminiThoughtSignatureExtraContent(stored?.perCall);
 					if (extraContent) replayedToolCall.extra_content = extraContent;
 					return replayedToolCall;
 				});
 				for (const toolCall of toolCalls) {
-					const messageSignature = getGeminiMessageThoughtSignature(
-						parseStoredThoughtSignature(toolCall.thoughtSignature),
-					);
+					const stored = normalizeStoredGeminiSignature(parseStoredThoughtSignature(toolCall.thoughtSignature));
+					const messageSignature = getGeminiMessageThoughtSignature(stored?.message);
 					if (!messageSignature) continue;
 					assistantMsg[messageSignature.field] = messageSignature.signature;
 					break;
 				}
 				const reasoningDetails = toolCalls.flatMap(tc => {
-					const parsed = parseStoredThoughtSignature(tc.thoughtSignature);
-					if (
-						parsed === undefined ||
-						getGeminiThoughtSignatureExtraContent(parsed) ||
-						getGeminiMessageThoughtSignature(parsed)
-					) {
-						return [];
-					}
-					return [parsed];
+					const stored = normalizeStoredGeminiSignature(parseStoredThoughtSignature(tc.thoughtSignature));
+					const perCall = stored?.perCall;
+					if (perCall === undefined || getGeminiThoughtSignatureExtraContent(perCall)) return [];
+					return [perCall];
 				});
 				if (reasoningDetails.length > 0) {
 					assistantMsg.reasoning_details = reasoningDetails;

--- a/packages/ai/test/openai-completions-thought-signature.test.ts
+++ b/packages/ai/test/openai-completions-thought-signature.test.ts
@@ -91,8 +91,8 @@ async function expectThoughtSignatureRoundTrip(signature: SignatureShape): Promi
 	const toolCall = findToolCall([assistant]);
 	const capturedSignature =
 		signature.type === "tool"
-			? JSON.stringify({ [signature.namespace]: { thought_signature: "opaque-signature" } })
-			: JSON.stringify({ [signature.field]: "opaque-signature" });
+			? JSON.stringify({ perCall: { [signature.namespace]: { thought_signature: "opaque-signature" } } })
+			: JSON.stringify({ message: { [signature.field]: "opaque-signature" } });
 
 	expect(toolCall.thoughtSignature).toBe(capturedSignature);
 
@@ -154,5 +154,73 @@ describe("OpenAI-compatible Gemini thought signatures", () => {
 
 	it("round-trips a message-level thought_signature alias", async () => {
 		await expectThoughtSignatureRoundTrip({ type: "message", field: "thought_signature" });
+	});
+
+	it("preserves both extra_content and a message-level signature together", async () => {
+		const payloads: unknown[] = [];
+		let requestIndex = 0;
+		const fetchMock: FetchImpl = Object.assign(
+			async (_input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+				if (typeof init?.body === "string") payloads.push(JSON.parse(init.body));
+				if (requestIndex++ === 0) {
+					return sseResponse(
+						{
+							role: "assistant",
+							thinking_signature: "message-sig",
+							tool_calls: [
+								{
+									index: 0,
+									id: "call_1",
+									type: "function",
+									function: { name: "read", arguments: '{"path":"README.md"}' },
+									extra_content: { google: { thought_signature: "per-call-sig" } },
+								},
+							],
+						},
+						"tool_calls",
+					);
+				}
+				return sseResponse({ role: "assistant", content: "done" }, "stop");
+			},
+			{ preconnect: fetch.preconnect },
+		);
+
+		const assistant = await streamOpenAICompletions(
+			model,
+			{ messages: [userMessage] },
+			{ apiKey: "test-key", fetch: fetchMock },
+		).result();
+		const toolCall = findToolCall([assistant]);
+		const toolResult: Message = {
+			role: "toolResult",
+			toolCallId: toolCall.id,
+			toolName: toolCall.name,
+			content: [{ type: "text", text: "README contents" }],
+			isError: false,
+			timestamp: 2,
+		};
+		await streamOpenAICompletions(
+			model,
+			{ messages: [userMessage, assistant, toolResult] },
+			{ apiKey: "test-key", fetch: fetchMock },
+		).result();
+
+		const replayPayload = payloads[1];
+		if (typeof replayPayload !== "object" || replayPayload === null) {
+			throw new Error("continuation payload missing");
+		}
+		const replayMessages = Reflect.get(replayPayload, "messages");
+		if (!Array.isArray(replayMessages)) throw new Error("continuation messages missing");
+		const replayedAssistant = replayMessages.find(
+			message => typeof message === "object" && message !== null && Reflect.get(message, "role") === "assistant",
+		);
+		if (typeof replayedAssistant !== "object" || replayedAssistant === null) {
+			throw new Error("replayed assistant message missing");
+		}
+		expect(replayedAssistant).toMatchObject({
+			role: "assistant",
+			thinking_signature: "message-sig",
+			tool_calls: [{ id: "call_1", extra_content: { google: { thought_signature: "per-call-sig" } } }],
+		});
 	});
 });

--- a/packages/ai/test/openai-completions-thought-signature.test.ts
+++ b/packages/ai/test/openai-completions-thought-signature.test.ts
@@ -22,6 +22,10 @@ const userMessage: Message = {
 	timestamp: 1,
 };
 
+type SignatureShape =
+	| { type: "tool"; namespace: "google" | "vertex" }
+	| { type: "message"; field: "thinking_signature" | "thought_signature" };
+
 function sseResponse(delta: Record<string, unknown>, finishReason: "stop" | "tool_calls"): Response {
 	const chunks = [
 		{
@@ -43,26 +47,26 @@ function sseResponse(delta: Record<string, unknown>, finishReason: "stop" | "too
 	return new Response(body, { headers: { "content-type": "text/event-stream" } });
 }
 
-function createFetch(namespace: "google" | "vertex", payloads: unknown[]): FetchImpl {
+function createFetch(signature: SignatureShape, payloads: unknown[]): FetchImpl {
 	let requestIndex = 0;
 	async function mockFetch(_input: string | URL | Request, init?: RequestInit): Promise<Response> {
 		if (typeof init?.body === "string") payloads.push(JSON.parse(init.body));
 		if (requestIndex++ === 0) {
-			return sseResponse(
-				{
-					role: "assistant",
-					tool_calls: [
-						{
-							index: 0,
-							id: "call_1",
-							type: "function",
-							function: { name: "read", arguments: '{"path":"README.md"}' },
-							extra_content: { [namespace]: { thought_signature: "opaque-signature" } },
-						},
-					],
-				},
-				"tool_calls",
-			);
+			const toolCall: Record<string, unknown> = {
+				index: 0,
+				id: "call_1",
+				type: "function",
+				function: { name: "read", arguments: '{"path":"README.md"}' },
+			};
+			const delta: Record<string, unknown> = { role: "assistant", tool_calls: [toolCall] };
+			if (signature.type === "tool") {
+				toolCall.extra_content = {
+					[signature.namespace]: { thought_signature: "opaque-signature" },
+				};
+			} else {
+				delta[signature.field] = "opaque-signature";
+			}
+			return sseResponse(delta, "tool_calls");
 		}
 		return sseResponse({ role: "assistant", content: "done" }, "stop");
 	}
@@ -76,18 +80,21 @@ function findToolCall(messages: Message[]): ToolCall {
 	return toolCall;
 }
 
-async function expectThoughtSignatureRoundTrip(namespace: "google" | "vertex"): Promise<void> {
+async function expectThoughtSignatureRoundTrip(signature: SignatureShape): Promise<void> {
 	const payloads: unknown[] = [];
-	const fetchMock = createFetch(namespace, payloads);
+	const fetchMock = createFetch(signature, payloads);
 	const assistant = await streamOpenAICompletions(
 		model,
 		{ messages: [userMessage] },
 		{ apiKey: "test-key", fetch: fetchMock },
 	).result();
 	const toolCall = findToolCall([assistant]);
-	const extraContent = { [namespace]: { thought_signature: "opaque-signature" } };
+	const capturedSignature =
+		signature.type === "tool"
+			? JSON.stringify({ [signature.namespace]: { thought_signature: "opaque-signature" } })
+			: JSON.stringify({ [signature.field]: "opaque-signature" });
 
-	expect(toolCall.thoughtSignature).toBe(JSON.stringify(extraContent));
+	expect(toolCall.thoughtSignature).toBe(capturedSignature);
 
 	const toolResult: Message = {
 		role: "toolResult",
@@ -112,18 +119,40 @@ async function expectThoughtSignatureRoundTrip(namespace: "google" | "vertex"): 
 	const replayedAssistant = replayMessages.find(
 		message => typeof message === "object" && message !== null && Reflect.get(message, "role") === "assistant",
 	);
-	expect(replayedAssistant).toMatchObject({
-		role: "assistant",
-		tool_calls: [{ id: "call_1", extra_content: extraContent }],
-	});
+	if (typeof replayedAssistant !== "object" || replayedAssistant === null) {
+		throw new Error("replayed assistant message missing");
+	}
+	if (signature.type === "tool") {
+		expect(replayedAssistant).toMatchObject({
+			role: "assistant",
+			tool_calls: [
+				{
+					id: "call_1",
+					extra_content: {
+						[signature.namespace]: { thought_signature: "opaque-signature" },
+					},
+				},
+			],
+		});
+	} else {
+		expect(Reflect.get(replayedAssistant, signature.field)).toBe("opaque-signature");
+	}
 }
 
 describe("OpenAI-compatible Gemini thought signatures", () => {
 	it("round-trips the google signature namespace", async () => {
-		await expectThoughtSignatureRoundTrip("google");
+		await expectThoughtSignatureRoundTrip({ type: "tool", namespace: "google" });
 	});
 
 	it("round-trips the vertex signature namespace", async () => {
-		await expectThoughtSignatureRoundTrip("vertex");
+		await expectThoughtSignatureRoundTrip({ type: "tool", namespace: "vertex" });
+	});
+
+	it("round-trips a message-level thinking_signature", async () => {
+		await expectThoughtSignatureRoundTrip({ type: "message", field: "thinking_signature" });
+	});
+
+	it("round-trips a message-level thought_signature alias", async () => {
+		await expectThoughtSignatureRoundTrip({ type: "message", field: "thought_signature" });
 	});
 });


### PR DESCRIPTION
## Repro
A streamed OpenAI-compatible Gemini assistant delta with a tool call and top-level `thinking_signature` loses the signature before continuation replay. `bun test packages/ai/test/openai-completions-thought-signature.test.ts --test-name-pattern 'message-level thinking_signature'` failed before the fix with expected `{"thinking_signature":"opaque-signature"}` and received `undefined`.

## Cause
`packages/ai/src/providers/openai-completions.ts` only captured signatures from `tool_calls[].extra_content.google|vertex` and `reasoning_details`; its stream parser ignored message-level `thinking_signature`, and its request builder had no corresponding assistant-message replay path.

## Fix
- Capture non-empty message-level `thinking_signature` and `thought_signature` aliases from streamed assistant deltas and retain them on the originating tool-call turn.
- Replay the captured value on that assistant message under its original field name without also emitting it as `reasoning_details`.
- Cover both top-level aliases alongside the existing Google and Vertex namespaced shapes.
- Document the fix in the pi-ai changelog.

## Verification
`bun test packages/ai/test/openai-completions-thought-signature.test.ts` passes: 4 tests, 8 assertions. `bun check` passes.

Fixes #10630