### PR TITLE
fix(coding-agent): answer clarifying custom input before re-asking

### DIFF
--- a/packages/coding-agent/src/prompts/tools/ask.md
+++ b/packages/coding-agent/src/prompts/tools/ask.md
@@ -9,6 +9,7 @@ Ask user for clarification/input during task execution.
 - Use `questions` for related questions, not one at a time.
 - Set `multi: true` on a question to allow multiple selections.
 - Short option labels; explanatory tradeoffs in `description`, not labels.
+- A custom input (`Other`) can be a clarifying question, not an answer (e.g. "what do you mean?", "explain X", "why?"). If so, answer it in response text first, then call `ask` again for the still-open question(s).
 </instruction>
 
 <caution>


### PR DESCRIPTION
Custom input via Other can be a clarifying question, not an answer (e.g. what do you mean, explain X). Without guidance the model treats it as a bad answer and re-asks with no explanation.

Teach the ask prompt: answer it in response text first, then call ask again for the still-open question(s).

Repro: ask a question, reply in Other with 'what are you talking about?', tool returns 'User provided custom input: ...' framed as an answer.

Tests: bun test test/tools/ask.test.ts (49 pass).