### PR TITLE
fix(tools): account for partial-line preview in read truncation notice

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed two idle subagents exchanging a single IRC message ping-ponging forever: wake-turn relays are now tagged and never relayed back, so each automated relay is delivered exactly once instead of waking a reciprocal relay until manual cancellation.
+- Fixed the read tool's truncation notice reporting `Showing 0 of N lines` (with `outputLines`/`outputBytes` of 0) when a single line larger than the byte budget is shown as a partial preview; it now reports the delivered partial line, e.g. `Showing line N (partial, 50.0KB of 68.4KB) of N` ([#10768](https://github.com/can1357/oh-my-pi/issues/10768)).
 
 ## [18.1.8] - 2026-09-03
 

--- a/packages/coding-agent/src/tools/output-meta.ts
+++ b/packages/coding-agent/src/tools/output-meta.ts
@@ -44,6 +44,12 @@ export interface TruncationMeta {
 	artifactId?: string;
 	/** Next offset for pagination (head truncation only) */
 	nextOffset?: number;
+	/**
+	 * The single shown line is a byte-capped preview of one oversized line, not
+	 * a complete line. `outputBytes`/`totalBytes` are the preview vs full line
+	 * size; renders a distinct "partial" notice instead of a line range.
+	 */
+	partialLine?: boolean;
 }
 
 /**
@@ -136,6 +142,24 @@ export class OutputMetaBuilder {
 				: "bytes";
 
 		const effectiveTotalLines = totalFileLines ?? result.totalLines;
+
+		if (result.firstLineExceedsLimit) {
+			// The window collected no complete line; the body is a byte-capped
+			// preview of one oversized line. Describe that partial line instead of
+			// deriving an empty range that renders "Showing 0 of N lines".
+			this.#meta.truncation = {
+				direction,
+				truncatedBy: "bytes",
+				totalLines: effectiveTotalLines,
+				totalBytes: result.totalBytes,
+				outputLines,
+				outputBytes,
+				shownRange: { start: startLine, end: startLine },
+				partialLine: true,
+				artifactId,
+			};
+			return this;
+		}
 
 		if (isMiddle) {
 			const elidedLines = result.elidedLines ?? Math.max(0, effectiveTotalLines - outputLines);
@@ -469,6 +493,15 @@ export function formatTruncationMetaNotice(truncation: TruncationMeta): string {
 		if (truncation.nextOffset != null) {
 			notice += `. Use :${truncation.nextOffset} to continue`;
 		}
+		if (truncation.artifactId != null) {
+			notice += `. ${formatFullOutputReference(truncation.artifactId)}`;
+		}
+		return notice;
+	}
+
+	if (truncation.partialLine) {
+		const line = truncation.shownRange?.start ?? 1;
+		notice = `Showing line ${line} (partial, ${formatBytes(truncation.outputBytes)} of ${formatBytes(truncation.totalBytes)}) of ${truncation.totalLines}`;
 		if (truncation.artifactId != null) {
 			notice += `. ${formatFullOutputReference(truncation.artifactId)}`;
 		}

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -1802,15 +1802,21 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 					const totalSelectedBytes = collectedBytes;
 					const wasTruncated = collectedLines.length < totalSelectedLines || stoppedByByteLimit;
 					const firstLineExceedsLimit = firstLineByteLength !== undefined && firstLineByteLength > maxBytesForRead;
+					// A first line larger than the byte budget collects no complete
+					// line, yet the window still renders a byte-capped preview.
+					// Account for that preview so the notice/meta describe the
+					// delivered partial line rather than reporting zero over the
+					// ~50 KB shown on screen.
+					const previewBytes = firstLineExceedsLimit ? (firstLinePreview?.bytes ?? 0) : 0;
 
 					const truncation: TruncationResult = {
 						content: selectedContent,
 						truncated: wasTruncated,
 						truncatedBy: stoppedByByteLimit ? "bytes" : wasTruncated ? "lines" : undefined,
 						totalLines: totalSelectedLines,
-						totalBytes: totalSelectedBytes,
-						outputLines: collectedLines.length,
-						outputBytes: collectedBytes,
+						totalBytes: firstLineExceedsLimit ? (firstLineByteLength ?? previewBytes) : totalSelectedBytes,
+						outputLines: firstLineExceedsLimit ? (previewBytes > 0 ? 1 : 0) : collectedLines.length,
+						outputBytes: firstLineExceedsLimit ? previewBytes : collectedBytes,
 						lastLinePartial: false,
 						firstLineExceedsLimit,
 					};
@@ -2215,14 +2221,17 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 		const totalSelectedLines = totalFileLines - startLine;
 		const wasTruncated = collectedLines.length < totalSelectedLines || stoppedByByteLimit;
 		const firstLineExceedsLimit = firstLineByteLength !== undefined && firstLineByteLength > maxBytesForRead;
+		// Mirror the plain-file path: a preview-only oversized first line must
+		// count as one delivered partial line, not zero.
+		const previewBytes = firstLineExceedsLimit ? (firstLinePreview?.bytes ?? 0) : 0;
 		const truncation: TruncationResult = {
 			content: selectedContent,
 			truncated: wasTruncated,
 			truncatedBy: stoppedByByteLimit ? "bytes" : wasTruncated ? "lines" : undefined,
 			totalLines: totalSelectedLines,
-			totalBytes: collectedBytes,
-			outputLines: collectedLines.length,
-			outputBytes: collectedBytes,
+			totalBytes: firstLineExceedsLimit ? (firstLineByteLength ?? previewBytes) : collectedBytes,
+			outputLines: firstLineExceedsLimit ? (previewBytes > 0 ? 1 : 0) : collectedLines.length,
+			outputBytes: firstLineExceedsLimit ? previewBytes : collectedBytes,
 			lastLinePartial: false,
 			firstLineExceedsLimit,
 		};

--- a/packages/coding-agent/test/tools/read-raw-range.test.ts
+++ b/packages/coding-agent/test/tools/read-raw-range.test.ts
@@ -5,6 +5,7 @@ import * as path from "node:path";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
 import { ReadTool } from "@oh-my-pi/pi-coding-agent/tools/read";
+import { formatTruncationMetaNotice } from "@oh-my-pi/pi-coding-agent/tools/output-meta";
 
 function getTextOutput(result: { content: Array<{ type: string; text?: string }> }): string {
 	return result.content
@@ -74,5 +75,32 @@ describe("read tool raw range exactness", () => {
 		expect(output).toContain("L31");
 		expect(output).toContain("L30");
 		expect(output).toContain("L32");
+	});
+
+	it("accounts for the displayed preview when a single raw line exceeds the byte budget", async () => {
+		// Regression #10768: an oversized first line collects no complete line but
+		// still renders a ~50 KB byte-capped preview. The truncation meta used to
+		// report outputLines=0/outputBytes=0/totalBytes=0, so the notice claimed
+		// "Showing 0 of N lines (0B limit)" over visible content.
+		const bigFile = path.join(testDir, "big.txt");
+		const bigLine = "x".repeat(70000);
+		await Bun.write(bigFile, `first\n${bigLine}\nlast\n`);
+
+		const result = await tool.execute("call-oversized-line", { path: `${bigFile}:raw:2-2` });
+		const body = getTextOutput(result);
+		expect(Buffer.byteLength(body, "utf-8")).toBeGreaterThan(50000);
+
+		const truncation = result.details?.meta?.truncation;
+		expect(truncation).toBeDefined();
+		if (!truncation) throw new Error("expected truncation meta");
+		expect(truncation.partialLine).toBe(true);
+		expect(truncation.outputLines).toBe(1);
+		expect(truncation.outputBytes).toBe(Buffer.byteLength(body, "utf-8"));
+		expect(truncation.totalBytes).toBe(70000);
+
+		const notice = formatTruncationMetaNotice(truncation);
+		expect(notice).toContain("(partial,");
+		expect(notice).not.toMatch(/Showing 0 of/);
+		expect(notice).not.toContain("0B limit");
 	});
 });


### PR DESCRIPTION
## Repro
Reading a file (or artifact) whose single requested line is larger than the read byte budget (`<path>:raw:N-N`, line > ~51,200 B) delivers ~51,200 B of that line as a byte-capped preview in the result body, but the truncation notice reports zero. Reproduced on the current default branch via `ReadTool.execute` on a file whose line 2 is 70,000 B (`<file>:raw:2-2`): body = 51,200 B; `details.meta.truncation` = `{outputLines:0, outputBytes:0, totalBytes:0, shownRange:{start:2,end:1}}`; rendered notice = `Showing 0 of 4 lines (0B limit). Use :2 to continue`.

## Cause
The `firstLineExceedsLimit` branches in `read.ts` (`#executeInner` plain-file path and `#readArtifactFile`) build the `TruncationResult` from `collectedLines`/`collectedBytes` only. When the first line alone overflows the budget the window collects no complete line, so `outputLines`, `outputBytes`, and `totalBytes` are all 0 even though `firstLinePreview` (~50 KB) is rendered. `OutputMetaBuilder.truncation()` then derives `shownRange = startLine + outputLines - 1` → an empty range, and `formatTruncationMetaNotice` falls back to `Showing ${outputLines} of ${totalLines} lines`.

## Fix
- `read.ts`: in both `firstLineExceedsLimit` branches, populate the `TruncationResult` from the delivered preview — `outputLines` = 1 when a preview was shown, `outputBytes` = preview bytes, `totalBytes` = the full oversized line's byte length.
- `output-meta.ts`: add a `partialLine` field to `TruncationMeta`; `OutputMetaBuilder.truncation()` now emits a partial-line meta (single-line `shownRange`, `partialLine: true`) for the `firstLineExceedsLimit` case instead of an empty range.
- `output-meta.ts`: `formatTruncationMetaNotice` renders `Showing line N (partial, <shown> of <full>) of <total>` for partial-line meta.

## Verification
Added a regression test in `test/tools/read-raw-range.test.ts` asserting the meta accounts for the preview (`outputLines: 1`, `outputBytes` = delivered bytes, `totalBytes` = full line size, `partialLine: true`) and the notice reads `Showing line 2 (partial, 50.0KB of 68.4KB) of N` with no `Showing 0 of` / `0B limit`. `bun test test/tools/read-raw-range.test.ts -t "accounts for the displayed preview"` passes, as does the existing `read-single-pass.test.ts` oversized-line test. `bun check` passes. (Unrelated pre-existing failures in this worktree: tests hitting `getEditStore` throw `new EditStore()` undefined because the native `@oh-my-pi/pi-natives` addon is not loaded here — reproduced on pristine `main`, on code paths untouched by this change.) Fixes #10768