### PR TITLE
fix(coding-agent): honor disabled rule frontmatter

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Rules with `enabled: false` frontmatter are now omitted during discovery, matching disabled skills ([#10769](https://github.com/can1357/oh-my-pi/issues/10769)).
 - Fixed two idle subagents exchanging a single IRC message ping-ponging forever: wake-turn relays are now tagged and never relayed back, so each automated relay is delivered exactly once instead of waking a reciprocal relay until manual cancellation.
 
 ## [18.1.8] - 2026-09-03

--- a/packages/coding-agent/src/capability/rule.ts
+++ b/packages/coding-agent/src/capability/rule.ts
@@ -21,6 +21,8 @@ export const BUILTIN_DEFAULTS_PROVIDER_ID = "builtin-defaults";
  * Parsed frontmatter from rule files.
  */
 export interface RuleFrontmatter {
+	/** Whether discovery should omit this rule. */
+	enabled?: boolean;
 	description?: string;
 	globs?: string[];
 	alwaysApply?: boolean;

--- a/packages/coding-agent/src/discovery/agents.ts
+++ b/packages/coding-agent/src/discovery/agents.ts
@@ -17,7 +17,7 @@ import { type SlashCommand, slashCommandCapability } from "../capability/slash-c
 import { type SystemPrompt, systemPromptCapability } from "../capability/system-prompt";
 import type { LoadContext, LoadResult } from "../capability/types";
 import {
-	buildRuleFromMarkdown,
+	discoverRuleFromMarkdown,
 	calculateDepth,
 	createSourceMeta,
 	loadFilesFromDir,
@@ -185,7 +185,7 @@ async function loadRules(ctx: LoadContext): Promise<LoadResult<Rule>> {
 		loadFilesFromDir<Rule>(ctx, dir, PROVIDER_ID, level, {
 			extensions: ["md", "mdc"],
 			transform: (name, content, filePath, source) =>
-				buildRuleFromMarkdown(name, content, filePath, source, { stripNamePattern: /\.(md|mdc)$/ }),
+				discoverRuleFromMarkdown(name, content, filePath, source, { stripNamePattern: /\.(md|mdc)$/ }),
 		});
 
 	const results = await Promise.all([

--- a/packages/coding-agent/src/discovery/builtin.ts
+++ b/packages/coding-agent/src/discovery/builtin.ts
@@ -25,7 +25,7 @@ import { type CustomTool, toolCapability } from "../capability/tool";
 import type { LoadContext, LoadResult } from "../capability/types";
 import { expandTilde } from "../tools/path-utils";
 import {
-	buildRuleFromMarkdown,
+	discoverRuleFromMarkdown,
 	createSourceMeta,
 	discoverExtensionModulePaths,
 	expandEnvVarsDeep,
@@ -378,7 +378,7 @@ async function loadRules(ctx: LoadContext): Promise<LoadResult<Rule>> {
 		const result = await loadFilesFromDir<Rule>(ctx, rulesDir, PROVIDER_ID, level, {
 			extensions: ["md", "mdc"],
 			transform: (name, content, path, source) =>
-				buildRuleFromMarkdown(name, content, path, source, { stripNamePattern: /\.(md|mdc)$/ }),
+				discoverRuleFromMarkdown(name, content, path, source, { stripNamePattern: /\.(md|mdc)$/ }),
 		});
 		items.push(...result.items);
 		if (result.warnings) warnings.push(...result.warnings);
@@ -412,7 +412,8 @@ async function loadStickyRulesFile(filePath: string, level: "user" | "project"):
 	if (!content) return null;
 	const source = createSourceMeta(PROVIDER_ID, filePath, level);
 	const ruleName = level === "project" ? "RULES@project" : "RULES";
-	const rule = buildRuleFromMarkdown("RULES.md", content, filePath, source, { ruleName });
+	const rule = discoverRuleFromMarkdown("RULES.md", content, filePath, source, { ruleName });
+	if (!rule) return null;
 	// Force alwaysApply regardless of frontmatter — the whole point of RULES.md
 	// is to be reattached every turn.
 	return { ...rule, alwaysApply: true };

--- a/packages/coding-agent/src/discovery/claude-plugins.ts
+++ b/packages/coding-agent/src/discovery/claude-plugins.ts
@@ -18,7 +18,7 @@ import { type CustomTool, toolCapability } from "../capability/tool";
 import type { LoadContext, LoadResult } from "../capability/types";
 import { legacyProviderAllowed } from "./agent-plugin-format";
 import {
-	buildRuleFromMarkdown,
+	discoverRuleFromMarkdown,
 	type ClaudePluginRoot,
 	createSourceMeta,
 	expandEnvVarsDeep,
@@ -264,7 +264,7 @@ async function loadRules(ctx: LoadContext): Promise<LoadResult<Rule>> {
 			loadFilesFromDir<Rule>(ctx, path.join(root.path, "rules"), PROVIDER_ID, root.scope, {
 				extensions: ["md", "mdc"],
 				transform: (name, content, filePath, source) =>
-					buildRuleFromMarkdown(name, content, filePath, source, { stripNamePattern: /\.(md|mdc)$/ }),
+					discoverRuleFromMarkdown(name, content, filePath, source, { stripNamePattern: /\.(md|mdc)$/ }),
 			}),
 		),
 	);

--- a/packages/coding-agent/src/discovery/cline.ts
+++ b/packages/coding-agent/src/discovery/cline.ts
@@ -10,7 +10,7 @@ import { readDirEntries, readFile } from "../capability/fs";
 import type { Rule } from "../capability/rule";
 import { ruleCapability } from "../capability/rule";
 import type { LoadContext, LoadResult } from "../capability/types";
-import { buildRuleFromMarkdown, createSourceMeta, loadFilesFromDir } from "./helpers";
+import { createSourceMeta, discoverRuleFromMarkdown, loadFilesFromDir } from "./helpers";
 
 const PROVIDER_ID = "cline";
 const DISPLAY_NAME = "Cline";
@@ -53,7 +53,7 @@ async function loadRules(ctx: LoadContext): Promise<LoadResult<Rule>> {
 		const result = await loadFilesFromDir(ctx, found.path, PROVIDER_ID, "project", {
 			extensions: ["md"],
 			transform: (name, content, path, source) =>
-				buildRuleFromMarkdown(name, content, path, source, { stripNamePattern: /\.md$/ }),
+				discoverRuleFromMarkdown(name, content, path, source, { stripNamePattern: /\.md$/ }),
 		});
 
 		items.push(...result.items);
@@ -67,7 +67,8 @@ async function loadRules(ctx: LoadContext): Promise<LoadResult<Rule>> {
 		}
 
 		const source = createSourceMeta(PROVIDER_ID, found.path, "project");
-		items.push(buildRuleFromMarkdown("clinerules.md", content, found.path, source, { ruleName: "clinerules" }));
+		const rule = discoverRuleFromMarkdown("clinerules.md", content, found.path, source, { ruleName: "clinerules" });
+		if (rule) items.push(rule);
 	}
 
 	return { items, warnings };

--- a/packages/coding-agent/src/discovery/cursor.ts
+++ b/packages/coding-agent/src/discovery/cursor.ts
@@ -24,7 +24,7 @@ import type { Settings } from "../capability/settings";
 import { settingsCapability } from "../capability/settings";
 import type { LoadContext, LoadResult, SourceMeta } from "../capability/types";
 import {
-	buildRuleFromMarkdown,
+	discoverRuleFromMarkdown,
 	createSourceMeta,
 	expandEnvVarsDeep,
 	getProjectPath,
@@ -141,8 +141,8 @@ async function loadRules(ctx: LoadContext): Promise<LoadResult<Rule>> {
 	return { items, warnings };
 }
 
-function transformMDCRule(name: string, content: string, path: string, source: SourceMeta): Rule {
-	return buildRuleFromMarkdown(name, content, path, source, { stripNamePattern: /\.(mdc|md)$/ });
+function transformMDCRule(name: string, content: string, path: string, source: SourceMeta): Rule | null {
+	return discoverRuleFromMarkdown(name, content, path, source, { stripNamePattern: /\.(mdc|md)$/ });
 }
 
 // =============================================================================

--- a/packages/coding-agent/src/discovery/github.ts
+++ b/packages/coding-agent/src/discovery/github.ts
@@ -27,7 +27,7 @@ import { type Skill, skillCapability } from "../capability/skill";
 import type { LoadContext, LoadResult, SourceMeta } from "../capability/types";
 
 import {
-	buildRuleFromMarkdown,
+	discoverRuleFromMarkdown,
 	calculateDepth,
 	createSourceMeta,
 	getProjectPath,
@@ -206,9 +206,10 @@ function transformInstructionRule(
 		warnings.push(`Missing applyTo in ${filePath}; loaded without GitHub glob scoping.`);
 	}
 
-	const rule = buildRuleFromMarkdown(name, content, filePath, source, {
+	const rule = discoverRuleFromMarkdown(name, content, filePath, source, {
 		stripNamePattern: /\.instructions\.md$/,
 	});
+	if (!rule) return null;
 	if (applyToGlobs?.some(isAlwaysApplyGlob)) {
 		return { ...rule, alwaysApply: true, globs: undefined };
 	}

--- a/packages/coding-agent/src/discovery/helpers.ts
+++ b/packages/coding-agent/src/discovery/helpers.ts
@@ -198,21 +198,20 @@ export function parseArrayOrCSV(value: unknown): string[] | undefined {
 	return undefined;
 }
 
-/**
- * Build a canonical rule item from a markdown/markdown-frontmatter document.
- */
-export function buildRuleFromMarkdown(
+interface RuleMarkdownOptions {
+	ruleName?: string;
+	stripNamePattern?: RegExp;
+}
+
+function buildRule(
 	name: string,
-	content: string,
+	body: string,
+	frontmatter: RuleFrontmatter,
 	filePath: string,
 	source: SourceMeta,
-	options?: {
-		ruleName?: string;
-		stripNamePattern?: RegExp;
-	},
+	options?: RuleMarkdownOptions,
 ): Rule {
-	const { frontmatter, body } = parseFrontmatter(content, { source: filePath });
-	const { condition, astCondition, scope } = parseRuleConditionAndScope(frontmatter as RuleFrontmatter);
+	const { condition, astCondition, scope } = parseRuleConditionAndScope(frontmatter);
 
 	let globs: string[] | undefined;
 	if (Array.isArray(frontmatter.globs)) {
@@ -241,6 +240,31 @@ export function buildRuleFromMarkdown(
 		interruptMode,
 		_source: source,
 	};
+}
+
+/** Build a canonical rule from Markdown, including explicitly loaded disabled files. */
+export function buildRuleFromMarkdown(
+	name: string,
+	content: string,
+	filePath: string,
+	source: SourceMeta,
+	options?: RuleMarkdownOptions,
+): Rule {
+	const { frontmatter, body } = parseFrontmatter(content, { source: filePath });
+	return buildRule(name, body, frontmatter as RuleFrontmatter, filePath, source, options);
+}
+
+/** Build a discovered rule from Markdown, returning null when its frontmatter disables it. */
+export function discoverRuleFromMarkdown(
+	name: string,
+	content: string,
+	filePath: string,
+	source: SourceMeta,
+	options?: RuleMarkdownOptions,
+): Rule | null {
+	const { frontmatter, body } = parseFrontmatter(content, { source: filePath });
+	if (frontmatter.enabled === false) return null;
+	return buildRule(name, body, frontmatter as RuleFrontmatter, filePath, source, options);
 }
 
 /**

--- a/packages/coding-agent/src/discovery/omp-plugins.ts
+++ b/packages/coding-agent/src/discovery/omp-plugins.ts
@@ -30,7 +30,7 @@ import { type CustomTool, toolCapability } from "../capability/tool";
 import type { LoadContext, LoadResult } from "../capability/types";
 import { legacyProviderAllowed } from "./agent-plugin-format";
 import {
-	buildRuleFromMarkdown,
+	discoverRuleFromMarkdown,
 	createSourceMeta,
 	expandEnvVarsDeep,
 	loadFilesFromDir,
@@ -117,7 +117,7 @@ async function loadRules(ctx: LoadContext): Promise<LoadResult<Rule>> {
 			loadFilesFromDir<Rule>(ctx, path.join(root.path, "rules"), PROVIDER_ID, root.level, {
 				extensions: ["md", "mdc"],
 				transform: (name, content, filePath, source) =>
-					buildRuleFromMarkdown(name, content, filePath, source, { stripNamePattern: /\.(md|mdc)$/ }),
+					discoverRuleFromMarkdown(name, content, filePath, source, { stripNamePattern: /\.(md|mdc)$/ }),
 			}),
 		),
 	);

--- a/packages/coding-agent/src/discovery/windsurf.ts
+++ b/packages/coding-agent/src/discovery/windsurf.ts
@@ -18,7 +18,7 @@ import { type MCPServer, mcpCapability } from "../capability/mcp";
 import { type Rule, ruleCapability } from "../capability/rule";
 import type { LoadContext, LoadResult } from "../capability/types";
 import {
-	buildRuleFromMarkdown,
+	discoverRuleFromMarkdown,
 	createSourceMeta,
 	expandEnvVarsDeep,
 	getProjectPath,
@@ -109,7 +109,10 @@ async function loadRules(ctx: LoadContext): Promise<LoadResult<Rule>> {
 		const content = await readFile(userPath);
 		if (content) {
 			const source = createSourceMeta(PROVIDER_ID, userPath, "user");
-			items.push(buildRuleFromMarkdown("global_rules.md", content, userPath, source, { ruleName: "global_rules" }));
+			const rule = discoverRuleFromMarkdown("global_rules.md", content, userPath, source, {
+				ruleName: "global_rules",
+			});
+			if (rule) items.push(rule);
 		}
 	}
 
@@ -119,7 +122,7 @@ async function loadRules(ctx: LoadContext): Promise<LoadResult<Rule>> {
 		const result = await loadFilesFromDir<Rule>(ctx, projectRulesDir, PROVIDER_ID, "project", {
 			extensions: ["md"],
 			transform: (name, content, path, source) =>
-				buildRuleFromMarkdown(name, content, path, source, { stripNamePattern: /\.md$/ }),
+				discoverRuleFromMarkdown(name, content, path, source, { stripNamePattern: /\.md$/ }),
 		});
 		items.push(...result.items);
 		if (result.warnings) warnings.push(...result.warnings);

--- a/packages/coding-agent/test/discovery/builtin-rules-md.test.ts
+++ b/packages/coding-agent/test/discovery/builtin-rules-md.test.ts
@@ -149,6 +149,23 @@ test("alwaysApply is forced even when frontmatter says false", async () => {
 	expect(userRule?.content).toContain("Stick around anyway.");
 });
 
+test("enabled false omits a discovered rule", async () => {
+	const rulesDir = path.join(home, ".omp", "agent", "rules");
+	writeFile(
+		path.join(rulesDir, "disabled-example.md"),
+		"---\nenabled: false\ncondition: DISABLED_EXAMPLE\nscope: [tool:edit]\n---\nDisabled rule.\n",
+	);
+	writeFile(
+		path.join(rulesDir, "active-example.md"),
+		"---\ncondition: ACTIVE_EXAMPLE\nscope: [tool:edit]\n---\nActive rule.\n",
+	);
+
+	const rules = await loadNativeRules({ cwd: project, home, repoRoot: project });
+
+	expect(rules.find(rule => rule.name === "disabled-example")).toBeUndefined();
+	expect(rules.find(rule => rule.name === "active-example")?.condition).toEqual(["ACTIVE_EXAMPLE"]);
+});
+
 test("absent RULES.md does not produce a rule", async () => {
 	// No RULES.md anywhere — only a sibling .omp/rules/ to make sure the directory exists.
 	writeFile(path.join(home, ".omp", "agent", "rules", "other.md"), "# Unrelated rule\n");


### PR DESCRIPTION
## Repro

Create `~/.omp/agent/rules/disabled-example.md` with `enabled: false`, a `DISABLED_EXAMPLE` condition, and `tool:edit` scope, then run `omp ttsr test --json --source tool --tool edit --path src/a.jl DISABLED_EXAMPLE`; before this fix, `disabled-example` appears in `triggered`.

## Cause

`buildRuleFromMarkdown` in `packages/coding-agent/src/discovery/helpers.ts` parsed Markdown frontmatter into a `Rule` without checking `frontmatter.enabled`, and every rule discovery provider registered that result. Skill discovery had a separate early return for the same flag.

## Fix

- Added a discovery-specific Markdown rule builder that omits files with `enabled: false` while preserving explicit rule loading for inspection.
- Routed native and imported rule providers through the discovery-specific builder, including standalone and sticky rule files.
- Added native discovery regression coverage and an Unreleased changelog entry.

## Verification

`bun test packages/coding-agent/test/discovery/builtin-rules-md.test.ts` passes with 7 tests; `bun run check:types` passes in `packages/coding-agent`; the original isolated `omp ttsr test` repro now returns an empty `triggered` list for `disabled-example`.

Fixes #10769