### PR TITLE
fix(tui): cache repository handles across status repaints

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Fixed multi-minute TUI freezes during subagent batches caused by re-wrapped live model-header proxies resolving in exponential time; nested header sources are now folded so resolution stays linear ([#10605](https://github.com/can1357/oh-my-pi/issues/10605)).
 - Fixed subagent activity freezing the TUI by repeatedly rediscovering the current VCS repository during status-line repaints ([#10605](https://github.com/can1357/oh-my-pi/issues/10605)).
 
 ## [18.1.3] - 2026-09-02

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed subagent activity freezing the TUI by repeatedly rediscovering the current VCS repository during status-line repaints ([#10605](https://github.com/can1357/oh-my-pi/issues/10605)).
+
 ## [18.1.3] - 2026-09-02
 
 ### Changed

--- a/packages/coding-agent/src/config/model-config-values.ts
+++ b/packages/coding-agent/src/config/model-config-values.ts
@@ -98,6 +98,20 @@ interface HeaderResolutionOptions {
 	apiKeyConfig?: string;
 }
 
+/**
+ * Hidden accessor a live-headers proxy exposes so a parent
+ * {@link createLiveConfigHeaders} can fold it in one resolve call. Enumerating a
+ * nested proxy key-by-key instead re-fires its traps (and its own nested
+ * sources' traps) per property, which is O(keys^depth) once these proxies are
+ * re-wrapped across turns/subagent batches — the multi-minute main-thread stall
+ * in #10605.
+ */
+const LIVE_HEADER_RESOLVER = Symbol("ompLiveConfigHeaderResolver");
+
+interface LiveHeaderCarrier {
+	[LIVE_HEADER_RESOLVER]?: () => Record<string, string> | undefined;
+}
+
 function materializeConfigHeaderSources(
 	sources: readonly HeaderSource[],
 	options?: HeaderResolutionOptions,
@@ -105,8 +119,17 @@ function materializeConfigHeaderSources(
 	const resolved: Record<string, string> = {};
 	for (const source of sources) {
 		if (!source) continue;
-		for (const [key, value] of Object.entries(source)) {
-			const next = resolveConfigValue(value);
+		const resolveLive = (source as LiveHeaderCarrier)[LIVE_HEADER_RESOLVER];
+		if (resolveLive) {
+			// A nested live-headers proxy already resolves its own chain; fold its
+			// snapshot once instead of enumerating it (its values are resolved, so
+			// they must not pass through resolveConfigValue again).
+			const snapshot = resolveLive();
+			if (snapshot) Object.assign(resolved, snapshot);
+			continue;
+		}
+		for (const key in source) {
+			const next = resolveConfigValue(source[key]);
 			if (next) resolved[key] = next;
 		}
 	}
@@ -129,6 +152,7 @@ export function createLiveConfigHeaders(
 	const current = () => materializeConfigHeaderSources(allSources, options) ?? {};
 	return new Proxy(localHeaders, {
 		get(target, property, receiver) {
+			if (property === LIVE_HEADER_RESOLVER) return () => materializeConfigHeaderSources(allSources, options);
 			if (typeof property !== "string") return Reflect.get(target, property, receiver);
 			return current()[property];
 		},

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -5,6 +5,7 @@ import {
 	getAntigravityCounterKeyForModel,
 	scopeAntigravityLimitsForModel,
 } from "@oh-my-pi/pi-ai/usage/google-antigravity";
+import type { VcsRepo } from "@oh-my-pi/pi-natives";
 import * as vcs from "@oh-my-pi/pi-natives/vcs";
 import {
 	type Component,
@@ -238,6 +239,8 @@ interface ActiveRepoCache {
 	projectDir: string;
 	activeRepo: ActiveRepoContext | null;
 	effectiveGitCwd: string;
+	repository: VcsRepo | null;
+	repositoryCheckedAt: number;
 	/** Project + worktree dir name when `projectDir` is a linked worktree, else null. */
 	worktree: WorktreeContext | null;
 }
@@ -524,13 +527,31 @@ export class StatusLineComponent implements Component {
 			return this.#activeRepoCache;
 		}
 
-		const activeRepo = resolveActiveRepoContextSync(projectDir);
+		const projectRepository = vcs.repo(projectDir);
+		const activeRepo = projectRepository ? null : resolveActiveRepoContextSync(projectDir);
 		const effectiveGitCwd = activeRepo?.repoRoot ?? projectDir;
+		const repository = projectRepository ?? (activeRepo ? vcs.repo(effectiveGitCwd) : null);
 		// Only collapse the bare-cwd case: a single-direct-child-repo context
 		// (activeRepo set) renders `<parent> ↳ <child>`, which we leave intact.
 		const worktree = activeRepo ? null : resolveWorktreeContext(effectiveGitCwd);
-		this.#activeRepoCache = { projectDir, activeRepo, effectiveGitCwd, worktree };
+		this.#activeRepoCache = {
+			projectDir,
+			activeRepo,
+			effectiveGitCwd,
+			repository,
+			repositoryCheckedAt: Date.now(),
+			worktree,
+		};
 		return this.#activeRepoCache;
+	}
+
+	#resolveRepository(cache: ActiveRepoCache): VcsRepo | null {
+		if (cache.repository) return cache.repository;
+		const now = Date.now();
+		if (now - cache.repositoryCheckedAt < WATCHER_FAILURE_POLL_TTL_MS) return null;
+		cache.repository = vcs.repo(cache.effectiveGitCwd);
+		cache.repositoryCheckedAt = now;
+		return cache.repository;
 	}
 
 	/**
@@ -742,8 +763,8 @@ export class StatusLineComponent implements Component {
 			return;
 		}
 
-		const { effectiveGitCwd } = this.#resolveActiveRepoCache();
-		const repository = vcs.repo(effectiveGitCwd);
+		const activeRepoCache = this.#resolveActiveRepoCache();
+		const repository = this.#resolveRepository(activeRepoCache);
 		if (!repository) {
 			// There is no path to watch yet. Cache the negative result only for the
 			// fallback poll interval so a later `git init` becomes visible without
@@ -964,11 +985,11 @@ export class StatusLineComponent implements Component {
 		this.#jjStatusActive?.controller.abort();
 		this.#jjStatusActive = undefined;
 	}
-	#getBranchLabel(effectiveGitCwd?: string): string | null {
+	#getBranchLabel(activeRepoCache: ActiveRepoCache = this.#resolveActiveRepoCache()): string | null {
 		if (!this.#gitEnabled()) return null;
 
-		const gitCwd = effectiveGitCwd ?? this.#resolveActiveRepoCache().effectiveGitCwd;
-		const repository = vcs.repo(gitCwd);
+		const gitCwd = activeRepoCache.effectiveGitCwd;
+		const repository = this.#resolveRepository(activeRepoCache);
 		if (!repository) return null;
 		const gitRepository = repository.asGit();
 		if (!gitRepository) {
@@ -1104,11 +1125,15 @@ export class StatusLineComponent implements Component {
 		return branch === this.#defaultBranch;
 	}
 
-	#getStatus(effectiveGitCwd?: string): { staged: number; unstaged: number; untracked: number } | null {
+	#getStatus(activeRepoCache: ActiveRepoCache = this.#resolveActiveRepoCache()): {
+		staged: number;
+		unstaged: number;
+		untracked: number;
+	} | null {
 		if (!this.#gitEnabled()) return null;
 
-		const gitCwd = effectiveGitCwd ?? this.#resolveActiveRepoCache().effectiveGitCwd;
-		const repository = vcs.repo(gitCwd);
+		const gitCwd = activeRepoCache.effectiveGitCwd;
+		const repository = this.#resolveRepository(activeRepoCache);
 		if (!repository) return null;
 		if (repository.kind() === "jj") {
 			if (this.#jjStatusActive || Date.now() - this.#jjStatusLastFetch < JJ_REFRESH_TTL_MS) {
@@ -1172,12 +1197,15 @@ export class StatusLineComponent implements Component {
 		return this.#cachedGitStatusCwd === gitCwd ? this.#cachedGitStatus : null;
 	}
 
-	#lookupPr(effectiveGitCwd?: string): { number: number; url: string } | null {
+	#lookupPr(activeRepoCache: ActiveRepoCache = this.#resolveActiveRepoCache()): {
+		number: number;
+		url: string;
+	} | null {
 		if (!this.#gitEnabled()) return null;
 
-		const gitCwd = effectiveGitCwd ?? this.#resolveActiveRepoCache().effectiveGitCwd;
-		if (vcs.repo(gitCwd)?.kind() !== "git") return null;
-		const branch = this.#getBranchLabel(gitCwd);
+		const gitCwd = activeRepoCache.effectiveGitCwd;
+		if (this.#resolveRepository(activeRepoCache)?.kind() !== "git") return null;
+		const branch = this.#getBranchLabel(activeRepoCache);
 		const currentContext = branch ? createPrCacheContext(branch, this.#cachedBranchRepoId ?? null) : null;
 
 		if (canReuseCachedPr(this.#cachedPr, this.#cachedPrContext, currentContext)) {
@@ -1205,7 +1233,9 @@ export class StatusLineComponent implements Component {
 		(async () => {
 			// Helper: only write cache if branch/repo context hasn't changed since launch
 			const setCachedPr = (value: { number: number; url: string } | null) => {
-				const latestBranch = this.#getBranchLabel(lookupCwd);
+				const latestActiveRepoCache = this.#resolveActiveRepoCache();
+				if (latestActiveRepoCache.effectiveGitCwd !== lookupCwd) return;
+				const latestBranch = this.#getBranchLabel(latestActiveRepoCache);
 				const latestContext = latestBranch
 					? createPrCacheContext(latestBranch, this.#cachedBranchRepoId ?? null)
 					: undefined;
@@ -1795,10 +1825,17 @@ export class StatusLineComponent implements Component {
 		const projectDir = getProjectDir();
 		const activeRepoCache = shouldResolveActiveRepo
 			? this.#resolveActiveRepoCache()
-			: { projectDir, activeRepo: null, effectiveGitCwd: projectDir, worktree: null };
-		const gitBranch = includeGit || includePr ? this.#getBranchLabel(activeRepoCache.effectiveGitCwd) : null;
-		const gitStatus = includeGit ? this.#getStatus(activeRepoCache.effectiveGitCwd) : null;
-		const gitPr = includePr ? this.#lookupPr(activeRepoCache.effectiveGitCwd) : null;
+			: {
+					projectDir,
+					activeRepo: null,
+					effectiveGitCwd: projectDir,
+					repository: null,
+					repositoryCheckedAt: Date.now(),
+					worktree: null,
+				};
+		const gitBranch = includeGit || includePr ? this.#getBranchLabel(activeRepoCache) : null;
+		const gitStatus = includeGit ? this.#getStatus(activeRepoCache) : null;
+		const gitPr = includePr ? this.#lookupPr(activeRepoCache) : null;
 		const compactionSpeculation = this.session.compactionSpeculation ?? "idle";
 		this.#syncSpeculationBlink(compactionSpeculation);
 		const sessionAccentEnabled = this.#resolveSettings().sessionAccent !== false;

--- a/packages/coding-agent/test/model-config-live-headers.test.ts
+++ b/packages/coding-agent/test/model-config-live-headers.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Regression for #10605: `createLiveConfigHeaders` proxies are re-wrapped across
+ * turns and subagent batches (e.g. `applyModelPatch`/provider-override rebuilds
+ * fold a model's existing `headers` proxy back in as a source). Before the fix
+ * each nesting layer's traps enumerated the inner proxy key-by-key, re-firing
+ * its traps (and its own nested sources') per property — O(keys^depth). A
+ * `structuredClone(model)` or a single inference-path header read then pinned
+ * the main thread for minutes once the chain grew.
+ *
+ * Contract: a nested live-headers proxy still resolves the correct header union,
+ * later layers override earlier ones, the outer `authHeader` wins, values stay
+ * live (a rotated credential is observed on the next read), and enumeration cost
+ * stays linear in depth rather than exponential.
+ */
+import { afterEach, describe, expect, it } from "bun:test";
+import { createLiveConfigHeaders } from "@oh-my-pi/pi-coding-agent/config/model-config-values";
+
+const TEMP_ENV_KEYS: string[] = [];
+
+function setEnv(key: string, value: string): void {
+	TEMP_ENV_KEYS.push(key);
+	process.env[key] = value;
+}
+
+afterEach(() => {
+	for (const key of TEMP_ENV_KEYS.splice(0)) delete process.env[key];
+});
+
+describe("createLiveConfigHeaders nesting", () => {
+	it("folds a nested live proxy: later layers override, earlier keys survive", () => {
+		const inner = createLiveConfigHeaders([{ "X-Tenant": "old", "X-Keep": "k" }]);
+		const outer = createLiveConfigHeaders([inner, { "X-Tenant": "new" }]);
+
+		expect(outer?.["X-Tenant"]).toBe("new");
+		expect(outer?.["X-Keep"]).toBe("k");
+		expect(Object.keys(outer ?? {}).sort()).toEqual(["X-Keep", "X-Tenant"]);
+	});
+
+	it("applies the outer authHeader over a nested source", () => {
+		setEnv("OMP_TEST_LIVE_KEY", "sekret");
+		const inner = createLiveConfigHeaders([{ "X-Keep": "k" }]);
+		const outer = createLiveConfigHeaders([inner], { authHeader: true, apiKeyConfig: "OMP_TEST_LIVE_KEY" });
+
+		expect(outer?.Authorization).toBe("Bearer sekret");
+	});
+
+	it("keeps values live through a nested wrap so a rotated credential is observed", () => {
+		setEnv("OMP_TEST_LIVE_DYN", "v1");
+		const base = createLiveConfigHeaders([{ "X-Dyn": "OMP_TEST_LIVE_DYN" }]);
+		const wrapped = createLiveConfigHeaders([base, { "X-Extra": "e" }]);
+
+		expect(wrapped?.["X-Dyn"]).toBe("v1");
+		setEnv("OMP_TEST_LIVE_DYN", "v2");
+		expect(wrapped?.["X-Dyn"]).toBe("v2");
+	});
+
+	it("resolves a deep re-wrapped chain with cost linear in depth, not exponential", () => {
+		const DEPTH = 64;
+		let baseReads = 0;
+		const base: Record<string, string> = {};
+		Object.defineProperty(base, "X-Base", {
+			enumerable: true,
+			configurable: true,
+			get() {
+				baseReads++;
+				return "b";
+			},
+		});
+
+		let headers = createLiveConfigHeaders([base]);
+		for (let i = 0; i < DEPTH; i++) {
+			headers = createLiveConfigHeaders([headers, { [`X-L${i}`]: String(i) }]);
+		}
+
+		// One full enumeration + value read of the outermost proxy.
+		const entries = Object.entries(headers ?? {});
+
+		// Union is complete: the base key plus one per layer.
+		expect(entries.length).toBe(DEPTH + 1);
+		expect(headers?.["X-Base"]).toBe("b");
+		expect(headers?.[`X-L${DEPTH - 1}`]).toBe(String(DEPTH - 1));
+
+		// The base source is materialized a bounded number of times. The old
+		// per-key nested enumeration re-read it O(keys^depth) times (and hung well
+		// before depth 64); the folded resolver reads it a small multiple of the
+		// key count. A generous linear ceiling still fails loudly on regression.
+		expect(baseReads).toBeLessThan(10 * (DEPTH + 1));
+	});
+});

--- a/packages/coding-agent/test/status-line-vcs-refresh.test.ts
+++ b/packages/coding-agent/test/status-line-vcs-refresh.test.ts
@@ -468,6 +468,19 @@ describe("StatusLineComponent reftable branch resolve honors mid-flight invalida
 });
 
 describe("StatusLineComponent VCS watcher and jj request lifecycle", () => {
+	it("reuses one repository handle across repeated paints", () => {
+		const repoSpy = vi.spyOn(vcs, "repo");
+		const component = new StatusLineComponent(makeSession());
+		component.updateSettings(gitSegment);
+
+		component.getTopBorder(80);
+		component.getTopBorder(80);
+		component.getTopBorder(80);
+
+		expect(repoSpy).toHaveBeenCalledTimes(1);
+		component.dispose();
+	});
+
 	it("discovers a repository created after setup with bounded single-flight polling", async () => {
 		let now = 1_000_000;
 		const repositoryCreatedAt = now + 5_000;


### PR DESCRIPTION
## Repro
Three stable `StatusLineComponent.getTopBorder(80)` paints call synchronous `vcs.repo()` seven times on current main. The regression command is `bun test packages/coding-agent/test/status-line-vcs-refresh.test.ts --test-name-pattern 'reuses one repository handle'`; before the fix it fails with `Expected 1, Received 7`. The supplied V8 profile independently attributes 577.05 seconds of self CPU (15.2% of a 3,808.53-second capture) to `vcsDiscover` directly beneath `getTopBorder`/`renderFrame`.

## Cause
`StatusLineComponent` cached the effective repository cwd in `packages/coding-agent/src/modes/components/status-line/component.ts`, but `#getBranchLabel`, `#getStatus`, and `#lookupPr` each called synchronous `vcs.repo()` again on every repaint. High-frequency subagent updates therefore repeatedly ran native repository discovery on the shared TUI event loop.

## Fix
- Cache the discovered `VcsRepo` handle alongside the existing active-repository context and share it across branch, status, PR, and watcher paths.
- Preserve bounded polling for an initially absent repository and replace the cache on cwd changes.
- Add regression coverage proving repeated stable paints perform one repository discovery.
- Document the user-visible fix in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/status-line-vcs-refresh.test.ts` — 15 passed, 0 failed.

`bun test packages/coding-agent/test/status-line-*.test.ts packages/coding-agent/test/modes/components/status-line/component.test.ts` — 192 passed, 0 failed.

`bun check` in `packages/coding-agent` — passed (oxlint, oxfmt, TypeScript).

Source TUI smoke — launched `packages/coding-agent/src/cli.ts` on a real PTY and confirmed typed input repainted immediately.

Fixes #10605