### PR TITLE
fix(catalog): cap vercel muse-spark-1.3-contributor output tokens

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Capped the Vercel AI Gateway `meta/muse-spark-1.3-contributor` output budget to 131072 tokens so requests no longer fail with HTTP 400 ([#10705](https://github.com/can1357/oh-my-pi/issues/10705)).
+
 ## [18.1.6] - 2026-09-03
 
 ### Added

--- a/packages/catalog/src/compat/rules.json
+++ b/packages/catalog/src/compat/rules.json
@@ -12848,6 +12848,27 @@
 				}
 			},
 			{
+				"source": "providers/vercel-ai-gateway.kdl:79",
+				"providers": [
+					"vercel-ai-gateway"
+				],
+				"models": [
+					{
+						"kind": "exact",
+						"value": "meta/muse-spark-1.2-contributor"
+					},
+					{
+						"kind": "exact",
+						"value": "meta/muse-spark-1.3-contributor"
+					}
+				],
+				"catalog": {
+					"limitsPatch": {
+						"maxTokens": 131072
+					}
+				}
+			},
+			{
 				"source": "providers/vllm.kdl:4",
 				"class": "qwen",
 				"providers": [

--- a/packages/catalog/src/compat/rules/providers/vercel-ai-gateway.kdl
+++ b/packages/catalog/src/compat/rules/providers/vercel-ai-gateway.kdl
@@ -70,4 +70,15 @@ provider "vercel-ai-gateway" {
 	models "openai/gpt-5.1-codex-mini" {
 		thinking-efforts "medium" "high"
 	}
+	// Vercel reports context_window and max_tokens both as 1_048_576 for the
+	// Meta Muse Spark contributor SKUs, but the upstream Meta deployment 400s
+	// when max_tokens plus any prompt exceeds that shared window. Cap output to
+	// OMP's first-party Meta ceiling; the context window stays as reported.
+	// #9115 capped 1.2-contributor in TS; 1.3-contributor regressed the same
+	// way (#10705), so both live here now.
+	models "meta/muse-spark-1.2-contributor" "meta/muse-spark-1.3-contributor" {
+		limits-patch {
+			max-tokens 131072
+		}
+	}
 }

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -346013,7 +346013,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 1048576,
+			"maxTokens": 131072,
 			"identity": {
 				"class": "meta",
 				"family": "muse-spark",

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -3711,12 +3711,6 @@ export function vercelAiGatewayModelManagerOptions(
 				): ModelSpec<"anthropic-messages"> => {
 					const pricing = entry.pricing as Record<string, unknown> | undefined;
 					const tags = Array.isArray(entry.tags) ? (entry.tags as string[]) : [];
-					const reportedMaxTokens = typeof entry.max_tokens === "number" ? entry.max_tokens : defaults.maxTokens;
-					const modelId = typeof entry.id === "string" ? entry.id : defaults.id;
-					const maxTokens =
-						modelId === "meta/muse-spark-1.2-contributor" && typeof reportedMaxTokens === "number"
-							? Math.min(reportedMaxTokens, 131_072)
-							: reportedMaxTokens;
 
 					return {
 						...defaults,
@@ -3731,7 +3725,7 @@ export function vercelAiGatewayModelManagerOptions(
 						},
 						contextWindow:
 							typeof entry.context_window === "number" ? entry.context_window : defaults.contextWindow,
-						maxTokens,
+						maxTokens: typeof entry.max_tokens === "number" ? entry.max_tokens : defaults.maxTokens,
 					};
 				},
 				fetch: config?.fetch,

--- a/packages/catalog/test/vercel-ai-gateway-provider.test.ts
+++ b/packages/catalog/test/vercel-ai-gateway-provider.test.ts
@@ -1,27 +1,35 @@
 import { describe, expect, test } from "bun:test";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { vercelAiGatewayModelManagerOptions } from "@oh-my-pi/pi-catalog/provider-models/openai-compat";
 
 describe("Vercel AI Gateway provider", () => {
-	test("caps meta/muse-spark-1.2-contributor output allowance to 131072 while preserving context window", async () => {
-		// Vercel currently reports both context_window and max_tokens as 1M for the
-		// contributor model, which makes Anthropic messages requests fail with 400
-		// when prompt + max_tokens exceeds the shared context window. The mapper
-		// must cap the output allowance while leaving the context window intact.
-		const contributorId = "meta/muse-spark-1.2-contributor";
+	test("caps Meta Muse Spark contributor output allowance to 131072 while preserving context window", async () => {
+		// Vercel reports both context_window and max_tokens as 1M for the Muse Spark
+		// contributor SKUs, which makes Anthropic messages requests 400 when prompt +
+		// max_tokens exceeds the shared context window. The `limits-patch` rule in
+		// providers/vercel-ai-gateway.kdl must cap the output allowance for both the
+		// 1.2 and 1.3 contributor ids (#9115, #10705) while leaving the context
+		// window — and the non-contributor SKUs — untouched.
+		const contributor12 = "meta/muse-spark-1.2-contributor";
+		const contributor13 = "meta/muse-spark-1.3-contributor";
+		const plain13 = "meta/muse-spark-1.3";
 		const controlId = "anthropic/claude-sonnet-4-5-20250929";
+		const oneMegModel = (id: string, owner: string) => ({
+			id,
+			object: "model",
+			owned_by: owner,
+			tags: ["tool-use", "reasoning", "vision"],
+			context_window: 1_048_576,
+			max_tokens: 1_048_576,
+			pricing: { input: 0.0000001, output: 0.0000002 },
+		});
 		const fetchMock = (async () =>
 			Response.json({
 				object: "list",
 				data: [
-					{
-						id: contributorId,
-						object: "model",
-						owned_by: "meta",
-						tags: ["tool-use", "reasoning", "vision"],
-						context_window: 1_048_576,
-						max_tokens: 1_048_576,
-						pricing: { input: 0.0000001, output: 0.0000002 },
-					},
+					oneMegModel(contributor12, "meta"),
+					oneMegModel(contributor13, "meta"),
+					oneMegModel(plain13, "meta"),
 					{
 						id: controlId,
 						object: "model",
@@ -35,14 +43,24 @@ describe("Vercel AI Gateway provider", () => {
 			})) as unknown as typeof fetch;
 
 		const options = vercelAiGatewayModelManagerOptions({ fetch: fetchMock });
-		const models = await options.fetchDynamicModels?.();
-		expect(models).not.toBeNull();
-		const byId = new Map((models ?? []).map(model => [model.id, model]));
+		const specs = await options.fetchDynamicModels?.();
+		expect(specs).not.toBeNull();
+		// The model manager rebuilds every discovered spec via `buildModel`, which is
+		// where the KDL limits-patch is applied — assert the built contract, not the
+		// raw discovery spec.
+		const byId = new Map((specs ?? []).map(spec => [spec.id, buildModel(spec)]));
 
-		const contributor = byId.get(contributorId);
-		expect(contributor).toBeDefined();
-		expect(contributor?.contextWindow).toBe(1_048_576);
-		expect(contributor?.maxTokens).toBe(131_072);
+		for (const id of [contributor12, contributor13]) {
+			const model = byId.get(id);
+			expect(model).toBeDefined();
+			expect(model?.contextWindow).toBe(1_048_576);
+			expect(model?.maxTokens).toBe(131_072);
+		}
+
+		// The non-contributor SKU is out of scope and must keep its reported budget.
+		const plain = byId.get(plain13);
+		expect(plain).toBeDefined();
+		expect(plain?.maxTokens).toBe(1_048_576);
 
 		const control = byId.get(controlId);
 		expect(control).toBeDefined();


### PR DESCRIPTION
## Repro
Every chat request to `vercel-ai-gateway/meta/muse-spark-1.3-contributor` fails with HTTP 400 `"The request contains invalid parameters"`. Vercel reports both `context_window` and `max_tokens` as `1048576`, so omp posts `max_tokens=1048576` to `ai-gateway.vercel.sh/v1/messages`; prompt plus requested output then exceeds the shared 1M context window and the gateway 400s (`1048576` -> 400, `65536` -> 200). Reproduced against `main`:

```
$ bun -e 'import("@oh-my-pi/pi-catalog/build").then(({buildModel})=>console.log(buildModel({id:"meta/muse-spark-1.3-contributor",api:"anthropic-messages",provider:"vercel-ai-gateway",baseUrl:"https://ai-gateway.vercel.sh",contextWindow:1048576,maxTokens:1048576,reasoning:true,input:["text"],cost:{input:1,output:3,cacheRead:0.2,cacheWrite:1},name:"x"}).maxTokens))'
1048576
```

## Cause
The only output cap for this provider was a hardcoded `modelId === "meta/muse-spark-1.2-contributor"` branch in `vercelAiGatewayModelManagerOptions` (`packages/catalog/src/provider-models/openai-compat.ts`), added by #9115. The sibling `meta/muse-spark-1.3-contributor` was never covered, so its Vercel-reported `maxTokens` flowed through uncapped into both live discovery and the bundled `models.json` row.

## Fix
- Add a `limits-patch { max-tokens 131072 }` rule for `meta/muse-spark-1.2-contributor` and `meta/muse-spark-1.3-contributor` in `packages/catalog/src/compat/rules/providers/vercel-ai-gateway.kdl`, so the cap is applied by `buildModel` on both runtime discovery and catalog generation (context window left at the reported `1048576`).
- Remove the hardcoded id special-case from the Vercel discovery mapper.
- Regenerate `packages/catalog/src/compat/rules.json` (`bun run gen:compat`) and cap the bundled `vercel-ai-gateway/meta/muse-spark-1.3-contributor` `maxTokens` to `131072` (the value a full `gen:models` produces from the new rule; single-line change mirroring #9115).
- Rewrite `packages/catalog/test/vercel-ai-gateway-provider.test.ts` to assert the built-model contract (`maxTokens=131072`, `contextWindow=1048576`) for both contributor SKUs, that the non-contributor `meta/muse-spark-1.3` stays uncapped, and that a control model is untouched.

## Verification
`bun test` in `packages/catalog` — 869 pass / 0 fail. `bun run check:types` clean. Post-fix `buildModel` returns `maxTokens=131072` for both contributor SKUs and `1048576` for `meta/muse-spark-1.3`; bundled `models.json` diff is a single line.

Fixes #10705