### PR TITLE
fix(catalog): raise Cursor context windows to documented sizes

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -63,7 +63,7 @@
 
 ### Fixed
 
-- Raised Cursor context windows to Cursor's documented sizes (Grok 4.5/4.6 256k, Kimi K2.7 Code 262k, GPT-5.6 272k, Claude Opus 5 and Fable 300k by default) so compaction no longer fires too early, without lowering existing 1M Max-mode windows.
+- Raised Cursor context windows to Cursor's documented sizes (Grok 4.5/4.6 256k, default/Auto 256k, Kimi K2.7 Code 262k, GPT-5.6 272k, Claude Opus 5 and Fable 300k by default) so compaction no longer fires too early, without lowering existing 1M Max-mode windows.
 
 ## [18.1.6] - 2026-09-03
 

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -61,6 +61,10 @@
 
 - Fixed `omp models refresh` so revoked ChatGPT account tokens no longer prevent the remaining OpenAI Codex models from being discovered.
 
+### Fixed
+
+- Raised Cursor context windows to Cursor's documented sizes (Grok 4.5/4.6 256k, Kimi K2.7 Code 262k, GPT-5.6 272k, Claude Opus 5 and Fable 300k by default) so compaction no longer fires too early, without lowering existing 1M Max-mode windows.
+
 ## [18.1.6] - 2026-09-03
 
 ### Added

--- a/packages/catalog/src/compat/rules.json
+++ b/packages/catalog/src/compat/rules.json
@@ -7821,7 +7821,22 @@
 				}
 			},
 			{
-				"source": "providers/cursor.kdl:54",
+				"source": "providers/cursor.kdl:52",
+				"providers": [
+					"cursor"
+				],
+				"models": [
+					{
+						"kind": "exact",
+						"value": "default"
+					}
+				],
+				"catalog": {
+					"contextWindowFloor": 256000
+				}
+			},
+			{
+				"source": "providers/cursor.kdl:57",
 				"providers": [
 					"cursor"
 				],
@@ -7855,7 +7870,7 @@
 				}
 			},
 			{
-				"source": "providers/cursor.kdl:57",
+				"source": "providers/cursor.kdl:60",
 				"providers": [
 					"cursor"
 				],
@@ -7889,7 +7904,7 @@
 				}
 			},
 			{
-				"source": "providers/cursor.kdl:61",
+				"source": "providers/cursor.kdl:64",
 				"providers": [
 					"cursor"
 				],
@@ -7907,7 +7922,7 @@
 				}
 			},
 			{
-				"source": "providers/cursor.kdl:65",
+				"source": "providers/cursor.kdl:68",
 				"providers": [
 					"cursor"
 				],
@@ -7940,7 +7955,7 @@
 				}
 			},
 			{
-				"source": "providers/cursor.kdl:69",
+				"source": "providers/cursor.kdl:72",
 				"providers": [
 					"cursor"
 				],
@@ -7980,7 +7995,7 @@
 				}
 			},
 			{
-				"source": "providers/cursor.kdl:74",
+				"source": "providers/cursor.kdl:77",
 				"providers": [
 					"cursor"
 				],
@@ -7999,7 +8014,7 @@
 				}
 			},
 			{
-				"source": "providers/cursor.kdl:78",
+				"source": "providers/cursor.kdl:81",
 				"providers": [
 					"cursor"
 				],

--- a/packages/catalog/src/compat/rules.json
+++ b/packages/catalog/src/compat/rules.json
@@ -7705,11 +7705,33 @@
 				],
 				"family": "fable",
 				"catalog": {
-					"requiresCursorToolSchemaProjection": true
+					"requiresCursorToolSchemaProjection": true,
+					"contextWindowFloor": 300000
 				}
 			},
 			{
-				"source": "providers/cursor.kdl:14",
+				"source": "providers/cursor.kdl:12",
+				"class": "anthropic",
+				"providers": [
+					"cursor"
+				],
+				"family": "opus",
+				"revision": [
+					{
+						"op": ">=",
+						"revision": "5.0.0"
+					},
+					{
+						"op": "<",
+						"revision": "6.0.0"
+					}
+				],
+				"catalog": {
+					"contextWindowFloor": 300000
+				}
+			},
+			{
+				"source": "providers/cursor.kdl:23",
 				"class": "kimi",
 				"providers": [
 					"cursor"
@@ -7724,7 +7746,59 @@
 				}
 			},
 			{
-				"source": "providers/cursor.kdl:19",
+				"source": "providers/cursor.kdl:27",
+				"class": "kimi",
+				"providers": [
+					"cursor"
+				],
+				"family": "k2.7-code",
+				"catalog": {
+					"contextWindowFloor": 262000
+				}
+			},
+			{
+				"source": "providers/cursor.kdl:34",
+				"class": "xai",
+				"providers": [
+					"cursor"
+				],
+				"family": "grok",
+				"revision": [
+					{
+						"op": ">=",
+						"revision": "4.5.0"
+					},
+					{
+						"op": "<",
+						"revision": "4.7.0"
+					}
+				],
+				"catalog": {
+					"contextWindowFloor": 256000
+				}
+			},
+			{
+				"source": "providers/cursor.kdl:42",
+				"class": "openai",
+				"providers": [
+					"cursor"
+				],
+				"revision": [
+					{
+						"op": ">=",
+						"revision": "5.6.0"
+					},
+					{
+						"op": "<",
+						"revision": "5.7.0"
+					}
+				],
+				"catalog": {
+					"contextWindowFloor": 272000
+				}
+			},
+			{
+				"source": "providers/cursor.kdl:48",
 				"providers": [
 					"cursor"
 				],
@@ -7747,7 +7821,7 @@
 				}
 			},
 			{
-				"source": "providers/cursor.kdl:25",
+				"source": "providers/cursor.kdl:54",
 				"providers": [
 					"cursor"
 				],
@@ -7781,7 +7855,7 @@
 				}
 			},
 			{
-				"source": "providers/cursor.kdl:28",
+				"source": "providers/cursor.kdl:57",
 				"providers": [
 					"cursor"
 				],
@@ -7815,7 +7889,7 @@
 				}
 			},
 			{
-				"source": "providers/cursor.kdl:32",
+				"source": "providers/cursor.kdl:61",
 				"providers": [
 					"cursor"
 				],
@@ -7833,7 +7907,7 @@
 				}
 			},
 			{
-				"source": "providers/cursor.kdl:36",
+				"source": "providers/cursor.kdl:65",
 				"providers": [
 					"cursor"
 				],
@@ -7866,7 +7940,7 @@
 				}
 			},
 			{
-				"source": "providers/cursor.kdl:40",
+				"source": "providers/cursor.kdl:69",
 				"providers": [
 					"cursor"
 				],
@@ -7906,7 +7980,7 @@
 				}
 			},
 			{
-				"source": "providers/cursor.kdl:45",
+				"source": "providers/cursor.kdl:74",
 				"providers": [
 					"cursor"
 				],
@@ -7925,7 +7999,7 @@
 				}
 			},
 			{
-				"source": "providers/cursor.kdl:49",
+				"source": "providers/cursor.kdl:78",
 				"providers": [
 					"cursor"
 				],

--- a/packages/catalog/src/compat/rules/providers/cursor.kdl
+++ b/packages/catalog/src/compat/rules/providers/cursor.kdl
@@ -49,6 +49,9 @@ provider "cursor" {
 		input-modalities "text" "image"
 		context-window-floor 1000000
 	}
+	models "default" {
+		context-window-floor 256000
+	}
 	// Cursor-only families verified to accept selectedImages even though the
 	// roster carries no modality metadata.
 	models "cursor-grok-4" "cursor-grok-4.*" "cursor-grok-4-*" "cursor-grok-4:*" "cursor-grok-4_*" {

--- a/packages/catalog/src/compat/rules/providers/cursor.kdl
+++ b/packages/catalog/src/compat/rules/providers/cursor.kdl
@@ -5,6 +5,15 @@ provider "cursor" {
 	class "anthropic" {
 		family "fable" {
 			requires-cursor-tool-schema-projection #true
+			// Cursor advertised Context window 300k (Max 1M recovered elsewhere).
+			context-window-floor 300000
+		}
+		family "opus" {
+			revision ">=5 <6" {
+				// Cursor advertised Claude Opus 5 Context window 300k; Max 1M
+				// stays recovered on labeled/maxMode rows via Math.max.
+				context-window-floor 300000
+			}
 		}
 	}
 	// GetUsableModels advertises no input modalities or context windows.
@@ -14,6 +23,26 @@ provider "cursor" {
 		family "k3" {
 			input-modalities "text" "image"
 			context-window-floor 1000000
+		}
+		family "k2.7-code" {
+			// Cursor advertised Kimi K2.7 Code Context window 262k.
+			context-window-floor 262000
+		}
+	}
+	class "xai" {
+		family "grok" {
+			revision ">=4.5 <4.7" {
+				// Cursor advertised Grok 4.5/4.6 Context window 256k (product
+				// cap; not xAI native 500k). Max context is unmarked.
+				context-window-floor 256000
+			}
+		}
+	}
+	class "openai" {
+		revision ">=5.6 <5.7" {
+			// Cursor advertised GPT-5.6 Sol/Terra/Luna Context window 272k;
+			// raises unlabeled -fast variants from the 200k default.
+			context-window-floor 272000
 		}
 	}
 	models "k3" "*/k3" {

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -58646,7 +58646,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 200000,
+			"contextWindow": 256000,
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
 			"requiresGlyphTokenization": false,

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -58466,7 +58466,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 200000,
+			"contextWindow": 256000,
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
 			"thinking": {
@@ -58510,7 +58510,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 200000,
+			"contextWindow": 256000,
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
 			"thinking": {
@@ -58554,7 +58554,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 200000,
+			"contextWindow": 256000,
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
 			"thinking": {
@@ -58600,7 +58600,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 200000,
+			"contextWindow": 256000,
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
 			"thinking": {
@@ -60378,7 +60378,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 200000,
+			"contextWindow": 272000,
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
 			"requestModelId": "gpt-5.6-luna-none-fast",
@@ -60476,7 +60476,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 200000,
+			"contextWindow": 272000,
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
 			"requestModelId": "gpt-5.6-sol-none-fast",
@@ -60574,7 +60574,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 200000,
+			"contextWindow": 272000,
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
 			"requestModelId": "gpt-5.6-terra-none-fast",
@@ -60696,7 +60696,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 200000,
+			"contextWindow": 262000,
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
 			"thinking": {

--- a/packages/catalog/test/cursor-discovery.test.ts
+++ b/packages/catalog/test/cursor-discovery.test.ts
@@ -304,6 +304,7 @@ describe("fetchCursorUsableModels", () => {
 			models: [
 				create(ModelDetailsSchema, { modelId: "cursor-grok-4.6" }),
 				create(ModelDetailsSchema, { modelId: "cursor-grok-4.5" }),
+				create(ModelDetailsSchema, { modelId: "default" }),
 				create(ModelDetailsSchema, { modelId: "kimi-k2.7-code" }),
 				create(ModelDetailsSchema, { modelId: "gpt-5.6-sol-fast" }),
 				create(ModelDetailsSchema, { modelId: "claude-opus-5-preview" }),
@@ -320,6 +321,7 @@ describe("fetchCursorUsableModels", () => {
 			expect.objectContaining({ id: "claude-opus-5-preview", contextWindow: 200_000 }),
 			expect.objectContaining({ id: "cursor-grok-4.5", contextWindow: 256_000 }),
 			expect.objectContaining({ id: "cursor-grok-4.6", contextWindow: 256_000 }),
+			expect.objectContaining({ id: "default", contextWindow: 256_000 }),
 			expect.objectContaining({ id: "gpt-5.6-sol-fast", contextWindow: 272_000 }),
 			expect.objectContaining({ id: "gpt-5.6-sol-medium", contextWindow: 1_000_000 }),
 			expect.objectContaining({ id: "kimi-k2.7-code", contextWindow: 262_000 }),
@@ -331,6 +333,7 @@ describe("fetchCursorUsableModels", () => {
 			expect.objectContaining({ id: "claude-opus-5-preview", contextWindow: 300_000 }),
 			expect.objectContaining({ id: "cursor-grok-4.5", contextWindow: 256_000 }),
 			expect.objectContaining({ id: "cursor-grok-4.6", contextWindow: 256_000 }),
+			expect.objectContaining({ id: "default", contextWindow: 256_000 }),
 			expect.objectContaining({ id: "gpt-5.6-sol-fast", contextWindow: 272_000 }),
 			expect.objectContaining({ id: "gpt-5.6-sol-medium", contextWindow: 1_000_000 }),
 			expect.objectContaining({ id: "kimi-k2.7-code", contextWindow: 262_000 }),

--- a/packages/catalog/test/cursor-discovery.test.ts
+++ b/packages/catalog/test/cursor-discovery.test.ts
@@ -295,11 +295,11 @@ describe("fetchCursorUsableModels", () => {
 	});
 
 	it("raises documented Cursor context-window floors at buildModel time", async () => {
-		// GetUsableModels specs stay on the 200k discovery fallback (bundled
-		// refs for these ids are 200k). `providers/cursor.kdl`
-		// context-window-floor applies once the spec is built. Opus/fable
-		// use unbundled preview ids so the 300k floor is not masked by a 1M
-		// bundled reference. A labeled gpt-5.6 row stays at 1M.
+		// Discovered models that match bundled references receive the
+		// reference's contextWindow (256k Grok, 262k Kimi, 272k GPT-5.6).
+		// Unbundled preview ids stay on the 200k discovery fallback, then
+		// `providers/cursor.kdl` context-window-floor applies once the spec
+		// is built. A labeled gpt-5.6 row stays at 1M.
 		const response = create(GetUsableModelsResponseSchema, {
 			models: [
 				create(ModelDetailsSchema, { modelId: "cursor-grok-4.6" }),
@@ -318,11 +318,11 @@ describe("fetchCursorUsableModels", () => {
 		expect(models).toEqual([
 			expect.objectContaining({ id: "claude-fable-5-preview", contextWindow: 200_000 }),
 			expect.objectContaining({ id: "claude-opus-5-preview", contextWindow: 200_000 }),
-			expect.objectContaining({ id: "cursor-grok-4.5", contextWindow: 200_000 }),
-			expect.objectContaining({ id: "cursor-grok-4.6", contextWindow: 200_000 }),
-			expect.objectContaining({ id: "gpt-5.6-sol-fast", contextWindow: 200_000 }),
+			expect.objectContaining({ id: "cursor-grok-4.5", contextWindow: 256_000 }),
+			expect.objectContaining({ id: "cursor-grok-4.6", contextWindow: 256_000 }),
+			expect.objectContaining({ id: "gpt-5.6-sol-fast", contextWindow: 272_000 }),
 			expect.objectContaining({ id: "gpt-5.6-sol-medium", contextWindow: 1_000_000 }),
-			expect.objectContaining({ id: "kimi-k2.7-code", contextWindow: 200_000 }),
+			expect.objectContaining({ id: "kimi-k2.7-code", contextWindow: 262_000 }),
 		]);
 
 		const built = models?.map(model => buildModel(model));

--- a/packages/catalog/test/cursor-discovery.test.ts
+++ b/packages/catalog/test/cursor-discovery.test.ts
@@ -294,6 +294,49 @@ describe("fetchCursorUsableModels", () => {
 		]);
 	});
 
+	it("raises documented Cursor context-window floors at buildModel time", async () => {
+		// GetUsableModels specs stay on the 200k discovery fallback (bundled
+		// refs for these ids are 200k). `providers/cursor.kdl`
+		// context-window-floor applies once the spec is built. Opus/fable
+		// use unbundled preview ids so the 300k floor is not masked by a 1M
+		// bundled reference. A labeled gpt-5.6 row stays at 1M.
+		const response = create(GetUsableModelsResponseSchema, {
+			models: [
+				create(ModelDetailsSchema, { modelId: "cursor-grok-4.6" }),
+				create(ModelDetailsSchema, { modelId: "cursor-grok-4.5" }),
+				create(ModelDetailsSchema, { modelId: "kimi-k2.7-code" }),
+				create(ModelDetailsSchema, { modelId: "gpt-5.6-sol-fast" }),
+				create(ModelDetailsSchema, { modelId: "claude-opus-5-preview" }),
+				create(ModelDetailsSchema, { modelId: "claude-fable-5-preview" }),
+				create(ModelDetailsSchema, { modelId: "gpt-5.6-sol-medium", displayName: "GPT-5.6 Sol 1M" }),
+			],
+		});
+		const floorBaseUrl = await startCursorDiscoveryServer(toBinary(GetUsableModelsResponseSchema, response));
+
+		const models = await fetchCursorUsableModels({ apiKey: "test-token", baseUrl: floorBaseUrl, timeoutMs: 1_000 });
+
+		expect(models).toEqual([
+			expect.objectContaining({ id: "claude-fable-5-preview", contextWindow: 200_000 }),
+			expect.objectContaining({ id: "claude-opus-5-preview", contextWindow: 200_000 }),
+			expect.objectContaining({ id: "cursor-grok-4.5", contextWindow: 200_000 }),
+			expect.objectContaining({ id: "cursor-grok-4.6", contextWindow: 200_000 }),
+			expect.objectContaining({ id: "gpt-5.6-sol-fast", contextWindow: 200_000 }),
+			expect.objectContaining({ id: "gpt-5.6-sol-medium", contextWindow: 1_000_000 }),
+			expect.objectContaining({ id: "kimi-k2.7-code", contextWindow: 200_000 }),
+		]);
+
+		const built = models?.map(model => buildModel(model));
+		expect(built).toEqual([
+			expect.objectContaining({ id: "claude-fable-5-preview", contextWindow: 300_000 }),
+			expect.objectContaining({ id: "claude-opus-5-preview", contextWindow: 300_000 }),
+			expect.objectContaining({ id: "cursor-grok-4.5", contextWindow: 256_000 }),
+			expect.objectContaining({ id: "cursor-grok-4.6", contextWindow: 256_000 }),
+			expect.objectContaining({ id: "gpt-5.6-sol-fast", contextWindow: 272_000 }),
+			expect.objectContaining({ id: "gpt-5.6-sol-medium", contextWindow: 1_000_000 }),
+			expect.objectContaining({ id: "kimi-k2.7-code", contextWindow: 262_000 }),
+		]);
+	});
+
 	it("keeps the default window below the GLM 5.2 floor and outside the coding variants", async () => {
 		const response = create(GetUsableModelsResponseSchema, {
 			models: [

--- a/packages/catalog/test/generated-policies.test.ts
+++ b/packages/catalog/test/generated-policies.test.ts
@@ -458,6 +458,7 @@ describe("generated model policies", () => {
 		const windows: Array<[string, number]> = [
 			["cursor-grok-4.5", 256_000],
 			["cursor-grok-4.6", 256_000],
+			["default", 256_000],
 			["kimi-k2.7-code", 262_000],
 			["claude-opus-5-preview", 300_000],
 			["claude-fable-5-preview", 300_000],
@@ -489,6 +490,7 @@ describe("generated model policies", () => {
 		const windows: Array<[string, number]> = [
 			["cursor-grok-4.5", 256_000],
 			["cursor-grok-4.6", 256_000],
+			["default", 256_000],
 			["kimi-k2.7-code", 262_000],
 			["gpt-5.6-sol-fast", 272_000],
 		];
@@ -501,6 +503,7 @@ describe("generated model policies", () => {
 		const windows: Array<[string, number]> = [
 			["cursor-grok-4.5", 256_000],
 			["cursor-grok-4.6", 256_000],
+			["default", 256_000],
 			["kimi-k2.7-code", 262_000],
 			["gpt-5.6-sol-fast", 272_000],
 		];

--- a/packages/catalog/test/generated-policies.test.ts
+++ b/packages/catalog/test/generated-policies.test.ts
@@ -8,6 +8,9 @@ import {
 	linkOpenAIPromotionTargets,
 } from "../scripts/generated-policies";
 import { buildModel } from "../src/build";
+import { resolveProviderModels } from "../src/model-manager";
+import { getBundledModel } from "../src/models";
+import { cursorModelManagerOptions } from "../src/provider-models/special";
 
 function createSpec<TApi extends Api>(overrides: {
 	id: string;
@@ -480,6 +483,31 @@ describe("generated model policies", () => {
 				}),
 			).contextWindow,
 		).toBe(1_000_000);
+	});
+
+	it("ships documented Cursor context windows in the bundled catalog", () => {
+		const windows: Array<[string, number]> = [
+			["cursor-grok-4.5", 256_000],
+			["cursor-grok-4.6", 256_000],
+			["kimi-k2.7-code", 262_000],
+			["gpt-5.6-sol-fast", 272_000],
+		];
+		for (const [id, contextWindow] of windows) {
+			expect(getBundledModel("cursor", id)?.contextWindow).toBe(contextWindow);
+		}
+	});
+
+	it("resolves documented Cursor context windows offline", async () => {
+		const windows: Array<[string, number]> = [
+			["cursor-grok-4.5", 256_000],
+			["cursor-grok-4.6", 256_000],
+			["kimi-k2.7-code", 262_000],
+			["gpt-5.6-sol-fast", 272_000],
+		];
+		const resolved = await resolveProviderModels(cursorModelManagerOptions(), "offline");
+		for (const [id, contextWindow] of windows) {
+			expect(resolved.models.find(model => model.id === id)?.contextWindow).toBe(contextWindow);
+		}
 	});
 
 	it("pins MiniMax-M3 long-context providers to 1M context", () => {

--- a/packages/catalog/test/generated-policies.test.ts
+++ b/packages/catalog/test/generated-policies.test.ts
@@ -449,6 +449,39 @@ describe("generated model policies", () => {
 		}
 	});
 
+	it("applies documented Cursor context-window floors at build time", () => {
+		// Rule-owned (`providers/cursor.kdl` context-window-floor): baked at
+		// build time. createSpec defaults to the 200k discovery fallback.
+		const windows: Array<[string, number]> = [
+			["cursor-grok-4.5", 256_000],
+			["cursor-grok-4.6", 256_000],
+			["kimi-k2.7-code", 262_000],
+			["claude-opus-5-preview", 300_000],
+			["claude-fable-5-preview", 300_000],
+			["gpt-5.6-sol-fast", 272_000],
+			["kimi-k3-max", 1_000_000],
+			["composer-2.5", 200_000],
+			["cursor-grok-5", 200_000],
+			["k3-256k", 200_000],
+		];
+		for (const [id, contextWindow] of windows) {
+			expect(buildGenerated(createSpec({ id, api: "cursor-agent", provider: "cursor" })).contextWindow).toBe(
+				contextWindow,
+			);
+		}
+
+		expect(
+			buildGenerated(
+				createSpec({
+					id: "cursor-grok-4.6",
+					api: "cursor-agent",
+					provider: "cursor",
+					contextWindow: 1_000_000,
+				}),
+			).contextWindow,
+		).toBe(1_000_000);
+	});
+
 	it("pins MiniMax-M3 long-context providers to 1M context", () => {
 		const models = [
 			createSpec({


### PR DESCRIPTION
## Summary

Aligns Cursor provider context-window floors with Cursor's public documentation (https://cursor.com/docs/models-and-pricing):

- **Grok 4.5 / 4.6**: Raised from the default 200k fallback to **256k** (`context-window-floor 256000`).
- **Kimi K2.7 Code**: Raised from 200k to **262k** (`context-window-floor 262000`).
- **GPT-5.6 (Sol / Terra / Luna)**: Raised from 200k to **272k** (`context-window-floor 272000`), ensuring unlabeled `-fast` variants do not fall back to 200k.
- **Claude Opus 5 & Claude Fable**: Raised baseline default from 200k to **300k** (`context-window-floor 300000`). Existing 1M Max-mode / labeled rows remain preserved via `Math.max`.

`GetUsableModels` carries no context-window field, so Cursor models without 1M signals previously fell back to the 200k default, triggering premature auto-compaction.

## Verification

- `bun run gen:compat` regenerated `packages/catalog/src/compat/rules.json`.
- `bun test packages/catalog` passed (871 tests across 104 files).
- Added regression tests in `packages/catalog/test/cursor-discovery.test.ts` and `packages/catalog/test/generated-policies.test.ts`.