### PR TITLE
fix(input): wait for first queued item before draining the rest

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Queue shorthand (`->`/`=>`) submitted on an idle session with an existing transcript now delivers items one per yield in order, instead of draining the whole queue at once and sending item 2 before item 1 ([#10802](https://github.com/can1357/oh-my-pi/issues/10802)).
+
 ## [18.1.10] - 2026-09-04
 
 ### Changed

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -1368,14 +1368,24 @@ export class InputController {
 		try {
 			if (startImmediately && this.ctx.onInputCallback) {
 				const first = messages[0] ?? "";
+				const dispatched = Promise.withResolvers<void>();
 				const submission = this.ctx.startPendingSubmission({
 					text: first,
 					images,
 					imageLinks,
 					streamingBehavior: "followUp",
 				});
+				submission.onSettled = dispatched.resolve;
 				this.ctx.onInputCallback(submission);
 				queuedCount = 1;
+				// onInputCallback only resolves the run loop's input promise; the
+				// session.prompt() for the first item runs later, so the session is still
+				// idle here. Enqueuing the remaining follow-ups now would let the idle
+				// queue-drain start a turn from item 2 before item 1 is in flight —
+				// inverting delivery order on a mid-session transcript (issue #10802).
+				// Wait until the first item's turn has actually started (or its dispatch
+				// settled) so the follow-ups queue behind a streaming session instead.
+				await dispatched.promise;
 			}
 			while (queuedCount < messages.length) {
 				const message = messages[queuedCount] ?? "";

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -2030,6 +2030,9 @@ export class InteractiveMode implements InteractiveModeContext {
 		const preserveDraft = this.#pendingSubmissionPreservesDraft;
 
 		submission.cancelled = true;
+		// A cancelled first item never starts a turn; unblock a queue-shorthand
+		// dispatch waiting on it so the rest still flush (issue #10802).
+		submission.onSettled?.();
 		this.#pendingSubmittedInput = undefined;
 		this.#pendingSubmissionPreservesDraft = false;
 		this.clearOptimisticUserMessage();
@@ -2111,6 +2114,9 @@ export class InteractiveMode implements InteractiveModeContext {
 				this.#stopLoadingAnimation(true);
 			}
 		}
+		// Unblock a queue-shorthand dispatch waiting on this submission's turn to start
+		// (issue #10802). Idempotent — resolving an already-settled promise is a no-op.
+		input.onSettled?.();
 	}
 
 	#computeEditorMaxHeight(): number {
@@ -5099,7 +5105,11 @@ export class InteractiveMode implements InteractiveModeContext {
 	}
 
 	showError(message: string): void {
+		const submission = this.#pendingSubmittedInput;
 		this.#pendingSubmittedInput = undefined;
+		// Dispatch failed before a turn started; unblock a queue-shorthand dispatch
+		// waiting on this submission (issue #10802).
+		submission?.onSettled?.();
 		this.#pendingSubmissionPreservesDraft = false;
 		this.clearOptimisticUserMessage();
 		this.#pendingWorkingMessage = undefined;

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -73,6 +73,12 @@ export type SubmittedUserInput = {
 	streamingBehavior?: "steer" | "followUp";
 	cancelled: boolean;
 	started: boolean;
+	/** Resolved once dispatch settles — the run loop's `session.prompt()` for this
+	 *  submission has started its turn (session now streaming), the submission was
+	 *  cancelled, or dispatch errored. Queue-shorthand (`->`/`=>`) awaits this before
+	 *  enqueuing the remaining follow-ups so their idle queue-drain cannot start a
+	 *  turn from item 2 before item 1 is in flight (issue #10802). */
+	onSettled?: () => void;
 };
 
 export type TodoStatus = "pending" | "in_progress" | "completed" | "abandoned" | "blocked";

--- a/packages/coding-agent/test/input-controller-slash-history.test.ts
+++ b/packages/coding-agent/test/input-controller-slash-history.test.ts
@@ -16,7 +16,11 @@ function makeCtx(isStreaming = false) {
 	const followUp = vi.fn(async (_text: string, _images?: ImageContent[]) => {});
 	const steer = vi.fn(async (_text: string, _images?: ImageContent[]) => {});
 	const prompt = vi.fn(async () => false);
-	const onInputCallback = vi.fn();
+	// Mirror the run loop: accepting the submission dispatches its turn and settles
+	// it. Queue-shorthand awaits this settle before enqueuing the rest (#10802).
+	const onInputCallback = vi.fn((submission?: { onSettled?: () => void }) => {
+		submission?.onSettled?.();
+	});
 	let text = "";
 	const editor = {
 		onSubmit: undefined as undefined | ((t: string) => Promise<void>),

--- a/packages/coding-agent/test/queue-shorthand-idle-drain.test.ts
+++ b/packages/coding-agent/test/queue-shorthand-idle-drain.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as path from "node:path";
+import { Agent } from "@oh-my-pi/pi-agent-core";
+import type { Context, ImageContent } from "@oh-my-pi/pi-ai";
+import { createMockModel } from "@oh-my-pi/pi-ai/providers/mock";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { InputController } from "@oh-my-pi/pi-coding-agent/modes/controllers/input-controller";
+import type { InteractiveModeContext, SubmittedUserInput } from "@oh-my-pi/pi-coding-agent/modes/types";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { convertToLlm } from "@oh-my-pi/pi-coding-agent/session/messages";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+/** Newest user-authored text in a provider context — the message that triggered the turn. */
+function lastUserText(context: Context): string {
+	for (let i = context.messages.length - 1; i >= 0; i--) {
+		const message = context.messages[i];
+		if (message?.role !== "user") continue;
+		const content = message.content;
+		if (typeof content === "string") return content;
+		return content
+			.filter((part): part is { type: "text"; text: string } => part.type === "text")
+			.map(part => part.text)
+			.join("");
+	}
+	return "";
+}
+
+describe("queue shorthand on an idle mid-session (#10802)", () => {
+	let tempDir: TempDir;
+	let authStorage: AuthStorage;
+	let session: AgentSession | undefined;
+
+	beforeEach(async () => {
+		tempDir = TempDir.createSync("@pi-queue-idle-drain-");
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "auth.db"));
+		authStorage.setRuntimeApiKey("mock", "mock-test-key");
+	});
+
+	afterEach(async () => {
+		await session?.dispose();
+		authStorage.close();
+		tempDir.removeSync();
+	});
+
+	it("dispatches the first item and delivers the rest one-per-yield in order", async () => {
+		const contexts: Context[] = [];
+		const mock = createMockModel({
+			handler: (context: Context) => {
+				contexts.push(context);
+				return { content: ["ok"], stopReason: "stop" };
+			},
+		});
+		const agent = new Agent({
+			getApiKey: () => "mock-test-key",
+			initialState: { model: mock.model, systemPrompt: ["Test"], tools: [], messages: [] },
+			convertToLlm,
+			streamFn: mock.stream,
+		});
+		const settings = Settings.isolated({ "compaction.enabled": false, "todo.enabled": false });
+		settings.setModelRole("default", `${mock.model.provider}/${mock.model.id}`);
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(tempDir.path()),
+			settings,
+			modelRegistry: new ModelRegistry(authStorage),
+		});
+		session.setFollowUpMode("one-at-a-time");
+
+		// Seed a mid-session transcript so the tail is an assistant message — the
+		// distinguishing precondition: on an empty transcript the idle-drain gate
+		// declines and the bug does not manifest.
+		await session.prompt("earlier turn");
+		await session.waitForIdle();
+
+		let text = "";
+		const editor = {
+			onSubmit: undefined as undefined | ((t: string) => Promise<void>),
+			getText: () => text,
+			setText: (t: string) => {
+				text = t;
+			},
+			setCollapsedText: (t: string) => {
+				text = t;
+			},
+			getExpandedText: () => text,
+			composerChips: () => [],
+			addToHistory: vi.fn(),
+			pendingImages: [] as ImageContent[],
+			pendingImageLinks: [] as (string | undefined)[],
+			imageLinks: undefined as (string | undefined)[] | undefined,
+			clearDraft(historyText?: string) {
+				if (historyText !== undefined) this.addToHistory(historyText);
+				text = "";
+				this.imageLinks = undefined;
+				this.pendingImages = [];
+				this.pendingImageLinks = [];
+			},
+		};
+		// Faithful stand-in for the interactive run loop: onInputCallback only
+		// resolves the input promise; the actual session.prompt() for the first item
+		// runs later (a queued microtask here), and the submission settles (as
+		// submitInteractiveInput's finally does) once that prompt has dispatched.
+		const runLoop = { session };
+		const onInputCallback = vi.fn((submission: SubmittedUserInput) => {
+			queueMicrotask(() => {
+				void (async () => {
+					try {
+						await runLoop.session.prompt(submission.text, {
+							images: submission.images,
+							streamingBehavior: submission.streamingBehavior,
+						});
+					} finally {
+						submission.onSettled?.();
+					}
+				})();
+			});
+		});
+
+		const ctx = {
+			editor,
+			session,
+			focusedAgentId: undefined,
+			collabGuest: undefined,
+			showStatus: vi.fn(),
+			onInputCallback,
+			startPendingSubmission: (input: {
+				text: string;
+				images?: ImageContent[];
+				imageLinks?: (string | undefined)[];
+				customType?: string;
+				display?: boolean;
+				streamingBehavior?: "steer" | "followUp";
+			}): SubmittedUserInput => ({ ...input, cancelled: false, started: false }),
+			ui: { requestRender: vi.fn() },
+			compactionQueuedMessages: [],
+			skillCommands: new Map(),
+			fileSlashCommands: new Set<string>(),
+			withLocalSubmission: async (_text: string, fn: () => Promise<unknown>) => fn(),
+			updatePendingMessagesDisplay: vi.fn(),
+			showWarning: vi.fn(),
+			showError: vi.fn(),
+		} as unknown as InteractiveModeContext;
+
+		const controller = new InputController(ctx);
+		controller.setupEditorSubmitHandler();
+
+		const input = "=>\n1. ITEM ONE\n2. ITEM TWO\n3. ITEM THREE";
+		editor.setText(input);
+		await editor.onSubmit?.(input);
+
+		await session.waitForIdle();
+
+		// The seed turn is contexts[0]; the three queued items follow in order.
+		const queued = contexts.slice(1).map(lastUserText);
+		expect(queued).toEqual(["ITEM ONE", "ITEM TWO", "ITEM THREE"]);
+	});
+});


### PR DESCRIPTION
## Repro
Submitting a queue-shorthand prompt (`->`/`=>` with an enumerated list) on an **idle** session that already has a transcript (assistant/toolResult tail) drains the whole queue at once and inverts order: item 2 gets the first provider request and item 1 arrives last, while the status still reports `Sent first message; queued N for later yields`. Driving `InputController#queueForYield` through a real `AgentSession` (mock provider, `followUpMode: one-at-a-time`, mid-session tail) and simulating the run loop (item 1 dispatched after the follow-ups are enqueued) captures provider requests in the order `ITEM TWO, ITEM ONE, ITEM THREE`. Reproduce: `bun test packages/coding-agent/test/queue-shorthand-idle-drain.test.ts`.

## Cause
In `queueForYield` (`packages/coding-agent/src/modes/controllers/input-controller.ts`) the immediate-start path dispatched the first item via `ctx.onInputCallback`, which only resolves the interactive run loop's input promise — `session.prompt()` for item 1 runs later. Items 2..N were then enqueued synchronously through `session.followUp()` while `session.isStreaming` was still `false`. Each enqueue schedules `#scheduleIdleQueueDrain`, and `AgentSession#canAutoContinueForFollowUp` (`packages/coding-agent/src/session/agent-session.ts`) accepts an `assistant`/`toolResult` tail, so `agent.continue()` dequeued item 2 before item 1's turn was ever in flight. On a fresh (empty) transcript the gate declines the empty tail, which is why the bug only appears mid-session.

## Fix
- Added an optional `onSettled` callback to `SubmittedUserInput` (`modes/types.ts`) — resolved once the submission's turn starts (session streaming) or it is cancelled/errored.
- `queueForYield` now sets `onSettled` on the first item's submission and `await`s it after `onInputCallback` before enqueuing the remaining follow-ups, so they queue behind a streaming session and drain one per yield in order.
- Resolve `onSettled` at every pending-submission clear site in `interactive-mode.ts`: `finishPendingSubmission` (run loop's finally, after `session.prompt()` dispatched), `cancelPendingSubmission`, and `showError` (idempotent, and covers the no-turn/command and failure paths so the queue never strands).
- Updated the `makeCtx` mock in `input-controller-slash-history.test.ts` to settle the submission, mirroring the run loop.

## Verification
`bun test packages/coding-agent/test/queue-shorthand-idle-drain.test.ts packages/coding-agent/test/input-controller-slash-history.test.ts packages/coding-agent/test/main-interactive-input.test.ts packages/coding-agent/test/agent-session-aside-delivery.test.ts packages/coding-agent/test/agent-session-advisor-suppression.test.ts packages/coding-agent/test/agent-session-async-delivery.test.ts packages/coding-agent/test/agent-session-queued-steer-delivery.test.ts packages/coding-agent/test/agent-session-new-session-queued-steer.test.ts` — all green (new regression test asserts `ITEM ONE, ITEM TWO, ITEM THREE`; it fails on the pre-fix code with `ITEM TWO` first). `bun check` passes. Fixes #10802