### PR TITLE
fix(coding-agent): keep digits in minted MCP tool names

### DIFF
--- a/docs/mcp-server-tool-authoring.md
+++ b/docs/mcp-server-tool-authoring.md
@@ -143,7 +143,7 @@ mcp__<sanitized_server_name>_<sanitized_tool_name>
 Rules:
 
 - lowercases
-- non-`[a-z_]` chars become `_`
+- non-`[a-z0-9_]` chars become `_`
 - repeated underscores collapse
 - redundant `<server>_` prefix in tool name is stripped once
 - names longer than 64 characters keep a readable prefix and append `_` plus the first eight base-36

--- a/docs/mcp-server-tool-authoring.md
+++ b/docs/mcp-server-tool-authoring.md
@@ -156,6 +156,11 @@ lexicographically comparing the original `<server-name>\0<tool-name>` origin
 key. The losing origin is logged and omitted, so reconnect or discovery order
 cannot change ownership.
 
+Before digits were kept, digit-bearing servers minted digit-stripped names
+(`context7` → `mcp__context_query_docs`). User `tools.approval` `deny`/`prompt`
+policies keyed on such a legacy name still apply to the renamed tool
+(fail-closed); legacy `allow` entries are not inherited and must be re-keyed.
+
 ### Schema mapping
 
 `tool-bridge.ts` passes each MCP `inputSchema` through `normalizeSchemaForMCP()` before registering it as a `CustomTool` schema.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed MCP tool names dropping digits, which renamed servers such as `context7` (`mcp__context_query_docs` → `mcp__context7_query_docs`) and collapsed servers differing only by a digit onto the same tool names, costing one of them a tool ([#10179](https://github.com/can1357/oh-my-pi/pull/10179) by [@bitboxx](https://github.com/bitboxx)). User `tools.approval` `deny`/`prompt` policies written against the old digit-stripped names keep applying to the renamed tools; `allow` entries and exact (non-glob) `tools.xdevInlineDevices` patterns need updating to the new names.
+
 ## [18.1.10] - 2026-09-04
 
 ### Changed
@@ -331,9 +335,6 @@
 - Fixed `lsp diagnostics` incorrectly reporting success for project-aware pull-diagnostic servers when diagnostics time out or fail.
 - Corrected labels under `Settings > Context > Compaction Token Limit`.
 - Fixed orphaned pages, iframes, and workers accumulating in the shared headless browser after abnormal OMP session termination.
-### Fixed
-
-- Fixed MCP tool names dropping digits, which renamed servers such as `context7` and collapsed servers differing only by a digit onto the same tool names ([#10179](https://github.com/can1357/oh-my-pi/pull/10179) by [@bitboxx](https://github.com/bitboxx)).
 
 ## [18.0.10] - 2026-08-28
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -331,6 +331,9 @@
 - Fixed `lsp diagnostics` incorrectly reporting success for project-aware pull-diagnostic servers when diagnostics time out or fail.
 - Corrected labels under `Settings > Context > Compaction Token Limit`.
 - Fixed orphaned pages, iframes, and workers accumulating in the shared headless browser after abnormal OMP session termination.
+### Fixed
+
+- Fixed MCP tool names dropping digits, which renamed servers such as `context7` and collapsed servers differing only by a digit onto the same tool names ([#10179](https://github.com/can1357/oh-my-pi/pull/10179) by [@bitboxx](https://github.com/bitboxx)).
 
 ## [18.0.10] - 2026-08-28
 

--- a/packages/coding-agent/src/extensibility/custom-tools/types.ts
+++ b/packages/coding-agent/src/extensibility/custom-tools/types.ts
@@ -228,6 +228,9 @@ export interface CustomTool<TParams extends TSchema = TSchema, TDetails = any> {
 	mcpServerName?: string;
 	/** Original MCP tool name for discovery/search metadata. */
 	mcpToolName?: string;
+	/** Previous public name when a rename changed minting (e.g. digits kept in
+	 *  MCP names). Approval resolution honors `deny`/`prompt` keyed on it. */
+	legacyName?: string;
 
 	/** Capability tier declaration used by approval gates. Omitted means "exec". */
 	approval?: ToolApproval;

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -639,6 +639,9 @@ export interface ToolDefinition<TParams extends TSchema = TSchema, TDetails = un
 	mcpServerName?: string;
 	/** Original MCP tool name for discovery/search metadata. */
 	mcpToolName?: string;
+	/** Previous public name when a rename changed minting. Forwarded through
+	 *  RegisteredToolAdapter so approval falls back to legacy `deny`/`prompt`. */
+	legacyName?: string;
 	/** Optional environment hook applied when the interactive user shell invokes this tool's shell surface. */
 	shellEnv?: ToolShellEnvironmentHook;
 	/** Authoritative originating file for a discovered custom-tool module. */

--- a/packages/coding-agent/src/mcp/tool-bridge.ts
+++ b/packages/coding-agent/src/mcp/tool-bridge.ts
@@ -684,6 +684,8 @@ export class MCPTool implements CustomTool<TSchema, MCPToolDetails> {
  */
 export class DeferredMCPTool implements CustomTool<TSchema, MCPToolDetails> {
 	readonly name: string;
+	/** See {@link MCPTool.legacyName}. */
+	readonly legacyName?: string;
 	readonly label: string;
 	readonly description: string;
 	readonly parameters: TSchema;
@@ -719,6 +721,7 @@ export class DeferredMCPTool implements CustomTool<TSchema, MCPToolDetails> {
 		private readonly reconnect?: MCPReconnect,
 	) {
 		this.name = createMCPToolName(serverName, tool.name);
+		this.legacyName = createLegacyMCPToolName(serverName, tool.name);
 		this.label = `${serverName}/${tool.name}`;
 		this.description = tool.description ?? `MCP tool from ${serverName}`;
 		this.parameters = normalizeSchemaForMCP(tool.inputSchema) as TSchema;

--- a/packages/coding-agent/src/mcp/tool-bridge.ts
+++ b/packages/coding-agent/src/mcp/tool-bridge.ts
@@ -406,7 +406,7 @@ async function reconnectWithAbort(
 function sanitizeMCPToolNamePart(value: string, fallback: string): string {
 	const sanitized = value
 		.toLowerCase()
-		.replace(/[^a-z_]+/g, "_")
+		.replace(/[^a-z0-9_]+/g, "_")
 		.replace(/_+/g, "_")
 		.replace(/^_+|_+$/g, "");
 

--- a/packages/coding-agent/src/mcp/tool-bridge.ts
+++ b/packages/coding-agent/src/mcp/tool-bridge.ts
@@ -414,6 +414,36 @@ function sanitizeMCPToolNamePart(value: string, fallback: string): string {
 }
 
 /**
+ * Mint the name {@link createMCPToolName} produced before digits were kept in
+ * sanitized parts: same algorithm, but `[^a-z_]+` collapses to `_`. Digit-
+ * bearing servers/tools were renamed by that fix, so user config keys written
+ * against the old form (`tools.approval`, `tools.xdevInlineDevices`) no longer
+ * match. Approval resolution consults this legacy key as a fail-closed
+ * fallback. Returns `undefined` when minting is unchanged (no digits involved).
+ */
+export function createLegacyMCPToolName(serverName: string, toolName: string): string | undefined {
+	const sanitizeLegacy = (value: string, fallback: string): string => {
+		const sanitized = value
+			.toLowerCase()
+			.replace(/[^a-z_]+/g, "_")
+			.replace(/_+/g, "_")
+			.replace(/^_+|_+$/g, "");
+		return sanitized.length > 0 ? sanitized : fallback;
+	};
+
+	const legacyServerName = sanitizeLegacy(serverName, "server");
+	const legacyToolName = sanitizeLegacy(toolName, "tool");
+	const prefixWithUnderscore = `${legacyServerName}_`;
+	const normalizedToolName = legacyToolName.startsWith(prefixWithUnderscore)
+		? legacyToolName.slice(prefixWithUnderscore.length)
+		: legacyToolName;
+	const legacyName = capMCPToolNameLength(`mcp__${legacyServerName}_${normalizedToolName}`);
+	const currentName = createMCPToolName(serverName, toolName);
+
+	return legacyName !== currentName ? legacyName : undefined;
+}
+
+/**
  * Longest tool name strict validators accept. OpenAI Responses/Completions and
  * Meta Responses enforce `^[a-zA-Z0-9_-]{1,64}$`; names over 64 chars are
  * rejected with HTTP 400 `name must be at most 64 characters` (#9130).
@@ -535,6 +565,12 @@ export function parseMCPToolName(name: string): { serverName: string; toolName: 
  */
 export class MCPTool implements CustomTool<TSchema, MCPToolDetails> {
 	readonly name: string;
+	/**
+	 * Name this tool had before digits were kept in minted names, if different.
+	 * Approval resolution honors `deny`/`prompt` user policies written against
+	 * this key so the rename cannot silently unblock a restricted MCP server.
+	 */
+	readonly legacyName?: string;
 	readonly label: string;
 	readonly description: string;
 	readonly parameters: TSchema;
@@ -564,6 +600,7 @@ export class MCPTool implements CustomTool<TSchema, MCPToolDetails> {
 		private readonly reconnect?: MCPReconnect,
 	) {
 		this.name = createMCPToolName(connection.name, tool.name);
+		this.legacyName = createLegacyMCPToolName(connection.name, tool.name);
 		this.label = `${connection.name}/${tool.name}`;
 		this.description = tool.description ?? `MCP tool from ${connection.name}`;
 		this.parameters = normalizeSchemaForMCP(tool.inputSchema) as TSchema;

--- a/packages/coding-agent/src/mcp/tool-bridge.ts
+++ b/packages/coding-agent/src/mcp/tool-bridge.ts
@@ -403,10 +403,10 @@ async function reconnectWithAbort(
  * "puppeteer_screenshot"), strips the redundant prefix to produce
  * "mcp__puppeteer_screenshot" instead of "mcp__puppeteer_puppeteer_screenshot".
  */
-function sanitizeMCPToolNamePart(value: string, fallback: string): string {
+function sanitizeMCPToolNamePart(value: string, fallback: string, keepDigits: boolean): string {
 	const sanitized = value
 		.toLowerCase()
-		.replace(/[^a-z0-9_]+/g, "_")
+		.replace(keepDigits ? /[^a-z0-9_]+/g : /[^a-z_]+/g, "_")
 		.replace(/_+/g, "_")
 		.replace(/^_+|_+$/g, "");
 
@@ -414,32 +414,38 @@ function sanitizeMCPToolNamePart(value: string, fallback: string): string {
 }
 
 /**
+ * Shared mint pipeline. `keepDigits` selects the sanitizer variant: the
+ * current mint keeps `0-9`, the legacy variant strips them exactly as the
+ * pre-fix `sanitizeMCPToolNamePart` did. Both halves route through this one
+ * function so the two mints can only ever differ by that character class —
+ * if the prefix-strip or cap rules change, the legacy alias changes with them.
+ */
+function mintMCPToolName(serverName: string, toolName: string, keepDigits: boolean): string {
+	const sanitizedServerName = sanitizeMCPToolNamePart(serverName, "server", keepDigits);
+	const sanitizedToolName = sanitizeMCPToolNamePart(toolName, "tool", keepDigits);
+
+	// Strip redundant server name prefix from tool name if present
+	const prefixWithUnderscore = `${sanitizedServerName}_`;
+
+	let normalizedToolName = sanitizedToolName;
+	if (sanitizedToolName.startsWith(prefixWithUnderscore)) {
+		normalizedToolName = sanitizedToolName.slice(prefixWithUnderscore.length);
+	}
+
+	return capMCPToolNameLength(`mcp__${sanitizedServerName}_${normalizedToolName}`);
+}
+
+/**
  * Mint the name {@link createMCPToolName} produced before digits were kept in
- * sanitized parts: same algorithm, but `[^a-z_]+` collapses to `_`. Digit-
- * bearing servers/tools were renamed by that fix, so user config keys written
- * against the old form (`tools.approval`, `tools.xdevInlineDevices`) no longer
- * match. Approval resolution consults this legacy key as a fail-closed
- * fallback. Returns `undefined` when minting is unchanged (no digits involved).
+ * sanitized parts (`[^a-z_]+` collapsed to `_`). Digit-bearing servers/tools
+ * were renamed by that fix, so user config keys written against the old form
+ * (`tools.approval`, `tools.xdevInlineDevices`) would no longer match.
+ * Approval resolution consults this legacy key as a fail-closed fallback.
+ * Returns `undefined` when minting is unchanged (no digits involved).
  */
 export function createLegacyMCPToolName(serverName: string, toolName: string): string | undefined {
-	const sanitizeLegacy = (value: string, fallback: string): string => {
-		const sanitized = value
-			.toLowerCase()
-			.replace(/[^a-z_]+/g, "_")
-			.replace(/_+/g, "_")
-			.replace(/^_+|_+$/g, "");
-		return sanitized.length > 0 ? sanitized : fallback;
-	};
-
-	const legacyServerName = sanitizeLegacy(serverName, "server");
-	const legacyToolName = sanitizeLegacy(toolName, "tool");
-	const prefixWithUnderscore = `${legacyServerName}_`;
-	const normalizedToolName = legacyToolName.startsWith(prefixWithUnderscore)
-		? legacyToolName.slice(prefixWithUnderscore.length)
-		: legacyToolName;
-	const legacyName = capMCPToolNameLength(`mcp__${legacyServerName}_${normalizedToolName}`);
+	const legacyName = mintMCPToolName(serverName, toolName, false);
 	const currentName = createMCPToolName(serverName, toolName);
-
 	return legacyName !== currentName ? legacyName : undefined;
 }
 
@@ -467,18 +473,7 @@ function capMCPToolNameLength(name: string): string {
 }
 
 export function createMCPToolName(serverName: string, toolName: string): string {
-	const sanitizedServerName = sanitizeMCPToolNamePart(serverName, "server");
-	const sanitizedToolName = sanitizeMCPToolNamePart(toolName, "tool");
-
-	// Strip redundant server name prefix from tool name if present
-	const prefixWithUnderscore = `${sanitizedServerName}_`;
-
-	let normalizedToolName = sanitizedToolName;
-	if (sanitizedToolName.startsWith(prefixWithUnderscore)) {
-		normalizedToolName = sanitizedToolName.slice(prefixWithUnderscore.length);
-	}
-
-	return capMCPToolNameLength(`mcp__${sanitizedServerName}_${normalizedToolName}`);
+	return mintMCPToolName(serverName, toolName, true);
 }
 
 export interface MCPToolOriginSource {

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1027,6 +1027,9 @@ export function customToolToDefinition(tool: CustomTool, sourcePath?: string): T
 		strict: tool.strict,
 		mcpServerName: tool.mcpServerName,
 		mcpToolName: tool.mcpToolName,
+		// Forwarded so MCP tools renamed by the digit-keeping mint keep honoring
+		// legacy `deny`/`prompt` policies; RegisteredToolAdapter re-exposes it.
+		legacyName: tool.legacyName,
 		sourcePath,
 		execute: (toolCallId, params, signal, onUpdate, ctx) =>
 			tool.execute(toolCallId, params, onUpdate, createCustomToolContext(ctx), signal),

--- a/packages/coding-agent/src/tools/approval.ts
+++ b/packages/coding-agent/src/tools/approval.ts
@@ -13,7 +13,15 @@ export type { ToolApproval, ToolApprovalDecision, ToolTier } from "@oh-my-pi/pi-
 export type ApprovalPolicy = "allow" | "deny" | "prompt";
 export type ApprovalMode = "always-ask" | "write" | "yolo";
 
-type ApprovalSubject = Pick<AgentTool, "name" | "approval" | "formatApprovalDetails">;
+type ApprovalSubject = Pick<AgentTool, "name" | "approval" | "formatApprovalDetails"> & {
+	/**
+	 * Previous public name of this tool, when a rename changed how it mints.
+	 * MCP tools minted before digits were kept carry their digit-stripped name
+	 * here so user `deny`/`prompt` policies written against it still apply
+	 * (`allow` is deliberately not inherited — see resolveApproval).
+	 */
+	readonly legacyName?: string;
+};
 
 export interface ResolvedApproval {
 	policy: ApprovalPolicy;
@@ -133,6 +141,22 @@ export function resolveApproval(
 	const effectiveUserPolicy = userPolicy ?? fallbackPolicy;
 	const userPolicyKey = userPolicy !== undefined ? policyKey : tool.name;
 
+	// Legacy-name fallback for renamed tools (e.g. MCP mints that gained digits).
+	// Fail-closed: only `deny`/`prompt` carry over from the old key, so a
+	// forgotten restrictive policy keeps protecting the renamed tool, while a
+	// stale `allow` cannot mask a `deny` another user sets under the new name.
+	const legacyPolicy =
+		effectiveUserPolicy === undefined &&
+		typeof tool.legacyName === "string" &&
+		tool.legacyName !== tool.name &&
+		Object.hasOwn(userConfig, tool.legacyName)
+			? normalizePolicy(userConfig[tool.legacyName])
+			: undefined;
+	const inheritedPolicy = legacyPolicy === "deny" || legacyPolicy === "prompt" ? legacyPolicy : undefined;
+	const inheritedPolicyKey = inheritedPolicy !== undefined ? tool.legacyName : undefined;
+	const combinedUserPolicy = effectiveUserPolicy ?? inheritedPolicy;
+	const combinedUserPolicyKey = effectiveUserPolicy !== undefined ? userPolicyKey : inheritedPolicyKey;
+
 	if (decision.policy === "deny") {
 		return {
 			policy: "deny",
@@ -143,13 +167,13 @@ export function resolveApproval(
 			...(decision.reason ? { reason: decision.reason } : {}),
 		};
 	}
-	if (effectiveUserPolicy === "deny") {
+	if (combinedUserPolicy === "deny") {
 		return {
 			policy: "deny",
 			tier: decision.tier,
 			override: decision.override,
 			source: "user",
-			policyKey: userPolicyKey,
+			...(combinedUserPolicyKey ? { policyKey: combinedUserPolicyKey } : {}),
 		};
 	}
 
@@ -165,11 +189,11 @@ export function resolveApproval(
 			};
 		}
 		return {
-			policy: effectiveUserPolicy ?? "allow",
+			policy: combinedUserPolicy ?? "allow",
 			tier: decision.tier,
 			override: false,
-			source: effectiveUserPolicy ? "user" : "mode",
-			...(effectiveUserPolicy ? { policyKey: userPolicyKey } : {}),
+			source: combinedUserPolicy ? "user" : "mode",
+			...(combinedUserPolicyKey ? { policyKey: combinedUserPolicyKey } : {}),
 		};
 	}
 
@@ -195,13 +219,13 @@ export function resolveApproval(
 		};
 	}
 
-	if (effectiveUserPolicy) {
+	if (combinedUserPolicy) {
 		return {
-			policy: effectiveUserPolicy,
+			policy: combinedUserPolicy,
 			tier: decision.tier,
 			override: false,
 			source: "user",
-			policyKey: userPolicyKey,
+			...(combinedUserPolicyKey ? { policyKey: combinedUserPolicyKey } : {}),
 		};
 	}
 

--- a/packages/coding-agent/test/mcp-reconnect.test.ts
+++ b/packages/coding-agent/test/mcp-reconnect.test.ts
@@ -92,6 +92,15 @@ describe("createMCPToolName", () => {
 		expect(createMCPToolName("puppeteer", "puppeteer_screenshot")).toBe("mcp__puppeteer_screenshot");
 	});
 
+	it("keeps digits, so servers differing only by a digit stay distinct", () => {
+		// The sanitizer used to strip 0-9, minting mcp__context_query_docs for
+		// server "context7" and collapsing "foo1"/"foo2" onto one name, which
+		// then cost one of them a tool via deduplicateMCPToolsByName().
+		expect(createMCPToolName("context7", "query-docs")).toBe("mcp__context7_query_docs");
+		expect(createMCPToolName("s3-storage", "get_object")).toBe("mcp__s3_storage_get_object");
+		expect(createMCPToolName("foo1", "run")).not.toBe(createMCPToolName("foo2", "run"));
+	});
+
 	it("is deterministic and keeps distinct overlong names distinct", () => {
 		const a = createMCPToolName("chrome-devtools-mcp", "chrome_devtools_performance_analyze_insight");
 		const b = createMCPToolName("chrome-devtools-mcp", "chrome_devtools_performance_analyze_insight");

--- a/packages/coding-agent/test/mcp-reconnect.test.ts
+++ b/packages/coding-agent/test/mcp-reconnect.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "bun:test";
 import { createMCPJsonRpcError, MCPTransportError } from "@oh-my-pi/pi-coding-agent/mcp/errors";
 import type { MCPReconnect } from "@oh-my-pi/pi-coding-agent/mcp/tool-bridge";
 import {
+	createLegacyMCPToolName,
 	createMCPToolName,
 	DeferredMCPTool,
 	deduplicateMCPToolsByName,
@@ -99,6 +100,13 @@ describe("createMCPToolName", () => {
 		expect(createMCPToolName("context7", "query-docs")).toBe("mcp__context7_query_docs");
 		expect(createMCPToolName("s3-storage", "get_object")).toBe("mcp__s3_storage_get_object");
 		expect(createMCPToolName("foo1", "run")).not.toBe(createMCPToolName("foo2", "run"));
+	});
+
+	it("mints the pre-rename legacy name only for digit-bearing servers/tools", () => {
+		expect(createLegacyMCPToolName("context7", "query-docs")).toBe("mcp__context_query_docs");
+		expect(createLegacyMCPToolName("s3-storage", "get_object")).toBe("mcp__s_storage_get_object");
+		expect(createLegacyMCPToolName("puppeteer", "puppeteer_screenshot")).toBeUndefined();
+		expect(createLegacyMCPToolName("plain", "tool")).toBeUndefined();
 	});
 
 	it("is deterministic and keeps distinct overlong names distinct", () => {

--- a/packages/coding-agent/test/mcp-reconnect.test.ts
+++ b/packages/coding-agent/test/mcp-reconnect.test.ts
@@ -109,6 +109,18 @@ describe("createMCPToolName", () => {
 		expect(createLegacyMCPToolName("plain", "tool")).toBeUndefined();
 	});
 
+	it("exposes the legacy alias on both live and deferred tools", () => {
+		// Slow-startup servers register DeferredMCPTool instead of MCPTool;
+		// approval fallback must not depend on connection timing (#10810 review).
+		const digitTool = { name: "query-docs", inputSchema: { type: "object" as const } };
+		const live = new MCPTool(makeConnection(mockTransport(async () => ({})), "context7"), digitTool);
+		const deferred = new DeferredMCPTool("context7", digitTool, async () => {
+			throw new Error("unneeded");
+		});
+		expect(live.legacyName).toBe("mcp__context_query_docs");
+		expect(deferred.legacyName).toBe("mcp__context_query_docs");
+	});
+
 	it("is deterministic and keeps distinct overlong names distinct", () => {
 		const a = createMCPToolName("chrome-devtools-mcp", "chrome_devtools_performance_analyze_insight");
 		const b = createMCPToolName("chrome-devtools-mcp", "chrome_devtools_performance_analyze_insight");

--- a/packages/coding-agent/test/tools/approval.test.ts
+++ b/packages/coding-agent/test/tools/approval.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { customToolToDefinition } from "@oh-my-pi/pi-coding-agent/sdk";
 import type { AgentTool, ToolApproval } from "@oh-my-pi/pi-agent-core";
 import { LSP_READONLY_ACTIONS } from "@oh-my-pi/pi-coding-agent/lsp";
 import {
@@ -210,6 +211,22 @@ describe("MCP fallback and prompt formatting", () => {
 	it("ignores legacyName for tools whose mint did not change", () => {
 		const unchanged = { ...tool("mcp__puppeteer_screenshot", "write"), legacyName: "mcp__puppeteer_screenshot" };
 		expect(resolveApproval(unchanged, {}, "yolo", { mcp__puppeteer_screenshot: "deny" }).policy).toBe("deny");
+	});
+
+	it("survives the sdk custom-tool → definition bridge", () => {
+		// The eager/headless path (sdk.ts customToolToDefinition) rebuilds the
+		// tool as a ToolDefinition; legacyName must be forwarded so the alias
+		// still reaches RegisteredToolAdapter → resolveApproval.
+		const definition = customToolToDefinition({
+			name: "mcp__context7_query_docs",
+			label: "context7/query-docs",
+			description: "MCP tool from context7",
+			parameters: { type: "object" },
+			legacyName: "mcp__context_query_docs",
+			approval: "write",
+		} as never);
+		expect(definition.legacyName).toBe("mcp__context_query_docs");
+		expect(resolveApproval(definition, {}, "yolo", { mcp__context_query_docs: "deny" }).policy).toBe("deny");
 	});
 
 	it("formats MCP origin, reason, and per-tool details", () => {

--- a/packages/coding-agent/test/tools/approval.test.ts
+++ b/packages/coding-agent/test/tools/approval.test.ts
@@ -171,6 +171,47 @@ describe("MCP fallback and prompt formatting", () => {
 		expect(resolveApproval(subject, {}, "always-ask")).toMatchObject({ policy: "prompt", tier: "write" });
 	});
 
+	it("honors deny/prompt policies written against a tool's legacy (pre-rename) name", () => {
+		// MCP mints gained digits (context7 → mcp__context7_*); a forgotten
+		// `tools.approval.mcp__context_query_docs: deny` must keep protecting the
+		// renamed tool instead of silently reverting to the mode default.
+		const renamed = { ...tool("mcp__context7_query_docs", "write"), legacyName: "mcp__context_query_docs" };
+		expect(resolveApproval(renamed, {}, "yolo", { mcp__context_query_docs: "deny" })).toMatchObject({
+			policy: "deny",
+			source: "user",
+			policyKey: "mcp__context_query_docs",
+		});
+		expect(resolveApproval(renamed, {}, "yolo", { mcp__context_query_docs: "prompt" }).policy).toBe("prompt");
+	});
+
+	it("does not inherit a legacy-name allow", () => {
+		// Fail-closed: a stale `allow` under the old name must not mask a deny
+		// set under the new name, so legacy keys only carry deny/prompt.
+		const renamed = { ...tool("mcp__context7_query_docs", "write"), legacyName: "mcp__context_query_docs" };
+		expect(resolveApproval(renamed, {}, "always-ask", { mcp__context_query_docs: "allow" }).policy).toBe("prompt");
+		expect(
+			resolveApproval(renamed, {}, "yolo", {
+				mcp__context_query_docs: "allow",
+				mcp__context7_query_docs: "deny",
+			}).policy,
+		).toBe("deny");
+	});
+
+	it("prefers the current-name policy over the legacy one", () => {
+		const renamed = { ...tool("mcp__context7_query_docs", "write"), legacyName: "mcp__context_query_docs" };
+		expect(
+			resolveApproval(renamed, {}, "yolo", {
+				mcp__context_query_docs: "deny",
+				mcp__context7_query_docs: "allow",
+			}),
+		).toMatchObject({ policy: "allow", policyKey: "mcp__context7_query_docs" });
+	});
+
+	it("ignores legacyName for tools whose mint did not change", () => {
+		const unchanged = { ...tool("mcp__puppeteer_screenshot", "write"), legacyName: "mcp__puppeteer_screenshot" };
+		expect(resolveApproval(unchanged, {}, "yolo", { mcp__puppeteer_screenshot: "deny" }).policy).toBe("deny");
+	});
+
 	it("formats MCP origin, reason, and per-tool details", () => {
 		const subject = tool("mcp__server__dangerous", undefined, () => ["Path: /tmp/out", "Content:\nhello"]);
 		expect(formatApprovalPrompt(subject, {}, "Needs confirmation").split("\n")).toEqual([


### PR DESCRIPTION
Supersedes #10179 (stalled 6 days, merge-dirty, unaddressed P1 review) — carries bitboxx's original commit rebased onto current main, plus a fix for the codex-connector P1.

## Original change (bitboxx, preserved)

`sanitizeMCPToolNamePart` stripped digits (`context7` → `mcp__context_query_docs`, `foo1`/`foo2` collided and lost a tool to `deduplicateMCPToolsByName`). Now `0-9` is kept; hyphens still collapse deliberately (gemma/gemini dialects and the harmony catalog need `[A-Za-z_]\w*`).

## Added in this PR (codex-connector P1)

The rename silently invalidated `tools.approval` keys written against digit-stripped names — `mcp__context_query_docs: deny` no longer matched the renamed `mcp__context7_query_docs`, and in default yolo mode a denied call became allowed.

- `MCPTool` now carries `legacyName` (the pre-fix mint; `undefined` when unchanged).
- `resolveApproval` falls back to the legacy key only when no current-name policy exists — and only honors `deny`/`prompt`, so a stale `allow` can't mask a restrictive policy. Current-name entries always win (explicit migration path).
- Regression tests assert resolved decisions (policy/source/policyKey), not just minted names. Docs + changelog updated: legacy `deny`/`prompt` keep working; `allow` and exact `xdevInlineDevices` globs need re-keying.

## Verification

- New fallback + mint tests and 22 existing `resolveApproval` expectations exercised against the changed module: all pass.
- Full `bun test` + `bun run check` deferred to CI (local run blocked on unbuilt `pi_natives` native addon, unrelated to this change).

Co-Authored-By: Martin <martin@bitboxx.com>
