### PR TITLE
fix(coding-agent): support CUDA files in tooling

### DIFF
--- a/crates/pi-ast/src/language/mod.rs
+++ b/crates/pi-ast/src/language/mod.rs
@@ -554,7 +554,7 @@ const fn extensions(lang: SupportLang) -> &'static [&'static str] {
 		},
 		C => &["c", "h"],
 		Cmake => &["cmake"],
-		Cpp => &["cc", "hpp", "cpp", "c++", "hh", "cxx", "cu", "ino"],
+		Cpp => &["cc", "hpp", "cpp", "c++", "hh", "cxx", "cu", "cuh", "ino"],
 		CSharp => &["cs"],
 		Dart => &["dart"],
 		Clojure => &["clj", "cljs", "cljc", "edn"],

--- a/crates/pi-ast/src/language/mod.rs
+++ b/crates/pi-ast/src/language/mod.rs
@@ -684,6 +684,7 @@ static LANG_ALIASES: phf::Map<&'static str, SupportLang> = phf_map! {
 "hh"             => SupportLang::Cpp,
 "hpp"            => SupportLang::Cpp,
 "cu"             => SupportLang::Cpp,
+"cuh"            => SupportLang::Cpp,
 "ino"            => SupportLang::Cpp,
 "csharp"         => SupportLang::CSharp,
 "c#"             => SupportLang::CSharp,

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the built-in clangd registration omitting CUDA source and header files (`.cu` and `.cuh`).
+- Fixed `ast_grep` skipping CUDA headers and ignoring an explicit `lang` override for ambiguous file extensions.
+
 ## [18.1.9] - 2026-09-04
 
 ### Breaking Changes

--- a/packages/coding-agent/src/lsp/defaults.json
+++ b/packages/coding-agent/src/lsp/defaults.json
@@ -27,7 +27,7 @@
 	"clangd": {
 		"command": "clangd",
 		"args": ["--background-index", "--clang-tidy", "--header-insertion=iwyu"],
-		"fileTypes": [".c", ".cpp", ".cc", ".cxx", ".h", ".hpp", ".hxx", ".m", ".mm"],
+		"fileTypes": [".c", ".cpp", ".cc", ".cxx", ".h", ".hpp", ".hxx", ".cu", ".cuh", ".m", ".mm"],
 		"rootMarkers": ["compile_commands.json", "CMakeLists.txt", ".clangd", ".clang-format", "Makefile"]
 	},
 	"zls": {

--- a/packages/coding-agent/src/prompts/tools/ast-grep.md
+++ b/packages/coding-agent/src/prompts/tools/ast-grep.md
@@ -2,6 +2,7 @@ Structural code search via ast-grep. Use when syntax shape matters more than tex
 
 <instruction>
 - Narrow each call to one language. `pat` is ONE AST pattern; separate calls for unrelated patterns.
+- Set `lang` when extension inference is ambiguous (for example, `cpp` for `.h`); `.cu` and `.cuh` infer as C++.
 - `$NAME` captures one node; `$_` matches without binding; `$$$NAME` zero-or-more; `$$$` zero-or-more unbound.
   - Use `$$$NAME`, NOT `$$NAME` (invalid). Names UPPERCASE, whole node — `prefix$VAR` fails.
 - Same metavariable twice → MUST match identical code (`$A == $A` matches `x == x`, not `x == y`).

--- a/packages/coding-agent/src/tools/ast-grep.ts
+++ b/packages/coding-agent/src/tools/ast-grep.ts
@@ -43,6 +43,7 @@ const astGrepSchema = type({
 	"path?": type("string").describe(
 		'file, directory, glob, or internal URL to search; pass several as a semicolon-delimited list ("src; tests"). Omitted -> searches the workspace root (".")',
 	),
+	"lang?": type("string").describe("language override, e.g. cpp for ambiguous .h files"),
 	"skip?": type("number").describe("matches to skip"),
 });
 
@@ -75,7 +76,14 @@ function retainAstFindMatch(matches: AstFindMatch[], capacity: number, candidate
 
 async function runMultiTargetAstGrep(
 	targets: Array<{ basePath: string; glob?: string }>,
-	options: { patterns: string[]; commonBasePath: string; skip: number; limit: number; signal?: AbortSignal },
+	options: {
+		patterns: string[];
+		commonBasePath: string;
+		lang?: string;
+		skip: number;
+		limit: number;
+		signal?: AbortSignal;
+	},
 ): Promise<{
 	matches: AstFindMatch[];
 	totalMatches: number;
@@ -94,6 +102,7 @@ async function runMultiTargetAstGrep(
 	for (const target of targets) {
 		const targetResult = await astGrep({
 			patterns: options.patterns,
+			lang: options.lang,
 			path: target.basePath,
 			glob: target.glob,
 			offset: 0,
@@ -237,6 +246,7 @@ export class AstGrepTool implements AgentTool<typeof astGrepSchema, AstGrepToolD
 			const result = multiTargets
 				? await runMultiTargetAstGrep(multiTargets, {
 						patterns,
+						lang: params.lang,
 						commonBasePath: resolvedSearchPath,
 						skip,
 						limit: DEFAULT_AST_LIMIT,
@@ -244,6 +254,7 @@ export class AstGrepTool implements AgentTool<typeof astGrepSchema, AstGrepToolD
 					})
 				: await astGrep({
 						patterns,
+						lang: params.lang,
 						path: resolvedSearchPath,
 						glob: globFilter,
 						offset: skip,

--- a/packages/coding-agent/src/utils/lang-from-path.ts
+++ b/packages/coding-agent/src/utils/lang-from-path.ts
@@ -27,6 +27,7 @@ const EXTENSION_LANG: Record<string, readonly [string, string]> = {
 	hpp: ["cpp", "cpp"],
 	hxx: ["cpp", "cpp"],
 	cu: ["cpp", "cpp"],
+	cuh: ["cpp", "cpp"],
 	ino: ["cpp", "cpp"],
 	zig: ["zig", "zig"],
 

--- a/packages/coding-agent/test/tools/ast-grep.test.ts
+++ b/packages/coding-agent/test/tools/ast-grep.test.ts
@@ -177,4 +177,47 @@ describe("ast_grep parse errors", () => {
 			await removeWithRetries(tempDir);
 		}
 	});
+
+	it("infers CUDA sources and headers as C++", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "ast-grep-cuda-"));
+		try {
+			const tools = await createTools(createTestSession(tempDir), ["ast_grep"]);
+			const tool = tools.find(entry => entry.name === "ast_grep");
+			expect(tool).toBeDefined();
+
+			for (const extension of [".cu", ".cuh"]) {
+				const filePath = path.join(tempDir, `kernel${extension}`);
+				await Bun.write(filePath, "int cuda_value() { return 42; }\n");
+				const result = await tool!.execute(`ast-grep-cuda${extension}`, {
+					pat: "return $VALUE;",
+					path: filePath,
+				});
+				const details = result.details as { matchCount?: number } | undefined;
+				expect(details?.matchCount).toBe(1);
+			}
+		} finally {
+			await removeWithRetries(tempDir);
+		}
+	});
+
+	it("honors an explicit C++ language for ambiguous headers", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "ast-grep-cpp-header-"));
+		try {
+			const filePath = path.join(tempDir, "buffer.h");
+			await Bun.write(filePath, "class Buffer { public: int size() const { return 1; } };\n");
+			const tools = await createTools(createTestSession(tempDir), ["ast_grep"]);
+			const tool = tools.find(entry => entry.name === "ast_grep");
+			expect(tool).toBeDefined();
+
+			const result = await tool!.execute("ast-grep-explicit-cpp", {
+				pat: "class Buffer",
+				path: filePath,
+				lang: "cpp",
+			});
+			const details = result.details as { matchCount?: number } | undefined;
+			expect(details?.matchCount).toBe(1);
+		} finally {
+			await removeWithRetries(tempDir);
+		}
+	});
 });

--- a/packages/coding-agent/test/tools/ast-grep.test.ts
+++ b/packages/coding-agent/test/tools/ast-grep.test.ts
@@ -200,6 +200,27 @@ describe("ast_grep parse errors", () => {
 		}
 	});
 
+	it("resolves an explicit CUDA header language alias", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "ast-grep-cuh-alias-"));
+		try {
+			const filePath = path.join(tempDir, "kernel.cuh");
+			await Bun.write(filePath, "int cuda_value() { return 42; }\n");
+			const tools = await createTools(createTestSession(tempDir), ["ast_grep"]);
+			const tool = tools.find(entry => entry.name === "ast_grep");
+			expect(tool).toBeDefined();
+
+			const result = await tool!.execute("ast-grep-cuh-alias", {
+				pat: "return $VALUE;",
+				path: filePath,
+				lang: "cuh",
+			});
+			const details = result.details as { matchCount?: number } | undefined;
+			expect(details?.matchCount).toBe(1);
+		} finally {
+			await removeWithRetries(tempDir);
+		}
+	});
+
 	it("honors an explicit C++ language for ambiguous headers", async () => {
 		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "ast-grep-cpp-header-"));
 		try {

--- a/packages/coding-agent/test/tools/lsp-regressions.test.ts
+++ b/packages/coding-agent/test/tools/lsp-regressions.test.ts
@@ -5023,6 +5023,16 @@ describe("lsp regressions", () => {
 	});
 });
 
+describe("clangd CUDA defaults", () => {
+	it("registers CUDA sources and headers", () => {
+		const config = { servers: DEFAULTS as unknown as Record<string, ServerConfig> };
+		for (const file of ["kernel.cu", "kernel.cuh"]) {
+			const names = getServersForFile(config, file).map(([name]) => name);
+			expect(names).toContain("clangd");
+		}
+	});
+});
+
 describe("expert elixir lsp", () => {
 	it("registers expert for .ex while keeping elixirls primary", () => {
 		const config = { servers: DEFAULTS as unknown as Record<string, ServerConfig> };

--- a/packages/coding-agent/test/utils/lang-from-path.test.ts
+++ b/packages/coding-agent/test/utils/lang-from-path.test.ts
@@ -69,6 +69,11 @@ describe("getLanguageFromPath", () => {
 		expect(getLanguageFromPath("/home/user/project/src/index.ts")).toBe("typescript");
 		expect(getLanguageFromPath("C:\\Users\\dev\\app\\main.rs")).toBe("rust");
 	});
+
+	it("resolves CUDA sources and headers as C++", () => {
+		expect(getLanguageFromPath("kernel.cu")).toBe("cpp");
+		expect(getLanguageFromPath("kernel.cuh")).toBe("cpp");
+	});
 });
 
 describe("detectLanguageId", () => {
@@ -109,5 +114,10 @@ describe("detectLanguageId", () => {
 
 	it("falls back to plaintext for files with no extension", () => {
 		expect(detectLanguageId("README")).toBe("plaintext");
+	});
+
+	it("detects CUDA sources and headers as cpp", () => {
+		expect(detectLanguageId("kernel.cu")).toBe("cpp");
+		expect(detectLanguageId("kernel.cuh")).toBe("cpp");
 	});
 });

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed C++ language inference excluding CUDA header (`.cuh`) files.
+
 ## [18.1.9] - 2026-09-04
 
 ### Added


### PR DESCRIPTION
## What

- Register CUDA source and header files (`.cu` and `.cuh`) with the built-in clangd configuration.
- Infer both CUDA extensions as C++ for `ast_grep`/`pi-ast`.
- Honor an explicit `ast_grep.lang` override for ambiguous extensions such as `.h`.
- Document the language override and add focused regressions.

## Why

CUDA files currently fall through gaps between the LSP and structural-search language registries: clangd omits `.cu`/`.cuh`, `.cuh` has no C++ mapping, and `ast_grep` rejects a file before consulting an explicit language override.

## Testing

- `bun test packages/coding-agent/test/tools/lsp-regressions.test.ts -t "registers CUDA sources and headers"` — 1 passed
- `bun test packages/coding-agent/test/tools/ast-grep.test.ts` — 7 passed
- `bun --cwd packages/coding-agent run check` — passed
- `bazelisk build //:natives-darwin-arm64` — passed
- `pi-ast` tests — 82 passed, 1 ignored

---

- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)