### PR TITLE
fix(tui): refresh inspect_image notice when role cycle keeps tool hidden

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the `inspect_image` status hint naming the previous model after cycling roles (Ctrl+P) between two models that share image-input capability ([#10729](https://github.com/can1357/oh-my-pi/issues/10729)).
+
 ## [18.1.7] - 2026-09-03
 
 ### Breaking Changes

--- a/packages/coding-agent/src/session/session-tools.ts
+++ b/packages/coding-agent/src/session/session-tools.ts
@@ -250,6 +250,14 @@ export class SessionTools {
 	#toolRegistryMutationScope = new AsyncLocalStorage<boolean>();
 	#toolRegistryMutationTail: Promise<void> = Promise.resolve();
 	#promptModelKey: string | undefined;
+	/**
+	 * Model identity (`formatModelString`) last named by an inspect_image
+	 * status notice. Consulted by {@link reconcileInspectImageAfterModelChange}
+	 * to refresh the hint when consecutive switches keep the tool hidden but
+	 * change the active model — otherwise the notice keeps naming the previous
+	 * model (issue #10729).
+	 */
+	#lastInspectImageNoticeModel: string | undefined;
 	#rebuildSystemPrompt: SessionToolsOptions["rebuildSystemPrompt"];
 	#getMcpServerInstructions: SessionToolsOptions["getMcpServerInstructions"];
 	#setActiveToolNames: SessionToolsOptions["setActiveToolNames"];
@@ -1602,23 +1610,32 @@ export class SessionTools {
 
 	/**
 	 * Reconciles inspect_image after a model change and surfaces a notice when
-	 * the visible tool set actually flipped. Called from every model-change
-	 * path — including retry-fallback switches that bypass
-	 * {@link syncAfterModelChange}.
+	 * the visible tool set flips, or when consecutive switches keep the tool
+	 * hidden for image capability but change the active model (the hint names
+	 * the model, so it would otherwise keep naming the previous one — issue
+	 * #10729). Called from every model-change path — including retry-fallback
+	 * switches that bypass {@link syncAfterModelChange}.
 	 */
 	reconcileInspectImageAfterModelChange(): Promise<void> {
 		return this.runToolRegistryMutation(async () => {
 			const before = this.getEnabledToolNames().includes("inspect_image");
 			const reconciled = await this.reconcileInspectImageTool();
+			if (!reconciled) return;
 			const after = this.getEnabledToolNames().includes("inspect_image");
-			if (!reconciled || before === after) return;
 			const model = this.#host.model();
 			const modelName = model ? formatModelString(model) : "the current model";
+			const flipped = before !== after;
+			// The hidden-state hint names the active model to explain why
+			// inspect_image vanished; refresh it when the model changed while the
+			// tool stays hidden, otherwise the prior hint keeps naming the old model.
+			const staleHiddenModel = !after && !flipped && modelName !== this.#lastInspectImageNoticeModel;
+			if (!flipped && !staleHiddenModel) return;
+			this.#lastInspectImageNoticeModel = modelName;
 			this.#host.emitNotice(
 				"info",
 				after
 					? `inspect_image is now available: ${modelName} has no native image input.`
-					: `inspect_image is now hidden: ${modelName} supports image input natively. Override with /vision on.`,
+					: `inspect_image ${flipped ? "is now hidden" : "stays hidden"}: ${modelName} supports image input natively. Override with /vision on.`,
 				"vision",
 			);
 		});

--- a/packages/coding-agent/test/inspect-image-notice-model.test.ts
+++ b/packages/coding-agent/test/inspect-image-notice-model.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "bun:test";
+import * as path from "node:path";
+import { createMockModel, registerMockApi } from "@oh-my-pi/pi-ai/providers/mock";
+import { TempDir } from "@oh-my-pi/pi-utils";
+import { ModelRegistry } from "../src/config/model-registry";
+import { Settings } from "../src/config/settings";
+import { createAgentSession } from "../src/sdk";
+import { AuthStorage } from "../src/session/auth-storage";
+import { SessionManager } from "../src/session/session-manager";
+
+registerMockApi();
+
+describe("inspect_image status notice after model change", () => {
+	it("names the newly active model when cycling between two image-capable models", async () => {
+		const dir = TempDir.createSync("@inspect-image-notice-");
+		const auth = await AuthStorage.create(path.join(dir.path(), "auth.db"));
+		try {
+			auth.setRuntimeApiKey("mock", "test-key");
+			const text = createMockModel({ id: "text", handler: () => ({ content: ["a"] }) });
+			const visionA = createMockModel({ id: "visionA", handler: () => ({ content: ["b"] }) });
+			visionA.input.push("image");
+			const visionB = createMockModel({ id: "visionB", handler: () => ({ content: ["c"] }) });
+			visionB.input.push("image");
+			const settings = Settings.isolated({
+				"compaction.enabled": false,
+				"images.blockImages": false,
+				"todo.enabled": false,
+				"retry.enabled": false,
+			});
+			const { session } = await createAgentSession({
+				cwd: dir.path(),
+				agentDir: dir.path(),
+				authStorage: auth,
+				modelRegistry: new ModelRegistry(auth, path.join(dir.path(), "models.yml")),
+				model: text,
+				settings,
+				sessionManager: SessionManager.inMemory(dir.path()),
+				disableExtensionDiscovery: true,
+				enableMCP: false,
+				enableLsp: false,
+				skills: [],
+				rules: [],
+				contextFiles: [],
+			});
+			const visionNotices: string[] = [];
+			const unsubscribe = session.subscribe(event => {
+				if (event.type === "notice" && event.source === "vision") visionNotices.push(event.message);
+			});
+			try {
+				// text -> visionA: tool flips to hidden, notice names visionA.
+				await session.setModel(visionA);
+				expect(visionNotices.at(-1)).toContain("hidden");
+				expect(visionNotices.at(-1)).toContain("mock/visionA");
+
+				// visionA -> visionB: tool stays hidden (both image-capable). The
+				// notice must refresh to name visionB, not keep naming visionA.
+				await session.setModel(visionB);
+				expect(visionNotices.at(-1)).toContain("mock/visionB");
+				expect(visionNotices.at(-1)).not.toContain("mock/visionA");
+			} finally {
+				unsubscribe();
+				await session.dispose();
+			}
+		} finally {
+			auth.close();
+			dir.removeSync();
+		}
+	});
+});


### PR DESCRIPTION
## Repro
With roles where `default` has no native image input and both `slow` and `smol` do, cycling with Ctrl+P from `default` → `slow` → `smol` leaves the `inspect_image` status hint naming `slow` instead of `smol`. Reproduced with three mock roles (one text-only, two image-capable): `text -> visionA` flips the tool hidden and emits `inspect_image is now hidden: mock/visionA …`; `visionA -> visionB` emits nothing, so the last `vision` notice still names `mock/visionA`. Run: `bun test test/inspect-image-notice-model.test.ts`.

## Cause
`SessionTools.reconcileInspectImageAfterModelChange()` in `packages/coding-agent/src/session/session-tools.ts` gated notice emission on a capability flip (`before === after` early-return) while the notice text is model-specific (`formatModelString`). Switching between two models on the same side of the image-capability boundary keeps `inspect_image` hidden, so the gate skips emission and the earlier model-named hint goes stale. The Ctrl+P path (`input-controller.cycleRoleModel` → `showModelCycleTrack`) never calls `showStatus`, so nothing overwrites the stale hint.

## Fix
- Add `#lastInspectImageNoticeModel` to track the model identity last named by an `inspect_image` notice.
- Emit the notice when the tool set flips (unchanged) OR when the tool stays hidden and the active model changed since the last notice, so the hint always names the current model. Refresh case reads `stays hidden` rather than `is now hidden`.
- Only the hidden state refreshes on a non-flip model change; text→text cycling (tool stays available) is unaffected, avoiding notice spam.

## Verification
`bun test test/inspect-image-notice-model.test.ts test/nonvision-model-switch.test.ts` → 2 pass (new regression test plus the existing flip-notice test). `bun check` clean. Fixes #10729