### PR TITLE
fix(collab): reclaim the host room after a half-open relay drop

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed a shared collab session being destroyed with "a host is already connected for this room" after the host's relay connection dropped: the host now treats that conflict as its own stale registration for up to two minutes and keeps retrying, so the room and its invite link survive and guests can reconnect with the same link; the reconnect notice waits until the new connection has stayed up long enough for a rejection to have arrived.
+
 ## [18.1.12] - 2026-09-06
 
 - Fixed edit and write results to report the formatted bytes actually committed by LSP writethrough.

--- a/packages/coding-agent/src/collab/crypto.ts
+++ b/packages/coding-agent/src/collab/crypto.ts
@@ -9,6 +9,10 @@ import type { CollabFrame } from "./protocol";
 
 const AES_ALGORITHM = "AES-GCM";
 const IV_LENGTH = 12;
+/** GCM authentication tag appended by {@link seal}. */
+const GCM_TAG_BYTES = 16;
+/** Shortest payload {@link open} can authenticate: an IV and a tag, with or without text. */
+export const MIN_SEALED_BYTES = IV_LENGTH + GCM_TAG_BYTES;
 const TEXT_ENCODER = new TextEncoder();
 const TEXT_DECODER = new TextDecoder();
 
@@ -44,7 +48,7 @@ export async function seal(key: CryptoKey, frame: CollabFrame): Promise<Uint8Arr
 
 /** Inverse of {@link seal}. Throws on auth failure or malformed input. */
 export async function open(key: CryptoKey, data: Uint8Array): Promise<CollabFrame> {
-	if (data.byteLength <= IV_LENGTH) {
+	if (data.byteLength < MIN_SEALED_BYTES) {
 		throw new Error("Sealed frame too short");
 	}
 	const iv = asStrict(data.subarray(0, IV_LENGTH));

--- a/packages/coding-agent/src/collab/host.ts
+++ b/packages/coding-agent/src/collab/host.ts
@@ -234,7 +234,7 @@ export class CollabHost {
 				firstOpen.resolve();
 			}
 		};
-		socket.onFrame = (frame, fromPeer) => this.#handleFrame(frame, fromPeer);
+		socket.onFrame = (frame, fromPeer, legId) => this.#handleFrame(frame, fromPeer, legId);
 		socket.onControl = msg => {
 			if (msg.t === "peer-left") this.#handlePeerLeft(msg.peer);
 		};
@@ -245,12 +245,26 @@ export class CollabHost {
 				return;
 			}
 			if (willReconnect) {
+				// The relay frees the room as soon as it observes our close, so every guest
+				// was dropped with 4001 and has to rejoin under a fresh peer id. No peer-left
+				// arrives for the old ids, so drop them now — before a rejoining guest can
+				// register — or they linger in the participant list and keep
+				// #hasWritablePeers() routing UI requests to peers that cannot answer.
+				// Pending UI requests stay: #handleHello replays them to the rejoining guest.
+				this.#peers.clear();
+				this.#updateStatusSegment();
 				this.#ctx.showStatus(`Collab relay connection lost (${reason}), reconnecting…`, { dim: true });
 			} else {
 				void this.#teardown();
 				this.#ctx.session.emitNotice("warning", `Collab ended: ${reason}`, "collab");
 			}
 		};
+		socket.onReconnect = () =>
+			this.#ctx.session.emitNotice(
+				"info",
+				"Collab relay reconnected — guests must rejoin with the same link",
+				"collab",
+			);
 		socket.connect();
 
 		const timeout = setTimeout(
@@ -337,25 +351,25 @@ export class CollabHost {
 		this.#socket.send(frame);
 	}
 
-	#handleFrame(frame: CollabFrame, fromPeer: number): void {
+	#handleFrame(frame: CollabFrame, fromPeer: number, legId: number): void {
 		switch (frame.t) {
 			case "hello":
 				this.#handleHello(frame.name, frame.proto, frame.writeToken, fromPeer);
 				break;
 			case "prompt":
-				this.#handlePrompt(frame.text, frame.images, fromPeer);
+				this.#handlePrompt(frame.text, frame.images, fromPeer, legId);
 				break;
 			case "abort":
 				this.#handleAbort(fromPeer);
 				break;
 			case "agent-cmd":
-				this.#handleAgentCmd(frame.cmd, frame.agentId, frame.text, fromPeer);
+				this.#handleAgentCmd(frame.cmd, frame.agentId, frame.text, fromPeer, legId);
 				break;
 			case "ui-response":
 				this.#handleUiResponse(frame.reqId, frame.value, fromPeer);
 				break;
 			case "fetch-transcript":
-				void this.#handleFetchTranscript(frame.reqId, frame.agentId, frame.fromByte, fromPeer);
+				void this.#handleFetchTranscript(frame.reqId, frame.agentId, frame.fromByte, fromPeer, legId);
 				break;
 			default:
 				logger.debug("collab host ignoring unexpected frame", { type: frame.t, fromPeer });
@@ -473,7 +487,7 @@ export class CollabHost {
 		this.#pendingUi.get(reqId)?.settle({ kind: "answered", value });
 	}
 
-	#handlePrompt(text: string, images: ImageContent[] | undefined, fromPeer: number): void {
+	#handlePrompt(text: string, images: ImageContent[] | undefined, fromPeer: number, legId: number): void {
 		const peer = this.#peers.get(fromPeer);
 		if (!peer?.canWrite) {
 			this.#rejectReadOnly("prompting", fromPeer);
@@ -500,8 +514,10 @@ export class CollabHost {
 				{ streamingBehavior: "steer", queueChipText: text },
 			)
 			.catch(err => {
+				// Tagged with the arrival leg: a steered prompt settles when the turn that
+				// absorbed it does, long after a reconnect may have re-minted this peer id.
 				logger.warn("collab guest prompt failed", { error: String(err) });
-				this.#socket?.send({ t: "error", message: `prompt failed: ${String(err)}` }, fromPeer);
+				this.#socket?.send({ t: "error", message: `prompt failed: ${String(err)}` }, fromPeer, legId);
 			});
 	}
 
@@ -590,7 +606,13 @@ export class CollabHost {
 		}, AGENTS_DEBOUNCE_MS);
 	}
 
-	#handleAgentCmd(cmd: "chat" | "kill" | "revive", agentId: string, text: string | undefined, fromPeer: number): void {
+	#handleAgentCmd(
+		cmd: "chat" | "kill" | "revive",
+		agentId: string,
+		text: string | undefined,
+		fromPeer: number,
+		legId: number,
+	): void {
 		if (!this.#peers.get(fromPeer)?.canWrite) {
 			this.#rejectReadOnly("agent control", fromPeer);
 			return;
@@ -601,9 +623,12 @@ export class CollabHost {
 			this.#socket?.send({ t: "error", message: `agent ${agentId}: advisor transcripts are read-only` }, fromPeer);
 			return;
 		}
+		// Tagged with the arrival leg: these settle when an agent lifecycle does, which can
+		// outlast a reconnect, and the relay hands peer ids out from 1 again once it frees
+		// the room — an untagged reply would name whoever inherited this one.
 		const fail = (err: unknown) => {
 			logger.warn("collab agent-cmd failed", { cmd, agentId, error: String(err) });
-			this.#socket?.send({ t: "error", message: `agent ${agentId}: ${String(err)}` }, fromPeer);
+			this.#socket?.send({ t: "error", message: `agent ${agentId}: ${String(err)}` }, fromPeer, legId);
 		};
 		switch (cmd) {
 			case "chat": {
@@ -638,9 +663,18 @@ export class CollabHost {
 	}
 
 	/** Incremental transcript read mirroring the hub's readFileIncremental contract. */
-	async #handleFetchTranscript(reqId: number, agentId: string, fromByte: number, fromPeer: number): Promise<void> {
+	async #handleFetchTranscript(
+		reqId: number,
+		agentId: string,
+		fromByte: number,
+		fromPeer: number,
+		legId: number,
+	): Promise<void> {
+		// Answered on the leg that asked: the reads below can straddle a reconnect, and the
+		// relay hands peer ids out from 1 again once it frees the room, so a reply that
+		// named only the id could reach whoever inherited it.
 		const reply = (text: string, newSize: number, error?: string) =>
-			this.#socket?.send({ t: "transcript", reqId, text, newSize, error }, fromPeer);
+			this.#socket?.send({ t: "transcript", reqId, text, newSize, error }, fromPeer, legId);
 		const file = AgentRegistry.global().get(agentId)?.sessionFile;
 		if (!file) {
 			reply("", fromByte, "no transcript available");

--- a/packages/coding-agent/src/collab/relay-client.ts
+++ b/packages/coding-agent/src/collab/relay-client.ts
@@ -2,28 +2,91 @@
  * Client-side WebSocket wrapper for collab live-session sharing.
  *
  * Connects to a relay room, seals/opens AES-GCM frames, and reconnects with
- * exponential backoff on transient drops. Fatal relay close codes (room gone,
- * host conflict, room full) and decryption failures never reconnect.
+ * exponential backoff on transient drops. Room-gone and room-full closes and
+ * decryption failures are terminal. A host conflict is terminal too, except
+ * during a bounded reclaim period after an established host connection drops:
+ * there it means the relay has not yet released our own stale registration.
  */
 import { logger } from "@oh-my-pi/pi-utils";
-import { open, seal } from "./crypto";
+import { MIN_SEALED_BYTES, open, seal } from "./crypto";
 import type { CollabFrame, RelayControlMessage } from "./protocol";
 import { packEnvelope, unpackEnvelope } from "./protocol";
 
+/** Relay close codes that must never trigger a reconnect. */
 const FATAL_CLOSE_REASONS: Record<number, string> = {
 	4001: "room closed",
 	4004: "no such room",
-	4009: "a host is already connected for this room",
 	4029: "room is full",
 };
 
 const BACKOFF_BASE_MS = 1_000;
 const BACKOFF_MAX_MS = 30_000;
-/** Max enveloped frames buffered while a reconnect is pending; overflow is dropped. */
+/**
+ * Frames buffered while a reconnect is pending, and the backpressure spill on a live leg.
+ * Full means the arrival is refused, not that something queued is evicted: the queue stays
+ * the ordered prefix the session emitted, which is what the reconnect case needs, since
+ * every guest rejoins the leg that comes back and its snapshot re-derives the tail. A
+ * refusal on a live accepted leg is not repaired by anything — sending resumes once the
+ * socket drains, so the guest sees a gap — but there both choices leave a gap, and it
+ * takes a socket that stops draining for 256 frames to get there.
+ */
 const MAX_PENDING_SENDS = 256;
+/**
+ * What relay control may hold while a leg has not settled. Sized in transitions: a
+ * `peer-joined`/`peer-left` charges ~312 bytes, so this carries ~26,800 of them, against
+ * the 18,528 the reference relay was measured minting into one settle window at its
+ * fastest. Past it a transition is dropped, and only a lost `peer-left` costs anything —
+ * the session keeps listing a guest that is gone. Nothing client-side can stop control
+ * from crowding out control, so the number is the whole defence.
+ */
+const MAX_HELD_CONTROL_BYTES = 8 * 1024 * 1024;
+/** What peers may hold. Control cannot spend it and it cannot spend control's. */
+const MAX_HELD_PEER_BYTES = 8 * 1024 * 1024;
+/**
+ * Every message a leg holds is charged to one of the two budgets, so their sum is what a
+ * hold can retain: no message is kept past it, whoever sent it. What a refusal costs is
+ * never charged, so the per-leg latch set is memory beside this, bounded by the number of
+ * distinct ids the relay mints and dropped with the leg.
+ */
+const MAX_HELD_INBOUND_BYTES = MAX_HELD_CONTROL_BYTES + MAX_HELD_PEER_BYTES;
+/**
+ * A stream's first bytes are judged against the whole peer budget rather than against what
+ * the budget has left for competition, and this much of the budget is kept out of that
+ * competition to make room for them. Without both, the budget is first-come and one guest
+ * — the slot cost makes a few hundred KB of small frames enough — spends what the rest of
+ * the room needs for its `hello`s, the one message nothing re-sends.
+ *
+ * What that buys, exactly: traffic past a stream's floor cannot take the last megabyte, so
+ * a guest's handshake lands while thousands of them fit in the reserve. It is a reserve,
+ * not a per-stream allocation — sixteen ids each holding a full floor spend it — and a
+ * stream past its floor competes, so a guest's large frame is still held while the room is
+ * quiet: the floor bounds what the room can lose to one stream, not what a guest may send.
+ */
+const HELD_STREAM_FLOOR_BYTES = 64 * 1024;
+const HELD_FLOOR_RESERVE_BYTES = 1024 * 1024;
+const HELD_INBOUND_SLOT_BYTES = 256;
 const WS_BACKPRESSURE_THRESHOLD = 64 * 1024;
 const WS_BACKPRESSURE_DRAIN_THRESHOLD = 32 * 1024;
 const WS_BACKPRESSURE_DRAIN_RETRY_MS = 25;
+
+/**
+ * Host conflict. Fatal on a cold connect (another host really owns the room),
+ * but transient right after our own established socket died: the relay has not
+ * yet observed that close and still holds our stale registration. Measured
+ * against the live relay, it frees the room immediately once it sees a close, so
+ * this only happens on a half-open death, where the stale hold lasts until the
+ * relay's own read/ping deadline.
+ */
+const HOST_CONFLICT_CODE = 4009;
+const HOST_CONFLICT_REASON = "a host is already connected for this room";
+/** How long a host that just lost an established socket may keep reclaiming its room. */
+const HOST_RECLAIM_WINDOW_MS = 120_000;
+/**
+ * The relay upgrades a socket before it applies room policy, so a leg it is about to
+ * reject with 4009 reaches onopen first. A host reconnect stays provisional for this
+ * long: only a leg that survives it holds the room.
+ */
+const LEG_SETTLE_MS = 2_000;
 
 export interface CollabSocketOptions {
 	/** wss://host[:port]/r/<roomId> — no query string. */
@@ -35,10 +98,17 @@ export interface CollabSocketOptions {
 export class CollabSocket {
 	/** Fires after every successful (re)connect. */
 	onOpen?: () => void;
-	onFrame?: (frame: CollabFrame, fromPeer: number) => void;
+	/**
+	 * `legId` names the relay registration this frame arrived on. A reply computed across an
+	 * await must pass it back to {@link CollabSocket.send}, or a peer id the next leg minted
+	 * again would take it: relay ids restart at 1 whenever the room is freed.
+	 */
+	onFrame?: (frame: CollabFrame, fromPeer: number, legId: number) => void;
 	onControl?: (msg: RelayControlMessage) => void;
 	/** Fires once per terminal close (intentional, fatal code, or bad key). willReconnect=true for transient drops that will retry. */
 	onClose?: (reason: string, willReconnect: boolean) => void;
+	/** Fires when a reconnect produced a socket the relay kept, meaning guests must rejoin. */
+	onReconnect?: () => void;
 
 	readonly #opts: CollabSocketOptions;
 	#ws: WebSocket | null = null;
@@ -51,8 +121,50 @@ export class CollabSocket {
 	#sendChain: Promise<void> = Promise.resolve();
 	/** Serializes open() so frames are delivered in arrival order. */
 	#recvChain: Promise<void> = Promise.resolve();
-	/** Envelopes sealed while disconnected, flushed on the next open. */
-	#pendingSends: Uint8Array[] = [];
+	/**
+	 * Envelopes sealed while disconnected, flushed on the next accepted leg. `peer` is the
+	 * envelope's target: 0 is a broadcast, anything else is directed at one guest.
+	 */
+	#pendingSends: { envelope: Uint8Array; peer: number }[] = [];
+	/**
+	 * Inbound messages — frames and relay control alike, in one queue so they keep one
+	 * order — that arrived on a leg which has not settled yet. Replayed once it does and
+	 * dropped with the leg if it never does, so nothing the session acts on outlives the
+	 * registration that minted the ids it names. Only messages the session could act on are
+	 * held: text that is not relay control and bytes that could not open are dropped at
+	 * intake rather than charged.
+	 */
+	#heldInbound: (string | ArrayBuffer | Uint8Array)[] = [];
+	/** Charged against MAX_HELD_PEER_BYTES; the map totals this counter, one entry per stream. */
+	#heldPeerBytes = 0;
+	#heldStreamBytes = new Map<number, number>();
+	/** Charged against MAX_HELD_CONTROL_BYTES, which peers cannot spend. */
+	#heldControlBytes = 0;
+	/**
+	 * Peer ids the live leg has heard from. The relay is the only source of a peer id and
+	 * it hands out fresh ones per room, so this set is exactly the set of ids that are
+	 * addressable right now; anything else belongs to a registration that is gone.
+	 */
+	#legPeers = new Set<number>();
+	/** Settle delay that promotes a provisional reconnect leg to the accepted one. */
+	#legSettleTimer: NodeJS.Timeout | undefined;
+	/**
+	 * Names the socket the client is registered on: 0 before the first connect, and still
+	 * the dead leg's number while a reconnect is between sockets. It only counts up, so it
+	 * separates registrations the relay's own peer ids cannot — those restart at 1 whenever
+	 * the room is freed. The delivery property belongs to `send`'s `onLeg` gate and holds
+	 * only for the callers that pass it, so every directed reply computed across an await
+	 * has to.
+	 */
+	#legId = 0;
+	/** True once any leg survived relay policy; distinguishes a cold connect from a reconnect. */
+	#everAccepted = false;
+	/** True once the live leg survived relay policy; a provisional leg may still be rejected. */
+	#legAccepted = false;
+	/** Epoch ms until which a 4009 counts as a stale-registration retry, 0 = cold. */
+	#reclaimUntil = 0;
+	/** Backoff counter for conflict retries, kept separate because onopen fires before a 4009 close. */
+	#conflictAttempt = 0;
 
 	constructor(opts: CollabSocketOptions) {
 		this.#opts = opts;
@@ -66,24 +178,74 @@ export class CollabSocket {
 		if (this.#ws || this.#retryTimer) return;
 		this.#closed = false;
 		this.#attempt = 0;
+		this.#everAccepted = false;
+		this.#legAccepted = false;
+		this.#reclaimUntil = 0;
+		this.#conflictAttempt = 0;
 		this.#openSocket();
 	}
 
-	send(frame: CollabFrame, targetPeer = 0): void {
+	/**
+	 * `onLeg` is REQUIRED of any directed reply a caller computes across an await, and is
+	 * the `legId` {@link CollabSocket.onFrame} handed it with the request. The leg capture
+	 * below only sees the leg live when `send` is finally called, so an untagged reply that
+	 * outlived its own leg is handed to whoever inherited its peer id — the relay mints ids
+	 * from 1 again each time it frees the room. A reply issued before the handler's first
+	 * await is already on the arrival leg and needs nothing; a broadcast has no peer
+	 * identity to inherit and takes no tag.
+	 */
+	send(frame: CollabFrame, targetPeer = 0, onLeg?: number): void {
+		// The leg live when the caller issued this frame, captured before the chain can park
+		// it behind a seal: a peer id names a guest only on its own relay registration, and
+		// reading the field after the await would accept the leg that inherited the number.
+		const issuedOn = this.#ws;
 		this.#sendChain = this.#sendChain
 			.then(async () => {
 				if (this.#closed) {
 					logger.debug("collab: dropping frame, socket closed", { t: frame.t });
 					return;
 				}
+				// A provisional leg counts as closed for sending: the relay may still
+				// reject it, and anything handed to it would be lost with the leg.
 				const openWs = this.#ws;
-				if (openWs && openWs.readyState === WebSocket.OPEN) this.#drainPendingSends(openWs);
+				if (openWs && this.#legAccepted && openWs.readyState === WebSocket.OPEN) {
+					this.#drainPendingSends(openWs);
+				}
 				const sealed = await seal(this.#opts.key, frame);
+				// Re-checked after the seal: close() ran while this link was parked, and the
+				// buffer it emptied must not be refilled behind a terminal state.
+				if (this.#closed) {
+					logger.debug("collab: dropping frame sealed across a close", { t: frame.t });
+					return;
+				}
+				// A reply that names the leg it answers is checked against that, not against
+				// the leg it happens to be sent on: an id re-minted by a later registration
+				// passes every other test here, because by then it is a live id of a live leg.
+				if (onLeg !== undefined && onLeg !== this.#legId) {
+					logger.debug("collab: dropping a reply whose leg is gone", { t: frame.t, peer: targetPeer, onLeg });
+					return;
+				}
+				// A peer id only means something on the leg that minted it. The relay frees
+				// the room when it observes our close and hands ids out from 1 again, so an
+				// envelope addressed to a peer this leg never saw — or issued on a leg that
+				// has since been replaced — would land on whoever inherited that number.
+				// Broadcasts stay valid: the relay fans them to whoever is in the room.
+				if (targetPeer !== 0 && (this.#ws !== issuedOn || !this.#legPeers.has(targetPeer))) {
+					// While a leg is provisional no id is introduced yet, so the same gate also
+					// catches a reply the session offered before its guest was handed over.
+					logger.debug("collab: dropping directed frame, its peer is not addressable", {
+						t: frame.t,
+						peer: targetPeer,
+						held: this.#heldInbound.length,
+						legAccepted: this.#legAccepted,
+					});
+					return;
+				}
 				const envelope = packEnvelope(targetPeer, sealed);
 				const ws = this.#ws;
-				if (ws && ws.readyState === WebSocket.OPEN) {
+				if (ws && this.#legAccepted && ws.readyState === WebSocket.OPEN) {
 					if (this.#pendingSends.length > 0) {
-						this.#enqueuePendingSend(envelope, frame.t);
+						this.#enqueuePendingSend(envelope, targetPeer);
 						if (ws.bufferedAmount < WS_BACKPRESSURE_DRAIN_THRESHOLD) {
 							this.#drainPendingSends(ws);
 						} else {
@@ -92,26 +254,26 @@ export class CollabSocket {
 						return;
 					}
 					if (ws.bufferedAmount >= WS_BACKPRESSURE_THRESHOLD) {
-						this.#enqueuePendingSend(envelope, frame.t);
+						this.#enqueuePendingSend(envelope, targetPeer);
 						this.#scheduleBackpressureDrain(ws);
 						return;
 					}
 					ws.send(envelope);
 					return;
 				}
-				this.#enqueuePendingSend(envelope, frame.t);
+				this.#enqueuePendingSend(envelope, targetPeer);
 			})
 			.catch((err: unknown) => {
 				logger.debug("collab: send failed", { error: String(err) });
 			});
 	}
 
-	#enqueuePendingSend(envelope: Uint8Array, frameType: CollabFrame["t"]): void {
+	#enqueuePendingSend(envelope: Uint8Array, peer: number): void {
 		if (this.#pendingSends.length >= MAX_PENDING_SENDS) {
-			logger.debug("collab: dropping frame, reconnect buffer full", { t: frameType });
+			logger.debug("collab: reconnect buffer full, dropping frame", { peer, queued: this.#pendingSends.length });
 			return;
 		}
-		this.#pendingSends.push(envelope);
+		this.#pendingSends.push({ envelope, peer });
 	}
 
 	#drainPendingSends(ws: WebSocket): void {
@@ -120,9 +282,9 @@ export class CollabSocket {
 			ws.readyState === WebSocket.OPEN &&
 			ws.bufferedAmount < WS_BACKPRESSURE_DRAIN_THRESHOLD
 		) {
-			const envelope = this.#pendingSends.shift();
-			if (!envelope) return;
-			ws.send(envelope);
+			const pending = this.#pendingSends.shift();
+			if (!pending) return;
+			ws.send(pending.envelope);
 		}
 	}
 
@@ -132,9 +294,10 @@ export class CollabSocket {
 			this.#backpressureDrainTimer = undefined;
 			this.#sendChain = this.#sendChain
 				.then(async () => {
-					if (this.#closed || this.#ws !== ws || ws.readyState !== WebSocket.OPEN) return;
+					if (this.#closed || this.#ws !== ws || !this.#legAccepted || ws.readyState !== WebSocket.OPEN) return;
 					this.#drainPendingSends(ws);
 					if (this.#pendingSends.length > 0) this.#scheduleBackpressureDrain(ws);
+					else this.#flushHeldInbound(ws);
 				})
 				.catch((err: unknown) => {
 					logger.debug("collab: backpressure drain failed", { error: String(err) });
@@ -142,10 +305,15 @@ export class CollabSocket {
 		}, WS_BACKPRESSURE_DRAIN_RETRY_MS);
 	}
 
-	#clearBackpressureDrain(): void {
+	/** Drops both timers owned by the live socket: the drain retry and the leg settle. */
+	#clearSocketTimers(): void {
 		if (this.#backpressureDrainTimer !== undefined) {
 			clearTimeout(this.#backpressureDrainTimer);
 			this.#backpressureDrainTimer = undefined;
+		}
+		if (this.#legSettleTimer !== undefined) {
+			clearTimeout(this.#legSettleTimer);
+			this.#legSettleTimer = undefined;
 		}
 	}
 
@@ -153,10 +321,12 @@ export class CollabSocket {
 	close(): void {
 		const hadActivity = this.#ws !== null || this.#retryTimer !== undefined;
 		this.#clearRetry();
-		this.#clearBackpressureDrain();
+		this.#clearSocketTimers();
 		const wasClosed = this.#closed;
 		this.#closed = true;
 		this.#pendingSends.length = 0;
+		this.#legPeers.clear();
+		this.#dropHeldInbound();
 		const ws = this.#ws;
 		this.#ws = null;
 		if (ws) {
@@ -170,17 +340,37 @@ export class CollabSocket {
 	}
 
 	#openSocket(): void {
-		this.#clearBackpressureDrain();
+		this.#clearSocketTimers();
+		this.#legAccepted = false;
+		this.#legId++;
+		this.#legPeers.clear();
+		this.#dropHeldInbound();
 		const ws = new WebSocket(`${this.#opts.wsUrl}?role=${this.#opts.role}`);
 		ws.binaryType = "arraybuffer";
 		this.#ws = ws;
 		ws.onopen = () => {
 			if (this.#ws !== ws) return;
-			this.#attempt = 0;
-			if (this.#pendingSends.length > 0) {
-				this.#drainPendingSends(ws);
-				if (this.#pendingSends.length > 0) this.#scheduleBackpressureDrain(ws);
+			const reconnect = this.#everAccepted;
+			logger.info("collab: relay socket open", { role: this.#opts.role, reconnect });
+			// A host reconnect leg is the one the relay may still reject with 4009, and
+			// onopen fires before that rejection. Until the leg survives LEG_SETTLE_MS it
+			// stays provisional: no backlog drain (the rejected leg would swallow those
+			// frames), no reclaim-state reset, and no callback claiming a live room.
+			// #reclaimUntil deliberately survives onopen — clearing it here would hammer
+			// the relay at the base backoff delay. A cold leg is exempt because it has
+			// nothing to lose: no backlog, no room to reclaim, and its consumer needs the
+			// open to finish `start()` inside the connect timeout.
+			if (reconnect && this.#opts.role === "host") {
+				this.#legSettleTimer = setTimeout(() => {
+					this.#legSettleTimer = undefined;
+					if (this.#ws !== ws || ws.readyState !== WebSocket.OPEN) return;
+					this.#acceptLeg(ws);
+					this.onOpen?.();
+					this.onReconnect?.();
+				}, LEG_SETTLE_MS);
+				return;
 			}
+			this.#acceptLeg(ws);
 			this.onOpen?.();
 		};
 		ws.onmessage = (event: MessageEvent) => {
@@ -192,25 +382,223 @@ export class CollabSocket {
 		};
 		ws.onclose = (event: CloseEvent) => {
 			if (this.#ws !== ws) return;
-			this.#clearBackpressureDrain();
+			this.#clearSocketTimers();
 			this.#ws = null;
 			this.#handleClose(event.code, event.reason);
 		};
 	}
 
+	/**
+	 * Promotes the live leg to the one holding the room and flushes what queued while it
+	 * was provisional. The reclaim deadline and the conflict ladder deliberately survive:
+	 * the settle window is a send/notify heuristic, not an acknowledgement from the relay,
+	 * so a 4009 that arrives late (packet loss on an already-degraded path) must still be
+	 * reclaimable instead of tearing the room down. They are retired on the next drop of
+	 * an accepted leg, which is where a fresh window genuinely starts.
+	 */
+	#acceptLeg(ws: WebSocket): void {
+		this.#legAccepted = true;
+		this.#everAccepted = true;
+		this.#attempt = 0;
+		if (this.#pendingSends.length > 0) {
+			this.#drainPendingSends(ws);
+			if (this.#pendingSends.length > 0) this.#scheduleBackpressureDrain(ws);
+		}
+		this.#flushHeldInbound(ws);
+	}
+
+	/**
+	 * Replays what the leg held, but not before the buffer is empty and the socket is
+	 * writable: the session answers these messages with a rejoin handshake, and a handshake
+	 * started behind a backlog — or into a congested socket — is the one thing the buffer
+	 * bound cannot shed without truncating it. Not ready means the drain timer stays armed
+	 * and brings us back here, at the same 25ms cadence the spill already uses.
+	 *
+	 * On this runtime the wait is normally zero: Bun's client keeps `bufferedAmount` at 0
+	 * even under 200 MB of unflushed sends, so the drain above empties the buffer in one
+	 * call and the replay runs inline. The check is what keeps the property true where
+	 * backpressure is reported, which is the same reason the spill it rides on exists. The
+	 * wait itself is bounded only by the buffer draining or the leg dying — a socket that
+	 * cannot write cannot deliver a welcome either — and nothing on the guest side bounds
+	 * it: `guest.ts` arms its welcome and snapshot timers only inside the first join, so a
+	 * resyncing guest has no watchdog of its own. Deferring further would need one.
+	 */
+	#flushHeldInbound(ws: WebSocket): void {
+		if (this.#heldInbound.length === 0) {
+			// A refusal can land on an empty hold, so the latches it set have to be given back
+			// here as well: the wait they belong to is over, and nothing else reaches them
+			// until the leg dies.
+			this.#dropHeldInbound();
+			return;
+		}
+		if (this.#pendingSends.length > 0 || ws.bufferedAmount >= WS_BACKPRESSURE_DRAIN_THRESHOLD) {
+			this.#scheduleBackpressureDrain(ws);
+			return;
+		}
+		const held = this.#heldInbound;
+		this.#dropHeldInbound();
+		logger.debug("collab: replaying inbound the leg held", { messages: held.length });
+		for (const data of held) this.#handleMessage(ws, data);
+	}
+
+	/**
+	 * Empties the hold and gives back its budget. Used both when a leg dies — its ids name a
+	 * registration the relay has already recycled — and after a replay, which is why it
+	 * hands out a fresh array instead of truncating the one the caller is about to walk.
+	 */
+	#dropHeldInbound(): void {
+		this.#heldInbound = [];
+		this.#heldPeerBytes = 0;
+		this.#heldStreamBytes.clear();
+		this.#heldControlBytes = 0;
+	}
+
+	/**
+	 * The relay control message this text carries, or null when it is not one. Validated all
+	 * the way to the fields the consumers read: `null` parses fine and reading `t` off it
+	 * throws, `[]` and untagged objects parse fine and would otherwise reach the session
+	 * typed as control, and a `peer-left` without a numeric `peer` would have the session
+	 * retire `undefined`.
+	 */
+	#parseControl(data: string): RelayControlMessage | null {
+		let parsed: unknown;
+		try {
+			parsed = JSON.parse(data);
+		} catch {
+			return null;
+		}
+		if (typeof parsed !== "object" || parsed === null || !("t" in parsed)) return null;
+		if (parsed.t === "room-closed") return { t: "room-closed" };
+		if (parsed.t !== "peer-joined" && parsed.t !== "peer-left") return null;
+		if (!("peer" in parsed) || typeof parsed.peer !== "number") return null;
+		return { t: parsed.t, peer: parsed.peer };
+	}
+
 	#handleMessage(ws: WebSocket, data: unknown): void {
-		if (typeof data === "string") {
-			try {
-				this.onControl?.(JSON.parse(data) as RelayControlMessage);
-			} catch {
-				logger.debug("collab: ignoring malformed control message");
+		// A provisional leg is one the relay may still reject with 4009, and every peer id
+		// the messages on it carry was minted for a registration that dies with the leg.
+		// Handing them to the session now would have the host answer a guest across a leg
+		// that never held the room: the reply is lost with the leg, and a snapshot already
+		// promised to a guest cannot be promised again. So inbound is held until the leg
+		// settles and dropped with the leg if it never does, so nothing the session acts on
+		// outlives the ids it names. It is also what keeps the reconnect buffer free of
+		// rejoin handshakes: a provisional leg answers nobody. A non-empty hold keeps
+		// holding even on a settled leg, or a message arriving mid-wait would overtake the
+		// prefix that is still waiting to be replayed.
+		if (!this.#legAccepted || this.#heldInbound.length > 0) {
+			const message =
+				typeof data === "string" || data instanceof ArrayBuffer || data instanceof Uint8Array ? data : null;
+			if (message === null) {
+				logger.debug("collab: ignoring inbound of an unexpected type");
+				return;
 			}
+			// Charged an upper bound on what holding it retains — a string is at most UTF-16 in
+			// memory — plus a flat slot cost, so a flood of tiny messages spends the ceiling
+			// too. Nothing enters the hold unvalidated: text that is not a control message and
+			// bytes that are not an envelope are dropped here rather than carried to the
+			// replay and discarded there, where they would have spent a budget the room's own
+			// traffic needs.
+			const bytes =
+				(typeof message === "string" ? message.length * 2 : message.byteLength) + HELD_INBOUND_SLOT_BYTES;
+			if (typeof message === "string") {
+				if (this.#parseControl(message) === null) {
+					logger.debug("collab: ignoring malformed control message");
+					return;
+				}
+				// Control spends its own budget, which peers cannot touch, so a room's churn is
+				// never turned away by peer traffic: a dropped `peer-left` is the one loss that
+				// leaves state behind — a guest the session keeps listing, counting as writable
+				// and addressing for the rest of the leg. Past that budget a transition is
+				// dropped all the same, because a relay streaming text must not be able to grow
+				// the hold; nothing client-side can keep control from crowding out control. A
+				// refused control is not latched: relay ids only move forward, so a control
+				// arriving after a refused one is never its successor, and latching would
+				// refuse the `peer-left` that still fits.
+				if (this.#heldControlBytes + bytes > MAX_HELD_CONTROL_BYTES) {
+					logger.debug("collab: inbound hold is full of control, dropping message", {
+						bytes,
+						held: this.#heldInbound.length,
+						controlBytes: this.#heldControlBytes,
+					});
+					return;
+				}
+				this.#heldInbound.push(message);
+				this.#heldControlBytes += bytes;
+				return;
+			}
+			// Held only if `open` could accept it at replay: a payload with no room for an IV
+			// and a GCM tag can only fail, and failing there ends the session over bytes this
+			// leg was never going to act on. Longer garbage still fails, which is the accepted
+			// pre-existing behaviour of any frame that does not decrypt.
+			const envelope = unpackEnvelope(message instanceof ArrayBuffer ? new Uint8Array(message) : message);
+			if (!envelope || envelope.payload.byteLength < MIN_SEALED_BYTES) {
+				logger.debug("collab: ignoring inbound that could not be a sealed frame");
+				return;
+			}
+			// A refusal is per message, and deliberately not sticky. Inbound carries no trains:
+			// every guest→host frame is an independent request, and the only order that
+			// matters is that a `hello` precedes the rest — which is exactly what a sticky
+			// refusal would break. A guest reconnecting flushes what it queued during the
+			// outage before its own onOpen sends that `hello`, so refusing the queued frame
+			// and then holding its `hello` against it would leave that guest connected,
+			// unwelcomed and with no watchdog to notice. Losing the queued prompt is visible
+			// to whoever typed it; losing the `hello` is visible to nobody.
+			const peer = envelope.peerId;
+			// Within its own floor a stream is judged against the whole peer budget; past it,
+			// against what the floor reserve leaves — so a loud guest can fill the hold with
+			// real traffic and the next guest's handshake still gets in. Every id is accounted
+			// the same way, including 0, the broadcast slot.
+			const streamBytes = this.#heldStreamBytes.get(peer) ?? 0;
+			const budget =
+				streamBytes + bytes <= HELD_STREAM_FLOOR_BYTES
+					? MAX_HELD_PEER_BYTES
+					: MAX_HELD_PEER_BYTES - HELD_FLOOR_RESERVE_BYTES;
+			if (this.#heldPeerBytes + bytes > budget) {
+				logger.debug("collab: inbound hold is full, dropping message", {
+					bytes,
+					peer,
+					held: this.#heldInbound.length,
+					peerBytes: this.#heldPeerBytes,
+					streamBytes,
+				});
+				return;
+			}
+			this.#heldInbound.push(message);
+			this.#heldPeerBytes += bytes;
+			this.#heldStreamBytes.set(peer, streamBytes + bytes);
+			return;
+		}
+		if (typeof data === "string") {
+			const msg = this.#parseControl(data);
+			if (msg === null) {
+				logger.debug("collab: ignoring malformed control message");
+				return;
+			}
+			// The gate reads this synchronously, so a departed id stops being addressable at
+			// once, while the session is told on the recv chain: control and frames share one
+			// order, or a peer-left could land before the frame the relay routed ahead of it
+			// and leave the session holding a guest it had already been told was gone. The
+			// chain also means a control message can now be dropped on a leg change instead
+			// of always firing — only ever a notice about a room the consumer is tearing down,
+			// since onClose(willReconnect) already clears the peers it would name.
+			if (msg.t === "peer-left") this.#legPeers.delete(msg.peer);
+			this.#recvChain = this.#recvChain
+				.then(() => {
+					if (this.#ws !== ws) return;
+					this.onControl?.(msg);
+				})
+				.catch((err: unknown) => {
+					logger.debug("collab: control handler failed", { error: String(err) });
+				});
 			return;
 		}
 		const bytes = data instanceof ArrayBuffer ? new Uint8Array(data) : data instanceof Uint8Array ? data : null;
 		if (!bytes) return;
 		const envelope = unpackEnvelope(bytes);
 		if (!envelope) return;
+		// Recorded before decryption: a peer becomes addressable as soon as the relay routes
+		// its traffic to us, whether or not this particular frame opens.
+		if (envelope.peerId !== 0) this.#legPeers.add(envelope.peerId);
 		this.#recvChain = this.#recvChain
 			.then(async () => {
 				if (this.#ws !== ws) return;
@@ -218,11 +606,22 @@ export class CollabSocket {
 				try {
 					frame = await open(this.#opts.key, envelope.payload);
 				} catch {
+					// The same recheck the success arm makes: this frame may have finished
+					// decrypting on a leg that has since died. The bytes are just as broken
+					// either way — what depends on the leg is whether ending the session over
+					// them is warranted, and killing a reconnect the client already promised,
+					// for a frame nobody can act on, is not.
+					if (this.#ws !== ws) {
+						logger.debug("collab: dropping a frame that failed to open on a leg already gone", {
+							peer: envelope.peerId,
+						});
+						return;
+					}
 					this.#failFatal("bad key or corrupted frame");
 					return;
 				}
 				if (this.#ws !== ws) return;
-				this.onFrame?.(frame, envelope.peerId);
+				this.onFrame?.(frame, envelope.peerId, this.#legId);
 			})
 			.catch((err: unknown) => {
 				logger.debug("collab: frame handler failed", { error: String(err) });
@@ -231,16 +630,65 @@ export class CollabSocket {
 
 	#handleClose(code: number, reason: string): void {
 		if (this.#closed) return;
-		this.#clearBackpressureDrain();
-		const fatalReason = FATAL_CLOSE_REASONS[code];
+		this.#clearSocketTimers();
+		// Only a leg that survived relay policy proves we held the room. A leg that died
+		// before or during its settle window renews nothing, or alternating pre-open drops
+		// and 4009 rejections would extend the reclaim deadline forever.
+		const legAccepted = this.#legAccepted;
+		this.#legAccepted = false;
+		// The peers this leg knew died with it, so their ids are stale; the relay hands the
+		// same numbers to whoever connects next. Buffered broadcasts survive; directed
+		// frames and inbound the leg never got to answer cannot.
+		this.#legPeers.clear();
+		this.#dropHeldInbound();
+		const dropped = this.#pendingSends.reduce((count, entry) => (entry.peer === 0 ? count : count + 1), 0);
+		if (dropped > 0) {
+			this.#pendingSends = this.#pendingSends.filter(entry => entry.peer === 0);
+			logger.debug("collab: dropped buffered directed frames, their peers are gone", { dropped });
+		}
+
+		const reclaimMsLeft = this.#reclaimUntil - Date.now();
+		const isConflict = code === HOST_CONFLICT_CODE && this.#opts.role === "host" && this.#everAccepted;
+		if (isConflict && reclaimMsLeft > 0) {
+			logger.debug("collab: relay still holds the previous host, retrying", {
+				code,
+				attempt: this.#conflictAttempt,
+				reclaimMsLeft,
+			});
+			this.onClose?.("relay has not released the previous host yet", true);
+			// Capped at the deadline, so the ladder always spends the window it advertises:
+			// an unclamped 30s step from ~92s would open at 122s, where the leg is already
+			// fatal on arrival and the tail of the window goes unprobed.
+			this.#scheduleRetry(this.#conflictAttempt++, reclaimMsLeft);
+			return;
+		}
+
+		const fatalReason = code === HOST_CONFLICT_CODE ? HOST_CONFLICT_REASON : FATAL_CLOSE_REASONS[code];
 		if (fatalReason !== undefined) {
 			this.#closed = true;
 			this.#pendingSends.length = 0;
+			logger.info("collab: relay closed the socket permanently", {
+				code,
+				reason: fatalReason,
+				role: this.#opts.role,
+			});
 			this.onClose?.(fatalReason, false);
 			return;
 		}
+
+		// Only a leg the relay kept opens a fresh reclaim window and ladder; a provisional
+		// or pre-open death keeps the previous deadline and attempt count.
+		if (legAccepted) {
+			if (this.#opts.role === "host") this.#reclaimUntil = Date.now() + HOST_RECLAIM_WINDOW_MS;
+			this.#conflictAttempt = 0;
+		}
+		logger.info("collab: relay connection dropped, reconnecting", { code, reason, attempt: this.#attempt });
 		this.onClose?.(reason || `connection lost (code ${code})`, true);
-		this.#scheduleRetry();
+		// Capped at the deadline like the conflict ladder: a 30s step from the tail of the
+		// window would open the next leg past it and leave the last stretch of the reclaim
+		// period — the part where the relay has usually released the room — unprobed.
+		const reclaimLeftMs = this.#reclaimUntil - Date.now();
+		this.#scheduleRetry(this.#attempt++, reclaimLeftMs > 0 ? reclaimLeftMs : Number.POSITIVE_INFINITY);
 	}
 
 	/** Decryption failure: wrong key or corrupted frame. Never reconnect. */
@@ -249,9 +697,11 @@ export class CollabSocket {
 		this.#closed = true;
 		this.#clearRetry();
 		this.#pendingSends.length = 0;
+		this.#legPeers.clear();
+		this.#dropHeldInbound();
 		const ws = this.#ws;
 		this.#ws = null;
-		this.#clearBackpressureDrain();
+		this.#clearSocketTimers();
 		if (ws) {
 			try {
 				ws.close(1000);
@@ -262,15 +712,21 @@ export class CollabSocket {
 		this.onClose?.(reason, false);
 	}
 
-	#scheduleRetry(): void {
-		const base = Math.min(BACKOFF_BASE_MS * 2 ** this.#attempt, BACKOFF_MAX_MS);
-		this.#attempt++;
-		const delay = base * (0.75 + Math.random() * 0.5);
+	/**
+	 * Arms the single retry timer with the exponential step for `attempt`, jittered by ±25%
+	 * so reconnecting clients do not align, and never longer than `capMs` — the reclaim
+	 * deadline passes itself here so a conflict retry cannot be scheduled past the window
+	 * it is trying to spend.
+	 */
+	#scheduleRetry(attempt: number, capMs = Number.POSITIVE_INFINITY): void {
+		const backoffMs = Math.min(BACKOFF_BASE_MS * 2 ** attempt, BACKOFF_MAX_MS) * (0.75 + Math.random() * 0.5);
+		const delayMs = Math.min(backoffMs, capMs);
+		logger.debug("collab: reconnect scheduled", { attempt, delayMs: Math.round(delayMs) });
 		this.#retryTimer = setTimeout(() => {
 			this.#retryTimer = undefined;
 			if (this.#closed) return;
 			this.#openSocket();
-		}, delay);
+		}, delayMs);
 	}
 
 	#clearRetry(): void {

--- a/packages/coding-agent/test/collab/helpers/recycling-relay.ts
+++ b/packages/coding-agent/test/collab/helpers/recycling-relay.ts
@@ -1,0 +1,168 @@
+/**
+ * In-memory relay that recycles peer ids the way the reference relay does.
+ *
+ * `packages/collab-web/scripts/local-relay.ts` keys rooms by roomId, mints guest ids from
+ * `nextPeerId: 1`, and `rooms.delete(roomId)` the moment the host socket closes. So a host
+ * that drops and reconnects gets a brand new room whose first guest is peer 1 again — the
+ * precondition for a reply that outlived its own leg being handed to the wrong guest.
+ * `helpers/in-memory-relay.ts` never frees the room, so its ids only ever climb and that
+ * collision cannot happen there; this fixture frees it.
+ */
+import { packEnvelope, rewriteEnvelopePeer, unpackEnvelope } from "../../../src/collab/protocol";
+
+let activeRelay: RecyclingRelay | null = null;
+const RealWebSocket = globalThis.WebSocket;
+
+export class RelayWebSocket {
+	static readonly CONNECTING = 0;
+	static readonly OPEN = 1;
+	static readonly CLOSING = 2;
+	static readonly CLOSED = 3;
+	static instances: RelayWebSocket[] = [];
+
+	binaryType = "blob";
+	bufferedAmount = 0;
+	readyState: number = RelayWebSocket.CONNECTING;
+	readonly role: "host" | "guest";
+	peerId = 0;
+	onopen: (() => void) | null = null;
+	onmessage: ((event: { data: unknown }) => void) | null = null;
+	onerror: (() => void) | null = null;
+	onclose: ((event: { code: number; reason: string }) => void) | null = null;
+	readonly #relay: RecyclingRelay;
+
+	constructor(url: string) {
+		const relay = activeRelay;
+		if (!relay) throw new Error("RelayWebSocket: no active relay");
+		this.#relay = relay;
+		this.role = new URL(url).searchParams.get("role") === "host" ? "host" : "guest";
+		RelayWebSocket.instances.push(this);
+		queueMicrotask(() => {
+			if (this.readyState !== RelayWebSocket.CONNECTING) return;
+			this.readyState = RelayWebSocket.OPEN;
+			relay.connect(this);
+			this.onopen?.();
+		});
+	}
+
+	send(data: Uint8Array): void {
+		if (this.readyState !== RelayWebSocket.OPEN) return;
+		const bytes = new Uint8Array(data);
+		queueMicrotask(() => this.#relay.forward(this, bytes));
+	}
+
+	close(_code?: number): void {
+		if (this.readyState === RelayWebSocket.CLOSED) return;
+		this.readyState = RelayWebSocket.CLOSED;
+		this.#relay.disconnect(this);
+		queueMicrotask(() => this.onclose?.({ code: 1000, reason: "closed" }));
+	}
+
+	/** Half-open drop: the transport dies under the client with a transient code. */
+	dropTransient(): void {
+		if (this.readyState === RelayWebSocket.CLOSED) return;
+		this.readyState = RelayWebSocket.CLOSED;
+		this.#relay.disconnect(this);
+		this.onclose?.({ code: 1006, reason: "Connection ended" });
+	}
+
+	deliver(bytes: Uint8Array): void {
+		if (this.readyState !== RelayWebSocket.OPEN) return;
+		const copy = new Uint8Array(bytes);
+		queueMicrotask(() => this.onmessage?.({ data: copy.buffer }));
+	}
+
+	deliverControl(json: string): void {
+		if (this.readyState !== RelayWebSocket.OPEN) return;
+		queueMicrotask(() => this.onmessage?.({ data: json }));
+	}
+}
+
+export class RecyclingRelay {
+	#host: RelayWebSocket | null = null;
+	#guests = new Map<number, RelayWebSocket>();
+	#nextPeerId = 1;
+	/** Peer ids minted per host registration, in order, for the assertions below. */
+	readonly minted: number[] = [];
+	rooms = 0;
+	/** Fires as the relay forwards a guest frame to the host, before the host observes it. */
+	onGuestFrame: ((peerId: number) => void) | null = null;
+
+	get hostConnected(): boolean {
+		return this.#host !== null;
+	}
+
+	connect(ws: RelayWebSocket): void {
+		if (ws.role === "host") {
+			if (this.#host) return; // a second host would get 4009; not modelled here
+			this.#host = ws;
+			this.#nextPeerId = 1;
+			this.#guests = new Map();
+			this.rooms++;
+			return;
+		}
+		if (!this.#host) return;
+		ws.peerId = this.#nextPeerId++;
+		this.minted.push(ws.peerId);
+		this.#guests.set(ws.peerId, ws);
+		this.#host.deliverControl(JSON.stringify({ t: "peer-joined", peer: ws.peerId }));
+	}
+
+	forward(from: RelayWebSocket, bytes: Uint8Array): void {
+		if (from.role === "host") {
+			if (this.#host !== from) return;
+			const envelope = unpackEnvelope(bytes);
+			if (!envelope) return;
+			if (envelope.peerId === 0) {
+				for (const guest of this.#guests.values()) guest.deliver(bytes);
+			} else {
+				this.#guests.get(envelope.peerId)?.deliver(bytes);
+			}
+			return;
+		}
+		if (!this.#guests.has(from.peerId) || this.#guests.get(from.peerId) !== from) return;
+		rewriteEnvelopePeer(bytes, from.peerId);
+		this.onGuestFrame?.(from.peerId);
+		this.#host?.deliver(bytes);
+	}
+
+	/** Room teardown mirrors the reference relay: host close frees the room and kicks guests. */
+	disconnect(ws: RelayWebSocket): void {
+		if (ws.role === "host") {
+			if (this.#host !== ws) return;
+			this.#host = null;
+			const closure = JSON.stringify({ t: "room-closed" });
+			for (const guest of this.#guests.values()) {
+				guest.deliverControl(closure);
+				queueMicrotask(() => guest.onclose?.({ code: 4001, reason: "room closed" }));
+				guest.readyState = RelayWebSocket.CLOSED;
+			}
+			this.#guests = new Map();
+			return;
+		}
+		if (this.#guests.get(ws.peerId) !== ws) return;
+		this.#guests.delete(ws.peerId);
+		this.#host?.deliverControl(JSON.stringify({ t: "peer-left", peer: ws.peerId }));
+	}
+}
+
+export function installRecyclingRelay(): RecyclingRelay {
+	activeRelay = new RecyclingRelay();
+	RelayWebSocket.instances = [];
+	globalThis.WebSocket = RelayWebSocket as unknown as typeof WebSocket;
+	return activeRelay;
+}
+
+export function uninstallRecyclingRelay(): void {
+	globalThis.WebSocket = RealWebSocket;
+	activeRelay = null;
+}
+
+/** The host's live transport, for the half-open drop these cases need. */
+export function hostLeg(): RelayWebSocket {
+	const leg = RelayWebSocket.instances.filter(ws => ws.role === "host").at(-1);
+	if (!leg) throw new Error("no host leg");
+	return leg;
+}
+
+export { packEnvelope };

--- a/packages/coding-agent/test/collab/host-reply-leg.test.ts
+++ b/packages/coding-agent/test/collab/host-reply-leg.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Contract: a directed reply the host computes across an await is delivered to the guest
+ * that asked, or to nobody.
+ *
+ * The relay mints peer ids per room from 1 and frees the room the moment the host socket
+ * closes, so a host that drops and reclaims meets a *different* guest holding the number
+ * its unfinished handler captured. `CollabSocket.send` therefore takes the `legId` that
+ * came with the request, and every host handler that answers after an await has to pass
+ * it — the leg capture inside `send` only sees the leg the reply is finally sent on, which
+ * by then is live, addressable and wrong.
+ *
+ * The socket-level suites pin the gate; these cases pin the callsites, because a handler
+ * that forgets the argument is invisible to both the gate and the type checker.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { importRoomKey } from "../../src/collab/crypto";
+import { CollabHost } from "../../src/collab/host";
+import { COLLAB_PROTO, type CollabFrame, parseCollabLink } from "../../src/collab/protocol";
+import { CollabSocket } from "../../src/collab/relay-client";
+import type { InteractiveModeContext } from "../../src/modes/types";
+import { AgentRegistry } from "../../src/registry/agent-registry";
+import type { AgentSession } from "../../src/session/agent-session";
+import {
+	hostLeg,
+	installRecyclingRelay,
+	type RecyclingRelay,
+	uninstallRecyclingRelay,
+} from "./helpers/recycling-relay";
+
+/** Mirrors LEG_SETTLE_MS in the client: a reclaimed leg is provisional for this long. */
+const LEG_SETTLE_MS = 2_000;
+/** How long a reply is given to reach the wire after its handler unparks. */
+const REPLY_WINDOW_MS = 400;
+
+interface HostHarness {
+	ctx: InteractiveModeContext;
+	/** Prompt turns the host is waiting on, newest last; rejecting one answers its guest. */
+	promptCalls: { reject: (err: Error) => void }[];
+}
+
+function makeHostContext(): HostHarness {
+	const promptCalls: { reject: (err: Error) => void }[] = [];
+	const ctx = {
+		settings: { get: () => "" },
+		sessionManager: {
+			getSessionId: () => "sess-reply-leg",
+			getCwd: () => "/tmp",
+			getSessionFile: () => undefined,
+			snapshotForReplication: () => ({
+				header: { type: "session", id: "sess-reply-leg", timestamp: new Date().toISOString(), cwd: "/tmp" },
+				entries: [],
+			}),
+			onEntryAppended: undefined,
+		},
+		session: {
+			isStreaming: false,
+			queuedMessageCount: 0,
+			sessionName: "reply-leg",
+			model: undefined,
+			thinkingLevel: undefined,
+			subscribe: () => () => {},
+			emitNotice: () => {},
+			promptCustomMessage: () => {
+				const { promise, reject } = Promise.withResolvers<void>();
+				promptCalls.push({ reject });
+				return promise;
+			},
+			abort: () => Promise.resolve(),
+		},
+		eventBus: undefined,
+		statusLine: {
+			setCollabStatus: () => {},
+			invalidate: () => {},
+			getCachedContextBreakdown: () => ({ usedTokens: 0, contextWindow: 0 }),
+		},
+		ui: { requestRender: () => {} },
+		showStatus: () => {},
+		showError: () => {},
+		updatePendingMessagesDisplay: () => {},
+		collabHost: undefined,
+	} as unknown as InteractiveModeContext;
+	return { ctx, promptCalls };
+}
+
+interface TestGuest {
+	socket: CollabSocket;
+	frames: CollabFrame[];
+	peerId: number;
+}
+
+const sleep = (ms: number): Promise<void> => {
+	const { promise, resolve } = Promise.withResolvers<void>();
+	setTimeout(resolve, ms);
+	return promise;
+};
+
+let harness: HostHarness;
+let host: CollabHost;
+let relay: RecyclingRelay;
+let tmpDir: string;
+const openGuests: CollabSocket[] = [];
+
+async function joinAsGuest(name: string): Promise<TestGuest> {
+	const parsed = parseCollabLink(host.link);
+	if ("error" in parsed) throw new Error(parsed.error);
+	const writeToken = parsed.writeToken ? Buffer.from(parsed.writeToken).toString("base64url") : undefined;
+	const key = await importRoomKey(parsed.key);
+	const socket = new CollabSocket({ wsUrl: parsed.wsUrl, role: "guest", key });
+	openGuests.push(socket);
+	const frames: CollabFrame[] = [];
+	const welcomed = Promise.withResolvers<void>();
+	socket.onFrame = frame => {
+		frames.push(frame);
+		if (frame.t === "welcome") welcomed.resolve();
+	};
+	socket.onOpen = () => socket.send({ t: "hello", proto: COLLAB_PROTO, name, writeToken });
+	socket.connect();
+	await welcomed.promise;
+	return { socket, frames, peerId: relay.minted.at(-1) ?? 0 };
+}
+
+/** Drops the host's transport half-open, then waits for the reclaimed leg to open and settle. */
+async function reclaimRoom(): Promise<void> {
+	const roomsBefore = relay.rooms;
+	hostLeg().dropTransient();
+	const deadline = Date.now() + 15_000;
+	while (relay.rooms === roomsBefore && Date.now() < deadline) await sleep(25);
+	if (relay.rooms === roomsBefore) throw new Error("the host never reconnected");
+	await sleep(LEG_SETTLE_MS + 400);
+}
+
+beforeEach(async () => {
+	tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "collab-reply-leg-"));
+	relay = installRecyclingRelay();
+	harness = makeHostContext();
+	host = new CollabHost(harness.ctx);
+	await host.start("ws://localhost:8787");
+});
+
+afterEach(async () => {
+	for (const socket of openGuests.splice(0)) socket.close();
+	uninstallRecyclingRelay();
+	await host.stop("test done");
+	await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe("CollabHost directed replies across a reclaim", () => {
+	it("does not hand a failed prompt's error to the guest that inherited the peer id", async () => {
+		const guestA = await joinAsGuest("guest-A");
+		expect(guestA.peerId).toBe(1);
+		// A steered prompt settles when the turn that absorbed it does — seconds to minutes,
+		// far longer than a reclaim takes.
+		guestA.socket.send({ t: "prompt", text: "the prompt guest A typed" });
+		const deadline = Date.now() + 5_000;
+		while (harness.promptCalls.length === 0 && Date.now() < deadline) await sleep(25);
+		expect(harness.promptCalls).toHaveLength(1);
+
+		guestA.socket.close();
+		await reclaimRoom();
+		const guestB = await joinAsGuest("guest-B");
+		// The crux: the fresh room handed guest B the number guest A's prompt captured.
+		expect(guestB.peerId).toBe(guestA.peerId);
+
+		harness.promptCalls[0]?.reject(new Error("guest A's prompt failed"));
+		await sleep(REPLY_WINDOW_MS);
+
+		expect(guestB.frames.filter(frame => frame.t === "error")).toEqual([]);
+	}, 30_000);
+
+	it("does not hand a failed agent command's error to the guest that inherited the peer id", async () => {
+		const registry = AgentRegistry.global();
+		const abortGate = Promise.withResolvers<void>();
+		const ref = registry.register({
+			id: "Reply-Leg-Agent",
+			displayName: "Reply-Leg-Agent",
+			kind: "sub",
+			session: { abort: () => abortGate.promise, dispose: async () => {} } as unknown as AgentSession,
+			sessionFile: path.join(tmpDir, "agent.jsonl"),
+			status: "running",
+		});
+		try {
+			const guestA = await joinAsGuest("guest-A");
+			expect(guestA.peerId).toBe(1);
+			// `kill` awaits the agent's abort, which the gate above holds open across the drop.
+			guestA.socket.send({ t: "agent-cmd", cmd: "kill", agentId: "Reply-Leg-Agent" });
+			await sleep(200);
+
+			guestA.socket.close();
+			await reclaimRoom();
+			const guestB = await joinAsGuest("guest-B");
+			expect(guestB.peerId).toBe(guestA.peerId);
+
+			abortGate.reject(new Error("guest A's kill failed"));
+			await sleep(REPLY_WINDOW_MS);
+
+			expect(guestB.frames.filter(frame => frame.t === "error")).toEqual([]);
+		} finally {
+			registry.unregister("Reply-Leg-Agent", ref);
+		}
+	}, 30_000);
+
+	it("still answers the guest that asked when no leg was lost", async () => {
+		const guest = await joinAsGuest("guest-A");
+		guest.socket.send({ t: "prompt", text: "a prompt that fails on its own leg" });
+		const deadline = Date.now() + 5_000;
+		while (harness.promptCalls.length === 0 && Date.now() < deadline) await sleep(25);
+
+		harness.promptCalls[0]?.reject(new Error("this turn failed"));
+		await sleep(REPLY_WINDOW_MS);
+
+		expect(guest.frames.filter(frame => frame.t === "error")).toHaveLength(1);
+	}, 30_000);
+});

--- a/packages/coding-agent/test/collab/relay-client-host-reclaim.test.ts
+++ b/packages/coding-agent/test/collab/relay-client-host-reclaim.test.ts
@@ -1,0 +1,1548 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import { COLLAB_PROTO, ENVELOPE_HEADER_LENGTH, packEnvelope, unpackEnvelope } from "../../src/collab/protocol";
+import { CollabSocket } from "../../src/collab/relay-client";
+
+const ORIGINAL_WEBSOCKET = globalThis.WebSocket;
+const HOST_CONFLICT_REASON = "a host is already connected for this room";
+const RECLAIM_RETRY_REASON = "relay has not released the previous host yet";
+const RECLAIM_WINDOW_MS = 120_000;
+const LEG_SETTLE_MS = 2_000;
+/** Backoff jitter is `0.75 + Math.random() * 0.5`: 0 pins the shortest ladder, 0.5 the base, 1 the longest. */
+const JITTER_SHORTEST = 0;
+const JITTER_NEUTRAL = 0.5;
+const JITTER_LONGEST = 1;
+/** Mirrors MAX_PENDING_SENDS in the client. */
+const PENDING_SEND_LIMIT = 256;
+/** Mirrors MAX_HELD_CONTROL_BYTES in the client. */
+const HOLD_CONTROL_LIMIT = 8 * 1024 * 1024;
+/** Mirrors MAX_HELD_PEER_BYTES in the client. */
+const HOLD_PEER_BYTES_LIMIT = 8 * 1024 * 1024;
+/** Mirrors HELD_STREAM_FLOOR_BYTES: what a stream may hold whatever the room is doing. */
+const HOLD_STREAM_FLOOR = 64 * 1024;
+/** What a stream past its floor competes for: the peer budget less HELD_FLOOR_RESERVE_BYTES. */
+const HOLD_COMPETE_LIMIT = HOLD_PEER_BYTES_LIMIT - 1024 * 1024;
+/** Payload size that makes a handful of held frames exceed what a stream competes for. */
+const FAT_PAYLOAD_BYTES = 2 * 1024 * 1024;
+/** Mirrors HELD_INBOUND_SLOT_BYTES in the client. */
+const HOLD_SLOT_BYTES = 256;
+/** Mirrors WS_BACKPRESSURE_DRAIN_RETRY_MS in the client. */
+const BACKPRESSURE_RETRY_MS = 25;
+/** Target peer of the frame standing in for a rejoining guest's welcome. */
+const REJOIN_PEER = 7;
+/** A guest that speaks after the hold already refused a message. */
+const LATE_GUEST = 9;
+/** A peer that spends its whole share of the hold on small frames. */
+const FLOOD_PEER = 30;
+
+/** Stand-in plaintext for an inbound guest frame; `open()` only needs valid frame JSON. */
+const HELLO_PAYLOAD = new TextEncoder().encode(JSON.stringify({ t: "bye", reason: "hello stand-in" })).buffer;
+
+/** Relay leg the tests drive by hand; InMemoryRelay models no host conflict, so it cannot be reused. */
+class ScriptedWebSocket {
+	static readonly CONNECTING = 0;
+	static readonly OPEN = 1;
+	static readonly CLOSING = 2;
+	static readonly CLOSED = 3;
+	static instances: ScriptedWebSocket[] = [];
+
+	/** Newest leg the client opened: the one the relay would answer. */
+	static get latest(): ScriptedWebSocket {
+		const leg = ScriptedWebSocket.instances.at(-1);
+		if (!leg) throw new Error("CollabSocket did not construct a WebSocket");
+		return leg;
+	}
+
+	readonly url: string;
+	binaryType = "arraybuffer";
+	bufferedAmount = 0;
+	sent: Uint8Array[] = [];
+	onclose: ((event: CloseEvent) => void) | null = null;
+	onerror: ((event: Event) => void) | null = null;
+	onmessage: ((event: MessageEvent) => void) | null = null;
+	onopen: ((event: Event) => void) | null = null;
+	readyState = ScriptedWebSocket.CONNECTING;
+
+	constructor(url: string) {
+		this.url = url;
+		ScriptedWebSocket.instances.push(this);
+	}
+
+	send(data: Uint8Array): void {
+		this.sent.push(data);
+	}
+
+	open(): void {
+		this.readyState = ScriptedWebSocket.OPEN;
+		this.onopen?.(new Event("open"));
+	}
+
+	/** Real Bun passes through CLOSING: the close frame is seen a task before onclose dispatches. */
+	beginClosing(): void {
+		this.readyState = ScriptedWebSocket.CLOSING;
+	}
+
+	/**
+	 * The relay routing a guest's frame to us is the only way a peer id becomes
+	 * addressable, so a test that sends to one has to let it speak first.
+	 */
+	introducePeer(peer: number): void {
+		this.onmessage?.({ data: packEnvelope(peer, new Uint8Array(32)).buffer } as MessageEvent);
+	}
+
+	closeWith(code: number, reason: string): void {
+		if (this.readyState === ScriptedWebSocket.CLOSED) return;
+		this.readyState = ScriptedWebSocket.CLOSED;
+		this.onclose?.({ code, reason } as CloseEvent);
+	}
+
+	/** Relay leg that still holds the previous registration: it upgrades first, then closes 4009. */
+	rejectAsHostConflict(): void {
+		this.open();
+		this.closeWith(4009, HOST_CONFLICT_REASON);
+	}
+
+	close(code = 1000): void {
+		this.closeWith(code, "closed");
+	}
+}
+
+interface SocketHarness {
+	socket: CollabSocket;
+	closes: { reason: string; willReconnect: boolean }[];
+	opens: string[];
+	reconnects: string[];
+}
+
+function startSocket(role: "host" | "guest"): SocketHarness {
+	const closes: { reason: string; willReconnect: boolean }[] = [];
+	const opens: string[] = [];
+	const reconnects: string[] = [];
+	const socket = new CollabSocket({
+		wsUrl: "ws://localhost:8788/r/reclaim",
+		role,
+		key: {} as CryptoKey,
+	});
+	socket.onClose = (reason, willReconnect) => closes.push({ reason, willReconnect });
+	socket.onOpen = () => opens.push("open");
+	socket.onReconnect = () => reconnects.push("reconnected");
+	socket.connect();
+	return { socket, closes, opens, reconnects };
+}
+
+/** Models a relay that never releases the room: reject every reconnect until the client gives up. */
+function rejectUntilFatal(closes: { willReconnect: boolean }[]): { attempts: number; elapsedMs: number } {
+	const startInstances = ScriptedWebSocket.instances.length;
+	let attempts = 0;
+	let elapsedMs = 0;
+	while (elapsedMs < 600_000 && !closes.some(close => !close.willReconnect)) {
+		vi.advanceTimersByTime(50);
+		elapsedMs += 50;
+		const created = ScriptedWebSocket.instances.length - startInstances;
+		if (created > attempts) {
+			attempts = created;
+			ScriptedWebSocket.latest.rejectAsHostConflict();
+		}
+	}
+	return { attempts, elapsedMs };
+}
+
+describe("CollabSocket host room reclaim", () => {
+	beforeEach(() => {
+		ScriptedWebSocket.instances = [];
+		vi.useFakeTimers();
+		globalThis.WebSocket = ScriptedWebSocket as unknown as typeof WebSocket;
+	});
+
+	afterEach(() => {
+		globalThis.WebSocket = ORIGINAL_WEBSOCKET;
+		vi.restoreAllMocks();
+		vi.useRealTimers();
+	});
+
+	it("treats a cold-connect 4009 as fatal", () => {
+		vi.spyOn(Math, "random").mockReturnValue(JITTER_NEUTRAL);
+		const { socket, closes } = startSocket("host");
+		try {
+			ScriptedWebSocket.latest.rejectAsHostConflict();
+
+			expect(closes).toEqual([{ reason: HOST_CONFLICT_REASON, willReconnect: false }]);
+			vi.advanceTimersByTime(RECLAIM_WINDOW_MS);
+			expect(ScriptedWebSocket.instances).toHaveLength(1);
+		} finally {
+			socket.close();
+		}
+	});
+
+	it("retries 4009 after an established socket died, then announces the reclaimed room", () => {
+		vi.spyOn(Math, "random").mockReturnValue(JITTER_NEUTRAL);
+		const { socket, closes, reconnects } = startSocket("host");
+		try {
+			ScriptedWebSocket.latest.open();
+			ScriptedWebSocket.latest.closeWith(1006, "Connection ended");
+			expect(closes).toEqual([{ reason: "Connection ended", willReconnect: true }]);
+
+			vi.advanceTimersByTime(1_000);
+			expect(ScriptedWebSocket.instances).toHaveLength(2);
+
+			for (const delayMs of [1_000, 2_000, 4_000]) {
+				ScriptedWebSocket.latest.rejectAsHostConflict();
+				vi.advanceTimersByTime(delayMs);
+			}
+			expect(ScriptedWebSocket.instances).toHaveLength(5);
+			expect(closes.filter(close => !close.willReconnect)).toEqual([]);
+			expect(closes.slice(1).map(close => close.reason)).toEqual([
+				RECLAIM_RETRY_REASON,
+				RECLAIM_RETRY_REASON,
+				RECLAIM_RETRY_REASON,
+			]);
+			// Each rejected socket fired onopen; none of them may announce a reconnect.
+			expect(reconnects).toEqual([]);
+
+			ScriptedWebSocket.latest.open();
+			vi.advanceTimersByTime(LEG_SETTLE_MS - 1);
+			expect(reconnects).toEqual([]);
+			vi.advanceTimersByTime(1);
+			expect(reconnects).toEqual(["reconnected"]);
+		} finally {
+			socket.close();
+		}
+	});
+
+	it("backs off exponentially across 4009 rejections even though each one fires onopen", () => {
+		vi.spyOn(Math, "random").mockReturnValue(JITTER_NEUTRAL);
+		const { socket } = startSocket("host");
+		try {
+			ScriptedWebSocket.latest.open();
+			ScriptedWebSocket.latest.closeWith(1006, "Connection ended");
+			vi.advanceTimersByTime(1_000);
+
+			let expectedSockets = 2;
+			for (const delayMs of [1_000, 2_000, 4_000]) {
+				ScriptedWebSocket.latest.rejectAsHostConflict();
+				vi.advanceTimersByTime(delayMs - 1);
+				expect(ScriptedWebSocket.instances).toHaveLength(expectedSockets);
+				vi.advanceTimersByTime(1);
+				expectedSockets++;
+				expect(ScriptedWebSocket.instances).toHaveLength(expectedSockets);
+			}
+		} finally {
+			socket.close();
+		}
+	});
+
+	it("gives up on 4009 once the reclaim window is spent, without hammering the relay", () => {
+		vi.spyOn(Math, "random").mockReturnValue(JITTER_LONGEST);
+		const expired = startSocket("host");
+		try {
+			ScriptedWebSocket.latest.open();
+			ScriptedWebSocket.latest.closeWith(1006, "Connection ended");
+			// Relay silent for longer than the window, so the next 4009 is a real host conflict.
+			vi.advanceTimersByTime(RECLAIM_WINDOW_MS + 1);
+			ScriptedWebSocket.latest.rejectAsHostConflict();
+
+			expect(expired.closes.at(-1)).toEqual({ reason: HOST_CONFLICT_REASON, willReconnect: false });
+			vi.advanceTimersByTime(RECLAIM_WINDOW_MS);
+			expect(ScriptedWebSocket.instances).toHaveLength(2);
+		} finally {
+			expired.socket.close();
+		}
+
+		const stuck = startSocket("host");
+		try {
+			ScriptedWebSocket.latest.open();
+			ScriptedWebSocket.latest.closeWith(1006, "Connection ended");
+
+			// A relay that keeps rejecting must exhaust the window, not retry forever. Retries
+			// are clamped to the deadline, so the last one lands on it rather than past it.
+			const { attempts, elapsedMs } = rejectUntilFatal(stuck.closes);
+			expect(attempts).toBeLessThan(10);
+			expect(elapsedMs).toBeGreaterThanOrEqual(RECLAIM_WINDOW_MS);
+			expect(stuck.closes.at(-1)).toEqual({ reason: HOST_CONFLICT_REASON, willReconnect: false });
+
+			const socketsAtGiveUp = ScriptedWebSocket.instances.length;
+			vi.advanceTimersByTime(RECLAIM_WINDOW_MS);
+			expect(ScriptedWebSocket.instances).toHaveLength(socketsAtGiveUp);
+		} finally {
+			stuck.socket.close();
+		}
+	});
+
+	it("fails a guest immediately on 4009 even after an established socket died", () => {
+		vi.spyOn(Math, "random").mockReturnValue(JITTER_NEUTRAL);
+		const { socket, closes } = startSocket("guest");
+		try {
+			ScriptedWebSocket.latest.open();
+			ScriptedWebSocket.latest.closeWith(1006, "Connection ended");
+			vi.advanceTimersByTime(1_000);
+			expect(ScriptedWebSocket.instances).toHaveLength(2);
+
+			ScriptedWebSocket.latest.rejectAsHostConflict();
+
+			expect(closes).toEqual([
+				{ reason: "Connection ended", willReconnect: true },
+				{ reason: HOST_CONFLICT_REASON, willReconnect: false },
+			]);
+			vi.advanceTimersByTime(RECLAIM_WINDOW_MS);
+			expect(ScriptedWebSocket.instances).toHaveLength(2);
+		} finally {
+			socket.close();
+		}
+	});
+
+	it("holds queued frames until the reclaim leg survives the relay's policy window", async () => {
+		vi.spyOn(Math, "random").mockReturnValue(JITTER_NEUTRAL);
+		vi.spyOn(crypto.subtle, "encrypt").mockResolvedValue(new Uint8Array([1, 2, 3, 4]).buffer);
+		const { socket } = startSocket("host");
+		try {
+			ScriptedWebSocket.latest.open();
+			ScriptedWebSocket.latest.closeWith(1006, "Connection ended");
+			socket.send({ t: "bye", reason: "queued while reconnecting" });
+			for (let flush = 0; flush < 5; flush++) await Promise.resolve();
+
+			vi.advanceTimersByTime(1_000);
+			const rejected = ScriptedWebSocket.latest;
+			rejected.rejectAsHostConflict();
+			for (let flush = 0; flush < 5; flush++) await Promise.resolve();
+			// The rejected leg opened, so draining into it would have consumed the backlog
+			// and left the reclaimed room with nothing to replay.
+			expect(rejected.sent).toEqual([]);
+
+			vi.advanceTimersByTime(1_000);
+			const reclaimed = ScriptedWebSocket.latest;
+			reclaimed.open();
+			for (let flush = 0; flush < 5; flush++) await Promise.resolve();
+			expect(reclaimed.sent).toEqual([]);
+
+			vi.advanceTimersByTime(LEG_SETTLE_MS);
+			for (let flush = 0; flush < 5; flush++) await Promise.resolve();
+			expect(reclaimed.sent).toHaveLength(1);
+		} finally {
+			socket.close();
+		}
+	});
+
+	it("renews the reclaim window only from a leg the relay kept", () => {
+		vi.spyOn(Math, "random").mockReturnValue(JITTER_NEUTRAL);
+		const preOpen = startSocket("host");
+		try {
+			ScriptedWebSocket.latest.open();
+			ScriptedWebSocket.latest.closeWith(1006, "Connection ended");
+			vi.advanceTimersByTime(RECLAIM_WINDOW_MS + 1);
+			// A retry leg that dies before onopen never held the room: it must not push the
+			// deadline forward, or alternating drops and 4009s would reclaim forever.
+			ScriptedWebSocket.latest.closeWith(1006, "Connection ended");
+			vi.advanceTimersByTime(2_000);
+			ScriptedWebSocket.latest.rejectAsHostConflict();
+
+			expect(preOpen.closes.at(-1)).toEqual({ reason: HOST_CONFLICT_REASON, willReconnect: false });
+		} finally {
+			preOpen.socket.close();
+		}
+
+		const provisional = startSocket("host");
+		try {
+			ScriptedWebSocket.latest.open();
+			ScriptedWebSocket.latest.closeWith(1006, "Connection ended");
+			vi.advanceTimersByTime(1_000);
+			// Same for a leg that reached onopen but died before its settle window closed.
+			ScriptedWebSocket.latest.open();
+			vi.advanceTimersByTime(LEG_SETTLE_MS - 1);
+			ScriptedWebSocket.latest.closeWith(1006, "Connection ended");
+			expect(provisional.reconnects).toEqual([]);
+
+			vi.advanceTimersByTime(RECLAIM_WINDOW_MS);
+			ScriptedWebSocket.latest.rejectAsHostConflict();
+
+			expect(provisional.closes.at(-1)).toEqual({ reason: HOST_CONFLICT_REASON, willReconnect: false });
+		} finally {
+			provisional.socket.close();
+		}
+	});
+
+	it("keeps retrying to the deadline on the shortest jitter without hammering the relay", () => {
+		vi.spyOn(Math, "random").mockReturnValue(JITTER_SHORTEST);
+		const { socket, closes } = startSocket("host");
+		try {
+			ScriptedWebSocket.latest.open();
+			ScriptedWebSocket.latest.closeWith(1006, "Connection ended");
+
+			const legTimes: number[] = [];
+			let elapsedMs = 0;
+			let seen = ScriptedWebSocket.instances.length;
+			while (elapsedMs <= RECLAIM_WINDOW_MS && !closes.some(close => !close.willReconnect)) {
+				if (ScriptedWebSocket.instances.length > seen) {
+					seen = ScriptedWebSocket.instances.length;
+					legTimes.push(elapsedMs);
+					ScriptedWebSocket.latest.rejectAsHostConflict();
+					continue;
+				}
+				vi.advanceTimersByTime(50);
+				elapsedMs += 50;
+			}
+
+			// Shortest jitter is the densest ladder the window can produce: it still fits in
+			// ten attempts, the last retry lands exactly on the deadline, and the 4009 that
+			// comes back from it is fatal because the window is spent.
+			expect(legTimes.filter(at => at < RECLAIM_WINDOW_MS).length).toBeLessThanOrEqual(10);
+			expect(legTimes.at(-1)).toBe(RECLAIM_WINDOW_MS);
+			expect(closes.at(-1)).toEqual({ reason: HOST_CONFLICT_REASON, willReconnect: false });
+		} finally {
+			socket.close();
+		}
+	});
+
+	it("clamps a conflict retry that would overshoot the reclaim deadline", () => {
+		vi.spyOn(Math, "random").mockReturnValue(JITTER_NEUTRAL);
+		const { socket, closes } = startSocket("host");
+		try {
+			ScriptedWebSocket.latest.open();
+			ScriptedWebSocket.latest.closeWith(1006, "Connection ended");
+
+			const legTimes: number[] = [];
+			let elapsedMs = 0;
+			let seen = ScriptedWebSocket.instances.length;
+			while (elapsedMs <= RECLAIM_WINDOW_MS && !closes.some(close => !close.willReconnect)) {
+				if (ScriptedWebSocket.instances.length > seen) {
+					seen = ScriptedWebSocket.instances.length;
+					legTimes.push(elapsedMs);
+					ScriptedWebSocket.latest.rejectAsHostConflict();
+					continue;
+				}
+				vi.advanceTimersByTime(50);
+				elapsedMs += 50;
+			}
+
+			// On neutral jitter the eighth conflict lands at 92s and the next 30s step would
+			// open at 122s, past the deadline, leaving the last 28s of the window unprobed.
+			expect(legTimes.filter(at => at < RECLAIM_WINDOW_MS)).toEqual([
+				1_000, 2_000, 4_000, 8_000, 16_000, 32_000, 62_000, 92_000,
+			]);
+			expect(legTimes.at(-1)).toBe(RECLAIM_WINDOW_MS);
+			expect(closes.at(-1)).toEqual({ reason: HOST_CONFLICT_REASON, willReconnect: false });
+		} finally {
+			socket.close();
+		}
+	});
+
+	it("keeps reclaiming when the relay's 4009 lands after the settle window", () => {
+		vi.spyOn(Math, "random").mockReturnValue(JITTER_NEUTRAL);
+		const { socket, closes, reconnects } = startSocket("host");
+		try {
+			ScriptedWebSocket.latest.open();
+			ScriptedWebSocket.latest.closeWith(1006, "Connection ended");
+			vi.advanceTimersByTime(1_000);
+
+			const late = ScriptedWebSocket.latest;
+			late.open();
+			// Surviving the settle window is a send/notify heuristic, not an acknowledgement:
+			// on a degraded path the rejection can still be in flight.
+			vi.advanceTimersByTime(LEG_SETTLE_MS);
+			expect(reconnects).toEqual(["reconnected"]);
+
+			late.closeWith(4009, HOST_CONFLICT_REASON);
+
+			expect(closes.at(-1)).toEqual({ reason: RECLAIM_RETRY_REASON, willReconnect: true });
+			const legsBefore = ScriptedWebSocket.instances.length;
+			vi.advanceTimersByTime(1_000);
+			expect(ScriptedWebSocket.instances).toHaveLength(legsBefore + 1);
+			ScriptedWebSocket.latest.open();
+			vi.advanceTimersByTime(LEG_SETTLE_MS);
+			expect(reconnects).toEqual(["reconnected", "reconnected"]);
+		} finally {
+			socket.close();
+		}
+	});
+
+	it("answers nobody while the leg is provisional, then replies once it is real", async () => {
+		vi.spyOn(Math, "random").mockReturnValue(JITTER_NEUTRAL);
+		vi.spyOn(crypto.subtle, "encrypt").mockResolvedValue(new Uint8Array([1, 2, 3, 4]).buffer);
+		vi.spyOn(crypto.subtle, "decrypt").mockResolvedValue(HELLO_PAYLOAD);
+		const { socket } = startSocket("host");
+		try {
+			ScriptedWebSocket.latest.open();
+			ScriptedWebSocket.latest.closeWith(1006, "Connection ended");
+			socket.send({ t: "bye", reason: "entry appended during the outage" });
+			for (let tick = 0; tick < 50; tick++) await Promise.resolve();
+
+			vi.advanceTimersByTime(1_000);
+			const reclaimed = ScriptedWebSocket.latest;
+			reclaimed.open();
+			// The relay routes a rejoining guest's hello onto the provisional leg. Nothing
+			// answers it there: the leg can still be rejected with 4009, and a welcome sent
+			// across it would die with the leg while promising the guest a snapshot.
+			reclaimed.introducePeer(REJOIN_PEER);
+			socket.send({ t: "bye", reason: "reply nobody asked for yet" }, REJOIN_PEER);
+			for (let tick = 0; tick < 200; tick++) await Promise.resolve();
+			expect(reclaimed.sent).toEqual([]);
+
+			vi.advanceTimersByTime(LEG_SETTLE_MS);
+			for (let tick = 0; tick < 200; tick++) await Promise.resolve();
+
+			// The outage backlog flushes, and the held hello reaches the session only now —
+			// so this is where the id becomes addressable and the reply goes out.
+			socket.send({ t: "bye", reason: "welcome on a leg that holds the room" }, REJOIN_PEER);
+			for (let tick = 0; tick < 200; tick++) await Promise.resolve();
+
+			const peers = reclaimed.sent.map(envelope => unpackEnvelope(envelope)?.peerId);
+			expect(peers).toEqual([0, REJOIN_PEER]);
+		} finally {
+			socket.close();
+		}
+	});
+
+	it("drops the inbound a rejected leg held instead of replaying it onto the next one", async () => {
+		vi.spyOn(Math, "random").mockReturnValue(JITTER_NEUTRAL);
+		vi.spyOn(crypto.subtle, "decrypt").mockResolvedValue(HELLO_PAYLOAD);
+		const inbound: number[] = [];
+		const { socket } = startSocket("host");
+		socket.onFrame = (_frame, fromPeer) => inbound.push(fromPeer);
+		try {
+			ScriptedWebSocket.latest.open();
+			ScriptedWebSocket.latest.closeWith(1006, "Connection ended");
+			vi.advanceTimersByTime(1_000);
+			const rejected = ScriptedWebSocket.latest;
+			rejected.open();
+			rejected.introducePeer(REJOIN_PEER);
+			// Nothing reaches the session while the leg is provisional, not even once the
+			// chain has had every chance to run.
+			for (let tick = 0; tick < 50; tick++) await Promise.resolve();
+			expect(inbound).toEqual([]);
+			// 4009: this leg never held the room, so every id it heard from belongs to a
+			// registration the relay is about to hand out again from 1.
+			rejected.rejectAsHostConflict();
+			vi.advanceTimersByTime(1_000);
+			const next = ScriptedWebSocket.latest;
+			next.open();
+			vi.advanceTimersByTime(LEG_SETTLE_MS);
+			for (let tick = 0; tick < 200; tick++) await Promise.resolve();
+
+			expect(next).not.toBe(rejected);
+			expect(inbound).toEqual([]);
+		} finally {
+			socket.close();
+		}
+	});
+
+	it("never sends a directed frame on a leg that did not mint its peer id", async () => {
+		vi.spyOn(Math, "random").mockReturnValue(JITTER_NEUTRAL);
+		vi.spyOn(crypto.subtle, "encrypt").mockResolvedValue(new Uint8Array([1, 2, 3, 4]).buffer);
+		const { socket } = startSocket("host");
+		try {
+			ScriptedWebSocket.latest.open();
+			// A reply to a guest of this room generation loses its race with the drop: the
+			// relay frees the room and hands the same peer id to whoever connects next, so
+			// this envelope must never reach the wire.
+			ScriptedWebSocket.latest.closeWith(1006, "Connection ended");
+			socket.send({ t: "bye", reason: "reply to a guest of the dead room" }, REJOIN_PEER);
+			socket.send({ t: "bye", reason: "session event" });
+			for (let tick = 0; tick < 20; tick++) await Promise.resolve();
+
+			vi.advanceTimersByTime(1_000);
+			const reclaimed = ScriptedWebSocket.latest;
+			reclaimed.open();
+			vi.advanceTimersByTime(LEG_SETTLE_MS);
+			for (let tick = 0; tick < 20; tick++) await Promise.resolve();
+
+			const peers = reclaimed.sent.map(envelope => unpackEnvelope(envelope)?.peerId);
+			expect(peers).toEqual([0]);
+		} finally {
+			socket.close();
+		}
+	});
+
+	it("refuses inbound past the hold's byte ceiling and replays the prefix it kept", async () => {
+		vi.spyOn(Math, "random").mockReturnValue(JITTER_NEUTRAL);
+		vi.spyOn(crypto.subtle, "decrypt").mockResolvedValue(HELLO_PAYLOAD);
+		const inbound: number[] = [];
+		const { socket } = startSocket("host");
+		socket.onFrame = (_frame, fromPeer) => inbound.push(fromPeer);
+		try {
+			ScriptedWebSocket.latest.open();
+			ScriptedWebSocket.latest.closeWith(1006, "Connection ended");
+			vi.advanceTimersByTime(1_000);
+			const reclaimed = ScriptedWebSocket.latest;
+			reclaimed.open();
+			// The ceiling is on bytes, not messages, so what it turns away is a peer pushing
+			// megabytes into the settle window — never the handful of small frames a whole
+			// room's rejoin costs. What it keeps stays an ordered prefix: a message delivered
+			// after a dropped predecessor is what has the session act on a guest it was never
+			// introduced to.
+			const envelopes = Array.from({ length: 8 }, (_, index) =>
+				packEnvelope(index + 1, new Uint8Array(FAT_PAYLOAD_BYTES)),
+			);
+			const charge = (envelopes[0]?.buffer.byteLength ?? 0) + HOLD_SLOT_BYTES;
+			const fits = Math.floor(HOLD_COMPETE_LIMIT / charge);
+			for (const envelope of envelopes) reclaimed.onmessage?.({ data: envelope.buffer } as MessageEvent);
+			vi.advanceTimersByTime(LEG_SETTLE_MS);
+			for (let tick = 0; tick < 400; tick++) await Promise.resolve();
+
+			expect(fits).toBeLessThan(envelopes.length);
+			expect(inbound).toEqual(Array.from({ length: fits }, (_, index) => index + 1));
+		} finally {
+			socket.close();
+		}
+	});
+
+	it("keeps holding a whole room's rejoin, far short of the ceiling", async () => {
+		vi.spyOn(Math, "random").mockReturnValue(JITTER_NEUTRAL);
+		vi.spyOn(crypto.subtle, "decrypt").mockResolvedValue(HELLO_PAYLOAD);
+		const inbound: number[] = [];
+		const controls: number[] = [];
+		const { socket } = startSocket("host");
+		socket.onFrame = (_frame, fromPeer) => inbound.push(fromPeer);
+		socket.onControl = msg => controls.push(msg.t === "peer-left" ? -1 : 1);
+		try {
+			ScriptedWebSocket.latest.open();
+			ScriptedWebSocket.latest.closeWith(1006, "Connection ended");
+			vi.advanceTimersByTime(1_000);
+			const reclaimed = ScriptedWebSocket.latest;
+			reclaimed.open();
+			// The traffic a reclaim really produces: the relay 4001'd the room, so every guest
+			// rejoins at once with a peer-joined and a hello. None of it may be refused — a
+			// dropped hello leaves that guest waiting on a welcome nothing will re-request.
+			const guests = 400;
+			for (let peer = 1; peer <= guests; peer++) {
+				reclaimed.onmessage?.({ data: JSON.stringify({ t: "peer-joined", peer }) } as MessageEvent);
+				reclaimed.introducePeer(peer);
+			}
+			// Held, not answered: the leg can still be rejected, and the room is what the hold
+			// has to carry across the settle without refusing any of it.
+			for (let tick = 0; tick < 4_000; tick++) await Promise.resolve();
+			expect(inbound).toEqual([]);
+			expect(controls).toEqual([]);
+
+			vi.advanceTimersByTime(LEG_SETTLE_MS);
+			for (let tick = 0; tick < 4_000; tick++) await Promise.resolve();
+
+			expect(inbound).toEqual(Array.from({ length: guests }, (_, index) => index + 1));
+			expect(controls).toHaveLength(guests);
+		} finally {
+			socket.close();
+		}
+	});
+
+	it("refuses a frame that overruns the send buffer instead of leaving a gap", async () => {
+		vi.spyOn(Math, "random").mockReturnValue(JITTER_NEUTRAL);
+		vi.spyOn(crypto.subtle, "encrypt").mockResolvedValue(new Uint8Array([1, 2, 3, 4]).buffer);
+		vi.spyOn(crypto.subtle, "decrypt").mockResolvedValue(HELLO_PAYLOAD);
+		const { socket } = startSocket("host");
+		try {
+			const leg = ScriptedWebSocket.latest;
+			leg.open();
+			for (let peer = 1; peer <= PENDING_SEND_LIMIT + 4; peer++) leg.introducePeer(peer);
+			for (let tick = 0; tick < 2_000; tick++) await Promise.resolve();
+
+			// A guest that stopped reading: everything spills into the buffer. Past its bound
+			// the arrival is refused rather than evicting from the queue, so what ships stays
+			// the ordered prefix the session emitted — a hole in a replicated entry stream
+			// leaves every replica silently wrong, a missing tail is refilled by the next
+			// rejoin snapshot.
+			leg.bufferedAmount = 1_000_000;
+			for (let peer = 1; peer <= PENDING_SEND_LIMIT + 4; peer++) {
+				socket.send({ t: "bye", reason: `reply ${peer}` }, peer);
+			}
+			for (let tick = 0; tick < 4_000; tick++) await Promise.resolve();
+			expect(leg.sent).toEqual([]);
+
+			leg.bufferedAmount = 0;
+			vi.advanceTimersByTime(BACKPRESSURE_RETRY_MS);
+			for (let tick = 0; tick < 2_000; tick++) await Promise.resolve();
+
+			const peers = leg.sent.map(envelope => unpackEnvelope(envelope)?.peerId);
+			expect(peers).toHaveLength(PENDING_SEND_LIMIT);
+			expect(peers[0]).toBe(1);
+			expect(peers.at(-1)).toBe(PENDING_SEND_LIMIT);
+		} finally {
+			socket.close();
+		}
+	});
+
+	it("refuses a broadcast that overruns the send buffer too", async () => {
+		vi.spyOn(Math, "random").mockReturnValue(JITTER_NEUTRAL);
+		let tag = 0;
+		vi.spyOn(crypto.subtle, "encrypt").mockImplementation(() =>
+			Promise.resolve(new Uint8Array([tag++, 0, 0, 0]).buffer),
+		);
+		const { socket } = startSocket("host");
+		try {
+			const leg = ScriptedWebSocket.latest;
+			leg.open();
+			// Session entries are broadcasts, and they are what actually fills the buffer when
+			// the relay stops reading. The bound is on the buffer, not on who a frame is for,
+			// and it refuses the arrival: evicting instead would ship a queue that starts
+			// after the entry the guest last saw.
+			leg.bufferedAmount = 1_000_000;
+			for (let entry = 0; entry < PENDING_SEND_LIMIT + 4; entry++) {
+				socket.send({ t: "bye", reason: `entry ${entry}` });
+			}
+			for (let tick = 0; tick < 4_000; tick++) await Promise.resolve();
+			expect(leg.sent).toEqual([]);
+
+			leg.bufferedAmount = 0;
+			vi.advanceTimersByTime(BACKPRESSURE_RETRY_MS);
+			for (let tick = 0; tick < 2_000; tick++) await Promise.resolve();
+
+			expect(leg.sent).toHaveLength(PENDING_SEND_LIMIT);
+			const tags = leg.sent.map(envelope => unpackEnvelope(envelope)?.payload.at(-4));
+			expect(tags[0]).toBe(0);
+			expect(tags.at(-1)).toBe(PENDING_SEND_LIMIT - 1);
+		} finally {
+			socket.close();
+		}
+	});
+
+	it("renews the reclaim window on every accepted drop, not just the first", () => {
+		vi.spyOn(Math, "random").mockReturnValue(JITTER_NEUTRAL);
+		const { socket, closes, reconnects } = startSocket("host");
+		try {
+			ScriptedWebSocket.latest.open();
+			ScriptedWebSocket.latest.closeWith(1006, "Connection ended");
+			vi.advanceTimersByTime(1_000);
+			ScriptedWebSocket.latest.open();
+			vi.advanceTimersByTime(LEG_SETTLE_MS);
+			expect(reconnects).toEqual(["reconnected"]);
+
+			// The reclaimed leg serves the session until just before the first window would
+			// have expired, then dies half-open: its own window has to start from there, or
+			// every outage after the first two minutes is unreclaimable.
+			vi.advanceTimersByTime(RECLAIM_WINDOW_MS - LEG_SETTLE_MS - 2_000);
+			ScriptedWebSocket.latest.closeWith(1006, "Connection ended");
+			vi.advanceTimersByTime(1_000);
+			ScriptedWebSocket.latest.rejectAsHostConflict();
+
+			expect(closes.at(-1)).toEqual({ reason: RECLAIM_RETRY_REASON, willReconnect: true });
+		} finally {
+			socket.close();
+		}
+	});
+
+	it("restarts the conflict ladder after a reclaimed leg drops again", () => {
+		vi.spyOn(Math, "random").mockReturnValue(JITTER_NEUTRAL);
+		const { socket, reconnects } = startSocket("host");
+		try {
+			ScriptedWebSocket.latest.open();
+			ScriptedWebSocket.latest.closeWith(1006, "Connection ended");
+			vi.advanceTimersByTime(1_000);
+			ScriptedWebSocket.latest.rejectAsHostConflict();
+			vi.advanceTimersByTime(1_000);
+			ScriptedWebSocket.latest.open();
+			vi.advanceTimersByTime(LEG_SETTLE_MS);
+			expect(reconnects).toEqual(["reconnected"]);
+
+			// A fresh outage must probe at the base step again instead of inheriting the
+			// ladder the previous reclaim had climbed.
+			ScriptedWebSocket.latest.closeWith(1006, "Connection ended");
+			vi.advanceTimersByTime(1_000);
+			ScriptedWebSocket.latest.rejectAsHostConflict();
+			const legs = ScriptedWebSocket.instances.length;
+			vi.advanceTimersByTime(999);
+			expect(ScriptedWebSocket.instances).toHaveLength(legs);
+			vi.advanceTimersByTime(1);
+			expect(ScriptedWebSocket.instances).toHaveLength(legs + 1);
+		} finally {
+			socket.close();
+		}
+	});
+
+	it("restarts the transient ladder once a leg is accepted", () => {
+		vi.spyOn(Math, "random").mockReturnValue(JITTER_NEUTRAL);
+		const { socket } = startSocket("host");
+		try {
+			ScriptedWebSocket.latest.open();
+			ScriptedWebSocket.latest.closeWith(1006, "Connection ended");
+			vi.advanceTimersByTime(1_000);
+			ScriptedWebSocket.latest.open();
+			vi.advanceTimersByTime(LEG_SETTLE_MS);
+			ScriptedWebSocket.latest.closeWith(1006, "Connection ended");
+
+			const legs = ScriptedWebSocket.instances.length;
+			vi.advanceTimersByTime(999);
+			expect(ScriptedWebSocket.instances).toHaveLength(legs);
+			vi.advanceTimersByTime(1);
+			expect(ScriptedWebSocket.instances).toHaveLength(legs + 1);
+		} finally {
+			socket.close();
+		}
+	});
+
+	it("keeps growing the conflict ladder across accepted legs", () => {
+		vi.spyOn(Math, "random").mockReturnValue(JITTER_NEUTRAL);
+		const { socket, reconnects } = startSocket("host");
+		try {
+			ScriptedWebSocket.latest.open();
+			ScriptedWebSocket.latest.closeWith(1006, "Connection ended");
+			vi.advanceTimersByTime(1_000);
+			ScriptedWebSocket.latest.open();
+			vi.advanceTimersByTime(LEG_SETTLE_MS);
+			// Late rejection: the leg settled, so acceptance must not refill the ladder, or
+			// an accept → late-4009 loop reconnects on a fixed short cycle for the whole window.
+			ScriptedWebSocket.latest.closeWith(4009, HOST_CONFLICT_REASON);
+			vi.advanceTimersByTime(1_000);
+			ScriptedWebSocket.latest.open();
+			vi.advanceTimersByTime(LEG_SETTLE_MS);
+			expect(reconnects).toEqual(["reconnected", "reconnected"]);
+			ScriptedWebSocket.latest.closeWith(4009, HOST_CONFLICT_REASON);
+
+			const legs = ScriptedWebSocket.instances.length;
+			vi.advanceTimersByTime(1_000);
+			expect(ScriptedWebSocket.instances).toHaveLength(legs);
+			vi.advanceTimersByTime(1_000);
+			expect(ScriptedWebSocket.instances).toHaveLength(legs + 1);
+		} finally {
+			socket.close();
+		}
+	});
+
+	it("withholds onOpen until the provisional leg settles", () => {
+		vi.spyOn(Math, "random").mockReturnValue(JITTER_NEUTRAL);
+		const { socket, opens } = startSocket("host");
+		try {
+			ScriptedWebSocket.latest.open();
+			expect(opens).toHaveLength(1);
+			ScriptedWebSocket.latest.closeWith(1006, "Connection ended");
+			vi.advanceTimersByTime(1_000);
+			ScriptedWebSocket.latest.open();
+
+			vi.advanceTimersByTime(LEG_SETTLE_MS - 1);
+			expect(opens).toHaveLength(1);
+			vi.advanceTimersByTime(1);
+			expect(opens).toHaveLength(2);
+		} finally {
+			socket.close();
+		}
+	});
+
+	it("accepts a guest reconnect leg immediately", async () => {
+		vi.spyOn(Math, "random").mockReturnValue(JITTER_NEUTRAL);
+		vi.spyOn(crypto.subtle, "encrypt").mockResolvedValue(new Uint8Array([1, 2, 3, 4]).buffer);
+		const { socket, opens } = startSocket("guest");
+		try {
+			ScriptedWebSocket.latest.open();
+			ScriptedWebSocket.latest.closeWith(1006, "Connection ended");
+			vi.advanceTimersByTime(1_000);
+			const leg = ScriptedWebSocket.latest;
+			leg.open();
+
+			// A guest can never be rejected with 4009, so deferring its hello by the settle
+			// window would only delay the rejoin.
+			expect(opens).toHaveLength(2);
+			socket.send({ t: "hello", proto: COLLAB_PROTO, name: "guest" });
+			for (let tick = 0; tick < 5; tick++) await Promise.resolve();
+			expect(leg.sent).toHaveLength(1);
+		} finally {
+			socket.close();
+		}
+	});
+
+	it("does not promote a leg that entered CLOSING before its settle window ended", async () => {
+		vi.spyOn(Math, "random").mockReturnValue(JITTER_NEUTRAL);
+		vi.spyOn(crypto.subtle, "encrypt").mockResolvedValue(new Uint8Array([1, 2, 3, 4]).buffer);
+		const { socket, reconnects } = startSocket("host");
+		try {
+			ScriptedWebSocket.latest.open();
+			ScriptedWebSocket.latest.closeWith(1006, "Connection ended");
+			socket.send({ t: "bye", reason: "queued while reconnecting" });
+			for (let tick = 0; tick < 5; tick++) await Promise.resolve();
+
+			vi.advanceTimersByTime(1_000);
+			const leg = ScriptedWebSocket.latest;
+			leg.open();
+			// The relay's close frame lands before onclose dispatches, which is the window
+			// where Bun reports CLOSING and a send would buffer without ever flushing.
+			leg.beginClosing();
+			vi.advanceTimersByTime(LEG_SETTLE_MS);
+			for (let tick = 0; tick < 5; tick++) await Promise.resolve();
+
+			expect(reconnects).toEqual([]);
+			expect(leg.sent).toEqual([]);
+		} finally {
+			socket.close();
+		}
+	});
+
+	it("holds a provisional leg's inbound until it settles, in one arrival order", async () => {
+		vi.spyOn(Math, "random").mockReturnValue(JITTER_NEUTRAL);
+		vi.spyOn(crypto.subtle, "encrypt").mockResolvedValue(new Uint8Array([1, 2, 3, 4]).buffer);
+		vi.spyOn(crypto.subtle, "decrypt").mockResolvedValue(
+			new TextEncoder().encode(JSON.stringify({ t: "hello", proto: COLLAB_PROTO, name: "guest" })).buffer,
+		);
+		const events: string[] = [];
+		const { socket, reconnects } = startSocket("host");
+		socket.onFrame = (frame, fromPeer) => events.push(`frame:${frame.t}:${fromPeer}`);
+		socket.onControl = msg => events.push(`control:${msg.t}`);
+		try {
+			ScriptedWebSocket.latest.open();
+			ScriptedWebSocket.latest.closeWith(1006, "Connection ended");
+			vi.advanceTimersByTime(1_000);
+			const leg = ScriptedWebSocket.latest;
+			leg.open();
+			expect(reconnects).toEqual([]);
+
+			leg.onmessage?.({ data: packEnvelope(REJOIN_PEER, new Uint8Array(32)).buffer } as MessageEvent);
+			leg.onmessage?.({ data: JSON.stringify({ t: "peer-left", peer: REJOIN_PEER }) } as MessageEvent);
+			for (let tick = 0; tick < 50; tick++) await Promise.resolve();
+			expect(events).toEqual([]);
+
+			vi.advanceTimersByTime(LEG_SETTLE_MS);
+			for (let tick = 0; tick < 50; tick++) await Promise.resolve();
+
+			// Frames decrypt on a chain while control messages parse synchronously, so the
+			// two share one order: told that a guest left before hearing from it, the session
+			// would put it back in the participant list and address an id that is gone.
+			expect(events).toEqual([`frame:hello:${REJOIN_PEER}`, "control:peer-left"]);
+			socket.send({ t: "bye", reason: "after the guest left" }, REJOIN_PEER);
+			for (let tick = 0; tick < 50; tick++) await Promise.resolve();
+			expect(leg.sent).toEqual([]);
+		} finally {
+			socket.close();
+		}
+	});
+
+	it("arms no timer past close() during a provisional leg", () => {
+		vi.spyOn(Math, "random").mockReturnValue(JITTER_NEUTRAL);
+		const { socket } = startSocket("host");
+		ScriptedWebSocket.latest.open();
+		ScriptedWebSocket.latest.closeWith(1006, "Connection ended");
+		vi.advanceTimersByTime(1_000);
+		ScriptedWebSocket.latest.open();
+
+		socket.close();
+
+		expect(vi.getTimerCount()).toBe(0);
+	});
+
+	it("drops a frame sealed across a close instead of refilling the buffer", async () => {
+		vi.spyOn(Math, "random").mockReturnValue(JITTER_NEUTRAL);
+		const seal = Promise.withResolvers<ArrayBuffer>();
+		vi.spyOn(crypto.subtle, "encrypt").mockReturnValue(seal.promise);
+		const { socket } = startSocket("host");
+		ScriptedWebSocket.latest.open();
+		socket.send({ t: "bye", reason: "sealed across the close" });
+		// The send is parked inside seal(), so it resumes after close() emptied the buffer.
+		for (let tick = 0; tick < 5; tick++) await Promise.resolve();
+		socket.close();
+		seal.resolve(new Uint8Array([1, 2, 3, 4]).buffer);
+		for (let tick = 0; tick < 20; tick++) await Promise.resolve();
+
+		socket.connect();
+		const revived = ScriptedWebSocket.latest;
+		revived.open();
+		for (let tick = 0; tick < 20; tick++) await Promise.resolve();
+
+		expect(revived.sent).toEqual([]);
+		socket.close();
+	});
+
+	it("caps a transient retry at the reclaim deadline too", () => {
+		vi.spyOn(Math, "random").mockReturnValue(JITTER_NEUTRAL);
+		const { socket } = startSocket("host");
+		try {
+			ScriptedWebSocket.latest.open();
+			ScriptedWebSocket.latest.closeWith(1006, "Connection ended");
+
+			// A flapping path: every retry leg dies before it opens, so the transient ladder
+			// climbs while the window runs. Its last step must land on the deadline, not past
+			// it, or the stretch where the relay has usually released the room goes unprobed.
+			const legTimes: number[] = [];
+			let elapsedMs = 0;
+			let seen = ScriptedWebSocket.instances.length;
+			while (elapsedMs <= RECLAIM_WINDOW_MS) {
+				if (ScriptedWebSocket.instances.length > seen) {
+					seen = ScriptedWebSocket.instances.length;
+					legTimes.push(elapsedMs);
+					ScriptedWebSocket.latest.closeWith(1006, "Connection ended");
+					continue;
+				}
+				vi.advanceTimersByTime(50);
+				elapsedMs += 50;
+			}
+
+			expect(legTimes).toEqual([1_000, 3_000, 7_000, 15_000, 31_000, 61_000, 91_000, RECLAIM_WINDOW_MS]);
+		} finally {
+			socket.close();
+		}
+	});
+
+	it("stops addressing a peer the relay reports as gone", async () => {
+		vi.spyOn(Math, "random").mockReturnValue(JITTER_NEUTRAL);
+		vi.spyOn(crypto.subtle, "encrypt").mockResolvedValue(new Uint8Array([1, 2, 3, 4]).buffer);
+		vi.spyOn(crypto.subtle, "decrypt").mockResolvedValue(HELLO_PAYLOAD);
+		const { socket } = startSocket("host");
+		try {
+			const leg = ScriptedWebSocket.latest;
+			leg.open();
+			leg.introducePeer(REJOIN_PEER);
+			socket.send({ t: "bye", reason: "while the guest is here" }, REJOIN_PEER);
+			for (let tick = 0; tick < 20; tick++) await Promise.resolve();
+			expect(leg.sent).toHaveLength(1);
+
+			leg.onmessage?.({ data: JSON.stringify({ t: "peer-left", peer: REJOIN_PEER }) } as MessageEvent);
+			socket.send({ t: "bye", reason: "after the guest left" }, REJOIN_PEER);
+			for (let tick = 0; tick < 20; tick++) await Promise.resolve();
+
+			expect(leg.sent).toHaveLength(1);
+		} finally {
+			socket.close();
+		}
+	});
+
+	it("retires a departed peer id even while an earlier frame is still decrypting", async () => {
+		vi.spyOn(Math, "random").mockReturnValue(JITTER_NEUTRAL);
+		vi.spyOn(crypto.subtle, "encrypt").mockResolvedValue(new Uint8Array([1, 2, 3, 4]).buffer);
+		const pendingOpen = Promise.withResolvers<ArrayBuffer>();
+		vi.spyOn(crypto.subtle, "decrypt").mockReturnValue(pendingOpen.promise);
+		const { socket } = startSocket("host");
+		try {
+			const leg = ScriptedWebSocket.latest;
+			leg.open();
+			leg.introducePeer(REJOIN_PEER);
+			// The relay reports the guest gone while its first frame is still inside open().
+			// Addressability is a send-time gate, so the id has to stop being addressable now,
+			// not whenever the decryption queued ahead of it finishes.
+			leg.onmessage?.({ data: JSON.stringify({ t: "peer-left", peer: REJOIN_PEER }) } as MessageEvent);
+			socket.send({ t: "bye", reason: "reply to a guest that already left" }, REJOIN_PEER);
+			for (let tick = 0; tick < 20; tick++) await Promise.resolve();
+
+			expect(leg.sent).toEqual([]);
+		} finally {
+			pendingOpen.resolve(HELLO_PAYLOAD);
+			socket.close();
+		}
+	});
+
+	it("starts the next leg's hold with a fresh byte budget", async () => {
+		vi.spyOn(Math, "random").mockReturnValue(JITTER_NEUTRAL);
+		vi.spyOn(crypto.subtle, "decrypt").mockResolvedValue(HELLO_PAYLOAD);
+		const inbound: number[] = [];
+		const { socket } = startSocket("host");
+		socket.onFrame = (_frame, fromPeer) => inbound.push(fromPeer);
+		try {
+			ScriptedWebSocket.latest.open();
+			ScriptedWebSocket.latest.closeWith(1006, "Connection ended");
+			vi.advanceTimersByTime(1_000);
+			const rejected = ScriptedWebSocket.latest;
+			rejected.open();
+			// A peer fills the provisional leg's hold, then the relay rejects the leg. What
+			// that registration spent is gone with it: charging it against the next leg would
+			// refuse the rejoin arriving there a welcome nobody will ask for again.
+			for (let message = 1; message <= 8; message++) {
+				rejected.onmessage?.({
+					data: packEnvelope(message, new Uint8Array(FAT_PAYLOAD_BYTES)).buffer,
+				} as MessageEvent);
+			}
+			rejected.rejectAsHostConflict();
+
+			vi.advanceTimersByTime(1_000);
+			const reclaimed = ScriptedWebSocket.latest;
+			reclaimed.open();
+			for (let message = 1; message <= 8; message++) {
+				reclaimed.onmessage?.({
+					data: packEnvelope(message, new Uint8Array(FAT_PAYLOAD_BYTES)).buffer,
+				} as MessageEvent);
+			}
+			vi.advanceTimersByTime(LEG_SETTLE_MS);
+			for (let tick = 0; tick < 400; tick++) await Promise.resolve();
+
+			const charge = FAT_PAYLOAD_BYTES + ENVELOPE_HEADER_LENGTH + HOLD_SLOT_BYTES;
+			const fits = Math.floor(HOLD_COMPETE_LIMIT / charge);
+			expect(fits).toBeLessThan(8);
+			expect(inbound).toEqual(Array.from({ length: fits }, (_, index) => index + 1));
+		} finally {
+			socket.close();
+		}
+	});
+
+	it("lets one peer fill the hold and still admits another guest's handshake", async () => {
+		vi.spyOn(Math, "random").mockReturnValue(JITTER_NEUTRAL);
+		vi.spyOn(crypto.subtle, "decrypt").mockResolvedValue(HELLO_PAYLOAD);
+		const inbound: number[] = [];
+		const { socket } = startSocket("host");
+		socket.onFrame = (_frame, fromPeer) => inbound.push(fromPeer);
+		try {
+			ScriptedWebSocket.latest.open();
+			ScriptedWebSocket.latest.closeWith(1006, "Connection ended");
+			vi.advanceTimersByTime(1_000);
+			const reclaimed = ScriptedWebSocket.latest;
+			reclaimed.open();
+			// One peer spends everything a stream past its floor may compete for. What it holds
+			// is bounded — the flat slot cost is what makes even small frames spend a budget —
+			// and the floor the peer budget keeps back is what gets the next guest's `hello`
+			// in, which is the one message nothing re-sends.
+			const loud = packEnvelope(FLOOD_PEER, new Uint8Array(32));
+			const charge = loud.buffer.byteLength + HOLD_SLOT_BYTES;
+			const competes = Math.floor(HOLD_COMPETE_LIMIT / charge);
+			for (let message = 0; message < competes + 8; message++) {
+				reclaimed.onmessage?.({ data: loud.buffer } as MessageEvent);
+			}
+			reclaimed.introducePeer(LATE_GUEST);
+			vi.advanceTimersByTime(LEG_SETTLE_MS);
+			for (let tick = 0; tick < 120_000; tick++) await Promise.resolve();
+
+			expect(inbound.filter(peer => peer === FLOOD_PEER)).toHaveLength(competes);
+			expect(inbound.at(-1)).toBe(LATE_GUEST);
+		} finally {
+			socket.close();
+		}
+	});
+
+	it("spends each budget to its last byte, and not one message further", async () => {
+		vi.spyOn(Math, "random").mockReturnValue(JITTER_NEUTRAL);
+		vi.spyOn(crypto.subtle, "decrypt").mockResolvedValue(HELLO_PAYLOAD);
+		const inbound: number[] = [];
+		const controls: string[] = [];
+		const { socket } = startSocket("host");
+		socket.onFrame = (_frame, fromPeer) => inbound.push(fromPeer);
+		socket.onControl = msg => controls.push(msg.t);
+		try {
+			ScriptedWebSocket.latest.open();
+			ScriptedWebSocket.latest.closeWith(1006, "Connection ended");
+			vi.advanceTimersByTime(1_000);
+			const reclaimed = ScriptedWebSocket.latest;
+			reclaimed.open();
+			// Both budgets are priced to divide exactly, so the message that lands on the last
+			// byte is held and the one after it is refused. A guest turned away with a budget
+			// byte to spare loses a `hello` nothing re-sends, so the boundary is a contract.
+			const empty = JSON.stringify({ t: "peer-joined", peer: 1, pad: "" });
+			const control = JSON.stringify({
+				t: "peer-joined",
+				peer: 1,
+				pad: "x".repeat(4_096 / 2 - HOLD_SLOT_BYTES / 2 - empty.length),
+			});
+			const controlFits = HOLD_CONTROL_LIMIT / (control.length * 2 + HOLD_SLOT_BYTES);
+			for (let message = 0; message < controlFits + 1; message++) {
+				reclaimed.onmessage?.({ data: control } as MessageEvent);
+			}
+			const frame = packEnvelope(
+				REJOIN_PEER,
+				new Uint8Array(1024 * 1024 - ENVELOPE_HEADER_LENGTH - HOLD_SLOT_BYTES),
+			);
+			const frameFits = HOLD_COMPETE_LIMIT / (1024 * 1024);
+			for (let message = 0; message < frameFits + 1; message++) {
+				reclaimed.onmessage?.({ data: frame.buffer } as MessageEvent);
+			}
+			vi.advanceTimersByTime(LEG_SETTLE_MS);
+			for (let tick = 0; tick < 40_000; tick++) await Promise.resolve();
+
+			expect(controlFits % 1).toBe(0);
+			expect(frameFits % 1).toBe(0);
+			expect(controls).toHaveLength(controlFits);
+			expect(inbound).toHaveLength(frameFits);
+		} finally {
+			socket.close();
+		}
+	});
+
+	it("charges the broadcast slot like any stream, reserve included", async () => {
+		vi.spyOn(Math, "random").mockReturnValue(JITTER_NEUTRAL);
+		vi.spyOn(crypto.subtle, "decrypt").mockResolvedValue(HELLO_PAYLOAD);
+		const inbound: number[] = [];
+		const { socket } = startSocket("host");
+		socket.onFrame = (_frame, fromPeer) => inbound.push(fromPeer);
+		try {
+			ScriptedWebSocket.latest.open();
+			ScriptedWebSocket.latest.closeWith(1006, "Connection ended");
+			vi.advanceTimersByTime(1_000);
+			const reclaimed = ScriptedWebSocket.latest;
+			reclaimed.open();
+			// Exempting id 0 from the latch is not the same as exempting it from accounting:
+			// judged inside its floor forever, it would spend the reserve a guest's handshake
+			// needs, one floor-sized frame at a time.
+			const floorFrame = packEnvelope(
+				0,
+				new Uint8Array(HOLD_STREAM_FLOOR - ENVELOPE_HEADER_LENGTH - HOLD_SLOT_BYTES),
+			);
+			for (let message = 0; message < HOLD_PEER_BYTES_LIMIT / HOLD_STREAM_FLOOR; message++) {
+				reclaimed.onmessage?.({ data: floorFrame.buffer } as MessageEvent);
+			}
+			reclaimed.introducePeer(REJOIN_PEER);
+			vi.advanceTimersByTime(LEG_SETTLE_MS);
+			for (let tick = 0; tick < 4_000; tick++) await Promise.resolve();
+
+			expect(inbound.filter(peer => peer === 0)).toHaveLength(HOLD_COMPETE_LIMIT / HOLD_STREAM_FLOOR);
+			expect(inbound.at(-1)).toBe(REJOIN_PEER);
+		} finally {
+			socket.close();
+		}
+	});
+
+	it("holds a guest's large frame while the room is quiet", async () => {
+		vi.spyOn(Math, "random").mockReturnValue(JITTER_NEUTRAL);
+		vi.spyOn(crypto.subtle, "decrypt").mockResolvedValue(HELLO_PAYLOAD);
+		const inbound: number[] = [];
+		const { socket } = startSocket("host");
+		socket.onFrame = (_frame, fromPeer) => inbound.push(fromPeer);
+		try {
+			ScriptedWebSocket.latest.open();
+			ScriptedWebSocket.latest.closeWith(1006, "Connection ended");
+			vi.advanceTimersByTime(1_000);
+			const reclaimed = ScriptedWebSocket.latest;
+			reclaimed.open();
+			// Nothing caps what a guest may send: a prompt carrying an image runs to megabytes.
+			// A stream's floor bounds what the room can lose to it, not what it may send, so a
+			// frame far past the floor is still held while the budget has room — and the guest
+			// is not silenced for the window either.
+			reclaimed.introducePeer(REJOIN_PEER);
+			reclaimed.onmessage?.({
+				data: packEnvelope(REJOIN_PEER, new Uint8Array(HOLD_STREAM_FLOOR * 40)).buffer,
+			} as MessageEvent);
+			reclaimed.onmessage?.({ data: packEnvelope(REJOIN_PEER, new Uint8Array(64)).buffer } as MessageEvent);
+			vi.advanceTimersByTime(LEG_SETTLE_MS);
+			for (let tick = 0; tick < 400; tick++) await Promise.resolve();
+
+			expect(inbound).toEqual([REJOIN_PEER, REJOIN_PEER, REJOIN_PEER]);
+		} finally {
+			socket.close();
+		}
+	});
+
+	it("never silences the broadcast slot, whatever it was refused for", async () => {
+		vi.spyOn(Math, "random").mockReturnValue(JITTER_NEUTRAL);
+		vi.spyOn(crypto.subtle, "decrypt").mockResolvedValue(HELLO_PAYLOAD);
+		const inbound: number[] = [];
+		const { socket } = startSocket("host");
+		socket.onFrame = (_frame, fromPeer) => inbound.push(fromPeer);
+		try {
+			ScriptedWebSocket.latest.open();
+			ScriptedWebSocket.latest.closeWith(1006, "Connection ended");
+			vi.advanceTimersByTime(1_000);
+			const reclaimed = ScriptedWebSocket.latest;
+			reclaimed.open();
+			// Peer 0 is the broadcast slot, not a guest. Latching it the way a guest's stream
+			// is latched would silence everything the room is told for the rest of the hold,
+			// because it is every guest's predecessor rather than one guest's.
+			reclaimed.onmessage?.({ data: packEnvelope(0, new Uint8Array(HOLD_PEER_BYTES_LIMIT)).buffer } as MessageEvent);
+			reclaimed.onmessage?.({ data: packEnvelope(0, new Uint8Array(64)).buffer } as MessageEvent);
+			reclaimed.introducePeer(REJOIN_PEER);
+			vi.advanceTimersByTime(LEG_SETTLE_MS);
+			for (let tick = 0; tick < 400; tick++) await Promise.resolve();
+
+			expect(inbound).toEqual([0, REJOIN_PEER]);
+		} finally {
+			socket.close();
+		}
+	});
+
+	it("ignores control that carries no peer the session could act on", async () => {
+		vi.spyOn(Math, "random").mockReturnValue(JITTER_NEUTRAL);
+		vi.spyOn(crypto.subtle, "decrypt").mockResolvedValue(HELLO_PAYLOAD);
+		const controls: string[] = [];
+		const { socket } = startSocket("host");
+		socket.onControl = msg => controls.push(msg.t);
+		try {
+			ScriptedWebSocket.latest.open();
+			ScriptedWebSocket.latest.closeWith(1006, "Connection ended");
+			vi.advanceTimersByTime(1_000);
+			const reclaimed = ScriptedWebSocket.latest;
+			reclaimed.open();
+			// A transition names a peer, and the session retires that id when it hears one.
+			// Forwarding a departure with no id has it retire `undefined`, which is a silent
+			// no-op that looks like a departure was handled.
+			for (const text of ['{"t":"peer-left"}', '{"t":"peer-joined","peer":"7"}', '{"t":"made-up","peer":7}', "[]"]) {
+				reclaimed.onmessage?.({ data: text } as MessageEvent);
+			}
+			reclaimed.onmessage?.({ data: JSON.stringify({ t: "peer-left", peer: REJOIN_PEER }) } as MessageEvent);
+			vi.advanceTimersByTime(LEG_SETTLE_MS);
+			for (let tick = 0; tick < 400; tick++) await Promise.resolve();
+
+			expect(controls).toEqual(["peer-left"]);
+		} finally {
+			socket.close();
+		}
+	});
+
+	it("does not hold an envelope whose payload could never be opened", async () => {
+		vi.spyOn(Math, "random").mockReturnValue(JITTER_NEUTRAL);
+		vi.spyOn(crypto.subtle, "decrypt").mockResolvedValue(HELLO_PAYLOAD);
+		const inbound: number[] = [];
+		const { socket, closes } = startSocket("host");
+		socket.onFrame = (_frame, fromPeer) => inbound.push(fromPeer);
+		try {
+			ScriptedWebSocket.latest.open();
+			ScriptedWebSocket.latest.closeWith(1006, "Connection ended");
+			vi.advanceTimersByTime(1_000);
+			const reclaimed = ScriptedWebSocket.latest;
+			reclaimed.open();
+			// A payload with no room for an IV and a GCM tag can only fail authentication, and
+			// failing at replay ends the session as a bad key, taking the rest of the replay
+			// with it. Every length below the structural floor is dropped here instead — the
+			for (const payload of [0, 1, 12, 13, 27]) {
+				reclaimed.onmessage?.({
+					data: packEnvelope(FLOOD_PEER, new Uint8Array(payload)).buffer,
+				} as MessageEvent);
+			}
+			reclaimed.introducePeer(REJOIN_PEER);
+			vi.advanceTimersByTime(LEG_SETTLE_MS);
+			for (let tick = 0; tick < 400; tick++) await Promise.resolve();
+
+			expect(inbound).toEqual([REJOIN_PEER]);
+			expect(closes).toEqual([{ reason: "Connection ended", willReconnect: true }]);
+		} finally {
+			socket.close();
+		}
+	});
+
+	it("does not let bytes that are no envelope occupy the hold", async () => {
+		vi.spyOn(Math, "random").mockReturnValue(JITTER_NEUTRAL);
+		vi.spyOn(crypto.subtle, "decrypt").mockResolvedValue(HELLO_PAYLOAD);
+		const inbound: number[] = [];
+		const { socket, closes } = startSocket("host");
+		socket.onFrame = (_frame, fromPeer) => inbound.push(fromPeer);
+		try {
+			ScriptedWebSocket.latest.open();
+			ScriptedWebSocket.latest.closeWith(1006, "Connection ended");
+			vi.advanceTimersByTime(1_000);
+			const reclaimed = ScriptedWebSocket.latest;
+			reclaimed.open();
+			// Bytes too short to carry a peer id are not traffic of any stream. Charged and
+			// held, the flat slot cost turns a few hundred KB of them into the whole budget,
+			// and the first one to reach `open` at replay ends the session — so they are
+			// dropped here, where they cost nothing and take nothing with them.
+			const stub = new Uint8Array([1, 2]);
+			for (let message = 0; message <= HOLD_PEER_BYTES_LIMIT / HOLD_SLOT_BYTES; message++) {
+				reclaimed.onmessage?.({ data: stub.buffer } as MessageEvent);
+			}
+			reclaimed.introducePeer(REJOIN_PEER);
+			vi.advanceTimersByTime(LEG_SETTLE_MS);
+			for (let tick = 0; tick < 400; tick++) await Promise.resolve();
+
+			expect(inbound).toEqual([REJOIN_PEER]);
+			expect(closes).toEqual([{ reason: "Connection ended", willReconnect: true }]);
+		} finally {
+			socket.close();
+		}
+	});
+
+	it("keeps the hold's ceiling intact when the relay delivers something unexpected", async () => {
+		vi.spyOn(Math, "random").mockReturnValue(JITTER_NEUTRAL);
+		vi.spyOn(crypto.subtle, "decrypt").mockResolvedValue(HELLO_PAYLOAD);
+		const inbound: number[] = [];
+		const { socket } = startSocket("host");
+		socket.onFrame = (_frame, fromPeer) => inbound.push(fromPeer);
+		try {
+			ScriptedWebSocket.latest.open();
+			ScriptedWebSocket.latest.closeWith(1006, "Connection ended");
+			vi.advanceTimersByTime(1_000);
+			const reclaimed = ScriptedWebSocket.latest;
+			reclaimed.open();
+			// Something the wire grammar has no room for. Held, it would be charged bytes it
+			// does not have and take the ceiling with it: the messages behind it are then
+			// admitted without a bound, and the leg holds whatever the room can push.
+			reclaimed.onmessage?.({ data: 42 } as unknown as MessageEvent);
+			for (let message = 1; message <= 8; message++) {
+				reclaimed.onmessage?.({
+					data: packEnvelope(message, new Uint8Array(FAT_PAYLOAD_BYTES)).buffer,
+				} as MessageEvent);
+			}
+			vi.advanceTimersByTime(LEG_SETTLE_MS);
+			for (let tick = 0; tick < 400; tick++) await Promise.resolve();
+
+			const charge = FAT_PAYLOAD_BYTES + ENVELOPE_HEADER_LENGTH + HOLD_SLOT_BYTES;
+			const fits = Math.floor(HOLD_COMPETE_LIMIT / charge);
+			expect(fits).toBeLessThan(8);
+			expect(inbound).toEqual(Array.from({ length: fits }, (_, index) => index + 1));
+		} finally {
+			socket.close();
+		}
+	});
+
+	it("keeps a message whose charge exactly fills a stream's share", async () => {
+		vi.spyOn(Math, "random").mockReturnValue(JITTER_NEUTRAL);
+		vi.spyOn(crypto.subtle, "decrypt").mockResolvedValue(HELLO_PAYLOAD);
+		const inbound: number[] = [];
+		const { socket } = startSocket("host");
+		socket.onFrame = (_frame, fromPeer) => inbound.push(fromPeer);
+		try {
+			ScriptedWebSocket.latest.open();
+			ScriptedWebSocket.latest.closeWith(1006, "Connection ended");
+			vi.advanceTimersByTime(1_000);
+			const reclaimed = ScriptedWebSocket.latest;
+			reclaimed.open();
+			// Two messages from one guest, priced at exactly half its share each. The bound is
+			// on what would overrun it, so the arrival that lands on it to the byte is still
+			// held: a rejoin must not be turned away by a rounding choice.
+			const halfPayload = HOLD_STREAM_FLOOR / 2 - HOLD_SLOT_BYTES - ENVELOPE_HEADER_LENGTH;
+			for (let message = 0; message < 2; message++) {
+				reclaimed.onmessage?.({
+					data: packEnvelope(REJOIN_PEER, new Uint8Array(halfPayload)).buffer,
+				} as MessageEvent);
+			}
+			vi.advanceTimersByTime(LEG_SETTLE_MS);
+			for (let tick = 0; tick < 400; tick++) await Promise.resolve();
+
+			expect(inbound).toEqual([REJOIN_PEER, REJOIN_PEER]);
+		} finally {
+			socket.close();
+		}
+	});
+
+	it("delivers a rejoin hello that arrives behind a refused frame", async () => {
+		vi.spyOn(Math, "random").mockReturnValue(JITTER_NEUTRAL);
+		vi.spyOn(crypto.subtle, "decrypt").mockResolvedValue(HELLO_PAYLOAD);
+		const inbound: number[] = [];
+		const { socket } = startSocket("host");
+		socket.onFrame = (_frame, fromPeer) => inbound.push(fromPeer);
+		try {
+			ScriptedWebSocket.latest.open();
+			ScriptedWebSocket.latest.closeWith(1006, "Connection ended");
+			vi.advanceTimersByTime(1_000);
+			const reclaimed = ScriptedWebSocket.latest;
+			reclaimed.open();
+			// A guest reconnecting flushes what it queued during the outage before its own
+			// onOpen sends the `hello`, so the host meets a large prompt first and the
+			// handshake behind it. Holding the prompt's refusal against the `hello` would
+			// leave that guest connected, unwelcomed, and with no watchdog to notice: a lost
+			// prompt is visible to whoever typed it, a lost `hello` to nobody.
+			const chatty = REJOIN_PEER;
+			reclaimed.onmessage?.({
+				data: packEnvelope(chatty, new Uint8Array(HOLD_COMPETE_LIMIT - 2 * 1024 * 1024)).buffer,
+			} as MessageEvent);
+			reclaimed.onmessage?.({
+				data: packEnvelope(chatty, new Uint8Array(2 * 1024 * 1024)).buffer,
+			} as MessageEvent);
+			reclaimed.onmessage?.({ data: packEnvelope(chatty, new Uint8Array(300)).buffer } as MessageEvent);
+			reclaimed.introducePeer(LATE_GUEST);
+			vi.advanceTimersByTime(LEG_SETTLE_MS);
+			for (let tick = 0; tick < 400; tick++) await Promise.resolve();
+
+			// The frame that did not fit is gone; everything else from that guest still lands.
+			expect(inbound).toEqual([chatty, chatty, LATE_GUEST]);
+		} finally {
+			socket.close();
+		}
+	});
+
+	it("holds a whole room that rejoins behind a frame too big to hold", async () => {
+		vi.spyOn(Math, "random").mockReturnValue(JITTER_NEUTRAL);
+		vi.spyOn(crypto.subtle, "decrypt").mockResolvedValue(HELLO_PAYLOAD);
+		const inbound: number[] = [];
+		const { socket } = startSocket("host");
+		socket.onFrame = (_frame, fromPeer) => inbound.push(fromPeer);
+		try {
+			ScriptedWebSocket.latest.open();
+			ScriptedWebSocket.latest.closeWith(1006, "Connection ended");
+			vi.advanceTimersByTime(1_000);
+			const reclaimed = ScriptedWebSocket.latest;
+			reclaimed.open();
+			// A guest prompt larger than the whole ceiling arrives first — guests have no
+			// send-side size cap, so this is legal traffic. It cannot be held, but refusing it
+			// must not spend the budget the rejoining room needs: every one of those hellos is
+			// that guest's only one, and nothing re-requests a welcome.
+			reclaimed.onmessage?.({
+				data: packEnvelope(REJOIN_PEER, new Uint8Array(HOLD_PEER_BYTES_LIMIT)).buffer,
+			} as MessageEvent);
+			const guests = 100;
+			for (let peer = 1; peer <= guests; peer++) reclaimed.introducePeer(peer);
+			vi.advanceTimersByTime(LEG_SETTLE_MS);
+			for (let tick = 0; tick < 2_000; tick++) await Promise.resolve();
+
+			// Nobody is latched by the refusal, so every guest including that one is served.
+			expect(inbound).toEqual(Array.from({ length: guests }, (_, index) => index + 1));
+		} finally {
+			socket.close();
+		}
+	});
+
+	it("still hears a guest leave once the ceiling is full", async () => {
+		vi.spyOn(Math, "random").mockReturnValue(JITTER_NEUTRAL);
+		vi.spyOn(crypto.subtle, "decrypt").mockResolvedValue(HELLO_PAYLOAD);
+		const inbound: number[] = [];
+		const controls: string[] = [];
+		const { socket } = startSocket("host");
+		socket.onFrame = (_frame, fromPeer) => inbound.push(fromPeer);
+		socket.onControl = msg => controls.push(msg.t);
+		try {
+			ScriptedWebSocket.latest.open();
+			ScriptedWebSocket.latest.closeWith(1006, "Connection ended");
+			vi.advanceTimersByTime(1_000);
+			const reclaimed = ScriptedWebSocket.latest;
+			reclaimed.open();
+			// The guest rejoins, then a roomful of peers spends every byte peers are allowed to
+			// spend, and only after that does the guest leave. The departure has to land
+			// anyway: refusing it would leave the session listing that guest and counting it as
+			// one that can answer a ui-request for the rest of the leg — the one refusal that
+			// leaves state behind. Control has a budget of its own for exactly this.
+			reclaimed.introducePeer(REJOIN_PEER);
+			for (let peer = 40; peer < 48; peer++) {
+				for (let message = 0; message < 4; message++) {
+					reclaimed.onmessage?.({
+						data: packEnvelope(peer, new Uint8Array(1024 * 1024)).buffer,
+					} as MessageEvent);
+				}
+			}
+			reclaimed.onmessage?.({ data: JSON.stringify({ t: "peer-left", peer: REJOIN_PEER }) } as MessageEvent);
+			vi.advanceTimersByTime(LEG_SETTLE_MS);
+			for (let tick = 0; tick < 4_000; tick++) await Promise.resolve();
+
+			expect(inbound[0]).toBe(REJOIN_PEER);
+			expect(controls).toEqual(["peer-left"]);
+		} finally {
+			socket.close();
+		}
+	});
+
+	it("bounds held control as well, once it has spent its own budget", async () => {
+		vi.spyOn(Math, "random").mockReturnValue(JITTER_NEUTRAL);
+		vi.spyOn(crypto.subtle, "decrypt").mockResolvedValue(HELLO_PAYLOAD);
+		const controls: string[] = [];
+		const { socket } = startSocket("host");
+		socket.onControl = msg => controls.push(msg.t);
+		try {
+			ScriptedWebSocket.latest.open();
+			ScriptedWebSocket.latest.closeWith(1006, "Connection ended");
+			vi.advanceTimersByTime(1_000);
+			const reclaimed = ScriptedWebSocket.latest;
+			reclaimed.open();
+			// A relay streaming text instead of a room's transitions cannot grow the hold: its
+			// budget is spent to the message. And because a refused control is not latched, the
+			// departure behind the refusals still lands — it is what the budget exists for, and
+			// the only transition whose loss leaves the session listing a guest that is gone.
+			const padded = JSON.stringify({ t: "peer-joined", peer: 1, pad: "x".repeat(64 * 1024) });
+			const charge = padded.length * 2 + HOLD_SLOT_BYTES;
+			const fits = Math.floor(HOLD_CONTROL_LIMIT / charge);
+			for (let message = 0; message < fits + 8; message++) {
+				reclaimed.onmessage?.({ data: padded } as MessageEvent);
+			}
+			reclaimed.onmessage?.({ data: JSON.stringify({ t: "peer-left", peer: REJOIN_PEER }) } as MessageEvent);
+			vi.advanceTimersByTime(LEG_SETTLE_MS);
+			for (let tick = 0; tick < 2_000; tick++) await Promise.resolve();
+
+			expect(controls.filter(t => t === "peer-joined")).toHaveLength(fits);
+			expect(controls.at(-1)).toBe("peer-left");
+		} finally {
+			socket.close();
+		}
+	});
+
+	it("does not let text that is no control message occupy the hold", async () => {
+		vi.spyOn(Math, "random").mockReturnValue(JITTER_NEUTRAL);
+		vi.spyOn(crypto.subtle, "decrypt").mockResolvedValue(HELLO_PAYLOAD);
+		const inbound: number[] = [];
+		const controls: string[] = [];
+		const { socket } = startSocket("host");
+		socket.onFrame = (_frame, fromPeer) => inbound.push(fromPeer);
+		socket.onControl = msg => controls.push(msg.t);
+		try {
+			ScriptedWebSocket.latest.open();
+			ScriptedWebSocket.latest.closeWith(1006, "Connection ended");
+			vi.advanceTimersByTime(1_000);
+			const reclaimed = ScriptedWebSocket.latest;
+			reclaimed.open();
+			// Junk is rejected at intake, not carried to the replay and discarded there. Held,
+			// it spends the budget a room's transitions need — and it is priced by the slot
+			// cost, so it takes only a few hundred KB of it to spend all of them.
+			const junk = "{oops";
+			for (let message = 0; message <= HOLD_CONTROL_LIMIT / HOLD_SLOT_BYTES; message++) {
+				reclaimed.onmessage?.({ data: junk } as MessageEvent);
+			}
+			reclaimed.onmessage?.({ data: JSON.stringify({ t: "peer-joined", peer: REJOIN_PEER }) } as MessageEvent);
+			reclaimed.introducePeer(REJOIN_PEER);
+			vi.advanceTimersByTime(LEG_SETTLE_MS);
+			for (let tick = 0; tick < 2_000; tick++) await Promise.resolve();
+
+			expect(controls).toEqual(["peer-joined"]);
+			expect(inbound).toEqual([REJOIN_PEER]);
+		} finally {
+			socket.close();
+		}
+	});
+});

--- a/packages/coding-agent/test/collab/relay-client-leg-scope.test.ts
+++ b/packages/coding-agent/test/collab/relay-client-leg-scope.test.ts
@@ -1,0 +1,627 @@
+/**
+ * Contract: a relay peer id is only addressable on the leg that minted it.
+ *
+ * The relay is the sole source of peer ids and it hands them out per room, restarting at
+ * 1 when it frees a room. So an envelope addressed to a peer the live leg never heard from
+ * belongs to a registration that is gone, and delivering it would hand one guest's frame
+ * to whoever inherited that number. These cases pin that scoping, the terminal close codes
+ * that must never reconnect, and the single-leg invariant — all of which the reclaim suite
+ * exercises only incidentally.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import { packEnvelope, unpackEnvelope } from "../../src/collab/protocol";
+import { CollabSocket } from "../../src/collab/relay-client";
+
+const ORIGINAL_WEBSOCKET = globalThis.WebSocket;
+const HOST_CONFLICT_REASON = "a host is already connected for this room";
+const RECLAIM_WINDOW_MS = 120_000;
+const LEG_SETTLE_MS = 2_000;
+/** Backoff jitter is `0.75 + Math.random() * 0.5`; 0.5 pins the base delay. */
+const JITTER_NEUTRAL = 0.5;
+/** Guests a settle replay introduces at once in the bulk case below. */
+const ROOM_GUESTS = 40;
+/** Mirrors MAX_PENDING_SENDS in the client. */
+const PENDING_SEND_LIMIT = 256;
+/** Mirrors WS_BACKPRESSURE_DRAIN_RETRY_MS in the client. */
+const BACKPRESSURE_RETRY_MS = 25;
+const REJOIN_PEER = 7;
+/** A second guest that speaks after the leg settled but before the hold replayed. */
+const LATE_GUEST = 9;
+/** Stand-in plaintext for an inbound guest frame; `open()` only needs valid frame JSON. */
+const GUEST_PAYLOAD = new TextEncoder().encode(JSON.stringify({ t: "bye", reason: "guest frame" })).buffer;
+
+class ScriptedWebSocket {
+	static readonly CONNECTING = 0;
+	static readonly OPEN = 1;
+	static readonly CLOSING = 2;
+	static readonly CLOSED = 3;
+	static instances: ScriptedWebSocket[] = [];
+
+	static get latest(): ScriptedWebSocket {
+		const leg = ScriptedWebSocket.instances.at(-1);
+		if (!leg) throw new Error("CollabSocket did not construct a WebSocket");
+		return leg;
+	}
+
+	readonly url: string;
+	binaryType = "arraybuffer";
+	bufferedAmount = 0;
+	sent: Uint8Array[] = [];
+	onclose: ((event: CloseEvent) => void) | null = null;
+	onerror: ((event: Event) => void) | null = null;
+	onmessage: ((event: MessageEvent) => void) | null = null;
+	onopen: ((event: Event) => void) | null = null;
+	readyState = ScriptedWebSocket.CONNECTING;
+
+	constructor(url: string) {
+		this.url = url;
+		ScriptedWebSocket.instances.push(this);
+	}
+
+	send(data: Uint8Array): void {
+		this.sent.push(data);
+	}
+
+	open(): void {
+		this.readyState = ScriptedWebSocket.OPEN;
+		this.onopen?.(new Event("open"));
+	}
+
+	/** The relay routing a guest's frame to us is what makes its id addressable. */
+	introducePeer(peer: number): void {
+		this.onmessage?.({ data: packEnvelope(peer, new Uint8Array(32)).buffer } as MessageEvent);
+	}
+
+	closeWith(code: number, reason: string): void {
+		if (this.readyState === ScriptedWebSocket.CLOSED) return;
+		this.readyState = ScriptedWebSocket.CLOSED;
+		this.onclose?.({ code, reason } as CloseEvent);
+	}
+
+	/**
+	 * Real Bun moves to CLOSING and dispatches the close event a task later, so frames the
+	 * relay already queued still arrive on a leg the client has detached.
+	 */
+	close(code = 1000): void {
+		if (this.readyState === ScriptedWebSocket.CLOSED) return;
+		this.readyState = ScriptedWebSocket.CLOSING;
+		queueMicrotask(() => this.closeWith(code, "closed"));
+	}
+}
+
+function startHost(): CollabSocket {
+	const socket = new CollabSocket({ wsUrl: "ws://localhost:8788/r/scope", role: "host", key: {} as CryptoKey });
+	socket.connect();
+	return socket;
+}
+
+describe("CollabSocket leg-scoped peer ids", () => {
+	beforeEach(() => {
+		ScriptedWebSocket.instances = [];
+		vi.useFakeTimers();
+		vi.spyOn(Math, "random").mockReturnValue(JITTER_NEUTRAL);
+		globalThis.WebSocket = ScriptedWebSocket as unknown as typeof WebSocket;
+	});
+
+	afterEach(() => {
+		globalThis.WebSocket = ORIGINAL_WEBSOCKET;
+		vi.restoreAllMocks();
+		vi.useRealTimers();
+	});
+
+	it("retires the peer ids of a leg that died, dropping a reply queued during the outage", async () => {
+		vi.spyOn(crypto.subtle, "encrypt").mockResolvedValue(new Uint8Array([1, 2, 3, 4]).buffer);
+		vi.spyOn(crypto.subtle, "decrypt").mockResolvedValue(GUEST_PAYLOAD);
+		const socket = startHost();
+		try {
+			const established = ScriptedWebSocket.latest;
+			established.open();
+			established.introducePeer(REJOIN_PEER);
+			for (let tick = 0; tick < 20; tick++) await Promise.resolve();
+			established.closeWith(1006, "Connection ended");
+
+			// An async host handler finishes after the drop and answers the guest it was
+			// serving. The relay has recycled the room and will hand that number to someone
+			// else, so the reply must not survive; the broadcast still may.
+			socket.send({ t: "bye", reason: "reply to a guest of the dead room" }, REJOIN_PEER);
+			socket.send({ t: "bye", reason: "session event" });
+			for (let tick = 0; tick < 20; tick++) await Promise.resolve();
+
+			vi.advanceTimersByTime(1_000);
+			const reclaimed = ScriptedWebSocket.latest;
+			reclaimed.open();
+			vi.advanceTimersByTime(LEG_SETTLE_MS);
+			for (let tick = 0; tick < 20; tick++) await Promise.resolve();
+
+			expect(reclaimed.sent.map(envelope => unpackEnvelope(envelope)?.peerId)).toEqual([0]);
+		} finally {
+			socket.close();
+		}
+	});
+
+	it("purges buffered replies when their leg dies and keeps the buffered broadcasts", async () => {
+		vi.spyOn(crypto.subtle, "encrypt").mockResolvedValue(new Uint8Array([1, 2, 3, 4]).buffer);
+		vi.spyOn(crypto.subtle, "decrypt").mockResolvedValue(GUEST_PAYLOAD);
+		const socket = startHost();
+		try {
+			ScriptedWebSocket.latest.open();
+			ScriptedWebSocket.latest.closeWith(1006, "Connection ended");
+			vi.advanceTimersByTime(1_000);
+			const rejected = ScriptedWebSocket.latest;
+			rejected.open();
+			// The guest spoke on this very leg, so its reply is addressable and reaches the
+			// buffer rather than the send-time drop.
+			rejected.introducePeer(REJOIN_PEER);
+			socket.send({ t: "bye", reason: "welcome for a guest of this leg" }, REJOIN_PEER);
+			socket.send({ t: "bye", reason: "session event" });
+			for (let tick = 0; tick < 20; tick++) await Promise.resolve();
+			expect(rejected.sent).toEqual([]);
+
+			// The relay rejects the leg and recycles the room, so the buffered reply now
+			// names a number the next guest will inherit.
+			rejected.closeWith(4009, HOST_CONFLICT_REASON);
+			vi.advanceTimersByTime(1_000);
+			const reclaimed = ScriptedWebSocket.latest;
+			reclaimed.open();
+			vi.advanceTimersByTime(LEG_SETTLE_MS);
+			for (let tick = 0; tick < 20; tick++) await Promise.resolve();
+
+			expect(reclaimed.sent.map(envelope => unpackEnvelope(envelope)?.peerId)).toEqual([0]);
+		} finally {
+			socket.close();
+		}
+	});
+
+	it("drops a reply addressed to a peer id minted before close()", async () => {
+		vi.spyOn(crypto.subtle, "encrypt").mockResolvedValue(new Uint8Array([1, 2, 3, 4]).buffer);
+		vi.spyOn(crypto.subtle, "decrypt").mockResolvedValue(GUEST_PAYLOAD);
+		const socket = startHost();
+		try {
+			const first = ScriptedWebSocket.latest;
+			first.open();
+			first.introducePeer(REJOIN_PEER);
+			for (let tick = 0; tick < 20; tick++) await Promise.resolve();
+
+			socket.close();
+			socket.connect();
+			const revived = ScriptedWebSocket.latest;
+			revived.open();
+			socket.send({ t: "bye", reason: "reply to a peer of the previous session" }, REJOIN_PEER);
+			socket.send({ t: "bye", reason: "session event" });
+			for (let tick = 0; tick < 20; tick++) await Promise.resolve();
+
+			expect(revived.sent.map(envelope => unpackEnvelope(envelope)?.peerId)).toEqual([0]);
+		} finally {
+			socket.close();
+		}
+	});
+	it("drops what a provisional leg held when close() ends the session", async () => {
+		vi.spyOn(crypto.subtle, "encrypt").mockResolvedValue(new Uint8Array([1, 2, 3, 4]).buffer);
+		vi.spyOn(crypto.subtle, "decrypt").mockResolvedValue(GUEST_PAYLOAD);
+		const inbound: number[] = [];
+		const socket = startHost();
+		socket.onFrame = (_frame, fromPeer) => inbound.push(fromPeer);
+		try {
+			ScriptedWebSocket.latest.open();
+			ScriptedWebSocket.latest.closeWith(1006, "Connection ended");
+			vi.advanceTimersByTime(1_000);
+			const provisional = ScriptedWebSocket.latest;
+			provisional.open();
+			provisional.introducePeer(REJOIN_PEER);
+			for (let tick = 0; tick < 20; tick++) await Promise.resolve();
+			expect(inbound).toEqual([]);
+
+			// The session ends while the leg is still provisional, then starts again. What
+			// that leg held names peers of a room the relay has recycled since.
+			socket.close();
+			socket.connect();
+			const revived = ScriptedWebSocket.latest;
+			revived.open();
+			socket.send({ t: "bye", reason: "reply to a peer of the previous session" }, REJOIN_PEER);
+			for (let tick = 0; tick < 20; tick++) await Promise.resolve();
+
+			expect(inbound).toEqual([]);
+			expect(revived.sent).toEqual([]);
+		} finally {
+			socket.close();
+		}
+	});
+
+	it("introduces every guest a provisional leg heard from when it settles", async () => {
+		vi.spyOn(crypto.subtle, "encrypt").mockResolvedValue(new Uint8Array([1, 2, 3, 4]).buffer);
+		vi.spyOn(crypto.subtle, "decrypt").mockResolvedValue(GUEST_PAYLOAD);
+		const socket = startHost();
+		try {
+			ScriptedWebSocket.latest.open();
+			ScriptedWebSocket.latest.closeWith(1006, "Connection ended");
+			vi.advanceTimersByTime(1_000);
+			const reclaimed = ScriptedWebSocket.latest;
+			reclaimed.open();
+			// A whole room rejoins onto the provisional leg. None of them is addressable
+			// there: the leg the relay may still reject would swallow the reply.
+			for (let peer = 1; peer <= ROOM_GUESTS; peer++) reclaimed.introducePeer(peer);
+			for (let peer = 1; peer <= ROOM_GUESTS; peer++) {
+				socket.send({ t: "bye", reason: `too early for guest ${peer}` }, peer);
+			}
+			for (let tick = 0; tick < 2_000; tick++) await Promise.resolve();
+			expect(reclaimed.sent).toEqual([]);
+
+			vi.advanceTimersByTime(LEG_SETTLE_MS);
+			for (let tick = 0; tick < 2_000; tick++) await Promise.resolve();
+			// The replay hands the session all of them, so every id is answerable at once.
+			for (let peer = 1; peer <= ROOM_GUESTS; peer++) {
+				socket.send({ t: "bye", reason: `welcome ${peer}` }, peer);
+			}
+			for (let tick = 0; tick < 2_000; tick++) await Promise.resolve();
+
+			const served = reclaimed.sent.map(envelope => unpackEnvelope(envelope)?.peerId);
+			expect(served).toEqual(Array.from({ length: ROOM_GUESTS }, (_, index) => index + 1));
+		} finally {
+			socket.close();
+		}
+	});
+
+	it("makes a peer addressable as soon as its traffic arrives, before the frame decrypts", async () => {
+		vi.spyOn(crypto.subtle, "encrypt").mockResolvedValue(new Uint8Array([1, 2, 3, 4]).buffer);
+		const pendingOpen = Promise.withResolvers<ArrayBuffer>();
+		vi.spyOn(crypto.subtle, "decrypt").mockReturnValue(pendingOpen.promise);
+		const socket = startHost();
+		try {
+			const leg = ScriptedWebSocket.latest;
+			leg.open();
+			// The relay routing the frame is what makes the id real; a reply must not wait on
+			// our own decryption of it.
+			leg.introducePeer(REJOIN_PEER);
+			socket.send({ t: "bye", reason: "reply while the inbound frame is still opening" }, REJOIN_PEER);
+			for (let tick = 0; tick < 20; tick++) await Promise.resolve();
+
+			expect(leg.sent.map(envelope => unpackEnvelope(envelope)?.peerId)).toEqual([REJOIN_PEER]);
+		} finally {
+			pendingOpen.resolve(GUEST_PAYLOAD);
+			socket.close();
+		}
+	});
+
+	it("does not deliver a frame that finished decrypting after its leg died", async () => {
+		const pendingOpen = Promise.withResolvers<ArrayBuffer>();
+		vi.spyOn(crypto.subtle, "decrypt").mockReturnValue(pendingOpen.promise);
+		const framesFrom: number[] = [];
+		const socket = startHost();
+		socket.onFrame = (_frame, fromPeer) => framesFrom.push(fromPeer);
+		try {
+			const established = ScriptedWebSocket.latest;
+			established.open();
+			established.introducePeer(REJOIN_PEER);
+			// The leg dies while the frame is still inside open(). Delivering it afterwards
+			// would re-register a peer of the dead room in the consumer that just cleared it.
+			established.closeWith(1006, "Connection ended");
+			pendingOpen.resolve(GUEST_PAYLOAD);
+			for (let tick = 0; tick < 20; tick++) await Promise.resolve();
+
+			expect(framesFrom).toEqual([]);
+		} finally {
+			socket.close();
+		}
+	});
+
+	it("does not end the session over a frame that failed to open on a leg already gone", async () => {
+		vi.spyOn(Math, "random").mockReturnValue(JITTER_NEUTRAL);
+		const pendingOpen = Promise.withResolvers<ArrayBuffer>();
+		vi.spyOn(crypto.subtle, "decrypt").mockReturnValue(pendingOpen.promise);
+		const closes: { reason: string; willReconnect: boolean }[] = [];
+		const socket = startHost();
+		socket.onClose = (reason, willReconnect) => closes.push({ reason, willReconnect });
+		try {
+			const established = ScriptedWebSocket.latest;
+			established.open();
+			established.introducePeer(REJOIN_PEER);
+			// The frame is inside open() when its leg dies, and then it turns out to be
+			// corrupt. A key is only proven wrong by traffic the live leg accepted: treating
+			// this as fatal would tear the room down and cancel the reconnect the client has
+			// already promised, over a frame nobody can act on.
+			for (let tick = 0; tick < 5; tick++) await Promise.resolve();
+			established.closeWith(1006, "Connection ended");
+			pendingOpen.promise.catch(() => {});
+			pendingOpen.reject(new Error("corrupted frame"));
+			for (let tick = 0; tick < 20; tick++) await Promise.resolve();
+
+			expect(closes).toEqual([{ reason: "Connection ended", willReconnect: true }]);
+			vi.advanceTimersByTime(1_000);
+			expect(ScriptedWebSocket.latest).not.toBe(established);
+		} finally {
+			socket.close();
+		}
+	});
+
+	it("ignores control JSON that parses but carries no tag", async () => {
+		vi.spyOn(crypto.subtle, "encrypt").mockResolvedValue(new Uint8Array([1, 2, 3, 4]).buffer);
+		vi.spyOn(crypto.subtle, "decrypt").mockResolvedValue(GUEST_PAYLOAD);
+		const controls: string[] = [];
+		const socket = startHost();
+		socket.onControl = msg => controls.push(msg.t);
+		try {
+			const leg = ScriptedWebSocket.latest;
+			leg.open();
+			// A custom or malfunctioning relay can send syntactically valid JSON that is not a
+			// control object at all. Reading a field off it would throw out of the socket's
+			// message handler, where nothing catches it, instead of being ignored the way a
+			// syntax error is — and the leg would be left half-processed.
+			for (const payload of ["null", "[]", "42", '"peer-left"', "{}", "{oops"]) {
+				leg.onmessage?.({ data: payload } as MessageEvent);
+			}
+			leg.onmessage?.({ data: JSON.stringify({ t: "peer-left", peer: REJOIN_PEER }) } as MessageEvent);
+			for (let tick = 0; tick < 20; tick++) await Promise.resolve();
+
+			expect(controls).toEqual(["peer-left"]);
+			expect(socket.isOpen).toBe(true);
+		} finally {
+			socket.close();
+		}
+	});
+
+	it("does not hand the session a control message from a leg that died", async () => {
+		const pendingOpen = Promise.withResolvers<ArrayBuffer>();
+		vi.spyOn(crypto.subtle, "decrypt").mockReturnValue(pendingOpen.promise);
+		const controls: string[] = [];
+		const socket = startHost();
+		socket.onControl = msg => controls.push(msg.t);
+		try {
+			const established = ScriptedWebSocket.latest;
+			established.open();
+			established.introducePeer(REJOIN_PEER);
+			// Control rides the same chain as frames, so this peer-left is parked behind the
+			// frame still inside open(); by the time the chain moves, the leg is gone and the
+			// consumer has already retired the whole room.
+			established.onmessage?.({ data: JSON.stringify({ t: "peer-left", peer: REJOIN_PEER }) } as MessageEvent);
+			established.closeWith(1006, "Connection ended");
+			pendingOpen.resolve(GUEST_PAYLOAD);
+			for (let tick = 0; tick < 20; tick++) await Promise.resolve();
+
+			expect(controls).toEqual([]);
+		} finally {
+			socket.close();
+		}
+	});
+
+	it("ignores a frame dispatched by a socket the client already abandoned", async () => {
+		vi.spyOn(crypto.subtle, "encrypt").mockResolvedValue(new Uint8Array([1, 2, 3, 4]).buffer);
+		vi.spyOn(crypto.subtle, "decrypt").mockResolvedValue(GUEST_PAYLOAD);
+		const socket = startHost();
+		try {
+			const abandoned = ScriptedWebSocket.latest;
+			abandoned.open();
+			socket.close();
+			socket.connect();
+			const revived = ScriptedWebSocket.latest;
+			revived.open();
+			// close() detaches the old socket while it is only CLOSING, so frames the relay
+			// already queued still dispatch: their ids must not become addressable here.
+			abandoned.introducePeer(REJOIN_PEER);
+			socket.send({ t: "bye", reason: "reply to a peer of the abandoned leg" }, REJOIN_PEER);
+			for (let tick = 0; tick < 20; tick++) await Promise.resolve();
+
+			expect(revived.sent).toEqual([]);
+		} finally {
+			socket.close();
+		}
+	});
+
+	it("keeps one leg when connect() is called again while a leg or a retry is live", () => {
+		const socket = startHost();
+		try {
+			ScriptedWebSocket.latest.open();
+			socket.connect();
+			// A second leg would race the first for the room and lose one of them to 4009.
+			expect(ScriptedWebSocket.instances).toHaveLength(1);
+
+			ScriptedWebSocket.latest.closeWith(1006, "Connection ended");
+			socket.connect();
+			expect(ScriptedWebSocket.instances).toHaveLength(1);
+			vi.advanceTimersByTime(1_000);
+			expect(ScriptedWebSocket.instances).toHaveLength(2);
+		} finally {
+			socket.close();
+		}
+	});
+
+	it.each([
+		[4001, "room closed"],
+		[4004, "no such room"],
+		[4029, "room is full"],
+	])("ends the session on close code %i instead of reconnecting", (code, reason) => {
+		const closes: { reason: string; willReconnect: boolean }[] = [];
+		const socket = startHost();
+		socket.onClose = (closeReason, willReconnect) => closes.push({ reason: closeReason, willReconnect });
+		try {
+			const leg = ScriptedWebSocket.latest;
+			leg.open();
+			// The relay's final word on the room: retrying only spins against a room that
+			// keeps answering the same way.
+			leg.closeWith(code, "relay policy");
+
+			expect(closes).toEqual([{ reason, willReconnect: false }]);
+			vi.advanceTimersByTime(RECLAIM_WINDOW_MS);
+			expect(ScriptedWebSocket.instances).toHaveLength(1);
+		} finally {
+			socket.close();
+		}
+	});
+
+	it("drops a reply whose seal straddled a leg change, even when the id was re-minted", async () => {
+		const seal = Promise.withResolvers<ArrayBuffer>();
+		vi.spyOn(crypto.subtle, "encrypt").mockReturnValue(seal.promise);
+		vi.spyOn(crypto.subtle, "decrypt").mockResolvedValue(GUEST_PAYLOAD);
+		const socket = startHost();
+		try {
+			const established = ScriptedWebSocket.latest;
+			established.open();
+			established.introducePeer(REJOIN_PEER);
+			// The host answers the guest it just heard from, but the reply parks inside its
+			// seal behind the rest of the send chain.
+			socket.send({ t: "bye", reason: "reply for a guest of the first leg" }, REJOIN_PEER);
+			for (let tick = 0; tick < 5; tick++) await Promise.resolve();
+			established.closeWith(1006, "Connection ended");
+
+			vi.advanceTimersByTime(1_000);
+			const reclaimed = ScriptedWebSocket.latest;
+			reclaimed.open();
+			// The fresh room hands the same number to a different guest, so checking
+			// addressability against the live leg alone would wave the parked reply through.
+			reclaimed.introducePeer(REJOIN_PEER);
+			seal.resolve(new Uint8Array([1, 2, 3, 4]).buffer);
+			vi.advanceTimersByTime(LEG_SETTLE_MS);
+			for (let tick = 0; tick < 20; tick++) await Promise.resolve();
+
+			expect(established.sent).toEqual([]);
+			expect(reclaimed.sent).toEqual([]);
+		} finally {
+			socket.close();
+		}
+	});
+
+	it("drops a reply whose handler outlived the leg that asked, even when the id was re-minted", async () => {
+		vi.spyOn(crypto.subtle, "encrypt").mockResolvedValue(new Uint8Array([1, 2, 3, 4]).buffer);
+		vi.spyOn(crypto.subtle, "decrypt").mockResolvedValue(GUEST_PAYLOAD);
+		const asked: number[] = [];
+		const socket = startHost();
+		socket.onFrame = (_frame, _fromPeer, legId) => asked.push(legId);
+		try {
+			const established = ScriptedWebSocket.latest;
+			established.open();
+			established.introducePeer(REJOIN_PEER);
+			for (let tick = 0; tick < 20; tick++) await Promise.resolve();
+			const legOfRequest = asked.at(-1);
+			expect(legOfRequest).toBeGreaterThan(0);
+
+			// The handler reads a transcript off disk, so it answers after the leg it was
+			// asked on has already died and the fresh room has handed the same number to
+			// somebody else. Everything else about the reply looks current at that point.
+			established.closeWith(1006, "Connection ended");
+			vi.advanceTimersByTime(1_000);
+			const reclaimed = ScriptedWebSocket.latest;
+			reclaimed.open();
+			reclaimed.introducePeer(REJOIN_PEER);
+			vi.advanceTimersByTime(LEG_SETTLE_MS);
+			for (let tick = 0; tick < 20; tick++) await Promise.resolve();
+			socket.send({ t: "bye", reason: "transcript for a guest of the first leg" }, REJOIN_PEER, legOfRequest);
+			for (let tick = 0; tick < 20; tick++) await Promise.resolve();
+
+			expect(reclaimed.sent).toEqual([]);
+			// Naming the live leg is what a synchronous reply does, and that still ships.
+			socket.send({ t: "bye", reason: "reply on the leg that asked" }, REJOIN_PEER, asked.at(-1));
+			for (let tick = 0; tick < 20; tick++) await Promise.resolve();
+			expect(reclaimed.sent).toHaveLength(1);
+		} finally {
+			socket.close();
+		}
+	});
+
+	it("replays the hold only once the backlog left the buffer and the socket is writable", async () => {
+		vi.spyOn(crypto.subtle, "encrypt").mockResolvedValue(new Uint8Array([1, 2, 3, 4]).buffer);
+		vi.spyOn(crypto.subtle, "decrypt").mockResolvedValue(GUEST_PAYLOAD);
+		const inbound: number[] = [];
+		const socket = startHost();
+		socket.onFrame = (_frame, fromPeer) => inbound.push(fromPeer);
+		try {
+			ScriptedWebSocket.latest.open();
+			ScriptedWebSocket.latest.closeWith(1006, "Connection ended");
+			for (let frame = 0; frame < PENDING_SEND_LIMIT; frame++) {
+				socket.send({ t: "bye", reason: `outage backlog ${frame}` });
+			}
+			for (let tick = 0; tick < 4_000; tick++) await Promise.resolve();
+
+			vi.advanceTimersByTime(1_000);
+			const reclaimed = ScriptedWebSocket.latest;
+			// The reclaimed leg opens congested, so the backlog cannot leave at settle.
+			// Handing the guest's hello to the session here would have it answer with a
+			// welcome that queues behind a full buffer, where a train cannot fit.
+			reclaimed.bufferedAmount = 1_000_000;
+			reclaimed.open();
+			reclaimed.introducePeer(REJOIN_PEER);
+			vi.advanceTimersByTime(LEG_SETTLE_MS);
+			for (let tick = 0; tick < 2_000; tick++) await Promise.resolve();
+			expect(inbound).toEqual([]);
+			expect(reclaimed.sent).toEqual([]);
+
+			reclaimed.bufferedAmount = 0;
+			vi.advanceTimersByTime(BACKPRESSURE_RETRY_MS);
+			for (let tick = 0; tick < 4_000; tick++) await Promise.resolve();
+
+			// Backlog first, then the hello: the guest is answered by a leg whose buffer has
+			// room for the handshake it is about to be promised.
+			expect(reclaimed.sent).toHaveLength(PENDING_SEND_LIMIT);
+			expect(inbound).toEqual([REJOIN_PEER]);
+		} finally {
+			socket.close();
+		}
+	});
+
+	it("keeps a fresh arrival behind the hold that is still waiting to replay", async () => {
+		vi.spyOn(crypto.subtle, "encrypt").mockResolvedValue(new Uint8Array([1, 2, 3, 4]).buffer);
+		vi.spyOn(crypto.subtle, "decrypt").mockResolvedValue(GUEST_PAYLOAD);
+		const inbound: number[] = [];
+		const socket = startHost();
+		socket.onFrame = (_frame, fromPeer) => inbound.push(fromPeer);
+		try {
+			ScriptedWebSocket.latest.open();
+			ScriptedWebSocket.latest.closeWith(1006, "Connection ended");
+			for (let frame = 0; frame < PENDING_SEND_LIMIT; frame++) {
+				socket.send({ t: "bye", reason: `outage backlog ${frame}` });
+			}
+			for (let tick = 0; tick < 4_000; tick++) await Promise.resolve();
+
+			vi.advanceTimersByTime(1_000);
+			const reclaimed = ScriptedWebSocket.latest;
+			reclaimed.bufferedAmount = 1_000_000;
+			reclaimed.open();
+			reclaimed.introducePeer(REJOIN_PEER);
+			vi.advanceTimersByTime(LEG_SETTLE_MS);
+			for (let tick = 0; tick < 2_000; tick++) await Promise.resolve();
+			expect(inbound).toEqual([]);
+
+			// The room keeps talking after the leg settled, while the replay is still waiting
+			// on the backlog. This frame has to queue behind the hold: handed over first, the
+			// session hears the room in an order the relay never sent.
+			reclaimed.introducePeer(LATE_GUEST);
+			for (let tick = 0; tick < 2_000; tick++) await Promise.resolve();
+			expect(inbound).toEqual([]);
+
+			reclaimed.bufferedAmount = 0;
+			vi.advanceTimersByTime(BACKPRESSURE_RETRY_MS);
+			for (let tick = 0; tick < 4_000; tick++) await Promise.resolve();
+
+			expect(inbound).toEqual([REJOIN_PEER, LATE_GUEST]);
+		} finally {
+			socket.close();
+		}
+	});
+
+	it("waits out a congested socket before replaying, with nothing queued to send", async () => {
+		vi.spyOn(crypto.subtle, "decrypt").mockResolvedValue(GUEST_PAYLOAD);
+		const inbound: number[] = [];
+		const socket = startHost();
+		socket.onFrame = (_frame, fromPeer) => inbound.push(fromPeer);
+		try {
+			ScriptedWebSocket.latest.open();
+			ScriptedWebSocket.latest.closeWith(1006, "Connection ended");
+			vi.advanceTimersByTime(1_000);
+			const reclaimed = ScriptedWebSocket.latest;
+			// No outage backlog: congestion alone has to hold the replay back, and the drain
+			// timer the flush arms for itself is the only thing that can bring it back.
+			reclaimed.bufferedAmount = 1_000_000;
+			reclaimed.open();
+			reclaimed.introducePeer(REJOIN_PEER);
+			vi.advanceTimersByTime(LEG_SETTLE_MS);
+			for (let tick = 0; tick < 2_000; tick++) await Promise.resolve();
+			expect(inbound).toEqual([]);
+
+			reclaimed.bufferedAmount = 0;
+			vi.advanceTimersByTime(BACKPRESSURE_RETRY_MS);
+			for (let tick = 0; tick < 2_000; tick++) await Promise.resolve();
+
+			expect(inbound).toEqual([REJOIN_PEER]);
+		} finally {
+			socket.close();
+		}
+	});
+});


### PR DESCRIPTION
## What

<img width="2016" height="886" alt="스크린샷 2026-09-04 12 19 56" src="https://github.com/user-attachments/assets/0446598f-ecb1-4fea-93bb-9ac49e7a59e7" />

This PR is a fix that prevents the room from disappearing entirely due to a host conflict when the host reconnects after its relay connection died without a close handshake (half-open), which is what a Collab session left idle for a long time ends up hitting.

## Why

A host whose relay socket died without a close handshake saw 1006 and reconnected ~1s later, but the relay had not observed that close yet and still held the room, so it answered 4009. Because 4009 sat in FATAL_CLOSE_REASONS the host tore itself down and the room was collected: guests dropped with 4001 and the invite link started answering 4004, so the session was unrecoverable even though a second retry would have attached. Idling by itself is not the trigger: a host socket left completely idle for 300s stays open, because the relay's own protocol pings keep resetting the Cloudflare idle timer.

4009 is now conditional. It stays fatal on a cold connect, where another host really owns the room, and for guests, which never enter the reclaim path; it is retried with exponential backoff while a host that already had an established socket is inside a 120s reclaim window, capped at 8 attempts so the retry budget stays under ten tries. The conflict backoff uses its own counter: the relay completes the upgrade before it applies room policy, so a rejected socket fires onopen too, and sharing the transient counter would reset the ladder into 1s hammering.

Sockets also send a 30s WebSocket ping, so a dead path is detected by our own write instead of the relay's deadline. This is armed for both roles, so a coding-agent guest socket pings every 30s as well; narrowing it to hosts is a one-line change if you would rather leave guest traffic untouched. Connection-state transitions now reach the logger instead of TUI-only status text, and a reconnect that holds for 2s emits a notice that guests must rejoin with the same link.

## Testing

I verified whether this issue occurred by comparing Collab sessions before and after the patch was applied over a period of approximately 15 hours.

Additionally, in the OMP on the branch where this PR had not been applied, as expected, the connection was lost after a prolonged period of inactivity, and although a retry was attempted, a host conflict occurred and the room disappeared; however, on the branch where the PR had been applied, the room did not disappear.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)