### PR TITLE
fix(ai): synthesize non-empty reasoning_text on DeepSeek Responses replay

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed DeepSeek-family Responses replay (e.g. opencode-go) rejecting a resumed thinking-mode turn with `400 The reasoning_text in the thinking mode must be passed back to the API` when compaction dropped the turn's reasoning; a non-empty placeholder is now synthesized instead of an empty `reasoning_text` ([#10690](https://github.com/can1357/oh-my-pi/issues/10690)).
+
 ## [18.1.6] - 2026-09-03
 
 ### Breaking Changes

--- a/packages/ai/src/providers/openai-shared.ts
+++ b/packages/ai/src/providers/openai-shared.ts
@@ -2111,6 +2111,19 @@ function parseResponseReasoningReplayItem(signature: string | undefined): Respon
 	}
 }
 
+/**
+ * Non-empty `reasoning_text` shipped for a synthesized reasoning item when no
+ * thinking text survived history reconstruction. DeepSeek-family Responses
+ * targets (e.g. opencode-go) reject BOTH a missing reasoning item and one whose
+ * `reasoning_text` is empty — "The reasoning_text in the thinking mode must be
+ * passed back to the API" (#8248 covered the missing case, #10690 the empty
+ * one). The item's presence plus a non-empty payload is what satisfies the
+ * contract; the exact text is immaterial once the source turn's reasoning is
+ * gone. Kept out of `reasoning_content="."`-territory since DeepSeek rejects the
+ * bare-dot synthetic placeholder on the chat-completions path.
+ */
+export const SYNTHETIC_REASONING_REPLAY_PLACEHOLDER = "reasoning unavailable";
+
 export function convertResponsesAssistantMessage<TApi extends Api>(
 	assistantMsg: AssistantMessage,
 	model: Model<TApi>,
@@ -2268,12 +2281,15 @@ export function convertResponsesAssistantMessage<TApi extends Api>(
 	if (requiresReasoningItem && !reasoningItemEmitted && outputItems.length > 0) {
 		// Replay the demoted reasoning (already present in `content` as visible
 		// text) as a structured reasoning item so the thinking-mode continuation
-		// carries the `reasoning_text` the provider requires. The text may be empty
-		// when the source turn was minted by another model and its reasoning is
-		// already folded into the message text; the item's presence is what
-		// satisfies the provider contract, mirroring the empty `reasoning_content`
-		// placeholder used on the chat-completions path.
-		const reasoningText = carriedReasoningTexts.join("\n");
+		// carries the `reasoning_text` the provider requires. When no thinking
+		// text survived reconstruction (source turn minted by another model, or
+		// reasoning dropped by compaction/archive budget) the carried text is
+		// empty — and DeepSeek-family targets reject an empty `reasoning_text`
+		// exactly like a missing item (#10690), so substitute a non-empty
+		// placeholder. The `id` still prefers a surviving upstream item id.
+		const carriedReasoningText = carriedReasoningTexts.join("\n");
+		const reasoningText =
+			carriedReasoningText.length > 0 ? carriedReasoningText : SYNTHETIC_REASONING_REPLAY_PLACEHOLDER;
 		const reasoningId =
 			synthesizedReasoningItemId ?? `rs_${Bun.hash(`${model.id}:${msgIndex}:${reasoningText}`).toString(36)}`;
 		const reasoningItem: ResponseReasoningItem = {

--- a/packages/ai/test/issue-10690-repro.test.ts
+++ b/packages/ai/test/issue-10690-repro.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from "bun:test";
+import { streamOpenAIResponses } from "@oh-my-pi/pi-ai/providers/openai-responses";
+import {
+	convertResponsesAssistantMessage,
+	SYNTHETIC_REASONING_REPLAY_PLACEHOLDER,
+} from "@oh-my-pi/pi-ai/providers/openai-shared";
+import type { AssistantMessage, Context, Model } from "@oh-my-pi/pi-ai/types";
+import { Effort } from "@oh-my-pi/pi-catalog/effort";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+
+// Issue #10690: follow-up to #8248. The Responses reasoning synthesizer replays a
+// reasoning item for each assistant turn a DeepSeek-family target requires. When
+// no thinking text survives history reconstruction (compaction/archive budget
+// drops the reasoning while the turn's message/tool-call items remain), the
+// synthesized item previously carried `reasoning_text: ""`. opencode-go/DeepSeek
+// rejects an empty `reasoning_text` exactly like a missing one:
+//   400 The reasoning_text in the thinking mode must be passed back to the API.
+// The synthesized item must therefore always carry a non-empty `reasoning_text`.
+
+interface ReasoningTextPart {
+	type: string;
+	text: string;
+}
+interface ResponsesInputItem {
+	type: string;
+	id?: string;
+	role?: string;
+	content?: unknown;
+}
+interface ResponsesPayload {
+	input?: ResponsesInputItem[];
+	reasoning?: { effort?: string };
+}
+
+function abortedSignal(): AbortSignal {
+	const controller = new AbortController();
+	controller.abort();
+	return controller.signal;
+}
+
+function capture(model: Model<"openai-responses">, context: Context): Promise<ResponsesPayload> {
+	const { promise, resolve } = Promise.withResolvers<ResponsesPayload>();
+	streamOpenAIResponses(model, context, {
+		apiKey: "sk-test",
+		reasoning: Effort.XHigh,
+		signal: abortedSignal(),
+		onPayload: payload => resolve(payload as ResponsesPayload),
+	});
+	return promise;
+}
+
+function reasoningItems(payload: ResponsesPayload): ResponsesInputItem[] {
+	return (payload.input ?? []).filter(item => item.type === "reasoning");
+}
+
+function reasoningTextOf(item: ResponsesInputItem): string {
+	const content = Array.isArray(item.content) ? (item.content as ReasoningTextPart[]) : [];
+	return content
+		.filter(part => part.type === "reasoning_text")
+		.map(part => part.text)
+		.join("");
+}
+
+const deepseek = getBundledModel("opencode-go", "deepseek-v4-flash") as Model<"openai-responses">;
+
+const usage = {
+	input: 0,
+	output: 0,
+	cacheRead: 0,
+	cacheWrite: 0,
+	totalTokens: 0,
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+} as const;
+
+describe("issue #10690: DeepSeek Responses replay must never synthesize empty reasoning_text", () => {
+	it("substitutes a non-empty placeholder when the turn has no surviving thinking block", async () => {
+		// Compaction dropped the reasoning entirely; only the message survives.
+		const prior: AssistantMessage = {
+			role: "assistant",
+			api: "openai-responses",
+			provider: "opencode-go",
+			model: "deepseek-v4-flash",
+			stopReason: "stop",
+			usage,
+			content: [{ type: "text", text: "Edited bar.ts." }],
+			timestamp: Date.now(),
+		};
+		const context: Context = {
+			messages: [
+				{ role: "user", content: "Edit bar", timestamp: Date.now() },
+				prior,
+				{ role: "user", content: "Run the tests", timestamp: Date.now() },
+			],
+		};
+
+		const payload = await capture(deepseek, context);
+		const reasoning = reasoningItems(payload);
+		expect(reasoning).toHaveLength(1);
+		const text = reasoningTextOf(reasoning[0]!);
+		expect(text.length).toBeGreaterThan(0);
+		expect(text).toBe(SYNTHETIC_REASONING_REPLAY_PLACEHOLDER);
+	});
+
+	it("substitutes a non-empty placeholder for an empty-text thinking block, preserving its upstream id", () => {
+		// The reporter's exact shape reaches the encoder: a reasoning item survived
+		// with a real upstream id but an empty payload. The synthesis branch keeps
+		// the id and replaces the empty text with the placeholder. Driven through
+		// the encoder directly because an empty-text thinking block is dropped by
+		// transform-messages before the full stream path re-encodes it.
+		const prior: AssistantMessage = {
+			role: "assistant",
+			api: "openai-responses",
+			provider: "opencode-go",
+			model: "deepseek-v4-flash",
+			stopReason: "stop",
+			usage,
+			content: [
+				{ type: "thinking", thinking: "", itemId: "rs_upstream" },
+				{ type: "text", text: "Edited bar.ts." },
+			],
+			timestamp: Date.now(),
+		};
+
+		const items = convertResponsesAssistantMessage(
+			prior,
+			deepseek,
+			0,
+			new Set<string>(),
+			true,
+			undefined,
+			false,
+			true,
+			undefined,
+			undefined,
+			true,
+		) as ResponsesInputItem[];
+		const reasoning = items.filter(item => item.type === "reasoning");
+		expect(reasoning).toHaveLength(1);
+		expect(reasoning[0]!.id).toBe("rs_upstream");
+		expect(reasoningTextOf(reasoning[0]!)).toBe(SYNTHETIC_REASONING_REPLAY_PLACEHOLDER);
+	});
+
+	it("preserves real surviving thinking text instead of the placeholder", async () => {
+		// Precedence: a non-empty carried thinking text is replayed verbatim and
+		// the placeholder is not substituted.
+		const prior: AssistantMessage = {
+			role: "assistant",
+			api: "openai-responses",
+			provider: "opencode-go",
+			model: "deepseek-v4-flash",
+			stopReason: "stop",
+			usage,
+			content: [
+				{ type: "thinking", thinking: "Inspect bar.ts before editing." },
+				{ type: "text", text: "Edited bar.ts." },
+			],
+			timestamp: Date.now(),
+		};
+		const context: Context = {
+			messages: [
+				{ role: "user", content: "Edit bar", timestamp: Date.now() },
+				prior,
+				{ role: "user", content: "Run the tests", timestamp: Date.now() },
+			],
+		};
+
+		const payload = await capture(deepseek, context);
+		const reasoning = reasoningItems(payload);
+		expect(reasoning).toHaveLength(1);
+		expect(reasoningTextOf(reasoning[0]!)).toBe("Inspect bar.ts before editing.");
+	});
+});


### PR DESCRIPTION
## Repro
Encoding a resumed conversation whose replayed `opencode-go/deepseek-v4-flash` assistant turn has no surviving thinking text makes the Responses encoder synthesize `content:[{"type":"reasoning_text","text":""}]`. opencode-go/DeepSeek rejects that empty payload exactly like a missing item — `400 The reasoning_text in the thinking mode must be passed back to the API`. Both a turn with only a text block (compaction dropped the reasoning) and a turn with an empty-text thinking block carrying an upstream `itemId` (the reporter's exact shape) reproduce it. Verified deterministically via `bun test packages/ai/test/issue-10690-repro.test.ts`.

## Cause
`convertResponsesAssistantMessage` in `packages/ai/src/providers/openai-shared.ts` collects carried thinking with `block.thinking.trim().length > 0`, then ships `carriedReasoningTexts.join("\n")` verbatim as the synthesized item's `reasoning_text`. When nothing survives reconstruction the join is `""`. This is the present-but-empty degenerate case of #8248: #8250 added the synthesizer but deliberately left the empty-text branch unvalidated against the live backend; this report is that validation.

## Fix
- Add `SYNTHETIC_REASONING_REPLAY_PLACEHOLDER` and substitute it for the synthesized `reasoning_text` only when the carried thinking text is empty; the surviving-text path is unchanged and the upstream reasoning-item id is still preferred.
- Kept out of `reasoning_content="."` territory, which DeepSeek rejects on the chat-completions path.
- Regression tests in `packages/ai/test/issue-10690-repro.test.ts` cover the no-thinking-block turn, the empty-text-thinking-block-with-upstream-id turn (driven through the encoder directly, since transform-messages drops empty-text thinking blocks), and the surviving-text precedence case.

## Verification
`bun test packages/ai/test/issue-10690-repro.test.ts packages/ai/test/issue-8248-repro.test.ts` → 8 pass. Full `packages/ai` suite: 4417 pass / 1 fail in `proxy.test.ts` (`normalizes hyphenated provider ids to underscores`), which passes in isolation — a pre-existing full-suite env-ordering artifact unrelated to this diff (this change touches only the reasoning synthesizer). Fixes #10690