### PR TITLE
fix(lsp): bridge Volar 3 tsserver requests

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Fixed
 
+- Fixed Volar 3 Vue language features timing out by bridging its TypeScript server requests ([#10659](https://github.com/can1357/oh-my-pi/issues/10659)).
 - Fixed protocol handler incorrectly escaping raw text content from agent responses
 - Fixed `<task-result>` previews of structured subagent yields collapsing to a lone `{` when the JSON's second line exceeded the preview budget
 - Fixed `/usage` freezing the TUI for several seconds while it loaded the activity heatmap on a large stats database; the dashboard now opens immediately and the heatmap plus session sync load from a background subprocess.

--- a/packages/coding-agent/src/lsp/client.ts
+++ b/packages/coding-agent/src/lsp/client.ts
@@ -326,6 +326,68 @@ function queueWriteMessage(
 	return result;
 }
 
+const TSSERVER_REQUEST_NOTIFICATION = "tsserver/request";
+const TSSERVER_RESPONSE_NOTIFICATION = "tsserver/response";
+const TSSERVER_REQUEST_COMMAND = "typescript.tsserverRequest";
+
+type TsserverRequestParams = [[LspJsonRpcId, string, unknown]];
+
+function isTsserverRequestParams(params: unknown): params is TsserverRequestParams {
+	if (!Array.isArray(params) || params.length !== 1) return false;
+	const request = params[0];
+	return (
+		Array.isArray(request) &&
+		request.length === 3 &&
+		(typeof request[0] === "number" || typeof request[0] === "string") &&
+		typeof request[1] === "string"
+	);
+}
+
+function supportsExecuteCommand(client: LspClient, command: string): boolean {
+	const provider = client.serverCapabilities?.executeCommandProvider;
+	if (typeof provider !== "object" || provider === null || !("commands" in provider)) return false;
+	return Array.isArray(provider.commands) && provider.commands.includes(command);
+}
+
+function findExecuteCommandClient(cwd: string, command: string): LspClient | undefined {
+	const resolvedCwd = path.resolve(cwd);
+	for (const client of clients.values()) {
+		if (path.resolve(client.cwd) === resolvedCwd && supportsExecuteCommand(client, command)) return client;
+	}
+	return undefined;
+}
+
+async function handleTsserverRequestNotification(client: LspClient, params: unknown): Promise<void> {
+	if (!isTsserverRequestParams(params)) {
+		logger.warn("LSP received malformed tsserver/request notification", { server: client.name });
+		return;
+	}
+
+	const [id, command, payload] = params[0];
+	const tsClient = findExecuteCommandClient(client.cwd, TSSERVER_REQUEST_COMMAND);
+	let body: unknown = null;
+	if (tsClient) {
+		try {
+			const response = await sendRequest(tsClient, "workspace/executeCommand", {
+				command: TSSERVER_REQUEST_COMMAND,
+				arguments: [command, payload],
+			});
+			if (typeof response === "object" && response !== null && "body" in response) {
+				body = response.body ?? null;
+			}
+		} catch (error) {
+			logger.warn("LSP tsserver request forwarding failed", {
+				server: client.name,
+				error: error instanceof Error ? error.message : String(error),
+			});
+		}
+	} else {
+		logger.warn("LSP tsserver bridge has no compatible TypeScript client", { server: client.name });
+	}
+
+	await sendNotification(client, TSSERVER_RESPONSE_NOTIFICATION, [[id, body]]);
+}
+
 // =============================================================================
 // Message Reader
 // =============================================================================
@@ -400,6 +462,13 @@ async function startMessageReader(client: LspClient): Promise<void> {
 										client.resolveProjectLoaded();
 									}
 								}
+							} else if (message.method === TSSERVER_REQUEST_NOTIFICATION) {
+								void handleTsserverRequestNotification(client, message.params).catch(error => {
+									logger.warn("LSP tsserver response notification failed", {
+										server: client.name,
+										error: error instanceof Error ? error.message : String(error),
+									});
+								});
 							}
 						}
 					} else if ("id" in message && message.id !== undefined) {

--- a/packages/coding-agent/test/fixtures/fake-lsp-server.ts
+++ b/packages/coding-agent/test/fixtures/fake-lsp-server.ts
@@ -21,6 +21,9 @@ interface CloseDocumentParams {
 	textDocument: { uri: string };
 }
 
+const mode = Bun.argv[2] ?? "default";
+const VOLAR_TSSERVER_REQUEST_ID = 1;
+
 let initializeCount = 0;
 let processId: number | null = null;
 const didOpen: Record<string, number> = {};
@@ -33,6 +36,7 @@ const pendingServerRequests = new Map<
 	string | number,
 	{ resolve: (response: { result: unknown; error: unknown }) => void }
 >();
+let pendingVolarDocumentSymbol: string | number | undefined;
 
 function send(message: JsonRpcMessage): void {
 	const json = JSON.stringify(message);
@@ -83,12 +87,43 @@ async function handleRequest(message: JsonRpcMessage): Promise<void> {
 			initializeCount++;
 			const params = message.params as { processId?: number | null } | undefined;
 			processId = params?.processId ?? null;
+			const capabilities =
+				mode === "volar"
+					? { documentSymbolProvider: true }
+					: mode === "typescript"
+						? { executeCommandProvider: { commands: ["typescript.tsserverRequest"] } }
+						: {};
 			respond(id, {
-				capabilities: {},
-				serverInfo: { name: "fake-lsp", version: String(process.pid) },
+				capabilities,
+				serverInfo: { name: mode === "default" ? "fake-lsp" : `fake-lsp-${mode}`, version: String(process.pid) },
 			});
 			break;
 		}
+		case "textDocument/documentSymbol":
+			if (mode !== "volar") {
+				respond(id, undefined, { code: -32601, message: `Method not found: ${message.method}` });
+				break;
+			}
+			pendingVolarDocumentSymbol = id;
+			send({
+				jsonrpc: "2.0",
+				method: "tsserver/request",
+				params: [[VOLAR_TSSERVER_REQUEST_ID, "_vue:projectInfo", { file: "/workspace/App.vue" }]],
+			});
+			break;
+		case "workspace/executeCommand":
+			if (
+				mode !== "typescript" ||
+				typeof message.params !== "object" ||
+				message.params === null ||
+				!("command" in message.params) ||
+				message.params.command !== "typescript.tsserverRequest"
+			) {
+				respond(id, undefined, { code: -32601, message: `Method not found: ${message.method}` });
+				break;
+			}
+			respond(id, { body: message.params });
+			break;
 		case "test/state": {
 			const didChangeSnapshot: Record<string, number[]> = {};
 			for (const uri in didChange) didChangeSnapshot[uri] = [...didChange[uri]];
@@ -152,6 +187,15 @@ function handleNotification(message: JsonRpcMessage): void {
 			const { uri } = params.textDocument;
 			didClose.push(uri);
 			documents.delete(uri);
+			break;
+		}
+		case "tsserver/response": {
+			if (mode !== "volar" || pendingVolarDocumentSymbol === undefined || !Array.isArray(message.params)) break;
+			const response = message.params[0];
+			if (!Array.isArray(response) || response[0] !== VOLAR_TSSERVER_REQUEST_ID) break;
+			const requestId = pendingVolarDocumentSymbol;
+			pendingVolarDocumentSymbol = undefined;
+			respond(requestId, response[1] ?? null);
 			break;
 		}
 		case "exit":

--- a/packages/coding-agent/test/lsp/volar-bridge.test.ts
+++ b/packages/coding-agent/test/lsp/volar-bridge.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as path from "node:path";
+import { getOrCreateClient, sendRequest, shutdownAll } from "@oh-my-pi/pi-coding-agent/lsp/client";
+import type { ServerConfig } from "@oh-my-pi/pi-coding-agent/lsp/types";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+const fixturePath = path.join(import.meta.dir, "..", "fixtures", "fake-lsp-server.ts");
+
+function serverConfig(mode: "typescript" | "volar"): ServerConfig {
+	return {
+		command: process.execPath,
+		args: [fixturePath, mode],
+		fileTypes: mode === "volar" ? [".vue"] : [".ts"],
+		rootMarkers: [],
+	};
+}
+
+afterEach(async () => {
+	await shutdownAll();
+});
+
+describe("Volar tsserver bridge", () => {
+	it("forwards tsserver requests through a compatible TypeScript client", async () => {
+		const tempDir = TempDir.createSync("@omp-volar-bridge-");
+		try {
+			await getOrCreateClient(serverConfig("typescript"), tempDir.path(), 1_000);
+			const volar = await getOrCreateClient(serverConfig("volar"), tempDir.path(), 1_000);
+
+			const result = await sendRequest(
+				volar,
+				"textDocument/documentSymbol",
+				{ textDocument: { uri: "file:///workspace/App.vue" } },
+				undefined,
+				1_000,
+			);
+
+			expect(result).toEqual({
+				command: "typescript.tsserverRequest",
+				arguments: ["_vue:projectInfo", { file: "/workspace/App.vue" }],
+			});
+		} finally {
+			tempDir.removeSync();
+		}
+	});
+
+	it("answers Volar with null when no compatible TypeScript client is live", async () => {
+		const tempDir = TempDir.createSync("@omp-volar-no-tsserver-");
+		try {
+			const volar = await getOrCreateClient(serverConfig("volar"), tempDir.path(), 1_000);
+
+			const result = await sendRequest(
+				volar,
+				"textDocument/documentSymbol",
+				{ textDocument: { uri: "file:///workspace/App.vue" } },
+				undefined,
+				1_000,
+			);
+
+			expect(result).toBeNull();
+		} finally {
+			tempDir.removeSync();
+		}
+	});
+});


### PR DESCRIPTION
## Repro
With a Vue 3 fixture containing `@vue/language-server@3.3.11`, `typescript-language-server@4.4.0`, and TypeScript 5.9.2, `cd /tmp/omp-volar-10659 && bun repro.ts` initializes both servers through `getOrCreateClient`, opens `App.vue`, and sends `textDocument/documentSymbol`; before this fix it exits 1 with `LSP request textDocument/documentSymbol timed out after 2000ms`.

## Cause
`packages/coding-agent/src/lsp/client.ts` routed diagnostics and progress notifications but ignored Volar 3's nested `tsserver/request` notification. Volar retained that request and withheld the pending `textDocument/documentSymbol` response because no client forwarded it through `workspace/executeCommand`.

## Fix
- Detect compatible same-workspace clients through the advertised `typescript.tsserverRequest` execute command.
- Forward Volar's command and payload, then return the TypeScript response body through `tsserver/response`; return `null` on missing or failed TypeScript clients so Volar releases its pending request.
- Extend the fake LSP fixture and add protocol-level coverage for successful forwarding and the no-client path.
- Document the user-visible fix in the coding-agent changelog.

## Verification
`bun test test/lsp/volar-bridge.test.ts test/lsp-mux.test.ts test/tools/lsp-regressions.test.ts` passes 127 tests. `bun check` passes. Re-running the real Volar 3.3.11 reproduction returns the expected template and script symbols in 1.78 seconds.

Fixes #10659