### PR TITLE
fix(coding-agent): stop idle subagents ping-ponging wake-turn relays

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,6 +12,9 @@
 - Fixed the Model Hub sidebar jumping to the top when provider refreshes rebuild the list; the focused model, or its nearest remaining entry, is now preserved.
 - Fixed the `inspect_image` status hint showing the wrong model after switching between image-capable model roles.
 - Fixed multi-minute TUI freezes during subagent activity and batch execution.
+### Fixed
+
+- Fixed two idle subagents exchanging a single IRC message ping-ponging forever: wake-turn relays are now tagged and never relayed back, so each automated relay is delivered exactly once instead of waking a reciprocal relay until manual cancellation.
 
 ## [18.1.7] - 2026-09-03
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed two idle subagents exchanging a single IRC message ping-ponging forever: wake-turn relays are now tagged and never relayed back, so each automated relay is delivered exactly once instead of waking a reciprocal relay until manual cancellation.
+
 ## [18.1.8] - 2026-09-03
 
 ### Fixed
@@ -12,9 +16,6 @@
 - Fixed the Model Hub sidebar jumping to the top when provider refreshes rebuild the list; the focused model, or its nearest remaining entry, is now preserved.
 - Fixed the `inspect_image` status hint showing the wrong model after switching between image-capable model roles.
 - Fixed multi-minute TUI freezes during subagent activity and batch execution.
-### Fixed
-
-- Fixed two idle subagents exchanging a single IRC message ping-ponging forever: wake-turn relays are now tagged and never relayed back, so each automated relay is delivered exactly once instead of waking a reciprocal relay until manual cancellation.
 
 ## [18.1.7] - 2026-09-03
 

--- a/packages/coding-agent/src/irc/bus.ts
+++ b/packages/coding-agent/src/irc/bus.ts
@@ -32,6 +32,13 @@ export interface IrcMessage {
 	ts: number;
 	/** Message id being answered. */
 	replyTo?: string;
+	/**
+	 * Automated wake-turn relay of a woken subagent's stop output (task executor
+	 * `relayWakeTurnOutput`). Relays are answers, never wake sources: the
+	 * recipient's own wake-turn relay must skip them or two idle peers
+	 * ping-pong forever.
+	 */
+	wakeRelay?: boolean;
 }
 
 export interface IrcDeliveryReceipt {

--- a/packages/coding-agent/src/session/irc-bridge.ts
+++ b/packages/coding-agent/src/session/irc-bridge.ts
@@ -164,7 +164,7 @@ export class IrcBridge {
 		// An idle subagent runs a monitored wake turn whose output is relayed
 		// back to the sender (task executor `relayWakeTurnOutput`); the main
 		// agent and mid-turn asides have no such relay.
-		const relayOnStop = !streaming && !planModeIdle && msg.to !== MAIN_AGENT_ID;
+		const relayOnStop = !streaming && !planModeIdle && msg.to !== MAIN_AGENT_ID && msg.wakeRelay !== true;
 		const record: CustomMessage = {
 			role: "custom",
 			customType: "irc:incoming",
@@ -177,7 +177,13 @@ export class IrcBridge {
 				relayOnStop,
 			}),
 			display: true,
-			details: { id: msg.id, from: msg.from, message: msg.body, ...(msg.replyTo ? { replyTo: msg.replyTo } : {}) },
+			details: {
+				id: msg.id,
+				from: msg.from,
+				message: msg.body,
+				...(msg.replyTo ? { replyTo: msg.replyTo } : {}),
+				...(msg.wakeRelay ? { wakeRelay: true } : {}),
+			},
 			attribution: "agent",
 			timestamp: msg.ts,
 		};

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -2461,6 +2461,9 @@ function wakeSources(records: AgentMessage[], selfId: string): WakeSource[] {
 		const details = record.details && typeof record.details === "object" ? record.details : undefined;
 		const from = details ? Reflect.get(details, "from") : undefined;
 		if (typeof from !== "string" || from === selfId || sources.some(source => source.from === from)) continue;
+		// Automated wake-turn relays are answers, not wake sources: relaying one
+		// back would ping-pong two idle peers forever.
+		if (details && Reflect.get(details, "wakeRelay") === true) continue;
 		const messageId = details ? Reflect.get(details, "id") : undefined;
 		sources.push({ from, messageId: typeof messageId === "string" ? messageId : undefined });
 	}
@@ -2495,7 +2498,13 @@ async function relayWakeTurnOutput(args: {
 			: args.turnText.trim();
 	if (!body) return;
 	for (const source of pending) {
-		const receipt = await bus.send({ from: args.id, to: source.from, body, replyTo: source.messageId });
+		const receipt = await bus.send({
+			from: args.id,
+			to: source.from,
+			body,
+			replyTo: source.messageId,
+			wakeRelay: true,
+		});
 		if (receipt.outcome === "failed") {
 			logger.warn("IRC wake-turn relay failed", { from: args.id, to: source.from, error: receipt.error });
 		}

--- a/packages/coding-agent/test/session/irc-bridge-relay.test.ts
+++ b/packages/coding-agent/test/session/irc-bridge-relay.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "bun:test";
+import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
+import { IrcBridge, type IrcBridgeHost } from "@oh-my-pi/pi-coding-agent/session/irc-bridge";
+import type { CustomMessage } from "@oh-my-pi/pi-coding-agent/session/messages";
+
+function makeBridge() {
+	const woken: AgentMessage[][] = [];
+	const host = {
+		isDisposed: () => false,
+		isStreaming: () => false,
+		planModeEnabled: () => false,
+		emitSessionEvent: async () => {},
+		wakeForIrc: (records: AgentMessage[]) => {
+			woken.push(records);
+		},
+	} as unknown as IrcBridgeHost;
+	return { bridge: new IrcBridge(host), woken };
+}
+
+describe("IrcBridge wake-relay marking", () => {
+	it("marks relay messages so the peer never relays them back", async () => {
+		const { bridge, woken } = makeBridge();
+		const outcome = await bridge.deliver(
+			{ id: "irc-1", from: "B", to: "A", body: "You hang up", ts: Date.now(), wakeRelay: true },
+			undefined,
+		);
+
+		expect(outcome).toBe("woken");
+		expect(woken).toHaveLength(1);
+		const record = woken[0][0] as CustomMessage;
+		expect(record.details).toMatchObject({ from: "B", wakeRelay: true });
+		// The model-facing card must not promise a relay that will never come.
+		expect(record.content).toContain("No one replies on your behalf");
+	});
+
+	it("still advertises the stop relay for genuine messages", async () => {
+		const { bridge, woken } = makeBridge();
+		await bridge.deliver({ id: "irc-2", from: "B", to: "A", body: "status?", ts: Date.now() }, undefined);
+
+		const record = woken[0][0] as CustomMessage;
+		expect(record.details).not.toHaveProperty("wakeRelay");
+		expect(record.content).toContain("is delivered to");
+	});
+});

--- a/packages/coding-agent/test/task/persisted-revive.test.ts
+++ b/packages/coding-agent/test/task/persisted-revive.test.ts
@@ -15,7 +15,7 @@ import type { CustomMessage } from "@oh-my-pi/pi-coding-agent/session/messages";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import { createPersistedSubagentReviverFactory } from "@oh-my-pi/pi-coding-agent/task/persisted-revive";
 import { EventBus } from "@oh-my-pi/pi-coding-agent/utils/event-bus";
-import { IrcBus } from "@oh-my-pi/pi-coding-agent/irc/bus";
+import { IrcBus, type IrcMessage } from "@oh-my-pi/pi-coding-agent/irc/bus";
 import { TempDir } from "@oh-my-pi/pi-utils";
 
 const tempDirs: TempDir[] = [];
@@ -617,6 +617,44 @@ describe("persisted subagent revival", () => {
 			await handle.trackedReplies[0];
 
 			expect(await duplicate).toBeNull();
+			AgentLifecycleManager.resetGlobalForTests();
+			AgentRegistry.resetGlobalForTests();
+			IrcBus.resetGlobalForTests();
+		});
+		it("never relays a wake turn woken by another relay", async () => {
+			// Two idle subagents exchanging one message used to ping-pong forever:
+			// each relay woke the peer, whose stop-text was relayed straight back.
+			// Relay messages are answers, not wake sources, so the echo stops here.
+			const cwd = makeTempDir("@pi-revive-relay-echo-");
+			const { handle } = await reviveWithWaker(cwd);
+			const observer = handle.observer();
+			expect(observer).toBeDefined();
+
+			// A live peer captures whatever the turn relays instead of a null
+			// `bus.wait`: fully deterministic, no timer dependence.
+			const delivered: IrcMessage[] = [];
+			AgentRegistry.global().register({
+				id: "Peer",
+				displayName: "Peer",
+				kind: "sub",
+				status: "idle",
+				session: {
+					deliverIrcMessage: async (msg: IrcMessage) => {
+						delivered.push(msg);
+						return "injected" as const;
+					},
+				} as unknown as AgentSession,
+			});
+			const relayRecord: CustomMessage = {
+				...wakeRecord("Peer"),
+				details: { id: "irc-43", from: "Peer", message: "You hang up", wakeRelay: true },
+			};
+			const finish = observer?.([relayRecord]);
+			handle.setLastAssistantText("No YOU hang up");
+			await finish?.();
+			await handle.trackedReplies[0];
+
+			expect(delivered).toHaveLength(0);
 			AgentLifecycleManager.resetGlobalForTests();
 			AgentRegistry.resetGlobalForTests();
 			IrcBus.resetGlobalForTests();


### PR DESCRIPTION
## What

`relayWakeTurnOutput` relayed an awoken subagent's stop text back to the
sender on every IRC wake, including wakes caused by a previous relay, so
two idle peers exchanging one message echoed forever. Relays are now
tagged (`IrcMessage.wakeRelay`, propagated into the `irc:incoming`
record) and skipped as wake sources; the incoming card tells the model
no one replies on its behalf.

- `src/irc/bus.ts`: new optional `IrcMessage.wakeRelay` marker.
- `src/session/irc-bridge.ts`: `relayOnStop` gated on `!msg.wakeRelay`,
  marker propagated into record details (no template change needed —
  `relayOnStop: false` already renders "No one replies on your behalf").
- `src/task/executor.ts`: `wakeSources()` skips relay-marked records;
  relay sends set `wakeRelay: true`.
- Tests: `test/session/irc-bridge-relay.test.ts` (marker production +
  card text); wake-turn-relay case in `test/task/persisted-revive.test.ts`
  asserting via a capturing peer session (deterministic, no timer
  dependence).

## Why

Commit `c878baf0` introduced the wake-turn relay with only a
`sentSince(id, peer, turnStartTime)` guard, which checks sends *during
the current turn* — a previous turn's relay always predates it. Two idle
subagents exchanging a single message loop "You hang up" / "No YOU hang
up" until manually cancelled, burning tokens unattended.

## Testing

- Red/green: without the fix the new regression test captures the echo
  (`delivered` length 1); with it, silence. Bridge marker tests fail
  before, pass after.
- Existing wake-turn relay test ("delivers the turn's final text")
  still passes; `check:types`, `lint`, `oxfmt --check` clean.
- Note: `IrcBus.wait` calls that must *expire* hang on a Windows dev
  box without built natives (pre-existing, also affects "stays silent"
  locally); full suites run in CI where natives are built via bazel.

---

- [X] `bun check` passes
- [X] Tested locally
- [X] CHANGELOG updated (if user-facing)