### PR TITLE
fix(tui): expose OverlayHandle.isFocused()

### DIFF
--- a/packages/coding-agent/test/interactive-mode-plan-review.test.ts
+++ b/packages/coding-agent/test/interactive-mode-plan-review.test.ts
@@ -479,6 +479,7 @@ describe("InteractiveMode plan review rendering", () => {
 			hide: vi.fn(),
 			setHidden: vi.fn(),
 			isHidden: vi.fn(() => false),
+			isFocused: vi.fn(() => true),
 		};
 		vi.spyOn(mode.ui, "showOverlay").mockImplementation((component, options) => {
 			if (!(component instanceof PlanReviewOverlay)) throw new Error("Expected Plan Review overlay");

--- a/packages/coding-agent/test/modes/components/codex-reset-fireworks.test.ts
+++ b/packages/coding-agent/test/modes/components/codex-reset-fireworks.test.ts
@@ -36,6 +36,7 @@ function makeHost(rows = 24): FakeHost {
 					},
 					setHidden() {},
 					isHidden: () => false,
+					isFocused: () => true,
 				} satisfies OverlayHandle;
 			},
 			setFocus(component) {

--- a/packages/coding-agent/test/modes/components/pause-screen.test.ts
+++ b/packages/coding-agent/test/modes/components/pause-screen.test.ts
@@ -34,6 +34,7 @@ function makeHost(rows = 24): FakeHost {
 					},
 					setHidden() {},
 					isHidden: () => false,
+					isFocused: () => true,
 				};
 			},
 			setFocus() {},

--- a/packages/coding-agent/test/modes/controllers/extension-ui-controller.test.ts
+++ b/packages/coding-agent/test/modes/controllers/extension-ui-controller.test.ts
@@ -29,6 +29,7 @@ function makeHarness() {
 		hide: vi.fn(),
 		setHidden: vi.fn(),
 		isHidden: vi.fn(() => false),
+		isFocused: vi.fn(() => true),
 	};
 	const showOverlay = vi.fn(() => fakeHandle);
 	let uiContext: ExtensionUIContext | undefined;

--- a/packages/coding-agent/test/modes/controllers/resume-preflight.test.ts
+++ b/packages/coding-agent/test/modes/controllers/resume-preflight.test.ts
@@ -59,7 +59,7 @@ function createResumeContext(opts: { flushFails?: boolean; sourceCwd?: string; p
 			terminal: { rows: 24 },
 			showOverlay: vi.fn((component: unknown) => {
 				selector = component as SessionSelector.SessionSelectorComponent;
-				return { hide, setHidden: vi.fn(), isHidden: () => false };
+				return { hide, setHidden: vi.fn(), isHidden: () => false, isFocused: () => true };
 			}),
 		},
 		editor,

--- a/packages/coding-agent/test/modes/controllers/selector-controller-overlay-focus.test.ts
+++ b/packages/coding-agent/test/modes/controllers/selector-controller-overlay-focus.test.ts
@@ -122,7 +122,7 @@ describe("SelectorController session replacement overlay", () => {
 			ui: {
 				showOverlay: vi.fn(component => {
 					selector = component as SessionSelectorComponent;
-					return { hide, setHidden: vi.fn(), isHidden: () => false };
+					return { hide, setHidden: vi.fn(), isHidden: () => false, isFocused: () => true };
 				}),
 				setFocus: vi.fn(),
 				requestRender: vi.fn(),

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed the band composer dropping its status row while the top border has no content, so the status line no longer pushes the prompt down when it attaches.
+- Fixed plugins crashing when checking whether their overlay is focused via `OverlayHandle.isFocused()` ([#10664](https://github.com/can1357/oh-my-pi/issues/10664)).
 
 ## [18.1.5] - 2026-09-03
 

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -394,6 +394,8 @@ export interface OverlayHandle {
 	setHidden(hidden: boolean): void;
 	/** Check if overlay is temporarily hidden */
 	isHidden(): boolean;
+	/** Check if this overlay currently has focus */
+	isFocused(): boolean;
 }
 
 /**
@@ -1042,6 +1044,7 @@ export class TUI extends Container {
 				this.requestRender();
 			},
 			isHidden: () => entry.hidden,
+			isFocused: () => this.#focusedComponent === component,
 		};
 	}
 

--- a/packages/tui/test/overlay-focus.test.ts
+++ b/packages/tui/test/overlay-focus.test.ts
@@ -248,4 +248,24 @@ describe("TUI overlay focus", () => {
 			tui.stop();
 		}
 	});
+	it("reports whether the overlay currently has focus", () => {
+		const terminal = new MinimalTerminal();
+		const tui = new TUI(terminal);
+		const editor = new FocusRecorder("editor");
+		const questionnaire = new FocusRecorder("questionnaire");
+		const dialog = new FocusRecorder("dialog");
+
+		tui.addChild(editor);
+		tui.setFocus(editor);
+
+		const questionnaireHandle = tui.showOverlay(questionnaire);
+		expect(questionnaireHandle.isFocused()).toBe(true);
+
+		const dialogHandle = tui.showOverlay(dialog);
+		expect(questionnaireHandle.isFocused()).toBe(false);
+		expect(dialogHandle.isFocused()).toBe(true);
+
+		dialogHandle.hide();
+		expect(questionnaireHandle.isFocused()).toBe(true);
+	});
 });


### PR DESCRIPTION
## Repro

Calling `isFocused()` on the handle returned by `TUI.showOverlay()` reproduces the plugin failure on current `main`: `bun test packages/tui/test/overlay-focus.test.ts` fails with `TypeError: questionnaireHandle.isFocused is not a function`.

## Cause

`packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts` remaps `@earendil-works/pi-tui` imports to OMP’s bundled TUI, but `OverlayHandle` and `TUI.showOverlay()` in `packages/tui/src/tui.ts` omitted the upstream `isFocused()` contract. Plugins compiled against that API therefore received an incompatible runtime handle.

## Fix

- Add `OverlayHandle.isFocused()` and implement it against the TUI’s current focused component.
- Cover focus transitions as overlays are stacked and removed.
- Update existing overlay-handle test doubles and the TUI changelog.

## Verification

`bun test packages/tui/test/overlay-focus.test.ts` — 5 pass, 0 fail.

`bun run --cwd packages/tui test` — 1,435 pass, 0 fail.

`bun check` — passed.

Fixes #10664