### PR TITLE
fix(natives): stopped a stale WAYLAND_DISPLAY from hiding the X11 desktop backend

### DIFF
--- a/crates/pi-natives/src/desktop/linux/mod.rs
+++ b/crates/pi-natives/src/desktop/linux/mod.rs
@@ -2,7 +2,7 @@ pub mod ax;
 pub mod wayland;
 pub mod x11;
 
-use std::{ffi::OsStr, os::unix::fs::FileTypeExt, path::Path};
+use std::{ffi::OsStr, mem::MaybeUninit, os::unix::net::UnixStream, path::Path};
 
 use super::{
 	backend::Backend,
@@ -11,7 +11,7 @@ use super::{
 };
 
 pub fn new_backend(display: DisplaySelector) -> CoreResult<Box<dyn Backend>> {
-	let wayland = wayland_socket_exists(
+	let wayland = wayland_reachable(
 		std::env::var_os("WAYLAND_SOCKET").as_deref(),
 		std::env::var_os("WAYLAND_DISPLAY").as_deref(),
 		std::env::var_os("XDG_RUNTIME_DIR").as_deref(),
@@ -27,17 +27,18 @@ pub fn new_backend(display: DisplaySelector) -> CoreResult<Box<dyn Backend>> {
 	))
 }
 
-/// Check for a Wayland compositor the way libwayland does. `WAYLAND_SOCKET` is
-/// an inherited connection. An absolute `WAYLAND_DISPLAY` is the socket path.
-/// A relative one lives under `XDG_RUNTIME_DIR`. The path has to be a unix
-/// socket, so a name left over from a dead session, an empty value, or a name
-/// a wrapper script set for its own reasons cannot hide a live X11 display.
-fn wayland_socket_exists(
+/// Check for a Wayland compositor the way libwayland connects. A valid
+/// `WAYLAND_SOCKET` is an inherited socket descriptor. Otherwise an absolute
+/// `WAYLAND_DISPLAY` is the socket path and a relative one lives under
+/// `XDG_RUNTIME_DIR`, and something has to accept a connection there. A stale
+/// name, an orphaned socket file, an empty value, or a descriptor that is
+/// closed or not a socket cannot hide a live X11 display.
+fn wayland_reachable(
 	socket_fd: Option<&OsStr>,
 	display: Option<&OsStr>,
 	runtime_dir: Option<&OsStr>,
 ) -> bool {
-	if socket_fd.is_some() {
+	if socket_fd.is_some_and(is_socket_fd) {
 		return true;
 	}
 	let Some(display) = display.filter(|display| !display.is_empty()) else {
@@ -45,18 +46,44 @@ fn wayland_socket_exists(
 	};
 	let display = Path::new(display);
 	if display.is_absolute() {
-		return is_socket(display);
+		return UnixStream::connect(display).is_ok();
 	}
-	runtime_dir.is_some_and(|runtime_dir| is_socket(&Path::new(runtime_dir).join(display)))
+	runtime_dir
+		.is_some_and(|runtime_dir| UnixStream::connect(Path::new(runtime_dir).join(display)).is_ok())
 }
 
-fn is_socket(path: &Path) -> bool {
-	std::fs::metadata(path).is_ok_and(|metadata| metadata.file_type().is_socket())
+/// libwayland parses `WAYLAND_SOCKET` as a whole-string integer and rejects
+/// descriptors that are not open. Requiring a socket as well rules out numbers
+/// that happen to name some other open file.
+fn is_socket_fd(value: &OsStr) -> bool {
+	let Some(fd) = value
+		.to_str()
+		.and_then(|value| value.parse::<libc::c_int>().ok())
+	else {
+		return false;
+	};
+	let mut stat = MaybeUninit::<libc::stat>::uninit();
+	// SAFETY: `fstat` only writes through the out-pointer and reports EBADF for
+	// a closed or negative descriptor; nothing here takes ownership of `fd`.
+	if unsafe { libc::fstat(fd, stat.as_mut_ptr()) } != 0 {
+		return false;
+	}
+	// SAFETY: a zero return from `fstat` means the struct was fully written.
+	let stat = unsafe { stat.assume_init() };
+	stat.st_mode & libc::S_IFMT == libc::S_IFSOCK
 }
 
 #[cfg(test)]
 mod tests {
-	use std::{ffi::OsString, os::unix::net::UnixListener, path::PathBuf};
+	use std::{
+		ffi::OsString,
+		fs::File,
+		os::{
+			fd::AsRawFd,
+			unix::{fs::FileTypeExt, net::UnixListener},
+		},
+		path::PathBuf,
+	};
 
 	use super::*;
 
@@ -86,15 +113,26 @@ mod tests {
 	}
 
 	#[test]
-	fn ignores_wayland_display_without_socket() {
-		let runtime = RuntimeDir::new("no-socket");
+	fn ignores_wayland_display_without_listener() {
+		let runtime = RuntimeDir::new("no-listener");
 		std::fs::write(runtime.0.join("plain-file"), b"").expect("write file");
+		let orphan = runtime.0.join("orphan");
+		drop(UnixListener::bind(&orphan).expect("bind socket"));
+		assert!(
+			std::fs::metadata(&orphan)
+				.expect("orphan socket file")
+				.file_type()
+				.is_socket(),
+			"dropping the listener must leave the socket inode behind"
+		);
 
-		assert!(!wayland_socket_exists(None, None, Some(runtime.as_os_str())));
-		assert!(!wayland_socket_exists(None, Some(&os("")), Some(runtime.as_os_str())));
-		assert!(!wayland_socket_exists(None, Some(&os("wayland-0")), Some(runtime.as_os_str())));
-		assert!(!wayland_socket_exists(None, Some(&os("wayland-0")), None));
-		assert!(!wayland_socket_exists(None, Some(&os("plain-file")), Some(runtime.as_os_str())));
+		assert!(!wayland_reachable(None, None, Some(runtime.as_os_str())));
+		assert!(!wayland_reachable(None, Some(&os("")), Some(runtime.as_os_str())));
+		assert!(!wayland_reachable(None, Some(&os("wayland-0")), Some(runtime.as_os_str())));
+		assert!(!wayland_reachable(None, Some(&os("wayland-0")), None));
+		assert!(!wayland_reachable(None, Some(&os("plain-file")), Some(runtime.as_os_str())));
+		assert!(!wayland_reachable(None, Some(&os("orphan")), Some(runtime.as_os_str())));
+		assert!(!wayland_reachable(None, Some(orphan.as_os_str()), None));
 	}
 
 	#[test]
@@ -102,7 +140,7 @@ mod tests {
 		let runtime = RuntimeDir::new("relative");
 		let _listener = UnixListener::bind(runtime.0.join("wayland-0")).expect("bind socket");
 
-		assert!(wayland_socket_exists(None, Some(&os("wayland-0")), Some(runtime.as_os_str())));
+		assert!(wayland_reachable(None, Some(&os("wayland-0")), Some(runtime.as_os_str())));
 	}
 
 	#[test]
@@ -111,11 +149,32 @@ mod tests {
 		let socket = runtime.0.join("compositor.sock");
 		let _listener = UnixListener::bind(&socket).expect("bind socket");
 
-		assert!(wayland_socket_exists(None, Some(socket.as_os_str()), None));
+		assert!(wayland_reachable(None, Some(socket.as_os_str()), None));
 	}
 
 	#[test]
 	fn accepts_inherited_wayland_socket_fd() {
-		assert!(wayland_socket_exists(Some(&os("3")), None, None));
+		let (socket, _peer) = UnixStream::pair().expect("socketpair");
+
+		assert!(wayland_reachable(Some(&os(&socket.as_raw_fd().to_string())), None, None));
+	}
+
+	#[test]
+	fn ignores_invalid_wayland_socket_fd() {
+		let runtime = RuntimeDir::new("bad-fd");
+		let file = File::create(runtime.0.join("plain-file")).expect("create file");
+		let (socket, _peer) = UnixStream::pair().expect("socketpair");
+		// Park the duplicate above the range the rest of the test process
+		// allocates from, so the number stays closed once it is closed.
+		// SAFETY: duplicates a descriptor owned by `socket`; the copy is closed
+		// below and nothing else references it.
+		let closed = unsafe { libc::fcntl(socket.as_raw_fd(), libc::F_DUPFD_CLOEXEC, 512) };
+		assert!(closed >= 512, "dup failed: {}", std::io::Error::last_os_error());
+		// SAFETY: `closed` is the duplicate created above.
+		assert_eq!(unsafe { libc::close(closed) }, 0);
+
+		for value in ["", " ", "x", "3x", "-1", &closed.to_string(), &file.as_raw_fd().to_string()] {
+			assert!(!wayland_reachable(Some(&os(value)), None, None), "WAYLAND_SOCKET={value:?}");
+		}
 	}
 }

--- a/crates/pi-natives/src/desktop/linux/mod.rs
+++ b/crates/pi-natives/src/desktop/linux/mod.rs
@@ -2,6 +2,8 @@ pub mod ax;
 pub mod wayland;
 pub mod x11;
 
+use std::{ffi::OsStr, os::unix::fs::FileTypeExt, path::Path};
+
 use super::{
 	backend::Backend,
 	error::{CoreResult, DesktopError},
@@ -9,13 +11,111 @@ use super::{
 };
 
 pub fn new_backend(display: DisplaySelector) -> CoreResult<Box<dyn Backend>> {
-	if std::env::var_os("WAYLAND_DISPLAY").is_some() {
+	let wayland = wayland_socket_exists(
+		std::env::var_os("WAYLAND_SOCKET").as_deref(),
+		std::env::var_os("WAYLAND_DISPLAY").as_deref(),
+		std::env::var_os("XDG_RUNTIME_DIR").as_deref(),
+	);
+	if wayland {
 		return Ok(Box::new(wayland::WaylandBackend::new(display)));
 	}
 	if std::env::var_os("DISPLAY").is_some() {
 		return Ok(Box::new(x11::X11Backend::new(display)?));
 	}
 	Err(DesktopError::capture_failed(
-		"no display server (neither WAYLAND_DISPLAY nor DISPLAY is set)",
+		"no display server reachable (no Wayland socket and DISPLAY is not set)",
 	))
+}
+
+/// Check for a Wayland compositor the way libwayland does. `WAYLAND_SOCKET` is
+/// an inherited connection. An absolute `WAYLAND_DISPLAY` is the socket path.
+/// A relative one lives under `XDG_RUNTIME_DIR`. The path has to be a unix
+/// socket, so a name left over from a dead session, an empty value, or a name
+/// a wrapper script set for its own reasons cannot hide a live X11 display.
+fn wayland_socket_exists(
+	socket_fd: Option<&OsStr>,
+	display: Option<&OsStr>,
+	runtime_dir: Option<&OsStr>,
+) -> bool {
+	if socket_fd.is_some() {
+		return true;
+	}
+	let Some(display) = display.filter(|display| !display.is_empty()) else {
+		return false;
+	};
+	let display = Path::new(display);
+	if display.is_absolute() {
+		return is_socket(display);
+	}
+	runtime_dir.is_some_and(|runtime_dir| is_socket(&Path::new(runtime_dir).join(display)))
+}
+
+fn is_socket(path: &Path) -> bool {
+	std::fs::metadata(path).is_ok_and(|metadata| metadata.file_type().is_socket())
+}
+
+#[cfg(test)]
+mod tests {
+	use std::{ffi::OsString, os::unix::net::UnixListener, path::PathBuf};
+
+	use super::*;
+
+	struct RuntimeDir(PathBuf);
+
+	impl RuntimeDir {
+		fn new(test: &str) -> Self {
+			let path = std::env::temp_dir().join(format!("omp-wayland-{test}-{}", std::process::id()));
+			let _ = std::fs::remove_dir_all(&path);
+			std::fs::create_dir_all(&path).expect("create runtime dir");
+			Self(path)
+		}
+
+		fn as_os_str(&self) -> &OsStr {
+			self.0.as_os_str()
+		}
+	}
+
+	impl Drop for RuntimeDir {
+		fn drop(&mut self) {
+			let _ = std::fs::remove_dir_all(&self.0);
+		}
+	}
+
+	fn os(value: &str) -> OsString {
+		OsString::from(value)
+	}
+
+	#[test]
+	fn ignores_wayland_display_without_socket() {
+		let runtime = RuntimeDir::new("no-socket");
+		std::fs::write(runtime.0.join("plain-file"), b"").expect("write file");
+
+		assert!(!wayland_socket_exists(None, None, Some(runtime.as_os_str())));
+		assert!(!wayland_socket_exists(None, Some(&os("")), Some(runtime.as_os_str())));
+		assert!(!wayland_socket_exists(None, Some(&os("wayland-0")), Some(runtime.as_os_str())));
+		assert!(!wayland_socket_exists(None, Some(&os("wayland-0")), None));
+		assert!(!wayland_socket_exists(None, Some(&os("plain-file")), Some(runtime.as_os_str())));
+	}
+
+	#[test]
+	fn accepts_relative_socket_under_runtime_dir() {
+		let runtime = RuntimeDir::new("relative");
+		let _listener = UnixListener::bind(runtime.0.join("wayland-0")).expect("bind socket");
+
+		assert!(wayland_socket_exists(None, Some(&os("wayland-0")), Some(runtime.as_os_str())));
+	}
+
+	#[test]
+	fn accepts_absolute_socket_path() {
+		let runtime = RuntimeDir::new("absolute");
+		let socket = runtime.0.join("compositor.sock");
+		let _listener = UnixListener::bind(&socket).expect("bind socket");
+
+		assert!(wayland_socket_exists(None, Some(socket.as_os_str()), None));
+	}
+
+	#[test]
+	fn accepts_inherited_wayland_socket_fd() {
+		assert!(wayland_socket_exists(Some(&os("3")), None, None));
+	}
 }

--- a/docs/computer-use.md
+++ b/docs/computer-use.md
@@ -27,7 +27,7 @@ tools:
 | `computer.maxWidth`  |  `3840` | Maximum screenshot width. Some model transports impose an effective coordinate-safe cap of 1280.                  |
 | `computer.maxHeight` |  `2400` | Maximum screenshot height. Some model transports impose an effective coordinate-safe cap of 896.                  |
 
-There is no `computer.backend` setting: the native addon selects the platform backend. On Linux it picks Wayland when `WAYLAND_SOCKET` is set or `WAYLAND_DISPLAY` names a socket that exists. Otherwise it picks X11 when `DISPLAY` is set. The `/computer`, `/computer on`, `/computer off`, and `/computer status` commands toggle or inspect the current session without writing config. Start a new session after changing settings files.
+There is no `computer.backend` setting: the native addon selects the platform backend. On Linux it picks Wayland when `WAYLAND_SOCKET` is an open socket descriptor or `WAYLAND_DISPLAY` names a socket that accepts connections. Otherwise it picks X11 when `DISPLAY` is set. The `/computer`, `/computer on`, `/computer off`, and `/computer status` commands toggle or inspect the current session without writing config. Start a new session after changing settings files.
 
 `tools.approvalMode: write` allows inspection helpers (window listing, screenshots, AX reads, clipboard reads) and `computer.run` calls declared with `read_only: true`; it prompts for input and mutation helpers. An explicit `tools.approval.computer: allow | prompt | deny` overrides the mode.
 

--- a/docs/computer-use.md
+++ b/docs/computer-use.md
@@ -27,7 +27,7 @@ tools:
 | `computer.maxWidth`  |  `3840` | Maximum screenshot width. Some model transports impose an effective coordinate-safe cap of 1280.                  |
 | `computer.maxHeight` |  `2400` | Maximum screenshot height. Some model transports impose an effective coordinate-safe cap of 896.                  |
 
-There is no `computer.backend` setting: the native addon selects the platform backend. The `/computer`, `/computer on`, `/computer off`, and `/computer status` commands toggle or inspect the current session without writing config. Start a new session after changing settings files.
+There is no `computer.backend` setting: the native addon selects the platform backend. On Linux it picks Wayland when `WAYLAND_SOCKET` is set or `WAYLAND_DISPLAY` names a socket that exists. Otherwise it picks X11 when `DISPLAY` is set. The `/computer`, `/computer on`, `/computer off`, and `/computer status` commands toggle or inspect the current session without writing config. Start a new session after changing settings files.
 
 `tools.approvalMode: write` allows inspection helpers (window listing, screenshots, AX reads, clipboard reads) and `computer.run` calls declared with `read_only: true`; it prompts for input and mutation helpers. An explicit `tools.approval.computer: allow | prompt | deny` overrides the mode.
 

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the Linux desktop backend choosing Wayland whenever `WAYLAND_DISPLAY` is set, even when the named socket does not exist. A stale or empty `WAYLAND_DISPLAY` no longer hides a working X11 display from `computer`.
+
 ## [18.1.9] - 2026-09-04
 
 ### Added

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed the Linux desktop backend choosing Wayland whenever `WAYLAND_DISPLAY` is set, even when the named socket does not exist. A stale or empty `WAYLAND_DISPLAY` no longer hides a working X11 display from `computer`.
+- Fixed the Linux desktop backend choosing Wayland whenever `WAYLAND_DISPLAY` or `WAYLAND_SOCKET` is set, even when nothing accepts connections there. A stale, orphaned, or empty value no longer hides a working X11 display from `computer`.
 
 ## [18.1.9] - 2026-09-04
 

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed the Linux desktop backend choosing Wayland whenever `WAYLAND_DISPLAY` or `WAYLAND_SOCKET` is set, even when nothing accepts connections there. A stale, orphaned, or empty value no longer hides a working X11 display from `computer`.
+- Fixed the Linux desktop backend choosing Wayland whenever `WAYLAND_DISPLAY` or `WAYLAND_SOCKET` is set, even when nothing accepts connections there. A stale, orphaned, or empty value no longer hides a working X11 display from `computer` ([#10752](https://github.com/can1357/oh-my-pi/pull/10752) by [@jake8302](https://github.com/jake8302)).
 
 ## [18.1.9] - 2026-09-04
 


### PR DESCRIPTION
## What

On Linux, `new_backend` chose Wayland whenever `WAYLAND_DISPLAY` was set. It never checked that the name pointed at a socket.

It now checks the way libwayland connects. A `WAYLAND_SOCKET` that parses as an integer and names an open socket descriptor means Wayland. Otherwise `WAYLAND_DISPLAY` is resolved (absolute path, or a name under `XDG_RUNTIME_DIR`) and something must accept a connection there. If not, X11 is used when `DISPLAY` is set.

## Why

I hit this in a Lima VM where a wrapper sets WAYLAND_DISPLAY for clipboard forwarding and computer use went dead even though Xvfb was running; I reviewed the diff and the socket check is what I'd expect.

The Wayland backend never opens the socket itself, so a stale name from a dead session, `WAYLAND_DISPLAY=""` (noted in #9935), or a wrapper that sets the variable for its own reasons picked a backend that cannot capture in shipped builds while a working X11 display was ignored. Real Wayland sessions have the socket and are unchanged.

## Testing

Unit tests bind real unix sockets in a temp dir and do not touch the process environment. They cover unset, empty, missing socket, no `XDG_RUNTIME_DIR`, regular file, orphaned socket inode from a dropped listener, relative socket, absolute socket, and `WAYLAND_SOCKET` as a live socketpair, empty, non-numeric, trailing garbage, negative, closed, and a regular-file descriptor.

Built the addon and loaded it through `native/desktop-adapter.js` on a VM with Xvfb on `:99` and `WAYLAND_DISPLAY` naming a socket that does not exist. Shipped 18.1.6: `backend: wayland`, 0 displays, `capture: false`. This branch: `backend: x11`, 1 display, `capture: true`. A live listener at that path selects Wayland; a regular file or an orphaned socket inode there selects X11. `WAYLAND_SOCKET` empty, `abc`, a closed number, or stdin selects X11; an inherited socketpair descriptor selects Wayland.

`cargo fmt --check`, `cargo clippy -p pi-natives --no-deps -- -D warnings`, and all 14 `desktop::linux` tests pass.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)


