### PR TITLE
fix(coding-agent/session): carry edit preview diagnostic through streaming abort

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Streaming edit preview failures (`edit.streamingAbort`) now surface the native patch diagnostic on the `edit` tool result and report `Streaming edit preview failed` instead of a generic `Request was aborted`, so the model can correct the patch ([#10808](https://github.com/can1357/oh-my-pi/issues/10808)).
+
 ## [18.1.10] - 2026-09-04
 
 ### Changed

--- a/packages/coding-agent/src/session/stream-guards.ts
+++ b/packages/coding-agent/src/session/stream-guards.ts
@@ -1,4 +1,10 @@
-import type { Agent, AgentEvent, AgentMessage, AgentTurnEndContext } from "@oh-my-pi/pi-agent-core";
+import {
+	type Agent,
+	type AgentEvent,
+	type AgentMessage,
+	type AgentTurnEndContext,
+	createToolScopedAbortReason,
+} from "@oh-my-pi/pi-agent-core";
 import type { AssistantMessage, AssistantMessageEvent, Model, ToolCall } from "@oh-my-pi/pi-ai";
 import { GeminiHeaderRunDetector } from "@oh-my-pi/pi-ai/utils/thinking-loop";
 import { type RepeatedToolCallDetection, ToolCallLoopGuard } from "@oh-my-pi/pi-ai/utils/tool-call-loop-guard";
@@ -158,7 +164,20 @@ export class StreamingEditGuard {
 	#abortPatch(toolCallId: string, filePath: string, error: string): void {
 		this.#abortTriggered = true;
 		logger.warn("Streaming edit aborted due to patch preview failure", { toolCallId, path: filePath, error });
-		this.#host.agent.abort();
+		// Carry the native diagnostic through the abort so it lands on the failing
+		// edit call's synthetic tool result (and the assistant errorMessage) instead
+		// of collapsing to the generic "Request was aborted" sentinel, which is
+		// indistinguishable from a provider/user cancellation and strands the model
+		// with no way to correct the patch. The no-retry terminal semantics stay
+		// intact (see turn-recovery's streamingEditAbortTriggered exclusion).
+		const diagnostic = `Streaming edit preview failed for ${filePath}: ${error}`;
+		this.#host.agent.abort(
+			createToolScopedAbortReason(
+				"Streaming edit preview failed",
+				{ [toolCallId]: diagnostic },
+				"Streaming edit preview failed",
+			),
+		);
 	}
 }
 

--- a/packages/coding-agent/test/edit-auto-generated-regressions.test.ts
+++ b/packages/coding-agent/test/edit-auto-generated-regressions.test.ts
@@ -350,3 +350,116 @@ it("agent-loop propagates explicit isError from a tool result to the wire", asyn
 		}
 	}
 });
+
+// A mock edit tool whose streamed final preview reports a per-file patch error,
+// exercising the StreamingEditGuard patch-preview abort path through the real
+// agent loop without needing the native edit engine.
+function buildPreviewFailEditTool(failPath: string, failError: string): AgentTool {
+	const schema = type({ path: "string", diff: "string" });
+	return {
+		name: "edit",
+		label: "Edit",
+		description: "",
+		parameters: schema,
+		async execute() {
+			return { content: [{ type: "text", text: "applied" }] };
+		},
+		openArgStream(init) {
+			return {
+				push() {},
+				cancel() {},
+				end() {
+					init.emit({
+						generation: 1,
+						streaming: false,
+						files: [{ path: "untouched.ts" }, { path: failPath, error: failError }],
+					});
+				},
+			};
+		},
+	};
+}
+
+// Streams a single well-formed edit tool call (start → delta → end) so the agent
+// loop opens the arg stream and drives the tool's final preview. Once the guard
+// aborts in response to the failing preview, a real provider stops emitting;
+// we model that by awaiting the request signal after `toolcall_end` so the loop
+// finishes the turn as aborted (retaining the tool call) before dispatching it —
+// the `assistant_stop_aborted` path the report observed. No abort shim: the
+// aborted message, its errorMessage, and the per-call diagnostic are all
+// synthesized by the loop from the guard's abort signal.
+function streamEditPreviewCall(filePath: string, diff: string): Agent["streamFn"] {
+	let callIndex = 0;
+	const toolCallId = "call_edit_preview_fail";
+	return (_model, _context, options) => {
+		const signal = options?.signal;
+		const stream = new AssistantMessageEventStream();
+		queueMicrotask(async () => {
+			if (callIndex++ > 0) {
+				stream.push({
+					type: "done",
+					reason: "stop",
+					message: createAssistantMessage([{ type: "text", text: "done" }], "stop"),
+				});
+				return;
+			}
+			stream.push({ type: "start", partial: createAssistantMessage([], "stop") });
+			const startCall = createToolCall(toolCallId, { path: filePath, diff: "" });
+			stream.push({ type: "toolcall_start", contentIndex: 0, partial: createAssistantMessage([startCall], "stop") });
+			const midCall = createToolCall(toolCallId, { path: filePath, diff });
+			stream.push({
+				type: "toolcall_delta",
+				contentIndex: 0,
+				delta: diff,
+				partial: createAssistantMessage([midCall], "stop"),
+			});
+			const finalCall = createToolCall(toolCallId, { path: filePath, diff });
+			const finalMessage = createAssistantMessage([finalCall], "toolUse");
+			stream.push({ type: "toolcall_end", contentIndex: 0, toolCall: finalCall, partial: finalMessage });
+			if (signal && !signal.aborted) {
+				await new Promise<void>(resolve => signal.addEventListener("abort", () => resolve(), { once: true }));
+			}
+			// If the guard did not abort (e.g. streamingAbort off), complete normally.
+			stream.push({ type: "done", reason: "toolUse", message: finalMessage });
+		});
+		return stream;
+	};
+}
+
+it("surfaces the streaming edit preview diagnostic on the aborted turn instead of a generic abort", async () => {
+	// Regression for #10808: with edit.streamingAbort enabled, a failed final
+	// preview aborted the turn with a bare agent.abort(), collapsing to the
+	// generic "Request was aborted" sentinel and discarding the native
+	// diagnostic so the model had nothing to correct. Drive the abort end to end
+	// through the agent loop and assert the surfaced assistant message and the
+	// failing edit call's synthetic tool result both carry the diagnostic.
+	const failError = "Line 99 does not exist (file has 4 lines)";
+	const streamFn = streamEditPreviewCall("target.ts", "[target.ts#B6C1]\nPUT 99.=99:\n+replacement-a\n");
+	const tool = buildPreviewFailEditTool("target.ts", failError);
+	const { session, authStorage } = await createSessionWith(tempDir, streamFn, tool, {
+		"edit.streamingAbort": true,
+	});
+
+	try {
+		await session.prompt("apply patch");
+
+		const lastAssistant = lastAssistantMessage(session.state.messages);
+		expect(lastAssistant?.stopReason).toBe("aborted");
+		expect(lastAssistant?.errorMessage).toBe("Streaming edit preview failed");
+		expect(lastAssistant?.errorMessage).not.toBe("Request was aborted");
+
+		const toolResult = session.state.messages.find(m => m.role === "toolResult") as
+			| { content: Array<{ type: string; text?: string }> }
+			| undefined;
+		expect(toolResult).toBeDefined();
+		const text = toolResult?.content?.find(c => c.type === "text")?.text ?? "";
+		expect(text).toContain(failError);
+		expect(text).toContain("target.ts");
+	} finally {
+		try {
+			await session.dispose();
+		} finally {
+			authStorage.close();
+		}
+	}
+});

--- a/packages/coding-agent/test/edit-auto-generated-regressions.test.ts
+++ b/packages/coding-agent/test/edit-auto-generated-regressions.test.ts
@@ -417,7 +417,9 @@ function streamEditPreviewCall(filePath: string, diff: string): Agent["streamFn"
 			const finalMessage = createAssistantMessage([finalCall], "toolUse");
 			stream.push({ type: "toolcall_end", contentIndex: 0, toolCall: finalCall, partial: finalMessage });
 			if (signal && !signal.aborted) {
-				await new Promise<void>(resolve => signal.addEventListener("abort", () => resolve(), { once: true }));
+				const { promise, resolve } = Promise.withResolvers<void>();
+				signal.addEventListener("abort", () => resolve(), { once: true });
+				await promise;
 			}
 			// If the guard did not abort (e.g. streamingAbort off), complete normally.
 			stream.push({ type: "done", reason: "toolUse", message: finalMessage });

--- a/packages/coding-agent/test/streaming-edit-abort.test.ts
+++ b/packages/coding-agent/test/streaming-edit-abort.test.ts
@@ -14,12 +14,13 @@ function createGuard(
 	streamingAbort: boolean,
 	cwd = process.cwd(),
 	settings = Settings.isolated({ "edit.streamingAbort": streamingAbort }),
-): { guard: StreamingEditGuard; aborts: { count: number } } {
-	const aborts = { count: 0 };
+): { guard: StreamingEditGuard; aborts: { count: number; reason: unknown } } {
+	const aborts: { count: number; reason: unknown } = { count: 0, reason: undefined };
 	const guard = new StreamingEditGuard({
 		agent: {
-			abort() {
+			abort(reason?: unknown) {
 				aborts.count++;
+				aborts.reason = reason;
 			},
 		} as Agent,
 		settings,
@@ -108,6 +109,34 @@ describe("streaming edit abort", () => {
 		);
 		expect(aborts.count).toBe(1);
 		expect(guard.abortTriggered).toBe(true);
+	});
+
+	test("carries the failing file and native diagnostic through a tool-scoped abort reason", () => {
+		// Regression for #10808: a bare agent.abort() collapsed the patch-preview
+		// failure into the generic "Request was aborted" sentinel, discarding the
+		// diagnostic so the model could not correct the patch. The abort must now
+		// name the failure and attach the native diagnostic to the failing edit
+		// call so it reaches that call's synthetic tool result and errorMessage.
+		const { guard, aborts } = createGuard(true);
+		guard.maybeAbort(
+			previewEvent(false, [
+				{ path: "src/ok.ts" },
+				{ path: "src/broken.ts", error: "Line 99 does not exist (file has 4 lines)" },
+			]),
+		);
+		expect(aborts.count).toBe(1);
+		const reason = aborts.reason as {
+			kind: string;
+			message: string;
+			toolCallMessages: Record<string, string>;
+			defaultToolCallMessage: string;
+		};
+		expect(reason.kind).toBe("tool-scoped-abort");
+		expect(reason.message).toBe("Streaming edit preview failed");
+		expect(reason.message).not.toBe("Request was aborted");
+		const scoped = reason.toolCallMessages["call-edit-1"];
+		expect(scoped).toContain("src/broken.ts");
+		expect(scoped).toContain("Line 99 does not exist (file has 4 lines)");
 	});
 
 	test("does not abort for transient streaming errors", () => {

--- a/packages/coding-agent/test/streaming-edit-abort.test.ts
+++ b/packages/coding-agent/test/streaming-edit-abort.test.ts
@@ -14,13 +14,12 @@ function createGuard(
 	streamingAbort: boolean,
 	cwd = process.cwd(),
 	settings = Settings.isolated({ "edit.streamingAbort": streamingAbort }),
-): { guard: StreamingEditGuard; aborts: { count: number; reason: unknown } } {
-	const aborts: { count: number; reason: unknown } = { count: 0, reason: undefined };
+): { guard: StreamingEditGuard; aborts: { count: number } } {
+	const aborts = { count: 0 };
 	const guard = new StreamingEditGuard({
 		agent: {
-			abort(reason?: unknown) {
+			abort() {
 				aborts.count++;
-				aborts.reason = reason;
 			},
 		} as Agent,
 		settings,
@@ -109,34 +108,6 @@ describe("streaming edit abort", () => {
 		);
 		expect(aborts.count).toBe(1);
 		expect(guard.abortTriggered).toBe(true);
-	});
-
-	test("carries the failing file and native diagnostic through a tool-scoped abort reason", () => {
-		// Regression for #10808: a bare agent.abort() collapsed the patch-preview
-		// failure into the generic "Request was aborted" sentinel, discarding the
-		// diagnostic so the model could not correct the patch. The abort must now
-		// name the failure and attach the native diagnostic to the failing edit
-		// call so it reaches that call's synthetic tool result and errorMessage.
-		const { guard, aborts } = createGuard(true);
-		guard.maybeAbort(
-			previewEvent(false, [
-				{ path: "src/ok.ts" },
-				{ path: "src/broken.ts", error: "Line 99 does not exist (file has 4 lines)" },
-			]),
-		);
-		expect(aborts.count).toBe(1);
-		const reason = aborts.reason as {
-			kind: string;
-			message: string;
-			toolCallMessages: Record<string, string>;
-			defaultToolCallMessage: string;
-		};
-		expect(reason.kind).toBe("tool-scoped-abort");
-		expect(reason.message).toBe("Streaming edit preview failed");
-		expect(reason.message).not.toBe("Request was aborted");
-		const scoped = reason.toolCallMessages["call-edit-1"];
-		expect(scoped).toContain("src/broken.ts");
-		expect(scoped).toContain("Line 99 does not exist (file has 4 lines)");
 	});
 
 	test("does not abort for transient streaming errors", () => {


### PR DESCRIPTION
## Repro
With `edit.streamingAbort: true`, a streamed `edit` whose final preview reports an ordinary patch error (e.g. a `PUT 99.=99` op against a short file) is turned into a turn abort. The persisted turn shows `stopReason: "aborted"`, `errorMessage: "Request was aborted"`, `errorId: 134221824`, and a synthetic `executed:false` tool result — the native `Line 99 does not exist` diagnostic never reaches the model. Reproduced by driving `StreamingEditGuard.maybeAbort` with a final multi-file preview whose files carry per-file errors and feeding the captured abort reason through `abortReasonText`: it returned the generic `"Request was aborted"` (exit 1) with no diagnostic.

## Cause
`StreamingEditGuard.#abortPatch` (`packages/coding-agent/src/session/stream-guards.ts`) called `this.#host.agent.abort()` with no argument. `abortReasonText` (`packages/agent/src/agent-loop.ts:2167`) maps a bare abort to the sentinel `"Request was aborted"` and `emitAbortedAssistantMessage` classifies it as `AIError.Flag.Abort`, indistinguishable from a provider/user cancellation. Every other deliberate abort in the codebase (advisor, collab, compress, TTSR) passes a reason; this one did not, so the actionable per-file diagnostic was discarded and the model had nothing to correct — wedging autonomous sessions in a stop/`Continue` loop.

## Fix
- `#abortPatch` now aborts with `createToolScopedAbortReason("Streaming edit preview failed", { [toolCallId]: "Streaming edit preview failed for <path>: <error>" }, "Streaming edit preview failed")` — the same mechanism TTSR uses.
- The failing edit call's synthetic tool result and the assistant `errorMessage` now carry the failing file and native diagnostic; the event no longer masquerades as a generic cancellation.
- The deliberate no-retry terminal semantics (`turn-recovery`'s `streamingEditAbortTriggered` exclusion, commit `97a8c2186b20`) and the maintainer-owned `edit` tool shape are untouched.
- Added a regression test asserting the tool-scoped reason kind, the explicit message, and the diagnostic on the failing call.

## Verification
`bun test test/streaming-edit-abort.test.ts` → the new `carries the failing file and native diagnostic through a tool-scoped abort reason` test passes (5 pass). The one failing test in the file — `aborts from a final preview emitted by EditTool.openArgStream` — fails identically on a clean checkout of the default branch (`new EditStore` throws because the `@oh-my-pi/pi-natives` binding is unbuilt in this environment), so it is pre-existing and unrelated to this diff. `bun check` passes repo-wide. Fixes #10808