### PR TITLE
fix(coding-agent): report omitted oversized read lines

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Report oversized selected lines that cannot fit after read context, with a working raw recovery selector instead of a looping continuation hint ([#10775](https://github.com/can1357/oh-my-pi/issues/10775)).
+
 ## [18.1.10] - 2026-09-04
 
 ### Changed

--- a/packages/coding-agent/src/tools/output-meta.ts
+++ b/packages/coding-agent/src/tools/output-meta.ts
@@ -99,6 +99,8 @@ export interface TruncationOptions {
 	artifactId?: string;
 	/** Byte budget that stopped the read, when truncation is byte-limited. */
 	maxBytes?: number;
+	/** Override the derived continuation line; `null` suppresses an unsafe continuation hint. */
+	nextOffset?: number | null;
 }
 
 export interface TruncationSummaryOptions {
@@ -216,7 +218,12 @@ export class OutputMetaBuilder {
 			maxBytes,
 			shownRange: { start: shownStart, end: shownEnd },
 			artifactId,
-			nextOffset: direction === "head" ? shownEnd + 1 : undefined,
+			nextOffset:
+				direction === "head"
+					? options.nextOffset === null
+						? undefined
+						: (options.nextOffset ?? shownEnd + 1)
+					: undefined,
 		};
 
 		return this;

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -239,13 +239,37 @@ interface ReadLineWindow {
 	lines: string[];
 	totalFileLines: number;
 	collectedBytes: number;
+	selectedBytes: number;
 	stoppedByByteLimit: boolean;
+	/** First source line that could not fit in the remaining byte budget. */
+	byteLimitLine?: { index: number; byteLength: number };
 	firstLinePreview?: { text: string; bytes: number };
 	firstLineByteLength?: number;
 	/** Whether the fully scanned source ended in a newline. */
 	hasTrailingNewline: boolean;
 	/** False when `stopScanAfterCollect` cut the scan short — `totalFileLines` is then a lower bound. */
 	reachedEof: boolean;
+}
+
+function omittedRequestedLine(
+	line: ReadLineWindow["byteLimitLine"],
+	requestedStart: number,
+	effectiveLimit: number,
+	rawSelector: boolean,
+	hasLeadingOutput: boolean,
+): ReadLineWindow["byteLimitLine"] {
+	if (rawSelector || !hasLeadingOutput || !line) return undefined;
+	return line.index >= requestedStart && line.index < requestedStart + effectiveLimit ? line : undefined;
+}
+
+function formatOmittedRequestedLineNotice(
+	line: NonNullable<ReadLineWindow["byteLimitLine"]>,
+	maxBytes: number,
+	rawTarget: string,
+): string {
+	return `[Line ${line.index + 1} is ${formatBytes(
+		line.byteLength,
+	)} and could not fit after preceding context in the ${formatBytes(maxBytes)} read budget. Use ${rawTarget} to read that line without context (byte-capped if it exceeds the budget), or widen the requested range to increase the budget.]`;
 }
 
 /**
@@ -276,6 +300,7 @@ function collectLineWindowFromBuffer(
 		lines: [],
 		totalFileLines,
 		collectedBytes: 0,
+		selectedBytes: 0,
 		stoppedByByteLimit: false,
 		hasTrailingNewline: endsWithNewline,
 		reachedEof: true,
@@ -299,7 +324,10 @@ function collectLineWindowFromBuffer(
 		const lineEnd = newlineAt === -1 ? bytes.length : newlineAt;
 		const lineByteLength = lineEnd - lineStart;
 
-		if (selectedLinesSeen < selectedLineLimit) selectedLinesSeen++;
+		if (selectedLinesSeen < selectedLineLimit) {
+			window.selectedBytes += (selectedLinesSeen > 0 ? 1 : 0) + lineByteLength;
+			selectedLinesSeen++;
+		}
 		// Preview covers the first selected line only, capped at the byte budget:
 		// the oversized-first-line branch renders it when no full line fits.
 		if (window.lines.length === 0 && window.firstLinePreview === undefined && lineByteLength > 0) {
@@ -314,10 +342,12 @@ function collectLineWindowFromBuffer(
 				doneCollecting = true;
 			} else if (window.lines.length === 0 && lineByteLength > maxBytes) {
 				window.stoppedByByteLimit = true;
+				window.byteLimitLine = { index, byteLength: lineByteLength };
 				doneCollecting = true;
 				window.firstLineByteLength ??= lineByteLength;
 			} else if (window.lines.length > 0 && window.collectedBytes + separatorBytes + lineByteLength > maxBytes) {
 				window.stoppedByByteLimit = true;
+				window.byteLimitLine = { index, byteLength: lineByteLength };
 				doneCollecting = true;
 			} else {
 				window.lines.push(rawSegments[index] ?? "");
@@ -359,7 +389,9 @@ async function streamLinesFromFile(
 	const collectedLines: string[] = [];
 	let lineIndex = 0;
 	let collectedBytes = 0;
+	let selectedBytes = 0;
 	let stoppedByByteLimit = false;
+	let byteLimitLine: { index: number; byteLength: number } | undefined;
 	let doneCollecting = false;
 	let reachedEof = true;
 	let fileHandle: fs.FileHandle | null = null;
@@ -420,6 +452,7 @@ async function streamLinesFromFile(
 
 	const finalizeLine = () => {
 		if (lineIndex >= startLine && (selectedLineLimit === null || selectedLinesSeen < selectedLineLimit)) {
+			selectedBytes += (selectedLinesSeen > 0 ? 1 : 0) + currentLineLength;
 			selectedLinesSeen++;
 		}
 
@@ -429,12 +462,14 @@ async function streamLinesFromFile(
 				doneCollecting = true;
 			} else if (collectedLines.length === 0 && currentLineLength > maxBytes) {
 				stoppedByByteLimit = true;
+				byteLimitLine = { index: lineIndex, byteLength: currentLineLength };
 				doneCollecting = true;
 				if (firstLineByteLength === undefined) {
 					firstLineByteLength = currentLineLength;
 				}
 			} else if (collectedLines.length > 0 && collectedBytes + separatorBytes + currentLineLength > maxBytes) {
 				stoppedByByteLimit = true;
+				byteLimitLine = { index: lineIndex, byteLength: currentLineLength };
 				doneCollecting = true;
 			} else {
 				const lineText = decodeLine();
@@ -534,7 +569,9 @@ async function streamLinesFromFile(
 		lines: collectedLines,
 		totalFileLines: lineIndex,
 		collectedBytes,
+		selectedBytes,
 		stoppedByByteLimit,
+		byteLimitLine,
 		firstLinePreview,
 		firstLineByteLength,
 		reachedEof,
@@ -1516,7 +1553,10 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 		let sourcePath: string | undefined;
 		let columnTruncated = 0;
 		let truncationInfo:
-			| { result: TruncationResult; options: { direction: "head"; startLine?: number; totalFileLines?: number } }
+			| {
+					result: TruncationResult;
+					options: { direction: "head"; startLine?: number; totalFileLines?: number; nextOffset?: number | null };
+			  }
 			| undefined;
 
 		if (isVideoPath(absolutePath)) {
@@ -1758,7 +1798,9 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 						lines: collectedLines,
 						totalFileLines,
 						collectedBytes,
+						selectedBytes,
 						stoppedByByteLimit,
+						byteLimitLine,
 						firstLinePreview,
 						firstLineByteLength,
 						reachedEof,
@@ -1813,9 +1855,15 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 					const userLimitedLines = collectedLines.length;
 
 					const totalSelectedLines = totalFileLines - startLine;
-					const totalSelectedBytes = collectedBytes;
 					const wasTruncated = collectedLines.length < totalSelectedLines || stoppedByByteLimit;
 					const firstLineExceedsLimit = firstLineByteLength !== undefined && firstLineByteLength > maxBytesForRead;
+					const omittedSelectedLine = omittedRequestedLine(
+						byteLimitLine,
+						requestedStart,
+						effectiveLimit,
+						rawSelector,
+						collectedLines.length > 0,
+					);
 					// A first line larger than the byte budget collects no complete
 					// line, yet the window still renders a byte-capped preview.
 					// Account for that preview so the notice/meta describe the
@@ -1828,7 +1876,7 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 						truncated: wasTruncated,
 						truncatedBy: stoppedByByteLimit ? "bytes" : wasTruncated ? "lines" : undefined,
 						totalLines: totalSelectedLines,
-						totalBytes: firstLineExceedsLimit ? (firstLineByteLength ?? previewBytes) : totalSelectedBytes,
+						totalBytes: firstLineExceedsLimit ? (firstLineByteLength ?? previewBytes) : selectedBytes,
 						outputLines: firstLineExceedsLimit ? (previewBytes > 0 ? 1 : 0) : collectedLines.length,
 						outputBytes: firstLineExceedsLimit ? previewBytes : collectedBytes,
 						lastLinePartial: false,
@@ -1934,6 +1982,14 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 						};
 					} else if (truncation.truncated) {
 						outputText = formatBracketAwareText() ?? formatText(truncation.content, startLineDisplay);
+						if (omittedSelectedLine) {
+							const lineNumber = omittedSelectedLine.index + 1;
+							outputText += `\n\n${formatOmittedRequestedLineNotice(
+								omittedSelectedLine,
+								maxBytesForRead,
+								`:raw:${lineNumber}-${lineNumber}`,
+							)}`;
+						}
 						details = { truncation };
 						sourcePath = absolutePath;
 						truncationInfo = {
@@ -1942,6 +1998,7 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 								direction: "head",
 								startLine: startLineDisplay,
 								totalFileLines: reachedEof ? totalFileLines : undefined,
+								nextOffset: omittedSelectedLine ? null : undefined,
 							},
 						};
 					} else if (startLine + userLimitedLines < totalFileLines || !reachedEof) {
@@ -2212,7 +2269,9 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 			lines: collectedLines,
 			totalFileLines,
 			collectedBytes,
+			selectedBytes,
 			stoppedByByteLimit,
+			byteLimitLine,
 			firstLinePreview,
 			firstLineByteLength,
 			reachedEof,
@@ -2235,6 +2294,13 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 		const totalSelectedLines = totalFileLines - startLine;
 		const wasTruncated = collectedLines.length < totalSelectedLines || stoppedByByteLimit;
 		const firstLineExceedsLimit = firstLineByteLength !== undefined && firstLineByteLength > maxBytesForRead;
+		const omittedSelectedLine = omittedRequestedLine(
+			byteLimitLine,
+			requestedStart,
+			effectiveLimit,
+			rawSelector,
+			collectedLines.length > 0,
+		);
 		// Mirror the plain-file path: a preview-only oversized first line must
 		// count as one delivered partial line, not zero.
 		const previewBytes = firstLineExceedsLimit ? (firstLinePreview?.bytes ?? 0) : 0;
@@ -2243,7 +2309,7 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 			truncated: wasTruncated,
 			truncatedBy: stoppedByByteLimit ? "bytes" : wasTruncated ? "lines" : undefined,
 			totalLines: totalSelectedLines,
-			totalBytes: firstLineExceedsLimit ? (firstLineByteLength ?? previewBytes) : collectedBytes,
+			totalBytes: firstLineExceedsLimit ? (firstLineByteLength ?? previewBytes) : selectedBytes,
 			outputLines: firstLineExceedsLimit ? (previewBytes > 0 ? 1 : 0) : collectedLines.length,
 			outputBytes: firstLineExceedsLimit ? previewBytes : collectedBytes,
 			lastLinePartial: false,
@@ -2263,7 +2329,10 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 
 		let outputText: string;
 		let truncationInfo:
-			| { result: TruncationResult; options: { direction: "head"; startLine?: number; totalFileLines?: number } }
+			| {
+					result: TruncationResult;
+					options: { direction: "head"; startLine?: number; totalFileLines?: number; nextOffset?: number | null };
+			  }
 			| undefined;
 		if (truncation.firstLineExceedsLimit) {
 			const firstLineBytes = firstLineByteLength ?? 0;
@@ -2285,12 +2354,21 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 		} else {
 			outputText = formatText(truncation.content, startLineDisplay);
 			if (truncation.truncated) {
+				if (omittedSelectedLine) {
+					const lineNumber = omittedSelectedLine.index + 1;
+					outputText += `\n\n${formatOmittedRequestedLineNotice(
+						omittedSelectedLine,
+						maxBytesForRead,
+						`${artifactUrl}:raw:${lineNumber}-${lineNumber}`,
+					)}`;
+				}
 				truncationInfo = {
 					result: truncation,
 					options: {
 						direction: "head",
 						startLine: startLineDisplay,
 						totalFileLines: reachedEof ? totalFileLines : undefined,
+						nextOffset: omittedSelectedLine ? null : undefined,
 					},
 				};
 			} else if (startLine + collectedLines.length < totalFileLines || !reachedEof) {

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -254,12 +254,12 @@ interface ReadLineWindow {
 function omittedRequestedLine(
 	line: ReadLineWindow["byteLimitLine"],
 	requestedStart: number,
-	effectiveLimit: number,
 	rawSelector: boolean,
-	hasLeadingOutput: boolean,
+	leadingContext: number,
+	collectedLineCount: number,
 ): ReadLineWindow["byteLimitLine"] {
-	if (rawSelector || !hasLeadingOutput || !line) return undefined;
-	return line.index >= requestedStart && line.index < requestedStart + effectiveLimit ? line : undefined;
+	if (rawSelector || !line || leadingContext === 0) return undefined;
+	return line.index === requestedStart && collectedLineCount === leadingContext ? line : undefined;
 }
 
 function formatOmittedRequestedLineNotice(
@@ -1860,9 +1860,9 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 					const omittedSelectedLine = omittedRequestedLine(
 						byteLimitLine,
 						requestedStart,
-						effectiveLimit,
 						rawSelector,
-						collectedLines.length > 0,
+						leadingContext,
+						collectedLines.length,
 					);
 					// A first line larger than the byte budget collects no complete
 					// line, yet the window still renders a byte-capped preview.
@@ -2297,9 +2297,9 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 		const omittedSelectedLine = omittedRequestedLine(
 			byteLimitLine,
 			requestedStart,
-			effectiveLimit,
 			rawSelector,
-			collectedLines.length > 0,
+			leadingContext,
+			collectedLines.length,
 		);
 		// Mirror the plain-file path: a preview-only oversized first line must
 		// count as one delivered partial line, not zero.

--- a/packages/coding-agent/test/tools/read-artifact-large.test.ts
+++ b/packages/coding-agent/test/tools/read-artifact-large.test.ts
@@ -8,6 +8,7 @@ import {
 	resetRegisteredArtifactDirsForTests,
 } from "@oh-my-pi/pi-coding-agent/internal-urls/registry-helpers";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+import { formatTruncationMetaNotice } from "@oh-my-pi/pi-coding-agent/tools/output-meta";
 import { ReadTool } from "@oh-my-pi/pi-coding-agent/tools/read";
 
 function getTextOutput(result: { content: Array<{ type: string; text?: string }> }): string {
@@ -37,6 +38,10 @@ function largeArtifactText(): string {
 		{ length: 400 },
 		(_, index) => `line-${String(index + 1).padStart(3, "0")} ${"x".repeat(256)}`,
 	).join("\n");
+}
+
+function oversizedSelectedLineArtifact(): string {
+	return ["leading-context", `oversized-${"x".repeat(70_000)}-end`, "trailing-one", "trailing-two"].join("\n");
 }
 
 describe("read tool large artifact handling", () => {
@@ -108,6 +113,48 @@ describe("read tool large artifact handling", () => {
 		const result = await tool.execute("call-raw-tail", { path: "artifact://0:raw:301-" });
 
 		expect(result.details?.totalLines).toBe(400);
+	});
+
+	it("reports an oversized selected line instead of sending a looping continuation selector", async () => {
+		await Bun.write(path.join(artifactDir, "0.mcp.log"), oversizedSelectedLineArtifact());
+
+		const result = await tool.execute("call-oversized-selected", { path: "artifact://0:2-2" });
+		const output = getTextOutput(result);
+
+		expect(output).toContain("leading-context");
+		expect(output).toContain("Line 2 is 68.4KB");
+		expect(output).toContain("50.0KB read budget");
+		expect(output).toContain("artifact://0:raw:2-2");
+		const truncation = result.details?.meta?.truncation;
+		expect(truncation?.totalBytes).toBeGreaterThan(70_000);
+		expect(truncation?.nextOffset).toBeUndefined();
+		if (!truncation) throw new Error("expected truncation metadata");
+		expect(formatTruncationMetaNotice(truncation)).not.toContain("Use :2 to continue");
+	});
+
+	it("still returns the oversized selected line when a wider range raises the byte budget", async () => {
+		await Bun.write(path.join(artifactDir, "0.mcp.log"), oversizedSelectedLineArtifact());
+
+		const result = await tool.execute("call-wide-oversized-selected", { path: "artifact://0:2-142" });
+		const output = getTextOutput(result);
+
+		expect(output).toContain("oversized-");
+		expect(output).toContain("trailing-two");
+		expect(output).not.toContain("could not fit after preceding context");
+		expect(result.details?.meta?.truncation).toBeUndefined();
+	});
+
+	it("keeps raw oversized-line reads context-free and byte-capped", async () => {
+		await Bun.write(path.join(artifactDir, "0.mcp.log"), oversizedSelectedLineArtifact());
+
+		const result = await tool.execute("call-raw-oversized-selected", { path: "artifact://0:raw:2-2" });
+		const output = getTextOutput(result);
+
+		expect(output).toStartWith("oversized-");
+		expect(output).not.toContain("leading-context");
+		expect(output).not.toContain("trailing-one");
+		expect(result.details?.meta?.truncation?.partialLine).toBe(true);
+		expect(result.details?.meta?.truncation?.shownRange).toEqual({ start: 2, end: 2 });
 	});
 
 	it("tails an artifact with :-N by counting lines first, then streaming only that window", async () => {

--- a/packages/coding-agent/test/tools/read-artifact-large.test.ts
+++ b/packages/coding-agent/test/tools/read-artifact-large.test.ts
@@ -44,6 +44,10 @@ function oversizedSelectedLineArtifact(): string {
 	return ["leading-context", `oversized-${"x".repeat(70_000)}-end`, "trailing-one", "trailing-two"].join("\n");
 }
 
+function byteLimitedRangeArtifact(): string {
+	return Array.from({ length: 100 }, (_, index) => `line-${index + 1} ${"x".repeat(1_016)}`).join("\n");
+}
+
 describe("read tool large artifact handling", () => {
 	let testDir: string;
 	let artifactDir: string;
@@ -113,6 +117,24 @@ describe("read tool large artifact handling", () => {
 		const result = await tool.execute("call-raw-tail", { path: "artifact://0:raw:301-" });
 
 		expect(result.details?.totalLines).toBe(400);
+	});
+
+	it("keeps the continuation when the byte budget stops inside requested artifact content", async () => {
+		await Bun.write(path.join(artifactDir, "0.mcp.log"), byteLimitedRangeArtifact());
+
+		const result = await tool.execute("call-byte-limited-range", { path: "artifact://0:1-100" });
+		const output = getTextOutput(result);
+		const truncation = result.details?.meta?.truncation;
+
+		expect(output).not.toContain("could not fit after preceding context");
+		expect(output).not.toContain("to read that line without context");
+		expect(truncation).toBeDefined();
+		if (!truncation) throw new Error("expected truncation metadata");
+		const shownRange = truncation.shownRange;
+		expect(shownRange).toBeDefined();
+		if (!shownRange) throw new Error("expected shown range");
+		expect(truncation.nextOffset).toBe(shownRange.end + 1);
+		expect(formatTruncationMetaNotice(truncation)).toContain(`Use :${truncation.nextOffset} to continue`);
 	});
 
 	it("reports an oversized selected line instead of sending a looping continuation selector", async () => {

--- a/packages/coding-agent/test/tools/read-raw-range.test.ts
+++ b/packages/coding-agent/test/tools/read-raw-range.test.ts
@@ -77,6 +77,28 @@ describe("read tool raw range exactness", () => {
 		expect(output).toContain("L32");
 	});
 
+	it("keeps the continuation when the byte budget stops inside requested buffered content", async () => {
+		const bufferedFile = path.join(testDir, "buffered-range.txt");
+		await Bun.write(
+			bufferedFile,
+			Array.from({ length: 100 }, (_, index) => `line-${index + 1} ${"x".repeat(1_016)}`).join("\n"),
+		);
+
+		const result = await tool.execute("call-buffered-byte-limited-range", { path: `${bufferedFile}:1-100` });
+		const output = getTextOutput(result);
+		const truncation = result.details?.meta?.truncation;
+
+		expect(output).not.toContain("could not fit after preceding context");
+		expect(output).not.toContain(":raw:");
+		expect(truncation).toBeDefined();
+		if (!truncation) throw new Error("expected truncation metadata");
+		const shownRange = truncation.shownRange;
+		expect(shownRange).toBeDefined();
+		if (!shownRange) throw new Error("expected shown range");
+		expect(truncation.nextOffset).toBe(shownRange.end + 1);
+		expect(formatTruncationMetaNotice(truncation)).toContain(`Use :${truncation.nextOffset} to continue`);
+	});
+
 	it("reports an oversized selected line from a buffered local file with a safe raw recovery selector", async () => {
 		const bufferedFile = path.join(testDir, "buffered-oversized.txt");
 		await Bun.write(

--- a/packages/coding-agent/test/tools/read-raw-range.test.ts
+++ b/packages/coding-agent/test/tools/read-raw-range.test.ts
@@ -77,6 +77,34 @@ describe("read tool raw range exactness", () => {
 		expect(output).toContain("L32");
 	});
 
+	it("reports an oversized selected line from a buffered local file with a safe raw recovery selector", async () => {
+		const bufferedFile = path.join(testDir, "buffered-oversized.txt");
+		await Bun.write(
+			bufferedFile,
+			["leading-context", `oversized-${"x".repeat(70_000)}-end`, "trailing-one", "trailing-two"].join("\n"),
+		);
+
+		const result = await tool.execute("call-buffered-oversized-selected", { path: `${bufferedFile}:2-2` });
+		const output = getTextOutput(result);
+
+		expect(output).toContain("leading-context");
+		expect(output).toContain("Line 2 is 68.4KB");
+		expect(output).toContain("50.0KB read budget");
+		expect(output).toContain(":raw:2-2");
+		const truncation = result.details?.meta?.truncation;
+		expect(truncation?.totalBytes).toBeGreaterThan(70_000);
+		expect(truncation?.nextOffset).toBeUndefined();
+		if (!truncation) throw new Error("expected truncation metadata");
+		expect(formatTruncationMetaNotice(truncation)).not.toContain("Use :2 to continue");
+
+		const recovered = await tool.execute("call-buffered-oversized-raw", { path: `${bufferedFile}:raw:2-2` });
+		const recoveredOutput = getTextOutput(recovered);
+		expect(recoveredOutput).toStartWith("oversized-");
+		expect(recoveredOutput).not.toContain("leading-context");
+		expect(recoveredOutput).not.toContain("trailing-one");
+		expect(recovered.details?.meta?.truncation?.partialLine).toBe(true);
+	});
+
 	it("accounts for the displayed preview when a single raw line exceeds the byte budget", async () => {
 		// Regression #10768: an oversized first line collects no complete line but
 		// still renders a ~50 KB byte-capped preview. The truncation meta used to


### PR DESCRIPTION
## What

- Preserve the first byte-limited source line number and selected-window byte total in both buffered and streaming reads.
- When context consumes the budget before a requested line, report that line’s actual size and budget, recommend a raw same-line selector, and suppress the looping derived continuation offset.
- Add regression coverage for the narrow failure plus wide-range and raw-mode controls, and document the fix in the changelog.

## Why

Fixes #10775.

I reviewed the full diff; this change makes an omitted oversized selected line explicit and points readers to a recovery request that does not repeat the same context-expanded failure.

## Testing

- Direct regression exercise: artifact://0:2-2 previously returned only its leading context; it now names the 68.4KB selected line, reports the 50.0KB budget, recommends artifact://0:raw:2-2, and emits no nextOffset.
- Wide-range control returns the selected line and trailing context; raw:2-2 remains context-free and byte-capped.
- bun test packages/coding-agent/test/tools/read-artifact-large.test.ts packages/coding-agent/test/tools/read-raw-range.test.ts packages/coding-agent/test/tools/strip-output-notice.test.ts — 24 pass, 0 fail.
- bun --cwd=packages/coding-agent run check — oxlint, oxfmt, and tsgo pass.
- Additional streaming-output.test.ts run: 62 pass, 1 pre-existing/environmental SIXEL-disabled sanitizer failure under local Bun 1.3.5 (the repository declares Bun 1.4.0); the changed read and output-notice paths pass.

---

- [x] bun check passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)