### PR TITLE
fix(plugins): relink over a directory left by a git install

### DIFF
--- a/packages/coding-agent/src/extensibility/plugins/installer.ts
+++ b/packages/coding-agent/src/extensibility/plugins/installer.ts
@@ -1,6 +1,6 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import { getAgentDir, getProjectDir, isEnoent } from "@oh-my-pi/pi-utils";
+import { getAgentDir, getProjectDir } from "@oh-my-pi/pi-utils";
 import { extractPackageName } from "./parser";
 import type { InstalledPlugin } from "./types";
 
@@ -186,15 +186,8 @@ export async function linkPlugin(localPath: string): Promise<void> {
 		await fs.mkdir(scopeDir, { recursive: true });
 	}
 
-	// Remove existing if present
-	try {
-		const stats = await fs.lstat(linkPath);
-		if (stats.isSymbolicLink() || stats.isDirectory()) {
-			await fs.unlink(linkPath);
-		}
-	} catch (err) {
-		if (!isEnoent(err)) throw err;
-	}
+	// Whatever is there — a stale link, or a real directory from a git install.
+	await fs.rm(linkPath, { recursive: true, force: true });
 
 	// Create symlink using fs instead of shell command
 	await fs.symlink(absolutePath, linkPath);

--- a/packages/coding-agent/src/extensibility/plugins/manager.ts
+++ b/packages/coding-agent/src/extensibility/plugins/manager.ts
@@ -793,15 +793,8 @@ export class PluginManager {
 			await fs.promises.mkdir(scopeDir, { recursive: true });
 		}
 
-		// Remove existing
-		try {
-			const stats = await fs.promises.lstat(linkPath);
-			if (stats.isSymbolicLink() || stats.isDirectory()) {
-				await fs.promises.unlink(linkPath);
-			}
-		} catch (err) {
-			if (!isEnoent(err)) throw err;
-		}
+		// Whatever is there — a stale link, or a real directory from a git install.
+		await fs.promises.rm(linkPath, { recursive: true, force: true });
 
 		await fs.promises.symlink(absolutePath, linkPath);
 

--- a/packages/coding-agent/test/plugin-install-local.test.ts
+++ b/packages/coding-agent/test/plugin-install-local.test.ts
@@ -142,6 +142,21 @@ describe("runPluginCommand({ action: 'install', args: [<local>] })", () => {
 			enabled: true,
 		});
 	});
+
+	test("links over a real directory left by a git install", async () => {
+		// A git-sourced install leaves a directory, not a symlink, under the
+		// plugin's name. Relinking must replace it rather than fail on unlink.
+		const localPlugin = await createLocalPlugin(tmpRoot);
+		const linkTarget = path.join(tmpRoot, "plugins", "node_modules", "kimi-datasource");
+		await fs.mkdir(linkTarget, { recursive: true });
+		await Bun.write(path.join(linkTarget, "package.json"), JSON.stringify({ name: "kimi-datasource" }));
+
+		await new PluginManager(tmpRoot).link(localPlugin);
+
+		expect((await fs.lstat(linkTarget)).isSymbolicLink()).toBe(true);
+		expect(await fs.readlink(linkTarget)).toBe(localPlugin);
+	});
+
 	test("list --json includes linked local plugin without package dependencies", async () => {
 		const localPlugin = await createLocalPlugin(tmpRoot);
 		const output: string[] = [];


### PR DESCRIPTION
`linkPluginDirectory` checks `stats.isDirectory()` and then calls `fs.unlink`,
which cannot remove a directory. The surrounding handler only swallows `ENOENT`,
so the failure escapes and the install aborts.

A plugin installed from a git URL leaves a real directory at the link path, so
re-linking or reinstalling over it fails. On Linux the error is
`EISDIR: illegal operation on a directory, unlink`; POSIX also permits `EPERM`,
which is what macOS and the BSDs return.

`marketplace/manager.ts` already handles this correctly with
`fs.rm(linkPath, { recursive: true, force: true })`. This makes `installer.ts`
and `plugins/manager.ts` match it, which also removes the now-unused `isEnoent`
import from `installer.ts`.

## Verification

`bun test packages/coding-agent/test/plugin-install-local.test.ts` — 7 pass.
The added case links over a real directory left by a git install and fails on
`origin/main`.
