### PR TITLE
feat: show live subagent metrics

### DIFF
--- a/packages/coding-agent/src/modes/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/components/tool-execution.ts
@@ -203,12 +203,18 @@ export function sharedSpinnerFrame(frameCount: number, now: number = performance
 	return frameCount > 0 ? Math.floor(now / SPINNER_GLYPH_ADVANCE_MS) % frameCount : 0;
 }
 
-/** Live tool blocks currently driving a spinner. A single shared ticker (below)
- * advances and repaints every registered block per glyph step, so N concurrent
- * live/streaming blocks — e.g. parallel `task` subagents — cost one 80ms timer
- * and one coalesced render frame per tick instead of N unsynchronized timers
- * each independently waking the render scheduler (issue #8731). */
-const liveSpinnerBlocks = new Set<ToolExecutionComponent>();
+/** Anything the shared ticker repaints per glyph step. */
+export interface SpinnerTickTarget {
+	tickSpinner(frame: number): void;
+}
+
+/** Live blocks currently driving a spinner. A single shared ticker (below)
+ * advances and repaints every registered target per glyph step, so N concurrent
+ * live/streaming blocks — e.g. parallel `task` subagents, or the subagent HUD
+ * above the editor — cost one 80ms timer and one coalesced render frame per
+ * tick instead of N unsynchronized timers each independently waking the render
+ * scheduler (issue #8731). */
+const liveSpinnerBlocks = new Set<SpinnerTickTarget>();
 let sharedSpinnerTimer: NodeJS.Timeout | undefined;
 
 /** Arm the shared spinner ticker if it is not already running. */
@@ -216,19 +222,19 @@ function ensureSharedSpinnerTicker(): void {
 	if (sharedSpinnerTimer) return;
 	sharedSpinnerTimer = setInterval(() => {
 		const frame = sharedSpinnerFrame(theme.spinnerFrames.length);
-		// Removing the current block mid-iteration is safe on a Set.
+		// Removing the current target mid-iteration is safe on a Set.
 		for (const block of liveSpinnerBlocks) block.tickSpinner(frame);
 	}, SPINNER_RENDER_INTERVAL_MS);
 }
 
-/** Register a live block with the shared ticker, starting it on first use. */
-function registerSpinnerBlock(block: ToolExecutionComponent): void {
+/** Register a live target with the shared ticker, starting it on first use. */
+export function registerSpinnerBlock(block: SpinnerTickTarget): void {
 	liveSpinnerBlocks.add(block);
 	ensureSharedSpinnerTicker();
 }
 
-/** Drop a block; stop the ticker once no live block remains. */
-function unregisterSpinnerBlock(block: ToolExecutionComponent): void {
+/** Drop a target; stop the ticker once no live target remains. */
+export function unregisterSpinnerBlock(block: SpinnerTickTarget): void {
 	if (!liveSpinnerBlocks.delete(block)) return;
 	if (liveSpinnerBlocks.size === 0 && sharedSpinnerTimer) {
 		clearInterval(sharedSpinnerTimer);

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -126,6 +126,8 @@ import {
 	agentStatParts,
 	agentTypeBadge,
 	estimateAgentEtaMs,
+	formatAgentActivity,
+	formatAgentProgressBar,
 	formatEta,
 	formatTaskId,
 	shortModelLabel,
@@ -138,6 +140,7 @@ import { normalizeLocalScheme, resolveToCwd } from "../tools/path-utils";
 import {
 	formatDuration as formatElapsedDuration,
 	formatMoreItems,
+	formatStatusIcon,
 	replaceTabs,
 	shortenPath,
 	TRUNCATE_LENGTHS,
@@ -192,7 +195,13 @@ import { type PlanReviewAnnotationState, PlanReviewOverlay } from "./components/
 import { PlanSaveOverlay, type PlanSaveOverlayResult } from "./components/plan-save-overlay";
 import { SessionInfoOverlay } from "./components/session-info-overlay";
 import { StatusLineComponent } from "./components/status-line";
-import { stopSharedSpinnerTicker, type ToolExecutionHandle } from "./components/tool-execution";
+import {
+	registerSpinnerBlock,
+	type SpinnerTickTarget,
+	stopSharedSpinnerTicker,
+	type ToolExecutionHandle,
+	unregisterSpinnerBlock,
+} from "./components/tool-execution";
 import { TranscriptContainer } from "./components/transcript-container";
 import type { LspServerInfo as WelcomeLspServerInfo } from "./components/welcome";
 import { Composer, type ComposerStatusSnapshot } from "./composer";
@@ -513,10 +522,14 @@ const SUBAGENT_OBSERVER_UI_COALESCE_MS = 100;
  * Build the anchored subagent HUD block: a bold accent "Subagents" header plus
  * a bounded set of running-agent rows in the same `Id ⟨role⟩: description` shape
  * the inline task rows use (muted task preview when no description was given),
- * each followed by one dim stats line: resolved model, requests, prompt/output
- * volume, cache hit rate, output rate, context gauge, cost, elapsed, and a
- * peer-derived ETA (median runtime of finished agents of the same type this
- * session). Stats appear as soon as the first assistant turn settles.
+ * each followed by one dim line: a progress bar (elapsed over the peer-derived
+ * total — median runtime of finished agents of the same type this session — or
+ * an indeterminate sweep while no peer has finished), elapsed and eta, what the
+ * agent is doing right now (`tool: intent`), then resolved model, requests,
+ * prompt/output volume, cache hit rate, output rate, context gauge, and cost.
+ * Stats appear as soon as the first assistant turn settles. With
+ * `spinnerFrame` the row leads with the shared spinner glyph and the sweep
+ * advances on `nowMs`; without it (no ticker) the row is static.
  * Layout mirrors the Todos HUD exactly: unindented header, then
  * `renderTreeList` rows (dim connectors) shifted right by one space.
  * Only detached background spawns are listed: a sync task call blocks the
@@ -528,6 +541,7 @@ export function renderSubagentHudLines(
 	sessions: ObservableSession[],
 	columns: number,
 	nowMs: number = Date.now(),
+	spinnerFrame?: number,
 ): string[] {
 	const running = sessions.filter(
 		session => session.kind === "subagent" && session.status === "active" && session.detached === true,
@@ -539,7 +553,10 @@ export function renderSubagentHudLines(
 		if (session.kind === "subagent" && session.progress) peers.push(session.progress);
 	}
 
-	const dot = theme.styledSymbol("status.done", "accent");
+	const marker =
+		spinnerFrame === undefined
+			? theme.styledSymbol("status.done", "accent")
+			: theme.fg("accent", formatStatusIcon("running", theme, spinnerFrame));
 	const visible = running.slice(0, SUBAGENT_HUD_VISIBLE_LIMIT);
 	const hiddenCount = running.length - visible.length;
 	const rows = renderTreeList(
@@ -550,7 +567,7 @@ export function renderSubagentHudLines(
 				const displayId = formatTaskId(session.id);
 				const role = session.agent ?? session.progress?.agent;
 				const badge = agentTypeBadge(role, theme);
-				let line = `${dot} ${theme.fg("accent", theme.bold(displayId))}${badge}`;
+				let line = `${marker} ${theme.fg("accent", theme.bold(displayId))}${badge}`;
 				const description = session.description?.trim() || session.progress?.description?.trim();
 				const distinctDescription =
 					description && !labelEchoesHandle(session.id, description) ? description : undefined;
@@ -572,19 +589,32 @@ export function renderSubagentHudLines(
 				}
 				const progress = session.progress;
 				if (!progress) return line;
-				const stats: string[] = [];
+				const elapsedMs = agentElapsedMs(progress, nowMs);
+				const etaMs = estimateAgentEtaMs(progress, peers, elapsedMs);
+				// Liveness first, so a narrow viewport truncates the accounting, not
+				// the motion: bar, elapsed/eta, current tool, then usage.
+				const stats: string[] = [
+					formatAgentProgressBar(
+						{ elapsedMs, etaMs, nowMs: spinnerFrame === undefined ? undefined : nowMs },
+						theme,
+					),
+				];
+				if (elapsedMs > 0) stats.push(theme.fg("dim", formatElapsedDuration(elapsedMs)));
+				const eta = formatEta(etaMs);
+				if (eta) stats.push(theme.fg(etaMs !== undefined && etaMs < 0 ? "warning" : "dim", eta));
+				const activity = formatAgentActivity(progress, theme, nowMs);
+				if (activity) stats.push(activity);
 				if (progress.resolvedModel) {
 					stats.push(theme.fg("dim", truncateToWidth(replaceTabs(shortModelLabel(progress.resolvedModel)), 32)));
 				}
 				// Tool count and model badge are covered by the row above / the model
-				// fragment; elapsed sits between the usage fragments and the eta.
-				stats.push(...agentStatParts({ ...progress, toolCount: undefined, resolvedModel: undefined }, theme));
-				const elapsedMs = agentElapsedMs(progress, nowMs);
-				if (elapsedMs > 0) stats.push(theme.fg("dim", formatElapsedDuration(elapsedMs)));
-				const etaMs = estimateAgentEtaMs(progress, peers, elapsedMs);
-				const eta = formatEta(etaMs);
-				if (eta) stats.push(theme.fg(etaMs !== undefined && etaMs < 0 ? "warning" : "dim", eta));
-				if (stats.length === 0) return line;
+				// fragment; eta already sits beside the bar.
+				stats.push(
+					...agentStatParts(
+						{ ...progress, toolCount: undefined, resolvedModel: undefined, etaMs: undefined },
+						theme,
+					),
+				);
 				const statsLine = ` ${theme.fg("dim", theme.tree.hook)} ${stats.join(theme.fg("dim", theme.sep.dot))}`;
 				return [line, truncateToWidth(statsLine, Math.max(TRUNCATE_LENGTHS.SHORT, columns - 4))];
 			},
@@ -598,15 +628,27 @@ export function renderSubagentHudLines(
 }
 
 /**
- * Dynamic HUD component. The TUI already repaints while task/job spinners are
- * live; deriving rows here lets elapsed/eta advance on those frames without
- * owning another timer or leaking lifecycle work.
+ * Live HUD component. Registered with the shared tool spinner ticker while any
+ * detached subagent runs, so the spinner glyph, sweep bar, elapsed, and
+ * current-tool fragment advance every glyph step even though detached spawns
+ * leave no live tool block behind to drive repaints. Ticks are
+ * component-scoped so the transcript subtree is reused per frame.
  */
-class SubagentHudComponent implements Component {
-	constructor(private readonly sessions: () => ObservableSession[]) {}
+class SubagentHudComponent implements Component, SpinnerTickTarget {
+	#frame: number | undefined;
+
+	constructor(
+		private readonly ui: TUI,
+		private readonly sessions: () => ObservableSession[],
+	) {}
+
+	tickSpinner(frame: number): void {
+		this.#frame = frame;
+		this.ui.requestComponentRender(this);
+	}
 
 	render(width: number): readonly string[] {
-		return renderSubagentHudLines(this.sessions(), width);
+		return renderSubagentHudLines(this.sessions(), width, Date.now(), this.#frame);
 	}
 }
 
@@ -889,6 +931,8 @@ export class InteractiveMode implements InteractiveModeContext {
 	#eventBusUnsubscribers: Array<() => void> = [];
 	#observerUiSyncTimer?: NodeJS.Timeout;
 	#observerUiSyncNeedsTodoReconcile = false;
+	/** The one live HUD instance; present exactly while it is registered with the spinner ticker. */
+	#subagentHud?: SubagentHudComponent;
 	#agentRegistryUnsubscribe?: () => void;
 	#agentRegistrySubscriptionTarget?: AgentRegistry;
 	#mcpStatusOrder: string[] = [];
@@ -2849,15 +2893,26 @@ export class InteractiveMode implements InteractiveModeContext {
 
 	/**
 	 * Anchored HUD of in-flight subagents, mirroring the Todos block above the
-	 * editor. Driven entirely by observer-registry change events, so rows appear
-	 * on spawn and the whole block clears itself once the last subagent leaves
-	 * the "active" state.
+	 * editor. Rows appear on observer-registry change events; while any are
+	 * shown the single HUD component stays registered with the shared spinner
+	 * ticker so it repaints per glyph step, and it unregisters (stopping the
+	 * ticker if nothing else is live) once the last subagent leaves "active".
 	 */
 	#renderSubagentList(): void {
-		this.subagentContainer.clear();
 		const sessions = this.#observerRegistry.getSessions();
-		if (renderSubagentHudLines(sessions, this.ui.terminal.columns).length === 0) return;
-		this.subagentContainer.addChild(new SubagentHudComponent(() => this.#observerRegistry.getSessions()));
+		if (renderSubagentHudLines(sessions, this.ui.terminal.columns).length === 0) {
+			if (this.#subagentHud) {
+				unregisterSpinnerBlock(this.#subagentHud);
+				this.#subagentHud = undefined;
+			}
+			this.subagentContainer.clear();
+			return;
+		}
+		if (this.#subagentHud) return;
+		this.#subagentHud = new SubagentHudComponent(this.ui, () => this.#observerRegistry.getSessions());
+		this.subagentContainer.clear();
+		this.subagentContainer.addChild(this.#subagentHud);
+		registerSpinnerBlock(this.#subagentHud);
 	}
 
 	async #loadTodoList(source: AgentSession = this.session): Promise<void> {

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -133,6 +133,7 @@ import {
 	shortModelLabel,
 } from "../task/render";
 import type { AgentProgress } from "../task/types";
+import { getSubagentDurationHistory } from "../task/run-history";
 import type { ConfiguredThinkingLevel } from "../thinking";
 import { tinyTitleClient } from "../tiny/title-client";
 import type { LspStartupServerInfo } from "../tools";
@@ -522,14 +523,14 @@ const SUBAGENT_OBSERVER_UI_COALESCE_MS = 100;
  * Build the anchored subagent HUD block: a bold accent "Subagents" header plus
  * a bounded set of running-agent rows in the same `Id ⟨role⟩: description` shape
  * the inline task rows use (muted task preview when no description was given),
- * each followed by one dim line: a progress bar (elapsed over the peer-derived
- * total — median runtime of finished agents of the same type this session — or
- * an indeterminate sweep while no peer has finished), elapsed and eta, what the
- * agent is doing right now (`tool: intent`), then resolved model, requests,
- * prompt/output volume, cache hit rate, output rate, context gauge, and cost.
- * Stats appear as soon as the first assistant turn settles. With
- * `spinnerFrame` the row leads with the shared spinner glyph and the sweep
- * advances on `nowMs`; without it (no ticker) the row is static.
+ * each followed by one dim line: a progress bar with percentage (elapsed over
+ * the estimated total — median runtime of finished agents of the same type
+ * this session, else the cross-session history for that type; empty until any
+ * such run exists), elapsed and eta, what the agent is doing right now
+ * (`tool: intent`), then resolved model, requests, prompt/output volume, cache
+ * hit rate, output rate, context gauge, and cost. Stats appear as soon as the
+ * first assistant turn settles. With `spinnerFrame` the row leads with the
+ * shared spinner glyph; without it (no ticker) the row is static.
  * Layout mirrors the Todos HUD exactly: unindented header, then
  * `renderTreeList` rows (dim connectors) shifted right by one space.
  * Only detached background spawns are listed: a sync task call blocks the
@@ -590,15 +591,10 @@ export function renderSubagentHudLines(
 				const progress = session.progress;
 				if (!progress) return line;
 				const elapsedMs = agentElapsedMs(progress, nowMs);
-				const etaMs = estimateAgentEtaMs(progress, peers, elapsedMs);
+				const etaMs = estimateAgentEtaMs(progress, peers, elapsedMs, getSubagentDurationHistory(progress.agent));
 				// Liveness first, so a narrow viewport truncates the accounting, not
 				// the motion: bar, elapsed/eta, current tool, then usage.
-				const stats: string[] = [
-					formatAgentProgressBar(
-						{ elapsedMs, etaMs, nowMs: spinnerFrame === undefined ? undefined : nowMs },
-						theme,
-					),
-				];
+				const stats: string[] = [formatAgentProgressBar({ elapsedMs, etaMs }, theme)];
 				if (elapsedMs > 0) stats.push(theme.fg("dim", formatElapsedDuration(elapsedMs)));
 				const eta = formatEta(etaMs);
 				if (eta) stats.push(theme.fg(etaMs !== undefined && etaMs < 0 ? "warning" : "dim", eta));
@@ -629,7 +625,7 @@ export function renderSubagentHudLines(
 
 /**
  * Live HUD component. Registered with the shared tool spinner ticker while any
- * detached subagent runs, so the spinner glyph, sweep bar, elapsed, and
+ * detached subagent runs, so the spinner glyph, bar, elapsed, and
  * current-tool fragment advance every glyph step even though detached spawns
  * leave no live tool block behind to drive repaints. Ticks are
  * component-scoped so the transcript subtree is reused per frame.

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -121,12 +121,28 @@ import { STTController, type SttState } from "../stt";
 import { resolveCliEntryCmd } from "../subprocess/worker-client";
 import { discoverTitleSystemPromptFile, resolvePromptInput } from "../system-prompt";
 import { labelEchoesHandle } from "../task/label";
-import { agentTypeBadge, formatTaskId } from "../task/render";
+import {
+	agentElapsedMs,
+	agentStatParts,
+	agentTypeBadge,
+	estimateAgentEtaMs,
+	formatEta,
+	formatTaskId,
+	shortModelLabel,
+} from "../task/render";
+import type { AgentProgress } from "../task/types";
 import type { ConfiguredThinkingLevel } from "../thinking";
 import { tinyTitleClient } from "../tiny/title-client";
 import type { LspStartupServerInfo } from "../tools";
 import { normalizeLocalScheme, resolveToCwd } from "../tools/path-utils";
-import { formatMoreItems, replaceTabs, shortenPath, TRUNCATE_LENGTHS, truncateToWidth } from "../tools/render-utils";
+import {
+	formatDuration as formatElapsedDuration,
+	formatMoreItems,
+	replaceTabs,
+	shortenPath,
+	TRUNCATE_LENGTHS,
+	truncateToWidth,
+} from "../tools/render-utils";
 import { setAutoQaConsentHandler } from "../tools/report-tool-issue";
 import {
 	formatPhaseDisplayName,
@@ -496,7 +512,11 @@ const SUBAGENT_OBSERVER_UI_COALESCE_MS = 100;
 /**
  * Build the anchored subagent HUD block: a bold accent "Subagents" header plus
  * a bounded set of running-agent rows in the same `Id ⟨role⟩: description` shape
- * the inline task rows use (muted task preview when no description was given).
+ * the inline task rows use (muted task preview when no description was given),
+ * each followed by one dim stats line: resolved model, requests, prompt/output
+ * volume, cache hit rate, output rate, context gauge, cost, elapsed, and a
+ * peer-derived ETA (median runtime of finished agents of the same type this
+ * session). Stats appear as soon as the first assistant turn settles.
  * Layout mirrors the Todos HUD exactly: unindented header, then
  * `renderTreeList` rows (dim connectors) shifted right by one space.
  * Only detached background spawns are listed: a sync task call blocks the
@@ -504,11 +524,20 @@ const SUBAGENT_OBSERVER_UI_COALESCE_MS = 100;
  * eval `agent()` spawns are rendered by their own eval cell tree.
  * Returns an empty array when nothing is running so the container can clear.
  */
-export function renderSubagentHudLines(sessions: ObservableSession[], columns: number): string[] {
+export function renderSubagentHudLines(
+	sessions: ObservableSession[],
+	columns: number,
+	nowMs: number = Date.now(),
+): string[] {
 	const running = sessions.filter(
 		session => session.kind === "subagent" && session.status === "active" && session.detached === true,
 	);
 	if (running.length === 0) return [];
+	// Finished peers (any batch this session) are the ETA ground truth.
+	const peers: AgentProgress[] = [];
+	for (const session of sessions) {
+		if (session.kind === "subagent" && session.progress) peers.push(session.progress);
+	}
 
 	const dot = theme.styledSymbol("status.done", "accent");
 	const visible = running.slice(0, SUBAGENT_HUD_VISIBLE_LIMIT);
@@ -541,7 +570,23 @@ export function renderSubagentHudLines(sessions: ObservableSession[], columns: n
 						line += ` ${theme.fg("muted", truncateToWidth(formatted, TRUNCATE_LENGTHS.SHORT))}`;
 					}
 				}
-				return line;
+				const progress = session.progress;
+				if (!progress) return line;
+				const stats: string[] = [];
+				if (progress.resolvedModel) {
+					stats.push(theme.fg("dim", truncateToWidth(replaceTabs(shortModelLabel(progress.resolvedModel)), 32)));
+				}
+				// Tool count and model badge are covered by the row above / the model
+				// fragment; elapsed sits between the usage fragments and the eta.
+				stats.push(...agentStatParts({ ...progress, toolCount: undefined, resolvedModel: undefined }, theme));
+				const elapsedMs = agentElapsedMs(progress, nowMs);
+				if (elapsedMs > 0) stats.push(theme.fg("dim", formatElapsedDuration(elapsedMs)));
+				const etaMs = estimateAgentEtaMs(progress, peers, elapsedMs);
+				const eta = formatEta(etaMs);
+				if (eta) stats.push(theme.fg(etaMs !== undefined && etaMs < 0 ? "warning" : "dim", eta));
+				if (stats.length === 0) return line;
+				const statsLine = ` ${theme.fg("dim", theme.tree.hook)} ${stats.join(theme.fg("dim", theme.sep.dot))}`;
+				return [line, truncateToWidth(statsLine, Math.max(TRUNCATE_LENGTHS.SHORT, columns - 4))];
 			},
 		},
 		theme,
@@ -550,6 +595,19 @@ export function renderSubagentHudLines(sessions: ObservableSession[], columns: n
 		rows.push(theme.fg("dim", `… ${hiddenCount} more running — open Agent Hub for full list`));
 	}
 	return ["", theme.bold(theme.fg("accent", "Subagents")), ...rows.map(line => ` ${line}`)];
+}
+
+/**
+ * Dynamic HUD component. The TUI already repaints while task/job spinners are
+ * live; deriving rows here lets elapsed/eta advance on those frames without
+ * owning another timer or leaking lifecycle work.
+ */
+class SubagentHudComponent implements Component {
+	constructor(private readonly sessions: () => ObservableSession[]) {}
+
+	render(width: number): readonly string[] {
+		return renderSubagentHudLines(this.sessions(), width);
+	}
 }
 
 const CTRL_L_APPEARANCE_RESPONSE_DEADLINE_MS = 2000;
@@ -2797,9 +2855,9 @@ export class InteractiveMode implements InteractiveModeContext {
 	 */
 	#renderSubagentList(): void {
 		this.subagentContainer.clear();
-		const lines = renderSubagentHudLines(this.#observerRegistry.getSessions(), this.ui.terminal.columns);
-		if (lines.length === 0) return;
-		this.subagentContainer.addChild(new Text(lines.join("\n"), 1, 0));
+		const sessions = this.#observerRegistry.getSessions();
+		if (renderSubagentHudLines(sessions, this.ui.terminal.columns).length === 0) return;
+		this.subagentContainer.addChild(new SubagentHudComponent(() => this.#observerRegistry.getSessions()));
 	}
 
 	async #loadTodoList(source: AgentSession = this.session): Promise<void> {

--- a/packages/coding-agent/src/session/agent-storage.ts
+++ b/packages/coding-agent/src/session/agent-storage.ts
@@ -148,6 +148,8 @@ export class AgentStorage {
 	#listModelPerfStmt: Statement;
 	#upsertCommandUsageStmt: Statement;
 	#listCommandUsageStmt: Statement;
+	#insertSubagentRunStmt: Statement;
+	#listSubagentRunsStmt: Statement;
 	#modelUsageCache: string[] | null = null;
 	/** Only the real user db auto-imports stats.db history; custom paths (tests, embedding) opt in explicitly. */
 	#autoPerfBackfill: boolean;
@@ -207,6 +209,12 @@ ON CONFLICT(model_key) DO UPDATE SET
 ON CONFLICT(name) DO UPDATE SET count = command_usage.count + 1, last_used_at = ${SQLITE_NOW_EPOCH}`,
 		);
 		this.#listCommandUsageStmt = this.#db.prepare("SELECT name, count FROM command_usage");
+		this.#insertSubagentRunStmt = this.#db.prepare(
+			"INSERT INTO subagent_runs (agent, duration_ms, requests) VALUES (?, ?, ?)",
+		);
+		this.#listSubagentRunsStmt = this.#db.prepare(
+			"SELECT agent, duration_ms FROM subagent_runs ORDER BY id DESC LIMIT ?",
+		);
 	}
 
 	/**
@@ -245,6 +253,15 @@ CREATE TABLE IF NOT EXISTS command_usage (
 	count INTEGER NOT NULL DEFAULT 0,
 	last_used_at INTEGER NOT NULL DEFAULT (${SQLITE_NOW_EPOCH})
 );
+
+CREATE TABLE IF NOT EXISTS subagent_runs (
+	id INTEGER PRIMARY KEY AUTOINCREMENT,
+	agent TEXT NOT NULL,
+	duration_ms INTEGER NOT NULL,
+	requests INTEGER NOT NULL DEFAULT 0,
+	finished_at INTEGER NOT NULL DEFAULT (${SQLITE_NOW_EPOCH})
+);
+CREATE INDEX IF NOT EXISTS subagent_runs_agent_id ON subagent_runs (agent, id);
 
 CREATE TABLE IF NOT EXISTS meta (
 	key TEXT PRIMARY KEY,
@@ -440,6 +457,8 @@ FROM model_usage_legacy
 		this.#listModelPerfStmt.finalize();
 		this.#upsertCommandUsageStmt.finalize();
 		this.#listCommandUsageStmt.finalize();
+		this.#insertSubagentRunStmt.finalize();
+		this.#listSubagentRunsStmt.finalize();
 		// SqliteAuthCredentialStore.close() finalizes its own statements and
 		// closes the shared #db handle — must run after our statements finalize.
 		this.#authStore.close();
@@ -524,6 +543,32 @@ FROM model_usage_legacy
 			return counts;
 		} catch (error) {
 			logger.warn("AgentStorage failed to list command usage", { error: String(error) });
+			return {};
+		}
+	}
+
+	/** Record one finished subagent run so later sessions can estimate runtime for that agent type. */
+	recordSubagentRun(agent: string, durationMs: number, requests: number): void {
+		try {
+			this.#insertSubagentRunStmt.run(agent, Math.max(0, Math.round(durationMs)), Math.max(0, requests));
+		} catch (error) {
+			logger.warn("AgentStorage failed to record subagent run", { agent, error: String(error) });
+		}
+	}
+
+	/**
+	 * Durations of the most recent finished runs, newest first, grouped by agent
+	 * type. Reads the latest `limit` rows overall, so a busy agent type does not
+	 * starve a rare one of samples beyond that window.
+	 */
+	listRecentSubagentRuns(limit = 400): Record<string, number[]> {
+		try {
+			const rows = this.#listSubagentRunsStmt.all(limit) as Array<{ agent: string; duration_ms: number }>;
+			const byAgent: Record<string, number[]> = {};
+			for (const row of rows) (byAgent[row.agent] ??= []).push(row.duration_ms);
+			return byAgent;
+		} catch (error) {
+			logger.warn("AgentStorage failed to list subagent runs", { error: String(error) });
 			return {};
 		}
 	}

--- a/packages/coding-agent/src/session/turn-recovery.ts
+++ b/packages/coding-agent/src/session/turn-recovery.ts
@@ -2005,6 +2005,11 @@ export class TurnRecovery {
 		if (!this.#activeRetryFallback) return false;
 		if (this.#activeRetryFallback.pinned) return false;
 		if (this.#getRetryFallbackRevertPolicy() !== "cooldown-expiry") return false;
+		// A fallback switch is only a routing decision until that model has had a
+		// chance to serve. A slow failed fallback can outlive the primary's
+		// cooldown; restoring here would skip the next selected candidate and
+		// oscillate back to the known-failing primary inside the same retry saga.
+		if (!this.#activeRetryFallback.served) return false;
 
 		const {
 			originalSelector: originalSelectorRaw,

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -71,6 +71,7 @@ import { generateTaskLabel } from "./label";
 import { resolveAgentPrewalkDefault } from "./prewalk";
 import { isReadOnlyAgent } from "./read-only-policy";
 import { formatTaskResultSummary } from "./result-summary";
+import { recordSubagentRun } from "./run-history";
 import { subprocessToolRegistry } from "./subprocess-tool-registry";
 import {
 	type AgentDefinition,
@@ -2327,6 +2328,11 @@ async function finalizeRunResult(args: FinalizeRunArgs): Promise<SingleResult> {
 		: undefined;
 	progress.status = wasAborted ? "aborted" : exitCode === 0 ? "completed" : "failed";
 	monitor.scheduleProgress(true);
+	// Completed runs (not follow-up turns on a revived agent) feed the
+	// cross-session runtime history behind the HUD progress bar.
+	if (progress.status === "completed" && !args.followUpTurn) {
+		recordSubagentRun(agent.name, Date.now() - args.startTime, progress.requests);
+	}
 
 	// Emit lifecycle end event after finalization so yield status is reflected
 	const settledPayload = {

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -1096,6 +1096,7 @@ function createSubagentRunMonitor(args: RunMonitorArgs): SubagentRunMonitor {
 		tokens: 0,
 		cost: 0,
 		durationMs: 0,
+		startedAtMs: startTime,
 		modelOverride: args.modelOverride,
 		modelRole: args.modelRole,
 	};
@@ -1131,6 +1132,13 @@ function createSubagentRunMonitor(args: RunMonitorArgs): SubagentRunMonitor {
 		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 	};
 	let hasUsage = false;
+	/**
+	 * When the in-flight turn's model request was dispatched (`turn_start`);
+	 * feeds `progress.generationMs` at the assistant `message_end`. Measured
+	 * from the request, not `message_start`: non-streaming providers emit
+	 * start and end back-to-back, which would make the window ~0 ms.
+	 */
+	let requestStartMs: number | undefined;
 	let budgetSteerSent = false;
 	let budgetLimitExceeded = false;
 	let budgetStopRequested = false;
@@ -1452,6 +1460,10 @@ function createSubagentRunMonitor(args: RunMonitorArgs): SubagentRunMonitor {
 		let flushProgress = false;
 
 		switch (event.type) {
+			case "turn_start":
+				requestStartMs = now;
+				break;
+
 			case "message_start":
 				if (event.message?.role === "assistant") {
 					resetRecentOutput();
@@ -1707,6 +1719,10 @@ function createSubagentRunMonitor(args: RunMonitorArgs): SubagentRunMonitor {
 							accumulatedUsage.cost.total += getNumberField(costRecord, "total") ?? 0;
 							progress.cost = accumulatedUsage.cost.total;
 						}
+						progress.inputTokens = accumulatedUsage.input;
+						progress.outputTokens = accumulatedUsage.output;
+						progress.cacheReadTokens = accumulatedUsage.cacheRead;
+						progress.cacheWriteTokens = accumulatedUsage.cacheWrite;
 					}
 					// Accumulate tokens for progress display
 					progress.tokens += getUsageTokens(messageUsage);
@@ -1718,6 +1734,10 @@ function createSubagentRunMonitor(args: RunMonitorArgs): SubagentRunMonitor {
 							progress.contextTokens = perTurnTotal;
 						}
 					}
+				}
+				if (role === "assistant" && requestStartMs !== undefined) {
+					progress.generationMs = (progress.generationMs ?? 0) + Math.max(0, now - requestStartMs);
+					requestStartMs = undefined;
 				}
 				break;
 			}
@@ -2341,6 +2361,7 @@ async function finalizeRunResult(args: FinalizeRunArgs): Promise<SingleResult> {
 		requests: progress.requests,
 		contextTokens: progress.contextTokens,
 		contextWindow: progress.contextWindow,
+		generationMs: progress.generationMs,
 		modelOverride,
 		modelRole,
 		resolvedModel: progress.resolvedModel,

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -51,6 +51,7 @@ import { AgentOutputManager } from "./output-manager";
 import { mapWithConcurrencyLimitAllSettled, Semaphore } from "./parallel";
 import { renderResult, renderCall as renderTaskCall } from "./render";
 import { repairTaskParams } from "./repair-args";
+import { loadSubagentRunHistory } from "./run-history";
 import { resolveEffectiveSubagentPolicy, runStructuredSubagent, StructuredSubagentError } from "./structured-subagent";
 
 function renderSubagentUserPrompt(assignment: string): string {
@@ -674,6 +675,9 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		signal?: AbortSignal,
 		onUpdate?: AgentToolUpdateCallback<TaskToolDetails>,
 	): Promise<AgentToolResult<TaskToolDetails>> {
+		// Opens agent.db once per process so finished runs persist and the HUD's
+		// runtime estimate has cross-session samples from the first spawn.
+		void loadSubagentRunHistory();
 		const params = repairTaskParams(rawParams as TaskParams);
 		// Schema defaults fill `agent` for model calls, but internal callers
 		// and stale transcripts can bypass arktype. `spawnParamsFor` resolves each

--- a/packages/coding-agent/src/task/render.ts
+++ b/packages/coding-agent/src/task/render.ts
@@ -85,43 +85,147 @@ function getStatusIcon(status: AgentProgress["status"], theme: Theme, spinnerFra
 	}
 }
 
+/** Stats an agent row can carry; the inline task rows and the subagent HUD share one formatter. */
+export interface AgentStatOptions {
+	toolCount?: number;
+	requests?: number;
+	/** Cumulative usage breakdown; see {@link AgentProgress.inputTokens}. */
+	inputTokens?: number;
+	outputTokens?: number;
+	cacheReadTokens?: number;
+	cacheWriteTokens?: number;
+	generationMs?: number;
+	contextTokens?: number;
+	contextWindow?: number;
+	cost: number;
+	/** Remaining-time estimate; negative = past the estimate by that much. See {@link estimateAgentEtaMs}. */
+	etaMs?: number;
+	resolvedModel?: string;
+	showResolvedModelBadge?: boolean;
+}
+
+/** `42 tok/s` mean output rate over the agent's assistant-message wall time; undefined until measurable. */
+export function formatOutputRate(
+	outputTokens: number | undefined,
+	generationMs: number | undefined,
+): string | undefined {
+	if (!outputTokens || !generationMs || generationMs <= 0) return undefined;
+	const rate = (outputTokens / generationMs) * 1000;
+	return `${rate < 10 ? rate.toFixed(1) : Math.round(rate).toString()} tok/s`;
+}
+
+/** `cache 91%`: share of prompt tokens served from the provider cache; undefined before any prompt tokens. */
+export function formatCacheHitRate(opts: {
+	inputTokens?: number;
+	cacheReadTokens?: number;
+	cacheWriteTokens?: number;
+}): string | undefined {
+	const prompt = (opts.inputTokens ?? 0) + (opts.cacheReadTokens ?? 0) + (opts.cacheWriteTokens ?? 0);
+	if (prompt <= 0) return undefined;
+	return `cache ${Math.round(((opts.cacheReadTokens ?? 0) / prompt) * 100)}%`;
+}
+
 /**
- * Append tool-count, context, and cost stats to a status line string.
+ * `eta ~2m` while under the peer-derived estimate, `1m over` once past it.
+ * Undefined when no estimate exists — never a fabricated countdown.
  */
-function appendAgentStats(
-	line: string,
-	opts: {
-		toolCount?: number;
-		requests?: number;
-		tokens: number;
-		contextTokens?: number;
-		contextWindow?: number;
-		cost: number;
-		resolvedModel?: string;
-		showResolvedModelBadge?: boolean;
-	},
-	theme: Theme,
-): string {
+export function formatEta(etaMs: number | undefined): string | undefined {
+	if (etaMs === undefined || !Number.isFinite(etaMs)) return undefined;
+	if (etaMs >= 0) return `eta ~${formatDuration(Math.max(etaMs, 1000))}`;
+	return `${formatDuration(-etaMs)} over`;
+}
+
+/**
+ * Elapsed ms for a progress row at `nowMs`: live from `startedAtMs` while the
+ * agent is pending/running (the emit-driven `durationMs` stalls when the agent
+ * is quiet), the settled `durationMs` otherwise.
+ */
+export function agentElapsedMs(
+	progress: Pick<AgentProgress, "status" | "durationMs" | "startedAtMs">,
+	nowMs: number,
+): number {
+	if ((progress.status === "running" || progress.status === "pending") && progress.startedAtMs !== undefined) {
+		return Math.max(progress.durationMs, nowMs - progress.startedAtMs);
+	}
+	return progress.durationMs;
+}
+
+/**
+ * Remaining-time estimate for a live agent: median runtime of already-finished
+ * peers of the same agent type minus this agent's elapsed time. The only
+ * ground truth for "how long does a scout take" is other scouts in this
+ * session, so with no finished peer there is no estimate (undefined).
+ * Negative means the agent has outlived the peer median by that much.
+ */
+export function estimateAgentEtaMs(
+	progress: Pick<AgentProgress, "id" | "agent" | "durationMs">,
+	peers: Iterable<Pick<AgentProgress, "id" | "agent" | "status" | "durationMs">>,
+	elapsedMs: number = progress.durationMs,
+): number | undefined {
+	const durations: number[] = [];
+	for (const peer of peers) {
+		if (peer.id === progress.id || peer.agent !== progress.agent) continue;
+		if (peer.status !== "completed" || !(peer.durationMs > 0)) continue;
+		durations.push(peer.durationMs);
+	}
+	if (durations.length === 0) return undefined;
+	durations.sort((a, b) => a - b);
+	const mid = durations.length >> 1;
+	const median = durations.length % 2 === 1 ? durations[mid] : (durations[mid - 1] + durations[mid]) / 2;
+	return median - elapsedMs;
+}
+
+/** `<provider>/<id>[:level]` → `<id>[:level]`; the HUD has no room for the provider. */
+export function shortModelLabel(selector: string): string {
+	const slash = selector.indexOf("/");
+	return slash === -1 ? selector : selector.slice(slash + 1);
+}
+
+/**
+ * Styled stat fragments for an agent row, in display order: tools, requests,
+ * prompt/completion volume, cache hit rate, output rate, context gauge, cost,
+ * eta, model. Each fragment is omitted when its input is absent or zero.
+ */
+export function agentStatParts(opts: AgentStatOptions, theme: Theme): string[] {
+	const parts: string[] = [];
 	if (opts.toolCount) {
-		line += `${theme.sep.dot}${theme.fg("dim", `${formatNumber(opts.toolCount)} ${theme.icon.extensionTool}`)}`;
+		parts.push(theme.fg("dim", `${formatNumber(opts.toolCount)} ${theme.icon.extensionTool}`));
 	}
 	if (opts.requests) {
-		line += `${theme.sep.dot}${theme.fg("dim", `${formatNumber(opts.requests)} req`)}`;
+		parts.push(theme.fg("dim", `${formatNumber(opts.requests)} req`));
 	}
+	// Prompt volume is the full context sent (uncached + cached); the cache
+	// fragment right after says how much of it was a cache hit.
+	const promptTokens = (opts.inputTokens ?? 0) + (opts.cacheReadTokens ?? 0) + (opts.cacheWriteTokens ?? 0);
+	if (promptTokens > 0 || opts.outputTokens) {
+		parts.push(theme.fg("dim", `↑${formatNumber(promptTokens)} ↓${formatNumber(opts.outputTokens ?? 0)}`));
+	}
+	const cache = formatCacheHitRate(opts);
+	if (cache) parts.push(theme.fg("dim", cache));
+	const rate = formatOutputRate(opts.outputTokens, opts.generationMs);
+	if (rate) parts.push(theme.fg("dim", rate));
 	// Current per-turn context — match the status line's `<pct>%/<window>` gauge (e.g. `5.1%/1M`).
 	if (opts.contextTokens && opts.contextTokens > 0) {
 		const ctx =
 			opts.contextWindow && opts.contextWindow > 0
 				? formatContextUsage((opts.contextTokens / opts.contextWindow) * 100, opts.contextWindow)
 				: `${formatNumber(opts.contextTokens)}`;
-		line += `${theme.sep.dot}${theme.fg("dim", ctx)}`;
+		parts.push(theme.fg("dim", ctx));
 	}
 	if (opts.cost > 0) {
-		line += `${theme.sep.dot}${theme.fg("statusLineCost", `$${opts.cost.toFixed(2)}`)}`;
+		parts.push(theme.fg("statusLineCost", `$${opts.cost.toFixed(2)}`));
 	}
+	const eta = formatEta(opts.etaMs);
+	if (eta) parts.push(theme.fg(opts.etaMs !== undefined && opts.etaMs < 0 ? "warning" : "dim", eta));
 	if (opts.resolvedModel && opts.showResolvedModelBadge) {
-		line += `${theme.sep.dot}${theme.fg("dim", truncateToWidth(replaceTabs(opts.resolvedModel), 30))}`;
+		parts.push(theme.fg("dim", truncateToWidth(replaceTabs(opts.resolvedModel), 30)));
 	}
+	return parts;
+}
+
+/** Append {@link agentStatParts} to a status line, dot-separated. */
+function appendAgentStats(line: string, opts: AgentStatOptions, theme: Theme): string {
+	for (const part of agentStatParts(opts, theme)) line += `${theme.sep.dot}${part}`;
 	return line;
 }
 
@@ -896,6 +1000,8 @@ function renderAgentProgress(
 	seenNestedTasks?: WeakSet<object>,
 	nestedDepth = 0,
 	nowMs = Date.now(),
+	/** Sibling rows of the same call; finished peers of the same agent type feed the ETA. */
+	peers?: readonly AgentProgress[],
 ): string[] {
 	const lines: string[] = [];
 
@@ -954,7 +1060,8 @@ function renderAgentProgress(
 			const taskPreview = previewLine(sanitizeText(progress.assignment ?? progress.task), 40);
 			statusLine += ` ${theme.fg("muted", taskPreview)}`;
 		}
-		statusLine = appendAgentStats(statusLine, { ...progress, showResolvedModelBadge: showBadge }, theme);
+		const etaMs = peers ? estimateAgentEtaMs(progress, peers, agentElapsedMs(progress, nowMs)) : undefined;
+		statusLine = appendAgentStats(statusLine, { ...progress, etaMs, showResolvedModelBadge: showBadge }, theme);
 	} else if (progress.status === "completed") {
 		statusLine = appendAgentStats(statusLine, { ...progress, showResolvedModelBadge: showBadge }, theme);
 	}
@@ -1257,8 +1364,12 @@ function renderAgentResult(
 	statusLine = appendAgentStats(
 		statusLine,
 		{
-			tokens: result.tokens,
 			requests: result.requests,
+			inputTokens: result.usage?.input,
+			outputTokens: result.usage?.output,
+			cacheReadTokens: result.usage?.cacheRead,
+			cacheWriteTokens: result.usage?.cacheWrite,
+			generationMs: result.generationMs,
 			contextTokens: result.contextTokens,
 			contextWindow: result.contextWindow,
 			cost: result.usage?.cost.total ?? 0,
@@ -1588,7 +1699,19 @@ export function renderResult(
 			}
 			for (const progress of visible) {
 				lines.push(
-					...renderAgentProgress(progress, "", "  ", expanded, theme, spinnerFrame, frozen, undefined, 0, nowMs),
+					...renderAgentProgress(
+						progress,
+						"",
+						"  ",
+						expanded,
+						theme,
+						spinnerFrame,
+						frozen,
+						undefined,
+						0,
+						nowMs,
+						ordered,
+					),
 				);
 			}
 		} else if (details.results && details.results.length > 0) {
@@ -1615,7 +1738,19 @@ export function renderResult(
 				: [];
 			for (const progress of supplementalProgress) {
 				lines.push(
-					...renderAgentProgress(progress, "", "  ", expanded, theme, spinnerFrame, frozen, undefined, 0, nowMs),
+					...renderAgentProgress(
+						progress,
+						"",
+						"  ",
+						expanded,
+						theme,
+						spinnerFrame,
+						frozen,
+						undefined,
+						0,
+						nowMs,
+						supplementalProgress,
+					),
 				);
 			}
 
@@ -1804,6 +1939,7 @@ function renderNestedTaskTree(
 						seen,
 						depth + 1,
 						nowMs,
+						ordered,
 					),
 				);
 			});

--- a/packages/coding-agent/src/task/render.ts
+++ b/packages/coding-agent/src/task/render.ts
@@ -181,6 +181,78 @@ export function shortModelLabel(selector: string): string {
 	return slash === -1 ? selector : selector.slice(slash + 1);
 }
 
+/** Cells in the HUD progress bar. */
+export const AGENT_PROGRESS_BAR_WIDTH = 10;
+const AGENT_PROGRESS_SWEEP_WIDTH = 3;
+/** Matches the shared spinner cadence so the sweep advances one cell per repaint. */
+const AGENT_PROGRESS_SWEEP_STEP_MS = 80;
+/** A single tool call past this reads as stuck; the activity fragment shows its elapsed. */
+const AGENT_SLOW_TOOL_MS = 5000;
+
+/**
+ * Progress bar for a live agent. Determinate — elapsed over the peer-derived
+ * total, full and warning-colored once over — when an eta exists. Without one
+ * there is nothing honest to fill against, so the bar is an indeterminate
+ * sweep driven by `nowMs`: it reads as motion only while a ticker repaints the
+ * row. `nowMs` undefined (frozen row) renders the static empty bar.
+ */
+export function formatAgentProgressBar(
+	opts: { elapsedMs: number; etaMs?: number; nowMs?: number },
+	theme: Theme,
+	width = AGENT_PROGRESS_BAR_WIDTH,
+): string {
+	const { filled, empty } = theme.progress;
+	if (opts.etaMs !== undefined && Number.isFinite(opts.etaMs)) {
+		const over = opts.etaMs < 0;
+		const total = opts.elapsedMs + opts.etaMs;
+		const cells = over || total <= 0 ? width : Math.min(width, Math.round((opts.elapsedMs / total) * width));
+		return theme.fg(over ? "warning" : "accent", filled.repeat(cells)) + theme.fg("dim", empty.repeat(width - cells));
+	}
+	if (opts.nowMs === undefined) return theme.fg("dim", empty.repeat(width));
+	const span = width - AGENT_PROGRESS_SWEEP_WIDTH;
+	const tick = Math.floor(opts.nowMs / AGENT_PROGRESS_SWEEP_STEP_MS) % (span * 2);
+	const start = tick <= span ? tick : span * 2 - tick;
+	return (
+		theme.fg("dim", empty.repeat(start)) +
+		theme.fg("accent", filled.repeat(AGENT_PROGRESS_SWEEP_WIDTH)) +
+		theme.fg("dim", empty.repeat(span - start))
+	);
+}
+
+/**
+ * What a running agent is doing right now: `tool: intent` for the in-flight
+ * call (plus its elapsed once it passes {@link AGENT_SLOW_TOOL_MS}), or the
+ * most recent finished call, dimmed, while the model is between tools.
+ * Undefined when the agent is not running or has no tool history yet.
+ */
+export function formatAgentActivity(
+	progress: Pick<
+		AgentProgress,
+		"status" | "currentTool" | "currentToolArgs" | "currentToolStartMs" | "lastIntent" | "recentTools"
+	>,
+	theme: Theme,
+	nowMs: number,
+): string | undefined {
+	if (progress.status !== "running") return undefined;
+	if (progress.currentTool) {
+		let fragment = theme.fg("muted", sanitizeText(progress.currentTool));
+		const detail = progress.lastIntent ?? progress.currentToolArgs;
+		if (detail) fragment += `: ${theme.fg("dim", previewLine(sanitizeText(detail), 40))}`;
+		if (progress.currentToolStartMs) {
+			const elapsed = nowMs - progress.currentToolStartMs;
+			if (elapsed > AGENT_SLOW_TOOL_MS)
+				fragment += `${theme.sep.dot}${theme.fg("warning", formatDuration(elapsed))}`;
+		}
+		return fragment;
+	}
+	const recent = progress.recentTools[0];
+	if (!recent) return undefined;
+	let fragment = theme.fg("dim", sanitizeText(recent.tool));
+	const detail = progress.lastIntent ?? recent.args;
+	if (detail) fragment += `: ${theme.fg("dim", previewLine(sanitizeText(detail), 40))}`;
+	return fragment;
+}
+
 /**
  * Styled stat fragments for an agent row, in display order: tools, requests,
  * prompt/completion volume, cache hit rate, output rate, context gauge, cost,
@@ -1071,31 +1143,8 @@ function renderAgentProgress(
 	lines.push(...renderTaskSection(progress.assignment ?? progress.task, continuePrefix, expanded, theme));
 
 	// Current tool (if running) or most recent completed tool
-	if (progress.status === "running") {
-		if (progress.currentTool) {
-			let toolLine = `${continuePrefix}${theme.tree.hook} ${theme.fg("muted", sanitizeText(progress.currentTool))}`;
-			const toolDetail = progress.lastIntent ?? progress.currentToolArgs;
-			if (toolDetail) {
-				toolLine += `: ${theme.fg("dim", previewLine(sanitizeText(toolDetail), 40))}`;
-			}
-			if (progress.currentToolStartMs) {
-				const elapsed = nowMs - progress.currentToolStartMs;
-				if (elapsed > 5000) {
-					toolLine += `${theme.sep.dot}${theme.fg("warning", formatDuration(elapsed))}`;
-				}
-			}
-			lines.push(toolLine);
-		} else if (progress.recentTools.length > 0) {
-			// Show most recent completed tool when idle between tools
-			const recent = progress.recentTools[0];
-			let toolLine = `${continuePrefix}${theme.tree.hook} ${theme.fg("dim", sanitizeText(recent.tool))}`;
-			const toolDetail = progress.lastIntent ?? recent.args;
-			if (toolDetail) {
-				toolLine += `: ${theme.fg("dim", previewLine(sanitizeText(toolDetail), 40))}`;
-			}
-			lines.push(toolLine);
-		}
-	}
+	const activity = formatAgentActivity(progress, theme, nowMs);
+	if (activity) lines.push(`${continuePrefix}${theme.tree.hook} ${activity}`);
 
 	// Retry detail line: surface why the subagent is paused and roughly how
 	// long until the next attempt. Without this, the parent UI would just

--- a/packages/coding-agent/src/task/render.ts
+++ b/packages/coding-agent/src/task/render.ts
@@ -37,6 +37,7 @@ import {
 import { framedBlock, renderStatusLine } from "../tui";
 import { repairDoubleEncodedJsonString } from "./repair-args";
 import { subprocessToolRegistry } from "./subprocess-tool-registry";
+import { getSubagentDurationHistory } from "./run-history";
 import type { AgentProgress, SingleResult, TaskItem, TaskParams, TaskToolDetails, YieldItem } from "./types";
 import { assembleYieldResult } from "./yield-assembly";
 
@@ -152,22 +153,25 @@ export function agentElapsedMs(
 
 /**
  * Remaining-time estimate for a live agent: median runtime of already-finished
- * peers of the same agent type minus this agent's elapsed time. The only
- * ground truth for "how long does a scout take" is other scouts in this
- * session, so with no finished peer there is no estimate (undefined).
- * Negative means the agent has outlived the peer median by that much.
+ * peers of the same agent type this session (same batch, same load) minus
+ * this agent's elapsed time; with no finished peer, the median of the
+ * cross-session {@link getSubagentDurationHistory} samples for that type.
+ * Undefined only when neither exists — never a fabricated countdown.
+ * Negative means the agent has outlived the median by that much.
  */
 export function estimateAgentEtaMs(
 	progress: Pick<AgentProgress, "id" | "agent" | "durationMs">,
 	peers: Iterable<Pick<AgentProgress, "id" | "agent" | "status" | "durationMs">>,
 	elapsedMs: number = progress.durationMs,
+	history: readonly number[] = [],
 ): number | undefined {
-	const durations: number[] = [];
+	let durations: number[] = [];
 	for (const peer of peers) {
 		if (peer.id === progress.id || peer.agent !== progress.agent) continue;
 		if (peer.status !== "completed" || !(peer.durationMs > 0)) continue;
 		durations.push(peer.durationMs);
 	}
+	if (durations.length === 0) durations = history.filter(ms => ms > 0);
 	if (durations.length === 0) return undefined;
 	durations.sort((a, b) => a - b);
 	const mid = durations.length >> 1;
@@ -183,39 +187,33 @@ export function shortModelLabel(selector: string): string {
 
 /** Cells in the HUD progress bar. */
 export const AGENT_PROGRESS_BAR_WIDTH = 10;
-const AGENT_PROGRESS_SWEEP_WIDTH = 3;
-/** Matches the shared spinner cadence so the sweep advances one cell per repaint. */
-const AGENT_PROGRESS_SWEEP_STEP_MS = 80;
 /** A single tool call past this reads as stuck; the activity fragment shows its elapsed. */
 const AGENT_SLOW_TOOL_MS = 5000;
 
 /**
- * Progress bar for a live agent. Determinate — elapsed over the peer-derived
- * total, full and warning-colored once over — when an eta exists. Without one
- * there is nothing honest to fill against, so the bar is an indeterminate
- * sweep driven by `nowMs`: it reads as motion only while a ticker repaints the
- * row. `nowMs` undefined (frozen row) renders the static empty bar.
+ * Progress bar for a live agent: elapsed over the estimated total (elapsed +
+ * eta, from finished peers this session or cross-session history for the
+ * agent type), with the percentage after it; full and warning-colored once
+ * over. With no estimate at all — the first ever run of an agent type on this
+ * machine — the bar stays empty and unlabelled rather than sweep or invent a
+ * number.
  */
 export function formatAgentProgressBar(
-	opts: { elapsedMs: number; etaMs?: number; nowMs?: number },
+	opts: { elapsedMs: number; etaMs?: number },
 	theme: Theme,
 	width = AGENT_PROGRESS_BAR_WIDTH,
 ): string {
 	const { filled, empty } = theme.progress;
-	if (opts.etaMs !== undefined && Number.isFinite(opts.etaMs)) {
-		const over = opts.etaMs < 0;
-		const total = opts.elapsedMs + opts.etaMs;
-		const cells = over || total <= 0 ? width : Math.min(width, Math.round((opts.elapsedMs / total) * width));
-		return theme.fg(over ? "warning" : "accent", filled.repeat(cells)) + theme.fg("dim", empty.repeat(width - cells));
-	}
-	if (opts.nowMs === undefined) return theme.fg("dim", empty.repeat(width));
-	const span = width - AGENT_PROGRESS_SWEEP_WIDTH;
-	const tick = Math.floor(opts.nowMs / AGENT_PROGRESS_SWEEP_STEP_MS) % (span * 2);
-	const start = tick <= span ? tick : span * 2 - tick;
+	if (opts.etaMs === undefined || !Number.isFinite(opts.etaMs)) return theme.fg("dim", empty.repeat(width));
+	const over = opts.etaMs < 0;
+	const total = opts.elapsedMs + opts.etaMs;
+	const ratio = over || total <= 0 ? 1 : opts.elapsedMs / total;
+	const cells = Math.min(width, Math.round(ratio * width));
+	const color = over ? "warning" : "accent";
 	return (
-		theme.fg("dim", empty.repeat(start)) +
-		theme.fg("accent", filled.repeat(AGENT_PROGRESS_SWEEP_WIDTH)) +
-		theme.fg("dim", empty.repeat(span - start))
+		theme.fg(color, filled.repeat(cells)) +
+		theme.fg("dim", empty.repeat(width - cells)) +
+		` ${theme.fg(color, `${Math.round(ratio * 100)}%`)}`
 	);
 }
 
@@ -1132,7 +1130,14 @@ function renderAgentProgress(
 			const taskPreview = previewLine(sanitizeText(progress.assignment ?? progress.task), 40);
 			statusLine += ` ${theme.fg("muted", taskPreview)}`;
 		}
-		const etaMs = peers ? estimateAgentEtaMs(progress, peers, agentElapsedMs(progress, nowMs)) : undefined;
+		const etaMs = peers
+			? estimateAgentEtaMs(
+					progress,
+					peers,
+					agentElapsedMs(progress, nowMs),
+					getSubagentDurationHistory(progress.agent),
+				)
+			: undefined;
 		statusLine = appendAgentStats(statusLine, { ...progress, etaMs, showResolvedModelBadge: showBadge }, theme);
 	} else if (progress.status === "completed") {
 		statusLine = appendAgentStats(statusLine, { ...progress, showResolvedModelBadge: showBadge }, theme);

--- a/packages/coding-agent/src/task/run-history.ts
+++ b/packages/coding-agent/src/task/run-history.ts
@@ -1,0 +1,68 @@
+/**
+ * Cross-session runtime history per subagent type, backing the HUD's
+ * progress bar from the first spawn of a session.
+ *
+ * Persisted in agent.db's `subagent_runs` table (see {@link AgentStorage}).
+ * {@link recordSubagentRun} is called once per finished run; the HUD reads
+ * {@link getSubagentDurationHistory} synchronously per frame. In-session peers
+ * still win when present (same batch, same load); this is the fallback for a
+ * batch whose first agent has not finished yet.
+ *
+ * Until {@link loadSubagentRunHistory} resolves, runs stay in memory only —
+ * headless paths and tests that never initialize the store never open agent.db.
+ */
+
+import { logger } from "@oh-my-pi/pi-utils";
+import { AgentStorage } from "../session/agent-storage";
+
+/** Newest-first samples kept per agent type; older runs drift out of the median. */
+const HISTORY_PER_AGENT = 20;
+
+let history: Record<string, number[]> = {};
+let storage: AgentStorage | undefined;
+let loadPromise: Promise<void> | undefined;
+
+function pushSample(target: Record<string, number[]>, agent: string, durationMs: number): void {
+	const samples = (target[agent] ??= []);
+	samples.unshift(durationMs);
+	if (samples.length > HISTORY_PER_AGENT) samples.length = HISTORY_PER_AGENT;
+}
+
+/** Load persisted run durations once per process; concurrent calls share one read. */
+export function loadSubagentRunHistory(): Promise<void> {
+	loadPromise ??= (async () => {
+		try {
+			const opened = await AgentStorage.open();
+			const persisted = opened.listRecentSubagentRuns();
+			for (const agent in persisted) persisted[agent] = persisted[agent]!.slice(0, HISTORY_PER_AGENT);
+			// Runs that finished while the load was in flight are newer than anything persisted.
+			for (const agent in history) {
+				for (let i = history[agent]!.length - 1; i >= 0; i--) pushSample(persisted, agent, history[agent]![i]!);
+			}
+			history = persisted;
+			storage = opened;
+		} catch (err) {
+			logger.warn("Failed to load subagent run history", { error: String(err) });
+		}
+	})();
+	return loadPromise;
+}
+
+/** Newest-first durations of finished runs for an agent type; empty when none are known. */
+export function getSubagentDurationHistory(agent: string): readonly number[] {
+	return history[agent] ?? [];
+}
+
+/** Record a finished run (completed only — aborted/failed runs are not a runtime sample). */
+export function recordSubagentRun(agent: string, durationMs: number, requests: number): void {
+	if (!(durationMs > 0)) return;
+	pushSample(history, agent, durationMs);
+	storage?.recordSubagentRun(agent, durationMs, requests);
+}
+
+/** Test-only: reset in-memory history state. */
+export function __resetSubagentRunHistoryForTests(): void {
+	history = {};
+	storage = undefined;
+	loadPromise = undefined;
+}

--- a/packages/coding-agent/src/task/types.ts
+++ b/packages/coding-agent/src/task/types.ts
@@ -424,6 +424,28 @@ export interface AgentProgress {
 	contextTokens?: number;
 	/** Model's context window in tokens, when known. Lets the UI render `<curr>/<window>` gauges. */
 	contextWindow?: number;
+	/**
+	 * Cumulative assistant-turn usage breakdown. Absent until the first assistant
+	 * message settles. Prompt total is `inputTokens + cacheReadTokens +
+	 * cacheWriteTokens`; `cacheReadTokens / prompt total` is the cache hit rate.
+	 */
+	inputTokens?: number;
+	outputTokens?: number;
+	cacheReadTokens?: number;
+	cacheWriteTokens?: number;
+	/**
+	 * Wall-clock ms the agent spent waiting on the model: each turn's request
+	 * dispatch (`turn_start`) to its assistant `message_end`, summed. Includes
+	 * provider latency, so `outputTokens / generationMs` is the effective
+	 * output rate as experienced; tool execution time is excluded.
+	 */
+	generationMs?: number;
+	/**
+	 * Epoch ms the run started. `durationMs` only advances on progress emits, so
+	 * a quiet agent (long tool call, awaiting yield) reads stale; live surfaces
+	 * derive elapsed from this instead.
+	 */
+	startedAtMs?: number;
 	/** Cumulative billing cost in USD, accumulated incrementally from message_end events. */
 	cost: number;
 	durationMs: number;
@@ -498,6 +520,8 @@ export interface SingleResult {
 	contextTokens?: number;
 	/** Model's context window in tokens, when known. */
 	contextWindow?: number;
+	/** Summed model-request wall time; lets completed rows retain effective output rate. */
+	generationMs?: number;
 	modelOverride?: string | string[];
 	/** Explicit pre-expansion model role alias selected for this run. */
 	modelRole?: string;

--- a/packages/coding-agent/test/agent-session-retry-fallback.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-fallback.test.ts
@@ -366,6 +366,74 @@ describe("AgentSession retry fallback", () => {
 		]);
 	});
 
+	it("does not restore an expired primary before the selected fallback gets one request", async () => {
+		const primaryModel = getBundledModel("anthropic", "claude-sonnet-4-5");
+		const firstFallback = getBundledModel("openai", "gpt-4o-mini");
+		const secondFallback = getBundledModel("openai", "gpt-4o");
+		if (!primaryModel || !firstFallback || !secondFallback) {
+			throw new Error("Expected bundled test models to exist");
+		}
+
+		let now = Date.now();
+		vi.spyOn(Date, "now").mockImplementation(() => now);
+		const requestedModels: string[] = [];
+		const mock = createMockModel();
+		const agent = new Agent({
+			getApiKey: model => `${model.provider}-test-key`,
+			initialState: {
+				model: primaryModel,
+				systemPrompt: ["Test"],
+				tools: [],
+				messages: [],
+			},
+			streamFn: (model, context, options) => {
+				requestedModels.push(`${model.provider}/${model.id}`);
+				if (model.provider === primaryModel.provider && model.id === primaryModel.id) {
+					mock.push({ throw: "overloaded_error: provider returned error 503 retry-after-ms=50" });
+				} else if (model.provider === firstFallback.provider && model.id === firstFallback.id) {
+					// Reproduce a slow first fallback: the primary cooldown expires
+					// before this failed attempt returns.
+					now += 100;
+					mock.push({ throw: "service unavailable: 503 overloaded" });
+				} else if (model.provider === secondFallback.provider && model.id === secondFallback.id) {
+					mock.push({ content: ["Recovered on second fallback"] });
+				} else {
+					throw new Error(`Unexpected model requested during retry fallback test: ${model.provider}/${model.id}`);
+				}
+				return mock.stream(model, context, options);
+			},
+		});
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"retry.baseDelayMs": 5,
+			"retry.fallbackRevertPolicy": "cooldown-expiry",
+			"retry.fallbackChains": {
+				default: [
+					`${firstFallback.provider}/${firstFallback.id}`,
+					`${secondFallback.provider}/${secondFallback.id}`,
+				],
+			},
+		});
+		settings.setModelRole("default", `${primaryModel.provider}/${primaryModel.id}`);
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+		});
+
+		await session.prompt("Recover without reverting mid-chain");
+		await session.waitForIdle();
+
+		expect(requestedModels).toEqual([
+			`${primaryModel.provider}/${primaryModel.id}`,
+			`${firstFallback.provider}/${firstFallback.id}`,
+			`${secondFallback.provider}/${secondFallback.id}`,
+		]);
+		expect(session.model?.provider).toBe(secondFallback.provider);
+		expect(session.model?.id).toBe(secondFallback.id);
+	});
+
 	it("hops to the chain owned by a fallback that is the last entry of the chain it came from", async () => {
 		const primaryModel = getBundledModel("anthropic", "claude-sonnet-4-5");
 		const firstFallback = getBundledModel("openai", "gpt-4o-mini");

--- a/packages/coding-agent/test/subagent-hud-render.test.ts
+++ b/packages/coding-agent/test/subagent-hud-render.test.ts
@@ -317,6 +317,109 @@ describe("subagent HUD lines", () => {
 		}
 		expect(out).toContain("2 more running");
 	});
+
+	it("renders a stats line per row: model, requests, volume, cache, rate, elapsed", () => {
+		const out = render(
+			[
+				makeSession({
+					id: "ExtScout",
+					agent: "scout",
+					description: "Audit the extension loader",
+					progress: makeProgress({
+						id: "ExtScout",
+						agent: "scout",
+						description: "Audit the extension loader",
+						resolvedModel: "anthropic/claude-fable-5-1:high",
+						requests: 3,
+						toolCount: 7,
+						inputTokens: 100,
+						outputTokens: 4_200,
+						cacheReadTokens: 900,
+						cacheWriteTokens: 0,
+						generationMs: 100_000,
+						durationMs: 150_000,
+						cost: 0.42,
+					}),
+				}),
+			],
+			160,
+		);
+		const lines = out.split("\n");
+		const rowIndex = lines.findIndex(line => line.includes("ExtScout ⟦scout⟧: Audit the extension loader"));
+		expect(rowIndex).toBeGreaterThan(0);
+		const stats = lines[rowIndex + 1];
+		expect(stats).toContain("claude-fable-5-1:high");
+		expect(stats).not.toContain("anthropic/");
+		expect(stats).toContain("3 req");
+		expect(stats).toContain("↑1K ↓4.2K");
+		expect(stats).toContain("cache 90%");
+		expect(stats).toContain("42 tok/s");
+		expect(stats).toContain("$0.42");
+		expect(stats).toContain("2m30s");
+		// The tool count already lives on the Task block row; the HUD stats line skips it.
+		expect(stats).not.toContain("7 ");
+		// No finished scout yet: no eta is invented.
+		expect(stats).not.toContain("eta");
+	});
+
+	it("omits the stats line until progress exists and estimates eta from finished peers", () => {
+		const bare = render([makeSession({ id: "Fresh", description: "just spawned" })]);
+		expect(bare.split("\n")).toHaveLength(3);
+
+		const finishedScout = makeSession({
+			id: "DoneScout",
+			agent: "scout",
+			status: "completed",
+			progress: makeProgress({ id: "DoneScout", agent: "scout", status: "completed", durationMs: 120_000 }),
+		});
+		const finishedTask = makeSession({
+			id: "DoneTask",
+			agent: "task",
+			status: "completed",
+			progress: makeProgress({ id: "DoneTask", agent: "task", status: "completed", durationMs: 10_000 }),
+		});
+		const live = makeSession({
+			id: "LiveScout",
+			agent: "scout",
+			description: "still reading",
+			progress: makeProgress({ id: "LiveScout", agent: "scout", description: "still reading", durationMs: 30_000 }),
+		});
+		const out = render([finishedScout, finishedTask, live], 160);
+		expect(out).not.toContain("DoneScout");
+		expect(out).toContain("eta ~1m30s");
+
+		const overrun = render(
+			[finishedScout, makeSession({ ...live, progress: { ...live.progress!, durationMs: 200_000 } })],
+			160,
+		);
+		expect(overrun).toContain("1m20s over");
+	});
+
+	it("derives elapsed and eta from startedAtMs so a quiet agent keeps ticking", () => {
+		const finished = makeSession({
+			id: "DoneScout",
+			agent: "scout",
+			status: "completed",
+			progress: makeProgress({ id: "DoneScout", agent: "scout", status: "completed", durationMs: 60_000 }),
+		});
+		// Last progress emit said 5s, but the wall clock is 45s past the start.
+		const quiet = makeSession({
+			id: "QuietScout",
+			agent: "scout",
+			description: "stuck in a long read",
+			progress: makeProgress({
+				id: "QuietScout",
+				agent: "scout",
+				description: "stuck in a long read",
+				durationMs: 5_000,
+				startedAtMs: 1_000_000,
+			}),
+		});
+		const out = Bun.stripANSI(renderSubagentHudLines([finished, quiet], 160, 1_045_000).join("\n"));
+		expect(out).toContain("45.0s");
+		expect(out).toContain("eta ~15.0s");
+		expect(out).not.toContain("└ 5.0s");
+	});
 });
 
 describe("InteractiveMode subagent observer UI sync", () => {

--- a/packages/coding-agent/test/subagent-hud-render.test.ts
+++ b/packages/coding-agent/test/subagent-hud-render.test.ts
@@ -19,6 +19,7 @@ import { initTheme, theme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { __resetSubagentRunHistoryForTests, recordSubagentRun } from "@oh-my-pi/pi-coding-agent/task/run-history";
 import {
 	type AgentProgress,
 	type SubagentLifecyclePayload,
@@ -96,6 +97,8 @@ describe("subagent HUD lines", () => {
 	beforeAll(async () => {
 		await initTheme();
 	});
+	// Module-global history: runs finished by other test files in this process would leak in.
+	beforeEach(() => __resetSubagentRunHistoryForTests());
 
 	it("renders running subagents as Id: description under a Subagents header", () => {
 		const out = render([
@@ -421,7 +424,7 @@ describe("subagent HUD lines", () => {
 		expect(out).not.toContain("└ 5.0s");
 	});
 
-	it("leads the stats line with a bar: determinate against the peer median, sweeping without one", () => {
+	it("leads the stats line with a percent bar against the peer median, empty with no estimate", () => {
 		const finished = makeSession({
 			id: "DoneScout",
 			agent: "scout",
@@ -435,7 +438,7 @@ describe("subagent HUD lines", () => {
 			progress: makeProgress({ id: "LiveScout", agent: "scout", description: "halfway", durationMs: 50_000 }),
 		});
 		const half = Bun.stripANSI(renderSubagentHudLines([finished, live], 160).join("\n"));
-		expect(half).toContain("└ ━━━━━─────");
+		expect(half).toContain("└ ━━━━━───── 50%");
 		expect(half).toContain("eta ~50.0s");
 
 		const over = Bun.stripANSI(
@@ -444,17 +447,48 @@ describe("subagent HUD lines", () => {
 				160,
 			).join("\n"),
 		);
-		expect(over).toContain("└ ━━━━━━━━━━");
+		expect(over).toContain("└ ━━━━━━━━━━ 100%");
 		expect(over).toContain("30.0s over");
 
-		// No finished peer: static empty bar when unanimated, a moving 3-cell
-		// sweep (position from the clock) once a spinner frame is supplied.
-		const still = Bun.stripANSI(renderSubagentHudLines([live], 160).join("\n"));
-		expect(still).toContain("└ ──────────");
-		const sweepA = Bun.stripANSI(renderSubagentHudLines([live], 160, 0, 0).join("\n"));
-		const sweepB = Bun.stripANSI(renderSubagentHudLines([live], 160, 160, 2).join("\n"));
-		expect(sweepA).toContain("└ ━━━───────");
-		expect(sweepB).toContain("└ ──━━━─────");
+		// No finished peer and no history: an empty, unlabelled bar — nothing sweeps or is invented.
+		const bare = Bun.stripANSI(renderSubagentHudLines([live], 160).join("\n"));
+		expect(bare).toContain("└ ────────── · 50.0s");
+		expect(bare).not.toContain("%");
+	});
+
+	it("estimates from cross-session history for the agent type when no peer has finished", () => {
+		recordSubagentRun("scout", 200_000, 12);
+		recordSubagentRun("scout", 100_000, 9);
+		recordSubagentRun("task", 900_000, 40);
+		try {
+			const live = makeSession({
+				id: "FirstScout",
+				agent: "scout",
+				description: "first of its batch",
+				progress: makeProgress({
+					id: "FirstScout",
+					agent: "scout",
+					description: "first of its batch",
+					durationMs: 30_000,
+				}),
+			});
+			// Median of the scout history is 150s; the task run is a different type.
+			const out = Bun.stripANSI(renderSubagentHudLines([live], 160).join("\n"));
+			expect(out).toContain("└ ━━──────── 20%");
+			expect(out).toContain("eta ~2m");
+
+			// A finished peer in this session outranks history.
+			const peer = makeSession({
+				id: "DoneScout",
+				agent: "scout",
+				status: "completed",
+				progress: makeProgress({ id: "DoneScout", agent: "scout", status: "completed", durationMs: 60_000 }),
+			});
+			const withPeer = Bun.stripANSI(renderSubagentHudLines([peer, live], 160).join("\n"));
+			expect(withPeer).toContain("└ ━━━━━───── 50%");
+		} finally {
+			__resetSubagentRunHistoryForTests();
+		}
 	});
 
 	it("swaps the dot for the spinner glyph when a frame is supplied", () => {

--- a/packages/coding-agent/test/subagent-hud-render.test.ts
+++ b/packages/coding-agent/test/subagent-hud-render.test.ts
@@ -15,7 +15,7 @@ import {
 	type ObservableSession,
 	SessionObserverRegistry,
 } from "@oh-my-pi/pi-coding-agent/modes/session-observer-registry";
-import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { initTheme, theme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
@@ -420,6 +420,84 @@ describe("subagent HUD lines", () => {
 		expect(out).toContain("eta ~15.0s");
 		expect(out).not.toContain("└ 5.0s");
 	});
+
+	it("leads the stats line with a bar: determinate against the peer median, sweeping without one", () => {
+		const finished = makeSession({
+			id: "DoneScout",
+			agent: "scout",
+			status: "completed",
+			progress: makeProgress({ id: "DoneScout", agent: "scout", status: "completed", durationMs: 100_000 }),
+		});
+		const live = makeSession({
+			id: "LiveScout",
+			agent: "scout",
+			description: "halfway",
+			progress: makeProgress({ id: "LiveScout", agent: "scout", description: "halfway", durationMs: 50_000 }),
+		});
+		const half = Bun.stripANSI(renderSubagentHudLines([finished, live], 160).join("\n"));
+		expect(half).toContain("└ ━━━━━─────");
+		expect(half).toContain("eta ~50.0s");
+
+		const over = Bun.stripANSI(
+			renderSubagentHudLines(
+				[finished, makeSession({ ...live, progress: { ...live.progress!, durationMs: 130_000 } })],
+				160,
+			).join("\n"),
+		);
+		expect(over).toContain("└ ━━━━━━━━━━");
+		expect(over).toContain("30.0s over");
+
+		// No finished peer: static empty bar when unanimated, a moving 3-cell
+		// sweep (position from the clock) once a spinner frame is supplied.
+		const still = Bun.stripANSI(renderSubagentHudLines([live], 160).join("\n"));
+		expect(still).toContain("└ ──────────");
+		const sweepA = Bun.stripANSI(renderSubagentHudLines([live], 160, 0, 0).join("\n"));
+		const sweepB = Bun.stripANSI(renderSubagentHudLines([live], 160, 160, 2).join("\n"));
+		expect(sweepA).toContain("└ ━━━───────");
+		expect(sweepB).toContain("└ ──━━━─────");
+	});
+
+	it("swaps the dot for the spinner glyph when a frame is supplied", () => {
+		const live = makeSession({ id: "Spinner", description: "moving" });
+		const frames = theme.spinnerFrames;
+		const still = Bun.stripANSI(renderSubagentHudLines([live], 120).join("\n"));
+		expect(still).toContain(`${theme.status.done} Spinner`);
+		const spun = Bun.stripANSI(renderSubagentHudLines([live], 120, Date.now(), 1).join("\n"));
+		expect(spun).toContain(`${Bun.stripANSI(frames[1])} Spinner`);
+		expect(spun).not.toContain(`${theme.status.done} Spinner`);
+	});
+
+	it("shows the in-flight tool and intent, flagging a call that has run past five seconds", () => {
+		const reading = makeSession({
+			id: "Reader",
+			description: "reading",
+			progress: makeProgress({
+				id: "Reader",
+				description: "reading",
+				durationMs: 20_000,
+				currentTool: "read",
+				lastIntent: "Scanning the loader",
+				currentToolStartMs: 1_000_000,
+			}),
+		});
+		const quick = Bun.stripANSI(renderSubagentHudLines([reading], 160, 1_002_000).join("\n"));
+		expect(quick).toContain("read: Scanning the loader");
+		expect(quick).not.toContain("read: Scanning the loader · 2.0s");
+		const slow = Bun.stripANSI(renderSubagentHudLines([reading], 160, 1_012_000).join("\n"));
+		expect(slow).toContain("read: Scanning the loader · 12.0s");
+
+		const between = makeSession({
+			id: "Thinker",
+			description: "thinking",
+			progress: makeProgress({
+				id: "Thinker",
+				description: "thinking",
+				durationMs: 20_000,
+				recentTools: [{ tool: "grep", args: "pattern=foo", endMs: 5 }],
+			}),
+		});
+		expect(Bun.stripANSI(renderSubagentHudLines([between], 160).join("\n"))).toContain("grep: pattern=foo");
+	});
 });
 
 describe("InteractiveMode subagent observer UI sync", () => {
@@ -487,7 +565,9 @@ describe("InteractiveMode subagent observer UI sync", () => {
 		}
 
 		await Promise.resolve();
-		vi.runAllTimers();
+		// Advance only past the coalesce window: the HUD arms the shared 80ms
+		// spinner interval, which `runAllTimers` would spin on forever.
+		vi.advanceTimersByTime(150);
 		await Promise.resolve();
 
 		const hud = Bun.stripANSI(mode.subagentContainer.render(120).join("\n"));

--- a/packages/coding-agent/test/task/agent-stats-render.test.ts
+++ b/packages/coding-agent/test/task/agent-stats-render.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Contract: agent rows (inline task block and subagent HUD) share one stats
+ * formatter. Prompt/output volume, cache hit rate, and output rate appear once
+ * the usage breakdown exists; the ETA is derived only from finished peers of
+ * the same agent type — no peer, no estimate — and flips to `<dur> over` once
+ * the agent outlives the peer median.
+ */
+import type { RenderResultOptions } from "@oh-my-pi/pi-agent-core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { getThemeByName, type Theme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import {
+	agentStatParts,
+	estimateAgentEtaMs,
+	formatCacheHitRate,
+	formatEta,
+	formatOutputRate,
+	shortModelLabel,
+} from "@oh-my-pi/pi-coding-agent/task/render";
+import { taskToolRenderer } from "@oh-my-pi/pi-coding-agent/task/renderer";
+import type { AgentProgress, SingleResult, TaskToolDetails } from "@oh-my-pi/pi-coding-agent/task/types";
+
+function progress(overrides: Partial<AgentProgress> & { id: string }): AgentProgress {
+	return {
+		index: 0,
+		agent: "scout",
+		agentSource: "bundled",
+		status: "running",
+		task: "inspect",
+		recentTools: [],
+		recentOutput: [],
+		toolCount: 0,
+		requests: 0,
+		tokens: 0,
+		cost: 0,
+		durationMs: 0,
+		...overrides,
+	};
+}
+
+function renderRows(rows: AgentProgress[]): string {
+	const details: TaskToolDetails = { projectAgentsDir: null, results: [], totalDurationMs: 0, progress: rows };
+	const options: RenderResultOptions = { expanded: false, isPartial: true, spinnerFrame: 0 };
+	return Bun.stripANSI(
+		taskToolRenderer
+			.renderResult({ content: [{ type: "text", text: "" }], details }, options, theme)
+			.render(160)
+			.join("\n"),
+	);
+}
+
+function renderResults(results: SingleResult[]): string {
+	const details: TaskToolDetails = { projectAgentsDir: null, results, totalDurationMs: 0 };
+	const options: RenderResultOptions = { expanded: false, isPartial: false, spinnerFrame: 0 };
+	return Bun.stripANSI(
+		taskToolRenderer
+			.renderResult({ content: [{ type: "text", text: "" }], details }, options, theme)
+			.render(160)
+			.join("\n"),
+	);
+}
+
+let theme: Theme;
+
+describe("agent stat formatters", () => {
+	beforeEach(async () => {
+		resetSettingsForTest();
+		await Settings.init({ inMemory: true });
+		theme = (await getThemeByName("dark"))!;
+	});
+	afterEach(() => {
+		vi.restoreAllMocks();
+		resetSettingsForTest();
+	});
+
+	it("formats output rate only once measurable", () => {
+		expect(formatOutputRate(undefined, undefined)).toBeUndefined();
+		expect(formatOutputRate(100, 0)).toBeUndefined();
+		expect(formatOutputRate(0, 5_000)).toBeUndefined();
+		expect(formatOutputRate(4_200, 100_000)).toBe("42 tok/s");
+		expect(formatOutputRate(75, 10_000)).toBe("7.5 tok/s");
+	});
+
+	it("formats cache hit rate over the full prompt volume", () => {
+		expect(formatCacheHitRate({})).toBeUndefined();
+		expect(formatCacheHitRate({ inputTokens: 100, cacheReadTokens: 900, cacheWriteTokens: 0 })).toBe("cache 90%");
+		expect(formatCacheHitRate({ inputTokens: 50, cacheReadTokens: 0, cacheWriteTokens: 50 })).toBe("cache 0%");
+	});
+
+	it("derives the eta from finished peers of the same agent type only", () => {
+		const me = progress({ id: "Me", agent: "scout", durationMs: 30_000 });
+		const peers = [
+			me,
+			progress({ id: "A", agent: "scout", status: "completed", durationMs: 60_000 }),
+			progress({ id: "B", agent: "scout", status: "completed", durationMs: 100_000 }),
+			progress({ id: "C", agent: "scout", status: "completed", durationMs: 80_000 }),
+			// Wrong type, still running, and failed peers are not evidence.
+			progress({ id: "D", agent: "task", status: "completed", durationMs: 1 }),
+			progress({ id: "E", agent: "scout", status: "running", durationMs: 500_000 }),
+			progress({ id: "F", agent: "scout", status: "failed", durationMs: 5 }),
+		];
+		expect(estimateAgentEtaMs(me, peers)).toBe(50_000);
+		expect(estimateAgentEtaMs(me, [me])).toBeUndefined();
+		expect(estimateAgentEtaMs({ ...me, durationMs: 90_000 }, peers)).toBe(-10_000);
+	});
+
+	it("formats the eta as a countdown or an overrun, never fabricating one", () => {
+		expect(formatEta(undefined)).toBeUndefined();
+		expect(formatEta(50_000)).toBe("eta ~50.0s");
+		expect(formatEta(200)).toBe("eta ~1.0s");
+		expect(formatEta(-90_000)).toBe("1m30s over");
+	});
+
+	it("strips the provider from a model selector", () => {
+		expect(shortModelLabel("anthropic/claude-fable-5-1:high")).toBe("claude-fable-5-1:high");
+		expect(shortModelLabel("local-model")).toBe("local-model");
+	});
+
+	it("emits volume, cache, rate, and eta fragments in display order", () => {
+		const parts = agentStatParts(
+			{
+				requests: 3,
+				inputTokens: 100,
+				outputTokens: 4_200,
+				cacheReadTokens: 900,
+				cacheWriteTokens: 0,
+				generationMs: 100_000,
+				cost: 0.5,
+				etaMs: 30_000,
+			},
+			theme,
+		).map(part => Bun.stripANSI(part));
+		expect(parts).toEqual(["3 req", "↑1K ↓4.2K", "cache 90%", "42 tok/s", "$0.50", "eta ~30.0s"]);
+		expect(agentStatParts({ cost: 0 }, theme)).toEqual([]);
+	});
+
+	it("shows live usage and a peer-derived eta on running inline rows", () => {
+		const rows = [
+			progress({ id: "Done", status: "completed", durationMs: 60_000, requests: 4 }),
+			progress({
+				id: "Live",
+				description: "reading configs",
+				durationMs: 20_000,
+				requests: 2,
+				inputTokens: 200,
+				outputTokens: 500,
+				cacheReadTokens: 1_800,
+				cacheWriteTokens: 0,
+				generationMs: 10_000,
+			}),
+		];
+		const out = renderRows(rows);
+		const liveRow = out.split("\n").find(line => line.includes("Live"));
+		expect(liveRow).toContain("↑2K ↓500");
+		expect(liveRow).toContain("cache 90%");
+		expect(liveRow).toContain("50 tok/s");
+		expect(liveRow).toContain("eta ~40.0s");
+		// A lone running agent has no finished peer: no eta is invented.
+		const alone = renderRows([rows[1]])
+			.split("\n")
+			.find(line => line.includes("Live"));
+		expect(alone).not.toContain("eta");
+	});
+
+	it("retains usage and effective output rate on completed rows", () => {
+		const result: SingleResult = {
+			index: 0,
+			id: "Done",
+			agent: "scout",
+			agentSource: "bundled",
+			task: "inspect",
+			exitCode: 0,
+			output: "done",
+			stderr: "",
+			truncated: false,
+			durationMs: 20_000,
+			generationMs: 10_000,
+			tokens: 700,
+			requests: 2,
+			usage: {
+				input: 200,
+				output: 500,
+				cacheRead: 1_800,
+				cacheWrite: 0,
+				totalTokens: 2_500,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+		};
+		const row = renderResults([result])
+			.split("\n")
+			.find(line => line.includes("Done"));
+		expect(row).toContain("↑2K ↓500");
+		expect(row).toContain("cache 90%");
+		expect(row).toContain("50 tok/s");
+		expect(row).toContain("20.0s");
+	});
+});

--- a/packages/coding-agent/test/task/agent-stats-render.test.ts
+++ b/packages/coding-agent/test/task/agent-stats-render.test.ts
@@ -104,6 +104,14 @@ describe("agent stat formatters", () => {
 		expect(estimateAgentEtaMs({ ...me, durationMs: 90_000 }, peers)).toBe(-10_000);
 	});
 
+	it("falls back to cross-session history only when no peer of the type has finished", () => {
+		const me = progress({ id: "Me", agent: "scout", durationMs: 30_000 });
+		const peer = progress({ id: "A", agent: "scout", status: "completed", durationMs: 60_000 });
+		expect(estimateAgentEtaMs(me, [me], 30_000, [200_000, 100_000, 150_000])).toBe(120_000);
+		expect(estimateAgentEtaMs(me, [me, peer], 30_000, [200_000, 100_000, 150_000])).toBe(30_000);
+		expect(estimateAgentEtaMs(me, [me], 30_000, [0, -5])).toBeUndefined();
+	});
+
 	it("formats the eta as a countdown or an overrun, never fabricating one", () => {
 		expect(formatEta(undefined)).toBeUndefined();
 		expect(formatEta(50_000)).toBe("eta ~50.0s");

--- a/packages/coding-agent/test/task/executor-live-usage.test.ts
+++ b/packages/coding-agent/test/task/executor-live-usage.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Contract: `AgentProgress` carries a live usage breakdown (prompt volume split
+ * into uncached input / cache read / cache write, plus output) and the summed
+ * model wait time per turn (`turn_start` → assistant `message_end`), so the HUD
+ * and inline rows can show in/out volume, cache hit rate, and output rate while
+ * the agent is still running. Only assistant `message_end` events count;
+ * tool-result usage is ignored, and a `message_end` with no open turn adds no
+ * generation time. The window starts at the request, not `message_start`:
+ * non-streaming providers emit start and end back-to-back.
+ */
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import type { AssistantMessage } from "@oh-my-pi/pi-ai";
+import type { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import type { CreateAgentSessionResult } from "@oh-my-pi/pi-coding-agent/sdk";
+import * as sdkModule from "@oh-my-pi/pi-coding-agent/sdk";
+import type { AgentSession, AgentSessionEvent } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { runSubprocess } from "@oh-my-pi/pi-coding-agent/task/executor";
+import type { AgentDefinition, AgentProgress } from "@oh-my-pi/pi-coding-agent/task/types";
+import { EventBus } from "@oh-my-pi/pi-coding-agent/utils/event-bus";
+
+function assistantMessage(usage: {
+	input: number;
+	output: number;
+	cacheRead: number;
+	cacheWrite: number;
+	totalTokens: number;
+}): AssistantMessage {
+	// Executor reads role/content/usage only; the cast documents the structural double.
+	return {
+		role: "assistant",
+		content: [],
+		usage: { ...usage, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0.01 } },
+	} as unknown as AssistantMessage;
+}
+
+function yieldEvents(): AgentSessionEvent[] {
+	return [
+		{ type: "tool_execution_start", toolCallId: "final-yield", toolName: "yield", args: {} },
+		{
+			type: "tool_execution_end",
+			toolCallId: "final-yield",
+			toolName: "yield",
+			result: { content: [{ type: "text", text: "Result submitted." }], details: { status: "success", data: {} } },
+			isError: false,
+		},
+	] as AgentSessionEvent[];
+}
+
+const agent: AgentDefinition = { name: "task", description: "test", systemPrompt: "test", source: "bundled" };
+
+/** Runs the executor against a scripted event stream; `clock` advances `Date.now()` between events. */
+async function runScript(
+	steps: Array<{ atMs: number; event: AgentSessionEvent }>,
+): Promise<{ snapshots: AgentProgress[]; exitCode: number }> {
+	let nowMs = 0;
+	vi.spyOn(Date, "now").mockImplementation(() => nowMs);
+	const listeners: Array<(event: AgentSessionEvent) => void> = [];
+	const session = {
+		state: { messages: [] },
+		agent: { state: { systemPrompt: ["test"] } },
+		model: undefined,
+		extensionRunner: undefined,
+		sessionManager: { appendSessionInit: () => {} },
+		getActiveToolNames: () => ["read", "yield"],
+		getEnabledToolNames: () => ["read", "yield"],
+		setActiveToolsByName: async () => {},
+		subscribe: (listener: (event: AgentSessionEvent) => void) => {
+			listeners.push(listener);
+			return () => listeners.splice(listeners.indexOf(listener), 1);
+		},
+		prompt: async () => {
+			// Listeners may unsubscribe during dispatch; iterate a snapshot.
+			const dispatch = (event: AgentSessionEvent) => {
+				for (const listener of listeners.slice()) listener(event);
+			};
+			for (const step of steps) {
+				nowMs = step.atMs;
+				dispatch(step.event);
+			}
+			for (const event of yieldEvents()) dispatch(event);
+		},
+		waitForIdle: async () => {},
+		prepareForHeadlessAdvisorDrain: () => {},
+		waitForAdvisorCatchup: async () => true,
+		getLastAssistantMessage: () => undefined,
+		abort: async () => {},
+		isAborted: () => false,
+		dispose: async () => {},
+		setIrcWakeTurnObserver: () => {},
+		subscribeRunState: () => () => {},
+	};
+	vi.spyOn(sdkModule, "createAgentSession").mockResolvedValue({
+		session: session as unknown as AgentSession,
+	} as CreateAgentSessionResult);
+
+	const snapshots: AgentProgress[] = [];
+	const result = await runSubprocess({
+		cwd: "/tmp",
+		agent,
+		task: "usage scenario",
+		description: "live usage",
+		index: 0,
+		id: `live-usage-${Math.random().toString(36).slice(2)}`,
+		settings: Settings.isolated(),
+		modelRegistry: { refresh: async () => {} } as ModelRegistry,
+		enableLsp: false,
+		signal: new AbortController().signal,
+		eventBus: new EventBus(),
+		onProgress: progress => snapshots.push(progress),
+	});
+	return { snapshots, exitCode: result.exitCode };
+}
+
+describe("subagent live usage breakdown", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("accumulates prompt/output split and per-turn model wait time across turns", async () => {
+		const turn1 = assistantMessage({ input: 100, output: 50, cacheRead: 900, cacheWrite: 0, totalTokens: 1050 });
+		const turn2 = assistantMessage({ input: 20, output: 30, cacheRead: 1000, cacheWrite: 80, totalTokens: 1130 });
+		const { snapshots, exitCode } = await runScript([
+			{ atMs: 1_000, event: { type: "turn_start" } as AgentSessionEvent },
+			// A non-streaming provider: start and end land together, long after the request.
+			{ atMs: 2_999, event: { type: "message_start", message: turn1 } as AgentSessionEvent },
+			{ atMs: 3_000, event: { type: "message_end", message: turn1 } as AgentSessionEvent },
+			// Tool-result usage never counts: neither the breakdown nor the clock moves.
+			{
+				atMs: 4_000,
+				event: {
+					type: "message_end",
+					message: { role: "toolResult", content: [], usage: { input: 999, output: 999 } },
+				} as unknown as AgentSessionEvent,
+			},
+			{ atMs: 5_000, event: { type: "turn_start" } as AgentSessionEvent },
+			{ atMs: 5_200, event: { type: "message_start", message: turn2 } as AgentSessionEvent },
+			{ atMs: 6_000, event: { type: "message_end", message: turn2 } as AgentSessionEvent },
+		]);
+		expect(exitCode).toBe(0);
+		const final = snapshots[snapshots.length - 1];
+		expect(final).toMatchObject({
+			inputTokens: 120,
+			outputTokens: 80,
+			cacheReadTokens: 1900,
+			cacheWriteTokens: 80,
+			generationMs: 3_000,
+			requests: 2,
+		});
+	});
+
+	it("leaves the breakdown absent until the first assistant turn settles", async () => {
+		const turn = assistantMessage({ input: 10, output: 5, cacheRead: 0, cacheWrite: 0, totalTokens: 15 });
+		const { snapshots } = await runScript([
+			{ atMs: 1_000, event: { type: "turn_start" } as AgentSessionEvent },
+			{ atMs: 1_100, event: { type: "message_start", message: turn } as AgentSessionEvent },
+			{
+				atMs: 1_500,
+				event: { type: "tool_execution_start", toolCallId: "t0", toolName: "read", args: {} } as AgentSessionEvent,
+			},
+			{
+				atMs: 1_600,
+				event: {
+					type: "tool_execution_end",
+					toolCallId: "t0",
+					toolName: "read",
+					result: { content: [{ type: "text", text: "ok" }] },
+					isError: false,
+				} as AgentSessionEvent,
+			},
+			{ atMs: 2_000, event: { type: "message_end", message: turn } as AgentSessionEvent },
+		]);
+		const beforeTurnEnd = snapshots.find(snapshot => snapshot.requests === 0);
+		expect(beforeTurnEnd).toBeDefined();
+		expect(beforeTurnEnd?.inputTokens).toBeUndefined();
+		expect(beforeTurnEnd?.generationMs).toBeUndefined();
+		const final = snapshots[snapshots.length - 1];
+		expect(final).toMatchObject({ inputTokens: 10, outputTokens: 5, generationMs: 1_000 });
+	});
+
+	it("adds no generation time for a message_end outside an open turn", async () => {
+		const turn = assistantMessage({ input: 10, output: 5, cacheRead: 0, cacheWrite: 0, totalTokens: 15 });
+		const { snapshots } = await runScript([
+			{ atMs: 2_000, event: { type: "message_end", message: turn } as AgentSessionEvent },
+		]);
+		const final = snapshots[snapshots.length - 1];
+		expect(final.outputTokens).toBe(5);
+		expect(final.generationMs).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## What

- Show the resolved model, request count, prompt and output tokens, cache hit rate, effective output rate, cost, elapsed time, and ETA beneath each active subagent HUD row.
- Carry the live usage breakdown and model-request wall time through `AgentProgress`. Retain the output rate on completed task rows.
- Derive ETA from the median runtime of completed peers of the same agent type. Omit the ETA until peer data exists.
- Render elapsed time from `startedAtMs`, so quiet agents do not show stale timing.

## Why

The anchored Subagents HUD shows only each agent name, role, and assignment. Operators cannot see which model is running, whether prompt caching works, how fast a model responds, how much context each agent consumes, or when comparable work usually finishes.

## Testing

- `bun --cwd=packages/coding-agent run check:types`
- 125 tests across the affected HUD, task renderer, executor, job badge, and Agent Hub files
- Built the standalone binary and ran `./dist/omp --smoke-test`
- Exercised a live detached-scout batch in the TUI and observed model, requests, prompt/output volume, cache hit rate, output rate, context gauge, and elapsed time

---

- [x] Targeted type check passes
- [x] Tested locally
- [ ] CHANGELOG updated (maintainer release process)