### PR TITLE
feat(coding-agent): unify primary and retry fallbacks in one reorder set

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -32,6 +32,9 @@
 ### Changed
 
 - Agent delegation is now model-aware, allowing some models to favor focused inline work instead of spawning subagents.
+### Changed
+
+- The `/models` roles view now treats a role's primary model and its retry fallbacks as one reorder set: `]` on the primary demotes it into the chain and `[` on the first fallback promotes it to primary. `[`/`]` on a role no longer reorder the quick-switch cycle; use shift+↑/↓ for that.
 
 ### Fixed
 

--- a/packages/coding-agent/src/modes/components/model-hub.ts
+++ b/packages/coding-agent/src/modes/components/model-hub.ts
@@ -28,7 +28,13 @@ import {
 	visibleWidth,
 } from "@oh-my-pi/pi-tui";
 import type { ModelRegistry } from "../../config/model-registry";
-import { type ModelRoleLookup, type ResolvedModelRoleValue, resolveModelRoleValue } from "../../config/model-resolver";
+import {
+	type ModelRoleLookup,
+	type ResolvedModelRoleValue,
+	parseModelString,
+	resolveExplicitModelRole,
+	resolveModelRoleValue,
+} from "../../config/model-resolver";
 import { getKnownRoleIds, getRoleInfo } from "../../config/model-roles";
 import type { Settings } from "../../config/settings";
 import { AUTO_THINKING, type ConfiguredThinkingLevel, getConfiguredThinkingLevelMetadata } from "../../thinking";
@@ -1139,8 +1145,127 @@ export class ModelHubComponent implements Component {
 		this.#roleIndex = Math.min(this.#roleIndex, Math.max(0, this.#rolesRows.length - 1));
 	}
 
-	/** Move a chain entry one slot earlier/later; the cursor follows the moved entry. */
+	/** Effective persisted primary for `role` plus the scope a rewrite belongs in. */
+	#effectivePrimary(role: string): { value: string | undefined; scope: ModelRoleSelectionScope | undefined } {
+		if (this.#settings.get("modelRoleStorage") === "project") {
+			const source = this.#settings.getModelRoleSource(role);
+			if (source === "project") return { value: this.#settings.getProjectModelRole(role), scope: "project" };
+			if (source === "global") return { value: this.#settings.getGlobalModelRole(role), scope: "global" };
+			return { value: undefined, scope: undefined };
+		}
+		return { value: this.#settings.getModelRole(role), scope: undefined };
+	}
+
+	#hasLiteralModel(provider: string, id: string): boolean {
+		const selector = `${provider}/${id}`;
+		if (this.#availableItems.some(item => item.selector === selector)) return true;
+		const registry = this.#registry as unknown as { find?: (provider: string, id: string) => Model | undefined };
+		if (typeof registry.find === "function") {
+			try {
+				if (registry.find(provider, id) !== undefined) return true;
+			} catch {
+				// Fall through to the snapshot scan below.
+			}
+		}
+		try {
+			return this.#registry.getAll().some(model => model.provider === provider && model.id === id);
+		} catch {
+			return false;
+		}
+	}
+
+	#parseSimpleSelector(value: string): { base: string; level: ConfiguredThinkingLevel | undefined } | undefined {
+		const trimmed = value.trim();
+		if (!trimmed || trimmed.includes(",") || trimmed.includes("*") || trimmed.includes("@")) return undefined;
+		// Legacy `pi/<role>` aliases share the provider/id shape, so only a
+		// value that actually resolves as a role alias refuses the move. A
+		// custom provider literally named `pi` still crosses the boundary.
+		if (resolveExplicitModelRole(trimmed, this.#settings) !== undefined) return undefined;
+		const parsed = parseModelString(trimmed, {
+			allowMaxSuffix: true,
+			allowAutoAlias: true,
+			isLiteralModelId: (provider, id) => this.#hasLiteralModel(provider, id),
+		});
+		if (!parsed) return undefined;
+		return { base: `${parsed.provider}/${parsed.id}`, level: parsed.thinkingLevel };
+	}
+	#findModelForBase(base: string): Model | undefined {
+		const slash = base.indexOf("/");
+		if (slash <= 0) return undefined;
+		const provider = base.slice(0, slash);
+		const id = base.slice(slash + 1);
+		if (!provider || !id) return undefined;
+		const registry = this.#registry as unknown as { find?: (provider: string, id: string) => Model | undefined };
+		if (typeof registry.find === "function") {
+			try {
+				const found = registry.find(provider, id);
+				if (found) return found;
+			} catch {
+				// Fall through to the snapshot scans below.
+			}
+		}
+		try {
+			for (const model of this.#registry.getAll()) {
+				if (model.provider === provider && model.id === id) return model;
+			}
+		} catch {
+			// Fall through to the browser snapshot below.
+		}
+		return this.#availableItems.find(item => item.selector === base)?.model;
+	}
+
+	/**
+	 * Exchange `role`'s primary with its first fallback entry. Promoting out of
+	 * an auto-selected role drops the chain head into the primary slot with no
+	 * demotion. The promoted model must be currently available: the primary
+	 * write can fail asynchronously (the live default role switches the
+	 * session), and the chain must not move under a rejected primary.
+	 * Returns true when both callbacks ran.
+	 */
+	#swapPrimaryWithFirstFallback(role: string): boolean {
+		if (role.includes("/")) return false;
+		const chain = [...(this.#fallbackChains()[role] ?? [])];
+		if (chain.length === 0) return false;
+		const primary = this.#effectivePrimary(role);
+		if (primary.value !== undefined && !this.#parseSimpleSelector(primary.value)) return false;
+		const newPrimaryRaw = chain[0];
+		if (newPrimaryRaw === undefined) return false;
+		const parsed = this.#parseSimpleSelector(newPrimaryRaw);
+		if (!parsed) return false;
+		const model = this.#findModelForBase(parsed.base);
+		if (!model) return false;
+		// Gate on the resolved model, not the raw spelling: chain entries may
+		// use alias spellings (collapsed variants, dotted revisions, routed
+		// references) that resolve to a differently spelled available model.
+		if (
+			!this.#availableItems.some(
+				item => item.model === model || (item.model.provider === model.provider && item.model.id === model.id),
+			)
+		)
+			return false;
+		const newChain = primary.value === undefined ? chain.slice(1) : [primary.value, ...chain.slice(1)];
+		this.#callbacks.onAssign(model, role, parsed.level ?? ThinkingLevel.Inherit, parsed.base, primary.scope);
+		this.#setFallbackChain(role, newChain);
+		return true;
+	}
+
+	/** Move `role`'s primary one slot later; the cursor follows the demoted model. */
+	#moveRoleModel(role: string, delta: -1 | 1): void {
+		if (delta < 0 || role.includes("/")) return;
+		const hadPrimary = this.#effectivePrimary(role).value !== undefined;
+		if (!this.#swapPrimaryWithFirstFallback(role)) return;
+		this.#roleIndex += hadPrimary ? 1 : 0;
+	}
+
+	/**
+	 * Move a chain entry one slot earlier/later; crossing the top promotes the
+	 * entry to primary. The cursor follows the moved entry.
+	 */
 	#moveFallback(row: { role: string; chainIndex: number }, delta: -1 | 1): void {
+		if (!row.role.includes("/") && row.chainIndex === 0 && delta === -1) {
+			if (this.#swapPrimaryWithFirstFallback(row.role)) this.#roleIndex -= 1;
+			return;
+		}
 		const chain = [...(this.#fallbackChains()[row.role] ?? [])];
 		const target = row.chainIndex + delta;
 		if (row.chainIndex >= chain.length || target < 0 || target >= chain.length) return;
@@ -1449,8 +1574,9 @@ export class ModelHubComponent implements Component {
 			else if (row?.kind === "chainKey") this.#setFallbackChain(row.role, []);
 			return;
 		}
-		// Reordering: [ / shift+↑ moves the row earlier, ] / shift+↓ later —
-		// cycle order on a role row, chain order on a fallback row.
+		// Reordering: brackets walk the role's model order (primary plus
+		// fallbacks as one set; the primary cannot move earlier). Shift+arrows
+		// walk the quick-switch cycle on a role row, the model order below it.
 		if (matchesKey(data, "shift+up")) {
 			if (role) this.#moveCycleMembership(role, -1);
 			else if (row?.kind === "fallback") this.#moveFallback(row, -1);
@@ -1480,12 +1606,12 @@ export class ModelHubComponent implements Component {
 			return;
 		}
 		if (printable === "[") {
-			if (role) this.#moveCycleMembership(role, -1);
+			if (role) this.#moveRoleModel(role, -1);
 			else if (row?.kind === "fallback") this.#moveFallback(row, -1);
 			return;
 		}
 		if (printable === "]") {
-			if (role) this.#moveCycleMembership(role, 1);
+			if (role) this.#moveRoleModel(role, 1);
 			else if (row?.kind === "fallback") this.#moveFallback(row, 1);
 			return;
 		}
@@ -2017,7 +2143,7 @@ export class ModelHubComponent implements Component {
 			if (row?.kind === "newFallback") {
 				return "↑/↓ rows · Enter new model/provider fallback chain · ← providers";
 			}
-			return "↑/↓ rows · Enter pick · f fallback · x clear · t thinking · c cycle · [/] reorder · n new";
+			return "↑/↓ rows · Enter pick · f fallback · x clear · t thinking · c cycle · [/] models · shift+↑/↓ cycle · n new";
 		}
 		if (entry.kind === "provider" && entry.locked) {
 			return entry.oauth ? "Enter log in · ↑/↓ providers · Esc close" : "↑/↓ providers · Esc close";

--- a/packages/coding-agent/src/modes/components/model-hub.ts
+++ b/packages/coding-agent/src/modes/components/model-hub.ts
@@ -1155,23 +1155,11 @@ export class ModelHubComponent implements Component {
 		}
 		return { value: this.#settings.getModelRole(role), scope: undefined };
 	}
-
 	#hasLiteralModel(provider: string, id: string): boolean {
 		const selector = `${provider}/${id}`;
 		if (this.#availableItems.some(item => item.selector === selector)) return true;
-		const registry = this.#registry as unknown as { find?: (provider: string, id: string) => Model | undefined };
-		if (typeof registry.find === "function") {
-			try {
-				if (registry.find(provider, id) !== undefined) return true;
-			} catch {
-				// Fall through to the snapshot scan below.
-			}
-		}
-		try {
-			return this.#registry.getAll().some(model => model.provider === provider && model.id === id);
-		} catch {
-			return false;
-		}
+		if (this.#registry.find(provider, id) !== undefined) return true;
+		return this.#registry.getAll().some(model => model.provider === provider && model.id === id);
 	}
 
 	#parseSimpleSelector(value: string): { base: string; level: ConfiguredThinkingLevel | undefined } | undefined {
@@ -1195,23 +1183,11 @@ export class ModelHubComponent implements Component {
 		const provider = base.slice(0, slash);
 		const id = base.slice(slash + 1);
 		if (!provider || !id) return undefined;
-		const registry = this.#registry as unknown as { find?: (provider: string, id: string) => Model | undefined };
-		if (typeof registry.find === "function") {
-			try {
-				const found = registry.find(provider, id);
-				if (found) return found;
-			} catch {
-				// Fall through to the snapshot scans below.
-			}
-		}
-		try {
-			for (const model of this.#registry.getAll()) {
-				if (model.provider === provider && model.id === id) return model;
-			}
-		} catch {
-			// Fall through to the browser snapshot below.
-		}
-		return this.#availableItems.find(item => item.selector === base)?.model;
+		return (
+			this.#registry.find(provider, id) ??
+			this.#registry.getAll().find(model => model.provider === provider && model.id === id) ??
+			this.#availableItems.find(item => item.selector === base)?.model
+		);
 	}
 
 	/**

--- a/packages/coding-agent/test/model-hub.test.ts
+++ b/packages/coding-agent/test/model-hub.test.ts
@@ -72,7 +72,8 @@ function makeRegistry(models: () => Model[], overrides: RegistryOverrides = {}):
 		getDiscoverableProviders: overrides.getDiscoverableProviders ?? (() => []),
 		getProviderDiscoveryState: overrides.getProviderDiscoveryState ?? (() => undefined),
 		authStorage: { hasAuth: () => false },
-		...(overrides.find ? { find: overrides.find } : {}),
+		find:
+			overrides.find ?? ((provider, id) => models().find(model => model.provider === provider && model.id === id)),
 	} as unknown as ModelRegistry;
 }
 

--- a/packages/coding-agent/test/model-hub.test.ts
+++ b/packages/coding-agent/test/model-hub.test.ts
@@ -7,6 +7,7 @@ import { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import type { Model } from "@oh-my-pi/pi-ai";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { formatModelSelectorValue } from "@oh-my-pi/pi-coding-agent/config/model-resolver";
 import type { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import {
@@ -16,7 +17,7 @@ import {
 	resetProviderAutoRefreshGuard,
 } from "@oh-my-pi/pi-coding-agent/modes/components/model-hub";
 import { getThemeByName, setThemeInstance, theme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
-import { AUTO_THINKING } from "@oh-my-pi/pi-coding-agent/thinking";
+import { AUTO_THINKING, type ConfiguredThinkingLevel } from "@oh-my-pi/pi-coding-agent/thinking";
 import type { TUI } from "@oh-my-pi/pi-tui";
 
 function normalize(lines: readonly string[]): string {
@@ -59,8 +60,8 @@ interface RegistryOverrides {
 	getAll?: () => Model[];
 	getDiscoverableProviders?: () => string[];
 	getProviderDiscoveryState?: (providerId: string) => unknown;
+	find?: (provider: string, id: string) => Model | undefined;
 }
-
 function makeRegistry(models: () => Model[], overrides: RegistryOverrides = {}): ModelRegistry {
 	return {
 		refresh: overrides.refresh ?? (async () => {}),
@@ -71,6 +72,7 @@ function makeRegistry(models: () => Model[], overrides: RegistryOverrides = {}):
 		getDiscoverableProviders: overrides.getDiscoverableProviders ?? (() => []),
 		getProviderDiscoveryState: overrides.getProviderDiscoveryState ?? (() => undefined),
 		authStorage: { hasAuth: () => false },
+		...(overrides.find ? { find: overrides.find } : {}),
 	} as unknown as ModelRegistry;
 }
 
@@ -136,6 +138,8 @@ const DOWN = "\x1b[B";
 const UP = "\x1b[A";
 const LEFT = "\x1b[D";
 const ESC = "\x1b";
+const SHIFT_UP = "\x1b[1;2A";
+const SHIFT_DOWN = "\x1b[1;2B";
 
 describe("ModelHub", () => {
 	beforeAll(async () => {
@@ -393,7 +397,7 @@ describe("ModelHub", () => {
 	});
 
 	describe("quick-switch cycle and custom roles", () => {
-		test("c toggles cycle membership, [ reorders, and the preview tracks the order", () => {
+		test("c toggles cycle membership, shift+↑ reorders, and the preview tracks the order", () => {
 			const model = makeModel("test", "cycle-model");
 			const settings = Settings.isolated({});
 			const changes: string[][] = [];
@@ -419,8 +423,8 @@ describe("ModelHub", () => {
 			// …c again re-appends it at the end…
 			hub.handleInput("c");
 			expect(changes[1]).toEqual(["smol", "slow", "default"]);
-			// …and [ moves it one slot earlier.
-			hub.handleInput("[");
+			// …and shift+↑ moves it one slot earlier.
+			hub.handleInput(SHIFT_UP);
 			expect(changes[2]).toEqual(["smol", "default", "slow"]);
 
 			// The preview line renders the resulting ctrl+p track in order.
@@ -830,6 +834,298 @@ describe("ModelHub", () => {
 			// Cursor followed the moved entry: x removes model-a, not model-b.
 			hub.handleInput("x");
 			expect(onFallbackChainChange).toHaveBeenLastCalledWith("default", ["test/model-b"]);
+		});
+		test("] on a role demotes the primary into the chain and promotes the first fallback", () => {
+			const a = makeModel("test", "model-a");
+			const b = makeModel("test", "model-b");
+			const c = makeModel("test", "model-c");
+			const settings = Settings.isolated({
+				modelRoles: { default: "test/model-a" },
+				"retry.fallbackChains": { default: ["test/model-b", "test/model-c"] },
+			});
+			const onAssign = vi.fn(
+				(model: Model, role: string, thinkingLevel: ConfiguredThinkingLevel | undefined, selector: string) => {
+					settings.setModelRole(role, formatModelSelectorValue(selector, thinkingLevel));
+				},
+			);
+			const { hub, onFallbackChainChange } = createHub({
+				models: [a, b, c],
+				scoped: true,
+				settings,
+				callbacks: { onAssign },
+			});
+
+			enterRolesView(hub);
+			hub.handleInput("]"); // primary model-a trades places with fallback model-b
+			expect(onAssign).toHaveBeenCalledTimes(1);
+			expect(onAssign.mock.calls[0]?.[0]).toBe(b);
+			expect(onAssign.mock.calls[0]?.[1]).toBe("default");
+			expect(onAssign.mock.calls[0]?.[2]).toBe(ThinkingLevel.Inherit);
+			expect(onAssign.mock.calls[0]?.[3]).toBe("test/model-b");
+			expect(onFallbackChainChange).toHaveBeenLastCalledWith("default", ["test/model-a", "test/model-c"]);
+
+			// Cursor followed the demoted primary: x removes model-a, not model-b.
+			hub.handleInput("x");
+			expect(onFallbackChainChange).toHaveBeenLastCalledWith("default", ["test/model-c"]);
+		});
+
+		test("[ on the first fallback promotes it to primary", () => {
+			const a = makeModel("test", "model-a");
+			const b = makeModel("test", "model-b");
+			const c = makeModel("test", "model-c");
+			const settings = Settings.isolated({
+				modelRoles: { default: "test/model-a" },
+				"retry.fallbackChains": { default: ["test/model-b", "test/model-c"] },
+			});
+			const onAssign = vi.fn(
+				(model: Model, role: string, thinkingLevel: ConfiguredThinkingLevel | undefined, selector: string) => {
+					settings.setModelRole(role, formatModelSelectorValue(selector, thinkingLevel));
+				},
+			);
+			const { hub, onFallbackChainChange } = createHub({
+				models: [a, b, c],
+				scoped: true,
+				settings,
+				callbacks: { onAssign },
+			});
+
+			enterRolesView(hub);
+			hub.handleInput(DOWN); // first chain entry (model-b)
+			hub.handleInput("[");
+			expect(onAssign).toHaveBeenCalledTimes(1);
+			expect(onAssign.mock.calls[0]?.[0]).toBe(b);
+			expect(onAssign.mock.calls[0]?.[3]).toBe("test/model-b");
+			expect(onFallbackChainChange).toHaveBeenLastCalledWith("default", ["test/model-a", "test/model-c"]);
+
+			// Cursor followed the promoted entry back to the role row.
+			expect(footerLine(hub.render(220))).toContain("Enter pick");
+		});
+
+		test("reorder carries each model's thinking level across the primary boundary", () => {
+			const a = makeModel("test", "model-a");
+			const b = makeModel("test", "model-b");
+			const settings = Settings.isolated({
+				modelRoles: { default: "test/model-a:low" },
+				"retry.fallbackChains": { default: ["test/model-b"] },
+			});
+			const onAssign = vi.fn(
+				(model: Model, role: string, thinkingLevel: ConfiguredThinkingLevel | undefined, selector: string) => {
+					settings.setModelRole(role, formatModelSelectorValue(selector, thinkingLevel));
+				},
+			);
+			const { hub, onFallbackChainChange } = createHub({
+				models: [a, b],
+				scoped: true,
+				settings,
+				callbacks: { onAssign },
+			});
+
+			enterRolesView(hub);
+			hub.handleInput("]");
+			expect(onAssign.mock.calls[0]?.[0]).toBe(b);
+			expect(onAssign.mock.calls[0]?.[2]).toBe(ThinkingLevel.Inherit);
+			expect(onFallbackChainChange).toHaveBeenLastCalledWith("default", ["test/model-a:low"]);
+		});
+
+		test("] on an auto-selected role promotes the first fallback with no demotion", () => {
+			const a = makeModel("test", "model-a");
+			const b = makeModel("test", "model-b");
+			const settings = Settings.isolated({
+				"retry.fallbackChains": { default: ["test/model-a", "test/model-b"] },
+			});
+			const onAssign = vi.fn(
+				(model: Model, role: string, thinkingLevel: ConfiguredThinkingLevel | undefined, selector: string) => {
+					settings.setModelRole(role, formatModelSelectorValue(selector, thinkingLevel));
+				},
+			);
+			const { hub, onFallbackChainChange } = createHub({
+				models: [a, b],
+				scoped: true,
+				settings,
+				callbacks: { onAssign },
+			});
+
+			enterRolesView(hub);
+			hub.handleInput("]");
+			expect(onAssign).toHaveBeenCalledTimes(1);
+			expect(onAssign.mock.calls[0]?.[0]).toBe(a);
+			expect(onAssign.mock.calls[0]?.[3]).toBe("test/model-a");
+			expect(onFallbackChainChange).toHaveBeenLastCalledWith("default", ["test/model-b"]);
+		});
+
+		test("complex primaries refuse the cross-boundary move instead of overwriting config", () => {
+			const a = makeModel("test", "model-a");
+			const b = makeModel("test", "model-b");
+			const settings = Settings.isolated({
+				modelRoles: { default: "test/model-a,test/model-b" },
+				"retry.fallbackChains": { default: ["test/model-b"] },
+			});
+			const { hub, onAssign, onFallbackChainChange } = createHub({
+				models: [a, b],
+				scoped: true,
+				settings,
+			});
+
+			enterRolesView(hub);
+			hub.handleInput("]"); // role row: complex primary stays put
+			expect(onAssign).not.toHaveBeenCalled();
+			expect(onFallbackChainChange).not.toHaveBeenCalled();
+
+			hub.handleInput(DOWN); // first chain entry
+			hub.handleInput("["); // promote past a complex primary also refuses
+			expect(onAssign).not.toHaveBeenCalled();
+			expect(onFallbackChainChange).not.toHaveBeenCalled();
+		});
+		test("legacy pi/ alias primaries refuse the cross-boundary move", () => {
+			const a = makeModel("test", "model-a");
+			const b = makeModel("test", "model-b");
+			const settings = Settings.isolated({
+				modelRoles: { default: "pi/smol", smol: "test/model-a" },
+				"retry.fallbackChains": { default: ["test/model-b"] },
+			});
+			const { hub, onAssign, onFallbackChainChange } = createHub({
+				models: [a, b],
+				scoped: true,
+				settings,
+			});
+
+			enterRolesView(hub);
+			hub.handleInput("]"); // role row: the alias stays put, nothing demotes into the chain
+			expect(onAssign).not.toHaveBeenCalled();
+			expect(onFallbackChainChange).not.toHaveBeenCalled();
+			expect(settings.getModelRole("default")).toBe("pi/smol");
+		});
+
+		test("unavailable fallback models refuse promotion instead of moving the chain", () => {
+			const a = makeModel("test", "model-a");
+			const b = makeModel("test", "model-b");
+			const settings = Settings.isolated({
+				modelRoles: { default: "test/model-a" },
+				"retry.fallbackChains": { default: ["test/model-b"] },
+			});
+			const { hub, onAssign, onFallbackChainChange } = createHub({
+				models: [a, b],
+				settings,
+				registry: { getAvailable: () => [a] },
+			});
+
+			enterRolesView(hub);
+			hub.handleInput("]");
+			expect(onAssign).not.toHaveBeenCalled();
+			expect(onFallbackChainChange).not.toHaveBeenCalled();
+		});
+
+		test("scoped literal :max ids promote as literal models, not thinking levels", () => {
+			const a = makeModel("test", "model-a");
+			const literalMax = makeModel("test", "model:max");
+			const settings = Settings.isolated({
+				modelRoles: { default: "test/model-a" },
+				"retry.fallbackChains": { default: ["test/model:max"] },
+			});
+			const onAssign = vi.fn(
+				(model: Model, role: string, thinkingLevel: ConfiguredThinkingLevel | undefined, selector: string) => {
+					settings.setModelRole(role, formatModelSelectorValue(selector, thinkingLevel));
+				},
+			);
+			const { hub, onFallbackChainChange } = createHub({
+				models: [a, literalMax],
+				scoped: true,
+				settings,
+				registry: { getAll: () => [a] },
+				callbacks: { onAssign },
+			});
+
+			enterRolesView(hub);
+			hub.handleInput("]");
+			expect(onAssign).toHaveBeenCalledTimes(1);
+			expect(onAssign.mock.calls[0]?.[0]).toBe(literalMax);
+			expect(onAssign.mock.calls[0]?.[2]).toBe(ThinkingLevel.Inherit);
+			expect(onAssign.mock.calls[0]?.[3]).toBe("test/model:max");
+			expect(onFallbackChainChange).toHaveBeenLastCalledWith("default", ["test/model-a"]);
+		});
+		test("a custom provider literally named pi still crosses the boundary", () => {
+			const a = makeModel("test", "model-a");
+			const piModel = makeModel("pi", "somemodel");
+			const b = makeModel("test", "model-b");
+			const settings = Settings.isolated({
+				modelRoles: { default: "pi/somemodel" },
+				"retry.fallbackChains": { default: ["test/model-b"] },
+			});
+			const onAssign = vi.fn(
+				(model: Model, role: string, thinkingLevel: ConfiguredThinkingLevel | undefined, selector: string) => {
+					settings.setModelRole(role, formatModelSelectorValue(selector, thinkingLevel));
+				},
+			);
+			const { hub, onFallbackChainChange } = createHub({
+				models: [a, piModel, b],
+				scoped: true,
+				settings,
+				callbacks: { onAssign },
+			});
+
+			enterRolesView(hub);
+			hub.handleInput("]");
+			expect(onAssign).toHaveBeenCalledTimes(1);
+			expect(onAssign.mock.calls[0]?.[0]).toBe(b);
+			expect(onAssign.mock.calls[0]?.[3]).toBe("test/model-b");
+			expect(onFallbackChainChange).toHaveBeenLastCalledWith("default", ["pi/somemodel"]);
+		});
+		test("alias-spelled fallbacks promote when they resolve to an available model", () => {
+			const a = makeModel("test", "model-a");
+			const canonical = makeModel("test", "model-b");
+			const settings = Settings.isolated({
+				modelRoles: { default: "test/model-a" },
+				"retry.fallbackChains": { default: ["test/model-b-alias"] },
+			});
+			const onAssign = vi.fn(
+				(model: Model, role: string, thinkingLevel: ConfiguredThinkingLevel | undefined, selector: string) => {
+					settings.setModelRole(role, formatModelSelectorValue(selector, thinkingLevel));
+				},
+			);
+			const { hub, onFallbackChainChange } = createHub({
+				models: [a, canonical],
+				scoped: true,
+				settings,
+				registry: {
+					find: (provider: string, id: string) =>
+						provider === "test" && id === "model-b-alias" ? canonical : undefined,
+				},
+				callbacks: { onAssign },
+			});
+
+			enterRolesView(hub);
+			hub.handleInput("]");
+			expect(onAssign).toHaveBeenCalledTimes(1);
+			expect(onAssign.mock.calls[0]?.[0]).toBe(canonical);
+			expect(onAssign.mock.calls[0]?.[3]).toBe("test/model-b-alias");
+			expect(onFallbackChainChange).toHaveBeenLastCalledWith("default", ["test/model-a"]);
+		});
+
+		test("[ and ] on a role leave the quick-switch cycle alone; shift+arrows still reorder it", () => {
+			const model = makeModel("test", "cycle-model");
+			const settings = Settings.isolated({});
+			const changes: string[][] = [];
+			const { hub } = createHub({
+				models: [model],
+				scoped: true,
+				settings,
+				callbacks: {
+					onCycleOrderChange: order => {
+						changes.push([...order]);
+						settings.set("cycleOrder", order);
+					},
+				},
+			});
+
+			enterRolesView(hub);
+			hub.handleInput("[");
+			hub.handleInput("]");
+			expect(changes).toEqual([]);
+
+			hub.handleInput(SHIFT_DOWN);
+			expect(changes[0]).toEqual(["smol", "slow", "default"]);
+			hub.handleInput(SHIFT_UP);
+			expect(changes[1]).toEqual(["smol", "default", "slow"]);
 		});
 
 		test("windows the roles list so model-keyed chains past the panel height stay reachable", () => {


### PR DESCRIPTION
The `/models` roles view treats a role's primary model and its retry fallbacks as one reorder set.

- `]` on a primary demotes it into the chain head and promotes the first fallback.
- `[` on the first fallback promotes it to primary.
- `[`/`]` on a role no longer reorder the quick-switch cycle; shift+up/down still does. The role footer advertises both.
- Each model keeps its thinking suffix across the swap. Aliases, multi-pattern values, wildcards, and upstream routing refuse the cross-boundary move instead of overwriting config. Promotion requires a currently available model.

Verified: `bun test test/model-hub.test.ts` (59 pass), `oxlint`, `oxfmt --check`, `check:types` clean. Reviewed by two parallel reviewer agents; all confirmed findings fixed.