### PR TITLE
fix(tui): keep model hub sidebar focus stable across rebuilds

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the Model Hub sidebar scroll/selection jumping to the top when an on-focus provider refresh rebuilt the list; the focused entry (or its nearest survivor) now stays put ([#10722](https://github.com/can1357/oh-my-pi/issues/10722)).
+
 ## [18.1.7] - 2026-09-03
 
 ### Breaking Changes

--- a/packages/coding-agent/src/modes/components/model-hub.ts
+++ b/packages/coding-agent/src/modes/components/model-hub.ts
@@ -115,6 +115,17 @@ interface SidebarEntry {
 	catalogCount?: number;
 }
 
+/**
+ * The focused sidebar entry plus its screen row, captured before a rebuild so
+ * the viewport can be restored around it. `index` is the entry's position in
+ * `#entries` (−1 when absent); `offset` is its row relative to the scroll top.
+ */
+interface SidebarAnchor {
+	id: string;
+	index: number;
+	offset: number;
+}
+
 interface StripChip {
 	label: string;
 	/** Pre-styled label body (without selection decoration). */
@@ -308,6 +319,10 @@ export class ModelHubComponent implements Component {
 
 	/** Rebuild items, roles, and the sidebar from the registry's in-memory state. */
 	#syncFromRegistryState(): void {
+		// A background rebuild (provider refresh, mutation) must not yank the
+		// sidebar viewport: remember the focused entry's screen row so it — or
+		// its nearest survivor — stays put after #buildSidebar reshuffles entries.
+		const anchor = this.#captureSidebarAnchor();
 		let allModels: ReadonlyArray<Model>;
 		let availableModels: ReadonlyArray<Model>;
 		if (this.#scopedModels.length > 0) {
@@ -346,6 +361,7 @@ export class ModelHubComponent implements Component {
 		}
 
 		this.#buildSidebar(allModels, availableModels);
+		this.#restoreSidebarAnchor(anchor);
 		this.#applyScope();
 	}
 
@@ -473,6 +489,45 @@ export class ModelHubComponent implements Component {
 			this.#activeEntryId = "all";
 			this.#sidebarFollowActive = true;
 		}
+	}
+
+	/** Snapshot the focused entry and its row within the sidebar viewport. */
+	#captureSidebarAnchor(): SidebarAnchor {
+		const index = this.#entries.findIndex(entry => entry.id === this.#activeEntryId);
+		return { id: this.#activeEntryId, index, offset: index - this.#sidebarScroll };
+	}
+
+	/**
+	 * Reposition the sidebar after {@link #buildSidebar} rebuilt `#entries`. A
+	 * surviving focused entry keeps its screen row; if it vanished (a keyless
+	 * provider flipping back to hidden mid-navigation), focus falls to the
+	 * nearest surviving entry instead of snapping to the top.
+	 */
+	#restoreSidebarAnchor(anchor: SidebarAnchor): void {
+		if (anchor.index < 0) return;
+		const survivor = this.#entries.findIndex(entry => entry.id === anchor.id);
+		if (survivor >= 0) {
+			this.#sidebarScroll = Math.max(0, survivor - anchor.offset);
+			return;
+		}
+		const replacement = this.#nearestNavigableEntry(anchor.index);
+		if (!replacement) return;
+		this.#activeEntryId = replacement.id;
+		this.#sidebarScroll = Math.max(0, this.#entries.indexOf(replacement) - anchor.offset);
+	}
+
+	/** The selectable entry nearest `preferredIndex` in the current `#entries`. */
+	#nearestNavigableEntry(preferredIndex: number): SidebarEntry | undefined {
+		const entries = this.#entries;
+		if (entries.length === 0) return undefined;
+		const start = Math.max(0, Math.min(preferredIndex, entries.length - 1));
+		for (let radius = 0; radius < entries.length; radius++) {
+			for (const index of radius === 0 ? [start] : [start + radius, start - radius]) {
+				const entry = entries[index];
+				if (entry && !this.#isHopSkipped(entry)) return entry;
+			}
+		}
+		return undefined;
 	}
 
 	#activeEntry(): SidebarEntry {

--- a/packages/coding-agent/test/model-hub.test.ts
+++ b/packages/coding-agent/test/model-hub.test.ts
@@ -288,6 +288,52 @@ describe("ModelHub", () => {
 		});
 	});
 
+	describe("sidebar rebuild during navigation", () => {
+		test("keeps focus on a surviving provider when the focused entry vanishes on refresh", async () => {
+			vi.useFakeTimers();
+			try {
+				const models = [makeModel("alpha", "m"), makeModel("beta", "m"), makeModel("gamma", "m")];
+				// A keyless discoverable local endpoint: starts visible (discovery
+				// "empty"), then its on-focus refresh finds it unreachable and it
+				// flips to hidden (optional + "unavailable"), vanishing from the list.
+				let localStatus = "empty";
+				const { hub } = createHub({
+					models,
+					registry: {
+						getDiscoverableProviders: () => ["delta-local"],
+						getProviderDiscoveryState: providerId =>
+							providerId === "delta-local" ? { optional: true, status: localStatus } : undefined,
+						refreshProvider: async providerId => {
+							if (providerId === "delta-local") localStatus = "unavailable";
+						},
+					},
+				});
+				installTestTheme();
+
+				// Sidebar order: Roles, All models, [sep], alpha, beta, delta-local, gamma.
+				// Hop down onto the keyless provider, which schedules its refresh.
+				hub.handleInput(DOWN); // all → alpha
+				hub.handleInput(DOWN); // alpha → beta
+				hub.handleInput(DOWN); // beta → delta-local
+				expect(normalize(hub.render(220))).toContain("delta-local ·");
+
+				// Fire the debounced on-focus refresh, then flush the async rebuild
+				// (refreshProvider resolves on a microtask before #syncFromRegistryState).
+				vi.advanceTimersByTime(200);
+				await Promise.resolve();
+				await Promise.resolve();
+
+				// delta-local is gone; focus must land on the neighbouring provider,
+				// not snap back to "All models" at the top.
+				const rendered = normalize(hub.render(220));
+				expect(rendered).not.toContain("All available models");
+				expect(rendered).toContain("gamma ·");
+			} finally {
+				vi.useRealTimers();
+			}
+		});
+	});
+
 	describe("typing focus", () => {
 		test("typing on All models switches focus to model list and navigates results with arrows", () => {
 			const modelA = makeModel("test", "model-a");


### PR DESCRIPTION
## Repro
Open `/model` with keyless local providers (ollama, lm-studio, llama.cpp, vllm) present and unconfigured, then arrow down through the sidebar. Each newly focused provider triggers an on-focus online refresh; when it completes the sidebar rebuilds and the cursor/scroll jumps back to the top, so reaching entries below is a fight. Reproduced with a unit test: focus a keyless discoverable provider that starts visible (discovery `empty`), let its refresh flip it to `unavailable` (hidden), and the sidebar snaps to `All models`.

`bun test test/model-hub.test.ts -t "sidebar rebuild during navigation"`

## Cause
`#setActiveEntry` (`packages/coding-agent/src/modes/components/model-hub.ts`) schedules an on-focus provider refresh whose completion (`#refreshProviderInBackground`) calls `#syncFromRegistryState`, rebuilding `#entries` via `#buildSidebar`/`#composeEntries` without preserving `#sidebarScroll` relative to the focused entry. Keyless discoverable providers flip visibility (`idle`<->`empty`/`unavailable`) mid-navigation; when the focused entry vanishes, `#composeEntries` resets `#activeEntryId` to `"all"` and follow-active snaps the viewport to the top.

## Fix
- Added `SidebarAnchor` plus `#captureSidebarAnchor`/`#restoreSidebarAnchor`/`#nearestNavigableEntry`.
- `#syncFromRegistryState` now snapshots the focused entry and its screen row before `#buildSidebar` and restores it after: a surviving entry keeps the same row; a vanished entry falls to the nearest surviving navigable entry instead of jumping to the top.

## Verification
`bun test test/model-hub.test.ts` (49 pass, incl. new regression test) and `bun test test/issue-2761-hidden-local-providers.test.ts` (8 pass). Pre-publish `bun run fix`/`bun check` gate ran clean on push.

Fixes #10722