### PR TITLE
Add strict shared LSP failure policy

### DIFF
--- a/docs/tools/lsp.md
+++ b/docs/tools/lsp.md
@@ -49,13 +49,23 @@
 3. `getConfig()` loads and caches `LspConfig` per cwd, applies idle-timeout config via `setIdleTimeout()`, and reuses the cached config on later calls. Workspace `reload` is the explicit exception: it clears and rebuilds that cwd's config cache before reloading the newly selected servers.
 4. Config loading in `packages/coding-agent/src/lsp/config.ts` merges `defaults.json` with JSON/YAML overrides from project, project config dirs, user config dirs, plugin roots/marketplace metadata, and home; if there are no overrides it auto-detects servers from root markers plus executable discovery. See [LSP configuration](../lsp-config.md) for filenames, precedence, and server fields.
 5. Server routing uses `getServersForFile()` / `getServerForFile()` from `config.ts`: extension or basename match, then sort primary servers before linters. `index.ts` further filters custom linter clients out of navigation/refactor paths with `getLspServersForFile()` / `getLspServerForFile()`.
-6. `getOrCreateClient()` caches one client per `command:cwd`. With `lsp.shared` (default `true` in SDK sessions), it first asks the broker-managed project mux for a shared transport; failure falls back to a private `ptree.spawn()`. An external `lspmux` wrapper takes precedence over broker sharing. The client then starts its message reader, sends `initialize`, stores capabilities, and sends `initialized`.
+6. `getOrCreateClient()` caches one client per `command:cwd`. With `lsp.shared` (default `true` in SDK sessions), it first asks the broker-managed project mux for a shared transport; if that fails, the default policy logs the broker/mux cause at warning level and falls back to a private `ptree.spawn()`. With `lsp.requireShared: true`, the same failure is returned as an `LSP error:` and no private process is spawned. An external `lspmux` wrapper takes precedence over broker sharing. The client then starts its message reader, sends `initialize`, stores capabilities, and sends `initialized`.
 7. The message reader in `client.ts` parses LSP frames, resolves pending requests, caches `publishDiagnostics`, tracks `$/progress` tokens for project-load completion, answers `workspace/configuration`, and applies `workspace/applyEdit` requests through `applyWorkspaceEdit()`.
 8. File-scoped actions call `ensureFileOpen()` before requests. Column resolution uses `resolveSymbolColumn()` from `utils.ts`: read the target file, pick first non-whitespace when `symbol` is omitted, otherwise find the exact or case-insensitive match on the target line and honor `#N` occurrence selectors.
 9. Actions dispatch in `LspTool.execute()` through dedicated branches: workspace-only branches (`status`, some `diagnostics`, workspace `symbols`, workspace `reload`, `capabilities`, `request`) run before the single-file switch; all other single-file actions share one client lookup and `switch(action)`.
 10. Requests go through `sendRequest()` in `client.ts`, which allocates an incrementing JSON-RPC id, installs abort and timeout handling, sends `$/cancelRequest` on abort, and rejects on timeout or process exit.
 11. Actions that return edits either preview with `formatWorkspaceEdit()` or apply with `applyWorkspaceEdit()` from `edits.ts`; `rename_file` also performs the filesystem rename and then sends `workspace/didRenameFiles`.
 12. Non-abort failures inside the single-file action block are converted to `LSP error: ...`; many precondition failures return explicit text without throwing.
+
+### Shared LSP failure policy
+
+`lsp.shared` defaults to `true` and remains backward compatible: a broker or mux startup/handshake failure is logged with its underlying cause, then the client falls back to a private language-server process. Set the opt-in `lsp.requireShared` setting to fail closed instead:
+
+```bash
+omp config set lsp.requireShared true
+```
+
+The setting belongs in the active OMP agent configuration (`omp config path`), not `.omp/lsp.yaml`, which configures language-server commands and routing. It is read when an OMP session is created; restart active sessions after changing it. Strict mode applies only when `lsp.shared` is also enabled, and an external `lspmux` wrapper remains authoritative.
 
 ## Modes / Variants
 ### Routing and workspace scope

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added the opt-in `lsp.requireShared` setting to fail closed when broker-shared LSP is unavailable.
+
+### Changed
+
+- Shared LSP broker and mux startup/handshake failures now retain their causes and log at warning level before the default private fallback.
+
+### Fixed
+
+- Strict shared-LSP failures no longer leave a rejected client-creation lock that blocks retries.
+
 ## [18.1.6] - 2026-09-03
 
 ### Breaking Changes

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -3819,6 +3819,17 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	"lsp.requireShared": {
+		type: "boolean",
+		default: false,
+		ui: {
+			tab: "files",
+			group: "LSP",
+			label: "Require Shared Language Servers",
+			description: "Fail LSP requests when shared mode is unavailable instead of spawning a private language server",
+		},
+	},
+
 	"lsp.formatOnWrite": {
 		type: "boolean",
 		default: false,

--- a/packages/coding-agent/src/lsp/client.ts
+++ b/packages/coding-agent/src/lsp/client.ts
@@ -50,10 +50,16 @@ const IDLE_CHECK_INTERVAL_MS = 60 * 1000;
 // tests that drive getOrCreateClient directly never touch the daemon broker;
 // the SDK turns it on from the `lsp.shared` setting at session creation.
 let sharedLspEnabled = false;
+let sharedLspRequired = false;
 
 /** Enable or disable attaching to broker-shared language servers. */
 export function setSharedLspEnabled(enabled: boolean): void {
 	sharedLspEnabled = enabled;
+}
+
+/** Require the broker-shared transport instead of allowing a private fallback. */
+export function setSharedLspRequired(required: boolean): void {
+	sharedLspRequired = required;
 }
 
 /**
@@ -1006,11 +1012,18 @@ export async function getOrCreateClient(
 			: { command: baseCommand, args: baseArgs };
 
 		// Prefer the broker-shared server unless an external lspmux wrapper is
-		// already multiplexing this command. Any shared-path failure falls back
-		// to a private spawn so LSP never regresses on broker trouble.
+		// already multiplexing this command. By default, shared-path failure
+		// falls back to a private spawn; requireShared makes that path fail closed.
 		let proc: LspTransport | null = null;
 		if (sharedLspEnabled && command === baseCommand) {
-			proc = await connectSharedLspTransport({ command, args, cwd, env, signal });
+			proc = await connectSharedLspTransport({
+				command,
+				args,
+				cwd,
+				env,
+				signal,
+				requireShared: sharedLspRequired,
+			});
 		}
 		proc ??= ptree.spawn([command, ...args], {
 			cwd,
@@ -1143,6 +1156,11 @@ export async function getOrCreateClient(
 	})();
 
 	clientLocks.set(key, { promise: clientPromise, cwd, config, token: lockToken });
+	// Shared transport setup can reject before the initialization try/finally
+	// below is entered; never leave a rejected promise wedged in clientLocks.
+	void clientPromise.catch(() => {
+		if (clientLocks.get(key)?.token === lockToken) clientLocks.delete(key);
+	});
 	return clientPromise;
 }
 

--- a/packages/coding-agent/src/lsp/mux/daemon.ts
+++ b/packages/coding-agent/src/lsp/mux/daemon.ts
@@ -6,8 +6,8 @@
  * first use, stopped when the last omp process in the project exits), dials
  * its socket, performs the `omp/muxConnect` handshake, and returns an
  * {@link LspTransport} the ordinary LSP client machinery drives exactly like
- * a locally spawned server. Every failure degrades to `null` so callers fall
- * back to a process-local spawn.
+ * a locally spawned server. The connector preserves the detailed failure for
+ * strict callers and logs it before the default private fallback.
  */
 import * as net from "node:net";
 import * as os from "node:os";
@@ -39,6 +39,14 @@ const PROBE_TIMEOUT_MS = 1_500;
 const READY_TIMEOUT_MS = 15_000;
 /** probe→describe→start rounds; bounds cross-process start races and wedged-mux replacement. */
 const ENSURE_ATTEMPTS = 3;
+
+function errorMessage(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}
+
+function contextualError(message: string, error: unknown): Error {
+	return new Error(`${message}: ${errorMessage(error)}`, { cause: error });
+}
 
 /** Dial a mux endpoint (Unix socket or Windows named pipe) with a bounded connect. */
 function connectEndpoint(endpoint: string, timeoutMs: number): Promise<net.Socket> {
@@ -200,8 +208,8 @@ async function dialMuxServer(endpoint: string, params: MuxConnectParams): Promis
 	}
 }
 
-/** True when a mux answers the ping handshake at `endpoint`. */
-async function probeMux(endpoint: string): Promise<boolean> {
+/** Return the concrete failure when a mux does not answer the ping handshake. */
+async function probeMuxFailure(endpoint: string): Promise<Error | undefined> {
 	try {
 		const socket = await connectEndpoint(endpoint, PROBE_TIMEOUT_MS);
 		try {
@@ -210,36 +218,54 @@ async function probeMux(endpoint: string): Promise<boolean> {
 				{ jsonrpc: "2.0", id: "probe", method: MUX_PING_METHOD, params: null },
 				PROBE_TIMEOUT_MS,
 			);
-			return response.result === MUX_PING_RESULT;
+			if (response.result === MUX_PING_RESULT) return undefined;
+			return new Error(`LSP mux ping returned an unexpected response at ${endpoint}`);
 		} finally {
 			socket.destroy();
 		}
-	} catch {
-		return false;
+	} catch (error) {
+		return error instanceof Error ? error : new Error(String(error));
 	}
+}
+
+/** True when a mux answers the ping handshake at `endpoint`. */
+async function probeMux(endpoint: string): Promise<boolean> {
+	return (await probeMuxFailure(endpoint)) === undefined;
 }
 
 /**
  * Ensure the project's mux daemon is running under the broker and reachable.
- * Returns its endpoint, or null when the shared path is unavailable.
+ * Throws a contextual error when the shared path is unavailable.
  */
-async function ensureLspMuxDaemon(projectDir: string, signal?: AbortSignal): Promise<string | null> {
+async function ensureLspMuxDaemon(projectDir: string, signal?: AbortSignal): Promise<string> {
 	const client = await daemonClientForProject(projectDir);
 	const endpoint = lspMuxEndpoint(client.projectDir, daemonRuntimeDir(client.projectDir));
 	// The broker connection doubles as the presence lease keeping the daemon alive.
-	await client.request({ op: "ping" }, signal);
-	if (await probeMux(endpoint)) return endpoint;
+	try {
+		await client.request({ op: "ping" }, signal);
+	} catch (error) {
+		signal?.throwIfAborted();
+		throw contextualError(`LSP broker unavailable for ${client.projectDir}`, error);
+	}
+
+	const initialFailure = await probeMuxFailure(endpoint);
+	if (!initialFailure) return endpoint;
+	let lastFailure = contextualError(`LSP mux probe failed at ${endpoint}`, initialFailure);
 	const spawn = resolveWorkerSpawnCmd(LSP_MUX_WORKER_ARG);
 	for (let attempt = 0; attempt < ENSURE_ATTEMPTS; attempt++) {
 		signal?.throwIfAborted();
 		// A concurrent start may have won since the last round; adopt it.
-		if (await probeMux(endpoint)) return endpoint;
+		const probeFailure = await probeMuxFailure(endpoint);
+		if (!probeFailure) return endpoint;
+		lastFailure = contextualError(`LSP mux probe failed at ${endpoint}`, probeFailure);
 		const existing = await describeQuietly(client, LSP_MUX_DAEMON_NAME, "LSP mux", signal);
 		if (existing && existing.state !== "exited" && existing.state !== "failed") {
 			if (existing.readyAt === undefined) {
 				await waitReady(client, LSP_MUX_DAEMON_NAME, "LSP mux", signal, READY_TIMEOUT_MS);
 			}
-			if (await probeMux(endpoint)) return endpoint;
+			const readyFailure = await probeMuxFailure(endpoint);
+			if (!readyFailure) return endpoint;
+			lastFailure = contextualError(`LSP mux remained unreachable at ${endpoint}`, readyFailure);
 			// Live record but nothing listening: replace the wedged daemon.
 			await stopQuietly(client, LSP_MUX_DAEMON_NAME, "LSP mux", signal);
 			continue;
@@ -266,25 +292,32 @@ async function ensureLspMuxDaemon(projectDir: string, signal?: AbortSignal): Pro
 				},
 				signal,
 			);
-			if (started.op !== "start") continue;
-			if (await probeMux(endpoint)) return endpoint;
+			if (started.op !== "start") {
+				lastFailure = new Error(`LSP mux broker returned ${started.op} instead of start`);
+				continue;
+			}
+			const startedFailure = await probeMuxFailure(endpoint);
+			if (!startedFailure) return endpoint;
+			lastFailure = contextualError(`LSP mux did not answer after broker start at ${endpoint}`, startedFailure);
 			await stopQuietly(client, LSP_MUX_DAEMON_NAME, "LSP mux", signal);
 		} catch (error) {
 			signal?.throwIfAborted();
-			// Lost a cross-process start race; the next round adopts the winner.
+			lastFailure = contextualError(`LSP mux broker start failed for ${client.projectDir}`, error);
+			// Preserve the debug detail for contention diagnostics; the connector
+			// emits the final contextual failure at warning level.
 			logger.debug("LSP mux start contention", {
 				name: LSP_MUX_DAEMON_NAME,
-				error: error instanceof Error ? error.message : String(error),
+				error: errorMessage(error),
 			});
 		}
 	}
-	return null;
+	throw new Error(`LSP mux unavailable for ${client.projectDir}: ${lastFailure.message}`, { cause: lastFailure });
 }
 
 /**
  * Open a broker-shared transport for one language server, ensuring the mux
- * daemon first. Returns null (after a debug log) when the shared path is
- * unavailable so the caller falls back to a process-local spawn.
+ * daemon first. Default callers receive null after a warning so they can fall
+ * back to a process-local spawn; strict callers receive the same failure.
  */
 export async function connectSharedLspTransport(opts: {
 	command: string;
@@ -292,10 +325,10 @@ export async function connectSharedLspTransport(opts: {
 	cwd: string;
 	env?: Record<string, string>;
 	signal?: AbortSignal;
+	requireShared?: boolean;
 }): Promise<LspTransport | null> {
 	try {
 		const endpoint = await ensureLspMuxDaemon(opts.cwd, opts.signal);
-		if (!endpoint) return null;
 		return await dialMuxServer(endpoint, {
 			command: opts.command,
 			args: opts.args,
@@ -304,11 +337,21 @@ export async function connectSharedLspTransport(opts: {
 		});
 	} catch (error) {
 		if (opts.signal?.aborted) throw error;
-		logger.debug("Shared LSP transport unavailable; falling back to local spawn", {
-			command: opts.command,
-			cwd: opts.cwd,
-			error: error instanceof Error ? error.message : String(error),
+		const failure = new Error(`Shared LSP transport unavailable for ${opts.cwd}: ${errorMessage(error)}`, {
+			cause: error,
 		});
+		logger.warn(
+			opts.requireShared
+				? "Shared LSP transport unavailable; strict mode prevented private spawn"
+				: "Shared LSP transport unavailable; falling back to local spawn",
+			{
+				command: opts.command,
+				cwd: opts.cwd,
+				error: failure.message,
+				requireShared: opts.requireShared === true,
+			},
+		);
+		if (opts.requireShared) throw failure;
 		return null;
 	}
 }

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -128,7 +128,7 @@ import {
 import { type FileSlashCommand, loadSlashCommands as loadSlashCommandsInternal } from "./extensibility/slash-commands";
 import type { HindsightSessionState } from "./hindsight/state";
 import { LocalProtocolHandler, type LocalProtocolOptions } from "./internal-urls";
-import { setSharedLspEnabled } from "./lsp/client";
+import { setSharedLspEnabled, setSharedLspRequired } from "./lsp/client";
 import { LSP_STARTUP_EVENT_CHANNEL, type LspStartupEvent } from "./lsp/startup-events";
 import {
 	deduplicateMCPToolsByName,
@@ -4034,8 +4034,10 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 
 		// Broker-shared language servers: one server per project, multiplexed
 		// across omp instances by the LSP mux daemon. Session-level because the
-		// flag lives in module state consulted on every client cold-start.
-		setSharedLspEnabled(enableLsp && settings.get("lsp.shared"));
+		// flags live in module state consulted on every client cold-start.
+		const sharedLsp = enableLsp && settings.get("lsp.shared");
+		setSharedLspEnabled(sharedLsp);
+		setSharedLspRequired(sharedLsp && settings.get("lsp.requireShared"));
 
 		// Start LSP warmup in the background so startup does not block on language server initialization.
 		// With `lsp.lazy` (the default) the warmup is skipped: recognized servers are still discovered and

--- a/packages/coding-agent/test/lsp-shared-client.test.ts
+++ b/packages/coding-agent/test/lsp-shared-client.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { closeDaemonClients, daemonClientForProject } from "../src/launch/client";
+import {
+	getOrCreateClient,
+	sendRequest,
+	setSharedLspEnabled,
+	setSharedLspRequired,
+	shutdownAll,
+} from "../src/lsp/client";
+import { LSP_MUX_DAEMON_NAME } from "../src/lsp/mux/protocol";
+import { connectSharedLspTransport } from "../src/lsp/mux/daemon";
+import type { ServerConfig } from "../src/lsp/types";
+
+const testRoot = path.resolve(import.meta.dir, "../../../build/task108-lsp-integration");
+const fixturePath = path.join(import.meta.dir, "fixtures", "fake-lsp-server.ts");
+const originalCompiled = process.env.PI_COMPILED;
+const projects = new Set<string>();
+
+function fakeServerConfig(): ServerConfig {
+	return {
+		command: process.execPath,
+		args: ["run", fixturePath],
+		fileTypes: [".fake"],
+		languageId: "fake",
+		rootMarkers: [".git"],
+	};
+}
+
+async function makeProject(): Promise<string> {
+	await fs.mkdir(testRoot, { recursive: true });
+	const projectDir = await fs.mkdtemp(path.join(testRoot, "project-"));
+	await fs.writeFile(path.join(projectDir, ".git"), "test project\n");
+	projects.add(projectDir);
+	return projectDir;
+}
+
+async function stopProjectMux(projectDir: string): Promise<void> {
+	try {
+		const broker = await daemonClientForProject(projectDir);
+		await broker.request({ op: "stop", name: LSP_MUX_DAEMON_NAME, timeoutMs: 5_000 });
+	} catch {
+		// The strict failure test intentionally leaves no ready mux to stop.
+	}
+}
+
+async function describeProjectMux(projectDir: string): Promise<{ state: string; pid?: number }> {
+	const broker = await daemonClientForProject(projectDir);
+	const result = await broker.request({ op: "describe", name: LSP_MUX_DAEMON_NAME });
+	if (result.op !== "describe") throw new Error(`unexpected broker response: ${result.op}`);
+	return { state: result.daemon.state, pid: result.daemon.pid };
+}
+
+afterEach(async () => {
+	setSharedLspEnabled(false);
+	setSharedLspRequired(false);
+	if (originalCompiled === undefined) delete process.env.PI_COMPILED;
+	else process.env.PI_COMPILED = originalCompiled;
+	await shutdownAll();
+	for (const projectDir of projects) await stopProjectMux(projectDir);
+	await closeDaemonClients();
+	projects.clear();
+	await fs.rm(testRoot, { recursive: true, force: true });
+});
+
+describe("broker-shared LSP client", () => {
+	it("starts one broker mux and reuses its serial client", async () => {
+		const projectDir = await makeProject();
+		setSharedLspEnabled(true);
+		setSharedLspRequired(false);
+
+		const client = await getOrCreateClient(fakeServerConfig(), projectDir, 20_000);
+		expect(client.proc.sharedMux).toBe(true);
+		expect(await sendRequest(client, "test/echo", { value: 1 })).toEqual({ value: 1 });
+		expect(await getOrCreateClient(fakeServerConfig(), projectDir)).toBe(client);
+
+		const mux = await describeProjectMux(projectDir);
+		expect(mux.state).toBe("ready");
+		expect(mux.pid).toBeTypeOf("number");
+	});
+
+	it("converges concurrent connector calls on one project mux", async () => {
+		const projectDir = await makeProject();
+		setSharedLspEnabled(true);
+		setSharedLspRequired(false);
+		const config = fakeServerConfig();
+		const transports = await Promise.all(
+			Array.from({ length: 5 }, () =>
+				connectSharedLspTransport({
+					command: config.command,
+					args: config.args ?? [],
+					cwd: projectDir,
+				}),
+			),
+		);
+
+		expect(transports).toHaveLength(5);
+		expect(transports.every(transport => transport?.sharedMux === true)).toBe(true);
+		const mux = await describeProjectMux(projectDir);
+		expect(mux.state).toBe("ready");
+		expect(mux.pid).toBeTypeOf("number");
+		for (const transport of transports) transport?.kill();
+	});
+
+	it("fails closed with the mux cause and cleans the client lock", async () => {
+		const projectDir = await makeProject();
+		setSharedLspEnabled(true);
+		setSharedLspRequired(true);
+		// Keep the broker valid, then make only the mux worker command invalid.
+		const broker = await daemonClientForProject(projectDir);
+		await broker.request({ op: "ping" });
+		process.env.PI_COMPILED = "1";
+
+		await expect(getOrCreateClient(fakeServerConfig(), projectDir, 20_000)).rejects.toThrow(/LSP mux unavailable/);
+
+		// The same client key must be retryable after strict mode is disabled;
+		// this also proves the strict rejection did not spawn the fake server.
+		setSharedLspRequired(false);
+		const privateClient = await getOrCreateClient(fakeServerConfig(), projectDir, 20_000);
+		expect(privateClient.proc.sharedMux).not.toBe(true);
+		expect(await sendRequest(privateClient, "test/echo", { value: 2 })).toEqual({ value: 2 });
+	});
+});


### PR DESCRIPTION
## Summary

- Add opt-in `lsp.requireShared` setting, wired from SDK session settings and documented separately from `.omp/lsp.yaml`.
- Preserve broker/mux startup, probe, and handshake causes; emit a warning before the existing private fallback.
- In strict mode, return a contextual error before `ptree.spawn`; clean rejected client locks so the same key can retry.
- Preserve external `lspmux` precedence and default fallback behavior.

## Verification

- `bun test packages/coding-agent/test/lsp-shared-client.test.ts packages/coding-agent/test/lsp-mux.test.ts`
- 12 pass, 37 expect() calls.
- The integration tests exercise the real broker, mux worker, serial reuse, concurrent connector startup, strict mux-worker failure, and compatibility fallback.

The mux intentionally allocates one language-server child per active link to isolate unsaved document overlays; this change verifies one broker-owned project mux under contention and does not alter that upstream isolation contract. Related context: #10628.