### PR TITLE
fix(coding-agent): avoid duplicate eval display output

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixed
 
+- Fixed structured Eval `display()` values appearing twice in the TUI while preserving their model-facing text ([#10778](https://github.com/can1357/oh-my-pi/issues/10778)).
 - Fixed fallback authorization-code prompts remaining active after native OAuth callback completion.
 - Fixed a rare issue where reciprocal idle subagents could continue waking one another indefinitely.
 - Fixed `/wt` and `git worktree add` failing when the new worktree targeted the same commit as the clean source checkout.

--- a/packages/coding-agent/src/tools/eval.ts
+++ b/packages/coding-agent/src/tools/eval.ts
@@ -795,19 +795,20 @@ export class EvalTool implements AgentTool<typeof evalSchema> {
 				const displayText = formatDisplayOutputsForText(cellDisplayOutputs);
 				const visibleDisplayText =
 					displayText && imageText ? `${displayText}\n\n${imageText}` : displayText || imageText;
-				const cellOutput =
+				const modelCellOutput =
 					stdoutTrimmed && visibleDisplayText
 						? `${stdoutTrimmed}\n\n${visibleDisplayText}`
 						: stdoutTrimmed || visibleDisplayText;
-				cellResult.output = cellOutput;
+				cellResult.output =
+					stdoutTrimmed && imageText ? `${stdoutTrimmed}\n\n${imageText}` : stdoutTrimmed || imageText;
 				cellResult.exitCode = result.exitCode;
 				cellResult.durationMs = durationMs;
 				cellResult.statusEvents = cellStatusEvents.length > 0 ? cellStatusEvents : undefined;
 				cellResult.hasMarkdown = cellHasMarkdown || undefined;
 
-				if (cellOutput) {
-					cellOutputs.push(cellOutput);
-					appendTail(cellOutput);
+				if (modelCellOutput) {
+					cellOutputs.push(modelCellOutput);
+					appendTail(modelCellOutput);
 				}
 
 				if (result.cancelled) {

--- a/packages/coding-agent/test/tools/eval-display-text.test.ts
+++ b/packages/coding-agent/test/tools/eval-display-text.test.ts
@@ -2,8 +2,9 @@ import { afterEach, describe, expect, it, vi } from "bun:test";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import * as evalIndex from "@oh-my-pi/pi-coding-agent/eval";
 import * as pyKernel from "@oh-my-pi/pi-coding-agent/eval/py/kernel";
+import { getThemeByName, setThemeInstance } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
-import { EvalTool } from "@oh-my-pi/pi-coding-agent/tools/eval";
+import { EvalTool, evalToolRenderer } from "@oh-my-pi/pi-coding-agent/tools/eval";
 
 function makeSession(): ToolSession {
 	return {
@@ -45,25 +46,33 @@ describe("EvalTool display() text surfacing", () => {
 		vi.restoreAllMocks();
 	});
 
-	it("includes display() JSON values in the text content the model sees", async () => {
+	it("renders structured display values once while preserving model text", async () => {
+		const sentinel = "render-once-sentinel";
 		vi.spyOn(pyKernel, "checkPythonKernelAvailability").mockResolvedValue({ ok: true });
 		vi.spyOn(evalIndex.jsBackend, "execute").mockResolvedValue(
 			baseResult({
-				displayOutputs: [{ type: "json", data: { stdout: "hi", exit_code: 0 } }],
+				displayOutputs: [{ type: "json", data: { text: sentinel, details: { value: 1 } } }],
 			}) as never,
 		);
 
 		const tool = new EvalTool(makeSession());
 		const result = await tool.execute("call-display-json", {
 			language: "js",
-			code: "```js\ndisplay({ stdout: 'hi', exit_code: 0 });\n```\n",
+			code: "display(result);",
 		});
 
-		const text = result.content.map(c => (c.type === "text" ? c.text : "")).join("\n");
-		expect(text).toContain("display[1]");
-		expect(text).toContain('"stdout": "hi"');
-		expect(text).toContain('"exit_code": 0');
-		expect(text).not.toBe("(no text output)");
+		const modelText = result.content.map(content => (content.type === "text" ? content.text : "")).join("\n");
+		expect(modelText).toContain("display[1]");
+		expect(modelText).toContain(sentinel);
+		expect(modelText).toContain('"value": 1');
+		const theme = (await getThemeByName("dark"))!;
+		expect(theme).toBeDefined();
+		setThemeInstance(theme);
+
+		const rendered = Bun.stripANSI(
+			evalToolRenderer.renderResult(result, { expanded: true, isPartial: false }, theme).render(120).join("\n"),
+		);
+		expect(rendered.match(new RegExp(sentinel, "g"))).toHaveLength(1);
 	});
 
 	it("interleaves stdout text and display() JSON values", async () => {


### PR DESCRIPTION
> Closed as a duplicate of #10779, which implements the same model/TUI output split and includes expanded structured-display coverage.

## What

- Keep structured Eval `display()` text in the model-facing result.
- Exclude that text from per-cell TUI output so the JSON tree renders the value once.
- Add an end-to-end renderer regression test and changelog entry.

## Why

Fixes #10778.

## Testing

- `bun test packages/coding-agent/test/tools/eval-display-format.test.ts packages/coding-agent/test/tools/eval-display-text.test.ts packages/coding-agent/test/core/js-executor.test.ts` — 32 passed
- `bun run check:types` in `packages/coding-agent`
- Scoped `oxlint` and `oxfmt --check` on changed TypeScript files
- Full `bun check` is blocked by lint warnings in the pre-existing untracked `packages/coding-agent/src/internal-urls/docs-index.generated.ts`
- Direct TUI smoke was blocked by the stale local native addon missing `editDescription`; the renderer regression exercises the complete Eval result-to-TUI component path

---

- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)