### PR TITLE
fix(commit): recompose commit text after compatibility folding

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Report oversized selected lines that cannot fit after read context, with a working raw recovery selector instead of a looping continuation hint ([#10775](https://github.com/can1357/oh-my-pi/issues/10775)).
 - Fixed WorkPool child sessions crashing during startup while constructing their incremental `yield` tool schema.
+- Commit summaries written in Vietnamese, Korean, and other accented scripts are no longer rejected for exceeding the length limit, and keep their accents as typed.
 
 ## [18.1.10] - 2026-09-04
 

--- a/packages/coding-agent/src/commit/conventional/normalization.ts
+++ b/packages/coding-agent/src/commit/conventional/normalization.ts
@@ -120,9 +120,23 @@ const POST_NFKD_REPLACEMENTS: Record<string, string> = {
 	"\ufeff": "",
 };
 
-/** Normalize Unicode punctuation, symbols, fractions, arrows, and spaces. */
+/**
+ * Normalize Unicode punctuation, symbols, fractions, arrows, and spaces.
+ *
+ * NFKD is the vehicle for the compatibility folding (fractions, super/subscripts,
+ * ligatures, fullwidth forms); it also splits every precomposed letter into a base
+ * plus combining marks, which is not part of that intent. Recomposing with NFC
+ * afterwards keeps each folding — compatibility mappings never recompose — while
+ * restoring the author's letters, so a summary is measured and stored at the length
+ * it was written. Without it the byte guard below counts the decomposition instead:
+ * Vietnamese inflates ~1.23x and Hangul ~2.4x, so a summary well inside the limit is
+ * rejected for exceeding it.
+ */
 export function normalizeCommitUnicode(text: string): string {
-	return replaceCharacters(replaceCharacters(text, PRE_NFKD_REPLACEMENTS).normalize("NFKD"), POST_NFKD_REPLACEMENTS);
+	return replaceCharacters(
+		replaceCharacters(text, PRE_NFKD_REPLACEMENTS).normalize("NFKD"),
+		POST_NFKD_REPLACEMENTS,
+	).normalize("NFC");
 }
 
 /** Estimate tokens with llm-git's four-UTF-8-bytes rule. */

--- a/packages/coding-agent/test/commit-conventional.test.ts
+++ b/packages/coding-agent/test/commit-conventional.test.ts
@@ -16,13 +16,18 @@ import type {
 	CommitInferenceRequest,
 	CommitInferenceResponse,
 } from "../src/commit/conventional/inference";
+import { conventionalCommit } from "../src/commit/conventional/commit-types";
 import { buildFileBatches } from "../src/commit/conventional/map-reduce";
 import {
 	fallbackSummary,
 	parseConventionalAnalysisMarkdown,
 	parseSummaryMarkdown,
 } from "../src/commit/conventional/markdown";
-import { normalizeSummaryVerb } from "../src/commit/conventional/normalization";
+import {
+	normalizeCommitUnicode,
+	normalizeSummaryVerb,
+	postProcessCommitMessage,
+} from "../src/commit/conventional/normalization";
 import {
 	extractComponentsFromPath,
 	extractPathFromRename,
@@ -312,5 +317,62 @@ describe("commit inference cache", () => {
 		});
 		expect(cache.get("k")).toEqual({ text: "# fix: corrected bug", stopReason: "stop", costUsd: 0.01 });
 		cache.close();
+	});
+});
+
+describe("commit unicode normalization", () => {
+	// NFKD is only the vehicle for compatibility folding; letters have to come
+	// back composed, or the byte guard in postProcessCommitMessage measures a
+	// decomposition the author never wrote.
+	test("recomposes precomposed letters instead of leaving combining marks", () => {
+		for (const written of [
+			"sửa lỗi hiển thị",
+			"Đặt lại mật khẩu người dùng",
+			"한국어 표시 수정",
+			"correção de codificação",
+		]) {
+			expect(normalizeCommitUnicode(written)).toBe(written);
+		}
+	});
+
+	test("still folds compatibility forms down to ASCII", () => {
+		const printableAscii = /^[ -~]*$/;
+		for (const [input, expected] of [
+			["½ done", "1/2 done"],
+			["x² + y²", "x^2 + y^2"],
+			["H₂O", "H_2O"],
+			["ﬁle", "file"],
+			["①②③", "123"],
+			["ｆｕｌｌ", "full"],
+			["a ≠ b", "a != b"],
+			["“quoted”", '"quoted"'],
+			["a → b", "a -> b"],
+			["α λ", "alpha lambda"],
+		] as const) {
+			const folded = normalizeCommitUnicode(input);
+			expect(folded).toBe(expected);
+			expect(printableAscii.test(folded)).toBe(true);
+		}
+	});
+
+	// The guard counts UTF-8 bytes, so a decomposed summary is measured at a
+	// length its author never wrote: Vietnamese inflates ~1.23x, Hangul ~2.4x.
+	test("accepts non-ASCII summaries that fit the byte limit as written", () => {
+		const vietnamese = "sửa lỗi bộ đệm không được giải phóng khi người dùng đóng phiên làm việc giữa chừng";
+		expect(Buffer.byteLength(vietnamese)).toBeLessThanOrEqual(DEFAULT_CONFIG.summaryHardLimit);
+
+		const processed = postProcessCommitMessage(conventionalCommit({ type: "fix", summary: vietnamese }), config());
+		expect(processed.summary).toBe(vietnamese);
+	});
+
+	test("keeps body details and footers composed", () => {
+		const detail = "Đặt lại mật khẩu người dùng";
+		const footer = "Refs: vấn-đề-123";
+		const processed = postProcessCommitMessage(
+			conventionalCommit({ type: "fix", summary: "corrected a bug", body: [detail], footers: [footer] }),
+			config(),
+		);
+		expect(processed.body).toEqual([`${detail}.`]);
+		expect(processed.footers).toEqual([footer]);
 	});
 });


### PR DESCRIPTION
## What

`normalizeCommitUnicode` folds compatibility forms (fractions, super/subscripts, ligatures, fullwidth) to ASCII by running `NFKD`, but never recomposes afterwards. NFKD also decomposes every *precomposed letter* into a base plus combining marks, which is not part of that intent — and the function keeps the decomposition.

This change appends `.normalize("NFC")` to the pipeline. Compatibility mappings never recompose, so all the intended foldings survive; only the author's letters are put back together.

## Why

`postProcessCommitMessage` measures the summary in UTF-8 bytes *after* that call:

```ts
if (Buffer.byteLength(summary) > config.summaryHardLimit) {
    throw new Error(`Summary exceeds ${config.summaryHardLimit} bytes`);
}
```

Decomposition inflates the measurement for any script that uses precomposed letters — Vietnamese by ~1.23x, Hangul by ~2.4x — so a summary that fits gets rejected for exceeding the limit. Measured with the repo's own code:

| summary | as written | after `normalizeCommitUnicode` |
| --- | --- | --- |
| `sửa lỗi bộ đệm không được giải phóng khi người dùng đóng phiên làm việc giữa chừng` | 113 B | **139 B** |
| `한국어 입력기에서 조합 중인 글자가 사라지는 문제를 수정` | 79 B | **187 B** |

The limit is 128 bytes, so both are rejected. `postProcessCommitMessage` is called uncaught in `validateAndProcess`, so the throw propagates out of `generateConventionalCommit` and commit generation fails rather than degrading. The upstream cap does not help either: `generate.ts:313` uses `sliceCodePoints(chosen, 0, config.summaryHardLimit)`, which counts code points against a budget the guard then reads as bytes.

Text that is short enough to pass is still affected — it reaches Git decomposed rather than as the author typed it.

## Testing

Reproduced and confirmed fixed against the byte guard itself, through the repo's own code path:

- **Before** — `postProcessCommitMessage` with the 113-byte Vietnamese summary above threw `Summary exceeds 128 bytes`. `normalizeCommitUnicode` returned 139 bytes / 109 code points, byte-identical to `NFKD` of the input.
- **After** — the same call returns the summary unchanged: 113 bytes, 82 code points, strictly equal to the input string.

Four tests added to `commit-conventional.test.ts`. Reverting the one-line change fails three of them, including `accepts non-ASCII summaries that fit the byte limit as written`, which fails with the production error `Summary exceeds 128 bytes`. The fourth (`still folds compatibility forms down to ASCII`) passes either way by design — it is the regression guard proving NFC does not undo the folding, checked over ½ ² ₂ ﬁ ① ｆｕｌｌ ≠ “” → α.

Checks run:

- `bun test packages/coding-agent/test/commit-conventional.test.ts` — 20 pass, 0 fail
- `bun run check:ts` — passes across the workspace (oxlint, oxfmt, and `tsgo --noEmit` per package). This change is TypeScript only, so `check:rs` was not run.
- `commit-execute.test.ts` has one failure (`abortOnGitFailure (issue #7834) > surfaces a refusing hook's message...`). It reproduces identically on an unpatched tree — same test name, same 2 pass / 1 fail — so it does not come from this change.

---

- [x] `bun run check:ts` passes (Rust untouched; `check:rs` not run)
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
