### PR TITLE
fix(coding-agent): verify remaining artifact writes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -14,6 +14,9 @@
 - Fixed `/usage` freezing the TUI for several seconds while it loaded the activity heatmap on a large stats database; the dashboard now opens immediately and the heatmap plus session sync load from a background subprocess.
 - Fixed the status line missing from the first frame at startup and appearing only after the session loaded; the last run's status row is cached per project and painted immediately, then replaced in place by the live one.
 - Fixed Bash builtins (`cut`, `sed`, `ls`, `sort`, `uniq`, `cat`, and the rest) printing `<name>: Broken pipe (os error 32)` / `write error` and exiting 1 when a downstream stage quit early (`cut f | head`, `cut f | sed 'bad'`); they now die silently with status 141 like standalone utilities under SIGPIPE.
+### Fixed
+
+- Fixed truncated `read` URL output and `github run_watch` results publishing an `artifact://` link whose file was written short, so a failed spill now advertises no artifact instead of an incomplete one ([#10641](https://github.com/can1357/oh-my-pi/pull/10641) by [@aktanazat](https://github.com/aktanazat)).
 
 ## [18.1.5] - 2026-09-03
 

--- a/packages/coding-agent/src/tools/fetch.ts
+++ b/packages/coding-agent/src/tools/fetch.ts
@@ -6,7 +6,7 @@ import type { AgentToolResult } from "@oh-my-pi/pi-agent-core";
 import { type FetchImpl, getEnvApiKey, type ImageContent, type TextContent } from "@oh-my-pi/pi-ai";
 import { htmlToMarkdown } from "@oh-my-pi/pi-natives";
 import { type Component, Text } from "@oh-my-pi/pi-tui";
-import { $which, ptree, truncate } from "@oh-my-pi/pi-utils";
+import { $which, logger, ptree, truncate } from "@oh-my-pi/pi-utils";
 import { type ArchiveFormat, listArchiveRoot, sniffArchiveFormat } from "@oh-my-pi/pi-utils/ar";
 import type { Settings } from "../config/settings";
 import { readEditableNotebookText } from "../edit/notebook";
@@ -14,6 +14,7 @@ import type { RenderResultOptions } from "../extensibility/custom-tools/types";
 import { type Theme, theme } from "../modes/theme/theme";
 import type { ToolSession } from "../sdk";
 import type { AgentStorage } from "../session/agent-storage";
+import { writeArtifact } from "../session/artifacts";
 import { DEFAULT_MAX_BYTES, truncateHead } from "../session/streaming-output";
 import { renderStatusLine, urlHyperlink } from "../tui";
 import { CachedOutputBlock, markFramedBlockComponent } from "../tui/output-block";
@@ -1591,13 +1592,29 @@ async function findArtifactPath(session: ToolSession, artifactId: string): Promi
 	}
 }
 
+/**
+ * Persist the read output as an artifact, or report that none exists.
+ *
+ * `writeArtifact()` stages a sibling temp file and verifies the bytes before
+ * publishing, so a short or failed write never leaves a truncated file where
+ * `artifact://<id>` can resolve it. Returning `undefined` keeps the caller from
+ * advertising an id for content that is not on disk (issue #9646).
+ */
 async function persistReadUrlArtifact(
 	session: ToolSession,
 	output: string,
 ): Promise<{ id?: string; path?: string } | undefined> {
 	const artifact = await session.allocateOutputArtifact?.("read");
 	if (!artifact?.path) return undefined;
-	await Bun.write(artifact.path, output);
+	try {
+		await writeArtifact(artifact.path, output);
+	} catch (error) {
+		logger.warn("read: failed to persist url output artifact", {
+			path: artifact.path,
+			error: error instanceof Error ? error.message : String(error),
+		});
+		return undefined;
+	}
 	return artifact;
 }
 

--- a/packages/coding-agent/src/tools/gh-common.ts
+++ b/packages/coding-agent/src/tools/gh-common.ts
@@ -1,7 +1,8 @@
 import * as path from "node:path";
 import type { AgentToolResult } from "@oh-my-pi/pi-agent-core";
 import * as vcs from "@oh-my-pi/pi-natives/vcs";
-import { untilAborted } from "@oh-my-pi/pi-utils";
+import { logger, untilAborted } from "@oh-my-pi/pi-utils";
+import { writeArtifact } from "../session/artifacts";
 import { github } from "../utils/github";
 import type { ToolSession } from ".";
 import type { GhToolDetails } from "./gh";
@@ -317,6 +318,16 @@ export async function tryResolveCurrentRepoFresh(
 	}
 }
 
+/**
+ * Save the full result as an artifact and return its id, or `undefined` when no
+ * artifact exists.
+ *
+ * `writeArtifact()` stages a sibling temp file and verifies the bytes before
+ * publishing, so a short or failed write never leaves a truncated file where
+ * `artifact://<id>` can resolve it. Callers pass the returned id to
+ * `appendArtifactReference()`, which advertises it to the model, so a failed
+ * write must yield no id (issue #9646).
+ */
 export async function saveArtifactText(
 	session: ToolSession,
 	toolType: string,
@@ -327,7 +338,15 @@ export async function saveArtifactText(
 		return undefined;
 	}
 
-	await Bun.write(artifactPath, text);
+	try {
+		await writeArtifact(artifactPath, text);
+	} catch (error) {
+		logger.warn("gh: failed to persist result artifact", {
+			path: artifactPath,
+			error: error instanceof Error ? error.message : String(error),
+		});
+		return undefined;
+	}
 	return artifactId;
 }
 

--- a/packages/coding-agent/test/tools/artifact-write-verification.test.ts
+++ b/packages/coding-agent/test/tools/artifact-write-verification.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Contract: a tool that allocates an artifact path publishes its id only after
+ * the bytes are verified on disk.
+ *
+ * `ArtifactManager.save()` routes through `writeArtifact()`, which stages a
+ * sibling temp file and checks the written byte count, the on-disk size, and
+ * readability before an atomic rename. The `allocateOutputArtifact()` +
+ * caller-writes shape bypassed that helper and wrote with a bare `Bun.write()`,
+ * so a short write published an id for a truncated file — the same failure
+ * reproduced for #9646, at call sites #9649 did not reach.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+import { saveArtifactText } from "@oh-my-pi/pi-coding-agent/tools/gh-common";
+import { ReadTool } from "@oh-my-pi/pi-coding-agent/tools/read";
+import * as scrapers from "@oh-my-pi/pi-coding-agent/web/scrapers/types";
+import { removeSyncWithRetries, Snowflake } from "@oh-my-pi/pi-utils";
+
+let testDir: string;
+let artifactsDir: string;
+
+function makeSession(): ToolSession {
+	const sessionFile = path.join(testDir, "session.jsonl");
+	let nextArtifactId = 0;
+	return {
+		cwd: testDir,
+		hasUI: false,
+		getSessionFile: () => sessionFile,
+		getArtifactsDir: () => artifactsDir,
+		getSessionSpawns: () => null,
+		allocateOutputArtifact: async (toolType: string) => {
+			const id = String(nextArtifactId++);
+			return { id, path: path.join(artifactsDir, `${id}.${toolType}.log`) };
+		},
+		settings: Settings.isolated({ "fetch.enabled": true }),
+	} as unknown as ToolSession;
+}
+
+/**
+ * Model the #9646 short write: writes inside the artifacts directory land
+ * partially and report the truncated count. Every other write passes through so
+ * the mock cannot disturb unrelated files.
+ */
+function shortWriteArtifacts(): void {
+	const realWrite = Bun.write.bind(Bun);
+	vi.spyOn(Bun, "write").mockImplementation(async (target, content) => {
+		if (typeof target === "string" && target.startsWith(artifactsDir)) {
+			await realWrite(target, String(content).slice(0, 3));
+			return 3;
+		}
+		return realWrite(target as Parameters<typeof realWrite>[0], content as string);
+	});
+}
+
+beforeEach(() => {
+	testDir = path.join(os.tmpdir(), `omp-artifact-write-verification-${Snowflake.next()}`);
+	artifactsDir = path.join(testDir, "session");
+	fs.mkdirSync(artifactsDir, { recursive: true });
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	removeSyncWithRetries(testDir);
+});
+
+describe("gh result artifacts", () => {
+	it("publishes no artifact id when the write falls short", async () => {
+		shortWriteArtifacts();
+
+		const artifactId = await saveArtifactText(makeSession(), "gh", "full run watch result body");
+
+		// An id here would be advertised as artifact://<id> by
+		// appendArtifactReference() while the file holds 3 of 26 bytes.
+		expect(artifactId).toBeUndefined();
+		// Neither the destination nor a staging file survives.
+		expect(fs.readdirSync(artifactsDir)).toEqual([]);
+	});
+
+	it("publishes the artifact id and the whole body on a good write", async () => {
+		const body = "full run watch result body";
+
+		const artifactId = await saveArtifactText(makeSession(), "gh", body);
+
+		expect(artifactId).toBe("0");
+		expect(fs.readFileSync(path.join(artifactsDir, "0.gh.log"), "utf8")).toBe(body);
+	});
+});
+
+describe("read URL artifacts", () => {
+	/** Long enough that the read output truncates and needs a spill artifact. */
+	const LONG_BODY = "content line\n".repeat(40_000);
+
+	function stubLoadPage(body: string): void {
+		vi.spyOn(scrapers, "loadPage").mockImplementation(async (requestedUrl: string) => ({
+			ok: true,
+			status: 200,
+			finalUrl: requestedUrl,
+			contentType: "text/plain",
+			content: body,
+		}));
+	}
+
+	it("publishes no artifact id when the spill write falls short", async () => {
+		stubLoadPage(LONG_BODY);
+		shortWriteArtifacts();
+
+		const result = await new ReadTool(makeSession()).execute("call", { path: "https://example.com/big.txt" });
+		const truncation = result.details?.meta?.truncation;
+
+		// Truncation metadata proves this is the path that spills an artifact.
+		if (!truncation) throw new Error("expected the read output to truncate");
+		// This id is what the renderer turns into `artifact://<id>`; publishing it
+		// would point the caller at 3 bytes of the withheld output.
+		expect(truncation.artifactId).toBeUndefined();
+		// Neither the destination nor a staging file survives.
+		expect(fs.readdirSync(artifactsDir)).toEqual([]);
+	});
+
+	it("publishes the artifact id once the spill write is verified", async () => {
+		stubLoadPage(LONG_BODY);
+
+		const result = await new ReadTool(makeSession()).execute("call", { path: "https://example.com/big.txt" });
+		const truncation = result.details?.meta?.truncation;
+
+		if (!truncation) throw new Error("expected the read output to truncate");
+		expect(truncation.artifactId).toBe("0");
+		// The spilled artifact holds every byte the preview was cut from, which is
+		// exactly what verifying the write before publishing the id guarantees.
+		expect(truncation.totalBytes).toBeGreaterThan(truncation.outputBytes);
+		expect(fs.statSync(path.join(artifactsDir, "0.read.log")).size).toBe(truncation.totalBytes);
+	});
+});


### PR DESCRIPTION
<!-- HUMAN SENTENCE REQUIRED: replace this block with one sentence in your own words before opening. -->

## Repro

`bun test packages/coding-agent/test/tools/artifact-write-verification.test.ts` on
`main` (`2b8471bc3`), with `Bun.write` modelling the #9646 short write for paths
inside the artifacts directory only:

```
Received: "0"
(fail) gh result artifacts > publishes no artifact id when the write falls short
Received: "0"
(fail) read URL artifacts > publishes no artifact id when the spill write falls short
 2 pass
 2 fail
```

Both sites returned artifact id `0` after writing 3 bytes. The read result then
carries `meta.truncation.artifactId = "0"` while the preview has already dropped
the rest, and `github run_watch` appends `artifact://0`. Following either pointer
reaches 3 bytes of a 500 KB body. The two good-path cases pass on `main`, which
isolates the defect to the failed write.

## Cause

`writeArtifact()` stages a sibling temp file and checks the written byte count,
the on-disk size, and readability before an atomic rename. Only three call sites
use it. The `allocateOutputArtifact()`-then-caller-writes shape skips it:

- `tools/fetch.ts` `persistReadUrlArtifact()` did `await Bun.write(artifact.path, output)` and returned the artifact.
- `tools/gh-common.ts` `saveArtifactText()` did `await Bun.write(artifactPath, text)` and returned `artifactId`.

Neither checked the result, so a short write published an id for a truncated
file. #9649 fixed this class for the content-in path (`ArtifactManager.save()`)
and for the task output artifact; these two sites allocate the path themselves
and were missed.

## Fix

Route both through the existing `writeArtifact()` helper and drop the id when it
throws. No verification logic is duplicated.

Both callers already treat a missing id as "no artifact": `ensureReadUrlArtifact`
keeps the entry unchanged when `persistReadUrlArtifact` returns `undefined`, and
`appendArtifactReference()` returns the text untouched without an id. So a failed
write now advertises nothing instead of an incomplete artifact, and a failed
write no longer propagates out of a read either.

## Scope note

`materializeReadUrlContent()` in the same file also writes with a bare
`Bun.write()`, but its path is returned for an immediate in-process search rather
than published as an `artifact://` id, so it is not the same defect and is left
alone. `tools/bash.ts`, `tools/browser.ts`, `tools/computer.ts`, and
`tools/eval.ts` also allocate artifact paths, but they append incrementally
through `OutputSink`/`TailBuffer`; write-then-rename does not fit a streaming
writer, so they need a different approach and are out of scope here.

## Verification

`bun test packages/coding-agent/test/tools/artifact-write-verification.test.ts`
- on `main`: 2 pass, 2 fail (both sites publish an id for a 3-byte file)
- with the fix: 4 pass, 0 fail

`bun test packages/coding-agent/test/tools/artifact-write-verification.test.ts packages/coding-agent/test/tools/fetch-raw-mode.test.ts packages/coding-agent/test/tools/fetch-url-selectors.test.ts packages/coding-agent/test/artifacts-integrity.test.ts`
- 27 pass, 0 fail

`bun test packages/coding-agent/test/tools/fetch-jina-stall.test.ts packages/coding-agent/test/tools/fetch-kagi-toggle.test.ts packages/coding-agent/test/tools/fetch-binary-dispatch.test.ts`
- 28 pass, 0 fail

The new test drives the real tools: `ReadTool.execute()` against a stubbed
`loadPage`, and `saveArtifactText()` directly. It asserts the published artifact
id and the bytes on disk, and the happy path asserts the spilled file size equals
`meta.truncation.totalBytes`, so the artifact is provably the whole output the
preview was cut from.

Found while confirming that #9649 superseded #9663, which I closed.
