### PR TITLE
feat(coding-agent): add worktree.cleanSource setting to clean original checkout on /wt

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -24,6 +24,9 @@
 - Local tiny models for titles, memory, and automatic thinking classification now share on-demand workers across omp processes, reducing redundant resource usage; workers stop automatically after inactivity.
 - PI_TINY_DEVICE=metal now selects the MLX backend on macOS.
 - Updated agent reactions to trigger on the opening emoji instead of requiring a newline, consuming any following whitespace.
+### Added
+
+- Added the `worktree.cleanSource` setting to reset and clean the original checkout when creating a worktree with `/wt`.
 
 ### Fixed
 

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -4909,6 +4909,18 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	"worktree.cleanSource": {
+		type: "boolean",
+		default: false,
+		ui: {
+			tab: "tasks",
+			group: "Isolation",
+			label: "Clean Source Checkout on /wt",
+			description:
+				"When creating a worktree with `/wt`, reset tracked changes and remove untracked files from the original checkout after carrying them over",
+		},
+	},
+
 	"task.isolation.apply": {
 		type: "boolean",
 		default: true,

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -141,6 +141,7 @@ const HOST_DEFAULTED_SETTING_PATHS: SettingPath[] = [
 	"task.isolation.enabled",
 	"isolation.backend",
 	"worktree.clone",
+	"worktree.cleanSource",
 	"task.isolation.apply",
 	"task.isolation.merge",
 	"task.isolation.commits",

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -45,6 +45,7 @@ import type { AuthStorage, OAuthAccountIdentity } from "../../session/auth-stora
 import type { CompactMode } from "../../session/compact-modes";
 import type { NewSessionOptions } from "../../session/session-entries";
 import {
+	cleanSourceCheckoutIfConfigured,
 	createSessionWorktree,
 	defaultSessionWorktreeBranch,
 	formatSessionWorktreeSummary,
@@ -1248,10 +1249,14 @@ export class CommandController {
 			logger.warn("worktree clone fell back to plain checkout", { path: worktree.path, error: worktree.cloneError });
 		}
 		if (await this.#relocateSession(worktree.path)) {
+			const cleanup = await cleanSourceCheckoutIfConfigured(cwd, this.ctx.settings);
+			if (cleanup.errorMessage !== undefined) {
+				this.ctx.showWarning(`Worktree created, but cleaning source checkout failed: ${cleanup.errorMessage}`);
+			}
 			this.ctx.present([
 				new Spacer(1),
 				new Text(
-					`${theme.fg("accent", `${theme.status.success} ${formatSessionWorktreeSummary(worktree)}`)}`,
+					`${theme.fg("accent", `${theme.status.success} ${formatSessionWorktreeSummary(worktree, cleanup.cleaned)}`)}`,
 					1,
 					1,
 				),

--- a/packages/coding-agent/src/session/session-worktree.ts
+++ b/packages/coding-agent/src/session/session-worktree.ts
@@ -12,7 +12,7 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import type { IsoBackendKind } from "@oh-my-pi/pi-natives";
 import * as vcs from "@oh-my-pi/pi-natives/vcs";
-import { getWorktreeDir, hashPath } from "@oh-my-pi/pi-utils";
+import { getWorktreeDir, hashPath, logger } from "@oh-my-pi/pi-utils";
 import type { Settings } from "../config/settings";
 import { formatIsolationBackend, parseIsolationBackend } from "../task/worktree";
 import { resolveAvailableWorktreePath } from "../tools/gh-pr-checkout";
@@ -35,17 +35,49 @@ export function defaultSessionWorktreeBranch(now = new Date()): string {
 }
 
 /** One-line confirmation shown after the session moved into `worktree`. */
-export function formatSessionWorktreeSummary(worktree: SessionWorktree): string {
+export function formatSessionWorktreeSummary(worktree: SessionWorktree, sourceCleaned = false): string {
 	const how =
 		worktree.clonedWith === undefined ? "checked out" : `cloned via ${formatIsolationBackend(worktree.clonedWith)}`;
-	return `Moved to worktree ${worktree.path} on branch ${worktree.branch} (${how}, uncommitted changes carried over).`;
+	const changeStatus = sourceCleaned
+		? "uncommitted changes moved, source checkout cleaned"
+		: "uncommitted changes carried over";
+	return `Moved to worktree ${worktree.path} on branch ${worktree.branch} (${how}, ${changeStatus}).`;
 }
 
+/**
+ * If `worktree.cleanSource` is enabled, resets and cleans the source checkout.
+ * Catches git errors and returns `{ cleaned: true }` on success, or `{ cleaned: false, errorMessage }` on failure.
+ */
+export async function cleanSourceCheckoutIfConfigured(
+	sourceCwd: string,
+	settings: Settings,
+): Promise<{ cleaned: boolean; errorMessage?: string }> {
+	if (!settings.get("worktree.cleanSource")) {
+		return { cleaned: false };
+	}
+	try {
+		const repository = vcs.requireGit(sourceCwd);
+		await repository.reset("hard", "HEAD");
+		await repository.clean({});
+		return { cleaned: true };
+	} catch (error) {
+		logger.warn("failed to clean source checkout after /wt", { cwd: sourceCwd, error });
+		return {
+			cleaned: false,
+			errorMessage: error instanceof Error ? error.message : String(error),
+		};
+	}
+}
 /**
  * Create the worktree for `/wt`. Throws with a user-facing message when `cwd`
  * is not a git checkout, `branch` already exists, or git refuses.
  */
 export async function createSessionWorktree(cwd: string, settings: Settings, branch: string): Promise<SessionWorktree> {
+	try {
+		await settings.flush();
+	} catch (err) {
+		throw new Error(`Failed to save pending settings: ${err instanceof Error ? err.message : String(err)}`);
+	}
 	const repository = vcs.git(cwd);
 	if (!repository) {
 		throw new Error(`Not inside a git repository: ${cwd}`);

--- a/packages/coding-agent/src/slash-commands/builtin-lifecycle.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-lifecycle.ts
@@ -13,6 +13,7 @@ import { USER_INTERRUPT_LABEL } from "../session/messages";
 import { resolveResumableSession } from "../session/session-listing";
 import { toggleSessionPin } from "../session/session-pins";
 import {
+	cleanSourceCheckoutIfConfigured,
 	createSessionWorktree,
 	defaultSessionWorktreeBranch,
 	formatSessionWorktreeSummary,
@@ -693,15 +694,22 @@ export const BUILTIN_LIFECYCLE_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> =
 		handle: async (command, runtime) => {
 			if (runtime.session.isStreaming) return usage("Cannot create a worktree while streaming.", runtime);
 			const branch = command.args.trim() || defaultSessionWorktreeBranch();
+			const sourceCwd = runtime.sessionManager.getCwd();
 			let worktree: SessionWorktree;
 			try {
-				worktree = await createSessionWorktree(runtime.sessionManager.getCwd(), runtime.settings, branch);
+				worktree = await createSessionWorktree(sourceCwd, runtime.settings, branch);
 			} catch (err) {
 				return usage(`Worktree creation failed: ${errorMessage(err)}`, runtime);
 			}
 			const failure = await relocateHeadlessSession(runtime, worktree.path);
 			if (failure) return failure;
-			await runtime.output(formatSessionWorktreeSummary(worktree));
+			const cleanup = await cleanSourceCheckoutIfConfigured(sourceCwd, runtime.settings);
+			if (cleanup.errorMessage !== undefined) {
+				await runtime.output(
+					`Warning: Worktree created, but cleaning source checkout failed: ${cleanup.errorMessage}`,
+				);
+			}
+			await runtime.output(formatSessionWorktreeSummary(worktree, cleanup.cleaned));
 			return commandConsumed();
 		},
 		handleTui: async (command, runtime) => {

--- a/packages/coding-agent/test/acp-builtins.test.ts
+++ b/packages/coding-agent/test/acp-builtins.test.ts
@@ -900,6 +900,108 @@ describe("wave 3 commands", () => {
 		}
 	});
 
+	it("/wt: with worktree.cleanSource=true, cleans the source checkout while preserving the worktree", async () => {
+		const { output, runtime, fakeSessionManager } = createRuntime();
+		runtime.settings.override("worktree.cleanSource", true);
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "omp-wt-clean-"));
+		const repoDir = path.join(root, "repo");
+		const worktreeBase = path.join(root, "wt");
+		const originalProjectDir = process.cwd();
+		const originalWorktreeDir = process.env.OMP_WORKTREE_DIR;
+		process.env.OMP_WORKTREE_DIR = worktreeBase;
+		const git = async (...args: string[]) => {
+			const proc = Bun.spawn(["git", ...args], { cwd: repoDir, stdout: "pipe", stderr: "pipe" });
+			const [stdout, code] = await Promise.all([new Response(proc.stdout).text(), proc.exited]);
+			expect(code).toBe(0);
+			return stdout.trim();
+		};
+		try {
+			await fs.mkdir(repoDir, { recursive: true });
+			await git("init", "-q", "-b", "main");
+			await git("config", "user.email", "t@example.com");
+			await git("config", "user.name", "t");
+			await Bun.write(path.join(repoDir, "tracked.txt"), "committed\n");
+			await Bun.write(path.join(repoDir, ".gitignore"), "build/\n");
+			await git("add", "-A");
+			await git("commit", "-qm", "init");
+			await Bun.write(path.join(repoDir, "tracked.txt"), "edited\n");
+			await Bun.write(path.join(repoDir, "untracked.txt"), "new\n");
+			await Bun.write(path.join(repoDir, "build/out.txt"), "ignored\n");
+			fakeSessionManager._cwd = repoDir;
+
+			const result = await executeAcpBuiltinSlashCommand("/wt feature/clean", runtime);
+
+			expect(result).toEqual({ consumed: true });
+			const movedTo = fakeSessionManager._movedTo;
+			expect(movedTo).toBeDefined();
+			expect(movedTo!.startsWith(await fs.realpath(worktreeBase))).toBe(true);
+			expect(output[0]).toContain(`Moved to worktree ${movedTo} on branch feature/clean`);
+			expect(output[0]).toContain("uncommitted changes moved, source checkout cleaned");
+			// The worktree carries all uncommitted changes.
+			expect(await Bun.file(path.join(movedTo!, "tracked.txt")).text()).toBe("edited\n");
+			expect(await Bun.file(path.join(movedTo!, "untracked.txt")).text()).toBe("new\n");
+			// The source checkout was reset and cleaned.
+			expect(await Bun.file(path.join(repoDir, "tracked.txt")).text()).toBe("committed\n");
+			expect(await Bun.file(path.join(repoDir, "untracked.txt")).exists()).toBe(false);
+			// Ignored files survive in the source checkout.
+			expect(await Bun.file(path.join(repoDir, "build/out.txt")).text()).toBe("ignored\n");
+			expect(await git("symbolic-ref", "HEAD")).toBe("refs/heads/main");
+			expect(await git("status", "--porcelain")).toBe("");
+		} finally {
+			setProjectDir(originalProjectDir);
+			if (originalWorktreeDir === undefined) delete process.env.OMP_WORKTREE_DIR;
+			else process.env.OMP_WORKTREE_DIR = originalWorktreeDir;
+			await fs.rm(root, { recursive: true, force: true });
+		}
+	});
+
+	it("/wt: aborts and leaves source checkout untouched when settings flush fails", async () => {
+		const { output, runtime, fakeSessionManager } = createRuntime();
+		spyOn(runtime.settings, "flush").mockRejectedValue(new Error("disk full"));
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "omp-wt-flush-fail-"));
+		const repoDir = path.join(root, "repo");
+		const worktreeBase = path.join(root, "wt");
+		const originalProjectDir = process.cwd();
+		const originalWorktreeDir = process.env.OMP_WORKTREE_DIR;
+		process.env.OMP_WORKTREE_DIR = worktreeBase;
+		const git = async (...args: string[]) => {
+			const proc = Bun.spawn(["git", ...args], { cwd: repoDir, stdout: "pipe", stderr: "pipe" });
+			const [stdout, code] = await Promise.all([new Response(proc.stdout).text(), proc.exited]);
+			expect(code).toBe(0);
+			return stdout.trim();
+		};
+		try {
+			await fs.mkdir(repoDir, { recursive: true });
+			await git("init", "-q", "-b", "main");
+			await git("config", "user.email", "t@example.com");
+			await git("config", "user.name", "t");
+			await Bun.write(path.join(repoDir, "tracked.txt"), "committed\n");
+			await git("add", "-A");
+			await git("commit", "-qm", "init");
+			await Bun.write(path.join(repoDir, "tracked.txt"), "dirty\n");
+			fakeSessionManager._cwd = repoDir;
+
+			const result = await executeAcpBuiltinSlashCommand("/wt feature/flush-fail", runtime);
+
+			expect(result).toEqual({ consumed: true });
+			expect(output[0]).toContain("Failed to save pending settings: disk full");
+			expect(fakeSessionManager._movedTo).toBeUndefined();
+			expect(await Bun.file(path.join(repoDir, "tracked.txt")).text()).toBe("dirty\n");
+			// Assert aborted BEFORE branch or worktree snapshot creation
+			const branchExists = await git("branch", "--list", "feature/flush-fail");
+			expect(branchExists).toBe("");
+			const worktrees = await git("worktree", "list", "--porcelain");
+			expect(worktrees).not.toContain("feature/flush-fail");
+			const wtDirs = await fs.readdir(worktreeBase).catch(() => []);
+			expect(wtDirs).toEqual([]);
+		} finally {
+			setProjectDir(originalProjectDir);
+			if (originalWorktreeDir === undefined) delete process.env.OMP_WORKTREE_DIR;
+			else process.env.OMP_WORKTREE_DIR = originalWorktreeDir;
+			await fs.rm(root, { recursive: true, force: true });
+		}
+	});
+
 	// /memory
 	it("/memory unknown: returns usage message", async () => {
 		const { output, runtime } = createRuntime();


### PR DESCRIPTION
## Summary
Adds the `worktree.cleanSource` setting (`boolean`, default: `false`). When enabled, `/wt` resets and cleans the original checkout after successfully relocating the session into the new linked worktree, leaving the main checkout at a clean baseline.

## Key Changes
- **Setting**: Added `worktree.cleanSource` to `settings-schema.ts` (under `Isolation`) and `HOST_DEFAULTED_SETTING_PATHS` in `main.ts`.
- **Pre-Copy Flush**: Centralized `await settings.flush()` at the entry of `createSessionWorktree()` so pending in-memory project configurations are persisted to disk before the worktree snapshot is taken, preventing unwritten settings from being wiped.
- **Cleanup Helper**: Added `cleanSourceCheckoutIfConfigured(sourceCwd, settings)` in `session-worktree.ts`. Runs `git reset --hard HEAD` and `git clean` (retaining ignored files like `.env` and build caches). Non-fatal failures are reported as warnings without aborting worktree relocation or confirmation output.
- **Confirmation Summary**: Updated `formatSessionWorktreeSummary(worktree, sourceCleaned)` to report `"uncommitted changes moved, source checkout cleaned"` when cleanup succeeds.
- **Tests**: Added contract tests in `packages/coding-agent/test/acp-builtins.test.ts` covering the enabled cleanup path and asserting that flush failures abort before branch or worktree directory allocation.