### PR TITLE
fix(mnemopi): clamp metric-fact prefix window to nearest structural boundary

### DIFF
--- a/packages/mnemopi/src/core/beam/consolidate.ts
+++ b/packages/mnemopi/src/core/beam/consolidate.ts
@@ -576,8 +576,26 @@ export function extractAndStoreFacts(
 		const rawUnit = match[2] ?? "";
 		let unit = rawUnit.toLowerCase();
 		if (unit.endsWith("s") && !unit.endsWith("ms")) unit = unit.slice(0, -1);
-		const prefixWords = text
-			.slice(Math.max(0, (match.index ?? 0) - 50), match.index ?? 0)
+		// The naive fixed 50-char lookbehind can cross a markdown table cell, a code fence, or
+		// a sentence boundary and glue unrelated words into one underscore-joined key (e.g.
+		// "iam-role_smrx/sm-secrets_ssm-parameters_api" -> "2api" from a table row, or
+		// "cadence_90/60/5_30-_second" from a run-on list). Clamping the window to start after
+		// the nearest preceding structural boundary -- newline, table pipe, sentence-ending
+		// punctuation, or a backtick -- keeps the phrase within one cell/sentence/line, matching
+		// what a human would read as "the words right before this number" rather than 50 raw
+		// characters regardless of what they cross.
+		//
+		// A bare `.` is NOT always a sentence boundary: "v1.2", "3.14", "18.0.8" all contain
+		// dots that are part of a version/decimal number, not sentence punctuation. Only count
+		// `.`/`!`/`?` as a boundary when followed by whitespace or the end of the window -- i.e.
+		// it actually ends a sentence.
+		const windowStart = Math.max(0, (match.index ?? 0) - 50);
+		let window = text.slice(windowStart, match.index ?? 0);
+		const boundaryMatch = /\n|\||`|[.!?](?=\s|$)|;/g;
+		let lastBoundary = -1;
+		for (let m = boundaryMatch.exec(window); m; m = boundaryMatch.exec(window)) lastBoundary = m.index;
+		if (lastBoundary !== -1) window = window.slice(lastBoundary + 1);
+		const prefixWords = window
 			.replace(/`[^`]*`/g, " ")
 			.split(/\s+/)
 			.map(w => w.replace(/[.,:;!?()[\]"'`*_]/g, ""))

--- a/packages/mnemopi/test/beam-consolidate-unit.test.ts
+++ b/packages/mnemopi/test/beam-consolidate-unit.test.ts
@@ -353,4 +353,123 @@ describe("beam consolidation free functions", () => {
 		const facts = beam.db.query("SELECT COUNT(*) AS count FROM memoria_facts").get() as { count: number };
 		expect(facts.count).toBe(0);
 	});
+
+	it("metric prefix stops at a markdown table pipe, not 50 raw chars back (regression, garbled-metric-facts audit 2026-09-03)", () => {
+		const beam = trackedState();
+		// Real garbled sample from a live bank: "iam-role_smrx/sm-secrets_ssm-parameters_api" -> "2api",
+		// produced when the 50-char lookbehind crossed a table row's pipe delimiters and glued
+		// three unrelated cells together.
+		const text = "| iam-role | smrx/sm-secrets | ssm-parameters | uses 2 APIs |\n";
+		extractAndStoreFacts(beam, text, 1, "table-row-source");
+
+		const rows = beam.db.query("SELECT subject, object FROM facts WHERE predicate = 'metric'").all() as Array<{
+			subject: string;
+			object: string;
+		}>;
+		expect(rows.length).toBeGreaterThanOrEqual(1);
+		for (const row of rows) {
+			expect(row.subject).not.toContain("iam-role");
+			expect(row.subject).not.toContain("secrets");
+			expect(row.subject).not.toContain("ssm-parameters");
+		}
+		expect(rows.some(row => row.subject === "uses_api")).toBe(true);
+	});
+
+	it("metric prefix stops at a sentence boundary, not 50 raw chars back", () => {
+		const beam = trackedState();
+		// Real garbled sample: "owns_both+rewrote_one_second" -> "30seconds", from a run-on
+		// sentence where the lookbehind crossed a period into an unrelated prior clause.
+		const text = "Alice owns both services. Bob rewrote the migration step in 30 seconds flat.\n";
+		extractAndStoreFacts(beam, text, 1, "sentence-source");
+
+		const rows = beam.db.query("SELECT subject, object FROM facts WHERE predicate = 'metric'").all() as Array<{
+			subject: string;
+			object: string;
+		}>;
+		expect(rows.length).toBeGreaterThanOrEqual(1);
+		for (const row of rows) {
+			expect(row.subject).not.toContain("owns");
+			expect(row.subject).not.toContain("both");
+		}
+	});
+
+	it("still extracts a clean metric key from a normal single-line sentence (no false negatives)", () => {
+		const beam = trackedState();
+		const text = "The p99 response time is 250ms under load.\n";
+		extractAndStoreFacts(beam, text, 1, "clean-source");
+
+		const rows = beam.db.query("SELECT subject, object FROM facts WHERE predicate = 'metric'").all() as Array<{
+			subject: string;
+			object: string;
+		}>;
+		expect(rows.length).toBe(1);
+		expect(rows[0]?.subject).toBe("p99_response_time_ms");
+		expect(rows[0]?.object).toBe("250ms");
+	});
+
+	it("still extracts known-good short technical metric names that trip the review script's heuristic", () => {
+		const beam = trackedState();
+		const text = "The imdsv2 max lifetime is 15 days by policy.\n";
+		extractAndStoreFacts(beam, text, 1, "short-key-source");
+
+		const rows = beam.db.query("SELECT subject, object FROM facts WHERE predicate = 'metric'").all() as Array<{
+			subject: string;
+			object: string;
+		}>;
+		expect(rows.length).toBe(1);
+		expect(rows[0]?.subject).toBe("imdsv2_max_lifetime_day");
+		expect(rows[0]?.object).toBe("15days");
+	});
+
+	it("does not treat a version/decimal dot as a sentence boundary (regression, blocker-review fix)", () => {
+		const beam = trackedState();
+		// "v1.2" and "3.14"-style dots must NOT truncate the prefix window: only a `.` followed
+		// by whitespace (a real sentence end) is a boundary. Before this correction, the naive
+		// `[.!?;]` boundary set treated every literal dot as a break, silently dropping
+		// "Deployed" from the key and changing extraction behavior for ordinary version mentions.
+		const text = "Deployed v1.2 migration finished in 30 seconds flat.\n";
+		extractAndStoreFacts(beam, text, 1, "version-dot-source");
+
+		const rows = beam.db.query("SELECT subject, object FROM facts WHERE predicate = 'metric'").all() as Array<{
+			subject: string;
+			object: string;
+		}>;
+		expect(rows.length).toBe(1);
+		expect(rows[0]?.subject).toBe("v12_migration_finished_second");
+		expect(rows[0]?.object).toBe("30seconds");
+	});
+
+	it("still truncates at a real sentence-ending period even when an earlier version dot is present", () => {
+		const beam = trackedState();
+		// Confirms the fix distinguishes "v1.2" (decimal, not a boundary) from the period that
+		// actually ends the first sentence -- the extractor must still stop there.
+		const text = "Deployed v1.2. Migration finished in 30 seconds flat.\n";
+		extractAndStoreFacts(beam, text, 1, "sentence-after-version-source");
+
+		const rows = beam.db.query("SELECT subject, object FROM facts WHERE predicate = 'metric'").all() as Array<{
+			subject: string;
+			object: string;
+		}>;
+		expect(rows.length).toBe(1);
+		expect(rows[0]?.subject).toBe("migration_finished_second");
+		expect(rows[0]?.subject).not.toContain("v1");
+		expect(rows[0]?.subject).not.toContain("deployed");
+	});
+
+	it("does not leak words from before a backtick code span into the metric key", () => {
+		const beam = trackedState();
+		// The backtick boundary must stop the window at the code span, not just mask its
+		// contents -- otherwise words before the span could still glue onto the key.
+		const text = "Run `npm install --legacy-peer-deps` then wait about 30 seconds for it to finish.\n";
+		extractAndStoreFacts(beam, text, 1, "backtick-source");
+
+		const rows = beam.db.query("SELECT subject, object FROM facts WHERE predicate = 'metric'").all() as Array<{
+			subject: string;
+			object: string;
+		}>;
+		expect(rows.length).toBe(1);
+		expect(rows[0]?.subject).not.toContain("npm");
+		expect(rows[0]?.subject).not.toContain("install");
+		expect(rows[0]?.subject).not.toContain("run");
+	});
 });


### PR DESCRIPTION
## Problem

`extractAndStoreFacts` in `packages/mnemopi/src/core/beam/consolidate.ts` builds a `metric` fact key by taking the 50 raw characters immediately preceding each `\d+ (unit)` match and joining the last 3 filtered words with underscores.

When that fixed 50-char window crosses a markdown table pipe, a code fence, or a sentence boundary, it glues unrelated words from different cells/sentences into one garbage key. Measured against live Mnemopi banks (2026-09-03): ~2-5% of all `metric` facts across every bank checked matched this pattern, e.g.:

```
"iam-role_smrx/sm-secrets_ssm-parameters_api" -> "2api"
"owns_both+rewrote_one_second" -> "30seconds"
"cadence_90/60/5_30-_second" -> "60seconds"
```

## Fix

Clamp the lookbehind window to start immediately after the nearest preceding structural boundary — newline, table pipe (`|`), backtick, or sentence-ending punctuation (`.!?;`) — so the extracted phrase never crosses into a different table cell, sentence, or line.

**Important correction from an earlier version of this PR**: a bare `.` is not always a sentence boundary — `v1.2`, `3.14`, `18.0.8` all embed dots that are part of a version/decimal number, not sentence punctuation. `.`/`!`/`?` only count as a boundary when followed by whitespace or the end of the window, never when immediately followed by a digit. This is verified by a dedicated regression test that checks both the false-positive case (`"Deployed v1.2 migration..."` — dot must NOT truncate) and that a real sentence-ending period right after a version mention (`"Deployed v1.2. Migration..."`) still correctly truncates.

## Testing

- 7 new regression tests:
  - Table-row and run-on-sentence leaks (the confirmed-garbled patterns)
  - Two false-negative guards (known-good metric phrases, including a short technical name that would trip a naive "looks garbled" heuristic)
  - Version/decimal-dot false-positive guard, and its counterpart confirming a real sentence boundary after a version mention still truncates correctly
  - Backtick code-span leak guard
- Full `packages/mnemopi` test suite: **463 pass, 0 fail, 74 files** — no regressions.
- Verified the original regression tests fail against the pre-fix code (confirms the bug is real) and all pass after the fix.

Branch based on the `18.0.8` tag commit to match the currently-released version; no other files touched.
