### PR TITLE
fix(import): mark an imported API error as a failed turn

### DIFF
--- a/packages/coding-agent/src/session/claude-session-store.ts
+++ b/packages/coding-agent/src/session/claude-session-store.ts
@@ -254,7 +254,9 @@ function convertRecord(
 			provider: "anthropic",
 			model,
 			usage: claudeUsage(record.message.usage),
-			stopReason: stopReason(record.message.stop_reason),
+			// An API-error record still carries a completed stop_reason, so the flag
+			// beside it is the only thing that says the turn failed.
+			stopReason: record.isApiErrorMessage === true ? "error" : stopReason(record.message.stop_reason),
 			timestamp,
 		};
 		const responseId = stringField(record.message, "id");

--- a/packages/coding-agent/test/foreign-session-stores.test.ts
+++ b/packages/coding-agent/test/foreign-session-stores.test.ts
@@ -89,7 +89,7 @@ async function createClaudeFixture(): Promise<{ info: ForeignSessionInfo; store:
 }
 
 describe("ClaudeSessionStore", () => {
-	it("imports an API error as a failed turn a prune can reach", async () => {
+	it("imports an API error as a failed turn", async () => {
 		const root = path.join(tempRoot, ".claude");
 		const cwd = path.join(tempRoot, "overloaded");
 		const id = "22222222-2222-4222-8222-222222222222";

--- a/packages/coding-agent/test/foreign-session-stores.test.ts
+++ b/packages/coding-agent/test/foreign-session-stores.test.ts
@@ -89,6 +89,53 @@ async function createClaudeFixture(): Promise<{ info: ForeignSessionInfo; store:
 }
 
 describe("ClaudeSessionStore", () => {
+	it("imports an API error as a failed turn a prune can reach", async () => {
+		const root = path.join(tempRoot, ".claude");
+		const cwd = path.join(tempRoot, "overloaded");
+		const id = "22222222-2222-4222-8222-222222222222";
+		await writeJsonl(path.join(root, "history.jsonl"), [
+			{ sessionId: id, timestamp: 1_767_225_600_000, display: ".", project: cwd },
+		]);
+		await writeJsonl(path.join(root, "projects", cwd.replaceAll(path.sep, "-"), `${id}.jsonl`), [
+			{
+				type: "user",
+				uuid: "u",
+				parentUuid: null,
+				timestamp: "2026-01-01T00:00:00.000Z",
+				cwd,
+				message: { content: "." },
+			},
+			{
+				type: "assistant",
+				uuid: "a",
+				parentUuid: "u",
+				timestamp: "2026-01-01T00:00:01.000Z",
+				isApiErrorMessage: true,
+				apiErrorStatus: 529,
+				error: "server_error",
+				// Claude Code stamps a completed stop_reason on the record even
+				// though nothing was answered.
+				message: {
+					id: "msg_err",
+					model: "claude-sonnet-4-5",
+					stop_reason: "stop_sequence",
+					content: [{ type: "text", text: "API Error: 529 Overloaded." }],
+				},
+			},
+		]);
+		const store = new ClaudeSessionStore(root);
+		const info = (await store.list())[0];
+		if (!info) throw new Error("Overloaded fixture was not listed");
+		const manager = await store.load(info);
+
+		const assistant = manager.getEntries().find(e => e.type === "message" && e.message.role === "assistant");
+		if (assistant?.type !== "message" || assistant.message.role !== "assistant") {
+			throw new Error("Missing imported assistant");
+		}
+		expect(assistant.message.stopReason).toBe("error");
+		expect(assistant.message.errorStatus).toBe(529);
+	});
+
 	it("uses current history metadata and converts linked messages in memory", async () => {
 		const { info, store } = await createClaudeFixture();
 


### PR DESCRIPTION
Claude Code records an API error as an assistant record carrying
`isApiErrorMessage: true`, `apiErrorStatus`, and `error`, while still stamping a
completed `stop_reason` inside the message. `convertRecord` reads only
`stop_reason`, so the imported turn gets `stopReason: "stop"`.

The same function already copies `errorMessage` and `errorStatus` onto the
message, so a single imported entry ends up asserting both that it failed
(`errorStatus: 529`, `errorMessage: "server_error"`) and that it completed
normally (`stopReason: "stop"`). Those cannot both be right; the record-level
flag is the only field that says the turn produced no answer.

## Verification

`bun test packages/coding-agent/test/foreign-session-stores.test.ts` — 7 pass.
Reverting the single expression fails the added case with
`Expected: "error" / Received: "stop"`.
