### PR TITLE
feat(statusLine): add registerStatusLineSegment extension API

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -116,6 +116,7 @@ Core methods:
 - `registerTool`, `registerCommand`, `registerShortcut`, `registerFlag`
 - `registerMessageRenderer`, `registerAssistantThinkingRenderer`
 - `registerComposerShape`
+- `registerStatusLineSegment`
 - `setLabel`, `getFlag`
 - `sendMessage`, `sendUserMessage`, `appendEntry`, `exec`
 - `getActiveTools`, `getAllTools`, `setActiveTools`
@@ -698,6 +699,31 @@ All render methods receive `width`, `paddingX`, the theme's `box` glyphs, and th
 - `scrollbarThumb`: this row intersects the editor scrollbar thumb.
 
 The built-in implementations in `packages/tui/src/components/composer/` are the reference for framed, rule, filled-surface, and IME-safe layouts.
+
+## Status line segment renderer
+
+`registerStatusLineSegment(id, renderer)` contributes a named segment that a user can place in `statusLine.leftSegments` / `statusLine.rightSegments` (with `statusLine.preset: custom`), alongside the built-in ids.
+
+```ts
+import type { ExtensionAPI } from "@oh-my-pi/pi-coding-agent";
+
+export default function (pi: ExtensionAPI) {
+  pi.registerStatusLineSegment("acme-branch", (ctx, theme) => ({
+    content: theme.fg("accent", ctx.git?.branch ?? "detached"),
+    visible: ctx.git?.branch != null,
+  }));
+}
+```
+
+The renderer receives a read-only `StatusLineSegmentContext` (`width`, `usage`, `contextPercent`, `contextTokens`, `contextWindow`, `git.branch`, `activeMs`) and the active `theme`, and returns `{ content, visible }`.
+
+Semantics:
+
+- Built-in ids always win: registering an id that names a built-in segment (e.g. `model`) is shadowed, not overridden.
+- When two extensions register the same non-built-in id, the most recently loaded extension wins (matching command lookup).
+- The renderer runs inside the owning session's settings scope, so a synchronous settings read resolves that session's values.
+- Returned `content` is sanitized for the single-row status bar: complete SGR color sequences survive; other escape sequences and C0/C1 control characters are stripped or collapsed to spaces.
+- A renderer that throws is logged and degrades to an invisible segment rather than crashing the bar.
 
 ## Custom message renderer
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -690,7 +690,7 @@ tui:
 | `tui.hyperlinks`            | enum    | `auto`           | `off`, `auto`, `always`.                                                  |
 | `tui.resizeScrollback`      | enum    | `rebuild`        | How a settled width resize refreshes transcript rows kept in terminal scrollback: `append` replays the transcript at the new width below retained history, `rebuild` erases pane scrollback then replays one current-width copy, `preserve` repaints only the viewport. |
 
-For a custom status line, set `statusLine.preset: custom` and configure `statusLine.leftSegments`, `statusLine.rightSegments`, and `statusLine.segmentOptions`. Include `status` in either segment list to render extension statuses registered through `ctx.ui.setStatus()`, ordered by key and joined inline. Set `statusLine.showHookStatus: false` to suppress the same statuses in the footer.
+For a custom status line, set `statusLine.preset: custom` and configure `statusLine.leftSegments`, `statusLine.rightSegments`, and `statusLine.segmentOptions`. Include `status` in either segment list to render extension statuses registered through `ctx.ui.setStatus()`, ordered by key and joined inline. Set `statusLine.showHookStatus: false` to suppress the same statuses in the footer. Both segment lists also accept ids registered by an extension via `registerStatusLineSegment`; an id that is neither built-in nor extension-registered renders nothing.
 
 ### Interaction
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added the `registerStatusLineSegment(id, renderer)` extension API, letting extensions contribute named status-line segments usable from `statusLine.leftSegments` / `statusLine.rightSegments` alongside the built-in segment ids ([#1966](https://github.com/can1357/oh-my-pi/issues/1966)).
+
 ## [18.1.7] - 2026-09-03
 
 ### Breaking Changes

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -263,12 +263,6 @@ export type StatusLineSegmentId =
 	| "usage"
 	| "collab";
 
-/**
- * A status-line segment reference: a built-in id, or an arbitrary id an
- * extension registered via `registerStatusLineSegment`. Kept as a distinct
- * type (rather than widening `StatusLineSegmentId` itself) so built-in ids
- * keep literal-type autocomplete in config and preset definitions.
- */
 export type StatusLineSegmentRef = StatusLineSegmentId | (string & {});
 
 /** Submenu choice metadata. */

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -263,6 +263,14 @@ export type StatusLineSegmentId =
 	| "usage"
 	| "collab";
 
+/**
+ * A status-line segment reference: a built-in id, or an arbitrary id an
+ * extension registered via `registerStatusLineSegment`. Kept as a distinct
+ * type (rather than widening `StatusLineSegmentId` itself) so built-in ids
+ * keep literal-type autocomplete in config and preset definitions.
+ */
+export type StatusLineSegmentRef = StatusLineSegmentId | (string & {});
+
 /** Submenu choice metadata. */
 export type SubmenuOption<V extends string = string> = {
 	value: V;
@@ -969,9 +977,9 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
-	"statusLine.leftSegments": { type: "array", default: [] as StatusLineSegmentId[] },
+	"statusLine.leftSegments": { type: "array", default: [] as StatusLineSegmentRef[] },
 
-	"statusLine.rightSegments": { type: "array", default: [] as StatusLineSegmentId[] },
+	"statusLine.rightSegments": { type: "array", default: [] as StatusLineSegmentRef[] },
 
 	"statusLine.segmentOptions": { type: "record", default: {} as Record<string, unknown> },
 
@@ -6274,8 +6282,8 @@ export interface StatusLineSettings {
 	preset: StatusLinePreset;
 	separator: StatusLineSeparatorStyle;
 	showHookStatus: boolean;
-	leftSegments: StatusLineSegmentId[];
-	rightSegments: StatusLineSegmentId[];
+	leftSegments: StatusLineSegmentRef[];
+	rightSegments: StatusLineSegmentRef[];
 	segmentOptions: Record<string, unknown>;
 }
 

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -263,6 +263,12 @@ export type StatusLineSegmentId =
 	| "usage"
 	| "collab";
 
+/**
+ * A status-line segment reference: a built-in {@link StatusLineSegmentId}, or an
+ * arbitrary id an extension registered via `registerStatusLineSegment`. Kept
+ * distinct from `StatusLineSegmentId` so built-in ids keep literal-type
+ * autocomplete in config and preset definitions.
+ */
 export type StatusLineSegmentRef = StatusLineSegmentId | (string & {});
 
 /** Submenu choice metadata. */

--- a/packages/coding-agent/src/extensibility/extensions/loader.ts
+++ b/packages/coding-agent/src/extensibility/extensions/loader.ts
@@ -48,6 +48,7 @@ import type {
 	PreparedExtension,
 	ProviderConfig,
 	RegisteredCommand,
+	StatusLineSegmentRenderer,
 	ToolDefinition,
 	ToolInfo,
 } from "./types";
@@ -233,6 +234,10 @@ class ConcreteExtensionAPI implements ExtensionAPI, IExtensionRuntime {
 		this.extension.messageRenderers.set(customType, renderer as MessageRenderer);
 	}
 
+	registerStatusLineSegment(id: string, renderer: StatusLineSegmentRenderer): void {
+		this.extension.statusLineSegments.set(id, renderer);
+	}
+
 	registerAssistantThinkingRenderer(renderer: AssistantThinkingRenderer): void {
 		this.extension.assistantThinkingRenderers.push(renderer);
 	}
@@ -349,6 +354,7 @@ function createExtension(extensionPath: string, resolvedPath: string): Extension
 		fileDeleteFallbackHandlers: [],
 		messageRenderers: new Map(),
 		composerShapes: new Map(),
+		statusLineSegments: new Map(),
 		commands: new Map(),
 		flags: new Map(),
 		shortcuts: new Map(),

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -1146,13 +1146,6 @@ export class ExtensionRunner {
 		return withActiveSettings(this.settings, fn);
 	}
 
-	/**
-	 * Look up an extension-registered status-line segment by id. Callers are
-	 * expected to check built-in segment ids first — a built-in id always
-	 * wins, so this is only consulted for unrecognized ids. When multiple
-	 * extensions register the same id, the most recently loaded one wins,
-	 * matching `getCommand`.
-	 */
 	getStatusLineSegment(id: string): StatusLineSegmentRenderer | undefined {
 		for (let index = this.extensions.length - 1; index >= 0; index -= 1) {
 			const renderer = this.extensions[index]?.statusLineSegments.get(id);

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -64,6 +64,7 @@ import type {
 	SessionCompactingResult,
 	SessionStopEvent,
 	SessionStopEventResult,
+	StatusLineSegmentRenderer,
 	ToolCallEvent,
 	ToolCallEventResult,
 	ToolRegistrationListener,
@@ -1143,6 +1144,23 @@ export class ExtensionRunner {
 	 */
 	runScoped<T>(fn: () => T): T {
 		return withActiveSettings(this.settings, fn);
+	}
+
+	/**
+	 * Look up an extension-registered status-line segment by id. Callers are
+	 * expected to check built-in segment ids first — a built-in id always
+	 * wins, so this is only consulted for unrecognized ids. When multiple
+	 * extensions register the same id, the most recently loaded one wins,
+	 * matching `getCommand`.
+	 */
+	getStatusLineSegment(id: string): StatusLineSegmentRenderer | undefined {
+		for (let index = this.extensions.length - 1; index >= 0; index -= 1) {
+			const renderer = this.extensions[index]?.statusLineSegments.get(id);
+			if (renderer) {
+				return renderer;
+			}
+		}
+		return undefined;
 	}
 
 	/**

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -1178,10 +1178,6 @@ export type AssistantThinkingRenderer = (
 	theme: Theme,
 ) => Component | undefined;
 
-// ============================================================================
-// Status Line Segments
-// ============================================================================
-
 export interface StatusLineSegmentUsage {
 	inputTokens: number;
 	outputTokens: number;
@@ -1192,17 +1188,13 @@ export interface StatusLineSegmentUsage {
 	tokensPerSecond: number | null;
 }
 
-/** Data made available to an extension-registered status-line segment renderer. */
 export interface StatusLineSegmentContext {
-	/** Terminal columns budgeted for the whole status line; segments do not need to truncate to this themselves. */
 	width: number;
 	usage: StatusLineSegmentUsage;
-	/** Context usage percent, or null when unknown (e.g. right after compaction). */
 	contextPercent: number | null;
 	contextTokens: number;
 	contextWindow: number;
 	git: { branch: string | null } | null;
-	/** Active (non-idle) processing time accumulated this session, in ms. */
 	activeMs: number;
 }
 
@@ -1447,16 +1439,6 @@ export interface ExtensionAPI {
 	 */
 	registerComposerShape(definition: ComposerShapeDefinition): void;
 
-	/**
-	 * Register a named status-line segment usable from `statusLine.leftSegments` /
-	 * `statusLine.rightSegments` config, alongside the built-in segment ids.
-	 *
-	 * A built-in segment id always renders as the built-in segment — a plugin
-	 * registering e.g. `"model"` is shadowed rather than replacing it, so
-	 * built-in behavior can't be silently hijacked by a plugin id collision.
-	 * When two extensions register the same non-built-in id, the most
-	 * recently loaded extension wins, matching command lookup (`getCommand`).
-	 */
 	registerStatusLineSegment(id: string, renderer: StatusLineSegmentRenderer): void;
 
 	// =========================================================================

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -1178,6 +1178,7 @@ export type AssistantThinkingRenderer = (
 	theme: Theme,
 ) => Component | undefined;
 
+/** Token, cache, cost, and throughput totals for the current session. */
 export interface StatusLineSegmentUsage {
 	inputTokens: number;
 	outputTokens: number;
@@ -1188,21 +1189,28 @@ export interface StatusLineSegmentUsage {
 	tokensPerSecond: number | null;
 }
 
+/** Read-only session snapshot passed to an extension-registered status-line segment renderer. */
 export interface StatusLineSegmentContext {
+	/** Terminal columns budgeted for the whole status line; renderers need not truncate to this. */
 	width: number;
 	usage: StatusLineSegmentUsage;
+	/** Context-window usage percent, or null when unknown (e.g. right after compaction). */
 	contextPercent: number | null;
 	contextTokens: number;
 	contextWindow: number;
+	/** Current git branch (as { branch }), or null outside a repo or when git is disabled. */
 	git: { branch: string | null } | null;
+	/** Active (non-idle) processing time accumulated this session, in ms. */
 	activeMs: number;
 }
 
+/** A segment renderer's output: the rendered string and whether to show it. */
 export interface StatusLineSegmentResult {
 	content: string;
 	visible: boolean;
 }
 
+/** Renders one extension status-line segment from the session snapshot and active theme. */
 export type StatusLineSegmentRenderer = (ctx: StatusLineSegmentContext, theme: Theme) => StatusLineSegmentResult;
 
 // ============================================================================
@@ -1439,6 +1447,15 @@ export interface ExtensionAPI {
 	 */
 	registerComposerShape(definition: ComposerShapeDefinition): void;
 
+	/**
+	 * Register a named status-line segment usable from `statusLine.leftSegments` /
+	 * `statusLine.rightSegments`, alongside the built-in segment ids.
+	 *
+	 * A built-in segment id always renders the built-in segment; registering that
+	 * id is shadowed rather than replacing it. When two extensions register the
+	 * same non-built-in id, the most recently loaded extension wins (matching
+	 * `getCommand`). A renderer that throws degrades to an invisible segment.
+	 */
 	registerStatusLineSegment(id: string, renderer: StatusLineSegmentRenderer): void;
 
 	// =========================================================================

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -1179,6 +1179,41 @@ export type AssistantThinkingRenderer = (
 ) => Component | undefined;
 
 // ============================================================================
+// Status Line Segments
+// ============================================================================
+
+export interface StatusLineSegmentUsage {
+	inputTokens: number;
+	outputTokens: number;
+	cacheReadTokens: number;
+	cacheWriteTokens: number;
+	totalTokens: number;
+	cost: number;
+	tokensPerSecond: number | null;
+}
+
+/** Data made available to an extension-registered status-line segment renderer. */
+export interface StatusLineSegmentContext {
+	/** Terminal columns budgeted for the whole status line; segments do not need to truncate to this themselves. */
+	width: number;
+	usage: StatusLineSegmentUsage;
+	/** Context usage percent, or null when unknown (e.g. right after compaction). */
+	contextPercent: number | null;
+	contextTokens: number;
+	contextWindow: number;
+	git: { branch: string | null } | null;
+	/** Active (non-idle) processing time accumulated this session, in ms. */
+	activeMs: number;
+}
+
+export interface StatusLineSegmentResult {
+	content: string;
+	visible: boolean;
+}
+
+export type StatusLineSegmentRenderer = (ctx: StatusLineSegmentContext, theme: Theme) => StatusLineSegmentResult;
+
+// ============================================================================
 // Command Registration
 // ============================================================================
 
@@ -1411,6 +1446,18 @@ export interface ExtensionAPI {
 	 * replaced; when extensions reuse an id, the later extension wins.
 	 */
 	registerComposerShape(definition: ComposerShapeDefinition): void;
+
+	/**
+	 * Register a named status-line segment usable from `statusLine.leftSegments` /
+	 * `statusLine.rightSegments` config, alongside the built-in segment ids.
+	 *
+	 * A built-in segment id always renders as the built-in segment — a plugin
+	 * registering e.g. `"model"` is shadowed rather than replacing it, so
+	 * built-in behavior can't be silently hijacked by a plugin id collision.
+	 * When two extensions register the same non-built-in id, the most
+	 * recently loaded extension wins, matching command lookup (`getCommand`).
+	 */
+	registerStatusLineSegment(id: string, renderer: StatusLineSegmentRenderer): void;
 
 	// =========================================================================
 	// Actions
@@ -1758,6 +1805,7 @@ export interface Extension {
 	fileDeleteFallbackHandlers: FileDeleteFallbackHandler[];
 	messageRenderers: Map<string, MessageRenderer>;
 	composerShapes: Map<string, ComposerShapeDefinition>;
+	statusLineSegments: Map<string, StatusLineSegmentRenderer>;
 	commands: Map<string, RegisteredCommand>;
 	flags: Map<string, ExtensionFlag>;
 	shortcuts: Map<KeyId, ExtensionShortcut>;

--- a/packages/coding-agent/src/modes/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/components/settings-selector.ts
@@ -38,7 +38,7 @@ import type {
 	ContextLineMode,
 	SettingTab,
 	StatusLinePreset,
-	StatusLineSegmentId,
+	StatusLineSegmentRef,
 	StatusLineSeparatorStyle,
 } from "../../config/settings-schema";
 import { SETTING_TABS, TAB_METADATA } from "../../config/settings-schema";
@@ -566,8 +566,8 @@ export interface SettingsRuntimeContext {
 export interface StatusLinePreviewSettings {
 	preset?: StatusLinePreset;
 	contextLine?: ContextLineMode;
-	leftSegments?: StatusLineSegmentId[];
-	rightSegments?: StatusLineSegmentId[];
+	leftSegments?: StatusLineSegmentRef[];
+	rightSegments?: StatusLineSegmentRef[];
 	separator?: StatusLineSeparatorStyle;
 	sessionAccent?: boolean;
 	transparent?: boolean;

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -514,12 +514,6 @@ export class StatusLineComponent implements Component {
 	#gitEnabled(): boolean {
 		return settings.get("git.enabled");
 	}
-	/**
-	 * True when the status line needs live git branch data: a built-in git/pr
-	 * segment, or a registered extension segment whose render context exposes
-	 * `ctx.git.branch`. Gates the cache-invalidating HEAD watcher so an
-	 * extension branch segment stays fresh across HEAD changes.
-	 */
 	#watchesGitBranch(): boolean {
 		const effectiveSettings = this.#resolveSettings();
 		return (
@@ -530,11 +524,6 @@ export class StatusLineComponent implements Component {
 		);
 	}
 
-	/**
-	 * True when a configured id is backed by an actually-registered extension
-	 * segment (not built-in, and a renderer is registered for it). Unknown or
-	 * mistyped ids are excluded so they don't trigger git branch resolution.
-	 */
 	#hasRegisteredExtensionSegment(segments: readonly StatusLineSegmentRef[]): boolean {
 		const runner = this.session.extensionRunner;
 		if (!runner) return false;
@@ -1954,8 +1943,6 @@ export class StatusLineComponent implements Component {
 			(hasGitSegment(effectiveSettings.leftSegments) || hasGitSegment(effectiveSettings.rightSegments));
 		const includePr =
 			gitEnabled && (hasPrSegment(effectiveSettings.leftSegments) || hasPrSegment(effectiveSettings.rightSegments));
-		// An extension segment may render the branch via its context, so resolve
-		// the branch label for custom-only layouts too — not just built-in git/pr.
 		const includeBranch =
 			gitEnabled &&
 			(this.#hasRegisteredExtensionSegment(effectiveSettings.leftSegments) ||

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -34,13 +34,13 @@ import {
 } from "../codex-reset-fireworks";
 import { canReuseCachedPr, createPrCacheContext, isSamePrCacheContext, type PrCacheContext } from "./git-utils";
 import { getPreset } from "./presets";
-import { renderSegment, type SegmentContext } from "./segments";
+import { isBuiltInSegmentId, renderSegment, type SegmentContext } from "./segments";
 import { getSeparator } from "./separators";
 import type {
 	CollabStatus,
 	EffectiveStatusLineSettings,
-	StatusLineSegmentId,
 	StatusLineSegmentOptions,
+	StatusLineSegmentRef,
 	StatusLineSettings,
 } from "./types";
 
@@ -301,22 +301,22 @@ const EMPTY_MESSAGES: readonly AgentMessage[] = [];
 const STATUS_USAGE_START_DELAY_MS = 0;
 const STATUS_USAGE_REFRESH_TIMEOUT_MS = 2_000;
 
-function isContextSegment(segment: StatusLineSegmentId): boolean {
+function isContextSegment(segment: StatusLineSegmentRef): boolean {
 	return segment === "context_pct" || segment === "context_total";
 }
 
-function hasContextSegment(segments: readonly StatusLineSegmentId[]): boolean {
+function hasContextSegment(segments: readonly StatusLineSegmentRef[]): boolean {
 	return segments.includes("context_pct") || segments.includes("context_total");
 }
 
-function hasNonContextSegment(segments: readonly StatusLineSegmentId[]): boolean {
+function hasNonContextSegment(segments: readonly StatusLineSegmentRef[]): boolean {
 	for (const segment of segments) {
 		if (!isContextSegment(segment)) return true;
 	}
 	return false;
 }
 
-function removeContextSegments(parts: string[], segments: StatusLineSegmentId[]): void {
+function removeContextSegments(parts: string[], segments: StatusLineSegmentRef[]): void {
 	let writeIndex = 0;
 	for (let readIndex = 0; readIndex < segments.length; readIndex++) {
 		const segment = segments[readIndex];
@@ -337,18 +337,18 @@ function embeddedContextGaugeMinWidth(percent: number, contextWindow: number): n
 	return formatEmbeddedContextPercent(percent).length + formatNumber(contextWindow).length + 4;
 }
 
-function hasGitSegment(segments: readonly StatusLineSegmentId[]): boolean {
+function hasGitSegment(segments: readonly StatusLineSegmentRef[]): boolean {
 	return segments.includes("git");
 }
 
-function hasPrSegment(segments: readonly StatusLineSegmentId[]): boolean {
+function hasPrSegment(segments: readonly StatusLineSegmentRef[]): boolean {
 	return segments.includes("pr");
 }
-function hasPathSegment(segments: readonly StatusLineSegmentId[]): boolean {
+function hasPathSegment(segments: readonly StatusLineSegmentRef[]): boolean {
 	return segments.includes("path");
 }
 
-function hasGitBackedSegment(segments: readonly StatusLineSegmentId[]): boolean {
+function hasGitBackedSegment(segments: readonly StatusLineSegmentRef[]): boolean {
 	return hasGitSegment(segments) || hasPrSegment(segments);
 }
 
@@ -514,11 +514,34 @@ export class StatusLineComponent implements Component {
 	#gitEnabled(): boolean {
 		return settings.get("git.enabled");
 	}
-	#hasGitBackedSegment(): boolean {
+	/**
+	 * True when the status line needs live git branch data: a built-in git/pr
+	 * segment, or a registered extension segment whose render context exposes
+	 * `ctx.git.branch`. Gates the cache-invalidating HEAD watcher so an
+	 * extension branch segment stays fresh across HEAD changes.
+	 */
+	#watchesGitBranch(): boolean {
 		const effectiveSettings = this.#resolveSettings();
 		return (
-			hasGitBackedSegment(effectiveSettings.leftSegments) || hasGitBackedSegment(effectiveSettings.rightSegments)
+			hasGitBackedSegment(effectiveSettings.leftSegments) ||
+			hasGitBackedSegment(effectiveSettings.rightSegments) ||
+			this.#hasRegisteredExtensionSegment(effectiveSettings.leftSegments) ||
+			this.#hasRegisteredExtensionSegment(effectiveSettings.rightSegments)
 		);
+	}
+
+	/**
+	 * True when a configured id is backed by an actually-registered extension
+	 * segment (not built-in, and a renderer is registered for it). Unknown or
+	 * mistyped ids are excluded so they don't trigger git branch resolution.
+	 */
+	#hasRegisteredExtensionSegment(segments: readonly StatusLineSegmentRef[]): boolean {
+		const runner = this.session.extensionRunner;
+		if (!runner) return false;
+		for (const segment of segments) {
+			if (!isBuiltInSegmentId(segment) && runner.getStatusLineSegment(segment)) return true;
+		}
+		return false;
 	}
 
 	#resolveActiveRepoCache(): ActiveRepoCache {
@@ -744,7 +767,7 @@ export class StatusLineComponent implements Component {
 		this.#retireGitWatcher();
 		this.#gitWatcherUnavailable = false;
 
-		if (!this.#gitEnabled() || !this.#hasGitBackedSegment()) {
+		if (!this.#gitEnabled() || !this.#watchesGitBranch()) {
 			this.invalidateGitCaches();
 			return;
 		}
@@ -1759,6 +1782,7 @@ export class StatusLineComponent implements Component {
 		includePath: boolean,
 		includeGit: boolean,
 		includePr: boolean,
+		includeBranch: boolean,
 		previewTitle?: string,
 	): SegmentContext {
 		const state = this.session.state;
@@ -1798,12 +1822,13 @@ export class StatusLineComponent implements Component {
 			contextPercent = collabState.contextUsage.percent ?? contextPercent;
 		}
 
-		const shouldResolveActiveRepo = this.#gitEnabled() && (includePath || includeGit || includePr);
+		const shouldResolveActiveRepo = this.#gitEnabled() && (includePath || includeGit || includePr || includeBranch);
 		const projectDir = getProjectDir();
 		const activeRepoCache = shouldResolveActiveRepo
 			? this.#resolveActiveRepoCache()
 			: { projectDir, activeRepo: null, effectiveGitCwd: projectDir, worktree: null };
-		const gitBranch = includeGit || includePr ? this.#getBranchLabel(activeRepoCache.effectiveGitCwd) : null;
+		const gitBranch =
+			includeGit || includePr || includeBranch ? this.#getBranchLabel(activeRepoCache.effectiveGitCwd) : null;
 		const gitStatus = includeGit ? this.#getStatus(activeRepoCache.effectiveGitCwd) : null;
 		const gitPr = includePr ? this.#lookupPr(activeRepoCache.effectiveGitCwd) : null;
 		const compactionSpeculation = this.session.compactionSpeculation ?? "idle";
@@ -1929,12 +1954,19 @@ export class StatusLineComponent implements Component {
 			(hasGitSegment(effectiveSettings.leftSegments) || hasGitSegment(effectiveSettings.rightSegments));
 		const includePr =
 			gitEnabled && (hasPrSegment(effectiveSettings.leftSegments) || hasPrSegment(effectiveSettings.rightSegments));
+		// An extension segment may render the branch via its context, so resolve
+		// the branch label for custom-only layouts too — not just built-in git/pr.
+		const includeBranch =
+			gitEnabled &&
+			(this.#hasRegisteredExtensionSegment(effectiveSettings.leftSegments) ||
+				this.#hasRegisteredExtensionSegment(effectiveSettings.rightSegments));
 		const liveCtx = this.#buildSegmentContext(
 			width,
 			effectiveSettings.segmentOptions,
 			includePath,
 			includeGit,
 			includePr,
+			includeBranch,
 			previewTitle,
 		);
 		const ctx: SegmentContext = placeholders ? { ...liveCtx, startupPlaceholder: true } : liveCtx;
@@ -1960,7 +1992,7 @@ export class StatusLineComponent implements Component {
 
 		// Collect visible segment contents
 		const leftParts: string[] = [];
-		const leftSegIds: StatusLineSegmentId[] = [];
+		const leftSegIds: StatusLineSegmentRef[] = [];
 		const leftSegmentIds = layout === "plain-right" ? [] : effectiveSettings.leftSegments;
 		for (const segId of leftSegmentIds) {
 			if (subagentBadge && segId === "subagents") continue;
@@ -1974,7 +2006,7 @@ export class StatusLineComponent implements Component {
 		}
 
 		const rightParts: string[] = [];
-		const rightSegIds: StatusLineSegmentId[] = [];
+		const rightSegIds: StatusLineSegmentRef[] = [];
 		const rightSegmentIds = layout === "plain-left" ? [] : effectiveSettings.rightSegments;
 		for (const segId of rightSegmentIds) {
 			if (subagentBadge && segId === "subagents") continue;

--- a/packages/coding-agent/src/modes/components/status-line/segments.ts
+++ b/packages/coding-agent/src/modes/components/status-line/segments.ts
@@ -937,12 +937,13 @@ export function renderSegment(id: StatusLineSegmentRef, ctx: SegmentContext): Re
 		return SEGMENTS[id].render(ctx);
 	}
 
-	const extensionRenderer = ctx.session.extensionRunner?.getStatusLineSegment(id);
-	if (!extensionRenderer) {
+	const runner = ctx.session.extensionRunner;
+	const extensionRenderer = runner?.getStatusLineSegment(id);
+	if (!runner || !extensionRenderer) {
 		return { content: "", visible: false };
 	}
 	try {
-		const rendered = extensionRenderer(toExtensionSegmentContext(ctx), theme);
+		const rendered = runner.runScoped(() => extensionRenderer(toExtensionSegmentContext(ctx), theme));
 		return { content: sanitizeStyledStatusText(rendered.content), visible: rendered.visible };
 	} catch (error) {
 		logger.warn(`status-line segment "${id}" threw during render: ${error instanceof Error ? error.message : error}`);

--- a/packages/coding-agent/src/modes/components/status-line/segments.ts
+++ b/packages/coding-agent/src/modes/components/status-line/segments.ts
@@ -908,7 +908,6 @@ export const SEGMENTS: Record<StatusLineSegmentId, StatusLineSegment> = {
 	collab: collabSegment,
 };
 
-/** Maps the internal render context down to the smaller, stable shape exposed to extensions. */
 function toExtensionSegmentContext(ctx: SegmentContext): ExtensionStatusLineSegmentContext {
 	return {
 		width: ctx.width,
@@ -929,16 +928,11 @@ function toExtensionSegmentContext(ctx: SegmentContext): ExtensionStatusLineSegm
 	};
 }
 
-/** True when `id` names a built-in segment (an own key of {@link SEGMENTS}), not an extension-registered id. */
 export function isBuiltInSegmentId(id: StatusLineSegmentRef): id is StatusLineSegmentId {
 	return Object.hasOwn(SEGMENTS, id);
 }
 
 export function renderSegment(id: StatusLineSegmentRef, ctx: SegmentContext): RenderedSegment {
-	// Built-in ids always win, even if a plugin registered the same id — see
-	// `ExtensionRunner.getStatusLineSegment`. The own-key check keeps an
-	// arbitrary extension id from resolving an inherited `Object.prototype`
-	// member (e.g. "toString") as a bogus segment and crashing the render.
 	if (isBuiltInSegmentId(id)) {
 		return SEGMENTS[id].render(ctx);
 	}
@@ -949,8 +943,6 @@ export function renderSegment(id: StatusLineSegmentRef, ctx: SegmentContext): Re
 	}
 	try {
 		const rendered = extensionRenderer(toExtensionSegmentContext(ctx), theme);
-		// Extension content shares the built-in single-row surface: strip
-		// row-breaking control characters while preserving intentional styling.
 		return { content: sanitizeStyledStatusText(rendered.content), visible: rendered.visible };
 	} catch (error) {
 		logger.warn(`status-line segment "${id}" threw during render: ${error instanceof Error ? error.message : error}`);

--- a/packages/coding-agent/src/modes/components/status-line/segments.ts
+++ b/packages/coding-agent/src/modes/components/status-line/segments.ts
@@ -2,14 +2,28 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import { SPINNER_ADVANCE_MS, TERMINAL } from "@oh-my-pi/pi-tui";
-import { formatDuration, formatNumber, getProjectDir, pathIsWithin, relativePathWithinRoot } from "@oh-my-pi/pi-utils";
+import {
+	formatDuration,
+	formatNumber,
+	getProjectDir,
+	logger,
+	pathIsWithin,
+	relativePathWithinRoot,
+} from "@oh-my-pi/pi-utils";
+import type { StatusLineSegmentContext as ExtensionStatusLineSegmentContext } from "../../../extensibility/extensions/types";
 import { type Theme, type ThemeColor, theme } from "../../../modes/theme/theme";
 import { shortenPath, TRUNCATE_LENGTHS, truncateToWidth } from "../../../tools/render-utils";
 import { fileHyperlink } from "../../../tui/hyperlink";
 import { getSessionAccentAnsi, getSessionAccentHex } from "../../../utils/session-color";
-import { sanitizeStatusText } from "../../shared";
+import { sanitizeStatusText, sanitizeStyledStatusText } from "../../shared";
 import { formatContextUsage, getContextUsageLevel, getContextUsageThemeColor } from "./context-thresholds";
-import type { RenderedSegment, SegmentContext, StatusLineSegment, StatusLineSegmentId } from "./types";
+import type {
+	RenderedSegment,
+	SegmentContext,
+	StatusLineSegment,
+	StatusLineSegmentId,
+	StatusLineSegmentRef,
+} from "./types";
 
 export type { SegmentContext } from "./types";
 
@@ -894,12 +908,54 @@ export const SEGMENTS: Record<StatusLineSegmentId, StatusLineSegment> = {
 	collab: collabSegment,
 };
 
-export function renderSegment(id: StatusLineSegmentId, ctx: SegmentContext): RenderedSegment {
-	const segment = SEGMENTS[id];
-	if (!segment) {
+/** Maps the internal render context down to the smaller, stable shape exposed to extensions. */
+function toExtensionSegmentContext(ctx: SegmentContext): ExtensionStatusLineSegmentContext {
+	return {
+		width: ctx.width,
+		usage: {
+			inputTokens: ctx.usageStats.input,
+			outputTokens: ctx.usageStats.output,
+			cacheReadTokens: ctx.usageStats.cacheRead,
+			cacheWriteTokens: ctx.usageStats.cacheWrite,
+			totalTokens: ctx.usageStats.totalTokens,
+			cost: ctx.usageStats.cost,
+			tokensPerSecond: ctx.usageStats.tokensPerSecond,
+		},
+		contextPercent: ctx.contextPercent,
+		contextTokens: ctx.contextTokens,
+		contextWindow: ctx.contextWindow,
+		git: { branch: ctx.git.branch },
+		activeMs: ctx.activeMs,
+	};
+}
+
+/** True when `id` names a built-in segment (an own key of {@link SEGMENTS}), not an extension-registered id. */
+export function isBuiltInSegmentId(id: StatusLineSegmentRef): id is StatusLineSegmentId {
+	return Object.hasOwn(SEGMENTS, id);
+}
+
+export function renderSegment(id: StatusLineSegmentRef, ctx: SegmentContext): RenderedSegment {
+	// Built-in ids always win, even if a plugin registered the same id — see
+	// `ExtensionRunner.getStatusLineSegment`. The own-key check keeps an
+	// arbitrary extension id from resolving an inherited `Object.prototype`
+	// member (e.g. "toString") as a bogus segment and crashing the render.
+	if (isBuiltInSegmentId(id)) {
+		return SEGMENTS[id].render(ctx);
+	}
+
+	const extensionRenderer = ctx.session.extensionRunner?.getStatusLineSegment(id);
+	if (!extensionRenderer) {
 		return { content: "", visible: false };
 	}
-	return segment.render(ctx);
+	try {
+		const rendered = extensionRenderer(toExtensionSegmentContext(ctx), theme);
+		// Extension content shares the built-in single-row surface: strip
+		// row-breaking control characters while preserving intentional styling.
+		return { content: sanitizeStyledStatusText(rendered.content), visible: rendered.visible };
+	} catch (error) {
+		logger.warn(`status-line segment "${id}" threw during render: ${error instanceof Error ? error.message : error}`);
+		return { content: "", visible: false };
+	}
 }
 
 export const ALL_SEGMENT_IDS: StatusLineSegmentId[] = Object.keys(SEGMENTS) as StatusLineSegmentId[];

--- a/packages/coding-agent/src/modes/components/status-line/types.ts
+++ b/packages/coding-agent/src/modes/components/status-line/types.ts
@@ -3,13 +3,14 @@ import type {
 	ContextLineMode,
 	StatusLinePreset,
 	StatusLineSegmentId,
+	StatusLineSegmentRef,
 	StatusLineSeparatorStyle,
 } from "../../../config/settings-schema";
 import type { AgentSession } from "../../../session/agent-session";
 import type { ActiveRepoContext } from "../../../utils/active-repo-context";
 import type { LoopLimitRuntime } from "../../loop-limit";
 
-export type { ContextLineMode, StatusLinePreset, StatusLineSegmentId, StatusLineSeparatorStyle };
+export type { ContextLineMode, StatusLinePreset, StatusLineSegmentId, StatusLineSegmentRef, StatusLineSeparatorStyle };
 
 /** Collab session indicator + (guest-only) host-state override for segments. */
 export interface CollabStatus {
@@ -28,8 +29,8 @@ export interface StatusLineSegmentOptions {
 
 export interface StatusLineSettings {
 	preset?: StatusLinePreset;
-	leftSegments?: StatusLineSegmentId[];
-	rightSegments?: StatusLineSegmentId[];
+	leftSegments?: StatusLineSegmentRef[];
+	rightSegments?: StatusLineSegmentRef[];
 	separator?: StatusLineSeparatorStyle;
 	segmentOptions?: StatusLineSegmentOptions;
 	showHookStatus?: boolean;

--- a/packages/coding-agent/src/modes/shared.ts
+++ b/packages/coding-agent/src/modes/shared.ts
@@ -15,18 +15,7 @@ export function sanitizeStatusText(text: string): string {
 		.trim();
 }
 
-/**
- * Sanitize extension-provided status content for a single-line status while
- * preserving a segment's themed color. Only complete SGR sequences (`\x1b[…m`)
- * survive; every other escape sequence (cursor moves, OSC hyperlinks, screen
- * clears) is stripped, and all C0/C1 controls — including tabs, newlines, and
- * carriage returns that would break the one-row status bar — are mapped to a
- * space. Runs are then collapsed and the ends trimmed.
- */
 export function sanitizeStyledStatusText(text: string): string {
-	// A capturing split isolates SGR sequences at odd indices (kept verbatim);
-	// the surrounding text has tabs expanded via the central helper, then any
-	// remaining ANSI and C0/C1 control bytes scrubbed to spaces.
 	return text
 		.split(/(\x1b\[[0-9;:]*m)/g)
 		.map((part, index) =>

--- a/packages/coding-agent/src/modes/shared.ts
+++ b/packages/coding-agent/src/modes/shared.ts
@@ -1,4 +1,4 @@
-import type { TabBarTheme } from "@oh-my-pi/pi-tui";
+import { replaceTabs, type TabBarTheme } from "@oh-my-pi/pi-tui";
 import { sanitizeText } from "@oh-my-pi/pi-utils";
 import { theme } from "./theme/theme";
 
@@ -11,6 +11,28 @@ import { theme } from "./theme/theme";
 export function sanitizeStatusText(text: string): string {
 	return sanitizeText(text)
 		.replace(/[\u0000-\u001f\u007f-\u009f]/g, " ")
+		.replace(/ +/g, " ")
+		.trim();
+}
+
+/**
+ * Sanitize extension-provided status content for a single-line status while
+ * preserving a segment's themed color. Only complete SGR sequences (`\x1b[…m`)
+ * survive; every other escape sequence (cursor moves, OSC hyperlinks, screen
+ * clears) is stripped, and all C0/C1 controls — including tabs, newlines, and
+ * carriage returns that would break the one-row status bar — are mapped to a
+ * space. Runs are then collapsed and the ends trimmed.
+ */
+export function sanitizeStyledStatusText(text: string): string {
+	// A capturing split isolates SGR sequences at odd indices (kept verbatim);
+	// the surrounding text has tabs expanded via the central helper, then any
+	// remaining ANSI and C0/C1 control bytes scrubbed to spaces.
+	return text
+		.split(/(\x1b\[[0-9;:]*m)/g)
+		.map((part, index) =>
+			index % 2 === 1 ? part : Bun.stripANSI(replaceTabs(part)).replace(/[\u0000-\u001f\u007f-\u009f]/g, " "),
+		)
+		.join("")
 		.replace(/ +/g, " ")
 		.trim();
 }

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -493,8 +493,6 @@ describe("ExtensionRunner", () => {
 				modelRegistry,
 			);
 
-			// getStatusLineSegment searches extensions in reverse load order, so the
-			// explicit (later-loaded) extension wins — matching getCommand precedence.
 			const renderer = runner.getStatusLineSegment("dup_seg");
 			expect(renderer).toBeDefined();
 			const rendered = (renderer as unknown as () => { content: string })();

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -457,6 +457,51 @@ describe("ExtensionRunner", () => {
 		});
 	});
 
+	describe("status line segments", () => {
+		const segCode = (id: string, content: string) => `
+			export default function(pi) {
+				pi.registerStatusLineSegment("${id}", () => ({ content: "${content}", visible: true }));
+			}
+		`;
+
+		it("exposes a registered status-line segment via getStatusLineSegment", async () => {
+			fs.writeFileSync(path.join(extensionsDir, "seg.ts"), segCode("my_seg", "SEG"));
+			const result = await loadTestExtensions();
+			const runner = new ExtensionRunner(
+				result.extensions,
+				result.runtime,
+				tempDir.path(),
+				sessionManager,
+				modelRegistry,
+			);
+
+			expect(runner.getStatusLineSegment("my_seg")).toBeDefined();
+			expect(runner.getStatusLineSegment("not-registered")).toBeUndefined();
+		});
+
+		it("prefers the later-loaded extension for a conflicting segment id", async () => {
+			fs.writeFileSync(path.join(extensionsDir, "discovered-seg.ts"), segCode("dup_seg", "DISCOVERED"));
+			const explicitExtensionPath = path.join(tempDir.path(), "explicit-seg.ts");
+			fs.writeFileSync(explicitExtensionPath, segCode("dup_seg", "EXPLICIT"));
+
+			const result = await loadTestExtensions([explicitExtensionPath]);
+			const runner = new ExtensionRunner(
+				result.extensions,
+				result.runtime,
+				tempDir.path(),
+				sessionManager,
+				modelRegistry,
+			);
+
+			// getStatusLineSegment searches extensions in reverse load order, so the
+			// explicit (later-loaded) extension wins — matching getCommand precedence.
+			const renderer = runner.getStatusLineSegment("dup_seg");
+			expect(renderer).toBeDefined();
+			const rendered = (renderer as unknown as () => { content: string })();
+			expect(rendered.content).toBe("EXPLICIT");
+		});
+	});
+
 	describe("error handling", () => {
 		it("calls error listeners when handler throws", async () => {
 			const extCode = `
@@ -3929,6 +3974,7 @@ describe("ExtensionRunner", () => {
 				fileDeleteFallbackHandlers: [],
 				messageRenderers: new Map(),
 				composerShapes: new Map(),
+				statusLineSegments: new Map(),
 				commands: new Map(),
 				flags: new Map(),
 				shortcuts: new Map(),

--- a/packages/coding-agent/test/sdk-credential-disabled-bridge.test.ts
+++ b/packages/coding-agent/test/sdk-credential-disabled-bridge.test.ts
@@ -510,6 +510,7 @@ describe("createAgentSession credential_disabled subscription", () => {
 				fileDeleteFallbackHandlers: [],
 				messageRenderers: new Map(),
 				composerShapes: new Map(),
+				statusLineSegments: new Map(),
 				commands: new Map(),
 				flags: new Map(),
 				shortcuts: new Map(),

--- a/packages/coding-agent/test/status-line-extension-segments.test.ts
+++ b/packages/coding-agent/test/status-line-extension-segments.test.ts
@@ -31,7 +31,14 @@ afterEach(() => {
 	vi.restoreAllMocks();
 });
 
-function makeSession(extensionRunner?: { getStatusLineSegment: (id: string) => unknown }) {
+function makeSession(extensionRunner?: {
+	getStatusLineSegment: (id: string) => unknown;
+	runScoped?: <T>(fn: () => T) => T;
+}) {
+	const runner =
+		extensionRunner && typeof extensionRunner.runScoped !== "function"
+			? { ...extensionRunner, runScoped: <T>(fn: () => T): T => fn() }
+			: extensionRunner;
 	return {
 		state: { messages: [], model: undefined },
 		messages: [],
@@ -47,7 +54,7 @@ function makeSession(extensionRunner?: { getStatusLineSegment: (id: string) => u
 		getGoalModeState: () => null,
 		getAsyncJobSnapshot: () => ({ running: [] }),
 		modelRegistry: { isUsingOAuth: () => false },
-		extensionRunner,
+		extensionRunner: runner,
 		sessionManager: {
 			getSessionName: () => "extension segments test",
 			getUsageStatistics: () => ({
@@ -205,6 +212,36 @@ describe("extension-registered status line segments", () => {
 		expect(content).toContain("LINE1 LINE2 TAB");
 		expect(content).not.toContain("\n");
 		expect(content).not.toContain("\t");
+	});
+
+	it("runs an extension segment renderer inside the runner's settings scope", () => {
+		const order: string[] = [];
+		const component = new StatusLineComponent(
+			makeSession({
+				getStatusLineSegment: id =>
+					id === "scoped_widget"
+						? () => {
+								order.push("render");
+								return { content: "SCOPED", visible: true };
+							}
+						: undefined,
+				runScoped: <T>(fn: () => T): T => {
+					order.push("enter");
+					const result = fn();
+					order.push("exit");
+					return result;
+				},
+			}),
+		);
+		component.updateSettings({
+			preset: "custom",
+			leftSegments: ["scoped_widget"],
+			rightSegments: [],
+			separator: "powerline-thin",
+		});
+
+		expect(component.getTopBorder(80).content).toContain("SCOPED");
+		expect(order).toEqual(["enter", "render", "exit"]);
 	});
 });
 

--- a/packages/coding-agent/test/status-line-extension-segments.test.ts
+++ b/packages/coding-agent/test/status-line-extension-segments.test.ts
@@ -159,8 +159,6 @@ describe("extension-registered status line segments", () => {
 		);
 		component.updateSettings({
 			preset: "custom",
-			// "toString"/"constructor" resolve inherited members on a plain object;
-			// they must be treated as unregistered, not dispatched as fake segments.
 			leftSegments: ["toString", "constructor", "my_widget"],
 			rightSegments: [],
 			separator: "powerline-thin",
@@ -173,8 +171,6 @@ describe("extension-registered status line segments", () => {
 	});
 
 	it("renders an extension segment registered under a prototype-named id", () => {
-		// An own-key built-in check must still let an extension claim an id that
-		// collides with an Object.prototype member name.
 		const component = new StatusLineComponent(
 			makeSession({
 				getStatusLineSegment: id =>
@@ -214,7 +210,6 @@ describe("extension-registered status line segments", () => {
 
 describe("extension status line segment context", () => {
 	it("maps the internal render context onto the public StatusLineSegmentContext shape", () => {
-		// No repository → deterministic null branch regardless of the host checkout.
 		vi.spyOn(vcs, "repo").mockReturnValue(null);
 		let captured: StatusLineSegmentContext | undefined;
 		const component = new StatusLineComponent(
@@ -238,7 +233,6 @@ describe("extension status line segment context", () => {
 		component.getTopBorder(80);
 		expect(captured).toBeDefined();
 		expect(captured?.width).toBe(80);
-		// Mirrors the zeroed usage stats the mock session reports.
 		expect(captured?.usage).toEqual({
 			inputTokens: 0,
 			outputTokens: 0,
@@ -345,8 +339,6 @@ describe("git branch resolution for extension segments", () => {
 		component.watchBranch(() => {
 			repaints += 1;
 		});
-		// A custom-only registered extension layout must still install the watcher
-		// so a later HEAD change invalidates the cached branch and repaints.
 		expect(watchSpy).toHaveBeenCalled();
 		expect(watchCallback).toBeDefined();
 		watchCallback?.();

--- a/packages/coding-agent/test/status-line-extension-segments.test.ts
+++ b/packages/coding-agent/test/status-line-extension-segments.test.ts
@@ -1,0 +1,406 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { loadExtensions } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/loader";
+import { ExtensionRunner } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/runner";
+import type { StatusLineSegmentContext } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/types";
+import { StatusLineComponent } from "@oh-my-pi/pi-coding-agent/modes/components/status-line";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import type { VcsGitRepo, VcsGitRepoInfo, VcsHeadState, VcsRepo } from "@oh-my-pi/pi-natives";
+import * as vcs from "@oh-my-pi/pi-natives/vcs";
+import { getProjectAgentDir, getProjectDir, setProjectDir, TempDir } from "@oh-my-pi/pi-utils";
+
+const originalProjectDir = getProjectDir();
+
+beforeAll(async () => {
+	resetSettingsForTest();
+	await Settings.init({ inMemory: true });
+	await initTheme();
+});
+
+afterAll(() => {
+	resetSettingsForTest();
+	setProjectDir(originalProjectDir);
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+function makeSession(extensionRunner?: { getStatusLineSegment: (id: string) => unknown }) {
+	return {
+		state: { messages: [], model: undefined },
+		messages: [],
+		model: undefined,
+		systemPrompt: [],
+		agent: { state: { tools: [] } },
+		skills: [],
+		isStreaming: false,
+		isAutoThinking: false,
+		autoResolvedThinkingLevel: () => undefined,
+		isFastModeActive: () => false,
+		isFastModeEnabled: () => false,
+		getGoalModeState: () => null,
+		getAsyncJobSnapshot: () => ({ running: [] }),
+		modelRegistry: { isUsingOAuth: () => false },
+		extensionRunner,
+		sessionManager: {
+			getSessionName: () => "extension segments test",
+			getUsageStatistics: () => ({
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				orchestrationInput: 0,
+				orchestrationOutput: 0,
+				orchestrationCacheRead: 0,
+				premiumRequests: 0,
+				cost: 0,
+			}),
+		},
+	} as unknown as ConstructorParameters<typeof StatusLineComponent>[0];
+}
+
+describe("extension-registered status line segments", () => {
+	it("renders an extension-registered segment id", () => {
+		const component = new StatusLineComponent(
+			makeSession({
+				getStatusLineSegment: id =>
+					id === "my_widget" ? () => ({ content: "MY-WIDGET", visible: true }) : undefined,
+			}),
+		);
+		component.updateSettings({
+			preset: "custom",
+			leftSegments: ["my_widget"],
+			rightSegments: [],
+			separator: "powerline-thin",
+		});
+
+		expect(component.getTopBorder(80).content).toContain("MY-WIDGET");
+	});
+
+	it("omits an unregistered segment id while keeping registered siblings", () => {
+		const component = new StatusLineComponent(
+			makeSession({
+				getStatusLineSegment: id =>
+					id === "my_widget" ? () => ({ content: "MY-WIDGET", visible: true }) : undefined,
+			}),
+		);
+		component.updateSettings({
+			preset: "custom",
+			leftSegments: ["not_a_real_segment", "my_widget"],
+			rightSegments: [],
+			separator: "powerline-thin",
+		});
+
+		const content = component.getTopBorder(80).content;
+		expect(content).toContain("MY-WIDGET");
+		expect(content).not.toContain("not_a_real_segment");
+	});
+
+	it("does not consult the extension registry for a built-in id", () => {
+		let calledWith: string | undefined;
+		const component = new StatusLineComponent(
+			makeSession({
+				getStatusLineSegment: id => {
+					calledWith = id;
+					return () => ({ content: "SHOULD-NOT-APPEAR", visible: true });
+				},
+			}),
+		);
+		component.updateSettings({
+			preset: "custom",
+			leftSegments: ["pi"],
+			rightSegments: [],
+			separator: "powerline-thin",
+		});
+
+		const content = component.getTopBorder(80).content;
+		expect(content).not.toContain("SHOULD-NOT-APPEAR");
+		expect(calledWith).toBeUndefined();
+	});
+
+	it("treats a throwing extension segment as invisible while keeping registered siblings", () => {
+		const component = new StatusLineComponent(
+			makeSession({
+				getStatusLineSegment: id => {
+					if (id === "broken_widget")
+						return () => {
+							throw new Error("boom");
+						};
+					if (id === "my_widget") return () => ({ content: "MY-WIDGET", visible: true });
+					return undefined;
+				},
+			}),
+		);
+		component.updateSettings({
+			preset: "custom",
+			leftSegments: ["broken_widget", "my_widget"],
+			rightSegments: [],
+			separator: "powerline-thin",
+		});
+
+		const content = component.getTopBorder(80).content;
+		expect(content).toContain("MY-WIDGET");
+		expect(content).not.toContain("boom");
+	});
+
+	it("does not dispatch an inherited Object.prototype key as a built-in segment", () => {
+		const component = new StatusLineComponent(
+			makeSession({
+				getStatusLineSegment: id =>
+					id === "my_widget" ? () => ({ content: "MY-WIDGET", visible: true }) : undefined,
+			}),
+		);
+		component.updateSettings({
+			preset: "custom",
+			// "toString"/"constructor" resolve inherited members on a plain object;
+			// they must be treated as unregistered, not dispatched as fake segments.
+			leftSegments: ["toString", "constructor", "my_widget"],
+			rightSegments: [],
+			separator: "powerline-thin",
+		});
+
+		const content = component.getTopBorder(80).content;
+		expect(content).toContain("MY-WIDGET");
+		expect(content).not.toContain("function");
+		expect(content).not.toContain("[object");
+	});
+
+	it("renders an extension segment registered under a prototype-named id", () => {
+		// An own-key built-in check must still let an extension claim an id that
+		// collides with an Object.prototype member name.
+		const component = new StatusLineComponent(
+			makeSession({
+				getStatusLineSegment: id =>
+					id === "toString" ? () => ({ content: "PROTO-WIDGET", visible: true }) : undefined,
+			}),
+		);
+		component.updateSettings({
+			preset: "custom",
+			leftSegments: ["toString"],
+			rightSegments: [],
+			separator: "powerline-thin",
+		});
+
+		expect(component.getTopBorder(80).content).toContain("PROTO-WIDGET");
+	});
+
+	it("sanitizes row-breaking control characters from extension content", () => {
+		const component = new StatusLineComponent(
+			makeSession({
+				getStatusLineSegment: id =>
+					id === "nl_widget" ? () => ({ content: "LINE1\nLINE2\tTAB", visible: true }) : undefined,
+			}),
+		);
+		component.updateSettings({
+			preset: "custom",
+			leftSegments: ["nl_widget"],
+			rightSegments: [],
+			separator: "powerline-thin",
+		});
+
+		const content = component.getTopBorder(80).content;
+		expect(content).toContain("LINE1 LINE2 TAB");
+		expect(content).not.toContain("\n");
+		expect(content).not.toContain("\t");
+	});
+});
+
+describe("extension status line segment context", () => {
+	it("maps the internal render context onto the public StatusLineSegmentContext shape", () => {
+		// No repository → deterministic null branch regardless of the host checkout.
+		vi.spyOn(vcs, "repo").mockReturnValue(null);
+		let captured: StatusLineSegmentContext | undefined;
+		const component = new StatusLineComponent(
+			makeSession({
+				getStatusLineSegment: id =>
+					id === "probe"
+						? (ctx: StatusLineSegmentContext) => {
+								captured = ctx;
+								return { content: "PROBE", visible: true };
+							}
+						: undefined,
+			}),
+		);
+		component.updateSettings({
+			preset: "custom",
+			leftSegments: ["probe"],
+			rightSegments: [],
+			separator: "powerline-thin",
+		});
+
+		component.getTopBorder(80);
+		expect(captured).toBeDefined();
+		expect(captured?.width).toBe(80);
+		// Mirrors the zeroed usage stats the mock session reports.
+		expect(captured?.usage).toEqual({
+			inputTokens: 0,
+			outputTokens: 0,
+			cacheReadTokens: 0,
+			cacheWriteTokens: 0,
+			totalTokens: 0,
+			cost: 0,
+			tokensPerSecond: null,
+		});
+		expect(captured?.git).toEqual({ branch: null });
+		expect(typeof captured?.activeMs).toBe("number");
+	});
+});
+
+const fakeRefHead: VcsHeadState = {
+	kind: "ref",
+	branch: "feature/x",
+	refName: "refs/heads/feature/x",
+	commit: undefined,
+};
+const fakeRepoInfo: VcsGitRepoInfo = {
+	commonDir: "/fake/.git",
+	gitDir: "/fake/.git",
+	gitEntryPath: "/fake/.git",
+	headPath: "/fake/.git/HEAD",
+	repoRoot: "/fake",
+	isReftable: false,
+};
+const fakeGitRepo = {
+	headSync: () => fakeRefHead,
+	linkedWorktree: () => null,
+} as unknown as VcsGitRepo;
+const fakeVcsRepo = {
+	kind: () => "git",
+	asGit: () => fakeGitRepo,
+	asJj: () => null,
+	root: () => fakeRepoInfo.repoRoot,
+	watchTarget: () => fakeRepoInfo.headPath,
+} as unknown as VcsRepo;
+
+describe("git branch resolution for extension segments", () => {
+	it("resolves the branch for a custom-only extension layout with no built-in git/pr segment", () => {
+		vi.spyOn(vcs, "gitInfo").mockReturnValue(fakeRepoInfo);
+		vi.spyOn(vcs, "repo").mockReturnValue(fakeVcsRepo);
+		let captured: StatusLineSegmentContext | undefined;
+		const component = new StatusLineComponent(
+			makeSession({
+				getStatusLineSegment: id =>
+					id === "branch_probe"
+						? (ctx: StatusLineSegmentContext) => {
+								captured = ctx;
+								return { content: "BRANCH", visible: true };
+							}
+						: undefined,
+			}),
+		);
+		component.updateSettings({
+			preset: "custom",
+			leftSegments: ["branch_probe"],
+			rightSegments: [],
+			separator: "powerline-thin",
+		});
+
+		component.getTopBorder(80);
+		expect(captured?.git).toEqual({ branch: "feature/x" });
+	});
+
+	it("does not resolve git for an unregistered id, avoiding work for stale config", () => {
+		const repoSpy = vi.spyOn(vcs, "repo").mockReturnValue(fakeVcsRepo);
+		const component = new StatusLineComponent(makeSession());
+		component.updateSettings({
+			preset: "custom",
+			leftSegments: ["not_registered"],
+			rightSegments: [],
+			separator: "powerline-thin",
+		});
+
+		component.getTopBorder(80);
+		expect(repoSpy).not.toHaveBeenCalled();
+	});
+
+	it("installs a HEAD watcher so an extension branch segment refreshes on HEAD change", () => {
+		vi.spyOn(vcs, "gitInfo").mockReturnValue(fakeRepoInfo);
+		vi.spyOn(vcs, "repo").mockReturnValue(fakeVcsRepo);
+		let watchCallback: (() => void) | undefined;
+		const watchSpy = vi.spyOn(vcs, "watch").mockImplementation((_repo, onChange) => {
+			watchCallback = onChange;
+			return () => {};
+		});
+		const component = new StatusLineComponent(
+			makeSession({
+				getStatusLineSegment: id =>
+					id === "branch_probe" ? () => ({ content: "BRANCH", visible: true }) : undefined,
+			}),
+		);
+		component.updateSettings({
+			preset: "custom",
+			leftSegments: ["branch_probe"],
+			rightSegments: [],
+			separator: "powerline-thin",
+		});
+
+		let repaints = 0;
+		component.watchBranch(() => {
+			repaints += 1;
+		});
+		// A custom-only registered extension layout must still install the watcher
+		// so a later HEAD change invalidates the cached branch and repaints.
+		expect(watchSpy).toHaveBeenCalled();
+		expect(watchCallback).toBeDefined();
+		watchCallback?.();
+		expect(repaints).toBe(1);
+	});
+});
+
+describe("registerStatusLineSegment end-to-end render", () => {
+	let tempDir: TempDir;
+	let authStorage: AuthStorage;
+	let modelRegistry: ModelRegistry;
+
+	beforeAll(async () => {
+		tempDir = TempDir.createSync("@pi-statusline-e2e-");
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "auth.db"));
+		modelRegistry = new ModelRegistry(authStorage);
+	});
+
+	afterAll(() => {
+		authStorage.close();
+		tempDir.removeSync();
+	});
+
+	it("renders a segment registered by a real extension through a real ExtensionRunner", async () => {
+		const extensionsDir = path.join(getProjectAgentDir(tempDir.path()), "extensions");
+		fs.mkdirSync(extensionsDir, { recursive: true });
+		const extensionPath = path.join(extensionsDir, "seg.ts");
+		fs.writeFileSync(
+			extensionPath,
+			`export default function(pi) {
+				pi.registerStatusLineSegment("e2e_widget", () => ({ content: "E2E-WIDGET", visible: true }));
+			}`,
+		);
+
+		const loaded = await loadExtensions([extensionPath], tempDir.path());
+		expect(loaded.errors).toEqual([]);
+		const sessionManager = SessionManager.inMemory(tempDir.path());
+		const runner = new ExtensionRunner(
+			loaded.extensions,
+			loaded.runtime,
+			tempDir.path(),
+			sessionManager,
+			modelRegistry,
+		);
+		expect(runner.getStatusLineSegment("e2e_widget")).toBeDefined();
+
+		const component = new StatusLineComponent(makeSession(runner));
+		component.updateSettings({
+			preset: "custom",
+			leftSegments: ["e2e_widget"],
+			rightSegments: [],
+			separator: "powerline-thin",
+		});
+
+		expect(component.getTopBorder(80).content).toContain("E2E-WIDGET");
+	});
+});

--- a/packages/coding-agent/test/status-text-sanitization.test.ts
+++ b/packages/coding-agent/test/status-text-sanitization.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { sanitizeStatusText } from "@oh-my-pi/pi-coding-agent/modes/shared";
+import { sanitizeStatusText, sanitizeStyledStatusText } from "@oh-my-pi/pi-coding-agent/modes/shared";
 
 describe("sanitizeStatusText", () => {
 	it("strips OSC, DCS, PM, APC, and 8-bit CSI escape sequences", () => {
@@ -14,5 +14,23 @@ describe("sanitizeStatusText", () => {
 			" suffix";
 
 		expect(sanitizeStatusText(input)).toBe("prefix link red suffix");
+	});
+});
+
+describe("sanitizeStyledStatusText", () => {
+	it("preserves complete SGR color/style sequences verbatim", () => {
+		expect(sanitizeStyledStatusText("\x1b[1;32mgreen\x1b[0m")).toBe("\x1b[1;32mgreen\x1b[0m");
+	});
+
+	it("strips non-SGR escape sequences (cursor moves, screen clears, OSC hyperlinks)", () => {
+		expect(sanitizeStyledStatusText("a\x1b[2Jb")).toBe("ab");
+		expect(sanitizeStyledStatusText("a\x1b[10;5Hb")).toBe("ab");
+		expect(sanitizeStyledStatusText("\x1b]8;;https://example.com\x07link\x1b]8;;\x07")).toBe("link");
+	});
+
+	it("maps row-breaking controls (tab, newline, carriage return, lone ESC) to spaces and collapses runs", () => {
+		expect(sanitizeStyledStatusText("a\tb\nc\rd")).toBe("a b c d");
+		expect(sanitizeStyledStatusText("keep\x1b[1m   \x1b[0m color")).toBe("keep\x1b[1m \x1b[0m color");
+		expect(sanitizeStyledStatusText("\x1b[31m\x1b[2Jred\x1b[0m\nend")).toBe("\x1b[31mred\x1b[0m end");
 	});
 });


### PR DESCRIPTION
This implements the extension-facing part of #1966: a way for plugins to add their own status-line segments. It leaves out the disable and replace pieces, which still have open maintainer questions on the issue.

## What it adds

Extensions can call `registerStatusLineSegment(id, renderer)`. Once registered, the id works anywhere the built-in segment ids do, in `statusLine.leftSegments` and `statusLine.rightSegments`.

The renderer receives a small `StatusLineSegmentContext` (width, usage, context tokens and percent, git branch, active time) and the current `Theme`, and returns `{ content, visible }`.

## How it behaves

- Built-in ids always win. A plugin that registers `"model"` is shadowed, so it can't take over a built-in segment.
- If two extensions register the same id, the last one loaded wins, the same rule `getCommand` already uses.
- A renderer that throws becomes an invisible segment instead of breaking the whole status line.
- The bar sanitizes returned content for its single row: it keeps SGR color but drops tabs, newlines, and other escape or control sequences, so a segment can't corrupt the layout.
- For a custom-only layout it still resolves the git branch and installs the HEAD watcher, so a branch-aware extension segment stays current after a checkout.

## Not included

The issue also asks for `statusLine.enabled: false` and full renderer replacement. Those depend on decisions that are still open on the thread, so they're not part of this change.

## Tests

New coverage for the content sanitizer, built-in versus extension precedence, a throwing renderer, prototype-named ids, git branch resolution and its watcher, and a full-path test that loads a real extension through `ExtensionRunner` and renders it in `StatusLineComponent`. Type checking (`tsgo`), `oxlint`, `oxfmt`, and the focused status-line and extension test suites all pass.

Refs #1966
