### PR TITLE
fix(coding-agent): load OMP marketplace skills

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -42,6 +42,7 @@
 
 ### Fixed
 
+- Fixed OMP-installed marketplace plugins not registering their bundled skills unless Claude user sources were enabled.
 - Fixed local title models receiving unsupported online examples and failing with certain tokenizer templates.
 - Fixed model picker search selection so it moves to the best matching result after results change.
 - Fixed /new sometimes reviving the previous conversation in the current process or after a restart.

--- a/packages/coding-agent/src/discovery/claude-plugins.ts
+++ b/packages/coding-agent/src/discovery/claude-plugins.ts
@@ -45,7 +45,10 @@ async function allowedRoots(
 ): Promise<{ roots: ClaudePluginRoot[]; warnings: string[] }> {
 	const { roots, warnings } = await listClaudePluginRoots(ctx.home, ctx.cwd);
 	const userEnabled = isUserSourceEnabled("claude-plugins", ctx) || isUserSourceEnabled("claude", ctx);
-	const scopedRoots = userEnabled ? roots : roots.filter(r => r.scope === "project");
+	const ownedRoots = roots.filter(root => root.registry !== "omp");
+	const scopedRoots = ownedRoots.filter(
+		root => root.registry === "plugin-dir" || root.scope === "project" || userEnabled,
+	);
 	const flags = await Promise.all(scopedRoots.map(root => legacyProviderAllowed(root.path, surface)));
 	return { roots: scopedRoots.filter((_, i) => flags[i]), warnings };
 }

--- a/packages/coding-agent/src/discovery/helpers.ts
+++ b/packages/coding-agent/src/discovery/helpers.ts
@@ -948,6 +948,8 @@ export interface ClaudePluginRoot {
 	version: string;
 	/** Absolute path to plugin root */
 	path: string;
+	/** Registry or explicit input that contributed this root */
+	registry: "claude" | "omp" | "plugin-dir";
 	/** Whether this is a user or project scope plugin */
 	scope: "user" | "project";
 }
@@ -1165,6 +1167,7 @@ export async function listClaudePluginRoots(
 					roots.push({
 						id: pluginId,
 						marketplace,
+						registry: "claude",
 						plugin: pluginName,
 						version: entry.version || "unknown",
 						path: entry.installPath,
@@ -1213,6 +1216,7 @@ export async function listClaudePluginRoots(
 					roots.push({
 						id: pluginId,
 						marketplace,
+						registry: "omp",
 						plugin: pluginName,
 						version: entry.version || "unknown",
 						path: entry.installPath,
@@ -1251,6 +1255,7 @@ export async function listClaudePluginRoots(
 						projectRoots.push({
 							id: pluginId,
 							marketplace,
+							registry: "omp",
 							plugin: pluginName,
 							version: entry.version || "unknown",
 							path: entry.installPath,
@@ -1374,7 +1379,7 @@ export async function injectPluginDirRoots(home: string, dirs: string[], cwd?: s
 			}
 		}
 
-		injected.push(buildPluginDirRoot(resolved, pluginName));
+		injected.push({ ...buildPluginDirRoot(resolved, pluginName), registry: "plugin-dir" });
 	}
 
 	// Set injected roots BEFORE populating cache so listClaudePluginRoots merges them.

--- a/packages/coding-agent/src/discovery/omp-extension-roots.ts
+++ b/packages/coding-agent/src/discovery/omp-extension-roots.ts
@@ -269,8 +269,8 @@ async function isDirectory(p: string): Promise<boolean> {
  *    `.claude/settings.json`, and honors overlays/overrides), never re-derived
  *    from a partial `.omp` disk scan; scopeless callers read the persisted
  *    `.omp` config, which supplies its own level.
- * 3. Installed npm/link plugins under `<plugins>/node_modules/`, added only in
- *    `merge` mode. Marketplace installs load via the `claude-plugins` provider.
+ * 3. Installed npm/link plugins and OMP marketplace roots, added only in
+ *    `merge` mode. Claude marketplace roots stay with `claude-plugins`.
  *
  * `explicit-only` mode (an SDK `disableExtensionDiscovery` session) contributes
  * the explicit lane alone — no ambient `extensions:`, installed plugins, or
@@ -340,15 +340,13 @@ export async function listOmpExtensionRoots(ctx: LoadContext): Promise<OmpExtens
 }
 
 /**
- * Enumerate every enabled npm/link plugin's package directory so its conventional
- * `skills/`, `hooks/`, `tools/`, `commands/`, `rules/`, `prompts/`, and
- * `.mcp.json` are wired into discovery — mirrors how `getAllPluginExtensionPaths`
- * already feeds the extension factory loader.
+ * Enumerate every enabled npm/link plugin package plus OMP marketplace roots
+ * so conventional `skills/`, hooks, tools, commands, rules, prompts, and
+ * `.mcp.json` resources participate in OMP discovery.
  *
- * Marketplace installs also create runtime symlinks for enable-state persistence,
- * but their resources are discovered through the `claude-plugins` provider.
- * Filtering them here prevents `/status` from showing the same plugin under both
- * "Claude Code Marketplace" and "OMP Extension Packages".
+ * OMP marketplace roots come directly from OMP's registry, even when a package
+ * has no runtime extension link. Claude marketplace roots remain owned by the
+ * `claude-plugins` provider. Matching runtime links are filtered as duplicates.
  */
 async function realpathOrResolved(p: string): Promise<string> {
 	try {
@@ -365,6 +363,9 @@ async function listInstalledPluginRoots(ctx: LoadContext): Promise<InjectedRoot[
 			getEnabledPlugins(ctx.cwd, { home: ctx.home }),
 			listClaudePluginRoots(ctx.home, ctx.cwd),
 		]);
+		const ompMarketplaceRoots = marketplaceRoots.roots
+			.filter(root => root.registry === "omp")
+			.map(({ path: p, scope }) => ({ path: p, level: scope }));
 		const marketplaceRealpaths = new Set(
 			await Promise.all(marketplaceRoots.roots.map(root => realpathOrResolved(root.path))),
 		);
@@ -375,9 +376,10 @@ async function listInstalledPluginRoots(ctx: LoadContext): Promise<InjectedRoot[
 				realpath: await realpathOrResolved(plugin.path),
 			})),
 		);
-		return installedRoots
+		const nonMarketplaceRoots = installedRoots
 			.filter(root => !marketplaceRealpaths.has(root.realpath))
 			.map(({ path: p, scope }) => ({ path: p, level: scope }));
+		return [...ompMarketplaceRoots, ...nonMarketplaceRoots];
 	} catch (err) {
 		logger.debug("listInstalledPluginRoots: enumeration failed", { error: String(err) });
 		return [];

--- a/packages/coding-agent/test/discovery/claude-plugins.test.ts
+++ b/packages/coding-agent/test/discovery/claude-plugins.test.ts
@@ -138,6 +138,7 @@ describe("listClaudePluginRoots", () => {
 		expect(result.roots[0]).toEqual({
 			id: "test-plugin@test-market",
 			marketplace: "test-market",
+			registry: "claude",
 			plugin: "test-plugin",
 			version: "1.0.0",
 			path: "/path/to/test-plugin",
@@ -172,6 +173,7 @@ describe("listClaudePluginRoots", () => {
 			{
 				id: "relocated@market",
 				marketplace: "market",
+				registry: "claude",
 				plugin: "relocated",
 				version: "1.0.0",
 				path: "/path/to/relocated",

--- a/packages/coding-agent/test/discovery/omp-plugins.test.ts
+++ b/packages/coding-agent/test/discovery/omp-plugins.test.ts
@@ -12,11 +12,16 @@
  * `home` instead of `os.homedir()`. Module-level CLI injection state is
  * reset between cases so they cannot poison each other.
  */
-import { afterEach, beforeEach, expect, test } from "bun:test";
+import { afterEach, beforeEach, expect, test, vi } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { getCapability, loadCapability } from "@oh-my-pi/pi-coding-agent/capability";
+import {
+	getCapability,
+	getEnabledProviders,
+	loadCapability,
+	setEnabledProviders,
+} from "@oh-my-pi/pi-coding-agent/capability";
 import { clearCache } from "@oh-my-pi/pi-coding-agent/capability/fs";
 import { hookCapability } from "@oh-my-pi/pi-coding-agent/capability/hook";
 import { mcpCapability } from "@oh-my-pi/pi-coding-agent/capability/mcp";
@@ -28,6 +33,7 @@ import { toolCapability } from "@oh-my-pi/pi-coding-agent/capability/tool";
 import type { LoadContext, Provider } from "@oh-my-pi/pi-coding-agent/capability/types";
 // Register all discovery providers as a side effect.
 import "@oh-my-pi/pi-coding-agent/discovery";
+import { clearClaudePluginRootsCache } from "@oh-my-pi/pi-coding-agent/discovery/helpers";
 import {
 	clearOmpExtensionCliRoots,
 	injectOmpExtensionCliRoots,
@@ -36,6 +42,7 @@ import {
 	withOmpExtensionRootScope,
 } from "@oh-my-pi/pi-coding-agent/discovery/omp-extension-roots";
 import { discoverExtensionPaths } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/loader";
+import { loadSkills } from "@oh-my-pi/pi-coding-agent/extensibility/skills";
 import { getConfigRootDir, removeSyncWithRetries, setAgentDir } from "@oh-my-pi/pi-utils";
 
 const PROVIDER_ID = "omp-plugins";
@@ -44,6 +51,7 @@ let tempDir: string;
 let home: string;
 let project: string;
 let ext: string;
+let originalEnabledProviders: string[];
 
 const originalAgentDirEnv = process.env.PI_CODING_AGENT_DIR;
 const fallbackAgentDir = path.join(getConfigRootDir(), "agent");
@@ -92,9 +100,13 @@ function buildExtensionPackage(packageDir: string, skillName = "my-skill"): void
 
 beforeEach(() => {
 	clearCache();
+	clearClaudePluginRootsCache();
 	clearOmpExtensionCliRoots();
+	originalEnabledProviders = getEnabledProviders();
+	setEnabledProviders(originalEnabledProviders.filter(id => id !== "claude" && id !== "claude-plugins"));
 	tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "omp-plugins-"));
 	home = path.join(tempDir, "home");
+	vi.spyOn(os, "homedir").mockReturnValue(home);
 	project = path.join(tempDir, "project");
 	ext = path.join(tempDir, "my-extension");
 	fs.mkdirSync(home, { recursive: true });
@@ -106,13 +118,16 @@ beforeEach(() => {
 
 afterEach(() => {
 	clearCache();
+	clearClaudePluginRootsCache();
 	clearOmpExtensionCliRoots();
+	setEnabledProviders(originalEnabledProviders);
 	if (originalAgentDirEnv) {
 		setAgentDir(originalAgentDirEnv);
 	} else {
 		setAgentDir(fallbackAgentDir);
 		delete process.env.PI_CODING_AGENT_DIR;
 	}
+	vi.restoreAllMocks();
 	removeSyncWithRetries(tempDir);
 });
 
@@ -151,6 +166,33 @@ test("user settings.json#extensions also feeds sub-discovery", async () => {
 
 	const skills = await loadFromPlugin<{ name: string }>(skillCapability.id, ctx());
 	expect(skills.map(s => s.name)).toContain("my-skill");
+});
+
+test("OMP marketplace registry surfaces user plugin skills without Claude opt-in", async () => {
+	const marketplacePlugin = path.join(tempDir, "marketplace-plugin");
+	buildExtensionPackage(marketplacePlugin, "marketplace-skill");
+	writeFile(
+		path.join(home, ".omp", "plugins", "installed_plugins.json"),
+		JSON.stringify({
+			version: 2,
+			plugins: {
+				"marketplace-plugin@test-market": [
+					{
+						scope: "user",
+						installPath: marketplacePlugin,
+						version: "1.0.0",
+						enabled: true,
+					},
+				],
+			},
+		}),
+	);
+	clearClaudePluginRootsCache();
+
+	const result = await loadSkills({ cwd: project });
+
+	expect(result.skills.map(skill => skill.name)).toContain("marketplace-skill");
+	expect(result.skills.find(skill => skill.name === "marketplace-skill")?._source?.provider).toBe("omp-plugins");
 });
 
 test("project config.yml#extensions surfaces every sub-directory (#9768)", async () => {


### PR DESCRIPTION
## Problem

OMP-installed marketplace plugins could appear installed and enabled while their bundled skills were absent. For example, the Compound Engineering plugin was present in `~/.omp/plugins/installed_plugins.json`, but `/skill:ce-plan` was not registered.

## Cause

OMP and Claude marketplace roots were merged into the same root list and both were routed through the `claude-plugins` discovery provider. User-scoped roots in that provider require Claude user-source discovery to be enabled, so OMP's own marketplace roots were filtered out before their `skills/` directories were scanned.

## Fix

- preserve whether each marketplace root came from Claude, OMP, or an explicit plugin directory
- keep Claude roots owned by `claude-plugins`
- route OMP registry roots through `omp-plugins`, independent of Claude user-source settings and runtime extension links
- add regression coverage proving an OMP user installation registers its bundled skills without Claude discovery enabled

## Verification

- `bun test test/discovery/omp-plugins.test.ts test/discovery/claude-plugins.test.ts` — 45 passed, 0 failed
- `bun run check:types` — passed
- source RPC smoke advertised `/skill:ce-plan` and the other installed Compound Engineering skills