### PR TITLE
fix(vibe): gate turn truncation on a published artifact

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -14,6 +14,9 @@
 - Fixed `/usage` freezing the TUI for several seconds while it loaded the activity heatmap on a large stats database; the dashboard now opens immediately and the heatmap plus session sync load from a background subprocess.
 - Fixed the status line missing from the first frame at startup and appearing only after the session loaded; the last run's status row is cached per project and painted immediately, then replaced in place by the live one.
 - Fixed Bash builtins (`cut`, `sed`, `ls`, `sort`, `uniq`, `cat`, and the rest) printing `<name>: Broken pipe (os error 32)` / `write error` and exiting 1 when a downstream stage quit early (`cut f | head`, `cut f | sed 'bad'`); they now die silently with status 141 like standalone utilities under SIGPIPE.
+### Fixed
+
+- Fixed long vibe worker turns advertising an unresolvable `agent://` full-output link when the child's output artifact was not published; the full response now stays inline ([#10640](https://github.com/can1357/oh-my-pi/pull/10640) by [@aktanazat](https://github.com/aktanazat)).
 
 ## [18.1.5] - 2026-09-03
 

--- a/packages/coding-agent/src/vibe/runtime.ts
+++ b/packages/coding-agent/src/vibe/runtime.ts
@@ -1528,7 +1528,15 @@ export class VibeSessionRegistry {
 		const traceOverflow = Math.max(0, turn.toolCount - turn.trace.length);
 		let response = result.output.trim() || "(no output)";
 		let responseTruncated = false;
-		if (response.length > RESPONSE_PREVIEW_MAX) {
+		// Truncating requires somewhere to send the caller for the rest. The
+		// `agent://<id>` pointer in the template resolves by scanning for
+		// `<id>.md`, which `finalizeRunResult()` publishes only after
+		// `writeArtifact()` verified it, so an unverified write leaves
+		// `outputPath` unset and that URI absent (issue #9646). Without this
+		// guard a long turn advertises a pointer to nothing and the withheld
+		// bytes are unreachable; keep the full response inline instead. This
+		// mirrors the gate #9649 applied to the task envelope.
+		if (response.length > RESPONSE_PREVIEW_MAX && result.outputPath) {
 			const slice = response.slice(0, RESPONSE_PREVIEW_MAX);
 			const lastNewline = slice.lastIndexOf("\n");
 			response = lastNewline > 0 ? slice.slice(0, lastNewline) : slice;

--- a/packages/coding-agent/test/vibe/turn-artifact-gate.test.ts
+++ b/packages/coding-agent/test/vibe/turn-artifact-gate.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Contract: a vibe turn advertises `agent://<id>` only when the child's output
+ * artifact was actually published.
+ *
+ * `vibe-turn-result.md` renders `full-output="agent://{{id}}"` whenever
+ * `responseTruncated` is set, and `agent://` resolution scans for `<id>.md`.
+ * `finalizeRunResult()` assigns `SingleResult.outputPath` only after
+ * `writeArtifact()` verified the bytes, so an unverified write leaves that URI
+ * absent. Gating truncation on `outputPath` keeps the withheld bytes reachable:
+ * without a receipt the whole response stays inline. #9649 applied the same
+ * gate to the task envelope (`task/index.ts`) and left this sibling ungated.
+ */
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import { AsyncJobManager } from "@oh-my-pi/pi-coding-agent/async/job-manager";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { AgentRegistry } from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
+import * as executorModule from "@oh-my-pi/pi-coding-agent/task/executor";
+import type { SingleResult } from "@oh-my-pi/pi-coding-agent/task/types";
+import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+import { VibeSessionRegistry } from "@oh-my-pi/pi-coding-agent/vibe/runtime";
+
+/** Longer than the runtime's 6000-character `RESPONSE_PREVIEW_MAX`. */
+const LONG_OUTPUT = `${"work line\n".repeat(700)}tail marker`;
+
+/**
+ * Run one vibe turn whose child returns `LONG_OUTPUT`, and return the settled
+ * turn text the caller receives. `outputPath` decides whether the executor
+ * reports a published artifact.
+ */
+async function settleLongTurn(options: { outputPath?: string }): Promise<string> {
+	const manager = new AsyncJobManager({ onJobComplete: () => {} });
+	const session = {
+		cwd: "/tmp",
+		settings: Settings.isolated({}),
+		asyncJobManager: manager,
+		getSessionId: () => "parent-session",
+		// No session file: the spawn stays in-memory and skips lifecycle persistence.
+		getSessionFile: () => null,
+		getArtifactsDir: () => null,
+		taskDepth: 0,
+		enableLsp: false,
+	} as unknown as ToolSession;
+
+	vi.spyOn(executorModule, "runSubprocess").mockImplementation(
+		async executorOptions =>
+			({
+				index: 0,
+				id: executorOptions.id,
+				agent: executorOptions.agent.name,
+				agentSource: "bundled",
+				task: executorOptions.task,
+				exitCode: 0,
+				output: LONG_OUTPUT,
+				stderr: "",
+				truncated: false,
+				durationMs: 1,
+				tokens: 0,
+				requests: 0,
+				...(options.outputPath
+					? {
+							outputPath: options.outputPath,
+							outputMeta: { lineCount: 701, charCount: LONG_OUTPUT.length },
+						}
+					: {}),
+			}) as SingleResult,
+	);
+
+	try {
+		const { jobId } = await VibeSessionRegistry.global().spawn(session, { cli: "good", prompt: "work" });
+		// The run promise resolves void; `#settleTurn`'s text lands on the job.
+		const job = manager.getJob(jobId);
+		await job?.promise;
+		return job?.resultText ?? "";
+	} finally {
+		await manager.dispose({ timeoutMs: 1_000 });
+	}
+}
+
+describe("vibe turn artifact gate", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+		VibeSessionRegistry.resetGlobalForTests();
+		AgentRegistry.resetGlobalForTests();
+	});
+
+	it("keeps a long response inline when no artifact was published", async () => {
+		const text = await settleLongTurn({});
+
+		// No receipt means no resolvable pointer, so the bytes must stay here.
+		expect(text).not.toContain("full-output=");
+		expect(text).not.toContain('truncated="true"');
+		expect(text).toContain("tail marker");
+	});
+
+	it("advertises the artifact pointer once the output artifact exists", async () => {
+		const text = await settleLongTurn({ outputPath: "/tmp/omp-vibe-artifacts/worker.md" });
+
+		expect(text).toContain('truncated="true"');
+		expect(text).toMatch(/full-output="agent:\/\/[^"]+"/);
+		// Truncation is the point of the pointer: the tail is withheld.
+		expect(text).not.toContain("tail marker");
+	});
+});


### PR DESCRIPTION
<!-- HUMAN SENTENCE REQUIRED: replace this block with one sentence in your own words before opening. -->

## Repro

`bun test packages/coding-agent/test/vibe/turn-artifact-gate.test.ts` on `main`
(`2b8471bc3`). A vibe turn whose child returns 7011 characters and no published
artifact settles as:

```
<vibe-turn session="ActualCrow" cli="good" turn="1" status="completed" duration="1ms">
<activity tool-calls="0" requests="0">
</activity>
<response truncated="true" full-output="agent://ActualCrow">
work line
...
```

The tail is withheld and `agent://ActualCrow` resolves to nothing, so those bytes
are unreachable. The first test fails on `main` and the second passes, which
isolates the defect to the no-artifact case.

## Cause

`#settleTurn()` in `vibe/runtime.ts` set `responseTruncated` from
`response.length > RESPONSE_PREVIEW_MAX` alone. `vibe-turn-result.md` renders
`full-output="agent://{{id}}"` whenever that flag is set, and
`AgentProtocolHandler` resolves the URI by scanning registered artifact
directories for `<id>.md`. `finalizeRunResult()` assigns
`SingleResult.outputPath` only after `writeArtifact()` has verified the written
byte count, the on-disk size, and readability, so a failed or unverified write
leaves `outputPath` unset and no `<id>.md` on disk. The envelope still dropped
the tail and still advertised the pointer.

#9649 fixed exactly this shape for the task envelope by gating truncation in
`task/index.ts` on `&& result.outputPath`. The vibe call site consumes the same
`SingleResult` and was left ungated. Codex flagged this specific path by name
during review of #9663:

> other task-typed jobs such as vibe turns (`vibe/runtime.ts`), tan clones, and
> security scans either use a different `agentId` or never write an `.md`
> artifact ... callers are directed to a URL that returns `Not found`

(https://github.com/can1357/oh-my-pi/pull/9663#discussion_r3847320128)

## Fix

Gate the vibe truncation on `result.outputPath`, mirroring #9649. A turn without
a published artifact now keeps its full response inline, so nothing is withheld
behind a URI that cannot resolve. A turn with a published artifact is unchanged
and still advertises the pointer.

One condition, one comment, plus the regression. No other behavior is touched.

## Verification

`bun test packages/coding-agent/test/vibe/turn-artifact-gate.test.ts`
- on `main`: 1 pass, 1 fail (the no-artifact case renders `full-output=`)
- with the fix: 2 pass, 0 fail

`bun test packages/coding-agent/test/vibe/ packages/coding-agent/test/tools/vibe-render.test.ts packages/coding-agent/test/task/task-batch.test.ts`
- 45 pass, 0 fail, 182 expect() calls, 6 files

The new test drives the real path end to end: it calls
`VibeSessionRegistry.spawn()` and reads the settled job's `resultText`, with only
`runSubprocess` stubbed to control `output` and `outputPath`. It asserts the
rendered envelope, not the prompt text.

Found while confirming that #9649 superseded #9663, which I closed.
