### PR TITLE
fix(catalog): use zcode:// scheme for Z.AI coding-plan oauth

### DIFF
--- a/packages/ai/test/zai-oauth.test.ts
+++ b/packages/ai/test/zai-oauth.test.ts
@@ -10,7 +10,7 @@ const TOKEN_URL = "https://zcode.z.ai/api/v1/oauth/token";
 const BUSINESS_LOGIN_URL = "https://api.z.ai/api/auth/z/login";
 const BIZ_BASE = "https://api.z.ai";
 const KEYS_URL = `${BIZ_BASE}/api/biz/v1/organization/org-1/projects/proj-1/api_keys`;
-const REDIRECT_URI = "http://127.0.0.1:9999/callback";
+const REDIRECT_URI = "zcode://zai-auth/callback";
 
 interface RecordedRequest {
 	url: string;
@@ -119,19 +119,24 @@ afterEach(() => {
 });
 
 describe("zai oauth flow", () => {
-	it("generates a no-PKCE authorization URL with the ZCode client id", async () => {
-		vi.spyOn(Bun, "serve").mockReturnValue({ port: 9999, stop: () => {} } as unknown as Bun.Server<unknown>);
+	it("advertises the ZCode desktop-scheme redirect and binds no callback server (#10745)", async () => {
+		// Z.AI's server-side allowlist now rejects every loopback redirect_uri for the
+		// reused ZCode client; only `zcode://zai-auth/callback` validates, so the flow
+		// runs manual-only — no local callback server is bound and the user pastes the
+		// redirect URL/code back.
+		const serveSpy = vi.spyOn(Bun, "serve");
 		const controller = new AbortController();
 		let url = "";
 		const login = getProviderDefinition("zai-coding-plan")?.login;
 		if (!login) throw new Error("zai-coding-plan login is unavailable");
-		await login({
+		const error = await login({
 			signal: controller.signal,
 			onAuth: info => {
 				url = info.url;
+				// Stop before waiting on pasted input that never arrives in the test.
 				controller.abort();
 			},
-		}).catch(() => undefined);
+		}).catch((caught: unknown) => caught);
 		const authUrl = new URL(url);
 
 		expect(authUrl.origin + authUrl.pathname).toBe(AUTHORIZE_URL);
@@ -141,51 +146,9 @@ describe("zai oauth flow", () => {
 		expect(authUrl.searchParams.get("state")).not.toBeNull();
 		expect(authUrl.searchParams.get("code_challenge")).toBeNull();
 		expect(authUrl.searchParams.get("code_challenge_method")).toBeNull();
-	});
-
-	it("advertises the ZCode-registered CLI redirect, never a random port (#10245)", async () => {
-		const serveSpy = vi
-			.spyOn(Bun, "serve")
-			.mockReturnValue({ port: 9999, stop: () => {} } as unknown as Bun.Server<unknown>);
-		const controller = new AbortController();
-		const captured: { redirect: string | null } = { redirect: null };
-		const login = getProviderDefinition("zai-coding-plan")?.login;
-		if (!login) throw new Error("zai-coding-plan login is unavailable");
-		const error = await login({
-			signal: controller.signal,
-			onAuth: ({ url }) => {
-				captured.redirect = new URL(url).searchParams.get("redirect_uri");
-				// Stop before waiting on a callback that never arrives in the test.
-				controller.abort();
-			},
-		}).catch((caught: unknown) => caught);
-
-		// Z.AI's allowlist only registers this exact CLI redirect for the reused
-		// ZCode client id; anything else is rejected before the login page.
-		expect(captured.redirect).toBe(REDIRECT_URI);
 		expect(error).toBeInstanceOf(AIError.LoginCancelledError);
-		// Bound the IPv4 loopback on the exact registered port — no fallback.
-		expect(serveSpy.mock.calls.every(([options]) => options.hostname === "127.0.0.1" && options.port === 9999)).toBe(
-			true,
-		);
-	});
-
-	it("rejects an occupied fixed callback port before opening the browser", async () => {
-		const serveSpy = vi.spyOn(Bun, "serve").mockImplementation(() => {
-			throw Object.assign(new Error("EADDRINUSE"), { code: "EADDRINUSE" });
-		});
-		const onAuth = vi.fn();
-		const login = getProviderDefinition("zai-coding-plan")?.login;
-		if (!login) throw new Error("zai-coding-plan login is unavailable");
-		const error = await login({ onAuth }).catch((caught: unknown) => caught);
-
-		expect(error).toBeInstanceOf(AIError.ConfigurationError);
-		if (!(error instanceof AIError.ConfigurationError)) throw error;
-		expect(error.message).toContain(
-			"OAuth callback port 9999 is in use, but oauth.redirectUri (http://127.0.0.1:9999/callback) requires this exact port",
-		);
-		expect(onAuth).not.toHaveBeenCalled();
-		expect(serveSpy.mock.calls.every(([options]) => options.port === 9999)).toBe(true);
+		// Manual-only: never binds a loopback callback server.
+		expect(serveSpy).not.toHaveBeenCalled();
 	});
 
 	it("exchanges the code, does business-login, then mints an id.secret key (create path)", async () => {

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `/login zai` (Z.AI GLM Coding Plan sign-in) failing at the authorize step after Z.AI stopped registering loopback redirect URIs: the flow now uses the ZCode desktop scheme `zcode://zai-auth/callback` with the paste-code fallback, and honors a `ZAI_OAUTH_REDIRECT_URI` override ([#10745](https://github.com/can1357/oh-my-pi/issues/10745)).
+
 ## [18.1.8] - 2026-09-03
 
 ### Added

--- a/packages/catalog/src/compat/rules.json
+++ b/packages/catalog/src/compat/rules.json
@@ -15166,16 +15166,19 @@
 						]
 					},
 					"callback": {
-						"port": 9999,
+						"port": 0,
 						"path": "/callback",
-						"hostname": "127.0.0.1",
-						"portFallback": false,
-						"manualOnly": false,
+						"hostname": "localhost",
+						"portFallback": true,
+						"manualOnly": true,
 						"redirectUri": {
-							"value": "http://127.0.0.1:9999/callback"
+							"value": "zcode://zai-auth/callback",
+							"env": [
+								"ZAI_OAUTH_REDIRECT_URI"
+							]
 						}
 					},
-					"instructions": "Complete Z.ai login in your browser. If the browser cannot reach this machine, paste the final redirect URL or authorization code when prompted.",
+					"instructions": "Complete Z.ai login in your browser. After you approve, the browser may show an unknown-scheme (zcode://) page or appear to do nothing — that is expected. Copy that final redirect URL (or the authorization code from it) and paste it back here when prompted.",
 					"token": {
 						"url": {
 							"value": "https://zcode.z.ai/api/v1/oauth/token",
@@ -15216,7 +15219,7 @@
 				"refresh": {
 					"kind": "none"
 				},
-				"callbackPort": 9999,
+				"callbackPort": 0,
 				"pasteCode": true
 			},
 			{

--- a/packages/catalog/src/compat/rules/auth/zai-coding-plan.kdl
+++ b/packages/catalog/src/compat/rules/auth/zai-coding-plan.kdl
@@ -4,9 +4,12 @@ auth "zai-coding-plan" {
 		client-id "client_P8X5CMWmlaRO9gyO-KSqtg" env="ZAI_OAUTH_CLIENT_ID"
 		authorize-url "https://chat.z.ai/api/oauth/authorize" env="ZAI_OAUTH_AUTHORIZE_URL"
 		// No PKCE: matches ZCode's authorize request verbatim.
-		// ZCode registers this exact loopback URI; any other host/port is rejected (#10245).
-		callback port=9999 path="/callback" hostname="127.0.0.1" redirect-uri="http://127.0.0.1:9999/callback" port-fallback=#false
-		instructions "Complete Z.ai login in your browser. If the browser cannot reach this machine, paste the final redirect URL or authorization code when prompted."
+		// Z.AI's server-side allowlist now rejects every loopback redirect_uri for
+		// this client (#10745); only ZCode's desktop scheme still validates. Advertise
+		// it and complete via the pasted redirect URL/code — no local callback binds.
+		// `redirect-uri-env` lets users adapt to further allowlist shifts without a release.
+		callback port=0 redirect-uri="zcode://zai-auth/callback" redirect-uri-env="ZAI_OAUTH_REDIRECT_URI" manual-only=#true
+		instructions "Complete Z.ai login in your browser. After you approve, the browser may show an unknown-scheme (zcode://) page or appear to do nothing — that is expected. Copy that final redirect URL (or the authorization code from it) and paste it back here when prompted."
 		token url="https://zcode.z.ai/api/v1/oauth/token" url-env="ZAI_OAUTH_TOKEN_URL" body="json" standard=#false {
 			params {
 				provider "zai"


### PR DESCRIPTION
## Repro
`/login zai` (the `zai-coding-plan` `oauth-code` rule) advertises `redirect_uri=http://127.0.0.1:9999/callback` to `https://chat.z.ai/api/oauth/authorize`. Since ~Sep 3 2026 Z.AI's server-side allowlist rejects every loopback variant for the reused ZCode client `client_P8X5CMWmlaRO9gyO-KSqtg` with `400 {"detail":"Redirect URI not registered for this client"}`, before any code is issued, so the paste-code fallback cannot rescue it. The bundled pin is confirmed on `main`:

```
$ jq -r '.auth.providers[] | select(.id=="zai-coding-plan") | .login.callback.redirectUri.value' packages/catalog/src/compat/rules.json
http://127.0.0.1:9999/callback
```

The provider-side 400 itself is not headlessly reproducible (the `/authorize/info` probe 401s without an authenticated chat.z.ai session); the reporter's live probe in #10745 is the authoritative evidence that only `zcode://zai-auth/callback` still validates.

## Cause
`packages/catalog/src/compat/rules/auth/zai-coding-plan.kdl` pinned the loopback callback (`callback port=9999 ... redirect-uri="http://127.0.0.1:9999/callback"`), a value #10246 chose to match ZCode's then-registered URI. Z.AI has since narrowed its allowlist to the ZCode desktop scheme only, leaving our pin unregistered.

## Fix
- `zai-coding-plan.kdl`: replace the loopback callback with `callback port=0 redirect-uri="zcode://zai-auth/callback" redirect-uri-env="ZAI_OAUTH_REDIRECT_URI" manual-only=#true` — the same custom-scheme, manual-paste pattern `gitlab-duo-agent.kdl` already uses. No local callback server binds; the user pastes the redirect URL/code back. `parseCallbackInput` already extracts `code`/`state` from a `zcode://` URL, and `resolveCallbackOptions` passes a statically-configured non-http redirect URI through unchanged.
- Update the login `instructions` to explain the browser may show an unknown-scheme page after consent and the callback URL/code should be pasted back.
- Add the `ZAI_OAUTH_REDIRECT_URI` env override alongside the existing client-id/authorize-url/token-url overrides so further allowlist shifts can be worked around without a release.
- Regenerate `rules.json` via `bun run gen:compat`.
- Rewrite `packages/ai/test/zai-oauth.test.ts`: the old tests defended the now-removed fixed-loopback-port contract (`Bun.serve` bound to `127.0.0.1:9999`, port-in-use rejection). Replace them with one test asserting the authorize URL advertises `zcode://zai-auth/callback` and no callback server is bound; the mint-key exchange tests now assert the `zcode://` redirect_uri.

## Verification
`bun test test/zai-oauth.test.ts` (in `packages/ai`) → 7 pass / 0 fail. `bun run gen:compat` regenerates `rules.json` with `manualOnly: true`, `redirectUri.value: "zcode://zai-auth/callback"`, and the `ZAI_OAUTH_REDIRECT_URI` env override. The provider-side acceptance of `zcode://zai-auth/callback` relies on the reporter's authenticated probe (not headlessly reproducible). Fixes #10745