### PR TITLE
fix(coding-agent): keep automatic snapcompact baseline local

### DIFF
--- a/packages/coding-agent/src/session/session-maintenance.ts
+++ b/packages/coding-agent/src/session/session-maintenance.ts
@@ -117,6 +117,9 @@ const COMPACTION_CHECK_BLOCK_AUTOMATIC_CONTINUATION: CompactionCheckResult = {
 	continuationScheduled: false,
 	automaticContinuationBlocked: true,
 };
+const RELIABLE_LOCAL_MESSAGE_COUNT_OPTIONS = {
+	excludeEncryptedReasoning: true,
+} as const satisfies MessageCountOptions;
 
 /**
  * Consecutive `response.incomplete` (length-stop) recoveries that produce no
@@ -973,27 +976,18 @@ export class SessionMaintenance {
 						ctxWindow > 0
 							? ctxWindow - effectiveReserveTokens(ctxWindow, effectiveSettings)
 							: Number.POSITIVE_INFINITY;
-					const projected = this.#projectSnapcompactContextTokens(preparation, snapcompactResult);
-					// No-reduction decision runs in the encrypted-reasoning-excluded domain
-					// on both sides: opaque replay signatures (thinkingSignature /
-					// redactedThinking) have no trustworthy local token price, so counting
-					// them in the archived region's baseline while the imaged projection
-					// drops them lets an inflating result pass the guard (#10716). The
-					// window-fit check below keeps the conservative `projected`.
-					const projectedForReduction = this.#projectSnapcompactContextTokens(preparation, snapcompactResult, {
-						excludeEncryptedReasoning: true,
-					});
+					const projection = this.#projectSnapcompactContextTokens(preparation, snapcompactResult);
 					const reductionBaseline = this.#projectPreSnapcompactContextTokens(preparation);
-					if (projectedForReduction >= reductionBaseline) {
+					if (projection.reductionTokens >= reductionBaseline) {
 						logger.warn("Snapcompact projection would not reduce context", {
 							model: this.#model?.id,
-							projected: projectedForReduction,
+							projected: projection.reductionTokens,
 							reductionBaseline,
 						});
 						this.#host.emitNotice("warning", "snapcompact would not reduce context.", "compaction");
 						throw new Error("snapcompact would not reduce context locally.");
 					}
-					if (projected > budget) {
+					if (projection.budgetTokens > budget) {
 						logger.warn("Snapcompact still overflows the window after frame-budget sizing", {
 							model: this.#model?.id,
 						});
@@ -1572,11 +1566,10 @@ export class SessionMaintenance {
 		// diverges from what the provider bills, so counting it would let a
 		// thinking-heavy turn falsely trip the floor. The provider usage (the
 		// other arm of compactionContextTokens) already accounts for it.
-		const opts = { excludeEncryptedReasoning: true } as const;
 		return (
 			computeNonMessageTokens(this.#host.nonMessageTokenSource(), this.#tokenizer) +
-			this.#tokenizer.countMessages(this.#host.messages(), opts) +
-			this.#tokenizer.countMessages(pendingMessages, opts)
+			this.#tokenizer.countMessages(this.#host.messages(), RELIABLE_LOCAL_MESSAGE_COUNT_OPTIONS) +
+			this.#tokenizer.countMessages(pendingMessages, RELIABLE_LOCAL_MESSAGE_COUNT_OPTIONS)
 		);
 	}
 
@@ -1609,13 +1602,15 @@ export class SessionMaintenance {
 	 * imaged projection drops — inflated this baseline enough to accept an
 	 * inflating result (#10716). The caller's reduction-side projection excludes
 	 * them symmetrically so the comparison stays in one local token domain.
+	 * Automatic triggers deliberately do not substitute `triggerContextTokens`
+	 * here: that value can be provider-anchored or include pending input, neither
+	 * of which is part of this prepared local history (#10716).
 	 */
 	#projectPreSnapcompactContextTokens(preparation: CompactionPreparation): number {
-		const opts = { excludeEncryptedReasoning: true } as const;
 		let tokens = computeNonMessageTokens(this.#host.nonMessageTokenSource(), this.#tokenizer);
-		tokens += this.#tokenizer.countMessages(preparation.messagesToSummarize, opts);
-		tokens += this.#tokenizer.countMessages(preparation.turnPrefixMessages, opts);
-		tokens += this.#tokenizer.countMessages(preparation.recentMessages, opts);
+		tokens += this.#tokenizer.countMessages(preparation.messagesToSummarize, RELIABLE_LOCAL_MESSAGE_COUNT_OPTIONS);
+		tokens += this.#tokenizer.countMessages(preparation.turnPrefixMessages, RELIABLE_LOCAL_MESSAGE_COUNT_OPTIONS);
+		tokens += this.#tokenizer.countMessages(preparation.recentMessages, RELIABLE_LOCAL_MESSAGE_COUNT_OPTIONS);
 		return tokens;
 	}
 
@@ -1674,8 +1669,6 @@ export class SessionMaintenance {
 		await this.runAutoCompaction("threshold", false, false, false, {
 			autoContinue: false,
 			triggerContextTokens: contextTokens,
-			pendingContextTokens: this.#tokenizer.countMessages(messages),
-			preparedContextTokens: this.#estimateStoredContextTokens(),
 			phase: "pre_turn",
 		});
 	}
@@ -2499,18 +2492,16 @@ export class SessionMaintenance {
 	}
 
 	/**
-	 * Project the post-compaction context size of a snapcompact result: kept
-	 * recent messages + the summary message with its re-attached frames + the
-	 * fixed non-message overhead (system prompt + tools). Mirrors how the
-	 * compacted context is rebuilt, so the estimate matches the wire shape, and
-	 * lets the caller decide whether snapcompact brought the context under the
-	 * window or should fall back to an LLM summary.
+	 * Project post-snapcompact context in two domains. `budgetTokens`
+	 * conservatively includes opaque provider-replay payloads because they are
+	 * billed when replayed. `reductionTokens` excludes their untrustworthy local
+	 * byte size so the no-reduction guard compares the same reliable content
+	 * before and after snapcompact.
 	 */
 	#projectSnapcompactContextTokens(
 		preparation: CompactionPreparation,
 		result: snapcompact.CompactionResult,
-		options?: MessageCountOptions,
-	): number {
+	): { budgetTokens: number; reductionTokens: number } {
 		const archive = snapcompact.getPreservedArchive(result.preserveData);
 		const blocks = archive
 			? snapcompact.historyBlocks(archive, { maxFrameDataBytes: snapcompact.FRAME_DATA_BYTES_BUDGET })
@@ -2524,11 +2515,15 @@ export class SessionMaintenance {
 				blocks,
 			},
 		);
-		let tokens =
+		const sharedTokens =
 			computeNonMessageTokens(this.#host.nonMessageTokenSource(), this.#tokenizer) +
 			this.#tokenizer.countMessage(summaryMessage);
-		tokens += this.#tokenizer.countMessages(preparation.recentMessages, options);
-		return tokens;
+		return {
+			budgetTokens: sharedTokens + this.#tokenizer.countMessages(preparation.recentMessages),
+			reductionTokens:
+				sharedTokens +
+				this.#tokenizer.countMessages(preparation.recentMessages, RELIABLE_LOCAL_MESSAGE_COUNT_OPTIONS),
+		};
 	}
 
 	/**
@@ -2958,10 +2953,6 @@ export class SessionMaintenance {
 		options: {
 			autoContinue?: boolean;
 			triggerContextTokens?: number;
-			/** Tokens from pending messages included in triggerContextTokens but absent from the prepared history. */
-			pendingContextTokens?: number;
-			/** Stored context before pending messages, measured before preparation rewrites its representation. */
-			preparedContextTokens?: number;
 			suppressContinuation?: boolean;
 			phase?: CodexCompactionContext["phase"];
 			terminalTextAnswer?: boolean;
@@ -3455,40 +3446,21 @@ export class SessionMaintenance {
 								ctxWindow > 0
 									? ctxWindow - effectiveReserveTokens(ctxWindow, effectiveSettings)
 									: Number.POSITIVE_INFINITY;
-							const projected = this.#projectSnapcompactContextTokens(preparation, snapcompactResult);
-							// Reduction check in the encrypted-reasoning-excluded domain so opaque
-							// replay signatures cannot inflate the removable baseline (#10716);
-							// `triggerContextTokens` is already an encrypted-excluded stored
-							// estimate, and `#projectPreSnapcompactContextTokens` now matches it.
-							const projectedForReduction = this.#projectSnapcompactContextTokens(
-								preparation,
-								snapcompactResult,
-								{
-									excludeEncryptedReasoning: true,
-								},
-							);
-							const reductionBaseline =
-								options.triggerContextTokens !== undefined
-									? Math.max(0, options.triggerContextTokens - (options.pendingContextTokens ?? 0))
-									: this.#projectPreSnapcompactContextTokens(preparation);
-							const preparedReductionBaseline =
-								options.preparedContextTokens === undefined
-									? reductionBaseline
-									: Math.max(0, reductionBaseline - options.preparedContextTokens) +
-										this.#projectPreSnapcompactContextTokens(preparation);
-							if (projectedForReduction >= preparedReductionBaseline) {
+							const projection = this.#projectSnapcompactContextTokens(preparation, snapcompactResult);
+							const reductionBaseline = this.#projectPreSnapcompactContextTokens(preparation);
+							if (projection.reductionTokens >= reductionBaseline) {
 								logger.warn("Snapcompact projection would not reduce context", {
 									model: this.#model?.id,
-									projected: projectedForReduction,
-									reductionBaseline: preparedReductionBaseline,
+									projected: projection.reductionTokens,
+									reductionBaseline,
 								});
 								snapcompactBlocker =
 									"snapcompact would not reduce context; trying the next preferred compaction method.";
 								snapcompactResult = undefined;
-							} else if (projected > budget) {
+							} else if (projection.budgetTokens > budget) {
 								logger.warn("Snapcompact still overflows the window after frame-budget sizing", {
 									model: this.#model?.id,
-									projected,
+									projected: projection.budgetTokens,
 									budget,
 								});
 								snapcompactBlocker =

--- a/packages/coding-agent/test/agent-session-snapcompact-auto-fallback.test.ts
+++ b/packages/coding-agent/test/agent-session-snapcompact-auto-fallback.test.ts
@@ -9,6 +9,7 @@ import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import type { CompactionMethod } from "@oh-my-pi/pi-coding-agent/session/compaction-methods";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import * as snapcompact from "@oh-my-pi/snapcompact";
 
 const UNRENDERABLE_SNAPCOMPACT_TEXT = "\uE000\uE001\uE002\uE003\uE004\uE005\uE006\uE007\uE008\uE009";
 
@@ -34,7 +35,9 @@ async function createHarness(modelRegistry: ModelRegistry, options: HarnessOptio
 		initialState: { model: activeModel, systemPrompt: ["Test"], tools: [], messages: [] },
 	});
 	const sessionManager = SessionManager.inMemory();
-	const seed = options.seedMessages ?? [{ role: "user", content: "hello", timestamp: Date.now() }];
+	const seed = options.seedMessages ?? [
+		{ role: "user", content: "archived context ".repeat(256), timestamp: Date.now() },
+	];
 	for (const message of seed) sessionManager.appendMessage(message);
 	const firstKeptEntryId = sessionManager.getBranch()[0]?.id;
 	if (!firstKeptEntryId) throw new Error("Expected seeded branch entry");
@@ -65,6 +68,12 @@ async function createHarness(modelRegistry: ModelRegistry, options: HarnessOptio
 		tokensBefore: 123,
 		details: {},
 	});
+	vi.spyOn(snapcompact, "compact").mockImplementation(async preparation => ({
+		summary: "Reduced local snapcompact history.",
+		shortSummary: "Reduced history.",
+		firstKeptEntryId: preparation.firstKeptEntryId,
+		tokensBefore: preparation.tokensBefore,
+	}));
 	const end = Promise.withResolvers<{ action: string; errorMessage?: string }>();
 	const notices: string[] = [];
 	session.subscribe(event => {

--- a/packages/coding-agent/test/agent-session-snapcompact-encrypted-reasoning.test.ts
+++ b/packages/coding-agent/test/agent-session-snapcompact-encrypted-reasoning.test.ts
@@ -10,9 +10,10 @@
  * inflated the removable baseline above the frame projection, so an
  * inflating image-frame result was accepted and persisted (context grew).
  *
- * Contract defended: opaque reasoning bytes are excluded symmetrically from the
- * no-reduction comparison, so a result that grows reliable local content is
- * rejected regardless of how large the archived region's signature is.
+ * Contract defended: opaque reasoning bytes are excluded symmetrically from
+ * the no-reduction comparison, and automatic compaction compares against its
+ * prepared local history rather than a provider-anchored trigger. A result
+ * that grows reliable local content is rejected in both paths.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import { Agent } from "@oh-my-pi/pi-agent-core";
@@ -83,24 +84,20 @@ describe("AgentSession snapcompact no-reduction guard: opaque reasoning", () => 
 				"compaction.autoContinue": false,
 				"compaction.asyncEnabled": false,
 				"compaction.keepRecentTokens": 1,
+				"compaction.thresholdTokens": 80_000,
+				"compaction.thresholdPercent": -1,
+				"contextPromotion.enabled": false,
 			}),
 			modelRegistry,
 		});
 	});
 
-	afterEach(async () => {
-		await session?.dispose();
-		authStorage?.close();
-		vi.restoreAllMocks();
-	});
-
-	it("rejects an inflating snapcompact result even when the archived region has a huge opaque signature", async () => {
+	function stubInflatingSnapcompact() {
 		const branchEntries = sessionManager.getBranch();
 		const firstKeptEntry = branchEntries[branchEntries.length - 1];
 		if (!firstKeptEntry?.id) throw new Error("Expected branch entry with id");
-
 		const frame = { data: "ZmFrZQ==", mimeType: "image/png", cols: 64, rows: 40, chars: 4 } as const;
-		vi.spyOn(snapcompact, "compact").mockResolvedValue({
+		return vi.spyOn(snapcompact, "compact").mockResolvedValue({
 			summary: "archived onto frames",
 			shortSummary: "archived",
 			firstKeptEntryId: firstKeptEntry.id,
@@ -110,12 +107,59 @@ describe("AgentSession snapcompact no-reduction guard: opaque reasoning", () => 
 				snapcompact: { frames: [frame, frame, frame], totalChars: 12, truncatedChars: 0 },
 			},
 		});
+	}
+
+	afterEach(async () => {
+		await session?.dispose();
+		authStorage?.close();
+		vi.restoreAllMocks();
+	});
+
+	it("rejects an inflating snapcompact result even when the archived region has a huge opaque signature", async () => {
+		const compactSpy = stubInflatingSnapcompact();
 
 		// 3 frames ≈ 15k tokens >> the handful of tokens of real archived text,
 		// so this result grows reliable local content and must be rejected.
 		await expect(session.compact(undefined, { mode: "snapcompact" })).rejects.toThrow(
 			"snapcompact would not reduce context locally.",
 		);
+		expect(compactSpy).toHaveBeenCalledTimes(1);
+		expect(sessionManager.getEntries().some(entry => entry.type === "compaction")).toBe(false);
+	});
+
+	it("rejects the same inflation when provider usage triggers automatic compaction", async () => {
+		const compactSpy = stubInflatingSnapcompact();
+		const model = session.model;
+		if (!model) throw new Error("Expected active model");
+		const compactionEnd = Promise.withResolvers<string | undefined>();
+		session.subscribe(event => {
+			if (event.type === "auto_compaction_end" && event.action === "snapcompact") {
+				compactionEnd.resolve(event.errorMessage);
+			}
+		});
+		const thresholdAssistant = {
+			role: "assistant" as const,
+			content: [{ type: "text" as const, text: "threshold trigger" }],
+			api: model.api,
+			provider: model.provider,
+			model: model.id,
+			stopReason: "stop" as const,
+			usage: {
+				input: 88_483,
+				output: 10,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 88_493,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			timestamp: Date.now(),
+		};
+
+		session.agent.emitExternalEvent({ type: "message_end", message: thresholdAssistant });
+		session.agent.emitExternalEvent({ type: "agent_end", messages: [thresholdAssistant] });
+
+		expect(await compactionEnd.promise).toContain("would not reduce context");
+		expect(compactSpy).toHaveBeenCalledTimes(1);
 		expect(sessionManager.getEntries().some(entry => entry.type === "compaction")).toBe(false);
 	});
 });


### PR DESCRIPTION
## What remains after the upstream fix

Main now contains [`15b430314e`](https://github.com/can1357/oh-my-pi/commit/15b430314e7eb98c3f864b6bca6639b53790ee2d), which excludes opaque reasoning symmetrically from snapcompact's manual no-reduction comparison.

This PR has been rebased onto current `main` and now contains only the follow-up that commit did not cover: normal threshold-triggered automatic compaction can still retain a provider-only delta in its reduction baseline.

Fixes #10716.

## Remaining bug

`triggerContextTokens` is produced through `compactionContextTokens(providerUsage, storedLocal)`. When provider usage wins, the previous automatic formula preserves that provider-only delta even after adjusting for prepared local context.

For example:

```text
triggerContextTokens  = 88,483
prepared local history = about 1,000
```

A locally inflating projection below roughly 88k can still pass, although snapcompact only replaces the prepared local history. The automatic comparison is therefore not in the same reliable-local domain fixed by `15b430314e`.

## Fix

- Derive the automatic reduction baseline directly from the live `CompactionPreparation` via `#projectPreSnapcompactContextTokens()`.
- Do not use provider usage or pending input to price the prepared history snapcompact replaces.
- Remove the obsolete `pendingContextTokens` / `preparedContextTokens` normalization fields.
- Return explicit `reductionTokens` and `budgetTokens` projections so reliable-local savings and conservative model-window fit cannot be mixed.
- Reuse one `RELIABLE_LOCAL_MESSAGE_COUNT_OPTIONS` policy for all comparable local counts.

Manual and automatic guards now enforce:

```text
projection.reductionTokens < prepared reliable-local baseline
```

while `projection.budgetTokens` remains the conservative replay-fit check.

## Regression

The upstream opaque-reasoning fixture now also drives a real threshold-triggered `agent_end` with provider input usage of `88_483`.

With the provider-anchored baseline restored, the test fails because the inflating result is accepted and `auto_compaction_end.errorMessage` is absent:

```text
0 pass
1 fail
```

With this change:

```text
1 pass
0 fail
```

The test does not use `runIdleCompaction()`, so it exercises the exact automatic path called out in review.

Method-order fixtures were also corrected so successful local snapcompact cases contain genuinely reducible history rather than depending on provider-reported usage for apparent savings.

## Verification

```text
$ bun test   packages/coding-agent/test/agent-session-snapcompact-encrypted-reasoning.test.ts   packages/coding-agent/test/agent-session-snapcompact-no-reduction.test.ts   packages/coding-agent/test/agent-session-snapcompact-auto-fallback.test.ts   packages/coding-agent/test/agent-session-snapcompact-budget.test.ts   packages/coding-agent/test/agent-session-snapcompact-frame-dead-end.test.ts   packages/coding-agent/test/agent-session-manual-snapcompact-fallback.test.ts   packages/agent/test/message-cache.test.ts   packages/coding-agent/test/compaction.test.ts

83 pass
1 skip
0 fail
237 expect() calls
```

```text
$ bun run check
check:rs | Done in 22.02s
check:ts | Done in 32.86s
exit: 0
```

The only warning is the existing future-incompatibility notice for third-party `nix v0.28.0`.

## Scope after rebase

```text
packages/coding-agent/src/session/session-maintenance.ts                       +35 / -63
packages/coding-agent/test/agent-session-snapcompact-auto-fallback.test.ts     +10 / -1
packages/coding-agent/test/agent-session-snapcompact-encrypted-reasoning.test.ts +56 / -12
```

No new dependency, public API, setting, migration, changelog duplication, or compatibility alias.
