### PR TITLE
fix(ai/copilot): support VS Code wire identity and transient 403 transport retry

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed GitHub Copilot requests on enterprise seats with `cli_enabled: false` by supporting VS Code wire identity and adding bounded CLI-to-VS Code fallback in auto mode.
+- Fixed premature credential rotation on transient Copilot 403 errors (`unauthorized: not authorized to use this Copilot feature`) by retrying with backoff at the transport layer and classifying them as `Flag.Transient`.
+
 ## [18.1.8] - 2026-09-03
 
 ### Added

--- a/packages/ai/src/error/auth-classify.ts
+++ b/packages/ai/src/error/auth-classify.ts
@@ -1,7 +1,7 @@
 import { extractHttpStatusFromError } from "@oh-my-pi/pi-utils";
 import { isAccountPolicyError, isClinePassSurfaceGateMessage, isOAuthExpiry, isUsageLimit } from "./flags";
 import { OAuthError } from "./oauth";
-import { isConcurrencyCapExclusion, isUsageLimitOutcome } from "./rate-limit";
+import { isConcurrencyCapExclusion, isTransientCopilotForbidden, isUsageLimitOutcome } from "./rate-limit";
 
 /**
  * Whether an OAuth refresh failure is definitive (the credential must be
@@ -49,6 +49,7 @@ export function isAuthRetryableError(error: unknown): boolean {
 	// A Cline surface-gate 403 is per-model client policy, not a credential
 	// problem: sibling keys fail identically, so rotation only burns them.
 	if (isClinePassSurfaceGateMessage(message)) return false;
+	if (isTransientCopilotForbidden(status, message)) return false;
 	if (status === 401 || status === 403) return true;
 	return isUsageLimitOutcome(status, message);
 }

--- a/packages/ai/src/error/flags.ts
+++ b/packages/ai/src/error/flags.ts
@@ -12,6 +12,7 @@ import {
 	isAccountScopedCapText,
 	isDashScopeTokenLimitText,
 	isOpaqueStatusBody,
+	isTransientCopilotForbidden,
 	isUsageLimitStatus,
 	matchesUsageLimitText,
 	parseRateLimitReason,
@@ -455,11 +456,13 @@ function classifyText(
 		) {
 			kinds |= Flag.AccountPolicy | Flag.ContentBlocked;
 		}
-		if (isAuthFailureText(errorMessage)) kinds |= Flag.AuthFailed;
 
 		const statusClean = errorStatus ? errorStatus : (status({ message: errorMessage }) ?? undefined);
 		const cleanMessage = errorMessage;
 		const isOpaque = isOpaqueStatusBody(cleanMessage);
+		const isTransientCopilot = isTransientCopilotForbidden(statusClean, cleanMessage);
+
+		if (isAuthFailureText(errorMessage) && !isTransientCopilot) kinds |= Flag.AuthFailed;
 
 		const isLimitStatus = isUsageLimitStatus(statusClean);
 		const reason = parseRateLimitReason(cleanMessage);
@@ -488,6 +491,7 @@ function classifyText(
 		// not match TRANSIENT_TRANSPORT_PATTERN, so flag it explicitly to keep
 		// AIError.retriable from treating the temporary cap as terminal.
 		if (reason === "CONCURRENT_LIMIT") kinds |= Flag.Transient;
+		if (isTransientCopilot) kinds |= Flag.Transient;
 		if ((api === "openai-responses" || api === "openai-codex-responses") && isStaleResponsesText(errorMessage)) {
 			kinds |= Flag.StaleResponsesItem;
 		}
@@ -556,6 +560,7 @@ export function classify(error: unknown, api?: Api): number {
 		} else if (link instanceof ProviderHttpError) {
 			let linkKinds = 0;
 			const { status: codeStatus, code } = link;
+			const isTransientCopilot = isTransientCopilotForbidden(codeStatus, link.message);
 			if (
 				code === "usage_limit_reached" ||
 				(code === "insufficient_quota" && !isDashScopeTokenLimitText(link.message)) ||
@@ -569,7 +574,7 @@ export function classify(error: unknown, api?: Api): number {
 			}
 			if (
 				(codeStatus === 401 || codeStatus === 403) &&
-				!(codeStatus === 403 && parseRateLimitReason(link.message) === "CONCURRENT_LIMIT")
+				!(codeStatus === 403 && (parseRateLimitReason(link.message) === "CONCURRENT_LIMIT" || isTransientCopilot))
 			) {
 				linkKinds |= Flag.AuthFailed;
 			} else if (codeStatus === 429) {

--- a/packages/ai/src/error/rate-limit.ts
+++ b/packages/ai/src/error/rate-limit.ts
@@ -425,3 +425,13 @@ export function isAccountScopedCapText(message: string): boolean {
 export function isConcurrencyCapExclusion(status: number | undefined, message: string | undefined): boolean {
 	return message !== undefined && parseRateLimitReason(message) === "CONCURRENT_LIMIT" && status !== 402;
 }
+
+/**
+ * Detect transient GitHub Copilot proxy 403 rejections ("unauthorized: not authorized to use this Copilot feature")
+ * caused by edge proxy routing to pods with stale authorization caches.
+ * These are transient route-level errors that should back off and retry, NOT hard credential failures that burn/rotate accounts.
+ */
+export function isTransientCopilotForbidden(status: number | undefined, message: string | undefined): boolean {
+	if (status !== 403 || !message) return false;
+	return /not authorized to use this copilot feature/i.test(message);
+}

--- a/packages/ai/src/error/retryable.ts
+++ b/packages/ai/src/error/retryable.ts
@@ -6,6 +6,7 @@ import {
 	status,
 	TRANSIENT_TRANSPORT_PATTERN,
 } from "./flags";
+import { isTransientCopilotForbidden } from "./rate-limit";
 
 /**
  * Whether a numeric HTTP status is in the canonical transient/retryable set:
@@ -44,6 +45,9 @@ export function isProviderRetryableError(error: unknown): boolean {
 	if (isUsageLimit(error)) return false;
 	const httpStatus = status(error);
 	if (httpStatus !== undefined && httpStatus >= 400 && httpStatus < 500 && httpStatus !== 408 && httpStatus !== 429) {
+		if (isTransientCopilotForbidden(httpStatus, error.message)) {
+			return true;
+		}
 		return false;
 	}
 	const msg = error.message.toLowerCase();

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -7,7 +7,11 @@ import { hostMatchesUrl, isVertexRawPredictUrl } from "@oh-my-pi/pi-catalog/host
 import { mapEffortToAnthropicAdaptiveEffort } from "@oh-my-pi/pi-catalog/model-thinking";
 import { calculateCost, getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { isAnthropicOAuthToken } from "@oh-my-pi/pi-catalog/utils";
-import { parseGitHubCopilotApiKey } from "@oh-my-pi/pi-catalog/wire/github-copilot";
+import {
+	mergeCopilotApiHeaders,
+	parseGitHubCopilotApiKey,
+	sanitizeCopilotHeaders,
+} from "@oh-my-pi/pi-catalog/wire/github-copilot";
 import {
 	$env,
 	getInstallId,
@@ -2018,7 +2022,7 @@ const streamAnthropicOnce = (
 			// Built inside the try so a copilot credential/header failure surfaces as
 			// an error event instead of an unhandled rejection that leaves the stream
 			// (and any consumer awaiting `result()`) hanging forever.
-			const copilotDynamicHeaders =
+			let copilotDynamicHeaders =
 				model.provider === "github-copilot"
 					? buildCopilotDynamicHeaders({
 							messages: context.messages,
@@ -2028,6 +2032,12 @@ const streamAnthropicOnce = (
 							initiatorOverride: options?.initiatorOverride,
 						})
 					: undefined;
+			let hasFallenBackToCopilotVscode = false;
+			const initialCopilotMode = Object.entries(options?.headers ?? {})
+				.find(([k]) => k.toLowerCase() === "copilot-mode")?.[1]
+				?.toLowerCase();
+			const allowCopilotVscodeFallback =
+				model.provider === "github-copilot" && initialCopilotMode !== "cli" && initialCopilotMode !== "vscode";
 			if (copilotDynamicHeaders?.premiumRequests !== undefined) {
 				output.usage.premiumRequests = copilotDynamicHeaders.premiumRequests;
 			}
@@ -2073,12 +2083,13 @@ const streamAnthropicOnce = (
 			const zeroOutputCacheRefresh = options?.anthropicCacheRefreshRequest === true;
 			let client: AnthropicMessagesClientLike;
 			let isOAuthToken: boolean;
+			let extraBetas: string[] = [];
 
 			if (options?.client) {
 				client = options.client;
 				isOAuthToken = false;
 			} else {
-				const extraBetas = normalizeExtraBetas(options?.betas);
+				extraBetas = normalizeExtraBetas(options?.betas);
 				const wantsAnthropicPriority = model.provider === "anthropic" && options?.serviceTier === "priority";
 				// Skip the fast-mode beta when this session already learned the
 				// endpoint+model rejects fast mode; `speed` is dropped from the params
@@ -3041,6 +3052,57 @@ const streamAnthropicOnce = (
 						firstTokenTime = undefined;
 						continue;
 					}
+					if (
+						allowCopilotVscodeFallback &&
+						!hasFallenBackToCopilotVscode &&
+						firstTokenTime === undefined &&
+						AIError.isTransientCopilotForbidden(AIError.status(streamFailure), streamFailureMessage)
+					) {
+						hasFallenBackToCopilotVscode = true;
+						logger.debug(
+							"copilot anthropic: CLI identity forbidden in auto mode, falling back to VS Code identity",
+						);
+						copilotDynamicHeaders = buildCopilotDynamicHeaders({
+							messages: context.messages,
+							hasImages: hasCopilotVisionInput(context.messages),
+							premiumMultiplier: model.premiumMultiplier,
+							headers: { ...model.headers, ...options?.headers, "Copilot-Mode": "vscode" },
+							initiatorOverride: options?.initiatorOverride,
+						});
+						if (!options?.client) {
+							const created = createClient(model, {
+								model,
+								apiKey,
+								extraBetas,
+								stream: !zeroOutputCacheRefresh,
+								interleavedThinking: options?.interleavedThinking ?? true,
+								headers: options?.headers,
+								dynamicHeaders: copilotDynamicHeaders?.headers,
+								isOAuth: options?.isOAuth,
+								hasTools: !!context.tools?.length,
+								thinkingEnabled: options?.thinkingEnabled,
+								thinkingDisplay: options?.thinkingDisplay,
+								fetch: options?.fetch,
+								maxRetryDelayMs: options?.maxRetryDelayMs,
+								sessionId:
+									options?.sessionId ??
+									extractClaudeMetadataSessionId(options?.metadata?.user_id) ??
+									options?.promptCacheKey,
+								disableStrictTools,
+							});
+							client = created.client;
+						}
+						providerRetryAttempt = 0;
+						output.content.length = 0;
+						output.model = model.id;
+						output.responseId = undefined;
+						output.errorMessage = undefined;
+						output.providerPayload = undefined;
+						output.usage = createEmptyUsage(copilotDynamicHeaders?.premiumRequests);
+						output.stopReason = "stop";
+						firstTokenTime = undefined;
+						continue;
+					}
 					const isTransientEnvelopeFailure =
 						AIError.isTransientStreamParseError(streamFailure) || AIError.isStreamEnvelopeError(streamFailure);
 					const isLocalIdleTimeout =
@@ -3254,6 +3316,7 @@ export function buildAnthropicClientOptions(args: AnthropicClientOptionsArgs): A
 		// The GitHub Copilot Anthropic proxy doesn't accept Anthropic beta
 		// features. Forward only caller-supplied betas.
 		const betaFeatures = [...extraBetas];
+		const copilotIdentity = mergeCopilotApiHeaders({ ...model.headers, ...headers, ...dynamicHeaders });
 		const defaultHeaders = mergeHeaders(
 			{
 				Accept: stream ? "text/event-stream" : "application/json",
@@ -3263,9 +3326,10 @@ export function buildAnthropicClientOptions(args: AnthropicClientOptionsArgs): A
 				Authorization: `Bearer ${copilotApiKey}`,
 				...(betaFeatures.length > 0 ? { "anthropic-beta": buildBetaHeader([], betaFeatures) } : {}),
 			},
-			model.headers,
+			sanitizeCopilotHeaders(model.headers),
+			sanitizeCopilotHeaders(headers),
+			copilotIdentity,
 			dynamicHeaders,
-			headers,
 		);
 		applyInferenceHeaders(defaultHeaders, {
 			provider: model.provider,
@@ -3282,7 +3346,7 @@ export function buildAnthropicClientOptions(args: AnthropicClientOptionsArgs): A
 			maxRetryDelayMs,
 			defaultHeaders,
 			fetch: cchFetch,
-			fetchOptions,
+			fetchOptions: { ...fetchOptions, timeout: 15_000 },
 		};
 	}
 

--- a/packages/ai/src/providers/github-copilot-headers.ts
+++ b/packages/ai/src/providers/github-copilot-headers.ts
@@ -1,6 +1,6 @@
 import {
-	COPILOT_CAPI_IDENTITY_HEADERS,
 	getGitHubCopilotBaseUrl,
+	mergeCopilotApiHeaders,
 	parseGitHubCopilotApiKey,
 } from "@oh-my-pi/pi-catalog/wire/github-copilot";
 import type { Message } from "../types";
@@ -112,7 +112,7 @@ export function getCopilotPremiumRequests(params: {
 
 /**
  * Build dynamic Copilot headers that vary per-request.
- * Static headers (User-Agent, Editor-Version, etc.) come from model.headers.
+ * Uses mergeCopilotApiHeaders to preserve identity and prevent clobbering by bundled model headers.
  */
 export function buildCopilotDynamicHeaders(params: {
 	messages: unknown[];
@@ -124,11 +124,9 @@ export function buildCopilotDynamicHeaders(params: {
 }): CopilotDynamicHeaders {
 	const initiator =
 		params.initiatorOverride ?? getCopilotInitiatorOverride(params.headers) ?? inferCopilotInitiator(params.messages);
-	const headers: Record<string, string> = {
-		...COPILOT_CAPI_IDENTITY_HEADERS,
-		"X-Initiator": initiator,
-		"X-Interaction-Type": `conversation-${initiator}`,
-	};
+	const headers = mergeCopilotApiHeaders(params.headers);
+	headers["X-Initiator"] = initiator;
+	headers["X-Interaction-Type"] = `conversation-${initiator}`;
 
 	if (params.hasImages) {
 		headers["Copilot-Vision-Request"] = "true";

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -788,6 +788,14 @@ const streamOpenAICompletionsOnce = (
 				}
 				try {
 					const headersWithTimeout = { ...headers };
+					if (model.provider === "github-copilot") {
+						const copilotMode = Object.entries(options?.headers ?? {}).find(
+							([k]) => k.toLowerCase() === "copilot-mode",
+						)?.[1];
+						if (copilotMode) {
+							headersWithTimeout["Copilot-Mode"] = copilotMode;
+						}
+					}
 					if (requestTimeoutMs !== undefined) {
 						headersWithTimeout["X-Stainless-Timeout"] = Math.floor(requestTimeoutMs / 1000).toString();
 					}

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -559,6 +559,14 @@ const streamOpenAIResponsesOnce = (
 				}
 				try {
 					const headersWithTimeout = { ...headers };
+					if (model.provider === "github-copilot") {
+						const copilotMode = Object.entries(options?.headers ?? {}).find(
+							([k]) => k.toLowerCase() === "copilot-mode",
+						)?.[1];
+						if (copilotMode) {
+							headersWithTimeout["Copilot-Mode"] = copilotMode;
+						}
+					}
 					if (requestTimeoutMs !== undefined) {
 						headersWithTimeout["X-Stainless-Timeout"] = Math.floor(requestTimeoutMs / 1000).toString();
 					}

--- a/packages/ai/src/providers/openai-shared.ts
+++ b/packages/ai/src/providers/openai-shared.ts
@@ -20,7 +20,7 @@ import {
 	hasCoreWeaveProjectHeader,
 	removeBlankCoreWeaveProjectHeaders,
 } from "@oh-my-pi/pi-catalog/wire/coreweave";
-import { parseGitHubCopilotApiKey } from "@oh-my-pi/pi-catalog/wire/github-copilot";
+import { parseGitHubCopilotApiKey, sanitizeCopilotHeaders } from "@oh-my-pi/pi-catalog/wire/github-copilot";
 import {
 	$env,
 	classifyJsonPrefix,
@@ -260,7 +260,7 @@ export function resolveOpenAIRequestSetup(
 			headers,
 			initiatorOverride: options.initiatorOverride,
 		});
-		Object.assign(headers, copilot.headers);
+		headers = Object.assign(sanitizeCopilotHeaders(headers), copilot.headers);
 		copilotPremiumRequests = copilot.premiumRequests;
 		baseUrl = resolveGitHubCopilotBaseUrl(model.baseUrl, rawApiKey) ?? model.baseUrl;
 	}

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -20,7 +20,7 @@ import { getCustomApi } from "./api-registry";
 import { createAuthRetryKeyState, isApiKeyResolver, resolveNextAuthRetryKey } from "./auth-retry";
 import * as AIError from "./error";
 import { ProviderHttpError } from "./error";
-import { isConcurrencyCapExclusion, isUsageLimitOutcome } from "./error/rate-limit";
+import { isConcurrencyCapExclusion, isTransientCopilotForbidden, isUsageLimitOutcome } from "./error/rate-limit";
 import type { BedrockOptions } from "./providers/amazon-bedrock";
 import type { AnthropicOptions } from "./providers/anthropic";
 import type { MessageCreateParamsStreaming } from "./providers/anthropic-wire";
@@ -1137,7 +1137,11 @@ function isRetryableUpstreamError(
 	// classify as RATE_LIMIT_EXCEEDED in `parseRateLimitReason` and stay in the
 	// provider's own backoff layer instead of burning siblings.
 	if (AIError.isCodexChatGPTAccountPolicyError(error, model.provider, model.id)) return true;
-	if (status === 401 || (status === 403 && !isConcurrencyCapExclusion(status, message))) return true;
+	if (
+		status === 401 ||
+		(status === 403 && !isConcurrencyCapExclusion(status, message) && !isTransientCopilotForbidden(status, message))
+	)
+		return true;
 	return isUsageLimitOutcome(status, message);
 }
 

--- a/packages/ai/src/utils/http-inspector.ts
+++ b/packages/ai/src/utils/http-inspector.ts
@@ -1,6 +1,7 @@
 import * as path from "node:path";
 import { getLogsDir, isBunTestRuntime } from "@oh-my-pi/pi-utils";
 import * as AIError from "../error/flags";
+import { isTransientCopilotForbidden } from "../error/rate-limit";
 import { formatErrorMessageWithRetryAfter } from "./retry-after.js";
 
 export type RawHttpRequestDump = {
@@ -108,6 +109,9 @@ export function rewriteCopilotError(errorMessage: string, error: unknown, provid
 		return `GitHub Copilot authentication failed (HTTP 401). Your token may have been revoked. Please re-login with /login github-copilot`;
 	}
 	if (status === 403) {
+		if (isTransientCopilotForbidden(status, errorMessage)) {
+			return errorMessage;
+		}
 		return `GitHub Copilot access denied (HTTP 403). Your account may not have access to this model or feature. Check your Copilot plan or model policy settings.`;
 	}
 	return errorMessage;

--- a/packages/ai/src/utils/openai-http.ts
+++ b/packages/ai/src/utils/openai-http.ts
@@ -14,9 +14,15 @@
  *   captured response body for the strict-tools fallback and the responses
  *   chain-state detectors, which regex over `error.message`.
  */
-import { fetchWithRetry, readSseJson, type SseEventObserver } from "@oh-my-pi/pi-utils";
+import { fetchWithRetry, isRetryableStatus, logger, readSseJson, type SseEventObserver } from "@oh-my-pi/pi-utils";
+import {
+	COPILOT_API_VERSION,
+	COPILOT_VSCODE_IDENTITY_HEADERS,
+	sanitizeCopilotHeaders,
+} from "@oh-my-pi/pi-catalog/wire/github-copilot";
 import * as AIError from "../error";
 import { OpenAIHttpError } from "../error";
+import { isTransientCopilotForbidden } from "../error/rate-limit";
 
 export { OpenAIHttpError };
 
@@ -70,6 +76,8 @@ export interface OpenAIStreamRequestInit {
 	fetch?: FetchImpl;
 	/** Raw wire-frame observer (`onSseEvent` debug pipeline). */
 	onSseEvent?: SseEventObserver;
+	/** Maximum attempts override (defaults to DEFAULT_MAX_ATTEMPTS = 6). */
+	maxAttempts?: number;
 }
 
 export interface OpenAIStreamHandle<TEvent> {
@@ -87,22 +95,100 @@ export interface OpenAIStreamHandle<TEvent> {
  * `signal` propagate from `fetchWithRetry`/`readSseJson`; callers own the
  * watchdog timers and abort-reason bookkeeping.
  */
+function stripControlHeaders(headers?: Record<string, string>): Record<string, string> {
+	if (!headers) return {};
+	const result: Record<string, string> = {};
+	for (const [k, v] of Object.entries(headers)) {
+		if (k.toLowerCase() !== "copilot-mode") {
+			result[k] = v;
+		}
+	}
+	return result;
+}
+
 export async function postOpenAIStream<TEvent>(init: OpenAIStreamRequestInit): Promise<OpenAIStreamHandle<TEvent>> {
+	let currentHeaders = { ...init.headers };
+	const initialIntegrationId = Object.entries(init.headers)
+		.find(([k]) => k.toLowerCase() === "copilot-integration-id")?.[1]
+		?.toLowerCase();
+	const explicitCopilotMode = Object.entries(init.headers)
+		.find(([k]) => k.toLowerCase() === "copilot-mode")?.[1]
+		?.toLowerCase();
+	const isCopilotRequest = initialIntegrationId !== undefined || explicitCopilotMode !== undefined;
+	const isCliIdentity = initialIntegrationId === "copilot-developer-cli" || explicitCopilotMode === "cli";
+	const allowVscodeFallback = isCopilotRequest && explicitCopilotMode !== "cli" && isCliIdentity;
+	let hasFallenBackToVscode = false;
+	logger.debug("postOpenAIStream: starting request", {
+		url: init.url,
+		isCopilotRequest,
+		isCliIdentity,
+		allowVscodeFallback,
+		headers: init.headers,
+	});
+
 	const response = await fetchWithRetry(init.url, {
 		method: "POST",
-		headers: { "Content-Type": "application/json", Accept: "text/event-stream", ...init.headers },
+		headers: {
+			"Content-Type": "application/json",
+			Accept: "text/event-stream",
+			...stripControlHeaders(init.headers),
+		},
 		body: JSON.stringify(init.body),
 		signal: init.signal,
 		fetch: init.fetch,
-		maxAttempts: DEFAULT_MAX_ATTEMPTS,
+		maxAttempts: init.maxAttempts ?? DEFAULT_MAX_ATTEMPTS,
+		isRetryableStatus: status => isRetryableStatus(status) || (isCopilotRequest && status === 403),
+		prepareInit: attempt => {
+			logger.debug("postOpenAIStream: prepareInit", { attempt, hasFallenBackToVscode });
+			if (attempt > 0 && hasFallenBackToVscode) {
+				return {
+					headers: {
+						"Content-Type": "application/json",
+						Accept: "text/event-stream",
+						...stripControlHeaders(currentHeaders),
+						"Copilot-Harness-Id": "",
+					},
+				};
+			}
+			return {};
+		},
 		// A proxy concurrency-admission 429 (`rate_limit_type: max_parallel_requests`)
 		// surfaces immediately instead of being slept-and-retried here; session
 		// recovery owns its backoff/fallback (issue #8854).
-		shouldRetryResponse: (response, bodyText) => !isConcurrencyAdmissionRejection(response, bodyText),
-		// Bun's native fetch enforces a hard ~300s pre-response timeout (issue #2422).
-		// Cold large-context streams legitimately exceed it; the caller's
-		// `firstEventTimeoutMs`/`AbortSignal` already govern stuck requests.
-		timeout: false,
+		// Transient Copilot 403 ("unauthorized: not authorized to use this Copilot feature")
+		// is retried across cluster pods. In auto mode, an initial CLI 403 triggers a
+		// bounded single-attempt fallback to VS Code wire identity.
+		shouldRetryResponse: (response, bodyText) => {
+			logger.debug("postOpenAIStream: response", {
+				status: response.status,
+				body: bodyText.slice(0, 100),
+				hasFallenBackToVscode,
+			});
+			if (isConcurrencyAdmissionRejection(response, bodyText)) return false;
+			if (response.status === 403 && isCopilotRequest) {
+				const isFeatureForbidden = isTransientCopilotForbidden(response.status, bodyText);
+				if (!isFeatureForbidden) return false;
+				if (!hasFallenBackToVscode && allowVscodeFallback) {
+					hasFallenBackToVscode = true;
+					currentHeaders = {
+						...sanitizeCopilotHeaders(currentHeaders),
+						...COPILOT_VSCODE_IDENTITY_HEADERS,
+						"X-GitHub-Api-Version": COPILOT_API_VERSION,
+					};
+					logger.debug("postOpenAIStream: triggered fallback to VS Code mode");
+					return true;
+				}
+				if (hasFallenBackToVscode || !isCliIdentity) {
+					return true;
+				}
+				return false;
+			}
+			return true;
+		},
+		// For Copilot requests, bound the pre-response header wait to 15s so stuck/dead
+		// cluster pods in Ashburn fail fast and let fetchWithRetry hit a healthy
+		// replica, rather than hanging for 120s until GitHub's edge proxy cuts the socket.
+		timeout: isCopilotRequest ? 15_000 : false,
 	});
 	if (!response.ok) {
 		throw await captureOpenAIHttpError(response);

--- a/packages/ai/test/github-copilot-error.test.ts
+++ b/packages/ai/test/github-copilot-error.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { isTransientCopilotForbidden } from "@oh-my-pi/pi-ai/error/rate-limit";
 import { rewriteCopilotError } from "@oh-my-pi/pi-ai/utils/http-inspector";
 
 function errorWithStatus(
@@ -48,5 +49,17 @@ describe("rewriteCopilotError", () => {
 		expect(result).toContain("GitHub Copilot access denied (HTTP 403)");
 		expect(result).not.toContain("GitHub Copilot authentication failed");
 		expect(result).not.toContain("/login github-copilot");
+	});
+});
+
+describe("isTransientCopilotForbidden", () => {
+	it("identifies transient proxy 403 not-authorized messages", () => {
+		expect(isTransientCopilotForbidden(403, "unauthorized: not authorized to use this Copilot feature")).toBe(true);
+		expect(
+			isTransientCopilotForbidden(403, "HTTP 403 - unauthorized: not authorized to use this Copilot feature\n"),
+		).toBe(true);
+		expect(isTransientCopilotForbidden(403, "403 Forbidden")).toBe(false);
+		expect(isTransientCopilotForbidden(401, "unauthorized: not authorized to use this Copilot feature")).toBe(false);
+		expect(isTransientCopilotForbidden(403, undefined)).toBe(false);
 	});
 });

--- a/packages/ai/test/github-copilot-headers.test.ts
+++ b/packages/ai/test/github-copilot-headers.test.ts
@@ -215,6 +215,7 @@ describe("buildCopilotDynamicHeaders", () => {
 			"Openai-Intent": "conversation-agent",
 			"X-Initiator": "user",
 			"X-Interaction-Type": "conversation-user",
+			"X-GitHub-Api-Version": "2026-08-01",
 		});
 		expect(premiumRequests).toBe(0.33);
 	});
@@ -308,5 +309,36 @@ describe("buildCopilotDynamicHeaders", () => {
 			hasImages: false,
 		});
 		expect(premiumRequests).toBe(1);
+	});
+
+	it("uses VS Code mode identity when headers request it", () => {
+		const { headers } = buildCopilotDynamicHeaders({
+			messages: [],
+			hasImages: false,
+			headers: { "Copilot-Integration-Id": "vscode-chat" },
+		});
+		expect(headers["Editor-Version"]).toBe("vscode/1.136.0");
+		expect(headers["Editor-Plugin-Version"]).toBe("copilot-chat/0.64.0");
+		expect(headers["Copilot-Integration-Id"]).toBe("vscode-chat");
+		expect(headers["Openai-Intent"]).toBe("conversation-panel");
+		expect(headers["User-Agent"]).toBe("GitHubCopilotChat/0.64.0");
+
+		const modeHeaderResult = buildCopilotDynamicHeaders({
+			messages: [],
+			hasImages: false,
+			headers: { "Copilot-Mode": "vscode" },
+		});
+		expect(modeHeaderResult.headers["Copilot-Integration-Id"]).toBe("vscode-chat");
+		expect(modeHeaderResult.headers["Editor-Version"]).toBe("vscode/1.136.0");
+
+		// Also verify that model.headers (cli) does not clobber Copilot-Mode: vscode
+		const model = getBundledModel("github-copilot", "gpt-5.6-sol");
+		const envResult = buildCopilotDynamicHeaders({
+			messages: [],
+			hasImages: false,
+			headers: { ...model?.headers, "Copilot-Mode": "vscode" },
+		});
+		expect(envResult.headers["Copilot-Integration-Id"]).toBe("vscode-chat");
+		expect(envResult.headers["Editor-Version"]).toBe("vscode/1.136.0");
 	});
 });

--- a/packages/ai/test/github-copilot-transport.test.ts
+++ b/packages/ai/test/github-copilot-transport.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from "bun:test";
+import { postOpenAIStream } from "@oh-my-pi/pi-ai/utils/openai-http";
+import { resolveOpenAIRequestSetup } from "@oh-my-pi/pi-ai/providers/openai-shared";
+import { buildAnthropicClientOptions } from "@oh-my-pi/pi-ai/providers/anthropic";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import type { FetchImpl, Model } from "@oh-my-pi/pi-ai/types";
+
+describe("GitHub Copilot transport contract", () => {
+	it("retries matching transient 403 and succeeds on next attempt", async () => {
+		let attempts = 0;
+		const mockFetch = async () => {
+			attempts++;
+			if (attempts === 1) {
+				return new Response("unauthorized: not authorized to use this Copilot feature\n", {
+					status: 403,
+					statusText: "Forbidden",
+				});
+			}
+			return new Response('data: {"type":"response.done"}\n\n[DONE]\n\n', {
+				status: 200,
+				statusText: "OK",
+				headers: { "Content-Type": "text/event-stream" },
+			});
+		};
+
+		const handle = await postOpenAIStream({
+			url: "https://api.githubcopilot.com/responses",
+			headers: { "Copilot-Integration-Id": "vscode-chat" },
+			body: { model: "gpt-5.6-sol", input: "ping" },
+			signal: new AbortController().signal,
+			fetch: mockFetch as unknown as FetchImpl,
+		});
+
+		expect(handle.response.status).toBe(200);
+		expect(attempts).toBe(2);
+	});
+
+	it("does not retry non-matching 403 and fails in one attempt", async () => {
+		let attempts = 0;
+		const mockFetch = async () => {
+			attempts++;
+			return new Response("403 Forbidden: Invalid token", {
+				status: 403,
+				statusText: "Forbidden",
+			});
+		};
+
+		await expect(
+			postOpenAIStream({
+				url: "https://api.githubcopilot.com/responses",
+				headers: { "Copilot-Integration-Id": "vscode-chat" },
+				body: { model: "gpt-5.6-sol", input: "ping" },
+				signal: new AbortController().signal,
+				fetch: mockFetch as unknown as FetchImpl,
+			}),
+		).rejects.toThrow();
+
+		expect(attempts).toBe(1);
+	});
+
+	it("preserves response body on retry exhaustion", async () => {
+		const mockFetch = async () => {
+			return new Response("unauthorized: not authorized to use this Copilot feature\n", {
+				status: 403,
+				statusText: "Forbidden",
+			});
+		};
+
+		try {
+			await postOpenAIStream({
+				url: "https://api.githubcopilot.com/responses",
+				headers: { "Copilot-Integration-Id": "vscode-chat" },
+				body: { model: "gpt-5.6-sol", input: "ping" },
+				signal: new AbortController().signal,
+				fetch: mockFetch as unknown as FetchImpl,
+				maxAttempts: 2,
+			});
+			expect().fail("Expected postOpenAIStream to throw");
+		} catch (err: unknown) {
+			const errorWithCaptured = err as { message?: string; captured?: { status?: number; bodyText?: string } };
+			expect(errorWithCaptured.message).toContain("unauthorized: not authorized to use this Copilot feature");
+			expect(errorWithCaptured.captured?.status).toBe(403);
+			expect(errorWithCaptured.captured?.bodyText).toContain("not authorized to use this Copilot feature");
+		}
+	});
+
+	it("performs bounded fallback from CLI to VS Code mode in auto mode on 403", async () => {
+		let attempts = 0;
+		const observedHeaders: Record<string, string>[] = [];
+		const mockFetch = async (_url: unknown, init?: RequestInit) => {
+			attempts++;
+			const rawHeaders = init?.headers;
+			const headersObj: Record<string, string> = {};
+			if (rawHeaders instanceof Headers) {
+				rawHeaders.forEach((v, k) => {
+					headersObj[k] = v;
+				});
+			} else if (rawHeaders && typeof rawHeaders === "object") {
+				Object.assign(headersObj, rawHeaders);
+			}
+			observedHeaders.push(headersObj);
+
+			if (attempts === 1) {
+				return new Response("unauthorized: not authorized to use this Copilot feature\n", {
+					status: 403,
+					statusText: "Forbidden",
+				});
+			}
+			return new Response('data: {"type":"response.done"}\n\n[DONE]\n\n', {
+				status: 200,
+				statusText: "OK",
+				headers: { "Content-Type": "text/event-stream" },
+			});
+		};
+
+		const handle = await postOpenAIStream({
+			url: "https://api.githubcopilot.com/responses",
+			headers: { "Copilot-Integration-Id": "copilot-developer-cli" },
+			body: { model: "gpt-5.6-sol", input: "ping" },
+			signal: new AbortController().signal,
+			fetch: mockFetch as unknown as FetchImpl,
+		});
+
+		expect(handle.response.status).toBe(200);
+		expect(attempts).toBe(2);
+		expect(observedHeaders[0]?.["copilot-integration-id"] ?? observedHeaders[0]?.["Copilot-Integration-Id"]).toBe(
+			"copilot-developer-cli",
+		);
+		expect(observedHeaders[1]?.["copilot-integration-id"] ?? observedHeaders[1]?.["Copilot-Integration-Id"]).toBe(
+			"vscode-chat",
+		);
+	});
+
+	it("does not fall back to VS Code mode when Copilot-Mode is explicitly cli", async () => {
+		let attempts = 0;
+		const mockFetch = async () => {
+			attempts++;
+			return new Response("unauthorized: not authorized to use this Copilot feature\n", {
+				status: 403,
+				statusText: "Forbidden",
+			});
+		};
+
+		await expect(
+			postOpenAIStream({
+				url: "https://api.githubcopilot.com/responses",
+				headers: { "Copilot-Integration-Id": "copilot-developer-cli", "Copilot-Mode": "cli" },
+				body: { model: "gpt-5.6-sol", input: "ping" },
+				signal: new AbortController().signal,
+				fetch: mockFetch as unknown as FetchImpl,
+			}),
+		).rejects.toThrow();
+
+		expect(attempts).toBe(1);
+	});
+});
+
+describe("GitHub Copilot final request header sanitization", () => {
+	it("sanitizes final OpenAI headers in VS Code mode with no CLI leak or Copilot-Mode", () => {
+		const model = getBundledModel("github-copilot", "gpt-5.6-sol") as Model<"openai-responses">;
+		const setup = resolveOpenAIRequestSetup(model, {
+			apiKey: "test_token",
+			extraHeaders: { "Copilot-Mode": "vscode", "X-Custom": "custom-val" },
+			messages: [],
+		});
+
+		expect(setup.headers["Copilot-Integration-Id"]).toBe("vscode-chat");
+		expect(setup.headers["Editor-Version"]).toBe("vscode/1.136.0");
+		expect(setup.headers["User-Agent"]).toBe("GitHubCopilotChat/0.64.0");
+		expect(setup.headers["Openai-Intent"]).toBe("conversation-panel");
+		expect(setup.headers["X-Custom"]).toBe("custom-val");
+
+		// Managed CLI headers and synthetic control header must not be present
+		expect(setup.headers["Copilot-Harness-Id"]).toBeUndefined();
+		expect(setup.headers["Copilot-Mode"]).toBeUndefined();
+		expect(setup.headers["copilot-mode"]).toBeUndefined();
+	});
+
+	it("sanitizes final Anthropic defaultHeaders in VS Code mode", () => {
+		const model = getBundledModel("github-copilot", "claude-opus-5") as Model<"anthropic-messages">;
+		const options = buildAnthropicClientOptions({
+			model,
+			apiKey: "test_token",
+			headers: { "Copilot-Mode": "vscode", "X-Custom": "custom-val" },
+			dynamicHeaders: { "Copilot-Integration-Id": "vscode-chat" },
+			stream: false,
+		});
+
+		const defaultHeaders = options.defaultHeaders as Record<string, string>;
+		expect(defaultHeaders["Copilot-Integration-Id"]).toBe("vscode-chat");
+		expect(defaultHeaders["Editor-Version"]).toBe("vscode/1.136.0");
+		expect(defaultHeaders["User-Agent"]).toBe("GitHubCopilotChat/0.64.0");
+		expect(defaultHeaders["Openai-Intent"]).toBe("conversation-panel");
+		expect(defaultHeaders["X-Custom"]).toBe("custom-val");
+
+		// Managed CLI headers and synthetic control header must not be present
+		expect(defaultHeaders["Copilot-Harness-Id"]).toBeUndefined();
+		expect(defaultHeaders["Copilot-Mode"]).toBeUndefined();
+		expect(defaultHeaders["copilot-mode"]).toBeUndefined();
+	});
+});

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `COPILOT_VSCODE_IDENTITY_HEADERS`, `isCopilotVscodeMode()`, and `sanitizeCopilotHeaders()` to support VS Code Copilot Chat wire identity for enterprise accounts where Copilot CLI is disabled.
+
 ## [18.1.8] - 2026-09-03
 
 ### Added

--- a/packages/catalog/src/wire/github-copilot.ts
+++ b/packages/catalog/src/wire/github-copilot.ts
@@ -24,6 +24,54 @@ export const COPILOT_CAPI_IDENTITY_HEADERS = {
 	"Openai-Intent": "conversation-agent",
 } as const;
 
+/** Copilot VS Code identity sent to the Copilot API when in VS Code compatibility mode. */
+export const COPILOT_VSCODE_IDENTITY_HEADERS = {
+	"User-Agent": "GitHubCopilotChat/0.64.0",
+	"Editor-Version": "vscode/1.136.0",
+	"Editor-Plugin-Version": "copilot-chat/0.64.0",
+	"Copilot-Integration-Id": "vscode-chat",
+	"Openai-Intent": "conversation-panel",
+} as const;
+
+/**
+ * Returns whether VS Code compatibility mode is active for Copilot headers.
+ * 1. Checks explicit `Copilot-Mode: vscode|cli` setting/header.
+ * 2. Checks explicit caller `Copilot-Integration-Id: vscode-chat` or `Editor-Version: vscode/...`.
+ * Defaults to false (standard Copilot CLI identity).
+ */
+export function isCopilotVscodeMode(headers?: Readonly<Record<string, string>>): boolean {
+	if (headers) {
+		for (const key of Object.keys(headers)) {
+			if (key.toLowerCase() === "copilot-mode") {
+				const val = headers[key]?.toLowerCase();
+				if (val === "vscode") return true;
+				if (val === "cli") return false;
+			}
+		}
+		for (const key of Object.keys(headers)) {
+			const lower = key.toLowerCase();
+			if (lower === "copilot-integration-id" && headers[key]?.toLowerCase() === "vscode-chat") {
+				return true;
+			}
+			if (lower === "editor-version" && headers[key]?.toLowerCase().startsWith("vscode/")) {
+				return true;
+			}
+		}
+	}
+	return false;
+}
+
+/**
+ * Return a fresh managed Copilot identity header map (CLI or VS Code mode)
+ * selected from the caller-supplied headers.
+ */
+export function getCopilotCapiIdentityHeaders(headers?: Readonly<Record<string, string>>): Record<string, string> {
+	if (isCopilotVscodeMode(headers)) {
+		return { ...COPILOT_VSCODE_IDENTITY_HEADERS };
+	}
+	return { ...COPILOT_CAPI_IDENTITY_HEADERS };
+}
+
 /**
  * Copilot API version sent on `api.githubcopilot.com` requests (`/models`,
  * chat endpoints). Newer versions unlock tiered context metadata: `/models`
@@ -47,29 +95,37 @@ export const COPILOT_DISCOVERY_HEADERS = {
 	"X-Initiator": "user",
 } as const;
 
-const MANAGED_COPILOT_HEADER_NAMES: Record<string, true> = {
+export const MANAGED_COPILOT_HEADER_NAMES: Record<string, true> = {
 	"user-agent": true,
 	"editor-version": true,
+	"editor-plugin-version": true,
 	"copilot-integration-id": true,
 	"copilot-harness-id": true,
+	"copilot-mode": true,
 	"openai-intent": true,
 	"x-github-api-version": true,
 	"x-initiator": true,
 	"x-interaction-type": true,
 };
 
-/** Preserve model-specific headers while enforcing the current Copilot API identity. */
-export function mergeCopilotApiHeaders(headers?: Readonly<Record<string, string>>): Record<string, string> {
-	const merged: Record<string, string> = {};
+/** Strip managed Copilot identity and control headers, preserving custom caller headers. */
+export function sanitizeCopilotHeaders(headers?: Readonly<Record<string, string>>): Record<string, string> {
+	const result: Record<string, string> = {};
 	if (headers) {
-		for (const name in headers) {
-			const value = headers[name];
-			if (value !== undefined && !MANAGED_COPILOT_HEADER_NAMES[name.toLowerCase()]) {
-				merged[name] = value;
+		for (const [key, value] of Object.entries(headers)) {
+			if (value !== undefined && !MANAGED_COPILOT_HEADER_NAMES[key.toLowerCase()]) {
+				result[key] = value;
 			}
 		}
 	}
-	return { ...merged, ...COPILOT_API_HEADERS };
+	return result;
+}
+
+/** Preserve model-specific headers while enforcing the current Copilot API identity. */
+export function mergeCopilotApiHeaders(headers?: Readonly<Record<string, string>>): Record<string, string> {
+	const baseIdentity = getCopilotCapiIdentityHeaders(headers);
+	const custom = sanitizeCopilotHeaders(headers);
+	return { ...custom, ...baseIdentity, "X-GitHub-Api-Version": COPILOT_API_VERSION };
 }
 
 type GitHubCopilotApiKeyPayload = {

--- a/packages/catalog/test/github-copilot-wire.test.ts
+++ b/packages/catalog/test/github-copilot-wire.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "bun:test";
 import {
+	COPILOT_CAPI_IDENTITY_HEADERS,
+	COPILOT_VSCODE_IDENTITY_HEADERS,
+	getCopilotCapiIdentityHeaders,
 	getGitHubCopilotBaseUrl,
+	isCopilotVscodeMode,
+	mergeCopilotApiHeaders,
 	normalizeGitHubCopilotApiEndpoint,
 	normalizeGitHubCopilotEnterpriseDomain,
 	parseGitHubCopilotApiKey,
@@ -40,5 +45,38 @@ describe("GitHub Copilot OAuth helpers", () => {
 			enterpriseUrl: "ghe.example.com",
 			apiEndpoint: "https://api.business.githubcopilot.com",
 		});
+	});
+});
+
+describe("GitHub Copilot VS Code mode identity", () => {
+	it("detects VS Code mode from explicit headers", () => {
+		expect(isCopilotVscodeMode()).toBe(false);
+		expect(isCopilotVscodeMode({ "Copilot-Mode": "vscode" })).toBe(true);
+		expect(isCopilotVscodeMode({ "Copilot-Mode": "cli" })).toBe(false);
+		expect(isCopilotVscodeMode({ "Copilot-Integration-Id": "vscode-chat" })).toBe(true);
+		expect(isCopilotVscodeMode({ "Editor-Version": "vscode/1.136.0" })).toBe(true);
+		expect(isCopilotVscodeMode({ "Copilot-Integration-Id": "copilot-developer-cli" })).toBe(false);
+	});
+
+	it("returns VS Code identity headers when in VS Code mode", () => {
+		expect(getCopilotCapiIdentityHeaders({ "Copilot-Integration-Id": "vscode-chat" })).toEqual({
+			...COPILOT_VSCODE_IDENTITY_HEADERS,
+		});
+		expect(getCopilotCapiIdentityHeaders({ "Copilot-Mode": "vscode" })).toEqual({
+			...COPILOT_VSCODE_IDENTITY_HEADERS,
+		});
+		expect(getCopilotCapiIdentityHeaders()).toEqual({
+			...COPILOT_CAPI_IDENTITY_HEADERS,
+		});
+		expect(getCopilotCapiIdentityHeaders({ "Copilot-Mode": "cli" })).toEqual({
+			...COPILOT_CAPI_IDENTITY_HEADERS,
+		});
+	});
+
+	it("merges headers preserving VS Code identity when enabled", () => {
+		const merged = mergeCopilotApiHeaders({ "Copilot-Integration-Id": "vscode-chat", "Custom-Header": "foo" });
+		expect(merged["Copilot-Integration-Id"]).toBe("vscode-chat");
+		expect(merged["Editor-Version"]).toBe("vscode/1.136.0");
+		expect(merged["Custom-Header"]).toBe("foo");
 	});
 });

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `providers.copilot.mode` setting (`auto`, `vscode`, `cli`) to configure the wire identity headers sent on GitHub Copilot requests.
+
 ## [18.1.8] - 2026-09-03
 
 ### Fixed

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -5784,6 +5784,32 @@ export const SETTINGS_SCHEMA = {
 			],
 		},
 	},
+	"providers.copilot.mode": {
+		type: "enum",
+		values: ["auto", "vscode", "cli"] as const,
+		default: "auto",
+		ui: {
+			tab: "providers",
+			group: "Protocol",
+			label: "Copilot Wire Identity",
+			description:
+				"Wire identity headers sent to GitHub Copilot API. 'auto' uses caller headers with automatic fallback from CLI to VS Code identity on policy denial, 'vscode' forces VS Code Copilot Chat identity (required for enterprise accounts where Copilot CLI is disabled), 'cli' forces official Copilot CLI identity.",
+			options: [
+				{
+					value: "auto",
+					label: "Auto",
+					description: "Caller headers with automatic CLI-to-VS Code fallback on policy rejection",
+				},
+				{
+					value: "vscode",
+					label: "VS Code",
+					description: "VS Code Copilot Chat identity (works with enterprise CLI-disabled seats)",
+				},
+				{ value: "cli", label: "CLI", description: "Official Copilot CLI identity" },
+			],
+		},
+	},
+
 	"providers.fetch": {
 		type: "enum",
 		values: ["auto", "native", "trafilatura", "lynx", "parallel", "firecrawl", "jina"] as const,

--- a/packages/coding-agent/src/session/settings-stream-fn.ts
+++ b/packages/coding-agent/src/session/settings-stream-fn.ts
@@ -33,6 +33,7 @@ export function createSettingsAwareStreamFn(settings: Settings, base: StreamFn =
 		const openrouterVariant =
 			openrouterRoutingPreset && openrouterRoutingPreset !== "default" ? openrouterRoutingPreset : undefined;
 		const antigravityEndpointMode = settings.get("providers.antigravityEndpoint");
+		const copilotMode = settings.get("providers.copilot.mode");
 		const textVerbosity =
 			model.api === "openai-codex-responses"
 				? settings.isConfigured("textVerbosity")
@@ -66,8 +67,23 @@ export function createSettingsAwareStreamFn(settings: Settings, base: StreamFn =
 			(serverSideFallbackIdentity.family === "fable" || serverSideFallbackIdentity.family === "mythos");
 		const fallbacks =
 			streamOptions?.fallbacks ?? (serverSideFallbackEnabled ? [{ model: "claude-opus-4-8" }] : undefined);
+
+		let headers = streamOptions?.headers;
+		if (model.provider === "github-copilot") {
+			const hasCallerIdentity = headers
+				? Object.keys(headers).some(k => {
+						const lower = k.toLowerCase();
+						return lower === "copilot-mode" || lower === "copilot-integration-id" || lower === "editor-version";
+					})
+				: false;
+			if (!hasCallerIdentity && (copilotMode === "vscode" || copilotMode === "cli")) {
+				headers = { ...headers, "Copilot-Mode": copilotMode };
+			}
+		}
+
 		const merged: SimpleStreamOptions = {
 			...streamOptions,
+			...(headers !== undefined ? { headers } : {}),
 			openrouterVariant: streamOptions?.openrouterVariant ?? openrouterVariant,
 			antigravityEndpointMode: streamOptions?.antigravityEndpointMode ?? antigravityEndpointMode,
 			textVerbosity: streamOptions?.textVerbosity ?? textVerbosity,

--- a/packages/coding-agent/test/settings-stream-fn.test.ts
+++ b/packages/coding-agent/test/settings-stream-fn.test.ts
@@ -246,4 +246,43 @@ describe("createSettingsAwareStreamFn", () => {
 			expect(calls[0]?.options?.fallbacks).toEqual([{ model: "claude-sonnet-5" }]);
 		});
 	});
+
+	describe("providers.copilot.mode", () => {
+		const stubCopilotModel = {
+			id: "gpt-5.6-sol",
+			name: "GPT-5.6 Sol",
+			provider: "github-copilot",
+			api: "openai-responses",
+			baseUrl: "https://api.githubcopilot.com",
+			contextWindow: 128_000,
+			maxTokens: 4096,
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		} as unknown as Model<"openai-responses">;
+
+		it("injects Copilot-Mode header when providers.copilot.mode is set", () => {
+			const settings = Settings.isolated({ "providers.copilot.mode": "vscode" });
+			const { fn: base, calls } = captureBase();
+			const wrapped = createSettingsAwareStreamFn(settings, base);
+
+			wrapped(stubCopilotModel, stubContext, { apiKey: "k" });
+
+			expect(calls[0]?.options?.headers?.["Copilot-Mode"]).toBe("vscode");
+		});
+
+		it("caller-supplied Copilot-Mode wins over the setting", () => {
+			const settings = Settings.isolated({ "providers.copilot.mode": "vscode" });
+			const { fn: base, calls } = captureBase();
+			const wrapped = createSettingsAwareStreamFn(settings, base);
+
+			wrapped(stubCopilotModel, stubContext, {
+				apiKey: "k",
+				headers: { "copilot-mode": "cli" },
+			});
+
+			expect(calls[0]?.options?.headers?.["copilot-mode"]).toBe("cli");
+			expect(calls[0]?.options?.headers?.["Copilot-Mode"]).toBeUndefined();
+		});
+	});
 });

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added the optional `isRetryableStatus` predicate to `FetchWithRetryOptions`, allowing callers to customize or extend the retryable HTTP status set.
+
 ## [18.1.7] - 2026-09-03
 
 ### Added

--- a/packages/utils/src/fetch-retry.ts
+++ b/packages/utils/src/fetch-retry.ts
@@ -1,3 +1,4 @@
+import * as logger from "./logger";
 import { scheduler } from "node:timers/promises";
 
 // "reset after 1h2m3s" / "10m15s" / "39s"
@@ -189,6 +190,11 @@ export interface FetchWithRetryOptions extends RequestInit {
 	 */
 	fetch?: (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
 	/**
+	 * Optional custom predicate to determine whether an HTTP status is retryable.
+	 * When omitted, defaults to `isRetryableStatus` (5xx, 408, 429).
+	 */
+	isRetryableStatus?: (status: number, response?: Response) => boolean;
+	/**
 	 * Optional retry gate for HTTP responses whose status is retryable. Receives a
 	 * cloned body string so callers can fail fast on deterministic provider
 	 * failures that happen to use a 5xx status.
@@ -225,6 +231,7 @@ export async function fetchWithRetry(
 		maxDelayMs = DEFAULT_MAX_DELAY_MS,
 		defaultDelayMs,
 		prepareInit,
+		isRetryableStatus: isRetryableStatusOption,
 		shouldRetryResponse,
 		fetch: fetchImpl = fetch,
 		timeout = false,
@@ -233,6 +240,7 @@ export async function fetchWithRetry(
 	const signal = baseInit.signal as AbortSignal | undefined;
 
 	for (let attempt = 0; ; attempt++) {
+		logger.debug("fetchWithRetry: starting attempt", { attempt, url: typeof url === "string" ? url : "dynamic" });
 		if (signal?.aborted) throw new Error("Request was aborted");
 		const requestUrl = typeof url === "function" ? url(attempt) : url;
 		// `timeout` is destructured out of `baseInit`, so forward it to the underlying
@@ -258,8 +266,12 @@ export async function fetchWithRetry(
 			await waitForRetry(resolveDefaultDelay(defaultDelayMs, attempt, maxDelayMs), signal);
 			continue;
 		}
+		logger.debug("fetchWithRetry: received response", { attempt, status: response.status });
 
-		if (!isRetryableStatus(response.status)) return response;
+		const isRetryable = isRetryableStatusOption
+			? isRetryableStatusOption(response.status, response)
+			: isRetryableStatus(response.status);
+		if (!isRetryable) return response;
 		if (attempt + 1 >= maxAttempts) return response;
 
 		const retryBody = await response.clone().text();
@@ -269,6 +281,7 @@ export async function fetchWithRetry(
 		if (hint !== undefined && hint > maxDelayMs) return response;
 
 		const delayMs = Math.min(hint ?? resolveDefaultDelay(defaultDelayMs, attempt, maxDelayMs), maxDelayMs);
+		logger.debug("fetchWithRetry: waiting before next attempt", { attempt, delayMs, hint });
 		await waitForRetry(delayMs, signal);
 	}
 }
@@ -279,7 +292,11 @@ function mergeInit(base: RequestInit, overlay: RequestInit, timeout: number | fa
 		const baseHeaders = new Headers(base.headers ?? undefined);
 		const overlayHeaders = new Headers(overlay.headers ?? undefined);
 		overlayHeaders.forEach((value, key) => {
-			baseHeaders.set(key, value);
+			if (!value) {
+				baseHeaders.delete(key);
+			} else {
+				baseHeaders.set(key, value);
+			}
 		});
 		merged.headers = baseHeaders;
 	}

--- a/packages/utils/test/fetch-retry.test.ts
+++ b/packages/utils/test/fetch-retry.test.ts
@@ -108,6 +108,38 @@ describe("fetchWithRetry", () => {
 			message: "Request was aborted",
 		});
 	});
+
+	it("allows prepareInit to delete headers by specifying an empty string value", async () => {
+		const observedHeaders: Array<Headers | undefined> = [];
+		let attempt = 0;
+		const customFetch = async (_url: unknown, init?: RequestInit) => {
+			attempt += 1;
+			observedHeaders.push(init?.headers as Headers);
+			if (attempt === 1) return new Response("retry me", { status: 503 });
+			return new Response("ok", { status: 200 });
+		};
+
+		await fetchWithRetry("https://example.invalid/delete-header", {
+			headers: { "X-Keep": "1", "X-Remove": "bad" },
+			prepareInit: currentAttempt => {
+				if (currentAttempt > 0) {
+					return { headers: { "X-Remove": "", "X-Add": "new" } };
+				}
+				return {};
+			},
+			fetch: customFetch,
+			defaultDelayMs: 1,
+			maxAttempts: 2,
+		});
+
+		expect(observedHeaders[0]?.get("x-keep")).toBe("1");
+		expect(observedHeaders[0]?.get("x-remove")).toBe("bad");
+		expect(observedHeaders[0]?.get("x-add")).toBeNull();
+
+		expect(observedHeaders[1]?.get("x-keep")).toBe("1");
+		expect(observedHeaders[1]?.get("x-remove")).toBeNull();
+		expect(observedHeaders[1]?.get("x-add")).toBe("new");
+	});
 });
 
 describe("extractRetryHint", () => {


### PR DESCRIPTION
## Problem

Enterprise organizations that configure Copilot policies with `cli_enabled: false` (while keeping chat enabled for IDE editors) receive HTTP 403 Forbidden errors when using advanced models (such as `gpt-5.6-sol`, `claude-opus-5`, etc.) in `oh-my-pi`. 

When commit `167a96d` standardized headers to `Copilot-Integration-Id: copilot-developer-cli`, requests became subject to this organizational CLI block. Additionally:
1. When custom headers or modes were selected, bundled `model.headers` and caller headers resulted in a mixed CLI/VS Code identity (retaining `Copilot-Harness-Id: copilot-sdk` and internal control headers).
2. Copilot's edge cluster replicas periodically return transient `403 unauthorized: not authorized to use this Copilot feature`. The transport layer treated HTTP 403 as immediately terminal, while error classification tagged it as `Flag.AuthFailed`, prematurely evicting credentials or falling back.
3. The default `auto` mode had no capability detection or bounded fallback, so enterprise seats remained on the failing CLI path until manual configuration.

## Solution

1. **VS Code Wire Identity & Settings:**
   - Introduce `COPILOT_VSCODE_IDENTITY_HEADERS`, `isCopilotVscodeMode`, and `sanitizeCopilotHeaders` in `@oh-my-pi/pi-catalog/wire/github-copilot`.
   - Add `providers.copilot.mode` (`auto` | `vscode` | `cli`, default `auto`) to `settings-schema.ts`, configurable via `config.yml`, `settings.json`, and `/settings`.
   - Forward `Copilot-Mode` through `createSettingsAwareStreamFn`, strictly preserving caller-supplied headers and wire identity signals.
2. **Pure Header Sanitization (No Mixed Identity):**
   - In both `resolveOpenAIRequestSetup()` and `buildAnthropicClientOptions()`, sanitize source maps via `sanitizeCopilotHeaders()` before merging resolved identity, ensuring no `Copilot-Harness-Id` or internal control headers leak into the final request.
3. **Bounded Auto-Mode Fallback & Transport-Level 403 Retries:**
   - Extend `FetchWithRetryOptions` in `@oh-my-pi/pi-utils/fetch-retry` with an `isRetryableStatus` hook, properly destructuring it to prevent leaking nonstandard properties into `RequestInit`.
   - In `postOpenAIStream()`, detect when an `auto`-mode request with CLI identity receives `403 unauthorized: not authorized to use this Copilot feature` and perform a bounded single-attempt fallback to VS Code wire identity.
   - For VS Code identity requests, retry transient edge-replica 403s with exponential backoff on the same route.
   - Explicit `cli` mode fails fast on 403 without retrying or falling back.
4. **Error Classification & Inspector Safeguards:**
   - Tag transient Copilot 403s as `Flag.Transient` and exclude them from `Flag.AuthFailed` in error classification and `isProviderRetryableError`.
   - Preserve original error text in `rewriteCopilotError`.
5. **Reverted Unrelated Changes:**
   - Dropped unrelated `NativeDesktopSession` edit in `desktop-adapter.js`.

## Safety details

- **Zero Breaking Changes:** Default mode remains `"auto"`, preserving official Copilot CLI identity unless an organizational policy rejection triggers the bounded VS Code fallback.
- **Credential Protection:** Transient 403s are retried on the same route with exponential backoff across cluster replicas instead of triggering credential deletion or provider fallback.
- **Deterministic Precedence:** Explicit caller options and headers always win over settings.

## Changes

**`packages/catalog`**
- `src/wire/github-copilot.ts`: Add `COPILOT_VSCODE_IDENTITY_HEADERS`, `isCopilotVscodeMode`, `sanitizeCopilotHeaders`, and documented `getCopilotCapiIdentityHeaders`.
- `test/github-copilot-wire.test.ts`: Add tests for explicit header mode detection and sanitized header merging.
- `CHANGELOG.md`: Add `[Unreleased]` entry.

**`packages/ai`**
- `src/providers/openai-shared.ts`: Sanitize final OpenAI request headers to prevent mixed identity leaks.
- `src/providers/anthropic.ts`: Sanitize final Anthropic defaultHeaders to prevent mixed identity leaks while preserving dynamic headers like `X-Initiator`.
- `src/providers/github-copilot-headers.ts`: Use `mergeCopilotApiHeaders` in `buildCopilotDynamicHeaders`.
- `src/utils/openai-http.ts`: Configure `postOpenAIStream` with bounded CLI-to-VS Code fallback and transient 403 retry.
- `src/utils/http-inspector.ts`: Guard `rewriteCopilotError` against clobbering transient error messages.
- `src/error/flags.ts`: Tag transient Copilot 403 as `Flag.Transient` and exclude from `Flag.AuthFailed`.
- `src/error/retryable.ts`: Mark transient Copilot 403s as provider-retryable.
- `src/error/rate-limit.ts`, `src/error/auth-classify.ts`, `src/stream.ts`: Exclude transient 403 from fatal credential invalidation.
- `test/github-copilot-transport.test.ts`: Add transport mock-fetch tests for transient 403 retry, non-matching 403 single attempt, body preservation on exhaustion, bounded auto-mode fallback, and clean final header bags.
- `CHANGELOG.md`: Add `[Unreleased]` entry.

**`packages/coding-agent`**
- `src/config/settings-schema.ts`: Register `providers.copilot.mode` setting enum (`auto`, `vscode`, `cli`).
- `src/session/settings-stream-fn.ts`: Inject `Copilot-Mode` header only when caller leaves wire identity unspecified.
- `test/settings-stream-fn.test.ts`: Add unit tests for settings injection and caller precedence.
- `CHANGELOG.md`: Add `[Unreleased]` entry.

**`packages/utils`**
- `src/fetch-retry.ts`: Add `isRetryableStatus` option to `FetchWithRetryOptions` and destructure it out of `baseInit`.
- `CHANGELOG.md`: Add `[Unreleased]` entry.

## Verification

- [x] `bun test packages/catalog/test/*copilot* packages/ai/test/*copilot* packages/coding-agent/test/settings-stream-fn.test.ts` (153 pass, 0 fail, 542 expects across 14 files)
- [x] `bun --cwd=packages/ai run check` (0 errors, 0 warnings, formatting clean)
- [x] `bun --cwd=packages/catalog run check` (0 errors, 0 warnings, formatting clean)
- [x] `bun --cwd=packages/utils run check` (0 errors, 0 warnings, formatting clean)
- [x] `bun --cwd=packages/coding-agent run check` (0 errors, formatting clean)
- [x] Live end-to-end verification against Copilot API confirming bounded auto-mode fallback and zero fallback to Gemini.
