### PR TITLE
fix(vibe): gate turn truncation on a published output artifact

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Fixed `/usage` freezing the TUI for several seconds while it loaded the activity heatmap on a large stats database; the dashboard now opens immediately and the heatmap plus session sync load from a background subprocess.
 - Fixed the status line missing from the first frame at startup and appearing only after the session loaded; the last run's status row is cached per project and painted immediately, then replaced in place by the live one.
 - Fixed Bash builtins (`cut`, `sed`, `ls`, `sort`, `uniq`, `cat`, and the rest) printing `<name>: Broken pipe (os error 32)` / `write error` and exiting 1 when a downstream stage quit early (`cut f | head`, `cut f | sed 'bad'`); they now die silently with status 141 like standalone utilities under SIGPIPE.
+- Fixed a long `vibe` turn advertising `full-output="agent://<id>"` when the worker published no output artifact, leaving the withheld tail unreachable; truncation is now gated on the artifact and the full response stays inline without one.
 
 ## [18.1.5] - 2026-09-03
 

--- a/packages/coding-agent/src/vibe/runtime.ts
+++ b/packages/coding-agent/src/vibe/runtime.ts
@@ -1528,7 +1528,15 @@ export class VibeSessionRegistry {
 		const traceOverflow = Math.max(0, turn.toolCount - turn.trace.length);
 		let response = result.output.trim() || "(no output)";
 		let responseTruncated = false;
-		if (response.length > RESPONSE_PREVIEW_MAX) {
+		// Truncating requires somewhere to send the caller for the rest. The
+		// `agent://<id>` pointer in the template resolves by scanning for
+		// `<id>.md`, which `finalizeRunResult()` publishes only after
+		// `writeArtifact()` verified it, so an unverified write leaves
+		// `outputPath` unset and that URI absent (issue #9646). Without this
+		// guard a long turn advertises a pointer to nothing and the withheld
+		// bytes are unreachable; keep the full response inline instead. This
+		// mirrors the gate #9649 applied to the task envelope.
+		if (response.length > RESPONSE_PREVIEW_MAX && result.outputPath) {
 			const slice = response.slice(0, RESPONSE_PREVIEW_MAX);
 			const lastNewline = slice.lastIndexOf("\n");
 			response = lastNewline > 0 ? slice.slice(0, lastNewline) : slice;

--- a/packages/coding-agent/test/vibe/turn-artifact-gate.test.ts
+++ b/packages/coding-agent/test/vibe/turn-artifact-gate.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Contract: a vibe turn advertises `agent://<id>` only when the child's output
+ * artifact was actually published.
+ *
+ * `vibe-turn-result.md` renders `full-output="agent://{{id}}"` whenever
+ * `responseTruncated` is set, and `agent://` resolution scans for `<id>.md`.
+ * `finalizeRunResult()` assigns `SingleResult.outputPath` only after
+ * `writeArtifact()` verified the bytes, so an unverified write leaves that URI
+ * absent. Gating truncation on `outputPath` keeps the withheld bytes reachable:
+ * without a receipt the whole response stays inline. #9649 applied the same
+ * gate to the task envelope (`task/index.ts`) and left this sibling ungated.
+ */
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import { AsyncJobManager } from "@oh-my-pi/pi-coding-agent/async/job-manager";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { AgentRegistry } from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
+import * as executorModule from "@oh-my-pi/pi-coding-agent/task/executor";
+import type { SingleResult } from "@oh-my-pi/pi-coding-agent/task/types";
+import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+import { VibeSessionRegistry } from "@oh-my-pi/pi-coding-agent/vibe/runtime";
+
+/** Longer than the runtime's 6000-character `RESPONSE_PREVIEW_MAX`. */
+const LONG_OUTPUT = `${"work line\n".repeat(700)}tail marker`;
+
+/**
+ * Run one vibe turn whose child returns `LONG_OUTPUT`, and return the settled
+ * turn text the caller receives. `outputPath` decides whether the executor
+ * reports a published artifact.
+ */
+async function settleLongTurn(options: { outputPath?: string }): Promise<string> {
+	const manager = new AsyncJobManager({ onJobComplete: () => {} });
+	const session = {
+		cwd: "/tmp",
+		settings: Settings.isolated({}),
+		asyncJobManager: manager,
+		getSessionId: () => "parent-session",
+		// No session file: the spawn stays in-memory and skips lifecycle persistence.
+		getSessionFile: () => null,
+		getArtifactsDir: () => null,
+		taskDepth: 0,
+		enableLsp: false,
+	} as unknown as ToolSession;
+
+	vi.spyOn(executorModule, "runSubprocess").mockImplementation(
+		async executorOptions =>
+			({
+				index: 0,
+				id: executorOptions.id,
+				agent: executorOptions.agent.name,
+				agentSource: "bundled",
+				task: executorOptions.task,
+				exitCode: 0,
+				output: LONG_OUTPUT,
+				stderr: "",
+				truncated: false,
+				durationMs: 1,
+				tokens: 0,
+				requests: 0,
+				...(options.outputPath
+					? {
+							outputPath: options.outputPath,
+							outputMeta: { lineCount: 701, charCount: LONG_OUTPUT.length },
+						}
+					: {}),
+			}) as SingleResult,
+	);
+
+	try {
+		const { jobId } = await VibeSessionRegistry.global().spawn(session, { cli: "good", prompt: "work" });
+		// The run promise resolves void; `#settleTurn`'s text lands on the job.
+		const job = manager.getJob(jobId);
+		await job?.promise;
+		return job?.resultText ?? "";
+	} finally {
+		await manager.dispose({ timeoutMs: 1_000 });
+	}
+}
+
+describe("vibe turn artifact gate", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+		VibeSessionRegistry.resetGlobalForTests();
+		AgentRegistry.resetGlobalForTests();
+	});
+
+	it("keeps a long response inline when no artifact was published", async () => {
+		const text = await settleLongTurn({});
+
+		// No receipt means no resolvable pointer, so the bytes must stay here.
+		expect(text).not.toContain("full-output=");
+		expect(text).not.toContain('truncated="true"');
+		expect(text).toContain("tail marker");
+	});
+
+	it("advertises the artifact pointer once the output artifact exists", async () => {
+		const text = await settleLongTurn({ outputPath: "/tmp/omp-vibe-artifacts/worker.md" });
+
+		expect(text).toContain('truncated="true"');
+		expect(text).toMatch(/full-output="agent:\/\/[^"]+"/);
+		// Truncation is the point of the pointer: the tail is withheld.
+		expect(text).not.toContain("tail marker");
+	});
+});


### PR DESCRIPTION
I opened this PR with the wrong fix and I am replacing it wholesale. My first
version removed the `full-output` attribute outright, on the strength of a
reproduction that never ran the executor. It was circular: I rendered the
template standalone, resolved a URI for an id nothing had written, and called
the resulting miss a bug. I reviewed the real path afterward and the pointer
works for a first turn. Removing it would have dropped the tail of long turns
that had a perfectly good artifact behind them. Corrected diff below.

## What is actually wrong

A long vibe turn slices its response at `RESPONSE_PREVIEW_MAX` and tells the
caller where the rest is:

```
<response truncated="true" full-output="agent://Va1B2c3D4">
```

`agent://` resolves by scanning for `<id>.md`, which `finalizeRunResult`
publishes only after `writeArtifact` verified the bytes
(`task/executor.ts:2268-2272`). When nothing was published the URI resolves to
nothing, and because the response was already sliced the withheld tail is
unreachable.

A first spawn does publish one, so the pointer is correct there:

- `vibe/runtime.ts:1320` — `artifactsDir = sessionArtifactsDir ?? path.join(os.tmpdir(), …)`, never null, and `:1322` registers it when it is a tmp dir
- `vibe/runtime.ts:1334`, `:1343` — `#buildSpawnOptions` passes `id: record.id` and `artifactsDir`
- `task/executor.ts:2268` — `if (args.artifactsDir && (!args.followUpTurn || hasYield))` writes `<id>.md`

The gap is a follow-up turn. `vibe/runtime.ts:1437` passes
`artifactsDir: session.getSessionFile()?.slice(0, -6)`, which is `undefined`
without a session file, so the executor writes nothing and `outputPath` stays
unset while `#settleTurn` still advertises the URI.

## The fix

One condition at `vibe/runtime.ts:1531`:

```ts
if (response.length > RESPONSE_PREVIEW_MAX && result.outputPath) {
```

Without a receipt the full response stays inline, so no bytes are lost in
either branch.

This mirrors the sibling gate at `task/result-summary.ts:53-55`:

```ts
const truncated = outputCharCount > FULL_OUTPUT_THRESHOLD && result.outputPath !== undefined;
const preview = truncated ? previewHead(output) : output;
```

It hands back the whole output when there is no artifact. Gating the slice
reproduces that behavior exactly.

## Verification

The test drives a real turn through `VibeSessionRegistry.spawn()` with
`runSubprocess` mocked, so it exercises `#settleTurn` rather than the template
in isolation. It asserts both directions, including that the tail survives when
the response stays inline. A template-render test structurally cannot catch
this, which is how my first version passed its own tests while being wrong.

Reverting the one condition fails it. The failure is the bug verbatim, a turn
with no artifact advertising a dead pointer:

```
Expected to not contain: "full-output="
Received: "…<response truncated="true" full-output="agent://WrongMarsupial">…"
(fail) vibe turn artifact gate > keeps a long response inline when no artifact was published
```

The second case passes with or without the gate, which is the direct evidence
that the pointer is correct when an artifact exists and must not be removed.

- `bun test test/vibe/turn-artifact-gate.test.ts`: 2 pass, 0 fail
- `bun test test/tools/vibe-render.test.ts`: 6 pass, 0 fail
- `bun run check:types` for `packages/coding-agent`: clean
- `oxlint` and `oxfmt --check` on both touched files: clean
- `git diff --cached --check`: clean

Test contributed by RevivePR9663, who also caught the error in my first
version.

Assisted-by: Claude Fable 5.1

