### PR TITLE
fix(config): refetch discoverable models with omitted headers on session resume

### DIFF
--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -591,6 +591,23 @@ export class ModelRegistry {
 	 * and patch its context window to what the backend actually serves.
 	 */
 	async refreshSelectedModelMetadata(model: Model<Api>): Promise<Model<Api>> {
+		const discoverableConfig = this.#discoverableProviders.find(
+			providerConfig => providerConfig.provider === model.provider,
+		);
+		if (discoverableConfig) {
+			// The model cache never persists live request headers (#5780). A
+			// resumed session's previously-selected model can be restored from a
+			// disk row that has this model's headers omitted (and thus unusable),
+			// racing the background refetch that would otherwise reattach them.
+			// Force a synchronous online refetch before the first request goes
+			// out, rather than serving a request with a missing auth header.
+			const cacheProviderId = this.#configuredDiscoveryCacheProviderId(discoverableConfig);
+			const cache = readModelCache<Api>(cacheProviderId, 24 * 60 * 60 * 1000, Date.now, this.#cacheDbPath);
+			if (cache?.headerOmittedModelIds.includes(model.id)) {
+				await this.refreshProvider(model.provider, "online");
+				model = this.find(model.provider, model.id) ?? model;
+			}
+		}
 		const discoveryConfig = this.#findLazyRuntimeDiscovery(model.provider);
 		if (!discoveryConfig) {
 			return model;


### PR DESCRIPTION
## Problem
A resumed session's previously-selected model can be restored from a `model_cache` row whose headers were omitted from disk (#5780), racing the background discovery refetch that would otherwise reattach them. For custom header-authenticated discovery providers (e.g. an on-prem gateway behind a subscription-key header), this sends the first request of a resumed session without its required auth header, producing a 401 that only clears once the user manually reselects the model via `/model` (forcing a fresh discovery call).

Confirmed via `~/.omp/agent/models.db`: on-prem gateway models are consistently flagged in both `header_omitted_model_ids` and `unrestorable_header_model_ids` after a session-cache write, with no bundled/static entry to restore from (fully dynamic discovery, no fallback catalog).

## Fix
Generalize `refreshSelectedModelMetadata` (previously scoped to llama.cpp/LM Studio lazy-runtime-metadata probing) to also force a synchronous online refetch for any discoverable provider when the resumed model's id is present in `header_omitted_model_ids`, before the first request goes out. Scoped precisely to the affected model id, so unaffected providers/models take no extra network hit at startup.

## Testing
- `bun x tsc --noEmit -p packages/coding-agent/tsconfig.json`: clean (pre-existing unrelated error in `packages/tui/test/virtual-terminal.ts` only).
- Not yet reproduced end-to-end against a live on-prem gateway session; opening as draft pending that verification.