### PR TITLE
fix(coding-agent): parse bracketed hashline event paths

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed user-scope marketplace plugins installed through `omp` losing their skills unless the Claude plugin source was separately enabled ([#10662](https://github.com/can1357/oh-my-pi/issues/10662)).
+- Fixed bracketed hashline edit targets appearing as `undefined` to extension path allowlists ([#10688](https://github.com/can1357/oh-my-pi/issues/10688)).
 
 ## [18.1.6] - 2026-09-03
 

--- a/packages/coding-agent/src/extensibility/tool-event-input.ts
+++ b/packages/coding-agent/src/extensibility/tool-event-input.ts
@@ -1,4 +1,6 @@
-const HASHLINE_FILE_PREFIX = "¶";
+import { HL_FILE_PREFIX, HL_FILE_SUFFIX } from "../tools/hashline-format";
+
+const LEGACY_HASHLINE_FILE_PREFIX = "¶";
 const HASHLINE_FILE_TAG_RE = /#[0-9a-fA-F]{4}$/u;
 
 interface ToolEventInputResolver {
@@ -45,11 +47,20 @@ function extractHashlinePaths(input: string): string[] {
 	const paths: string[] = [];
 	const stripped = input.startsWith("\uFEFF") ? input.slice(1) : input;
 	for (const rawLine of stripped.split("\n")) {
-		const line = rawLine.replace(/\r$/, "").trimStart();
-		if (!line.startsWith(HASHLINE_FILE_PREFIX)) continue;
-		let prefixEnd = 0;
-		while (prefixEnd < line.length && line[prefixEnd] === HASHLINE_FILE_PREFIX) prefixEnd++;
-		const path = normalizeHashlineHeaderPath(line.slice(prefixEnd));
+		const line = rawLine.replace(/\r$/, "");
+		let body: string;
+		if (line.startsWith(HL_FILE_PREFIX) && line.endsWith(HL_FILE_SUFFIX)) {
+			body = line.slice(HL_FILE_PREFIX.length, line.length - HL_FILE_SUFFIX.length);
+		} else {
+			const legacyLine = line.trimStart();
+			if (!legacyLine.startsWith(LEGACY_HASHLINE_FILE_PREFIX)) continue;
+			let prefixEnd = 0;
+			while (prefixEnd < legacyLine.length && legacyLine[prefixEnd] === LEGACY_HASHLINE_FILE_PREFIX) {
+				prefixEnd++;
+			}
+			body = legacyLine.slice(prefixEnd);
+		}
+		const path = normalizeHashlineHeaderPath(body);
 		if (path) paths.push(path);
 	}
 	return paths;
@@ -60,9 +71,9 @@ export function normalizeToolEventInput(toolName: string, input: Record<string, 
 	if (toolName !== "edit" || stringField(input, "path")) return input;
 
 	// Hashline edit mode: the only authoritative target list is the parsed
-	// `¶PATH#TAG` headers inside the patch. Trusting a passthrough
-	// `_path` here would let a model-supplied field override the real edit
-	// target and bypass extension gates that allowlist by path.
+	// `[PATH#TAG]` (or legacy `¶PATH#TAG`) headers inside the patch.
+	// Trusting a passthrough `_path` here would let a model-supplied field
+	// override the real edit target and bypass extension path allowlists.
 	const rawInput = stringField(input, "input") ?? stringField(input, "_input");
 	if (rawInput !== undefined) {
 		const hashlinePaths = extractHashlinePaths(rawInput);

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -2625,7 +2625,7 @@ describe("ExtensionRunner", () => {
 			};
 		}
 
-		it("exposes a single hashline edit path to extension gate handlers", async () => {
+		it("allows bracketed Markdown paths, blocks non-Markdown paths, and accepts legacy headers", async () => {
 			const eventsPath = path.join(tempDir.path(), "tool-call-events.jsonl");
 			const extCode = `
 				import * as fs from "node:fs";
@@ -2637,7 +2637,7 @@ describe("ExtensionRunner", () => {
 							${JSON.stringify(eventsPath)},
 							JSON.stringify({ path: event.input.path, paths: event.input.paths }) + "\\n",
 						);
-						if (typeof event.input.path !== "string") {
+						if (typeof event.input.path !== "string" || !event.input.path.endsWith(".md")) {
 							return { block: true, reason: \`Blocked: \${event.input.path}\` };
 						}
 					});
@@ -2656,17 +2656,37 @@ describe("ExtensionRunner", () => {
 			const wrapped = new ExtensionToolWrapper(createHashlineEditTool(), runner);
 
 			const resultMessage = await wrapped.execute("tool-call-id", {
-				input: "¶plans/switch-case-array-syntax.md#ABC1\n27 27\n+new content",
+				input: [
+					"*** Begin Patch",
+					'["plans/switch case-array.md"#ABC1]',
+					"PUT 27.=27:",
+					"+new content",
+					"*** End Patch",
+				].join("\n"),
+			});
+			await expect(
+				wrapped.execute("non-markdown-tool-call-id", {
+					input: "[packages/coding-agent/src/main.ts#BCD2]\nPUT 1.=1:\n+changed",
+				}),
+			).rejects.toThrow("Blocked: packages/coding-agent/src/main.ts");
+			const legacyResult = await wrapped.execute("legacy-tool-call-id", {
+				input: "¶plans/legacy.md#CDE3\n27 27\n+new content",
 			});
 
 			expect(resultMessage.content).toEqual([{ type: "text", text: "ok" }]);
+			expect(legacyResult.content).toEqual([{ type: "text", text: "ok" }]);
 			const events = fs
 				.readFileSync(eventsPath, "utf8")
 				.trim()
 				.split("\n")
 				.map(line => JSON.parse(line));
 			expect(events).toEqual([
-				{ path: "plans/switch-case-array-syntax.md", paths: ["plans/switch-case-array-syntax.md"] },
+				{ path: "plans/switch case-array.md", paths: ["plans/switch case-array.md"] },
+				{
+					path: "packages/coding-agent/src/main.ts",
+					paths: ["packages/coding-agent/src/main.ts"],
+				},
+				{ path: "plans/legacy.md", paths: ["plans/legacy.md"] },
 			]);
 		});
 		it("keeps non-tag hash suffixes in hashline edit paths", async () => {
@@ -2697,7 +2717,7 @@ describe("ExtensionRunner", () => {
 			const wrapped = new ExtensionToolWrapper(createHashlineEditTool(), runner);
 
 			await wrapped.execute("tool-call-id", {
-				input: "¶plans/foo.md#notatag\n27 27\n+new content",
+				input: "[plans/foo.md#notatag]\nPUT 27.=27:\n+new content",
 			});
 
 			const events = fs
@@ -2737,7 +2757,7 @@ describe("ExtensionRunner", () => {
 
 			await wrapped.execute("tool-call-id", {
 				_path: "plans/allowed.md",
-				input: "¶src/secret.ts#ABC1\n27 27\n+evil content",
+				input: "[src/secret.ts#ABC1]\nPUT 27.=27:\n+evil content",
 			});
 
 			const events = fs
@@ -2780,7 +2800,7 @@ describe("ExtensionRunner", () => {
 
 			await expect(
 				wrapped.execute("tool-call-id", {
-					input: "¶plans/switch-case-array-syntax.md#ABC1\n27 27\n+new content\n¶packages/coding-agent/src/main.ts#DEF2\n1 1\n+changed",
+					input: "[plans/switch-case-array-syntax.md#ABC1]\nPUT 27.=27:\n+new content\n[packages/coding-agent/src/main.ts#DEF2]\nPUT 1.=1:\n+changed",
 				}),
 			).rejects.toThrow("Blocked: undefined");
 


### PR DESCRIPTION
## Repro
Calling `normalizeToolEventInput("edit", { input: patch })` with `patch` containing `[plans/vas-module-and-partner-portal.md#AE8D]` on current `main` left `path` and `paths` unset; the exact command was `bun --cwd packages/coding-agent -e '<normalize the reported bracketed patch and print the event path>'`, which printed `Blocked: undefined`.

## Cause
`extractHashlinePaths()` in `packages/coding-agent/src/extensibility/tool-event-input.ts` recognized only legacy `¶PATH#TAG` headers, while current hashline edit payloads identify sections with `[PATH#TAG]`; extension and hook allowlists therefore received no normalized target.

## Fix
- Parse current bracketed hashline section headers using the shared delimiters while retaining legacy pilcrow compatibility.
- Preserve canonical 4-hex tag stripping, quoted paths, `_path` precedence protection, and singular-versus-multi-target semantics.
- Extend extension-gate regression coverage across Markdown allow, non-Markdown block, multiple targets, quoted paths with spaces, noncanonical suffixes, and legacy headers.
- Add the user-visible fix to the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/extensions-runner.test.ts` passed with 84 tests and 212 assertions. `bun --cwd=packages/coding-agent run check` passed. Re-running the reported patch normalization printed `{"path":"plans/vas-module-and-partner-portal.md","paths":["plans/vas-module-and-partner-portal.md"]}` followed by `allowed`.

Fixes #10688