### PR TITLE
fix(lsp): surface push diagnostics when pull is unsupported

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- `lsp diagnostics` now surfaces diagnostics from push-only language servers (those without pull-diagnostics support) that publish once and do not re-publish on refresh, instead of reporting `OK` ([#10787](https://github.com/can1357/oh-my-pi/issues/10787)).
+
 ## [18.1.9] - 2026-09-04
 
 ### Breaking Changes

--- a/packages/coding-agent/src/lsp/client.ts
+++ b/packages/coding-agent/src/lsp/client.ts
@@ -1223,7 +1223,7 @@ export async function ensureFileOpen(client: LspClient, filePath: string, signal
 			signal,
 		);
 
-		client.openFiles.set(uri, { version: 1, languageId });
+		client.openFiles.set(uri, { version: 1, languageId, contentHash: String(Bun.hash(content)) });
 		client.lastActivity = Date.now();
 	})();
 
@@ -1295,12 +1295,13 @@ export async function syncContent(
 				},
 				signal,
 			);
-			client.openFiles.set(uri, { version: 1, languageId });
+			client.openFiles.set(uri, { version: 1, languageId, contentHash: String(Bun.hash(content)) });
 			client.lastActivity = Date.now();
 			return;
 		}
 
 		const version = ++info.version;
+		info.contentHash = String(Bun.hash(content));
 		throwIfAborted(signal);
 		await sendNotification(
 			client,
@@ -1401,10 +1402,17 @@ export async function notifyWorkspaceWatchedFiles(
 }
 
 /**
- * Refresh a file in the LSP client.
- * Increments version, sends didChange and didSave notifications.
+ * Refresh a file in the LSP client: increment the version and send didChange +
+ * didSave. Returns whether the on-disk content differs from what the server was
+ * last sent, so callers can decide whether previously published diagnostics
+ * still describe the current content (#10787). A file that was not open (or has
+ * since vanished) is reported as changed so no stale fallback is reused.
  */
-export async function refreshFile(client: LspClient, filePath: string, signal?: AbortSignal): Promise<void> {
+export async function refreshFile(
+	client: LspClient,
+	filePath: string,
+	signal?: AbortSignal,
+): Promise<{ contentChanged: boolean }> {
 	throwIfAborted(signal);
 	const uri = fileToUri(filePath);
 	const lockKey = `${client.name}:${uri}`;
@@ -1414,6 +1422,9 @@ export async function refreshFile(client: LspClient, filePath: string, signal?: 
 		await untilAborted(signal, () => existingLock);
 	}
 
+	// Default to "changed" so the not-open and missing-file branches never let a
+	// caller reuse diagnostics for content the server did not just analyze.
+	let contentChanged = true;
 	const refreshPromise = (async () => {
 		throwIfAborted(signal);
 		// Drop cached diagnostics for this URI before asking the server to recompute.
@@ -1435,6 +1446,9 @@ export async function refreshFile(client: LspClient, filePath: string, signal?: 
 			if (isEnoent(err)) return;
 			throw err;
 		}
+		const contentHash = String(Bun.hash(content));
+		contentChanged = info.contentHash !== contentHash;
+		info.contentHash = contentHash;
 		const version = ++info.version;
 		throwIfAborted(signal);
 
@@ -1468,6 +1482,7 @@ export async function refreshFile(client: LspClient, filePath: string, signal?: 
 	} finally {
 		fileOperationLocks.delete(lockKey);
 	}
+	return { contentChanged };
 }
 
 async function waitForExit(client: LspClient, timeoutMs: number): Promise<boolean> {

--- a/packages/coding-agent/src/lsp/diagnostics.ts
+++ b/packages/coding-agent/src/lsp/diagnostics.ts
@@ -202,6 +202,14 @@ interface WaitForDiagnosticsOptions {
 	 * publish be superseded by the fresh one.
 	 */
 	settleMs?: number;
+	/**
+	 * Last-known published diagnostics for the URI, captured before the caller's
+	 * `refreshFile` dropped the cache. When a push-only server (no pull capability)
+	 * never re-publishes within the budget, this is returned instead of a false
+	 * `OK`, so servers that publish once (e.g. clice on didOpen) are not silently
+	 * dropped (#10787). A fresh publish, even empty, always supersedes it.
+	 */
+	fallbackDiagnostics?: Diagnostic[];
 }
 
 /**
@@ -244,7 +252,14 @@ export async function waitForDiagnostics(
 	uri: string,
 	options: WaitForDiagnosticsOptions = {},
 ): Promise<Diagnostic[]> {
-	const { timeoutMs = 3000, signal, minVersion, expectedDocumentVersion, settleMs = DIAGNOSTICS_SETTLE_MS } = options;
+	const {
+		timeoutMs = 3000,
+		signal,
+		minVersion,
+		expectedDocumentVersion,
+		settleMs = DIAGNOSTICS_SETTLE_MS,
+		fallbackDiagnostics,
+	} = options;
 	const deadline = Date.now() + timeoutMs;
 	let pullAttempted = false;
 	let pullResultPromise: Promise<PullDiagnosticsOutcome> | undefined;
@@ -317,6 +332,17 @@ export async function waitForDiagnostics(
 		// let it collapse into a clean empty result the caller renders as "OK".
 		if (pullFailure !== undefined) {
 			throw pullFailure instanceof Error ? pullFailure : new Error(String(pullFailure));
+		}
+		// A push-only server that never re-published within the budget leaves no
+		// fresh cache entry. Surface the last-known publish rather than a false
+		// "OK" (#10787). A fresh publish — even empty — would have been returned
+		// above and left `client.diagnostics` populated, so it supersedes this.
+		if (
+			fallbackDiagnostics !== undefined &&
+			!supportsDocumentDiagnostics(client) &&
+			client.diagnostics.get(uri) === undefined
+		) {
+			return fallbackDiagnostics;
 		}
 		return [];
 	}

--- a/packages/coding-agent/src/lsp/diagnostics.ts
+++ b/packages/coding-agent/src/lsp/diagnostics.ts
@@ -342,6 +342,10 @@ export async function waitForDiagnostics(
 			!supportsDocumentDiagnostics(client) &&
 			client.diagnostics.get(uri) === undefined
 		) {
+			// Restore the publish so later queries still snapshot it as a fallback;
+			// otherwise the fix survives only one refresh. Kept unversioned so a
+			// genuine fresh publish still supersedes it via the paths above.
+			client.diagnostics.set(uri, { diagnostics: fallbackDiagnostics, version: null });
 			return fallbackDiagnostics;
 		}
 		return [];

--- a/packages/coding-agent/src/lsp/tool.ts
+++ b/packages/coding-agent/src/lsp/tool.ts
@@ -350,6 +350,9 @@ export class LspTool implements AgentTool<typeof lspSchema, LspToolDetails, Them
 							throwIfAborted(signal);
 						}
 						const minVersion = client.diagnosticsVersion;
+						// Capture the last-known publish before refreshFile clears it, so a
+						// push-only server that will not re-publish still surfaces (#10787).
+						const lastPublished = client.diagnostics.get(uri)?.diagnostics;
 						await refreshFile(client, resolved, signal);
 						const expectedDocumentVersion = client.openFiles.get(uri)?.version;
 						// Project-aware servers (Roslyn, tsserver, …) compute pull diagnostics
@@ -366,6 +369,7 @@ export class LspTool implements AgentTool<typeof lspSchema, LspToolDetails, Them
 							signal,
 							minVersion,
 							expectedDocumentVersion,
+							fallbackDiagnostics: lastPublished,
 						});
 						allDiagnostics.push(...diagnostics);
 						succeededServers++;

--- a/packages/coding-agent/src/lsp/tool.ts
+++ b/packages/coding-agent/src/lsp/tool.ts
@@ -353,7 +353,7 @@ export class LspTool implements AgentTool<typeof lspSchema, LspToolDetails, Them
 						// Capture the last-known publish before refreshFile clears it, so a
 						// push-only server that will not re-publish still surfaces (#10787).
 						const lastPublished = client.diagnostics.get(uri)?.diagnostics;
-						await refreshFile(client, resolved, signal);
+						const { contentChanged } = await refreshFile(client, resolved, signal);
 						const expectedDocumentVersion = client.openFiles.get(uri)?.version;
 						// Project-aware servers (Roslyn, tsserver, …) compute pull diagnostics
 						// on demand; their first response routinely overruns the 3s single-file
@@ -369,7 +369,10 @@ export class LspTool implements AgentTool<typeof lspSchema, LspToolDetails, Them
 							signal,
 							minVersion,
 							expectedDocumentVersion,
-							fallbackDiagnostics: lastPublished,
+							// Only reuse the snapshot when the refresh did not change the
+							// document; otherwise it describes content the server no longer
+							// has and could report a since-fixed error indefinitely.
+							fallbackDiagnostics: contentChanged ? undefined : lastPublished,
 						});
 						allDiagnostics.push(...diagnostics);
 						succeededServers++;

--- a/packages/coding-agent/src/lsp/types.ts
+++ b/packages/coding-agent/src/lsp/types.ts
@@ -404,6 +404,12 @@ export interface LspTransport {
 export interface OpenFile {
 	version: number;
 	languageId: string;
+	/**
+	 * Hash of the content last sent to the server (didOpen/didChange). Lets a
+	 * refresh detect out-of-band disk edits so previously published diagnostics
+	 * are not reused as a fallback for content the server never analyzed (#10787).
+	 */
+	contentHash?: string;
 }
 
 export interface PendingRequest {

--- a/packages/coding-agent/test/tools/lsp-regressions.test.ts
+++ b/packages/coding-agent/test/tools/lsp-regressions.test.ts
@@ -1846,6 +1846,73 @@ describe("lsp regressions", () => {
 		}
 	}, 45_000);
 
+	it("drops the push-only fallback after the file content changes out of band (#10787)", async () => {
+		const tempDir = TempDir.createSync("@omp-lsp-push-only-stale-");
+		try {
+			const targetFile = path.join(tempDir.path(), "main.cpp");
+			await Bun.write(targetFile, "int main() { UnknownType x; return 0; }\n");
+			const uri = fileToUri(targetFile);
+			const diagnostic: Diagnostic = {
+				message: "unknown type name 'UnknownType'",
+				severity: 1,
+				code: "undeclared_type",
+				source: "clice",
+				range: { start: { line: 0, character: 13 }, end: { line: 0, character: 24 } },
+			};
+
+			// Push-only server that publishes only on didOpen and never re-publishes.
+			const fakeServer = installFakeLsp((message, server) => {
+				if (message.method === "initialize") {
+					server.send({ jsonrpc: "2.0", id: message.id, result: { capabilities: {} } });
+					server.send({
+						jsonrpc: "2.0",
+						method: "$/progress",
+						params: { token: "workspace", value: { kind: "begin" } },
+					});
+					server.send({
+						jsonrpc: "2.0",
+						method: "$/progress",
+						params: { token: "workspace", value: { kind: "end" } },
+					});
+				} else if (message.method === "textDocument/didOpen") {
+					server.send({
+						jsonrpc: "2.0",
+						method: "textDocument/publishDiagnostics",
+						params: { uri, diagnostics: [diagnostic] },
+					});
+				} else if (message.method === "textDocument/diagnostic") {
+					server.send({ jsonrpc: "2.0", id: message.id, error: { code: -32601, message: "method not found" } });
+				} else if (message.method === "shutdown") {
+					server.send({ jsonrpc: "2.0", id: message.id, result: null });
+				} else if (message.method === "exit") {
+					server.exit(0);
+				}
+			});
+
+			const serverConfig: ServerConfig = { command: "clice", fileTypes: ["cpp"], rootMarkers: [] };
+			vi.spyOn(lspConfig, "loadConfig").mockReturnValue({
+				servers: { clice: serverConfig },
+				idleTimeoutMs: undefined,
+			});
+			vi.spyOn(lspConfig, "getServersForFile").mockReturnValue([["clice", serverConfig]]);
+
+			const tool = new LspTool(makeLspSession(tempDir.path()));
+			// First query opens the file and surfaces the didOpen publish.
+			const first = await tool.execute("stale-1", { action: "diagnostics", file: targetFile, timeout: 15 });
+			expect(textResult(first)).toContain("unknown type name 'UnknownType'");
+			// The error is fixed on disk out of band; refreshFile sees new content and
+			// the silent server never re-publishes, so the stale diagnostic must NOT
+			// be resurrected — a since-fixed error would otherwise stick forever.
+			await Bun.write(targetFile, "int main() { return 0; }\n");
+			const second = await tool.execute("stale-2", { action: "diagnostics", file: targetFile, timeout: 15 });
+			expect(textResult(second)).not.toContain("unknown type name 'UnknownType'");
+			expect(textResult(second)).toBe("OK");
+		} finally {
+			await lspClient.shutdownAll();
+			tempDir.removeSync();
+		}
+	}, 45_000);
+
 	it("does not reuse stale file diagnostics after another URI publishes", async () => {
 		const tempDir = TempDir.createSync("@omp-lsp-stale-diags-");
 		try {

--- a/packages/coding-agent/test/tools/lsp-regressions.test.ts
+++ b/packages/coding-agent/test/tools/lsp-regressions.test.ts
@@ -1769,6 +1769,66 @@ describe("lsp regressions", () => {
 		);
 	}
 
+	it("surfaces published diagnostics for a push-only server that stops re-publishing on refresh (#10787)", async () => {
+		const tempDir = TempDir.createSync("@omp-lsp-push-only-");
+		try {
+			const targetFile = path.join(tempDir.path(), "main.cpp");
+			await Bun.write(targetFile, "int main() { UnknownType x; return 0; }\n");
+			const uri = fileToUri(targetFile);
+			const diagnostic: Diagnostic = {
+				message: "unknown type name 'UnknownType'",
+				severity: 1,
+				code: "undeclared_type",
+				source: "clice",
+				range: { start: { line: 0, character: 13 }, end: { line: 0, character: 24 } },
+			};
+
+			// Push-only server: advertises no diagnosticProvider and never registers
+			// textDocument/diagnostic, so a pull is a hard -32601. It publishes once on
+			// didOpen and stays silent on the didChange/didSave that `refreshFile` emits
+			// (mirrors clice recompiling only when a translation unit first opens).
+			const fakeServer = installFakeLsp((message, server) => {
+				if (message.method === "initialize") {
+					server.send({ jsonrpc: "2.0", id: message.id, result: { capabilities: {} } });
+				} else if (message.method === "textDocument/didOpen") {
+					server.send({
+						jsonrpc: "2.0",
+						method: "textDocument/publishDiagnostics",
+						params: { uri, diagnostics: [diagnostic] },
+					});
+				} else if (message.method === "textDocument/diagnostic") {
+					server.send({ jsonrpc: "2.0", id: message.id, error: { code: -32601, message: "method not found" } });
+				} else if (message.method === "shutdown") {
+					server.send({ jsonrpc: "2.0", id: message.id, result: null });
+				} else if (message.method === "exit") {
+					server.exit(0);
+				}
+			});
+
+			const serverConfig: ServerConfig = { command: "clice", fileTypes: ["cpp"], rootMarkers: [] };
+			vi.spyOn(lspConfig, "loadConfig").mockReturnValue({
+				servers: { clice: serverConfig },
+				idleTimeoutMs: undefined,
+			});
+			vi.spyOn(lspConfig, "getServersForFile").mockReturnValue([["clice", serverConfig]]);
+
+			const tool = new LspTool(makeLspSession(tempDir.path()));
+			// First query opens the file; the didOpen publish is surfaced directly.
+			const first = await tool.execute("push-1", { action: "diagnostics", file: targetFile, timeout: 20 });
+			expect(textResult(first)).toContain("unknown type name 'UnknownType'");
+			// Second query: the file is already open, so `refreshFile` sends
+			// didChange/didSave and the server never re-publishes. The last published
+			// diagnostic must still surface instead of collapsing to a false "OK".
+			const second = await tool.execute("push-2", { action: "diagnostics", file: targetFile, timeout: 20 });
+			expect(textResult(second)).not.toBe("OK");
+			expect(textResult(second)).toContain("unknown type name 'UnknownType'");
+			expect(fakeServer.received.map(m => m.method)).not.toContain("textDocument/diagnostic");
+		} finally {
+			await lspClient.shutdownAll();
+			tempDir.removeSync();
+		}
+	}, 30_000);
+
 	it("does not reuse stale file diagnostics after another URI publishes", async () => {
 		const tempDir = TempDir.createSync("@omp-lsp-stale-diags-");
 		try {

--- a/packages/coding-agent/test/tools/lsp-regressions.test.ts
+++ b/packages/coding-agent/test/tools/lsp-regressions.test.ts
@@ -1790,6 +1790,18 @@ describe("lsp regressions", () => {
 			const fakeServer = installFakeLsp((message, server) => {
 				if (message.method === "initialize") {
 					server.send({ jsonrpc: "2.0", id: message.id, result: { capabilities: {} } });
+					// Resolve project load immediately so the test does not pay the 15s
+					// PROJECT_LOAD_TIMEOUT_MS fallback on the first query.
+					server.send({
+						jsonrpc: "2.0",
+						method: "$/progress",
+						params: { token: "workspace", value: { kind: "begin" } },
+					});
+					server.send({
+						jsonrpc: "2.0",
+						method: "$/progress",
+						params: { token: "workspace", value: { kind: "end" } },
+					});
 				} else if (message.method === "textDocument/didOpen") {
 					server.send({
 						jsonrpc: "2.0",
@@ -1814,20 +1826,25 @@ describe("lsp regressions", () => {
 
 			const tool = new LspTool(makeLspSession(tempDir.path()));
 			// First query opens the file; the didOpen publish is surfaced directly.
-			const first = await tool.execute("push-1", { action: "diagnostics", file: targetFile, timeout: 20 });
+			const first = await tool.execute("push-1", { action: "diagnostics", file: targetFile, timeout: 15 });
 			expect(textResult(first)).toContain("unknown type name 'UnknownType'");
 			// Second query: the file is already open, so `refreshFile` sends
 			// didChange/didSave and the server never re-publishes. The last published
 			// diagnostic must still surface instead of collapsing to a false "OK".
-			const second = await tool.execute("push-2", { action: "diagnostics", file: targetFile, timeout: 20 });
+			const second = await tool.execute("push-2", { action: "diagnostics", file: targetFile, timeout: 15 });
 			expect(textResult(second)).not.toBe("OK");
 			expect(textResult(second)).toContain("unknown type name 'UnknownType'");
+			// Third query: the re-surfaced publish must have been re-cached, so a
+			// still-silent server keeps returning it instead of decaying to "OK".
+			const third = await tool.execute("push-3", { action: "diagnostics", file: targetFile, timeout: 15 });
+			expect(textResult(third)).not.toBe("OK");
+			expect(textResult(third)).toContain("unknown type name 'UnknownType'");
 			expect(fakeServer.received.map(m => m.method)).not.toContain("textDocument/diagnostic");
 		} finally {
 			await lspClient.shutdownAll();
 			tempDir.removeSync();
 		}
-	}, 30_000);
+	}, 45_000);
 
 	it("does not reuse stale file diagnostics after another URI publishes", async () => {
 		const tempDir = TempDir.createSync("@omp-lsp-stale-diags-");


### PR DESCRIPTION
## Repro
A push-only language server — one whose server capabilities advertise no `diagnosticProvider` and that never registers `textDocument/diagnostic` (a direct pull returns `-32601: method not found`) — publishes diagnostics through `textDocument/publishDiagnostics` on `didOpen` but does not re-publish on subsequent `didChange`/`didSave` (e.g. clice compiling a C++ translation unit once). Running `lsp diagnostics` on such a file after it is already open returns `OK` while real diagnostics exist. Reproduced with a fake push-only server: `bun test test/tools/lsp-regressions.test.ts -t "push-only server that stops re-publishing"`.

## Cause
`refreshFile` (`src/lsp/client.ts`) unconditionally drops the cached `publishDiagnostics` entry for the URI before the wait, and `waitForDiagnostics` (`src/lsp/diagnostics.ts`) returns `[]` on timeout when the server has no pull capability and never re-publishes. OMP correctly never issues the pull for a push-only server, so the already-delivered diagnostics are simply discarded and the tool renders a false `OK`.

## Fix
- `waitForDiagnostics` gains a `fallbackDiagnostics` option (`src/lsp/diagnostics.ts`): on a push-only timeout (`!supportsDocumentDiagnostics(client)`) with no fresh publish cached for the URI, it returns the fallback instead of `[]`. A fresh publish — even empty — is still returned by the existing paths and supersedes the fallback.
- The `lsp diagnostics` tool branch (`src/lsp/tool.ts`) snapshots `client.diagnostics.get(uri)?.diagnostics` before `refreshFile` clears it and passes it as `fallbackDiagnostics`. The edit/write writethrough path is unchanged, so post-edit content never resurrects stale pre-edit diagnostics.

## Verification
`bun test test/tools/lsp-regressions.test.ts test/tools/lsp-diagnostics-freshness.test.ts` → 134 pass, 1 fail. The sole failure (`hashlineStripPrefixes is not a function` in `src/tools/hashline-format.ts`, exercised by the write tool) is a stale `@oh-my-pi/pi-natives` binary in the CI shell and is unrelated to this diagnostics-only change. The new push-only regression test fails before the fix (`lsp diagnostics -> OK`) and passes after. Fixes #10787