### PR TITLE
fix(task): preserve reports across data-less yield turns

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -332,6 +332,7 @@
 - Fixed messages typed while an edit or write tool was streaming from discarding the completed tool call and triggering unnecessary regeneration.
 - Fixed self-hosted Firecrawl URLs with origin-only base URLs from gaining an extra slash.
 - Fixed omp commit auto-staging from including macOS Unicode-normalization duplicates or files ignored by nested .gitignore rules.
+- Fixed data-less subagent yields discarding a report when the report and yield tool call arrive in separate assistant messages ([#10635](https://github.com/can1357/oh-my-pi/issues/10635)).
 
 ## [18.1.5] - 2026-09-03
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - MCP HTTP reconnects now release obsolete tool generations instead of growing session memory on every reconnect ([#11784](https://github.com/can1357/oh-my-pi/issues/11784)).
 - `/debug` memory reports now keep large heap snapshots out of JavaScript strings and reject empty snapshots instead of saving zero-byte files ([#11785](https://github.com/can1357/oh-my-pi/issues/11785)).
+- Fixed data-less subagent yields discarding a report when the report and yield tool call arrive in separate assistant messages ([#10635](https://github.com/can1357/oh-my-pi/issues/10635)).
 
 ## [18.1.18] - 2026-09-11
 
@@ -332,7 +333,6 @@
 - Fixed messages typed while an edit or write tool was streaming from discarding the completed tool call and triggering unnecessary regeneration.
 - Fixed self-hosted Firecrawl URLs with origin-only base URLs from gaining an extra slash.
 - Fixed omp commit auto-staging from including macOS Unicode-normalization duplicates or files ignored by nested .gitignore rules.
-- Fixed data-less subagent yields discarding a report when the report and yield tool call arrive in separate assistant messages ([#10635](https://github.com/can1357/oh-my-pi/issues/10635)).
 
 ## [18.1.5] - 2026-09-03
 

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -1071,6 +1071,8 @@ interface SubagentRunMonitor {
 	/** Best-effort capture of the last assistant text for cancelled-run salvage. */
 	captureSalvage(session: AgentSession): void;
 	lastAssistantSalvageText(): string | undefined;
+	/** Last non-empty completed assistant message text for data-less yields. */
+	lastAssistantText(): string | undefined;
 	/** Final raw output: end-of-run assistant text when available, else accumulated chunks. */
 	rawOutput(): string;
 	scheduleProgress(flush?: boolean): void;
@@ -1161,6 +1163,7 @@ function createSubagentRunMonitor(args: RunMonitorArgs): SubagentRunMonitor {
 	let terminalError: string | undefined;
 	let consecutiveYieldToolErrors = 0;
 	let lastAssistantSalvageText: string | undefined;
+	let lastAssistantText: string | undefined;
 	let activeSessionAbortPromise: Promise<void> | undefined;
 
 	const abortActiveSession = (): Promise<void> => {
@@ -1665,11 +1668,13 @@ function createSubagentRunMonitor(args: RunMonitorArgs): SubagentRunMonitor {
 					progress.requests += 1;
 					const eventContent = isRecord(event) && "content" in event ? event.content : undefined;
 					const messageContent = getMessageContent(event.message) || eventContent;
+					let messageText = "";
 					if (messageContent && Array.isArray(messageContent)) {
 						for (const block of messageContent) {
 							if (!isRecord(block)) continue;
 							if (block.type === "text" && typeof block.text === "string") {
 								outputChunks.push(block.text);
+								messageText = messageText ? `${messageText}\n${block.text}` : block.text;
 								continue;
 							}
 							if (block.type !== "toolCall" || typeof block.name !== "string") continue;
@@ -1678,6 +1683,9 @@ function createSubagentRunMonitor(args: RunMonitorArgs): SubagentRunMonitor {
 								flushProgress = true;
 							}
 						}
+					}
+					if (messageText.trim()) {
+						lastAssistantText = messageText;
 					}
 					if (softRequestBudget > 0 && !abortSent && !yieldCallPending) {
 						const stopThreshold = softRequestBudget * 1.5;
@@ -1751,14 +1759,19 @@ function createSubagentRunMonitor(args: RunMonitorArgs): SubagentRunMonitor {
 				// Extract final content from assistant messages only (not user prompts)
 				if (event.messages && Array.isArray(event.messages)) {
 					for (const msg of event.messages) {
-						if ((msg as { role?: string })?.role !== "assistant") continue;
+						if (!isRecord(msg) || msg.role !== "assistant") continue;
 						const messageContent = getMessageContent(msg);
+						let messageText = "";
 						if (messageContent && Array.isArray(messageContent)) {
 							for (const block of messageContent) {
 								if (block.type === "text" && block.text) {
 									finalOutputChunks.push(block.text);
+									messageText = messageText ? `${messageText}\n${block.text}` : block.text;
 								}
 							}
+						}
+						if (messageText.trim()) {
+							lastAssistantText = messageText;
 						}
 					}
 				}
@@ -1930,6 +1943,7 @@ function createSubagentRunMonitor(args: RunMonitorArgs): SubagentRunMonitor {
 		attach,
 		captureSalvage,
 		lastAssistantSalvageText: () => lastAssistantSalvageText,
+		lastAssistantText: () => lastAssistantText,
 		rawOutput: () => (finalOutputChunks.length > 0 ? finalOutputChunks.join("") : outputChunks.join("")),
 		scheduleProgress,
 		finish: () => {
@@ -2286,7 +2300,7 @@ async function finalizeRunResult(args: FinalizeRunArgs): Promise<SingleResult> {
 			outputSchema: args.outputSchema,
 			outputSchemaMode: args.outputSchemaMode,
 			outputSchemaSource: args.outputSchemaSource,
-			lastAssistantText: monitor.lastAssistantSalvageText(),
+			lastAssistantText: monitor.lastAssistantText() ?? monitor.lastAssistantSalvageText(),
 		});
 	} finally {
 		popLoopPhase();

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -1559,6 +1559,13 @@ function createSubagentRunMonitor(args: RunMonitorArgs): SubagentRunMonitor {
 							isError: event.isError,
 						});
 						if (data !== undefined) {
+							// Bind the contemporaneous assistant turn to each yield: a
+							// data-less/`useLastTurn` section resolves from the text current
+							// when it executed, so multiple incremental sections keep their
+							// own reports instead of collapsing onto the run's final message.
+							if (event.toolName === "yield" && isRecord(data) && lastAssistantText !== undefined) {
+								data.lastTurnText = lastAssistantText;
+							}
 							recordExtractedToolData(event.toolName, data);
 						}
 					}

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -89,7 +89,7 @@ import {
 	type TaskToolDetails,
 	type YieldItem,
 } from "./types";
-import { arrayValuedLabels, assembleYieldResult } from "./yield-assembly";
+import { arrayValuedLabels, assembleYieldResult, yieldUsesLastTurn } from "./yield-assembly";
 
 export type { YieldItem } from "./types";
 
@@ -1559,11 +1559,16 @@ function createSubagentRunMonitor(args: RunMonitorArgs): SubagentRunMonitor {
 							isError: event.isError,
 						});
 						if (data !== undefined) {
-							// Bind the contemporaneous assistant turn to each yield: a
-							// data-less/`useLastTurn` section resolves from the text current
-							// when it executed, so multiple incremental sections keep their
-							// own reports instead of collapsing onto the run's final message.
-							if (event.toolName === "yield" && isRecord(data) && lastAssistantText !== undefined) {
+							// Bind the contemporaneous assistant turn only to yields that
+							// resolve from it (data-less / `useLastTurn`); stamping every
+							// yield would duplicate unselected assistant prose into the
+							// public result payload of ordinary structured yields.
+							if (
+								event.toolName === "yield" &&
+								isRecord(data) &&
+								lastAssistantText !== undefined &&
+								yieldUsesLastTurn(data)
+							) {
 								data.lastTurnText = lastAssistantText;
 							}
 							recordExtractedToolData(event.toolName, data);

--- a/packages/coding-agent/src/task/render.ts
+++ b/packages/coding-agent/src/task/render.ts
@@ -164,6 +164,7 @@ function extractIncrementalReviewResult(
 		type: item.type,
 		status: item.status === "aborted" ? "aborted" : item.status === "success" ? "success" : undefined,
 		useLastTurn: item.useLastTurn,
+		lastTurnText: item.lastTurnText,
 	}));
 	const assembled = assembleYieldResult(yieldItems, undefined, REVIEWER_ARRAY_LABELS);
 	const data = assembled?.data;
@@ -194,6 +195,8 @@ interface RenderYieldItem {
 	type?: string | string[];
 	status?: string;
 	useLastTurn?: boolean;
+	/** Assistant text bound to this yield when it executed (see `YieldItem.lastTurnText`). */
+	lastTurnText?: string;
 }
 
 /**
@@ -233,6 +236,7 @@ function normalizeYieldData(value: unknown): RenderYieldItem[] {
 			type,
 			status: typeof record.status === "string" ? record.status : undefined,
 			useLastTurn: record.useLastTurn === true ? true : undefined,
+			lastTurnText: typeof record.lastTurnText === "string" ? record.lastTurnText : undefined,
 		});
 	}
 	return normalized;

--- a/packages/coding-agent/src/task/types.ts
+++ b/packages/coding-agent/src/task/types.ts
@@ -406,6 +406,13 @@ export interface YieldItem {
 	/** True when an incremental workpool yield completed every item in its batch. */
 	complete?: boolean;
 	/**
+	 * Assistant text captured when this yield executed, used to resolve a
+	 * data-less/`useLastTurn` payload. Stamped per yield so multiple data-less
+	 * incremental sections each bind their own contemporaneous turn instead of
+	 * every item collapsing onto the run's final assistant message.
+	 */
+	lastTurnText?: string;
+	/**
 	 * Set by the in-tool yield validator when it exhausted its retry budget and
 	 * accepted schema-invalid data anyway. The executor preserves that override
 	 * during post-mortem validation.

--- a/packages/coding-agent/src/task/yield-assembly.ts
+++ b/packages/coding-agent/src/task/yield-assembly.ts
@@ -47,11 +47,14 @@ function resolveYieldPayload(
 ): { value: unknown; fromLastAssistantText: boolean; missingData: boolean } {
 	const hasData = item.data !== undefined;
 	const shouldUseLastTurn = item.useLastTurn === true || (labels.length > 0 && !hasData);
-	if (shouldUseLastTurn && lastAssistantText !== undefined) {
+	// Prefer the text bound to this specific yield; fall back to the run-level
+	// value only for items the executor never stamped (e.g. render rebuilds).
+	const resolvedText = item.lastTurnText ?? lastAssistantText;
+	if (shouldUseLastTurn && resolvedText !== undefined) {
 		return {
-			value: lastAssistantText,
+			value: resolvedText,
 			fromLastAssistantText: true,
-			missingData: lastAssistantText.length === 0,
+			missingData: resolvedText.length === 0,
 		};
 	}
 	return {

--- a/packages/coding-agent/src/task/yield-assembly.ts
+++ b/packages/coding-agent/src/task/yield-assembly.ts
@@ -25,7 +25,7 @@ function isIncrementalYieldType(type: YieldItem["type"]): type is string[] {
 	return Array.isArray(type) && type.length > 0;
 }
 
-function getYieldLabels(type: YieldItem["type"]): string[] {
+function getYieldLabels(type: unknown): string[] {
 	if (typeof type === "string") {
 		const label = type.trim();
 		return label ? [label] : [];
@@ -40,17 +40,26 @@ function getYieldLabels(type: YieldItem["type"]): string[] {
 	return labels;
 }
 
+/**
+ * True when a yield resolves its payload from the last assistant turn rather
+ * than its own `data` — an explicit `useLastTurn`, or a data-less typed section.
+ * Gates both payload resolution and the executor's per-yield text stamp so
+ * ordinary structured yields never carry unselected assistant prose.
+ */
+export function yieldUsesLastTurn(item: { data?: unknown; type?: unknown; useLastTurn?: unknown }): boolean {
+	if (item.useLastTurn === true) return true;
+	if (item.data !== undefined) return false;
+	return getYieldLabels(item.type).length > 0;
+}
+
 function resolveYieldPayload(
 	item: YieldItem,
 	lastAssistantText: string | undefined,
-	labels: string[],
 ): { value: unknown; fromLastAssistantText: boolean; missingData: boolean } {
-	const hasData = item.data !== undefined;
-	const shouldUseLastTurn = item.useLastTurn === true || (labels.length > 0 && !hasData);
 	// Prefer the text bound to this specific yield; fall back to the run-level
 	// value only for items the executor never stamped (e.g. render rebuilds).
 	const resolvedText = item.lastTurnText ?? lastAssistantText;
-	if (shouldUseLastTurn && resolvedText !== undefined) {
+	if (yieldUsesLastTurn(item) && resolvedText !== undefined) {
 		return {
 			value: resolvedText,
 			fromLastAssistantText: true,
@@ -163,7 +172,7 @@ export function assembleYieldResult(
 		if (!isIncrementalYieldType(item.type)) continue;
 		schemaOverridden ||= item.schemaOverridden === true;
 		const labels = getYieldLabels(item.type);
-		const resolved = resolveYieldPayload(item, lastAssistantText, labels);
+		const resolved = resolveYieldPayload(item, lastAssistantText);
 		missingData ||= resolved.missingData;
 		for (const label of labels) {
 			appendYieldSection(sections, sectionCounts, label, resolved.value, arrayLabels?.has(label) ?? false);
@@ -175,7 +184,7 @@ export function assembleYieldResult(
 	// `type: "result"` finalize that carries `data` is the complete result, used
 	// verbatim — never wrapped in a section.
 	if (terminalItem && terminalItem.data !== undefined) {
-		const resolved = resolveYieldPayload(terminalItem, lastAssistantText, []);
+		const resolved = resolveYieldPayload(terminalItem, lastAssistantText);
 		return {
 			data: resolved.value,
 			schemaOverridden: terminalItem.schemaOverridden === true,
@@ -191,7 +200,7 @@ export function assembleYieldResult(
 	}
 
 	if (!terminalItem) return undefined;
-	const resolved = resolveYieldPayload(terminalItem, lastAssistantText, getYieldLabels(terminalItem.type));
+	const resolved = resolveYieldPayload(terminalItem, lastAssistantText);
 	return {
 		data: resolved.value,
 		schemaOverridden: terminalItem.schemaOverridden === true,

--- a/packages/coding-agent/test/task/render-yield-shape.test.ts
+++ b/packages/coding-agent/test/task/render-yield-shape.test.ts
@@ -184,4 +184,34 @@ describe("task renderer: malformed yield slot (#1987)", () => {
 		expect(text).toContain("Findings:");
 		expect(text).toContain("Handle null response");
 	});
+
+	it("reconstructs reviewer results when a section resolves from bound last-turn text", async () => {
+		// The `explanation` section is data-less (useLastTurn); its prose lives in
+		// `lastTurnText`. The renderer must carry that field through normalization
+		// so the review verdict reconstructs instead of the output being suppressed.
+		const text = await renderResultText({
+			yield: [
+				{
+					type: ["findings"],
+					data: {
+						title: "Handle null response",
+						body: "Null response reaches the formatter and crashes rendering.",
+						priority: 1,
+						confidence: 0.8,
+						file_path: "src/review.ts",
+						line_start: 42,
+						line_end: 42,
+					},
+					status: "success",
+				},
+				{ type: ["overall_correctness"], data: "incorrect", status: "success" },
+				{ type: ["explanation"], useLastTurn: true, lastTurnText: "One bug blocks approval.", status: "success" },
+				{ type: ["confidence"], data: 0.8, status: "success" },
+			],
+		});
+
+		expect(text).toContain("Patch is incorrect");
+		expect(text).toContain("One bug blocks approval");
+		expect(text).toContain("Handle null response");
+	});
 });

--- a/packages/coding-agent/test/task/task-guards.test.ts
+++ b/packages/coding-agent/test/task/task-guards.test.ts
@@ -352,6 +352,23 @@ describe("runSubprocess request guards", () => {
 		expect(JSON.parse(result.output)).toEqual({ findings: ["first finding report", "second finding report"] });
 	});
 
+	it("does not stamp last-turn text onto structured yields that carry data", async () => {
+		const settings = Settings.isolated({ "task.maxRuntimeMs": 0 });
+		const handle = createFakeSession({
+			events: [assistantMessageEnd("long analysis prose the caller never selected"), yieldToolEnd()],
+		});
+		mockCreateAgentSession(handle.session);
+
+		const result = await runSubprocess({ ...baseOptions, id: "subagent-structured-yield", settings });
+
+		expect(result.exitCode).toBe(0);
+		expect(JSON.parse(result.output)).toEqual({ ok: true });
+		// A yield with explicit data must not carry the preceding prose into the
+		// public result payload.
+		const items = result.extractedToolData?.yield as Array<Record<string, unknown>> | undefined;
+		expect(items?.[0]?.lastTurnText).toBeUndefined();
+	});
+
 	it("salvages the last assistant text for an aborted child with no completed output", async () => {
 		const settings = Settings.isolated({ "task.maxRuntimeMs": 50 });
 		const handle = createFakeSession({

--- a/packages/coding-agent/test/task/task-guards.test.ts
+++ b/packages/coding-agent/test/task/task-guards.test.ts
@@ -24,6 +24,8 @@ import { createSessionDefaults } from "../helpers/session-defaults";
  * 3. A cancelled/aborted child that produced no completed output salvages its
  *    last assistant text into a `[cancelled after N req, …]` summary instead
  *    of the parent seeing "(no output)" and redoing the work.
+ * 4. A data-less terminal yield resolves the preceding non-empty assistant
+ *    message when the yield tool call lands in a separate turn.
  */
 
 interface SteerCall {
@@ -68,6 +70,19 @@ function yieldToolEnd(): AgentSessionEvent {
 		},
 		isError: false,
 	} as AgentSessionEvent;
+}
+
+function dataLessYieldToolEnd(): AgentSessionEvent {
+	return {
+		type: "tool_execution_end",
+		toolCallId: "tool-yield",
+		toolName: "yield",
+		result: {
+			content: [{ type: "text", text: "Result submitted." }],
+			details: { status: "success", type: "result", useLastTurn: true },
+		},
+		isError: false,
+	} as unknown as AgentSessionEvent;
 }
 
 function createFakeSession(config: FakeSessionConfig = {}): FakeSessionHandle {
@@ -276,6 +291,25 @@ describe("runSubprocess request guards", () => {
 		expect(result.abortReason).toContain("request budget exceeded");
 		expect(handle.abortCalls()).toBeGreaterThanOrEqual(1);
 		expect(handle.steerCalls.length).toBe(1);
+	});
+
+	it("uses the preceding assistant report when a data-less yield is a separate message", async () => {
+		const settings = Settings.isolated({ "task.maxRuntimeMs": 0 });
+		const report = "# Inventory\n\nComplete report.";
+		const handle = createFakeSession({
+			events: [assistantMessageEnd(report), assistantMessageEnd(""), dataLessYieldToolEnd()],
+			lastAssistantMessage: {
+				role: "assistant",
+				stopReason: "toolUse",
+				content: [{ type: "toolCall", id: "tool-yield", name: "yield", arguments: {} }],
+			},
+		});
+		mockCreateAgentSession(handle.session);
+
+		const result = await runSubprocess({ ...baseOptions, id: "subagent-data-less-yield", settings });
+
+		expect(result.exitCode).toBe(0);
+		expect(result.output).toBe(report);
 	});
 
 	it("salvages the last assistant text for an aborted child with no completed output", async () => {

--- a/packages/coding-agent/test/task/task-guards.test.ts
+++ b/packages/coding-agent/test/task/task-guards.test.ts
@@ -85,6 +85,19 @@ function dataLessYieldToolEnd(): AgentSessionEvent {
 	} as unknown as AgentSessionEvent;
 }
 
+function incrementalYieldToolEnd(id: string, label: string): AgentSessionEvent {
+	return {
+		type: "tool_execution_end",
+		toolCallId: id,
+		toolName: "yield",
+		result: {
+			content: [{ type: "text", text: "Result submitted." }],
+			details: { status: "success", type: [label], useLastTurn: true },
+		},
+		isError: false,
+	} as unknown as AgentSessionEvent;
+}
+
 function createFakeSession(config: FakeSessionConfig = {}): FakeSessionHandle {
 	let abortCount = 0;
 	const steerCalls: SteerCall[] = [];
@@ -310,6 +323,33 @@ describe("runSubprocess request guards", () => {
 
 		expect(result.exitCode).toBe(0);
 		expect(result.output).toBe(report);
+	});
+
+	it("binds each data-less incremental yield to its own report turn", async () => {
+		const settings = Settings.isolated({ "task.maxRuntimeMs": 0 });
+		const handle = createFakeSession({
+			events: [
+				assistantMessageEnd("first finding report"),
+				incrementalYieldToolEnd("tool-inc-1", "findings"),
+				assistantMessageEnd("second finding report"),
+				incrementalYieldToolEnd("tool-inc-2", "findings"),
+				assistantMessageEnd(""),
+				dataLessYieldToolEnd(),
+			],
+			lastAssistantMessage: {
+				role: "assistant",
+				stopReason: "toolUse",
+				content: [{ type: "toolCall", id: "tool-yield", name: "yield", arguments: {} }],
+			},
+		});
+		mockCreateAgentSession(handle.session);
+
+		const result = await runSubprocess({ ...baseOptions, id: "subagent-incremental-yield", settings });
+
+		expect(result.exitCode).toBe(0);
+		// Each section keeps its contemporaneous report instead of both collapsing
+		// onto the run's final assistant message.
+		expect(JSON.parse(result.output)).toEqual({ findings: ["first finding report", "second finding report"] });
 	});
 
 	it("salvages the last assistant text for an aborted child with no completed output", async () => {


### PR DESCRIPTION
## Repro
A focused `runSubprocess` harness emits a report-bearing assistant `message_end`, then a text-free assistant turn and successful data-less `yield`; `bun test packages/coding-agent/test/task/task-guards.test.ts` failed before the fix because `result.exitCode` was 1 instead of 0.

## Cause
`createSubagentRunMonitor` in `packages/coding-agent/src/task/executor.ts` retained assistant output in aggregate chunks but supplied `finalizeSubprocessOutput` only with `lastAssistantSalvageText`, which `captureSalvage` sampled from the terminal assistant message during teardown. A tool-call-only yield message therefore hid the preceding non-empty report from data-less yield assembly.

## Fix
- Track the latest non-empty completed assistant message while handling `message_end` and `agent_end` events.
- Resolve data-less yields from that tracked message while retaining teardown salvage as the abort fallback.
- Cover separate report and yield messages with an end-to-end subprocess regression and document the user-visible fix in the changelog.

## Verification
`bun test packages/coding-agent/test/task/task-guards.test.ts packages/coding-agent/test/task/executor-warnings.test.ts` passes: 27 tests, 90 assertions. `bun check` passes.

Fixes #10635