### PR TITLE
fix(compaction): preserve codex v2 cache prefix

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Codex V2 remote compaction rebuilding the request prefix differently from normal turns, restoring prompt-cache reuse ([#10786](https://github.com/can1357/oh-my-pi/issues/10786)).
+
 ## [18.1.6] - 2026-09-03
 
 ### Added

--- a/packages/agent/src/compaction/compaction-v2-streaming.ts
+++ b/packages/agent/src/compaction/compaction-v2-streaming.ts
@@ -347,6 +347,9 @@ async function attemptCompactionV2Streaming(
 		store: false,
 		stream: true,
 	};
+	if (options.codexMetadata) {
+		body.client_metadata = options.codexMetadata.clientMetadata;
+	}
 
 	if (shouldUseCodexProviderTransport(model)) {
 		const eventStream = await openCodexCompactionEventStream(model, body, {

--- a/packages/agent/src/compaction/compaction-v2-streaming.ts
+++ b/packages/agent/src/compaction/compaction-v2-streaming.ts
@@ -71,15 +71,11 @@ export interface CompactionV2Usage {
 	reasoningOutputTokens?: number;
 }
 
-/** Request body fields needed for Responses-stream V2 compaction. */
+/** Provider-ready Responses body and local state needed for V2 compaction. */
 export interface CompactionV2Request {
-	model: string;
+	body: OpenAICodexCompactionBody;
 	input: unknown[];
-	instructions: string;
 	retainedMessageBudget: number;
-	tools?: unknown[];
-	/** Responses reasoning param (effort + summary), matching a normal turn; omitted for non-reasoning models. */
-	reasoning?: { effort: string; summary: string };
 	sessionId?: string;
 	promptCacheKey?: string;
 }
@@ -205,13 +201,44 @@ export function buildCompactionV2Request(
 		retainedMessageBudget?: number;
 	},
 ): CompactionV2Request {
-	return {
+	const cacheOptions = { sessionId: options?.sessionId, promptCacheKey: options?.promptCacheKey };
+	const promptCacheKey = getOpenAIPromptCacheKey(cacheOptions);
+	const body: OpenAICodexCompactionBody = {
 		model: resolveCompactionV2Model(model),
 		input,
 		instructions,
+		stream: true,
+		store: false,
+		...(options?.reasoning || model.useResponsesLite
+			? {
+					reasoning: model.useResponsesLite ? { ...options?.reasoning, context: "all_turns" } : options?.reasoning,
+					include: ["reasoning.encrypted_content"],
+				}
+			: {}),
+		...(promptCacheKey ? { prompt_cache_key: promptCacheKey } : {}),
+		...(options?.tools && options.tools.length > 0 ? { tools: options.tools, tool_choice: "auto" } : {}),
+	};
+	if (model.useResponsesLite) {
+		applyCodexResponsesLiteShape(body);
+	}
+	return buildCompactionV2RequestFromBody(model, body, options);
+}
+
+/** Wrap a body built by the normal Codex serializer for V2 compaction transport. */
+export function buildCompactionV2RequestFromBody(
+	model: Model,
+	body: OpenAICodexCompactionBody,
+	options?: {
+		sessionId?: string;
+		promptCacheKey?: string;
+		retainedMessageBudget?: number;
+	},
+): CompactionV2Request {
+	const input = Array.isArray(body.input) ? body.input : [];
+	return {
+		body: { ...body, model: resolveCompactionV2Model(model), input },
+		input,
 		retainedMessageBudget: resolveCompactionV2RetainedMessageBudget(options?.retainedMessageBudget),
-		reasoning: options?.reasoning,
-		tools: options?.tools,
 		sessionId: options?.sessionId,
 		promptCacheKey: options?.promptCacheKey,
 	};
@@ -312,35 +339,14 @@ async function attemptCompactionV2Streaming(
 	},
 ): Promise<CompactionV2Response> {
 	// Faithful to Codex: append the compaction trigger as the final input item
-	// of an otherwise-normal Responses request, then stream the result. `store`
-	// stays false — compaction must never persist a server-side response object.
-	const cacheOptions = { sessionId: request.sessionId, promptCacheKey: request.promptCacheKey };
-	const promptCacheKey = getOpenAIPromptCacheKey(cacheOptions);
+	// of an otherwise-normal Responses request. `store` remains false —
+	// compaction must never persist a server-side response object.
 	const body: OpenAICodexCompactionBody = {
-		model: request.model,
+		...request.body,
 		input: [...request.input, COMPACTION_TRIGGER_ITEM],
-		instructions: request.instructions,
-		stream: true,
 		store: false,
-		...(request.reasoning || model.useResponsesLite
-			? {
-					// Lite implies gpt-5.4+, where codex-rs sends `all_turns` replay.
-					reasoning: model.useResponsesLite ? { ...request.reasoning, context: "all_turns" } : request.reasoning,
-					include: ["reasoning.encrypted_content"],
-				}
-			: {}),
-		...(promptCacheKey ? { prompt_cache_key: promptCacheKey } : {}),
-		...(request.tools && request.tools.length > 0 ? { tools: request.tools, tool_choice: "auto" } : {}),
+		stream: true,
 	};
-	if (options.codexMetadata) {
-		body.client_metadata = options.codexMetadata.clientMetadata;
-	}
-	// Responses Lite models take the same rewrite on the compaction stream:
-	// instructions/tools ride as input items (codex-rs `compact_remote_v2`
-	// builds through `build_responses_request`).
-	if (model.useResponsesLite) {
-		applyCodexResponsesLiteShape(body);
-	}
 
 	if (shouldUseCodexProviderTransport(model)) {
 		const eventStream = await openCodexCompactionEventStream(model, body, {
@@ -425,7 +431,7 @@ function buildCompactionV2Headers(
 		headers[OPENAI_HEADERS.BETA] = OPENAI_HEADER_VALUES.BETA_RESPONSES;
 		headers[OPENAI_HEADERS.ORIGINATOR] = OPENAI_HEADER_VALUES.ORIGINATOR_CODEX;
 		headers[OPENAI_HEADERS.CODEX_BETA_FEATURES] = OPENAI_HEADER_VALUES.REMOTE_COMPACTION_V2;
-		headers[OPENAI_HEADERS.ROUTING_HINT] = codexRoutingHint(request.model, undefined);
+		headers[OPENAI_HEADERS.ROUTING_HINT] = codexRoutingHint(request.body.model, undefined);
 		if (model.useResponsesLite) {
 			headers[OPENAI_HEADERS.RESPONSES_LITE] = "true";
 		}

--- a/packages/agent/src/compaction/compaction.ts
+++ b/packages/agent/src/compaction/compaction.ts
@@ -25,7 +25,12 @@ import {
 } from "@oh-my-pi/pi-ai";
 import type { Dialect } from "@oh-my-pi/pi-ai/dialect";
 import * as AIError from "@oh-my-pi/pi-ai/error";
-import { createOpenAICodexCompactionRequestContext } from "@oh-my-pi/pi-ai/providers/openai-codex-responses";
+import {
+	buildTransformedCodexRequestBody,
+	createOpenAICodexCompactionRequestContext,
+	type OpenAICodexCompactionBody,
+} from "@oh-my-pi/pi-ai/providers/openai-codex-responses";
+import type { InputItem as CodexInputItem } from "@oh-my-pi/pi-ai/providers/openai-codex/request-transformer";
 import { convertTools } from "@oh-my-pi/pi-ai/providers/openai-responses";
 import { buildResponsesInput, resolveOpenAICompatPolicy } from "@oh-my-pi/pi-ai/providers/openai-shared";
 import { stripOpenAIResponsesOutputOnlyStatusesForReplay } from "@oh-my-pi/pi-ai/utils";
@@ -39,6 +44,7 @@ import { Tokenizer } from "../tokenizer";
 import type { AgentMessage } from "../types";
 import {
 	buildCompactionV2Request,
+	buildCompactionV2RequestFromBody,
 	getCompactionV2PreserveData,
 	requestCompactionV2Streaming,
 	shouldUseCompactionV2Streaming,
@@ -660,7 +666,8 @@ export interface SummaryOptions {
 	promptOverride?: string;
 	extraContext?: string[];
 	remoteEndpoint?: string;
-	remoteInstructions?: string;
+	/** Stable system-prompt segments from the live turn, preserved for provider cache reuse. */
+	remoteSystemPrompt?: string[];
 	initiatorOverride?: MessageAttribution;
 	metadata?: Record<string, unknown>;
 	convertToLlm?: ConvertToLlm;
@@ -1433,6 +1440,19 @@ export function prepareCompaction(
 // ============================================================================
 
 const TURN_PREFIX_SUMMARIZATION_PROMPT = prompt.render(compactionTurnPrefixPrompt);
+function isCodexResponsesModel(model: Model): model is Model<"openai-codex-responses"> {
+	return model.api === "openai-codex-responses";
+}
+
+function isCodexInputItem(item: Record<string, unknown>): item is CodexInputItem & Record<string, unknown> {
+	return (
+		(item.id === undefined || item.id === null || typeof item.id === "string") &&
+		(item.type === undefined || item.type === null || typeof item.type === "string") &&
+		(item.role === undefined || typeof item.role === "string") &&
+		(item.call_id === undefined || item.call_id === null || typeof item.call_id === "string") &&
+		(item.name === undefined || typeof item.name === "string")
+	);
+}
 
 function openAiCompatSupportsImageDetailOriginal(model: Model): boolean {
 	const compat = model.compat;
@@ -1546,7 +1566,7 @@ export async function compact(
 		promptOverride: options?.promptOverride,
 		extraContext: options?.extraContext,
 		remoteEndpoint: settings.remoteEnabled === false ? undefined : settings.remoteEndpoint,
-		remoteInstructions: options?.remoteInstructions,
+		remoteSystemPrompt: options?.remoteSystemPrompt,
 		initiatorOverride: options?.initiatorOverride,
 		metadata: options?.metadata,
 		convertToLlm: options?.convertToLlm,
@@ -1598,17 +1618,62 @@ export async function compact(
 			previousRemoteCompaction?.provider === model.provider
 				? previousRemoteCompaction.replacementHistory
 				: undefined;
-		const remoteHistory = buildOpenAiResponsesCompactionInput(
-			(summaryOptions.convertToLlm ?? defaultConvertToLlm)(remoteMessages),
-			model,
-			previousReplacementHistory,
-		);
+		const messages = (summaryOptions.convertToLlm ?? defaultConvertToLlm)(remoteMessages);
+		const remoteSystemPrompt = summaryOptions.remoteSystemPrompt ?? [SUMMARIZATION_SYSTEM_PROMPT];
+		let codexBody: OpenAICodexCompactionBody | undefined;
+		let remoteHistory: Array<Record<string, unknown>>;
+		if (isCodexResponsesModel(model)) {
+			const previousCodexInput: CodexInputItem[] = [];
+			for (const item of previousReplacementHistory ?? []) {
+				if (!isCodexInputItem(item)) {
+					throw new Error("Stored Codex V2 compaction history contains an invalid input item");
+				}
+				previousCodexInput.push(item);
+			}
+			codexBody = await buildTransformedCodexRequestBody(
+				model,
+				{ systemPrompt: remoteSystemPrompt, messages, tools: summaryOptions.tools },
+				{
+					reasoning: resolveCompactionEffort(model, summaryOptions.thinkingLevel),
+					responsesLite: model.useResponsesLite,
+					sessionId: summaryOptions.sessionId,
+					promptCacheKey: summaryOptions.promptCacheKey,
+					providerSessionState: summaryOptions.providerSessionState,
+					codexCompaction: createOpenAICodexCompactionRequestContext({
+						context: summaryOptions.codexCompaction,
+						implementation: "responses_compaction_v2",
+					}),
+				},
+				undefined,
+				previousCodexInput,
+			);
+			const input = Array.isArray(codexBody.input) ? codexBody.input : [];
+			const nativeInput: Array<Record<string, unknown>> = [];
+			for (const item of input) {
+				if (!isRecord(item)) {
+					throw new Error("Codex V2 compaction input contains a non-object item");
+				}
+				nativeInput.push(item);
+			}
+			remoteHistory = stripOpenAIResponsesOutputOnlyStatusesForReplay(nativeInput);
+			codexBody.input = remoteHistory;
+		} else {
+			remoteHistory = buildOpenAiResponsesCompactionInput(messages, model, previousReplacementHistory);
+		}
 		if (remoteHistory.length > 0) {
 			try {
-				const instructions = summaryOptions.remoteInstructions ?? SUMMARIZATION_SYSTEM_PROMPT;
-				const tools = summaryOptions.tools
-					? convertTools(summaryOptions.tools, model.compat.supportsStrictMode, model)
-					: undefined;
+				const instructions = codexBody
+					? typeof codexBody.instructions === "string"
+						? codexBody.instructions
+						: ""
+					: remoteSystemPrompt.join("\n\n");
+				const tools = codexBody
+					? Array.isArray(codexBody.tools)
+						? codexBody.tools
+						: undefined
+					: summaryOptions.tools
+						? convertTools(summaryOptions.tools, model.compat.supportsStrictMode, model)
+						: undefined;
 				const trimmed = trimRemoteCompactionInputToContextWindow(
 					remoteHistory,
 					new Tokenizer(model),
@@ -1626,13 +1691,18 @@ export async function compact(
 						contextWindow: model.contextWindow,
 					});
 				}
-				const request = buildCompactionV2Request(model, trimmed.input, instructions, {
-					tools,
-					reasoning: buildCompactionV2Reasoning(model, summaryOptions.thinkingLevel),
+				const requestOptions = {
 					sessionId: summaryOptions.sessionId,
 					promptCacheKey: summaryOptions.promptCacheKey,
 					retainedMessageBudget: settings.v2RetainedMessageBudget,
-				});
+				};
+				const request = codexBody
+					? buildCompactionV2RequestFromBody(model, { ...codexBody, input: trimmed.input }, requestOptions)
+					: buildCompactionV2Request(model, trimmed.input, instructions, {
+							...requestOptions,
+							tools,
+							reasoning: buildCompactionV2Reasoning(model, summaryOptions.thinkingLevel),
+						});
 				const remote = await withAuth(
 					apiKey,
 					key =>
@@ -1685,7 +1755,7 @@ export async function compact(
 							model,
 							key,
 							remoteHistory,
-							summaryOptions.remoteInstructions ?? SUMMARIZATION_SYSTEM_PROMPT,
+							summaryOptions.remoteSystemPrompt?.join("\n\n") ?? SUMMARIZATION_SYSTEM_PROMPT,
 							signal,
 							{
 								fetch: summaryOptions.fetch,

--- a/packages/agent/test/remote-compaction.test.ts
+++ b/packages/agent/test/remote-compaction.test.ts
@@ -934,6 +934,7 @@ describe("requestCompactionV2Streaming", () => {
 		);
 		let betaFeaturesHeader: string | undefined;
 		let residencyHeader: string | undefined;
+		let clientMetadata: Record<string, unknown> | undefined;
 		const fetchMock: FetchImpl = async (_input, init) => {
 			if (!init?.headers || init.headers instanceof Headers || Array.isArray(init.headers)) {
 				throw new Error("Expected V2 compaction to send headers as a plain object");
@@ -942,6 +943,10 @@ describe("requestCompactionV2Streaming", () => {
 			const rawResidencyHeader = init.headers["x-openai-internal-codex-residency"];
 			betaFeaturesHeader = typeof rawBetaFeaturesHeader === "string" ? rawBetaFeaturesHeader : undefined;
 			residencyHeader = typeof rawResidencyHeader === "string" ? rawResidencyHeader : undefined;
+			const parsedBody: unknown = JSON.parse(String(init.body));
+			if (isRecord(parsedBody) && isRecord(parsedBody.client_metadata)) {
+				clientMetadata = parsedBody.client_metadata;
+			}
 			return sseResponse([
 				{
 					type: "response.output_item.done",
@@ -956,6 +961,7 @@ describe("requestCompactionV2Streaming", () => {
 
 		expect(betaFeaturesHeader).toBe("remote_compaction_v2");
 		expect(residencyHeader).toBe("us");
+		expect(clientMetadata?.["x-codex-installation-id"]).toBe(TEST_INSTALLATION_ID);
 	});
 
 	test("retries transient V2 stream failures with a fresh request attempt", async () => {

--- a/packages/agent/test/remote-compaction.test.ts
+++ b/packages/agent/test/remote-compaction.test.ts
@@ -23,7 +23,10 @@ import {
 } from "@oh-my-pi/pi-agent-core/compaction/openai";
 import * as ai from "@oh-my-pi/pi-ai";
 import * as AIError from "@oh-my-pi/pi-ai/error";
-import { getOpenAICodexTransportDetails } from "@oh-my-pi/pi-ai/providers/openai-codex-responses";
+import {
+	buildTransformedCodexRequestBody,
+	getOpenAICodexTransportDetails,
+} from "@oh-my-pi/pi-ai/providers/openai-codex-responses";
 import type {
 	AssistantMessage,
 	CodexCompactionContext,
@@ -1196,6 +1199,46 @@ describe("Responses Lite remote compaction", () => {
 			content: [{ type: "input_text", text: "compact instructions" }],
 		});
 		expect(captured?.body.input?.at(-1)).toEqual({ type: "compaction_trigger" });
+	});
+
+	test("V2 compaction preserves the normal Codex Lite input prefix", async () => {
+		const model = makeCodexLiteModel();
+		const systemPrompt = ["base instructions", "workspace instructions"];
+		const messages = [
+			{ role: "user" as const, content: "first user request", timestamp: 1 },
+			{ role: "user" as const, content: "second user request", timestamp: 2 },
+		];
+		const normalBody = await buildTransformedCodexRequestBody(
+			model,
+			{ systemPrompt, messages },
+			{ sessionId: "codex-cache-session", responsesLite: true },
+		);
+		const preparation: CompactionPreparation = {
+			firstKeptEntryId: "kept-1",
+			messagesToSummarize: [messages[0]],
+			turnPrefixMessages: [],
+			recentMessages: [messages[1]],
+			isSplitTurn: false,
+			tokensBefore: 100_000,
+			fileOps: createFileOps(),
+			settings: {
+				...DEFAULT_COMPACTION_SETTINGS,
+				remoteStreamingV2Enabled: true,
+			},
+		};
+		let captured: CapturedLiteExchange | undefined;
+		const fetchMock: FetchImpl = async (_input, init) => {
+			captured = captureStreamLite(init);
+			return sseResponse(compactionV2Events("enc-cache"));
+		};
+
+		await compact(preparation, model, CODEX_RESIDENCY_TOKEN, undefined, undefined, {
+			fetch: fetchMock,
+			remoteSystemPrompt: systemPrompt,
+			sessionId: "codex-cache-session",
+		});
+
+		expect(JSON.stringify(captured?.body.input?.slice(0, -1))).toBe(JSON.stringify(normalBody.input));
 	});
 
 	test("V2 compaction isolates its Lite WebSocket from the full Responses session", async () => {

--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -1541,10 +1541,11 @@ export async function buildTransformedCodexRequestBody(
 	context: Context,
 	options: OpenAICodexResponsesOptions | undefined,
 	promptCacheKey = getOpenAIPromptCacheKey(options),
+	inputPrefix: InputItem[] = [],
 ): Promise<RequestBody> {
 	const params: RequestBody = {
 		model: model.requestModelId ?? model.id,
-		input: convertMessages(model, context),
+		input: [...inputPrefix, ...convertMessages(model, context)],
 		stream: true,
 		prompt_cache_key: promptCacheKey,
 	};

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Codex V2 remote compaction rebuilding the request prefix differently from normal turns, restoring prompt-cache reuse ([#10786](https://github.com/can1357/oh-my-pi/issues/10786)).
+
 ## [18.1.9] - 2026-09-04
 
 ### Breaking Changes

--- a/packages/coding-agent/src/session/session-maintenance.ts
+++ b/packages/coding-agent/src/session/session-maintenance.ts
@@ -1046,7 +1046,7 @@ export class SessionMaintenance {
 						{
 							promptOverride: this.#host.obfuscateTextForProvider(compactionPrep.hookPrompt),
 							extraContext: compactionPrep.hookContext,
-							remoteInstructions: this.#host.baseSystemPrompt().join("\n\n"),
+							remoteSystemPrompt: this.#host.baseSystemPrompt(),
 							convertToLlm: messages => this.#host.convertToLlmForSideRequest(messages),
 							codexCompaction,
 						},
@@ -1407,7 +1407,7 @@ export class SessionMaintenance {
 				{
 					promptOverride: this.#host.obfuscateTextForProvider(compactionPrep.hookPrompt),
 					extraContext: compactionPrep.hookContext,
-					remoteInstructions: this.#host.baseSystemPrompt().join("\n\n"),
+					remoteSystemPrompt: this.#host.baseSystemPrompt(),
 					codexCompaction,
 					// Isolate from the live turn: remote compaction transports key
 					// sticky provider sessions by sessionId, and a speculation
@@ -3587,7 +3587,7 @@ export class SessionMaintenance {
 								{
 									promptOverride: this.#host.obfuscateTextForProvider(compactionPrep.hookPrompt),
 									extraContext: compactionPrep.hookContext,
-									remoteInstructions: this.#host.baseSystemPrompt().join("\n\n"),
+									remoteSystemPrompt: this.#host.baseSystemPrompt(),
 									metadata: this.#host.agent.metadataForProvider(candidate.provider),
 									initiatorOverride: "agent",
 									convertToLlm: messages => this.#host.convertToLlmForSideRequest(messages),

--- a/packages/coding-agent/test/compaction.test.ts
+++ b/packages/coding-agent/test/compaction.test.ts
@@ -834,7 +834,7 @@ describe("remote compaction setting", () => {
 		vi.spyOn(ai, "completeSimple").mockResolvedValue(createAssistantMessage("Short summary"));
 
 		const result = await compact(preparation, model, "test-api-key", undefined, undefined, {
-			remoteInstructions: "BASE INSTRUCTIONS",
+			remoteSystemPrompt: ["BASE INSTRUCTIONS"],
 			fetch: fetchSpy,
 		});
 		const requestBody = JSON.parse(String(fetchHandler.mock.calls[0]?.[1]?.body)) as {


### PR DESCRIPTION
## Repro
A focused wire-contract regression compared the serialized input of a normal Codex Lite turn with V2 compaction for the same two-part system prompt and conversation: `bun test packages/agent/test/remote-compaction.test.ts --filter "V2 compaction preserves the normal Codex Lite input prefix"`. Before the fix it failed because compaction emitted one joined developer item where the normal turn emitted two separate items.

## Cause
`SessionMaintenance` collapsed `baseSystemPrompt()` with `join("\n\n")`, and `compact()` in `packages/agent/src/compaction/compaction.ts` rebuilt the V2 body with the generic Responses serializer. Normal Codex requests instead use `buildTransformedCodexRequestBody()` in `packages/ai/src/providers/openai-codex-responses.ts`, so the compaction request diverged near the start of the cacheable prefix before appending `compaction_trigger`.

## Fix
- Preserve the live base-system-prompt segments through every compaction call site.
- Build Codex V2 bodies through the normal Codex serializer, including native history, prompt placement, tool serialization, reasoning shape, and Responses Lite rewriting.
- Wrap the canonical body for V2 transport and append only the terminal `compaction_trigger`.
- Add a regression asserting byte-identical normal-turn and pre-trigger compaction input.

## Verification
`bun test packages/agent/test/remote-compaction.test.ts` passed 51 tests; `bun test packages/coding-agent/test/compaction.test.ts` passed 48 tests with 1 skip; package checks passed for `packages/ai`, `packages/agent`, and `packages/coding-agent`; the pre-publish `bun check` gate also passed. Fixes #10786