### PR TITLE
fix(tools): keep a failed artifact write from failing the tool

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Fixed `/usage` freezing the TUI for several seconds while it loaded the activity heatmap on a large stats database; the dashboard now opens immediately and the heatmap plus session sync load from a background subprocess.
 - Fixed the status line missing from the first frame at startup and appearing only after the session loaded; the last run's status row is cached per project and painted immediately, then replaced in place by the live one.
 - Fixed Bash builtins (`cut`, `sed`, `ls`, `sort`, `uniq`, `cat`, and the rest) printing `<name>: Broken pipe (os error 32)` / `write error` and exiting 1 when a downstream stage quit early (`cut f | head`, `cut f | sed 'bad'`); they now die silently with status 141 like standalone utilities under SIGPIPE.
+- Fixed a failed output-artifact write aborting an otherwise completed `fetch` or `gh` tool call; both now route through the verified artifact writer and simply omit the `artifact://` reference when the write does not land.
 
 ## [18.1.5] - 2026-09-03
 

--- a/packages/coding-agent/src/tools/fetch.ts
+++ b/packages/coding-agent/src/tools/fetch.ts
@@ -6,7 +6,7 @@ import type { AgentToolResult } from "@oh-my-pi/pi-agent-core";
 import { type FetchImpl, getEnvApiKey, type ImageContent, type TextContent } from "@oh-my-pi/pi-ai";
 import { htmlToMarkdown } from "@oh-my-pi/pi-natives";
 import { type Component, Text } from "@oh-my-pi/pi-tui";
-import { $which, ptree, truncate } from "@oh-my-pi/pi-utils";
+import { $which, logger, ptree, truncate } from "@oh-my-pi/pi-utils";
 import { type ArchiveFormat, listArchiveRoot, sniffArchiveFormat } from "@oh-my-pi/pi-utils/ar";
 import type { Settings } from "../config/settings";
 import { readEditableNotebookText } from "../edit/notebook";
@@ -14,6 +14,7 @@ import type { RenderResultOptions } from "../extensibility/custom-tools/types";
 import { type Theme, theme } from "../modes/theme/theme";
 import type { ToolSession } from "../sdk";
 import type { AgentStorage } from "../session/agent-storage";
+import { writeArtifact } from "../session/artifacts";
 import { DEFAULT_MAX_BYTES, truncateHead } from "../session/streaming-output";
 import { renderStatusLine, urlHyperlink } from "../tui";
 import { CachedOutputBlock, markFramedBlockComponent } from "../tui/output-block";
@@ -1597,7 +1598,22 @@ async function persistReadUrlArtifact(
 ): Promise<{ id?: string; path?: string } | undefined> {
 	const artifact = await session.allocateOutputArtifact?.("read");
 	if (!artifact?.path) return undefined;
-	await Bun.write(artifact.path, output);
+	// The id ships to the model as `artifact://<id>`, so publish one only for an
+	// artifact the filesystem confirmed, and never let a failed side-channel
+	// write discard a completed fetch. Same shape as the bash, browser, and
+	// computer artifact writers.
+	try {
+		await writeArtifact(artifact.path, output);
+	} catch (error) {
+		// `writeArtifact` distinguishes a short write from a failed one, so keep
+		// the reason: silently dropping the id hides a filesystem problem that
+		// only shows up as a missing `artifact://` link.
+		logger.warn("Failed to persist read artifact", {
+			path: artifact.path,
+			error: error instanceof Error ? error.message : String(error),
+		});
+		return undefined;
+	}
 	return artifact;
 }
 

--- a/packages/coding-agent/src/tools/gh-common.ts
+++ b/packages/coding-agent/src/tools/gh-common.ts
@@ -1,7 +1,8 @@
 import * as path from "node:path";
 import type { AgentToolResult } from "@oh-my-pi/pi-agent-core";
 import * as vcs from "@oh-my-pi/pi-natives/vcs";
-import { untilAborted } from "@oh-my-pi/pi-utils";
+import { logger, untilAborted } from "@oh-my-pi/pi-utils";
+import { writeArtifact } from "../session/artifacts";
 import { github } from "../utils/github";
 import type { ToolSession } from ".";
 import type { GhToolDetails } from "./gh";
@@ -327,7 +328,23 @@ export async function saveArtifactText(
 		return undefined;
 	}
 
-	await Bun.write(artifactPath, text);
+	// Callers embed this id as `artifact://<id>`, so publish one only for an
+	// artifact the filesystem confirmed, and never let a failed side-channel
+	// write discard a completed tool result. Same shape as the bash, browser,
+	// and computer artifact writers.
+	try {
+		await writeArtifact(artifactPath, text);
+	} catch (error) {
+		// `writeArtifact` distinguishes a short write from a failed one, so keep
+		// the reason: silently dropping the id hides a filesystem problem that
+		// only shows up as a missing `artifact://` link.
+		logger.warn("Failed to persist tool output artifact", {
+			toolType,
+			path: artifactPath,
+			error: error instanceof Error ? error.message : String(error),
+		});
+		return undefined;
+	}
 	return artifactId;
 }
 

--- a/packages/coding-agent/test/tools/fetch-raw-mode.test.ts
+++ b/packages/coding-agent/test/tools/fetch-raw-mode.test.ts
@@ -183,3 +183,65 @@ describe("read URL with multi-range selector (regression: was stuck on URL → 4
 		expect(loadSpy).toHaveBeenCalledWith("https://example.com/file.txt", expect.anything());
 	});
 });
+
+describe("read URL artifact publication", () => {
+	let testDir: string;
+	beforeEach(() => {
+		testDir = path.join(os.tmpdir(), `fetch-artifact-${Snowflake.next()}`);
+		fs.mkdirSync(testDir, { recursive: true });
+	});
+	afterEach(() => {
+		vi.restoreAllMocks();
+		removeSyncWithRetries(testDir);
+	});
+
+	/** A selector read is the path that sets `ensureArtifact` (read.ts:1151). */
+	function sessionWithArtifactsDir(artifactsDir: string): ToolSession {
+		return {
+			cwd: testDir,
+			hasUI: false,
+			getSessionFile: () => path.join(testDir, "session.jsonl"),
+			getArtifactsDir: () => artifactsDir,
+			getSessionSpawns: () => null,
+			allocateOutputArtifact: async toolType => ({
+				id: "0",
+				path: path.join(artifactsDir, `0.${toolType}.log`),
+			}),
+			settings: Settings.isolated({ "fetch.enabled": true }),
+		};
+	}
+
+	const body = Array.from({ length: 12 }, (_, i) => `content ${i + 1}`).join("\n");
+
+	it("publishes the artifact when the write lands", async () => {
+		const artifactsDir = path.join(testDir, "artifacts");
+		fs.mkdirSync(artifactsDir, { recursive: true });
+		stubLoadPage(body, "text/plain");
+
+		const result = await new ReadTool(sessionWithArtifactsDir(artifactsDir)).execute("call", {
+			// Body line N lands at output line N+6, after the URL header prefix.
+			path: "https://example.com/file.txt:8-9",
+		});
+
+		expect(result.content.length).toBeGreaterThan(0);
+		expect(fs.readFileSync(path.join(artifactsDir, "0.read.log"), "utf8")).toContain("content 2");
+	});
+
+	it("still returns the read when the artifact write fails", async () => {
+		// The artifacts dir path is a regular file, so the write cannot land.
+		// A failed side-channel artifact must not discard a completed read.
+		const blocker = path.join(testDir, "not-a-dir");
+		fs.writeFileSync(blocker, "");
+		stubLoadPage(body, "text/plain");
+
+		const result = await new ReadTool(sessionWithArtifactsDir(blocker)).execute("call", {
+			path: "https://example.com/file.txt:8-9",
+		});
+
+		const text = result.content
+			.filter((c): c is { type: "text"; text: string } => c.type === "text")
+			.map(c => c.text)
+			.join("\n");
+		expect(text).toContain("content 2");
+	});
+});

--- a/packages/coding-agent/test/tools/gh.test.ts
+++ b/packages/coding-agent/test/tools/gh.test.ts
@@ -15,7 +15,7 @@ import {
 	parseSearchDateBound,
 	resolveDefaultRepoMemoized,
 } from "@oh-my-pi/pi-coding-agent/tools/gh";
-import { parseIssueUrl, parsePullRequestUrl } from "@oh-my-pi/pi-coding-agent/tools/gh-common";
+import { parseIssueUrl, parsePullRequestUrl, saveArtifactText } from "@oh-my-pi/pi-coding-agent/tools/gh-common";
 import { github } from "@oh-my-pi/pi-coding-agent/utils/github";
 import { withRepoLock } from "@oh-my-pi/pi-coding-agent/utils/repo-lock";
 import type { VcsGitRepo } from "@oh-my-pi/pi-natives";
@@ -1796,5 +1796,39 @@ describe("GitHub URL parsing", () => {
 		return expect(resolveDefaultRepoMemoized(`/tmp/gh-canonical-identity-${Date.now()}`)).resolves.toBe(
 			"acme/widgets",
 		);
+	});
+});
+
+describe("saveArtifactText", () => {
+	let tmpDir: string;
+
+	beforeEach(async () => {
+		tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-gh-artifact-"));
+	});
+
+	afterEach(async () => {
+		await removeWithRetries(tmpDir);
+	});
+
+	it("publishes an id for an artifact it wrote", async () => {
+		const artifactsDir = path.join(tmpDir, "artifacts");
+		await fs.mkdir(artifactsDir, { recursive: true });
+		const session = createSession(tmpDir, Settings.isolated({ "github.enabled": true }), artifactsDir);
+
+		const artifactId = await saveArtifactText(session, "gh", "full failed-job logs\n");
+
+		expect(artifactId).toBe("0");
+		expect(await fs.readFile(path.join(artifactsDir, "0-gh.md"), "utf8")).toBe("full failed-job logs\n");
+	});
+
+	it("drops the id instead of failing the tool when the artifact write fails", async () => {
+		// A completed `gh run watch` embeds this id as `artifact://<id>`. A
+		// failed side-channel write must not discard the result the tool already
+		// produced, and must not advertise an artifact that is not there.
+		const blocker = path.join(tmpDir, "not-a-dir");
+		await fs.writeFile(blocker, "");
+		const session = createSession(tmpDir, Settings.isolated({ "github.enabled": true }), blocker);
+
+		expect(await saveArtifactText(session, "gh", "full failed-job logs\n")).toBeUndefined();
 	});
 });


### PR DESCRIPTION
two of the artifact writers had no guard so a failed write killed the whole tool call. gh run watch would poll the run, pull every failed job log, then hand back nothing. now those two log it and keep the result.

Two of the five artifact writers wrote the allocated artifact with a bare `Bun.write` and no caller guarding the throw: `saveArtifactText` (`gh-common.ts:321`) and `persistReadUrlArtifact` (`fetch.ts:1595`). A failed side-channel write threw out of a tool call that had already done all of its real work.

`gh-run-watch.ts:855` is the clearest case: it resolves the repo, polls the run to completion, and fetches every failed job's log, then throws all of that away if the artifact write fails.

The other three writers already degrade safely and return `undefined` on a failed write: `bash.ts`, `browser.ts`, and `computer.ts`.

Both sites now wrap the write and return `undefined`, and they log the reason instead of swallowing it, so the caller keeps its result and omits the `artifact://` reference. `finalizeRunResult` logs on this same path (`task/executor.ts:2277-2283`). Both also route through `writeArtifact`, which verifies byte count and readability before an atomic rename, so a published id cannot point at a truncated file. Same class as #9649, at two call sites it did not reach.

Non-goal: `bash.ts`, `browser.ts`, and `computer.ts` keep their `Bun.write`. They already degrade safely, so converting them is a separate change with no bug behind it.

Verification:

- `bun test test/tools/gh.test.ts`: 61 pass, 0 fail (2 new)
- `bun test test/tools/fetch-raw-mode.test.ts`: 9 pass, 0 fail (2 new)

Each guard was checked by reverting its own source file to upstream, where its new test fails.


