### PR TITLE
feat(advisor): deliver concerns at the next model step

### DIFF
--- a/docs/advisor-watchdog.md
+++ b/docs/advisor-watchdog.md
@@ -52,7 +52,7 @@ persisting `advisor.enabled`:
 omp -p --advisor "Review this task."
 ```
 
-While a primary prompt is running, advisor concerns and blockers continue to steer that live turn. After the final prompt settles, print mode preserves late advisor notes without starting hidden primary turns, then waits up to ten minutes for final reviews before disposing the session. Error exits use a 30-second drain budget so failed automation can terminate. If either deadline expires, OMP logs the reviews that disposal will abandon; completed reviews retain their transcript and token/cost usage.
+While a primary prompt is running, an advisor blocker still steers that live turn and a concern lands as a non-interrupting aside at the primary's next step. After the final prompt settles, print mode preserves late advisor notes without starting hidden primary turns, then waits up to ten minutes for final reviews before disposing the session. Error exits use a 30-second drain budget so failed automation can terminate. If either deadline expires, OMP logs the reviews that disposal will abandon; completed reviews retain their transcript and token/cost usage.
 
 Slash commands:
 
@@ -103,11 +103,11 @@ Advisor tools are built against the isolated advisor `ToolSession` and wrapped w
 
 The `advise` tool accepts one note and an optional severity:
 
-| Severity        | Delivery                                                                                                                                                             | Intended use                                                                 |
-| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
-| omitted / `nit` | Non-interrupting aside, batched into the primary transcript at the next step boundary.                                                                               | Cleanup, simplification, low-risk edge cases.                                |
-| `concern`       | Interrupting steering message when the delivery constraints below permit it. A late terminal-answer `concern` is preserved as a visible card instead.                | Material risk, likely wrong direction, missing constraint, hallucinated API. |
-| `blocker`       | Interrupting steering message when the delivery constraints below permit it. Unlike a `concern`, a terminal answer alone does not prevent it from triggering a turn. | Continuing would clearly waste work or produce broken output.                |
+| Severity        | Delivery                                                                                                                                                                                                                           | Intended use                                                                 |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| omitted / `nit` | Non-interrupting aside batched into the primary transcript at the next step boundary while the primary is running; a visible advisor card when it is idle. Withheld during an in-progress review until the first completed update. | Cleanup, simplification, low-risk edge cases.                                |
+| `concern`       | Non-interrupting aside at the next step boundary while the primary is running; never aborts a tool. When the primary is idle it is preserved as a visible card after a terminal answer, or triggers a turn after a mid-work yield. | Material risk, likely wrong direction, missing constraint, hallucinated API. |
+| `blocker`       | Interrupting steering message when the delivery constraints below permit it. Unlike a `concern`, a terminal answer alone does not prevent it from triggering a turn.                                                               | Continuing would clearly waste work or produce broken output.                |
 
 Accepted notes are rendered into the primary transcript as XML-escaped `<advisory>` elements. Named roster advisors add an `advisor` attribute:
 
@@ -119,23 +119,22 @@ note text
 
 When you deliberately interrupt the agent (Esc, or a cancel from collab, ACP, RPC, the SDK, or an extension), the advisor stops auto-resuming it. An interrupting `concern`/`blocker` raised while the run is stopped is recorded as a visible advisor card instead of restarting the turn, and a concern already in flight when you interrupt is preserved the same way rather than driving a surprise resume. The advice re-enters context the next time you resume — a new message, the `.`/`c` continue shortcut, or a steer/follow-up.
 
-A normal yield the agent drove itself is treated differently from a deliberate interrupt, but it is not a blanket "always steers and resumes". The loop state and completed turn first determine the normal delivery path:
+A normal yield the agent drove itself is treated differently from a deliberate interrupt, but it is not a blanket "always steers and resumes". The loop state and the completed turn determine delivery:
 
-- **While the loop is still streaming** (the raise arrived before the yield, or during a resume you already drove), the note normally steers into the live turn.
-- **Once the loop has yielded and gone idle**, delivery keys on how the turn ended:
-  - If the primary's tail is a **terminal text answer with no queued work**, a late `concern` is preserved as a visible card rather than waking the agent to restate a completed turn (#4840) — it re-enters context on the next resume (a new message, `.`/`c`, or a steer/follow-up), exactly like the interrupt case. A `blocker` is the exception: it normally steers a triggered turn, because it means the agent handed off broken or unexercised work that must be acknowledged before the turn is considered done (#5628).
-  - Otherwise (the agent yielded mid-work, no terminal answer), an idle `concern`/`blocker` normally triggers a fresh turn so the advice is acted on immediately.
+- **While the loop is still streaming**, a `blocker` steers into the live turn and aborts the in-flight tool under `interruptMode: immediate`, while a `concern` or `nit` is queued as a non-interrupting aside and injected before the next model step, after the current tool batch completes, so a concern never aborts a running tool.
+- **Once the loop has yielded and gone idle**, a terminal text answer with no queued work preserves a late `concern` as a visible card (#4840) that re-enters context on the next resume, while a `blocker` still steers a triggered turn (#5628); a mid-work yield lets an idle `concern` or `blocker` trigger a fresh turn; and a `nit` raised while idle is preserved as a visible card because nothing polls the aside queue until the next run.
+- **When the loop settles**, any advisor aside queued after the loop's last step boundary, still queued when the user interrupted, or still queued when `/compact` reconnects the session, is re-recorded as a visible card instead of lingering until the next prompt.
 
 Two session/client constraints can still preserve a note whose normal delivery path is steering:
 
 - **Plan mode:** every would-be advisor steer is preserved as a visible card, even while the primary loop is streaming, because only user-driven turns converge on ask/resolve.
 - **ACP with deferred agent-initiated turns:** when `deferAgentInitiatedTurns` is enabled and the bridge has not allowed agent-initiated turns, an idle would-be steer is preserved because the client cannot represent the triggered turn as busy. Advice raised while the primary loop is already streaming can still steer into that live turn.
 
-So the advisor can steer and resume a run the agent ended on its own **while it is running or yielded mid-work and the current mode/client permits steering**. When steering is blocked instead, the note is either preserved as a card (the terminal-answer, plan-mode, and deferred-ACP cases above) or downgraded to a non-interrupting aside (the `advisor.immuneTurns` cooldown below); either way it waits for the next step boundary or resume rather than waking the agent.
+So the advisor can steer and resume a run only with a `blocker` while it is running, or with a `concern` or `blocker` after a mid-work yield, and only when the current mode/client permits steering. Every other note is a next-step aside while the loop runs or a visible card once it is idle.
 
-`advisor.immuneTurns` limits interruption frequency. After the advisor successfully delivers a `concern` or `blocker` through the steering channel, later concerns/blockers are routed as non-interrupting asides until the configured number of primary turns has completed. The default is `3`. `nit` notes are unchanged, and advice raised while user-interrupt auto-resume suppression is active is still preserved instead of restarting a stopped run.
+`advisor.immuneTurns` limits how often the advisor can wake an idle agent. After a note steers or triggers a turn, later concerns are preserved as visible cards instead of triggering a turn until the configured number of primary turns has completed. The default is `3`. A `blocker` is exempt, a `nit` is unchanged, and concerns raised while the agent is running are unaffected because they never interrupt.
 
-While an advisor update is reviewing work still in progress, `AdviseTool` withholds `nit` and `concern` calls; only a `blocker` may interrupt partial work. The tool also suppresses the same whitespace-normalized note at an equal or lower severity while allowing a real escalation (`nit` → `concern` → `blocker`).
+While an advisor update is reviewing work still in progress, `AdviseTool` withholds `nit` calls until the first completed update (the advisor receives a `Deferred` receipt and must not re-raise the point); a `concern` is routed immediately and reaches the running primary at its next step; only a `blocker` may interrupt partial work. The tool also suppresses the same whitespace-normalized note at an equal or lower severity while allowing a real escalation (`nit` → `concern` → `blocker`).
 
 ### Emission guard
 
@@ -146,7 +145,7 @@ Each advisor has its own `AdvisorEmissionGuard` (`src/advisor/emission-guard.ts`
 3. **Exact-text dedupe.** Any normalized note already accepted by this advisor in this session is dropped. The FIFO history holds at most 4096 entries.
 4. **Per-update rate limit.** At most one note per advisor model `prompt()` cycle is accepted. Suppressed noise never consumes the budget.
 
-Guard-level suppression is invisible to the model because `AdviseTool` has already returned `Recorded.`. The tool's earlier equal-or-lower-severity duplicate check is intentionally visible as `Duplicate advice ignored.`; in-progress non-blockers return `Recorded.` without routing.
+Guard-level suppression is invisible to the model because `AdviseTool` has already returned `Recorded.`. The tool's earlier equal-or-lower-severity duplicate check is intentionally visible as `Duplicate advice ignored.`; in-progress nits return `Deferred ...` and are routed on the first completed update.
 
 The guard's full state — dedupe history and per-update gate — clears on every advisor reset (compaction, session switch, `/new`), so a re-primed reviewer can re-raise issues it already raised against the rewritten transcript.
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -381,7 +381,7 @@ See [Advisor and WATCHDOG.md](./advisor-watchdog.md) for runtime behavior, `WATC
 | `advisor.enabled`     | boolean | `false` | Enable the advisor runtime when `modelRoles.advisor` resolves to an available model.                                                                 |
 | `task.agentAdvisor`   | record  | `{}`    | Per-agent subagent advisor: agent name → `"on"` / `"off"` / advisor model pattern. Overrides agent frontmatter `advisor`; configured from the `/agents` hub. |
 | `advisor.syncBacklog` | enum    | `off`   | Bounded advisor catch-up delay: `off`, `1`, `3`, or `5`. The primary waits up to 30 seconds only while advisor backlog is at or above the threshold. |
-| `advisor.immuneTurns` | number  | `3`     | After a `concern`/`blocker` interrupts, route further concerns/blockers as non-interrupting asides for this many completed primary turns.            |
+| `advisor.immuneTurns` | number  | `3`     | After an advisor blocker interrupts or a concern wakes an idle agent, further concerns are shown as cards instead of waking the agent for this many completed primary turns. Blockers are exempt. |
 
 ### Thinking
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Advisor concerns raised while the agent is mid-turn now reach it at its next step as non-interrupting asides instead of after the turn completes; only blockers interrupt a running tool ([#10600](https://github.com/can1357/oh-my-pi/issues/10600)).
+
+### Fixed
+
+- Fixed advisor notes lingering invisibly until the next prompt when they arrived after the agent's last step or while it was idle; they are now shown as advisor cards ([#10600](https://github.com/can1357/oh-my-pi/issues/10600)).
+
 ## [18.1.7] - 2026-09-03
 
 ### Breaking Changes

--- a/packages/coding-agent/src/advisor/advise-tool.ts
+++ b/packages/coding-agent/src/advisor/advise-tool.ts
@@ -67,10 +67,11 @@ export function formatAdvisorBatchContent(notes: readonly AdvisorNote[]): string
 }
 
 /**
- * Whether advice at this severity should interrupt the running agent (delivered
- * via the steering channel, aborting in-flight tools) rather than ride the
- * non-interrupting aside queue that lands at the next step boundary. `concern`
- * and `blocker` interrupt; a plain `nit` queues.
+ * Whether a note at this severity may wake or interrupt the primary. A
+ * `blocker` steers even into a streaming turn; a `concern` only wakes an idle
+ * mid-work primary and is subject to the immune-turn window; a plain `nit`
+ * never does. A streaming primary receives concerns and nits as next-step
+ * asides.
  */
 export function isInterruptingSeverity(severity: AdvisorSeverity | undefined): boolean {
 	return severity === "concern" || severity === "blocker";
@@ -93,28 +94,33 @@ export function isAdvisorInterruptImmuneTurnActive(opts: {
  *
  * - A `preserveOnly` caller records every note that arrives while the primary
  *   is idle as a visible card and never starts a new primary turn.
- * - A non-interrupting `nit` always rides the non-interrupting aside queue.
- * - An interrupting `concern`/`blocker` is normally steered into the agent: into
- *   the live turn while one is streaming, or (when idle) a triggered turn so the
- *   advice is acted on immediately.
- * - If the primary tail is already a terminal text answer and there is no queued
- *   work, a late `concern` is preserved as a visible card instead of waking the
- *   primary to restate completion. A `blocker` is the exception: it means the
- *   agent handed off broken or unexercised work, so it still steers a triggered
- *   turn to force the primary to acknowledge and continue before the turn is
- *   considered done (#5628) — deferring it to the next user turn is the bug.
- * - After a deliberate user interrupt (`autoResumeSuppressed`) the advisor must
- *   not auto-resume the stopped run. While the agent is idle — or still tearing
- *   the interrupted turn down (`aborting`) — the note is preserved as a visible
- *   card instead of restarting the run. But once a turn is actively streaming
- *   again (a resume the user already drove), steering the note in does NOT
- *   auto-resume anything, so it is delivered live. Parking it during an active
- *   run instead strands it (it never reaches the running agent) and the withheld
- *   notes dump as one burst at the next user prompt — the bug this guards.
- * - During the post-interrupt immune-turn window, further `concern` notes are
- *   downgraded to asides; preservation still wins. A `blocker` is exempt: it
- *   means the agent handed off broken or unexercised work, so it still steers a
- *   triggered turn even right after a prior interrupt (#5628).
+ * - The aside channel is only used while the primary loop is live — streaming
+ *   and not aborting — because that is the only time the loop polls
+ *   `getAsideMessages` again; a note parked any other time would strand. A
+ *   live loop therefore receives a `nit` or a `concern` as a next-step aside
+ *   and is never interrupted by a concern; only a `blocker` still steers into
+ *   the live turn.
+ * - Once the loop is idle a `nit` is preserved as a visible card. A `concern`
+ *   after a terminal answer with no queued work is preserved instead of waking
+ *   the primary to restate completion; a `concern` after a mid-work yield
+ *   steers a triggered turn so the advice is acted on immediately. A `blocker`
+ *   always steers a triggered turn: it means the agent handed off broken or
+ *   unexercised work, so the primary must acknowledge and continue before the
+ *   turn is considered done (#5628) — deferring it to the next user turn is
+ *   the bug.
+ * - The user-interrupt guard is unchanged: after a deliberate user interrupt
+ *   (`autoResumeSuppressed`) the advisor must not auto-resume the stopped run.
+ *   While the agent is idle — or still tearing the interrupted turn down
+ *   (`aborting`) — the note is preserved as a visible card instead of
+ *   restarting the run. But once a turn is actively streaming again (a resume
+ *   the user already drove), steering the note in does NOT auto-resume
+ *   anything, so it is delivered live. Parking it during an active run instead
+ *   strands it (it never reaches the running agent) and the withheld notes
+ *   dump as one burst at the next user prompt — the bug this guards.
+ * - During the post-interrupt immune-turn window an idle `concern` is
+ *   preserved as a visible card instead of triggering a turn (a streaming one
+ *   still rides the aside queue); a `blocker` remains exempt and still steers
+ *   a triggered turn even right after a prior interrupt (#5628).
  */
 export function resolveAdvisorDeliveryChannel(opts: {
 	severity: AdvisorSeverity | undefined;
@@ -126,11 +132,13 @@ export function resolveAdvisorDeliveryChannel(opts: {
 	preserveOnly?: boolean;
 }): AdvisorDeliveryChannel {
 	if (opts.preserveOnly && !opts.streaming) return "preserve";
-	if (!isInterruptingSeverity(opts.severity)) return "aside";
+	const live = opts.streaming && !opts.aborting;
+	if (!isInterruptingSeverity(opts.severity)) return live ? "aside" : "preserve";
 	if (opts.autoResumeSuppressed && (opts.aborting || !opts.streaming)) return "preserve";
+	if (live && opts.severity !== "blocker") return "aside";
 	if (opts.terminalAnswerNoQueuedWork && opts.severity !== "blocker" && !opts.streaming && !opts.aborting)
 		return "preserve";
-	if (opts.interruptImmuneTurnActive && opts.severity !== "blocker") return "aside";
+	if (opts.interruptImmuneTurnActive && opts.severity !== "blocker") return "preserve";
 	return "steer";
 }
 

--- a/packages/coding-agent/src/advisor/advise-tool.ts
+++ b/packages/coding-agent/src/advisor/advise-tool.ts
@@ -194,11 +194,11 @@ export class AdviseTool implements AgentTool<typeof adviseSchema, AdviseDetails>
 	 *  by retagging the same text at a lower or equal severity. */
 	#deliveredNoteSeverities = new Map<string, number>();
 	#inProgressUpdate = false;
-	/** Notes withheld while the primary was mid-turn, in arrival order. Flushed
-	 *  deterministically on the first `beginUpdate(false)` so delivery does not
-	 *  depend on the advisor model choosing to re-raise (it may not, since the
-	 *  tool previously returned "Recorded." for a note that was never routed).
-	 *  Cleared on `resetDeliveredNotes` alongside the delivered-rank map. */
+	/** Nits withheld while the primary was mid-turn, in arrival order. A concern
+	 *  never enters this queue: it takes the live path and routing delivers it to
+	 *  a streaming primary as a next-step aside. Flushed deterministically on the
+	 *  first `beginUpdate(false)`; cleared on `resetDeliveredNotes` alongside the
+	 *  delivered-rank map. */
 	#deferredNotes: { key: string; note: string; severity?: AdviseDetails["severity"] }[] = [];
 
 	/**
@@ -217,8 +217,8 @@ export class AdviseTool implements AgentTool<typeof adviseSchema, AdviseDetails>
 
 	/**
 	 * Mark whether the next advisor prompt reviews an in-progress primary turn.
-	 * Non-blockers are withheld until a completed update so partial work does
-	 * not interrupt the primary before it can finish its planned steps.
+	 * Nits are withheld until a completed update so partial work is not
+	 * nitpicked; concerns and blockers are always routed immediately.
 	 */
 	beginUpdate(inProgress: boolean): void {
 		const wasInProgress = this.#inProgressUpdate;
@@ -248,19 +248,14 @@ export class AdviseTool implements AgentTool<typeof adviseSchema, AdviseDetails>
 		_onUpdate?: AgentToolUpdateCallback<AdviseDetails>,
 		_context?: AgentToolContext,
 	): Promise<AgentToolResult<AdviseDetails>> {
-		if (this.#inProgressUpdate && args.severity !== "blocker") {
-			// Withheld, not delivered: queue for the deterministic flush on the next
-			// completed update. Skip if an identical note is already pending so a
-			// long mid-turn can't pile up 20 copies of the same advice. Tell the
-			// advisor the truth — the previous "Recorded." made it believe the note
-			// reached the primary, so it never re-raised and the advice was lost.
+		if (this.#inProgressUpdate && advisorSeverityRank(args.severity) === ADVISOR_SEVERITY_RANK.nit) {
+			// Withheld, not delivered: only nits queue here, for the deterministic
+			// flush on the next completed update. Skip if an identical nit is
+			// already pending so a long mid-turn can't pile up 20 copies of the
+			// same advice.
 			const key = advisorNoteDedupeKey(args.note);
 			const pending = this.#deferredNotes.find(item => item.key === key);
-			if (pending) {
-				// Escalating an already-queued note reuses its slot; never a new one.
-				if (advisorSeverityRank(args.severity) > advisorSeverityRank(pending.severity))
-					pending.severity = args.severity;
-			} else if (this.accept(args.note)) {
+			if (!pending && this.accept(args.note)) {
 				// Reserve the update's one slot now (the emission guard filters noise
 				// and enforces the per-update budget at the moment the note is emitted,
 				// exactly like the live path); hold it for the flush. A suppressed or
@@ -278,11 +273,11 @@ export class AdviseTool implements AgentTool<typeof adviseSchema, AdviseDetails>
 				useless: true,
 			};
 		}
-		// Live path (completed update, or a blocker that must interrupt now). If the
+		// Live path (completed update, or a mid-turn concern or blocker). If the
 		// note already holds a deferred reservation, it cleared the emission guard
 		// when reserved — pull it from the backlog and deliver without re-accepting,
-		// so a blocker escalation of a still-queued nit/concern interrupts at its
-		// blocker severity instead of being rejected as already-seen and arriving
+		// so a concern or blocker escalation of a still-queued nit interrupts at
+		// its higher severity instead of being rejected as already-seen and arriving
 		// late at the lower deferred severity.
 		const key = advisorNoteDedupeKey(args.note);
 		const reservedIndex = this.#deferredNotes.findIndex(item => item.key === key);

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -574,9 +574,9 @@ export const SETTINGS_SCHEMA = {
 			group: "Advisor",
 			label: "Advisor Immune Turns",
 			description:
-				"After an advisor concern or blocker interrupts, route further concerns/blockers non-interruptingly for this many primary turns.",
+				"After an advisor blocker interrupts the agent or a concern wakes an idle agent, show further concerns as visible cards instead of waking the agent for this many primary turns. Blockers are exempt. Concerns raised while the agent is running always land at its next step and are unaffected.",
 			options: [
-				{ value: "0", label: "0 turns", description: "Allow every concern/blocker to interrupt." },
+				{ value: "0", label: "0 turns", description: "Let every concern wake an idle agent." },
 				{ value: "1", label: "1 turn" },
 				{ value: "2", label: "2 turns" },
 				{ value: "3", label: "3 turns", description: "Default." },

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -838,6 +838,7 @@ export class AgentSession {
 		this.#promptInFlightCount = Math.max(0, this.#promptInFlightCount - 1);
 		if (this.#promptInFlightCount !== 0) return;
 		this.yieldQueue.requestIdleFlush();
+		this.#advisors.preserveQueuedAdvice();
 		this.#releasePowerAssertion();
 		this.#flushPendingAgentEnd();
 		if (this.#inFlightSettledCallbacks.length === 0) {
@@ -1072,6 +1073,7 @@ export class AgentSession {
 	#resetInFlight(): void {
 		this.#promptInFlightCount = 0;
 		this.yieldQueue.requestIdleFlush();
+		this.#advisors.preserveQueuedAdvice();
 		this.#releasePowerAssertion();
 		this.#flushPendingAgentEnd();
 		if (this.#inFlightSettledCallbacks.length === 0) {
@@ -1675,6 +1677,7 @@ export class AgentSession {
 			onSseEvent: this.#onSseEvent,
 			isDisposed: () => this.#isDisposed,
 			abortInProgress: () => this.#abortInProgress,
+			isAgentConnected: () => this.#unsubscribeAgent !== undefined,
 			allowAgentInitiatedTurns: () => this.#allowAcpAgentInitiatedTurns,
 			planModeState: () => this.#planModeState,
 			clientBridge: () => this.#clientBridge,
@@ -4223,6 +4226,9 @@ export class AgentSession {
 	#reconnectToAgent(): void {
 		if (this.#unsubscribeAgent) return; // Already connected
 		this.#unsubscribeAgent = this.agent.subscribe(this.#handleAgentEvent);
+		// An aside queued before the disconnect (e.g. a `/compact` boundary) has no
+		// subscriber until this line runs; re-record it now that events flow again.
+		this.#advisors.preserveQueuedAdvice();
 	}
 
 	#activeProviderSessionId(sessionId?: string): string {
@@ -7503,7 +7509,9 @@ export class AgentSession {
 		// Pull advisor concerns out of the steer/follow-up queues before any await so
 		// the post-abort stranded-message drain can't auto-resume the run on them.
 		// They are re-recorded as visible advice once the agent settles (below).
-		const strandedAdvisorCards = userInterrupt ? this.#extractQueuedAdvisorCards() : [];
+		const strandedAdvisorCards = userInterrupt
+			? [...this.#extractQueuedAdvisorCards(), ...this.#advisors.drainQueuedAdvice()]
+			: [];
 		// Session switch/compact paths disconnect first; explicit aborts should
 		// leave any queued steer/follow-up visible for the user rather than
 		// auto-starting a fresh turn during cleanup.

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -7549,35 +7549,40 @@ export class AgentSession {
 			await manualCompactionCleanup;
 			await this.#drainAutolearnCapture();
 			await this.#goalRuntime.onTaskAborted({ reason: options?.goalReason ?? "interrupted" });
-			// Clear prompt-in-flight state: waitForIdle resolves when the agent loop's finally
-			// block runs, but nested prompt setup/finalizers may still be unwinding. Without this,
-			// a subsequent prompt() can incorrectly observe the session as busy after an abort.
-			this.#resetInFlight();
-			this.#resetSessionStopContinuationState();
-			this.#clearPendingSessionStopContinuations();
-			// Safety net: if the agent loop aborted without producing an assistant
-			// message (e.g. failed before the first stream), the in-flight yield was
-			// never resolved or rejected by the normal message_end path. Reject it now
-			// so any requeue callback still fires and the queue stays consistent.
-			if (this.#toolChoiceQueue.hasInFlight) {
-				this.#toolChoiceQueue.reject("aborted");
-			}
-			// Re-record advisor concerns the interrupt would otherwise strand, as
-			// visible/persisted advice without triggering a turn (the agent is idle
-			// now): cards steered into the queue before the user stopped, plus any
-			// that arrived via enqueueAdvice mid-abort and were parked hidden in
-			// #pendingNextTurnMessages while the turn was still tearing down. Other
-			// deferred next-turn context (non-advisor) stays queued, in order.
-			const parkedAdvisorCards = this.#pendingNextTurnMessages.filter(isAdvisorCard);
-			if (parkedAdvisorCards.length > 0) {
-				this.#pendingNextTurnMessages = this.#pendingNextTurnMessages.filter(m => !isAdvisorCard(m));
-			}
-			for (const card of [...strandedAdvisorCards, ...parkedAdvisorCards]) {
-				this.#preserveAdvisorCard(card);
-			}
 		} finally {
-			this.#abortInProgress = false;
-			this.#drainStrandedQueuedMessages();
+			try {
+				// Always clear prompt-in-flight state after the core agent reaches
+				// idle, even when a later cleanup callback rejects.
+				this.#resetInFlight();
+				this.#resetSessionStopContinuationState();
+				this.#clearPendingSessionStopContinuations();
+				// Safety net: if the agent loop aborted without producing an
+				// assistant message, reject the in-flight yield so its requeue
+				// callback still runs and the queue remains consistent.
+				if (this.#toolChoiceQueue.hasInFlight) {
+					this.#toolChoiceQueue.reject("aborted");
+				}
+				if (userInterrupt) {
+					// Reclaim advisor cards from every queue in the finally-safe path.
+					// Keep #abortInProgress set while preserving: if cleanup rejected
+					// before the agent reached idle, #preserveAdvisorCard parks the card
+					// for the next prompt instead of injecting it into a live stream.
+					const parkedAdvisorCards = this.#pendingNextTurnMessages.filter(isAdvisorCard);
+					if (parkedAdvisorCards.length > 0) {
+						this.#pendingNextTurnMessages = this.#pendingNextTurnMessages.filter(m => !isAdvisorCard(m));
+					}
+					const queuedAdvisorCards = [
+						...strandedAdvisorCards,
+						...this.#extractQueuedAdvisorCards(),
+						...this.#advisors.drainQueuedAdvice(),
+						...parkedAdvisorCards,
+					];
+					for (const card of queuedAdvisorCards) this.#preserveAdvisorCard(card);
+				}
+			} finally {
+				this.#abortInProgress = false;
+				this.#drainStrandedQueuedMessages();
+			}
 		}
 	}
 

--- a/packages/coding-agent/src/session/session-advisors.ts
+++ b/packages/coding-agent/src/session/session-advisors.ts
@@ -245,6 +245,7 @@ export interface SessionAdvisorsHost {
 	onSseEvent: SimpleStreamOptions["onSseEvent"] | undefined;
 	isDisposed(): boolean;
 	abortInProgress(): boolean;
+	isAgentConnected(): boolean;
 	allowAgentInitiatedTurns(): boolean;
 	planModeState(): PlanModeState | undefined;
 	clientBridge(): ClientBridge | undefined;
@@ -602,6 +603,21 @@ export class SessionAdvisors {
 	/** Waits for all advisor-card persistence handlers currently in flight. */
 	async waitForPendingCardEvents(): Promise<void> {
 		await Promise.allSettled(this.#pendingAdvisorCardEvents);
+	}
+
+	/** Remove every queued advisor aside, built into one card, for a caller that preserves it itself (the user-interrupt abort). */
+	drainQueuedAdvice(): CustomMessage[] {
+		const card = this.#host.yieldQueue.drainKind("advisor");
+		return card && isAdvisorCard(card) ? [card] : [];
+	}
+
+	/** Re-record advisor asides that missed the loop's last poll as visible cards.
+	 *  No-op while the loop still runs, while an abort is tearing it down, or while
+	 *  the session is disconnected from agent events (`/compact`), because a card
+	 *  emitted then has no subscriber to persist it. */
+	preserveQueuedAdvice(): void {
+		if (this.#host.agent.state.isStreaming || this.#host.abortInProgress() || !this.#host.isAgentConnected()) return;
+		for (const card of this.drainQueuedAdvice()) this.#host.preserveAdvisorCard(card);
 	}
 
 	// Advisor runtime lifecycle
@@ -1084,7 +1100,7 @@ export class SessionAdvisors {
 				getModelIdentity: () => formatModelString(advisorRef.agent.state.model),
 				beginAdvisorUpdate: inProgress => {
 					advisorRef.recorder.beginTurn();
-					// Flush the deferred backlog (notes already cleared the emission guard
+					// Flush the deferred nit backlog (notes already cleared the emission guard
 					// when reserved), then reset the guard's per-update budget for this
 					// prompt's live notes.
 					advisorRef.adviseTool.beginUpdate(inProgress);
@@ -1159,7 +1175,7 @@ export class SessionAdvisors {
 		}
 
 		// One shared non-blocking aside channel for all advisors; the build callback
-		// aggregates every advisor's queued nits into one card (each entry already
+		// aggregates every advisor's queued nits and concerns into one card (each entry already
 		// carries its own `advisor` name).
 		if (this.#advisors.length > 0 && !this.#advisorYieldQueueUnsubscribe) {
 			this.#advisorYieldQueueUnsubscribe = this.#host.yieldQueue.register<AdvisorNote>("advisor", {
@@ -1183,15 +1199,17 @@ export class SessionAdvisors {
 	}
 
 	/**
-	 * Route one accepted advice note from `advisor` to the primary. Concern and
-	 * blocker interrupt the running agent through the steering channel; once the
-	 * loop has yielded, `triggerTurn` resumes it. After a terminal text answer with
-	 * no queued work, a concern is preserved as a visible advisor card, while a
-	 * blocker wakes the primary to acknowledge work it handed off incorrectly.
-	 * After a deliberate user interrupt auto-resume is suppressed while idle/unwinding
-	 * (the note becomes a preserved card re-entering on resume); a live-streaming turn is
-	 * steered in directly. A plain nit always rides the non-interrupting YieldQueue
-	 * aside. Suppression by the per-advisor emission guard drops the note silently —
+	 * Route one accepted advice note from `advisor` to the primary. A blocker
+	 * interrupts a running agent through the steering channel; a concern or nit
+	 * raised against a running agent rides the non-interrupting YieldQueue aside
+	 * and lands at the next model step. Once the loop is idle, a concern after a
+	 * terminal answer is preserved as a visible advisor card, a concern after a
+	 * mid-work yield triggers a turn, a blocker wakes the primary to acknowledge
+	 * work it handed off incorrectly, and any nit is preserved as a visible card
+	 * because nothing would poll the aside queue. After a deliberate user interrupt
+	 * auto-resume is suppressed while idle/unwinding (the note becomes a preserved
+	 * card re-entering on resume); a live-streaming turn is steered in directly.
+	 * Suppression by the per-advisor emission guard drops the note silently —
 	 * the model still saw `Recorded.`, so it isn't tempted to rephrase the same note
 	 * past the dedupe.
 	 */

--- a/packages/coding-agent/src/session/yield-queue.ts
+++ b/packages/coding-agent/src/session/yield-queue.ts
@@ -179,6 +179,23 @@ export class YieldQueue {
 		return thunks;
 	}
 
+	/**
+	 * Build and remove every queued entry of one kind without injecting it.
+	 * Used to re-record advisor asides that missed the loop's last poll as
+	 * visible cards. Returns null when nothing is queued or the dispatcher
+	 * skipped the batch.
+	 */
+	drainKind(kind: string): AgentMessage | null {
+		const dispatcher = this.#dispatchers.get(kind);
+		if (!dispatcher) return null;
+		const entries = this.#drain(kind);
+		if (entries.length === 0) return null;
+		const built = this.#build(kind, dispatcher, entries);
+		if (!built) return null;
+		this.#resolveEntries(built.entries);
+		return built.message;
+	}
+
 	/** Drop queued entries. With `kind`, drop only that kind's entries (leaving
 	 *  any pending idle-flush for other kinds intact); otherwise drop everything. */
 	clear(kind?: string): void {

--- a/packages/coding-agent/test/advisor/advisor.test.ts
+++ b/packages/coding-agent/test/advisor/advisor.test.ts
@@ -712,33 +712,35 @@ describe("advisor", () => {
 			expect(onAdvice).toHaveBeenNthCalledWith(3, note, "blocker");
 		});
 
-		it("defers non-blockers per update and flushes the backlog on the next completed update", async () => {
+		it("defers only nits per update; concerns and blockers route immediately", async () => {
 			const onAdvice = vi.fn();
 			const tool = new AdviseTool(onAdvice);
 			const note = "The result still needs a focused regression test.";
 
 			tool.beginUpdate(true);
-			const deferred = await tool.execute("tc-1", { note, severity: "concern" });
+			const recorded = await tool.execute("tc-1", { note, severity: "concern" });
 			await tool.execute("tc-2", { note: "A destructive command is running.", severity: "blocker" });
 
-			// Deferred notes are NOT delivered mid-turn; blocker still goes through.
-			expect(onAdvice).toHaveBeenCalledTimes(1);
-			expect(onAdvice).toHaveBeenCalledWith("A destructive command is running.", "blocker");
-			// The tool tells the advisor the note is deferred, not silently "Recorded.".
+			// Concerns and blockers are NOT withheld mid-turn; both route at once.
+			expect(onAdvice).toHaveBeenCalledTimes(2);
+			expect(onAdvice).toHaveBeenNthCalledWith(1, note, "concern");
+			expect(onAdvice).toHaveBeenNthCalledWith(2, "A destructive command is running.", "blocker");
+			// The live path tells the advisor the note reached the primary.
+			expect(JSON.stringify(recorded.content)).toContain("Recorded.");
+
+			// A nit in a later in-progress update is withheld instead.
+			tool.beginUpdate(true);
+			const deferred = await tool.execute("tc-3", { note: "Minor naming cleanup.", severity: "nit" });
+			expect(onAdvice).toHaveBeenCalledTimes(2);
 			expect(JSON.stringify(deferred.content)).toContain("Deferred");
 
-			// A second distinct concern in a later in-progress update queues its own slot.
-			tool.beginUpdate(true);
-			await tool.execute("tc-3", { note: "Minor naming cleanup.", severity: "nit" });
-
-			// Completing the turn deterministically flushes both withheld notes,
-			// oldest first — no reliance on the advisor model re-raising them.
+			// Completing the turn deterministically flushes the withheld nit — no
+			// reliance on the advisor model re-raising it.
 			tool.beginUpdate(false);
 			expect(onAdvice).toHaveBeenCalledTimes(3);
-			expect(onAdvice).toHaveBeenNthCalledWith(2, note, "concern");
 			expect(onAdvice).toHaveBeenNthCalledWith(3, "Minor naming cleanup.", "nit");
 
-			// A later explicit re-raise of the same note is deduped (already delivered).
+			// A later explicit re-raise of the delivered concern is deduped.
 			await tool.execute("tc-4", { note, severity: "concern" });
 			expect(onAdvice).toHaveBeenCalledTimes(3);
 		});
@@ -749,17 +751,17 @@ describe("advisor", () => {
 			const note = "Same point raised repeatedly.";
 
 			tool.beginUpdate(true);
-			await tool.execute("tc-1", { note, severity: "concern" });
-			await tool.execute("tc-2", { note, severity: "concern" });
-			await tool.execute("tc-3", { note, severity: "concern" });
+			await tool.execute("tc-1", { note, severity: "nit" });
+			await tool.execute("tc-2", { note, severity: "nit" });
+			await tool.execute("tc-3", { note, severity: "nit" });
 
 			tool.beginUpdate(false);
-			// Identical note queued once, flushed once.
+			// Identical nit queued once, flushed once.
 			expect(onAdvice).toHaveBeenCalledTimes(1);
-			expect(onAdvice).toHaveBeenCalledWith(note, "concern");
+			expect(onAdvice).toHaveBeenCalledWith(note, "nit");
 		});
 
-		it("retains the highest severity when duplicate deferred advice escalates", async () => {
+		it("a concern that escalates a queued nit routes at once and empties the nit's slot", async () => {
 			const onAdvice = vi.fn();
 			const tool = new AdviseTool(onAdvice);
 
@@ -767,15 +769,19 @@ describe("advisor", () => {
 			await tool.execute("tc-1", { note: "Same point raised repeatedly.", severity: "nit" });
 			await tool.execute("tc-2", { note: "Same   point raised repeatedly.", severity: "concern" });
 
+			// The concern takes the live path immediately, consuming the nit's reservation.
+			expect(onAdvice).toHaveBeenCalledTimes(1);
+			expect(onAdvice).toHaveBeenCalledWith("Same   point raised repeatedly.", "concern");
+
+			// The flush no longer holds the nit: its slot was emptied by the escalation.
 			tool.beginUpdate(false);
 			expect(onAdvice).toHaveBeenCalledTimes(1);
-			expect(onAdvice).toHaveBeenCalledWith("Same point raised repeatedly.", "concern");
 		});
 
-		it("flushes one deferred concern per update past the per-update emission budget on a late catch-up", async () => {
+		it("flushes one deferred nit per update past the per-update emission budget on a late catch-up", async () => {
 			// Regression for #10271 ("The Advisor is Late"): in yolo mode the primary
 			// is continuously mid-turn, so the advisor runs many in-progress updates
-			// (one concern each) and the whole backlog is replayed in a single catch-up
+			// (one nit each) and the whole backlog is replayed in a single catch-up
 			// flush. Each note cleared the emission guard when it was emitted, so the
 			// flush must deliver the full backlog instead of collapsing it to one note.
 			const delivered: string[] = [];
@@ -790,24 +796,32 @@ describe("advisor", () => {
 				tool.beginUpdate(inProgress);
 				guard.beginUpdate();
 			};
-			const concerns = [
+			const nits = [
 				"Bare `location` cannot work outside the page; inspect with `await page.url()`.",
 				"Scope navigation to the visualizer's own `.viz-container`.",
 				'BFS uses `progressType="bar"`, so it has no `.viz-pill` controls.',
 				"Tab switching delegates from a trusted click; a dispatched KeyboardEvent is untrusted.",
 			];
+			const concern = "The migration drops the users table without a backup.";
 
-			// Each concern arrives in its own in-progress advisor update.
-			for (const [i, note] of concerns.entries()) {
+			// Each nit arrives in its own in-progress advisor update.
+			for (const [i, note] of nits.entries()) {
 				beginUpdate(true);
-				await tool.execute(`c-${i}`, { note, severity: "concern" });
+				await tool.execute(`c-${i}`, { note, severity: "nit" });
 			}
 			// All withheld mid-turn — nothing reaches the primary yet.
 			expect(delivered).toEqual([]);
 
-			// Turn completes: the deferred backlog flushes, oldest first, in full.
+			// A concern raised in a later in-progress update routes immediately,
+			// ahead of the still-withheld nit backlog.
+			beginUpdate(true);
+			await tool.execute("c-4", { note: concern, severity: "concern" });
+			expect(delivered).toEqual([concern]);
+
+			// Turn completes: the deferred nit backlog flushes, oldest first, in full,
+			// after the already-delivered concern.
 			beginUpdate(false);
-			expect(delivered).toEqual(concerns);
+			expect(delivered).toEqual([concern, ...nits]);
 		});
 
 		it("caps a single in-progress prompt spraying distinct notes to one deferred note", async () => {
@@ -826,18 +840,18 @@ describe("advisor", () => {
 			};
 
 			beginUpdate(true);
-			await tool.execute("x-0", { note: "First mid-turn concern.", severity: "concern" });
-			await tool.execute("x-1", { note: "Second mid-turn concern.", severity: "concern" });
-			await tool.execute("x-2", { note: "Third mid-turn concern.", severity: "concern" });
+			await tool.execute("x-0", { note: "First mid-turn nit.", severity: "nit" });
+			await tool.execute("x-1", { note: "Second mid-turn nit.", severity: "nit" });
+			await tool.execute("x-2", { note: "Third mid-turn nit.", severity: "nit" });
 			beginUpdate(false);
-			expect(delivered).toEqual(["First mid-turn concern."]);
+			expect(delivered).toEqual(["First mid-turn nit."]);
 		});
 
-		it("does not let a suppressed phrase burn the deferred slot ahead of a real concern", async () => {
-			// P1 review regression: a noise phrase emitted before a substantive concern
+		it("does not let a suppressed phrase burn the deferred slot ahead of a real nit", async () => {
+			// P1 review regression: a noise phrase emitted before a substantive nit
 			// in the same in-progress update must not consume the update's slot. The
 			// emission guard filters it out at emission without spending the budget, so
-			// the following concern is still reserved and flushed.
+			// the following nit is still reserved and flushed.
 			const delivered: string[] = [];
 			const guard = new AdvisorEmissionGuard();
 			const tool = new AdviseTool(
@@ -850,10 +864,10 @@ describe("advisor", () => {
 			};
 
 			beginUpdate(true);
-			await tool.execute("n-0", { note: "Stop.", severity: "concern" });
+			await tool.execute("n-0", { note: "Stop.", severity: "nit" });
 			await tool.execute("n-1", {
 				note: "The migration drops the users table without a backup.",
-				severity: "concern",
+				severity: "nit",
 			});
 			beginUpdate(false);
 			expect(delivered).toEqual(["The migration drops the users table without a backup."]);
@@ -880,11 +894,11 @@ describe("advisor", () => {
 		});
 
 		it("delivers a blocker escalation of a reserved note live instead of dropping it as already seen", async () => {
-			// P1 review regression: a note reserved as a nit/concern during an
-			// in-progress update, then escalated to blocker before the backlog flushes,
-			// even with casing/punctuation changed, must reuse its normalized reservation,
-			// and interrupt at blocker severity now — not be rejected as already-seen
-			// and arrive late at the lower deferred severity.
+			// P1 review regression: a nit reserved during an in-progress update, then
+			// escalated to blocker before the backlog flushes, even with casing or
+			// punctuation changed, must reuse its normalized reservation, and
+			// interrupt at blocker severity now — not be rejected as already-seen and
+			// arrive late at the lower deferred severity.
 			const delivered: { note: string; severity?: string }[] = [];
 			const guard = new AdvisorEmissionGuard();
 			const tool = new AdviseTool(
@@ -899,7 +913,7 @@ describe("advisor", () => {
 			const escalatedNote = "THE MIGRATION DROPS THE USERS TABLE WITHOUT A BACKUP!";
 
 			beginUpdate(true);
-			await tool.execute("e-0", { note, severity: "concern" });
+			await tool.execute("e-0", { note, severity: "nit" });
 			// Reserved, not delivered.
 			expect(delivered).toEqual([]);
 

--- a/packages/coding-agent/test/advisor/advisor.test.ts
+++ b/packages/coding-agent/test/advisor/advisor.test.ts
@@ -5948,6 +5948,12 @@ describe("advisor", () => {
 	// window (`streaming: false`) a suppressed note must `preserve`, never `steer`,
 	// or it strands and #drainStrandedQueuedMessages auto-resumes it. Do not swap
 	// the call site back to session `isStreaming`.
+	//
+	// Delivery channels: an aside is only routed while the loop is live
+	// (streaming and not aborting) — that is the only window in which the loop
+	// polls getAsideMessages again. Once the loop is idle, a nit (and an
+	// immune-window idle concern) is preserved as a visible card instead of
+	// parking a note nothing will ever drain.
 	describe("resolveAdvisorDeliveryChannel", () => {
 		it("preserves every severity when a headless drain forbids primary turns", () => {
 			for (const severity of [undefined, "nit", "concern", "blocker"] as const) {
@@ -5974,50 +5980,84 @@ describe("advisor", () => {
 					preserveOnly: true,
 				}),
 			).toBe("aside");
-			for (const severity of ["concern", "blocker"] as const) {
+			expect(
+				resolveAdvisorDeliveryChannel({
+					severity: "concern",
+					autoResumeSuppressed: false,
+					streaming: true,
+					aborting: false,
+					preserveOnly: true,
+				}),
+			).toBe("aside");
+			expect(
+				resolveAdvisorDeliveryChannel({
+					severity: "blocker",
+					autoResumeSuppressed: false,
+					streaming: true,
+					aborting: false,
+					preserveOnly: true,
+				}),
+			).toBe("steer");
+		});
+
+		it("routes a nit as an aside only while the loop is live, preserving it otherwise", () => {
+			for (const severity of [undefined, "nit"] as const) {
 				expect(
 					resolveAdvisorDeliveryChannel({
 						severity,
 						autoResumeSuppressed: false,
 						streaming: true,
 						aborting: false,
-						preserveOnly: true,
 					}),
-				).toBe("steer");
+				).toBe("aside");
+				expect(
+					resolveAdvisorDeliveryChannel({
+						severity,
+						autoResumeSuppressed: true,
+						streaming: true,
+						aborting: true,
+					}),
+				).toBe("preserve");
+				expect(
+					resolveAdvisorDeliveryChannel({
+						severity,
+						autoResumeSuppressed: false,
+						streaming: false,
+						aborting: false,
+					}),
+				).toBe("preserve");
 			}
 		});
 
-		it("routes a non-interrupting nit to the aside queue regardless of state", () => {
+		it("a concern raised against a streaming primary never steers", () => {
 			expect(
 				resolveAdvisorDeliveryChannel({
-					severity: "nit",
-					autoResumeSuppressed: true,
-					streaming: true,
-					aborting: true,
-				}),
-			).toBe("aside");
-			expect(
-				resolveAdvisorDeliveryChannel({
-					severity: undefined,
+					severity: "concern",
 					autoResumeSuppressed: false,
-					streaming: false,
+					streaming: true,
 					aborting: false,
 				}),
 			).toBe("aside");
+			expect(
+				resolveAdvisorDeliveryChannel({
+					severity: "blocker",
+					autoResumeSuppressed: false,
+					streaming: true,
+					aborting: false,
+				}),
+			).toBe("steer");
 		});
 
-		it("steers concern/blocker when no user interrupt is in effect", () => {
+		it("an idle mid-work concern or blocker steers a triggered turn", () => {
 			for (const severity of ["concern", "blocker"] as const) {
-				for (const streaming of [true, false]) {
-					expect(
-						resolveAdvisorDeliveryChannel({
-							severity,
-							autoResumeSuppressed: false,
-							streaming,
-							aborting: false,
-						}),
-					).toBe("steer");
-				}
+				expect(
+					resolveAdvisorDeliveryChannel({
+						severity,
+						autoResumeSuppressed: false,
+						streaming: false,
+						aborting: false,
+					}),
+				).toBe("steer");
 			}
 		});
 
@@ -6045,7 +6085,7 @@ describe("advisor", () => {
 			).toBe("steer");
 		});
 
-		it("downgrades concern to aside during immune turns, but still steers a blocker (#5628)", () => {
+		it("preserves an idle concern during immune turns, keeps a streaming one on the aside queue, and still steers a blocker (#5628)", () => {
 			expect(
 				resolveAdvisorDeliveryChannel({
 					severity: "concern",
@@ -6055,6 +6095,15 @@ describe("advisor", () => {
 					interruptImmuneTurnActive: true,
 				}),
 			).toBe("aside");
+			expect(
+				resolveAdvisorDeliveryChannel({
+					severity: "concern",
+					autoResumeSuppressed: false,
+					streaming: false,
+					aborting: false,
+					interruptImmuneTurnActive: true,
+				}),
+			).toBe("preserve");
 			expect(
 				resolveAdvisorDeliveryChannel({
 					severity: "blocker",
@@ -6074,6 +6123,18 @@ describe("advisor", () => {
 				}),
 			).toBe("preserve");
 		});
+
+		it("steers a concern during abort teardown when no user interrupt is in effect", () => {
+			expect(
+				resolveAdvisorDeliveryChannel({
+					severity: "concern",
+					autoResumeSuppressed: false,
+					streaming: true,
+					aborting: true,
+				}),
+			).toBe("steer");
+		});
+
 		it("preserves an interrupting note while suppressed AND idle (no auto-resume of a stopped run)", () => {
 			for (const severity of ["concern", "blocker"] as const) {
 				expect(
@@ -6100,17 +6161,23 @@ describe("advisor", () => {
 			).toBe("preserve");
 		});
 
-		it("steers an interrupting note while suppressed once a turn is streaming again and not aborting (the fix)", () => {
-			for (const severity of ["concern", "blocker"] as const) {
-				expect(
-					resolveAdvisorDeliveryChannel({
-						severity,
-						autoResumeSuppressed: true,
-						streaming: true,
-						aborting: false,
-					}),
-				).toBe("steer");
-			}
+		it("delivers a suppressed note once a turn is streaming again and not aborting instead of stranding it (the fix)", () => {
+			expect(
+				resolveAdvisorDeliveryChannel({
+					severity: "concern",
+					autoResumeSuppressed: true,
+					streaming: true,
+					aborting: false,
+				}),
+			).toBe("aside");
+			expect(
+				resolveAdvisorDeliveryChannel({
+					severity: "blocker",
+					autoResumeSuppressed: true,
+					streaming: true,
+					aborting: false,
+				}),
+			).toBe("steer");
 		});
 	});
 	describe("advisor transcript filenames", () => {

--- a/packages/coding-agent/test/agent-session-advisor-next-step-delivery.test.ts
+++ b/packages/coding-agent/test/agent-session-advisor-next-step-delivery.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Contract: advisor asides queued for the primary's next model step must not
+ * strand when no loop is left to poll the aside queue. At settle (the turn
+ * ends with the aside still queued) and on a deliberate user interrupt, the
+ * queued aside is re-recorded as a visible, persisted advisor card; the aside
+ * queue is left empty and no extra model turn runs.
+ */
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
+import { Agent } from "@oh-my-pi/pi-agent-core";
+import { createMockModel, type MockModel, type MockResponse } from "@oh-my-pi/pi-ai/providers/mock";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { USER_INTERRUPT_LABEL } from "@oh-my-pi/pi-coding-agent/session/messages";
+import { isAdvisorCard } from "@oh-my-pi/pi-coding-agent/session/queued-messages";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+const ADVISOR_TYPE = "advisor";
+
+interface CompletedAdvisorHarness {
+	session: AgentSession;
+	sessionManager: SessionManager;
+	mock: MockModel;
+	advisorMock: MockModel;
+}
+
+interface ParkedAdvisorHarness {
+	session: AgentSession;
+	sessionManager: SessionManager;
+	mock: MockModel;
+	advisorMock: MockModel;
+	/** Resolves the moment the first turn's model stream begins. */
+	streamStarted: Promise<void>;
+}
+
+describe("AgentSession advisor next-step delivery", () => {
+	let tempDir: TempDir;
+	let session: AgentSession;
+	const authStorages: AuthStorage[] = [];
+
+	beforeAll(() => {
+		tempDir = TempDir.createSync("@pi-advisor-next-step-");
+	});
+
+	afterEach(async () => {
+		// dispose() aborts the agent, cancelling a parked first-turn stream.
+		try {
+			await session?.dispose();
+		} finally {
+			for (const authStorage of authStorages.splice(0)) authStorage.close();
+		}
+	});
+
+	afterAll(async () => {
+		await tempDir?.remove();
+	});
+
+	/**
+	 * Single primary turn that answers with text. The advisor is enabled (its
+	 * yield-queue kind registered) but scripted to emit nothing, so the only
+	 * advisor traffic in a test is what the test itself enqueues.
+	 */
+	async function createCompletedAdvisorSession(): Promise<CompletedAdvisorHarness> {
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5")!;
+		const mock = createMockModel({
+			responses: [{ content: ["EXACT VERDICT"], stopReason: "stop" }],
+		});
+		const advisorMock = createMockModel({ handler: () => ({ content: [], stopReason: "stop" }) });
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model, systemPrompt: ["Test"], tools: [] },
+			streamFn: mock.stream,
+		});
+		const sessionManager = SessionManager.inMemory();
+		const settings = Settings.isolated({ "compaction.enabled": false, "retry.enabled": false });
+		settings.setModelRole("advisor", "anthropic/claude-sonnet-4-5");
+		const authStorage = await AuthStorage.create(":memory:");
+		authStorages.push(authStorage);
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		const modelRegistry = new ModelRegistry(authStorage, tempDir.join("models.yml"));
+		session = new AgentSession({
+			agent,
+			sessionManager,
+			settings,
+			modelRegistry,
+			advisorTools: [],
+			advisorStreamFn: advisorMock.stream,
+		});
+		return { session, sessionManager, mock, advisorMock };
+	}
+
+	/**
+	 * First turn parks open (a 60s mock delay that abort cancels) so the aside
+	 * can be enqueued while the agent is genuinely streaming. `streamStarted`
+	 * resolves from the mock handler, before the delay, so tests await the real
+	 * stream-begin signal rather than a timer.
+	 */
+	async function createParkedAdvisorSession(tailResponses: MockResponse[] = []): Promise<ParkedAdvisorHarness> {
+		const started = Promise.withResolvers<void>();
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5")!;
+		const mock = createMockModel({
+			responses: [
+				() => {
+					started.resolve();
+					return { content: ["working"], delayMs: 60_000 };
+				},
+				...tailResponses,
+			],
+		});
+		const advisorMock = createMockModel({ handler: () => ({ content: [], stopReason: "stop" }) });
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model, systemPrompt: ["Test"], tools: [] },
+			streamFn: mock.stream,
+		});
+		const sessionManager = SessionManager.inMemory();
+		const settings = Settings.isolated({ "compaction.enabled": false, "retry.enabled": false });
+		settings.setModelRole("advisor", "anthropic/claude-sonnet-4-5");
+		const authStorage = await AuthStorage.create(":memory:");
+		authStorages.push(authStorage);
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		const modelRegistry = new ModelRegistry(authStorage, tempDir.join("models.yml"));
+		session = new AgentSession({
+			agent,
+			sessionManager,
+			settings,
+			modelRegistry,
+			advisorTools: [],
+			advisorStreamFn: advisorMock.stream,
+		});
+		return { session, sessionManager, mock, advisorMock, streamStarted: started.promise };
+	}
+
+	/** Records the transcript content of every persisted advisor card. */
+	function capturePersistedAdvisorCards(sessionManager: SessionManager): string[] {
+		const persisted: string[] = [];
+		sessionManager.onEntryAppended = entry => {
+			if (entry.type === "custom_message" && entry.customType === ADVISOR_TYPE) {
+				persisted.push(typeof entry.content === "string" ? entry.content : JSON.stringify(entry.content));
+			}
+		};
+		return persisted;
+	}
+
+	it("preserves an advisor aside that missed the loop's last poll as a visible card at settle", async () => {
+		const { session: harness, sessionManager, mock } = await createCompletedAdvisorSession();
+		const persisted = capturePersistedAdvisorCards(sessionManager);
+
+		expect(harness.setAdvisorEnabled(true)).toBe(true);
+		// The aside lands via an agent_end listener: after the loop's final aside
+		// poll, with no loop left to drain it, until the settle re-records it.
+		const unsubscribe = harness.agent.subscribe(event => {
+			if (event.type === "agent_end") {
+				harness.yieldQueue.enqueue("advisor", { note: "late fixture note", severity: "concern" });
+			}
+		});
+		try {
+			await harness.prompt("answer with exactly one line");
+			await harness.waitForIdle();
+		} finally {
+			unsubscribe();
+		}
+
+		expect(harness.agent.state.messages.filter(isAdvisorCard)).toHaveLength(1);
+		expect(persisted).toHaveLength(1);
+		expect(persisted[0]).toContain("late fixture note");
+		expect(harness.yieldQueue.has("advisor")).toBe(false);
+		// The aside is delivered without waking the primary: one model request.
+		expect(mock.calls).toHaveLength(1);
+	});
+
+	it("preserves a queued advisor aside across a user interrupt as a visible card without resuming the run", async () => {
+		const {
+			session: harness,
+			sessionManager,
+			mock,
+			streamStarted,
+		} = await createParkedAdvisorSession([{ content: ["must not run"], stopReason: "stop" }]);
+		const persisted = capturePersistedAdvisorCards(sessionManager);
+
+		expect(harness.setAdvisorEnabled(true)).toBe(true);
+		const running = harness.prompt("do the thing");
+		await streamStarted;
+
+		// The advisor queues an aside against the next model step; the user
+		// interrupt skips the loop's remaining polls, stranding it while the
+		// parked turn is still unwinding.
+		harness.yieldQueue.enqueue("advisor", { note: "interrupted fixture note", severity: "concern" });
+
+		await harness.abort({ reason: USER_INTERRUPT_LABEL });
+		await harness.waitForIdle();
+		await running.catch(() => {});
+
+		expect(harness.agent.state.messages.filter(isAdvisorCard)).toHaveLength(1);
+		expect(persisted).toHaveLength(1);
+		expect(persisted[0]).toContain("interrupted fixture note");
+		expect(harness.yieldQueue.has("advisor")).toBe(false);
+		// The parked turn's tail response was never consumed: no resume ran.
+		expect(mock.calls).toHaveLength(1);
+	});
+});

--- a/packages/coding-agent/test/agent-session-advisor-next-step-delivery.test.ts
+++ b/packages/coding-agent/test/agent-session-advisor-next-step-delivery.test.ts
@@ -6,19 +6,24 @@
  * queue is left empty and no extra model turn runs.
  */
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
-import { Agent } from "@oh-my-pi/pi-agent-core";
+import { type } from "@oh-my-pi/omptype";
+import { Agent, type AgentTool } from "@oh-my-pi/pi-agent-core";
+import type { ToolResultMessage } from "@oh-my-pi/pi-ai";
 import { createMockModel, type MockModel, type MockResponse } from "@oh-my-pi/pi-ai/providers/mock";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import type { AdvisorMessageDetails } from "@oh-my-pi/pi-coding-agent/advisor/advise-tool";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
-import { USER_INTERRUPT_LABEL } from "@oh-my-pi/pi-coding-agent/session/messages";
+import { convertToLlm, USER_INTERRUPT_LABEL } from "@oh-my-pi/pi-coding-agent/session/messages";
 import { isAdvisorCard } from "@oh-my-pi/pi-coding-agent/session/queued-messages";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import { TempDir } from "@oh-my-pi/pi-utils";
 
 const ADVISOR_TYPE = "advisor";
+/** The one concern the advisor raises against the first (mid-turn) delta. */
+const MID_TURN_CONCERN = "the fixture edit looks incomplete; double-check the second step";
 
 interface CompletedAdvisorHarness {
 	session: AgentSession;
@@ -134,6 +139,101 @@ describe("AgentSession advisor next-step delivery", () => {
 		return { session, sessionManager, mock, advisorMock, streamStarted: started.promise };
 	}
 
+	/**
+	 * The advisor only sees the primary through turn-end deltas, so a concern it
+	 * raises while the primary is mid-turn can only travel as a YieldQueue aside:
+	 * the primary script issues a tool call, then a second tool call the test
+	 * holds open, then a final answer, and the advisor raises one concern
+	 * against the first (in-progress) delta while that second tool call is parked.
+	 */
+	interface MidTurnConcernHarness {
+		session: AgentSession;
+		mock: MockModel;
+		advisorMock: MockModel;
+		/** Resolves with the held tool call's abort signal once that call starts. */
+		heldToolStarted: Promise<AbortSignal>;
+		/** Releases the held tool call. */
+		releaseHeldTool: () => void;
+	}
+
+	async function createMidTurnConcernSession(): Promise<MidTurnConcernHarness> {
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5")!;
+		const stepCall = (input: string): MockResponse => ({
+			content: [{ type: "toolCall", name: "fixture_step", arguments: { input } }],
+		});
+		const mock = createMockModel({
+			responses: [stepCall("first"), stepCall("second"), { content: ["DONE"], stopReason: "stop" }],
+		});
+		const advisorMock = createMockModel({
+			responses: [
+				{
+					// Small delay so the concern cannot race the loop's aside poll that
+					// runs immediately after the first turn end; it must arrive while
+					// the second tool call is in flight.
+					delayMs: 5,
+					content: [
+						{ type: "toolCall", name: "advise", arguments: { note: MID_TURN_CONCERN, severity: "concern" } },
+					],
+				},
+				{ content: [], stopReason: "stop" },
+			],
+			// Later deltas (second turn end, final answer) must not error the advisor.
+			handler: () => ({ content: [], stopReason: "stop" }),
+		});
+
+		const fixtureStepParams = type({ input: "string" });
+		let invocations = 0;
+		const heldToolStarted = Promise.withResolvers<AbortSignal>();
+		const gate = Promise.withResolvers<void>();
+		const fixtureStep: AgentTool<typeof fixtureStepParams> = {
+			name: "fixture_step",
+			label: "Fixture Step",
+			description: "Deterministic two-step test tool",
+			parameters: fixtureStepParams,
+			execute: async (_toolCallId, _params, signal) => {
+				invocations++;
+				if (invocations === 2) {
+					if (!signal) throw new Error("expected the loop to pass an abort signal to the tool");
+					heldToolStarted.resolve(signal);
+					await gate.promise;
+				}
+				return { content: [{ type: "text", text: `step ${invocations} ran` }] };
+			},
+		};
+
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model, systemPrompt: ["Test"], tools: [fixtureStep] },
+			streamFn: mock.stream,
+			// Production wires the session converter at the agent boundary
+			// (sdk.ts); without it a bare test agent drops the custom advisor
+			// card from the provider request instead of folding it in.
+			convertToLlm,
+		});
+		const sessionManager = SessionManager.inMemory();
+		const settings = Settings.isolated({ "compaction.enabled": false, "retry.enabled": false });
+		settings.setModelRole("advisor", "anthropic/claude-sonnet-4-5");
+		const authStorage = await AuthStorage.create(":memory:");
+		authStorages.push(authStorage);
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		const modelRegistry = new ModelRegistry(authStorage, tempDir.join("models.yml"));
+		session = new AgentSession({
+			agent,
+			sessionManager,
+			settings,
+			modelRegistry,
+			advisorTools: [],
+			advisorStreamFn: advisorMock.stream,
+		});
+		return {
+			session,
+			mock,
+			advisorMock,
+			heldToolStarted: heldToolStarted.promise,
+			releaseHeldTool: () => gate.resolve(),
+		};
+	}
+
 	/** Records the transcript content of every persisted advisor card. */
 	function capturePersistedAdvisorCards(sessionManager: SessionManager): string[] {
 		const persisted: string[] = [];
@@ -200,5 +300,92 @@ describe("AgentSession advisor next-step delivery", () => {
 		expect(harness.yieldQueue.has("advisor")).toBe(false);
 		// The parked turn's tail response was never consumed: no resume ran.
 		expect(mock.calls).toHaveLength(1);
+	});
+
+	it("delivers a mid-turn advisor concern to the primary at its next model step without aborting the running tool", async () => {
+		const {
+			session: harness,
+			mock,
+			advisorMock,
+			heldToolStarted,
+			releaseHeldTool,
+		} = await createMidTurnConcernSession();
+
+		expect(harness.setAdvisorEnabled(true)).toBe(true);
+		const running = harness.prompt("run the fixture steps");
+		const heldSignal = await heldToolStarted;
+
+		// The advisor reviews the first (in-progress) delta while the second tool
+		// call is parked. Its advise call runs inside that review prompt, so once
+		// the advisor catches up the concern is on the aside queue; the loop only
+		// polls asides again after the held tool resolves.
+		expect(await harness.waitForAdvisorCatchup(10_000)).toBe(true);
+		expect(harness.yieldQueue.has("advisor")).toBe(true);
+
+		// Non-interrupting: the concern bypasses the steering queue entirely.
+		expect(harness.agent.peekSteeringQueue().filter(isAdvisorCard)).toHaveLength(0);
+
+		// The running tool is not aborted to make room for the aside.
+		expect(heldSignal.aborted).toBe(false);
+		releaseHeldTool();
+
+		await running;
+		await harness.waitForIdle();
+		expect(await harness.waitForAdvisorCatchup(10_000)).toBe(true);
+
+		// The concern reached the primary at its next model step (request three).
+		expect(mock.calls).toHaveLength(3);
+		const thirdRequestAsides: string[] = [];
+		for (const message of mock.calls[2].context.messages) {
+			if (message.role !== "developer") continue;
+			const blocks =
+				typeof message.content === "string" ? [{ type: "text" as const, text: message.content }] : message.content;
+			for (const part of blocks) {
+				if (part.type === "text") thirdRequestAsides.push(part.text);
+			}
+		}
+		const asideText = thirdRequestAsides.join("\n");
+		expect(asideText).toContain("<advisory");
+		expect(asideText).toContain('severity="concern"');
+		expect(asideText).toContain(MID_TURN_CONCERN);
+
+		// And it exists as a proper advisor card in the transcript (not a steer).
+		const messageLog = harness.agent.state.messages;
+		const cards = messageLog.filter(isAdvisorCard);
+		expect(cards).toHaveLength(1);
+		const details = cards[0].details as AdvisorMessageDetails;
+		expect(details.notes).toHaveLength(1);
+		expect(details.notes[0].note).toBe(MID_TURN_CONCERN);
+		expect(details.notes[0].severity).toBe("concern");
+
+		// The card landed mid-run: after the held tool's result, before the
+		// final assistant answer — not parked to the end of the transcript.
+		const cardIndex = messageLog.findIndex(isAdvisorCard);
+		const lastToolResultIndex = messageLog.findLastIndex(message => message.role === "toolResult");
+		const finalAssistantIndex = messageLog.findLastIndex(message => message.role === "assistant");
+		expect(cardIndex).toBeGreaterThan(lastToolResultIndex);
+		expect(cardIndex).toBeLessThan(finalAssistantIndex);
+
+		// No tool call was skipped to make room for the advisory.
+		const toolResults: ToolResultMessage[] = [];
+		for (const message of messageLog) {
+			if (message.role === "toolResult") toolResults.push(message);
+		}
+		expect(toolResults.length).toBeGreaterThan(0);
+		for (const result of toolResults) {
+			expect(JSON.stringify(result.content)).not.toContain("Skipped due to pending system advisory");
+		}
+
+		// The advisor was not told to defer: its advise call got `Recorded.`.
+		expect(advisorMock.calls.length).toBeGreaterThanOrEqual(2);
+		const adviseResults: ToolResultMessage[] = [];
+		for (const message of advisorMock.calls[1].context.messages) {
+			if (message.role === "toolResult" && message.toolName === "advise") adviseResults.push(message);
+		}
+		expect(adviseResults).toHaveLength(1);
+		expect(adviseResults[0].content.some(part => part.type === "text" && part.text === "Recorded.")).toBe(true);
+
+		// The loop consumed the aside: nothing stranded at settle.
+		expect(harness.yieldQueue.has("advisor")).toBe(false);
 	});
 });

--- a/packages/coding-agent/test/agent-session-advisor-next-step-delivery.test.ts
+++ b/packages/coding-agent/test/agent-session-advisor-next-step-delivery.test.ts
@@ -5,7 +5,7 @@
  * queued aside is re-recorded as a visible, persisted advisor card; the aside
  * queue is left empty and no extra model turn runs.
  */
-import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
 import { type } from "@oh-my-pi/omptype";
 import { Agent, type AgentTool } from "@oh-my-pi/pi-agent-core";
 import type { ToolResultMessage } from "@oh-my-pi/pi-ai";
@@ -300,6 +300,26 @@ describe("AgentSession advisor next-step delivery", () => {
 		expect(harness.yieldQueue.has("advisor")).toBe(false);
 		// The parked turn's tail response was never consumed: no resume ran.
 		expect(mock.calls).toHaveLength(1);
+	});
+
+	it("preserves a queued advisor aside when user-interrupt cleanup rejects", async () => {
+		const { session: harness, sessionManager, streamStarted } = await createParkedAdvisorSession();
+		const persisted = capturePersistedAdvisorCards(sessionManager);
+
+		expect(harness.setAdvisorEnabled(true)).toBe(true);
+		const running = harness.prompt("do the thing");
+		await streamStarted;
+		harness.yieldQueue.enqueue("advisor", { note: "cleanup rejection fixture note", severity: "concern" });
+
+		vi.spyOn(harness.goalRuntime, "onTaskAborted").mockRejectedValueOnce(new Error("fixture cleanup rejected"));
+		await expect(harness.abort({ reason: USER_INTERRUPT_LABEL })).rejects.toThrow("fixture cleanup rejected");
+		await harness.waitForIdle();
+		await running.catch(() => {});
+
+		expect(harness.agent.state.messages.filter(isAdvisorCard)).toHaveLength(1);
+		expect(persisted).toHaveLength(1);
+		expect(persisted[0]).toContain("cleanup rejection fixture note");
+		expect(harness.yieldQueue.has("advisor")).toBe(false);
 	});
 
 	it("delivers a mid-turn advisor concern to the primary at its next model step without aborting the running tool", async () => {

--- a/packages/coding-agent/test/agent-session-auto-compaction-queue.test.ts
+++ b/packages/coding-agent/test/agent-session-auto-compaction-queue.test.ts
@@ -8,6 +8,7 @@ import { ExtensionRuntime, loadExtensionFromFactory } from "@oh-my-pi/pi-coding-
 import { ExtensionRunner } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/runner";
 import { AgentSession, type AgentSessionEvent } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { isAdvisorCard } from "@oh-my-pi/pi-coding-agent/session/queued-messages";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import * as unexpectedStopClassifier from "@oh-my-pi/pi-coding-agent/session/unexpected-stop-classifier";
 import { EventBus } from "@oh-my-pi/pi-coding-agent/utils/event-bus";
@@ -321,6 +322,57 @@ describe("AgentSession auto-compaction queue resume", () => {
 
 		// compact()'s finally re-drained the stranded queue after reconnecting.
 		expect(continueSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it("preserves advisor advice queued while manual compaction is disconnected", async () => {
+		session.settings.set("compaction.keepRecentTokens", 1);
+		session.settings.setModelRole("advisor", "anthropic/claude-sonnet-4-5");
+		expect(session.setAdvisorEnabled(true)).toBe(true);
+		sessionManager.appendMessage({
+			role: "assistant",
+			content: [{ type: "text", text: "previous answer" }],
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: "claude-sonnet-4-5",
+			stopReason: "stop",
+			usage: {
+				input: 1_000,
+				output: 100,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 1_100,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			timestamp: Date.now(),
+		});
+		session.agent.replaceMessages(session.buildDisplaySessionContext().messages);
+
+		const gate = Promise.withResolvers<void>();
+		(globalThis as typeof globalThis & { __ompManualCompactGate?: Promise<void> }).__ompManualCompactGate =
+			gate.promise;
+		const compactPromise = session.compact();
+		while (!getRuntimeSignals().includes("before_compact:enter")) {
+			await Promise.resolve();
+		}
+
+		session.yieldQueue.enqueue("advisor", {
+			note: "compaction boundary fixture note",
+			severity: "concern",
+		});
+		expect(session.yieldQueue.has("advisor")).toBe(true);
+
+		gate.resolve();
+		await compactPromise;
+		await session.waitForIdle();
+
+		const cards = session.agent.state.messages.filter(isAdvisorCard);
+		expect(cards).toHaveLength(1);
+		expect(cards[0].content).toContain("compaction boundary fixture note");
+		expect(session.yieldQueue.has("advisor")).toBe(false);
+		const persistedCards = sessionManager
+			.getEntries()
+			.filter(entry => entry.type === "custom_message" && entry.customType === "advisor");
+		expect(persistedCards).toHaveLength(1);
 	});
 
 	it("cancels an in-flight auto-compaction when manual compact startup aborts", async () => {

--- a/packages/coding-agent/test/session/yield-queue.test.ts
+++ b/packages/coding-agent/test/session/yield-queue.test.ts
@@ -286,4 +286,63 @@ describe("YieldQueue", () => {
 
 		expect(thunks[0]!()).toBeNull();
 	});
+	test("drainKind builds one message from every queued entry without injecting", () => {
+		const harness = createHarness(true);
+		harness.queue.register<Entry>("advisor", {
+			build: entries => userMessage(entries.map(entry => entry.id).join(",")),
+		});
+		harness.queue.register<Entry>("completion", {
+			build: entries => userMessage(entries.map(entry => entry.id).join(",")),
+		});
+
+		harness.queue.enqueue("advisor", { id: "first" });
+		harness.queue.enqueue("advisor", { id: "second" });
+		harness.queue.enqueue("completion", { id: "done" });
+
+		const message = harness.queue.drainKind("advisor");
+
+		expect(message && messageText(message)).toBe("first,second");
+		expect(harness.queue.has("advisor")).toBe(false);
+		expect(harness.queue.has("completion")).toBe(true);
+		expect(messageText(harness.queue.drainKind("completion")!)).toBe("done");
+		expect(harness.streamingMessages).toHaveLength(0);
+		expect(harness.idleBatches).toHaveLength(0);
+	});
+
+	test("drainKind resolves the drained kind's receipts immediately", async () => {
+		const harness = createHarness(true);
+		harness.queue.register<Entry>("advisor", {
+			build: entries => userMessage(entries.map(entry => entry.id).join(",")),
+		});
+
+		const receipt = harness.queue.enqueueWithReceipt("advisor", { id: "aside" });
+		const message = harness.queue.drainKind("advisor");
+
+		expect(message && messageText(message)).toBe("aside");
+		await receipt;
+	});
+
+	test("drainKind returns null for unregistered kinds and kinds with nothing queued", () => {
+		const harness = createHarness(true);
+		harness.queue.register<Entry>("items", {
+			build: entries => userMessage(entries.map(entry => entry.id).join(",")),
+		});
+
+		expect(harness.queue.drainKind("unregistered")).toBeNull();
+		expect(harness.queue.drainKind("items")).toBeNull();
+	});
+
+	test("drainKind rejects receipts when the dispatcher skips the batch", async () => {
+		const harness = createHarness(true);
+		harness.queue.register<Entry>("advisor", {
+			build: () => null,
+		});
+
+		const receipt = harness.queue.enqueueWithReceipt("advisor", { id: "aside" });
+		expect(harness.queue.drainKind("advisor")).toBeNull();
+		expect(harness.queue.has("advisor")).toBe(false);
+		expect(harness.streamingMessages).toHaveLength(0);
+		expect(harness.idleBatches).toHaveLength(0);
+		await expect(receipt).rejects.toThrow("Yield queue dispatcher skipped entry: advisor");
+	});
 });


### PR DESCRIPTION
> As of now, the advisor never deliver concern messages during a run, it's always deferred to after the turn's end, which most of the times, it's too late. So I came up with this solution. If this is not the desired direction for the advisor, please let me know and we can work together to adjust it.

## Problem

In the investigated five-hour yolo run, 13 concerns were generated during work but appeared only after the final report; the first waited 5h03m55s. Issue #10600 reports the same default-policy failure across 44 sessions: stale/lost notes, severity inflation when unheard concerns are re-raised as blockers, and blocker-triggered tool aborts.

The behavior is cumulative: #6756 suppressed WIP non-blockers to avoid derailing partial work; #8960 queued them instead of dropping them; #10271/#10273 preserved the full backlog but intentionally left its timing unchanged; #5186 preserved late concerns rather than waking a duplicate final turn; and #5631 kept blockers immediate.

## Decisions and solution

This addresses roboomp's policy questions on #10600 as follows:

- `blocker`: unchanged immediate steer.
- in-progress `concern`: keep its severity, but enqueue it through the existing non-interrupting aside path for the next primary model step; never abort the active tool.
- `nit`: remain deferred until turn completion.
- boundary races: if an advisor aside misses the loop's final poll, preserve it visibly across normal settlement, user interruption, and disconnect/reconnect instead of losing it (the lifecycle concern also raised around #9745).
- configuration: no new setting. #9074 remains the separate opt-in proposal for concern-level forced steering; #10372 controls timing for already-steered advice and does not solve the upstream WIP gate.
- stale-note replacement/retraction remains separate scope; prompt next-step delivery removes the multi-hour replay window without adding another queue policy.

Also clarifies that `advisor.immuneTurns` is a cooldown for waking an idle primary after interrupting advice, not a general delay for concerns.

Fixes #10600.

## Verification

- `bunx bun@1.4.0 run check`
- `bunx bun@1.4.0 test test/advisor/advisor.test.ts test/session/yield-queue.test.ts test/agent-session-advisor-suppression.test.ts test/agent-session-advisor-next-step-delivery.test.ts --timeout=30000` — 221 passed, 0 failed.
- Live source smoke on Bun 1.4.0: during a 90-second tool step, the advisor raised a concern; it appeared before the primary's next edit, the active tool was not aborted, and the task's Bun test passed.

Baseline note: the starting commit is not locally green on Bun 1.4.0; it reproduces eight existing failures in the untouched eval-prelude, computer-watchdog, and browser-cmux tests. A separate visible-browser viewport assertion is environment-sensitive and also outside this diff.