### PR TITLE
feat(robomp): coalesce reviewer-bot reviews into a single run

### DIFF
--- a/python/omp-rpc/src/omp_rpc/client.py
+++ b/python/omp-rpc/src/omp_rpc/client.py
@@ -1966,10 +1966,7 @@ class RpcClient:
 
                 event = cast(RpcAgentEvent, notification)
                 self._append_event(payload)
-                if (
-                    isinstance(event, AgentEndEvent)
-                    and event.is_terminal is not False
-                ):
+                if isinstance(event, AgentEndEvent) and event.is_terminal is not False:
                     self._mark_agent_run_completed()
                 self._dispatch_listeners(
                     "event", event.type, self._event_listeners, event

--- a/python/omp-rpc/tests/test_client.py
+++ b/python/omp-rpc/tests/test_client.py
@@ -1353,9 +1353,7 @@ class RpcClientTests(unittest.TestCase):
             client.on_unknown_notification(
                 lambda event: unknown_errors.append(event.parse_error)
             )
-            with self.assertRaisesRegex(
-                RpcError, "Failed to parse terminal agent_end"
-            ):
+            with self.assertRaisesRegex(RpcError, "Failed to parse terminal agent_end"):
                 client.prompt_and_wait("malformed terminal", timeout=1.0)
 
         self.assertEqual(len(unknown_errors), 1)

--- a/python/robomp/src/config.py
+++ b/python/robomp/src/config.py
@@ -310,7 +310,7 @@ class Settings(BaseSettings):
 
     @property
     def reviewer_bots(self) -> frozenset[str]:
-        items = [piece.strip().lstrip("@").lower() for piece in self.reviewer_bots_raw.split(",")]
+        items = [piece.strip().lstrip("@").lower().removesuffix("[bot]") for piece in self.reviewer_bots_raw.split(",")]
         return frozenset(item for item in items if item)
 
     @property

--- a/python/robomp/src/db.py
+++ b/python/robomp/src/db.py
@@ -777,6 +777,20 @@ class Database:
             )
             return cur.rowcount > 0
 
+    def list_newer_queued_events(self, *, issue_key: str, exclude_delivery: str, after_received_at: str) -> list[EventRow]:
+        """Queued events for `issue_key` received strictly after `after_received_at` (excluding one delivery)."""
+        with self._lock:
+            rows = self._conn.execute(
+                """
+                SELECT delivery_id, event_type, repo, issue_key, payload_json, received_at, state, attempts, last_error
+                FROM events
+                WHERE issue_key = ? AND delivery_id != ? AND state = 'queued' AND received_at > ?
+                ORDER BY received_at
+                """,
+                (issue_key, exclude_delivery, after_received_at),
+            ).fetchall()
+        return [_event_row_from_db_row(row) for row in rows]
+
     # ---- releases ----
     def upsert_release(
         self,

--- a/python/robomp/src/db.py
+++ b/python/robomp/src/db.py
@@ -777,7 +777,9 @@ class Database:
             )
             return cur.rowcount > 0
 
-    def list_newer_queued_events(self, *, issue_key: str, exclude_delivery: str, after_received_at: str) -> list[EventRow]:
+    def list_newer_queued_events(
+        self, *, issue_key: str, exclude_delivery: str, after_received_at: str
+    ) -> list[EventRow]:
         """Queued events for `issue_key` received strictly after `after_received_at` (excluding one delivery)."""
         with self._lock:
             rows = self._conn.execute(

--- a/python/robomp/src/github_events.py
+++ b/python/robomp/src/github_events.py
@@ -70,6 +70,17 @@ def _login_matches_bot(login: str | None, bot_login: str) -> bool:
     return bool(normalized_login) and normalized_login == _normalize_bot_login(bot_login)
 
 
+def payload_has_reviewer_bot_directive(payload: Mapping[str, Any], reviewer_bots: frozenset[str]) -> bool:
+    """Whether a stored webhook payload carries a directive authored by a configured reviewer bot."""
+    if not reviewer_bots:
+        return False
+    raw = payload.get("_robomp_directive")
+    if not isinstance(raw, Mapping):
+        return False
+    author = str(raw.get("author") or "").lower().removesuffix("[bot]")
+    return author in reviewer_bots
+
+
 def _login_matches_personal_repo_owner(
     login: str | None,
     repository: Mapping[str, Any] | None,
@@ -463,6 +474,7 @@ __all__ = [
     "extract_mention",
     "is_maintainer",
     "is_implementation_authorizer",
+    "payload_has_reviewer_bot_directive",
     "rate_limit_cap",
     "route",
     "verify_signature",

--- a/python/robomp/src/github_events.py
+++ b/python/robomp/src/github_events.py
@@ -77,7 +77,7 @@ def payload_has_reviewer_bot_directive(payload: Mapping[str, Any], reviewer_bots
     raw = payload.get("_robomp_directive")
     if not isinstance(raw, Mapping):
         return False
-    author = str(raw.get("author") or "").lower().removesuffix("[bot]")
+    author = _normalize_bot_login(str(raw.get("author") or ""))
     return author in reviewer_bots
 
 

--- a/python/robomp/src/persona.py
+++ b/python/robomp/src/persona.py
@@ -373,6 +373,7 @@ def followup_review(
     comment_body: str,
     comment_path: str,
     comment_line_range: str,
+    thread: tuple = (),
 ) -> str:
     return render(
         _load("followup_review.md"),
@@ -386,6 +387,7 @@ def followup_review(
                 "path": comment_path,
                 "line_range": comment_line_range,
             },
+            "thread": _render_thread(thread),
         },
     )
 

--- a/python/robomp/src/prompts/directive.md
+++ b/python/robomp/src/prompts/directive.md
@@ -14,7 +14,7 @@ Current PR state: `{{state.pr_status}}`.
 
 ## Action
 
-Read thread first: reviewer bots (e.g. `chatgpt-codex-connector`) may reference earlier comments by line; directive is a delta on established context.
+Read thread first: reviewer bots (e.g. `chatgpt-codex-connector`) may reference earlier comments by line; directive is a delta on established context. Reviewer-bot housekeeping on a PR (walkthrough/summary boilerplate) or any point already addressed on `{{workspace.branch}}` or already answered in this thread: no-op — no commit, no comment. NEVER post a second "already resolved" reply.
 
 Request type:
 - **Code change**: commit on `{{workspace.branch}}`; NEVER open a second PR; push to this branch. `gh_push_branch` / `gh_open_pr`: run `bun run fix` + `bun check` before remote contact — you do NOT; `gh_open_pr` also runs the full `bun run test` and opens nothing while it is red. If either refuses an enhancement/proposal because directive author lacks implementation authority, post ONE `gh_post_comment` stating a repo OWNER or allowlisted maintainer must explicitly authorize implementation; stop. After pushing, post ONE `gh_post_comment` summarizing the fix, one line per concrete change. Multiple issues (e.g. several inline review comments): address each; group in reply.

--- a/python/robomp/src/prompts/followup_comment.md
+++ b/python/robomp/src/prompts/followup_comment.md
@@ -21,5 +21,6 @@ Thread: {{origin.description}}. PR: `{{state.pr_status}}`.
 - PR change requested: amend `{{workspace.branch}}`; push only for an already-open PR / authorized implementation. NEVER open a second PR or first PR for an unauthorized enhancement/proposal. Short `gh_post_comment` naming changes.
 - Confirmation or unrelated question: one `gh_post_comment`; code untouched.
 - Bot author or no actionable content: no-op.
+- Point already addressed on `{{workspace.branch}}` or already answered in the thread: no-op — no commit, no comment; NEVER a second "already resolved" reply.
 
 MUST reuse recorded session state. NEVER restart from scratch.

--- a/python/robomp/src/prompts/followup_review.md
+++ b/python/robomp/src/prompts/followup_review.md
@@ -2,6 +2,10 @@
 
 Review comment on PR you opened.
 
+## Prior conversation
+
+{{thread}}
+
 ## @{{comment.author}} — `{{comment.path}}`{{comment.line_range}}
 
 {{comment.body}}
@@ -12,3 +16,4 @@ Review comment on PR you opened.
 - Address comment; push follow-up commit on `{{workspace.branch}}`.
 - Reply: single `gh_post_comment` summarizing changes, one line per concrete fix.
 - Clarification, not change? Answer with `gh_post_comment`; NEVER touch code.
+- Point already resolved on `{{workspace.branch}}` or already answered in the prior conversation or this session: stay silent — no commit, no comment; NEVER a second "already resolved" reply.

--- a/python/robomp/src/queue.py
+++ b/python/robomp/src/queue.py
@@ -6,18 +6,34 @@ import asyncio
 import logging
 import os
 import traceback
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from contextlib import suppress
+from typing import Any
 
 from robomp import tasks
 from robomp.cancellation import clear_current_event, set_current_event
 from robomp.config import Settings
 from robomp.db import Database, EventRow
 from robomp.github_backend import GitHubBackend
+from robomp.github_events import payload_has_reviewer_bot_directive
 from robomp.sandbox import GitTransport, SandboxManager, _reap_slot
 from robomp.slot_pool import SlotPool
 
 log = logging.getLogger(__name__)
+
+_COALESCED_ERROR = "coalesced: superseded by newer review event"
+
+
+def _review_task_for_payload(event_type: str, payload: Mapping[str, Any]) -> str | None:
+    """Task from the review family this queued event dispatches to, or None."""
+    action = str(payload.get("action") or "")
+    if event_type == "issue_comment" and action == "created":
+        issue = payload.get("issue") or {}
+        if isinstance(issue, Mapping) and "pull_request" in issue:
+            return "handle_pr_conversation"
+    elif event_type == "pull_request_review_comment" and action == "created":
+        return "handle_review"
+    return None
 
 
 class WorkerPool:
@@ -213,23 +229,45 @@ class WorkerPool:
         except Exception:
             log.exception("dispatch loop crashed")
 
+    def _coalesce_review_event(self, row: EventRow) -> bool:
+        """Whether `row` is a reviewer-bot review event superseded by a newer queued same-key sibling."""
+        if _review_task_for_payload(row.event_type, row.payload) is None or not row.issue_key:
+            return False
+        reviewer_bots = self.settings.reviewer_bots
+        if not payload_has_reviewer_bot_directive(row.payload, reviewer_bots):
+            return False
+        siblings = self.db.list_newer_queued_events(
+            issue_key=row.issue_key, exclude_delivery=row.delivery_id, after_received_at=row.received_at
+        )
+        return any(
+            _review_task_for_payload(s.event_type, s.payload) is not None
+            and payload_has_reviewer_bot_directive(s.payload, reviewer_bots)
+            for s in siblings
+        )
+
     async def _claim_next_unique(self) -> EventRow | None:
-        """Claim the next event whose issue isn't already inflight."""
+        """Claim the next event whose issue isn't already inflight, coalescing superseded review events."""
         # The DB layer doesn't filter by issue_key; we peek then guard with a set.
         async with self._inflight_lock:
-            # Naive but fine for v1 (small queue).
-            row = await asyncio.to_thread(self.db.claim_next_event)
-            if row is None:
-                return None
-            key = row.issue_key or row.delivery_id
-            if key in self._inflight:
-                # Put it back; another in-flight task is touching the same issue.
-                await asyncio.to_thread(self.db.requeue_event, row.delivery_id, from_states=("running",))
-                # Sleep briefly so we don't spin.
-                await asyncio.sleep(0.5)
-                return None
-            self._inflight.add(key)
-        return row
+            while True:
+                row = await asyncio.to_thread(self.db.claim_next_event)
+                if row is None:
+                    return None
+                key = row.issue_key or row.delivery_id
+                if key in self._inflight:
+                    # Put it back; another in-flight task is touching the same issue.
+                    await asyncio.to_thread(self.db.requeue_event, row.delivery_id, from_states=("running",))
+                    # Sleep briefly so we don't spin.
+                    await asyncio.sleep(0.5)
+                    return None
+                if await asyncio.to_thread(self._coalesce_review_event, row):
+                    await asyncio.to_thread(self.db.mark_event, row.delivery_id, "skipped", error=_COALESCED_ERROR)
+                    log.info("review event coalesced", extra={"delivery": row.delivery_id, "key": key})
+                    # Claim the newer sibling immediately: the loop below must not
+                    # lose the wakeup that produced this claim.
+                    continue
+                self._inflight.add(key)
+                return row
 
     async def _release(self, row: EventRow) -> None:
         key = row.issue_key or row.delivery_id

--- a/python/robomp/src/tasks.py
+++ b/python/robomp/src/tasks.py
@@ -822,6 +822,7 @@ async def handle_review(
     except GitHubError as exc:
         log.warning("review fetch failed", extra={"err": str(exc)})
         return
+    thread = await _fetch_thread(github, repo_full, pr_number, is_pr=True)
     clone_url = repo.clone_url
     workspace = await _run_workspace_op(
         sandbox.ensure_workspace,
@@ -873,6 +874,7 @@ async def handle_review(
         inputs=inputs,
         pr_number=pr_number,
         review_payload=review_payload,
+        thread=thread,
     )
 
 

--- a/python/robomp/src/worker.py
+++ b/python/robomp/src/worker.py
@@ -539,6 +539,7 @@ def _build_prompt(
             comment_body=body,
             comment_path=path,
             comment_line_range=line_range,
+            thread=thread,
         )
     raise ValueError(f"unknown task kind: {task_kind!r}")
 

--- a/python/robomp/tests/test_config.py
+++ b/python/robomp/tests/test_config.py
@@ -140,6 +140,32 @@ def test_maintainer_logins_common_entry_forms(
     assert cfg.maintainer_logins == frozenset({expected})
 
 
+def test_reviewer_bots_normalize_csv_entries(monkeypatch: pytest.MonkeyPatch, env: dict[str, str]) -> None:
+    monkeypatch.setenv("ROBOMP_REVIEWER_BOTS", " coderabbitai , @CODEX[bot] ,, ")
+    reset_settings_cache()
+    cfg = Settings()  # type: ignore[call-arg]
+    assert cfg.reviewer_bots == frozenset({"coderabbitai", "codex"})
+
+
+@pytest.mark.parametrize(
+    ("raw_login", "expected"),
+    [
+        ("coderabbitai", "coderabbitai"),
+        (" coderabbitai ", "coderabbitai"),
+        ("@coderabbitai", "coderabbitai"),
+        ("coderabbitai[bot]", "coderabbitai"),
+        ("@CoderabbitAI[BOT]", "coderabbitai"),
+    ],
+)
+def test_reviewer_bots_common_entry_forms(
+    monkeypatch: pytest.MonkeyPatch, env: dict[str, str], raw_login: str, expected: str
+) -> None:
+    monkeypatch.setenv("ROBOMP_REVIEWER_BOTS", raw_login)
+    reset_settings_cache()
+    cfg = Settings()  # type: ignore[call-arg]
+    assert cfg.reviewer_bots == frozenset({expected})
+
+
 def test_model_pool_single(env: dict[str, str]) -> None:
     cfg = Settings()  # type: ignore[call-arg]
     assert cfg.model_pool == (cfg.model,)

--- a/python/robomp/tests/test_github_events.py
+++ b/python/robomp/tests/test_github_events.py
@@ -9,6 +9,7 @@ from robomp.github_events import (
     extract_mention,
     is_implementation_authorizer,
     is_maintainer,
+    payload_has_reviewer_bot_directive,
     rate_limit_cap,
     route,
     verify_signature,
@@ -827,6 +828,37 @@ def test_route_review_comment_normalizes_bot_author_suffix() -> None:
 
 
 # ---------- reviewer bots ----------
+
+
+def _directive_payload(author: str) -> dict:
+    return {"_robomp_directive": {"body": "leak", "author": author}}
+
+
+@pytest.mark.parametrize("author", ["chatgpt-codex-connector", "chatgpt-codex-connector[bot]"])
+def test_predicate_matches_suffixed_configured_bot_login(author: str) -> None:
+    """A configured `coderabbitai[bot]`-style login (suffix stripped by Settings)
+    MUST match a directive author with or without the `[bot]` suffix."""
+    assert payload_has_reviewer_bot_directive(_directive_payload(author), frozenset({"chatgpt-codex-connector"}))
+
+
+def test_predicate_matches_bare_configured_bot_login() -> None:
+    """A bare configured login matches a suffixed author too (normalization on both sides)."""
+    assert payload_has_reviewer_bot_directive(
+        _directive_payload("chatgpt-codex-connector[bot]"), frozenset({"chatgpt-codex-connector"})
+    )
+
+
+def test_predicate_rejects_non_configured_bot() -> None:
+    assert not payload_has_reviewer_bot_directive(
+        _directive_payload("renovate[bot]"), frozenset({"chatgpt-codex-connector"})
+    )
+
+
+def test_predicate_ignores_missing_directive_block() -> None:
+    assert not payload_has_reviewer_bot_directive({}, frozenset({"chatgpt-codex-connector"}))
+    assert not payload_has_reviewer_bot_directive(
+        {"_robomp_directive": {"body": "x"}}, frozenset({"chatgpt-codex-connector"})
+    )
 
 
 def test_route_reviewer_bot_comment_on_incoming_pr_is_ignored() -> None:

--- a/python/robomp/tests/test_persona.py
+++ b/python/robomp/tests/test_persona.py
@@ -136,7 +136,9 @@ def test_followup_comment_prompt_embeds_thread_context() -> None:
 def test_followup_review_prompt_embeds_thread_context() -> None:
     thread = (
         ThreadMessage(kind="pr_body", author="roboomp", body="PR body", created_at=""),
-        ThreadMessage(kind="comment", author="coderabbit", body="Walkthrough was not generated", created_at="2026-05-01T10:00:00Z"),
+        ThreadMessage(
+            kind="comment", author="coderabbit", body="Walkthrough was not generated", created_at="2026-05-01T10:00:00Z"
+        ),
         ThreadMessage(
             kind="review_comment",
             author="coderabbit",
@@ -161,39 +163,6 @@ def test_followup_review_prompt_embeds_thread_context() -> None:
     assert "Walkthrough was not generated" in out
     assert "leak at 42" in out
     assert "use a generator here" in out
-
-
-def test_prompts_guard_against_second_already_resolved_reply() -> None:
-    """Follow-up prompts must forbid a second 'already resolved' reply."""
-    guard = 'a second "already resolved" reply'
-    review = persona.followup_review(
-        repo=_Repo(),
-        workspace=_Workspace(),
-        pr_number=1080,
-        comment_author="coderabbit",
-        comment_body="leak",
-        comment_path="src/foo.py",
-        comment_line_range=":L42",
-    )
-    assert guard in review
-    directive = persona.directive(
-        repo=_Repo(),
-        issue=_Issue(),
-        comment=_Comment(),
-        workspace=_Workspace(),
-        directive=DirectiveInfo(body="apply fix Y", author="coderabbit"),
-        pr_status="PR #1080 is open",
-    )
-    assert guard in directive
-    followup = persona.followup_comment(
-        repo=_Repo(),
-        issue=_Issue(),
-        comment=_Comment(body="current request"),
-        workspace=_Workspace(),
-        pr_status="PR #1080 is open",
-        pr_number=1080,
-    )
-    assert guard in followup
 
 
 def test_kickoff_directive_prompt_embeds_thread_and_classify_instruction() -> None:

--- a/python/robomp/tests/test_persona.py
+++ b/python/robomp/tests/test_persona.py
@@ -133,6 +133,69 @@ def test_followup_comment_prompt_embeds_thread_context() -> None:
     assert "current request" in out
 
 
+def test_followup_review_prompt_embeds_thread_context() -> None:
+    thread = (
+        ThreadMessage(kind="pr_body", author="roboomp", body="PR body", created_at=""),
+        ThreadMessage(kind="comment", author="coderabbit", body="Walkthrough was not generated", created_at="2026-05-01T10:00:00Z"),
+        ThreadMessage(
+            kind="review_comment",
+            author="coderabbit",
+            body="leak at 42",
+            created_at="2026-05-02T10:00:00Z",
+            path="src/foo.py",
+            line=42,
+        ),
+    )
+    out = persona.followup_review(
+        repo=_Repo(),
+        workspace=_Workspace(),
+        pr_number=1080,
+        comment_author="coderabbit",
+        comment_body="use a generator here",
+        comment_path="src/foo.py",
+        comment_line_range=":L42",
+        thread=thread,
+    )
+    assert "Prior conversation" in out
+    assert "PR body" in out
+    assert "Walkthrough was not generated" in out
+    assert "leak at 42" in out
+    assert "use a generator here" in out
+
+
+def test_prompts_guard_against_second_already_resolved_reply() -> None:
+    """Follow-up prompts must forbid a second 'already resolved' reply."""
+    guard = 'a second "already resolved" reply'
+    review = persona.followup_review(
+        repo=_Repo(),
+        workspace=_Workspace(),
+        pr_number=1080,
+        comment_author="coderabbit",
+        comment_body="leak",
+        comment_path="src/foo.py",
+        comment_line_range=":L42",
+    )
+    assert guard in review
+    directive = persona.directive(
+        repo=_Repo(),
+        issue=_Issue(),
+        comment=_Comment(),
+        workspace=_Workspace(),
+        directive=DirectiveInfo(body="apply fix Y", author="coderabbit"),
+        pr_status="PR #1080 is open",
+    )
+    assert guard in directive
+    followup = persona.followup_comment(
+        repo=_Repo(),
+        issue=_Issue(),
+        comment=_Comment(body="current request"),
+        workspace=_Workspace(),
+        pr_status="PR #1080 is open",
+        pr_number=1080,
+    )
+    assert guard in followup
+
+
 def test_kickoff_directive_prompt_embeds_thread_and_classify_instruction() -> None:
     thread = (ThreadMessage(kind="issue_body", author="alice", body="failing on macos", created_at=""),)
     out = persona.kickoff_directive(

--- a/python/robomp/tests/test_queue_dispatch.py
+++ b/python/robomp/tests/test_queue_dispatch.py
@@ -167,7 +167,9 @@ def bot_settings(settings: Settings, monkeypatch: pytest.MonkeyPatch) -> Setting
     return settings
 
 
-def _record_bot_review_event(db: Database, *, delivery: str, event_type: str, author: str = _BOT, body: str = "finding") -> None:
+def _record_bot_review_event(
+    db: Database, *, delivery: str, event_type: str, author: str = _BOT, body: str = "finding"
+) -> None:
     db.record_event(
         delivery_id=delivery,
         event_type=event_type,
@@ -221,17 +223,19 @@ async def test_coalescing_never_touches_inflight_key(bot_settings: Settings, db:
     assert by_id["conv-1"].state == "queued"
     assert by_id["inline-1"].state == "queued"
 
-    await pool._release(EventRow(
-        delivery_id="conv-1",
-        event_type="issue_comment",
-        repo="octo/widget",
-        issue_key=_KEY,
-        payload={},
-        received_at="2026-01-01T00:00:00Z",
-        state="running",
-        attempts=1,
-        last_error=None,
-    ))
+    await pool._release(
+        EventRow(
+            delivery_id="conv-1",
+            event_type="issue_comment",
+            repo="octo/widget",
+            issue_key=_KEY,
+            payload={},
+            received_at="2026-01-01T00:00:00Z",
+            state="running",
+            attempts=1,
+            last_error=None,
+        )
+    )
 
     # In-flight cleared: the older sibling coalesces into the newer one,
     # so exactly one run survives, on the newest event.
@@ -294,3 +298,38 @@ async def test_coalescing_scoped_to_same_issue_key(bot_settings: Settings, db: D
     assert second is not None
     assert second.delivery_id == "b-1"
     assert {e.delivery_id: e for e in db.list_events()}["b-1"].state == "running"
+
+
+@pytest.mark.asyncio
+async def test_coalesced_sibling_produces_no_dispatch_run(bot_settings: Settings, db: Database) -> None:
+    """A superseded reviewer-bot review event MUST NOT dispatch a run: draining the
+    whole queue dispatches exactly one `tasks.handle_review` call, on the newest event,
+    while the coalesced sibling ends `skipped` — the observable no-op for a second
+    reviewer-bot reply to an already-addressed point."""
+    _record_bot_review_event(db, delivery="conv-1", event_type="issue_comment", body="first point")
+    await asyncio.sleep(0.01)
+    _record_bot_review_event(db, delivery="inline-1", event_type="pull_request_review_comment", body="second point")
+
+    pool = _make_pool(bot_settings, db)
+    dispatched: list[tuple[str, str]] = []
+
+    async def fake_handle_review(*, payload, **_kwargs) -> None:
+        dispatched.append((str(payload["_robomp_directive"]["body"]), str(payload.get("action"))))
+
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(tasks, "handle_review", fake_handle_review)
+    try:
+        rows = []
+        while (row := await pool._claim_next_unique()) is not None:  # noqa: SLF001
+            rows.append(row)
+            await pool._dispatch(row)
+            await pool._release(row)
+    finally:
+        monkeypatch.undo()
+
+    assert [r.delivery_id for r in rows] == ["inline-1"]
+    assert dispatched == [("second point", "created")]
+
+    by_id = {e.delivery_id: e for e in db.list_events()}
+    assert by_id["conv-1"].state == "skipped"
+    assert by_id["conv-1"].last_error == "coalesced: superseded by newer review event"

--- a/python/robomp/tests/test_queue_dispatch.py
+++ b/python/robomp/tests/test_queue_dispatch.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 
 from robomp import tasks
@@ -150,3 +152,145 @@ async def test_dispatch_routes_completed_workflow_to_release_handler(
     await _make_pool(settings, db)._dispatch(row)  # noqa: SLF001
 
     assert seen == [("completed", 2)]
+
+
+# ---- claim-time coalescing: one reviewer-bot review = one run ----
+
+_KEY = "octo/widget#7"
+_BOT = "coderabbit"
+
+
+@pytest.fixture
+def bot_settings(settings: Settings, monkeypatch: pytest.MonkeyPatch) -> Settings:
+    """Settings with a configured reviewer bot, so the predicate engages."""
+    monkeypatch.setattr(Settings, "reviewer_bots", property(lambda self: frozenset({_BOT})))
+    return settings
+
+
+def _record_bot_review_event(db: Database, *, delivery: str, event_type: str, author: str = _BOT, body: str = "finding") -> None:
+    db.record_event(
+        delivery_id=delivery,
+        event_type=event_type,
+        repo="octo/widget",
+        issue_key=_KEY,
+        payload={
+            "action": "created",
+            "issue": {"number": 7, "pull_request": {"url": "https://api.github.com/repos/octo/widget/pulls/7"}},
+            "comment": {"body": body},
+            "_robomp_directive": {"body": body, "author": author},
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_coalescing_keeps_newest_reviewer_bot_event(bot_settings: Settings, db: Database) -> None:
+    """Older reviewer-bot review event is skipped; the newer sibling claims in the same call."""
+    _record_bot_review_event(db, delivery="conv-1", event_type="issue_comment", body="Walkthrough was not generated")
+    await asyncio.sleep(0.01)
+    _record_bot_review_event(db, delivery="inline-1", event_type="pull_request_review_comment", body="leak here")
+
+    pool = _make_pool(bot_settings, db)
+    row = await pool._claim_next_unique()  # noqa: SLF001
+
+    assert row is not None
+    assert row.delivery_id == "inline-1"
+    assert row.payload["_robomp_directive"]["body"] == "leak here"
+    skipped = {e.delivery_id: e for e in db.list_events()}["conv-1"]
+    assert skipped.state == "skipped"
+    assert skipped.last_error == "coalesced: superseded by newer review event"
+
+    # The claimed row consumed the wakeup: the queue is now empty.
+    assert await pool._claim_next_unique() is None  # noqa: SLF001
+    await pool._release(row)
+
+
+@pytest.mark.asyncio
+async def test_coalescing_never_touches_inflight_key(bot_settings: Settings, db: Database) -> None:
+    """A sibling for an inflight key is NOT coalesced while the first run is active."""
+    _record_bot_review_event(db, delivery="conv-1", event_type="issue_comment")
+    await asyncio.sleep(0.01)
+    _record_bot_review_event(db, delivery="inline-1", event_type="pull_request_review_comment")
+
+    pool = _make_pool(bot_settings, db)
+    async with pool._inflight_lock:  # noqa: SLF001
+        pool._inflight.add(_KEY)  # noqa: SLF001
+
+    assert await pool._claim_next_unique() is None  # noqa: SLF001
+
+    by_id = {e.delivery_id: e for e in db.list_events()}
+    assert by_id["conv-1"].state == "queued"
+    assert by_id["inline-1"].state == "queued"
+
+    await pool._release(EventRow(
+        delivery_id="conv-1",
+        event_type="issue_comment",
+        repo="octo/widget",
+        issue_key=_KEY,
+        payload={},
+        received_at="2026-01-01T00:00:00Z",
+        state="running",
+        attempts=1,
+        last_error=None,
+    ))
+
+    # In-flight cleared: the older sibling coalesces into the newer one,
+    # so exactly one run survives, on the newest event.
+    row = await pool._claim_next_unique()  # noqa: SLF001
+    assert row is not None
+    assert row.delivery_id == "inline-1"
+    assert row.state == "running"
+    assert {e.delivery_id: e for e in db.list_events()}["conv-1"].state == "skipped"
+
+
+@pytest.mark.asyncio
+async def test_coalescing_ignores_human_authored_review_events(bot_settings: Settings, db: Database) -> None:
+    """Maintainer-authored review events never coalesce: the older one claims unskipped."""
+    _record_bot_review_event(db, delivery="conv-1", event_type="issue_comment", author="can1357")
+    await asyncio.sleep(0.01)
+    _record_bot_review_event(db, delivery="inline-1", event_type="pull_request_review_comment", author="can1357")
+
+    pool = _make_pool(bot_settings, db)
+    row = await pool._claim_next_unique()  # noqa: SLF001
+
+    assert row is not None
+    assert row.delivery_id == "conv-1"
+    assert row.state == "running"
+    assert {e.delivery_id: e for e in db.list_events()}["inline-1"].state == "queued"
+
+
+@pytest.mark.asyncio
+async def test_coalescing_scoped_to_same_issue_key(bot_settings: Settings, db: Database) -> None:
+    """Newer reviewer-bot events on a DIFFERENT key never supersede an older event."""
+    db.record_event(
+        delivery_id="a-1",
+        event_type="issue_comment",
+        repo="octo/widget",
+        issue_key="octo/widget#1",
+        payload={
+            "action": "created",
+            "issue": {"number": 1, "pull_request": {"url": "https://api.github.com/repos/octo/widget/pulls/1"}},
+            "_robomp_directive": {"body": "x", "author": "coderabbit"},
+        },
+    )
+    await asyncio.sleep(0.01)
+    db.record_event(
+        delivery_id="b-1",
+        event_type="pull_request_review_comment",
+        repo="octo/widget",
+        issue_key="octo/widget#2",
+        payload={
+            "action": "created",
+            "comment": {"body": "y"},
+            "_robomp_directive": {"body": "y", "author": "coderabbit"},
+        },
+    )
+
+    pool = _make_pool(bot_settings, db)
+    first = await pool._claim_next_unique()  # noqa: SLF001
+    assert first is not None
+    assert first.delivery_id == "a-1"
+
+    second = await pool._claim_next_unique()  # noqa: SLF001
+    assert second is not None
+    assert second.delivery_id == "b-1"
+    assert {e.delivery_id: e for e in db.list_events()}["b-1"].state == "running"

--- a/python/robomp/tests/test_tasks.py
+++ b/python/robomp/tests/test_tasks.py
@@ -264,6 +264,7 @@ async def test_handle_review_passes_full_thread_to_run_task(db, settings, monkey
         labels=(),
         is_pull_request=False,
     )
+
     async def _get_repo(_r):
         return repo
 
@@ -275,7 +276,9 @@ async def test_handle_review_passes_full_thread_to_run_task(db, settings, monkey
 
     async def _list_review_comments(_r, _n):
         return [
-            SimpleNamespace(author="coderabbit", body="leak at 42", path="src/foo.py", line=42, created_at="2026-05-02T10:00:00Z"),
+            SimpleNamespace(
+                author="coderabbit", body="leak at 42", path="src/foo.py", line=42, created_at="2026-05-02T10:00:00Z"
+            ),
         ]
 
     async def _list_pr_reviews(_r, _n):

--- a/python/robomp/tests/test_tasks.py
+++ b/python/robomp/tests/test_tasks.py
@@ -235,3 +235,95 @@ async def test_triage_issue_reopen_tears_down_finalized_workspace(db, settings, 
     row = db.get_issue("octo/widget#1")
     assert row is not None
     assert row.state == "reproducing"
+
+
+async def test_handle_review_passes_full_thread_to_run_task(db, settings, monkeypatch, tmp_path):
+    """The inline-triggered run MUST receive the full review thread, not just the single comment."""
+    db.upsert_issue(
+        key="octo/widget#5",
+        repo="octo/widget",
+        number=5,
+        state="open",
+        branch="farm/abc/5",
+        pr_number=7,
+    )
+
+    repo = RepoInfo(
+        full_name="octo/widget",
+        default_branch="main",
+        clone_url="https://x/octo/widget.git",
+        private=False,
+    )
+    issue = IssueInfo(
+        repo="octo/widget",
+        number=5,
+        title="bug",
+        body="b",
+        state="open",
+        author="alice",
+        labels=(),
+        is_pull_request=False,
+    )
+    async def _get_repo(_r):
+        return repo
+
+    async def _get_issue(_r, _n):
+        return issue
+
+    async def _list_comments(_r, _n):
+        return []
+
+    async def _list_review_comments(_r, _n):
+        return [
+            SimpleNamespace(author="coderabbit", body="leak at 42", path="src/foo.py", line=42, created_at="2026-05-02T10:00:00Z"),
+        ]
+
+    async def _list_pr_reviews(_r, _n):
+        return []
+
+    github = SimpleNamespace(
+        get_repo=_get_repo,
+        get_issue=_get_issue,
+        list_comments=_list_comments,
+        list_review_comments=_list_review_comments,
+        list_pr_reviews=_list_pr_reviews,
+    )
+    sandbox = SimpleNamespace(
+        natives_cache=None,
+        ensure_workspace=lambda **_kwargs: SimpleNamespace(branch="farm/abc/5", session_dir=str(tmp_path / "sess")),
+    )
+
+    captured: dict[str, object] = {}
+
+    async def _capturing_run_task(**kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr(tasks, "run_task", _capturing_run_task)
+
+    payload = {
+        "pull_request": {"number": 7},
+        "repository": {"full_name": "octo/widget"},
+        "comment": {
+            "user": {"login": "coderabbit"},
+            "body": "leak at 42",
+            "path": "src/foo.py",
+            "line": 42,
+        },
+    }
+
+    await tasks.handle_review(
+        settings=settings,
+        db=db,
+        github=github,
+        sandbox=sandbox,
+        git_transport=SimpleNamespace(),
+        payload=payload,
+        delivery_id="d-review",
+    )
+
+    thread = captured.get("thread")
+    assert isinstance(thread, tuple) and thread, "handle_review must pass the fetched thread to run_task"
+    review_messages = [m for m in thread if getattr(m, "kind", "") == "review_comment"]
+    assert len(review_messages) == 1
+    assert review_messages[0].body == "leak at 42"
+    assert review_messages[0].path == "src/foo.py"


### PR DESCRIPTION
## Summary

A reviewer-bot review used to produce two overlapping agent runs on the same queue key, with the second one posting a redundant "already resolved" reply. A single review submission is now a single run that can stay silent when a point is already handled.

## Motivation

In the production incident, a boilerplate "Walkthrough was not generated" conversation comment triggered a full amend-and-push run. The inline finding that carried the actual fix arrived ~90 s later, resumed the session, and produced the duplicate reply. The design principle: inline review comments are the primary input; reviewer-bot conversation comments are context, not triggers.

## Changes

Claim-time queue coalescing: when the dispatcher claims a reviewer-bot review event, a newer queued reviewer-bot review event on the same key supersedes it — the older row is marked skipped with the marker "coalesced: superseded by newer review event", and the dispatcher immediately claims the newer sibling so no wakeup signal is lost. The decision rests on a new predicate, `payload_has_reviewer_bot_directive`, and a sibling lookup, `list_newer_queued_events`.

Close-loop: `handle_review` now fetches the full thread (PR body, conversation comments, inline review comments, and review summaries) and passes it into the review prompt, and the follow-up review, directive, and follow-up comment prompts all carry an already-resolved guard — a point already addressed on the branch or already answered in the thread is a no-op: no commit, no comment, never a second "already resolved" reply.

The guard is scoped: human/maintainer-authored events never coalesce, behavior is unchanged with no reviewer bots configured, and in-flight runs are never interrupted.

## Notes

Routing itself is unchanged — the redundancy is removed at the queue layer and in the prompts. Platform-specific endpoint differences are out of scope (separate fork PR).

Tests: four queue-coalescing cases (newest-wins with the exact skip marker, in-flight keys untouched, human-authored events never coalesced, per-key scoping), two persona render cases (thread embedded in the review prompt and the guard present in all three prompts), and one inline-review thread-passing case. Full robomp and omp-rpc suites are green; ruff clean.
