### PR TITLE
fix(acp): filter invalid read locations

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed ACP clients receiving non-file read locations and updates for released terminals, preventing invalid worktree scans and terminal errors on Windows ([#10678](https://github.com/can1357/oh-my-pi/issues/10678)).
+
 ## [18.1.6] - 2026-09-03
 
 ### Breaking Changes

--- a/packages/coding-agent/src/modes/acp/acp-event-mapper.ts
+++ b/packages/coding-agent/src/modes/acp/acp-event-mapper.ts
@@ -1,3 +1,4 @@
+import * as fs from "node:fs";
 import type {
 	SessionNotification,
 	SessionUpdate,
@@ -8,7 +9,7 @@ import type {
 } from "@oh-my-pi/pi-utils/acp";
 import { parseXdUrl } from "../../internal-urls/xd-protocol";
 import type { AgentSessionEvent } from "../../session/agent-session";
-import { resolveToCwd, splitPathAndSel, splitPathAndSelPreferringLiteralSync } from "../../tools/path-utils";
+import { resolveToCwd, splitPathAndSelPreferringLiteralSync } from "../../tools/path-utils";
 import type { TodoStatus } from "../../tools/todo";
 import { canonicalizeMessage } from "../../utils/thinking-display";
 
@@ -58,6 +59,10 @@ interface BinaryLikeContent extends TypedValue {
 
 interface PathContainer {
 	path?: unknown;
+}
+
+interface ResolvedPathContainer {
+	resolvedPath?: unknown;
 }
 
 interface OldPathContainer {
@@ -642,23 +647,34 @@ function toAcpLocationPath(value: string, cwd?: string): string {
  */
 const INTERNAL_URL_SUBJECT = /^[a-z][a-z0-9+.-]*:\/\//i;
 
+function existingFileLocationPath(raw: string | undefined, cwd?: string): string | undefined {
+	if (!raw || INTERNAL_URL_SUBJECT.test(raw)) return undefined;
+	const resolved = toAcpLocationPath(raw, cwd);
+	try {
+		return fs.statSync(resolved).isFile() ? resolved : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
 /**
- * For the `read` tool, peel a trailing read selector (`:1-20`, `:raw`,
- * `:1-20:raw`, comma-separated ranges) off the filesystem path so the ACP
- * location names the file actually accessed rather than the selector-bearing
- * expression — Zed Follow otherwise treats the selector as part of the
- * filename and opens an empty buffer. Literal POSIX filenames that legitimately
- * end in selector-shaped text (e.g. `report:1-20`) are preserved via the same
- * literal-path precedence the read tool uses. Non-read tools and internal URLs
- * pass through unchanged — colons in write/edit targets are valid filenames.
+ * Return the single existing file represented by a `read` argument.
+ *
+ * ACP locations are editor navigation targets, not tool inputs. Read inputs may
+ * name selectors, delimited paths, globs, directories, archive members, or
+ * internal resources, so only a path that resolves to a regular file is safe
+ * to publish. Literal selector-shaped filenames retain read-tool precedence.
  */
 function readLocationBasePath(
 	raw: string | undefined,
 	cwd: string | undefined,
 	toolName: string | undefined,
 ): string | undefined {
-	if (raw === undefined || toolName !== "read" || INTERNAL_URL_SUBJECT.test(raw)) return raw;
-	return cwd ? splitPathAndSelPreferringLiteralSync(raw, cwd).path : splitPathAndSel(raw).path;
+	if (raw === undefined || toolName !== "read") return raw;
+	if (!cwd || INTERNAL_URL_SUBJECT.test(raw)) return undefined;
+
+	const candidate = splitPathAndSelPreferringLiteralSync(raw, cwd).path;
+	return existingFileLocationPath(candidate, cwd);
 }
 
 function extractToolLocations(args: unknown, cwd?: string, toolName?: string): ToolCallLocation[] {
@@ -685,6 +701,13 @@ function extractToolLocationsFromResult(result: unknown, cwd?: string): ToolCall
 	const details = (result as { details?: unknown }).details;
 	if (typeof details !== "object" || details === null) return [];
 	const direct = extractToolLocations(details, cwd);
+	const resolvedFile = existingFileLocationPath(
+		extractStringProperty<ResolvedPathContainer>(details, "resolvedPath"),
+		cwd,
+	);
+	if (resolvedFile && !direct.some(location => location.path === resolvedFile)) {
+		direct.push({ path: resolvedFile });
+	}
 	const perFile = (details as { perFileResults?: unknown }).perFileResults;
 	if (!Array.isArray(perFile)) {
 		return direct;

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -354,6 +354,7 @@ export interface BashToolDetails {
 	exitCode?: number;
 	/** True when the command was killed by its timeout deadline (not a failure). */
 	timedOut?: boolean;
+	/** Live ACP update only; completed results refer to released terminals. */
 	terminalId?: string;
 	async?: {
 		state: "running" | "completed" | "failed";
@@ -676,7 +677,6 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 		options: {
 			requestedTimeoutSec?: number;
 			notices?: readonly string[];
-			terminalId?: string;
 			wallTimeMs?: number;
 		} = {},
 	): Promise<AgentToolResult<BashToolDetails>> {
@@ -712,9 +712,6 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 		}
 		if (options.requestedTimeoutSec !== undefined && options.requestedTimeoutSec !== timeoutSec) {
 			details.requestedTimeoutSeconds = options.requestedTimeoutSec;
-		}
-		if (options.terminalId !== undefined) {
-			details.terminalId = options.terminalId;
 		}
 		if (options.wallTimeMs !== undefined) {
 			details.wallTimeMs = options.wallTimeMs;
@@ -1364,7 +1361,6 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 				return this.#buildCompletedResult(bridgeResult, timeoutSec, {
 					requestedTimeoutSec,
 					notices: bridgeNotices,
-					terminalId: handle.terminalId,
 					wallTimeMs: performance.now() - bridgeWallTimeStart,
 				});
 			} finally {

--- a/packages/coding-agent/test/acp-event-mapper.test.ts
+++ b/packages/coding-agent/test/acp-event-mapper.test.ts
@@ -1039,26 +1039,32 @@ describe("ACP event mapper", () => {
 	});
 
 	it("builds replayed read tool-call locations against the replay cwd", () => {
-		const replayArgs = normalizeReplayToolArguments(JSON.stringify({ path: "src/foo.ts" }));
-		const update = buildToolCallStartUpdate({
-			toolCallId: "toolu_replay_read",
-			toolName: "read",
-			args: replayArgs.args,
-			cwd: path.resolve("/repo"),
-			status: "completed",
-		});
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "acp-replay-read-"));
+		fs.writeFileSync(path.join(dir, "foo.ts"), "data\n");
+		try {
+			const replayArgs = normalizeReplayToolArguments(JSON.stringify({ path: "foo.ts" }));
+			const update = buildToolCallStartUpdate({
+				toolCallId: "toolu_replay_read",
+				toolName: "read",
+				args: replayArgs.args,
+				cwd: dir,
+				status: "completed",
+			});
 
-		expectAcpStructure(arkSessionNotification, { sessionId: "session-1", update });
-		expect(update).toMatchObject({
-			sessionUpdate: "tool_call",
-			toolCallId: "toolu_replay_read",
-			title: "read: src/foo.ts",
-			kind: "read",
-			status: "completed",
-			rawInput: { path: "src/foo.ts" },
-			locations: [{ path: path.resolve("/repo", "src/foo.ts") }],
-		});
-		expect("content" in update).toBe(false);
+			expectAcpStructure(arkSessionNotification, { sessionId: "session-1", update });
+			expect(update).toMatchObject({
+				sessionUpdate: "tool_call",
+				toolCallId: "toolu_replay_read",
+				title: "read: foo.ts",
+				kind: "read",
+				status: "completed",
+				rawInput: { path: "foo.ts" },
+				locations: [{ path: path.join(dir, "foo.ts") }],
+			});
+			expect("content" in update).toBe(false);
+		} finally {
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
 	});
 
 	it("keeps malformed replay arguments as raw input without command content", () => {
@@ -1126,53 +1132,109 @@ describe("ACP event mapper", () => {
 		expect(update.title).toBe("read: README.md");
 		expect(update.kind).toBe("read");
 		expect(update.rawInput).toEqual({ path: "README.md" });
-		expect(update.locations).toEqual([{ path: "README.md" }]);
+		expect("locations" in update).toBe(false);
 		expect("content" in update).toBe(false);
 	});
 	it("resolves tool_execution_start locations against mapper cwd", () => {
-		const updates = mapAgentSessionEventToAcpSessionUpdates(
-			{
-				type: "tool_execution_start",
-				toolCallId: "toolu_read_cwd",
-				toolName: "read",
-				args: { path: "src/file.ts" },
-			} as AgentSessionEvent,
-			"session-1",
-			{ cwd: "/repo" },
-		);
-
-		expect(updates).toHaveLength(1);
-		expectAcpNotifications(updates);
-		const update = updates[0]!.update as { sessionUpdate: string; locations?: { path: string }[]; content?: unknown };
-		expect(update.sessionUpdate).toBe("tool_call");
-		expect(update.locations).toEqual([{ path: path.resolve("/repo", "src/file.ts") }]);
-		expect("content" in update).toBe(false);
-	});
-	it("strips read selectors from the ACP location while preserving rawInput", () => {
-		const cases: Array<{ path: string; base: string }> = [
-			{ path: "src/file.ts:1-20", base: "src/file.ts" },
-			{ path: "src/file.ts:raw", base: "src/file.ts" },
-			{ path: "src/file.ts:1-20:raw", base: "src/file.ts" },
-			{ path: "src/file.ts:raw:1-20", base: "src/file.ts" },
-			{ path: "src/file.ts:5-16,960-973", base: "src/file.ts" },
-		];
-		for (const { path: readPath, base } of cases) {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "acp-read-cwd-"));
+		fs.writeFileSync(path.join(dir, "file.ts"), "data\n");
+		try {
 			const updates = mapAgentSessionEventToAcpSessionUpdates(
 				{
 					type: "tool_execution_start",
-					toolCallId: `toolu_read_sel_${base}`,
+					toolCallId: "toolu_read_cwd",
 					toolName: "read",
-					args: { path: readPath },
+					args: { path: "file.ts" },
 				} as AgentSessionEvent,
 				"session-1",
-				{ cwd: "/repo" },
+				{ cwd: dir },
+			);
+
+			expect(updates).toHaveLength(1);
+			expectAcpNotifications(updates);
+			const update = updates[0]!.update as {
+				sessionUpdate: string;
+				locations?: { path: string }[];
+				content?: unknown;
+			};
+			expect(update.sessionUpdate).toBe("tool_call");
+			expect(update.locations).toEqual([{ path: path.join(dir, "file.ts") }]);
+			expect("content" in update).toBe(false);
+		} finally {
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+	});
+	it("strips read selectors from the ACP location while preserving rawInput", () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "acp-read-selector-"));
+		fs.writeFileSync(path.join(dir, "file.ts"), "data\n");
+		const cases = ["file.ts:1-20", "file.ts:raw", "file.ts:1-20:raw", "file.ts:raw:1-20", "file.ts:5-16,960-973"];
+		try {
+			for (const readPath of cases) {
+				const updates = mapAgentSessionEventToAcpSessionUpdates(
+					{
+						type: "tool_execution_start",
+						toolCallId: `toolu_read_sel_${readPath}`,
+						toolName: "read",
+						args: { path: readPath },
+					} as AgentSessionEvent,
+					"session-1",
+					{ cwd: dir },
+				);
+				expectAcpNotifications(updates);
+				const update = updates[0]!.update as { locations?: { path: string }[]; rawInput?: unknown };
+				expect(update.locations).toEqual([{ path: path.join(dir, "file.ts") }]);
+				expect(update.rawInput).toEqual({ path: readPath });
+			}
+		} finally {
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+	});
+	it("omits read locations that are not single existing files", () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "acp-read-non-file-"));
+		fs.mkdirSync(path.join(dir, "docs"));
+		fs.writeFileSync(path.join(dir, "file.ts"), "data\n");
+		fs.writeFileSync(path.join(dir, "archive.rar"), "data\n");
+		const cases = ["src/**/*.ts", "file.ts:1-20; docs", "docs", "archive.rar:inner/SKILL.md"];
+		try {
+			for (const readPath of cases) {
+				const updates = mapAgentSessionEventToAcpSessionUpdates(
+					{
+						type: "tool_execution_start",
+						toolCallId: `toolu_read_non_file_${readPath}`,
+						toolName: "read",
+						args: { path: readPath },
+					} as AgentSessionEvent,
+					"session-1",
+					{ cwd: dir },
+				);
+				expectAcpNotifications(updates);
+				expect("locations" in updates[0]!.update).toBe(false);
+			}
+		} finally {
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+	});
+	it("publishes the resolved file location when a read completes", () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "acp-read-result-"));
+		const file = path.join(dir, "file.ts");
+		fs.writeFileSync(file, "data\n");
+		try {
+			const updates = mapAgentSessionEventToAcpSessionUpdates(
+				{
+					type: "tool_execution_end",
+					toolCallId: "toolu_read_result",
+					toolName: "read",
+					isError: false,
+					result: { content: [{ type: "text", text: "data" }], details: { resolvedPath: file } },
+				} as AgentSessionEvent,
+				"session-1",
+				{ cwd: dir },
 			);
 			expectAcpNotifications(updates);
-			const update = updates[0]!.update as { locations?: { path: string }[]; rawInput?: unknown };
-			expect(update.locations).toEqual([{ path: path.resolve("/repo", base) }]);
-			// The full selector-bearing expression stays in rawInput so the client
-			// can still see exactly what the model asked for.
-			expect(update.rawInput).toEqual({ path: readPath });
+			const update = updates[0]!.update as { locations?: { path: string }[] };
+			expect(update.locations).toEqual([{ path: file }]);
+		} finally {
+			fs.rmSync(dir, { recursive: true, force: true });
 		}
 	});
 	it("keeps a real file literally named like a selector as the read location", () => {

--- a/packages/coding-agent/test/bash-acp-terminal.test.ts
+++ b/packages/coding-agent/test/bash-acp-terminal.test.ts
@@ -60,7 +60,7 @@ afterEach(() => {
 });
 
 describe("BashTool ACP terminal routing", () => {
-	it("routes through bridge, emits terminalId update, and releases the handle", async () => {
+	it("emits a live terminal update but releases it before the completed result", async () => {
 		const stubText = "hello from terminal\n";
 
 		const handle: ClientBridgeTerminalHandle = {
@@ -103,8 +103,8 @@ describe("BashTool ACP terminal routing", () => {
 		const text = result.content.find(c => c.type === "text");
 		expect(text?.text).toContain("hello from terminal");
 
-		// The result details must carry terminalId for the ACP event mapper
-		expect(result.details?.terminalId).toBe("term-xyz");
+		// Completed tool updates must not refer clients to the released terminal.
+		expect(result.details?.terminalId).toBeUndefined();
 
 		// The handle must always be released
 		expect(releaseSpy).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## Repro
On current `main`, calling `mapAgentSessionEventToAcpSessionUpdates` for `read` inputs such as `src/**/*.ts`, `src/foo.ts:1-20; docs`, and `docs` emitted those expressions as `ToolCallLocation.path`; reproduced with `bun -e` importing `packages/coding-agent/src/modes/acp/acp-event-mapper.ts` and printing each mapped `tool_execution_start` update.

## Cause
`readLocationBasePath` in `packages/coding-agent/src/modes/acp/acp-event-mapper.ts` stripped line selectors but did not verify that the remaining value was one existing regular file, so globs, delimited expressions, directories, archive members, and unresolved paths reached ACP locations. Separately, `BashTool.#buildCompletedResult` retained the ACP terminal ID even though `BashTool.execute` released that handle in `finally` before the completed tool event was mapped.

## Fix
- Publish a read location only when it resolves to an existing regular file, while preserving literal selector-shaped filename precedence.
- Publish the resolved regular-file path from successful read results so safe navigation remains available after execution.
- Keep terminal IDs on live bash updates only; completed results no longer reference released handles.
- Add regression coverage and an Unreleased changelog entry.

## Verification
`bun test packages/coding-agent/test/acp-event-mapper.test.ts packages/coding-agent/test/bash-acp-terminal.test.ts` passes: 55 tests, 0 failures. Re-running the focused mapper reproduction reports `<omitted>` for the glob, delimited expression, and directory. The pre-publish `bun run fix` and `bun check` gate passed during branch push.

Fixes #10678