### PR TITLE
feat(acp): agent-wake notifications for parked agent-initiated turns

### DIFF
--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -163,6 +163,13 @@ function isPromptTurnInFlight(turn: PromptTurnState | undefined): turn is Prompt
 	return turn !== undefined && (!turn.settled || turn.cleanup !== undefined);
 }
 
+/** `clientCapabilities._meta["bb.dev"].agentWake === 1` — the client drains parked agent turns on wake. */
+function clientAdvertisesAgentWake(capabilities: ClientCapabilities | undefined): boolean {
+	const bbDev = capabilities?._meta?.["bb.dev"];
+	if (typeof bbDev !== "object" || bbDev === null) return false;
+	return "agentWake" in bbDev && bbDev.agentWake === 1;
+}
+
 type ManagedSessionRecord = {
 	session: AgentSession;
 	setToolUIContext: ((uiContext: ExtensionUIContext, hasUI: boolean) => void) | undefined;
@@ -613,6 +620,8 @@ export class AcpAgent implements Agent {
 	#disposePromise: Promise<void> | undefined;
 	#cleanupRegistered = false;
 	#clientCapabilities: ClientCapabilities | undefined;
+	/** Client advertised `bb.dev.agentWake` — parked agent turns get `_omp/session/wake`. */
+	#clientWakeAware = false;
 	#cancelCleanupTimeoutMs = ACP_CANCEL_CLEANUP_TIMEOUT_MS;
 	#blobs = new BlobStore(getBlobsDir());
 
@@ -629,6 +638,7 @@ export class AcpAgent implements Agent {
 	async initialize(params: InitializeRequest): Promise<InitializeResponse> {
 		this.#registerConnectionCleanup();
 		this.#clientCapabilities = params.clientCapabilities;
+		this.#clientWakeAware = clientAdvertisesAgentWake(params.clientCapabilities);
 		const authMethods: AuthMethod[] = [
 			{
 				id: "agent",
@@ -669,6 +679,9 @@ export class AcpAgent implements Agent {
 					resume: {},
 					close: {},
 				},
+				// Mirror the client's wake advertisement so it knows parked agent turns
+				// arrive as `_omp/session/wake` notifications. Spec-ignorable `_meta`,
+				...(this.#clientWakeAware ? { _meta: { "oh-my-pi": { agentWake: 1 } } } : {}),
 			},
 		};
 	}
@@ -1320,7 +1333,9 @@ export class AcpAgent implements Agent {
 		setToolUIContext: ((uiContext: ExtensionUIContext, hasUI: boolean) => void) | undefined,
 	): Promise<ManagedSessionRecord> {
 		const record = this.#createManagedSessionRecord(session, setToolUIContext);
-		session.setClientBridge(createAcpClientBridge(this.#connection, session.sessionId, this.#clientCapabilities));
+		session.setClientBridge(
+			createAcpClientBridge(this.#connection, session.sessionId, this.#clientCapabilities, this.#clientWakeAware),
+		);
 		// `record.lifetimeUnsubscribe` is installed in `#scheduleBootstrapUpdates`
 		// so it shares the bootstrap race guard — see that comment for why.
 		try {
@@ -1629,7 +1644,15 @@ export class AcpAgent implements Agent {
 			promptTurn.reject(error);
 			return;
 		}
-		promptTurn.resolve(response ?? { stopReason: "end_turn" });
+		const finalResponse = response ?? { stopReason: "end_turn" };
+		// Wake-aware clients learn about async work they cannot see yet (running or
+		// parked jobs) so they can decide whether to re-prompt; `_meta` only, never
+		// a custom stopReason or root field.
+		const pendingAsyncJobs = this.#clientWakeAware ? record.session.getPendingAsyncJobCount() : 0;
+		if (pendingAsyncJobs > 0) {
+			finalResponse._meta = { ...finalResponse._meta, "oh-my-pi": { pendingAsyncJobs } };
+		}
+		promptTurn.resolve(finalResponse);
 	}
 
 	#resolveStopReason(

--- a/packages/coding-agent/src/modes/acp/acp-client-bridge.ts
+++ b/packages/coding-agent/src/modes/acp/acp-client-bridge.ts
@@ -4,6 +4,7 @@
  * `AgentSession`) can route through the client when it advertises the
  * relevant capabilities at `initialize` time.
  */
+import { logger } from "@oh-my-pi/pi-utils";
 import type {
 	PermissionOption as AcpPermissionOption,
 	TerminalHandle as AcpTerminalHandle,
@@ -14,6 +15,7 @@ import type {
 } from "@oh-my-pi/pi-utils/acp";
 import type {
 	ClientBridge,
+	ClientBridgeAgentWakeNotification,
 	ClientBridgeCapabilities,
 	ClientBridgeCreateTerminalParams,
 	ClientBridgePermissionOption,
@@ -22,10 +24,13 @@ import type {
 	ClientBridgeTerminalHandle,
 } from "../../session/client-bridge";
 
+const AGENT_WAKE_NOTIFICATION_METHOD = "_omp/session/wake";
+
 export function createAcpClientBridge(
 	connection: AgentSideConnection,
 	sessionId: string,
 	clientCapabilities: ClientCapabilities | undefined,
+	wakeAware = false,
 ): ClientBridge {
 	const capabilities: ClientBridgeCapabilities = {
 		readTextFile: clientCapabilities?.fs?.readTextFile === true,
@@ -37,6 +42,9 @@ export function createAcpClientBridge(
 	};
 
 	const bridge: ClientBridge = { capabilities, deferAgentInitiatedTurns: true };
+	if (wakeAware) {
+		bridge.notifyAgentWake = notification => sendAgentWakeNotification(connection, sessionId, notification);
+	}
 
 	if (capabilities.readTextFile) {
 		bridge.readTextFile = async params => {
@@ -109,6 +117,28 @@ function wrapTerminalHandle(handle: AcpTerminalHandle): ClientBridgeTerminalHand
 			await handle.release();
 		},
 	};
+}
+
+function sendAgentWakeNotification(
+	connection: AgentSideConnection,
+	sessionId: string,
+	notification: ClientBridgeAgentWakeNotification,
+): void {
+	connection
+		.notify(AGENT_WAKE_NOTIFICATION_METHOD, {
+			sessionId,
+			reason: notification.reason,
+			batchId: notification.batchId,
+		})
+		.catch(error => {
+			// Fire-and-forget by design: a dropped wake only delays the parked
+			// batch until the client's next prompt, which drains it regardless.
+			logger.warn("Failed to send _omp/session/wake notification", {
+				sessionId,
+				reason: notification.reason,
+				error: error instanceof Error ? error.message : String(error),
+			});
+		});
 }
 
 async function requestPermission(

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -267,7 +267,7 @@ import {
 	isSuccessfulCheckpointEntry,
 	semanticToolResult,
 } from "./checkpoint-entries";
-import type { ClientBridge } from "./client-bridge";
+import type { ClientBridge, ClientBridgeAgentWakeReason } from "./client-bridge";
 import {
 	type CodexAutoRedeemCoordinator,
 	type CodexResetAction,
@@ -1422,6 +1422,29 @@ export class AgentSession {
 			injectIdle: async messages => {
 				const first = messages[0];
 				if (!first) return;
+				if (
+					this.#clientBridge?.deferAgentInitiatedTurns &&
+					this.#clientBridge.notifyAgentWake &&
+					!this.#allowAcpAgentInitiatedTurns
+				) {
+					// Wake-aware client: park the settled batch for the client's next
+					// prompt instead of a server-initiated turn it cannot show as busy.
+					// Returning normally settles the flush receipts (ASIDE_MESSAGE_COMMIT),
+					// so the delivery pipeline sees the batch as handed off, not stuck.
+					// Every idle dispatcher (async-result, launch completion) builds a
+					// session CustomMessage; the queue only types it as core AgentMessage.
+					const parked = messages.filter((message): message is CustomMessage => message.role === "custom");
+					if (parked.length < messages.length) {
+						logger.warn("Wake parking dropped non-custom idle messages", {
+							dropped: messages.length - parked.length,
+						});
+					}
+					for (const message of parked) {
+						this.#queueHiddenNextTurnMessage(message, false);
+					}
+					this.#notifyAgentWake("async-jobs-settled");
+					return;
+				}
 				this.#beginInFlight();
 				try {
 					await this.agent.prompt(messages.length === 1 ? first : messages);
@@ -2090,30 +2113,26 @@ export class AgentSession {
 	}
 
 	/**
-	 * True when a background async job owned by this agent is still running with
-	 * an unsuppressed delivery, a finished job's delivery is still queued or in
-	 * flight, or a delivered result is still sitting on the yield queue awaiting
-	 * injection. In every case the async-result follow-up will re-wake the loop,
-	 * so a settle observed now is a scheduling pause rather than a terminal stop:
-	 * stop-time passes (todo reminder, session_stop hooks) defer to the settle
-	 * reached once the session is fully idle. Suppressed deliveries
-	 * (acknowledged, or watched by an in-flight `hub` wait) never wake the loop,
-	 * so they don't count.
+	 * Number of owner-scoped async jobs whose results are not yet visible in
+	 * this session's transcript: running jobs with an unsuppressed delivery,
+	 * finished jobs whose delivery is still queued or in flight, and delivered
+	 * results still sitting on the yield queue awaiting injection. In every
+	 * case the async-result follow-up will re-wake the loop, so a settle
+	 * observed now is a scheduling pause rather than a terminal stop. Suppressed
+	 * deliveries (acknowledged, or watched by an in-flight `hub` wait) never
+	 * wake the loop, so they don't count.
 	 */
-	#hasPendingAsyncWake(): boolean {
+	getPendingAsyncJobCount(): number {
 		const manager = this.#asyncJobManager;
-		if (!manager) return false;
+		if (!manager) return 0;
 		const ownerFilter = this.#agentId ? { ownerId: this.#agentId } : undefined;
-		return (
-			manager.getRunningJobs(ownerFilter).some(job => !manager.isDeliverySuppressed(job.id)) ||
-			manager.hasPendingDeliveries(ownerFilter) ||
-			// Delivered but not yet injected: the sink has enqueued the
-			// async-result follow-up on the yield queue, and the manager no
-			// longer reports it. Without this leg a terminal yield in the
-			// (idle-flush delay / step-boundary) handoff window would read as
-			// quiescent and the run driver would drop the queued result.
-			this.yieldQueue.has(ASYNC_RESULT_MESSAGE_TYPE)
-		);
+		const running = manager.getRunningJobs(ownerFilter).filter(job => !manager.isDeliverySuppressed(job.id)).length;
+		// queued already includes in-flight deliveries (see getDeliveryState).
+		return running + manager.getDeliveryState(ownerFilter).queued + this.yieldQueue.count(ASYNC_RESULT_MESSAGE_TYPE);
+	}
+
+	#hasPendingAsyncWake(): boolean {
+		return this.getPendingAsyncJobCount() > 0;
 	}
 
 	/**
@@ -6874,6 +6893,13 @@ export class AgentSession {
 		);
 	}
 
+	/** Tell a wake-aware client that agent work is parked awaiting its next prompt. */
+	#notifyAgentWake(reason: ClientBridgeAgentWakeReason): void {
+		const bridge = this.#clientBridge;
+		if (!bridge?.notifyAgentWake) return;
+		bridge.notifyAgentWake({ reason, batchId: Bun.randomUUIDv7() });
+	}
+
 	async #promptQueuedHiddenNextTurnMessages(): Promise<void> {
 		if (this.#pendingNextTurnMessages.length === 0) {
 			return;
@@ -7077,6 +7103,7 @@ export class AgentSession {
 			if (options?.triggerTurn) {
 				if (this.#clientBridge?.deferAgentInitiatedTurns && !this.#allowAcpAgentInitiatedTurns) {
 					this.#queueHiddenNextTurnMessage(normalizedAppMessage, false);
+					this.#notifyAgentWake("agent-initiated");
 					return false;
 				}
 				return await this.#promptAgentInitiatedMessage(normalizedAppMessage, {
@@ -7116,6 +7143,7 @@ export class AgentSession {
 			}
 			if (this.#clientBridge?.deferAgentInitiatedTurns && !this.#allowAcpAgentInitiatedTurns) {
 				this.#queueHiddenNextTurnMessage(normalizedAppMessage, false);
+				this.#notifyAgentWake("agent-initiated");
 				return false;
 			}
 			return await this.#promptAgentInitiatedMessage(normalizedAppMessage, {
@@ -7126,6 +7154,7 @@ export class AgentSession {
 		if (options?.triggerTurn) {
 			if (this.#clientBridge?.deferAgentInitiatedTurns && !this.#allowAcpAgentInitiatedTurns) {
 				this.#queueHiddenNextTurnMessage(normalizedAppMessage, false);
+				this.#notifyAgentWake("agent-initiated");
 				return false;
 			}
 			return await this.#promptAgentInitiatedMessage(normalizedAppMessage);

--- a/packages/coding-agent/src/session/client-bridge.ts
+++ b/packages/coding-agent/src/session/client-bridge.ts
@@ -31,6 +31,15 @@ export interface ClientBridgePermissionToolCall {
 	locations?: { path: string; line?: number }[];
 }
 
+/** Reason an agent-side wake notification was emitted after parking agent work. */
+export type ClientBridgeAgentWakeReason = "async-jobs-settled" | "agent-initiated";
+
+export interface ClientBridgeAgentWakeNotification {
+	reason: ClientBridgeAgentWakeReason;
+	/** Correlates one parked batch; clients may use it to dedupe wake notifications. */
+	batchId: string;
+}
+
 export type ClientBridgePermissionOptionKind = "allow_once" | "allow_always" | "reject_once" | "reject_always";
 
 export interface ClientBridgePermissionOption {
@@ -74,6 +83,12 @@ export interface ClientBridge {
 	readonly capabilities: ClientBridgeCapabilities;
 	/** ACP v1 clients cannot show server-initiated turns as busy after prompt response. */
 	readonly deferAgentInitiatedTurns?: boolean;
+	/**
+	 * Present only when the client advertised wake awareness at `initialize`.
+	 * Emitted after agent work is parked for the client's next prompt instead of
+	 * starting a server-initiated turn the client cannot show as busy.
+	 */
+	notifyAgentWake?(notification: ClientBridgeAgentWakeNotification): void;
 	readTextFile?(params: { path: string; line?: number; limit?: number }): Promise<string>;
 	writeTextFile?(params: { path: string; content: string }): Promise<void>;
 	createTerminal?(params: ClientBridgeCreateTerminalParams): Promise<ClientBridgeTerminalHandle>;

--- a/packages/coding-agent/src/session/yield-queue.ts
+++ b/packages/coding-agent/src/session/yield-queue.ts
@@ -102,6 +102,11 @@ export class YieldQueue {
 		return false;
 	}
 
+	/** Number of queued (not yet drained) entries for a kind. */
+	count(kind: string): number {
+		return this.#entries.get(kind)?.length ?? 0;
+	}
+
 	/** Arrange an idle flush for entries queued near the end of a streaming run. */
 	requestIdleFlush(): void {
 		for (const [kind, dispatcher] of this.#dispatchers) {

--- a/packages/coding-agent/test/acp-agent-wake.test.ts
+++ b/packages/coding-agent/test/acp-agent-wake.test.ts
@@ -1,0 +1,551 @@
+/**
+ * ACP agent wake (`clientCapabilities._meta["bb.dev"].agentWake`): wake-aware
+ * clients get parked agent-initiated turns plus `_omp/session/wake`
+ * notifications instead of server-initiated turns they cannot show as busy,
+ * and `session/prompt` responses carry `pendingAsyncJobs` in
+ * `PromptResponse._meta`. Non-advertising clients keep today's behavior.
+ */
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Agent } from "@oh-my-pi/pi-agent-core";
+import type { Model } from "@oh-my-pi/pi-ai";
+import { createMockModel, type MockModel } from "@oh-my-pi/pi-ai/providers/mock";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { AsyncJobManager } from "@oh-my-pi/pi-coding-agent/async";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { AcpAgent } from "@oh-my-pi/pi-coding-agent/modes/acp/acp-agent";
+import { createAcpClientBridge } from "@oh-my-pi/pi-coding-agent/modes/acp/acp-client-bridge";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { convertToLlm } from "@oh-my-pi/pi-coding-agent/session/messages";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { getConfigRootDir, setAgentDir } from "@oh-my-pi/pi-utils";
+import type {
+	AgentSideConnection,
+	ClientCapabilities,
+	InitializeRequest,
+	NewSessionRequest,
+	PromptRequest,
+	SessionNotification,
+	Validator,
+} from "@oh-my-pi/pi-utils/acp";
+import { zNewSessionResponse, zPromptResponse } from "@oh-my-pi/pi-utils/acp";
+
+/** Validates an ACP wire payload against the in-house protocol schemas. */
+function expectAcpStructure(schema: Validator<unknown>, value: unknown): void {
+	const result = schema.safeParse(value);
+	expect(result.success, result.success ? undefined : JSON.stringify(result.error.issues, null, 2)).toBe(true);
+}
+
+const TEST_MODELS: Model[] = [
+	buildModel({
+		id: "claude-sonnet-4-20250514",
+		name: "Claude Sonnet",
+		api: "anthropic-messages",
+		provider: "anthropic",
+		baseUrl: "https://example.invalid",
+		reasoning: true,
+		input: ["text", "image"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 200_000,
+		maxTokens: 8_192,
+	}),
+];
+
+interface RecordedNotification {
+	method: string;
+	params: unknown;
+}
+
+function createRecordingConnection(): { connection: AgentSideConnection; notifications: RecordedNotification[] } {
+	const notifications: RecordedNotification[] = [];
+	const connection = {
+		sessionUpdate: async (_notification: SessionNotification) => {},
+		notify: async (method: string, params: unknown) => {
+			notifications.push({ method, params });
+		},
+		signal: new AbortController().signal,
+		closed: Promise.withResolvers<void>().promise,
+	} as unknown as AgentSideConnection;
+	return { connection, notifications };
+}
+
+function wakeAdvertiseRequest(): InitializeRequest {
+	return {
+		protocolVersion: 1,
+		clientCapabilities: { _meta: { "bb.dev": { agentWake: 1 } } } as ClientCapabilities,
+	} as InitializeRequest;
+}
+
+function plainAdvertiseRequest(): InitializeRequest {
+	return { protocolVersion: 1, clientCapabilities: {} } as InitializeRequest;
+}
+
+function makeAssistantMessage(text: string) {
+	return {
+		role: "assistant" as const,
+		content: [{ type: "text" as const, text }],
+		api: "anthropic-messages" as const,
+		provider: "anthropic" as const,
+		model: TEST_MODELS[0]!.id,
+		usage: {
+			input: 10,
+			output: 5,
+			cacheRead: 2,
+			cacheWrite: 1,
+			totalTokens: 18,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop" as const,
+		timestamp: Date.now(),
+	};
+}
+
+class FakeAgentSession {
+	sessionManager: SessionManager;
+	sessionId: string;
+	agent: { sessionId: string; waitForIdle: () => Promise<void> };
+	model: Model | undefined;
+	thinkingLevel: string | undefined;
+	customCommands: [] = [];
+	extensionRunner = undefined;
+	isStreaming = false;
+	queuedMessageCount = 0;
+	systemPrompt = "system";
+	disposed = false;
+	fastMode = false;
+	promptCalls: string[] = [];
+	skillsSettings = { enableSkillCommands: true };
+	skills: Array<{ name: string; description: string; filePath: string; baseDir: string; source: string }> = [];
+	planModeState: unknown;
+	waitForIdleCalls = 0;
+	pendingAsyncJobCount = 0;
+	#listeners = new Set<(event: unknown) => void>();
+
+	constructor(cwd: string) {
+		this.sessionManager = SessionManager.create(cwd);
+		this.sessionId = this.sessionManager.getSessionId();
+		this.agent = {
+			sessionId: this.sessionId,
+			waitForIdle: async () => {
+				this.waitForIdleCalls++;
+			},
+		};
+		this.model = TEST_MODELS[0];
+	}
+
+	get settings() {
+		return { get: (_path: string) => false };
+	}
+
+	get sessionName(): string {
+		return this.sessionManager.getHeader()?.title ?? `Session ${this.sessionId}`;
+	}
+
+	get modelRegistry(): { getApiKey: (model: Model) => Promise<string> } {
+		return { getApiKey: async (_model: Model) => "test-key" };
+	}
+
+	getAvailableModels(): Model[] {
+		return TEST_MODELS;
+	}
+
+	getAvailableThinkingLevels(): ReadonlyArray<string> {
+		return ["low", "medium", "high"];
+	}
+
+	setThinkingLevel(_level: string | undefined): void {}
+	setSlashCommands(_commands: unknown[]): void {}
+	async setModel(_model: Model): Promise<void> {}
+	subscribe(listener: (event: unknown) => void): () => void {
+		this.#listeners.add(listener);
+		return () => {
+			this.#listeners.delete(listener);
+		};
+	}
+
+	async prompt(text: string): Promise<boolean> {
+		this.promptCalls.push(text);
+		this.isStreaming = true;
+		this.sessionManager.appendMessage({ role: "user", content: text, timestamp: Date.now() });
+		const assistantMessage = makeAssistantMessage("pong");
+		for (const listener of this.#listeners) {
+			listener({
+				type: "message_update",
+				message: assistantMessage,
+				assistantMessageEvent: { type: "text_delta", delta: "pong" },
+			});
+		}
+		this.sessionManager.appendMessage(assistantMessage);
+		for (const listener of this.#listeners) {
+			listener({ type: "agent_end", messages: [assistantMessage] });
+		}
+		this.isStreaming = false;
+		return true;
+	}
+
+	async waitForIdle(): Promise<void> {
+		this.waitForIdleCalls++;
+	}
+
+	getPendingAsyncJobCount(): number {
+		return this.pendingAsyncJobCount;
+	}
+
+	async drainAsyncJobDeliveriesForAcp(_options?: { timeoutMs?: number }): Promise<boolean> {
+		return false;
+	}
+
+	async abort(): Promise<void> {
+		this.isStreaming = false;
+	}
+
+	async promptCustomMessage(): Promise<void> {}
+	async refreshMCPTools(_tools: unknown[]): Promise<void> {}
+	getContextUsage(): undefined {
+		return undefined;
+	}
+	async switchSession(sessionPath: string): Promise<boolean> {
+		await this.sessionManager.setSessionFile(sessionPath);
+		this.sessionId = this.sessionManager.getSessionId();
+		this.agent.sessionId = this.sessionId;
+		return true;
+	}
+	async dispose(): Promise<void> {
+		this.disposed = true;
+		await this.sessionManager.close();
+	}
+	async reload(): Promise<void> {}
+	async newSession(): Promise<boolean> {
+		await this.sessionManager.newSession();
+		this.sessionId = this.sessionManager.getSessionId();
+		this.agent.sessionId = this.sessionId;
+		return true;
+	}
+	async branch(): Promise<{ cancelled: boolean }> {
+		return { cancelled: false };
+	}
+	async navigateTree(): Promise<{ cancelled: boolean }> {
+		return { cancelled: false };
+	}
+	getActiveToolNames(): string[] {
+		return [];
+	}
+	getAllToolNames(): string[] {
+		return [];
+	}
+	setActiveToolsByName(_toolNames: string[]): void {}
+	setClientBridge(_bridge: unknown): void {}
+	getPlanModeState(): unknown {
+		return this.planModeState;
+	}
+	setPlanModeState(_state: unknown): void {}
+	setPlanProposalHandler(_handler: unknown): void {}
+	peekPlanProposalHandler(): undefined {
+		return undefined;
+	}
+	setPlanReferencePath(_path: string): void {}
+	getToolByName(_name: string): undefined {
+		return undefined;
+	}
+	toggleFastMode(): boolean {
+		this.fastMode = !this.fastMode;
+		return this.fastMode;
+	}
+	setFastMode(_enabled: boolean): boolean {
+		return true;
+	}
+	isFastModeEnabled(): boolean {
+		return this.fastMode;
+	}
+	setForcedToolChoice(_toolName: string): void {}
+	async sendCustomMessage(): Promise<void> {}
+	async sendUserMessage(): Promise<void> {}
+	async compact(): Promise<void> {}
+	async fork(): Promise<boolean> {
+		return false;
+	}
+}
+
+const cleanupRoots: string[] = [];
+const originalAgentDir = process.env.PI_CODING_AGENT_DIR;
+const fallbackAgentDir = path.join(getConfigRootDir(), "agent");
+
+async function createAcpHarness(): Promise<{
+	agent: AcpAgent;
+	notifications: RecordedNotification[];
+	sessions: FakeAgentSession[];
+	cwd: string;
+}> {
+	const root = await fs.promises.mkdtemp(path.join(os.tmpdir(), "omp-acp-wake-"));
+	cleanupRoots.push(root);
+	const agentDir = path.join(root, "agent");
+	const cwd = path.join(root, "cwd");
+	await fs.promises.mkdir(agentDir, { recursive: true });
+	await fs.promises.mkdir(cwd, { recursive: true });
+	setAgentDir(agentDir);
+
+	const { connection, notifications } = createRecordingConnection();
+	const sessions: FakeAgentSession[] = [new FakeAgentSession(cwd)];
+	const factory = async (next: string) => {
+		const session = new FakeAgentSession(next);
+		sessions.push(session);
+		return { session: session as unknown as AgentSession, setToolUIContext: () => {} };
+	};
+	const agent = new AcpAgent(connection, factory, sessions[0] as unknown as AgentSession);
+	return { agent, notifications, sessions, cwd };
+}
+describe("ACP agent wake advertisement", () => {
+	afterEach(async () => {
+		if (originalAgentDir) {
+			setAgentDir(originalAgentDir);
+		} else {
+			setAgentDir(fallbackAgentDir);
+			delete process.env.PI_CODING_AGENT_DIR;
+		}
+		for (const root of cleanupRoots.splice(0)) {
+			await fs.promises.rm(root, { recursive: true, force: true });
+		}
+	});
+
+	it("mirrors agentWake in agentCapabilities._meta only for wake-advertised clients", async () => {
+		const { agent } = await createAcpHarness();
+		const wakeResponse = await agent.initialize(wakeAdvertiseRequest());
+		expect(wakeResponse.agentCapabilities?._meta).toEqual({ "oh-my-pi": { agentWake: 1 } });
+
+		const plainResponse = await agent.initialize(plainAdvertiseRequest());
+		expect(plainResponse.agentCapabilities?._meta).toBeUndefined();
+	});
+
+	it("stamps pendingAsyncJobs on prompt responses only for wake-aware clients with pending work", async () => {
+		const { agent, sessions, cwd } = await createAcpHarness();
+		await agent.initialize(wakeAdvertiseRequest());
+		const created = await agent.newSession({ cwd, mcpServers: [] } as NewSessionRequest);
+		expectAcpStructure(zNewSessionResponse, created);
+		const session = sessions.find(candidate => candidate.sessionId === created.sessionId)!;
+		session.pendingAsyncJobCount = 2;
+
+		const pending = await agent.prompt({
+			sessionId: created.sessionId,
+			prompt: [{ type: "text", text: "ping" }],
+		} as PromptRequest);
+		expectAcpStructure(zPromptResponse, pending);
+		expect(pending.stopReason).toBe("end_turn");
+		expect(pending._meta).toEqual({ "oh-my-pi": { pendingAsyncJobs: 2 } });
+
+		session.pendingAsyncJobCount = 0;
+		const idle = await agent.prompt({
+			sessionId: created.sessionId,
+			prompt: [{ type: "text", text: "ping again" }],
+		} as PromptRequest);
+		expect(idle._meta).toBeUndefined();
+	});
+
+	it("leaves prompt responses _meta-free for non-advertising clients even with pending work", async () => {
+		const { agent, sessions, cwd } = await createAcpHarness();
+		await agent.initialize(plainAdvertiseRequest());
+		const created = await agent.newSession({ cwd, mcpServers: [] } as NewSessionRequest);
+		const session = sessions.find(candidate => candidate.sessionId === created.sessionId)!;
+		session.pendingAsyncJobCount = 2;
+
+		const response = await agent.prompt({
+			sessionId: created.sessionId,
+			prompt: [{ type: "text", text: "ping" }],
+		} as PromptRequest);
+		expectAcpStructure(zPromptResponse, response);
+		expect(response._meta).toBeUndefined();
+	});
+});
+
+describe("ACP client bridge wake notifications", () => {
+	it("sends _omp/session/wake on the connection for wake-aware bridges only", async () => {
+		const { connection, notifications } = createRecordingConnection();
+		const wakeBridge = createAcpClientBridge(connection, "session-1", undefined, true);
+		wakeBridge.notifyAgentWake!({ reason: "async-jobs-settled", batchId: "batch-1" });
+		await Promise.resolve();
+
+		expect(notifications).toEqual([
+			{
+				method: "_omp/session/wake",
+				params: { sessionId: "session-1", reason: "async-jobs-settled", batchId: "batch-1" },
+			},
+		]);
+
+		const plainBridge = createAcpClientBridge(connection, "session-2", undefined, false);
+		expect(plainBridge.notifyAgentWake).toBeUndefined();
+		expect(notifications).toHaveLength(1);
+	});
+});
+
+describe("AgentSession wake-aware parked delivery", () => {
+	const authStorages: AuthStorage[] = [];
+	const sessions: AgentSession[] = [];
+
+	afterEach(async () => {
+		for (const session of sessions.splice(0)) {
+			await session.dispose();
+		}
+		for (const authStorage of authStorages.splice(0)) {
+			authStorage.close();
+		}
+		AsyncJobManager.resetForTests();
+	});
+
+	interface WakeSessionHarness {
+		session: AgentSession;
+		mock: MockModel;
+		notifications: RecordedNotification[];
+		manager: AsyncJobManager;
+	}
+
+	async function createWakeSession(wakeAware: boolean): Promise<WakeSessionHarness> {
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5")!;
+		const mock = createMockModel({ handler: () => ({ content: ["Done"] }) });
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model, systemPrompt: ["Test"], tools: [] },
+			convertToLlm,
+			streamFn: mock.stream,
+		});
+		const authStorage = await AuthStorage.create(":memory:");
+		authStorages.push(authStorage);
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		const manager = new AsyncJobManager({});
+		AsyncJobManager.setInstance(manager);
+
+		const session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated(),
+			modelRegistry: new ModelRegistry(authStorage),
+			agentId: "Main",
+			asyncJobManager: manager,
+		});
+		sessions.push(session);
+		const { connection, notifications } = createRecordingConnection();
+		session.setClientBridge(createAcpClientBridge(connection, session.sessionId, undefined, wakeAware));
+		return { session, mock, notifications, manager };
+	}
+
+	function messageIncludes(messages: Array<{ content: unknown }>, needle: string): boolean {
+		return messages.some(message => {
+			if (typeof message.content === "string") {
+				return message.content.includes(needle);
+			}
+			return (
+				Array.isArray(message.content) &&
+				message.content.some(content => content.type === "text" && content.text.includes(needle))
+			);
+		});
+	}
+
+	function observeAsyncResultEnqueue(session: AgentSession): Promise<void> {
+		const queued = Promise.withResolvers<void>();
+		const enqueue = session.yieldQueue.enqueueWithReceipt.bind(session.yieldQueue);
+		vi.spyOn(session.yieldQueue, "enqueueWithReceipt").mockImplementation((kind, entry) => {
+			const receipt = enqueue(kind, entry);
+			if (kind === "async-result") queued.resolve();
+			return receipt;
+		});
+		return queued.promise;
+	}
+
+	it("parks an agent-initiated turn and emits _omp/session/wake instead of prompting", async () => {
+		const { session, mock, notifications } = await createWakeSession(true);
+
+		const dispatched = await session.sendCustomMessage(
+			{ customType: "hub-yield", content: "peer result ready", display: true },
+			{ deliverAs: "nextTurn", triggerTurn: true },
+		);
+		expect(dispatched).toBe(false);
+		expect(mock.calls).toHaveLength(0);
+		expect(notifications).toEqual([
+			{
+				method: "_omp/session/wake",
+				params: {
+					sessionId: session.sessionId,
+					reason: "agent-initiated",
+					batchId: expect.any(String),
+				},
+			},
+		]);
+
+		// The parked message rides along with the client's next real prompt.
+		await session.prompt("drain the parked batch");
+		expect(mock.calls).toHaveLength(1);
+		expect(messageIncludes(mock.calls[0]!.context.messages, "peer result ready")).toBe(true);
+	});
+
+	it("parks settled async results and emits async-jobs-settled without a detached prompt", async () => {
+		const { session, mock, notifications, manager } = await createWakeSession(true);
+
+		const gate = Promise.withResolvers<string>();
+		manager.register("bash", "gated job", () => gate.promise, { id: "wake-job", ownerId: "Main" });
+		expect(session.getPendingAsyncJobCount()).toBe(1);
+
+		gate.resolve("job finished: ALL GREEN");
+		await session.settleAsyncWork();
+
+		expect(mock.calls).toHaveLength(0);
+		expect(notifications).toEqual([
+			{
+				method: "_omp/session/wake",
+				params: {
+					sessionId: session.sessionId,
+					reason: "async-jobs-settled",
+					batchId: expect.any(String),
+				},
+			},
+		]);
+
+		// The wake-answer prompt drains the parked batch as context.
+		await session.prompt("what finished?");
+		expect(mock.calls).toHaveLength(1);
+		expect(messageIncludes(mock.calls[0]!.context.messages, "ALL GREEN")).toBe(true);
+	});
+
+	it("injects within-prompt while drainAsyncJobDeliveriesForAcp holds agent-initiated turns open", async () => {
+		const { session, mock, notifications, manager } = await createWakeSession(true);
+
+		const enqueued = observeAsyncResultEnqueue(session);
+		const gate = Promise.withResolvers<string>();
+		manager.register("bash", "gated job", () => gate.promise, { id: "drain-job", ownerId: "Main" });
+		gate.resolve("job finished: DRAINED IN PROMPT");
+		await enqueued;
+
+		const drained = await session.drainAsyncJobDeliveriesForAcp();
+		await session.waitForIdle();
+		expect(drained).toBe(true);
+		expect(mock.calls).toHaveLength(1);
+		expect(messageIncludes(mock.calls[0]!.context.messages, "DRAINED IN PROMPT")).toBe(true);
+		expect(notifications).toEqual([]);
+	});
+
+	it("keeps non-advertising clients byte-identical: silent parking and autonomous follow-ups", async () => {
+		const parked = await createWakeSession(false);
+		const dispatched = await parked.session.sendCustomMessage(
+			{ customType: "hub-yield", content: "peer result ready", display: true },
+			{ deliverAs: "nextTurn", triggerTurn: true },
+		);
+		expect(dispatched).toBe(false);
+		expect(parked.mock.calls).toHaveLength(0);
+		expect(parked.notifications).toEqual([]);
+		await parked.session.prompt("drain the parked batch");
+		expect(parked.mock.calls).toHaveLength(1);
+
+		const settled = await createWakeSession(false);
+		const gate = Promise.withResolvers<string>();
+		settled.manager.register("bash", "gated job", () => gate.promise, { id: "plain-job", ownerId: "Main" });
+		gate.resolve("job finished: ALL GREEN");
+		await settled.session.settleAsyncWork();
+
+		// Today's behavior: the async result still autonomously prompts.
+		expect(settled.mock.calls).toHaveLength(1);
+		expect(messageIncludes(settled.mock.calls[0]!.context.messages, "ALL GREEN")).toBe(true);
+		expect(settled.notifications).toEqual([]);
+	});
+});


### PR DESCRIPTION
Concrete implementation of **option (b)** from #9157 — opening as a draft so the (b)-vs-(c) decision has working code to react to. **Close this if you prefer (c) hold-turn; the capability gating means the two are not coupled.**

## Problem

ACP v1 clients cannot display agent-initiated turns that arrive after the prompt response resolves. omp parks those turns (`deferAgentInitiatedTurns`) for the client's *next* prompt — correct per spec, but the client has no way to know parked work exists, so it sits idle showing nothing (bb issue get-bb/bb#2122, design thread #9157).

## Design: capability-gated wake + park, no protocol extensions

All extension points are spec-legal ACP v1: `_meta` on capability objects, `_`-prefixed notifications. No custom stopReasons, no root fields, no protocol version bump.

1. **Handshake** — client advertises `clientCapabilities._meta["bb.dev"] = { agentWake: 1 }`; agent mirrors `agentCapabilities._meta["oh-my-pi"] = { agentWake: 1 }` (precedent: `session_info_update` already carries `_meta`).
2. **Wake notification** — after parking agent work, the agent emits `_omp/session/wake { sessionId, reason, batchId }` (fire-and-forget, `reason` ∈ `"agent-initiated" | "async-jobs-settled"`, `batchId` = UUIDv7 for dedupe).
3. **Idle injection parks instead of prompting** — for wake-aware clients, settled async-job batches queue as hidden next-turn messages (existing `#queueHiddenNextTurnMessage` machinery) rather than firing a detached autonomous prompt. Flush receipts still settle (`ASIDE_MESSAGE_COMMIT` fires when `injectIdle` returns), so `drainDeliveries` never hangs. Within-prompt draining (`#waitForAcpPromptIdle` → `drainAsyncJobDeliveriesForAcp`) still injects normally — the interception keys on `!#allowAcpAgentInitiatedTurns`.
4. **Prompt response hints** — `#finishPrompt` stamps `PromptResponse._meta["oh-my-pi"] = { pendingAsyncJobs: N }` when wake-aware work is still invisible (running unsupplied jobs + queued/in-flight deliveries + queued yield-queue results), so a client can decide to hold its spinner or re-prompt.

**Non-advertising clients are byte-identical**: no bridge hook installed, no notifications, no `_meta`, autonomous follow-ups unchanged (test-verified).

## Consumption path (verified)

The parked batch drains on the client's next `session/prompt`: `AcpAgent.prompt` → `AgentSession.prompt` → `#promptWithMessage` injects `#pendingNextTurnMessages` after the user message and clears them. A client that answers the wake with a prompt gets the parked results as context on that turn — a synthetic resume needs no new server-side turn.

## Durability (scoped out, deliberately)

`#pendingNextTurnMessages` is in-memory today for every `deferAgentInitiatedTurns` client; a persisted wake marker without persisting the batch would advertise work that no longer exists, and persisting arbitrary `CustomMessage`s is a replay-safety design of its own. Missed wakes cost latency only — the batch drains on the client's next prompt regardless.

## Tests (`test/acp-agent-wake.test.ts`, 8 tests)

- handshake mirrored iff advertised; `_meta`-free otherwise
- `pendingAsyncJobs` stamped only for wake-aware clients with pending work; zero-count omits `_meta`
- bridge sends `_omp/session/wake` only on wake-aware bridges
- agent-initiated park → notification, no model call; parked batch rides the next prompt
- async settle → parked + `"async-jobs-settled"`, no detached prompt; batch rides the next prompt
- within-prompt drain still injects (mutation-verified: removing the `!#allowAcpAgentInitiatedTurns` term fails this test)
- non-advertising: silent parking + autonomous follow-up preserved

Gate: `bun run check` (oxlint, oxfmt, tsgo) clean; coding-agent test suite green (incl. full `acp-*` family and async-delivery tests).

Closes #9157 (option (b) branch). Companion client-side consumption: get-bb/bb#2461 (bb #3004 already merged the session_busy retry half).
