### PR TITLE
fix(tui): respect terminal color depth for session accents

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Fixed session accent colors rendering as bright white in terminals without truecolor support, including Terminal.app ([#10759](https://github.com/can1357/oh-my-pi/issues/10759)).
 - Fixed two idle subagents exchanging a single IRC message ping-ponging forever: wake-turn relays are now tagged and never relayed back, so each automated relay is delivered exactly once instead of waking a reciprocal relay until manual cancellation.
 
 ## [18.1.8] - 2026-09-03

--- a/packages/coding-agent/src/utils/session-color.ts
+++ b/packages/coding-agent/src/utils/session-color.ts
@@ -1,3 +1,4 @@
+import { TERMINAL } from "@oh-my-pi/pi-tui";
 import { hexToOklch, oklchCusp, oklchToHex, relativeLuminance } from "@oh-my-pi/pi-utils";
 
 /**
@@ -242,10 +243,11 @@ export function getSessionAccentHex(name: string, theme: SessionAccentTheme): st
 }
 
 /**
- * Convert a hex accent color to an ANSI-16m foreground escape sequence.
+ * Convert a hex accent color to an ANSI foreground escape sequence matching
+ * the detected terminal color depth.
  * Returns `undefined` if `hex` is nullish or Bun.color conversion fails.
  */
 export function getSessionAccentAnsi(hex: string | undefined): string | undefined {
 	if (!hex) return undefined;
-	return Bun.color(hex, "ansi-16m") ?? undefined;
+	return Bun.color(hex, TERMINAL.trueColor ? "ansi-16m" : "ansi-256") ?? undefined;
 }

--- a/packages/coding-agent/test/theme-color-mode.test.ts
+++ b/packages/coding-agent/test/theme-color-mode.test.ts
@@ -1,3 +1,4 @@
+import * as path from "node:path";
 import { describe, expect, it } from "bun:test";
 import { colorToAnsi, detectColorMode } from "../src/modes/theme/color";
 
@@ -7,5 +8,34 @@ describe("theme color mode", () => {
 
 		expect(mode).toBe("256color");
 		expect(colorToAnsi("#f5e0ac", mode)).toBe("\x1b[38;5;223m");
+	});
+
+	it("emits 256-color session accents for macOS Terminal.app", async () => {
+		const proc = Bun.spawn(
+			[
+				process.execPath,
+				"--eval",
+				'import { getSessionAccentAnsi } from "./packages/coding-agent/src/utils/session-color.ts"; process.stdout.write(getSessionAccentAnsi("#f5e0ac") ?? "undefined");',
+			],
+			{
+				cwd: path.resolve(import.meta.dir, "../../.."),
+				env: {
+					...process.env,
+					TERM_PROGRAM: "Apple_Terminal",
+					TERM: "xterm-256color",
+					COLORTERM: "",
+				},
+				stdout: "pipe",
+				stderr: "pipe",
+			},
+		);
+		const [exitCode, stdout, stderr] = await Promise.all([
+			proc.exited,
+			new Response(proc.stdout).text(),
+			new Response(proc.stderr).text(),
+		]);
+
+		expect(exitCode, stderr).toBe(0);
+		expect(stdout).toBe("\x1b[38;5;223m");
 	});
 });


### PR DESCRIPTION
## Repro
With `TERM_PROGRAM=Apple_Terminal`, `TERM=xterm-256color`, and no `COLORTERM`, run `bun -e 'import { getSessionAccentAnsi } from "./packages/coding-agent/src/utils/session-color.ts"; console.log(JSON.stringify(getSessionAccentAnsi("#336699")));'`; before this fix it emitted `\u001b[38;2;51;102;153m`, a 24-bit SGR sequence unsupported by Terminal.app.

## Cause
`getSessionAccentAnsi` in `packages/coding-agent/src/utils/session-color.ts` always passed `ansi-16m` to `Bun.color`, bypassing the process-wide `TERMINAL.trueColor` capability already used by other renderers.

## Fix
- Select `ansi-16m` only for truecolor terminals and `ansi-256` otherwise.
- Cover the Terminal.app environment in an isolated regression test.
- Document the user-visible correction in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/theme-color-mode.test.ts` passes with 2 tests and 0 failures. Re-running the repro emits `\u001b[38;5;60m`, confirming the 256-color path. The pre-publish `bun run fix` and `bun check` gate passed.

Fixes #10759