### PR TITLE
fix(coding-agent): serialize session pin toggles with a cross-process lock and atomic replace

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -196,6 +196,7 @@
 - Fixed frame skips while streaming long markdown Write previews ([#10955](https://github.com/can1357/oh-my-pi/issues/10955)).
 - LiteLLM discovery no longer caches an empty catalog after a timed-out run: a rich-metadata timeout now falls back to `/v1/models`, and a discovery failure with no prior catalog leaves the cache untouched so the next launch retries immediately instead of hiding discovery-only models ([#10964](https://github.com/can1357/oh-my-pi/issues/10964)).
 - Searching `free` in the model picker now finds every zero-cost model, not just the ones with `free` in their id.
+- Fixed concurrent `/pin` toggles from multiple omp instances silently dropping each other's pins, and crashes mid-write corrupting the pins file.
 
 ## [18.1.11] - 2026-09-05
 
@@ -225,9 +226,6 @@
 
 - Fixed Codex V2 remote compaction rebuilding the request prefix differently from normal turns, restoring prompt-cache reuse ([#10786](https://github.com/can1357/oh-my-pi/issues/10786)).
 - Restored mouse clicks, hover, and wheel scrolling in Plan Review.
-### Fixed
-
-- Fixed concurrent `/pin` toggles from multiple omp instances silently dropping each other's pins, and crashes mid-write corrupting the pins file.
 
 ## [18.1.9] - 2026-09-04
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -25,6 +25,7 @@
 - `/move` now checks BTW migration availability before confirming or creating a missing target directory, preventing leftover directories after a refused move.
 - BTW errors now shorten embedded home paths and sanitize control characters and oversized text before display, while retaining original diagnostic errors.
 - Read error and preview rendering now sanitizes tabs and Windows-style CRLF (e.g. ssh host-key failures, tab-indented fetched content) so raw output can no longer tear the result frame.
+- Fixed concurrent `/pin` toggles from multiple omp instances silently dropping each other's pins, and crashes mid-write corrupting the pins file.
 ### Added
 
 - Added session-local `/btw` history with persistent answers and follow-ups; bare `/btw` reopens history, Escape cancels running answers before closing, and new questions no longer replace an in-progress answer.
@@ -196,7 +197,6 @@
 - Fixed frame skips while streaming long markdown Write previews ([#10955](https://github.com/can1357/oh-my-pi/issues/10955)).
 - LiteLLM discovery no longer caches an empty catalog after a timed-out run: a rich-metadata timeout now falls back to `/v1/models`, and a discovery failure with no prior catalog leaves the cache untouched so the next launch retries immediately instead of hiding discovery-only models ([#10964](https://github.com/can1357/oh-my-pi/issues/10964)).
 - Searching `free` in the model picker now finds every zero-cost model, not just the ones with `free` in their id.
-- Fixed concurrent `/pin` toggles from multiple omp instances silently dropping each other's pins, and crashes mid-write corrupting the pins file.
 
 ## [18.1.11] - 2026-09-05
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -225,6 +225,9 @@
 
 - Fixed Codex V2 remote compaction rebuilding the request prefix differently from normal turns, restoring prompt-cache reuse ([#10786](https://github.com/can1357/oh-my-pi/issues/10786)).
 - Restored mouse clicks, hover, and wheel scrolling in Plan Review.
+### Fixed
+
+- Fixed concurrent `/pin` toggles from multiple omp instances silently dropping each other's pins, and crashes mid-write corrupting the pins file.
 
 ## [18.1.9] - 2026-09-04
 

--- a/packages/coding-agent/src/session/session-pins.ts
+++ b/packages/coding-agent/src/session/session-pins.ts
@@ -1,8 +1,15 @@
+import { randomUUID } from "node:crypto";
+import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { getAgentDir, isEnoent, logger } from "@oh-my-pi/pi-utils";
+import { withFileLock } from "@oh-my-pi/pi-utils/file-lock";
 import type { SessionInfo } from "./session-listing";
 
 const PINS_FILENAME = "session-pins.json";
+
+function pinsPath(agentDir: string): string {
+	return path.join(agentDir, PINS_FILENAME);
+}
 
 /**
  * Read the global set of pinned session ids (`~/.omp/session-pins.json`). Pins
@@ -12,7 +19,7 @@ const PINS_FILENAME = "session-pins.json";
  */
 export async function loadPinnedSessionIds(agentDir: string = getAgentDir()): Promise<Set<string>> {
 	try {
-		const pins: unknown = await Bun.file(path.join(agentDir, PINS_FILENAME)).json();
+		const pins: unknown = JSON.parse(await fs.readFile(pinsPath(agentDir), "utf-8"));
 		if (!Array.isArray(pins)) return new Set();
 		return new Set(pins.filter((id): id is string => typeof id === "string"));
 	} catch (err) {
@@ -22,12 +29,31 @@ export async function loadPinnedSessionIds(agentDir: string = getAgentDir()): Pr
 	}
 }
 
-/** Toggle one session's pin and persist the set; returns the new pinned state. */
+/**
+ * Toggle one session's pin and persist the set; returns the new pinned state.
+ *
+ * The read-modify-write runs under the shared cross-process file lock and
+ * commits via write-temp-then-rename, mirroring the MCP config writer: two omp
+ * instances toggling pins concurrently can no longer lose each other's update
+ * (load-load-write-write), and a crash mid-write leaves the previous pins file
+ * intact instead of a truncated one that degrades to an empty set.
+ */
 export async function toggleSessionPin(sessionId: string, agentDir: string = getAgentDir()): Promise<boolean> {
-	const pinned = await loadPinnedSessionIds(agentDir);
-	if (!pinned.delete(sessionId)) pinned.add(sessionId);
-	await Bun.write(path.join(agentDir, PINS_FILENAME), JSON.stringify([...pinned], null, "\t"));
-	return pinned.has(sessionId);
+	const filePath = pinsPath(agentDir);
+	await fs.mkdir(agentDir, { recursive: true });
+	return withFileLock(filePath, async () => {
+		const pinned = await loadPinnedSessionIds(agentDir);
+		if (!pinned.delete(sessionId)) pinned.add(sessionId);
+		const tmpPath = `${filePath}.${process.pid}.${randomUUID()}.tmp`;
+		try {
+			await fs.writeFile(tmpPath, JSON.stringify([...pinned], null, "\t"), { encoding: "utf-8", mode: 0o600 });
+			await fs.rename(tmpPath, filePath);
+		} catch (error) {
+			await fs.rm(tmpPath, { force: true }).catch(() => {});
+			throw error;
+		}
+		return pinned.has(sessionId);
+	});
 }
 
 /**

--- a/packages/coding-agent/src/session/session-pins.ts
+++ b/packages/coding-agent/src/session/session-pins.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { getAgentDir, isEnoent, logger } from "@oh-my-pi/pi-utils";
 import { withFileLock } from "@oh-my-pi/pi-utils/file-lock";
+import { replaceFileAtomically } from "../utils/atomic-file";
 import type { SessionInfo } from "./session-listing";
 
 const PINS_FILENAME = "session-pins.json";
@@ -33,10 +34,12 @@ export async function loadPinnedSessionIds(agentDir: string = getAgentDir()): Pr
  * Toggle one session's pin and persist the set; returns the new pinned state.
  *
  * The read-modify-write runs under the shared cross-process file lock and
- * commits via write-temp-then-rename, mirroring the MCP config writer: two omp
- * instances toggling pins concurrently can no longer lose each other's update
- * (load-load-write-write), and a crash mid-write leaves the previous pins file
- * intact instead of a truncated one that degrades to an empty set.
+ * commits via write-temp-then-atomic-replace, mirroring the MCP config
+ * writer: two omp instances toggling pins concurrently can no longer lose
+ * each other's update (load-load-write-write), and a crash mid-write leaves
+ * the previous pins file intact instead of a truncated one that degrades to
+ * an empty set. The replace preserves the destination across Windows
+ * EPERM/EEXIST rename failures (`replaceFileAtomically`).
  */
 export async function toggleSessionPin(sessionId: string, agentDir: string = getAgentDir()): Promise<boolean> {
 	const filePath = pinsPath(agentDir);
@@ -47,7 +50,7 @@ export async function toggleSessionPin(sessionId: string, agentDir: string = get
 		const tmpPath = `${filePath}.${process.pid}.${randomUUID()}.tmp`;
 		try {
 			await fs.writeFile(tmpPath, JSON.stringify([...pinned], null, "\t"), { encoding: "utf-8", mode: 0o600 });
-			await fs.rename(tmpPath, filePath);
+			await replaceFileAtomically(tmpPath, filePath);
 		} catch (error) {
 			await fs.rm(tmpPath, { force: true }).catch(() => {});
 			throw error;

--- a/packages/coding-agent/test/session-pins.test.ts
+++ b/packages/coding-agent/test/session-pins.test.ts
@@ -137,25 +137,33 @@ describe("session-pins", () => {
 		// stranded a truncated file the next launch degraded to an empty set.
 		// The sampler observes on-disk states CONCURRENTLY with the toggles:
 		// every observed state must parse (or be absent); a torn write or a
-		// rename window that exposes partial content fails the parse. Real I/O
-		// interleaving is the point of this test, so the sampler loop awaits
-		// the toggles' own promises rather than sleeping fixed durations.
+		// rename window that exposes partial content fails the parse.
+		// Completion is polled WITHOUT awaiting the aggregate promise, so the
+		// loop keeps reading between writes; a rejected toggle propagates via
+		// the final Promise.all instead of hanging the sampler.
 		const ids = Array.from({ length: 12 }, (_, i) => `session-torn-${i}`);
 		const pinsFile = path.join(tempDir, "session-pins.json");
-		const toggles = ids.map(id => toggleSessionPin(id, tempDir));
+		let settledCount = 0;
+		const toggles = ids.map(id =>
+			toggleSessionPin(id, tempDir).finally(() => {
+				settledCount++;
+			}),
+		);
+		let samples = 0;
 		const sampler = (async () => {
-			while (true) {
+			while (settledCount < toggles.length) {
 				try {
 					const raw = await fs.readFile(pinsFile, "utf-8");
 					if (raw.length > 0) JSON.parse(raw);
+					samples++;
 				} catch (err) {
 					const code = (err as NodeJS.ErrnoException).code;
 					if (code !== "ENOENT") throw err;
 				}
-				if ((await Promise.allSettled(toggles)).every(r => r.status === "fulfilled")) break;
 			}
 		})();
 		await Promise.all([sampler, ...toggles]);
+		expect(samples).toBeGreaterThan(0);
 
 		const raw = await fs.readFile(pinsFile, "utf-8");
 		expect(() => JSON.parse(raw)).not.toThrow();

--- a/packages/coding-agent/test/session-pins.test.ts
+++ b/packages/coding-agent/test/session-pins.test.ts
@@ -132,15 +132,35 @@ describe("session-pins", () => {
 		for (const id of ids) expect(loaded.has(id)).toBe(true);
 	});
 
-	it("never leaves a truncated pins file behind after concurrent writes", async () => {
+	it("never exposes a truncated pins file while writes are in flight", async () => {
+		// Regression: Bun.write truncated in place, so a crash mid-write
+		// stranded a truncated file the next launch degraded to an empty set.
+		// The sampler observes on-disk states CONCURRENTLY with the toggles:
+		// every observed state must parse (or be absent); a torn write or a
+		// rename window that exposes partial content fails the parse. Real I/O
+		// interleaving is the point of this test, so the sampler loop awaits
+		// the toggles' own promises rather than sleeping fixed durations.
 		const ids = Array.from({ length: 12 }, (_, i) => `session-torn-${i}`);
-		await Promise.all(ids.map(id => toggleSessionPin(id, tempDir)));
+		const pinsFile = path.join(tempDir, "session-pins.json");
+		const toggles = ids.map(id => toggleSessionPin(id, tempDir));
+		const sampler = (async () => {
+			while (true) {
+				try {
+					const raw = await fs.readFile(pinsFile, "utf-8");
+					if (raw.length > 0) JSON.parse(raw);
+				} catch (err) {
+					const code = (err as NodeJS.ErrnoException).code;
+					if (code !== "ENOENT") throw err;
+				}
+				if ((await Promise.allSettled(toggles)).every(r => r.status === "fulfilled")) break;
+			}
+		})();
+		await Promise.all([sampler, ...toggles]);
 
-		// Every intermediate state on disk must be valid JSON: a torn write used
-		// to truncate in place, and the next launch degraded it to an empty set.
-		const raw = await fs.readFile(path.join(tempDir, "session-pins.json"), "utf-8");
+		const raw = await fs.readFile(pinsFile, "utf-8");
 		expect(() => JSON.parse(raw)).not.toThrow();
 		expect((JSON.parse(raw) as string[]).length).toBe(ids.length);
-		expect(await fs.readdir(tempDir)).not.toContain(expect.stringMatching(/\.tmp$/));
+		const files = await fs.readdir(tempDir);
+		expect(files.some(f => f.endsWith(".tmp"))).toBe(false);
 	});
 });

--- a/packages/coding-agent/test/session-pins.test.ts
+++ b/packages/coding-agent/test/session-pins.test.ts
@@ -154,7 +154,7 @@ describe("session-pins", () => {
 			while (settledCount < toggles.length) {
 				try {
 					const raw = await fs.readFile(pinsFile, "utf-8");
-					if (raw.length > 0) JSON.parse(raw);
+					JSON.parse(raw);
 					samples++;
 				} catch (err) {
 					const code = (err as NodeJS.ErrnoException).code;

--- a/packages/coding-agent/test/session-pins.test.ts
+++ b/packages/coding-agent/test/session-pins.test.ts
@@ -118,4 +118,29 @@ describe("session-pins", () => {
 		// Pin unknown id -> no change to order
 		expect(sortPinnedFirst(all, new Set(["unknown-id"])).map(s => s.id)).toEqual(["s1", "s2", "s3", "s4"]);
 	});
+
+	it("keeps every pin when many toggles race concurrently", async () => {
+		// Regression: toggleSessionPin used to load-modify-write without a lock,
+		// so overlapping toggles from multiple omp instances (CLI picker,
+		// interactive mode, collab guest) interleaved load-load-write-write and
+		// silently dropped each other's pins.
+		const ids = Array.from({ length: 24 }, (_, i) => `session-race-${i}`);
+		await Promise.all(ids.map(id => toggleSessionPin(id, tempDir)));
+
+		const loaded = await loadPinnedSessionIds(tempDir);
+		expect(loaded.size).toBe(ids.length);
+		for (const id of ids) expect(loaded.has(id)).toBe(true);
+	});
+
+	it("never leaves a truncated pins file behind after concurrent writes", async () => {
+		const ids = Array.from({ length: 12 }, (_, i) => `session-torn-${i}`);
+		await Promise.all(ids.map(id => toggleSessionPin(id, tempDir)));
+
+		// Every intermediate state on disk must be valid JSON: a torn write used
+		// to truncate in place, and the next launch degraded it to an empty set.
+		const raw = await fs.readFile(path.join(tempDir, "session-pins.json"), "utf-8");
+		expect(() => JSON.parse(raw)).not.toThrow();
+		expect((JSON.parse(raw) as string[]).length).toBe(ids.length);
+		expect(await fs.readdir(tempDir)).not.toContain(expect.stringMatching(/\.tmp$/));
+	});
 });


### PR DESCRIPTION
## What

`toggleSessionPin` now runs its read-modify-write under `withFileLock` (`@oh-my-pi/pi-utils/file-lock`) and commits via write-temp-then-rename with a per-writer unique temp name — mirroring the established MCP config writer pattern (`src/mcp/config-writer.ts`).

## Why

`~/.omp/session-pins.json` is shared by every omp instance, but `toggleSessionPin` did a bare load → mutate → `Bun.write`:

- **Lost updates:** two overlapping `/pin` toggles (CLI picker + interactive mode + collab guest all share the file) interleave load-load-write-write, and the second write silently drops the first pin.
- **Torn writes:** `Bun.write` truncates in place; a crash mid-write strands a truncated file, and the next launch hits the corrupt-file branch (`logger.warn` → empty set), erasing every pin.

Both failure modes are covered by new regressions in `packages/coding-agent/test/session-pins.test.ts` that fail on the old implementation (verified via `git stash`: 2 fail → after fix 0 fail).

## Testing

- `bun test ./packages/coding-agent/test/session-pins.test.ts` — 6 pass / 0 fail (24 concurrent toggles all survive; final file is valid JSON with all ids; no `.tmp` leftovers).
- Red/green verified: both new tests fail on the pre-fix implementation.
- `bun test ./packages/coding-agent/test/session-pins.test.ts ./packages/coding-agent/test/slash-commands/` — 163 pass / 0 fail (the `/pin` command suites are unaffected).
- `bun x tsc --noEmit -p packages/coding-agent` — clean.
- `bun run check:tools` (oxlint + oxfmt) — clean.

---

- [x] `bun check` passes (TS side clean; `check:rs` needs cargo, unavailable here)
- [x] Tested locally
- [x] CHANGELOG updated