### PR TITLE
fix(discovery): gate claude-plugins skills by root origin

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed omp-installed marketplace plugins and `--plugin-dir` plugins still losing their skills when the Claude plugin source was not separately enabled, completing the #10666 fix ([#10743](https://github.com/can1357/oh-my-pi/issues/10743)).
+
 ## [18.1.8] - 2026-09-03
 
 ### Fixed

--- a/packages/coding-agent/src/capability/types.ts
+++ b/packages/coding-agent/src/capability/types.ts
@@ -145,6 +145,14 @@ export interface SourceMeta {
 	path: string;
 	/** Whether this came from user-level, project-level, or native config */
 	level: "user" | "project" | "native";
+	/**
+	 * Registry or CLI source that supplied a plugin root, when the provider
+	 * tracks it (currently `claude-plugins`: `"claude"` for `~/.claude/plugins`,
+	 * `"omp"` for omp's own registry, `"plugin-dir"` for `--plugin-dir`). Lets
+	 * user-scope gating distinguish omp's own installs from the foreign Claude
+	 * tree — see `isSourceEnabled` in `extensibility/skills.ts` (#10743).
+	 */
+	origin?: string;
 }
 
 /**

--- a/packages/coding-agent/src/discovery/claude-plugins.ts
+++ b/packages/coding-agent/src/discovery/claude-plugins.ts
@@ -231,6 +231,7 @@ async function loadSkills(ctx: LoadContext): Promise<LoadResult<Skill>> {
 						providerId: PROVIDER_ID,
 						level: root.scope,
 						includeSelf: true,
+						origin: root.origin,
 					}),
 				),
 			);

--- a/packages/coding-agent/src/discovery/helpers.ts
+++ b/packages/coding-agent/src/discovery/helpers.ts
@@ -144,12 +144,18 @@ export function resolveCopilotHome(home: string): string {
 /**
  * Create source metadata for an item.
  */
-export function createSourceMeta(provider: string, filePath: string, level: "user" | "project"): SourceMeta {
+export function createSourceMeta(
+	provider: string,
+	filePath: string,
+	level: "user" | "project",
+	origin?: string,
+): SourceMeta {
 	return {
 		provider,
 		providerName: "", // Filled in by registry
 		path: path.resolve(filePath),
 		level,
+		...(origin !== undefined && { origin }),
 	};
 }
 
@@ -393,6 +399,12 @@ export interface ScanSkillsFromDirOptions {
 	 * semantic every non-Claude provider relies on.
 	 */
 	includeSelf?: boolean;
+	/**
+	 * Registry/CLI origin of the plugin root supplying these skills, forwarded
+	 * to {@link SourceMeta.origin} so user-scope gating can tell omp's own
+	 * installs (`omp`, `plugin-dir`) from the foreign Claude tree (`claude`).
+	 */
+	origin?: string;
 }
 
 // Stable ordering used for skill lists in prompts: name (case-insensitive), then name, then path.
@@ -442,7 +454,7 @@ export async function scanSkillsFromDir(
 				content: body,
 				frontmatter: frontmatter as SkillFrontmatter,
 				level,
-				_source: createSourceMeta(providerId, skillPath, level),
+				_source: createSourceMeta(providerId, skillPath, level, options.origin),
 			});
 		} catch {
 			warnings.push(`Failed to read skill file: ${skillPath}`);

--- a/packages/coding-agent/src/extensibility/skills.ts
+++ b/packages/coding-agent/src/extensibility/skills.ts
@@ -167,6 +167,13 @@ export async function loadSkills(options: LoadSkillsOptions = {}): Promise<LoadS
 		if (provider === "native" && level === "project") return enablePiProject;
 		if (provider === "agents" && level === "user") return enableAgentsUser;
 		if (provider === "agents" && level === "project") return enableAgentsProject;
+		// User-scope claude-plugins skills carry the root's origin (#10743). omp's
+		// own installs (`omp` registry, `--plugin-dir`) are not the foreign
+		// ~/.claude/plugins tree, so the foreign opt-in gate applies only to
+		// claude-origin roots — parity with allowedRoots() in
+		// discovery/claude-plugins.ts. Without this, #10666's root-level fix is
+		// re-dropped here for every user-level claude-plugins skill.
+		if (provider === "claude-plugins" && source.origin !== undefined && source.origin !== "claude") return true;
 		if (level === "user") return isUserSourceEnabled(provider);
 		return true;
 	}

--- a/packages/coding-agent/test/discovery/claude-plugins.test.ts
+++ b/packages/coding-agent/test/discovery/claude-plugins.test.ts
@@ -10,6 +10,7 @@ import {
 	parseClaudePluginsRegistry,
 } from "@oh-my-pi/pi-coding-agent/discovery/helpers";
 import type { Skill } from "@oh-my-pi/pi-coding-agent/capability/skill";
+import { loadSkills } from "@oh-my-pi/pi-coding-agent/extensibility/skills";
 import { __resetDirsFromEnvForTests, removeWithRetries, setAgentDir } from "@oh-my-pi/pi-utils";
 import "@oh-my-pi/pi-coding-agent/discovery/claude-plugins";
 
@@ -558,6 +559,59 @@ describe("listClaudePluginRoots", () => {
 
 		expect(result.all.find(skill => skill.name === "omp-demo")?._source.provider).toBe("claude-plugins");
 		expect(result.all.find(skill => skill.name === "claude-demo")).toBeUndefined();
+	});
+
+	test("loadSkills surfaces omp-installed plugin skills without enabling the Claude source", async () => {
+		// Regression (#10743): #10666 fixed allowedRoots() to keep user-scope roots
+		// with origin !== "claude", but isSourceEnabled() in extensibility/skills.ts
+		// re-dropped them via isUserSourceEnabled("claude-plugins"). The origin now
+		// rides SourceMeta, so the foreign gate applies only to claude-origin roots.
+		const ompPluginPath = path.join(tempDir, "plugins", "omp-owned");
+		const claudePluginPath = path.join(tempDir, "plugins", "claude-owned");
+		const ompRegistryPath = path.join(tempDir, ".omp", "plugins", "installed_plugins.json");
+		const claudeRegistryPath = path.join(tempDir, ".claude", "plugins", "installed_plugins.json");
+		await Promise.all([
+			fs.mkdir(path.join(ompPluginPath, "skills", "omp-demo"), { recursive: true }),
+			fs.mkdir(path.join(claudePluginPath, "skills", "claude-demo"), { recursive: true }),
+			fs.mkdir(path.dirname(ompRegistryPath), { recursive: true }),
+			fs.mkdir(path.dirname(claudeRegistryPath), { recursive: true }),
+		]);
+		await Promise.all([
+			fs.writeFile(
+				path.join(ompPluginPath, "skills", "omp-demo", "SKILL.md"),
+				"---\nname: omp-demo\ndescription: OMP skill\n---\nBody\n",
+			),
+			fs.writeFile(
+				path.join(claudePluginPath, "skills", "claude-demo", "SKILL.md"),
+				"---\nname: claude-demo\ndescription: Claude skill\n---\nBody\n",
+			),
+			fs.writeFile(
+				ompRegistryPath,
+				JSON.stringify({
+					version: 2,
+					plugins: {
+						"omp-owned@market": [{ scope: "user", installPath: ompPluginPath, version: "1.0.0" }],
+					},
+				}),
+			),
+			fs.writeFile(
+				claudeRegistryPath,
+				JSON.stringify({
+					version: 2,
+					plugins: {
+						"claude-owned@market": [{ scope: "user", installPath: claudePluginPath, version: "1.0.0" }],
+					},
+				}),
+			),
+		]);
+
+		// enabledProviders unset (beforeEach disables the claude-plugins/claude
+		// user sources): the omp-origin skill must still load; the claude-origin
+		// one must stay opt-in.
+		const { skills } = await loadSkills({ cwd: tempDir });
+
+		expect(skills.map(s => s.name)).toContain("omp-demo");
+		expect(skills.map(s => s.name)).not.toContain("claude-demo");
 	});
 
 	test("defaults scope to user when not specified", async () => {


### PR DESCRIPTION
## Repro
With `enabledProviders` unset, an omp-registry (`~/.omp/plugins/installed_plugins.json`) or `--plugin-dir` marketplace plugin's skills never reach the agent — `skill://<name>` returns `Unknown skill` and the skill is absent from the system-prompt list. Driving the full pipeline (`loadSkills` in `extensibility/skills.ts`) against an omp-origin install reproduces it:

```
bun test test/discovery/claude-plugins.test.ts -t "loadSkills surfaces"
# without the fix:
# expect(skills.map(s => s.name)).toContain("omp-demo")
# Received: []
```

## Cause
#10666 fixed `allowedRoots()` (`discovery/claude-plugins.ts:48`) to keep user-scope roots with `origin !== "claude"`, but every claude-plugins skill is tagged by `scanSkillsFromDir` with `_source = { provider: "claude-plugins", level: "user" }` and no origin. `loadSkills`' `isSourceEnabled()` then falls through to the generic foreign gate `isUserSourceEnabled("claude-plugins")` (`extensibility/skills.ts`), which returns `false` for every user-level claude-plugins skill when `enabledProviders` is empty — regardless of whether the root came from `~/.claude/plugins`, `~/.omp/plugins`, or `--plugin-dir`. The root-level origin distinction #10666 added never reached this check.

## Fix
- Add optional `origin` to `SourceMeta` (`capability/types.ts`).
- Thread the root `origin` through `createSourceMeta` and `ScanSkillsFromDirOptions` (`discovery/helpers.ts`), and pass `root.origin` from the claude-plugins skill scan (`discovery/claude-plugins.ts`).
- In `isSourceEnabled` (`extensibility/skills.ts`), apply the claude-plugins foreign opt-in gate only to `origin === "claude"` roots — parity with `allowedRoots()`.
- Regression test drives `loadSkills` end-to-end: omp-origin skill loads, claude-origin skill stays opt-in, with `enabledProviders` unset.

## Verification
`bun test test/discovery/claude-plugins.test.ts` (19 pass) and `bun test test/skills.test.ts` (49 pass). Confirmed the new test fails (`Received: []`) with the origin gate reverted and passes with it. Fixes #10743