### PR TITLE
fix(ai): send OpenCode routing headers on go/zen requests

### DIFF
--- a/packages/agent/src/compaction/compaction-v2-streaming.ts
+++ b/packages/agent/src/compaction/compaction-v2-streaming.ts
@@ -396,6 +396,10 @@ function buildCompactionV2Headers(
 	const cacheOptions = { sessionId: request.sessionId, promptCacheKey: request.promptCacheKey };
 	const routingSessionId = getOpenAIResponsesRoutingSessionId(cacheOptions);
 	const promptCacheSessionId = getOpenAIPromptCacheKey(cacheOptions);
+	const requiresOpenCodeRoutingHeaders =
+		model.compat !== undefined &&
+		"requiresOpenCodeRoutingHeaders" in model.compat &&
+		model.compat.requiresOpenCodeRoutingHeaders === true;
 	const headers: Record<string, string> =
 		api === "azure-openai-responses"
 			? {
@@ -406,7 +410,13 @@ function buildCompactionV2Headers(
 			: {
 					"content-type": "application/json",
 					...resolveOpenAIRequestSetup(
-						{ provider: model.provider, id: model.id, baseUrl: model.baseUrl, headers: model.headers },
+						{
+							provider: model.provider,
+							id: model.id,
+							baseUrl: model.baseUrl,
+							headers: model.headers,
+							compat: { requiresOpenCodeRoutingHeaders },
+						},
 						{
 							apiKey,
 							messages: [],

--- a/packages/agent/src/compaction/compaction-v2-streaming.ts
+++ b/packages/agent/src/compaction/compaction-v2-streaming.ts
@@ -407,7 +407,13 @@ function buildCompactionV2Headers(
 					"content-type": "application/json",
 					...resolveOpenAIRequestSetup(
 						{ provider: model.provider, id: model.id, baseUrl: model.baseUrl, headers: model.headers },
-						{ apiKey, messages: [], openAISessionId: routingSessionId, promptCacheSessionId },
+						{
+							apiKey,
+							messages: [],
+							openAISessionId: routingSessionId,
+							promptCacheSessionId,
+							opencodeSessionId: request.sessionId,
+						},
 					).headers,
 				};
 	if (api === "openai-codex-responses" || model.provider === "openai-codex") {

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Anthropic and OpenRouter 402 credit-exhaustion errors ("would exceed your available credits", "Insufficient credits") now switch to a sibling account instead of stopping the turn with a retry hint.
+- OpenCode Go/Zen requests now send the required `x-opencode-session` (stable per conversation) and `x-opencode-client: omp` routing headers, so inference keeps working after OpenCode began rejecting header-less callers; explicit `headers` config still overrides them ([#10653](https://github.com/can1357/oh-my-pi/issues/10653)).
 
 ## [18.1.5] - 2026-09-03
 

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -8,6 +8,7 @@ import { mapEffortToAnthropicAdaptiveEffort } from "@oh-my-pi/pi-catalog/model-t
 import { calculateCost, getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { isAnthropicOAuthToken } from "@oh-my-pi/pi-catalog/utils";
 import { parseGitHubCopilotApiKey } from "@oh-my-pi/pi-catalog/wire/github-copilot";
+import { opencodeRoutingHeaders } from "@oh-my-pi/pi-catalog/wire/opencode";
 import {
 	$env,
 	getInstallId,
@@ -3334,6 +3335,16 @@ export function buildAnthropicClientOptions(args: AnthropicClientOptionsArgs): A
 	// header and keep `apiKey` so the client emits `X-Api-Key`.
 	if (model.provider === "opencode-go" || model.provider === "opencode-zen" || model.provider === "umans") {
 		delete defaultHeaders.Authorization;
+		// OpenCode's gateway requires a stable per-conversation `x-opencode-session`
+		// on inference requests and errors header-less callers; `x-opencode-client`
+		// attributes the request for upstream stats. Defaults only — user/model
+		// headers already merged into `defaultHeaders` win.
+		if (model.provider === "opencode-go" || model.provider === "opencode-zen") {
+			const routing = opencodeRoutingHeaders(claudeCodeSessionId);
+			for (const name in routing) {
+				if (getHeaderCaseInsensitive(defaultHeaders, name) === undefined) defaultHeaders[name] = routing[name];
+			}
+		}
 		return {
 			isOAuthToken: false,
 			apiKey,

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -8,7 +8,7 @@ import { mapEffortToAnthropicAdaptiveEffort } from "@oh-my-pi/pi-catalog/model-t
 import { calculateCost, getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { isAnthropicOAuthToken } from "@oh-my-pi/pi-catalog/utils";
 import { parseGitHubCopilotApiKey } from "@oh-my-pi/pi-catalog/wire/github-copilot";
-import { opencodeRoutingHeaders } from "@oh-my-pi/pi-catalog/wire/opencode";
+import { isOpenCodeProvider, opencodeRoutingHeaders } from "@oh-my-pi/pi-catalog/wire/opencode";
 import {
 	$env,
 	getInstallId,
@@ -3339,7 +3339,7 @@ export function buildAnthropicClientOptions(args: AnthropicClientOptionsArgs): A
 		// on inference requests and errors header-less callers; `x-opencode-client`
 		// attributes the request for upstream stats. Defaults only — user/model
 		// headers already merged into `defaultHeaders` win.
-		if (model.provider === "opencode-go" || model.provider === "opencode-zen") {
+		if (isOpenCodeProvider(model.provider)) {
 			const routing = opencodeRoutingHeaders(claudeCodeSessionId);
 			for (const name in routing) {
 				if (getHeaderCaseInsensitive(defaultHeaders, name) === undefined) defaultHeaders[name] = routing[name];

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -8,7 +8,7 @@ import { mapEffortToAnthropicAdaptiveEffort } from "@oh-my-pi/pi-catalog/model-t
 import { calculateCost, getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { isAnthropicOAuthToken } from "@oh-my-pi/pi-catalog/utils";
 import { parseGitHubCopilotApiKey } from "@oh-my-pi/pi-catalog/wire/github-copilot";
-import { isOpenCodeProvider, opencodeRoutingHeaders } from "@oh-my-pi/pi-catalog/wire/opencode";
+import { opencodeRoutingHeaders } from "@oh-my-pi/pi-catalog/wire/opencode";
 import {
 	$env,
 	getInstallId,
@@ -3339,7 +3339,7 @@ export function buildAnthropicClientOptions(args: AnthropicClientOptionsArgs): A
 		// on inference requests and errors header-less callers; `x-opencode-client`
 		// attributes the request for upstream stats. Defaults only — user/model
 		// headers already merged into `defaultHeaders` win.
-		if (isOpenCodeProvider(model.provider)) {
+		if (model.compat.requiresOpenCodeRoutingHeaders) {
 			const routing = opencodeRoutingHeaders(claudeCodeSessionId);
 			for (const name in routing) {
 				if (getHeaderCaseInsensitive(defaultHeaders, name) === undefined) defaultHeaders[name] = routing[name];

--- a/packages/ai/src/providers/google.ts
+++ b/packages/ai/src/providers/google.ts
@@ -1,4 +1,4 @@
-import { isOpenCodeProvider, opencodeRoutingHeaders } from "@oh-my-pi/pi-catalog/wire/opencode";
+import { opencodeRoutingHeaders } from "@oh-my-pi/pi-catalog/wire/opencode";
 import * as AIError from "../error";
 import { getEnvApiKey } from "../stream";
 import type { Context, Model, StreamFunction } from "../types";
@@ -39,7 +39,7 @@ export const streamGoogle: StreamFunction<"google-generative-ai"> = (
 			const url = `${base}/models/${model.id}:streamGenerateContent?alt=sse`;
 			const headers: Record<string, string> = {
 				"x-goog-api-key": apiKey,
-				...(isOpenCodeProvider(model.provider) ? opencodeRoutingHeaders(options?.sessionId) : {}),
+				...(model.compat.requiresOpenCodeRoutingHeaders ? opencodeRoutingHeaders(options?.sessionId) : {}),
 				...model.headers,
 				...options?.headers,
 			};

--- a/packages/ai/src/providers/google.ts
+++ b/packages/ai/src/providers/google.ts
@@ -1,3 +1,4 @@
+import { isOpenCodeProvider, opencodeRoutingHeaders } from "@oh-my-pi/pi-catalog/wire/opencode";
 import * as AIError from "../error";
 import { getEnvApiKey } from "../stream";
 import type { Context, Model, StreamFunction } from "../types";
@@ -38,6 +39,7 @@ export const streamGoogle: StreamFunction<"google-generative-ai"> = (
 			const url = `${base}/models/${model.id}:streamGenerateContent?alt=sse`;
 			const headers: Record<string, string> = {
 				"x-goog-api-key": apiKey,
+				...(isOpenCodeProvider(model.provider) ? opencodeRoutingHeaders(options?.sessionId) : {}),
 				...model.headers,
 				...options?.headers,
 			};

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -731,6 +731,7 @@ const streamOpenAICompletionsOnce = (
 				options?.headers,
 				options?.initiatorOverride,
 				getOpenAIPromptCacheKey(options),
+				options?.sessionId,
 			);
 			const premiumRequestsTotal = copilotPremiumRequests;
 			let appliedStrictTools = false;
@@ -1505,6 +1506,7 @@ function createRequestSetup(
 	extraHeaders?: Record<string, string>,
 	initiatorOverride?: MessageAttribution,
 	promptCacheSessionId?: string,
+	opencodeSessionId?: string,
 ): OpenAIRequestSetup & { baseUrl: string } {
 	const apiVersion = $env.AZURE_OPENAI_API_VERSION || "2024-10-21";
 	const deploymentName = parseAzureDeploymentNameMap($env.AZURE_OPENAI_DEPLOYMENT_NAME_MAP).get(model.id) ?? model.id;
@@ -1513,6 +1515,7 @@ function createRequestSetup(
 		extraHeaders,
 		initiatorOverride,
 		promptCacheSessionId,
+		opencodeSessionId,
 		messages: context.messages,
 		defaultBaseUrl: "https://api.openai.com/v1",
 		// Provider auth/header overlay: Kimi-code hosts require shared client

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -447,6 +447,7 @@ const streamOpenAIResponsesOnce = (
 				messages: context.messages,
 				openAISessionId: routingSessionId,
 				promptCacheSessionId,
+				opencodeSessionId: options?.sessionId,
 			});
 			const premiumRequestsTotal = copilotPremiumRequests;
 			const providerSessionState = getOpenAIResponsesProviderSessionState(model, options?.providerSessionState);

--- a/packages/ai/src/providers/openai-shared.ts
+++ b/packages/ai/src/providers/openai-shared.ts
@@ -21,7 +21,7 @@ import {
 	removeBlankCoreWeaveProjectHeaders,
 } from "@oh-my-pi/pi-catalog/wire/coreweave";
 import { parseGitHubCopilotApiKey } from "@oh-my-pi/pi-catalog/wire/github-copilot";
-import { isOpenCodeProvider, opencodeRoutingHeaders } from "@oh-my-pi/pi-catalog/wire/opencode";
+import { opencodeRoutingHeaders } from "@oh-my-pi/pi-catalog/wire/opencode";
 import {
 	$env,
 	classifyJsonPrefix,
@@ -150,7 +150,7 @@ export interface OpenAIStrictToolsState {
 export interface OpenAIRequestSetupModel extends OpenAIModelIdentity {
 	headers?: Record<string, string>;
 	premiumMultiplier?: number;
-	compat?: Pick<ResolvedOpenAISharedCompat, "promptCacheSessionHeader">;
+	compat?: Pick<ResolvedOpenAISharedCompat, "promptCacheSessionHeader" | "requiresOpenCodeRoutingHeaders">;
 }
 
 /** Cache identity controls shared by OpenAI-family transports. */
@@ -321,7 +321,7 @@ export function resolveOpenAIRequestSetup(
 	// inference requests and error header-less callers; `x-opencode-client`
 	// attributes the request for upstream stats. Defaults only — explicit
 	// user/config headers of the same name already sit in `headers` and win.
-	if (isOpenCodeProvider(model.provider)) {
+	if (model.compat?.requiresOpenCodeRoutingHeaders) {
 		const routing = opencodeRoutingHeaders(options.opencodeSessionId);
 		for (const name in routing) {
 			setHeaderIfAbsent(headers, name, routing[name]);

--- a/packages/ai/src/providers/openai-shared.ts
+++ b/packages/ai/src/providers/openai-shared.ts
@@ -21,6 +21,7 @@ import {
 	removeBlankCoreWeaveProjectHeaders,
 } from "@oh-my-pi/pi-catalog/wire/coreweave";
 import { parseGitHubCopilotApiKey } from "@oh-my-pi/pi-catalog/wire/github-copilot";
+import { opencodeRoutingHeaders } from "@oh-my-pi/pi-catalog/wire/opencode";
 import {
 	$env,
 	classifyJsonPrefix,
@@ -173,6 +174,8 @@ export interface OpenAIRequestSetupOptions {
 	};
 	openAISessionId?: string;
 	promptCacheSessionId?: string;
+	/** Stable per-conversation session id for OpenCode Go/Zen routing headers. */
+	opencodeSessionId?: string;
 }
 
 export interface OpenAIRequestSetup {
@@ -313,6 +316,16 @@ export function resolveOpenAIRequestSetup(
 	}
 	if (options.promptCacheSessionId && model.compat?.promptCacheSessionHeader) {
 		setHeaderIfAbsent(headers, model.compat.promptCacheSessionHeader, options.promptCacheSessionId);
+	}
+	// OpenCode Go/Zen require a stable per-conversation `x-opencode-session` on
+	// inference requests and error header-less callers; `x-opencode-client`
+	// attributes the request for upstream stats. Defaults only — explicit
+	// user/config headers of the same name already sit in `headers` and win.
+	if (model.provider === "opencode-go" || model.provider === "opencode-zen") {
+		const routing = opencodeRoutingHeaders(options.opencodeSessionId);
+		for (const name in routing) {
+			setHeaderIfAbsent(headers, name, routing[name]);
+		}
 	}
 
 	if (options.defaultBaseUrl !== undefined) {

--- a/packages/ai/src/providers/openai-shared.ts
+++ b/packages/ai/src/providers/openai-shared.ts
@@ -21,7 +21,7 @@ import {
 	removeBlankCoreWeaveProjectHeaders,
 } from "@oh-my-pi/pi-catalog/wire/coreweave";
 import { parseGitHubCopilotApiKey } from "@oh-my-pi/pi-catalog/wire/github-copilot";
-import { opencodeRoutingHeaders } from "@oh-my-pi/pi-catalog/wire/opencode";
+import { isOpenCodeProvider, opencodeRoutingHeaders } from "@oh-my-pi/pi-catalog/wire/opencode";
 import {
 	$env,
 	classifyJsonPrefix,
@@ -321,7 +321,7 @@ export function resolveOpenAIRequestSetup(
 	// inference requests and error header-less callers; `x-opencode-client`
 	// attributes the request for upstream stats. Defaults only — explicit
 	// user/config headers of the same name already sit in `headers` and win.
-	if (model.provider === "opencode-go" || model.provider === "opencode-zen") {
+	if (isOpenCodeProvider(model.provider)) {
 		const routing = opencodeRoutingHeaders(options.opencodeSessionId);
 		for (const name in routing) {
 			setHeaderIfAbsent(headers, name, routing[name]);

--- a/packages/ai/test/issue-10653-repro.test.ts
+++ b/packages/ai/test/issue-10653-repro.test.ts
@@ -6,14 +6,16 @@
  * notice: enforced starting 2026-09). Because the header-less caller is OMP's
  * own outbound request layer, users cannot add it on their side.
  *
- * Root cause: neither the OpenAI-family request setup
- * (`resolveOpenAIRequestSetup`) nor the Anthropic client builder
- * (`buildAnthropicClientOptions`) attached OpenCode routing headers. The fix
- * sends `x-opencode-session: <sessionId>` and `x-opencode-client: omp` as
- * defaults on both transports, with explicit user/config `headers` winning.
+ * Root cause: the OpenAI-family request setup
+ * (`resolveOpenAIRequestSetup`), Anthropic client builder
+ * (`buildAnthropicClientOptions`), and Google transport (`streamGoogle`) did
+ * not attach OpenCode routing headers. The fix sends `x-opencode-session:
+ * <sessionId>` and `x-opencode-client: omp` as defaults on every transport,
+ * with explicit user/config `headers` winning.
  */
 import { describe, expect, it } from "bun:test";
 import { streamAnthropic } from "@oh-my-pi/pi-ai/providers/anthropic";
+import { streamGoogle } from "@oh-my-pi/pi-ai/providers/google";
 import { streamOpenAICompletions } from "@oh-my-pi/pi-ai/providers/openai-completions";
 import { streamOpenAIResponses } from "@oh-my-pi/pi-ai/providers/openai-responses";
 import type { Context, Model, ModelSpec } from "@oh-my-pi/pi-ai/types";
@@ -44,6 +46,19 @@ const ZEN_ANTHROPIC_MODEL: Model<"anthropic-messages"> = buildModel({
 	contextWindow: 200_000,
 	maxTokens: 8_192,
 } as ModelSpec<"anthropic-messages">);
+
+const ZEN_GOOGLE_MODEL: Model<"google-generative-ai"> = buildModel({
+	id: "gemini-3-pro-preview",
+	name: "Gemini 3 Pro Preview",
+	api: "google-generative-ai",
+	provider: "opencode-zen",
+	baseUrl: "https://opencode.ai/zen/v1",
+	reasoning: false,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 1_000_000,
+	maxTokens: 65_536,
+} as ModelSpec<"google-generative-ai">);
 
 const GO_RESPONSES_MODEL: Model<"openai-responses"> = buildModel({
 	id: "deepseek-v4-flash",
@@ -117,6 +132,41 @@ describe("issue #10653 — OpenCode routing headers", () => {
 
 		expect(captured?.get("x-opencode-session")).toBe("conv-resp-456");
 		expect(captured?.get("x-opencode-client")).toBe("omp");
+	});
+
+	it("attaches x-opencode-session + x-opencode-client on opencode-zen Google requests", async () => {
+		let captured: Headers | undefined;
+		const fetchMock = (async (_input: string | URL | Request, init?: RequestInit) => {
+			captured = new Headers(init?.headers);
+			return stubJson(400);
+		}) as typeof fetch;
+
+		await streamGoogle(ZEN_GOOGLE_MODEL, CONTEXT, {
+			apiKey: "sk-zen-test",
+			sessionId: "conv-google-789",
+			fetch: fetchMock,
+		}).result();
+
+		expect(captured?.get("x-opencode-session")).toBe("conv-google-789");
+		expect(captured?.get("x-opencode-client")).toBe("omp");
+	});
+
+	it("lets explicit Google headers override OpenCode routing defaults", async () => {
+		let captured: Headers | undefined;
+		const fetchMock = (async (_input: string | URL | Request, init?: RequestInit) => {
+			captured = new Headers(init?.headers);
+			return stubJson(400);
+		}) as typeof fetch;
+
+		await streamGoogle(ZEN_GOOGLE_MODEL, CONTEXT, {
+			apiKey: "sk-zen-test",
+			sessionId: "conv-google-789",
+			headers: { "x-opencode-client": "pi", "x-opencode-session": "user-google" },
+			fetch: fetchMock,
+		}).result();
+
+		expect(captured?.get("x-opencode-client")).toBe("pi");
+		expect(captured?.get("x-opencode-session")).toBe("user-google");
 	});
 
 	it("lets an explicit user header override the default x-opencode-client", async () => {

--- a/packages/ai/test/issue-10653-repro.test.ts
+++ b/packages/ai/test/issue-10653-repro.test.ts
@@ -186,4 +186,25 @@ describe("issue #10653 — OpenCode routing headers", () => {
 		expect(captured?.get("x-opencode-client")).toBe("pi");
 		expect(captured?.get("x-opencode-session")).toBe("user-pinned");
 	});
+
+	it("still sends a non-empty x-opencode-session when the caller omits sessionId", async () => {
+		const capture = async () => {
+			let captured: Headers | undefined;
+			const fetchMock = (async (_input: string | URL | Request, init?: RequestInit) => {
+				captured = new Headers(init?.headers);
+				return stubJson(400);
+			}) as typeof fetch;
+			await streamOpenAICompletions(GO_OPENAI_MODEL, CONTEXT, { apiKey: "sk-go-test", fetch: fetchMock }).result();
+			return captured;
+		};
+
+		const first = await capture();
+		const second = await capture();
+		const fallback = first?.get("x-opencode-session");
+		expect(fallback).toBeTruthy();
+		expect(first?.get("x-opencode-client")).toBe("omp");
+		// The fallback identity is process-stable so a session-less caller's
+		// turns route as one conversation.
+		expect(second?.get("x-opencode-session")).toBe(fallback);
+	});
 });

--- a/packages/ai/test/issue-10653-repro.test.ts
+++ b/packages/ai/test/issue-10653-repro.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Repro for #10653 — OMP sends no `x-opencode-session` / `x-opencode-client`
+ * header on inference requests to `opencode-go` / `opencode-zen`. OpenCode's
+ * gateway (`opencode.ai/zen`) now requires a stable per-conversation
+ * `x-opencode-session` for routing and errors header-less requests (operator
+ * notice: enforced starting 2026-09). Because the header-less caller is OMP's
+ * own outbound request layer, users cannot add it on their side.
+ *
+ * Root cause: neither the OpenAI-family request setup
+ * (`resolveOpenAIRequestSetup`) nor the Anthropic client builder
+ * (`buildAnthropicClientOptions`) attached OpenCode routing headers. The fix
+ * sends `x-opencode-session: <sessionId>` and `x-opencode-client: omp` as
+ * defaults on both transports, with explicit user/config `headers` winning.
+ */
+import { describe, expect, it } from "bun:test";
+import { streamAnthropic } from "@oh-my-pi/pi-ai/providers/anthropic";
+import { streamOpenAICompletions } from "@oh-my-pi/pi-ai/providers/openai-completions";
+import { streamOpenAIResponses } from "@oh-my-pi/pi-ai/providers/openai-responses";
+import type { Context, Model, ModelSpec } from "@oh-my-pi/pi-ai/types";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+
+const GO_OPENAI_MODEL: Model<"openai-completions"> = buildModel({
+	id: "kimi-k2.7-code",
+	name: "Kimi K2.7 Code",
+	api: "openai-completions",
+	provider: "opencode-go",
+	baseUrl: "https://opencode.ai/zen/go/v1",
+	reasoning: false,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 256_000,
+	maxTokens: 16_384,
+} as ModelSpec<"openai-completions">);
+
+const ZEN_ANTHROPIC_MODEL: Model<"anthropic-messages"> = buildModel({
+	id: "claude-haiku-4-5",
+	name: "Claude Haiku 4.5",
+	api: "anthropic-messages",
+	provider: "opencode-zen",
+	baseUrl: "https://opencode.ai/zen/v1",
+	reasoning: false,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 200_000,
+	maxTokens: 8_192,
+} as ModelSpec<"anthropic-messages">);
+
+const GO_RESPONSES_MODEL: Model<"openai-responses"> = buildModel({
+	id: "deepseek-v4-flash",
+	name: "DeepSeek V4 Flash",
+	api: "openai-responses",
+	provider: "opencode-go",
+	baseUrl: "https://opencode.ai/zen/go/v1",
+	reasoning: false,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 128_000,
+	maxTokens: 8_192,
+} as ModelSpec<"openai-responses">);
+
+const CONTEXT: Context = { systemPrompt: [], messages: [{ role: "user", content: "hi", timestamp: 0 }] };
+
+function stubJson(status: number): Response {
+	return new Response(JSON.stringify({ error: { type: "captured", message: "captured" } }), {
+		status,
+		headers: { "Content-Type": "application/json" },
+	});
+}
+
+describe("issue #10653 — OpenCode routing headers", () => {
+	it("attaches x-opencode-session + x-opencode-client on opencode-go OpenAI requests", async () => {
+		let captured: Headers | undefined;
+		const fetchMock = (async (_input: string | URL | Request, init?: RequestInit) => {
+			captured = new Headers(init?.headers);
+			return stubJson(400);
+		}) as typeof fetch;
+
+		await streamOpenAICompletions(GO_OPENAI_MODEL, CONTEXT, {
+			apiKey: "sk-go-test",
+			sessionId: "conv-abc-123",
+			fetch: fetchMock,
+		}).result();
+
+		expect(captured?.get("x-opencode-session")).toBe("conv-abc-123");
+		expect(captured?.get("x-opencode-client")).toBe("omp");
+	});
+
+	it("attaches x-opencode-session + x-opencode-client on opencode-zen Anthropic requests", async () => {
+		let captured: Headers | undefined;
+		const fetchMock = (async (_input: string | URL | Request, init?: RequestInit) => {
+			captured = new Headers(init?.headers);
+			return stubJson(400);
+		}) as typeof fetch;
+
+		await streamAnthropic(ZEN_ANTHROPIC_MODEL, CONTEXT, {
+			apiKey: "sk-zen-test",
+			sessionId: "conv-xyz-789",
+			fetch: fetchMock,
+		}).result();
+
+		expect(captured?.get("x-opencode-session")).toBe("conv-xyz-789");
+		expect(captured?.get("x-opencode-client")).toBe("omp");
+	});
+
+	it("attaches x-opencode-session + x-opencode-client on opencode-go Responses requests", async () => {
+		let captured: Headers | undefined;
+		const fetchMock = (async (_input: string | URL | Request, init?: RequestInit) => {
+			captured = new Headers(init?.headers);
+			return stubJson(400);
+		}) as typeof fetch;
+
+		await streamOpenAIResponses(GO_RESPONSES_MODEL, CONTEXT, {
+			apiKey: "sk-go-test",
+			sessionId: "conv-resp-456",
+			fetch: fetchMock,
+		}).result();
+
+		expect(captured?.get("x-opencode-session")).toBe("conv-resp-456");
+		expect(captured?.get("x-opencode-client")).toBe("omp");
+	});
+
+	it("lets an explicit user header override the default x-opencode-client", async () => {
+		let captured: Headers | undefined;
+		const fetchMock = (async (_input: string | URL | Request, init?: RequestInit) => {
+			captured = new Headers(init?.headers);
+			return stubJson(400);
+		}) as typeof fetch;
+
+		await streamOpenAICompletions(GO_OPENAI_MODEL, CONTEXT, {
+			apiKey: "sk-go-test",
+			sessionId: "conv-abc-123",
+			headers: { "x-opencode-client": "pi", "x-opencode-session": "user-pinned" },
+			fetch: fetchMock,
+		}).result();
+
+		expect(captured?.get("x-opencode-client")).toBe("pi");
+		expect(captured?.get("x-opencode-session")).toBe("user-pinned");
+	});
+});

--- a/packages/catalog/src/compat/axes.ts
+++ b/packages/catalog/src/compat/axes.ts
@@ -223,6 +223,7 @@ export const AXES: Readonly<Record<string, AxisDef>> = {
 	"supports-function-part-id": wire("supportsFunctionPartId", ["google"]),
 
 	// ── wire: shared across surfaces ──
+	"requires-opencode-routing-headers": wire("requiresOpenCodeRoutingHeaders", [...OAI, "anthropic", "google"]),
 	"stream-first-event-timeout-ms": wire("streamFirstEventTimeoutMs", [...OAI, "google"]),
 	"stream-idle-timeout-ms": wire("streamIdleTimeoutMs", [...OAI, "anthropic", "bedrock", "google"]),
 	"strip-image-input": wire("stripImageInput", [...OAI, "anthropic", "google"]),

--- a/packages/catalog/src/compat/rules.json
+++ b/packages/catalog/src/compat/rules.json
@@ -11068,7 +11068,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:15",
+				"source": "providers/opencode-go.kdl:17",
 				"class": "deepseek",
 				"providers": [
 					"opencode-go"
@@ -11079,7 +11079,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:13",
+				"source": "providers/opencode-go.kdl:15",
 				"class": "deepseek",
 				"providers": [
 					"opencode-go"
@@ -11089,7 +11089,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:20",
+				"source": "providers/opencode-go.kdl:22",
 				"providers": [
 					"opencode-go"
 				],
@@ -11104,7 +11104,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:26",
+				"source": "providers/opencode-go.kdl:28",
 				"providers": [
 					"opencode-go"
 				],
@@ -11126,7 +11126,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:32",
+				"source": "providers/opencode-go.kdl:34",
 				"class": "glm",
 				"providers": [
 					"opencode-go"
@@ -11136,7 +11136,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:35",
+				"source": "providers/opencode-go.kdl:37",
 				"class": "kimi",
 				"providers": [
 					"opencode-go"
@@ -11146,7 +11146,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:39",
+				"source": "providers/opencode-go.kdl:41",
 				"class": "mimo",
 				"providers": [
 					"opencode-go"
@@ -11157,7 +11157,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:38",
+				"source": "providers/opencode-go.kdl:40",
 				"class": "mimo",
 				"providers": [
 					"opencode-go"
@@ -11167,7 +11167,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:46",
+				"source": "providers/opencode-go.kdl:48",
 				"class": "qwen",
 				"providers": [
 					"opencode-go"
@@ -11193,7 +11193,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:50",
+				"source": "providers/opencode-go.kdl:52",
 				"class": "qwen",
 				"providers": [
 					"opencode-go"
@@ -11219,7 +11219,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:56",
+				"source": "providers/opencode-go.kdl:58",
 				"providers": [
 					"opencode-go"
 				],
@@ -11244,7 +11244,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:61",
+				"source": "providers/opencode-go.kdl:63",
 				"providers": [
 					"opencode-go"
 				],
@@ -11264,7 +11264,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:66",
+				"source": "providers/opencode-go.kdl:68",
 				"providers": [
 					"opencode-go"
 				],
@@ -11286,7 +11286,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:71",
+				"source": "providers/opencode-go.kdl:73",
 				"providers": [
 					"opencode-go"
 				],
@@ -11307,7 +11307,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:75",
+				"source": "providers/opencode-go.kdl:77",
 				"providers": [
 					"opencode-go"
 				],
@@ -11334,7 +11334,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:79",
+				"source": "providers/opencode-go.kdl:81",
 				"providers": [
 					"opencode-go"
 				],
@@ -11356,7 +11356,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:84",
+				"source": "providers/opencode-go.kdl:86",
 				"providers": [
 					"opencode-go"
 				],
@@ -11371,7 +11371,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-go.kdl:88",
+				"source": "providers/opencode-go.kdl:90",
 				"providers": [
 					"opencode-go"
 				],
@@ -11396,6 +11396,7 @@
 					"opencode-go"
 				],
 				"wire": {
+					"requiresOpenCodeRoutingHeaders": true,
 					"whenThinking": {
 						"requiresReasoningContentForToolCalls": true,
 						"allowsSyntheticReasoningContentForToolCalls": false,
@@ -11407,7 +11408,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-zen.kdl:16",
+				"source": "providers/opencode-zen.kdl:18",
 				"class": "anthropic",
 				"providers": [
 					"opencode-zen"
@@ -11433,7 +11434,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-zen.kdl:20",
+				"source": "providers/opencode-zen.kdl:22",
 				"class": "deepseek",
 				"providers": [
 					"opencode-zen"
@@ -11443,7 +11444,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-zen.kdl:23",
+				"source": "providers/opencode-zen.kdl:25",
 				"class": "glm",
 				"providers": [
 					"opencode-zen"
@@ -11453,7 +11454,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-zen.kdl:26",
+				"source": "providers/opencode-zen.kdl:28",
 				"class": "kimi",
 				"providers": [
 					"opencode-zen"
@@ -11463,7 +11464,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-zen.kdl:30",
+				"source": "providers/opencode-zen.kdl:32",
 				"class": "mimo",
 				"providers": [
 					"opencode-zen"
@@ -11474,7 +11475,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-zen.kdl:35",
+				"source": "providers/opencode-zen.kdl:37",
 				"class": "minimax",
 				"providers": [
 					"opencode-zen"
@@ -11485,7 +11486,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-zen.kdl:40",
+				"source": "providers/opencode-zen.kdl:42",
 				"class": "openai",
 				"providers": [
 					"opencode-zen"
@@ -11505,7 +11506,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-zen.kdl:44",
+				"source": "providers/opencode-zen.kdl:46",
 				"class": "unknown",
 				"providers": [
 					"opencode-zen"
@@ -11515,7 +11516,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-zen.kdl:48",
+				"source": "providers/opencode-zen.kdl:50",
 				"class": "xai",
 				"providers": [
 					"opencode-zen"
@@ -11526,7 +11527,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-zen.kdl:53",
+				"source": "providers/opencode-zen.kdl:55",
 				"providers": [
 					"opencode-zen"
 				],
@@ -11548,7 +11549,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-zen.kdl:58",
+				"source": "providers/opencode-zen.kdl:60",
 				"providers": [
 					"opencode-zen"
 				],
@@ -11566,7 +11567,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-zen.kdl:62",
+				"source": "providers/opencode-zen.kdl:64",
 				"providers": [
 					"opencode-zen"
 				],
@@ -11623,7 +11624,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-zen.kdl:67",
+				"source": "providers/opencode-zen.kdl:69",
 				"providers": [
 					"opencode-zen"
 				],
@@ -11644,7 +11645,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-zen.kdl:71",
+				"source": "providers/opencode-zen.kdl:73",
 				"providers": [
 					"opencode-zen"
 				],
@@ -11668,7 +11669,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-zen.kdl:75",
+				"source": "providers/opencode-zen.kdl:77",
 				"providers": [
 					"opencode-zen"
 				],
@@ -11686,7 +11687,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-zen.kdl:79",
+				"source": "providers/opencode-zen.kdl:81",
 				"providers": [
 					"opencode-zen"
 				],
@@ -11709,7 +11710,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-zen.kdl:84",
+				"source": "providers/opencode-zen.kdl:86",
 				"providers": [
 					"opencode-zen"
 				],
@@ -11733,7 +11734,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-zen.kdl:89",
+				"source": "providers/opencode-zen.kdl:91",
 				"providers": [
 					"opencode-zen"
 				],
@@ -11753,7 +11754,7 @@
 				}
 			},
 			{
-				"source": "providers/opencode-zen.kdl:99",
+				"source": "providers/opencode-zen.kdl:101",
 				"providers": [
 					"opencode-zen"
 				],
@@ -11779,6 +11780,7 @@
 					"opencode-zen"
 				],
 				"wire": {
+					"requiresOpenCodeRoutingHeaders": true,
 					"whenThinking": {
 						"requiresReasoningContentForToolCalls": true,
 						"allowsSyntheticReasoningContentForToolCalls": false,

--- a/packages/catalog/src/compat/rules/providers/opencode-go.kdl
+++ b/packages/catalog/src/compat/rules/providers/opencode-go.kdl
@@ -1,6 +1,8 @@
 // Provider-wire compat for "opencode-go"; regenerated from the frozen census using deployment contract selectors.
 
 provider "opencode-go" {
+	// OpenCode requires stable routing identity on every inference transport.
+	requires-opencode-routing-headers #true
 	// Replaces the OpenCode reasoning-model whenThinking fallback object.
 	when-thinking {
 		requires-reasoning-content-for-tool-calls #true

--- a/packages/catalog/src/compat/rules/providers/opencode-zen.kdl
+++ b/packages/catalog/src/compat/rules/providers/opencode-zen.kdl
@@ -1,6 +1,8 @@
 // Provider-wire compat for "opencode-zen"; regenerated from the frozen census using deployment contract selectors.
 
 provider "opencode-zen" {
+	// OpenCode requires stable routing identity on every inference transport.
+	requires-opencode-routing-headers #true
 	// Replaces the OpenCode reasoning-model whenThinking fallback object.
 	// Applies to every completions-routed reasoning model, discovered ids
 	// included; the engine drops whenThinking for non-reasoning specs.

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -258647,7 +258647,8 @@
 				"streamMarkupHealingPattern": "dsml",
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
-				"usesOpenAIToolCallIdLimit": false
+				"usesOpenAIToolCallIdLimit": false,
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"deepseek-v4-flash-vision-exp": {
@@ -258791,8 +258792,10 @@
 					"thinkingLoopGuard": "deepseek",
 					"rejectRootObjectUnion": false,
 					"retryWithoutStrictOnGrammarError": false,
-					"supportsPromptCacheKey": false
-				}
+					"supportsPromptCacheKey": false,
+					"requiresOpenCodeRoutingHeaders": true
+				},
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"deepseek-v4-pro": {
@@ -258935,8 +258938,10 @@
 					"thinkingLoopGuard": "deepseek",
 					"rejectRootObjectUnion": false,
 					"retryWithoutStrictOnGrammarError": false,
-					"supportsPromptCacheKey": false
-				}
+					"supportsPromptCacheKey": false,
+					"requiresOpenCodeRoutingHeaders": true
+				},
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"glm-5": {
@@ -259080,8 +259085,10 @@
 					"stripImageInput": false,
 					"rejectRootObjectUnion": false,
 					"retryWithoutStrictOnGrammarError": false,
-					"supportsPromptCacheKey": false
-				}
+					"supportsPromptCacheKey": false,
+					"requiresOpenCodeRoutingHeaders": true
+				},
+				"requiresOpenCodeRoutingHeaders": true
 			},
 			"supportsComputerUse": false
 		},
@@ -259227,8 +259234,10 @@
 					"stripImageInput": false,
 					"rejectRootObjectUnion": false,
 					"retryWithoutStrictOnGrammarError": false,
-					"supportsPromptCacheKey": false
-				}
+					"supportsPromptCacheKey": false,
+					"requiresOpenCodeRoutingHeaders": true
+				},
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"glm-5.2": {
@@ -259373,8 +259382,10 @@
 					"stripImageInput": false,
 					"rejectRootObjectUnion": false,
 					"retryWithoutStrictOnGrammarError": false,
-					"supportsPromptCacheKey": false
-				}
+					"supportsPromptCacheKey": false,
+					"requiresOpenCodeRoutingHeaders": true
+				},
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"glm-5.3": {
@@ -259519,8 +259530,10 @@
 					"stripImageInput": false,
 					"rejectRootObjectUnion": false,
 					"retryWithoutStrictOnGrammarError": false,
-					"supportsPromptCacheKey": false
-				}
+					"supportsPromptCacheKey": false,
+					"requiresOpenCodeRoutingHeaders": true
+				},
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"glm-5.3-flash": {
@@ -259667,8 +259680,10 @@
 					"stripImageInput": false,
 					"rejectRootObjectUnion": false,
 					"retryWithoutStrictOnGrammarError": false,
-					"supportsPromptCacheKey": false
-				}
+					"supportsPromptCacheKey": false,
+					"requiresOpenCodeRoutingHeaders": true
+				},
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"gpt-5.6-luna": {
@@ -259758,7 +259773,8 @@
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
-				"usesOpenAIToolCallIdLimit": false
+				"usesOpenAIToolCallIdLimit": false,
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"grok-4.5": {
@@ -259848,7 +259864,8 @@
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
-				"usesOpenAIToolCallIdLimit": false
+				"usesOpenAIToolCallIdLimit": false,
+				"requiresOpenCodeRoutingHeaders": true
 			},
 			"supportsComputerUse": false
 		},
@@ -259940,7 +259957,8 @@
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
-				"usesOpenAIToolCallIdLimit": false
+				"usesOpenAIToolCallIdLimit": false,
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"hy3": {
@@ -260081,8 +260099,10 @@
 					"stripImageInput": false,
 					"rejectRootObjectUnion": false,
 					"retryWithoutStrictOnGrammarError": false,
-					"supportsPromptCacheKey": false
-				}
+					"supportsPromptCacheKey": false,
+					"requiresOpenCodeRoutingHeaders": true
+				},
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"hy4-preview": {
@@ -260223,8 +260243,10 @@
 					"stripImageInput": false,
 					"rejectRootObjectUnion": false,
 					"retryWithoutStrictOnGrammarError": false,
-					"supportsPromptCacheKey": false
-				}
+					"supportsPromptCacheKey": false,
+					"requiresOpenCodeRoutingHeaders": true
+				},
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"kimi-k2.5": {
@@ -260369,8 +260391,10 @@
 					"stripImageInput": false,
 					"rejectRootObjectUnion": false,
 					"retryWithoutStrictOnGrammarError": false,
-					"supportsPromptCacheKey": false
-				}
+					"supportsPromptCacheKey": false,
+					"requiresOpenCodeRoutingHeaders": true
+				},
+				"requiresOpenCodeRoutingHeaders": true
 			},
 			"supportsComputerUse": false
 		},
@@ -260519,8 +260543,10 @@
 					"stripImageInput": false,
 					"rejectRootObjectUnion": false,
 					"retryWithoutStrictOnGrammarError": false,
-					"supportsPromptCacheKey": false
-				}
+					"supportsPromptCacheKey": false,
+					"requiresOpenCodeRoutingHeaders": true
+				},
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"kimi-k2.7-code": {
@@ -260666,8 +260692,10 @@
 					"stripImageInput": false,
 					"rejectRootObjectUnion": false,
 					"retryWithoutStrictOnGrammarError": false,
-					"supportsPromptCacheKey": false
-				}
+					"supportsPromptCacheKey": false,
+					"requiresOpenCodeRoutingHeaders": true
+				},
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"kimi-k3": {
@@ -260826,8 +260854,10 @@
 					"stripImageInput": false,
 					"rejectRootObjectUnion": false,
 					"retryWithoutStrictOnGrammarError": false,
-					"supportsPromptCacheKey": false
-				}
+					"supportsPromptCacheKey": false,
+					"requiresOpenCodeRoutingHeaders": true
+				},
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"longcat-2.0": {
@@ -260968,8 +260998,10 @@
 					"stripImageInput": false,
 					"rejectRootObjectUnion": false,
 					"retryWithoutStrictOnGrammarError": false,
-					"supportsPromptCacheKey": false
-				}
+					"supportsPromptCacheKey": false,
+					"requiresOpenCodeRoutingHeaders": true
+				},
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"mimo-v2-omni": {
@@ -261115,8 +261147,10 @@
 					"stripImageInput": false,
 					"rejectRootObjectUnion": false,
 					"retryWithoutStrictOnGrammarError": false,
-					"supportsPromptCacheKey": false
-				}
+					"supportsPromptCacheKey": false,
+					"requiresOpenCodeRoutingHeaders": true
+				},
+				"requiresOpenCodeRoutingHeaders": true
 			},
 			"supportsComputerUse": false,
 			"compatConfig": {
@@ -261265,8 +261299,10 @@
 					"stripImageInput": false,
 					"rejectRootObjectUnion": false,
 					"retryWithoutStrictOnGrammarError": false,
-					"supportsPromptCacheKey": false
-				}
+					"supportsPromptCacheKey": false,
+					"requiresOpenCodeRoutingHeaders": true
+				},
+				"requiresOpenCodeRoutingHeaders": true
 			},
 			"supportsComputerUse": false,
 			"compatConfig": {
@@ -261417,8 +261453,10 @@
 					"stripImageInput": false,
 					"rejectRootObjectUnion": false,
 					"retryWithoutStrictOnGrammarError": false,
-					"supportsPromptCacheKey": false
-				}
+					"supportsPromptCacheKey": false,
+					"requiresOpenCodeRoutingHeaders": true
+				},
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"mimo-v2.5-pro": {
@@ -261564,8 +261602,10 @@
 					"stripImageInput": false,
 					"rejectRootObjectUnion": false,
 					"retryWithoutStrictOnGrammarError": false,
-					"supportsPromptCacheKey": false
-				}
+					"supportsPromptCacheKey": false,
+					"requiresOpenCodeRoutingHeaders": true
+				},
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"minimax-m2.5": {
@@ -261627,7 +261667,8 @@
 				"replayUnsignedThinking": true,
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
-				"stripImageInput": false
+				"stripImageInput": false,
+				"requiresOpenCodeRoutingHeaders": true
 			},
 			"supportsComputerUse": false
 		},
@@ -261769,8 +261810,10 @@
 					"stripImageInput": false,
 					"rejectRootObjectUnion": false,
 					"retryWithoutStrictOnGrammarError": false,
-					"supportsPromptCacheKey": false
-				}
+					"supportsPromptCacheKey": false,
+					"requiresOpenCodeRoutingHeaders": true
+				},
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"minimax-m3": {
@@ -261913,8 +261956,10 @@
 					"stripImageInput": false,
 					"rejectRootObjectUnion": false,
 					"retryWithoutStrictOnGrammarError": false,
-					"supportsPromptCacheKey": false
-				}
+					"supportsPromptCacheKey": false,
+					"requiresOpenCodeRoutingHeaders": true
+				},
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"muse-spark-1.2-contributor": {
@@ -262004,7 +262049,8 @@
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
-				"usesOpenAIToolCallIdLimit": false
+				"usesOpenAIToolCallIdLimit": false,
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"muse-spark-1.3-contributor": {
@@ -262094,7 +262140,8 @@
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
-				"usesOpenAIToolCallIdLimit": false
+				"usesOpenAIToolCallIdLimit": false,
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"ox-alpha-free": {
@@ -262234,8 +262281,10 @@
 					"stripImageInput": false,
 					"rejectRootObjectUnion": false,
 					"retryWithoutStrictOnGrammarError": false,
-					"supportsPromptCacheKey": false
-				}
+					"supportsPromptCacheKey": false,
+					"requiresOpenCodeRoutingHeaders": true
+				},
+				"requiresOpenCodeRoutingHeaders": true
 			},
 			"supportsComputerUse": false
 		},
@@ -262378,8 +262427,10 @@
 					"stripImageInput": false,
 					"rejectRootObjectUnion": false,
 					"retryWithoutStrictOnGrammarError": false,
-					"supportsPromptCacheKey": false
-				}
+					"supportsPromptCacheKey": false,
+					"requiresOpenCodeRoutingHeaders": true
+				},
+				"requiresOpenCodeRoutingHeaders": true
 			},
 			"supportsComputerUse": false
 		},
@@ -262523,8 +262574,10 @@
 					"stripImageInput": false,
 					"rejectRootObjectUnion": false,
 					"retryWithoutStrictOnGrammarError": false,
-					"supportsPromptCacheKey": false
-				}
+					"supportsPromptCacheKey": false,
+					"requiresOpenCodeRoutingHeaders": true
+				},
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"qwen3.7-max": {
@@ -262666,8 +262719,10 @@
 					"stripImageInput": false,
 					"rejectRootObjectUnion": false,
 					"retryWithoutStrictOnGrammarError": false,
-					"supportsPromptCacheKey": false
-				}
+					"supportsPromptCacheKey": false,
+					"requiresOpenCodeRoutingHeaders": true
+				},
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"qwen3.7-plus": {
@@ -262810,8 +262865,10 @@
 					"stripImageInput": false,
 					"rejectRootObjectUnion": false,
 					"retryWithoutStrictOnGrammarError": false,
-					"supportsPromptCacheKey": false
-				}
+					"supportsPromptCacheKey": false,
+					"requiresOpenCodeRoutingHeaders": true
+				},
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"qwen3.8-flash": {
@@ -262872,7 +262929,8 @@
 				"replayUnsignedThinking": true,
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
-				"stripImageInput": false
+				"stripImageInput": false,
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"qwen3.8-max": {
@@ -263015,8 +263073,10 @@
 					"stripImageInput": false,
 					"rejectRootObjectUnion": false,
 					"retryWithoutStrictOnGrammarError": false,
-					"supportsPromptCacheKey": false
-				}
+					"supportsPromptCacheKey": false,
+					"requiresOpenCodeRoutingHeaders": true
+				},
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		}
 	},
@@ -263158,8 +263218,10 @@
 					"thinkingLoopGuard": "deepseek",
 					"rejectRootObjectUnion": false,
 					"retryWithoutStrictOnGrammarError": false,
-					"supportsPromptCacheKey": false
-				}
+					"supportsPromptCacheKey": false,
+					"requiresOpenCodeRoutingHeaders": true
+				},
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"claude-3-5-haiku": {
@@ -263210,7 +263272,8 @@
 				"replayUnsignedThinking": false,
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": false,
-				"stripImageInput": false
+				"stripImageInput": false,
+				"requiresOpenCodeRoutingHeaders": true
 			},
 			"supportsComputerUse": false
 		},
@@ -263274,7 +263337,8 @@
 				"replayUnsignedThinking": true,
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
-				"stripImageInput": false
+				"stripImageInput": false,
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"claude-fable-5-1": {
@@ -263338,7 +263402,8 @@
 				"replayUnsignedThinking": true,
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
-				"stripImageInput": false
+				"stripImageInput": false,
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"claude-haiku-4-5": {
@@ -263400,7 +263465,8 @@
 				"replayUnsignedThinking": true,
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
-				"stripImageInput": false
+				"stripImageInput": false,
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"claude-opus-4-1": {
@@ -263461,7 +263527,8 @@
 				"replayUnsignedThinking": true,
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
-				"stripImageInput": false
+				"stripImageInput": false,
+				"requiresOpenCodeRoutingHeaders": true
 			},
 			"supportsComputerUse": false
 		},
@@ -263524,7 +263591,8 @@
 				"replayUnsignedThinking": true,
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
-				"stripImageInput": false
+				"stripImageInput": false,
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"claude-opus-4-6": {
@@ -263585,7 +263653,8 @@
 				"replayUnsignedThinking": true,
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
-				"stripImageInput": false
+				"stripImageInput": false,
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"claude-opus-4-7": {
@@ -263648,7 +263717,8 @@
 				"replayUnsignedThinking": true,
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
-				"stripImageInput": false
+				"stripImageInput": false,
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"claude-opus-4-8": {
@@ -263711,7 +263781,8 @@
 				"replayUnsignedThinking": true,
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
-				"stripImageInput": false
+				"stripImageInput": false,
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"claude-opus-5": {
@@ -263774,7 +263845,8 @@
 				"replayUnsignedThinking": true,
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
-				"stripImageInput": false
+				"stripImageInput": false,
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"claude-sonnet-4": {
@@ -263836,7 +263908,8 @@
 				"replayUnsignedThinking": true,
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
-				"stripImageInput": false
+				"stripImageInput": false,
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"claude-sonnet-4-5": {
@@ -263898,7 +263971,8 @@
 				"replayUnsignedThinking": true,
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
-				"stripImageInput": false
+				"stripImageInput": false,
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"claude-sonnet-4-6": {
@@ -263958,7 +264032,8 @@
 				"replayUnsignedThinking": true,
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
-				"stripImageInput": false
+				"stripImageInput": false,
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"claude-sonnet-5": {
@@ -264021,7 +264096,8 @@
 				"replayUnsignedThinking": true,
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
-				"stripImageInput": false
+				"stripImageInput": false,
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"deepseek-v4-flash": {
@@ -264164,8 +264240,10 @@
 					"thinkingLoopGuard": "deepseek",
 					"rejectRootObjectUnion": false,
 					"retryWithoutStrictOnGrammarError": false,
-					"supportsPromptCacheKey": false
-				}
+					"supportsPromptCacheKey": false,
+					"requiresOpenCodeRoutingHeaders": true
+				},
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"deepseek-v4-flash-free": {
@@ -264307,8 +264385,10 @@
 					"thinkingLoopGuard": "deepseek",
 					"rejectRootObjectUnion": false,
 					"retryWithoutStrictOnGrammarError": false,
-					"supportsPromptCacheKey": false
-				}
+					"supportsPromptCacheKey": false,
+					"requiresOpenCodeRoutingHeaders": true
+				},
+				"requiresOpenCodeRoutingHeaders": true
 			},
 			"supportsComputerUse": false
 		},
@@ -264452,8 +264532,10 @@
 					"thinkingLoopGuard": "deepseek",
 					"rejectRootObjectUnion": false,
 					"retryWithoutStrictOnGrammarError": false,
-					"supportsPromptCacheKey": false
-				}
+					"supportsPromptCacheKey": false,
+					"requiresOpenCodeRoutingHeaders": true
+				},
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"gemini-3-flash": {
@@ -264503,7 +264585,8 @@
 				"claudeThinkingBetaHeader": false,
 				"antigravityClaudeToolMode": false,
 				"stripImageInput": false,
-				"thinkingLoopGuard": "gemini"
+				"thinkingLoopGuard": "gemini",
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"gemini-3-pro": {
@@ -264550,7 +264633,8 @@
 				"claudeThinkingBetaHeader": false,
 				"antigravityClaudeToolMode": false,
 				"stripImageInput": false,
-				"thinkingLoopGuard": "gemini"
+				"thinkingLoopGuard": "gemini",
+				"requiresOpenCodeRoutingHeaders": true
 			},
 			"supportsComputerUse": false
 		},
@@ -264599,7 +264683,8 @@
 				"claudeThinkingBetaHeader": false,
 				"antigravityClaudeToolMode": false,
 				"stripImageInput": false,
-				"thinkingLoopGuard": "gemini"
+				"thinkingLoopGuard": "gemini",
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"gemini-3.5-flash": {
@@ -264649,7 +264734,8 @@
 				"claudeThinkingBetaHeader": false,
 				"antigravityClaudeToolMode": false,
 				"stripImageInput": false,
-				"thinkingLoopGuard": "gemini"
+				"thinkingLoopGuard": "gemini",
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"gemini-3.5-flash-lite": {
@@ -264699,7 +264785,8 @@
 				"claudeThinkingBetaHeader": false,
 				"antigravityClaudeToolMode": false,
 				"stripImageInput": false,
-				"thinkingLoopGuard": "gemini"
+				"thinkingLoopGuard": "gemini",
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"gemini-3.6-flash": {
@@ -264749,7 +264836,8 @@
 				"claudeThinkingBetaHeader": false,
 				"antigravityClaudeToolMode": false,
 				"stripImageInput": false,
-				"thinkingLoopGuard": "gemini"
+				"thinkingLoopGuard": "gemini",
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"gemini-3.7-flash": {
@@ -264798,7 +264886,8 @@
 				"claudeThinkingBetaHeader": false,
 				"antigravityClaudeToolMode": false,
 				"stripImageInput": false,
-				"thinkingLoopGuard": "gemini"
+				"thinkingLoopGuard": "gemini",
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"gemini-3.8-flash": {
@@ -264848,7 +264937,8 @@
 				"claudeThinkingBetaHeader": false,
 				"antigravityClaudeToolMode": false,
 				"stripImageInput": false,
-				"thinkingLoopGuard": "gemini"
+				"thinkingLoopGuard": "gemini",
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"glm-4.6": {
@@ -264989,8 +265079,10 @@
 					"stripImageInput": false,
 					"rejectRootObjectUnion": false,
 					"retryWithoutStrictOnGrammarError": false,
-					"supportsPromptCacheKey": false
-				}
+					"supportsPromptCacheKey": false,
+					"requiresOpenCodeRoutingHeaders": true
+				},
+				"requiresOpenCodeRoutingHeaders": true
 			},
 			"supportsComputerUse": false
 		},
@@ -265132,8 +265224,10 @@
 					"stripImageInput": false,
 					"rejectRootObjectUnion": false,
 					"retryWithoutStrictOnGrammarError": false,
-					"supportsPromptCacheKey": false
-				}
+					"supportsPromptCacheKey": false,
+					"requiresOpenCodeRoutingHeaders": true
+				},
+				"requiresOpenCodeRoutingHeaders": true
 			},
 			"supportsComputerUse": false
 		},
@@ -265279,8 +265373,10 @@
 					"stripImageInput": false,
 					"rejectRootObjectUnion": false,
 					"retryWithoutStrictOnGrammarError": false,
-					"supportsPromptCacheKey": false
-				}
+					"supportsPromptCacheKey": false,
+					"requiresOpenCodeRoutingHeaders": true
+				},
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"glm-5.1": {
@@ -265425,8 +265521,10 @@
 					"stripImageInput": false,
 					"rejectRootObjectUnion": false,
 					"retryWithoutStrictOnGrammarError": false,
-					"supportsPromptCacheKey": false
-				}
+					"supportsPromptCacheKey": false,
+					"requiresOpenCodeRoutingHeaders": true
+				},
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"glm-5.2": {
@@ -265571,8 +265669,10 @@
 					"stripImageInput": false,
 					"rejectRootObjectUnion": false,
 					"retryWithoutStrictOnGrammarError": false,
-					"supportsPromptCacheKey": false
-				}
+					"supportsPromptCacheKey": false,
+					"requiresOpenCodeRoutingHeaders": true
+				},
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"gpt-5": {
@@ -265661,7 +265761,8 @@
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
-				"usesOpenAIToolCallIdLimit": false
+				"usesOpenAIToolCallIdLimit": false,
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"gpt-5-codex": {
@@ -265750,7 +265851,8 @@
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
-				"usesOpenAIToolCallIdLimit": false
+				"usesOpenAIToolCallIdLimit": false,
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"gpt-5-nano": {
@@ -265839,7 +265941,8 @@
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
-				"usesOpenAIToolCallIdLimit": false
+				"usesOpenAIToolCallIdLimit": false,
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"gpt-5.1": {
@@ -265928,7 +266031,8 @@
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
-				"usesOpenAIToolCallIdLimit": false
+				"usesOpenAIToolCallIdLimit": false,
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"gpt-5.1-codex": {
@@ -266017,7 +266121,8 @@
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
-				"usesOpenAIToolCallIdLimit": false
+				"usesOpenAIToolCallIdLimit": false,
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"gpt-5.1-codex-max": {
@@ -266108,7 +266213,8 @@
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
-				"usesOpenAIToolCallIdLimit": false
+				"usesOpenAIToolCallIdLimit": false,
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"gpt-5.1-codex-mini": {
@@ -266195,7 +266301,8 @@
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
-				"usesOpenAIToolCallIdLimit": false
+				"usesOpenAIToolCallIdLimit": false,
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"gpt-5.2": {
@@ -266284,7 +266391,8 @@
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
-				"usesOpenAIToolCallIdLimit": false
+				"usesOpenAIToolCallIdLimit": false,
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"gpt-5.2-codex": {
@@ -266373,7 +266481,8 @@
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
-				"usesOpenAIToolCallIdLimit": false
+				"usesOpenAIToolCallIdLimit": false,
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"gpt-5.3-codex": {
@@ -266462,7 +266571,8 @@
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
-				"usesOpenAIToolCallIdLimit": false
+				"usesOpenAIToolCallIdLimit": false,
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"gpt-5.3-codex-spark": {
@@ -266551,7 +266661,8 @@
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
-				"usesOpenAIToolCallIdLimit": false
+				"usesOpenAIToolCallIdLimit": false,
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"gpt-5.4": {
@@ -266640,7 +266751,8 @@
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
-				"usesOpenAIToolCallIdLimit": false
+				"usesOpenAIToolCallIdLimit": false,
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"gpt-5.4-mini": {
@@ -266729,7 +266841,8 @@
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
-				"usesOpenAIToolCallIdLimit": false
+				"usesOpenAIToolCallIdLimit": false,
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"gpt-5.4-nano": {
@@ -266818,7 +266931,8 @@
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
-				"usesOpenAIToolCallIdLimit": false
+				"usesOpenAIToolCallIdLimit": false,
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"gpt-5.4-pro": {
@@ -266907,7 +267021,8 @@
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
-				"usesOpenAIToolCallIdLimit": false
+				"usesOpenAIToolCallIdLimit": false,
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"gpt-5.5": {
@@ -266997,7 +267112,8 @@
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
-				"usesOpenAIToolCallIdLimit": false
+				"usesOpenAIToolCallIdLimit": false,
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"gpt-5.5-pro": {
@@ -267087,7 +267203,8 @@
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
-				"usesOpenAIToolCallIdLimit": false
+				"usesOpenAIToolCallIdLimit": false,
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"gpt-5.6-luna": {
@@ -267177,7 +267294,8 @@
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
-				"usesOpenAIToolCallIdLimit": false
+				"usesOpenAIToolCallIdLimit": false,
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"gpt-5.6-sol": {
@@ -267267,7 +267385,8 @@
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
-				"usesOpenAIToolCallIdLimit": false
+				"usesOpenAIToolCallIdLimit": false,
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"gpt-5.6-terra": {
@@ -267357,7 +267476,8 @@
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
-				"usesOpenAIToolCallIdLimit": false
+				"usesOpenAIToolCallIdLimit": false,
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"grok-4.5": {
@@ -267448,7 +267568,8 @@
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
-				"usesOpenAIToolCallIdLimit": false
+				"usesOpenAIToolCallIdLimit": false,
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"grok-4.6": {
@@ -267539,7 +267660,8 @@
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
-				"usesOpenAIToolCallIdLimit": false
+				"usesOpenAIToolCallIdLimit": false,
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"grok-build-0.1": {
@@ -267630,7 +267752,8 @@
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
-				"usesOpenAIToolCallIdLimit": false
+				"usesOpenAIToolCallIdLimit": false,
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"hy3-free": {
@@ -267770,8 +267893,10 @@
 					"stripImageInput": false,
 					"rejectRootObjectUnion": false,
 					"retryWithoutStrictOnGrammarError": false,
-					"supportsPromptCacheKey": false
-				}
+					"supportsPromptCacheKey": false,
+					"requiresOpenCodeRoutingHeaders": true
+				},
+				"requiresOpenCodeRoutingHeaders": true
 			},
 			"supportsComputerUse": false
 		},
@@ -267912,8 +268037,10 @@
 					"stripImageInput": false,
 					"rejectRootObjectUnion": false,
 					"retryWithoutStrictOnGrammarError": false,
-					"supportsPromptCacheKey": false
-				}
+					"supportsPromptCacheKey": false,
+					"requiresOpenCodeRoutingHeaders": true
+				},
+				"requiresOpenCodeRoutingHeaders": true
 			},
 			"supportsComputerUse": false
 		},
@@ -268066,8 +268193,10 @@
 					"stripImageInput": false,
 					"rejectRootObjectUnion": false,
 					"retryWithoutStrictOnGrammarError": false,
-					"supportsPromptCacheKey": false
-				}
+					"supportsPromptCacheKey": false,
+					"requiresOpenCodeRoutingHeaders": true
+				},
+				"requiresOpenCodeRoutingHeaders": true
 			},
 			"supportsComputerUse": false
 		},
@@ -268214,8 +268343,10 @@
 					"stripImageInput": false,
 					"rejectRootObjectUnion": false,
 					"retryWithoutStrictOnGrammarError": false,
-					"supportsPromptCacheKey": false
-				}
+					"supportsPromptCacheKey": false,
+					"requiresOpenCodeRoutingHeaders": true
+				},
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"kimi-k2.6": {
@@ -268363,8 +268494,10 @@
 					"stripImageInput": false,
 					"rejectRootObjectUnion": false,
 					"retryWithoutStrictOnGrammarError": false,
-					"supportsPromptCacheKey": false
-				}
+					"supportsPromptCacheKey": false,
+					"requiresOpenCodeRoutingHeaders": true
+				},
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"kimi-k2.7-code": {
@@ -268510,8 +268643,10 @@
 					"stripImageInput": false,
 					"rejectRootObjectUnion": false,
 					"retryWithoutStrictOnGrammarError": false,
-					"supportsPromptCacheKey": false
-				}
+					"supportsPromptCacheKey": false,
+					"requiresOpenCodeRoutingHeaders": true
+				},
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"kimi-k3": {
@@ -268670,8 +268805,10 @@
 					"stripImageInput": false,
 					"rejectRootObjectUnion": false,
 					"retryWithoutStrictOnGrammarError": false,
-					"supportsPromptCacheKey": false
-				}
+					"supportsPromptCacheKey": false,
+					"requiresOpenCodeRoutingHeaders": true
+				},
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"laguna-s-2.1-free": {
@@ -268811,8 +268948,10 @@
 					"stripImageInput": false,
 					"rejectRootObjectUnion": false,
 					"retryWithoutStrictOnGrammarError": false,
-					"supportsPromptCacheKey": false
-				}
+					"supportsPromptCacheKey": false,
+					"requiresOpenCodeRoutingHeaders": true
+				},
+				"requiresOpenCodeRoutingHeaders": true
 			},
 			"supportsComputerUse": false
 		},
@@ -268890,7 +269029,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"requiresOpenCodeRoutingHeaders": true
 			},
 			"supportsComputerUse": false
 		},
@@ -269032,8 +269172,10 @@
 					"stripImageInput": false,
 					"rejectRootObjectUnion": false,
 					"retryWithoutStrictOnGrammarError": false,
-					"supportsPromptCacheKey": false
-				}
+					"supportsPromptCacheKey": false,
+					"requiresOpenCodeRoutingHeaders": true
+				},
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"ling-3.0-flash-free": {
@@ -269173,8 +269315,10 @@
 					"stripImageInput": false,
 					"rejectRootObjectUnion": false,
 					"retryWithoutStrictOnGrammarError": false,
-					"supportsPromptCacheKey": false
-				}
+					"supportsPromptCacheKey": false,
+					"requiresOpenCodeRoutingHeaders": true
+				},
+				"requiresOpenCodeRoutingHeaders": true
 			},
 			"supportsComputerUse": false
 		},
@@ -269315,8 +269459,10 @@
 					"stripImageInput": false,
 					"rejectRootObjectUnion": false,
 					"retryWithoutStrictOnGrammarError": false,
-					"supportsPromptCacheKey": false
-				}
+					"supportsPromptCacheKey": false,
+					"requiresOpenCodeRoutingHeaders": true
+				},
+				"requiresOpenCodeRoutingHeaders": true
 			},
 			"supportsComputerUse": false
 		},
@@ -269457,8 +269603,10 @@
 					"stripImageInput": false,
 					"rejectRootObjectUnion": false,
 					"retryWithoutStrictOnGrammarError": false,
-					"supportsPromptCacheKey": false
-				}
+					"supportsPromptCacheKey": false,
+					"requiresOpenCodeRoutingHeaders": true
+				},
+				"requiresOpenCodeRoutingHeaders": true
 			},
 			"supportsComputerUse": false
 		},
@@ -269604,8 +269752,10 @@
 					"stripImageInput": false,
 					"rejectRootObjectUnion": false,
 					"retryWithoutStrictOnGrammarError": false,
-					"supportsPromptCacheKey": false
-				}
+					"supportsPromptCacheKey": false,
+					"requiresOpenCodeRoutingHeaders": true
+				},
+				"requiresOpenCodeRoutingHeaders": true
 			},
 			"supportsComputerUse": false
 		},
@@ -269752,8 +269902,10 @@
 					"stripImageInput": false,
 					"rejectRootObjectUnion": false,
 					"retryWithoutStrictOnGrammarError": false,
-					"supportsPromptCacheKey": false
-				}
+					"supportsPromptCacheKey": false,
+					"requiresOpenCodeRoutingHeaders": true
+				},
+				"requiresOpenCodeRoutingHeaders": true
 			},
 			"supportsComputerUse": false
 		},
@@ -269899,8 +270051,10 @@
 					"stripImageInput": false,
 					"rejectRootObjectUnion": false,
 					"retryWithoutStrictOnGrammarError": false,
-					"supportsPromptCacheKey": false
-				}
+					"supportsPromptCacheKey": false,
+					"requiresOpenCodeRoutingHeaders": true
+				},
+				"requiresOpenCodeRoutingHeaders": true
 			},
 			"supportsComputerUse": false
 		},
@@ -270048,8 +270202,10 @@
 					"stripImageInput": false,
 					"rejectRootObjectUnion": false,
 					"retryWithoutStrictOnGrammarError": false,
-					"supportsPromptCacheKey": false
-				}
+					"supportsPromptCacheKey": false,
+					"requiresOpenCodeRoutingHeaders": true
+				},
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"minimax-m2.1": {
@@ -270189,8 +270345,10 @@
 					"stripImageInput": false,
 					"rejectRootObjectUnion": false,
 					"retryWithoutStrictOnGrammarError": false,
-					"supportsPromptCacheKey": false
-				}
+					"supportsPromptCacheKey": false,
+					"requiresOpenCodeRoutingHeaders": true
+				},
+				"requiresOpenCodeRoutingHeaders": true
 			},
 			"supportsComputerUse": false
 		},
@@ -270332,8 +270490,10 @@
 					"stripImageInput": false,
 					"rejectRootObjectUnion": false,
 					"retryWithoutStrictOnGrammarError": false,
-					"supportsPromptCacheKey": false
-				}
+					"supportsPromptCacheKey": false,
+					"requiresOpenCodeRoutingHeaders": true
+				},
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"minimax-m2.5-free": {
@@ -270395,7 +270555,8 @@
 				"replayUnsignedThinking": true,
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
-				"stripImageInput": false
+				"stripImageInput": false,
+				"requiresOpenCodeRoutingHeaders": true
 			},
 			"supportsComputerUse": false
 		},
@@ -270537,8 +270698,10 @@
 					"stripImageInput": false,
 					"rejectRootObjectUnion": false,
 					"retryWithoutStrictOnGrammarError": false,
-					"supportsPromptCacheKey": false
-				}
+					"supportsPromptCacheKey": false,
+					"requiresOpenCodeRoutingHeaders": true
+				},
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"minimax-m3": {
@@ -270681,8 +270844,10 @@
 					"stripImageInput": false,
 					"rejectRootObjectUnion": false,
 					"retryWithoutStrictOnGrammarError": false,
-					"supportsPromptCacheKey": false
-				}
+					"supportsPromptCacheKey": false,
+					"requiresOpenCodeRoutingHeaders": true
+				},
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"minimax-m3-free": {
@@ -270824,8 +270989,10 @@
 					"stripImageInput": false,
 					"rejectRootObjectUnion": false,
 					"retryWithoutStrictOnGrammarError": false,
-					"supportsPromptCacheKey": false
-				}
+					"supportsPromptCacheKey": false,
+					"requiresOpenCodeRoutingHeaders": true
+				},
+				"requiresOpenCodeRoutingHeaders": true
 			},
 			"supportsComputerUse": false
 		},
@@ -270916,7 +271083,8 @@
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
-				"usesOpenAIToolCallIdLimit": false
+				"usesOpenAIToolCallIdLimit": false,
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"muse-spark-1.2-contributor-free": {
@@ -271006,7 +271174,8 @@
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
-				"usesOpenAIToolCallIdLimit": false
+				"usesOpenAIToolCallIdLimit": false,
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"muse-spark-1.3-contributor-free": {
@@ -271096,7 +271265,8 @@
 				"streamMarkupHealingPattern": "thinking",
 				"reasoningDeltasMayBeCumulative": false,
 				"emptyLengthFinishIsContextError": false,
-				"usesOpenAIToolCallIdLimit": false
+				"usesOpenAIToolCallIdLimit": false,
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"nemotron-3-super-free": {
@@ -271236,8 +271406,10 @@
 					"stripImageInput": false,
 					"rejectRootObjectUnion": false,
 					"retryWithoutStrictOnGrammarError": false,
-					"supportsPromptCacheKey": false
-				}
+					"supportsPromptCacheKey": false,
+					"requiresOpenCodeRoutingHeaders": true
+				},
+				"requiresOpenCodeRoutingHeaders": true
 			},
 			"supportsComputerUse": false
 		},
@@ -271379,8 +271551,10 @@
 					"stripImageInput": false,
 					"rejectRootObjectUnion": false,
 					"retryWithoutStrictOnGrammarError": false,
-					"supportsPromptCacheKey": false
-				}
+					"supportsPromptCacheKey": false,
+					"requiresOpenCodeRoutingHeaders": true
+				},
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"nemotron-3.5-lightning-free": {
@@ -271521,8 +271695,10 @@
 					"stripImageInput": false,
 					"rejectRootObjectUnion": false,
 					"retryWithoutStrictOnGrammarError": false,
-					"supportsPromptCacheKey": false
-				}
+					"supportsPromptCacheKey": false,
+					"requiresOpenCodeRoutingHeaders": true
+				},
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"north-mini-code-free": {
@@ -271662,8 +271838,10 @@
 					"stripImageInput": false,
 					"rejectRootObjectUnion": false,
 					"retryWithoutStrictOnGrammarError": false,
-					"supportsPromptCacheKey": false
-				}
+					"supportsPromptCacheKey": false,
+					"requiresOpenCodeRoutingHeaders": true
+				},
+				"requiresOpenCodeRoutingHeaders": true
 			},
 			"supportsComputerUse": false
 		},
@@ -271725,7 +271903,8 @@
 				"replayUnsignedThinking": true,
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
-				"stripImageInput": false
+				"stripImageInput": false,
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"qwen3.6-plus": {
@@ -271786,7 +271965,8 @@
 				"replayUnsignedThinking": true,
 				"escapeBuiltinToolNames": false,
 				"injectClaudeCodeInstruction": true,
-				"stripImageInput": false
+				"stripImageInput": false,
+				"requiresOpenCodeRoutingHeaders": true
 			}
 		},
 		"qwen3.6-plus-free": {
@@ -271927,8 +272107,10 @@
 					"stripImageInput": false,
 					"rejectRootObjectUnion": false,
 					"retryWithoutStrictOnGrammarError": false,
-					"supportsPromptCacheKey": false
-				}
+					"supportsPromptCacheKey": false,
+					"requiresOpenCodeRoutingHeaders": true
+				},
+				"requiresOpenCodeRoutingHeaders": true
 			},
 			"supportsComputerUse": false
 		},
@@ -272069,8 +272251,10 @@
 					"stripImageInput": false,
 					"rejectRootObjectUnion": false,
 					"retryWithoutStrictOnGrammarError": false,
-					"supportsPromptCacheKey": false
-				}
+					"supportsPromptCacheKey": false,
+					"requiresOpenCodeRoutingHeaders": true
+				},
+				"requiresOpenCodeRoutingHeaders": true
 			},
 			"supportsComputerUse": false
 		},
@@ -272148,7 +272332,8 @@
 				"stripImageInput": false,
 				"rejectRootObjectUnion": false,
 				"retryWithoutStrictOnGrammarError": false,
-				"supportsPromptCacheKey": false
+				"supportsPromptCacheKey": false,
+				"requiresOpenCodeRoutingHeaders": true
 			},
 			"supportsComputerUse": false
 		},
@@ -272289,8 +272474,10 @@
 					"stripImageInput": false,
 					"rejectRootObjectUnion": false,
 					"retryWithoutStrictOnGrammarError": false,
-					"supportsPromptCacheKey": false
-				}
+					"supportsPromptCacheKey": false,
+					"requiresOpenCodeRoutingHeaders": true
+				},
+				"requiresOpenCodeRoutingHeaders": true
 			},
 			"supportsComputerUse": false
 		}

--- a/packages/catalog/src/types.ts
+++ b/packages/catalog/src/types.ts
@@ -343,6 +343,8 @@ export interface OpenAICompat {
 	extraBody?: Record<string, unknown>;
 	/** Request-session header that should mirror the normalized prompt-cache key. Default: unset. */
 	promptCacheSessionHeader?: "x-grok-conv-id";
+	/** Whether requests require OpenCode's per-conversation routing headers. */
+	requiresOpenCodeRoutingHeaders?: boolean;
 	/** Whether chat-completions payloads should include provider-specific prompt-cache markers. */
 	cacheControlFormat?: "anthropic" | undefined;
 	/**
@@ -532,6 +534,8 @@ export interface AnthropicCompat {
 	 * OAuth defaults on non-official Anthropic endpoints.
 	 */
 	allowAnthropicHeaderOverrides?: boolean;
+	/** Whether requests require OpenCode's per-conversation routing headers. */
+	requiresOpenCodeRoutingHeaders?: boolean;
 	/**
 	 * Replay unsigned `thinking` blocks from prior assistant turns as native
 	 * thinking instead of demoting them to text. Official Anthropic enforces
@@ -697,6 +701,8 @@ export interface ResolvedOpenAISharedCompat {
 	emptyLengthFinishIsContextError: boolean;
 	usesOpenAIToolCallIdLimit: boolean;
 	promptCacheSessionHeader?: OpenAICompat["promptCacheSessionHeader"];
+	/** Whether requests require OpenCode's per-conversation routing headers. */
+	requiresOpenCodeRoutingHeaders?: boolean;
 	/**
 	 * Whether this model accepts explicit OpenAI prompt-cache breakpoints.
 	 * Built catalog models always materialize this false-by-default value;
@@ -770,6 +776,7 @@ export type ResolvedOpenAICompat = ResolvedOpenAISharedCompat &
 			| "emptyLengthFinishIsContextError"
 			| "usesOpenAIToolCallIdLimit"
 			| "promptCacheSessionHeader"
+			| "requiresOpenCodeRoutingHeaders"
 			| "supportsPromptCacheBreakpoints"
 			| "promptCacheBreakpointTtl"
 			| "openRouterRouting"
@@ -853,7 +860,11 @@ export interface ResolvedOpenAIResponsesCompat extends ResolvedOpenAISharedCompa
 export type ResolvedOpenRouterCompat = ResolvedOpenAICompat & ResolvedOpenAIResponsesCompat;
 
 /** Fully-resolved anthropic-messages compat view (same contract as `ResolvedOpenAICompat`). */
-export type ResolvedAnthropicCompat = Required<Omit<AnthropicCompat, "streamIdleTimeoutMs" | "thinkingLoopGuard">> & {
+export type ResolvedAnthropicCompat = Required<
+	Omit<AnthropicCompat, "streamIdleTimeoutMs" | "thinkingLoopGuard" | "requiresOpenCodeRoutingHeaders">
+> & {
+	/** Whether requests require OpenCode's per-conversation routing headers. */
+	requiresOpenCodeRoutingHeaders?: boolean;
 	/** Thinking-loop watchdog guard family applied to streamed reasoning. */
 	thinkingLoopGuard?: AnthropicCompat["thinkingLoopGuard"];
 	/**
@@ -903,6 +914,8 @@ export type ResolvedDevinCompat = Required<DevinCompat>;
  * compat cascade; sparse overrides follow the same shape.
  */
 export interface GoogleCompat {
+	/** Whether requests require OpenCode's per-conversation routing headers. */
+	requiresOpenCodeRoutingHeaders?: boolean;
 	/** Whether functionCall/functionResponse parts carry the `id` field. */
 	supportsFunctionPartId?: boolean;
 	/** Add the bypass sentinel to every unsigned Gemini function call. */
@@ -937,13 +950,19 @@ export interface GoogleCompat {
 export type ResolvedGoogleCompat = Required<
 	Omit<
 		GoogleCompat,
-		"streamFirstEventTimeoutMs" | "streamIdleTimeoutMs" | "thinkingLoopGuard" | "antigravityUsageLabel"
+		| "streamFirstEventTimeoutMs"
+		| "streamIdleTimeoutMs"
+		| "thinkingLoopGuard"
+		| "antigravityUsageLabel"
+		| "requiresOpenCodeRoutingHeaders"
 	>
 > & {
 	streamFirstEventTimeoutMs?: number;
 	streamIdleTimeoutMs?: number;
 	thinkingLoopGuard?: GoogleCompat["thinkingLoopGuard"];
 	antigravityUsageLabel?: string;
+	/** Whether requests require OpenCode's per-conversation routing headers. */
+	requiresOpenCodeRoutingHeaders?: boolean;
 };
 
 /** Sparse, user-authored compat overrides for a given API (models.json / config vocabulary). */

--- a/packages/catalog/src/wire/opencode.ts
+++ b/packages/catalog/src/wire/opencode.ts
@@ -12,12 +12,24 @@
 export const OPENCODE_CLIENT_ID = "omp";
 
 /**
- * Routing headers for an OpenCode inference request. `x-opencode-session` is
- * emitted only when a stable session id is available; `x-opencode-client` is
- * always present.
+ * Process-stable fallback session id for direct `pi-ai` callers that omit
+ * `sessionId`. The gateway rejects inference requests without
+ * `x-opencode-session`, so the header must always be present; a single id per
+ * process keeps such calls grouped as one conversation and distinct across
+ * processes. Lazily minted so importing this module allocates nothing.
+ */
+let fallbackSessionId: string | undefined;
+
+/**
+ * Routing headers for an OpenCode inference request. `x-opencode-session`
+ * carries the caller's stable per-conversation id, falling back to a
+ * process-stable id when none is supplied so the required header is never
+ * omitted; `x-opencode-client` attributes the caller.
  */
 export function opencodeRoutingHeaders(sessionId: string | undefined): Record<string, string> {
-	const headers: Record<string, string> = { "x-opencode-client": OPENCODE_CLIENT_ID };
-	if (sessionId) headers["x-opencode-session"] = sessionId;
-	return headers;
+	fallbackSessionId ??= crypto.randomUUID();
+	return {
+		"x-opencode-client": OPENCODE_CLIENT_ID,
+		"x-opencode-session": sessionId || fallbackSessionId,
+	};
 }

--- a/packages/catalog/src/wire/opencode.ts
+++ b/packages/catalog/src/wire/opencode.ts
@@ -11,11 +11,6 @@
 /** Client identifier reported to OpenCode's routing gateway. */
 export const OPENCODE_CLIENT_ID = "omp";
 
-/** Whether a provider routes through the OpenCode Go/Zen gateway. */
-export function isOpenCodeProvider(provider: string): boolean {
-	return provider === "opencode-go" || provider === "opencode-zen";
-}
-
 /**
  * Routing headers for an OpenCode inference request. `x-opencode-session` is
  * emitted only when a stable session id is available; `x-opencode-client` is

--- a/packages/catalog/src/wire/opencode.ts
+++ b/packages/catalog/src/wire/opencode.ts
@@ -11,6 +11,11 @@
 /** Client identifier reported to OpenCode's routing gateway. */
 export const OPENCODE_CLIENT_ID = "omp";
 
+/** Whether a provider routes through the OpenCode Go/Zen gateway. */
+export function isOpenCodeProvider(provider: string): boolean {
+	return provider === "opencode-go" || provider === "opencode-zen";
+}
+
 /**
  * Routing headers for an OpenCode inference request. `x-opencode-session` is
  * emitted only when a stable session id is available; `x-opencode-client` is

--- a/packages/catalog/src/wire/opencode.ts
+++ b/packages/catalog/src/wire/opencode.ts
@@ -1,0 +1,23 @@
+/**
+ * OpenCode Go/Zen (`opencode.ai/zen`) routing headers.
+ *
+ * The gateway requires a stable per-conversation `x-opencode-session` on
+ * inference requests for routing/optimization and errors header-less callers
+ * (operator notice: enforced starting 2026-09). `x-opencode-client` attributes
+ * the calling client for upstream usage stats. Both are sent as defaults —
+ * explicit user/config headers of the same name win at the call site.
+ */
+
+/** Client identifier reported to OpenCode's routing gateway. */
+export const OPENCODE_CLIENT_ID = "omp";
+
+/**
+ * Routing headers for an OpenCode inference request. `x-opencode-session` is
+ * emitted only when a stable session id is available; `x-opencode-client` is
+ * always present.
+ */
+export function opencodeRoutingHeaders(sessionId: string | undefined): Record<string, string> {
+	const headers: Record<string, string> = { "x-opencode-client": OPENCODE_CLIENT_ID };
+	if (sessionId) headers["x-opencode-session"] = sessionId;
+	return headers;
+}


### PR DESCRIPTION
## Repro
A transport-level test streams through `opencode-go` (OpenAI-completions and OpenAI-responses) and `opencode-zen` (Anthropic-messages) with a mock `fetch` and a `sessionId`, then inspects the outbound request headers. Before the fix, `x-opencode-session` and `x-opencode-client` are both absent (`null`). OpenCode's gateway (`opencode.ai/zen`) now requires a stable per-conversation `x-opencode-session` and errors header-less callers; the header-less caller is OMP's own outbound layer, so users cannot add it on their side.

```
cd packages/ai && bun test test/issue-10653-repro.test.ts
```

## Cause
Neither the OpenAI-family request setup (`resolveOpenAIRequestSetup` in `packages/ai/src/providers/openai-shared.ts`) nor the Anthropic client builder (`buildAnthropicClientOptions` in `packages/ai/src/providers/anthropic.ts`) attached any OpenCode routing headers. Every `opencode-go`/`opencode-zen` inference request — chat-completions, responses, Anthropic-messages, and remote compaction — went out without `x-opencode-session`/`x-opencode-client`.

## Fix
- Add `packages/catalog/src/wire/opencode.ts` with `opencodeRoutingHeaders(sessionId)` returning `x-opencode-client: omp` plus `x-opencode-session: <sessionId>` when a session id is present.
- `resolveOpenAIRequestSetup`: new `opencodeSessionId` option; for `opencode-go`/`opencode-zen` set the routing headers via `setHeaderIfAbsent` so explicit user/config `headers` win. Threaded through the completions (`createRequestSetup`) and responses call sites from `options.sessionId`, and through remote compaction (`buildCompactionV2Headers`) from `request.sessionId`.
- `buildAnthropicClientOptions`: inside the existing opencode `X-Api-Key` branch, add the routing headers using the already-resolved `claudeCodeSessionId` (= `options.sessionId`), only when absent case-insensitively so merged user/model headers win.

## Verification
`cd packages/ai && bun test test/issue-10653-repro.test.ts` — 4 pass (openai-completions, openai-responses, anthropic-messages, and user-header-override). Related suites green: `bun test test/issue-6510-repro.test.ts test/issue-8248-repro.test.ts test/github-copilot-anthropic-auth.test.ts` (22 pass) and `packages/agent bun test test/remote-compaction.test.ts` (50 pass). `bun check` passes repo-wide. Fixes #10653