### PR TITLE
fix(coding-agent): restore getSupportedThinkingLevels in legacy pi-ai shim

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -107,6 +107,9 @@
 - Fixed WorkPool child sessions crashing during startup while constructing their incremental `yield` tool schema.
 - Commit summaries written in Vietnamese, Korean, and other accented scripts are no longer rejected for exceeding the length limit, and keep their accents as typed.
 - Tool-scoped TTSR rules now match finalized arguments reliably when providers stream short or throttled tool calls ([#10910](https://github.com/can1357/oh-my-pi/issues/10910)).
+### Fixed
+
+- Restored `getSupportedThinkingLevels` in the legacy `pi-ai` shim so extensions importing it from `@earendil-works/pi-ai` (e.g. `@companion-ai/feynman`) pass Bun's named-export check and load ([#10800](https://github.com/can1357/oh-my-pi/issues/10800)).
 
 ## [18.1.10] - 2026-09-04
 

--- a/packages/coding-agent/src/extensibility/legacy-pi-ai-shim.ts
+++ b/packages/coding-agent/src/extensibility/legacy-pi-ai-shim.ts
@@ -29,7 +29,7 @@ import {
 	streamSimple,
 } from "@oh-my-pi/pi-ai";
 import type { Effort } from "@oh-my-pi/pi-catalog/effort";
-import { clampThinkingLevelForModel } from "@oh-my-pi/pi-catalog/model-thinking";
+import { clampThinkingLevelForModel, getSupportedEfforts } from "@oh-my-pi/pi-catalog/model-thinking";
 import {
 	calculateCost,
 	getBundledModel,
@@ -86,6 +86,20 @@ export function StringEnum<T extends string | number>(
 export function clampThinkingLevel<TApi extends Api>(model: Model<TApi>, level: Effort | "off"): Effort | "off" {
 	if (level === "off") return "off";
 	return clampThinkingLevelForModel(model, level) ?? "off";
+}
+
+/**
+ * Enumerate the thinking levels a model supports, mirroring historical pi-ai's
+ * `getSupportedThinkingLevels` (`@earendil-works/pi-ai` `models.ts`). Upstream
+ * returns `["off"]` for non-reasoning models and, for reasoning models, `off`
+ * followed by each selectable effort in canonical order; OMP's baked
+ * `getSupportedEfforts` supplies that effort ladder directly. Legacy `/thinking`
+ * menus (e.g. `@companion-ai/feynman`) call this to list the levels a user may
+ * pick for the active model.
+ */
+export function getSupportedThinkingLevels<TApi extends Api>(model: Model<TApi>): (Effort | "off")[] {
+	if (!model.reasoning) return ["off"];
+	return ["off", ...getSupportedEfforts(model)];
 }
 
 /**

--- a/packages/coding-agent/test/extensibility/legacy-pi-ai-type-remap.test.ts
+++ b/packages/coding-agent/test/extensibility/legacy-pi-ai-type-remap.test.ts
@@ -174,6 +174,26 @@ describe("legacy-pi @(scope)/pi-ai root `Type` remap (issue #1437)", () => {
 		expect(loaded.quota).toBe(false);
 		expect(loaded.ok).toBe(false);
 	});
+
+	it("exports getSupportedThinkingLevels for legacy thinking menus (issue #10800)", async () => {
+		// `@earendil-works/pi-ai` exports getSupportedThinkingLevels from its
+		// package root (models.ts). Plugins such as `@companion-ai/feynman`
+		// import it to build their `/thinking` level menu, so a missing shim
+		// export surfaced as a plain
+		// `Export named 'getSupportedThinkingLevels' not found` at load time.
+		const loaded = (await loadLegacyPiModule(
+			await writeFixtureExtension(
+				[
+					'import { getSupportedThinkingLevels } from "@earendil-works/pi-ai";',
+					"export const reasoning = getSupportedThinkingLevels({ reasoning: true, thinking: { efforts: ['low', 'high', 'max'] } });",
+					"export const nonReasoning = getSupportedThinkingLevels({ reasoning: false });",
+				].join("\n"),
+			),
+		)) as { reasoning: string[]; nonReasoning: string[] };
+
+		expect(loaded.reasoning).toEqual(["off", "low", "high", "max"]);
+		expect(loaded.nonReasoning).toEqual(["off"]);
+	});
 });
 
 describe("legacy pi package root remaps (issue #1474)", () => {


### PR DESCRIPTION
## Repro
OMP redirects `@earendil-works/pi-ai` root imports to `legacy-pi-ai-shim.ts`. An extension importing `getSupportedThinkingLevels` from that root (e.g. `@companion-ai/feynman@0.3.47`, whose `/thinking` command calls `getSupportedThinkingLevels(ctx.model)`) fails Bun's static named-export check and never loads. Reproduced by loading a fixture extension through `loadLegacyPiModule`:

```
bun test test/extensibility/legacy-pi-ai-type-remap.test.ts -t getSupportedThinkingLevels
```

Before the fix: `SyntaxError: Export named 'getSupportedThinkingLevels' not found in module '.../legacy-pi-ai-shim.ts'.`

## Cause
`packages/coding-agent/src/extensibility/legacy-pi-ai-shim.ts` re-exports the pi-ai surface plus a hand-audited set of bridged symbols (`clampThinkingLevel`, `isRetryableAssistantError`, `isContextOverflow`, …) but never bridged `getSupportedThinkingLevels`. Upstream `@earendil-works/pi-ai` exports it from `models.ts` (verified in `0.84.2` and `0.85.0`), so the shim's omission — not upstream — breaks the import. Same class as #6847 (`isRetryableAssistantError`) and #6648 (`clampThinkingLevel`).

## Fix
- Add `getSupportedThinkingLevels<TApi>(model)` to `legacy-pi-ai-shim.ts`, mirroring upstream's contract: `["off"]` for non-reasoning models, and `off` followed by the model's supported efforts (canonical order) for reasoning models, sourced from OMP's baked `getSupportedEfforts`.
- Import `getSupportedEfforts` alongside the existing `clampThinkingLevelForModel` from `@oh-my-pi/pi-catalog/model-thinking`.
- Add a regression test in `legacy-pi-ai-type-remap.test.ts` loading the symbol through `@earendil-works/pi-ai`.
- Changelog entry under `[Unreleased]`.

## Verification
`bun test test/extensibility/legacy-pi-ai-type-remap.test.ts -t getSupportedThinkingLevels` passes; the reasoning model returns `["off","low","high","max"]` and the non-reasoning model returns `["off"]`. `bun check` is clean across all packages. The 4 unrelated failures in the same test file's issue-#1474 block are pre-existing in a fresh worktree: they need the generated `src/export/html/tool-views.generated.js` (produced by `gen:tool-views`/`prepack`), which is absent before a build and independent of this change. Fixes #10800