### PR TITLE
fix(tools): report actual artifact read byte limit

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed two idle subagents exchanging a single IRC message ping-ponging forever: wake-turn relays are now tagged and never relayed back, so each automated relay is delivered exactly once instead of waking a reciprocal relay until manual cancellation.
+- Fixed byte-limited artifact reads reporting the displayed byte count as the read limit instead of the actual budget ([#10764](https://github.com/can1357/oh-my-pi/issues/10764)).
 
 ## [18.1.8] - 2026-09-03
 

--- a/packages/coding-agent/src/tools/output-meta.ts
+++ b/packages/coding-agent/src/tools/output-meta.ts
@@ -91,6 +91,8 @@ export interface TruncationOptions {
 	startLine?: number;
 	totalFileLines?: number;
 	artifactId?: string;
+	/** Byte budget that stopped the read, when truncation is byte-limited. */
+	maxBytes?: number;
 }
 
 export interface TruncationSummaryOptions {
@@ -125,7 +127,7 @@ export class OutputMetaBuilder {
 	truncation(result: TruncationResult, options: TruncationOptions): this {
 		if (!result.truncated) return this;
 
-		const { direction, startLine = 1, totalFileLines, artifactId } = options;
+		const { direction, startLine = 1, totalFileLines, artifactId, maxBytes } = options;
 		const outputLines = result.outputLines ?? result.totalLines;
 		const outputBytes = result.outputBytes ?? result.totalBytes;
 		const isMiddle = direction === "middle" || result.truncatedBy === "middle";
@@ -187,6 +189,7 @@ export class OutputMetaBuilder {
 			totalBytes: result.totalBytes,
 			outputLines,
 			outputBytes,
+			maxBytes,
 			shownRange: { start: shownStart, end: shownEnd },
 			artifactId,
 			nextOffset: direction === "head" ? shownEnd + 1 : undefined,

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -2288,7 +2288,9 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 			.text(outputText)
 			.sourcePath(artifact.path)
 			.sourceInternal(url.href);
-		if (truncationInfo) resultBuilder.truncation(truncationInfo.result, truncationInfo.options);
+		if (truncationInfo) {
+			resultBuilder.truncation(truncationInfo.result, { ...truncationInfo.options, maxBytes: maxBytesForRead });
+		}
 		return resultBuilder.done();
 	}
 

--- a/packages/coding-agent/test/tools.test.ts
+++ b/packages/coding-agent/test/tools.test.ts
@@ -951,6 +951,25 @@ describe("Coding Agent Tools", () => {
 			expect(result.details?.truncation?.outputLines).toBe(defaultLimit);
 		});
 
+		it("reports the artifact byte budget that truncated a ranged read", async () => {
+			const artifactsDir = path.join(testDir, "artifact-limit-session");
+			fs.mkdirSync(artifactsDir, { recursive: true });
+			fs.writeFileSync(path.join(artifactsDir, "7.mcp.log"), `skip\n{\n${"x".repeat(60 * 1024)}\ntail`);
+			const artifactSession = createTestToolSession(testDir, Settings.isolated(), {
+				localProtocolOptions: {
+					getArtifactsDir: () => artifactsDir,
+					getSessionId: () => "artifact-limit-session",
+				},
+			});
+			const artifactReadTool = wrapToolWithMetaNotice(new ReadTool(artifactSession));
+
+			const result = await artifactReadTool.execute("test-call-artifact-byte-limit", {
+				path: "artifact://7:3-4",
+			});
+
+			expect(getTextOutput(result)).toContain("[Showing lines 2-2 of 4 (50.0KB limit). Use :3 to continue]");
+		});
+
 		it("should spill oversized read output to an artifact", async () => {
 			const testFile = path.join(testDir, "oversized-read.txt");
 			const line = "0123456789".repeat(20);


### PR DESCRIPTION
## Repro
A 60KB synthetic artifact with a one-byte context line followed by an over-budget line reproduces the bad notice with `bun test packages/coding-agent/test/tools.test.ts --test-name-pattern 'reports the artifact byte budget'`: before the fix it rendered `(1B limit)` instead of the 50KB read budget.

## Cause
`ReadTool.#readArtifactFile` in `packages/coding-agent/src/tools/read.ts` computed `maxBytesForRead`, but passed only the collected-byte `TruncationResult` into `OutputMetaBuilder.truncation`; `packages/coding-agent/src/tools/output-meta.ts` therefore had no configured budget and `formatTruncationMetaNotice` fell back to `outputBytes` under the `limit` label.

## Fix
- Add the byte budget to `TruncationOptions` and preserve it in `TruncationMeta`.
- Pass `maxBytesForRead` from ranged artifact reads into the truncation metadata builder.
- Cover the misleading one-byte context-line case and document the user-facing fix.

## Verification
`bun test packages/coding-agent/test/tools.test.ts --test-name-pattern 'reports the artifact byte budget'` passes (1 pass, 0 fail). `bun check` passes.

Fixes #10764