### PR TITLE
fix(lsp): glob diagnostics wait the per-file budget instead of a 400ms batch cap

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `lsp diagnostics` on a glob reporting every file as "all language servers failed" on large workspaces: multi-file requests now wait the same per-file budget as single-file requests instead of a 400ms cap that project-aware servers such as rust-analyzer never met on their first pull (#10701).
+
 ## [18.1.7] - 2026-09-03
 
 ### Breaking Changes

--- a/packages/coding-agent/src/lsp/diagnostics.ts
+++ b/packages/coding-agent/src/lsp/diagnostics.ts
@@ -39,7 +39,6 @@ export const SINGLE_DIAGNOSTICS_WAIT_TIMEOUT_MS = 3000;
  * (still capped by the tool-level timeout).
  */
 export const PROJECT_DIAGNOSTICS_WAIT_TIMEOUT_MS = 10_000;
-export const BATCH_DIAGNOSTICS_WAIT_TIMEOUT_MS = 400;
 const DIAGNOSTICS_POLL_MS = 100;
 const DIAGNOSTICS_SETTLE_MS = 250;
 /**

--- a/packages/coding-agent/src/lsp/tool.ts
+++ b/packages/coding-agent/src/lsp/tool.ts
@@ -33,7 +33,6 @@ import {
 import { getLinterClient } from "./clients";
 import { getServersForFile } from "./config";
 import {
-	BATCH_DIAGNOSTICS_WAIT_TIMEOUT_MS,
 	formatLocationWithContext,
 	hasRustWorkspaceAncestor,
 	isOnlyQueriedDeclaration,
@@ -352,15 +351,15 @@ export class LspTool implements AgentTool<typeof lspSchema, LspToolDetails, Them
 						const minVersion = client.diagnosticsVersion;
 						await refreshFile(client, resolved, signal);
 						const expectedDocumentVersion = client.openFiles.get(uri)?.version;
-						// Project-aware servers (Roslyn, tsserver, …) compute pull diagnostics
-						// on demand; their first response routinely overruns the 3s single-file
-						// budget, which would otherwise surface as a false "OK". An explicit
-						// diagnostics request can afford to wait, bounded by the tool timeout.
-						const waitCapMs = detailed
-							? BATCH_DIAGNOSTICS_WAIT_TIMEOUT_MS
-							: isProjectAwareLspServer(serverConfig)
-								? PROJECT_DIAGNOSTICS_WAIT_TIMEOUT_MS
-								: SINGLE_DIAGNOSTICS_WAIT_TIMEOUT_MS;
+						// Project-aware servers (Roslyn, tsserver, rust-analyzer, …) compute pull
+						// diagnostics on demand; their first response routinely overruns the 3s
+						// single-file budget. A shorter per-file cap for globs made every file of
+						// a large workspace report "all language servers failed" (the pull never
+						// returned in time), so batch and single requests share one cap and the
+						// tool timeout bounds the whole loop.
+						const waitCapMs = isProjectAwareLspServer(serverConfig)
+							? PROJECT_DIAGNOSTICS_WAIT_TIMEOUT_MS
+							: SINGLE_DIAGNOSTICS_WAIT_TIMEOUT_MS;
 						const diagnostics = await waitForDiagnostics(client, uri, {
 							timeoutMs: Math.min(waitCapMs, timeoutSec * 1000),
 							signal,

--- a/packages/coding-agent/test/tools/lsp-regressions.test.ts
+++ b/packages/coding-agent/test/tools/lsp-regressions.test.ts
@@ -1902,6 +1902,63 @@ describe("lsp regressions", () => {
 		}
 	});
 
+	it("waits the project-aware budget per file when diagnostics target a glob (#10701)", async () => {
+		const tempDir = TempDir.createSync("@omp-lsp-glob-slow-pull-");
+		try {
+			const files = ["a.ts", "b.ts"].map(name => path.join(tempDir.path(), name));
+			for (const file of files) await Bun.write(file, "export const x = 1;\n");
+			await initTheme();
+
+			const server: ServerConfig = { command: "slow-pull-lsp", fileTypes: ["ts"], rootMarkers: [] };
+			const client = {
+				name: "slow-pull-lsp",
+				cwd: tempDir.path(),
+				config: server,
+				proc: { stdin: { write() {}, flush: async () => {} } } as unknown as LspClient["proc"],
+				requestId: 0,
+				diagnostics: new Map(),
+				diagnosticsVersion: 0,
+				openFiles: new Map(),
+				pendingRequests: new Map(),
+				messageBuffer: new Uint8Array(),
+				isReading: false,
+				status: "ready",
+				lastActivity: Date.now(),
+				writeQueue: Promise.resolve(),
+				activeProgressTokens: new Set(),
+				projectLoaded: Promise.resolve(),
+				resolveProjectLoaded: () => {},
+				serverCapabilities: { diagnosticProvider: {} },
+			} as LspClient;
+			vi.spyOn(lspConfig, "loadConfig").mockReturnValue({ servers: {}, idleTimeoutMs: undefined });
+			vi.spyOn(lspConfig, "getServersForFile").mockReturnValue([["slow-pull-lsp", server]]);
+			vi.spyOn(lspClient, "getOrCreateClient").mockResolvedValue(client);
+			// First pull on a large workspace takes longer than the old 400ms batch cap.
+			const pullMs = 800;
+			vi.spyOn(lspClient, "sendRequest").mockImplementation(
+				(_client, _method, _params, _signal, timeoutMs) =>
+					new Promise((resolve, reject) => {
+						setTimeout(() => resolve({ kind: "full", items: [] }), pullMs);
+						if (timeoutMs !== undefined && timeoutMs < pullMs) {
+							setTimeout(() => reject(new Error(`timed out after ${timeoutMs}ms`)), timeoutMs);
+						}
+					}),
+			);
+
+			const result = await new LspTool(makeLspSession(tempDir.path())).execute("glob-slow-pull", {
+				action: "diagnostics",
+				file: path.join(tempDir.path(), "*.ts"),
+				timeout: 5,
+			});
+
+			expect(result.details?.success).toBe(true);
+			expect(textResult(result)).not.toContain("all language servers failed");
+		} finally {
+			vi.restoreAllMocks();
+			tempDir.removeSync();
+		}
+	});
+
 	it("reports failure when every workspace-symbol server fails (#8387)", async () => {
 		const tempDir = TempDir.createSync("@omp-lsp-workspace-symbol-all-fail-");
 		try {


### PR DESCRIPTION
Closes #10701

## Bug

`lsp diagnostics` on a glob (or the post-edit batch) capped each file's wait at `BATCH_DIAGNOSTICS_WAIT_TIMEOUT_MS = 400` and used that as the `textDocument/diagnostic` request timeout. A project-aware server whose first pull computes analysis on demand (rust-analyzer on a 4.3M-line workspace) never answers in 400ms, so every file rendered as `all language servers failed (rust-analyzer)` while the server was healthy and a single-file request on the same file succeeded.

## Change

- `tool.ts`: batch requests use the same per-file cap as single requests (10s project-aware, 3s otherwise). The tool-level `timeout` signal already bounds the whole loop, so no new total bound is needed.
- `diagnostics.ts`: delete the now-unused constant.
- Regression test: a two-file glob against a fake server whose pull answers after 800ms. Fails on `main` (`success: false`, "all language servers failed"), passes here.
- CHANGELOG entry under Unreleased.

## Verification

```
packages/coding-agent$ bun run check        # oxlint, oxfmt, tsgo: clean
packages/coding-agent$ bun test test/tools/lsp-regressions.test.ts test/lsp
Ran 163 tests across 9 files. 0 fail
```