### PR TITLE
fix(ai): preserve opaque Responses call ids

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Gemini 3 tool continuations through OpenAI Responses relays by preserving provider call IDs verbatim ([#10749](https://github.com/can1357/oh-my-pi/issues/10749)).
+
 ## [18.1.8] - 2026-09-03
 
 ### Added

--- a/packages/ai/src/utils.ts
+++ b/packages/ai/src/utils.ts
@@ -46,18 +46,11 @@ export function normalizeResponsesToolCallId(
 ): { callId: string; itemId: string } {
 	const [callId, itemId] = id.split("|");
 	if (callId && itemId) {
-		const normalizedCallId = truncateResponseItemId(callId, getIdPrefix(callId, "call"));
-		const normalizedItemId = normalizeResponsesItemId(itemId, itemPrefix);
-		return { callId: normalizedCallId, itemId: normalizedItemId };
+		return { callId, itemId: normalizeResponsesItemId(itemId, itemPrefix) };
 	}
 	const hash = Bun.hash(id).toString(36);
 	const normalizedCallId = id.startsWith("call_") ? truncateResponseItemId(id, "call") : `call_${hash}`;
 	return { callId: normalizedCallId, itemId: `${itemPrefix}_${hash}` };
-}
-
-function getIdPrefix(id: string, fallback: string): string {
-	const prefix = id.match(/^([a-zA-Z][a-zA-Z0-9]*)_/)?.[1];
-	return prefix || fallback;
 }
 
 function getExplicitIdPrefix(id: string): string | undefined {
@@ -224,7 +217,6 @@ export function sanitizeOpenAIResponsesHistoryItemsForReplay(
 	items: Array<Record<string, unknown>>,
 	options: OpenAIResponsesReplaySanitizeOptions = {},
 ): ResponseInput {
-	const normalizedCallIds = new Map<string, string>();
 	const supportsImageDetailOriginal = options.supportsImageDetailOriginal !== false;
 	const computerLinkedReasoningItems =
 		options.supportsComputerUse === false
@@ -234,7 +226,6 @@ export function sanitizeOpenAIResponsesHistoryItemsForReplay(
 		const preserveForComputer = computerLinkedReasoningItems?.has(item) === true;
 		const sanitizedItem = sanitizeOpenAIResponsesHistoryItemForReplay(
 			item,
-			normalizedCallIds,
 			supportsImageDetailOriginal,
 			preserveForComputer,
 		);
@@ -407,7 +398,6 @@ export function sanitizeOpenAIResponsesAssistantFallbackItemsForReplay(items: Re
 
 function sanitizeOpenAIResponsesHistoryItemForReplay(
 	item: Record<string, unknown>,
-	normalizedCallIds: Map<string, string>,
 	supportsImageDetailOriginal: boolean,
 	preserveReasoningItemIds: boolean,
 ): OpenAIResponsesReplayItem | undefined {
@@ -426,9 +416,6 @@ function sanitizeOpenAIResponsesHistoryItemForReplay(
 	}
 	const { id: _id, ...sanitizedItem } = item;
 	if (item.type === "computer_call" && typeof item.id === "string") sanitizedItem.id = item.id;
-	if (typeof item.call_id === "string") {
-		sanitizedItem.call_id = normalizeReplayedResponsesHistoryCallId(item.call_id, normalizedCallIds);
-	}
 
 	return clampReplayItemImageDetail(
 		sanitizedItem,
@@ -462,14 +449,6 @@ function sanitizeOpenAIResponsesImageGenerationCallForReplay(
 		status: "completed",
 		result: item.result,
 	};
-}
-
-function normalizeReplayedResponsesHistoryCallId(value: string, normalizedValues: Map<string, string>): string {
-	const normalized = normalizedValues.get(value);
-	if (normalized) return normalized;
-	const next = truncateResponseItemId(value, getIdPrefix(value, "call"));
-	normalizedValues.set(value, next);
-	return next;
 }
 
 export function createOpenAIResponsesHistoryPayload(

--- a/packages/ai/test/openai-responses-history-payload.test.ts
+++ b/packages/ai/test/openai-responses-history-payload.test.ts
@@ -7,7 +7,7 @@ import {
 import { type OpenAIResponsesOptions, streamOpenAIResponses } from "@oh-my-pi/pi-ai/providers/openai-responses";
 import { buildResponsesInput } from "@oh-my-pi/pi-ai/providers/openai-shared";
 import type { Context, Model, ModelSpec, ProviderSessionState, Tool } from "@oh-my-pi/pi-ai/types";
-import { createOpenAIResponsesHistoryPayload, truncateResponseItemId } from "@oh-my-pi/pi-ai/utils";
+import { createOpenAIResponsesHistoryPayload } from "@oh-my-pi/pi-ai/utils";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { type GeneratedProvider, getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import * as piUtils from "@oh-my-pi/pi-utils";
@@ -1182,12 +1182,12 @@ describe("OpenAI responses history payload", () => {
 		]);
 	});
 
-	it("strips output-only replay metadata while preserving paired call_id values", async () => {
+	it("strips output-only replay metadata while echoing opaque call_id values verbatim", async () => {
 		const opaqueReasoningId = `item_${"copilot/reasoning+token=".repeat(8)}`;
 		const opaqueMessageId = `item_${"copilot/message+opaque=".repeat(8)}`;
-		const opaqueCallId = `call_${"copilot/tool-call+opaque/=".repeat(8)}`;
+		const opaqueCallId = `googleai-ts1:${"function-signature.".repeat(12)}`;
 		const opaqueFunctionItemId = `item_${"copilot/function-item+opaque/=".repeat(8)}`;
-		const opaqueCustomCallId = `call_${"copilot/custom-call+opaque/=".repeat(8)}`;
+		const opaqueCustomCallId = `googleai-ts1:${"custom-signature.".repeat(12)}`;
 		const opaqueCustomItemId = `item_${"copilot/custom-item+opaque/=".repeat(8)}`;
 		const replayHistoryItems: Array<Record<string, unknown>> = [
 			{ type: "reasoning", id: opaqueReasoningId, encrypted_content: "enc_opaque", status: "completed" },
@@ -1249,7 +1249,6 @@ describe("OpenAI responses history payload", () => {
 		const itemReference = findResponsesInputItem(payload.input, "item_reference");
 		const compactionItem = findResponsesInputItem(payload.input, "compaction");
 		const compactionSummaryItem = findResponsesInputItem(payload.input, "compaction_summary");
-		const expectedCallId = truncateResponseItemId(opaqueCallId, "call");
 
 		expect(reasoningItem).toBeDefined();
 		expect(messageItem).toBeDefined();
@@ -1276,10 +1275,9 @@ describe("OpenAI responses history payload", () => {
 		expect(compactionItem?.encrypted_content).toBe("encrypted-compaction");
 		expect(compactionSummaryItem?.summary).toBe("compacted context");
 		expect(functionCallItem).toBeDefined();
-		expect(functionCallItem!.call_id).toBe(expectedCallId);
-		expect(functionCallOutputItem?.call_id).toBe(expectedCallId);
-		expect(customToolCallItem?.call_id).toBe(truncateResponseItemId(opaqueCustomCallId, "call"));
-		expect((functionCallItem!.call_id as string).length).toBeLessThanOrEqual(64);
+		expect(functionCallItem!.call_id).toBe(opaqueCallId);
+		expect(functionCallOutputItem?.call_id).toBe(opaqueCallId);
+		expect(customToolCallItem?.call_id).toBe(opaqueCustomCallId);
 		expect(containsAssistantOutputText(payload.input, "Sanitized assistant answer")).toBe(true);
 		expect(replayHistoryItems[0]?.id).toBe(opaqueReasoningId);
 		expect(replayHistoryItems[1]?.id).toBe(opaqueMessageId);

--- a/packages/ai/test/utils-responses-id.test.ts
+++ b/packages/ai/test/utils-responses-id.test.ts
@@ -2,14 +2,13 @@ import { describe, expect, it } from "bun:test";
 import { normalizeResponsesToolCallId } from "@oh-my-pi/pi-ai/utils";
 
 describe("normalizeResponsesToolCallId", () => {
-	it("preserves existing item prefix when truncating oversized ids", () => {
-		const callId = `call_${"a".repeat(80)}`;
+	it("preserves opaque call ids while truncating oversized item ids", () => {
+		const callId = `googleai-ts1:${"a".repeat(80)}.signature`;
 		const itemId = `fcr_${"b".repeat(120)}`;
 
 		const normalized = normalizeResponsesToolCallId(`${callId}|${itemId}`);
 
-		expect(normalized.callId.startsWith("call_")).toBe(true);
-		expect(normalized.callId.length).toBeLessThanOrEqual(64);
+		expect(normalized.callId).toBe(callId);
 		expect(normalized.itemId.startsWith("fcr_")).toBe(true);
 		expect(normalized.itemId.length).toBeLessThanOrEqual(64);
 	});


### PR DESCRIPTION
## Repro
A Responses tool call carrying a 197-byte `googleai-ts1:…` ID reproduces the failure with `bun -e 'import { normalizeResponsesToolCallId } from "./packages/ai/src/utils.ts"; const callId = `googleai-ts1:${"A".repeat(180)}.sig`; console.log(normalizeResponsesToolCallId(`${callId}|fc_1`).callId)'`: before the fix the replayed value was `call_2zrqvy2brw9da` rather than the provider ID.

## Cause
`normalizeResponsesToolCallId` and `sanitizeOpenAIResponsesHistoryItemsForReplay` in `packages/ai/src/utils.ts` applied the Responses item-ID 64-byte limit to `call_id`; long signature-bearing provider IDs were therefore hashed before both the function call and its output were replayed.

## Fix
- Preserve the provider `call_id` component verbatim while continuing to normalize the separate response item ID.
- Stop rewriting `call_id` values in native Responses history sanitization.
- Cover both reconstructed and native-history replay with long Gemini-style opaque IDs.
- Document the fix in the AI package changelog.

## Verification
`bun test packages/ai/test/utils-responses-id.test.ts packages/ai/test/openai-responses-history-payload.test.ts packages/ai/test/transform-messages-dedup.test.ts` passes: 42 tests, 0 failures. The original 197-byte replay probe now reports `unchanged: true`. The pre-publish `bun run fix` and `bun check` gate passed. Fixes #10749