### PR TITLE
fix(tui): scroll the session tree by one offset for the whole window

### DIFF
--- a/packages/coding-agent/src/modes/components/tree-selector.ts
+++ b/packages/coding-agent/src/modes/components/tree-selector.ts
@@ -618,6 +618,15 @@ class TreeList implements Component {
 		const rowWidth = contentRowWidth(width, this.#filteredNodes.length, this.maxVisibleLines);
 		const rows: string[] = [];
 
+		// One horizontal scroll position for the whole window: a per-row offset
+		// would put a different tree depth in the same column on each line, so
+		// connectors and gutters would stop describing one shape.
+		const depthOf = (flatNode: FlatNode): number =>
+			this.#multipleRoots ? Math.max(0, flatNode.indent - 1) : flatNode.indent;
+		const windowDepths = this.#filteredNodes.slice(startIndex, endIndex).map(depthOf);
+		const deepest = windowDepths.length > 0 ? Math.max(...windowDepths) : 0;
+		const windowOffset = Math.max(0, deepest - maxIndentLevels);
+
 		for (let i = startIndex; i < endIndex; i++) {
 			const flatNode = this.#filteredNodes[i];
 			const entry = flatNode.node.entry;
@@ -627,7 +636,7 @@ class TreeList implements Component {
 			const cursor = isSelected ? theme.fg("accent", "› ") : "  ";
 
 			// If multiple roots, shift display (roots at 0, not 1)
-			const displayIndent = this.#multipleRoots ? Math.max(0, flatNode.indent - 1) : flatNode.indent;
+			const displayIndent = depthOf(flatNode);
 
 			// Build prefix with gutters at their correct positions, clamped to
 			// `maxIndentLevels` cells so the content always fits. When clamped, the
@@ -636,8 +645,8 @@ class TreeList implements Component {
 			const hasConnector = flatNode.showConnector && !flatNode.isVirtualRootChild;
 			const connectorSymbol = hasConnector ? (flatNode.isLast ? theme.tree.last : theme.tree.branch) : "";
 			const connectorChars = hasConnector ? Array.from(connectorSymbol) : [];
-			const renderedIndent = Math.min(displayIndent, maxIndentLevels);
-			const scrollOffset = displayIndent - renderedIndent;
+			const scrollOffset = Math.min(windowOffset, displayIndent);
+			const renderedIndent = displayIndent - scrollOffset;
 			const connectorPositionDisplay = hasConnector ? renderedIndent - 1 : -1;
 			// Linear rows reuse their branch head's depth. Existing sibling
 			// gutters remain visible; terminal gutters remain terminated.

--- a/packages/coding-agent/test/modes/components/tree-selector-clamp-frame.test.ts
+++ b/packages/coding-agent/test/modes/components/tree-selector-clamp-frame.test.ts
@@ -1,0 +1,97 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
+import { TreeSelectorComponent } from "@oh-my-pi/pi-coding-agent/modes/components/tree-selector";
+import * as themeModule from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import type { SessionEntry, SessionTreeNode } from "@oh-my-pi/pi-coding-agent/session/session-entries";
+
+let counter = 0;
+function makeNode(role: "user" | "assistant", text: string, parentId: string | null = null): SessionTreeNode {
+	const id = `e${counter++}`;
+	const message: AgentMessage =
+		role === "user"
+			? { role: "user", content: text, timestamp: counter }
+			: ({
+					role: "assistant",
+					content: [{ type: "text", text }],
+					timestamp: counter,
+					stopReason: "stop",
+				} as AgentMessage);
+	const entry: SessionEntry = {
+		type: "message",
+		id,
+		parentId,
+		timestamp: new Date().toISOString(),
+		message,
+	};
+	return { entry, children: [] };
+}
+
+function chain(parent: SessionTreeNode, role: "user" | "assistant", text: string): SessionTreeNode {
+	const node = makeNode(role, text, parent.entry.id);
+	parent.children.push(node);
+	return node;
+}
+
+/** A spine of `forks` interrupted turns, returning the tree and its active leaf. */
+function forkedSpine(forks: number): { root: SessionTreeNode; leaf: SessionTreeNode } {
+	counter = 0;
+	const root = makeNode("user", "root question");
+	let cursor: SessionTreeNode = root;
+	for (let fork = 0; fork < forks; fork++) {
+		chain(cursor, "assistant", `abandoned ${fork}`);
+		cursor = chain(cursor, "user", `follow-up ${fork}`);
+	}
+	return { root, leaf: cursor };
+}
+
+function renderStripped(root: SessionTreeNode, leaf: SessionTreeNode): string[] {
+	const selector = new TreeSelectorComponent(
+		[root],
+		leaf.entry.id,
+		30,
+		() => {},
+		() => {},
+	);
+	return selector.renderContent(120).map(line => Bun.stripANSI(line));
+}
+
+/** Column of a row's `├─`/`└─`, or `undefined` when it draws no connector. */
+function connectorColumn(row: string): number | undefined {
+	const column = row.search(/[├└]─/);
+	return column < 0 ? undefined : column;
+}
+
+describe("clamped rows share one horizontal frame", () => {
+	beforeAll(async () => {
+		await themeModule.initTheme(false, undefined, undefined, "dark", "light");
+	});
+
+	// 120 columns caps the prefix at 18 levels, so 25 forks render scrolled.
+	// Offsetting each row by its own depth puts unrelated depths in one column,
+	// stacking the `└─` that closes each abandoned turn at one width.
+	it("steps closing connectors outward one level at a time", () => {
+		const { root, leaf } = forkedSpine(25);
+		const closing = renderStripped(root, leaf)
+			.filter(row => /└─/.test(row))
+			.map(row => row.search(/└─/));
+
+		expect(closing.length).toBeGreaterThan(2);
+		for (const [left, right] of closing.slice(0, -1).map((column, i) => [column, closing[i + 1]])) {
+			expect(right).toBeLessThan(left);
+		}
+	});
+
+	// A `└─` is the last child at its level, so its column stays empty below.
+	it("leaves a terminated column empty on every row beneath it", () => {
+		const { root, leaf } = forkedSpine(25);
+		const rows = renderStripped(root, leaf);
+
+		for (const [index, row] of rows.entries()) {
+			const column = connectorColumn(row);
+			if (column === undefined || row[column] !== "└") continue;
+			for (const below of rows.slice(index + 1)) {
+				expect(below[column] ?? " ").not.toBe("│");
+			}
+		}
+	});
+});


### PR DESCRIPTION
<!-- REQUIRED: replace this line with one sentence in your own words. -->

The session tree derives a horizontal scroll offset per row from that row's own
depth (`scrollOffset = displayIndent - renderedIndent`). Rows at different depths
therefore scroll by different amounts, so a connector closing a branch two levels
down and one closing a branch twenty-seven levels down land in the same column.
Gutters also run past connectors that have already terminated them.

This computes one offset for the whole visible window from its deepest row, and
clamps each row to it (`scrollOffset = min(windowOffset, displayIndent)`), so a
column means the same depth on every line.

## Verification

<!-- REQUIRED: replace with what you actually ran and saw, e.g. opening /tree on
a deep session before and after. -->

Ran against a clean checkout of `origin/main` plus this commit:
`bun test packages/coding-agent/test/modes/components/tree-selector-clamp-frame.test.ts`
— 2 pass. Reverting only `tree-selector.ts` to `origin/main` and keeping the test
fails with `Expected: < 53 / Received: 53`, two closing connectors stacking in
one column.

Note: of the two cases, "steps closing connectors outward one level at a time" is
the regression guard; "leaves a terminated column empty" documents the related
gutter invariant and passes either way.
