### PR TITLE
docs(settings): update project config example to methodOrder

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -242,7 +242,7 @@ tools:
     bash: prompt
 
 compaction:
-  strategy: snapcompact
+  methodOrder: [snapcompact, remote, soft]
   thresholdPercent: 80
 
 theme:


### PR DESCRIPTION
## Repro
The project-local config example in `docs/settings.md` (lines 244-246) shows `compaction:\n  strategy: snapcompact`. `compaction.strategy` was removed in coding-agent 17.4.0 in favor of `compaction.methodOrder`, which the same page documents (line 638) and uses (line 624). Copying the example writes deprecated config that only survives via the compatibility migration shim. Reproduce by reading `docs/settings.md` around the `## Project-local config` heading, or `omp://settings.md`, and comparing the example against the `compaction.methodOrder` catalog rows further down.

## Cause
The example was not updated when the compaction settings were migrated. `packages/coding-agent/src/config/settings.ts:2136-2185` migrates legacy `compaction.strategy`/`compaction.remoteEnabled` to `compaction.methodOrder` and then deletes the legacy keys; a `strategy: snapcompact` with default `remoteEnabled` maps to `methodOrder: [snapcompact, remote, soft]`.

## Fix
- `docs/settings.md`: replace `strategy: snapcompact` in the project-local config example with `methodOrder: [snapcompact, remote, soft]` — the exact equivalent the migration produces — so the copyable example matches the current, self-consistent setting.

## Verification
Grepped `docs/` for `strategy: snapcompact` / `compaction.strategy` / `remoteEnabled`: the edited line was the only stale occurrence. Docs-only change; no test suite applies. Fixes #10734