### PR TITLE
fix(session): preserve codex identity across resumes

### DIFF
--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -489,6 +489,11 @@ interface CodexProviderSessionState extends ProviderSessionState {
 
 /** Request classification encoded in Codex turn metadata. */
 export type OpenAICodexRequestKind = "turn" | "prewarm" | "compaction";
+/** Durable Codex conversation identity restored by hosts across process lifetimes. */
+export interface OpenAICodexSessionIdentity {
+	threadId: string;
+	windowId: string;
+}
 
 interface CodexMetadataSessionState {
 	sessionId: string;
@@ -546,11 +551,14 @@ const CODEX_RESERVED_METADATA_KEYS: Record<string, true> = {
 	workspaces: true,
 };
 
-function createCodexMetadataSessionState(sessionId: string): CodexMetadataSessionState {
+function createCodexMetadataSessionState(
+	sessionId: string,
+	identity?: Readonly<OpenAICodexSessionIdentity>,
+): CodexMetadataSessionState {
 	return {
 		sessionId,
-		threadId: crypto.randomUUID(),
-		windowId: crypto.randomUUID(),
+		threadId: identity?.threadId ?? crypto.randomUUID(),
+		windowId: identity?.windowId ?? crypto.randomUUID(),
 		turnStates: new Map(),
 	};
 }
@@ -565,6 +573,32 @@ function getOrCreateCodexMetadataSessionState(
 	const created = createCodexMetadataSessionState(sessionId);
 	providerState.metadataSessions.set(sessionId, created);
 	return created;
+}
+function codexSessionIdentity(session: CodexMetadataSessionState): OpenAICodexSessionIdentity {
+	return {
+		threadId: session.threadId,
+		windowId: session.windowId,
+	};
+}
+
+/**
+ * Restore a durable Codex identity into process-local provider state, or create
+ * the identity that a host must persist before its first request.
+ */
+export function ensureOpenAICodexSessionIdentity(options: {
+	providerSessionState: Map<string, ProviderSessionState>;
+	sessionId: string;
+	identity?: Readonly<OpenAICodexSessionIdentity>;
+}): OpenAICodexSessionIdentity | undefined {
+	const sessionId = normalizeOpenAIPromptCacheKey(options.sessionId);
+	if (!sessionId) return undefined;
+	const providerState = getCodexProviderSessionState(options.providerSessionState);
+	if (!providerState) return undefined;
+	const existing = providerState.metadataSessions.get(sessionId);
+	if (existing) return codexSessionIdentity(existing);
+	const created = createCodexMetadataSessionState(sessionId, options.identity);
+	providerState.metadataSessions.set(sessionId, created);
+	return codexSessionIdentity(created);
 }
 
 function getOrCreateCodexTurnState(
@@ -762,19 +796,22 @@ export function createOpenAICodexCompatibilityMetadata(
  * Invalidate Codex history-dependent transport state after compaction while
  * retaining the session identity and live connection.
  */
-export function resetOpenAICodexHistoryAfterCompaction(options: OpenAICodexCompactionResetOptions): void {
+export function resetOpenAICodexHistoryAfterCompaction(
+	options: OpenAICodexCompactionResetOptions,
+): OpenAICodexSessionIdentity | undefined {
 	const providerState = options.providerSessionState?.get(CODEX_PROVIDER_SESSION_STATE_KEY);
-	if (!isCodexProviderSessionState(providerState)) return;
+	if (!isCodexProviderSessionState(providerState)) return undefined;
 	for (const websocketState of providerState.webSocketSessions.values()) {
 		resetCodexWebSocketAppendState(websocketState);
 	}
 	const sessionId = normalizeOpenAIPromptCacheKey(options.sessionId);
-	if (!sessionId) return;
+	if (!sessionId) return undefined;
 	const metadataSession = providerState.metadataSessions.get(sessionId);
-	if (!metadataSession) return;
+	if (!metadataSession) return undefined;
 	metadataSession.windowId = crypto.randomUUID();
 	metadataSession.compactionOperationId = undefined;
 	metadataSession.reuseTurnForNextRequest = options.compaction.phase !== "standalone_turn";
+	return codexSessionIdentity(metadataSession);
 }
 
 interface CodexRequestContext {

--- a/packages/ai/test/openai-codex-stream.test.ts
+++ b/packages/ai/test/openai-codex-stream.test.ts
@@ -3151,7 +3151,7 @@ describe("openai-codex streaming", () => {
 		expect(websocketInstances[1]?.readyState).toBe(MockWebSocket.CLOSED);
 		expect(websocketInstances[1]?.options?.headers?.["x-codex-turn-state"]).toBe("ws-turn-state-1");
 		expect(websocketInstances[1]?.options?.headers?.["x-models-etag"]).toBe("models-etag-1");
-		resetOpenAICodexHistoryAfterCompaction({
+		const rotatedIdentity = resetOpenAICodexHistoryAfterCompaction({
 			providerSessionState,
 			sessionId: "ws-handshake-session",
 			compaction: midTurnCompaction,
@@ -3236,7 +3236,13 @@ describe("openai-codex streaming", () => {
 			request_kind: "turn",
 			turn_started_at_unix_ms: context.messages[0]?.timestamp,
 		});
-		expect(typeof continuationMetadata["x-codex-window-id"]).toBe("string");
+		const firstThreadId = firstMetadata.thread_id;
+		const continuationWindowId = continuationMetadata["x-codex-window-id"];
+		if (typeof firstThreadId !== "string" || typeof continuationWindowId !== "string") {
+			throw new Error("expected Codex thread and window identity");
+		}
+		expect(rotatedIdentity?.threadId).toBe(firstThreadId);
+		expect(rotatedIdentity?.windowId).toBe(continuationWindowId);
 		expect(continuationMetadata["x-codex-window-id"]).not.toBe(firstMetadata["x-codex-window-id"]);
 		expect(firstMetadata.session_id).toBe(continuationHeaders.get("session-id"));
 		expect(firstMetadata.thread_id).toBe(continuationHeaders.get("thread-id"));

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Preserved Codex thread and window identity when resuming a session, retaining provider affinity and prompt-cache reuse ([#10799](https://github.com/can1357/oh-my-pi/issues/10799)).
+
 ## [18.1.10] - 2026-09-04
 
 ### Changed

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1343,18 +1343,20 @@ export class AgentSession {
 			}
 		});
 		this.#detachUsageBeforeModelCall = this.agent.addBeforeModelCallHook(async signal => {
+			if (this.settings.get("retry.usageAwareFallback")) {
+				let preflightRequired = true;
+				if (this.#usagePreflightReadyForNextModelCall) {
+					const checkedModel = this.#usagePreflightReadyModel;
+					this.#usagePreflightReadyForNextModelCall = false;
+					this.#usagePreflightReadyModel = undefined;
+					preflightRequired = checkedModel !== this.model;
+				}
+				if (preflightRequired && !(await this.#runUsageAwarePreflight(signal))) {
+					signal?.throwIfAborted();
+					throw new DOMException("Usage preflight cancelled", "AbortError");
+				}
+			}
 			this.#ensureCodexSessionIdentity();
-			if (!this.settings.get("retry.usageAwareFallback")) return;
-			if (this.#usagePreflightReadyForNextModelCall) {
-				const checkedModel = this.#usagePreflightReadyModel;
-				this.#usagePreflightReadyForNextModelCall = false;
-				this.#usagePreflightReadyModel = undefined;
-				if (checkedModel === this.model) return;
-			}
-			if (!(await this.#runUsageAwarePreflight(signal))) {
-				signal?.throwIfAborted();
-				throw new DOMException("Usage preflight cancelled", "AbortError");
-			}
 		});
 		const statsHost: SessionStatsTrackerHost = {
 			session: this,

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -76,7 +76,11 @@ import type {
 } from "@oh-my-pi/pi-ai";
 import { type Effort, streamSimple } from "@oh-my-pi/pi-ai";
 import * as AIError from "@oh-my-pi/pi-ai/error";
-import { resetOpenAICodexHistoryAfterCompaction } from "@oh-my-pi/pi-ai/providers/openai-codex-responses";
+import {
+	ensureOpenAICodexSessionIdentity,
+	type OpenAICodexSessionIdentity,
+	resetOpenAICodexHistoryAfterCompaction,
+} from "@oh-my-pi/pi-ai/providers/openai-codex-responses";
 import { toolWireSchema } from "@oh-my-pi/pi-ai/utils/schema";
 import { preferredDialect } from "@oh-my-pi/pi-catalog/identity";
 import { modelsAreEqual } from "@oh-my-pi/pi-catalog/models";
@@ -346,7 +350,7 @@ import {
 import type { BuildSessionContextOptions, SessionContext } from "./session-context";
 import { getRestorableSessionModels } from "./session-context";
 import { formatSessionDumpText } from "./session-dump-format";
-import type { BranchSummaryEntry, NewSessionOptions } from "./session-entries";
+import type { BranchSummaryEntry, NewSessionOptions, SessionEntry } from "./session-entries";
 import { SessionHandoff, type SessionHandoffHost } from "./session-handoff";
 import {
 	COMPACTION_CHECK_NONE,
@@ -378,6 +382,20 @@ import { TodoTracker, type TodoTrackerHost } from "./todo-tracker";
 import { TtsrCoordinator, type TtsrCoordinatorHost } from "./ttsr-coordinator";
 
 const PLAN_MODE_REMINDER_MAX = 3;
+const CODEX_SESSION_IDENTITY_ENTRY_TYPE = "openai-codex-session-identity";
+
+function persistedCodexSessionIdentity(entries: readonly SessionEntry[]): OpenAICodexSessionIdentity | undefined {
+	for (let i = entries.length - 1; i >= 0; i--) {
+		const entry = entries[i];
+		if (entry?.type !== "custom" || entry.customType !== CODEX_SESSION_IDENTITY_ENTRY_TYPE) continue;
+		if (!isRecord(entry.data)) return undefined;
+		const threadId = stringProperty(entry.data, "threadId");
+		const windowId = stringProperty(entry.data, "windowId");
+		return threadId && windowId ? { threadId, windowId } : undefined;
+	}
+	return undefined;
+}
+
 const POST_PROMPT_DRAIN_TIMEOUT_MS = 5_000;
 
 /** Internal marker for hook messages queued through the agent loop */
@@ -709,6 +727,7 @@ export class AgentSession {
 	#usagePreflightReadyModel: Model | undefined;
 	#detachUsageBeforeQueueDequeue: (() => void) | undefined;
 	#detachUsageBeforeModelCall: (() => void) | undefined;
+	#codexSessionIdentityKey: string | undefined;
 
 	#transformContext: (messages: AgentMessage[], signal?: AbortSignal) => AgentMessage[] | Promise<AgentMessage[]>;
 	#onPayload: SimpleStreamOptions["onPayload"] | undefined;
@@ -1324,6 +1343,7 @@ export class AgentSession {
 			}
 		});
 		this.#detachUsageBeforeModelCall = this.agent.addBeforeModelCallHook(async signal => {
+			this.#ensureCodexSessionIdentity();
 			if (!this.settings.get("retry.usageAwareFallback")) return;
 			if (this.#usagePreflightReadyForNextModelCall) {
 				const checkedModel = this.#usagePreflightReadyModel;
@@ -1607,6 +1627,7 @@ export class AgentSession {
 		this.agent.beforeToolCall = (ctx, signal) => this.#beforeToolCall(ctx, signal);
 		this.agent.providerSessionState = this.#providerSessionState;
 		this.#syncAgentSessionId();
+		this.#ensureCodexSessionIdentity({ restoreOnly: true });
 		this.#todo.syncFromBranch();
 		this.#goalRuntime = new GoalRuntime({
 			getState: () => this.#goalModeState,
@@ -4261,6 +4282,28 @@ export class AgentSession {
 		}
 	}
 
+	#recordCodexSessionIdentity(identity: OpenAICodexSessionIdentity): void {
+		const persisted = persistedCodexSessionIdentity(this.sessionManager.getBranch());
+		if (persisted?.threadId === identity.threadId && persisted.windowId === identity.windowId) return;
+		this.sessionManager.appendCustomEntry(CODEX_SESSION_IDENTITY_ENTRY_TYPE, identity);
+	}
+
+	#ensureCodexSessionIdentity(options?: { fresh?: boolean; restoreOnly?: boolean }): void {
+		if (this.model?.api !== "openai-codex-responses") return;
+		const sessionId = this.sessionId;
+		if (!options?.fresh && this.#codexSessionIdentityKey === sessionId) return;
+		const persisted = options?.fresh ? undefined : persistedCodexSessionIdentity(this.sessionManager.getBranch());
+		if (options?.restoreOnly && !persisted) return;
+		const identity = ensureOpenAICodexSessionIdentity({
+			providerSessionState: this.#providerSessionState,
+			sessionId,
+			identity: persisted,
+		});
+		if (!identity) return;
+		this.#codexSessionIdentityKey = sessionId;
+		if (!persisted) this.#recordCodexSessionIdentity(identity);
+	}
+
 	/**
 	 * Set agent.sessionId from the session manager and install a dynamic
 	 * metadata resolver so every Anthropic API request carries
@@ -4666,6 +4709,7 @@ export class AgentSession {
 		}
 
 		this.#providerSessionState.clear();
+		this.#codexSessionIdentityKey = undefined;
 	}
 
 	freshSession(): FreshSessionResult | undefined {
@@ -4675,6 +4719,7 @@ export class AgentSession {
 		this.#closeAllProviderSessions("fresh session");
 		this.#freshProviderSessionId = Bun.randomUUIDv7();
 		this.#syncAgentSessionId();
+		this.#ensureCodexSessionIdentity({ fresh: true });
 		this.#memory.rekeyForCurrentSessionId();
 		this.agent.appendOnlyContext?.invalidateForModelChange();
 		return {
@@ -4752,6 +4797,7 @@ export class AgentSession {
 		this.#closeAllProviderSessions("reset context");
 		this.#freshProviderSessionId = Bun.randomUUIDv7();
 		this.#syncAgentSessionId();
+		this.#ensureCodexSessionIdentity({ fresh: true });
 		this.#memory.rekeyForCurrentSessionId();
 		this.agent.appendOnlyContext?.invalidateForModelChange();
 
@@ -8255,11 +8301,12 @@ export class AgentSession {
 	}
 
 	#resetCodexProviderAfterCompaction(compaction: CodexCompactionContext): void {
-		resetOpenAICodexHistoryAfterCompaction({
+		const identity = resetOpenAICodexHistoryAfterCompaction({
 			providerSessionState: this.#providerSessionState,
 			sessionId: this.sessionId,
 			compaction,
 		});
+		if (identity) this.#recordCodexSessionIdentity(identity);
 	}
 
 	#resetCurrentResponsesProviderSession(reason: string): void {
@@ -8305,6 +8352,7 @@ export class AgentSession {
 		const providerKeys = new Set<string>();
 		if (currentModel.api === "openai-codex-responses" || nextModel.api === "openai-codex-responses") {
 			providerKeys.add("openai-codex-responses");
+			this.#codexSessionIdentityKey = undefined;
 		}
 		if (currentModel.api === "openai-responses") {
 			providerKeys.add(`openai-responses:${currentModel.provider}`);

--- a/packages/coding-agent/test/session-codex-identity.test.ts
+++ b/packages/coding-agent/test/session-codex-identity.test.ts
@@ -1,0 +1,143 @@
+import { expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import { Agent } from "@oh-my-pi/pi-agent-core";
+import type { AssistantMessage } from "@oh-my-pi/pi-ai";
+import { createOpenAICodexCompatibilityMetadata } from "@oh-my-pi/pi-ai/providers/openai-codex-responses";
+import { AssistantMessageEventStream } from "@oh-my-pi/pi-ai/utils/event-stream";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { convertToLlm } from "@oh-my-pi/pi-coding-agent/session/messages";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+const CODEX_MODEL = getBundledModel("openai-codex", "gpt-5.6-terra");
+if (!CODEX_MODEL || CODEX_MODEL.api !== "openai-codex-responses") {
+	throw new Error("Expected the bundled Codex test model");
+}
+
+interface ObservedRequest {
+	sessionId: string | undefined;
+	promptCacheKey: string | undefined;
+	threadId: string;
+	windowId: string;
+	turnId: string;
+	messages: string[];
+}
+
+function createSession(
+	sessionManager: SessionManager,
+	authStorage: AuthStorage,
+	observed: ObservedRequest[],
+): AgentSession {
+	const modelRegistry = new ModelRegistry(authStorage);
+	const agent = new Agent({
+		initialState: {
+			model: CODEX_MODEL,
+			systemPrompt: ["Test"],
+			tools: [],
+			messages: sessionManager.buildSessionContext().messages,
+		},
+		promptCacheKey: sessionManager.getSessionId(),
+		getApiKey: () => "test-key",
+		convertToLlm,
+		streamFn: (_model, context, options) => {
+			const providerSessionState = options?.providerSessionState;
+			const sessionId = options?.sessionId;
+			if (!providerSessionState || !sessionId) throw new Error("Expected Codex session options");
+			const metadata = createOpenAICodexCompatibilityMetadata({
+				providerSessionState,
+				sessionId,
+				requestKind: "turn",
+			}).clientMetadata;
+			observed.push({
+				sessionId,
+				promptCacheKey: options.promptCacheKey,
+				threadId: metadata.thread_id,
+				windowId: metadata["x-codex-window-id"],
+				turnId: metadata.turn_id,
+				messages: context.messages.map(message => JSON.stringify(message)),
+			});
+			const message: AssistantMessage = {
+				role: "assistant",
+				content: [{ type: "text", text: "Done." }],
+				api: CODEX_MODEL.api,
+				provider: CODEX_MODEL.provider,
+				model: CODEX_MODEL.id,
+				usage: {
+					input: 0,
+					output: 0,
+					cacheRead: 0,
+					cacheWrite: 0,
+					totalTokens: 0,
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+				},
+				stopReason: "stop",
+				timestamp: Date.now(),
+			};
+			const stream = new AssistantMessageEventStream();
+			queueMicrotask(() => {
+				stream.push({ type: "start", partial: message });
+				stream.push({ type: "done", reason: "stop", message });
+			});
+			return stream;
+		},
+	});
+	const settings = Settings.isolated({
+		"async.enabled": false,
+		"compaction.enabled": false,
+		"marketplace.autoUpdate": "off",
+		"todo.enabled": false,
+	});
+	settings.setModelRole("default", `${CODEX_MODEL.provider}/${CODEX_MODEL.id}`);
+	return new AgentSession({
+		agent,
+		sessionManager,
+		settings,
+		modelRegistry,
+		toolRegistry: new Map(),
+	});
+}
+
+it("preserves Codex thread and window identity across a persisted session resume", async () => {
+	using tempDir = TempDir.createSync("@omp-codex-session-identity-");
+	const cwd = tempDir.join("project");
+	const sessionDir = tempDir.join("sessions");
+	await fs.mkdir(cwd, { recursive: true });
+	await fs.mkdir(sessionDir, { recursive: true });
+	const authStorage = await AuthStorage.create(tempDir.join("auth.db"));
+	authStorage.setRuntimeApiKey("openai-codex", "test-key");
+	const observed: ObservedRequest[] = [];
+	let firstSession: AgentSession | undefined;
+	let resumedSession: AgentSession | undefined;
+	try {
+		const firstManager = SessionManager.create(cwd, sessionDir);
+		await firstManager.ensureOnDisk();
+		firstSession = createSession(firstManager, authStorage, observed);
+		await firstSession.prompt("before exit");
+		const sessionFile = firstManager.getSessionFile();
+		if (!sessionFile) throw new Error("Expected persisted session file");
+		await firstSession.dispose();
+		firstSession = undefined;
+
+		const resumedManager = await SessionManager.open(sessionFile, sessionDir);
+		resumedSession = createSession(resumedManager, authStorage, observed);
+		await resumedSession.prompt("after resume");
+
+		expect(observed).toHaveLength(2);
+		const before = observed[0]!;
+		const resumed = observed[1]!;
+		expect(resumed.sessionId).toBe(before.sessionId);
+		expect(resumed.promptCacheKey).toBe(before.promptCacheKey);
+		expect(resumed.threadId).toBe(before.threadId);
+		expect(resumed.windowId).toBe(before.windowId);
+		expect(resumed.turnId).not.toBe(before.turnId);
+		expect(resumed.messages.slice(0, before.messages.length)).toEqual(before.messages);
+	} finally {
+		await firstSession?.dispose();
+		await resumedSession?.dispose();
+		authStorage.close();
+	}
+});

--- a/packages/coding-agent/test/session-codex-identity.test.ts
+++ b/packages/coding-agent/test/session-codex-identity.test.ts
@@ -1,7 +1,7 @@
-import { expect, it } from "bun:test";
+import { expect, it, vi } from "bun:test";
 import * as fs from "node:fs/promises";
 import { Agent } from "@oh-my-pi/pi-agent-core";
-import type { AssistantMessage } from "@oh-my-pi/pi-ai";
+import type { AssistantMessage, Model } from "@oh-my-pi/pi-ai";
 import { createOpenAICodexCompatibilityMetadata } from "@oh-my-pi/pi-ai/providers/openai-codex-responses";
 import { AssistantMessageEventStream } from "@oh-my-pi/pi-ai/utils/event-stream";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
@@ -31,11 +31,13 @@ function createSession(
 	sessionManager: SessionManager,
 	authStorage: AuthStorage,
 	observed: ObservedRequest[],
+	options: { model?: Model; settings?: Settings } = {},
 ): AgentSession {
+	const model = options.model ?? CODEX_MODEL;
 	const modelRegistry = new ModelRegistry(authStorage);
 	const agent = new Agent({
 		initialState: {
-			model: CODEX_MODEL,
+			model,
 			systemPrompt: ["Test"],
 			tools: [],
 			messages: sessionManager.buildSessionContext().messages,
@@ -43,10 +45,12 @@ function createSession(
 		promptCacheKey: sessionManager.getSessionId(),
 		getApiKey: () => "test-key",
 		convertToLlm,
-		streamFn: (_model, context, options) => {
-			const providerSessionState = options?.providerSessionState;
-			const sessionId = options?.sessionId;
-			if (!providerSessionState || !sessionId) throw new Error("Expected Codex session options");
+		streamFn: (requestModel, context, streamOptions) => {
+			const providerSessionState = streamOptions?.providerSessionState;
+			const sessionId = streamOptions?.sessionId;
+			if (!providerSessionState || !sessionId || requestModel.api !== "openai-codex-responses") {
+				throw new Error("Expected Codex session options");
+			}
 			const metadata = createOpenAICodexCompatibilityMetadata({
 				providerSessionState,
 				sessionId,
@@ -54,7 +58,7 @@ function createSession(
 			}).clientMetadata;
 			observed.push({
 				sessionId,
-				promptCacheKey: options.promptCacheKey,
+				promptCacheKey: streamOptions.promptCacheKey,
 				threadId: metadata.thread_id,
 				windowId: metadata["x-codex-window-id"],
 				turnId: metadata.turn_id,
@@ -63,9 +67,9 @@ function createSession(
 			const message: AssistantMessage = {
 				role: "assistant",
 				content: [{ type: "text", text: "Done." }],
-				api: CODEX_MODEL.api,
-				provider: CODEX_MODEL.provider,
-				model: CODEX_MODEL.id,
+				api: requestModel.api,
+				provider: requestModel.provider,
+				model: requestModel.id,
 				usage: {
 					input: 0,
 					output: 0,
@@ -85,13 +89,15 @@ function createSession(
 			return stream;
 		},
 	});
-	const settings = Settings.isolated({
-		"async.enabled": false,
-		"compaction.enabled": false,
-		"marketplace.autoUpdate": "off",
-		"todo.enabled": false,
-	});
-	settings.setModelRole("default", `${CODEX_MODEL.provider}/${CODEX_MODEL.id}`);
+	const settings =
+		options.settings ??
+		Settings.isolated({
+			"async.enabled": false,
+			"compaction.enabled": false,
+			"marketplace.autoUpdate": "off",
+			"todo.enabled": false,
+		});
+	settings.setModelRole("default", `${model.provider}/${model.id}`);
 	return new AgentSession({
 		agent,
 		sessionManager,
@@ -101,7 +107,7 @@ function createSession(
 	});
 }
 
-it("preserves Codex thread and window identity across a persisted session resume", async () => {
+it("persists Codex identity after usage preflight switches models and across resume", async () => {
 	using tempDir = TempDir.createSync("@omp-codex-session-identity-");
 	const cwd = tempDir.join("project");
 	const sessionDir = tempDir.join("sessions");
@@ -109,13 +115,46 @@ it("preserves Codex thread and window identity across a persisted session resume
 	await fs.mkdir(sessionDir, { recursive: true });
 	const authStorage = await AuthStorage.create(tempDir.join("auth.db"));
 	authStorage.setRuntimeApiKey("openai-codex", "test-key");
+	authStorage.setRuntimeApiKey("anthropic", "test-key");
 	const observed: ObservedRequest[] = [];
+	const primaryModel = getBundledModel("anthropic", "claude-sonnet-4-5");
+	if (!primaryModel) throw new Error("Expected the bundled primary test model");
+	const fallbackSettings = Settings.isolated({
+		"async.enabled": false,
+		"compaction.enabled": false,
+		"marketplace.autoUpdate": "off",
+		"retry.usageAwareFallback": true,
+		"retry.usageReservePolicy": "auto",
+		"retry.fallbackChains": {
+			default: [`${CODEX_MODEL.provider}/${CODEX_MODEL.id}`],
+		},
+		"todo.enabled": false,
+	});
+	vi.spyOn(authStorage, "getModelUsageHealth").mockImplementation(async provider =>
+		provider === primaryModel.provider
+			? {
+					state: "reserve",
+					accounts: [
+						{
+							credentialId: 1,
+							credentialType: "oauth",
+							selected: true,
+							state: "reserve",
+							remainingFraction: 0.05,
+						},
+					],
+				}
+			: { state: "healthy", accounts: [] },
+	);
 	let firstSession: AgentSession | undefined;
 	let resumedSession: AgentSession | undefined;
 	try {
 		const firstManager = SessionManager.create(cwd, sessionDir);
 		await firstManager.ensureOnDisk();
-		firstSession = createSession(firstManager, authStorage, observed);
+		firstSession = createSession(firstManager, authStorage, observed, {
+			model: primaryModel,
+			settings: fallbackSettings,
+		});
 		await firstSession.prompt("before exit");
 		const sessionFile = firstManager.getSessionFile();
 		if (!sessionFile) throw new Error("Expected persisted session file");
@@ -139,5 +178,6 @@ it("preserves Codex thread and window identity across a persisted session resume
 		await firstSession?.dispose();
 		await resumedSession?.dispose();
 		authStorage.close();
+		vi.restoreAllMocks();
 	}
 });


### PR DESCRIPTION
## Repro
A persisted Codex session was exercised through two independent `AgentSession` lifetimes with the same session ID and prompt-cache key. Before the fix, the second lifetime retained `session_id` but reminted `thread_id` and `x-codex-window-id`; the executable regression is `bun test packages/coding-agent/test/session-codex-identity.test.ts`.

## Cause
`createCodexMetadataSessionState` in `packages/ai/src/providers/openai-codex-responses.ts` generated thread/window UUIDs inside the process-local `ProviderSessionState` map. `AgentSession` restored its logical session and prompt-cache identity from disk, but had no durable Codex identity to seed into a new provider-state map.

## Fix
- Expose a typed Codex identity seed/snapshot boundary in the provider and return the rotated identity after compaction.
- Journal the active thread/window identity as hidden session state, restore it before startup prewarm and model calls, and persist compaction rotations.
- Add a two-lifetime session regression covering stable session, cache, thread, and window IDs; a fresh turn ID; and append-only history.
- Document the user-visible fix in the coding-agent changelog.

## Verification
`bun test packages/ai/test/openai-codex-stream.test.ts packages/ai/test/openai-codex-responses-lite.test.ts` passed 130 tests; `bun test packages/coding-agent/test/session-codex-identity.test.ts packages/ai/test/openai-codex-stream.test.ts -t "preserves Codex thread and window identity|isolates compaction transport"` passed 2 focused regressions; `bun check` passed.

Fixes #10799