### PR TITLE
fix(lsp): drop 400ms glob diagnostics batch cap

### DIFF
--- a/docs/tools/lsp.md
+++ b/docs/tools/lsp.md
@@ -278,8 +278,7 @@ Uses the same location normalization and output shape as `definition`, but sends
 - Idle-client sweep interval when enabled: `60_000ms` — `IDLE_CHECK_INTERVAL_MS` in `packages/coding-agent/src/lsp/client.ts`.
 - Failed initialization backoff: `3 * 60 * 1000ms` — `INIT_FAILURE_BACKOFF_MS`; a matching single-file or workspace `reload` clears this negative cache so retry is immediate.
 - Diagnostic message output cap: first `50` messages — `DIAGNOSTIC_MESSAGE_LIMIT` in `packages/coding-agent/src/lsp/index.ts`.
-- Single-file diagnostics wait: `3_000ms` — `SINGLE_DIAGNOSTICS_WAIT_TIMEOUT_MS`.
-- Batch/glob diagnostics wait per file: `400ms` — `BATCH_DIAGNOSTICS_WAIT_TIMEOUT_MS`.
+- Single-file and batch/glob diagnostics wait per file: `3_000ms` (`SINGLE_DIAGNOSTICS_WAIT_TIMEOUT_MS`), or `10_000ms` for project-aware servers (`PROJECT_DIAGNOSTICS_WAIT_TIMEOUT_MS`); the tool-level `timeout` bounds the whole batch.
 - Glob diagnostic target cap: first `20` matches — `MAX_GLOB_DIAGNOSTIC_TARGETS`.
 - Workspace symbol cap: first `200` entries — `WORKSPACE_SYMBOL_LIMIT`.
 - Reference context cap: first `50` references include source context — `REFERENCE_CONTEXT_LIMIT`.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `lsp diagnostics` on a glob reporting every file as "all language servers failed" on large workspaces; batches now use the same per-file wait budget as single-file requests instead of a 400ms cap ([#10701](https://github.com/can1357/oh-my-pi/issues/10701)).
+
 ## [18.1.7] - 2026-09-03
 
 ### Breaking Changes

--- a/packages/coding-agent/src/lsp/diagnostics.ts
+++ b/packages/coding-agent/src/lsp/diagnostics.ts
@@ -39,7 +39,6 @@ export const SINGLE_DIAGNOSTICS_WAIT_TIMEOUT_MS = 3000;
  * (still capped by the tool-level timeout).
  */
 export const PROJECT_DIAGNOSTICS_WAIT_TIMEOUT_MS = 10_000;
-export const BATCH_DIAGNOSTICS_WAIT_TIMEOUT_MS = 400;
 const DIAGNOSTICS_POLL_MS = 100;
 const DIAGNOSTICS_SETTLE_MS = 250;
 /**

--- a/packages/coding-agent/src/lsp/tool.ts
+++ b/packages/coding-agent/src/lsp/tool.ts
@@ -33,7 +33,6 @@ import {
 import { getLinterClient } from "./clients";
 import { getServersForFile } from "./config";
 import {
-	BATCH_DIAGNOSTICS_WAIT_TIMEOUT_MS,
 	formatLocationWithContext,
 	hasRustWorkspaceAncestor,
 	isOnlyQueriedDeclaration,
@@ -352,15 +351,15 @@ export class LspTool implements AgentTool<typeof lspSchema, LspToolDetails, Them
 						const minVersion = client.diagnosticsVersion;
 						await refreshFile(client, resolved, signal);
 						const expectedDocumentVersion = client.openFiles.get(uri)?.version;
-						// Project-aware servers (Roslyn, tsserver, …) compute pull diagnostics
-						// on demand; their first response routinely overruns the 3s single-file
-						// budget, which would otherwise surface as a false "OK". An explicit
-						// diagnostics request can afford to wait, bounded by the tool timeout.
-						const waitCapMs = detailed
-							? BATCH_DIAGNOSTICS_WAIT_TIMEOUT_MS
-							: isProjectAwareLspServer(serverConfig)
-								? PROJECT_DIAGNOSTICS_WAIT_TIMEOUT_MS
-								: SINGLE_DIAGNOSTICS_WAIT_TIMEOUT_MS;
+						// Project-aware servers (Roslyn, tsserver, rust-analyzer, …) compute pull
+						// diagnostics on demand; their first response routinely overruns the 3s
+						// single-file budget, which would otherwise surface as a false "OK" (or, on
+						// a glob batch, a false "all language servers failed"). Batches use the same
+						// per-file cap as single files — the tool-level `timeout` signal already
+						// bounds the whole loop, so no extra per-file throttle is needed.
+						const waitCapMs = isProjectAwareLspServer(serverConfig)
+							? PROJECT_DIAGNOSTICS_WAIT_TIMEOUT_MS
+							: SINGLE_DIAGNOSTICS_WAIT_TIMEOUT_MS;
 						const diagnostics = await waitForDiagnostics(client, uri, {
 							timeoutMs: Math.min(waitCapMs, timeoutSec * 1000),
 							signal,

--- a/packages/coding-agent/test/tools/lsp-regressions.test.ts
+++ b/packages/coding-agent/test/tools/lsp-regressions.test.ts
@@ -1902,6 +1902,76 @@ describe("lsp regressions", () => {
 		}
 	});
 
+	it("glob diagnostics give a project-aware server the per-file cap, not a 400ms batch cap (#10701)", async () => {
+		const tempDir = TempDir.createSync("@omp-lsp-glob-cap-");
+		await initTheme();
+		try {
+			const a = path.join(tempDir.path(), "a.rs");
+			const b = path.join(tempDir.path(), "b.rs");
+			await Promise.all([Bun.write(a, "fn a() {}\n"), Bun.write(b, "fn b() {}\n")]);
+
+			// Project-aware: no createClient, no isLinter → isProjectAwareLspServer is true.
+			const server: ServerConfig = { command: "test-lsp", fileTypes: [".rs"], rootMarkers: ["Cargo.toml"] };
+			const client: LspClient = {
+				name: "test-lsp",
+				cwd: tempDir.path(),
+				config: server,
+				proc: { stdin: { write() {}, flush: async () => {} } } as unknown as LspClient["proc"],
+				requestId: 0,
+				diagnostics: new Map(),
+				diagnosticsVersion: 1,
+				openFiles: new Map(),
+				pendingRequests: new Map(),
+				messageBuffer: new Uint8Array(),
+				isReading: false,
+				status: "ready",
+				lastActivity: Date.now(),
+				writeQueue: Promise.resolve(),
+				activeProgressTokens: new Set(),
+				projectLoaded: Promise.resolve(),
+				resolveProjectLoaded: () => {},
+				// Advertise LSP 3.17 pull diagnostics so the tool issues textDocument/diagnostic.
+				serverCapabilities: { diagnosticProvider: {} },
+			} as unknown as LspClient;
+
+			vi.spyOn(lspConfig, "loadConfig").mockReturnValue({ servers: {}, idleTimeoutMs: undefined });
+			vi.spyOn(lspConfig, "getServersForFile").mockReturnValue([["test-lsp", server]]);
+			vi.spyOn(lspClient, "getOrCreateClient").mockResolvedValue(client);
+			vi.spyOn(lspClient, "refreshFile").mockResolvedValue(undefined);
+			// The first on-demand pull needs more budget than the old 400ms batch cap.
+			// Keyed off the per-request timeout the tool hands down (deterministic, no
+			// wall clock): under the old cap it would be 400ms and this rejects; with
+			// the per-file cap it is the project-aware budget and the pull answers.
+			const REQUIRED_PULL_BUDGET_MS = 800;
+			vi.spyOn(lspClient, "sendRequest").mockImplementation(async (_client, method, _params, _signal, timeoutMs) => {
+				if (method === "textDocument/diagnostic") {
+					if (timeoutMs !== undefined && timeoutMs < REQUIRED_PULL_BUDGET_MS) {
+						throw new Error(`LSP request textDocument/diagnostic timed out after ${timeoutMs}ms`);
+					}
+					return { kind: "full", items: [] };
+				}
+				return null;
+			});
+
+			const result = await new LspTool(makeLspSession(tempDir.path())).execute("glob-cap", {
+				action: "diagnostics",
+				file: "*.rs",
+				timeout: 20,
+			});
+
+			// A healthy server that simply computes on demand must not render as a total
+			// failure across the batch.
+			expect(result.details?.success).toBe(true);
+			const output = textResult(result);
+			expect(output).not.toContain("all language servers failed");
+			expect(output).toContain("a.rs: no issues");
+			expect(output).toContain("b.rs: no issues");
+		} finally {
+			vi.restoreAllMocks();
+			tempDir.removeSync();
+		}
+	});
+
 	it("reports failure when every workspace-symbol server fails (#8387)", async () => {
 		const tempDir = TempDir.createSync("@omp-lsp-workspace-symbol-all-fail-");
 		try {


### PR DESCRIPTION
## Repro
`lsp diagnostics` with a glob (or any pattern matching more than one file) against a large project-aware workspace reports every file as `✘ <file>: all language servers failed (rust-analyzer)`, while `rust-analyzer analysis-stats` loads the same workspace fine and a single-file `lsp diagnostics` on the same file succeeds. Reproduced on this branch with a two-file glob against a project-aware fake server whose pull needs more than 400ms of budget: single file → `OK` (10s cap), glob → both files `all language servers failed` (400ms cap). Command: `bun test test/tools/lsp-regressions.test.ts`.

## Cause
`packages/coding-agent/src/lsp/tool.ts` picked `waitCapMs = detailed ? BATCH_DIAGNOSTICS_WAIT_TIMEOUT_MS (400) : …`, where `detailed` is true whenever more than one file matched. That 400ms value is threaded straight into the `textDocument/diagnostic` request timeout via `waitForDiagnostics` → `requestDocumentDiagnostics` in `diagnostics.ts`. A project-aware server (`isProjectAwareLspServer` is true for any non-linter LSP, including rust-analyzer) whose first pull computes analysis on demand cannot answer inside 400ms, so the pull rejects with a timeout, lands in `failedServers`, and each file renders as a total failure. Single-file requests already carved out `PROJECT_DIAGNOSTICS_WAIT_TIMEOUT_MS` (10s) for exactly this — the batch path was never updated.

## Fix
- `tool.ts`: batch/glob requests now use the same per-file cap as single requests — `PROJECT_DIAGNOSTICS_WAIT_TIMEOUT_MS` (10s) for project-aware servers, `SINGLE_DIAGNOSTICS_WAIT_TIMEOUT_MS` (3s) otherwise. The tool-level `timeout` signal already bounds the whole loop, so no per-file throttle is needed; dropped the `detailed` branch and the now-unused import.
- `diagnostics.ts`: deleted the now-unused `BATCH_DIAGNOSTICS_WAIT_TIMEOUT_MS` constant.
- `docs/tools/lsp.md`: updated the diagnostics-wait line to reflect the per-file budgets and drop the deleted constant.
- `lsp-regressions.test.ts`: added a regression test — a two-file glob against a project-aware server whose pull needs more budget than the old 400ms cap now succeeds (`no issues`) instead of `all language servers failed`.
- `CHANGELOG.md`: entry under `[Unreleased]`.

## Verification
`bun test test/tools/lsp-regressions.test.ts` → 117 pass, 0 fail. `bun test test/lsp` → 46 pass, 0 fail. `bun run fix` + `bun check` ran clean via the pre-publish gate. Fixes #10701