### PR TITLE
fix(coding-agent): exclude opaque reasoning from snapcompact no-reduction baseline

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed snapcompact accepting a context-inflating result when the archived history carried a large opaque reasoning-replay signature (e.g. OpenAI Codex `encrypted_content`); the no-reduction guard now excludes opaque reasoning bytes symmetrically so an inflating archive is rejected and the next compaction method runs ([#10716](https://github.com/can1357/oh-my-pi/issues/10716)).
+
 ## [18.1.7] - 2026-09-03
 
 ### Breaking Changes

--- a/packages/coding-agent/src/session/session-maintenance.ts
+++ b/packages/coding-agent/src/session/session-maintenance.ts
@@ -5,6 +5,7 @@ import {
 	type Agent,
 	type AgentMessage,
 	type AgentTurnEndContext,
+	type MessageCountOptions,
 	resolveTelemetry,
 	type StreamFn,
 	type ThinkingLevel,
@@ -973,11 +974,20 @@ export class SessionMaintenance {
 							? ctxWindow - effectiveReserveTokens(ctxWindow, effectiveSettings)
 							: Number.POSITIVE_INFINITY;
 					const projected = this.#projectSnapcompactContextTokens(preparation, snapcompactResult);
+					// No-reduction decision runs in the encrypted-reasoning-excluded domain
+					// on both sides: opaque replay signatures (thinkingSignature /
+					// redactedThinking) have no trustworthy local token price, so counting
+					// them in the archived region's baseline while the imaged projection
+					// drops them lets an inflating result pass the guard (#10716). The
+					// window-fit check below keeps the conservative `projected`.
+					const projectedForReduction = this.#projectSnapcompactContextTokens(preparation, snapcompactResult, {
+						excludeEncryptedReasoning: true,
+					});
 					const reductionBaseline = this.#projectPreSnapcompactContextTokens(preparation);
-					if (projected >= reductionBaseline) {
+					if (projectedForReduction >= reductionBaseline) {
 						logger.warn("Snapcompact projection would not reduce context", {
 							model: this.#model?.id,
-							projected,
+							projected: projectedForReduction,
 							reductionBaseline,
 						});
 						this.#host.emitNotice("warning", "snapcompact would not reduce context.", "compaction");
@@ -1592,12 +1602,20 @@ export class SessionMaintenance {
 	 * `preparation.tokensBefore`, which carries only provider usage (zero for
 	 * imported sessions with no usage metadata, or a deflated figure behind a
 	 * payload-shrinking hook) and would falsely reject reducing archives (#10023).
+	 *
+	 * Opaque provider-replay payloads (`thinkingSignature` / `redactedThinking`)
+	 * are excluded from every region: their local byte size is not a trustworthy
+	 * token price (#2628), and counting them in the archived region — which the
+	 * imaged projection drops — inflated this baseline enough to accept an
+	 * inflating result (#10716). The caller's reduction-side projection excludes
+	 * them symmetrically so the comparison stays in one local token domain.
 	 */
 	#projectPreSnapcompactContextTokens(preparation: CompactionPreparation): number {
+		const opts = { excludeEncryptedReasoning: true } as const;
 		let tokens = computeNonMessageTokens(this.#host.nonMessageTokenSource(), this.#tokenizer);
-		tokens += this.#tokenizer.countMessages(preparation.messagesToSummarize);
-		tokens += this.#tokenizer.countMessages(preparation.turnPrefixMessages);
-		tokens += this.#tokenizer.countMessages(preparation.recentMessages);
+		tokens += this.#tokenizer.countMessages(preparation.messagesToSummarize, opts);
+		tokens += this.#tokenizer.countMessages(preparation.turnPrefixMessages, opts);
+		tokens += this.#tokenizer.countMessages(preparation.recentMessages, opts);
 		return tokens;
 	}
 
@@ -2488,7 +2506,11 @@ export class SessionMaintenance {
 	 * lets the caller decide whether snapcompact brought the context under the
 	 * window or should fall back to an LLM summary.
 	 */
-	#projectSnapcompactContextTokens(preparation: CompactionPreparation, result: snapcompact.CompactionResult): number {
+	#projectSnapcompactContextTokens(
+		preparation: CompactionPreparation,
+		result: snapcompact.CompactionResult,
+		options?: MessageCountOptions,
+	): number {
 		const archive = snapcompact.getPreservedArchive(result.preserveData);
 		const blocks = archive
 			? snapcompact.historyBlocks(archive, { maxFrameDataBytes: snapcompact.FRAME_DATA_BYTES_BUDGET })
@@ -2505,7 +2527,7 @@ export class SessionMaintenance {
 		let tokens =
 			computeNonMessageTokens(this.#host.nonMessageTokenSource(), this.#tokenizer) +
 			this.#tokenizer.countMessage(summaryMessage);
-		tokens += this.#tokenizer.countMessages(preparation.recentMessages);
+		tokens += this.#tokenizer.countMessages(preparation.recentMessages, options);
 		return tokens;
 	}
 
@@ -3434,6 +3456,17 @@ export class SessionMaintenance {
 									? ctxWindow - effectiveReserveTokens(ctxWindow, effectiveSettings)
 									: Number.POSITIVE_INFINITY;
 							const projected = this.#projectSnapcompactContextTokens(preparation, snapcompactResult);
+							// Reduction check in the encrypted-reasoning-excluded domain so opaque
+							// replay signatures cannot inflate the removable baseline (#10716);
+							// `triggerContextTokens` is already an encrypted-excluded stored
+							// estimate, and `#projectPreSnapcompactContextTokens` now matches it.
+							const projectedForReduction = this.#projectSnapcompactContextTokens(
+								preparation,
+								snapcompactResult,
+								{
+									excludeEncryptedReasoning: true,
+								},
+							);
 							const reductionBaseline =
 								options.triggerContextTokens !== undefined
 									? Math.max(0, options.triggerContextTokens - (options.pendingContextTokens ?? 0))
@@ -3443,10 +3476,10 @@ export class SessionMaintenance {
 									? reductionBaseline
 									: Math.max(0, reductionBaseline - options.preparedContextTokens) +
 										this.#projectPreSnapcompactContextTokens(preparation);
-							if (projected >= preparedReductionBaseline) {
+							if (projectedForReduction >= preparedReductionBaseline) {
 								logger.warn("Snapcompact projection would not reduce context", {
 									model: this.#model?.id,
-									projected,
+									projected: projectedForReduction,
 									reductionBaseline: preparedReductionBaseline,
 								});
 								snapcompactBlocker =

--- a/packages/coding-agent/test/agent-session-snapcompact-encrypted-reasoning.test.ts
+++ b/packages/coding-agent/test/agent-session-snapcompact-encrypted-reasoning.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Regression test for issue #10716.
+ *
+ * Snapcompact's no-reduction guard (#10023) rejects a result whose imaged
+ * projection is not smaller than the pre-compaction context. The baseline it
+ * compared against counted opaque provider-replay payloads
+ * (`thinkingSignature` / `redactedThinking`) as ordinary text tokens, while the
+ * imaged projection and the stored-context estimate exclude them (#2628). A
+ * large OpenAI Codex `encrypted_content` signature in the archived region then
+ * inflated the removable baseline above the frame projection, so an
+ * inflating image-frame result was accepted and persisted (context grew).
+ *
+ * Contract defended: opaque reasoning bytes are excluded symmetrically from the
+ * no-reduction comparison, so a result that grows reliable local content is
+ * rejected regardless of how large the archived region's signature is.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import { Agent } from "@oh-my-pi/pi-agent-core";
+import type { Message } from "@oh-my-pi/pi-ai";
+import { createMockModel } from "@oh-my-pi/pi-ai/providers/mock";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import * as snapcompact from "@oh-my-pi/snapcompact";
+
+describe("AgentSession snapcompact no-reduction guard: opaque reasoning", () => {
+	let session: AgentSession;
+	let sessionManager: SessionManager;
+	let authStorage: AuthStorage;
+	let modelRegistry: ModelRegistry;
+
+	beforeEach(async () => {
+		authStorage = await AuthStorage.create(":memory:");
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		modelRegistry = new ModelRegistry(authStorage);
+		sessionManager = SessionManager.inMemory();
+
+		const bundled = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!bundled) throw new Error("Expected bundled claude-sonnet-4-5 model");
+		const model = { ...bundled, contextWindow: 200_000, maxTokens: 64_000 };
+
+		// A tiny real conversation whose archived region carries an opaque
+		// reasoning-replay signature far larger than its text.
+		const bigSignature = "x".repeat(400_000);
+		const seed: Message[] = [
+			{ role: "user", content: [{ type: "text", text: "first question" }], timestamp: Date.now() },
+			{
+				role: "assistant",
+				content: [
+					{ type: "thinking", thinking: "short", thinkingSignature: bigSignature },
+					{ type: "text", text: "first answer" },
+				],
+				api: "anthropic-messages",
+				provider: "anthropic",
+				model: "claude-sonnet-4-5",
+				stopReason: "stop",
+				usage: {
+					input: 20,
+					output: 10,
+					cacheRead: 0,
+					cacheWrite: 0,
+					totalTokens: 30,
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+				},
+				timestamp: Date.now(),
+			},
+			{ role: "user", content: [{ type: "text", text: "second question" }], timestamp: Date.now() },
+		];
+		const agent = new Agent({
+			initialState: { model, systemPrompt: ["Test"], tools: [], messages: seed },
+			streamFn: createMockModel({ responses: [{ content: ["Done"] }] }).stream,
+		});
+		for (const message of seed) sessionManager.appendMessage(message);
+
+		session = new AgentSession({
+			agent,
+			sessionManager,
+			settings: Settings.isolated({
+				"compaction.methodOrder": ["snapcompact"],
+				"compaction.autoContinue": false,
+				"compaction.asyncEnabled": false,
+				"compaction.keepRecentTokens": 1,
+			}),
+			modelRegistry,
+		});
+	});
+
+	afterEach(async () => {
+		await session?.dispose();
+		authStorage?.close();
+		vi.restoreAllMocks();
+	});
+
+	it("rejects an inflating snapcompact result even when the archived region has a huge opaque signature", async () => {
+		const branchEntries = sessionManager.getBranch();
+		const firstKeptEntry = branchEntries[branchEntries.length - 1];
+		if (!firstKeptEntry?.id) throw new Error("Expected branch entry with id");
+
+		const frame = { data: "ZmFrZQ==", mimeType: "image/png", cols: 64, rows: 40, chars: 4 } as const;
+		vi.spyOn(snapcompact, "compact").mockResolvedValue({
+			summary: "archived onto frames",
+			shortSummary: "archived",
+			firstKeptEntryId: firstKeptEntry.id,
+			tokensBefore: 100_000,
+			details: { readFiles: [], modifiedFiles: [] },
+			preserveData: {
+				snapcompact: { frames: [frame, frame, frame], totalChars: 12, truncatedChars: 0 },
+			},
+		});
+
+		// 3 frames ≈ 15k tokens >> the handful of tokens of real archived text,
+		// so this result grows reliable local content and must be rejected.
+		await expect(session.compact(undefined, { mode: "snapcompact" })).rejects.toThrow(
+			"snapcompact would not reduce context locally.",
+		);
+		expect(sessionManager.getEntries().some(entry => entry.type === "compaction")).toBe(false);
+	});
+});


### PR DESCRIPTION
## Repro
With an `openai-codex`-style session whose archived region carries an assistant turn with a large opaque `thinkingSignature`/`encrypted_content` payload and only a little ordinary text, a manual snapcompact producing image frames is accepted even though it grows reliable local content. Reproduced with a deterministic test (`packages/coding-agent/test/agent-session-snapcompact-encrypted-reasoning.test.ts`): seed a 400k-char signature on the archived turn, stub `snapcompact.compact` to return 3 frames (~15k projected tokens), then `session.compact(undefined, { mode: "snapcompact" })`. On the prior code the call resolves (commits) instead of rejecting.

```
bun test test/agent-session-snapcompact-encrypted-reasoning.test.ts
# before fix: error: Expected promise that rejects / Received promise that resolved (0 pass / 1 fail)
```

## Cause
`SessionMaintenance.#projectPreSnapcompactContextTokens` (`packages/coding-agent/src/session/session-maintenance.ts`) counted `messagesToSummarize` + `turnPrefixMessages` + `recentMessages` with `Tokenizer.countMessages` and no options, so opaque provider-replay bytes (`thinkingSignature` / `redactedThinking`) were tokenized as ordinary text. The imaged projection (`#projectSnapcompactContextTokens`) and the stored-context estimate (`#estimateStoredContextTokens`) both exclude those bytes (#2628). The archived region's signature therefore inflated only the reduction baseline, pushing it above the frame projection so the `projected >= reductionBaseline` guard (#10023) under-fired and an inflating result was persisted.

## Fix
- `#projectPreSnapcompactContextTokens` now counts every region with `{ excludeEncryptedReasoning: true }`, matching the stored-context estimate's domain.
- `#projectSnapcompactContextTokens` gained an optional `MessageCountOptions` argument, forwarded to the kept-tail count.
- Both guard sites (manual `#runManualCompaction` path and automatic `runAutoCompaction` path) compute a `projectedForReduction` (encrypted-excluded) for the no-reduction comparison, keeping the conservative `projected` for the `projected > budget` window-fit check.

## Verification
`bun test` on the new regression test plus the existing snapcompact suites:
```
bun test test/agent-session-snapcompact-encrypted-reasoning.test.ts test/agent-session-snapcompact-no-reduction.test.ts test/agent-session-snapcompact-budget.test.ts test/agent-session-snapcompact-auto-fallback.test.ts test/agent-session-snapcompact-frame-dead-end.test.ts test/agent-session-manual-snapcompact-fallback.test.ts test/compaction-thinking-model.test.ts
# all pass
```
`bun run check:types` passes; `bun run fix` applied. Fixes #10716