### PR TITLE
fix(coding-agent): refresh WorkPool yield prompts

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 - Python cells are no longer replayed automatically after a kernel crash, preventing duplicate side effects; the next call starts a fresh kernel.
 - Session rewrites preserve open-reader snapshots and replacement identity when a rename needs an EPERM fallback.
+- Fixed WorkPool children retaining a stale Gemini-formatted `yield` declaration when pooled items were installed or cleared.
 
 ## [18.1.14] - 2026-09-07
 
@@ -80,9 +81,6 @@
 
 - Fixed Codex V2 remote compaction rebuilding the request prefix differently from normal turns, restoring prompt-cache reuse ([#10786](https://github.com/can1357/oh-my-pi/issues/10786)).
 - Restored mouse clicks, hover, and wheel scrolling in Plan Review.
-### Fixed
-
-- Fixed WorkPool children receiving the ordinary `yield` contract in Gemini-formatted tool prompts after pooled items were installed.
 
 ## [18.1.9] - 2026-09-04
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -80,6 +80,9 @@
 
 - Fixed Codex V2 remote compaction rebuilding the request prefix differently from normal turns, restoring prompt-cache reuse ([#10786](https://github.com/can1357/oh-my-pi/issues/10786)).
 - Restored mouse clicks, hover, and wheel scrolling in Plan Review.
+### Fixed
+
+- Fixed WorkPool children receiving the ordinary `yield` contract in Gemini-formatted tool prompts after pooled items were installed.
 
 ## [18.1.9] - 2026-09-04
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1020,7 +1020,20 @@ export class AgentSession {
 		// advertise one yield schema while the runtime enforces the other, so join
 		// the transition before building the turn from a consistent contract.
 		void this.whenWorkPoolYieldSettled()
-			.then(() => this.agent.prompt(records))
+			.then(() => {
+				// Synchronous ownership check, atomic with the dispatch below:
+				// agent.prompt() claims streaming with no await in between, and the
+				// yield contract above mutates synchronously, so no install can
+				// interleave here. Never start an ordinary wake under an installed
+				// pooled contract (it would emit keyed yields against another
+				// turn's items); preserve the records as asides instead.
+				if (this.agent.state.isStreaming || this.#workPoolYieldItems.length > 0) {
+					this.#irc.queueAside(records);
+					logger.debug("IRC wake turn deferred: worker busy or pooled");
+					return;
+				}
+				return this.agent.prompt(records);
+			})
 			.catch(error => {
 				if (error instanceof AgentBusyError) {
 					// Lost the prompt race (e.g. a WorkPool follow-up dispatched
@@ -7395,31 +7408,43 @@ export class AgentSession {
 
 	/** Replace the pooled-turn yield contract and rebuild the provider prompt when it changes. */
 	setWorkPoolYieldItems(items: readonly WorkPoolYieldItem[]): Promise<void> {
-		// Serialize transitions so a pooled install racing a clear (or an IRC
-		// wake racing either) observes them in call order. The change check runs
-		// inside the chain against the live set: a call-time check could no-op
-		// against a contract a queued transition has not applied yet.
-		const run = this.#workPoolYieldTransition.then(() => this.#applyWorkPoolYieldItems(items));
-		this.#workPoolYieldTransition = run.catch(() => {});
-		return run;
-	}
-
-	/** Settles when any in-flight yield contract transition completes. Wake-turn
-	 *  entry joins it so a turn never builds from a half-applied contract. */
-	whenWorkPoolYieldSettled(): Promise<void> {
-		return this.#workPoolYieldTransition;
-	}
-
-	async #applyWorkPoolYieldItems(items: readonly WorkPoolYieldItem[]): Promise<void> {
+		// Publish the new contract synchronously: prompt dispatchers (IRC wakes,
+		// follow-up turns) decide on live state in await-free sections, so the
+		// mutation must be visible before the first await. Live state is always
+		// post-last-call, so the change check cannot go stale; the prompt rebuild
+		// stays async on the serialized tail below.
 		const current = this.#workPoolYieldItems;
 		if (
 			current.length === items.length &&
 			current.every((item, index) => item.id === items[index]?.id && item.index === items[index]?.index)
 		) {
-			return;
+			return this.#workPoolYieldTransition;
 		}
-		this.#workPoolYieldItems = items.map(item => ({ ...item }));
-		await this.refreshBaseSystemPrompt();
+		const previous = current;
+		const applied = items.map(item => ({ ...item }));
+		this.#workPoolYieldItems = applied;
+		const run = this.#workPoolYieldTransition.then(async () => {
+			try {
+				await this.refreshBaseSystemPrompt();
+			} catch (error) {
+				// Roll back to the pre-transition contract so gated readers never
+				// observe a half-applied runtime/provider pair. A newer transition
+				// may have replaced the set meanwhile; only restore what this one
+				// installed.
+				if (this.#workPoolYieldItems === applied) {
+					this.#workPoolYieldItems = previous;
+				}
+				throw error;
+			}
+		});
+		this.#workPoolYieldTransition = run.catch(() => {});
+		return run;
+	}
+
+	/** Settles when any in-flight yield prompt rebuild completes. Wake-turn entry
+	 *  joins it so a turn never builds from stale provider bytes. */
+	whenWorkPoolYieldSettled(): Promise<void> {
+		return this.#workPoolYieldTransition;
 	}
 
 	#buildReplanTitleContext(): string {

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -912,6 +912,13 @@ export class AgentSession {
 		if (this.#modeExitDrainSuppressionDepth > 0 || this.#isDisposed || this.isStreaming || !this.#irc.hasPending()) {
 			return;
 		}
+		// A pooled yield contract means a pool turn owns this worker (installed,
+		// dispatching, or dispatch-imminent). Waking here would either emit keyed
+		// yields against its items or re-queue into the deferral path forever, so
+		// leave the records pending until the contract clears.
+		if (this.#workPoolYieldItems.length > 0) {
+			return;
+		}
 		// Session transitions call #disconnectFromAgent() BEFORE `await abort()`, and only bump
 		// #sessionGeneration/clear the IRC queue several awaits later once they reach agent.reset().
 		// A normalization await that resolves in that gap sees an unchanged generation and an idle,

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -7443,23 +7443,21 @@ export class AgentSession {
 				// installed.
 				if (this.#workPoolYieldItems === applied) {
 					this.#workPoolYieldItems = previous;
-					// Republish the restored contract through a trailing entry: an
-					// overlapping refresh may already have published newer bytes,
-					// and the equality fast path would otherwise never repair the
-					// mismatch. Appending (never awaiting the tail here) cannot
-					// deadlock; a republish failure only warns since the caller
-					// already sees this transition's error.
-					this.#workPoolYieldTransition = this.#workPoolYieldTransition.then(async () => {
-						try {
-							await this.refreshBaseSystemPrompt();
-						} catch (republishError) {
-							logger.warn("WorkPool yield contract republish failed", {
-								error: republishError instanceof Error ? republishError.message : String(republishError),
-							});
-							return;
-						}
-						this.#resumeStrandedIrcAsides();
-					});
+					// Republish inline so waiters gated on this transition observe
+					// the restored pair: a trailing entry would settle those
+					// waiters before the repair runs. An overlapping refresh may
+					// already have published newer bytes, and the equality fast
+					// path would otherwise never repair the mismatch. A republish
+					// failure only warns since the caller already sees error.
+					try {
+						await this.refreshBaseSystemPrompt();
+					} catch (republishError) {
+						logger.warn("WorkPool yield contract republish failed", {
+							error: republishError instanceof Error ? republishError.message : String(republishError),
+						});
+						throw error;
+					}
+					this.#resumeStrandedIrcAsides();
 				}
 				throw error;
 			}

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1022,6 +1022,14 @@ export class AgentSession {
 		void this.whenWorkPoolYieldSettled()
 			.then(() => this.agent.prompt(records))
 			.catch(error => {
+				if (error instanceof AgentBusyError) {
+					// Lost the prompt race (e.g. a WorkPool follow-up dispatched
+					// first): preserve the records as asides for the running turn
+					// instead of dropping them with the failed wake.
+					this.#irc.queueAside(records);
+					logger.debug("IRC wake turn deferred behind the running turn");
+					return;
+				}
 				turnError = error;
 				logger.warn("IRC wake turn failed", { error: String(error) });
 			})

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -7493,6 +7493,7 @@ export class AgentSession {
 			// contract is published, let it wake (or stay parked when pooled).
 			this.#resumeStrandedIrcAsides();
 		});
+		this.#workPoolYieldTransition = run.catch(() => {});
 		return run;
 	}
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1006,12 +1006,10 @@ export class AgentSession {
 			this.agent.replaceQueues([...this.agent.peekSteeringQueue()], []);
 			if (parkedQueueDrainBlocked) this.#queuedMessageDrainBlocked = false;
 		}
+		// The wake observer is attached only once prompt ownership is won below: a
+		// deferred wake runs no turn, so observing it would capture the next
+		// turn's yield/output and relay it as this wake's reply.
 		let finishObservation: ((error?: unknown) => void | Promise<void>) | undefined;
-		try {
-			finishObservation = this.#ircWakeTurnObserver?.(records);
-		} catch (error) {
-			logger.warn("IRC wake turn observer failed to start", { error: String(error) });
-		}
 		this.#resetPromptMaintenanceState();
 		// Capture the generation before the wake so its post-prompt recovery wait
 		// bails the instant an abort (which bumps #promptGeneration) supersedes
@@ -1038,6 +1036,11 @@ export class AgentSession {
 					this.#irc.queueAside(records);
 					logger.debug("IRC wake turn deferred: worker busy or pooled");
 					return;
+				}
+				try {
+					finishObservation = this.#ircWakeTurnObserver?.(records);
+				} catch (error) {
+					logger.warn("IRC wake turn observer failed to start", { error: String(error) });
 				}
 				return this.agent.prompt(records);
 			})
@@ -7453,11 +7456,16 @@ export class AgentSession {
 							logger.warn("WorkPool yield contract republish failed", {
 								error: republishError instanceof Error ? republishError.message : String(republishError),
 							});
+							return;
 						}
+						this.#resumeStrandedIrcAsides();
 					});
 				}
 				throw error;
 			}
+			// A deferred wake may be parked while pooled; now that the fresh
+			// contract is published, let it wake (or stay parked when pooled).
+			this.#resumeStrandedIrcAsides();
 		});
 		this.#workPoolYieldTransition = run.catch(() => {});
 		return run;

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -628,6 +628,12 @@ export class AgentSession {
 	#planModeReminderAwaitingProgress = false;
 	readonly #todo: TodoTracker;
 	#workPoolYieldItems: readonly WorkPoolYieldItem[] = [];
+	/** Item set matching the last successfully rebuilt provider prompt. The base
+	 *  prompt starts consistent with the empty set; every later value is a
+	 *  snapshot taken after a prompt rebuild resolves. Rollback restores this —
+	 *  never the merely requested previous set, which may belong to a transition
+	 *  that itself failed. Never mutated in place; replaced wholesale. */
+	#lastPublishedWorkPoolYieldItems: readonly WorkPoolYieldItem[] = [];
 	/** Serialized tail of pooled-turn yield contract transitions; never rejects. */
 	#workPoolYieldTransition: Promise<void> = Promise.resolve();
 	#replanTitleRefreshInFlight: Promise<void> | undefined = undefined;
@@ -7448,19 +7454,20 @@ export class AgentSession {
 		) {
 			return this.#workPoolYieldTransition;
 		}
-		const previous = current;
 		const applied = items.map(item => ({ ...item }));
 		this.#workPoolYieldItems = applied;
 		const run = this.#workPoolYieldTransition.then(async () => {
 			try {
 				await this.refreshBaseSystemPrompt();
 			} catch (error) {
-				// Roll back to the pre-transition contract so gated readers never
-				// observe a half-applied runtime/provider pair. A newer transition
-				// may have replaced the set meanwhile; only restore what this one
-				// installed.
+				// Roll back to the last successfully published contract so gated
+				// readers never observe a half-applied runtime/provider pair. A
+				// newer transition may have replaced the set meanwhile; only
+				// restore what this one installed. `previous` is deliberately not
+				// the target: when overlapping transitions fail in sequence, it can
+				// belong to a transition whose caller already saw a rejection.
 				if (this.#workPoolYieldItems === applied) {
-					this.#workPoolYieldItems = previous;
+					this.#workPoolYieldItems = this.#lastPublishedWorkPoolYieldItems;
 					// Republish inline so waiters gated on this transition observe
 					// the restored pair: a trailing entry would settle those
 					// waiters before the repair runs. An overlapping refresh may
@@ -7479,11 +7486,13 @@ export class AgentSession {
 				}
 				throw error;
 			}
+			// Record what this rebuild published for future rollbacks: the live set
+			// as of success. Then drain any wake parked while pooled.
+			this.#lastPublishedWorkPoolYieldItems = this.#workPoolYieldItems.map(item => ({ ...item }));
 			// A deferred wake may be parked while pooled; now that the fresh
 			// contract is published, let it wake (or stay parked when pooled).
 			this.#resumeStrandedIrcAsides();
 		});
-		this.#workPoolYieldTransition = run.catch(() => {});
 		return run;
 	}
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -7379,9 +7379,17 @@ export class AgentSession {
 		return this.#workPoolYieldItems;
 	}
 
-	/** Replace the item labels before starting a pooled turn. */
-	setWorkPoolYieldItems(items: readonly WorkPoolYieldItem[]): void {
+	/** Replace the pooled-turn yield contract and rebuild the provider prompt when it changes. */
+	async setWorkPoolYieldItems(items: readonly WorkPoolYieldItem[]): Promise<void> {
+		const current = this.#workPoolYieldItems;
+		if (
+			current.length === items.length &&
+			current.every((item, index) => item.id === items[index]?.id && item.index === items[index]?.index)
+		) {
+			return;
+		}
 		this.#workPoolYieldItems = items.map(item => ({ ...item }));
+		await this.refreshBaseSystemPrompt();
 	}
 
 	#buildReplanTitleContext(): string {

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -628,6 +628,8 @@ export class AgentSession {
 	#planModeReminderAwaitingProgress = false;
 	readonly #todo: TodoTracker;
 	#workPoolYieldItems: readonly WorkPoolYieldItem[] = [];
+	/** Serialized tail of pooled-turn yield contract transitions; never rejects. */
+	#workPoolYieldTransition: Promise<void> = Promise.resolve();
 	#replanTitleRefreshInFlight: Promise<void> | undefined = undefined;
 	/** Resolved TITLE_SYSTEM.md override applied to every automatic session-title
 	 *  generation path. Refresh via {@link AgentSession.setTitleSystemPrompt} when
@@ -1013,8 +1015,12 @@ export class AgentSession {
 		const generation = this.#promptGeneration;
 		this.#beginInFlight();
 		let turnError: unknown;
-		void this.agent
-			.prompt(records)
+		// A pooled-turn yield transition (item-set mutation + prompt rebuild) may be
+		// in flight when the wake lands. Starting the turn on the stale prompt would
+		// advertise one yield schema while the runtime enforces the other, so join
+		// the transition before building the turn from a consistent contract.
+		void this.whenWorkPoolYieldSettled()
+			.then(() => this.agent.prompt(records))
 			.catch(error => {
 				turnError = error;
 				logger.warn("IRC wake turn failed", { error: String(error) });
@@ -7380,7 +7386,23 @@ export class AgentSession {
 	}
 
 	/** Replace the pooled-turn yield contract and rebuild the provider prompt when it changes. */
-	async setWorkPoolYieldItems(items: readonly WorkPoolYieldItem[]): Promise<void> {
+	setWorkPoolYieldItems(items: readonly WorkPoolYieldItem[]): Promise<void> {
+		// Serialize transitions so a pooled install racing a clear (or an IRC
+		// wake racing either) observes them in call order. The change check runs
+		// inside the chain against the live set: a call-time check could no-op
+		// against a contract a queued transition has not applied yet.
+		const run = this.#workPoolYieldTransition.then(() => this.#applyWorkPoolYieldItems(items));
+		this.#workPoolYieldTransition = run.catch(() => {});
+		return run;
+	}
+
+	/** Settles when any in-flight yield contract transition completes. Wake-turn
+	 *  entry joins it so a turn never builds from a half-applied contract. */
+	whenWorkPoolYieldSettled(): Promise<void> {
+		return this.#workPoolYieldTransition;
+	}
+
+	async #applyWorkPoolYieldItems(items: readonly WorkPoolYieldItem[]): Promise<void> {
 		const current = this.#workPoolYieldItems;
 		if (
 			current.length === items.length &&

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -7433,6 +7433,21 @@ export class AgentSession {
 				// installed.
 				if (this.#workPoolYieldItems === applied) {
 					this.#workPoolYieldItems = previous;
+					// Republish the restored contract through a trailing entry: an
+					// overlapping refresh may already have published newer bytes,
+					// and the equality fast path would otherwise never repair the
+					// mismatch. Appending (never awaiting the tail here) cannot
+					// deadlock; a republish failure only warns since the caller
+					// already sees this transition's error.
+					this.#workPoolYieldTransition = this.#workPoolYieldTransition.then(async () => {
+						try {
+							await this.refreshBaseSystemPrompt();
+						} catch (republishError) {
+							logger.warn("WorkPool yield contract republish failed", {
+								error: republishError instanceof Error ? republishError.message : String(republishError),
+							});
+						}
+					});
 				}
 				throw error;
 			}

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -926,7 +926,9 @@ export class AgentSession {
 		// and race the transition's own reset — same rationale as #drainStrandedQueuedMessages.
 		if (this.#unsubscribeAgent === undefined) return;
 		if (this.#canAutoContinueForFollowUp() && this.agent.hasQueuedMessages()) return;
-		const records = this.#irc.drainPending();
+		// Parked wake records resume alongside ordinary stranded asides; they were
+		// already decided wake-intended at deferral time.
+		const records = [...this.#irc.drainDeferredWakes(), ...this.#irc.drainPending()];
 		if (this.#planModeState?.enabled) {
 			// Plan mode: fold stranded IRC asides into context without waking an
 			// autonomous turn. Convergence to ask/resolve stays user-driven.
@@ -1029,12 +1031,20 @@ export class AgentSession {
 				// Synchronous ownership check, atomic with the dispatch below:
 				// agent.prompt() claims streaming with no await in between, and the
 				// yield contract above mutates synchronously, so no install can
-				// interleave here. Never start an ordinary wake under an installed
-				// pooled contract (it would emit keyed yields against another
-				// turn's items); preserve the records as asides instead.
-				if (this.agent.state.isStreaming || this.#workPoolYieldItems.length > 0) {
+				// interleave here.
+				if (this.#workPoolYieldItems.length > 0) {
+					// A pooled turn owns this worker (installed, running, or
+					// dispatch-imminent): park wake-intended records where pooled
+					// turns cannot flush them, for a monitored wake after clearing.
+					// Flushing them as ordinary asides would feed them to the batch
+					// with no observer to reply to the sender.
+					this.#irc.queueDeferredWake(records);
+					logger.debug("IRC wake turn parked while pooled");
+					return;
+				}
+				if (this.agent.state.isStreaming) {
 					this.#irc.queueAside(records);
-					logger.debug("IRC wake turn deferred: worker busy or pooled");
+					logger.debug("IRC wake turn deferred behind the running turn");
 					return;
 				}
 				try {
@@ -1046,11 +1056,16 @@ export class AgentSession {
 			})
 			.catch(error => {
 				if (error instanceof AgentBusyError) {
-					// Lost the prompt race (e.g. a WorkPool follow-up dispatched
-					// first): preserve the records as asides for the running turn
-					// instead of dropping them with the failed wake.
-					this.#irc.queueAside(records);
-					logger.debug("IRC wake turn deferred behind the running turn");
+					// Lost the prompt race after passing the checks above: an
+					// ordinary running turn takes these as asides, but a pooled
+					// turn must not flush them, so park them instead.
+					if (this.#workPoolYieldItems.length > 0) {
+						this.#irc.queueDeferredWake(records);
+						logger.debug("IRC wake turn parked while pooled");
+					} else {
+						this.#irc.queueAside(records);
+						logger.debug("IRC wake turn deferred behind the running turn");
+					}
 					return;
 				}
 				turnError = error;

--- a/packages/coding-agent/src/session/irc-bridge.ts
+++ b/packages/coding-agent/src/session/irc-bridge.ts
@@ -28,6 +28,10 @@ export class IrcBridge {
 	readonly #host: IrcBridgeHost;
 	#interrupts: AgentMessage[] = [];
 	#asides: AgentMessage[] = [];
+	/** Wake-intended records parked while a pooled yield contract owns the worker.
+	 *  Pooled turns must not flush these (no observer would reply to the sender);
+	 *  they resume into a monitored wake once the contract clears. */
+	#deferredWakes: AgentMessage[] = [];
 	/** In-flight replies owed to peers: side-channel auto-replies and wake-turn relays. */
 	readonly #pendingReplies = new Set<Promise<void>>();
 
@@ -42,7 +46,7 @@ export class IrcBridge {
 
 	/** Whether any undelivered IRC record remains queued. */
 	hasPending(): boolean {
-		return this.#interrupts.length > 0 || this.#asides.length > 0;
+		return this.#interrupts.length > 0 || this.#asides.length > 0 || this.#deferredWakes.length > 0;
 	}
 
 	/**
@@ -97,6 +101,20 @@ export class IrcBridge {
 	 *  session transition, and extension `deliverAs: "aside"` sends. */
 	queueAside(records: AgentMessage[]): void {
 		this.#asides.push(...records);
+	}
+
+	/** Parks wake-intended records while a pooled contract owns the worker. Unlike
+	 *  asides, these are invisible to turn injection (`flushPending`, the loop
+	 *  aside poll) and resume into a monitored wake once the contract clears. */
+	queueDeferredWake(records: AgentMessage[]): void {
+		this.#deferredWakes.push(...records);
+	}
+
+	/** Takes parked wake records for a post-clear monitored wake, oldest first. */
+	drainDeferredWakes(): AgentMessage[] {
+		const records = this.#deferredWakes;
+		this.#deferredWakes = [];
+		return records;
 	}
 
 	/** Surfaces and consumes queued incoming records before automatic injection. */

--- a/packages/coding-agent/src/session/irc-bridge.ts
+++ b/packages/coding-agent/src/session/irc-bridge.ts
@@ -78,12 +78,15 @@ export class IrcBridge {
 	/** Snapshots and discards every queued IRC record — used when a session-boundary transition
 	 *  (new/switch) begins, since an aborted turn skips its final aside poll and would otherwise
 	 *  leak the outgoing transcript's extension/peer content into the next session via the first
-	 *  ordinary prompt's `flushPending()`. Pass the snapshot to `restorePending` to undo the clear
+	 *  ordinary prompt's `flushPending()`. Deferred wakes ride along: without them a later
+	 *  contract clear could wake the new transcript with a peer message belonging to the
+	 *  previous session. Pass the snapshot to `restorePending` to undo the clear
 	 *  if the transition is rolled back. */
-	clearPending(): { interrupts: AgentMessage[]; asides: AgentMessage[] } {
-		const snapshot = { interrupts: this.#interrupts, asides: this.#asides };
+	clearPending(): { interrupts: AgentMessage[]; asides: AgentMessage[]; deferredWakes: AgentMessage[] } {
+		const snapshot = { interrupts: this.#interrupts, asides: this.#asides, deferredWakes: this.#deferredWakes };
 		this.#interrupts = [];
 		this.#asides = [];
+		this.#deferredWakes = [];
 		return snapshot;
 	}
 
@@ -92,9 +95,14 @@ export class IrcBridge {
 	 *  the rolled-back switch's async load/hooks were still running) instead of overwriting it, so
 	 *  those newly arrived records aren't silently discarded — snapshot records precede them since
 	 *  they arrived first. */
-	restorePending(snapshot: { interrupts: AgentMessage[]; asides: AgentMessage[] }): void {
+	restorePending(snapshot: {
+		interrupts: AgentMessage[];
+		asides: AgentMessage[];
+		deferredWakes: AgentMessage[];
+	}): void {
 		this.#interrupts = [...snapshot.interrupts, ...this.#interrupts];
 		this.#asides = [...snapshot.asides, ...this.#asides];
+		this.#deferredWakes = [...snapshot.deferredWakes, ...this.#deferredWakes];
 	}
 
 	/** Queues records for the next step-boundary aside injection: IRC wakes deferred by a

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -2812,6 +2812,13 @@ export interface FollowUpTurnOptions {
 }
 
 async function installWorkPoolYieldItems(session: AgentSession, items: readonly WorkPoolYieldItem[]): Promise<void> {
+	const current = session.getWorkPoolYieldItems();
+	if (
+		current.length === items.length &&
+		current.every((item, index) => item.id === items[index]?.id && item.index === items[index]?.index)
+	) {
+		return;
+	}
 	session.setWorkPoolYieldItems(items);
 	await session.refreshBaseSystemPrompt();
 }

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -2811,6 +2811,11 @@ export interface FollowUpTurnOptions {
 	workPoolYieldItems?: WorkPoolYieldItem[];
 }
 
+async function installWorkPoolYieldItems(session: AgentSession, items: readonly WorkPoolYieldItem[]): Promise<void> {
+	session.setWorkPoolYieldItems(items);
+	await session.refreshBaseSystemPrompt();
+}
+
 /**
  * Continue a previously spawned (keep-alive) subagent with one more monitored
  * turn: revive it if parked, send `message` as a real prompt, drive it to
@@ -2827,7 +2832,7 @@ export async function runSubagentFollowUpTurn(options: FollowUpTurnOptions): Pro
 	const index = options.index ?? 0;
 	const startTime = Date.now();
 	const session = await AgentLifecycleManager.global().ensureLive(id);
-	session.setWorkPoolYieldItems(options.workPoolYieldItems ?? []);
+	await installWorkPoolYieldItems(session, options.workPoolYieldItems ?? []);
 	const ref = AgentRegistry.global().get(id);
 	const sessionFile = ref?.sessionFile ?? undefined;
 
@@ -3506,7 +3511,9 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 			if (filteredSubagentTools.length !== subagentToolNames.length) {
 				await awaitAbortable(session.setActiveToolsByName(filteredSubagentTools));
 			}
-			if (options.workPoolYieldItems) session.setWorkPoolYieldItems(options.workPoolYieldItems);
+			if (options.workPoolYieldItems) {
+				await awaitAbortable(installWorkPoolYieldItems(session, options.workPoolYieldItems));
+			}
 			const enabledSubagentTools = session.getEnabledToolNames();
 			// The enabled set includes the synthetic write transport injected for
 			// explicit tool lists that omitted write. `session_init.tools` is later

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -2902,10 +2902,11 @@ export async function runSubagentFollowUpTurn(options: FollowUpTurnOptions): Pro
 	emitSubagentFrame(options.eventBus, options.subagentEventBus, TASK_SUBAGENT_LIFECYCLE_CHANNEL, startedPayload);
 
 	monitor.setActiveSession(session);
+	// The batch monitor attaches per attempt; the hook below detaches before each
+	// backoff and reattaches for the retry, so the teardown always releases the
+	// current attempt — including when the drive rejects and no winning attempt
+	// was ever assigned.
 	let outcome: DriveOutcome;
-	// The batch monitor attaches per attempt (see below); this holds the winning
-	// attempt's unsubscribe for the shared teardown.
-	let unsubscribe: (() => void) | undefined;
 	// An IRC wake may own the session when this turn dispatches. drive retries the
 	// initial prompt through this hook: detach first so the wake turn's `yield`
 	// neither marks this batch yielded nor leaks into its result, restore the
@@ -2925,14 +2926,13 @@ export async function runSubagentFollowUpTurn(options: FollowUpTurnOptions): Pro
 			await session.setWorkPoolYieldItems(options.workPoolYieldItems ?? []);
 			attemptUnsubscribe = monitor.attach(session);
 		});
-		unsubscribe = attemptUnsubscribe;
 	} finally {
 		try {
 			await untilAborted(AbortSignal.timeout(5000), () => monitor.waitForActiveSessionAbort());
 		} catch {
 			// Ignore abort cleanup timeouts; the session stays adopted either way.
 		}
-		unsubscribe?.();
+		attemptUnsubscribe();
 		const active = monitor.takeActiveSession();
 		if (active) monitor.captureSalvage(active);
 		monitor.finish();

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -2852,27 +2852,31 @@ export async function runSubagentFollowUpTurn(options: FollowUpTurnOptions): Pro
 	// Bounded: a worker that never settles fails its batch instead of installing
 	// under the active turn or hanging the pool.
 	let ownershipWaits = 0;
-	while (session.isStreaming && ownershipWaits < 3) {
-		ownershipWaits++;
-		if (signal) {
-			await untilAborted(signal, () => session.waitForIdle());
-		} else {
-			await session.waitForIdle();
+	const acquireOwnership = async (): Promise<void> => {
+		while (session.isStreaming && ownershipWaits < 3) {
+			ownershipWaits++;
+			if (signal) {
+				await untilAborted(signal, () => session.waitForIdle());
+			} else {
+				await session.waitForIdle();
+			}
 		}
-	}
-	if (session.isStreaming) {
-		throw new Error(
-			`Subagent ${id} stayed busy through 3 ownership waits; refusing to install the pooled yield contract under an active turn`,
-		);
-	}
-	await session.setWorkPoolYieldItems(options.workPoolYieldItems ?? []);
+		if (session.isStreaming) {
+			throw new Error(
+				`Subagent ${id} stayed busy through 3 ownership waits; refusing to install the pooled yield contract under an active turn`,
+			);
+		}
+	};
+	await acquireOwnership();
 	// Revalidate until the worker survives an install round-trip unchanged: the
 	// waits/rebuild above can outlast the idle TTL, letting park() detach this
 	// instance mid-install. Each observed replacement means another full park
 	// cycle, so reinstall on the fresh session (revivals start empty) and check
 	// again; genuine churn fails fast instead of driving a stale instance, and
-	// a released worker throws instead of driving a corpse.
+	// a released worker throws instead of driving a corpse. A replacement may
+	// already be streaming a wake, so ownership is reacquired every round.
 	for (let acquireAttempts = 0; ; acquireAttempts++) {
+		await session.setWorkPoolYieldItems(options.workPoolYieldItems ?? []);
 		const live = await AgentLifecycleManager.global().ensureLive(id);
 		if (live === session) break;
 		if (acquireAttempts >= 2) {
@@ -2881,7 +2885,7 @@ export async function runSubagentFollowUpTurn(options: FollowUpTurnOptions): Pro
 			);
 		}
 		session = live;
-		await session.setWorkPoolYieldItems(options.workPoolYieldItems ?? []);
+		await acquireOwnership();
 	}
 	const ref = AgentRegistry.global().get(id);
 	const sessionFile = ref?.sessionFile ?? undefined;

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -3319,12 +3319,6 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 			// Root resolved by the latest roster ensure; the prompt callback renders
 			// live peer rows scoped to it, so a session switch hides stale parked trees.
 			let ircRootSessionFile: string | undefined;
-			// Live session for prompt rebuilds: the systemPrompt callback is
-			// re-invoked by refreshBaseSystemPrompt() after setWorkPoolYieldItems()
-			// mutates the session. Reading the live item set keeps the rendered
-			// Workpool completion block in sync when pooled items are cleared
-			// before a retained-worker wake turn; the captured options alone stay stale.
-			let liveSubagentSession: AgentSession | undefined;
 
 			// Captured by the lifecycle reviver: rebuilding an equivalent session from
 			// the same JSONL file re-invokes createAgentSession with the exact options
@@ -3376,8 +3370,14 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 						worktree: worktree ?? "",
 						outputSchema: normalizedOutputSchema,
 						outputSchemaOverridesAgent: options.outputSchemaOverridesAgent === true,
+						// Read the live item set through the registry instead of capturing
+						// the session: this callback outlives the turn via the lifecycle
+						// reviver, and a captured session would pin its whole graph past
+						// TTL park disposal.
 						workPoolYieldItems:
-							liveSubagentSession?.getWorkPoolYieldItems?.() ?? options.workPoolYieldItems ?? [],
+							AgentRegistry.global().get(id)?.session?.getWorkPoolYieldItems?.() ??
+							options.workPoolYieldItems ??
+							[],
 						ircPeers: ircRoster?.peers ?? [],
 						ircParkedCount: ircRoster?.parkedCount ?? 0,
 						ircOmittedCount: ircRoster?.omittedCount ?? 0,
@@ -3437,7 +3437,6 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 			let session: AgentSession;
 			try {
 				({ session } = await awaitAbortable(sessionPromise));
-				liveSubagentSession = session;
 			} catch (err) {
 				// Abort raced session startup. The session may still resolve later
 				// holding live LSP/MCP child processes — dispose it when it does so
@@ -3487,7 +3486,6 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 					});
 					AgentRegistry.global().syncSessionStatus(id, revived);
 					installIrcWakeTurnMonitor(revived);
-					liveSubagentSession = revived;
 					return revived;
 				};
 			}

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -7,7 +7,7 @@
 import * as fs from "node:fs/promises";
 import path from "node:path";
 import type { AgentEvent, AgentIdentity, AgentMessage, AgentTelemetryConfig } from "@oh-my-pi/pi-agent-core";
-import { EventLoopKeepalive, recordHandoff, resolveTelemetry } from "@oh-my-pi/pi-agent-core";
+import { AgentBusyError, EventLoopKeepalive, recordHandoff, resolveTelemetry } from "@oh-my-pi/pi-agent-core";
 import type { Api, Model, ServiceTierByFamily, Usage } from "@oh-my-pi/pi-ai";
 import { logger, popLoopPhase, prompt, pushLoopPhase, untilAborted } from "@oh-my-pi/pi-utils";
 import { ASYNC_JOB_MANAGER_SHUTDOWN_REASON, AsyncJobManager } from "../async";
@@ -2866,8 +2866,29 @@ export async function runSubagentFollowUpTurn(options: FollowUpTurnOptions): Pro
 	monitor.setActiveSession(session);
 	const unsubscribe = monitor.attach(session);
 	let outcome: DriveOutcome;
+	// An IRC wake may win the prompt race while this turn installs its pooled
+	// contract. On AgentBusyError back off: restore the ordinary contract so the
+	// running wake cannot consume pooled items, wait it out, then reinstall and
+	// retry. Bounded so a wedged worker still fails the batch instead of hanging it.
+	let dispatchAttempts = 0;
 	try {
-		outcome = await driveSessionToYield(session, monitor, message);
+		for (;;) {
+			try {
+				outcome = await driveSessionToYield(session, monitor, message);
+				break;
+			} catch (error) {
+				dispatchAttempts++;
+				if (!(error instanceof AgentBusyError) || dispatchAttempts >= 3 || signal?.aborted) throw error;
+				logger.debug("Subagent follow-up lost the prompt race to an IRC wake; backing off", { id });
+				await session.setWorkPoolYieldItems([]);
+				if (signal) {
+					await untilAborted(signal, () => session.waitForIdle());
+				} else {
+					await session.waitForIdle();
+				}
+				await session.setWorkPoolYieldItems(options.workPoolYieldItems ?? []);
+			}
+		}
 	} finally {
 		try {
 			await untilAborted(AbortSignal.timeout(5000), () => monitor.waitForActiveSessionAbort());
@@ -3327,6 +3348,12 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 			const buildSubagentSessionOptions = (
 				sessionManagerForRun: SessionManager,
 				expectedAgentRef: CreateAgentSessionOptions["expectedAgentRef"],
+				// Parked workers always revive with an empty runtime yield set; a
+				// pooled follow-up reinstalls its items explicitly before turning.
+				// Without this, the registry lookup below misses (session === null
+				// while the replacement builds) and the revived prompt resurrects
+				// the launch-time pooled instructions against an ordinary runtime.
+				forRevive = false,
 			): CreateAgentSessionOptions => ({
 				cwd: worktree ?? cwd,
 				additionalDirectories: worktree !== undefined ? undefined : options.additionalDirectories,
@@ -3373,11 +3400,12 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 						// Read the live item set through the registry instead of capturing
 						// the session: this callback outlives the turn via the lifecycle
 						// reviver, and a captured session would pin its whole graph past
-						// TTL park disposal.
+						// TTL park disposal. Parked revivals build while the registry
+						// session is null, so render the cleared set rather than
+						// resurrecting the launch-time pooled instructions.
 						workPoolYieldItems:
 							AgentRegistry.global().get(id)?.session?.getWorkPoolYieldItems?.() ??
-							options.workPoolYieldItems ??
-							[],
+							(forRevive ? [] : (options.workPoolYieldItems ?? [])),
 						ircPeers: ircRoster?.peers ?? [],
 						ircParkedCount: ircRoster?.parkedCount ?? 0,
 						ircOmittedCount: ircRoster?.omittedCount ?? 0,
@@ -3472,7 +3500,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 						);
 					}
 					const { session: revived } = await createAgentSession(
-						buildSubagentSessionOptions(reopened, expectedAgentRef),
+						buildSubagentSessionOptions(reopened, expectedAgentRef, true),
 					);
 					// Re-run the executor's extension wiring on the rebuilt session.
 					// Skipping it leaves the runner pre-init, so a `tool_call` handler

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -3319,6 +3319,12 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 			// Root resolved by the latest roster ensure; the prompt callback renders
 			// live peer rows scoped to it, so a session switch hides stale parked trees.
 			let ircRootSessionFile: string | undefined;
+			// Live session for prompt rebuilds: the systemPrompt callback is
+			// re-invoked by refreshBaseSystemPrompt() after setWorkPoolYieldItems()
+			// mutates the session. Reading the live item set keeps the rendered
+			// Workpool completion block in sync when pooled items are cleared
+			// before a retained-worker wake turn; the captured options alone stay stale.
+			let liveSubagentSession: AgentSession | undefined;
 
 			// Captured by the lifecycle reviver: rebuilding an equivalent session from
 			// the same JSONL file re-invokes createAgentSession with the exact options
@@ -3370,7 +3376,8 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 						worktree: worktree ?? "",
 						outputSchema: normalizedOutputSchema,
 						outputSchemaOverridesAgent: options.outputSchemaOverridesAgent === true,
-						workPoolYieldItems: options.workPoolYieldItems ?? [],
+						workPoolYieldItems:
+							liveSubagentSession?.getWorkPoolYieldItems?.() ?? options.workPoolYieldItems ?? [],
 						ircPeers: ircRoster?.peers ?? [],
 						ircParkedCount: ircRoster?.parkedCount ?? 0,
 						ircOmittedCount: ircRoster?.omittedCount ?? 0,
@@ -3430,6 +3437,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 			let session: AgentSession;
 			try {
 				({ session } = await awaitAbortable(sessionPromise));
+				liveSubagentSession = session;
 			} catch (err) {
 				// Abort raced session startup. The session may still resolve later
 				// holding live LSP/MCP child processes — dispose it when it does so
@@ -3479,6 +3487,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 					});
 					AgentRegistry.global().syncSessionStatus(id, revived);
 					installIrcWakeTurnMonitor(revived);
+					liveSubagentSession = revived;
 					return revived;
 				};
 			}

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -2866,12 +2866,23 @@ export async function runSubagentFollowUpTurn(options: FollowUpTurnOptions): Pro
 		);
 	}
 	await session.setWorkPoolYieldItems(options.workPoolYieldItems ?? []);
-	// Reacquire: the waits/rebuild above can outlast the idle TTL, letting park()
-	// detach this instance before the turn starts. A revived replacement starts
-	// with an empty contract, so reinstall (a no-op unless revived); a released
-	// worker throws here instead of driving a corpse.
-	session = await AgentLifecycleManager.global().ensureLive(id);
-	await session.setWorkPoolYieldItems(options.workPoolYieldItems ?? []);
+	// Revalidate until the worker survives an install round-trip unchanged: the
+	// waits/rebuild above can outlast the idle TTL, letting park() detach this
+	// instance mid-install. Each observed replacement means another full park
+	// cycle, so reinstall on the fresh session (revivals start empty) and check
+	// again; genuine churn fails fast instead of driving a stale instance, and
+	// a released worker throws instead of driving a corpse.
+	for (let acquireAttempts = 0; ; acquireAttempts++) {
+		const live = await AgentLifecycleManager.global().ensureLive(id);
+		if (live === session) break;
+		if (acquireAttempts >= 2) {
+			throw new Error(
+				`Subagent ${id} was replaced during every install attempt; refusing to drive a stale worker session`,
+			);
+		}
+		session = live;
+		await session.setWorkPoolYieldItems(options.workPoolYieldItems ?? []);
+	}
 	const ref = AgentRegistry.global().get(id);
 	const sessionFile = ref?.sessionFile ?? undefined;
 

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -2845,6 +2845,20 @@ export async function runSubagentFollowUpTurn(options: FollowUpTurnOptions): Pro
 	const index = options.index ?? 0;
 	const startTime = Date.now();
 	const session = await AgentLifecycleManager.global().ensureLive(id);
+	// Acquire turn ownership before mutating the shared yield contract: installing
+	// pooled items under a running ordinary wake would reject its in-flight tool
+	// calls. The check-to-install section below has no await, so once idle is
+	// observed no wake dispatch can interleave before the synchronous mutation.
+	// Bounded so a wedged worker fails its batch instead of hanging the pool.
+	let ownershipWaits = 0;
+	while (session.isStreaming && ownershipWaits < 3) {
+		ownershipWaits++;
+		if (signal) {
+			await untilAborted(signal, () => session.waitForIdle());
+		} else {
+			await session.waitForIdle();
+		}
+	}
 	await session.setWorkPoolYieldItems(options.workPoolYieldItems ?? []);
 	const ref = AgentRegistry.global().get(id);
 	const sessionFile = ref?.sessionFile ?? undefined;

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -2849,7 +2849,8 @@ export async function runSubagentFollowUpTurn(options: FollowUpTurnOptions): Pro
 	// pooled items under a running ordinary wake would reject its in-flight tool
 	// calls. The check-to-install section below has no await, so once idle is
 	// observed no wake dispatch can interleave before the synchronous mutation.
-	// Bounded so a wedged worker fails its batch instead of hanging the pool.
+	// Bounded: a worker that never settles fails its batch instead of installing
+	// under the active turn or hanging the pool.
 	let ownershipWaits = 0;
 	while (session.isStreaming && ownershipWaits < 3) {
 		ownershipWaits++;
@@ -2858,6 +2859,11 @@ export async function runSubagentFollowUpTurn(options: FollowUpTurnOptions): Pro
 		} else {
 			await session.waitForIdle();
 		}
+	}
+	if (session.isStreaming) {
+		throw new Error(
+			`Subagent ${id} stayed busy through 3 ownership waits; refusing to install the pooled yield contract under an active turn`,
+		);
 	}
 	await session.setWorkPoolYieldItems(options.workPoolYieldItems ?? []);
 	const ref = AgentRegistry.global().get(id);

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -1952,6 +1952,10 @@ async function driveSessionToYield(
 	session: AgentSession,
 	monitor: SubagentRunMonitor,
 	task: string,
+	// Invoked when the initial prompt loses a prompt race (AgentBusyError) before
+	// retrying. Lets the caller restore a safe contract and detach its monitor
+	// while backing off. Absent, the busy error keeps the old path.
+	onPromptBusy?: () => Promise<void>,
 ): Promise<DriveOutcome> {
 	using _keepalive = new EventLoopKeepalive();
 	const abortSignal = monitor.abortSignal;
@@ -1989,7 +1993,21 @@ async function driveSessionToYield(
 
 	try {
 		try {
-			await awaitAbortable(session.prompt(task, { attribution: "agent" }));
+			// An IRC wake may own the session when this turn dispatches. Its prompt
+			// wins the race and this prompt throws AgentBusyError; back off through
+			// the caller hook and retry. Bounded so a wedged worker still resolves
+			// instead of hanging the batch.
+			let promptAttempts = 0;
+			for (;;) {
+				try {
+					await awaitAbortable(session.prompt(task, { attribution: "agent" }));
+					break;
+				} catch (error) {
+					promptAttempts++;
+					if (!(error instanceof AgentBusyError) || promptAttempts >= 3 || !onPromptBusy) throw error;
+					await onPromptBusy();
+				}
+			}
 			await awaitAbortable(session.waitForIdle());
 		} catch (err) {
 			// A budget stop or a yield turn-stop (terminal yield parked behind
@@ -2864,38 +2882,37 @@ export async function runSubagentFollowUpTurn(options: FollowUpTurnOptions): Pro
 	emitSubagentFrame(options.eventBus, options.subagentEventBus, TASK_SUBAGENT_LIFECYCLE_CHANNEL, startedPayload);
 
 	monitor.setActiveSession(session);
-	const unsubscribe = monitor.attach(session);
 	let outcome: DriveOutcome;
-	// An IRC wake may win the prompt race while this turn installs its pooled
-	// contract. On AgentBusyError back off: restore the ordinary contract so the
-	// running wake cannot consume pooled items, wait it out, then reinstall and
-	// retry. Bounded so a wedged worker still fails the batch instead of hanging it.
-	let dispatchAttempts = 0;
+	// The batch monitor attaches per attempt (see below); this holds the winning
+	// attempt's unsubscribe for the shared teardown.
+	let unsubscribe: (() => void) | undefined;
+	// An IRC wake may own the session when this turn dispatches. drive retries the
+	// initial prompt through this hook: detach first so the wake turn's `yield`
+	// neither marks this batch yielded nor leaks into its result, restore the
+	// ordinary contract so the wake cannot consume pooled items, wait it out,
+	// then reinstall and reattach for the retry.
+	let attemptUnsubscribe = monitor.attach(session);
 	try {
-		for (;;) {
-			try {
-				outcome = await driveSessionToYield(session, monitor, message);
-				break;
-			} catch (error) {
-				dispatchAttempts++;
-				if (!(error instanceof AgentBusyError) || dispatchAttempts >= 3 || signal?.aborted) throw error;
-				logger.debug("Subagent follow-up lost the prompt race to an IRC wake; backing off", { id });
-				await session.setWorkPoolYieldItems([]);
-				if (signal) {
-					await untilAborted(signal, () => session.waitForIdle());
-				} else {
-					await session.waitForIdle();
-				}
-				await session.setWorkPoolYieldItems(options.workPoolYieldItems ?? []);
+		outcome = await driveSessionToYield(session, monitor, message, async () => {
+			attemptUnsubscribe();
+			logger.debug("Subagent follow-up lost the prompt race to an IRC wake; backing off", { id });
+			await session.setWorkPoolYieldItems([]);
+			if (signal) {
+				await untilAborted(signal, () => session.waitForIdle());
+			} else {
+				await session.waitForIdle();
 			}
-		}
+			await session.setWorkPoolYieldItems(options.workPoolYieldItems ?? []);
+			attemptUnsubscribe = monitor.attach(session);
+		});
+		unsubscribe = attemptUnsubscribe;
 	} finally {
 		try {
 			await untilAborted(AbortSignal.timeout(5000), () => monitor.waitForActiveSessionAbort());
 		} catch {
 			// Ignore abort cleanup timeouts; the session stays adopted either way.
 		}
-		unsubscribe();
+		unsubscribe?.();
 		const active = monitor.takeActiveSession();
 		if (active) monitor.captureSalvage(active);
 		monitor.finish();

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -2811,18 +2811,6 @@ export interface FollowUpTurnOptions {
 	workPoolYieldItems?: WorkPoolYieldItem[];
 }
 
-async function installWorkPoolYieldItems(session: AgentSession, items: readonly WorkPoolYieldItem[]): Promise<void> {
-	const current = session.getWorkPoolYieldItems();
-	if (
-		current.length === items.length &&
-		current.every((item, index) => item.id === items[index]?.id && item.index === items[index]?.index)
-	) {
-		return;
-	}
-	session.setWorkPoolYieldItems(items);
-	await session.refreshBaseSystemPrompt();
-}
-
 /**
  * Continue a previously spawned (keep-alive) subagent with one more monitored
  * turn: revive it if parked, send `message` as a real prompt, drive it to
@@ -2839,7 +2827,7 @@ export async function runSubagentFollowUpTurn(options: FollowUpTurnOptions): Pro
 	const index = options.index ?? 0;
 	const startTime = Date.now();
 	const session = await AgentLifecycleManager.global().ensureLive(id);
-	await installWorkPoolYieldItems(session, options.workPoolYieldItems ?? []);
+	await session.setWorkPoolYieldItems(options.workPoolYieldItems ?? []);
 	const ref = AgentRegistry.global().get(id);
 	const sessionFile = ref?.sessionFile ?? undefined;
 
@@ -3519,7 +3507,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				await awaitAbortable(session.setActiveToolsByName(filteredSubagentTools));
 			}
 			if (options.workPoolYieldItems) {
-				await awaitAbortable(installWorkPoolYieldItems(session, options.workPoolYieldItems));
+				await awaitAbortable(session.setWorkPoolYieldItems(options.workPoolYieldItems));
 			}
 			const enabledSubagentTools = session.getEnabledToolNames();
 			// The enabled set includes the synthetic write transport injected for

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -2844,7 +2844,7 @@ export async function runSubagentFollowUpTurn(options: FollowUpTurnOptions): Pro
 	const { id, agent, message, signal } = options;
 	const index = options.index ?? 0;
 	const startTime = Date.now();
-	const session = await AgentLifecycleManager.global().ensureLive(id);
+	let session = await AgentLifecycleManager.global().ensureLive(id);
 	// Acquire turn ownership before mutating the shared yield contract: installing
 	// pooled items under a running ordinary wake would reject its in-flight tool
 	// calls. The check-to-install section below has no await, so once idle is
@@ -2865,6 +2865,12 @@ export async function runSubagentFollowUpTurn(options: FollowUpTurnOptions): Pro
 			`Subagent ${id} stayed busy through 3 ownership waits; refusing to install the pooled yield contract under an active turn`,
 		);
 	}
+	await session.setWorkPoolYieldItems(options.workPoolYieldItems ?? []);
+	// Reacquire: the waits/rebuild above can outlast the idle TTL, letting park()
+	// detach this instance before the turn starts. A revived replacement starts
+	// with an empty contract, so reinstall (a no-op unless revived); a released
+	// worker throws here instead of driving a corpse.
+	session = await AgentLifecycleManager.global().ensureLive(id);
 	await session.setWorkPoolYieldItems(options.workPoolYieldItems ?? []);
 	const ref = AgentRegistry.global().get(id);
 	const sessionFile = ref?.sessionFile ?? undefined;

--- a/packages/coding-agent/src/task/workpool.ts
+++ b/packages/coding-agent/src/task/workpool.ts
@@ -3,6 +3,7 @@ import type { CustomTool } from "../extensibility/custom-tools/types";
 import workpoolBatchTemplate from "../prompts/tools/workpool-batch.md" with { type: "text" };
 import workpoolTurnResultTemplate from "../prompts/tools/workpool-turn-result.md" with { type: "text" };
 import { AgentRegistry, MAIN_AGENT_ID } from "../registry/agent-registry";
+import { AgentLifecycleManager } from "../registry/agent-lifecycle";
 import type { CustomMessage } from "../session/messages";
 import type { ToolSession } from "../tools";
 import { isIrcEnabled } from "../tools/hub";
@@ -451,6 +452,23 @@ export class WorkPool {
 				batch: batch.id,
 				error: error instanceof Error ? error.message : String(error),
 			});
+			// The runtime already flipped to the ordinary schema while the prompt
+			// still advertises the keyed one. The worker must not survive as a
+			// messageable session: release the lifecycle adoption (guarded by the
+			// registry ref so a newer same-id ref is never taken down) so neither
+			// pool reuse nor an IRC wake can reach the inconsistent contract.
+			if (ref) {
+				try {
+					await AgentLifecycleManager.global().release(agent.id, ref);
+				} catch (releaseError) {
+					logger.warn("workpool: failed to release worker after yield clear failure", {
+						pool: this.name,
+						agent: agent.id,
+						batch: batch.id,
+						error: releaseError instanceof Error ? releaseError.message : String(releaseError),
+					});
+				}
+			}
 		}
 		if (this.freshAgents) {
 			agent.state = "dead";

--- a/packages/coding-agent/src/task/workpool.ts
+++ b/packages/coding-agent/src/task/workpool.ts
@@ -456,10 +456,13 @@ export class WorkPool {
 			// still advertises the keyed one. The worker must not survive as a
 			// messageable session: release the lifecycle adoption (guarded by the
 			// registry ref so a newer same-id ref is never taken down) so neither
-			// pool reuse nor an IRC wake can reach the inconsistent contract.
+			// pool reuse nor an IRC wake can reach the inconsistent contract. The
+			// tombstone keeps the ref terminal so a later persisted-agent scan
+			// cannot resurrect the transcript as parked with a stale pooled
+			// declaration and an empty runtime set.
 			if (ref) {
 				try {
-					await AgentLifecycleManager.global().release(agent.id, ref);
+					await AgentLifecycleManager.global().release(agent.id, ref, { tombstone: true });
 				} catch (releaseError) {
 					logger.warn("workpool: failed to release worker after yield clear failure", {
 						pool: this.name,

--- a/packages/coding-agent/src/task/workpool.ts
+++ b/packages/coding-agent/src/task/workpool.ts
@@ -437,7 +437,21 @@ export class WorkPool {
 		agent.jobId = undefined;
 		const ref = AgentRegistry.global().get(agent.id);
 		// Retained idle workers can wake through IRC, so clear the runtime schema and cached inline declaration together.
-		await ref?.session?.setWorkPoolYieldItems([]);
+		// A refresh failure must not strand the pool in #waitForDrain(): items are
+		// already terminal, so keep the turn result, drop the worker instead of
+		// reusing it with a stale keyed declaration, and still notify drain.
+		let yieldCleared = true;
+		try {
+			await ref?.session?.setWorkPoolYieldItems([]);
+		} catch (error) {
+			yieldCleared = false;
+			logger.warn("workpool: failed to clear yield contract", {
+				pool: this.name,
+				agent: agent.id,
+				batch: batch.id,
+				error: error instanceof Error ? error.message : String(error),
+			});
+		}
 		if (this.freshAgents) {
 			agent.state = "dead";
 			const index = this.agents.indexOf(agent);
@@ -447,7 +461,7 @@ export class WorkPool {
 			this.#notifyDrained();
 			return;
 		}
-		if (ref && (ref.status === "idle" || ref.status === "parked")) {
+		if (yieldCleared && ref && (ref.status === "idle" || ref.status === "parked")) {
 			this.#drain(agent);
 		} else {
 			agent.state = "dead";

--- a/packages/coding-agent/src/task/workpool.ts
+++ b/packages/coding-agent/src/task/workpool.ts
@@ -422,21 +422,22 @@ export class WorkPool {
 		manager.watchJobs([jobId]);
 	}
 
-	#settleTurn(agent: WorkPoolAgent, batch: WorkPoolBatch, result: TurnOutcome): string {
-		this.#finishTurn(agent, batch, result);
+	async #settleTurn(agent: WorkPoolAgent, batch: WorkPoolBatch, result: TurnOutcome): Promise<string> {
+		await this.#finishTurn(agent, batch, result);
 		const delivery = this.#renderTurnResult(agent, batch, result);
 		if (batch.status !== "completed") throw new Error(delivery);
 		return delivery;
 	}
 
-	#finishTurn(agent: WorkPoolAgent, batch: WorkPoolBatch, result: TurnOutcome): void {
+	async #finishTurn(agent: WorkPoolAgent, batch: WorkPoolBatch, result: TurnOutcome): Promise<void> {
 		batch.status = result.aborted ? "cancelled" : result.exitCode !== 0 || result.error ? "failed" : "completed";
 		batch.output = result.output;
 		for (const item of batch.items) item.status = batch.status;
 		agent.turns++;
 		agent.jobId = undefined;
 		const ref = AgentRegistry.global().get(agent.id);
-		ref?.session?.setWorkPoolYieldItems([]);
+		// Retained idle workers can wake through IRC, so clear the runtime schema and cached inline declaration together.
+		await ref?.session?.setWorkPoolYieldItems([]);
 		if (this.freshAgents) {
 			agent.state = "dead";
 			const index = this.agents.indexOf(agent);

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -383,8 +383,8 @@ export interface ToolSession {
 	setTodoPhases?: (phases: TodoPhase[]) => void;
 	/** Active workpool items whose incremental yields complete the current turn. */
 	getWorkPoolYieldItems?: () => readonly WorkPoolYieldItem[];
-	/** Replace the active workpool item contract before a pooled turn starts. */
-	setWorkPoolYieldItems?: (items: readonly WorkPoolYieldItem[]) => void;
+	/** Replace the active workpool item contract and refresh its provider-facing prompt. */
+	setWorkPoolYieldItems?: (items: readonly WorkPoolYieldItem[]) => Promise<void>;
 	/** The tool-choice queue used to force forthcoming tool invocations and carry invocation handlers. */
 	getToolChoiceQueue?(): ToolChoiceQueue;
 	/** Build a model-provider-specific ToolChoice that targets the named tool, or undefined if unsupported. */

--- a/packages/coding-agent/test/agent-session-aside-delivery.test.ts
+++ b/packages/coding-agent/test/agent-session-aside-delivery.test.ts
@@ -808,6 +808,40 @@ describe("AgentSession aside delivery", () => {
 		expect(drained[0]).toBe(original);
 		expect(drained[1]).toBe(duringRollback);
 	});
+	it("IrcBridge boundary snapshots carry deferred wakes with the other queues", () => {
+		// A parked wake must not survive a session switch while ordinary asides
+		// are discarded: the later contract clear would otherwise wake the new
+		// transcript with a peer message belonging to the previous session.
+		// Rollback restores the same ordering guarantee as the other queues.
+		const host: IrcBridgeHost = {
+			agent: {} as Agent,
+			sessionManager: {} as SessionManager,
+			settings: {} as Settings,
+			isDisposed: () => false,
+			isStreaming: () => false,
+			planModeEnabled: () => false,
+			emitSessionEvent: async () => {},
+			wakeForIrc: () => {},
+			runEphemeralTurn: async () => ({ replyText: "" }),
+		};
+		const irc = new IrcBridge(host);
+		const wake: AgentMessage = {
+			role: "custom",
+			customType: "irc:incoming",
+			content: "peer ping",
+			display: true,
+			details: { id: "w1", from: "peer", message: "peer ping" },
+			attribution: "agent",
+			timestamp: Date.now(),
+		};
+		irc.queueDeferredWake([wake]);
+		const snapshot = irc.clearPending();
+		expect(irc.hasPending()).toBe(false);
+		expect(irc.drainDeferredWakes()).toEqual([]);
+		irc.restorePending(snapshot);
+		expect(irc.drainDeferredWakes()).toEqual([wake]);
+		expect(irc.hasPending()).toBe(false);
+	});
 	it("IrcBridge parks deferred wakes where turn injection cannot flush them", () => {
 		// A wake deferred while pooled must survive the next pooled turn's
 		// pre-dispatch flush and loop aside poll: with no observer attached,

--- a/packages/coding-agent/test/agent-session-aside-delivery.test.ts
+++ b/packages/coding-agent/test/agent-session-aside-delivery.test.ts
@@ -808,6 +808,49 @@ describe("AgentSession aside delivery", () => {
 		expect(drained[0]).toBe(original);
 		expect(drained[1]).toBe(duringRollback);
 	});
+	it("IrcBridge parks deferred wakes where turn injection cannot flush them", () => {
+		// A wake deferred while pooled must survive the next pooled turn's
+		// pre-dispatch flush and loop aside poll: with no observer attached,
+		// flushing it as an ordinary aside would answer the sender never.
+		const emitted: AgentMessage[] = [];
+		const host: IrcBridgeHost = {
+			agent: {
+				emitExternalEvent: (event: { message: AgentMessage }) => emitted.push(event.message),
+			} as unknown as Agent,
+			sessionManager: {} as SessionManager,
+			settings: {} as Settings,
+			isDisposed: () => false,
+			isStreaming: () => false,
+			planModeEnabled: () => false,
+			emitSessionEvent: async () => {},
+			wakeForIrc: () => {},
+			runEphemeralTurn: async () => ({ replyText: "" }),
+		};
+		const irc = new IrcBridge(host);
+		const wake: AgentMessage = {
+			role: "custom",
+			customType: "irc:incoming",
+			content: "peer ping",
+			display: true,
+			details: { id: "w1", from: "peer", message: "peer ping" },
+			attribution: "agent",
+			timestamp: Date.now(),
+		};
+		const aside: AgentMessage = {
+			role: "user",
+			content: [{ type: "text", text: "NOTE" }],
+			attribution: "user",
+			timestamp: Date.now(),
+		};
+		irc.queueDeferredWake([wake]);
+		irc.queueAside([aside]);
+		expect(irc.hasPending()).toBe(true);
+		irc.flushPending();
+		expect(emitted).toEqual([aside, aside]);
+		expect(irc.drainPending()).toEqual([]);
+		expect(irc.drainDeferredWakes()).toEqual([wake]);
+		expect(irc.hasPending()).toBe(false);
+	});
 
 	it("drops a queued aside whose normalization outlives a concurrent newSession()", async () => {
 		// Regression: #queueUserMessage's aside branch used to enqueue into IrcBridge

--- a/packages/coding-agent/test/sdk-workpool-yield-schema.test.ts
+++ b/packages/coding-agent/test/sdk-workpool-yield-schema.test.ts
@@ -31,51 +31,73 @@ describe("SDK workpool yield schema", () => {
 		if (fs.existsSync(registryDir)) removeSyncWithRetries(registryDir);
 	});
 
-	it("reads the dynamic yield schema during construction and switches it before a pooled turn", async () => {
-		const { session } = await createAgentSession({
-			cwd: registryDir,
-			agentDir: registryDir,
-			modelRegistry,
-			sessionManager: SessionManager.inMemory(),
-			settings: Settings.isolated({ inlineToolDescriptors: "on" }),
-			model: getBundledModel("openai", "gpt-4o-mini"),
-			disableExtensionDiscovery: true,
-			skills: [],
-			contextFiles: [],
-			promptTemplates: [],
-			slashCommands: [],
-			enableMCP: false,
-			enableLsp: false,
-			skipPythonPreflight: true,
-			requireYieldTool: true,
-			toolNames: ["yield"],
-			outputSchema: {
-				type: "object",
-				properties: { "pool#1": {} },
-				required: ["pool#1"],
-				additionalProperties: false,
-			},
-			parentTaskPrefix: "workpool-worker",
-			agentId: "workpool-worker",
-			agentName: "scout",
-			agentDisplayName: "scout",
-			taskDepth: 1,
-		});
-		sessions.push(session);
-		const tool = session.getToolByName("yield");
-		if (!tool) throw new Error("Missing yield tool");
-		expect(Reflect.get(tool.parameters, "properties")).toHaveProperty("type");
-		expect(Reflect.get(tool.parameters, "properties")).not.toHaveProperty("key");
+	for (const [dialect, toolSettings] of [
+		["native", {}],
+		["gemini", { "tools.format": "gemini" }],
+	] as const) {
+		it("switches the constructed yield tool before a pooled turn starts (" + dialect + ")", async () => {
+			const { session } = await createAgentSession({
+				cwd: registryDir,
+				agentDir: registryDir,
+				modelRegistry,
+				sessionManager: SessionManager.inMemory(),
+				settings: Settings.isolated({ ...toolSettings, inlineToolDescriptors: "on" }),
+				model: getBundledModel("openai", "gpt-4o-mini"),
+				disableExtensionDiscovery: true,
+				skills: [],
+				contextFiles: [],
+				promptTemplates: [],
+				slashCommands: [],
+				enableMCP: false,
+				enableLsp: false,
+				skipPythonPreflight: true,
+				requireYieldTool: true,
+				toolNames: ["yield"],
+				outputSchema: {
+					type: "object",
+					properties: { "pool#1": {} },
+					required: ["pool#1"],
+					additionalProperties: false,
+				},
+				parentTaskPrefix: "workpool-worker",
+				agentId: "workpool-worker",
+				agentName: "scout",
+				agentDisplayName: "scout",
+				taskDepth: 1,
+			});
+			sessions.push(session);
+			const tool = session.getToolByName("yield");
+			if (!tool) throw new Error("Missing yield tool");
+			expect(Reflect.get(tool.parameters, "properties")).toHaveProperty("type");
+			expect(Reflect.get(tool.parameters, "properties")).not.toHaveProperty("key");
 
-		session.setWorkPoolYieldItems([{ id: "pool#1", index: 1 }]);
-		expect(Reflect.get(tool.parameters, "required")).toEqual(["key"]);
-		const properties = Reflect.get(tool.parameters, "properties");
-		expect(properties).toHaveProperty("key");
-		expect(properties).not.toHaveProperty("type");
-		const activeTool = session.agent.state.tools.find(candidate => candidate.name === "yield");
-		if (!activeTool) throw new Error("Missing active yield tool");
-		expect(Reflect.get(activeTool.parameters, "required")).toEqual(["key"]);
-		const result = await tool.execute("yield-pool-1", { key: 1, data: { answer: 42 } });
-		expect(result.details).toMatchObject({ type: ["pool#1"], complete: true });
-	});
+			session.setWorkPoolYieldItems([{ id: "pool#1", index: 1 }]);
+			await session.refreshBaseSystemPrompt();
+			expect(Reflect.get(tool.parameters, "required")).toEqual(["key"]);
+			const properties = Reflect.get(tool.parameters, "properties");
+			expect(properties).toHaveProperty("key");
+			expect(properties).not.toHaveProperty("type");
+			const activeTool = session.agent.state.tools.find(candidate => candidate.name === "yield");
+			if (!activeTool) throw new Error("Missing active yield tool");
+			expect(Reflect.get(activeTool.parameters, "required")).toEqual(["key"]);
+			const providerContext = await session.agent.buildSideRequestContext([]);
+			if (dialect === "native") {
+				const providerTool = providerContext.tools?.find(candidate => candidate.name === "yield");
+				if (!providerTool) throw new Error("Missing provider yield tool");
+				expect(Reflect.get(providerTool.parameters, "required")).toEqual(["key"]);
+			} else {
+				const providerSystemPrompt = providerContext.systemPrompt;
+				if (!providerSystemPrompt) throw new Error("Missing provider system prompt");
+				const providerPrompt = providerSystemPrompt.join("\n");
+				expect(providerPrompt.match(/type yield =/g)).toHaveLength(1);
+				const yieldStart = providerPrompt.indexOf("type yield =");
+				const nextType = providerPrompt.indexOf("\ntype ", yieldStart + 1);
+				const yieldDeclaration = providerPrompt.slice(yieldStart, nextType < 0 ? providerPrompt.length : nextType);
+				expect(yieldDeclaration).toContain("key: 1,");
+				expect(yieldDeclaration).not.toContain("result:");
+			}
+			const result = await tool.execute("yield-pool-1", { key: 1, data: { answer: 42 } });
+			expect(result.details).toMatchObject({ type: ["pool#1"], complete: true });
+		});
+	}
 });

--- a/packages/coding-agent/test/sdk-workpool-yield-schema.test.ts
+++ b/packages/coding-agent/test/sdk-workpool-yield-schema.test.ts
@@ -131,5 +131,45 @@ describe("SDK workpool yield schema", () => {
 			expect(clearedProperties).not.toHaveProperty("key");
 			await expectProviderYieldContract(session, dialect, false);
 		});
+		it("serializes concurrent yield contract transitions in call order (" + dialect + ")", async () => {
+			const { session } = await createAgentSession({
+				cwd: registryDir,
+				agentDir: registryDir,
+				modelRegistry,
+				sessionManager: SessionManager.inMemory(),
+				settings: Settings.isolated({ ...toolSettings, inlineToolDescriptors: "on" }),
+				model: getBundledModel("openai", "gpt-4o-mini"),
+				disableExtensionDiscovery: true,
+				skills: [],
+				contextFiles: [],
+				promptTemplates: [],
+				slashCommands: [],
+				enableMCP: false,
+				enableLsp: false,
+				skipPythonPreflight: true,
+				requireYieldTool: true,
+				toolNames: ["yield"],
+				outputSchema: {
+					type: "object",
+					properties: { "pool#1": {} },
+					required: ["pool#1"],
+					additionalProperties: false,
+				},
+				parentTaskPrefix: "workpool-chain",
+				agentId: "workpool-chain",
+				agentName: "scout",
+				agentDisplayName: "scout",
+				taskDepth: 1,
+			});
+			sessions.push(session);
+			// A pooled install racing a clear must settle in call order: the clear
+			// runs after the install even though neither was awaited, so the wake
+			// gate joined here observes the cleared ordinary contract.
+			const install = session.setWorkPoolYieldItems([{ id: "pool#1", index: 1 }]);
+			const clear = session.setWorkPoolYieldItems([]);
+			await Promise.all([install, clear, session.whenWorkPoolYieldSettled()]);
+			expect(session.getWorkPoolYieldItems()).toEqual([]);
+			await expectProviderYieldContract(session, dialect, false);
+		});
 	}
 });

--- a/packages/coding-agent/test/sdk-workpool-yield-schema.test.ts
+++ b/packages/coding-agent/test/sdk-workpool-yield-schema.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { afterAll, beforeAll, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -9,7 +9,8 @@ import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { createAgentSession } from "@oh-my-pi/pi-coding-agent/sdk";
 import type { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
-import { removeSyncWithRetries, Snowflake } from "@oh-my-pi/pi-utils";
+import { removeSyncWithRetries, Snowflake, prompt } from "@oh-my-pi/pi-utils";
+import subagentSystemPromptTemplate from "../src/prompts/system/subagent-system-prompt.md" with { type: "text" };
 
 async function expectProviderYieldContract(
 	session: AgentSession,
@@ -171,10 +172,56 @@ describe("SDK workpool yield schema", () => {
 			expect(session.getWorkPoolYieldItems()).toEqual([]);
 			await expectProviderYieldContract(session, dialect, false);
 		});
-		it("re-renders prompt sections from the live yield contract (" + dialect + ")", async () => {
-			// The base-prompt rebuild must re-invoke the prompt closure against the
-			// live item set on every transition: install renders pooled, clearing
-			// renders ordinary. Markers are test-local; no prompt wording is pinned.
+		it("rolls back the runtime contract when the prompt refresh fails (" + dialect + ")", async () => {
+			const { session } = await createAgentSession({
+				cwd: registryDir,
+				agentDir: registryDir,
+				modelRegistry,
+				sessionManager: SessionManager.inMemory(),
+				settings: Settings.isolated({ ...toolSettings, inlineToolDescriptors: "on" }),
+				model: getBundledModel("openai", "gpt-4o-mini"),
+				disableExtensionDiscovery: true,
+				skills: [],
+				contextFiles: [],
+				promptTemplates: [],
+				slashCommands: [],
+				enableMCP: false,
+				enableLsp: false,
+				skipPythonPreflight: true,
+				requireYieldTool: true,
+				toolNames: ["yield"],
+				outputSchema: {
+					type: "object",
+					properties: { "pool#1": {} },
+					required: ["pool#1"],
+					additionalProperties: false,
+				},
+				parentTaskPrefix: "workpool-rollback",
+				agentId: "workpool-rollback",
+				agentName: "scout",
+				agentDisplayName: "scout",
+				taskDepth: 1,
+			});
+			sessions.push(session);
+			// The runtime flips before the rebuild runs; a rebuild failure must
+			// restore the previous set so gated readers never observe a
+			// half-applied pair, while the failure still surfaces to the caller
+			// and the serialization tail still settles.
+			const refresh = vi.spyOn(session, "refreshBaseSystemPrompt");
+			refresh.mockRejectedValueOnce(new Error("rebuild boom"));
+			await expect(session.setWorkPoolYieldItems([{ id: "pool#1", index: 1 }])).rejects.toThrow("rebuild boom");
+			expect(session.getWorkPoolYieldItems()).toEqual([]);
+			await session.whenWorkPoolYieldSettled();
+			await expectProviderYieldContract(session, dialect, false);
+			await session.setWorkPoolYieldItems([{ id: "pool#1", index: 1 }]);
+			await expectProviderYieldContract(session, dialect, true);
+		});
+		it("re-renders the pooled instructions from the live yield contract (" + dialect + ")", async () => {
+			// The base-prompt rebuild must re-render the real subagent completion
+			// block against the live item set on every transition: install shows the
+			// keyed workpool protocol, clearing restores the ordinary one. Markers
+			// below are the template's own contract branches, also covered by the
+			// static render test in task/workpool.test.ts.
 			// oxlint-disable-next-line prefer-const -- captured by the prompt closure before assignment
 			let live: AgentSession | undefined;
 			const { session } = await createAgentSession({
@@ -202,7 +249,20 @@ describe("SDK workpool yield schema", () => {
 				},
 				systemPrompt: base => [
 					...base,
-					`yield-contract:${live ? (live.getWorkPoolYieldItems().length > 0 ? "pooled" : "ordinary") : "boot"}`,
+					prompt.render(subagentSystemPromptTemplate, {
+						agent: "Worker",
+						context: "",
+						planReference: "",
+						planReferencePath: "",
+						worktree: "",
+						outputSchema: undefined,
+						outputSchemaOverridesAgent: false,
+						workPoolYieldItems: live?.getWorkPoolYieldItems() ?? [],
+						ircPeers: [],
+						ircParkedCount: 0,
+						ircOmittedCount: 0,
+						ircSelfId: "",
+					}),
 				],
 				parentTaskPrefix: "workpool-prompt-sync",
 				agentId: "workpool-prompt-sync",
@@ -214,10 +274,11 @@ describe("SDK workpool yield schema", () => {
 			live = session;
 			const promptText = () => session.agent.state.systemPrompt.join("\n");
 			await session.setWorkPoolYieldItems([{ id: "pool#1", index: 1 }]);
-			expect(promptText()).toContain("yield-contract:pooled");
+			expect(promptText()).toContain("{ key: <1-based number>, data: <outcome> }");
+			expect(promptText()).not.toContain("Yield protocol:");
 			await session.setWorkPoolYieldItems([]);
-			expect(promptText()).toContain("yield-contract:ordinary");
-			expect(promptText()).not.toContain("yield-contract:pooled");
+			expect(promptText()).toContain("Yield protocol:");
+			expect(promptText()).not.toContain("{ key: <1-based number>, data: <outcome> }");
 		});
 	}
 });

--- a/packages/coding-agent/test/sdk-workpool-yield-schema.test.ts
+++ b/packages/coding-agent/test/sdk-workpool-yield-schema.test.ts
@@ -204,7 +204,7 @@ describe("SDK workpool yield schema", () => {
 			});
 			sessions.push(session);
 			// The runtime flips before the rebuild runs; a rebuild failure must
-			// restore the previous set so gated readers never observe a
+			// restore the last published set so gated readers never observe a
 			// half-applied pair, while the failure still surfaces to the caller
 			// and the serialization tail still settles.
 			const refresh = vi.spyOn(session, "refreshBaseSystemPrompt");
@@ -216,58 +216,100 @@ describe("SDK workpool yield schema", () => {
 			await session.setWorkPoolYieldItems([{ id: "pool#1", index: 1 }]);
 			await expectProviderYieldContract(session, dialect, true);
 		});
-		it(
-			"republishes the restored prompt when a queued clear fails after overlapping an install (" + dialect + ")",
-			async () => {
-				const { session } = await createAgentSession({
-					cwd: registryDir,
-					agentDir: registryDir,
-					modelRegistry,
-					sessionManager: SessionManager.inMemory(),
-					settings: Settings.isolated({ ...toolSettings, inlineToolDescriptors: "on" }),
-					model: getBundledModel("openai", "gpt-4o-mini"),
-					disableExtensionDiscovery: true,
-					skills: [],
-					contextFiles: [],
-					promptTemplates: [],
-					slashCommands: [],
-					enableMCP: false,
-					enableLsp: false,
-					skipPythonPreflight: true,
-					requireYieldTool: true,
-					toolNames: ["yield"],
-					outputSchema: {
-						type: "object",
-						properties: { "pool#1": {} },
-						required: ["pool#1"],
-						additionalProperties: false,
-					},
-					parentTaskPrefix: "workpool-republish",
-					agentId: "workpool-republish",
-					agentName: "scout",
-					agentDisplayName: "scout",
-					taskDepth: 1,
-				});
-				sessions.push(session);
-				// Overlapping install then clear: the first queued refresh reads the
-				// newer (cleared) live set, so when the clear's refresh rejects, the
-				// rollback restores pooled items against ordinary bytes. The trailing
-				// republish must restore the pooled prompt too, or a same-items retry
-				// takes the equality fast path and the mismatch persists.
-				const refresh = vi.spyOn(session, "refreshBaseSystemPrompt");
-				refresh.mockResolvedValueOnce(undefined);
-				refresh.mockRejectedValueOnce(new Error("rebuild boom"));
-				const install = session.setWorkPoolYieldItems([{ id: "pool#1", index: 1 }]);
-				const clear = session.setWorkPoolYieldItems([]);
-				await install;
-				await expect(clear).rejects.toThrow("rebuild boom");
-				await session.whenWorkPoolYieldSettled();
-				expect(session.getWorkPoolYieldItems()).toEqual([{ id: "pool#1", index: 1 }]);
-				await expectProviderYieldContract(session, dialect, true);
-				await session.setWorkPoolYieldItems([{ id: "pool#1", index: 1 }]);
-				await expectProviderYieldContract(session, dialect, true);
-			},
-		);
+		it("restores the last published contract when overlapping transitions both fail (" + dialect + ")", async () => {
+			const { session } = await createAgentSession({
+				cwd: registryDir,
+				agentDir: registryDir,
+				modelRegistry,
+				sessionManager: SessionManager.inMemory(),
+				settings: Settings.isolated({ ...toolSettings, inlineToolDescriptors: "on" }),
+				model: getBundledModel("openai", "gpt-4o-mini"),
+				disableExtensionDiscovery: true,
+				skills: [],
+				contextFiles: [],
+				promptTemplates: [],
+				slashCommands: [],
+				enableMCP: false,
+				enableLsp: false,
+				skipPythonPreflight: true,
+				requireYieldTool: true,
+				toolNames: ["yield"],
+				outputSchema: {
+					type: "object",
+					properties: { "pool#1": {} },
+					required: ["pool#1"],
+					additionalProperties: false,
+				},
+				parentTaskPrefix: "workpool-double-fail",
+				agentId: "workpool-double-fail",
+				agentName: "scout",
+				agentDisplayName: "scout",
+				taskDepth: 1,
+			});
+			sessions.push(session);
+			// Both rebuilds reject: the clear's rollback must restore the last
+			// published (ordinary) contract, not the install's requested set
+			// whose caller already saw a rejection. A rejected pooled contract
+			// must never become active again.
+			const refresh = vi.spyOn(session, "refreshBaseSystemPrompt");
+			refresh.mockRejectedValueOnce(new Error("first boom"));
+			refresh.mockRejectedValueOnce(new Error("second boom"));
+			const install = session.setWorkPoolYieldItems([{ id: "pool#1", index: 1 }]);
+			const clear = session.setWorkPoolYieldItems([]);
+			await expect(install).rejects.toThrow("first boom");
+			await expect(clear).rejects.toThrow("second boom");
+			await session.whenWorkPoolYieldSettled();
+			expect(session.getWorkPoolYieldItems()).toEqual([]);
+			await expectProviderYieldContract(session, dialect, false);
+		});
+		it("converges an overlapping install and failing clear to the cleared contract (" + dialect + ")", async () => {
+			const { session } = await createAgentSession({
+				cwd: registryDir,
+				agentDir: registryDir,
+				modelRegistry,
+				sessionManager: SessionManager.inMemory(),
+				settings: Settings.isolated({ ...toolSettings, inlineToolDescriptors: "on" }),
+				model: getBundledModel("openai", "gpt-4o-mini"),
+				disableExtensionDiscovery: true,
+				skills: [],
+				contextFiles: [],
+				promptTemplates: [],
+				slashCommands: [],
+				enableMCP: false,
+				enableLsp: false,
+				skipPythonPreflight: true,
+				requireYieldTool: true,
+				toolNames: ["yield"],
+				outputSchema: {
+					type: "object",
+					properties: { "pool#1": {} },
+					required: ["pool#1"],
+					additionalProperties: false,
+				},
+				parentTaskPrefix: "workpool-republish",
+				agentId: "workpool-republish",
+				agentName: "scout",
+				agentDisplayName: "scout",
+				taskDepth: 1,
+			});
+			sessions.push(session);
+			// Overlapping install then clear: the successful refresh publishes
+			// the newer (cleared) live set, so when the clear's refresh rejects,
+			// rolling back to the last published contract keeps runtime and
+			// provider on ordinary instead of resurrecting the rejected install.
+			const refresh = vi.spyOn(session, "refreshBaseSystemPrompt");
+			refresh.mockResolvedValueOnce(undefined);
+			refresh.mockRejectedValueOnce(new Error("rebuild boom"));
+			const install = session.setWorkPoolYieldItems([{ id: "pool#1", index: 1 }]);
+			const clear = session.setWorkPoolYieldItems([]);
+			await install;
+			await expect(clear).rejects.toThrow("rebuild boom");
+			await session.whenWorkPoolYieldSettled();
+			expect(session.getWorkPoolYieldItems()).toEqual([]);
+			await expectProviderYieldContract(session, dialect, false);
+			await session.setWorkPoolYieldItems([{ id: "pool#1", index: 1 }]);
+			await expectProviderYieldContract(session, dialect, true);
+		});
 		it("re-renders the pooled instructions from the live yield contract (" + dialect + ")", async () => {
 			// The base-prompt rebuild must re-render the real subagent completion
 			// block against the live item set on every transition: install shows the

--- a/packages/coding-agent/test/sdk-workpool-yield-schema.test.ts
+++ b/packages/coding-agent/test/sdk-workpool-yield-schema.test.ts
@@ -171,5 +171,53 @@ describe("SDK workpool yield schema", () => {
 			expect(session.getWorkPoolYieldItems()).toEqual([]);
 			await expectProviderYieldContract(session, dialect, false);
 		});
+		it("re-renders prompt sections from the live yield contract (" + dialect + ")", async () => {
+			// The base-prompt rebuild must re-invoke the prompt closure against the
+			// live item set on every transition: install renders pooled, clearing
+			// renders ordinary. Markers are test-local; no prompt wording is pinned.
+			// oxlint-disable-next-line prefer-const -- captured by the prompt closure before assignment
+			let live: AgentSession | undefined;
+			const { session } = await createAgentSession({
+				cwd: registryDir,
+				agentDir: registryDir,
+				modelRegistry,
+				sessionManager: SessionManager.inMemory(),
+				settings: Settings.isolated({ ...toolSettings, inlineToolDescriptors: "on" }),
+				model: getBundledModel("openai", "gpt-4o-mini"),
+				disableExtensionDiscovery: true,
+				skills: [],
+				contextFiles: [],
+				promptTemplates: [],
+				slashCommands: [],
+				enableMCP: false,
+				enableLsp: false,
+				skipPythonPreflight: true,
+				requireYieldTool: true,
+				toolNames: ["yield"],
+				outputSchema: {
+					type: "object",
+					properties: { "pool#1": {} },
+					required: ["pool#1"],
+					additionalProperties: false,
+				},
+				systemPrompt: base => [
+					...base,
+					`yield-contract:${live ? (live.getWorkPoolYieldItems().length > 0 ? "pooled" : "ordinary") : "boot"}`,
+				],
+				parentTaskPrefix: "workpool-prompt-sync",
+				agentId: "workpool-prompt-sync",
+				agentName: "scout",
+				agentDisplayName: "scout",
+				taskDepth: 1,
+			});
+			sessions.push(session);
+			live = session;
+			const promptText = () => session.agent.state.systemPrompt.join("\n");
+			await session.setWorkPoolYieldItems([{ id: "pool#1", index: 1 }]);
+			expect(promptText()).toContain("yield-contract:pooled");
+			await session.setWorkPoolYieldItems([]);
+			expect(promptText()).toContain("yield-contract:ordinary");
+			expect(promptText()).not.toContain("yield-contract:pooled");
+		});
 	}
 });

--- a/packages/coding-agent/test/sdk-workpool-yield-schema.test.ts
+++ b/packages/coding-agent/test/sdk-workpool-yield-schema.test.ts
@@ -216,6 +216,58 @@ describe("SDK workpool yield schema", () => {
 			await session.setWorkPoolYieldItems([{ id: "pool#1", index: 1 }]);
 			await expectProviderYieldContract(session, dialect, true);
 		});
+		it(
+			"republishes the restored prompt when a queued clear fails after overlapping an install (" + dialect + ")",
+			async () => {
+				const { session } = await createAgentSession({
+					cwd: registryDir,
+					agentDir: registryDir,
+					modelRegistry,
+					sessionManager: SessionManager.inMemory(),
+					settings: Settings.isolated({ ...toolSettings, inlineToolDescriptors: "on" }),
+					model: getBundledModel("openai", "gpt-4o-mini"),
+					disableExtensionDiscovery: true,
+					skills: [],
+					contextFiles: [],
+					promptTemplates: [],
+					slashCommands: [],
+					enableMCP: false,
+					enableLsp: false,
+					skipPythonPreflight: true,
+					requireYieldTool: true,
+					toolNames: ["yield"],
+					outputSchema: {
+						type: "object",
+						properties: { "pool#1": {} },
+						required: ["pool#1"],
+						additionalProperties: false,
+					},
+					parentTaskPrefix: "workpool-republish",
+					agentId: "workpool-republish",
+					agentName: "scout",
+					agentDisplayName: "scout",
+					taskDepth: 1,
+				});
+				sessions.push(session);
+				// Overlapping install then clear: the first queued refresh reads the
+				// newer (cleared) live set, so when the clear's refresh rejects, the
+				// rollback restores pooled items against ordinary bytes. The trailing
+				// republish must restore the pooled prompt too, or a same-items retry
+				// takes the equality fast path and the mismatch persists.
+				const refresh = vi.spyOn(session, "refreshBaseSystemPrompt");
+				refresh.mockResolvedValueOnce(undefined);
+				refresh.mockRejectedValueOnce(new Error("rebuild boom"));
+				const install = session.setWorkPoolYieldItems([{ id: "pool#1", index: 1 }]);
+				const clear = session.setWorkPoolYieldItems([]);
+				await install;
+				await expect(clear).rejects.toThrow("rebuild boom");
+				await session.whenWorkPoolYieldSettled();
+				expect(session.getWorkPoolYieldItems()).toEqual([{ id: "pool#1", index: 1 }]);
+				await expectProviderYieldContract(session, dialect, true);
+				await session.setWorkPoolYieldItems([{ id: "pool#1", index: 1 }]);
+				await expectProviderYieldContract(session, dialect, true);
+			},
+		);
 		it("re-renders the pooled instructions from the live yield contract (" + dialect + ")", async () => {
 			// The base-prompt rebuild must re-render the real subagent completion
 			// block against the live item set on every transition: install shows the

--- a/packages/coding-agent/test/sdk-workpool-yield-schema.test.ts
+++ b/packages/coding-agent/test/sdk-workpool-yield-schema.test.ts
@@ -11,6 +11,47 @@ import type { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-sessi
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import { removeSyncWithRetries, Snowflake } from "@oh-my-pi/pi-utils";
 
+async function expectProviderYieldContract(
+	session: AgentSession,
+	dialect: "native" | "gemini",
+	pooled: boolean,
+): Promise<void> {
+	const providerContext = await session.agent.buildSideRequestContext([]);
+	if (dialect === "native") {
+		const providerTool = providerContext.tools?.find(candidate => candidate.name === "yield");
+		if (!providerTool) throw new Error("Missing provider yield tool");
+		const properties = Reflect.get(providerTool.parameters, "properties");
+		if (pooled) {
+			expect(Reflect.get(providerTool.parameters, "required")).toEqual(["key"]);
+			expect(properties).toHaveProperty("key");
+			expect(properties).not.toHaveProperty("type");
+		} else {
+			expect(properties).toHaveProperty("type");
+			expect(properties).not.toHaveProperty("key");
+		}
+		return;
+	}
+
+	const providerSystemPrompt = providerContext.systemPrompt;
+	if (!providerSystemPrompt) throw new Error("Missing provider system prompt");
+	const providerPrompt = providerSystemPrompt.join("\n");
+	expect(providerPrompt.match(/type yield =/g)).toHaveLength(1);
+	const yieldStart = providerPrompt.indexOf("type yield =");
+	const nextType = providerPrompt.indexOf("\ntype ", yieldStart + 1);
+	const namespaceEnd = providerPrompt.indexOf("\n\n} // namespace functions", yieldStart + 1);
+	let yieldEnd = nextType;
+	if (yieldEnd < 0 || (namespaceEnd >= 0 && namespaceEnd < yieldEnd)) yieldEnd = namespaceEnd;
+	if (yieldEnd < 0) throw new Error("Missing provider yield declaration boundary");
+	const yieldDeclaration = providerPrompt.slice(yieldStart, yieldEnd);
+	if (pooled) {
+		expect(yieldDeclaration).toContain("key: 1,");
+		expect(yieldDeclaration).not.toContain("type?:");
+	} else {
+		expect(yieldDeclaration).toContain("type?:");
+		expect(yieldDeclaration).not.toContain("key:");
+	}
+}
+
 describe("SDK workpool yield schema", () => {
 	let registryDir: string;
 	let authStorage: AuthStorage;
@@ -35,7 +76,7 @@ describe("SDK workpool yield schema", () => {
 		["native", {}],
 		["gemini", { "tools.format": "gemini" }],
 	] as const) {
-		it("switches the constructed yield tool before a pooled turn starts (" + dialect + ")", async () => {
+		it("keeps the provider yield contract synchronized through a pooled turn (" + dialect + ")", async () => {
 			const { session } = await createAgentSession({
 				cwd: registryDir,
 				agentDir: registryDir,
@@ -70,9 +111,9 @@ describe("SDK workpool yield schema", () => {
 			if (!tool) throw new Error("Missing yield tool");
 			expect(Reflect.get(tool.parameters, "properties")).toHaveProperty("type");
 			expect(Reflect.get(tool.parameters, "properties")).not.toHaveProperty("key");
+			await expectProviderYieldContract(session, dialect, false);
 
-			session.setWorkPoolYieldItems([{ id: "pool#1", index: 1 }]);
-			await session.refreshBaseSystemPrompt();
+			await session.setWorkPoolYieldItems([{ id: "pool#1", index: 1 }]);
 			expect(Reflect.get(tool.parameters, "required")).toEqual(["key"]);
 			const properties = Reflect.get(tool.parameters, "properties");
 			expect(properties).toHaveProperty("key");
@@ -80,24 +121,15 @@ describe("SDK workpool yield schema", () => {
 			const activeTool = session.agent.state.tools.find(candidate => candidate.name === "yield");
 			if (!activeTool) throw new Error("Missing active yield tool");
 			expect(Reflect.get(activeTool.parameters, "required")).toEqual(["key"]);
-			const providerContext = await session.agent.buildSideRequestContext([]);
-			if (dialect === "native") {
-				const providerTool = providerContext.tools?.find(candidate => candidate.name === "yield");
-				if (!providerTool) throw new Error("Missing provider yield tool");
-				expect(Reflect.get(providerTool.parameters, "required")).toEqual(["key"]);
-			} else {
-				const providerSystemPrompt = providerContext.systemPrompt;
-				if (!providerSystemPrompt) throw new Error("Missing provider system prompt");
-				const providerPrompt = providerSystemPrompt.join("\n");
-				expect(providerPrompt.match(/type yield =/g)).toHaveLength(1);
-				const yieldStart = providerPrompt.indexOf("type yield =");
-				const nextType = providerPrompt.indexOf("\ntype ", yieldStart + 1);
-				const yieldDeclaration = providerPrompt.slice(yieldStart, nextType < 0 ? providerPrompt.length : nextType);
-				expect(yieldDeclaration).toContain("key: 1,");
-				expect(yieldDeclaration).not.toContain("result:");
-			}
+			await expectProviderYieldContract(session, dialect, true);
 			const result = await tool.execute("yield-pool-1", { key: 1, data: { answer: 42 } });
 			expect(result.details).toMatchObject({ type: ["pool#1"], complete: true });
+
+			await session.setWorkPoolYieldItems([]);
+			const clearedProperties = Reflect.get(tool.parameters, "properties");
+			expect(clearedProperties).toHaveProperty("type");
+			expect(clearedProperties).not.toHaveProperty("key");
+			await expectProviderYieldContract(session, dialect, false);
 		});
 	}
 });

--- a/packages/coding-agent/test/task/executor-subagent-reminders.test.ts
+++ b/packages/coding-agent/test/task/executor-subagent-reminders.test.ts
@@ -206,6 +206,43 @@ describe("runSubprocess yield reminders", () => {
 		expect(createAgentSessionSpy).toHaveBeenCalledTimes(1);
 	});
 
+	it("refreshes the provider-facing prompt after installing workpool yield items", async () => {
+		const calls: string[] = [];
+		const session = createMockSession(({ emit }) => {
+			emit({
+				type: "tool_execution_end",
+				toolCallId: "tool-workpool-yield-schema",
+				toolName: "yield",
+				result: {
+					content: [{ type: "text", text: "Result submitted." }],
+					details: { status: "success", data: { ok: true } },
+				},
+				isError: false,
+			});
+		});
+		const mutableSession = session as unknown as {
+			setWorkPoolYieldItems: AgentSession["setWorkPoolYieldItems"];
+			refreshBaseSystemPrompt: AgentSession["refreshBaseSystemPrompt"];
+		};
+		mutableSession.setWorkPoolYieldItems = items => {
+			calls.push("set:" + items.map(item => item.id).join(","));
+		};
+		mutableSession.refreshBaseSystemPrompt = async () => {
+			calls.push("refresh");
+		};
+		mockCreateAgentSession(session);
+
+		const result = await runSubprocess({
+			...baseOptions,
+			id: "subagent-workpool-yield-schema",
+			workPoolYieldItems: [{ id: "pool#1", index: 1 }],
+		});
+
+		expect(result.error).toBeUndefined();
+		expect(result.exitCode).toBe(0);
+		expect(calls).toEqual(["set:pool#1", "refresh"]);
+	});
+
 	it("splices the subagent role prompt before the trailing system section", async () => {
 		let userPrompt = "";
 		const session = createMockSession(({ text, emit }) => {

--- a/packages/coding-agent/test/task/executor-subagent-reminders.test.ts
+++ b/packages/coding-agent/test/task/executor-subagent-reminders.test.ts
@@ -206,8 +206,9 @@ describe("runSubprocess yield reminders", () => {
 		expect(createAgentSessionSpy).toHaveBeenCalledTimes(1);
 	});
 
-	it("refreshes the provider-facing prompt after installing workpool yield items", async () => {
+	it("refreshes the provider-facing prompt only when workpool yield items change", async () => {
 		const calls: string[] = [];
+		let installedItems: Array<{ id: string; index: number }> = [];
 		const session = createMockSession(({ emit }) => {
 			emit({
 				type: "tool_execution_end",
@@ -221,26 +222,41 @@ describe("runSubprocess yield reminders", () => {
 			});
 		});
 		const mutableSession = session as unknown as {
+			getWorkPoolYieldItems: AgentSession["getWorkPoolYieldItems"];
 			setWorkPoolYieldItems: AgentSession["setWorkPoolYieldItems"];
 			refreshBaseSystemPrompt: AgentSession["refreshBaseSystemPrompt"];
 		};
+		mutableSession.getWorkPoolYieldItems = () => installedItems;
 		mutableSession.setWorkPoolYieldItems = items => {
-			calls.push("set:" + items.map(item => item.id).join(","));
+			installedItems = items.map(item => ({ ...item }));
+			calls.push("set:" + items.map(item => item.index + ":" + item.id).join(","));
 		};
 		mutableSession.refreshBaseSystemPrompt = async () => {
 			calls.push("refresh");
 		};
 		mockCreateAgentSession(session);
 
-		const result = await runSubprocess({
+		const first = await runSubprocess({
 			...baseOptions,
-			id: "subagent-workpool-yield-schema",
+			id: "subagent-workpool-yield-schema-first",
 			workPoolYieldItems: [{ id: "pool#1", index: 1 }],
 		});
+		const unchanged = await runSubprocess({
+			...baseOptions,
+			id: "subagent-workpool-yield-schema-unchanged",
+			workPoolYieldItems: [{ id: "pool#1", index: 1 }],
+		});
+		const changed = await runSubprocess({
+			...baseOptions,
+			id: "subagent-workpool-yield-schema-changed",
+			workPoolYieldItems: [{ id: "pool#2", index: 2 }],
+		});
 
-		expect(result.error).toBeUndefined();
-		expect(result.exitCode).toBe(0);
-		expect(calls).toEqual(["set:pool#1", "refresh"]);
+		for (const result of [first, unchanged, changed]) {
+			expect(result.error).toBeUndefined();
+			expect(result.exitCode).toBe(0);
+		}
+		expect(calls).toEqual(["set:1:pool#1", "refresh", "set:2:pool#2", "refresh"]);
 	});
 
 	it("splices the subagent role prompt before the trailing system section", async () => {

--- a/packages/coding-agent/test/task/executor-subagent-reminders.test.ts
+++ b/packages/coding-agent/test/task/executor-subagent-reminders.test.ts
@@ -206,59 +206,6 @@ describe("runSubprocess yield reminders", () => {
 		expect(createAgentSessionSpy).toHaveBeenCalledTimes(1);
 	});
 
-	it("refreshes the provider-facing prompt only when workpool yield items change", async () => {
-		const calls: string[] = [];
-		let installedItems: Array<{ id: string; index: number }> = [];
-		const session = createMockSession(({ emit }) => {
-			emit({
-				type: "tool_execution_end",
-				toolCallId: "tool-workpool-yield-schema",
-				toolName: "yield",
-				result: {
-					content: [{ type: "text", text: "Result submitted." }],
-					details: { status: "success", data: { ok: true } },
-				},
-				isError: false,
-			});
-		});
-		const mutableSession = session as unknown as {
-			getWorkPoolYieldItems: AgentSession["getWorkPoolYieldItems"];
-			setWorkPoolYieldItems: AgentSession["setWorkPoolYieldItems"];
-			refreshBaseSystemPrompt: AgentSession["refreshBaseSystemPrompt"];
-		};
-		mutableSession.getWorkPoolYieldItems = () => installedItems;
-		mutableSession.setWorkPoolYieldItems = items => {
-			installedItems = items.map(item => ({ ...item }));
-			calls.push("set:" + items.map(item => item.index + ":" + item.id).join(","));
-		};
-		mutableSession.refreshBaseSystemPrompt = async () => {
-			calls.push("refresh");
-		};
-		mockCreateAgentSession(session);
-
-		const first = await runSubprocess({
-			...baseOptions,
-			id: "subagent-workpool-yield-schema-first",
-			workPoolYieldItems: [{ id: "pool#1", index: 1 }],
-		});
-		const unchanged = await runSubprocess({
-			...baseOptions,
-			id: "subagent-workpool-yield-schema-unchanged",
-			workPoolYieldItems: [{ id: "pool#1", index: 1 }],
-		});
-		const changed = await runSubprocess({
-			...baseOptions,
-			id: "subagent-workpool-yield-schema-changed",
-			workPoolYieldItems: [{ id: "pool#2", index: 2 }],
-		});
-
-		for (const result of [first, unchanged, changed]) {
-			expect(result.error).toBeUndefined();
-			expect(result.exitCode).toBe(0);
-		}
-		expect(calls).toEqual(["set:1:pool#1", "refresh", "set:2:pool#2", "refresh"]);
-	});
-
 	it("splices the subagent role prompt before the trailing system section", async () => {
 		let userPrompt = "";
 		const session = createMockSession(({ text, emit }) => {

--- a/packages/coding-agent/test/task/executor-subagent-reminders.test.ts
+++ b/packages/coding-agent/test/task/executor-subagent-reminders.test.ts
@@ -428,12 +428,42 @@ describe("runSubprocess yield reminders", () => {
 			.mockResolvedValue(revived);
 		try {
 			const result = await runSubagentFollowUpTurn({ ...baseOptions, id: "subagent-revive", message: "batch work" });
-			expect(ensureLive).toHaveBeenCalledTimes(2);
+			expect(ensureLive).toHaveBeenCalledTimes(3);
 			expect(calls).toEqual(["setYield:stale", "setYield:revived"]);
 			expect(result.exitCode).toBe(0);
 			expect(result.output).toContain('"revived": true');
 		} finally {
 			AgentRegistry.global().unregister("subagent-revive");
+		}
+	});
+	it("fails fast when parking replaces the worker on every install", async () => {
+		const sessions = [
+			createMockSession(() => {}),
+			createMockSession(() => {}),
+			createMockSession(() => {}),
+			createMockSession(() => {}),
+		];
+		for (const session of sessions) {
+			const mutable: { setWorkPoolYieldItems: (items: unknown[]) => Promise<void> } = session as unknown as {
+				setWorkPoolYieldItems: (items: unknown[]) => Promise<void>;
+			};
+			mutable.setWorkPoolYieldItems = async () => {};
+		}
+		// A park slipping into every rebuild window replaces the worker each
+		// round trip: fail after three instead of chasing replacements forever.
+		const ensureLive = vi
+			.spyOn(AgentLifecycleManager.global(), "ensureLive")
+			.mockResolvedValueOnce(sessions[0]!)
+			.mockResolvedValueOnce(sessions[1]!)
+			.mockResolvedValueOnce(sessions[2]!)
+			.mockResolvedValue(sessions[3]!);
+		try {
+			await expect(
+				runSubagentFollowUpTurn({ ...baseOptions, id: "subagent-churn", message: "batch work" }),
+			).rejects.toThrow("was replaced during every install attempt");
+			expect(ensureLive).toHaveBeenCalledTimes(4);
+		} finally {
+			AgentRegistry.global().unregister("subagent-churn");
 		}
 	});
 	it("sends reminder prompt when subagent stops without yield", async () => {

--- a/packages/coding-agent/test/task/executor-subagent-reminders.test.ts
+++ b/packages/coding-agent/test/task/executor-subagent-reminders.test.ts
@@ -356,6 +356,40 @@ describe("runSubprocess yield reminders", () => {
 			AgentRegistry.global().unregister("subagent-prewait");
 		}
 	});
+	it("fails the follow-up instead of installing under a wedged turn", async () => {
+		const calls: string[] = [];
+		const session = createMockSession(() => {});
+		const mutable = session as unknown as {
+			isStreaming: boolean;
+			setWorkPoolYieldItems: (items: unknown[]) => Promise<void>;
+			waitForIdle: () => Promise<void>;
+		};
+		Object.defineProperty(mutable, "isStreaming", { value: true, configurable: true });
+		mutable.setWorkPoolYieldItems = async () => {
+			calls.push("setYield");
+		};
+		mutable.waitForIdle = async () => {
+			calls.push("waitForIdle");
+		};
+		AgentRegistry.global().register({
+			id: "subagent-wedged",
+			displayName: "subagent-wedged",
+			kind: "sub",
+			status: "idle",
+			session,
+		});
+		try {
+			// Three waits still streaming: installing now would corrupt the active
+			// turn, and waiting forever would hang the pool, so fail instead.
+			await expect(
+				runSubagentFollowUpTurn({ ...baseOptions, id: "subagent-wedged", message: "batch work" }),
+			).rejects.toThrow("stayed busy through 3 ownership waits");
+			expect(calls).toEqual(["waitForIdle", "waitForIdle", "waitForIdle"]);
+			expect(calls).not.toContain("setYield");
+		} finally {
+			AgentRegistry.global().unregister("subagent-wedged");
+		}
+	});
 	it("sends reminder prompt when subagent stops without yield", async () => {
 		const prompts: string[] = [];
 		const promptOptions: Array<PromptOptions | undefined> = [];

--- a/packages/coding-agent/test/task/executor-subagent-reminders.test.ts
+++ b/packages/coding-agent/test/task/executor-subagent-reminders.test.ts
@@ -6,6 +6,7 @@ import type { ExtensionActions, LoadExtensionsResult } from "@oh-my-pi/pi-coding
 import type { CreateAgentSessionResult } from "@oh-my-pi/pi-coding-agent/sdk";
 import * as sdkModule from "@oh-my-pi/pi-coding-agent/sdk";
 import { AgentRegistry } from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
+import { AgentLifecycleManager } from "@oh-my-pi/pi-coding-agent/registry/agent-lifecycle";
 import type { AgentSession, AgentSessionEvent, PromptOptions } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import type { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import {
@@ -388,6 +389,51 @@ describe("runSubprocess yield reminders", () => {
 			expect(calls).not.toContain("setYield");
 		} finally {
 			AgentRegistry.global().unregister("subagent-wedged");
+		}
+	});
+	it("drives the reacquired session when parking replaces the worker mid-install", async () => {
+		const calls: string[] = [];
+		const stale = createMockSession(() => {});
+		const revived = createMockSession(({ emit }) => {
+			emit({
+				type: "tool_execution_end",
+				toolCallId: "tool-revive",
+				toolName: "yield",
+				result: {
+					content: [{ type: "text", text: "Result submitted." }],
+					details: { status: "success", data: { revived: true } },
+				},
+				isError: false,
+			});
+		});
+		// Mock sessions lack the real yield-contract method; attach a tracker.
+		const staleMutable = stale as unknown as {
+			setWorkPoolYieldItems: (items: unknown[]) => Promise<void>;
+		};
+		staleMutable.setWorkPoolYieldItems = async () => {
+			calls.push("setYield:stale");
+		};
+		const revivedMutable = revived as unknown as {
+			setWorkPoolYieldItems: (items: unknown[]) => Promise<void>;
+		};
+		revivedMutable.setWorkPoolYieldItems = async () => {
+			calls.push("setYield:revived");
+		};
+		// The idle TTL fires during the install rebuild: the follow-up must drive
+		// the revived replacement (reinstalling its empty contract) instead of
+		// the detached corpse.
+		const ensureLive = vi
+			.spyOn(AgentLifecycleManager.global(), "ensureLive")
+			.mockResolvedValueOnce(stale)
+			.mockResolvedValue(revived);
+		try {
+			const result = await runSubagentFollowUpTurn({ ...baseOptions, id: "subagent-revive", message: "batch work" });
+			expect(ensureLive).toHaveBeenCalledTimes(2);
+			expect(calls).toEqual(["setYield:stale", "setYield:revived"]);
+			expect(result.exitCode).toBe(0);
+			expect(result.output).toContain('"revived": true');
+		} finally {
+			AgentRegistry.global().unregister("subagent-revive");
 		}
 	});
 	it("sends reminder prompt when subagent stops without yield", async () => {

--- a/packages/coding-agent/test/task/executor-subagent-reminders.test.ts
+++ b/packages/coding-agent/test/task/executor-subagent-reminders.test.ts
@@ -5,6 +5,7 @@ import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import type { ExtensionActions, LoadExtensionsResult } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/types";
 import type { CreateAgentSessionResult } from "@oh-my-pi/pi-coding-agent/sdk";
 import * as sdkModule from "@oh-my-pi/pi-coding-agent/sdk";
+import { AgentRegistry } from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
 import type { AgentSession, AgentSessionEvent, PromptOptions } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import type { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import {
@@ -243,6 +244,52 @@ describe("runSubprocess yield reminders", () => {
 		expect(systemPrompt?.[2]).not.toMatch(/CONTEXT\n=+/);
 		expect(systemPrompt?.[3]).toBe("now");
 		expect(userPrompt).not.toMatch(/CONTEXT\n=+/);
+	});
+	it("derives pooled yield instructions from the live registry session", async () => {
+		const session = createMockSession(({ emit }) => {
+			emit({
+				type: "tool_execution_end",
+				toolCallId: "tool-live-yield",
+				toolName: "yield",
+				result: {
+					content: [{ type: "text", text: "Result submitted." }],
+					details: { status: "success", data: { ok: true } },
+				},
+				isError: false,
+			});
+		});
+		const createAgentSessionSpy = mockCreateAgentSession(session);
+
+		await runSubprocess({
+			...baseOptions,
+			id: "subagent-live-yield",
+			task: "Do the task.",
+		});
+
+		const systemPromptBuilder = createAgentSessionSpy.mock.calls[0]?.[0]?.systemPrompt;
+		expect(systemPromptBuilder).toBeFunction();
+		if (typeof systemPromptBuilder !== "function") throw new Error("Expected system prompt builder");
+		// The prompt callback is re-invoked on every base-prompt refresh, so it
+		// must follow the live contract (e.g. after WorkPool clears pooled items)
+		// rather than the options captured at startup.
+		const liveItems = [{ id: "pool#1", index: 1 }];
+		AgentRegistry.global().register({
+			id: "subagent-live-yield",
+			displayName: "subagent-live-yield",
+			kind: "sub",
+			status: "idle",
+			session: { getWorkPoolYieldItems: () => liveItems } as unknown as AgentSession,
+		});
+		try {
+			const pooled = systemPromptBuilder(["system"]);
+			expect(pooled?.[0]).toContain("Workpool yield protocol:");
+			liveItems.length = 0;
+			const cleared = systemPromptBuilder(["system"]);
+			expect(cleared?.[0]).toContain("Yield protocol:");
+			expect(cleared?.[0]).not.toContain("Workpool yield protocol:");
+		} finally {
+			AgentRegistry.global().unregister("subagent-live-yield");
+		}
 	});
 
 	it("sends reminder prompt when subagent stops without yield", async () => {

--- a/packages/coding-agent/test/task/executor-subagent-reminders.test.ts
+++ b/packages/coding-agent/test/task/executor-subagent-reminders.test.ts
@@ -306,6 +306,56 @@ describe("runSubprocess yield reminders", () => {
 			AgentRegistry.global().unregister("subagent-race");
 		}
 	});
+	it("waits out a running turn before installing the pooled contract", async () => {
+		const calls: string[] = [];
+		let streaming = true;
+		const session = createMockSession(({ emit }) => {
+			emit({
+				type: "tool_execution_end",
+				toolCallId: "tool-batch",
+				toolName: "yield",
+				result: {
+					content: [{ type: "text", text: "Result submitted." }],
+					details: { status: "success", data: { batch: true } },
+				},
+				isError: false,
+			});
+		});
+		const mutable = session as unknown as {
+			isStreaming: boolean;
+			setWorkPoolYieldItems: (items: unknown[]) => Promise<void>;
+			waitForIdle: () => Promise<void>;
+		};
+		Object.defineProperty(mutable, "isStreaming", { get: () => streaming, configurable: true });
+		mutable.setWorkPoolYieldItems = async () => {
+			calls.push("setYield");
+		};
+		mutable.waitForIdle = async () => {
+			calls.push("waitForIdle");
+			streaming = false;
+		};
+		AgentRegistry.global().register({
+			id: "subagent-prewait",
+			displayName: "subagent-prewait",
+			kind: "sub",
+			status: "idle",
+			session,
+		});
+		try {
+			// Installing pooled items under the running ordinary wake would reject
+			// its in-flight calls, so the follow-up must observe idle first.
+			const result = await runSubagentFollowUpTurn({
+				...baseOptions,
+				id: "subagent-prewait",
+				message: "batch work",
+			});
+			expect(calls.slice(0, 2)).toEqual(["waitForIdle", "setYield"]);
+			expect(result.exitCode).toBe(0);
+			expect(result.output).toContain('"batch": true');
+		} finally {
+			AgentRegistry.global().unregister("subagent-prewait");
+		}
+	});
 	it("sends reminder prompt when subagent stops without yield", async () => {
 		const prompts: string[] = [];
 		const promptOptions: Array<PromptOptions | undefined> = [];

--- a/packages/coding-agent/test/task/executor-subagent-reminders.test.ts
+++ b/packages/coding-agent/test/task/executor-subagent-reminders.test.ts
@@ -5,10 +5,12 @@ import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import type { ExtensionActions, LoadExtensionsResult } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/types";
 import type { CreateAgentSessionResult } from "@oh-my-pi/pi-coding-agent/sdk";
 import * as sdkModule from "@oh-my-pi/pi-coding-agent/sdk";
+import { AgentRegistry } from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
 import type { AgentSession, AgentSessionEvent, PromptOptions } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import type { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import {
 	finalizeSubprocessOutput,
+	runSubagentFollowUpTurn,
 	runSubprocess,
 	SUBAGENT_WARNING_MISSING_YIELD,
 } from "@oh-my-pi/pi-coding-agent/task/executor";
@@ -243,6 +245,66 @@ describe("runSubprocess yield reminders", () => {
 		expect(systemPrompt?.[2]).not.toMatch(/CONTEXT\n=+/);
 		expect(systemPrompt?.[3]).toBe("now");
 		expect(userPrompt).not.toMatch(/CONTEXT\n=+/);
+	});
+	it("does not let an intervening wake yield satisfy the batch after a lost prompt race", async () => {
+		let prompts = 0;
+		let wakeEmitted = false;
+		let emitWake: ((event: AgentSessionEvent) => void) | undefined;
+		const session = createMockSession(({ emit }) => {
+			emitWake ??= emit;
+			prompts++;
+			// An IRC wake owns the session when the follow-up first dispatches.
+			if (prompts === 1) throw new AgentBusyError("wake turn is running");
+			emit({
+				type: "tool_execution_end",
+				toolCallId: "tool-batch",
+				toolName: "yield",
+				result: {
+					content: [{ type: "text", text: "Result submitted." }],
+					details: { status: "success", data: { batch: true } },
+				},
+				isError: false,
+			});
+		});
+		const mutable = session as unknown as {
+			setWorkPoolYieldItems: (items: unknown[]) => Promise<void>;
+			waitForIdle: () => Promise<void>;
+		};
+		mutable.setWorkPoolYieldItems = async () => {};
+		mutable.waitForIdle = async () => {
+			// The wake turn yields while the batch backs off. The batch monitor
+			// must be detached, so this yield neither marks the batch yielded
+			// nor leaks wake output into the batch result.
+			if (!wakeEmitted) {
+				wakeEmitted = true;
+				emitWake?.({
+					type: "tool_execution_end",
+					toolCallId: "tool-wake",
+					toolName: "yield",
+					result: {
+						content: [{ type: "text", text: "Wake done." }],
+						details: { status: "success", data: { intruder: true } },
+					},
+					isError: false,
+				});
+			}
+		};
+		AgentRegistry.global().register({
+			id: "subagent-race",
+			displayName: "subagent-race",
+			kind: "sub",
+			status: "idle",
+			session,
+		});
+		try {
+			const result = await runSubagentFollowUpTurn({ ...baseOptions, id: "subagent-race", message: "batch work" });
+			expect(prompts).toBe(2);
+			expect(result.exitCode).toBe(0);
+			expect(result.output).toContain('"batch": true');
+			expect(result.output).not.toContain("intruder");
+		} finally {
+			AgentRegistry.global().unregister("subagent-race");
+		}
 	});
 	it("sends reminder prompt when subagent stops without yield", async () => {
 		const prompts: string[] = [];

--- a/packages/coding-agent/test/task/executor-subagent-reminders.test.ts
+++ b/packages/coding-agent/test/task/executor-subagent-reminders.test.ts
@@ -466,6 +466,62 @@ describe("runSubprocess yield reminders", () => {
 			AgentRegistry.global().unregister("subagent-churn");
 		}
 	});
+	it("waits out a wake running on the replacement worker before reinstalling", async () => {
+		const calls: string[] = [];
+		let revivedStreaming = true;
+		const stale = createMockSession(() => {});
+		const revived = createMockSession(({ emit }) => {
+			emit({
+				type: "tool_execution_end",
+				toolCallId: "tool-revive-wake",
+				toolName: "yield",
+				result: {
+					content: [{ type: "text", text: "Result submitted." }],
+					details: { status: "success", data: { revived: true } },
+				},
+				isError: false,
+			});
+		});
+		// Mock sessions lack the real session surface; attach trackers.
+		const staleMutable = stale as unknown as {
+			setWorkPoolYieldItems: (items: unknown[]) => Promise<void>;
+		};
+		staleMutable.setWorkPoolYieldItems = async () => {
+			calls.push("setYield:stale");
+		};
+		const revivedMutable = revived as unknown as {
+			isStreaming: boolean;
+			setWorkPoolYieldItems: (items: unknown[]) => Promise<void>;
+			waitForIdle: () => Promise<void>;
+		};
+		Object.defineProperty(revivedMutable, "isStreaming", { get: () => revivedStreaming, configurable: true });
+		revivedMutable.setWorkPoolYieldItems = async () => {
+			calls.push("setYield:revived");
+		};
+		revivedMutable.waitForIdle = async () => {
+			calls.push("waitForIdle:revived");
+			revivedStreaming = false;
+		};
+		// Parking swaps the worker mid-install while an IRC delivery revives the
+		// replacement straight into an ordinary wake: the follow-up must wait out
+		// that wake before installing the keyed contract, not reject its yield.
+		const ensureLive = vi
+			.spyOn(AgentLifecycleManager.global(), "ensureLive")
+			.mockResolvedValueOnce(stale)
+			.mockResolvedValue(revived);
+		try {
+			const result = await runSubagentFollowUpTurn({
+				...baseOptions,
+				id: "subagent-revive-wake",
+				message: "batch work",
+			});
+			expect(calls).toEqual(["setYield:stale", "waitForIdle:revived", "setYield:revived"]);
+			expect(result.exitCode).toBe(0);
+			expect(result.output).toContain('"revived": true');
+		} finally {
+			AgentRegistry.global().unregister("subagent-revive-wake");
+		}
+	});
 	it("sends reminder prompt when subagent stops without yield", async () => {
 		const prompts: string[] = [];
 		const promptOptions: Array<PromptOptions | undefined> = [];

--- a/packages/coding-agent/test/task/executor-subagent-reminders.test.ts
+++ b/packages/coding-agent/test/task/executor-subagent-reminders.test.ts
@@ -5,7 +5,6 @@ import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import type { ExtensionActions, LoadExtensionsResult } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/types";
 import type { CreateAgentSessionResult } from "@oh-my-pi/pi-coding-agent/sdk";
 import * as sdkModule from "@oh-my-pi/pi-coding-agent/sdk";
-import { AgentRegistry } from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
 import type { AgentSession, AgentSessionEvent, PromptOptions } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import type { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import {
@@ -245,53 +244,6 @@ describe("runSubprocess yield reminders", () => {
 		expect(systemPrompt?.[3]).toBe("now");
 		expect(userPrompt).not.toMatch(/CONTEXT\n=+/);
 	});
-	it("derives pooled yield instructions from the live registry session", async () => {
-		const session = createMockSession(({ emit }) => {
-			emit({
-				type: "tool_execution_end",
-				toolCallId: "tool-live-yield",
-				toolName: "yield",
-				result: {
-					content: [{ type: "text", text: "Result submitted." }],
-					details: { status: "success", data: { ok: true } },
-				},
-				isError: false,
-			});
-		});
-		const createAgentSessionSpy = mockCreateAgentSession(session);
-
-		await runSubprocess({
-			...baseOptions,
-			id: "subagent-live-yield",
-			task: "Do the task.",
-		});
-
-		const systemPromptBuilder = createAgentSessionSpy.mock.calls[0]?.[0]?.systemPrompt;
-		expect(systemPromptBuilder).toBeFunction();
-		if (typeof systemPromptBuilder !== "function") throw new Error("Expected system prompt builder");
-		// The prompt callback is re-invoked on every base-prompt refresh, so it
-		// must follow the live contract (e.g. after WorkPool clears pooled items)
-		// rather than the options captured at startup.
-		const liveItems = [{ id: "pool#1", index: 1 }];
-		AgentRegistry.global().register({
-			id: "subagent-live-yield",
-			displayName: "subagent-live-yield",
-			kind: "sub",
-			status: "idle",
-			session: { getWorkPoolYieldItems: () => liveItems } as unknown as AgentSession,
-		});
-		try {
-			const pooled = systemPromptBuilder(["system"]);
-			expect(pooled?.[0]).toContain("Workpool yield protocol:");
-			liveItems.length = 0;
-			const cleared = systemPromptBuilder(["system"]);
-			expect(cleared?.[0]).toContain("Yield protocol:");
-			expect(cleared?.[0]).not.toContain("Workpool yield protocol:");
-		} finally {
-			AgentRegistry.global().unregister("subagent-live-yield");
-		}
-	});
-
 	it("sends reminder prompt when subagent stops without yield", async () => {
 		const prompts: string[] = [];
 		const promptOptions: Array<PromptOptions | undefined> = [];

--- a/packages/coding-agent/test/task/workpool.test.ts
+++ b/packages/coding-agent/test/task/workpool.test.ts
@@ -3,6 +3,7 @@ import { AsyncJobManager } from "../../src/async";
 import { Settings } from "../../src/config/settings";
 import subagentSystemPrompt from "../../src/prompts/system/subagent-system-prompt.md" with { type: "text" };
 import { AgentRegistry } from "../../src/registry/agent-registry";
+import { AgentLifecycleManager } from "../../src/registry/agent-lifecycle";
 import type { AgentSession } from "../../src/session/agent-session";
 import { HubTool } from "../../src/tools/hub";
 import type { CustomMessage } from "../../src/session/messages";
@@ -141,6 +142,9 @@ afterEach(async () => {
 	managers.clear();
 	vi.restoreAllMocks();
 	AgentRegistry.resetGlobalForTests();
+	// The global lifecycle binds its registry at construction; drop it with the
+	// registry so release() in later tests manages the current instance.
+	AgentLifecycleManager.resetGlobalForTests();
 	WorkPoolRegistry.resetForTests();
 });
 
@@ -215,6 +219,41 @@ describe("WorkPool dispatch", () => {
 		expect(followSpy.mock.calls[0]?.[0].message).not.toContain("todo");
 		follow.resolve();
 		await finishPool(session, workpool);
+	});
+	it("releases the worker session when clearing the yield contract fails", async () => {
+		const session = makeSession([], 1);
+		let workerId = "";
+		let disposed = false;
+		vi.spyOn(structured, "runStructuredSubagent").mockImplementation(async request => {
+			workerId = request.identity?.id ?? "missing";
+			// Retained worker whose prompt rebuild throws after the runtime
+			// contract already flipped: pool-local drop alone would leave it
+			// messageable with a stale keyed declaration.
+			AgentRegistry.global().register({
+				id: workerId,
+				displayName: workerId,
+				kind: "sub",
+				status: "idle",
+				session: {
+					setWorkPoolYieldItems: async () => {
+						throw new Error("prompt rebuild boom");
+					},
+					dispose: async () => {
+						disposed = true;
+					},
+				} as unknown as AgentSession,
+			});
+			return execution(workerId);
+		});
+		const workpool = pool(session, "poison");
+		workpool.push(["one"]);
+		await finishPool(session, workpool);
+		// The successful turn result survives the cleanup failure, but the
+		// poisoned worker is gone locally and unmessageable via the registry.
+		expect(workpool.batches[0]?.status).toBe("completed");
+		expect(workpool.agents.length).toBe(0);
+		expect(disposed).toBe(true);
+		expect(AgentRegistry.global().get(workerId)).toBeUndefined();
 	});
 
 	it("requeues a dead agent's queued items onto another worker", async () => {

--- a/packages/coding-agent/test/task/workpool.test.ts
+++ b/packages/coding-agent/test/task/workpool.test.ts
@@ -220,7 +220,7 @@ describe("WorkPool dispatch", () => {
 		follow.resolve();
 		await finishPool(session, workpool);
 	});
-	it("releases the worker session when clearing the yield contract fails", async () => {
+	it("tombstones the worker session when clearing the yield contract fails", async () => {
 		const session = makeSession([], 1);
 		let workerId = "";
 		let disposed = false;
@@ -249,11 +249,13 @@ describe("WorkPool dispatch", () => {
 		workpool.push(["one"]);
 		await finishPool(session, workpool);
 		// The successful turn result survives the cleanup failure, but the
-		// poisoned worker is gone locally and unmessageable via the registry.
+		// poisoned worker is gone locally and left terminal in the registry: a
+		// later persisted-agent scan must not resurrect it as parked.
 		expect(workpool.batches[0]?.status).toBe("completed");
 		expect(workpool.agents.length).toBe(0);
 		expect(disposed).toBe(true);
-		expect(AgentRegistry.global().get(workerId)).toBeUndefined();
+		expect(AgentRegistry.global().get(workerId)?.status).toBe("aborted");
+		expect(AgentRegistry.global().get(workerId)?.session).toBeNull();
 	});
 
 	it("requeues a dead agent's queued items onto another worker", async () => {

--- a/packages/coding-agent/test/tools/irc.test.ts
+++ b/packages/coding-agent/test/tools/irc.test.ts
@@ -1266,8 +1266,8 @@ describe("IRC", () => {
 				observations++;
 			});
 			await session.setWorkPoolYieldItems([{ id: "pool#1", index: 1 }]);
-			const queueAside = vi.spyOn(IrcBridge.prototype, "queueAside");
-			queueAside.mockClear();
+			const queueDeferredWake = vi.spyOn(IrcBridge.prototype, "queueDeferredWake");
+			queueDeferredWake.mockClear();
 			const outcome = await session.deliverIrcMessage({
 				id: "msg-pooled",
 				from: "0-Peer",
@@ -1281,30 +1281,30 @@ describe("IRC", () => {
 			// another turn's items, so no turn starts while the contract is pooled.
 			expect(promptSpy).not.toHaveBeenCalled();
 			// The deferral must not re-arm itself through the idle drain: the
-			// records stay pending until the contract clears instead of chaining
+			// records stay parked until the contract clears instead of chaining
 			// wake observers indefinitely.
 			// Yield the event loop repeatedly: a re-armed chain would schedule more
-			// queueAside calls per turn of the loop, while fixed code schedules
+			// parking calls per turn of the loop, while fixed code schedules
+			// nothing further, so extra yields cannot flake this assertion.
 			for (let i = 0; i < 20; i++) {
 				const { promise, resolve } = Promise.withResolvers<void>();
 				setImmediate(resolve);
 				await promise;
 			}
-			expect(queueAside).toHaveBeenCalledTimes(1);
+			expect(queueDeferredWake).toHaveBeenCalledTimes(1);
 			// No turn ran, so the wake observer must never have attached: otherwise
 			// it would finalize the next turn's output as this wake's reply.
 			expect(observations).toBe(0);
+			// Clearing publishes the ordinary contract; the resume drain must turn
+			// the parked record into a monitored wake with no later message.
+			promptSpy.mockClear();
 			await session.setWorkPoolYieldItems([]);
-			await session.deliverIrcMessage({
-				id: "msg-clear",
-				from: "0-Peer",
-				to: "0-Me",
-				body: "status?",
-				ts: Date.now(),
-			});
 			for (let i = 0; i < 10; i++) await Promise.resolve();
-			// Liveness: the worker still wakes once the contract is ordinary (the
-			// deferred record may additionally resume as its own turn).
+			for (let i = 0; i < 20; i++) {
+				const { promise, resolve } = Promise.withResolvers<void>();
+				setImmediate(resolve);
+				await promise;
+			}
 			expect(promptSpy).toHaveBeenCalled();
 		});
 

--- a/packages/coding-agent/test/tools/irc.test.ts
+++ b/packages/coding-agent/test/tools/irc.test.ts
@@ -1255,6 +1255,37 @@ describe("IRC", () => {
 			const event = await ircEvent;
 			expect(event.type).toBe("irc_message");
 		});
+		it("defers an idle wake while a pooled yield contract is installed", async () => {
+			const { session } = createRealSession();
+			sessions.push(session);
+			vi.spyOn(session, "refreshBaseSystemPrompt").mockResolvedValue(undefined);
+			const promptSpy = vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined);
+			await session.setWorkPoolYieldItems([{ id: "pool#1", index: 1 }]);
+			const outcome = await session.deliverIrcMessage({
+				id: "msg-pooled",
+				from: "0-Peer",
+				to: "0-Me",
+				body: "status?",
+				ts: Date.now(),
+			});
+			expect(outcome).toBe("woken");
+			for (let i = 0; i < 10; i++) await Promise.resolve();
+			// An ordinary wake under pooled items would emit keyed yields against
+			// another turn's items, so no turn starts while the contract is pooled.
+			expect(promptSpy).not.toHaveBeenCalled();
+			await session.setWorkPoolYieldItems([]);
+			await session.deliverIrcMessage({
+				id: "msg-clear",
+				from: "0-Peer",
+				to: "0-Me",
+				body: "status?",
+				ts: Date.now(),
+			});
+			for (let i = 0; i < 10; i++) await Promise.resolve();
+			// Liveness: the worker still wakes once the contract is ordinary (the
+			// deferred record may additionally resume as its own turn).
+			expect(promptSpy).toHaveBeenCalled();
+		});
 
 		it("queues peer IRC as an interrupt while a turn is streaming", async () => {
 			const { session } = createRealSession();

--- a/packages/coding-agent/test/tools/irc.test.ts
+++ b/packages/coding-agent/test/tools/irc.test.ts
@@ -1261,6 +1261,10 @@ describe("IRC", () => {
 			sessions.push(session);
 			vi.spyOn(session, "refreshBaseSystemPrompt").mockResolvedValue(undefined);
 			const promptSpy = vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined);
+			let observations = 0;
+			session.setIrcWakeTurnObserver(() => () => {
+				observations++;
+			});
 			await session.setWorkPoolYieldItems([{ id: "pool#1", index: 1 }]);
 			const queueAside = vi.spyOn(IrcBridge.prototype, "queueAside");
 			queueAside.mockClear();
@@ -1281,9 +1285,15 @@ describe("IRC", () => {
 			// wake observers indefinitely.
 			// Yield the event loop repeatedly: a re-armed chain would schedule more
 			// queueAside calls per turn of the loop, while fixed code schedules
-			// nothing further, so extra yields cannot flake this assertion.
-			for (let i = 0; i < 20; i++) await new Promise<void>(resolve => setImmediate(resolve));
+			for (let i = 0; i < 20; i++) {
+				const { promise, resolve } = Promise.withResolvers<void>();
+				setImmediate(resolve);
+				await promise;
+			}
 			expect(queueAside).toHaveBeenCalledTimes(1);
+			// No turn ran, so the wake observer must never have attached: otherwise
+			// it would finalize the next turn's output as this wake's reply.
+			expect(observations).toBe(0);
 			await session.setWorkPoolYieldItems([]);
 			await session.deliverIrcMessage({
 				id: "msg-clear",

--- a/packages/coding-agent/test/tools/irc.test.ts
+++ b/packages/coding-agent/test/tools/irc.test.ts
@@ -9,6 +9,7 @@ import { IrcBus, type IrcMessage } from "@oh-my-pi/pi-coding-agent/irc/bus";
 import { AgentLifecycleManager } from "@oh-my-pi/pi-coding-agent/registry/agent-lifecycle";
 import { AgentRegistry } from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
 import { AgentSession, type AgentSessionEvent } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { IrcBridge } from "@oh-my-pi/pi-coding-agent/session/irc-bridge";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import type { CustomMessage } from "@oh-my-pi/pi-coding-agent/session/messages";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
@@ -1261,6 +1262,8 @@ describe("IRC", () => {
 			vi.spyOn(session, "refreshBaseSystemPrompt").mockResolvedValue(undefined);
 			const promptSpy = vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined);
 			await session.setWorkPoolYieldItems([{ id: "pool#1", index: 1 }]);
+			const queueAside = vi.spyOn(IrcBridge.prototype, "queueAside");
+			queueAside.mockClear();
 			const outcome = await session.deliverIrcMessage({
 				id: "msg-pooled",
 				from: "0-Peer",
@@ -1273,6 +1276,14 @@ describe("IRC", () => {
 			// An ordinary wake under pooled items would emit keyed yields against
 			// another turn's items, so no turn starts while the contract is pooled.
 			expect(promptSpy).not.toHaveBeenCalled();
+			// The deferral must not re-arm itself through the idle drain: the
+			// records stay pending until the contract clears instead of chaining
+			// wake observers indefinitely.
+			// Yield the event loop repeatedly: a re-armed chain would schedule more
+			// queueAside calls per turn of the loop, while fixed code schedules
+			// nothing further, so extra yields cannot flake this assertion.
+			for (let i = 0; i < 20; i++) await new Promise<void>(resolve => setImmediate(resolve));
+			expect(queueAside).toHaveBeenCalledTimes(1);
 			await session.setWorkPoolYieldItems([]);
 			await session.deliverIrcMessage({
 				id: "msg-clear",


### PR DESCRIPTION
## Problem

WorkPool changes the active `yield` contract after session initialization. Gemini-formatted tool declarations are cached in the base system prompt, so changing only the runtime items leaves the provider-facing declaration stale. This affects both installation of pooled items and clearing them after a turn: a retained worker waking later can otherwise see a keyed declaration while its runtime expects the ordinary contract.

This is separate from the construction-time crash fixed by #10755.

## Change

- Make `AgentSession.setWorkPoolYieldItems()` own the item-set comparison, mutation, and provider-prompt refresh. It now returns `Promise<void>`.
- Skip mutation and refresh when item IDs and indexes are unchanged, including empty-to-empty non-pooled follow-ups.
- Await the setter in startup, follow-up, and WorkPool completion paths; the SDK tool-session bridge forwards the promise.
- Await clearing before retained-worker pool reuse.
- Replace mock call-order coverage with real native/Gemini provider-context assertions for ordinary → pooled → ordinary declarations.

## Verification

Rebased onto upstream `949c78f936cfe112c4d7c08751adcf3865425609`. The new SDK regression reproduced the stale Gemini declaration before the fix (`1 pass, 1 fail`) and passes afterward. Focused SDK/WorkPool/executor suites pass `34/34` with `159` expectations across three files; the coding-agent check passes.

The tests inspect the actual provider-facing tool schemas and generated inline declaration, rather than mocked method-call order.
