### PR TITLE
feat(utils): add project dotenv opt-out

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -33,7 +33,11 @@ Set `PI_IGNORE_PROJECT_ENV=1` in the launcher environment or an OMP-owned dotenv
 PI_IGNORE_PROJECT_ENV=1
 ```
 
-An exact `1` in the launcher, agent, config-root, or home source enables the opt-out; all other values have no effect, so a project value cannot negate an OMP-owned opt-out. Launcher variables remain available, and agent/config-root/home dotenv files retain their normal precedence. With the opt-out active, shipped compiled binaries skip the project `.env` parse entirely, while source and npm launches also remove `.env.local` and mode-specific values that Bun may have loaded before OMP code starts. In those Bun-autoloaded modes, a project-local `PI_IGNORE_PROJECT_ENV=1` may cause that same project source to discard itself, but it cannot re-enable project loading; configure the flag in the launcher or an OMP-owned file for consistent behavior. Bun's `--no-env-file` flag alone disables only Bun's loader; OMP still loads the project `.env` unless `PI_IGNORE_PROJECT_ENV=1` is also set.
+An exact `1` in the launcher, agent, config-root, or home source enables the opt-out; all other values have no effect, so a project value cannot negate an OMP-owned opt-out. Launcher variables remain available, and agent/config-root/home dotenv files retain their normal precedence.
+
+Shipped compiled binaries skip the project `.env` parse entirely. Linux source/npm launches use `/proc/self/environ` to remove Bun-preloaded `.env`, `.env.local`, and mode-specific values without deleting same-valued launcher variables. On platforms without an authoritative launch-environment snapshot, source/npm launches must also disable Bun's preload with `--no-env-file`; OMP exits with an actionable error rather than guessing variable provenance. `BUN_OPTIONS=--no-env-file` supplies that flag to an installed npm launcher.
+
+Bun's `--no-env-file` flag alone disables only Bun's loader; OMP still loads the project `.env` unless `PI_IGNORE_PROJECT_ENV=1` is also set.
 
 ---
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -24,6 +24,17 @@ The agent/root locations respect profiles, `PI_CONFIG_DIR`, and—only for the d
 
 Additional rule inside each `.env` file: every `OMP_*` key is mirrored to its `PI_*` alias, and that mirrored value replaces a same-file `PI_*` value. This mirroring applies to parsed dotenv files, not arbitrary variables inherited from the parent process.
 
+### Disabling project dotenv loading
+
+Set `PI_IGNORE_PROJECT_ENV=1` in the launcher environment or an OMP-owned dotenv file (`~/.omp/agent/.env`, `~/.omp/.env`, or `~/.env`) to exclude the launch directory's `.env` files from OMP:
+
+```dotenv
+# ~/.omp/.env
+PI_IGNORE_PROJECT_ENV=1
+```
+
+An exact `1` in the launcher, agent, config-root, or home source enables the opt-out; all other values have no effect, so a project value cannot negate an OMP-owned opt-out. Launcher variables remain available, and agent/config-root/home dotenv files retain their normal precedence. With the opt-out active, shipped compiled binaries skip the project `.env` parse entirely, while source and npm launches also remove `.env.local` and mode-specific values that Bun may have loaded before OMP code starts. In those Bun-autoloaded modes, a project-local `PI_IGNORE_PROJECT_ENV=1` may cause that same project source to discard itself, but it cannot re-enable project loading; configure the flag in the launcher or an OMP-owned file for consistent behavior. Bun's `--no-env-file` flag alone disables only Bun's loader; OMP still loads the project `.env` unless `PI_IGNORE_PROJECT_ENV=1` is also set.
+
 ---
 
 ## 1) Model/provider authentication

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Added
 
+- Added `PI_IGNORE_PROJECT_ENV=1` to prevent launch-directory dotenv files from supplying OMP provider credentials and runtime configuration ([#4599](https://github.com/can1357/oh-my-pi/issues/4599)).
 - Added agent reactions: a reply that opens with a lone emoji line shows the emoji as a badge on your message bubble instead of in the text; toggle the prompt invitation with the tui.reactions setting.
 - Added video attachment and reading support through ffmpeg, including preview grids with metadata and timestamp/frame selectors such as :412 and :1h5m42s.
 - Enhanced the model picker with intelligence indicators, catalog TPS estimates, provider-aware ranking, and provider-supplied badges and descriptions.

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `PI_IGNORE_PROJECT_ENV=1` to exclude launch-directory dotenv files while retaining launcher and OMP-level environment sources ([#4599](https://github.com/can1357/oh-my-pi/issues/4599)).
+
 ## [18.1.6] - 2026-09-03
 
 ### Added

--- a/packages/utils/src/env.ts
+++ b/packages/utils/src/env.ts
@@ -236,17 +236,46 @@ export function parseEnvFile(filePath: string): Record<string, string> {
 	return result;
 }
 
-// Eagerly parse the user's $HOME/.env and the current project's .env (from cwd)
+const IGNORE_PROJECT_ENV_VAR = "PI_IGNORE_PROJECT_ENV";
+
+function shouldIgnoreProjectEnv(
+	agentEnv: Record<string, string>,
+	configEnv: Record<string, string>,
+	homeEnv: Record<string, string>,
+): boolean {
+	// Bun.env is required for launcher-provided flags where no authoritative
+	// pre-dotenv snapshot is available. In source/npm launches it may already
+	// include project dotenv values, but a project-provided "1" can only exclude
+	// that same source; no project value can negate an OMP-owned opt-out.
+	return [Bun.env, agentEnv, configEnv, homeEnv].some(source => source[IGNORE_PROJECT_ENV_VAR] === "1");
+}
+
+// Parse OMP-owned dotenv sources first: the project source is conditional on
+// an early-boot flag that cannot wait for Settings initialization.
 const homeEnv = parseEnvFile(path.join(os.homedir(), ".env"));
 const piEnv = parseEnvFile(path.join(getConfigRootDir(), ".env"));
 const agentEnv = parseEnvFile(path.join(getAgentDir(), ".env"));
-const projectEnv = parseEnvFile(path.join(getProjectDir(), ".env"));
+const projectDir = getProjectDir();
+const ignoreProjectEnv = shouldIgnoreProjectEnv(agentEnv, piEnv, homeEnv);
+const projectEnv = ignoreProjectEnv ? {} : parseEnvFile(path.join(projectDir, ".env"));
 
 for (const key of Object.keys(Bun.env)) {
 	const value = Bun.env[key];
 	if (!isSafeEnvName(key) || isMacosMallocStackLoggingEnvName(key) || value === undefined || !isSafeEnvValue(value)) {
 		delete Bun.env[key];
 	}
+}
+
+// With the opt-out active, shipped compiled binaries and explicit
+// --no-env-file launches have no pre-JS Bun dotenv values to clean. Source/npm
+// launches need one provenance-aware cleanup pass for values Bun already added.
+const projectEnvMayBePreloaded = !isCompiledBinary() && !process.execArgv.includes("--no-env-file");
+if (ignoreProjectEnv && projectEnvMayBePreloaded) {
+	const filtered = filterChildShellEnv(Bun.env, projectDir);
+	for (const key of Object.keys(Bun.env)) {
+		if (!(key in filtered)) delete Bun.env[key];
+	}
+	for (const [key, value] of Object.entries(filtered)) Bun.env[key] = value;
 }
 
 for (const file of [projectEnv, agentEnv, piEnv, homeEnv]) {

--- a/packages/utils/src/env.ts
+++ b/packages/utils/src/env.ts
@@ -269,8 +269,15 @@ for (const key of Object.keys(Bun.env)) {
 // With the opt-out active, shipped compiled binaries and explicit
 // --no-env-file launches have no pre-JS Bun dotenv values to clean. Source/npm
 // launches need one provenance-aware cleanup pass for values Bun already added.
-const projectEnvMayBePreloaded = !isCompiledBinary() && !process.execArgv.includes("--no-env-file");
+// Use the module URL rather than isCompiledBinary(): PI_COMPILED is intentionally
+// accepted by that public helper but is untrusted at this project-env boundary.
+const projectEnvMayBePreloaded = !hasCompiledModuleUrl() && !process.execArgv.includes("--no-env-file");
 if (ignoreProjectEnv && projectEnvMayBePreloaded) {
+	if (!launchEnvValues) {
+		throw new Error(
+			"PI_IGNORE_PROJECT_ENV=1 requires Bun's --no-env-file when running OMP from source or npm without an authoritative launch-environment snapshot; shipped compiled binaries support the opt-out directly.",
+		);
+	}
 	const filtered = filterChildShellEnv(Bun.env, projectDir);
 	for (const key of Object.keys(Bun.env)) {
 		if (!(key in filtered)) delete Bun.env[key];
@@ -436,6 +443,11 @@ export function getDbBusyTimeoutMs(): number {
 	return isInteractiveHost() ? 5000 : 1000;
 }
 
+function hasCompiledModuleUrl(): boolean {
+	const url = import.meta.url;
+	return url.includes("$bunfs") || url.includes("~BUN") || url.includes("%7EBUN");
+}
+
 /**
  * True when this code is running inside a `bun build --compile` standalone
  * binary. Detects via the embedded virtual-filesystem path markers
@@ -446,8 +458,7 @@ export function getDbBusyTimeoutMs(): number {
  */
 export function isCompiledBinary(): boolean {
 	if (process.env.PI_COMPILED || Bun.env.PI_COMPILED) return true;
-	const url = import.meta.url;
-	return url.includes("$bunfs") || url.includes("~BUN") || url.includes("%7EBUN");
+	return hasCompiledModuleUrl();
 }
 
 const TRUTHY: Dict<boolean> = {

--- a/packages/utils/test/env.test.ts
+++ b/packages/utils/test/env.test.ts
@@ -248,11 +248,17 @@ interface ProjectEnvProbe {
 	inherited: string | null;
 }
 
-async function runProjectEnvProbe(options: {
+interface ProjectEnvProcessResult {
+	exitCode: number;
+	stdout: string;
+	stderr: string;
+}
+
+async function spawnProjectEnvProbe(options: {
 	launchFlag?: string;
 	configFlag?: string;
 	bunArgs?: string[];
-}): Promise<ProjectEnvProbe> {
+}): Promise<ProjectEnvProcessResult> {
 	const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-utils-project-env-"));
 	tempDirs.push(root);
 	const projectDir = path.join(root, "project");
@@ -264,7 +270,7 @@ async function runProjectEnvProbe(options: {
 	fs.mkdirSync(configDir, { recursive: true });
 	fs.writeFileSync(
 		path.join(projectDir, ".env"),
-		"PROJECT_ONLY=project\nSHARED_VALUE=project\nINHERITED_VALUE=project\n",
+		"PROJECT_ONLY=project\nSHARED_VALUE=project\nINHERITED_VALUE=same\nPI_COMPILED=1\n",
 	);
 	fs.writeFileSync(path.join(projectDir, ".env.local"), "LOCAL_ONLY=local\n");
 	fs.writeFileSync(path.join(agentDir, ".env"), "SHARED_VALUE=agent\n");
@@ -289,7 +295,7 @@ async function runProjectEnvProbe(options: {
 			OMP_PROFILE: undefined,
 			BUN_ENV: undefined,
 			HOME: homeDir,
-			INHERITED_VALUE: "launcher",
+			INHERITED_VALUE: "same",
 			LOCAL_ONLY: undefined,
 			NODE_ENV: undefined,
 			PI_CODING_AGENT_DIR: agentDir,
@@ -311,8 +317,17 @@ async function runProjectEnvProbe(options: {
 		new Response(proc.stderr).text(),
 		proc.exited,
 	]);
-	expect(exitCode, stderr).toBe(0);
-	return JSON.parse(stdout) as ProjectEnvProbe;
+	return { exitCode, stdout, stderr };
+}
+
+async function runProjectEnvProbe(options: {
+	launchFlag?: string;
+	configFlag?: string;
+	bunArgs?: string[];
+}): Promise<ProjectEnvProbe> {
+	const result = await spawnProjectEnvProbe(options);
+	expect(result.exitCode, result.stderr).toBe(0);
+	return JSON.parse(result.stdout) as ProjectEnvProbe;
 }
 
 describe("PI_IGNORE_PROJECT_ENV", () => {
@@ -320,15 +335,27 @@ describe("PI_IGNORE_PROJECT_ENV", () => {
 		project: null,
 		local: null,
 		shared: "agent",
-		inherited: "launcher",
+		inherited: "same",
 	};
 
-	it("excludes Bun-preloaded project dotenv values when inherited from the launcher", async () => {
-		expect(await runProjectEnvProbe({ launchFlag: "1" })).toEqual(withoutProject);
-	});
+	it.skipIf(process.platform !== "linux")(
+		"ignores a project PI_COMPILED spoof and preserves a same-valued launcher variable",
+		async () => {
+			expect(await runProjectEnvProbe({ launchFlag: "1" })).toEqual(withoutProject);
+		},
+	);
+
+	it.skipIf(process.platform === "linux")(
+		"rejects ambiguous source cleanup without an authoritative launch snapshot",
+		async () => {
+			const result = await spawnProjectEnvProbe({ launchFlag: "1" });
+			expect(result.exitCode).not.toBe(0);
+			expect(result.stderr).toContain("requires Bun's --no-env-file");
+		},
+	);
 
 	it("can be enabled from the OMP config-root dotenv file", async () => {
-		expect(await runProjectEnvProbe({ configFlag: "1" })).toEqual(withoutProject);
+		expect(await runProjectEnvProbe({ configFlag: "1", bunArgs: ["--no-env-file"] })).toEqual(withoutProject);
 	});
 
 	it("skips the manual project merge when Bun autoloading is disabled", async () => {
@@ -381,7 +408,7 @@ describe("PI_IGNORE_PROJECT_ENV", () => {
 			project: "project",
 			local: null,
 			shared: "project",
-			inherited: "launcher",
+			inherited: "same",
 		});
 	});
 
@@ -390,7 +417,7 @@ describe("PI_IGNORE_PROJECT_ENV", () => {
 			project: "project",
 			local: "local",
 			shared: "project",
-			inherited: "launcher",
+			inherited: "same",
 		});
 	});
 });

--- a/packages/utils/test/env.test.ts
+++ b/packages/utils/test/env.test.ts
@@ -241,6 +241,160 @@ describe("filterChildShellEnv", () => {
 	});
 });
 
+interface ProjectEnvProbe {
+	project: string | null;
+	local: string | null;
+	shared: string | null;
+	inherited: string | null;
+}
+
+async function runProjectEnvProbe(options: {
+	launchFlag?: string;
+	configFlag?: string;
+	bunArgs?: string[];
+}): Promise<ProjectEnvProbe> {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-utils-project-env-"));
+	tempDirs.push(root);
+	const projectDir = path.join(root, "project");
+	const agentDir = path.join(root, "agent");
+	const homeDir = path.join(root, "home");
+	const configDir = path.join(homeDir, ".omp");
+	fs.mkdirSync(projectDir);
+	fs.mkdirSync(agentDir);
+	fs.mkdirSync(configDir, { recursive: true });
+	fs.writeFileSync(
+		path.join(projectDir, ".env"),
+		"PROJECT_ONLY=project\nSHARED_VALUE=project\nINHERITED_VALUE=project\n",
+	);
+	fs.writeFileSync(path.join(projectDir, ".env.local"), "LOCAL_ONLY=local\n");
+	fs.writeFileSync(path.join(agentDir, ".env"), "SHARED_VALUE=agent\n");
+	if (options.configFlag) {
+		fs.writeFileSync(path.join(configDir, ".env"), `PI_IGNORE_PROJECT_ENV=${options.configFlag}\n`);
+	}
+
+	const envModulePath = path.join(import.meta.dir, "..", "src", "env.ts");
+	const script = [
+		`import { $env } from ${JSON.stringify(envModulePath)};`,
+		"process.stdout.write(JSON.stringify({",
+		"  project: $env.PROJECT_ONLY ?? null,",
+		"  local: $env.LOCAL_ONLY ?? null,",
+		"  shared: $env.SHARED_VALUE ?? null,",
+		"  inherited: $env.INHERITED_VALUE ?? null,",
+		"}));",
+	].join("\n");
+	const proc = Bun.spawn([process.execPath, ...(options.bunArgs ?? []), "--no-install", "--eval", script], {
+		cwd: projectDir,
+		env: {
+			...process.env,
+			OMP_PROFILE: undefined,
+			BUN_ENV: undefined,
+			HOME: homeDir,
+			INHERITED_VALUE: "launcher",
+			LOCAL_ONLY: undefined,
+			NODE_ENV: undefined,
+			PI_CODING_AGENT_DIR: agentDir,
+			PI_COMPILED: undefined,
+			PI_PROFILE: undefined,
+			XDG_CACHE_HOME: undefined,
+			XDG_CONFIG_HOME: undefined,
+			XDG_DATA_HOME: undefined,
+			XDG_STATE_HOME: undefined,
+			PI_IGNORE_PROJECT_ENV: options.launchFlag,
+			PROJECT_ONLY: undefined,
+			SHARED_VALUE: undefined,
+		},
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	const [stdout, stderr, exitCode] = await Promise.all([
+		new Response(proc.stdout).text(),
+		new Response(proc.stderr).text(),
+		proc.exited,
+	]);
+	expect(exitCode, stderr).toBe(0);
+	return JSON.parse(stdout) as ProjectEnvProbe;
+}
+
+describe("PI_IGNORE_PROJECT_ENV", () => {
+	const withoutProject = {
+		project: null,
+		local: null,
+		shared: "agent",
+		inherited: "launcher",
+	};
+
+	it("excludes Bun-preloaded project dotenv values when inherited from the launcher", async () => {
+		expect(await runProjectEnvProbe({ launchFlag: "1" })).toEqual(withoutProject);
+	});
+
+	it("can be enabled from the OMP config-root dotenv file", async () => {
+		expect(await runProjectEnvProbe({ configFlag: "1" })).toEqual(withoutProject);
+	});
+
+	it("skips the manual project merge when Bun autoloading is disabled", async () => {
+		expect(await runProjectEnvProbe({ launchFlag: "1", bunArgs: ["--no-env-file"] })).toEqual(withoutProject);
+	});
+
+	it.skipIf(process.platform === "win32" || !Bun.which("mkfifo"))(
+		"does not open the project dotenv when Bun autoloading is disabled",
+		async () => {
+			const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-utils-project-env-fifo-"));
+			tempDirs.push(root);
+			const projectDir = path.join(root, "project");
+			const agentDir = path.join(root, "agent");
+			const homeDir = path.join(root, "home");
+			fs.mkdirSync(projectDir);
+			fs.mkdirSync(agentDir);
+			fs.mkdirSync(homeDir);
+			const envPath = path.join(projectDir, ".env");
+			const mkfifo = Bun.spawnSync([Bun.which("mkfifo")!, envPath], { stdout: "pipe", stderr: "pipe" });
+			expect(mkfifo.exitCode, Buffer.from(mkfifo.stderr).toString()).toBe(0);
+
+			const envModulePath = path.join(import.meta.dir, "..", "src", "env.ts");
+			const proc = Bun.spawn(
+				[process.execPath, "--no-env-file", "--no-install", "--eval", `import ${JSON.stringify(envModulePath)};`],
+				{
+					cwd: projectDir,
+					env: {
+						...process.env,
+						HOME: homeDir,
+						PI_CODING_AGENT_DIR: agentDir,
+						PI_IGNORE_PROJECT_ENV: "1",
+					},
+					signal: AbortSignal.timeout(2000),
+					stdout: "pipe",
+					stderr: "pipe",
+				},
+			);
+			const [stdout, stderr, exitCode] = await Promise.all([
+				new Response(proc.stdout).text(),
+				new Response(proc.stderr).text(),
+				proc.exited,
+			]);
+			expect({ exitCode, stderr, stdout }).toEqual({ exitCode: 0, stderr: "", stdout: "" });
+		},
+		5000,
+	);
+
+	it("keeps OMP project loading enabled when only Bun autoloading is disabled", async () => {
+		expect(await runProjectEnvProbe({ bunArgs: ["--no-env-file"] })).toEqual({
+			project: "project",
+			local: null,
+			shared: "project",
+			inherited: "launcher",
+		});
+	});
+
+	it("keeps project dotenv loading enabled by default", async () => {
+		expect(await runProjectEnvProbe({})).toEqual({
+			project: "project",
+			local: "local",
+			shared: "project",
+			inherited: "launcher",
+		});
+	});
+});
+
 describe("isBunTestRuntime", () => {
 	it("does not treat shared application env names as a test runner signal", async () => {
 		expect(await runRuntimeProbe({ NODE_ENV: "test", BUN_ENV: undefined, PI_TEST_RUNTIME: undefined })).toBe(false);


### PR DESCRIPTION
## What

- Add `PI_IGNORE_PROJECT_ENV=1` as an early-bootstrap opt-out for launch-directory dotenv files.
- Resolve the flag monotonically from the launcher or OMP-owned dotenv files (`~/.omp/agent/.env`, `~/.omp/.env`, `~/.env`): any exact `1` enables the opt-out, and other values cannot negate it.
- Preserve launcher variables and normal agent/config-root/home dotenv precedence.
- With `PI_IGNORE_PROJECT_ENV=1`, compiled binaries skip OMP's project `.env` parse, Linux source/npm launches remove Bun-preloaded values using an authoritative `/proc` snapshot, and source/npm launches without such a snapshot require Bun's `--no-env-file`. The Bun flag alone does not disable OMP's loader.

## Why

Project dotenv files commonly contain credentials for the project itself rather than for OMP. OMP currently treats those values as its own runtime configuration: a project `XAI_API_KEY` enables xAI models without an OMP login, while a project `GITHUB_TOKEN` overrides the GitHub CLI account selected by an inherited `GH_CONFIG_DIR`, causing private `pr://` reads to fail under the wrong account.

This is an early-boot decision, so an environment flag is available at the point where a normal Settings value is not. Existing behavior remains unchanged unless the flag is exactly `1`. Fixes #4599.

### My Own Words

In my opinion, OMP should not be reading `.env` files as it just causes issues and has no benefits, at least for me. I've opted to keep the default behaviour as-is since I know others might be relying on this behaviour. I'm also aware of #4598, and I was originally planning to ask the author to re-open it, but I opted against it when I realized it had a few issues:
- The test is vacuous
- The code was not correct

This version is correct for both compiled and non-compiled versions, and keeps behaviour unchanged unless `PI_IGNORE_PROJECT_ENV=1` is set in either the launcher environment or OMP-owned dotenv files.

## Testing

- The new subprocess regression cases failed before the implementation: all three opt-out cases retained project `.env` values, while the unchanged-default control passed.
- `bun test packages/utils/test/env.test.ts` — 25 passed, 1 platform-specific test skipped on Linux, 0 failed.
- `bun test packages/coding-agent/test/non-interactive-env.test.ts` — 12 passed, 0 failed.
- `bun --cwd=packages/utils run check` — passed.
- Built the compiled OMP 18.1.6 binary with `bun run build`.
- Compiled-binary no-read checks used a FIFO as the project `.env`; OMP returned immediately without opening it when the flag came from either the launcher or `~/.omp/.env`.
- Launched the compiled binary from a private repository containing `XAI_API_KEY` and `GITHUB_TOKEN` in `.env` with `PI_IGNORE_PROJECT_ENV=1`:
  - `omp models xai --json` returned `{"models":[]}`.
  - The inherited `GH_CONFIG_DIR` remained effective and a fully qualified private `pr://...?limit=1` listing succeeded.
- Default and Bun-only behavior remain covered: without either flag, project `.env` and `.env.local` values load with project precedence; with only `--no-env-file`, OMP still loads `.env` while Bun-specific `.env.local` loading stays disabled.
- Blocker regressions cover a project-controlled `PI_COMPILED=1`, preservation of a launcher variable whose value exactly matches the project dotenv, and fail-closed behavior on source/npm platforms without an authoritative launch snapshot.
- Manually compared the compiled binary with and without `PI_IGNORE_PROJECT_ENV=1` from a black-box repository:
  - Without the flag, project credentials remained available as expected.
  - With the flag, xAI models were unavailable, private `pr://` access used the inherited GitHub CLI account, and the interactive TUI behaved normally.
- Repeated the provider and private-PR checks through the non-compiled `src/cli.ts` entrypoint, both with and without the opt-out; both modes behaved as expected.
- Tested source mode with Bun's `--no-env-file` flag:
  - `PI_IGNORE_PROJECT_ENV=1` plus `--no-env-file` excluded the project `.env`.
  - `--no-env-file` alone still allowed OMP's manual project `.env` loader, confirming the two controls are independent.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
