### PR TITLE
fix(ai): preserve opaque same-model tool-call ids on anthropic-messages

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed custom `anthropic-messages` providers (e.g. a Gemini proxy that encodes the thought signature in the tool-call id) having same-model tool-call ids mangled to Anthropic's `^[a-zA-Z0-9_-]{1,64}$` charset; opaque ids from non-official endpoints now round-trip verbatim ([#10753](https://github.com/can1357/oh-my-pi/issues/10753)).
+
 ## [18.1.8] - 2026-09-03
 
 ### Added

--- a/packages/ai/src/providers/transform-messages.ts
+++ b/packages/ai/src/providers/transform-messages.ts
@@ -948,12 +948,26 @@ export function transformMessages<TApi extends Api>(
 
 					let normalizedId: string | undefined;
 					if (isAnthropicTarget) {
-						normalizedId = normalizeAnthropicTargetToolCallId(
-							toolCall.id,
-							model,
-							assistantMsg,
-							normalizeToolCallId,
-						);
+						// A same-model tool-call id is the endpoint's own opaque
+						// correlation token and MUST round-trip verbatim: a custom
+						// `anthropic-messages` proxy fronting Gemini encodes the thought
+						// signature in it (#10753), and any id an endpoint minted it will
+						// accept back. Anthropic's `^[a-zA-Z0-9_-]{1,64}$` rule is only
+						// enforced on the wire by official endpoints, so we still
+						// normalize there (a real Claude id already matches, making this
+						// a no-op for genuine data while defending against a foreign id
+						// that slipped in mislabeled as same-model). Cross-model replay
+						// always normalizes — the id is not the target's token. Mirrors
+						// the same-model opaque-id preservation in openai-completions
+						// (#8642) and openai-responses (#10749).
+						if (!isSameModel || model.compat.officialEndpoint) {
+							normalizedId = normalizeAnthropicTargetToolCallId(
+								toolCall.id,
+								model,
+								assistantMsg,
+								normalizeToolCallId,
+							);
+						}
 					} else if (!isSameModel && normalizeToolCallId) {
 						normalizedId = normalizeToolCallId(toolCall.id, model, assistantMsg);
 					}

--- a/packages/ai/test/transform-messages-anthropic-tool-call-id.test.ts
+++ b/packages/ai/test/transform-messages-anthropic-tool-call-id.test.ts
@@ -1,0 +1,109 @@
+// Same-model tool-call ids are opaque provider correlation tokens and must
+// round-trip verbatim on the anthropic-messages send path: a custom
+// `api: anthropic-messages` proxy fronting Gemini encodes the thought
+// signature in the id, so enforcing Anthropic's `^[a-zA-Z0-9_-]{1,64}$` rule
+// unconditionally breaks the round-trip (#10753). Cross-model (foreign-origin)
+// ids still get sanitized to a valid Anthropic id, mirroring the same-model
+// opaque-id preservation already done for openai-completions (#8642) and
+// openai-responses (#10749).
+import { describe, expect, it } from "bun:test";
+import { transformMessages } from "@oh-my-pi/pi-ai/providers/transform-messages";
+import type { AssistantMessage, Message, Model, ModelSpec, ToolResultMessage } from "@oh-my-pi/pi-ai/types";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+
+const ANTHROPIC_TOOL_CALL_ID = /^[a-zA-Z0-9_-]{1,64}$/;
+
+// A Gemini-over-anthropic-messages id: exceeds 64 chars and carries `/` and `=`,
+// none of which Anthropic's id charset permits.
+const GEMINI_ID = `call_abc123/thoughtSignature=CiQBxY9z${"a".repeat(80)}==`;
+
+function makeModel(): Model<"anthropic-messages"> {
+	return buildModel({
+		api: "anthropic-messages",
+		provider: "custom-gemini",
+		id: "gemini-3-pro",
+		name: "Gemini via anthropic-messages proxy",
+		baseUrl: "https://proxy.example.com/anthropic",
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		maxTokens: 8_192,
+		contextWindow: 1_000_000,
+		reasoning: true,
+	} as ModelSpec<"anthropic-messages">);
+}
+
+function assistantWithCall(id: string, source: Partial<AssistantMessage>): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "toolCall", id, name: "get_weather", arguments: { location: "Paris" } }],
+		api: "anthropic-messages",
+		provider: "custom-gemini",
+		model: "gemini-3-pro",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "toolUse",
+		timestamp: 0,
+		...source,
+	};
+}
+
+function toolResult(id: string): ToolResultMessage {
+	return {
+		role: "toolResult",
+		toolCallId: id,
+		toolName: "get_weather",
+		content: [{ type: "text", text: "15C" }],
+		isError: false,
+		timestamp: 0,
+	} as ToolResultMessage;
+}
+
+function emittedIds(messages: Message[], model: Model<"anthropic-messages">) {
+	const transformed = transformMessages(messages, model);
+	const callId = transformed
+		.filter((m): m is AssistantMessage => m.role === "assistant")
+		.flatMap(m => m.content)
+		.find(b => b.type === "toolCall") as { id: string } | undefined;
+	const resultId = transformed.find((m): m is ToolResultMessage => m.role === "toolResult")?.toolCallId;
+	return { callId: callId?.id, resultId };
+}
+
+describe("anthropic-messages tool-call id normalization", () => {
+	it("round-trips a same-model opaque id verbatim, keeping call/result paired", () => {
+		const model = makeModel();
+		const messages: Message[] = [
+			{ role: "user", content: "weather?", timestamp: 0 },
+			assistantWithCall(GEMINI_ID, { provider: "custom-gemini", model: "gemini-3-pro" }),
+			toolResult(GEMINI_ID),
+		];
+
+		const { callId, resultId } = emittedIds(messages, model);
+
+		expect(callId).toBe(GEMINI_ID);
+		expect(resultId).toBe(GEMINI_ID);
+	});
+
+	it("sanitizes a foreign-origin id to a valid Anthropic id on cross-model replay", () => {
+		const model = makeModel();
+		const messages: Message[] = [
+			{ role: "user", content: "weather?", timestamp: 0 },
+			// Different provider/model than the target: the id is not the target's
+			// own correlation token, so it must be normalized to Anthropic's charset.
+			assistantWithCall(GEMINI_ID, { provider: "openai", model: "gpt-4", api: "anthropic-messages" }),
+			toolResult(GEMINI_ID),
+		];
+
+		const { callId, resultId } = emittedIds(messages, model);
+
+		expect(callId).not.toBe(GEMINI_ID);
+		expect(callId).toMatch(ANTHROPIC_TOOL_CALL_ID);
+		// The result must follow the call onto the sanitized id.
+		expect(resultId).toBe(callId);
+	});
+});


### PR DESCRIPTION
## Repro
A custom `api: anthropic-messages` provider fronting a Gemini model encodes the thought signature in the tool-call id. On the next turn, the outbound converter mangles that id. Building such a model (target `provider`/`api`/`id` matching the assistant turn, i.e. same-model replay) and running `convertAnthropicMessages([...same-model Gemini tool call + result...], model, false)` produces:

```
original id:   call_abc123/thoughtSignature=CiQBxY9z...==
wire tool_use: call_abc123_thoughtSignature_CiQBxY9z...   (truncated to 64 chars; `/` and `=` rewritten to `_`)
```

The round-trip the Gemini proxy requires is broken.

## Cause
`transformMessages` (`packages/ai/src/providers/transform-messages.ts`) called `normalizeAnthropicTargetToolCallId` for **every** `isAnthropicTarget`, unconditionally enforcing Anthropic's `^[a-zA-Z0-9_-]{1,64}$` id rule (char rewrite + 64-char truncation, else a `toolu_<hash>` fallback). The openai-completions (#8642) and openai-responses (#10749) paths already skip normalization for same-model replay because a same-model id is an opaque provider correlation token; the anthropic path was missing that guard.

## Fix
- In the `toolCall` branch of `transformMessages`, normalize the anthropic-target id only when `!isSameModel || model.compat.officialEndpoint`.
  - Same-model replay to a **non-official** endpoint (custom `anthropic-messages` proxy) now preserves the id verbatim — any id an endpoint minted, it accepts back.
  - **Official** endpoints still normalize: a real Claude id already matches the pattern (no-op for genuine data) while a foreign id mislabeled as same-model is still defended against. This keeps the official-endpoint sanitization the dedup tests rely on.
  - Cross-model replay is unchanged: foreign ids are still normalized.
- Added `packages/ai/test/transform-messages-anthropic-tool-call-id.test.ts` covering same-model verbatim round-trip (id + paired result) and cross-model normalization to a valid Anthropic id.

## Verification
`bun test test/transform-messages-anthropic-tool-call-id.test.ts test/duplicate-tool-results.test.ts test/transform-messages-dedup.test.ts` → 39 pass, 0 fail. Full `packages/ai` suite: the only failure is the pre-existing `getProxyForProvider > normalizes hyphenated provider ids to underscores` env-isolation flake (passes in isolation, unrelated to this change). Manually confirmed via `convertAnthropicMessages`: same-model opaque id round-trips byte-identical and pairs with its result; cross-model id is sanitized to `^[a-zA-Z0-9_-]{1,64}$` and its result follows onto the sanitized id.

Fixes #10753