### PR TITLE
fix(hashline): suggest real hunk keywords on unified-diff input

### DIFF
--- a/packages/hashline/CHANGELOG.md
+++ b/packages/hashline/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the unified-diff contamination error naming `replace`, `delete`, and `insert` ops that the grammar does not accept; it now points at `PUT`, `CUT`, and the gap forms.
+
 ## [18.0.4] - 2026-08-24
 
 ### Changed

--- a/packages/hashline/src/input.ts
+++ b/packages/hashline/src/input.ts
@@ -191,7 +191,7 @@ function splitRawSections(input: string, options: SplitOptions = {}): RawSection
 		if (/^@@\s+[-+]?\d+,\d+\s+[-+]?\d+,\d+\s+@@/.test(firstTrimmed)) {
 			throw new Error(
 				"unified-diff hunk header (`@@ -N,M +N,M @@`) is not valid in hashline. " +
-					`File sections start with \`${HL_FILE_PREFIX}path${HL_FILE_HASH_SEP}HASH${HL_FILE_SUFFIX}\`; use \`replace\`, \`delete\`, or \`insert\` ops.`,
+					`File sections start with \`${HL_FILE_PREFIX}path${HL_FILE_HASH_SEP}HASH${HL_FILE_SUFFIX}\`; use \`PUT 1.=1:\` with \`+final-content\` rows to replace, \`CUT 1.=1\` to delete, or \`PUT <1:\` / \`PUT >1:\` to insert.`,
 			);
 		}
 		const preview = JSON.stringify(firstLine.slice(0, 120));

--- a/packages/hashline/src/input.ts
+++ b/packages/hashline/src/input.ts
@@ -11,7 +11,14 @@ import * as path from "node:path";
 import { applyEdits } from "./apply";
 import { resolveBlockEdits } from "./block";
 import { hasClipboardEdit } from "./clipboard";
-import { HL_FILE_HASH_EXAMPLES, HL_FILE_HASH_LENGTH, HL_FILE_HASH_SEP, HL_FILE_PREFIX, HL_FILE_SUFFIX } from "./format";
+import {
+	HL_FILE_HASH_EXAMPLES,
+	HL_FILE_HASH_LENGTH,
+	HL_FILE_HASH_SEP,
+	HL_FILE_PREFIX,
+	HL_FILE_SUFFIX,
+	HL_RANGE_SEP,
+} from "./format";
 import { CLIPBOARD_INTERLEAVED_SECTIONS } from "./messages";
 import { parsePatch, parsePatchStreaming } from "./parser";
 import { Tokenizer } from "./tokenizer";
@@ -191,7 +198,7 @@ function splitRawSections(input: string, options: SplitOptions = {}): RawSection
 		if (/^@@\s+[-+]?\d+,\d+\s+[-+]?\d+,\d+\s+@@/.test(firstTrimmed)) {
 			throw new Error(
 				"unified-diff hunk header (`@@ -N,M +N,M @@`) is not valid in hashline. " +
-					`File sections start with \`${HL_FILE_PREFIX}path${HL_FILE_HASH_SEP}HASH${HL_FILE_SUFFIX}\`; use \`PUT 1.=1:\` with \`+final-content\` rows to replace, \`CUT 1.=1\` to delete, or \`PUT <1:\` / \`PUT >1:\` to insert.`,
+					`File sections start with \`${HL_FILE_PREFIX}path${HL_FILE_HASH_SEP}HASH${HL_FILE_SUFFIX}\`; use \`PUT 1${HL_RANGE_SEP}1:\` with \`+final-content\` rows to replace, \`CUT 1${HL_RANGE_SEP}1\` to delete, or \`PUT <1:\` / \`PUT >1:\` to insert.`,
 			);
 		}
 		const preview = JSON.stringify(firstLine.slice(0, 120));

--- a/packages/hashline/test/core-contracts.test.ts
+++ b/packages/hashline/test/core-contracts.test.ts
@@ -180,6 +180,11 @@ describe("hashline input splitter", () => {
 	it("rejects unified-diff hunk headers on the first line", () => {
 		const input = ["@@ -1,3 +1,3 @@", "PUT <1:", repl("x")].join("\n");
 		expect(() => splitHashlineInputs(input)).toThrow(/unified-diff hunk header/);
+		// The remediation has to name keywords the grammar accepts. A model that
+		// follows `replace`/`delete`/`insert` guidance just fails a second time.
+		expect(() => splitHashlineInputs(input)).toThrow(/`PUT 1\.=1:`/);
+		expect(() => splitHashlineInputs(input)).toThrow(/`CUT 1\.=1`/);
+		expect(() => splitHashlineInputs(input)).toThrow(/`PUT <1:`/);
 	});
 });
 


### PR DESCRIPTION
the error message told models to use replace, delete, and insert. none of those exist, the parser only takes PUT, CUT, REM, MV. now it names the real ones.

`packages/hashline/src/input.ts` now emits:

> File sections start with `[path#HASH]`; use `PUT 1.=1:` with `+final-content` rows to replace, `CUT 1.=1` to delete, or `PUT <1:` / `PUT >1:` to insert.

`packages/hashline/src/grammar.lark` defines exactly those four keywords. `replace` and `insert_after` are internal `BlockOp` enum names that `src/messages.ts` maps to `PUT` forms before any guidance is rendered (`BLOCK_OP_FORMS`, `messages.ts:623-628`).

The existing test `rejects unified-diff hunk headers on the first line` gained three assertions that the guidance names `PUT 1.=1:`, `CUT 1.=1`, and `PUT <1:`. Reverting `input.ts` alone fails it.

- `bun test test/core-contracts.test.ts` in `packages/hashline`: 20 pass, 0 fail
- `bun test` in `packages/hashline`: 315 pass, 0 fail, 12 files
