### PR TITLE
fix(mnemopi): consolidate eligible working memory at session start

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed two idle subagents exchanging a single IRC message ping-ponging forever: wake-turn relays are now tagged and never relayed back, so each automated relay is delivered exactly once instead of waking a reciprocal relay until manual cancellation.
+- Fixed Mnemopi silently deleting explicitly retained/learned long-term memory after a session gap over 24h: eligible working memory is now consolidated to episodic at session start (before the first write can TTL-trim unpromoted rows), instead of only when `/memory enqueue` was run manually ([#10770](https://github.com/can1357/oh-my-pi/issues/10770)).
 
 ## [18.1.8] - 2026-09-03
 

--- a/packages/coding-agent/src/mnemopi/backend.ts
+++ b/packages/coding-agent/src/mnemopi/backend.ts
@@ -90,6 +90,9 @@ async function installMnemopiState(session: AgentSession, config: MnemopiBackend
 	await previous?.dispose();
 	try {
 		state.attachSessionListeners();
+		// Promote age-eligible working memory to episodic before the session's
+		// first write can TTL-trim unconsolidated retain/learn rows (#10770).
+		state.promoteEligibleWorkingMemory();
 		return state;
 	} catch (error) {
 		setMnemopiSessionState(session, undefined);

--- a/packages/coding-agent/src/mnemopi/state.ts
+++ b/packages/coding-agent/src/mnemopi/state.ts
@@ -624,6 +624,36 @@ export class MnemopiSessionState {
 	}
 
 	/**
+	 * Promote age-eligible working-memory rows to episodic once at session start,
+	 * before any write can trigger the working-memory TTL trim.
+	 *
+	 * `remember` runs `trimWorkingMemory` on every write, which deletes
+	 * unconsolidated rows older than `workingMemoryTtlHours` (24h). Consolidation
+	 * (`sleep`) is age-gated to rows >= 12h old, but otherwise only ran via the
+	 * explicit `/memory enqueue` path (`dispose` passes `sleep:false`, #4843), so
+	 * `retain`/`learn`/transcript rows that were never manually enqueued were
+	 * silently deleted after a >24h session gap (#10770). Running the age-gated
+	 * sleep here stamps `consolidated_at` on those rows before the session's first
+	 * write, so the `consolidated_at IS NULL` trim filter no longer removes them.
+	 *
+	 * Bank-global because each bank opens with `sessionId = <bank>`, so a single
+	 * session-scoped `sleep` covers rows written by every prior session. Cheap
+	 * when nothing is old enough — `sleep` short-circuits to a no-op with no
+	 * eligible rows — and failures are logged, never thrown, so a consolidation
+	 * error cannot make the backend inert.
+	 */
+	promoteEligibleWorkingMemory(): void {
+		if (this.aliasOf) return;
+		for (const memory of this.scoped.owned) {
+			try {
+				memory.sleep(false);
+			} catch (error) {
+				this.#logLifecycleFailure("startup consolidation", [this.scoped.retain.bank], error);
+			}
+		}
+	}
+
+	/**
 	 * Capture the current transcript by default, drain in-flight fact extraction,
 	 * and optionally run beam consolidation on every owned bank.
 	 * The explicit `/memory enqueue` path

--- a/packages/coding-agent/test/memory-tools.test.ts
+++ b/packages/coding-agent/test/memory-tools.test.ts
@@ -632,6 +632,85 @@ describe("Mnemopi backend lifecycle", () => {
 		expect(retainMemory.sleepAllSessions).toHaveBeenCalledTimes(1);
 	});
 
+	it("consolidates age-eligible working memory at session start so the next write does not TTL-trim it (#10770)", () => {
+		const state = registerMnemopiState();
+		const memory = state.getScopedRetainTarget().memory;
+		const beam = memory.beam;
+		// Explicit retain from a prior session: STATED, unconsolidated.
+		const retainId = memory.remember("durable lesson worth keeping across sessions", {
+			source: "coding-agent-retain",
+			importance: 0.75,
+			scope: "bank",
+			extract: false,
+		});
+		// Simulate a >24h session gap: past the 24h TTL and the 12h sleep gate.
+		const oldTs = new Date(Date.now() - 48 * 3_600_000).toISOString();
+		beam.db.run("UPDATE working_memory SET timestamp = ? WHERE id = ?", [oldTs, retainId]);
+
+		// Session start consolidation stamps consolidated_at before any write.
+		state.promoteEligibleWorkingMemory();
+		const consolidatedAt = (
+			beam.db.query("SELECT consolidated_at FROM working_memory WHERE id = ?").get(retainId) as {
+				consolidated_at: string | null;
+			} | null
+		)?.consolidated_at;
+		expect(consolidatedAt).not.toBeNull();
+
+		// A later write triggers trimWorkingMemory(); the consolidated row survives.
+		memory.remember("a fresh note in the new session", { source: "coding-agent-transcript", scope: "bank" });
+		expect(memory.get(retainId)).not.toBeNull();
+	});
+
+	it("promotes aged working memory when the backend starts a top-level session (#10770)", async () => {
+		const settings = Settings.isolated({
+			"memory.backend": "mnemopi",
+			"mnemopi.noEmbeddings": true,
+			"mnemopi.llmMode": "none",
+		});
+		// Seed an aged, unconsolidated retain row, then close the bank handles so
+		// backend.start reopens the same DB file from disk.
+		const seed = registerMnemopiState();
+		const seedMemory = seed.getScopedRetainTarget().memory;
+		const retainId = seedMemory.remember("aged durable lesson", {
+			source: "coding-agent-retain",
+			scope: "bank",
+			extract: false,
+		});
+		seedMemory.beam.db.run("UPDATE working_memory SET timestamp = ? WHERE id = ?", [
+			new Date(Date.now() - 48 * 3_600_000).toISOString(),
+			retainId,
+		]);
+		await seed.dispose({ consolidate: false });
+		registeredMnemopiState = undefined;
+		resetMemoryForTests();
+
+		const session = {
+			sessionId: TEST_SESSION_ID,
+			settings,
+			modelRegistry: { getApiKeyForProvider: async () => undefined, resolver: () => async () => undefined },
+			sessionManager: { getEntries: () => [], getCwd: () => "/tmp" },
+			emitNotice: () => {},
+			getHindsightSessionState: () => undefined,
+			subscribe: () => () => {},
+		} as never;
+		await mnemopiBackend.start({
+			session,
+			settings,
+			modelRegistry: { getApiKeyForProvider: async () => undefined, resolver: () => async () => undefined } as never,
+			agentDir: path.dirname(tempDbPath!),
+			taskDepth: 0,
+		});
+
+		const started = getMnemopiSessionState(session);
+		expect(started).toBeDefined();
+		registeredMnemopiState = started;
+		const row = started!
+			.getScopedRetainTarget()
+			.memory.beam.db.query("SELECT consolidated_at FROM working_memory WHERE id = ?")
+			.get(retainId) as { consolidated_at: string | null } | null;
+		expect(row?.consolidated_at).not.toBeNull();
+	});
+
 	it("does not re-store retained turns during consolidation or after resume", async () => {
 		const entries = Array.from({ length: 6 }, (_, index) => ({
 			type: "message",

--- a/packages/coding-agent/test/memory-tools.test.ts
+++ b/packages/coding-agent/test/memory-tools.test.ts
@@ -662,14 +662,19 @@ describe("Mnemopi backend lifecycle", () => {
 	});
 
 	it("promotes aged working memory when the backend starts a top-level session (#10770)", async () => {
+		// Resolve seed and started session to the SAME bank/db: `global` scoping
+		// with the shared `default` bank maps the retain bank straight to dbPath.
 		const settings = Settings.isolated({
 			"memory.backend": "mnemopi",
 			"mnemopi.noEmbeddings": true,
 			"mnemopi.llmMode": "none",
+			"mnemopi.scoping": "global",
+			"mnemopi.bank": "default",
+			"mnemopi.dbPath": makeMnemopiConfig().dbPath,
 		});
 		// Seed an aged, unconsolidated retain row, then close the bank handles so
 		// backend.start reopens the same DB file from disk.
-		const seed = registerMnemopiState();
+		const seed = registerMnemopiState(makeMnemopiConfig({ scoping: "global", bank: "default" }));
 		const seedMemory = seed.getScopedRetainTarget().memory;
 		const retainId = seedMemory.remember("aged durable lesson", {
 			source: "coding-agent-retain",
@@ -684,10 +689,11 @@ describe("Mnemopi backend lifecycle", () => {
 		registeredMnemopiState = undefined;
 		resetMemoryForTests();
 
+		const modelRegistry = { getApiKeyForProvider: async () => undefined, resolver: () => async () => undefined };
 		const session = {
 			sessionId: TEST_SESSION_ID,
 			settings,
-			modelRegistry: { getApiKeyForProvider: async () => undefined, resolver: () => async () => undefined },
+			modelRegistry,
 			sessionManager: { getEntries: () => [], getCwd: () => "/tmp" },
 			emitNotice: () => {},
 			getHindsightSessionState: () => undefined,
@@ -696,7 +702,7 @@ describe("Mnemopi backend lifecycle", () => {
 		await mnemopiBackend.start({
 			session,
 			settings,
-			modelRegistry: { getApiKeyForProvider: async () => undefined, resolver: () => async () => undefined } as never,
+			modelRegistry: modelRegistry as never,
 			agentDir: path.dirname(tempDbPath!),
 			taskDepth: 0,
 		});
@@ -704,11 +710,13 @@ describe("Mnemopi backend lifecycle", () => {
 		const started = getMnemopiSessionState(session);
 		expect(started).toBeDefined();
 		registeredMnemopiState = started;
-		const row = started!
-			.getScopedRetainTarget()
-			.memory.beam.db.query("SELECT consolidated_at FROM working_memory WHERE id = ?")
-			.get(retainId) as { consolidated_at: string | null } | null;
-		expect(row?.consolidated_at).not.toBeNull();
+		const memory = started!.getScopedRetainTarget().memory;
+		// The row must have survived start into the reopened bank, and a later
+		// write (which triggers trimWorkingMemory) must not remove it — start
+		// promoted it to episodic, so the TTL trim skips it.
+		expect(memory.get(retainId)).not.toBeNull();
+		memory.remember("a fresh note after start", { source: "coding-agent-transcript", scope: "bank" });
+		expect(memory.get(retainId)).not.toBeNull();
 	});
 
 	it("does not re-store retained turns during consolidation or after resume", async () => {


### PR DESCRIPTION
## Repro
Store an explicit `retain`/`learn` memory (or let a transcript auto-retain) in the Mnemopi backend, leave the project idle for over 24h, then start a new session and issue any write. The previously retained "long-term" row is gone. Reproduced against the current tree with `BeamMemory` directly (banks open with `sessionId = <bank>`, so trim/sleep are bank-global): an aged `source='coding-agent-retain'`, `trust_tier='STATED'`, `consolidated_at=NULL` row is present before a later `remember()` and deleted after it (`before write: true | after write: false`), cascading its facts/embeddings/annotations.

## Cause
`remember()` runs `trimWorkingMemory()` (`packages/mnemopi/src/core/beam/store.ts`) on every write, deleting `consolidated_at IS NULL` rows older than the 24h TTL. The only path that sets `consolidated_at` is `sleep()`, which is age-gated to rows >= 12h old and, in the coding-agent, previously ran only via the manual `/memory enqueue` path — `MnemopiSessionState.dispose()` passes `sleep:false` on the interactive exit path (#4843). So `retain`/`learn`/transcript rows that were never manually enqueued were never promoted to episodic before the TTL trim removed them, silently, after any >24h session gap. This is why the reporter observed empty `episodic_memory`/`consolidation_log` across every bank.

## Fix
- Add `MnemopiSessionState.promoteEligibleWorkingMemory()` (`packages/coding-agent/src/mnemopi/state.ts`): runs the age-gated `sleep(false)` on every owned bank, stamping `consolidated_at` (and creating the episodic summary) so the `consolidated_at IS NULL` trim filter skips those rows. Bank-scoped `sleep` suffices because every session shares `sessionId = <bank>`. Errors are logged, never thrown, so consolidation failure cannot make the backend inert.
- Invoke it from `installMnemopiState()` (`packages/coding-agent/src/mnemopi/backend.ts`) right after listeners attach, so the promotion completes before the session's first write can trim. This runs on the session-start path only and leaves the #4843-optimised interactive exit path (`sleep:false`) untouched.
- Add a changelog entry.

## Verification
`bun test test/memory-tools.test.ts` — 65 pass, 0 fail. Two added regression tests (`#10770`): (1) an aged unconsolidated `coding-agent-retain` row is stamped `consolidated_at` by `promoteEligibleWorkingMemory()` and survives a subsequent trim-triggering write; (2) a top-level `mnemopiBackend.start` promotes a pre-seeded aged row (proves the start wiring). `bun check` passes (format + typecheck, all packages). Fixes #10770