### PR TITLE
anthropic: clamp image dimensions and payload size to the API limits

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Anthropic and OpenRouter 402 credit-exhaustion errors ("would exceed your available credits", "Insufficient credits") now switch to a sibling account instead of stopping the turn with a retry hint.
+- Fixed Anthropic requests failing with HTTP 400 `At least one of the image dimensions exceed max allowed size: 8000 pixels` when a tall screenshot sat in history; every image now respects the host's per-side image limit instead of only requests carrying more than 20 images.
 
 ## [18.1.5] - 2026-09-03
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Anthropic and OpenRouter 402 credit-exhaustion errors ("would exceed your available credits", "Insufficient credits") now switch to a sibling account instead of stopping the turn with a retry hint.
 - Fixed Anthropic requests failing with HTTP 400 `At least one of the image dimensions exceed max allowed size: 8000 pixels` when a tall screenshot sat in history; every image now respects the host's per-side image limit instead of only requests carrying more than 20 images.
+- Fixed Anthropic requests failing with HTTP 400 `image exceeds 10 MB maximum` when a dense screenshot sat in history; oversized image payloads are now re-encoded down to the host's byte limit, at full resolution when re-encoding alone is enough.
 
 ## [18.1.5] - 2026-09-03
 

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -919,16 +919,34 @@ function decodeAnthropicToolName(name: string, isOAuthToken: boolean, escapeBuil
 const ANTHROPIC_MANY_IMAGE_THRESHOLD = 20;
 const ANTHROPIC_MANY_IMAGE_MAX_DIMENSION = 2000;
 /**
- * Hard limit of the canonical Anthropic Messages API, used when resolved model
- * policy names no other. Anthropic rejects any image whose width or height
- * exceeds this ("At least one of the image dimensions exceed max allowed size:
- * 8000 pixels") no matter how many images the request carries, and the
- * rejection poisons every retry and model fallback because the block stays in
- * context. Tall full-page screenshots cross it routinely, so every request
- * clamps to it. A host whose image contract differs sets `max-image-dimension`
- * in the KDL compatibility rules.
+ * Image contract of the canonical Anthropic Messages API, used when resolved
+ * model policy names no other: 8000px per side ("At least one of the image
+ * dimensions exceed max allowed size: 8000 pixels") and a 10 MB base64
+ * payload per block ("image exceeds 10 MB maximum: 14012300 bytes >
+ * 10485760 bytes"), measured on the encoded string rather than the decoded
+ * bytes. Either rejection poisons every retry and model fallback because the
+ * block stays in context, so both are clamped before the request goes out.
+ * A host with a different image contract sets `max-image-dimension` /
+ * `max-image-payload-bytes` in the KDL compatibility rules.
  */
 const ANTHROPIC_MAX_IMAGE_DIMENSION = 8000;
+const ANTHROPIC_MAX_IMAGE_PAYLOAD_BYTES = 10 * 1024 * 1024;
+/** Headroom for the surrounding JSON and any provider-side accounting. */
+const ANTHROPIC_IMAGE_PAYLOAD_HEADROOM = 0.9;
+/** Re-encode passes allowed to bring one image under the byte budget. */
+const ANTHROPIC_IMAGE_RESIZE_ATTEMPTS = 4;
+
+/**
+ * Image bounds for one request. `maxDimension` and `payloadBudget` come from
+ * resolved model policy (`max-image-dimension`, `max-image-payload-bytes`) so
+ * a deployment whose image contract differs from the canonical API can
+ * override them, and the many-image path tightens `maxDimension` further
+ * because many images share one request budget.
+ */
+interface AnthropicImageCaps {
+	maxDimension: number;
+	payloadBudget: number;
+}
 
 function countAnthropicImageBlocks(messages: Message[]): number {
 	let count = 0;
@@ -961,21 +979,22 @@ function anthropicImageResizeConcurrency(maxDimension: number): number {
 }
 
 /**
- * Memoized resize results keyed on ImageContent identity, per target
- * dimension. Callers keep message objects stable across turns, so without this
- * every request (and every in-provider retry of a fresh turn) re-decodes and
+ * Memoized resize results keyed on ImageContent identity, per cap pair.
+ * Callers keep message objects stable across turns, so without this every
+ * request (and every in-provider retry of a fresh turn) re-decodes and
  * re-encodes the same oversized screenshots. A cached value identical to the
- * key means "already within bounds / unresizable — skip the decode". The cap
- * depends on image count and on resolved policy, so each cap keeps its own
+ * key means "already within bounds / unresizable — skip the decode". The caps
+ * depend on image count and on resolved policy, so each pair keeps its own
  * cache: a value cached at 8000px is not reusable at 2000px.
  */
-const anthropicImageResizeCaches = new Map<number, WeakMap<ImageContent, ImageContent>>();
+const anthropicImageResizeCaches = new Map<string, WeakMap<ImageContent, ImageContent>>();
 
-function anthropicImageResizeCache(maxDimension: number): WeakMap<ImageContent, ImageContent> {
-	const existing = anthropicImageResizeCaches.get(maxDimension);
+function anthropicImageResizeCache(caps: AnthropicImageCaps): WeakMap<ImageContent, ImageContent> {
+	const key = `${caps.maxDimension}:${caps.payloadBudget}`;
+	const existing = anthropicImageResizeCaches.get(key);
 	if (existing) return existing;
 	const created = new WeakMap<ImageContent, ImageContent>();
-	anthropicImageResizeCaches.set(maxDimension, created);
+	anthropicImageResizeCaches.set(key, created);
 	return created;
 }
 
@@ -1008,29 +1027,51 @@ function createResizeLimiter(limit: number): ResizeLimiter {
 	};
 }
 
-async function resizeAnthropicImageBlock(block: ImageContent, maxDimension: number): Promise<ImageContent> {
+async function resizeAnthropicImageBlock(block: ImageContent, caps: AnthropicImageCaps): Promise<ImageContent> {
+	const { maxDimension, payloadBudget } = caps;
 	try {
 		const inputBuffer = Buffer.from(block.data, "base64");
 		const { width, height } = await new Bun.Image(inputBuffer).metadata();
 		if (!width || !height) return block;
-		if (width <= maxDimension && height <= maxDimension) return block;
+		const overDimension = width > maxDimension || height > maxDimension;
+		const overBudget = block.data.length > payloadBudget;
+		if (!overDimension && !overBudget) return block;
 
-		const scale = Math.min(maxDimension / width, maxDimension / height);
-		const targetWidth = Math.max(1, Math.min(maxDimension, Math.round(width * scale)));
-		const targetHeight = Math.max(1, Math.min(maxDimension, Math.round(height * scale)));
-		// One encoder at a time: a full-resolution surface is hundreds of
-		// megabytes, so the two candidates never coexist.
-		const png = await new Bun.Image(inputBuffer).resize(targetWidth, targetHeight).png().bytes();
-		const jpeg = await new Bun.Image(inputBuffer).resize(targetWidth, targetHeight).jpeg({ quality: 85 }).bytes();
-		const best =
-			png.length <= jpeg.length ? { buffer: png, mimeType: "image/png" } : { buffer: jpeg, mimeType: "image/jpeg" };
+		// Fitting the pixel cap does not imply fitting the byte cap: a dense
+		// screenshot re-encodes large even at the cap. Shrink by the overshoot in
+		// area terms until the payload fits or the passes run out.
+		let scale = Math.min(1, maxDimension / width, maxDimension / height);
+		let best: { buffer: Uint8Array; mimeType: string } | undefined;
+		for (let attempt = 0; attempt < ANTHROPIC_IMAGE_RESIZE_ATTEMPTS; attempt++) {
+			const targetWidth = Math.max(1, Math.min(maxDimension, Math.round(width * scale)));
+			const targetHeight = Math.max(1, Math.min(maxDimension, Math.round(height * scale)));
+			// One encoder at a time: a full-resolution surface is hundreds of
+			// megabytes, so the two candidates never coexist.
+			const png = await new Bun.Image(inputBuffer).resize(targetWidth, targetHeight).png().bytes();
+			const jpeg = await new Bun.Image(inputBuffer).resize(targetWidth, targetHeight).jpeg({ quality: 85 }).bytes();
+			best =
+				png.length <= jpeg.length
+					? { buffer: png, mimeType: "image/png" }
+					: { buffer: jpeg, mimeType: "image/jpeg" };
 
+			// Base64 expands three bytes into four characters; the encoded length
+			// is what Anthropic measures, so derive it without encoding.
+			const encoded = Math.ceil(best.buffer.length / 3) * 4;
+			if (encoded <= payloadBudget) break;
+			if (targetWidth === 1 && targetHeight === 1) break;
+			scale *= Math.max(0.25, Math.sqrt(payloadBudget / encoded) * 0.9);
+		}
+		if (!best) return block;
+
+		const data = Buffer.from(best.buffer).toString("base64");
+		// An image inside the pixel cap is only worth replacing if it shrank.
+		if (!overDimension && data.length >= block.data.length) return block;
 		// The rebuilt block carries no `url` or `providerFile`: those reference
 		// the original bytes, and Anthropic validates a referenced image after
 		// fetching it, so keeping either would resend the oversized copy.
 		return {
 			type: "image",
-			data: Buffer.from(best.buffer).toString("base64"),
+			data,
 			mimeType: best.mimeType,
 		};
 	} catch (error) {
@@ -1046,16 +1087,16 @@ async function resizeAnthropicImageContent(
 	content: (TextContent | ImageContent)[],
 	state: { resized: number },
 	limit: ResizeLimiter,
-	maxDimension: number,
+	caps: AnthropicImageCaps,
 ): Promise<(TextContent | ImageContent)[]> {
 	let changed = false;
-	const cache = anthropicImageResizeCache(maxDimension);
+	const cache = anthropicImageResizeCache(caps);
 	const next = await Promise.all(
 		content.map(async block => {
 			if (block.type !== "image") return block;
 			let resized = cache.get(block);
 			if (resized === undefined) {
-				resized = await limit(() => resizeAnthropicImageBlock(block, maxDimension));
+				resized = await limit(() => resizeAnthropicImageBlock(block, caps));
 				cache.set(block, resized);
 			}
 			if (resized !== block) {
@@ -1072,15 +1113,15 @@ async function resizeAnthropicImageMessage(
 	message: Message,
 	state: { resized: number },
 	limit: ResizeLimiter,
-	maxDimension: number,
+	caps: AnthropicImageCaps,
 ): Promise<Message> {
 	if (message.role === "user" || message.role === "developer") {
 		if (!Array.isArray(message.content)) return message;
-		const content = await resizeAnthropicImageContent(message.content, state, limit, maxDimension);
+		const content = await resizeAnthropicImageContent(message.content, state, limit, caps);
 		return content === message.content ? message : { ...message, content };
 	}
 	if (message.role === "toolResult") {
-		const content = await resizeAnthropicImageContent(message.content, state, limit, maxDimension);
+		const content = await resizeAnthropicImageContent(message.content, state, limit, caps);
 		return content === message.content ? message : { ...message, content };
 	}
 	return message;
@@ -1097,13 +1138,18 @@ async function prepareAnthropicImageContext(context: Context, model: Model<"anth
 		imageCount > ANTHROPIC_MANY_IMAGE_THRESHOLD
 			? Math.min(ANTHROPIC_MANY_IMAGE_MAX_DIMENSION, hostMaxDimension)
 			: hostMaxDimension;
+	const maxPayloadBytes = model.compat.maxImagePayloadBytes ?? ANTHROPIC_MAX_IMAGE_PAYLOAD_BYTES;
+	const caps: AnthropicImageCaps = {
+		maxDimension,
+		payloadBudget: Math.floor(maxPayloadBytes * ANTHROPIC_IMAGE_PAYLOAD_HEADROOM),
+	};
 
 	let changed = false;
 	const state = { resized: 0 };
 	const limit = createResizeLimiter(anthropicImageResizeConcurrency(maxDimension));
 	const messages = await Promise.all(
 		context.messages.map(async message => {
-			const next = await resizeAnthropicImageMessage(message, state, limit, maxDimension);
+			const next = await resizeAnthropicImageMessage(message, state, limit, caps);
 			if (next !== message) changed = true;
 			return next;
 		}),

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -918,6 +918,17 @@ function decodeAnthropicToolName(name: string, isOAuthToken: boolean, escapeBuil
 
 const ANTHROPIC_MANY_IMAGE_THRESHOLD = 20;
 const ANTHROPIC_MANY_IMAGE_MAX_DIMENSION = 2000;
+/**
+ * Hard limit of the canonical Anthropic Messages API, used when resolved model
+ * policy names no other. Anthropic rejects any image whose width or height
+ * exceeds this ("At least one of the image dimensions exceed max allowed size:
+ * 8000 pixels") no matter how many images the request carries, and the
+ * rejection poisons every retry and model fallback because the block stays in
+ * context. Tall full-page screenshots cross it routinely, so every request
+ * clamps to it. A host whose image contract differs sets `max-image-dimension`
+ * in the KDL compatibility rules.
+ */
+const ANTHROPIC_MAX_IMAGE_DIMENSION = 8000;
 
 function countAnthropicImageBlocks(messages: Message[]): number {
 	let count = 0;
@@ -931,24 +942,50 @@ function countAnthropicImageBlocks(messages: Message[]): number {
 	return count;
 }
 
-const ANTHROPIC_IMAGE_RESIZE_CONCURRENCY = 4;
+/**
+ * Ceiling on encoder output pixels in flight. One 8000x8000 RGBA surface is
+ * roughly 256 MiB, so admitting four of them would spike the CLI by a
+ * gigabyte; at the full-resolution cap this yields a single pipeline, while
+ * the many-image cap encodes at most 2000px and keeps the four-way fan-out.
+ */
+const ANTHROPIC_IMAGE_RESIZE_PIXEL_BUDGET = 16_000_000;
+const ANTHROPIC_IMAGE_RESIZE_MAX_CONCURRENCY = 4;
+
+function anthropicImageResizeConcurrency(maxDimension: number): number {
+	const perPipeline = maxDimension * maxDimension;
+	if (perPipeline <= 0) return ANTHROPIC_IMAGE_RESIZE_MAX_CONCURRENCY;
+	return Math.max(
+		1,
+		Math.min(ANTHROPIC_IMAGE_RESIZE_MAX_CONCURRENCY, Math.floor(ANTHROPIC_IMAGE_RESIZE_PIXEL_BUDGET / perPipeline)),
+	);
+}
 
 /**
- * Memoized resize results keyed on ImageContent identity. Callers keep message
- * objects stable across turns, so without this every request (and every
- * in-provider retry of a fresh turn) re-decodes and re-encodes the same
- * oversized screenshots. A cached value identical to the key means "already
- * within bounds / unresizable — skip the decode".
+ * Memoized resize results keyed on ImageContent identity, per target
+ * dimension. Callers keep message objects stable across turns, so without this
+ * every request (and every in-provider retry of a fresh turn) re-decodes and
+ * re-encodes the same oversized screenshots. A cached value identical to the
+ * key means "already within bounds / unresizable — skip the decode". The cap
+ * depends on image count and on resolved policy, so each cap keeps its own
+ * cache: a value cached at 8000px is not reusable at 2000px.
  */
-const anthropicManyImageResizeCache = new WeakMap<ImageContent, ImageContent>();
+const anthropicImageResizeCaches = new Map<number, WeakMap<ImageContent, ImageContent>>();
+
+function anthropicImageResizeCache(maxDimension: number): WeakMap<ImageContent, ImageContent> {
+	const existing = anthropicImageResizeCaches.get(maxDimension);
+	if (existing) return existing;
+	const created = new WeakMap<ImageContent, ImageContent>();
+	anthropicImageResizeCaches.set(maxDimension, created);
+	return created;
+}
 
 type ResizeLimiter = <R>(fn: () => Promise<R>) => Promise<R>;
 
 /**
  * Bounded-concurrency gate for image decode/encode work. The many-image path
  * fans out over every block of every message; unbounded, 100+ oversized images
- * would decode concurrently (two encode pipelines each) and spike memory by
- * gigabytes. Slots are handed off directly to the next waiter on release.
+ * would decode concurrently and spike memory by gigabytes. Slots are handed
+ * off directly to the next waiter on release.
  */
 function createResizeLimiter(limit: number): ResizeLimiter {
 	let active = 0;
@@ -971,31 +1008,33 @@ function createResizeLimiter(limit: number): ResizeLimiter {
 	};
 }
 
-async function resizeAnthropicManyImageBlock(block: ImageContent): Promise<ImageContent> {
+async function resizeAnthropicImageBlock(block: ImageContent, maxDimension: number): Promise<ImageContent> {
 	try {
 		const inputBuffer = Buffer.from(block.data, "base64");
 		const { width, height } = await new Bun.Image(inputBuffer).metadata();
 		if (!width || !height) return block;
-		if (width <= ANTHROPIC_MANY_IMAGE_MAX_DIMENSION && height <= ANTHROPIC_MANY_IMAGE_MAX_DIMENSION) return block;
+		if (width <= maxDimension && height <= maxDimension) return block;
 
-		const scale = Math.min(ANTHROPIC_MANY_IMAGE_MAX_DIMENSION / width, ANTHROPIC_MANY_IMAGE_MAX_DIMENSION / height);
-		const targetWidth = Math.max(1, Math.min(ANTHROPIC_MANY_IMAGE_MAX_DIMENSION, Math.round(width * scale)));
-		const targetHeight = Math.max(1, Math.min(ANTHROPIC_MANY_IMAGE_MAX_DIMENSION, Math.round(height * scale)));
-
-		const [png, jpeg] = await Promise.all([
-			new Bun.Image(inputBuffer).resize(targetWidth, targetHeight).png().bytes(),
-			new Bun.Image(inputBuffer).resize(targetWidth, targetHeight).jpeg({ quality: 85 }).bytes(),
-		]);
+		const scale = Math.min(maxDimension / width, maxDimension / height);
+		const targetWidth = Math.max(1, Math.min(maxDimension, Math.round(width * scale)));
+		const targetHeight = Math.max(1, Math.min(maxDimension, Math.round(height * scale)));
+		// One encoder at a time: a full-resolution surface is hundreds of
+		// megabytes, so the two candidates never coexist.
+		const png = await new Bun.Image(inputBuffer).resize(targetWidth, targetHeight).png().bytes();
+		const jpeg = await new Bun.Image(inputBuffer).resize(targetWidth, targetHeight).jpeg({ quality: 85 }).bytes();
 		const best =
 			png.length <= jpeg.length ? { buffer: png, mimeType: "image/png" } : { buffer: jpeg, mimeType: "image/jpeg" };
 
+		// The rebuilt block carries no `url` or `providerFile`: those reference
+		// the original bytes, and Anthropic validates a referenced image after
+		// fetching it, so keeping either would resend the oversized copy.
 		return {
 			type: "image",
 			data: Buffer.from(best.buffer).toString("base64"),
 			mimeType: best.mimeType,
 		};
 	} catch (error) {
-		logger.warn("anthropic: failed to resize oversized image for many-image request", {
+		logger.warn("anthropic: failed to resize oversized image", {
 			mimeType: block.mimeType,
 			error: error instanceof Error ? error.message : String(error),
 		});
@@ -1003,27 +1042,21 @@ async function resizeAnthropicManyImageBlock(block: ImageContent): Promise<Image
 	}
 }
 
-async function resizeAnthropicManyImageContent(
+async function resizeAnthropicImageContent(
 	content: (TextContent | ImageContent)[],
 	state: { resized: number },
 	limit: ResizeLimiter,
+	maxDimension: number,
 ): Promise<(TextContent | ImageContent)[]> {
 	let changed = false;
+	const cache = anthropicImageResizeCache(maxDimension);
 	const next = await Promise.all(
 		content.map(async block => {
-			// Remotely referenced blocks never put base64 on the wire, so their size
-			// cannot violate the many-image request budget — and resizing would
-			// desync fallback bytes from the advertised remote image.
-			if (
-				block.type !== "image" ||
-				block.url ||
-				(block.providerFile?.provider === "anthropic" && block.providerFile.id)
-			)
-				return block;
-			let resized = anthropicManyImageResizeCache.get(block);
+			if (block.type !== "image") return block;
+			let resized = cache.get(block);
 			if (resized === undefined) {
-				resized = await limit(() => resizeAnthropicManyImageBlock(block));
-				anthropicManyImageResizeCache.set(block, resized);
+				resized = await limit(() => resizeAnthropicImageBlock(block, maxDimension));
+				cache.set(block, resized);
 			}
 			if (resized !== block) {
 				changed = true;
@@ -1035,43 +1068,51 @@ async function resizeAnthropicManyImageContent(
 	return changed ? next : content;
 }
 
-async function resizeAnthropicManyImageMessage(
+async function resizeAnthropicImageMessage(
 	message: Message,
 	state: { resized: number },
 	limit: ResizeLimiter,
+	maxDimension: number,
 ): Promise<Message> {
 	if (message.role === "user" || message.role === "developer") {
 		if (!Array.isArray(message.content)) return message;
-		const content = await resizeAnthropicManyImageContent(message.content, state, limit);
+		const content = await resizeAnthropicImageContent(message.content, state, limit, maxDimension);
 		return content === message.content ? message : { ...message, content };
 	}
 	if (message.role === "toolResult") {
-		const content = await resizeAnthropicManyImageContent(message.content, state, limit);
+		const content = await resizeAnthropicImageContent(message.content, state, limit, maxDimension);
 		return content === message.content ? message : { ...message, content };
 	}
 	return message;
 }
 
-async function prepareAnthropicManyImageContext(context: Context, supportsImages: boolean): Promise<Context> {
-	if (!supportsImages) return context;
+async function prepareAnthropicImageContext(context: Context, model: Model<"anthropic-messages">): Promise<Context> {
+	if (!model.input.includes("image")) return context;
 	const imageCount = countAnthropicImageBlocks(context.messages);
-	if (imageCount <= ANTHROPIC_MANY_IMAGE_THRESHOLD) return context;
+	if (imageCount === 0) return context;
+	// Many images share one request size budget, so they get the tighter cap.
+	// A smaller set only has to clear the host's per-image limit.
+	const hostMaxDimension = model.compat.maxImageDimension ?? ANTHROPIC_MAX_IMAGE_DIMENSION;
+	const maxDimension =
+		imageCount > ANTHROPIC_MANY_IMAGE_THRESHOLD
+			? Math.min(ANTHROPIC_MANY_IMAGE_MAX_DIMENSION, hostMaxDimension)
+			: hostMaxDimension;
 
 	let changed = false;
 	const state = { resized: 0 };
-	const limit = createResizeLimiter(ANTHROPIC_IMAGE_RESIZE_CONCURRENCY);
+	const limit = createResizeLimiter(anthropicImageResizeConcurrency(maxDimension));
 	const messages = await Promise.all(
 		context.messages.map(async message => {
-			const next = await resizeAnthropicManyImageMessage(message, state, limit);
+			const next = await resizeAnthropicImageMessage(message, state, limit, maxDimension);
 			if (next !== message) changed = true;
 			return next;
 		}),
 	);
 	if (!changed) return context;
-	logger.debug("anthropic: resized oversized images for many-image request", {
+	logger.debug("anthropic: resized oversized images", {
 		imageCount,
 		resized: state.resized,
-		maxDimension: ANTHROPIC_MANY_IMAGE_MAX_DIMENSION,
+		maxDimension,
 	});
 	return { ...context, messages };
 }
@@ -2183,7 +2224,7 @@ const streamAnthropicOnce = (
 				client = created.client;
 				isOAuthToken = created.isOAuthToken;
 			}
-			const preparedContext = await prepareAnthropicManyImageContext(context, model.input.includes("image"));
+			const preparedContext = await prepareAnthropicImageContext(context, model);
 			const prepareParams = async (): Promise<MessageCreateParamsStreaming> => {
 				let nextParams = buildParams(model, preparedContext, isOAuthToken, options, {
 					disableStrictTools,

--- a/packages/ai/test/anthropic-many-image-resize.test.ts
+++ b/packages/ai/test/anthropic-many-image-resize.test.ts
@@ -6,18 +6,23 @@ import { buildModel } from "@oh-my-pi/pi-catalog/build";
 const RED_1X1_PNG_BASE64 =
 	"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4z8AAAAMBAQDJ/pLvAAAAAElFTkSuQmCC";
 
-const model: Model<"anthropic-messages"> = buildModel({
-	id: "claude-sonnet-4-5",
-	name: "Claude Sonnet 4.5",
-	api: "anthropic-messages",
-	provider: "anthropic",
-	baseUrl: "https://api.anthropic.com",
-	reasoning: false,
-	input: ["text", "image"],
-	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-	contextWindow: 200_000,
-	maxTokens: 8_192,
-});
+function makeAnthropicModel(compat?: { maxImageDimension?: number }): Model<"anthropic-messages"> {
+	return buildModel({
+		id: "claude-sonnet-4-5",
+		name: "Claude Sonnet 4.5",
+		api: "anthropic-messages",
+		provider: "anthropic",
+		baseUrl: "https://api.anthropic.com",
+		reasoning: false,
+		input: ["text", "image"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 200_000,
+		maxTokens: 8_192,
+		compat,
+	});
+}
+
+const model = makeAnthropicModel();
 
 const emptyUsage: Usage = {
 	input: 0,
@@ -28,9 +33,18 @@ const emptyUsage: Usage = {
 	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 };
 
+type AnthropicImageSourceWire =
+	| { type: "base64"; media_type: string; data: string }
+	| { type: "url"; url: string }
+	| { type: "file"; file_id: string };
+
 type AnthropicImageBlock = {
 	type: "image";
-	source: { type: "base64"; media_type: string; data: string };
+	source: AnthropicImageSourceWire;
+};
+
+type AnthropicBase64ImageBlock = AnthropicImageBlock & {
+	source: Extract<AnthropicImageSourceWire, { type: "base64" }>;
 };
 
 type AnthropicToolResultBlock = {
@@ -84,9 +98,12 @@ function makeToolResultContext(images: ImageContent[]): Context {
 	};
 }
 
-function capturePayload(context: Context): Promise<AnthropicPayload> {
+function capturePayload(
+	context: Context,
+	requestModel: Model<"anthropic-messages"> = model,
+): Promise<AnthropicPayload> {
 	const { promise, resolve } = Promise.withResolvers<AnthropicPayload>();
-	void streamAnthropic(model, context, {
+	void streamAnthropic(requestModel, context, {
 		apiKey: "sk-ant-test",
 		isOAuth: false,
 		signal: abortedSignal(),
@@ -98,7 +115,7 @@ function capturePayload(context: Context): Promise<AnthropicPayload> {
 	return promise;
 }
 
-function isAnthropicImageBlock(value: unknown): value is AnthropicImageBlock {
+function isAnthropicImageBlock(value: unknown): value is AnthropicBase64ImageBlock {
 	if (!value || typeof value !== "object") return false;
 	const block = value as Record<string, unknown>;
 	if (block.type !== "image") return false;
@@ -111,7 +128,7 @@ function isAnthropicImageBlock(value: unknown): value is AnthropicImageBlock {
 	);
 }
 
-function extractToolResultImages(payload: AnthropicPayload): AnthropicImageBlock[] {
+function extractToolResultBlocks(payload: AnthropicPayload): Array<TextContent | AnthropicImageBlock> {
 	const lastMessage = payload.messages.at(-1);
 	expect(lastMessage).toBeDefined();
 	expect(Array.isArray(lastMessage?.content)).toBe(true);
@@ -121,7 +138,11 @@ function extractToolResultImages(payload: AnthropicPayload): AnthropicImageBlock
 	expect(toolResult).toBeDefined();
 	if (!toolResult || !Array.isArray(toolResult.content))
 		throw new Error("Expected Anthropic tool_result content array");
-	return toolResult.content.filter(isAnthropicImageBlock);
+	return toolResult.content;
+}
+
+function extractToolResultImages(payload: AnthropicPayload): AnthropicBase64ImageBlock[] {
+	return extractToolResultBlocks(payload).filter(isAnthropicImageBlock);
 }
 
 describe("Anthropic many-image payload resizing", () => {
@@ -144,7 +165,26 @@ describe("Anthropic many-image payload resizing", () => {
 		expect(height).toBeLessThanOrEqual(2000);
 	});
 
-	it("leaves oversized images untouched below the many-image threshold", async () => {
+	it("clamps a single image past Anthropic's hard 8000px limit", async () => {
+		// Reproduces the 400 "At least one of the image dimensions exceed max
+		// allowed size: 8000 pixels" from a full-page screenshot tool result.
+		const tallData = await makeRedPng(1440, 8570);
+		const tallImage: ImageContent = { type: "image", data: tallData, mimeType: "image/png" };
+		const context = makeToolResultContext([tallImage]);
+
+		const payload = await capturePayload(context);
+
+		const images = extractToolResultImages(payload);
+		expect(images).toHaveLength(1);
+		expect(images[0].source.data).not.toBe(tallData);
+		expect(tallImage.data).toBe(tallData);
+
+		const { width, height } = await new Bun.Image(Buffer.from(images[0].source.data, "base64")).metadata();
+		expect(height).toBe(8000);
+		expect(width).toBe(1344);
+	});
+
+	it("leaves images within the hard limit untouched below the many-image threshold", async () => {
 		const largeData = await makeRedPng(2400, 1200);
 		const largeImage: ImageContent = { type: "image", data: largeData, mimeType: "image/png" };
 		const smallImage: ImageContent = { type: "image", data: RED_1X1_PNG_BASE64, mimeType: "image/png" };
@@ -155,5 +195,71 @@ describe("Anthropic many-image payload resizing", () => {
 		const images = extractToolResultImages(payload);
 		expect(images).toHaveLength(20);
 		expect(images[0].source.data).toBe(largeData);
+	});
+
+	it("clamps referenced images and drops the reference when the bytes change", async () => {
+		// Anthropic fetches a URL mirror or file reference and then validates the
+		// image, so an oversized referenced block 400s exactly like inline bytes.
+		// Narrow on purpose: the assertion is the height clamp, and two
+		// full-height encoder passes per image are the slow part of this file.
+		const tallData = await makeRedPng(240, 8570);
+		const mirrored: ImageContent = {
+			type: "image",
+			data: tallData,
+			mimeType: "image/png",
+			url: "https://blobs.test/tall.png",
+		};
+		const referenced: ImageContent = {
+			type: "image",
+			data: tallData,
+			mimeType: "image/png",
+			providerFile: { provider: "anthropic", id: "file_tall" },
+		};
+
+		const payload = await capturePayload(makeToolResultContext([mirrored, referenced]));
+
+		const images = extractToolResultImages(payload);
+		expect(images).toHaveLength(2);
+		for (const image of images) {
+			expect(image.source.data).not.toBe(tallData);
+			const { height } = await new Bun.Image(Buffer.from(image.source.data, "base64")).metadata();
+			expect(height).toBe(8000);
+		}
+		expect(mirrored.url).toBe("https://blobs.test/tall.png");
+		expect(referenced.providerFile?.id).toBe("file_tall");
+	});
+
+	it("keeps the reference on a referenced image already inside the caps", async () => {
+		const smallImage: ImageContent = {
+			type: "image",
+			data: RED_1X1_PNG_BASE64,
+			mimeType: "image/png",
+			url: "https://blobs.test/small.png",
+		};
+
+		const payload = await capturePayload(makeToolResultContext([smallImage]));
+
+		const sources = extractToolResultBlocks(payload)
+			.filter((block): block is AnthropicImageBlock => block.type === "image")
+			.map(block => block.source);
+		expect(sources).toEqual([{ type: "url", url: "https://blobs.test/small.png" }]);
+	});
+
+	it("clamps to a host image-dimension policy tighter than the API default", async () => {
+		// The cap is resolved model policy (`max-image-dimension`), so a
+		// deployment whose image contract differs from the canonical Anthropic
+		// API overrides it instead of inheriting 8000px.
+		const tightModel = makeAnthropicModel({ maxImageDimension: 4000 });
+		expect(tightModel.compat.maxImageDimension).toBe(4000);
+		const tallData = await makeRedPng(1440, 8570);
+		const tallImage: ImageContent = { type: "image", data: tallData, mimeType: "image/png" };
+
+		const payload = await capturePayload(makeToolResultContext([tallImage]), tightModel);
+
+		const images = extractToolResultImages(payload);
+		expect(images).toHaveLength(1);
+		const { width, height } = await new Bun.Image(Buffer.from(images[0].source.data, "base64")).metadata();
+		expect(height).toBe(4000);
+		expect(width).toBe(672);
 	});
 });

--- a/packages/ai/test/anthropic-many-image-resize.test.ts
+++ b/packages/ai/test/anthropic-many-image-resize.test.ts
@@ -184,6 +184,31 @@ describe("Anthropic many-image payload resizing", () => {
 		expect(width).toBe(1344);
 	});
 
+	it("re-encodes an image past Anthropic's 10 MB payload limit", async () => {
+		// Reproduces the 400 "image exceeds 10 MB maximum: 14012300 bytes >
+		// 10485760 bytes" from a dense full-page screenshot: inside the 8000px
+		// cap, over the byte cap. Trailing bytes after IEND stand in for that
+		// payload so the test does not spend a minute encoding noise.
+		const seed = Buffer.from(RED_1X1_PNG_BASE64, "base64");
+		const canvas = await new Bun.Image(seed).resize(1200, 900, { filter: "nearest" }).png().bytes();
+		const heavyData = Buffer.concat([Buffer.from(canvas), Buffer.alloc(8 * 1024 * 1024, 7)]).toString("base64");
+		expect(heavyData.length).toBeGreaterThan(10 * 1024 * 1024);
+		const heavyImage: ImageContent = { type: "image", data: heavyData, mimeType: "image/png" };
+		const context = makeToolResultContext([heavyImage]);
+
+		const payload = await capturePayload(context);
+
+		const images = extractToolResultImages(payload);
+		expect(images).toHaveLength(1);
+		expect(images[0].source.data.length).toBeLessThanOrEqual(9 * 1024 * 1024);
+		expect(heavyImage.data).toBe(heavyData);
+
+		// Only the payload was over the limit, so the pixels survive intact.
+		const { width, height } = await new Bun.Image(Buffer.from(images[0].source.data, "base64")).metadata();
+		expect(width).toBe(1200);
+		expect(height).toBe(900);
+	});
+
 	it("leaves images within the hard limit untouched below the many-image threshold", async () => {
 		const largeData = await makeRedPng(2400, 1200);
 		const largeImage: ImageContent = { type: "image", data: largeData, mimeType: "image/png" };

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added a `max-image-dimension` compat axis so an Anthropic-compatible host whose per-side image limit differs from the canonical API can override it instead of inheriting 8000px.
+
 ## [18.1.5] - 2026-09-03
 
 ### Added

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Added a `max-image-dimension` compat axis so an Anthropic-compatible host whose per-side image limit differs from the canonical API can override it instead of inheriting 8000px.
+- Added `max-image-dimension` and `max-image-payload-bytes` compat axes so an Anthropic-compatible host whose image limits differ from the canonical API can override them instead of inheriting 8000px and 10 MB.
 
 ## [18.1.5] - 2026-09-03
 

--- a/packages/catalog/src/compat/axes.ts
+++ b/packages/catalog/src/compat/axes.ts
@@ -184,6 +184,7 @@ export const AXES: Readonly<Record<string, AxisDef>> = {
 	"escape-builtin-tool-names": wire("escapeBuiltinToolNames", ["anthropic"]),
 	"inject-claude-code-instruction": wire("injectClaudeCodeInstruction", ["anthropic"]),
 	"max-image-dimension": wire("maxImageDimension", ["anthropic"]),
+	"max-image-payload-bytes": wire("maxImagePayloadBytes", ["anthropic"]),
 	"official-endpoint": wire("officialEndpoint", ["anthropic", "openai-responses"]),
 	"replay-unsigned-thinking": wire("replayUnsignedThinking", ["anthropic"]),
 	"requires-thinking-enabled": wire("requiresThinkingEnabled", ["anthropic"]),

--- a/packages/catalog/src/compat/axes.ts
+++ b/packages/catalog/src/compat/axes.ts
@@ -183,6 +183,7 @@ export const AXES: Readonly<Record<string, AxisDef>> = {
 	"disable-strict-tools": wire("disableStrictTools", ["anthropic"]),
 	"escape-builtin-tool-names": wire("escapeBuiltinToolNames", ["anthropic"]),
 	"inject-claude-code-instruction": wire("injectClaudeCodeInstruction", ["anthropic"]),
+	"max-image-dimension": wire("maxImageDimension", ["anthropic"]),
 	"official-endpoint": wire("officialEndpoint", ["anthropic", "openai-responses"]),
 	"replay-unsigned-thinking": wire("replayUnsignedThinking", ["anthropic"]),
 	"requires-thinking-enabled": wire("requiresThinkingEnabled", ["anthropic"]),

--- a/packages/catalog/src/compat/resolve.ts
+++ b/packages/catalog/src/compat/resolve.ts
@@ -863,6 +863,7 @@ function resolveAnthropicPolicy(
 		// owns those numbers. The keys must exist for a KDL rule or a
 		// user-authored `compat` block to override them.
 		maxImageDimension: undefined,
+		maxImagePayloadBytes: undefined,
 		thinkingLoopGuard: undefined,
 		streamIdleTimeoutMs: spec.compat?.streamIdleTimeoutMs,
 	};

--- a/packages/catalog/src/compat/resolve.ts
+++ b/packages/catalog/src/compat/resolve.ts
@@ -859,6 +859,10 @@ function resolveAnthropicPolicy(
 		escapeBuiltinToolNames: false,
 		injectClaudeCodeInstruction: true,
 		stripImageInput: false,
+		// Unset means "canonical Anthropic image contract"; the request builder
+		// owns those numbers. The keys must exist for a KDL rule or a
+		// user-authored `compat` block to override them.
+		maxImageDimension: undefined,
 		thinkingLoopGuard: undefined,
 		streamIdleTimeoutMs: spec.compat?.streamIdleTimeoutMs,
 	};

--- a/packages/catalog/src/types.ts
+++ b/packages/catalog/src/types.ts
@@ -583,6 +583,15 @@ export interface AnthropicCompat {
 	 * with a different image contract override it. Default: 8000.
 	 */
 	maxImageDimension?: number;
+	/**
+	 * Largest base64 payload a single image block may carry, in bytes. The
+	 * canonical Anthropic API measures the encoded string, not the decoded
+	 * bytes (`image exceeds 10 MB maximum: 14012300 bytes > 10485760 bytes`),
+	 * and an image inside {@link maxImageDimension} can still cross it, so
+	 * payload size is clamped on its own. Hosts with a different image
+	 * contract override it. Default: 10485760.
+	 */
+	maxImagePayloadBytes?: number;
 	/** Thinking-loop watchdog guard family applied to streamed reasoning. */
 	thinkingLoopGuard?: "gemini" | "deepseek" | "xai";
 }
@@ -863,13 +872,19 @@ export type ResolvedOpenRouterCompat = ResolvedOpenAICompat & ResolvedOpenAIResp
 
 /** Fully-resolved anthropic-messages compat view (same contract as `ResolvedOpenAICompat`). */
 export type ResolvedAnthropicCompat = Required<
-	Omit<AnthropicCompat, "streamIdleTimeoutMs" | "thinkingLoopGuard" | "maxImageDimension">
+	Omit<AnthropicCompat, "streamIdleTimeoutMs" | "thinkingLoopGuard" | "maxImageDimension" | "maxImagePayloadBytes">
 > & {
 	/**
 	 * Largest width or height a single image block may carry. Undefined defers
 	 * to the canonical Anthropic API limit applied by the request builder.
 	 */
 	maxImageDimension?: number;
+	/**
+	 * Largest base64 image payload a single block may carry, in bytes.
+	 * Undefined defers to the canonical Anthropic API limit applied by the
+	 * request builder.
+	 */
+	maxImagePayloadBytes?: number;
 	/** Thinking-loop watchdog guard family applied to streamed reasoning. */
 	thinkingLoopGuard?: AnthropicCompat["thinkingLoopGuard"];
 	/**

--- a/packages/catalog/src/types.ts
+++ b/packages/catalog/src/types.ts
@@ -574,6 +574,15 @@ export interface AnthropicCompat {
 	injectClaudeCodeInstruction?: boolean;
 	/** Strip image inputs before encoding (text-only serving of a multimodal id). */
 	stripImageInput?: boolean;
+	/**
+	 * Largest width or height a single image block may carry. The canonical
+	 * Anthropic API rejects anything larger with `At least one of the image
+	 * dimensions exceed max allowed size: 8000 pixels`, and the rejection
+	 * poisons every retry and model fallback because the block stays in
+	 * context, so the request builder downscales to this value first. Hosts
+	 * with a different image contract override it. Default: 8000.
+	 */
+	maxImageDimension?: number;
 	/** Thinking-loop watchdog guard family applied to streamed reasoning. */
 	thinkingLoopGuard?: "gemini" | "deepseek" | "xai";
 }
@@ -853,7 +862,14 @@ export interface ResolvedOpenAIResponsesCompat extends ResolvedOpenAISharedCompa
 export type ResolvedOpenRouterCompat = ResolvedOpenAICompat & ResolvedOpenAIResponsesCompat;
 
 /** Fully-resolved anthropic-messages compat view (same contract as `ResolvedOpenAICompat`). */
-export type ResolvedAnthropicCompat = Required<Omit<AnthropicCompat, "streamIdleTimeoutMs" | "thinkingLoopGuard">> & {
+export type ResolvedAnthropicCompat = Required<
+	Omit<AnthropicCompat, "streamIdleTimeoutMs" | "thinkingLoopGuard" | "maxImageDimension">
+> & {
+	/**
+	 * Largest width or height a single image block may carry. Undefined defers
+	 * to the canonical Anthropic API limit applied by the request builder.
+	 */
+	maxImageDimension?: number;
 	/** Thinking-loop watchdog guard family applied to streamed reasoning. */
 	thinkingLoopGuard?: AnthropicCompat["thinkingLoopGuard"];
 	/**


### PR DESCRIPTION
## What

Run the Anthropic image prep pass on every request with images and pick the cap from the image count: 2000px past the many-image threshold as before, otherwise Anthropic's hard 8000px per-side limit. The resize memo is keyed per cap, since a block cached at 8000px is not reusable at 2000px.

The second commit treats payload size as its own trigger. Anthropic caps a single image at 10 MB measured on the base64 string, and a dense capture crosses that while still inside the pixel cap. When only the bytes are over, the re-encode keeps the source resolution; the loop shrinks by the overshoot in area terms and gives up after four passes instead of spinning.

## Why

Anthropic rejects any image wider or taller than 8000 pixels:

```
400 invalid_request_error
messages.11.content.8.image.source.base64.data: At least one of the
image dimensions exceed max allowed size: 8000 pixels
```

`prepareAnthropicManyImageContext` only downscaled when a request carried more than `ANTHROPIC_MANY_IMAGE_THRESHOLD` (20) images, so a single tall screenshot went out raw. Measured case: a 1440x8570 full-page capture in a tool result. The block stays in history, so every in-provider retry and every model in the fallback chain re-sent it and failed the same way, which ends the session until the stored image is edited by hand.

`packages/ai/test/image-limits.test.ts` already documents and measures the 8000px ceiling; nothing enforced it.

The byte cap is a separate rejection with the same failure mode:

```
400 invalid_request_error
messages.81.content.1.tool_result.content.0.image.source.base64: image
exceeds 10 MB maximum: 14012300 bytes > 10485760 bytes
```

Measured case: a 1440x5216 full-page capture, 10,509,225 bytes, 14,012,300 as base64. It sits inside the 8000px cap, so the first commit leaves it alone. Re-encoding holds 1440x5216 and lands at 1,003,461 bytes, 1,337,948 as base64.

## Testing

- New case in `packages/ai/test/anthropic-many-image-resize.test.ts`: a single 1440x8570 image goes out as 1344x8000 while below the many-image threshold. Mutation check: restoring the old threshold guard turns it red.
- Second case in the same file: an image inside the pixel cap but over the byte cap is re-encoded under the budget at unchanged 1200x900. Mutation check: stashing the byte clamp turns it red.
- `bun test packages/ai/test/anthropic` — 378 pass, 0 fail across 27 files.
- `bun --cwd=packages/ai run check` — clean (oxlint, oxfmt, tsgo).
- End to end on the session that produced the 8000px 400 above, same 112-message context, same oversized blob, `claude-haiku-4-5`: stock 18.1.5 returns the 400 and cascades down the fallback chain; a build with this commit answers normally.
- End to end on the 10 MB case: a build with both commits answers normally on the exact 10,509,225-byte capture that stock 18.1.5 rejects with the error above.

---

- [x] `bun check` passes (ran the `packages/ai` workspace check, not the Rust half)
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
