### PR TITLE
perf(memories): read bounded head slice of session files in collectThreads

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -225,6 +225,9 @@
 
 - Fixed Codex V2 remote compaction rebuilding the request prefix differently from normal turns, restoring prompt-cache reuse ([#10786](https://github.com/can1357/oh-my-pi/issues/10786)).
 - Restored mouse clicks, hover, and wheel scrolling in Plan Review.
+### Changed
+
+- Memory startup now reads only the head slice of past session JSONL files (`collectThreads`) instead of loading and splitting whole files, avoiding large heap allocations when past sessions are large.
 
 ## [18.1.9] - 2026-09-04
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -227,7 +227,7 @@
 - Restored mouse clicks, hover, and wheel scrolling in Plan Review.
 ### Changed
 
-- Memory startup now reads only the head slice of past session JSONL files (`collectThreads`) instead of loading and splitting whole files, avoiding large heap allocations when past sessions are large.
+- Reduced startup memory and latency when initializing memory with large session histories by reading only session header metadata instead of loading entire transcripts into memory.
 
 ## [18.1.9] - 2026-09-04
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Reduced startup memory and latency when initializing memory with large session histories by reading only session header metadata instead of loading entire transcripts into memory.
+
 ### Added
 
 - `/usage` now shows prepaid credit balances (e.g. Charm Hyper's `100 credits left`) on the provider cards and account summaries instead of `no data` ([#11656](https://github.com/can1357/oh-my-pi/pull/11656) by [@oldschoola](https://github.com/oldschoola)).
@@ -182,7 +186,6 @@
 - Ranged reads of text without bracket characters skip unnecessary lexical context scanning.
 - Muse Code sessions send a compact hashline edit description (~3 KB less per request); all other models keep the full prompt.
 - Transcript usage row now shows the prompt-to-yield time as a bare delta, keeping the clock icon for time to first token only.
-- Reduced startup memory and latency when initializing memory with large session histories by reading only session header metadata instead of loading entire transcripts into memory.
 
 ### Fixed
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -182,6 +182,7 @@
 - Ranged reads of text without bracket characters skip unnecessary lexical context scanning.
 - Muse Code sessions send a compact hashline edit description (~3 KB less per request); all other models keep the full prompt.
 - Transcript usage row now shows the prompt-to-yield time as a bare delta, keeping the clock icon for time to first token only.
+- Reduced startup memory and latency when initializing memory with large session histories by reading only session header metadata instead of loading entire transcripts into memory.
 
 ### Fixed
 
@@ -225,9 +226,6 @@
 
 - Fixed Codex V2 remote compaction rebuilding the request prefix differently from normal turns, restoring prompt-cache reuse ([#10786](https://github.com/can1357/oh-my-pi/issues/10786)).
 - Restored mouse clicks, hover, and wheel scrolling in Plan Review.
-### Changed
-
-- Reduced startup memory and latency when initializing memory with large session histories by reading only session header metadata instead of loading entire transcripts into memory.
 
 ## [18.1.9] - 2026-09-04
 

--- a/packages/coding-agent/src/memories/index.ts
+++ b/packages/coding-agent/src/memories/index.ts
@@ -5,7 +5,15 @@ import * as path from "node:path";
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
 import { type ApiKey, completeSimple, Effort, type Model, retryTransientCompletion } from "@oh-my-pi/pi-ai";
 import { clampThinkingLevelForModel } from "@oh-my-pi/pi-catalog/model-thinking";
-import { getAgentDbPath, getMemoriesDir, isEnoent, logger, parseJsonlLenient, prompt } from "@oh-my-pi/pi-utils";
+import {
+	getAgentDbPath,
+	getMemoriesDir,
+	isEnoent,
+	logger,
+	parseJsonlLenient,
+	peekFile,
+	prompt,
+} from "@oh-my-pi/pi-utils";
 
 import type { ModelRegistry } from "../config/model-registry";
 import { getModelMatchPreferences, resolveModelRoleValue } from "../config/model-resolver";
@@ -640,6 +648,7 @@ function markPhase2FailureWithFallback(
 	}
 }
 
+/** @internal Exported for unit-testing. */
 export async function collectThreads(session: AgentSession, currentThreadId?: string): Promise<MemoryThread[]> {
 	const sessionDir = session.sessionManager.getSessionDir();
 	const files = await fs.readdir(sessionDir);
@@ -663,7 +672,9 @@ export async function collectThreads(session: AgentSession, currentThreadId?: st
 			// falls on the slice boundary, fall back to a full read.
 			const HEAD_CAP = 64 * 1024;
 			let isLarge = stat.size > HEAD_CAP;
-			let fileText = isLarge ? await Bun.file(fullPath).slice(0, HEAD_CAP).text() : await Bun.file(fullPath).text();
+			let fileText = isLarge
+				? await peekFile(fullPath, HEAD_CAP, bytes => new TextDecoder().decode(bytes))
+				: await Bun.file(fullPath).text();
 			let lines = fileText.split(/\r?\n/);
 			let sawTitleSlot = false;
 			for (let i = 0; i < lines.length; i++) {

--- a/packages/coding-agent/src/memories/index.ts
+++ b/packages/coding-agent/src/memories/index.ts
@@ -640,7 +640,7 @@ function markPhase2FailureWithFallback(
 	}
 }
 
-async function collectThreads(session: AgentSession, currentThreadId?: string): Promise<MemoryThread[]> {
+export async function collectThreads(session: AgentSession, currentThreadId?: string): Promise<MemoryThread[]> {
 	const sessionDir = session.sessionManager.getSessionDir();
 	const files = await fs.readdir(sessionDir);
 	const threads: MemoryThread[] = [];
@@ -656,10 +656,24 @@ async function collectThreads(session: AgentSession, currentThreadId?: string): 
 		let cwd = "";
 		let id = name.slice(0, -6);
 		try {
-			const fileText = await Bun.file(fullPath).text();
+			// Bounded head read: session files can grow to hundreds of MBs, but the
+			// session header line always lives at line 1 (or line 2 after a title
+			// slot). Reading a small head slice avoids full-file read and line-split
+			// allocations on startup for every past session. If the candidate line
+			// falls on the slice boundary, fall back to a full read.
+			const HEAD_CAP = 64 * 1024;
+			let isLarge = stat.size > HEAD_CAP;
+			let fileText = isLarge ? await Bun.file(fullPath).slice(0, HEAD_CAP).text() : await Bun.file(fullPath).text();
+			let lines = fileText.split(/\r?\n/);
 			let sawTitleSlot = false;
-			for (const rawLine of fileText.split(/\r?\n/)) {
-				const line = rawLine.trim();
+			for (let i = 0; i < lines.length; i++) {
+				// If the slice was cut before this line terminated, fall back to full read
+				if (isLarge && i === lines.length - 1) {
+					fileText = await Bun.file(fullPath).text();
+					lines = fileText.split(/\r?\n/);
+					isLarge = false;
+				}
+				const line = lines[i].trim();
 				if (!line) continue;
 				const parsed = parseJsonlLenient<Record<string, unknown>>(line);
 				const header = Array.isArray(parsed) && parsed.length > 0 ? parsed[0] : undefined;

--- a/packages/coding-agent/test/memories/collect-threads.test.ts
+++ b/packages/coding-agent/test/memories/collect-threads.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { collectThreads } from "@oh-my-pi/pi-coding-agent/memories";
+
+function makeFakeSession(sessionDir: string): AgentSession {
+	return {
+		sessionManager: {
+			getSessionDir: () => sessionDir,
+			getCwd: () => sessionDir,
+			getSessionId: () => "current-active-session",
+		},
+	} as unknown as AgentSession;
+}
+
+describe("collectThreads", () => {
+	let tempDir: string;
+
+	beforeEach(async () => {
+		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-collect-threads-test-"));
+	});
+
+	afterEach(async () => {
+		await fs.rm(tempDir, { recursive: true, force: true });
+	});
+
+	it("parses header from standard session file", async () => {
+		const filePath = path.join(tempDir, "sess-1.jsonl");
+		await Bun.write(
+			filePath,
+			'{"type":"session","id":"custom-id-1","cwd":"/projects/my-app"}\n{"type":"user","message":"hi"}\n',
+		);
+
+		const threads = await collectThreads(makeFakeSession(tempDir));
+		expect(threads.length).toBe(1);
+		expect(threads[0]?.id).toBe("custom-id-1");
+		expect(threads[0]?.cwd).toBe("/projects/my-app");
+		expect(threads[0]?.sourceKind).toBe("cli");
+	});
+
+	it("skips title slot and extracts session header on line 2", async () => {
+		const filePath = path.join(tempDir, "sess-2.jsonl");
+		await Bun.write(
+			filePath,
+			'{"type":"title","title":"Sprint planning"}\n{"type":"session","id":"custom-id-2","cwd":"/repo"}\n',
+		);
+
+		const threads = await collectThreads(makeFakeSession(tempDir));
+		expect(threads.length).toBe(1);
+		expect(threads[0]?.id).toBe("custom-id-2");
+		expect(threads[0]?.cwd).toBe("/repo");
+	});
+
+	it("filters out the current active thread", async () => {
+		const activeFile = path.join(tempDir, "active.jsonl");
+		await Bun.write(activeFile, '{"type":"session","id":"active-thread","cwd":"/work"}\n');
+		const otherFile = path.join(tempDir, "other.jsonl");
+		await Bun.write(otherFile, '{"type":"session","id":"other-thread","cwd":"/work"}\n');
+
+		const threads = await collectThreads(makeFakeSession(tempDir), "active-thread");
+		expect(threads.length).toBe(1);
+		expect(threads[0]?.id).toBe("other-thread");
+	});
+
+	it("ignores non-jsonl files and degrades malformed entries gracefully", async () => {
+		await Bun.write(path.join(tempDir, "notes.txt"), "not a session");
+		await Bun.write(path.join(tempDir, "broken.jsonl"), "{invalid json\n");
+		await Bun.write(path.join(tempDir, "empty.jsonl"), "");
+
+		const threads = await collectThreads(makeFakeSession(tempDir));
+		// broken.jsonl should degrade to id from filename ("broken") and cwd=""
+		const broken = threads.find(t => t.id === "broken");
+		expect(broken).toBeDefined();
+		expect(broken?.cwd).toBe("");
+	});
+
+	it("falls back to full read when header crosses the head-cap boundary", async () => {
+		const filePath = path.join(tempDir, "padded-boundary.jsonl");
+		// Pad the title line so the session header starts near ~64 KB and crosses the boundary
+		const longTitle = '{"type":"title","title":"' + "a".repeat(65530) + '"}\n';
+		const sessionHeader = '{"type":"session","id":"boundary-id","cwd":"/boundary/dir"}\n';
+		await Bun.write(filePath, longTitle + sessionHeader + "tail\n");
+
+		const threads = await collectThreads(makeFakeSession(tempDir));
+		expect(threads.length).toBe(1);
+		expect(threads[0]?.id).toBe("boundary-id");
+		expect(threads[0]?.cwd).toBe("/boundary/dir");
+	});
+
+	it("extracts header from a large session file whose body exceeds the head cap", async () => {
+		const filePath = path.join(tempDir, "big-session.jsonl");
+		// Session header line (~70 bytes), then 250 KB of conversation lines
+		const header = '{"type":"session","id":"big-id","cwd":"/big/project"}\n';
+		const bigBody = '{"type":"assistant","message":"' + "x".repeat(1000) + '"}\n'.repeat(250);
+		await Bun.write(filePath, header + bigBody);
+
+		const threads = await collectThreads(makeFakeSession(tempDir));
+		expect(threads.length).toBe(1);
+		expect(threads[0]?.id).toBe("big-id");
+		expect(threads[0]?.cwd).toBe("/big/project");
+	});
+});

--- a/packages/coding-agent/test/memories/collect-threads.test.ts
+++ b/packages/coding-agent/test/memories/collect-threads.test.ts
@@ -93,7 +93,7 @@ describe("collectThreads", () => {
 		const filePath = path.join(tempDir, "big-session.jsonl");
 		// Session header line (~70 bytes), then 250 KB of conversation lines
 		const header = '{"type":"session","id":"big-id","cwd":"/big/project"}\n';
-		const bigBody = '{"type":"assistant","message":"' + "x".repeat(1000) + '"}\n'.repeat(250);
+		const bigBody = ('{"type":"assistant","message":"' + "x".repeat(1000) + '"}\n').repeat(250);
 		await Bun.write(filePath, header + bigBody);
 
 		const threads = await collectThreads(makeFakeSession(tempDir));


### PR DESCRIPTION
## What

In `collectThreads` (`packages/coding-agent/src/memories/index.ts`), session files are now read via a 64 KB head slice (`Bun.file(fullPath).slice(0, 64 * 1024).text()`) instead of reading and line-splitting the entire file. If the candidate header line falls on the slice boundary, it falls back to a full read.

## Why

During memory startup (Phase 1, `runPhase1`), `collectThreads` scans every `.jsonl` file in the sessions directory to extract its `cwd` and session `id`. The session header is always at line 1 (or line 2 after an optional `title` slot). Previously, `await Bun.file(fullPath).text()` loaded and line-split the **entire** session file for each historical session. For operators with multi-MB or multi-GB session archives, this caused O(total corpus size) heap allocations and unnecessary disk I/O on every startup.

The fallback preserves 100% behavioral equivalence: if a candidate header line crosses the 64 KB boundary, the full-file read is performed.

## Testing

- Added dedicated unit suite `packages/coding-agent/test/memories/collect-threads.test.ts` (6 pass / 0 fail):
  - Standard session file (header on line 1)
  - Title slot handling (header on line 2)
  - Current active thread exclusion
  - Boundary fallback (title padded to ~64 KB so header crosses slice boundary — verifies fallback works)
  - Large session file (250 KB body beyond header)
  - Malformed and empty file handling
- `bun test ./packages/coding-agent/test/memories/collect-threads.test.ts` — 6 pass / 0 fail
- `bun x tsc --noEmit -p packages/coding-agent` — clean
- `bun run check:tools` (oxlint + oxfmt) — clean

---

- [x] `bun check` passes (TS side clean; `check:rs` needs cargo, unavailable here)
- [x] Tested locally
- [x] CHANGELOG updated