### PR TITLE
fix(agent): preserve terminal yields across steering

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed queued steering skipping tool calls whose emitted result must commit before the message is handled.
+
 ## [18.1.2] - 2026-09-01
 
 ### Fixed

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -2299,6 +2299,15 @@ async function prepareToolCallDispatch(
 	}
 	return prepared;
 }
+function resolveToolCallFlag<TArgs>(policy: boolean | ((args: TArgs) => boolean) | undefined, args: TArgs): boolean {
+	if (typeof policy !== "function") return policy === true;
+	try {
+		return policy(args);
+	} catch {
+		return false;
+	}
+}
+
 /**
  * Execute tool calls from an assistant message.
  */
@@ -2365,25 +2374,14 @@ async function executeToolCalls(
 			args: toolCall.arguments as Record<string, unknown>,
 		};
 		const { tool, args } = prepared;
-		const interruptibleMode = tool?.interruptible;
-		let interruptible = false;
-		if (typeof interruptibleMode === "function") {
-			try {
-				// Resolved from the prepared (possibly hook-revised) args so an
-				// argument-dependent policy governs the call that actually runs.
-				interruptible = interruptibleMode(args);
-			} catch {
-				// Resolver failures default to preserving the tool's outcome.
-				interruptible = false;
-			}
-		} else {
-			interruptible = interruptibleMode === true;
-		}
+		const interruptible = resolveToolCallFlag(tool?.interruptible, args);
+		const deferSteering = resolveToolCallFlag(tool?.deferSteering, args);
 		return {
 			toolCall,
 			tool,
 			args,
 			interruptible,
+			deferSteering,
 			signal: interruptible ? interruptibleSignal : nonInterruptibleSignal,
 			started: false,
 			result: undefined as AgentToolResult<any> | undefined,
@@ -2503,8 +2501,12 @@ async function executeToolCalls(
 		// work still queued behind the aborted wait too — otherwise a batched
 		// `todo`/`write` gets dropped as "Skipped due to pending peer interrupt"
 		// purely for being ordered after the wait (#7493). User/system steering
-		// still preempts everything queued.
-		if (interruptState.triggered && (record.interruptible || interruptState.source !== "irc")) {
+		// still preempts queued work unless the call protects a committed outcome.
+		if (
+			interruptState.triggered &&
+			!record.deferSteering &&
+			(record.interruptible || interruptState.source !== "irc")
+		) {
 			// Skip both span emission and the collector orphan record here. The
 			// tail sweep below (after `Promise.allSettled`) is the single path
 			// that handles "no result message was produced" — it calls

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -2407,15 +2407,18 @@ async function executeToolCalls(
 	});
 
 	const checkIrcInterrupts = async (): Promise<void> => {
-		// IRC only fires once: a peer interrupt already recorded on interruptState
-		// must not re-abort, and (unlike steering) never re-consumes a queue.
-		if (!shouldInterruptImmediately || signal?.aborted || interruptState.triggered) return;
-		if (hasIrcInterrupts && (await hasIrcInterrupts())) {
+		// IRC has its own abort channel: steering may have fired first while a
+		// deferred interruptible call is still running. The controller, not the
+		// shared first-interrupt state, is the idempotence guard.
+		if (!shouldInterruptImmediately || signal?.aborted || ircAbortController.signal.aborted) return;
+		if (hasIrcInterrupts && (await hasIrcInterrupts()) && !ircAbortController.signal.aborted) {
 			// Peer IRC hard-aborts interruptible waits only; foreground tools keep
 			// running (no partial side effects) but get the cooperative soft
 			// signal so backgroundable work can step aside for the peer message.
-			interruptState.triggered = true;
-			interruptState.source = "irc";
+			if (!interruptState.triggered) {
+				interruptState.triggered = true;
+				interruptState.source = "irc";
+			}
 			ircAbortController.abort();
 			steeringSoftController.abort();
 		}
@@ -2456,6 +2459,9 @@ async function executeToolCalls(
 				steeringAbortController.abort();
 				steeringSoftController.abort();
 			}
+			// IRC uses an independent queue and must remain observable after
+			// steering so deferred interruptible calls retain peer cancellation.
+			await checkIrcInterrupts();
 			return;
 		}
 		await checkIrcInterrupts();
@@ -2735,7 +2741,7 @@ async function executeToolCalls(
 	// detection hard-aborts interruptible waits, soft-signals cooperative tools
 	// (auto-background bash), and skips not-yet-started tools, so the boundary
 	// dequeue below injects the message promptly. Gated on immediate-interrupt
-	// mode; checkSteering is idempotent (no-op once triggered).
+	// mode; per-channel abort controllers make repeated checks idempotent.
 	const watchSteeringWhileRunning =
 		shouldInterruptImmediately && (hasSteeringMessages !== undefined || hasIrcInterrupts !== undefined);
 	const eventDrivenSteeringWatch =

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -2351,11 +2351,16 @@ async function executeToolCalls(
 	// anything; ignoring it is always safe.
 	const steeringSoftController = new AbortController();
 	// Interruptible tools (pure waits: hub wait, vibe) observe steering +
-	// external + IRC aborts. Every other tool sees ONLY the external signal:
-	// neither queued steering nor a peer IRC ever hard-kills a partially
-	// side-effecting foreground tool (e.g. `bash`) — those get the cooperative
-	// `steeringSignal` above, and the message injects at the next boundary.
+	// external + IRC aborts. Calls that defer steering omit only the steering
+	// abort, retaining external and peer-IRC cancellation. Every other tool sees
+	// ONLY the external signal: neither queued steering nor a peer IRC ever
+	// hard-kills a partially side-effecting foreground tool (e.g. `bash`) —
+	// those get the cooperative `steeringSignal` above, and the message injects
+	// at the next boundary.
 	const nonInterruptibleSignal: AbortSignal = signal ?? new AbortController().signal;
+	const deferredSteeringSignal: AbortSignal = signal
+		? AbortSignal.any([signal, ircAbortController.signal])
+		: ircAbortController.signal;
 	const interruptibleSignal: AbortSignal = signal
 		? AbortSignal.any([signal, steeringAbortController.signal, ircAbortController.signal])
 		: AbortSignal.any([steeringAbortController.signal, ircAbortController.signal]);
@@ -2376,13 +2381,18 @@ async function executeToolCalls(
 		const { tool, args } = prepared;
 		const interruptible = resolveToolCallFlag(tool?.interruptible, args);
 		const deferSteering = resolveToolCallFlag(tool?.deferSteering, args);
+		const toolSignal = interruptible
+			? deferSteering
+				? deferredSteeringSignal
+				: interruptibleSignal
+			: nonInterruptibleSignal;
 		return {
 			toolCall,
 			tool,
 			args,
 			interruptible,
 			deferSteering,
-			signal: interruptible ? interruptibleSignal : nonInterruptibleSignal,
+			signal: toolSignal,
 			started: false,
 			result: undefined as AgentToolResult<any> | undefined,
 			isError: false,
@@ -2502,9 +2512,10 @@ async function executeToolCalls(
 		// `todo`/`write` gets dropped as "Skipped due to pending peer interrupt"
 		// purely for being ordered after the wait (#7493). User/system steering
 		// still preempts queued work unless the call protects a committed outcome.
+		const defersCurrentInterrupt = record.deferSteering && interruptState.source !== "irc";
 		if (
 			interruptState.triggered &&
-			!record.deferSteering &&
+			!defersCurrentInterrupt &&
 			(record.interruptible || interruptState.source !== "irc")
 		) {
 			// Skip both span emission and the collector orphan record here. The

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -795,6 +795,15 @@ export interface AgentTool<
 	 */
 	interruptible?: boolean | ((args: Partial<Static<TParameters>>) => boolean);
 	/**
+	 * Whether a queued steering message must wait for this not-yet-started call
+	 * to execute. A function resolves this per call from the prepared arguments.
+	 *
+	 * Reserve this for calls whose emitted result is a committed protocol
+	 * outcome; ordinary queued work remains skippable so immediate steering stays
+	 * responsive.
+	 */
+	deferSteering?: boolean | ((args: Partial<Static<TParameters>>) => boolean);
+	/**
 	 * Controls how the INTENT_FIELD (`i`) is handled for this tool.
 	 * - `"require"` (default): `i` is injected and required in the parameter schema.
 	 * - `"optional"`: `i` is injected as an optional/nullable field.

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -795,8 +795,10 @@ export interface AgentTool<
 	 */
 	interruptible?: boolean | ((args: Partial<Static<TParameters>>) => boolean);
 	/**
-	 * Whether a queued steering message must wait for this not-yet-started call
-	 * to execute. A function resolves this per call from the prepared arguments.
+	 * Whether a queued steering message must wait for this call to execute. A
+	 * function resolves this per call from the prepared arguments. When both
+	 * policies are enabled, this overrides {@link interruptible} for steering;
+	 * external and peer-IRC aborts still apply.
 	 *
 	 * Reserve this for calls whose emitted result is a committed protocol
 	 * outcome; ordinary queued work remains skippable so immediate steering stays

--- a/packages/agent/test/agent-loop.test.ts
+++ b/packages/agent/test/agent-loop.test.ts
@@ -1691,6 +1691,75 @@ describe("agentLoop with AgentMessage", () => {
 		expect(deferredEnd?.isError).toBe(false);
 	});
 
+	it("checks IRC cancellation after steering already interrupted the batch", async () => {
+		const toolSchema = type({ value: "string" });
+		const executed: string[] = [];
+		const tool: AgentTool<typeof toolSchema, { value: string }> = {
+			name: "echo",
+			label: "Echo",
+			description: "Echo tool",
+			parameters: toolSchema,
+			concurrency: "exclusive",
+			interruptible: params => params.value === "deferred",
+			deferSteering: params => params.value === "deferred",
+			async execute(_toolCallId, params) {
+				executed.push(params.value);
+				return {
+					content: [{ type: "text", text: `ok:${params.value}` }],
+					details: { value: params.value },
+				};
+			},
+		};
+		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [tool] };
+		const parentSteer: AgentMessage = {
+			role: "user",
+			content: "parent steering",
+			attribution: "agent",
+			timestamp: Date.now(),
+		};
+		let steerDelivered = false;
+		let ircChecks = 0;
+		const mock = createMockModel({
+			responses: [
+				{
+					content: [
+						{ type: "toolCall", id: "tool-first", name: "echo", arguments: { value: "first" } },
+						{ type: "toolCall", id: "tool-deferred", name: "echo", arguments: { value: "deferred" } },
+					],
+				},
+				{ content: ["done"] },
+			],
+		});
+		const config: AgentLoopConfig = {
+			model: mock.model,
+			convertToLlm: identityConverter,
+			interruptMode: "immediate",
+			hasSteeringMessages: () =>
+				executed.length >= 1 && !steerDelivered ? { queued: true, source: "agent" } : { queued: false },
+			hasIrcInterrupts: () => {
+				ircChecks++;
+				return executed.length >= 1;
+			},
+			getSteeringMessages: async () => {
+				if (executed.length < 1 || steerDelivered) return [];
+				steerDelivered = true;
+				return [parentSteer];
+			},
+		};
+
+		const events: AgentEvent[] = [];
+		const stream = agentLoop([createUserMessage("start")], context, config, undefined, mock.stream);
+		for await (const event of stream) events.push(event);
+
+		expect(ircChecks).toBeGreaterThan(0);
+		expect(executed).toEqual(["first"]);
+		const deferredEnd = events.find(
+			(event): event is Extract<AgentEvent, { type: "tool_execution_end" }> =>
+				event.type === "tool_execution_end" && event.toolCallId === "tool-deferred",
+		);
+		expect(deferredEnd?.isError).toBe(true);
+	});
+
 	it("should skip remaining tool calls with system advisory wording when advisor steering is queued", async () => {
 		const toolSchema = type({ value: "string" });
 		const executed: string[] = [];

--- a/packages/agent/test/agent-loop.test.ts
+++ b/packages/agent/test/agent-loop.test.ts
@@ -1625,6 +1625,72 @@ describe("agentLoop with AgentMessage", () => {
 		expect(sawInterruptInContext).toBe(true);
 	});
 
+	it("keeps deferred interruptible calls off the steering-aborted signal", async () => {
+		const toolSchema = type({ value: "string" });
+		const executed: string[] = [];
+		let deferredSignalAborted: boolean | undefined;
+		const tool: AgentTool<typeof toolSchema, { value: string }> = {
+			name: "echo",
+			label: "Echo",
+			description: "Echo tool",
+			parameters: toolSchema,
+			concurrency: "exclusive",
+			interruptible: params => params.value === "deferred",
+			deferSteering: params => params.value === "deferred",
+			async execute(_toolCallId, params, signal) {
+				if (params.value === "deferred") deferredSignalAborted = signal?.aborted;
+				executed.push(params.value);
+				return {
+					content: [{ type: "text", text: `ok:${params.value}` }],
+					details: { value: params.value },
+				};
+			},
+		};
+		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [tool] };
+		const parentSteer: AgentMessage = {
+			role: "user",
+			content: "parent steering",
+			attribution: "agent",
+			timestamp: Date.now(),
+		};
+		let steerDelivered = false;
+		const mock = createMockModel({
+			responses: [
+				{
+					content: [
+						{ type: "toolCall", id: "tool-first", name: "echo", arguments: { value: "first" } },
+						{ type: "toolCall", id: "tool-deferred", name: "echo", arguments: { value: "deferred" } },
+					],
+				},
+				{ content: ["done"] },
+			],
+		});
+		const config: AgentLoopConfig = {
+			model: mock.model,
+			convertToLlm: identityConverter,
+			interruptMode: "immediate",
+			hasSteeringMessages: () =>
+				executed.length >= 1 && !steerDelivered ? { queued: true, source: "agent" } : { queued: false },
+			getSteeringMessages: async () => {
+				if (executed.length < 1 || steerDelivered) return [];
+				steerDelivered = true;
+				return [parentSteer];
+			},
+		};
+
+		const events: AgentEvent[] = [];
+		const stream = agentLoop([createUserMessage("start")], context, config, undefined, mock.stream);
+		for await (const event of stream) events.push(event);
+
+		expect(executed).toEqual(["first", "deferred"]);
+		expect(deferredSignalAborted).toBe(false);
+		const deferredEnd = events.find(
+			(event): event is Extract<AgentEvent, { type: "tool_execution_end" }> =>
+				event.type === "tool_execution_end" && event.toolCallId === "tool-deferred",
+		);
+		expect(deferredEnd?.isError).toBe(false);
+	});
+
 	it("should skip remaining tool calls with system advisory wording when advisor steering is queued", async () => {
 		const toolSchema = type({ value: "string" });
 		const executed: string[] = [];

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Fixed `/usage` freezing the TUI for several seconds while it loaded the activity heatmap on a large stats database; the dashboard now opens immediately and the heatmap plus session sync load from a background subprocess.
 - Fixed the status line missing from the first frame at startup and appearing only after the session loaded; the last run's status row is cached per project and painted immediately, then replaced in place by the live one.
 - Fixed Bash builtins (`cut`, `sed`, `ls`, `sort`, `uniq`, `cat`, and the rest) printing `<name>: Broken pipe (os error 32)` / `write error` and exiting 1 when a downstream stage quit early (`cut f | head`, `cut f | sed 'bad'`); they now die silently with status 141 like standalone utilities under SIGPIPE.
+- Fixed parent steering discarding an already-emitted terminal subagent yield and leaving the task running ([#10645](https://github.com/can1357/oh-my-pi/issues/10645)).
 
 ## [18.1.5] - 2026-09-03
 

--- a/packages/coding-agent/src/tools/yield.ts
+++ b/packages/coding-agent/src/tools/yield.ts
@@ -268,6 +268,11 @@ export class YieldTool implements AgentTool<TSchema, YieldDetails> {
 	strict = true;
 	readonly intent = "omit" as const;
 	lenientArgValidation = true;
+	/** Protects terminal submissions; incremental section yields remain steerable. */
+	readonly deferSteering = (args: unknown): boolean => {
+		if (!isPlainRecord(args)) return true;
+		return !Array.isArray(args.type);
+	};
 
 	readonly #validate?: (value: unknown) => JsonSchemaValidationResult;
 	readonly #validateSection?: ReadonlyMap<string, (value: unknown) => JsonSchemaValidationResult>;

--- a/packages/coding-agent/src/tools/yield.ts
+++ b/packages/coding-agent/src/tools/yield.ts
@@ -268,10 +268,19 @@ export class YieldTool implements AgentTool<TSchema, YieldDetails> {
 	strict = true;
 	readonly intent = "omit" as const;
 	lenientArgValidation = true;
-	/** Protects terminal submissions; incremental section yields remain steerable. */
+	/**
+	 * Protects terminal submissions from a queued steering skip. Only a
+	 * successful incremental section (`type: [...]` with a non-error result)
+	 * stays steerable — it matches the subprocess registry's `shouldTerminate`
+	 * classification below, so an array-typed *error* submission (terminal
+	 * `status: "aborted"`) is protected like every other terminal yield.
+	 */
 	readonly deferSteering = (args: unknown): boolean => {
 		if (!isPlainRecord(args)) return true;
-		return !Array.isArray(args.type);
+		const yieldType = args.type;
+		if (!Array.isArray(yieldType) || yieldType.length === 0) return true;
+		const result = resolveResultRecord(args, yieldType as string[]);
+		return result !== undefined && typeof result.error === "string";
 	};
 
 	readonly #validate?: (value: unknown) => JsonSchemaValidationResult;

--- a/packages/coding-agent/test/tools/yield.test.ts
+++ b/packages/coding-agent/test/tools/yield.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from "bun:test";
+import { Agent, type AgentEvent } from "@oh-my-pi/pi-agent-core";
+import { createMockModel } from "@oh-my-pi/pi-ai/providers/mock";
 import { convertOpenAICodexResponsesTools } from "@oh-my-pi/pi-ai/providers/openai-codex-responses";
 import type { Model, Tool, ToolCall } from "@oh-my-pi/pi-ai/types";
 import { enforceStrictSchema } from "@oh-my-pi/pi-ai/utils/schema";
@@ -57,6 +59,62 @@ describe("YieldTool", () => {
 		const tool = new YieldTool(createSession());
 		const result = await tool.execute("call-1", { result: { data: { ok: true } } } as never);
 		expect(result.details).toEqual({ data: { ok: true }, status: "success", error: undefined });
+	});
+	it("executes a terminal yield emitted before parent steering", async () => {
+		const tool = new YieldTool(createSession());
+		const yieldCall: ToolCall = {
+			type: "toolCall",
+			id: "tool-yield-steering",
+			name: "yield",
+			arguments: { result: { data: { report: "finished" } } },
+		};
+		const mock = createMockModel({
+			responses: [{ content: [yieldCall] }, { content: ["parent steering handled"] }],
+		});
+		const agent = new Agent({
+			initialState: {
+				model: mock.model,
+				systemPrompt: ["Test"],
+				tools: [tool],
+				messages: [],
+			},
+			streamFn: mock.stream,
+			interruptMode: "immediate",
+		});
+		const events: AgentEvent[] = [];
+		let steeringSent = false;
+		const unsubscribe = agent.subscribe(event => {
+			events.push(event);
+			if (
+				!steeringSent &&
+				event.type === "message_update" &&
+				event.message.role === "assistant" &&
+				event.message.content.some(content => content.type === "toolCall" && content.name === "yield")
+			) {
+				steeringSent = true;
+				agent.steer({
+					role: "user",
+					content: "Wrap up now with your findings.",
+					attribution: "agent",
+					timestamp: Date.now(),
+				});
+			}
+		});
+
+		await agent.prompt("start");
+		unsubscribe();
+
+		expect(steeringSent).toBe(true);
+		const yieldEnd = events.find(
+			(event): event is Extract<AgentEvent, { type: "tool_execution_end" }> =>
+				event.type === "tool_execution_end" && event.toolCallId === yieldCall.id,
+		);
+		expect(yieldEnd?.isError).toBe(false);
+		expect(yieldEnd?.result.details).toEqual({
+			data: { report: "finished" },
+			status: "success",
+			error: undefined,
+		});
 	});
 
 	it("accepts aborted payload with error only", async () => {

--- a/packages/coding-agent/test/tools/yield.test.ts
+++ b/packages/coding-agent/test/tools/yield.test.ts
@@ -9,6 +9,7 @@ import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
 import { YieldTool } from "@oh-my-pi/pi-coding-agent/tools/yield";
+import { subprocessToolRegistry } from "@oh-my-pi/pi-coding-agent/task/subprocess-tool-registry";
 import { arrayValuedLabels } from "../../src/task/yield-assembly";
 
 function createSession(overrides: Partial<ToolSession> = {}): ToolSession {
@@ -115,6 +116,31 @@ describe("YieldTool", () => {
 			status: "success",
 			error: undefined,
 		});
+	});
+
+	it("defers steering for every terminal yield, including array-typed error submissions", async () => {
+		const handler = subprocessToolRegistry.getHandler("yield");
+		if (!handler?.shouldTerminate) throw new Error("yield subprocess handler must register shouldTerminate");
+		const shouldTerminate = handler.shouldTerminate;
+		const cases: Array<{ label: string; args: Record<string, unknown> }> = [
+			{ label: "array-typed error", args: { type: ["findings"], result: { error: "blocked" } } },
+			{ label: "array-typed success section", args: { type: ["findings"], result: { data: "one finding" } } },
+			{ label: "string-typed terminal success", args: { type: "summary", result: { data: { ok: true } } } },
+			{ label: "untyped terminal success", args: { result: { data: { ok: true } } } },
+		];
+		for (const { label, args } of cases) {
+			const tool = new YieldTool(createSession());
+			const result = await tool.execute(`call-${label}`, args as never);
+			const terminal = shouldTerminate({
+				toolName: "yield",
+				toolCallId: `call-${label}`,
+				result: { content: result.content, details: result.details },
+				isError: result.isError,
+			});
+			// A queued steering skip must fire only for a call the registry treats
+			// as non-terminal — otherwise the parent never receives the outcome.
+			expect({ label, defer: tool.deferSteering(args) }).toEqual({ label, defer: terminal });
+		}
 	});
 
 	it("accepts aborted payload with error only", async () => {


### PR DESCRIPTION
## Repro
A focused `YieldTool` test queues agent-attributed steering from the streamed yield `message_update`, matching `hub send` landing after the call is emitted but before execution. `cd packages/coding-agent && bun test test/tools/yield.test.ts --test-name-pattern 'executes a terminal yield emitted before parent steering'` failed before the fix because the yield `tool_execution_end` had `isError: true` instead of the expected successful result.

## Cause
`executeToolCalls` in `packages/agent/src/agent-loop.ts` treated queued parent steering as permission to skip every not-yet-started call, so an emitted `YieldTool` call received a synthetic steering-skip result before `YieldTool.execute` could commit it; `AgentSession` therefore never observed a successful terminal yield and the subprocess remained unsettled.

## Fix
- Added a per-call `AgentTool.deferSteering` execution policy for emitted protocol outcomes that must commit before queued steering is handled.
- Applied that policy to terminal `YieldTool` calls while leaving array-typed incremental yields on the existing immediate-steering path.
- Added the parent-steering regression and release notes for both affected packages.

## Verification
`bun test packages/coding-agent/test/tools/yield.test.ts packages/agent/test/agent-loop.test.ts packages/agent/test/agent.test.ts` passed with 199 tests and 751 assertions. The publish gate also completed `bun run fix` and `bun check` successfully.

Fixes #10645