### PR TITLE
fix(ai): reduce GitHub Copilot OAuth scopes

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -53,6 +53,8 @@
 - Anthropic and OpenRouter credit-exhaustion errors now automatically switch to a sibling account instead of stopping the turn with a retry hint.
 - Fixed OpenCode Go and Zen requests by including the required stable per-conversation session identification.
 - Improved Anthropic prompt caching so explicit cache breakpoints preserve reusable tools and system prompts when the message tail changes.
+- Anthropic and OpenRouter 402 credit-exhaustion errors ("would exceed your available credits", "Insufficient credits") now switch to a sibling account instead of stopping the turn with a retry hint.
+- GitHub Copilot sign-in now requests only basic profile access, restoring login for Enterprise organizations that reject repository, gist, and Codespaces permissions ([#10656](https://github.com/can1357/oh-my-pi/issues/10656)).
 
 ## [18.1.5] - 2026-09-03
 

--- a/packages/ai/src/registry/oauth/github-copilot.ts
+++ b/packages/ai/src/registry/oauth/github-copilot.ts
@@ -16,7 +16,7 @@ import type { FetchImpl } from "../../types";
 import type { OAuthController, OAuthCredentials } from "./types";
 
 const CLIENT_ID = "Ov23ctDVkRmgkPke0Mmm";
-const OAUTH_SCOPE = "read:user,read:org,repo,gist,codespace";
+const OAUTH_SCOPE = "read:user";
 const OAUTH_HEADERS = {
 	Accept: "application/json",
 	"Content-Type": "application/x-www-form-urlencoded",

--- a/packages/ai/test/github-copilot-login.test.ts
+++ b/packages/ai/test/github-copilot-login.test.ts
@@ -28,7 +28,7 @@ function accessTokenResponse(token = "ghu_test") {
 	return {
 		access_token: token,
 		token_type: "bearer",
-		scope: "read:user,read:org,repo,gist,codespace",
+		scope: "read:user",
 	};
 }
 
@@ -48,7 +48,7 @@ function modelPolicyOk() {
 }
 
 describe("loginGitHubCopilot", () => {
-	it("happy path (github.com)", async () => {
+	it("requests only the scopes needed for Copilot API access", async () => {
 		let pollCount = 0;
 		const fetchMock = vi.fn(async (input: string | URL, init?: RequestInit) => {
 			const url = typeof input === "string" ? input : input.toString();
@@ -56,7 +56,7 @@ describe("loginGitHubCopilot", () => {
 				expect(init?.method).toBe("POST");
 				expectOfficialOAuthRequest(init, {
 					client_id: "Ov23ctDVkRmgkPke0Mmm",
-					scope: "read:user,read:org,repo,gist,codespace",
+					scope: "read:user",
 				});
 				return new Response(JSON.stringify(deviceCodeResponse()), {
 					status: 200,


### PR DESCRIPTION
## Repro
On v18.1.5, the official Copilot OAuth app’s device-flow request includes `read:org,repo,gist,codespace`, so Enterprise organizations that reject those permissions cannot complete login. `bun test packages/ai/test/github-copilot-login.test.ts --test-name-pattern "requests only the scopes needed"` reproduced the regression with the received scope `read:user,read:org,repo,gist,codespace` instead of `read:user`.

## Cause
`startDeviceFlow` in `packages/ai/src/registry/oauth/github-copilot.ts` copied the Copilot CLI product’s full OAuth scope list when the official client ID was adopted, although omp uses the token only for Copilot API access.

## Fix
- Keep the official Copilot CLI client ID required for client-gated models.
- Request only `read:user` during device login.
- Assert the exact least-privilege device-flow request and document the Enterprise login fix.

## Verification
`bun test packages/ai/test/github-copilot-login.test.ts` passes all 12 tests. The pre-publish `bun run fix` and `bun check` gate also passes.

Fixes #10656