### PR TITLE
fix(coding-agent): preserve giant lines in tail windows

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed two idle subagents exchanging a single IRC message ping-ponging forever: wake-turn relays are now tagged and never relayed back, so each automated relay is delivered exactly once instead of waking a reciprocal relay until manual cancellation.
+- Fixed large MCP tool-result previews collapsing their tail window to closing braces when an oversized output line preceded them ([#10761](https://github.com/can1357/oh-my-pi/issues/10761)).
 
 ## [18.1.8] - 2026-09-03
 

--- a/packages/coding-agent/src/session/streaming-output.ts
+++ b/packages/coding-agent/src/session/streaming-output.ts
@@ -108,6 +108,7 @@ export interface TruncationResult {
 	tailLines?: number;
 	/** True when either retained side is a partial byte range of a source line. */
 	partialByteWindows?: boolean;
+	/** True when the retained suffix ends with a partial final source line. */
 	lastLinePartial?: boolean;
 	firstLineExceedsLimit?: boolean;
 }
@@ -469,7 +470,8 @@ export function truncateTail(content: string, options: TruncationOptions = {}): 
 				totalBytes,
 				outputLines: includedLines + (partialLine.bytes > 0 ? 1 : 0),
 				outputBytes: bytesUsed + separator.length + partialLine.bytes,
-				lastLinePartial: partialLine.bytes > 0,
+				partialByteWindows: partialLine.bytes > 0,
+				lastLinePartial: partialLine.bytes > 0 && !hasCompleteLines,
 				firstLineExceedsLimit: false,
 			};
 		}
@@ -544,6 +546,7 @@ export function truncateMiddle(content: string, options: TruncationOptions = {})
 	const tailLinesKept = tail.outputLines ?? 0;
 	const headBytesKept = head.outputBytes ?? Buffer.byteLength(head.content, "utf-8");
 	const tailBytesKept = tail.outputBytes ?? Buffer.byteLength(tail.content, "utf-8");
+	const tailHasPartialWindow = tail.partialByteWindows === true || tail.lastLinePartial === true;
 
 	// A giant first/last line cannot use one of the line-preserving windows. Use
 	// a byte window only for that side and retain the normal line cap on the other.
@@ -580,15 +583,15 @@ export function truncateMiddle(content: string, options: TruncationOptions = {})
 			elidedLines: Math.max(0, totalLines - actualHeadLines - actualTailLines),
 			headLines: actualHeadLines,
 			tailLines: actualTailLines,
-			partialByteWindows: useByteHead || useByteTail || tail.lastLinePartial === true,
+			partialByteWindows: useByteHead || useByteTail || tailHasPartialWindow,
 			elidedBytes,
-			lastLinePartial: true,
+			lastLinePartial: tail.lastLinePartial,
 			firstLineExceedsLimit: false,
 		};
 	}
 	// Fully retained line windows need no marker. A partial tail still omitted
 	// bytes from its source line even when the windows account for every line.
-	if (headLinesKept + tailLinesKept >= totalLines && !tail.lastLinePartial) {
+	if (headLinesKept + tailLinesKept >= totalLines && !tailHasPartialWindow) {
 		return noTruncResult(content, totalLines, totalBytes);
 	}
 
@@ -612,6 +615,7 @@ export function truncateMiddle(content: string, options: TruncationOptions = {})
 		elidedBytes,
 		headLines: headLinesKept,
 		tailLines: tailLinesKept,
+		partialByteWindows: tailHasPartialWindow,
 		lastLinePartial: tail.lastLinePartial,
 		firstLineExceedsLimit: false,
 	};
@@ -1447,6 +1451,8 @@ export function formatTailTruncationNotice(
 			lastLineSizePart = ` (line is ${formatBytes(Buffer.byteLength(lastLine, "utf-8"))})`;
 		}
 		notice = `[Showing last ${formatBytes(truncation.outputBytes ?? truncation.totalBytes)} of line ${endLine}${lastLineSizePart}${fullOutputPart}${suffix}]`;
+	} else if (truncation.partialByteWindows) {
+		notice = `[Showing last ${formatBytes(truncation.outputBytes ?? truncation.totalBytes)} across lines ${startLine}-${endLine} of ${truncation.totalLines}; line ${startLine} is partial${fullOutputPart}${suffix}]`;
 	} else {
 		notice = `[Showing lines ${startLine}-${endLine} of ${truncation.totalLines}${fullOutputPart}${suffix}]`;
 	}

--- a/packages/coding-agent/src/session/streaming-output.ts
+++ b/packages/coding-agent/src/session/streaming-output.ts
@@ -429,58 +429,51 @@ export function truncateTail(content: string, options: TruncationOptions = {}): 
 		}
 
 		const lineCodeUnits = end - lineStart;
+		let partialLine: ByteTruncationResult | undefined;
 
-		// Fast reject huge line without slicing/encoding.
-		if (lineCodeUnits > remaining) {
+		// Fast reject a giant line without slicing/encoding.
+		if (lineCodeUnits > maxBytes) {
 			truncatedBy = "bytes";
-			if (includedLines === 0) {
-				// Window the line substring to avoid materializing a giant string.
-				const windowStart = Math.max(lineStart, end - maxBytes);
-				const window = content.substring(windowStart, end);
-				const tail = truncateTailBytes(window, maxBytes);
-				return {
-					content: tail.text,
-					truncated: true,
-					truncatedBy: "bytes",
-					totalLines,
-					totalBytes,
-					outputLines: 1,
-					outputBytes: tail.bytes,
-					lastLinePartial: true,
-					firstLineExceedsLimit: false,
-				};
+			// Window the line substring to avoid materializing a giant string.
+			const windowStart = Math.max(lineStart, end - remaining);
+			const window = content.substring(windowStart, end);
+			partialLine = truncateTailBytes(window, remaining);
+		} else {
+			const lineText = content.slice(lineStart, end);
+			const lineBytes = Buffer.byteLength(lineText, "utf-8");
+
+			if (lineBytes > remaining) {
+				truncatedBy = "bytes";
+				if (lineBytes > maxBytes) partialLine = truncateTailBytes(lineText, remaining);
+			} else {
+				bytesUsed += sepBytes + lineBytes;
+				includedLines++;
+				startIndex = lineStart;
+
+				if (nl === -1) break;
+				end = nl; // exclude the newline itself; it'll be accounted as sepBytes in the next iteration
+				continue;
 			}
-			break;
 		}
 
-		const lineText = content.slice(lineStart, end);
-		const lineBytes = Buffer.byteLength(lineText, "utf-8");
-
-		if (lineBytes > remaining) {
-			truncatedBy = "bytes";
-			if (includedLines === 0) {
-				const tail = truncateTailBytes(lineText, maxBytes);
-				return {
-					content: tail.text,
-					truncated: true,
-					truncatedBy: "bytes",
-					totalLines,
-					totalBytes,
-					outputLines: 1,
-					outputBytes: tail.bytes,
-					lastLinePartial: true,
-					firstLineExceedsLimit: false,
-				};
-			}
-			break;
+		if (partialLine && (partialLine.bytes > 0 || includedLines === 0)) {
+			const hasCompleteLines = includedLines > 0;
+			const separator = hasCompleteLines && partialLine.bytes > 0 ? NL : "";
+			const completeTail = hasCompleteLines ? content.slice(startIndex) : "";
+			const output = materializeString(`${partialLine.text}${separator}${completeTail}`);
+			return {
+				content: output,
+				truncated: true,
+				truncatedBy: "bytes",
+				totalLines,
+				totalBytes,
+				outputLines: includedLines + (partialLine.bytes > 0 ? 1 : 0),
+				outputBytes: bytesUsed + separator.length + partialLine.bytes,
+				lastLinePartial: partialLine.bytes > 0,
+				firstLineExceedsLimit: false,
+			};
 		}
-
-		bytesUsed += sepBytes + lineBytes;
-		includedLines++;
-		startIndex = lineStart;
-
-		if (nl === -1) break;
-		end = nl; // exclude the newline itself; it'll be accounted as sepBytes in the next iteration
+		break;
 	}
 
 	if (includedLines >= maxLines && bytesUsed <= maxBytes) truncatedBy = "lines";

--- a/packages/coding-agent/test/streaming-output.test.ts
+++ b/packages/coding-agent/test/streaming-output.test.ts
@@ -154,6 +154,16 @@ describe("truncateTail", () => {
 		expect(result.truncatedBy).toBe("bytes");
 		expect(result.lastLinePartial).toBe(true);
 	});
+
+	test("fills the remaining byte budget from a giant line before smaller trailing lines", () => {
+		const result = truncateTail("abcdefghijk\n}\n```", { maxLines: 10, maxBytes: 10 });
+
+		expect(result.content).toBe("hijk\n}\n```");
+		expect(result.truncatedBy).toBe("bytes");
+		expect(result.outputLines).toBe(3);
+		expect(result.outputBytes).toBe(10);
+		expect(result.lastLinePartial).toBe(true);
+	});
 });
 
 describe("truncateLine", () => {
@@ -622,7 +632,7 @@ describe("truncateMiddle", () => {
 		expect(result.content).toContain("elided");
 		expect(result.elidedBytes).toBeGreaterThan(0);
 		expect(result.headLines).toBe(1);
-		expect(result.tailLines).toBe(2);
+		expect(result.tailLines).toBe(3);
 	});
 
 	test("does not duplicate overlapping fallback windows", () => {

--- a/packages/coding-agent/test/streaming-output.test.ts
+++ b/packages/coding-agent/test/streaming-output.test.ts
@@ -162,7 +162,8 @@ describe("truncateTail", () => {
 		expect(result.truncatedBy).toBe("bytes");
 		expect(result.outputLines).toBe(3);
 		expect(result.outputBytes).toBe(10);
-		expect(result.lastLinePartial).toBe(true);
+		expect(result.partialByteWindows).toBe(true);
+		expect(result.lastLinePartial).toBe(false);
 	});
 });
 
@@ -554,7 +555,7 @@ describe("truncation notice formatting", () => {
 		expect(formatTailTruncationNotice(truncation)).toBe("");
 	});
 
-	test("formatTailTruncationNotice supports partial-line and complete-line notices", () => {
+	test("formatTailTruncationNotice distinguishes partial leading and final lines", () => {
 		const partialLineTruncation = truncateTail("abcdefghij", { maxLines: 10, maxBytes: 4 });
 		const partialLineNotice = formatTailTruncationNotice(partialLineTruncation, {
 			fullOutputPath: "/tmp/full.log",
@@ -570,6 +571,11 @@ describe("truncation notice formatting", () => {
 
 		const byteTruncation = truncateTail("aaa\nbbbb\ncc", { maxLines: 10, maxBytes: 6 });
 		expect(formatTailTruncationNotice(byteTruncation)).toBe("\n\n[Showing lines 3-3 of 3]");
+
+		const leadingPartialTruncation = truncateTail("abcdefghijk\n}\n```", { maxLines: 10, maxBytes: 10 });
+		expect(formatTailTruncationNotice(leadingPartialTruncation)).toBe(
+			"\n\n[Showing last 10B across lines 1-3 of 3; line 1 is partial]",
+		);
 	});
 
 	test("formatHeadTruncationNotice returns empty string for non-truncated results", () => {
@@ -633,6 +639,8 @@ describe("truncateMiddle", () => {
 		expect(result.elidedBytes).toBeGreaterThan(0);
 		expect(result.headLines).toBe(1);
 		expect(result.tailLines).toBe(3);
+		expect(result.partialByteWindows).toBe(true);
+		expect(result.lastLinePartial).toBe(false);
 	});
 
 	test("does not duplicate overlapping fallback windows", () => {


### PR DESCRIPTION
## Repro
Calling `truncateTail()` with a 20-byte tail budget on an MCP-shaped result containing a 30-byte payload line followed by `}` and a closing fence returned only the 5-byte envelope suffix. Reproduced with `bun -e 'import { truncateTail } from "./packages/coding-agent/src/session/streaming-output.ts"; const input = `head\n${"x".repeat(30)}\n}\n\`\`\``; console.log(JSON.stringify(truncateTail(input, { maxBytes: 20, maxLines: 10 }), null, 2));'`.

## Cause
`truncateTail()` in `packages/coding-agent/src/session/streaming-output.ts` stopped its reverse line walk whenever an oversized line followed already-retained complete lines. Its byte-window fallback only ran when no line had yet been retained, so small MCP envelope lines prevented the giant structured-content line from using the remaining tail budget.

## Fix
- Byte-window the suffix of a line that exceeds the full tail budget and compose it before retained trailing lines.
- Preserve whole-line behavior when an ordinary line only exceeds the remaining budget.
- Cover the MCP-shaped giant-line-plus-envelope case and update middle-window line accounting.
- Document the user-visible fix in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/streaming-output.test.ts` passed 63 tests. Re-running the reproduction returned 20 bytes (`xxxxxxxxxxxxxx\n}\n```), with `lastLinePartial: true` and three retained lines. The pre-publish `bun run fix` and `bun check` gate passed during branch publication. Fixes #10761