### PR TITLE
feat(ai,coding-agent): add auth.accountSelection to keep multi-account routing on the first stored account

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added the `accountSelection` AuthStorage option (`balanced` | `fixed`), also read from `auth.accountSelection` in `config.yml` by `discoverAuthStorage`, so multi-account setups can stay on the first stored account and only move to a sibling once it is blocked ([#10766](https://github.com/can1357/oh-my-pi/pull/10766) by [@realitsyourman](https://github.com/realitsyourman)).
+
 ## [18.1.8] - 2026-09-03
 
 ### Added

--- a/packages/ai/src/auth-broker/discover.ts
+++ b/packages/ai/src/auth-broker/discover.ts
@@ -16,7 +16,7 @@ import {
 	MAIN_CONFIG_FILENAMES,
 } from "@oh-my-pi/pi-utils";
 import { YAML } from "bun";
-import { AuthStorage } from "../auth-storage";
+import { type AuthAccountSelection, AuthStorage } from "../auth-storage";
 import * as AIError from "../error";
 import { AuthBrokerClient, AuthBrokerError } from "./client";
 import { type AuthBrokerAccountPool, RemoteAuthCredentialStore } from "./remote-store";
@@ -40,6 +40,8 @@ export interface DiscoverAuthStorageOptions {
 	sourceLabel?: string;
 	/** Programmatic pool for SDK hosts. Takes precedence over the environment file. */
 	accountPool?: AuthBrokerAccountPool;
+	/** Credential selection policy. Defaults to `auth.accountSelection` from config.yml, then `balanced`. */
+	accountSelection?: AuthAccountSelection;
 }
 
 /** Path to the local bearer token file. Created by `omp auth-broker token`. */
@@ -73,7 +75,10 @@ async function readTokenFile(): Promise<string | null> {
 interface ConfigSnapshot {
 	url?: string;
 	token?: string;
+	accountSelection?: AuthAccountSelection;
 }
+
+const ACCOUNT_SELECTION_CONFIG_KEY = "auth.accountSelection";
 
 /**
  * Resolve a dotted config key (e.g. `auth.broker.url`) against a parsed YAML
@@ -95,6 +100,15 @@ function readDottedString(record: Record<string, unknown>, dottedKey: string): s
 	return typeof flat === "string" ? flat : undefined;
 }
 
+/** Parse `auth.accountSelection`; unknown values fall back to the default with a warning. */
+function readAccountSelection(record: Record<string, unknown>, configPath: string): AuthAccountSelection | undefined {
+	const raw = readDottedString(record, ACCOUNT_SELECTION_CONFIG_KEY);
+	if (raw === undefined) return undefined;
+	if (raw === "balanced" || raw === "fixed") return raw;
+	logger.warn(`Invalid ${ACCOUNT_SELECTION_CONFIG_KEY}; using balanced`, { path: configPath, value: raw });
+	return undefined;
+}
+
 async function readConfigYaml(agentDir: string): Promise<ConfigSnapshot> {
 	for (const filename of MAIN_CONFIG_FILENAMES) {
 		const configPath = path.join(agentDir, filename);
@@ -105,7 +119,8 @@ async function readConfigYaml(agentDir: string): Promise<ConfigSnapshot> {
 			const record = parsed as Record<string, unknown>;
 			const url = readDottedString(record, "auth.broker.url");
 			const token = readDottedString(record, "auth.broker.token");
-			return { url, token };
+			const accountSelection = readAccountSelection(record, configPath);
+			return { url, token, accountSelection };
 		} catch (err) {
 			if (isEnoent(err)) continue;
 			logger.warn("auth-broker config unreadable", { path: configPath, error: String(err) });
@@ -235,6 +250,7 @@ export async function discoverAuthStorage(options: DiscoverAuthStorageOptions = 
 		agentDir,
 		configValueResolver: options.configValueResolver,
 	});
+	const accountSelection = options.accountSelection ?? (await readConfigYaml(agentDir)).accountSelection;
 
 	if (brokerConfig) {
 		const accountPool = options.accountPool ?? (await loadAuthBrokerAccountPool());
@@ -296,6 +312,7 @@ export async function discoverAuthStorage(options: DiscoverAuthStorageOptions = 
 		const storage = new AuthStorage(store, {
 			configValueResolver: options.configValueResolver,
 			sourceLabel: options.sourceLabel ?? `broker ${brokerConfig.url}`,
+			accountSelection,
 		});
 		await storage.reload();
 		return storage;
@@ -305,6 +322,7 @@ export async function discoverAuthStorage(options: DiscoverAuthStorageOptions = 
 	const storage = await AuthStorage.create(dbPath, {
 		configValueResolver: options.configValueResolver,
 		sourceLabel: options.sourceLabel ?? `local ${dbPath}`,
+		accountSelection,
 	});
 	await storage.reload();
 	return storage;

--- a/packages/ai/src/auth-broker/discover.ts
+++ b/packages/ai/src/auth-broker/discover.ts
@@ -206,8 +206,21 @@ function resolveSnapshotTtlMs(): number {
 export async function resolveAuthBrokerConfig(
 	options: ResolveAuthBrokerConfigOptions = {},
 ): Promise<AuthBrokerClientConfig | null> {
+	return (await resolveAuthBrokerConfigWithSnapshot(options)).config;
+}
+
+/**
+ * {@link resolveAuthBrokerConfig} plus a memoised reader for the parsed
+ * `config.yml`, so callers that need other keys from the same file (account
+ * selection) do not parse it a second time.
+ */
+async function resolveAuthBrokerConfigWithSnapshot(
+	options: ResolveAuthBrokerConfigOptions,
+): Promise<{ config: AuthBrokerClientConfig | null; readSnapshot: () => Promise<ConfigSnapshot> }> {
 	const agentDir = options.agentDir ?? getAgentDir();
 	const resolveConfig = options.configValueResolver ?? defaultResolveConfigValue;
+	let snapshot: Promise<ConfigSnapshot> | undefined;
+	const readSnapshot = (): Promise<ConfigSnapshot> => (snapshot ??= readConfigYaml(agentDir));
 
 	const envUrl = process.env.OMP_AUTH_BROKER_URL;
 	const envToken = process.env.OMP_AUTH_BROKER_TOKEN;
@@ -215,7 +228,7 @@ export async function resolveAuthBrokerConfig(
 	let url = envUrl && envUrl.length > 0 ? envUrl : undefined;
 	let configToken: string | undefined;
 	if (!url || !envToken) {
-		const fromConfig = await readConfigYaml(agentDir);
+		const fromConfig = await readSnapshot();
 		if (!url && fromConfig.url) {
 			const resolved = await resolveConfig(fromConfig.url);
 			if (resolved && resolved.length > 0) url = resolved;
@@ -225,7 +238,7 @@ export async function resolveAuthBrokerConfig(
 			if (resolved && resolved.length > 0) configToken = resolved;
 		}
 	}
-	if (!url) return null;
+	if (!url) return { config: null, readSnapshot };
 
 	const token =
 		(envToken && envToken.length > 0 ? envToken : undefined) ?? configToken ?? (await readTokenFile()) ?? undefined;
@@ -236,7 +249,7 @@ export async function resolveAuthBrokerConfig(
 				`Set OMP_AUTH_BROKER_TOKEN, the \`auth.broker.token\` config entry, or place one at ${getAuthBrokerTokenFilePath()}.`,
 		);
 	}
-	return { url, token };
+	return { config: { url, token }, readSnapshot };
 }
 
 /**
@@ -246,11 +259,11 @@ export async function resolveAuthBrokerConfig(
  */
 export async function discoverAuthStorage(options: DiscoverAuthStorageOptions = {}): Promise<AuthStorage> {
 	const agentDir = options.agentDir ?? getAgentDir();
-	const brokerConfig = await resolveAuthBrokerConfig({
+	const { config: brokerConfig, readSnapshot } = await resolveAuthBrokerConfigWithSnapshot({
 		agentDir,
 		configValueResolver: options.configValueResolver,
 	});
-	const accountSelection = options.accountSelection ?? (await readConfigYaml(agentDir)).accountSelection;
+	const accountSelection = options.accountSelection ?? (await readSnapshot()).accountSelection;
 
 	if (brokerConfig) {
 		const accountPool = options.accountPool ?? (await loadAuthBrokerAccountPool());

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -3022,6 +3022,16 @@ export class AuthStorage {
 	}
 
 	/**
+	 * Whether `sessionId`'s current OAuth account was chosen by an explicit pin
+	 * (`pinSessionOAuthAccount` with `origin: "user"`) rather than automatic
+	 * routing. Lets session persistence replay the pin with the same origin.
+	 */
+	isSessionOAuthAccountPinned(provider: string, sessionId: string | undefined): boolean {
+		const sessionPref = this.#getSessionCredential(provider, sessionId);
+		return sessionPref?.type === "oauth" && sessionPref.pinned === true;
+	}
+
+	/**
 	 * Get the OAuth account identity for a provider, preferring the credential that
 	 * is session-sticky for `sessionId`. This is a read-only lookup for display and
 	 * metadata paths; it does not refresh tokens, rank usage, or advance selection.

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -581,9 +581,24 @@ export interface CredentialDisabledEvent {
 	disabledCause: string;
 }
 
+/**
+ * How AuthStorage chooses among several stored credentials for one provider.
+ *
+ * - `balanced` (default): spread load across accounts — a session starts from
+ *   its hashed position, session-less lookups round-robin — and rank by live
+ *   usage headroom.
+ * - `fixed`: always start from the first stored credential and move to the
+ *   next one only when the current credential is blocked (rate-limited,
+ *   exhausted, or failed to refresh). Usage reports are not consulted for
+ *   selection; plan-gated openai-codex models still verify tier eligibility.
+ */
+export type AuthAccountSelection = "balanced" | "fixed";
+
 export type AuthStorageOptions = {
 	usageProviderResolver?: (provider: Provider) => UsageProvider | undefined;
 	rankingStrategyResolver?: (provider: Provider) => CredentialRankingStrategy | undefined;
+	/** Credential selection policy. Default: `balanced`. */
+	accountSelection?: AuthAccountSelection;
 	usageFetch?: typeof fetch;
 	usageRequestTimeoutMs?: number;
 	usageLogger?: UsageLogger;
@@ -1341,6 +1356,7 @@ export class AuthStorage {
 	#runtimeUsageProviderOverrides: Map<Provider, { provider: UsageProvider; apiKey?: string }> = new Map();
 	#usageReportCacheKeysByProvider: Map<Provider, Set<string>> = new Map();
 	#rankingStrategyResolver?: (provider: Provider) => CredentialRankingStrategy | undefined;
+	#accountSelection: AuthAccountSelection;
 	#usageCache: UsageCache;
 	#usageCacheEpoch = 0;
 	#usageRequestInFlight: Map<string, Promise<UsageReport | null>> = new Map();
@@ -1376,6 +1392,7 @@ export class AuthStorage {
 		this.#configValueResolver = options.configValueResolver ?? defaultConfigValueResolver;
 		this.#usageProviderResolver = options.usageProviderResolver ?? resolveDefaultUsageProvider;
 		this.#rankingStrategyResolver = options.rankingStrategyResolver ?? resolveDefaultRankingStrategy;
+		this.#accountSelection = options.accountSelection ?? "balanced";
 		this.#usageCache = new AuthStorageUsageCache(this.#store);
 		// Opportunistic hygiene, once per AuthStorage lifetime: drop expired
 		// cache rows (24h last-good retention). A cheap indexed DELETE;
@@ -1429,6 +1446,11 @@ export class AuthStorage {
 		if (this.#closed) return;
 		this.#closed = true;
 		this.#store.close();
+	}
+
+	/** Credential selection policy this storage was constructed with. */
+	get accountSelection(): AuthAccountSelection {
+		return this.#accountSelection;
 	}
 
 	getGeneration(): number {
@@ -1771,10 +1793,12 @@ export class AuthStorage {
 	 * Returns credential indices in priority order for selection.
 	 * With sessionId: starts from hashed index (consistent per session).
 	 * Without sessionId: starts from round-robin index (load balancing).
+	 * Under `fixed` account selection: always starts from the first stored credential.
 	 * Order wraps around so all credentials are tried if earlier ones are blocked.
 	 */
 	#getCredentialOrder(providerKey: string, sessionId: string | undefined, total: number): number[] {
 		if (total <= 1) return [0];
+		if (this.#accountSelection === "fixed") return Array.from({ length: total }, (_, index) => index);
 		const start = sessionId
 			? this.#getHashedIndex(sessionId, total)
 			: this.#getNextRoundRobinIndex(providerKey, total);
@@ -2256,7 +2280,7 @@ export class AuthStorage {
 		const order = this.#getCredentialOrder(providerKey, sessionId, credentials.length);
 		const fallback = credentials[order[0]];
 		const strategy = this.#rankingStrategyResolver?.(provider);
-		if (!strategy) {
+		if (!strategy || this.#accountSelection === "fixed") {
 			for (const idx of order) {
 				const candidate = credentials[idx];
 				if (!this.#isCredentialBlocked(provider, providerKey, candidate.index)) {
@@ -4752,6 +4776,9 @@ export class AuthStorage {
 		if (planRequirement !== "none" && left.planPriority !== right.planPriority) {
 			return left.planPriority - right.planPriority;
 		}
+		// Fixed selection ranks on availability and plan eligibility only; the
+		// stored-position tie-break in the caller decides the rest.
+		if (this.#accountSelection === "fixed") return 0;
 		if (left.hasPriorityBoost !== right.hasPriorityBoost) return left.hasPriorityBoost ? -1 : 1;
 		// Short-window guard: candidates whose primary (e.g. 5h) window is
 		// nearly exhausted rank behind cool ones regardless of drain urgency —
@@ -4976,7 +5003,9 @@ export class AuthStorage {
 		const blockScopes = credentialBlockScopesForRequest(provider, strategy, rankingContext, blockScope);
 		const planRequirement = resolveOpenAICodexPlanRequirement(provider, options?.modelId);
 		const hasPlanRequirement = planRequirement !== "none";
-		const checkUsage = strategy !== undefined && (credentials.length > 1 || hasPlanRequirement);
+		const checkUsage =
+			strategy !== undefined &&
+			(hasPlanRequirement || (credentials.length > 1 && this.#accountSelection !== "fixed"));
 		const sessionCredential = this.#getSessionCredential(provider, sessionId);
 		const sessionPreferredIndex = sessionCredential?.type === "oauth" ? sessionCredential.index : undefined;
 		const sessionPreferredCredential =

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -1313,6 +1313,21 @@ type UsageRankedCandidate<T extends AuthCredential> = UsageCandidate<T> & {
 type RankedOAuthCandidate = UsageRankedCandidate<OAuthCredential>;
 type RankedApiKeyCandidate = UsageRankedCandidate<ApiKeyCredential>;
 
+/** Credential a session last resolved (or was explicitly pinned to). */
+type SessionCredentialRecord = {
+	type: AuthCredential["type"];
+	index: number;
+	lastUsedAtMs?: number;
+	/**
+	 * Set by an explicit user pin (`pinSessionOAuthAccount` with the default
+	 * `origin: "user"`). Under `fixed` account selection only pinned records may
+	 * keep a session away from the first available stored credential; automatic
+	 * stickiness recorded after a fallthrough must not. Cleared once a different
+	 * credential serves the session.
+	 */
+	pinned?: boolean;
+};
+
 // ─────────────────────────────────────────────────────────────────────────────
 // AuthStorage Class
 // ─────────────────────────────────────────────────────────────────────────────
@@ -1332,10 +1347,7 @@ export class AuthStorage {
 	/** Tracks next credential index per provider:type key for round-robin distribution (non-session use). */
 	#providerRoundRobinIndex: Map<string, number> = new Map();
 	/** Tracks the last used credential per provider for a session (used for rate-limit switching). */
-	#sessionLastCredential: Map<
-		string,
-		Map<string, { type: AuthCredential["type"]; index: number; lastUsedAtMs?: number }>
-	> = new Map();
+	#sessionLastCredential: Map<string, Map<string, SessionCredentialRecord>> = new Map();
 	/** Recent bearer fingerprints resolved for each durable OAuth row; used only for delayed usage-limit attribution. */
 	#oauthBearerFingerprints: Map<string, Map<number, string[]>> = new Map();
 	/** Maps provider:type -> credentialIndex -> blockedUntilMs for temporary backoff. */
@@ -1448,9 +1460,19 @@ export class AuthStorage {
 		this.#store.close();
 	}
 
-	/** Credential selection policy this storage was constructed with. */
+	/** Credential selection policy currently in effect. */
 	get accountSelection(): AuthAccountSelection {
 		return this.#accountSelection;
+	}
+
+	/**
+	 * Replace the selection policy after construction. The coding-agent applies the
+	 * settings layer here once it has loaded, so config overlays (`--config`,
+	 * `PI_CONFIG_FILES`) and project settings reach credential routing even though
+	 * discovery only saw `<agentDir>/config.yml`.
+	 */
+	setAccountSelection(selection: AuthAccountSelection): void {
+		this.#accountSelection = selection;
 	}
 
 	getGeneration(): number {
@@ -2014,11 +2036,18 @@ export class AuthStorage {
 		type: AuthCredential["type"],
 		index: number,
 		lastUsedAtMs?: number,
+		options?: { pinned?: boolean },
 	): void {
 		if (!sessionId) return;
 		const nowMs = lastUsedAtMs ?? Date.now();
-		const sessionMap = this.#sessionLastCredential.get(provider) ?? new Map();
-		sessionMap.set(sessionId, { type, index, lastUsedAtMs: nowMs });
+		const sessionMap = this.#sessionLastCredential.get(provider) ?? new Map<string, SessionCredentialRecord>();
+		// An explicit pin survives re-records of the same credential and is dropped as soon as a
+		// different credential serves the session (the pinned one was blocked and fell through).
+		const previous = sessionMap.get(sessionId);
+		const pinned =
+			options?.pinned ?? (previous?.type === type && previous.index === index ? previous.pinned : undefined);
+		const record: SessionCredentialRecord = { type, index, lastUsedAtMs: nowMs, ...(pinned ? { pinned } : {}) };
+		sessionMap.set(sessionId, record);
 		this.#sessionLastCredential.set(provider, sessionMap);
 
 		try {
@@ -2030,6 +2059,7 @@ export class AuthStorage {
 					index,
 					credentialId,
 					lastUsedAtMs: nowMs,
+					...(pinned ? { pinned } : {}),
 				});
 				// Expires in 30 days
 				const expiresAtSec = Math.floor(nowMs / 1000) + 30 * 24 * 60 * 60;
@@ -2041,10 +2071,7 @@ export class AuthStorage {
 	}
 
 	/** Retrieves the last credential used by a session. */
-	#getSessionCredential(
-		provider: string,
-		sessionId: string | undefined,
-	): { type: AuthCredential["type"]; index: number; lastUsedAtMs?: number } | undefined {
+	#getSessionCredential(provider: string, sessionId: string | undefined): SessionCredentialRecord | undefined {
 		if (!sessionId) return undefined;
 		let sessionMap = this.#sessionLastCredential.get(provider);
 		if (sessionMap?.has(sessionId)) {
@@ -2059,6 +2086,7 @@ export class AuthStorage {
 					index: number;
 					credentialId?: number;
 					lastUsedAtMs?: number;
+					pinned?: boolean;
 				};
 
 				if (val.credentialId !== undefined) {
@@ -2079,10 +2107,11 @@ export class AuthStorage {
 					sessionMap = new Map();
 					this.#sessionLastCredential.set(provider, sessionMap);
 				}
-				const sessionVal = {
+				const sessionVal: SessionCredentialRecord = {
 					type: val.type,
 					index: val.index,
 					lastUsedAtMs: val.lastUsedAtMs,
+					...(val.pinned === true ? { pinned: true } : {}),
 				};
 				sessionMap.set(sessionId, sessionVal);
 				return sessionVal;
@@ -2280,21 +2309,25 @@ export class AuthStorage {
 		const order = this.#getCredentialOrder(providerKey, sessionId, credentials.length);
 		const fallback = credentials[order[0]];
 		const strategy = this.#rankingStrategyResolver?.(provider);
+		const rankingContext: CredentialRankingContext = {
+			modelId: options?.modelId,
+		};
+		const blockScope = strategy?.blockScope?.(rankingContext);
+		// Scoped (e.g. per-tier) blocks only exist for providers with a strategy; keep the
+		// strategy-less path on the unscoped check it always used.
+		const blockScopes = strategy
+			? credentialBlockScopesForRequest(provider, strategy, rankingContext, blockScope)
+			: undefined;
 		if (!strategy || this.#accountSelection === "fixed") {
 			for (const idx of order) {
 				const candidate = credentials[idx];
-				if (!this.#isCredentialBlocked(provider, providerKey, candidate.index)) {
+				if (!this.#isCredentialBlocked(provider, providerKey, candidate.index, blockScopes)) {
 					return candidate;
 				}
 			}
 			return fallback;
 		}
 
-		const rankingContext: CredentialRankingContext = {
-			modelId: options?.modelId,
-		};
-		const blockScope = strategy.blockScope?.(rankingContext);
-		const blockScopes = credentialBlockScopesForRequest(provider, strategy, rankingContext, blockScope);
 		const candidates = await this.#rankApiKeySelections({
 			providerKey,
 			provider,
@@ -5007,7 +5040,14 @@ export class AuthStorage {
 			strategy !== undefined &&
 			(hasPlanRequirement || (credentials.length > 1 && this.#accountSelection !== "fixed"));
 		const sessionCredential = this.#getSessionCredential(provider, sessionId);
-		const sessionPreferredIndex = sessionCredential?.type === "oauth" ? sessionCredential.index : undefined;
+		// Under `fixed`, automatic stickiness must not keep a session on the sibling it fell
+		// through to once an earlier stored credential is available again; only an explicit
+		// user pin may. Dropping the preference here disables every downstream hoist.
+		const sessionPreferredIndex =
+			sessionCredential?.type === "oauth" &&
+			(this.#accountSelection !== "fixed" || sessionCredential.pinned === true)
+				? sessionCredential.index
+				: undefined;
 		const sessionPreferredCredential =
 			sessionPreferredIndex !== undefined
 				? credentials.find(entry => entry.index === sessionPreferredIndex)?.credential
@@ -6000,7 +6040,16 @@ export class AuthStorage {
 		provider: string,
 		sessionId: string,
 		credentialId: number,
-		options?: { lastUsedAtMs?: number },
+		options?: {
+			lastUsedAtMs?: number;
+			/**
+			 * `user` (default): an explicit choice that also holds under `fixed` account
+			 * selection. `restore`: a persisted sticky replayed on session resume — it keeps
+			 * the warm-cache semantics under `balanced` but yields to the first available
+			 * stored credential under `fixed`.
+			 */
+			origin?: "user" | "restore";
+		},
 	): boolean {
 		if (!sessionId || this.#runtimeOverrides.has(provider) || this.#configOverrides.has(provider)) {
 			return false;
@@ -6009,7 +6058,9 @@ export class AuthStorage {
 		const index = stored.findIndex(entry => entry.id === credentialId);
 		const target = stored[index];
 		if (target?.credential.type !== "oauth") return false;
-		this.#recordSessionCredential(provider, sessionId, "oauth", index, options?.lastUsedAtMs);
+		this.#recordSessionCredential(provider, sessionId, "oauth", index, options?.lastUsedAtMs, {
+			pinned: (options?.origin ?? "user") === "user",
+		});
 		return true;
 	}
 

--- a/packages/ai/test/auth-broker-account-selection-config.test.ts
+++ b/packages/ai/test/auth-broker-account-selection-config.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { discoverAuthStorage } from "@oh-my-pi/pi-ai/auth-broker";
+import type { AuthStorage } from "@oh-my-pi/pi-ai/auth-storage";
+import { removeWithRetries } from "../../utils/src/temp";
+import { withEnv } from "./helpers";
+
+const SUPPRESS_AUTH_BROKER_ENV = {
+	OMP_AUTH_BROKER_URL: undefined,
+	OMP_AUTH_BROKER_TOKEN: undefined,
+	OMP_AUTH_BROKER_ACCOUNT_POOL_FILE: undefined,
+} as const;
+
+describe("auth.accountSelection config discovery", () => {
+	let agentDir = "";
+	let storage: AuthStorage | null = null;
+
+	beforeEach(async () => {
+		agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-ai-account-selection-config-"));
+	});
+
+	afterEach(async () => {
+		storage?.close();
+		storage = null;
+		if (agentDir) {
+			await removeWithRetries(agentDir);
+			agentDir = "";
+		}
+	});
+
+	async function discover(config: string, accountSelection?: "balanced" | "fixed"): Promise<AuthStorage> {
+		await Bun.write(path.join(agentDir, "config.yml"), config);
+		let discovered: AuthStorage | undefined;
+		await withEnv(SUPPRESS_AUTH_BROKER_ENV, async () => {
+			discovered = await discoverAuthStorage({ agentDir, accountSelection });
+		});
+		if (!discovered) throw new Error("discoverAuthStorage returned nothing");
+		storage = discovered;
+		return discovered;
+	}
+
+	test("flat `auth.accountSelection: fixed` opens the local store with fixed selection", async () => {
+		// Regression: the setting is written by `omp config set` but never reaches AuthStorage.
+		expect((await discover("auth.accountSelection: fixed\n")).accountSelection).toBe("fixed");
+	});
+
+	test("nested `auth: { accountSelection }` resolves the same way", async () => {
+		expect((await discover("auth:\n  accountSelection: fixed\n")).accountSelection).toBe("fixed");
+	});
+
+	test("an unknown value falls back to balanced instead of failing startup", async () => {
+		expect((await discover("auth.accountSelection: sticky\n")).accountSelection).toBe("balanced");
+	});
+
+	test("an explicit option wins over config.yml", async () => {
+		expect((await discover("auth.accountSelection: fixed\n", "balanced")).accountSelection).toBe("balanced");
+	});
+});

--- a/packages/ai/test/auth-storage-account-selection.test.ts
+++ b/packages/ai/test/auth-storage-account-selection.test.ts
@@ -1,0 +1,278 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { withOAuthAccess } from "@oh-my-pi/pi-ai/auth-retry";
+import {
+	type AuthAccountSelection,
+	type AuthCredentialStore,
+	AuthStorage,
+	SqliteAuthCredentialStore,
+} from "@oh-my-pi/pi-ai/auth-storage";
+import * as oauthUtils from "@oh-my-pi/pi-ai/registry/oauth";
+import type { UsageProvider, UsageReport } from "@oh-my-pi/pi-ai/usage";
+import { removeWithRetries } from "../../utils/src/temp";
+
+const OAUTH_PROVIDER = "unit-account-selection";
+const HOUR_MS = 60 * 60 * 1000;
+const SESSION_SAMPLE_COUNT = 12;
+
+function oauthCredential(suffix: string) {
+	return {
+		type: "oauth" as const,
+		access: `access-${suffix}`,
+		refresh: `refresh-${suffix}`,
+		expires: Date.now() + HOUR_MS,
+		accountId: `acc-${suffix}`,
+		email: `${suffix}@example.com`,
+	};
+}
+
+function zaiUsage(apiKey: string, remaining: number): UsageReport {
+	return {
+		provider: "zai",
+		fetchedAt: Date.now(),
+		limits: [
+			{
+				id: `zai:requests:5h:${apiKey}`,
+				label: "ZAI Request Quota",
+				scope: { provider: "zai", windowId: "5h", shared: true },
+				window: { id: "5h", label: "5 Hour", durationMs: 5 * HOUR_MS, resetsAt: Date.now() + HOUR_MS },
+				amount: {
+					unit: "requests",
+					used: 100 - remaining,
+					limit: 100,
+					remaining,
+					remainingFraction: remaining / 100,
+					usedFraction: (100 - remaining) / 100,
+				},
+				status: remaining === 0 ? "exhausted" : "ok",
+			},
+		],
+	};
+}
+
+const CODEX_PROVIDER = "openai-codex";
+/** Any `gpt-5.6-sol` request needs a paid Codex plan, so selection must consult usage reports. */
+const PLAN_GATED_CODEX_MODEL = "gpt-5.6-sol";
+
+function codexUsage(accountId: string, primaryUsedFraction: number, planType: string): UsageReport {
+	// The Codex ranking strategy recognises windows by `openai-codex:primary` / `:secondary` ids.
+	const window = (key: "primary" | "secondary", windowId: string, durationMs: number, usedFraction: number) => ({
+		id: `openai-codex:${key}`,
+		label: `${key} window`,
+		scope: { provider: CODEX_PROVIDER, windowId, shared: true },
+		window: { id: windowId, label: `${key} window`, durationMs, resetsAt: Date.now() + durationMs },
+		amount: {
+			unit: "percent" as const,
+			used: usedFraction * 100,
+			limit: 100,
+			remaining: (1 - usedFraction) * 100,
+			usedFraction,
+			remainingFraction: 1 - usedFraction,
+		},
+		status: "ok" as const,
+	});
+	return {
+		provider: CODEX_PROVIDER,
+		fetchedAt: Date.now(),
+		limits: [
+			window("primary", "5h", 5 * HOUR_MS, primaryUsedFraction),
+			window("secondary", "7d", 7 * 24 * HOUR_MS, 0.5),
+		],
+		metadata: { accountId, planType, allowed: true, limitReached: false },
+	};
+}
+
+describe("AuthStorage account selection policy", () => {
+	let tempDir = "";
+	let store: AuthCredentialStore | null = null;
+	let authStorage: AuthStorage | null = null;
+
+	beforeEach(async () => {
+		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-ai-account-selection-"));
+		store = await SqliteAuthCredentialStore.open(path.join(tempDir, "agent.db"));
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		authStorage?.close();
+		store?.close();
+		store = null;
+		authStorage = null;
+		if (tempDir) {
+			await removeWithRetries(tempDir);
+			tempDir = "";
+		}
+	});
+
+	function openStorage(accountSelection?: AuthAccountSelection, usageProvider?: UsageProvider): AuthStorage {
+		if (!store) throw new Error("test setup failed");
+		authStorage = new AuthStorage(store, {
+			accountSelection,
+			usageProviderResolver: provider => (provider === usageProvider?.id ? usageProvider : undefined),
+		});
+		return authStorage;
+	}
+
+	function mockOAuthRefresh(): void {
+		vi.spyOn(oauthUtils, "getOAuthApiKey").mockImplementation(async (provider, credentials) => {
+			const credential = credentials[provider];
+			return credential ? { newCredentials: credential, apiKey: credential.access } : null;
+		});
+	}
+
+	async function seedThreeOAuthAccounts(storage: AuthStorage): Promise<void> {
+		await storage.set(OAUTH_PROVIDER, [oauthCredential("a"), oauthCredential("b"), oauthCredential("c")]);
+	}
+
+	function resolveEmail(storage: AuthStorage, sessionId: string): Promise<string | undefined> {
+		return withOAuthAccess(storage, OAUTH_PROVIDER, access => Promise.resolve(access.email), { sessionId });
+	}
+
+	async function resolveEmailsForFreshSessions(
+		storage: AuthStorage,
+		prefix: string,
+	): Promise<Set<string | undefined>> {
+		const emails = new Set<string | undefined>();
+		for (let index = 0; index < SESSION_SAMPLE_COUNT; index += 1) {
+			emails.add(await resolveEmail(storage, `${prefix}-${index}`));
+		}
+		return emails;
+	}
+
+	test("balanced (default) spreads fresh sessions across sibling OAuth accounts", async () => {
+		// Negative contract for the tests below: if session-hashed starts ever stop
+		// distributing, `fixed` would be indistinguishable from the default.
+		mockOAuthRefresh();
+		const storage = openStorage();
+		await seedThreeOAuthAccounts(storage);
+
+		const emails = await resolveEmailsForFreshSessions(storage, "balanced");
+
+		expect(emails.size).toBeGreaterThan(1);
+	});
+
+	test("fixed: every fresh session resolves the first stored OAuth account", async () => {
+		// Regression: a backup account starts serving brand-new sessions again.
+		mockOAuthRefresh();
+		const storage = openStorage("fixed");
+		await seedThreeOAuthAccounts(storage);
+
+		const emails = await resolveEmailsForFreshSessions(storage, "fixed");
+
+		expect([...emails]).toEqual(["a@example.com"]);
+	});
+
+	test("fixed: session-less lookups do not round-robin across OAuth accounts", async () => {
+		// Regression: background lookups (no session id) rotate a→b→c again.
+		mockOAuthRefresh();
+		const storage = openStorage("fixed");
+		await seedThreeOAuthAccounts(storage);
+
+		const keys = [
+			await storage.getApiKey(OAUTH_PROVIDER),
+			await storage.getApiKey(OAUTH_PROVIDER),
+			await storage.getApiKey(OAUTH_PROVIDER),
+		];
+
+		expect(keys).toEqual(["access-a", "access-a", "access-a"]);
+	});
+
+	test("fixed: a usage-limited first account falls through to the next stored account", async () => {
+		// Regression: the pinned-first policy keeps hammering a rate-limited account
+		// (or starts spreading to `c` instead of the next sibling `b`).
+		mockOAuthRefresh();
+		const storage = openStorage("fixed");
+		await seedThreeOAuthAccounts(storage);
+		expect(await resolveEmail(storage, "limited-session")).toBe("a@example.com");
+
+		await storage.markUsageLimitReached(OAUTH_PROVIDER, "limited-session", { retryAfterMs: HOUR_MS });
+
+		expect(await resolveEmail(storage, "limited-session")).toBe("b@example.com");
+		expect(await resolveEmail(storage, "another-session")).toBe("b@example.com");
+	});
+
+	test("fixed: stored API keys resolve in stored order without consulting usage reports", async () => {
+		// Regression: fixed mode silently ranks API keys by quota again, flipping to
+		// the sibling key and probing the usage endpoint on every resolve.
+		const fetchUsage = vi.fn(async (params: { credential: { apiKey?: string } }) =>
+			params.credential.apiKey === "zai-exhausted" ? zaiUsage("zai-exhausted", 0) : zaiUsage("zai-healthy", 80),
+		);
+		const usageProvider: UsageProvider = {
+			id: "zai",
+			fetchUsage: fetchUsage as UsageProvider["fetchUsage"],
+			supports: params => params.provider === "zai" && params.credential.type === "api_key",
+		};
+		const storage = openStorage("fixed", usageProvider);
+		await storage.set("zai", [
+			{ type: "api_key", key: "zai-exhausted", source: "login" },
+			{ type: "api_key", key: "zai-healthy", source: "login" },
+		]);
+
+		expect(await storage.getApiKey("zai")).toBe("zai-exhausted");
+		expect(fetchUsage).not.toHaveBeenCalled();
+	});
+
+	function codexUsageProvider(reports: Map<string, UsageReport>): UsageProvider {
+		return {
+			id: CODEX_PROVIDER,
+			async fetchUsage(params) {
+				const accountId = params.credential.accountId;
+				return accountId ? (reports.get(accountId) ?? null) : null;
+			},
+		};
+	}
+
+	async function seedTwoCodexAccounts(storage: AuthStorage): Promise<void> {
+		await storage.set(CODEX_PROVIDER, [oauthCredential("first"), oauthCredential("second")]);
+	}
+
+	test("balanced (default) moves a plan-gated Codex request off a hot first account", async () => {
+		// Negative contract for the fixed test below: usage ranking must still
+		// prefer the cool sibling, or `fixed` would be indistinguishable from it.
+		mockOAuthRefresh();
+		const reports = new Map<string, UsageReport>([
+			["acc-first", codexUsage("acc-first", 0.9, "plus")],
+			["acc-second", codexUsage("acc-second", 0.1, "plus")],
+		]);
+		const storage = openStorage(undefined, codexUsageProvider(reports));
+		await seedTwoCodexAccounts(storage);
+
+		expect(await storage.getApiKey(CODEX_PROVIDER, "codex-balanced", { modelId: PLAN_GATED_CODEX_MODEL })).toBe(
+			"access-second",
+		);
+	});
+
+	test("fixed: a plan-gated Codex request stays on the first eligible account despite a cooler sibling", async () => {
+		// Regression: plan verification re-enables headroom ranking, so the
+		// backup account silently takes over whenever the primary runs hot.
+		mockOAuthRefresh();
+		const reports = new Map<string, UsageReport>([
+			["acc-first", codexUsage("acc-first", 0.9, "plus")],
+			["acc-second", codexUsage("acc-second", 0.1, "plus")],
+		]);
+		const storage = openStorage("fixed", codexUsageProvider(reports));
+		await seedTwoCodexAccounts(storage);
+
+		expect(await storage.getApiKey(CODEX_PROVIDER, "codex-fixed", { modelId: PLAN_GATED_CODEX_MODEL })).toBe(
+			"access-first",
+		);
+	});
+
+	test("fixed: a plan-gated Codex request skips a first account whose plan is ineligible", async () => {
+		// Regression: fixed selection stops consulting plan tiers and sends a
+		// paid-only model to a free account, which the provider rejects.
+		mockOAuthRefresh();
+		const reports = new Map<string, UsageReport>([
+			["acc-first", codexUsage("acc-first", 0.1, "free")],
+			["acc-second", codexUsage("acc-second", 0.1, "plus")],
+		]);
+		const storage = openStorage("fixed", codexUsageProvider(reports));
+		await seedTwoCodexAccounts(storage);
+
+		expect(await storage.getApiKey(CODEX_PROVIDER, "codex-fixed-plan", { modelId: PLAN_GATED_CODEX_MODEL })).toBe(
+			"access-second",
+		);
+	});
+});

--- a/packages/ai/test/auth-storage-account-selection.test.ts
+++ b/packages/ai/test/auth-storage-account-selection.test.ts
@@ -11,6 +11,7 @@ import {
 } from "@oh-my-pi/pi-ai/auth-storage";
 import * as oauthUtils from "@oh-my-pi/pi-ai/registry/oauth";
 import type { UsageProvider, UsageReport } from "@oh-my-pi/pi-ai/usage";
+import * as claudeUsage from "@oh-my-pi/pi-ai/usage/claude";
 import { removeWithRetries } from "../../utils/src/temp";
 
 const OAUTH_PROVIDER = "unit-account-selection";
@@ -274,5 +275,99 @@ describe("AuthStorage account selection policy", () => {
 		expect(await storage.getApiKey(CODEX_PROVIDER, "codex-fixed-plan", { modelId: PLAN_GATED_CODEX_MODEL })).toBe(
 			"access-second",
 		);
+	});
+
+	const SHORT_BLOCK_MS = 20;
+
+	test("balanced (default) keeps a session on the sibling it fell through to after the primary unblocks", async () => {
+		// Negative contract for the fixed test below: warm-cache stickiness is the
+		// documented balanced behaviour and must not silently change.
+		mockOAuthRefresh();
+		const storage = openStorage();
+		await seedThreeOAuthAccounts(storage);
+		expect(await resolveEmail(storage, "sticky-session")).toBe("a@example.com");
+		await storage.markUsageLimitReached(OAUTH_PROVIDER, "sticky-session", { retryAfterMs: SHORT_BLOCK_MS });
+		expect(await resolveEmail(storage, "sticky-session")).toBe("b@example.com");
+
+		await Bun.sleep(SHORT_BLOCK_MS * 3);
+
+		expect(await resolveEmail(storage, "sticky-session")).toBe("b@example.com");
+	});
+
+	test("fixed: a session that fell through to a sibling returns to the first account once it unblocks", async () => {
+		// Regression: automatic stickiness keeps the session on the backup account
+		// forever, so "always use the first account" only holds for new sessions.
+		mockOAuthRefresh();
+		const storage = openStorage("fixed");
+		await seedThreeOAuthAccounts(storage);
+		expect(await resolveEmail(storage, "recovering-session")).toBe("a@example.com");
+		await storage.markUsageLimitReached(OAUTH_PROVIDER, "recovering-session", { retryAfterMs: SHORT_BLOCK_MS });
+		expect(await resolveEmail(storage, "recovering-session")).toBe("b@example.com");
+
+		await Bun.sleep(SHORT_BLOCK_MS * 3);
+
+		expect(await resolveEmail(storage, "recovering-session")).toBe("a@example.com");
+	});
+
+	test("fixed: an explicit session pin still wins, survives resolves and restarts, but a restored pin yields", async () => {
+		// Regression: `/session pin` becomes a no-op under fixed selection, or a
+		// resumed session's replayed sticky keeps it off the first account.
+		mockOAuthRefresh();
+		const credentialStore = store;
+		if (!credentialStore) throw new Error("test setup failed");
+		const storage = openStorage("fixed");
+		await seedThreeOAuthAccounts(storage);
+		const second = storage.listOAuthAccounts(OAUTH_PROVIDER)[1];
+		if (!second) throw new Error("expected second OAuth account");
+
+		expect(storage.pinSessionOAuthAccount(OAUTH_PROVIDER, "user-pin", second.credentialId)).toBe(true);
+		expect(await resolveEmail(storage, "user-pin")).toBe("b@example.com");
+		expect(await resolveEmail(storage, "user-pin")).toBe("b@example.com");
+
+		const restarted = new AuthStorage(credentialStore, { accountSelection: "fixed" });
+		await restarted.reload();
+		expect(await resolveEmail(restarted, "user-pin")).toBe("b@example.com");
+
+		expect(
+			restarted.pinSessionOAuthAccount(OAUTH_PROVIDER, "resumed", second.credentialId, { origin: "restore" }),
+		).toBe(true);
+		expect(await resolveEmail(restarted, "resumed")).toBe("a@example.com");
+	});
+
+	test("fixed: a tier-scoped rate-limit block on the first API key falls through for that tier only", async () => {
+		// Regression: fixed API-key selection ignores scoped blocks, so the gateway
+		// retry after a Fable 429 receives the same blocked key again.
+		vi.spyOn(claudeUsage.claudeUsageProvider, "fetchUsage").mockResolvedValue(null);
+		const storage = openStorage("fixed");
+		await storage.set("anthropic", [
+			{ type: "api_key", key: "sk-first", source: "login" },
+			{ type: "api_key", key: "sk-second", source: "login" },
+		]);
+		expect(await storage.getApiKey("anthropic", "fable-session", { modelId: "claude-fable-5" })).toBe("sk-first");
+
+		await storage.markUsageLimitReached("anthropic", "fable-session", { modelId: "claude-fable-5" });
+
+		expect(await storage.getApiKey("anthropic", "fable-retry", { modelId: "claude-fable-5" })).toBe("sk-second");
+		expect(await storage.getApiKey("anthropic", "sonnet-session", { modelId: "claude-sonnet-4-5" })).toBe("sk-first");
+	});
+
+	test("setAccountSelection switches the policy for subsequent lookups", async () => {
+		// Regression: the settings layer (config overlays) can no longer override
+		// what discovery read from config.yml.
+		mockOAuthRefresh();
+		const storage = openStorage();
+		await seedThreeOAuthAccounts(storage);
+		expect([await storage.getApiKey(OAUTH_PROVIDER), await storage.getApiKey(OAUTH_PROVIDER)]).toEqual([
+			"access-a",
+			"access-b",
+		]);
+
+		storage.setAccountSelection("fixed");
+
+		expect(storage.accountSelection).toBe("fixed");
+		expect([await storage.getApiKey(OAUTH_PROVIDER), await storage.getApiKey(OAUTH_PROVIDER)]).toEqual([
+			"access-a",
+			"access-a",
+		]);
 	});
 });

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Added the `auth.accountSelection` setting (`balanced` | `fixed`): `fixed` keeps every session on the first logged-in account of a provider and only moves to a sibling when it is rate-limited or exhausted, instead of balancing sessions across accounts by usage headroom ([#10766](https://github.com/can1357/oh-my-pi/pull/10766) by [@realitsyourman](https://github.com/realitsyourman)).
+- Added the `auth.accountSelection` setting (`balanced` | `fixed`): `fixed` keeps every session on the first logged-in account of a provider and only moves to a sibling when it is rate-limited or exhausted, instead of balancing sessions across accounts by usage headroom; a session returns to the first account once it recovers, and an explicit `/session pin` still wins ([#10766](https://github.com/can1357/oh-my-pi/pull/10766) by [@realitsyourman](https://github.com/realitsyourman)).
 
 ### Fixed
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added the `auth.accountSelection` setting (`balanced` | `fixed`): `fixed` keeps every session on the first logged-in account of a provider and only moves to a sibling when it is rate-limited or exhausted, instead of balancing sessions across accounts by usage headroom ([#10766](https://github.com/can1357/oh-my-pi/pull/10766) by [@realitsyourman](https://github.com/realitsyourman)).
+
 ### Fixed
 
 - Fixed two idle subagents exchanging a single IRC message ping-ponging forever: wake-turn relays are now tagged and never relayed back, so each automated relay is delivered exactly once instead of waking a reciprocal relay until manual cancellation.

--- a/packages/coding-agent/src/cli/auth-gateway-cli.ts
+++ b/packages/coding-agent/src/cli/auth-gateway-cli.ts
@@ -32,9 +32,10 @@ import {
 } from "@oh-my-pi/pi-ai/auth-broker";
 import { DEFAULT_AUTH_GATEWAY_BIND, startAuthGateway } from "@oh-my-pi/pi-ai/auth-gateway";
 import { type GeneratedProvider, getBundledModels } from "@oh-my-pi/pi-catalog/models";
-import { getConfigRootDir, isEnoent, logger, VERSION } from "@oh-my-pi/pi-utils";
+import { getConfigRootDir, getProjectDir, isEnoent, logger, VERSION } from "@oh-my-pi/pi-utils";
 import chalk from "@oh-my-pi/pi-utils/chalk";
 import { ModelRegistry } from "../config/model-registry";
+import { Settings } from "../config/settings";
 import { type AuthBrokerClientConfig, resolveAuthBrokerConfig } from "../session/auth-broker-config";
 
 export type AuthGatewayAction = "serve" | "token" | "status" | "check";
@@ -177,6 +178,9 @@ async function runServe(flags: AuthGatewayCommandArgs["flags"]): Promise<void> {
 	}
 	const bind = flags.bind ?? DEFAULT_AUTH_GATEWAY_BIND;
 	const gatewayToken = flags.noAuth ? null : await ensureToken();
+	// The gateway routes every forwarded request through this storage, so it must
+	// honour the same `auth.accountSelection` policy as an interactive session.
+	const settings = await Settings.init({ cwd: getProjectDir() });
 
 	// Build a broker-backed AuthStorage — same pattern as discoverAuthStorage()
 	// in sdk.ts. The gateway never touches local SQLite.
@@ -194,6 +198,7 @@ async function runServe(flags: AuthGatewayCommandArgs["flags"]): Promise<void> {
 	// gateway only needs to construct the store and pass it in.
 	const storage = new AuthStorage(store, {
 		sourceLabel: `broker ${brokerConfig.url}`,
+		accountSelection: settings.get("auth.accountSelection"),
 	});
 	await storage.reload();
 

--- a/packages/coding-agent/src/cli/dry-balance-cli.ts
+++ b/packages/coding-agent/src/cli/dry-balance-cli.ts
@@ -531,6 +531,7 @@ async function createDefaultRuntime(): Promise<DryBalanceRuntime> {
 	try {
 		const cwd = getProjectDir();
 		const settings = await Settings.init({ cwd });
+		authStorage.setAccountSelection(settings.get("auth.accountSelection"));
 		const modelRegistry = new ModelRegistry(authStorage);
 		await loadCliExtensionProviders(modelRegistry, settings, cwd);
 		return {

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -368,6 +368,11 @@ export class ModelRegistry {
 	) {
 		this.#ignoreLocalModelConfig = options?.ignoreLocalModelConfig ?? false;
 		this.#settings = options?.settings;
+		// The settings layer (config overlays, project settings) decides the
+		// account-selection policy; discovery only saw `<agentDir>/config.yml`.
+		// Applied here so every boot path that hands the registry its settings
+		// (runRootCommand, createAgentSession) routes credentials the same way.
+		if (options?.settings) this.authStorage.setAccountSelection(options.settings.get("auth.accountSelection"));
 		this.#fetch =
 			options?.fetch ??
 			(isBunTestRuntime()

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -1,5 +1,5 @@
 import * as path from "node:path";
-import type { ApiKeyResolver, FetchImpl, UsageProvider } from "@oh-my-pi/pi-ai";
+import type { ApiKeyResolver, AuthAccountSelection, FetchImpl, UsageProvider } from "@oh-my-pi/pi-ai";
 import { registerCustomApi, unregisterCustomApis } from "@oh-my-pi/pi-ai/api-registry";
 import { registerOAuthProvider, unregisterOAuthProvider, unregisterOAuthProviders } from "@oh-my-pi/pi-ai/oauth";
 import type { OAuthCredentials, OAuthLoginCallbacks } from "@oh-my-pi/pi-ai/oauth/types";
@@ -182,6 +182,18 @@ function getDisabledProviderIdsFromSettings(settingsInstance?: Settings): Set<st
 		return new Set((settingsInstance ?? settings).get("disabledProviders"));
 	} catch {
 		return new Set();
+	}
+}
+
+/**
+ * Effective `auth.accountSelection`, or undefined when no settings source is
+ * available (SDK embedding, early boot) so discovery's `config.yml` value stands.
+ */
+function getAccountSelectionFromSettings(settingsInstance?: Settings): AuthAccountSelection | undefined {
+	try {
+		return (settingsInstance ?? settings).get("auth.accountSelection");
+	} catch {
+		return undefined;
 	}
 }
 
@@ -370,9 +382,11 @@ export class ModelRegistry {
 		this.#settings = options?.settings;
 		// The settings layer (config overlays, project settings) decides the
 		// account-selection policy; discovery only saw `<agentDir>/config.yml`.
-		// Applied here so every boot path that hands the registry its settings
-		// (runRootCommand, createAgentSession) routes credentials the same way.
-		if (options?.settings) this.authStorage.setAccountSelection(options.settings.get("auth.accountSelection"));
+		// Applied here so every boot path — explicit settings (runRootCommand,
+		// createAgentSession) or the initialised singleton (models/bench/commit
+		// runtimes) — routes credentials the same way.
+		const accountSelection = getAccountSelectionFromSettings(options?.settings);
+		if (accountSelection) this.authStorage.setAccountSelection(accountSelection);
 		this.#fetch =
 			options?.fetch ??
 			(isBunTestRuntime()

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1837,6 +1837,31 @@ export const SETTINGS_SCHEMA = {
 				"Maximum wait between retries, in ms. When the provider asks us to wait longer than this and no credential or model fallback succeeds, the request fails fast instead of sleeping (e.g. 3-hour Anthropic rate-limit windows). 0 disables the ceiling — to let the session auto-resume through provider-stated quota resets.",
 		},
 	},
+	"auth.accountSelection": {
+		type: "enum",
+		values: ["balanced", "fixed"] as const,
+		default: "balanced",
+		ui: {
+			tab: "model",
+			group: "Retry & Fallback",
+			label: "Account Selection",
+			description:
+				"How requests pick among multiple logged-in accounts of the same provider. Applies to OAuth accounts and stored API keys alike.",
+			options: [
+				{
+					value: "balanced",
+					label: "Balanced",
+					description: "Spread sessions across accounts and prefer the one with the most usage headroom",
+				},
+				{
+					value: "fixed",
+					label: "Fixed",
+					description:
+						"Always use the first stored account; move to the next only when it is rate-limited or exhausted",
+				},
+			],
+		},
+	},
 	"retry.modelFallback": {
 		type: "boolean",
 		default: true,

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -3088,6 +3088,7 @@ const SETTING_HOOKS: Partial<Record<SettingPath, SettingHook<any>>> = {
 	"hindsight.bankIdPrefix": () => hindsightScopeSignal.fire(),
 	"hindsight.scoping": () => hindsightScopeSignal.fire(),
 	extendedContext: () => extendedContextSignal.fire(),
+	"auth.accountSelection": () => accountSelectionSignal.fire(),
 	"worktree.base": value => {
 		const dir = typeof value === "string" && value.trim() ? value : undefined;
 		// Always call so an unset/empty value clears a previously-applied override.
@@ -3144,6 +3145,13 @@ const extendedContextSignal = new SettingSignal("extendedContext");
  * Returns an unsubscribe function.
  */
 export const onExtendedContextChanged = (cb: () => void) => extendedContextSignal.on(cb);
+
+/**
+ * Fires when the effective `auth.accountSelection` changes so live sessions can
+ * re-apply the policy to their `AuthStorage` without a restart.
+ */
+const accountSelectionSignal = new SettingSignal("auth.accountSelection");
+export const onAccountSelectionChanged = (cb: () => void) => accountSelectionSignal.on(cb);
 
 /** Fires when `statusLine.sessionAccent` changes at runtime. */
 const statusLineSessionAccentSignal = new SettingSignal("statusLine.sessionAccent");

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1342,6 +1342,10 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			"options.authStorage and options.modelRegistry.authStorage must be the same instance when both are provided",
 		);
 	}
+	// Discovery only read `<agentDir>/config.yml`; the settings layer also carries
+	// `--config` / `PI_CONFIG_FILES` overlays and project settings, so it decides the
+	// account-selection policy for storage this session created.
+	if (ownsAuthStorage) authStorage.setAccountSelection(settings.get("auth.accountSelection"));
 	// Subscribe before any getApiKey() call so startup model probes can't fire a
 	// credential_disabled event past us. An embedder's constructor handler makes the
 	// listener set non-empty from construction, which defeats AuthStorage's no-listener

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1342,6 +1342,10 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			"options.authStorage and options.modelRegistry.authStorage must be the same instance when both are provided",
 		);
 	}
+	// The settings layer is authoritative for account selection whichever caller
+	// built the registry (runRootCommand, benchmark harnesses, SDK hosts): a
+	// registry constructed before `Settings.init` never saw the effective policy.
+	authStorage.setAccountSelection(settings.get("auth.accountSelection"));
 	// Subscribe before any getApiKey() call so startup model probes can't fire a
 	// credential_disabled event past us. An embedder's constructor handler makes the
 	// listener set non-empty from construction, which defeats AuthStorage's no-listener

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1342,10 +1342,6 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			"options.authStorage and options.modelRegistry.authStorage must be the same instance when both are provided",
 		);
 	}
-	// Discovery only read `<agentDir>/config.yml`; the settings layer also carries
-	// `--config` / `PI_CONFIG_FILES` overlays and project settings, so it decides the
-	// account-selection policy for storage this session created.
-	if (ownsAuthStorage) authStorage.setAccountSelection(settings.get("auth.accountSelection"));
 	// Subscribe before any getApiKey() call so startup model probes can't fire a
 	// credential_disabled event past us. An embedder's constructor handler makes the
 	// listener set non-empty from construction, which defeats AuthStorage's no-listener

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -108,6 +108,7 @@ import { buildServiceTierByFamily } from "../config/service-tier";
 import type { Settings, SkillsSettings } from "../config/settings";
 import {
 	onAppendOnlyModeChanged,
+	onAccountSelectionChanged,
 	onCodeModeChanged,
 	onExtendedContextChanged,
 	onModelRolesChanged,
@@ -577,6 +578,7 @@ export class AgentSession {
 	#unsubscribeAppendOnly?: () => void;
 	#unsubscribeModelRoles?: () => void;
 	#unsubscribeExtendedContext?: () => void;
+	#unsubscribeAccountSelection?: () => void;
 	#unsubscribeCodeMode?: () => void;
 	/** Last (enable, providerId) tuple resolved by `#syncAppendOnlyContext` — used to skip no-op invalidations. */
 	#lastAppendOnlyResolution?: { enable: boolean; providerId: string | undefined };
@@ -1820,6 +1822,11 @@ export class AgentSession {
 		// restores) premium long-context windows, and the live model object must
 		// follow so compaction thresholds and context display react immediately.
 		this.#unsubscribeExtendedContext = onExtendedContextChanged(() => void this.#reapplyExtendedContextPolicy());
+		// Re-apply the account-selection policy when it is changed at runtime
+		// (`/settings`, `omp config set`): the registry only applied it at construction.
+		this.#unsubscribeAccountSelection = onAccountSelectionChanged(() =>
+			this.#modelRegistry.authStorage.setAccountSelection(this.settings.get("auth.accountSelection")),
+		);
 		this.#unsubscribeCodeMode = onCodeModeChanged(() => {
 			void this.#tools.reconcileCodeMode().catch(error => {
 				logger.warn("Code Mode reconcile after setting change failed", { error: String(error) });
@@ -4552,6 +4559,10 @@ export class AgentSession {
 		if (this.#unsubscribeExtendedContext) {
 			this.#unsubscribeExtendedContext();
 			this.#unsubscribeExtendedContext = undefined;
+		}
+		if (this.#unsubscribeAccountSelection) {
+			this.#unsubscribeAccountSelection();
+			this.#unsubscribeAccountSelection = undefined;
 		}
 		if (this.#unsubscribeCodeMode) {
 			this.#unsubscribeCodeMode();

--- a/packages/coding-agent/src/session/auth-storage.ts
+++ b/packages/coding-agent/src/session/auth-storage.ts
@@ -5,6 +5,7 @@
 
 export type {
 	ApiKeyCredential,
+	AuthAccountSelection,
 	AuthCredential,
 	AuthCredentialEntry,
 	AuthCredentialStore,

--- a/packages/coding-agent/src/session/credential-pin.ts
+++ b/packages/coding-agent/src/session/credential-pin.ts
@@ -55,10 +55,10 @@ export function credentialPinHash(provider: string, identity: CredentialPinIdent
 
 /**
  * Record the account that served the latest assistant turn for `provider`.
- * Appends a `credential_pin` entry only when the account differs from the
- * branch's latest pin, so steady-state sessions add a single entry; the
- * effective last-use time is derived from later assistant turns on read
- * (see `SessionManager.getCredentialPins`).
+ * Appends a `credential_pin` entry only when the account (or its explicit-pin
+ * origin) differs from the branch's latest pin, so steady-state sessions add a
+ * single entry; the effective last-use time is derived from later assistant
+ * turns on read (see `SessionManager.getCredentialPins`).
  */
 export function recordCredentialPin(
 	authStorage: AuthStorage,
@@ -69,8 +69,11 @@ export function recordCredentialPin(
 	const identity = authStorage.getOAuthAccountIdentity(provider, sessionId);
 	if (!identity) return;
 	const hash = credentialPinHash(provider, identity);
-	if (!hash || sessionManager.getCredentialPins().get(provider)?.hash === hash) return;
-	sessionManager.appendCredentialPin(provider, hash);
+	if (!hash) return;
+	const pinned = authStorage.isSessionOAuthAccountPinned(provider, sessionId);
+	const latest = sessionManager.getCredentialPins().get(provider);
+	if (latest?.hash === hash && latest.pinned === pinned) return;
+	sessionManager.appendCredentialPin(provider, hash, { pinned });
 }
 
 /**
@@ -78,7 +81,9 @@ export function recordCredentialPin(
  * session stickiness. No-op per provider when the account is gone (logged out)
  * or when a live sticky already exists (same-process branch/session switches
  * must not clobber fresher routing). Seeds with the session's effective
- * last-use time so stale resumes still fall through to usage ranking.
+ * last-use time so stale resumes still fall through to usage ranking. An
+ * explicit `/session pin` is replayed as a user pin so it keeps overriding
+ * `fixed` account selection; automatic pins are replayed as restores.
  */
 export function seedCredentialPins(authStorage: AuthStorage, sessionManager: SessionManager, sessionId: string): void {
 	for (const [provider, pin] of sessionManager.getCredentialPins()) {
@@ -88,7 +93,7 @@ export function seedCredentialPins(authStorage: AuthStorage, sessionManager: Ses
 		if (!match) continue;
 		authStorage.pinSessionOAuthAccount(provider, sessionId, match.credentialId, {
 			lastUsedAtMs: pin.lastUsedAt,
-			origin: "restore",
+			origin: pin.pinned ? "user" : "restore",
 		});
 	}
 }

--- a/packages/coding-agent/src/session/credential-pin.ts
+++ b/packages/coding-agent/src/session/credential-pin.ts
@@ -88,6 +88,7 @@ export function seedCredentialPins(authStorage: AuthStorage, sessionManager: Ses
 		if (!match) continue;
 		authStorage.pinSessionOAuthAccount(provider, sessionId, match.credentialId, {
 			lastUsedAtMs: pin.lastUsedAt,
+			origin: "restore",
 		});
 	}
 }

--- a/packages/coding-agent/src/session/session-entries.ts
+++ b/packages/coding-agent/src/session/session-entries.ts
@@ -226,6 +226,8 @@ export interface CredentialPinEntry extends SessionEntryBase {
 	provider: string;
 	/** `credentialPinHash()` of the serving account's identity + scope tuple. */
 	hash: string;
+	/** True when the account was chosen by an explicit `/session pin` rather than automatic routing. */
+	pinned?: boolean;
 }
 
 /** Session init entry - captures initial context for subagent sessions (debugging/replay). */

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -2522,13 +2522,17 @@ export class SessionManager {
 		return [...names];
 	}
 
-	/** Append a credential pin recording which OAuth account served `provider`. */
-	appendCredentialPin(provider: string, hash: string): string {
+	/**
+	 * Append a credential pin recording which OAuth account served `provider`.
+	 * `pinned` marks an explicit `/session pin` so a resume restores it as a user pin.
+	 */
+	appendCredentialPin(provider: string, hash: string, options?: { pinned?: boolean }): string {
 		const entry: CredentialPinEntry = {
 			type: "credential_pin",
 			...this.#freshEntryFields(),
 			provider,
 			hash,
+			...(options?.pinned ? { pinned: true } : {}),
 		};
 		this.#recordEntry(entry);
 		return entry.id;
@@ -2544,11 +2548,15 @@ export class SessionManager {
 	 * account, so its timestamp advances `lastUsedAt` — a resume seconds after
 	 * the last turn seeds a warm sticky instead of a stale one.
 	 */
-	getCredentialPins(): Map<string, { hash: string; lastUsedAt: number }> {
-		const pins = new Map<string, { hash: string; lastUsedAt: number }>();
+	getCredentialPins(): Map<string, { hash: string; lastUsedAt: number; pinned: boolean }> {
+		const pins = new Map<string, { hash: string; lastUsedAt: number; pinned: boolean }>();
 		for (const entry of this.getBranch()) {
 			if (entry.type === "credential_pin") {
-				pins.set(entry.provider, { hash: entry.hash, lastUsedAt: new Date(entry.timestamp).getTime() });
+				pins.set(entry.provider, {
+					hash: entry.hash,
+					lastUsedAt: new Date(entry.timestamp).getTime(),
+					pinned: entry.pinned === true,
+				});
 			} else if (entry.type === "message" && entry.message.role === "assistant") {
 				const pin = pins.get(entry.message.provider);
 				if (pin) pin.lastUsedAt = Math.max(pin.lastUsedAt, entry.message.timestamp);

--- a/packages/coding-agent/test/credential-pin.test.ts
+++ b/packages/coding-agent/test/credential-pin.test.ts
@@ -141,6 +141,64 @@ describe("credential pins", () => {
 		expect(active?.orgId).toBe("org-2");
 	});
 
+	test("an explicit pin is persisted as pinned and replayed as a user pin under fixed selection", async () => {
+		// Regression: `/session pin` is recorded like automatic routing, so a broker
+		// resume replays it as a restore and fixed selection snaps back to account a.
+		const manager = SessionManager.create(tempDir.path(), tempDir.path());
+		const sessionId = manager.getSessionId();
+		manager.appendMessage({ role: "user", content: "hello", timestamp: Date.now() });
+		manager.appendMessage(assistantMessage("anthropic", Date.now()));
+		const accountB = storage
+			.listOAuthAccounts("anthropic", sessionId)
+			.find(account => account.accountId === "account-b");
+		expect(storage.pinSessionOAuthAccount("anthropic", sessionId, accountB!.credentialId)).toBe(true);
+		recordCredentialPin(storage, manager, sessionId, "anthropic");
+		expect(manager.getCredentialPins().get("anthropic")?.pinned).toBe(true);
+		await manager.flush();
+
+		const file = manager.getSessionFile();
+		if (!file) throw new Error("expected a session file");
+		const reopened = await SessionManager.open(file);
+		expect(reopened.getCredentialPins().get("anthropic")?.pinned).toBe(true);
+
+		// Fresh process with fixed selection and no sticky (broker-mode resume).
+		const freshStore = new SqliteAuthCredentialStore(new Database(":memory:"));
+		freshStore.saveOAuth("anthropic", mintOAuthCredential("a"));
+		freshStore.saveOAuth("anthropic", mintOAuthCredential("b"));
+		const fixedStorage = new AuthStorage(freshStore, { accountSelection: "fixed" });
+		await fixedStorage.reload();
+		seedCredentialPins(fixedStorage, reopened, sessionId);
+
+		// Replayed as a user pin: fixed selection keeps honouring it (pi-ai's
+		// account-selection tests cover the resolve semantics of a user pin).
+		expect(fixedStorage.listOAuthAccounts("anthropic", sessionId).find(account => account.active)?.accountId).toBe(
+			"account-b",
+		);
+		expect(fixedStorage.isSessionOAuthAccountPinned("anthropic", sessionId)).toBe(true);
+	});
+
+	test("an automatic pin is replayed as a restore and yields to fixed selection", async () => {
+		const manager = SessionManager.create(tempDir.path(), tempDir.path());
+		const sessionId = manager.getSessionId();
+		const hash = credentialPinHash("anthropic", { accountId: "account-b", email: "b@example.com" });
+		manager.appendCredentialPin("anthropic", hash!);
+		expect(manager.getCredentialPins().get("anthropic")?.pinned).toBe(false);
+
+		const freshStore = new SqliteAuthCredentialStore(new Database(":memory:"));
+		freshStore.saveOAuth("anthropic", mintOAuthCredential("a"));
+		freshStore.saveOAuth("anthropic", mintOAuthCredential("b"));
+		const fixedStorage = new AuthStorage(freshStore, { accountSelection: "fixed" });
+		await fixedStorage.reload();
+		seedCredentialPins(fixedStorage, manager, sessionId);
+
+		// Replayed as a restore: the sticky exists for warm-cache reuse under
+		// balanced, but fixed selection may route back to the first account.
+		expect(fixedStorage.listOAuthAccounts("anthropic", sessionId).find(account => account.active)?.accountId).toBe(
+			"account-b",
+		);
+		expect(fixedStorage.isSessionOAuthAccountPinned("anthropic", sessionId)).toBe(false);
+	});
+
 	test("seeding never clobbers a live sticky from the same process", () => {
 		const manager = SessionManager.create(tempDir.path(), tempDir.path());
 		const sessionId = manager.getSessionId();

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -1688,6 +1688,25 @@ describe("ModelRegistry", () => {
 			expect(registry.getDiscoverableProviders()).not.toContain("ollama");
 		});
 
+		test("applies the settings layer's auth.accountSelection to its AuthStorage", async () => {
+			// Regression: `omp --config` / `PI_CONFIG_FILES` overlays set the policy in
+			// Settings but credential routing keeps whatever discovery read from config.yml.
+			const settingsInstance = await Settings.init({
+				inMemory: true,
+				overrides: { "auth.accountSelection": "fixed" },
+			});
+
+			new ModelRegistry(authStorage, modelsJsonPath, { settings: settingsInstance });
+			expect(authStorage.accountSelection).toBe("fixed");
+
+			// The settings layer is authoritative in both directions.
+			authStorage.setAccountSelection("fixed");
+			resetSettingsForTest();
+			const defaults = await Settings.init({ inMemory: true });
+			new ModelRegistry(authStorage, modelsJsonPath, { settings: defaults });
+			expect(authStorage.accountSelection).toBe("balanced");
+		});
+
 		test("refresh skips discovery probes for disabled local providers", async () => {
 			await Settings.init({
 				inMemory: true,

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -1707,6 +1707,20 @@ describe("ModelRegistry", () => {
 			expect(authStorage.accountSelection).toBe("balanced");
 		});
 
+		test("falls back to the initialised Settings singleton when constructed without settings", async () => {
+			// Regression: `omp models --config fixed.yml` (and bench/commit/cleanse
+			// runtimes) build the registry without passing settings and keep routing
+			// by whatever discovery read from config.yml.
+			await Settings.init({
+				inMemory: true,
+				overrides: { "auth.accountSelection": "fixed" },
+			});
+
+			new ModelRegistry(authStorage, modelsJsonPath);
+
+			expect(authStorage.accountSelection).toBe("fixed");
+		});
+
 		test("refresh skips discovery probes for disabled local providers", async () => {
 			await Settings.init({
 				inMemory: true,

--- a/packages/coding-agent/test/sdk-model-selection.test.ts
+++ b/packages/coding-agent/test/sdk-model-selection.test.ts
@@ -130,6 +130,25 @@ describe("createAgentSession deferred model pattern resolution", () => {
 		};
 	}
 
+	test("applies auth.accountSelection from the settings layer to a caller-provided ModelRegistry", async () => {
+		// Regression: harnesses that build the registry before Settings.init (the
+		// TypeScript edit benchmark) keep discovery's balanced policy for every request.
+		const settings = Settings.isolated({ "auth.accountSelection": "fixed" });
+		expect(fixtureAuthStorage.accountSelection).toBe("balanced");
+
+		const { session } = await createAgentSession({
+			...buildSessionOptions("runtime-provider/runtime-model"),
+			settings,
+		});
+
+		try {
+			expect(fixtureAuthStorage.accountSelection).toBe("fixed");
+		} finally {
+			await session.dispose();
+			fixtureAuthStorage.setAccountSelection("balanced");
+		}
+	});
+
 	test("resolves explicit modelPattern after extension providers register", async () => {
 		const { session, modelFallbackMessage } = await createAgentSession(
 			buildSessionOptions("runtime-provider/runtime-model"),

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -9,6 +9,7 @@ import { __providerInFlightForTesting, streamSimple } from "@oh-my-pi/pi-ai/stre
 import type { Context } from "@oh-my-pi/pi-ai/types";
 import {
 	__physicalTargetSegmentsForTesting,
+	onAccountSelectionChanged,
 	onAppendOnlyModeChanged,
 	onCodeModeChanged,
 	onModelRolesChanged,
@@ -1155,6 +1156,28 @@ describe("Settings", () => {
 			expect(Settings.isolated({ inlineToolDescriptors: true }).get("inlineToolDescriptors")).toBe("on");
 			expect(Settings.isolated({ inlineToolDescriptors: false }).get("inlineToolDescriptors")).toBe("off");
 			expect(Settings.isolated().get("inlineToolDescriptors")).toBe("auto");
+		});
+	});
+
+	describe("auth.accountSelection hooks", () => {
+		it("notifies subscribers when the policy is set at runtime", () => {
+			// Regression: switching Balanced -> Fixed in /settings leaves the live
+			// AuthStorage balanced until the next process start.
+			const isolated = Settings.isolated();
+			const values: string[] = [];
+			const unsubscribe = onAccountSelectionChanged(() => {
+				values.push(isolated.get("auth.accountSelection"));
+			});
+
+			try {
+				isolated.set("auth.accountSelection", "fixed");
+				expect(values).toEqual(["fixed"]);
+
+				isolated.set("auth.accountSelection", "balanced");
+				expect(values).toEqual(["fixed", "balanced"]);
+			} finally {
+				unsubscribe();
+			}
 		});
 	});
 


### PR DESCRIPTION
## Summary

Adds `auth.accountSelection` (`balanced` | `fixed`, default `balanced`) so multi-account users can opt out of account balancing.

With `fixed`, every OAuth / API-key lookup starts from the first stored credential of the provider and only moves to a sibling once that credential is blocked (rate-limited, exhausted, refresh failure). Usage reports are not consulted for selection any more. Plan-gated `openai-codex` models still verify tier eligibility, but tie-break on stored position instead of usage headroom, so a hot primary account is no longer silently swapped for the backup.

`balanced` is unchanged.

Session stickiness under `fixed`: a session that fell through to a sibling returns to the first account once it is available again. An explicit `/session pin` still wins (persisted with a `pinned` marker in the sticky cache and in the session file's `credential_pin` entry, so a broker-backed resume replays it as a user pin); automatic pins replayed from a session file yield to the fixed order.

The effective policy inside omp comes from the settings layer (`omp config set auth.accountSelection fixed`, i.e. the nested `auth: { accountSelection }` form, including `--config` / `PI_CONFIG_FILES` overlays and project settings). `discoverAuthStorage` also reads the key from `config.yml` for pi-ai consumers that never load `Settings`.

- `packages/ai`: `AuthStorageOptions.accountSelection` + `AuthStorage.accountSelection` getter; `#getCredentialOrder` returns stored order, `#resolveOAuthSelection` / `#selectApiKeyCredential` skip usage ranking, `#compareUsageRankedCandidatePriority` stops after plan eligibility. `discoverAuthStorage` reads `auth.accountSelection` from `config.yml` (flat or nested, like `auth.broker.*`) and warns + falls back to `balanced` on unknown values.
- `packages/coding-agent`: `auth.accountSelection` enum setting (Model tab → Retry & Fallback); the effective value is applied to the `AuthStorage` (`setAccountSelection`) by `ModelRegistry` from explicit settings or the initialised singleton (covers `runRootCommand`, `omp models`, bench/commit/cleanse runtimes), by `createAgentSession` for whichever registry a caller hands it (benchmark harnesses that build the registry before `Settings.init`), explicitly in `omp dry-balance` and `omp auth-gateway serve`, and re-applied live by `AgentSession` through the new `onAccountSelectionChanged` hook when the setting changes at runtime (`/settings`, reload).
- Changelog entries in both packages.

**Author note:** I reviewed the full diff. I use two accounts and didn't like that the account changed on every session, so I added a fixed option.

## Verification

- `bun run check` in `packages/ai` and `packages/coding-agent`: pass.
- `bun test test/auth-storage-*.test.ts test/auth-broker-*.test.ts` in `packages/ai`: 404 pass (incl. 17 new tests in `auth-storage-account-selection.test.ts` and `auth-broker-account-selection-config.test.ts`: fixed vs balanced routing, blocked fallthrough and return to the primary, explicit vs restored pins, tier-scoped API-key blocks, plan-gated Codex, `setAccountSelection`, config parsing).
- `packages/coding-agent`: `settings-layout`, `sdk-model-selection`, `agent-session-retry-fallback` tests pass.
- End to end with `omp dry-balance` (source tree, isolated `PI_CODING_AGENT_DIR` with two stored accounts per provider):

  | config | model | first | second |
  |---|---|---|---|
  | (none) | github-copilot/gpt-5.4 | 21 | 19 |
  | `auth.accountSelection: fixed` | github-copilot/gpt-5.4 | 40 | 0 |
  | `auth.accountSelection: fixed` | openai-codex/gpt-5.6-terra | 40 | 0 |
  | `auth.accountSelection: fixed` | openai-codex/gpt-5.6-sol (plan-gated) | 40 | 0 |
  | nested `auth: { accountSelection: fixed }` | github-copilot/gpt-5.4 | 40 | 0 |
  | `auth.accountSelection: sticky` (invalid) | github-copilot/gpt-5.4 | 25 | 15 |
  | nested `fixed` via `PI_CONFIG_FILES` overlay only (no config.yml) | github-copilot/gpt-5.4 | 40 | 0 |
  | config.yml `fixed` + overlay `balanced` (overlay wins) | github-copilot/gpt-5.4 | 17 | 23 |

- `omp config set auth.accountSelection fixed` writes the nested key and `config get` reads it back; `config set auth.accountSelection sticky` is rejected with `Valid values: balanced, fixed`.
