### PR TITLE
feat: add configurable currency symbol for cost display

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `statusLine.costPrefix` setting to customize the currency symbol displayed before cost amounts in the status line (default: `$`). Cosmetic only — does not convert values.
+
 ### Fixed
 
 - Fixed user-scope marketplace plugins installed through `omp` losing their skills unless the Claude plugin source was separately enabled ([#10662](https://github.com/can1357/oh-my-pi/issues/10662)).

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -976,7 +976,8 @@ export const SETTINGS_SCHEMA = {
 			tab: "appearance",
 			group: "Status Line",
 			label: "Cost Prefix",
-			description: "Prefix displayed before cost amounts (e.g. $, ¥, €, £). Cosmetic only — does not convert values.",
+			description:
+				"Prefix displayed before cost amounts (e.g. $, ¥, €, £). Cosmetic only — does not convert values.",
 		},
 	},
 

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -969,6 +969,17 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	"statusLine.currencySymbol": {
+		type: "string",
+		default: "$",
+		ui: {
+			tab: "appearance",
+			group: "Status Line",
+			label: "Currency Symbol",
+			description: "Symbol displayed before cost amounts (e.g. $, ¥, €, £)",
+		},
+	},
+
 	"statusLine.leftSegments": { type: "array", default: [] as StatusLineSegmentId[] },
 
 	"statusLine.rightSegments": { type: "array", default: [] as StatusLineSegmentId[] },
@@ -6294,6 +6305,7 @@ export interface StatusLineSettings {
 	preset: StatusLinePreset;
 	separator: StatusLineSeparatorStyle;
 	showHookStatus: boolean;
+	currencySymbol: string;
 	leftSegments: StatusLineSegmentId[];
 	rightSegments: StatusLineSegmentId[];
 	segmentOptions: Record<string, unknown>;

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -969,14 +969,14 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
-	"statusLine.currencySymbol": {
+	"statusLine.costPrefix": {
 		type: "string",
 		default: "$",
 		ui: {
 			tab: "appearance",
 			group: "Status Line",
-			label: "Currency Symbol",
-			description: "Symbol displayed before cost amounts (e.g. $, ¥, €, £)",
+			label: "Cost Prefix",
+			description: "Prefix displayed before cost amounts (e.g. $, ¥, €, £). Cosmetic only — does not convert values.",
 		},
 	},
 
@@ -6305,7 +6305,7 @@ export interface StatusLineSettings {
 	preset: StatusLinePreset;
 	separator: StatusLineSeparatorStyle;
 	showHookStatus: boolean;
-	currencySymbol: string;
+	costPrefix: string;
 	leftSegments: StatusLineSegmentId[];
 	rightSegments: StatusLineSegmentId[];
 	segmentOptions: Record<string, unknown>;

--- a/packages/coding-agent/src/modes/components/footer.ts
+++ b/packages/coding-agent/src/modes/components/footer.ts
@@ -217,6 +217,7 @@ export class FooterComponent implements Component {
 		const normalizedPremiumRequests = Math.round((totalPremiumRequests + Number.EPSILON) * 100) / 100;
 		if (totalCost || usingSubscription || normalizedPremiumRequests) {
 			const billingParts: string[] = [];
+			const costPrefix = sanitizeStatusText(settings.get("statusLine.costPrefix") ?? "$");
 			if (totalCost) {
 				const formatted = totalCost.toFixed(3);
 				if (usingSubscription) {
@@ -226,7 +227,7 @@ export class FooterComponent implements Component {
 							: `S${formatted}`;
 					billingParts.push(spend);
 				} else {
-					billingParts.push(`$${formatted}`);
+					billingParts.push(`${costPrefix}${formatted}`);
 				}
 			} else if (usingSubscription) {
 				billingParts.push(theme.getSymbolPreset() === "nerd" && subscriptionIcon ? subscriptionIcon : "(sub)");

--- a/packages/coding-agent/src/modes/components/status-line/segments.ts
+++ b/packages/coding-agent/src/modes/components/status-line/segments.ts
@@ -7,6 +7,7 @@ import { type Theme, type ThemeColor, theme } from "../../../modes/theme/theme";
 import { shortenPath, TRUNCATE_LENGTHS, truncateToWidth } from "../../../tools/render-utils";
 import { fileHyperlink } from "../../../tui/hyperlink";
 import { getSessionAccentAnsi, getSessionAccentHex } from "../../../utils/session-color";
+import { settings } from "../../../config/settings";
 import { sanitizeStatusText } from "../../shared";
 import { formatContextUsage, getContextUsageLevel, getContextUsageThemeColor } from "./context-thresholds";
 import type { RenderedSegment, SegmentContext, StatusLineSegment, StatusLineSegmentId } from "./types";
@@ -75,9 +76,9 @@ function stripDisplayRoot(pwd: string): string {
 function normalizePremiumRequests(value: number): number {
 	return Math.round((value + Number.EPSILON) * 100) / 100;
 }
-function formatSpend(amount: number, usingSubscription: boolean, uiTheme: Theme): string {
+function formatSpend(amount: number, usingSubscription: boolean, uiTheme: Theme, costPrefix = "$"): string {
 	const formatted = amount.toFixed(2);
-	if (!usingSubscription) return `$${formatted}`;
+	if (!usingSubscription) return `${costPrefix}${formatted}`;
 	if (uiTheme.getSymbolPreset() === "nerd") {
 		const icon = uiTheme.icon.subscription;
 		return icon ? `${icon} ${formatted}` : `S${formatted}`;
@@ -94,8 +95,8 @@ function formatAdvisorSpend(amount: number, usingSubscription: boolean, uiTheme:
 	return `${spend} (adv)`;
 }
 
-function formatSpendPlaceholder(usingSubscription: boolean, uiTheme: Theme): string {
-	if (!usingSubscription) return "$…";
+function formatSpendPlaceholder(usingSubscription: boolean, uiTheme: Theme, costPrefix = "$"): string {
+	if (!usingSubscription) return `${costPrefix}…`;
 	if (uiTheme.getSymbolPreset() === "nerd" && uiTheme.icon.subscription) {
 		return `${uiTheme.icon.subscription} …`;
 	}
@@ -559,6 +560,7 @@ const costSegment: StatusLineSegment = {
 		const normalizedPremiumRequests = normalizePremiumRequests(premiumRequests);
 		const state = ctx.session.state;
 		const usingSubscription = state.model ? (ctx.session.modelRegistry?.isUsingOAuth(state.model) ?? false) : false;
+		const costPrefix = sanitizeStatusText(settings.get("statusLine.costPrefix") ?? "$");
 
 		if (!cost && !advisorCost && !usingSubscription && !normalizedPremiumRequests) {
 			return { content: "", visible: false };
@@ -568,8 +570,8 @@ const costSegment: StatusLineSegment = {
 		if (cost) {
 			billingParts.push(
 				ctx.startupPlaceholder
-					? formatSpendPlaceholder(usingSubscription, theme)
-					: formatSpend(cost, usingSubscription, theme),
+					? formatSpendPlaceholder(usingSubscription, theme, costPrefix)
+					: formatSpend(cost, usingSubscription, theme, costPrefix),
 			);
 		} else if (usingSubscription) {
 			billingParts.push(

--- a/packages/coding-agent/src/modes/components/status-line/segments.ts
+++ b/packages/coding-agent/src/modes/components/status-line/segments.ts
@@ -560,7 +560,8 @@ const costSegment: StatusLineSegment = {
 		const normalizedPremiumRequests = normalizePremiumRequests(premiumRequests);
 		const state = ctx.session.state;
 		const usingSubscription = state.model ? (ctx.session.modelRegistry?.isUsingOAuth(state.model) ?? false) : false;
-		const costPrefix = sanitizeStatusText(settings.get("statusLine.costPrefix") ?? "$");
+		let costPrefix = "$";
+		try { costPrefix = sanitizeStatusText(settings.get("statusLine.costPrefix") ?? "$"); } catch { /* settings not initialized */ }
 
 		if (!cost && !advisorCost && !usingSubscription && !normalizedPremiumRequests) {
 			return { content: "", visible: false };

--- a/packages/coding-agent/src/modes/components/status-line/segments.ts
+++ b/packages/coding-agent/src/modes/components/status-line/segments.ts
@@ -561,7 +561,11 @@ const costSegment: StatusLineSegment = {
 		const state = ctx.session.state;
 		const usingSubscription = state.model ? (ctx.session.modelRegistry?.isUsingOAuth(state.model) ?? false) : false;
 		let costPrefix = "$";
-		try { costPrefix = sanitizeStatusText(settings.get("statusLine.costPrefix") ?? "$"); } catch { /* settings not initialized */ }
+		try {
+			costPrefix = sanitizeStatusText(settings.get("statusLine.costPrefix") ?? "$");
+		} catch {
+			/* settings not initialized */
+		}
 
 		if (!cost && !advisorCost && !usingSubscription && !normalizedPremiumRequests) {
 			return { content: "", visible: false };


### PR DESCRIPTION
## Summary

Add `statusLine.currencySymbol` setting that controls the symbol shown before cost amounts in the footer status line.

- **Default:** `$` (unchanged behavior)
- **Configurable:** Users can set any symbol (e.g. `¥`, `€`, `£`)
- **Location:** Appearance → Status Line → Currency Symbol

## Changes

- `settings-schema.ts`: Add `statusLine.currencySymbol` string setting with UI metadata
- `footer.ts`: Read the setting and use it for cost display

## Motivation

Users operating in non-USD environments may prefer to display costs with their local currency symbol for clarity.