### PR TITLE
fix(tui): preserve distinct narrow usage labels

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Fixed
 
+- Fixed narrow `/usage` dashboards truncating distinct quota labels to identical text ([#10649](https://github.com/can1357/oh-my-pi/issues/10649)).
 - Fixed protocol handler incorrectly escaping raw text content from agent responses
 - Fixed `<task-result>` previews of structured subagent yields collapsing to a lone `{` when the JSON's second line exceeded the preview budget
 - Fixed `/usage` freezing the TUI for several seconds while it loaded the activity heatmap on a large stats database; the dashboard now opens immediately and the heatmap plus session sync load from a background subprocess.

--- a/packages/coding-agent/src/modes/components/usage-dashboard.ts
+++ b/packages/coding-agent/src/modes/components/usage-dashboard.ts
@@ -126,6 +126,15 @@ function aggregateRowStatus(windows: CardWindowRow[]): UsageLimit["status"] {
 	return "unknown";
 }
 
+/** Shared leading word to omit when it would hide distinguishing suffixes at narrow widths. */
+function sharedLeadingWordPrefix(windows: readonly CardWindowRow[], labelWidth: number): string {
+	if (windows.length < 2 || windows.every(window => visibleWidth(window.label) <= labelWidth)) return "";
+	const separator = windows[0].label.indexOf(" ");
+	if (separator < 1) return "";
+	const prefix = windows[0].label.slice(0, separator + 1);
+	return windows.every(window => window.label.startsWith(prefix) && window.label.length > prefix.length) ? prefix : "";
+}
+
 /**
  * Collapse usage reports into one compact card per provider: limits grouped by
  * quota bucket (label + window), each bucket showing the mean used fraction
@@ -400,13 +409,14 @@ export class UsageDashboardComponent implements Component {
 			0,
 		);
 		const labelWidth = Math.min(16, Math.max(6, width - 24));
+		const sharedLabelPrefix = sharedLeadingWordPrefix(visibleWindows, labelWidth);
 		const barWidth = Math.max(5, width - 2 - labelWidth - 1 - 5 - (resetWidth > 0 ? resetWidth + 1 : 0));
 		for (const window of visibleWindows) {
 			const tagPlain = window.windowTag
 				? truncateToWidth(window.windowTag, Math.max(2, Math.floor(labelWidth / 2) - 1))
 				: "";
 			const baseWidth = tagPlain ? labelWidth - visibleWidth(tagPlain) - 1 : labelWidth;
-			const basePlain = truncateToWidth(window.label, baseWidth).padEnd(baseWidth);
+			const basePlain = truncateToWidth(window.label.slice(sharedLabelPrefix.length), baseWidth).padEnd(baseWidth);
 			const label = tagPlain
 				? `${theme.fg("muted", basePlain)} ${theme.fg("dim", tagPlain)}`
 				: theme.fg("muted", basePlain);

--- a/packages/coding-agent/test/usage-dashboard.test.ts
+++ b/packages/coding-agent/test/usage-dashboard.test.ts
@@ -1,7 +1,12 @@
-import { describe, expect, it } from "bun:test";
+import { beforeAll, describe, expect, it } from "bun:test";
 import type { DailyActivityPoint } from "@oh-my-pi/omp-stats/shared-types";
 import type { UsageReport } from "@oh-my-pi/pi-ai";
-import { buildHeatmapLayout, buildProviderCards } from "@oh-my-pi/pi-coding-agent/modes/components/usage-dashboard";
+import {
+	buildHeatmapLayout,
+	buildProviderCards,
+	UsageDashboardComponent,
+} from "@oh-my-pi/pi-coding-agent/modes/components/usage-dashboard";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 
 function day(day: string, cost: number, requests = 1): DailyActivityPoint {
 	return { day, cost, requests, totalTokens: 0 };
@@ -106,5 +111,35 @@ describe("buildProviderCards", () => {
 		expect(idle.sort()).toEqual(["cursor", "ollama-cloud"]);
 		const unlimited = cards.find(card => card.provider === "ollama-cloud");
 		expect(unlimited?.unlimited).toBe(true);
+	});
+});
+
+describe("UsageDashboardComponent", () => {
+	beforeAll(async () => {
+		await initTheme();
+	});
+
+	it("keeps shared-prefix limit labels distinguishable at narrow widths", () => {
+		const reports = [
+			report("anthropic", "a@x.test", [
+				limit("anthropic", "a", "7d", "Claude 7 Day", 0.55, "warning"),
+				limit("anthropic", "a", "7d-fable", "Claude 7 Day (Fable)", 0.46, "ok"),
+				limit("anthropic", "a", "5h", "Claude 5 Hour", 0.01, "ok"),
+				limit("anthropic", "a", "extra", "Claude Extra", 1, "exhausted"),
+			]),
+		];
+		const dashboard = new UsageDashboardComponent({
+			reports,
+			renderDetail: () => "",
+			loadActivity: async push => push([]),
+			requestRender: () => {},
+			onClose: () => {},
+		});
+
+		const rendered = Bun.stripANSI(dashboard.render(73).join("\n"));
+		expect(rendered).toContain("7 Day");
+		expect(rendered).toContain("7 Day (F…");
+		expect(rendered).not.toContain("Claude 7…");
+		dashboard.dispose();
 	});
 });


### PR DESCRIPTION
## Repro
Rendering `/usage` at 73 columns with Anthropic 7 Day, 7 Day (Fable), 5 Hour, and Extra limits reproduced two `Claude 7…` rows. The regression command is `bun test packages/coding-agent/test/usage-dashboard.test.ts`; before the fix, the narrow-label assertion failed with the duplicate rendered rows.

## Cause
`UsageDashboardComponent.#renderCardLines()` in `packages/coding-agent/src/modes/components/usage-dashboard.ts` assigned a 9-column label budget at this width and always truncated labels from the right, preserving the shared `Claude ` prefix while discarding the distinguishing suffixes.

## Fix
- Omit one leading word shared by every visible card row only when at least one label exceeds the available label width.
- Cover the 73-column Anthropic layout with a component-rendering regression test.
- Document the user-visible fix in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/usage-dashboard.test.ts` passed: 7 tests, 0 failures. `bun run check` in `packages/coding-agent` passed. A headless 73x33 PTY render showed distinct `7 Day` and `7 Day (F…` rows.

Fixes #10649