### PR TITLE
fix(catalog): correct Bedrock Fable 5.1 effort levels

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Amazon Bedrock Claude Fable 5.1 effort metadata to expose `xhigh` and `max` instead of the unsupported `minimal` level. ([#10788](https://github.com/can1357/oh-my-pi/pull/10788) by [@voonfoo](https://github.com/voonfoo))
+
 ## [18.1.9] - 2026-09-04
 
 ### Added

--- a/packages/catalog/src/compat/rules.json
+++ b/packages/catalog/src/compat/rules.json
@@ -7065,6 +7065,33 @@
 				"providers": [
 					"amazon-bedrock"
 				],
+				"family": "fable",
+				"revision": [
+					{
+						"op": ">=",
+						"revision": "5.1.0"
+					},
+					{
+						"op": "<",
+						"revision": "5.2.0"
+					}
+				],
+				"thinking": {
+					"efforts": [
+						"low",
+						"medium",
+						"high",
+						"xhigh",
+						"max"
+					]
+				}
+			},
+			{
+				"source": "providers/amazon-bedrock.kdl:11",
+				"class": "anthropic",
+				"providers": [
+					"amazon-bedrock"
+				],
 				"family": "opus",
 				"revision": [
 					{
@@ -7081,7 +7108,7 @@
 				}
 			},
 			{
-				"source": "providers/amazon-bedrock.kdl:10",
+				"source": "providers/amazon-bedrock.kdl:15",
 				"class": "anthropic",
 				"providers": [
 					"amazon-bedrock"
@@ -7109,7 +7136,7 @@
 				}
 			},
 			{
-				"source": "providers/amazon-bedrock.kdl:16",
+				"source": "providers/amazon-bedrock.kdl:21",
 				"class": "openai",
 				"providers": [
 					"amazon-bedrock"
@@ -7119,7 +7146,7 @@
 				}
 			},
 			{
-				"source": "providers/amazon-bedrock.kdl:19",
+				"source": "providers/amazon-bedrock.kdl:24",
 				"class": "deepseek",
 				"providers": [
 					"amazon-bedrock"
@@ -7137,7 +7164,7 @@
 				}
 			},
 			{
-				"source": "providers/amazon-bedrock.kdl:24",
+				"source": "providers/amazon-bedrock.kdl:29",
 				"class": "minimax",
 				"providers": [
 					"amazon-bedrock"
@@ -7148,7 +7175,7 @@
 				}
 			},
 			{
-				"source": "providers/amazon-bedrock.kdl:28",
+				"source": "providers/amazon-bedrock.kdl:33",
 				"class": "unknown",
 				"providers": [
 					"amazon-bedrock"
@@ -7164,7 +7191,7 @@
 				}
 			},
 			{
-				"source": "providers/amazon-bedrock.kdl:33",
+				"source": "providers/amazon-bedrock.kdl:38",
 				"providers": [
 					"amazon-bedrock"
 				],

--- a/packages/catalog/src/compat/rules/providers/amazon-bedrock.kdl
+++ b/packages/catalog/src/compat/rules/providers/amazon-bedrock.kdl
@@ -2,6 +2,11 @@
 
 provider "amazon-bedrock" {
 	class "anthropic" {
+		family "fable" {
+			revision ">=5.1 <5.2" {
+				thinking-efforts "low" "medium" "high" "xhigh" "max"
+			}
+		}
 		family "opus" {
 			revision ">=4.6 <4.7" {
 				thinking-mode "anthropic-adaptive"

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -32679,10 +32679,11 @@
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
-					"high"
+					"high",
+					"xhigh",
+					"max"
 				],
 				"supportsDisplay": true,
 				"prefixBinding": true
@@ -33344,10 +33345,11 @@
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
-					"high"
+					"high",
+					"xhigh",
+					"max"
 				],
 				"supportsDisplay": true,
 				"prefixBinding": true
@@ -35571,10 +35573,11 @@
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
-					"high"
+					"high",
+					"xhigh",
+					"max"
 				],
 				"supportsDisplay": true,
 				"prefixBinding": true
@@ -36277,10 +36280,11 @@
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
-					"high"
+					"high",
+					"xhigh",
+					"max"
 				],
 				"supportsDisplay": true,
 				"prefixBinding": true

--- a/packages/catalog/test/model-thinking.test.ts
+++ b/packages/catalog/test/model-thinking.test.ts
@@ -779,6 +779,36 @@ describe("model thinking derivation", () => {
 		expect(direct.compat.supportsTurnScopedSystem).toBe(true);
 	});
 
+	it("uses Bedrock Fable 5.1's five supported effort levels", () => {
+		const ids = [
+			"global.anthropic.claude-fable-5-1",
+			"eu.anthropic.claude-fable-5-1",
+			"us.anthropic.claude-fable-5-1",
+			"us-gov.anthropic.claude-fable-5-1",
+		];
+
+		for (const id of ids) {
+			const model = createModel({
+				id,
+				api: "bedrock-converse-stream",
+				provider: "amazon-bedrock",
+			});
+
+			expect(getSupportedEfforts(model)).toEqual([Effort.Low, Effort.Medium, Effort.High, Effort.XHigh, Effort.Max]);
+			expect(() => mapEffortToAnthropicAdaptiveEffort(model, Effort.Minimal)).toThrow(/not supported/);
+			expect(mapEffortToAnthropicAdaptiveEffort(model, Effort.XHigh)).toBe("xhigh");
+			expect(mapEffortToAnthropicAdaptiveEffort(model, Effort.Max)).toBe("max");
+		}
+
+		const previousRevision = createModel({
+			id: "global.anthropic.claude-fable-5",
+			api: "bedrock-converse-stream",
+			provider: "amazon-bedrock",
+		});
+		expect(getSupportedEfforts(previousRevision)).toEqual([Effort.Low, Effort.Medium, Effort.High, Effort.Max]);
+		expect(() => mapEffortToAnthropicAdaptiveEffort(previousRevision, Effort.XHigh)).toThrow(/not supported/);
+	});
+
 	it("does not advertise mid-conversation system messages on Claude Sonnet 5", () => {
 		const sonnet5 = createModel({
 			id: "claude-sonnet-5",


### PR DESCRIPTION
## What

Corrects Amazon Bedrock Claude Fable 5.1 effort metadata from `minimal, low, medium, high` to the wire-supported `low, medium, high, xhigh, max` ladder across the global, EU, US, and GovCloud inference-profile IDs.

The provider rule, compiled compatibility data, and bundled model catalog are updated together. The resolver regression covers all four Fable 5.1 profile prefixes and keeps Fable 5 on its existing four-tier ladder.

## Why

Bedrock validates `output_config.effort` model-side. Live Converse requests accepted `low`, `medium`, `high`, `xhigh`, and `max`, while `minimal` was rejected with that exact accepted enum. OMP fell back to `minimal..high` for revision 5.1, so it advertised an invalid tier and silently clamped `xhigh` and `max` selections to `high`.

The fix is scoped to `amazon-bedrock` + Anthropic Fable + revision `>=5.1 <5.2`; other Claude families and Fable 5 are unchanged.

## Testing

- Regression before the fix: expected `low, medium, high, xhigh, max`; received `minimal, low, medium, high`.
- Focused Fable 5.1 resolver test: 1 pass, including `minimal` rejection, `xhigh`/`max` wire mappings, and the Fable 5 boundary.
- Adjacent catalog, generated-policy, parity, and Bedrock tests: 85 pass / 0 fail.
- `bun run check:ts`: clean across all workspaces.
- Live AWS Bedrock calls through the rebuilt binary completed at both `--thinking=xhigh` and `--thinking=max`.
- Full catalog sweep on Windows: 870 pass / 2 fail. The two `issue-8867-repro.test.ts` SQLite quarantine assertions fail identically on clean `upstream/main`.

---

- [x] `bun check` passes (TS side; no Rust changes)
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)