### PR TITLE
fix(acp): keep healthy MCP servers when a sibling fails to connect

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Fixed `/usage` freezing the TUI for several seconds while it loaded the activity heatmap on a large stats database; the dashboard now opens immediately and the heatmap plus session sync load from a background subprocess.
 - Fixed the status line missing from the first frame at startup and appearing only after the session loaded; the last run's status row is cached per project and painted immediately, then replaced in place by the live one.
 - Fixed Bash builtins (`cut`, `sed`, `ls`, `sort`, `uniq`, `cat`, and the rest) printing `<name>: Broken pipe (os error 32)` / `write error` and exiting 1 when a downstream stage quit early (`cut f | head`, `cut f | sed 'bad'`); they now die silently with status 141 like standalone utilities under SIGPIPE.
+- Fixed an ACP `session/new` failing entirely when one configured MCP server could not connect; healthy servers now keep their tools and the failed server is logged instead of rejecting the session ([#10651](https://github.com/can1357/oh-my-pi/issues/10651)).
 
 ## [18.1.5] - 2026-09-03
 

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -2672,12 +2672,14 @@ export class AcpAgent implements Agent {
 		}
 
 		const result = await manager.connectServers(configs, sources);
+		// A server that fails to connect must not strand its healthy siblings:
+		// `connectServers` already isolates per-server failures, so surface them
+		// via the logger and keep the servers that did connect instead of
+		// rejecting the whole session (issue #10651).
 		if (result.errors.size > 0) {
-			throw new Error(
-				Array.from(result.errors.entries())
-					.map(([name, message]) => `${name}: ${message}`)
-					.join("; "),
-			);
+			logger.warn("ACP MCP servers failed to connect", {
+				errors: Array.from(result.errors.entries()).map(([server, error]) => ({ server, error })),
+			});
 		}
 
 		record.mcpManager = manager;

--- a/packages/coding-agent/test/acp-agent.test.ts
+++ b/packages/coding-agent/test/acp-agent.test.ts
@@ -3336,4 +3336,37 @@ describe("ACP agent MCP server configuration (late-connecting servers)", () => {
 			refreshSpy.mockRestore();
 		}
 	}, 15_000);
+
+	/**
+	 * Regression test for issue #10651: one MCP server that fails to connect
+	 * used to reject `session/new` and strand every healthy sibling's tools.
+	 * `MCPManager.connectServers` isolates per-server failures, but
+	 * `#configureMcpServers` threw whenever `errors` was non-empty and never
+	 * assigned the manager. It now surfaces the failures via the logger and
+	 * keeps the healthy servers' tools.
+	 */
+	it("keeps a healthy server's tools when a sibling server fails to connect", async () => {
+		const MANY_TOOLS_FIXTURE = path.join(import.meta.dir, "fixtures", "many-tools-mcp.ts");
+		const harness = await createHarness();
+		const refreshSpy = spyOn(FakeAgentSession.prototype, "refreshMCPTools");
+		const namesOf = (tools: unknown[]) => (tools as Array<{ name: string }>).map(tool => tool.name);
+
+		try {
+			const created = await harness.agent.newSession({
+				cwd: harness.cwdA,
+				mcpServers: [
+					{ name: "healthy", command: BUN_EXEC, args: [MANY_TOOLS_FIXTURE], env: [] },
+					{ name: "broken", command: path.join(harness.cwdA, "does-not-exist-mcp"), args: [], env: [] },
+				],
+			});
+			// The broken sibling must not reject session creation.
+			expectAcpStructure(zNewSessionResponse, created);
+			// The healthy server's tools must still reach the session registry.
+			await pollUntil(() =>
+				namesOf(refreshSpy.mock.calls.at(-1)?.[0] ?? []).some(name => name.startsWith("mcp__healthy_")),
+			);
+		} finally {
+			refreshSpy.mockRestore();
+		}
+	}, 15_000);
 });


### PR DESCRIPTION
## Repro
An ACP client that supplies two `mcpServers` in `session/new` — one healthy, one whose `command` is a bad path (or an `http` server pointed at a closed port) — has the whole session rejected, and the healthy server's tools never register. Reproduced with a new regression test:

```
bun test test/acp-agent.test.ts -t "keeps a healthy server"
```

Against the pre-fix code it fails with `error: broken: ENOENT ... posix_spawn` thrown from `#configureMcpServers`, so `session/new` rejects and the healthy server's 45 tools are dropped.

## Cause
`AcpAgent.#configureMcpServers` (`packages/coding-agent/src/modes/acp/acp-agent.ts`) awaited `MCPManager.connectServers` and then `throw`ew whenever the returned `errors` map was non-empty, before ever assigning `record.mcpManager` or refreshing tools. `connectServers` already isolates per-server failures via `Promise.allSettled` and returns `{ tools, errors, connectedServers }`, so this all-or-nothing throw negated that isolation — one broken entry stranded every healthy sibling. The interactive/CLI path (`mcp-command-controller.ts`) surfaces the same `errors` non-fatally, confirming the ACP throw is the outlier.

## Fix
- Replace the `throw` on `result.errors.size > 0` in `#configureMcpServers` with a `logger.warn` carrying per-server `{ server, error }` diagnostics.
- Fall through to `record.mcpManager = manager` and the queued `enqueueMcpToolsRefresh()`, so servers that did connect always register their tools regardless of sibling failures.
- Add a regression test in `acp-agent.test.ts` (healthy + broken stdio servers → `session/new` resolves and the healthy server's `mcp__healthy_*` tools reach the session registry).
- Changelog entry under `[Unreleased] > Fixed`.

Request #1 in the issue (prefix/glob keys in `tools.approval` or a dedicated `mcp.approvalMode`) is a new config surface and is intentionally out of scope — it needs a maintainer decision on the config shape.

## Verification
`bun test test/acp-agent.test.ts test/acp-mcp-isolation.test.ts` → 82 pass, 0 fail (the new regression test fails before the fix, passes after). Fixes #10651