### PR TITLE
feat(ai): Meta Model API account sign-in via KDL custom login hook

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Meta Model API `/login` now offers Muse-style browser sign-in (Meta account device flow plus Model API key mint) alongside pasting a dashboard key.
+
 ## [18.1.6] - 2026-09-03
 
 ### Breaking Changes

--- a/packages/ai/src/error/oauth.ts
+++ b/packages/ai/src/error/oauth.ts
@@ -24,6 +24,8 @@ export type OAuthErrorKind =
 	| "configuration"
 	/** Cloud project provisioning / onboarding (loadCodeAssist, onboardUser). */
 	| "provisioning"
+	/** Subscription/payment gate: plan required, upgrade/purchase needed (require_payment). */
+	| "entitlement"
 	/** OIDC / endpoint discovery failed. */
 	| "discovery";
 

--- a/packages/ai/src/registry/hooks/custom.ts
+++ b/packages/ai/src/registry/hooks/custom.ts
@@ -7,6 +7,7 @@ import type { Lazy, LoginHook, RefreshHook } from "./types";
 export const CUSTOM_LOGIN_HOOKS: Record<string, Lazy<LoginHook>> = {
 	"github-copilot": () => import("../oauth/github-copilot").then(module => module.loginGitHubCopilotHook),
 	cursor: () => import("../oauth/cursor").then(module => module.loginCursorHook),
+	meta: () => import("../oauth/meta").then(module => module.loginMetaHook),
 	perplexity: () => import("../oauth/perplexity").then(module => module.loginPerplexity),
 };
 export const CUSTOM_REFRESH_HOOKS: Record<string, Lazy<RefreshHook>> = {

--- a/packages/ai/src/registry/oauth/meta.ts
+++ b/packages/ai/src/registry/oauth/meta.ts
@@ -1,0 +1,450 @@
+/**
+ * Meta Model API account sign-in — the `meta` custom login hook declared in
+ * `rules/auth/meta.kdl`. Mirrors Muse Code's first-run menu: browser sign-in
+ * (RFC 8628 device authorization against `auth.meta.com`, then minting a
+ * Model API key from the account grant at `api.meta.ai/muse-code/key`) or
+ * pasting a dashboard key (MMA accounts and CI cannot use browser sign-in).
+ *
+ * The POC stores the minted key, not the account grant: this hook returns a
+ * plain API-key string, which `AuthStorage.login` persists as an `api_key`
+ * row (`source: "login"`) under provider `meta` — the existing transport
+ * picks it up unchanged. Account tokens are discarded after minting.
+ *
+ * Wire shapes below come from static RE of muse-x86-linux 1.0.2-R2040.1:
+ * no User-Agent is sent; the version is pinned via `x-api-version: 1.0.0`.
+ * The mint body/schema was inferred from the binary and confirmed against a
+ * live Meta account sign-in.
+ */
+
+import { $env } from "@oh-my-pi/pi-utils";
+import * as AIError from "../../error";
+import type { FetchImpl } from "../../types";
+import { validateApiKeyAgainstModelsEndpoint } from "../api-key-validation";
+import { type OAuthDeviceCodePollResult, pollOAuthDeviceCodeFlow } from "./device-code";
+import type { OAuthController } from "./types";
+
+const META_DASHBOARD_URL = "https://developer.meta.com/ai/";
+const META_DASHBOARD_INSTRUCTIONS = "Create or copy your key from the Meta Model API dashboard";
+const META_MODELS_URL = "https://api.meta.ai/v1/models";
+
+const META_AUTH_BASE_URL = "https://auth.meta.com";
+const META_API_BASE_URL = "https://api.meta.ai";
+const META_OAUTH_DEVICE_URL = `${META_AUTH_BASE_URL}/oidc/device/authorization/`;
+const META_OAUTH_TOKEN_URL = `${META_AUTH_BASE_URL}/oidc/device/token/`;
+const META_MINT_URL = `${META_API_BASE_URL}/muse-code/key`;
+const META_X_API_VERSION = "1.0.0";
+const META_ONBOARD_URL = "https://dev.meta.ai";
+
+// Muse Code's OAuth client id, borrowed as a POC mock pending a Meta-issued
+// client id for omp (user in talks). `MUSE_CLIENT_ID` overrides it so the swap
+// needs no rebuild.
+const DEFAULT_META_CLIENT_ID = "1031625952748946";
+
+const TOKEN_REQUEST_TIMEOUT_MS = 20_000;
+
+const META_LOGIN_CHOICE_MESSAGE = [
+	"How do you want to sign in to Meta Model API?",
+	"1. Sign in with browser (Meta account)",
+	"2. Paste an API key (dashboard or MMA keys)",
+	"Enter 1 or 2",
+].join("\n");
+
+interface MetaDeviceAuthorization {
+	deviceCode: string;
+	userCode: string;
+	/** Full verification URL (code pre-embedded when the server provides it). */
+	verificationUrl: string;
+	expiresInSeconds: number;
+	intervalSeconds: number;
+}
+
+interface MetaAccountTokens {
+	access: string;
+}
+
+interface MetaMintedKey {
+	apiKey: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+/** Resolve the OAuth client id: `MUSE_CLIENT_ID` override, else the borrowed Muse default. */
+function resolveMetaClientId(): string {
+	const override = $env.MUSE_CLIENT_ID?.trim();
+	return override && override.length > 0 ? override : DEFAULT_META_CLIENT_ID;
+}
+
+/**
+ * Validate a Meta auth URL against its scheme and host.
+ *
+ * The verification URL is opened in the user's browser, so pin it to the
+ * Meta auth origin rather than following a response-supplied redirect.
+ *
+ * @throws OAuthError `Invalid Meta <field>: <url>` when scheme or host fails.
+ */
+function validateMetaAuthUrl(url: string, field: string): string {
+	let parsed: URL;
+	try {
+		parsed = new URL(url);
+	} catch {
+		throw new AIError.OAuthError(`Invalid Meta ${field}: ${url}`, {
+			kind: "validation",
+			provider: "meta",
+		});
+	}
+	if (parsed.protocol !== "https:") {
+		throw new AIError.OAuthError(`Invalid Meta ${field}: ${url}`, {
+			kind: "validation",
+			provider: "meta",
+		});
+	}
+	const host = parsed.hostname.toLowerCase();
+	const valid =
+		host === "meta.com" || host.endsWith(".meta.com") || host === "facebook.com" || host.endsWith(".facebook.com");
+	if (!valid) {
+		throw new AIError.OAuthError(`Invalid Meta ${field}: ${url}`, {
+			kind: "validation",
+			provider: "meta",
+		});
+	}
+	return url;
+}
+
+function parseMetaDeviceAuthorization(payload: unknown): MetaDeviceAuthorization {
+	if (!isRecord(payload)) {
+		throw new AIError.OAuthError("Meta device-code response was not a JSON object.", {
+			kind: "validation",
+			provider: "meta",
+		});
+	}
+	const deviceCode = typeof payload.device_code === "string" ? payload.device_code.trim() : "";
+	const userCode = typeof payload.user_code === "string" ? payload.user_code.trim() : "";
+	// RFC 8628 servers commonly omit `verification_uri_complete`; either field
+	// is enough to route the user (the code is shown alongside either way).
+	const verificationUrl =
+		(typeof payload.verification_uri_complete === "string" ? payload.verification_uri_complete.trim() : "") ||
+		(typeof payload.verification_uri === "string" ? payload.verification_uri.trim() : "");
+	const expiresInSeconds = payload.expires_in;
+	const intervalSeconds = payload.interval;
+	if (
+		!deviceCode ||
+		!userCode ||
+		!verificationUrl ||
+		typeof expiresInSeconds !== "number" ||
+		!Number.isFinite(expiresInSeconds) ||
+		expiresInSeconds <= 0 ||
+		typeof intervalSeconds !== "number" ||
+		!Number.isFinite(intervalSeconds) ||
+		intervalSeconds <= 0
+	) {
+		throw new AIError.OAuthError("Meta device-code response missing or invalid required fields.", {
+			kind: "validation",
+			provider: "meta",
+		});
+	}
+	return {
+		deviceCode,
+		userCode,
+		verificationUrl: validateMetaAuthUrl(verificationUrl, "verification_uri"),
+		expiresInSeconds,
+		intervalSeconds,
+	};
+}
+
+/** POST the device-authorization form (client_id only — no scope, per Muse). */
+async function requestMetaDeviceAuthorization(
+	fetchImpl: FetchImpl,
+	signal?: AbortSignal,
+): Promise<MetaDeviceAuthorization> {
+	let response: Response;
+	try {
+		const timeoutSignal = AbortSignal.timeout(TOKEN_REQUEST_TIMEOUT_MS);
+		response = await fetchImpl(META_OAUTH_DEVICE_URL, {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/x-www-form-urlencoded",
+				Accept: "application/json",
+				"x-api-version": META_X_API_VERSION,
+			},
+			body: new URLSearchParams({ client_id: resolveMetaClientId() }),
+			redirect: "error",
+			signal: signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal,
+		});
+	} catch (error) {
+		if (signal?.aborted) throw new AIError.LoginCancelledError();
+		throw new AIError.OAuthError(
+			`Meta device-code request failed: ${error instanceof Error ? error.message : String(error)}`,
+			{ kind: "device-auth", provider: "meta", cause: error },
+		);
+	}
+	if (!response.ok) {
+		let detail = "";
+		try {
+			detail = (await response.text()).trim();
+		} catch {
+			// Status code is the diagnostic when the body is unreadable.
+		}
+		throw new AIError.OAuthError(`Meta device-code request failed: ${response.status}${detail ? ` ${detail}` : ""}`, {
+			kind: "device-auth",
+			provider: "meta",
+			status: response.status,
+		});
+	}
+	let payload: unknown;
+	try {
+		payload = await response.json();
+	} catch (error) {
+		throw new AIError.OAuthError(
+			`Meta device-code response returned invalid JSON: ${error instanceof Error ? error.message : String(error)}`,
+			{ kind: "validation", provider: "meta", cause: error },
+		);
+	}
+	return parseMetaDeviceAuthorization(payload);
+}
+
+/**
+ * Poll the device token endpoint once and classify the outcome. Terminal
+ * RFC 8628 errors (`access_denied`, `expired_token`, …) stop the flow; the
+ * shared poller translates pending/slow_down into back-off.
+ */
+async function pollMetaDeviceToken(
+	deviceCode: string,
+	fetchImpl: FetchImpl,
+	signal?: AbortSignal,
+): Promise<OAuthDeviceCodePollResult<MetaAccountTokens>> {
+	let response: Response;
+	try {
+		const timeoutSignal = AbortSignal.timeout(TOKEN_REQUEST_TIMEOUT_MS);
+		response = await fetchImpl(META_OAUTH_TOKEN_URL, {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/x-www-form-urlencoded",
+				Accept: "application/json",
+				"x-api-version": META_X_API_VERSION,
+			},
+			body: new URLSearchParams({
+				grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+				client_id: resolveMetaClientId(),
+				device_code: deviceCode,
+			}),
+			redirect: "error",
+			signal: signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal,
+		});
+	} catch (error) {
+		if (signal?.aborted) throw new AIError.LoginCancelledError();
+		throw new AIError.OAuthError(
+			`Meta device-code token polling failed: ${error instanceof Error ? error.message : String(error)}`,
+			{ kind: "polling", provider: "meta", cause: error },
+		);
+	}
+
+	let payload: unknown;
+	try {
+		payload = await response.json();
+	} catch (error) {
+		throw new AIError.OAuthError(
+			`Meta device-code token polling returned invalid JSON: ${
+				error instanceof Error ? error.message : String(error)
+			}`,
+			{
+				kind: "polling",
+				provider: "meta",
+				status: response.status,
+				cause: error,
+			},
+		);
+	}
+
+	const errorCode = isRecord(payload) && typeof payload.error === "string" ? payload.error : "";
+	if (errorCode === "authorization_pending") return { status: "pending" };
+	if (errorCode === "slow_down") return { status: "slow_down" };
+
+	if (!response.ok || errorCode) {
+		const errorDescription =
+			isRecord(payload) && typeof payload.error_description === "string" ? payload.error_description : "";
+		const detail = errorDescription || errorCode || String(response.status);
+		throw new AIError.OAuthError(`Meta device-code sign-in failed: ${detail}`, {
+			kind: "device-auth",
+			provider: "meta",
+			status: response.status,
+		});
+	}
+
+	const accessToken = isRecord(payload) && typeof payload.access_token === "string" ? payload.access_token.trim() : "";
+	if (!accessToken) {
+		throw new AIError.OAuthError("Meta device-code token response missing access_token.", {
+			kind: "validation",
+			provider: "meta",
+		});
+	}
+	return { status: "complete", value: { access: accessToken } };
+}
+
+/**
+ * Mint a Model API key from an authorized Meta account grant.
+ *
+ * Terminal account states are surfaced as structured OAuthErrors:
+ * not-onboarded → `provisioning` (route to {@link META_ONBOARD_URL});
+ * subscription/payment gate → `entitlement` (route to `action_url`).
+ */
+async function mintMetaModelApiKey(
+	accessToken: string,
+	fetchImpl: FetchImpl,
+	signal?: AbortSignal,
+): Promise<MetaMintedKey> {
+	let response: Response;
+	try {
+		const timeoutSignal = AbortSignal.timeout(TOKEN_REQUEST_TIMEOUT_MS);
+		response = await fetchImpl(META_MINT_URL, {
+			method: "POST",
+			headers: {
+				Authorization: `Bearer ${accessToken}`,
+				"Content-Type": "application/json",
+				Accept: "application/json",
+				"x-api-version": META_X_API_VERSION,
+			},
+			body: JSON.stringify({ onboard: true }),
+			redirect: "error",
+			signal: signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal,
+		});
+	} catch (error) {
+		if (signal?.aborted) throw new AIError.LoginCancelledError();
+		throw new AIError.OAuthError(
+			`Meta Model API key mint failed: ${error instanceof Error ? error.message : String(error)}`,
+			{ kind: "provisioning", provider: "meta", cause: error },
+		);
+	}
+
+	let payload: unknown;
+	try {
+		payload = await response.json();
+	} catch (error) {
+		throw new AIError.OAuthError(
+			`Meta Model API key mint returned invalid JSON: ${error instanceof Error ? error.message : String(error)}`,
+			{ kind: "validation", provider: "meta", cause: error },
+		);
+	}
+	if (!isRecord(payload)) {
+		throw new AIError.OAuthError("Meta Model API key mint response was not a JSON object.", {
+			kind: "validation",
+			provider: "meta",
+		});
+	}
+
+	const apiKey = typeof payload.api_key === "string" ? payload.api_key.trim() : "";
+	if (apiKey) {
+		return { apiKey };
+	}
+
+	// Account-gate states (schema inferred from the Muse binary, confirmed on a
+	// live account sign-in).
+	const errorText = [payload.error, payload.message, payload.error_code]
+		.filter((v): v is string => typeof v === "string")
+		.join(" ");
+
+	if (payload.require_payment === true || /pay|subscription|plan/i.test(errorText)) {
+		const actionUrl = typeof payload.action_url === "string" ? payload.action_url.trim() : "";
+		throw new AIError.OAuthError(
+			`Meta subscription required to mint a Model API key.${actionUrl ? ` Subscribe here: ${actionUrl}` : ""}`,
+			{ kind: "entitlement", provider: "meta", status: response.status },
+		);
+	}
+	if (/onboard|dev\.meta\.ai/i.test(errorText)) {
+		throw new AIError.OAuthError(
+			`Meta account is not onboarded for Model API. Complete onboarding at ${META_ONBOARD_URL} and try again.`,
+			{ kind: "provisioning", provider: "meta", status: response.status },
+		);
+	}
+
+	throw new AIError.OAuthError(
+		`Meta Model API key mint failed: HTTP ${response.status}${errorText ? ` ${errorText}` : ""}`,
+		{ kind: "provisioning", provider: "meta", status: response.status },
+	);
+}
+
+/**
+ * Browser sign-in: authorize against the Meta account, poll to approval, mint
+ * the Model API key, and discard the account grant.
+ *
+ * Opens the device verification URL (via `onAuth`), polls until the user
+ * approves, mints the key, and returns it. Throws {@link AIError.OAuthError}
+ * on denial, expiry, timeout, or account states that block minting.
+ */
+async function loginMetaAccount(callbacks: OAuthController): Promise<string> {
+	const fetchImpl = callbacks.fetch ?? fetch;
+	const device = await requestMetaDeviceAuthorization(fetchImpl, callbacks.signal);
+	callbacks.onAuth?.({
+		url: device.verificationUrl,
+		instructions: `Enter code: ${device.userCode}`,
+	});
+	callbacks.onProgress?.("Waiting for Meta account authorization...");
+
+	const tokens = await pollOAuthDeviceCodeFlow({
+		poll: () => pollMetaDeviceToken(device.deviceCode, fetchImpl, callbacks.signal),
+		intervalSeconds: device.intervalSeconds,
+		expiresInSeconds: device.expiresInSeconds,
+		signal: callbacks.signal,
+	});
+
+	callbacks.onProgress?.("Minting Model API key...");
+	const minted = await mintMetaModelApiKey(tokens.access, fetchImpl, callbacks.signal);
+	return minted.apiKey;
+}
+
+/** Paste an API key from the Meta Model API dashboard, validated against /v1/models. */
+async function pasteMetaApiKey(callbacks: OAuthController): Promise<string> {
+	if (!callbacks.onPrompt) {
+		throw new AIError.OnPromptRequiredError("Meta Model API");
+	}
+	callbacks.onAuth?.({
+		url: META_DASHBOARD_URL,
+		instructions: META_DASHBOARD_INSTRUCTIONS,
+	});
+	const answer = await callbacks.onPrompt({
+		message: "Paste your Meta Model API key",
+		placeholder: "Model API key",
+	});
+	if (callbacks.signal?.aborted) {
+		throw new AIError.LoginCancelledError();
+	}
+	const trimmed = answer.trim();
+	if (!trimmed) {
+		throw new AIError.ApiKeyRequiredError();
+	}
+	callbacks.onProgress?.("Validating API key...");
+	await validateApiKeyAgainstModelsEndpoint({
+		provider: "Meta Model API",
+		apiKey: trimmed,
+		modelsUrl: META_MODELS_URL,
+		signal: callbacks.signal,
+		fetch: callbacks.fetch,
+	});
+	return trimmed;
+}
+
+/**
+ * `meta` custom login hook: Muse-Code-style choice between browser sign-in
+ * (device flow + mint) and pasting a dashboard key. Enter (empty) defaults to
+ * browser sign-in, Muse's primary first-run action; returns the key string
+ * either way so `AuthStorage` persists an `api_key` row.
+ */
+export async function loginMetaHook(callbacks: OAuthController): Promise<string> {
+	if (!callbacks.onPrompt) {
+		throw new AIError.OnPromptRequiredError("Meta Model API");
+	}
+	const choice = (
+		await callbacks.onPrompt({
+			message: META_LOGIN_CHOICE_MESSAGE,
+			placeholder: "1",
+		})
+	).trim();
+	if (callbacks.signal?.aborted) {
+		throw new AIError.LoginCancelledError();
+	}
+	if (choice === "2") {
+		return pasteMetaApiKey(callbacks);
+	}
+	return loginMetaAccount(callbacks);
+}

--- a/packages/ai/test/meta-provider.test.ts
+++ b/packages/ai/test/meta-provider.test.ts
@@ -44,12 +44,17 @@ describe("Meta Model API Responses requests", () => {
 });
 
 describe("Meta Model API login", () => {
-	test("validates pasted keys against the models endpoint without running inference", async () => {
+	test("paste menu option validates the key against the models endpoint without running inference", async () => {
 		let requestedUrl = "";
 		let authorization = "";
+		let promptCount = 0;
 		const apiKey = await loginMeta({
 			onAuth: () => {},
-			onPrompt: async () => " meta-test-key ",
+			onPrompt: async () => {
+				promptCount += 1;
+				// First prompt is the method menu; pick paste, then supply the key.
+				return promptCount === 1 ? "2" : " meta-test-key ";
+			},
 			fetch: (input, init) => {
 				requestedUrl = String(input);
 				authorization = new Headers(init?.headers).get("Authorization") ?? "";
@@ -58,6 +63,7 @@ describe("Meta Model API login", () => {
 		});
 
 		expect(apiKey).toBe("meta-test-key");
+		expect(promptCount).toBe(2);
 		expect(requestedUrl).toBe("https://api.meta.ai/v1/models");
 		expect(authorization).toBe("Bearer meta-test-key");
 	});

--- a/packages/ai/test/registry/oauth/meta-oauth.test.ts
+++ b/packages/ai/test/registry/oauth/meta-oauth.test.ts
@@ -1,0 +1,293 @@
+import { describe, expect, it, vi } from "bun:test";
+import * as AIError from "../../../src/error";
+import { loginMetaHook } from "../../../src/registry/oauth/meta";
+import type { FetchImpl } from "../../../src/types";
+
+const DEVICE_URL = "https://auth.meta.com/oidc/device/authorization/";
+const TOKEN_URL = "https://auth.meta.com/oidc/device/token/";
+const MINT_URL = "https://api.meta.ai/muse-code/key";
+
+const DEVICE_AUTHORIZATION = {
+	device_code: "device-code-123",
+	user_code: "ABCD-EFGH",
+	verification_uri: "https://auth.meta.com/activate",
+	verification_uri_complete: "https://auth.meta.com/activate?user_code=ABCD-EFGH",
+	expires_in: 600,
+	interval: 1,
+};
+
+type RecordedRequest = {
+	url: string;
+	init: RequestInit | undefined;
+};
+
+type JsonResponse = {
+	body: unknown;
+	status?: number;
+};
+
+function jsonResponse(body: unknown, status: number = 200): Response {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: { "Content-Type": "application/json" },
+	});
+}
+
+type MetaAccountFetchOptions = {
+	deviceAuth?: JsonResponse;
+	tokenResponses?: readonly JsonResponse[];
+	mint?: JsonResponse;
+};
+
+function createMetaAccountFetch(options: MetaAccountFetchOptions) {
+	const requests: RecordedRequest[] = [];
+	let tokenIndex = 0;
+	const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+		const url = typeof input === "string" ? input : input instanceof Request ? input.url : input.toString();
+		requests.push({ url, init });
+
+		if (url === DEVICE_URL) {
+			if (!options.deviceAuth) throw new Error(`Unexpected Meta device request ${requests.length}`);
+			return jsonResponse(options.deviceAuth.body, options.deviceAuth.status);
+		}
+		if (url === TOKEN_URL) {
+			const tokenResponse = options.tokenResponses?.[tokenIndex];
+			tokenIndex += 1;
+			if (!tokenResponse) throw new Error(`Unexpected Meta token poll ${tokenIndex}`);
+			return jsonResponse(tokenResponse.body, tokenResponse.status);
+		}
+		if (url === MINT_URL) {
+			if (!options.mint) throw new Error(`Unexpected Meta mint request ${requests.length}`);
+			return jsonResponse(options.mint.body, options.mint.status);
+		}
+		throw new Error(`Unexpected Meta request: ${url}`);
+	});
+
+	return { fetchMock: fetchMock as unknown as FetchImpl, requests };
+}
+
+/** Return the i-th recorded request, failing loudly when the flow made fewer calls than expected. */
+function requestAt(requests: readonly RecordedRequest[], index: number): RecordedRequest {
+	const request = requests[index];
+	if (!request) {
+		throw new Error(`Expected a Meta request at index ${index}, got ${requests.length}`);
+	}
+	return request;
+}
+
+function formBody(request: RecordedRequest): URLSearchParams {
+	const body = request.init?.body;
+	if (!(body instanceof URLSearchParams)) {
+		throw new Error("Expected an application/x-www-form-urlencoded body");
+	}
+	return body;
+}
+
+function jsonBody(request: RecordedRequest): unknown {
+	const body = request.init?.body;
+	if (typeof body !== "string") {
+		throw new Error("Expected a JSON string body");
+	}
+	return JSON.parse(body) as unknown;
+}
+
+function headerValue(request: RecordedRequest, name: string): string | undefined {
+	return new Headers(request.init?.headers).get(name) ?? undefined;
+}
+
+/** Run a browser-arm login (menu choice 1) and return the thrown error (or null on success). */
+async function runBrowserLogin(options: MetaAccountFetchOptions): Promise<{
+	apiKey: string | null;
+	error: unknown;
+	requests: RecordedRequest[];
+}> {
+	const { fetchMock, requests } = createMetaAccountFetch(options);
+	try {
+		const apiKey = await loginMetaHook({
+			fetch: fetchMock,
+			onAuth: () => {},
+			onProgress: () => {},
+			onPrompt: async () => "1",
+		});
+		return { apiKey, error: null, requests };
+	} catch (error) {
+		return { apiKey: null, error, requests };
+	}
+}
+
+const OK_TOKEN_RESPONSE = {
+	access_token: "account-access-token",
+	refresh_token: "refresh",
+	expires_in: 3600,
+};
+
+describe("loginMetaHook browser sign-in", () => {
+	it("authorizes, polls to approval, mints a key, and returns the minted key", async () => {
+		const { fetchMock, requests } = createMetaAccountFetch({
+			deviceAuth: { body: DEVICE_AUTHORIZATION },
+			tokenResponses: [{ body: { error: "authorization_pending" } }, { body: OK_TOKEN_RESPONSE }],
+			mint: { body: { api_key: "minted-key-123" } },
+		});
+
+		const authEvents: Array<{ url: string; instructions?: string }> = [];
+		const progress: string[] = [];
+		const apiKey = await loginMetaHook({
+			fetch: fetchMock,
+			onAuth: info => authEvents.push(info),
+			onProgress: message => progress.push(message),
+			onPrompt: async () => "1",
+		});
+
+		expect(apiKey).toBe("minted-key-123");
+		expect(authEvents).toEqual([
+			{
+				url: "https://auth.meta.com/activate?user_code=ABCD-EFGH",
+				instructions: "Enter code: ABCD-EFGH",
+			},
+		]);
+		expect(progress).toEqual(["Waiting for Meta account authorization...", "Minting Model API key..."]);
+
+		// x-api-version pins every call; no User-Agent is sent (Muse wire parity).
+		for (const request of requests) {
+			expect(headerValue(request, "x-api-version")).toBe("1.0.0");
+			expect(headerValue(request, "user-agent")).toBeUndefined();
+		}
+		expect(requests.map(request => request.url)).toEqual([DEVICE_URL, TOKEN_URL, TOKEN_URL, MINT_URL]);
+		expect(formBody(requestAt(requests, 0)).get("client_id")).toBe("1031625952748946");
+		const poll = formBody(requestAt(requests, 2));
+		expect(poll.get("grant_type")).toBe("urn:ietf:params:oauth:grant-type:device_code");
+		expect(poll.get("device_code")).toBe("device-code-123");
+		const mint = requestAt(requests, 3);
+		expect(headerValue(mint, "Authorization")).toBe("Bearer account-access-token");
+		expect(jsonBody(mint)).toEqual({ onboard: true });
+	});
+
+	it("defaults an empty menu choice to browser sign-in like Muse's primary action", async () => {
+		const { fetchMock, requests } = createMetaAccountFetch({
+			deviceAuth: { body: DEVICE_AUTHORIZATION },
+			tokenResponses: [{ body: OK_TOKEN_RESPONSE }],
+			mint: { body: { api_key: "minted-key-123" } },
+		});
+
+		const apiKey = await loginMetaHook({
+			fetch: fetchMock,
+			onAuth: () => {},
+			onPrompt: async () => "",
+		});
+
+		expect(apiKey).toBe("minted-key-123");
+		expect(requests.map(request => request.url)).toEqual([DEVICE_URL, TOKEN_URL, MINT_URL]);
+	});
+
+	it("falls back to verification_uri and surfaces the code when _complete is absent", async () => {
+		const { fetchMock, requests } = createMetaAccountFetch({
+			deviceAuth: {
+				body: { ...DEVICE_AUTHORIZATION, verification_uri_complete: undefined },
+			},
+			tokenResponses: [{ body: OK_TOKEN_RESPONSE }],
+			mint: { body: { api_key: "minted-key-123" } },
+		});
+		const authEvents: Array<{ url: string; instructions?: string }> = [];
+		await loginMetaHook({
+			fetch: fetchMock,
+			onAuth: info => authEvents.push(info),
+			onPrompt: async () => "1",
+		});
+
+		expect(authEvents).toEqual([
+			{
+				url: "https://auth.meta.com/activate",
+				instructions: "Enter code: ABCD-EFGH",
+			},
+		]);
+		expect(requests).toHaveLength(3);
+	});
+
+	it("rejects terminal access_denied without minting", async () => {
+		const { error, requests } = await runBrowserLogin({
+			deviceAuth: { body: DEVICE_AUTHORIZATION },
+			tokenResponses: [
+				{
+					body: {
+						error: "access_denied",
+						error_description: "User denied the request",
+					},
+				},
+			],
+			mint: { body: { api_key: "never" } },
+		});
+
+		expect(error).toBeInstanceOf(AIError.OAuthError);
+		expect(String(error)).toMatch(/denied the request/);
+		expect(requests.map(request => request.url)).toEqual([DEVICE_URL, TOKEN_URL]);
+	});
+
+	it("rejects an expired device code", async () => {
+		const { error, requests } = await runBrowserLogin({
+			deviceAuth: { body: DEVICE_AUTHORIZATION },
+			tokenResponses: [{ body: { error: "expired_token" } }],
+			mint: { body: { api_key: "never" } },
+		});
+
+		expect(error).toBeInstanceOf(AIError.OAuthError);
+		expect((error as AIError.OAuthError).kind).toBe("device-auth");
+		expect(String(error)).toMatch(/expired_token/);
+		expect(requests).toHaveLength(2);
+	});
+
+	it("classifies a slow_down token response as a retry, not a failure", async () => {
+		const { apiKey, requests } = await runBrowserLogin({
+			deviceAuth: { body: DEVICE_AUTHORIZATION },
+			tokenResponses: [{ body: { error: "slow_down" } }, { body: OK_TOKEN_RESPONSE }],
+			mint: { body: { api_key: "minted-key-123" } },
+		});
+
+		// RFC 8628 slow_down back-off (+5s per response) makes this poll cadence
+		// real: allow the retry sleep inside the helper to elapse.
+		expect(apiKey).toBe("minted-key-123");
+		expect(requests.map(request => request.url)).toEqual([DEVICE_URL, TOKEN_URL, TOKEN_URL, MINT_URL]);
+	}, 15_000);
+});
+
+describe("loginMetaHook mint states", () => {
+	it("maps require_payment to an entitlement error carrying the action URL", async () => {
+		const { error } = await runBrowserLogin({
+			deviceAuth: { body: DEVICE_AUTHORIZATION },
+			tokenResponses: [{ body: OK_TOKEN_RESPONSE }],
+			mint: {
+				body: {
+					require_payment: true,
+					action_url: "https://www.meta.ai/subscribe",
+				},
+			},
+		});
+
+		expect(error).toBeInstanceOf(AIError.OAuthError);
+		expect((error as AIError.OAuthError).kind).toBe("entitlement");
+		expect(String(error)).toMatch(/https:\/\/www\.meta\.ai\/subscribe/);
+	});
+
+	it("maps not-onboarded to a provisioning error routing to dev.meta.ai", async () => {
+		const { error } = await runBrowserLogin({
+			deviceAuth: { body: DEVICE_AUTHORIZATION },
+			tokenResponses: [{ body: OK_TOKEN_RESPONSE }],
+			mint: {
+				body: { error: "account not onboarded", status: 400 },
+				status: 400,
+			},
+		});
+
+		expect(error).toBeInstanceOf(AIError.OAuthError);
+		expect((error as AIError.OAuthError).kind).toBe("provisioning");
+		expect(String(error)).toMatch(/dev\.meta\.ai/);
+	});
+
+	it("propagates a failed device-code request as a device-auth error", async () => {
+		const { error } = await runBrowserLogin({
+			deviceAuth: { body: { error: "server_error" }, status: 500 },
+		});
+
+		expect(error).toBeInstanceOf(AIError.OAuthError);
+		expect((error as AIError.OAuthError).kind).toBe("device-auth");
+	});
+});

--- a/packages/catalog/src/compat/rules.json
+++ b/packages/catalog/src/compat/rules.json
@@ -16292,15 +16292,8 @@
 				"apiKeyFormat": "bearer",
 				"name": "Meta Model API",
 				"login": {
-					"kind": "api-key",
-					"authUrl": "https://developer.meta.com/ai/",
-					"instructions": "Create or copy your key from the Meta Model API dashboard",
-					"prompt": "Paste your Meta Model API key",
-					"placeholder": "Model API key",
-					"validate": {
-						"kind": "models-endpoint",
-						"url": "https://api.meta.ai/v1/models"
-					}
+					"kind": "custom",
+					"hook": "meta"
 				}
 			},
 			{

--- a/packages/catalog/src/compat/rules/auth/meta.kdl
+++ b/packages/catalog/src/compat/rules/auth/meta.kdl
@@ -1,9 +1,7 @@
 auth "meta" {
 	name "Meta Model API"
-	login "api-key" {
-		auth-url "https://developer.meta.com/ai/"
-		instructions "Create or copy your key from the Meta Model API dashboard"
-		prompt "Paste your Meta Model API key" placeholder="Model API key"
-		validate "models-endpoint" url="https://api.meta.ai/v1/models"
-	}
+	// Muse-Code-style login, implemented by the `meta` custom hook in
+	// @oh-my-pi/pi-ai: browser sign-in (device flow + Model API key mint) or
+	// pasting a dashboard key (MMA accounts and CI cannot use browser sign-in).
+	login "custom" hook="meta"
 }


### PR DESCRIPTION
What

Adds Muse-Code-style browser sign-in for the Meta Model API (/login → meta): RFC 8628 device authorization against
auth.meta.com, polling to approval, then minting a Model API key from the account grant at api.meta.ai/muse-code/key.
The minted key is persisted as an api_key row under provider meta, so the existing transport picks it up with no wire
changes; pasting a dashboard key stays first-class (MMA accounts and CI cannot use browser sign-in per Meta docs).

Ports cleanly onto the declarative auth architecture: rules/auth/meta.kdl now declares login "custom" hook="meta" (+
regenerated rules.json), registered in hooks/custom.ts, with the full menu/device-flow/mint/paste implemented in
registry/oauth/meta.ts (loginMetaHook). Adds OAuthErrorKind "entitlement" for the mint require_payment gate;
not-onboarded maps to provisioning routing to dev.meta.ai.

POC scoping: the OAuth client id 1031625952748946 is borrowed from Muse Code (overridable via MUSE_CLIENT_ID) pending a
Meta-issued id;

Why

The meta login previously only accepted a dashboard key; the Muse "Sign in with browser (Meta account)" path was missing
entirely. Follows docs/meta-login-poc-plan.md (branch meta-muse-login).